### PR TITLE
Disable glibc  memory allocator for arrow

### DIFF
--- a/internal/core/conanfile.py
+++ b/internal/core/conanfile.py
@@ -26,6 +26,8 @@ class MilvusConan(ConanFile):
         "arrow:parquet": True,
         "arrow:compute": True,
         "arrow:with_zstd": True,
+        "arrow:shared": False,
+        "arrow:with_mimalloc": True,
         "aws-sdk-cpp:text-to-speech": False,
         "aws-sdk-cpp:transfer": False,
         "gtest:build_gmock": False,
@@ -34,12 +36,12 @@ class MilvusConan(ConanFile):
     should_build = False
 
     def configure(self):
-
         # Macos M1 cannot use jemalloc
         if self.settings.os != "Macos" or self.settings.arch in ("x86_64", "x86"):
-            self.requires("jemalloc/5.3.0")
+            self.requires("jemalloc/5.2.1")
 
     def imports(self):
+        self.copy("librocksdb.a", "../lib", "lib")
         self.copy("*.dylib", "../lib", "lib")
         self.copy("*.dll", "../lib", "lib")
         self.copy("*.so*", "../lib", "lib")

--- a/internal/datacoord/server_test.go
+++ b/internal/datacoord/server_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/schemapb"
+
 	"github.com/milvus-io/milvus/internal/common"
 	etcdkv "github.com/milvus-io/milvus/internal/kv/etcd"
 	"github.com/milvus-io/milvus/internal/log"
@@ -3236,6 +3237,7 @@ func TestDataCoord_Import(t *testing.T) {
 	t.Run("no datanode available", func(t *testing.T) {
 		svr := newTestServer(t, nil)
 		Params.BaseTable.Save("minio.address", "minio:9000")
+		defer Params.BaseTable.Reset("minio.address")
 		resp, err := svr.Import(svr.ctx, &datapb.ImportTaskRequest{
 			ImportTask: &datapb.ImportTask{
 				CollectionId: 100,


### PR DESCRIPTION
issue #21177 
use mimalloc to replace glibc and jemalloc
Signed-off-by: yun.zhang <yun.zhang@zilliz.com>