### PR TITLE
Trim segmentinfo binlog for VChaninfo usage

### DIFF
--- a/internal/datacoord/server_test.go
+++ b/internal/datacoord/server_test.go
@@ -1196,7 +1196,7 @@ func TestGetRecoveryInfo(t *testing.T) {
 		assert.EqualValues(t, commonpb.ErrorCode_Success, resp.Status.ErrorCode)
 		assert.EqualValues(t, 1, len(resp.GetChannels()))
 		assert.EqualValues(t, 0, len(resp.GetChannels()[0].GetUnflushedSegments()))
-		assert.ElementsMatch(t, []*datapb.SegmentInfo{seg1, seg2}, resp.GetChannels()[0].GetFlushedSegments())
+		assert.ElementsMatch(t, []*datapb.SegmentInfo{trimSegmentInfo(seg1), trimSegmentInfo(seg2)}, resp.GetChannels()[0].GetFlushedSegments())
 		assert.EqualValues(t, 20, resp.GetChannels()[0].GetSeekPosition().GetTimestamp())
 	})
 


### PR DESCRIPTION
Remove not needed binlog info from VChannelInfo

Related: #9787 

/kind bug enhancement

Signed-off-by: Congqi Xia <congqi.xia@zilliz.com>