### PR TITLE
Use fmt.Errorf instead of str concat in func.go

### DIFF
--- a/internal/util/funcutil/func.go
+++ b/internal/util/funcutil/func.go
@@ -172,7 +172,7 @@ func GetAttrByKeyFromRepeatedKV(key string, kvs []*commonpb.KeyValuePair) (strin
 		}
 	}
 
-	return "", errors.New("key " + key + " not found")
+	return "", fmt.Errorf("key %s not found", key)
 }
 
 // CheckCtxValid check if the context is valid


### PR DESCRIPTION
Refine the error msg conposing logic according to the log standard

/kind improvement

Signed-off-by: Congqi Xia <congqi.xia@zilliz.com>