### PR TITLE
Add ca-certificates to Dockerfile

### DIFF
--- a/build/docker/milvus/Dockerfile
+++ b/build/docker/milvus/Dockerfile
@@ -15,7 +15,7 @@ FROM milvusdb/openblas:ubuntu18.04-20210428 AS openblas
 FROM ubuntu:bionic-20200921
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends libtbb-dev gfortran netcat iputils-ping && \
+    apt-get install -y --no-install-recommends libtbb-dev gfortran netcat iputils-ping ca-certificates && \
     apt-get remove --purge -y && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
I didn't find related issue

---

While trying to configure milvus with S3 instead of minio, I run into the issue, where during start al the components would complain about `x509 unknown authority` while trying to connect to S3 upstream endpoint.

Here is values file I've used with helm

```
minio:
  enabled: false

externalS3:
  enabled: true
  host: "s3.eu-west-1.amazonaws.com"
  port: "443"
  accessKey: "AKI<secure>HH"
  secretKey: "K<secure>C2"
  useSSL: true
  bucketName: "dev-search-milvus"
```

I've then manually edited all the relevant deployments (datacoord, indexcoord, datanode, indexnode, querycoord, querynode) and replaced this: 

```
args:
- milvus
- run
- <component>
```

with:

```
  - args:
    - -c
    - apt update; apt install ca-certificates -y; milvus run <component>
    command:
    - /bin/sh
```

And that fixed my issue.

This PR adds `ca-certificates` package into `milvus` Dockerfile so that publicly trusted upstream endpoints can be also trusted while accessing those endpoints from containers.
