### PR TITLE
Expose minio client option region for s3-compatible storage

### DIFF
--- a/internal/datanode/flow_graph_insert_buffer_node.go
+++ b/internal/datanode/flow_graph_insert_buffer_node.go
@@ -847,6 +847,7 @@ func newInsertBufferNode(
 		AccessKeyID:       Params.MinioAccessKeyID,
 		SecretAccessKeyID: Params.MinioSecretAccessKey,
 		UseSSL:            Params.MinioUseSSL,
+		Region:            Params.MinioRegion,
 		CreateBucket:      true,
 		BucketName:        Params.MinioBucketName,
 	}

--- a/internal/datanode/param_table.go
+++ b/internal/datanode/param_table.go
@@ -61,6 +61,7 @@ type ParamTable struct {
 	MinioAccessKeyID     string
 	MinioSecretAccessKey string
 	MinioUseSSL          bool
+	MinioRegion          string
 	MinioBucketName      string
 }
 
@@ -108,6 +109,7 @@ func (p *ParamTable) Init() {
 		p.initMinioAccessKeyID()
 		p.initMinioSecretAccessKey()
 		p.initMinioUseSSL()
+		p.initMinioRegion()
 		p.initMinioBucketName()
 	})
 }
@@ -239,6 +241,14 @@ func (p *ParamTable) initMinioUseSSL() {
 		panic(err)
 	}
 	p.MinioUseSSL, _ = strconv.ParseBool(usessl)
+}
+
+func (p *ParamTable) initMinioRegion() {
+	region, err := p.Load("minio.region")
+	if err != nil {
+		panic(err)
+	}
+	p.MinioRegion = region
 }
 
 func (p *ParamTable) initMinioBucketName() {

--- a/internal/datanode/param_table_test.go
+++ b/internal/datanode/param_table_test.go
@@ -94,6 +94,11 @@ func TestParamTable_DataNode(t *testing.T) {
 		log.Println("MinioUseSSL:", useSSL)
 	})
 
+	t.Run("Test MinioRegion", func(t *testing.T) {
+		name := Params.MinioRegion
+		log.Println("MinioRegion:", name)
+	})
+
 	t.Run("Test MinioBucketName", func(t *testing.T) {
 		name := Params.MinioBucketName
 		log.Println("MinioBucketName:", name)

--- a/internal/indexcoord/index_coord.go
+++ b/internal/indexcoord/index_coord.go
@@ -169,6 +169,7 @@ func (i *IndexCoord) Init() error {
 		AccessKeyID:       Params.MinIOAccessKeyID,
 		SecretAccessKeyID: Params.MinIOSecretAccessKey,
 		UseSSL:            Params.MinIOUseSSL,
+		Region:            Params.MinIORegion,
 		BucketName:        Params.MinioBucketName,
 		CreateBucket:      true,
 	}

--- a/internal/indexcoord/paramtable.go
+++ b/internal/indexcoord/paramtable.go
@@ -37,6 +37,7 @@ type ParamTable struct {
 	MinIOAccessKeyID     string
 	MinIOSecretAccessKey string
 	MinIOUseSSL          bool
+	MinIORegion          string
 	MinioBucketName      string
 
 	Log log.Config
@@ -57,6 +58,7 @@ func (pt *ParamTable) Init() {
 		pt.initMinIOAccessKeyID()
 		pt.initMinIOSecretAccessKey()
 		pt.initMinIOUseSSL()
+		pt.initMinIORegion()
 		pt.initMinioBucketName()
 	})
 }
@@ -134,6 +136,14 @@ func (pt *ParamTable) initMinIOUseSSL() {
 	if err != nil {
 		panic(err)
 	}
+}
+
+func (pt *ParamTable) initMinIORegion() {
+	region, err := pt.Load("minio.region")
+	if err != nil {
+		panic(err)
+	}
+	pt.MinIORegion = region
 }
 
 func (pt *ParamTable) initMinioBucketName() {

--- a/internal/indexnode/indexnode.go
+++ b/internal/indexnode/indexnode.go
@@ -104,6 +104,7 @@ func (i *IndexNode) Init() error {
 		AccessKeyID:       Params.MinIOAccessKeyID,
 		SecretAccessKeyID: Params.MinIOSecretAccessKey,
 		UseSSL:            Params.MinIOUseSSL,
+		Region:            Params.MinIORegion,
 		BucketName:        Params.MinioBucketName,
 		CreateBucket:      true,
 	}

--- a/internal/indexnode/paramtable.go
+++ b/internal/indexnode/paramtable.go
@@ -45,6 +45,7 @@ type ParamTable struct {
 	MinIOAccessKeyID     string
 	MinIOSecretAccessKey string
 	MinIOUseSSL          bool
+	MinIORegion          string
 	MinioBucketName      string
 
 	Log log.Config
@@ -70,6 +71,7 @@ func (pt *ParamTable) initParams() {
 	pt.initMinIOAccessKeyID()
 	pt.initMinIOSecretAccessKey()
 	pt.initMinIOUseSSL()
+	pt.initMinIORegion()
 	pt.initMinioBucketName()
 	pt.initEtcdEndpoints()
 	pt.initMetaRootPath()
@@ -108,6 +110,14 @@ func (pt *ParamTable) initMinIOUseSSL() {
 	if err != nil {
 		panic(err)
 	}
+}
+
+func (pt *ParamTable) initMinIORegion() {
+	ret, err := pt.Load("minio.region")
+	if err != nil {
+		panic(err)
+	}
+	pt.MinIORegion = ret
 }
 
 func (pt *ParamTable) initEtcdEndpoints() {

--- a/internal/indexnode/paramtable_test.go
+++ b/internal/indexnode/paramtable_test.go
@@ -46,3 +46,8 @@ func TestParamTable_MinIOUseSSL(t *testing.T) {
 	useSSL := Params.MinIOUseSSL
 	assert.Equal(t, useSSL, false)
 }
+
+func TestParamTable_MinIORegion(t *testing.T) {
+	region := Params.MinIORegion
+	assert.Equal(t, region, "")
+}

--- a/internal/kv/minio/minio_kv.go
+++ b/internal/kv/minio/minio_kv.go
@@ -39,16 +39,23 @@ type Option struct {
 	SecretAccessKeyID string
 	UseSSL            bool
 	CreateBucket      bool // when bucket not existed, create it
+	Region            string
 }
 
 func NewMinIOKV(ctx context.Context, option *Option) (*MinIOKV, error) {
 	var minIOClient *minio.Client
 	var err error
 	log.Debug("MinioKV NewMinioKV", zap.Any("option", option))
-	minIOClient, err = minio.New(option.Address, &minio.Options{
+
+	clntOptions := &minio.Options{
 		Creds:  credentials.NewStaticV4(option.AccessKeyID, option.SecretAccessKeyID, ""),
 		Secure: option.UseSSL,
-	})
+	}
+	if option.Region != "" {
+		clntOptions.Region = option.Region
+	}
+
+	minIOClient, err = minio.New(option.Address, clntOptions)
 	// options nil or invalid formatted endpoint, don't need retry
 	if err != nil {
 		return nil, err

--- a/internal/kv/minio/minio_kv_test.go
+++ b/internal/kv/minio/minio_kv_test.go
@@ -32,11 +32,13 @@ func newMinIOKVClient(ctx context.Context, bucketName string) (*miniokv.MinIOKV,
 	secretAccessKey, _ := Params.Load("minio.secretAccessKey")
 	useSSLStr, _ := Params.Load("minio.useSSL")
 	useSSL, _ := strconv.ParseBool(useSSLStr)
+	region, _ := Params.Load("minio.region")
 	option := &miniokv.Option{
 		Address:           endPoint,
 		AccessKeyID:       accessKeyID,
 		SecretAccessKeyID: secretAccessKey,
 		UseSSL:            useSSL,
+		Region:            region,
 		BucketName:        bucketName,
 		CreateBucket:      true,
 	}

--- a/internal/querycoord/mock_3rd_component.go
+++ b/internal/querycoord/mock_3rd_component.go
@@ -284,6 +284,7 @@ func newDataCoordMock(ctx context.Context) (*dataCoordMock, error) {
 		SecretAccessKeyID: Params.MinioSecretAccessKey,
 		UseSSL:            Params.MinioUseSSLStr,
 		BucketName:        Params.MinioBucketName,
+		Region:            Params.MinioRegion,
 		CreateBucket:      true,
 	}
 	kv, err := minioKV.NewMinIOKV(ctx, option)

--- a/internal/querycoord/param_table.go
+++ b/internal/querycoord/param_table.go
@@ -57,6 +57,7 @@ type ParamTable struct {
 	MinioAccessKeyID     string
 	MinioSecretAccessKey string
 	MinioUseSSLStr       bool
+	MinioRegion          string
 	MinioBucketName      string
 }
 
@@ -95,6 +96,7 @@ func (p *ParamTable) Init() {
 		p.initMinioAccessKeyID()
 		p.initMinioSecretAccessKey()
 		p.initMinioUseSSLStr()
+		p.initMinioRegion()
 		p.initMinioBucketName()
 	})
 }
@@ -238,6 +240,14 @@ func (p *ParamTable) initMinioUseSSLStr() {
 		panic(err)
 	}
 	p.MinioUseSSLStr = sslBoolean
+}
+
+func (p *ParamTable) initMinioRegion() {
+	region, err := p.Load("minio.region")
+	if err != nil {
+		panic(err)
+	}
+	p.MinioRegion = region
 }
 
 func (p *ParamTable) initMinioBucketName() {

--- a/internal/querynode/index_loader.go
+++ b/internal/querynode/index_loader.go
@@ -365,6 +365,7 @@ func newIndexLoader(ctx context.Context, rootCoord types.RootCoord, indexCoord t
 		AccessKeyID:       Params.MinioAccessKeyID,
 		SecretAccessKeyID: Params.MinioSecretAccessKey,
 		UseSSL:            Params.MinioUseSSLStr,
+		Region:            Params.MinioRegion,
 		CreateBucket:      true,
 		BucketName:        Params.MinioBucketName,
 	}

--- a/internal/querynode/load_service_test.go
+++ b/internal/querynode/load_service_test.go
@@ -817,6 +817,7 @@ func generateInsertBinLog(collectionID UniqueID, partitionID UniqueID, segmentID
 		AccessKeyID:       Params.MinioAccessKeyID,
 		SecretAccessKeyID: Params.MinioSecretAccessKey,
 		UseSSL:            Params.MinioUseSSLStr,
+		Region:            Params.MinioRegion,
 		BucketName:        bucketName,
 		CreateBucket:      true,
 	}
@@ -902,6 +903,7 @@ func generateIndex(segmentID UniqueID) ([]string, error) {
 		AccessKeyID:       Params.MinioAccessKeyID,
 		SecretAccessKeyID: Params.MinioSecretAccessKey,
 		UseSSL:            Params.MinioUseSSLStr,
+		Region:            Params.MinioRegion,
 		BucketName:        Params.MinioBucketName,
 		CreateBucket:      true,
 	}

--- a/internal/querynode/param_table.go
+++ b/internal/querynode/param_table.go
@@ -44,6 +44,7 @@ type ParamTable struct {
 	MinioAccessKeyID     string
 	MinioSecretAccessKey string
 	MinioUseSSLStr       bool
+	MinioRegion          string
 	MinioBucketName      string
 
 	// search
@@ -92,6 +93,7 @@ func (p *ParamTable) Init() {
 		p.initMinioAccessKeyID()
 		p.initMinioSecretAccessKey()
 		p.initMinioUseSSLStr()
+		p.initMinioRegion()
 		p.initMinioBucketName()
 
 		p.initPulsarAddress()
@@ -159,6 +161,14 @@ func (p *ParamTable) initMinioUseSSLStr() {
 		panic(err)
 	}
 	p.MinioUseSSLStr = sslBoolean
+}
+
+func (p *ParamTable) initMinioRegion() {
+	region, err := p.Load("minio.region")
+	if err != nil {
+		panic(err)
+	}
+	p.MinioRegion = region
 }
 
 func (p *ParamTable) initMinioBucketName() {

--- a/internal/querynode/param_table_test.go
+++ b/internal/querynode/param_table_test.go
@@ -54,6 +54,11 @@ func TestParamTable_minio(t *testing.T) {
 		useSSL := Params.MinioUseSSLStr
 		assert.Equal(t, useSSL, false)
 	})
+
+	t.Run("Test region", func(t *testing.T) {
+		region := Params.MinioRegion
+		assert.Equal(t, region, "")
+	})
 }
 
 func TestParamTable_statsServiceTimeInterval(t *testing.T) {

--- a/internal/querynode/query_service.go
+++ b/internal/querynode/query_service.go
@@ -62,6 +62,7 @@ func newQueryService(ctx context.Context,
 		AccessKeyID:       Params.MinioAccessKeyID,
 		SecretAccessKeyID: Params.MinioSecretAccessKey,
 		UseSSL:            Params.MinioUseSSLStr,
+		Region:            Params.MinioRegion,
 		CreateBucket:      true,
 		BucketName:        Params.MinioBucketName,
 	}

--- a/internal/querynode/segment_loader.go
+++ b/internal/querynode/segment_loader.go
@@ -313,6 +313,7 @@ func newSegmentLoader(ctx context.Context, rootCoord types.RootCoord, indexCoord
 		AccessKeyID:       Params.MinioAccessKeyID,
 		SecretAccessKeyID: Params.MinioSecretAccessKey,
 		UseSSL:            Params.MinioUseSSLStr,
+		Region:            Params.MinioRegion,
 		CreateBucket:      true,
 		BucketName:        Params.MinioBucketName,
 	}

--- a/internal/storage/vector_chunk_manager_test.go
+++ b/internal/storage/vector_chunk_manager_test.go
@@ -146,11 +146,13 @@ func newMinIOKVClient(ctx context.Context, bucketName string) (*miniokv.MinIOKV,
 	secretAccessKey, _ := Params.Load("minio.secretAccessKey")
 	useSSLStr, _ := Params.Load("minio.useSSL")
 	useSSL, _ := strconv.ParseBool(useSSLStr)
+	region, _ := Params.Load("minio.region")
 	option := &miniokv.Option{
 		Address:           endPoint,
 		AccessKeyID:       accessKeyID,
 		SecretAccessKeyID: secretAccessKey,
 		UseSSL:            useSSL,
+		Region:            region,
 		BucketName:        bucketName,
 		CreateBucket:      true,
 	}


### PR DESCRIPTION
S3-compatible storages may have different region naming rules than AWS S3, it is convenient to allow user to set region. Since _minio.Client.Options_ already has option _region_ and _minio_kv.go_ does not set it explicitly, this PR just makes it configurable.

Resolves: 
See also: #7419 

Signed-off-by: ryeyao <rye.y.cn@gmail.com>
