### PR TITLE
[skip e2e] Remove redundant header files for query/SubSearchResult.cpp

### DIFF
--- a/internal/core/src/query/SubSearchResult.cpp
+++ b/internal/core/src/query/SubSearchResult.cpp
@@ -9,10 +9,10 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
+#include <cmath>
+
 #include "exceptions/EasyAssert.h"
 #include "query/SubSearchResult.h"
-#include "segcore/Reduce.h"
-#include <cmath>
 
 namespace milvus::query {
 


### PR DESCRIPTION
Signed-off-by: yudong.cai <yudong.cai@zilliz.com>