### PR TITLE
#3656 Search with nprobe=0 should be invalid for BIN_IVF_FLAT index

### DIFF
--- a/core/src/index/knowhere/knowhere/index/vector_index/ConfAdapterMgr.cpp
+++ b/core/src/index/knowhere/knowhere/index/vector_index/ConfAdapterMgr.cpp
@@ -42,7 +42,7 @@ AdapterMgr::RegisterAdapter() {
     REGISTER_CONF_ADAPTER(IVFSQConfAdapter, IndexEnum::INDEX_FAISS_IVFSQ8, ivfsq8_adapter);
     REGISTER_CONF_ADAPTER(IVFSQConfAdapter, IndexEnum::INDEX_FAISS_IVFSQ8H, ivfsq8h_adapter);
     REGISTER_CONF_ADAPTER(BinIDMAPConfAdapter, IndexEnum::INDEX_FAISS_BIN_IDMAP, idmap_bin_adapter);
-    REGISTER_CONF_ADAPTER(BinIDMAPConfAdapter, IndexEnum::INDEX_FAISS_BIN_IVFFLAT, ivf_bin_adapter);
+    REGISTER_CONF_ADAPTER(BinIVFConfAdapter, IndexEnum::INDEX_FAISS_BIN_IVFFLAT, ivf_bin_adapter);
     REGISTER_CONF_ADAPTER(NSGConfAdapter, IndexEnum::INDEX_NSG, nsg_adapter);
 #ifdef MILVUS_SUPPORT_SPTAG
     REGISTER_CONF_ADAPTER(ConfAdapter, IndexEnum::INDEX_SPTAG_KDT_RNT, sptag_kdt_adapter);

--- a/tests/milvus_python_test/entity/test_search.py
+++ b/tests/milvus_python_test/entity/test_search.py
@@ -1579,6 +1579,22 @@ class TestSearchInvalid(object):
             res = connect.search(collection, query)
 
     @pytest.mark.level(2)
+    def test_search_with_invalid_params_binary(self, connect, binary_collection):
+        '''
+        target: test search fuction, with the wrong nprobe
+        method: search with nprobe
+        expected: raise an error, and the connection is normal
+        '''
+        nq = 1
+        index_type = "BIN_IVF_FLAT"
+        int_vectors, entities, ids = init_binary_data(connect, binary_collection)
+        query_int_vectors, query_entities, tmp_ids = init_binary_data(connect, binary_collection, nb=1, insert=False)
+        connect.create_index(binary_collection, binary_field_name, {"index_type": index_type, "metric_type": "JACCARD", "params": {"nlist": 1024}})
+        query, vecs = gen_query_vectors(binary_field_name, query_entities, top_k, nq, search_params={"nprobe": 0}, metric_type="JACCARD")
+        with pytest.raises(Exception) as e:
+            res = connect.search(binary_collection, query)
+
+    @pytest.mark.level(2)
     def test_search_with_empty_params(self, connect, collection, args, get_simple_index):
         '''
         target: test search fuction, with empty search params


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

Fixes #3656

**What this PR does / why we need it:**

Fix nprobe error

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
