### PR TITLE
Enable compaction in config.yaml

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -168,7 +168,7 @@ dataCoord:
     serverMaxSendSize: 2147483647 # math.MaxInt32
     clientMaxRecvSize: 104857600 # 100 MB, 100 * 1024 * 1024
     clientMaxSendSize: 104857600 # 100 MB, 100 * 1024 * 1024
-  enableCompaction: false # Enable data segment compression
+  enableCompaction: true # Enable data segment compression
   enableGarbageCollection: false
 
   segment:


### PR DESCRIPTION
Helm chart and python tests enabled compaction, yet
the milvus.yaml disabled. This caused local smoke tests
failure

Signed-off-by: yangxuan <xuan.yang@zilliz.com>

/kind bug
/kind improvement