### PR TITLE
use better names for timing MACROs #556

### DIFF
--- a/core/src/db/DBImpl.cpp
+++ b/core/src/db/DBImpl.cpp
@@ -793,9 +793,9 @@ DBImpl::BackgroundCompaction(std::set<std::string> table_ids) {
     }
 
     {
-        uint64_t ttl = 5 * meta::M_SEC;  // default: file will be deleted after few minutes
+        uint64_t ttl = 5 * meta::MINUTE;  // default: file will be deleted after few minutes
         if (options_.mode_ == DBOptions::MODE::CLUSTER_WRITABLE) {
-            ttl = meta::D_SEC;
+            ttl = meta::DAY;
         }
         meta_ptr_->CleanUpFilesWithTTL(ttl);
     }

--- a/core/src/db/meta/MetaConsts.h
+++ b/core/src/db/meta/MetaConsts.h
@@ -27,10 +27,10 @@ const size_t US_PS = 1000 * MS_PS;
 const size_t NS_PS = 1000 * US_PS;
 
 const size_t SECOND = 1UL;
-const size_t M_SEC = 60 * SECOND;
-const size_t H_SEC = 60 * M_SEC;
-const size_t D_SEC = 24 * H_SEC;
-const size_t W_SEC = 7 * D_SEC;
+const size_t MINUTE = 60 * SECOND;
+const size_t HOUR = 60 * MINUTE;
+const size_t DAY = 24 * HOUR;
+const size_t WEEK = 7 * DAY;
 
 // This value is to ignore small raw files when building index.
 // The reason is:

--- a/core/src/db/meta/MySQLMetaImpl.cpp
+++ b/core/src/db/meta/MySQLMetaImpl.cpp
@@ -1664,7 +1664,7 @@ MySQLMetaImpl::Archive() {
         auto& criteria = kv.first;
         auto& limit = kv.second;
         if (criteria == engine::ARCHIVE_CONF_DAYS) {
-            size_t usecs = limit * D_SEC * US_PS;
+            size_t usecs = limit * DAY * US_PS;
             int64_t now = utils::GetMicroSecTimeStamp();
 
             try {

--- a/core/src/db/meta/SqliteMetaImpl.cpp
+++ b/core/src/db/meta/SqliteMetaImpl.cpp
@@ -1204,7 +1204,7 @@ SqliteMetaImpl::Archive() {
         auto& criteria = kv.first;
         auto& limit = kv.second;
         if (criteria == engine::ARCHIVE_CONF_DAYS) {
-            int64_t usecs = limit * D_SEC * US_PS;
+            int64_t usecs = limit * DAY * US_PS;
             int64_t now = utils::GetMicroSecTimeStamp();
             try {
                 // multi-threads call sqlite update may get exception('bad logic', etc), so we add a lock here

--- a/core/unittest/db/test_meta.cpp
+++ b/core/unittest/db/test_meta.cpp
@@ -141,7 +141,7 @@ TEST_F(MetaTest, ARCHIVE_TEST_DAYS) {
         status = impl.CreateTableFile(table_file);
         table_file.file_type_ = milvus::engine::meta::TableFileSchema::NEW;
         int day = rand_r(&seed) % (days_num * 2);
-        table_file.created_on_ = ts - day * milvus::engine::meta::D_SEC * milvus::engine::meta::US_PS - 10000;
+        table_file.created_on_ = ts - day * milvus::engine::meta::DAY * milvus::engine::meta::US_PS - 10000;
         status = impl.UpdateTableFile(table_file);
         files.push_back(table_file);
         days.push_back(day);

--- a/core/unittest/db/test_meta_mysql.cpp
+++ b/core/unittest/db/test_meta_mysql.cpp
@@ -145,7 +145,7 @@ TEST_F(MySqlMetaTest, ARCHIVE_TEST_DAYS) {
         status = impl.CreateTableFile(table_file);
         table_file.file_type_ = milvus::engine::meta::TableFileSchema::NEW;
         int day = rand_r(&seed) % (days_num * 2);
-        table_file.created_on_ = ts - day * milvus::engine::meta::D_SEC * milvus::engine::meta::US_PS - 10000;
+        table_file.created_on_ = ts - day * milvus::engine::meta::DAY * milvus::engine::meta::US_PS - 10000;
         status = impl.UpdateTableFile(table_file);
         files.push_back(table_file);
         days.push_back(day);


### PR DESCRIPTION
Conflicts:
	core/src/db/DBImpl.cpp