### PR TITLE
[skip e2e] Fail ci when upload codecov report failed

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -89,7 +89,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./go_coverage.txt,./lcov_output.info
           name: ubuntu-${{ matrix.ubuntu }}-unittests
-          fail_ci_if_error: false
+          fail_ci_if_error: true
       - name: Retry Upload coverage to Codecov
         if: "steps.upload_cov.outcome=='failure' && github.repository == 'milvus-io/milvus'"
         uses: codecov/codecov-action@v3.1.0


### PR DESCRIPTION
Signed-off-by: Jenny Li <jing.li@zilliz.com>
fix #19035