### PR TITLE
Clean unnecessary deps to make milvus

### DIFF
--- a/.github/workflows/code-checker.yaml
+++ b/.github/workflows/code-checker.yaml
@@ -144,4 +144,4 @@ jobs:
           CCACHE_DIR: ${{ github.workspace }}/.ccache
         run: |
           go version
-          mingw32-make verifiers build-go
+          mingw32-make verifiers milvus

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -126,7 +126,7 @@ Milvus depends on etcd, Pulsar and MinIO. Using Docker Compose to manage these i
 To build the Milvus project, run the following command:
 
 ```shell
-$ make all
+$ make milvus
 ```
 
 If this command succeed, you will now have an executable at `bin/milvus` off of your Milvus project directory.

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,17 @@ ARCH := $(shell arch)
 mode = Release
 disk_index = OFF
 
-all: build-cpp build-go
+
+milvus: build-cpp print-build-info
+ifeq ($(RELEASE), TRUE)
+	@echo "Update milvus/api version ..."
+	@(env bash $(PWD)/scripts/update_api_version.sh)
+endif
+	@echo "Building Milvus ..."
+	@source $(PWD)/scripts/setenv.sh && \
+		mkdir -p $(INSTALL_PATH) && go env -w CGO_ENABLED="1" && \
+		GO111MODULE=on $(GO) build -ldflags="-r $${RPATH} -X '$(OBJPREFIX).BuildTags=$(BUILD_TAGS)' -X '$(OBJPREFIX).BuildTime=$(BUILD_TIME)' -X '$(OBJPREFIX).GitCommit=$(GIT_COMMIT)' -X '$(OBJPREFIX).GoVersion=$(GO_VERSION)'" \
+		${APPLE_SILICON_FLAG} -o $(INSTALL_PATH)/milvus $(PWD)/cmd/main.go 1>/dev/null
 
 get-build-deps:
 	@(env bash $(PWD)/scripts/install_deps.sh)
@@ -96,16 +106,7 @@ print-build-info:
 	@echo "Git Commit: $(GIT_COMMIT)"
 	@echo "Go Version: $(GO_VERSION)"
 
-milvus: build-cpp print-build-info
-ifeq ($(RELEASE), TRUE)
-	@echo "Update milvus/api version ..."
-	@(env bash $(PWD)/scripts/update_api_version.sh)
-endif
-	@echo "Building Milvus ..."
-	@source $(PWD)/scripts/setenv.sh && \
-		mkdir -p $(INSTALL_PATH) && go env -w CGO_ENABLED="1" && \
-		GO111MODULE=on $(GO) build -ldflags="-r $${RPATH} -X '$(OBJPREFIX).BuildTags=$(BUILD_TAGS)' -X '$(OBJPREFIX).BuildTime=$(BUILD_TIME)' -X '$(OBJPREFIX).GitCommit=$(GIT_COMMIT)' -X '$(OBJPREFIX).GoVersion=$(GO_VERSION)'" \
-		${APPLE_SILICON_FLAG} -o $(INSTALL_PATH)/milvus $(PWD)/cmd/main.go 1>/dev/null
+
 
 embd-milvus: build-cpp-embd print-build-info
 	@echo "Building **Embedded** Milvus ..."
@@ -114,7 +115,7 @@ embd-milvus: build-cpp-embd print-build-info
 		GO111MODULE=on $(GO) build -ldflags="-r /tmp/milvus/lib/ -X '$(OBJPREFIX).BuildTags=$(BUILD_TAGS)' -X '$(OBJPREFIX).BuildTime=$(BUILD_TIME)' -X '$(OBJPREFIX).GitCommit=$(GIT_COMMIT)' -X '$(OBJPREFIX).GoVersion=$(GO_VERSION)'" \
 		${APPLE_SILICON_FLAG} -buildmode=c-shared -o $(INSTALL_PATH)/embd-milvus.so $(PWD)/pkg/embedded/embedded.go 1>/dev/null
 
-build-go: milvus
+
 
 build-cpp: 
 	@echo "Building Milvus cpp library ..."
@@ -227,7 +228,7 @@ docker: install
 	./build/build_image.sh
 
 # Build each component and install binary to $GOPATH/bin.
-install: all
+install: milvus
 	@echo "Installing binary to './bin'"
 	@mkdir -p $(GOPATH)/bin && cp -f $(PWD)/bin/milvus $(GOPATH)/bin/milvus
 	@mkdir -p $(LIBRARY_PATH) && cp -r -P $(PWD)/internal/core/output/lib/*.so* $(LIBRARY_PATH)

--- a/build/README.md
+++ b/build/README.md
@@ -115,7 +115,7 @@ docker exec -ti milvus_builder_1 bash
 Compile the project and run unit test, see details at the [DEVELOPMENT.md](../DEVELOPMENT.md)
 
 ```shell
-make all
+make milvus
 ```
 
 ```shell

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -46,7 +46,7 @@ $ make verifiers
 Compile milvus
 
 ```shell
-$ make all
+$ make milvus
 ```
 
 ## Install docker-compose


### PR DESCRIPTION
Signed-off-by: Jenny Li <jing.li@zilliz.com>
/kind improvement


The old logic is 
1. install = all + "put milvus into right place"
2. all = build-cpp +  build-go
3.  build-go = milvus
4. milvus = build-cpp + "code block to build-go"
 we can see `all` is just` milvus`.

The new logic is to remove the step 2,3
1. install=milvus + "put milvus into right place"
2. milvus = build-cpp + "code block to build-go"

And put milvus as default make target