### PR TITLE
Change default retentionSizeInMB to 8192(8GB)

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -44,9 +44,9 @@ pulsar:
 
 rocksmq:
   path: /var/lib/milvus/rdb_data
-  rocksmqPageSize: 2147483648 # 2 GB, 2 * 1024 * 1024 * 1024
-  retentionTimeInMinutes: 4320 # 3 days, 3 * 24 * 60
-  retentionSizeInMB: 0
+  rocksmqPageSize: 2147483648 # 2 GB, 2 * 1024 * 1024 * 1024 bytes
+  retentionTimeInMinutes: 10080 # 7 days, 7 * 24 * 60 minutes
+  retentionSizeInMB: 8192 # 8 GB, 8 * 1024 MB
 
 # Related configuration of rootCoord, used to handle data definition language (DDL) and data control language (DCL) requests
 rootCoord:

--- a/internal/util/rocksmq/server/rocksmq/rocksmq_retention.go
+++ b/internal/util/rocksmq/server/rocksmq/rocksmq_retention.go
@@ -26,10 +26,10 @@ import (
 )
 
 // RocksmqRetentionTimeInMinutes is the time of retention
-var RocksmqRetentionTimeInMinutes int64 = 4320
+var RocksmqRetentionTimeInMinutes int64 = 10080
 
 // RocksmqRetentionSizeInMB is the size of retention
-var RocksmqRetentionSizeInMB int64 = 0
+var RocksmqRetentionSizeInMB int64 = 8192
 
 // Const value that used to convert unit
 const (


### PR DESCRIPTION
Signed-off-by: fishpenguin <kun.yu@zilliz.com>

/kind improvement

Used to be 0, means that messages will be deleted once a page is full when do check. Changing to 2GB seems more reasonable. 