### PR TITLE
FixBug: Incorrect handling of time synchronization 

### DIFF
--- a/internal/datacoord/segment_manager.go
+++ b/internal/datacoord/segment_manager.go
@@ -383,10 +383,7 @@ func (s *SegmentManager) GetFlushableSegments(ctx context.Context, channel strin
 	ret := make([]UniqueID, 0, len(s.segments))
 	for _, id := range s.segments {
 		info := s.meta.GetSegment(id)
-		if info == nil {
-			continue
-		}
-		if info.InsertChannel != channel {
+		if info == nil || info.InsertChannel != channel {
 			continue
 		}
 		if s.flushPolicy(info, t) {
@@ -403,10 +400,7 @@ func (s *SegmentManager) ExpireAllocations(channel string, ts Timestamp) error {
 	defer s.mu.Unlock()
 	for _, id := range s.segments {
 		segment := s.meta.GetSegment(id)
-		if segment == nil {
-			continue
-		}
-		if segment.InsertChannel != channel {
+		if segment == nil || segment.InsertChannel != channel {
 			continue
 		}
 		for i := 0; i < len(segment.allocations); i++ {
@@ -426,11 +420,7 @@ func (s *SegmentManager) tryToSealSegment(ts Timestamp, channel string) error {
 	channelInfo := make(map[string][]*SegmentInfo)
 	for _, id := range s.segments {
 		info := s.meta.GetSegment(id)
-		if info == nil {
-			log.Warn("Failed to get seg info from meta", zap.Int64("id", id))
-			continue
-		}
-		if info.InsertChannel != channel {
+		if info == nil || info.InsertChannel != channel {
 			continue
 		}
 		channelInfo[info.InsertChannel] = append(channelInfo[info.InsertChannel], info)

--- a/internal/datacoord/server.go
+++ b/internal/datacoord/server.go
@@ -335,8 +335,6 @@ func (s *Server) startDataNodeTtLoop(ctx context.Context) {
 
 			ch := ttMsg.ChannelName
 			ts := ttMsg.Timestamp
-			// log.Debug("Receive datanode timetick msg", zap.String("channel", ch),
-			// zap.Any("ts", ts))
 			segments, err := s.segmentManager.GetFlushableSegments(ctx, ch, ts)
 			if err != nil {
 				log.Warn("get flushable segments failed", zap.Error(err))

--- a/internal/proxy/channels_time_ticker_test.go
+++ b/internal/proxy/channels_time_ticker_test.go
@@ -11,7 +11,6 @@
 
 package proxy
 
-/*
 import (
 	"context"
 	"math/rand"
@@ -38,7 +37,8 @@ func newMockTsoAllocator() *mockTsoAllocator {
 }
 
 func newGetStatisticsFunc(pchans []pChan) getPChanStatisticsFuncType {
-	pchanNum := rand.Uint64()%5 + 1
+	total_pchan := len(pchans)
+	pchanNum := rand.Uint64()%(uint64(total_pchan)) + 1
 	pchans2 := make([]pChan, 0, pchanNum)
 	for i := 0; uint64(i) < pchanNum; i++ {
 		pchans2 = append(pchans2, pchans[i])
@@ -223,4 +223,3 @@ func TestChannelsTimeTickerImpl_getMinTsStatistics(t *testing.T) {
 
 	time.Sleep(time.Second)
 }
-*/

--- a/internal/proxy/channels_time_ticker_test.go
+++ b/internal/proxy/channels_time_ticker_test.go
@@ -37,8 +37,8 @@ func newMockTsoAllocator() *mockTsoAllocator {
 }
 
 func newGetStatisticsFunc(pchans []pChan) getPChanStatisticsFuncType {
-	total_pchan := len(pchans)
-	pchanNum := rand.Uint64()%(uint64(total_pchan)) + 1
+	totalPchan := len(pchans)
+	pchanNum := rand.Uint64()%(uint64(totalPchan)) + 1
 	pchans2 := make([]pChan, 0, pchanNum)
 	for i := 0; uint64(i) < pchanNum; i++ {
 		pchans2 = append(pchans2, pchans[i])

--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -99,6 +99,7 @@ type dmlTask interface {
 	task
 	getChannels() ([]vChan, error)
 	getPChanStats() (map[pChan]pChanStatistics, error)
+	getChannelsTimerTicker() channelsTimeTicker
 }
 
 type BaseInsertTask = msgstream.InsertMsg
@@ -151,6 +152,10 @@ func (it *InsertTask) SetTs(ts Timestamp) {
 
 func (it *InsertTask) EndTs() Timestamp {
 	return it.EndTimestamp
+}
+
+func (it *InsertTask) getChannelsTimerTicker() channelsTimeTicker {
+	return it.chTicker
 }
 
 func (it *InsertTask) getPChanStats() (map[pChan]pChanStatistics, error) {
@@ -1023,15 +1028,6 @@ func (it *InsertTask) Execute(ctx context.Context) error {
 			it.result.Status.Reason = err.Error()
 			return err
 		}
-	}
-
-	pchans, err := it.chMgr.getChannels(collID)
-	if err != nil {
-		return err
-	}
-	for _, pchan := range pchans {
-		log.Debug("Proxy InsertTask add pchan", zap.Any("pchan", pchan))
-		_ = it.chTicker.addPChan(pchan)
 	}
 
 	// Assign SegmentID

--- a/internal/proxy/task_scheduler.go
+++ b/internal/proxy/task_scheduler.go
@@ -224,7 +224,6 @@ func (queue *DmTaskQueue) Enqueue(t task) error {
 	if err != nil {
 		return err
 	}
-
 	_ = queue.addPChanStats(t)
 
 	return nil
@@ -248,10 +247,10 @@ func (queue *DmTaskQueue) addPChanStats(t task) error {
 	if dmT, ok := t.(dmlTask); ok {
 		stats, err := dmT.getPChanStats()
 		if err != nil {
+			log.Debug("Proxy DmTaskQueue addPChanStats", zap.Any("tID", t.ID()),
+				zap.Any("stats", stats), zap.Error(err))
 			return err
 		}
-		log.Debug("Proxy DmTaskQueue addPChanStats", zap.Any("tID", t.ID()),
-			zap.Any("stats", stats))
 		queue.statsLock.Lock()
 		for cName, stat := range stats {
 			info, ok := queue.pChanStatisticsInfos[cName]
@@ -263,6 +262,7 @@ func (queue *DmTaskQueue) addPChanStats(t task) error {
 					},
 				}
 				queue.pChanStatisticsInfos[cName] = info
+				dmT.getChannelsTimerTicker().addPChan(cName)
 			} else {
 				if info.minTs > stat.minTs {
 					queue.pChanStatisticsInfos[cName].minTs = stat.minTs
@@ -275,7 +275,7 @@ func (queue *DmTaskQueue) addPChanStats(t task) error {
 		}
 		queue.statsLock.Unlock()
 	} else {
-		return fmt.Errorf("Proxy addUnissuedTask reflect to dmlTask failed, tID:%v", t.ID())
+		return fmt.Errorf("proxy addUnissuedTask reflect to dmlTask failed, tID:%v", t.ID())
 	}
 	return nil
 }


### PR DESCRIPTION
The proxy incorrectly advances the time synchronization message.
DataCoord should distinguish ChannelName when processing synchronization time messages.

Resolves: #6436 #6573 #6507 
Signed-off-by: zhenshan.cao <zhenshan.cao@zilliz.com>



