### PR TITLE
[skip ci] Remove space based on  Jenkinsfile lint

### DIFF
--- a/build/ci/jenkins/PR.groovy
+++ b/build/ci/jenkins/PR.groovy
@@ -75,7 +75,7 @@ pipeline {
         }
 
 
-        stage ('Install & E2E Test') {
+        stage('Install & E2E Test') {
                 matrix {
                     axes {
                         axis {


### PR DESCRIPTION
Signed-off-by: Jenny Li <jing.li@zilliz.com>
/kind improvement
fix the lint error `There is whitespace between method name and parenthesis in a method call.GroovyLint(SpaceAfterMethodCallName-37)`

/cc @LoveEachDay @zwd1208 @yanliang567