### PR TITLE
fix virtual destructor

### DIFF
--- a/core/src/cache/DataObj.h
+++ b/core/src/cache/DataObj.h
@@ -20,6 +20,7 @@ class DataObj {
  public:
     virtual int64_t
     Size() = 0;
+    virtual ~DataObj() = default;
 };
 
 using DataObjPtr = std::shared_ptr<DataObj>;


### PR DESCRIPTION
**What type of PR is this?**
- [x] BUG


**Which issue(s) this PR fixes:**

Any base class that has virtual functions should have a virtual destructor, for correctly destructing derived objects via base references. 