### PR TITLE
Upgrade to knowhere-v1.3.0, remove seldom used index types

### DIFF
--- a/internal/core/src/indexbuilder/VecIndexCreator.cpp
+++ b/internal/core/src/indexbuilder/VecIndexCreator.cpp
@@ -75,14 +75,6 @@ VecIndexCreator::parse_impl(const std::string& serialized_params_str, knowhere::
     /************************** PQ Params *****************************/
     check_parameter<int>(conf, knowhere::indexparam::PQ_M, stoi_closure, std::nullopt);
 
-#ifdef MILVUS_SUPPORT_NSG
-    /************************** NSG Parameter **************************/
-    check_parameter<int>(conf, knowhere::indexparam::KNNG, stoi_closure, std::nullopt);
-    check_parameter<int>(conf, knowhere::indexparam::SEARCH_LENGTH, stoi_closure, std::nullopt);
-    check_parameter<int>(conf, knowhere::indexparam::OUT_DEGREE, stoi_closure, std::nullopt);
-    check_parameter<int>(conf, knowhere::indexparam::CANDIDATE, stoi_closure, std::nullopt);
-#endif
-
     /************************** HNSW Params *****************************/
     check_parameter<int>(conf, knowhere::indexparam::EFCONSTRUCTION, stoi_closure, std::nullopt);
     check_parameter<int>(conf, knowhere::indexparam::HNSW_M, stoi_closure, std::nullopt);
@@ -91,23 +83,6 @@ VecIndexCreator::parse_impl(const std::string& serialized_params_str, knowhere::
     /************************** Annoy Params *****************************/
     check_parameter<int>(conf, knowhere::indexparam::N_TREES, stoi_closure, std::nullopt);
     check_parameter<int>(conf, knowhere::indexparam::SEARCH_K, stoi_closure, std::nullopt);
-
-#ifdef MILVUS_SUPPORT_NGT
-    /************************** NGT Params *****************************/
-    check_parameter<int>(conf, knowhere::indexparam::EDGE_SIZE, stoi_closure, std::nullopt);
-
-    /************************** NGT Search Params *****************************/
-    check_parameter<float>(conf, knowhere::indexparam::EPSILON, stof_closure, std::nullopt);
-    check_parameter<int>(conf, knowhere::indexparam::MAX_SEARCH_EDGES, stoi_closure, std::nullopt);
-
-    /************************** NGT_PANNG Params *****************************/
-    check_parameter<int>(conf, knowhere::indexparam::FORCEDLY_PRUNED_EDGE_SIZE, stoi_closure, std::nullopt);
-    check_parameter<int>(conf, knowhere::indexparam::SELECTIVELY_PRUNED_EDGE_SIZE, stoi_closure, std::nullopt);
-
-    /************************** NGT_ONNG Params *****************************/
-    check_parameter<int>(conf, knowhere::indexparam::OUTGOING_EDGE_SIZE, stoi_closure, std::nullopt);
-    check_parameter<int>(conf, knowhere::indexparam::INCOMING_EDGE_SIZE, stoi_closure, std::nullopt);
-#endif
 }
 
 void

--- a/internal/core/src/indexbuilder/utils.cpp
+++ b/internal/core/src/indexbuilder/utils.cpp
@@ -22,10 +22,6 @@ std::vector<knowhere::IndexType>
 NM_List() {
     static std::vector<knowhere::IndexType> ret{
         knowhere::IndexEnum::INDEX_FAISS_IVFFLAT,
-#ifdef MILVUS_SUPPORT_NSG
-        knowhere::IndexEnum::INDEX_NSG,
-#endif
-        knowhere::IndexEnum::INDEX_RHNSWFlat,
     };
     return ret;
 }
@@ -43,19 +39,8 @@ std::vector<knowhere::IndexType>
 Need_ID_List() {
     static std::vector<knowhere::IndexType> ret{
         // knowhere::IndexEnum::INDEX_FAISS_BIN_IVFFLAT,
-        // knowhere::IndexEnum::INDEX_NSG,
     };
 
-    return ret;
-}
-
-std::vector<knowhere::IndexType>
-Need_BuildAll_list() {
-    static std::vector<knowhere::IndexType> ret{
-#ifdef MILVUS_SUPPORT_NSG
-        knowhere::IndexEnum::INDEX_NSG,
-#endif
-    };
     return ret;
 }
 
@@ -82,11 +67,6 @@ is_in_bin_list(const knowhere::IndexType& index_type) {
 bool
 is_in_nm_list(const knowhere::IndexType& index_type) {
     return is_in_list<knowhere::IndexType>(index_type, NM_List);
-}
-
-bool
-is_in_need_build_all_list(const knowhere::IndexType& index_type) {
-    return is_in_list<knowhere::IndexType>(index_type, Need_BuildAll_list);
 }
 
 bool

--- a/internal/core/src/indexbuilder/utils.h
+++ b/internal/core/src/indexbuilder/utils.h
@@ -32,9 +32,6 @@ BIN_List();
 std::vector<knowhere::IndexType>
 Need_ID_List();
 
-std::vector<knowhere::IndexType>
-Need_BuildAll_list();
-
 std::vector<std::tuple<knowhere::IndexType, knowhere::MetricType>>
 unsupported_index_combinations();
 
@@ -47,9 +44,6 @@ is_in_bin_list(const knowhere::IndexType& index_type);
 
 bool
 is_in_nm_list(const knowhere::IndexType& index_type);
-
-bool
-is_in_need_build_all_list(const knowhere::IndexType& index_type);
 
 bool
 is_in_need_id_list(const knowhere::IndexType& index_type);

--- a/internal/core/src/query/deprecated/ValidationUtil.cpp
+++ b/internal/core/src/query/deprecated/ValidationUtil.cpp
@@ -187,17 +187,8 @@ ValidateVectorIndexType(std::string& index_type, bool is_binary) {
         knowhere::IndexEnum::INDEX_FAISS_IVFFLAT,
         knowhere::IndexEnum::INDEX_FAISS_IVFPQ,
         knowhere::IndexEnum::INDEX_FAISS_IVFSQ8,
-#ifdef MILVUS_GPU_VERSION
-        knowhere::IndexEnum::INDEX_FAISS_IVFSQ8H,
-#endif
-        knowhere::IndexEnum::INDEX_NSG,
         knowhere::IndexEnum::INDEX_HNSW,
         knowhere::IndexEnum::INDEX_ANNOY,
-        knowhere::IndexEnum::INDEX_RHNSWFlat,
-        knowhere::IndexEnum::INDEX_RHNSWPQ,
-        knowhere::IndexEnum::INDEX_RHNSWSQ,
-        knowhere::IndexEnum::INDEX_NGTPANNG,
-        knowhere::IndexEnum::INDEX_NGTONNG,
     };
 
     static std::set<std::string> s_binary_index_types = {
@@ -264,7 +255,6 @@ ValidateIndexParams(const milvus::json& index_params, int64_t dimension, const s
         return Status::OK();
     } else if (index_type == knowhere::IndexEnum::INDEX_FAISS_IVFFLAT ||
                index_type == knowhere::IndexEnum::INDEX_FAISS_IVFSQ8 ||
-               index_type == knowhere::IndexEnum::INDEX_FAISS_IVFSQ8H ||
                index_type == knowhere::IndexEnum::INDEX_FAISS_BIN_IVFFLAT) {
         auto status = CheckParameterRange(index_params, knowhere::IndexParams::nlist, 1, 65536);
         if (!status.ok()) {
@@ -311,26 +301,7 @@ ValidateIndexParams(const milvus::json& index_params, int64_t dimension, const s
             LOG_SERVER_ERROR_ << msg;
             return Status(SERVER_INVALID_ARGUMENT, msg);
         }*/
-    } else if (index_type == knowhere::IndexEnum::INDEX_NSG) {
-        auto status = CheckParameterRange(index_params, knowhere::IndexParams::search_length, 10, 300);
-        if (!status.ok()) {
-            return status;
-        }
-        status = CheckParameterRange(index_params, knowhere::IndexParams::out_degree, 5, 300);
-        if (!status.ok()) {
-            return status;
-        }
-        status = CheckParameterRange(index_params, knowhere::IndexParams::candidate, 50, 1000);
-        if (!status.ok()) {
-            return status;
-        }
-        status = CheckParameterRange(index_params, knowhere::IndexParams::knng, 5, 300);
-        if (!status.ok()) {
-            return status;
-        }
-    } else if (index_type == knowhere::IndexEnum::INDEX_HNSW || index_type == knowhere::IndexEnum::INDEX_RHNSWFlat ||
-               index_type == knowhere::IndexEnum::INDEX_RHNSWPQ || index_type == knowhere::IndexEnum::INDEX_RHNSWSQ ||
-               index_type == knowhere::IndexEnum::INDEX_RHNSWFlat) {
+    } else if (index_type == knowhere::IndexEnum::INDEX_HNSW) {
         auto status = CheckParameterRange(index_params, knowhere::IndexParams::M, 4, 64);
         if (!status.ok()) {
             return status;
@@ -338,42 +309,6 @@ ValidateIndexParams(const milvus::json& index_params, int64_t dimension, const s
         status = CheckParameterRange(index_params, knowhere::IndexParams::efConstruction, 8, 512);
         if (!status.ok()) {
             return status;
-        }
-
-        if (index_type == knowhere::IndexEnum::INDEX_RHNSWPQ) {
-            status = CheckParameterExistence(index_params, knowhere::IndexParams::PQM);
-            if (!status.ok()) {
-                return status;
-            }
-
-            // special check for 'PQM' parameter
-            int64_t pqm_value = index_params[knowhere::IndexParams::PQM];
-            if (!milvus::knowhere::IVFPQConfAdapter::GetValidCPUM(dimension, pqm_value)) {
-                std::string msg = "Invalid m, dimension can't not be divided by m ";
-                LOG_SERVER_ERROR_ << msg;
-                return Status(SERVER_INVALID_ARGUMENT, msg);
-            }
-            /*int64_t pqm_value = index_params[knowhere::IndexParams::PQM];
-            if (resset.empty()) {
-                std::string msg = "Invalid collection dimension, unable to get reasonable values for 'PQM'";
-                LOG_SERVER_ERROR_ << msg;
-                return Status(SERVER_INVALID_COLLECTION_DIMENSION, msg);
-            }
-
-            auto iter = std::find(std::begin(resset), std::end(resset), pqm_value);
-            if (iter == std::end(resset)) {
-                std::string msg =
-                    "Invalid " + std::string(knowhere::IndexParams::PQM) + ", must be one of the following values: ";
-                for (size_t i = 0; i < resset.size(); i++) {
-                    if (i != 0) {
-                        msg += ",";
-                    }
-                    msg += std::to_string(resset[i]);
-                }
-
-                LOG_SERVER_ERROR_ << msg;
-                return Status(SERVER_INVALID_ARGUMENT, msg);
-            }*/
         }
     } else if (index_type == knowhere::IndexEnum::INDEX_ANNOY) {
         auto status = CheckParameterRange(index_params, knowhere::IndexParams::n_trees, 1, 1024);

--- a/internal/core/src/query/visitors/VerifyPlanNodeVisitor.cpp
+++ b/internal/core/src/query/visitors/VerifyPlanNodeVisitor.cpp
@@ -32,24 +32,15 @@ class VerifyPlanNodeVisitor : PlanNodeVisitor {
 static knowhere::IndexType
 InferIndexType(const Json& search_params) {
     // ivf -> nprobe
-    // nsg -> search_length
-    // hnsw/rhnsw/*pq/*sq -> ef
+    // hnsw -> ef
     // annoy -> search_k
-    // ngtpanng / ngtonng -> max_search_edges / epsilon
     static const std::map<std::string, knowhere::IndexType> key_list = [] {
         std::map<std::string, knowhere::IndexType> list;
         namespace ip = knowhere::indexparam;
         namespace ie = knowhere::IndexEnum;
         list.emplace(ip::NPROBE, ie::INDEX_FAISS_IVFFLAT);
-#ifdef MILVUS_SUPPORT_NSG
-        list.emplace(ip::search_length, ie::INDEX_NSG);
-#endif
         list.emplace(ip::EF, ie::INDEX_HNSW);
         list.emplace(ip::SEARCH_K, ie::INDEX_ANNOY);
-#ifdef MILVUS_SUPPORT_NGT
-        list.emplace(ip::max_search_edges, ie::INDEX_NGTONNG);
-        list.emplace(ip::epsilon, ie::INDEX_NGTONNG);
-#endif
         return list;
     }();
     auto dbg_str = search_params.dump();

--- a/internal/core/thirdparty/knowhere/CMakeLists.txt
+++ b/internal/core/thirdparty/knowhere/CMakeLists.txt
@@ -11,8 +11,8 @@
 # or implied. See the License for the specific language governing permissions and limitations under the License.
 #-------------------------------------------------------------------------------
 
-set( KNOWHERE_VERSION v1.2.0 )
-set( KNOWHERE_SOURCE_MD5 "acc955a3b90c03f0afd0ff855e594777")
+set( KNOWHERE_VERSION v1.3.0 )
+set( KNOWHERE_SOURCE_MD5 "e43de07b5a5603bda1e340cc7309c115")
 
 if ( DEFINED ENV{MILVUS_KNOWHERE_URL} )
     set( KNOWHERE_SOURCE_URL "$ENV{MILVUS_KNOWHERE_URL}" )
@@ -29,6 +29,7 @@ macro(build_knowhere)
             ${EP_COMMON_CMAKE_ARGS}
             -DCMAKE_BUILD_TYPE=Release
             -DCMAKE_INSTALL_PREFIX=${KNOWHERE_INSTALL_PREFIX}
+            -DKNOWHERE_WITH_DISKANN=false
             )
 
     externalproject_add(knowhere_ep

--- a/internal/core/unittest/test_index_wrapper.cpp
+++ b/internal/core/unittest/test_index_wrapper.cpp
@@ -48,22 +48,8 @@ class IndexWrapperTest : public ::testing::TestWithParam<Param> {
             {knowhere::IndexEnum::INDEX_FAISS_IVFSQ8, false},
             {knowhere::IndexEnum::INDEX_FAISS_BIN_IVFFLAT, true},
             {knowhere::IndexEnum::INDEX_FAISS_BIN_IDMAP, true},
-#ifdef MILVUS_SUPPORT_SPTAG
-            {knowhere::IndexEnum::INDEX_SPTAG_KDT_RNT, false},
-            {knowhere::IndexEnum::INDEX_SPTAG_BKT_RNT, false},
-#endif
             {knowhere::IndexEnum::INDEX_HNSW, false},
             {knowhere::IndexEnum::INDEX_ANNOY, false},
-            {knowhere::IndexEnum::INDEX_RHNSWFlat, false},
-            {knowhere::IndexEnum::INDEX_RHNSWPQ, false},
-            {knowhere::IndexEnum::INDEX_RHNSWSQ, false},
-#ifdef MILVUS_SUPPORT_NGT
-            {knowhere::IndexEnum::INDEX_NGTPANNG, false},
-            {knowhere::IndexEnum::INDEX_NGTONNG, false},
-#endif
-#ifdef MILVUS_SUPPORT_NSG
-            {knowhere::IndexEnum::INDEX_NSG, false},
-#endif
         };
 
         is_binary = is_binary_map[index_type];
@@ -159,28 +145,6 @@ TEST(IVFFLATNM, Query) {
     ASSERT_TRUE(stats != nullptr);
     index->ClearStatistics();
 }
-
-#ifdef MILVUS_SUPPORT_NSG
-TEST(NSG, Query) {
-    auto index_type = knowhere::IndexEnum::INDEX_NSG;
-    auto metric_type = knowhere::metric::L2;
-    auto conf = generate_conf(index_type, metric_type);
-    auto index = knowhere::VecIndexFactory::GetInstance().CreateVecIndex(index_type);
-    auto dataset = GenDataset(NB, metric_type, false);
-    auto xb_data = dataset.get_col<float>(0);
-    auto xb_dataset = knowhere::GenDataset(NB, DIM, xb_data.data());
-    index->BuildAll(xb_dataset, conf);
-    auto bs = index->Serialize(conf);
-    auto bptr = std::make_shared<knowhere::Binary>();
-    bptr->data = std::shared_ptr<uint8_t[]>((uint8_t*)xb_data.data(), [&](uint8_t*) {});
-    bptr->size = DIM * NB * sizeof(float);
-    bs.Append(RAW_DATA, bptr);
-    index->Load(bs);
-    auto xq_data = dataset.get_col<float>(0);
-    auto xq_dataset = knowhere::GenDataset(NQ, DIM, xq_data.data());
-    auto result = index->Query(xq_dataset, conf, nullptr);
-}
-#endif
 
 TEST(BINFLAT, Build) {
     auto index_type = knowhere::IndexEnum::INDEX_FAISS_BIN_IVFFLAT;
@@ -394,23 +358,9 @@ INSTANTIATE_TEST_CASE_P(
                       std::pair(knowhere::IndexEnum::INDEX_FAISS_BIN_IVFFLAT, knowhere::metric::JACCARD),
                       std::pair(knowhere::IndexEnum::INDEX_FAISS_BIN_IVFFLAT, knowhere::metric::TANIMOTO),
                       std::pair(knowhere::IndexEnum::INDEX_FAISS_BIN_IDMAP, knowhere::metric::JACCARD),
-#ifdef MILVUS_SUPPORT_SPTAG
-                      std::pair(knowhere::IndexEnum::INDEX_SPTAG_KDT_RNT, knowhere::metric::L2),
-                      std::pair(knowhere::IndexEnum::INDEX_SPTAG_BKT_RNT, knowhere::metric::L2),
-#endif
                       std::pair(knowhere::IndexEnum::INDEX_HNSW, knowhere::metric::L2),
-                      std::pair(knowhere::IndexEnum::INDEX_ANNOY, knowhere::metric::L2),
-                      std::pair(knowhere::IndexEnum::INDEX_RHNSWFlat, knowhere::metric::L2),
-                      std::pair(knowhere::IndexEnum::INDEX_RHNSWPQ, knowhere::metric::L2),
-                      std::pair(knowhere::IndexEnum::INDEX_RHNSWSQ, knowhere::metric::L2)
-#ifdef MILVUS_SUPPORT_NGT
-                          std::pair(knowhere::IndexEnum::INDEX_NGTPANNG, knowhere::metric::L2),
-                      std::pair(knowhere::IndexEnum::INDEX_NGTONNG, knowhere::metric::L2),
-#endif
-#ifdef MILVUS_SUPPORT_NSG
-                      std::pair(knowhere::IndexEnum::INDEX_NSG, knowhere::metric::L2)
-#endif
-                          ));
+                      std::pair(knowhere::IndexEnum::INDEX_ANNOY, knowhere::metric::L2)
+                      ));
 
 TEST_P(IndexWrapperTest, Constructor) {
     auto index =

--- a/internal/core/unittest/test_utils/indexbuilder_test_utils.h
+++ b/internal/core/unittest/test_utils/indexbuilder_test_utils.h
@@ -109,36 +109,6 @@ generate_conf(const knowhere::IndexType& index_type, const knowhere::MetricType&
             {knowhere::meta::DIM, DIM},
             {knowhere::meta::TOPK, K},
         };
-#ifdef MILVUS_SUPPORT_NSG
-    } else if (index_type == knowhere::IndexEnum::INDEX_NSG) {
-        return knowhere::Config{
-            {knowhere::meta::METRIC_TYPE, metric_type},
-            {knowhere::meta::DIM, DIM},
-            {knowhere::meta::TOPK, K},
-            {knowhere::indexparam::NLIST, 163},
-            {knowhere::indexparam::NPROBE, 8},
-            {knowhere::indexparam::KNNG, 20},
-            {knowhere::indexparam::SEARCH_LENGTH, 40},
-            {knowhere::indexparam::OUT_DEGREE, 30},
-            {knowhere::indexparam::CANDIDATE, 100},
-        };
-#endif
-#ifdef MILVUS_SUPPORT_SPTAG
-    } else if (index_type == knowhere::IndexEnum::INDEX_SPTAG_KDT_RNT) {
-        return knowhere::Config{
-            {knowhere::meta::SLICE_SIZE, knowhere::index_file_slice_size},
-            {knowhere::meta::METRIC_TYPE, metric_type},
-            {knowhere::meta::DIM, DIM},
-            {knowhere::meta::TOPK, 10},
-        };
-    } else if (index_type == knowhere::IndexEnum::INDEX_SPTAG_BKT_RNT) {
-        return knowhere::Config{
-            {knowhere::meta::SLICE_SIZE, knowhere::index_file_slice_size},
-            {knowhere::meta::METRIC_TYPE, metric_type},
-            {knowhere::meta::DIM, DIM},
-            {knowhere::meta::TOPK, 10},
-        };
-#endif
     } else if (index_type == knowhere::IndexEnum::INDEX_HNSW) {
         return knowhere::Config{
             {knowhere::meta::SLICE_SIZE, knowhere::index_file_slice_size},
@@ -158,63 +128,6 @@ generate_conf(const knowhere::IndexType& index_type, const knowhere::MetricType&
             {knowhere::indexparam::N_TREES, 4},
             {knowhere::indexparam::SEARCH_K, 100},
         };
-    } else if (index_type == knowhere::IndexEnum::INDEX_RHNSWFlat) {
-        return knowhere::Config{
-            {knowhere::meta::SLICE_SIZE, knowhere::index_file_slice_size},
-            {knowhere::meta::METRIC_TYPE, metric_type},
-            {knowhere::meta::DIM, DIM},
-            {knowhere::meta::TOPK, K},
-            {knowhere::indexparam::HNSW_M, 16},
-            {knowhere::indexparam::EFCONSTRUCTION, 200},
-            {knowhere::indexparam::EF, 200},
-        };
-    } else if (index_type == knowhere::IndexEnum::INDEX_RHNSWPQ) {
-        return knowhere::Config{
-            {knowhere::meta::SLICE_SIZE, knowhere::index_file_slice_size},
-            {knowhere::meta::METRIC_TYPE, metric_type},
-            {knowhere::meta::DIM, DIM},
-            {knowhere::meta::TOPK, K},
-            {knowhere::indexparam::HNSW_M, 16},
-            {knowhere::indexparam::EFCONSTRUCTION, 200},
-            {knowhere::indexparam::EF, 200},
-            {knowhere::indexparam::PQ_M, 8},
-        };
-    } else if (index_type == knowhere::IndexEnum::INDEX_RHNSWSQ) {
-        return knowhere::Config{
-            {knowhere::meta::SLICE_SIZE, knowhere::index_file_slice_size},
-            {knowhere::meta::METRIC_TYPE, metric_type},
-            {knowhere::meta::DIM, DIM},
-            {knowhere::meta::TOPK, K},
-            {knowhere::indexparam::HNSW_M, 16},
-            {knowhere::indexparam::EFCONSTRUCTION, 200},
-            {knowhere::indexparam::EF, 200},
-        };
-#ifdef MILVUS_SUPPORT_NGT
-    } else if (index_type == knowhere::IndexEnum::INDEX_NGTPANNG) {
-        return knowhere::Config{
-            {knowhere::meta::SLICE_SIZE, knowhere::index_file_slice_size},
-            {knowhere::meta::METRIC_TYPE, metric_type},
-            {knowhere::meta::DIM, DIM},
-            {knowhere::meta::TOPK, K},
-            {knowhere::indexparam::EDGE_SIZE, 10},
-            {knowhere::indexparam::EPSILON, 0.1},
-            {knowhere::indexparam::MAX_SEARCH_EDGES, 50},
-            {knowhere::indexparam::FORCEDLY_PRUNED_EDGE_SIZE, 60},
-            {knowhere::indexparam::SELECTIVELY_PRUNED_EDGE_SIZE, 30},
-        };
-    } else if (index_type == knowhere::IndexEnum::INDEX_NGTONNG) {
-        return knowhere::Config{
-            {knowhere::meta::SLICE_SIZE, knowhere::index_file_slice_size},
-            {knowhere::meta::METRIC_TYPE, metric_type},
-            {knowhere::meta::DIM, DIM},
-            {knowhere::meta::TOPK, K},
-            {knowhere::indexparam::EDGE_SIZE, 20},
-            {knowhere::indexparam::EPSILON, 0.1},
-            {knowhere::indexparam::MAX_SEARCH_EDGES, 50},
-            {knowhere::indexparam::OUTGOING_EDGE_SIZE, 5},
-            {knowhere::indexparam::INCOMING_EDGE_SIZE, 40},
-        };
-#endif
     }
     return knowhere::Config();
 }

--- a/internal/util/indexcgowrapper/index_test.go
+++ b/internal/util/indexcgowrapper/index_test.go
@@ -4,12 +4,10 @@
 package indexcgowrapper
 
 import (
-	"fmt"
 	"strconv"
 	"testing"
 
 	"github.com/milvus-io/milvus/internal/proto/schemapb"
-
 	"github.com/stretchr/testify/assert"
 )
 
@@ -19,18 +17,11 @@ const (
 	IndexFaissIVFFlat    = "IVF_FLAT"
 	IndexFaissIVFPQ      = "IVF_PQ"
 	IndexFaissIVFSQ8     = "IVF_SQ8"
-	IndexFaissIVFSQ8H    = "IVF_SQ8_HYBRID"
 	IndexFaissBinIDMap   = "BIN_FLAT"
 	IndexFaissBinIVFFlat = "BIN_IVF_FLAT"
-	IndexNsg             = "NSG"
 
-	IndexHNSW      = "HNSW"
-	IndexRHNSWFlat = "RHNSW_FLAT"
-	IndexRHNSWPQ   = "RHNSW_PQ"
-	IndexRHNSWSQ   = "RHNSW_SQ"
-	IndexANNOY     = "ANNOY"
-	IndexNGTPANNG  = "NGT_PANNG"
-	IndexNGTONNG   = "NGT_ONNG"
+	IndexHNSW  = "HNSW"
+	IndexANNOY = "ANNOY"
 
 	// metric type
 	L2       = "L2"
@@ -44,13 +35,9 @@ const (
 	m              = 4
 	nbits          = 8
 	nb             = 1000
-	nprobe         = 8
 	sliceSize      = 4
 	efConstruction = 200
 	ef             = 200
-	edgeSize       = 10
-	epsilon        = 0.1
-	maxSearchEdges = 50
 )
 
 type vecTestCase struct {
@@ -70,24 +57,10 @@ func generateFloatVectorTestCases() []vecTestCase {
 		{IndexFaissIVFPQ, IP, false, schemapb.DataType_FloatVector},
 		{IndexFaissIVFSQ8, L2, false, schemapb.DataType_FloatVector},
 		{IndexFaissIVFSQ8, IP, false, schemapb.DataType_FloatVector},
-		//{IndexFaissIVFSQ8H, L2, false, schemapb.DataType_FloatVector}, // TODO: enable gpu
-		//{IndexFaissIVFSQ8H, IP, false, schemapb.DataType_FloatVector},
-		//{IndexNsg, L2, false, schemapb.DataType_FloatVector},
-		//{IndexNsg, IP, false, schemapb.DataType_FloatVector},
 		{IndexHNSW, L2, false, schemapb.DataType_FloatVector},
 		{IndexHNSW, IP, false, schemapb.DataType_FloatVector},
-		{IndexRHNSWFlat, L2, false, schemapb.DataType_FloatVector},
-		{IndexRHNSWFlat, IP, false, schemapb.DataType_FloatVector},
-		{IndexRHNSWPQ, L2, false, schemapb.DataType_FloatVector},
-		{IndexRHNSWPQ, IP, false, schemapb.DataType_FloatVector},
-		{IndexRHNSWSQ, L2, false, schemapb.DataType_FloatVector},
-		{IndexRHNSWSQ, IP, false, schemapb.DataType_FloatVector},
 		{IndexANNOY, L2, false, schemapb.DataType_FloatVector},
 		{IndexANNOY, IP, false, schemapb.DataType_FloatVector},
-		//{IndexNGTPANNG, L2, false, schemapb.DataType_FloatVector},
-		//{IndexNGTPANNG, IP, false, schemapb.DataType_FloatVector},
-		//{IndexNGTONNG, L2, false, schemapb.DataType_FloatVector},
-		//{IndexNGTONNG, IP, false, schemapb.DataType_FloatVector},
 	}
 }
 
@@ -127,60 +100,15 @@ func generateParams(indexType, metricType string) (map[string]string, map[string
 		indexParams["nlist"] = strconv.Itoa(nlist)
 		indexParams["nbits"] = strconv.Itoa(nbits)
 		indexParams["SLICE_SIZE"] = strconv.Itoa(sliceSize)
-	} else if indexType == IndexFaissIVFSQ8H {
-		// TODO: enable gpu
-	} else if indexType == IndexNsg {
-		indexParams["dim"] = strconv.Itoa(dim)
-		indexParams["nlist"] = strconv.Itoa(163)
-		indexParams["nprobe"] = strconv.Itoa(nprobe)
-		indexParams["knng"] = strconv.Itoa(20)
-		indexParams["search_length"] = strconv.Itoa(40)
-		indexParams["out_degree"] = strconv.Itoa(30)
-		indexParams["candidate_pool_size"] = strconv.Itoa(100)
 	} else if indexType == IndexHNSW {
 		indexParams["dim"] = strconv.Itoa(dim)
 		indexParams["M"] = strconv.Itoa(16)
 		indexParams["efConstruction"] = strconv.Itoa(efConstruction)
 		indexParams["ef"] = strconv.Itoa(ef)
-	} else if indexType == IndexRHNSWFlat {
-		indexParams["dim"] = strconv.Itoa(dim)
-		indexParams["M"] = strconv.Itoa(16)
-		indexParams["efConstruction"] = strconv.Itoa(efConstruction)
-		indexParams["ef"] = strconv.Itoa(ef)
-		indexParams["SLICE_SIZE"] = strconv.Itoa(sliceSize)
-	} else if indexType == IndexRHNSWPQ {
-		indexParams["dim"] = strconv.Itoa(dim)
-		indexParams["M"] = strconv.Itoa(16)
-		indexParams["efConstruction"] = strconv.Itoa(efConstruction)
-		indexParams["ef"] = strconv.Itoa(ef)
-		indexParams["SLICE_SIZE"] = strconv.Itoa(sliceSize)
-		indexParams["PQM"] = strconv.Itoa(8)
-	} else if indexType == IndexRHNSWSQ {
-		indexParams["dim"] = strconv.Itoa(dim)
-		indexParams["M"] = strconv.Itoa(16)
-		indexParams["efConstruction"] = strconv.Itoa(efConstruction)
-		indexParams["ef"] = strconv.Itoa(ef)
-		indexParams["SLICE_SIZE"] = strconv.Itoa(sliceSize)
 	} else if indexType == IndexANNOY {
 		indexParams["dim"] = strconv.Itoa(dim)
 		indexParams["n_trees"] = strconv.Itoa(4)
 		indexParams["search_k"] = strconv.Itoa(100)
-		indexParams["SLICE_SIZE"] = strconv.Itoa(sliceSize)
-	} else if indexType == IndexNGTPANNG {
-		indexParams["dim"] = strconv.Itoa(dim)
-		indexParams["edge_size"] = strconv.Itoa(edgeSize)
-		indexParams["epsilon"] = fmt.Sprint(epsilon)
-		indexParams["max_search_edges"] = strconv.Itoa(maxSearchEdges)
-		indexParams["forcedly_pruned_edge_size"] = strconv.Itoa(60)
-		indexParams["selectively_pruned_edge_size"] = strconv.Itoa(30)
-		indexParams["SLICE_SIZE"] = strconv.Itoa(sliceSize)
-	} else if indexType == IndexNGTONNG {
-		indexParams["dim"] = strconv.Itoa(dim)
-		indexParams["edge_size"] = strconv.Itoa(edgeSize)
-		indexParams["epsilon"] = fmt.Sprint(epsilon)
-		indexParams["max_search_edges"] = strconv.Itoa(maxSearchEdges)
-		indexParams["outgoing_edge_size"] = strconv.Itoa(5)
-		indexParams["incoming_edge_size"] = strconv.Itoa(40)
 		indexParams["SLICE_SIZE"] = strconv.Itoa(sliceSize)
 	} else if indexType == IndexFaissBinIVFFlat { // binary vector
 		indexParams["dim"] = strconv.Itoa(dim)

--- a/tests/benchmark/milvus_benchmark/client.py
+++ b/tests/benchmark/milvus_benchmark/client.py
@@ -16,15 +16,11 @@ INDEX_MAP = {
     "flat": "FLAT",
     "ivf_flat": "IVF_FLAT",
     "ivf_sq8": "IVF_SQ8",
-    "nsg": "NSG",
-    "ivf_sq8h": "IVF_SQ8_HYBRID",
     "ivf_pq": "IVF_PQ",
     "hnsw": "HNSW",
     "annoy": "ANNOY",
     "bin_flat": "BIN_FLAT",
     "bin_ivf_flat": "BIN_IVF_FLAT",
-    "rhnsw_pq": "RHNSW_PQ",
-    "rhnsw_sq": "RHNSW_SQ"
 }
 epsilon = 0.1
 DEFAULT_WARM_QUERY_TOPK = 1

--- a/tests/python_client/common/common_func.py
+++ b/tests/python_client/common/common_func.py
@@ -386,19 +386,14 @@ def gen_invaild_search_params_type():
         if index_type == "FLAT":
             continue
         search_params.append({"index_type": index_type, "search_params": {"invalid_key": invalid_search_key}})
-        if index_type in ["IVF_FLAT", "IVF_SQ8", "IVF_SQ8H", "IVF_PQ"]:
+        if index_type in ["IVF_FLAT", "IVF_SQ8", "IVF_PQ"]:
             for nprobe in ct.get_invalid_ints:
                 ivf_search_params = {"index_type": index_type, "search_params": {"nprobe": nprobe}}
                 search_params.append(ivf_search_params)
-        elif index_type in ["HNSW", "RHNSW_FLAT", "RHNSW_PQ", "RHNSW_SQ"]:
+        elif index_type in ["HNSW"]:
             for ef in ct.get_invalid_ints:
                 hnsw_search_param = {"index_type": index_type, "search_params": {"ef": ef}}
                 search_params.append(hnsw_search_param)
-        elif index_type in ["NSG", "RNSG"]:
-            for search_length in ct.get_invalid_ints:
-                nsg_search_param = {"index_type": index_type, "search_params": {"search_length": search_length}}
-                search_params.append(nsg_search_param)
-            search_params.append({"index_type": index_type, "search_params": {"invalid_key": invalid_search_key}})
         elif index_type == "ANNOY":
             for search_k in ct.get_invalid_ints:
                 if isinstance(search_k, int):
@@ -410,7 +405,7 @@ def gen_invaild_search_params_type():
 
 def gen_search_param(index_type, metric_type="L2"):
     search_params = []
-    if index_type in ["FLAT", "IVF_FLAT", "IVF_SQ8", "IVF_SQ8H", "IVF_PQ"]:
+    if index_type in ["FLAT", "IVF_FLAT", "IVF_SQ8", "IVF_PQ"]:
         for nprobe in [64, 128]:
             ivf_search_params = {"metric_type": metric_type, "params": {"nprobe": nprobe}}
             search_params.append(ivf_search_params)
@@ -422,14 +417,10 @@ def gen_search_param(index_type, metric_type="L2"):
         for nprobe in [64, 128]:
             binary_search_params = {"metric_type": metric_type, "params": {"nprobe": nprobe}}
             search_params.append(binary_search_params)
-    elif index_type in ["HNSW", "RHNSW_FLAT", "RHNSW_PQ", "RHNSW_SQ"]:
+    elif index_type in ["HNSW"]:
         for ef in [64, 32768]:
             hnsw_search_param = {"metric_type": metric_type, "params": {"ef": ef}}
             search_params.append(hnsw_search_param)
-    elif index_type in ["NSG", "RNSG"]:
-        for search_length in [100, 300]:
-            nsg_search_param = {"metric_type": metric_type, "params": {"search_length": search_length}}
-            search_params.append(nsg_search_param)
     elif index_type == "ANNOY":
         for search_k in [1000, 5000]:
             annoy_search_param = {"metric_type": metric_type, "params": {"search_k": search_k}}
@@ -442,19 +433,15 @@ def gen_search_param(index_type, metric_type="L2"):
 
 def gen_invalid_search_param(index_type, metric_type="L2"):
     search_params = []
-    if index_type in ["FLAT", "IVF_FLAT", "IVF_SQ8", "IVF_SQ8H", "IVF_PQ"] \
+    if index_type in ["FLAT", "IVF_FLAT", "IVF_SQ8", "IVF_PQ"] \
             or index_type in ["BIN_FLAT", "BIN_IVF_FLAT"]:
         for nprobe in [-1]:
             ivf_search_params = {"metric_type": metric_type, "params": {"nprobe": nprobe}}
             search_params.append(ivf_search_params)
-    elif index_type in ["HNSW", "RHNSW_FLAT", "RHNSW_PQ", "RHNSW_SQ"]:
+    elif index_type in ["HNSW"]:
         for ef in [-1]:
             hnsw_search_param = {"metric_type": metric_type, "params": {"ef": ef}}
             search_params.append(hnsw_search_param)
-    elif index_type in ["NSG", "RNSG"]:
-        for search_length in [100, 300]:
-            nsg_search_param = {"metric_type": metric_type, "params": {"search_length": search_length}}
-            search_params.append(nsg_search_param)
     elif index_type == "ANNOY":
         for search_k in ["-1"]:
             annoy_search_param = {"metric_type": metric_type, "params": {"search_k": search_k}}

--- a/tests/python_client/common/common_type.py
+++ b/tests/python_client/common/common_type.py
@@ -164,20 +164,16 @@ get_wrong_format_dict = [
 ]
 
 """ Specially defined list """
-all_index_types = ["FLAT", "IVF_FLAT", "IVF_SQ8", "IVF_PQ", "HNSW", "ANNOY", "RHNSW_FLAT", "RHNSW_PQ", "RHNSW_SQ",
-                   "BIN_FLAT", "BIN_IVF_FLAT"]
+all_index_types = ["FLAT", "IVF_FLAT", "IVF_SQ8", "IVF_PQ", "HNSW", "ANNOY", "BIN_FLAT", "BIN_IVF_FLAT"]
 
 default_index_params = [{"nlist": 128}, {"nlist": 128}, {"nlist": 128}, {"nlist": 128, "m": 16, "nbits": 8},
-                        {"M": 48, "efConstruction": 500}, {"n_trees": 50}, {"M": 48, "efConstruction": 500},
-                        {"M": 48, "efConstruction": 500, "PQM": 8}, {"M": 48, "efConstruction": 500}, {"nlist": 128},
-                        {"nlist": 128}]
+                        {"M": 48, "efConstruction": 500}, {"n_trees": 50}, {"nlist": 128}, {"nlist": 128}]
 
 Handler_type = ["GRPC", "HTTP"]
-index_cpu_not_support = ["IVF_SQ8_HYBRID"]
 binary_support = ["BIN_FLAT", "BIN_IVF_FLAT"]
-delete_support = ["FLAT", "IVF_FLAT", "IVF_SQ8", "IVF_SQ8_HYBRID", "IVF_PQ"]
-ivf = ["FLAT", "IVF_FLAT", "IVF_SQ8", "IVF_SQ8_HYBRID", "IVF_PQ"]
-skip_pq = ["IVF_PQ", "RHNSW_PQ", "RHNSW_SQ"]
+delete_support = ["FLAT", "IVF_FLAT", "IVF_SQ8", "IVF_PQ"]
+ivf = ["FLAT", "IVF_FLAT", "IVF_SQ8", "IVF_PQ"]
+skip_pq = ["IVF_PQ"]
 binary_metrics = ["JACCARD", "HAMMING", "TANIMOTO", "SUBSTRUCTURE", "SUPERSTRUCTURE"]
 structure_metrics = ["SUBSTRUCTURE", "SUPERSTRUCTURE"]
 

--- a/tests/python_client/deploy/common.py
+++ b/tests/python_client/deploy/common.py
@@ -1,13 +1,10 @@
 import json
 from utils.util_log import test_log as log
 
-all_index_types = ["FLAT", "IVF_FLAT", "IVF_SQ8", "IVF_PQ", "HNSW", "ANNOY", "RHNSW_FLAT", "RHNSW_PQ", "RHNSW_SQ",
-                   "BIN_FLAT", "BIN_IVF_FLAT"]
+all_index_types = ["FLAT", "IVF_FLAT", "IVF_SQ8", "IVF_PQ", "HNSW", "ANNOY", "BIN_FLAT", "BIN_IVF_FLAT"]
 
 default_index_params = [{"nlist": 128}, {"nlist": 128}, {"nlist": 128}, {"nlist": 128, "m": 16, "nbits": 8},
-                        {"M": 48, "efConstruction": 500}, {"n_trees": 50}, {"M": 48, "efConstruction": 500},
-                        {"M": 48, "efConstruction": 500, "PQM": 8}, {"M": 48, "efConstruction": 500}, {"nlist": 128},
-                        {"nlist": 128}]
+                        {"M": 48, "efConstruction": 500}, {"n_trees": 50}, {"nlist": 128}, {"nlist": 128}]
 
 index_params_map = dict(zip(all_index_types, default_index_params))
 
@@ -25,7 +22,7 @@ def gen_index_param(index_type):
 
 def gen_search_param(index_type, metric_type="L2"):
     search_params = []
-    if index_type in ["FLAT", "IVF_FLAT", "IVF_SQ8", "IVF_SQ8H", "IVF_PQ"]:
+    if index_type in ["FLAT", "IVF_FLAT", "IVF_SQ8", "IVF_PQ"]:
         for nprobe in [10]:
             ivf_search_params = {"metric_type": metric_type, "params": {"nprobe": nprobe}}
             search_params.append(ivf_search_params)
@@ -33,14 +30,10 @@ def gen_search_param(index_type, metric_type="L2"):
         for nprobe in [10]:
             bin_search_params = {"metric_type": "HAMMING", "params": {"nprobe": nprobe}}
             search_params.append(bin_search_params)
-    elif index_type in ["HNSW", "RHNSW_FLAT", "RHNSW_PQ", "RHNSW_SQ"]:
+    elif index_type in ["HNSW"]:
         for ef in [64]:
             hnsw_search_param = {"metric_type": metric_type, "params": {"ef": ef}}
             search_params.append(hnsw_search_param)
-    elif index_type in ["NSG", "RNSG"]:
-        for search_length in [100]:
-            nsg_search_param = {"metric_type": metric_type, "params": {"search_length": search_length}}
-            search_params.append(nsg_search_param)
     elif index_type == "ANNOY":
         for search_k in [1000]:
             annoy_search_param = {"metric_type": metric_type, "params": {"search_k": search_k}}

--- a/tests/python_client/deploy/scripts/utils.py
+++ b/tests/python_client/deploy/scripts/utils.py
@@ -5,12 +5,10 @@ from pymilvus import (
     Collection, list_collections,
 )
 
-all_index_types = ["FLAT", "IVF_FLAT", "IVF_SQ8", "IVF_PQ", "HNSW", "ANNOY", "RHNSW_FLAT", "RHNSW_PQ", "RHNSW_SQ"]
+all_index_types = ["FLAT", "IVF_FLAT", "IVF_SQ8", "IVF_PQ", "HNSW", "ANNOY"]
 
 default_index_params = [{"nlist": 128}, {"nlist": 128}, {"nlist": 128}, {"nlist": 128, "m": 16, "nbits": 8},
-                        {"M": 48, "efConstruction": 500}, {"n_trees": 50}, {"M": 48, "efConstruction": 500},
-                        {"M": 48, "efConstruction": 500, "PQM": 8}, {"M": 48, "efConstruction": 500}, {"nlist": 128},
-                        {"nlist": 128}]
+                        {"M": 48, "efConstruction": 500}, {"n_trees": 50}, {"nlist": 128}, {"nlist": 128}]
 
 index_params_map = dict(zip(all_index_types, default_index_params))
 
@@ -28,7 +26,7 @@ def filter_collections_by_prefix(prefix):
 
 def gen_search_param(index_type, metric_type="L2"):
     search_params = []
-    if index_type in ["FLAT", "IVF_FLAT", "IVF_SQ8", "IVF_SQ8H", "IVF_PQ"]:
+    if index_type in ["FLAT", "IVF_FLAT", "IVF_SQ8", "IVF_PQ"]:
         for nprobe in [10]:
             ivf_search_params = {"metric_type": metric_type, "params": {"nprobe": nprobe}}
             search_params.append(ivf_search_params)
@@ -36,14 +34,10 @@ def gen_search_param(index_type, metric_type="L2"):
         for nprobe in [10]:
             bin_search_params = {"metric_type": "HAMMING", "params": {"nprobe": nprobe}}
             search_params.append(bin_search_params)
-    elif index_type in ["HNSW", "RHNSW_FLAT", "RHNSW_PQ", "RHNSW_SQ"]:
+    elif index_type in ["HNSW"]:
         for ef in [64]:
             hnsw_search_param = {"metric_type": metric_type, "params": {"ef": ef}}
             search_params.append(hnsw_search_param)
-    elif index_type in ["NSG", "RNSG"]:
-        for search_length in [100]:
-            nsg_search_param = {"metric_type": metric_type, "params": {"search_length": search_length}}
-            search_params.append(nsg_search_param)
     elif index_type == "ANNOY":
         for search_k in [1000]:
             annoy_search_param = {"metric_type": metric_type, "params": {"search_k": search_k}}

--- a/tests/python_client/testcases/test_collection.py
+++ b/tests/python_client/testcases/test_collection.py
@@ -2584,9 +2584,6 @@ class TestLoadPartition(TestcaseBase):
         params=gen_simple_index()
     )
     def get_simple_index(self, request, connect):
-        # if str(connect._cmd("mode")) == "CPU":
-        #     if request.param["index_type"] in index_cpu_not_support():
-        #         pytest.skip("sq8h not support in cpu mode")
         return request.param
 
     @pytest.fixture(

--- a/tests/python_client/testcases/test_search.py
+++ b/tests/python_client/testcases/test_search.py
@@ -298,8 +298,8 @@ class TestCollectionSearchInvalid(TestcaseBase):
 
     @pytest.mark.tags(CaseLabel.L1)
     @pytest.mark.parametrize("index, params",
-                             zip(ct.all_index_types[:9],
-                                 ct.default_index_params[:9]))
+                             zip(ct.all_index_types[:6],
+                                 ct.default_index_params[:6]))
     def test_search_invalid_params_type(self, index, params):
         """
         target: test search with invalid search params
@@ -678,8 +678,8 @@ class TestCollectionSearchInvalid(TestcaseBase):
 
     @pytest.mark.tags(CaseLabel.L1)
     @pytest.mark.parametrize("index, params",
-                             zip(ct.all_index_types[1:9],
-                                 ct.default_index_params[1:9]))
+                             zip(ct.all_index_types[1:6],
+                                 ct.default_index_params[1:6]))
     def test_search_different_index_invalid_params(self, index, params):
         """
         target: test search with different index
@@ -1295,8 +1295,8 @@ class TestCollectionSearch(TestcaseBase):
 
     @pytest.mark.tags(CaseLabel.L1)
     @pytest.mark.parametrize("index, params",
-                             zip(ct.all_index_types[:9],
-                                 ct.default_index_params[:9]))
+                             zip(ct.all_index_types[:6],
+                                 ct.default_index_params[:6]))
     def test_search_after_different_index_with_params(self, dim, index, params, auto_id, _async):
         """
         target: test search after different index
@@ -1335,8 +1335,8 @@ class TestCollectionSearch(TestcaseBase):
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("index, params",
-                             zip(ct.all_index_types[:9],
-                                 ct.default_index_params[:9]))
+                             zip(ct.all_index_types[:6],
+                                 ct.default_index_params[:6]))
     def test_search_after_different_index_with_min_dim(self, index, params, auto_id, _async):
         """
         target: test search after different index with min dim
@@ -1373,8 +1373,8 @@ class TestCollectionSearch(TestcaseBase):
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("index, params",
-                             zip(ct.all_index_types[:9],
-                                 ct.default_index_params[:9]))
+                             zip(ct.all_index_types[:6],
+                                 ct.default_index_params[:6]))
     def test_search_after_index_different_metric_type(self, dim, index, params, auto_id, _async):
         """
         target: test search with different metric type
@@ -2676,8 +2676,8 @@ class TestSearchBase(TestcaseBase):
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("index, params",
-                             zip(ct.all_index_types[:9],
-                                 ct.default_index_params[:9]))
+                             zip(ct.all_index_types[:6],
+                                 ct.default_index_params[:6]))
     def test_search_index_empty_partition(self, index, params):
         """
         target: test basic search function, all the search params are correct, test all index params, and build
@@ -2725,8 +2725,8 @@ class TestSearchBase(TestcaseBase):
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("index, params",
-                             zip(ct.all_index_types[:9],
-                                 ct.default_index_params[:9]))
+                             zip(ct.all_index_types[:6],
+                                 ct.default_index_params[:6]))
     def test_search_index_partitions(self, index, params, get_top_k):
         """
         target: test basic search function, all the search params are correct, test all index params, and build
@@ -2785,8 +2785,8 @@ class TestSearchBase(TestcaseBase):
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("index, params",
-                             zip(ct.all_index_types[:9],
-                                 ct.default_index_params[:9]))
+                             zip(ct.all_index_types[:6],
+                                 ct.default_index_params[:6]))
     def test_search_ip_after_index(self, index, params):
         """
         target: test basic search function, all the search params are correct, test all index params, and build
@@ -2842,8 +2842,8 @@ class TestSearchBase(TestcaseBase):
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("index, params",
-                             zip(ct.all_index_types[:9],
-                                 ct.default_index_params[:9]))
+                             zip(ct.all_index_types[:6],
+                                 ct.default_index_params[:6]))
     def test_search_ip_index_empty_partition(self, index, params):
         """
         target: test basic search function, all the search params are correct, test all index params, and build
@@ -2885,8 +2885,8 @@ class TestSearchBase(TestcaseBase):
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("index, params",
-                             zip(ct.all_index_types[:9],
-                                 ct.default_index_params[:9]))
+                             zip(ct.all_index_types[:6],
+                                 ct.default_index_params[:6]))
     def test_search_ip_index_partitions(self, index, params):
         """
         target: test basic search function, all the search params are correct, test all index params, and build

--- a/tests/python_client/utils/util_pymilvus.py
+++ b/tests/python_client/utils/util_pymilvus.py
@@ -32,19 +32,13 @@ default_tag = "1970_01_01"
 row_count = "row_count"
 
 # TODO:
-# TODO: disable RHNSW_SQ/PQ in 0.11.0
 all_index_types = [
     "FLAT",
     "IVF_FLAT",
     "IVF_SQ8",
-    # "IVF_SQ8_HYBRID",
     "IVF_PQ",
     "HNSW",
-    # "NSG",
     "ANNOY",
-    "RHNSW_FLAT",
-    "RHNSW_PQ",
-    "RHNSW_SQ",
     "BIN_FLAT",
     "BIN_IVF_FLAT"
 ]
@@ -53,14 +47,9 @@ default_index_params = [
     {"nlist": 128},
     {"nlist": 128},
     {"nlist": 128},
-    # {"nlist": 128},
     {"nlist": 128, "m": 16, "nbits": 8},
     {"M": 48, "efConstruction": 500},
-    # {"search_length": 50, "out_degree": 40, "candidate_pool_size": 100, "knng": 50},
     {"n_trees": 50},
-    {"M": 48, "efConstruction": 500},
-    {"M": 48, "efConstruction": 500, "PQM": 8},
-    {"M": 48, "efConstruction": 500},
     {"nlist": 128},
     {"nlist": 128}
 ]
@@ -70,24 +59,20 @@ def create_target_index(index, field_name):
     index["field_name"] = field_name
 
 
-def index_cpu_not_support():
-    return ["IVF_SQ8_HYBRID"]
-
-
 def binary_support():
     return ["BIN_FLAT", "BIN_IVF_FLAT"]
 
 
 def delete_support():
-    return ["FLAT", "IVF_FLAT", "IVF_SQ8", "IVF_SQ8_HYBRID", "IVF_PQ"]
+    return ["FLAT", "IVF_FLAT", "IVF_SQ8", "IVF_PQ"]
 
 
 def ivf():
-    return ["FLAT", "IVF_FLAT", "IVF_SQ8", "IVF_SQ8_HYBRID", "IVF_PQ"]
+    return ["FLAT", "IVF_FLAT", "IVF_SQ8", "IVF_PQ"]
 
 
 def skip_pq():
-    return ["IVF_PQ", "RHNSW_PQ", "RHNSW_SQ"]
+    return ["IVF_PQ"]
 
 
 def binary_metrics():
@@ -748,15 +733,10 @@ def gen_invaild_search_params():
             for nprobe in gen_invalid_params():
                 ivf_search_params = {"index_type": index_type, "search_params": {"nprobe": nprobe}}
                 search_params.append(ivf_search_params)
-        elif index_type in ["HNSW", "RHNSW_PQ", "RHNSW_SQ"]:
+        elif index_type in ["HNSW"]:
             for ef in gen_invalid_params():
                 hnsw_search_param = {"index_type": index_type, "search_params": {"ef": ef}}
                 search_params.append(hnsw_search_param)
-        elif index_type == "NSG":
-            for search_length in gen_invalid_params():
-                nsg_search_param = {"index_type": index_type, "search_params": {"search_length": search_length}}
-                search_params.append(nsg_search_param)
-            search_params.append({"index_type": index_type, "search_params": {"invalid_key": 100}})
         elif index_type == "ANNOY":
             for search_k in gen_invalid_params():
                 if isinstance(search_k, int):
@@ -776,36 +756,12 @@ def gen_invalid_index():
         index_params.append(index_param)
     for M in gen_invalid_params():
         index_param = {"index_type": "HNSW", "params": {"M": M, "efConstruction": 100}}
-        index_param = {"index_type": "RHNSW_PQ", "params": {"M": M, "efConstruction": 100}}
-        index_param = {"index_type": "RHNSW_SQ", "params": {"M": M, "efConstruction": 100}}
         index_params.append(index_param)
     for efConstruction in gen_invalid_params():
         index_param = {"index_type": "HNSW", "params": {"M": 16, "efConstruction": efConstruction}}
-        index_param = {"index_type": "RHNSW_PQ", "params": {"M": 16, "efConstruction": efConstruction}}
-        index_param = {"index_type": "RHNSW_SQ", "params": {"M": 16, "efConstruction": efConstruction}}
-        index_params.append(index_param)
-    for search_length in gen_invalid_params():
-        index_param = {"index_type": "NSG",
-                       "params": {"search_length": search_length, "out_degree": 40, "candidate_pool_size": 50,
-                                  "knng": 100}}
-        index_params.append(index_param)
-    for out_degree in gen_invalid_params():
-        index_param = {"index_type": "NSG",
-                       "params": {"search_length": 100, "out_degree": out_degree, "candidate_pool_size": 50,
-                                  "knng": 100}}
-        index_params.append(index_param)
-    for candidate_pool_size in gen_invalid_params():
-        index_param = {"index_type": "NSG", "params": {"search_length": 100, "out_degree": 40,
-                                                       "candidate_pool_size": candidate_pool_size,
-                                                       "knng": 100}}
         index_params.append(index_param)
     index_params.append({"index_type": "IVF_FLAT", "params": {"invalid_key": 1024}})
     index_params.append({"index_type": "HNSW", "params": {"invalid_key": 16, "efConstruction": 100}})
-    index_params.append({"index_type": "RHNSW_PQ", "params": {"invalid_key": 16, "efConstruction": 100}})
-    index_params.append({"index_type": "RHNSW_SQ", "params": {"invalid_key": 16, "efConstruction": 100}})
-    index_params.append({"index_type": "NSG",
-                         "params": {"invalid_key": 100, "out_degree": 40, "candidate_pool_size": 300,
-                                    "knng": 100}})
     for invalid_n_trees in gen_invalid_params():
         index_params.append({"index_type": "ANNOY", "params": {"n_trees": invalid_n_trees}})
 
@@ -817,16 +773,12 @@ def gen_index():
     pq_ms = [128, 64, 32, 16, 8, 4]
     Ms = [5, 24, 48]
     efConstructions = [100, 300, 500]
-    search_lengths = [10, 100, 300]
-    out_degrees = [5, 40, 300]
-    candidate_pool_sizes = [50, 100, 300]
-    knngs = [5, 100, 300]
 
     index_params = []
     for index_type in all_index_types:
         if index_type in ["FLAT", "BIN_FLAT", "BIN_IVF_FLAT"]:
             index_params.append({"index_type": index_type, "index_param": {"nlist": 1024}})
-        elif index_type in ["IVF_FLAT", "IVF_SQ8", "IVF_SQ8_HYBRID"]:
+        elif index_type in ["IVF_FLAT", "IVF_SQ8"]:
             ivf_params = [{"index_type": index_type, "index_param": {"nlist": nlist}} \
                           for nlist in nlists]
             index_params.extend(ivf_params)
@@ -835,20 +787,11 @@ def gen_index():
                             for nlist in nlists \
                             for m in pq_ms]
             index_params.extend(IVFPQ_params)
-        elif index_type in ["HNSW", "RHNSW_SQ", "RHNSW_PQ"]:
+        elif index_type in ["HNSW"]:
             hnsw_params = [{"index_type": index_type, "index_param": {"M": M, "efConstruction": efConstruction}} \
                            for M in Ms \
                            for efConstruction in efConstructions]
             index_params.extend(hnsw_params)
-        elif index_type == "NSG":
-            nsg_params = [{"index_type": index_type,
-                           "index_param": {"search_length": search_length, "out_degree": out_degree,
-                                           "candidate_pool_size": candidate_pool_size, "knng": knng}} \
-                          for search_length in search_lengths \
-                          for out_degree in out_degrees \
-                          for candidate_pool_size in candidate_pool_sizes \
-                          for knng in knngs]
-            index_params.extend(nsg_params)
 
     return index_params
 
@@ -888,12 +831,9 @@ def get_search_param(index_type, metric_type="L2"):
     if index_type in ivf() or index_type in binary_support():
         nprobe64 = {"nprobe": 64}
         search_params.update({"params": nprobe64})
-    elif index_type in ["HNSW", "RHNSW_FLAT", "RHNSW_SQ", "RHNSW_PQ"]:
+    elif index_type in ["HNSW"]:
         ef64 = {"ef": 64}
         search_params.update({"params": ef64})
-    elif index_type == "NSG":
-        length100 = {"search_length": 100}
-        search_params.update({"params": length100})
     elif index_type == "ANNOY":
         search_k = {"search_k": 1000}
         search_params.update({"params": search_k})


### PR DESCRIPTION
Signed-off-by: yudong.cai <yudong.cai@zilliz.com>

Upgrade to knowhere-v1.3.0, remove following index support:
- IVF_SQ8H
- RHNSW_FLAT
- RHNSW_PQ
- RHNSW_SQ
- NGT
- NSG
- SPTAG