### PR TITLE
Rename IndexRootPath to IndexStorageRootPath

### DIFF
--- a/internal/indexcoord/index_coord.go
+++ b/internal/indexcoord/index_coord.go
@@ -628,7 +628,7 @@ func (i *IndexCoord) recycleUnusedIndexFiles() {
 			log.Debug("IndexCoord recycleUnusedIndexFiles", zap.Int("Need recycle tasks num", len(metas)))
 			for _, meta := range metas {
 				if meta.indexMeta.MarkDeleted {
-					unusedIndexFilePathPrefix := Params.IndexRootPath + "/" + strconv.Itoa(int(meta.indexMeta.IndexBuildID))
+					unusedIndexFilePathPrefix := Params.IndexStorageRootPath + "/" + strconv.Itoa(int(meta.indexMeta.IndexBuildID))
 					log.Debug("IndexCoord recycleUnusedIndexFiles",
 						zap.Int64("Recycle the index files for deleted index with indexBuildID", meta.indexMeta.IndexBuildID))
 					if err := i.kv.RemoveWithPrefix(unusedIndexFilePathPrefix); err != nil {
@@ -642,7 +642,7 @@ func (i *IndexCoord) recycleUnusedIndexFiles() {
 					log.Debug("IndexCoord recycleUnusedIndexFiles",
 						zap.Int64("Recycle the low version index files of the index with indexBuildID", meta.indexMeta.IndexBuildID))
 					for j := 1; j < int(meta.indexMeta.Version); j++ {
-						unusedIndexFilePathPrefix := Params.IndexRootPath + "/" + strconv.Itoa(int(meta.indexMeta.IndexBuildID)) + "/" + strconv.Itoa(j)
+						unusedIndexFilePathPrefix := Params.IndexStorageRootPath + "/" + strconv.Itoa(int(meta.indexMeta.IndexBuildID)) + "/" + strconv.Itoa(j)
 						if err := i.kv.RemoveWithPrefix(unusedIndexFilePathPrefix); err != nil {
 							log.Error("IndexCoord recycleUnusedIndexFiles Remove index files failed",
 								zap.Bool("MarkDeleted", false), zap.Error(err))

--- a/internal/indexcoord/param_table.go
+++ b/internal/indexcoord/param_table.go
@@ -33,10 +33,10 @@ type ParamTable struct {
 	Address string
 	Port    int
 
-	EtcdEndpoints []string
-	KvRootPath    string
-	MetaRootPath  string
-	IndexRootPath string
+	EtcdEndpoints        []string
+	KvRootPath           string
+	MetaRootPath         string
+	IndexStorageRootPath string
 
 	MinIOAddress         string
 	MinIOAccessKeyID     string
@@ -69,7 +69,7 @@ func (pt *ParamTable) Init() {
 	pt.initMinIOSecretAccessKey()
 	pt.initMinIOUseSSL()
 	pt.initMinioBucketName()
-	pt.initIndexRootPath()
+	pt.initIndexStorageRootPath()
 	pt.initRoleName()
 }
 
@@ -162,13 +162,13 @@ func (pt *ParamTable) initMinioBucketName() {
 	pt.MinioBucketName = bucketName
 }
 
-// initIndexRootPath initializes the root path of index files.
-func (pt *ParamTable) initIndexRootPath() {
+// initIndexStorageRootPath initializes the root path of index files.
+func (pt *ParamTable) initIndexStorageRootPath() {
 	rootPath, err := pt.Load("minio.rootPath")
 	if err != nil {
 		panic(err)
 	}
-	pt.IndexRootPath = path.Join(rootPath, "index_files")
+	pt.IndexStorageRootPath = path.Join(rootPath, "index_files")
 }
 
 func (pt *ParamTable) initRoleName() {

--- a/internal/indexcoord/param_table_test.go
+++ b/internal/indexcoord/param_table_test.go
@@ -74,8 +74,8 @@ func TestParamTable(t *testing.T) {
 		t.Logf("UpdatedTime: %v", Params.UpdatedTime)
 	})
 
-	t.Run("initIndexRootPath", func(t *testing.T) {
-		t.Logf("IndexRootPath: %v", Params.IndexRootPath)
+	t.Run("initIndexStorageRootPath", func(t *testing.T) {
+		t.Logf("IndexStorageRootPath: %v", Params.IndexStorageRootPath)
 	})
 }
 

--- a/internal/indexnode/param_table.go
+++ b/internal/indexnode/param_table.go
@@ -40,9 +40,9 @@ type ParamTable struct {
 	NodeID int64
 	Alias  string
 
-	EtcdEndpoints []string
-	MetaRootPath  string
-	IndexRootPath string
+	EtcdEndpoints        []string
+	MetaRootPath         string
+	IndexStorageRootPath string
 
 	MinIOAddress         string
 	MinIOAccessKeyID     string
@@ -91,7 +91,7 @@ func (pt *ParamTable) initParams() {
 	pt.initMinioBucketName()
 	pt.initEtcdEndpoints()
 	pt.initMetaRootPath()
-	pt.initIndexRootPath()
+	pt.initIndexStorageRootPath()
 	pt.initRoleName()
 	pt.initKnowhereSimdType()
 }
@@ -151,12 +151,12 @@ func (pt *ParamTable) initMetaRootPath() {
 	pt.MetaRootPath = path.Join(rootPath, subPath)
 }
 
-func (pt *ParamTable) initIndexRootPath() {
+func (pt *ParamTable) initIndexStorageRootPath() {
 	rootPath, err := pt.Load("minio.rootPath")
 	if err != nil {
 		panic(err)
 	}
-	pt.IndexRootPath = path.Join(rootPath, "index_files")
+	pt.IndexStorageRootPath = path.Join(rootPath, "index_files")
 }
 
 func (pt *ParamTable) initMinioBucketName() {

--- a/internal/indexnode/param_table_test.go
+++ b/internal/indexnode/param_table_test.go
@@ -87,8 +87,8 @@ func TestParamTable(t *testing.T) {
 		t.Logf("UpdatedTime: %v", Params.UpdatedTime)
 	})
 
-	t.Run("IndexRootPath", func(t *testing.T) {
-		t.Logf("IndexRootPath: %v", Params.IndexRootPath)
+	t.Run("IndexStorageRootPath", func(t *testing.T) {
+		t.Logf("IndexStorageRootPath: %v", Params.IndexStorageRootPath)
 	})
 }
 

--- a/internal/indexnode/task.go
+++ b/internal/indexnode/task.go
@@ -412,7 +412,7 @@ func (it *IndexBuildTask) Execute(ctx context.Context) error {
 
 		getSavePathByKey := func(key string) string {
 
-			return path.Join(Params.IndexRootPath, strconv.Itoa(int(it.req.IndexBuildID)), strconv.Itoa(int(it.req.Version)),
+			return path.Join(Params.IndexStorageRootPath, strconv.Itoa(int(it.req.IndexBuildID)), strconv.Itoa(int(it.req.Version)),
 				strconv.Itoa(int(partitionID)), strconv.Itoa(int(segmentID)), key)
 		}
 		saveBlob := func(path string, value []byte) error {


### PR DESCRIPTION
IndexRootPath is index file's blob storage prefix.
But the name is confusing with the MetaRootPath, which is prefix of etcd.

This PR changes the IndexRootPath to IndexStorageRootPath to
elimilate the confusion.

Signed-off-by: yangxuan <xuan.yang@zilliz.com>

/kind improvement
/cc @xiaocai2333 