### PR TITLE
[skip ci] Remove not used code from e2e-k8s.sh

### DIFF
--- a/tests/scripts/e2e-k8s.sh
+++ b/tests/scripts/e2e-k8s.sh
@@ -341,12 +341,6 @@ if [[ -z "${SKIP_INSTALL:-}" ]]; then
 fi
 
 if [[ -z "${SKIP_TEST:-}" ]]; then
-# Prepare e2e test,install pytest requirements 
-  if [[ -n "${DISABLE_KIND:-}" ]]; then
-    trace "prepare e2e test"  install_pytest_requirements  
-  else
-    trace "prepare e2e test" "${ROOT}/tests/scripts/prepare_e2e.sh"
-  fi
 
   if [[ -n "${TEST_TIMEOUT:-}" ]]; then
     if [[ -n "${DISABLE_KIND:-}" ]]; then


### PR DESCRIPTION
Signed-off-by: Jenny Li <jing.li@zilliz.com>
/kind improvement
/cc @LoveEachDay @zwd1208 @yanliang567

Now we used ci-e2e.sh to run e2e test in the CI workflow(Jenkins), so remove this in case any misunderstanding.