### PR TITLE
Update pymilvus version to 2.1.0.dev57

### DIFF
--- a/tests/python_client/requirements.txt
+++ b/tests/python_client/requirements.txt
@@ -9,7 +9,7 @@ allure-pytest==2.7.0
 pytest-print==0.2.1
 pytest-level==0.1.1
 pytest-xdist==2.2.1
-pymilvus==2.1.0.dev56
+pymilvus==2.1.0.dev57
 pytest-rerunfailures==9.1.1
 git+https://github.com/Projectplace/pytest-tags
 ndg-httpsclient

--- a/tests/python_client/testcases/test_connection.py
+++ b/tests/python_client/testcases/test_connection.py
@@ -50,7 +50,7 @@ class TestConnectionParams(TestcaseBase):
         self.connection_wrap.get_connection_addr(alias=DefaultConfig.DEFAULT_USING)
 
         # No check for **kwargs
-        self.connection_wrap.connect(alias=DefaultConfig.DEFAULT_USING, _kwargs=[1, 2],
+        self.connection_wrap.connect(alias=DefaultConfig.DEFAULT_USING, host=1,
                                      check_task=ct.CheckTasks.err_res,
                                      check_items={ct.err_code: 0, ct.err_msg: cem.NoHostPort})
 


### PR DESCRIPTION
Existing alias without host and port are valid params

Signed-off-by: yangxuan <xuan.yang@zilliz.com>

/assign @wangting0128 @binbinlv 