### PR TITLE
Add more logs on failure path in load segments

### DIFF
--- a/internal/querycoord/cluster.go
+++ b/internal/querycoord/cluster.go
@@ -831,6 +831,10 @@ func estimateSegmentsSize(segments *querypb.LoadSegmentsRequest, kvClient kv.Dat
 					if err != nil {
 						indexSize, err = storage.GetBinlogSize(kvClient, path)
 						if err != nil {
+							log.Warn("estimate index size wrong",
+								zap.Int64("segmentID", loadInfo.GetSegmentID()),
+								zap.String("path", path),
+								zap.Error(err))
 							return 0, err
 						}
 					}
@@ -847,6 +851,10 @@ func estimateSegmentsSize(segments *querypb.LoadSegmentsRequest, kvClient kv.Dat
 				if err != nil {
 					binlogSize, err = storage.GetBinlogSize(kvClient, path.GetLogPath())
 					if err != nil {
+						log.Warn("estimate binlog size wrong",
+							zap.Int64("segmentID", loadInfo.GetSegmentID()),
+							zap.String("binlog path", path.GetLogPath()),
+							zap.Error(err))
 						return 0, err
 					}
 				}

--- a/internal/querycoord/segment_allocator_test.go
+++ b/internal/querycoord/segment_allocator_test.go
@@ -122,6 +122,12 @@ func TestShuffleSegmentsToQueryNode(t *testing.T) {
 
 		assert.Equal(t, node2ID, firstReq.DstNodeID)
 		assert.Equal(t, node2ID, secondReq.DstNodeID)
+
+		err = shuffleSegmentsToQueryNodeV2(baseCtx, reqs, cluster, true, nil, nil)
+		assert.Nil(t, err)
+
+		assert.Equal(t, node2ID, firstReq.DstNodeID)
+		assert.Equal(t, node2ID, secondReq.DstNodeID)
 	})
 
 	err = removeAllSession()


### PR DESCRIPTION
This PR added more clarified logs
- in IO failures of estimateSegmentsSize
- in esitimate goroutines

See also: #13250

Signed-off-by: yangxuan <xuan.yang@zilliz.com>

/kind improvement