### PR TITLE
Upgrade knowhere to 1.3.8

### DIFF
--- a/internal/core/thirdparty/knowhere/CMakeLists.txt
+++ b/internal/core/thirdparty/knowhere/CMakeLists.txt
@@ -11,8 +11,8 @@
 # or implied. See the License for the specific language governing permissions and limitations under the License.
 #-------------------------------------------------------------------------------
 
-set( KNOWHERE_VERSION v1.3.7 )
-set( KNOWHERE_SOURCE_MD5 "a418d9c8e507d2fed22dc7c3cfa8b703")
+set( KNOWHERE_VERSION v1.3.8 )
+set( KNOWHERE_SOURCE_MD5 "ab77c01f88f0eead84c979fe2356ce7b")
 
 if ( DEFINED ENV{MILVUS_KNOWHERE_URL} )
     set( KNOWHERE_SOURCE_URL "$ENV{MILVUS_KNOWHERE_URL}" )


### PR DESCRIPTION
Signed-off-by: Li Liu <li.liu@zilliz.com>

[Knowhere 1.3.8](https://github.com/milvus-io/knowhere/releases/tag/v1.3.8) fixed some bugs:

1. DiskANN cannot return K results when filtered too much vectors.
2. Bruteforce didn't do protect for omp.
3. Parallel loading DiskANN crashes due to jemalloc issue.

issue: #21934 #21787