### PR TITLE
Define new SubSearchResult constructor to avoid memory copy for growing segment search

### DIFF
--- a/internal/core/src/query/SearchOnGrowing.cpp
+++ b/internal/core/src/query/SearchOnGrowing.cpp
@@ -99,7 +99,6 @@ FloatSearch(const segcore::SegmentGrowingImpl& segment,
         }
         final_qr.merge(sub_qr);
     }
-    current_chunk_id = max_chunk;
     results.distances_ = std::move(final_qr.mutable_distances());
     results.seg_offsets_ = std::move(final_qr.mutable_seg_offsets());
     results.unity_topK_ = topk;

--- a/internal/core/src/query/SubSearchResult.cpp
+++ b/internal/core/src/query/SubSearchResult.cpp
@@ -68,13 +68,6 @@ SubSearchResult::merge(const SubSearchResult& sub_result) {
     }
 }
 
-SubSearchResult
-SubSearchResult::merge(const SubSearchResult& left, const SubSearchResult& right) {
-    auto left_copy = left;
-    left_copy.merge(right);
-    return left_copy;
-}
-
 void
 SubSearchResult::round_values() {
     if (round_decimal_ == -1)

--- a/internal/core/src/query/SubSearchResult.h
+++ b/internal/core/src/query/SubSearchResult.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <limits>
+#include <utility>
 #include <vector>
 #include "common/Types.h"
 
@@ -20,12 +21,21 @@ namespace milvus::query {
 class SubSearchResult {
  public:
     SubSearchResult(int64_t num_queries, int64_t topk, const knowhere::MetricType& metric_type, int64_t round_decimal)
-        : metric_type_(metric_type),
-          num_queries_(num_queries),
+        : num_queries_(num_queries),
           topk_(topk),
+          round_decimal_(round_decimal),
+          metric_type_(metric_type),
           seg_offsets_(num_queries * topk, -1),
-          distances_(num_queries * topk, init_value(metric_type)),
-          round_decimal_(round_decimal) {
+          distances_(num_queries * topk, init_value(metric_type)) {
+    }
+
+    SubSearchResult(SubSearchResult&& other)
+        : num_queries_(other.num_queries_),
+          topk_(other.topk_),
+          round_decimal_(other.round_decimal_),
+          metric_type_(other.metric_type_),
+          seg_offsets_(std::move(other.seg_offsets_)),
+          distances_(std::move(other.distances_)) {
     }
 
  public:
@@ -87,9 +97,6 @@ class SubSearchResult {
 
     void
     round_values();
-
-    static SubSearchResult
-    merge(const SubSearchResult& left, const SubSearchResult& right);
 
     void
     merge(const SubSearchResult& sub_result);


### PR DESCRIPTION
Signed-off-by: yudong.cai <yudong.cai@zilliz.com>