### PR TITLE
Return buildID when creating index if the index alreay exists

### DIFF
--- a/internal/rootcoord/root_coord.go
+++ b/internal/rootcoord/root_coord.go
@@ -921,7 +921,8 @@ func (c *Core) BuildIndex(ctx context.Context, segID typeutil.UniqueID, field *s
 	sp, ctx := trace.StartSpanFromContext(ctx)
 	defer sp.Finish()
 	if c.MetaTable.IsSegmentIndexed(segID, field, idxInfo.IndexParams) {
-		return 0, nil
+		info, err := c.MetaTable.GetSegmentIndexInfoByID(segID, field.FieldID, idxInfo.GetIndexName())
+		return info.BuildID, err
 	}
 	rows, err := c.CallGetNumRowsService(ctx, segID, isFlush)
 	if err != nil {


### PR DESCRIPTION
issue: #16916 
Signed-off-by: Cai.Zhang <cai.zhang@zilliz.com>

1. RootCoord should return the buildID when building the index, if the index already exists.
2. To avoid flush failures, the second flush request should not be skipped, even if the first flush request is in progress when the second refresh request if issued.