### PR TITLE
storage: enableing compile with aws sdk by default.

### DIFF
--- a/core/build.sh
+++ b/core/build.sh
@@ -16,9 +16,8 @@ WITH_MKL="OFF"
 WITH_PROMETHEUS="ON"
 FIU_ENABLE="OFF"
 BUILD_OPENBLAS="ON"
-WITH_AWS="OFF"
 
-while getopts "p:d:t:f:ulrcgahzmeis" arg; do
+while getopts "p:d:t:f:ulrcgahzmei" arg; do
   case $arg in
   p)
     INSTALL_PREFIX=$OPTARG
@@ -63,9 +62,6 @@ while getopts "p:d:t:f:ulrcgahzmeis" arg; do
   a)
     FPGA_VERSION="ON"
     ;;
-  s)
-    WITH_AWS="ON"
-    ;;
   h) # help
     echo "
 
@@ -83,11 +79,10 @@ parameter:
 -e: build without prometheus(default: OFF)
 -i: build FIU_ENABLE(default: OFF)
 -a: build FPGA(default: OFF)
--s: build with AWS S3(default: OFF)
 -h: help
 
 usage:
-./build.sh -p \${INSTALL_PREFIX} -t \${BUILD_TYPE} [-u] [-l] [-r] [-c] [-z] [-g] [-a] [-m] [-e] [-s] [-h]
+./build.sh -p \${INSTALL_PREFIX} -t \${BUILD_TYPE} [-u] [-l] [-r] [-c] [-z] [-g] [-a] [-m] [-e] [-h]
                 "
     exit 0
     ;;
@@ -122,7 +117,6 @@ CMAKE_CMD="cmake \
 -DFAISS_WITH_MKL=${WITH_MKL} \
 -DMILVUS_WITH_PROMETHEUS=${WITH_PROMETHEUS} \
 -DMILVUS_WITH_FIU=${FIU_ENABLE} \
--DMILVUS_WITH_AWS=${WITH_AWS} \
 ../"
 echo ${CMAKE_CMD}
 ${CMAKE_CMD}

--- a/core/cmake/DefineOptions.cmake
+++ b/core/cmake/DefineOptions.cmake
@@ -86,7 +86,7 @@ define_option(MILVUS_WITH_OPENTRACING "Build with Opentracing" ON)
 
 define_option(MILVUS_WITH_FIU "Build with fiu" OFF)
 
-define_option(MILVUS_WITH_AWS "Build with aws" OFF)
+define_option(MILVUS_WITH_AWS "Build with aws" ON)
 
 define_option(MILVUS_WITH_OATPP "Build with oatpp" ON)
 

--- a/core/conf/demo/server_config.yaml
+++ b/core/conf/demo/server_config.yaml
@@ -64,9 +64,24 @@ network:
 #                      | flushes data to disk.                                      |            |                 |
 #                      | 0 means disable the regular flush.                         |            |                 |
 #----------------------+------------------------------------------------------------+------------+-----------------+
+# s3_enabled           | If using s3 storage backend.                               | Boolean    | false           |
+#----------------------+------------------------------------------------------------+------------+-----------------+
+# s3_address           | The s3 server address, support domain/hostname/ipaddress   | String     | 127.0.0.1       |
+#----------------------+------------------------------------------------------------+------------+-----------------+
+# s3_port              | The s3 server port.                                        | Integer    | 80              |
+#----------------------+------------------------------------------------------------+------------+-----------------+
+# s3_access_key        | The access key for accessing s3 service.                   | String     | s3_access_key   |
+#----------------------+------------------------------------------------------------+------------+-----------------+
+# s3_secret_key        | The secrey key for accessing s3 service.                   | String     | s3_secret_key   |
+#----------------------+------------------------------------------------------------+------------+-----------------+
+# s3_bucket            | The s3 bucket name for store milvus's data.                | String     | s3_bucket       |
+#                      | Note: please using differnet bucket for different milvus   |            |                 |
+#                      |       cluster.                                             |            |                 |
+#----------------------+------------------------------------------------------------+------------+-----------------+
 storage:
   path: /var/lib/milvus
   auto_flush_interval: 1
+
 
 #----------------------+------------------------------------------------------------+------------+-----------------+
 # WAL Config           | Description                                                | Type       | Default         |

--- a/shards/all_in_one/ro_server.yml
+++ b/shards/all_in_one/ro_server.yml
@@ -64,6 +64,20 @@ network:
 #                      | flushes data to disk.                                      |            |                 |
 #                      | 0 means disable the regular flush.                         |            |                 |
 #----------------------+------------------------------------------------------------+------------+-----------------+
+# s3_enabled           | If using s3 storage backend.                               | Boolean    | false           |
+#----------------------+------------------------------------------------------------+------------+-----------------+
+# s3_address           | The s3 server address, support domain/hostname/ipaddress   | String     | 127.0.0.1       |
+#----------------------+------------------------------------------------------------+------------+-----------------+
+# s3_port              | The s3 server port.                                        | Integer    | 80              |
+#----------------------+------------------------------------------------------------+------------+-----------------+
+# s3_access_key        | The access key for accessing s3 service.                   | String     | s3_access_key   |
+#----------------------+------------------------------------------------------------+------------+-----------------+
+# s3_secret_key        | The secrey key for accessing s3 service.                   | String     | s3_secret_key   |
+#----------------------+------------------------------------------------------------+------------+-----------------+
+# s3_bucket            | The s3 bucket name for store milvus's data.                | String     | s3_bucket       |
+#                      | Note: please using differnet bucket for different milvus   |            |                 |
+#                      |       cluster.                                             |            |                 |
+#----------------------+------------------------------------------------------------+------------+-----------------+
 storage:
   path: /var/lib/milvus
   auto_flush_interval: 1

--- a/shards/all_in_one/wr_server.yml
+++ b/shards/all_in_one/wr_server.yml
@@ -64,6 +64,20 @@ network:
 #                      | flushes data to disk.                                      |            |                 |
 #                      | 0 means disable the regular flush.                         |            |                 |
 #----------------------+------------------------------------------------------------+------------+-----------------+
+# s3_enabled           | If using s3 storage backend.                               | Boolean    | false           |
+#----------------------+------------------------------------------------------------+------------+-----------------+
+# s3_address           | The s3 server address, support domain/hostname/ipaddress   | String     | 127.0.0.1       |
+#----------------------+------------------------------------------------------------+------------+-----------------+
+# s3_port              | The s3 server port.                                        | Integer    | 80              |
+#----------------------+------------------------------------------------------------+------------+-----------------+
+# s3_access_key        | The access key for accessing s3 service.                   | String     | s3_access_key   |
+#----------------------+------------------------------------------------------------+------------+-----------------+
+# s3_secret_key        | The secrey key for accessing s3 service.                   | String     | s3_secret_key   |
+#----------------------+------------------------------------------------------------+------------+-----------------+
+# s3_bucket            | The s3 bucket name for store milvus's data.                | String     | s3_bucket       |
+#                      | Note: please using differnet bucket for different milvus   |            |                 |
+#                      |       cluster.                                             |            |                 |
+#----------------------+------------------------------------------------------------+------------+-----------------+
 storage:
   path: /var/lib/milvus
   auto_flush_interval: 1

--- a/shards/all_in_one_with_mysql/ro_server.yml
+++ b/shards/all_in_one_with_mysql/ro_server.yml
@@ -64,6 +64,19 @@ network:
 #                      | flushes data to disk.                                      |            |                 |
 #                      | 0 means disable the regular flush.                         |            |                 |
 #----------------------+------------------------------------------------------------+------------+-----------------+
+# s3_enabled           | If using s3 storage backend.                               | Boolean    | false           |
+#----------------------+------------------------------------------------------------+------------+-----------------+
+# s3_address           | The s3 server address, support domain/hostname/ipaddress   | String     | 127.0.0.1       |
+#----------------------+------------------------------------------------------------+------------+-----------------+
+# s3_port              | The s3 server port.                                        | Integer    | 80              |
+#----------------------+------------------------------------------------------------+------------+-----------------+
+# s3_access_key        | The access key for accessing s3 service.                   | String     | s3_access_key   |
+#----------------------+------------------------------------------------------------+------------+-----------------+
+# s3_secret_key        | The secrey key for accessing s3 service.                   | String     | s3_secret_key   |
+#----------------------+------------------------------------------------------------+------------+-----------------+
+# s3_bucket            | The s3 bucket name for store milvus's data.                | String     | s3_bucket       |
+#                      | Note: please using differnet bucket for different milvus   |            |                 |
+#----------------------+------------------------------------------------------------+------------+-----------------+
 storage:
   path: /var/lib/milvus
   auto_flush_interval: 1

--- a/shards/all_in_one_with_mysql/wr_server.yml
+++ b/shards/all_in_one_with_mysql/wr_server.yml
@@ -68,6 +68,19 @@ network:
 #                      | delete unused segment file from disk after it was marked   |            |                 |
 #                      | as soft-delete state.(this is a hidden config)             |            |                 |
 #----------------------+------------------------------------------------------------+------------+-----------------+
+# s3_enabled           | If using s3 storage backend.                               | Boolean    | false           |
+#----------------------+------------------------------------------------------------+------------+-----------------+
+# s3_address           | The s3 server address, support domain/hostname/ipaddress   | String     | 127.0.0.1       |
+#----------------------+------------------------------------------------------------+------------+-----------------+
+# s3_port              | The s3 server port.                                        | Integer    | 80              |
+#----------------------+------------------------------------------------------------+------------+-----------------+
+# s3_access_key        | The access key for accessing s3 service.                   | String     | s3_access_key   |
+#----------------------+------------------------------------------------------------+------------+-----------------+
+# s3_secret_key        | The secrey key for accessing s3 service.                   | String     | s3_secret_key   |
+#----------------------+------------------------------------------------------------+------------+-----------------+
+# s3_bucket            | The s3 bucket name for store milvus's data.                | String     | s3_bucket       |
+#                      | Note: please using differnet bucket for different milvus   |            |                 |
+#----------------------+------------------------------------------------------------+------------+-----------------+
 storage:
   path: /var/lib/milvus
   auto_flush_interval: 1


### PR DESCRIPTION
* enabling compile with AWS by default
* add s3 related configure item's description in servier_config
* part of #5335

Resolves: #5335
See also: #5335

Signed-off-by: Ji Bin <matrixji@live.com>
