### PR TITLE
Optimize import  of index wrapper

### DIFF
--- a/tests/python_client/base/index_wrapper.py
+++ b/tests/python_client/base/index_wrapper.py
@@ -2,8 +2,7 @@ import sys
 from pymilvus import Index
 
 sys.path.append("..")
-from check.param_check import *
-from check.func_check import *
+from check.func_check import ResponseChecker
 from utils.api_request import api_request
 
 


### PR DESCRIPTION
- remove import `*` in `index_wrapper.py`

issue: #8393

Signed-off-by: ThreadDao yufen.zong@zilliz.com