### PR TITLE
Add support for scalar field in index builder.

### DIFF
--- a/internal/core/src/indexbuilder/CMakeLists.txt
+++ b/internal/core/src/indexbuilder/CMakeLists.txt
@@ -13,6 +13,7 @@
 set(INDEXBUILDER_FILES
         IndexWrapper.cpp
         index_c.cpp
+        scalar_index_c.cpp
         init_c.cpp
         )
 add_library(milvus_indexbuilder SHARED
@@ -27,8 +28,8 @@ endif ()
 
 # link order matters
 target_link_libraries(milvus_indexbuilder
-        knowhere
         milvus_common
+        knowhere
         ${TBB}
         ${PLATFORM_LIBS}
         pthread

--- a/internal/core/src/indexbuilder/ScalarIndexCreator-inl.h
+++ b/internal/core/src/indexbuilder/ScalarIndexCreator-inl.h
@@ -1,0 +1,64 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+
+#include <knowhere/index/structured_index_simple/StructuredIndexSort.h>
+#include <pb/schema.pb.h>
+#include "indexbuilder/common.h"
+#include <string>
+#include <memory>
+
+namespace milvus::indexbuilder {
+
+template <typename T>
+ScalarIndexCreator<T>::ScalarIndexCreator(const char* type_params, const char* index_params) {
+    Helper::ParseFromString(type_params_, std::string(type_params));
+    Helper::ParseFromString(index_params_, std::string(index_params));
+    // TODO: create index according to the params.
+    index_ = std::make_shared<knowhere::scalar::StructuredIndexSort<T>>();
+}
+
+template <typename T>
+void
+ScalarIndexCreator<T>::Build(const knowhere::DatasetPtr& dataset) {
+    auto size = dataset->Get<int64_t>(knowhere::meta::ROWS);
+    auto data = dataset->Get<const void*>(knowhere::meta::TENSOR);
+    index_->Build(size, static_cast<const T*>(data));
+}
+
+template <typename T>
+std::unique_ptr<knowhere::BinarySet>
+ScalarIndexCreator<T>::Serialize() {
+    return std::make_unique<knowhere::BinarySet>(index_->Serialize(config_));
+}
+
+// not sure that the pointer of a golang bool array acts like other types.
+template <>
+void
+ScalarIndexCreator<bool>::Build(const milvus::knowhere::DatasetPtr& dataset) {
+    auto size = dataset->Get<int64_t>(knowhere::meta::ROWS);
+    auto data = dataset->Get<const char*>(knowhere::meta::TENSOR);
+    proto::schema::BoolArray arr;
+    arr.ParseFromArray(data, size);
+    index_->Build(arr.data().size(), arr.data().data());
+}
+
+template <>
+void
+ScalarIndexCreator<std::string>::Build(const milvus::knowhere::DatasetPtr& dataset) {
+    auto size = dataset->Get<int64_t>(knowhere::meta::ROWS);
+    auto data = dataset->Get<const char*>(knowhere::meta::TENSOR);
+    proto::schema::StringArray arr;
+    arr.ParseFromArray(data, size);
+    auto p = (std::string*)(arr.data().data());
+    index_->Build(arr.data().size(), p);
+}
+
+}  // namespace milvus::indexbuilder

--- a/internal/core/src/indexbuilder/ScalarIndexCreator.h
+++ b/internal/core/src/indexbuilder/ScalarIndexCreator.h
@@ -1,0 +1,44 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+
+#include "indexbuilder/ScalarIndexCreatorBase.h"
+#include "knowhere/index/structured_index_simple/StructuredIndex.h"
+#include "pb/index_cgo_msg.pb.h"
+#include <string>
+#include <memory>
+
+namespace milvus::indexbuilder {
+
+template <typename T>
+class ScalarIndexCreator : public ScalarIndexCreatorBase {
+    // of course, maybe we can support combination index later.
+    // for example, we can create index for combination of (field a, field b),
+    // attribute filtering on the combination can be speed up.
+    static_assert(std::is_fundamental_v<T> || std::is_same_v<T, std::string>);
+
+ public:
+    ScalarIndexCreator(const char* type_params, const char* index_params);
+
+    void
+    Build(const knowhere::DatasetPtr& dataset) override;
+
+    std::unique_ptr<knowhere::BinarySet>
+    Serialize() override;
+
+ private:
+    knowhere::scalar::StructuredIndexPtr<T> index_ = nullptr;
+    proto::indexcgo::MapParams type_params_;
+    proto::indexcgo::MapParams index_params_;
+    milvus::json config_;
+};
+}  // namespace milvus::indexbuilder
+
+#include "ScalarIndexCreator-inl.h"

--- a/internal/core/src/indexbuilder/ScalarIndexCreatorBase.h
+++ b/internal/core/src/indexbuilder/ScalarIndexCreatorBase.h
@@ -1,0 +1,32 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+
+#pragma once
+
+#include "knowhere/common/Dataset.h"
+#include "knowhere/common/BinarySet.h"
+#include <memory>
+
+namespace milvus::indexbuilder {
+class ScalarIndexCreatorBase {
+ public:
+    virtual ~ScalarIndexCreatorBase() = default;
+
+    virtual void
+    Build(const knowhere::DatasetPtr& dataset) = 0;
+
+    virtual std::unique_ptr<knowhere::BinarySet>
+    Serialize() = 0;
+};
+
+using ScalarIndexCreatorBasePtr = std::unique_ptr<ScalarIndexCreatorBase>;
+
+}  // namespace milvus::indexbuilder

--- a/internal/core/src/indexbuilder/ScalarIndexFactory.h
+++ b/internal/core/src/indexbuilder/ScalarIndexFactory.h
@@ -1,0 +1,72 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+
+#pragma once
+
+#include <pb/schema.pb.h>
+#include <cmath>
+#include "indexbuilder/ScalarIndexCreatorBase.h"
+#include "indexbuilder/ScalarIndexCreator.h"
+#include "indexbuilder/type_c.h"
+#include <memory>
+#include <string>
+
+namespace milvus::indexbuilder {
+
+// consider template factory if too many factories are needed.
+class ScalarIndexFactory {
+ public:
+    ScalarIndexFactory() = default;
+    ScalarIndexFactory(const ScalarIndexFactory&) = delete;
+    ScalarIndexFactory
+    operator=(const ScalarIndexFactory&) = delete;
+
+ public:
+    static ScalarIndexFactory&
+    GetInstance() {
+        // thread-safe enough after c++ 11
+        static ScalarIndexFactory instance;
+        return instance;
+    }
+
+    ScalarIndexCreatorBasePtr
+    CreateScalarIndex(DataType dtype, const char* type_params, const char* index_params) {
+        auto real_dtype = proto::schema::DataType(dtype);
+        auto invalid_dtype_msg = std::string("invalid data type: ") + std::to_string(real_dtype);
+
+        switch (real_dtype) {
+            case milvus::proto::schema::Bool:
+                return std::make_unique<ScalarIndexCreator<bool>>(type_params, index_params);
+            case milvus::proto::schema::Int8:
+                return std::make_unique<ScalarIndexCreator<int8_t>>(type_params, index_params);
+            case milvus::proto::schema::Int16:
+                return std::make_unique<ScalarIndexCreator<int16_t>>(type_params, index_params);
+            case milvus::proto::schema::Int32:
+                return std::make_unique<ScalarIndexCreator<int32_t>>(type_params, index_params);
+            case milvus::proto::schema::Int64:
+                return std::make_unique<ScalarIndexCreator<int64_t>>(type_params, index_params);
+            case milvus::proto::schema::Float:
+                return std::make_unique<ScalarIndexCreator<float_t>>(type_params, index_params);
+            case milvus::proto::schema::Double:
+                return std::make_unique<ScalarIndexCreator<double_t>>(type_params, index_params);
+            case milvus::proto::schema::String:
+                return std::make_unique<ScalarIndexCreator<std::string>>(type_params, index_params);
+            case milvus::proto::schema::None:
+            case milvus::proto::schema::BinaryVector:
+            case milvus::proto::schema::FloatVector:
+            case milvus::proto::schema::DataType_INT_MIN_SENTINEL_DO_NOT_USE_:
+            case milvus::proto::schema::DataType_INT_MAX_SENTINEL_DO_NOT_USE_:
+                throw std::invalid_argument(invalid_dtype_msg);
+        }
+    }
+};
+
+}  // namespace milvus::indexbuilder

--- a/internal/core/src/indexbuilder/common.h
+++ b/internal/core/src/indexbuilder/common.h
@@ -1,0 +1,33 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+
+#include "pb/index_cgo_msg.pb.h"
+#include "exceptions/EasyAssert.h"
+#include <google/protobuf/text_format.h>
+#include <string>
+
+namespace milvus::indexbuilder {
+
+struct Helper {
+    static void
+    ParseFromString(proto::indexcgo::MapParams& params, const std::string& str) {
+        auto ok = google::protobuf::TextFormat::ParseFromString(str, &params);
+        AssertInfo(ok, "failed to parse params from string");
+    }
+
+    static void
+    ParseParams(proto::indexcgo::MapParams& params, const char* data, const size_t size) {
+        auto ok = params.ParseFromArray(data, size);
+        AssertInfo(ok, "failed to parse params from array");
+    }
+};
+
+}  // namespace milvus::indexbuilder

--- a/internal/core/src/indexbuilder/index_c.cpp
+++ b/internal/core/src/indexbuilder/index_c.cpp
@@ -17,6 +17,7 @@
 
 #endif
 
+#include "exceptions/EasyAssert.h"
 #include "knowhere/index/vector_index/adapter/VectorAdapter.h"
 #include "indexbuilder/IndexWrapper.h"
 #include "indexbuilder/index_c.h"

--- a/internal/core/src/indexbuilder/index_c.h
+++ b/internal/core/src/indexbuilder/index_c.h
@@ -16,13 +16,9 @@ extern "C" {
 #endif
 
 #include <stdint.h>
-#include "segcore/collection_c.h"
 #include "common/type_c.h"
 #include "common/vector_index_c.h"
-
-typedef void* CIndex;
-typedef void* CIndexQueryResult;
-typedef void* CBinary;
+#include "indexbuilder/type_c.h"
 
 // TODO: how could we pass map between go and c++ more efficiently?
 // Solution: using Protobuf instead of JSON, this way significantly increase programming efficiency

--- a/internal/core/src/indexbuilder/scalar_index_c.cpp
+++ b/internal/core/src/indexbuilder/scalar_index_c.cpp
@@ -1,0 +1,107 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+
+#ifndef __APPLE__
+#include <malloc.h>
+#endif
+
+#include <knowhere/index/vector_index/adapter/VectorAdapter.h>
+#include "exceptions/EasyAssert.h"
+#include "indexbuilder/scalar_index_c.h"
+#include "indexbuilder/ScalarIndexFactory.h"
+
+CStatus
+CreateScalarIndex(enum DataType dtype,
+                  const char* serialized_type_params,
+                  const char* serialized_index_params,
+                  CScalarIndexBuilder* res_index) {
+    auto status = CStatus();
+    try {
+        AssertInfo(res_index, "failed to create scalar index, passed index was null");
+
+        *res_index = milvus::indexbuilder::ScalarIndexFactory::GetInstance()
+                         .CreateScalarIndex(dtype, serialized_type_params, serialized_index_params)
+                         .release();
+
+        status.error_code = Success;
+        status.error_msg = "";
+    } catch (std::exception& e) {
+        status.error_code = UnexpectedError;
+        status.error_msg = strdup(e.what());
+    }
+    return status;
+}
+
+// field_data:
+//  1, serialized proto::schema::BoolArray, if type is bool;
+//  2, serialized proto::schema::StringArray, if type is string;
+//  3, raw pointer, if type is of fundamental;
+// TODO: optimize here if necessary.
+CStatus
+BuildScalarIndex(CScalarIndex c_index, const void* field_data, uint64_t size) {
+    auto status = CStatus();
+    try {
+        AssertInfo(c_index, "failed to build scalar index, passed index was null");
+
+        auto real_index = (milvus::indexbuilder::ScalarIndexCreatorBase*)c_index;
+        const int64_t dim = 8;  // not important here
+        auto dataset = milvus::knowhere::GenDataset(size, dim, field_data);
+        real_index->Build(dataset);
+
+        status.error_code = Success;
+        status.error_msg = "";
+    } catch (std::exception& e) {
+        status.error_code = UnexpectedError;
+        status.error_msg = strdup(e.what());
+    }
+    return status;
+}
+
+CStatus
+SerializeScalarIndexToBinarySet(CScalarIndex c_index, CBinarySet* c_binary_set) {
+    auto status = CStatus();
+    try {
+        AssertInfo(c_index, "failed to serialize scalar index, passed index was null");
+        AssertInfo(c_binary_set, "failed to serialize scalar index, passed c_binary_set was null");
+
+        auto real_index = (milvus::indexbuilder::ScalarIndexCreatorBase*)c_index;
+        *c_binary_set = real_index->Serialize().release();
+
+        status.error_code = Success;
+        status.error_msg = "";
+    } catch (std::exception& e) {
+        status.error_code = UnexpectedError;
+        status.error_msg = strdup(e.what());
+    }
+    return status;
+}
+
+CStatus
+DeleteScalarIndex(CScalarIndex c_index) {
+    auto status = CStatus();
+    try {
+        AssertInfo(c_index, "failed to serialize scalar index, passed index was null");
+
+        auto real_index = (milvus::indexbuilder::ScalarIndexCreatorBase*)c_index;
+        delete real_index;
+
+#ifndef __APPLE__
+        malloc_trim(0);
+#endif
+
+        status.error_code = Success;
+        status.error_msg = "";
+    } catch (std::exception& e) {
+        status.error_code = UnexpectedError;
+        status.error_msg = strdup(e.what());
+    }
+    return status;
+}

--- a/internal/core/src/indexbuilder/scalar_index_c.h
+++ b/internal/core/src/indexbuilder/scalar_index_c.h
@@ -1,0 +1,45 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+#include "common/type_c.h"
+#include "common/vector_index_c.h"
+#include "indexbuilder/type_c.h"
+
+CStatus
+CreateScalarIndex(enum DataType dtype,
+                  const char* serialized_type_params,
+                  const char* serialized_index_params,
+                  CScalarIndex* res_index);
+
+// field_data:
+//  1, serialized proto::schema::BoolArray, if type is bool;
+//  2, serialized proto::schema::StringArray, if type is string;
+//  3, raw pointer, if type is of fundamental;
+// TODO: optimize here if necessary.
+CStatus
+BuildScalarIndex(CScalarIndex c_index, const void* field_data, uint64_t size);
+
+CStatus
+SerializeScalarIndexToBinarySet(CScalarIndex c_index, CBinarySet* c_binary_set);
+
+CStatus
+DeleteScalarIndex(CScalarIndex c_index);
+
+#ifdef __cplusplus
+};
+#endif

--- a/internal/core/src/indexbuilder/type_c.h
+++ b/internal/core/src/indexbuilder/type_c.h
@@ -1,0 +1,38 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+
+#pragma once
+
+// pure C don't support that we use schemapb.DataType directly.
+// Note: the value of all enumerations must match the corresponding schemapb.DataType.
+// TODO: what if there are increments in schemapb.DataType.
+enum DataType {
+    None = 0,
+    Bool = 1,
+    Int8 = 2,
+    Int16 = 3,
+    Int32 = 4,
+    Int64 = 5,
+
+    Float = 10,
+    Double = 11,
+
+    String = 20,
+
+    BinaryVector = 100,
+    FloatVector = 101,
+};
+
+typedef void* CIndex;
+typedef void* CIndexQueryResult;
+typedef void* CBinary;
+typedef void* CScalarIndexBuilder;
+typedef void* CScalarIndex;


### PR DESCRIPTION
Signed-off-by: dragondriver <jiquan.long@zilliz.com>
issue: #15867 
/kind improvement

Add support for scalar field in index builder.
Unify the interface of scalar index & vector index.