### PR TITLE
Expose REST-API port in docker-compose for cluster setup

### DIFF
--- a/deployments/docker/cluster/docker-compose-apple-silicon.yml
+++ b/deployments/docker/cluster/docker-compose-apple-silicon.yml
@@ -69,6 +69,7 @@ services:
       PULSAR_ADDRESS: pulsar://pulsar:6650
     ports:
       - "19530:19530"
+      - "9091:9091"
 
   querycoord:
     container_name: milvus-querycoord

--- a/deployments/docker/cluster/docker-compose.yml
+++ b/deployments/docker/cluster/docker-compose.yml
@@ -73,6 +73,7 @@ services:
       PULSAR_ADDRESS: pulsar://pulsar:6650
     ports:
       - "19530:19530"
+      - "9091:9091"
 
   querycoord:
     container_name: milvus-querycoord


### PR DESCRIPTION
Fixes #18613

- add the restapi port 9091 to the list of exposed ports in the docker-compose file

Signed-off-by: Jonas Hahn <jonas.hahn@ecodia.de>