### PR TITLE
Bugfix: increase offset after read in s3 IO reader.

### DIFF
--- a/core/src/storage/s3/S3IOReader.cpp
+++ b/core/src/storage/s3/S3IOReader.cpp
@@ -25,6 +25,7 @@ S3IOReader::open(const std::string& name) {
 void
 S3IOReader::read(void* ptr, int64_t size) {
     memcpy(ptr, buffer_.data() + pos_, size);
+    pos_ += size;
 }
 
 void


### PR DESCRIPTION
In S3IOReader::read, it not increase the `_pos` offset after reading, so the behavior is different from what the original DiskIOReader does.
And in our testing, we received an incorrect vector id in the search response from the read-only instance. As the [file-size unit] in the header of S3's object is read again while reading all ids. and it used as the first id of the current segment.

Resolves: #5390 #5356

Signed-off-by: Ji Bin <matrixji@live.com>
