### PR TITLE
Upgrade lint version for fixing fails on latest ubuntu-20 image

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout Milvus
         uses: actions/checkout@v1
       - name: Check Dockerfile
-        uses: reviewdog/action-hadolint@v1.16.1
+        uses: reviewdog/action-hadolint@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-check # Default is github-pr-check


### PR DESCRIPTION
Signed-off-by: Jenny Li <jing.li@zilliz.com>
/kind improvement
folllow the solution under https://github.com/reviewdog/action-hadolint/issues/54 to fix the action runner on ubuntu 