### PR TITLE
[skip e2e] Add push for 2.*.*

### DIFF
--- a/.github/workflows/code-checker.yaml
+++ b/.github/workflows/code-checker.yaml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - master
+      - 2.*.*
   pull_request:
     # file paths to consider in the event. Optional; defaults to all.
     paths:


### PR DESCRIPTION
Signed-off-by: Jenny Li <jing.li@zilliz.com>
/kind improvement
follow the rule for github action cache https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache need action to save cache for branch 2.1.0