### PR TITLE
Add a timestamp to the blacklist and cache it

### DIFF
--- a/core/src/cache/CpuCacheMgr.cpp
+++ b/core/src/cache/CpuCacheMgr.cpp
@@ -22,6 +22,7 @@ namespace milvus {
 namespace cache {
 
 const char* BloomFilter_Suffix = ".bloomfilter";
+const char* Blacklist_Suffix = ".blacklist";
 
 CpuCacheMgr::CpuCacheMgr() {
     // All config values have been checked in Config::ValidateConfig()

--- a/core/src/cache/CpuCacheMgr.h
+++ b/core/src/cache/CpuCacheMgr.h
@@ -23,6 +23,7 @@ namespace cache {
 
 // Define cache key suffix
 extern const char* BloomFilter_Suffix;
+extern const char* Blacklist_Suffix;
 
 class CpuCacheMgr : public CacheMgr<DataObjPtr>, public server::CacheConfigHandler {
  private:

--- a/core/src/db/DBImpl.cpp
+++ b/core/src/db/DBImpl.cpp
@@ -479,8 +479,8 @@ DBImpl::PreloadCollection(const std::shared_ptr<server::Context>& context, const
         }
 
         auto json = milvus::json::parse(file.index_params_);
-        ExecutionEnginePtr engine =
-            EngineFactory::Build(file.dimension_, file.location_, engine_type, (MetricType)file.metric_type_, json);
+        ExecutionEnginePtr engine = EngineFactory::Build(file.dimension_, file.location_, engine_type,
+                                                         (MetricType)file.metric_type_, json, file.updated_time_);
         fiu_do_on("DBImpl.PreloadCollection.null_engine", engine = nullptr);
         if (engine == nullptr) {
             LOG_ENGINE_ERROR_ << "Invalid engine type";
@@ -552,8 +552,8 @@ DBImpl::ReleaseCollection(const std::shared_ptr<server::Context>& context, const
         }
 
         auto json = milvus::json::parse(file.index_params_);
-        ExecutionEnginePtr engine =
-            EngineFactory::Build(file.dimension_, file.location_, engine_type, (MetricType)file.metric_type_, json);
+        ExecutionEnginePtr engine = EngineFactory::Build(file.dimension_, file.location_, engine_type,
+                                                         (MetricType)file.metric_type_, json, file.updated_time_);
 
         if (engine == nullptr) {
             LOG_ENGINE_ERROR_ << "Invalid engine type";

--- a/core/src/db/DBImpl.cpp
+++ b/core/src/db/DBImpl.cpp
@@ -493,7 +493,7 @@ DBImpl::PreloadCollection(const std::shared_ptr<server::Context>& context, const
             fiu_do_on("DBImpl.PreloadCollection.engine_throw_exception", throw std::exception());
             std::string msg = "Pre-loaded file: " + file.file_id_ + " size: " + std::to_string(file.file_size_);
             TimeRecorderAuto rc_1(msg);
-            status = engine->Load(true);
+            status = engine->Load(false, true);
             if (!status.ok()) {
                 return status;
             }

--- a/core/src/db/engine/EngineFactory.cpp
+++ b/core/src/db/engine/EngineFactory.cpp
@@ -20,7 +20,7 @@ namespace engine {
 
 ExecutionEnginePtr
 EngineFactory::Build(uint16_t dimension, const std::string& location, EngineType index_type, MetricType metric_type,
-                     const milvus::json& index_params) {
+                     const milvus::json& index_params, int64_t time_stamp) {
     if (index_type == EngineType::INVALID) {
         LOG_ENGINE_ERROR_ << "Unsupported engine type";
         return nullptr;
@@ -28,32 +28,11 @@ EngineFactory::Build(uint16_t dimension, const std::string& location, EngineType
 
     LOG_ENGINE_DEBUG_ << "EngineFactory index type: " << (int)index_type;
     ExecutionEnginePtr execution_engine_ptr =
-        std::make_shared<ExecutionEngineImpl>(dimension, location, index_type, metric_type, index_params);
+        std::make_shared<ExecutionEngineImpl>(dimension, location, index_type, metric_type, index_params, time_stamp);
 
     execution_engine_ptr->Init();
     return execution_engine_ptr;
 }
-
-// ExecutionEnginePtr
-// EngineFactory::Build(uint16_t dimension,
-//                     const std::string& location,
-//                     EngineType index_type,
-//                     MetricType metric_type,
-//                     std::unordered_map<std::string, DataType>& attr_type,
-//                     const milvus::json& index_params) {
-//
-//    if (index_type == EngineType::INVALID) {
-//        ENGINE_LOG_ERROR << "Unsupported engine type";
-//        return nullptr;
-//    }
-//
-//    ENGINE_LOG_DEBUG << "EngineFactory index type: " << (int)index_type;
-//    ExecutionEnginePtr execution_engine_ptr =
-//        std::make_shared<ExecutionEngineImpl>(dimension, location, index_type, metric_type, attr_type, index_params);
-//
-//    execution_engine_ptr->Init();
-//    return execution_engine_ptr;
-//}
 
 }  // namespace engine
 }  // namespace milvus

--- a/core/src/db/engine/EngineFactory.h
+++ b/core/src/db/engine/EngineFactory.h
@@ -24,15 +24,7 @@ class EngineFactory {
  public:
     static ExecutionEnginePtr
     Build(uint16_t dimension, const std::string& location, EngineType index_type, MetricType metric_type,
-          const milvus::json& index_params);
-
-    //    static ExecutionEnginePtr
-    //    Build(uint16_t dimension,
-    //          const std::string& location,
-    //          EngineType index_type,
-    //          MetricType metric_type,
-    //          std::unordered_map<std::string, DataType>& attr_type,
-    //          const milvus::json& index_params);
+          const milvus::json& index_params, int64_t time_stamp);
 };
 
 }  // namespace engine

--- a/core/src/db/engine/ExecutionEngine.h
+++ b/core/src/db/engine/ExecutionEngine.h
@@ -86,7 +86,7 @@ class ExecutionEngine {
     Serialize() = 0;
 
     virtual Status
-    Load(bool to_cache = true) = 0;
+    Load(bool load_blacklist, bool to_cache = true) = 0;
 
     virtual Status
     CopyToFpga() = 0;

--- a/core/src/db/engine/ExecutionEngineImpl.h
+++ b/core/src/db/engine/ExecutionEngineImpl.h
@@ -28,10 +28,10 @@ namespace engine {
 class ExecutionEngineImpl : public ExecutionEngine {
  public:
     ExecutionEngineImpl(uint16_t dimension, const std::string& location, EngineType index_type, MetricType metric_type,
-                        const milvus::json& index_params);
+                        const milvus::json& index_params, int64_t time_stamp);
 
     ExecutionEngineImpl(knowhere::VecIndexPtr index, const std::string& location, EngineType index_type,
-                        MetricType metric_type, const milvus::json& index_params);
+                        MetricType metric_type, const milvus::json& index_params, int64_t time_stamp);
 
     size_t
     Count() const override;
@@ -46,7 +46,7 @@ class ExecutionEngineImpl : public ExecutionEngine {
     Serialize() override;
 
     Status
-    Load(bool to_cache) override;
+    Load(bool load_blacklist, bool to_cache) override;
 
     Status
     CopyToGpu(uint64_t device_id, bool hybrid = false) override;
@@ -135,12 +135,10 @@ class ExecutionEngineImpl : public ExecutionEngine {
     EngineType index_type_;
     MetricType metric_type_;
 
-    int64_t vector_count_;
-
     milvus::json index_params_;
     int64_t gpu_num_ = 0;
 
-    bool gpu_cache_enable_ = false;
+    int64_t time_stamp_;
 };
 
 }  // namespace engine

--- a/core/src/db/insert/MemTable.cpp
+++ b/core/src/db/insert/MemTable.cpp
@@ -263,19 +263,28 @@ MemTable::ApplyDeletes() {
 
         TimeRecorder rec("handle segment " + file.segment_id_);
 
-        auto& segment_id = file.segment_id_;
+        // prepare segment_files
         meta::FilesHolder segment_holder;
-        status = meta_->GetCollectionFilesBySegmentId(segment_id, segment_holder);
+        status = meta_->GetCollectionFilesBySegmentId(file.segment_id_, segment_holder);
         if (!status.ok()) {
             break;
         }
-
-        segment::UidsPtr uids_ptr = nullptr;
-
         milvus::engine::meta::SegmentsSchema& segment_files = segment_holder.HoldFiles();
 
+        // prepare segment dir
         std::string segment_dir;
         utils::GetParentPath(file.location_, segment_dir);
+
+        // load uids
+        segment::UidsPtr uids_ptr = nullptr;
+        for (auto& segment_file : segment_files) {
+            auto data_obj_ptr = cache::CpuCacheMgr::GetInstance()->GetItem(segment_file.location_);
+            auto index = std::static_pointer_cast<knowhere::VecIndex>(data_obj_ptr);
+            if (index != nullptr) {
+                uids_ptr = index->GetUids();
+                break;
+            }
+        }
         if (uids_ptr == nullptr) {
             // load uids from disk
             segment::SegmentReader segment_reader(segment_dir);
@@ -285,9 +294,7 @@ MemTable::ApplyDeletes() {
             }
         }
 
-        segment::DeletedDocsPtr deleted_docs = std::make_shared<segment::DeletedDocs>();
-
-        rec.RecordSection("Loading uids and deleted docs");
+        rec.RecordSection("Loading uids");
 
         std::sort(ids_to_check.begin(), ids_to_check.end());
 
@@ -296,6 +303,7 @@ MemTable::ApplyDeletes() {
         auto find_diff = std::chrono::duration<double>::zero();
         auto set_diff = std::chrono::duration<double>::zero();
 
+        segment::DeletedDocsPtr deleted_docs = std::make_shared<segment::DeletedDocs>();
         for (size_t i = 0; i < uids_ptr->size(); ++i) {
             auto find_start = std::chrono::high_resolution_clock::now();
 

--- a/core/src/index/knowhere/knowhere/index/Index.h
+++ b/core/src/index/knowhere/knowhere/index/Index.h
@@ -38,9 +38,14 @@ class Blacklist : public milvus::cache::DataObj {
 
     int64_t
     Size() override {
-        return (bitset_ != nullptr) ? 0 : bitset_->size();
+        int64_t sz = sizeof(Blacklist);
+        if (bitset_) {
+            sz += bitset_->size();
+        }
+        return sz;
     }
 
+    int64_t time_stamp_ = -1;
     faiss::ConcurrentBitsetPtr bitset_ = nullptr;
 };
 

--- a/core/src/scheduler/task/BuildIndexTask.cpp
+++ b/core/src/scheduler/task/BuildIndexTask.cpp
@@ -46,7 +46,7 @@ XBuildIndexTask::XBuildIndexTask(SegmentSchemaPtr file, TaskLabelPtr label)
 
         auto json = milvus::json::parse(file_->index_params_);
         to_index_engine_ = EngineFactory::Build(file_->dimension_, file_->location_, engine_type,
-                                                (MetricType)file_->metric_type_, json);
+                                                (MetricType)file_->metric_type_, json, file_->updated_time_);
     }
 }
 
@@ -62,7 +62,7 @@ XBuildIndexTask::Load(milvus::scheduler::LoadType type, uint8_t device_id) {
         auto options = build_index_job->options();
         try {
             if (type == LoadType::DISK2CPU) {
-                stat = to_index_engine_->Load(options.insert_cache_immediately_);
+                stat = to_index_engine_->Load(false, options.insert_cache_immediately_);
                 type_str = "DISK2CPU";
             } else if (type == LoadType::CPU2GPU) {
                 stat = to_index_engine_->CopyToIndexFileToGpu(device_id);

--- a/core/src/scheduler/task/SearchTask.cpp
+++ b/core/src/scheduler/task/SearchTask.cpp
@@ -127,7 +127,7 @@ XSearchTask::XSearchTask(const std::shared_ptr<server::Context>& context, Segmen
         }
 
         index_engine_ = EngineFactory::Build(file_->dimension_, file_->location_, engine_type,
-                                             (MetricType)file_->metric_type_, json_params);
+                                             (MetricType)file_->metric_type_, json_params, file_->updated_time_);
     }
 }
 
@@ -143,7 +143,7 @@ XSearchTask::Load(LoadType type, uint8_t device_id) {
     try {
         fiu_do_on("XSearchTask.Load.throw_std_exception", throw std::exception());
         if (type == LoadType::DISK2CPU) {
-            stat = index_engine_->Load();
+            stat = index_engine_->Load(true);
             type_str = "DISK2CPU";
         } else if (type == LoadType::CPU2GPU) {
             bool hybrid = false;

--- a/core/src/utils/CommonUtil.cpp
+++ b/core/src/utils/CommonUtil.cpp
@@ -13,6 +13,7 @@
 #include "cache/CpuCacheMgr.h"
 #include "cache/GpuCacheMgr.h"
 #include "config/Config.h"
+#include "db/Utils.h"
 #include "utils/Log.h"
 
 #include <dirent.h>
@@ -264,8 +265,12 @@ CommonUtil::EraseFromCache(const std::string& item_key) {
         return;
     }
 
+    std::string segment_dir;
+    engine::utils::GetParentPath(item_key, segment_dir);
+
     cache::CpuCacheMgr::GetInstance()->EraseItem(item_key);
-    cache::CpuCacheMgr::GetInstance()->EraseItem(item_key + cache::BloomFilter_Suffix);
+    cache::CpuCacheMgr::GetInstance()->EraseItem(segment_dir + cache::BloomFilter_Suffix);
+    cache::CpuCacheMgr::GetInstance()->EraseItem(segment_dir + cache::Blacklist_Suffix);
 
 #ifdef MILVUS_GPU_VERSION
     server::Config& config = server::Config::GetInstance();
@@ -281,7 +286,6 @@ CommonUtil::EraseFromCache(const std::string& item_key) {
 
 #ifdef MILVUS_FPGA_VERSION
     cache::FpgaCacheMgr::GetInstance()->EraseItem(item_key);
-    cache::FpgaCacheMgr::GetInstance()->EraseItem(item_key + cache::BloomFilter_Suffix);
 #endif
 }
 

--- a/core/unittest/db/test_engine.cpp
+++ b/core/unittest/db/test_engine.cpp
@@ -36,7 +36,8 @@ CreateExecEngine(const milvus::json& json_params, milvus::engine::MetricType met
         INIT_PATH,
         milvus::engine::EngineType::FAISS_IDMAP,
         metric,
-        json_params);
+        json_params,
+        0);
 
     std::vector<float> data;
     std::shared_ptr<std::vector<int64_t>> ids = std::make_shared<std::vector<int64_t>>();
@@ -75,7 +76,8 @@ TEST_F(EngineTest, FACTORY_TEST) {
             "/tmp/milvus_index_1",
             milvus::engine::EngineType::INVALID,
             milvus::engine::MetricType::IP,
-            index_params);
+            index_params,
+            0);
 
         ASSERT_TRUE(engine_ptr == nullptr);
     }
@@ -86,7 +88,8 @@ TEST_F(EngineTest, FACTORY_TEST) {
             "/tmp/milvus_index_1",
             milvus::engine::EngineType::FAISS_IDMAP,
             milvus::engine::MetricType::IP,
-            index_params);
+            index_params,
+            0);
 
         ASSERT_TRUE(engine_ptr != nullptr);
     }
@@ -94,7 +97,7 @@ TEST_F(EngineTest, FACTORY_TEST) {
     {
         auto engine_ptr =
             milvus::engine::EngineFactory::Build(512, "/tmp/milvus_index_1", milvus::engine::EngineType::FAISS_IVFFLAT,
-                                                 milvus::engine::MetricType::IP, index_params);
+                                                 milvus::engine::MetricType::IP, index_params, 0);
 
         ASSERT_TRUE(engine_ptr != nullptr);
     }
@@ -105,7 +108,8 @@ TEST_F(EngineTest, FACTORY_TEST) {
             "/tmp/milvus_index_1",
             milvus::engine::EngineType::FAISS_IVFSQ8,
             milvus::engine::MetricType::IP,
-            index_params);
+            index_params,
+            0);
 
         ASSERT_TRUE(engine_ptr != nullptr);
     }
@@ -116,7 +120,8 @@ TEST_F(EngineTest, FACTORY_TEST) {
             "/tmp/milvus_index_1",
             milvus::engine::EngineType::NSG_MIX,
             milvus::engine::MetricType::IP,
-            index_params);
+            index_params,
+            0);
 
         ASSERT_TRUE(engine_ptr != nullptr);
     }
@@ -127,7 +132,8 @@ TEST_F(EngineTest, FACTORY_TEST) {
             "/tmp/milvus_index_1",
             milvus::engine::EngineType::FAISS_PQ,
             milvus::engine::MetricType::IP,
-            index_params);
+            index_params,
+            0);
 
         ASSERT_TRUE(engine_ptr != nullptr);
     }
@@ -135,7 +141,7 @@ TEST_F(EngineTest, FACTORY_TEST) {
     {
         auto engine_ptr = milvus::engine::EngineFactory::Build(
             512, "/tmp/milvus_index_1", milvus::engine::EngineType::SPTAG_KDT,
-            milvus::engine::MetricType::L2, index_params);
+            milvus::engine::MetricType::L2, index_params, 0);
 
         ASSERT_TRUE(engine_ptr != nullptr);
     }
@@ -143,7 +149,7 @@ TEST_F(EngineTest, FACTORY_TEST) {
     {
         auto engine_ptr = milvus::engine::EngineFactory::Build(
             512, "/tmp/milvus_index_1", milvus::engine::EngineType::SPTAG_KDT,
-            milvus::engine::MetricType::L2, index_params);
+            milvus::engine::MetricType::L2, index_params, 0);
 
         ASSERT_TRUE(engine_ptr != nullptr);
     }
@@ -219,8 +225,8 @@ TEST_F(EngineTest, ENGINE_IMPL_NULL_INDEX_TEST) {
     uint16_t dimension = 64;
     std::string file_path = "/tmp/milvus_index_1";
     milvus::json index_params = {{"nlist", 1024}};
-    auto engine_ptr = milvus::engine::EngineFactory::Build(
-        dimension, file_path, milvus::engine::EngineType::FAISS_IVFFLAT, milvus::engine::MetricType::IP, index_params);
+    auto engine_ptr = milvus::engine::EngineFactory::Build(dimension, file_path,
+        milvus::engine::EngineType::FAISS_IVFFLAT, milvus::engine::MetricType::IP, index_params, 0);
 
     fiu_init(0); // init
     fiu_enable("read_null_index", 1, NULL, 0);
@@ -256,8 +262,8 @@ TEST_F(EngineTest, ENGINE_IMPL_THROW_EXCEPTION_TEST) {
     fiu_init(0); // init
     fiu_enable("ValidateStringNotBool", 1, NULL, 0);
 
-    auto engine_ptr = milvus::engine::EngineFactory::Build(
-        dimension, file_path, milvus::engine::EngineType::FAISS_IVFFLAT, milvus::engine::MetricType::IP, index_params);
+    auto engine_ptr = milvus::engine::EngineFactory::Build(dimension, file_path,
+        milvus::engine::EngineType::FAISS_IVFFLAT, milvus::engine::MetricType::IP, index_params, 0);
 
     fiu_disable("ValidateStringNotBool");
 

--- a/core/unittest/scheduler/test_task.cpp
+++ b/core/unittest/scheduler/test_task.cpp
@@ -100,14 +100,14 @@ TEST(TaskTest, TEST_TASK) {
     milvus::json json = {{"nlist", 16384}};
     build_index_task.to_index_engine_ =
         EngineFactory::Build(file->dimension_, file->location_, (EngineType)file->engine_type_,
-                             (MetricType)file->metric_type_, json);
+                             (MetricType)file->metric_type_, json, 0);
 
     build_index_task.Execute();
 
     fiu_enable("XBuildIndexTask.Execute.build_index_fail", 1, NULL, 0);
     build_index_task.to_index_engine_ =
         EngineFactory::Build(file->dimension_, file->location_, (EngineType)file->engine_type_,
-                             (MetricType)file->metric_type_, json);
+                             (MetricType)file->metric_type_, json, 0);
     build_index_task.Execute();
     fiu_disable("XBuildIndexTask.Execute.build_index_fail");
 
@@ -115,20 +115,20 @@ TEST(TaskTest, TEST_TASK) {
     fiu_enable("XBuildIndexTask.Execute.has_collection", 1, NULL, 0);
     build_index_task.to_index_engine_ =
         EngineFactory::Build(file->dimension_, file->location_, (EngineType)file->engine_type_,
-                             (MetricType)file->metric_type_, json);
+                             (MetricType)file->metric_type_, json, 0);
     build_index_task.Execute();
 
     fiu_enable("XBuildIndexTask.Execute.throw_std_exception", 1, NULL, 0);
     build_index_task.to_index_engine_ =
         EngineFactory::Build(file->dimension_, file->location_, (EngineType)file->engine_type_,
-                             (MetricType)file->metric_type_, json);
+                             (MetricType)file->metric_type_, json, 0);
     build_index_task.Execute();
     fiu_disable("XBuildIndexTask.Execute.throw_std_exception");
 
     fiu_enable("XBuildIndexTask.Execute.update_table_file_fail", 1, NULL, 0);
     build_index_task.to_index_engine_ =
         EngineFactory::Build(file->dimension_, file->location_, (EngineType)file->engine_type_,
-                             (MetricType)file->metric_type_, json);
+                             (MetricType)file->metric_type_, json, 0);
     build_index_task.Execute();
     fiu_disable("XBuildIndexTask.Execute.update_table_file_fail");
 


### PR DESCRIPTION
(1) Add a timestamp to the blacklist and cache it.
(2) If timestamp mismatches, it will load `DeleteDocs` to regenerate it.
(3) Only `SearchTask` will load blacklist.
(4) Fix `BloomFilter` cache cleaning.

Resolves:  #4897, #4625

Signed-off-by: shengjun.li <shengjun.li@zilliz.com>
