### PR TITLE
Fix double-freed global variable in easylogging lib

### DIFF
--- a/internal/core/CMakeLists.txt
+++ b/internal/core/CMakeLists.txt
@@ -16,6 +16,15 @@
 
 cmake_minimum_required( VERSION 3.18 )
 
+# To debug memory issues, you can comment out these below two lines.
+# Also, they are identical to that you define these environments:
+# CFLAGS="-fno-stack-protector -fno-omit-frame-pointer -fno-var-tracking -fsanitize=address"
+# CXXFLAGS="-fno-stack-protector -fno-omit-frame-pointer -fno-var-tracking -fsanitize=address"
+# LDFLAGS="-fno-stack-protector -fno-omit-frame-pointer -fno-var-tracking -fsanitize=address"
+
+# add_compile_options(-fno-stack-protector -fno-omit-frame-pointer -fno-var-tracking -fsanitize=address)
+# add_link_options(-fno-stack-protector -fno-omit-frame-pointer -fno-var-tracking -fsanitize=address)
+
 if ( APPLE )
     set( CMAKE_CROSSCOMPILING TRUE )
     set( RUN_HAVE_GNU_POSIX_REGEX 0 )

--- a/internal/core/src/log/CMakeLists.txt
+++ b/internal/core/src/log/CMakeLists.txt
@@ -12,8 +12,8 @@
 #-------------------------------------------------------------------------------
 set(LOG_FILES   ${MILVUS_ENGINE_SRC}/log/Log.cpp
                 ${MILVUS_ENGINE_SRC}/log/Log.h
-                ${MILVUS_THIRDPARTY_SRC}/easyloggingpp/easylogging++.cc
-                ${MILVUS_THIRDPARTY_SRC}/easyloggingpp/easylogging++.h
+                #${MILVUS_THIRDPARTY_SRC}/easyloggingpp/easylogging++.cc
+                #${MILVUS_THIRDPARTY_SRC}/easyloggingpp/easylogging++.h
                 )
 
 add_library(milvus_log STATIC ${LOG_FILES})

--- a/internal/core/src/log/Log.cpp
+++ b/internal/core/src/log/Log.cpp
@@ -15,7 +15,14 @@
 // limitations under the License.
 
 #include "log/Log.h"
-INITIALIZE_EASYLOGGINGPP
+
+/*
+ * INITIALIZE_EASYLOGGINGPP will create a global variable whose name is same to that already created in knowhere,
+ * which will lead a `double-free` bug when the program exits.
+ * For why this issue happened please refer to
+ * https://gcc-help.gcc.gnu.narkive.com/KZGaXRNr/global-variable-in-static-library-double-free-or-corruption-error.
+ */
+// INITIALIZE_EASYLOGGINGPP
 
 #ifdef WIN32
 #include <Windows.h>


### PR DESCRIPTION
Signed-off-by: longjiquan <jiquan.long@zilliz.com>
/kind bug
issue: #17639 