### PR TITLE
Limit ioPoolSize to 32 to avoid overwhelming system at loading time

### DIFF
--- a/internal/querynode/segment_loader.go
+++ b/internal/querynode/segment_loader.go
@@ -956,7 +956,7 @@ func newSegmentLoader(
 	}
 
 	ioPoolSize := cpuNum * 2
-	if ioPoolSize < 32 {
+	if ioPoolSize > 32 {
 		ioPoolSize = 32
 	}
 	ioPool, err := concurrency.NewPool(ioPoolSize, ants.WithPreAlloc(true))


### PR DESCRIPTION
Currently, I see that each loading segment tasks are submitted to an I/O pool of size max(32,cpuNum*2), while I think it should be min(32,cpuNum*2). Using `max(32,cpuNum*2)` might overwhelm the system, affect to HA feature of the query nodes. Please review. Thanks.
Related issue: https://github.com/milvus-io/milvus/issues/19851