### PR TITLE
raise the limitation of hnsw ef parameter to 32768

### DIFF
--- a/core/src/index/knowhere/knowhere/index/vector_index/ConfAdapter.cpp
+++ b/core/src/index/knowhere/knowhere/index/vector_index/ConfAdapter.cpp
@@ -270,7 +270,7 @@ HNSWConfAdapter::CheckTrain(Config& oricfg, const IndexMode mode) {
 
 bool
 HNSWConfAdapter::CheckSearch(Config& oricfg, const IndexType type, const IndexMode mode) {
-    static int64_t MAX_EF = 4096;
+    static int64_t MAX_EF = 32768;
 
     CheckIntByRange(knowhere::IndexParams::ef, oricfg[knowhere::meta::TOPK], MAX_EF);
 

--- a/core/src/utils/ValidationUtil.cpp
+++ b/core/src/utils/ValidationUtil.cpp
@@ -306,7 +306,7 @@ ValidationUtil::ValidateSearchParams(const milvus::json& search_params,
             break;
         }
         case (int32_t)engine::EngineType::HNSW: {
-            auto status = CheckParameterRange(search_params, knowhere::IndexParams::ef, topk, 4096);
+            auto status = CheckParameterRange(search_params, knowhere::IndexParams::ef, topk, 32768);
             if (!status.ok()) {
                 return status;
             }


### PR DESCRIPTION
Signed-off-by: cmli <chengming.li@zilliz.com>

**What type of PR is this?**

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

Fixes #3639 

**What this PR does / why we need it:**

raise the limitation of hnsw ef parameter to 32768 because topk's limitation has raised to 16384.

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
