### PR TITLE
Add RootPath field back

### DIFF
--- a/internal/log/config.go
+++ b/internal/log/config.go
@@ -26,6 +26,8 @@ const (
 
 // FileLogConfig serializes file log related config in toml/json.
 type FileLogConfig struct {
+	// Log rootpath
+	RootPath string `toml:"rootpath" json:"rootpath"`
 	// Log filename, leave empty to disable file log.
 	Filename string `toml:"filename" json:"filename"`
 	// Max size for a single file, in MB.

--- a/internal/util/logutil/logutil.go
+++ b/internal/util/logutil/logutil.go
@@ -162,6 +162,7 @@ func SetupLogger(cfg *log.Config) {
 		wrapper := &zapWrapper{logger, logLevel}
 		grpclog.SetLoggerV2(wrapper)
 
+		log.Info("Log directory", zap.String("configDir", cfg.File.RootPath))
 		log.Info("Set log file to ", zap.String("path", cfg.File.Filename))
 	})
 }


### PR DESCRIPTION
Signed-off-by: yah01 <yang.cen@zilliz.com>
/kind bug
#19927 removes a unused field, but a recent PR uses this field again