### PR TITLE
Fix GroupChecker unit testcase may fail

### DIFF
--- a/internal/util/timerecord/group_checker_test.go
+++ b/internal/util/timerecord/group_checker_test.go
@@ -26,7 +26,7 @@ import (
 func TestGroupChecker(t *testing.T) {
 	groupName := `test_group`
 	signal := make(chan []string, 1)
-	gc1 := GetGroupChecker(groupName, 10*time.Millisecond, func(list []string) {
+	gc1 := GetGroupChecker(groupName, 500*time.Millisecond, func(list []string) {
 		signal <- list
 	})
 	gc1.Check("1")
@@ -35,7 +35,7 @@ func TestGroupChecker(t *testing.T) {
 	})
 	gc2.Check("2")
 
-	assert.Equal(t, 10*time.Millisecond, gc2.d)
+	assert.Equal(t, 500*time.Millisecond, gc2.d)
 
 	list := <-signal
 	assert.ElementsMatch(t, []string{"1", "2"}, list)


### PR DESCRIPTION
10ms period is too short, the group checker may schedule before the second value stored

Signed-off-by: yah01 <yang.cen@zilliz.com>
/kind improvement