### PR TITLE
Refine log when initialize dml channels

### DIFF
--- a/internal/rootcoord/dml_channels.go
+++ b/internal/rootcoord/dml_channels.go
@@ -172,7 +172,9 @@ func newDmlChannels(ctx context.Context, factory msgstream.Factory, chanNamePref
 	}
 
 	heap.Init(&d.channelsHeap)
-	log.Debug("init dml channels", zap.Int64("num", chanNum))
+
+	log.Info("init dml channels", zap.String("prefix", chanNamePrefix), zap.Int64("num", chanNum))
+
 	metrics.RootCoordNumOfDMLChannel.Add(float64(chanNum))
 	metrics.RootCoordNumOfMsgStream.Add(float64(chanNum))
 


### PR DESCRIPTION
issue: #21710 
This log level should be `INFO`, and `prefix` is necessary to be printed also.
Signed-off-by: longjiquan <jiquan.long@zilliz.com>