### PR TITLE
Fix parse segment id logic cannot handle rootPath with slash

### DIFF
--- a/internal/datacoord/garbage_collector.go
+++ b/internal/datacoord/garbage_collector.go
@@ -138,7 +138,7 @@ func (gc *garbageCollector) scan() {
 				continue
 			}
 
-			segmentID, err := storage.ParseSegmentIDByBinlog(infoKey)
+			segmentID, err := storage.ParseSegmentIDByBinlog(infoKey, gc.option.rootPath)
 			if err != nil {
 				log.Error("parse segment id error", zap.String("infoKey", infoKey), zap.Error(err))
 				continue

--- a/internal/storage/binlog_util.go
+++ b/internal/storage/binlog_util.go
@@ -8,10 +8,21 @@ import (
 
 // ParseSegmentIDByBinlog parse segment id from binlog paths
 // if path format is not expected, returns error
-func ParseSegmentIDByBinlog(path string) (UniqueID, error) {
-	// binlog path should consist of "[prefix]/insertLog/collID/partID/segID/fieldID/fileName"
-	keyStr := strings.Split(path, "/")
-	if len(keyStr) != 7 {
+func ParseSegmentIDByBinlog(path, rootPath string) (UniqueID, error) {
+	// check path contains rootPath as prefix
+	if !strings.HasPrefix(path, rootPath) {
+		return 0, fmt.Errorf("path \"%s\" does not contains rootPath \"%s\"", path, rootPath)
+	}
+	p := path[len(rootPath):]
+
+	// remove leading "/"
+	for strings.HasPrefix(p, "/") {
+		p = p[1:]
+	}
+
+	// binlog path should consist of "[log_type]/collID/partID/segID/fieldID/fileName"
+	keyStr := strings.Split(p, "/")
+	if len(keyStr) != 6 {
 		return 0, fmt.Errorf("%s is not a valid binlog path", path)
 	}
 	return strconv.ParseInt(keyStr[len(keyStr)-3], 10, 64)

--- a/internal/storage/binlog_util_test.go
+++ b/internal/storage/binlog_util_test.go
@@ -11,6 +11,7 @@ func TestParseSegmentIDByBinlog(t *testing.T) {
 	type testCase struct {
 		name        string
 		input       string
+		rootPath    string
 		expectError bool
 		expectID    UniqueID
 	}
@@ -19,35 +20,40 @@ func TestParseSegmentIDByBinlog(t *testing.T) {
 		{
 			name:        "normal case",
 			input:       "files/insertLog/123/456/1/101/10000001",
+			rootPath:    "files",
 			expectError: false,
 			expectID:    1,
 		},
 		{
 			name:        "normal case long id",
 			input:       "files/insertLog/123/456/434828745294479362/101/10000001",
+			rootPath:    "files",
 			expectError: false,
 			expectID:    434828745294479362,
 		},
 		{
 			name:        "bad format",
 			input:       "files/123",
+			rootPath:    "files",
 			expectError: true,
 		},
 		{
 			name:        "empty input",
 			input:       "",
+			rootPath:    "files",
 			expectError: true,
 		},
 		{
 			name:        "non-number segmentid",
 			input:       "files/insertLog/123/456/segment_id/101/10000001",
+			rootPath:    "files",
 			expectError: true,
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			id, err := ParseSegmentIDByBinlog(tc.input)
+			id, err := ParseSegmentIDByBinlog(tc.input, tc.rootPath)
 			if tc.expectError {
 				assert.Error(t, err)
 			} else {


### PR DESCRIPTION
Related to #18431

/kind bug

Signed-off-by: Congqi Xia <congqi.xia@zilliz.com>