### PR TITLE
Fix QueryCollection retrieve unit test

### DIFF
--- a/internal/querynode/mock_test.go
+++ b/internal/querynode/mock_test.go
@@ -1459,8 +1459,8 @@ func genSimpleRetrievePlanExpr() ([]byte, error) {
 				Expr: &planpb.Expr_TermExpr{
 					TermExpr: &planpb.TermExpr{
 						ColumnInfo: &planpb.ColumnInfo{
-							FieldId:  simpleConstField.id,
-							DataType: simpleConstField.dataType,
+							FieldId:  simplePKField.id,
+							DataType: simplePKField.dataType,
 						},
 						Values: []*planpb.GenericValue{
 							{
@@ -1483,7 +1483,7 @@ func genSimpleRetrievePlanExpr() ([]byte, error) {
 				},
 			},
 		},
-		OutputFieldIds: []int64{simpleConstField.id},
+		OutputFieldIds: []int64{simplePKField.id},
 	}
 	planExpr, err := proto.Marshal(planNode)
 	return planExpr, err

--- a/internal/querynode/query_collection.go
+++ b/internal/querynode/query_collection.go
@@ -1333,6 +1333,7 @@ func (q *queryCollection) retrieve(msg queryMsg) error {
 	if err != nil {
 		return err
 	}
+	log.Debug("retrieve result", zap.String("ids", result.Ids.String()))
 	reduceDuration := tr.Record(fmt.Sprintf("merge result done, msgID = %d", retrieveMsg.ID()))
 	metrics.QueryNodeReduceLatency.WithLabelValues(fmt.Sprint(Params.QueryNodeCfg.QueryNodeID), metrics.QueryLabel).Observe(float64(reduceDuration.Milliseconds()))
 

--- a/internal/querynode/query_collection_test.go
+++ b/internal/querynode/query_collection_test.go
@@ -656,7 +656,7 @@ func TestQueryCollection_search(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestQueryCollection_receive(t *testing.T) {
+func TestQueryCollection_retrieve(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	queryCollection, err := genSimpleQueryCollection(ctx, cancel)
@@ -676,12 +676,6 @@ func TestQueryCollection_receive(t *testing.T) {
 	assert.NoError(t, err)
 
 	queryCollection.vectorChunkManager = vecCM
-
-	err = queryCollection.streaming.replica.removeSegment(defaultSegmentID)
-	assert.NoError(t, err)
-
-	err = queryCollection.historical.replica.removeSegment(defaultSegmentID)
-	assert.NoError(t, err)
 
 	msg, err := genSimpleRetrieveMsg()
 	assert.NoError(t, err)


### PR DESCRIPTION
Resolves #16375

The query collection now retrieves rows in the segment.
```
[2022/04/04 09:26:16.881 +08:00] [DEBUG] [query_collection.go:1417] ["skip duplicated query result"] [count=0]
[2022/04/04 09:26:16.881 +08:00] [DEBUG] [query_collection.go:1336] ["retrieve result"] [ids="int_id:<data:1 data:2 data:3 > "]
[2022/04/04 09:26:16.881 +08:00] [DEBUG] [time_recorder.go:78] ["retrieve 0: merge result done, msgID = 1560331235926702661 (0ms)"]
[2022/04/04 09:26:16.881 +08:00] [DEBUG] [proxy_session_manager.go:126] ["success to send retrieve result"] [node=0] [base="msg_type:RetrieveResult msgID:1560331235926702661 "]
[2022/04/04 09:26:16.881 +08:00] [DEBUG] [query_collection.go:1366] ["QueryNode publish RetrieveResultMsg"] [msgID=1560331235926702661] [vChannels="[query-node-unittest-DML-0]"] [collectionID=0] [sealedSegmentRetrieved="[2]"]
[2022/04/04 09:26:16.881 +08:00] [DEBUG] [time_recorder.go:78] ["retrieve 0: all done, msgID = 1560331235926702661 (0ms)"]
--- PASS: TestQueryCollection_retrieve (0.02s)
PASS
```

Signed-off-by: Letian Jiang <letian.jiang@zilliz.com>