### PR TITLE
Refine Read method of MinioChunkManager

### DIFF
--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -4411,7 +4411,7 @@ func (node *Proxy) CheckHealth(ctx context.Context, request *milvuspb.CheckHealt
 }
 
 func (node *Proxy) RenameCollection(ctx context.Context, req *milvuspb.RenameCollectionRequest) (*commonpb.Status, error) {
-	ctx, sp := otel.Tracer(typeutil.ProxyRole).Start(ctx, "Proxy-RefreshPolicyInfoCache")
+	ctx, sp := otel.Tracer(typeutil.ProxyRole).Start(ctx, "Proxy-RenameCollection")
 	defer sp.End()
 
 	log := log.Ctx(ctx).With(


### PR DESCRIPTION
issue #22234

The current Implementation to  GetObject from Mino Server/S3:
```
object, err := mcm.getMinioObject(ctx, mcm.bucketName, filePath, minio.GetObjectOptions{})
if err != nil {
  return nil, err
}
defer object.Close()

objectInfo, err := object.Stat()
if err != nil {
  return nil, err
}

data, err := Read(object, objectInfo.Size)
if err != nil {
  return nil, err
}
```
it just starts a goroutine and waits to receive a request when getMinioObject is executed.
1. Stats method of the Minio object will launch a HeaderMethod 
1. Read method of the Minio object will launch a GetMethod 

Some problems are exposed:
1.  Get one Object need launch two requests.
2. Have extra memory copy within GetObject API

