### PR TITLE
Refine search logs in querynode

### DIFF
--- a/internal/querynode/reduce_test.go
+++ b/internal/querynode/reduce_test.go
@@ -93,7 +93,7 @@ func TestReduce_AllFunc(t *testing.T) {
 	searchReq.timestamp = 0
 	assert.NoError(t, err)
 
-	searchResult, err := segment.search(searchReq)
+	searchResult, err := segment.search(ctx, searchReq)
 	assert.NoError(t, err)
 
 	err = checkSearchResult(nq, plan, searchResult)

--- a/internal/querynode/search.go
+++ b/internal/querynode/search.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"sync"
 
+	"go.uber.org/zap"
+
 	"github.com/milvus-io/milvus-proto/go-api/commonpb"
 	"github.com/milvus-io/milvus/internal/log"
 	"github.com/milvus-io/milvus/internal/metrics"
@@ -31,16 +33,23 @@ import (
 // searchOnSegments performs search on listed segments
 // all segment ids are validated before calling this function
 func searchSegments(ctx context.Context, replica ReplicaInterface, segType segmentType, searchReq *searchRequest, segIDs []UniqueID) ([]*SearchResult, error) {
-	// results variables
-	resultCh := make(chan *SearchResult, len(segIDs))
-	errs := make([]error, len(segIDs))
+	var (
+		// results variables
+		resultCh = make(chan *SearchResult, len(segIDs))
+		errs     = make([]error, len(segIDs))
+		wg       sync.WaitGroup
+
+		// For log only
+		mu                   sync.Mutex
+		segmentsWithoutIndex []UniqueID
+	)
+
 	searchLabel := metrics.SealedSegmentLabel
 	if segType == commonpb.SegmentState_Growing {
 		searchLabel = metrics.GrowingSegmentLabel
 	}
 
 	// calling segment search in goroutines
-	var wg sync.WaitGroup
 	for i, segID := range segIDs {
 		wg.Add(1)
 		go func(segID UniqueID, i int) {
@@ -53,9 +62,15 @@ func searchSegments(ctx context.Context, replica ReplicaInterface, segType segme
 				log.Error(err.Error()) // should not happen but still ignore it since the result is still correct
 				return
 			}
+
+			if !seg.hasLoadIndexForIndexedField(searchReq.searchFieldID) {
+				mu.Lock()
+				segmentsWithoutIndex = append(segmentsWithoutIndex, segID)
+				mu.Unlock()
+			}
 			// record search time
 			tr := timerecord.NewTimeRecorder("searchOnSegments")
-			searchResult, err := seg.search(searchReq)
+			searchResult, err := seg.search(ctx, searchReq)
 			errs[i] = err
 			resultCh <- searchResult
 			// update metrics
@@ -76,6 +91,10 @@ func searchSegments(ctx context.Context, replica ReplicaInterface, segType segme
 			deleteSearchResults(searchResults)
 			return nil, err
 		}
+	}
+
+	if len(segmentsWithoutIndex) > 0 {
+		log.Ctx(ctx).Info("search growing/sealed segments without indexes", zap.Int64s("segmentIDs", segmentsWithoutIndex))
 	}
 
 	return searchResults, nil

--- a/internal/querynode/segment.go
+++ b/internal/querynode/segment.go
@@ -305,7 +305,7 @@ func (s *Segment) getMemSize() int64 {
 	return int64(memoryUsageInBytes)
 }
 
-func (s *Segment) search(searchReq *searchRequest) (*SearchResult, error) {
+func (s *Segment) search(ctx context.Context, searchReq *searchRequest) (*SearchResult, error) {
 	/*
 		CStatus
 		Search(void* plan,
@@ -327,7 +327,7 @@ func (s *Segment) search(searchReq *searchRequest) (*SearchResult, error) {
 
 	loadIndex := s.hasLoadIndexForIndexedField(searchReq.searchFieldID)
 	var searchResult SearchResult
-	log.Debug("start do search on segment",
+	log.Ctx(ctx).Debug("start do search on segment",
 		zap.Int64("msgID", searchReq.msgID),
 		zap.Int64("segmentID", s.segmentID),
 		zap.String("segmentType", s.segmentType.String()),
@@ -341,7 +341,7 @@ func (s *Segment) search(searchReq *searchRequest) (*SearchResult, error) {
 	if err := HandleCStatus(&status, "Search failed"); err != nil {
 		return nil, err
 	}
-	log.Debug("do search on segment done",
+	log.Ctx(ctx).Debug("do search on segment done",
 		zap.Int64("msgID", searchReq.msgID),
 		zap.Int64("segmentID", s.segmentID),
 		zap.String("segmentType", s.segmentType.String()),

--- a/internal/querynode/segment_test.go
+++ b/internal/querynode/segment_test.go
@@ -424,7 +424,7 @@ func TestSegment_segmentSearch(t *testing.T) {
 	req, err := parseSearchRequest(plan, placeGroupByte)
 	assert.NoError(t, err)
 
-	searchResult, err := segment.search(req)
+	searchResult, err := segment.search(ctx, req)
 	assert.NoError(t, err)
 
 	err = checkSearchResult(nq, plan, searchResult)

--- a/internal/querynode/validate.go
+++ b/internal/querynode/validate.go
@@ -47,7 +47,7 @@ func validateOnHistoricalReplica(ctx context.Context, replica ReplicaInterface, 
 		}
 	}
 
-	log.Ctx(ctx).Debug("read target partitions", zap.Int64("collectionID", collectionID), zap.Int64s("partitionIDs", searchPartIDs))
+	log.Ctx(ctx).Debug("read target partitions on historical replica", zap.Int64("collectionID", collectionID), zap.Int64s("partitionIDs", searchPartIDs))
 	col, err2 := replica.getCollectionByID(collectionID)
 	if err2 != nil {
 		return searchPartIDs, segmentIDs, err2
@@ -55,8 +55,8 @@ func validateOnHistoricalReplica(ctx context.Context, replica ReplicaInterface, 
 
 	// all partitions have been released
 	if len(searchPartIDs) == 0 && col.getLoadType() == loadTypePartition {
-		return searchPartIDs, segmentIDs, errors.New("partitions have been released , collectionID = " +
-			fmt.Sprintln(collectionID) + "target partitionIDs = " + fmt.Sprintln(searchPartIDs))
+		return searchPartIDs, segmentIDs,
+			fmt.Errorf("partitions have been released , collectionID = %d, target partitionID = %v", collectionID, searchPartIDs)
 	}
 	if len(searchPartIDs) == 0 && col.getLoadType() == loadTypeCollection {
 		return searchPartIDs, segmentIDs, nil
@@ -112,7 +112,7 @@ func validateOnStreamReplica(ctx context.Context, replica ReplicaInterface, coll
 		}
 	}
 
-	log.Ctx(ctx).Debug("read target partitions", zap.Int64("collectionID", collectionID), zap.Int64s("partitionIDs", searchPartIDs))
+	log.Ctx(ctx).Debug("read target partitions on stream replica", zap.Int64("collectionID", collectionID), zap.Int64s("partitionIDs", searchPartIDs))
 	col, err2 := replica.getCollectionByID(collectionID)
 	if err2 != nil {
 		return searchPartIDs, segmentIDs, err2
@@ -120,19 +120,13 @@ func validateOnStreamReplica(ctx context.Context, replica ReplicaInterface, coll
 
 	// all partitions have been released
 	if len(searchPartIDs) == 0 && col.getLoadType() == loadTypePartition {
-		return searchPartIDs, segmentIDs, errors.New("partitions have been released , collectionID = " +
-			fmt.Sprintln(collectionID) + "target partitionIDs = " + fmt.Sprintln(searchPartIDs))
+		return searchPartIDs, segmentIDs,
+			fmt.Errorf("partitions have been released , collectionID = %d, target partitionIDs = %v", collectionID, searchPartIDs)
 	}
 	if len(searchPartIDs) == 0 && col.getLoadType() == loadTypeCollection {
 		return searchPartIDs, segmentIDs, nil
 	}
 
 	segmentIDs, err = replica.getSegmentIDsByVChannel(searchPartIDs, vChannel, segmentTypeGrowing)
-	log.Ctx(ctx).Debug("validateOnStreamReplica getSegmentIDsByVChannel",
-		zap.Any("collectionID", collectionID),
-		zap.Any("vChannel", vChannel),
-		zap.Any("partitionIDs", searchPartIDs),
-		zap.Any("segmentIDs", segmentIDs),
-		zap.Error(err))
-	return searchPartIDs, segmentIDs, nil
+	return searchPartIDs, segmentIDs, err
 }

--- a/internal/util/timerecord/time_recorder.go
+++ b/internal/util/timerecord/time_recorder.go
@@ -91,7 +91,7 @@ func (tr *TimeRecorder) CtxElapse(ctx context.Context, msg string) time.Duration
 
 func (tr *TimeRecorder) printTimeRecord(ctx context.Context, msg string, span time.Duration) {
 	log.Ctx(ctx).WithOptions(zap.AddCallerSkip(2)).
-		Debug(fmt.Sprintf("timerecorder %s: record elapsed duration", tr.header),
+		Debug(fmt.Sprintf("tr/%s", tr.header),
 			zap.String("msg", msg),
 			zap.Duration("duration", span),
 		)


### PR DESCRIPTION
- Make sure all logs logging with ctx
- Add an info log for searching on not-indexed segments
- Separate log prefix of shardleader and non-shardleaders

See also: #20975

Signed-off-by: yangxuan <xuan.yang@zilliz.com>