### PR TITLE
Fix go.mod missing atomic library error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	go.etcd.io/etcd/api/v3 v3.5.0
 	go.etcd.io/etcd/client/v3 v3.5.0
 	go.etcd.io/etcd/server/v3 v3.5.0
+	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/zap v1.17.0
 	golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6
 	google.golang.org/grpc v1.38.0


### PR DESCRIPTION
Fix go.mod missing atomic library error
Issue #7381 

Signed-off-by: godchen <qingxiang.chen@zilliz.com>