### PR TITLE
Remove `SetSegmentState` and seal segment in segment allocator

### DIFF
--- a/internal/dataservice/meta_test.go
+++ b/internal/dataservice/meta_test.go
@@ -173,9 +173,6 @@ func TestMeta_Basic(t *testing.T) {
 		assert.EqualValues(t, 1, len(segIDs))
 		assert.Contains(t, segIDs, segID1_1)
 
-		// check OpenSegment/SealSegment/FlushSegment
-		err = meta.OpenSegment(segID0_0, 100)
-		assert.Nil(t, err)
 		err = meta.SealSegment(segID0_0, 200)
 		assert.Nil(t, err)
 		err = meta.FlushSegment(segID0_0, 300)
@@ -183,7 +180,6 @@ func TestMeta_Basic(t *testing.T) {
 
 		info0_0, err = meta.GetSegment(segID0_0)
 		assert.Nil(t, err)
-		assert.NotZero(t, info0_0.OpenTime)
 		assert.NotZero(t, info0_0.SealedTime)
 		assert.NotZero(t, info0_0.FlushedTime)
 
@@ -286,10 +282,6 @@ func TestMeta_Basic(t *testing.T) {
 
 		// check drop non-exist segment
 		err = meta.DropSegment(segIDInvalid)
-		assert.NotNil(t, err)
-
-		// check open non-exist segment
-		err = meta.OpenSegment(segIDInvalid, 100)
 		assert.NotNil(t, err)
 
 		// check seal non-exist segment

--- a/internal/dataservice/watcher.go
+++ b/internal/dataservice/watcher.go
@@ -107,10 +107,6 @@ func (watcher *dataNodeTimeTickWatcher) handleTimeTickMsg(msg *msgstream.TimeTic
 				log.Error("get segment from meta error", zap.Int64("segmentID", id), zap.Error(err))
 				continue
 			}
-			if err = watcher.meta.SetSegmentState(id, commonpb.SegmentState_Sealed); err != nil {
-				log.Error("set segment state error", zap.Int64("segmentID", id), zap.Error(err))
-				continue
-			}
 			collID, segID := sInfo.CollectionID, sInfo.ID
 			coll2Segs[collID] = append(coll2Segs[collID], segID)
 			watcher.allocator.DropSegment(ctx, id)


### PR DESCRIPTION
Segment should be sealed once it exceeds the limited size. This operation
should be done in segment allocator. Watcher only check the status to
decide whether the segment will be flushed.

Signed-off-by: sunby <bingyi.sun@zilliz.com>
