### PR TITLE
Enable ZSTD compression for binlog

### DIFF
--- a/internal/storage/cwrapper/CMakeLists.txt
+++ b/internal/storage/cwrapper/CMakeLists.txt
@@ -42,7 +42,8 @@ macro( build_arrow )
 
     set( ARROW_CMAKE_ARGS
         "-DARROW_WITH_LZ4=OFF"
-        "-DARROW_WITH_ZSTD=OFF"
+        "-DARROW_WITH_ZSTD=ON"
+        "-Dzstd_SOURCE=BUNDLED"
         "-DARROW_WITH_BROTLI=OFF"
         "-DARROW_WITH_SNAPPY=OFF"
         "-DARROW_WITH_ZLIB=OFF"


### PR DESCRIPTION
Enable ZSTD compression of Parquet, for milvus' binlog
Resolve #15561 
Signed-off-by: yah01 <yang.cen@zilliz.com>