### PR TITLE
Use RmqFactory in DataNode unit test

### DIFF
--- a/internal/datanode/data_node_test.go
+++ b/internal/datanode/data_node_test.go
@@ -51,10 +51,15 @@ import (
 
 func TestMain(t *testing.M) {
 	rand.Seed(time.Now().Unix())
+	path := "/tmp/milvus_ut/rdb_data"
+	os.Setenv("ROCKSMQ_PATH", path)
+	defer os.RemoveAll(path)
+
 	Params.DataNodeCfg.InitAlias("datanode-alias-1")
 	Params.Init()
 	// change to specific channel for test
 	Params.CommonCfg.DataCoordTimeTick = Params.CommonCfg.DataCoordTimeTick + strconv.Itoa(rand.Int())
+
 	code := t.Run()
 	os.Exit(code)
 }

--- a/internal/datanode/mock_test.go
+++ b/internal/datanode/mock_test.go
@@ -53,7 +53,7 @@ const debug = false
 var emptyFlushAndDropFunc flushAndDropFunc = func(_ []*segmentFlushPack) {}
 
 func newIDLEDataNodeMock(ctx context.Context) *DataNode {
-	msFactory := msgstream.NewPmsFactory()
+	msFactory := msgstream.NewRmsFactory()
 	node := NewDataNode(ctx, msFactory)
 
 	rc := &RootCoordFactory{


### PR DESCRIPTION
Use Rocksmq instead of Pulsar in DataNode unittest
- Avoid pulsar seek problem caused timeout issue
- Remove third party component dependency in unit test

See also: #15986

/kind improvement

Signed-off-by: Congqi Xia <congqi.xia@zilliz.com>