### PR TITLE
Fix query node crash when retrieved 0 result

### DIFF
--- a/internal/querynode/query_collection.go
+++ b/internal/querynode/query_collection.go
@@ -1286,6 +1286,14 @@ func mergeRetrieveResults(dataArr []*segcorepb.RetrieveResults) (*segcorepb.Retr
 		}
 	}
 
+	// not found, return default values indicating not result found
+	if final == nil {
+		final = &segcorepb.RetrieveResults{
+			Ids:        nil,
+			FieldsData: []*schemapb.FieldData{},
+		}
+	}
+
 	return final, nil
 }
 


### PR DESCRIPTION
Fix #6075

Fix query node crash when retrieve logic found 0 result

Signed-off-by: Congqi Xia <congqi.xia@zilliz.com>

