### PR TITLE
Fix mock querynode server session not revoked

### DIFF
--- a/internal/querycoord/mock_querynode_server_test.go
+++ b/internal/querycoord/mock_querynode_server_test.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"strconv"
 	"sync"
+	"time"
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -172,6 +173,9 @@ func (qs *queryNodeServerMock) start() error {
 
 func (qs *queryNodeServerMock) stop() error {
 	qs.cancel()
+	if qs.session != nil {
+		qs.session.Revoke(time.Second)
+	}
 	if qs.grpcServer != nil {
 		qs.grpcServer.GracefulStop()
 	}


### PR DESCRIPTION
Revoke mock `QueryNode` server session when it's stopped
This PR reduces the running time of `TestLoadBalanceIndexedSegmentsAfterNodeDown` from 60+ seconds to less than 1+ seconds
Also related to #17212 #17215
/kind improvement

Signed-off-by: Congqi Xia <congqi.xia@zilliz.com>