### PR TITLE
add user special kafka client config

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -96,7 +96,11 @@ pulsar:
   maxMessageSize: 5242880 # 5 * 1024 * 1024 Bytes, Maximum size of each message in pulsar.
 
 # If you want to enable kafka, needs to comment the pulsar configs
-#kafka:
+kafka:
+  producer:
+    client.id: dc
+  consumer:
+    client.id: dc1
 #  brokerList: localhost1:9092,localhost2:9092,localhost3:9092
 #  saslUsername: username
 #  saslPassword: password

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -64,7 +64,9 @@ func (m *Manager) GetConfig(key string) (string, error) {
 }
 
 //GetConfigsByPattern returns key values that matched pattern
-func (m *Manager) GetConfigsByPattern(pattern string) map[string]string {
+// withPrefix : whether key include the prefix of pattern
+func (m *Manager) GetConfigsByPattern(pattern string, withPrefix bool) map[string]string {
+
 	m.RLock()
 	defer m.RUnlock()
 	matchedConfig := make(map[string]string)
@@ -77,7 +79,16 @@ func (m *Manager) GetConfigsByPattern(pattern string) map[string]string {
 			if err != nil {
 				continue
 			}
-			matchedConfig[key] = sValue
+
+			checkAndCutOffKey := func() string {
+				if withPrefix {
+					return key
+				}
+				return strings.Replace(key, pattern, "", 1)
+			}
+
+			finalKey := checkAndCutOffKey()
+			matchedConfig[finalKey] = sValue
 		}
 	}
 	return matchedConfig

--- a/internal/mq/msgstream/mq_kafka_msgstream_test.go
+++ b/internal/mq/msgstream/mq_kafka_msgstream_test.go
@@ -445,7 +445,7 @@ func getKafkaInputStream(ctx context.Context, kafkaAddress string, producerChann
 		"api.version.request": true,
 		"linger.ms":           10,
 	}
-	kafkaClient := kafkawrapper.NewKafkaClientInstanceWithConfigMap(config)
+	kafkaClient := kafkawrapper.NewKafkaClientInstanceWithConfigMap(config, nil, nil)
 	inputStream, _ := NewMqMsgStream(ctx, 100, 100, kafkaClient, factory.NewUnmarshalDispatcher())
 	inputStream.AsProducer(producerChannels)
 	for _, opt := range opts {

--- a/internal/mq/msgstream/mqwrapper/kafka/kafka_client_test.go
+++ b/internal/mq/msgstream/mqwrapper/kafka/kafka_client_test.go
@@ -308,6 +308,29 @@ func TestKafkaClient_NewKafkaClientInstanceWithConfig(t *testing.T) {
 	client := NewKafkaClientInstanceWithConfig(config3)
 	assert.NotNil(t, client)
 	assert.NotNil(t, client.basicConfig)
+
+	consumerConfig := make(map[string]string)
+	consumerConfig["client.id"] = "dc"
+	config4 := &paramtable.KafkaConfig{Address: "addr", SaslUsername: "username", SaslPassword: "password", ConsumerExtraConfig: consumerConfig}
+	client4 := NewKafkaClientInstanceWithConfig(config4)
+	assert.Equal(t, "dc", client4.consumerConfig["client.id"])
+
+	newConsumerConfig := client4.newConsumerConfig("test", 0)
+	clientID, err := newConsumerConfig.Get("client.id", "")
+	assert.Nil(t, err)
+	assert.Equal(t, "dc", clientID)
+
+	producerConfig := make(map[string]string)
+	producerConfig["client.id"] = "dc1"
+	config5 := &paramtable.KafkaConfig{Address: "addr", SaslUsername: "username", SaslPassword: "password", ProducerExtraConfig: producerConfig}
+	client5 := NewKafkaClientInstanceWithConfig(config5)
+	assert.Equal(t, "dc1", client5.producerConfig["client.id"])
+
+	newProducerConfig := client5.newProducerConfig()
+	pClientID, err := newProducerConfig.Get("client.id", "")
+	assert.Nil(t, err)
+	assert.Equal(t, pClientID, "dc1")
+
 }
 
 func createKafkaClient(t *testing.T) *kafkaClient {

--- a/internal/util/paramtable/base_table.go
+++ b/internal/util/paramtable/base_table.go
@@ -212,7 +212,11 @@ func (gp *BaseTable) Get(key string) string {
 }
 
 func (gp *BaseTable) GetByPattern(pattern string) map[string]string {
-	return gp.mgr.GetConfigsByPattern(pattern)
+	return gp.mgr.GetConfigsByPattern(pattern, true)
+}
+
+func (gp *BaseTable) GetConfigSubSet(pattern string) map[string]string {
+	return gp.mgr.GetConfigsByPattern(pattern, false)
 }
 
 // For compatible reason, only visiable for Test

--- a/internal/util/paramtable/base_table_test.go
+++ b/internal/util/paramtable/base_table_test.go
@@ -13,6 +13,7 @@ package paramtable
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -25,6 +26,25 @@ func TestMain(m *testing.M) {
 	baseParams.Init()
 	code := m.Run()
 	os.Exit(code)
+}
+
+func TestBaseTable_GetConfigSubSet(t *testing.T) {
+	prefix := "rootcoord."
+	configs := baseParams.mgr.Configs()
+
+	configsWithPrefix := make(map[string]string)
+	for k, v := range configs {
+		if strings.HasPrefix(k, prefix) {
+			configsWithPrefix[k] = v
+		}
+	}
+
+	subSet := baseParams.GetConfigSubSet(prefix)
+
+	for k := range configs {
+		assert.Equal(t, subSet[k], configs[prefix+k])
+	}
+	assert.Equal(t, len(subSet), len(configsWithPrefix))
 }
 
 func TestBaseTable_SaveAndLoad(t *testing.T) {

--- a/internal/util/paramtable/component_param_test.go
+++ b/internal/util/paramtable/component_param_test.go
@@ -30,6 +30,16 @@ func TestComponentParam(t *testing.T) {
 	var CParams ComponentParam
 	CParams.Init()
 
+	t.Run("test kafkaConfig", func(t *testing.T) {
+
+		params := CParams.ServiceParam.KafkaCfg
+		producerConfig := params.ProducerExtraConfig
+		assert.Equal(t, "dc", producerConfig["client.id"])
+
+		consumerConfig := params.ConsumerExtraConfig
+		assert.Equal(t, "dc1", consumerConfig["client.id"])
+	})
+
 	t.Run("test commonConfig", func(t *testing.T) {
 		Params := CParams.CommonCfg
 

--- a/internal/util/paramtable/service_param.go
+++ b/internal/util/paramtable/service_param.go
@@ -38,6 +38,8 @@ const (
 	SuggestPulsarMaxMessageSize = 5 * 1024 * 1024
 	defaultEtcdLogLevel         = "info"
 	defaultEtcdLogPath          = "stdout"
+	KafkaProducerConfigPrefix   = "kafka.producer."
+	KafkaConsumerConfigPrefix   = "kafka.consumer."
 )
 
 // ServiceParam is used to quickly and easily access all basic service configurations.
@@ -365,12 +367,14 @@ func (p *PulsarConfig) initMaxMessageSize() {
 
 // --- kafka ---
 type KafkaConfig struct {
-	Base             *BaseTable
-	Address          string
-	SaslUsername     string
-	SaslPassword     string
-	SaslMechanisms   string
-	SecurityProtocol string
+	Base                *BaseTable
+	Address             string
+	SaslUsername        string
+	SaslPassword        string
+	SaslMechanisms      string
+	SecurityProtocol    string
+	ConsumerExtraConfig map[string]string
+	ProducerExtraConfig map[string]string
 }
 
 func (k *KafkaConfig) init(base *BaseTable) {
@@ -380,6 +384,7 @@ func (k *KafkaConfig) init(base *BaseTable) {
 	k.initSaslPassword()
 	k.initSaslMechanisms()
 	k.initSecurityProtocol()
+	k.initExtraKafkaConfig()
 }
 
 func (k *KafkaConfig) initAddress() {
@@ -400,6 +405,11 @@ func (k *KafkaConfig) initSaslMechanisms() {
 
 func (k *KafkaConfig) initSecurityProtocol() {
 	k.SecurityProtocol = k.Base.LoadWithDefault("kafka.securityProtocol", "SASL_SSL")
+}
+
+func (k *KafkaConfig) initExtraKafkaConfig() {
+	k.ConsumerExtraConfig = k.Base.GetConfigSubSet(KafkaConsumerConfigPrefix)
+	k.ProducerExtraConfig = k.Base.GetConfigSubSet(KafkaProducerConfigPrefix)
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Signed-off-by: wanggang11335 <wanggang11335@autohome.com.cn>

fix #18760
Users can specify the configuration of the kafka client through `kafka.consumer.xxx=yyy`, `kafka.producer.aaa=bbb`, `kafka.producer.ccc=ddd`.

In our usage scenario, we use client.id to authorize the kafka client. With this configuration, we can easily combine milvus with our kafka authorization system，and we can also set some throughput-related and session timeout parameters according to the amount of data.