### PR TITLE
stop add new node into cluster before validated

### DIFF
--- a/internal/datacoord/cluster.go
+++ b/internal/datacoord/cluster.go
@@ -95,17 +95,18 @@ func newCluster(ctx context.Context, dataManager *clusterNodeManager,
 		assignPolicy:     defaultAssignPolicy(),
 	}
 
+	c.candidateManager = newCandidateManager(20, c.validateDataNode, c.enableDataNode)
+
 	for _, opt := range opts {
 		opt.apply(c)
 	}
 
-	c.candidateManager = newCandidateManager(20, c.validateDataNode, c.enableDataNode)
 	return c
 }
 
 // startup applies statup policy
 func (c *cluster) startup(dataNodes []*datapb.DataNodeInfo) error {
-	deltaChange := c.dataManager.updateCluster(dataNodes)
+	/*deltaChange := c.dataManager.updateCluster(dataNodes)
 	nodes, chanBuffer := c.dataManager.getDataNodes(false)
 	var rets []*datapb.DataNodeInfo
 	var err error
@@ -117,7 +118,8 @@ func (c *cluster) startup(dataNodes []*datapb.DataNodeInfo) error {
 		//does not trigger new another refresh, pending evt will do
 	}
 	c.dataManager.updateDataNodes(rets, chanBuffer)
-	return nil
+	return nil*/
+	return c.refresh(dataNodes)
 }
 
 // refresh rough refresh datanode status after event received

--- a/internal/datacoord/cluster.go
+++ b/internal/datacoord/cluster.go
@@ -150,8 +150,10 @@ func (c *cluster) refresh(dataNodes []*datapb.DataNodeInfo) error {
 			}
 		}
 	}
-	_, buffer := c.dataManager.getDataNodes(true)
-	c.updateNodeWatch(restartNodes, buffer)
+	if len(restartNodes) > 0 {
+		_, buffer := c.dataManager.getDataNodes(true)
+		c.updateNodeWatch(restartNodes, buffer)
+	}
 
 	// 3. offline do unregister
 	unregisterNodes := make([]*datapb.DataNodeInfo, 0, len(deltaChange.offlines)) // possible nodes info to unregister

--- a/internal/datacoord/cluster_data_manager.go
+++ b/internal/datacoord/cluster_data_manager.go
@@ -97,15 +97,6 @@ func (c *clusterNodeManager) updateCluster(dataNodes []*datapb.DataNodeInfo) *cl
 			continue
 		}
 
-		newNode := &dataNodeInfo{
-			info: &datapb.DataNodeInfo{
-				Address:  n.Address,
-				Version:  n.Version,
-				Channels: []*datapb.ChannelStatus{},
-			},
-			status: online,
-		}
-		c.dataNodes[n.Address] = newNode
 		newNodes = append(newNodes, n.Address)
 	}
 
@@ -166,6 +157,7 @@ func (c *clusterNodeManager) unregister(addr string) *datapb.DataNodeInfo {
 	if !ok {
 		return nil
 	}
+	delete(c.dataNodes, addr)
 	node.status = offline
 	c.updateMetrics()
 	return node.info


### PR DESCRIPTION
Stop adding new data nodes into cluster in updateCluster func

Should fix #5976 

Signed-off-by: Congqi Xia <congqi.xia@zilliz.com>
