### PR TITLE
Reduce the memory used by load disk index

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -373,7 +373,7 @@ common:
     SearchListSize: 100
     PQCodeBudgetGBRatio: 0.125
     BuildNumThreadsRatio: 1.0
-    SearchCacheBudgetGBRatio: 0.125
+    SearchCacheBudgetGBRatio: 0.10
     LoadNumThreadRatio: 8.0
     BeamWidthRatio: 4.0
   # This parameter specify how many times the number of threads is the number of cores

--- a/internal/util/autoindex/bigdata_index.go
+++ b/internal/util/autoindex/bigdata_index.go
@@ -35,7 +35,7 @@ const (
 	BeamWidthRatioKey               = "beamwidth_ratio"
 	DefaultPQCodeBudgetGBRatio      = 0.125
 	DefaultBuildNumThreadsRatio     = 1.0
-	DefaultSearchCacheBudgetGBRatio = 0.125
+	DefaultSearchCacheBudgetGBRatio = 0.10
 	DefaultLoadNumThreadRatio       = 8.0
 	DefaultBeamWidthRatio           = 4.0
 )

--- a/internal/util/autoindex/bigdata_index_test.go
+++ b/internal/util/autoindex/bigdata_index_test.go
@@ -53,7 +53,7 @@ func TestBigDataIndex_parse(t *testing.T) {
 		assert.Equal(t, 1.0, extraParams.BuildNumThreadsRatio)
 		assert.Equal(t, 8.0, extraParams.LoadNumThreadRatio)
 		assert.Equal(t, 0.125, extraParams.PQCodeBudgetGBRatio)
-		assert.Equal(t, 0.125, extraParams.SearchCacheBudgetGBRatio)
+		assert.Equal(t, 0.10, extraParams.SearchCacheBudgetGBRatio)
 	})
 
 	t.Run("parse with nil", func(t *testing.T) {
@@ -62,7 +62,7 @@ func TestBigDataIndex_parse(t *testing.T) {
 		assert.Equal(t, 1.0, extraParams.BuildNumThreadsRatio)
 		assert.Equal(t, 8.0, extraParams.LoadNumThreadRatio)
 		assert.Equal(t, 0.125, extraParams.PQCodeBudgetGBRatio)
-		assert.Equal(t, 0.125, extraParams.SearchCacheBudgetGBRatio)
+		assert.Equal(t, 0.10, extraParams.SearchCacheBudgetGBRatio)
 	})
 
 	t.Run("new from json normal", func(t *testing.T) {
@@ -93,7 +93,7 @@ func TestBigDataIndex_parse(t *testing.T) {
 		assert.Equal(t, 1.0, extraParams.BuildNumThreadsRatio)
 		assert.Equal(t, 8.0, extraParams.LoadNumThreadRatio)
 		assert.Equal(t, 0.125, extraParams.PQCodeBudgetGBRatio)
-		assert.Equal(t, 0.125, extraParams.SearchCacheBudgetGBRatio)
+		assert.Equal(t, 0.10, extraParams.SearchCacheBudgetGBRatio)
 		assert.Equal(t, 4.0, extraParams.BeamWidthRatio)
 	})
 
@@ -107,7 +107,7 @@ func TestBigDataIndex_parse(t *testing.T) {
 		assert.Equal(t, 1.0, extraParams.BuildNumThreadsRatio)
 		assert.Equal(t, 8.0, extraParams.LoadNumThreadRatio)
 		assert.Equal(t, 0.125, extraParams.PQCodeBudgetGBRatio)
-		assert.Equal(t, 0.125, extraParams.SearchCacheBudgetGBRatio)
+		assert.Equal(t, 0.10, extraParams.SearchCacheBudgetGBRatio)
 		assert.Equal(t, 4.0, extraParams.BeamWidthRatio)
 	})
 

--- a/internal/util/indexparams/disk_index_params_test.go
+++ b/internal/util/indexparams/disk_index_params_test.go
@@ -45,7 +45,7 @@ func TestDiskIndexParams(t *testing.T) {
 
 		searchCacheBudgetGBRatio, err := strconv.ParseFloat(indexParams[SearchCacheBudgetRatioKey], 64)
 		assert.NoError(t, err)
-		assert.Equal(t, 0.125, searchCacheBudgetGBRatio)
+		assert.Equal(t, 0.10, searchCacheBudgetGBRatio)
 
 		loadNumThreadRatio, err := strconv.ParseFloat(indexParams[NumLoadThreadRatioKey], 64)
 		assert.NoError(t, err)

--- a/internal/util/paramtable/component_param.go
+++ b/internal/util/paramtable/component_param.go
@@ -43,7 +43,7 @@ const (
 	DefaultSearchListSize           = 100
 	DefaultPQCodeBudgetGBRatio      = 0.125
 	DefaultBuildNumThreadsRatio     = 1.0
-	DefaultSearchCacheBudgetGBRatio = 0.125
+	DefaultSearchCacheBudgetGBRatio = 0.10
 	DefaultLoadNumThreadRatio       = 8.0
 	DefaultBeamWidthRatio           = 4.0
 )


### PR DESCRIPTION
/kind improvement

reduce cache size of loaded disk index in memory. This has a search performance penalty of less than 10%.

Signed-off-by: xige-16 <xi.ge@zilliz.com>