### PR TITLE
Minor memory leak when building IVF_SQ8 on GPU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Please mark all change in change log and use the issue from GitHub
 # Milvus 1.0.0-beta (TBD)
 ## Bug
 -   \#4739 Fix mishards probe test problem
+-   \#4749 Fix minor memory leak when building IVF_SQ8 on GPU
 
 ## Feature
 -   \#3977 Support logging to stdout

--- a/core/src/index/knowhere/knowhere/common/Exception.cpp
+++ b/core/src/index/knowhere/knowhere/common/Exception.cpp
@@ -9,6 +9,7 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
+#include <string.h>
 #include <cstdio>
 
 #include "Log.h"
@@ -26,13 +27,13 @@ KnowhereException::KnowhereException(const std::string& m, const char* funcName,
     msg.resize(size + 1);
     snprintf(&msg[0], msg.size(), "Error in %s at %s:%d: %s", funcName, file, line, m.c_str());
 #else
-    std::string file_path(file);
-    auto const pos = file_path.find_last_of('/');
-    auto filename = file_path.substr(pos + 1).c_str();
-
+    const char* filename = funcName;
+    while (auto tmp = strchr(filename, '/')) {
+        filename = tmp + 1;
+    }
     int size = snprintf(nullptr, 0, "Error in %s at %s:%d: %s", funcName, filename, line, m.c_str());
     msg.resize(size + 1);
-    snprintf(&msg[0], msg.size(), "Error in %s at %s:%d: %s", funcName, filename, line, m.c_str());
+    snprintf(msg.data(), msg.size(), "Error in %s at %s:%d: %s", funcName, filename, line, m.c_str());
 #endif
 }
 

--- a/core/src/index/knowhere/knowhere/index/vector_index/gpu/IndexGPUIVFPQ.cpp
+++ b/core/src/index/knowhere/knowhere/index/vector_index/gpu/IndexGPUIVFPQ.cpp
@@ -32,12 +32,10 @@ GPUIVFPQ::Train(const DatasetPtr& dataset_ptr, const Config& config) {
     auto gpu_res = FaissGpuResourceMgr::GetInstance().GetRes(gpu_id_);
     if (gpu_res != nullptr) {
         ResScope rs(gpu_res, gpu_id_, true);
-        auto device_index =
-            new faiss::gpu::GpuIndexIVFPQ(gpu_res->faiss_res.get(), dim, config[IndexParams::nlist].get<int64_t>(),
-                                          config[IndexParams::m], config[IndexParams::nbits],
-                                          GetMetricType(config[Metric::TYPE].get<std::string>()));  // IP not support
+        auto device_index = new faiss::gpu::GpuIndexIVFPQ(
+            gpu_res->faiss_res.get(), dim, config[IndexParams::nlist].get<int64_t>(), config[IndexParams::m],
+            config[IndexParams::nbits], GetMetricType(config[Metric::TYPE].get<std::string>()));
         device_index->train(rows, (float*)p_data);
-
         index_.reset(device_index);
         res_ = gpu_res;
     } else {

--- a/core/src/index/knowhere/knowhere/index/vector_index/gpu/IndexIVFSQHybrid.cpp
+++ b/core/src/index/knowhere/knowhere/index/vector_index/gpu/IndexIVFSQHybrid.cpp
@@ -51,6 +51,7 @@ IVFSQHybrid::Train(const DatasetPtr& dataset_ptr, const Config& config) {
         gpu_mode_ = 2;
         index_mode_ = IndexMode::MODE_GPU;
     } else {
+        delete build_index;
         KNOWHERE_THROW_MSG("Build IVFSQHybrid can't get gpu resource");
     }
 

--- a/core/src/index/unittest/test_annoy.cpp
+++ b/core/src/index/unittest/test_annoy.cpp
@@ -66,6 +66,7 @@ TEST_P(AnnoyTest, annoy_basic) {
 
     auto result = index_->Query(query_dataset, conf);
     AssertAnns(result, nq, k);
+    ReleaseQueryResult(result);
 
     /*
      * output result to check by eyes
@@ -105,10 +106,12 @@ TEST_P(AnnoyTest, annoy_delete) {
 
     auto result1 = index_->Query(query_dataset, conf);
     AssertAnns(result1, nq, k);
+    ReleaseQueryResult(result1);
 
     index_->SetBlacklist(bitset);
     auto result2 = index_->Query(query_dataset, conf);
     AssertAnns(result2, nq, k, CheckMode::CHECK_NOT_EQUAL);
+    ReleaseQueryResult(result2);
 
     /*
      * delete result checked by eyes
@@ -201,6 +204,7 @@ TEST_P(AnnoyTest, annoy_serialize) {
         ASSERT_EQ(index_->Dim(), dim);
         auto result = index_->Query(query_dataset, conf);
         AssertAnns(result, nq, conf[milvus::knowhere::meta::TOPK]);
+        ReleaseQueryResult(result);
     }
 }
 

--- a/core/src/index/unittest/test_binaryidmap.cpp
+++ b/core/src/index/unittest/test_binaryidmap.cpp
@@ -64,6 +64,7 @@ TEST_P(BinaryIDMAPTest, binaryidmap_basic) {
     auto result = index_->Query(query_dataset, conf);
     AssertAnns(result, nq, k);
     // PrintResult(result, nq, k);
+    ReleaseQueryResult(result);
 
     auto binaryset = index_->Serialize();
     auto new_index = std::make_shared<milvus::knowhere::BinaryIDMAP>();
@@ -71,6 +72,7 @@ TEST_P(BinaryIDMAPTest, binaryidmap_basic) {
     auto result2 = new_index->Query(query_dataset, conf);
     AssertAnns(result2, nq, k);
     // PrintResult(re_result, nq, k);
+    ReleaseQueryResult(result2);
 
     faiss::ConcurrentBitsetPtr concurrent_bitset_ptr = std::make_shared<faiss::ConcurrentBitset>(nb);
     for (int64_t i = 0; i < nq; ++i) {
@@ -80,6 +82,7 @@ TEST_P(BinaryIDMAPTest, binaryidmap_basic) {
 
     auto result_bs_1 = index_->Query(query_dataset, conf);
     AssertAnns(result_bs_1, nq, k, CheckMode::CHECK_NOT_EQUAL);
+    ReleaseQueryResult(result_bs_1);
 
     // auto result4 = index_->SearchById(id_dataset, conf);
     // AssertAneq(result4, nq, k);
@@ -108,6 +111,7 @@ TEST_P(BinaryIDMAPTest, binaryidmap_serialize) {
         auto re_result = index_->Query(query_dataset, conf);
         AssertAnns(re_result, nq, k);
         //        PrintResult(re_result, nq, k);
+        ReleaseQueryResult(re_result);
         EXPECT_EQ(index_->Count(), nb);
         EXPECT_EQ(index_->Dim(), dim);
         auto binaryset = index_->Serialize();
@@ -127,5 +131,6 @@ TEST_P(BinaryIDMAPTest, binaryidmap_serialize) {
         auto result = index_->Query(query_dataset, conf);
         AssertAnns(result, nq, k);
         // PrintResult(result, nq, k);
+        ReleaseQueryResult(result);
     }
 }

--- a/core/src/index/unittest/test_binaryivf.cpp
+++ b/core/src/index/unittest/test_binaryivf.cpp
@@ -74,6 +74,7 @@ TEST_P(BinaryIVFTest, binaryivf_basic) {
     auto result = index_->Query(query_dataset, conf);
     AssertAnns(result, nq, conf[milvus::knowhere::meta::TOPK]);
     // PrintResult(result, nq, k);
+    ReleaseQueryResult(result);
 
     faiss::ConcurrentBitsetPtr concurrent_bitset_ptr = std::make_shared<faiss::ConcurrentBitset>(nb);
     for (int64_t i = 0; i < nq; ++i) {
@@ -83,6 +84,7 @@ TEST_P(BinaryIVFTest, binaryivf_basic) {
 
     auto result2 = index_->Query(query_dataset, conf);
     AssertAnns(result2, nq, k, CheckMode::CHECK_NOT_EQUAL);
+    ReleaseQueryResult(result2);
 
 #if 0
     auto result3 = index_->QueryById(id_dataset, conf);
@@ -147,5 +149,6 @@ TEST_P(BinaryIVFTest, binaryivf_serialize) {
         auto result = index_->Query(query_dataset, conf);
         AssertAnns(result, nq, conf[milvus::knowhere::meta::TOPK]);
         // PrintResult(result, nq, k);
+        ReleaseQueryResult(result);
     }
 }

--- a/core/src/index/unittest/test_customized_index.cpp
+++ b/core/src/index/unittest/test_customized_index.cpp
@@ -70,6 +70,7 @@ TEST_F(SingleIndexTest, IVFSQHybrid) {
                 auto result = gpu_idx->Query(query_dataset, conf);
                 AssertAnns(result, nq, conf[milvus::knowhere::meta::TOPK]);
                 // PrintResult(result, nq, k);
+                ReleaseQueryResult(result);
             }
         }
     }
@@ -86,6 +87,7 @@ TEST_F(SingleIndexTest, IVFSQHybrid) {
         auto result = gpu_idx->Query(query_dataset, conf);
         AssertAnns(result, nq, conf[milvus::knowhere::meta::TOPK]);
         // PrintResult(result, nq, k);
+        ReleaseQueryResult(result);
 
         milvus::json quantizer_conf{{milvus::knowhere::meta::DEVICEID, DEVICEID}, {"mode", 2}};
         for (int i = 0; i < 2; ++i) {
@@ -96,6 +98,7 @@ TEST_F(SingleIndexTest, IVFSQHybrid) {
             auto result = new_idx->Query(query_dataset, conf);
             AssertAnns(result, nq, conf[milvus::knowhere::meta::TOPK]);
             // PrintResult(result, nq, k);
+            ReleaseQueryResult(result);
         }
     }
 
@@ -116,6 +119,7 @@ TEST_F(SingleIndexTest, IVFSQHybrid) {
             AssertAnns(result, nq, conf[milvus::knowhere::meta::TOPK]);
             //            PrintResult(result, nq, k);
             hybrid_idx->UnsetQuantizer();
+            ReleaseQueryResult(result);
         }
     }
 }

--- a/core/src/index/unittest/test_gpuresource.cpp
+++ b/core/src/index/unittest/test_gpuresource.cpp
@@ -76,6 +76,7 @@ TEST_F(GPURESTEST, copyandsearch) {
     index_->AddWithoutIds(base_dataset, conf);
     auto result = index_->Query(query_dataset, conf);
     AssertAnns(result, nq, k);
+    ReleaseQueryResult(result);
 
     index_->SetIndexSize(nb * dim * sizeof(float));
     auto cpu_idx = milvus::knowhere::cloner::CopyGpuToCpu(index_, milvus::knowhere::Config());
@@ -88,7 +89,8 @@ TEST_F(GPURESTEST, copyandsearch) {
     auto search_func = [&] {
         // TimeRecorder tc("search&load");
         for (int i = 0; i < search_count; ++i) {
-            search_idx->Query(query_dataset, conf);
+            auto result = search_idx->Query(query_dataset, conf);
+            ReleaseQueryResult(result);
             // if (i > search_count - 6 || i == 0)
             //    tc.RecordSection("search once");
         }
@@ -107,7 +109,8 @@ TEST_F(GPURESTEST, copyandsearch) {
     milvus::knowhere::TimeRecorder tc("Basic");
     milvus::knowhere::cloner::CopyCpuToGpu(cpu_idx, DEVICEID, milvus::knowhere::Config());
     tc.RecordSection("Copy to gpu once");
-    search_idx->Query(query_dataset, conf);
+    auto result2 = search_idx->Query(query_dataset, conf);
+    ReleaseQueryResult(result2);
     tc.RecordSection("Search once");
     search_func();
     tc.RecordSection("Search total cost");
@@ -147,6 +150,7 @@ TEST_F(GPURESTEST, trainandsearch) {
         for (int i = 0; i < search_count; ++i) {
             auto result = search_idx->Query(query_dataset, conf);
             AssertAnns(result, nq, k);
+            ReleaseQueryResult(result);
         }
     };
 

--- a/core/src/index/unittest/test_hnsw.cpp
+++ b/core/src/index/unittest/test_hnsw.cpp
@@ -63,6 +63,7 @@ TEST_P(HNSWTest, HNSW_basic) {
 
     auto result = index_->Query(query_dataset, conf);
     AssertAnns(result, nq, k);
+    ReleaseQueryResult(result);
 }
 
 TEST_P(HNSWTest, HNSW_delete) {
@@ -79,10 +80,12 @@ TEST_P(HNSWTest, HNSW_delete) {
     }
     auto result1 = index_->Query(query_dataset, conf);
     AssertAnns(result1, nq, k);
+    ReleaseQueryResult(result1);
 
     index_->SetBlacklist(bitset);
     auto result2 = index_->Query(query_dataset, conf);
     AssertAnns(result2, nq, k, CheckMode::CHECK_NOT_EQUAL);
+    ReleaseQueryResult(result2);
 
     /*
      * delete result checked by eyes
@@ -136,6 +139,7 @@ TEST_P(HNSWTest, HNSW_serialize) {
         EXPECT_EQ(index_->Dim(), dim);
         auto result = index_->Query(query_dataset, conf);
         AssertAnns(result, nq, conf[milvus::knowhere::meta::TOPK]);
+        ReleaseQueryResult(result);
     }
 }
 

--- a/core/src/index/unittest/test_idmap.cpp
+++ b/core/src/index/unittest/test_idmap.cpp
@@ -85,6 +85,7 @@ TEST_P(IDMAPTest, idmap_basic) {
     auto result = index_->Query(query_dataset, conf);
     AssertAnns(result, nq, k);
     //    PrintResult(result, nq, k);
+    ReleaseQueryResult(result);
 
     if (index_mode_ == milvus::knowhere::IndexMode::MODE_GPU) {
 #ifdef MILVUS_GPU_VERSION
@@ -99,6 +100,7 @@ TEST_P(IDMAPTest, idmap_basic) {
     auto result2 = new_index->Query(query_dataset, conf);
     AssertAnns(result2, nq, k);
     //    PrintResult(re_result, nq, k);
+    ReleaseQueryResult(result2);
 
 #if 0
     auto result3 = new_index->QueryById(id_dataset, conf);
@@ -116,6 +118,7 @@ TEST_P(IDMAPTest, idmap_basic) {
 
     auto result_bs_1 = index_->Query(query_dataset, conf);
     AssertAnns(result_bs_1, nq, k, CheckMode::CHECK_NOT_EQUAL);
+    ReleaseQueryResult(result_bs_1);
 
 #if 0
     auto result_bs_2 = index_->QueryById(id_dataset, conf);
@@ -154,6 +157,7 @@ TEST_P(IDMAPTest, idmap_serialize) {
         auto re_result = index_->Query(query_dataset, conf);
         AssertAnns(re_result, nq, k);
         //        PrintResult(re_result, nq, k);
+        ReleaseQueryResult(re_result);
         EXPECT_EQ(index_->Count(), nb);
         EXPECT_EQ(index_->Dim(), dim);
         auto binaryset = index_->Serialize();
@@ -173,6 +177,7 @@ TEST_P(IDMAPTest, idmap_serialize) {
         auto result = index_->Query(query_dataset, conf);
         AssertAnns(result, nq, k);
         //        PrintResult(result, nq, k);
+        ReleaseQueryResult(result);
     }
 }
 
@@ -192,6 +197,7 @@ TEST_P(IDMAPTest, idmap_copy) {
     auto result = index_->Query(query_dataset, conf);
     AssertAnns(result, nq, k);
     // PrintResult(result, nq, k);
+    ReleaseQueryResult(result);
 
     {
         // clone
@@ -206,6 +212,7 @@ TEST_P(IDMAPTest, idmap_copy) {
         auto clone_index = milvus::knowhere::cloner::CopyCpuToGpu(index_, DEVICEID, conf);
         auto clone_result = clone_index->Query(query_dataset, conf);
         AssertAnns(clone_result, nq, k);
+        ReleaseQueryResult(clone_result);
         ASSERT_THROW({ std::static_pointer_cast<milvus::knowhere::GPUIDMAP>(clone_index)->GetRawVectors(); },
                      milvus::knowhere::KnowhereException);
 
@@ -218,6 +225,7 @@ TEST_P(IDMAPTest, idmap_copy) {
         clone_index->Load(binary);
         auto new_result = clone_index->Query(query_dataset, conf);
         AssertAnns(new_result, nq, k);
+        ReleaseQueryResult(new_result);
 
         //        auto clone_gpu_idx = clone_index->Clone();
         //        auto clone_gpu_res = clone_gpu_idx->Search(query_dataset, conf);
@@ -227,6 +235,7 @@ TEST_P(IDMAPTest, idmap_copy) {
         auto host_index = milvus::knowhere::cloner::CopyGpuToCpu(clone_index, conf);
         auto host_result = host_index->Query(query_dataset, conf);
         AssertAnns(host_result, nq, k);
+        ReleaseQueryResult(host_result);
         ASSERT_TRUE(std::static_pointer_cast<milvus::knowhere::IDMAP>(host_index)->GetRawVectors() != nullptr);
 
         // gpu to gpu
@@ -235,6 +244,7 @@ TEST_P(IDMAPTest, idmap_copy) {
             std::static_pointer_cast<milvus::knowhere::GPUIDMAP>(device_index)->CopyGpuToGpu(DEVICEID, conf);
         auto device_result = new_device_index->Query(query_dataset, conf);
         AssertAnns(device_result, nq, k);
+        ReleaseQueryResult(device_result);
     }
 }
 #endif

--- a/core/src/index/unittest/test_sptag.cpp
+++ b/core/src/index/unittest/test_sptag.cpp
@@ -67,6 +67,7 @@ TEST_P(SPTAGTest, sptag_basic) {
     // index_->Add(base_dataset, conf);
     auto result = index_->Query(query_dataset, conf);
     AssertAnns(result, nq, k);
+    ReleaseQueryResult(result);
 
     {
         auto ids = result->Get<int64_t*>(milvus::knowhere::meta::IDS);
@@ -100,6 +101,7 @@ TEST_P(SPTAGTest, sptag_serialize) {
     auto result = new_index->Query(query_dataset, conf);
     AssertAnns(result, nq, k);
     PrintResult(result, nq, k);
+    ReleaseQueryResult(result);
     ASSERT_EQ(new_index->Count(), nb);
     ASSERT_EQ(new_index->Dim(), dim);
     //        ASSERT_THROW({ new_index->Clone(); }, milvus::knowhere::KnowhereException);
@@ -136,5 +138,6 @@ TEST_P(SPTAGTest, sptag_serialize) {
         auto result = new_index->Query(query_dataset, conf);
         AssertAnns(result, nq, k);
         PrintResult(result, nq, k);
+        ReleaseQueryResult(result);
     }
 }

--- a/core/src/index/unittest/test_vecindex.cpp
+++ b/core/src/index/unittest/test_vecindex.cpp
@@ -85,6 +85,7 @@ TEST_P(VecIndexTest, basic) {
     auto result = index_->Query(query_dataset, conf);
     AssertAnns(result, nq, conf[milvus::knowhere::meta::TOPK]);
     PrintResult(result, nq, k);
+    ReleaseQueryResult(result);
 }
 
 TEST_P(VecIndexTest, serialize) {
@@ -95,6 +96,7 @@ TEST_P(VecIndexTest, serialize) {
     EXPECT_EQ(index_->index_mode(), index_mode_);
     auto result = index_->Query(query_dataset, conf);
     AssertAnns(result, nq, conf[milvus::knowhere::meta::TOPK]);
+    ReleaseQueryResult(result);
 
     auto binaryset = index_->Serialize();
     auto new_index = milvus::knowhere::VecIndexFactory::GetInstance().CreateVecIndex(index_type_, index_mode_);
@@ -105,6 +107,7 @@ TEST_P(VecIndexTest, serialize) {
     EXPECT_EQ(index_->index_mode(), new_index->index_mode());
     auto new_result = new_index_->Query(query_dataset, conf);
     AssertAnns(new_result, nq, conf[milvus::knowhere::meta::TOPK]);
+    ReleaseQueryResult(new_result);
 }
 
 // todo

--- a/core/src/index/unittest/utils.cpp
+++ b/core/src/index/unittest/utils.cpp
@@ -230,6 +230,15 @@ PrintResult(const milvus::knowhere::DatasetPtr& result, const int& nq, const int
     std::cout << "dist\n" << ss_dist.str() << std::endl;
 }
 
+void
+ReleaseQueryResult(const milvus::knowhere::DatasetPtr& result) {
+    float* res_dist = result->Get<float*>(milvus::knowhere::meta::DISTANCE);
+    free(res_dist);
+
+    int64_t* res_ids = result->Get<int64_t*>(milvus::knowhere::meta::IDS);
+    free(res_ids);
+}
+
 // not used
 #if 0
 void

--- a/core/src/index/unittest/utils.h
+++ b/core/src/index/unittest/utils.h
@@ -83,6 +83,9 @@ AssertBinVec(const milvus::knowhere::DatasetPtr& result, const milvus::knowhere:
 void
 PrintResult(const milvus::knowhere::DatasetPtr& result, const int& nq, const int& k);
 
+void
+ReleaseQueryResult(const milvus::knowhere::DatasetPtr& result);
+
 struct FileIOWriter {
     std::fstream fs;
     std::string name;


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

Fixes #4749

**What this PR does / why we need it:**

(1) fix memory leak when building ivf_sq8 index
(2) fix life cycle of variable in knowhere exception
(3) fix memory leak in knowhere UT

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
