### PR TITLE
Enable marisa trie compilation on macOS

### DIFF
--- a/internal/core/thirdparty/CMakeLists.txt
+++ b/internal/core/thirdparty/CMakeLists.txt
@@ -64,7 +64,7 @@ add_subdirectory( boost_ext )
 add_subdirectory( arrow )
 
 # ******************************* Thridparty marisa ********************************
-# TODO: support apple & win.
-if ( LINUX )
+# TODO: support win.
+if ( LINUX OR APPLE)
     add_subdirectory( marisa )
 endif()

--- a/internal/core/thirdparty/marisa/CMakeLists.txt
+++ b/internal/core/thirdparty/marisa/CMakeLists.txt
@@ -13,7 +13,12 @@ macro(build_marisa)
 
     set (MARISA_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
     set (MARISA_DIR "${CMAKE_CURRENT_BINARY_DIR}/src")
-    set (MARISA_CONFIGURE_COMMAND cd ${MARISA_DIR} && libtoolize && autoreconf -i && ./configure --prefix=${MARISA_INSTALL_PREFIX})
+    if ( LINUX )
+          set (MARISA_CONFIGURE_COMMAND cd ${MARISA_DIR} && libtoolize && autoreconf -i && ./configure --prefix=${MARISA_INSTALL_PREFIX})
+    else()
+          set (MARISA_CONFIGURE_COMMAND brew install automake && cd ${MARISA_DIR} && glibtoolize && autoreconf -i && ./configure --prefix=${MARISA_INSTALL_PREFIX})
+    endif()
+
     set (MARISA_BUILD_COMMAND make -j)
     set (MARISA_INSTALL_COMMAND make install)
 


### PR DESCRIPTION
Support to compile marisa trie on macOS, verified on x86 macbook
Signed-off-by: xiaofan-luan <xiaofan.luan@zilliz.com>