### PR TITLE
Refine compareAndSwap interface in etcdKV

### DIFF
--- a/internal/datanode/data_node_test.go
+++ b/internal/datanode/data_node_test.go
@@ -757,10 +757,9 @@ func TestWatchChannel(t *testing.T) {
 				chPut <- struct{}{}
 				return r
 			},
-			func(vChan string) bool {
+			func(vChan string) {
 				node.handleDeleteEvent(vChan)
 				chDel <- struct{}{}
-				return true
 			}, time.Millisecond*100,
 		)
 		node.eventManagerMap.Store(ch, m)
@@ -795,10 +794,9 @@ func TestWatchChannel(t *testing.T) {
 				chPut <- struct{}{}
 				return r
 			},
-			func(vChan string) bool {
+			func(vChan string) {
 				node.handleDeleteEvent(vChan)
 				chDel <- struct{}{}
-				return true
 			}, time.Millisecond*100,
 		)
 		node.eventManagerMap.Store(ch, m)

--- a/internal/datanode/event_manager_test.go
+++ b/internal/datanode/event_manager_test.go
@@ -34,7 +34,7 @@ func TestChannelEventManager(t *testing.T) {
 			ran = true
 			ch <- struct{}{}
 			return nil
-		}, func(name string) bool { return true }, time.Millisecond*10)
+		}, func(name string) {}, time.Millisecond*10)
 
 		em.Run()
 		em.handleEvent(event{
@@ -56,7 +56,7 @@ func TestChannelEventManager(t *testing.T) {
 			ran = true
 			ch <- struct{}{}
 			return nil
-		}, func(name string) bool { return true }, time.Millisecond*10)
+		}, func(name string) {}, time.Millisecond*10)
 
 		em.Run()
 		em.handleEvent(event{
@@ -89,7 +89,7 @@ func TestChannelEventManager(t *testing.T) {
 			}
 
 			return errors.New("mocked error")
-		}, func(name string) bool { return true }, time.Millisecond*10)
+		}, func(name string) {}, time.Millisecond*10)
 
 		em.Run()
 		em.handleEvent(event{
@@ -107,7 +107,7 @@ func TestChannelEventManager(t *testing.T) {
 	t.Run("retry until timeout", func(t *testing.T) {
 		em := newChannelEventManager(func(info *datapb.ChannelWatchInfo, version int64) error {
 			return errors.New("mocked error")
-		}, func(name string) bool { return true }, time.Millisecond*100)
+		}, func(name string) {}, time.Millisecond*100)
 
 		ch := make(chan struct{}, 1)
 
@@ -136,7 +136,7 @@ func TestChannelEventManager(t *testing.T) {
 		ch := make(chan struct{}, 1)
 		em := newChannelEventManager(func(info *datapb.ChannelWatchInfo, version int64) error {
 			return errors.New("mocked error")
-		}, func(name string) bool { return true }, time.Millisecond*10)
+		}, func(name string) {}, time.Millisecond*10)
 
 		go func() {
 			ddl := time.Now().Add(time.Minute)
@@ -172,10 +172,9 @@ func TestChannelEventManager(t *testing.T) {
 			func(info *datapb.ChannelWatchInfo, version int64) error {
 				return errors.New("mocked error")
 			},
-			func(name string) bool {
+			func(name string) {
 				ran = true
 				ch <- struct{}{}
-				return true
 			},
 			time.Millisecond*10,
 		)
@@ -212,9 +211,7 @@ func TestChannelEventManager(t *testing.T) {
 				}
 				return errors.New("mocked error")
 			},
-			func(name string) bool {
-				return false
-			},
+			func(name string) {},
 			time.Millisecond*10)
 		em.Run()
 		em.handleEvent(event{
@@ -253,9 +250,7 @@ func TestChannelEventManager(t *testing.T) {
 				func(info *datapb.ChannelWatchInfo, version int64) error {
 					return errors.New("mocked error")
 				},
-				func(name string) bool {
-					return false
-				},
+				func(name string) {},
 				time.Millisecond*100,
 			)
 

--- a/internal/indexcoord/meta_table_test.go
+++ b/internal/indexcoord/meta_table_test.go
@@ -70,8 +70,8 @@ func TestMetaTable(t *testing.T) {
 
 	t.Run("saveIndexMeta", func(t *testing.T) {
 		meta := &Meta{
-			indexMeta: indexMeta1,
-			revision:  10,
+			indexMeta:    indexMeta1,
+			indexVersion: 10,
 		}
 		err = metaTable.saveIndexMeta(meta)
 		assert.NotNil(t, err)

--- a/internal/indexnode/indexnode_mock.go
+++ b/internal/indexnode/indexnode_mock.go
@@ -19,6 +19,7 @@ package indexnode
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 
 	"go.uber.org/zap"
@@ -89,10 +90,14 @@ func (inm *Mock) buildIndexTask() {
 					if err != nil {
 						return err
 					}
-					err = inm.etcdKV.CompareVersionAndSwap(req.MetaPath, versions[0],
-						string(metaData))
+					success, err := inm.etcdKV.CompareVersionAndSwap(req.MetaPath, versions[0], string(metaData))
 					if err != nil {
+						// TODO, we don't need to reload if it is just etcd error
+						log.Warn("failed to compare and swap in etcd", zap.Int64("buildID", req.IndexBuildID), zap.Error(err))
 						return err
+					}
+					if !success {
+						return fmt.Errorf("failed to save index meta in etcd, buildId: %d, source version: %d", req.IndexBuildID, versions[0])
 					}
 					return nil
 				}
@@ -117,10 +122,15 @@ func (inm *Mock) buildIndexTask() {
 					if err != nil {
 						return err
 					}
-					err = inm.etcdKV.CompareVersionAndSwap(req.MetaPath, versions[0],
-						string(metaData))
+
+					success, err := inm.etcdKV.CompareVersionAndSwap(req.MetaPath, versions[0], string(metaData))
 					if err != nil {
+						// TODO, we don't need to reload if it is just etcd error
+						log.Warn("failed to compare and swap in etcd", zap.Int64("buildID", req.IndexBuildID), zap.Error(err))
 						return err
+					}
+					if !success {
+						return fmt.Errorf("failed to save index meta in etcd, buildId: %d, source version: %d", req.IndexBuildID, versions[0])
 					}
 
 					indexMeta2 := indexpb.IndexMeta{}
@@ -139,10 +149,14 @@ func (inm *Mock) buildIndexTask() {
 					if err != nil {
 						return err
 					}
-					err = inm.etcdKV.CompareVersionAndSwap(req.MetaPath, versions2[0],
-						string(metaData2))
+					success, err = inm.etcdKV.CompareVersionAndSwap(req.MetaPath, versions2[0], string(metaData2))
 					if err != nil {
+						// TODO, we don't need to reload if it is just etcd error
+						log.Warn("failed to compare and swap in etcd", zap.Int64("buildID", req.IndexBuildID), zap.Error(err))
 						return err
+					}
+					if !success {
+						return fmt.Errorf("failed to save index meta in etcd, buildId: %d, source version: %d", req.IndexBuildID, versions[0])
 					}
 					return nil
 				}

--- a/internal/kv/etcd/embed_etcd_kv_test.go
+++ b/internal/kv/etcd/embed_etcd_kv_test.go
@@ -17,12 +17,10 @@
 package etcdkv_test
 
 import (
-	"errors"
 	"os"
 	"testing"
 	"time"
 
-	"github.com/milvus-io/milvus/internal/kv"
 	"github.com/milvus-io/milvus/internal/util/metricsinfo"
 
 	embed_etcd_kv "github.com/milvus-io/milvus/internal/kv/etcd"
@@ -810,24 +808,25 @@ func TestEmbedEtcd(te *testing.T) {
 			assert.Equal(t, revision+1, resp.Header.Revision)
 		}
 
-		var compareErr *kv.CompareFailedError
-		err = metaKv.CompareVersionAndSwap("a/b/c", 0, "1")
+		success, err := metaKv.CompareVersionAndSwap("a/b/c", 0, "1")
 		assert.NoError(t, err)
+		assert.True(t, success)
 
 		value, err := metaKv.Load("a/b/c")
 		assert.NoError(t, err)
 		assert.Equal(t, value, "1")
 
-		err = metaKv.CompareVersionAndSwap("a/b/c", 0, "1")
-		assert.Error(t, err)
-		assert.True(t, errors.As(err, &compareErr))
+		success, err = metaKv.CompareVersionAndSwap("a/b/c", 0, "1")
+		assert.NoError(t, err)
+		assert.False(t, success)
 
-		err = metaKv.CompareValueAndSwap("a/b/c", "1", "2")
+		success, err = metaKv.CompareValueAndSwap("a/b/c", "1", "2")
+		assert.True(t, success)
 		assert.NoError(t, err)
 
-		err = metaKv.CompareValueAndSwap("a/b/c", "1", "2")
-		assert.Error(t, err)
-		assert.True(t, errors.As(err, &compareErr))
+		success, err = metaKv.CompareValueAndSwap("a/b/c", "1", "2")
+		assert.NoError(t, err)
+		assert.False(t, success)
 	})
 
 	te.Run("Etcd Revision Bytes", func(t *testing.T) {
@@ -865,24 +864,25 @@ func TestEmbedEtcd(te *testing.T) {
 			assert.Equal(t, revision+1, resp.Header.Revision)
 		}
 
-		var compareErr *kv.CompareFailedError
-		err = metaKv.CompareVersionAndSwapBytes("a/b/c", 0, []byte("1"))
+		success, err := metaKv.CompareVersionAndSwapBytes("a/b/c", 0, []byte("1"))
 		assert.NoError(t, err)
+		assert.True(t, success)
 
 		value, err := metaKv.LoadBytes("a/b/c")
 		assert.NoError(t, err)
 		assert.Equal(t, value, []byte("1"))
 
-		err = metaKv.CompareVersionAndSwapBytes("a/b/c", 0, []byte("1"))
-		assert.Error(t, err)
-		assert.True(t, errors.As(err, &compareErr))
+		success, err = metaKv.CompareVersionAndSwapBytes("a/b/c", 0, []byte("1"))
+		assert.NoError(t, err)
+		assert.False(t, success)
 
-		err = metaKv.CompareValueAndSwapBytes("a/b/c", []byte("1"), []byte("2"))
+		success, err = metaKv.CompareValueAndSwapBytes("a/b/c", []byte("1"), []byte("2"))
+		assert.True(t, success)
 		assert.NoError(t, err)
 
-		err = metaKv.CompareValueAndSwapBytes("a/b/c", []byte("1"), []byte("2"))
-		assert.Error(t, err)
-		assert.True(t, errors.As(err, &compareErr))
+		success, err = metaKv.CompareValueAndSwapBytes("a/b/c", []byte("1"), []byte("2"))
+		assert.NoError(t, err)
+		assert.False(t, success)
 
 	})
 

--- a/internal/kv/etcd/etcd_kv_test.go
+++ b/internal/kv/etcd/etcd_kv_test.go
@@ -17,12 +17,10 @@
 package etcdkv_test
 
 import (
-	"errors"
 	"os"
 	"testing"
 	"time"
 
-	"github.com/milvus-io/milvus/internal/kv"
 	etcdkv "github.com/milvus-io/milvus/internal/kv/etcd"
 	"github.com/milvus-io/milvus/internal/util/etcd"
 	"github.com/milvus-io/milvus/internal/util/paramtable"
@@ -732,24 +730,25 @@ func TestEtcdKV_Load(te *testing.T) {
 			assert.Equal(t, revision+1, resp.Header.Revision)
 		}
 
-		var compareErr *kv.CompareFailedError
-		err = etcdKV.CompareVersionAndSwap("a/b/c", 0, "1")
+		success, err := etcdKV.CompareVersionAndSwap("a/b/c", 0, "1")
 		assert.NoError(t, err)
+		assert.True(t, success)
 
 		value, err := etcdKV.Load("a/b/c")
 		assert.NoError(t, err)
 		assert.Equal(t, value, "1")
 
-		err = etcdKV.CompareVersionAndSwap("a/b/c", 0, "1")
-		assert.Error(t, err)
-		assert.True(t, errors.As(err, &compareErr))
+		success, err = etcdKV.CompareVersionAndSwap("a/b/c", 0, "1")
+		assert.NoError(t, err)
+		assert.False(t, success)
 
-		err = etcdKV.CompareValueAndSwap("a/b/c", "1", "2")
+		success, err = etcdKV.CompareValueAndSwap("a/b/c", "1", "2")
+		assert.True(t, success)
 		assert.NoError(t, err)
 
-		err = etcdKV.CompareValueAndSwap("a/b/c", "1", "2")
-		assert.Error(t, err)
-		assert.True(t, errors.As(err, &compareErr))
+		success, err = etcdKV.CompareValueAndSwap("a/b/c", "1", "2")
+		assert.NoError(t, err)
+		assert.False(t, success)
 	})
 
 	te.Run("Etcd Revision Bytes", func(t *testing.T) {
@@ -784,24 +783,25 @@ func TestEtcdKV_Load(te *testing.T) {
 			assert.Equal(t, revision+1, resp.Header.Revision)
 		}
 
-		var compareErr *kv.CompareFailedError
-		err = etcdKV.CompareVersionAndSwapBytes("a/b/c", 0, []byte("1"))
+		success, err := etcdKV.CompareVersionAndSwapBytes("a/b/c", 0, []byte("1"))
 		assert.NoError(t, err)
+		assert.True(t, success)
 
 		value, err := etcdKV.LoadBytes("a/b/c")
 		assert.NoError(t, err)
 		assert.Equal(t, string(value), "1")
 
-		err = etcdKV.CompareVersionAndSwapBytes("a/b/c", 0, []byte("1"))
-		assert.Error(t, err)
-		assert.True(t, errors.As(err, &compareErr))
+		success, err = etcdKV.CompareVersionAndSwapBytes("a/b/c", 0, []byte("1"))
+		assert.NoError(t, err)
+		assert.False(t, success)
 
-		err = etcdKV.CompareValueAndSwapBytes("a/b/c", []byte("1"), []byte("2"))
+		success, err = etcdKV.CompareValueAndSwapBytes("a/b/c", []byte("1"), []byte("2"))
+		assert.True(t, success)
 		assert.NoError(t, err)
 
-		err = etcdKV.CompareValueAndSwapBytes("a/b/c", []byte("1"), []byte("2"))
-		assert.Error(t, err)
-		assert.True(t, errors.As(err, &compareErr))
+		success, err = etcdKV.CompareValueAndSwapBytes("a/b/c", []byte("1"), []byte("2"))
+		assert.NoError(t, err)
+		assert.False(t, success)
 	})
 
 	te.Run("Etcd Lease", func(t *testing.T) {

--- a/internal/kv/kv.go
+++ b/internal/kv/kv.go
@@ -73,8 +73,8 @@ type MetaKv interface {
 	SaveWithIgnoreLease(key, value string) error
 	Grant(ttl int64) (id clientv3.LeaseID, err error)
 	KeepAlive(id clientv3.LeaseID) (<-chan *clientv3.LeaseKeepAliveResponse, error)
-	CompareValueAndSwap(key, value, target string, opts ...clientv3.OpOption) error
-	CompareVersionAndSwap(key string, version int64, target string, opts ...clientv3.OpOption) error
+	CompareValueAndSwap(key, value, target string, opts ...clientv3.OpOption) (bool, error)
+	CompareVersionAndSwap(key string, version int64, target string, opts ...clientv3.OpOption) (bool, error)
 }
 
 // SnapShotKV is TxnKV for snapshot data. It must save timestamp.

--- a/internal/kv/mock_kv.go
+++ b/internal/kv/mock_kv.go
@@ -147,10 +147,10 @@ func (m *MockMetaKV) KeepAlive(id clientv3.LeaseID) (<-chan *clientv3.LeaseKeepA
 	panic("not implemented") // TODO: Implement
 }
 
-func (m *MockMetaKV) CompareValueAndSwap(key, value, target string, opts ...clientv3.OpOption) error {
+func (m *MockMetaKV) CompareValueAndSwap(key, value, target string, opts ...clientv3.OpOption) (bool, error) {
 	panic("not implemented") // TODO: Implement
 }
 
-func (m *MockMetaKV) CompareVersionAndSwap(key string, version int64, target string, opts ...clientv3.OpOption) error {
+func (m *MockMetaKV) CompareVersionAndSwap(key string, version int64, target string, opts ...clientv3.OpOption) (bool, error) {
 	panic("not implemented") // TODO: Implement
 }

--- a/internal/querycoord/replica_test.go
+++ b/internal/querycoord/replica_test.go
@@ -125,11 +125,11 @@ func (m *mockMetaKV) KeepAlive(id clientv3.LeaseID) (<-chan *clientv3.LeaseKeepA
 	panic("not implemented") // TODO: Implement
 }
 
-func (m *mockMetaKV) CompareValueAndSwap(key string, value string, target string, opts ...clientv3.OpOption) error {
+func (m *mockMetaKV) CompareValueAndSwap(key string, value string, target string, opts ...clientv3.OpOption) (bool, error) {
 	panic("not implemented") // TODO: Implement
 }
 
-func (m *mockMetaKV) CompareVersionAndSwap(key string, version int64, target string, opts ...clientv3.OpOption) error {
+func (m *mockMetaKV) CompareVersionAndSwap(key string, version int64, target string, opts ...clientv3.OpOption) (bool, error) {
 	panic("not implemented") // TODO: Implement
 }
 


### PR DESCRIPTION
fix #18066 
1. change the etcd compareAndSwap interface
2. fix the case datanode leak flowgraph
3. fix the case indexnode write meaning less etcd path

Signed-off-by: xiaofan-luan <xiaofan.luan@zilliz.com>