### PR TITLE
Rename paramtable structure

### DIFF
--- a/cmd/roles/roles.go
+++ b/cmd/roles/roles.go
@@ -52,7 +52,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/typeutil"
 )
 
-var Params paramtable.GlobalParamTable
+var Params paramtable.ComponentParam
 
 func newMsgFactory(localMsg bool) msgstream.Factory {
 	if localMsg {

--- a/internal/allocator/global_id_test.go
+++ b/internal/allocator/global_id_test.go
@@ -27,7 +27,7 @@ import (
 
 var gTestIDAllocator *GlobalIDAllocator
 
-var Params paramtable.GlobalParamTable
+var Params paramtable.ComponentParam
 
 func TestGlobalTSOAllocator_All(t *testing.T) {
 	Params.Init()

--- a/internal/datacoord/server.go
+++ b/internal/datacoord/server.go
@@ -89,7 +89,7 @@ type rootCoordCreatorFunc func(ctx context.Context, metaRootPath string, etcdCli
 // makes sure Server implements `DataCoord`
 var _ types.DataCoord = (*Server)(nil)
 
-var Params paramtable.GlobalParamTable
+var Params paramtable.ComponentParam
 
 // Server implements `types.Datacoord`
 // handles Data Cooridinator related jobs

--- a/internal/datanode/data_node.go
+++ b/internal/datanode/data_node.go
@@ -78,7 +78,7 @@ const illegalRequestErrStr = "Illegal request"
 var _ types.DataNode = (*DataNode)(nil)
 
 // Params from config.yaml
-var Params paramtable.GlobalParamTable
+var Params paramtable.ComponentParam
 
 // DataNode communicates with outside services and unioun all
 // services in datanode package.

--- a/internal/distributed/indexnode/client/client_test.go
+++ b/internal/distributed/indexnode/client/client_test.go
@@ -35,7 +35,7 @@ import (
 	"google.golang.org/grpc"
 )
 
-var ParamsGlobal paramtable.GlobalParamTable
+var ParamsGlobal paramtable.ComponentParam
 
 func Test_NewClient(t *testing.T) {
 	ClientParams.InitOnce(typeutil.IndexNodeRole)

--- a/internal/distributed/indexnode/service_test.go
+++ b/internal/distributed/indexnode/service_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var ParamsGlobal paramtable.GlobalParamTable
+var ParamsGlobal paramtable.ComponentParam
 
 func TestIndexNodeServer(t *testing.T) {
 	ctx := context.Background()

--- a/internal/indexcoord/index_coord.go
+++ b/internal/indexcoord/index_coord.go
@@ -60,7 +60,7 @@ const (
 	indexSizeFactor = 6
 )
 
-var Params paramtable.GlobalParamTable
+var Params paramtable.ComponentParam
 
 // IndexCoord is a component responsible for scheduling index construction tasks and maintaining index status.
 // IndexCoord accepts requests from rootcoord to build indexes, delete indexes, and query index information.

--- a/internal/indexnode/indexnode.go
+++ b/internal/indexnode/indexnode.go
@@ -68,7 +68,7 @@ var _ types.IndexNode = (*IndexNode)(nil)
 var _ types.IndexNodeComponent = (*IndexNode)(nil)
 
 // Params is a GlobalParamTable singleton of indexnode
-var Params paramtable.GlobalParamTable
+var Params paramtable.ComponentParam
 
 // IndexNode is a component that executes the task of building indexes.
 type IndexNode struct {

--- a/internal/kv/etcd/embed_etcd_config_test.go
+++ b/internal/kv/etcd/embed_etcd_config_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestEtcdConfigLoad(te *testing.T) {
 	os.Setenv(metricsinfo.DeployModeEnvKey, metricsinfo.StandaloneDeployMode)
-	param := new(paramtable.BaseParamTable)
+	param := new(paramtable.ServiceParam)
 	param.Init()
 	param.BaseTable.Save("etcd.use.embed", "true")
 	// TODO, not sure if the relative path works for ci environment

--- a/internal/kv/etcd/embed_etcd_kv_test.go
+++ b/internal/kv/etcd/embed_etcd_kv_test.go
@@ -31,7 +31,7 @@ import (
 
 func TestEmbedEtcd(te *testing.T) {
 	os.Setenv(metricsinfo.DeployModeEnvKey, metricsinfo.StandaloneDeployMode)
-	param := new(paramtable.BaseParamTable)
+	param := new(paramtable.ServiceParam)
 	param.Init()
 	param.BaseTable.Save("etcd.use.embed", "true")
 	param.BaseTable.Save("etcd.config.path", "../../../configs/advanced/etcd.yaml")

--- a/internal/kv/etcd/embed_etcd_restart_test.go
+++ b/internal/kv/etcd/embed_etcd_restart_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestEtcdRestartLoad(te *testing.T) {
 	os.Setenv(metricsinfo.DeployModeEnvKey, metricsinfo.StandaloneDeployMode)
-	param := new(paramtable.BaseParamTable)
+	param := new(paramtable.ServiceParam)
 	param.Init()
 	param.BaseTable.Save("etcd.use.embed", "true")
 	// TODO, not sure if the relative path works for ci environment

--- a/internal/kv/etcd/etcd_kv_test.go
+++ b/internal/kv/etcd/etcd_kv_test.go
@@ -29,7 +29,7 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
-var Params paramtable.GlobalParamTable
+var Params paramtable.ComponentParam
 
 func TestMain(m *testing.M) {
 	Params.Init()

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -54,7 +54,7 @@ type Timestamp = typeutil.Timestamp
 // make sure Proxy implements types.Proxy
 var _ types.Proxy = (*Proxy)(nil)
 
-var Params paramtable.GlobalParamTable
+var Params paramtable.ComponentParam
 
 // Proxy of milvus
 type Proxy struct {

--- a/internal/querycoord/query_coord.go
+++ b/internal/querycoord/query_coord.go
@@ -64,7 +64,7 @@ type queryChannelInfo struct {
 }
 
 // Params is param table of query coordinator
-var Params paramtable.GlobalParamTable
+var Params paramtable.ComponentParam
 
 // QueryCoord is the coordinator of queryNodes
 type QueryCoord struct {

--- a/internal/querynode/query_node.go
+++ b/internal/querynode/query_node.go
@@ -65,7 +65,7 @@ var _ types.QueryNode = (*QueryNode)(nil)
 // make sure QueryNode implements types.QueryNodeComponent
 var _ types.QueryNodeComponent = (*QueryNode)(nil)
 
-var Params paramtable.GlobalParamTable
+var Params paramtable.ComponentParam
 
 // QueryNode communicates with outside services and union all
 // services in querynode package.

--- a/internal/rootcoord/root_coord.go
+++ b/internal/rootcoord/root_coord.go
@@ -79,7 +79,7 @@ func metricProxy(v int64) string {
 	return fmt.Sprintf("client_%d", v)
 }
 
-var Params paramtable.GlobalParamTable
+var Params paramtable.ComponentParam
 
 // Core root coordinator core
 type Core struct {

--- a/internal/util/etcd/etcd_util_test.go
+++ b/internal/util/etcd/etcd_util_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var Params paramtable.BaseParamTable
+var Params paramtable.ServiceParam
 
 func TestEtcd(t *testing.T) {
 	Params.Init()

--- a/internal/util/paramtable/base_table.go
+++ b/internal/util/paramtable/base_table.go
@@ -64,10 +64,6 @@ func (gp *BaseTable) Init() {
 	gp.configDir = gp.initConfPath()
 	log.Debug("config directory", zap.String("configDir", gp.configDir))
 
-	gp.loadFromCommonYaml()
-
-	gp.loadFromComponentYaml()
-
 	gp.loadFromMilvusYaml()
 
 	gp.tryloadFromEnv()
@@ -113,28 +109,6 @@ func (gp *BaseTable) loadFromMilvusYaml() {
 	if err := gp.LoadYaml("milvus.yaml"); err != nil {
 		panic(err)
 	}
-}
-
-func (gp *BaseTable) loadFromComponentYaml() bool {
-	configFile := gp.configDir + "advanced/component.yaml"
-	if _, err := os.Stat(configFile); err == nil {
-		if err := gp.LoadYaml("advanced/component.yaml"); err != nil {
-			panic(err)
-		}
-		return true
-	}
-	return false
-}
-
-func (gp *BaseTable) loadFromCommonYaml() bool {
-	configFile := gp.configDir + "advanced/common.yaml"
-	if _, err := os.Stat(configFile); err == nil {
-		if err := gp.LoadYaml("advanced/common.yaml"); err != nil {
-			panic(err)
-		}
-		return true
-	}
-	return false
 }
 
 func (gp *BaseTable) tryloadFromEnv() {

--- a/internal/util/paramtable/component_param_test.go
+++ b/internal/util/paramtable/component_param_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/milvus-io/milvus/internal/util/typeutil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -28,12 +27,12 @@ func shouldPanic(t *testing.T, name string, f func()) {
 	t.Errorf("%s should have panicked", name)
 }
 
-func TestGlobalParamTable(t *testing.T) {
-	var GlobalParams GlobalParamTable
-	GlobalParams.Init()
+func TestComponentParam(t *testing.T) {
+	var CParams ComponentParam
+	CParams.Init()
 
 	t.Run("test commonConfig", func(t *testing.T) {
-		Params := GlobalParams.CommonCfg
+		Params := CParams.CommonCfg
 
 		assert.NotEqual(t, Params.DefaultPartitionName, "")
 		t.Logf("default partition name = %s", Params.DefaultPartitionName)
@@ -45,14 +44,14 @@ func TestGlobalParamTable(t *testing.T) {
 	})
 
 	t.Run("test knowhereConfig", func(t *testing.T) {
-		Params := GlobalParams.KnowhereCfg
+		Params := CParams.KnowhereCfg
 
 		assert.NotEqual(t, Params.SimdType, "")
 		t.Logf("knowhere simd type = %s", Params.SimdType)
 	})
 
 	t.Run("test knowhereConfig", func(t *testing.T) {
-		Params := GlobalParams.MsgChannelCfg
+		Params := CParams.MsgChannelCfg
 
 		// -- rootcoord --
 		assert.Equal(t, Params.RootCoordTimeTick, "by-dev-rootcoord-timetick")
@@ -96,7 +95,7 @@ func TestGlobalParamTable(t *testing.T) {
 	})
 
 	t.Run("test rootCoordConfig", func(t *testing.T) {
-		Params := GlobalParams.RootCoordCfg
+		Params := CParams.RootCoordCfg
 
 		assert.NotEqual(t, Params.MaxPartitionNum, 0)
 		t.Logf("master MaxPartitionNum = %d", Params.MaxPartitionNum)
@@ -111,7 +110,7 @@ func TestGlobalParamTable(t *testing.T) {
 	})
 
 	t.Run("test proxyConfig", func(t *testing.T) {
-		Params := GlobalParams.ProxyCfg
+		Params := CParams.ProxyCfg
 
 		t.Logf("TimeTickInterval: %v", Params.TimeTickInterval)
 
@@ -132,50 +131,50 @@ func TestGlobalParamTable(t *testing.T) {
 	})
 
 	t.Run("test proxyConfig panic", func(t *testing.T) {
-		Params := GlobalParams.ProxyCfg
+		Params := CParams.ProxyCfg
 
 		shouldPanic(t, "proxy.timeTickInterval", func() {
-			Params.BaseParams.Save("proxy.timeTickInterval", "")
+			Params.Base.Save("proxy.timeTickInterval", "")
 			Params.initTimeTickInterval()
 		})
 
 		shouldPanic(t, "proxy.msgStream.timeTick.bufSize", func() {
-			Params.BaseParams.Save("proxy.msgStream.timeTick.bufSize", "abc")
+			Params.Base.Save("proxy.msgStream.timeTick.bufSize", "abc")
 			Params.initMsgStreamTimeTickBufSize()
 		})
 
 		shouldPanic(t, "proxy.maxNameLength", func() {
-			Params.BaseParams.Save("proxy.maxNameLength", "abc")
+			Params.Base.Save("proxy.maxNameLength", "abc")
 			Params.initMaxNameLength()
 		})
 
 		shouldPanic(t, "proxy.maxFieldNum", func() {
-			Params.BaseParams.Save("proxy.maxFieldNum", "abc")
+			Params.Base.Save("proxy.maxFieldNum", "abc")
 			Params.initMaxFieldNum()
 		})
 
 		shouldPanic(t, "proxy.maxShardNum", func() {
-			Params.BaseParams.Save("proxy.maxShardNum", "abc")
+			Params.Base.Save("proxy.maxShardNum", "abc")
 			Params.initMaxShardNum()
 		})
 
 		shouldPanic(t, "proxy.maxDimension", func() {
-			Params.BaseParams.Save("proxy.maxDimension", "-asdf")
+			Params.Base.Save("proxy.maxDimension", "-asdf")
 			Params.initMaxDimension()
 		})
 
 		shouldPanic(t, "proxy.maxTaskNum", func() {
-			Params.BaseParams.Save("proxy.maxTaskNum", "-asdf")
+			Params.Base.Save("proxy.maxTaskNum", "-asdf")
 			Params.initMaxTaskNum()
 		})
 	})
 
 	t.Run("test queryCoordConfig", func(t *testing.T) {
-		//Params := GlobalParams.QueryCoordCfg
+		//Params := CParams.QueryCoordCfg
 	})
 
 	t.Run("test queryNodeConfig", func(t *testing.T) {
-		Params := GlobalParams.QueryNodeCfg
+		Params := CParams.QueryNodeCfg
 
 		cacheSize := Params.CacheSize
 		assert.Equal(t, int64(32), cacheSize)
@@ -213,11 +212,11 @@ func TestGlobalParamTable(t *testing.T) {
 	})
 
 	t.Run("test dataCoordConfig", func(t *testing.T) {
-		//Params := GlobalParams.DataCoordCfg
+		//Params := CParams.DataCoordCfg
 	})
 
 	t.Run("test dataNodeConfig", func(t *testing.T) {
-		Params := GlobalParams.DataNodeCfg
+		Params := CParams.DataNodeCfg
 
 		Params.NodeID = 2
 		Params.Refresh()
@@ -256,7 +255,7 @@ func TestGlobalParamTable(t *testing.T) {
 	})
 
 	t.Run("test indexCoordConfig", func(t *testing.T) {
-		Params := GlobalParams.IndexCoordCfg
+		Params := CParams.IndexCoordCfg
 
 		t.Logf("Address: %v", Params.Address)
 
@@ -272,7 +271,7 @@ func TestGlobalParamTable(t *testing.T) {
 	})
 
 	t.Run("test indexNodeConfig", func(t *testing.T) {
-		Params := GlobalParams.IndexNodeCfg
+		Params := CParams.IndexNodeCfg
 
 		t.Logf("IP: %v", Params.IP)
 
@@ -292,66 +291,4 @@ func TestGlobalParamTable(t *testing.T) {
 
 		t.Logf("IndexStorageRootPath: %v", Params.IndexStorageRootPath)
 	})
-}
-
-func TestGrpcServerParams(t *testing.T) {
-	role := typeutil.DataNodeRole
-	var Params GrpcServerConfig
-	Params.InitOnce(role)
-
-	assert.Equal(t, Params.Domain, role)
-	t.Logf("Domain = %s", Params.Domain)
-
-	assert.NotEqual(t, Params.IP, "")
-	t.Logf("IP = %s", Params.IP)
-
-	assert.NotZero(t, Params.Port)
-	t.Logf("Port = %d", Params.Port)
-
-	t.Logf("Address = %s", Params.GetAddress())
-
-	assert.NotZero(t, Params.ServerMaxRecvSize)
-	t.Logf("ServerMaxRecvSize = %d", Params.ServerMaxRecvSize)
-
-	Params.Remove(role + ".grpc.serverMaxRecvSize")
-	Params.initServerMaxRecvSize()
-	assert.Equal(t, Params.ServerMaxRecvSize, DefaultServerMaxRecvSize)
-
-	assert.NotZero(t, Params.ServerMaxSendSize)
-	t.Logf("ServerMaxSendSize = %d", Params.ServerMaxSendSize)
-
-	Params.Remove(role + ".grpc.serverMaxSendSize")
-	Params.initServerMaxSendSize()
-	assert.Equal(t, Params.ServerMaxSendSize, DefaultServerMaxSendSize)
-}
-
-func TestGrpcClientParams(t *testing.T) {
-	role := typeutil.DataNodeRole
-	var Params GrpcClientConfig
-	Params.InitOnce(role)
-
-	assert.Equal(t, Params.Domain, role)
-	t.Logf("Domain = %s", Params.Domain)
-
-	assert.NotEqual(t, Params.IP, "")
-	t.Logf("IP = %s", Params.IP)
-
-	assert.NotZero(t, Params.Port)
-	t.Logf("Port = %d", Params.Port)
-
-	t.Logf("Address = %s", Params.GetAddress())
-
-	assert.NotZero(t, Params.ClientMaxRecvSize)
-	t.Logf("ClientMaxRecvSize = %d", Params.ClientMaxRecvSize)
-
-	Params.Remove(role + ".grpc.clientMaxRecvSize")
-	Params.initClientMaxRecvSize()
-	assert.Equal(t, Params.ClientMaxRecvSize, DefaultClientMaxRecvSize)
-
-	assert.NotZero(t, Params.ClientMaxSendSize)
-	t.Logf("ClientMaxSendSize = %d", Params.ClientMaxSendSize)
-
-	Params.Remove(role + ".grpc.clientMaxSendSize")
-	Params.initClientMaxSendSize()
-	assert.Equal(t, Params.ClientMaxSendSize, DefaultClientMaxSendSize)
 }

--- a/internal/util/paramtable/grpc_param.go
+++ b/internal/util/paramtable/grpc_param.go
@@ -1,0 +1,211 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License.
+
+package paramtable
+
+import (
+	"math"
+	"strconv"
+	"sync"
+
+	"github.com/go-basic/ipv4"
+	"github.com/milvus-io/milvus/internal/log"
+	"go.uber.org/zap"
+)
+
+const (
+	// DefaultServerMaxSendSize defines the maximum size of data per grpc request can send by server side.
+	DefaultServerMaxSendSize = math.MaxInt32
+
+	// DefaultServerMaxRecvSize defines the maximum size of data per grpc request can receive by server side.
+	DefaultServerMaxRecvSize = math.MaxInt32
+
+	// DefaultClientMaxSendSize defines the maximum size of data per grpc request can send by client side.
+	DefaultClientMaxSendSize = 100 * 1024 * 1024
+
+	// DefaultClientMaxRecvSize defines the maximum size of data per grpc request can receive by client side.
+	DefaultClientMaxRecvSize = 100 * 1024 * 1024
+)
+
+///////////////////////////////////////////////////////////////////////////////
+// --- grpc ---
+type grpcConfig struct {
+	ServiceParam
+
+	once   sync.Once
+	Domain string
+	IP     string
+	Port   int
+}
+
+func (p *grpcConfig) init(domain string) {
+	p.ServiceParam.Init()
+	p.Domain = domain
+
+	p.LoadFromEnv()
+	p.LoadFromArgs()
+	p.initPort()
+}
+
+// LoadFromEnv is used to initialize configuration items from env.
+func (p *grpcConfig) LoadFromEnv() {
+	p.IP = ipv4.LocalIP()
+}
+
+// LoadFromArgs is used to initialize configuration items from args.
+func (p *grpcConfig) LoadFromArgs() {
+
+}
+
+func (p *grpcConfig) initPort() {
+	p.Port = p.ParseInt(p.Domain + ".port")
+}
+
+// GetAddress return grpc address
+func (p *grpcConfig) GetAddress() string {
+	return p.IP + ":" + strconv.Itoa(p.Port)
+}
+
+// GrpcServerConfig is configuration for grpc server.
+type GrpcServerConfig struct {
+	grpcConfig
+
+	ServerMaxSendSize int
+	ServerMaxRecvSize int
+}
+
+// InitOnce initialize grpc server config once
+func (p *GrpcServerConfig) InitOnce(domain string) {
+	p.once.Do(func() {
+		p.init(domain)
+	})
+}
+
+func (p *GrpcServerConfig) init(domain string) {
+	p.grpcConfig.init(domain)
+
+	p.initServerMaxSendSize()
+	p.initServerMaxRecvSize()
+}
+
+func (p *GrpcServerConfig) initServerMaxSendSize() {
+	var err error
+
+	valueStr, err := p.Load(p.Domain + ".grpc.serverMaxSendSize")
+	if err != nil {
+		p.ServerMaxSendSize = DefaultServerMaxSendSize
+	}
+
+	value, err := strconv.Atoi(valueStr)
+	if err != nil {
+		log.Warn("Failed to parse grpc.serverMaxSendSize, set to default",
+			zap.String("rol", p.Domain), zap.String("grpc.serverMaxSendSize", valueStr),
+			zap.Error(err))
+
+		p.ServerMaxSendSize = DefaultServerMaxSendSize
+	} else {
+		p.ServerMaxSendSize = value
+	}
+
+	log.Debug("initServerMaxSendSize",
+		zap.String("role", p.Domain), zap.Int("grpc.serverMaxSendSize", p.ServerMaxSendSize))
+}
+
+func (p *GrpcServerConfig) initServerMaxRecvSize() {
+	var err error
+
+	valueStr, err := p.Load(p.Domain + ".grpc.serverMaxRecvSize")
+	if err != nil {
+		p.ServerMaxRecvSize = DefaultServerMaxRecvSize
+	}
+
+	value, err := strconv.Atoi(valueStr)
+	if err != nil {
+		log.Warn("Failed to parse grpc.serverMaxRecvSize, set to default",
+			zap.String("role", p.Domain), zap.String("grpc.serverMaxRecvSize", valueStr),
+			zap.Error(err))
+
+		p.ServerMaxRecvSize = DefaultServerMaxRecvSize
+	} else {
+		p.ServerMaxRecvSize = value
+	}
+
+	log.Debug("initServerMaxRecvSize",
+		zap.String("role", p.Domain), zap.Int("grpc.serverMaxRecvSize", p.ServerMaxRecvSize))
+}
+
+// GrpcClientConfig is configuration for grpc client.
+type GrpcClientConfig struct {
+	grpcConfig
+
+	ClientMaxSendSize int
+	ClientMaxRecvSize int
+}
+
+// InitOnce initialize grpc client config once
+func (p *GrpcClientConfig) InitOnce(domain string) {
+	p.once.Do(func() {
+		p.init(domain)
+	})
+}
+
+func (p *GrpcClientConfig) init(domain string) {
+	p.grpcConfig.init(domain)
+
+	p.initClientMaxSendSize()
+	p.initClientMaxRecvSize()
+}
+
+func (p *GrpcClientConfig) initClientMaxSendSize() {
+	var err error
+
+	valueStr, err := p.Load(p.Domain + ".grpc.clientMaxSendSize")
+	if err != nil {
+		p.ClientMaxSendSize = DefaultClientMaxSendSize
+	}
+
+	value, err := strconv.Atoi(valueStr)
+	if err != nil {
+		log.Warn("Failed to parse grpc.clientMaxSendSize, set to default",
+			zap.String("role", p.Domain), zap.String("grpc.clientMaxSendSize", valueStr),
+			zap.Error(err))
+
+		p.ClientMaxSendSize = DefaultClientMaxSendSize
+	} else {
+		p.ClientMaxSendSize = value
+	}
+
+	log.Debug("initClientMaxSendSize",
+		zap.String("role", p.Domain), zap.Int("grpc.clientMaxSendSize", p.ClientMaxSendSize))
+}
+
+func (p *GrpcClientConfig) initClientMaxRecvSize() {
+	var err error
+
+	valueStr, err := p.Load(p.Domain + ".grpc.clientMaxRecvSize")
+	if err != nil {
+		p.ClientMaxRecvSize = DefaultClientMaxRecvSize
+	}
+
+	value, err := strconv.Atoi(valueStr)
+	if err != nil {
+		log.Warn("Failed to parse grpc.clientMaxRecvSize, set to default",
+			zap.String("role", p.Domain), zap.String("grpc.clientMaxRecvSize", valueStr),
+			zap.Error(err))
+
+		p.ClientMaxRecvSize = DefaultClientMaxRecvSize
+	} else {
+		p.ClientMaxRecvSize = value
+	}
+
+	log.Debug("initClientMaxRecvSize",
+		zap.String("role", p.Domain), zap.Int("grpc.clientMaxRecvSize", p.ClientMaxRecvSize))
+}

--- a/internal/util/paramtable/grpc_param_test.go
+++ b/internal/util/paramtable/grpc_param_test.go
@@ -1,0 +1,81 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License.
+
+package paramtable
+
+import (
+	"testing"
+
+	"github.com/milvus-io/milvus/internal/util/typeutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGrpcServerParams(t *testing.T) {
+	role := typeutil.DataNodeRole
+	var Params GrpcServerConfig
+	Params.InitOnce(role)
+
+	assert.Equal(t, Params.Domain, role)
+	t.Logf("Domain = %s", Params.Domain)
+
+	assert.NotEqual(t, Params.IP, "")
+	t.Logf("IP = %s", Params.IP)
+
+	assert.NotZero(t, Params.Port)
+	t.Logf("Port = %d", Params.Port)
+
+	t.Logf("Address = %s", Params.GetAddress())
+
+	assert.NotZero(t, Params.ServerMaxRecvSize)
+	t.Logf("ServerMaxRecvSize = %d", Params.ServerMaxRecvSize)
+
+	Params.Remove(role + ".grpc.serverMaxRecvSize")
+	Params.initServerMaxRecvSize()
+	assert.Equal(t, Params.ServerMaxRecvSize, DefaultServerMaxRecvSize)
+
+	assert.NotZero(t, Params.ServerMaxSendSize)
+	t.Logf("ServerMaxSendSize = %d", Params.ServerMaxSendSize)
+
+	Params.Remove(role + ".grpc.serverMaxSendSize")
+	Params.initServerMaxSendSize()
+	assert.Equal(t, Params.ServerMaxSendSize, DefaultServerMaxSendSize)
+}
+
+func TestGrpcClientParams(t *testing.T) {
+	role := typeutil.DataNodeRole
+	var Params GrpcClientConfig
+	Params.InitOnce(role)
+
+	assert.Equal(t, Params.Domain, role)
+	t.Logf("Domain = %s", Params.Domain)
+
+	assert.NotEqual(t, Params.IP, "")
+	t.Logf("IP = %s", Params.IP)
+
+	assert.NotZero(t, Params.Port)
+	t.Logf("Port = %d", Params.Port)
+
+	t.Logf("Address = %s", Params.GetAddress())
+
+	assert.NotZero(t, Params.ClientMaxRecvSize)
+	t.Logf("ClientMaxRecvSize = %d", Params.ClientMaxRecvSize)
+
+	Params.Remove(role + ".grpc.clientMaxRecvSize")
+	Params.initClientMaxRecvSize()
+	assert.Equal(t, Params.ClientMaxRecvSize, DefaultClientMaxRecvSize)
+
+	assert.NotZero(t, Params.ClientMaxSendSize)
+	t.Logf("ClientMaxSendSize = %d", Params.ClientMaxSendSize)
+
+	Params.Remove(role + ".grpc.clientMaxSendSize")
+	Params.initClientMaxSendSize()
+	assert.Equal(t, Params.ClientMaxSendSize, DefaultClientMaxSendSize)
+}

--- a/internal/util/paramtable/service_param.go
+++ b/internal/util/paramtable/service_param.go
@@ -25,9 +25,14 @@ import (
 	"github.com/milvus-io/milvus/internal/util/metricsinfo"
 )
 
+const (
+	// SuggestPulsarMaxMessageSize defines the maximum size of Pulsar message.
+	SuggestPulsarMaxMessageSize = 5 * 1024 * 1024
+)
+
 // BaseParamTable is a derived struct of BaseTable. It achieves Composition by
 // embedding BaseTable. It is used to quickly and easily access the system configuration.
-type BaseParamTable struct {
+type ServiceParam struct {
 	BaseTable
 
 	EtcdCfg    EtcdConfig
@@ -38,7 +43,7 @@ type BaseParamTable struct {
 
 // Init is an override method of BaseTable's Init. It mainly calls the
 // Init of BaseTable and do some other initialization.
-func (p *BaseParamTable) Init() {
+func (p *ServiceParam) Init() {
 	p.BaseTable.Init()
 
 	p.EtcdCfg.init(&p.BaseTable)

--- a/internal/util/paramtable/service_param_test.go
+++ b/internal/util/paramtable/service_param_test.go
@@ -19,12 +19,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestBaseParamTable(t *testing.T) {
-	var BaseParams BaseParamTable
-	BaseParams.Init()
+func TestServiceParam(t *testing.T) {
+	var SParams ServiceParam
+	SParams.Init()
 
 	t.Run("test etcdConfig", func(t *testing.T) {
-		Params := BaseParams.EtcdCfg
+		Params := SParams.EtcdCfg
 
 		assert.NotZero(t, len(Params.Endpoints))
 		t.Logf("etcd endpoints = %s", Params.Endpoints)
@@ -45,7 +45,7 @@ func TestBaseParamTable(t *testing.T) {
 	})
 
 	t.Run("test pulsarConfig", func(t *testing.T) {
-		Params := BaseParams.PulsarCfg
+		Params := SParams.PulsarCfg
 
 		assert.NotEqual(t, Params.Address, "")
 		t.Logf("pulsar address = %s", Params.Address)
@@ -54,14 +54,14 @@ func TestBaseParamTable(t *testing.T) {
 	})
 
 	t.Run("test rocksmqConfig", func(t *testing.T) {
-		Params := BaseParams.RocksmqCfg
+		Params := SParams.RocksmqCfg
 
 		assert.NotEqual(t, Params.Path, "")
 		t.Logf("rocksmq path = %s", Params.Path)
 	})
 
 	t.Run("test minioConfig", func(t *testing.T) {
-		Params := BaseParams.MinioCfg
+		Params := SParams.MinioCfg
 
 		addr := Params.Address
 		equal := addr == "localhost:9000" || addr == "minio:9000"


### PR DESCRIPTION
Rename base_param to service_param, rename global_param to component_param.
Separate grpc_param.go from component_param.go

Signed-off-by: yudong.cai <yudong.cai@zilliz.com>
Issue: #12478