### PR TITLE
Add segment reference count and handles change info in ShardCluster

### DIFF
--- a/internal/querynode/query_channel_test.go
+++ b/internal/querynode/query_channel_test.go
@@ -97,13 +97,7 @@ func TestQueryChannel_AsConsumer(t *testing.T) {
 		mqs := &mockQueryMsgStream{}
 		mqs.On("Close").Return()
 
-		qc := &queryChannel{
-			closeCh:      make(chan struct{}),
-			collectionID: defaultCollectionID,
-
-			streaming:      nil,
-			queryMsgStream: mqs,
-		}
+		qc := NewQueryChannel(defaultCollectionID, nil, mqs, nil)
 
 		mqs.On("AsConsumer", []string{defaultDMLChannel}, defaultSubName).Return()
 
@@ -122,13 +116,7 @@ func TestQueryChannel_AsConsumer(t *testing.T) {
 		mqs := &mockQueryMsgStream{}
 		mqs.On("Close").Return()
 
-		qc := &queryChannel{
-			closeCh:      make(chan struct{}),
-			collectionID: defaultCollectionID,
-
-			streaming:      nil,
-			queryMsgStream: mqs,
-		}
+		qc := NewQueryChannel(defaultCollectionID, nil, mqs, nil)
 
 		mqs.On("AsConsumer", []string{defaultDMLChannel}, defaultSubName).Return()
 
@@ -146,13 +134,8 @@ func TestQueryChannel_AsConsumer(t *testing.T) {
 		mqs := &mockQueryMsgStream{}
 		mqs.On("Close").Return()
 
-		qc := &queryChannel{
-			closeCh:      make(chan struct{}),
-			collectionID: defaultCollectionID,
+		qc := NewQueryChannel(defaultCollectionID, nil, mqs, nil)
 
-			streaming:      nil,
-			queryMsgStream: mqs,
-		}
 		msgID := make([]byte, 8)
 		rand.Read(msgID)
 		pos := &internalpb.MsgPosition{MsgID: msgID}

--- a/internal/querynode/query_shard_service.go
+++ b/internal/querynode/query_shard_service.go
@@ -138,12 +138,7 @@ func (q *queryShardService) getQueryChannel(collectionID int64) *queryChannel {
 	qc, ok := q.queryChannels[collectionID]
 	if !ok {
 		queryStream, _ := q.factory.NewQueryMsgStream(q.ctx)
-		qc = &queryChannel{
-			closeCh:        make(chan struct{}),
-			collectionID:   collectionID,
-			queryMsgStream: queryStream,
-			streaming:      q.streaming,
-		}
+		qc = NewQueryChannel(collectionID, q.shardClusterService, queryStream, q.streaming)
 		q.queryChannels[collectionID] = qc
 	}
 

--- a/internal/querynode/shard_cluster_service.go
+++ b/internal/querynode/shard_cluster_service.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	grpcquerynodeclient "github.com/milvus-io/milvus/internal/distributed/querynode/client"
+	"github.com/milvus-io/milvus/internal/proto/querypb"
 	"github.com/milvus-io/milvus/internal/util"
 	"github.com/milvus-io/milvus/internal/util/sessionutil"
 	"github.com/milvus-io/milvus/internal/util/typeutil"
@@ -106,4 +107,21 @@ func (s *ShardClusterService) releaseCollection(collectionID int64) {
 		}
 		return true
 	})
+}
+
+// HandoffSegments dispatch segmentChangeInfo to related shardClusters
+func (s *ShardClusterService) HandoffSegments(collectionID int64, info *querypb.SegmentChangeInfo) {
+	var wg sync.WaitGroup
+	s.clusters.Range(func(k, v interface{}) bool {
+		cs := v.(*ShardCluster)
+		if cs.collectionID == collectionID {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				cs.HandoffSegments(info)
+			}()
+		}
+		return true
+	})
+	wg.Wait()
 }


### PR DESCRIPTION
Resolves #16619
Add reference count for each search/query request
For SegmentChangeInfo
- Wait all segments in OnlineList to be loaded
- Add handoff event into pending list
- Wait all segments in OfflineList is not used (reference count = 0)

/kind enhancement

Signed-off-by: Congqi Xia <congqi.xia@zilliz.com>