### PR TITLE
Seek to latest when watch delta channel

### DIFF
--- a/internal/querynode/mock_msgstream_test.go
+++ b/internal/querynode/mock_msgstream_test.go
@@ -1,0 +1,90 @@
+package querynode
+
+import (
+	"errors"
+
+	"github.com/milvus-io/milvus/internal/proto/internalpb"
+
+	"github.com/milvus-io/milvus/internal/mq/msgstream"
+)
+
+type mockMessageID struct {
+	msgstream.MessageID
+	serialize          func() []byte
+	atEarliestPosition bool
+	lessOrEqualThan    func(msgID []byte) (bool, error)
+}
+
+func (m mockMessageID) Serialize() []byte {
+	if m.serialize != nil {
+		return m.serialize()
+	}
+	return nil
+}
+
+func (m mockMessageID) AtEarliestPosition() bool {
+	return m.atEarliestPosition
+}
+
+func (m mockMessageID) LessOrEqualThan(msgID []byte) (bool, error) {
+	if m.lessOrEqualThan != nil {
+		return m.lessOrEqualThan(msgID)
+	}
+	return false, errors.New("mock")
+}
+
+func newMockMessageID() *mockMessageID {
+	return &mockMessageID{}
+}
+
+type mockMsgStream struct {
+	msgstream.MsgStream
+	asProducer     func([]string)
+	asConsumer     func([]string, string)
+	seek           func([]*internalpb.MsgPosition) error
+	setRepack      func(repackFunc msgstream.RepackFunc)
+	getLatestMsgID func(channel string) (msgstream.MessageID, error)
+	close          func()
+}
+
+func (m *mockMsgStream) AsProducer(producers []string) {
+	if m.asProducer != nil {
+		m.asProducer(producers)
+	}
+}
+
+func (m *mockMsgStream) AsConsumer(consumers []string, subName string) {
+	if m.asConsumer != nil {
+		m.asConsumer(consumers, subName)
+	}
+}
+
+func (m *mockMsgStream) Seek(position []*internalpb.MsgPosition) error {
+	if m.seek != nil {
+		return m.seek(position)
+	}
+	return errors.New("mock")
+}
+
+func (m *mockMsgStream) SetRepackFunc(repackFunc msgstream.RepackFunc) {
+	if m.setRepack != nil {
+		m.setRepack(repackFunc)
+	}
+}
+
+func (m *mockMsgStream) GetLatestMsgID(channel string) (msgstream.MessageID, error) {
+	if m.getLatestMsgID != nil {
+		return m.getLatestMsgID(channel)
+	}
+	return nil, errors.New("mock")
+}
+
+func (m *mockMsgStream) Close() {
+	if m.close != nil {
+		m.close()
+	}
+}
+
+func newMockMsgStream() *mockMsgStream {
+	return &mockMsgStream{}
+}

--- a/internal/querynode/task.go
+++ b/internal/querynode/task.go
@@ -432,7 +432,7 @@ func (w *watchDeltaChannelsTask) Execute(ctx context.Context) error {
 	// channels as consumer
 	for channel, fg := range channel2FlowGraph {
 		// use pChannel to consume
-		err = fg.consumeFlowGraphFromLatest(VPDeltaChannels[channel], consumeSubName)
+		err = fg.seekToLatest(VPDeltaChannels[channel], consumeSubName)
 		if err != nil {
 			log.Error("msgStream as consumer failed for deltaChannels", zap.Int64("collectionID", collectionID), zap.Strings("vDeltaChannels", vDeltaChannels))
 			break


### PR DESCRIPTION
When we think a collection is loaded, it's related delta channel should be watched by querynode.
However, when we start flow graph of the delta channel, the consumption of delta topic is asynchronous.
When the upstream began to produce message, the consumers of related delta channel didn't even establish the
connection to the topic, so after the delta consumer began to consume delete message from latest position,
the message produced before will be lost in flow graph.
This pr will fix this issue by letting flowgraph seek to latest position of delta channel.
By seeking to this position, the later message produced won't be lost by delta flowgraph.

Signed-off-by: longjiquan <jiquan.long@zilliz.com>
issue: #17178 #17176 