### PR TITLE
Remove load collection check in Proxy

### DIFF
--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1172,18 +1172,6 @@ func TestProxy(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, commonpb.ErrorCode_Success, resp.ErrorCode)
 
-		// load the same collection, test loaded check
-		colInfo, err := globalMetaCache.GetCollectionInfo(ctx, collectionName)
-		assert.NoError(t, err)
-		colInfo.isLoaded = true
-		resp, err = proxy.LoadCollection(ctx, &milvuspb.LoadCollectionRequest{
-			Base:           nil,
-			DbName:         dbName,
-			CollectionName: collectionName,
-		})
-		assert.NoError(t, err)
-		assert.Equal(t, commonpb.ErrorCode_Success, resp.ErrorCode)
-
 		// load other collection -> fail
 		resp, err = proxy.LoadCollection(ctx, &milvuspb.LoadCollectionRequest{
 			Base:           nil,

--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -2591,23 +2591,6 @@ func (lct *loadCollectionTask) Execute(ctx context.Context) (err error) {
 		return err
 	}
 
-	// check if loaded
-	info, err := globalMetaCache.GetCollectionInfo(ctx, lct.CollectionName)
-	if err != nil {
-		return fmt.Errorf("GetCollectionInfo failed, collection = %s, err = %s", lct.CollectionName, err)
-	}
-	if info.isLoaded { // TODO: may not be thread safe
-		log.Debug("collection has been loaded",
-			zap.String("role", typeutil.ProxyRole),
-			zap.String("collectionName", lct.CollectionName),
-			zap.Int64("collectionID", collID),
-			zap.Int64("msgID", lct.GetBase().GetMsgID()))
-		lct.result = &commonpb.Status{
-			ErrorCode: commonpb.ErrorCode_Success,
-		}
-		return nil
-	}
-
 	lct.collectionID = collID
 	collSchema, err := globalMetaCache.GetCollectionSchema(ctx, lct.CollectionName)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: bigsheeper <yihao.dai@zilliz.com>

Remove load collection check when `LoadCollection` in Proxy, because `LoadCollection` need to do a replica number check in QueryCoord.

issues: #18088 