### PR TITLE
Fix crashes with sptag index

### DIFF
--- a/core/src/index/knowhere/knowhere/adapter/SptagAdapter.cpp
+++ b/core/src/index/knowhere/knowhere/adapter/SptagAdapter.cpp
@@ -10,6 +10,7 @@
 // or implied. See the License for the specific language governing permissions and limitations under the License.
 
 #include "knowhere/adapter/SptagAdapter.h"
+
 #include "VectorAdapter.h"
 
 namespace knowhere {
@@ -19,7 +20,7 @@ ConvertToMetadataSet(const DatasetPtr& dataset) {
     auto elems = dataset->Get<int64_t>(meta::ROWS);
     auto p_data = dataset->Get<const int64_t*>(meta::IDS);
 
-    auto p_offset = (int64_t*)malloc(sizeof(int64_t) * elems);
+    auto p_offset = (int64_t*)malloc(sizeof(int64_t) * (elems + 1));
     for (auto i = 0; i <= elems; ++i) p_offset[i] = i * 8;
 
     std::shared_ptr<SPTAG::MetadataSet> metaset(

--- a/core/src/index/knowhere/knowhere/common/BinarySet.h
+++ b/core/src/index/knowhere/knowhere/common/BinarySet.h
@@ -11,6 +11,8 @@
 
 #pragma once
 
+#include <string.h>
+
 #include <map>
 #include <memory>
 #include <string>
@@ -27,6 +29,13 @@ struct Binary {
     int64_t size = 0;
 };
 using BinaryPtr = std::shared_ptr<Binary>;
+
+inline uint8_t*
+CopyBinary(const BinaryPtr& bin) {
+    uint8_t* newdata = new uint8_t[bin->size];
+    memcpy(newdata, bin->data.get(), bin->size);
+    return newdata;
+}
 
 class BinarySet {
  public:

--- a/core/src/index/knowhere/knowhere/index/vector_index/IndexSPTAG.cpp
+++ b/core/src/index/knowhere/knowhere/index/vector_index/IndexSPTAG.cpp
@@ -104,7 +104,7 @@ CPUSPTAGRNG::Load(const BinarySet& binary_set) {
     index_blobs.push_back(SPTAG::ByteArray(deleteid->data.get(), deleteid->size, false));
 
     auto metadata1 = binary_set.GetByName("metadata1");
-    index_blobs.push_back(SPTAG::ByteArray(metadata1->data.get(), metadata1->size, false));
+    index_blobs.push_back(SPTAG::ByteArray(CopyBinary(metadata1), metadata1->size, true));
 
     auto metadata2 = binary_set.GetByName("metadata2");
     index_blobs.push_back(SPTAG::ByteArray(metadata2->data.get(), metadata2->size, false));

--- a/core/src/scheduler/job/BuildIndexJob.cpp
+++ b/core/src/scheduler/job/BuildIndexJob.cpp
@@ -39,9 +39,10 @@ BuildIndexJob::AddToIndexFiles(const engine::meta::TableFileSchemaPtr& to_index_
                      << ", location: " << to_index_file->location_;
 
     to_index_files_[to_index_file->id_] = to_index_file;
+    return true;
 }
 
-Status&
+void
 BuildIndexJob::WaitBuildIndexFinish() {
     std::unique_lock<std::mutex> lock(mutex_);
     cv_.wait(lock, [this] { return to_index_files_.empty(); });

--- a/core/src/scheduler/job/BuildIndexJob.h
+++ b/core/src/scheduler/job/BuildIndexJob.h
@@ -44,7 +44,7 @@ class BuildIndexJob : public Job, public server::CacheConfigHandler {
     bool
     AddToIndexFiles(const TableFileSchemaPtr& to_index_file);
 
-    Status&
+    void
     WaitBuildIndexFinish();
 
     void


### PR DESCRIPTION
**What type of PR is this?**

bug

**What this PR does / why we need it:**

Fix various crashes while indexing/searching using sptag indexes.

**Special notes for your reviewer:**

Compiled with g++-9.2.
 I could reproduce crashes when indexing 50k random vectors (dim 300).
If you cant reproduce, you can compile with flags `-fsanitize=address -fsanitize-recover=all`.
Errors that lead to crashes are easily seen with this sanitizer.

 

