### PR TITLE
Limit MinDim to build disk index

### DIFF
--- a/internal/querynode/segment_loader.go
+++ b/internal/querynode/segment_loader.go
@@ -861,8 +861,7 @@ func GetStorageSizeByIndexInfo(indexInfo *querypb.FieldIndexInfo) (uint64, uint6
 	}
 	if indexType == indexparamcheck.IndexDISKANN {
 		neededMemSize := indexInfo.IndexSize / UsedDiskMemoryRatio
-		neededDiskSize := indexInfo.IndexSize - neededMemSize
-		return uint64(neededMemSize), uint64(neededDiskSize), nil
+		return uint64(neededMemSize), uint64(indexInfo.IndexSize), nil
 	}
 
 	return uint64(indexInfo.IndexSize), 0, nil

--- a/internal/util/indexparamcheck/conf_adapter.go
+++ b/internal/util/indexparamcheck/conf_adapter.go
@@ -59,7 +59,10 @@ const (
 	// DefaultMaxDim is the largest dimension supported in Milvus
 	DefaultMaxDim = 32768
 
-	DiskAnnMinDim = 1
+	// If Dim = 32 and raw vector data = 2G, query node need 24G disk space When loading the vectors' disk index
+	// If Dim = 2, and raw vector data = 2G, query node need 240G disk space When loading the vectors' disk index
+	// So DiskAnnMinDim should be greater than or equal to 32 to avoid running out of disk space
+	DiskAnnMinDim = 32
 	DiskAnnMaxDim = 1024
 
 	NgtMinEdgeSize = 1


### PR DESCRIPTION
/kind improvement

pick from v2.2.0

If Dim = 32 and raw vector data = 2G, query node need 24G disk space When loading the vectors' disk index
If Dim = 2, and raw vector data = 2G, query node need 240G disk space When loading the vectors' disk index
So DiskAnnMinDim should be greater than or equal to 32 to avoid running out of disk space

Signed-off-by: xige-16 [xi.ge@zilliz.com](mailto:xi.ge@zilliz.com)