### PR TITLE
Suit the range of HNSW parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please mark all change in change log and use the issue from GitHub
 -   \#2557 fix random crash of INSERT_DUPLICATE_ID case
 -   \#2598 fix Milvus docker image report illegal instruction
 -   \#2617 Fix HNSW and RNSG index files size
+-   \#2637 Suit the range of HNSW parameters
 
 ## Feature
 

--- a/core/src/index/knowhere/knowhere/index/vector_index/ConfAdapter.cpp
+++ b/core/src/index/knowhere/knowhere/index/vector_index/ConfAdapter.cpp
@@ -230,10 +230,10 @@ NSGConfAdapter::CheckSearch(Config& oricfg, const IndexType type, const IndexMod
 
 bool
 HNSWConfAdapter::CheckTrain(Config& oricfg, const IndexMode mode) {
-    static int64_t MIN_EFCONSTRUCTION = 100;
-    static int64_t MAX_EFCONSTRUCTION = 800;
-    static int64_t MIN_M = 5;
-    static int64_t MAX_M = 48;
+    static int64_t MIN_EFCONSTRUCTION = 8;
+    static int64_t MAX_EFCONSTRUCTION = 512;
+    static int64_t MIN_M = 4;
+    static int64_t MAX_M = 64;
 
     CheckIntByRange(knowhere::meta::ROWS, DEFAULT_MIN_ROWS, DEFAULT_MAX_ROWS);
     CheckIntByRange(knowhere::IndexParams::efConstruction, MIN_EFCONSTRUCTION, MAX_EFCONSTRUCTION);

--- a/core/src/utils/ValidationUtil.cpp
+++ b/core/src/utils/ValidationUtil.cpp
@@ -261,11 +261,11 @@ ValidationUtil::ValidateIndexParams(const milvus::json& index_params,
             break;
         }
         case (int32_t)engine::EngineType::HNSW: {
-            auto status = CheckParameterRange(index_params, knowhere::IndexParams::M, 5, 48);
+            auto status = CheckParameterRange(index_params, knowhere::IndexParams::M, 4, 64);
             if (!status.ok()) {
                 return status;
             }
-            status = CheckParameterRange(index_params, knowhere::IndexParams::efConstruction, 100, 500);
+            status = CheckParameterRange(index_params, knowhere::IndexParams::efConstruction, 8, 512);
             if (!status.ok()) {
                 return status;
             }


### PR DESCRIPTION
Signed-off-by: shengjun.li <shengjun.li@zilliz.com>

**What type of PR is this?**
bug

**What this PR does / why we need it:**
The valid range of HNSW parameters was unsuitable.
And from now, parameter ‘Ｍ’ can be in in the ragne of [4, 64] and parameter ‘efConstruction' can be in the ragne of [8, 512].

**Which issue(s) this PR fixes:**
Fixes #2637

**Special notes for your reviewer:**
none

**Additional documentation (e.g. design docs, usage docs, etc.):**
Milvus reference

@JinHai-CN  please cherry-pick to master