### PR TITLE
Remove import start of test restart file

### DIFF
--- a/tests/python_client/testcases/stability/test_restart.py
+++ b/tests/python_client/testcases/stability/test_restart.py
@@ -6,7 +6,8 @@ import logging
 import json
 from multiprocessing import Pool, Process
 import pytest
-from utils.utils import *
+from utils.utils import get_milvus, restart_server, gen_entities, gen_unique_str, default_nb
+from common.constants import default_fields, default_entities
 from common.common_type import CaseLabel
 
 
@@ -50,7 +51,7 @@ class TestRestartBase:
         connect.flush([collection])
         res_count = connect.count_entities(collection)
         logging.getLogger().info(res_count)
-        assert res_count == 2 * nb
+        assert res_count == 2 * default_nb
         # restart server
         logging.getLogger().info("Start restart server")
         assert restart_server(args["service_name"])
@@ -58,7 +59,7 @@ class TestRestartBase:
         new_connect = get_milvus(args["ip"], args["port"], handler=args["handler"])
         res_count = new_connect.count_entities(collection)
         logging.getLogger().info(res_count)
-        assert res_count == 2 * nb
+        assert res_count == 2 * default_nb
 
     @pytest.mark.tags(CaseLabel.L2)
     def _test_insert_during_flushing(self, connect, collection, args):


### PR DESCRIPTION
- Remove import `*` of `test_restart.py`

issue: #8393

Signed-off-by: ThreadDao yufen.zong@zilliz.com