### PR TITLE
Fix datacoord_test.go failed

### DIFF
--- a/internal/datacoord/server.go
+++ b/internal/datacoord/server.go
@@ -90,8 +90,16 @@ type Server struct {
 	rootCoordClientCreator rootCoordCreatorFunc
 }
 
+type Option func(svr *Server)
+
+func SetRootCoordCreator(creator rootCoordCreatorFunc) Option {
+	return func(svr *Server) {
+		svr.rootCoordClientCreator = creator
+	}
+}
+
 // CreateServer create `Server` instance
-func CreateServer(ctx context.Context, factory msgstream.Factory) (*Server, error) {
+func CreateServer(ctx context.Context, factory msgstream.Factory, opts ...Option) (*Server, error) {
 	rand.Seed(time.Now().UnixNano())
 	s := &Server{
 		ctx:                    ctx,
@@ -99,6 +107,10 @@ func CreateServer(ctx context.Context, factory msgstream.Factory) (*Server, erro
 		flushCh:                make(chan UniqueID, 1024),
 		dataClientCreator:      defaultDataNodeCreatorFunc,
 		rootCoordClientCreator: defaultRootCoordCreatorFunc,
+	}
+
+	for _, opt := range opts {
+		opt(s)
 	}
 	return s, nil
 }

--- a/internal/distributed/datacoord/datacoord_test.go
+++ b/internal/distributed/datacoord/datacoord_test.go
@@ -17,6 +17,7 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/milvus-io/milvus/internal/datacoord"
 	"github.com/milvus-io/milvus/internal/msgstream"
 	"github.com/milvus-io/milvus/internal/proto/commonpb"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
@@ -81,18 +82,21 @@ func (m *mockRootCoord) ShowCollections(ctx context.Context, req *milvuspb.ShowC
 func TestRun(t *testing.T) {
 	ctx := context.Background()
 	msFactory := msgstream.NewPmsFactory()
-	dsServer, err := NewServer(ctx, msFactory)
+	var mockRootCoordCreator = func(ctx context.Context, metaRootPath string,
+		etcdEndpoints []string) (types.RootCoord, error) {
+		return &mockRootCoord{}, nil
+	}
+	dsServer, err := NewServer(ctx, msFactory, datacoord.SetRootCoordCreator(mockRootCoordCreator))
 	assert.Nil(t, err)
 
 	Params.Init()
-	Params.Port = 1000000
-	err = dsServer.Run()
-	assert.NotNil(t, err)
-	assert.EqualError(t, err, "listen tcp: address 1000000: invalid port")
-
 	Params.Port = rand.Int()%100 + 10000
 	err = dsServer.Run()
 	assert.Nil(t, err)
+	defer func() {
+		err = dsServer.Stop()
+		assert.Nil(t, err)
+	}()
 
 	t.Run("get component states", func(t *testing.T) {
 		req := &internalpb.GetComponentStatesRequest{}
@@ -161,7 +165,7 @@ func TestRun(t *testing.T) {
 		req := &datapb.GetPartitionStatisticsRequest{}
 		rsp, err := dsServer.GetPartitionStatistics(ctx, req)
 		assert.Nil(t, err)
-		assert.Nil(t, rsp)
+		assert.Equal(t, rsp.Status.ErrorCode, commonpb.ErrorCode_Success)
 	})
 
 	t.Run("get segment info channel", func(t *testing.T) {
@@ -171,6 +175,4 @@ func TestRun(t *testing.T) {
 		assert.Equal(t, rsp.Status.ErrorCode, commonpb.ErrorCode_Success)
 	})
 
-	err = dsServer.Stop()
-	assert.Nil(t, err)
 }


### PR DESCRIPTION
Create a mock rootcoord when testing datacoord to hide the network layer
issue: #6557
Signed-off-by: sunby <bingyi.sun@zilliz.com>