### PR TITLE
Fix pulsar error check

### DIFF
--- a/internal/mq/msgstream/mqwrapper/pulsar/pulsar_client.go
+++ b/internal/mq/msgstream/mqwrapper/pulsar/pulsar_client.go
@@ -18,6 +18,7 @@ package pulsar
 
 import (
 	"errors"
+	"strings"
 	"sync"
 
 	"github.com/apache/pulsar-client-go/pulsar"
@@ -33,24 +34,6 @@ type pulsarClient struct {
 
 var sc *pulsarClient
 var once sync.Once
-
-func isPulsarError(err error, result ...pulsar.Result) bool {
-	if len(result) == 0 {
-		return false
-	}
-
-	perr, ok := err.(*pulsar.Error)
-	if !ok {
-		return false
-	}
-	for _, r := range result {
-		if perr.Result() == r {
-			return true
-		}
-	}
-
-	return false
-}
 
 // NewClient creates a pulsarClient object
 // according to the parameter opts of type pulsar.ClientOptions
@@ -96,8 +79,7 @@ func (pc *pulsarClient) Subscribe(options mqwrapper.ConsumerOptions) (mqwrapper.
 		MessageChannel:              receiveChannel,
 	})
 	if err != nil {
-		// exclusive consumer already exist
-		if isPulsarError(err, pulsar.ConsumerBusy) {
+		if strings.Contains(err.Error(), "ConsumerBusy") {
 			return nil, retry.Unrecoverable(err)
 		}
 		return nil, err

--- a/internal/mq/msgstream/mqwrapper/pulsar/pulsar_consumer_test.go
+++ b/internal/mq/msgstream/mqwrapper/pulsar/pulsar_consumer_test.go
@@ -19,9 +19,13 @@ package pulsar
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/milvus-io/milvus/internal/mq/msgstream/mqwrapper"
+	"github.com/streamnative/pulsarctl/pkg/cmdutils"
+	"github.com/streamnative/pulsarctl/pkg/pulsar/utils"
 
 	"github.com/apache/pulsar-client-go/pulsar"
 	"github.com/stretchr/testify/assert"
@@ -130,4 +134,81 @@ func TestPulsarConsumer_Close(t *testing.T) {
 
 	// test double close
 	pulsarConsumer.Close()
+}
+
+func TestPulsarClientCloseUnsubscribeError(t *testing.T) {
+	topic := "TestPulsarClientCloseUnsubscribeError"
+	subName := "test"
+	pulsarAddress, _ := Params.Load("_PulsarAddress")
+
+	client, err := pulsar.NewClient(pulsar.ClientOptions{URL: pulsarAddress})
+	defer client.Close()
+	assert.NoError(t, err)
+
+	consumer, err := client.Subscribe(pulsar.ConsumerOptions{
+		Topic:                       topic,
+		SubscriptionName:            subName,
+		Type:                        pulsar.Exclusive,
+		SubscriptionInitialPosition: pulsar.SubscriptionPositionEarliest,
+	})
+	defer consumer.Close()
+	assert.NoError(t, err)
+
+	// subscribe agiain
+	_, err = client.Subscribe(pulsar.ConsumerOptions{
+		Topic:                       topic,
+		SubscriptionName:            subName,
+		Type:                        pulsar.Exclusive,
+		SubscriptionInitialPosition: pulsar.SubscriptionPositionEarliest,
+	})
+	defer consumer.Close()
+	assert.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "ConsumerBusy"))
+
+	topicName, err := utils.GetTopicName(topic)
+	assert.NoError(t, err)
+
+	pulsarURL, err := url.ParseRequestURI(pulsarAddress)
+	if err != nil {
+		panic(err)
+	}
+	webport := Params.LoadWithDefault("pulsar.webport", "80")
+	cmdutils.PulsarCtlConfig.WebServiceURL = "http://" + pulsarURL.Hostname() + ":" + webport
+	admin := cmdutils.NewPulsarClient()
+	err = admin.Subscriptions().Delete(*topicName, subName, true)
+	if err != nil {
+		cmdutils.PulsarCtlConfig.WebServiceURL = "http://" + pulsarURL.Hostname() + ":" + "8080"
+		admin := cmdutils.NewPulsarClient()
+		err = admin.Subscriptions().Delete(*topicName, subName, true)
+		assert.NoError(t, err)
+	}
+
+	err = consumer.Unsubscribe()
+	assert.True(t, strings.Contains(err.Error(), "Consumer not found"))
+	fmt.Println(err)
+}
+
+func TestPulsarClientUnsubscribeTwice(t *testing.T) {
+	topic := "TestPulsarClientUnsubscribeTwice"
+	subName := "test"
+	pulsarAddress, _ := Params.Load("_PulsarAddress")
+
+	client, err := pulsar.NewClient(pulsar.ClientOptions{URL: pulsarAddress})
+	defer client.Close()
+	assert.NoError(t, err)
+
+	consumer, err := client.Subscribe(pulsar.ConsumerOptions{
+		Topic:                       topic,
+		SubscriptionName:            subName,
+		Type:                        pulsar.Exclusive,
+		SubscriptionInitialPosition: pulsar.SubscriptionPositionEarliest,
+	})
+	defer consumer.Close()
+	assert.NoError(t, err)
+
+	err = consumer.Unsubscribe()
+	assert.NoError(t, err)
+	err = consumer.Unsubscribe()
+	assert.True(t, strings.Contains(err.Error(), "Consumer not found"))
+	fmt.Println(err)
 }


### PR DESCRIPTION
related to #18206
Use pulsar error string as error check rather than pulsar result due to pulsar go client didn't setup error type correctly
Signed-off-by: xiaofan-luan <xiaofan.luan@zilliz.com>