### PR TITLE
[skip e2e] Add cache third party for ut

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -58,6 +58,12 @@ jobs:
           path: .docker/amd64-ubuntu${{ matrix.ubuntu }}-ccache
           key: ubuntu${{ matrix.ubuntu }}-ccache-${{ env.corehash }}
           restore-keys: ubuntu${{ matrix.ubuntu }}-ccache-
+      - name: Cache Third Party
+        uses: actions/cache@v3
+        with:
+          path: .docker/thirdparty
+          key: ubuntu${{ matrix.ubuntu }}-thirdparty-${{ hashFiles('internal/core/thirdparty/**') }}
+          restore-keys: ubuntu${{ matrix.ubuntu }}-thirdparty-
       - name: Cache Go Mod Volumes
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
Signed-off-by: Jenny Li <jing.li@zilliz.com>
/kind improvement
UT should cache third party the same as code checker https://github.com/milvus-io/milvus/blob/master/.github/workflows/code-checker.yaml#L48
