### PR TITLE
Change ci schedule for 1.1 branch

### DIFF
--- a/ci/jenkins/Jenkinsfile
+++ b/ci/jenkins/Jenkinsfile
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 
 String cron_timezone = "TZ=Asia/Shanghai"
-String cron_string = BRANCH_NAME == "1.1" ? "50 22 * * * " : ""
+String cron_string = BRANCH_NAME == "1.1" ? "50 3 * * SUN " : ""
 
 pipeline {
     agent none


### PR DESCRIPTION
Change the ci schedule for 1.1 branch.

Originally the 1.1 ci runs every day 22:50, while the nightly ci runs at the same time. This creates a resource competition. After discussion team, we decide to run 1.1 ci weekly at sunday 3:50 a.m.

Signed-off-by: <edward.zeng> <jie.zeng@zilliz.com>
