### PR TITLE
Fix a debug error in IDE

### DIFF
--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -188,7 +188,7 @@ func (m *meta) SaveBinlogAndCheckPoints(segID UniqueID, flushed bool,
 
 	for _, id := range modSegments {
 		if segment := m.segments.GetSegment(id); segment != nil {
-			segBytes := proto.MarshalTextString(segment)
+			segBytes := proto.MarshalTextString(segment.SegmentInfo)
 			key := buildSegmentPath(segment.GetCollectionID(), segment.GetPartitionID(), segment.GetID())
 			kv[key] = segBytes
 		}


### PR DESCRIPTION
Signed-off-by: yhmo <yihua.mo@zilliz.com>

Related issue: #6540

Root cause: the proto.MarshalTextString() doesn't allow non-proto object