### PR TITLE
QueryCoord holds segment lock while processing handoff

### DIFF
--- a/internal/querycoord/global_meta_broker.go
+++ b/internal/querycoord/global_meta_broker.go
@@ -189,7 +189,7 @@ func (broker *globalMetaBroker) getIndexFilePaths(ctx context.Context, buildID i
 
 	if pathResponse.Status.ErrorCode != commonpb.ErrorCode_Success {
 		err = fmt.Errorf("get index info from indexCoord failed, buildID = %d, reason = %s", buildID, pathResponse.Status.Reason)
-		log.Error(err.Error())
+		log.RatedInfo(10, err.Error())
 		return nil, err
 	}
 	log.Info("get index info from indexCoord successfully", zap.Int64("buildID", buildID))


### PR DESCRIPTION
This PR does the following:
* Revert #17619 
* Make QueryCoord hold segment lock while processing handoff

Fix #17567 

Signed-off-by: Letian Jiang <letian.jiang@zilliz.com>