### PR TITLE
Remove kafka consumer ack

### DIFF
--- a/internal/mq/msgstream/mqwrapper/kafka/kafka_consumer.go
+++ b/internal/mq/msgstream/mqwrapper/kafka/kafka_consumer.go
@@ -198,8 +198,9 @@ func (kc *Consumer) internalSeek(offset kafka.Offset, inclusive bool) error {
 }
 
 func (kc *Consumer) Ack(message mqwrapper.Message) {
-	kafkaMsg, _ := message.(*kafkaMessage)
-	kc.c.CommitMessage(kafkaMsg.msg)
+	// Do nothing
+	// Kafka retention mechanism only depends on retention configuration,
+	// it does not relate to the commit with consumer's offsets.
 }
 
 func (kc *Consumer) GetLatestMsgID() (mqwrapper.MessageID, error) {


### PR DESCRIPTION
issue #20212 #19633 

It is not worth committing offset during consuming messages and it also causes a significant performance issue.  

Signed-off-by: yun.zhang <yun.zhang@zilliz.com>