### PR TITLE
Make duplicate flush recalls success and other logic update

### DIFF
--- a/internal/datacoord/session_manager.go
+++ b/internal/datacoord/session_manager.go
@@ -112,7 +112,7 @@ func (c *SessionManager) Flush(ctx context.Context, nodeID int64, req *datapb.Fl
 func (c *SessionManager) execFlush(ctx context.Context, nodeID int64, req *datapb.FlushSegmentsRequest) {
 	cli, err := c.getClient(ctx, nodeID)
 	if err != nil {
-		log.Warn("failed to get client", zap.Int64("nodeID", nodeID), zap.Error(err))
+		log.Warn("failed to get dataNode client", zap.Int64("dataNode ID", nodeID), zap.Error(err))
 		return
 	}
 	ctx, cancel := context.WithTimeout(ctx, flushTimeout)
@@ -120,11 +120,10 @@ func (c *SessionManager) execFlush(ctx context.Context, nodeID int64, req *datap
 
 	resp, err := cli.FlushSegments(ctx, req)
 	if err := VerifyResponse(resp, err); err != nil {
-		log.Warn("failed to flush", zap.Int64("node", nodeID), zap.Error(err))
-		return
+		log.Error("flush call (perhaps partially) failed", zap.Int64("dataNode ID", nodeID), zap.Error(err))
+	} else {
+		log.Info("flush call succeeded", zap.Int64("dataNode ID", nodeID))
 	}
-
-	log.Info("success to flush", zap.Int64("node", nodeID), zap.Any("segments", req))
 }
 
 // Compaction is a grpc interface. It will send request to DataNode with provided `nodeID` asynchronously.

--- a/internal/datanode/cache.go
+++ b/internal/datanode/cache.go
@@ -48,6 +48,13 @@ func (c *Cache) Cache(ID UniqueID) {
 	c.cacheMap.Store(ID, struct{}{})
 }
 
+// checkOrCache returns true if `key` is present.
+// Otherwise, it returns false and stores `key` into cache.
+func (c *Cache) checkOrCache(key UniqueID) bool {
+	_, exist := c.cacheMap.LoadOrStore(key, struct{}{})
+	return exist
+}
+
 // Remove removes a set of IDs from the cache
 func (c *Cache) Remove(IDs ...UniqueID) {
 	for _, id := range IDs {

--- a/internal/datanode/cache_test.go
+++ b/internal/datanode/cache_test.go
@@ -30,6 +30,10 @@ func TestSegmentCache(t *testing.T) {
 	segCache.Cache(UniqueID(0))
 	assert.True(t, segCache.checkIfCached(0))
 
+	assert.False(t, segCache.checkOrCache(UniqueID(1)))
+	assert.True(t, segCache.checkIfCached(1))
+	assert.True(t, segCache.checkOrCache(UniqueID(1)))
+
 	segCache.Remove(UniqueID(0))
 	assert.False(t, segCache.checkIfCached(0))
 }

--- a/internal/datanode/data_node_test.go
+++ b/internal/datanode/data_node_test.go
@@ -236,7 +236,7 @@ func TestDataNode(t *testing.T) {
 		// dup call
 		status, err := node1.FlushSegments(node1.ctx, req)
 		assert.NoError(t, err)
-		assert.Equal(t, commonpb.ErrorCode_UnexpectedError, status.ErrorCode)
+		assert.Equal(t, commonpb.ErrorCode_Success, status.ErrorCode)
 
 		// failure call
 		req = &datapb.FlushSegmentsRequest{


### PR DESCRIPTION
Latest logic:
1) Duplicate flush calls on same segment will not result in errors (same as the original design)
2) `FlushSegments` now still flushes stale segments even if some non-stale segment failed to get flushed

issue: #16749

/kind enhancement

Signed-off-by: Yuchen Gao <yuchen.gao@zilliz.com>