### PR TITLE
[skip e2e] Change krte to rte

### DIFF
--- a/build/ci/jenkins/PublishImages.groovy
+++ b/build/ci/jenkins/PublishImages.groovy
@@ -5,7 +5,7 @@ pipeline {
         kubernetes {
             label "milvus-e2e-test-kind"
             defaultContainer 'main'
-            yamlFile "build/ci/jenkins/pod/krte.yaml"
+            yamlFile "build/ci/jenkins/pod/rte.yaml"
             customWorkspace '/home/jenkins/agent/workspace'
             // We allow this pod to remain active for a while, later jobs can
             // reuse cache in previous created nodes.


### PR DESCRIPTION
Signed-off-by: Jenny Li <jing.li@zilliz.com>
/kind improvement
ci & nightly has already changed to use rte.yaml, change publish image to use rte to be consistent.
will remove krte later, so that we can only maintain one pod yaml