### PR TITLE
[Cherry-Pick] Add With method for MLogger (#21530)

### DIFF
--- a/internal/log/mlogger.go
+++ b/internal/log/mlogger.go
@@ -6,6 +6,14 @@ type MLogger struct {
 	*zap.Logger
 }
 
+// With encapsulates zap.Logger With method to return MLogger instance.
+func (l *MLogger) With(fields ...zap.Field) *MLogger {
+	nl := &MLogger{
+		Logger: l.Logger.With(fields...),
+	}
+	return nl
+}
+
 func (l *MLogger) RatedDebug(cost float64, msg string, fields ...zap.Field) bool {
 	if R().CheckCredit(cost) {
 		l.Debug(msg, fields...)


### PR DESCRIPTION
Cherry pick from master #21530 
Add `With` method to return `MLogger` instead of `zap.Logger` to enable `RatedLog` after `With`

/kind improvement

Signed-off-by: Congqi Xia <congqi.xia@zilliz.com>