### PR TITLE
Change pulsar retentionSizeInMB to 8192(8GB)

### DIFF
--- a/deployments/docker/cluster/docker-compose.yml
+++ b/deployments/docker/cluster/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       # nettyMaxFrameSizeBytes must be calculated from maxMessageSize + 10240 (padding)
       - nettyMaxFrameSizeBytes=104867840 # this is 104857600 + 10240 (padding)
       - defaultRetentionTimeInMinutes=10080
-      - defaultRetentionSizeInMB=-1
+      - defaultRetentionSizeInMB=8192
       # maxMessageSize is missing from standalone.conf, must use PULSAR_PREFIX_ to get it configured
       - PULSAR_PREFIX_maxMessageSize=104857600
       - PULSAR_GC=-XX:+UseG1GC

--- a/deployments/docker/dev/docker-compose.yml
+++ b/deployments/docker/dev/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       # nettyMaxFrameSizeBytes must be calculated from maxMessageSize + 10240 (padding)
       - nettyMaxFrameSizeBytes=104867840 # this is 104857600 + 10240 (padding)
       - defaultRetentionTimeInMinutes=10080
-      - defaultRetentionSizeInMB=-1
+      - defaultRetentionSizeInMB=8192
       # maxMessageSize is missing from standalone.conf, must use PULSAR_PREFIX_ to get it configured
       - PULSAR_PREFIX_maxMessageSize=104857600
       - PULSAR_GC=-XX:+UseG1GC


### PR DESCRIPTION
Signed-off-by: fishpenguin <kun.yu@zilliz.com>

/kind improvement

Reason: Used to be -1 ,means that pulsar won't do expired clean by size. Change to 8GB, if the message grows to 8GB, message will be expired clean up.