### PR TITLE
Read datanode insertbuf from env

### DIFF
--- a/internal/datanode/param_table.go
+++ b/internal/datanode/param_table.go
@@ -142,7 +142,7 @@ func (p *ParamTable) initFlowGraphMaxParallelism() {
 
 // ---- flush configs ----
 func (p *ParamTable) initFlushInsertBufferSize() {
-	p.FlushInsertBufferSize = p.ParseInt64("datanode.flush.insertBufSize")
+	p.FlushInsertBufferSize = p.ParseInt64("_DATANODE_INSERTBUFSIZE")
 }
 
 func (p *ParamTable) initInsertBinlogRootPath() {

--- a/internal/util/paramtable/basetable.go
+++ b/internal/util/paramtable/basetable.go
@@ -238,6 +238,22 @@ func (gp *BaseTable) tryloadFromEnv() {
 	if err != nil {
 		panic(err)
 	}
+
+	insertBufferFlushSize := os.Getenv("DATA_NODE_IBUFSIZE")
+	if insertBufferFlushSize == "" {
+		//var err error
+		insertBufferFlushSize, err = gp.Load("datanode.flush.insertBufSize")
+		if err != nil {
+			panic(err)
+		}
+	}
+	if insertBufferFlushSize == "" {
+		insertBufferFlushSize = "16777216" //use default
+	}
+	err = gp.Save("_DATANODE_INSERTBUFSIZE", insertBufferFlushSize)
+	if err != nil {
+		panic(err)
+	}
 }
 
 func (gp *BaseTable) Load(key string) (string, error) {


### PR DESCRIPTION
Add method to change datanode insertbuffersize via env

env key name is DATA_NODE_IBUFSIZE

/kind improvement

Signed-off-by: Congqi Xia <congqi.xia@zilliz.com>