### PR TITLE
Improve datacoord log

### DIFF
--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -124,7 +124,7 @@ func (s *Server) Flush(ctx context.Context, req *datapb.FlushRequest) (*datapb.F
 		zap.Int64("collectionID", req.GetCollectionID()),
 		zap.Int64s("sealSegments", sealedSegmentIDs),
 		zap.Int64s("flushSegments", flushSegmentIDs),
-		zap.Int64("timeOfSeal", timeOfSeal.Unix()))
+		zap.Time("timeOfSeal", timeOfSeal))
 	resp.Status.ErrorCode = commonpb.ErrorCode_Success
 	resp.DbID = req.GetDbID()
 	resp.CollectionID = req.GetCollectionID()
@@ -1136,7 +1136,7 @@ func (s *Server) GetFlushState(ctx context.Context, req *milvuspb.GetFlushStateR
 	}
 
 	if len(unflushed) != 0 {
-		log.Info("DataCoord receive GetFlushState request, Flushed is false", zap.Int64s("segmentIDs", unflushed), zap.Int("len", len(unflushed)))
+		log.RatedInfo(10, "DataCoord receive GetFlushState request, Flushed is false", zap.Int64s("segmentIDs", unflushed), zap.Int("len", len(unflushed)))
 		resp.Flushed = false
 	} else {
 		log.Info("DataCoord receive GetFlushState request, Flushed is true", zap.Int64s("segmentIDs", req.GetSegmentIDs()), zap.Int("len", len(req.GetSegmentIDs())))


### PR DESCRIPTION
Signed-off-by: bigsheeper <yihao.dai@zilliz.com>

/kind improvement

1. unix time is not readable:
![image](https://user-images.githubusercontent.com/42060877/209933831-171d82ff-c676-4523-9417-73f4df29770c.png)

2. There are too many `GetFlushState xxx false` log printed if flush gets stuck, and log file would be hundreds MB size:
![image](https://user-images.githubusercontent.com/42060877/209933944-222fc18f-3fd3-4a8d-99ea-e68926da6bd9.png)
