### PR TITLE
Fix an issue where query coord calls MinioChunkManager during init

### DIFF
--- a/internal/querycoord/query_coord.go
+++ b/internal/querycoord/query_coord.go
@@ -190,13 +190,7 @@ func (qc *QueryCoord) Init() error {
 		// we only try best to reload the leader addresses
 		reloadShardLeaderAddress(qc.meta, qc.cluster)
 
-		qc.chunkManager, initError = storage.NewMinioChunkManager(qc.loopCtx,
-			storage.Address(Params.MinioCfg.Address),
-			storage.AccessKeyID(Params.MinioCfg.AccessKeyID),
-			storage.SecretAccessKeyID(Params.MinioCfg.SecretAccessKey),
-			storage.UseSSL(Params.MinioCfg.UseSSL),
-			storage.BucketName(Params.MinioCfg.BucketName),
-			storage.CreateBucket(true))
+		qc.chunkManager, initError = qc.factory.NewVectorStorageChunkManager(qc.loopCtx)
 
 		if initError != nil {
 			log.Error("query coordinator init cluster failed", zap.Error(initError))

--- a/internal/querynode/query_shard_service.go
+++ b/internal/querynode/query_shard_service.go
@@ -55,14 +55,7 @@ func newQueryShardService(ctx context.Context, historical *historical, streaming
 	enabled, _ := Params.Load("localStorage.enabled")
 	localCacheEnabled, _ := strconv.ParseBool(enabled)
 	localChunkManager := storage.NewLocalChunkManager(storage.RootPath(path))
-	remoteChunkManager, _ := storage.NewMinioChunkManager(
-		ctx,
-		storage.Address(Params.MinioCfg.Address),
-		storage.AccessKeyID(Params.MinioCfg.AccessKeyID),
-		storage.SecretAccessKeyID(Params.MinioCfg.SecretAccessKey),
-		storage.UseSSL(Params.MinioCfg.UseSSL),
-		storage.BucketName(Params.MinioCfg.BucketName),
-		storage.CreateBucket(true))
+	remoteChunkManager, _ := factory.NewVectorStorageChunkManager(ctx)
 
 	qss := &queryShardService{
 		ctx:                 queryShardServiceCtx,

--- a/internal/storage/minio_chunk_manager.go
+++ b/internal/storage/minio_chunk_manager.go
@@ -45,6 +45,7 @@ type MinioChunkManager struct {
 var _ ChunkManager = (*MinioChunkManager)(nil)
 
 // NewMinioChunkManager create a new local manager object.
+// Deprecated: Do not call this directly! Use factory.NewVectorStorageChunkManager instead.
 func NewMinioChunkManager(ctx context.Context, opts ...Option) (*MinioChunkManager, error) {
 	c := newDefaultConfig()
 	for _, opt := range opts {
@@ -53,6 +54,7 @@ func NewMinioChunkManager(ctx context.Context, opts ...Option) (*MinioChunkManag
 
 	return newMinioChunkManagerWithConfig(ctx, c)
 }
+
 func newMinioChunkManagerWithConfig(ctx context.Context, c *config) (*MinioChunkManager, error) {
 	minIOClient, err := minio.New(c.address, &minio.Options{
 		Creds:  credentials.NewStaticV4(c.accessKeyID, c.secretAccessKeyID, ""),

--- a/internal/storage/minio_chunk_manager_test.go
+++ b/internal/storage/minio_chunk_manager_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TODO: NewMinioChunkManager is deprecated. Rewrite this unittest.
 func newMinIOChunkManager(ctx context.Context, bucketName string) (*MinioChunkManager, error) {
 	endPoint, _ := Params.Load("_MinioAddress")
 	accessKeyID, _ := Params.Load("minio.accessKeyID")


### PR DESCRIPTION
It causes Milvus not runnable with storageType: local config.

issue: #15604

/kind enhancement

Signed-off-by: Yuchen Gao <yuchen.gao@zilliz.com>