### PR TITLE
Do not use DataCoord context when DataNode is handling import task

### DIFF
--- a/internal/datanode/mock_test.go
+++ b/internal/datanode/mock_test.go
@@ -279,7 +279,7 @@ func (ds *DataCoordFactory) BroadcastAlteredCollection(ctx context.Context, req 
 
 func (ds *DataCoordFactory) GetSegmentInfo(ctx context.Context, req *datapb.GetSegmentInfoRequest) (*datapb.GetSegmentInfoResponse, error) {
 	if ds.GetSegmentInfosError {
-		return nil, errors.New("mock error")
+		return nil, errors.New("mock get segment info error")
 	}
 	if ds.GetSegmentInfosNotSuccess {
 		return &datapb.GetSegmentInfoResponse{
@@ -1027,7 +1027,7 @@ func (m *RootCoordFactory) ReportImport(ctx context.Context, req *rootcoordpb.Im
 	if m.ReportImportErr {
 		return &commonpb.Status{
 			ErrorCode: commonpb.ErrorCode_Success,
-		}, fmt.Errorf("mock error")
+		}, fmt.Errorf("mock report import error")
 	}
 	if m.ReportImportNotSuccess {
 		return &commonpb.Status{

--- a/internal/util/importutil/import_wrapper.go
+++ b/internal/util/importutil/import_wrapper.go
@@ -61,6 +61,9 @@ const (
 	MaxTotalSizeInMemory = 2 * 1024 * 1024 * 1024 // 2GB
 )
 
+// ReportImportAttempts is the maximum # of attempts to retry when import fails.
+var ReportImportAttempts uint = 10
+
 type ImportWrapper struct {
 	ctx              context.Context            // for canceling parse process
 	cancel           context.CancelFunc         // for canceling parse process
@@ -342,9 +345,9 @@ func (p *ImportWrapper) reportPersisted() error {
 	// persist state task is valuable, retry more times in case fail this task only because of network error
 	reportErr := retry.Do(p.ctx, func() error {
 		return p.reportFunc(p.importResult)
-	}, retry.Attempts(10))
+	}, retry.Attempts(ReportImportAttempts))
 	if reportErr != nil {
-		log.Warn("import wrapper: fail to report import state to root coord", zap.Error(reportErr))
+		log.Warn("import wrapper: fail to report import state to RootCoord", zap.Error(reportErr))
 		return reportErr
 	}
 	return nil


### PR DESCRIPTION
So that when DataCoord is down, DataNode can still proceed.

/kind bug

issue: #19730

Signed-off-by: Yuchen Gao <yuchen.gao@zilliz.com>