### PR TITLE
index created by std::make_shared

### DIFF
--- a/core/src/index/knowhere/knowhere/index/vector_index/gpu/IndexGPUIVF.cpp
+++ b/core/src/index/knowhere/knowhere/index/vector_index/gpu/IndexGPUIVF.cpp
@@ -41,11 +41,9 @@ GPUIVF::Train(const DatasetPtr& dataset_ptr, const Config& config) {
         idx_config.device = static_cast<int32_t>(gpu_id_);
         int32_t nlist = config[IndexParams::nlist];
         faiss::MetricType metric_type = GetMetricType(config[Metric::TYPE].get<std::string>());
-        auto device_index =
-            new faiss::gpu::GpuIndexIVFFlat(gpu_res->faiss_res.get(), dim, nlist, metric_type, idx_config);
-        device_index->train(rows, (float*)p_data);
-
-        index_.reset(device_index);
+        index_ = std::make_shared<faiss::gpu::GpuIndexIVFFlat>(gpu_res->faiss_res.get(), dim, nlist, metric_type,
+                                                               idx_config);
+        index_->train(rows, (float*)p_data);
         res_ = gpu_res;
     } else {
         KNOWHERE_THROW_MSG("Build IVF can't get gpu resource");

--- a/core/src/index/knowhere/knowhere/index/vector_index/gpu/IndexGPUIVFPQ.cpp
+++ b/core/src/index/knowhere/knowhere/index/vector_index/gpu/IndexGPUIVFPQ.cpp
@@ -38,10 +38,9 @@ GPUIVFPQ::Train(const DatasetPtr& dataset_ptr, const Config& config) {
         int32_t m = config[IndexParams::m];
         int32_t nbits = config[IndexParams::nbits];
         faiss::MetricType metric_type = GetMetricType(config[Metric::TYPE].get<std::string>());
-        auto device_index =
-            new faiss::gpu::GpuIndexIVFPQ(gpu_res->faiss_res.get(), dim, nlist, m, nbits, metric_type, idx_config);
-        device_index->train(rows, (float*)p_data);
-        index_.reset(device_index);
+        index_ = std::make_shared<faiss::gpu::GpuIndexIVFPQ>(gpu_res->faiss_res.get(), dim, nlist, m, nbits,
+                                                             metric_type, idx_config);
+        index_->train(rows, (float*)p_data);
         res_ = gpu_res;
     } else {
         KNOWHERE_THROW_MSG("Build IVFPQ can't get gpu resource");

--- a/core/src/index/knowhere/knowhere/index/vector_index/gpu/IndexGPUIVFSQ.cpp
+++ b/core/src/index/knowhere/knowhere/index/vector_index/gpu/IndexGPUIVFSQ.cpp
@@ -36,10 +36,9 @@ GPUIVFSQ::Train(const DatasetPtr& dataset_ptr, const Config& config) {
         idx_config.device = static_cast<int32_t>(gpu_id_);
         int32_t nlist = config[IndexParams::nlist];
         faiss::MetricType metric_type = GetMetricType(config[Metric::TYPE].get<std::string>());
-        auto device_index = new faiss::gpu::GpuIndexIVFScalarQuantizer(
+        index_ = std::make_shared<faiss::gpu::GpuIndexIVFScalarQuantizer>(
             gpu_res->faiss_res.get(), dim, nlist, faiss::QuantizerType::QT_8bit, metric_type, true, idx_config);
-        device_index->train(rows, (float*)p_data);
-        index_.reset(device_index);
+        index_->train(rows, (float*)p_data);
         res_ = gpu_res;
     } else {
         KNOWHERE_THROW_MSG("Build IVFSQ can't get gpu resource");


### PR DESCRIPTION
Exception thrown from `device_index->train` will cause
`device_index` memory leak.
So, objects created by `std::make_shared` now.

Signed-off-by: shengjun.li <shengjun.li@zilliz.com>
