### PR TITLE
Replace pulsar compression type zstd with lz4

### DIFF
--- a/internal/mq/msgstream/mqwrapper/pulsar/pulsar_client.go
+++ b/internal/mq/msgstream/mqwrapper/pulsar/pulsar_client.go
@@ -71,7 +71,7 @@ func NewClient(opts pulsar.ClientOptions) (*pulsarClient, error) {
 func (pc *pulsarClient) CreateProducer(options mqwrapper.ProducerOptions) (mqwrapper.Producer, error) {
 	opts := pulsar.ProducerOptions{Topic: options.Topic}
 	if options.EnableCompression {
-		opts.CompressionType = pulsar.ZSTD
+		opts.CompressionType = pulsar.LZ4
 	}
 
 	pp, err := pc.client.CreateProducer(opts)


### PR DESCRIPTION
Using lz4, the insert performance tested by #17895 will increase almost 10% than version in 2.0.2.
Signed-off-by: longjiquan <jiquan.long@zilliz.com>
issue: #17895 