### PR TITLE
docs: fix Response status code

### DIFF
--- a/core/src/server/web_impl/README.md
+++ b/core/src/server/web_impl/README.md
@@ -1316,7 +1316,7 @@ Obtain vectors by ID.
 
 | Status code | Description                                                       |
 | ----------- | ----------------------------------------------------------------- |
-| 201         | Created                                                           |
+| 200         | The request is successful.                                        |
 | 400         | The request is incorrect. Refer to the error message for details. |
 | 404         | The required resource does not exist.                             |
 


### PR DESCRIPTION
I used Milvus for the first time the other day.
And, very nice application !

I was using it according to the documentation, but then I noticed an error in the documentation.
It's a very simple mistake.

The following endpoint do not return Status 201 on success.

`/collections/{collection_name}/vectors?ids={vector_id_list}` (GET)

The actual is returned status 200.

This PR is to correct mistake in that document.

Signed-off-by: e155417k@st.u-gakugei.ac.jp
