### PR TITLE
Fix ci schedule

### DIFF
--- a/ci/jenkins/Jenkinsfile
+++ b/ci/jenkins/Jenkinsfile
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 
 String cron_timezone = "TZ=Asia/Shanghai"
-String cron_string = BRANCH_NAME == "1.1" ? "50 3 * * SUN " : ""
+String cron_string = BRANCH_NAME == "1.1" ? "50 3 * * 0 " : ""
 
 pipeline {
     agent none


### PR DESCRIPTION
The 1.1 ci is broken due to that Jenkins doesn't support `SUN` for week of day.
![image](https://user-images.githubusercontent.com/1573213/131060086-444d76f5-3c54-411b-a2cf-c211f88f3233.png)

Signed-off-by: <edward.zeng> <jie.zeng@zilliz.com>
