### PR TITLE
Fix the capacity of bloom filter

### DIFF
--- a/core/src/codecs/IdBloomFilterFormat.h
+++ b/core/src/codecs/IdBloomFilterFormat.h
@@ -34,7 +34,7 @@ class IdBloomFilterFormat {
     write(const storage::FSHandlerPtr& fs_ptr, const segment::IdBloomFilterPtr& id_bloom_filter_ptr) = 0;
 
     virtual void
-    create(const storage::FSHandlerPtr& fs_ptr, segment::IdBloomFilterPtr& id_bloom_filter_ptr) = 0;
+    create(int64_t capacity, segment::IdBloomFilterPtr& id_bloom_filter_ptr) = 0;
 };
 
 using IdBloomFilterFormatPtr = std::shared_ptr<IdBloomFilterFormat>;

--- a/core/src/codecs/default/DefaultIdBloomFilterFormat.cpp
+++ b/core/src/codecs/default/DefaultIdBloomFilterFormat.cpp
@@ -28,8 +28,12 @@
 namespace milvus {
 namespace codec {
 
-constexpr unsigned int bloom_filter_capacity = 500000;
-constexpr double bloom_filter_error_rate = 0.01;
+// for compatibility with version 1.0.0
+constexpr unsigned int BLOOM_FILTER_CAPACITY = 500000;
+constexpr double BLOOM_FILTER_ERROR_RATE = 0.01;
+
+// the magic num is converted from string "bloom_0"
+constexpr int64_t BLOOM_FILTER_MAGIC_NUM = 0x305F6D6F6F6C62;
 
 void
 DefaultIdBloomFilterFormat::read(const storage::FSHandlerPtr& fs_ptr, segment::IdBloomFilterPtr& id_bloom_filter_ptr) {
@@ -38,10 +42,45 @@ DefaultIdBloomFilterFormat::read(const storage::FSHandlerPtr& fs_ptr, segment::I
     std::string dir_path = fs_ptr->operation_ptr_->GetDirectory();
     const std::string bloom_filter_file_path = dir_path + "/" + bloom_filter_filename_;
     scaling_bloom_t* bloom_filter{nullptr};
-    if (fs_ptr->operation_ptr_->CacheGet(bloom_filter_file_path)) {
-        bloom_filter =
-            new_scaling_bloom_from_file(bloom_filter_capacity, bloom_filter_error_rate, bloom_filter_file_path.c_str());
-    }
+    do {
+        if (!fs_ptr->operation_ptr_->CacheGet(bloom_filter_file_path)) {
+            LOG_ENGINE_ERROR_ << "Fail to cache get bloom filter: " << bloom_filter_file_path;
+            break;
+        }
+        if (!fs_ptr->reader_ptr_->open(bloom_filter_file_path)) {
+            LOG_ENGINE_ERROR_ << "Fail to open bloom filter: " << bloom_filter_file_path;
+            break;
+        }
+
+        unsigned int capacity = 0;
+        double error_rate = 0;
+        size_t bitmap_bytes = 0;
+
+        int64_t magic_num = 0;
+        fs_ptr->reader_ptr_->read(&magic_num, sizeof(magic_num));
+        if (magic_num != BLOOM_FILTER_MAGIC_NUM) {
+            capacity = BLOOM_FILTER_CAPACITY;
+            error_rate = BLOOM_FILTER_ERROR_RATE;
+            bitmap_bytes = fs_ptr->reader_ptr_->length() - sizeof(int64_t);
+            fs_ptr->reader_ptr_->seekg(sizeof(int64_t));
+        } else {
+            fs_ptr->reader_ptr_->read(&capacity, sizeof(capacity));
+            fs_ptr->reader_ptr_->read(&error_rate, sizeof(error_rate));
+            fs_ptr->reader_ptr_->read(&bitmap_bytes, sizeof(bitmap_bytes));
+        }
+
+        bitmap_t* bitmap = new_bitmap(bitmap_bytes);
+        if (bitmap != nullptr) {
+            fs_ptr->reader_ptr_->read(bitmap->array, bitmap_bytes);
+            bloom_filter = new_scaling_bloom_from_bitmap(capacity, error_rate, bitmap);
+            if (bloom_filter == nullptr) {
+                free_bitmap(bitmap);
+            }
+        }
+
+        fs_ptr->reader_ptr_->close();
+    } while (0);
+
     fiu_do_on("bloom_filter_nullptr", (free_scaling_bloom(bloom_filter) || (bloom_filter = nullptr)));
     if (bloom_filter == nullptr) {
         std::string err_msg =
@@ -59,28 +98,28 @@ DefaultIdBloomFilterFormat::write(const storage::FSHandlerPtr& fs_ptr,
 
     std::string dir_path = fs_ptr->operation_ptr_->GetDirectory();
     const std::string bloom_filter_file_path = dir_path + "/" + bloom_filter_filename_;
-    if (scaling_bloom_flush(id_bloom_filter_ptr->GetBloomFilter()) == -1) {
+    if (!fs_ptr->writer_ptr_->open(bloom_filter_file_path)) {
         std::string err_msg =
             "Failed to write bloom filter to file: " + bloom_filter_file_path + ". " + std::strerror(errno);
         LOG_ENGINE_ERROR_ << err_msg;
         throw Exception(SERVER_UNEXPECTED_ERROR, err_msg);
     }
+
+    auto bloom_filter = id_bloom_filter_ptr->GetBloomFilter();
+
+    int64_t magic_num = BLOOM_FILTER_MAGIC_NUM;
+    fs_ptr->writer_ptr_->write(&magic_num, sizeof(magic_num));
+    fs_ptr->writer_ptr_->write(&bloom_filter->capacity, sizeof(bloom_filter->capacity));
+    fs_ptr->writer_ptr_->write(&bloom_filter->error_rate, sizeof(bloom_filter->error_rate));
+    fs_ptr->writer_ptr_->write(&bloom_filter->bitmap->bytes, sizeof(bloom_filter->bitmap->bytes));
+    fs_ptr->writer_ptr_->write(bloom_filter->bitmap->array, bloom_filter->bitmap->bytes);
+    fs_ptr->writer_ptr_->close();
     fs_ptr->operation_ptr_->CachePut(bloom_filter_file_path);
 }
 
 void
-DefaultIdBloomFilterFormat::create(const storage::FSHandlerPtr& fs_ptr,
-                                   segment::IdBloomFilterPtr& id_bloom_filter_ptr) {
-    std::string dir_path = fs_ptr->operation_ptr_->GetDirectory();
-    const std::string bloom_filter_file_path = dir_path + "/" + bloom_filter_filename_;
-    scaling_bloom_t* bloom_filter =
-        new_scaling_bloom(bloom_filter_capacity, bloom_filter_error_rate, bloom_filter_file_path.c_str());
-    if (bloom_filter == nullptr) {
-        std::string err_msg =
-            "Failed to read bloom filter from file: " + bloom_filter_file_path + ". " + std::strerror(errno);
-        LOG_ENGINE_ERROR_ << err_msg;
-        throw Exception(SERVER_UNEXPECTED_ERROR, err_msg);
-    }
+DefaultIdBloomFilterFormat::create(int64_t capacity, segment::IdBloomFilterPtr& id_bloom_filter_ptr) {
+    scaling_bloom_t* bloom_filter = new_scaling_bloom(capacity, BLOOM_FILTER_ERROR_RATE);
     id_bloom_filter_ptr = std::make_shared<segment::IdBloomFilter>(bloom_filter);
 }
 

--- a/core/src/codecs/default/DefaultIdBloomFilterFormat.cpp
+++ b/core/src/codecs/default/DefaultIdBloomFilterFormat.cpp
@@ -61,8 +61,8 @@ DefaultIdBloomFilterFormat::read(const storage::FSHandlerPtr& fs_ptr, segment::I
         if (magic_num != BLOOM_FILTER_MAGIC_NUM) {
             capacity = BLOOM_FILTER_CAPACITY;
             error_rate = BLOOM_FILTER_ERROR_RATE;
-            bitmap_bytes = fs_ptr->reader_ptr_->length() - sizeof(int64_t);
-            fs_ptr->reader_ptr_->seekg(sizeof(int64_t));
+            bitmap_bytes = static_cast<size_t>(fs_ptr->reader_ptr_->length());
+            fs_ptr->reader_ptr_->seekg(0);
         } else {
             fs_ptr->reader_ptr_->read(&capacity, sizeof(capacity));
             fs_ptr->reader_ptr_->read(&error_rate, sizeof(error_rate));

--- a/core/src/codecs/default/DefaultIdBloomFilterFormat.h
+++ b/core/src/codecs/default/DefaultIdBloomFilterFormat.h
@@ -37,7 +37,7 @@ class DefaultIdBloomFilterFormat : public IdBloomFilterFormat {
     write(const storage::FSHandlerPtr& fs_ptr, const segment::IdBloomFilterPtr& id_bloom_filter_ptr) override;
 
     void
-    create(const storage::FSHandlerPtr& fs_ptr, segment::IdBloomFilterPtr& id_bloom_filter_ptr) override;
+    create(int64_t capacity, segment::IdBloomFilterPtr& id_bloom_filter_ptr) override;
 
     // No copy and move
     DefaultIdBloomFilterFormat(const DefaultIdBloomFilterFormat&) = delete;

--- a/core/src/segment/IdBloomFilter.cpp
+++ b/core/src/segment/IdBloomFilter.cpp
@@ -54,7 +54,6 @@ IdBloomFilter::Add(doc_id_t uid) {
     if (scaling_bloom_add(bloom_filter_, s.c_str(), s.size(), uid) == -1) {
         // Counter overflow does not affect bloom filter's normal functionality
         LOG_ENGINE_WARNING_ << "Warning adding id=" << s << " to bloom filter: 4 bit counter Overflow";
-        // return Status(DB_BLOOM_FILTER_ERROR, "Bloom filter error: 4 bit counter Overflow");
     }
     return Status::OK();
 }
@@ -66,7 +65,6 @@ IdBloomFilter::Remove(doc_id_t uid) {
     if (scaling_bloom_remove(bloom_filter_, s.c_str(), s.size(), uid) == -1) {
         // Should never go in here, but just to be safe
         LOG_ENGINE_WARNING_ << "Warning removing id=" << s << " in bloom filter: Decrementing zero in counter";
-        // return Status(DB_BLOOM_FILTER_ERROR, "Error removing in bloom filter: Decrementing zero in counter");
     }
     return Status::OK();
 }

--- a/core/src/segment/SegmentWriter.cpp
+++ b/core/src/segment/SegmentWriter.cpp
@@ -180,11 +180,11 @@ SegmentWriter::WriteBloomFilter() {
 
         TimeRecorder recorder("SegmentWriter::WriteBloomFilter");
 
-        default_codec.GetIdBloomFilterFormat()->create(fs_ptr_, segment_ptr_->id_bloom_filter_ptr_);
+        auto& uids = segment_ptr_->vectors_ptr_->GetUids();
+        default_codec.GetIdBloomFilterFormat()->create(uids.size(), segment_ptr_->id_bloom_filter_ptr_);
 
         recorder.RecordSection("Initializing bloom filter");
 
-        auto& uids = segment_ptr_->vectors_ptr_->GetUids();
         for (auto& uid : uids) {
             segment_ptr_->id_bloom_filter_ptr_->Add(uid);
         }

--- a/core/thirdparty/dablooms/LICENSE
+++ b/core/thirdparty/dablooms/LICENSE
@@ -1,0 +1,17 @@
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/core/thirdparty/dablooms/dablooms.cpp
+++ b/core/thirdparty/dablooms/dablooms.cpp
@@ -1,6 +1,5 @@
 /* Copyright @2012 by Justin Hines at Bitly under a very liberal license. See LICENSE in the source distribution. */
 
-#define _GNU_SOURCE
 #include <sys/stat.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -28,84 +27,46 @@ const char *dablooms_version(void)
 
 void free_bitmap(bitmap_t *bitmap)
 {
-    if ((munmap(bitmap->array, bitmap->bytes)) < 0) {
-        perror("Error, unmapping memory");
+    if (bitmap != nullptr) {
+        free(bitmap->array);
+        free(bitmap);
     }
-    close(bitmap->fd);
-    free(bitmap);
 }
 
-bitmap_t *bitmap_resize(bitmap_t *bitmap, size_t old_size, size_t new_size)
+bitmap_t *bitmap_resize(bitmap_t *bitmap, size_t new_size)
 {
-    int fd = bitmap->fd;
-    struct stat fileStat;
+    size_t old_size = (bitmap->array == nullptr) ? 0 : bitmap->bytes;
+    char* new_array = (char*)realloc(bitmap->array, new_size);
+    if (new_array == nullptr) {
+        // Todo: malloc error
 
-    fstat(fd, &fileStat);
-    size_t size = fileStat.st_size;
-
-    /* grow file if necessary */
-    if (size < new_size) {
-        if (ftruncate(fd, new_size) < 0) {
-            perror("Error increasing file size with ftruncate");
-            free_bitmap(bitmap);
-            close(fd);
-            return NULL;
-        }
-    }
-    lseek(fd, 0, SEEK_SET);
-
-    /* resize if mmap exists and possible on this os, else new mmap */
-    if (bitmap->array != NULL) {
-#if __linux
-        bitmap->array = (char *)mremap(bitmap->array, old_size, new_size, MREMAP_MAYMOVE);
-        if (bitmap->array == MAP_FAILED) {
-            perror("Error resizing mmap");
-            free_bitmap(bitmap);
-            close(fd);
-            return NULL;
-        }
-#else
-        if (munmap(bitmap->array, bitmap->bytes) < 0) {
-            perror("Error unmapping memory");
-            free_bitmap(bitmap);
-            close(fd);
-            return NULL;
-        }
-        bitmap->array = NULL;
-#endif
-    }
-    if (bitmap->array == NULL) {
-        bitmap->array = (char *)mmap(0, new_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-        if (bitmap->array == MAP_FAILED) {
-            perror("Error init mmap");
-            free_bitmap(bitmap);
-            close(fd);
-            return NULL;
+    } else {
+        bitmap->bytes = new_size;
+        bitmap->array = new_array;
+        if (new_size > old_size) {
+            memset(bitmap->array + old_size, 0, new_size - old_size);
         }
     }
 
-    bitmap->bytes = new_size;
     return bitmap;
 }
 
 /* Create a new bitmap, not full featured, simple to give
  * us a means of interacting with the 4 bit counters */
-bitmap_t *new_bitmap(int fd, size_t bytes)
+bitmap_t *new_bitmap(size_t bytes)
 {
     bitmap_t *bitmap;
-
-    if ((bitmap = (bitmap_t *)malloc(sizeof(bitmap_t))) == NULL) {
-        return NULL;
+    if ((bitmap = (bitmap_t *)malloc(sizeof(bitmap_t))) == nullptr) {
+        return nullptr;
     }
 
+    if ((bitmap->array = (char*)malloc(bytes)) == nullptr) {
+        free(bitmap);
+        return nullptr;
+    }
+
+    memset(bitmap->array, 0, bytes);
     bitmap->bytes = bytes;
-    bitmap->fd = fd;
-    bitmap->array = NULL;
-
-    if ((bitmap = bitmap_resize(bitmap, 0, bytes)) == NULL) {
-        return NULL;
-    }
-
     return bitmap;
 }
 
@@ -167,16 +128,6 @@ int bitmap_check(bitmap_t *bitmap, unsigned int index, long offset)
     }
 }
 
-int bitmap_flush(bitmap_t *bitmap)
-{
-    if ((msync(bitmap->array, bitmap->bytes, MS_ASYNC) < 0)) {
-        perror("Error, flushing bitmap to disk");
-        return -1;
-    } else {
-        return 0;
-    }
-}
-
 /*
  * Perform the actual hashing for `key`
  *
@@ -200,55 +151,25 @@ void hash_func(counting_bloom_t *bloom, const char *key, size_t key_len, uint32_
     }
 }
 
-int free_counting_bloom(counting_bloom_t *bloom)
-{
-    if (bloom != NULL) {
-        free(bloom->hashes);
-        bloom->hashes = NULL;
-        free_bitmap(bloom->bitmap);
-        free(bloom);
-        bloom = NULL;
-    }
-    return 0;
-}
-
 counting_bloom_t *counting_bloom_init(unsigned int capacity, double error_rate, long offset)
 {
     counting_bloom_t *bloom;
 
-    if ((bloom = (counting_bloom_t *)malloc(sizeof(counting_bloom_t))) == NULL) {
-        fprintf(stderr, "Error, could not realloc a new bloom filter\n");
-        return NULL;
+    if ((bloom = (counting_bloom_t *)malloc(sizeof(counting_bloom_t))) == nullptr) {
+        return nullptr;
     }
-    bloom->bitmap = NULL;
+    bloom->bitmap = nullptr;
     bloom->capacity = capacity;
     bloom->error_rate = error_rate;
     bloom->offset = offset + sizeof(counting_bloom_header_t);
-    bloom->nfuncs = (int) ceil(log(1 / error_rate) / log(2));
-    bloom->counts_per_func = (int) ceil(capacity * fabs(log(error_rate)) / (bloom->nfuncs * pow(log(2), 2)));
+    bloom->nfuncs = (size_t) ceil(log(1 / error_rate) / log(2));
+    bloom->counts_per_func = (unsigned int) ceil(capacity * fabs(log(error_rate)) / (bloom->nfuncs * pow(log(2), 2)));
     bloom->size = bloom->nfuncs * bloom->counts_per_func;
     /* rounding-up integer divide by 2 of bloom->size */
     bloom->num_bytes = ((bloom->size + 1) / 2) + sizeof(counting_bloom_header_t);
     bloom->hashes = (uint32_t *)calloc(bloom->nfuncs, sizeof(uint32_t));
 
     return bloom;
-}
-
-counting_bloom_t *new_counting_bloom(unsigned int capacity, double error_rate, const char *filename)
-{
-    counting_bloom_t *cur_bloom;
-    int fd;
-
-    if ((fd = open(filename, O_RDWR | O_CREAT | O_TRUNC, (mode_t)0600)) < 0) {
-        perror("Error, Opening File Failed");
-        fprintf(stderr, " %s \n", filename);
-        return NULL;
-    }
-
-    cur_bloom = counting_bloom_init(capacity, error_rate, 0);
-    cur_bloom->bitmap = new_bitmap(fd, cur_bloom->num_bytes);
-    cur_bloom->header = (counting_bloom_header_t *)(cur_bloom->bitmap->array);
-    return cur_bloom;
 }
 
 int counting_bloom_add(counting_bloom_t *bloom, const char *s, size_t len)
@@ -315,9 +236,7 @@ int free_scaling_bloom(scaling_bloom_t *bloom)
     int i;
     for (i = bloom->num_blooms - 1; i >= 0; i--) {
         free(bloom->blooms[i]->hashes);
-        bloom->blooms[i]->hashes = NULL;
         free(bloom->blooms[i]);
-        bloom->blooms[i] = NULL;
     }
     free(bloom->blooms);
     free_bitmap(bloom->bitmap);
@@ -326,7 +245,7 @@ int free_scaling_bloom(scaling_bloom_t *bloom)
 }
 
 /* creates a new counting bloom filter from a given scaling bloom filter, with count and id */
-counting_bloom_t *new_counting_bloom_from_scale(scaling_bloom_t *bloom)
+counting_bloom_t *new_counting_bloom_from_scale(scaling_bloom_t *bloom, bool extern_bitmap = false)
 {
     int i;
     long offset;
@@ -335,24 +254,26 @@ counting_bloom_t *new_counting_bloom_from_scale(scaling_bloom_t *bloom)
 
     error_rate = bloom->error_rate * (pow(ERROR_TIGHTENING_RATIO, bloom->num_blooms + 1));
 
-    if ((bloom->blooms = (counting_bloom_t **)realloc(bloom->blooms, (bloom->num_blooms + 1) * sizeof(counting_bloom_t *))) == NULL) {
-        fprintf(stderr, "Error, could not realloc a new bloom filter\n");
-        return NULL;
+    if ((bloom->blooms = (counting_bloom_t **)realloc(bloom->blooms, (bloom->num_blooms + 1) * sizeof(counting_bloom_t *))) == nullptr) {
+        return nullptr;
     }
 
     cur_bloom = counting_bloom_init(bloom->capacity, error_rate, bloom->num_bytes);
     bloom->blooms[bloom->num_blooms] = cur_bloom;
-
-    bloom->bitmap = bitmap_resize(bloom->bitmap, bloom->num_bytes, bloom->num_bytes + cur_bloom->num_bytes);
-
-    /* reset header pointer, as mmap may have moved */
-    bloom->header = (scaling_bloom_header_t *) bloom->bitmap->array;
-
-    /* Set the pointers for these header structs to the right location since mmap may have moved */
     bloom->num_blooms++;
-    for (i = 0; i < bloom->num_blooms; i++) {
-        offset = bloom->blooms[i]->offset - sizeof(counting_bloom_header_t);
-        bloom->blooms[i]->header = (counting_bloom_header_t *) (bloom->bitmap->array + offset);
+
+    if (!extern_bitmap) {
+        bloom->bitmap = bitmap_resize(bloom->bitmap, bloom->num_bytes + cur_bloom->num_bytes);
+        /* reset header pointer, as realloc may have moved */
+        bloom->header = (scaling_bloom_header_t *) bloom->bitmap->array;
+        /* Set the pointers for these header structs to the right location since realloc may have moved */
+        for (i = 0; i < bloom->num_blooms; i++) {
+            offset = bloom->blooms[i]->offset - sizeof(counting_bloom_header_t);
+            bloom->blooms[i]->header = (counting_bloom_header_t *) (bloom->bitmap->array + offset);
+        }
+    } else {
+        offset = cur_bloom->offset - sizeof(counting_bloom_header_t);
+        cur_bloom->header = (counting_bloom_header_t *) (bloom->bitmap->array + offset);
     }
 
     bloom->num_bytes += cur_bloom->num_bytes;
@@ -361,54 +282,9 @@ counting_bloom_t *new_counting_bloom_from_scale(scaling_bloom_t *bloom)
     return cur_bloom;
 }
 
-counting_bloom_t *new_counting_bloom_from_file(unsigned int capacity, double error_rate, const char *filename)
-{
-    int fd;
-    off_t size;
-
-    counting_bloom_t *bloom;
-
-    if ((fd = open(filename, O_RDWR, (mode_t)0600)) < 0) {
-        fprintf(stderr, "Error, Could not open file %s: %s\n", filename, strerror(errno));
-        return NULL;
-    }
-    if ((size = lseek(fd, 0, SEEK_END)) < 0) {
-        perror("Error, calling lseek() to tell file size");
-        close(fd);
-        return NULL;
-    }
-    if (size == 0) {
-        fprintf(stderr, "Error, File size zero\n");
-    }
-
-    bloom = counting_bloom_init(capacity, error_rate, 0);
-
-    if (size != bloom->num_bytes) {
-        free_counting_bloom(bloom);
-        fprintf(stderr, "Error, Actual filesize and expected filesize are not equal\n");
-        return NULL;
-    }
-    if ((bloom->bitmap = new_bitmap(fd, size)) == NULL) {
-        fprintf(stderr, "Error, Could not create bitmap with file\n");
-        free_counting_bloom(bloom);
-        return NULL;
-    }
-
-    bloom->header = (counting_bloom_header_t *)(bloom->bitmap->array);
-
-    return bloom;
-}
-
 uint64_t scaling_bloom_clear_seqnums(scaling_bloom_t *bloom)
 {
-    uint64_t seqnum;
-
-    if (bloom->header->disk_seqnum != 0) {
-        // disk_seqnum cleared on disk before any other changes
-        bloom->header->disk_seqnum = 0;
-        bitmap_flush(bloom->bitmap);
-    }
-    seqnum = bloom->header->mem_seqnum;
+    uint64_t seqnum = bloom->header->mem_seqnum;
     bloom->header->mem_seqnum = 0;
     return seqnum;
 }
@@ -418,7 +294,7 @@ int scaling_bloom_add(scaling_bloom_t *bloom, const char *s, size_t len, uint64_
     int i;
     uint64_t seqnum;
 
-    counting_bloom_t *cur_bloom = NULL;
+    counting_bloom_t *cur_bloom = nullptr;
     for (i = bloom->num_blooms - 1; i >= 0; i--) {
         cur_bloom = bloom->blooms[i];
         if (id >= cur_bloom->header->id) {
@@ -428,7 +304,7 @@ int scaling_bloom_add(scaling_bloom_t *bloom, const char *s, size_t len, uint64_
 
     seqnum = scaling_bloom_clear_seqnums(bloom);
 
-    if ((id > bloom->header->max_id) && (cur_bloom->header->count >= cur_bloom->capacity - 1)) {
+    if ((id > bloom->header->max_id) && (cur_bloom->header->count >= cur_bloom->capacity)) {
         cur_bloom = new_counting_bloom_from_scale(bloom);
         cur_bloom->header->count = 0;
         cur_bloom->header->id = bloom->header->max_id + 1;
@@ -484,40 +360,21 @@ int scaling_bloom_check(scaling_bloom_t *bloom, const char *s, size_t len)
     return 0;
 }
 
-int scaling_bloom_flush(scaling_bloom_t *bloom)
-{
-    if (bitmap_flush(bloom->bitmap) != 0) {
-        return -1;
-    }
-    // all changes written to disk before disk_seqnum set
-    if (bloom->header->disk_seqnum == 0) {
-        bloom->header->disk_seqnum = bloom->header->mem_seqnum;
-        return bitmap_flush(bloom->bitmap);
-    }
-    return 0;
-}
-
-uint64_t scaling_bloom_mem_seqnum(scaling_bloom_t *bloom)
-{
-    return bloom->header->mem_seqnum;
-}
-
-uint64_t scaling_bloom_disk_seqnum(scaling_bloom_t *bloom)
-{
-    return bloom->header->disk_seqnum;
-}
-
-scaling_bloom_t *scaling_bloom_init(unsigned int capacity, double error_rate, const char *filename, int fd)
+scaling_bloom_t *scaling_bloom_init(unsigned int capacity, double error_rate, bitmap_t* bitmap = nullptr)
 {
     scaling_bloom_t *bloom;
 
-    if ((bloom = (scaling_bloom_t *)malloc(sizeof(scaling_bloom_t))) == NULL) {
-        return NULL;
+    if ((bloom = (scaling_bloom_t *)malloc(sizeof(scaling_bloom_t))) == nullptr) {
+        return nullptr;
     }
-    if ((bloom->bitmap = new_bitmap(fd, sizeof(scaling_bloom_header_t))) == NULL) {
-        fprintf(stderr, "Error, Could not create bitmap with file\n");
-        free_scaling_bloom(bloom);
-        return NULL;
+
+    if (bitmap == nullptr) {
+        if ((bloom->bitmap = new_bitmap(sizeof(scaling_bloom_header_t))) == nullptr) {
+            free(bloom);
+            return nullptr;
+        }
+    } else {
+        bloom->bitmap = bitmap;
     }
 
     bloom->header = (scaling_bloom_header_t *) bloom->bitmap->array;
@@ -525,31 +382,21 @@ scaling_bloom_t *scaling_bloom_init(unsigned int capacity, double error_rate, co
     bloom->error_rate = error_rate;
     bloom->num_blooms = 0;
     bloom->num_bytes = sizeof(scaling_bloom_header_t);
-    bloom->fd = fd;
-    bloom->blooms = NULL;
+    bloom->blooms = nullptr;
 
     return bloom;
 }
 
-scaling_bloom_t *new_scaling_bloom(unsigned int capacity, double error_rate, const char *filename)
+scaling_bloom_t *new_scaling_bloom(unsigned int capacity, double error_rate)
 {
-
     scaling_bloom_t *bloom;
     counting_bloom_t *cur_bloom;
-    int fd;
 
-    if ((fd = open(filename, O_RDWR | O_CREAT | O_TRUNC, (mode_t)0600)) < 0) {
-        perror("Error, Opening File Failed");
-        fprintf(stderr, " %s \n", filename);
-        return NULL;
-    }
-
-    bloom = scaling_bloom_init(capacity, error_rate, filename, fd);
+    bloom = scaling_bloom_init(capacity, error_rate);
 
     if (!(cur_bloom = new_counting_bloom_from_scale(bloom))) {
-        fprintf(stderr, "Error, Could not create counting bloom\n");
         free_scaling_bloom(bloom);
-        return NULL;
+        return nullptr;
     }
     cur_bloom->header->count = 0;
     cur_bloom->header->id = 0;
@@ -558,39 +405,25 @@ scaling_bloom_t *new_scaling_bloom(unsigned int capacity, double error_rate, con
     return bloom;
 }
 
-scaling_bloom_t *new_scaling_bloom_from_file(unsigned int capacity, double error_rate, const char *filename)
+scaling_bloom_t *new_scaling_bloom_from_bitmap(unsigned int capacity, double error_rate, bitmap_t* bitmap)
 {
-    int fd;
-    off_t size;
-
     scaling_bloom_t *bloom;
     counting_bloom_t *cur_bloom;
 
-    if ((fd = open(filename, O_RDWR, (mode_t)0600)) < 0) {
-        fprintf(stderr, "Error, Could not open file %s: %s\n", filename, strerror(errno));
-        return NULL;
-    }
-    if ((size = lseek(fd, 0, SEEK_END)) < 0) {
-        perror("Error, calling lseek() to tell file size");
-        close(fd);
-        return NULL;
-    }
-    if (size == 0) {
-        fprintf(stderr, "Error, File size zero\n");
+    if ((bloom = scaling_bloom_init(capacity, error_rate, bitmap)) == nullptr) {
+        return nullptr;
     }
 
-    bloom = scaling_bloom_init(capacity, error_rate, filename, fd);
-
-    size -= sizeof(scaling_bloom_header_t);
+    int size = bitmap->bytes - sizeof(scaling_bloom_header_t);
     while (size) {
-        cur_bloom = new_counting_bloom_from_scale(bloom);
+        cur_bloom = new_counting_bloom_from_scale(bloom, true);
         // leave count and id as they were set in the file
         size -= cur_bloom->num_bytes;
         if (size < 0) {
             free_scaling_bloom(bloom);
-            fprintf(stderr, "Error, Actual filesize and expected filesize are not equal\n");
-            return NULL;
+            return nullptr;
         }
     }
+
     return bloom;
 }

--- a/core/thirdparty/dablooms/dablooms.h
+++ b/core/thirdparty/dablooms/dablooms.h
@@ -9,18 +9,16 @@ const char *dablooms_version(void);
 
 typedef struct {
     size_t bytes;
-    int    fd;
     char  *array;
 } bitmap_t;
 
 
 bitmap_t *bitmap_resize(bitmap_t *bitmap, size_t old_size, size_t new_size);
-bitmap_t *new_bitmap(int fd, size_t bytes);
+bitmap_t *new_bitmap(size_t bytes);
 
 int bitmap_increment(bitmap_t *bitmap, unsigned int index, long offset);
 int bitmap_decrement(bitmap_t *bitmap, unsigned int index, long offset);
 int bitmap_check(bitmap_t *bitmap, unsigned int index, long offset);
-int bitmap_flush(bitmap_t *bitmap);
 
 void free_bitmap(bitmap_t *bitmap);
 
@@ -29,7 +27,6 @@ typedef struct {
     uint32_t count;
     uint32_t _pad;
 } counting_bloom_header_t;
-
 
 typedef struct {
     counting_bloom_header_t *header;
@@ -44,9 +41,6 @@ typedef struct {
     bitmap_t *bitmap;
 } counting_bloom_t;
 
-int free_counting_bloom(counting_bloom_t *bloom);
-counting_bloom_t *new_counting_bloom(unsigned int capacity, double error_rate, const char *filename);
-counting_bloom_t *new_counting_bloom_from_file(unsigned int capacity, double error_rate, const char *filename);
 int counting_bloom_add(counting_bloom_t *bloom, const char *s, size_t len);
 int counting_bloom_remove(counting_bloom_t *bloom, const char *s, size_t len);
 int counting_bloom_check(counting_bloom_t *bloom, const char *s, size_t len);
@@ -54,7 +48,6 @@ int counting_bloom_check(counting_bloom_t *bloom, const char *s, size_t len);
 typedef struct {
     uint64_t max_id;
     uint64_t mem_seqnum;
-    uint64_t disk_seqnum;
 } scaling_bloom_header_t;
 
 typedef struct {
@@ -63,18 +56,14 @@ typedef struct {
     unsigned int num_blooms;
     size_t num_bytes;
     double error_rate;
-    int fd;
     counting_bloom_t **blooms;
     bitmap_t *bitmap;
 } scaling_bloom_t;
 
-scaling_bloom_t *new_scaling_bloom(unsigned int capacity, double error_rate, const char *filename);
-scaling_bloom_t *new_scaling_bloom_from_file(unsigned int capacity, double error_rate, const char *filename);
+scaling_bloom_t *new_scaling_bloom(unsigned int capacity, double error_rate);
+scaling_bloom_t *new_scaling_bloom_from_bitmap(unsigned int capacity, double error_rate, bitmap_t* bitmap);
 int free_scaling_bloom(scaling_bloom_t *bloom);
 int scaling_bloom_add(scaling_bloom_t *bloom, const char *s, size_t len, uint64_t id);
 int scaling_bloom_remove(scaling_bloom_t *bloom, const char *s, size_t len, uint64_t id);
 int scaling_bloom_check(scaling_bloom_t *bloom, const char *s, size_t len);
-int scaling_bloom_flush(scaling_bloom_t *bloom);
-uint64_t scaling_bloom_mem_seqnum(scaling_bloom_t *bloom);
-uint64_t scaling_bloom_disk_seqnum(scaling_bloom_t *bloom);
 #endif

--- a/core/thirdparty/dablooms/dablooms.h
+++ b/core/thirdparty/dablooms/dablooms.h
@@ -48,6 +48,7 @@ int counting_bloom_check(counting_bloom_t *bloom, const char *s, size_t len);
 typedef struct {
     uint64_t max_id;
     uint64_t mem_seqnum;
+    uint64_t reserved;
 } scaling_bloom_header_t;
 
 typedef struct {

--- a/core/unittest/thirdparty/test_dablooms.cpp
+++ b/core/unittest/thirdparty/test_dablooms.cpp
@@ -25,29 +25,19 @@
 #include "utils.h"
 
 TEST_F(DabloomsTest, CORRECTNESS_TEST) {
-    FILE* fp;
     scaling_bloom_t* bloom;
     int32_t i;
     struct stats results = {0};
 
-    if ((fp = fopen(bloom_file, "r"))) {
-        fclose(fp);
-        remove(bloom_file);
-    }
-
-    bloom = new_scaling_bloom(2 * CAPACITY, ERROR_RATE, bloom_file);
+    bloom = new_scaling_bloom(2 * CAPACITY, ERROR_RATE);
     ASSERT_NE(bloom, nullptr);
 
     auto start = std::chrono::system_clock::now();
 
-    std::mutex lock;
-
     for (i = 0; i < 2 * CAPACITY; i++) {
         if (i % 2 == 0) {
             std::string tmp = std::to_string(i);
-            lock.lock();
             scaling_bloom_add(bloom, tmp.c_str(), tmp.size(), i);
-            lock.unlock();
         }
     }
 
@@ -62,9 +52,7 @@ TEST_F(DabloomsTest, CORRECTNESS_TEST) {
     for (i = 0; i < 2 * CAPACITY; i++) {
         if (i % 2 == 1) {
             std::string tmp = std::to_string(i);
-            lock.lock();
             bloom_score(scaling_bloom_check(bloom, tmp.c_str(), tmp.size()), 0, &results);
-            lock.unlock();
         }
     }
 
@@ -74,12 +62,6 @@ TEST_F(DabloomsTest, CORRECTNESS_TEST) {
               << double(duration.count()) * std::chrono::microseconds::period::num /
                      std::chrono::microseconds::period::den
               << " s" << std::endl;
-
-//    fclose(fp);
-    if ((fp = fopen(bloom_file, "r"))) {
-        fclose(fp);
-        remove(bloom_file);
-    }
 
     printf(
         "Elements added:   %6d"
@@ -96,18 +78,12 @@ TEST_F(DabloomsTest, CORRECTNESS_TEST) {
 }
 
 TEST_F(DabloomsTest, FILE_OPT_TEST) {
-    FILE* fp;
     scaling_bloom_t* bloom;
     int i, key_removed;
     struct stats results1 = {0};
     struct stats results2 = {0};
 
-    if ((fp = fopen(bloom_file, "r"))) {
-        fclose(fp);
-        remove(bloom_file);
-    }
-
-    bloom = new_scaling_bloom(CAPACITY, ERROR_RATE, bloom_file);
+    bloom = new_scaling_bloom(CAPACITY, ERROR_RATE);
     ASSERT_NE(bloom, nullptr);
 
     auto start = std::chrono::system_clock::now();
@@ -146,108 +122,87 @@ TEST_F(DabloomsTest, FILE_OPT_TEST) {
                      std::chrono::microseconds::period::den
               << " s" << std::endl;
 
-    free_scaling_bloom(bloom);
-    bloom = new_scaling_bloom_from_file(CAPACITY, ERROR_RATE, bloom_file);
-
-    ASSERT_NE(bloom, nullptr);
-
-    for (i = 0; i < CAPACITY; i++) {
-        std::string tmp = std::to_string(i);
-        key_removed = (i % 5 == 0);
-        bloom_score(scaling_bloom_check(bloom, tmp.c_str(), tmp.size()), !key_removed, &results2);
-    }
-    //fclose(fp);
-    if ((fp = fopen(bloom_file, "r"))) {
-        fclose(fp);
-        remove(bloom_file);
-    }
-
-    printf(
-        "Elements added:   %6d"
-        "\n"
-        "Elements removed: %6d"
-        "\n"
-        "Total size: %d KiB"
-        "\n\n",
-        i, i / 5, (int)bloom->num_bytes / 1024);
-
+    bitmap_t* bitmap = bloom->bitmap;
+    bloom->bitmap = nullptr;
     free_scaling_bloom(bloom);
 
     print_results(&results1);
 
-    ASSERT_EQ(results1.false_negatives, results2.false_negatives);
-    ASSERT_EQ(results1.false_positives, results2.false_positives);
-    ASSERT_EQ(results1.true_negatives, results2.true_negatives);
-    ASSERT_EQ(results1.true_positives, results2.true_positives);
+    // new_scaling_bloom_from_bitmap
+    scaling_bloom_t* bloom_copy = new_scaling_bloom_from_bitmap(CAPACITY, ERROR_RATE, bitmap);
+
+    for (i = 0; i < CAPACITY; i++) {
+        std::string tmp = std::to_string(i);
+        key_removed = (i % 5 == 0);
+        bloom_score(scaling_bloom_check(bloom_copy, tmp.c_str(), tmp.size()), !key_removed, &results2);
+    }
+
+    free_scaling_bloom(bloom_copy);
+
+    print_results(&results2);
 }
 
-TEST_F(DabloomsTest, xxx) {
-    FILE* fp;
+TEST_F(DabloomsTest, CNT_LARGER_THAN_CAP) {
     scaling_bloom_t* bloom;
-    int32_t i;
-    struct stats results = {0};
+    int i, key_removed;
+    struct stats results1 = {0};
+    struct stats results2 = {0};
 
-    if ((fp = fopen(bloom_file, "r"))) {
-        fclose(fp);
-        remove(bloom_file);
-    }
-
-    bloom = new_scaling_bloom(2 * CAPACITY, ERROR_RATE, bloom_file);
+    bloom = new_scaling_bloom(CAPACITY / 4, ERROR_RATE);
     ASSERT_NE(bloom, nullptr);
 
-    std::mutex lock;
+    auto start = std::chrono::system_clock::now();
 
     for (i = 0; i < CAPACITY; i++) {
         std::string tmp = std::to_string(i);
-        lock.lock();
         scaling_bloom_add(bloom, tmp.c_str(), tmp.size(), i);
-        lock.unlock();
+    }
+
+    auto end = std::chrono::system_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+    std::cout << std::endl
+              << "Time costs for add: "
+              << double(duration.count()) * std::chrono::microseconds::period::num /
+                 std::chrono::microseconds::period::den
+              << " s" << std::endl;
+    start = std::chrono::system_clock::now();
+
+    for (i = 0; i < CAPACITY; i++) {
+        if (i % 5 == 0) {
+            std::string tmp = std::to_string(i);
+            scaling_bloom_remove(bloom, tmp.c_str(), tmp.size(), i);
+        }
     }
 
     for (i = 0; i < CAPACITY; i++) {
         std::string tmp = std::to_string(i);
-        lock.lock();
-        scaling_bloom_add(bloom, tmp.c_str(), tmp.size(), i);
-        lock.unlock();
+        key_removed = (i % 5 == 0);
+        bloom_score(scaling_bloom_check(bloom, tmp.c_str(), tmp.size()), !key_removed, &results1);
     }
 
-    for (i = 0; i < CAPACITY; i++) {
-        std::string tmp = std::to_string(i);
-        lock.lock();
-        scaling_bloom_remove(bloom, tmp.c_str(), tmp.size(), i);
-        lock.unlock();
-    }
+    end = std::chrono::system_clock::now();
+    duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+    std::cout << "Time costs for remove: "
+              << double(duration.count()) * std::chrono::microseconds::period::num /
+                 std::chrono::microseconds::period::den
+              << " s" << std::endl;
 
-    for (i = 0; i < CAPACITY; i++) {
-        std::string tmp = std::to_string(i);
-        lock.lock();
-        bloom_score(scaling_bloom_check(bloom, tmp.c_str(), tmp.size()), 1, &results);
-        lock.unlock();
-    }
-
-    print_results(&results);
-    results = {0, 0, 0, 0};
-
-    for (i = 0; i < CAPACITY; i++) {
-        std::string tmp = std::to_string(i);
-        lock.lock();
-        scaling_bloom_remove(bloom, tmp.c_str(), tmp.size(), i);
-        lock.unlock();
-    }
-
-    for (i = 0; i < CAPACITY; i++) {
-        std::string tmp = std::to_string(i);
-        lock.lock();
-        bloom_score(scaling_bloom_check(bloom, tmp.c_str(), tmp.size()), 0, &results);
-        lock.unlock();
-    }
-
+    bitmap_t* bitmap = bloom->bitmap;
+    bloom->bitmap = nullptr;
     free_scaling_bloom(bloom);
 
-    if ((fp = fopen(bloom_file, "r"))) {
-        fclose(fp);
-        remove(bloom_file);
+    print_results(&results1);
+
+    // new_scaling_bloom_from_bitmap
+    scaling_bloom_t* bloom_copy = new_scaling_bloom_from_bitmap(CAPACITY / 4, ERROR_RATE, bitmap);
+
+    for (i = 0; i < CAPACITY; i++) {
+        std::string tmp = std::to_string(i);
+        key_removed = (i % 5 == 0);
+        bloom_score(scaling_bloom_check(bloom_copy, tmp.c_str(), tmp.size()), !key_removed, &results2);
     }
 
-    print_results(&results);
+    free_scaling_bloom(bloom_copy);
+
+    print_results(&results2);
 }

--- a/core/unittest/thirdparty/test_dablooms.cpp
+++ b/core/unittest/thirdparty/test_dablooms.cpp
@@ -139,7 +139,10 @@ TEST_F(DabloomsTest, FILE_OPT_TEST) {
 
     free_scaling_bloom(bloom_copy);
 
-    print_results(&results2);
+    ASSERT_EQ(results1.false_negatives, results2.false_negatives);
+    ASSERT_EQ(results1.false_positives, results2.false_positives);
+    ASSERT_EQ(results1.true_negatives, results2.true_negatives);
+    ASSERT_EQ(results1.true_positives, results2.true_positives);
 }
 
 TEST_F(DabloomsTest, CNT_LARGER_THAN_CAP) {
@@ -204,5 +207,8 @@ TEST_F(DabloomsTest, CNT_LARGER_THAN_CAP) {
 
     free_scaling_bloom(bloom_copy);
 
-    print_results(&results2);
+    ASSERT_EQ(results1.false_negatives, results2.false_negatives);
+    ASSERT_EQ(results1.false_positives, results2.false_positives);
+    ASSERT_EQ(results1.true_negatives, results2.true_negatives);
+    ASSERT_EQ(results1.true_positives, results2.true_positives);
 }

--- a/core/unittest/thirdparty/utils.h
+++ b/core/unittest/thirdparty/utils.h
@@ -22,8 +22,6 @@
 #define CAPACITY 1000000
 #define ERROR_RATE .05
 
-static const char* bloom_file = "/tmp/bloom_file.bin";
-
 struct stats {
     int true_positives;
     int true_negatives;


### PR DESCRIPTION
Signed-off-by: shengjun.li <shengjun.li@zilliz.com>

**What type of PR is this?**

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

Fixes #4894

**What this PR does / why we need it:**
(1) add dablooms license
(2) remove mmap in dablooms
(3) fix a boundary judgment bug in dablooms
(4) the capacity of bloom filter is determined by the row count.
(5) add a magic number to be compatible with v1.0.0
***Note: This PR is compatible with v1.0.0, but v1.0.0 is not compatible with this PR.***

