### PR TITLE
Fix pulsar consumer goroutine leakage

### DIFF
--- a/internal/util/mqclient/pulsar_client.go
+++ b/internal/util/mqclient/pulsar_client.go
@@ -67,7 +67,7 @@ func (pc *pulsarClient) Subscribe(options ConsumerOptions) (Consumer, error) {
 	}
 	//consumer.Seek(pulsar.EarliestMessageID())
 	//consumer.SeekByTime(time.Unix(0, 0))
-	pConsumer := &pulsarConsumer{c: consumer}
+	pConsumer := &pulsarConsumer{c: consumer, closeCh: make(chan struct{})}
 
 	return pConsumer, nil
 }


### PR DESCRIPTION
Fix goroutine leakage caused by the unclosed receiveCh of pulsar client. 
Do a workaround by adding a `closeCh`

Fix issue: #7003 

Signed-off-by: Congqi Xia <congqi.xia@zilliz.com>

