### PR TITLE
Revert ExecTermExpr unordered_set to binary_search

### DIFF
--- a/internal/core/src/query/ExprImpl.h
+++ b/internal/core/src/query/ExprImpl.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <tuple>
 #include <vector>
 #include <boost/container/vector.hpp>
@@ -26,10 +27,11 @@ namespace milvus::query {
 
 template <typename T>
 struct TermExprImpl : TermExpr {
-    const std::vector<T> terms_;
+    std::vector<T> terms_;
 
     TermExprImpl(const FieldOffset field_offset, const DataType data_type, const std::vector<T>& terms)
         : TermExpr(field_offset, data_type), terms_(terms) {
+        std::sort(terms_.begin(), terms_.end());
     }
 };
 


### PR DESCRIPTION
Since unordered_set will do a hash for each id in the large group set
This change might cause performance degrade when querying by ids
Change back to binary_search first

Might related to #16196

/kind improvement
/cc @cydrain 

Signed-off-by: Congqi Xia <congqi.xia@zilliz.com>