### PR TITLE
Use all() api for bitset check

### DIFF
--- a/internal/core/src/query/visitors/ExecPlanNodeVisitor.cpp
+++ b/internal/core/src/query/visitors/ExecPlanNodeVisitor.cpp
@@ -88,22 +88,23 @@ ExecPlanNodeVisitor::VectorVisitorImpl(VectorPlanNode& node) {
         return;
     }
 
-    BitsetType bitset_holder;
+    std::unique_ptr<BitsetType> bitset_holder;
     if (node.predicate_.has_value()) {
-        bitset_holder = ExecExprVisitor(*segment, active_count, timestamp_).call_child(*node.predicate_.value());
-        bitset_holder.flip();
+        bitset_holder = std::make_unique<BitsetType>(
+            ExecExprVisitor(*segment, active_count, timestamp_).call_child(*node.predicate_.value()));
+        bitset_holder->flip();
     } else {
-        bitset_holder.resize(active_count, false);
+        bitset_holder = std::make_unique<BitsetType>(active_count, false);
     }
-    segment->mask_with_timestamps(bitset_holder, timestamp_);
+    segment->mask_with_timestamps(*bitset_holder, timestamp_);
 
-    segment->mask_with_delete(bitset_holder, active_count, timestamp_);
+    segment->mask_with_delete(*bitset_holder, active_count, timestamp_);
     // if bitset_holder is all 1's, we got empty result
-    if (bitset_holder.count() == bitset_holder.size()) {
+    if (bitset_holder->all()) {
         search_result_opt_ = empty_search_result(num_queries, node.search_info_);
         return;
     }
-    BitsetView final_view = bitset_holder;
+    BitsetView final_view = *bitset_holder;
     segment->vector_search(node.search_info_, src_data, num_queries, timestamp_, final_view, search_result);
 
     search_result_opt_ = std::move(search_result);


### PR DESCRIPTION
Signed-off-by: Li Liu <li.liu@zilliz.com>

issue: #20463

From the perf of nq=1 serial execution:
<img width="1195" alt="截屏2022-11-10 下午1 17 28" src="https://user-images.githubusercontent.com/105927039/201007029-f211e9d7-2fd1-4663-ac62-9223e4f7de7b.png">

We can see the `Bitset` resize used ~1.39% CPU and `Bitset` count used ~4.39% CPU.

So we do two things:
1. Use `all()` API to check if all bits are set instead of `count() == size()`. The experiment shows that for a bitset with size of  500,000, `all()` takes ~0.00015ms and `count() == size()` takes 0.047ms. There is a 300 times difference. 
2. Use constructor + copy instead of `resize()`. Test shows that `resize()` takes ~0.041ms, and constructor + copy takes ~0.036ms. There is a 5% optimization.
