### PR TITLE
Fix rocksmq seek error

### DIFF
--- a/internal/util/rocksmq/client/rocksmq/consumer_impl.go
+++ b/internal/util/rocksmq/client/rocksmq/consumer_impl.go
@@ -94,5 +94,10 @@ func (c *consumer) Chan() <-chan ConsumerMessage {
 }
 
 func (c *consumer) Seek(id UniqueID) error { //nolint:govet
-	return c.client.server.Seek(c.topic, c.consumerName, id)
+	err := c.client.server.Seek(c.topic, c.consumerName, id)
+	if err != nil {
+		return err
+	}
+	c.client.server.Notify(c.topic, c.consumerName)
+	return nil
 }

--- a/internal/util/rocksmq/server/rocksmq/rocksmq.go
+++ b/internal/util/rocksmq/server/rocksmq/rocksmq.go
@@ -38,4 +38,6 @@ type RocksMQ interface {
 	Consume(topicName string, groupName string, n int) ([]ConsumerMessage, error)
 	Seek(topicName string, groupName string, msgID UniqueID) error
 	ExistConsumerGroup(topicName string, groupName string) (bool, *Consumer)
+
+	Notify(topicName, groupName string)
 }

--- a/internal/util/rocksmq/server/rocksmq/rocksmq_impl.go
+++ b/internal/util/rocksmq/server/rocksmq/rocksmq_impl.go
@@ -400,3 +400,18 @@ func (rmq *rocksmq) Seek(topicName string, groupName string, msgID UniqueID) err
 
 	return nil
 }
+
+func (rmq *rocksmq) Notify(topicName, groupName string) {
+	if vals, ok := rmq.consumers.Load(topicName); ok {
+		for _, v := range vals.([]*Consumer) {
+			if v.GroupName == groupName {
+				select {
+				case v.MsgMutex <- struct{}{}:
+					continue
+				default:
+					continue
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Signed-off-by: fishpenguin <kun.yu@zilliz.com>

In milvus-standalone, when seek is called, rocksmq won't put a
mutex in MsgMutex channel, which cause that the consume
process hang. So the seek function in rocksmq needs to 
notify the consumer to consume.
