### PR TITLE
IVF_SQ8 and IVF_PQ cannot be built on multiple GPUs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ Please mark all change in change log and use the issue from GitHub
 -   \#4897 Query results contain some deleted ids
 -   \#5164 Exception should be raised if insert or delete entity on the none-existed partition
 -   \#5191 Mishards throw "index out of range" error after continually search/insert for a period of time
+-   \#5574 IVF_SQ8 and IVF_PQ cannot be built on multiple GPUs
 
 ## Feature
 
 ## Improvement
--   \#5161 Enable Gpu cache
+-   \#5142 Enable Gpu cache
 -   \#5204 Improve IVF query on GPU when no entity deleted
 
 ## Task

--- a/core/src/index/knowhere/knowhere/index/vector_index/gpu/IndexGPUIVF.cpp
+++ b/core/src/index/knowhere/knowhere/index/vector_index/gpu/IndexGPUIVF.cpp
@@ -38,7 +38,7 @@ GPUIVF::Train(const DatasetPtr& dataset_ptr, const Config& config) {
     if (gpu_res != nullptr) {
         ResScope rs(gpu_res, gpu_id_, true);
         faiss::gpu::GpuIndexIVFFlatConfig idx_config;
-        idx_config.device = gpu_id_;
+        idx_config.device = static_cast<int32_t>(gpu_id_);
         int32_t nlist = config[IndexParams::nlist];
         faiss::MetricType metric_type = GetMetricType(config[Metric::TYPE].get<std::string>());
         auto device_index =


### PR DESCRIPTION
The device id was not specified when the GPU index was created.

Resolves: #5574

Signed-off-by: shengjun.li <shengjun.li@zilliz.com>
