### PR TITLE
Fix not all segments state is drop after DropVirtualChannel

### DIFF
--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -351,6 +351,19 @@ func (m *meta) UpdateDropChannelSegmentInfo(channel string, segments []*SegmentI
 			modSegments[seg2Drop.GetID()] = segment
 		}
 	}
+	// set all channels of channel to dropped
+	for _, seg := range m.segments.segments {
+		if seg.InsertChannel != channel {
+			continue
+		}
+		_, ok := modSegments[seg.ID]
+		// seg inf mod segments are all in dropped state
+		if !ok {
+			clonedSeg := seg.Clone()
+			clonedSeg.State = commonpb.SegmentState_Dropped
+			modSegments[seg.ID] = clonedSeg
+		}
+	}
 
 	return m.batchSaveDropSegments(channel, modSegments)
 }

--- a/internal/datacoord/server_test.go
+++ b/internal/datacoord/server_test.go
@@ -960,6 +960,16 @@ func TestDropVirtualChannel(t *testing.T) {
 			err := svr.meta.AddSegment(NewSegmentInfo(s))
 			assert.Nil(t, err)
 		}
+		// add non matched segments
+		os := &datapb.SegmentInfo{
+			ID:            maxOperationsPerTxn + 100,
+			CollectionID:  0,
+			InsertChannel: "ch2",
+
+			State: commonpb.SegmentState_Growing,
+		}
+
+		svr.meta.AddSegment(NewSegmentInfo(os))
 
 		err := svr.channelManager.AddNode(0)
 		require.Nil(t, err)


### PR DESCRIPTION
Fixes not all segments state is dropped after DropVirtualChannel

See also #12648

/kind bug
/cc @sunby 

Signed-off-by: Congqi Xia <congqi.xia@zilliz.com>