### PR TITLE
Fix manual balance may return TaskStale error

### DIFF
--- a/internal/util/errorutil/util.go
+++ b/internal/util/errorutil/util.go
@@ -65,3 +65,37 @@ func UnHealthReasonWithComponentStatesOrErr(role string, nodeID typeutil.UniqueI
 
 	return true, ""
 }
+
+type ErrorChecker func(err error) bool
+
+func AnyError() ErrorChecker {
+	return func(err error) bool {
+		return err != nil
+	}
+}
+
+func Any(errs ...error) ErrorChecker {
+	return func(err error) bool {
+		if err == nil {
+			return false
+		}
+
+		for i := range errs {
+			if errors.Is(err, errs[i]) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+func Exclude(errs ...error) ErrorChecker {
+	return func(err error) bool {
+		if err == nil {
+			return false
+		}
+
+		checker := Any(errs...)
+		return !checker(err)
+	}
+}


### PR DESCRIPTION
the balancing segments may be compacted, which causes TaskStale

Signed-off-by: yah01 <yang.cen@zilliz.com>

related #19386 