### PR TITLE
Fix created timestamp of collections and partitions

### DIFF
--- a/internal/kv/kv.go
+++ b/internal/kv/kv.go
@@ -38,7 +38,7 @@ type TxnKV interface {
 type SnapShotKV interface {
 	Save(key, value string) (typeutil.Timestamp, error)
 	Load(key string, ts typeutil.Timestamp) (string, error)
-	MultiSave(kvs map[string]string, addition func(ts typeutil.Timestamp) (string, string, error)) (typeutil.Timestamp, error)
+	MultiSave(kvs map[string]string, additions ...func(ts typeutil.Timestamp) (string, string, error)) (typeutil.Timestamp, error)
 	LoadWithPrefix(key string, ts typeutil.Timestamp) ([]string, []string, error)
-	MultiSaveAndRemoveWithPrefix(saves map[string]string, removals []string, addition func(ts typeutil.Timestamp) (string, string, error)) (typeutil.Timestamp, error)
+	MultiSaveAndRemoveWithPrefix(saves map[string]string, removals []string, additions ...func(ts typeutil.Timestamp) (string, string, error)) (typeutil.Timestamp, error)
 }

--- a/internal/rootcoord/meta_snapshot_test.go
+++ b/internal/rootcoord/meta_snapshot_test.go
@@ -278,7 +278,7 @@ func TestMultiSave(t *testing.T) {
 	for i := 0; i < 20; i++ {
 		saves := map[string]string{"k1": fmt.Sprintf("v1-%d", i), "k2": fmt.Sprintf("v2-%d", i)}
 		vtso = typeutil.Timestamp(100 + i*5)
-		ts, err := ms.MultiSave(saves, nil)
+		ts, err := ms.MultiSave(saves)
 		assert.Nil(t, err)
 		assert.Equal(t, vtso, ts)
 	}
@@ -348,7 +348,7 @@ func TestMultiSaveAndRemoveWithPrefix(t *testing.T) {
 		sm := map[string]string{"ks": fmt.Sprintf("value-%d", i)}
 		dm := []string{fmt.Sprintf("kd-%04d", i-20)}
 		vtso = typeutil.Timestamp(100 + i*5)
-		ts, err := ms.MultiSaveAndRemoveWithPrefix(sm, dm, nil)
+		ts, err := ms.MultiSaveAndRemoveWithPrefix(sm, dm)
 		assert.Nil(t, err)
 		assert.Equal(t, vtso, ts)
 	}


### PR DESCRIPTION
Set CollectionInfo.CreateTime to the timestamp when save 
the metadata into etcd,not the timestamp when RootCoord 
receive the CreateCollection Request

Resolves: #6762 

Signed-off-by: yefu.chen <yefu.chen@zilliz.com>