### PR TITLE
Fix README offline installation

### DIFF
--- a/deployments/offline/README.md
+++ b/deployments/offline/README.md
@@ -63,8 +63,7 @@ The Docker images will be stored under **images** directory.
 Enter the following command to load the Docker images:
 
 ```shell
-$ cd images/
-$ for image in $(find . -type f -name "*.tar.gz") ; do gunzip -c $image | docker load; done
+$ for image in $(find . -type f -wholename "./images/*.tar.gz") ; do gunzip -c $image | docker load; done;
 ```
 
 ## Install Milvus


### PR DESCRIPTION
Hi, I am Dario, a developer at [BuildNN](https://github.com/buildnn).
When I tried to start `milvus` with the `docker-compose`, following this [guide ](https://milvus.io/docs/v2.0.x/install_offline-docker.md), I encountered a little error. When I tried to run 
```sh
docker-compose -f docker-compose.yml up -d
```
I was in the wrong directory.

With this fixing you avoid to enter the `images` directory

Related issue #15998

Signed-off-by: Dario Curreri <dariocurr@gmail.com>