### PR TITLE
MAXFLOAT to FLT_MAX for better compatibility

### DIFF
--- a/internal/core/src/segcore/ReduceStructure.h
+++ b/internal/core/src/segcore/ReduceStructure.h
@@ -9,6 +9,7 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
+#include <cfloat>
 #include <cmath>
 
 #include "common/Consts.h"
@@ -56,11 +57,11 @@ struct SearchResultPair {
                 distance_ = search_result_->result_distances_.at(offset_);
             } else {
                 primary_key_ = INVALID_ID;
-                distance_ = MAXFLOAT;
+                distance_ = FLT_MAX;
             }
         } else {
             primary_key_ = INVALID_ID;
-            distance_ = MAXFLOAT;
+            distance_ = FLT_MAX;
         }
     }
 };

--- a/internal/core/src/segcore/reduce_c.cpp
+++ b/internal/core/src/segcore/reduce_c.cpp
@@ -9,6 +9,7 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
+#include <cfloat>
 #include <unordered_set>
 #include <vector>
 
@@ -143,7 +144,7 @@ ReduceResultData(std::vector<SearchResult*>& search_results, int64_t nq, int64_t
         for (int j = 0; j < search_records[i].size(); j++) {
             auto& offset = search_records[i][j];
             primary_keys.push_back(offset != INVALID_OFFSET ? search_result->primary_keys_[offset] : INVALID_ID);
-            result_distances.push_back(offset != INVALID_OFFSET ? search_result->result_distances_[offset] : MAXFLOAT);
+            result_distances.push_back(offset != INVALID_OFFSET ? search_result->result_distances_[offset] : FLT_MAX);
             internal_seg_offsets.push_back(offset != INVALID_OFFSET ? search_result->internal_seg_offsets_[offset]
                                                                     : INVALID_SEG_OFFSET);
         }


### PR DESCRIPTION
MAXFLOAT is not standard in C++, so not available under windows/MSYS.
This improvement is for #7706

Related Issue: #7706

Signed-off-by: Ji Bin <matrixji@live.com>