### PR TITLE
[skip ci] Update doc of binlog event data

### DIFF
--- a/docs/developer_guides/chap08_binlog.md
+++ b/docs/developer_guides/chap08_binlog.md
@@ -92,8 +92,6 @@ INSERT_EVENT:
 | event  | fixed  |  StartTimestamp      x : 8   | min timestamp in this event                              |
 | data   | part   +------------------------------+----------------------------------------------------------+
 |        |        |  EndTimestamp      x+8 : 8   | max timestamp in this event                              |
-|        |        +------------------------------+----------------------------------------------------------+
-|        |        |  reserved         x+16 : y   | reserved part                                            |
 |        +--------+------------------------------+----------------------------------------------------------+
 |        |variable|  parquet payload             | payload in parquet format                                |
 |        |part    |                              |                                                          |


### PR DESCRIPTION
We don't have reserved part for event data, so remove it from documentation.

Signed-off-by: dragondriver <jiquan.long@zilliz.com>
/cc @czs007 @xiaofan-luan @scsven 
/kind improvement
issue: #9641 