### PR TITLE
[skip ci]  Disable service links

### DIFF
--- a/build/ci/jenkins/pod/krte.yaml
+++ b/build/ci/jenkins/pod/krte.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     app: milvus-e2e
 spec:
+  enableServiceLinks: false
   containers:
   - name: main
     image: milvusdb/krte:20210722-806d13f


### PR DESCRIPTION
set enableServiceLinks false to make information in `printenv ` more clean
Signed-off-by: Jenny Li <jing.li@zilliz.com>

/kind improvement
/cc @LoveEachDay @zwd1208 @yanliang567