### PR TITLE
Remove temporary variable to prevent memory fragmentation

### DIFF
--- a/internal/core/src/segcore/SegmentInterface.cpp
+++ b/internal/core/src/segcore/SegmentInterface.cpp
@@ -32,9 +32,7 @@ SegmentInternalInterface::FillPrimaryKeys(const query::Plan* plan, SearchResult&
     auto field_data = bulk_subscript(pk_field_id, results.seg_offsets_.data(), size);
     results.pk_type_ = DataType(field_data->type());
 
-    std::vector<PkType> pks(size);
-    ParsePksFromFieldData(pks, *field_data.get());
-    results.primary_keys_ = std::move(pks);
+    ParsePksFromFieldData(results.primary_keys_, *field_data.get());
 }
 
 void


### PR DESCRIPTION
Signed-off-by: bigsheeper <yihao.dai@zilliz.com>

/kind improvement

By testing, this temporary variable would lead to about **80%** memory fragmentation during reducing search result,
here is the testing code: https://github.com/bigsheeper/milvus/commit/a26780c83d0c4bdb2001654812a916ea599753f4