### PR TITLE
Rename concurrency package to conc

### DIFF
--- a/internal/datanode/data_sync_service.go
+++ b/internal/datanode/data_sync_service.go
@@ -35,7 +35,7 @@ import (
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/commonpbutil"
-	"github.com/milvus-io/milvus/internal/util/concurrency"
+	"github.com/milvus-io/milvus/internal/util/conc"
 	"github.com/milvus-io/milvus/internal/util/flowgraph"
 	"github.com/milvus-io/milvus/internal/util/funcutil"
 	"github.com/milvus-io/milvus/internal/util/paramtable"
@@ -203,7 +203,7 @@ func (dsService *dataSyncService) initNodes(vchanInfo *datapb.VchannelInfo, tick
 		return err
 	}
 
-	futures := make([]*concurrency.Future[any], 0, len(unflushedSegmentInfos)+len(flushedSegmentInfos))
+	futures := make([]*conc.Future[any], 0, len(unflushedSegmentInfos)+len(flushedSegmentInfos))
 
 	for _, us := range unflushedSegmentInfos {
 		if us.CollectionID != dsService.collectionID ||
@@ -283,7 +283,7 @@ func (dsService *dataSyncService) initNodes(vchanInfo *datapb.VchannelInfo, tick
 	tickler.watch()
 	defer tickler.stop()
 
-	err = concurrency.AwaitAll(futures...)
+	err = conc.AwaitAll(futures...)
 	if err != nil {
 		return err
 	}

--- a/internal/datanode/io_pool.go
+++ b/internal/datanode/io_pool.go
@@ -3,10 +3,10 @@ package datanode
 import (
 	"sync"
 
-	"github.com/milvus-io/milvus/internal/util/concurrency"
+	"github.com/milvus-io/milvus/internal/util/conc"
 )
 
-var ioPool *concurrency.Pool
+var ioPool *conc.Pool
 var ioPoolInitOnce sync.Once
 
 func initIOPool() {
@@ -15,10 +15,10 @@ func initIOPool() {
 		capacity = 32
 	}
 	// error only happens with negative expiry duration or with negative pre-alloc size.
-	ioPool = concurrency.NewPool(capacity)
+	ioPool = conc.NewPool(capacity)
 }
 
-func getOrCreateIOPool() *concurrency.Pool {
+func getOrCreateIOPool() *conc.Pool {
 	ioPoolInitOnce.Do(initIOPool)
 	return ioPool
 }

--- a/internal/datanode/io_pool_test.go
+++ b/internal/datanode/io_pool_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/milvus-io/milvus/internal/util/concurrency"
+	"github.com/milvus-io/milvus/internal/util/conc"
 	"github.com/milvus-io/milvus/internal/util/paramtable"
 )
 
@@ -23,14 +23,14 @@ func Test_getOrCreateIOPool(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			p := getOrCreateIOPool()
-			futures := make([]*concurrency.Future[any], 0, nTask)
+			futures := make([]*conc.Future[any], 0, nTask)
 			for j := 0; j < nTask; j++ {
 				future := p.Submit(func() (interface{}, error) {
 					return nil, nil
 				})
 				futures = append(futures, future)
 			}
-			err := concurrency.AwaitAll(futures...)
+			err := conc.AwaitAll(futures...)
 			assert.NoError(t, err)
 		}()
 	}

--- a/internal/querynode/impl_test.go
+++ b/internal/querynode/impl_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/milvus-io/milvus/internal/proto/internalpb"
 	"github.com/milvus-io/milvus/internal/proto/querypb"
 	queryPb "github.com/milvus-io/milvus/internal/proto/querypb"
-	"github.com/milvus-io/milvus/internal/util/concurrency"
+	"github.com/milvus-io/milvus/internal/util/conc"
 	"github.com/milvus-io/milvus/internal/util/etcd"
 	"github.com/milvus-io/milvus/internal/util/metricsinfo"
 	"github.com/milvus-io/milvus/internal/util/sessionutil"
@@ -116,7 +116,7 @@ func TestImpl_WatchDmChannels(t *testing.T) {
 		defer func() {
 			node.taskPool = originPool
 		}()
-		node.taskPool = concurrency.NewDefaultPool()
+		node.taskPool = conc.NewDefaultPool()
 		node.taskPool.Release()
 		status, err = node.WatchDmChannels(ctx, req)
 		assert.NoError(t, err)

--- a/internal/querynode/mock_test.go
+++ b/internal/querynode/mock_test.go
@@ -46,7 +46,7 @@ import (
 	"github.com/milvus-io/milvus/internal/proto/querypb"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/util"
-	"github.com/milvus-io/milvus/internal/util/concurrency"
+	"github.com/milvus-io/milvus/internal/util/conc"
 	"github.com/milvus-io/milvus/internal/util/dependency"
 	"github.com/milvus-io/milvus/internal/util/etcd"
 	"github.com/milvus-io/milvus/internal/util/funcutil"
@@ -1696,7 +1696,7 @@ func genSimpleQueryNodeWithMQFactory(ctx context.Context, fac dependency.Factory
 	node.etcdCli = etcdCli
 	node.initSession()
 
-	node.taskPool = concurrency.NewPool(2, ants.WithPreAlloc(true))
+	node.taskPool = conc.NewPool(2, ants.WithPreAlloc(true))
 	etcdKV := etcdkv.NewEtcdKV(etcdCli, Params.EtcdCfg.MetaRootPath.GetValue())
 	node.etcdKV = etcdKV
 

--- a/internal/querynode/query_node.go
+++ b/internal/querynode/query_node.go
@@ -46,7 +46,7 @@ import (
 	"github.com/milvus-io/milvus/internal/log"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/types"
-	"github.com/milvus-io/milvus/internal/util/concurrency"
+	"github.com/milvus-io/milvus/internal/util/conc"
 	"github.com/milvus-io/milvus/internal/util/dependency"
 	"github.com/milvus-io/milvus/internal/util/gc"
 	"github.com/milvus-io/milvus/internal/util/hardware"
@@ -124,7 +124,7 @@ type QueryNode struct {
 	queryShardService *queryShardService
 
 	// pool for load/release channel
-	taskPool *concurrency.Pool
+	taskPool *conc.Pool
 
 	IsStandAlone bool
 }
@@ -271,7 +271,7 @@ func (node *QueryNode) Init() error {
 		node.etcdKV = etcdkv.NewEtcdKV(node.etcdCli, Params.EtcdCfg.MetaRootPath.GetValue())
 		log.Info("queryNode try to connect etcd success", zap.Any("MetaRootPath", Params.EtcdCfg.MetaRootPath))
 
-		node.taskPool = concurrency.NewDefaultPool()
+		node.taskPool = conc.NewDefaultPool()
 		node.metaReplica = newCollectionReplica()
 		node.loader = newSegmentLoader(
 			node.metaReplica,

--- a/internal/util/conc/future.go
+++ b/internal/util/conc/future.go
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package concurrency
+package conc
 
 type future interface {
 	wait()

--- a/internal/util/conc/future_test.go
+++ b/internal/util/conc/future_test.go
@@ -14,43 +14,38 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package concurrency
+package conc
 
 import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/suite"
 )
 
-func TestPool(t *testing.T) {
-	pool := NewDefaultPool()
+type FutureSuite struct {
+	suite.Suite
+}
 
-	taskNum := pool.Cap() * 2
-	futures := make([]*Future[any], 0, taskNum)
-	for i := 0; i < taskNum; i++ {
-		res := i
-		future := pool.Submit(func() (interface{}, error) {
-			time.Sleep(500 * time.Millisecond)
-			return res, nil
-		})
-		futures = append(futures, future)
-	}
+func (s *FutureSuite) TestFuture() {
+	const sleepDuration = 200 * time.Millisecond
+	errFuture := Go(func() (any, error) {
+		time.Sleep(sleepDuration)
+		return nil, errors.New("errFuture")
+	})
 
-	assert.Greater(t, pool.Running(), 0)
-	AwaitAll(futures...)
-	for i, future := range futures {
-		res, err := future.Await()
-		assert.NoError(t, err)
-		assert.Equal(t, err, future.Err())
-		assert.True(t, future.OK())
-		assert.Equal(t, res, future.Value())
-		assert.Equal(t, i, res.(int))
+	resultFuture := Go(func() (int, error) {
+		time.Sleep(sleepDuration)
+		return 10, nil
+	})
 
-		// Await() should be idempotent
-		<-future.Inner()
-		resDup, errDup := future.Await()
-		assert.Equal(t, res, resDup)
-		assert.Equal(t, err, errDup)
-	}
+	s.False(errFuture.OK())
+	s.True(resultFuture.OK())
+	s.Error(errFuture.Err())
+	s.Equal(10, resultFuture.Value())
+}
+
+func TestFuture(t *testing.T) {
+	suite.Run(t, new(FutureSuite))
 }

--- a/internal/util/conc/pool.go
+++ b/internal/util/conc/pool.go
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package concurrency
+package conc
 
 import (
 	"runtime"


### PR DESCRIPTION
/kind improvement
As “concurrency“ is too long to use, prefer to use the simple name "conc"