### PR TITLE
Refine default value of some configurations

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -258,7 +258,7 @@ dataCoord:
   enableActiveStandby: false  # Enable active-standby
 
   channel:
-    maxWatchDuration: 60 # Timeout on watching channels (in seconds). Default 60 seconds.
+    maxWatchDuration: 600 # Timeout on watching channels (in seconds). Default 600 seconds.
 
   segment:
     maxSize: 512 # Maximum size of a segment in MB
@@ -290,7 +290,7 @@ dataCoord:
   gc:
     interval: 3600 # gc interval in seconds
     missingTolerance: 86400 # file meta missing tolerance duration in seconds, 60*24
-    dropTolerance: 86400 # file belongs to dropped entity tolerance duration in seconds, 60*24
+    dropTolerance: 3600 # file belongs to dropped entity tolerance duration in seconds, 3600
 
   bindIndexNodeMode:
     enable: false

--- a/internal/util/paramtable/component_param.go
+++ b/internal/util/paramtable/component_param.go
@@ -1408,7 +1408,7 @@ func (p *dataCoordConfig) init(base *BaseTable) {
 	p.MaxWatchDuration = ParamItem{
 		Key:          "dataCoord.channel.maxWatchDuration",
 		Version:      "2.2.1",
-		DefaultValue: "60",
+		DefaultValue: "600",
 	}
 	p.MaxWatchDuration.Init(base.mgr)
 
@@ -1520,7 +1520,7 @@ func (p *dataCoordConfig) init(base *BaseTable) {
 	p.CompactionTimeoutInSeconds = ParamItem{
 		Key:          "dataCoord.compaction.timeout",
 		Version:      "2.0.0",
-		DefaultValue: "180",
+		DefaultValue: "300",
 	}
 	p.CompactionTimeoutInSeconds.Init(base.mgr)
 
@@ -1555,7 +1555,7 @@ func (p *dataCoordConfig) init(base *BaseTable) {
 	p.SingleCompactionDeltalogMaxNum = ParamItem{
 		Key:          "dataCoord.compaction.single.deltalog.maxnum",
 		Version:      "2.0.0",
-		DefaultValue: "1000",
+		DefaultValue: "200",
 	}
 	p.SingleCompactionDeltalogMaxNum.Init(base.mgr)
 
@@ -1590,7 +1590,7 @@ func (p *dataCoordConfig) init(base *BaseTable) {
 	p.GCDropTolerance = ParamItem{
 		Key:          "dataCoord.gc.dropTolerance",
 		Version:      "2.0.0",
-		DefaultValue: "86400",
+		DefaultValue: "3600",
 	}
 	p.GCDropTolerance.Init(base.mgr)
 


### PR DESCRIPTION
/kind improvement
Signed-off-by: jaime <yun.zhang@zilliz.com>

Updating the default value of the below configurations:
dataCoord.compaction.single.deltalog.maxnum: 200
dataCoord.gc.dropTolerance : 3600(s)
dataCoord.channel.maxWatchDuration: 600(s)
dataCoord.compaction.timeout: 300(s)