### PR TITLE
Update version of Clang tools to v7.0 in ubuntu18.04 build environment

### DIFF
--- a/ci/docker/ubuntu-18.04-core.dockerfile
+++ b/ci/docker/ubuntu-18.04-core.dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends wget ca-certifi
     g++ git gfortran lsb-core \
     libboost-serialization-dev libboost-filesystem-dev libboost-system-dev libboost-regex-dev \
     curl libtool automake libssl-dev pkg-config libcurl4-openssl-dev python3-pip \
-    clang-format-7.0 clang-tidy-7.0 \
+    clang-format-7 clang-tidy-7 \
     lcov mysql-client libmysqlclient-dev intel-mkl-gnu-2019.5-281 intel-mkl-core-2019.5-281 && \
     apt-get remove --purge -y && \
     rm -rf /var/lib/apt/lists/*

--- a/ci/docker/ubuntu-18.04-core.dockerfile
+++ b/ci/docker/ubuntu-18.04-core.dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends wget ca-certifi
     g++ git gfortran lsb-core \
     libboost-serialization-dev libboost-filesystem-dev libboost-system-dev libboost-regex-dev \
     curl libtool automake libssl-dev pkg-config libcurl4-openssl-dev python3-pip \
-    clang-format-6.0 clang-tidy-6.0 \
+    clang-format-7.0 clang-tidy-7.0 \
     lcov mysql-client libmysqlclient-dev intel-mkl-gnu-2019.5-281 intel-mkl-core-2019.5-281 && \
     apt-get remove --purge -y && \
     rm -rf /var/lib/apt/lists/*

--- a/core/cmake/FindClangTools.cmake
+++ b/core/cmake/FindClangTools.cmake
@@ -33,6 +33,7 @@
 find_program(CLANG_TIDY_BIN
   NAMES
   clang-tidy-7.0
+  clang-tidy-7
   clang-tidy-6.0
   clang-tidy-5.0
   clang-tidy-4.0
@@ -86,6 +87,7 @@ else()
     find_program(CLANG_FORMAT_BIN
       NAMES
       clang-format-7.0
+      clang-format-7
       clang-format-6.0
       clang-format-5.0
       clang-format-4.0

--- a/docker/build_env/cpu/ubuntu18.04/Dockerfile
+++ b/docker/build_env/cpu/ubuntu18.04/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends wget ca-certifi
     g++ git gfortran lsb-core \
     libboost-serialization-dev libboost-filesystem-dev libboost-system-dev libboost-regex-dev \
     curl libtool automake libssl-dev pkg-config libcurl4-openssl-dev python3-pip \
-    clang-format-6.0 clang-tidy-6.0 \
+    clang-format-7.0 clang-tidy-7.0 \
     lcov mysql-client libmysqlclient-dev intel-mkl-gnu-2019.5-281 intel-mkl-core-2019.5-281 && \
     apt-get remove --purge -y && \
     rm -rf /var/lib/apt/lists/*

--- a/docker/build_env/cpu/ubuntu18.04/Dockerfile
+++ b/docker/build_env/cpu/ubuntu18.04/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends wget ca-certifi
     g++ git gfortran lsb-core \
     libboost-serialization-dev libboost-filesystem-dev libboost-system-dev libboost-regex-dev \
     curl libtool automake libssl-dev pkg-config libcurl4-openssl-dev python3-pip \
-    clang-format-7.0 clang-tidy-7.0 \
+    clang-format-7 clang-tidy-7 \
     lcov mysql-client libmysqlclient-dev intel-mkl-gnu-2019.5-281 intel-mkl-core-2019.5-281 && \
     apt-get remove --purge -y && \
     rm -rf /var/lib/apt/lists/*

--- a/docker/build_env/gpu/ubuntu18.04/Dockerfile
+++ b/docker/build_env/gpu/ubuntu18.04/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends wget && \
     apt-get update && apt-get install -y --no-install-recommends \
     git flex bison gfortran lsb-core \
     curl libtool automake libboost-all-dev libssl-dev pkg-config libcurl4-openssl-dev python3-pip \
-    clang-format-7.0 clang-tidy-7.0 \
+    clang-format-7 clang-tidy-7 \
     lcov mysql-client libmysqlclient-dev intel-mkl-gnu-2019.5-281 intel-mkl-core-2019.5-281 && \
     apt-get remove --purge -y && \
     rm -rf /var/lib/apt/lists/*

--- a/docker/build_env/gpu/ubuntu18.04/Dockerfile
+++ b/docker/build_env/gpu/ubuntu18.04/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends wget && \
     apt-get update && apt-get install -y --no-install-recommends \
     git flex bison gfortran lsb-core \
     curl libtool automake libboost-all-dev libssl-dev pkg-config libcurl4-openssl-dev python3-pip \
-    clang-format-6.0 clang-tidy-6.0 \
+    clang-format-7.0 clang-tidy-7.0 \
     lcov mysql-client libmysqlclient-dev intel-mkl-gnu-2019.5-281 intel-mkl-core-2019.5-281 && \
     apt-get remove --purge -y && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
**What type of PR is this?**

Improvement


**What this PR does / why we need it:**
Update clang tools version to v7.0 in ubuntu18.04 build environment



