### PR TITLE
Fix unit test in dataservice

### DIFF
--- a/internal/dataservice/server_test.go
+++ b/internal/dataservice/server_test.go
@@ -13,8 +13,11 @@ import (
 	"context"
 	"math"
 	"path"
+	"strconv"
 	"testing"
 	"time"
+
+	"math/rand"
 
 	"github.com/milvus-io/milvus/internal/msgstream"
 	"github.com/milvus-io/milvus/internal/proto/commonpb"
@@ -831,6 +834,8 @@ func TestGetRecoveryInfo(t *testing.T) {
 
 func newTestServer(t *testing.T, receiveCh chan interface{}) *Server {
 	Params.Init()
+	Params.TimeTickChannelName += strconv.Itoa(rand.Int())
+	Params.StatisticsChannelName += strconv.Itoa(rand.Int())
 	var err error
 	factory := msgstream.NewPmsFactory()
 	m := map[string]interface{}{


### PR DESCRIPTION
After a unit test complete, the msg stream will be closed. But in pulsar go
client, the connection between client and server will be reconnected.
Then we rebuild the msgstream immediately and produce a message, this
message will be sent to the previous connection which cause timeout of
test. We append the channelName wil a random value.

Signed-off-by: sunby <bingyi.sun@zilliz.com>
