### PR TITLE
Adaptation for latest MinGW64 (#18699)

### DIFF
--- a/.github/workflows/code-checker.yaml
+++ b/.github/workflows/code-checker.yaml
@@ -177,7 +177,7 @@ jobs:
           key: ${{ runner.os }}-ccache-${{ hashFiles('internal/core/**') }}
           restore-keys: ${{ runner.os }}-ccache-
       - name: Configure Toolchain
-        uses: msys2/setup-msys2@v2.10.3
+        uses: msys2/setup-msys2@v2.12.0
         with:
           msystem: mingw64
       - name: Install Deps
@@ -193,4 +193,5 @@ jobs:
           CCACHE_MAXSIZE: 2G
           CCACHE_DIR: ${{ github.workspace }}/.ccache
         run: |
+          go version
           mingw32-make verifiers build-go

--- a/internal/core/CMakeLists.txt
+++ b/internal/core/CMakeLists.txt
@@ -50,6 +50,14 @@ else ()
     message(FATAL_ERROR "Unsupported platform!" )
 endif ()
 
+if (CMAKE_COMPILER_IS_GNUCC)
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 11.99)
+        # ignore deprecated declarations for gcc>=12
+        # TODO: this workaround may removed when protobuf upgraded
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=deprecated-declarations")
+    endif ()
+endif ()
+
 set( CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake" )
 include( Utils )
 

--- a/scripts/install_deps_msys.sh
+++ b/scripts/install_deps_msys.sh
@@ -23,18 +23,19 @@ pacmanInstall()
     mingw-w64-x86_64-python2 \
     mingw-w64-x86_64-diffutils \
     mingw-w64-x86_64-arrow \
-    mingw-w64-x86_64-go \
-    mingw-w64-x86_64-rocksdb
+    mingw-w64-x86_64-go
+  pacman -U --noconfirm \
+    https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-rocksdb-6.26.1-1-any.pkg.tar.zst
 }
 
 updateKey()
 {
-	pacman-key --refresh-keys
+    pacman-key --refresh-keys
 }
 
 pacmanInstall || {
-	updateKey
-	pacmanInstall
+    updateKey
+    pacmanInstall
 
 }
 


### PR DESCRIPTION
Cherry pick from master
As the master is now compiled with go 1.18, we could update MinGW to the latest, and some adaptation is needed as GCC 12 is used in the newest MinGW.

Signed-off-by: Ji Bin <matrixji@live.com>