### PR TITLE
Fix Datacoord unsubAttempt using pchannel (#16337)

### DIFF
--- a/internal/datacoord/channel_manager.go
+++ b/internal/datacoord/channel_manager.go
@@ -26,6 +26,7 @@ import (
 	"github.com/milvus-io/milvus/internal/log"
 	"github.com/milvus-io/milvus/internal/msgstream"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
+	"github.com/milvus-io/milvus/internal/util/funcutil"
 	"github.com/milvus-io/milvus/internal/util/logutil"
 
 	v3rpc "go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
@@ -363,7 +364,9 @@ func (c *ChannelManager) unsubscribe(subName string, channel string) error {
 		return err
 	}
 
-	msgStream.AsConsumer([]string{channel}, subName)
+	pchannelName := funcutil.ToPhysicalChannel(channel)
+
+	msgStream.AsConsumer([]string{pchannelName}, subName)
 	msgStream.Close()
 	return nil
 }


### PR DESCRIPTION
Fix the channel name used when Datacoord unsub for DataNode
This channel shall always be pChannel instead of vChannel

See also #16334 

Signed-off-by: Congqi Xia <congqi.xia@zilliz.com>