### PR TITLE
Remove offLineNodes from watch states check

### DIFF
--- a/internal/datacoord/channel_checker.go
+++ b/internal/datacoord/channel_checker.go
@@ -101,14 +101,16 @@ func (c *channelStateTimer) startOne(watchState datapb.ChannelWatchState, channe
 		select {
 		case <-time.NewTimer(time.Until(timeoutT)).C:
 			log.Info("timeout and stop timer: wait for channel ACK timeout",
-				zap.String("state", watchState.String()),
+				zap.String("watch state", watchState.String()),
+				zap.Int64("nodeID", nodeID),
 				zap.String("channel name", channelName),
 				zap.Time("timeout time", timeoutT))
 			ackType := getAckType(watchState)
 			c.notifyTimeoutWatcher(&ackEvent{ackType, channelName, nodeID})
 		case <-stop:
 			log.Debug("stop timer before timeout",
-				zap.String("state", watchState.String()),
+				zap.String("watch state", watchState.String()),
+				zap.Int64("nodeID", nodeID),
 				zap.String("channel name", channelName),
 				zap.Time("timeout time", timeoutT))
 		}

--- a/internal/datacoord/channel_manager_test.go
+++ b/internal/datacoord/channel_manager_test.go
@@ -788,3 +788,31 @@ func TestChannelManager_RemoveChannel(t *testing.T) {
 		})
 	}
 }
+
+func TestChannelManager_HelperFunc(t *testing.T) {
+	c := &ChannelManager{}
+	t.Run("test getOldOnlines", func(t *testing.T) {
+		tests := []struct {
+			nodes  []int64
+			oNodes []int64
+
+			expectedOut []int64
+			desription  string
+		}{
+			{[]int64{}, []int64{}, []int64{}, "empty both"},
+			{[]int64{1}, []int64{}, []int64{}, "empty oNodes"},
+			{[]int64{}, []int64{1}, []int64{}, "empty nodes"},
+			{[]int64{1}, []int64{1}, []int64{1}, "same one"},
+			{[]int64{1, 2}, []int64{1}, []int64{1}, "same one 2"},
+			{[]int64{1}, []int64{1, 2}, []int64{1}, "same one 3"},
+			{[]int64{1, 2}, []int64{1, 2}, []int64{1, 2}, "same two"},
+		}
+
+		for _, test := range tests {
+			t.Run(test.desription, func(t *testing.T) {
+				nodes := c.getOldOnlines(test.nodes, test.oNodes)
+				assert.ElementsMatch(t, test.expectedOut, nodes)
+			})
+		}
+	})
+}

--- a/internal/util/sessionutil/session_util.go
+++ b/internal/util/sessionutil/session_util.go
@@ -117,6 +117,11 @@ func (s *Session) Init(serverName, address string, exclusive bool, triggerKill b
 	s.ServerID = serverID
 }
 
+// String makes Session struct able to be logged by zap
+func (s *Session) String() string {
+	return fmt.Sprintf("Session:<ServerID: %d, ServerName: %s>", s.ServerID, s.ServerName)
+}
+
 // Register will process keepAliveResponse to keep alive with etcd.
 func (s *Session) Register() {
 	ch, err := s.registerService()

--- a/internal/util/sessionutil/session_util_test.go
+++ b/internal/util/sessionutil/session_util_test.go
@@ -12,10 +12,12 @@ import (
 	"time"
 
 	etcdkv "github.com/milvus-io/milvus/internal/kv/etcd"
+	"github.com/milvus-io/milvus/internal/log"
 	"github.com/milvus-io/milvus/internal/util/etcd"
 	"github.com/milvus-io/milvus/internal/util/paramtable"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 
 	"go.etcd.io/etcd/api/v3/mvccpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -398,4 +400,9 @@ func TestSession_Registered(t *testing.T) {
 	assert.False(t, session.Registered())
 	session.UpdateRegistered(true)
 	assert.True(t, session.Registered())
+}
+
+func TestSession_String(t *testing.T) {
+	s := &Session{}
+	log.Debug("log session", zap.Any("session", s))
 }


### PR DESCRIPTION
This PR also
- add more information in log
- make Session able to logged by zap.Any/zap.String

Signed-off-by: yangxuan <xuan.yang@zilliz.com>

/kind bug
issue: #16114 