### PR TITLE
test: use `T.Setenv` to set env vars in tests

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -32,7 +32,7 @@ func TestConfigFromEnv(t *testing.T) {
 	_, err := mgr.GetConfig("test.env")
 	assert.EqualError(t, err, "key not found: test.env")
 
-	os.Setenv("TEST_ENV", "value")
+	t.Setenv("TEST_ENV", "value")
 	mgr, _ = Init(WithEnvSource(formatKey))
 
 	v, err := mgr.GetConfig("test.env")
@@ -54,8 +54,8 @@ func TestConfigFromRemote(t *testing.T) {
 
 	client := v3client.New(e.Server)
 
-	os.Setenv("TMP_KEY", "1")
-	os.Setenv("log.level", "info")
+	t.Setenv("TMP_KEY", "1")
+	t.Setenv("log.level", "info")
 	mgr, _ := Init(WithEnvSource(formatKey),
 		WithFilesSource("../../configs/milvus.yaml"),
 		WithEtcdSource(&EtcdInfo{

--- a/internal/datacoord/channel_manager_test.go
+++ b/internal/datacoord/channel_manager_test.go
@@ -18,7 +18,6 @@ package datacoord
 
 import (
 	"context"
-	"os"
 	"path"
 	"strconv"
 	"sync"
@@ -92,7 +91,7 @@ func TestChannelManager_StateTransfer(t *testing.T) {
 	}()
 
 	p := "/tmp/milvus_ut/rdb_data"
-	os.Setenv("ROCKSMQ_PATH", p)
+	t.Setenv("ROCKSMQ_PATH", p)
 
 	prefix := Params.DataCoordCfg.ChannelWatchSubPath
 

--- a/internal/kv/etcd/embed_etcd_config_test.go
+++ b/internal/kv/etcd/embed_etcd_config_test.go
@@ -29,13 +29,13 @@ import (
 )
 
 func TestEtcdConfigLoad(te *testing.T) {
-	os.Setenv(metricsinfo.DeployModeEnvKey, metricsinfo.StandaloneDeployMode)
+	te.Setenv(metricsinfo.DeployModeEnvKey, metricsinfo.StandaloneDeployMode)
 	param := new(paramtable.ServiceParam)
 
-	os.Setenv("etcd.use.embed", "true")
+	te.Setenv("etcd.use.embed", "true")
 	// TODO, not sure if the relative path works for ci environment
-	os.Setenv("etcd.config.path", "../../../configs/advanced/etcd.yaml")
-	os.Setenv("etcd.data.dir", "etcd.test.data.dir")
+	te.Setenv("etcd.config.path", "../../../configs/advanced/etcd.yaml")
+	te.Setenv("etcd.data.dir", "etcd.test.data.dir")
 
 	param.Init()
 	//clean up data

--- a/internal/kv/etcd/embed_etcd_kv_test.go
+++ b/internal/kv/etcd/embed_etcd_kv_test.go
@@ -17,7 +17,6 @@
 package etcdkv_test
 
 import (
-	"os"
 	"testing"
 	"time"
 
@@ -31,13 +30,13 @@ import (
 )
 
 func TestEmbedEtcd(te *testing.T) {
-	os.Setenv(metricsinfo.DeployModeEnvKey, metricsinfo.StandaloneDeployMode)
+	te.Setenv(metricsinfo.DeployModeEnvKey, metricsinfo.StandaloneDeployMode)
 	param := new(paramtable.ServiceParam)
-	os.Setenv("etcd.use.embed", "true")
-	os.Setenv("etcd.config.path", "../../../configs/advanced/etcd.yaml")
+	te.Setenv("etcd.use.embed", "true")
+	te.Setenv("etcd.config.path", "../../../configs/advanced/etcd.yaml")
 
 	dir := te.TempDir()
-	os.Setenv("etcd.data.dir", dir)
+	te.Setenv("etcd.data.dir", dir)
 
 	param.Init()
 

--- a/internal/kv/etcd/embed_etcd_restart_test.go
+++ b/internal/kv/etcd/embed_etcd_restart_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestEtcdRestartLoad(te *testing.T) {
 	etcdDataDir := "/tmp/_etcd_data"
-	os.Setenv(metricsinfo.DeployModeEnvKey, metricsinfo.StandaloneDeployMode)
+	te.Setenv(metricsinfo.DeployModeEnvKey, metricsinfo.StandaloneDeployMode)
 	param := new(paramtable.ServiceParam)
 	param.Init()
 	param.BaseTable.Save("etcd.use.embed", "true")

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -17,7 +17,6 @@
 package metrics
 
 import (
-	"os"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -42,6 +41,6 @@ func TestRegisterMetrics(t *testing.T) {
 func TestGetMetricsAddr(t *testing.T) {
 	assert.Equal(t, getMetricsAddr(), ":"+DefaultListenPort)
 	testPort := "9092"
-	os.Setenv(ListenPortEnvKey, testPort)
+	t.Setenv(ListenPortEnvKey, testPort)
 	assert.Equal(t, getMetricsAddr(), ":"+testPort)
 }

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -412,9 +412,8 @@ func TestProxy(t *testing.T) {
 	var wg sync.WaitGroup
 
 	path := "/tmp/milvus/rocksmq" + funcutil.GenRandomStr()
-	err = os.Setenv("ROCKSMQ_PATH", path)
+	t.Setenv("ROCKSMQ_PATH", path)
 	defer os.RemoveAll(path)
-	assert.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	ctx = GetContext(ctx, "root:123456")

--- a/internal/util/flowgraph/input_node_test.go
+++ b/internal/util/flowgraph/input_node_test.go
@@ -18,7 +18,6 @@ package flowgraph
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,7 +26,7 @@ import (
 )
 
 func TestInputNode(t *testing.T) {
-	os.Setenv("ROCKSMQ_PATH", "/tmp/MilvusTest/FlowGraph/TestInputNode")
+	t.Setenv("ROCKSMQ_PATH", "/tmp/MilvusTest/FlowGraph/TestInputNode")
 	factory := dependency.NewDefaultFactory(true)
 
 	msgStream, _ := factory.NewMsgStream(context.TODO())

--- a/internal/util/flowgraph/node_test.go
+++ b/internal/util/flowgraph/node_test.go
@@ -19,7 +19,6 @@ package flowgraph
 import (
 	"context"
 	"math"
-	"os"
 	"sync"
 	"testing"
 	"time"
@@ -57,7 +56,7 @@ func generateMsgPack() msgstream.MsgPack {
 }
 
 func TestNodeCtx_Start(t *testing.T) {
-	os.Setenv("ROCKSMQ_PATH", "/tmp/MilvusTest/FlowGraph/TestNodeStart")
+	t.Setenv("ROCKSMQ_PATH", "/tmp/MilvusTest/FlowGraph/TestNodeStart")
 	factory := dependency.NewDefaultFactory(true)
 
 	msgStream, _ := factory.NewMsgStream(context.TODO())

--- a/internal/util/metricsinfo/utils_test.go
+++ b/internal/util/metricsinfo/utils_test.go
@@ -12,41 +12,28 @@
 package metricsinfo
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestFillDeployMetricsWithEnv(t *testing.T) {
-	var err error
-
 	var m DeployMetrics
 
 	commit := "commit"
-	originalCommit := os.Getenv(GitCommitEnvKey)
-	err = os.Setenv(GitCommitEnvKey, commit)
-	assert.NoError(t, err)
+	t.Setenv(GitCommitEnvKey, commit)
 
 	deploy := "deploy"
-	originalDeploy := os.Getenv(DeployModeEnvKey)
-	err = os.Setenv(DeployModeEnvKey, deploy)
-	assert.NoError(t, err)
+	t.Setenv(DeployModeEnvKey, deploy)
 
 	version := "version"
-	originalVersion := os.Getenv(GitBuildTagsEnvKey)
-	err = os.Setenv(GitBuildTagsEnvKey, version)
-	assert.NoError(t, err)
+	t.Setenv(GitBuildTagsEnvKey, version)
 
 	goVersion := "go"
-	originalGoVersion := os.Getenv(MilvusUsedGoVersion)
-	err = os.Setenv(MilvusUsedGoVersion, goVersion)
-	assert.NoError(t, err)
+	t.Setenv(MilvusUsedGoVersion, goVersion)
 
 	buildTime := "build"
-	originalBuildTime := os.Getenv(MilvusBuildTimeEnvKey)
-	err = os.Setenv(MilvusBuildTimeEnvKey, buildTime)
-	assert.NoError(t, err)
+	t.Setenv(MilvusBuildTimeEnvKey, buildTime)
 
 	FillDeployMetricsWithEnv(&m)
 	assert.NotNil(t, m)
@@ -55,19 +42,4 @@ func TestFillDeployMetricsWithEnv(t *testing.T) {
 	assert.Equal(t, version, m.BuildVersion)
 	assert.Equal(t, goVersion, m.UsedGoVersion)
 	assert.Equal(t, buildTime, m.BuildTime)
-
-	err = os.Setenv(GitCommitEnvKey, originalCommit)
-	assert.NoError(t, err)
-
-	err = os.Setenv(DeployModeEnvKey, originalDeploy)
-	assert.NoError(t, err)
-
-	err = os.Setenv(GitBuildTagsEnvKey, originalVersion)
-	assert.NoError(t, err)
-
-	err = os.Setenv(MilvusUsedGoVersion, originalGoVersion)
-	assert.NoError(t, err)
-
-	err = os.Setenv(MilvusBuildTimeEnvKey, originalBuildTime)
-	assert.NoError(t, err)
 }

--- a/internal/util/paramtable/base_table_test.go
+++ b/internal/util/paramtable/base_table_test.go
@@ -109,7 +109,7 @@ func TestBaseTable_Get(t *testing.T) {
 
 func TestBaseTable_Pulsar(t *testing.T) {
 	//test PULSAR ADDRESS
-	os.Setenv("PULSAR_ADDRESS", "pulsar://localhost:6650")
+	t.Setenv("PULSAR_ADDRESS", "pulsar://localhost:6650")
 	baseParams.Init()
 
 	address := baseParams.Get("pulsar.address")
@@ -149,8 +149,8 @@ func TestBaseTable_Pulsar(t *testing.T) {
 // }
 
 func TestBaseTable_Env(t *testing.T) {
-	os.Setenv("milvus.test", "test")
-	os.Setenv("milvus.test.test2", "test2")
+	t.Setenv("milvus.test", "test")
+	t.Setenv("milvus.test.test2", "test2")
 
 	baseParams.Init()
 	result, _ := baseParams.Load("test")
@@ -159,11 +159,7 @@ func TestBaseTable_Env(t *testing.T) {
 	result, _ = baseParams.Load("test.test2")
 	assert.Equal(t, result, "test2")
 
-	err := os.Setenv("milvus.invalid=xxx", "test")
-	assert.Error(t, err)
-
-	err = os.Setenv("milvus.invalid", "xxx=test")
-	assert.NoError(t, err)
+	t.Setenv("milvus.invalid", "xxx=test")
 
 	baseParams.Init()
 	result, _ = baseParams.Load("invalid")

--- a/internal/util/paramtable/service_param_test.go
+++ b/internal/util/paramtable/service_param_test.go
@@ -12,7 +12,6 @@
 package paramtable
 
 import (
-	"os"
 	"testing"
 
 	"github.com/milvus-io/milvus/internal/util/metricsinfo"
@@ -52,10 +51,10 @@ func TestServiceParam(t *testing.T) {
 
 		// test UseEmbedEtcd
 		Params.Base.Save("etcd.use.embed", "true")
-		assert.Nil(t, os.Setenv(metricsinfo.DeployModeEnvKey, metricsinfo.ClusterDeployMode))
+		t.Setenv(metricsinfo.DeployModeEnvKey, metricsinfo.ClusterDeployMode)
 		assert.Panics(t, func() { Params.initUseEmbedEtcd() })
 
-		assert.Nil(t, os.Setenv(metricsinfo.DeployModeEnvKey, metricsinfo.StandaloneDeployMode))
+		t.Setenv(metricsinfo.DeployModeEnvKey, metricsinfo.StandaloneDeployMode)
 		Params.LoadCfgToMemory()
 	})
 


### PR DESCRIPTION
This PR replaces `os.Setenv` with `t.Setenv`. Starting from Go 1.17, we can use `t.Setenv` to set environment variable in test. The environment variable is automatically restored to its original value when the test and all its subtests complete. This ensures that each test does not start with leftover environment variables from previous completed tests.

```go
func TestFoo(t *testing.T) {
	// before
	key := "ENV"
	originalEnv := os.Getenv(key)
	
	if err := os.Setenv(key, "new value"); err != nil {
		t.Fatal(err)
	}
	defer func() {
		if err := os.Setenv(key, originalEnv); err != nil {
			t.Logf("failed to set env %s back to original value: %v", key, err)
		}
	}()
	
	// after
	t.Setenv(key, "new value")
}
```

Issue: https://github.com/milvus-io/milvus/issues/19650