### PR TITLE
Remove milvus mertrics collect for ci

### DIFF
--- a/build/ci/jenkins/Nightly.groovy
+++ b/build/ci/jenkins/Nightly.groovy
@@ -140,8 +140,7 @@ pipeline {
                                                     --set indexNode.replicas=2 \
                                                     --set dataNode.replicas=2 \
                                                     --version ${chart_version} \
-                                                    -f values/nightly.yaml \
-                                                    --set metrics.serviceMonitor.enabled=true"
+                                                    -f values/nightly.yaml "
                                                     """
                                                 }
                                             } else {

--- a/build/ci/jenkins/PR.groovy
+++ b/build/ci/jenkins/PR.groovy
@@ -128,7 +128,6 @@ pipeline {
                                                 --set etcd.metrics.enabled=true \
                                                 --set etcd.metrics.podMonitor.enabled=true \
                                                 --set etcd.nodeSelector.disk=fast \
-                                                --set metrics.serviceMonitor.enabled=true \
                                                 --version ${chart_version} \
                                                 -f values/pr.yaml" 
                                                 """

--- a/build/ci/jenkins/qa/PR.groovy
+++ b/build/ci/jenkins/qa/PR.groovy
@@ -128,7 +128,6 @@ pipeline {
                                                 --set minio.persistence.storageClass=local-path \
                                                 --set etcd.metrics.enabled=false \
                                                 --set etcd.metrics.podMonitor.enabled=false\
-                                                --set metrics.serviceMonitor.enabled=true \
                                                 --version ${chart_version} \
                                                 -f values/pr.yaml" 
                                                 """


### PR DESCRIPTION
Currently milvus metrics have lot of data that make prometheus is not able to handle so disable collect temporarily until the issue for metrics of milvus is fixed

Signed-off-by: Jenny Li <jing.li@zilliz.com>