### PR TITLE
Modify default value of some configurations

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -273,7 +273,7 @@ dataCoord:
   enableActiveStandby: false  # Enable active-standby
 
   channel:
-    maxWatchDuration: 60 # Timeout on watching channels (in seconds). Default 60 seconds.
+    maxWatchDuration: 600 # Timeout on watching channels (in seconds). Default 600 seconds.
 
   segment:
     maxSize: 512 # Maximum size of a segment in MB
@@ -303,7 +303,7 @@ dataCoord:
   gc:
     interval: 3600 # gc interval in seconds
     missingTolerance: 86400 # file meta missing tolerance duration in seconds, 60*24
-    dropTolerance: 86400 # file belongs to dropped entity tolerance duration in seconds, 60*24
+    dropTolerance: 3600 # file belongs to dropped entity tolerance duration in seconds
 
 
 dataNode:

--- a/internal/util/paramtable/component_param.go
+++ b/internal/util/paramtable/component_param.go
@@ -1344,7 +1344,7 @@ func (p *dataCoordConfig) init(base *BaseTable) {
 }
 
 func (p *dataCoordConfig) initMaxWatchDuration() {
-	p.MaxWatchDuration = time.Duration(p.Base.ParseInt64WithDefault("dataCoord.channel.maxWatchDuration", 60)) * time.Second
+	p.MaxWatchDuration = time.Duration(p.Base.ParseInt64WithDefault("dataCoord.channel.maxWatchDuration", 600)) * time.Second
 }
 
 func (p *dataCoordConfig) initSegmentMaxSize() {
@@ -1424,7 +1424,7 @@ func (p *dataCoordConfig) initSegmentProportion() {
 
 // compaction execution timeout
 func (p *dataCoordConfig) initCompactionTimeoutInSeconds() {
-	p.CompactionTimeoutInSeconds = p.Base.ParseInt32WithDefault("dataCoord.compaction.timeout", 60*3)
+	p.CompactionTimeoutInSeconds = p.Base.ParseInt32WithDefault("dataCoord.compaction.timeout", 60*5)
 }
 
 func (p *dataCoordConfig) initCompactionCheckIntervalInSeconds() {
@@ -1470,7 +1470,7 @@ func (p *dataCoordConfig) initGCMissingTolerance() {
 }
 
 func (p *dataCoordConfig) initGCDropTolerance() {
-	p.GCDropTolerance = time.Duration(p.Base.ParseInt64WithDefault("dataCoord.gc.dropTolerance", 24*60*60)) * time.Second
+	p.GCDropTolerance = time.Duration(p.Base.ParseInt64WithDefault("dataCoord.gc.dropTolerance", 3600)) * time.Second
 }
 
 func (p *dataCoordConfig) SetEnableAutoCompaction(enable bool) {


### PR DESCRIPTION
/kind improvement 

dataCoord.gc.dropTolerance : 3600(s)
dataCoord.channel.maxWatchDuration: 600(s)
dataCoord.compaction.timeout: 300(s)

Signed-off-by: jaime <yun.zhang@zilliz.com>