### PR TITLE
Update h5py for e2e tests

### DIFF
--- a/tests/python_client/requirements.txt
+++ b/tests/python_client/requirements.txt
@@ -35,7 +35,7 @@ timeout-decorator==0.5.0
 minio==7.1.5
 
 # for benchmark
-h5py==3.1.0
+h5py==3.7.0
 
 # for log
 loguru==0.6.0


### PR DESCRIPTION
Signed-off-by: yah01 <yang.cen@zilliz.com>
/kind improvement
h5py v3.1.0 can't run with python version > 3.8, for now many systems have installed python3.10 by default.
Python3.6 is not supported ever.