### PR TITLE
#3472 fix the crash caused by Task::label() is null

### DIFF
--- a/core/src/codecs/DeletedDocsFormat.cpp
+++ b/core/src/codecs/DeletedDocsFormat.cpp
@@ -86,9 +86,12 @@ DeletedDocsFormat::Write(const storage::FSHandlerPtr& fs_ptr, const std::string&
     size_t old_num_bytes;
     std::vector<engine::offset_t> delete_ids;
     if (exists) {
+        CHECK_MAGIC_VALID(fs_ptr, full_file_path);
+        CHECK_SUM_VALID(fs_ptr, full_file_path);
         if (!fs_ptr->reader_ptr_->Open(temp_path)) {
             return Status(SERVER_CANNOT_OPEN_FILE, "Fail to open tmp deleted docs file: " + temp_path);
         }
+        fs_ptr->reader_ptr_->Seekg(MAGIC_SIZE+HEADER_SIZE);
         fs_ptr->reader_ptr_->Read(&old_num_bytes, sizeof(size_t));
         delete_ids.resize(old_num_bytes / sizeof(engine::offset_t));
         fs_ptr->reader_ptr_->Read(delete_ids.data(), old_num_bytes);

--- a/core/src/codecs/DeletedDocsFormat.cpp
+++ b/core/src/codecs/DeletedDocsFormat.cpp
@@ -91,7 +91,7 @@ DeletedDocsFormat::Write(const storage::FSHandlerPtr& fs_ptr, const std::string&
         if (!fs_ptr->reader_ptr_->Open(temp_path)) {
             return Status(SERVER_CANNOT_OPEN_FILE, "Fail to open tmp deleted docs file: " + temp_path);
         }
-        fs_ptr->reader_ptr_->Seekg(MAGIC_SIZE+HEADER_SIZE);
+        fs_ptr->reader_ptr_->Seekg(MAGIC_SIZE + HEADER_SIZE);
         fs_ptr->reader_ptr_->Read(&old_num_bytes, sizeof(size_t));
         delete_ids.resize(old_num_bytes / sizeof(engine::offset_t));
         fs_ptr->reader_ptr_->Read(delete_ids.data(), old_num_bytes);

--- a/core/src/scheduler/resource/Resource.cpp
+++ b/core/src/scheduler/resource/Resource.cpp
@@ -158,9 +158,7 @@ Resource::loader_function() {
     SetThreadName("taskloader_th");
     while (running_) {
         std::unique_lock<std::mutex> lock(load_mutex_);
-        load_cv_.wait(lock, [&] {
-            return load_flag_;
-        });
+        load_cv_.wait(lock, [&] { return load_flag_; });
         load_flag_ = false;
         lock.unlock();
         while (true) {
@@ -196,9 +194,7 @@ Resource::executor_function() {
     }
     while (running_) {
         std::unique_lock<std::mutex> lock(exec_mutex_);
-        exec_cv_.wait(lock, [&] {
-            return exec_flag_;
-        });
+        exec_cv_.wait(lock, [&] { return exec_flag_; });
         exec_flag_ = false;
         lock.unlock();
         while (true) {

--- a/core/src/scheduler/resource/Resource.cpp
+++ b/core/src/scheduler/resource/Resource.cpp
@@ -158,7 +158,9 @@ Resource::loader_function() {
     SetThreadName("taskloader_th");
     while (running_) {
         std::unique_lock<std::mutex> lock(load_mutex_);
-        load_cv_.wait(lock, [&] { return load_flag_; });
+        load_cv_.wait(lock, [&] {
+            return load_flag_;
+        });
         load_flag_ = false;
         lock.unlock();
         while (true) {
@@ -194,7 +196,9 @@ Resource::executor_function() {
     }
     while (running_) {
         std::unique_lock<std::mutex> lock(exec_mutex_);
-        exec_cv_.wait(lock, [&] { return exec_flag_; });
+        exec_cv_.wait(lock, [&] {
+            return exec_flag_;
+        });
         exec_flag_ = false;
         lock.unlock();
         while (true) {
@@ -217,7 +221,7 @@ Resource::executor_function() {
                 ResMgrInst::GetInstance()->GetResource("disk")->WakeupLoader();
             }
 
-            task_item->task = FinishedTask::Create();
+            task_item->task = FinishedTask::Create(task_item->task);
 
             if (subscriber_) {
                 auto event = std::make_shared<FinishTaskEvent>(shared_from_this(), task_item);

--- a/core/src/scheduler/task/FinishedTask.cpp
+++ b/core/src/scheduler/task/FinishedTask.cpp
@@ -14,11 +14,14 @@
 namespace milvus::scheduler {
 
 std::shared_ptr<FinishedTask>
-FinishedTask::Create() {
-    return std::make_shared<FinishedTask>();
+FinishedTask::Create(const TaskPtr& task) {
+    return std::make_shared<FinishedTask>(task);
 }
 
-FinishedTask::FinishedTask() : Task(TaskType::SearchTask, nullptr) {
+FinishedTask::FinishedTask(const TaskPtr& task) : Task(TaskType::SearchTask, nullptr) {
+    Task::task_path_ = task->task_path_;
+    Task::type_ = task->type_;
+    Task::label_ = task->label_;
 }
 
 Status

--- a/core/src/scheduler/task/FinishedTask.h
+++ b/core/src/scheduler/task/FinishedTask.h
@@ -20,10 +20,10 @@ namespace milvus::scheduler {
 class FinishedTask : public Task {
  public:
     static std::shared_ptr<FinishedTask>
-    Create();
+    Create(const TaskPtr& task);
 
  public:
-    FinishedTask();
+    FinishedTask(const TaskPtr& task);
 
     Status
     OnLoad(LoadType type, uint8_t device_id) override;

--- a/core/src/scheduler/task/FinishedTask.h
+++ b/core/src/scheduler/task/FinishedTask.h
@@ -23,7 +23,7 @@ class FinishedTask : public Task {
     Create(const TaskPtr& task);
 
  public:
-    FinishedTask(const TaskPtr& task);
+    explicit FinishedTask(const TaskPtr& task);
 
     Status
     OnLoad(LoadType type, uint8_t device_id) override;


### PR DESCRIPTION
Signed-off-by: godchen0212 <qingxiang.chen@zilliz.com>

**What type of PR is this?**

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which branch you want to cherry-pick to?**

Not Available

**Which issue(s) this PR fixes:**

Fixes #3472 
Fixes #3490 

**What this PR does / why we need it:**

fix the bug of searching concurrently with avoid task label() to be null #issue 3472 and fix the bug caused by incorrect read in temp delete docs #issue 3490

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
