### PR TITLE
Change the default configs about segment size

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -250,7 +250,7 @@ dataCoord:
 
   segment:
     maxSize: 512 # Maximum size of a segment in MB
-    sealProportion: 0.25 # It's the minimum proportion for a segment which can be sealed
+    sealProportion: 0.125 # It's the minimum proportion for a segment which can be sealed
     assignmentExpiration: 2000 # The time of the assignment expiration in ms
     maxLife: 86400 # The max lifetime of segment in seconds, 24*60*60
     # If a segment didn't accept dml records in `maxIdleTime` and the size of segment is greater than

--- a/internal/util/paramtable/component_param.go
+++ b/internal/util/paramtable/component_param.go
@@ -1052,7 +1052,7 @@ func (p *dataCoordConfig) initSegmentMaxSize() {
 }
 
 func (p *dataCoordConfig) initSegmentSealProportion() {
-	p.SegmentSealProportion = p.Base.ParseFloatWithDefault("dataCoord.segment.sealProportion", 0.25)
+	p.SegmentSealProportion = p.Base.ParseFloatWithDefault("dataCoord.segment.sealProportion", 0.125)
 }
 
 func (p *dataCoordConfig) initSegAssignmentExpiration() {
@@ -1088,7 +1088,7 @@ func (p *dataCoordConfig) initEnableAutoCompaction() {
 }
 
 func (p *dataCoordConfig) initCompactionMinSegment() {
-	p.MinSegmentToMerge = p.Base.ParseIntWithDefault("dataCoord.compaction.min.segment", 4)
+	p.MinSegmentToMerge = p.Base.ParseIntWithDefault("dataCoord.compaction.min.segment", 3)
 }
 
 func (p *dataCoordConfig) initCompactionMaxSegment() {
@@ -1096,7 +1096,7 @@ func (p *dataCoordConfig) initCompactionMaxSegment() {
 }
 
 func (p *dataCoordConfig) initSegmentSmallProportion() {
-	p.SegmentSmallProportion = p.Base.ParseFloatWithDefault("dataCoord.segment.smallProportion", 0.5)
+	p.SegmentSmallProportion = p.Base.ParseFloatWithDefault("dataCoord.segment.smallProportion", 0.85)
 }
 
 // compaction execution timeout


### PR DESCRIPTION
Default sealed size -> 64M
Compaction target size -> 512M * 0.85 or more
Compaction min file size -> 4
Signed-off-by: xiaofan-luan <xiaofan.luan@zilliz.com>