### PR TITLE
Add options to build.sh for cuda arch Issue#2940

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ Please mark all changes in change log and use the issue from GitHub
 # Milvus 0.11.0 (TBD)
 
 ## Bug
-    \#2852 Fix Prometheus rebuild problem.
 -   \#2487 Remove timeout when creating collection in dev test
 -   \#2532 Fix Milvus docker image report illegal instruction
 -   \#2551 Fix test_hybrid_db and test_rpc error
@@ -27,6 +26,7 @@ Please mark all changes in change log and use the issue from GitHub
 -   \#2776 Fix too many data copies during creating IVF index
 -   \#2813 To implemente RNSG IP
 -   \#2890 Fix wrong index size
+-   \#2852 Fix Prometheus rebuild problem.
 
 ## Feature
     \#2940 Add option to build.sh for cuda arch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,10 @@ Please mark all changes in change log and use the issue from GitHub
 -   \#2768 After building the index, the number of vectors increases
 -   \#2776 Fix too many data copies during creating IVF index
 -   \#2813 To implemente RNSG IP
--   \#2890 Fix wrong index size
 -   \#2852 Fix Prometheus rebuild problem.
+-   \#2890 Fix wrong index size
 
 ## Feature
-    \#2940 Add option to build.sh for cuda arch
 -   \#2319 Redo metadata to support MVCC
 -   \#2509 Count up query statistics for debug ease
 -   \#2572 Support structured data index
@@ -38,6 +37,7 @@ Please mark all changes in change log and use the issue from GitHub
 -   \#2798 hnsw-sq8 support
 -   \#2802 Add new index: IVFSQ8NR
 -   \#2834 Add C++ sdk support 4 hnsw_sq8nr
+-   \#2940 Add option to build.sh for cuda arch
 
 ## Improvement
 -   \#2543 Remove secondary_path related code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Please mark all changes in change log and use the issue from GitHub
 -   \#2890 Fix wrong index size
 
 ## Feature
+    \#2940 Add option to build.sh for cuda arch
 -   \#2319 Redo metadata to support MVCC
 -   \#2509 Count up query statistics for debug ease
 -   \#2572 Support structured data index

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Please mark all changes in change log and use the issue from GitHub
 -   \#2813 To implemente RNSG IP
 -   \#2852 Fix Prometheus rebuild problem.
 -   \#2890 Fix wrong index size
+-   \#2952 Fix the result merging of IVF_PQ IP
 
 ## Feature
 -   \#2319 Redo metadata to support MVCC

--- a/ci/jenkins/Jenkinsfile
+++ b/ci/jenkins/Jenkinsfile
@@ -85,6 +85,7 @@ pipeline {
                                     container("milvus-${BINARY_VERSION}-build-env") {
                                         script {
                                             try{
+                                                boolean isNightlyTest = isTimeTriggeredBuild()
                                                 if (isNightlyTest || "${params.IS_MANUAL_TRIGGER_TYPE}" == "True") {
                                                     load "${env.WORKSPACE}/ci/jenkins/step/nightlyBuild.groovy"
                                                 } else {

--- a/ci/jenkins/Jenkinsfile
+++ b/ci/jenkins/Jenkinsfile
@@ -87,7 +87,7 @@ pipeline {
                                             try{
                                                 if (isNightlyTest || "${params.IS_MANUAL_TRIGGER_TYPE}" == "True") {
                                                     load "${env.WORKSPACE}/ci/jenkins/step/nightlyBuild.groovy"
-                                                else {
+                                                } else {
                                                     load "${env.WORKSPACE}/ci/jenkins/step/build.groovy"
                                                 }
                                             } catch (Exception e) {

--- a/ci/jenkins/Jenkinsfile
+++ b/ci/jenkins/Jenkinsfile
@@ -85,7 +85,11 @@ pipeline {
                                     container("milvus-${BINARY_VERSION}-build-env") {
                                         script {
                                             try{
-                                                load "${env.WORKSPACE}/ci/jenkins/step/build.groovy"
+                                                if (isNightlyTest || "${params.IS_MANUAL_TRIGGER_TYPE}" == "True") {
+                                                    load "${env.WORKSPACE}/ci/jenkins/step/nightlyBuild.groovy"
+                                                else {
+                                                    load "${env.WORKSPACE}/ci/jenkins/step/build.groovy"
+                                                }
                                             } catch (Exception e) {
                                                 containerLog "milvus-${BINARY_VERSION}-build-env"
                                                 throw e

--- a/ci/jenkins/step/build.groovy
+++ b/ci/jenkins/step/build.groovy
@@ -4,7 +4,7 @@ timeout(time: 120, unit: 'MINUTES') {
             def checkResult = sh(script: "./check_ccache.sh -l ${params.JFROG_ARTFACTORY_URL}/ccache", returnStatus: true)
     
             if ("${BINARY_VERSION}" == "gpu") {
-                sh "/bin/bash --login -c \". ./before-install.sh && ./build.sh -t ${params.BUILD_TYPE} -j4 -i ${env.MILVUS_INSTALL_PREFIX} --with_fiu --coverage -l -g -u\""
+                sh "/bin/bash --login -c \". ./before-install.sh && ./build.sh -t ${params.BUILD_TYPE} -j4 -i ${env.MILVUS_INSTALL_PREFIX} --with_fiu --coverage -l -g -u -s \"-gencode=arch=compute_61,code=sm_61 -gencode=arch=compute_75,code=sm_75\" \""
             } else {
                 sh "/bin/bash --login -c \". ./before-install.sh && ./build.sh -t ${params.BUILD_TYPE} -j4 -i ${env.MILVUS_INSTALL_PREFIX} --with_fiu --coverage -l -u\""
             }

--- a/ci/jenkins/step/build.groovy
+++ b/ci/jenkins/step/build.groovy
@@ -4,7 +4,7 @@ timeout(time: 120, unit: 'MINUTES') {
             def checkResult = sh(script: "./check_ccache.sh -l ${params.JFROG_ARTFACTORY_URL}/ccache", returnStatus: true)
     
             if ("${BINARY_VERSION}" == "gpu") {
-                sh "/bin/bash --login -c \". ./before-install.sh && ./build.sh -t ${params.BUILD_TYPE} -j4 -i ${env.MILVUS_INSTALL_PREFIX} --with_fiu --coverage -l -g -u -s \'-gencode=arch=compute_61,code=sm_61 -gencode=arch=compute_75,code=sm_75\' \""
+                sh "/bin/bash --login -c \". ./before-install.sh && ./build.sh -t ${params.BUILD_TYPE} -j4 -i ${env.MILVUS_INSTALL_PREFIX} --with_fiu --coverage -l -g -u -s '-gencode=arch=compute_61,code=sm_61;-gencode=arch=compute_75,code=sm_75' \""
             } else {
                 sh "/bin/bash --login -c \". ./before-install.sh && ./build.sh -t ${params.BUILD_TYPE} -j4 -i ${env.MILVUS_INSTALL_PREFIX} --with_fiu --coverage -l -u\""
             }

--- a/ci/jenkins/step/build.groovy
+++ b/ci/jenkins/step/build.groovy
@@ -4,7 +4,7 @@ timeout(time: 120, unit: 'MINUTES') {
             def checkResult = sh(script: "./check_ccache.sh -l ${params.JFROG_ARTFACTORY_URL}/ccache", returnStatus: true)
     
             if ("${BINARY_VERSION}" == "gpu") {
-                sh "/bin/bash --login -c \". ./before-install.sh && ./build.sh -t ${params.BUILD_TYPE} -j4 -i ${env.MILVUS_INSTALL_PREFIX} --with_fiu --coverage -l -g -u -s \'-gencode=arch=compute_61,code=sm_61 -gencode=arch=compute_75,code=sm_75\' \""
+                sh "/bin/bash --login -c \". ./before-install.sh && ./build.sh -t ${params.BUILD_TYPE} -j4 -i ${env.MILVUS_INSTALL_PREFIX} --with_fiu --coverage -l -g -u -s '-gencode=arch=compute_61,code=sm_61 -gencode=arch=compute_75,code=sm_75' \""
             } else {
                 sh "/bin/bash --login -c \". ./before-install.sh && ./build.sh -t ${params.BUILD_TYPE} -j4 -i ${env.MILVUS_INSTALL_PREFIX} --with_fiu --coverage -l -u\""
             }

--- a/ci/jenkins/step/build.groovy
+++ b/ci/jenkins/step/build.groovy
@@ -4,7 +4,7 @@ timeout(time: 120, unit: 'MINUTES') {
             def checkResult = sh(script: "./check_ccache.sh -l ${params.JFROG_ARTFACTORY_URL}/ccache", returnStatus: true)
     
             if ("${BINARY_VERSION}" == "gpu") {
-                sh "/bin/bash --login -c \". ./before-install.sh && ./build.sh -t ${params.BUILD_TYPE} -j4 -i ${env.MILVUS_INSTALL_PREFIX} --with_fiu --coverage -l -g -u -s \"-gencode=arch=compute_61,code=sm_61 -gencode=arch=compute_75,code=sm_75\" \""
+                sh "/bin/bash --login -c \". ./before-install.sh && ./build.sh -t ${params.BUILD_TYPE} -j4 -i ${env.MILVUS_INSTALL_PREFIX} --with_fiu --coverage -l -g -u -s \'-gencode=arch=compute_61,code=sm_61 -gencode=arch=compute_75,code=sm_75\' \""
             } else {
                 sh "/bin/bash --login -c \". ./before-install.sh && ./build.sh -t ${params.BUILD_TYPE} -j4 -i ${env.MILVUS_INSTALL_PREFIX} --with_fiu --coverage -l -u\""
             }

--- a/ci/jenkins/step/nightlyBuild.groovy
+++ b/ci/jenkins/step/nightlyBuild.groovy
@@ -4,7 +4,7 @@ timeout(time: 120, unit: 'MINUTES') {
             def checkResult = sh(script: "./check_ccache.sh -l ${params.JFROG_ARTFACTORY_URL}/ccache", returnStatus: true)
     
             if ("${BINARY_VERSION}" == "gpu") {
-                sh "/bin/bash --login -c \". ./before-install.sh && ./build.sh -t ${params.BUILD_TYPE} -j4 -i ${env.MILVUS_INSTALL_PREFIX} --with_fiu --coverage -l -g -u\""
+                sh "/bin/bash --login -c \". ./before-install.sh && ./build.sh -t ${params.BUILD_TYPE} -j4 -i ${env.MILVUS_INSTALL_PREFIX} --with_fiu --coverage -l -g -u -s \"-gencode=arch=compute_61,code=sm_61 -gencode=arch=compute_75,code=sm_75\" \""
             } else {
                 sh "/bin/bash --login -c \". ./before-install.sh && ./build.sh -t ${params.BUILD_TYPE} -j4 -i ${env.MILVUS_INSTALL_PREFIX} --with_fiu --coverage -l -u\""
             }

--- a/ci/jenkins/step/nightlyBuild.groovy
+++ b/ci/jenkins/step/nightlyBuild.groovy
@@ -4,7 +4,7 @@ timeout(time: 120, unit: 'MINUTES') {
             def checkResult = sh(script: "./check_ccache.sh -l ${params.JFROG_ARTFACTORY_URL}/ccache", returnStatus: true)
     
             if ("${BINARY_VERSION}" == "gpu") {
-                sh "/bin/bash --login -c \". ./before-install.sh && ./build.sh -t ${params.BUILD_TYPE} -j4 -i ${env.MILVUS_INSTALL_PREFIX} --with_fiu --coverage -l -g -u -s \"-gencode=arch=compute_61,code=sm_61 -gencode=arch=compute_75,code=sm_75\" \""
+                sh "/bin/bash --login -c \". ./before-install.sh && ./build.sh -t ${params.BUILD_TYPE} -j4 -i ${env.MILVUS_INSTALL_PREFIX} --with_fiu --coverage -l -g -u\""
             } else {
                 sh "/bin/bash --login -c \". ./before-install.sh && ./build.sh -t ${params.BUILD_TYPE} -j4 -i ${env.MILVUS_INSTALL_PREFIX} --with_fiu --coverage -l -u\""
             }

--- a/ci/scripts/build.sh
+++ b/ci/scripts/build.sh
@@ -12,6 +12,7 @@ SCRIPTS_DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 MILVUS_CORE_DIR="${SCRIPTS_DIR}/../../core"
 CORE_BUILD_DIR="${MILVUS_CORE_DIR}/cmake_build"
+CUDA_ARCH="DEFAULT"
 
 HELP="
 Usage:
@@ -26,6 +27,7 @@ Usage:
     -l                        Run cpplint & check clang-format
     -n                        No make and make install step
     -g                        Building for the architecture of the GPU in the system
+    -s [CUDA_ARCH]            Building for the cuda architecture
     --with_mkl                Build with MKL (default: OFF)
     --with_fiu                Build with FIU (default: OFF)
     -c or --coverage          Build Code Coverage
@@ -72,6 +74,10 @@ while true ; do
                 -p|--privileges) PRIVILEGES="ON" ; shift ;;
                 -v|--verbose) VERBOSE="1" ; shift ;;
                 -h|--help) echo -e "${HELP}" ; exit 0 ;;
+                -s)
+                        case "$2" in
+                                "") CUDA_ARCH="DEFAULT"; shift 2 ;;
+                                *) CUDA_ARCH=$2 ; shift 2 ;;
                 --) shift ; break ;;
                 *) echo "Internal error!" ; exit 1 ;;
         esac
@@ -125,6 +131,7 @@ CMAKE_CMD="cmake \
 -DFAISS_SOURCE=AUTO \
 -DOpenBLAS_SOURCE=AUTO \
 -DMILVUS_WITH_FIU=${FIU_ENABLE} \
+-DMILVUS_CUDA_ARCH=${CUDA_ARCH} \
 ${MILVUS_CORE_DIR}"
 echo ${CMAKE_CMD}
 ${CMAKE_CMD}

--- a/ci/scripts/build.sh
+++ b/ci/scripts/build.sh
@@ -12,7 +12,6 @@ SCRIPTS_DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 MILVUS_CORE_DIR="${SCRIPTS_DIR}/../../core"
 CORE_BUILD_DIR="${MILVUS_CORE_DIR}/cmake_build"
-CUDA_ARCH="DEFAULT"
 
 HELP="
 Usage:
@@ -23,11 +22,11 @@ Usage:
                               Install directory used by install.
     -t [BUILD_TYPE] or --build_type=[BUILD_TYPE]
                               Build type (default: Release)
+    -s [CUDA_ARCH]            Building for the cuda architecture
     -j[N] or --jobs=[N]       Allow N jobs at once; infinite jobs with no arg.
     -l                        Run cpplint & check clang-format
     -n                        No make and make install step
     -g                        Building for the architecture of the GPU in the system
-    -s [CUDA_ARCH]            Building for the cuda architecture
     --with_mkl                Build with MKL (default: OFF)
     --with_fiu                Build with FIU (default: OFF)
     -c or --coverage          Build Code Coverage
@@ -40,7 +39,7 @@ Usage:
 Use \"$0  --help\" for more information about a given command.
 "
 
-ARGS=`getopt -o "i:t:j::lngcupvh" -l "install_prefix::,build_type::,jobs::,with_mkl,with_fiu,coverage,tests,privileges,help" -n "$0" -- "$@"`
+ARGS=`getopt -o "i:t:s:j::lngcupvh" -l "install_prefix::,build_type::,jobs::,with_mkl,with_fiu,coverage,tests,privileges,help" -n "$0" -- "$@"`
 
 eval set -- "${ARGS}"
 
@@ -93,6 +92,7 @@ BUILD_UNITTEST=${BUILD_UNITTEST:="OFF"}
 BUILD_COVERAGE=${BUILD_COVERAGE:="OFF"}
 COMPILE_BUILD=${COMPILE_BUILD:="ON"}
 GPU_VERSION=${GPU_VERSION:="OFF"}
+CUDA_ARCH=${CUDA_ARCH:="DEFAULT"}
 RUN_CPPLINT=${RUN_CPPLINT:="OFF"}
 WITH_MKL=${WITH_MKL:="OFF"}
 FIU_ENABLE=${FIU_ENABLE:="OFF"}

--- a/ci/scripts/build.sh
+++ b/ci/scripts/build.sh
@@ -78,6 +78,7 @@ while true ; do
                         case "$2" in
                                 "") CUDA_ARCH="DEFAULT"; shift 2 ;;
                                 *) CUDA_ARCH=$2 ; shift 2 ;;
+                        esac ;;
                 --) shift ; break ;;
                 *) echo "Internal error!" ; exit 1 ;;
         esac

--- a/core/build.sh
+++ b/core/build.sh
@@ -16,9 +16,10 @@ FAISS_ROOT="" #FAISS root path
 FAISS_SOURCE="BUNDLED"
 WITH_PROMETHEUS="ON"
 FIU_ENABLE="OFF"
+CUDA_ARCH="DEFAULT"
 # BUILD_OPENBLAS="ON" # not used any more
 
-while getopts "p:d:t:f:ulrcghzmei" arg; do
+while getopts "p:d:t:f:s:ulrcghzmei" arg; do
   case $arg in
   p)
     INSTALL_PREFIX=$OPTARG
@@ -64,6 +65,9 @@ while getopts "p:d:t:f:ulrcghzmei" arg; do
   i)
     FIU_ENABLE="ON"
     ;;
+  s)
+    CUDA_ARCH=$OPTARG
+    ;;
   h) # help
     echo "
 
@@ -83,10 +87,11 @@ parameter:
 -m: build with MKL(default: OFF)
 -e: build without prometheus(default: OFF)
 -i: build FIU_ENABLE(default: OFF)
+-s: build with CUDA arch(default:DEFAULT), for example '-gencode=compute_61,code=sm_61'
 -h: help
 
 usage:
-./build.sh -p \${INSTALL_PREFIX} -t \${BUILD_TYPE} -f \${FAISS_ROOT} [-u] [-l] [-r] [-c] [-z] [-g] [-m] [-e] [-h]
+./build.sh -p \${INSTALL_PREFIX} -t \${BUILD_TYPE} -f \${FAISS_ROOT} -s \${CUDA_ARCH}[-u] [-l] [-r] [-c] [-z] [-g] [-m] [-e] [-h]
                 "
     exit 0
     ;;
@@ -122,6 +127,7 @@ CMAKE_CMD="cmake \
 -DFAISS_WITH_MKL=${WITH_MKL} \
 -DMILVUS_WITH_PROMETHEUS=${WITH_PROMETHEUS} \
 -DMILVUS_WITH_FIU=${FIU_ENABLE} \
+-DMILVUS_CUDA_ARCH=${CUDA_ARCH} \
 ../"
 echo ${CMAKE_CMD}
 ${CMAKE_CMD}

--- a/core/build.sh
+++ b/core/build.sh
@@ -87,7 +87,7 @@ parameter:
 -m: build with MKL(default: OFF)
 -e: build without prometheus(default: OFF)
 -i: build FIU_ENABLE(default: OFF)
--s: build with CUDA arch(default:DEFAULT), for example '-gencode=compute_61,code=sm_61'
+-s: build with CUDA arch(default:DEFAULT), for example '-gencode=compute_61,code=sm_61;-gencode=compute_75,code=sm_75'
 -h: help
 
 usage:

--- a/core/src/index/cmake/DefineOptionsCore.cmake
+++ b/core/src/index/cmake/DefineOptionsCore.cmake
@@ -84,6 +84,8 @@ define_option(KNOWHERE_WITH_FAISS_GPU_VERSION "Build with FAISS GPU version" ON)
 
 define_option(FAISS_WITH_MKL "Build FAISS with MKL" OFF)
 
+define_option(MILVUS_CUDA_ARCH "Build with CUDA arch" "DEFAULT")
+
 #----------------------------------------------------------------------
 set_option_category("Test and benchmark")
 

--- a/core/src/index/cmake/ThirdPartyPackagesCore.cmake
+++ b/core/src/index/cmake/ThirdPartyPackagesCore.cmake
@@ -541,6 +541,7 @@ macro(build_faiss)
                 "--with-cuda-arch=-gencode=arch=compute_60,code=sm_60 -gencode=arch=compute_61,code=sm_61 -gencode=arch=compute_70,code=sm_70 -gencode=arch=compute_75,code=sm_75"
                 )
         else()
+            STRING(REPLACE ";" " " MILVUS_CUDA_ARCH "${MILVUS_CUDA_ARCH}")
             set(FAISS_CONFIGURE_ARGS ${FAISS_CONFIGURE_ARGS}
                 "--with-cuda=${CUDA_TOOLKIT_ROOT_DIR}"
                 "--with-cuda-arch=${MILVUS_CUDA_ARCH}"

--- a/core/src/index/cmake/ThirdPartyPackagesCore.cmake
+++ b/core/src/index/cmake/ThirdPartyPackagesCore.cmake
@@ -535,10 +535,17 @@ macro(build_faiss)
     endif ()
 
     if (MILVUS_GPU_VERSION)
-        set(FAISS_CONFIGURE_ARGS ${FAISS_CONFIGURE_ARGS}
+        if (MILVUS_CUDA_ARCH STREQUAL "DEFAULT")
+            set(FAISS_CONFIGURE_ARGS ${FAISS_CONFIGURE_ARGS}
                 "--with-cuda=${CUDA_TOOLKIT_ROOT_DIR}"
                 "--with-cuda-arch=-gencode=arch=compute_60,code=sm_60 -gencode=arch=compute_61,code=sm_61 -gencode=arch=compute_70,code=sm_70 -gencode=arch=compute_75,code=sm_75"
                 )
+        else()
+            set(FAISS_CONFIGURE_ARGS ${FAISS_CONFIGURE_ARGS}
+                "--with-cuda=${CUDA_TOOLKIT_ROOT_DIR}"
+                "--with-cuda-arch=${MILVUS_CUDA_ARCH}"
+                )
+        endif ()
     else ()
         set(FAISS_CONFIGURE_ARGS ${FAISS_CONFIGURE_ARGS}
                 "CPPFLAGS=-DUSE_CPU"


### PR DESCRIPTION
Signed-off-by: yangxuan <xuan.yang@zilliz.com>

**What type of PR is this?**

Feature

**Which issue(s) this PR fixes:**

Fixes #2940

**Special notes for your reviewer:**

usage:

```shell
$ ./build.sh -g
$ ./build.sh -g -s "-gencode=arch=compute_61,code=sm_61"
$ ./build.sh -g -s "-gencode=arch=compute_61,code=sm_61;-gencode=arch=compute_75,code=sm_75"
```
**" "** is a must, multiple configs are separated by **;**