### PR TITLE
GPU cache will be cleaned up in time after the collection is dropped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Please mark all change in change log and use the issue from GitHub
 ## Bug
 -   \#4858 Fix the crash when query for a large topk on GPU Flat
 -   \#4862 The inserted data number increase automatically without any operations
+-   \#4894 The capacity of bloom filter should be determined by the row count of its segment
+-   \#4908 GPU cache will not be cleaned up in time after the collection is dropped
 
 ## Feature
 -   \#1434 Storage: enabling s3 storage support (implemented by Unisinsight)

--- a/core/src/cache/CpuCacheMgr.cpp
+++ b/core/src/cache/CpuCacheMgr.cpp
@@ -46,12 +46,6 @@ CpuCacheMgr::GetInstance() {
     return &s_mgr;
 }
 
-DataObjPtr
-CpuCacheMgr::GetIndex(const std::string& key) {
-    DataObjPtr obj = GetItem(key);
-    return obj;
-}
-
 void
 CpuCacheMgr::OnCpuCacheCapacityChanged(int64_t value) {
     SetCapacity(value);

--- a/core/src/cache/CpuCacheMgr.h
+++ b/core/src/cache/CpuCacheMgr.h
@@ -30,9 +30,6 @@ class CpuCacheMgr : public CacheMgr<DataObjPtr>, public server::CacheConfigHandl
     static CpuCacheMgr*
     GetInstance();
 
-    DataObjPtr
-    GetIndex(const std::string& key);
-
  protected:
     void
     OnCpuCacheCapacityChanged(int64_t value) override;

--- a/core/src/cache/FpgaCacheMgr.cpp
+++ b/core/src/cache/FpgaCacheMgr.cpp
@@ -9,6 +9,7 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied. See the License for the specific language governing permissions and limitations under the License.
 
+#ifdef MILVUS_FPGA_VERSION
 #include "cache/FpgaCacheMgr.h"
 
 #include <utility>
@@ -51,12 +52,6 @@ FpgaCacheMgr::GetInstance() {
     return &s_mgr;
 }
 
-DataObjPtr
-FpgaCacheMgr::GetIndex(const std::string& key) {
-    DataObjPtr obj = GetItem(key);
-    return obj;
-}
-
 void
 FpgaCacheMgr::OnCpuCacheCapacityChanged(int64_t value) {
     SetCapacity(value * unit);
@@ -64,3 +59,4 @@ FpgaCacheMgr::OnCpuCacheCapacityChanged(int64_t value) {
 
 }  // namespace cache
 }  // namespace milvus
+#endif

--- a/core/src/cache/FpgaCacheMgr.h
+++ b/core/src/cache/FpgaCacheMgr.h
@@ -9,6 +9,7 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied. See the License for the specific language governing permissions and limitations under the License.
 
+#ifdef MILVUS_FPGA_VERSION
 #pragma once
 
 #include <memory>
@@ -30,9 +31,6 @@ class FpgaCacheMgr : public CacheMgr<DataObjPtr>, public server::CacheConfigHand
     static FpgaCacheMgr*
     GetInstance();
 
-    DataObjPtr
-    GetIndex(const std::string& key);
-
  protected:
     void
     OnCpuCacheCapacityChanged(int64_t value) override;
@@ -40,3 +38,4 @@ class FpgaCacheMgr : public CacheMgr<DataObjPtr>, public server::CacheConfigHand
 
 }  // namespace cache
 }  // namespace milvus
+#endif

--- a/core/src/cache/GpuCacheMgr.cpp
+++ b/core/src/cache/GpuCacheMgr.cpp
@@ -21,6 +21,8 @@ namespace milvus {
 namespace cache {
 
 #ifdef MILVUS_GPU_VERSION
+const char* Quantizer_Suffix = ".quantizer";
+
 std::mutex GpuCacheMgr::global_mutex_;
 std::unordered_map<int64_t, GpuCacheMgrPtr> GpuCacheMgr::instance_;
 

--- a/core/src/cache/GpuCacheMgr.cpp
+++ b/core/src/cache/GpuCacheMgr.cpp
@@ -50,12 +50,6 @@ GpuCacheMgr::~GpuCacheMgr() {
     config.CancelCallBack(server::CONFIG_GPU_RESOURCE, server::CONFIG_GPU_RESOURCE_ENABLE, identity_);
 }
 
-DataObjPtr
-GpuCacheMgr::GetIndex(const std::string& key) {
-    DataObjPtr obj = GetItem(key);
-    return obj;
-}
-
 void
 GpuCacheMgr::InsertItem(const std::string& key, const milvus::cache::DataObjPtr& data) {
     if (gpu_enable_) {

--- a/core/src/cache/GpuCacheMgr.h
+++ b/core/src/cache/GpuCacheMgr.h
@@ -23,6 +23,10 @@ namespace milvus {
 namespace cache {
 
 #ifdef MILVUS_GPU_VERSION
+
+// Define cache key suffix
+extern const char* Quantizer_Suffix;
+
 class GpuCacheMgr;
 using GpuCacheMgrPtr = std::shared_ptr<GpuCacheMgr>;
 using MutexPtr = std::shared_ptr<std::mutex>;

--- a/core/src/cache/GpuCacheMgr.h
+++ b/core/src/cache/GpuCacheMgr.h
@@ -37,9 +37,6 @@ class GpuCacheMgr : public CacheMgr<DataObjPtr>, public server::GpuResourceConfi
 
     ~GpuCacheMgr();
 
-    DataObjPtr
-    GetIndex(const std::string& key);
-
     void
     InsertItem(const std::string& key, const DataObjPtr& data);
 

--- a/core/src/db/DBImpl.cpp
+++ b/core/src/db/DBImpl.cpp
@@ -562,7 +562,7 @@ DBImpl::ReLoadSegmentsDeletedDocs(const std::string& collection_id, const std::v
         std::string segment_dir;
         utils::GetParentPath(file.location_, segment_dir);
 
-        auto data_obj_ptr = cache::CpuCacheMgr::GetInstance()->GetIndex(file.location_);
+        auto data_obj_ptr = cache::CpuCacheMgr::GetInstance()->GetItem(file.location_);
         auto index = std::static_pointer_cast<knowhere::VecIndex>(data_obj_ptr);
         if (nullptr == index) {
             LOG_ENGINE_WARNING_ << "Index " << file.location_ << " not found";

--- a/core/src/db/engine/ExecutionEngineImpl.cpp
+++ b/core/src/db/engine/ExecutionEngineImpl.cpp
@@ -278,7 +278,7 @@ ExecutionEngineImpl::HybridLoad() const {
 
         for (auto& gpu : gpus) {
             auto cache = cache::GpuCacheMgr::GetInstance(gpu);
-            if (auto cached_quantizer = cache->GetIndex(key)) {
+            if (auto cached_quantizer = cache->GetItem(key)) {
                 device_id = gpu;
                 quantizer = std::static_pointer_cast<CachedQuantizer>(cached_quantizer)->Data();
                 break;
@@ -382,7 +382,7 @@ ExecutionEngineImpl::Serialize() {
 
 Status
 ExecutionEngineImpl::Load(bool to_cache) {
-    index_ = std::static_pointer_cast<knowhere::VecIndex>(cache::CpuCacheMgr::GetInstance()->GetIndex(location_));
+    index_ = std::static_pointer_cast<knowhere::VecIndex>(cache::CpuCacheMgr::GetInstance()->GetItem(location_));
     if (!index_) {
         // not in the cache
         std::string segment_dir;
@@ -513,7 +513,7 @@ ExecutionEngineImpl::Load(bool to_cache) {
 Status
 ExecutionEngineImpl::CopyToGpu(uint64_t device_id, bool hybrid) {
 #ifdef MILVUS_GPU_VERSION
-    auto data_obj_ptr = cache::GpuCacheMgr::GetInstance(device_id)->GetIndex(location_);
+    auto data_obj_ptr = cache::GpuCacheMgr::GetInstance(device_id)->GetItem(location_);
     auto index = std::static_pointer_cast<knowhere::VecIndex>(data_obj_ptr);
     bool already_in_cache = (index != nullptr);
     if (already_in_cache) {
@@ -579,7 +579,7 @@ ExecutionEngineImpl::CopyToIndexFileToGpu(uint64_t device_id) {
 Status
 ExecutionEngineImpl::CopyToCpu() {
 #ifdef MILVUS_GPU_VERSION
-    auto index = std::static_pointer_cast<knowhere::VecIndex>(cache::CpuCacheMgr::GetInstance()->GetIndex(location_));
+    auto index = std::static_pointer_cast<knowhere::VecIndex>(cache::CpuCacheMgr::GetInstance()->GetItem(location_));
     bool already_in_cache = (index != nullptr);
     if (already_in_cache) {
         index_ = index;
@@ -612,7 +612,7 @@ Status
 ExecutionEngineImpl::CopyToFpga() {
 #ifdef MILVUS_FPGA_VERSION
     auto cache_index_ =
-        std::static_pointer_cast<knowhere::VecIndex>(cache::FpgaCacheMgr::GetInstance()->GetIndex(location_));
+        std::static_pointer_cast<knowhere::VecIndex>(cache::FpgaCacheMgr::GetInstance()->GetItem(location_));
     bool already_in_cache = (cache_index_ != nullptr);
     if (!already_in_cache) {
         int64_t indexsize = index_->IndexSize();

--- a/core/src/db/engine/ExecutionEngineImpl.cpp
+++ b/core/src/db/engine/ExecutionEngineImpl.cpp
@@ -260,7 +260,7 @@ ExecutionEngineImpl::HybridLoad() const {
         return;
     }
 
-    const std::string key = location_ + ".quantizer";
+    const std::string key = location_ + cache::Quantizer_Suffix;
 
     server::Config& config = server::Config::GetInstance();
     std::vector<int64_t> gpus;

--- a/core/src/db/insert/MemTable.cpp
+++ b/core/src/db/insert/MemTable.cpp
@@ -274,7 +274,7 @@ MemTable::ApplyDeletes() {
         std::vector<faiss::ConcurrentBitsetPtr> blacklists;
         milvus::engine::meta::SegmentsSchema& segment_files = segment_holder.HoldFiles();
         for (auto& segment_file : segment_files) {
-            auto data_obj_ptr = cache::CpuCacheMgr::GetInstance()->GetIndex(segment_file.location_);
+            auto data_obj_ptr = cache::CpuCacheMgr::GetInstance()->GetItem(segment_file.location_);
             auto index = std::static_pointer_cast<knowhere::VecIndex>(data_obj_ptr);
             if (index != nullptr) {
                 faiss::ConcurrentBitsetPtr blacklist = index->GetBlacklist();

--- a/core/src/index/knowhere/knowhere/index/vector_index/gpu/IndexIVFSQHybrid.cpp
+++ b/core/src/index/knowhere/knowhere/index/vector_index/gpu/IndexIVFSQHybrid.cpp
@@ -70,8 +70,8 @@ IVFSQHybrid::CopyGpuToCpu(const Config& config) {
     if (auto* ivf_index = dynamic_cast<faiss::IndexIVF*>(host_index)) {
         if (ivf_index != nullptr) {
             ivf_index->to_readonly();
+            ivf_index->backup_quantizer();
         }
-        ivf_index->backup_quantizer();
     }
 
     std::shared_ptr<faiss::Index> new_index;

--- a/core/src/utils/CommonUtil.cpp
+++ b/core/src/utils/CommonUtil.cpp
@@ -271,7 +271,9 @@ CommonUtil::EraseFromCache(const std::string& item_key) {
     std::vector<int64_t> gpus;
     config.GetGpuResourceConfigSearchResources(gpus);
     for (auto& gpu : gpus) {
-        cache::GpuCacheMgr::GetInstance(gpu)->EraseItem(item_key);
+        // Only quantizer is cached in GPU now.
+        std::string key = item_key + cache::Quantizer_Suffix;
+        cache::GpuCacheMgr::GetInstance(gpu)->EraseItem(key);
     }
 #endif
 }

--- a/core/unittest/server/test_cache.cpp
+++ b/core/unittest/server/test_cache.cpp
@@ -132,10 +132,10 @@ TEST(CacheTest, CPU_CACHE_TEST) {
     std::shared_ptr<milvus::cache::DataObj> null_data_obj = nullptr;
     cpu_mgr->InsertItem("index_null", null_data_obj);
 
-    auto obj = cpu_mgr->GetIndex("index_0");
+    auto obj = cpu_mgr->GetItem("index_0");
     ASSERT_TRUE(obj == nullptr);
 
-    obj = cpu_mgr->GetIndex("index_" + std::to_string(item_count - 1));
+    obj = cpu_mgr->GetItem("index_" + std::to_string(item_count - 1));
     ASSERT_TRUE(obj != nullptr);
 
     {


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

Fixes #4908

**What this PR does / why we need it:**
(1) GPU cache will not be cleaned up in time after the collection is dropped
(2) remove the IF getIndex
(3) add a macro for FpgaCacheMgr
(4) fix a nullptr check

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
