### PR TITLE
storage: enabling s3 storage support.

### DIFF
--- a/core/build.sh
+++ b/core/build.sh
@@ -16,8 +16,9 @@ WITH_MKL="OFF"
 WITH_PROMETHEUS="ON"
 FIU_ENABLE="OFF"
 BUILD_OPENBLAS="ON"
+WITH_AWS="OFF"
 
-while getopts "p:d:t:f:ulrcgahzmei" arg; do
+while getopts "p:d:t:f:ulrcgahzmeis" arg; do
   case $arg in
   p)
     INSTALL_PREFIX=$OPTARG
@@ -62,6 +63,9 @@ while getopts "p:d:t:f:ulrcgahzmei" arg; do
   a)
     FPGA_VERSION="ON"
     ;;
+  s)
+    WITH_AWS="ON"
+    ;;
   h) # help
     echo "
 
@@ -79,10 +83,11 @@ parameter:
 -e: build without prometheus(default: OFF)
 -i: build FIU_ENABLE(default: OFF)
 -a: build FPGA(default: OFF)
+-s: build with AWS S3(default: OFF)
 -h: help
 
 usage:
-./build.sh -p \${INSTALL_PREFIX} -t \${BUILD_TYPE} [-u] [-l] [-r] [-c] [-z] [-g] [-a] [-m] [-e] [-h]
+./build.sh -p \${INSTALL_PREFIX} -t \${BUILD_TYPE} [-u] [-l] [-r] [-c] [-z] [-g] [-a] [-m] [-e] [-s] [-h]
                 "
     exit 0
     ;;
@@ -117,6 +122,7 @@ CMAKE_CMD="cmake \
 -DFAISS_WITH_MKL=${WITH_MKL} \
 -DMILVUS_WITH_PROMETHEUS=${WITH_PROMETHEUS} \
 -DMILVUS_WITH_FIU=${FIU_ENABLE} \
+-DMILVUS_WITH_AWS=${WITH_AWS} \
 ../"
 echo ${CMAKE_CMD}
 ${CMAKE_CMD}

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -120,11 +120,14 @@ set(web_server_files
 
 aux_source_directory(${MILVUS_ENGINE_SRC}/storage storage_main_files)
 aux_source_directory(${MILVUS_ENGINE_SRC}/storage/disk storage_disk_files)
-#aux_source_directory(${MILVUS_ENGINE_SRC}/storage/s3 storage_s3_files)
+if(MILVUS_WITH_AWS)
+aux_source_directory(${MILVUS_ENGINE_SRC}/storage/s3 storage_s3_files)
+endif()
+
 set(storage_files
         ${storage_main_files}
         ${storage_disk_files}
-#        ${storage_s3_files}
+        ${storage_s3_files}
         )
 
 aux_source_directory(${MILVUS_ENGINE_SRC}/utils utils_files)
@@ -236,6 +239,7 @@ if (MILVUS_WITH_PROMETHEUS)
 endif ()
 
 if (MILVUS_WITH_AWS)
+    add_compile_definitions(MILVUS_WITH_AWS)
     set(third_party_libs ${third_party_libs}
             ${s3_client_lib}
             curl

--- a/core/src/codecs/default/DefaultDeletedDocsFormat.cpp
+++ b/core/src/codecs/default/DefaultDeletedDocsFormat.cpp
@@ -40,6 +40,7 @@ DefaultDeletedDocsFormat::read(const storage::FSHandlerPtr& fs_ptr, segment::Del
 
     std::string dir_path = fs_ptr->operation_ptr_->GetDirectory();
     const std::string del_file_path = dir_path + "/" + deleted_docs_filename_;
+    fs_ptr->operation_ptr_->CacheGet(del_file_path);
 
     int del_fd = open(del_file_path.c_str(), O_RDONLY, 00664);
     if (del_fd == -1) {
@@ -83,6 +84,7 @@ DefaultDeletedDocsFormat::write(const storage::FSHandlerPtr& fs_ptr, const segme
 
     // Create a temporary file from the existing file
     const std::string temp_path = dir_path + "/" + "temp_del";
+    fs_ptr->operation_ptr_->CacheGet(del_file_path);
     bool exists = boost::filesystem::exists(del_file_path);
     if (exists) {
         boost::filesystem::copy_file(del_file_path, temp_path, boost::filesystem::copy_option::fail_if_exists);
@@ -144,6 +146,7 @@ DefaultDeletedDocsFormat::write(const storage::FSHandlerPtr& fs_ptr, const segme
 
     // Move temp file to delete file
     boost::filesystem::rename(temp_path, del_file_path);
+    fs_ptr->operation_ptr_->CachePut(del_file_path);
 }
 
 void
@@ -152,6 +155,7 @@ DefaultDeletedDocsFormat::readSize(const storage::FSHandlerPtr& fs_ptr, size_t& 
 
     std::string dir_path = fs_ptr->operation_ptr_->GetDirectory();
     const std::string del_file_path = dir_path + "/" + deleted_docs_filename_;
+    fs_ptr->operation_ptr_->CacheGet(del_file_path);
 
     int del_fd = open(del_file_path.c_str(), O_RDONLY, 00664);
     if (del_fd == -1) {

--- a/core/src/codecs/default/DefaultIdBloomFilterFormat.cpp
+++ b/core/src/codecs/default/DefaultIdBloomFilterFormat.cpp
@@ -82,7 +82,6 @@ DefaultIdBloomFilterFormat::create(const storage::FSHandlerPtr& fs_ptr,
         throw Exception(SERVER_UNEXPECTED_ERROR, err_msg);
     }
     id_bloom_filter_ptr = std::make_shared<segment::IdBloomFilter>(bloom_filter);
-    fs_ptr->operation_ptr_->CachePut(bloom_filter_file_path);
 }
 
 }  // namespace codec

--- a/core/src/codecs/default/DefaultIdBloomFilterFormat.h
+++ b/core/src/codecs/default/DefaultIdBloomFilterFormat.h
@@ -22,7 +22,6 @@
 
 #include "codecs/IdBloomFilterFormat.h"
 #include "segment/IdBloomFilter.h"
-#include "storage/disk/DiskOperation.h"
 
 namespace milvus {
 namespace codec {

--- a/core/src/codecs/default/DefaultVectorIndexFormat.cpp
+++ b/core/src/codecs/default/DefaultVectorIndexFormat.cpp
@@ -15,10 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include "codecs/default/DefaultVectorIndexFormat.h"
+
 #include <boost/filesystem.hpp>
 #include <memory>
 
-#include "codecs/default/DefaultVectorIndexFormat.h"
 #include "knowhere/common/BinarySet.h"
 #include "knowhere/index/vector_index/VecIndex.h"
 #include "knowhere/index/vector_index/VecIndexFactory.h"

--- a/core/src/config/Config.h
+++ b/core/src/config/Config.h
@@ -259,6 +259,21 @@ class Config {
     Status
     CheckStorageConfigFileCleanupTimeout(const std::string& value);
 
+#ifdef MILVUS_WITH_AWS
+    Status
+    CheckStorageConfigS3Enable(const std::string& value);
+    Status
+    CheckStorageConfigS3Address(const std::string& value);
+    Status
+    CheckStorageConfigS3Port(const std::string& value);
+    Status
+    CheckStorageConfigS3AccessKey(const std::string& value);
+    Status
+    CheckStorageConfigS3SecretKey(const std::string& value);
+    Status
+    CheckStorageConfigS3Bucket(const std::string& value);
+#endif
+
     /* metric config */
     Status
     CheckMetricConfigEnableMonitor(const std::string& value);
@@ -398,6 +413,26 @@ class Config {
     Status
     GetStorageConfigFileCleanupTimeup(int64_t& value);
 
+#ifdef MILVUS_WITH_AWS
+    Status
+    GetStorageConfigS3Enable(bool& value);
+
+    Status
+    GetStorageConfigS3Address(std::string& value);
+
+    Status
+    GetStorageConfigS3Port(std::string& value);
+
+    Status
+    GetStorageConfigS3AccessKey(std::string& value);
+
+    Status
+    GetStorageConfigS3SecretKey(std::string& value);
+
+    Status
+    GetStorageConfigS3Bucket(std::string& value);
+#endif
+
     /* metric config */
     Status
     GetMetricConfigEnableMonitor(bool& value);
@@ -529,6 +564,21 @@ class Config {
     SetStorageConfigAutoFlushInterval(const std::string& value);
     Status
     SetStorageConfigFileCleanupTimeout(const std::string& value);
+
+#ifdef MILVUS_WITH_AWS
+    Status
+    SetStorageConfigS3Enable(const std::string& value);
+    Status
+    SetStorageConfigS3Address(const std::string& value);
+    Status
+    SetStorageConfigS3Port(const std::string& value);
+    Status
+    SetStorageConfigS3AccessKey(const std::string& value);
+    Status
+    SetStorageConfigS3SecretKey(const std::string& value);
+    Status
+    SetStorageConfigS3Bucket(const std::string& value);
+#endif
 
     /* metric config */
     Status

--- a/core/src/segment/SegmentReader.cpp
+++ b/core/src/segment/SegmentReader.cpp
@@ -21,19 +21,14 @@
 
 #include "Vectors.h"
 #include "codecs/default/DefaultCodec.h"
-#include "storage/disk/DiskIOReader.h"
-#include "storage/disk/DiskIOWriter.h"
-#include "storage/disk/DiskOperation.h"
+#include "config/Config.h"
 #include "utils/Log.h"
 
 namespace milvus {
 namespace segment {
 
 SegmentReader::SegmentReader(const std::string& directory) {
-    storage::IOReaderPtr reader_ptr = std::make_shared<storage::DiskIOReader>();
-    storage::IOWriterPtr writer_ptr = std::make_shared<storage::DiskIOWriter>();
-    storage::OperationPtr operation_ptr = std::make_shared<storage::DiskOperation>(directory);
-    fs_ptr_ = std::make_shared<storage::FSHandler>(reader_ptr, writer_ptr, operation_ptr);
+    fs_ptr_ = milvus::storage::createFsHandler(directory);
     segment_ptr_ = std::make_shared<Segment>();
 }
 

--- a/core/src/segment/SegmentWriter.cpp
+++ b/core/src/segment/SegmentWriter.cpp
@@ -25,9 +25,6 @@
 #include "Vectors.h"
 #include "codecs/default/DefaultCodec.h"
 #include "db/Utils.h"
-#include "storage/disk/DiskIOReader.h"
-#include "storage/disk/DiskIOWriter.h"
-#include "storage/disk/DiskOperation.h"
 #include "utils/Log.h"
 #include "utils/TimeRecorder.h"
 
@@ -35,10 +32,7 @@ namespace milvus {
 namespace segment {
 
 SegmentWriter::SegmentWriter(const std::string& directory) {
-    storage::IOReaderPtr reader_ptr = std::make_shared<storage::DiskIOReader>();
-    storage::IOWriterPtr writer_ptr = std::make_shared<storage::DiskIOWriter>();
-    storage::OperationPtr operation_ptr = std::make_shared<storage::DiskOperation>(directory);
-    fs_ptr_ = std::make_shared<storage::FSHandler>(reader_ptr, writer_ptr, operation_ptr);
+    fs_ptr_ = milvus::storage::createFsHandler(directory);
     segment_ptr_ = std::make_shared<Segment>();
 }
 

--- a/core/src/storage/Operation.h
+++ b/core/src/storage/Operation.h
@@ -38,6 +38,12 @@ class Operation {
     virtual bool
     DeleteFile(const std::string& file_path) = 0;
 
+    virtual bool
+    CacheGet(const std::string& file_path) = 0;
+
+    virtual bool
+    CachePut(const std::string& file_path) = 0;
+
     // TODO(zhiru):
     //  open(), sync(), close()
     //  function that opens a stream for reading file

--- a/core/src/storage/disk/DiskOperation.cpp
+++ b/core/src/storage/disk/DiskOperation.cpp
@@ -15,11 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <boost/filesystem.hpp>
+#include "storage/disk/DiskOperation.h"
 
 #include <fiu-local.h>
 
-#include "storage/disk/DiskOperation.h"
+#include <boost/filesystem.hpp>
+
 #include "utils/Exception.h"
 #include "utils/Log.h"
 
@@ -65,6 +66,16 @@ DiskOperation::ListDirectory(std::vector<std::string>& file_paths) {
 bool
 DiskOperation::DeleteFile(const std::string& file_path) {
     return boost::filesystem::remove(file_path);
+}
+
+bool
+DiskOperation::CacheGet(const std::string& /* unused file_path */) {
+    return true;
+}
+
+bool
+DiskOperation::CachePut(const std::string& /* unused file_path */) {
+    return true;
 }
 
 }  // namespace storage

--- a/core/src/storage/disk/DiskOperation.h
+++ b/core/src/storage/disk/DiskOperation.h
@@ -31,17 +31,22 @@ class DiskOperation : public Operation {
     explicit DiskOperation(const std::string& dir_path);
 
     void
-    CreateDirectory();
+    CreateDirectory() final;
 
     const std::string&
-    GetDirectory() const;
+    GetDirectory() const final;
 
     void
-    ListDirectory(std::vector<std::string>& file_paths);
+    ListDirectory(std::vector<std::string>& file_paths) final;
 
     bool
-    DeleteFile(const std::string& file_path);
+    DeleteFile(const std::string& file_path) final;
 
+    bool
+    CacheGet(const std::string& file_path) final;
+
+    bool
+    CachePut(const std::string& file_path) final;
     // TODO(zhiru):
     //  open(), sync(), close()
     //  function that opens a stream for reading file

--- a/core/src/storage/s3/S3ClientWrapper.h
+++ b/core/src/storage/s3/S3ClientWrapper.h
@@ -30,6 +30,14 @@ class S3ClientWrapper {
         return wrapper;
     }
 
+    S3ClientWrapper() {
+        StartService();
+    }
+
+    ~S3ClientWrapper() {
+        StopService();
+    }
+
     Status
     StartService();
     void
@@ -48,11 +56,11 @@ class S3ClientWrapper {
     Status
     GetObjectStr(const std::string& object_key, std::string& content);
     Status
-    ListObjects(std::vector<std::string>& object_list, const std::string& marker = "");
+    ListObjects(std::vector<std::string>& object_list, const std::string& prefix = "");
     Status
     DeleteObject(const std::string& object_key);
     Status
-    DeleteObjects(const std::string& marker);
+    DeleteObjects(const std::string& prefix);
 
  private:
     std::shared_ptr<Aws::S3::S3Client> client_ptr_;

--- a/core/src/storage/s3/S3Operation.cpp
+++ b/core/src/storage/s3/S3Operation.cpp
@@ -1,0 +1,56 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License.
+
+#include "storage/s3/S3Operation.h"
+
+#include "storage/s3/S3ClientWrapper.h"
+
+namespace milvus {
+namespace storage {
+
+S3Operation::S3Operation(const std::string& dir_path) : dir_path_(dir_path), local_operation_(dir_path) {
+    CreateDirectory();
+}
+
+void
+S3Operation::CreateDirectory() {
+    local_operation_.CreateDirectory();
+}
+
+const std::string&
+S3Operation::GetDirectory() const {
+    return dir_path_;
+}
+
+void
+S3Operation::ListDirectory(std::vector<std::string>& file_paths) {
+    S3ClientWrapper::GetInstance().ListObjects(file_paths, dir_path_);
+}
+
+bool
+S3Operation::DeleteFile(const std::string& file_path) {
+    (void)local_operation_.DeleteFile(file_path);
+    return S3ClientWrapper::GetInstance().DeleteObject(file_path).ok();
+}
+
+bool
+S3Operation::CacheGet(const std::string& file_path) {
+    return S3ClientWrapper::GetInstance().GetObjectFile(file_path, file_path).ok();
+}
+
+bool
+S3Operation::CachePut(const std::string& file_path) {
+    // TODO: try introducing LRU
+    return S3ClientWrapper::GetInstance().PutObjectFile(file_path, file_path).ok();
+}
+
+}  // namespace storage
+}  // namespace milvus

--- a/core/src/storage/s3/S3Operation.h
+++ b/core/src/storage/s3/S3Operation.h
@@ -1,0 +1,52 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "storage/Operation.h"
+#include "storage/disk/DiskOperation.h"
+
+namespace milvus {
+namespace storage {
+
+class S3Operation : public Operation {
+ public:
+    explicit S3Operation(const std::string& dir_path);
+
+    void
+    CreateDirectory() final;
+
+    const std::string&
+    GetDirectory() const final;
+
+    void
+    ListDirectory(std::vector<std::string>& file_paths) final;
+
+    bool
+    DeleteFile(const std::string& file_path) final;
+
+    bool
+    CacheGet(const std::string& file_path) final;
+
+    bool
+    CachePut(const std::string& file_path) final;
+
+ private:
+    const std::string dir_path_;
+    DiskOperation local_operation_;
+};
+
+}  // namespace storage
+}  // namespace milvus


### PR DESCRIPTION
- very raw idea for support s3 storage, not enabled by default.
- need enabling compiled(cmake) with MILVUS_WITH_AWS.
- simple integration tested with ceph/radowsgw.

Signed-off-by: Ji Bin <matrixji@live.com>

**What type of PR is this?**

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

Fixes #1434 

**What this PR does / why we need it:**

Enabling S3 support on 1.x, currently I'm trying to running milvus with some s3 storage system, e.g Ceph's radowsgw.

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
