### PR TITLE
Increase nightly ci ephemeral-storage

### DIFF
--- a/build/ci/jenkins/pod/krte.yaml
+++ b/build/ci/jenkins/pod/krte.yaml
@@ -24,11 +24,11 @@ spec:
       limits:
         cpu: "6"
         memory: 12Gi
-        ephemeral-storage: "50Gi"
+        ephemeral-storage: "100Gi"
       requests:
         cpu: "3"
         memory: 10Gi
-        ephemeral-storage: "50Gi"
+        ephemeral-storage: "100Gi"
     volumeMounts:
     - mountPath: /docker-graph
       name: docker-graph


### PR DESCRIPTION
Originally the ephemeral-storage for nightly-ci krte pod is `50Gi`. The pod is get evicted because of storage usage exceeded the quota.
![image](https://user-images.githubusercontent.com/1573213/132168176-d6355090-a211-4f3a-bae6-945d7b092ec4.png)
```
Sep 06 11:45:43 test-worker6 kubelet[1877]: I0906 11:45:43.963190    1877 eviction_manager.go:578] eviction manager: pod milvus-e2e-test-kind-nightly-546tr-cmn0v_kube-ops(1d81845d-0eaf-11ec-ba94-1c1b0d568bc0) is evicted successfully
Sep 06 11:45:43 test-worker6 kubelet[1877]: I0906 11:45:43.963213    1877 eviction_manager.go:191] eviction manager: pods milvus-e2e-test-kind-nightly-546tr-cmn0v_kube-ops(1d81845d-0eaf-11ec-ba94-1c1b0d568bc0) evicted, waiting for pod to be cleaned up
```

Increase the ephemeral-storage to resolve the pod the eviction.
Resolves: #7494 

Signed-off-by: Edward Zeng <jie.zeng@zilliz.com>

/cc @zwd1208 
/cc @yanliang567 
