### PR TITLE
Fix miss to throw exception when failed to create dir (#21886)

### DIFF
--- a/internal/core/src/storage/LocalChunkManager.cpp
+++ b/internal/core/src/storage/LocalChunkManager.cpp
@@ -170,7 +170,7 @@ LocalChunkManager::CreateDir(const std::string& dir) {
     boost::filesystem::path dirPath(dir);
     auto create_success = boost::filesystem::create_directories(dirPath);
     if (!create_success) {
-        CreateFileException("create dir failed" + dir);
+        throw CreateFileException("create dir failed" + dir);
     }
 }
 


### PR DESCRIPTION
Signed-off-by: yah01 <yang.cen@zilliz.com>
/kind bug
fix https://github.com/milvus-io/milvus/issues/21885
see also #21886 