### PR TITLE
Fix query lock logic in query shard

### DIFF
--- a/internal/querynode/collection_test.go
+++ b/internal/querynode/collection_test.go
@@ -126,9 +126,10 @@ func TestCollection_releaseTime(t *testing.T) {
 
 	collection := newCollection(collectionID, schema)
 	t0 := Timestamp(1000)
-	collection.setReleaseTime(t0)
-	t1 := collection.getReleaseTime()
+	collection.setReleaseTime(t0, true)
+	t1, released := collection.getReleaseTime()
 	assert.Equal(t, t0, t1)
+	assert.True(t, released)
 }
 
 func TestCollection_loadType(t *testing.T) {

--- a/internal/querynode/impl.go
+++ b/internal/querynode/impl.go
@@ -458,6 +458,7 @@ func (node *QueryNode) ReleaseSegments(ctx context.Context, in *queryPb.ReleaseS
 	status := &commonpb.Status{
 		ErrorCode: commonpb.ErrorCode_Success,
 	}
+	// collection lock is not needed since we guarantee not query/search will be dispatch from leader
 	for _, id := range in.SegmentIDs {
 		err := node.historical.replica.removeSegment(id)
 		if err != nil {

--- a/internal/querynode/impl_test.go
+++ b/internal/querynode/impl_test.go
@@ -385,7 +385,7 @@ func TestImpl_GetSegmentInfo(t *testing.T) {
 			CollectionID: defaultCollectionID,
 		}
 
-		node.streaming.replica.(*collectionReplica).partitions = make(map[UniqueID]*Partition)
+		node.streaming.replica.(*metaReplica).partitions = make(map[UniqueID]*Partition)
 		rsp, err := node.GetSegmentInfo(ctx, req)
 		assert.NoError(t, err)
 		assert.Equal(t, commonpb.ErrorCode_UnexpectedError, rsp.Status.ErrorCode)
@@ -404,7 +404,7 @@ func TestImpl_GetSegmentInfo(t *testing.T) {
 			CollectionID: defaultCollectionID,
 		}
 
-		node.streaming.replica.(*collectionReplica).segments = make(map[UniqueID]*Segment)
+		node.streaming.replica.(*metaReplica).segments = make(map[UniqueID]*Segment)
 		rsp, err := node.GetSegmentInfo(ctx, req)
 		assert.NoError(t, err)
 		assert.Equal(t, commonpb.ErrorCode_UnexpectedError, rsp.Status.ErrorCode)
@@ -423,7 +423,7 @@ func TestImpl_GetSegmentInfo(t *testing.T) {
 			CollectionID: defaultCollectionID,
 		}
 
-		node.historical.replica.(*collectionReplica).partitions = make(map[UniqueID]*Partition)
+		node.historical.replica.(*metaReplica).partitions = make(map[UniqueID]*Partition)
 		rsp, err := node.GetSegmentInfo(ctx, req)
 		assert.NoError(t, err)
 		assert.Equal(t, commonpb.ErrorCode_UnexpectedError, rsp.Status.ErrorCode)
@@ -442,7 +442,7 @@ func TestImpl_GetSegmentInfo(t *testing.T) {
 			CollectionID: defaultCollectionID,
 		}
 
-		node.historical.replica.(*collectionReplica).segments = make(map[UniqueID]*Segment)
+		node.historical.replica.(*metaReplica).segments = make(map[UniqueID]*Segment)
 		rsp, err := node.GetSegmentInfo(ctx, req)
 		assert.NoError(t, err)
 		assert.Equal(t, commonpb.ErrorCode_UnexpectedError, rsp.Status.ErrorCode)

--- a/internal/querynode/meta_replica_test.go
+++ b/internal/querynode/meta_replica_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 //----------------------------------------------------------------------------------------------------- collection
-func TestCollectionReplica_getCollectionNum(t *testing.T) {
+func TestMetaReplica_getCollectionNum(t *testing.T) {
 	node := newQueryNodeMock()
 	initTestMeta(t, node, 0, 0)
 	assert.Equal(t, node.historical.replica.getCollectionNum(), 1)
@@ -34,14 +34,14 @@ func TestCollectionReplica_getCollectionNum(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestCollectionReplica_addCollection(t *testing.T) {
+func TestMetaReplica_addCollection(t *testing.T) {
 	node := newQueryNodeMock()
 	initTestMeta(t, node, 0, 0)
 	err := node.Stop()
 	assert.NoError(t, err)
 }
 
-func TestCollectionReplica_removeCollection(t *testing.T) {
+func TestMetaReplica_removeCollection(t *testing.T) {
 	node := newQueryNodeMock()
 	initTestMeta(t, node, 0, 0)
 	assert.Equal(t, node.historical.replica.getCollectionNum(), 1)
@@ -53,7 +53,7 @@ func TestCollectionReplica_removeCollection(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestCollectionReplica_getCollectionByID(t *testing.T) {
+func TestMetaReplica_getCollectionByID(t *testing.T) {
 	node := newQueryNodeMock()
 	collectionID := UniqueID(0)
 	initTestMeta(t, node, collectionID, 0)
@@ -65,7 +65,7 @@ func TestCollectionReplica_getCollectionByID(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestCollectionReplica_hasCollection(t *testing.T) {
+func TestMetaReplica_hasCollection(t *testing.T) {
 	node := newQueryNodeMock()
 	collectionID := UniqueID(0)
 	initTestMeta(t, node, collectionID, 0)
@@ -80,7 +80,7 @@ func TestCollectionReplica_hasCollection(t *testing.T) {
 }
 
 //----------------------------------------------------------------------------------------------------- partition
-func TestCollectionReplica_getPartitionNum(t *testing.T) {
+func TestMetaReplica_getPartitionNum(t *testing.T) {
 	node := newQueryNodeMock()
 	collectionID := UniqueID(0)
 	initTestMeta(t, node, collectionID, 0)
@@ -100,7 +100,7 @@ func TestCollectionReplica_getPartitionNum(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestCollectionReplica_addPartition(t *testing.T) {
+func TestMetaReplica_addPartition(t *testing.T) {
 	node := newQueryNodeMock()
 	collectionID := UniqueID(0)
 	initTestMeta(t, node, collectionID, 0)
@@ -117,7 +117,7 @@ func TestCollectionReplica_addPartition(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestCollectionReplica_removePartition(t *testing.T) {
+func TestMetaReplica_removePartition(t *testing.T) {
 	node := newQueryNodeMock()
 	collectionID := UniqueID(0)
 	initTestMeta(t, node, collectionID, 0)
@@ -137,7 +137,7 @@ func TestCollectionReplica_removePartition(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestCollectionReplica_getPartitionByTag(t *testing.T) {
+func TestMetaReplica_getPartitionByTag(t *testing.T) {
 	node := newQueryNodeMock()
 	collectionID := UniqueID(0)
 	initTestMeta(t, node, collectionID, 0)
@@ -157,7 +157,7 @@ func TestCollectionReplica_getPartitionByTag(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestCollectionReplica_hasPartition(t *testing.T) {
+func TestMetaReplica_hasPartition(t *testing.T) {
 	node := newQueryNodeMock()
 	collectionID := UniqueID(0)
 	initTestMeta(t, node, collectionID, 0)
@@ -175,7 +175,7 @@ func TestCollectionReplica_hasPartition(t *testing.T) {
 }
 
 //----------------------------------------------------------------------------------------------------- segment
-func TestCollectionReplica_addSegment(t *testing.T) {
+func TestMetaReplica_addSegment(t *testing.T) {
 	node := newQueryNodeMock()
 	collectionID := UniqueID(0)
 	initTestMeta(t, node, collectionID, 0)
@@ -193,7 +193,7 @@ func TestCollectionReplica_addSegment(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestCollectionReplica_removeSegment(t *testing.T) {
+func TestMetaReplica_removeSegment(t *testing.T) {
 	node := newQueryNodeMock()
 	collectionID := UniqueID(0)
 	initTestMeta(t, node, collectionID, 0)
@@ -214,7 +214,7 @@ func TestCollectionReplica_removeSegment(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestCollectionReplica_getSegmentByID(t *testing.T) {
+func TestMetaReplica_getSegmentByID(t *testing.T) {
 	node := newQueryNodeMock()
 	collectionID := UniqueID(0)
 	initTestMeta(t, node, collectionID, 0)
@@ -233,7 +233,7 @@ func TestCollectionReplica_getSegmentByID(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestCollectionReplica_getSegmentInfosByColID(t *testing.T) {
+func TestMetaReplica_getSegmentInfosByColID(t *testing.T) {
 	node := newQueryNodeMock()
 	collectionID := UniqueID(0)
 	pkType := schemapb.DataType_Int64
@@ -282,7 +282,7 @@ func TestCollectionReplica_getSegmentInfosByColID(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestCollectionReplica_hasSegment(t *testing.T) {
+func TestMetaReplica_hasSegment(t *testing.T) {
 	node := newQueryNodeMock()
 	collectionID := UniqueID(0)
 	initTestMeta(t, node, collectionID, 0)
@@ -305,7 +305,7 @@ func TestCollectionReplica_hasSegment(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestCollectionReplica_freeAll(t *testing.T) {
+func TestMetaReplica_freeAll(t *testing.T) {
 	node := newQueryNodeMock()
 	collectionID := UniqueID(0)
 	initTestMeta(t, node, collectionID, 0)
@@ -314,7 +314,7 @@ func TestCollectionReplica_freeAll(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestCollectionReplica_statistic(t *testing.T) {
+func TestMetaReplica_statistic(t *testing.T) {
 	t.Run("test getCollectionIDs", func(t *testing.T) {
 		replica, err := genSimpleReplica()
 		assert.NoError(t, err)

--- a/internal/querynode/query_collection.go
+++ b/internal/querynode/query_collection.go
@@ -495,7 +495,7 @@ func (q *queryCollection) receiveQueryMsg(msg queryMsg) error {
 		return err
 	}
 	guaranteeTs := msg.GuaranteeTs()
-	if guaranteeTs >= collection.getReleaseTime() {
+	if releaseTs, _ := collection.getReleaseTime(); guaranteeTs >= releaseTs {
 		err = fmt.Errorf("retrieve failed, collection has been released, msgID = %d, collectionID = %d", msg.ID(), collectionID)
 		publishErr := q.publishFailedQueryResult(msg, err.Error())
 		if publishErr != nil {

--- a/internal/querynode/task.go
+++ b/internal/querynode/task.go
@@ -723,18 +723,13 @@ func (r *releaseCollectionTask) Execute(ctx context.Context) error {
 }
 
 func (r *releaseCollectionTask) releaseReplica(replica ReplicaInterface, replicaType ReplicaType) error {
-	// block search/query operation
-	replica.queryLock()
-
 	collection, err := replica.getCollectionByID(r.req.CollectionID)
 	if err != nil {
-		replica.queryUnlock()
 		return err
 	}
 	// set release time
 	log.Info("set release time", zap.Any("collectionID", r.req.CollectionID))
-	collection.setReleaseTime(r.req.Base.Timestamp)
-	replica.queryUnlock()
+	collection.setReleaseTime(r.req.Base.Timestamp, true)
 
 	// remove all flow graphs of the target collection
 	var channels []Channel

--- a/internal/querynode/tsafe.go
+++ b/internal/querynode/tsafe.go
@@ -93,3 +93,10 @@ func (ts *tSafe) set(t Timestamp) {
 	//	zap.Any("channel", ts.channel),
 	//	zap.Any("t", m.t))
 }
+
+// close calls the close method of internal watcher if any
+func (ts *tSafe) close() {
+	if ts.watcher != nil {
+		ts.watcher.close()
+	}
+}

--- a/internal/querynode/tsafe_replica.go
+++ b/internal/querynode/tsafe_replica.go
@@ -94,6 +94,10 @@ func (t *tSafeReplica) removeTSafe(vChannel Channel) {
 	log.Info("remove tSafe replica",
 		zap.String("vChannel", vChannel),
 	)
+	tsafe, ok := t.tSafes[vChannel]
+	if ok {
+		tsafe.close()
+	}
 	delete(t.tSafes, vChannel)
 }
 


### PR DESCRIPTION
Previously query shard locks the querylock in collectionReplica before any search/query
The lock range is too large and easy to cause dead lock

This PR makes following changes:
- Rename collectionReplica to metaReplica which is more reasonable
- Make release collection operation cancels waiting search/query request
- Reduce the queryLock to collection level
- Add some unit tests for timeout & released case

/kind improvement
Related to #16809

Signed-off-by: Congqi Xia <congqi.xia@zilliz.com>