### PR TITLE
Fixbug: remove wrong check code

### DIFF
--- a/internal/indexcoord/index_coord.go
+++ b/internal/indexcoord/index_coord.go
@@ -293,12 +293,6 @@ func (i *IndexCoord) BuildIndex(ctx context.Context, req *indexpb.BuildIndexRequ
 		kv:          i.kv,
 	}
 
-	if i.nodeClients == nil || i.nodeClients.Len() <= 0 {
-		ret.Status.Reason = "IndexBuilding Service not available"
-		return ret, nil
-	}
-	t.nodeClients = i.nodeClients
-
 	var cancel func()
 	t.ctx, cancel = context.WithTimeout(ctx, reqTimeoutInterval)
 	defer cancel()

--- a/internal/indexcoord/task.go
+++ b/internal/indexcoord/task.go
@@ -77,7 +77,6 @@ type IndexAddTask struct {
 	buildQueue        TaskQueue
 	kv                kv.BaseKV
 	builderClient     types.IndexNode
-	nodeClients       *PriorityQueue
 	buildClientNodeID UniqueID
 }
 


### PR DESCRIPTION
The code to check whether there is an IndexNode online should be deleted. It is not mandatory to have an IndexNode when building an index.

Resolves: #6345 

Signed-off-by: zhenshan.cao <zhenshan.cao@zilliz.com>
