### PR TITLE
Improvements: Some adaptation for gcc-10.

### DIFF
--- a/internal/core/CMakeLists.txt
+++ b/internal/core/CMakeLists.txt
@@ -207,7 +207,7 @@ install(
 )
 
 install(
-        FILES ${CMAKE_BINARY_DIR}/src/segcore/libmilvus_segcore.so
+	FILES ${CMAKE_BINARY_DIR}/src/segcore/libmilvus_segcore${CMAKE_SHARED_LIBRARY_SUFFIX}
         DESTINATION lib
 )
 
@@ -218,8 +218,7 @@ install(
         FILES_MATCHING PATTERN "*_c.h"
 )
 
-install(
-        FILES ${CMAKE_BINARY_DIR}/src/indexbuilder/libmilvus_indexbuilder.so
+install(FILES ${CMAKE_BINARY_DIR}/src/indexbuilder/libmilvus_indexbuilder${CMAKE_SHARED_LIBRARY_SUFFIX}
         DESTINATION lib
 )
 

--- a/internal/core/src/index/knowhere/knowhere/index/vector_index/ConfAdapter.cpp
+++ b/internal/core/src/index/knowhere/knowhere/index/vector_index/ConfAdapter.cpp
@@ -96,7 +96,7 @@ MatchNlist(int64_t size, int64_t nlist) {
 
     if (nlist * MIN_POINTS_PER_CENTROID > size) {
         // nlist is too large, adjust to a proper value
-        nlist = std::max(1L, size / MIN_POINTS_PER_CENTROID);
+        nlist = std::max(static_cast<int64_t>(1), size / MIN_POINTS_PER_CENTROID);
         LOG_KNOWHERE_WARNING_ << "Row num " << size << " match nlist " << nlist;
     }
     return nlist;

--- a/internal/core/src/index/thirdparty/faiss/Clustering.cpp
+++ b/internal/core/src/index/thirdparty/faiss/Clustering.cpp
@@ -394,7 +394,7 @@ void Clustering::train_encoded (idx_t nx, const uint8_t *x_in,
         // reports.
         const float *x = reinterpret_cast<const float *>(x_in);
         for (size_t i = 0; i < nx * d; i++) {
-            FAISS_THROW_IF_NOT_MSG (finite (x[i]),
+            FAISS_THROW_IF_NOT_MSG (std::isfinite (x[i]),
                                     "input contains NaN's or Inf's");
         }
     }

--- a/internal/core/src/index/thirdparty/faiss/utils/distances_simd.cpp
+++ b/internal/core/src/index/thirdparty/faiss/utils/distances_simd.cpp
@@ -515,7 +515,7 @@ void fvec_madd (size_t n, const float *a,
                 float bf, const float *b, float *c)
 {
     if ((n & 3) == 0 &&
-        ((((long)a) | ((long)b) | ((long)c)) & 15) == 0)
+        ((((size_t)a) | ((size_t)b) | ((size_t)c)) & 15) == 0)
         fvec_madd_sse (n, a, bf, b, c);
     else
         fvec_madd_ref (n, a, bf, b, c);
@@ -602,7 +602,7 @@ int fvec_madd_and_argmin (size_t n, const float *a,
                           float bf, const float *b, float *c)
 {
     if ((n & 3) == 0 &&
-        ((((long)a) | ((long)b) | ((long)c)) & 15) == 0)
+        ((((size_t)a) | ((size_t)b) | ((size_t)c)) & 15) == 0)
         return fvec_madd_and_argmin_sse (n, a, bf, b, c);
     else
         return fvec_madd_and_argmin_ref (n, a, bf, b, c);

--- a/internal/core/src/index/thirdparty/faiss/utils/hamming-inl.h
+++ b/internal/core/src/index/thirdparty/faiss/utils/hamming-inl.h
@@ -15,7 +15,7 @@ namespace faiss {
 inline BitstringWriter::BitstringWriter(uint8_t *code, int code_size):
     code (code), code_size (code_size), i(0)
 {
-    bzero (code, code_size);
+    memset (code, 0, code_size);
 }
 
 inline void BitstringWriter::write(uint64_t x, int nbit) {

--- a/internal/core/src/index/thirdparty/faiss/utils/utils.cpp
+++ b/internal/core/src/index/thirdparty/faiss/utils/utils.cpp
@@ -319,7 +319,7 @@ size_t ranklist_intersection_size (size_t k1, const int64_t *v1,
         }
         k2 = wp;
     }
-    const int64_t seen_flag = 1L << 60;
+    const int64_t seen_flag = 1LL << 60;
     size_t count = 0;
     for (size_t i = 0; i < k1; i++) {
         int64_t q = v1 [i];


### PR DESCRIPTION
Support windows compile with MSYS (partial). This part including:

- CMakeLists.txt using CMAKE_SHARED_LIBRARY_SUFFIX instead .so
- Replace finite() with std::isfinite()
  ref: https://github.com/facebookresearch/faiss/pull/1341
- Replace bzero (deprecated in POSIX 2001) with memset.
  ref: https://github.com/facebookresearch/faiss/pull/1340
- Some int types match.

ref: #7706

Signed-off-by: Ji Bin <matrixji@live.com>