### PR TITLE
[skip e2e] Disable ConcurrentBuilds for publish image to reducee resources

### DIFF
--- a/ci/jenkins/PublishImages.groovy
+++ b/ci/jenkins/PublishImages.groovy
@@ -16,6 +16,7 @@ pipeline {
         timestamps()
         timeout(time: 36, unit: 'MINUTES')
         // parallelsAlwaysFailFast()
+        disableConcurrentBuilds()
     }
 
     environment {


### PR DESCRIPTION


Signed-off-by: Jenny Li <jing.li@zilliz.com>
/kind improvement