### PR TITLE
[skip e2e] Remove useless configuration rootcoord.timeout

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -62,7 +62,6 @@ rootCoord:
   dmlChannelNum: 256 # The number of dml channels created at system startup
   maxPartitionNum: 4096 # Maximum number of partitions in a collection
   minSegmentSizeToEnableIndex: 1024 # It's a threshold. When the segment size is less than this value, the segment will not be indexed
-  timeout: 3600 # time out, 5 seconds
 
 # Related configuration of proxy, used to validate client requests and reduce the returned results.
 proxy:

--- a/internal/util/paramtable/global_param.go
+++ b/internal/util/paramtable/global_param.go
@@ -308,8 +308,6 @@ type rootCoordConfig struct {
 	DefaultIndexName            string
 	MinSegmentSizeToEnableIndex int64
 
-	Timeout int
-
 	CreatedTime time.Time
 	UpdatedTime time.Time
 }
@@ -334,8 +332,6 @@ func (p *rootCoordConfig) init(bp *BaseParamTable) {
 	p.initMinSegmentSizeToEnableIndex()
 	p.initDefaultPartitionName()
 	p.initDefaultIndexName()
-
-	p.initTimeout()
 }
 
 func (p *rootCoordConfig) initPulsarAddress() {
@@ -443,10 +439,6 @@ func (p *rootCoordConfig) initDefaultPartitionName() {
 func (p *rootCoordConfig) initDefaultIndexName() {
 	name := p.BaseParams.LoadWithDefault("common.defaultIndexName", "_default_idx")
 	p.DefaultIndexName = name
-}
-
-func (p *rootCoordConfig) initTimeout() {
-	p.Timeout = p.BaseParams.ParseIntWithDefault("rootCoord.timeout", 3600)
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/internal/util/paramtable/global_param_test.go
+++ b/internal/util/paramtable/global_param_test.go
@@ -73,9 +73,6 @@ func TestGlobalParamTable(t *testing.T) {
 		assert.NotEqual(t, Params.DefaultIndexName, "")
 		t.Logf("default index name = %s", Params.DefaultIndexName)
 
-		assert.NotZero(t, Params.Timeout)
-		t.Logf("master timeout = %d", Params.Timeout)
-
 		Params.CreatedTime = time.Now()
 		Params.UpdatedTime = time.Now()
 		t.Logf("created time: %v", Params.CreatedTime)


### PR DESCRIPTION
Signed-off-by: yudong.cai <yudong.cai@zilliz.com>