### PR TITLE
[skip ci] Remove Kubectl for CI pytest

### DIFF
--- a/build/ci/jenkins/Nightly.groovy
+++ b/build/ci/jenkins/Nightly.groovy
@@ -139,14 +139,8 @@ pipeline {
                                                         sh """ 
                                                         MILVUS_HELM_RELEASE_NAME="${release_name}" \
                                                         MILVUS_CLUSTER_ENABLED="${clusterEnabled}" \
-                                                        ./e2e-k8s.sh \
-                                                        --skip-export-logs \
-                                                        --skip-install \
-                                                        --skip-cleanup \
-                                                        --skip-setup \
-                                                        --skip-build \
-                                                        --skip-build-image --test-extra-arg "-n 4 --tags L0 L1 L2 --repeat-scope=session" \
-                                                        --test-timeout ${e2e_timeout_seconds}
+                                                        TEST_TIMEOUT="${e2e_timeout_seconds}" \
+                                                        ./ci_e2e.sh  "-n 4 --tags L0 L1 L2 --repeat-scope=session"
                                                         """
                                                     } else {
                                                     error "Error: Unsupported Milvus client: ${MILVUS_CLIENT}"

--- a/tests/scripts/ci_e2e.sh
+++ b/tests/scripts/ci_e2e.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Copyright 2018 Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+ROOT="$( cd -P "$( dirname "$SOURCE" )/../.." && pwd )"
+
+set -e
+set -u
+set -x
+
+
+
+MILVUS_HELM_RELEASE_NAME="${MILVUS_HELM_RELEASE_NAME:-milvus-testing}"
+MILVUS_CLUSTER_ENABLED="${MILVUS_CLUSTER_ENABLED:-false}"
+MILVUS_HELM_NAMESPACE="${MILVUS_HELM_NAMESPACE:-default}"
+PARALLEL_NUM="${PARALLEL_NUM:-6}"
+MILVUS_CLIENT="${MILVUS_CLIENT:-pymilvus}"
+CI_LOG_PATH=/tmp/ci_logs/test
+MILVUS_SERVICE_NAME=$(echo "${MILVUS_HELM_RELEASE_NAME}-milvus.milvus-ci" | tr -d '\n')
+MILVUS_SERVICE_PORT="19530"
+
+# shellcheck source=build/lib.sh
+source "${ROOT}/build/lib.sh"
+
+
+# shellcheck source=ci-util.sh
+source "${ROOT}/tests/scripts/ci-util.sh"
+
+
+cd ${ROOT}/tests/python_client
+python3 -V
+if [ ! -d "${CI_LOG_PATH}" ]; then
+mkdir -p ${CI_LOG_PATH}
+fi
+trace "prepare e2e test"  install_pytest_requirements  
+
+pytest --host ${MILVUS_SERVICE_NAME} --port ${MILVUS_SERVICE_PORT} \
+                                        --html=${CI_LOG_PATH}/report.html --self-contained-html ${@:-}
+trace "e2e test" "timeout" "${TEST_TIMEOUT:-}" `pytest --host ${MILVUS_SERVICE_NAME} --port ${MILVUS_SERVICE_PORT} \
+                                        --html=${CI_LOG_PATH}/report.html --self-contained-html ${@:-}`


### PR DESCRIPTION
Signed-off-by: Jenny Li <jing.li@zilliz.com>
/kind improvement
/cc @LoveEachDay @zwd1208 @yanliang567

1. use new ci-e2e script to make code clean for pytest  stage only
2. use service name to access milvus istead of IP so that  do not need to install`kubectl` tool (save time)