### PR TITLE
Hide ID cache timeout settings from users.

### DIFF
--- a/configs/embedded-milvus.yaml
+++ b/configs/embedded-milvus.yaml
@@ -94,8 +94,6 @@ proxy:
   maxDimension: 32768 # Maximum dimension of a vector
   maxShardNum: 256 # Maximum number of shards in a collection
   maxTaskNum: 1024 # max task number of proxy task queue
-  bufFlagExpireTime: 300 # second, the time to expire bufFlag from cache in collectResultLoop. Default 300.
-  bufFlagCleanupInterval: 600 # second, the interval to clean bufFlag cache in collectResultLoop. Default 600.
   ginLogging: false # Whether to produce gin logs.
 
 

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -113,8 +113,6 @@ proxy:
   maxDimension: 32768 # Maximum dimension of a vector
   maxShardNum: 256 # Maximum number of shards in a collection
   maxTaskNum: 1024 # max task number of proxy task queue
-  bufFlagExpireTime: 3600 # second, the time to expire bufFlag from cache in collectResultLoop
-  bufFlagCleanupInterval: 600 # second, the interval to clean bufFlag cache in collectResultLoop
   ginLogging: true # Whether to produce gin logs.
 
 

--- a/internal/util/paramtable/component_param.go
+++ b/internal/util/paramtable/component_param.go
@@ -465,7 +465,7 @@ func (p *proxyConfig) initMaxTaskNum() {
 }
 
 func (p *proxyConfig) initBufFlagExpireTime() {
-	expireTime := p.Base.ParseInt64WithDefault("proxy.bufFlagExpireTime", 3600)
+	expireTime := p.Base.ParseInt64WithDefault("proxy.bufFlagExpireTime", 300)
 	p.BufFlagExpireTime = time.Duration(expireTime) * time.Second
 }
 


### PR DESCRIPTION
 Also change default expire time from 60 min to 5 min.

/kind improvement

issue: 15593

Signed-off-by: Yuchen Gao <yuchen.gao@zilliz.com>