### PR TITLE
Fix missing dml nodeIDs when recovering from old version

### DIFF
--- a/internal/querycoord/meta.go
+++ b/internal/querycoord/meta.go
@@ -253,9 +253,6 @@ func (m *MetaReplica) reloadFromKV() error {
 					nodes[nodeID] = struct{}{}
 				}
 			}
-			for nodeID := range nodes {
-				replica.NodeIds = append(replica.NodeIds, nodeID)
-			}
 
 			shardReplicas := make([]*milvuspb.ShardReplica, 0, len(dmChannels[collectionInfo.CollectionID]))
 			for _, dmc := range dmChannels[collectionInfo.CollectionID] {
@@ -264,6 +261,12 @@ func (m *MetaReplica) reloadFromKV() error {
 					// LeaderAddr: Will set it after the cluster is reloaded
 					DmChannelName: dmc.DmChannel,
 				})
+				nodes[dmc.NodeIDLoaded] = struct{}{}
+			}
+			replica.ShardReplicas = shardReplicas
+
+			for nodeID := range nodes {
+				replica.NodeIds = append(replica.NodeIds, nodeID)
 			}
 
 			err = m.addReplica(replica)


### PR DESCRIPTION
issue: #17416
Signed-off-by: sunby <bingyi.sun@zilliz.com>