### PR TITLE
Support using mmap to load data 

### DIFF
--- a/internal/core/src/common/FieldMeta.h
+++ b/internal/core/src/common/FieldMeta.h
@@ -26,7 +26,7 @@
 
 namespace milvus {
 
-inline int
+inline size_t
 datatype_sizeof(DataType data_type, int dim = 1) {
     switch (data_type) {
         case DataType::BOOL:
@@ -94,6 +94,17 @@ datatype_is_vector(DataType datatype) {
 
 inline bool
 datatype_is_string(DataType datatype) {
+    switch (datatype) {
+        case DataType::VARCHAR:
+        case DataType::STRING:
+            return true;
+        default:
+            return false;
+    }
+}
+
+inline bool
+datatype_is_variable(DataType datatype) {
     switch (datatype) {
         case DataType::VARCHAR:
         case DataType::STRING:
@@ -200,7 +211,7 @@ class FieldMeta {
         return type_;
     }
 
-    int64_t
+    size_t
     get_sizeof() const {
         if (is_vector()) {
             return datatype_sizeof(type_, get_dim());

--- a/internal/core/src/common/LoadInfo.h
+++ b/internal/core/src/common/LoadInfo.h
@@ -18,8 +18,8 @@
 
 #include <map>
 #include <string>
-#include "Types.h"
 
+#include "Types.h"
 #include "common/CDataType.h"
 
 // NOTE: field_id can be system field
@@ -29,11 +29,8 @@ struct LoadFieldDataInfo {
     int64_t field_id;
     //    const void* blob = nullptr;
     const milvus::DataArray* field_data;
-    int64_t row_count = -1;
-
-    // ~LoadFieldDataInfo() {
-    //     delete field_data;
-    // }
+    int64_t row_count{-1};
+    const char* mmap_dir_path{nullptr};
 };
 
 struct LoadDeletedRecordInfo {

--- a/internal/core/src/common/Span.h
+++ b/internal/core/src/common/Span.h
@@ -17,8 +17,8 @@
 #pragma once
 
 #include <cassert>
-#include <type_traits>
 #include <string>
+#include <type_traits>
 
 #include "Types.h"
 #include "VectorTrait.h"

--- a/internal/core/src/common/VectorTrait.h
+++ b/internal/core/src/common/VectorTrait.h
@@ -49,7 +49,8 @@ template <typename T>
 constexpr bool IsVector = std::is_base_of_v<VectorTrait, T>;
 
 template <typename T>
-constexpr bool IsScalar = std::is_fundamental_v<T> || std::is_same_v<T, std::string>;
+constexpr bool IsScalar =
+    std::is_fundamental_v<T> || std::is_same_v<T, std::string> || std::is_same_v<T, std::string_view>;
 
 template <typename T, typename Enabled = void>
 struct EmbeddedTypeImpl;

--- a/internal/core/src/common/type_c.h
+++ b/internal/core/src/common/type_c.h
@@ -74,6 +74,9 @@ typedef struct CLoadFieldDataInfo {
     const uint8_t* blob;
     uint64_t blob_size;
     int64_t row_count;
+    // Set null to disable mmap,
+    // mmap file path will be {mmap_dir_path}/{segment_id}/{field_id}
+    const char* mmap_dir_path;
 } CLoadFieldDataInfo;
 
 typedef struct CLoadDeletedRecordInfo {

--- a/internal/core/src/index/ScalarIndex.h
+++ b/internal/core/src/index/ScalarIndex.h
@@ -16,13 +16,14 @@
 
 #pragma once
 
+#include <boost/dynamic_bitset.hpp>
 #include <map>
 #include <memory>
 #include <string>
-#include <boost/dynamic_bitset.hpp>
-#include "index/Index.h"
+
 #include "common/Types.h"
 #include "exceptions/EasyAssert.h"
+#include "index/Index.h"
 
 namespace milvus::index {
 

--- a/internal/core/src/index/StringIndex.h
+++ b/internal/core/src/index/StringIndex.h
@@ -16,12 +16,14 @@
 
 #pragma once
 
-#include "index/ScalarIndex.h"
-#include <string>
-#include <memory>
-#include <vector>
-#include "index/Meta.h"
 #include <pb/schema.pb.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "index/Meta.h"
+#include "index/ScalarIndex.h"
 
 namespace milvus::index {
 

--- a/internal/core/src/index/StringIndexSort.h
+++ b/internal/core/src/index/StringIndexSort.h
@@ -37,7 +37,7 @@ class StringIndexSort : public ScalarIndexSort<std::string> {
     }
 
     const TargetBitmapPtr
-    PrefixMatch(std::string prefix) {
+    PrefixMatch(std::string_view prefix) {
         auto data = GetData();
         TargetBitmapPtr bitset = std::make_unique<TargetBitmap>(data.size());
         for (size_t i = 0; i < data.size(); i++) {

--- a/internal/core/src/query/PlanProto.cpp
+++ b/internal/core/src/query/PlanProto.cpp
@@ -9,15 +9,16 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
+#include "PlanProto.h"
+
 #include <google/protobuf/text_format.h>
 
 #include <string>
 
 #include "ExprImpl.h"
-#include "PlanProto.h"
+#include "common/VectorTrait.h"
 #include "generated/ExtractInfoExprVisitor.h"
 #include "generated/ExtractInfoPlanNodeVisitor.h"
-#include "common/VectorTrait.h"
 
 namespace milvus::query {
 namespace planpb = milvus::proto::plan;

--- a/internal/core/src/query/SearchOnSealed.cpp
+++ b/internal/core/src/query/SearchOnSealed.cpp
@@ -71,7 +71,7 @@ SearchOnSealedIndex(const Schema& schema,
 
 void
 SearchOnSealed(const Schema& schema,
-               const segcore::InsertRecord<true>& record,
+               const void* vec_data,
                const SearchInfo& search_info,
                const void* query_data,
                int64_t num_queries,
@@ -83,11 +83,9 @@ SearchOnSealed(const Schema& schema,
 
     query::dataset::SearchDataset dataset{search_info.metric_type_,   num_queries,     search_info.topk_,
                                           search_info.round_decimal_, field.get_dim(), query_data};
-    auto vec_data = record.get_field_data_base(field_id);
-    AssertInfo(vec_data->num_chunk() == 1, "num chunk not equal to 1 for sealed segment");
-    auto chunk_data = vec_data->get_chunk_data(0);
+
     CheckBruteForceSearchParam(field, search_info);
-    auto sub_qr = BruteForceSearch(dataset, chunk_data, row_count, search_info.search_params_, bitset);
+    auto sub_qr = BruteForceSearch(dataset, vec_data, row_count, search_info.search_params_, bitset);
 
     result.distances_ = std::move(sub_qr.mutable_distances());
     result.seg_offsets_ = std::move(sub_qr.mutable_seg_offsets());

--- a/internal/core/src/query/SearchOnSealed.h
+++ b/internal/core/src/query/SearchOnSealed.h
@@ -29,7 +29,7 @@ SearchOnSealedIndex(const Schema& schema,
 
 void
 SearchOnSealed(const Schema& schema,
-               const segcore::InsertRecord<true>& record,
+               const void* vec_data,
                const SearchInfo& search_info,
                const void* query_data,
                int64_t num_queries,

--- a/internal/core/src/query/Utils.h
+++ b/internal/core/src/query/Utils.h
@@ -35,4 +35,17 @@ Match<std::string>(const std::string& str, const std::string& val, OpType op) {
             PanicInfo("not supported");
     }
 }
+
+template <>
+inline bool
+Match<std::string_view>(const std::string_view& str, const std::string& val, OpType op) {
+    switch (op) {
+        case OpType::PrefixMatch:
+            return PrefixMatch(str, val);
+        case OpType::PostfixMatch:
+            return PostfixMatch(str, val);
+        default:
+            PanicInfo("not supported");
+    }
+}
 }  // namespace milvus::query

--- a/internal/core/src/query/visitors/ExecPlanNodeVisitor.cpp
+++ b/internal/core/src/query/visitors/ExecPlanNodeVisitor.cpp
@@ -9,12 +9,13 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
+#include "query/generated/ExecPlanNodeVisitor.h"
+
 #include <utility>
 
 #include "query/PlanImpl.h"
-#include "query/generated/ExecPlanNodeVisitor.h"
-#include "query/generated/ExecExprVisitor.h"
 #include "query/SubSearchResult.h"
+#include "query/generated/ExecExprVisitor.h"
 #include "segcore/SegmentGrowing.h"
 #include "utils/Json.h"
 

--- a/internal/core/src/segcore/InsertRecord.h
+++ b/internal/core/src/segcore/InsertRecord.h
@@ -11,18 +11,19 @@
 
 #pragma once
 
-#include <memory>
-#include <vector>
-#include <string>
 #include <algorithm>
+#include <memory>
+#include <string>
 #include <unordered_map>
 #include <utility>
+#include <vector>
 
+#include "TimestampIndex.h"
 #include "common/Schema.h"
+#include "easylogging++.h"
 #include "segcore/AckResponder.h"
 #include "segcore/ConcurrentVector.h"
 #include "segcore/Record.h"
-#include "TimestampIndex.h"
 
 namespace milvus::segcore {
 
@@ -310,8 +311,8 @@ struct InsertRecord {
 
  private:
     //    std::vector<std::unique_ptr<VectorBase>> fields_data_;
-    std::unordered_map<FieldId, std::unique_ptr<VectorBase>> fields_data_;
-    mutable std::shared_mutex shared_mutex_;
+    std::unordered_map<FieldId, std::unique_ptr<VectorBase>> fields_data_{};
+    mutable std::shared_mutex shared_mutex_{};
 };
 
 }  // namespace milvus::segcore

--- a/internal/core/src/segcore/SegmentGrowing.h
+++ b/internal/core/src/segcore/SegmentGrowing.h
@@ -38,6 +38,11 @@ class SegmentGrowing : public SegmentInternalInterface {
            const Timestamp* timestamps,
            const InsertData* insert_data) = 0;
 
+    virtual SegmentType
+    type() const override {
+        return SegmentType::Growing;
+    }
+
     // virtual int64_t
     // PreDelete(int64_t size) = 0;
 

--- a/internal/core/src/segcore/SegmentInterface.cpp
+++ b/internal/core/src/segcore/SegmentInterface.cpp
@@ -10,11 +10,13 @@
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
 #include "SegmentInterface.h"
+
 #include <cstdint>
+
+#include "Utils.h"
 #include "common/SystemProperty.h"
 #include "common/Types.h"
 #include "query/generated/ExecPlanNodeVisitor.h"
-#include "Utils.h"
 
 namespace milvus::segcore {
 
@@ -72,7 +74,6 @@ SegmentInternalInterface::Retrieve(const query::RetrievePlan* plan, Timestamp ti
     query::ExecPlanNodeVisitor visitor(*this, timestamp);
     auto retrieve_results = visitor.get_retrieve_result(*plan->plan_node_);
     retrieve_results.segment_ = (void*)this;
-
     results->mutable_offset()->Add(retrieve_results.result_offsets_.begin(), retrieve_results.result_offsets_.end());
 
     auto fields_data = results->mutable_fields_data();

--- a/internal/core/src/segcore/SegmentInterface.h
+++ b/internal/core/src/segcore/SegmentInterface.h
@@ -80,6 +80,9 @@ class SegmentInterface {
 
     virtual int64_t
     get_segment_id() const = 0;
+
+    virtual SegmentType
+    type() const = 0;
 };
 
 // internal API for DSL calculation

--- a/internal/core/src/segcore/SegmentSealed.h
+++ b/internal/core/src/segcore/SegmentSealed.h
@@ -33,6 +33,11 @@ class SegmentSealed : public SegmentInternalInterface {
     DropIndex(const FieldId field_id) = 0;
     virtual void
     DropFieldData(const FieldId field_id) = 0;
+
+    virtual SegmentType
+    type() const override {
+        return SegmentType::Sealed;
+    }
 };
 
 using SegmentSealedPtr = std::unique_ptr<SegmentSealed>;

--- a/internal/core/src/segcore/VariableField.h
+++ b/internal/core/src/segcore/VariableField.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <sys/mman.h>
+
+#include <string_view>
+#include <vector>
+
+#include "common/LoadInfo.h"
+
+namespace milvus::segcore {
+
+struct Entry {
+    char* data;
+    uint32_t length;
+};
+
+// Used for string/varchar field only,
+// TODO(yah01): make this generic
+class VariableField {
+ public:
+    explicit VariableField(int64_t segment_id, const FieldMeta& field_meta, const LoadFieldDataInfo& info) {
+        auto begin = info.field_data->scalars().string_data().data().begin();
+        auto end = info.field_data->scalars().string_data().data().end();
+
+        indices_.reserve(info.row_count);
+        while (begin != end) {
+            indices_.push_back(size_);
+            size_ += begin->size();
+            begin++;
+        }
+
+        data_ = (char*)CreateMap(segment_id, field_meta, info);
+        construct_views();
+    }
+
+    VariableField(VariableField&& field)
+        : indices_(std::move(field.indices_)), size_(field.size_), data_(field.data_), views_(std::move(field.views_)) {
+        field.data_ = nullptr;
+    }
+
+    ~VariableField() {
+        if (data_ != MAP_FAILED && data_ != nullptr) {
+            if (munmap(data_, size_)) {
+                AssertInfo(true, std::string("failed to unmap variable field err=") + strerror(errno));
+            }
+        }
+    }
+
+    char*
+    data() {
+        return data_;
+    }
+
+    const std::vector<std::string_view>&
+    views() const {
+        return views_;
+    }
+
+    size_t
+    size() const {
+        return size_;
+    }
+
+    Span<char>
+    operator[](const int i) const {
+        uint64_t next = (i + 1 == indices_.size()) ? size_ : indices_[i + 1];
+        uint64_t offset = indices_[i];
+        return Span<char>(data_ + offset, uint32_t(next - offset));
+    }
+
+ protected:
+    void
+    construct_views() {
+        views_.reserve(indices_.size());
+        for (size_t i = 0; i < indices_.size() - 1; i++) {
+            views_.emplace_back(data_ + indices_[i], indices_[i + 1] - indices_[i]);
+        }
+        views_.emplace_back(data_ + indices_.back(), size_ - indices_.back());
+    }
+
+ private:
+    std::vector<uint64_t> indices_{};
+    uint64_t size_{0};
+    char* data_{nullptr};
+
+    // Compatible with current Span type
+    std::vector<std::string_view> views_{};
+};
+}  // namespace milvus::segcore

--- a/internal/core/src/segcore/segment_c.cpp
+++ b/internal/core/src/segcore/segment_c.cpp
@@ -9,18 +9,18 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
+#include "segcore/segment_c.h"
+
 #include "common/CGoHelper.h"
 #include "common/LoadInfo.h"
 #include "common/Types.h"
 #include "common/type_c.h"
+#include "google/protobuf/text_format.h"
+#include "index/IndexInfo.h"
 #include "log/Log.h"
-
 #include "segcore/Collection.h"
 #include "segcore/SegmentGrowingImpl.h"
 #include "segcore/SegmentSealedImpl.h"
-#include "segcore/segment_c.h"
-#include "index/IndexInfo.h"
-#include "google/protobuf/text_format.h"
 
 //////////////////////////////    common interfaces    //////////////////////////////
 CSegmentInterface
@@ -206,8 +206,8 @@ LoadFieldData(CSegmentInterface c_segment, CLoadFieldDataInfo load_field_data_in
         auto field_data = std::make_unique<milvus::DataArray>();
         auto suc = field_data->ParseFromArray(load_field_data_info.blob, load_field_data_info.blob_size);
         AssertInfo(suc, "unmarshal field data string failed");
-        auto load_info =
-            LoadFieldDataInfo{load_field_data_info.field_id, field_data.get(), load_field_data_info.row_count};
+        auto load_info = LoadFieldDataInfo{load_field_data_info.field_id, field_data.get(),
+                                           load_field_data_info.row_count, load_field_data_info.mmap_dir_path};
         segment->LoadFieldData(load_info);
         return milvus::SuccessCStatus();
     } catch (std::exception& e) {

--- a/internal/core/unittest/test_c_api.cpp
+++ b/internal/core/unittest/test_c_api.cpp
@@ -9,27 +9,27 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
-#include <boost/format.hpp>
-#include <chrono>
 #include <google/protobuf/text_format.h>
 #include <gtest/gtest.h>
+
+#include <boost/format.hpp>
+#include <chrono>
 #include <iostream>
 #include <random>
 #include <string>
 #include <unordered_set>
 
-#include "knowhere/comp/index_param.h"
-
 #include "common/LoadInfo.h"
+#include "index/IndexFactory.h"
+#include "knowhere/comp/index_param.h"
 #include "pb/plan.pb.h"
 #include "query/ExprImpl.h"
 #include "segcore/Collection.h"
-#include "segcore/reduce_c.h"
 #include "segcore/Reduce.h"
+#include "segcore/reduce_c.h"
 #include "test_utils/DataGen.h"
-#include "index/IndexFactory.h"
-#include "test_utils/indexbuilder_test_utils.h"
 #include "test_utils/PbHelper.h"
+#include "test_utils/indexbuilder_test_utils.h"
 
 namespace chrono = std::chrono;
 

--- a/internal/core/unittest/test_common.cpp
+++ b/internal/core/unittest/test_common.cpp
@@ -13,17 +13,18 @@
 #include <segcore/ConcurrentVector.h>
 #include "common/Types.h"
 #include "common/Span.h"
+#include "common/VectorTrait.h"
 
 TEST(Common, Span) {
     using namespace milvus;
     using namespace milvus::segcore;
 
     Span<float> s1(nullptr, 100);
-    Span<FloatVector> s2(nullptr, 10, 16 * sizeof(float));
+    Span<milvus::FloatVector> s2(nullptr, 10, 16 * sizeof(float));
     SpanBase b1 = s1;
     SpanBase b2 = s2;
     auto r1 = static_cast<Span<float>>(b1);
-    auto r2 = static_cast<Span<FloatVector>>(b2);
+    auto r2 = static_cast<Span<milvus::FloatVector>>(b2);
     ASSERT_EQ(r1.row_count(), 100);
     ASSERT_EQ(r2.row_count(), 10);
     ASSERT_EQ(r2.element_sizeof(), 16 * sizeof(float));

--- a/internal/core/unittest/test_utils/DataGen.h
+++ b/internal/core/unittest/test_utils/DataGen.h
@@ -425,7 +425,10 @@ SearchResultToJson(const SearchResult& sr) {
 };
 
 inline void
-SealedLoadFieldData(const GeneratedData& dataset, SegmentSealed& seg, const std::set<int64_t>& exclude_fields = {}) {
+SealedLoadFieldData(const GeneratedData& dataset,
+                    SegmentSealed& seg,
+                    const std::set<int64_t>& exclude_fields = {},
+                    bool with_mmap = false) {
     auto row_count = dataset.row_ids_.size();
     {
         LoadFieldDataInfo info;
@@ -451,6 +454,9 @@ SealedLoadFieldData(const GeneratedData& dataset, SegmentSealed& seg, const std:
             continue;
         }
         LoadFieldDataInfo info;
+        if (with_mmap) {
+            info.mmap_dir_path = "./data/mmap-test";
+        }
         info.field_id = field_data.field_id();
         info.row_count = row_count;
         info.field_data = &field_data;

--- a/internal/indexnode/task.go
+++ b/internal/indexnode/task.go
@@ -294,6 +294,7 @@ func (it *indexBuildTask) BuildIndex(ctx context.Context) error {
 		indexBlobs,
 	)
 	if err != nil {
+		log.Warn("failed to serialize index", zap.Error(err))
 		return err
 	}
 	encodeIndexFileDur := it.tr.Record("index codec serialize done")

--- a/internal/querynode/segment.go
+++ b/internal/querynode/segment.go
@@ -779,6 +779,7 @@ func (s *Segment) segmentDelete(offset int64, entityIDs []primaryKey, timestamps
 }
 
 // -------------------------------------------------------------------------------------- interfaces for sealed segment
+
 func (s *Segment) segmentLoadFieldData(fieldID int64, rowCount int64, data *schemapb.FieldData) error {
 	/*
 		CStatus
@@ -799,11 +800,18 @@ func (s *Segment) segmentLoadFieldData(fieldID int64, rowCount int64, data *sche
 		return err
 	}
 
+	var mmapDirPath *C.char = nil
+	path := paramtable.Get().QueryNodeCfg.MmapDirPath.GetValue()
+	if len(path) > 0 {
+		mmapDirPath = C.CString(path)
+		defer C.free(unsafe.Pointer(mmapDirPath))
+	}
 	loadInfo := C.CLoadFieldDataInfo{
-		field_id:  C.int64_t(fieldID),
-		blob:      (*C.uint8_t)(unsafe.Pointer(&dataBlob[0])),
-		blob_size: C.uint64_t(len(dataBlob)),
-		row_count: C.int64_t(rowCount),
+		field_id:      C.int64_t(fieldID),
+		blob:          (*C.uint8_t)(unsafe.Pointer(&dataBlob[0])),
+		blob_size:     C.uint64_t(len(dataBlob)),
+		row_count:     C.int64_t(rowCount),
+		mmap_dir_path: mmapDirPath,
 	}
 
 	status := C.LoadFieldData(s.segmentPtr, loadInfo)

--- a/internal/querynode/segment_loader_test.go
+++ b/internal/querynode/segment_loader_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/milvus-io/milvus/internal/proto/querypb"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/util/funcutil"
+	"github.com/milvus-io/milvus/internal/util/paramtable"
 )
 
 func TestSegmentLoader_loadSegment(t *testing.T) {
@@ -51,6 +52,40 @@ func TestSegmentLoader_loadSegment(t *testing.T) {
 	assert.NoError(t, err)
 
 	t.Run("test load segment", func(t *testing.T) {
+		node, err := genSimpleQueryNode(ctx)
+		require.NoError(t, err)
+		defer node.Stop()
+
+		node.metaReplica.removeSegment(defaultSegmentID, segmentTypeSealed)
+		loader := node.loader
+		assert.NotNil(t, loader)
+
+		req := &querypb.LoadSegmentsRequest{
+			Base: &commonpb.MsgBase{
+				MsgType: commonpb.MsgType_LoadSegments,
+				MsgID:   rand.Int63(),
+			},
+			DstNodeID: 0,
+			Schema:    schema,
+			Infos: []*querypb.SegmentLoadInfo{
+				{
+					SegmentID:    defaultSegmentID,
+					PartitionID:  defaultPartitionID,
+					CollectionID: defaultCollectionID,
+					BinlogPaths:  fieldBinlog,
+					Statslogs:    statsLog,
+				},
+			},
+		}
+
+		_, err = loader.LoadSegment(ctx, req, segmentTypeSealed)
+		assert.NoError(t, err)
+	})
+
+	t.Run("test load segment with mmap", func(t *testing.T) {
+		key := paramtable.Get().QueryNodeCfg.MmapDirPath.Key
+		paramtable.Get().Save(key, "/tmp/mmap-test")
+		defer paramtable.Get().Reset(key)
 		node, err := genSimpleQueryNode(ctx)
 		require.NoError(t, err)
 		defer node.Stop()

--- a/internal/util/paramtable/component_param.go
+++ b/internal/util/paramtable/component_param.go
@@ -1305,6 +1305,7 @@ type queryNodeConfig struct {
 	// cache limit
 	CacheEnabled     ParamItem `refreshable:"false"`
 	CacheMemoryLimit ParamItem `refreshable:"false"`
+	MmapDirPath      ParamItem `refreshable:"false"`
 
 	GroupEnabled         ParamItem `refreshable:"true"`
 	MaxReceiveChanSize   ParamItem `refreshable:"false"`
@@ -1448,6 +1449,14 @@ func (p *queryNodeConfig) init(base *BaseTable) {
 		Export:       true,
 	}
 	p.CacheEnabled.Init(base.mgr)
+
+	p.MmapDirPath = ParamItem{
+		Key:          "queryNode.mmapDirPath",
+		Version:      "2.3.0",
+		DefaultValue: "",
+		Doc:          "The folder that storing data files for mmap, setting to a path will enable Milvus to load data with mmap",
+	}
+	p.MmapDirPath.Init(base.mgr)
 
 	p.GroupEnabled = ParamItem{
 		Key:          "queryNode.grouping.enabled",


### PR DESCRIPTION
Signed-off-by: yah01 <yang.cen@zilliz.com>
/kind improvement

This also avoids coping when matching prefix with string index,
also avoids coping when retrieving string column,
also stores strings continuously in memory to improve locality,
also fixes the data race when updating row count of sealed segment.

This may break the compatibility with Windows