### PR TITLE
update codeowner of CHANGELOG.md

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,7 @@
 # Each line is a component followed by one or more owners. 
 
 *                        @JinHai-CN
+CHANGELOG.md             @milvus-io/reviewer
 /.jenkins/               @jeffoverflow @cydrain
 /ci/                     @jeffoverflow @cydrain
 /core/                   @scsven


### PR DESCRIPTION
Signed-off-by: Wang Xiangyu <xy.wang@zilliz.com>

Update codeowner of CHANGELOG.md