### PR TITLE
Exposes the REST-API port on the standalone docker-compose file

### DIFF
--- a/deployments/docker/standalone/docker-compose.yml
+++ b/deployments/docker/standalone/docker-compose.yml
@@ -38,6 +38,7 @@ services:
       - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/milvus:/var/lib/milvus
     ports:
       - "19530:19530"
+      - "9091:9091"
     depends_on:
       - "etcd"
       - "minio"


### PR DESCRIPTION
Exposes the REST-API port on the standalone docker-compose file

Signed-off-by: Jonas Hahn <jonas.hahn@ecodia.de>
Fix https://github.com/milvus-io/milvus/issues/18604