### PR TITLE
Avoid linking targets multiple times in cmake and change make -j4 to -j8 in build.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Please mark all change in change log and use the ticket from JIRA.
 - MS-648 - Improve unittest
 - MS-655 - Upgrade SPTAG
 - \#42 - Put union of index_build_device and search resources to gpu_pool
+- \#67 - Avoid linking targets multiple times in cmake
 
 ## Feature
 - MS-614 - Preload table at startup

--- a/core/build.sh
+++ b/core/build.sh
@@ -93,7 +93,7 @@ cd ${BUILD_OUTPUT_DIR}
 
 # remove make cache since build.sh -l use default variables
 # force update the variables each time
-make rebuild_cache
+make rebuild_cache > /dev/null 2>&1
 
 CMAKE_CMD="cmake \
 -DBUILD_UNIT_TEST=${BUILD_UNITTEST} \
@@ -139,13 +139,12 @@ if [[ ${RUN_CPPLINT} == "ON" ]]; then
 #    fi
 #    echo "clang-tidy check passed!"
 else
-    # compile and build
-    make -j 4 || exit 1
 
     # strip binary symbol
     if [[ ${BUILD_TYPE} != "Debug" ]]; then
         strip src/milvus_server
     fi
 
-    make install || exit 1
+    # compile and build
+    make -j 8 install || exit 1
 fi

--- a/core/src/index/cmake/ThirdPartyPackagesCore.cmake
+++ b/core/src/index/cmake/ThirdPartyPackagesCore.cmake
@@ -331,10 +331,9 @@ macro(build_arrow)
                         CMAKE_ARGS
                         ${ARROW_CMAKE_ARGS}
                         BUILD_COMMAND
-                        ${MAKE}
-                        ${MAKE_BUILD_ARGS}
+                        ""
                         INSTALL_COMMAND
-                        ${MAKE} install
+                        ${MAKE} ${MAKE_BUILD_ARGS} install
                         BUILD_BYPRODUCTS
                         "${ARROW_STATIC_LIB}"
                         )
@@ -365,10 +364,9 @@ macro(build_arrow)
                 CMAKE_ARGS
                 ${ARROW_CMAKE_ARGS}
                 BUILD_COMMAND
-                ${MAKE}
-                ${MAKE_BUILD_ARGS}
+                ""
                 INSTALL_COMMAND
-                ${MAKE} install
+                ${MAKE} ${MAKE_BUILD_ARGS} install
                 BUILD_BYPRODUCTS
                 "${ARROW_STATIC_LIB}"
                 )


### PR DESCRIPTION
#67 