### PR TITLE
Auto create new segments when inserting too much rows

### DIFF
--- a/internal/datacoord/grpc_services.go
+++ b/internal/datacoord/grpc_services.go
@@ -80,15 +80,6 @@ func (s *Server) AssignSegmentID(ctx context.Context, req *datapb.AssignSegmentI
 
 	assigns := make([]*datapb.SegmentIDAssignment, 0, len(req.SegmentIDRequests))
 
-	var appendFailedAssignment = func(err string) {
-		assigns = append(assigns, &datapb.SegmentIDAssignment{
-			Status: &commonpb.Status{
-				ErrorCode: commonpb.ErrorCode_UnexpectedError,
-				Reason:    err,
-			},
-		})
-	}
-
 	for _, r := range req.SegmentIDRequests {
 		log.Debug("Handle assign segment request",
 			zap.Int64("collectionID", r.GetCollectionID()),
@@ -98,46 +89,39 @@ func (s *Server) AssignSegmentID(ctx context.Context, req *datapb.AssignSegmentI
 
 		if coll := s.meta.GetCollection(r.CollectionID); coll == nil {
 			if err := s.loadCollectionFromRootCoord(ctx, r.CollectionID); err != nil {
-				errMsg := fmt.Sprintf("Can not load collection %d", r.CollectionID)
-				appendFailedAssignment(errMsg)
 				log.Error("load collection from rootcoord error",
 					zap.Int64("collectionID", r.CollectionID),
 					zap.Error(err))
 				continue
 			}
 		}
-		//if err := s.validateAllocRequest(r.CollectionID, r.PartitionID, r.ChannelName); err != nil {
-		//result.Status.Reason = err.Error()
-		//assigns = append(assigns, result)
-		//continue
-		//}
+
 		s.cluster.Watch(r.ChannelName, r.CollectionID)
 
-		segmentID, retCount, expireTs, err := s.segmentManager.AllocSegment(ctx,
+		allocations, err := s.segmentManager.AllocSegment(ctx,
 			r.CollectionID, r.PartitionID, r.ChannelName, int64(r.Count))
 		if err != nil {
-			errMsg := fmt.Sprintf("Allocation of collection %d, partition %d, channel %s, count %d error:  %s",
-				r.CollectionID, r.PartitionID, r.ChannelName, r.Count, err.Error())
-			appendFailedAssignment(errMsg)
+			log.Warn("failed to alloc segment", zap.Any("request", r), zap.Error(err))
 			continue
 		}
 
-		log.Debug("Assign segment success", zap.Int64("segmentID", segmentID),
-			zap.Uint64("expireTs", expireTs))
+		log.Debug("Assign segment success", zap.Any("assignments", allocations))
 
-		result := &datapb.SegmentIDAssignment{
-			SegID:        segmentID,
-			ChannelName:  r.ChannelName,
-			Count:        uint32(retCount),
-			CollectionID: r.CollectionID,
-			PartitionID:  r.PartitionID,
-			ExpireTime:   expireTs,
-			Status: &commonpb.Status{
-				ErrorCode: commonpb.ErrorCode_Success,
-				Reason:    "",
-			},
+		for _, allocation := range allocations {
+			result := &datapb.SegmentIDAssignment{
+				SegID:        allocation.SegmentID,
+				ChannelName:  r.ChannelName,
+				Count:        uint32(allocation.NumOfRows),
+				CollectionID: r.CollectionID,
+				PartitionID:  r.PartitionID,
+				ExpireTime:   allocation.ExpireTime,
+				Status: &commonpb.Status{
+					ErrorCode: commonpb.ErrorCode_Success,
+					Reason:    "",
+				},
+			}
+			assigns = append(assigns, result)
 		}
-		assigns = append(assigns, result)
 	}
 	return &datapb.AssignSegmentIDResponse{
 		Status: &commonpb.Status{

--- a/internal/datacoord/segment_info.go
+++ b/internal/datacoord/segment_info.go
@@ -168,7 +168,7 @@ func SetAllocations(allocations []*Allocation) SegmentInfoOption {
 func AddAllocation(allocation *Allocation) SegmentInfoOption {
 	return func(segment *SegmentInfo) {
 		segment.allocations = append(segment.allocations, allocation)
-		segment.LastExpireTime = allocation.expireTime
+		segment.LastExpireTime = allocation.ExpireTime
 	}
 }
 

--- a/internal/datacoord/segment_manager.go
+++ b/internal/datacoord/segment_manager.go
@@ -29,14 +29,10 @@ import (
 	"github.com/milvus-io/milvus/internal/proto/datapb"
 )
 
-var errRemainInSufficient = func(requestRows int64) error {
-	return fmt.Errorf("segment remaining is insufficient for %d", requestRows)
-}
-
 // Manager manage segment related operations.
 type Manager interface {
 	// AllocSegment allocate rows and record the allocation.
-	AllocSegment(ctx context.Context, collectionID, partitionID UniqueID, channelName string, requestRows int64) (UniqueID, int64, Timestamp, error)
+	AllocSegment(ctx context.Context, collectionID, partitionID UniqueID, channelName string, requestRows int64) ([]*Allocation, error)
 	// DropSegment drop the segment from allocator.
 	DropSegment(ctx context.Context, segmentID UniqueID)
 	// SealAllSegments sealed all segmetns of collection with collectionID and return sealed segments
@@ -49,8 +45,9 @@ type Manager interface {
 
 // allcation entry for segment Allocation record
 type Allocation struct {
-	numOfRows  int64
-	expireTime Timestamp
+	SegmentID  UniqueID
+	NumOfRows  int64
+	ExpireTime Timestamp
 }
 
 // SegmentManager handles segment related logic
@@ -61,7 +58,7 @@ type SegmentManager struct {
 	helper              allocHelper
 	segments            []UniqueID
 	estimatePolicy      calUpperLimitPolicy
-	allocPolicy         allocatePolicy
+	allocPolicy         AllocatePolicy
 	segmentSealPolicies []segmentSealPolicy
 	channelSealPolicies []channelSealPolicy
 	flushPolicy         flushPolicy
@@ -103,7 +100,7 @@ func withCalUpperLimitPolicy(policy calUpperLimitPolicy) allocOption {
 }
 
 // get allocOption with allocPolicy
-func withAllocPolicy(policy allocatePolicy) allocOption {
+func withAllocPolicy(policy AllocatePolicy) allocOption {
 	return allocFunc(func(manager *SegmentManager) { manager.allocPolicy = policy })
 }
 
@@ -132,8 +129,8 @@ func defaultCalUpperLimitPolicy() calUpperLimitPolicy {
 	return calBySchemaPolicy
 }
 
-func defaultAlocatePolicy() allocatePolicy {
-	return allocatePolicyV1
+func defaultAlocatePolicy() AllocatePolicy {
+	return AllocatePolicyV1
 }
 
 func defaultSealPolicy() sealPolicy {
@@ -188,14 +185,14 @@ func (s *SegmentManager) getAllocation(numOfRows int64) *Allocation {
 	v := s.allocPool.Get()
 	if v == nil {
 		return &Allocation{
-			numOfRows: numOfRows,
+			NumOfRows: numOfRows,
 		}
 	}
 	a, ok := v.(*Allocation)
 	if !ok {
 		a = &Allocation{}
 	}
-	a.numOfRows = numOfRows
+	a.NumOfRows = numOfRows
 	return a
 }
 
@@ -206,79 +203,61 @@ func (s *SegmentManager) putAllocation(a *Allocation) {
 
 // AllocSegment allocate segment per request collcation, partication, channel and rows
 func (s *SegmentManager) AllocSegment(ctx context.Context, collectionID UniqueID,
-	partitionID UniqueID, channelName string, requestRows int64) (segID UniqueID, retCount int64, expireTime Timestamp, err error) {
+	partitionID UniqueID, channelName string, requestRows int64) ([]*Allocation, error) {
 	sp, _ := trace.StartSpanFromContext(ctx)
 	defer sp.Finish()
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	var segment *SegmentInfo
-	var allocation *Allocation
+	// filter segments
+	segments := make([]*SegmentInfo, 0)
 	for _, segmentID := range s.segments {
-		segment = s.meta.GetSegment(segmentID)
+		segment := s.meta.GetSegment(segmentID)
 		if segment == nil {
-			log.Warn("Failed to get seginfo from meta", zap.Int64("id", segmentID), zap.Error(err))
+			log.Warn("Failed to get seginfo from meta", zap.Int64("id", segmentID))
 			continue
 		}
 		if segment.State == commonpb.SegmentState_Sealed || segment.CollectionID != collectionID ||
 			segment.PartitionID != partitionID || segment.InsertChannel != channelName {
 			continue
 		}
-		allocation, err = s.alloc(segment, requestRows)
-		if err != nil {
-			return
-		}
-		if allocation != nil {
-			break
-		}
+		segments = append(segments, segment)
 	}
 
-	if allocation == nil {
-		segment, err = s.openNewSegment(ctx, collectionID, partitionID, channelName)
-		if err != nil {
-			return
-		}
-		segment = s.meta.GetSegment(segment.GetID())
-		if segment == nil {
-			log.Warn("Failed to get seg into from meta", zap.Int64("id", segment.GetID()), zap.Error(err))
-			return
-		}
-		allocation, err = s.alloc(segment, requestRows)
-		if err != nil {
-			return
-		}
-		if allocation == nil {
-			err = errRemainInSufficient(requestRows)
-			return
-		}
+	// apply allocate policy
+	maxCountPerSegment, err := s.estimateMaxNumOfRows(collectionID)
+	if err != nil {
+		return nil, err
 	}
+	newSegmentAllocations, existedSegmentAllocations := s.allocPolicy(segments,
+		requestRows, int64(maxCountPerSegment))
 
-	segID = segment.GetID()
-	retCount = allocation.numOfRows
-	expireTime = allocation.expireTime
-	return
-}
-
-func (s *SegmentManager) alloc(segment *SegmentInfo, numOfRows int64) (*Allocation, error) {
-	var allocSize int64
-	for _, allocItem := range segment.allocations {
-		allocSize += allocItem.numOfRows
-	}
-
-	if !s.allocPolicy(segment, numOfRows) {
-		return nil, nil
-	}
-
-	alloc := s.getAllocation(numOfRows)
+	// create new segments and add allocations
 	expireTs, err := s.genExpireTs()
 	if err != nil {
 		return nil, err
 	}
-	alloc.expireTime = expireTs
+	for _, allocation := range newSegmentAllocations {
+		segment, err := s.openNewSegment(ctx, collectionID, partitionID, channelName)
+		if err != nil {
+			return nil, err
+		}
+		allocation.ExpireTime = expireTs
+		allocation.SegmentID = segment.GetID()
+		if err := s.meta.AddAllocation(segment.GetID(), allocation); err != nil {
+			return nil, err
+		}
+	}
 
-	//safe here since info is a clone, used to pass expireTs out
-	s.meta.AddAllocation(segment.GetID(), alloc)
-	return alloc, nil
+	for _, allocation := range existedSegmentAllocations {
+		allocation.ExpireTime = expireTs
+		if err := s.meta.AddAllocation(allocation.SegmentID, allocation); err != nil {
+			return nil, err
+		}
+	}
+
+	allocations := append(newSegmentAllocations, existedSegmentAllocations...)
+	return allocations, nil
 }
 
 func (s *SegmentManager) genExpireTs() (Timestamp, error) {
@@ -425,7 +404,7 @@ func (s *SegmentManager) ExpireAllocations(channel string, ts Timestamp) error {
 			continue
 		}
 		for i := 0; i < len(segment.allocations); i++ {
-			if segment.allocations[i].expireTime <= ts {
+			if segment.allocations[i].ExpireTime <= ts {
 				a := segment.allocations[i]
 				segment.allocations = append(segment.allocations[:i], segment.allocations[i+1:]...)
 				s.putAllocation(a)

--- a/internal/datacoord/server.go
+++ b/internal/datacoord/server.go
@@ -407,7 +407,7 @@ func (s *Server) startActiveCheck(ctx context.Context) {
 			if ok {
 				continue
 			}
-			s.Stop()
+			go func() { s.Stop() }()
 			log.Debug("disconnect with etcd and shutdown data coordinator")
 			return
 		case <-ctx.Done():
@@ -487,7 +487,6 @@ func (s *Server) Stop() error {
 		return nil
 	}
 	log.Debug("DataCoord server shutdown")
-	atomic.StoreInt64(&s.isServing, ServerStateStopped)
 	s.cluster.Close()
 	s.stopServerLoop()
 	return nil


### PR DESCRIPTION
If a user inserts too much rows in a request. Now we will return a failed
response. Maybe auto creating new segments to hold that much rows is a
better way.

issue: #6664
Signed-off-by: sunby <bingyi.sun@zilliz.com>

Explain the problem that this commit is solving. Focus on why you
are making this change as opposed to how (the code explains that).
Are there side effects or other unintuitive consequences of this
change? Here's the place to explain them.

Further paragraphs come after blank lines.

 - Bullet points are okay, too

 - Typically a hyphen or asterisk is used for the bullet, preceded
   by a single space, with blank lines in between, but conventions
   vary here

Resolves: #<issue_id>, #<issue_id>
See also: #<related_issue_or_pr_id>

Signed-off-by: <username> <mail>
