### PR TITLE
Add column based segment insert in QueryNode

### DIFF
--- a/internal/querynode/flow_graph_insert_node_test.go
+++ b/internal/querynode/flow_graph_insert_node_test.go
@@ -26,7 +26,9 @@ import (
 	"github.com/milvus-io/milvus/internal/common"
 	"github.com/milvus-io/milvus/internal/mq/msgstream"
 	"github.com/milvus-io/milvus/internal/proto/commonpb"
+	"github.com/milvus-io/milvus/internal/proto/schemapb"
 	"github.com/milvus-io/milvus/internal/util/flowgraph"
+	"github.com/milvus-io/milvus/internal/util/typeutil"
 )
 
 func genFlowGraphInsertData() (*insertData, error) {
@@ -34,6 +36,10 @@ func genFlowGraphInsertData() (*insertData, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// complete the column data
+	schema := genSimpleSegCoreSchema()
+	ColumnData, _ := typeutil.TransferRowBasedDataToColumnBasedData(schema, insertMsg.RowData)
 
 	iData := &insertData{
 		insertIDs: map[UniqueID][]UniqueID{
@@ -44,6 +50,9 @@ func genFlowGraphInsertData() (*insertData, error) {
 		},
 		insertRecords: map[UniqueID][]*commonpb.Blob{
 			defaultSegmentID: insertMsg.RowData,
+		},
+		insertColumns: map[UniqueID][]*schemapb.FieldData{
+			defaultSegmentID: ColumnData,
 		},
 		insertOffset: map[UniqueID]int64{
 			defaultSegmentID: 0,

--- a/internal/util/typeutil/data_format_test.go
+++ b/internal/util/typeutil/data_format_test.go
@@ -17,16 +17,229 @@
 package typeutil
 
 import (
-	"encoding/binary"
 	"testing"
-
-	"github.com/milvus-io/milvus/internal/common"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/milvus-io/milvus/internal/proto/commonpb"
 	"github.com/milvus-io/milvus/internal/proto/schemapb"
 )
+
+func TestTransferRowBasedDataToColumnBasedData(t *testing.T) {
+	schema := &schemapb.CollectionSchema{
+		Name:        "testColl",
+		Description: "",
+		AutoID:      false,
+		Fields: []*schemapb.FieldSchema{
+			{
+				FieldID:      100,
+				Name:         "field_bool",
+				IsPrimaryKey: false,
+				Description:  "",
+				DataType:     1,
+			},
+			{
+				FieldID:      102,
+				Name:         "field_int32",
+				IsPrimaryKey: false,
+				Description:  "",
+				DataType:     4,
+			},
+			{
+				FieldID:      103,
+				Name:         "field_int64",
+				IsPrimaryKey: true,
+				Description:  "",
+				DataType:     5,
+			},
+			{
+				FieldID:      104,
+				Name:         "field_float",
+				IsPrimaryKey: false,
+				Description:  "",
+				DataType:     10,
+			},
+			{
+				FieldID:      105,
+				Name:         "field_double",
+				IsPrimaryKey: false,
+				Description:  "",
+				DataType:     11,
+			},
+			{
+				FieldID:      107,
+				Name:         "field_float_vector",
+				IsPrimaryKey: false,
+				Description:  "",
+				DataType:     101,
+				TypeParams: []*commonpb.KeyValuePair{
+					{
+						Key:   "dim",
+						Value: "1",
+					},
+				},
+			},
+			{
+				FieldID:      108,
+				Name:         "field_binary_vector",
+				IsPrimaryKey: false,
+				Description:  "",
+				DataType:     100,
+				TypeParams: []*commonpb.KeyValuePair{
+					{
+						Key:   "dim",
+						Value: "8",
+					},
+				},
+			},
+		},
+	}
+	rows := []*commonpb.Blob{
+		{
+			Value: []byte{
+				1,          // true
+				0, 0, 0, 0, // 0
+				0, 0, 0, 0, 0, 0, 0, 0, // 0
+				0, 0, 0, 0, // 0
+				0, 0, 0, 0, 0, 0, 0, 0, // 0
+				// b + 1, // "1"
+				0, 0, 0, 0, // 0
+				1, // 1
+			},
+		},
+		{
+			Value: []byte{
+				0,                // false
+				0xff, 0xff, 0, 0, // 0xffff
+				0xff, 0xff, 0xff, 0xff, 0, 0, 0, 0, // 0xffffffff
+				0, 0, 0, 0, // 0
+				0, 0, 0, 0, 0, 0, 0, 0, // 0
+				// b + 2, // "2"
+				0, 0, 0, 0, // 0
+				2, // 2
+			},
+		},
+		{
+			Value: []byte{
+				1,                      // false
+				0xff, 0xff, 0xff, 0x1f, // 0x1fffffff
+				0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x1f, // 0x1fffffffffffffff
+				0, 0, 0, 0, // 0
+				0, 0, 0, 0, 0, 0, 0, 0, // 0
+				// b + 3, // "3"
+				0, 0, 0, 0, // 0
+				3, // 3
+			},
+		},
+	}
+	columns, err := TransferRowBasedDataToColumnBasedData(schema, rows)
+	assert.NoError(t, err)
+	_columns := []*schemapb.FieldData{
+		{
+			Type: schemapb.DataType_Bool,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_BoolData{
+						BoolData: &schemapb.BoolArray{
+							Data: []bool{true, false, true},
+						},
+					},
+				},
+			},
+		},
+		{
+			Type: schemapb.DataType_Int32,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_IntData{
+						IntData: &schemapb.IntArray{
+							Data: []int32{0, 0xffff, 0x1fffffff},
+						},
+					},
+				},
+			},
+		},
+		{
+			Type: schemapb.DataType_Int64,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_LongData{
+						LongData: &schemapb.LongArray{
+							Data: []int64{0, 0xffffffff, 0x1fffffffffffffff},
+						},
+					},
+				},
+			},
+		},
+		{
+			Type: schemapb.DataType_Float,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_FloatData{
+						FloatData: &schemapb.FloatArray{
+							Data: []float32{0, 0, 0},
+						},
+					},
+				},
+			},
+		},
+		{
+			Type: schemapb.DataType_Double,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_DoubleData{
+						DoubleData: &schemapb.DoubleArray{
+							Data: []float64{0, 0, 0},
+						},
+					},
+				},
+			},
+		},
+		{
+			Type: schemapb.DataType_FloatVector,
+			Field: &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Dim: 1,
+					Data: &schemapb.VectorField_FloatVector{
+						FloatVector: &schemapb.FloatArray{
+							Data: []float32{0, 0, 0},
+						},
+					},
+				},
+			},
+		},
+		{
+			Type: schemapb.DataType_BinaryVector,
+			Field: &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Dim: 8,
+					Data: &schemapb.VectorField_BinaryVector{
+						BinaryVector: []byte{1, 2, 3},
+					},
+				},
+			},
+		},
+	}
+	for i := range columns {
+		assert.Equal(t, columns[i].Type, _columns[i].Type)
+
+	}
+	assert.Equal(
+		t,
+		columns[0].Field.(*schemapb.FieldData_Scalars).Scalars.Data.(*schemapb.ScalarField_BoolData).BoolData.Data,
+		_columns[0].Field.(*schemapb.FieldData_Scalars).Scalars.Data.(*schemapb.ScalarField_BoolData).BoolData.Data,
+	)
+	assert.Equal(
+		t,
+		columns[5].Field.(*schemapb.FieldData_Vectors).Vectors.Data.(*schemapb.VectorField_FloatVector).FloatVector.Data,
+		_columns[5].Field.(*schemapb.FieldData_Vectors).Vectors.Data.(*schemapb.VectorField_FloatVector).FloatVector.Data,
+	)
+	assert.Equal(
+		t,
+		columns[6].Field.(*schemapb.FieldData_Vectors).Vectors.Data.(*schemapb.VectorField_BinaryVector).BinaryVector,
+		_columns[6].Field.(*schemapb.FieldData_Vectors).Vectors.Data.(*schemapb.VectorField_BinaryVector).BinaryVector,
+	)
+}
 
 func TestTransferColumnBasedDataToRowBasedData(t *testing.T) {
 	fieldSchema := []*schemapb.FieldSchema{
@@ -211,50 +424,185 @@ func TestTransferColumnBasedDataToRowBasedData(t *testing.T) {
 	rows, err := TransferColumnBasedDataToRowBasedData(&schemapb.CollectionSchema{Fields: fieldSchema}, columns)
 	assert.NoError(t, err)
 	assert.Equal(t, 3, len(rows))
-	if common.Endian == binary.LittleEndian {
-		// low byte in high address
 
-		assert.ElementsMatch(t,
-			[]byte{
-				1,    // true
-				0,    // 0
-				0, 0, // 0
-				0, 0, 0, 0, // 0
-				0, 0, 0, 0, 0, 0, 0, 0, // 0
-				0, 0, 0, 0, // 0
-				0, 0, 0, 0, 0, 0, 0, 0, // 0
-				// b + 1, // "1"
-				1,          // 1
-				0, 0, 0, 0, // 0
+	// low byte in high address
+
+	assert.Equal(t,
+		[]byte{
+			1,    // true
+			0,    // 0
+			0, 0, // 0
+			0, 0, 0, 0, // 0
+			0, 0, 0, 0, 0, 0, 0, 0, // 0
+			0, 0, 0, 0, // 0
+			0, 0, 0, 0, 0, 0, 0, 0, // 0
+			// b + 1, // "1"
+			0, 0, 0, 0, // 0
+			1, // 1
+		},
+		rows[0].Value)
+	assert.Equal(t,
+		[]byte{
+			0,       // false
+			0xf,     // 0xf
+			0xff, 0, // 0xff
+			0xff, 0xff, 0, 0, // 0xffff
+			0xff, 0xff, 0xff, 0xff, 0, 0, 0, 0, // 0xffffffff
+			0, 0, 0, 0, // 0
+			0, 0, 0, 0, 0, 0, 0, 0, // 0
+			// b + 2, // "2"
+			0, 0, 0, 0, // 0
+			2, // 2
+		},
+		rows[1].Value)
+	assert.Equal(t,
+		[]byte{
+			1,          // false
+			0x1f,       // 0x1f
+			0xff, 0x1f, // 0x1fff
+			0xff, 0xff, 0xff, 0x1f, // 0x1fffffff
+			0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x1f, // 0x1fffffffffffffff
+			0, 0, 0, 0, // 0
+			0, 0, 0, 0, 0, 0, 0, 0, // 0
+			// b + 3, // "3"
+			0, 0, 0, 0, // 0
+			3, // 3
+		},
+		rows[2].Value)
+
+}
+
+func TestTransferColumnBasedDataToByteSlice(t *testing.T) {
+	schema := &schemapb.CollectionSchema{
+		Name:   "test",
+		AutoID: false,
+		Fields: []*schemapb.FieldSchema{
+			{
+				FieldID: 100,
 			},
-			rows[0].Value)
-		assert.ElementsMatch(t,
-			[]byte{
-				0,       // false
-				0xf,     // 0xf
-				0, 0xff, // 0xff
-				0, 0, 0xff, 0xff, // 0xffff
-				0, 0, 0, 0, 0xff, 0xff, 0xff, 0xff, // 0xffffffff
-				0, 0, 0, 0, // 0
-				0, 0, 0, 0, 0, 0, 0, 0, // 0
-				// b + 2, // "2"
-				2,          // 2
-				0, 0, 0, 0, // 0
+			{
+				FieldID: 103,
 			},
-			rows[1].Value)
-		assert.ElementsMatch(t,
-			[]byte{
-				1,          // false
-				0x1f,       // 0x1f
-				0xff, 0x1f, // 0x1fff
-				0xff, 0xff, 0xff, 0x1f, // 0x1fffffff
-				0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x1f, // 0x1fffffffffffffff
-				0, 0, 0, 0, // 0
-				0, 0, 0, 0, 0, 0, 0, 0, // 0
-				// b + 3, // "3"
-				3,          // 3
-				0, 0, 0, 0, // 0
+			{
+				FieldID: 104,
 			},
-			rows[2].Value)
+			{
+				FieldID: 105,
+			},
+			{
+				FieldID: 106,
+			},
+			{
+				FieldID: 107,
+			},
+			{
+				FieldID: 108,
+			},
+		},
 	}
+	columns := []*schemapb.FieldData{
+		{
+			FieldId: 100,
+			Type:    schemapb.DataType_Bool,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_BoolData{
+						BoolData: &schemapb.BoolArray{
+							Data: []bool{true, false, true},
+						},
+					},
+				},
+			},
+		},
+		{
+			FieldId: 103,
+			Type:    schemapb.DataType_Int32,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_IntData{
+						IntData: &schemapb.IntArray{
+							Data: []int32{0, 0xffff, 0x1fffffff},
+						},
+					},
+				},
+			},
+		},
+		{
+			FieldId: 104,
+			Type:    schemapb.DataType_Int64,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_LongData{
+						LongData: &schemapb.LongArray{
+							Data: []int64{0, 0xffffffff, 0x1fffffffffffffff},
+						},
+					},
+				},
+			},
+		},
+		{
+			FieldId: 105,
+			Type:    schemapb.DataType_Float,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_FloatData{
+						FloatData: &schemapb.FloatArray{
+							Data: []float32{0, 0, 0},
+						},
+					},
+				},
+			},
+		},
+		{
+			FieldId: 106,
+			Type:    schemapb.DataType_Double,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_DoubleData{
+						DoubleData: &schemapb.DoubleArray{
+							Data: []float64{0, 0, 0},
+						},
+					},
+				},
+			},
+		},
+		{
+			FieldId: 107,
+			Type:    schemapb.DataType_FloatVector,
+			Field: &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Dim: 1,
+					Data: &schemapb.VectorField_FloatVector{
+						FloatVector: &schemapb.FloatArray{
+							Data: []float32{0, 0, 0},
+						},
+					},
+				},
+			},
+		},
+		{
+			FieldId: 108,
+			Type:    schemapb.DataType_BinaryVector,
+			Field: &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Dim: 8,
+					Data: &schemapb.VectorField_BinaryVector{
+						BinaryVector: []byte{1, 2, 3},
+					},
+				},
+			},
+		},
+	}
+	data, err := TransferColumnBasedDataToByteSlice(schema, columns)
+	assert.NoError(t, err)
+	expected := []byte{
+		1, 0, 1,
+		0, 0, 0, 0, 0xff, 0xff, 0, 0, 0xff, 0xff, 0xff, 0x1f,
+		0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 0xff, 0xff, 0, 0, 0, 0, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x1f,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		1, 2, 3,
+	}
+	assert.Equal(t, expected, data)
 }


### PR DESCRIPTION
Related to issue #16085

Signed-off-by: Letian Jiang [letian.jiang@zilliz.com](mailto:letian.jiang@zilliz.com)

* Call segcore.InsertColumnData in flowgraph
* Add `TransferRowBasedDataToColumnBasedData` to ensure compatibility
* Fix unit test error 