### PR TITLE
fix flaws found in the process of ideal benchmark(#21504)

### DIFF
--- a/internal/querycoordv2/checkers/balance_checker.go
+++ b/internal/querycoordv2/checkers/balance_checker.go
@@ -42,6 +42,9 @@ func (b *BalanceChecker) Description() string {
 
 func (b *BalanceChecker) Check(ctx context.Context) []task.Task {
 	ret := make([]task.Task, 0)
+	if !Params.QueryCoordCfg.AutoBalance {
+		return ret
+	}
 	segmentPlans, channelPlans := b.Balance.Balance()
 
 	tasks := balance.CreateSegmentTasksFromPlans(ctx, b.ID(), Params.QueryCoordCfg.SegmentTaskTimeout, segmentPlans)

--- a/internal/querynode/shard_cluster.go
+++ b/internal/querynode/shard_cluster.go
@@ -833,9 +833,9 @@ func (sc *ShardCluster) GetStatistics(ctx context.Context, req *querypb.GetStati
 	segAllocs, versionID := sc.segmentAllocations(req.GetReq().GetPartitionIDs())
 	defer sc.finishUsage(versionID)
 
-	log.Info("cluster segment distribution", zap.Int("len", len(segAllocs)))
+	log.Debug("cluster segment distribution", zap.Int("len", len(segAllocs)))
 	for nodeID, segmentIDs := range segAllocs {
-		log.Info("segments distribution", zap.Int64("nodeID", nodeID), zap.Int64s("segments", segmentIDs))
+		log.Debug("segments distribution", zap.Int64("nodeID", nodeID), zap.Int64s("segments", segmentIDs))
 	}
 
 	// concurrent visiting nodes
@@ -924,9 +924,9 @@ func (sc *ShardCluster) Search(ctx context.Context, req *querypb.SearchRequest, 
 	segAllocs, versionID := sc.segmentAllocations(req.GetReq().GetPartitionIDs())
 	defer sc.finishUsage(versionID)
 
-	log.Info("cluster segment distribution", zap.Int("len", len(segAllocs)), zap.Int64s("partitionIDs", req.GetReq().GetPartitionIDs()))
+	log.Debug("cluster segment distribution", zap.Int("len", len(segAllocs)), zap.Int64s("partitionIDs", req.GetReq().GetPartitionIDs()))
 	for nodeID, segmentIDs := range segAllocs {
-		log.Info("segments distribution", zap.Int64("nodeID", nodeID), zap.Int64s("segments", segmentIDs))
+		log.Debug("segments distribution", zap.Int64("nodeID", nodeID), zap.Int64s("segments", segmentIDs))
 	}
 
 	// concurrent visiting nodes


### PR DESCRIPTION
1. enable paramter autoBalance
2. adjust inappropriate log info when searching in shardcluster
issue: #21504 

Signed-off-by: MrPresent-Han <chun.han@zilliz.com>
