### PR TITLE
Update h5py for e2e tests

### DIFF
--- a/tests/python_client/requirements.txt
+++ b/tests/python_client/requirements.txt
@@ -32,10 +32,10 @@ python-benedict==0.24.3
 timeout-decorator==0.5.0
 
 # version need to be consistent with protobuf used in pymilvus
-protobuf==3.17.1
+protobuf==3.19.0
 
 # for bulk load test
 minio==7.1.5
 
 # for benchmark
-h5py==3.1.0
+h5py==3.7.0


### PR DESCRIPTION
Signed-off-by: yah01 <yang.cen@zilliz.com>
/kind improvement
h5py v3.1.0 can't run with python version > 3.8, for now many systems have installed python3.10 by default.
Python3.6 is not supported ever.