### PR TITLE
[skip e2e] Update mergify rule for robot fight

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -85,23 +85,6 @@ pull_request_rules:
         add:
           - ci-passed
 
-  - name: Remove ci-passed when code check failed
-    conditions:
-      - base=master
-      - "check-failure=Code Checker AMD64 Ubuntu 18.04"
-    actions:
-      label:
-        remove:
-          - ci-passed
-
-  - name: Remove ci-passed when unittest failed
-    conditions:
-      - base=master
-      - "check-failure=Build and test AMD64 Ubuntu 18.04"
-    actions:
-      label:
-        remove:
-          - ci-passed
 
   - name: Blocking PR if missing a related issue or PR doesn't have kind/improvement label
     conditions:
@@ -155,7 +138,7 @@ pull_request_rules:
 
 
 
-  - name: Remove ci-passed label when rerun code checker
+  - name: Remove ci-passed label when status for code checker or ut  is not success
     conditions:
       - base=master
       - -files~=^(?!.*\.(go|h|cpp)).*$
@@ -167,7 +150,7 @@ pull_request_rules:
         remove:
           - ci-passed
 
-  - name: Remove ci-passed label when rerun jenkins test
+  - name: Remove ci-passed label when  status for jenkins job is not success
     conditions:
       - base=master
       - -files~=^(?!.*\.(go|h|cpp)).*$


### PR DESCRIPTION
Signed-off-by: Jenny Li <jing.li@zilliz.com>
/kind improvement
/cc @LoveEachDay @zwd1208 @yanliang567
1. the reason for robot fight is because remove label rule does not define file type
 (https://github.com/milvus-io/milvus/pull/13940 )
2. remove the two rules, as `!status-success` has already included `check-failure`, so they are duplicated, and the new rule have defined the files (which are code).