### PR TITLE
use shared_mutex instead of mutex

### DIFF
--- a/core/src/db/meta/backend/MySqlEngine.cpp
+++ b/core/src/db/meta/backend/MySqlEngine.cpp
@@ -227,7 +227,6 @@ MySqlEngine::Query(const MetaQueryContext& context, AttrsMapList& attrs) {
             return status;
         }
 
-        // std::lock_guard<std::mutex> lock(meta_mutex_);
         mysqlpp::Query query = connectionPtr->query(sql);
         auto res = query.store();
         if (!res) {
@@ -286,7 +285,6 @@ MySqlEngine::ExecuteTransaction(const std::vector<MetaApplyContext>& sql_context
 
         mysqlpp::Transaction trans(*connectionPtr, mysqlpp::Transaction::serializable, mysqlpp::Transaction::session);
 
-        // std::lock_guard<std::mutex> lock(meta_mutex_);
         for (auto& context : sql_contexts) {
             std::string sql;
             status = MetaHelper::MetaApplyContextToSql(context, sql);

--- a/core/src/db/meta/backend/MySqlEngine.h
+++ b/core/src/db/meta/backend/MySqlEngine.h
@@ -12,7 +12,6 @@
 #pragma once
 
 #include <memory>
-#include <mutex>
 #include <vector>
 
 #include "db/Types.h"
@@ -48,8 +47,6 @@ class MySqlEngine : public MetaEngine {
 
     std::shared_ptr<meta::MySQLConnectionPool> mysql_connection_pool_;
     bool safe_grab_ = false;  // Safely graps a connection from mysql pool
-
-    std::mutex meta_mutex_;
 };
 
 }  // namespace milvus::engine::meta

--- a/core/src/db/meta/backend/SqliteEngine.cpp
+++ b/core/src/db/meta/backend/SqliteEngine.cpp
@@ -207,7 +207,7 @@ SqliteEngine::Query(const MetaQueryContext& context, AttrsMapList& attrs) {
     std::string sql;
 
     STATUS_CHECK(MetaHelper::MetaQueryContextToSql(context, sql));
-    std::lock_guard<std::mutex> lock(meta_mutex_);
+    std::shared_lock<std::shared_mutex> lock(meta_mutex_);
 
     QueryData = &attrs;
     if (SQLITE_OK != sqlite3_exec(db_, sql.c_str(), QueryCallback, nullptr, nullptr)) {
@@ -230,7 +230,7 @@ SqliteEngine::ExecuteTransaction(const std::vector<MetaApplyContext>& sql_contex
         sqls.push_back(sql);
     }
 
-    std::lock_guard<std::mutex> lock(meta_mutex_);
+    std::unique_lock<std::shared_mutex> lock(meta_mutex_);
     if (SQLITE_OK != sqlite3_exec(db_, "BEGIN", nullptr, nullptr, nullptr)) {
         std::string sql_err = "Sqlite begin transaction failed: " + ErrorMsg(db_);
         return Status(DB_ERROR, sql_err);

--- a/core/src/db/meta/backend/SqliteEngine.h
+++ b/core/src/db/meta/backend/SqliteEngine.h
@@ -11,7 +11,7 @@
 
 #pragma once
 
-#include <mutex>
+#include <shared_mutex>
 #include <vector>
 
 #include <sqlite3.h>
@@ -43,7 +43,7 @@ class SqliteEngine : public MetaEngine {
  private:
     DBMetaOptions options_;
     sqlite3* db_;
-    std::mutex meta_mutex_;
+    mutable std::shared_mutex meta_mutex_;
 };
 
 }  // namespace milvus::engine::meta


### PR DESCRIPTION
**What type of PR is this?**

- [x] Improvement

**What this PR does / why we need it:**

Use `shared_mutex` instead of `mutex` to avoid contention between readings
