### PR TITLE
Dirty BloomFilter is left in the cache

### DIFF
--- a/core/src/cache/Cache.h
+++ b/core/src/cache/Cache.h
@@ -67,6 +67,9 @@ class Cache {
     insert(const std::string& key, const ItemObj& item);
 
     void
+    insert_if_not_exist(const std::string& key, const ItemObj& item);
+
+    void
     erase(const std::string& key);
 
     bool

--- a/core/src/cache/Cache.inl
+++ b/core/src/cache/Cache.inl
@@ -66,6 +66,16 @@ Cache<ItemObj>::insert(const std::string& key, const ItemObj& item) {
 
 template <typename ItemObj>
 void
+Cache<ItemObj>::insert_if_not_exist(const std::string& key, const ItemObj& item) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (lru_.exists(key) == true) {
+        return ;
+    }
+    insert_internal(key, item);
+}
+
+template <typename ItemObj>
+void
 Cache<ItemObj>::erase(const std::string& key) {
     std::lock_guard<std::mutex> lock(mutex_);
     erase_internal(key);

--- a/core/src/cache/CacheMgr.h
+++ b/core/src/cache/CacheMgr.h
@@ -37,6 +37,9 @@ class CacheMgr {
     InsertItem(const std::string& key, const ItemObj& data);
 
     virtual void
+    InsertItemIfNotExist(const std::string& key, const ItemObj& data);
+
+    virtual void
     EraseItem(const std::string& key);
 
     virtual bool

--- a/core/src/cache/CacheMgr.inl
+++ b/core/src/cache/CacheMgr.inl
@@ -64,6 +64,17 @@ CacheMgr<ItemObj>::InsertItem(const std::string& key, const ItemObj& data) {
 
 template <typename ItemObj>
 void
+CacheMgr<ItemObj>::InsertItemIfNotExist(const std::string& key, const ItemObj& data) {
+    if (cache_ == nullptr) {
+        LOG_SERVER_ERROR_ << "Cache doesn't exist";
+        return;
+    }
+    cache_->insert_if_not_exist(key, data);
+    server::Metrics::GetInstance().CacheAccessTotalIncrement();
+}
+
+template <typename ItemObj>
+void
 CacheMgr<ItemObj>::EraseItem(const std::string& key) {
     if (cache_ == nullptr) {
         LOG_SERVER_ERROR_ << "Cache doesn't exist";

--- a/core/src/db/DBImpl.cpp
+++ b/core/src/db/DBImpl.cpp
@@ -1502,7 +1502,7 @@ DBImpl::GetVectorsByIdHelper(const IDNumbers& id_array, std::vector<engine::Vect
         engine::utils::GetParentPath(file.location_, segment_dir);
         segment::SegmentReader segment_reader(segment_dir);
         segment::IdBloomFilterPtr id_bloom_filter_ptr;
-        auto status = segment_reader.LoadBloomFilter(id_bloom_filter_ptr);
+        auto status = segment_reader.LoadBloomFilter(id_bloom_filter_ptr, false);
         if (!status.ok()) {
             return status;
         }

--- a/core/src/db/insert/MemTable.cpp
+++ b/core/src/db/insert/MemTable.cpp
@@ -232,7 +232,7 @@ MemTable::ApplyDeletes() {
         utils::GetParentPath(file.location_, segment_dir);
 
         segment::SegmentReader segment_reader(segment_dir);
-        segment_reader.LoadBloomFilter(id_bloom_filter_ptr);
+        segment_reader.LoadBloomFilter(id_bloom_filter_ptr, true);
 
         for (auto& id : doc_ids_to_delete_) {
             if (id_bloom_filter_ptr->Check(id)) {

--- a/core/src/scheduler/JobMgr.cpp
+++ b/core/src/scheduler/JobMgr.cpp
@@ -98,7 +98,7 @@ JobMgr::worker_function() {
                     engine::utils::GetParentPath(location, segment_dir);
                     segment::SegmentReader segment_reader(segment_dir);
                     segment::IdBloomFilterPtr id_bloom_filter_ptr;
-                    segment_reader.LoadBloomFilter(id_bloom_filter_ptr);
+                    segment_reader.LoadBloomFilter(id_bloom_filter_ptr, false);
 
                     // Check if the id is present.
                     bool pass = true;

--- a/core/src/segment/SegmentReader.cpp
+++ b/core/src/segment/SegmentReader.cpp
@@ -104,7 +104,7 @@ SegmentReader::LoadVectorIndex(const std::string& location, segment::VectorIndex
 }
 
 Status
-SegmentReader::LoadBloomFilter(segment::IdBloomFilterPtr& id_bloom_filter_ptr) {
+SegmentReader::LoadBloomFilter(segment::IdBloomFilterPtr& id_bloom_filter_ptr, bool cache_force) {
     codec::DefaultCodec default_codec;
     try {
         // load id_bloom_filter from cache
@@ -117,7 +117,11 @@ SegmentReader::LoadBloomFilter(segment::IdBloomFilterPtr& id_bloom_filter_ptr) {
             default_codec.GetIdBloomFilterFormat()->read(fs_ptr_, id_bloom_filter_ptr);
 
             // add id_bloom_filter into cache
-            cache::CpuCacheMgr::GetInstance()->InsertItem(cache_key, id_bloom_filter_ptr);
+            if (cache_force) {
+                cache::CpuCacheMgr::GetInstance()->InsertItem(cache_key, id_bloom_filter_ptr);
+            } else {
+                cache::CpuCacheMgr::GetInstance()->InsertItemIfNotExist(cache_key, id_bloom_filter_ptr);
+            }
         }
     } catch (std::exception& e) {
         std::string err_msg = "Failed to load bloom filter: " + std::string(e.what());

--- a/core/src/segment/SegmentReader.h
+++ b/core/src/segment/SegmentReader.h
@@ -49,7 +49,7 @@ class SegmentReader {
     LoadVectorIndex(const std::string& location, segment::VectorIndexPtr& vector_index_ptr);
 
     Status
-    LoadBloomFilter(segment::IdBloomFilterPtr& id_bloom_filter_ptr);
+    LoadBloomFilter(segment::IdBloomFilterPtr& id_bloom_filter_ptr, bool cache_force);
 
     Status
     LoadDeletedDocs(segment::DeletedDocsPtr& deleted_docs_ptr);


### PR DESCRIPTION
Multi threads accessing will leave dirty BloomFilter in the cache.
Now, reading threads will not overwrite the cache. And it should be solved.
Issue 4897 involves BloomFilter and bitset. 
This PR try to fix BloomFilter firstly.

Resolves: #4897

Signed-off-by: cqy123456 <qianya.cheng@zilliz.com>