### PR TITLE
#2403 MySQL max_idle_time is 10 by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,14 @@ Please mark all change in change log and use the issue from GitHub
 
 ## Bug
 -   \#2378 Duplicate data after server restart
+-   \#2403 MySQL max_idle_time is 10 by default
 
 ## Feature
 -   \#2363 Update branch version
 
 ## Improvement
 -   \#2370 Clean compile warning
+-   \#2381 Upgrade FAISS to 1.6.3
 
 ## Task
 

--- a/core/src/db/meta/MySQLConnectionPool.h
+++ b/core/src/db/meta/MySQLConnectionPool.h
@@ -73,7 +73,7 @@ class MySQLConnectionPool : public mysqlpp::ConnectionPool {
 
     int max_pool_size_;
 
-    unsigned int max_idle_time_ = 0;  // 10 seconds
+    unsigned int max_idle_time_ = 10;  // 10 seconds
 };
 
 }  // namespace meta


### PR DESCRIPTION
Signed-off-by: jinhai <hai.jin@zilliz.com>

**What type of PR is this?**

bug


**What this PR does / why we need it:**
MySQL connection timeout constantly

**Which issue(s) this PR fixes:**

Fixes #2403 


**Special notes for your reviewer:**
No

**Does this PR introduce a user-facing change?:**
No

**Additional documentation (e.g. design docs, usage docs, etc.):**
N/A
