### PR TITLE
Support master get segment info channel name from config file

### DIFF
--- a/internal/distributed/masterservice/server.go
+++ b/internal/distributed/masterservice/server.go
@@ -108,9 +108,6 @@ func (s *Server) setClient() {
 		if err := dsClient.Start(); err != nil {
 			panic(err)
 		}
-		if err := funcutil.WaitForComponentInitOrHealthy(ctx, dsClient, "DataService", 1000000, 200*time.Millisecond); err != nil {
-			panic(err)
-		}
 		return dsClient
 	}
 	s.newIndexServiceClient = func(s, metaRootPath, etcdAddress string, timeout time.Duration) types.IndexService {

--- a/internal/masterservice/master_service.go
+++ b/internal/masterservice/master_service.go
@@ -709,10 +709,6 @@ func (c *Core) setMsgStreams() error {
 		}
 	}()
 
-	if Params.DataServiceSegmentChannel == "" {
-		return fmt.Errorf("DataServiceSegmentChannel is empty")
-	}
-
 	// data service will put msg into this channel when create segment
 	dsChanName := Params.DataServiceSegmentChannel
 	dsSubName := Params.MsgChannelSubName + "ds"
@@ -755,13 +751,6 @@ func (c *Core) SetNewProxyClient(f func(sess *sessionutil.Session) (types.ProxyN
 }
 
 func (c *Core) SetDataService(ctx context.Context, s types.DataService) error {
-	rsp, err := s.GetSegmentInfoChannel(ctx)
-	if err != nil {
-		return err
-	}
-	Params.DataServiceSegmentChannel = rsp.Value
-	log.Debug("data service segment", zap.String("channel name", Params.DataServiceSegmentChannel))
-
 	c.CallGetBinlogFilePathsService = func(segID typeutil.UniqueID, fieldID typeutil.UniqueID) (retFiles []string, retErr error) {
 		defer func() {
 			if err := recover(); err != nil {

--- a/internal/masterservice/param_table.go
+++ b/internal/masterservice/param_table.go
@@ -38,7 +38,7 @@ type ParamTable struct {
 	TimeTickChannel           string
 	DdChannel                 string
 	StatisticsChannel         string
-	DataServiceSegmentChannel string // get from data service, data service create segment, or data node flush segment
+	DataServiceSegmentChannel string // data service create segment, or data node flush segment
 
 	MaxPartitionNum             int64
 	DefaultPartitionName        string
@@ -71,6 +71,7 @@ func (p *ParamTable) Init() {
 		p.initTimeTickChannel()
 		p.initDdChannelName()
 		p.initStatisticsChannelName()
+		p.initSegmentInfoChannelName()
 
 		p.initMaxPartitionNum()
 		p.initMinSegmentSizeToEnableIndex()
@@ -155,6 +156,14 @@ func (p *ParamTable) initStatisticsChannelName() {
 		panic(err)
 	}
 	p.StatisticsChannel = channel
+}
+
+func (p *ParamTable) initSegmentInfoChannelName() {
+	channel, err := p.Load("msgChannel.chanNamePrefix.dataServiceSegmentInfo")
+	if err != nil {
+		panic(err)
+	}
+	p.DataServiceSegmentChannel = channel
 }
 
 func (p *ParamTable) initMaxPartitionNum() {


### PR DESCRIPTION
Support master get segment info channel name from config file
directly, instead of get from data service grpc.

Resolves: #5602 

Signed-off-by: yudong.cai <yudong.cai@zilliz.com>