### PR TITLE
Add libaio as a necessary dependency

### DIFF
--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -21,7 +21,7 @@ function install_linux_deps() {
       # for Ubuntu 18.04
       sudo apt install -y g++ gcc make lcov libtool m4 autoconf automake ccache libssl-dev zlib1g-dev libboost-regex-dev \
           libboost-program-options-dev libboost-system-dev libboost-filesystem-dev \
-          libboost-serialization-dev python3-dev libboost-python-dev libcurl4-openssl-dev gfortran libtbb-dev libzstd-dev
+          libboost-serialization-dev python3-dev libboost-python-dev libcurl4-openssl-dev gfortran libtbb-dev libzstd-dev libaio-dev
   elif [[ -x "$(command -v yum)" ]]; then
       # for CentOS 7
       sudo yum install -y epel-release centos-release-scl-rh && \


### PR DESCRIPTION
Signed-off-by: matchyc <meng_chen99@163.com>
issue: #18924
Why we need this:
Community users are unable to build milvus after we supported DiskANN without libaio by using instructions written in `README.md`. So we need to add it to this script, then allow community users to build milvus in a naive way.
And DiskANN is only available on Ubuntu.