### PR TITLE
Remove redundant conversion in event_writer.go

### DIFF
--- a/internal/storage/event_writer.go
+++ b/internal/storage/event_writer.go
@@ -17,7 +17,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"strconv"
 
 	"github.com/milvus-io/milvus/internal/common"
 	"github.com/milvus-io/milvus/internal/proto/schemapb"
@@ -86,7 +85,7 @@ func readMagicNumber(buffer io.Reader) (int32, error) {
 		return -1, err
 	}
 	if magicNumber != MagicNumber {
-		return -1, fmt.Errorf("parse magic number failed, expected: %s, actual: %s", strconv.Itoa(int(MagicNumber)), strconv.Itoa(int(magicNumber)))
+		return -1, fmt.Errorf("parse magic number failed, expected: %d, actual: %d", MagicNumber, magicNumber)
 	}
 
 	return magicNumber, nil


### PR DESCRIPTION
Remove redundant int to string, string to int conversion

/kind improvement

Signed-off-by: Congqi Xia <congqi.xia@zilliz.com>