### PR TITLE
index name is unique in collection scope

### DIFF
--- a/internal/distributed/masterservice/masterservice_test.go
+++ b/internal/distributed/masterservice/masterservice_test.go
@@ -626,7 +626,7 @@ func TestGrpcService(t *testing.T) {
 			FieldName:      "vector",
 			IndexName:      cms.Params.DefaultIndexName,
 		}
-		idx, err := core.MetaTable.GetIndexByName("testColl", "vector", cms.Params.DefaultIndexName)
+		idx, err := core.MetaTable.GetIndexByName("testColl", cms.Params.DefaultIndexName)
 		assert.Nil(t, err)
 		assert.Equal(t, len(idx), 1)
 		rsp, err := cli.DropIndex(ctx, req)

--- a/internal/masterservice/master_service_test.go
+++ b/internal/masterservice/master_service_test.go
@@ -859,7 +859,7 @@ func TestMasterService(t *testing.T) {
 			FieldName:      "vector",
 			IndexName:      Params.DefaultIndexName,
 		}
-		idx, err := core.MetaTable.GetIndexByName("testColl", "vector", Params.DefaultIndexName)
+		idx, err := core.MetaTable.GetIndexByName("testColl", Params.DefaultIndexName)
 		assert.Nil(t, err)
 		assert.Equal(t, len(idx), 1)
 
@@ -872,7 +872,7 @@ func TestMasterService(t *testing.T) {
 		assert.Equal(t, im.idxDropID[0], idx[0].IndexID)
 		im.mutex.Unlock()
 
-		idx, err = core.MetaTable.GetIndexByName("testColl", "vector", Params.DefaultIndexName)
+		idx, err = core.MetaTable.GetIndexByName("testColl", Params.DefaultIndexName)
 		assert.Nil(t, err)
 		assert.Equal(t, len(idx), 0)
 	})

--- a/internal/masterservice/meta_table.go
+++ b/internal/masterservice/meta_table.go
@@ -833,12 +833,10 @@ func (mt *metaTable) GetNotIndexedSegments(collName string, fieldName string, id
 
 	var dupIdx typeutil.UniqueID = 0
 	for _, f := range collMeta.FieldIndexes {
-		if f.FiledID == fieldSchema.FieldID {
-			if info, ok := mt.indexID2Meta[f.IndexID]; ok {
-				if info.IndexName == idxInfo.IndexName {
-					dupIdx = info.IndexID
-					break
-				}
+		if info, ok := mt.indexID2Meta[f.IndexID]; ok {
+			if info.IndexName == idxInfo.IndexName {
+				dupIdx = info.IndexID
+				break
 			}
 		}
 	}
@@ -926,7 +924,7 @@ func (mt *metaTable) GetNotIndexedSegments(collName string, fieldName string, id
 	return rstID, fieldSchema, nil
 }
 
-func (mt *metaTable) GetIndexByName(collName string, fieldName string, indexName string) ([]pb.IndexInfo, error) {
+func (mt *metaTable) GetIndexByName(collName, indexName string) ([]pb.IndexInfo, error) {
 	mt.ddLock.RLock()
 	defer mt.ddLock.RUnlock()
 
@@ -938,21 +936,15 @@ func (mt *metaTable) GetIndexByName(collName string, fieldName string, indexName
 	if !ok {
 		return nil, fmt.Errorf("collection %s not found", collName)
 	}
-	fieldSchema, err := mt.unlockGetFieldSchema(collName, fieldName)
-	if err != nil {
-		return nil, err
-	}
 
 	rstIndex := make([]pb.IndexInfo, 0, len(collMeta.FieldIndexes))
 	for _, idx := range collMeta.FieldIndexes {
-		if idx.FiledID == fieldSchema.FieldID {
-			idxInfo, ok := mt.indexID2Meta[idx.IndexID]
-			if !ok {
-				return nil, fmt.Errorf("index id = %d not found", idx.IndexID)
-			}
-			if indexName == "" || idxInfo.IndexName == indexName {
-				rstIndex = append(rstIndex, idxInfo)
-			}
+		idxInfo, ok := mt.indexID2Meta[idx.IndexID]
+		if !ok {
+			return nil, fmt.Errorf("index id = %d not found", idx.IndexID)
+		}
+		if indexName == "" || idxInfo.IndexName == indexName {
+			rstIndex = append(rstIndex, idxInfo)
 		}
 	}
 	return rstIndex, nil

--- a/internal/masterservice/meta_table_test.go
+++ b/internal/masterservice/meta_table_test.go
@@ -341,7 +341,7 @@ func TestMetaTable(t *testing.T) {
 	})
 
 	t.Run("get index by name", func(t *testing.T) {
-		idx, err := mt.GetIndexByName("testColl", "field110", "field110")
+		idx, err := mt.GetIndexByName("testColl", "field110")
 		assert.Nil(t, err)
 		assert.Equal(t, len(idx), 1)
 		assert.Equal(t, idx[0].IndexID, int64(10000))
@@ -357,9 +357,7 @@ func TestMetaTable(t *testing.T) {
 		}
 		assert.True(t, EqualKeyPairArray(idx[0].IndexParams, params))
 
-		_, err = mt.GetIndexByName("testColl", "field111", "idx200")
-		assert.NotNil(t, err)
-		idx, err = mt.GetIndexByName("testColl", "field110", "idx201")
+		idx, err = mt.GetIndexByName("testColl", "idx201")
 		assert.Nil(t, err)
 		assert.Zero(t, len(idx))
 	})
@@ -390,11 +388,11 @@ func TestMetaTable(t *testing.T) {
 		assert.Nil(t, err)
 		assert.False(t, ok)
 
-		idxs, err := mt.GetIndexByName("testColl", "field110", "field110")
+		idxs, err := mt.GetIndexByName("testColl", "field110")
 		assert.Nil(t, err)
 		assert.Zero(t, len(idxs))
 
-		idxs, err = mt.GetIndexByName("testColl", "field110", "field110-1")
+		idxs, err = mt.GetIndexByName("testColl", "field110-1")
 		assert.Nil(t, err)
 		assert.Equal(t, len(idxs), 1)
 		assert.Equal(t, idxs[0].IndexID, int64(2001))
@@ -963,7 +961,7 @@ func TestMetaTable(t *testing.T) {
 		assert.Nil(t, err)
 
 		mt.collName2ID["abc"] = 123
-		_, err = mt.GetIndexByName("abc", "def", "hij")
+		_, err = mt.GetIndexByName("abc", "hij")
 		assert.NotNil(t, err)
 		assert.EqualError(t, err, "collection abc not found")
 
@@ -980,7 +978,7 @@ func TestMetaTable(t *testing.T) {
 		err = mt.AddCollection(collInfo, partInfo, idxInfo)
 		assert.Nil(t, err)
 		mt.indexID2Meta = make(map[int64]pb.IndexInfo)
-		_, err = mt.GetIndexByName(collInfo.Schema.Name, collInfo.Schema.Fields[0].Name, idxInfo[0].IndexName)
+		_, err = mt.GetIndexByName(collInfo.Schema.Name, idxInfo[0].IndexName)
 		assert.NotNil(t, err)
 		assert.EqualError(t, err, fmt.Sprintf("index id = %d not found", idxInfo[0].IndexID))
 

--- a/internal/masterservice/task.go
+++ b/internal/masterservice/task.go
@@ -781,7 +781,7 @@ func (t *DescribeIndexReqTask) Execute(ctx context.Context) error {
 	if t.Type() != commonpb.MsgType_DescribeIndex {
 		return fmt.Errorf("describe index, msg type = %s", commonpb.MsgType_name[int32(t.Type())])
 	}
-	idx, err := t.core.MetaTable.GetIndexByName(t.Req.CollectionName, t.Req.FieldName, t.Req.IndexName)
+	idx, err := t.core.MetaTable.GetIndexByName(t.Req.CollectionName, t.Req.IndexName)
 	if err != nil {
 		return err
 	}
@@ -821,7 +821,7 @@ func (t *DropIndexReqTask) Execute(ctx context.Context) error {
 	if t.Type() != commonpb.MsgType_DropIndex {
 		return fmt.Errorf("drop index, msg type = %s", commonpb.MsgType_name[int32(t.Type())])
 	}
-	info, err := t.core.MetaTable.GetIndexByName(t.Req.CollectionName, t.Req.FieldName, t.Req.IndexName)
+	info, err := t.core.MetaTable.GetIndexByName(t.Req.CollectionName, t.Req.IndexName)
 	if err != nil {
 		log.Warn("GetIndexByName failed,", zap.String("collection name", t.Req.CollectionName), zap.String("field name", t.Req.FieldName), zap.String("index name", t.Req.IndexName), zap.Error(err))
 		return err


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

Fixes #

**What this PR does / why we need it:**
`index name` is unique in collection scope.
in the `meta table` of  `master`,  change typo of `GetIndeByName` from `GetIndexByName(collection_name, field_name, index_name)` to `GetCollectionByName(collection_name, index_name)`
