### PR TITLE
Delete Creating bucket when create core/minioChunkManager

### DIFF
--- a/internal/core/src/storage/MinioChunkManager.cpp
+++ b/internal/core/src/storage/MinioChunkManager.cpp
@@ -100,9 +100,12 @@ MinioChunkManager::MinioChunkManager(const StorageConfig& storage_config)
             config, Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never, false);
     }
 
-    if (!BucketExists(storage_config.bucket_name)) {
-        CreateBucket(storage_config.bucket_name);
-    }
+    // TODO ::BucketExist and CreateBucket func not work, should be fixed
+    // index node has already tried to create bucket when receive index task if bucket not exist
+    // query node has already tried to create bucket during init stage if bucket not exist
+    //    if (!BucketExists(storage_config.bucket_name)) {
+    //        CreateBucket(storage_config.bucket_name);
+    //    }
 
     LOG_SEGCORE_INFO_C << "init MinioChunkManager with parameter[endpoint: '" << storage_config.address
                        << "', access_key:'" << storage_config.access_key_id << "', access_value:'"


### PR DESCRIPTION
issue: #20045 
/kind bug

https://github.com/milvus-io/milvus/blob/c551de8f724dbc6a0ca5e199f5ce60c6afb8ec11/internal/storage/minio_chunk_manager.go#L94-L101

index node has already tried to create bucket when receive index task if bucket not exist
https://github.com/milvus-io/milvus/blob/c551de8f724dbc6a0ca5e199f5ce60c6afb8ec11/internal/indexnode/indexnode_service.go#L57

query node has already tried to create bucket during init stage if bucket not exist
https://github.com/milvus-io/milvus/blob/c551de8f724dbc6a0ca5e199f5ce60c6afb8ec11/internal/querynode/query_node.go#L242

So comment createBucket code in core/minioChunkManager is safe for now

Signed-off-by: xige-16 <xi.ge@zilliz.com>