### PR TITLE
[skip ci] Set docker mirror for ci build docker image

### DIFF
--- a/build/ci/jenkins/Jenkinsfile
+++ b/build/ci/jenkins/Jenkinsfile
@@ -33,7 +33,7 @@ pipeline {
                         customWorkspace '/home/jenkins/agent/workspace'
                         // We allow this pod to remain active for a while, later jobs can
                         // reuse cache in previous created nodes.
-                        idleMinutes 120
+                        // idleMinutes 120
                     }
                 }
                 environment {
@@ -52,6 +52,9 @@ pipeline {
                                 }
                             }
                             container('main') {
+                                dir ('build'){
+                                     sh './set_docker_mirror.sh'
+                                }
                                 dir ('tests/scripts') {
                                     script {
                                         sh 'printenv'

--- a/build/ci/jenkins/Nightly.groovy
+++ b/build/ci/jenkins/Nightly.groovy
@@ -47,6 +47,9 @@ pipeline {
         stage ('Build'){
             steps {
                 container('main') {
+                    dir ('build'){
+                            sh './set_docker_mirror.sh'
+                    }
                     dir ('tests/scripts') {
                         script {
                             sh 'printenv'

--- a/build/ci/jenkins/PR.groovy
+++ b/build/ci/jenkins/PR.groovy
@@ -20,7 +20,7 @@ pipeline {
                 defaultContainer 'main'
                 yamlFile 'build/ci/jenkins/pod/rte.yaml'
                 customWorkspace '/home/jenkins/agent/workspace'
-                idleMinutes 120
+                // idleMinutes 120
             }
     }
     environment {
@@ -42,6 +42,9 @@ pipeline {
         stage ('Build'){
             steps {
                 container('main') {
+                    dir ('build'){
+                            sh './set_docker_mirror.sh'
+                    }
                     dir ('tests/scripts') {
                         script {
                             sh 'printenv'

--- a/build/ci/jenkins/PublishImages.groovy
+++ b/build/ci/jenkins/PublishImages.groovy
@@ -32,6 +32,7 @@ pipeline {
             steps {
                 container('main') {
                     script {
+                        sh './build/set_docker_mirror.sh'
                         sh "build/builder.sh /bin/bash -c \"make install\""
 
                         def date = sh(returnStdout: true, script: 'date +%Y%m%d').trim()

--- a/build/set_docker_mirror.sh
+++ b/build/set_docker_mirror.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Use Internal docker mirror to solve  https://www.docker.com/increase-rate-limits
+set -e
+
+MIRROR_URL="http://10.201.177.237:5000"
+set_daemon_json_file(){
+    DOCKER_DAEMON_JSON_FILE="/etc/docker/daemon.json"
+    if test -f ${DOCKER_DAEMON_JSON_FILE}
+    then
+        cp  ${DOCKER_DAEMON_JSON_FILE} "${DOCKER_DAEMON_JSON_FILE}.bak"
+        if  grep -q registry-mirrors "${DOCKER_DAEMON_JSON_FILE}.bak";then
+             cat "${DOCKER_DAEMON_JSON_FILE}.bak" | sed -n "1h;1"'!'"H;\${g;s|\"registry-mirrors\":\s*\[[^]]*\]|\"registry-mirrors\": [\"${MIRROR_URL}\"]|g;p;}" |  tee ${DOCKER_DAEMON_JSON_FILE}
+        else
+            cat "${DOCKER_DAEMON_JSON_FILE}.bak" | sed -n "s|{|{\"registry-mirrors\": [\"${MIRROR_URL}\"],|g;p;" |  tee ${DOCKER_DAEMON_JSON_FILE}
+        fi
+    else
+        mkdir -p "/etc/docker"
+        echo "{\"registry-mirrors\": [\"${MIRROR_URL}\"]}" | tee ${DOCKER_DAEMON_JSON_FILE}
+    fi
+}
+restart_docker () {
+    echo "set-mirror.sh] service docker start"
+    docker ps -aq | xargs -r docker rm -f || true
+    service docker stop || true
+    service docker start 
+    while true; do
+    # docker ps -q should only work if the daemon is ready
+    docker info > /dev/null 2>&1 && break
+    if [[ ${WAIT_N} -lt 5 ]]; then
+      WAIT_N=$((WAIT_N+1))
+      echo " set-mirror.sh] Waiting for Docker to be ready, sleeping for ${WAIT_N} seconds ..."
+      sleep ${WAIT_N}
+    else
+      echo "set-mirror.sh] [SETUP] Reached maximum attempts, not waiting any longer ..."
+      break
+    fi
+  done
+  echo "Show Docker Info With mirror url"
+  docker info
+}
+
+set_mirror(){
+    set_daemon_json_file
+    restart_docker 
+    echo "Success."
+    exit 0
+    
+}
+
+set_mirror


### PR DESCRIPTION
Signed-off-by: Jenny Li <jing.li@zilliz.com>
/kind improvement
 /cc @LoveEachDay @zwd1208 @yanliang567
1. Add docker-mirror script to avoid pull rate limit https://www.docker.com/increase-rate-limits
2. Remove idle time to avoid idle pod issues like can not pull code
3. Roll back strategy is easy, just remove the code execute the `sh './set_docker_mirror.sh'` part 
4. Add devops email to get the failed build notification in case of any problems.