### PR TITLE
Limit the query node timetick log rate

### DIFF
--- a/internal/querynode/flow_graph_service_time_node.go
+++ b/internal/querynode/flow_graph_service_time_node.go
@@ -69,7 +69,7 @@ func (stNode *serviceTimeNode) Operate(in []flowgraph.Msg) []flowgraph.Msg {
 		)
 	}
 	p, _ := tsoutil.ParseTS(serviceTimeMsg.timeRange.timestampMax)
-	log.Debug("update tSafe:",
+	log.RatedDebug(10.0, "update tSafe:",
 		zap.Any("collectionID", stNode.collectionID),
 		zap.Any("tSafe", serviceTimeMsg.timeRange.timestampMax),
 		zap.Any("tSafe_p", p),


### PR DESCRIPTION
The "Update tsafe" log is too much when debuging the querynode.
This PR limits the rate of printing it to 10 second

Signed-off-by: Congqi Xia <congqi.xia@zilliz.com>