### PR TITLE
[cherry-pick]Make querynode handle segmentChangeInfo with multiple vchannel

### DIFF
--- a/internal/querynode/query_node.go
+++ b/internal/querynode/query_node.go
@@ -33,7 +33,6 @@ import "C"
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -372,39 +371,50 @@ func (node *QueryNode) watchChangeInfo() {
 
 func (node *QueryNode) handleSealedSegmentsChangeInfo(info *querypb.SealedSegmentsChangeInfo) {
 	for _, line := range info.GetInfos() {
-		vchannel, err := validateChangeChannel(line)
-		if err != nil {
-			log.Warn("failed to validate vchannel for SegmentChangeInfo", zap.Error(err))
-			continue
-		}
+		result := splitSegmentsChange(line)
 
-		node.ShardClusterService.HandoffVChannelSegments(vchannel, line)
+		for vchannel, changeInfo := range result {
+			err := node.ShardClusterService.HandoffVChannelSegments(vchannel, changeInfo)
+			if err != nil {
+				log.Warn("failed to handle vchannel segments", zap.String("vchannel", vchannel))
+			}
+		}
 	}
 }
 
-func validateChangeChannel(info *querypb.SegmentChangeInfo) (string, error) {
-	if len(info.GetOnlineSegments()) == 0 && len(info.GetOfflineSegments()) == 0 {
-		return "", errors.New("SegmentChangeInfo with no segments info")
+// splitSegmentsChange returns rearranged segmentChangeInfo in vchannel dimension
+func splitSegmentsChange(changeInfo *querypb.SegmentChangeInfo) map[string]*querypb.SegmentChangeInfo {
+	result := make(map[string]*querypb.SegmentChangeInfo)
+
+	for _, segment := range changeInfo.GetOnlineSegments() {
+		dmlChannel := segment.GetDmChannel()
+		info, has := result[dmlChannel]
+		if !has {
+			info = &querypb.SegmentChangeInfo{
+				OnlineNodeID:  changeInfo.OnlineNodeID,
+				OfflineNodeID: changeInfo.OfflineNodeID,
+			}
+
+			result[dmlChannel] = info
+		}
+
+		info.OnlineSegments = append(info.OnlineSegments, segment)
 	}
 
-	var channelName string
+	for _, segment := range changeInfo.GetOfflineSegments() {
+		dmlChannel := segment.GetDmChannel()
+		info, has := result[dmlChannel]
+		if !has {
+			info = &querypb.SegmentChangeInfo{
+				OnlineNodeID:  changeInfo.OnlineNodeID,
+				OfflineNodeID: changeInfo.OfflineNodeID,
+			}
 
-	for _, segment := range info.GetOnlineSegments() {
-		if channelName == "" {
-			channelName = segment.GetDmChannel()
+			result[dmlChannel] = info
 		}
-		if segment.GetDmChannel() != channelName {
-			return "", fmt.Errorf("found multilple channel name in one SegmentChangeInfo, channel1: %s, channel 2:%s", channelName, segment.GetDmChannel())
-		}
-	}
-	for _, segment := range info.GetOfflineSegments() {
-		if channelName == "" {
-			channelName = segment.GetDmChannel()
-		}
-		if segment.GetDmChannel() != channelName {
-			return "", fmt.Errorf("found multilple channel name in one SegmentChangeInfo, channel1: %s, channel 2:%s", channelName, segment.GetDmChannel())
-		}
+
+		info.OfflineSegments = append(info.OfflineSegments, segment)
 	}
 
-	return channelName, nil
+	return result
 }

--- a/internal/querynode/query_node_test.go
+++ b/internal/querynode/query_node_test.go
@@ -328,20 +328,19 @@ func TestQueryNode_watchChangeInfo(t *testing.T) {
 	wg.Wait()
 }
 
-func TestQueryNode_validateChangeChannel(t *testing.T) {
+func TestQueryNode_splitChangeChannel(t *testing.T) {
 
 	type testCase struct {
-		name                string
-		info                *querypb.SegmentChangeInfo
-		expectedError       bool
-		expectedChannelName string
+		name           string
+		info           *querypb.SegmentChangeInfo
+		expectedResult map[string]*querypb.SegmentChangeInfo
 	}
 
 	cases := []testCase{
 		{
-			name:          "empty info",
-			info:          &querypb.SegmentChangeInfo{},
-			expectedError: true,
+			name:           "empty info",
+			info:           &querypb.SegmentChangeInfo{},
+			expectedResult: map[string]*querypb.SegmentChangeInfo{},
 		},
 		{
 			name: "normal segment change info",
@@ -353,8 +352,16 @@ func TestQueryNode_validateChangeChannel(t *testing.T) {
 					{DmChannel: defaultDMLChannel},
 				},
 			},
-			expectedError:       false,
-			expectedChannelName: defaultDMLChannel,
+			expectedResult: map[string]*querypb.SegmentChangeInfo{
+				defaultDMLChannel: {
+					OnlineSegments: []*querypb.SegmentInfo{
+						{DmChannel: defaultDMLChannel},
+					},
+					OfflineSegments: []*querypb.SegmentInfo{
+						{DmChannel: defaultDMLChannel},
+					},
+				},
+			},
 		},
 		{
 			name: "empty offline change info",
@@ -363,8 +370,13 @@ func TestQueryNode_validateChangeChannel(t *testing.T) {
 					{DmChannel: defaultDMLChannel},
 				},
 			},
-			expectedError:       false,
-			expectedChannelName: defaultDMLChannel,
+			expectedResult: map[string]*querypb.SegmentChangeInfo{
+				defaultDMLChannel: {
+					OnlineSegments: []*querypb.SegmentInfo{
+						{DmChannel: defaultDMLChannel},
+					},
+				},
+			},
 		},
 		{
 			name: "empty online change info",
@@ -373,8 +385,13 @@ func TestQueryNode_validateChangeChannel(t *testing.T) {
 					{DmChannel: defaultDMLChannel},
 				},
 			},
-			expectedError:       false,
-			expectedChannelName: defaultDMLChannel,
+			expectedResult: map[string]*querypb.SegmentChangeInfo{
+				defaultDMLChannel: {
+					OfflineSegments: []*querypb.SegmentInfo{
+						{DmChannel: defaultDMLChannel},
+					},
+				},
+			},
 		},
 		{
 			name: "different channel in online",
@@ -384,7 +401,18 @@ func TestQueryNode_validateChangeChannel(t *testing.T) {
 					{DmChannel: "other_channel"},
 				},
 			},
-			expectedError: true,
+			expectedResult: map[string]*querypb.SegmentChangeInfo{
+				defaultDMLChannel: {
+					OnlineSegments: []*querypb.SegmentInfo{
+						{DmChannel: defaultDMLChannel},
+					},
+				},
+				"other_channel": {
+					OnlineSegments: []*querypb.SegmentInfo{
+						{DmChannel: "other_channel"},
+					},
+				},
+			},
 		},
 		{
 			name: "different channel in offline",
@@ -396,18 +424,32 @@ func TestQueryNode_validateChangeChannel(t *testing.T) {
 					{DmChannel: "other_channel"},
 				},
 			},
-			expectedError: true,
+			expectedResult: map[string]*querypb.SegmentChangeInfo{
+				defaultDMLChannel: {
+					OnlineSegments: []*querypb.SegmentInfo{
+						{DmChannel: defaultDMLChannel},
+					},
+				},
+				"other_channel": {
+					OfflineSegments: []*querypb.SegmentInfo{
+						{DmChannel: "other_channel"},
+					},
+				},
+			},
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			channelName, err := validateChangeChannel(tc.info)
-			if tc.expectedError {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-				assert.Equal(t, tc.expectedChannelName, channelName)
+			result := splitSegmentsChange(tc.info)
+			assert.Equal(t, len(tc.expectedResult), len(result))
+			for k, v := range tc.expectedResult {
+				r := assert.True(t, proto.Equal(v, result[k]))
+
+				if !r {
+					t.Log(v)
+					t.Log(result[k])
+				}
 			}
 		})
 	}
@@ -445,7 +487,7 @@ func TestQueryNode_handleSealedSegmentsChangeInfo(t *testing.T) {
 		})
 	})
 
-	t.Run("bad change info", func(t *testing.T) {
+	t.Run("multple vchannel change info", func(t *testing.T) {
 		assert.NotPanics(t, func() {
 			qn.handleSealedSegmentsChangeInfo(&querypb.SealedSegmentsChangeInfo{
 				Infos: []*querypb.SegmentChangeInfo{

--- a/internal/querynode/shard_cluster_service.go
+++ b/internal/querynode/shard_cluster_service.go
@@ -153,7 +153,7 @@ func (s *ShardClusterService) HandoffVChannelSegments(vchannel string, info *que
 	sc := raw.(*ShardCluster)
 	err := sc.HandoffSegments(info)
 	if err == nil {
-		log.Info("successfully handoff ", zap.String("channel", vchannel), zap.Any("segment", info))
+		log.Info("successfully handoff", zap.String("channel", vchannel), zap.Any("segment", info))
 	} else {
 		log.Warn("failed to handoff", zap.String("channel", vchannel), zap.Any("segment", info), zap.Error(err))
 	}


### PR DESCRIPTION
cherry pick from master
Let querynode split segmentChangeInfo according to vchannel instead of reporting error.

Fix #18008

/kind bug

Signed-off-by: Congqi Xia <congqi.xia@zilliz.com>