### PR TITLE
Use single-quotes instead of double-quotes in jenkinsfile

### DIFF
--- a/.jenkins/modules/Build/MilvusBuild.groovy
+++ b/.jenkins/modules/Build/MilvusBuild.groovy
@@ -13,9 +13,9 @@ timeout(time: 60, unit: 'MINUTES') {
 		}
 
 		withCredentials([usernamePassword(credentialsId: "${params.JFROG_CREDENTIALS_ID}", usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
-			sh '. ./before-install.sh && ./update_cache.sh -l ${params.JFROG_ARTFACTORY_URL}/ccache --cache_dir=\${CCACHE_DIR} -f \${CCACHE_COMPRESS_PACKAGE_FILE} -u $USERNAME -p $PASSWORD'
+			sh '. ./before-install.sh && ./update_cache.sh -l $JFROG_ARTFACTORY_URL/ccache --cache_dir=\${CCACHE_DIR} -f \${CCACHE_COMPRESS_PACKAGE_FILE} -u $USERNAME -p $PASSWORD'
 			if (isTimeTriggeredBuild) {
-				sh '. ./before-install.sh && ./update_cache.sh -l ${params.JFROG_ARTFACTORY_URL}/thirdparty --cache_dir=\${CUSTOM_THIRDPARTY_DOWNLOAD_PATH} -f \${THIRDPARTY_COMPRESS_PACKAGE_FILE} -u $USERNAME -p $PASSWORD'
+				sh '. ./before-install.sh && ./update_cache.sh -l $JFROG_ARTFACTORY_URL/thirdparty --cache_dir=\${CUSTOM_THIRDPARTY_DOWNLOAD_PATH} -f \${THIRDPARTY_COMPRESS_PACKAGE_FILE} -u $USERNAME -p $PASSWORD'
 			}
 		}
 	}

--- a/.jenkins/modules/Build/MilvusBuild.groovy
+++ b/.jenkins/modules/Build/MilvusBuild.groovy
@@ -13,9 +13,9 @@ timeout(time: 60, unit: 'MINUTES') {
 		}
 
 		withCredentials([usernamePassword(credentialsId: "${params.JFROG_CREDENTIALS_ID}", usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
-			sh ". ./before-install.sh && ./update_cache.sh -l ${params.JFROG_ARTFACTORY_URL}/ccache --cache_dir=\${CCACHE_DIR} -f \${CCACHE_COMPRESS_PACKAGE_FILE} -u ${USERNAME} -p ${PASSWORD}"
+			sh '. ./before-install.sh && ./update_cache.sh -l ${params.JFROG_ARTFACTORY_URL}/ccache --cache_dir=\${CCACHE_DIR} -f \${CCACHE_COMPRESS_PACKAGE_FILE} -u $USERNAME -p $PASSWORD'
 			if (isTimeTriggeredBuild) {
-				sh ". ./before-install.sh && ./update_cache.sh -l ${params.JFROG_ARTFACTORY_URL}/thirdparty --cache_dir=\${CUSTOM_THIRDPARTY_DOWNLOAD_PATH} -f \${THIRDPARTY_COMPRESS_PACKAGE_FILE} -u ${USERNAME} -p ${PASSWORD}"
+				sh '. ./before-install.sh && ./update_cache.sh -l ${params.JFROG_ARTFACTORY_URL}/thirdparty --cache_dir=\${CUSTOM_THIRDPARTY_DOWNLOAD_PATH} -f \${THIRDPARTY_COMPRESS_PACKAGE_FILE} -u $USERNAME -p $PASSWORD'
 			}
 		}
 	}

--- a/.jenkins/modules/Build/PackageBuild.groovy
+++ b/.jenkins/modules/Build/PackageBuild.groovy
@@ -1,7 +1,7 @@
 sh "rm -rf ${env.MILVUS_INSTALL_PREFIX}/unittest"
 sh "tar -zcvf ./${env.PROJECT_NAME}-${env.PACKAGE_VERSION}.tar.gz -C ${env.MILVUS_ROOT_PATH}/ ${env.PROJECT_NAME}"
 withCredentials([usernamePassword(credentialsId: "${params.JFROG_CREDENTIALS_ID}", usernameVariable: 'JFROG_USERNAME', passwordVariable: 'JFROG_PASSWORD')]) {
-    def uploadStatus = sh(returnStatus: true, script: "curl -u${JFROG_USERNAME}:${JFROG_PASSWORD} -T ./${env.PROJECT_NAME}-${env.PACKAGE_VERSION}.tar.gz ${params.JFROG_ARTFACTORY_URL}/milvus/package/${env.PROJECT_NAME}-${env.PACKAGE_VERSION}.tar.gz")
+    def uploadStatus = sh(returnStatus: true, script: 'curl -u$JFROG_USERNAME:$JFROG_PASSWORD -T ./${env.PROJECT_NAME}-${env.PACKAGE_VERSION}.tar.gz ${params.JFROG_ARTFACTORY_URL}/milvus/package/${env.PROJECT_NAME}-${env.PACKAGE_VERSION}.tar.gz')
     if (uploadStatus != 0) {
         error("\" ${env.PROJECT_NAME}-${env.PACKAGE_VERSION}.tar.gz \" upload to \" ${params.JFROG_ARTFACTORY_URL}/milvus/package/${env.PROJECT_NAME}-${env.PACKAGE_VERSION}.tar.gz \" failed!")
     }

--- a/.jenkins/modules/Build/PackageBuild.groovy
+++ b/.jenkins/modules/Build/PackageBuild.groovy
@@ -1,7 +1,7 @@
 sh "rm -rf ${env.MILVUS_INSTALL_PREFIX}/unittest"
 sh "tar -zcvf ./${env.PROJECT_NAME}-${env.PACKAGE_VERSION}.tar.gz -C ${env.MILVUS_ROOT_PATH}/ ${env.PROJECT_NAME}"
 withCredentials([usernamePassword(credentialsId: "${params.JFROG_CREDENTIALS_ID}", usernameVariable: 'JFROG_USERNAME', passwordVariable: 'JFROG_PASSWORD')]) {
-    def uploadStatus = sh(returnStatus: true, script: 'curl -u$JFROG_USERNAME:$JFROG_PASSWORD -T ./${env.PROJECT_NAME}-${env.PACKAGE_VERSION}.tar.gz ${params.JFROG_ARTFACTORY_URL}/milvus/package/${env.PROJECT_NAME}-${env.PACKAGE_VERSION}.tar.gz')
+    def uploadStatus = sh(returnStatus: true, script: 'curl -u$JFROG_USERNAME:$JFROG_PASSWORD -T ./$PROJECT_NAME-$PACKAGE_VERSION.tar.gz $JFROG_ARTFACTORY_URL/milvus/package/$PROJECT_NAME-$PACKAGE_VERSION.tar.gz')
     if (uploadStatus != 0) {
         error("\" ${env.PROJECT_NAME}-${env.PACKAGE_VERSION}.tar.gz \" upload to \" ${params.JFROG_ARTFACTORY_URL}/milvus/package/${env.PROJECT_NAME}-${env.PACKAGE_VERSION}.tar.gz \" failed!")
     }

--- a/.jenkins/modules/Publish/Publish.groovy
+++ b/.jenkins/modules/Publish/Publish.groovy
@@ -2,7 +2,7 @@ dir ("docker/deploy") {
     def binaryPackage = "${PROJECT_NAME}-${PACKAGE_VERSION}.tar.gz"
 
     withCredentials([usernamePassword(credentialsId: "${params.JFROG_CREDENTIALS_ID}", usernameVariable: 'JFROG_USERNAME', passwordVariable: 'JFROG_PASSWORD')]) {
-        def downloadStatus = sh(returnStatus: true, script: "curl -u${JFROG_USERNAME}:${JFROG_PASSWORD} -O ${params.JFROG_ARTFACTORY_URL}/milvus/package/${binaryPackage}")
+        def downloadStatus = sh(returnStatus: true, script: 'curl -u$JFROG_USERNAME:$JFROG_PASSWORD -O ${params.JFROG_ARTFACTORY_URL}/milvus/package/${binaryPackage}')
 
         if (downloadStatus != 0) {
             error("\" Download \" ${params.JFROG_ARTFACTORY_URL}/milvus/package/${binaryPackage} \" failed!")
@@ -16,7 +16,7 @@ dir ("docker/deploy") {
         sh "docker-compose build --force-rm ${BINARY_VERSION}_${OS_NAME}"
         try {
             withCredentials([usernamePassword(credentialsId: "${params.DOCKER_CREDENTIALS_ID}", usernameVariable: 'DOCKER_USERNAME', passwordVariable: 'DOCKER_PASSWORD')]) {
-                sh "docker login -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD} ${params.DOKCER_REGISTRY_URL}"
+                sh 'docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD ${params.DOKCER_REGISTRY_URL}'
                 sh "docker-compose push ${BINARY_VERSION}_${OS_NAME}"
             }
         } catch (exc) {

--- a/.jenkins/modules/Publish/Publish.groovy
+++ b/.jenkins/modules/Publish/Publish.groovy
@@ -2,7 +2,7 @@ dir ("docker/deploy") {
     def binaryPackage = "${PROJECT_NAME}-${PACKAGE_VERSION}.tar.gz"
 
     withCredentials([usernamePassword(credentialsId: "${params.JFROG_CREDENTIALS_ID}", usernameVariable: 'JFROG_USERNAME', passwordVariable: 'JFROG_PASSWORD')]) {
-        def downloadStatus = sh(returnStatus: true, script: 'curl -u$JFROG_USERNAME:$JFROG_PASSWORD -O $JFROG_ARTFACTORY_URL/milvus/package/${binaryPackage}')
+        def downloadStatus = sh(returnStatus: true, script: 'curl -u$JFROG_USERNAME:$JFROG_PASSWORD -O $JFROG_ARTFACTORY_URL/milvus/package/$PROJECT_NAME-$PACKAGE_VERSION.tar.gz')
 
         if (downloadStatus != 0) {
             error("\" Download \" ${params.JFROG_ARTFACTORY_URL}/milvus/package/${binaryPackage} \" failed!")

--- a/.jenkins/modules/Publish/Publish.groovy
+++ b/.jenkins/modules/Publish/Publish.groovy
@@ -2,7 +2,7 @@ dir ("docker/deploy") {
     def binaryPackage = "${PROJECT_NAME}-${PACKAGE_VERSION}.tar.gz"
 
     withCredentials([usernamePassword(credentialsId: "${params.JFROG_CREDENTIALS_ID}", usernameVariable: 'JFROG_USERNAME', passwordVariable: 'JFROG_PASSWORD')]) {
-        def downloadStatus = sh(returnStatus: true, script: 'curl -u$JFROG_USERNAME:$JFROG_PASSWORD -O ${params.JFROG_ARTFACTORY_URL}/milvus/package/${binaryPackage}')
+        def downloadStatus = sh(returnStatus: true, script: 'curl -u$JFROG_USERNAME:$JFROG_PASSWORD -O $JFROG_ARTFACTORY_URL/milvus/package/$binaryPackage')
 
         if (downloadStatus != 0) {
             error("\" Download \" ${params.JFROG_ARTFACTORY_URL}/milvus/package/${binaryPackage} \" failed!")
@@ -16,7 +16,7 @@ dir ("docker/deploy") {
         sh "docker-compose build --force-rm ${BINARY_VERSION}_${OS_NAME}"
         try {
             withCredentials([usernamePassword(credentialsId: "${params.DOCKER_CREDENTIALS_ID}", usernameVariable: 'DOCKER_USERNAME', passwordVariable: 'DOCKER_PASSWORD')]) {
-                sh 'docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD ${params.DOKCER_REGISTRY_URL}'
+                sh 'docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD $DOKCER_REGISTRY_URL'
                 sh "docker-compose push ${BINARY_VERSION}_${OS_NAME}"
             }
         } catch (exc) {

--- a/.jenkins/modules/Publish/Publish.groovy
+++ b/.jenkins/modules/Publish/Publish.groovy
@@ -2,7 +2,7 @@ dir ("docker/deploy") {
     def binaryPackage = "${PROJECT_NAME}-${PACKAGE_VERSION}.tar.gz"
 
     withCredentials([usernamePassword(credentialsId: "${params.JFROG_CREDENTIALS_ID}", usernameVariable: 'JFROG_USERNAME', passwordVariable: 'JFROG_PASSWORD')]) {
-        def downloadStatus = sh(returnStatus: true, script: 'curl -u$JFROG_USERNAME:$JFROG_PASSWORD -O $JFROG_ARTFACTORY_URL/milvus/package/$binaryPackage')
+        def downloadStatus = sh(returnStatus: true, script: 'curl -u$JFROG_USERNAME:$JFROG_PASSWORD -O $JFROG_ARTFACTORY_URL/milvus/package/${binaryPackage}')
 
         if (downloadStatus != 0) {
             error("\" Download \" ${params.JFROG_ARTFACTORY_URL}/milvus/package/${binaryPackage} \" failed!")


### PR DESCRIPTION
Signed-off-by: quicksilver <zhifeng.zhang@zilliz.com>

**What type of PR is this?**

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

Fixes #

**What this PR does / why we need it:**

Using single-quotes instead of double-quotes when referencing these sensitive environment variables prevents this type of leaking.

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
