### PR TITLE
Fix addSegment error, avoid the risk of mem leaks

### DIFF
--- a/internal/querynode/meta_replica.go
+++ b/internal/querynode/meta_replica.go
@@ -550,7 +550,8 @@ func (replica *metaReplica) addSegmentPrivate(segmentID UniqueID, partitionID Un
 		return err
 	}
 	if ok {
-		return nil
+		return fmt.Errorf("segment has been existed, "+
+			"segmentID = %d, collectionID = %d, segmentType = %s", segmentID, segment.collectionID, segType.String())
 	}
 	partition.addSegmentID(segmentID, segType)
 

--- a/internal/querynode/meta_replica_test.go
+++ b/internal/querynode/meta_replica_test.go
@@ -189,6 +189,18 @@ func TestMetaReplica_segment(t *testing.T) {
 		}
 	})
 
+	t.Run("test add duplicated segment", func(t *testing.T) {
+		replica, err := genSimpleReplica()
+		assert.NoError(t, err)
+		defer replica.freeAll()
+
+		err = replica.addSegment(defaultSegmentID, defaultPartitionID, defaultCollectionID, "", segmentTypeGrowing)
+		assert.NoError(t, err)
+
+		err = replica.addSegment(defaultSegmentID, defaultPartitionID, defaultCollectionID, "", segmentTypeGrowing)
+		assert.Error(t, err)
+	})
+
 	t.Run("test invalid segment type", func(t *testing.T) {
 		replica, err := genSimpleReplica()
 		assert.NoError(t, err)

--- a/internal/querynode/task_test.go
+++ b/internal/querynode/task_test.go
@@ -396,6 +396,8 @@ func TestTask_loadSegmentsTask(t *testing.T) {
 		node, err := genSimpleQueryNode(ctx)
 		assert.NoError(t, err)
 
+		node.metaReplica.removeSegment(defaultSegmentID, segmentTypeSealed)
+
 		fieldBinlog, statsLog, err := saveBinLog(ctx, defaultCollectionID, defaultPartitionID, defaultSegmentID, defaultMsgLength, schema)
 		assert.NoError(t, err)
 


### PR DESCRIPTION
Signed-off-by: bigsheeper <yihao.dai@zilliz.com>

When add the segment with same segmentID, the newSegment wouldn't be charged by metaReplica, and would never be released.

issues: #18310 