### PR TITLE
Add Extract() method to take out C pointer from BytesConverter without releasing it

### DIFF
--- a/internal/util/cgoconverter/bytes_converter.go
+++ b/internal/util/cgoconverter/bytes_converter.go
@@ -56,6 +56,12 @@ func (converter *BytesConverter) UnsafeGoBytes(cbytes *unsafe.Pointer, len int) 
 }
 
 func (converter *BytesConverter) Release(lease int32) {
+	p := converter.Extract(lease)
+
+	C.free(p)
+}
+
+func (converter *BytesConverter) Extract(lease int32) unsafe.Pointer {
 	pI, ok := converter.pointers.LoadAndDelete(lease)
 	if !ok {
 		panic("try to release the resource that doesn't exist")
@@ -66,7 +72,7 @@ func (converter *BytesConverter) Release(lease int32) {
 		panic("incorrect value type")
 	}
 
-	C.free(p)
+	return p
 }
 
 // Make sure only the caller own the converter
@@ -88,6 +94,10 @@ func UnsafeGoBytes(cbytes *unsafe.Pointer, len int) (int32, []byte) {
 
 func Release(lease int32) {
 	globalConverter.Release(lease)
+}
+
+func Extract(lease int32) unsafe.Pointer {
+	return globalConverter.Extract(lease)
 }
 
 // DO NOT provide ReleaseAll() method for global converter

--- a/internal/util/cgoconverter/bytes_converter_test.go
+++ b/internal/util/cgoconverter/bytes_converter_test.go
@@ -16,7 +16,6 @@ func TestBytesConverter(t *testing.T) {
 	defer Release(lease)
 	equalBytes(t, data, goBytes)
 
-	// data = make([]byte, maxByteArrayLen)
 	v := byte(0x57)
 	length = maxByteArrayLen
 	cbytes = mallocCBytes(v, maxByteArrayLen)
@@ -27,8 +26,6 @@ func TestBytesConverter(t *testing.T) {
 	if !isAll(goBytes, v) {
 		t.Errorf("incorrect value, all bytes should be %v", v)
 	}
-
-	// equalBytes(t, data, goBytes)
 }
 
 func TestConcurrentBytesConverter(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: yah01 <yah2er0ne@outlook.com>
#15612 