### PR TITLE
Fix channel lost after data node crash

### DIFF
--- a/internal/datacoord/cluster_store.go
+++ b/internal/datacoord/cluster_store.go
@@ -29,7 +29,7 @@ type ClusterStore interface {
 }
 
 type NodeInfo struct {
-	info    *datapb.DataNodeInfo
+	Info    *datapb.DataNodeInfo
 	eventCh chan *NodeEvent
 	client  types.DataNode
 	ctx     context.Context
@@ -46,7 +46,7 @@ type NodeEvent struct {
 func NewNodeInfo(ctx context.Context, info *datapb.DataNodeInfo) *NodeInfo {
 	ctx, cancel := context.WithCancel(ctx)
 	return &NodeInfo{
-		info:    info,
+		Info:    info,
 		eventCh: make(chan *NodeEvent, eventChBuffer),
 		ctx:     ctx,
 		cancel:  cancel,
@@ -55,7 +55,7 @@ func NewNodeInfo(ctx context.Context, info *datapb.DataNodeInfo) *NodeInfo {
 
 func (n *NodeInfo) ShadowClone(opts ...NodeOpt) *NodeInfo {
 	cloned := &NodeInfo{
-		info:    n.info,
+		Info:    n.Info,
 		eventCh: n.eventCh,
 		client:  n.client,
 		ctx:     n.ctx,
@@ -68,9 +68,9 @@ func (n *NodeInfo) ShadowClone(opts ...NodeOpt) *NodeInfo {
 }
 
 func (n *NodeInfo) Clone(opts ...NodeOpt) *NodeInfo {
-	info := proto.Clone(n.info).(*datapb.DataNodeInfo)
+	info := proto.Clone(n.Info).(*datapb.DataNodeInfo)
 	cloned := &NodeInfo{
-		info:    info,
+		Info:    info,
 		eventCh: n.eventCh,
 		client:  n.client,
 		ctx:     n.ctx,
@@ -156,7 +156,7 @@ func SetWatched(channelsName []string) NodeOpt {
 		for _, channelName := range channelsName {
 			channelsMap[channelName] = struct{}{}
 		}
-		for _, ch := range n.info.Channels {
+		for _, ch := range n.Info.Channels {
 			_, ok := channelsMap[ch.GetName()]
 			if !ok {
 				continue
@@ -176,12 +176,12 @@ func SetClient(client types.DataNode) NodeOpt {
 
 func AddChannels(channels []*datapb.ChannelStatus) NodeOpt {
 	return func(n *NodeInfo) {
-		n.info.Channels = append(n.info.Channels, channels...)
+		n.Info.Channels = append(n.Info.Channels, channels...)
 	}
 }
 
 func SetChannels(channels []*datapb.ChannelStatus) NodeOpt {
 	return func(n *NodeInfo) {
-		n.info.Channels = channels
+		n.Info.Channels = channels
 	}
 }

--- a/internal/datacoord/policy.go
+++ b/internal/datacoord/policy.go
@@ -62,15 +62,12 @@ var emptyUnregisterFunc dataNodeUnregisterPolicy = func(cluster []*NodeInfo, ses
 var randomAssignRegisterFunc dataNodeUnregisterPolicy = func(cluster []*NodeInfo, session *NodeInfo) []*NodeInfo {
 	if len(cluster) == 0 || // no available node
 		session == nil ||
-		len(session.info.GetChannels()) == 0 { // lost node not watching any channels
+		len(session.Info.GetChannels()) == 0 { // lost node not watching any channels
 		return []*NodeInfo{}
 	}
 
-	appliedNodes := make([]*NodeInfo, 0, len(session.info.GetChannels()))
-	channels := session.info.GetChannels()
-	// clear unregistered node's channels
-	node := session.Clone(SetChannels(nil))
-	appliedNodes = append(appliedNodes, node)
+	appliedNodes := make([]*NodeInfo, 0, len(session.Info.GetChannels()))
+	channels := session.Info.GetChannels()
 
 	raResult := make(map[int][]*datapb.ChannelStatus)
 	for _, chanSt := range channels {
@@ -117,7 +114,7 @@ var assignAllFunc channelAssignPolicy = func(cluster []*NodeInfo, channel string
 	ret := make([]*NodeInfo, 0)
 	for _, node := range cluster {
 		has := false
-		for _, ch := range node.info.GetChannels() {
+		for _, ch := range node.Info.GetChannels() {
 			if ch.Name == channel {
 				has = true
 				break
@@ -145,7 +142,7 @@ var balancedAssignFunc channelAssignPolicy = func(cluster []*NodeInfo, channel s
 	}
 	// filter existed channel
 	for _, node := range cluster {
-		for _, c := range node.info.GetChannels() {
+		for _, c := range node.Info.GetChannels() {
 			if c.GetName() == channel && c.GetCollectionID() == collectionID {
 				return nil
 			}
@@ -153,9 +150,9 @@ var balancedAssignFunc channelAssignPolicy = func(cluster []*NodeInfo, channel s
 	}
 	target, min := -1, math.MaxInt32
 	for k, v := range cluster {
-		if len(v.info.GetChannels()) < min {
+		if len(v.Info.GetChannels()) < min {
 			target = k
-			min = len(v.info.GetChannels())
+			min = len(v.Info.GetChannels())
 		}
 	}
 

--- a/internal/datacoord/policy_test.go
+++ b/internal/datacoord/policy_test.go
@@ -51,21 +51,21 @@ func TestRandomReassign(t *testing.T) {
 		},
 	}
 	cases := []*NodeInfo{
-		{info: caseInfo1},
-		{info: caseInfo2},
+		{Info: caseInfo1},
+		{Info: caseInfo2},
 		nil,
 	}
 
 	for _, ca := range cases {
 		nodes := p(clusters, ca)
-		if ca == nil || len(ca.info.GetChannels()) == 0 {
+		if ca == nil || len(ca.Info.GetChannels()) == 0 {
 			assert.Equal(t, 0, len(nodes))
 		} else {
-			for _, ch := range ca.info.GetChannels() {
+			for _, ch := range ca.Info.GetChannels() {
 				found := false
 			loop:
 				for _, node := range nodes {
-					for _, nch := range node.info.GetChannels() {
+					for _, nch := range node.Info.GetChannels() {
 						if nch.Name == ch.Name {
 							found = true
 							assert.EqualValues(t, datapb.ChannelWatchState_Uncomplete, nch.State)


### PR DESCRIPTION
If we start up 2 data nodes and one of them crashes. We expect that all
channels of the crashed node will be allcoated to another node. But now we
discover that these channels are lost after data node crashes. The reason
is we pass a NodeInfo with empty channel info. We fix it and improve log
print.

issue: #6501
Signed-off-by: sunby <bingyi.sun@zilliz.com>