### PR TITLE
Remove debug log in minio chunk manager

### DIFF
--- a/internal/storage/minio_chunk_manager.go
+++ b/internal/storage/minio_chunk_manager.go
@@ -356,7 +356,6 @@ func (mcm *MinioChunkManager) ListWithPrefix(prefix string, recursive bool) ([]s
 			if strings.HasSuffix(object.Key, "/") {
 				// enqueue when recursive is true
 				if recursive && object.Key != pre {
-					log.Warn("add next", zap.String("key", object.Key))
 					tasks.PushBack(object.Key)
 				}
 				continue


### PR DESCRIPTION
Remove debug log in `minioChunkManager.LoadWithPrefix`

/kind improvement

Signed-off-by: Congqi Xia <congqi.xia@zilliz.com>