### PR TITLE
Allow DataNode clean vchannel with meta error without panicking

### DIFF
--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -335,6 +335,7 @@ func (s *Server) SaveBinlogPaths(ctx context.Context, req *datapb.SaveBinlogPath
 	channel := segment.GetInsertChannel()
 	if !s.channelManager.Match(nodeID, channel) {
 		FailResponse(resp, fmt.Sprintf("channel %s is not watched on node %d", channel, nodeID))
+		resp.ErrorCode = commonpb.ErrorCode_MetaFailed
 		log.Warn("node is not matched with channel", zap.String("channel", channel), zap.Int64("nodeID", nodeID))
 		return resp, nil
 	}
@@ -412,6 +413,7 @@ func (s *Server) DropVirtualChannel(ctx context.Context, req *datapb.DropVirtual
 	nodeID := req.GetBase().GetSourceID()
 	if !s.channelManager.Match(nodeID, channel) {
 		FailResponse(resp.Status, fmt.Sprintf("channel %s is not watched on node %d", channel, nodeID))
+		resp.Status.ErrorCode = commonpb.ErrorCode_MetaFailed
 		log.Warn("node is not matched with channel", zap.String("channel", channel), zap.Int64("nodeID", nodeID))
 		return resp, nil
 	}

--- a/internal/datanode/mock_test.go
+++ b/internal/datanode/mock_test.go
@@ -164,14 +164,14 @@ type RootCoordFactory struct {
 type DataCoordFactory struct {
 	types.DataCoord
 
-	SaveBinlogPathError      bool
-	SaveBinlogPathNotSuccess bool
+	SaveBinlogPathError  bool
+	SaveBinlogPathStatus commonpb.ErrorCode
 
 	CompleteCompactionError      bool
 	CompleteCompactionNotSuccess bool
 
-	DropVirtualChannelError      bool
-	DropVirtualChannelNotSuccess bool
+	DropVirtualChannelError  bool
+	DropVirtualChannelStatus commonpb.ErrorCode
 }
 
 func (ds *DataCoordFactory) AssignSegmentID(ctx context.Context, req *datapb.AssignSegmentIDRequest) (*datapb.AssignSegmentIDResponse, error) {
@@ -202,27 +202,16 @@ func (ds *DataCoordFactory) SaveBinlogPaths(ctx context.Context, req *datapb.Sav
 	if ds.SaveBinlogPathError {
 		return nil, errors.New("Error")
 	}
-	if ds.SaveBinlogPathNotSuccess {
-		return &commonpb.Status{ErrorCode: commonpb.ErrorCode_UnexpectedError}, nil
-	}
-
-	return &commonpb.Status{ErrorCode: commonpb.ErrorCode_Success}, nil
+	return &commonpb.Status{ErrorCode: ds.SaveBinlogPathStatus}, nil
 }
 
 func (ds *DataCoordFactory) DropVirtualChannel(ctx context.Context, req *datapb.DropVirtualChannelRequest) (*datapb.DropVirtualChannelResponse, error) {
 	if ds.DropVirtualChannelError {
 		return nil, errors.New("error")
 	}
-	if ds.DropVirtualChannelNotSuccess {
-		return &datapb.DropVirtualChannelResponse{
-			Status: &commonpb.Status{
-				ErrorCode: commonpb.ErrorCode_UnexpectedError,
-			},
-		}, nil
-	}
 	return &datapb.DropVirtualChannelResponse{
 		Status: &commonpb.Status{
-			ErrorCode: commonpb.ErrorCode_Success,
+			ErrorCode: ds.DropVirtualChannelStatus,
 		},
 	}, nil
 }


### PR DESCRIPTION
Make `DataNode` not panicking when found virtual channel meta error
Let `DataCoord` return `MetaFailed` status when channel meta not matched

Related to #17097 

/kind bug

Signed-off-by: Congqi Xia <congqi.xia@zilliz.com>