### PR TITLE
Fix deadlock

### DIFF
--- a/internal/datacoord/compaction_trigger.go
+++ b/internal/datacoord/compaction_trigger.go
@@ -236,9 +236,10 @@ func (t *compactionTrigger) handleGlobalSignal(signal *compactionSignal) {
 		return (signal.collectionID == 0 || segment.CollectionID == signal.collectionID) &&
 			isSegmentHealthy(segment) &&
 			isFlush(segment) &&
-			IsParentDropped(t.meta, segment) &&
+			IsParentDroppedUnsafe(t.meta, segment) &&
 			!segment.isCompacting // not compacting now
 	}) // m is list of chanPartSegments, which is channel-partition organized segments
+
 	for _, group := range m {
 		if !signal.isForce && t.compactionHandler.isFull() {
 			break

--- a/internal/datacoord/util.go
+++ b/internal/datacoord/util.go
@@ -186,9 +186,22 @@ func extractSegmentsWithVectorIndex(vecFieldID map[int64]int64, segentIndexInfo 
 	return indexedSegments.Collect()
 }
 
+// IsParentDropped checks whether a segment exists,
+// with acquiring read-lock of meta.
 func IsParentDropped(meta *meta, segment *SegmentInfo) bool {
 	for _, from := range segment.CompactionFrom {
-		if meta.GetSegment(from) != nil {
+		if meta.GetSegmentUnsafe(from) != nil {
+			return false
+		}
+	}
+	return true
+}
+
+// IsParentDroppedUnsafe same as IsParentDropped,
+// but not acquiring read-lock of meta.
+func IsParentDroppedUnsafe(meta *meta, segment *SegmentInfo) bool {
+	for _, from := range segment.CompactionFrom {
+		if meta.segments.GetSegment(from) != nil {
 			return false
 		}
 	}

--- a/tests/python_client/testcases/test_compaction.py
+++ b/tests/python_client/testcases/test_compaction.py
@@ -46,6 +46,7 @@ class TestCompactionParams(TestcaseBase):
         expected: Merge into one segment
         """
         # init collection with one shard, insert into two segments
+        pytest.skip("DataCoord: for A, B -> C, will not compact segment C before A, B GCed, no method to check whether a segment is GCed")
         collection_w = self.collection_insert_multi_segments_one_shard(prefix, nb_of_segment=tmp_nb)
 
         # first compact two segments
@@ -861,6 +862,7 @@ class TestCompactionOperation(TestcaseBase):
         expected: Verify segments info
         """
         # greater than auto-merge threshold 10
+        pytest.skip("DataCoord: for A, B -> C, will not compact segment C before A, B GCed, no method to check whether a segment is GCed")
         num_of_segment = ct.compact_segment_num_threshold + 1
 
         # create collection shard_num=1, insert 11 segments, each with one entity


### PR DESCRIPTION
The IsParentDropped() acquires read lock of meta,
which leads to recursively acquire read lock

Signed-off-by: yah01 <yang.cen@zilliz.com>

/kind bug
#19339 