### PR TITLE
[skip e2e]Add url for issue also

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -121,7 +121,9 @@ pull_request_rules:
       - or:
         - base=master
         - base~=^2(\.\d+){2}$
-      - -body~=\#[0-9]{1,6}(\s+|$)
+      - or:
+        - body~=\#[0-9]{1,6}(\s+|$)
+        - body~=https://github.com/milvus-io/milvus/issues/[0-9]{1,6}(\s+|$)
       - -label=kind/improvement
       - -title~=\[automated\]
     actions:
@@ -140,7 +142,9 @@ pull_request_rules:
           - or:
             - base=master
             - base~=^2(\.\d+){2}$
-          - body~=\#[0-9]{1,6}(\s+|$)
+          - or:
+            - body~=\#[0-9]{1,6}(\s+|$)
+            - body~=https://github.com/milvus-io/milvus/issues/[0-9]{1,6}(\s+|$)
         - and:
           - base=master
           - label=kind/improvement


### PR DESCRIPTION
Signed-off-by: Jenny Li <jing.li@zilliz.com>

/kind improvement

Developers are confused with label `do-not-merge/missing-related-issue` with issue url like ![mbmLEXhZkK](https://user-images.githubusercontent.com/93511422/160328555-91aa1b82-e850-4c75-aef0-93fdccbdd644.png) for multiple times(more than 3), so  add issue link for checking, also.