### PR TITLE
Sync grpc DefaultKeepAliveTimeout to milvus.yaml

### DIFF
--- a/internal/util/paramtable/grpc_param.go
+++ b/internal/util/paramtable/grpc_param.go
@@ -41,7 +41,7 @@ const (
 	// Grpc Timeout related configs
 	DefaultDialTimeout      = 5000 * time.Millisecond
 	DefaultKeepAliveTime    = 10000 * time.Millisecond
-	DefaultKeepAliveTimeout = 3000 * time.Millisecond
+	DefaultKeepAliveTimeout = 20000 * time.Millisecond
 
 	ProxyInternalPort = 19529
 	ProxyExternalPort = 19530


### PR DESCRIPTION
Fix #17518 

/kind bug

Signed-off-by: Congqi Xia <congqi.xia@zilliz.com>