### PR TITLE
Update Etcd request size limit and storage size limit config

### DIFF
--- a/cmd/tools/datameta/main.go
+++ b/cmd/tools/datameta/main.go
@@ -29,7 +29,7 @@ var (
 func main() {
 	flag.Parse()
 
-	etcdCli, err := etcd.GetRemoteEtcdClient([]string{*etcdAddr})
+	etcdCli, err := etcd.GetRemoteEtcdClient([]string{*etcdAddr}, 10*1024*1024)
 	if err != nil {
 		log.Fatal("failed to connect to etcd", zap.Error(err))
 	}

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -21,6 +21,8 @@ etcd:
   rootPath: by-dev # The root path where data is stored in etcd
   metaSubPath: meta # metaRootPath = rootPath + '/' + metaSubPath
   kvSubPath: kv # kvRootPath = rootPath + '/' + kvSubPath
+  # client side request size limit, which should be >= server side limit (--max-request-bytes). Default 10 MB.
+  maxRequestBytes: 10485760
   log:
     # path is one of:
     #  - "default" as os.Stderr,

--- a/deployments/docker/cluster/docker-compose-apple-silicon.yml
+++ b/deployments/docker/cluster/docker-compose-apple-silicon.yml
@@ -10,7 +10,8 @@ services:
       - ETCD_QUOTA_BACKEND_BYTES=4294967296
     volumes:
       - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/etcd:/etcd
-    command: etcd -advertise-client-urls=http://127.0.0.1:2379 -listen-client-urls http://0.0.0.0:2379 --data-dir /etcd
+    command: etcd -advertise-client-urls=http://127.0.0.1:2379 -listen-client-urls http://0.0.0.0:2379 
+      --data-dir /etcd --quota-backend-bytes=8589934592 --max-request-bytes=10485760
 
   pulsar:
     container_name: milvus-pulsar

--- a/deployments/docker/cluster/docker-compose.yml
+++ b/deployments/docker/cluster/docker-compose.yml
@@ -10,7 +10,8 @@ services:
       - ETCD_QUOTA_BACKEND_BYTES=4294967296
     volumes:
       - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/etcd:/etcd
-    command: etcd -advertise-client-urls=http://127.0.0.1:2379 -listen-client-urls http://0.0.0.0:2379 --data-dir /etcd
+    command: etcd -advertise-client-urls=http://127.0.0.1:2379 -listen-client-urls http://0.0.0.0:2379 
+      --data-dir /etcd --quota-backend-bytes=8589934592 --max-request-bytes=10485760
 
   pulsar:
     container_name: milvus-pulsar

--- a/deployments/docker/dev/docker-compose-apple-silicon.yml
+++ b/deployments/docker/dev/docker-compose-apple-silicon.yml
@@ -5,7 +5,10 @@ services:
     image: quay.io/coreos/etcd:v3.5.0
     volumes:
       - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/etcd:/etcd
-    command: etcd -listen-peer-urls=http://127.0.0.1:2380 -advertise-client-urls=http://127.0.0.1:2379 -listen-client-urls http://0.0.0.0:2379,http://0.0.0.0:4001 -initial-advertise-peer-urls=http://127.0.0.1:2380 --initial-cluster default=http://127.0.0.1:2380
+    command: etcd -listen-peer-urls=http://127.0.0.1:2380 -advertise-client-urls=http://127.0.0.1:2379 
+      -listen-client-urls http://0.0.0.0:2379,http://0.0.0.0:4001 -initial-advertise-peer-urls=http://127.0.0.1:2380 
+      --initial-cluster default=http://127.0.0.1:2380 --data-dir /etcd --quota-backend-bytes=8589934592 
+      --max-request-bytes=10485760
     ports:
       - "2379:2379"
       - "2380:2380"

--- a/deployments/docker/dev/docker-compose.yml
+++ b/deployments/docker/dev/docker-compose.yml
@@ -5,7 +5,10 @@ services:
     image: quay.io/coreos/etcd:v3.5.0
     volumes:
       - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/etcd:/etcd
-    command: etcd -listen-peer-urls=http://127.0.0.1:2380 -advertise-client-urls=http://127.0.0.1:2379 -listen-client-urls http://0.0.0.0:2379,http://0.0.0.0:4001 -initial-advertise-peer-urls=http://127.0.0.1:2380 --initial-cluster default=http://127.0.0.1:2380 --data-dir /etcd
+    command: etcd -listen-peer-urls=http://127.0.0.1:2380 -advertise-client-urls=http://127.0.0.1:2379 
+      -listen-client-urls http://0.0.0.0:2379,http://0.0.0.0:4001 -initial-advertise-peer-urls=http://127.0.0.1:2380 
+      --initial-cluster default=http://127.0.0.1:2380 --data-dir /etcd --quota-backend-bytes=8589934592 
+      --max-request-bytes=10485760
     ports:
       - "2379:2379"
       - "2380:2380"

--- a/internal/distributed/connection_manager_test.go
+++ b/internal/distributed/connection_manager_test.go
@@ -251,7 +251,7 @@ func initSession(ctx context.Context) *sessionutil.Session {
 	log.Debug("metaRootPath", zap.Any("metaRootPath", metaRootPath))
 	log.Debug("etcdPoints", zap.Any("etcdPoints", etcdEndpoints))
 
-	etcdCli, err := etcd.GetRemoteEtcdClient(etcdEndpoints)
+	etcdCli, err := etcd.GetRemoteEtcdClient(etcdEndpoints, 10*1024*1024)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/mq/mqimpl/rocksmq/server/global_rmq_test.go
+++ b/internal/mq/mqimpl/rocksmq/server/global_rmq_test.go
@@ -34,7 +34,7 @@ func Test_InitRmq(t *testing.T) {
 		endpoints = "localhost:2379"
 	}
 	etcdEndpoints := strings.Split(endpoints, ",")
-	etcdCli, err := etcd.GetRemoteEtcdClient(etcdEndpoints)
+	etcdCli, err := etcd.GetRemoteEtcdClient(etcdEndpoints, 10*1024*1024)
 	defer etcdCli.Close()
 	if err != nil {
 		log.Fatalf("New clientv3 error = %v", err)

--- a/internal/mq/mqimpl/rocksmq/server/rocksmq_impl_test.go
+++ b/internal/mq/mqimpl/rocksmq/server/rocksmq_impl_test.go
@@ -314,7 +314,7 @@ func TestRocksmq_Seek(t *testing.T) {
 
 func TestRocksmq_Loop(t *testing.T) {
 	ep := etcdEndpoints()
-	etcdCli, err := etcd.GetRemoteEtcdClient(ep)
+	etcdCli, err := etcd.GetRemoteEtcdClient(ep, 10*1024*1024)
 	assert.Nil(t, err)
 	defer etcdCli.Close()
 	etcdKV := etcdkv.NewEtcdKV(etcdCli, "/etcd/test/root")
@@ -385,7 +385,7 @@ func TestRocksmq_Loop(t *testing.T) {
 
 func TestRocksmq_Goroutines(t *testing.T) {
 	ep := etcdEndpoints()
-	etcdCli, err := etcd.GetRemoteEtcdClient(ep)
+	etcdCli, err := etcd.GetRemoteEtcdClient(ep, 10*1024*1024)
 	assert.Nil(t, err)
 	defer etcdCli.Close()
 	etcdKV := etcdkv.NewEtcdKV(etcdCli, "/etcd/test/root")
@@ -460,7 +460,7 @@ func TestRocksmq_Goroutines(t *testing.T) {
 */
 func TestRocksmq_Throughout(t *testing.T) {
 	ep := etcdEndpoints()
-	etcdCli, err := etcd.GetRemoteEtcdClient(ep)
+	etcdCli, err := etcd.GetRemoteEtcdClient(ep, 10*1024*1024)
 	assert.Nil(t, err)
 	defer etcdCli.Close()
 	etcdKV := etcdkv.NewEtcdKV(etcdCli, "/etcd/test/root")
@@ -518,7 +518,7 @@ func TestRocksmq_Throughout(t *testing.T) {
 
 func TestRocksmq_MultiChan(t *testing.T) {
 	ep := etcdEndpoints()
-	etcdCli, err := etcd.GetRemoteEtcdClient(ep)
+	etcdCli, err := etcd.GetRemoteEtcdClient(ep, 10*1024*1024)
 	assert.Nil(t, err)
 	defer etcdCli.Close()
 	etcdKV := etcdkv.NewEtcdKV(etcdCli, "/etcd/test/root")
@@ -570,7 +570,7 @@ func TestRocksmq_MultiChan(t *testing.T) {
 
 func TestRocksmq_CopyData(t *testing.T) {
 	ep := etcdEndpoints()
-	etcdCli, err := etcd.GetRemoteEtcdClient(ep)
+	etcdCli, err := etcd.GetRemoteEtcdClient(ep, 10*1024*1024)
 	assert.Nil(t, err)
 	defer etcdCli.Close()
 	etcdKV := etcdkv.NewEtcdKV(etcdCli, "/etcd/test/root")
@@ -636,7 +636,7 @@ func TestRocksmq_CopyData(t *testing.T) {
 
 func TestRocksmq_SeekToLatest(t *testing.T) {
 	ep := etcdEndpoints()
-	etcdCli, err := etcd.GetRemoteEtcdClient(ep)
+	etcdCli, err := etcd.GetRemoteEtcdClient(ep, 10*1024*1024)
 	assert.Nil(t, err)
 	defer etcdCli.Close()
 	etcdKV := etcdkv.NewEtcdKV(etcdCli, "/etcd/test/root")
@@ -727,7 +727,7 @@ func TestRocksmq_SeekToLatest(t *testing.T) {
 
 func TestRocksmq_GetLatestMsg(t *testing.T) {
 	ep := etcdEndpoints()
-	etcdCli, err := etcd.GetRemoteEtcdClient(ep)
+	etcdCli, err := etcd.GetRemoteEtcdClient(ep, 10*1024*1024)
 	assert.Nil(t, err)
 	defer etcdCli.Close()
 	etcdKV := etcdkv.NewEtcdKV(etcdCli, "/etcd/test/root")
@@ -801,7 +801,7 @@ func TestRocksmq_GetLatestMsg(t *testing.T) {
 
 func TestRocksmq_Close(t *testing.T) {
 	ep := etcdEndpoints()
-	etcdCli, err := etcd.GetRemoteEtcdClient(ep)
+	etcdCli, err := etcd.GetRemoteEtcdClient(ep, 10*1024*1024)
 	assert.Nil(t, err)
 	defer etcdCli.Close()
 	etcdKV := etcdkv.NewEtcdKV(etcdCli, "/etcd/test/root")
@@ -834,7 +834,7 @@ func TestRocksmq_Close(t *testing.T) {
 
 func TestRocksmq_SeekWithNoConsumerError(t *testing.T) {
 	ep := etcdEndpoints()
-	etcdCli, err := etcd.GetRemoteEtcdClient(ep)
+	etcdCli, err := etcd.GetRemoteEtcdClient(ep, 10*1024*1024)
 	assert.Nil(t, err)
 	etcdKV := etcdkv.NewEtcdKV(etcdCli, "/etcd/test/root")
 	defer etcdKV.Close()

--- a/internal/mq/msgstream/mq_msgstream_test.go
+++ b/internal/mq/msgstream/mq_msgstream_test.go
@@ -76,7 +76,7 @@ func (f *fixture) setup() []parameters {
 		endpoints = "localhost:2379"
 	}
 	etcdEndpoints := strings.Split(endpoints, ",")
-	etcdCli, err := etcd.GetRemoteEtcdClient(etcdEndpoints)
+	etcdCli, err := etcd.GetRemoteEtcdClient(etcdEndpoints, 10*1024*1024)
 	defer etcdCli.Close()
 	if err != nil {
 		log.Fatalf("New clientv3 error = %v", err)
@@ -1398,7 +1398,7 @@ func initRmq(name string) *etcdkv.EtcdKV {
 		endpoints = "localhost:2379"
 	}
 	etcdEndpoints := strings.Split(endpoints, ",")
-	etcdCli, err := etcd.GetRemoteEtcdClient(etcdEndpoints)
+	etcdCli, err := etcd.GetRemoteEtcdClient(etcdEndpoints, 10*1024*1024)
 	if err != nil {
 		log.Fatalf("New clientv3 error = %v", err)
 	}

--- a/internal/tso/global_allocator_test.go
+++ b/internal/tso/global_allocator_test.go
@@ -36,7 +36,7 @@ func TestGlobalTSOAllocator_Initialize(t *testing.T) {
 		endpoints = "localhost:2379"
 	}
 	etcdEndpoints := strings.Split(endpoints, ",")
-	etcdCli, err := etcd.GetRemoteEtcdClient(etcdEndpoints)
+	etcdCli, err := etcd.GetRemoteEtcdClient(etcdEndpoints, 10*1024*1024)
 	assert.Nil(t, err)
 	defer etcdCli.Close()
 
@@ -76,7 +76,7 @@ func TestGlobalTSOAllocator_All(t *testing.T) {
 		endpoints = "localhost:2379"
 	}
 	etcdEndpoints := strings.Split(endpoints, ",")
-	etcdCli, err := etcd.GetRemoteEtcdClient(etcdEndpoints)
+	etcdCli, err := etcd.GetRemoteEtcdClient(etcdEndpoints, 10*1024*1024)
 	assert.NoError(t, err)
 	defer etcdCli.Close()
 	etcdKV := tsoutil.NewTSOKVBase(etcdCli, "/test/root/kv", "tsoTest")
@@ -165,7 +165,7 @@ func TestGlobalTSOAllocator_Fail(t *testing.T) {
 		endpoints = "localhost:2379"
 	}
 	etcdEndpoints := strings.Split(endpoints, ",")
-	etcdCli, err := etcd.GetRemoteEtcdClient(etcdEndpoints)
+	etcdCli, err := etcd.GetRemoteEtcdClient(etcdEndpoints, 10*1024*1024)
 	assert.NoError(t, err)
 	defer etcdCli.Close()
 	etcdKV := tsoutil.NewTSOKVBase(etcdCli, "/test/root/kv", "tsoTest")
@@ -209,7 +209,7 @@ func TestGlobalTSOAllocator_Update(t *testing.T) {
 		endpoints = "localhost:2379"
 	}
 	etcdEndpoints := strings.Split(endpoints, ",")
-	etcdCli, err := etcd.GetRemoteEtcdClient(etcdEndpoints)
+	etcdCli, err := etcd.GetRemoteEtcdClient(etcdEndpoints, 10*1024*1024)
 	assert.NoError(t, err)
 	defer etcdCli.Close()
 	etcdKV := tsoutil.NewTSOKVBase(etcdCli, "/test/root/kv", "tsoTest")
@@ -234,7 +234,7 @@ func TestGlobalTSOAllocator_load(t *testing.T) {
 		endpoints = "localhost:2379"
 	}
 	etcdEndpoints := strings.Split(endpoints, ",")
-	etcdCli, err := etcd.GetRemoteEtcdClient(etcdEndpoints)
+	etcdCli, err := etcd.GetRemoteEtcdClient(etcdEndpoints, 10*1024*1024)
 	assert.NoError(t, err)
 	defer etcdCli.Close()
 	etcdKV := tsoutil.NewTSOKVBase(etcdCli, "/test/root/kv", "tsoTest")

--- a/internal/util/etcd/etcd_util.go
+++ b/internal/util/etcd/etcd_util.go
@@ -34,23 +34,25 @@ func GetEtcdClient(cfg *paramtable.EtcdConfig) (*clientv3.Client, error) {
 		return GetEmbedEtcdClient()
 	}
 	if cfg.EtcdUseSSL {
-		return GetRemoteEtcdSSLClient(cfg.Endpoints, cfg.EtcdTLSCert, cfg.EtcdTLSKey, cfg.EtcdTLSCACert, cfg.EtcdTLSMinVersion)
+		return GetRemoteEtcdSSLClient(cfg.Endpoints, cfg.MaxRequestBytes, cfg.EtcdTLSCert, cfg.EtcdTLSKey, cfg.EtcdTLSCACert, cfg.EtcdTLSMinVersion)
 	}
-	return GetRemoteEtcdClient(cfg.Endpoints)
+	return GetRemoteEtcdClient(cfg.Endpoints, cfg.MaxRequestBytes)
 }
 
 // GetRemoteEtcdClient returns client of remote etcd by given endpoints
-func GetRemoteEtcdClient(endpoints []string) (*clientv3.Client, error) {
+func GetRemoteEtcdClient(endpoints []string, maxReqBytes int) (*clientv3.Client, error) {
 	return clientv3.New(clientv3.Config{
-		Endpoints:   endpoints,
-		DialTimeout: 5 * time.Second,
+		Endpoints:          endpoints,
+		DialTimeout:        5 * time.Second,
+		MaxCallSendMsgSize: maxReqBytes,
 	})
 }
 
-func GetRemoteEtcdSSLClient(endpoints []string, certFile string, keyFile string, caCertFile string, minVersion string) (*clientv3.Client, error) {
+func GetRemoteEtcdSSLClient(endpoints []string, maxReqBytes int, certFile string, keyFile string, caCertFile string, minVersion string) (*clientv3.Client, error) {
 	var cfg clientv3.Config
 	cfg.Endpoints = endpoints
 	cfg.DialTimeout = 5 * time.Second
+	cfg.MaxCallSendMsgSize = maxReqBytes
 	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 	if err != nil {
 		return nil, errors.Wrap(err, "load etcd cert key pair error")

--- a/internal/util/paramtable/service_param.go
+++ b/internal/util/paramtable/service_param.go
@@ -64,6 +64,7 @@ type EtcdConfig struct {
 	Endpoints         []string
 	MetaRootPath      string
 	KvRootPath        string
+	MaxRequestBytes   int
 	EtcdLogLevel      string
 	EtcdLogPath       string
 	EtcdUseSSL        bool
@@ -91,6 +92,7 @@ func (p *EtcdConfig) LoadCfgToMemory() {
 	} else {
 		p.initEndpoints()
 	}
+	p.initMaxRequestBytes()
 	p.initMetaRootPath()
 	p.initKvRootPath()
 	p.initEtcdLogLevel()
@@ -149,6 +151,18 @@ func (p *EtcdConfig) initKvRootPath() {
 		panic(err)
 	}
 	p.KvRootPath = path.Join(rootPath, subPath)
+}
+
+func (p *EtcdConfig) initMaxRequestBytes() {
+	maxReqBytesStr, err := p.Base.Load("etcd.maxRequestBytes")
+	if err != nil {
+		panic(err)
+	}
+	maxRequestBytes, err := strconv.ParseInt(maxReqBytesStr, 10, 32)
+	if err != nil {
+		panic(err)
+	}
+	p.MaxRequestBytes = int(maxRequestBytes)
 }
 
 func (p *EtcdConfig) initEtcdLogLevel() {

--- a/internal/util/sessionutil/session_util_test.go
+++ b/internal/util/sessionutil/session_util_test.go
@@ -36,7 +36,7 @@ func TestGetServerIDConcurrently(t *testing.T) {
 	}
 
 	etcdEndpoints := strings.Split(endpoints, ",")
-	etcdCli, err := etcd.GetRemoteEtcdClient(etcdEndpoints)
+	etcdCli, err := etcd.GetRemoteEtcdClient(etcdEndpoints, 10*1024*1024)
 	require.NoError(t, err)
 	defer etcdCli.Close()
 	etcdKV := etcdkv.NewEtcdKV(etcdCli, metaRoot)
@@ -83,7 +83,7 @@ func TestInit(t *testing.T) {
 	metaRoot := fmt.Sprintf("%d/%s", rand.Int(), DefaultServiceRoot)
 
 	etcdEndpoints := strings.Split(endpoints, ",")
-	etcdCli, err := etcd.GetRemoteEtcdClient(etcdEndpoints)
+	etcdCli, err := etcd.GetRemoteEtcdClient(etcdEndpoints, 10*1024*1024)
 	require.NoError(t, err)
 	etcdKV := etcdkv.NewEtcdKV(etcdCli, metaRoot)
 	err = etcdKV.RemoveWithPrefix("")
@@ -113,7 +113,7 @@ func TestUpdateSessions(t *testing.T) {
 
 	etcdEndpoints := strings.Split(endpoints, ",")
 	metaRoot := fmt.Sprintf("%d/%s", rand.Int(), DefaultServiceRoot)
-	etcdCli, err := etcd.GetRemoteEtcdClient(etcdEndpoints)
+	etcdCli, err := etcd.GetRemoteEtcdClient(etcdEndpoints, 10*1024*1024)
 	require.NoError(t, err)
 	defer etcdCli.Close()
 	etcdKV := etcdkv.NewEtcdKV(etcdCli, "")
@@ -134,7 +134,7 @@ func TestUpdateSessions(t *testing.T) {
 	sList := []*Session{}
 
 	getIDFunc := func() {
-		etcdCli, err := etcd.GetRemoteEtcdClient(etcdEndpoints)
+		etcdCli, err := etcd.GetRemoteEtcdClient(etcdEndpoints, 10*1024*1024)
 		require.NoError(t, err)
 		singleS := NewSession(ctx, metaRoot, etcdCli)
 		singleS.Init("test", "testAddr", false, false)
@@ -230,7 +230,7 @@ func TestWatcherHandleWatchResp(t *testing.T) {
 	etcdEndpoints := strings.Split(endpoints, ",")
 	metaRoot := fmt.Sprintf("%d/%s", rand.Int(), DefaultServiceRoot)
 
-	etcdCli, err := etcd.GetRemoteEtcdClient(etcdEndpoints)
+	etcdCli, err := etcd.GetRemoteEtcdClient(etcdEndpoints, 10*1024*1024)
 	require.NoError(t, err)
 	defer etcdCli.Close()
 
@@ -377,7 +377,7 @@ func TestSessionRevoke(t *testing.T) {
 	metaRoot := fmt.Sprintf("%d/%s", rand.Int(), DefaultServiceRoot)
 
 	etcdEndpoints := strings.Split(endpoints, ",")
-	etcdCli, err := etcd.GetRemoteEtcdClient(etcdEndpoints)
+	etcdCli, err := etcd.GetRemoteEtcdClient(etcdEndpoints, 10*1024*1024)
 	defer etcdCli.Close()
 	require.NoError(t, err)
 	etcdKV := etcdkv.NewEtcdKV(etcdCli, metaRoot)


### PR DESCRIPTION
issue: #17233

1) Update Etcd request size limit (client side) from 2.0 MiB to 10 MiB in milvus.yaml
2) Update Etcd request size limit (server side) from 2.0 MiB to 10 MiB in Etcd config (in docker compose yaml files)
3) Update Etcd storage size limit from 2GiB to 8GiB (as suggested here: https://etcd.io/docs/v3.3/dev-guide/limit/) (in docker compose yaml files)

Signed-off-by: Yuchen Gao <yuchen.gao@zilliz.com>