### PR TITLE
Rename timetickSync APIs and variables for better readability

### DIFF
--- a/internal/rootcoord/root_coord.go
+++ b/internal/rootcoord/root_coord.go
@@ -1033,18 +1033,18 @@ func (c *Core) Init() error {
 
 		chanMap := c.MetaTable.ListCollectionPhysicalChannels()
 		c.chanTimeTick = newTimeTickSync(c.ctx, c.session.ServerID, c.msFactory, chanMap)
-		c.chanTimeTick.addProxy(c.session)
+		c.chanTimeTick.addSession(c.session)
 		c.proxyClientManager = newProxyClientManager(c)
 
 		log.Debug("RootCoord, set proxy manager")
 		c.proxyManager = newProxyManager(
 			c.ctx,
 			c.etcdCli,
-			c.chanTimeTick.clearProxy,
+			c.chanTimeTick.clearSessions,
 			c.proxyClientManager.GetProxyClients,
 		)
-		c.proxyManager.AddSession(c.chanTimeTick.addProxy, c.proxyClientManager.AddProxyClient)
-		c.proxyManager.DelSession(c.chanTimeTick.delProxy, c.proxyClientManager.DelProxyClient)
+		c.proxyManager.AddSession(c.chanTimeTick.addSession, c.proxyClientManager.AddProxyClient)
+		c.proxyManager.DelSession(c.chanTimeTick.delSession, c.proxyClientManager.DelProxyClient)
 
 		c.metricsCacheManager = metricsinfo.NewMetricsCacheManager()
 

--- a/internal/rootcoord/root_coord_test.go
+++ b/internal/rootcoord/root_coord_test.go
@@ -756,11 +756,11 @@ func TestRootCoord(t *testing.T) {
 		//assert.True(t, ok)
 		//assert.Greater(t, ddm.Base.Timestamp, uint64(0))
 		core.chanTimeTick.lock.Lock()
-		assert.Equal(t, len(core.chanTimeTick.proxyTimeTick), 2)
-		pt, ok := core.chanTimeTick.proxyTimeTick[core.session.ServerID]
+		assert.Equal(t, len(core.chanTimeTick.sess2ChanTsMap), 2)
+		pt, ok := core.chanTimeTick.sess2ChanTsMap[core.session.ServerID]
 		assert.True(t, ok)
-		assert.Equal(t, shardsNum, int32(len(pt.chanTs)))
-		for chanName, ts := range pt.chanTs {
+		assert.Equal(t, shardsNum, int32(len(pt.chanTsMap)))
+		for chanName, ts := range pt.chanTsMap {
 			assert.Contains(t, createMeta.PhysicalChannelNames, chanName)
 			assert.Equal(t, pt.defaultTs, ts)
 		}
@@ -1838,7 +1838,7 @@ func TestRootCoord(t *testing.T) {
 		s, _ := core.UpdateChannelTimeTick(ctx, msg0)
 		assert.Equal(t, commonpb.ErrorCode_Success, s.ErrorCode)
 		time.Sleep(100 * time.Millisecond)
-		//t.Log(core.chanTimeTick.proxyTimeTick)
+		//t.Log(core.chanTimeTick.sess2ChanTsMap)
 
 		msg1 := &internalpb.ChannelTimeTickMsg{
 			Base: &commonpb.MsgBase{
@@ -1865,7 +1865,7 @@ func TestRootCoord(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 
 		// 2 proxy, 1 rootcoord
-		assert.Equal(t, 3, core.chanTimeTick.getProxyNum())
+		assert.Equal(t, 3, core.chanTimeTick.getSessionNum())
 
 		// add 3 proxy channels
 		assert.Equal(t, 3, core.chanTimeTick.getDmlChannelNum()-numChan)

--- a/internal/rootcoord/timeticksync_test.go
+++ b/internal/rootcoord/timeticksync_test.go
@@ -55,7 +55,7 @@ func TestTimetickSync(t *testing.T) {
 		defer wg.Done()
 		ttSync.sendToChannel()
 
-		ttSync.proxyTimeTick[1] = nil
+		ttSync.sess2ChanTsMap[1] = nil
 		ttSync.sendToChannel()
 
 		msg := &internalpb.ChannelTimeTickMsg{
@@ -63,7 +63,7 @@ func TestTimetickSync(t *testing.T) {
 				MsgType: commonpb.MsgType_TimeTick,
 			},
 		}
-		ttSync.proxyTimeTick[1] = newChanTsMsg(msg, 1)
+		ttSync.sess2ChanTsMap[1] = newChanTsMsg(msg, 1)
 		ttSync.sendToChannel()
 	})
 
@@ -97,7 +97,7 @@ func TestTimetickSync(t *testing.T) {
 		msg.Timestamps = append(msg.Timestamps, uint64(2))
 		msg.DefaultTimestamp = uint64(200)
 		cttMsg := newChanTsMsg(msg, 1)
-		ttSync.proxyTimeTick[msg.Base.SourceID] = cttMsg
+		ttSync.sess2ChanTsMap[msg.Base.SourceID] = cttMsg
 
 		ttSync.ddlMinTs = uint64(100)
 		err = ttSync.updateTimeTick(msg, "1")


### PR DESCRIPTION
Signed-off-by: yudong.cai <yudong.cai@zilliz.com>
Issue: #15245 