### PR TITLE
Correct auto-flush behaviour

### DIFF
--- a/internal/datanode/binlog_meta_test.go
+++ b/internal/datanode/binlog_meta_test.go
@@ -63,10 +63,10 @@ func TestMetaTable_Basic(t *testing.T) {
 
 	t.Run("TestBasic_SaveSegmentBinlogMetaTxn", func(t *testing.T) {
 		segID := UniqueID(999999)
-		fieldID2Path := map[UniqueID]string{
-			100: "a",
-			200: "b",
-			300: "c",
+		fieldID2Path := map[UniqueID][]string{
+			100: []string{"a"},
+			200: []string{"b"},
+			300: []string{"c"},
 		}
 
 		err := meta.SaveSegmentBinlogMetaTxn(segID, fieldID2Path)
@@ -87,10 +87,10 @@ func TestMetaTable_Basic(t *testing.T) {
 		assert.Equal(t, 1, len(metas))
 		assert.Equal(t, "c", metas[0].GetBinlogPath())
 
-		fieldID2Path2 := map[UniqueID]string{
-			100: "aa",
-			200: "bb",
-			300: "cc",
+		fieldID2Path2 := map[UniqueID][]string{
+			100: []string{"aa"},
+			200: []string{"bb"},
+			300: []string{"cc"},
 		}
 
 		err = meta.SaveSegmentBinlogMetaTxn(segID, fieldID2Path2)

--- a/internal/datanode/binlog_meta_test.go
+++ b/internal/datanode/binlog_meta_test.go
@@ -64,9 +64,9 @@ func TestMetaTable_Basic(t *testing.T) {
 	t.Run("TestBasic_SaveSegmentBinlogMetaTxn", func(t *testing.T) {
 		segID := UniqueID(999999)
 		fieldID2Path := map[UniqueID][]string{
-			100: []string{"a"},
-			200: []string{"b"},
-			300: []string{"c"},
+			100: {"a"},
+			200: {"b"},
+			300: {"c"},
 		}
 
 		err := meta.SaveSegmentBinlogMetaTxn(segID, fieldID2Path)
@@ -88,9 +88,9 @@ func TestMetaTable_Basic(t *testing.T) {
 		assert.Equal(t, "c", metas[0].GetBinlogPath())
 
 		fieldID2Path2 := map[UniqueID][]string{
-			100: []string{"aa"},
-			200: []string{"bb"},
-			300: []string{"cc"},
+			100: {"aa"},
+			200: {"bb"},
+			300: {"cc"},
 		}
 
 		err = meta.SaveSegmentBinlogMetaTxn(segID, fieldID2Path2)

--- a/internal/datanode/data_node_test.go
+++ b/internal/datanode/data_node_test.go
@@ -21,10 +21,12 @@ import (
 	"github.com/milvus-io/milvus/internal/proto/internalpb"
 )
 
-func TestDataNode(t *testing.T) {
+func TestMain(t *testing.M) {
 	Params.Init()
 	refreshChannelNames()
+}
 
+func TestDataNode(t *testing.T) {
 	node := newDataNodeMock()
 	node.Start()
 

--- a/internal/datanode/data_sync_service.go
+++ b/internal/datanode/data_sync_service.go
@@ -107,7 +107,7 @@ func (dsService *dataSyncService) initNodes() {
 
 	var filterDmNode Node = newFilteredDmNode()
 	var ddNode Node = newDDNode(dsService.ctx, mt, dsService.flushChan, dsService.replica)
-	var insertBufferNode Node = newInsertBufferNode(dsService.ctx, mt, dsService.replica, dsService.msFactory)
+	var insertBufferNode Node = newInsertBufferNode(dsService.ctx, mt, dsService.replica, dsService.msFactory, dsService.idAllocator)
 	var gcNode Node = newGCNode(dsService.replica)
 
 	dsService.fg.AddNode(dmStreamNode)

--- a/internal/datanode/flow_graph_insert_buffer_node_test.go
+++ b/internal/datanode/flow_graph_insert_buffer_node_test.go
@@ -61,7 +61,7 @@ func TestFlowGraphInsertBufferNode_Operate(t *testing.T) {
 	err = msFactory.SetParams(m)
 	assert.Nil(t, err)
 
-	iBNode := newInsertBufferNode(ctx, newBinlogMeta(), replica, msFactory)
+	iBNode := newInsertBufferNode(ctx, newBinlogMeta(), replica, msFactory, NewAllocatorFactory())
 	inMsg := genInsertMsg()
 	var iMsg flowgraph.Msg = &inMsg
 	iBNode.Operate([]flowgraph.Msg{iMsg})


### PR DESCRIPTION
Before this PR, DataNode considered auto-flush a valid flush
complete. It's wrong. So I open this PR to correct this behaviour
in DataNode.

Now binlog paths from auto-flush will be buffered in replica,
waiting until the manul flush to save into etcd all together.

See also: #5220, #5268
A follow up job of #5271 

Signed-off-by: yangxuan <xuan.yang@zilliz.com>
