### PR TITLE
Fix `sessions` concurrency problem

### DIFF
--- a/internal/datacoord/session_manager.go
+++ b/internal/datacoord/session_manager.go
@@ -237,13 +237,11 @@ func (c *SessionManager) execReCollectSegmentStats(ctx context.Context, nodeID i
 func (c *SessionManager) GetCompactionState() map[int64]*datapb.CompactionStateResult {
 	wg := sync.WaitGroup{}
 	ctx := context.Background()
-	c.sessions.RLock()
-	wg.Add(len(c.sessions.data))
-	c.sessions.RUnlock()
 
 	plans := sync.Map{}
 	c.sessions.RLock()
 	for nodeID, s := range c.sessions.data {
+		wg.Add(1)
 		go func(nodeID int64, s *Session) {
 			defer wg.Done()
 			cli, err := s.GetOrCreateClient(ctx)


### PR DESCRIPTION
/kind improvement

If the lock is accepted by other methods and the length of the `c.session.data` is decreased after executing `wg.Add`, the method can't return because the `wg.Wait`

Signed-off-by: SimFG <bang.fu@zilliz.com>