### PR TITLE
Remove CGO package dependence in DataCoord

### DIFF
--- a/cmd/components/data_coord.go
+++ b/cmd/components/data_coord.go
@@ -20,8 +20,8 @@ import (
 	"context"
 
 	"github.com/milvus-io/milvus/internal/log"
+	"github.com/milvus-io/milvus/internal/mq"
 	"github.com/milvus-io/milvus/internal/proto/internalpb"
-	"github.com/milvus-io/milvus/internal/util/dependency"
 
 	grpcdatacoordclient "github.com/milvus-io/milvus/internal/distributed/datacoord"
 )
@@ -33,7 +33,7 @@ type DataCoord struct {
 }
 
 // NewDataCoord creates a new DataCoord
-func NewDataCoord(ctx context.Context, factory dependency.Factory) (*DataCoord, error) {
+func NewDataCoord(ctx context.Context, factory mq.Factory) (*DataCoord, error) {
 	s := grpcdatacoordclient.NewServer(ctx, factory)
 
 	return &DataCoord{

--- a/cmd/components/data_node.go
+++ b/cmd/components/data_node.go
@@ -33,7 +33,7 @@ type DataNode struct {
 }
 
 // NewDataNode creates a new DataNode
-func NewDataNode(ctx context.Context, factory dependency.Factory) (*DataNode, error) {
+func NewDataNode(ctx context.Context, factory dependency.MixedFactory) (*DataNode, error) {
 	svr, err := grpcdatanode.NewServer(ctx, factory)
 	if err != nil {
 		return nil, err

--- a/cmd/components/index_coord.go
+++ b/cmd/components/index_coord.go
@@ -22,7 +22,7 @@ import (
 	grpcindexcoord "github.com/milvus-io/milvus/internal/distributed/indexcoord"
 	"github.com/milvus-io/milvus/internal/log"
 	"github.com/milvus-io/milvus/internal/proto/internalpb"
-	"github.com/milvus-io/milvus/internal/util/dependency"
+	"github.com/milvus-io/milvus/internal/storage"
 )
 
 // IndexCoord implements IndexCoord grpc server
@@ -31,7 +31,7 @@ type IndexCoord struct {
 }
 
 // NewIndexCoord creates a new IndexCoord
-func NewIndexCoord(ctx context.Context, factory dependency.Factory) (*IndexCoord, error) {
+func NewIndexCoord(ctx context.Context, factory storage.ChunkManagerFactory) (*IndexCoord, error) {
 	var err error
 	s := &IndexCoord{}
 	svr, err := grpcindexcoord.NewServer(ctx, factory)

--- a/cmd/components/index_node.go
+++ b/cmd/components/index_node.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/milvus-io/milvus/internal/log"
 	"github.com/milvus-io/milvus/internal/proto/internalpb"
-	"github.com/milvus-io/milvus/internal/util/dependency"
+	"github.com/milvus-io/milvus/internal/storage"
 
 	grpcindexnode "github.com/milvus-io/milvus/internal/distributed/indexnode"
 )
@@ -32,7 +32,7 @@ type IndexNode struct {
 }
 
 // NewIndexNode creates a new IndexNode
-func NewIndexNode(ctx context.Context, factory dependency.Factory) (*IndexNode, error) {
+func NewIndexNode(ctx context.Context, factory storage.ChunkManagerFactory) (*IndexNode, error) {
 	var err error
 	n := &IndexNode{}
 	svr, err := grpcindexnode.NewServer(ctx, factory)

--- a/cmd/components/proxy.go
+++ b/cmd/components/proxy.go
@@ -33,7 +33,7 @@ type Proxy struct {
 }
 
 // NewProxy creates a new Proxy
-func NewProxy(ctx context.Context, factory dependency.Factory) (*Proxy, error) {
+func NewProxy(ctx context.Context, factory dependency.MixedFactory) (*Proxy, error) {
 	var err error
 	n := &Proxy{}
 

--- a/cmd/components/query_coord.go
+++ b/cmd/components/query_coord.go
@@ -33,7 +33,7 @@ type QueryCoord struct {
 }
 
 // NewQueryCoord creates a new QueryCoord
-func NewQueryCoord(ctx context.Context, factory dependency.Factory) (*QueryCoord, error) {
+func NewQueryCoord(ctx context.Context, factory dependency.MixedFactory) (*QueryCoord, error) {
 	svr, err := grpcquerycoord.NewServer(ctx, factory)
 	if err != nil {
 		panic(err)

--- a/cmd/components/query_node.go
+++ b/cmd/components/query_node.go
@@ -33,7 +33,7 @@ type QueryNode struct {
 }
 
 // NewQueryNode creates a new QueryNode
-func NewQueryNode(ctx context.Context, factory dependency.Factory) (*QueryNode, error) {
+func NewQueryNode(ctx context.Context, factory dependency.MixedFactory) (*QueryNode, error) {
 	svr, err := grpcquerynode.NewServer(ctx, factory)
 	if err != nil {
 		return nil, err

--- a/cmd/components/root_coord.go
+++ b/cmd/components/root_coord.go
@@ -21,8 +21,8 @@ import (
 	"io"
 
 	"github.com/milvus-io/milvus/internal/log"
+	"github.com/milvus-io/milvus/internal/mq"
 	"github.com/milvus-io/milvus/internal/proto/internalpb"
-	"github.com/milvus-io/milvus/internal/util/dependency"
 
 	"github.com/opentracing/opentracing-go"
 
@@ -39,7 +39,7 @@ type RootCoord struct {
 }
 
 // NewRootCoord creates a new RoorCoord
-func NewRootCoord(ctx context.Context, factory dependency.Factory) (*RootCoord, error) {
+func NewRootCoord(ctx context.Context, factory mq.Factory) (*RootCoord, error) {
 	svr, err := rc.NewServer(ctx, factory)
 	if err != nil {
 		return nil, err

--- a/cmd/milvus/mck.go
+++ b/cmd/milvus/mck.go
@@ -240,7 +240,7 @@ func (c *mck) connectMinio() {
 		}
 		useSSL = minioUseSSL
 	}
-	chunkManagerFactory := storage.NewChunkManagerFactory("local", "minio",
+	chunkManagerFactory := storage.NewChunkManagerFactoryWithConfig("local", "minio",
 		storage.RootPath(c.params.LocalStorageCfg.Path),
 		storage.Address(getConfigValue(c.minioAddress, c.params.MinioCfg.Address, "minio_address")),
 		storage.AccessKeyID(getConfigValue(c.minioUsername, c.params.MinioCfg.AccessKeyID, "minio_username")),

--- a/internal/datacoord/channel_manager_test.go
+++ b/internal/datacoord/channel_manager_test.go
@@ -28,8 +28,8 @@ import (
 	"github.com/golang/protobuf/proto"
 
 	"github.com/milvus-io/milvus/internal/kv"
+	"github.com/milvus-io/milvus/internal/mq"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
-	"github.com/milvus-io/milvus/internal/util/dependency"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -278,7 +278,7 @@ func TestChannelManager_StateTransfer(t *testing.T) {
 
 		metakv.RemoveWithPrefix("")
 		ctx, cancel := context.WithCancel(context.TODO())
-		factory := dependency.NewDefaultFactory(true)
+		factory := mq.NewDefaultFactory(true)
 		_, err := factory.NewMsgStream(context.TODO())
 		require.NoError(t, err)
 		chManager, err := NewChannelManager(metakv, newMockHandler(), withMsgstreamFactory(factory))
@@ -323,7 +323,7 @@ func TestChannelManager_StateTransfer(t *testing.T) {
 	t.Run("ToRelease-ReleaseFail-CleanUpAndDelete-Reassign-ToWatch-1-DN", func(t *testing.T) {
 		metakv.RemoveWithPrefix("")
 		ctx, cancel := context.WithCancel(context.TODO())
-		factory := dependency.NewDefaultFactory(true)
+		factory := mq.NewDefaultFactory(true)
 		_, err := factory.NewMsgStream(context.TODO())
 		require.NoError(t, err)
 		chManager, err := NewChannelManager(metakv, newMockHandler(), withMsgstreamFactory(factory))
@@ -588,7 +588,7 @@ func TestChannelManager(t *testing.T) {
 			{UniqueID(116), "to-delete-chan"},
 		}
 
-		factory := dependency.NewDefaultFactory(true)
+		factory := mq.NewDefaultFactory(true)
 		_, err := factory.NewMsgStream(context.TODO())
 		require.NoError(t, err)
 		chManager, err := NewChannelManager(metakv, newMockHandler(), withMsgstreamFactory(factory))

--- a/internal/datacoord/server.go
+++ b/internal/datacoord/server.go
@@ -37,13 +37,13 @@ import (
 	etcdkv "github.com/milvus-io/milvus/internal/kv/etcd"
 	"github.com/milvus-io/milvus/internal/log"
 	"github.com/milvus-io/milvus/internal/metrics"
+	"github.com/milvus-io/milvus/internal/mq"
 	"github.com/milvus-io/milvus/internal/mq/msgstream"
 	"github.com/milvus-io/milvus/internal/mq/msgstream/mqwrapper"
 	"github.com/milvus-io/milvus/internal/proto/commonpb"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
 	"github.com/milvus-io/milvus/internal/proto/milvuspb"
 	"github.com/milvus-io/milvus/internal/types"
-	"github.com/milvus-io/milvus/internal/util/dependency"
 	"github.com/milvus-io/milvus/internal/util/funcutil"
 	"github.com/milvus-io/milvus/internal/util/logutil"
 	"github.com/milvus-io/milvus/internal/util/metricsinfo"
@@ -126,7 +126,7 @@ type Server struct {
 	metricsCacheManager *metricsinfo.MetricsCacheManager
 
 	flushCh chan UniqueID
-	factory dependency.Factory
+	factory mq.Factory
 
 	session   *sessionutil.Session
 	dnEventCh <-chan *sessionutil.SessionEvent
@@ -190,7 +190,7 @@ func SetSegmentManager(manager Manager) Option {
 }
 
 // CreateServer creates a `Server` instance
-func CreateServer(ctx context.Context, factory dependency.Factory, opts ...Option) *Server {
+func CreateServer(ctx context.Context, factory mq.Factory, opts ...Option) *Server {
 	rand.Seed(time.Now().UnixNano())
 	s := &Server{
 		ctx:                    ctx,

--- a/internal/datacoord/server_test.go
+++ b/internal/datacoord/server_test.go
@@ -43,13 +43,13 @@ import (
 	"github.com/milvus-io/milvus/internal/kv"
 	etcdkv "github.com/milvus-io/milvus/internal/kv/etcd"
 	"github.com/milvus-io/milvus/internal/log"
+	"github.com/milvus-io/milvus/internal/mq"
 	"github.com/milvus-io/milvus/internal/mq/msgstream"
 	"github.com/milvus-io/milvus/internal/proto/commonpb"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
 	"github.com/milvus-io/milvus/internal/proto/internalpb"
 	"github.com/milvus-io/milvus/internal/proto/milvuspb"
 	"github.com/milvus-io/milvus/internal/types"
-	"github.com/milvus-io/milvus/internal/util/dependency"
 	"github.com/milvus-io/milvus/internal/util/etcd"
 	"github.com/milvus-io/milvus/internal/util/metricsinfo"
 	"github.com/milvus-io/milvus/internal/util/sessionutil"
@@ -681,7 +681,7 @@ func TestService_WatchServices(t *testing.T) {
 	sc := make(chan os.Signal, 1)
 	signal.Notify(sc, syscall.SIGINT)
 	defer signal.Reset(syscall.SIGINT)
-	factory := dependency.NewDefaultFactory(true)
+	factory := mq.NewDefaultFactory(true)
 	svr := CreateServer(context.TODO(), factory)
 	svr.session = &sessionutil.Session{
 		TriggerKill: true,
@@ -801,7 +801,7 @@ func TestServer_watchQueryCoord(t *testing.T) {
 	assert.Nil(t, err)
 	etcdKV := etcdkv.NewEtcdKV(etcdCli, Params.EtcdCfg.MetaRootPath)
 	assert.NotNil(t, etcdKV)
-	factory := dependency.NewDefaultFactory(true)
+	factory := mq.NewDefaultFactory(true)
 	svr := CreateServer(context.TODO(), factory)
 	svr.session = &sessionutil.Session{
 		TriggerKill: true,
@@ -864,7 +864,7 @@ func TestServer_watchRootCoord(t *testing.T) {
 	assert.Nil(t, err)
 	etcdKV := etcdkv.NewEtcdKV(etcdCli, Params.EtcdCfg.MetaRootPath)
 	assert.NotNil(t, etcdKV)
-	factory := dependency.NewDefaultFactory(true)
+	factory := mq.NewDefaultFactory(true)
 	svr := CreateServer(context.TODO(), factory)
 	svr.session = &sessionutil.Session{
 		TriggerKill: true,
@@ -2291,7 +2291,7 @@ func TestOptions(t *testing.T) {
 		})
 		assert.NotNil(t, opt)
 
-		factory := dependency.NewDefaultFactory(true)
+		factory := mq.NewDefaultFactory(true)
 
 		svr := CreateServer(context.TODO(), factory, opt)
 		dn, err := svr.dataNodeCreator(context.Background(), "")
@@ -2873,7 +2873,7 @@ func newTestServer(t *testing.T, receiveCh chan interface{}, opts ...Option) *Se
 	var err error
 	Params.Init()
 	Params.CommonCfg.DataCoordTimeTick = Params.CommonCfg.DataCoordTimeTick + strconv.Itoa(rand.Int())
-	factory := dependency.NewDefaultFactory(true)
+	factory := mq.NewDefaultFactory(true)
 
 	etcdCli, err := etcd.GetEtcdClient(&Params.EtcdCfg)
 	assert.Nil(t, err)
@@ -2916,7 +2916,7 @@ func newTestServer2(t *testing.T, receiveCh chan interface{}, opts ...Option) *S
 	var err error
 	Params.Init()
 	Params.CommonCfg.DataCoordTimeTick = Params.CommonCfg.DataCoordTimeTick + strconv.Itoa(rand.Int())
-	factory := dependency.NewDefaultFactory(true)
+	factory := mq.NewDefaultFactory(true)
 
 	etcdCli, err := etcd.GetEtcdClient(&Params.EtcdCfg)
 	assert.Nil(t, err)

--- a/internal/datanode/data_node.go
+++ b/internal/datanode/data_node.go
@@ -121,11 +121,11 @@ type DataNode struct {
 
 	closer io.Closer
 
-	factory dependency.Factory
+	factory dependency.MixedFactory
 }
 
 // NewDataNode will return a DataNode with abnormal state.
-func NewDataNode(ctx context.Context, factory dependency.Factory) *DataNode {
+func NewDataNode(ctx context.Context, factory dependency.MixedFactory) *DataNode {
 	rand.Seed(time.Now().UnixNano())
 	ctx2, cancel2 := context.WithCancel(ctx)
 	node := &DataNode{

--- a/internal/datanode/mock_test.go
+++ b/internal/datanode/mock_test.go
@@ -981,7 +981,7 @@ func (m *RootCoordFactory) ReportImport(ctx context.Context, req *rootcoordpb.Im
 
 // FailMessageStreamFactory mock MessageStreamFactory failure
 type FailMessageStreamFactory struct {
-	dependency.Factory
+	dependency.MixedFactory
 }
 
 func (f *FailMessageStreamFactory) NewMsgStream(ctx context.Context) (msgstream.MsgStream, error) {

--- a/internal/distributed/datacoord/service.go
+++ b/internal/distributed/datacoord/service.go
@@ -33,12 +33,12 @@ import (
 
 	"github.com/milvus-io/milvus/internal/datacoord"
 	"github.com/milvus-io/milvus/internal/log"
+	"github.com/milvus-io/milvus/internal/mq"
 	"github.com/milvus-io/milvus/internal/proto/commonpb"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
 	"github.com/milvus-io/milvus/internal/proto/internalpb"
 	"github.com/milvus-io/milvus/internal/proto/milvuspb"
 	"github.com/milvus-io/milvus/internal/types"
-	"github.com/milvus-io/milvus/internal/util/dependency"
 	"github.com/milvus-io/milvus/internal/util/etcd"
 	"github.com/milvus-io/milvus/internal/util/funcutil"
 	"github.com/milvus-io/milvus/internal/util/logutil"
@@ -66,7 +66,7 @@ type Server struct {
 }
 
 // NewServer new data service grpc server
-func NewServer(ctx context.Context, factory dependency.Factory, opts ...datacoord.Option) *Server {
+func NewServer(ctx context.Context, factory mq.Factory, opts ...datacoord.Option) *Server {
 	ctx1, cancel := context.WithCancel(ctx)
 
 	s := &Server{

--- a/internal/distributed/datanode/service.go
+++ b/internal/distributed/datanode/service.go
@@ -61,7 +61,7 @@ type Server struct {
 	ctx         context.Context
 	cancel      context.CancelFunc
 	etcdCli     *clientv3.Client
-	factory     dependency.Factory
+	factory     dependency.MixedFactory
 
 	rootCoord types.RootCoord
 	dataCoord types.DataCoord
@@ -73,7 +73,7 @@ type Server struct {
 }
 
 // NewServer new DataNode grpc server
-func NewServer(ctx context.Context, factory dependency.Factory) (*Server, error) {
+func NewServer(ctx context.Context, factory dependency.MixedFactory) (*Server, error) {
 	ctx1, cancel := context.WithCancel(ctx)
 	var s = &Server{
 		ctx:         ctx1,

--- a/internal/distributed/indexcoord/client/client_test.go
+++ b/internal/distributed/indexcoord/client/client_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/milvus-io/milvus/internal/proto/indexpb"
 	"github.com/milvus-io/milvus/internal/proto/internalpb"
 	"github.com/milvus-io/milvus/internal/proto/milvuspb"
-	"github.com/milvus-io/milvus/internal/util/dependency"
+	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/util/etcd"
 	"github.com/milvus-io/milvus/internal/util/typeutil"
 )
@@ -36,7 +36,7 @@ import (
 func TestIndexCoordClient(t *testing.T) {
 	ClientParams.InitOnce(typeutil.IndexCoordRole)
 	ctx := context.Background()
-	factory := dependency.NewDefaultFactory(true)
+	factory := storage.NewDefaultChunkManagerFactory()
 	server, err := grpcindexcoord.NewServer(ctx, factory)
 	assert.Nil(t, err)
 	icm := &indexcoord.Mock{}

--- a/internal/distributed/indexcoord/service.go
+++ b/internal/distributed/indexcoord/service.go
@@ -38,8 +38,8 @@ import (
 	"github.com/milvus-io/milvus/internal/proto/indexpb"
 	"github.com/milvus-io/milvus/internal/proto/internalpb"
 	"github.com/milvus-io/milvus/internal/proto/milvuspb"
+	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/types"
-	"github.com/milvus-io/milvus/internal/util/dependency"
 	"github.com/milvus-io/milvus/internal/util/etcd"
 	"github.com/milvus-io/milvus/internal/util/funcutil"
 	"github.com/milvus-io/milvus/internal/util/paramtable"
@@ -284,7 +284,7 @@ func (s *Server) startGrpcLoop(grpcPort int) {
 }
 
 // NewServer create a new IndexCoord grpc server.
-func NewServer(ctx context.Context, factory dependency.Factory) (*Server, error) {
+func NewServer(ctx context.Context, factory storage.ChunkManagerFactory) (*Server, error) {
 	ctx1, cancel := context.WithCancel(ctx)
 	serverImp, err := indexcoord.NewIndexCoord(ctx, factory)
 	if err != nil {

--- a/internal/distributed/indexcoord/service_test.go
+++ b/internal/distributed/indexcoord/service_test.go
@@ -27,13 +27,13 @@ import (
 	"github.com/milvus-io/milvus/internal/proto/indexpb"
 	"github.com/milvus-io/milvus/internal/proto/internalpb"
 	"github.com/milvus-io/milvus/internal/proto/milvuspb"
-	"github.com/milvus-io/milvus/internal/util/dependency"
+	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/util/etcd"
 )
 
 func TestIndexCoordinateServer(t *testing.T) {
 	ctx := context.Background()
-	factory := dependency.NewDefaultFactory(true)
+	factory := storage.NewDefaultChunkManagerFactory()
 	server, err := NewServer(ctx, factory)
 	assert.Nil(t, err)
 	assert.NotNil(t, server)

--- a/internal/distributed/indexnode/service.go
+++ b/internal/distributed/indexnode/service.go
@@ -38,8 +38,8 @@ import (
 	"github.com/milvus-io/milvus/internal/proto/indexpb"
 	"github.com/milvus-io/milvus/internal/proto/internalpb"
 	"github.com/milvus-io/milvus/internal/proto/milvuspb"
+	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/types"
-	"github.com/milvus-io/milvus/internal/util/dependency"
 	"github.com/milvus-io/milvus/internal/util/etcd"
 	"github.com/milvus-io/milvus/internal/util/funcutil"
 	"github.com/milvus-io/milvus/internal/util/paramtable"
@@ -247,7 +247,7 @@ func (s *Server) GetMetrics(ctx context.Context, request *milvuspb.GetMetricsReq
 }
 
 // NewServer create a new IndexNode grpc server.
-func NewServer(ctx context.Context, factory dependency.Factory) (*Server, error) {
+func NewServer(ctx context.Context, factory storage.ChunkManagerFactory) (*Server, error) {
 	ctx1, cancel := context.WithCancel(ctx)
 	node, err := indexnode.NewIndexNode(ctx1, factory)
 	if err != nil {

--- a/internal/distributed/proxy/service.go
+++ b/internal/distributed/proxy/service.go
@@ -98,7 +98,7 @@ type Server struct {
 }
 
 // NewServer create a Proxy server.
-func NewServer(ctx context.Context, factory dependency.Factory) (*Server, error) {
+func NewServer(ctx context.Context, factory dependency.MixedFactory) (*Server, error) {
 
 	var err error
 	server := &Server{

--- a/internal/distributed/querycoord/service.go
+++ b/internal/distributed/querycoord/service.go
@@ -61,7 +61,7 @@ type Server struct {
 
 	queryCoord types.QueryCoordComponent
 
-	factory dependency.Factory
+	factory dependency.MixedFactory
 
 	etcdCli *clientv3.Client
 
@@ -73,7 +73,7 @@ type Server struct {
 }
 
 // NewServer create a new QueryCoord grpc server.
-func NewServer(ctx context.Context, factory dependency.Factory) (*Server, error) {
+func NewServer(ctx context.Context, factory dependency.MixedFactory) (*Server, error) {
 	ctx1, cancel := context.WithCancel(ctx)
 	svr, err := qc.NewQueryCoord(ctx1, factory)
 	if err != nil {

--- a/internal/distributed/querynode/service.go
+++ b/internal/distributed/querynode/service.go
@@ -68,7 +68,7 @@ type Server struct {
 }
 
 // NewServer create a new QueryNode grpc server.
-func NewServer(ctx context.Context, factory dependency.Factory) (*Server, error) {
+func NewServer(ctx context.Context, factory dependency.MixedFactory) (*Server, error) {
 	ctx1, cancel := context.WithCancel(ctx)
 
 	s := &Server{

--- a/internal/distributed/rootcoord/service.go
+++ b/internal/distributed/rootcoord/service.go
@@ -34,6 +34,7 @@ import (
 
 	pnc "github.com/milvus-io/milvus/internal/distributed/proxy/client"
 	"github.com/milvus-io/milvus/internal/log"
+	"github.com/milvus-io/milvus/internal/mq"
 	"github.com/milvus-io/milvus/internal/proto/commonpb"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
 	"github.com/milvus-io/milvus/internal/proto/internalpb"
@@ -42,7 +43,6 @@ import (
 	"github.com/milvus-io/milvus/internal/proto/rootcoordpb"
 	"github.com/milvus-io/milvus/internal/rootcoord"
 	"github.com/milvus-io/milvus/internal/types"
-	"github.com/milvus-io/milvus/internal/util/dependency"
 	"github.com/milvus-io/milvus/internal/util/etcd"
 	"github.com/milvus-io/milvus/internal/util/funcutil"
 	"github.com/milvus-io/milvus/internal/util/paramtable"
@@ -96,7 +96,7 @@ func (s *Server) AlterAlias(ctx context.Context, request *milvuspb.AlterAliasReq
 }
 
 // NewServer create a new RootCoord grpc server.
-func NewServer(ctx context.Context, factory dependency.Factory) (*Server, error) {
+func NewServer(ctx context.Context, factory mq.Factory) (*Server, error) {
 	ctx1, cancel := context.WithCancel(ctx)
 	s := &Server{
 		ctx:         ctx1,

--- a/internal/indexcoord/index_coord.go
+++ b/internal/indexcoord/index_coord.go
@@ -47,7 +47,6 @@ import (
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/tso"
 	"github.com/milvus-io/milvus/internal/types"
-	"github.com/milvus-io/milvus/internal/util/dependency"
 	"github.com/milvus-io/milvus/internal/util/metricsinfo"
 	"github.com/milvus-io/milvus/internal/util/paramtable"
 	"github.com/milvus-io/milvus/internal/util/retry"
@@ -80,7 +79,7 @@ type IndexCoord struct {
 
 	idAllocator *allocator.GlobalIDAllocator
 
-	factory      dependency.Factory
+	factory      storage.ChunkManagerFactory
 	etcdCli      *clientv3.Client
 	chunkManager storage.ChunkManager
 
@@ -109,7 +108,7 @@ type IndexCoord struct {
 type UniqueID = typeutil.UniqueID
 
 // NewIndexCoord creates a new IndexCoord component.
-func NewIndexCoord(ctx context.Context, factory dependency.Factory) (*IndexCoord, error) {
+func NewIndexCoord(ctx context.Context, factory storage.ChunkManagerFactory) (*IndexCoord, error) {
 	rand.Seed(time.Now().UnixNano())
 	ctx1, cancel := context.WithCancel(ctx)
 	i := &IndexCoord{

--- a/internal/indexcoord/index_coord_test.go
+++ b/internal/indexcoord/index_coord_test.go
@@ -41,7 +41,7 @@ import (
 	"github.com/milvus-io/milvus/internal/proto/internalpb"
 	"github.com/milvus-io/milvus/internal/proto/milvuspb"
 	"github.com/milvus-io/milvus/internal/proto/schemapb"
-	"github.com/milvus-io/milvus/internal/util/dependency"
+	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/util/etcd"
 	"github.com/milvus-io/milvus/internal/util/metricsinfo"
 	"github.com/milvus-io/milvus/internal/util/sessionutil"
@@ -60,7 +60,7 @@ func TestIndexCoord(t *testing.T) {
 	assert.Nil(t, err)
 	err = inm0.Start()
 	assert.Nil(t, err)
-	factory := dependency.NewDefaultFactory(true)
+	factory := storage.NewDefaultChunkManagerFactory()
 	ic, err := NewIndexCoord(ctx, factory)
 	assert.Nil(t, err)
 	ic.reqTimeoutInterval = time.Second * 10

--- a/internal/indexcoord/metrics_info_test.go
+++ b/internal/indexcoord/metrics_info_test.go
@@ -23,14 +23,14 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/milvus-io/milvus/internal/indexnode"
-	"github.com/milvus-io/milvus/internal/util/dependency"
+	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/util/etcd"
 	"github.com/milvus-io/milvus/internal/util/metricsinfo"
 )
 
 func TestGetSystemInfoMetrics(t *testing.T) {
 	ctx := context.Background()
-	factory := dependency.NewDefaultFactory(true)
+	factory := storage.NewDefaultChunkManagerFactory()
 	ic, err := NewIndexCoord(ctx, factory)
 	assert.Nil(t, err)
 	Params.Init()

--- a/internal/indexnode/indexnode.go
+++ b/internal/indexnode/indexnode.go
@@ -40,7 +40,6 @@ import (
 
 	"github.com/milvus-io/milvus/internal/metrics"
 	"github.com/milvus-io/milvus/internal/storage"
-	"github.com/milvus-io/milvus/internal/util/dependency"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
@@ -83,7 +82,7 @@ type IndexNode struct {
 
 	once sync.Once
 
-	factory      dependency.Factory
+	factory      storage.ChunkManagerFactory
 	chunkManager storage.ChunkManager
 	session      *sessionutil.Session
 
@@ -101,7 +100,7 @@ type IndexNode struct {
 }
 
 // NewIndexNode creates a new IndexNode component.
-func NewIndexNode(ctx context.Context, factory dependency.Factory) (*IndexNode, error) {
+func NewIndexNode(ctx context.Context, factory storage.ChunkManagerFactory) (*IndexNode, error) {
 	log.Debug("New IndexNode ...")
 	rand.Seed(time.Now().UnixNano())
 	ctx1, cancel := context.WithCancel(ctx)

--- a/internal/indexnode/indexnode_test.go
+++ b/internal/indexnode/indexnode_test.go
@@ -41,7 +41,6 @@ import (
 	"github.com/milvus-io/milvus/internal/proto/milvuspb"
 	"github.com/milvus-io/milvus/internal/proto/schemapb"
 	"github.com/milvus-io/milvus/internal/storage"
-	"github.com/milvus-io/milvus/internal/util/dependency"
 	"github.com/milvus-io/milvus/internal/util/etcd"
 	"github.com/milvus-io/milvus/internal/util/metricsinfo"
 	"github.com/milvus-io/milvus/internal/util/sessionutil"
@@ -65,7 +64,7 @@ func TestIndexNode(t *testing.T) {
 	floatVectorBinlogPath := "float_vector_binlog"
 	binaryVectorBinlogPath := "binary_vector_binlog"
 
-	factory := dependency.NewDefaultFactory(true)
+	factory := storage.NewDefaultChunkManagerFactory()
 	in, err := NewIndexNode(ctx, factory)
 	assert.Nil(t, err)
 	Params.Init()
@@ -480,7 +479,7 @@ func TestCreateIndexFailed(t *testing.T) {
 	metaPath2 := "FloatVector2"
 	floatVectorBinlogPath := "float_vector_binlog"
 
-	factory := dependency.NewDefaultFactory(true)
+	factory := storage.NewDefaultChunkManagerFactory()
 	in, err := NewIndexNode(ctx, factory)
 	assert.Nil(t, err)
 	Params.Init()
@@ -754,7 +753,7 @@ func TestCreateIndexFailed(t *testing.T) {
 func TestIndexNode_Error(t *testing.T) {
 	ctx := context.Background()
 
-	factory := dependency.NewDefaultFactory(true)
+	factory := storage.NewDefaultChunkManagerFactory()
 	in, err := NewIndexNode(ctx, factory)
 	assert.Nil(t, err)
 	Params.Init()

--- a/internal/mq/factory.go
+++ b/internal/mq/factory.go
@@ -1,0 +1,110 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mq
+
+import (
+	"context"
+
+	"github.com/milvus-io/milvus/internal/mq/msgstream"
+	"github.com/milvus-io/milvus/internal/util/paramtable"
+)
+
+type Factory interface {
+	msgstream.Factory
+	Init(p *paramtable.ComponentParam)
+}
+
+type DefaultFactory struct {
+	standAlone       bool
+	msgStreamFactory msgstream.Factory
+}
+
+func NewDefaultFactory(standAlone bool) *DefaultFactory {
+	return &DefaultFactory{
+		standAlone:       standAlone,
+		msgStreamFactory: msgstream.NewRmsFactory("/tmp/milvus/rocksmq/"),
+	}
+}
+
+func NewFactory(standAlone bool) *DefaultFactory {
+	return &DefaultFactory{standAlone: standAlone}
+}
+
+// Init create a msg factory(TODO only support one mq at the same time.)
+// In order to guarantee backward compatibility of config file, we still support multiple mq configs.
+// 1. Rocksmq only run on local mode, and it has the highest priority
+// 2. Pulsar has higher priority than Kafka within remote msg
+func (f *DefaultFactory) Init(params *paramtable.ComponentParam) {
+	// skip if using default factory
+	if f.msgStreamFactory != nil {
+		return
+	}
+
+	// init mq storage
+	if f.standAlone {
+		f.msgStreamFactory = f.initMQLocalService(params)
+		if f.msgStreamFactory == nil {
+			f.msgStreamFactory = f.initMQRemoteService(params)
+			if f.msgStreamFactory == nil {
+				panic("no available mq configuration, must config rocksmq, Pulsar or Kafka at least one of these!")
+			}
+		}
+		return
+	}
+
+	f.msgStreamFactory = f.initMQRemoteService(params)
+	if f.msgStreamFactory == nil {
+		panic("no available remote mq configuration, must config Pulsar or Kafka at least one of these!")
+	}
+}
+
+func (f *DefaultFactory) initMQLocalService(params *paramtable.ComponentParam) msgstream.Factory {
+	if params.RocksmqEnable() {
+		path, _ := params.Load("_RocksmqPath")
+		return msgstream.NewRmsFactory(path)
+	}
+	return nil
+}
+
+// initRemoteService Pulsar has higher priority than Kafka.
+func (f *DefaultFactory) initMQRemoteService(params *paramtable.ComponentParam) msgstream.Factory {
+	if params.PulsarEnable() {
+		return msgstream.NewPmsFactory(&params.PulsarCfg)
+	}
+
+	if params.KafkaEnable() {
+		return msgstream.NewKmsFactory(&params.KafkaCfg)
+	}
+
+	return nil
+}
+
+func (f *DefaultFactory) NewMsgStream(ctx context.Context) (msgstream.MsgStream, error) {
+	return f.msgStreamFactory.NewMsgStream(ctx)
+}
+
+func (f *DefaultFactory) NewTtMsgStream(ctx context.Context) (msgstream.MsgStream, error) {
+	return f.msgStreamFactory.NewTtMsgStream(ctx)
+}
+
+func (f *DefaultFactory) NewQueryMsgStream(ctx context.Context) (msgstream.MsgStream, error) {
+	return f.msgStreamFactory.NewQueryMsgStream(ctx)
+}
+
+func (f *DefaultFactory) NewMsgStreamDisposer(ctx context.Context) func([]string, string) error {
+	return f.msgStreamFactory.NewMsgStreamDisposer(ctx)
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -92,7 +92,7 @@ type Proxy struct {
 	session  *sessionutil.Session
 	shardMgr *shardClientMgr
 
-	factory dependency.Factory
+	factory dependency.MixedFactory
 
 	searchResultCh chan *internalpb.SearchResults
 
@@ -102,7 +102,7 @@ type Proxy struct {
 }
 
 // NewProxy returns a Proxy struct.
-func NewProxy(ctx context.Context, factory dependency.Factory) (*Proxy, error) {
+func NewProxy(ctx context.Context, factory dependency.MixedFactory) (*Proxy, error) {
 	rand.Seed(time.Now().UnixNano())
 	ctx1, cancel := context.WithCancel(ctx)
 	n := 1024 // better to be configurable

--- a/internal/querycoord/channel_unsubscribe.go
+++ b/internal/querycoord/channel_unsubscribe.go
@@ -27,9 +27,9 @@ import (
 
 	etcdkv "github.com/milvus-io/milvus/internal/kv/etcd"
 	"github.com/milvus-io/milvus/internal/log"
+	"github.com/milvus-io/milvus/internal/mq"
 	"github.com/milvus-io/milvus/internal/mq/msgstream"
 	"github.com/milvus-io/milvus/internal/proto/querypb"
-	"github.com/milvus-io/milvus/internal/util/dependency"
 	"github.com/milvus-io/milvus/internal/util/funcutil"
 )
 
@@ -41,7 +41,7 @@ type channelUnsubscribeHandler struct {
 	ctx      context.Context
 	cancel   context.CancelFunc
 	kvClient *etcdkv.EtcdKV
-	factory  msgstream.Factory
+	factory  mq.Factory
 
 	mut          sync.RWMutex // mutex for channelInfos, since container/list is not goroutine-safe
 	channelInfos *list.List
@@ -51,7 +51,7 @@ type channelUnsubscribeHandler struct {
 }
 
 // newChannelUnsubscribeHandler create a new handler service to unsubscribe channels
-func newChannelUnsubscribeHandler(ctx context.Context, kv *etcdkv.EtcdKV, factory dependency.Factory) (*channelUnsubscribeHandler, error) {
+func newChannelUnsubscribeHandler(ctx context.Context, kv *etcdkv.EtcdKV, factory mq.Factory) (*channelUnsubscribeHandler, error) {
 	childCtx, cancel := context.WithCancel(ctx)
 	handler := &channelUnsubscribeHandler{
 		ctx:      childCtx,

--- a/internal/querycoord/meta.go
+++ b/internal/querycoord/meta.go
@@ -109,7 +109,7 @@ type MetaReplica struct {
 	client kv.MetaKv // client of a reliable kv service, i.e. etcd client
 	//DDL lock
 	clientMutex sync.Mutex
-	factory     dependency.Factory
+	factory     dependency.MixedFactory
 	idAllocator func() (UniqueID, error)
 
 	//sync.RWMutex
@@ -127,7 +127,7 @@ type MetaReplica struct {
 	dataCoord types.DataCoord
 }
 
-func newMeta(ctx context.Context, kv kv.MetaKv, factory dependency.Factory, idAllocator func() (UniqueID, error)) (Meta, error) {
+func newMeta(ctx context.Context, kv kv.MetaKv, factory dependency.MixedFactory, idAllocator func() (UniqueID, error)) (Meta, error) {
 	childCtx, cancel := context.WithCancel(ctx)
 	collectionInfos := make(map[UniqueID]*querypb.CollectionInfo)
 	deltaChannelInfos := make(map[UniqueID][]*datapb.VchannelInfo)

--- a/internal/querycoord/query_coord.go
+++ b/internal/querycoord/query_coord.go
@@ -94,7 +94,7 @@ type QueryCoord struct {
 
 	stateCode atomic.Value
 
-	factory       dependency.Factory
+	factory       dependency.MixedFactory
 	chunkManager  storage.ChunkManager
 	groupBalancer Balancer
 }
@@ -284,7 +284,7 @@ func (qc *QueryCoord) UpdateStateCode(code internalpb.StateCode) {
 }
 
 // NewQueryCoord creates a QueryCoord object.
-func NewQueryCoord(ctx context.Context, factory dependency.Factory) (*QueryCoord, error) {
+func NewQueryCoord(ctx context.Context, factory dependency.MixedFactory) (*QueryCoord, error) {
 	rand.Seed(time.Now().UnixNano())
 	ctx1, cancel := context.WithCancel(ctx)
 	service := &QueryCoord{

--- a/internal/querycoord/query_coord_test.go
+++ b/internal/querycoord/query_coord_test.go
@@ -68,7 +68,7 @@ func TestMain(m *testing.M) {
 	os.Exit(exitCode)
 }
 
-func NewQueryCoordTest(ctx context.Context, factory dependency.Factory) (*QueryCoord, error) {
+func NewQueryCoordTest(ctx context.Context, factory dependency.MixedFactory) (*QueryCoord, error) {
 	queryCoord, err := NewQueryCoord(ctx, factory)
 	if err != nil {
 		return nil, err

--- a/internal/querynode/query_node.go
+++ b/internal/querynode/query_node.go
@@ -100,7 +100,7 @@ type QueryNode struct {
 	// etcd client
 	etcdCli *clientv3.Client
 
-	factory   dependency.Factory
+	factory   dependency.MixedFactory
 	scheduler *taskScheduler
 
 	session *sessionutil.Session
@@ -117,7 +117,7 @@ type QueryNode struct {
 }
 
 // NewQueryNode will return a QueryNode with abnormal state.
-func NewQueryNode(ctx context.Context, factory dependency.Factory) *QueryNode {
+func NewQueryNode(ctx context.Context, factory dependency.MixedFactory) *QueryNode {
 	ctx1, cancel := context.WithCancel(ctx)
 	node := &QueryNode{
 		queryNodeLoopCtx:    ctx1,

--- a/internal/querynode/query_node_test.go
+++ b/internal/querynode/query_node_test.go
@@ -109,7 +109,7 @@ func newQueryNodeMock() *QueryNode {
 	return svr
 }
 
-func newMessageStreamFactory() dependency.Factory {
+func newMessageStreamFactory() dependency.MixedFactory {
 	return dependency.NewDefaultFactory(true)
 }
 

--- a/internal/querynode/query_shard_service.go
+++ b/internal/querynode/query_shard_service.go
@@ -35,7 +35,7 @@ type queryShardService struct {
 	queryShardsMu sync.Mutex              // guards queryShards
 	queryShards   map[Channel]*queryShard // Virtual Channel -> *queryShard
 
-	factory dependency.Factory
+	factory dependency.MixedFactory
 
 	metaReplica  ReplicaInterface
 	tSafeReplica TSafeReplicaInterface
@@ -47,7 +47,7 @@ type queryShardService struct {
 	scheduler           *taskScheduler
 }
 
-func newQueryShardService(ctx context.Context, metaReplica ReplicaInterface, tSafeReplica TSafeReplicaInterface, clusterService *ShardClusterService, factory dependency.Factory, scheduler *taskScheduler) *queryShardService {
+func newQueryShardService(ctx context.Context, metaReplica ReplicaInterface, tSafeReplica TSafeReplicaInterface, clusterService *ShardClusterService, factory dependency.MixedFactory, scheduler *taskScheduler) *queryShardService {
 	queryShardServiceCtx, queryShardServiceCancel := context.WithCancel(ctx)
 
 	path := Params.LoadWithDefault("localStorage.Path", "/tmp/milvus/data")

--- a/internal/rootcoord/dml_channels_test.go
+++ b/internal/rootcoord/dml_channels_test.go
@@ -22,9 +22,9 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/milvus-io/milvus/internal/mq"
 	"github.com/milvus-io/milvus/internal/mq/msgstream"
 	"github.com/milvus-io/milvus/internal/mq/msgstream/mqwrapper"
-	"github.com/milvus-io/milvus/internal/util/dependency"
 	"github.com/milvus-io/milvus/internal/util/funcutil"
 
 	"github.com/stretchr/testify/assert"
@@ -39,7 +39,7 @@ func TestDmlChannels(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	factory := dependency.NewDefaultFactory(true)
+	factory := mq.NewDefaultFactory(true)
 	Params.Init()
 
 	dml := newDmlChannels(ctx, factory, dmlChanPrefix, totalDmlChannelNum)

--- a/internal/rootcoord/root_coord.go
+++ b/internal/rootcoord/root_coord.go
@@ -40,6 +40,7 @@ import (
 	etcdkv "github.com/milvus-io/milvus/internal/kv/etcd"
 	"github.com/milvus-io/milvus/internal/log"
 	"github.com/milvus-io/milvus/internal/metrics"
+	"github.com/milvus-io/milvus/internal/mq"
 	ms "github.com/milvus-io/milvus/internal/mq/msgstream"
 	"github.com/milvus-io/milvus/internal/proto/commonpb"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
@@ -55,7 +56,6 @@ import (
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util"
 	"github.com/milvus-io/milvus/internal/util/crypto"
-	"github.com/milvus-io/milvus/internal/util/dependency"
 	"github.com/milvus-io/milvus/internal/util/metricsinfo"
 	"github.com/milvus-io/milvus/internal/util/paramtable"
 	"github.com/milvus-io/milvus/internal/util/retry"
@@ -186,7 +186,7 @@ type Core struct {
 
 	session *sessionutil.Session
 
-	factory dependency.Factory
+	factory mq.Factory
 
 	//import manager
 	importManager *importManager
@@ -195,7 +195,7 @@ type Core struct {
 // --------------------- function --------------------------
 
 // NewCore creates a new rootcoord core
-func NewCore(c context.Context, factory dependency.Factory) (*Core, error) {
+func NewCore(c context.Context, factory mq.Factory) (*Core, error) {
 	ctx, cancel := context.WithCancel(c)
 	rand.Seed(time.Now().UnixNano())
 	core := &Core{

--- a/internal/rootcoord/root_coord_test.go
+++ b/internal/rootcoord/root_coord_test.go
@@ -37,6 +37,7 @@ import (
 	etcdkv "github.com/milvus-io/milvus/internal/kv/etcd"
 	memkv "github.com/milvus-io/milvus/internal/kv/mem"
 	"github.com/milvus-io/milvus/internal/log"
+	"github.com/milvus-io/milvus/internal/mq"
 	"github.com/milvus-io/milvus/internal/mq/msgstream"
 	"github.com/milvus-io/milvus/internal/proto/commonpb"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
@@ -50,7 +51,6 @@ import (
 	"github.com/milvus-io/milvus/internal/proto/schemapb"
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util"
-	"github.com/milvus-io/milvus/internal/util/dependency"
 	"github.com/milvus-io/milvus/internal/util/etcd"
 	"github.com/milvus-io/milvus/internal/util/funcutil"
 	"github.com/milvus-io/milvus/internal/util/metricsinfo"
@@ -624,7 +624,7 @@ func TestRootCoordInit(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	coreFactory := dependency.NewDefaultFactory(true)
+	coreFactory := mq.NewDefaultFactory(true)
 	Params.Init()
 	Params.RootCoordCfg.DmlChannelNum = TestDMLChannelNum
 
@@ -748,7 +748,7 @@ func TestRootCoordInitData(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	coreFactory := dependency.NewDefaultFactory(true)
+	coreFactory := mq.NewDefaultFactory(true)
 	Params.Init()
 	Params.RootCoordCfg.DmlChannelNum = TestDMLChannelNum
 
@@ -807,7 +807,7 @@ func TestRootCoord_Base(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	coreFactory := dependency.NewDefaultFactory(true)
+	coreFactory := mq.NewDefaultFactory(true)
 	Params.Init()
 	Params.RootCoordCfg.DmlChannelNum = TestDMLChannelNum
 	Params.RootCoordCfg.ImportIndexCheckInterval = 0.1
@@ -874,7 +874,7 @@ func TestRootCoord_Base(t *testing.T) {
 	err = core.SetQueryCoord(qm)
 	assert.NoError(t, err)
 
-	tmpFactory := dependency.NewDefaultFactory(true)
+	tmpFactory := mq.NewDefaultFactory(true)
 
 	dmlStream, _ := tmpFactory.NewMsgStream(ctx)
 	defer dmlStream.Close()
@@ -2871,7 +2871,7 @@ func TestRootCoord2(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	msFactory := dependency.NewDefaultFactory(true)
+	msFactory := mq.NewDefaultFactory(true)
 
 	Params.Init()
 	Params.RootCoordCfg.DmlChannelNum = TestDMLChannelNum
@@ -3161,7 +3161,7 @@ func TestCheckFlushedSegments(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	msFactory := dependency.NewDefaultFactory(true)
+	msFactory := mq.NewDefaultFactory(true)
 	Params.Init()
 	Params.RootCoordCfg.DmlChannelNum = TestDMLChannelNum
 	core, err := NewCore(ctx, msFactory)
@@ -3316,7 +3316,7 @@ func TestRootCoord_CheckZeroShardsNum(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	msFactory := dependency.NewDefaultFactory(true)
+	msFactory := mq.NewDefaultFactory(true)
 	Params.Init()
 	Params.RootCoordCfg.DmlChannelNum = TestDMLChannelNum
 

--- a/internal/rootcoord/timestamp_test.go
+++ b/internal/rootcoord/timestamp_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/milvus-io/milvus/internal/mq"
 	"github.com/milvus-io/milvus/internal/proto/commonpb"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
 	"github.com/milvus-io/milvus/internal/proto/indexpb"
@@ -32,7 +33,6 @@ import (
 	"github.com/milvus-io/milvus/internal/proto/querypb"
 	"github.com/milvus-io/milvus/internal/proto/rootcoordpb"
 	"github.com/milvus-io/milvus/internal/types"
-	"github.com/milvus-io/milvus/internal/util/dependency"
 	"github.com/milvus-io/milvus/internal/util/sessionutil"
 )
 
@@ -81,7 +81,7 @@ func BenchmarkAllocTimestamp(b *testing.B) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	factory := dependency.NewDefaultFactory(true)
+	factory := mq.NewDefaultFactory(true)
 	Params.Init()
 	core, err := NewCore(ctx, factory)
 

--- a/internal/rootcoord/timeticksync_test.go
+++ b/internal/rootcoord/timeticksync_test.go
@@ -23,16 +23,16 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/milvus-io/milvus/internal/mq"
 	"github.com/milvus-io/milvus/internal/proto/commonpb"
 	"github.com/milvus-io/milvus/internal/proto/internalpb"
-	"github.com/milvus-io/milvus/internal/util/dependency"
 )
 
 func TestTimetickSync(t *testing.T) {
 	ctx := context.Background()
 	sourceID := int64(100)
 
-	factory := dependency.NewDefaultFactory(true)
+	factory := mq.NewDefaultFactory(true)
 
 	//chanMap := map[typeutil.UniqueID][]string{
 	//	int64(1): {"rootcoord-dml_0"},

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -1,48 +1,110 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package storage
 
 import (
 	"context"
-	"errors"
+
+	"github.com/milvus-io/milvus/internal/util/paramtable"
 )
 
-type ChunkManagerFactory struct {
+type ChunkManagerFactory interface {
+	Init(p *paramtable.ComponentParam)
+	NewCacheStorageChunkManager(ctx context.Context) (ChunkManager, error)
+	NewVectorStorageChunkManager(ctx context.Context) (ChunkManager, error)
+}
+
+type DefaultChunkManagerFactory struct {
+	factory *chunkManagerFactory
+}
+
+func NewDefaultChunkManagerFactory() *DefaultChunkManagerFactory {
+	return &DefaultChunkManagerFactory{factory: newChunkManagerFactory("local", "local", RootPath("/tmp/milvus"))}
+}
+
+func NewChunkManagerFactoryWithConfig(cacheStorage, vectorStorage string, opts ...Option) *DefaultChunkManagerFactory {
+	c := newDefaultConfig()
+	for _, opt := range opts {
+		opt(c)
+	}
+	f := &chunkManagerFactory{
+		cacheStorage:  cacheStorage,
+		vectorStorage: vectorStorage,
+		config:        c,
+	}
+
+	return &DefaultChunkManagerFactory{factory: f}
+}
+
+func NewChunkManagerFactory() *DefaultChunkManagerFactory {
+	return &DefaultChunkManagerFactory{}
+}
+
+func (f *DefaultChunkManagerFactory) Init(params *paramtable.ComponentParam) {
+	if params.CommonCfg.StorageType == "local" {
+		f.factory = newChunkManagerFactory("local", "local",
+			RootPath(params.LocalStorageCfg.Path))
+	} else {
+		f.factory = newChunkManagerFactory("local", "minio",
+			RootPath(params.LocalStorageCfg.Path),
+			Address(params.MinioCfg.Address),
+			AccessKeyID(params.MinioCfg.AccessKeyID),
+			SecretAccessKeyID(params.MinioCfg.SecretAccessKey),
+			UseSSL(params.MinioCfg.UseSSL),
+			BucketName(params.MinioCfg.BucketName),
+			UseIAM(params.MinioCfg.UseIAM),
+			IAMEndpoint(params.MinioCfg.IAMEndpoint),
+			CreateBucket(true))
+	}
+}
+
+func (f *DefaultChunkManagerFactory) NewCacheStorageChunkManager(ctx context.Context) (ChunkManager, error) {
+	return f.factory.newCacheStorageChunkManager(ctx)
+}
+
+func (f *DefaultChunkManagerFactory) NewVectorStorageChunkManager(ctx context.Context) (ChunkManager, error) {
+	if f.factory.vectorStorage == "local" {
+		return f.factory.newCacheStorageChunkManager(ctx)
+	}
+	return f.factory.newVectorStorageChunkManager(ctx)
+}
+
+type chunkManagerFactory struct {
 	cacheStorage  string
 	vectorStorage string
 	config        *config
 }
 
-func NewChunkManagerFactory(cacheStorage, vectorStorage string, opts ...Option) *ChunkManagerFactory {
+func newChunkManagerFactory(cacheStorage, vectorStorage string, opts ...Option) *chunkManagerFactory {
 	c := newDefaultConfig()
 	for _, opt := range opts {
 		opt(c)
 	}
-	return &ChunkManagerFactory{
+	return &chunkManagerFactory{
 		cacheStorage:  cacheStorage,
 		vectorStorage: vectorStorage,
 		config:        c,
 	}
 }
 
-func (f *ChunkManagerFactory) newChunkManager(ctx context.Context, engine string) (ChunkManager, error) {
-	switch engine {
-	case "local":
-		return NewLocalChunkManager(RootPath(f.config.rootPath)), nil
-	case "minio":
-		return newMinioChunkManagerWithConfig(ctx, f.config)
-	default:
-		return nil, errors.New("no chunk manager implemented with engine: " + engine)
-	}
+func (f *chunkManagerFactory) newCacheStorageChunkManager(ctx context.Context) (ChunkManager, error) {
+	return NewLocalChunkManager(RootPath(f.config.rootPath)), nil
 }
 
-func (f *ChunkManagerFactory) NewCacheStorageChunkManager(ctx context.Context) (ChunkManager, error) {
-	return f.newChunkManager(ctx, f.cacheStorage)
-}
-
-func (f *ChunkManagerFactory) NewVectorStorageChunkManager(ctx context.Context) (ChunkManager, error) {
-	return f.newChunkManager(ctx, f.vectorStorage)
-}
-
-type Factory interface {
-	NewCacheStorageChunkManager(ctx context.Context) (ChunkManager, error)
-	NewVectorStorageChunkManager(ctx context.Context) (ChunkManager, error)
+func (f *chunkManagerFactory) newVectorStorageChunkManager(ctx context.Context) (ChunkManager, error) {
+	return newMinioChunkManagerWithConfig(ctx, f.config)
 }

--- a/internal/util/dependency/factory.go
+++ b/internal/util/dependency/factory.go
@@ -1,96 +1,66 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package dependency
 
 import (
 	"context"
 
+	"github.com/milvus-io/milvus/internal/mq"
 	"github.com/milvus-io/milvus/internal/mq/msgstream"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/util/paramtable"
 )
 
+// MixedFactory contains a msgstream factory and a chunkmanager factory.
+//
+// Only use a MixedFactory if you need both factories. For any packages using
+//  MixedFactory would depend on `storage` package, which is a CGO package.
+// Otherwise just import the factory you need from its own package.
+type MixedFactory interface {
+	mq.Factory
+	storage.ChunkManagerFactory
+}
+
 type DefaultFactory struct {
 	standAlone          bool
-	chunkManagerFactory storage.Factory
-	msgStreamFactory    msgstream.Factory
+	chunkManagerFactory storage.ChunkManagerFactory
+	msgStreamFactory    mq.Factory
 }
 
-func NewDefaultFactory(standAlone bool) *DefaultFactory {
+func NewDefaultFactory(standAlone bool) MixedFactory {
 	return &DefaultFactory{
-		standAlone:       standAlone,
-		msgStreamFactory: msgstream.NewRmsFactory("/tmp/milvus/rocksmq/"),
-		chunkManagerFactory: storage.NewChunkManagerFactory("local", "local",
-			storage.RootPath("/tmp/milvus")),
+		standAlone:          standAlone,
+		msgStreamFactory:    mq.NewDefaultFactory(standAlone),
+		chunkManagerFactory: storage.NewDefaultChunkManagerFactory(),
 	}
 }
 
-func NewFactory(standAlone bool) *DefaultFactory {
-	return &DefaultFactory{standAlone: standAlone}
+func NewFactory(standAlone bool) MixedFactory {
+	return &DefaultFactory{
+		standAlone:          standAlone,
+		msgStreamFactory:    mq.NewFactory(standAlone),
+		chunkManagerFactory: storage.NewChunkManagerFactory(),
+	}
 }
 
-// Init create a msg factory(TODO only support one mq at the same time.)
-// In order to guarantee backward compatibility of config file, we still support multiple mq configs.
-// 1. Rocksmq only run on local mode, and it has the highest priority
-// 2. Pulsar has higher priority than Kafka within remote msg
+// Init create a msg factory and a chunkmanager factory
 func (f *DefaultFactory) Init(params *paramtable.ComponentParam) {
-	// skip if using default factory
-	if f.msgStreamFactory != nil {
-		return
-	}
-
-	// init storage
-	if params.CommonCfg.StorageType == "local" {
-		f.chunkManagerFactory = storage.NewChunkManagerFactory("local", "local",
-			storage.RootPath(params.LocalStorageCfg.Path))
-	} else {
-		f.chunkManagerFactory = storage.NewChunkManagerFactory("local", "minio",
-			storage.RootPath(params.LocalStorageCfg.Path),
-			storage.Address(params.MinioCfg.Address),
-			storage.AccessKeyID(params.MinioCfg.AccessKeyID),
-			storage.SecretAccessKeyID(params.MinioCfg.SecretAccessKey),
-			storage.UseSSL(params.MinioCfg.UseSSL),
-			storage.BucketName(params.MinioCfg.BucketName),
-			storage.UseIAM(params.MinioCfg.UseIAM),
-			storage.IAMEndpoint(params.MinioCfg.IAMEndpoint),
-			storage.CreateBucket(true))
-	}
-
-	// init mq storage
-	if f.standAlone {
-		f.msgStreamFactory = f.initMQLocalService(params)
-		if f.msgStreamFactory == nil {
-			f.msgStreamFactory = f.initMQRemoteService(params)
-			if f.msgStreamFactory == nil {
-				panic("no available mq configuration, must config rocksmq, Pulsar or Kafka at least one of these!")
-			}
-		}
-		return
-	}
-
-	f.msgStreamFactory = f.initMQRemoteService(params)
-	if f.msgStreamFactory == nil {
-		panic("no available remote mq configuration, must config Pulsar or Kafka at least one of these!")
-	}
-}
-
-func (f *DefaultFactory) initMQLocalService(params *paramtable.ComponentParam) msgstream.Factory {
-	if params.RocksmqEnable() {
-		path, _ := params.Load("_RocksmqPath")
-		return msgstream.NewRmsFactory(path)
-	}
-	return nil
-}
-
-// initRemoteService Pulsar has higher priority than Kafka.
-func (f *DefaultFactory) initMQRemoteService(params *paramtable.ComponentParam) msgstream.Factory {
-	if params.PulsarEnable() {
-		return msgstream.NewPmsFactory(&params.PulsarCfg)
-	}
-
-	if params.KafkaEnable() {
-		return msgstream.NewKmsFactory(&params.KafkaCfg)
-	}
-
-	return nil
+	f.msgStreamFactory.Init(params)
+	f.chunkManagerFactory.Init(params)
 }
 
 func (f *DefaultFactory) NewMsgStream(ctx context.Context) (msgstream.MsgStream, error) {
@@ -115,11 +85,4 @@ func (f *DefaultFactory) NewCacheStorageChunkManager(ctx context.Context) (stora
 
 func (f *DefaultFactory) NewVectorStorageChunkManager(ctx context.Context) (storage.ChunkManager, error) {
 	return f.chunkManagerFactory.NewVectorStorageChunkManager(ctx)
-}
-
-type Factory interface {
-	msgstream.Factory
-	Init(p *paramtable.ComponentParam)
-	NewCacheStorageChunkManager(ctx context.Context) (storage.ChunkManager, error)
-	NewVectorStorageChunkManager(ctx context.Context) (storage.ChunkManager, error)
 }


### PR DESCRIPTION
This PR:
- Added a new `storage.ChunkManagerFactory` interface
and a `mq.Factory` interface
- Rename `dependency.Factory` into `dependency.MixedFactory`

After the above changes:
- DataCoord and RootCoord won't rely on storage CGO
- IndexCoord/IndexNode won't rely on msgstream

See also: #17863

Signed-off-by: yangxuan <xuan.yang@zilliz.com>