### PR TITLE
Fix pk2offset occupy too much memory

### DIFF
--- a/internal/core/src/common/Types.h
+++ b/internal/core/src/common/Types.h
@@ -21,6 +21,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <unordered_map>
 #include <tbb/concurrent_unordered_map.h>
 #include <tbb/concurrent_unordered_set.h>
 #include <boost/align/aligned_allocator.hpp>
@@ -74,7 +75,7 @@ using InsertData = proto::segcore::InsertRecord;
 using PkType = std::variant<std::monostate, int64_t, std::string>;
 // tbb::concurrent_unordered_multimap equal_range too slow when multi repeated key
 // using Pk2OffsetType = tbb::concurrent_unordered_multimap<PkType, int64_t, std::hash<PkType>>;
-using Pk2OffsetType = tbb::concurrent_unordered_map<PkType, tbb::concurrent_unordered_set<int64_t>, std::hash<PkType>>;
+using Pk2OffsetType = std::unordered_map<PkType, std::vector<int64_t>, std::hash<PkType>>;
 
 MetricType
 GetMetricType(const std::string& type);


### PR DESCRIPTION
fix issue: #18232 
/kind bug

empty tbb::concurrent_unordered_set also occupy 560 byte, pk2offset will use 56G memory when has 1b data
Signed-off-by: xige-16 <xi.ge@zilliz.com>