### PR TITLE
Specify describe collection timestamp in initBloomFilter

### DIFF
--- a/internal/datanode/data_node.go
+++ b/internal/datanode/data_node.go
@@ -369,8 +369,9 @@ func parseDeleteEventKey(key string) string {
 
 func (node *DataNode) handlePutEvent(watchInfo *datapb.ChannelWatchInfo) error {
 	vChanName := watchInfo.GetVchan().GetChannelName()
+	ts := Timestamp(watchInfo.StartTs)
 
-	if err := node.flowgraphManager.addAndStart(node, watchInfo.GetVchan()); err != nil {
+	if err := node.flowgraphManager.addAndStart(node, watchInfo.GetVchan(), ts); err != nil {
 		return fmt.Errorf("fail to add and start flowgraph for vChanName: %s, err: %v", vChanName, err)
 	}
 	log.Debug("handle put event: new data sync service success", zap.String("vChanName", vChanName))

--- a/internal/datanode/flow_graph_manager.go
+++ b/internal/datanode/flow_graph_manager.go
@@ -34,7 +34,7 @@ func newFlowgraphManager() *flowgraphManager {
 	return &flowgraphManager{}
 }
 
-func (fm *flowgraphManager) addAndStart(dn *DataNode, vchan *datapb.VchannelInfo) error {
+func (fm *flowgraphManager) addAndStart(dn *DataNode, vchan *datapb.VchannelInfo, ts Timestamp) error {
 	log.Debug("received Vchannel Info",
 		zap.String("vChannelName", vchan.GetChannelName()),
 		zap.Int("Unflushed Segment Number", len(vchan.GetUnflushedSegments())),
@@ -54,7 +54,7 @@ func (fm *flowgraphManager) addAndStart(dn *DataNode, vchan *datapb.VchannelInfo
 
 	var alloc allocatorInterface = newAllocator(dn.rootCoord)
 
-	dataSyncService, err := newDataSyncService(dn.ctx, make(chan flushMsg, 100), replica, alloc, dn.msFactory, vchan, dn.clearSignal, dn.dataCoord, dn.segmentCache, dn.blobKv, dn.compactionExecutor)
+	dataSyncService, err := newDataSyncService(dn.ctx, make(chan flushMsg, 100), replica, alloc, dn.msFactory, vchan, dn.clearSignal, dn.dataCoord, dn.segmentCache, dn.blobKv, dn.compactionExecutor, ts)
 	if err != nil {
 		log.Warn("new data sync service fail", zap.String("vChannelName", vchan.GetChannelName()), zap.Error(err))
 		return err

--- a/internal/datanode/segment_replica.go
+++ b/internal/datanode/segment_replica.go
@@ -52,9 +52,9 @@ type Replica interface {
 
 	listAllSegmentIDs() []UniqueID
 	addNewSegment(segID, collID, partitionID UniqueID, channelName string, startPos, endPos *internalpb.MsgPosition) error
-	addNormalSegment(segID, collID, partitionID UniqueID, channelName string, numOfRows int64, statsBinlog []*datapb.FieldBinlog, cp *segmentCheckPoint) error
+	addNormalSegment(segID, collID, partitionID UniqueID, channelName string, numOfRows int64, statsBinlog []*datapb.FieldBinlog, cp *segmentCheckPoint, ts Timestamp) error
 	filterSegments(channelName string, partitionID UniqueID) []*Segment
-	addFlushedSegment(segID, collID, partitionID UniqueID, channelName string, numOfRows int64, statsBinlog []*datapb.FieldBinlog) error
+	addFlushedSegment(segID, collID, partitionID UniqueID, channelName string, numOfRows int64, statsBinlog []*datapb.FieldBinlog, ts Timestamp) error
 	listNewSegmentsStartPositions() []*datapb.SegmentStartPosition
 	listSegmentsCheckPoints() map[UniqueID]segmentCheckPoint
 	updateSegmentEndPosition(segID UniqueID, endPos *internalpb.MsgPosition)
@@ -319,7 +319,7 @@ func (replica *SegmentReplica) filterSegments(channelName string, partitionID Un
 
 // addNormalSegment adds a *NotNew* and *NotFlushed* segment. Before add, please make sure there's no
 // such segment by `hasSegment`
-func (replica *SegmentReplica) addNormalSegment(segID, collID, partitionID UniqueID, channelName string, numOfRows int64, statsBinlogs []*datapb.FieldBinlog, cp *segmentCheckPoint) error {
+func (replica *SegmentReplica) addNormalSegment(segID, collID, partitionID UniqueID, channelName string, numOfRows int64, statsBinlogs []*datapb.FieldBinlog, cp *segmentCheckPoint, ts Timestamp) error {
 	if collID != replica.collectionID {
 		log.Warn("Mismatch collection",
 			zap.Int64("input ID", collID),
@@ -349,7 +349,7 @@ func (replica *SegmentReplica) addNormalSegment(segID, collID, partitionID Uniqu
 		seg.checkPoint = *cp
 		seg.endPos = &cp.pos
 	}
-	err := replica.initPKBloomFilter(seg, statsBinlogs)
+	err := replica.initPKBloomFilter(seg, statsBinlogs, ts)
 	if err != nil {
 		return err
 	}
@@ -366,7 +366,7 @@ func (replica *SegmentReplica) addNormalSegment(segID, collID, partitionID Uniqu
 
 // addFlushedSegment adds a *Flushed* segment. Before add, please make sure there's no
 // such segment by `hasSegment`
-func (replica *SegmentReplica) addFlushedSegment(segID, collID, partitionID UniqueID, channelName string, numOfRows int64, statsBinlogs []*datapb.FieldBinlog) error {
+func (replica *SegmentReplica) addFlushedSegment(segID, collID, partitionID UniqueID, channelName string, numOfRows int64, statsBinlogs []*datapb.FieldBinlog, ts Timestamp) error {
 
 	if collID != replica.collectionID {
 		log.Warn("Mismatch collection",
@@ -395,7 +395,7 @@ func (replica *SegmentReplica) addFlushedSegment(segID, collID, partitionID Uniq
 		maxPK:    math.MinInt64, // use min value represents no value
 	}
 
-	err := replica.initPKBloomFilter(seg, statsBinlogs)
+	err := replica.initPKBloomFilter(seg, statsBinlogs, ts)
 	if err != nil {
 		return err
 	}
@@ -410,11 +410,11 @@ func (replica *SegmentReplica) addFlushedSegment(segID, collID, partitionID Uniq
 	return nil
 }
 
-func (replica *SegmentReplica) initPKBloomFilter(s *Segment, statsBinlogs []*datapb.FieldBinlog) error {
+func (replica *SegmentReplica) initPKBloomFilter(s *Segment, statsBinlogs []*datapb.FieldBinlog, ts Timestamp) error {
 	if len(statsBinlogs) == 0 {
 		log.Info("statsBinlogs is empty")
 	}
-	schema, err := replica.getCollectionSchema(s.collectionID, 0)
+	schema, err := replica.getCollectionSchema(s.collectionID, ts)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Specify appropriate timestamp (instead of latest) for datanode to get collection schema from rootcoord. 
The timestamp comes from etcd put event.
Related to Issue #15608 

Signed-off-by: Letian Jiang <letian.jiang@zilliz.com>