### PR TITLE
Increase ephemeral-storage for krte container

### DIFF
--- a/build/ci/jenkins/pod/krte.yaml
+++ b/build/ci/jenkins/pod/krte.yaml
@@ -24,11 +24,11 @@ spec:
       limits:
         cpu: "6"
         memory: 12Gi
-        ephemeral-storage: "30Gi"
+        ephemeral-storage: "50Gi"
       requests:
         cpu: "3"
         memory: 10Gi
-        ephemeral-storage: "30Gi"
+        ephemeral-storage: "50Gi"
     volumeMounts:
     - mountPath: /docker-graph
       name: docker-graph


### PR DESCRIPTION
Nightly ci fails everyday recently due to the broken connection to the pod. The pod is evicted due to the ephemeral storage limits. So we increase the ephemeral storage limit.

Resolves: #7196 
Signed-off-by: Edward Zeng <jie.zeng@zilliz.com>
