### PR TITLE
storage: s3_address support domain/hostname.

### DIFF
--- a/core/src/config/Config.cpp
+++ b/core/src/config/Config.cpp
@@ -1297,7 +1297,7 @@ Config::CheckStorageConfigS3Enable(const std::string& value) {
 
 Status
 Config::CheckStorageConfigS3Address(const std::string& value) {
-    if (!ValidationUtil::ValidateIpAddress(value).ok()) {
+    if (!ValidationUtil::ValidateHostname(value).ok()) {
         std::string msg = "Invalid s3 address: " + value + ". Possible reason: storage_config.s3_address is invalid.";
         return Status(SERVER_INVALID_ARGUMENT, msg);
     }

--- a/core/src/utils/ValidationUtil.cpp
+++ b/core/src/utils/ValidationUtil.cpp
@@ -19,6 +19,7 @@
 #include "utils/StringHelpFunctions.h"
 
 #include <arpa/inet.h>
+#include <netdb.h>
 
 #ifdef MILVUS_GPU_VERSION
 
@@ -554,6 +555,18 @@ ValidationUtil::ValidateIpAddress(const std::string& ip_address) {
             return Status(SERVER_UNEXPECTED_ERROR, msg);
         }
     }
+}
+
+Status
+ValidationUtil::ValidateHostname(const std::string& hostname) {
+    struct hostent* hent = gethostbyname(hostname.c_str());
+    fiu_do_on("ValidationUtil.ValidateHostname.invalid_hostname", hent = nullptr);
+    if (!hent) {
+        std::string msg = "Unresolvable hostname: " + hostname;
+        LOG_SERVER_ERROR_ << msg;
+        return Status(SERVER_INVALID_ARGUMENT, msg);
+    }
+    return Status::OK();
 }
 
 Status

--- a/core/src/utils/ValidationUtil.h
+++ b/core/src/utils/ValidationUtil.h
@@ -81,6 +81,9 @@ class ValidationUtil {
     ValidateIpAddress(const std::string& ip_address);
 
     static Status
+    ValidateHostname(const std::string& hostname);
+
+    static Status
     ValidateStringIsNumber(const std::string& str);
 
     static Status

--- a/core/unittest/server/test_util.cpp
+++ b/core/unittest/server/test_util.cpp
@@ -745,6 +745,18 @@ TEST(ValidationUtilTest, VALIDATE_IPADDRESS_TEST) {
     fiu_disable("ValidationUtil.ValidateIpAddress.error_ip_result");
 }
 
+TEST(ValidationUtilTest, VALIDATE_HOSTNAME_TEST) {
+    ASSERT_EQ(milvus::server::ValidationUtil::ValidateHostname("127.0.0.1").code(), milvus::SERVER_SUCCESS);
+    ASSERT_EQ(milvus::server::ValidationUtil::ValidateHostname("localhost").code(), milvus::SERVER_SUCCESS);
+    ASSERT_EQ(milvus::server::ValidationUtil::ValidateHostname("192.168.100.100").code(), milvus::SERVER_SUCCESS);
+    ASSERT_NE(milvus::server::ValidationUtil::ValidateHostname("not a domain").code(), milvus::SERVER_SUCCESS);
+
+    fiu_init(0);
+    fiu_enable("ValidationUtil.ValidateHostname.invalid_hostname", 1, NULL, 0);
+    ASSERT_NE(milvus::server::ValidationUtil::ValidateIpAddress("not a hostname").code(), milvus::SERVER_SUCCESS);
+    fiu_disable("ValidationUtil.ValidateHostname.invalid_hostname");
+}
+
 TEST(ValidationUtilTest, VALIDATE_NUMBER_TEST) {
     ASSERT_EQ(milvus::server::ValidationUtil::ValidateStringIsNumber("1234").code(), milvus::SERVER_SUCCESS);
     ASSERT_NE(milvus::server::ValidationUtil::ValidateStringIsNumber("not number").code(), milvus::SERVER_SUCCESS);


### PR DESCRIPTION
In most cases, it is more appropriate to use the hostname or domain name
as the address of the S3 server.

Signed-off-by: Ji Bin <matrixji@live.com>
