### PR TITLE
Support windows compilations

### DIFF
--- a/internal/core/src/index/knowhere/CMakeLists.txt
+++ b/internal/core/src/index/knowhere/CMakeLists.txt
@@ -106,12 +106,17 @@ if (MILVUS_SUPPORT_SPTAG)
             )
 endif ()
 
+set(depend_fiu_libs "fiu")
+if (MSYS)
+set(depend_fiu_libs)
+endif ()
+
 set(depend_libs
         faiss
         gomp
         gfortran
         pthread
-        fiu
+        ${depend_fiu_libs}
         ngt
         index_log
         )

--- a/internal/core/src/index/knowhere/knowhere/index/vector_index/impl/nsg/NSG.cpp
+++ b/internal/core/src/index/knowhere/knowhere/index/vector_index/impl/nsg/NSG.cpp
@@ -17,6 +17,7 @@
 #include <iostream>
 #include <stack>
 #include <string>
+#include <random>
 #include <utility>
 
 #include "knowhere/common/Exception.h"
@@ -28,7 +29,8 @@ namespace milvus {
 namespace knowhere {
 namespace impl {
 
-unsigned int seed = 100;
+std::random_device seed_dev;
+std::mt19937 seed(seed_dev());
 
 NsgIndex::NsgIndex(const size_t& dimension, const size_t& n, Metric_Type metric)
     : dimension(dimension), ntotal(n), metric_type(metric) {
@@ -111,7 +113,8 @@ NsgIndex::InitNavigationPoint(float* data) {
 
     // select navigation point
     std::vector<Neighbor> resset;
-    navigation_point = rand_r(&seed) % ntotal;  // random initialize navigating point
+    std::uniform_int_distribution<> distrib(0, ntotal - 1);
+    navigation_point = distrib(seed);  // random initialize navigating point
     GetNeighbors(center, data, resset, knng);
     navigation_point = resset[0].id;
 
@@ -162,7 +165,8 @@ NsgIndex::GetNeighbors(const float* query,
             ++count;
         }
         while (count < buffer_size) {
-            node_t id = rand_r(&seed) % ntotal;
+            std::uniform_int_distribution<> distrib(0, ntotal - 1);
+            node_t id = distrib(seed);
             if (has_calculated_dist[id]) {
                 continue;  // duplicate id
             }
@@ -268,7 +272,8 @@ NsgIndex::GetNeighbors(const float* query, float* data, std::vector<Neighbor>& r
             ++count;
         }
         while (count < buffer_size) {
-            node_t id = rand_r(&seed) % ntotal;
+            std::uniform_int_distribution<> distrib(0, ntotal - 1);
+            node_t id = distrib(seed);
             if (has_calculated_dist[id]) {
                 continue;  // duplicate id
             }
@@ -366,7 +371,8 @@ NsgIndex::GetNeighbors(
             ++count;
         }
         while (count < buffer_size) {
-            node_t id = rand_r(&seed) % ntotal;
+            std::uniform_int_distribution<> distrib(0, ntotal - 1);
+            node_t id = distrib(seed);
             if (has_calculated_dist[id]) {
                 continue;  // duplicate id
             }
@@ -714,7 +720,8 @@ NsgIndex::FindUnconnectedNode(float* data, boost::dynamic_bitset<>& has_linked, 
     }
     if (found == 0) {
         while (true) {  // random a linked-node and add unlinked-node as its neighbor
-            size_t rid = rand_r(&seed) % ntotal;
+            std::uniform_int_distribution<> distrib(0, ntotal - 1);
+            size_t rid = distrib(seed);
             if (has_linked[rid]) {
                 root = rid;
                 break;

--- a/internal/core/src/index/thirdparty/NGT/CMakeLists.txt
+++ b/internal/core/src/index/thirdparty/NGT/CMakeLists.txt
@@ -20,11 +20,14 @@ string(TOLOWER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE_LOWER)
 message(STATUS "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
 message(STATUS "CMAKE_BUILD_TYPE_LOWER: ${CMAKE_BUILD_TYPE_LOWER}")
 
-if(${UNIX})
+if(UNIX OR MSYS)
     set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
 
     if(CMAKE_VERSION VERSION_LESS 3.1)
         set(BASE_OPTIONS "-Wall -std=gnu++0x -lrt")
+        if (MSYS)
+        set(BASE_OPTIONS "-Wall -std=gnu++0x")
+        endif()
 
         if(${NGT_AVX_DISABLED})
             message(STATUS "AVX will not be used to compute distances.")
@@ -76,4 +79,4 @@ if(${UNIX})
     endif() 
 
     add_subdirectory("${PROJECT_SOURCE_DIR}/lib")
-endif( ${UNIX} )
+endif()

--- a/internal/core/src/index/thirdparty/NGT/lib/CMakeLists.txt
+++ b/internal/core/src/index/thirdparty/NGT/lib/CMakeLists.txt
@@ -1,3 +1,3 @@
-if( ${UNIX} )
+if( UNIX OR MSYS )
 	add_subdirectory(${PROJECT_SOURCE_DIR}/lib/NGT)
 endif()

--- a/internal/core/src/index/thirdparty/NGT/lib/NGT/CMakeLists.txt
+++ b/internal/core/src/index/thirdparty/NGT/lib/NGT/CMakeLists.txt
@@ -1,4 +1,4 @@
-if( ${UNIX} )
+if( UNIX OR MSYS )
 	option(NGT_SHARED_MEMORY_ALLOCATOR "enable shared memory" OFF)
 	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/defines.h.in ${CMAKE_CURRENT_BINARY_DIR}/defines.h)
 	include_directories("${CMAKE_CURRENT_BINARY_DIR}" "${PROJECT_SOURCE_DIR}/lib" "${PROJECT_BINARY_DIR}/lib/")
@@ -27,7 +27,11 @@ if( ${UNIX} )
 			target_link_libraries(ngt gomp)
 		endif()
 	else(${APPLE})
+		if (MSYS)
+		target_link_libraries(ngt gomp mman)
+		else ()
 		target_link_libraries(ngt gomp rt)
+		endif ()
 	endif(${APPLE})
 
 	install(TARGETS

--- a/internal/core/src/index/thirdparty/NGT/lib/NGT/Common.h
+++ b/internal/core/src/index/thirdparty/NGT/lib/NGT/Common.h
@@ -33,6 +33,7 @@
 #include	<algorithm>
 #include	<typeinfo>
 
+#include	<sys/stat.h>
 #include	<sys/time.h>
 #include	<fcntl.h>
 

--- a/internal/core/src/index/thirdparty/NGT/lib/NGT/GetCoreNumber.cpp
+++ b/internal/core/src/index/thirdparty/NGT/lib/NGT/GetCoreNumber.cpp
@@ -7,7 +7,7 @@ int getCoreNumber()
 #ifndef __linux__
     SYSTEM_INFO sys_info;
     GetSystemInfo(&sys_info);
-    return sysInfo.dwNumberOfProcessors;
+    return sys_info.dwNumberOfProcessors;
 #else
     return get_nprocs();
 #endif

--- a/internal/core/src/index/thirdparty/NGT/lib/NGT/Index.h
+++ b/internal/core/src/index/thirdparty/NGT/lib/NGT/Index.h
@@ -543,7 +543,11 @@ public:
 #endif
     static void mkdir(const std::string & dir)
     {
+#ifdef WIN32
+        if (::mkdir(dir.c_str()))
+#else
         if (::mkdir(dir.c_str(), S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH) != 0)
+#endif
         {
             std::stringstream msg;
             msg << "NGT::Index::mkdir: Cannot make the specified directory. " << dir;

--- a/internal/core/src/index/thirdparty/NGT/lib/NGT/MmapManager.cpp
+++ b/internal/core/src/index/thirdparty/NGT/lib/NGT/MmapManager.cpp
@@ -75,7 +75,7 @@ namespace MemoryManager{
         std::cerr << "too long filepath" << std::endl;
         return false;
       }
-      if((size % sysconf(_SC_PAGESIZE) != 0) || ( size < MMAP_LOWER_SIZE )){
+      if((size % MMAP_CNTL_PAGE_SIZE != 0) || ( size < MMAP_LOWER_SIZE )){
         std::cerr << "input size error" << std::endl;
         return false;
       }
@@ -364,6 +364,9 @@ namespace MemoryManager{
 
   std::string getErrorStr(int32_t err_num){
     char err_msg[256];
+#ifdef WIN32
+    #define strerror_r(errno,buf,len) strerror_s(buf,len,errno)
+#endif
 #ifdef _GNU_SOURCE
     char *msg = strerror_r(err_num, err_msg, 256);
     return std::string(msg);

--- a/internal/core/src/index/thirdparty/NGT/lib/NGT/MmapManagerDefs.h
+++ b/internal/core/src/index/thirdparty/NGT/lib/NGT/MmapManagerDefs.h
@@ -25,7 +25,12 @@ namespace MemoryManager{
   
   const bool MMAP_DEFAULT_ALLOW_EXPAND = false; 
   const uint64_t MMAP_CNTL_FILE_RANGE = 16; 
-  const size_t MMAP_CNTL_FILE_SIZE = MMAP_CNTL_FILE_RANGE * sysconf(_SC_PAGESIZE); 
+  #ifdef WIN32
+  const size_t MMAP_CNTL_PAGE_SIZE = 65536;
+  #else
+  const size_t MMAP_CNTL_PAGE_SIZE = sysconf(_SC_PAGESIZE);
+  #endif
+  const size_t MMAP_CNTL_FILE_SIZE = MMAP_CNTL_FILE_RANGE * MMAP_CNTL_PAGE_SIZE;
   const uint64_t MMAP_MAX_FILE_NAME_LENGTH = 1024; 
   const std::string MMAP_CNTL_FILE_SUFFIX = "c"; 
   

--- a/internal/core/src/index/thirdparty/NGT/lib/NGT/SharedMemoryAllocator.h
+++ b/internal/core/src/index/thirdparty/NGT/lib/NGT/SharedMemoryAllocator.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include	"NGT/defines.h"
+#include	"NGT/MmapManagerDefs.h"
 #include	"NGT/MmapManager.h"
 
 #include	<unistd.h>
@@ -111,8 +112,8 @@ class SharedMemoryAllocator {
     if (msize == 0) {
       msize = NGT_SHARED_MEMORY_MAX_SIZE;
     }
-    size_t bsize = msize * 1048576 / sysconf(_SC_PAGESIZE) + 1; // 1048576=1M
-    uint64_t size = bsize * sysconf(_SC_PAGESIZE);
+    size_t bsize = msize * 1048576 / MemoryManager::MMAP_CNTL_PAGE_SIZE + 1; // 1048576=1M
+    uint64_t size = bsize * MemoryManager::MMAP_CNTL_PAGE_SIZE;
     MemoryManager::init_option_st option;
     MemoryManager::MmapManager::setDefaultOptionValue(option);
     option.use_expand = true;
@@ -171,7 +172,7 @@ class SharedMemoryAllocator {
 #if defined(MMAP_MANAGER) && !defined(NOT_USE_MMAP_ALLOCATOR)
     return mmanager->getAbsAddr(oft); 
 #else
-    return (void*)oft;
+    return reinterpret_cast<void*>(oft);
 #endif
   }
   off_t getOffset(void *adr) { 
@@ -181,7 +182,7 @@ class SharedMemoryAllocator {
 #if defined(MMAP_MANAGER) && !defined(NOT_USE_MMAP_ALLOCATOR)
     return mmanager->getRelAddr(adr); 
 #else
-    return (off_t)adr;
+    return static_cast<off_t>(reinterpret_cast<int64_t>(adr));
 #endif
   }
   size_t getMemorySize(GetMemorySizeType t) {

--- a/internal/core/src/index/thirdparty/faiss/Makefile
+++ b/internal/core/src/index/thirdparty/faiss/Makefile
@@ -32,7 +32,7 @@ NVCCFLAGS += -I.
 ############################
 # Building
 
-all: libfaiss.a libfaiss.$(SHAREDEXT)
+all: libfaiss.a
 
 libfaiss.a: $(OBJ)
 	$(AR) r $@ $^
@@ -55,15 +55,15 @@ libfaiss.$(SHAREDEXT): $(OBJ)
 	$(NVCC) $(NVCCFLAGS) -c $< -o $@
 
 clean:
-	rm -f libfaiss.a libfaiss.$(SHAREDEXT)
+	rm -f libfaiss.a
 	rm -f $(OBJ)
 
 
 ############################
 # Installing
 
-install: libfaiss.a libfaiss.$(SHAREDEXT) installdirs
-	cp libfaiss.a libfaiss.$(SHAREDEXT) $(DESTDIR)$(libdir)
+install: libfaiss.a installdirs
+	cp libfaiss.a $(DESTDIR)$(libdir)
 	tar cf - $(HEADERS) | tar xf - -C $(DESTDIR)$(includedir)/faiss/
 
 installdirs:


### PR DESCRIPTION
- remove unneded signal handler c++ source: SignalHandler.
- remove fiu linking under MSYS.
- int types alignment.
- build faiss only with static library, this simply for linking under MSYS.
- NGT source adaptation for MSYS:
  * using std::uniform_int_distribution instead of rand_r
  * int types alignment
  * mapping some POSIX function to windows c runtime.

issue: #7706

Signed-off-by: Ji Bin <matrixji@live.com>