### PR TITLE
Fix shardLeader cache concurrent access

### DIFF
--- a/internal/proxy/task_policies.go
+++ b/internal/proxy/task_policies.go
@@ -49,8 +49,7 @@ func (q queryNode) String() string {
 	return fmt.Sprintf("<NodeID: %d>", q.nodeID)
 }
 
-func updateShardsWithRoundRobin(shardsLeaders map[string][]queryNode) map[string][]queryNode {
-
+func updateShardsWithRoundRobin(shardsLeaders map[string][]queryNode) {
 	for channelID, leaders := range shardsLeaders {
 		if len(leaders) <= 1 {
 			continue
@@ -58,8 +57,6 @@ func updateShardsWithRoundRobin(shardsLeaders map[string][]queryNode) map[string
 
 		shardsLeaders[channelID] = append(leaders[1:], leaders[0])
 	}
-
-	return shardsLeaders
 }
 
 func roundRobinPolicy(ctx context.Context, getQueryNodePolicy getQueryNodePolicy, query func(UniqueID, types.QueryNode) error, leaders []queryNode) error {

--- a/internal/proxy/task_policies_test.go
+++ b/internal/proxy/task_policies_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestUpdateShardsWithRoundRobin(t *testing.T) {
-	in := map[string][]queryNode{
+	list := map[string][]queryNode{
 		"channel-1": {
 			{1, "addr1"},
 			{2, "addr2"},
@@ -26,12 +26,12 @@ func TestUpdateShardsWithRoundRobin(t *testing.T) {
 		},
 	}
 
-	out := updateShardsWithRoundRobin(in)
+	updateShardsWithRoundRobin(list)
 
-	assert.Equal(t, int64(2), out["channel-1"][0].nodeID)
-	assert.Equal(t, "addr2", out["channel-1"][0].address)
-	assert.Equal(t, int64(21), out["channel-2"][0].nodeID)
-	assert.Equal(t, "addr21", out["channel-2"][0].address)
+	assert.Equal(t, int64(2), list["channel-1"][0].nodeID)
+	assert.Equal(t, "addr2", list["channel-1"][0].address)
+	assert.Equal(t, int64(21), list["channel-2"][0].nodeID)
+	assert.Equal(t, "addr21", list["channel-2"][0].address)
 
 	t.Run("check print", func(t *testing.T) {
 		qns := []queryNode{


### PR DESCRIPTION
Fix  write map without mutex control
Also GetShards returns a copy of leader list instead of original one

Related to #17072

/kind bug

Signed-off-by: Congqi Xia <congqi.xia@zilliz.com>