### PR TITLE
Copy index file content to c memory

### DIFF
--- a/internal/core/src/common/vector_index_c.cpp
+++ b/internal/core/src/common/vector_index_c.cpp
@@ -47,7 +47,9 @@ AppendIndexBinary(CBinarySet c_binary_set, void* index_binary, int64_t index_siz
         auto binary_set = (milvus::knowhere::BinarySet*)c_binary_set;
         std::string index_key(c_index_key);
         uint8_t* index = (uint8_t*)index_binary;
-        std::shared_ptr<uint8_t[]> data(index, [](void*) {});
+        uint8_t* dup = new uint8_t[index_size]();
+        memcpy(dup, index, index_size);
+        std::shared_ptr<uint8_t[]> data(dup);
         binary_set->Append(index_key, data, index_size);
 
         status.error_code = Success;


### PR DESCRIPTION
Might be the root cause of #15896
The index content bytes were passed via unsafe.Pointer,
which shall be copy to cpp managed memory inmediately

This solution might cause a lot of memory consumption.
Maybe we need to store the index bytes in cpp memory in the first place.

/kind bug
/cc @czs007 

Signed-off-by: Congqi Xia <congqi.xia@zilliz.com>