### PR TITLE
fix parsing index_mode error

### DIFF
--- a/internal/core/src/index/Utils.cpp
+++ b/internal/core/src/index/Utils.cpp
@@ -127,11 +127,11 @@ GetIndexModeFromConfig(const Config& config) {
 
 IndexMode
 GetIndexMode(const std::string index_mode) {
-    if (index_mode.compare("CPU") != 0) {
+    if (index_mode.compare("CPU") == 0) {
         return IndexMode::MODE_CPU;
     }
 
-    if (index_mode.compare("GPU") != 0) {
+    if (index_mode.compare("GPU") == 0) {
         return IndexMode::MODE_GPU;
     }
 


### PR DESCRIPTION
I am testing milvus gpu index recently, and i finds a bug that milvus parses index_mode.