### PR TITLE
If the number of tasks to be executed great equal than 1, stop loading

### DIFF
--- a/core/src/scheduler/TaskTable.cpp
+++ b/core/src/scheduler/TaskTable.cpp
@@ -174,7 +174,7 @@ TaskTable::PickToLoad(uint64_t limit) {
         } else if (table_[index]->state == TaskTableItemState::LOADED) {
             cross = true;
             ++loaded_count;
-            if (loaded_count > 2) {
+            if (loaded_count >= 2) {
                 return std::vector<uint64_t>();
             }
         } else if (table_[index]->state == TaskTableItemState::START) {

--- a/core/src/scheduler/TaskTable.cpp
+++ b/core/src/scheduler/TaskTable.cpp
@@ -174,7 +174,7 @@ TaskTable::PickToLoad(uint64_t limit) {
         } else if (table_[index]->state == TaskTableItemState::LOADED) {
             cross = true;
             ++loaded_count;
-            if (loaded_count >= 2) {
+            if (loaded_count >= 1) {
                 return std::vector<uint64_t>();
             }
         } else if (table_[index]->state == TaskTableItemState::START) {


### PR DESCRIPTION
Signed-off-by: Wang Xiangyu <xy.wang@zilliz.com>

**What type of PR is this?**

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

Fixes #3835

**What this PR does / why we need it:**

Limit the number of tasks to executed avoid excessive GPU memory usage.
