### PR TITLE
 Validate partitionIDs & segmentIDs in query request

### DIFF
--- a/internal/querynode/query_shard_test.go
+++ b/internal/querynode/query_shard_test.go
@@ -138,6 +138,17 @@ func TestQueryShard_Query(t *testing.T) {
 		assert.ElementsMatch(t, resp.Ids.GetIntId().Data, []int64{1, 2, 3})
 	})
 
+	t.Run("query follower with wrong segment", func(t *testing.T) {
+		request := &querypb.QueryRequest{
+			Req:        req,
+			DmlChannel: "",
+			SegmentIDs: []int64{defaultSegmentID + 1},
+		}
+
+		_, err := qs.query(context.Background(), request)
+		assert.Error(t, err)
+	})
+
 	t.Run("query leader", func(t *testing.T) {
 		request := &querypb.QueryRequest{
 			Req:        req,


### PR DESCRIPTION
Validate partitionIDs & segmentIDs in query request
    * check partitions if they are released or unloaded
    * check segments if their collection/partition(s) are released or unloaded

Related to #16639 #16640 

Signed-off-by: Letian Jiang <letian.jiang@zilliz.com>