### PR TITLE
Fix the case that KNNG is not full

### DIFF
--- a/internal/core/src/index/knowhere/knowhere/index/vector_offset_index/IndexNSG_NM.cpp
+++ b/internal/core/src/index/knowhere/knowhere/index/vector_offset_index/IndexNSG_NM.cpp
@@ -134,6 +134,12 @@ NSG_NM::BuildAll(const DatasetPtr& dataset_ptr, const Config& config) {
     preprocess_index->GenGraph(raw_data, k, knng, config);
 #endif
 
+    for (size_t i = 0; i < knng.size(); i++) {
+        while (knng[i].size() > 0 && knng[i].back() == -1) {
+            knng[i].resize(knng[i].size() - 1);
+        }
+    }
+
     impl::BuildParams b_params;
     b_params.candidate_pool_size = config[IndexParams::candidate];
     b_params.out_degree = config[IndexParams::out_degree];


### PR DESCRIPTION
If the KNNG in NSG is not full, the server will crash.

Signed-off-by: shengjun.li <shengjun.li@zilliz.com>