### PR TITLE
Remove import star of test_mysql

### DIFF
--- a/tests/python_client/testcases/stability/test_mysql.py
+++ b/tests/python_client/testcases/stability/test_mysql.py
@@ -5,7 +5,9 @@ import threading
 import logging
 from multiprocessing import Pool, Process
 import pytest
-from utils.utils import *
+from pymilvus import IndexType
+
+from utils.utils import get_milvus, gen_vectors, default_dim
 from common.common_type import CaseLabel
 
 class TestMysql:


### PR DESCRIPTION
- Remove import `*` in `test_mysql.py`

issue: #8393

Signed-off-by: ThreadDao <yufen.zong@zilliz.com>