### PR TITLE
Save ddmsg info and type into ETCD

### DIFF
--- a/internal/masterservice/master_service_test.go
+++ b/internal/masterservice/master_service_test.go
@@ -13,6 +13,7 @@ package masterservice
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"sync"
@@ -403,6 +404,16 @@ func TestMasterService(t *testing.T) {
 		createMeta, err = core.MetaTable.GetCollectionByName("testColl-again")
 		assert.Nil(t, err)
 		assert.Equal(t, createMsg.CollectionID, createMeta.ID)
+
+		msgType, err := core.MetaTable.client.Load(DDMsgTypePrefix)
+		assert.Nil(t, err)
+		assert.Equal(t, CreateCollectionMsgType, msgType)
+
+		var meta map[string]string
+		metaStr, err := core.MetaTable.client.Load(DDMsgPrefix)
+		assert.Nil(t, err)
+		err = json.Unmarshal([]byte(metaStr), &meta)
+		assert.Nil(t, err)
 	})
 
 	t.Run("has collection", func(t *testing.T) {
@@ -524,6 +535,16 @@ func TestMasterService(t *testing.T) {
 
 		assert.Equal(t, 1, len(pm.GetCollArray()))
 		assert.Equal(t, "testColl", pm.GetCollArray()[0])
+
+		msgType, err := core.MetaTable.client.Load(DDMsgTypePrefix)
+		assert.Nil(t, err)
+		assert.Equal(t, CreatePartitionMsgType, msgType)
+
+		var meta map[string]string
+		metaStr, err := core.MetaTable.client.Load(DDMsgPrefix)
+		assert.Nil(t, err)
+		err = json.Unmarshal([]byte(metaStr), &meta)
+		assert.Nil(t, err)
 	})
 
 	t.Run("has partition", func(t *testing.T) {
@@ -913,6 +934,16 @@ func TestMasterService(t *testing.T) {
 
 		assert.Equal(t, 2, len(pm.GetCollArray()))
 		assert.Equal(t, "testColl", pm.GetCollArray()[1])
+
+		msgType, err := core.MetaTable.client.Load(DDMsgTypePrefix)
+		assert.Nil(t, err)
+		assert.Equal(t, DropPartitionMsgType, msgType)
+
+		var meta map[string]string
+		metaStr, err := core.MetaTable.client.Load(DDMsgPrefix)
+		assert.Nil(t, err)
+		err = json.Unmarshal([]byte(metaStr), &meta)
+		assert.Nil(t, err)
 	})
 
 	t.Run("drop collection", func(t *testing.T) {
@@ -966,6 +997,17 @@ func TestMasterService(t *testing.T) {
 		collArray = pm.GetCollArray()
 		assert.Equal(t, len(collArray), 3)
 		assert.Equal(t, collArray[2], "testColl")
+
+		msgType, err := core.MetaTable.client.Load(DDMsgTypePrefix)
+		assert.Nil(t, err)
+		assert.Equal(t, DropCollectionMsgType, msgType)
+
+		var collID typeutil.UniqueID
+		collIDByte, err := core.MetaTable.client.Load(DDMsgPrefix)
+		assert.Nil(t, err)
+		err = json.Unmarshal([]byte(collIDByte), &collID)
+		assert.Nil(t, err)
+		assert.Equal(t, collMeta.ID, collID)
 	})
 
 	t.Run("context_cancel", func(t *testing.T) {

--- a/internal/masterservice/master_service_test.go
+++ b/internal/masterservice/master_service_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/milvus-io/milvus/internal/msgstream"
 	"github.com/milvus-io/milvus/internal/proto/commonpb"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
+	"github.com/milvus-io/milvus/internal/proto/etcdpb"
 	"github.com/milvus-io/milvus/internal/proto/indexpb"
 	"github.com/milvus-io/milvus/internal/proto/internalpb"
 	"github.com/milvus-io/milvus/internal/proto/masterpb"
@@ -405,6 +406,7 @@ func TestMasterService(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, createMsg.CollectionID, createMeta.ID)
 
+		// check DDMsg type and info
 		msgType, err := core.MetaTable.client.Load(DDMsgTypePrefix)
 		assert.Nil(t, err)
 		assert.Equal(t, CreateCollectionMsgType, msgType)
@@ -414,6 +416,15 @@ func TestMasterService(t *testing.T) {
 		assert.Nil(t, err)
 		err = json.Unmarshal([]byte(metaStr), &meta)
 		assert.Nil(t, err)
+
+		k1 := fmt.Sprintf("%s/%d", CollectionMetaPrefix, createMeta.ID)
+		v1 := meta[k1]
+		var collInfo etcdpb.CollectionInfo
+		err = proto.UnmarshalText(v1, &collInfo)
+		assert.Nil(t, err)
+		assert.Equal(t, createMeta.ID, collInfo.ID)
+		assert.Equal(t, createMeta.CreateTime, collInfo.CreateTime)
+		assert.Equal(t, createMeta.PartitionIDs[0], collInfo.PartitionIDs[0])
 	})
 
 	t.Run("has collection", func(t *testing.T) {
@@ -536,6 +547,7 @@ func TestMasterService(t *testing.T) {
 		assert.Equal(t, 1, len(pm.GetCollArray()))
 		assert.Equal(t, "testColl", pm.GetCollArray()[0])
 
+		// check DDMsg type and info
 		msgType, err := core.MetaTable.client.Load(DDMsgTypePrefix)
 		assert.Nil(t, err)
 		assert.Equal(t, CreatePartitionMsgType, msgType)
@@ -545,6 +557,23 @@ func TestMasterService(t *testing.T) {
 		assert.Nil(t, err)
 		err = json.Unmarshal([]byte(metaStr), &meta)
 		assert.Nil(t, err)
+
+		k1 := fmt.Sprintf("%s/%d", CollectionMetaPrefix, collMeta.ID)
+		v1 := meta[k1]
+		var collInfo etcdpb.CollectionInfo
+		err = proto.UnmarshalText(v1, &collInfo)
+		assert.Nil(t, err)
+		assert.Equal(t, collMeta.ID, collInfo.ID)
+		assert.Equal(t, collMeta.CreateTime, collInfo.CreateTime)
+		assert.Equal(t, collMeta.PartitionIDs[0], collInfo.PartitionIDs[0])
+
+		k2 := fmt.Sprintf("%s/%d/%d", PartitionMetaPrefix, collMeta.ID, partMeta.PartitionID)
+		v2 := meta[k2]
+		var partInfo etcdpb.PartitionInfo
+		err = proto.UnmarshalText(v2, &partInfo)
+		assert.Nil(t, err)
+		assert.Equal(t, partMeta.PartitionName, partInfo.PartitionName)
+		assert.Equal(t, partMeta.PartitionID, partInfo.PartitionID)
 	})
 
 	t.Run("has partition", func(t *testing.T) {
@@ -935,6 +964,7 @@ func TestMasterService(t *testing.T) {
 		assert.Equal(t, 2, len(pm.GetCollArray()))
 		assert.Equal(t, "testColl", pm.GetCollArray()[1])
 
+		// check DDMsg type and info
 		msgType, err := core.MetaTable.client.Load(DDMsgTypePrefix)
 		assert.Nil(t, err)
 		assert.Equal(t, DropPartitionMsgType, msgType)
@@ -944,6 +974,15 @@ func TestMasterService(t *testing.T) {
 		assert.Nil(t, err)
 		err = json.Unmarshal([]byte(metaStr), &meta)
 		assert.Nil(t, err)
+
+		k1 := fmt.Sprintf("%s/%d", CollectionMetaPrefix, collMeta.ID)
+		v1 := meta[k1]
+		var collInfo etcdpb.CollectionInfo
+		err = proto.UnmarshalText(v1, &collInfo)
+		assert.Nil(t, err)
+		assert.Equal(t, collMeta.ID, collInfo.ID)
+		assert.Equal(t, collMeta.CreateTime, collInfo.CreateTime)
+		assert.Equal(t, collMeta.PartitionIDs[0], collInfo.PartitionIDs[0])
 	})
 
 	t.Run("drop collection", func(t *testing.T) {
@@ -998,6 +1037,7 @@ func TestMasterService(t *testing.T) {
 		assert.Equal(t, len(collArray), 3)
 		assert.Equal(t, collArray[2], "testColl")
 
+		// check DDMsg type and info
 		msgType, err := core.MetaTable.client.Load(DDMsgTypePrefix)
 		assert.Nil(t, err)
 		assert.Equal(t, DropCollectionMsgType, msgType)

--- a/internal/masterservice/meta_table.go
+++ b/internal/masterservice/meta_table.go
@@ -48,8 +48,8 @@ const (
 
 	CreateCollectionMsgType = "CreateCollection"
 	DropCollectionMsgType   = "DropCollection"
-	CreatePartitionMsgType = "CreatePartition"
-	DropPartitionMsgType   = "DropPartition"
+	CreatePartitionMsgType  = "CreatePartition"
+	DropPartitionMsgType    = "DropPartition"
 )
 
 type metaTable struct {

--- a/internal/masterservice/meta_table_test.go
+++ b/internal/masterservice/meta_table_test.go
@@ -434,7 +434,7 @@ func TestMetaTable(t *testing.T) {
 			return fmt.Errorf("milti remove with prefix error")
 		}
 		mockKV.multiSaveAndRemoveWithPrefix = func(save map[string]string, keys []string) error {
-			return fmt.Errorf("milti remove with prefix error")
+			return fmt.Errorf("milti save and remove with prefix error")
 		}
 		collInfo.PartitionIDs = nil
 		err := mt.AddCollection(collInfo, partInfo, idxInfo)

--- a/internal/masterservice/meta_table_test.go
+++ b/internal/masterservice/meta_table_test.go
@@ -433,6 +433,9 @@ func TestMetaTable(t *testing.T) {
 		mockKV.multiRemoveWithPrefix = func(keys []string) error {
 			return fmt.Errorf("milti remove with prefix error")
 		}
+		mockKV.multiSaveAndRemoveWithPrefix = func(save map[string]string, keys []string) error {
+			return fmt.Errorf("milti remove with prefix error")
+		}
 		collInfo.PartitionIDs = nil
 		err := mt.AddCollection(collInfo, partInfo, idxInfo)
 		assert.Nil(t, err)

--- a/internal/masterservice/meta_table_test.go
+++ b/internal/masterservice/meta_table_test.go
@@ -430,9 +430,6 @@ func TestMetaTable(t *testing.T) {
 		mockKV.multiSave = func(kvs map[string]string) error {
 			return nil
 		}
-		mockKV.multiRemoveWithPrefix = func(keys []string) error {
-			return fmt.Errorf("milti remove with prefix error")
-		}
 		mockKV.multiSaveAndRemoveWithPrefix = func(save map[string]string, keys []string) error {
 			return fmt.Errorf("milti save and remove with prefix error")
 		}
@@ -443,7 +440,7 @@ func TestMetaTable(t *testing.T) {
 		mt.indexID2Meta = make(map[int64]pb.IndexInfo)
 		err = mt.DeleteCollection(collInfo.ID)
 		assert.NotNil(t, err)
-		assert.EqualError(t, err, "milti remove with prefix error")
+		assert.EqualError(t, err, "milti save and remove with prefix error")
 	})
 
 	t.Run("get collection failed", func(t *testing.T) {

--- a/internal/masterservice/task.go
+++ b/internal/masterservice/task.go
@@ -141,10 +141,6 @@ func (t *CreateCollectionReqTask) Execute(ctx context.Context) error {
 		SegmentIDs:    make([]typeutil.UniqueID, 0, 16),
 	}
 	idxInfo := make([]*etcdpb.IndexInfo, 0, 16)
-
-	// record _default partition ID in collection meta
-	collMeta.PartitionIDs = append(collMeta.PartitionIDs, partMeta.PartitionID)
-
 	/////////////////////// ignore index param from create_collection /////////////////////////
 	//for _, field := range schema.Fields {
 	//	if field.DataType == schemapb.DataType_VectorFloat || field.DataType == schemapb.DataType_VectorBinary {


### PR DESCRIPTION
Save ddmsg info and type into ETCD to support re-send ddmsg 
when system restart or recover from failure (#5172)

Signed-off-by: yudong.cai <yudong.cai@zilliz.com>
