### PR TITLE
Remove debug log in querynode segment/node detector

### DIFF
--- a/internal/querynode/shard_node_detector.go
+++ b/internal/querynode/shard_node_detector.go
@@ -265,8 +265,5 @@ func (nd *etcdShardNodeDetector) handleDelEvent(e *clientv3.Event, collectionID,
 func (nd *etcdShardNodeDetector) parseReplicaInfo(bs []byte) (*milvuspb.ReplicaInfo, error) {
 	info := &milvuspb.ReplicaInfo{}
 	err := proto.Unmarshal(bs, info)
-	if err == nil {
-		log.Debug("ReplicaInfo", zap.Any("info", info))
-	}
 	return info, err
 }

--- a/internal/querynode/shard_segment_detector.go
+++ b/internal/querynode/shard_segment_detector.go
@@ -193,9 +193,6 @@ func (sd *etcdShardSegmentDetector) handleDelEvent(e *clientv3.Event, collection
 func (sd *etcdShardSegmentDetector) parseSegmentInfo(bs []byte) (*querypb.SegmentInfo, error) {
 	info := &querypb.SegmentInfo{}
 	err := proto.Unmarshal(bs, info)
-	if err == nil {
-		log.Debug("segment info", zap.Any("segmentInfo", info))
-	}
 	return info, err
 }
 


### PR DESCRIPTION
Remove redundant debug log in `ShardNodeDetector` and `ShardSegmentDetector`

/kind improvement

Signed-off-by: Congqi Xia <congqi.xia@zilliz.com>