### PR TITLE
[skip e2e]Add python for 20.04 to fix code check

### DIFF
--- a/.github/workflows/code-checker.yaml
+++ b/.github/workflows/code-checker.yaml
@@ -19,6 +19,7 @@ on:
       - Makefile
       - '!**.md'
       - '!build/ci/jenkins/**'
+      - '!build/docker/**'
       # FIXME(wxyu): not need to run code check, update the ci-passed rules and remove these two lines
       - go.mod
       - go.sum

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -31,6 +31,7 @@ on:
       - go.mod
       - '!**.md'
       - '!build/ci/jenkins/**'
+      - '!build/docker/**'
 
 jobs:
   ubuntu:

--- a/build/docker/builder/cpu/ubuntu20.04/Dockerfile
+++ b/build/docker/builder/cpu/ubuntu20.04/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends wget curl ca-ce
     wget -qO- "https://cmake.org/files/v3.18/cmake-3.18.6-Linux-x86_64.tar.gz" | tar --strip-components=1 -xz -C /usr/local && \
     apt-get update && apt-get install -y --no-install-recommends \
     g++ gcc gfortran git make ccache libssl-dev zlib1g-dev libboost-regex-dev libboost-program-options-dev libboost-system-dev \
-    libboost-filesystem-dev libboost-serialization-dev python3-dev libboost-python-dev libcurl4-openssl-dev libtbb-dev clang-format-10 clang-tidy-10 lcov libtool m4 autoconf automake  && \
+    libboost-filesystem-dev libboost-serialization-dev python3-dev libboost-python-dev libcurl4-openssl-dev libtbb-dev clang-format-10 clang-tidy-10 lcov libtool m4 autoconf automake python && \
     apt-get remove --purge -y && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Signed-off-by: Jenny Li <jing.li@zilliz.com>
/kind improvement

Need python for cpp check, 20.04 removed default python2.x, so add it back for code check
related code https://github.com/milvus-io/milvus/blob/master/internal/core/CMakeLists.txt#L166