### PR TITLE
fix crash when creating GPU index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Please mark all change in change log and use the issue from GitHub
 -   \#5010 IVF_PQ failed to query on GPU if 'nbits' doesn't equal to 8
 -   \#5050 Index type returned by get_collection_stats() is incorrect
 -   \#5063 Empty segment is serialized and crash milvus
+-   \#5078 Server crashed when creaing a GPU IVF index whose dimension is 2048/4086/8192
 
 ## Feature
 -   \#4564 Allow get_entity_by_id() in a specified partition

--- a/core/src/index/thirdparty/faiss/gpu/utils/StackDeviceMemory.cpp
+++ b/core/src/index/thirdparty/faiss/gpu/utils/StackDeviceMemory.cpp
@@ -65,6 +65,10 @@ StackDeviceMemory::Stack::getSizeAvailable() const {
 char*
 StackDeviceMemory::Stack::getAlloc(size_t size,
                                    cudaStream_t stream) {
+  if (size  == 0) {
+      return nullptr;
+  }
+
   if (size > (end_ - head_)) {
     // Too large for our stack
     DeviceScope s(device_);
@@ -133,6 +137,10 @@ void
 StackDeviceMemory::Stack::returnAlloc(char* p,
                                       size_t size,
                                       cudaStream_t stream) {
+  if (size  == 0) {
+      return;
+  }
+
   if (p < start_ || p >= end_) {
     // This is not on our stack; it was a one-off allocation
     DeviceScope s(device_);


### PR DESCRIPTION
Signed-off-by: shengjun.li <shengjun.li@zilliz.com>

**What type of PR is this?**
- [x] BUG

**Which issue(s) this PR fixes:**
Fixes #5078

**What this PR does / why we need it:**
StackDeviceMemory failed to deal the memory whose length is 0
