### PR TITLE
Make DataNode release rather than delete when reassign

### DIFF
--- a/internal/datacoord/policy_test.go
+++ b/internal/datacoord/policy_test.go
@@ -97,11 +97,10 @@ func TestConsistentHashRegisterPolicy(t *testing.T) {
 
 		updates := policy(store, 2)
 
-		// chan1 will be hash to 2, chan2 will be hash to 1
 		assert.NotNil(t, updates)
-		assert.Equal(t, 2, len(updates))
-		assert.EqualValues(t, &ChannelOp{Type: Delete, NodeID: 1, Channels: []*channel{channels[0]}}, updates[0])
-		assert.EqualValues(t, &ChannelOp{Type: Add, NodeID: 2, Channels: []*channel{channels[0]}}, updates[1])
+		assert.Equal(t, 1, len(updates))
+		// No Delete operation will be generated
+		assert.EqualValues(t, &ChannelOp{Type: Add, NodeID: 1, Channels: []*channel{channels[0]}}, updates[0])
 	})
 }
 
@@ -487,13 +486,8 @@ func TestAvgAssignRegisterPolicy(t *testing.T) {
 			},
 			[]*ChannelOp{
 				{
-					Type:     Delete,
-					NodeID:   1,
-					Channels: []*channel{{"ch1", 1}},
-				},
-				{
 					Type:     Add,
-					NodeID:   3,
+					NodeID:   1,
 					Channels: []*channel{{"ch1", 1}},
 				},
 			},
@@ -526,13 +520,8 @@ func TestAvgAssignRegisterPolicy(t *testing.T) {
 			},
 			[]*ChannelOp{
 				{
-					Type:     Delete,
-					NodeID:   1,
-					Channels: []*channel{{"ch1", 1}},
-				},
-				{
 					Type:     Add,
-					NodeID:   3,
+					NodeID:   1,
 					Channels: []*channel{{"ch1", 1}},
 				},
 			},


### PR DESCRIPTION
1. Reassgin now will assign to the original Node if no other nodes
   avaliable
2. Make AddNode balance async: ToRealse + Reassign

See also: #16114, #17270

Signed-off-by: yangxuan <xuan.yang@zilliz.com>