### PR TITLE
Enable etcd auto compaction for every 1000 revision

### DIFF
--- a/build/ci/jenkins/pod/krte.yaml
+++ b/build/ci/jenkins/pod/krte.yaml
@@ -49,6 +49,10 @@ spec:
       value: debug
     - name: ETCD_QUOTA_BACKEND_BYTES
       value: "4294967296"
+    - name: ETCD_AUTO_COMPACTION_MODE
+      value: "revision"
+    - name: ETCD_AUTO_COMPACTION_RETENTION
+      value: "1000"
     command:
     - etcd
     - -advertise-client-urls=http://127.0.0.1:2379


### PR DESCRIPTION
Enable etcd auto compaction to reduce the memory growth rate and db size.

Resolves: #7277 
Signed-off-by: Edward Zeng jie.zeng@zilliz.com
