### PR TITLE
Modify lastSyncTime in advance to prevent multiple flush binlogs

### DIFF
--- a/internal/datanode/flow_graph_insert_buffer_node.go
+++ b/internal/datanode/flow_graph_insert_buffer_node.go
@@ -489,6 +489,7 @@ func (ibNode *insertBufferNode) Sync(fgMsg *flowGraphMsg, seg2Upload []UniqueID,
 		segmentsToSync = append(segmentsToSync, task.segmentID)
 		ibNode.channel.rollInsertBuffer(task.segmentID)
 		ibNode.channel.RollPKstats(task.segmentID, pkStats)
+		ibNode.channel.setSegmentLastSyncTs(task.segmentID, endPosition.GetTimestamp())
 		metrics.DataNodeFlushBufferCount.WithLabelValues(fmt.Sprint(Params.DataNodeCfg.GetNodeID()), metrics.SuccessLabel).Inc()
 		metrics.DataNodeFlushBufferCount.WithLabelValues(fmt.Sprint(Params.DataNodeCfg.GetNodeID()), metrics.TotalLabel).Inc()
 		if task.auto {

--- a/internal/datanode/flow_graph_insert_buffer_node_test.go
+++ b/internal/datanode/flow_graph_insert_buffer_node_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/dependency"
 	"github.com/milvus-io/milvus/internal/util/flowgraph"
 	"github.com/milvus-io/milvus/internal/util/retry"
+	"github.com/milvus-io/milvus/internal/util/tsoutil"
 	"github.com/milvus-io/milvus/internal/util/typeutil"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
@@ -226,7 +227,12 @@ func TestFlowGraphInsertBufferNode_Operate(t *testing.T) {
 	}
 
 	inMsg := genFlowGraphInsertMsg(insertChannelName)
-	assert.NotPanics(t, func() { iBNode.Operate([]flowgraph.Msg{&inMsg}) })
+	iBNode.channel.setSegmentLastSyncTs(UniqueID(1), tsoutil.ComposeTSByTime(time.Now().Add(-11*time.Minute), 0))
+	assert.NotPanics(t, func() {
+		res := iBNode.Operate([]flowgraph.Msg{&inMsg})
+		assert.Subset(t, res[0].(*flowGraphMsg).segmentsToSync, []UniqueID{1})
+	})
+	assert.NotSubset(t, iBNode.channel.listSegmentIDsToSync(tsoutil.ComposeTSByTime(time.Now(), 0)), []UniqueID{1})
 
 	resendTTChan <- resendTTMsg{
 		segmentIDs: []int64{0, 1, 2},

--- a/internal/datanode/flush_manager.go
+++ b/internal/datanode/flush_manager.go
@@ -865,6 +865,5 @@ func flushNotifyFunc(dsService *dataSyncService, opts ...retry.Option) notifyMet
 		dsService.flushingSegCache.Remove(req.GetSegmentID())
 		dsService.channel.evictHistoryInsertBuffer(req.GetSegmentID(), pack.pos)
 		dsService.channel.evictHistoryDeleteBuffer(req.GetSegmentID(), pack.pos)
-		dsService.channel.setSegmentLastSyncTs(req.GetSegmentID(), pack.pos.GetTimestamp())
 	}
 }

--- a/internal/datanode/mock_test.go
+++ b/internal/datanode/mock_test.go
@@ -896,7 +896,7 @@ func genFlowGraphInsertMsg(chanName string) flowGraphMsg {
 		{
 			ChannelName: chanName,
 			MsgID:       make([]byte, 0),
-			Timestamp:   0,
+			Timestamp:   tsoutil.ComposeTSByTime(time.Now(), 0),
 		},
 	}
 


### PR DESCRIPTION
Signed-off-by: cai.zhang <cai.zhang@zilliz.com>
issue: #22034 