### PR TITLE
[skip ci] fix pr test slow issue

### DIFF
--- a/build/ci/jenkins/PR.groovy
+++ b/build/ci/jenkins/PR.groovy
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 
 int total_timeout_minutes = 120
-int e2e_timeout_seconds = 50 * 60
+int e2e_timeout_seconds = 70 * 60
 def imageTag=''
 
 pipeline {

--- a/build/ci/jenkins/pod/rte.yaml
+++ b/build/ci/jenkins/pod/rte.yaml
@@ -32,7 +32,7 @@ spec:
       name: build-cache
       subPath: docker-volume   
   - name: pytest
-    image: milvusdb/pytest:20211108-d14cf36
+    image: milvusdb/pytest:20211123-f95ef22
     volumeMounts:
     - mountPath: /ci-logs
       name: ci-logs  

--- a/tests/scripts/ci_e2e.sh
+++ b/tests/scripts/ci_e2e.sh
@@ -60,9 +60,9 @@ fi
 trace "prepare e2e test"  install_pytest_requirements  
 
 if [[ -n "${TEST_TIMEOUT:-}" ]]; then
-  timeout  "${TEST_TIMEOUT}" pytest --host ${MILVUS_SERVICE_NAME} --port ${MILVUS_SERVICE_PORT} \
+  timeout  "${TEST_TIMEOUT}" pytest -n ${PARALLEL_NUM} --host ${MILVUS_SERVICE_NAME} --port ${MILVUS_SERVICE_PORT} \
                                       --html=${CI_LOG_PATH}/report.html  --self-contained-html ${@:-}
 else
-  pytest --host ${MILVUS_SERVICE_NAME} --port ${MILVUS_SERVICE_PORT} \
+  pytest -n ${PARALLEL_NUM} --host ${MILVUS_SERVICE_NAME} --port ${MILVUS_SERVICE_PORT} \
                                       --html=${CI_LOG_PATH}/report.html --self-contained-html ${@:-}
 fi


### PR DESCRIPTION
Signed-off-by: Jenny Li <jing.li@zilliz.com>
/kind improvement
/cc @LoveEachDay @zwd1208 @yanliang567
1. update timeout to 70 to be the same with before move kind
2. update pytest docker image
3. add PARALLEL_NUM back