### PR TITLE
Simplify Dml-DeltaChannel mapping logic

### DIFF
--- a/internal/rootcoord/dml_channels_test.go
+++ b/internal/rootcoord/dml_channels_test.go
@@ -141,27 +141,18 @@ func TestDmlChannels(t *testing.T) {
 	assert.Panics(t, func() { dml.broadcastMark([]string{randStr}, nil) })
 	assert.Panics(t, func() { dml.removeChannels(randStr) })
 
-	// dml_xxx_0 => {chanName0, chanName2}
-	// dml_xxx_1 => {chanName1}
-	chanName0 := dml.getChannelName()
-	dml.addChannels(chanName0)
-	assert.Equal(t, 1, dml.getChannelNum())
-
-	chanName1 := dml.getChannelName()
-	dml.addChannels(chanName1)
+	chans0 := dml.getChannelNames(2)
+	dml.addChannels(chans0...)
 	assert.Equal(t, 2, dml.getChannelNum())
 
-	chanName2 := dml.getChannelName()
-	dml.addChannels(chanName2)
+	chans1 := dml.getChannelNames(1)
+	dml.addChannels(chans1...)
 	assert.Equal(t, 2, dml.getChannelNum())
 
-	dml.removeChannels(chanName0)
+	dml.removeChannels(chans1...)
 	assert.Equal(t, 2, dml.getChannelNum())
 
-	dml.removeChannels(chanName1)
-	assert.Equal(t, 1, dml.getChannelNum())
-
-	dml.removeChannels(chanName0)
+	dml.removeChannels(chans0...)
 	assert.Equal(t, 0, dml.getChannelNum())
 }
 
@@ -179,7 +170,7 @@ func TestDmChannelsFailure(t *testing.T) {
 		defer wg.Done()
 		mockFactory := &FailMessageStreamFactory{errBroadcast: true}
 		dml := newDmlChannels(context.TODO(), mockFactory, "test-newdmlchannel-root", 1)
-		chanName0 := dml.getChannelName()
+		chanName0 := dml.getChannelNames(1)[0]
 		dml.addChannels(chanName0)
 		require.Equal(t, 1, dml.getChannelNum())
 

--- a/internal/rootcoord/root_coord_test.go
+++ b/internal/rootcoord/root_coord_test.go
@@ -534,10 +534,9 @@ func createCollectionInMeta(dbName, collName string, core *Core, shardsNum int32
 	}
 
 	vchanNames := make([]string, t.ShardsNum)
-	chanNames := make([]string, t.ShardsNum)
+	chanNames := core.chanTimeTick.getDmlChannelNames(int(t.ShardsNum))
 	for i := int32(0); i < t.ShardsNum; i++ {
-		vchanNames[i] = fmt.Sprintf("%s_%dv%d", core.chanTimeTick.getDmlChannelName(), collID, i)
-		chanNames[i] = funcutil.ToPhysicalChannel(vchanNames[i])
+		vchanNames[i] = fmt.Sprintf("%s_%dv%d", chanNames[i], collID, i)
 	}
 
 	collInfo := model.Collection{
@@ -2271,15 +2270,11 @@ func TestRootCoord_Base(t *testing.T) {
 		assert.NoError(t, err)
 		time.Sleep(100 * time.Millisecond)
 
-		cn0 := core.chanTimeTick.getDmlChannelName()
-		cn1 := core.chanTimeTick.getDmlChannelName()
-		cn2 := core.chanTimeTick.getDmlChannelName()
-		core.chanTimeTick.addDmlChannels(cn0, cn1, cn2)
-
-		dn0 := core.chanTimeTick.getDeltaChannelName()
-		dn1 := core.chanTimeTick.getDeltaChannelName()
-		dn2 := core.chanTimeTick.getDeltaChannelName()
-		core.chanTimeTick.addDeltaChannels(dn0, dn1, dn2)
+		cns := core.chanTimeTick.getDmlChannelNames(3)
+		cn0 := cns[0]
+		cn1 := cns[1]
+		cn2 := cns[2]
+		core.chanTimeTick.addDmlChannels(cns...)
 
 		// wait for local channel reported
 		for {


### PR DESCRIPTION
- Remove redundant `dmlChannels` instance for delta channels
- Get dmlChannel names in batch

/kind improvement

Related to #15785 #18621

Signed-off-by: Congqi Xia <congqi.xia@zilliz.com>