### PR TITLE
Remove the `WithOptions` for avoiding the log object being cloned continuously

### DIFF
--- a/internal/log/global.go
+++ b/internal/log/global.go
@@ -21,25 +21,25 @@ import (
 // Debug logs a message at DebugLevel. The message includes any fields passed
 // at the log site, as well as any fields accumulated on the logger.
 func Debug(msg string, fields ...zap.Field) {
-	L().WithOptions(zap.AddCallerSkip(1)).Debug(msg, fields...)
+	L().Debug(msg, fields...)
 }
 
 // Info logs a message at InfoLevel. The message includes any fields passed
 // at the log site, as well as any fields accumulated on the logger.
 func Info(msg string, fields ...zap.Field) {
-	L().WithOptions(zap.AddCallerSkip(1)).Info(msg, fields...)
+	L().Info(msg, fields...)
 }
 
 // Warn logs a message at WarnLevel. The message includes any fields passed
 // at the log site, as well as any fields accumulated on the logger.
 func Warn(msg string, fields ...zap.Field) {
-	L().WithOptions(zap.AddCallerSkip(1)).Warn(msg, fields...)
+	L().Warn(msg, fields...)
 }
 
 // Error logs a message at ErrorLevel. The message includes any fields passed
 // at the log site, as well as any fields accumulated on the logger.
 func Error(msg string, fields ...zap.Field) {
-	L().WithOptions(zap.AddCallerSkip(1)).Error(msg, fields...)
+	L().Error(msg, fields...)
 }
 
 // Panic logs a message at PanicLevel. The message includes any fields passed
@@ -47,7 +47,7 @@ func Error(msg string, fields ...zap.Field) {
 //
 // The logger then panics, even if logging at PanicLevel is disabled.
 func Panic(msg string, fields ...zap.Field) {
-	L().WithOptions(zap.AddCallerSkip(1)).Panic(msg, fields...)
+	L().Panic(msg, fields...)
 }
 
 // Fatal logs a message at FatalLevel. The message includes any fields passed
@@ -56,7 +56,7 @@ func Panic(msg string, fields ...zap.Field) {
 // The logger then calls os.Exit(1), even if logging at FatalLevel is
 // disabled.
 func Fatal(msg string, fields ...zap.Field) {
-	L().WithOptions(zap.AddCallerSkip(1)).Fatal(msg, fields...)
+	L().Fatal(msg, fields...)
 }
 
 // RatedDebug print logs at debug level
@@ -64,7 +64,7 @@ func Fatal(msg string, fields ...zap.Field) {
 // return true if log successfully
 func RatedDebug(cost float64, msg string, fields ...zap.Field) bool {
 	if R().CheckCredit(cost) {
-		L().WithOptions(zap.AddCallerSkip(1)).Debug(msg, fields...)
+		L().Debug(msg, fields...)
 		return true
 	}
 	return false
@@ -75,7 +75,7 @@ func RatedDebug(cost float64, msg string, fields ...zap.Field) bool {
 // return true if log successfully
 func RatedInfo(cost float64, msg string, fields ...zap.Field) bool {
 	if R().CheckCredit(cost) {
-		L().WithOptions(zap.AddCallerSkip(1)).Info(msg, fields...)
+		L().Info(msg, fields...)
 		return true
 	}
 	return false
@@ -86,7 +86,7 @@ func RatedInfo(cost float64, msg string, fields ...zap.Field) bool {
 // return true if log successfully
 func RatedWarn(cost float64, msg string, fields ...zap.Field) bool {
 	if R().CheckCredit(cost) {
-		L().WithOptions(zap.AddCallerSkip(1)).Warn(msg, fields...)
+		L().Warn(msg, fields...)
 		return true
 	}
 	return false
@@ -95,7 +95,7 @@ func RatedWarn(cost float64, msg string, fields ...zap.Field) bool {
 // With creates a child logger and adds structured context to it.
 // Fields added to the child don't affect the parent, and vice versa.
 func With(fields ...zap.Field) *zap.Logger {
-	return L().WithOptions(zap.AddCallerSkip(1)).With(fields...)
+	return L().With(fields...)
 }
 
 // SetLevel alters the logging level.

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -33,6 +33,7 @@ package log
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"testing"
 	"time"
 
@@ -44,7 +45,7 @@ import (
 func TestExport(t *testing.T) {
 	ts := newTestLogSpy(t)
 	conf := &Config{Level: "debug", DisableTimestamp: true}
-	logger, _, _ := InitTestLogger(ts, conf)
+	logger, _, _ := InitTestLogger(ts, conf, zap.AddCallerSkip(1))
 	ReplaceGlobals(logger, nil)
 
 	Info("Testing")
@@ -53,6 +54,7 @@ func TestExport(t *testing.T) {
 	Error("Testing")
 	Sync()
 	ts.assertMessagesContains("log_test.go:")
+	logPanic()
 
 	ts = newTestLogSpy(t)
 	logger, _, _ = InitTestLogger(ts, conf)
@@ -64,6 +66,15 @@ func TestExport(t *testing.T) {
 	Sync()
 	ts.assertMessagesContains(`name=tester`)
 	ts.assertMessagesContains(`age=42`)
+}
+
+func logPanic() {
+	defer func() {
+		if err := recover(); err != nil {
+			fmt.Println("logPanic recover")
+		}
+	}()
+	Panic("Testing")
 }
 
 func TestZapTextEncoder(t *testing.T) {

--- a/internal/util/logutil/logutil.go
+++ b/internal/util/logutil/logutil.go
@@ -46,68 +46,68 @@ type zapWrapper struct {
 // Info logs a message at InfoLevel.
 func (w *zapWrapper) Info(args ...interface{}) {
 	if infoLog >= w.logLevel {
-		w.logger.WithOptions(zap.AddCallerSkip(1)).Sugar().Info(args...)
+		w.logger.Sugar().Info(args...)
 	}
 }
 
 func (w *zapWrapper) Infoln(args ...interface{}) {
 	if infoLog >= w.logLevel {
-		w.logger.WithOptions(zap.AddCallerSkip(1)).Sugar().Info(args...)
+		w.logger.Sugar().Info(args...)
 	}
 }
 
 func (w zapWrapper) Infof(format string, args ...interface{}) {
 	if infoLog >= w.logLevel {
-		w.logger.WithOptions(zap.AddCallerSkip(1)).Sugar().Infof(format, args...)
+		w.logger.Sugar().Infof(format, args...)
 	}
 }
 
 func (w zapWrapper) Warning(args ...interface{}) {
 	if warningLog >= w.logLevel {
-		w.logger.WithOptions(zap.AddCallerSkip(1)).Sugar().Warn(args...)
+		w.logger.Sugar().Warn(args...)
 	}
 }
 
 func (w zapWrapper) Warningln(args ...interface{}) {
 	if warningLog >= w.logLevel {
-		w.logger.WithOptions(zap.AddCallerSkip(1)).Sugar().Warn(args...)
+		w.logger.Sugar().Warn(args...)
 	}
 }
 
 func (w *zapWrapper) Warningf(format string, args ...interface{}) {
 	if warningLog >= w.logLevel {
-		w.logger.WithOptions(zap.AddCallerSkip(1)).Sugar().Warnf(format, args...)
+		w.logger.Sugar().Warnf(format, args...)
 	}
 }
 
 func (w zapWrapper) Error(args ...interface{}) {
 	if errorLog >= w.logLevel {
-		w.logger.WithOptions(zap.AddCallerSkip(1)).Sugar().Error(args...)
+		w.logger.Sugar().Error(args...)
 	}
 }
 
 func (w *zapWrapper) Errorln(args ...interface{}) {
 	if errorLog >= w.logLevel {
-		w.logger.WithOptions(zap.AddCallerSkip(1)).Sugar().Error(args...)
+		w.logger.Sugar().Error(args...)
 	}
 }
 
 func (w zapWrapper) Errorf(format string, args ...interface{}) {
 	if errorLog >= w.logLevel {
-		w.logger.WithOptions(zap.AddCallerSkip(1)).Sugar().Errorf(format, args...)
+		w.logger.Sugar().Errorf(format, args...)
 	}
 }
 
 func (w *zapWrapper) Fatal(args ...interface{}) {
-	w.logger.WithOptions(zap.AddCallerSkip(1)).Sugar().Fatal(args...)
+	w.logger.Sugar().Fatal(args...)
 }
 
 func (w zapWrapper) Fatalln(args ...interface{}) {
-	w.logger.WithOptions(zap.AddCallerSkip(1)).Sugar().Fatal(args...)
+	w.logger.Sugar().Fatal(args...)
 }
 
 func (w *zapWrapper) Fatalf(format string, args ...interface{}) {
-	w.logger.WithOptions(zap.AddCallerSkip(1)).Sugar().Fatalf(format, args...)
+	w.logger.Sugar().Fatalf(format, args...)
 }
 
 // V reports whether verbosity level l is at least the requested verbose level.
@@ -141,7 +141,7 @@ var once sync.Once
 func SetupLogger(cfg *log.Config) {
 	once.Do(func() {
 		// Initialize logger.
-		logger, p, err := log.InitLogger(cfg, zap.AddStacktrace(zap.ErrorLevel))
+		logger, p, err := log.InitLogger(cfg, zap.AddStacktrace(zap.ErrorLevel), zap.AddCallerSkip(1))
 		if err == nil {
 			log.ReplaceGlobals(logger, p)
 		} else {

--- a/internal/util/logutil/logutil_test.go
+++ b/internal/util/logutil/logutil_test.go
@@ -1,0 +1,32 @@
+package logutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.uber.org/zap/zapcore"
+
+	"github.com/milvus-io/milvus/internal/log"
+	"go.uber.org/zap"
+)
+
+func TestName(t *testing.T) {
+	conf := &log.Config{Level: "debug", DisableTimestamp: true}
+	logger, _, _ := log.InitTestLogger(t, conf, zap.AddCallerSkip(1), zap.Hooks(func(entry zapcore.Entry) error {
+		assert.Equal(t, "Testing", entry.Message)
+		return nil
+	}))
+	wrapper := &zapWrapper{logger, 0}
+
+	wrapper.Info("Testing")
+	wrapper.Infoln("Testing")
+	wrapper.Infof("%s", "Testing")
+	wrapper.Warning("Testing")
+	wrapper.Warningln("Testing")
+	wrapper.Warningf("%s", "Testing")
+	wrapper.Error("Testing")
+	wrapper.Errorln("Testing")
+	wrapper.Errorf("%s", "Testing")
+
+}


### PR DESCRIPTION
fix #17745
merge to the 2.1.0 branch

Signed-off-by: SimFG <bang.fu@zilliz.com>