### PR TITLE
Refine merger in executor

### DIFF
--- a/internal/querycoordv2/meta/target_manager.go
+++ b/internal/querycoordv2/meta/target_manager.go
@@ -83,7 +83,7 @@ func (mgr *TargetManager) RemoveSegment(segmentID int64) {
 
 func (mgr *TargetManager) removeSegment(segmentID int64) {
 	delete(mgr.segments, segmentID)
-	log.Info("segment removed from targets")
+	log.Info("segment removed from targets", zap.Int64("segment", segmentID))
 }
 
 // AddSegment adds segment into target set,

--- a/internal/querycoordv2/task/executor.go
+++ b/internal/querycoordv2/task/executor.go
@@ -133,6 +133,7 @@ func (ex *Executor) scheduleRequests() {
 }
 
 func (ex *Executor) processMergeTask(mergeTask *LoadSegmentsTask) {
+	startTs := time.Now()
 	task := mergeTask.tasks[0]
 	action := task.Actions()[mergeTask.steps[0]]
 
@@ -177,7 +178,8 @@ func (ex *Executor) processMergeTask(mergeTask *LoadSegmentsTask) {
 		log.Warn("failed to load segment", zap.String("reason", status.GetReason()))
 		return
 	}
-	log.Info("load segments done")
+	elapsed := time.Since(startTs)
+	log.Info("load segments done", zap.Int64("taskID", task.ID()), zap.Duration("time taken", elapsed))
 }
 
 func (ex *Executor) removeAction(task Task, step int) {
@@ -275,7 +277,7 @@ func (ex *Executor) loadSegment(task *SegmentTask, step int) error {
 
 func (ex *Executor) releaseSegment(task *SegmentTask, step int) {
 	defer ex.removeAction(task, step)
-
+	startTs := time.Now()
 	action := task.Actions()[step].(*SegmentAction)
 	defer action.isReleaseCommitted.Store(true)
 
@@ -332,7 +334,8 @@ func (ex *Executor) releaseSegment(task *SegmentTask, step int) {
 		log.Warn("failed to release segment", zap.String("reason", status.GetReason()))
 		return
 	}
-	log.Info("release segment done")
+	elapsed := time.Since(startTs)
+	log.Info("release segment done", zap.Int64("taskID", task.ID()), zap.Duration("time taken", elapsed))
 }
 
 func (ex *Executor) executeDmChannelAction(task *ChannelTask, step int) {
@@ -347,7 +350,7 @@ func (ex *Executor) executeDmChannelAction(task *ChannelTask, step int) {
 
 func (ex *Executor) subDmChannel(task *ChannelTask, step int) error {
 	defer ex.removeAction(task, step)
-
+	startTs := time.Now()
 	action := task.Actions()[step].(*ChannelAction)
 	log := log.With(
 		zap.Int64("taskID", task.ID()),
@@ -407,13 +410,14 @@ func (ex *Executor) subDmChannel(task *ChannelTask, step int) error {
 		log.Warn("failed to subscribe DmChannel", zap.String("reason", status.GetReason()))
 		return err
 	}
-	log.Info("subscribe DmChannel done")
+	elapsed := time.Since(startTs)
+	log.Info("subscribe DmChannel done", zap.Int64("taskID", task.ID()), zap.Duration("time taken", elapsed))
 	return nil
 }
 
 func (ex *Executor) unsubDmChannel(task *ChannelTask, step int) error {
 	defer ex.removeAction(task, step)
-
+	startTs := time.Now()
 	action := task.Actions()[step].(*ChannelAction)
 	log := log.With(
 		zap.Int64("taskID", task.ID()),
@@ -444,5 +448,12 @@ func (ex *Executor) unsubDmChannel(task *ChannelTask, step int) error {
 		log.Warn("failed to unsubscribe DmChannel", zap.String("reason", status.GetReason()))
 		return err
 	}
+
+	elapsed := time.Since(startTs)
+	log.Info("unsubscribe DmChannel done", zap.Int64("taskID", task.ID()), zap.Duration("time taken", elapsed))
 	return nil
+}
+
+func (ex *Executor) TriggerNow() {
+	ex.merger.TriggerNow()
 }

--- a/internal/querycoordv2/task/merger_test.go
+++ b/internal/querycoordv2/task/merger_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/milvus-io/milvus/internal/proto/internalpb"
 	"github.com/milvus-io/milvus/internal/proto/querypb"
 	. "github.com/milvus-io/milvus/internal/querycoordv2/params"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -126,9 +127,14 @@ func (suite *MergerSuite) TestMerge() {
 		suite.merger.Add(NewLoadSegmentsTask(task, 0, suite.requests[segmentID]))
 	}
 
+	start := time.Now()
 	suite.merger.Start(ctx)
 	defer suite.merger.Stop()
+	// wait until
+	suite.merger.TriggerNow()
 	taskI := <-suite.merger.Chan()
+	elapsed := time.Since(start)
+	assert.True(suite.T(), elapsed < 10*time.Millisecond)
 	task := taskI.(*LoadSegmentsTask)
 	suite.Len(task.tasks, 3)
 	suite.Len(task.steps, 3)

--- a/internal/querycoordv2/task/scheduler.go
+++ b/internal/querycoordv2/task/scheduler.go
@@ -449,6 +449,9 @@ func (scheduler *taskScheduler) schedule(node int64) {
 	log.Info("processed tasks",
 		zap.Int("toRemoveNum", len(toRemove)))
 
+	// trigger executor to execute at once
+	scheduler.executor.TriggerNow()
+
 	log.Debug("process tasks related to node done",
 		zap.Int("processingTaskNum", scheduler.processQueue.Len()),
 		zap.Int("waitingTaskNum", scheduler.waitQueue.Len()),


### PR DESCRIPTION
fix #20024
simplify the executor segment load task merger and add more logs. 
Signed-off-by: xiaofan-luan <xiaofan.luan@zilliz.com>