### PR TITLE
Use tt msg stream for consume delete msg

### DIFF
--- a/internal/querynode/mock_test.go
+++ b/internal/querynode/mock_test.go
@@ -1903,7 +1903,7 @@ func (mm *mockMsgStreamFactory) NewMsgStream(ctx context.Context) (msgstream.Msg
 }
 
 func (mm *mockMsgStreamFactory) NewTtMsgStream(ctx context.Context) (msgstream.MsgStream, error) {
-	return nil, nil
+	return mm.mockMqStream, nil
 }
 
 func (mm *mockMsgStreamFactory) NewQueryMsgStream(ctx context.Context) (msgstream.MsgStream, error) {

--- a/internal/querynode/segment_loader.go
+++ b/internal/querynode/segment_loader.go
@@ -710,7 +710,7 @@ func (loader *segmentLoader) loadDeltaLogs(ctx context.Context, segment *Segment
 func (loader *segmentLoader) FromDmlCPLoadDelete(ctx context.Context, collectionID int64, position *internalpb.MsgPosition,
 	segmentIDs []int64) error {
 	startTs := time.Now()
-	stream, err := loader.factory.NewMsgStream(ctx)
+	stream, err := loader.factory.NewTtMsgStream(ctx)
 	if err != nil {
 		return err
 	}
@@ -765,6 +765,7 @@ func (loader *segmentLoader) FromDmlCPLoadDelete(ctx context.Context, collection
 		zap.String("seekPos", position.String()),
 		zap.Any("lastMsg", lastMsgID), // use any in case of nil
 	)
+
 	hasMore := true
 	for hasMore {
 		select {
@@ -804,21 +805,19 @@ func (loader *segmentLoader) FromDmlCPLoadDelete(ctx context.Context, collection
 						return err
 					}
 				}
-
-				ret, err := lastMsgID.LessOrEqualThan(tsMsg.Position().MsgID)
-				if err != nil {
-					log.Warn("check whether current MsgID less than last MsgID failed",
-						zap.Int64("collectionID", collectionID),
-						zap.String("channel", pChannelName),
-						zap.Error(err),
-					)
-					return err
-				}
-
-				if ret {
-					hasMore = false
-					break
-				}
+			}
+			ret, err := lastMsgID.LessOrEqualThan(msgPack.EndPositions[0].MsgID)
+			if err != nil {
+				log.Warn("check whether current MsgID less than last MsgID failed",
+					zap.Int64("collectionID", collectionID),
+					zap.String("channel", pChannelName),
+					zap.Error(err),
+				)
+				return err
+			}
+			if ret {
+				hasMore = false
+				break
 			}
 		}
 	}

--- a/internal/querynode/segment_loader_test.go
+++ b/internal/querynode/segment_loader_test.go
@@ -827,7 +827,9 @@ func testConsumingDeltaMsg(ctx context.Context, t *testing.T, position *msgstrea
 		msgChan <- nil
 		deleteMsg1 := genDeleteMsg(defaultCollectionID+1, schemapb.DataType_Int64, defaultDelLength)
 		deleteMsg2 := genDeleteMsg(defaultCollectionID, schemapb.DataType_Int64, defaultDelLength)
-		msgChan <- &msgstream.MsgPack{Msgs: []msgstream.TsMsg{deleteMsg1, deleteMsg2}}
+		msgChan <- &msgstream.MsgPack{Msgs: []msgstream.TsMsg{deleteMsg1, deleteMsg2},
+			StartPositions: []*internalpb.MsgPosition{genMsgStreamBaseMsg().MsgPosition},
+			EndPositions:   []*internalpb.MsgPosition{genMsgStreamBaseMsg().MsgPosition}}
 	}
 	if closedStream {
 		close(msgChan)


### PR DESCRIPTION
Signed-off-by: cai.zhang <cai.zhang@zilliz.com>
issue: #21399 


1. The checkpoint of VChannel will point to the position of the entity message, not only tt msg.
2. Seek inclusive is false of msgStream, it will drop the first msg. (TtMsgStream inclusive is true)
3. So if the VChannel checkpoint is point the delete msg, it will lost the delete msg when loading.