### PR TITLE
Set start position for compact result segment

### DIFF
--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -531,10 +531,14 @@ func (m *meta) CompleteMergeCompaction(compactionLogs []*datapb.CompactionSegmen
 		}
 	}
 
-	var dmlPosition *internalpb.MsgPosition
+	var startPosition, dmlPosition *internalpb.MsgPosition
 	for _, s := range segments {
 		if dmlPosition == nil || s.GetDmlPosition().Timestamp > dmlPosition.Timestamp {
 			dmlPosition = s.GetDmlPosition()
+		}
+
+		if startPosition == nil || s.GetStartPosition().Timestamp < startPosition.Timestamp {
+			startPosition = s.GetStartPosition()
 		}
 	}
 
@@ -569,6 +573,7 @@ func (m *meta) CompleteMergeCompaction(compactionLogs []*datapb.CompactionSegmen
 			Binlogs:             result.GetInsertLogs(),
 			Statslogs:           result.GetField2StatslogPaths(),
 			Deltalogs:           deltalogs,
+			StartPosition:       startPosition,
 			DmlPosition:         dmlPosition,
 			CreatedByCompaction: true,
 			CompactionFrom:      compactionFrom,

--- a/internal/datacoord/server_test.go
+++ b/internal/datacoord/server_test.go
@@ -1291,7 +1291,7 @@ func TestShouldDropChannel(t *testing.T) {
 		CollectionID:   0,
 		PartitionID:    0,
 		InsertChannel:  "ch1",
-		State:          commonpb.SegmentState_Dropped,
+		State:          commonpb.SegmentState_Flushed,
 		CompactionFrom: []int64{4, 5},
 		StartPosition: &internalpb.MsgPosition{
 			ChannelName: "ch1",
@@ -1345,16 +1345,18 @@ func TestShouldDropChannel(t *testing.T) {
 		assert.True(t, r)
 	})
 
-	t.Run("channel with all dropped segments and compacted segments", func(t *testing.T) {
+	t.Run("channel with all dropped segments and flushed compacted segments", func(t *testing.T) {
 		err := svr.meta.AddSegment(NewSegmentInfo(s2))
 		require.Nil(t, err)
 
 		r := svr.handler.CheckShouldDropChannel("ch1")
-		assert.True(t, r)
+		assert.False(t, r)
 	})
 
 	t.Run("channel with other state segments", func(t *testing.T) {
-		err := svr.meta.AddSegment(NewSegmentInfo(s3))
+		err := svr.meta.DropSegment(2)
+		require.Nil(t, err)
+		err = svr.meta.AddSegment(NewSegmentInfo(s3))
 		require.Nil(t, err)
 
 		r := svr.handler.CheckShouldDropChannel("ch1")


### PR DESCRIPTION
Fix StartPosition of compaction result segment not set problem

See also #12265

/kind bug

Signed-off-by: Congqi Xia <congqi.xia@zilliz.com>