### PR TITLE
Set KinD pod anti-affinity to requiredDuringSchedulingIgnoredDuringExecution

### DIFF
--- a/build/ci/jenkins/pod/krte.yaml
+++ b/build/ci/jenkins/pod/krte.yaml
@@ -78,13 +78,11 @@ spec:
     name: cgroup
   affinity:
     podAntiAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-      - weight: 100
-        podAffinityTerm:
-          labelSelector:
-            matchExpressions:
-            - key: app
-              operator: In
-              values:
-              - milvus-e2e
-          topologyKey: kubernetes.io/hostname
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: app
+            operator: In
+            values:
+            - milvus-e2e
+        topologyKey: kubernetes.io/hostname


### PR DESCRIPTION
Set KinD pod anti-affinity to requiredDuringSchedulingIgnoredDuringExecution

Resolves: #6956

/cc @zwd1208 
