### PR TITLE
Make param names clearer in the `policy.go`

### DIFF
--- a/internal/datacoord/channel_manager.go
+++ b/internal/datacoord/channel_manager.go
@@ -765,10 +765,6 @@ func (c *ChannelManager) Reassign(nodeID UniqueID, channelName string) error {
 			zap.Int64("nodeID", nodeID),
 			zap.String("channel name", channelName))
 		updates.Add(nodeID, []*channel{ch})
-	} else {
-		if err := c.remove(nodeID, ch); err != nil {
-			return fmt.Errorf("failed to remove watch info: %v,%s", ch, err.Error())
-		}
 	}
 
 	log.Info("channel manager reassigning channels",
@@ -817,10 +813,6 @@ func (c *ChannelManager) CleanupAndReassign(nodeID UniqueID, channelName string)
 			zap.Int64("node ID", nodeID),
 			zap.String("channel name", channelName))
 		updates.Add(nodeID, []*channel{chToCleanUp})
-	} else {
-		if err := c.remove(nodeID, chToCleanUp); err != nil {
-			return fmt.Errorf("failed to remove watch info: %v,%s", chToCleanUp, err.Error())
-		}
 	}
 
 	log.Info("channel manager reassigning channels",


### PR DESCRIPTION
more detail: #20135

1. Make param names clearer in the `policy.go`, like:
the `avaNodeChannel ` means the `node` rather than `channel`
https://github.com/milvus-io/milvus/blob/e7df4993976884bc9f485663bc0a481857e6553a/internal/datacoord/policy.go#L55-L78
3. delete the repeated `remove` statement, the `reassign` policy has included the remove origin channels.
https://github.com/milvus-io/milvus/blob/11efa0bb5fd5ea521f103902bf40cb322c819915/internal/datacoord/channel_manager.go#L761-L772
https://github.com/milvus-io/milvus/blob/e7df4993976884bc9f485663bc0a481857e6553a/internal/datacoord/policy.go#L375-L425

Signed-off-by: SimFG <bang.fu@zilliz.com>