### PR TITLE
#1654 #1655 #1658 modify bitset from deque to vector

### DIFF
--- a/core/src/index/thirdparty/faiss/utils/ConcurrentBitset.cpp
+++ b/core/src/index/thirdparty/faiss/utils/ConcurrentBitset.cpp
@@ -19,12 +19,7 @@
 
 namespace faiss {
 
-ConcurrentBitset::ConcurrentBitset(id_type_t size) : size_(size) {
-    id_type_t bytes_count = (size >> 3) + 1;
-    // bitset_.resize(bytes_count, 0);
-    for (auto i = 0; i < bytes_count; ++i) {
-        bitset_.emplace_back(0);
-    }
+ConcurrentBitset::ConcurrentBitset(id_type_t size) : size_(size), bitset_((size + 7) >> 3) {
 }
 
 bool
@@ -40,6 +35,16 @@ ConcurrentBitset::set(id_type_t id) {
 void
 ConcurrentBitset::clear(id_type_t id) {
     bitset_[id >> 3].fetch_and(~(0x1 << (id & 0x7)));
+}
+
+ConcurrentBitset::id_type_t
+ConcurrentBitset::size() {
+    return size_;
+}
+
+const unsigned char*
+ConcurrentBitset::bitset() {
+    return reinterpret_cast<const unsigned char*>(bitset_.data());
 }
 
 }  // namespace faiss

--- a/core/src/index/thirdparty/faiss/utils/ConcurrentBitset.h
+++ b/core/src/index/thirdparty/faiss/utils/ConcurrentBitset.h
@@ -19,7 +19,7 @@
 
 #include <atomic>
 #include <memory>
-#include <deque>
+#include <vector>
 
 namespace faiss {
 
@@ -42,9 +42,16 @@ class ConcurrentBitset {
     void
     clear(id_type_t id);
 
+    id_type_t
+    size();
+
+    const unsigned char*
+    bitset();
+
  private:
-    std::deque<std::atomic<unsigned char>> bitset_;
     id_type_t size_;
+    std::vector<std::atomic<unsigned char>> bitset_;
+
 };
 
 using ConcurrentBitsetPtr = std::shared_ptr<ConcurrentBitset>;


### PR DESCRIPTION
What type of PR is this?
feature

What this PR does / why we need it:
Modify bitset from deque to vector.
It will be easier to add to delete GPU index later.

Which issue(s) this PR fixes:
prepare for #1654 #1655 #1658

Special notes for your reviewer:
youny626

Does this PR introduce a user-facing change?:
no

Additional documentation (e.g. design docs, usage docs, etc.):
none