### PR TITLE
Fix potential panic during DataCoord stopping

### DIFF
--- a/internal/datacoord/server.go
+++ b/internal/datacoord/server.go
@@ -906,12 +906,14 @@ func (s *Server) Stop() error {
 	s.cluster.Close()
 	s.garbageCollector.close()
 	s.stopServerLoop()
-	s.session.Revoke(time.Second)
 
 	if Params.DataCoordCfg.EnableCompaction.GetAsBool() {
 		s.stopCompactionTrigger()
 		s.stopCompactionHandler()
 	}
+
+	// Revoke operation should be set to end
+	s.session.Revoke(time.Second)
 	return nil
 }
 


### PR DESCRIPTION
The session revoke operation should be invoked after stopping all for Datacoord.
/kind improvement