### PR TITLE
Set queryCoord.loadTimeoutSeconds to 1h

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -176,7 +176,7 @@ queryCoord:
   channelTaskTimeout: 60000 # 1 minute
   segmentTaskTimeout: 120000 # 2 minute
   distPullInterval: 500
-  loadTimeoutSeconds: 600
+  loadTimeoutSeconds: 3600
   checkHandoffInterval: 5000
   taskMergeCap: 16
   enableActiveStandby: false  # Enable active-standby

--- a/internal/util/paramtable/component_param.go
+++ b/internal/util/paramtable/component_param.go
@@ -850,7 +850,7 @@ func (p *queryCoordConfig) initDistPullInterval() {
 }
 
 func (p *queryCoordConfig) initLoadTimeoutSeconds() {
-	timeout := p.Base.LoadWithDefault("queryCoord.loadTimeoutSeconds", "600")
+	timeout := p.Base.LoadWithDefault("queryCoord.loadTimeoutSeconds", "3600")
 	loadTimeout, err := strconv.ParseInt(timeout, 10, 64)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
/kind improvement

disk index load too slow, enlarge the queryCoord.loadTimeoutSeconds to avoid load fail

Signed-off-by: xige-16 <xi.ge@zilliz.com>