### PR TITLE
Fix Delta log loss after compaction

### DIFF
--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -795,7 +795,7 @@ func (m *meta) CompleteMergeCompaction(compactionLogs []*datapb.CompactionSegmen
 
 	var startPosition, dmlPosition *internalpb.MsgPosition
 	for _, s := range segments {
-		if dmlPosition == nil || s.GetDmlPosition().Timestamp > dmlPosition.Timestamp {
+		if dmlPosition == nil || s.GetDmlPosition().Timestamp < dmlPosition.Timestamp {
 			dmlPosition = s.GetDmlPosition()
 		}
 


### PR DESCRIPTION
related #17625
If multiple segment compact to one segment, we pick earliest check point of all segments as the compacted result checkpoint.
Signed-off-by: xiaofan-luan <xiaofan.luan@zilliz.com>