### PR TITLE
Add msg start/end position in descriptor event

### DIFF
--- a/docs/developer_guides/chap08_binlog.md
+++ b/docs/developer_guides/chap08_binlog.md
@@ -62,11 +62,19 @@ Binlog file consists of 4 bytes magic number and a series of events. The first e
 |        +----------------------------+
 |        | segment_id       56 : 8    | segment id (schema column does not need)
 |        +----------------------------+
-|        | start_timestamp  64 : 1    | minimum timestamp allocated by master of all events in this file
+|        | start_timestamp  64 : 8    | minimum timestamp allocated by master of all events in this file
 |        +----------------------------+
-|        | end_timestamp    65 : 1    | maximum timestamp allocated by master of all events in this file
+|        | end_timestamp    72 : 8    | maximum timestamp allocated by master of all events in this file
 |        +----------------------------+
-|        | post-header      66 : n    | array of n bytes, one byte per event type that the server knows about
+|        | start_pos_len    80 : 4    | length of start position message
+|        +----------------------------+
+|        | start_pos_msg    84 : 8    | start position message
+|        +----------------------------+
+|        | end_pos_len      92 : 4    | length of end position message
+|        +----------------------------+
+|        | end_pos_msg      96 : 8    | end position message
+|        +----------------------------+
+|        | post-header      104 : n   | array of n bytes, one byte per event type that the server knows about
 |        | lengths for all            |
 |        | event types                |
 +=====================================+

--- a/internal/storage/binlog_reader.go
+++ b/internal/storage/binlog_reader.go
@@ -44,7 +44,7 @@ func (reader *BinlogReader) NextEventReader() (*EventReader, error) {
 }
 
 func (reader *BinlogReader) readMagicNumber() (int32, error) {
-	if err := binary.Read(reader.buffer, binary.LittleEndian, &reader.magicNumber); err != nil {
+	if err := binary.Read(reader.buffer, binlogEndian, &reader.magicNumber); err != nil {
 		return -1, err
 	}
 	if reader.magicNumber != MagicNumber {

--- a/internal/storage/binlog_test.go
+++ b/internal/storage/binlog_test.go
@@ -51,6 +51,8 @@ func TestInsertBinlog(t *testing.T) {
 
 	w.SetStartTimeStamp(1000)
 	w.SetEndTimeStamp(2000)
+	w.SetStartPositionMsg([]byte{1, 2, 3})
+	w.SetEndPositionMsg([]byte{1, 2, 3})
 
 	_, err = w.GetBuffer()
 	assert.NotNil(t, err)
@@ -148,8 +150,34 @@ func TestInsertBinlog(t *testing.T) {
 	assert.Equal(t, schemapb.DataType(colType), schemapb.DataType_Int64)
 	pos += int(unsafe.Sizeof(colType))
 
+	// descriptor data start position len
+	sLen := UnsafeReadInt32(buf, pos)
+	assert.Equal(t, int32(3), sLen)
+	pos += int(unsafe.Sizeof(sLen))
+
+	// descriptor data start position msg
+	sMsg := make([]byte, 0, sLen)
+	for i := 0; i < int(sLen); i++ {
+		sMsg = append(sMsg, buf[pos])
+		pos++
+	}
+	assert.Equal(t, []byte{1, 2, 3}, sMsg)
+
+	// descriptor data end position len
+	eLen := UnsafeReadInt32(buf, pos)
+	assert.Equal(t, int32(3), eLen)
+	pos += int(unsafe.Sizeof(eLen))
+
+	// descriptor data end position msg
+	eMsg := make([]byte, 0, eLen)
+	for i := 0; i < int(eLen); i++ {
+		eMsg = append(eMsg, buf[pos])
+		pos++
+	}
+	assert.Equal(t, []byte{1, 2, 3}, eMsg)
+
 	//descriptor data, post header lengths
-	for i := DescriptorEventType; i < EventTypeEnd; i++ {
+	for _, i := range EventTypes {
 		size := getEventFixPartSize(i)
 		assert.Equal(t, uint8(size), buf[pos])
 		pos++
@@ -310,6 +338,8 @@ func TestDeleteBinlog(t *testing.T) {
 
 	w.SetStartTimeStamp(1000)
 	w.SetEndTimeStamp(2000)
+	w.SetStartPositionMsg([]byte{1, 2, 3})
+	w.SetEndPositionMsg([]byte{1, 2, 3})
 
 	_, err = w.GetBuffer()
 	assert.NotNil(t, err)
@@ -407,8 +437,34 @@ func TestDeleteBinlog(t *testing.T) {
 	assert.Equal(t, schemapb.DataType(colType), schemapb.DataType_Int64)
 	pos += int(unsafe.Sizeof(colType))
 
+	// descriptor data start position len
+	sLen := UnsafeReadInt32(buf, pos)
+	assert.Equal(t, int32(3), sLen)
+	pos += int(unsafe.Sizeof(sLen))
+
+	// descriptor data start position msg
+	sMsg := make([]byte, 0, sLen)
+	for i := 0; i < int(sLen); i++ {
+		sMsg = append(sMsg, buf[pos])
+		pos++
+	}
+	assert.Equal(t, []byte{1, 2, 3}, sMsg)
+
+	// descriptor data end position len
+	eLen := UnsafeReadInt32(buf, pos)
+	assert.Equal(t, int32(3), eLen)
+	pos += int(unsafe.Sizeof(eLen))
+
+	// descriptor data end position msg
+	eMsg := make([]byte, 0, eLen)
+	for i := 0; i < int(eLen); i++ {
+		eMsg = append(eMsg, buf[pos])
+		pos++
+	}
+	assert.Equal(t, []byte{1, 2, 3}, eMsg)
+
 	//descriptor data, post header lengths
-	for i := DescriptorEventType; i < EventTypeEnd; i++ {
+	for _, i := range EventTypes {
 		size := getEventFixPartSize(i)
 		assert.Equal(t, uint8(size), buf[pos])
 		pos++
@@ -569,6 +625,8 @@ func TestDDLBinlog1(t *testing.T) {
 
 	w.SetStartTimeStamp(1000)
 	w.SetEndTimeStamp(2000)
+	w.SetStartPositionMsg([]byte{1, 2, 3})
+	w.SetEndPositionMsg([]byte{1, 2, 3})
 
 	_, err = w.GetBuffer()
 	assert.NotNil(t, err)
@@ -666,8 +724,34 @@ func TestDDLBinlog1(t *testing.T) {
 	assert.Equal(t, schemapb.DataType(colType), schemapb.DataType_Int64)
 	pos += int(unsafe.Sizeof(colType))
 
+	// descriptor data start position len
+	sLen := UnsafeReadInt32(buf, pos)
+	assert.Equal(t, int32(3), sLen)
+	pos += int(unsafe.Sizeof(sLen))
+
+	// descriptor data start position msg
+	sMsg := make([]byte, 0, sLen)
+	for i := 0; i < int(sLen); i++ {
+		sMsg = append(sMsg, buf[pos])
+		pos++
+	}
+	assert.Equal(t, []byte{1, 2, 3}, sMsg)
+
+	// descriptor data end position len
+	eLen := UnsafeReadInt32(buf, pos)
+	assert.Equal(t, int32(3), eLen)
+	pos += int(unsafe.Sizeof(eLen))
+
+	// descriptor data end position msg
+	eMsg := make([]byte, 0, eLen)
+	for i := 0; i < int(eLen); i++ {
+		eMsg = append(eMsg, buf[pos])
+		pos++
+	}
+	assert.Equal(t, []byte{1, 2, 3}, eMsg)
+
 	//descriptor data, post header lengths
-	for i := DescriptorEventType; i < EventTypeEnd; i++ {
+	for _, i := range EventTypes {
 		size := getEventFixPartSize(i)
 		assert.Equal(t, uint8(size), buf[pos])
 		pos++
@@ -828,6 +912,8 @@ func TestDDLBinlog2(t *testing.T) {
 
 	w.SetStartTimeStamp(1000)
 	w.SetEndTimeStamp(2000)
+	w.SetStartPositionMsg([]byte{1, 2, 3})
+	w.SetEndPositionMsg([]byte{1, 2, 3})
 
 	_, err = w.GetBuffer()
 	assert.NotNil(t, err)
@@ -925,8 +1011,34 @@ func TestDDLBinlog2(t *testing.T) {
 	assert.Equal(t, schemapb.DataType(colType), schemapb.DataType_Int64)
 	pos += int(unsafe.Sizeof(colType))
 
+	// descriptor data start position len
+	sLen := UnsafeReadInt32(buf, pos)
+	assert.Equal(t, int32(3), sLen)
+	pos += int(unsafe.Sizeof(sLen))
+
+	// descriptor data start position msg
+	sMsg := make([]byte, 0, sLen)
+	for i := 0; i < int(sLen); i++ {
+		sMsg = append(sMsg, buf[pos])
+		pos++
+	}
+	assert.Equal(t, []byte{1, 2, 3}, sMsg)
+
+	// descriptor data end position len
+	eLen := UnsafeReadInt32(buf, pos)
+	assert.Equal(t, int32(3), eLen)
+	pos += int(unsafe.Sizeof(eLen))
+
+	// descriptor data end position msg
+	eMsg := make([]byte, 0, eLen)
+	for i := 0; i < int(eLen); i++ {
+		eMsg = append(eMsg, buf[pos])
+		pos++
+	}
+	assert.Equal(t, []byte{1, 2, 3}, eMsg)
+
 	//descriptor data, post header lengths
-	for i := DescriptorEventType; i < EventTypeEnd; i++ {
+	for _, i := range EventTypes {
 		size := getEventFixPartSize(i)
 		assert.Equal(t, uint8(size), buf[pos])
 		pos++
@@ -1072,7 +1184,7 @@ func TestNewBinlogReaderError(t *testing.T) {
 	assert.NotNil(t, err)
 
 	buffer := new(bytes.Buffer)
-	err = binary.Write(buffer, binary.LittleEndian, int32(MagicNumber))
+	err = binary.Write(buffer, binlogEndian, int32(MagicNumber))
 	assert.Nil(t, err)
 	data = buffer.Bytes()
 
@@ -1080,7 +1192,7 @@ func TestNewBinlogReaderError(t *testing.T) {
 	assert.Nil(t, reader)
 	assert.NotNil(t, err)
 
-	err = binary.Write(buffer, binary.LittleEndian, int32(555))
+	err = binary.Write(buffer, binlogEndian, int32(555))
 	assert.Nil(t, err)
 	data = buffer.Bytes()
 

--- a/internal/storage/binlog_writer.go
+++ b/internal/storage/binlog_writer.go
@@ -98,7 +98,7 @@ func (writer *baseBinlogWriter) Close() error {
 
 	var offset int32
 	writer.buffer = new(bytes.Buffer)
-	if err := binary.Write(writer.buffer, binary.LittleEndian, int32(MagicNumber)); err != nil {
+	if err := binary.Write(writer.buffer, binlogEndian, int32(MagicNumber)); err != nil {
 		return err
 	}
 	if err := writer.descriptorEvent.Write(writer.buffer); err != nil {

--- a/internal/storage/event_header.go
+++ b/internal/storage/event_header.go
@@ -33,7 +33,7 @@ func (header *baseEventHeader) GetMemoryUsageInBytes() int32 {
 }
 
 func (header *baseEventHeader) Write(buffer io.Writer) error {
-	return binary.Write(buffer, binary.LittleEndian, header)
+	return binary.Write(buffer, binlogEndian, header)
 }
 
 type descriptorEventHeader = baseEventHeader
@@ -44,7 +44,7 @@ type eventHeader struct {
 
 func readEventHeader(buffer io.Reader) (*eventHeader, error) {
 	header := &eventHeader{}
-	if err := binary.Read(buffer, binary.LittleEndian, header); err != nil {
+	if err := binary.Read(buffer, binlogEndian, header); err != nil {
 		return nil, err
 	}
 
@@ -53,7 +53,7 @@ func readEventHeader(buffer io.Reader) (*eventHeader, error) {
 
 func readDescriptorEventHeader(buffer io.Reader) (*descriptorEventHeader, error) {
 	header := &descriptorEventHeader{}
-	if err := binary.Read(buffer, binary.LittleEndian, header); err != nil {
+	if err := binary.Read(buffer, binlogEndian, header); err != nil {
 		return nil, err
 	}
 	return header, nil

--- a/internal/storage/event_writer_test.go
+++ b/internal/storage/event_writer_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestSizeofStruct(t *testing.T) {
 	var buf bytes.Buffer
-	err := binary.Write(&buf, binary.LittleEndian, baseEventHeader{})
+	err := binary.Write(&buf, binlogEndian, baseEventHeader{})
 	assert.Nil(t, err)
 	s1 := binary.Size(baseEventHeader{})
 	s2 := binary.Size(&baseEventHeader{})
@@ -33,11 +33,16 @@ func TestSizeofStruct(t *testing.T) {
 
 	de := descriptorEventData{
 		DescriptorEventDataFixPart: DescriptorEventDataFixPart{},
+		StartPositionLen:           4,
+		StartPositionMsg:           []byte{1, 1, 1, 1},
+		EndPositionLen:             4,
+		EndPositionMsg:             []byte{1, 1, 1, 1},
 		PostHeaderLengths:          []uint8{0, 1, 2, 3},
 	}
+
 	err = de.Write(&buf)
 	assert.Nil(t, err)
-	s3 := binary.Size(de.DescriptorEventDataFixPart) + binary.Size(de.PostHeaderLengths)
+	s3 := binary.Size(de.DescriptorEventDataFixPart) + binary.Size(de.PostHeaderLengths) + binary.Size(de.StartPositionMsg) + binary.Size(de.EndPositionMsg) + binary.Size(de.StartPositionLen) + binary.Size(de.EndPositionLen)
 	assert.Equal(t, s3, buf.Len())
 }
 

--- a/internal/storage/print_binlog.go
+++ b/internal/storage/print_binlog.go
@@ -84,6 +84,10 @@ func printBinlogFile(filename string) error {
 	if !ok {
 		return fmt.Errorf("undefine data type %d", r.descriptorEvent.descriptorEventData.PayloadDataType)
 	}
+	fmt.Printf("\tStartPositionLen: %v\n", r.descriptorEvent.StartPositionLen)
+	fmt.Printf("\tStartPositionMsg: %v\n", r.descriptorEvent.StartPositionMsg)
+	fmt.Printf("\tEndPositionLen: %v\n", r.descriptorEvent.EndPositionLen)
+	fmt.Printf("\tEndPositionMsg: %v\n", r.descriptorEvent.EndPositionMsg)
 	fmt.Printf("\tPayloadDataType: %v\n", dataTypeName)
 	fmt.Printf("\tPostHeaderLengths: %v\n", r.descriptorEvent.descriptorEventData.PostHeaderLengths)
 	eventNum := 0


### PR DESCRIPTION
QueryNode need to know the start/end position to load collection from
pulsar. So we record the position information in binlog.

Signed-off-by: sunby <bingyi.sun@zilliz.com>
