### PR TITLE
upgrade log4j to 2.17.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       - ETCD_QUOTA_BACKEND_BYTES=4294967296
 
   pulsar:
-    image: apachepulsar/pulsar:2.7.3
+    image: apachepulsar/pulsar:2.7.4
     command: bin/pulsar standalone --no-functions-worker --no-stream-storage
 
   minio:


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/15265
Apache released Log4j 2.17.0 to fix CVE-2021-45105.
Plusar also released Plusar 2.7.4 for the security issue. 

Ref: https://logging.apache.org/log4j/2.x/security.html
       https://github.com/apache/pulsar/releases/tag/v2.7.4

Signed-off-by: Yan Xin  <shu_yanx@hotmail.com>
