### PR TITLE
Update MemTable.cpp

### DIFF
--- a/core/src/db/insert/MemTable.cpp
+++ b/core/src/db/insert/MemTable.cpp
@@ -14,6 +14,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <unordered_set>
 
 #include "cache/CpuCacheMgr.h"
 #include "codecs/default/DefaultCodec.h"
@@ -226,7 +227,7 @@ MemTable::ApplyDeletes() {
         segment::UidsPtr uids_ptr = nullptr;
         segment::DeletedDocsPtr deleted_docs_ptr = nullptr;
 
-        std::set<segment::doc_id_t> ids_to_check;
+        std::unordered_set<segment::doc_id_t> ids_to_check;
 
         TimeRecorder rec("handle segment " + file.segment_id_);
 

--- a/core/src/db/insert/MemTable.cpp
+++ b/core/src/db/insert/MemTable.cpp
@@ -13,8 +13,8 @@
 #include <chrono>
 #include <memory>
 #include <string>
-#include <utility>
 #include <unordered_set>
+#include <utility>
 
 #include "cache/CpuCacheMgr.h"
 #include "codecs/default/DefaultCodec.h"


### PR DESCRIPTION
# 问题背景 
  当删除向量数很多时，如果再有删除向量，系统会运行很慢，影响一切写入操作。
  定位后发现是慢在MemTable::ApplyDeletes。
 
# 修改内容：
1. std::vector<segment::doc_id_t> ids_to_check  改成std::set
2. deleted_docs 内容写入 faiss::ConcurrentBitset中，用于查询
