### PR TITLE
Patch flawed segment info without dml channel when querycoord starts

### DIFF
--- a/internal/querycoord/meta_test.go
+++ b/internal/querycoord/meta_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
@@ -35,6 +36,7 @@ import (
 	"github.com/milvus-io/milvus/internal/proto/commonpb"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
 	"github.com/milvus-io/milvus/internal/proto/querypb"
+	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util"
 	"github.com/milvus-io/milvus/internal/util/etcd"
 )
@@ -644,4 +646,185 @@ func MockSaveSegments(segmentNum int) col2SegmentInfos {
 	saves[defaultCollectionID] = segments
 
 	return saves
+}
+
+type mockDataCoord struct {
+	types.DataCoord
+	mock.Mock
+}
+
+func (m *mockDataCoord) GetSegmentInfo(ctx context.Context, req *datapb.GetSegmentInfoRequest) (*datapb.GetSegmentInfoResponse, error) {
+	args := m.Called(ctx, req)
+	return args.Get(0).(*datapb.GetSegmentInfoResponse), args.Error(1)
+}
+
+type mockKV struct {
+	kv.MetaKv
+	mock.Mock
+}
+
+func (m *mockKV) Save(k, v string) error {
+	args := m.Called(k, v)
+	return args.Error(0)
+}
+
+func TestPatchSegmentInfo(t *testing.T) {
+
+	t.Run("No flawed segments", func(t *testing.T) {
+		mkv := &mockKV{}
+		dc := &mockDataCoord{}
+
+		meta := &MetaReplica{
+			collectionInfos: map[UniqueID]*querypb.CollectionInfo{},
+			dmChannelInfos:  map[string]*querypb.DmChannelWatchInfo{},
+			segmentsInfo:    newSegmentsInfo(mkv),
+			replicas:        NewReplicaInfos(),
+			client:          mkv,
+		}
+
+		mkv.Test(t)
+		dc.Test(t)
+		meta.segmentsInfo.segmentIDMap[1] = &querypb.SegmentInfo{SegmentID: 1, DmChannel: "dml_channel_01"}
+
+		err := meta.patchSegmentInfo(context.Background(), dc)
+		assert.NoError(t, err)
+
+		mkv.Mock.AssertNotCalled(t, "Save", mock.AnythingOfType("string"), mock.AnythingOfType("string"))
+		dc.Mock.AssertNotCalled(t, "GetSegmentInfo", mock.Anything, mock.Anything)
+	})
+
+	t.Run("with flawed segments", func(t *testing.T) {
+		mkv := &mockKV{}
+		dc := &mockDataCoord{}
+
+		meta := &MetaReplica{
+			collectionInfos: map[UniqueID]*querypb.CollectionInfo{},
+			dmChannelInfos:  map[string]*querypb.DmChannelWatchInfo{},
+			segmentsInfo:    newSegmentsInfo(mkv),
+			replicas:        NewReplicaInfos(),
+			client:          mkv,
+		}
+
+		mkv.Test(t)
+		dc.Test(t)
+		meta.segmentsInfo.segmentIDMap[1] = &querypb.SegmentInfo{SegmentID: 1, DmChannel: ""}
+
+		mkv.On("Save", mock.Anything, mock.Anything).Return(nil)
+		dc.On("GetSegmentInfo", context.Background(), &datapb.GetSegmentInfoRequest{
+			Base: &commonpb.MsgBase{
+				MsgType: commonpb.MsgType_SegmentInfo,
+			},
+			SegmentIDs:       []UniqueID{1},
+			IncludeUnHealthy: true,
+		}).Return(&datapb.GetSegmentInfoResponse{
+			Status: &commonpb.Status{ErrorCode: commonpb.ErrorCode_Success},
+			Infos: []*datapb.SegmentInfo{
+				{ID: 1, InsertChannel: "dml_channel_01"},
+			},
+		}, nil)
+
+		err := meta.patchSegmentInfo(context.Background(), dc)
+		assert.NoError(t, err)
+
+		info, err := meta.getSegmentInfoByID(1)
+		assert.NoError(t, err)
+		assert.NotEqual(t, "", info.DmChannel)
+	})
+
+	t.Run("GetSegmentInfo_error", func(t *testing.T) {
+		mkv := &mockKV{}
+		dc := &mockDataCoord{}
+
+		meta := &MetaReplica{
+			collectionInfos: map[UniqueID]*querypb.CollectionInfo{},
+			dmChannelInfos:  map[string]*querypb.DmChannelWatchInfo{},
+			segmentsInfo:    newSegmentsInfo(mkv),
+			replicas:        NewReplicaInfos(),
+			client:          mkv,
+			dataCoord:       dc,
+		}
+
+		mkv.Test(t)
+		dc.Test(t)
+		meta.segmentsInfo.segmentIDMap[1] = &querypb.SegmentInfo{SegmentID: 1, DmChannel: ""}
+
+		mkv.On("Save", mock.Anything, mock.Anything).Return(nil)
+		dc.On("GetSegmentInfo", context.Background(), &datapb.GetSegmentInfoRequest{
+			Base: &commonpb.MsgBase{
+				MsgType: commonpb.MsgType_SegmentInfo,
+			},
+			SegmentIDs:       []UniqueID{1},
+			IncludeUnHealthy: true,
+		}).Return((*datapb.GetSegmentInfoResponse)(nil), errors.New("mock"))
+
+		err := meta.patchSegmentInfo(context.Background(), dc)
+		assert.Error(t, err)
+	})
+
+	t.Run("GetSegmentInfo_fail", func(t *testing.T) {
+		mkv := &mockKV{}
+		dc := &mockDataCoord{}
+
+		meta := &MetaReplica{
+			collectionInfos: map[UniqueID]*querypb.CollectionInfo{},
+			dmChannelInfos:  map[string]*querypb.DmChannelWatchInfo{},
+			segmentsInfo:    newSegmentsInfo(mkv),
+			replicas:        NewReplicaInfos(),
+			client:          mkv,
+			dataCoord:       dc,
+		}
+
+		mkv.Test(t)
+		dc.Test(t)
+		meta.segmentsInfo.segmentIDMap[1] = &querypb.SegmentInfo{SegmentID: 1, DmChannel: ""}
+
+		mkv.On("Save", mock.Anything, mock.Anything).Return(nil)
+		dc.On("GetSegmentInfo", context.Background(), &datapb.GetSegmentInfoRequest{
+			Base: &commonpb.MsgBase{
+				MsgType: commonpb.MsgType_SegmentInfo,
+			},
+			SegmentIDs:       []UniqueID{1},
+			IncludeUnHealthy: true,
+		}).Return(&datapb.GetSegmentInfoResponse{
+			Status: &commonpb.Status{ErrorCode: commonpb.ErrorCode_SegmentNotFound},
+		}, nil)
+
+		err := meta.patchSegmentInfo(context.Background(), dc)
+		assert.Error(t, err)
+	})
+
+	t.Run("segments patched not found", func(t *testing.T) {
+		mkv := &mockKV{}
+		dc := &mockDataCoord{}
+
+		meta := &MetaReplica{
+			collectionInfos: map[UniqueID]*querypb.CollectionInfo{},
+			dmChannelInfos:  map[string]*querypb.DmChannelWatchInfo{},
+			segmentsInfo:    newSegmentsInfo(mkv),
+			replicas:        NewReplicaInfos(),
+			client:          mkv,
+		}
+
+		mkv.Test(t)
+		dc.Test(t)
+		meta.segmentsInfo.segmentIDMap[1] = &querypb.SegmentInfo{SegmentID: 1, DmChannel: ""}
+
+		mkv.On("Save", mock.Anything, mock.Anything).Return(nil)
+		dc.On("GetSegmentInfo", context.Background(), &datapb.GetSegmentInfoRequest{
+			Base: &commonpb.MsgBase{
+				MsgType: commonpb.MsgType_SegmentInfo,
+			},
+			SegmentIDs:       []UniqueID{1},
+			IncludeUnHealthy: true,
+		}).Return(&datapb.GetSegmentInfoResponse{
+			Status: &commonpb.Status{ErrorCode: commonpb.ErrorCode_Success},
+			Infos: []*datapb.SegmentInfo{
+				{ID: 2, InsertChannel: "dml_channel_01"},
+			},
+		}, nil)
+
+		err := meta.patchSegmentInfo(context.Background(), dc)
+		assert.Error(t, err)
+	})
+
 }

--- a/internal/querycoord/query_coord.go
+++ b/internal/querycoord/query_coord.go
@@ -166,6 +166,13 @@ func (qc *QueryCoord) Init() error {
 			return
 		}
 
+		// patch SegmentMeta from 2.0.2, with segment dml channel not set
+		initError = qc.meta.patchSegmentInfo(qc.loopCtx, qc.dataCoordClient)
+		if initError != nil {
+			log.Error("query coordinator patch segment meta failed", zap.Error(initError))
+			return
+		}
+
 		// init channelUnsubscribeHandler
 		qc.channelCleaner, initError = NewChannelCleaner(qc.loopCtx, qc.kvClient, qc.factory)
 		if initError != nil {


### PR DESCRIPTION
Related to #18370 

/kind bug

Signed-off-by: Congqi Xia <congqi.xia@zilliz.com>