### PR TITLE
Bugfix: fix local directory creating while using s3 storage. 

### DIFF
--- a/core/src/codecs/default/DefaultIdBloomFilterFormat.cpp
+++ b/core/src/codecs/default/DefaultIdBloomFilterFormat.cpp
@@ -114,7 +114,6 @@ DefaultIdBloomFilterFormat::write(const storage::FSHandlerPtr& fs_ptr,
     fs_ptr->writer_ptr_->write(&bloom_filter->bitmap->bytes, sizeof(bloom_filter->bitmap->bytes));
     fs_ptr->writer_ptr_->write(bloom_filter->bitmap->array, bloom_filter->bitmap->bytes);
     fs_ptr->writer_ptr_->close();
-    fs_ptr->operation_ptr_->CachePut(bloom_filter_file_path);
 }
 
 void

--- a/core/src/storage/disk/DiskOperation.cpp
+++ b/core/src/storage/disk/DiskOperation.cpp
@@ -35,8 +35,8 @@ DiskOperation::CreateDirectory() {
     bool is_dir = boost::filesystem::is_directory(dir_path_);
     fiu_do_on("DiskOperation.CreateDirectory.is_directory", is_dir = false);
     if (!is_dir) {
-        auto ret = boost::filesystem::create_directory(dir_path_);
-        fiu_do_on("DiskOperation.CreateDirectory.create_directory", ret = false);
+        auto ret = boost::filesystem::create_directories(dir_path_);
+        fiu_do_on("DiskOperation.CreateDirectory.create_directories", ret = false);
         if (!ret) {
             std::string err_msg = "Failed to create directory: " + dir_path_;
             LOG_ENGINE_ERROR_ << err_msg;

--- a/core/unittest/storage/test_disk.cpp
+++ b/core/unittest/storage/test_disk.cpp
@@ -69,9 +69,9 @@ TEST_F(StorageTest, DISK_OPERATION_TEST) {
 
     fiu_init(0);
     fiu_enable("DiskOperation.CreateDirectory.is_directory", 1, NULL, 0);
-    fiu_enable("DiskOperation.CreateDirectory.create_directory", 1, NULL, 0);
+    fiu_enable("DiskOperation.CreateDirectory.create_directories", 1, NULL, 0);
     ASSERT_ANY_THROW(disk_operation.CreateDirectory());
-    fiu_disable("DiskOperation.CreateDirectory.create_directory");
+    fiu_disable("DiskOperation.CreateDirectory.create_directories");
     fiu_disable("DiskOperation.CreateDirectory.is_directory");
 
     std::vector<std::string> file_paths;


### PR DESCRIPTION
- remove unneeded CachePut for bloom filter in s3 storage
- using create_directories instead of create_directory

Resolves: #5287 

Signed-off-by: Ji Bin <matrixji@live.com>

