### PR TITLE
remove redundant slashes

### DIFF
--- a/internal/util/paramtable/base_table.go
+++ b/internal/util/paramtable/base_table.go
@@ -158,7 +158,7 @@ func (gp *BaseTable) initConfPath() string {
 		configDir = runPath + "/configs/"
 		if _, err := os.Stat(configDir); err != nil {
 			_, fpath, _, _ := runtime.Caller(0)
-			configDir = path.Dir(fpath) + "/../../../configs/"
+			configDir = path.Dir(fpath) + "/../../../configs"
 		}
 	}
 	return configDir


### PR DESCRIPTION




Found an extra slash at [this](https://github.com/milvus-io/milvus/blob/9589bd38137a84e480ce0a26941c2c1220f264ad/internal/util/paramtable/base_table.go#L110)
Signed-off-by: wanggang11335 <wanggang11335@autohome.com.cn>