### PR TITLE
Resend unsuccessful ddMsg when master start

### DIFF
--- a/internal/distributed/masterservice/masterservice_test.go
+++ b/internal/distributed/masterservice/masterservice_test.go
@@ -94,28 +94,28 @@ func TestGrpcService(t *testing.T) {
 		return nil
 	}
 	createCollectionArray := make([]*internalpb.CreateCollectionRequest, 0, 16)
-	core.DdCreateCollectionReq = func(ctx context.Context, req *internalpb.CreateCollectionRequest) error {
+	core.SendDdCreateCollectionReq = func(ctx context.Context, req *internalpb.CreateCollectionRequest) error {
 		t.Logf("Create Colllection %s", req.CollectionName)
 		createCollectionArray = append(createCollectionArray, req)
 		return nil
 	}
 
 	dropCollectionArray := make([]*internalpb.DropCollectionRequest, 0, 16)
-	core.DdDropCollectionReq = func(ctx context.Context, req *internalpb.DropCollectionRequest) error {
+	core.SendDdDropCollectionReq = func(ctx context.Context, req *internalpb.DropCollectionRequest) error {
 		t.Logf("Drop Collection %s", req.CollectionName)
 		dropCollectionArray = append(dropCollectionArray, req)
 		return nil
 	}
 
 	createPartitionArray := make([]*internalpb.CreatePartitionRequest, 0, 16)
-	core.DdCreatePartitionReq = func(ctx context.Context, req *internalpb.CreatePartitionRequest) error {
+	core.SendDdCreatePartitionReq = func(ctx context.Context, req *internalpb.CreatePartitionRequest) error {
 		t.Logf("Create Partition %s", req.PartitionName)
 		createPartitionArray = append(createPartitionArray, req)
 		return nil
 	}
 
 	dropPartitionArray := make([]*internalpb.DropPartitionRequest, 0, 16)
-	core.DdDropPartitionReq = func(ctx context.Context, req *internalpb.DropPartitionRequest) error {
+	core.SendDdDropPartitionReq = func(ctx context.Context, req *internalpb.DropPartitionRequest) error {
 		t.Logf("Drop Partition %s", req.PartitionName)
 		dropPartitionArray = append(dropPartitionArray, req)
 		return nil

--- a/internal/masterservice/master_service.go
+++ b/internal/masterservice/master_service.go
@@ -52,6 +52,7 @@ import (
 
 // ------------------ struct -----------------------
 
+// used to save ddMsg into ETCD
 type DdOperation struct {
 	Body         []byte
 	Body1        []byte // used for DdCreateCollection only

--- a/internal/masterservice/master_service.go
+++ b/internal/masterservice/master_service.go
@@ -55,7 +55,7 @@ import (
 // ------------------ struct -----------------------
 
 type DdOperation struct {
-	Body         string
+	Body         []byte
 	Type         string
 	CollectionID typeutil.UniqueID
 	PartitionID  typeutil.UniqueID

--- a/internal/masterservice/master_service.go
+++ b/internal/masterservice/master_service.go
@@ -52,7 +52,7 @@ import (
 
 // ------------------ struct -----------------------
 
-// used to save ddMsg into ETCD
+// DdOperation used to save ddMsg into ETCD
 type DdOperation struct {
 	Body         []byte
 	Body1        []byte // used for DdCreateCollection only

--- a/internal/masterservice/master_service.go
+++ b/internal/masterservice/master_service.go
@@ -51,6 +51,15 @@ import (
 
 // ------------------ struct -----------------------
 
+type DdOperation struct {
+	Base         *commonpb.MsgBase
+	Body         string
+	Type         string
+	CollectionID typeutil.UniqueID
+	PartitionID  typeutil.UniqueID
+	Send         bool
+}
+
 // master core
 type Core struct {
 	/*

--- a/internal/masterservice/master_service.go
+++ b/internal/masterservice/master_service.go
@@ -422,8 +422,7 @@ func (c *Core) setDdOperationSend(t string) error {
 
 	// unpack DdOperation and set DdOperation.Send
 	var ddOp DdOperation
-	err = json.Unmarshal([]byte(ddOpStr), &ddOp)
-	if err != nil {
+	if err = json.Unmarshal([]byte(ddOpStr), &ddOp); err != nil {
 		return err
 	}
 	if t != ddOp.Type {
@@ -440,12 +439,7 @@ func (c *Core) setDdOperationSend(t string) error {
 	}
 
 	// save DdOperation info into etcd
-	err = c.MetaTable.client.Save(DDOperationPrefix, string(ddOpByte))
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return c.MetaTable.client.Save(DDOperationPrefix, string(ddOpByte))
 }
 
 func (c *Core) setMsgStreams() error {

--- a/internal/masterservice/master_service.go
+++ b/internal/masterservice/master_service.go
@@ -57,8 +57,6 @@ type DdOperation struct {
 	Body         []byte
 	Body1        []byte // used for DdCreateCollection only
 	Type         string
-	CollectionID typeutil.UniqueID
-	PartitionID  typeutil.UniqueID
 	Send         bool
 }
 

--- a/internal/masterservice/master_service.go
+++ b/internal/masterservice/master_service.go
@@ -56,6 +56,7 @@ import (
 
 type DdOperation struct {
 	Body         []byte
+	Body1        []byte // used for DdCreateCollection only
 	Type         string
 	CollectionID typeutil.UniqueID
 	PartitionID  typeutil.UniqueID

--- a/internal/masterservice/master_service.go
+++ b/internal/masterservice/master_service.go
@@ -23,6 +23,7 @@ import (
 	"go.etcd.io/etcd/clientv3"
 	"go.uber.org/zap"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/milvus-io/milvus/internal/allocator"
 	etcdkv "github.com/milvus-io/milvus/internal/kv/etcd"
 	"github.com/milvus-io/milvus/internal/log"
@@ -54,10 +55,10 @@ import (
 
 // DdOperation used to save ddMsg into ETCD
 type DdOperation struct {
-	Body         []byte
-	Body1        []byte // used for DdCreateCollection only
-	Type         string
-	Send         bool
+	Body  string `json:"body"`
+	Body1 string `json:"body1"` // used for CreateCollectionReq only
+	Type  string `json:"type"`
+	Send  bool   `json:"send"`
 }
 
 // master core
@@ -897,12 +898,12 @@ func (c *Core) reSendDdMsg(ctx context.Context) error {
 	switch ddOp.Type {
 	case CreateCollectionDDType:
 		var ddCollReq = internalpb.CreateCollectionRequest{}
-		if err = json.Unmarshal(ddOp.Body, &ddCollReq); err != nil {
+		if err = proto.UnmarshalText(ddOp.Body, &ddCollReq); err != nil {
 			return err
 		}
 		// TODO: can optimize
 		var ddPartReq = internalpb.CreatePartitionRequest{}
-		if err = json.Unmarshal(ddOp.Body1, &ddPartReq); err != nil {
+		if err = proto.UnmarshalText(ddOp.Body1, &ddPartReq); err != nil {
 			return err
 		}
 		if err = c.SendDdCreateCollectionReq(ctx, &ddCollReq); err != nil {
@@ -913,7 +914,7 @@ func (c *Core) reSendDdMsg(ctx context.Context) error {
 		}
 	case DropCollectionDDType:
 		var ddReq = internalpb.DropCollectionRequest{}
-		if err = json.Unmarshal(ddOp.Body, &ddReq); err != nil {
+		if err = proto.UnmarshalText(ddOp.Body, &ddReq); err != nil {
 			return err
 		}
 		if err = c.SendDdDropCollectionReq(ctx, &ddReq); err != nil {
@@ -921,7 +922,7 @@ func (c *Core) reSendDdMsg(ctx context.Context) error {
 		}
 	case CreatePartitionDDType:
 		var ddReq = internalpb.CreatePartitionRequest{}
-		if err = json.Unmarshal(ddOp.Body, &ddReq); err != nil {
+		if err = proto.UnmarshalText(ddOp.Body, &ddReq); err != nil {
 			return err
 		}
 		if err = c.SendDdCreatePartitionReq(ctx, &ddReq); err != nil {
@@ -929,7 +930,7 @@ func (c *Core) reSendDdMsg(ctx context.Context) error {
 		}
 	case DropPartitionDDType:
 		var ddReq = internalpb.DropPartitionRequest{}
-		if err = json.Unmarshal(ddOp.Body, &ddReq); err != nil {
+		if err = proto.UnmarshalText(ddOp.Body, &ddReq); err != nil {
 			return err
 		}
 		if err = c.SendDdDropPartitionReq(ctx, &ddReq); err != nil {

--- a/internal/masterservice/master_service_test.go
+++ b/internal/masterservice/master_service_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/milvus-io/milvus/internal/msgstream"
 	"github.com/milvus-io/milvus/internal/proto/commonpb"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
-	"github.com/milvus-io/milvus/internal/proto/etcdpb"
 	"github.com/milvus-io/milvus/internal/proto/indexpb"
 	"github.com/milvus-io/milvus/internal/proto/internalpb"
 	"github.com/milvus-io/milvus/internal/proto/masterpb"
@@ -416,18 +415,16 @@ func TestMasterService(t *testing.T) {
 		assert.Equal(t, createMeta.ID, ddOp.CollectionID)
 		assert.Equal(t, true, ddOp.Send)
 
-		var meta map[string]string
-		err = json.Unmarshal([]byte(ddOp.Body), &meta)
+		var ddCollReq = internalpb.CreateCollectionRequest{}
+		err = json.Unmarshal(ddOp.Body, &ddCollReq)
 		assert.Nil(t, err)
+		assert.Equal(t, createMeta.ID, ddCollReq.CollectionID)
 
-		k1 := fmt.Sprintf("%s/%d", CollectionMetaPrefix, ddOp.CollectionID)
-		v1 := meta[k1]
-		var collInfo etcdpb.CollectionInfo
-		err = proto.UnmarshalText(v1, &collInfo)
+		var ddPartReq = internalpb.CreatePartitionRequest{}
+		err = json.Unmarshal(ddOp.Body1, &ddPartReq)
 		assert.Nil(t, err)
-		assert.Equal(t, createMeta.ID, collInfo.ID)
-		assert.Equal(t, createMeta.CreateTime, collInfo.CreateTime)
-		assert.Equal(t, createMeta.PartitionIDs[0], collInfo.PartitionIDs[0])
+		assert.Equal(t, createMeta.ID, ddPartReq.CollectionID)
+		assert.Equal(t, createMeta.PartitionIDs[0], ddPartReq.PartitionID)
 	})
 
 	t.Run("has collection", func(t *testing.T) {

--- a/internal/masterservice/master_service_test.go
+++ b/internal/masterservice/master_service_test.go
@@ -982,18 +982,11 @@ func TestMasterService(t *testing.T) {
 		assert.Equal(t, dropPartID, ddOp.PartitionID)
 		assert.Equal(t, true, ddOp.Send)
 
-		var meta map[string]string
-		err = json.Unmarshal([]byte(ddOp.Body), &meta)
+		var ddReq = internalpb.DropPartitionRequest{}
+		err = json.Unmarshal([]byte(ddOp.Body), &ddReq)
 		assert.Nil(t, err)
-
-		k1 := fmt.Sprintf("%s/%d", CollectionMetaPrefix, ddOp.CollectionID)
-		v1 := meta[k1]
-		var collInfo etcdpb.CollectionInfo
-		err = proto.UnmarshalText(v1, &collInfo)
-		assert.Nil(t, err)
-		assert.Equal(t, collMeta.ID, collInfo.ID)
-		assert.Equal(t, collMeta.CreateTime, collInfo.CreateTime)
-		assert.Equal(t, collMeta.PartitionIDs[0], collInfo.PartitionIDs[0])
+		assert.Equal(t, collMeta.ID, ddReq.CollectionID)
+		assert.Equal(t, dropPartID, ddReq.PartitionID)
 	})
 
 	t.Run("drop collection", func(t *testing.T) {

--- a/internal/masterservice/master_service_test.go
+++ b/internal/masterservice/master_service_test.go
@@ -412,7 +412,6 @@ func TestMasterService(t *testing.T) {
 		err = json.Unmarshal([]byte(ddOpStr), &ddOp)
 		assert.Nil(t, err)
 		assert.Equal(t, CreateCollectionDDType, ddOp.Type)
-		assert.Equal(t, createMeta.ID, ddOp.CollectionID)
 		assert.Equal(t, true, ddOp.Send)
 
 		var ddCollReq = internalpb.CreateCollectionRequest{}
@@ -554,8 +553,6 @@ func TestMasterService(t *testing.T) {
 		err = json.Unmarshal([]byte(ddOpStr), &ddOp)
 		assert.Nil(t, err)
 		assert.Equal(t, CreatePartitionDDType, ddOp.Type)
-		assert.Equal(t, collMeta.ID, ddOp.CollectionID)
-		assert.Equal(t, partMeta.PartitionID, ddOp.PartitionID)
 		assert.Equal(t, true, ddOp.Send)
 
 		var ddReq = internalpb.CreatePartitionRequest{}
@@ -960,8 +957,6 @@ func TestMasterService(t *testing.T) {
 		err = json.Unmarshal([]byte(ddOpStr), &ddOp)
 		assert.Nil(t, err)
 		assert.Equal(t, DropPartitionDDType, ddOp.Type)
-		assert.Equal(t, collMeta.ID, ddOp.CollectionID)
-		assert.Equal(t, dropPartID, ddOp.PartitionID)
 		assert.Equal(t, true, ddOp.Send)
 
 		var ddReq = internalpb.DropPartitionRequest{}
@@ -1030,7 +1025,6 @@ func TestMasterService(t *testing.T) {
 		err = json.Unmarshal([]byte(ddOpStr), &ddOp)
 		assert.Nil(t, err)
 		assert.Equal(t, DropCollectionDDType, ddOp.Type)
-		assert.Equal(t, collMeta.ID, ddOp.CollectionID)
 		assert.Equal(t, true, ddOp.Send)
 
 		var ddReq = internalpb.DropCollectionRequest{}

--- a/internal/masterservice/master_service_test.go
+++ b/internal/masterservice/master_service_test.go
@@ -415,12 +415,12 @@ func TestMasterService(t *testing.T) {
 		assert.Equal(t, true, ddOp.Send)
 
 		var ddCollReq = internalpb.CreateCollectionRequest{}
-		err = json.Unmarshal(ddOp.Body, &ddCollReq)
+		err = proto.UnmarshalText(ddOp.Body, &ddCollReq)
 		assert.Nil(t, err)
 		assert.Equal(t, createMeta.ID, ddCollReq.CollectionID)
 
 		var ddPartReq = internalpb.CreatePartitionRequest{}
-		err = json.Unmarshal(ddOp.Body1, &ddPartReq)
+		err = proto.UnmarshalText(ddOp.Body1, &ddPartReq)
 		assert.Nil(t, err)
 		assert.Equal(t, createMeta.ID, ddPartReq.CollectionID)
 		assert.Equal(t, createMeta.PartitionIDs[0], ddPartReq.PartitionID)
@@ -556,7 +556,7 @@ func TestMasterService(t *testing.T) {
 		assert.Equal(t, true, ddOp.Send)
 
 		var ddReq = internalpb.CreatePartitionRequest{}
-		err = json.Unmarshal(ddOp.Body, &ddReq)
+		err = proto.UnmarshalText(ddOp.Body, &ddReq)
 		assert.Nil(t, err)
 		assert.Equal(t, collMeta.ID, ddReq.CollectionID)
 		assert.Equal(t, partMeta.PartitionID, ddReq.PartitionID)
@@ -960,7 +960,7 @@ func TestMasterService(t *testing.T) {
 		assert.Equal(t, true, ddOp.Send)
 
 		var ddReq = internalpb.DropPartitionRequest{}
-		err = json.Unmarshal(ddOp.Body, &ddReq)
+		err = proto.UnmarshalText(ddOp.Body, &ddReq)
 		assert.Nil(t, err)
 		assert.Equal(t, collMeta.ID, ddReq.CollectionID)
 		assert.Equal(t, dropPartID, ddReq.PartitionID)
@@ -1028,7 +1028,7 @@ func TestMasterService(t *testing.T) {
 		assert.Equal(t, true, ddOp.Send)
 
 		var ddReq = internalpb.DropCollectionRequest{}
-		err = json.Unmarshal(ddOp.Body, &ddReq)
+		err = proto.UnmarshalText(ddOp.Body, &ddReq)
 		assert.Nil(t, err)
 		assert.Equal(t, collMeta.ID, ddReq.CollectionID)
 	})

--- a/internal/masterservice/master_service_test.go
+++ b/internal/masterservice/master_service_test.go
@@ -1051,10 +1051,10 @@ func TestMasterService(t *testing.T) {
 		assert.Equal(t, collMeta.ID, ddOp.CollectionID)
 		assert.Equal(t, true, ddOp.Send)
 
-		var collID typeutil.UniqueID
-		err = json.Unmarshal([]byte(ddOp.Body), &collID)
+		var ddReq = internalpb.DropCollectionRequest{}
+		err = json.Unmarshal([]byte(ddOp.Body), &ddReq)
 		assert.Nil(t, err)
-		assert.Equal(t, collMeta.ID, collID)
+		assert.Equal(t, collMeta.ID, ddReq.CollectionID)
 	})
 
 	t.Run("context_cancel", func(t *testing.T) {

--- a/internal/masterservice/master_service_test.go
+++ b/internal/masterservice/master_service_test.go
@@ -562,7 +562,7 @@ func TestMasterService(t *testing.T) {
 		assert.Equal(t, true, ddOp.Send)
 
 		var ddReq = internalpb.CreatePartitionRequest{}
-		err = json.Unmarshal([]byte(ddOp.Body), &ddReq)
+		err = json.Unmarshal(ddOp.Body, &ddReq)
 		assert.Nil(t, err)
 		assert.Equal(t, collMeta.ID, ddReq.CollectionID)
 		assert.Equal(t, partMeta.PartitionID, ddReq.PartitionID)
@@ -968,7 +968,7 @@ func TestMasterService(t *testing.T) {
 		assert.Equal(t, true, ddOp.Send)
 
 		var ddReq = internalpb.DropPartitionRequest{}
-		err = json.Unmarshal([]byte(ddOp.Body), &ddReq)
+		err = json.Unmarshal(ddOp.Body, &ddReq)
 		assert.Nil(t, err)
 		assert.Equal(t, collMeta.ID, ddReq.CollectionID)
 		assert.Equal(t, dropPartID, ddReq.PartitionID)
@@ -1037,7 +1037,7 @@ func TestMasterService(t *testing.T) {
 		assert.Equal(t, true, ddOp.Send)
 
 		var ddReq = internalpb.DropCollectionRequest{}
-		err = json.Unmarshal([]byte(ddOp.Body), &ddReq)
+		err = json.Unmarshal(ddOp.Body, &ddReq)
 		assert.Nil(t, err)
 		assert.Equal(t, collMeta.ID, ddReq.CollectionID)
 	})

--- a/internal/masterservice/master_service_test.go
+++ b/internal/masterservice/master_service_test.go
@@ -406,13 +406,15 @@ func TestMasterService(t *testing.T) {
 		assert.Equal(t, createMsg.CollectionID, createMeta.ID)
 
 		// check DD operation info
+		flag, err := core.MetaTable.client.Load(DDMsgSendPrefix)
+		assert.Nil(t, err)
+		assert.Equal(t, "true", flag)
 		ddOpStr, err := core.MetaTable.client.Load(DDOperationPrefix)
 		assert.Nil(t, err)
 		var ddOp DdOperation
 		err = json.Unmarshal([]byte(ddOpStr), &ddOp)
 		assert.Nil(t, err)
 		assert.Equal(t, CreateCollectionDDType, ddOp.Type)
-		assert.Equal(t, true, ddOp.Send)
 
 		var ddCollReq = internalpb.CreateCollectionRequest{}
 		err = proto.UnmarshalText(ddOp.Body, &ddCollReq)
@@ -547,13 +549,15 @@ func TestMasterService(t *testing.T) {
 		assert.Equal(t, "testColl", pm.GetCollArray()[0])
 
 		// check DD operation info
+		flag, err := core.MetaTable.client.Load(DDMsgSendPrefix)
+		assert.Nil(t, err)
+		assert.Equal(t, "true", flag)
 		ddOpStr, err := core.MetaTable.client.Load(DDOperationPrefix)
 		assert.Nil(t, err)
 		var ddOp DdOperation
 		err = json.Unmarshal([]byte(ddOpStr), &ddOp)
 		assert.Nil(t, err)
 		assert.Equal(t, CreatePartitionDDType, ddOp.Type)
-		assert.Equal(t, true, ddOp.Send)
 
 		var ddReq = internalpb.CreatePartitionRequest{}
 		err = proto.UnmarshalText(ddOp.Body, &ddReq)
@@ -951,13 +955,15 @@ func TestMasterService(t *testing.T) {
 		assert.Equal(t, "testColl", pm.GetCollArray()[1])
 
 		// check DD operation info
+		flag, err := core.MetaTable.client.Load(DDMsgSendPrefix)
+		assert.Nil(t, err)
+		assert.Equal(t, "true", flag)
 		ddOpStr, err := core.MetaTable.client.Load(DDOperationPrefix)
 		assert.Nil(t, err)
 		var ddOp DdOperation
 		err = json.Unmarshal([]byte(ddOpStr), &ddOp)
 		assert.Nil(t, err)
 		assert.Equal(t, DropPartitionDDType, ddOp.Type)
-		assert.Equal(t, true, ddOp.Send)
 
 		var ddReq = internalpb.DropPartitionRequest{}
 		err = proto.UnmarshalText(ddOp.Body, &ddReq)
@@ -1019,13 +1025,15 @@ func TestMasterService(t *testing.T) {
 		assert.Equal(t, collArray[2], "testColl")
 
 		// check DD operation info
+		flag, err := core.MetaTable.client.Load(DDMsgSendPrefix)
+		assert.Nil(t, err)
+		assert.Equal(t, "true", flag)
 		ddOpStr, err := core.MetaTable.client.Load(DDOperationPrefix)
 		assert.Nil(t, err)
 		var ddOp DdOperation
 		err = json.Unmarshal([]byte(ddOpStr), &ddOp)
 		assert.Nil(t, err)
 		assert.Equal(t, DropCollectionDDType, ddOp.Type)
-		assert.Equal(t, true, ddOp.Send)
 
 		var ddReq = internalpb.DropCollectionRequest{}
 		err = proto.UnmarshalText(ddOp.Body, &ddReq)

--- a/internal/masterservice/master_service_test.go
+++ b/internal/masterservice/master_service_test.go
@@ -561,26 +561,11 @@ func TestMasterService(t *testing.T) {
 		assert.Equal(t, partMeta.PartitionID, ddOp.PartitionID)
 		assert.Equal(t, true, ddOp.Send)
 
-		var meta map[string]string
-		err = json.Unmarshal([]byte(ddOp.Body), &meta)
+		var ddReq = internalpb.CreatePartitionRequest{}
+		err = json.Unmarshal([]byte(ddOp.Body), &ddReq)
 		assert.Nil(t, err)
-
-		k1 := fmt.Sprintf("%s/%d", CollectionMetaPrefix, ddOp.CollectionID)
-		v1 := meta[k1]
-		var collInfo etcdpb.CollectionInfo
-		err = proto.UnmarshalText(v1, &collInfo)
-		assert.Nil(t, err)
-		assert.Equal(t, collMeta.ID, collInfo.ID)
-		assert.Equal(t, collMeta.CreateTime, collInfo.CreateTime)
-		assert.Equal(t, collMeta.PartitionIDs[0], collInfo.PartitionIDs[0])
-
-		k2 := fmt.Sprintf("%s/%d/%d", PartitionMetaPrefix, ddOp.CollectionID, ddOp.PartitionID)
-		v2 := meta[k2]
-		var partInfo etcdpb.PartitionInfo
-		err = proto.UnmarshalText(v2, &partInfo)
-		assert.Nil(t, err)
-		assert.Equal(t, partMeta.PartitionName, partInfo.PartitionName)
-		assert.Equal(t, partMeta.PartitionID, partInfo.PartitionID)
+		assert.Equal(t, collMeta.ID, ddReq.CollectionID)
+		assert.Equal(t, partMeta.PartitionID, ddReq.PartitionID)
 	})
 
 	t.Run("has partition", func(t *testing.T) {

--- a/internal/masterservice/master_service_test.go
+++ b/internal/masterservice/master_service_test.go
@@ -13,6 +13,7 @@ package masterservice
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"sync"
@@ -24,6 +25,7 @@ import (
 	"github.com/milvus-io/milvus/internal/msgstream"
 	"github.com/milvus-io/milvus/internal/proto/commonpb"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
+	"github.com/milvus-io/milvus/internal/proto/etcdpb"
 	"github.com/milvus-io/milvus/internal/proto/indexpb"
 	"github.com/milvus-io/milvus/internal/proto/internalpb"
 	"github.com/milvus-io/milvus/internal/proto/masterpb"
@@ -404,9 +406,28 @@ func TestMasterService(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, createMsg.CollectionID, createMeta.ID)
 
-		// check DD operation info removed
-		_, err = core.MetaTable.client.Load(DDOperationPrefix)
-		assert.NotNil(t, err)
+		// check DD operation info
+		ddOpStr, err := core.MetaTable.client.Load(DDOperationPrefix)
+		assert.Nil(t, err)
+		var ddOp DdOperation
+		err = json.Unmarshal([]byte(ddOpStr), &ddOp)
+		assert.Nil(t, err)
+		assert.Equal(t, CreateCollectionDDType, ddOp.Type)
+		assert.Equal(t, createMeta.ID, ddOp.CollectionID)
+		assert.Equal(t, true, ddOp.Send)
+
+		var meta map[string]string
+		err = json.Unmarshal([]byte(ddOp.Body), &meta)
+		assert.Nil(t, err)
+
+		k1 := fmt.Sprintf("%s/%d", CollectionMetaPrefix, ddOp.CollectionID)
+		v1 := meta[k1]
+		var collInfo etcdpb.CollectionInfo
+		err = proto.UnmarshalText(v1, &collInfo)
+		assert.Nil(t, err)
+		assert.Equal(t, createMeta.ID, collInfo.ID)
+		assert.Equal(t, createMeta.CreateTime, collInfo.CreateTime)
+		assert.Equal(t, createMeta.PartitionIDs[0], collInfo.PartitionIDs[0])
 	})
 
 	t.Run("has collection", func(t *testing.T) {
@@ -530,8 +551,36 @@ func TestMasterService(t *testing.T) {
 		assert.Equal(t, "testColl", pm.GetCollArray()[0])
 
 		// check DD operation info
-		_, err = core.MetaTable.client.Load(DDOperationPrefix)
-		assert.NotNil(t, err)
+		ddOpStr, err := core.MetaTable.client.Load(DDOperationPrefix)
+		assert.Nil(t, err)
+		var ddOp DdOperation
+		err = json.Unmarshal([]byte(ddOpStr), &ddOp)
+		assert.Nil(t, err)
+		assert.Equal(t, CreatePartitionDDType, ddOp.Type)
+		assert.Equal(t, collMeta.ID, ddOp.CollectionID)
+		assert.Equal(t, partMeta.PartitionID, ddOp.PartitionID)
+		assert.Equal(t, true, ddOp.Send)
+
+		var meta map[string]string
+		err = json.Unmarshal([]byte(ddOp.Body), &meta)
+		assert.Nil(t, err)
+
+		k1 := fmt.Sprintf("%s/%d", CollectionMetaPrefix, ddOp.CollectionID)
+		v1 := meta[k1]
+		var collInfo etcdpb.CollectionInfo
+		err = proto.UnmarshalText(v1, &collInfo)
+		assert.Nil(t, err)
+		assert.Equal(t, collMeta.ID, collInfo.ID)
+		assert.Equal(t, collMeta.CreateTime, collInfo.CreateTime)
+		assert.Equal(t, collMeta.PartitionIDs[0], collInfo.PartitionIDs[0])
+
+		k2 := fmt.Sprintf("%s/%d/%d", PartitionMetaPrefix, ddOp.CollectionID, ddOp.PartitionID)
+		v2 := meta[k2]
+		var partInfo etcdpb.PartitionInfo
+		err = proto.UnmarshalText(v2, &partInfo)
+		assert.Nil(t, err)
+		assert.Equal(t, partMeta.PartitionName, partInfo.PartitionName)
+		assert.Equal(t, partMeta.PartitionID, partInfo.PartitionID)
 	})
 
 	t.Run("has partition", func(t *testing.T) {
@@ -923,8 +972,28 @@ func TestMasterService(t *testing.T) {
 		assert.Equal(t, "testColl", pm.GetCollArray()[1])
 
 		// check DD operation info
-		_, err = core.MetaTable.client.Load(DDOperationPrefix)
-		assert.NotNil(t, err)
+		ddOpStr, err := core.MetaTable.client.Load(DDOperationPrefix)
+		assert.Nil(t, err)
+		var ddOp DdOperation
+		err = json.Unmarshal([]byte(ddOpStr), &ddOp)
+		assert.Nil(t, err)
+		assert.Equal(t, DropPartitionDDType, ddOp.Type)
+		assert.Equal(t, collMeta.ID, ddOp.CollectionID)
+		assert.Equal(t, dropPartID, ddOp.PartitionID)
+		assert.Equal(t, true, ddOp.Send)
+
+		var meta map[string]string
+		err = json.Unmarshal([]byte(ddOp.Body), &meta)
+		assert.Nil(t, err)
+
+		k1 := fmt.Sprintf("%s/%d", CollectionMetaPrefix, ddOp.CollectionID)
+		v1 := meta[k1]
+		var collInfo etcdpb.CollectionInfo
+		err = proto.UnmarshalText(v1, &collInfo)
+		assert.Nil(t, err)
+		assert.Equal(t, collMeta.ID, collInfo.ID)
+		assert.Equal(t, collMeta.CreateTime, collInfo.CreateTime)
+		assert.Equal(t, collMeta.PartitionIDs[0], collInfo.PartitionIDs[0])
 	})
 
 	t.Run("drop collection", func(t *testing.T) {
@@ -980,8 +1049,19 @@ func TestMasterService(t *testing.T) {
 		assert.Equal(t, collArray[2], "testColl")
 
 		// check DD operation info
-		_, err = core.MetaTable.client.Load(DDOperationPrefix)
-		assert.NotNil(t, err)
+		ddOpStr, err := core.MetaTable.client.Load(DDOperationPrefix)
+		assert.Nil(t, err)
+		var ddOp DdOperation
+		err = json.Unmarshal([]byte(ddOpStr), &ddOp)
+		assert.Nil(t, err)
+		assert.Equal(t, DropCollectionDDType, ddOp.Type)
+		assert.Equal(t, collMeta.ID, ddOp.CollectionID)
+		assert.Equal(t, true, ddOp.Send)
+
+		var collID typeutil.UniqueID
+		err = json.Unmarshal([]byte(ddOp.Body), &collID)
+		assert.Nil(t, err)
+		assert.Equal(t, collMeta.ID, collID)
 	})
 
 	t.Run("context_cancel", func(t *testing.T) {

--- a/internal/masterservice/master_service_test.go
+++ b/internal/masterservice/master_service_test.go
@@ -13,7 +13,6 @@ package masterservice
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"math/rand"
 	"sync"
@@ -25,7 +24,6 @@ import (
 	"github.com/milvus-io/milvus/internal/msgstream"
 	"github.com/milvus-io/milvus/internal/proto/commonpb"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
-	"github.com/milvus-io/milvus/internal/proto/etcdpb"
 	"github.com/milvus-io/milvus/internal/proto/indexpb"
 	"github.com/milvus-io/milvus/internal/proto/internalpb"
 	"github.com/milvus-io/milvus/internal/proto/masterpb"
@@ -406,28 +404,9 @@ func TestMasterService(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, createMsg.CollectionID, createMeta.ID)
 
-		// check DD operation info
-		ddOpStr, err := core.MetaTable.client.Load(DDOperationPrefix)
-		assert.Nil(t, err)
-		var ddOp DdOperation
-		err = json.Unmarshal([]byte(ddOpStr), &ddOp)
-		assert.Nil(t, err)
-		assert.Equal(t, CreateCollectionDDType, ddOp.Type)
-		assert.Equal(t, createMeta.ID, ddOp.CollectionID)
-		assert.Equal(t, true, ddOp.Send)
-
-		var meta map[string]string
-		err = json.Unmarshal([]byte(ddOp.Body), &meta)
-		assert.Nil(t, err)
-
-		k1 := fmt.Sprintf("%s/%d", CollectionMetaPrefix, ddOp.CollectionID)
-		v1 := meta[k1]
-		var collInfo etcdpb.CollectionInfo
-		err = proto.UnmarshalText(v1, &collInfo)
-		assert.Nil(t, err)
-		assert.Equal(t, createMeta.ID, collInfo.ID)
-		assert.Equal(t, createMeta.CreateTime, collInfo.CreateTime)
-		assert.Equal(t, createMeta.PartitionIDs[0], collInfo.PartitionIDs[0])
+		// check DD operation info removed
+		_, err = core.MetaTable.client.Load(DDOperationPrefix)
+		assert.NotNil(t, err)
 	})
 
 	t.Run("has collection", func(t *testing.T) {
@@ -551,36 +530,8 @@ func TestMasterService(t *testing.T) {
 		assert.Equal(t, "testColl", pm.GetCollArray()[0])
 
 		// check DD operation info
-		ddOpStr, err := core.MetaTable.client.Load(DDOperationPrefix)
-		assert.Nil(t, err)
-		var ddOp DdOperation
-		err = json.Unmarshal([]byte(ddOpStr), &ddOp)
-		assert.Nil(t, err)
-		assert.Equal(t, CreatePartitionDDType, ddOp.Type)
-		assert.Equal(t, collMeta.ID, ddOp.CollectionID)
-		assert.Equal(t, partMeta.PartitionID, ddOp.PartitionID)
-		assert.Equal(t, true, ddOp.Send)
-
-		var meta map[string]string
-		err = json.Unmarshal([]byte(ddOp.Body), &meta)
-		assert.Nil(t, err)
-
-		k1 := fmt.Sprintf("%s/%d", CollectionMetaPrefix, ddOp.CollectionID)
-		v1 := meta[k1]
-		var collInfo etcdpb.CollectionInfo
-		err = proto.UnmarshalText(v1, &collInfo)
-		assert.Nil(t, err)
-		assert.Equal(t, collMeta.ID, collInfo.ID)
-		assert.Equal(t, collMeta.CreateTime, collInfo.CreateTime)
-		assert.Equal(t, collMeta.PartitionIDs[0], collInfo.PartitionIDs[0])
-
-		k2 := fmt.Sprintf("%s/%d/%d", PartitionMetaPrefix, ddOp.CollectionID, ddOp.PartitionID)
-		v2 := meta[k2]
-		var partInfo etcdpb.PartitionInfo
-		err = proto.UnmarshalText(v2, &partInfo)
-		assert.Nil(t, err)
-		assert.Equal(t, partMeta.PartitionName, partInfo.PartitionName)
-		assert.Equal(t, partMeta.PartitionID, partInfo.PartitionID)
+		_, err = core.MetaTable.client.Load(DDOperationPrefix)
+		assert.NotNil(t, err)
 	})
 
 	t.Run("has partition", func(t *testing.T) {
@@ -972,28 +923,8 @@ func TestMasterService(t *testing.T) {
 		assert.Equal(t, "testColl", pm.GetCollArray()[1])
 
 		// check DD operation info
-		ddOpStr, err := core.MetaTable.client.Load(DDOperationPrefix)
-		assert.Nil(t, err)
-		var ddOp DdOperation
-		err = json.Unmarshal([]byte(ddOpStr), &ddOp)
-		assert.Nil(t, err)
-		assert.Equal(t, DropPartitionDDType, ddOp.Type)
-		assert.Equal(t, collMeta.ID, ddOp.CollectionID)
-		assert.Equal(t, dropPartID, ddOp.PartitionID)
-		assert.Equal(t, true, ddOp.Send)
-
-		var meta map[string]string
-		err = json.Unmarshal([]byte(ddOp.Body), &meta)
-		assert.Nil(t, err)
-
-		k1 := fmt.Sprintf("%s/%d", CollectionMetaPrefix, ddOp.CollectionID)
-		v1 := meta[k1]
-		var collInfo etcdpb.CollectionInfo
-		err = proto.UnmarshalText(v1, &collInfo)
-		assert.Nil(t, err)
-		assert.Equal(t, collMeta.ID, collInfo.ID)
-		assert.Equal(t, collMeta.CreateTime, collInfo.CreateTime)
-		assert.Equal(t, collMeta.PartitionIDs[0], collInfo.PartitionIDs[0])
+		_, err = core.MetaTable.client.Load(DDOperationPrefix)
+		assert.NotNil(t, err)
 	})
 
 	t.Run("drop collection", func(t *testing.T) {
@@ -1049,19 +980,8 @@ func TestMasterService(t *testing.T) {
 		assert.Equal(t, collArray[2], "testColl")
 
 		// check DD operation info
-		ddOpStr, err := core.MetaTable.client.Load(DDOperationPrefix)
-		assert.Nil(t, err)
-		var ddOp DdOperation
-		err = json.Unmarshal([]byte(ddOpStr), &ddOp)
-		assert.Nil(t, err)
-		assert.Equal(t, DropCollectionDDType, ddOp.Type)
-		assert.Equal(t, collMeta.ID, ddOp.CollectionID)
-		assert.Equal(t, true, ddOp.Send)
-
-		var collID typeutil.UniqueID
-		err = json.Unmarshal([]byte(ddOp.Body), &collID)
-		assert.Nil(t, err)
-		assert.Equal(t, collMeta.ID, collID)
+		_, err = core.MetaTable.client.Load(DDOperationPrefix)
+		assert.NotNil(t, err)
 	})
 
 	t.Run("context_cancel", func(t *testing.T) {

--- a/internal/masterservice/master_service_test.go
+++ b/internal/masterservice/master_service_test.go
@@ -407,13 +407,14 @@ func TestMasterService(t *testing.T) {
 		assert.Equal(t, createMsg.CollectionID, createMeta.ID)
 
 		// check DD operation info
-		ddOpStr, err := core.MetaTable.client.Load(DDMsgPrefix)
+		ddOpStr, err := core.MetaTable.client.Load(DDOperationPrefix)
 		assert.Nil(t, err)
 		var ddOp DdOperation
 		err = json.Unmarshal([]byte(ddOpStr), &ddOp)
 		assert.Nil(t, err)
-		assert.Equal(t, CreateCollectionMsgType, ddOp.Type)
+		assert.Equal(t, CreateCollectionDDType, ddOp.Type)
 		assert.Equal(t, createMeta.ID, ddOp.CollectionID)
+		assert.Equal(t, true, ddOp.Send)
 
 		var meta map[string]string
 		err = json.Unmarshal([]byte(ddOp.Body), &meta)
@@ -550,14 +551,15 @@ func TestMasterService(t *testing.T) {
 		assert.Equal(t, "testColl", pm.GetCollArray()[0])
 
 		// check DD operation info
-		ddOpStr, err := core.MetaTable.client.Load(DDMsgPrefix)
+		ddOpStr, err := core.MetaTable.client.Load(DDOperationPrefix)
 		assert.Nil(t, err)
 		var ddOp DdOperation
 		err = json.Unmarshal([]byte(ddOpStr), &ddOp)
 		assert.Nil(t, err)
-		assert.Equal(t, CreatePartitionMsgType, ddOp.Type)
+		assert.Equal(t, CreatePartitionDDType, ddOp.Type)
 		assert.Equal(t, collMeta.ID, ddOp.CollectionID)
 		assert.Equal(t, partMeta.PartitionID, ddOp.PartitionID)
+		assert.Equal(t, true, ddOp.Send)
 
 		var meta map[string]string
 		err = json.Unmarshal([]byte(ddOp.Body), &meta)
@@ -970,14 +972,15 @@ func TestMasterService(t *testing.T) {
 		assert.Equal(t, "testColl", pm.GetCollArray()[1])
 
 		// check DD operation info
-		ddOpStr, err := core.MetaTable.client.Load(DDMsgPrefix)
+		ddOpStr, err := core.MetaTable.client.Load(DDOperationPrefix)
 		assert.Nil(t, err)
 		var ddOp DdOperation
 		err = json.Unmarshal([]byte(ddOpStr), &ddOp)
 		assert.Nil(t, err)
-		assert.Equal(t, DropPartitionMsgType, ddOp.Type)
+		assert.Equal(t, DropPartitionDDType, ddOp.Type)
 		assert.Equal(t, collMeta.ID, ddOp.CollectionID)
 		assert.Equal(t, dropPartID, ddOp.PartitionID)
+		assert.Equal(t, true, ddOp.Send)
 
 		var meta map[string]string
 		err = json.Unmarshal([]byte(ddOp.Body), &meta)
@@ -1046,13 +1049,14 @@ func TestMasterService(t *testing.T) {
 		assert.Equal(t, collArray[2], "testColl")
 
 		// check DD operation info
-		ddOpStr, err := core.MetaTable.client.Load(DDMsgPrefix)
+		ddOpStr, err := core.MetaTable.client.Load(DDOperationPrefix)
 		assert.Nil(t, err)
 		var ddOp DdOperation
 		err = json.Unmarshal([]byte(ddOpStr), &ddOp)
 		assert.Nil(t, err)
-		assert.Equal(t, DropCollectionMsgType, ddOp.Type)
+		assert.Equal(t, DropCollectionDDType, ddOp.Type)
 		assert.Equal(t, collMeta.ID, ddOp.CollectionID)
+		assert.Equal(t, true, ddOp.Send)
 
 		var collID typeutil.UniqueID
 		err = json.Unmarshal([]byte(ddOp.Body), &collID)

--- a/internal/masterservice/master_service_test.go
+++ b/internal/masterservice/master_service_test.go
@@ -1679,25 +1679,25 @@ func TestCheckInit(t *testing.T) {
 	err = c.checkInit()
 	assert.NotNil(t, err)
 
-	c.DdCreateCollectionReq = func(ctx context.Context, req *internalpb.CreateCollectionRequest) error {
+	c.SendDdCreateCollectionReq = func(ctx context.Context, req *internalpb.CreateCollectionRequest) error {
 		return nil
 	}
 	err = c.checkInit()
 	assert.NotNil(t, err)
 
-	c.DdDropCollectionReq = func(ctx context.Context, req *internalpb.DropCollectionRequest) error {
+	c.SendDdDropCollectionReq = func(ctx context.Context, req *internalpb.DropCollectionRequest) error {
 		return nil
 	}
 	err = c.checkInit()
 	assert.NotNil(t, err)
 
-	c.DdCreatePartitionReq = func(ctx context.Context, req *internalpb.CreatePartitionRequest) error {
+	c.SendDdCreatePartitionReq = func(ctx context.Context, req *internalpb.CreatePartitionRequest) error {
 		return nil
 	}
 	err = c.checkInit()
 	assert.NotNil(t, err)
 
-	c.DdDropPartitionReq = func(ctx context.Context, req *internalpb.DropPartitionRequest) error {
+	c.SendDdDropPartitionReq = func(ctx context.Context, req *internalpb.DropPartitionRequest) error {
 		return nil
 	}
 	err = c.checkInit()

--- a/internal/masterservice/meta_table.go
+++ b/internal/masterservice/meta_table.go
@@ -230,7 +230,7 @@ func (mt *metaTable) AddProxy(po *pb.ProxyMeta) error {
 	return nil
 }
 
-func (mt *metaTable) encodeDdOperation(v interface{}, ddType string, collID typeutil.UniqueID, partID typeutil.UniqueID) (string, error){
+func (mt *metaTable) encodeDdOperation(v interface{}, ddType string, collID typeutil.UniqueID, partID typeutil.UniqueID) (string, error) {
 	vByte, err := json.Marshal(v)
 	if err != nil {
 		return "", err
@@ -241,7 +241,6 @@ func (mt *metaTable) encodeDdOperation(v interface{}, ddType string, collID type
 		Type:         ddType,
 		CollectionID: collID,
 		PartitionID:  partID,
-		Send:         false,
 	}
 	ddOpByte, err := json.Marshal(ddOp)
 	if err != nil {

--- a/internal/masterservice/meta_table.go
+++ b/internal/masterservice/meta_table.go
@@ -479,6 +479,12 @@ func (mt *metaTable) getPartitionByName(collID typeutil.UniqueID, partitionName 
 	return pb.PartitionInfo{}, fmt.Errorf("partition %s does not exist", partitionName)
 }
 
+func (mt *metaTable) GetPartitionByName(collID typeutil.UniqueID, partitionName string) (pb.PartitionInfo, error) {
+	mt.ddLock.RLock()
+	defer mt.ddLock.RUnlock()
+	return mt.getPartitionByName(collID, partitionName)
+}
+
 func (mt *metaTable) HasPartition(collID typeutil.UniqueID, partitionName string) bool {
 	mt.ddLock.RLock()
 	defer mt.ddLock.RUnlock()

--- a/internal/masterservice/meta_table.go
+++ b/internal/masterservice/meta_table.go
@@ -410,7 +410,7 @@ func (mt *metaTable) ListCollections() ([]string, error) {
 	return colls, nil
 }
 
-func (mt *metaTable) AddPartition(collID typeutil.UniqueID, partitionName string, partitionID typeutil.UniqueID) error {
+func (mt *metaTable) AddPartition(collID typeutil.UniqueID, partitionName string, partitionID typeutil.UniqueID, req *internalpb.CreatePartitionRequest) error {
 	mt.ddLock.Lock()
 	defer mt.ddLock.Unlock()
 	coll, ok := mt.collID2Meta[collID]
@@ -453,7 +453,7 @@ func (mt *metaTable) AddPartition(collID typeutil.UniqueID, partitionName string
 
 	// build DdOperation and save it into etcd, when ddmsg send fail,
 	// system can restore ddmsg from etcd and re-send
-	ddOpStr, err := EncodeDdOperation(meta, CreatePartitionDDType, collID, partitionID)
+	ddOpStr, err := EncodeDdOperation(*req, CreatePartitionDDType, collID, partitionID)
 	if err != nil {
 		return err
 	}

--- a/internal/masterservice/meta_table.go
+++ b/internal/masterservice/meta_table.go
@@ -40,6 +40,7 @@ const (
 	IndexMetaPrefix        = ComponentPrefix + "/index"
 
 	DDOperationPrefix = ComponentPrefix + "/dd-operation"
+	DDMsgSendPrefix   = ComponentPrefix + "/dd-msg-send"
 
 	CreateCollectionDDType = "CreateCollection"
 	DropCollectionDDType   = "DropCollection"
@@ -267,6 +268,7 @@ func (mt *metaTable) AddCollection(coll *pb.CollectionInfo, part *pb.PartitionIn
 
 	// save ddOpStr into etcd
 	meta[DDOperationPrefix] = ddOpStr
+	meta[DDMsgSendPrefix] = "false"
 
 	err := mt.client.MultiSave(meta)
 	if err != nil {
@@ -323,7 +325,10 @@ func (mt *metaTable) DeleteCollection(collID typeutil.UniqueID, ddOpStr string) 
 	}
 
 	// save ddOpStr into etcd
-	var saveMeta = map[string]string{DDOperationPrefix: ddOpStr}
+	var saveMeta = map[string]string{
+		DDOperationPrefix: ddOpStr,
+		DDMsgSendPrefix:   "false",
+	}
 
 	err := mt.client.MultiSaveAndRemoveWithPrefix(saveMeta, delMetakeys)
 	if err != nil {
@@ -440,6 +445,7 @@ func (mt *metaTable) AddPartition(collID typeutil.UniqueID, partitionName string
 
 	// save ddOpStr into etcd
 	meta[DDOperationPrefix] = ddOpStr
+	meta[DDMsgSendPrefix] = "false"
 
 	err := mt.client.MultiSave(meta)
 	if err != nil {
@@ -535,6 +541,7 @@ func (mt *metaTable) DeletePartition(collID typeutil.UniqueID, partitionName str
 
 	// save ddOpStr into etcd
 	meta[DDOperationPrefix] = ddOpStr
+	meta[DDMsgSendPrefix] = "false"
 
 	err := mt.client.MultiSaveAndRemoveWithPrefix(meta, delMetaKeys)
 	if err != nil {

--- a/internal/masterservice/meta_table.go
+++ b/internal/masterservice/meta_table.go
@@ -270,7 +270,7 @@ func (mt *metaTable) AddCollection(coll *pb.CollectionInfo, part *pb.PartitionIn
 	// build DdOperation and save it into etcd, when ddmsg send fail,
 	// system can restore ddmsg from etcd and re-send
 	if collReq != nil && partReq != nil {
-		ddOpStr, err := EncodeDdOperation(*collReq, *partReq, CreateCollectionDDType)
+		ddOpStr, err := EncodeDdOperation(collReq, partReq, CreateCollectionDDType)
 		if err != nil {
 			return err
 		}
@@ -335,7 +335,7 @@ func (mt *metaTable) DeleteCollection(collID typeutil.UniqueID, req *internalpb.
 	// build DdOperation and save it into etcd, when ddmsg send fail,
 	// system can restore ddmsg from etcd and re-send
 	if req != nil {
-		ddOpStr, err := EncodeDdOperation(*req, 0, DropCollectionDDType)
+		ddOpStr, err := EncodeDdOperation(req, nil, DropCollectionDDType)
 		if err != nil {
 			return err
 		}
@@ -458,7 +458,7 @@ func (mt *metaTable) AddPartition(collID typeutil.UniqueID, partitionName string
 	// build DdOperation and save it into etcd, when ddmsg send fail,
 	// system can restore ddmsg from etcd and re-send
 	if req != nil {
-		ddOpStr, err := EncodeDdOperation(*req, 0, CreatePartitionDDType)
+		ddOpStr, err := EncodeDdOperation(req, nil, CreatePartitionDDType)
 		if err != nil {
 			return err
 		}
@@ -560,7 +560,7 @@ func (mt *metaTable) DeletePartition(collID typeutil.UniqueID, partitionName str
 	// build DdOperation and save it into etcd, when ddmsg send fail,
 	// system can restore ddmsg from etcd and re-send
 	if req != nil {
-		ddOpStr, err := EncodeDdOperation(*req, 0, DropPartitionDDType)
+		ddOpStr, err := EncodeDdOperation(req, nil, DropPartitionDDType)
 		if err != nil {
 			return 0, err
 		}

--- a/internal/masterservice/meta_table.go
+++ b/internal/masterservice/meta_table.go
@@ -270,7 +270,7 @@ func (mt *metaTable) AddCollection(coll *pb.CollectionInfo, part *pb.PartitionIn
 	// build DdOperation and save it into etcd, when ddmsg send fail,
 	// system can restore ddmsg from etcd and re-send
 	if collReq != nil && partReq != nil {
-		ddOpStr, err := EncodeDdOperation(*collReq, *partReq, CreateCollectionDDType, coll.ID, 0)
+		ddOpStr, err := EncodeDdOperation(*collReq, *partReq, CreateCollectionDDType)
 		if err != nil {
 			return err
 		}
@@ -335,7 +335,7 @@ func (mt *metaTable) DeleteCollection(collID typeutil.UniqueID, req *internalpb.
 	// build DdOperation and save it into etcd, when ddmsg send fail,
 	// system can restore ddmsg from etcd and re-send
 	if req != nil {
-		ddOpStr, err := EncodeDdOperation(*req, 0, DropCollectionDDType, collID, 0)
+		ddOpStr, err := EncodeDdOperation(*req, 0, DropCollectionDDType)
 		if err != nil {
 			return err
 		}
@@ -458,7 +458,7 @@ func (mt *metaTable) AddPartition(collID typeutil.UniqueID, partitionName string
 	// build DdOperation and save it into etcd, when ddmsg send fail,
 	// system can restore ddmsg from etcd and re-send
 	if req != nil {
-		ddOpStr, err := EncodeDdOperation(*req, 0, CreatePartitionDDType, collID, partitionID)
+		ddOpStr, err := EncodeDdOperation(*req, 0, CreatePartitionDDType)
 		if err != nil {
 			return err
 		}
@@ -560,7 +560,7 @@ func (mt *metaTable) DeletePartition(collID typeutil.UniqueID, partitionName str
 	// build DdOperation and save it into etcd, when ddmsg send fail,
 	// system can restore ddmsg from etcd and re-send
 	if req != nil {
-		ddOpStr, err := EncodeDdOperation(*req, 0, DropPartitionDDType, collID, partMeta.PartitionID)
+		ddOpStr, err := EncodeDdOperation(*req, 0, DropPartitionDDType)
 		if err != nil {
 			return 0, err
 		}

--- a/internal/masterservice/meta_table.go
+++ b/internal/masterservice/meta_table.go
@@ -12,7 +12,6 @@
 package masterservice
 
 import (
-	"encoding/json"
 	"fmt"
 	"path"
 	"strconv"
@@ -230,25 +229,6 @@ func (mt *metaTable) AddProxy(po *pb.ProxyMeta) error {
 	return nil
 }
 
-func (mt *metaTable) encodeDdOperation(v interface{}, ddType string, collID typeutil.UniqueID, partID typeutil.UniqueID) (string, error) {
-	vByte, err := json.Marshal(v)
-	if err != nil {
-		return "", err
-	}
-	ddOp := DdOperation{
-		Base:         nil,
-		Body:         string(vByte),
-		Type:         ddType,
-		CollectionID: collID,
-		PartitionID:  partID,
-	}
-	ddOpByte, err := json.Marshal(ddOp)
-	if err != nil {
-		return "", err
-	}
-	return string(ddOpByte), nil
-}
-
 func (mt *metaTable) AddCollection(coll *pb.CollectionInfo, part *pb.PartitionInfo, idx []*pb.IndexInfo) error {
 	mt.ddLock.Lock()
 	defer mt.ddLock.Unlock()
@@ -288,7 +268,7 @@ func (mt *metaTable) AddCollection(coll *pb.CollectionInfo, part *pb.PartitionIn
 	}
 
 	// record dd operation
-	ddOpStr, err := mt.encodeDdOperation(meta, CreateCollectionDDType, coll.ID, 0)
+	ddOpStr, err := EncodeDdOperation(meta, CreateCollectionDDType, coll.ID, 0)
 	if err != nil {
 		return err
 	}
@@ -349,7 +329,7 @@ func (mt *metaTable) DeleteCollection(collID typeutil.UniqueID) error {
 	}
 
 	// record dd operation
-	ddOpStr, err := mt.encodeDdOperation(collID, DropCollectionDDType, collID, 0)
+	ddOpStr, err := EncodeDdOperation(collID, DropCollectionDDType, collID, 0)
 	if err != nil {
 		return err
 	}
@@ -471,7 +451,7 @@ func (mt *metaTable) AddPartition(collID typeutil.UniqueID, partitionName string
 	meta := map[string]string{k1: v1, k2: v2}
 
 	// record dd operation
-	ddOpStr, err := mt.encodeDdOperation(meta, CreatePartitionDDType, collID, partitionID)
+	ddOpStr, err := EncodeDdOperation(meta, CreatePartitionDDType, collID, partitionID)
 	if err != nil {
 		return err
 	}
@@ -561,7 +541,7 @@ func (mt *metaTable) DeletePartition(collID typeutil.UniqueID, partitionName str
 	}
 
 	// record dd operation
-	ddOpStr, err := mt.encodeDdOperation(meta, DropPartitionDDType, collID, partMeta.PartitionID)
+	ddOpStr, err := EncodeDdOperation(meta, DropPartitionDDType, collID, partMeta.PartitionID)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/masterservice/meta_table.go
+++ b/internal/masterservice/meta_table.go
@@ -42,14 +42,12 @@ const (
 	SegmentIndexMetaPrefix = ComponentPrefix + "/segment-index"
 	IndexMetaPrefix        = ComponentPrefix + "/index"
 
-	DDMsgPrefix     = ComponentPrefix + "/dd-msg"
-	DDMsgTypePrefix = ComponentPrefix + "/dd-msg-type"
-	DDMsgFlagPrefix = ComponentPrefix + "/dd-msg-flag"
+	DDOperationPrefix = ComponentPrefix + "/dd-operation"
 
-	CreateCollectionMsgType = "CreateCollection"
-	DropCollectionMsgType   = "DropCollection"
-	CreatePartitionMsgType  = "CreatePartition"
-	DropPartitionMsgType    = "DropPartition"
+	CreateCollectionDDType = "CreateCollection"
+	DropCollectionDDType   = "DropCollection"
+	CreatePartitionDDType  = "CreatePartition"
+	DropPartitionDDType    = "DropPartition"
 )
 
 type metaTable struct {
@@ -278,7 +276,7 @@ func (mt *metaTable) AddCollection(coll *pb.CollectionInfo, part *pb.PartitionIn
 	ddOp := DdOperation{
 		Base:         nil,
 		Body:         string(metaByte),
-		Type:         CreateCollectionMsgType,
+		Type:         CreateCollectionDDType,
 		CollectionID: coll.ID,
 		PartitionID:  0,
 		Send:         false,
@@ -287,7 +285,7 @@ func (mt *metaTable) AddCollection(coll *pb.CollectionInfo, part *pb.PartitionIn
 	if err != nil {
 		return err
 	}
-	meta[DDMsgPrefix] = string(ddOpByte)
+	meta[DDOperationPrefix] = string(ddOpByte)
 
 	err = mt.client.MultiSave(meta)
 	if err != nil {
@@ -351,7 +349,7 @@ func (mt *metaTable) DeleteCollection(collID typeutil.UniqueID) error {
 	ddOp := DdOperation{
 		Base:         nil,
 		Body:         string(collIDByte),
-		Type:         DropCollectionMsgType,
+		Type:         DropCollectionDDType,
 		CollectionID: collID,
 		PartitionID:  0,
 		Send:         false,
@@ -361,7 +359,7 @@ func (mt *metaTable) DeleteCollection(collID typeutil.UniqueID) error {
 		return err
 	}
 	saveMeta := map[string]string{
-		DDMsgPrefix: string(ddOpByte),
+		DDOperationPrefix: string(ddOpByte),
 	}
 
 	err = mt.client.MultiSaveAndRemoveWithPrefix(saveMeta, delMetakeys)
@@ -485,7 +483,7 @@ func (mt *metaTable) AddPartition(collID typeutil.UniqueID, partitionName string
 	ddOp := DdOperation{
 		Base:         nil,
 		Body:         string(metaByte),
-		Type:         CreatePartitionMsgType,
+		Type:         CreatePartitionDDType,
 		CollectionID: collID,
 		PartitionID:  partitionID,
 		Send:         false,
@@ -494,7 +492,7 @@ func (mt *metaTable) AddPartition(collID typeutil.UniqueID, partitionName string
 	if err != nil {
 		return err
 	}
-	meta[DDMsgPrefix] = string(ddOpByte)
+	meta[DDOperationPrefix] = string(ddOpByte)
 
 	err = mt.client.MultiSave(meta)
 	if err != nil {
@@ -587,7 +585,7 @@ func (mt *metaTable) DeletePartition(collID typeutil.UniqueID, partitionName str
 	ddOp := DdOperation{
 		Base:         nil,
 		Body:         string(metaByte),
-		Type:         DropPartitionMsgType,
+		Type:         DropPartitionDDType,
 		CollectionID: collID,
 		PartitionID:  partMeta.PartitionID,
 		Send:         false,
@@ -596,7 +594,7 @@ func (mt *metaTable) DeletePartition(collID typeutil.UniqueID, partitionName str
 	if err != nil {
 		return 0, err
 	}
-	meta[DDMsgPrefix] = string(ddOpByte)
+	meta[DDOperationPrefix] = string(ddOpByte)
 
 	err = mt.client.MultiSaveAndRemoveWithPrefix(meta, delMetaKeys)
 	if err != nil {

--- a/internal/masterservice/meta_table_test.go
+++ b/internal/masterservice/meta_table_test.go
@@ -267,10 +267,20 @@ func TestMetaTable(t *testing.T) {
 		field, err := mt.GetFieldSchema("testColl", "field110")
 		assert.Nil(t, err)
 		assert.Equal(t, field.FieldID, collInfo.Schema.Fields[0].FieldID)
+
+		// check DD operation flag
+		flag, err := mt.client.Load(DDMsgSendPrefix)
+		assert.Nil(t, err)
+		assert.Equal(t, "false", flag)
 	})
 
 	t.Run("add partition", func(t *testing.T) {
 		assert.Nil(t, mt.AddPartition(collID, partInfo.PartitionName, partInfo.PartitionID, ""))
+
+		// check DD operation flag
+		flag, err := mt.client.Load(DDMsgSendPrefix)
+		assert.Nil(t, err)
+		assert.Equal(t, "false", flag)
 	})
 
 	t.Run("add segment", func(t *testing.T) {
@@ -423,6 +433,11 @@ func TestMetaTable(t *testing.T) {
 		id, err := mt.DeletePartition(collID, partInfo.PartitionName, "")
 		assert.Nil(t, err)
 		assert.Equal(t, partID, id)
+
+		// check DD operation flag
+		flag, err := mt.client.Load(DDMsgSendPrefix)
+		assert.Nil(t, err)
+		assert.Equal(t, "false", flag)
 	})
 
 	t.Run("drop collection", func(t *testing.T) {
@@ -430,6 +445,11 @@ func TestMetaTable(t *testing.T) {
 		assert.NotNil(t, err)
 		err = mt.DeleteCollection(collID, "")
 		assert.Nil(t, err)
+
+		// check DD operation flag
+		flag, err := mt.client.Load(DDMsgSendPrefix)
+		assert.Nil(t, err)
+		assert.Equal(t, "false", flag)
 	})
 
 	/////////////////////////// these tests should run at last, it only used to hit the error lines ////////////////////////

--- a/internal/masterservice/meta_table_test.go
+++ b/internal/masterservice/meta_table_test.go
@@ -243,19 +243,19 @@ func TestMetaTable(t *testing.T) {
 
 	t.Run("add collection", func(t *testing.T) {
 		partInfoDefault.SegmentIDs = []int64{segID}
-		err = mt.AddCollection(collInfo, partInfoDefault, idxInfo, nil, nil)
+		err = mt.AddCollection(collInfo, partInfoDefault, idxInfo, "")
 		assert.NotNil(t, err)
 		partInfoDefault.SegmentIDs = []int64{}
 
 		collInfo.PartitionIDs = []int64{segID}
-		err = mt.AddCollection(collInfo, partInfoDefault, idxInfo, nil, nil)
+		err = mt.AddCollection(collInfo, partInfoDefault, idxInfo, "")
 		assert.NotNil(t, err)
 		collInfo.PartitionIDs = []int64{}
 
-		err = mt.AddCollection(collInfo, partInfoDefault, nil, nil, nil)
+		err = mt.AddCollection(collInfo, partInfoDefault, nil, "")
 		assert.NotNil(t, err)
 
-		err = mt.AddCollection(collInfo, partInfoDefault, idxInfo, nil, nil)
+		err = mt.AddCollection(collInfo, partInfoDefault, idxInfo, "")
 		assert.Nil(t, err)
 
 		collMeta, err := mt.GetCollectionByName("testColl")
@@ -270,7 +270,7 @@ func TestMetaTable(t *testing.T) {
 	})
 
 	t.Run("add partition", func(t *testing.T) {
-		assert.Nil(t, mt.AddPartition(collID, partInfo.PartitionName, partInfo.PartitionID, nil))
+		assert.Nil(t, mt.AddPartition(collID, partInfo.PartitionName, partInfo.PartitionID, ""))
 	})
 
 	t.Run("add segment", func(t *testing.T) {
@@ -420,15 +420,15 @@ func TestMetaTable(t *testing.T) {
 	})
 
 	t.Run("drop partition", func(t *testing.T) {
-		id, err := mt.DeletePartition(collID, partInfo.PartitionName, nil)
+		id, err := mt.DeletePartition(collID, partInfo.PartitionName, "")
 		assert.Nil(t, err)
 		assert.Equal(t, partID, id)
 	})
 
 	t.Run("drop collection", func(t *testing.T) {
-		err := mt.DeleteCollection(collIDInvalid, nil)
+		err := mt.DeleteCollection(collIDInvalid, "")
 		assert.NotNil(t, err)
-		err = mt.DeleteCollection(collID, nil)
+		err = mt.DeleteCollection(collID, "")
 		assert.Nil(t, err)
 	})
 
@@ -444,7 +444,7 @@ func TestMetaTable(t *testing.T) {
 			return fmt.Errorf("multi save error")
 		}
 		collInfo.PartitionIDs = nil
-		err := mt.AddCollection(collInfo, partInfo, idxInfo, nil, nil)
+		err := mt.AddCollection(collInfo, partInfo, idxInfo, "")
 		assert.NotNil(t, err)
 		assert.EqualError(t, err, "multi save error")
 	})
@@ -457,11 +457,11 @@ func TestMetaTable(t *testing.T) {
 			return fmt.Errorf("milti save and remove with prefix error")
 		}
 		collInfo.PartitionIDs = nil
-		err := mt.AddCollection(collInfo, partInfo, idxInfo, nil, nil)
+		err := mt.AddCollection(collInfo, partInfo, idxInfo, "")
 		assert.Nil(t, err)
 		mt.partitionID2Meta = make(map[typeutil.UniqueID]pb.PartitionInfo)
 		mt.indexID2Meta = make(map[int64]pb.IndexInfo)
-		err = mt.DeleteCollection(collInfo.ID, nil)
+		err = mt.DeleteCollection(collInfo.ID, "")
 		assert.NotNil(t, err)
 		assert.EqualError(t, err, "milti save and remove with prefix error")
 	})
@@ -472,7 +472,7 @@ func TestMetaTable(t *testing.T) {
 		}
 
 		collInfo.PartitionIDs = nil
-		err := mt.AddCollection(collInfo, partInfo, idxInfo, nil, nil)
+		err := mt.AddCollection(collInfo, partInfo, idxInfo, "")
 		assert.Nil(t, err)
 
 		seg := &datapb.SegmentInfo{
@@ -508,17 +508,17 @@ func TestMetaTable(t *testing.T) {
 		assert.Nil(t, err)
 
 		collInfo.PartitionIDs = nil
-		err = mt.AddCollection(collInfo, partInfo, idxInfo, nil, nil)
+		err = mt.AddCollection(collInfo, partInfo, idxInfo, "")
 		assert.Nil(t, err)
 
-		err = mt.AddPartition(2, "no-part", 22, nil)
+		err = mt.AddPartition(2, "no-part", 22, "")
 		assert.NotNil(t, err)
 		assert.EqualError(t, err, "can't find collection. id = 2")
 
 		coll := mt.collID2Meta[collInfo.ID]
 		coll.PartitionIDs = make([]int64, Params.MaxPartitionNum)
 		mt.collID2Meta[coll.ID] = coll
-		err = mt.AddPartition(coll.ID, "no-part", 22, nil)
+		err = mt.AddPartition(coll.ID, "no-part", 22, "")
 		assert.NotNil(t, err)
 		assert.EqualError(t, err, fmt.Sprintf("maximum partition's number should be limit to %d", Params.MaxPartitionNum))
 
@@ -528,7 +528,7 @@ func TestMetaTable(t *testing.T) {
 		mockKV.multiSave = func(kvs map[string]string) error {
 			return fmt.Errorf("multi save error")
 		}
-		err = mt.AddPartition(coll.ID, "no-part", 22, nil)
+		err = mt.AddPartition(coll.ID, "no-part", 22, "")
 		assert.NotNil(t, err)
 		assert.EqualError(t, err, "multi save error")
 
@@ -536,13 +536,13 @@ func TestMetaTable(t *testing.T) {
 			return nil
 		}
 		collInfo.PartitionIDs = nil
-		err = mt.AddCollection(collInfo, partInfo, idxInfo, nil, nil)
+		err = mt.AddCollection(collInfo, partInfo, idxInfo, "")
 		assert.Nil(t, err)
-		err = mt.AddPartition(coll.ID, partInfo.PartitionName, 22, nil)
+		err = mt.AddPartition(coll.ID, partInfo.PartitionName, 22, "")
 		assert.NotNil(t, err)
 		assert.EqualError(t, err, fmt.Sprintf("partition name = %s already exists", partInfo.PartitionName))
 
-		err = mt.AddPartition(coll.ID, "no-part", partInfo.PartitionID, nil)
+		err = mt.AddPartition(coll.ID, "no-part", partInfo.PartitionID, "")
 		assert.NotNil(t, err)
 		assert.EqualError(t, err, fmt.Sprintf("partition id = %d already exists", partInfo.PartitionID))
 	})
@@ -558,7 +558,7 @@ func TestMetaTable(t *testing.T) {
 		assert.Nil(t, err)
 
 		collInfo.PartitionIDs = nil
-		err = mt.AddCollection(collInfo, partInfo, idxInfo, nil, nil)
+		err = mt.AddCollection(collInfo, partInfo, idxInfo, "")
 		assert.Nil(t, err)
 
 		mt.partitionID2Meta = make(map[int64]pb.PartitionInfo)
@@ -579,14 +579,14 @@ func TestMetaTable(t *testing.T) {
 		assert.Nil(t, err)
 
 		collInfo.PartitionIDs = nil
-		err = mt.AddCollection(collInfo, partInfo, idxInfo, nil, nil)
+		err = mt.AddCollection(collInfo, partInfo, idxInfo, "")
 		assert.Nil(t, err)
 
-		_, err = mt.DeletePartition(collInfo.ID, Params.DefaultPartitionName, nil)
+		_, err = mt.DeletePartition(collInfo.ID, Params.DefaultPartitionName, "")
 		assert.NotNil(t, err)
 		assert.EqualError(t, err, "default partition cannot be deleted")
 
-		_, err = mt.DeletePartition(collInfo.ID, "abc", nil)
+		_, err = mt.DeletePartition(collInfo.ID, "abc", "")
 		assert.NotNil(t, err)
 		assert.EqualError(t, err, "partition abc does not exist")
 
@@ -596,12 +596,12 @@ func TestMetaTable(t *testing.T) {
 		mockKV.multiSaveAndRemoveWithPrefix = func(saves map[string]string, removals []string) error {
 			return fmt.Errorf("multi save and remove with prefix error")
 		}
-		_, err = mt.DeletePartition(collInfo.ID, pm.PartitionName, nil)
+		_, err = mt.DeletePartition(collInfo.ID, pm.PartitionName, "")
 		assert.NotNil(t, err)
 		assert.EqualError(t, err, "multi save and remove with prefix error")
 
 		mt.collID2Meta = make(map[int64]pb.CollectionInfo)
-		_, err = mt.DeletePartition(collInfo.ID, "abc", nil)
+		_, err = mt.DeletePartition(collInfo.ID, "abc", "")
 		assert.NotNil(t, err)
 		assert.EqualError(t, err, fmt.Sprintf("can't find collection id = %d", collInfo.ID))
 
@@ -621,7 +621,7 @@ func TestMetaTable(t *testing.T) {
 		assert.Nil(t, err)
 
 		collInfo.PartitionIDs = nil
-		err = mt.AddCollection(collInfo, partInfo, idxInfo, nil, nil)
+		err = mt.AddCollection(collInfo, partInfo, idxInfo, "")
 		assert.Nil(t, err)
 
 		noPart := pb.PartitionInfo{
@@ -667,7 +667,7 @@ func TestMetaTable(t *testing.T) {
 		assert.Nil(t, err)
 
 		collInfo.PartitionIDs = nil
-		err = mt.AddCollection(collInfo, partInfo, idxInfo, nil, nil)
+		err = mt.AddCollection(collInfo, partInfo, idxInfo, "")
 		assert.Nil(t, err)
 
 		seg := &datapb.SegmentInfo{
@@ -706,7 +706,7 @@ func TestMetaTable(t *testing.T) {
 		assert.Nil(t, err)
 
 		collInfo.PartitionIDs = nil
-		err = mt.AddCollection(collInfo, partInfo, idxInfo, nil, nil)
+		err = mt.AddCollection(collInfo, partInfo, idxInfo, "")
 		assert.Nil(t, err)
 		assert.Nil(t, mt.AddSegment(seg))
 
@@ -733,7 +733,7 @@ func TestMetaTable(t *testing.T) {
 		assert.Nil(t, err)
 
 		collInfo.PartitionIDs = nil
-		err = mt.AddCollection(collInfo, partInfo, idxInfo, nil, nil)
+		err = mt.AddCollection(collInfo, partInfo, idxInfo, "")
 		assert.Nil(t, err)
 
 		_, _, err = mt.DropIndex("abc", "abc", "abc")
@@ -770,7 +770,7 @@ func TestMetaTable(t *testing.T) {
 		err = mt.reloadFromKV()
 		assert.Nil(t, err)
 		collInfo.PartitionIDs = nil
-		err = mt.AddCollection(collInfo, partInfo, idxInfo, nil, nil)
+		err = mt.AddCollection(collInfo, partInfo, idxInfo, "")
 		assert.Nil(t, err)
 		mt.partitionID2Meta = make(map[int64]pb.PartitionInfo)
 		mockKV.multiSaveAndRemoveWithPrefix = func(saves map[string]string, removals []string) error {
@@ -795,7 +795,7 @@ func TestMetaTable(t *testing.T) {
 		assert.Nil(t, err)
 
 		collInfo.PartitionIDs = nil
-		err = mt.AddCollection(collInfo, partInfo, idxInfo, nil, nil)
+		err = mt.AddCollection(collInfo, partInfo, idxInfo, "")
 		assert.Nil(t, err)
 
 		_, err = mt.GetSegmentIndexInfoByID(101, 101, "abc")
@@ -854,7 +854,7 @@ func TestMetaTable(t *testing.T) {
 		assert.Nil(t, err)
 
 		collInfo.PartitionIDs = nil
-		err = mt.AddCollection(collInfo, partInfo, idxInfo, nil, nil)
+		err = mt.AddCollection(collInfo, partInfo, idxInfo, "")
 		assert.Nil(t, err)
 
 		mt.collID2Meta = make(map[int64]pb.CollectionInfo)
@@ -925,7 +925,7 @@ func TestMetaTable(t *testing.T) {
 		assert.Nil(t, err)
 
 		collInfo.PartitionIDs = nil
-		err = mt.AddCollection(collInfo, partInfo, idxInfo, nil, nil)
+		err = mt.AddCollection(collInfo, partInfo, idxInfo, "")
 		assert.Nil(t, err)
 
 		_, _, err = mt.GetNotIndexedSegments(collInfo.Schema.Name, "no-field", idx)
@@ -950,7 +950,7 @@ func TestMetaTable(t *testing.T) {
 			return nil
 		}
 		collInfo.PartitionIDs = nil
-		err = mt.AddCollection(collInfo, partInfo, idxInfo, nil, nil)
+		err = mt.AddCollection(collInfo, partInfo, idxInfo, "")
 		assert.Nil(t, err)
 		coll := mt.collID2Meta[collInfo.ID]
 		coll.FieldIndexes = append(coll.FieldIndexes, &pb.FieldIndexInfo{FiledID: coll.FieldIndexes[0].FiledID, IndexID: coll.FieldIndexes[0].IndexID + 1})
@@ -998,7 +998,7 @@ func TestMetaTable(t *testing.T) {
 		assert.Nil(t, err)
 
 		collInfo.PartitionIDs = nil
-		err = mt.AddCollection(collInfo, partInfo, idxInfo, nil, nil)
+		err = mt.AddCollection(collInfo, partInfo, idxInfo, "")
 		assert.Nil(t, err)
 		mt.indexID2Meta = make(map[int64]pb.IndexInfo)
 		_, _, err = mt.GetIndexByName(collInfo.Schema.Name, idxInfo[0].IndexName)

--- a/internal/masterservice/meta_table_test.go
+++ b/internal/masterservice/meta_table_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/milvus-io/milvus/internal/proto/commonpb"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
 	pb "github.com/milvus-io/milvus/internal/proto/etcdpb"
+	"github.com/milvus-io/milvus/internal/proto/internalpb"
 	"github.com/milvus-io/milvus/internal/proto/schemapb"
 	"github.com/milvus-io/milvus/internal/util/typeutil"
 	"github.com/stretchr/testify/assert"
@@ -159,7 +160,7 @@ func TestMetaTable(t *testing.T) {
 	//var createCollectionReq = internalpb.CreateCollectionRequest{}
 	//var dropCollectionReq = internalpb.DropCollectionRequest{}
 	//var createPartitionReq = internalpb.CreatePartitionRequest{}
-	//var dropPartitionReq = internalpb.DropPartitionRequest{}
+	var dropPartitionReq = internalpb.DropPartitionRequest{}
 
 	rand.Seed(time.Now().UnixNano())
 	randVal := rand.Int()
@@ -425,7 +426,7 @@ func TestMetaTable(t *testing.T) {
 	})
 
 	t.Run("drop partition", func(t *testing.T) {
-		id, err := mt.DeletePartition(collID, partInfo.PartitionName)
+		id, err := mt.DeletePartition(collID, partInfo.PartitionName, &dropPartitionReq)
 		assert.Nil(t, err)
 		assert.Equal(t, partID, id)
 	})
@@ -587,11 +588,11 @@ func TestMetaTable(t *testing.T) {
 		err = mt.AddCollection(collInfo, partInfo, idxInfo)
 		assert.Nil(t, err)
 
-		_, err = mt.DeletePartition(collInfo.ID, Params.DefaultPartitionName)
+		_, err = mt.DeletePartition(collInfo.ID, Params.DefaultPartitionName, &dropPartitionReq)
 		assert.NotNil(t, err)
 		assert.EqualError(t, err, "default partition cannot be deleted")
 
-		_, err = mt.DeletePartition(collInfo.ID, "abc")
+		_, err = mt.DeletePartition(collInfo.ID, "abc", &dropPartitionReq)
 		assert.NotNil(t, err)
 		assert.EqualError(t, err, "partition abc does not exist")
 
@@ -601,12 +602,12 @@ func TestMetaTable(t *testing.T) {
 		mockKV.multiSaveAndRemoveWithPrefix = func(saves map[string]string, removals []string) error {
 			return fmt.Errorf("multi save and remove with prefix error")
 		}
-		_, err = mt.DeletePartition(collInfo.ID, pm.PartitionName)
+		_, err = mt.DeletePartition(collInfo.ID, pm.PartitionName, &dropPartitionReq)
 		assert.NotNil(t, err)
 		assert.EqualError(t, err, "multi save and remove with prefix error")
 
 		mt.collID2Meta = make(map[int64]pb.CollectionInfo)
-		_, err = mt.DeletePartition(collInfo.ID, "abc")
+		_, err = mt.DeletePartition(collInfo.ID, "abc", &dropPartitionReq)
 		assert.NotNil(t, err)
 		assert.EqualError(t, err, fmt.Sprintf("can't find collection id = %d", collInfo.ID))
 

--- a/internal/masterservice/meta_table_test.go
+++ b/internal/masterservice/meta_table_test.go
@@ -159,7 +159,7 @@ func TestMetaTable(t *testing.T) {
 
 	//var createCollectionReq = internalpb.CreateCollectionRequest{}
 	var dropCollectionReq = internalpb.DropCollectionRequest{}
-	//var createPartitionReq = internalpb.CreatePartitionRequest{}
+	var createPartitionReq = internalpb.CreatePartitionRequest{}
 	var dropPartitionReq = internalpb.DropPartitionRequest{}
 
 	rand.Seed(time.Now().UnixNano())
@@ -276,7 +276,7 @@ func TestMetaTable(t *testing.T) {
 	})
 
 	t.Run("add partition", func(t *testing.T) {
-		assert.Nil(t, mt.AddPartition(collID, partInfo.PartitionName, partInfo.PartitionID))
+		assert.Nil(t, mt.AddPartition(collID, partInfo.PartitionName, partInfo.PartitionID, &createPartitionReq))
 	})
 
 	t.Run("add segment", func(t *testing.T) {
@@ -517,14 +517,14 @@ func TestMetaTable(t *testing.T) {
 		err = mt.AddCollection(collInfo, partInfo, idxInfo)
 		assert.Nil(t, err)
 
-		err = mt.AddPartition(2, "no-part", 22)
+		err = mt.AddPartition(2, "no-part", 22, &createPartitionReq)
 		assert.NotNil(t, err)
 		assert.EqualError(t, err, "can't find collection. id = 2")
 
 		coll := mt.collID2Meta[collInfo.ID]
 		coll.PartitionIDs = make([]int64, Params.MaxPartitionNum)
 		mt.collID2Meta[coll.ID] = coll
-		err = mt.AddPartition(coll.ID, "no-part", 22)
+		err = mt.AddPartition(coll.ID, "no-part", 22, &createPartitionReq)
 		assert.NotNil(t, err)
 		assert.EqualError(t, err, fmt.Sprintf("maximum partition's number should be limit to %d", Params.MaxPartitionNum))
 
@@ -534,7 +534,7 @@ func TestMetaTable(t *testing.T) {
 		mockKV.multiSave = func(kvs map[string]string) error {
 			return fmt.Errorf("multi save error")
 		}
-		err = mt.AddPartition(coll.ID, "no-part", 22)
+		err = mt.AddPartition(coll.ID, "no-part", 22, &createPartitionReq)
 		assert.NotNil(t, err)
 		assert.EqualError(t, err, "multi save error")
 
@@ -544,11 +544,11 @@ func TestMetaTable(t *testing.T) {
 		collInfo.PartitionIDs = nil
 		err = mt.AddCollection(collInfo, partInfo, idxInfo)
 		assert.Nil(t, err)
-		err = mt.AddPartition(coll.ID, partInfo.PartitionName, 22)
+		err = mt.AddPartition(coll.ID, partInfo.PartitionName, 22, &createPartitionReq)
 		assert.NotNil(t, err)
 		assert.EqualError(t, err, fmt.Sprintf("partition name = %s already exists", partInfo.PartitionName))
 
-		err = mt.AddPartition(coll.ID, "no-part", partInfo.PartitionID)
+		err = mt.AddPartition(coll.ID, "no-part", partInfo.PartitionID, &createPartitionReq)
 		assert.NotNil(t, err)
 		assert.EqualError(t, err, fmt.Sprintf("partition id = %d already exists", partInfo.PartitionID))
 	})

--- a/internal/masterservice/meta_table_test.go
+++ b/internal/masterservice/meta_table_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/milvus-io/milvus/internal/proto/commonpb"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
 	pb "github.com/milvus-io/milvus/internal/proto/etcdpb"
-	"github.com/milvus-io/milvus/internal/proto/internalpb"
 	"github.com/milvus-io/milvus/internal/proto/schemapb"
 	"github.com/milvus-io/milvus/internal/util/typeutil"
 	"github.com/stretchr/testify/assert"
@@ -157,11 +156,6 @@ func TestMetaTable(t *testing.T) {
 	const segID2 = typeutil.UniqueID(101)
 	const fieldID = typeutil.UniqueID(110)
 
-	//var createCollectionReq = internalpb.CreateCollectionRequest{}
-	var dropCollectionReq = internalpb.DropCollectionRequest{}
-	var createPartitionReq = internalpb.CreatePartitionRequest{}
-	var dropPartitionReq = internalpb.DropPartitionRequest{}
-
 	rand.Seed(time.Now().UnixNano())
 	randVal := rand.Int()
 	Params.Init()
@@ -249,19 +243,19 @@ func TestMetaTable(t *testing.T) {
 
 	t.Run("add collection", func(t *testing.T) {
 		partInfoDefault.SegmentIDs = []int64{segID}
-		err = mt.AddCollection(collInfo, partInfoDefault, idxInfo)
+		err = mt.AddCollection(collInfo, partInfoDefault, idxInfo, nil, nil)
 		assert.NotNil(t, err)
 		partInfoDefault.SegmentIDs = []int64{}
 
 		collInfo.PartitionIDs = []int64{segID}
-		err = mt.AddCollection(collInfo, partInfoDefault, idxInfo)
+		err = mt.AddCollection(collInfo, partInfoDefault, idxInfo, nil, nil)
 		assert.NotNil(t, err)
 		collInfo.PartitionIDs = []int64{}
 
-		err = mt.AddCollection(collInfo, partInfoDefault, nil)
+		err = mt.AddCollection(collInfo, partInfoDefault, nil, nil, nil)
 		assert.NotNil(t, err)
 
-		err = mt.AddCollection(collInfo, partInfoDefault, idxInfo)
+		err = mt.AddCollection(collInfo, partInfoDefault, idxInfo, nil, nil)
 		assert.Nil(t, err)
 
 		collMeta, err := mt.GetCollectionByName("testColl")
@@ -276,7 +270,7 @@ func TestMetaTable(t *testing.T) {
 	})
 
 	t.Run("add partition", func(t *testing.T) {
-		assert.Nil(t, mt.AddPartition(collID, partInfo.PartitionName, partInfo.PartitionID, &createPartitionReq))
+		assert.Nil(t, mt.AddPartition(collID, partInfo.PartitionName, partInfo.PartitionID, nil))
 	})
 
 	t.Run("add segment", func(t *testing.T) {
@@ -426,15 +420,15 @@ func TestMetaTable(t *testing.T) {
 	})
 
 	t.Run("drop partition", func(t *testing.T) {
-		id, err := mt.DeletePartition(collID, partInfo.PartitionName, &dropPartitionReq)
+		id, err := mt.DeletePartition(collID, partInfo.PartitionName, nil)
 		assert.Nil(t, err)
 		assert.Equal(t, partID, id)
 	})
 
 	t.Run("drop collection", func(t *testing.T) {
-		err := mt.DeleteCollection(collIDInvalid, &dropCollectionReq)
+		err := mt.DeleteCollection(collIDInvalid, nil)
 		assert.NotNil(t, err)
-		err = mt.DeleteCollection(collID, &dropCollectionReq)
+		err = mt.DeleteCollection(collID, nil)
 		assert.Nil(t, err)
 	})
 
@@ -450,7 +444,7 @@ func TestMetaTable(t *testing.T) {
 			return fmt.Errorf("multi save error")
 		}
 		collInfo.PartitionIDs = nil
-		err := mt.AddCollection(collInfo, partInfo, idxInfo)
+		err := mt.AddCollection(collInfo, partInfo, idxInfo, nil, nil)
 		assert.NotNil(t, err)
 		assert.EqualError(t, err, "multi save error")
 	})
@@ -463,11 +457,11 @@ func TestMetaTable(t *testing.T) {
 			return fmt.Errorf("milti save and remove with prefix error")
 		}
 		collInfo.PartitionIDs = nil
-		err := mt.AddCollection(collInfo, partInfo, idxInfo)
+		err := mt.AddCollection(collInfo, partInfo, idxInfo, nil, nil)
 		assert.Nil(t, err)
 		mt.partitionID2Meta = make(map[typeutil.UniqueID]pb.PartitionInfo)
 		mt.indexID2Meta = make(map[int64]pb.IndexInfo)
-		err = mt.DeleteCollection(collInfo.ID, &dropCollectionReq)
+		err = mt.DeleteCollection(collInfo.ID, nil)
 		assert.NotNil(t, err)
 		assert.EqualError(t, err, "milti save and remove with prefix error")
 	})
@@ -478,7 +472,7 @@ func TestMetaTable(t *testing.T) {
 		}
 
 		collInfo.PartitionIDs = nil
-		err := mt.AddCollection(collInfo, partInfo, idxInfo)
+		err := mt.AddCollection(collInfo, partInfo, idxInfo, nil, nil)
 		assert.Nil(t, err)
 
 		seg := &datapb.SegmentInfo{
@@ -514,17 +508,17 @@ func TestMetaTable(t *testing.T) {
 		assert.Nil(t, err)
 
 		collInfo.PartitionIDs = nil
-		err = mt.AddCollection(collInfo, partInfo, idxInfo)
+		err = mt.AddCollection(collInfo, partInfo, idxInfo, nil, nil)
 		assert.Nil(t, err)
 
-		err = mt.AddPartition(2, "no-part", 22, &createPartitionReq)
+		err = mt.AddPartition(2, "no-part", 22, nil)
 		assert.NotNil(t, err)
 		assert.EqualError(t, err, "can't find collection. id = 2")
 
 		coll := mt.collID2Meta[collInfo.ID]
 		coll.PartitionIDs = make([]int64, Params.MaxPartitionNum)
 		mt.collID2Meta[coll.ID] = coll
-		err = mt.AddPartition(coll.ID, "no-part", 22, &createPartitionReq)
+		err = mt.AddPartition(coll.ID, "no-part", 22, nil)
 		assert.NotNil(t, err)
 		assert.EqualError(t, err, fmt.Sprintf("maximum partition's number should be limit to %d", Params.MaxPartitionNum))
 
@@ -534,7 +528,7 @@ func TestMetaTable(t *testing.T) {
 		mockKV.multiSave = func(kvs map[string]string) error {
 			return fmt.Errorf("multi save error")
 		}
-		err = mt.AddPartition(coll.ID, "no-part", 22, &createPartitionReq)
+		err = mt.AddPartition(coll.ID, "no-part", 22, nil)
 		assert.NotNil(t, err)
 		assert.EqualError(t, err, "multi save error")
 
@@ -542,13 +536,13 @@ func TestMetaTable(t *testing.T) {
 			return nil
 		}
 		collInfo.PartitionIDs = nil
-		err = mt.AddCollection(collInfo, partInfo, idxInfo)
+		err = mt.AddCollection(collInfo, partInfo, idxInfo, nil, nil)
 		assert.Nil(t, err)
-		err = mt.AddPartition(coll.ID, partInfo.PartitionName, 22, &createPartitionReq)
+		err = mt.AddPartition(coll.ID, partInfo.PartitionName, 22, nil)
 		assert.NotNil(t, err)
 		assert.EqualError(t, err, fmt.Sprintf("partition name = %s already exists", partInfo.PartitionName))
 
-		err = mt.AddPartition(coll.ID, "no-part", partInfo.PartitionID, &createPartitionReq)
+		err = mt.AddPartition(coll.ID, "no-part", partInfo.PartitionID, nil)
 		assert.NotNil(t, err)
 		assert.EqualError(t, err, fmt.Sprintf("partition id = %d already exists", partInfo.PartitionID))
 	})
@@ -564,7 +558,7 @@ func TestMetaTable(t *testing.T) {
 		assert.Nil(t, err)
 
 		collInfo.PartitionIDs = nil
-		err = mt.AddCollection(collInfo, partInfo, idxInfo)
+		err = mt.AddCollection(collInfo, partInfo, idxInfo, nil, nil)
 		assert.Nil(t, err)
 
 		mt.partitionID2Meta = make(map[int64]pb.PartitionInfo)
@@ -585,14 +579,14 @@ func TestMetaTable(t *testing.T) {
 		assert.Nil(t, err)
 
 		collInfo.PartitionIDs = nil
-		err = mt.AddCollection(collInfo, partInfo, idxInfo)
+		err = mt.AddCollection(collInfo, partInfo, idxInfo, nil, nil)
 		assert.Nil(t, err)
 
-		_, err = mt.DeletePartition(collInfo.ID, Params.DefaultPartitionName, &dropPartitionReq)
+		_, err = mt.DeletePartition(collInfo.ID, Params.DefaultPartitionName, nil)
 		assert.NotNil(t, err)
 		assert.EqualError(t, err, "default partition cannot be deleted")
 
-		_, err = mt.DeletePartition(collInfo.ID, "abc", &dropPartitionReq)
+		_, err = mt.DeletePartition(collInfo.ID, "abc", nil)
 		assert.NotNil(t, err)
 		assert.EqualError(t, err, "partition abc does not exist")
 
@@ -602,12 +596,12 @@ func TestMetaTable(t *testing.T) {
 		mockKV.multiSaveAndRemoveWithPrefix = func(saves map[string]string, removals []string) error {
 			return fmt.Errorf("multi save and remove with prefix error")
 		}
-		_, err = mt.DeletePartition(collInfo.ID, pm.PartitionName, &dropPartitionReq)
+		_, err = mt.DeletePartition(collInfo.ID, pm.PartitionName, nil)
 		assert.NotNil(t, err)
 		assert.EqualError(t, err, "multi save and remove with prefix error")
 
 		mt.collID2Meta = make(map[int64]pb.CollectionInfo)
-		_, err = mt.DeletePartition(collInfo.ID, "abc", &dropPartitionReq)
+		_, err = mt.DeletePartition(collInfo.ID, "abc", nil)
 		assert.NotNil(t, err)
 		assert.EqualError(t, err, fmt.Sprintf("can't find collection id = %d", collInfo.ID))
 
@@ -627,7 +621,7 @@ func TestMetaTable(t *testing.T) {
 		assert.Nil(t, err)
 
 		collInfo.PartitionIDs = nil
-		err = mt.AddCollection(collInfo, partInfo, idxInfo)
+		err = mt.AddCollection(collInfo, partInfo, idxInfo, nil, nil)
 		assert.Nil(t, err)
 
 		noPart := pb.PartitionInfo{
@@ -673,7 +667,7 @@ func TestMetaTable(t *testing.T) {
 		assert.Nil(t, err)
 
 		collInfo.PartitionIDs = nil
-		err = mt.AddCollection(collInfo, partInfo, idxInfo)
+		err = mt.AddCollection(collInfo, partInfo, idxInfo, nil, nil)
 		assert.Nil(t, err)
 
 		seg := &datapb.SegmentInfo{
@@ -712,7 +706,7 @@ func TestMetaTable(t *testing.T) {
 		assert.Nil(t, err)
 
 		collInfo.PartitionIDs = nil
-		err = mt.AddCollection(collInfo, partInfo, idxInfo)
+		err = mt.AddCollection(collInfo, partInfo, idxInfo, nil, nil)
 		assert.Nil(t, err)
 		assert.Nil(t, mt.AddSegment(seg))
 
@@ -739,7 +733,7 @@ func TestMetaTable(t *testing.T) {
 		assert.Nil(t, err)
 
 		collInfo.PartitionIDs = nil
-		err = mt.AddCollection(collInfo, partInfo, idxInfo)
+		err = mt.AddCollection(collInfo, partInfo, idxInfo, nil, nil)
 		assert.Nil(t, err)
 
 		_, _, err = mt.DropIndex("abc", "abc", "abc")
@@ -776,7 +770,7 @@ func TestMetaTable(t *testing.T) {
 		err = mt.reloadFromKV()
 		assert.Nil(t, err)
 		collInfo.PartitionIDs = nil
-		err = mt.AddCollection(collInfo, partInfo, idxInfo)
+		err = mt.AddCollection(collInfo, partInfo, idxInfo, nil, nil)
 		assert.Nil(t, err)
 		mt.partitionID2Meta = make(map[int64]pb.PartitionInfo)
 		mockKV.multiSaveAndRemoveWithPrefix = func(saves map[string]string, removals []string) error {
@@ -801,7 +795,7 @@ func TestMetaTable(t *testing.T) {
 		assert.Nil(t, err)
 
 		collInfo.PartitionIDs = nil
-		err = mt.AddCollection(collInfo, partInfo, idxInfo)
+		err = mt.AddCollection(collInfo, partInfo, idxInfo, nil, nil)
 		assert.Nil(t, err)
 
 		_, err = mt.GetSegmentIndexInfoByID(101, 101, "abc")
@@ -860,7 +854,7 @@ func TestMetaTable(t *testing.T) {
 		assert.Nil(t, err)
 
 		collInfo.PartitionIDs = nil
-		err = mt.AddCollection(collInfo, partInfo, idxInfo)
+		err = mt.AddCollection(collInfo, partInfo, idxInfo, nil, nil)
 		assert.Nil(t, err)
 
 		mt.collID2Meta = make(map[int64]pb.CollectionInfo)
@@ -931,7 +925,7 @@ func TestMetaTable(t *testing.T) {
 		assert.Nil(t, err)
 
 		collInfo.PartitionIDs = nil
-		err = mt.AddCollection(collInfo, partInfo, idxInfo)
+		err = mt.AddCollection(collInfo, partInfo, idxInfo, nil, nil)
 		assert.Nil(t, err)
 
 		_, _, err = mt.GetNotIndexedSegments(collInfo.Schema.Name, "no-field", idx)
@@ -956,7 +950,7 @@ func TestMetaTable(t *testing.T) {
 			return nil
 		}
 		collInfo.PartitionIDs = nil
-		err = mt.AddCollection(collInfo, partInfo, idxInfo)
+		err = mt.AddCollection(collInfo, partInfo, idxInfo, nil, nil)
 		assert.Nil(t, err)
 		coll := mt.collID2Meta[collInfo.ID]
 		coll.FieldIndexes = append(coll.FieldIndexes, &pb.FieldIndexInfo{FiledID: coll.FieldIndexes[0].FiledID, IndexID: coll.FieldIndexes[0].IndexID + 1})
@@ -1004,7 +998,7 @@ func TestMetaTable(t *testing.T) {
 		assert.Nil(t, err)
 
 		collInfo.PartitionIDs = nil
-		err = mt.AddCollection(collInfo, partInfo, idxInfo)
+		err = mt.AddCollection(collInfo, partInfo, idxInfo, nil, nil)
 		assert.Nil(t, err)
 		mt.indexID2Meta = make(map[int64]pb.IndexInfo)
 		_, _, err = mt.GetIndexByName(collInfo.Schema.Name, idxInfo[0].IndexName)

--- a/internal/masterservice/meta_table_test.go
+++ b/internal/masterservice/meta_table_test.go
@@ -158,7 +158,7 @@ func TestMetaTable(t *testing.T) {
 	const fieldID = typeutil.UniqueID(110)
 
 	//var createCollectionReq = internalpb.CreateCollectionRequest{}
-	//var dropCollectionReq = internalpb.DropCollectionRequest{}
+	var dropCollectionReq = internalpb.DropCollectionRequest{}
 	//var createPartitionReq = internalpb.CreatePartitionRequest{}
 	var dropPartitionReq = internalpb.DropPartitionRequest{}
 
@@ -432,9 +432,9 @@ func TestMetaTable(t *testing.T) {
 	})
 
 	t.Run("drop collection", func(t *testing.T) {
-		err := mt.DeleteCollection(collIDInvalid)
+		err := mt.DeleteCollection(collIDInvalid, &dropCollectionReq)
 		assert.NotNil(t, err)
-		err = mt.DeleteCollection(collID)
+		err = mt.DeleteCollection(collID, &dropCollectionReq)
 		assert.Nil(t, err)
 	})
 
@@ -467,7 +467,7 @@ func TestMetaTable(t *testing.T) {
 		assert.Nil(t, err)
 		mt.partitionID2Meta = make(map[typeutil.UniqueID]pb.PartitionInfo)
 		mt.indexID2Meta = make(map[int64]pb.IndexInfo)
-		err = mt.DeleteCollection(collInfo.ID)
+		err = mt.DeleteCollection(collInfo.ID, &dropCollectionReq)
 		assert.NotNil(t, err)
 		assert.EqualError(t, err, "milti save and remove with prefix error")
 	})

--- a/internal/masterservice/task.go
+++ b/internal/masterservice/task.go
@@ -195,7 +195,14 @@ func (t *CreateCollectionReqTask) Execute(ctx context.Context) error {
 		PartitionID:    partInfo.PartitionID,
 	}
 
-	err = t.core.MetaTable.AddCollection(&collInfo, &partInfo, idxInfo, &ddCollReq, &ddPartReq)
+	// build DdOperation and save it into etcd, when ddmsg send fail,
+	// system can restore ddmsg from etcd and re-send
+	ddOpStr, err := EncodeDdOperation(&ddCollReq, &ddPartReq, CreateCollectionDDType)
+	if err != nil {
+		return err
+	}
+
+	err = t.core.MetaTable.AddCollection(&collInfo, &partInfo, idxInfo, ddOpStr)
 	if err != nil {
 		return err
 	}
@@ -252,7 +259,14 @@ func (t *DropCollectionReqTask) Execute(ctx context.Context) error {
 		CollectionID:   collMeta.ID,
 	}
 
-	err = t.core.MetaTable.DeleteCollection(collMeta.ID, &ddReq)
+	// build DdOperation and save it into etcd, when ddmsg send fail,
+	// system can restore ddmsg from etcd and re-send
+	ddOpStr, err := EncodeDdOperation(&ddReq, nil, DropCollectionDDType)
+	if err != nil {
+		return err
+	}
+
+	err = t.core.MetaTable.DeleteCollection(collMeta.ID, ddOpStr)
 	if err != nil {
 		return err
 	}
@@ -442,7 +456,14 @@ func (t *CreatePartitionReqTask) Execute(ctx context.Context) error {
 		PartitionID:    partID,
 	}
 
-	err = t.core.MetaTable.AddPartition(collMeta.ID, t.Req.PartitionName, partID, &ddReq)
+	// build DdOperation and save it into etcd, when ddmsg send fail,
+	// system can restore ddmsg from etcd and re-send
+	ddOpStr, err := EncodeDdOperation(&ddReq, nil, CreatePartitionDDType)
+	if err != nil {
+		return err
+	}
+
+	err = t.core.MetaTable.AddPartition(collMeta.ID, t.Req.PartitionName, partID, ddOpStr)
 	if err != nil {
 		return err
 	}
@@ -503,7 +524,14 @@ func (t *DropPartitionReqTask) Execute(ctx context.Context) error {
 		PartitionID:    partInfo.PartitionID,
 	}
 
-	_, err = t.core.MetaTable.DeletePartition(collInfo.ID, t.Req.PartitionName, &ddReq)
+	// build DdOperation and save it into etcd, when ddmsg send fail,
+	// system can restore ddmsg from etcd and re-send
+	ddOpStr, err := EncodeDdOperation(&ddReq, nil, DropPartitionDDType)
+	if err != nil {
+		return err
+	}
+
+	_, err = t.core.MetaTable.DeletePartition(collInfo.ID, t.Req.PartitionName, ddOpStr)
 	if err != nil {
 		return err
 	}

--- a/internal/masterservice/task.go
+++ b/internal/masterservice/task.go
@@ -211,7 +211,10 @@ func (t *CreateCollectionReqTask) Execute(ctx context.Context) error {
 	}
 
 	// Marking DDMsgFlagPrefix to true means ddMsg has been send successfully
-	t.core.MetaTable.client.Save(DDMsgFlagPrefix, "true")
+	err = t.core.MetaTable.client.Save(DDMsgFlagPrefix, "true")
+	if err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -278,7 +281,10 @@ func (t *DropCollectionReqTask) Execute(ctx context.Context) error {
 	}()
 
 	// Marking DDMsgFlagPrefix to true means ddMsg has been send successfully
-	t.core.MetaTable.client.Save(DDMsgFlagPrefix, "true")
+	err = t.core.MetaTable.client.Save(DDMsgFlagPrefix, "true")
+	if err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -462,7 +468,10 @@ func (t *CreatePartitionReqTask) Execute(ctx context.Context) error {
 	_ = t.core.InvalidateCollectionMetaCache(ctx, t.Req.Base.Timestamp, t.Req.DbName, t.Req.CollectionName)
 
 	// Marking DDMsgFlagPrefix to true means ddMsg has been send successfully
-	t.core.MetaTable.client.Save(DDMsgFlagPrefix, "true")
+	err = t.core.MetaTable.client.Save(DDMsgFlagPrefix, "true")
+	if err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -520,7 +529,10 @@ func (t *DropPartitionReqTask) Execute(ctx context.Context) error {
 	_ = t.core.InvalidateCollectionMetaCache(ctx, t.Req.Base.Timestamp, t.Req.DbName, t.Req.CollectionName)
 
 	// Marking DDMsgFlagPrefix to true means ddMsg has been send successfully
-	t.core.MetaTable.client.Save(DDMsgFlagPrefix, "true")
+	err = t.core.MetaTable.client.Save(DDMsgFlagPrefix, "true")
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/internal/masterservice/task.go
+++ b/internal/masterservice/task.go
@@ -217,7 +217,7 @@ func (t *CreateCollectionReqTask) Execute(ctx context.Context) error {
 	}
 
 	// Update DDOperation in etcd
-	return t.core.setDdOperationSend(CreateCollectionDDType)
+	return t.core.setDdMsgSendFlag(true)
 }
 
 type DropCollectionReqTask struct {
@@ -287,7 +287,7 @@ func (t *DropCollectionReqTask) Execute(ctx context.Context) error {
 	t.core.InvalidateCollectionMetaCache(ctx, t.Req.Base.Timestamp, t.Req.DbName, t.Req.CollectionName)
 
 	// Update DDOperation in etcd
-	return t.core.setDdOperationSend(DropCollectionDDType)
+	return t.core.setDdMsgSendFlag(true)
 }
 
 type HasCollectionReqTask struct {
@@ -477,7 +477,7 @@ func (t *CreatePartitionReqTask) Execute(ctx context.Context) error {
 	t.core.InvalidateCollectionMetaCache(ctx, t.Req.Base.Timestamp, t.Req.DbName, t.Req.CollectionName)
 
 	// Update DDOperation in etcd
-	return t.core.setDdOperationSend(CreatePartitionDDType)
+	return t.core.setDdMsgSendFlag(true)
 }
 
 type DropPartitionReqTask struct {
@@ -545,7 +545,7 @@ func (t *DropPartitionReqTask) Execute(ctx context.Context) error {
 	t.core.InvalidateCollectionMetaCache(ctx, t.Req.Base.Timestamp, t.Req.DbName, t.Req.CollectionName)
 
 	// Update DDOperation in etcd
-	return t.core.setDdOperationSend(DropPartitionDDType)
+	return t.core.setDdMsgSendFlag(true)
 }
 
 type HasPartitionReqTask struct {

--- a/internal/masterservice/task.go
+++ b/internal/masterservice/task.go
@@ -185,7 +185,7 @@ func (t *CreateCollectionReqTask) Execute(ctx context.Context) error {
 		Schema:         schemaBytes,
 	}
 
-	err = t.core.DdCreateCollectionReq(ctx, &ddReq)
+	err = t.core.SendDdCreateCollectionReq(ctx, &ddReq)
 	if err != nil {
 		return err
 	}
@@ -205,13 +205,13 @@ func (t *CreateCollectionReqTask) Execute(ctx context.Context) error {
 		PartitionID:    partMeta.PartitionID,
 	}
 
-	err = t.core.DdCreatePartitionReq(ctx, &ddPart)
+	err = t.core.SendDdCreatePartitionReq(ctx, &ddPart)
 	if err != nil {
 		return err
 	}
 
 	// Update DDOperation in etcd
-	err = t.core.SetDdOperationSend(CreateCollectionDDType)
+	err = t.core.setDdOperationSend(CreateCollectionDDType)
 	if err != nil {
 		return err
 	}
@@ -268,7 +268,7 @@ func (t *DropCollectionReqTask) Execute(ctx context.Context) error {
 		CollectionID:   collMeta.ID,
 	}
 
-	err = t.core.DdDropCollectionReq(ctx, &ddReq)
+	err = t.core.SendDdDropCollectionReq(ctx, &ddReq)
 	if err != nil {
 		return err
 	}
@@ -281,7 +281,7 @@ func (t *DropCollectionReqTask) Execute(ctx context.Context) error {
 	}()
 
 	// Update DDOperation in etcd
-	err = t.core.SetDdOperationSend(DropCollectionDDType)
+	err = t.core.setDdOperationSend(DropCollectionDDType)
 	if err != nil {
 		return err
 	}
@@ -459,7 +459,7 @@ func (t *CreatePartitionReqTask) Execute(ctx context.Context) error {
 		PartitionID:    partitionID,
 	}
 
-	err = t.core.DdCreatePartitionReq(ctx, &ddReq)
+	err = t.core.SendDdCreatePartitionReq(ctx, &ddReq)
 	if err != nil {
 		return err
 	}
@@ -468,7 +468,7 @@ func (t *CreatePartitionReqTask) Execute(ctx context.Context) error {
 	_ = t.core.InvalidateCollectionMetaCache(ctx, t.Req.Base.Timestamp, t.Req.DbName, t.Req.CollectionName)
 
 	// Update DDOperation in etcd
-	err = t.core.SetDdOperationSend(CreatePartitionDDType)
+	err = t.core.setDdOperationSend(CreatePartitionDDType)
 	if err != nil {
 		return err
 	}
@@ -520,7 +520,7 @@ func (t *DropPartitionReqTask) Execute(ctx context.Context) error {
 		PartitionID:    partID,
 	}
 
-	err = t.core.DdDropPartitionReq(ctx, &ddReq)
+	err = t.core.SendDdDropPartitionReq(ctx, &ddReq)
 	if err != nil {
 		return err
 	}
@@ -529,7 +529,7 @@ func (t *DropPartitionReqTask) Execute(ctx context.Context) error {
 	_ = t.core.InvalidateCollectionMetaCache(ctx, t.Req.Base.Timestamp, t.Req.DbName, t.Req.CollectionName)
 
 	// Update DDOperation in etcd
-	err = t.core.SetDdOperationSend(DropPartitionDDType)
+	err = t.core.setDdOperationSend(DropPartitionDDType)
 	if err != nil {
 		return err
 	}

--- a/internal/masterservice/task.go
+++ b/internal/masterservice/task.go
@@ -433,11 +433,7 @@ func (t *CreatePartitionReqTask) Execute(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	partitionID, _, err := t.core.idAllocator(1)
-	if err != nil {
-		return err
-	}
-	err = t.core.MetaTable.AddPartition(collMeta.ID, t.Req.PartitionName, partitionID)
+	partID, _, err := t.core.idAllocator(1)
 	if err != nil {
 		return err
 	}
@@ -449,7 +445,12 @@ func (t *CreatePartitionReqTask) Execute(ctx context.Context) error {
 		PartitionName:  t.Req.PartitionName,
 		DbID:           0, // todo, not used
 		CollectionID:   collMeta.ID,
-		PartitionID:    partitionID,
+		PartitionID:    partID,
+	}
+
+	err = t.core.MetaTable.AddPartition(collMeta.ID, t.Req.PartitionName, partID, &ddReq)
+	if err != nil {
+		return err
 	}
 
 	err = t.core.SendDdCreatePartitionReq(ctx, &ddReq)

--- a/internal/masterservice/task.go
+++ b/internal/masterservice/task.go
@@ -126,7 +126,7 @@ func (t *CreateCollectionReqTask) Execute(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	collMeta := etcdpb.CollectionInfo{
+	collInfo := etcdpb.CollectionInfo{
 		ID:           collID,
 		Schema:       &schema,
 		CreateTime:   collTs,
@@ -135,7 +135,7 @@ func (t *CreateCollectionReqTask) Execute(ctx context.Context) error {
 	}
 
 	// every collection has _default partition
-	partMeta := etcdpb.PartitionInfo{
+	partInfo := etcdpb.PartitionInfo{
 		PartitionName: Params.DefaultPartitionName,
 		PartitionID:   partitionID,
 		SegmentIDs:    make([]typeutil.UniqueID, 0, 16),
@@ -164,7 +164,7 @@ func (t *CreateCollectionReqTask) Execute(ctx context.Context) error {
 	//	}
 	//}
 
-	err = t.core.MetaTable.AddCollection(&collMeta, &partMeta, idxInfo)
+	err = t.core.MetaTable.AddCollection(&collInfo, &partInfo, idxInfo)
 	if err != nil {
 		return err
 	}
@@ -201,8 +201,8 @@ func (t *CreateCollectionReqTask) Execute(ctx context.Context) error {
 		CollectionName: t.Req.CollectionName,
 		PartitionName:  Params.DefaultPartitionName,
 		DbID:           0, //TODO, not used
-		CollectionID:   collMeta.ID,
-		PartitionID:    partMeta.PartitionID,
+		CollectionID:   collInfo.ID,
+		PartitionID:    partInfo.PartitionID,
 	}
 
 	err = t.core.SendDdCreatePartitionReq(ctx, &ddPart)

--- a/internal/masterservice/task.go
+++ b/internal/masterservice/task.go
@@ -210,8 +210,8 @@ func (t *CreateCollectionReqTask) Execute(ctx context.Context) error {
 		return err
 	}
 
-	// Marking DDMsgFlagPrefix to true means ddMsg has been send successfully
-	err = t.core.MetaTable.client.Save(DDMsgFlagPrefix, "true")
+	// Update DDOperation in etcd
+	err = t.core.SetDdOperationSend(CreateCollectionDDType)
 	if err != nil {
 		return err
 	}
@@ -280,8 +280,8 @@ func (t *DropCollectionReqTask) Execute(ctx context.Context) error {
 		}
 	}()
 
-	// Marking DDMsgFlagPrefix to true means ddMsg has been send successfully
-	err = t.core.MetaTable.client.Save(DDMsgFlagPrefix, "true")
+	// Update DDOperation in etcd
+	err = t.core.SetDdOperationSend(DropCollectionDDType)
 	if err != nil {
 		return err
 	}
@@ -467,8 +467,8 @@ func (t *CreatePartitionReqTask) Execute(ctx context.Context) error {
 	// error doesn't matter here
 	_ = t.core.InvalidateCollectionMetaCache(ctx, t.Req.Base.Timestamp, t.Req.DbName, t.Req.CollectionName)
 
-	// Marking DDMsgFlagPrefix to true means ddMsg has been send successfully
-	err = t.core.MetaTable.client.Save(DDMsgFlagPrefix, "true")
+	// Update DDOperation in etcd
+	err = t.core.SetDdOperationSend(CreatePartitionDDType)
 	if err != nil {
 		return err
 	}
@@ -528,8 +528,8 @@ func (t *DropPartitionReqTask) Execute(ctx context.Context) error {
 	// error doesn't matter here
 	_ = t.core.InvalidateCollectionMetaCache(ctx, t.Req.Base.Timestamp, t.Req.DbName, t.Req.CollectionName)
 
-	// Marking DDMsgFlagPrefix to true means ddMsg has been send successfully
-	err = t.core.MetaTable.client.Save(DDMsgFlagPrefix, "true")
+	// Update DDOperation in etcd
+	err = t.core.SetDdOperationSend(DropPartitionDDType)
 	if err != nil {
 		return err
 	}

--- a/internal/masterservice/util.go
+++ b/internal/masterservice/util.go
@@ -69,7 +69,7 @@ func GetFieldSchemaByIndexID(coll *etcdpb.CollectionInfo, idxID typeutil.UniqueI
 }
 
 // EncodeDdOperation serialize DdOperation into string
-func EncodeDdOperation(v interface{}, v1 interface{}, ddType string, collID typeutil.UniqueID, partID typeutil.UniqueID) (string, error) {
+func EncodeDdOperation(v interface{}, v1 interface{}, ddType string) (string, error) {
 	vByte, err := json.Marshal(v)
 	if err != nil {
 		return "", err
@@ -79,11 +79,10 @@ func EncodeDdOperation(v interface{}, v1 interface{}, ddType string, collID type
 		return "", err
 	}
 	ddOp := DdOperation{
-		Body:         vByte,
-		Body1:        v1Byte, // used for DdCreateCollection only
-		Type:         ddType,
-		CollectionID: collID,
-		PartitionID:  partID,
+		Body:  vByte,
+		Body1: v1Byte, // used for DdCreateCollection only
+		Type:  ddType,
+		Send:  false,
 	}
 	ddOpByte, err := json.Marshal(ddOp)
 	if err != nil {

--- a/internal/masterservice/util.go
+++ b/internal/masterservice/util.go
@@ -77,7 +77,6 @@ func EncodeDdOperation(m proto.Message, m1 proto.Message, ddType string) (string
 		Body:  mStr,
 		Body1: m1Str, // used for DdCreateCollection only
 		Type:  ddType,
-		Send:  false,
 	}
 	ddOpByte, err := json.Marshal(ddOp)
 	if err != nil {

--- a/internal/masterservice/util.go
+++ b/internal/masterservice/util.go
@@ -74,7 +74,7 @@ func EncodeDdOperation(v interface{}, ddType string, collID typeutil.UniqueID, p
 		return "", err
 	}
 	ddOp := DdOperation{
-		Body:         string(vByte),
+		Body:         vByte,
 		Type:         ddType,
 		CollectionID: collID,
 		PartitionID:  partID,

--- a/internal/masterservice/util.go
+++ b/internal/masterservice/util.go
@@ -12,6 +12,7 @@
 package masterservice
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/milvus-io/milvus/internal/proto/commonpb"
@@ -65,4 +66,23 @@ func GetFieldSchemaByIndexID(coll *etcdpb.CollectionInfo, idxID typeutil.UniqueI
 		return nil, fmt.Errorf("index id = %d is not attach to any field", idxID)
 	}
 	return GetFieldSchemaByID(coll, fieldID)
+}
+
+func EncodeDdOperation(v interface{}, ddType string, collID typeutil.UniqueID, partID typeutil.UniqueID) (string, error) {
+	vByte, err := json.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+	ddOp := DdOperation{
+		Base:         nil,
+		Body:         string(vByte),
+		Type:         ddType,
+		CollectionID: collID,
+		PartitionID:  partID,
+	}
+	ddOpByte, err := json.Marshal(ddOp)
+	if err != nil {
+		return "", err
+	}
+	return string(ddOpByte), nil
 }

--- a/internal/masterservice/util.go
+++ b/internal/masterservice/util.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/milvus-io/milvus/internal/proto/commonpb"
 	"github.com/milvus-io/milvus/internal/proto/etcdpb"
 	"github.com/milvus-io/milvus/internal/proto/schemapb"
@@ -69,18 +70,12 @@ func GetFieldSchemaByIndexID(coll *etcdpb.CollectionInfo, idxID typeutil.UniqueI
 }
 
 // EncodeDdOperation serialize DdOperation into string
-func EncodeDdOperation(v interface{}, v1 interface{}, ddType string) (string, error) {
-	vByte, err := json.Marshal(v)
-	if err != nil {
-		return "", err
-	}
-	v1Byte, err := json.Marshal(v1)
-	if err != nil {
-		return "", err
-	}
+func EncodeDdOperation(m proto.Message, m1 proto.Message, ddType string) (string, error) {
+	mStr := proto.MarshalTextString(m)
+	m1Str := proto.MarshalTextString(m1)
 	ddOp := DdOperation{
-		Body:  vByte,
-		Body1: v1Byte, // used for DdCreateCollection only
+		Body:  mStr,
+		Body1: m1Str, // used for DdCreateCollection only
 		Type:  ddType,
 		Send:  false,
 	}

--- a/internal/masterservice/util.go
+++ b/internal/masterservice/util.go
@@ -74,7 +74,6 @@ func EncodeDdOperation(v interface{}, ddType string, collID typeutil.UniqueID, p
 		return "", err
 	}
 	ddOp := DdOperation{
-		Base:         nil,
 		Body:         string(vByte),
 		Type:         ddType,
 		CollectionID: collID,

--- a/internal/masterservice/util.go
+++ b/internal/masterservice/util.go
@@ -68,6 +68,7 @@ func GetFieldSchemaByIndexID(coll *etcdpb.CollectionInfo, idxID typeutil.UniqueI
 	return GetFieldSchemaByID(coll, fieldID)
 }
 
+// EncodeDdOperation serialize DdOperation into string
 func EncodeDdOperation(v interface{}, v1 interface{}, ddType string, collID typeutil.UniqueID, partID typeutil.UniqueID) (string, error) {
 	vByte, err := json.Marshal(v)
 	if err != nil {

--- a/internal/masterservice/util.go
+++ b/internal/masterservice/util.go
@@ -68,13 +68,18 @@ func GetFieldSchemaByIndexID(coll *etcdpb.CollectionInfo, idxID typeutil.UniqueI
 	return GetFieldSchemaByID(coll, fieldID)
 }
 
-func EncodeDdOperation(v interface{}, ddType string, collID typeutil.UniqueID, partID typeutil.UniqueID) (string, error) {
+func EncodeDdOperation(v interface{}, v1 interface{}, ddType string, collID typeutil.UniqueID, partID typeutil.UniqueID) (string, error) {
 	vByte, err := json.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+	v1Byte, err := json.Marshal(v1)
 	if err != nil {
 		return "", err
 	}
 	ddOp := DdOperation{
 		Body:         vByte,
+		Body1:        v1Byte, // used for DdCreateCollection only
 		Type:         ddType,
 		CollectionID: collID,
 		PartitionID:  partID,


### PR DESCRIPTION
In distributed system, ddMsg such as CreateCollection,
DropCollection, CreatePartition and DropPartition may be send
un-successfully for many reasons, for example component down
or network issue.
When master get dd request, we save ddMsg into ETCD firstly
and use a flag to mark its status UNSEND. After ddMsg been
send successfully, we mark the flag to SEND.
When master bootup, we check the flag from ETCD firstly, if
we find the flag is UNSEND, we re-send corresponding ddMsg.

Resolves: #5213 

Signed-off-by: yudong.cai <yudong.cai@zilliz.com>
