### PR TITLE
Add configuration: whether to query fragments without index during se…

### DIFF
--- a/core/conf/demo/server_config.yaml
+++ b/core/conf/demo/server_config.yaml
@@ -33,9 +33,12 @@ cluster:
 #                      | Keep 'dialect://:@:/', 'dialect' can be either 'sqlite' or |            |                 |
 #                      | 'mysql', replace other texts with real values.             |            |                 |
 #----------------------+------------------------------------------------------------+------------+-----------------+
+# search_raw_enable    | The query has no indexed vectors or not                    | Boolean    | true            |
+#----------------------+------------------------------------------------------------+------------+-----------------+
 general:
   timezone: UTC+8
   meta_uri: sqlite://:@:/
+  search_raw_enable: true
 
 #----------------------+------------------------------------------------------------+------------+-----------------+
 # Network Config       | Description                                                | Type       | Default         |

--- a/core/conf/server_config.template
+++ b/core/conf/server_config.template
@@ -41,12 +41,15 @@ cluster:
 # meta_ssl_cert        | The path of the client SSL public key certificate file in  | String     |                 |
 #                      | PEM format.                                                |            |                 |
 #----------------------+------------------------------------------------------------+------------+-----------------+
+# search_raw_enable    | The query has no indexed vectors or not                    | Boolean    | true            |
+#----------------------+------------------------------------------------------------+------------+-----------------+
 general:
   timezone: UTC+8
   meta_uri: sqlite://:@:/
   meta_ssl_ca: 
   meta_ssl_key: 
   meta_ssl_cert: 
+  search_raw_enable: true
 
 #----------------------+------------------------------------------------------------+------------+-----------------+
 # Network Config       | Description                                                | Type       | Default         |

--- a/core/src/config/Config.cpp
+++ b/core/src/config/Config.cpp
@@ -2232,7 +2232,8 @@ Config::GetGeneralConfigMetaSslCert(std::string& value) {
 
 Status
 Config::GetGeneralConfigSearchRawEnable(bool& value) {
-    std::string str = GetConfigStr(CONFIG_GENERAL, CONFIG_GENERAL_SEARCH_RAW_ENABLE, CONFIG_GENERAL_SEARCH_RAW_ENABLE_DEFAULT);
+    std::string str =
+        GetConfigStr(CONFIG_GENERAL, CONFIG_GENERAL_SEARCH_RAW_ENABLE, CONFIG_GENERAL_SEARCH_RAW_ENABLE_DEFAULT);
     Status s = ValidationUtil::ValidateStringIsBool(str);
     if (!s.ok()) {
         return s;

--- a/core/src/config/Config.cpp
+++ b/core/src/config/Config.cpp
@@ -58,6 +58,8 @@ const char* CONFIG_GENERAL_METAURI_DEFAULT = "sqlite://:@:/";
 const char* CONFIG_GENERAL_META_SSL_CA = "meta_ssl_ca";
 const char* CONFIG_GENERAL_META_SSL_KEY = "meta_ssl_key";
 const char* CONFIG_GENERAL_META_SSL_CERT = "meta_ssl_cert";
+const char* CONFIG_GENERAL_SEARCH_RAW_ENABLE = "search_raw_enable";
+const char* CONFIG_GENERAL_SEARCH_RAW_ENABLE_DEFAULT = "true";
 
 /* network config */
 const char* CONFIG_NETWORK = "network";
@@ -320,6 +322,9 @@ Config::ValidateConfig() {
     std::string general_metauri;
     STATUS_CHECK(GetGeneralConfigMetaURI(general_metauri));
 
+    bool is_search_row;
+    STATUS_CHECK(GetGeneralConfigSearchRawEnable(is_search_row));
+
     /* network config */
     std::string bind_address;
     STATUS_CHECK(GetNetworkConfigBindAddress(bind_address));
@@ -506,6 +511,7 @@ Config::ResetDefaultConfig() {
     STATUS_CHECK(SetGeneralConfigMetaSslCa(""));
     STATUS_CHECK(SetGeneralConfigMetaSslKey(""));
     STATUS_CHECK(SetGeneralConfigMetaSslCert(""));
+    STATUS_CHECK(SetGeneralConfigSearchRawEnable(CONFIG_GENERAL_SEARCH_RAW_ENABLE_DEFAULT));
 
     /* network config */
     STATUS_CHECK(SetNetworkConfigBindAddress(CONFIG_NETWORK_BIND_ADDRESS_DEFAULT));
@@ -629,6 +635,8 @@ Config::SetConfigCli(const std::string& parent_key, const std::string& child_key
             status = SetGeneralConfigMetaSslKey(value);
         } else if (child_key == CONFIG_GENERAL_META_SSL_CERT) {
             status = SetGeneralConfigMetaSslCert(value);
+        } else if (child_key == CONFIG_GENERAL_SEARCH_RAW_ENABLE) {
+            status = SetGeneralConfigSearchRawEnable(value);
         } else {
             status = Status(SERVER_UNEXPECTED_ERROR, invalid_node_str);
         }
@@ -2222,6 +2230,17 @@ Config::GetGeneralConfigMetaSslCert(std::string& value) {
     return CheckGeneralConfigMetaSslCert(value);
 }
 
+Status
+Config::GetGeneralConfigSearchRawEnable(bool& value) {
+    std::string str = GetConfigStr(CONFIG_GENERAL, CONFIG_GENERAL_SEARCH_RAW_ENABLE, CONFIG_GENERAL_SEARCH_RAW_ENABLE_DEFAULT);
+    Status s = ValidationUtil::ValidateStringIsBool(str);
+    if (!s.ok()) {
+        return s;
+    }
+
+    return StringHelpFunctions::ConvertToBoolean(str, value);
+}
+
 #ifdef MILVUS_FPGA_VERSION
 Status
 Config::GetFpgaResourceConfigEnable(bool& value) {
@@ -2841,6 +2860,15 @@ Status
 Config::SetGeneralConfigMetaSslCert(const std::string& value) {
     STATUS_CHECK(CheckGeneralConfigMetaSslCert(value));
     return SetConfigValueInMem(CONFIG_GENERAL, CONFIG_GENERAL_META_SSL_CERT, value);
+}
+
+Status
+Config::SetGeneralConfigSearchRawEnable(const std::string& value) {
+    Status s = ValidationUtil::ValidateStringIsBool(value);
+    if (!s.ok()) {
+        return s;
+    }
+    return SetConfigValueInMem(CONFIG_GENERAL, CONFIG_GENERAL_SEARCH_RAW_ENABLE, value);
 }
 
 /* network config */

--- a/core/src/config/Config.h
+++ b/core/src/config/Config.h
@@ -44,6 +44,8 @@ extern const char* CONFIG_GENERAL_METAURI_DEFAULT;
 extern const char* CONFIG_GENERAL_META_SSL_CA;
 extern const char* CONFIG_GENERAL_META_SSL_KEY;
 extern const char* CONFIG_GENERAL_META_SSL_CERT;
+extern const char* CONFIG_GENERAL_SEARCH_RAW_ENABLE;
+extern const char* CONFIG_GENERAL_SEARCH_ROW_ENABLE_DEFAULT;
 
 /* network config */
 extern const char* CONFIG_NETWORK;
@@ -403,6 +405,8 @@ class Config {
     GetGeneralConfigMetaSslKey(std::string& value);
     Status
     GetGeneralConfigMetaSslCert(std::string& value);
+    Status
+    GetGeneralConfigSearchRawEnable(bool& value);
 
     /* network config */
     Status
@@ -564,6 +568,8 @@ class Config {
     SetGeneralConfigMetaSslKey(const std::string& value);
     Status
     SetGeneralConfigMetaSslCert(const std::string& value);
+    Status
+    SetGeneralConfigSearchRawEnable(const std::string& value);
 
     /* network config */
     Status
@@ -687,6 +693,12 @@ class Config {
     SetLogsLogToStdout(const std::string& value);
     Status
     SetLogsLogToFile(const std::string& value);
+
+    void
+    ClearCache() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        config_map_.clear();
+    }
 
  private:
     bool restart_required_ = false;

--- a/core/src/db/DBImpl.cpp
+++ b/core/src/db/DBImpl.cpp
@@ -420,13 +420,12 @@ DBImpl::PreloadCollection(const std::shared_ptr<server::Context>& context, const
         return SHUTDOWN_ERROR;
     }
 
-    bool  is_all_search_file = true;
+    bool is_all_search_file = true;
     server::Config::GetInstance().GetGeneralConfigSearchRawEnable(is_all_search_file);
 
     // step 1: get all collection files from collection
     meta::FilesHolder files_holder;
-    Status status = CollectFilesToSearch(collection_id, partition_tags, 
-                                         is_all_search_file, files_holder);
+    Status status = CollectFilesToSearch(collection_id, partition_tags, is_all_search_file, files_holder);
     if (!status.ok()) {
         return status;
     }
@@ -1761,12 +1760,11 @@ DBImpl::Query(const std::shared_ptr<server::Context>& context, const std::string
         return SHUTDOWN_ERROR;
     }
 
-    bool  is_all_search_file = true;
+    bool is_all_search_file = true;
     server::Config::GetInstance().GetGeneralConfigSearchRawEnable(is_all_search_file);
     // step 1: get all collection files from collection
     meta::FilesHolder files_holder;
-    Status status = CollectFilesToSearch(collection_id, partition_tags, 
-                                         is_all_search_file, files_holder);
+    Status status = CollectFilesToSearch(collection_id, partition_tags, is_all_search_file, files_holder);
     if (!status.ok()) {
         return status;
     }
@@ -2635,8 +2633,7 @@ DBImpl::ResumeIfLast() {
 
 Status
 DBImpl::CollectFilesToSearch(const std::string& collection_id, const std::vector<std::string>& partition_tags,
-                             bool is_all_search_file,
-                             meta::FilesHolder& files_holder) {
+                             bool is_all_search_file, meta::FilesHolder& files_holder) {
     Status status;
     std::set<std::string> partition_ids;
     if (partition_tags.empty()) {

--- a/core/src/db/DBImpl.h
+++ b/core/src/db/DBImpl.h
@@ -259,7 +259,8 @@ class DBImpl : public DB, public server::CacheConfigHandler, public server::Engi
     ResumeIfLast();
 
     Status
-    CollectFilesToSearch(const std::string& collection_id, const std::vector<std::string>& partition_tags,
+    CollectFilesToSearch(const std::string& collection_id, const std::vector<std::string>& partition_tags, 
+                         bool is_all_search_file,
                          meta::FilesHolder& files_holder);
 
  private:

--- a/core/src/db/DBImpl.h
+++ b/core/src/db/DBImpl.h
@@ -259,9 +259,8 @@ class DBImpl : public DB, public server::CacheConfigHandler, public server::Engi
     ResumeIfLast();
 
     Status
-    CollectFilesToSearch(const std::string& collection_id, const std::vector<std::string>& partition_tags, 
-                         bool is_all_search_file,
-                         meta::FilesHolder& files_holder);
+    CollectFilesToSearch(const std::string& collection_id, const std::vector<std::string>& partition_tags,
+                         bool is_all_search_file, meta::FilesHolder& files_holder);
 
  private:
     DBOptions options_;

--- a/core/src/db/meta/Meta.h
+++ b/core/src/db/meta/Meta.h
@@ -126,11 +126,12 @@ class Meta {
     GetPartitionName(const std::string& collection_id, const std::string& tag, std::string& partition_name) = 0;
 
     virtual Status
-    FilesToSearch(const std::string& collection_id, FilesHolder& files_holder) = 0;
+    FilesToSearch(const std::string& collection_id, FilesHolder& files_holder, 
+                  bool is_all_search_file = true) = 0;
 
     virtual Status
     FilesToSearchEx(const std::string& root_collection, const std::set<std::string>& partition_id_array,
-                    FilesHolder& files_holder) = 0;
+                    FilesHolder& files_holder, bool is_all_search_file = true) = 0;
 
     virtual Status
     FilesToMerge(const std::string& collection_id, FilesHolder& files_holder) = 0;

--- a/core/src/db/meta/Meta.h
+++ b/core/src/db/meta/Meta.h
@@ -126,8 +126,7 @@ class Meta {
     GetPartitionName(const std::string& collection_id, const std::string& tag, std::string& partition_name) = 0;
 
     virtual Status
-    FilesToSearch(const std::string& collection_id, FilesHolder& files_holder, 
-                  bool is_all_search_file = true) = 0;
+    FilesToSearch(const std::string& collection_id, FilesHolder& files_holder, bool is_all_search_file = true) = 0;
 
     virtual Status
     FilesToSearchEx(const std::string& root_collection, const std::set<std::string>& partition_id_array,

--- a/core/src/db/meta/MySQLMetaImpl.cpp
+++ b/core/src/db/meta/MySQLMetaImpl.cpp
@@ -1595,8 +1595,7 @@ MySQLMetaImpl::GetPartitionName(const std::string& collection_id, const std::str
 }
 
 Status
-MySQLMetaImpl::FilesToSearch(const std::string& collection_id, FilesHolder& files_holder, 
-                             bool is_all_search_file) {
+MySQLMetaImpl::FilesToSearch(const std::string& collection_id, FilesHolder& files_holder, bool is_all_search_file) {
     try {
         server::MetricCollector metric;
         mysqlpp::StoreQueryResult res;
@@ -1733,9 +1732,9 @@ MySQLMetaImpl::FilesToSearchEx(const std::string& root_collection, const std::se
                 // End
                 if (is_all_search_file) {
                     statement << " AND"
-                            << " (file_type = " << std::to_string(SegmentSchema::RAW)
-                            << " OR file_type = " << std::to_string(SegmentSchema::TO_INDEX)
-                            << " OR file_type = " << std::to_string(SegmentSchema::INDEX) << ");";
+                              << " (file_type = " << std::to_string(SegmentSchema::RAW)
+                              << " OR file_type = " << std::to_string(SegmentSchema::TO_INDEX)
+                              << " OR file_type = " << std::to_string(SegmentSchema::INDEX) << ");";
                 } else {
                     statement << " AND file_type = " << std::to_string(SegmentSchema::INDEX) << ";";
                 }

--- a/core/src/db/meta/MySQLMetaImpl.cpp
+++ b/core/src/db/meta/MySQLMetaImpl.cpp
@@ -1595,7 +1595,8 @@ MySQLMetaImpl::GetPartitionName(const std::string& collection_id, const std::str
 }
 
 Status
-MySQLMetaImpl::FilesToSearch(const std::string& collection_id, FilesHolder& files_holder) {
+MySQLMetaImpl::FilesToSearch(const std::string& collection_id, FilesHolder& files_holder, 
+                             bool is_all_search_file) {
     try {
         server::MetricCollector metric;
         mysqlpp::StoreQueryResult res;
@@ -1618,10 +1619,14 @@ MySQLMetaImpl::FilesToSearch(const std::string& collection_id, FilesHolder& file
                       << " FROM " << META_TABLEFILES << " WHERE table_id = " << mysqlpp::quote << collection_id;
 
             // End
-            statement << " AND"
-                      << " (file_type = " << std::to_string(SegmentSchema::RAW)
-                      << " OR file_type = " << std::to_string(SegmentSchema::TO_INDEX)
-                      << " OR file_type = " << std::to_string(SegmentSchema::INDEX) << ");";
+            if (is_all_search_file) {
+                statement << " AND"
+                          << " (file_type = " << std::to_string(SegmentSchema::RAW)
+                          << " OR file_type = " << std::to_string(SegmentSchema::TO_INDEX)
+                          << " OR file_type = " << std::to_string(SegmentSchema::INDEX) << ");";
+            } else {
+                statement << " AND file_type = " << std::to_string(SegmentSchema::INDEX) << ";";
+            }
 
             LOG_ENGINE_DEBUG_ << "FilesToSearch: " << statement.str();
 
@@ -1679,7 +1684,7 @@ MySQLMetaImpl::FilesToSearch(const std::string& collection_id, FilesHolder& file
 
 Status
 MySQLMetaImpl::FilesToSearchEx(const std::string& root_collection, const std::set<std::string>& partition_id_array,
-                               FilesHolder& files_holder) {
+                               FilesHolder& files_holder, bool is_all_search_file) {
     try {
         server::MetricCollector metric;
 
@@ -1726,10 +1731,14 @@ MySQLMetaImpl::FilesToSearchEx(const std::string& root_collection, const std::se
                 statement << ")";
 
                 // End
-                statement << " AND"
-                          << " (file_type = " << std::to_string(SegmentSchema::RAW)
-                          << " OR file_type = " << std::to_string(SegmentSchema::TO_INDEX)
-                          << " OR file_type = " << std::to_string(SegmentSchema::INDEX) << ");";
+                if (is_all_search_file) {
+                    statement << " AND"
+                            << " (file_type = " << std::to_string(SegmentSchema::RAW)
+                            << " OR file_type = " << std::to_string(SegmentSchema::TO_INDEX)
+                            << " OR file_type = " << std::to_string(SegmentSchema::INDEX) << ");";
+                } else {
+                    statement << " AND file_type = " << std::to_string(SegmentSchema::INDEX) << ";";
+                }
 
                 LOG_ENGINE_DEBUG_ << "FilesToSearchEx: " << statement.str();
 

--- a/core/src/db/meta/MySQLMetaImpl.h
+++ b/core/src/db/meta/MySQLMetaImpl.h
@@ -111,11 +111,12 @@ class MySQLMetaImpl : public Meta {
     GetPartitionName(const std::string& collection_id, const std::string& tag, std::string& partition_name) override;
 
     Status
-    FilesToSearch(const std::string& collection_id, FilesHolder& files_holder) override;
+    FilesToSearch(const std::string& collection_id, FilesHolder& files_holder, 
+                  bool is_all_search_file = true) override;
 
     Status
     FilesToSearchEx(const std::string& root_collection, const std::set<std::string>& partition_id_array,
-                    FilesHolder& files_holder) override;
+                    FilesHolder& files_holder, bool is_all_search_file = true) override;
 
     Status
     FilesToMerge(const std::string& collection_id, FilesHolder& files_holder) override;

--- a/core/src/db/meta/MySQLMetaImpl.h
+++ b/core/src/db/meta/MySQLMetaImpl.h
@@ -111,8 +111,7 @@ class MySQLMetaImpl : public Meta {
     GetPartitionName(const std::string& collection_id, const std::string& tag, std::string& partition_name) override;
 
     Status
-    FilesToSearch(const std::string& collection_id, FilesHolder& files_holder, 
-                  bool is_all_search_file = true) override;
+    FilesToSearch(const std::string& collection_id, FilesHolder& files_holder, bool is_all_search_file = true) override;
 
     Status
     FilesToSearchEx(const std::string& root_collection, const std::set<std::string>& partition_id_array,

--- a/core/src/db/meta/SqliteMetaImpl.h
+++ b/core/src/db/meta/SqliteMetaImpl.h
@@ -113,11 +113,12 @@ class SqliteMetaImpl : public Meta {
     GetPartitionName(const std::string& collection_id, const std::string& tag, std::string& partition_name) override;
 
     Status
-    FilesToSearch(const std::string& collection_id, FilesHolder& files_holder) override;
+    FilesToSearch(const std::string& collection_id, FilesHolder& files_holder, 
+                  bool is_all_search_file = true) override;
 
     Status
     FilesToSearchEx(const std::string& root_collection, const std::set<std::string>& partition_id_array,
-                    FilesHolder& files_holder) override;
+                    FilesHolder& files_holder, bool is_all_search_file = true) override;
 
     Status
     FilesToMerge(const std::string& collection_id, FilesHolder& files_holder) override;

--- a/core/src/db/meta/SqliteMetaImpl.h
+++ b/core/src/db/meta/SqliteMetaImpl.h
@@ -11,6 +11,8 @@
 
 #pragma once
 
+#include <sqlite3.h>
+
 #include <mutex>
 #include <set>
 #include <string>
@@ -19,8 +21,6 @@
 
 #include "Meta.h"
 #include "db/Options.h"
-
-#include <sqlite3.h>
 
 namespace milvus {
 namespace engine {
@@ -113,8 +113,7 @@ class SqliteMetaImpl : public Meta {
     GetPartitionName(const std::string& collection_id, const std::string& tag, std::string& partition_name) override;
 
     Status
-    FilesToSearch(const std::string& collection_id, FilesHolder& files_holder, 
-                  bool is_all_search_file = true) override;
+    FilesToSearch(const std::string& collection_id, FilesHolder& files_holder, bool is_all_search_file = true) override;
 
     Status
     FilesToSearchEx(const std::string& root_collection, const std::set<std::string>& partition_id_array,

--- a/core/unittest/db/test_meta_mysql.cpp
+++ b/core/unittest/db/test_meta_mysql.cpp
@@ -612,6 +612,21 @@ TEST_F(MySqlMetaTest, COLLECTION_FILES_TEST) {
     status = impl_->FilesToMerge("notexist", files_holder);
     ASSERT_EQ(status.code(), milvus::DB_NOT_FOUND);
 
+    files_holder.ReleaseFiles();
+    status = impl_->FilesToSearch(collection_id, files_holder, false);
+    ASSERT_EQ(files_holder.HoldFiles().size(), index_files_cnt);
+
+    std::set<std::string> coll_arr;
+    coll_arr.insert(collection_id);
+
+    files_holder.ReleaseFiles();
+    status = impl_->FilesToSearchEx(collection_id, coll_arr, files_holder, false);
+    ASSERT_EQ(files_holder.HoldFiles().size(), index_files_cnt);
+
+    files_holder.ReleaseFiles();
+    status = impl_->FilesToSearchEx(collection_id, coll_arr, files_holder);
+    ASSERT_EQ(files_holder.HoldFiles().size(), to_index_files_cnt + raw_files_cnt + index_files_cnt);
+
     table_file.file_type_ = milvus::engine::meta::SegmentSchema::RAW;
     table_file.file_size_ = milvus::engine::GB + 1;
     status = impl_->UpdateCollectionFile(table_file);

--- a/core/unittest/server/test_config.cpp
+++ b/core/unittest/server/test_config.cpp
@@ -1309,6 +1309,32 @@ TEST_F(ConfigTest, SERVER_CONFIG_OTHER_CONFIGS_FAIL_TEST) {
 #endif
 }
 
+TEST_F(ConfigTest, SEARCH_ROW_CONFIG_TEST) {
+    std::string conf_file = std::string(CONFIG_PATH) + VALID_CONFIG_FILE;
+    milvus::server::Config& config = milvus::server::Config::GetInstance();
+
+    config.ClearCache();
+    auto status = config.LoadConfigFile(conf_file);
+    ASSERT_TRUE(status.ok()) << status.message();
+
+    std::string config_json_str;
+    config.GetConfigJsonStr(config_json_str);
+    std::cout << config_json_str << std::endl;
+
+    bool  is_search_row;
+    config.GetGeneralConfigSearchRawEnable(is_search_row);
+    ASSERT_FALSE(is_search_row);
+
+    config.SetGeneralConfigSearchRawEnable("true");
+    config.GetGeneralConfigSearchRawEnable(is_search_row);
+    ASSERT_TRUE(is_search_row);
+
+    status = config.ResetDefaultConfig();
+    ASSERT_TRUE(status.ok()) << status.message();
+    config.GetGeneralConfigSearchRawEnable(is_search_row);
+    ASSERT_TRUE(is_search_row); 
+}
+
 TEST_F(ConfigTest, SERVER_CONFIG_UPDATE_TEST) {
     std::string conf_file = std::string(CONFIG_PATH) + VALID_CONFIG_FILE;
     std::string yaml_value;

--- a/core/unittest/server/test_config.cpp
+++ b/core/unittest/server/test_config.cpp
@@ -9,14 +9,14 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied. See the License for the specific language governing permissions and limitations under the License.
 
-#include <cmath>
-#include <limits>
-#include <thread>
-
 #include <fiu-control.h>
 #include <fiu-local.h>
 #include <gtest/gtest-death-test.h>
 #include <gtest/gtest.h>
+
+#include <cmath>
+#include <limits>
+#include <thread>
 
 #include "config/Config.h"
 #include "config/YamlConfigMgr.h"
@@ -1321,7 +1321,7 @@ TEST_F(ConfigTest, SEARCH_ROW_CONFIG_TEST) {
     config.GetConfigJsonStr(config_json_str);
     std::cout << config_json_str << std::endl;
 
-    bool  is_search_row;
+    bool is_search_row;
     config.GetGeneralConfigSearchRawEnable(is_search_row);
     ASSERT_FALSE(is_search_row);
 
@@ -1332,7 +1332,7 @@ TEST_F(ConfigTest, SEARCH_ROW_CONFIG_TEST) {
     status = config.ResetDefaultConfig();
     ASSERT_TRUE(status.ok()) << status.message();
     config.GetGeneralConfigSearchRawEnable(is_search_row);
-    ASSERT_TRUE(is_search_row); 
+    ASSERT_TRUE(is_search_row);
 }
 
 TEST_F(ConfigTest, SERVER_CONFIG_UPDATE_TEST) {

--- a/core/unittest/server/utils.cpp
+++ b/core/unittest/server/utils.cpp
@@ -32,6 +32,7 @@ static const char* VALID_CONFIG_STR =
     "general:\n"
     "  timezone: UTC+8\n"
     "  meta_uri: sqlite://:@:/\n"
+    "  search_raw_enable: false\n"
     "\n"
     "network:\n"
     "  bind.address: 0.0.0.0\n"


### PR DESCRIPTION
Function: 
     we hope there is a switch control, only the indexed vector can be queried.

Based on two requirements:
      1. When there are many vectors, if no index is established, the query performance will be poor.
      2. Sometimes we want to control the effect of the newly added vector.