### PR TITLE
[doc] Replace "JAVA" with "Java" in milvus20vs1x.md

### DIFF
--- a/milvus20vs1x.md
+++ b/milvus20vs1x.md
@@ -57,7 +57,7 @@
 	<tr>
 		<th>SDKs</th>
 		<td><li>Python</li><li>Java</li><li>Go</li><li>RESTful</li><li>C++</li></td>
-		<td><li>Python</li><li>Go (in planning)</li><li>JAVA (in planning)</li><li>RESTful (in planning)</li><li>C++ (in planning)</li></td>
+		<td><li>Python</li><li>Go (in planning)</li><li>Java (in planning)</li><li>RESTful (in planning)</li><li>C++ (in planning)</li></td>
 	</tr>
 	<tr>
 		<th>Release status</th>


### PR DESCRIPTION
Java should be spelled as "Java" when it is referred to as a Language, especially since "Java" has been used in the doc.
The change will not break any existing build.