### PR TITLE
Add flush interval

### DIFF
--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -13,6 +13,7 @@ package datacoord
 import (
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/milvus-io/milvus/internal/kv"
@@ -320,6 +321,12 @@ func (m *meta) SetCurrentRows(segmentID UniqueID, rows int64) {
 	m.Lock()
 	defer m.Unlock()
 	m.segments.SetCurrentRows(segmentID, rows)
+}
+
+func (m *meta) SetLastFlushTime(segmentID UniqueID, t time.Time) {
+	m.Lock()
+	defer m.Unlock()
+	m.segments.SetFlushTime(segmentID, t)
 }
 
 func (m *meta) saveSegmentInfo(segment *SegmentInfo) error {

--- a/internal/datacoord/segment_allocation_policy.go
+++ b/internal/datacoord/segment_allocation_policy.go
@@ -13,6 +13,7 @@ package datacoord
 
 import (
 	"sort"
+	"time"
 
 	"github.com/milvus-io/milvus/internal/proto/commonpb"
 	"github.com/milvus-io/milvus/internal/proto/schemapb"
@@ -126,6 +127,10 @@ func sealPolicyV1(maxCount, writtenCount, allocatedCount int64) bool {
 
 type flushPolicy func(segment *SegmentInfo, t Timestamp) bool
 
+const flushInterval = 2 * time.Second
+
 func flushPolicyV1(segment *SegmentInfo, t Timestamp) bool {
-	return segment.GetState() == commonpb.SegmentState_Sealed && segment.GetLastExpireTime() <= t
+	return segment.GetState() == commonpb.SegmentState_Sealed &&
+		segment.GetLastExpireTime() <= t &&
+		time.Since(segment.lastFlushTime) >= flushInterval
 }

--- a/internal/datacoord/server.go
+++ b/internal/datacoord/server.go
@@ -396,6 +396,7 @@ func (s *Server) startDataNodeTtLoop(ctx context.Context) {
 					continue
 				}
 				segmentInfos = append(segmentInfos, sInfo.SegmentInfo)
+				s.meta.SetLastFlushTime(id, time.Now())
 			}
 			if len(segmentInfos) > 0 {
 				s.cluster.Flush(segmentInfos)


### PR DESCRIPTION
Time tick message is sent about per 0.2 seconds. DataCoord will call
`FlushSegments` too frequently. We add a min interval for segment flush. A
segment will be flushed only once between the interval.

issue: #6995
Signed-off-by: sunby <bingyi.sun@zilliz.com>

