### PR TITLE
Fix DiskANN can't recovery after querynode reboots (#22488)

### DIFF
--- a/internal/core/src/index/VectorDiskIndex.cpp
+++ b/internal/core/src/index/VectorDiskIndex.cpp
@@ -39,8 +39,14 @@ VectorDiskAnnIndex<T>::VectorDiskAnnIndex(const IndexType& index_type,
     file_manager_ = std::dynamic_pointer_cast<storage::DiskFileManagerImpl>(file_manager);
     auto& local_chunk_manager = storage::LocalChunkManager::GetInstance();
     auto local_index_path_prefix = file_manager_->GetLocalIndexObjectPrefix();
-    AssertInfo(!local_chunk_manager.Exist(local_index_path_prefix),
-               "local index path " + local_index_path_prefix + " has been exist");
+
+    // As we have guarded dup-load in QueryNode,
+    // this assertion failed only if the Milvus rebooted in the same pod,
+    // need to remove these files then re-load the segment
+    if (local_chunk_manager.Exist(local_index_path_prefix)) {
+        local_chunk_manager.RemoveDir(local_index_path_prefix);
+    }
+
     local_chunk_manager.CreateDir(local_index_path_prefix);
     index_ = std::make_unique<knowhere::IndexDiskANN<T>>(local_index_path_prefix, metric_type, file_manager);
 }

--- a/internal/core/src/storage/LocalChunkManager.cpp
+++ b/internal/core/src/storage/LocalChunkManager.cpp
@@ -15,12 +15,13 @@
 // limitations under the License.
 
 #include "LocalChunkManager.h"
-#include "Exception.h"
 
-#include <sstream>
-#include <fstream>
 #include <boost/filesystem.hpp>
 #include <boost/system/error_code.hpp>
+#include <fstream>
+#include <sstream>
+
+#include "Exception.h"
 
 #define THROWLOCALERROR(FUNCTION)                                 \
     do {                                                          \
@@ -178,7 +179,7 @@ void
 LocalChunkManager::RemoveDir(const std::string& dir) {
     boost::filesystem::path dirPath(dir);
     boost::system::error_code err;
-    boost::filesystem::remove_all(dirPath);
+    boost::filesystem::remove_all(dirPath, err);
     if (err) {
         THROWLOCALERROR(RemoveDir);
     }


### PR DESCRIPTION
/kind bug
related https://github.com/milvus-io/milvus/issues/22460
Also fix missing to throw exception when failed to remove dir