### PR TITLE
Use msgstream bufsize for mqclient initialization

### DIFF
--- a/internal/msgstream/mq_msgstream.go
+++ b/internal/msgstream/mq_msgstream.go
@@ -144,6 +144,7 @@ func (ms *mqMsgStream) AsConsumerWithPosition(channels []string, subName string,
 				SubscriptionName:            subName,
 				Type:                        mqclient.Exclusive,
 				SubscriptionInitialPosition: position,
+				BufSize:                     ms.bufSize,
 			})
 			if err != nil {
 				return err
@@ -714,6 +715,7 @@ func (ms *MqTtMsgStream) AsConsumerWithPosition(channels []string, subName strin
 				SubscriptionName:            subName,
 				Type:                        mqclient.Exclusive,
 				SubscriptionInitialPosition: position,
+				BufSize:                     ms.bufSize,
 			})
 			if err != nil {
 				return err


### PR DESCRIPTION
Fix #14404 

/kind bug
/cc @xiaofan-luan @fishpenguin 

Signed-off-by: Congqi Xia <congqi.xia@zilliz.com>