### PR TITLE
[Cherry-Pick] Fix checkFullLoaded always returns all partitions as unloaded

### DIFF
--- a/internal/proxy/task_statistic.go
+++ b/internal/proxy/task_statistic.go
@@ -342,8 +342,9 @@ func checkFullLoaded(ctx context.Context, qc types.QueryCoord, collectionName st
 		for i, percentage := range resp.GetInMemoryPercentages() {
 			if percentage >= 100 {
 				loadedPartitionIDs = append(loadedPartitionIDs, resp.GetPartitionIDs()[i])
+			} else {
+				unloadPartitionIDs = append(unloadPartitionIDs, resp.GetPartitionIDs()[i])
 			}
-			unloadPartitionIDs = append(unloadPartitionIDs, resp.GetPartitionIDs()[i])
 		}
 		return loadedPartitionIDs, unloadPartitionIDs, nil
 	}


### PR DESCRIPTION
Signed-off-by: yah01 <yang.cen@zilliz.com>
/kind bug
cherry-pick #20514 