### PR TITLE
Add BindContext function for querycoord task scheduler

### DIFF
--- a/internal/querycoord/task.go
+++ b/internal/querycoord/task.go
@@ -99,6 +99,7 @@ type task interface {
 	getResultInfo() *commonpb.Status
 	updateTaskProcess()
 	elapseSpan() time.Duration
+	finishContext()
 }
 
 type baseTask struct {
@@ -296,6 +297,13 @@ func (bt *baseTask) rollBack(ctx context.Context) []task {
 
 func (bt *baseTask) elapseSpan() time.Duration {
 	return bt.timeRecorder.ElapseSpan()
+}
+
+// finishContext calls the cancel function for the trace ctx.
+func (bt *baseTask) finishContext() {
+	if bt.cancel != nil {
+		bt.cancel()
+	}
 }
 
 type loadCollectionTask struct {


### PR DESCRIPTION
Add `BindContext` to merge task and scheduler context cancel
Allows task context to be canceled if the querycoord is about to stop

Fix #17237

Signed-off-by: Congqi Xia <congqi.xia@zilliz.com>