### PR TITLE
Split blob into several string rows when index file is large

### DIFF
--- a/internal/storage/data_codec_test.go
+++ b/internal/storage/data_codec_test.go
@@ -373,6 +373,10 @@ func TestIndexFileBinlogCodec(t *testing.T) {
 			Key:   "ivf2",
 			Value: []byte{4, 5, 6},
 		},
+		{
+			Key:   "large",
+			Value: []byte(funcutil.RandomString(maxLengthPerRowOfIndexFile + 1)),
+		},
 	}
 
 	codec := NewIndexFileBinlogCodec()


### PR DESCRIPTION
Signed-off-by: dragondriver <jiquan.long@zilliz.com>
Fix: #8910 