### PR TITLE
Fix proxy crashes when retrieve task is called

### DIFF
--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -1344,6 +1344,7 @@ func (node *Proxy) Retrieve(ctx context.Context, request *milvuspb.RetrieveReque
 		},
 		resultBuf: make(chan []*internalpb.RetrieveResults),
 		retrieve:  request,
+		chMgr:     node.chMgr,
 		qc:        node.queryCoord,
 	}
 


### PR DESCRIPTION
Fix proxy crashing when retrieve API is invoked

Fix: #6655 

Signed-off-by: Congqi Xia <congqi.xia@zilliz.com>
