### PR TITLE
create default root user for authentication (#16545)

### DIFF
--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -23,6 +23,8 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/milvus-io/milvus/internal/util"
+
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/internal/common"
@@ -4165,6 +4167,12 @@ func (node *Proxy) UpdateCredential(ctx context.Context, req *milvuspb.UpdateCre
 
 func (node *Proxy) DeleteCredential(ctx context.Context, req *milvuspb.DeleteCredentialRequest) (*commonpb.Status, error) {
 	log.Debug("DeleteCredential", zap.String("role", typeutil.RootCoordRole), zap.String("username", req.Username))
+	if req.Username == util.UserRoot {
+		return &commonpb.Status{
+			ErrorCode: commonpb.ErrorCode_DeleteCredentialFailure,
+			Reason:    "user root cannot be deleted",
+		}, nil
+	}
 	result, err := node.rootCoord.DeleteCredential(ctx, req)
 	if err != nil { // for error like conntext timeout etc.
 		log.Error("delete credential fail", zap.String("username", req.Username), zap.Error(err))

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1971,7 +1971,7 @@ func TestProxy(t *testing.T) {
 	})
 
 	username := "test_username_" + funcutil.RandomString(15)
-	password := "xxx"
+	password := "password"
 
 	wg.Add(1)
 	t.Run("credential CREATE api", func(t *testing.T) {
@@ -2020,7 +2020,7 @@ func TestProxy(t *testing.T) {
 		defer wg.Done()
 
 		// 2. update credential
-		newPassword := "yyy"
+		newPassword := "new_password"
 		constructUpdateCredentialRequest := func() *milvuspb.UpdateCredentialRequest {
 			return &milvuspb.UpdateCredentialRequest{
 				Base:        nil,
@@ -2076,7 +2076,7 @@ func TestProxy(t *testing.T) {
 		defer wg.Done()
 
 		// 3. get credential
-		newPassword := "yyy"
+		newPassword := "new_password"
 		constructGetCredentialRequest := func() *rootcoordpb.GetCredentialRequest {
 			return &rootcoordpb.GetCredentialRequest{
 				Base:     nil,
@@ -2898,6 +2898,14 @@ func TestProxy(t *testing.T) {
 	t.Run("UpdateCredential fail, timeout", func(t *testing.T) {
 		defer wg.Done()
 		resp, err := proxy.UpdateCredential(shortCtx, &milvuspb.UpdateCredentialRequest{Username: "xxx"})
+		assert.NoError(t, err)
+		assert.NotEqual(t, commonpb.ErrorCode_Success, resp.ErrorCode)
+	})
+
+	wg.Add(1)
+	t.Run("DeleteCredential fail, user root cannot be deleted", func(t *testing.T) {
+		defer wg.Done()
+		resp, err := proxy.DeleteCredential(shortCtx, &milvuspb.DeleteCredentialRequest{Username: "root"})
 		assert.NoError(t, err)
 		assert.NotEqual(t, commonpb.ErrorCode_Success, resp.ErrorCode)
 	})

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -520,9 +520,9 @@ func ValidateUsername(username string) error {
 }
 
 func ValidatePassword(password string) error {
-	if int64(len(password)) > Params.ProxyCfg.MaxPasswordLength {
-		msg := "The length of password must be less than " +
-			strconv.FormatInt(Params.ProxyCfg.MaxPasswordLength, 10) + " characters."
+	if int64(len(password)) < Params.ProxyCfg.MinPasswordLength || int64(len(password)) > Params.ProxyCfg.MaxPasswordLength {
+		msg := "The length of password must be great than " + strconv.FormatInt(Params.ProxyCfg.MinPasswordLength, 10) +
+			" and less than " + strconv.FormatInt(Params.ProxyCfg.MaxPasswordLength, 10) + " characters."
 		return errors.New(msg)
 	}
 	return nil

--- a/internal/proxy/util_test.go
+++ b/internal/proxy/util_test.go
@@ -550,11 +550,11 @@ func TestValidateUsername(t *testing.T) {
 func TestValidatePassword(t *testing.T) {
 	Params.InitOnce()
 	// only spaces
-	res := ValidatePassword(" ")
-	assert.Nil(t, res)
+	res := ValidatePassword("")
+	assert.NotNil(t, res)
 	//
 	res = ValidatePassword("1abc")
-	assert.Nil(t, res)
+	assert.NotNil(t, res)
 	//
 	res = ValidatePassword("a1^7*).,")
 	assert.Nil(t, res)

--- a/internal/rootcoord/root_coord.go
+++ b/internal/rootcoord/root_coord.go
@@ -29,6 +29,9 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/milvus-io/milvus/internal/util"
+	"github.com/milvus-io/milvus/internal/util/crypto"
+
 	"github.com/milvus-io/milvus/internal/util/dependency"
 
 	"github.com/golang/protobuf/proto"
@@ -1119,6 +1122,13 @@ func (c *Core) Init() error {
 			c.impTaskKv,
 			c.CallImportService,
 		)
+		// init data
+		encryptedRootPassword, _ := crypto.PasswordEncrypt(util.DefaultRootPassword)
+		initError = c.MetaTable.AddCredential(&internalpb.CredentialInfo{Username: util.UserRoot, EncryptedPassword: encryptedRootPassword})
+		if initError != nil {
+			return
+		}
+		log.Debug("RootCoord init user root done")
 	})
 	if initError != nil {
 		log.Debug("RootCoord init error", zap.Error(initError))

--- a/internal/util/constant.go
+++ b/internal/util/constant.go
@@ -26,4 +26,6 @@ const (
 	// MemberCredID id for Milvus members (data/index/query node/coord component)
 	MemberCredID        = "@@milvus-member@@"
 	CredentialSeperator = ":"
+	UserRoot            = "root"
+	DefaultRootPassword = "Milvus"
 )

--- a/internal/util/paramtable/component_param.go
+++ b/internal/util/paramtable/component_param.go
@@ -408,6 +408,7 @@ type proxyConfig struct {
 	MsgStreamTimeTickBufSize int64
 	MaxNameLength            int64
 	MaxUsernameLength        int64
+	MinPasswordLength        int64
 	MaxPasswordLength        int64
 	MaxFieldNum              int64
 	MaxShardNum              int32
@@ -433,6 +434,7 @@ func (p *proxyConfig) init(base *BaseTable) {
 
 	p.initMsgStreamTimeTickBufSize()
 	p.initMaxNameLength()
+	p.initMinPasswordLength()
 	p.initMaxUsernameLength()
 	p.initMaxPasswordLength()
 	p.initMaxFieldNum()
@@ -475,6 +477,15 @@ func (p *proxyConfig) initMaxUsernameLength() {
 		panic(err)
 	}
 	p.MaxUsernameLength = maxUsernameLength
+}
+
+func (p *proxyConfig) initMinPasswordLength() {
+	str := p.Base.LoadWithDefault("proxy.minPasswordLength", "6")
+	minPasswordLength, err := strconv.ParseInt(str, 10, 64)
+	if err != nil {
+		panic(err)
+	}
+	p.MinPasswordLength = minPasswordLength
 }
 
 func (p *proxyConfig) initMaxPasswordLength() {

--- a/internal/util/paramtable/component_param_test.go
+++ b/internal/util/paramtable/component_param_test.go
@@ -157,6 +157,21 @@ func TestComponentParam(t *testing.T) {
 			Params.initMaxNameLength()
 		})
 
+		shouldPanic(t, "proxy.maxUsernameLength", func() {
+			Params.Base.Save("proxy.maxUsernameLength", "abc")
+			Params.initMaxUsernameLength()
+		})
+
+		shouldPanic(t, "proxy.minPasswordLength", func() {
+			Params.Base.Save("proxy.minPasswordLength", "abc")
+			Params.initMinPasswordLength()
+		})
+
+		shouldPanic(t, "proxy.maxPasswordLength", func() {
+			Params.Base.Save("proxy.maxPasswordLength", "abc")
+			Params.initMaxPasswordLength()
+		})
+
 		shouldPanic(t, "proxy.maxFieldNum", func() {
 			Params.Base.Save("proxy.maxFieldNum", "abc")
 			Params.initMaxFieldNum()


### PR DESCRIPTION
Signed-off-by: kejiang <ke.jiang@zilliz.com>

issue: https://github.com/milvus-io/milvus/issues/16545

ADD: create default root user when start up and cannot be deleted
ADD: password's length cannot less than 6 characters