### PR TITLE
Reduce the memory used by load disk index

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -364,7 +364,7 @@ common:
     SearchListSize: 100
     PGCodeBudgetGBRatio: 0.125
     BuildNumThreadsRatio: 1.0
-    SearchCacheBudgetGBRatio: 0.125
+    SearchCacheBudgetGBRatio: 0.10
     LoadNumThreadRatio: 8.0
     BeamWidthRatio: 4.0
   # This parameter specify how many times the number of threads is the number of cores


### PR DESCRIPTION
/kind improvement

reduce cache size of loaded disk index in memory. This has a search performance penalty of less than 10%.

Signed-off-by: xige-16 <xi.ge@zilliz.com>