### PR TITLE
[skip e2e]Disable rebuild centos env for code checker

### DIFF
--- a/.github/workflows/code-checker.yaml
+++ b/.github/workflows/code-checker.yaml
@@ -91,7 +91,6 @@ jobs:
           restore-keys: centos7-go-mod-
       - name: Code Check
         env:
-          CHECK_BUILDER: "1"
           OS_NAME: "centos7"
         run: |
            ./build/builder.sh /bin/bash -c "make install"


### PR DESCRIPTION
Signed-off-by: Jenny Li <jing.li@zilliz.com>
/kind improvement
Disable rebuild centos image to avoid download deps fail.