### PR TITLE
Improve IVF query on GPU if no entity deleted

### DIFF
--- a/core/src/index/thirdparty/faiss/gpu/impl/IVFUtilsSelect1.cu
+++ b/core/src/index/thirdparty/faiss/gpu/impl/IVFUtilsSelect1.cu
@@ -68,29 +68,39 @@ pass1SelectLists(void** listIndices,
   // BlockSelect add cannot be used in a warp divergent circumstance; we
   // handle the remainder warp below
   for (; i < limit; i += blockDim.x) {
-    index = getListIndex(queryId,
-                         start + i,
-                         listIndices,
-                         prefixSumOffsets,
-                         topQueryToCentroid,
-                         opt);
-    if (bitsetEmpty || (!(bitset[index >> 3] & (0x1 << (index & 0x7))))) {
+    do {
+      if (!bitsetEmpty) {
+        index = getListIndex(queryId,
+                             start + i,
+                             listIndices,
+                             prefixSumOffsets,
+                             topQueryToCentroid,
+                             opt);
+        if (bitset[index >> 3] & (0x1 << (index & 0x7))) {
+          break;
+        }
+      }
       heap.addThreadQ(distanceStart[i], start + i);
-    }
+    } while(0);
     heap.checkThreadQ();
   }
 
   // Handle warp divergence separately
   if (i < num) {
-    index = getListIndex(queryId,
-                         start + i,
-                         listIndices,
-                         prefixSumOffsets,
-                         topQueryToCentroid,
-                         opt);
-    if (bitsetEmpty || (!(bitset[index >> 3] & (0x1 << (index & 0x7))))) {
+    do {
+      if (!bitsetEmpty) {
+        index = getListIndex(queryId,
+                             start + i,
+                             listIndices,
+                             prefixSumOffsets,
+                             topQueryToCentroid,
+                             opt);
+        if (bitset[index >> 3] & (0x1 << (index & 0x7))) {
+          break;
+        }
+      }
       heap.addThreadQ(distanceStart[i], start + i);
-    }
+    } while(0);
   }
 
   // Merge all final results


### PR DESCRIPTION
Not to call getListIndex() if bitset is empty.

It is tested on my local machine.
nb = 400000, dim = 128 Index_type = IVF_FLAT, metric_type = L2, nlist=2048
nq = 1000, topk = 20, nprobe = 32
|   | 1.1.0 | This PR |
|---|---|---|
| Search in Knowhere | 142ms | 137ms |

Signed-off-by: shengjun.li <shengjun.li@zilliz.com>
