### PR TITLE
Make PayloadReader read column data in batch

### DIFF
--- a/internal/storage/payload_benchmark_test.go
+++ b/internal/storage/payload_benchmark_test.go
@@ -9,8 +9,8 @@ import (
 
 // workload setting for benchmark
 const (
-	numElements = 1000
-	vectorDim   = 8
+	numElements = 10000
+	vectorDim   = 512
 )
 
 func BenchmarkPayloadReader_Bool(b *testing.B) {

--- a/internal/storage/payload_test.go
+++ b/internal/storage/payload_test.go
@@ -20,12 +20,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/milvus-io/milvus/internal/proto/schemapb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus/internal/proto/schemapb"
 )
 
-func TestPayload_ReaderandWriter(t *testing.T) {
+func TestPayload_ReaderAndWriter(t *testing.T) {
 
 	t.Run("TestBool", func(t *testing.T) {
 		w, err := NewPayloadWriter(schemapb.DataType_Bool)
@@ -655,6 +656,27 @@ func TestPayload_ReaderandWriter(t *testing.T) {
 		_, err = r.GetBoolFromPayload()
 		assert.NotNil(t, err)
 	})
+	t.Run("TestGetBoolError2", func(t *testing.T) {
+		w, err := NewPayloadWriter(schemapb.DataType_Bool)
+		require.Nil(t, err)
+		require.NotNil(t, w)
+
+		err = w.AddBoolToPayload([]bool{true, false, true})
+		assert.Nil(t, err)
+
+		err = w.FinishPayloadWriter()
+		assert.Nil(t, err)
+
+		buffer, err := w.GetPayloadBufferFromWriter()
+		assert.Nil(t, err)
+
+		r, err := NewPayloadReader(schemapb.DataType_Bool, buffer)
+		assert.Nil(t, err)
+
+		r.numRows = 99
+		_, err = r.GetBoolFromPayload()
+		assert.NotNil(t, err)
+	})
 	t.Run("TestGetInt8Error", func(t *testing.T) {
 		w, err := NewPayloadWriter(schemapb.DataType_Bool)
 		require.Nil(t, err)
@@ -676,6 +698,27 @@ func TestPayload_ReaderandWriter(t *testing.T) {
 		assert.NotNil(t, err)
 
 		r.colType = 999
+		_, err = r.GetInt8FromPayload()
+		assert.NotNil(t, err)
+	})
+	t.Run("TestGetInt8Error2", func(t *testing.T) {
+		w, err := NewPayloadWriter(schemapb.DataType_Int8)
+		require.Nil(t, err)
+		require.NotNil(t, w)
+
+		err = w.AddInt8ToPayload([]int8{1, 2, 3})
+		assert.Nil(t, err)
+
+		err = w.FinishPayloadWriter()
+		assert.Nil(t, err)
+
+		buffer, err := w.GetPayloadBufferFromWriter()
+		assert.Nil(t, err)
+
+		r, err := NewPayloadReader(schemapb.DataType_Int8, buffer)
+		assert.Nil(t, err)
+
+		r.numRows = 99
 		_, err = r.GetInt8FromPayload()
 		assert.NotNil(t, err)
 	})
@@ -703,6 +746,27 @@ func TestPayload_ReaderandWriter(t *testing.T) {
 		_, err = r.GetInt16FromPayload()
 		assert.NotNil(t, err)
 	})
+	t.Run("TestGetInt16Error2", func(t *testing.T) {
+		w, err := NewPayloadWriter(schemapb.DataType_Int16)
+		require.Nil(t, err)
+		require.NotNil(t, w)
+
+		err = w.AddInt16ToPayload([]int16{1, 2, 3})
+		assert.Nil(t, err)
+
+		err = w.FinishPayloadWriter()
+		assert.Nil(t, err)
+
+		buffer, err := w.GetPayloadBufferFromWriter()
+		assert.Nil(t, err)
+
+		r, err := NewPayloadReader(schemapb.DataType_Int16, buffer)
+		assert.Nil(t, err)
+
+		r.numRows = 99
+		_, err = r.GetInt16FromPayload()
+		assert.NotNil(t, err)
+	})
 	t.Run("TestGetInt32Error", func(t *testing.T) {
 		w, err := NewPayloadWriter(schemapb.DataType_Bool)
 		require.Nil(t, err)
@@ -724,6 +788,27 @@ func TestPayload_ReaderandWriter(t *testing.T) {
 		assert.NotNil(t, err)
 
 		r.colType = 999
+		_, err = r.GetInt32FromPayload()
+		assert.NotNil(t, err)
+	})
+	t.Run("TestGetInt32Error2", func(t *testing.T) {
+		w, err := NewPayloadWriter(schemapb.DataType_Int32)
+		require.Nil(t, err)
+		require.NotNil(t, w)
+
+		err = w.AddInt32ToPayload([]int32{1, 2, 3})
+		assert.Nil(t, err)
+
+		err = w.FinishPayloadWriter()
+		assert.Nil(t, err)
+
+		buffer, err := w.GetPayloadBufferFromWriter()
+		assert.Nil(t, err)
+
+		r, err := NewPayloadReader(schemapb.DataType_Int32, buffer)
+		assert.Nil(t, err)
+
+		r.numRows = 99
 		_, err = r.GetInt32FromPayload()
 		assert.NotNil(t, err)
 	})
@@ -751,6 +836,27 @@ func TestPayload_ReaderandWriter(t *testing.T) {
 		_, err = r.GetInt64FromPayload()
 		assert.NotNil(t, err)
 	})
+	t.Run("TestGetInt64Error2", func(t *testing.T) {
+		w, err := NewPayloadWriter(schemapb.DataType_Int64)
+		require.Nil(t, err)
+		require.NotNil(t, w)
+
+		err = w.AddInt64ToPayload([]int64{1, 2, 3})
+		assert.Nil(t, err)
+
+		err = w.FinishPayloadWriter()
+		assert.Nil(t, err)
+
+		buffer, err := w.GetPayloadBufferFromWriter()
+		assert.Nil(t, err)
+
+		r, err := NewPayloadReader(schemapb.DataType_Int64, buffer)
+		assert.Nil(t, err)
+
+		r.numRows = 99
+		_, err = r.GetInt64FromPayload()
+		assert.NotNil(t, err)
+	})
 	t.Run("TestGetFloatError", func(t *testing.T) {
 		w, err := NewPayloadWriter(schemapb.DataType_Bool)
 		require.Nil(t, err)
@@ -772,6 +878,27 @@ func TestPayload_ReaderandWriter(t *testing.T) {
 		assert.NotNil(t, err)
 
 		r.colType = 999
+		_, err = r.GetFloatFromPayload()
+		assert.NotNil(t, err)
+	})
+	t.Run("TestGetFloatError2", func(t *testing.T) {
+		w, err := NewPayloadWriter(schemapb.DataType_Float)
+		require.Nil(t, err)
+		require.NotNil(t, w)
+
+		err = w.AddFloatToPayload([]float32{1, 2, 3})
+		assert.Nil(t, err)
+
+		err = w.FinishPayloadWriter()
+		assert.Nil(t, err)
+
+		buffer, err := w.GetPayloadBufferFromWriter()
+		assert.Nil(t, err)
+
+		r, err := NewPayloadReader(schemapb.DataType_Float, buffer)
+		assert.Nil(t, err)
+
+		r.numRows = 99
 		_, err = r.GetFloatFromPayload()
 		assert.NotNil(t, err)
 	})
@@ -799,6 +926,27 @@ func TestPayload_ReaderandWriter(t *testing.T) {
 		_, err = r.GetDoubleFromPayload()
 		assert.NotNil(t, err)
 	})
+	t.Run("TestGetDoubleError2", func(t *testing.T) {
+		w, err := NewPayloadWriter(schemapb.DataType_Double)
+		require.Nil(t, err)
+		require.NotNil(t, w)
+
+		err = w.AddDoubleToPayload([]float64{1, 2, 3})
+		assert.Nil(t, err)
+
+		err = w.FinishPayloadWriter()
+		assert.Nil(t, err)
+
+		buffer, err := w.GetPayloadBufferFromWriter()
+		assert.Nil(t, err)
+
+		r, err := NewPayloadReader(schemapb.DataType_Double, buffer)
+		assert.Nil(t, err)
+
+		r.numRows = 99
+		_, err = r.GetDoubleFromPayload()
+		assert.NotNil(t, err)
+	})
 	t.Run("TestGetStringError", func(t *testing.T) {
 		w, err := NewPayloadWriter(schemapb.DataType_Bool)
 		require.Nil(t, err)
@@ -820,6 +968,31 @@ func TestPayload_ReaderandWriter(t *testing.T) {
 		assert.NotNil(t, err)
 
 		r.colType = 999
+		_, err = r.GetStringFromPayload()
+		assert.NotNil(t, err)
+	})
+	t.Run("TestGetStringError2", func(t *testing.T) {
+		w, err := NewPayloadWriter(schemapb.DataType_String)
+		require.Nil(t, err)
+		require.NotNil(t, w)
+
+		err = w.AddOneStringToPayload("hello0")
+		assert.Nil(t, err)
+		err = w.AddOneStringToPayload("hello1")
+		assert.Nil(t, err)
+		err = w.AddOneStringToPayload("hello2")
+		assert.Nil(t, err)
+
+		err = w.FinishPayloadWriter()
+		assert.Nil(t, err)
+
+		buffer, err := w.GetPayloadBufferFromWriter()
+		assert.Nil(t, err)
+
+		r, err := NewPayloadReader(schemapb.DataType_String, buffer)
+		assert.Nil(t, err)
+
+		r.numRows = 99
 		_, err = r.GetStringFromPayload()
 		assert.NotNil(t, err)
 	})
@@ -847,6 +1020,27 @@ func TestPayload_ReaderandWriter(t *testing.T) {
 		_, _, err = r.GetBinaryVectorFromPayload()
 		assert.NotNil(t, err)
 	})
+	t.Run("TestGetBinaryVectorError2", func(t *testing.T) {
+		w, err := NewPayloadWriter(schemapb.DataType_BinaryVector)
+		require.Nil(t, err)
+		require.NotNil(t, w)
+
+		err = w.AddBinaryVectorToPayload([]byte{1, 0, 0, 0, 0, 0, 0, 0}, 8)
+		assert.Nil(t, err)
+
+		err = w.FinishPayloadWriter()
+		assert.Nil(t, err)
+
+		buffer, err := w.GetPayloadBufferFromWriter()
+		assert.Nil(t, err)
+
+		r, err := NewPayloadReader(schemapb.DataType_BinaryVector, buffer)
+		assert.Nil(t, err)
+
+		r.numRows = 99
+		_, _, err = r.GetBinaryVectorFromPayload()
+		assert.NotNil(t, err)
+	})
 	t.Run("TestGetFloatVectorError", func(t *testing.T) {
 		w, err := NewPayloadWriter(schemapb.DataType_Bool)
 		require.Nil(t, err)
@@ -868,6 +1062,27 @@ func TestPayload_ReaderandWriter(t *testing.T) {
 		assert.NotNil(t, err)
 
 		r.colType = 999
+		_, _, err = r.GetFloatVectorFromPayload()
+		assert.NotNil(t, err)
+	})
+	t.Run("TestGetFloatVectorError2", func(t *testing.T) {
+		w, err := NewPayloadWriter(schemapb.DataType_FloatVector)
+		require.Nil(t, err)
+		require.NotNil(t, w)
+
+		err = w.AddFloatVectorToPayload([]float32{1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0}, 8)
+		assert.Nil(t, err)
+
+		err = w.FinishPayloadWriter()
+		assert.Nil(t, err)
+
+		buffer, err := w.GetPayloadBufferFromWriter()
+		assert.Nil(t, err)
+
+		r, err := NewPayloadReader(schemapb.DataType_FloatVector, buffer)
+		assert.Nil(t, err)
+
+		r.numRows = 99
 		_, _, err = r.GetFloatVectorFromPayload()
 		assert.NotNil(t, err)
 	})


### PR DESCRIPTION
Add substitute implementations in PayloadReader which remove redundant slice copy, function call, and type assertions.

/kind improvement
Related to #16199 #16736

Benchmark results are listed in the following comments (go_reader2 is the newly added implementation).

Signed-off-by: Letian Jiang <letian.jiang@zilliz.com>