### PR TITLE
[skip ci] sync Mergify label loop bug

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -83,6 +83,7 @@ pull_request_rules:
   - name: Remove ci-passed when unittest failed
     conditions:
       - base=master
+      - -title~=\[skip ci\]
       - "check-failure=Build and test AMD64 Ubuntu 18.04"
     actions:
       label:
@@ -92,6 +93,7 @@ pull_request_rules:
   - name: Remove ci-passed when ci failed
     conditions:
       - base=master
+      - -title~=\[skip ci\]
       - "check-failure=continuous-integration/jenkins/pr-merge"
     actions:
       label:
@@ -101,6 +103,7 @@ pull_request_rules:
   - name: Remove ci-passed when ci pending
     conditions:
       - base=master
+      - -title~=\[skip ci\]
       - "check-pending=continuous-integration/jenkins/pr-merge"
     actions:
       label:


### PR DESCRIPTION
When the title has `[skip ci]` but CI is running two rules are fighting each other.

This change ensure label ci-passed is added and not removed by other rules

Signed-off-by: Mehdi Abaakouk <sileht@sileht.net>