### PR TITLE
Setup lastSyncTs when add segment to avoid sync next timetick

### DIFF
--- a/internal/datanode/channel_meta.go
+++ b/internal/datanode/channel_meta.go
@@ -209,6 +209,7 @@ func (c *ChannelMeta) addSegment(req addSegmentReq) error {
 		historyInsertBuf: make([]*BufferData, 0),
 		historyDeleteBuf: make([]*DelDataBuf, 0),
 		startPos:         req.startPos,
+		lastSyncTs:       req.recoverTs,
 	}
 	seg.setType(req.segType)
 	// Set up pk stats


### PR DESCRIPTION
Use recoverTS as lastSync when addSegment to avoid segment being synced next timetick
Related to #20663

/kind improvement


Signed-off-by: Congqi Xia <congqi.xia@zilliz.com>