### PR TITLE
Optimize partition wrapper import

### DIFF
--- a/tests/python_client/base/partition_wrapper.py
+++ b/tests/python_client/base/partition_wrapper.py
@@ -1,8 +1,9 @@
 import sys
 
+from pymilvus import Partition
+
 sys.path.append("..")
-from check.param_check import *
-from check.func_check import *
+from check.func_check import ResponseChecker
 from utils.api_request import api_request
 
 


### PR DESCRIPTION
- remove import `*` in `partition_wrapper.py`

issue: #8393

Signed-off-by: ThreadDao yufen.zong@zilliz.com