### PR TITLE
Remove copyrights from /tests/scripts

### DIFF
--- a/tests/scripts/e2e-k8s.sh
+++ b/tests/scripts/e2e-k8s.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-# Copyright (C) 2019-2020 Zilliz. All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
-# with the License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed to the LF AI&Data foundation under one or more contributor license agreements. See the 
+# NOTICE file distributed with this work for additional information regarding copyright ownership. 
+# The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may 
+# not use this file except in compliance with the License. 
+# 
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software distributed under the License
 # is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express

--- a/tests/scripts/e2e.sh
+++ b/tests/scripts/e2e.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-# Copyright (C) 2019-2020 Zilliz. All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
-# with the License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed to the LF AI&Data foundation under one or more contributor license agreements. See the 
+# NOTICE file distributed with this work for additional information regarding copyright ownership. 
+# The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may 
+# not use this file except in compliance with the License. 
+# 
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software distributed under the License
 # is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express

--- a/tests/scripts/export_logs.sh
+++ b/tests/scripts/export_logs.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-# Copyright (C) 2019-2020 Zilliz. All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
-# with the License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed to the LF AI&Data foundation under one or more contributor license agreements. See the 
+# NOTICE file distributed with this work for additional information regarding copyright ownership. 
+# The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may 
+# not use this file except in compliance with the License. 
+# 
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software distributed under the License
 # is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express

--- a/tests/scripts/install_milvus.sh
+++ b/tests/scripts/install_milvus.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-# Copyright (C) 2019-2020 Zilliz. All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
-# with the License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed to the LF AI&Data foundation under one or more contributor license agreements. See the 
+# NOTICE file distributed with this work for additional information regarding copyright ownership. 
+# The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may 
+# not use this file except in compliance with the License. 
+# 
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software distributed under the License
 # is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express

--- a/tests/scripts/prepare_e2e.sh
+++ b/tests/scripts/prepare_e2e.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-# Copyright (C) 2019-2020 Zilliz. All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
-# with the License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed to the LF AI&Data foundation under one or more contributor license agreements. See the 
+# NOTICE file distributed with this work for additional information regarding copyright ownership. 
+# The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may 
+# not use this file except in compliance with the License. 
+# 
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software distributed under the License
 # is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express

--- a/tests/scripts/uninstall_milvus.sh
+++ b/tests/scripts/uninstall_milvus.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-# Copyright (C) 2019-2020 Zilliz. All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
-# with the License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed to the LF AI&Data foundation under one or more contributor license agreements. See the 
+# NOTICE file distributed with this work for additional information regarding copyright ownership. 
+# The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may 
+# not use this file except in compliance with the License. 
+# 
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software distributed under the License
 # is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express


### PR DESCRIPTION
Removing copyrights as the project is owned by LF AI and not Zilliz.