### PR TITLE
Fix 6421, split raw vectors to serveral smaller one

### DIFF
--- a/internal/core/src/indexbuilder/IndexWrapper.h
+++ b/internal/core/src/indexbuilder/IndexWrapper.h
@@ -65,6 +65,9 @@ class IndexWrapper {
     knowhere::IndexMode
     get_index_mode();
 
+    int64_t
+    get_index_file_slice_size();
+
     template <typename T>
     std::optional<T>
     get_config_by_name(std::string name);


### PR DESCRIPTION
Signed-off-by: dragondriver <jiquan.long@zilliz.com>

Fix: #6421 