### PR TITLE
[skip e2e]remove ci-passed label when test is pending or failed

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -152,3 +152,17 @@ pull_request_rules:
       label:
         add:
           - ci-passed
+
+
+
+  - name: Remove ci-passed label when rerun test
+    conditions:
+      - base=master
+      - or:
+        - "status-success!=Code Checker AMD64 Ubuntu 18.04"
+        - "status-success!=Build and test AMD64 Ubuntu 18.04"
+        - "status-success!=continuous-integration/jenkins/pr-merge"        
+    actions:
+      label:
+        remove:
+          - ci-passed


### PR DESCRIPTION
Signed-off-by: Jenny Li <jing.li@zilliz.com>
/kind improvement
/cc @LoveEachDay @zwd1208 @yanliang567

1. remove when rerun any test 
2. `check-pending ` & `check-failure ` can be included in `status-success!=`