### PR TITLE
[skip e2e] Update mergify Rule for jenkins passed non-code changed

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -44,10 +44,10 @@ pull_request_rules:
         add:
           - ci-passed
   
-  - name: Test passed for tests scripts changed
+  - name: Test passed for non go or c++ code changed
     conditions:
       - base=master
-      - -files~=^(?!tests\/scripts).+
+      - files~=^(?!.*\.(go|h|cpp)).*$
       - "status-success=continuous-integration/jenkins/pr-merge"
     actions:
       label:


### PR DESCRIPTION
Signed-off-by: Jenny Li <jing.li@zilliz.com>
/kind improvement
 /cc @LoveEachDay @zwd1208 @yanliang567 
**Background**
1. https://github.com/milvus-io/milvus/pull/14439 does not add label automatically when jenkins job succeed.
2. The reason is  the pr change both test scripts and groovy file, test scripts rule does not cover groovy both.
**Solution**
1. They are not code(c++ or go) changed, so they do not need to run ut or code checker, but it need to run jenkins job.
2. The files rule should be consistent with the files  rule  in `Test passed for title skip e2e (label)`.