### PR TITLE
Improve the `stop` command

### DIFF
--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 echo "Stopping milvus..."
-kill -9 $(ps -e | grep milvus | awk '{print $1}')
+PROCESS=$(ps -e | grep milvus | grep -v grep | awk '{print $1}')
+kill -9 $PROCESS
 echo "Milvus stopped"
 


### PR DESCRIPTION
/kind improvement
Should filter the `grep` process

previous:
<img width="703" alt="image" src="https://user-images.githubusercontent.com/21985684/197146895-11461498-fce5-4c7d-8c80-9d1e1b937341.png">
<img width="2061" alt="image" src="https://user-images.githubusercontent.com/21985684/197147654-7c452545-18b4-4efe-bfb7-e63b96692559.png">

improved:
![image](https://user-images.githubusercontent.com/21985684/197152419-dee592a7-2a19-4a90-8cf4-c965161188cf.png)



Signed-off-by: SimFG <bang.fu@zilliz.com>