### PR TITLE
Add logger in ctx in order to trace logs between rpc calls

### DIFF
--- a/cmd/roles/roles.go
+++ b/cmd/roles/roles.go
@@ -48,7 +48,6 @@ import (
 	"github.com/milvus-io/milvus/internal/rootcoord"
 	"github.com/milvus-io/milvus/internal/util/etcd"
 	"github.com/milvus-io/milvus/internal/util/healthz"
-	"github.com/milvus-io/milvus/internal/util/logutil"
 	"github.com/milvus-io/milvus/internal/util/metricsinfo"
 	"github.com/milvus-io/milvus/internal/util/paramtable"
 	"github.com/milvus-io/milvus/internal/util/trace"
@@ -238,7 +237,7 @@ func (mr *MilvusRoles) runDataCoord(ctx context.Context, localMsg bool) *compone
 
 		factory := dependency.NewFactory(localMsg)
 
-		dctx := logutil.WithModule(ctx, "DataCoord")
+		dctx := log.WithModule(ctx, "DataCoord")
 		var err error
 		ds, err = components.NewDataCoord(dctx, factory)
 		if err != nil {
@@ -403,7 +402,7 @@ func (mr *MilvusRoles) Run(local bool, alias string) {
 
 	var pn *components.Proxy
 	if mr.EnableProxy {
-		pctx := logutil.WithModule(ctx, "Proxy")
+		pctx := log.WithModule(ctx, "Proxy")
 		pn = mr.runProxy(pctx, local, alias)
 		if pn != nil {
 			defer pn.Stop()

--- a/internal/datacoord/cluster.go
+++ b/internal/datacoord/cluster.go
@@ -99,7 +99,7 @@ func (c *Cluster) Flush(ctx context.Context, segments []*datapb.SegmentInfo, mar
 		collectionID = segment.CollectionID
 		nodeID, ok := channelNodes[segment.GetInsertChannel()]
 		if !ok {
-			log.Warn("channel is not allocated to any node", zap.String("channel", segment.GetInsertChannel()))
+			log.Ctx(ctx).Warn("channel is not allocated to any node", zap.String("channel", segment.GetInsertChannel()))
 			continue
 		}
 		nodeSegments[nodeID] = append(nodeSegments[nodeID], segment.GetID())
@@ -109,7 +109,7 @@ func (c *Cluster) Flush(ctx context.Context, segments []*datapb.SegmentInfo, mar
 		collectionID = segment.CollectionID
 		nodeID, ok := channelNodes[segment.GetInsertChannel()]
 		if !ok {
-			log.Warn("channel is not allocated to any node", zap.String("channel", segment.GetInsertChannel()))
+			log.Ctx(ctx).Warn("channel is not allocated to any node", zap.String("channel", segment.GetInsertChannel()))
 			continue
 		}
 		nodeMarks[nodeID] = append(nodeMarks[nodeID], segment.GetID())
@@ -131,7 +131,7 @@ func (c *Cluster) Flush(ctx context.Context, segments []*datapb.SegmentInfo, mar
 			SegmentIDs:     segments,
 			MarkSegmentIDs: marks,
 		}
-		log.Info("calling dataNode to flush",
+		log.Ctx(ctx).Info("calling dataNode to flush",
 			zap.Int64("dataNode ID", nodeID),
 			zap.Int64s("segments", segments),
 			zap.Int64s("marks", marks))

--- a/internal/datacoord/metrics_info.go
+++ b/internal/datacoord/metrics_info.go
@@ -44,12 +44,12 @@ func (s *Server) getSystemInfoMetrics(
 	}
 
 	// for each data node, fetch metrics info
-	log.Debug("datacoord.getSystemInfoMetrics",
+	log.Ctx(ctx).Debug("datacoord.getSystemInfoMetrics",
 		zap.Int("DataNodes number", len(nodes)))
 	for _, node := range nodes {
 		infos, err := s.getDataNodeMetrics(ctx, req, node)
 		if err != nil {
-			log.Warn("fails to get DataNode metrics", zap.Error(err))
+			log.Ctx(ctx).Warn("fails to get DataNode metrics", zap.Error(err))
 			continue
 		}
 		clusterTopology.ConnectedNodes = append(clusterTopology.ConnectedNodes, infos)
@@ -133,7 +133,7 @@ func (s *Server) getDataNodeMetrics(ctx context.Context, req *milvuspb.GetMetric
 
 	metrics, err := cli.GetMetrics(ctx, req)
 	if err != nil {
-		log.Warn("invalid metrics of DataNode was found",
+		log.Ctx(ctx).Warn("invalid metrics of DataNode was found",
 			zap.Error(err))
 		infos.BaseComponentInfos.ErrorReason = err.Error()
 		// err handled, returns nil
@@ -142,7 +142,7 @@ func (s *Server) getDataNodeMetrics(ctx context.Context, req *milvuspb.GetMetric
 	infos.BaseComponentInfos.Name = metrics.GetComponentName()
 
 	if metrics.GetStatus().GetErrorCode() != commonpb.ErrorCode_Success {
-		log.Warn("invalid metrics of DataNode was found",
+		log.Ctx(ctx).Warn("invalid metrics of DataNode was found",
 			zap.Any("error_code", metrics.Status.ErrorCode),
 			zap.Any("error_reason", metrics.Status.Reason))
 		infos.BaseComponentInfos.ErrorReason = metrics.GetStatus().GetReason()
@@ -151,7 +151,7 @@ func (s *Server) getDataNodeMetrics(ctx context.Context, req *milvuspb.GetMetric
 
 	err = metricsinfo.UnmarshalComponentInfos(metrics.GetResponse(), &infos)
 	if err != nil {
-		log.Warn("invalid metrics of DataNode found",
+		log.Ctx(ctx).Warn("invalid metrics of DataNode found",
 			zap.Error(err))
 		infos.BaseComponentInfos.ErrorReason = err.Error()
 		return infos, nil

--- a/internal/datacoord/segment_manager.go
+++ b/internal/datacoord/segment_manager.go
@@ -233,7 +233,7 @@ func (s *SegmentManager) AllocSegment(ctx context.Context, collectionID UniqueID
 	for _, segmentID := range s.segments {
 		segment := s.meta.GetSegment(segmentID)
 		if segment == nil {
-			log.Warn("Failed to get seginfo from meta", zap.Int64("id", segmentID))
+			log.Ctx(ctx).Warn("Failed to get seginfo from meta", zap.Int64("id", segmentID))
 			continue
 		}
 		if !satisfy(segment, collectionID, partitionID, channelName) || !isGrowing(segment) {
@@ -380,7 +380,7 @@ func (s *SegmentManager) openNewSegment(ctx context.Context, collectionID Unique
 		return nil, err
 	}
 	s.segments = append(s.segments, id)
-	log.Info("datacoord: estimateTotalRows: ",
+	log.Ctx(ctx).Info("datacoord: estimateTotalRows: ",
 		zap.Int64("CollectionID", segmentInfo.CollectionID),
 		zap.Int64("SegmentID", segmentInfo.ID),
 		zap.Int("Rows", maxNumOfRows),
@@ -411,7 +411,7 @@ func (s *SegmentManager) DropSegment(ctx context.Context, segmentID UniqueID) {
 	}
 	segment := s.meta.GetSegment(segmentID)
 	if segment == nil {
-		log.Warn("Failed to get segment", zap.Int64("id", segmentID))
+		log.Ctx(ctx).Warn("Failed to get segment", zap.Int64("id", segmentID))
 		return
 	}
 	s.meta.SetAllocations(segmentID, []*Allocation{})
@@ -434,7 +434,7 @@ func (s *SegmentManager) SealAllSegments(ctx context.Context, collectionID Uniqu
 	for _, id := range segCandidates {
 		info := s.meta.GetSegment(id)
 		if info == nil {
-			log.Warn("failed to get seg info from meta", zap.Int64("segment ID", id))
+			log.Ctx(ctx).Warn("failed to get seg info from meta", zap.Int64("segment ID", id))
 			continue
 		}
 		if info.CollectionID != collectionID {

--- a/internal/datacoord/session_manager.go
+++ b/internal/datacoord/session_manager.go
@@ -115,7 +115,7 @@ func (c *SessionManager) Flush(ctx context.Context, nodeID int64, req *datapb.Fl
 func (c *SessionManager) execFlush(ctx context.Context, nodeID int64, req *datapb.FlushSegmentsRequest) {
 	cli, err := c.getClient(ctx, nodeID)
 	if err != nil {
-		log.Warn("failed to get dataNode client", zap.Int64("dataNode ID", nodeID), zap.Error(err))
+		log.Ctx(ctx).Warn("failed to get dataNode client", zap.Int64("dataNode ID", nodeID), zap.Error(err))
 		return
 	}
 	ctx, cancel := context.WithTimeout(ctx, flushTimeout)
@@ -123,9 +123,9 @@ func (c *SessionManager) execFlush(ctx context.Context, nodeID int64, req *datap
 
 	resp, err := cli.FlushSegments(ctx, req)
 	if err := VerifyResponse(resp, err); err != nil {
-		log.Error("flush call (perhaps partially) failed", zap.Int64("dataNode ID", nodeID), zap.Error(err))
+		log.Ctx(ctx).Error("flush call (perhaps partially) failed", zap.Int64("dataNode ID", nodeID), zap.Error(err))
 	} else {
-		log.Info("flush call succeeded", zap.Int64("dataNode ID", nodeID))
+		log.Ctx(ctx).Info("flush call succeeded", zap.Int64("dataNode ID", nodeID))
 	}
 }
 
@@ -161,18 +161,18 @@ func (c *SessionManager) Import(ctx context.Context, nodeID int64, itr *datapb.I
 func (c *SessionManager) execImport(ctx context.Context, nodeID int64, itr *datapb.ImportTaskRequest) {
 	cli, err := c.getClient(ctx, nodeID)
 	if err != nil {
-		log.Warn("failed to get client for import", zap.Int64("nodeID", nodeID), zap.Error(err))
+		log.Ctx(ctx).Warn("failed to get client for import", zap.Int64("nodeID", nodeID), zap.Error(err))
 		return
 	}
 	ctx, cancel := context.WithTimeout(ctx, importTimeout)
 	defer cancel()
 	resp, err := cli.Import(ctx, itr)
 	if err := VerifyResponse(resp, err); err != nil {
-		log.Warn("failed to import", zap.Int64("node", nodeID), zap.Error(err))
+		log.Ctx(ctx).Warn("failed to import", zap.Int64("node", nodeID), zap.Error(err))
 		return
 	}
 
-	log.Info("success to import", zap.Int64("node", nodeID), zap.Any("import task", itr))
+	log.Ctx(ctx).Info("success to import", zap.Int64("node", nodeID), zap.Any("import task", itr))
 }
 
 // ReCollectSegmentStats collects segment stats info from DataNodes, after DataCoord reboots.
@@ -183,7 +183,7 @@ func (c *SessionManager) ReCollectSegmentStats(ctx context.Context, nodeID int64
 func (c *SessionManager) execReCollectSegmentStats(ctx context.Context, nodeID int64) {
 	cli, err := c.getClient(ctx, nodeID)
 	if err != nil {
-		log.Warn("failed to get dataNode client", zap.Int64("DataNode ID", nodeID), zap.Error(err))
+		log.Ctx(ctx).Warn("failed to get dataNode client", zap.Int64("DataNode ID", nodeID), zap.Error(err))
 		return
 	}
 	ctx, cancel := context.WithTimeout(ctx, reCollectTimeout)
@@ -195,10 +195,10 @@ func (c *SessionManager) execReCollectSegmentStats(ctx context.Context, nodeID i
 		},
 	})
 	if err := VerifyResponse(resp, err); err != nil {
-		log.Error("re-collect segment stats call failed",
+		log.Ctx(ctx).Error("re-collect segment stats call failed",
 			zap.Int64("DataNode ID", nodeID), zap.Error(err))
 	} else {
-		log.Info("re-collect segment stats call succeeded",
+		log.Ctx(ctx).Info("re-collect segment stats call succeeded",
 			zap.Int64("DataNode ID", nodeID),
 			zap.Int64s("segment stat collected", resp.GetSegResent()))
 	}
@@ -212,7 +212,7 @@ func (c *SessionManager) AddSegment(ctx context.Context, nodeID int64, req *data
 func (c *SessionManager) execAddSegment(ctx context.Context, nodeID int64, req *datapb.AddSegmentRequest) {
 	cli, err := c.getClient(ctx, nodeID)
 	if err != nil {
-		log.Warn("failed to get client for AddSegment", zap.Int64("DataNode ID", nodeID), zap.Error(err))
+		log.Ctx(ctx).Warn("failed to get client for AddSegment", zap.Int64("DataNode ID", nodeID), zap.Error(err))
 		return
 	}
 	ctx, cancel := context.WithTimeout(ctx, addSegmentTimeout)
@@ -220,11 +220,11 @@ func (c *SessionManager) execAddSegment(ctx context.Context, nodeID int64, req *
 	req.Base.SourceID = Params.DataCoordCfg.GetNodeID()
 	resp, err := cli.AddSegment(ctx, req)
 	if err := VerifyResponse(resp, err); err != nil {
-		log.Warn("failed to add segment", zap.Int64("DataNode ID", nodeID), zap.Error(err))
+		log.Ctx(ctx).Warn("failed to add segment", zap.Int64("DataNode ID", nodeID), zap.Error(err))
 		return
 	}
 
-	log.Info("success to add segment", zap.Int64("DataNode ID", nodeID), zap.Any("add segment req", req))
+	log.Ctx(ctx).Info("success to add segment", zap.Int64("DataNode ID", nodeID), zap.Any("add segment req", req))
 }
 
 func (c *SessionManager) getClient(ctx context.Context, nodeID int64) (types.DataNode, error) {

--- a/internal/datanode/binlog_io.go
+++ b/internal/datanode/binlog_io.go
@@ -124,7 +124,7 @@ func (b *binlogIO) upload(
 	for _, iData := range iDatas {
 		tf, ok := iData.Data[common.TimeStampField]
 		if !ok || tf.RowNum() == 0 {
-			log.Warn("binlog io uploading empty insert data",
+			log.Ctx(ctx).Warn("binlog io uploading empty insert data",
 				zap.Int64("segmentID", segID),
 				zap.Int64("collectionID", meta.GetID()),
 			)
@@ -133,7 +133,7 @@ func (b *binlogIO) upload(
 
 		kv, inpaths, statspaths, err := b.genInsertBlobs(iData, partID, segID, meta)
 		if err != nil {
-			log.Warn("generate insert blobs wrong",
+			log.Ctx(ctx).Warn("generate insert blobs wrong",
 				zap.Int64("collectionID", meta.GetID()),
 				zap.Int64("segmentID", segID),
 				zap.Error(err))
@@ -177,7 +177,7 @@ func (b *binlogIO) upload(
 	if dData.RowCount > 0 {
 		k, v, err := b.genDeltaBlobs(dData, meta.GetID(), partID, segID)
 		if err != nil {
-			log.Warn("generate delta blobs wrong",
+			log.Ctx(ctx).Warn("generate delta blobs wrong",
 				zap.Int64("collectionID", meta.GetID()),
 				zap.Int64("segmentID", segID),
 				zap.Error(err))
@@ -199,14 +199,14 @@ func (b *binlogIO) upload(
 	for err != nil {
 		select {
 		case <-ctx.Done():
-			log.Warn("ctx done when saving kvs to blob storage",
+			log.Ctx(ctx).Warn("ctx done when saving kvs to blob storage",
 				zap.Int64("collectionID", meta.GetID()),
 				zap.Int64("segmentID", segID),
 				zap.Int("number of kvs", len(kvs)))
 			return nil, errUploadToBlobStorage
 		default:
 			if err != errStart {
-				log.Warn("save binlog failed, retry in 50ms",
+				log.Ctx(ctx).Warn("save binlog failed, retry in 50ms",
 					zap.Int64("collectionID", meta.GetID()),
 					zap.Int64("segmentID", segID))
 				<-time.After(50 * time.Millisecond)

--- a/internal/datanode/flow_graph_delete_node.go
+++ b/internal/datanode/flow_graph_delete_node.go
@@ -106,7 +106,7 @@ func (dn *deleteNode) Close() {
 }
 
 func (dn *deleteNode) bufferDeleteMsg(msg *msgstream.DeleteMsg, tr TimeRange) error {
-	log.Debug("bufferDeleteMsg", zap.Any("primary keys", msg.PrimaryKeys), zap.String("vChannelName", dn.channelName))
+	log.Ctx(msg.TraceCtx()).Debug("bufferDeleteMsg", zap.Any("primary keys", msg.PrimaryKeys), zap.String("vChannelName", dn.channelName))
 
 	// Update delBuf for merged segments
 	compactedTo2From := dn.replica.listCompactedSegmentIDs()
@@ -211,9 +211,8 @@ func (dn *deleteNode) Operate(in []Msg) []Msg {
 		msg.SetTraceCtx(ctx)
 	}
 
-	for i, msg := range fgMsg.deleteMessages {
-		traceID, _, _ := trace.InfoFromSpan(spans[i])
-		log.Info("Buffer delete request in DataNode", zap.String("traceID", traceID))
+	for _, msg := range fgMsg.deleteMessages {
+		log.Ctx(msg.TraceCtx()).Info("Buffer delete request in DataNode")
 
 		err := dn.bufferDeleteMsg(msg, fgMsg.timeRange)
 		if err != nil {

--- a/internal/datanode/flow_graph_insert_buffer_node.go
+++ b/internal/datanode/flow_graph_insert_buffer_node.go
@@ -224,7 +224,7 @@ func (ibNode *insertBufferNode) Operate(in []Msg) []Msg {
 		if err != nil {
 			// error occurs when missing schema info or data is misaligned, should not happen
 			err = fmt.Errorf("insertBufferNode msg to buffer failed, err = %s", err)
-			log.Error(err.Error())
+			log.Ctx(msg.TraceCtx()).Error(err.Error())
 			panic(err)
 		}
 	}

--- a/internal/distributed/datanode/service.go
+++ b/internal/distributed/datanode/service.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 	"time"
 
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	ot "github.com/grpc-ecosystem/go-grpc-middleware/tracing/opentracing"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
@@ -44,6 +45,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/dependency"
 	"github.com/milvus-io/milvus/internal/util/etcd"
 	"github.com/milvus-io/milvus/internal/util/funcutil"
+	"github.com/milvus-io/milvus/internal/util/logutil"
 	"github.com/milvus-io/milvus/internal/util/paramtable"
 	"github.com/milvus-io/milvus/internal/util/retry"
 	"github.com/milvus-io/milvus/internal/util/trace"
@@ -134,8 +136,12 @@ func (s *Server) startGrpcLoop(grpcPort int) {
 		grpc.KeepaliveParams(kasp),
 		grpc.MaxRecvMsgSize(Params.ServerMaxRecvSize),
 		grpc.MaxSendMsgSize(Params.ServerMaxSendSize),
-		grpc.UnaryInterceptor(ot.UnaryServerInterceptor(opts...)),
-		grpc.StreamInterceptor(ot.StreamServerInterceptor(opts...)))
+		grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(
+			ot.UnaryServerInterceptor(opts...),
+			logutil.UnaryTraceLoggerInterceptor)),
+		grpc.StreamInterceptor(grpc_middleware.ChainStreamServer(
+			ot.StreamServerInterceptor(opts...),
+			logutil.StreamTraceLoggerInterceptor)))
 	datapb.RegisterDataNodeServer(s.grpcServer, s)
 
 	ctx, cancel := context.WithCancel(s.ctx)

--- a/internal/distributed/indexcoord/service.go
+++ b/internal/distributed/indexcoord/service.go
@@ -29,6 +29,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/keepalive"
 
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	ot "github.com/grpc-ecosystem/go-grpc-middleware/tracing/opentracing"
 	dcc "github.com/milvus-io/milvus/internal/distributed/datacoord/client"
 	"github.com/milvus-io/milvus/internal/indexcoord"
@@ -42,6 +43,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/dependency"
 	"github.com/milvus-io/milvus/internal/util/etcd"
 	"github.com/milvus-io/milvus/internal/util/funcutil"
+	"github.com/milvus-io/milvus/internal/util/logutil"
 	"github.com/milvus-io/milvus/internal/util/paramtable"
 	"github.com/milvus-io/milvus/internal/util/trace"
 	"github.com/milvus-io/milvus/internal/util/typeutil"
@@ -272,8 +274,12 @@ func (s *Server) startGrpcLoop(grpcPort int) {
 		grpc.KeepaliveParams(kasp),
 		grpc.MaxRecvMsgSize(Params.ServerMaxRecvSize),
 		grpc.MaxSendMsgSize(Params.ServerMaxSendSize),
-		grpc.UnaryInterceptor(ot.UnaryServerInterceptor(opts...)),
-		grpc.StreamInterceptor(ot.StreamServerInterceptor(opts...)))
+		grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(
+			ot.UnaryServerInterceptor(opts...),
+			logutil.UnaryTraceLoggerInterceptor)),
+		grpc.StreamInterceptor(grpc_middleware.ChainStreamServer(
+			ot.StreamServerInterceptor(opts...),
+			logutil.StreamTraceLoggerInterceptor)))
 	indexpb.RegisterIndexCoordServer(s.grpcServer, s)
 
 	go funcutil.CheckGrpcReady(ctx, s.grpcErrChan)

--- a/internal/distributed/proxy/service.go
+++ b/internal/distributed/proxy/service.go
@@ -62,6 +62,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/dependency"
 	"github.com/milvus-io/milvus/internal/util/etcd"
 	"github.com/milvus-io/milvus/internal/util/funcutil"
+	"github.com/milvus-io/milvus/internal/util/logutil"
 	"github.com/milvus-io/milvus/internal/util/paramtable"
 	"github.com/milvus-io/milvus/internal/util/trace"
 	"github.com/milvus-io/milvus/internal/util/typeutil"
@@ -170,10 +171,12 @@ func (s *Server) startExternalGrpc(grpcPort int, errChan chan error) {
 		grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(
 			ot.UnaryServerInterceptor(opts...),
 			grpc_auth.UnaryServerInterceptor(proxy.AuthenticationInterceptor),
+			logutil.UnaryTraceLoggerInterceptor,
 		)),
 		grpc.StreamInterceptor(grpc_middleware.ChainStreamServer(
 			ot.StreamServerInterceptor(opts...),
-			grpc_auth.StreamServerInterceptor(proxy.AuthenticationInterceptor))),
+			grpc_auth.StreamServerInterceptor(proxy.AuthenticationInterceptor),
+			logutil.StreamTraceLoggerInterceptor)),
 	}
 
 	if Params.TLSMode == 1 {
@@ -260,10 +263,12 @@ func (s *Server) startInternalGrpc(grpcPort int, errChan chan error) {
 		grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(
 			ot.UnaryServerInterceptor(opts...),
 			grpc_auth.UnaryServerInterceptor(proxy.AuthenticationInterceptor),
+			logutil.UnaryTraceLoggerInterceptor,
 		)),
 		grpc.StreamInterceptor(grpc_middleware.ChainStreamServer(
 			ot.StreamServerInterceptor(opts...),
 			grpc_auth.StreamServerInterceptor(proxy.AuthenticationInterceptor),
+			logutil.StreamTraceLoggerInterceptor,
 		)),
 	)
 	proxypb.RegisterProxyServer(s.grpcInternalServer, s)

--- a/internal/distributed/querycoord/service.go
+++ b/internal/distributed/querycoord/service.go
@@ -24,6 +24,7 @@ import (
 	"sync"
 	"time"
 
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	ot "github.com/grpc-ecosystem/go-grpc-middleware/tracing/opentracing"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
@@ -43,6 +44,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/dependency"
 	"github.com/milvus-io/milvus/internal/util/etcd"
 	"github.com/milvus-io/milvus/internal/util/funcutil"
+	"github.com/milvus-io/milvus/internal/util/logutil"
 	"github.com/milvus-io/milvus/internal/util/paramtable"
 	"github.com/milvus-io/milvus/internal/util/trace"
 	"github.com/milvus-io/milvus/internal/util/typeutil"
@@ -259,8 +261,12 @@ func (s *Server) startGrpcLoop(grpcPort int) {
 		grpc.KeepaliveParams(kasp),
 		grpc.MaxRecvMsgSize(Params.ServerMaxRecvSize),
 		grpc.MaxSendMsgSize(Params.ServerMaxSendSize),
-		grpc.UnaryInterceptor(ot.UnaryServerInterceptor(opts...)),
-		grpc.StreamInterceptor(ot.StreamServerInterceptor(opts...)))
+		grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(
+			ot.UnaryServerInterceptor(opts...),
+			logutil.UnaryTraceLoggerInterceptor)),
+		grpc.StreamInterceptor(grpc_middleware.ChainStreamServer(
+			ot.StreamServerInterceptor(opts...),
+			logutil.StreamTraceLoggerInterceptor)))
 	querypb.RegisterQueryCoordServer(s.grpcServer, s)
 
 	go funcutil.CheckGrpcReady(ctx, s.grpcErrChan)

--- a/internal/distributed/querynode/service.go
+++ b/internal/distributed/querynode/service.go
@@ -25,6 +25,7 @@ import (
 	"sync"
 	"time"
 
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	ot "github.com/grpc-ecosystem/go-grpc-middleware/tracing/opentracing"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
@@ -41,6 +42,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/dependency"
 	"github.com/milvus-io/milvus/internal/util/etcd"
 	"github.com/milvus-io/milvus/internal/util/funcutil"
+	"github.com/milvus-io/milvus/internal/util/logutil"
 	"github.com/milvus-io/milvus/internal/util/paramtable"
 	"github.com/milvus-io/milvus/internal/util/retry"
 	"github.com/milvus-io/milvus/internal/util/trace"
@@ -175,8 +177,12 @@ func (s *Server) startGrpcLoop(grpcPort int) {
 		grpc.KeepaliveParams(kasp),
 		grpc.MaxRecvMsgSize(Params.ServerMaxRecvSize),
 		grpc.MaxSendMsgSize(Params.ServerMaxSendSize),
-		grpc.UnaryInterceptor(ot.UnaryServerInterceptor(opts...)),
-		grpc.StreamInterceptor(ot.StreamServerInterceptor(opts...)))
+		grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(
+			ot.UnaryServerInterceptor(opts...),
+			logutil.UnaryTraceLoggerInterceptor)),
+		grpc.StreamInterceptor(grpc_middleware.ChainStreamServer(
+			ot.StreamServerInterceptor(opts...),
+			logutil.StreamTraceLoggerInterceptor)))
 	querypb.RegisterQueryNodeServer(s.grpcServer, s)
 
 	ctx, cancel := context.WithCancel(s.ctx)

--- a/internal/indexcoord/metrics_info.go
+++ b/internal/indexcoord/metrics_info.go
@@ -67,7 +67,7 @@ func getSystemInfoMetrics(
 	nodesMetrics := coord.nodeManager.getMetrics(ctx, req)
 	for _, nodeMetrics := range nodesMetrics {
 		if nodeMetrics.err != nil {
-			log.Warn("invalid metrics of index node was found",
+			log.Ctx(ctx).Warn("invalid metrics of index node was found",
 				zap.Error(nodeMetrics.err))
 			clusterTopology.ConnectedNodes = append(clusterTopology.ConnectedNodes, metricsinfo.IndexNodeInfos{
 				BaseComponentInfos: metricsinfo.BaseComponentInfos{
@@ -82,7 +82,7 @@ func getSystemInfoMetrics(
 		}
 
 		if nodeMetrics.resp.Status.ErrorCode != commonpb.ErrorCode_Success {
-			log.Warn("invalid metrics of index node was found",
+			log.Ctx(ctx).Warn("invalid metrics of index node was found",
 				zap.Any("error_code", nodeMetrics.resp.Status.ErrorCode),
 				zap.Any("error_reason", nodeMetrics.resp.Status.Reason))
 			clusterTopology.ConnectedNodes = append(clusterTopology.ConnectedNodes, metricsinfo.IndexNodeInfos{
@@ -99,7 +99,7 @@ func getSystemInfoMetrics(
 		infos := metricsinfo.IndexNodeInfos{}
 		err := metricsinfo.UnmarshalComponentInfos(nodeMetrics.resp.Response, &infos)
 		if err != nil {
-			log.Warn("invalid metrics of index node was found",
+			log.Ctx(ctx).Warn("invalid metrics of index node was found",
 				zap.Error(err))
 			clusterTopology.ConnectedNodes = append(clusterTopology.ConnectedNodes, metricsinfo.IndexNodeInfos{
 				BaseComponentInfos: metricsinfo.BaseComponentInfos{

--- a/internal/indexcoord/task.go
+++ b/internal/indexcoord/task.go
@@ -113,14 +113,14 @@ func (it *IndexAddTask) OnEnqueue() error {
 
 // PreExecute sets the indexBuildID to index task request.
 func (it *IndexAddTask) PreExecute(ctx context.Context) error {
-	log.Debug("IndexCoord IndexAddTask PreExecute", zap.Any("IndexBuildID", it.indexBuildID))
+	log.Ctx(ctx).Debug("IndexCoord IndexAddTask PreExecute", zap.Any("IndexBuildID", it.indexBuildID))
 	it.req.IndexBuildID = it.indexBuildID
 	return nil
 }
 
 // Execute adds the index task to meta table.
 func (it *IndexAddTask) Execute(ctx context.Context) error {
-	log.Debug("IndexCoord IndexAddTask Execute", zap.Any("IndexBuildID", it.indexBuildID))
+	log.Ctx(ctx).Debug("IndexCoord IndexAddTask Execute", zap.Any("IndexBuildID", it.indexBuildID))
 	err := it.table.AddIndex(it.indexBuildID, it.req)
 	if err != nil {
 		return err
@@ -130,6 +130,6 @@ func (it *IndexAddTask) Execute(ctx context.Context) error {
 
 // PostExecute does nothing here.
 func (it *IndexAddTask) PostExecute(ctx context.Context) error {
-	log.Debug("IndexCoord IndexAddTask PostExecute", zap.Any("IndexBuildID", it.indexBuildID))
+	log.Ctx(ctx).Debug("IndexCoord IndexAddTask PostExecute", zap.Any("IndexBuildID", it.indexBuildID))
 	return nil
 }

--- a/internal/indexnode/task_scheduler.go
+++ b/internal/indexnode/task_scheduler.go
@@ -259,7 +259,7 @@ func (sched *TaskScheduler) processTask(t task, q TaskQueue) {
 	t.SetError(err)
 
 	if t.GetState() == TaskStateAbandon {
-		log.Info("IndexNode scheduler abandon task",
+		log.Ctx(ctx).Info("IndexNode scheduler abandon task",
 			zap.String("TaskState", t.GetState().String()),
 			zap.Int64("taskID", t.ID()))
 		return

--- a/internal/log/mlogger.go
+++ b/internal/log/mlogger.go
@@ -1,0 +1,31 @@
+package log
+
+import "go.uber.org/zap"
+
+type MLogger struct {
+	*zap.Logger
+}
+
+func (l *MLogger) RatedDebug(cost float64, msg string, fields ...zap.Field) bool {
+	if R().CheckCredit(cost) {
+		l.Debug(msg, fields...)
+		return true
+	}
+	return false
+}
+
+func (l *MLogger) RatedInfo(cost float64, msg string, fields ...zap.Field) bool {
+	if R().CheckCredit(cost) {
+		l.Info(msg, fields...)
+		return true
+	}
+	return false
+}
+
+func (l *MLogger) RatedWarn(cost float64, msg string, fields ...zap.Field) bool {
+	if R().CheckCredit(cost) {
+		l.Warn(msg, fields...)
+		return true
+	}
+	return false
+}

--- a/internal/log/mlogger_test.go
+++ b/internal/log/mlogger_test.go
@@ -1,0 +1,89 @@
+package log
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+func TestExporterV2(t *testing.T) {
+	ts := newTestLogSpy(t)
+	conf := &Config{Level: "debug", DisableTimestamp: true}
+	logger, _, _ := InitTestLogger(ts, conf)
+	ReplaceGlobals(logger, nil)
+	ReplaceGlobalCtxLogger(logger)
+	ctx := WithTraceID(context.TODO(), "mock-trace")
+
+	Ctx(ctx).Info("Info Test")
+	Ctx(ctx).Debug("Debug Test")
+	Ctx(ctx).Warn("Warn Test")
+	Ctx(ctx).Error("Error Test")
+	Ctx(ctx).Sync()
+
+	ts.assertMessagesContains("mlogger_test.go")
+	ts.assertMessagesContains("traceID=mock-trace")
+
+	fieldCtx := WithFields(ctx, zap.String("field", "test"))
+	reqCtx := WithReqID(ctx, 123456)
+	modCtx := WithModule(ctx, "test")
+
+	Ctx(fieldCtx).Info("Info Test")
+	Ctx(fieldCtx).Sync()
+	ts.assertLastMessageContains("field=test")
+	ts.assertLastMessageContains("traceID=mock-trace")
+
+	Ctx(reqCtx).Info("Info Test")
+	Ctx(reqCtx).Sync()
+	ts.assertLastMessageContains("reqID=123456")
+	ts.assertLastMessageContains("traceID=mock-trace")
+	ts.assertLastMessageNotContains("field=test")
+
+	Ctx(modCtx).Info("Info Test")
+	Ctx(modCtx).Sync()
+	ts.assertLastMessageContains("module=test")
+	ts.assertLastMessageContains("traceID=mock-trace")
+	ts.assertLastMessageNotContains("reqID=123456")
+	ts.assertLastMessageNotContains("field=test")
+}
+
+func TestMLoggerRatedLog(t *testing.T) {
+	ts := newTestLogSpy(t)
+	conf := &Config{Level: "debug", DisableTimestamp: true}
+	logger, p, _ := InitTestLogger(ts, conf)
+	ReplaceGlobals(logger, p)
+
+	ctx := WithTraceID(context.TODO(), "test-trace")
+	time.Sleep(time.Duration(1) * time.Second)
+	success := Ctx(ctx).RatedDebug(1.0, "debug test")
+	assert.True(t, success)
+
+	time.Sleep(time.Duration(1) * time.Second)
+	success = Ctx(ctx).RatedInfo(1.0, "info test")
+	assert.True(t, success)
+
+	time.Sleep(time.Duration(1) * time.Second)
+	success = Ctx(ctx).RatedWarn(1.0, "warn test")
+	assert.True(t, success)
+
+	time.Sleep(time.Duration(1) * time.Second)
+	success = Ctx(ctx).RatedInfo(100.0, "info test")
+	assert.False(t, success)
+
+	successNum := 0
+	for i := 0; i < 1000; i++ {
+		if Ctx(ctx).RatedInfo(1.0, "info test") {
+			successNum++
+		}
+		time.Sleep(time.Duration(10) * time.Millisecond)
+	}
+	assert.True(t, successNum < 1000)
+	assert.True(t, successNum > 10)
+
+	time.Sleep(time.Duration(3) * time.Second)
+	success = Ctx(ctx).RatedInfo(3.0, "info test")
+	assert.True(t, success)
+	Ctx(ctx).Sync()
+}

--- a/internal/log/zap_log_test.go
+++ b/internal/log/zap_log_test.go
@@ -320,3 +320,17 @@ func (t *testLogSpy) assertMessagesNotContains(msg string) {
 		assert.NotContains(t.TB, actualMsg, msg)
 	}
 }
+
+func (t *testLogSpy) assertLastMessageContains(msg string) {
+	if len(t.Messages) == 0 {
+		assert.Error(t.TB, fmt.Errorf("empty message"))
+	}
+	assert.Contains(t.TB, t.Messages[len(t.Messages)-1], msg)
+}
+
+func (t *testLogSpy) assertLastMessageNotContains(msg string) {
+	if len(t.Messages) == 0 {
+		assert.Error(t.TB, fmt.Errorf("empty message"))
+	}
+	assert.NotContains(t.TB, t.Messages[len(t.Messages)-1], msg)
+}

--- a/internal/log/zap_text_encoder.go
+++ b/internal/log/zap_text_encoder.go
@@ -38,7 +38,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
-	"strings"
 	"sync"
 	"time"
 	"unicode/utf8"
@@ -61,35 +60,7 @@ func DefaultTimeEncoder(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
 
 // ShortCallerEncoder serializes a caller in file:line format.
 func ShortCallerEncoder(caller zapcore.EntryCaller, enc zapcore.PrimitiveArrayEncoder) {
-	enc.AppendString(getCallerString(caller))
-}
-
-func getCallerString(ec zapcore.EntryCaller) string {
-	if !ec.Defined {
-		return "<unknown>"
-	}
-
-	idx := strings.LastIndexByte(ec.File, '/')
-	buf := _pool.Get()
-	for i := idx + 1; i < len(ec.File); i++ {
-		b := ec.File[i]
-		switch {
-		case b >= 'A' && b <= 'Z':
-			buf.AppendByte(b)
-		case b >= 'a' && b <= 'z':
-			buf.AppendByte(b)
-		case b >= '0' && b <= '9':
-			buf.AppendByte(b)
-		case b == '.' || b == '-' || b == '_':
-			buf.AppendByte(b)
-		default:
-		}
-	}
-	buf.AppendByte(':')
-	buf.AppendInt(int64(ec.Line))
-	caller := buf.String()
-	buf.Free()
-	return caller
+	enc.AppendString(caller.TrimmedPath())
 }
 
 // For JSON-escaping; see textEncoder.safeAddString below.

--- a/internal/proxy/authentication_interceptor.go
+++ b/internal/proxy/authentication_interceptor.go
@@ -33,7 +33,7 @@ func validAuth(ctx context.Context, authorization []string) bool {
 
 	credInfo, err := globalMetaCache.GetCredentialInfo(ctx, username)
 	if err != nil {
-		log.Error("found no credential", zap.String("username", username), zap.Error(err))
+		log.Ctx(ctx).Error("found no credential", zap.String("username", username), zap.Error(err))
 		return false
 	}
 

--- a/internal/proxy/meta_cache.go
+++ b/internal/proxy/meta_cache.go
@@ -197,7 +197,7 @@ func (m *MetaCache) GetCollectionInfo(ctx context.Context, collectionName string
 		if showResp.Status.ErrorCode != commonpb.ErrorCode_Success {
 			return nil, errors.New(showResp.Status.Reason)
 		}
-		log.Debug("QueryCoord show collections",
+		log.Ctx(ctx).Debug("QueryCoord show collections",
 			zap.Int64("collID", collInfo.collID),
 			zap.Int64s("collections", showResp.GetCollectionIDs()),
 			zap.Int64s("collectionsInMemoryPercentages", showResp.GetInMemoryPercentages()),
@@ -230,7 +230,7 @@ func (m *MetaCache) GetCollectionSchema(ctx context.Context, collectionName stri
 		m.mu.RUnlock()
 		coll, err := m.describeCollection(ctx, collectionName)
 		if err != nil {
-			log.Warn("Failed to load collection from rootcoord ",
+			log.Ctx(ctx).Warn("Failed to load collection from rootcoord ",
 				zap.String("collection name ", collectionName),
 				zap.Error(err))
 			return nil, err
@@ -240,7 +240,7 @@ func (m *MetaCache) GetCollectionSchema(ctx context.Context, collectionName stri
 		m.updateCollection(coll, collectionName)
 		collInfo = m.collInfo[collectionName]
 		metrics.ProxyUpdateCacheLatency.WithLabelValues(strconv.FormatInt(Params.ProxyCfg.GetNodeID(), 10)).Observe(float64(tr.ElapseSpan().Milliseconds()))
-		log.Debug("Reload collection from root coordinator ",
+		log.Ctx(ctx).Debug("Reload collection from root coordinator ",
 			zap.String("collection name ", collectionName),
 			zap.Any("time (milliseconds) take ", tr.ElapseSpan().Milliseconds()))
 		return collInfo.schema, nil
@@ -302,7 +302,7 @@ func (m *MetaCache) GetPartitions(ctx context.Context, collectionName string) (m
 			return nil, err
 		}
 		metrics.ProxyUpdateCacheLatency.WithLabelValues(strconv.FormatInt(Params.ProxyCfg.GetNodeID(), 10)).Observe(float64(tr.ElapseSpan().Milliseconds()))
-		log.Debug("proxy", zap.Any("GetPartitions:partitions after update", partitions), zap.Any("collectionName", collectionName))
+		log.Ctx(ctx).Debug("proxy", zap.Any("GetPartitions:partitions after update", partitions), zap.Any("collectionName", collectionName))
 		ret := make(map[string]typeutil.UniqueID)
 		partInfo := m.collInfo[collectionName].partInfo
 		for k, v := range partInfo {
@@ -356,7 +356,7 @@ func (m *MetaCache) GetPartitionInfo(ctx context.Context, collectionName string,
 			return nil, err
 		}
 		metrics.ProxyUpdateCacheLatency.WithLabelValues(strconv.FormatInt(Params.ProxyCfg.GetNodeID(), 10)).Observe(float64(tr.ElapseSpan().Milliseconds()))
-		log.Debug("proxy", zap.Any("GetPartitionID:partitions after update", partitions), zap.Any("collectionName", collectionName))
+		log.Ctx(ctx).Debug("proxy", zap.Any("GetPartitionID:partitions after update", partitions), zap.Any("collectionName", collectionName))
 		partInfo, ok = m.collInfo[collectionName].partInfo[partitionName]
 		if !ok {
 			return nil, fmt.Errorf("partitionID of partitionName:%s can not be find", partitionName)
@@ -557,7 +557,7 @@ func (m *MetaCache) GetShards(ctx context.Context, withCache bool, collectionNam
 			info.leaderMutex.Unlock()
 			return shards, nil
 		}
-		log.Info("no shard cache for collection, try to get shard leaders from QueryCoord",
+		log.Ctx(ctx).Info("no shard cache for collection, try to get shard leaders from QueryCoord",
 			zap.String("collectionName", collectionName))
 	}
 	req := &querypb.GetShardLeadersRequest{

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -37,7 +37,6 @@ import (
 	"github.com/milvus-io/milvus/internal/proto/internalpb"
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/dependency"
-	"github.com/milvus-io/milvus/internal/util/logutil"
 	"github.com/milvus-io/milvus/internal/util/metricsinfo"
 	"github.com/milvus-io/milvus/internal/util/paramtable"
 	"github.com/milvus-io/milvus/internal/util/sessionutil"
@@ -114,7 +113,7 @@ func NewProxy(ctx context.Context, factory dependency.Factory) (*Proxy, error) {
 		shardMgr:       newShardClientMgr(),
 	}
 	node.UpdateStateCode(internalpb.StateCode_Abnormal)
-	logutil.Logger(ctx).Debug("create a new Proxy instance", zap.Any("state", node.stateCode.Load()))
+	log.Ctx(ctx).Debug("create a new Proxy instance", zap.Any("state", node.stateCode.Load()))
 	return node, nil
 
 }

--- a/internal/proxy/task_calc_distance.go
+++ b/internal/proxy/task_calc_distance.go
@@ -175,7 +175,7 @@ func (t *calcDistanceTask) Execute(ctx context.Context, request *milvuspb.CalcDi
 		return t.arrangeVectorsByIntID(inputIds, dict, retrievedVectors)
 	}
 
-	log.Debug("CalcDistance received",
+	log.Ctx(ctx).Debug("CalcDistance received",
 		zap.String("traceID", t.traceID),
 		zap.String("role", typeutil.ProxyRole),
 		zap.String("metric", metric))
@@ -183,13 +183,13 @@ func (t *calcDistanceTask) Execute(ctx context.Context, request *milvuspb.CalcDi
 	vectorsLeft := request.GetOpLeft().GetDataArray()
 	opLeft := request.GetOpLeft().GetIdArray()
 	if opLeft != nil {
-		log.Debug("OpLeft IdArray not empty, Get vectors by id",
+		log.Ctx(ctx).Debug("OpLeft IdArray not empty, Get vectors by id",
 			zap.String("traceID", t.traceID),
 			zap.String("role", typeutil.ProxyRole))
 
 		result, err := t.queryFunc(opLeft)
 		if err != nil {
-			log.Debug("Failed to get left vectors by id",
+			log.Ctx(ctx).Debug("Failed to get left vectors by id",
 				zap.Error(err),
 				zap.String("traceID", t.traceID),
 				zap.String("role", typeutil.ProxyRole))
@@ -202,13 +202,13 @@ func (t *calcDistanceTask) Execute(ctx context.Context, request *milvuspb.CalcDi
 			}, nil
 		}
 
-		log.Debug("OpLeft IdArray not empty, Get vectors by id done",
+		log.Ctx(ctx).Debug("OpLeft IdArray not empty, Get vectors by id done",
 			zap.String("traceID", t.traceID),
 			zap.String("role", typeutil.ProxyRole))
 
 		vectorsLeft, err = arrangeFunc(opLeft, result.FieldsData)
 		if err != nil {
-			log.Debug("Failed to re-arrange left vectors",
+			log.Ctx(ctx).Debug("Failed to re-arrange left vectors",
 				zap.Error(err),
 				zap.String("traceID", t.traceID),
 				zap.String("role", typeutil.ProxyRole))
@@ -221,14 +221,14 @@ func (t *calcDistanceTask) Execute(ctx context.Context, request *milvuspb.CalcDi
 			}, nil
 		}
 
-		log.Debug("Re-arrange left vectors done",
+		log.Ctx(ctx).Debug("Re-arrange left vectors done",
 			zap.String("traceID", t.traceID),
 			zap.String("role", typeutil.ProxyRole))
 	}
 
 	if vectorsLeft == nil {
 		msg := "Left vectors array is empty"
-		log.Debug(msg,
+		log.Ctx(ctx).Debug(msg,
 			zap.String("traceID", t.traceID),
 			zap.String("role", typeutil.ProxyRole))
 
@@ -243,13 +243,13 @@ func (t *calcDistanceTask) Execute(ctx context.Context, request *milvuspb.CalcDi
 	vectorsRight := request.GetOpRight().GetDataArray()
 	opRight := request.GetOpRight().GetIdArray()
 	if opRight != nil {
-		log.Debug("OpRight IdArray not empty, Get vectors by id",
+		log.Ctx(ctx).Debug("OpRight IdArray not empty, Get vectors by id",
 			zap.String("traceID", t.traceID),
 			zap.String("role", typeutil.ProxyRole))
 
 		result, err := t.queryFunc(opRight)
 		if err != nil {
-			log.Debug("Failed to get right vectors by id",
+			log.Ctx(ctx).Debug("Failed to get right vectors by id",
 				zap.Error(err),
 				zap.String("traceID", t.traceID),
 				zap.String("role", typeutil.ProxyRole))
@@ -262,13 +262,13 @@ func (t *calcDistanceTask) Execute(ctx context.Context, request *milvuspb.CalcDi
 			}, nil
 		}
 
-		log.Debug("OpRight IdArray not empty, Get vectors by id done",
+		log.Ctx(ctx).Debug("OpRight IdArray not empty, Get vectors by id done",
 			zap.String("traceID", t.traceID),
 			zap.String("role", typeutil.ProxyRole))
 
 		vectorsRight, err = arrangeFunc(opRight, result.FieldsData)
 		if err != nil {
-			log.Debug("Failed to re-arrange right vectors",
+			log.Ctx(ctx).Debug("Failed to re-arrange right vectors",
 				zap.Error(err),
 				zap.String("traceID", t.traceID),
 				zap.String("role", typeutil.ProxyRole))
@@ -281,14 +281,14 @@ func (t *calcDistanceTask) Execute(ctx context.Context, request *milvuspb.CalcDi
 			}, nil
 		}
 
-		log.Debug("Re-arrange right vectors done",
+		log.Ctx(ctx).Debug("Re-arrange right vectors done",
 			zap.String("traceID", t.traceID),
 			zap.String("role", typeutil.ProxyRole))
 	}
 
 	if vectorsRight == nil {
 		msg := "Right vectors array is empty"
-		log.Debug(msg,
+		log.Ctx(ctx).Debug(msg,
 			zap.String("traceID", t.traceID),
 			zap.String("role", typeutil.ProxyRole))
 
@@ -302,7 +302,7 @@ func (t *calcDistanceTask) Execute(ctx context.Context, request *milvuspb.CalcDi
 
 	if vectorsLeft.GetDim() != vectorsRight.GetDim() {
 		msg := "Vectors dimension is not equal"
-		log.Debug(msg,
+		log.Ctx(ctx).Debug(msg,
 			zap.String("traceID", t.traceID),
 			zap.String("role", typeutil.ProxyRole))
 
@@ -317,7 +317,7 @@ func (t *calcDistanceTask) Execute(ctx context.Context, request *milvuspb.CalcDi
 	if vectorsLeft.GetFloatVector() != nil && vectorsRight.GetFloatVector() != nil {
 		distances, err := distance.CalcFloatDistance(vectorsLeft.GetDim(), vectorsLeft.GetFloatVector().GetData(), vectorsRight.GetFloatVector().GetData(), metric)
 		if err != nil {
-			log.Debug("Failed to CalcFloatDistance",
+			log.Ctx(ctx).Debug("Failed to CalcFloatDistance",
 				zap.Error(err),
 				zap.Int64("leftDim", vectorsLeft.GetDim()),
 				zap.Int("leftLen", len(vectorsLeft.GetFloatVector().GetData())),
@@ -334,7 +334,7 @@ func (t *calcDistanceTask) Execute(ctx context.Context, request *milvuspb.CalcDi
 			}, nil
 		}
 
-		log.Debug("CalcFloatDistance done",
+		log.Ctx(ctx).Debug("CalcFloatDistance done",
 			zap.Error(err),
 			zap.String("traceID", t.traceID),
 			zap.String("role", typeutil.ProxyRole))
@@ -352,7 +352,7 @@ func (t *calcDistanceTask) Execute(ctx context.Context, request *milvuspb.CalcDi
 	if vectorsLeft.GetBinaryVector() != nil && vectorsRight.GetBinaryVector() != nil {
 		hamming, err := distance.CalcHammingDistance(vectorsLeft.GetDim(), vectorsLeft.GetBinaryVector(), vectorsRight.GetBinaryVector())
 		if err != nil {
-			log.Debug("Failed to CalcHammingDistance",
+			log.Ctx(ctx).Debug("Failed to CalcHammingDistance",
 				zap.Error(err),
 				zap.Int64("leftDim", vectorsLeft.GetDim()),
 				zap.Int("leftLen", len(vectorsLeft.GetBinaryVector())),
@@ -370,7 +370,7 @@ func (t *calcDistanceTask) Execute(ctx context.Context, request *milvuspb.CalcDi
 		}
 
 		if metric == distance.HAMMING {
-			log.Debug("CalcHammingDistance done",
+			log.Ctx(ctx).Debug("CalcHammingDistance done",
 				zap.String("traceID", t.traceID),
 				zap.String("role", typeutil.ProxyRole))
 
@@ -387,7 +387,7 @@ func (t *calcDistanceTask) Execute(ctx context.Context, request *milvuspb.CalcDi
 		if metric == distance.TANIMOTO {
 			tanimoto, err := distance.CalcTanimotoCoefficient(vectorsLeft.GetDim(), hamming)
 			if err != nil {
-				log.Debug("Failed to CalcTanimotoCoefficient",
+				log.Ctx(ctx).Debug("Failed to CalcTanimotoCoefficient",
 					zap.Error(err),
 					zap.String("traceID", t.traceID),
 					zap.String("role", typeutil.ProxyRole))
@@ -400,7 +400,7 @@ func (t *calcDistanceTask) Execute(ctx context.Context, request *milvuspb.CalcDi
 				}, nil
 			}
 
-			log.Debug("CalcTanimotoCoefficient done",
+			log.Ctx(ctx).Debug("CalcTanimotoCoefficient done",
 				zap.String("traceID", t.traceID),
 				zap.String("role", typeutil.ProxyRole))
 
@@ -420,7 +420,7 @@ func (t *calcDistanceTask) Execute(ctx context.Context, request *milvuspb.CalcDi
 		err = errors.New("cannot calculate distance between binary vectors and float vectors")
 	}
 
-	log.Debug("Failed to CalcDistance",
+	log.Ctx(ctx).Debug("Failed to CalcDistance",
 		zap.Error(err),
 		zap.String("traceID", t.traceID),
 		zap.String("role", typeutil.ProxyRole))

--- a/internal/proxy/task_policies.go
+++ b/internal/proxy/task_policies.go
@@ -40,7 +40,7 @@ func groupShardleadersWithSameQueryNode(
 	// check if all leaders were checked
 	for dml, idx := range nexts {
 		if idx >= len(shard2leaders[dml]) {
-			log.Warn("no shard leaders were available",
+			log.Ctx(ctx).Warn("no shard leaders were available",
 				zap.String("channel", dml),
 				zap.String("leaders", fmt.Sprintf("%v", shard2leaders[dml])))
 			if e, ok := errSet[dml]; ok {
@@ -59,7 +59,7 @@ func groupShardleadersWithSameQueryNode(
 		if _, ok := qnSet[nodeInfo.nodeID]; !ok {
 			qn, err := mgr.GetClient(ctx, nodeInfo.nodeID)
 			if err != nil {
-				log.Warn("failed to get shard leader", zap.Int64("nodeID", nodeInfo.nodeID), zap.Error(err))
+				log.Ctx(ctx).Warn("failed to get shard leader", zap.Int64("nodeID", nodeInfo.nodeID), zap.Error(err))
 				// if get client failed, just record error and wait for next round to get client and do query
 				errSet[dml] = err
 				continue
@@ -111,7 +111,7 @@ func mergeRoundRobinPolicy(
 			go func() {
 				defer wg.Done()
 				if err := query(ctx, nodeID, qn, channels); err != nil {
-					log.Warn("failed to do query with node", zap.Int64("nodeID", nodeID),
+					log.Ctx(ctx).Warn("failed to do query with node", zap.Int64("nodeID", nodeID),
 						zap.Strings("dmlChannels", channels), zap.Error(err))
 					mu.Lock()
 					defer mu.Unlock()
@@ -138,7 +138,7 @@ func mergeRoundRobinPolicy(
 					nextSet[dml] = dml2leaders[dml][idx].nodeID
 				}
 			}
-			log.Warn("retry another query node with round robin", zap.Any("Nexts", nextSet))
+			log.Ctx(ctx).Warn("retry another query node with round robin", zap.Any("Nexts", nextSet))
 		}
 	}
 	return nil

--- a/internal/proxy/task_scheduler.go
+++ b/internal/proxy/task_scheduler.go
@@ -438,7 +438,6 @@ func (sched *taskScheduler) processTask(t task, q taskQueue) {
 			"ID":   t.ID(),
 		})
 	defer span.Finish()
-	traceID, _, _ := trace.InfoFromSpan(span)
 
 	span.LogFields(oplog.Int64("scheduler process AddActiveTask", t.ID()))
 	q.AddActiveTask(t)
@@ -456,8 +455,7 @@ func (sched *taskScheduler) processTask(t task, q taskQueue) {
 	}()
 	if err != nil {
 		trace.LogError(span, err)
-		log.Error("Failed to pre-execute task: "+err.Error(),
-			zap.String("traceID", traceID))
+		log.Ctx(ctx).Error("Failed to pre-execute task: " + err.Error())
 		return
 	}
 
@@ -465,8 +463,7 @@ func (sched *taskScheduler) processTask(t task, q taskQueue) {
 	err = t.Execute(ctx)
 	if err != nil {
 		trace.LogError(span, err)
-		log.Error("Failed to execute task: "+err.Error(),
-			zap.String("traceID", traceID))
+		log.Ctx(ctx).Error("Failed to execute task: " + err.Error())
 		return
 	}
 
@@ -475,8 +472,7 @@ func (sched *taskScheduler) processTask(t task, q taskQueue) {
 
 	if err != nil {
 		trace.LogError(span, err)
-		log.Error("Failed to post-execute task: "+err.Error(),
-			zap.String("traceID", traceID))
+		log.Ctx(ctx).Error("Failed to post-execute task: " + err.Error())
 		return
 	}
 }

--- a/internal/querycoord/channel_allocator.go
+++ b/internal/querycoord/channel_allocator.go
@@ -56,7 +56,7 @@ func shuffleChannelsToQueryNode(ctx context.Context, reqs []*querypb.WatchDmChan
 		}
 		if len(onlineNodeIDs) == 0 {
 			err := errors.New("no online QueryNode to allocate")
-			log.Error("shuffleChannelsToQueryNode failed", zap.Error(err))
+			log.Ctx(ctx).Error("shuffleChannelsToQueryNode failed", zap.Error(err))
 			if !wait {
 				return err
 			}
@@ -85,7 +85,7 @@ func shuffleChannelsToQueryNode(ctx context.Context, reqs []*querypb.WatchDmChan
 		}
 
 		if len(availableNodeIDs) > 0 {
-			log.Debug("shuffleChannelsToQueryNode: shuffle channel to available QueryNode", zap.Int64s("available nodeIDs", availableNodeIDs))
+			log.Ctx(ctx).Debug("shuffleChannelsToQueryNode: shuffle channel to available QueryNode", zap.Int64s("available nodeIDs", availableNodeIDs))
 			for _, req := range reqs {
 				sort.Slice(availableNodeIDs, func(i, j int) bool {
 					return nodeID2NumChannels[availableNodeIDs[i]] < nodeID2NumChannels[availableNodeIDs[j]]
@@ -99,7 +99,7 @@ func shuffleChannelsToQueryNode(ctx context.Context, reqs []*querypb.WatchDmChan
 
 		if !wait {
 			err := errors.New("no available queryNode to allocate")
-			log.Error("shuffleChannelsToQueryNode failed", zap.Int64s("online nodeIDs", onlineNodeIDs), zap.Int64s("exclude nodeIDs", excludeNodeIDs), zap.Error(err))
+			log.Ctx(ctx).Error("shuffleChannelsToQueryNode failed", zap.Int64s("online nodeIDs", onlineNodeIDs), zap.Int64s("exclude nodeIDs", excludeNodeIDs), zap.Error(err))
 			return err
 		}
 

--- a/internal/querycoord/global_meta_broker.go
+++ b/internal/querycoord/global_meta_broker.go
@@ -62,15 +62,15 @@ func (broker *globalMetaBroker) invalidateCollectionMetaCache(ctx context.Contex
 
 	res, err := broker.rootCoord.InvalidateCollectionMetaCache(ctx1, req)
 	if err != nil {
-		log.Error("InvalidateCollMetaCacheRequest failed", zap.Int64("collectionID", collectionID), zap.Error(err))
+		log.Ctx(ctx).Error("InvalidateCollMetaCacheRequest failed", zap.Int64("collectionID", collectionID), zap.Error(err))
 		return err
 	}
 	if res.ErrorCode != commonpb.ErrorCode_Success {
 		err = errors.New(res.Reason)
-		log.Error("InvalidateCollMetaCacheRequest failed", zap.Int64("collectionID", collectionID), zap.Error(err))
+		log.Ctx(ctx).Error("InvalidateCollMetaCacheRequest failed", zap.Int64("collectionID", collectionID), zap.Error(err))
 		return err
 	}
-	log.Info("InvalidateCollMetaCacheRequest successfully", zap.Int64("collectionID", collectionID))
+	log.Ctx(ctx).Info("InvalidateCollMetaCacheRequest successfully", zap.Int64("collectionID", collectionID))
 
 	return nil
 }
@@ -86,16 +86,16 @@ func (broker *globalMetaBroker) showPartitionIDs(ctx context.Context, collection
 	}
 	showPartitionResponse, err := broker.rootCoord.ShowPartitions(ctx2, showPartitionRequest)
 	if err != nil {
-		log.Error("showPartition failed", zap.Int64("collectionID", collectionID), zap.Error(err))
+		log.Ctx(ctx).Error("showPartition failed", zap.Int64("collectionID", collectionID), zap.Error(err))
 		return nil, err
 	}
 
 	if showPartitionResponse.Status.ErrorCode != commonpb.ErrorCode_Success {
 		err = errors.New(showPartitionResponse.Status.Reason)
-		log.Error("showPartition failed", zap.Int64("collectionID", collectionID), zap.Error(err))
+		log.Ctx(ctx).Error("showPartition failed", zap.Int64("collectionID", collectionID), zap.Error(err))
 		return nil, err
 	}
-	log.Info("show partition successfully", zap.Int64("collectionID", collectionID), zap.Int64s("partitionIDs", showPartitionResponse.PartitionIDs))
+	log.Ctx(ctx).Info("show partition successfully", zap.Int64("collectionID", collectionID), zap.Int64s("partitionIDs", showPartitionResponse.PartitionIDs))
 
 	return showPartitionResponse.PartitionIDs, nil
 }
@@ -112,16 +112,16 @@ func (broker *globalMetaBroker) getRecoveryInfo(ctx context.Context, collectionI
 	}
 	recoveryInfo, err := broker.dataCoord.GetRecoveryInfo(ctx2, getRecoveryInfoRequest)
 	if err != nil {
-		log.Error("get recovery info failed", zap.Int64("collectionID", collectionID), zap.Int64("partitionID", partitionID), zap.Error(err))
+		log.Ctx(ctx).Error("get recovery info failed", zap.Int64("collectionID", collectionID), zap.Int64("partitionID", partitionID), zap.Error(err))
 		return nil, nil, err
 	}
 
 	if recoveryInfo.Status.ErrorCode != commonpb.ErrorCode_Success {
 		err = errors.New(recoveryInfo.Status.Reason)
-		log.Error("get recovery info failed", zap.Int64("collectionID", collectionID), zap.Int64("partitionID", partitionID), zap.Error(err))
+		log.Ctx(ctx).Error("get recovery info failed", zap.Int64("collectionID", collectionID), zap.Int64("partitionID", partitionID), zap.Error(err))
 		return nil, nil, err
 	}
-	log.Info("get recovery info successfully",
+	log.Ctx(ctx).Info("get recovery info successfully",
 		zap.Int64("collectionID", collectionID),
 		zap.Int64("partitionID", partitionID),
 		zap.Int("num channels", len(recoveryInfo.Channels)),
@@ -142,7 +142,7 @@ func (broker *globalMetaBroker) getIndexBuildID(ctx context.Context, collectionI
 	defer cancel2()
 	response, err := broker.rootCoord.DescribeSegment(ctx2, req)
 	if err != nil {
-		log.Error("describe segment from rootCoord failed",
+		log.Ctx(ctx).Error("describe segment from rootCoord failed",
 			zap.Int64("collectionID", collectionID),
 			zap.Int64("segmentID", segmentID),
 			zap.Error(err))
@@ -150,7 +150,7 @@ func (broker *globalMetaBroker) getIndexBuildID(ctx context.Context, collectionI
 	}
 	if response.Status.ErrorCode != commonpb.ErrorCode_Success {
 		err = errors.New(response.Status.Reason)
-		log.Error("describe segment from rootCoord failed",
+		log.Ctx(ctx).Error("describe segment from rootCoord failed",
 			zap.Int64("collectionID", collectionID),
 			zap.Int64("segmentID", segmentID),
 			zap.Error(err))
@@ -158,14 +158,14 @@ func (broker *globalMetaBroker) getIndexBuildID(ctx context.Context, collectionI
 	}
 
 	if !response.EnableIndex {
-		log.Info("describe segment from rootCoord successfully",
+		log.Ctx(ctx).Info("describe segment from rootCoord successfully",
 			zap.Int64("collectionID", collectionID),
 			zap.Int64("segmentID", segmentID),
 			zap.Bool("enableIndex", false))
 		return false, 0, nil
 	}
 
-	log.Info("describe segment from rootCoord successfully",
+	log.Ctx(ctx).Info("describe segment from rootCoord successfully",
 		zap.Int64("collectionID", collectionID),
 		zap.Int64("segmentID", segmentID),
 		zap.Bool("enableIndex", true),
@@ -181,7 +181,7 @@ func (broker *globalMetaBroker) getIndexFilePaths(ctx context.Context, buildID i
 	defer cancel3()
 	pathResponse, err := broker.indexCoord.GetIndexFilePaths(ctx3, indexFilePathRequest)
 	if err != nil {
-		log.Error("get index info from indexCoord failed",
+		log.Ctx(ctx).Error("get index info from indexCoord failed",
 			zap.Int64("indexBuildID", buildID),
 			zap.Error(err))
 		return nil, err
@@ -189,17 +189,17 @@ func (broker *globalMetaBroker) getIndexFilePaths(ctx context.Context, buildID i
 
 	if pathResponse.Status.ErrorCode != commonpb.ErrorCode_Success {
 		err = fmt.Errorf("get index info from indexCoord failed, buildID = %d, reason = %s", buildID, pathResponse.Status.Reason)
-		log.Error(err.Error())
+		log.Ctx(ctx).Error(err.Error())
 		return nil, err
 	}
-	log.Info("get index info from indexCoord successfully", zap.Int64("buildID", buildID))
+	log.Ctx(ctx).Info("get index info from indexCoord successfully", zap.Int64("buildID", buildID))
 
 	return pathResponse.FilePaths, nil
 }
 
 func (broker *globalMetaBroker) parseIndexInfo(ctx context.Context, segmentID UniqueID, indexInfo *querypb.FieldIndexInfo) error {
 	if !indexInfo.EnableIndex {
-		log.Debug(fmt.Sprintf("fieldID %d of segment %d don't has index", indexInfo.FieldID, segmentID))
+		log.Ctx(ctx).Debug(fmt.Sprintf("fieldID %d of segment %d don't has index", indexInfo.FieldID, segmentID))
 		return nil
 	}
 	buildID := indexInfo.BuildID
@@ -210,21 +210,21 @@ func (broker *globalMetaBroker) parseIndexInfo(ctx context.Context, segmentID Un
 
 	if len(indexFilePathInfos) != 1 {
 		err = fmt.Errorf("illegal index file paths, there should be only one vector column,  segmentID = %d, fieldID = %d, buildID = %d", segmentID, indexInfo.FieldID, buildID)
-		log.Error(err.Error())
+		log.Ctx(ctx).Error(err.Error())
 		return err
 	}
 
 	fieldPathInfo := indexFilePathInfos[0]
 	if len(fieldPathInfo.IndexFilePaths) == 0 {
 		err = fmt.Errorf("empty index paths, segmentID = %d, fieldID = %d, buildID = %d", segmentID, indexInfo.FieldID, buildID)
-		log.Error(err.Error())
+		log.Ctx(ctx).Error(err.Error())
 		return err
 	}
 
 	indexInfo.IndexFilePaths = fieldPathInfo.IndexFilePaths
 	indexInfo.IndexSize = int64(fieldPathInfo.SerializedSize)
 
-	log.Debug("get indexFilePath info from indexCoord success", zap.Int64("segmentID", segmentID), zap.Int64("fieldID", indexInfo.FieldID), zap.Int64("buildID", buildID), zap.Strings("indexPaths", fieldPathInfo.IndexFilePaths))
+	log.Ctx(ctx).Debug("get indexFilePath info from indexCoord success", zap.Int64("segmentID", segmentID), zap.Int64("fieldID", indexInfo.FieldID), zap.Int64("buildID", buildID), zap.Strings("indexPaths", fieldPathInfo.IndexFilePaths))
 
 	indexCodec := storage.NewIndexFileBinlogCodec()
 	for _, indexFilePath := range fieldPathInfo.IndexFilePaths {
@@ -232,7 +232,7 @@ func (broker *globalMetaBroker) parseIndexInfo(ctx context.Context, segmentID Un
 		if path.Base(indexFilePath) == storage.IndexParamsKey {
 			indexPiece, err := broker.cm.Read(indexFilePath)
 			if err != nil {
-				log.Error("load index params file failed",
+				log.Ctx(ctx).Error("load index params file failed",
 					zap.Int64("segmentID", segmentID),
 					zap.Int64("fieldID", indexInfo.FieldID),
 					zap.Int64("indexBuildID", buildID),
@@ -242,7 +242,7 @@ func (broker *globalMetaBroker) parseIndexInfo(ctx context.Context, segmentID Un
 			}
 			_, indexParams, indexName, indexID, err := indexCodec.Deserialize([]*storage.Blob{{Key: storage.IndexParamsKey, Value: indexPiece}})
 			if err != nil {
-				log.Error("deserialize index params file failed",
+				log.Ctx(ctx).Error("deserialize index params file failed",
 					zap.Int64("segmentID", segmentID),
 					zap.Int64("fieldID", indexInfo.FieldID),
 					zap.Int64("indexBuildID", buildID),
@@ -252,7 +252,7 @@ func (broker *globalMetaBroker) parseIndexInfo(ctx context.Context, segmentID Un
 			}
 			if len(indexParams) <= 0 {
 				err = fmt.Errorf("cannot find index param, segmentID = %d, fieldID = %d, buildID = %d, indexFilePath = %s", segmentID, indexInfo.FieldID, buildID, indexFilePath)
-				log.Error(err.Error())
+				log.Ctx(ctx).Error(err.Error())
 				return err
 			}
 			indexInfo.IndexName = indexName
@@ -264,11 +264,11 @@ func (broker *globalMetaBroker) parseIndexInfo(ctx context.Context, segmentID Un
 
 	if len(indexInfo.IndexParams) == 0 {
 		err = fmt.Errorf("no index params in Index file, segmentID = %d, fieldID = %d, buildID = %d, indexPaths = %v", segmentID, indexInfo.FieldID, buildID, fieldPathInfo.IndexFilePaths)
-		log.Error(err.Error())
+		log.Ctx(ctx).Error(err.Error())
 		return err
 	}
 
-	log.Info("set index info  success", zap.Int64("segmentID", segmentID), zap.Int64("fieldID", indexInfo.FieldID), zap.Int64("buildID", buildID))
+	log.Ctx(ctx).Info("set index info  success", zap.Int64("segmentID", segmentID), zap.Int64("fieldID", indexInfo.FieldID), zap.Int64("buildID", buildID))
 
 	return nil
 }
@@ -312,14 +312,14 @@ func (broker *globalMetaBroker) describeSegments(ctx context.Context, collection
 		SegmentIDs:   segmentIDs,
 	})
 	if err != nil {
-		log.Error("failed to describe segments",
+		log.Ctx(ctx).Error("failed to describe segments",
 			zap.Int64("collection", collectionID),
 			zap.Int64s("segments", segmentIDs),
 			zap.Error(err))
 		return nil, err
 	}
 
-	log.Info("describe segments successfully",
+	log.Ctx(ctx).Info("describe segments successfully",
 		zap.Int64("collection", collectionID),
 		zap.Int64s("segments", segmentIDs))
 
@@ -337,7 +337,7 @@ func (broker *globalMetaBroker) getFullIndexInfos(ctx context.Context, collectio
 	for _, segmentID := range segmentIDs {
 		infos, ok := resp.GetSegmentInfos()[segmentID]
 		if !ok {
-			log.Warn("segment not found",
+			log.Ctx(ctx).Warn("segment not found",
 				zap.Int64("collection", collectionID),
 				zap.Int64("segment", segmentID))
 			return nil, fmt.Errorf("segment not found, collection: %d, segment: %d", collectionID, segmentID)
@@ -368,7 +368,7 @@ func (broker *globalMetaBroker) getFullIndexInfos(ctx context.Context, collectio
 			paths, err := broker.getIndexFilePaths(ctx, info.BuildID)
 			//TODO:: returns partially successful index
 			if err != nil {
-				log.Warn("failed to get index file paths",
+				log.Ctx(ctx).Warn("failed to get index file paths",
 					zap.Int64("collection", collectionID),
 					zap.Int64("segment", segmentID),
 					zap.Int64("buildID", info.BuildID),
@@ -377,7 +377,7 @@ func (broker *globalMetaBroker) getFullIndexInfos(ctx context.Context, collectio
 			}
 
 			if len(paths) <= 0 || len(paths[0].IndexFilePaths) <= 0 {
-				log.Warn("index not ready", zap.Int64("index_build_id", info.BuildID))
+				log.Ctx(ctx).Warn("index not ready", zap.Int64("index_build_id", info.BuildID))
 				return nil, fmt.Errorf("index not ready, index build id: %d", info.BuildID)
 			}
 
@@ -391,7 +391,7 @@ func (broker *globalMetaBroker) getFullIndexInfos(ctx context.Context, collectio
 				// get index name, index params from binlog.
 				extra, err := broker.loadIndexExtraInfo(ctx, paths[0])
 				if err != nil {
-					log.Error("failed to load index extra info",
+					log.Ctx(ctx).Error("failed to load index extra info",
 						zap.Int64("index build id", info.BuildID),
 						zap.Error(err))
 					return nil, err
@@ -460,19 +460,19 @@ func (broker *globalMetaBroker) getSegmentStates(ctx context.Context, segmentID 
 	}
 	resp, err := broker.dataCoord.GetSegmentStates(ctx2, req)
 	if err != nil {
-		log.Error("get segment states failed from dataCoord,", zap.Int64("segmentID", segmentID), zap.Error(err))
+		log.Ctx(ctx).Error("get segment states failed from dataCoord,", zap.Int64("segmentID", segmentID), zap.Error(err))
 		return nil, err
 	}
 
 	if resp.Status.ErrorCode != commonpb.ErrorCode_Success {
 		err = errors.New(resp.Status.Reason)
-		log.Error("get segment states failed from dataCoord,", zap.Int64("segmentID", segmentID), zap.Error(err))
+		log.Ctx(ctx).Error("get segment states failed from dataCoord,", zap.Int64("segmentID", segmentID), zap.Error(err))
 		return nil, err
 	}
 
 	if len(resp.States) != 1 {
 		err = fmt.Errorf("the length of segmentStates result should be 1, segmentID = %d", segmentID)
-		log.Error(err.Error())
+		log.Ctx(ctx).Error(err.Error())
 		return nil, err
 	}
 
@@ -489,12 +489,12 @@ func (broker *globalMetaBroker) acquireSegmentsReferLock(ctx context.Context, ta
 	}
 	status, err := broker.dataCoord.AcquireSegmentLock(ctx, acquireSegLockReq)
 	if err != nil {
-		log.Error("QueryCoord acquire the segment reference lock error", zap.Int64s("segIDs", segmentIDs),
+		log.Ctx(ctx).Error("QueryCoord acquire the segment reference lock error", zap.Int64s("segIDs", segmentIDs),
 			zap.Error(err))
 		return err
 	}
 	if status.ErrorCode != commonpb.ErrorCode_Success {
-		log.Error("QueryCoord acquire the segment reference lock error", zap.Int64s("segIDs", segmentIDs),
+		log.Ctx(ctx).Error("QueryCoord acquire the segment reference lock error", zap.Int64s("segIDs", segmentIDs),
 			zap.String("failed reason", status.Reason))
 		return fmt.Errorf(status.Reason)
 	}
@@ -515,13 +515,13 @@ func (broker *globalMetaBroker) releaseSegmentReferLock(ctx context.Context, tas
 	if err := retry.Do(ctx, func() error {
 		status, err := broker.dataCoord.ReleaseSegmentLock(ctx, releaseSegReferLockReq)
 		if err != nil {
-			log.Error("QueryCoord release reference lock on segments failed", zap.Int64s("segmentIDs", segmentIDs),
+			log.Ctx(ctx).Error("QueryCoord release reference lock on segments failed", zap.Int64s("segmentIDs", segmentIDs),
 				zap.Error(err))
 			return err
 		}
 
 		if status.ErrorCode != commonpb.ErrorCode_Success {
-			log.Error("QueryCoord release reference lock on segments failed", zap.Int64s("segmentIDs", segmentIDs),
+			log.Ctx(ctx).Error("QueryCoord release reference lock on segments failed", zap.Int64s("segmentIDs", segmentIDs),
 				zap.String("failed reason", status.Reason))
 			return errors.New(status.Reason)
 		}

--- a/internal/querycoord/metrics_info.go
+++ b/internal/querycoord/metrics_info.go
@@ -69,7 +69,7 @@ func getSystemInfoMetrics(
 	nodesMetrics := qc.cluster.GetMetrics(ctx, req)
 	for _, nodeMetrics := range nodesMetrics {
 		if nodeMetrics.err != nil {
-			log.Warn("invalid metrics of query node was found",
+			log.Ctx(ctx).Warn("invalid metrics of query node was found",
 				zap.Error(nodeMetrics.err))
 			clusterTopology.ConnectedNodes = append(clusterTopology.ConnectedNodes, metricsinfo.QueryNodeInfos{
 				BaseComponentInfos: metricsinfo.BaseComponentInfos{
@@ -84,7 +84,7 @@ func getSystemInfoMetrics(
 		}
 
 		if nodeMetrics.resp.Status.ErrorCode != commonpb.ErrorCode_Success {
-			log.Warn("invalid metrics of query node was found",
+			log.Ctx(ctx).Warn("invalid metrics of query node was found",
 				zap.Any("error_code", nodeMetrics.resp.Status.ErrorCode),
 				zap.Any("error_reason", nodeMetrics.resp.Status.Reason))
 			clusterTopology.ConnectedNodes = append(clusterTopology.ConnectedNodes, metricsinfo.QueryNodeInfos{
@@ -101,7 +101,7 @@ func getSystemInfoMetrics(
 		infos := metricsinfo.QueryNodeInfos{}
 		err := metricsinfo.UnmarshalComponentInfos(nodeMetrics.resp.Response, &infos)
 		if err != nil {
-			log.Warn("invalid metrics of query node was found",
+			log.Ctx(ctx).Warn("invalid metrics of query node was found",
 				zap.Error(err))
 			clusterTopology.ConnectedNodes = append(clusterTopology.ConnectedNodes, metricsinfo.QueryNodeInfos{
 				BaseComponentInfos: metricsinfo.BaseComponentInfos{

--- a/internal/querycoord/query_coord.go
+++ b/internal/querycoord/query_coord.go
@@ -715,9 +715,9 @@ func (qc *QueryCoord) loadBalanceSegmentLoop() {
 					// if failed, wait for next balance loop
 					// it may be that the collection/partition of the balanced segment has been released
 					// it also may be other abnormal errors
-					log.Error("loadBalanceSegmentLoop: balance task execute failed", zap.Any("task", t))
+					log.Ctx(t.ctx).Error("loadBalanceSegmentLoop: balance task execute failed", zap.Any("task", t))
 				} else {
-					log.Info("loadBalanceSegmentLoop: balance task execute success", zap.Any("task", t))
+					log.Ctx(t.ctx).Info("loadBalanceSegmentLoop: balance task execute success", zap.Any("task", t))
 				}
 			}
 		}

--- a/internal/querycoord/querynode.go
+++ b/internal/querycoord/querynode.go
@@ -214,7 +214,7 @@ func (qn *queryNode) watchDeltaChannels(ctx context.Context, in *querypb.WatchDe
 
 func (qn *queryNode) releaseCollection(ctx context.Context, in *querypb.ReleaseCollectionRequest) error {
 	if !qn.isOnline() {
-		log.Warn("ReleaseCollection: the QueryNode has been offline, the release request is no longer needed", zap.Int64("nodeID", qn.id))
+		log.Ctx(ctx).Warn("ReleaseCollection: the QueryNode has been offline, the release request is no longer needed", zap.Int64("nodeID", qn.id))
 		return nil
 	}
 

--- a/internal/querynode/flow_graph_delete_node.go
+++ b/internal/querynode/flow_graph_delete_node.go
@@ -95,7 +95,7 @@ func (dNode *deleteNode) Operate(in []flowgraph.Msg) []flowgraph.Msg {
 	// 1. filter segment by bloom filter
 	for i, delMsg := range dMsg.deleteMessages {
 		traceID, _, _ := trace.InfoFromSpan(spans[i])
-		log.Debug("delete in historical replica",
+		log.Ctx(delMsg.TraceCtx()).Debug("delete in historical replica",
 			zap.String("channel", dNode.channel),
 			zap.Any("collectionID", delMsg.CollectionID),
 			zap.Any("collectionName", delMsg.CollectionName),
@@ -112,7 +112,7 @@ func (dNode *deleteNode) Operate(in []flowgraph.Msg) []flowgraph.Msg {
 			if err != nil {
 				// error occurs when missing meta info or unexpected pk type, should not happen
 				err = fmt.Errorf("deleteNode processDeleteMessages failed, collectionID = %d, err = %s, channel = %s", delMsg.CollectionID, err, dNode.channel)
-				log.Error(err.Error())
+				log.Ctx(delMsg.TraceCtx()).Error(err.Error())
 				panic(err)
 			}
 		}

--- a/internal/querynode/flow_graph_filter_delete_node.go
+++ b/internal/querynode/flow_graph_filter_delete_node.go
@@ -94,14 +94,14 @@ func (fddNode *filterDeleteNode) Operate(in []flowgraph.Msg) []flowgraph.Msg {
 			if err != nil {
 				// error occurs when missing meta info or data is misaligned, should not happen
 				err = fmt.Errorf("filterInvalidDeleteMessage failed, err = %s, collection = %d, channel = %s", err, fddNode.collectionID, fddNode.channel)
-				log.Error(err.Error())
+				log.Ctx(msg.TraceCtx()).Error(err.Error())
 				panic(err)
 			}
 			if resMsg != nil {
 				dMsg.deleteMessages = append(dMsg.deleteMessages, resMsg)
 			}
 		default:
-			log.Warn("invalid message type in filterDeleteNode",
+			log.Ctx(msg.TraceCtx()).Warn("invalid message type in filterDeleteNode",
 				zap.String("message type", msg.Type().String()),
 				zap.Int64("collection", fddNode.collectionID),
 				zap.String("channel", fddNode.channel))
@@ -129,7 +129,7 @@ func (fddNode *filterDeleteNode) filterInvalidDeleteMessage(msg *msgstream.Delet
 	}
 
 	if len(msg.Timestamps) <= 0 {
-		log.Debug("filter invalid delete message, no message",
+		log.Ctx(msg.TraceCtx()).Debug("filter invalid delete message, no message",
 			zap.String("channel", fddNode.channel),
 			zap.Any("collectionID", msg.CollectionID),
 			zap.Any("partitionID", msg.PartitionID))

--- a/internal/querynode/impl.go
+++ b/internal/querynode/impl.go
@@ -63,7 +63,7 @@ func (node *QueryNode) GetComponentStates(ctx context.Context) (*internalpb.Comp
 		StateCode: code,
 	}
 	stats.State = info
-	log.Debug("Get QueryNode component state done", zap.Any("stateCode", info.StateCode))
+	log.Ctx(ctx).Debug("Get QueryNode component state done", zap.Any("stateCode", info.StateCode))
 	return stats, nil
 }
 
@@ -116,10 +116,10 @@ func (node *QueryNode) WatchDmChannels(ctx context.Context, in *queryPb.WatchDmC
 			ErrorCode: commonpb.ErrorCode_UnexpectedError,
 			Reason:    err.Error(),
 		}
-		log.Warn(err.Error())
+		log.Ctx(ctx).Warn(err.Error())
 		return status, nil
 	}
-	log.Info("watchDmChannelsTask Enqueue done", zap.Int64("collectionID", in.CollectionID), zap.Int64("nodeID", Params.QueryNodeCfg.GetNodeID()), zap.Int64("replicaID", in.GetReplicaID()))
+	log.Ctx(ctx).Info("watchDmChannelsTask Enqueue done", zap.Int64("collectionID", in.CollectionID), zap.Int64("nodeID", Params.QueryNodeCfg.GetNodeID()), zap.Int64("replicaID", in.GetReplicaID()))
 	waitFunc := func() (*commonpb.Status, error) {
 		err = dct.WaitToFinish()
 		if err != nil {
@@ -127,10 +127,10 @@ func (node *QueryNode) WatchDmChannels(ctx context.Context, in *queryPb.WatchDmC
 				ErrorCode: commonpb.ErrorCode_UnexpectedError,
 				Reason:    err.Error(),
 			}
-			log.Warn(err.Error())
+			log.Ctx(ctx).Warn(err.Error())
 			return status, nil
 		}
-		log.Info("watchDmChannelsTask WaitToFinish done", zap.Int64("collectionID", in.CollectionID), zap.Int64("nodeID", Params.QueryNodeCfg.GetNodeID()))
+		log.Ctx(ctx).Info("watchDmChannelsTask WaitToFinish done", zap.Int64("collectionID", in.CollectionID), zap.Int64("nodeID", Params.QueryNodeCfg.GetNodeID()))
 		return &commonpb.Status{
 			ErrorCode: commonpb.ErrorCode_Success,
 		}, nil
@@ -165,11 +165,11 @@ func (node *QueryNode) WatchDeltaChannels(ctx context.Context, in *queryPb.Watch
 			ErrorCode: commonpb.ErrorCode_UnexpectedError,
 			Reason:    err.Error(),
 		}
-		log.Warn(err.Error())
+		log.Ctx(ctx).Warn(err.Error())
 		return status, nil
 	}
 
-	log.Info("watchDeltaChannelsTask Enqueue done", zap.Int64("collectionID", in.CollectionID), zap.Int64("nodeID", Params.QueryNodeCfg.GetNodeID()))
+	log.Ctx(ctx).Info("watchDeltaChannelsTask Enqueue done", zap.Int64("collectionID", in.CollectionID), zap.Int64("nodeID", Params.QueryNodeCfg.GetNodeID()))
 
 	waitFunc := func() (*commonpb.Status, error) {
 		err = dct.WaitToFinish()
@@ -178,11 +178,11 @@ func (node *QueryNode) WatchDeltaChannels(ctx context.Context, in *queryPb.Watch
 				ErrorCode: commonpb.ErrorCode_UnexpectedError,
 				Reason:    err.Error(),
 			}
-			log.Warn(err.Error())
+			log.Ctx(ctx).Warn(err.Error())
 			return status, nil
 		}
 
-		log.Info("watchDeltaChannelsTask WaitToFinish done", zap.Int64("collectionID", in.CollectionID), zap.Int64("nodeID", Params.QueryNodeCfg.GetNodeID()))
+		log.Ctx(ctx).Info("watchDeltaChannelsTask WaitToFinish done", zap.Int64("collectionID", in.CollectionID), zap.Int64("nodeID", Params.QueryNodeCfg.GetNodeID()))
 		return &commonpb.Status{
 			ErrorCode: commonpb.ErrorCode_Success,
 		}, nil
@@ -221,11 +221,11 @@ func (node *QueryNode) LoadSegments(ctx context.Context, in *queryPb.LoadSegment
 			ErrorCode: commonpb.ErrorCode_UnexpectedError,
 			Reason:    err.Error(),
 		}
-		log.Warn(err.Error())
+		log.Ctx(ctx).Warn(err.Error())
 		return status, nil
 	}
 
-	log.Info("loadSegmentsTask Enqueue done", zap.Int64("collectionID", in.CollectionID), zap.Int64s("segmentIDs", segmentIDs), zap.Int64("nodeID", Params.QueryNodeCfg.GetNodeID()))
+	log.Ctx(ctx).Info("loadSegmentsTask Enqueue done", zap.Int64("collectionID", in.CollectionID), zap.Int64s("segmentIDs", segmentIDs), zap.Int64("nodeID", Params.QueryNodeCfg.GetNodeID()))
 
 	waitFunc := func() (*commonpb.Status, error) {
 		err = dct.WaitToFinish()
@@ -234,10 +234,10 @@ func (node *QueryNode) LoadSegments(ctx context.Context, in *queryPb.LoadSegment
 				ErrorCode: commonpb.ErrorCode_UnexpectedError,
 				Reason:    err.Error(),
 			}
-			log.Warn(err.Error())
+			log.Ctx(ctx).Warn(err.Error())
 			return status, nil
 		}
-		log.Info("loadSegmentsTask WaitToFinish done", zap.Int64("collectionID", in.CollectionID), zap.Int64s("segmentIDs", segmentIDs), zap.Int64("nodeID", Params.QueryNodeCfg.GetNodeID()))
+		log.Ctx(ctx).Info("loadSegmentsTask WaitToFinish done", zap.Int64("collectionID", in.CollectionID), zap.Int64s("segmentIDs", segmentIDs), zap.Int64("nodeID", Params.QueryNodeCfg.GetNodeID()))
 		return &commonpb.Status{
 			ErrorCode: commonpb.ErrorCode_Success,
 		}, nil
@@ -272,18 +272,18 @@ func (node *QueryNode) ReleaseCollection(ctx context.Context, in *queryPb.Releas
 			ErrorCode: commonpb.ErrorCode_UnexpectedError,
 			Reason:    err.Error(),
 		}
-		log.Warn(err.Error())
+		log.Ctx(ctx).Warn(err.Error())
 		return status, nil
 	}
-	log.Info("releaseCollectionTask Enqueue done", zap.Int64("collectionID", in.CollectionID))
+	log.Ctx(ctx).Info("releaseCollectionTask Enqueue done", zap.Int64("collectionID", in.CollectionID))
 
 	func() {
 		err = dct.WaitToFinish()
 		if err != nil {
-			log.Warn(err.Error())
+			log.Ctx(ctx).Warn(err.Error())
 			return
 		}
-		log.Info("releaseCollectionTask WaitToFinish done", zap.Int64("collectionID", in.CollectionID))
+		log.Ctx(ctx).Info("releaseCollectionTask WaitToFinish done", zap.Int64("collectionID", in.CollectionID))
 	}()
 
 	status := &commonpb.Status{
@@ -318,18 +318,18 @@ func (node *QueryNode) ReleasePartitions(ctx context.Context, in *queryPb.Releas
 			ErrorCode: commonpb.ErrorCode_UnexpectedError,
 			Reason:    err.Error(),
 		}
-		log.Warn(err.Error())
+		log.Ctx(ctx).Warn(err.Error())
 		return status, nil
 	}
-	log.Info("releasePartitionsTask Enqueue done", zap.Int64("collectionID", in.CollectionID), zap.Int64s("partitionIDs", in.PartitionIDs))
+	log.Ctx(ctx).Info("releasePartitionsTask Enqueue done", zap.Int64("collectionID", in.CollectionID), zap.Int64s("partitionIDs", in.PartitionIDs))
 
 	func() {
 		err = dct.WaitToFinish()
 		if err != nil {
-			log.Warn(err.Error())
+			log.Ctx(ctx).Warn(err.Error())
 			return
 		}
-		log.Info("releasePartitionsTask WaitToFinish done", zap.Int64("collectionID", in.CollectionID), zap.Int64s("partitionIDs", in.PartitionIDs))
+		log.Ctx(ctx).Info("releasePartitionsTask WaitToFinish done", zap.Int64("collectionID", in.CollectionID), zap.Int64s("partitionIDs", in.PartitionIDs))
 	}()
 
 	status := &commonpb.Status{
@@ -373,7 +373,7 @@ func (node *QueryNode) ReleaseSegments(ctx context.Context, in *queryPb.ReleaseS
 		}
 	}
 
-	log.Info("release segments done", zap.Int64("collectionID", in.CollectionID), zap.Int64s("segmentIDs", in.SegmentIDs), zap.String("Scope", in.GetScope().String()))
+	log.Ctx(ctx).Info("release segments done", zap.Int64("collectionID", in.CollectionID), zap.Int64s("segmentIDs", in.SegmentIDs), zap.String("Scope", in.GetScope().String()))
 	return &commonpb.Status{
 		ErrorCode: commonpb.ErrorCode_Success,
 	}, nil
@@ -507,7 +507,7 @@ func (node *QueryNode) searchWithDmlChannel(ctx context.Context, req *queryPb.Se
 	}
 
 	msgID := req.GetReq().GetBase().GetMsgID()
-	log.Debug("Received SearchRequest",
+	log.Ctx(ctx).Debug("Received SearchRequest",
 		zap.Int64("msgID", msgID),
 		zap.Bool("fromShardLeader", req.GetFromShardLeader()),
 		zap.String("vChannel", dmlChannel),
@@ -522,7 +522,7 @@ func (node *QueryNode) searchWithDmlChannel(ctx context.Context, req *queryPb.Se
 
 	qs, err := node.queryShardService.getQueryShard(dmlChannel)
 	if err != nil {
-		log.Warn("Search failed, failed to get query shard",
+		log.Ctx(ctx).Warn("Search failed, failed to get query shard",
 			zap.Int64("msgID", msgID),
 			zap.String("dml channel", dmlChannel),
 			zap.Error(err))
@@ -531,7 +531,7 @@ func (node *QueryNode) searchWithDmlChannel(ctx context.Context, req *queryPb.Se
 		return failRet, nil
 	}
 
-	log.Debug("start do search",
+	log.Ctx(ctx).Debug("start do search",
 		zap.Int64("msgID", msgID),
 		zap.Bool("fromShardLeader", req.GetFromShardLeader()),
 		zap.String("vChannel", dmlChannel),
@@ -659,7 +659,7 @@ func (node *QueryNode) queryWithDmlChannel(ctx context.Context, req *queryPb.Que
 	}
 
 	msgID := req.GetReq().GetBase().GetMsgID()
-	log.Debug("Received QueryRequest",
+	log.Ctx(ctx).Debug("Received QueryRequest",
 		zap.Int64("msgID", msgID),
 		zap.Bool("fromShardLeader", req.GetFromShardLeader()),
 		zap.String("vChannel", dmlChannel),
@@ -674,12 +674,12 @@ func (node *QueryNode) queryWithDmlChannel(ctx context.Context, req *queryPb.Que
 
 	qs, err := node.queryShardService.getQueryShard(dmlChannel)
 	if err != nil {
-		log.Warn("Query failed, failed to get query shard", zap.Int64("msgID", msgID), zap.String("dml channel", dmlChannel), zap.Error(err))
+		log.Ctx(ctx).Warn("Query failed, failed to get query shard", zap.Int64("msgID", msgID), zap.String("dml channel", dmlChannel), zap.Error(err))
 		failRet.Status.Reason = err.Error()
 		return failRet, nil
 	}
 
-	log.Debug("start do query",
+	log.Ctx(ctx).Debug("start do query",
 		zap.Int64("msgID", msgID),
 		zap.Bool("fromShardLeader", req.GetFromShardLeader()),
 		zap.String("vChannel", dmlChannel),
@@ -847,18 +847,18 @@ func (node *QueryNode) SyncReplicaSegments(ctx context.Context, req *querypb.Syn
 		}, nil
 	}
 
-	log.Debug("Received SyncReplicaSegments request", zap.String("vchannelName", req.GetVchannelName()))
+	log.Ctx(ctx).Debug("Received SyncReplicaSegments request", zap.String("vchannelName", req.GetVchannelName()))
 
 	err := node.ShardClusterService.SyncReplicaSegments(req.GetVchannelName(), req.GetReplicaSegments())
 	if err != nil {
-		log.Warn("failed to sync replica semgents,", zap.String("vchannel", req.GetVchannelName()), zap.Error(err))
+		log.Ctx(ctx).Warn("failed to sync replica semgents,", zap.String("vchannel", req.GetVchannelName()), zap.Error(err))
 		return &commonpb.Status{
 			ErrorCode: commonpb.ErrorCode_UnexpectedError,
 			Reason:    err.Error(),
 		}, nil
 	}
 
-	log.Debug("SyncReplicaSegments Done", zap.String("vchannel", req.GetVchannelName()))
+	log.Ctx(ctx).Debug("SyncReplicaSegments Done", zap.String("vchannel", req.GetVchannelName()))
 
 	return &commonpb.Status{ErrorCode: commonpb.ErrorCode_Success}, nil
 }
@@ -867,7 +867,7 @@ func (node *QueryNode) SyncReplicaSegments(ctx context.Context, req *querypb.Syn
 // TODO(dragondriver): cache the Metrics and set a retention to the cache
 func (node *QueryNode) GetMetrics(ctx context.Context, req *milvuspb.GetMetricsRequest) (*milvuspb.GetMetricsResponse, error) {
 	if !node.isHealthy() {
-		log.Warn("QueryNode.GetMetrics failed",
+		log.Ctx(ctx).Warn("QueryNode.GetMetrics failed",
 			zap.Int64("node_id", Params.QueryNodeCfg.GetNodeID()),
 			zap.String("req", req.Request),
 			zap.Error(errQueryNodeIsUnhealthy(Params.QueryNodeCfg.GetNodeID())))
@@ -883,7 +883,7 @@ func (node *QueryNode) GetMetrics(ctx context.Context, req *milvuspb.GetMetricsR
 
 	metricType, err := metricsinfo.ParseMetricType(req.Request)
 	if err != nil {
-		log.Warn("QueryNode.GetMetrics failed to parse metric type",
+		log.Ctx(ctx).Warn("QueryNode.GetMetrics failed to parse metric type",
 			zap.Int64("node_id", Params.QueryNodeCfg.GetNodeID()),
 			zap.String("req", req.Request),
 			zap.Error(err))
@@ -900,7 +900,7 @@ func (node *QueryNode) GetMetrics(ctx context.Context, req *milvuspb.GetMetricsR
 	if metricType == metricsinfo.SystemInfoMetrics {
 		metrics, err := getSystemInfoMetrics(ctx, req, node)
 		if err != nil {
-			log.Warn("QueryNode.GetMetrics failed",
+			log.Ctx(ctx).Warn("QueryNode.GetMetrics failed",
 				zap.Int64("node_id", Params.QueryNodeCfg.GetNodeID()),
 				zap.String("req", req.Request),
 				zap.String("metric_type", metricType),
@@ -910,7 +910,7 @@ func (node *QueryNode) GetMetrics(ctx context.Context, req *milvuspb.GetMetricsR
 		return metrics, nil
 	}
 
-	log.Debug("QueryNode.GetMetrics failed, request metric type is not implemented yet",
+	log.Ctx(ctx).Debug("QueryNode.GetMetrics failed, request metric type is not implemented yet",
 		zap.Int64("node_id", Params.QueryNodeCfg.GetNodeID()),
 		zap.String("req", req.Request),
 		zap.String("metric_type", metricType))

--- a/internal/querynode/shard_cluster.go
+++ b/internal/querynode/shard_cluster.go
@@ -731,9 +731,9 @@ func (sc *ShardCluster) Search(ctx context.Context, req *querypb.SearchRequest, 
 	segAllocs, versionID := sc.segmentAllocations(req.GetReq().GetPartitionIDs())
 	defer sc.finishUsage(versionID)
 
-	log.Debug("cluster segment distribution", zap.Int("len", len(segAllocs)))
+	log.Ctx(ctx).Debug("cluster segment distribution", zap.Int("len", len(segAllocs)))
 	for nodeID, segmentIDs := range segAllocs {
-		log.Debug("segments distribution", zap.Int64("nodeID", nodeID), zap.Int64s("segments", segmentIDs))
+		log.Ctx(ctx).Debug("segments distribution", zap.Int64("nodeID", nodeID), zap.Int64s("segments", segmentIDs))
 	}
 
 	// concurrent visiting nodes
@@ -795,7 +795,7 @@ func (sc *ShardCluster) Search(ctx context.Context, req *querypb.SearchRequest, 
 
 	wg.Wait()
 	if err != nil {
-		log.Error(err.Error())
+		log.Ctx(ctx).Error(err.Error())
 		return nil, err
 	}
 
@@ -873,7 +873,7 @@ func (sc *ShardCluster) Query(ctx context.Context, req *querypb.QueryRequest, wi
 
 	wg.Wait()
 	if err != nil {
-		log.Error(err.Error())
+		log.Ctx(ctx).Error(err.Error())
 		return nil, err
 	}
 

--- a/internal/querynode/task_query.go
+++ b/internal/querynode/task_query.go
@@ -66,7 +66,7 @@ func (q *queryTask) queryOnStreaming() error {
 	q.QS.collection.RLock() // locks the collectionPtr
 	defer q.QS.collection.RUnlock()
 	if _, released := q.QS.collection.getReleaseTime(); released {
-		log.Debug("collection release before search", zap.Int64("msgID", q.ID()),
+		log.Ctx(q.Ctx()).Debug("collection release before search", zap.Int64("msgID", q.ID()),
 			zap.Int64("collectionID", q.CollectionID))
 		return fmt.Errorf("retrieve failed, collection has been released, collectionID = %d", q.CollectionID)
 	}
@@ -114,7 +114,7 @@ func (q *queryTask) queryOnHistorical() error {
 	defer q.QS.collection.RUnlock()
 
 	if _, released := q.QS.collection.getReleaseTime(); released {
-		log.Debug("collection release before search", zap.Int64("msgID", q.ID()),
+		log.Ctx(q.Ctx()).Debug("collection release before search", zap.Int64("msgID", q.ID()),
 			zap.Int64("collectionID", q.CollectionID))
 		return fmt.Errorf("retrieve failed, collection has been released, collectionID = %d", q.CollectionID)
 	}

--- a/internal/querynode/task_read.go
+++ b/internal/querynode/task_read.go
@@ -144,7 +144,7 @@ func (b *baseReadTask) Ready() (bool, error) {
 	}
 
 	if _, released := b.QS.collection.getReleaseTime(); released {
-		log.Debug("collection release before search", zap.Int64("collectionID", b.CollectionID))
+		log.Ctx(b.ctx).Debug("collection release before search", zap.Int64("collectionID", b.CollectionID))
 		return false, fmt.Errorf("collection has been released, taskID = %d, collectionID = %d", b.ID(), b.CollectionID)
 	}
 
@@ -158,7 +158,7 @@ func (b *baseReadTask) Ready() (bool, error) {
 	if guaranteeTs > serviceTime {
 		return false, nil
 	}
-	log.Debug("query msg can do",
+	log.Ctx(b.ctx).Debug("query msg can do",
 		zap.Any("collectionID", b.CollectionID),
 		zap.Any("sm.GuaranteeTimestamp", gt),
 		zap.Any("serviceTime", st),

--- a/internal/querynode/task_search.go
+++ b/internal/querynode/task_search.go
@@ -102,7 +102,7 @@ func (s *searchTask) searchOnStreaming() error {
 	s.QS.collection.RLock() // locks the collectionPtr
 	defer s.QS.collection.RUnlock()
 	if _, released := s.QS.collection.getReleaseTime(); released {
-		log.Debug("collection release before search", zap.Int64("msgID", s.ID()),
+		log.Ctx(s.Ctx()).Debug("collection release before search", zap.Int64("msgID", s.ID()),
 			zap.Int64("collectionID", s.CollectionID))
 		return fmt.Errorf("retrieve failed, collection has been released, collectionID = %d", s.CollectionID)
 	}
@@ -116,7 +116,7 @@ func (s *searchTask) searchOnStreaming() error {
 	// TODO add context
 	partResults, _, _, sErr := searchStreaming(s.QS.metaReplica, searchReq, s.CollectionID, s.iReq.GetPartitionIDs(), s.req.GetDmlChannels()[0])
 	if sErr != nil {
-		log.Debug("failed to search streaming data", zap.Int64("msgID", s.ID()),
+		log.Ctx(s.Ctx()).Debug("failed to search streaming data", zap.Int64("msgID", s.ID()),
 			zap.Int64("collectionID", s.CollectionID), zap.Error(sErr))
 		return sErr
 	}
@@ -139,7 +139,7 @@ func (s *searchTask) searchOnHistorical() error {
 	s.QS.collection.RLock() // locks the collectionPtr
 	defer s.QS.collection.RUnlock()
 	if _, released := s.QS.collection.getReleaseTime(); released {
-		log.Debug("collection release before search", zap.Int64("msgID", s.ID()),
+		log.Ctx(s.Ctx()).Debug("collection release before search", zap.Int64("msgID", s.ID()),
 			zap.Int64("collectionID", s.CollectionID))
 		return fmt.Errorf("retrieve failed, collection has been released, collectionID = %d", s.CollectionID)
 	}
@@ -235,7 +235,7 @@ func (s *searchTask) reduceResults(searchReq *searchRequest, results []*SearchRe
 		for i := 0; i < cnt; i++ {
 			blob, err := getSearchResultDataBlob(blobs, i)
 			if err != nil {
-				log.Debug("getSearchResultDataBlob for historical results error", zap.Int64("msgID", s.ID()),
+				log.Ctx(s.Ctx()).Debug("getSearchResultDataBlob for historical results error", zap.Int64("msgID", s.ID()),
 					zap.Error(err))
 				return err
 			}

--- a/internal/rootcoord/metrics_info.go
+++ b/internal/rootcoord/metrics_info.go
@@ -61,7 +61,7 @@ func (c *Core) getSystemInfoMetrics(ctx context.Context, req *milvuspb.GetMetric
 
 	resp, err := metricsinfo.MarshalTopology(rootCoordTopology)
 	if err != nil {
-		log.Warn("Failed to marshal system info metrics of root coordinator",
+		log.Ctx(ctx).Warn("Failed to marshal system info metrics of root coordinator",
 			zap.Error(err))
 
 		return &milvuspb.GetMetricsResponse{

--- a/internal/rootcoord/proxy_client_manager.go
+++ b/internal/rootcoord/proxy_client_manager.go
@@ -109,7 +109,7 @@ func (p *proxyClientManager) InvalidateCollectionMetaCache(ctx context.Context, 
 	defer p.lock.Unlock()
 
 	if len(p.proxyClient) == 0 {
-		log.Warn("proxy client is empty, InvalidateCollectionMetaCache will not send to any client")
+		log.Ctx(ctx).Warn("proxy client is empty, InvalidateCollectionMetaCache will not send to any client")
 		return nil
 	}
 
@@ -135,7 +135,7 @@ func (p *proxyClientManager) ReleaseDQLMessageStream(ctx context.Context, in *pr
 	defer p.lock.Unlock()
 
 	if len(p.proxyClient) == 0 {
-		log.Warn("proxy client is empty, ReleaseDQLMessageStream will not send to any client")
+		log.Ctx(ctx).Warn("proxy client is empty, ReleaseDQLMessageStream will not send to any client")
 		return nil
 	}
 
@@ -161,7 +161,7 @@ func (p *proxyClientManager) InvalidateCredentialCache(ctx context.Context, requ
 	defer p.lock.Unlock()
 
 	if len(p.proxyClient) == 0 {
-		log.Warn("proxy client is empty, InvalidateCredentialCache will not send to any client")
+		log.Ctx(ctx).Warn("proxy client is empty, InvalidateCredentialCache will not send to any client")
 		return nil
 	}
 
@@ -187,7 +187,7 @@ func (p *proxyClientManager) UpdateCredentialCache(ctx context.Context, request 
 	defer p.lock.Unlock()
 
 	if len(p.proxyClient) == 0 {
-		log.Warn("proxy client is empty, UpdateCredentialCache will not send to any client")
+		log.Ctx(ctx).Warn("proxy client is empty, UpdateCredentialCache will not send to any client")
 		return nil
 	}
 

--- a/internal/util/logutil/grpc_interceptor.go
+++ b/internal/util/logutil/grpc_interceptor.go
@@ -1,0 +1,33 @@
+package logutil
+
+import (
+	"context"
+
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
+	"github.com/milvus-io/milvus/internal/log"
+	"github.com/milvus-io/milvus/internal/util/trace"
+	"google.golang.org/grpc"
+)
+
+// UnaryTraceLoggerInterceptor adds a traced logger in unary rpc call ctx
+func UnaryTraceLoggerInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	traceID, _, _ := trace.InfoFromContext(ctx)
+	if traceID != "" {
+		newctx := log.WithTraceID(ctx, traceID)
+		return handler(newctx, req)
+	}
+	return handler(ctx, req)
+}
+
+// StreamTraceLoggerInterceptor add a traced logger in stream rpc call ctx
+func StreamTraceLoggerInterceptor(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	ctx := ss.Context()
+	traceID, _, _ := trace.InfoFromContext(ctx)
+	if traceID != "" {
+		newctx := log.WithTraceID(ctx, traceID)
+		wrappedStream := grpc_middleware.WrapServerStream(ss)
+		wrappedStream.WrappedContext = newctx
+		return handler(srv, wrappedStream)
+	}
+	return handler(srv, ss)
+}


### PR DESCRIPTION
/kind improvement
Adding a grpc middleware which attached a traced logger in ctx, so that logs corresponding to a request can be traced.

Signed-off-by: Zach41 <zongmei.zhang@zilliz.com>