### PR TITLE
Fix concurrent loading diskann index timeout

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -187,7 +187,7 @@ queryCoord:
   channelTaskTimeout: 60000 # 1 minute
   segmentTaskTimeout: 120000 # 2 minute
   distPullInterval: 500
-  loadTimeoutSeconds: 600
+  loadTimeoutSeconds: 1800
   checkHandoffInterval: 5000
   taskMergeCap: 8
   taskExecutionCap: 256

--- a/internal/util/paramtable/component_param.go
+++ b/internal/util/paramtable/component_param.go
@@ -905,7 +905,7 @@ func (p *queryCoordConfig) initDistPullInterval() {
 }
 
 func (p *queryCoordConfig) initLoadTimeoutSeconds() {
-	timeout := p.Base.LoadWithDefault("queryCoord.loadTimeoutSeconds", "600")
+	timeout := p.Base.LoadWithDefault("queryCoord.loadTimeoutSeconds", "1800")
 	loadTimeout, err := strconv.ParseInt(timeout, 10, 64)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
fix issue: #22330 

This fix can only reduce the probability of load diskann index timeout, and needs to be fixed in the knowhere project
Signed-off-by: xige-16 <xi.ge@zilliz.com>