### PR TITLE
Remove request body parser in endpoint 'list_partitions'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Please mark all changes in change log and use the issue from GitHub
 -   \#2617 Fix HNSW and RNSG index files size
 -   \#2637 Suit the range of HNSW parameters
 -   \#2649 Search parameter of annoy has conflict with document
+-   \#2690 Remove body parser in show-partitions endpoints
 
 ## Feature
 -   \#2319 Redo metadata to support MVCC

--- a/core/src/server/web_impl/controller/WebController.hpp
+++ b/core/src/server/web_impl/controller/WebController.hpp
@@ -462,7 +462,6 @@ class WebController : public oatpp::web::server::api::ApiController {
 
     ENDPOINT("GET", "/collections/{collection_name}/partitions", ShowPartitions, PATH(String, collection_name),
              QUERIES(const QueryParams&, query_params)) {
-        std::cout << "Show partition start ..." << std::endl;
         TimeRecorder tr(std::string(WEB_LOG_PREFIX) + "GET \'/collections/" + collection_name->std_str() +
                         "/partitions\'");
         tr.RecordSection("Received request.");

--- a/core/src/server/web_impl/controller/WebController.hpp
+++ b/core/src/server/web_impl/controller/WebController.hpp
@@ -461,7 +461,8 @@ class WebController : public oatpp::web::server::api::ApiController {
     ADD_CORS(ShowPartitions)
 
     ENDPOINT("GET", "/collections/{collection_name}/partitions", ShowPartitions, PATH(String, collection_name),
-             QUERIES(const QueryParams&, query_params), BODY_STRING(String, body)) {
+             QUERIES(const QueryParams&, query_params)) {
+        std::cout << "Show partition start ..." << std::endl;
         TimeRecorder tr(std::string(WEB_LOG_PREFIX) + "GET \'/collections/" + collection_name->std_str() +
                         "/partitions\'");
         tr.RecordSection("Received request.");
@@ -473,7 +474,7 @@ class WebController : public oatpp::web::server::api::ApiController {
         auto handler = WebRequestHandler();
 
         std::shared_ptr<OutgoingResponse> response;
-        auto status_dto = handler.ShowPartitions(collection_name, query_params, body, partition_list_dto);
+        auto status_dto = handler.ShowPartitions(collection_name, query_params, partition_list_dto);
         switch (status_dto->code->getValue()) {
             case StatusCode::SUCCESS:
                 response = createDtoResponse(Status::CODE_200, partition_list_dto);

--- a/core/src/server/web_impl/handler/WebRequestHandler.cpp
+++ b/core/src/server/web_impl/handler/WebRequestHandler.cpp
@@ -1487,7 +1487,6 @@ WebRequestHandler::ShowPartitions(const OString& collection_name, const OQueryPa
             Status(SERVER_UNEXPECTED_ERROR, "Query param 'offset' or 'page_size' should equal or bigger than 0"));
     }
 
-
     bool all_required = false;
     auto required = query_params.get("all_required");
     if (nullptr != required.get()) {

--- a/core/src/server/web_impl/handler/WebRequestHandler.cpp
+++ b/core/src/server/web_impl/handler/WebRequestHandler.cpp
@@ -1468,7 +1468,7 @@ WebRequestHandler::CreatePartition(const OString& collection_name, const Partiti
 }
 
 StatusDto::ObjectWrapper
-WebRequestHandler::ShowPartitions(const OString& collection_name, const OQueryParams& query_params/*, const OString& body*/,
+WebRequestHandler::ShowPartitions(const OString& collection_name, const OQueryParams& query_params,
                                   PartitionListDto::ObjectWrapper& partition_list_dto) {
     int64_t offset = 0;
     auto status = ParseQueryInteger(query_params, "offset", offset);
@@ -1487,34 +1487,6 @@ WebRequestHandler::ShowPartitions(const OString& collection_name, const OQueryPa
             Status(SERVER_UNEXPECTED_ERROR, "Query param 'offset' or 'page_size' should equal or bigger than 0"));
     }
 
-//    if (nullptr != body.get() && body->getSize() > 0) {
-//        auto body_json = nlohmann::json::parse(body->c_str());
-//        if (!body_json.contains("filter")) {
-//            RETURN_STATUS_DTO(BODY_FIELD_LOSS, "Field \'filter\' is required.")
-//        }
-//        auto filter_json = body_json["filter"];
-//        if (filter_json.contains("partition_tag")) {
-//            std::string tag = filter_json["partition_tag"];
-//            bool exists = false;
-//            status = request_handler_.HasPartition(context_ptr_, collection_name->std_str(), tag, exists);
-//            if (!status.ok()) {
-//                ASSIGN_RETURN_STATUS_DTO(status)
-//            }
-//            auto partition_dto = PartitionFieldsDto::createShared();
-//            if (exists) {
-//                partition_list_dto->count = 1;
-//                partition_dto->partition_tag = tag.c_str();
-//            } else {
-//                partition_list_dto->count = 0;
-//            }
-//            partition_list_dto->partitions = partition_list_dto->partitions->createShared();
-//            partition_list_dto->partitions->pushBack(partition_dto);
-//
-//            ASSIGN_RETURN_STATUS_DTO(status)
-//        } else {
-//            RETURN_STATUS_DTO(BODY_FIELD_LOSS, "Unknown field.")
-//        }
-//    }
 
     bool all_required = false;
     auto required = query_params.get("all_required");

--- a/core/src/server/web_impl/handler/WebRequestHandler.cpp
+++ b/core/src/server/web_impl/handler/WebRequestHandler.cpp
@@ -1468,7 +1468,7 @@ WebRequestHandler::CreatePartition(const OString& collection_name, const Partiti
 }
 
 StatusDto::ObjectWrapper
-WebRequestHandler::ShowPartitions(const OString& collection_name, const OQueryParams& query_params, const OString& body,
+WebRequestHandler::ShowPartitions(const OString& collection_name, const OQueryParams& query_params/*, const OString& body*/,
                                   PartitionListDto::ObjectWrapper& partition_list_dto) {
     int64_t offset = 0;
     auto status = ParseQueryInteger(query_params, "offset", offset);
@@ -1487,34 +1487,34 @@ WebRequestHandler::ShowPartitions(const OString& collection_name, const OQueryPa
             Status(SERVER_UNEXPECTED_ERROR, "Query param 'offset' or 'page_size' should equal or bigger than 0"));
     }
 
-    if (nullptr != body.get() && body->getSize() > 0) {
-        auto body_json = nlohmann::json::parse(body->c_str());
-        if (!body_json.contains("filter")) {
-            RETURN_STATUS_DTO(BODY_FIELD_LOSS, "Field \'filter\' is required.")
-        }
-        auto filter_json = body_json["filter"];
-        if (filter_json.contains("partition_tag")) {
-            std::string tag = filter_json["partition_tag"];
-            bool exists = false;
-            status = request_handler_.HasPartition(context_ptr_, collection_name->std_str(), tag, exists);
-            if (!status.ok()) {
-                ASSIGN_RETURN_STATUS_DTO(status)
-            }
-            auto partition_dto = PartitionFieldsDto::createShared();
-            if (exists) {
-                partition_list_dto->count = 1;
-                partition_dto->partition_tag = tag.c_str();
-            } else {
-                partition_list_dto->count = 0;
-            }
-            partition_list_dto->partitions = partition_list_dto->partitions->createShared();
-            partition_list_dto->partitions->pushBack(partition_dto);
-
-            ASSIGN_RETURN_STATUS_DTO(status)
-        } else {
-            RETURN_STATUS_DTO(BODY_FIELD_LOSS, "Unknown field.")
-        }
-    }
+//    if (nullptr != body.get() && body->getSize() > 0) {
+//        auto body_json = nlohmann::json::parse(body->c_str());
+//        if (!body_json.contains("filter")) {
+//            RETURN_STATUS_DTO(BODY_FIELD_LOSS, "Field \'filter\' is required.")
+//        }
+//        auto filter_json = body_json["filter"];
+//        if (filter_json.contains("partition_tag")) {
+//            std::string tag = filter_json["partition_tag"];
+//            bool exists = false;
+//            status = request_handler_.HasPartition(context_ptr_, collection_name->std_str(), tag, exists);
+//            if (!status.ok()) {
+//                ASSIGN_RETURN_STATUS_DTO(status)
+//            }
+//            auto partition_dto = PartitionFieldsDto::createShared();
+//            if (exists) {
+//                partition_list_dto->count = 1;
+//                partition_dto->partition_tag = tag.c_str();
+//            } else {
+//                partition_list_dto->count = 0;
+//            }
+//            partition_list_dto->partitions = partition_list_dto->partitions->createShared();
+//            partition_list_dto->partitions->pushBack(partition_dto);
+//
+//            ASSIGN_RETURN_STATUS_DTO(status)
+//        } else {
+//            RETURN_STATUS_DTO(BODY_FIELD_LOSS, "Unknown field.")
+//        }
+//    }
 
     bool all_required = false;
     auto required = query_params.get("all_required");

--- a/core/src/server/web_impl/handler/WebRequestHandler.h
+++ b/core/src/server/web_impl/handler/WebRequestHandler.h
@@ -195,7 +195,7 @@ class WebRequestHandler {
     CreatePartition(const OString& collection_name, const PartitionRequestDto::ObjectWrapper& param);
 
     StatusDto::ObjectWrapper
-    ShowPartitions(const OString& collection_name, const OQueryParams& query_params/*, const OString& body*/,
+    ShowPartitions(const OString& collection_name, const OQueryParams& query_params,
                    PartitionListDto::ObjectWrapper& partition_list_dto);
 
     StatusDto::ObjectWrapper

--- a/core/src/server/web_impl/handler/WebRequestHandler.h
+++ b/core/src/server/web_impl/handler/WebRequestHandler.h
@@ -195,7 +195,7 @@ class WebRequestHandler {
     CreatePartition(const OString& collection_name, const PartitionRequestDto::ObjectWrapper& param);
 
     StatusDto::ObjectWrapper
-    ShowPartitions(const OString& collection_name, const OQueryParams& query_params, const OString& body,
+    ShowPartitions(const OString& collection_name, const OQueryParams& query_params/*, const OString& body*/,
                    PartitionListDto::ObjectWrapper& partition_list_dto);
 
     StatusDto::ObjectWrapper

--- a/core/unittest/db/test_web.cpp
+++ b/core/unittest/db/test_web.cpp
@@ -952,29 +952,6 @@ TEST_F(WebControllerTest, PARTITION) {
     ASSERT_EQ(OStatus::CODE_404.code, response->getStatusCode());
 }
 
-TEST_F(WebControllerTest, PARTITION_FILTER) {
-    const OString collection_name = "test_controller_partition_" + OString(RandomName().c_str());
-    GenCollection(client_ptr, conncetion_ptr, collection_name, 64, 100, "L2");
-
-    nlohmann::json body_json;
-    body_json["filter"]["partition_tag"] = "tag_not_exists_";
-    auto response = client_ptr->showPartitions(collection_name, "0", "10", body_json.dump().c_str());
-    ASSERT_EQ(OStatus::CODE_200.code, response->getStatusCode());
-    auto result_dto = response->readBodyToDto<milvus::server::web::PartitionListDto>(object_mapper.get());
-    ASSERT_EQ(result_dto->count->getValue(), 0);
-
-    auto par_param = milvus::server::web::PartitionRequestDto::createShared();
-    par_param->partition_tag = "tag01";
-    response = client_ptr->createPartition(collection_name, par_param);
-    ASSERT_EQ(OStatus::CODE_201.code, response->getStatusCode());
-
-    body_json["filter"]["partition_tag"] = "tag01";
-    response = client_ptr->showPartitions(collection_name, "0", "10", body_json.dump().c_str());
-    ASSERT_EQ(OStatus::CODE_200.code, response->getStatusCode());
-    result_dto = response->readBodyToDto<milvus::server::web::PartitionListDto>(object_mapper.get());
-    ASSERT_EQ(result_dto->count->getValue(), 1);
-}
-
 TEST_F(WebControllerTest, SHOW_SEGMENTS) {
     OString collection_name = OString("test_milvus_web_segments_test_") + RandomName().c_str();
 

--- a/tests/milvus_python_test/entity/test_delete.py
+++ b/tests/milvus_python_test/entity/test_delete.py
@@ -118,7 +118,7 @@ class TestDeleteBase:
         assert status.OK()
         status = connect.delete_entity_by_id(collection, ids)
         assert status.OK()
-        time.sleep(2)
+        time.sleep(5)
         status, res = connect.count_entities(collection)
         assert status.OK()
         assert res == 0


### PR DESCRIPTION
Signed-off-by: yhz <413554850@qq.com>

**What type of PR is this?**

bug 

**Need this PR be picked to master branch?**

Need cherry-pick to 0.10.1 branch.

**Which issue(s) this PR fixes:**

Fixes #2690

**What this PR does / why we need it:**

The endpoint 'list_partitions' is defined to obtain request body for 'GET' method, which may hang up requests from node client. This PR is aimed to remove request body parser.

**Special notes for your reviewer:**


**Additional documentation (e.g. design docs, usage docs, etc.):**

