### PR TITLE
Check docker before setup kind cluster

### DIFF
--- a/tests/scripts/e2e-k8s.sh
+++ b/tests/scripts/e2e-k8s.sh
@@ -251,6 +251,11 @@ if [[ -z "${SKIP_SETUP:-}" ]]; then
   export DEFAULT_CLUSTER_YAML="${ROOT}/build/config/topology/trustworthy-jwt.yaml"
   export METRICS_SERVER_CONFIG_DIR="${ROOT}/build/config/metrics"
 
+  if ! docker info > /dev/null 2>&1; then
+    echo "KinD need docker to set up cluster - please start docker and try again!"
+    exit 1
+  fi
+
   if [[ "${TOPOLOGY}" == "SINGLE_CLUSTER" ]]; then
     trace "setup kind cluster" setup_kind_cluster "${SINGLE_CLUSTER_NAME}" "${NODE_IMAGE}" "${KIND_CONFIG}"
   else


### PR DESCRIPTION
Signed-off-by: Jenny Li <jing.li@zilliz.com>

/kind improvement
/cc @LoveEachDay @zwd1208 @yanliang567


check docker before setup kinD cluster to make the error message more clear when docker isn't running

Before the error message is 
```
ERROR: failed to delete cluster "kind": error listing nodes: failed to list clusters: command "docker ps -a --filter label=io.x-k8s.kind.cluster=kind --format '{{.Names}}'" failed with error: exit status 1
Command Output: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
Stack Trace:
sigs.k8s.io/kind/pkg/errors.WithStack
	sigs.k8s.io/kind/pkg/errors/errors.go:59
sigs.k8s.io/kind/pkg/exec.(*LocalCmd).Run
	sigs.k8s.io/kind/pkg/exec/local.go:124
sigs.k8s.io/kind/pkg/exec.OutputLines
	sigs.k8s.io/kind/pkg/exec/helpers.go:81
sigs.k8s.io/kind/pkg/cluster/internal/providers/docker.(*provider).ListNodes
	sigs.k8s.io/kind/pkg/cluster/internal/providers/docker/provider.go:125
sigs.k8s.io/kind/pkg/cluster/internal/delete.Cluster
	sigs.k8s.io/kind/pkg/cluster/internal/delete/delete.go:31
sigs.k8s.io/kind/pkg/cluster.(*Provider).Delete
	sigs.k8s.io/kind/pkg/cluster/provider.go:188
sigs.k8s.io/kind/pkg/cmd/kind/delete/cluster.deleteCluster
	sigs.k8s.io/kind/pkg/cmd/kind/delete/cluster/deletecluster.go:63
sigs.k8s.io/kind/pkg/cmd/kind/delete/cluster.NewCommand.func1
	sigs.k8s.io/kind/pkg/cmd/kind/delete/cluster/deletecluster.go:48
github.com/spf13/cobra.(*Command).execute
	github.com/spf13/cobra@v1.1.1/command.go:850
github.com/spf13/cobra.(*Command).ExecuteC
	github.com/spf13/cobra@v1.1.1/command.go:958
github.com/spf13/cobra.(*Command).Execute
	github.com/spf13/cobra@v1.1.1/command.go:895
sigs.k8s.io/kind/cmd/kind/app.Run
	sigs.k8s.io/kind/cmd/kind/app/main.go:53
sigs.k8s.io/kind/cmd/kind/app.Main
	sigs.k8s.io/kind/cmd/kind/app/main.go:35
main.main
	sigs.k8s.io/kind/main.go:25
runtime.main
	runtime/proc.go:225
runtime.goexit
	runtime/asm_amd64.s:1371
```


After improvement, you will see the 

```
KinD need docker to set up cluster - please start docker and try again!
```