### PR TITLE
Fix mis-copy of chunk in make_with_timestamps

### DIFF
--- a/internal/core/src/segcore/SegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/SegmentSealedImpl.cpp
@@ -726,7 +726,7 @@ void
 SegmentSealedImpl::mask_with_timestamps(BitsetType& bitset_chunk, Timestamp timestamp) const {
     // TODO change the
     AssertInfo(insert_record_.timestamps_.num_chunk() == 1, "num chunk not equal to 1 for sealed segment");
-    auto timestamps_data = insert_record_.timestamps_.get_chunk(0);
+    const auto& timestamps_data = insert_record_.timestamps_.get_chunk(0);
     AssertInfo(timestamps_data.size() == get_row_count(), "Timestamp size not equal to row count");
     auto range = insert_record_.timestamp_index_.get_active_range(timestamp);
 


### PR DESCRIPTION
Signed-off-by: Li Liu <li.liu@zilliz.com>

issue: #19971 

`get_chunk` will return a `const Chunk&`. If we use `auto x = get_chunk()`, `auto` will be deducted to `Chunk` instead of `const Chunk&`. This will cause extra copy of chunks.

To try get the type of a variable, we can do: 
```
#include <boost/type_index.hpp>
using boost::typeindex::type_id_with_cvr;
std::cout << type_id_with_cvr<decltype(x)>().pretty_name() << std::endl;
```

For 6M SIFT data, this copy can add ~1-1.5 ms to the latency for each segment search.
#### Improvement
With this fix, we can gain some benefit on the performance. In my local test environment(3c8g):
**Serial**: 
latency: 11ms->6ms
**Parallel**: 
latency: 49ms->37ms 
qps: 200->260