### PR TITLE
Make e2e build to have conan cache

### DIFF
--- a/build/builder.sh
+++ b/build/builder.sh
@@ -34,7 +34,6 @@ gid=$(id -g)
 
 mkdir -p "${DOCKER_VOLUME_DIRECTORY:-.docker}/amd64-${OS_NAME}-ccache"
 mkdir -p "${DOCKER_VOLUME_DIRECTORY:-.docker}/amd64-${OS_NAME}-go-mod"
-mkdir -p "${DOCKER_VOLUME_DIRECTORY:-.docker}/thirdparty"
 mkdir -p "${DOCKER_VOLUME_DIRECTORY:-.docker}/amd64-${OS_NAME}-vscode-extensions"
 mkdir -p "${DOCKER_VOLUME_DIRECTORY:-.docker}/amd64-${OS_NAME}-conan"
 chmod -R 777 "${DOCKER_VOLUME_DIRECTORY:-.docker}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,12 +27,11 @@ services:
       PULSAR_ADDRESS: ${PULSAR_ADDRESS}
       ETCD_ENDPOINTS: ${ETCD_ENDPOINTS}
       MINIO_ADDRESS: ${MINIO_ADDRESS}
-      CUSTOM_THIRDPARTY_PATH: /tmp/thirdparty
+      CONAN_USER_HOME: /home/milvus
     volumes: &builder-volumes
       - .:/go/src/github.com/milvus-io/milvus:delegated
       - ${DOCKER_VOLUME_DIRECTORY:-.docker}/${IMAGE_ARCH}-${OS_NAME}-ccache:/ccache:delegated
       - ${DOCKER_VOLUME_DIRECTORY:-.docker}/${IMAGE_ARCH}-${OS_NAME}-go-mod:/go/pkg/mod:delegated
-      - ${DOCKER_VOLUME_DIRECTORY:-.docker}/thirdparty:/tmp/thirdparty:delegated
       - ${DOCKER_VOLUME_DIRECTORY:-.docker}/${IMAGE_ARCH}-${OS_NAME}-vscode-extensions:/home/milvus/.vscode-server/extensions:delegated
       - ${DOCKER_VOLUME_DIRECTORY:-.docker}/${IMAGE_ARCH}-${OS_NAME}-conan:/home/milvus/.conan:delegated
     working_dir: '/go/src/github.com/milvus-io/milvus'


### PR DESCRIPTION
Signed-off-by: Jenny Li <jing.li@zilliz.com>
/kind improvement

1.Use CONAN_USER_HOME  to specify the path for conan cache
2.remove /tmp/thirdparty for using conan instead