### PR TITLE
Fix data race for indexcoord test

### DIFF
--- a/internal/indexnode/indexnode_mock.go
+++ b/internal/indexnode/indexnode_mock.go
@@ -183,7 +183,6 @@ func (inm *Mock) Register() error {
 	if inm.Err {
 		return errors.New("IndexNode register failed")
 	}
-	Params.Init()
 	inm.etcdKV = etcdkv.NewEtcdKV(inm.etcdCli, Params.EtcdCfg.MetaRootPath)
 	if err := inm.etcdKV.RemoveWithPrefix("session/" + typeutil.IndexNodeRole); err != nil {
 		return err


### PR DESCRIPTION
issue: #17031 
Signed-off-by: Cai.Zhang <cai.zhang@zilliz.com>

1. Before calling the `Register` interface, the param table must have been initialized, so there is unnecessary to do init again in the `Register` interface.