### PR TITLE
Fix issue 5333 uninitialized return value

### DIFF
--- a/internal/datanode/flow_graph_insert_buffer_node.go
+++ b/internal/datanode/flow_graph_insert_buffer_node.go
@@ -793,6 +793,7 @@ func (ibNode *insertBufferNode) getCollMetabySegID(segmentID UniqueID) (meta *et
 	if err != nil {
 		return
 	}
+	meta = &etcdpb.CollectionMeta{}
 	meta.ID = ret.collectionID
 
 	coll, err := ibNode.replica.getCollectionByID(ret.collectionID)


### PR DESCRIPTION
Fix uninitialized named value `meta` caused crash

Resolves #5333 

Signed-off-by: Congqi Xia <congqi.xia@zilliz.com>
