### PR TITLE
Refine scheduler & executor of QueryCoord

### DIFF
--- a/internal/querycoordv2/checkers/controller.go
+++ b/internal/querycoordv2/checkers/controller.go
@@ -124,7 +124,7 @@ func (controller *CheckerController) check(ctx context.Context) {
 	for _, task := range tasks {
 		err := controller.scheduler.Add(task)
 		if err != nil {
-			task.Cancel()
+			task.Cancel(err)
 			continue
 		}
 	}

--- a/internal/querycoordv2/handlers.go
+++ b/internal/querycoordv2/handlers.go
@@ -161,7 +161,7 @@ func (s *Server) balanceSegments(ctx context.Context, req *querypb.LoadBalanceRe
 		}
 		err = s.taskScheduler.Add(task)
 		if err != nil {
-			task.Cancel()
+			task.Cancel(err)
 			return err
 		}
 		tasks = append(tasks, task)

--- a/internal/querycoordv2/task/merger.go
+++ b/internal/querycoordv2/task/merger.go
@@ -91,15 +91,6 @@ func (merger *Merger[K, R]) schedule(ctx context.Context) {
 	}()
 }
 
-func (merger *Merger[K, R]) isStopped() bool {
-	select {
-	case <-merger.stopCh:
-		return true
-	default:
-		return false
-	}
-}
-
 func (merger *Merger[K, R]) Add(task MergeableTask[K, R]) {
 	merger.waitQueue <- task
 }

--- a/internal/querycoordv2/task/utils.go
+++ b/internal/querycoordv2/task/utils.go
@@ -167,7 +167,7 @@ func packLoadMeta(loadType querypb.LoadType, collectionID int64, partitions ...i
 	}
 }
 
-func packSubDmChannelRequest(
+func packSubChannelRequest(
 	task *ChannelTask,
 	action Action,
 	schema *schemapb.CollectionSchema,
@@ -189,7 +189,7 @@ func packSubDmChannelRequest(
 	}
 }
 
-func fillSubDmChannelRequest(
+func fillSubChannelRequest(
 	ctx context.Context,
 	req *querypb.WatchDmChannelsRequest,
 	broker meta.Broker,

--- a/internal/util/merr/errors.go
+++ b/internal/util/merr/errors.go
@@ -53,6 +53,7 @@ var (
 	ErrServiceUnavailable          = newMilvusError("service unavailable", 2, true)
 	ErrServiceMemoryLimitExceeded  = newMilvusError("memory limit exceeded", 3, false)
 	ErrServiceRequestLimitExceeded = newMilvusError("request limit exceeded", 4, true)
+	ErrServiceInternal             = newMilvusError("service internal error", 5, false) // Never return this error out of Milvus
 
 	// Collection related
 	ErrCollectionNotFound  = newMilvusError("collection not found", 100, false)
@@ -69,12 +70,15 @@ var (
 	ErrReplicaNotFound = newMilvusError("replica not found", 400, false)
 
 	// Channel related
-	ErrChannelNotFound = newMilvusError("channel not found", 500, false)
+	ErrChannelNotFound    = newMilvusError("channel not found", 500, false)
+	ErrChannelLack        = newMilvusError("channel lacks", 501, false)
+	ErrChannelReduplicate = newMilvusError("channel reduplicates", 502, false)
 
 	// Segment related
-	ErrSegmentNotFound  = newMilvusError("segment not found", 600, false)
-	ErrSegmentNotLoaded = newMilvusError("segment not loaded", 601, false)
-	ErrSegmentLack      = newMilvusError("segment lacks", 602, false)
+	ErrSegmentNotFound    = newMilvusError("segment not found", 600, false)
+	ErrSegmentNotLoaded   = newMilvusError("segment not loaded", 601, false)
+	ErrSegmentLack        = newMilvusError("segment lacks", 602, false)
+	ErrSegmentReduplicate = newMilvusError("segment reduplicates", 603, false)
 
 	// Index related
 	ErrIndexNotFound = newMilvusError("index not found", 700, false)

--- a/internal/util/merr/errors_test.go
+++ b/internal/util/merr/errors_test.go
@@ -63,6 +63,7 @@ func (s *ErrSuite) TestWrap() {
 	s.ErrorIs(WrapErrServiceUnavailable("test", "test init"), ErrServiceUnavailable)
 	s.ErrorIs(WrapErrServiceMemoryLimitExceeded(110, 100, "MLE"), ErrServiceMemoryLimitExceeded)
 	s.ErrorIs(WrapErrServiceRequestLimitExceeded(100, "too many requests"), ErrServiceRequestLimitExceeded)
+	s.ErrorIs(WrapErrServiceInternal("never throw out"), ErrServiceInternal)
 
 	// Collection related
 	s.ErrorIs(WrapErrCollectionNotFound("test_collection", "failed to get collection"), ErrCollectionNotFound)
@@ -80,11 +81,14 @@ func (s *ErrSuite) TestWrap() {
 
 	// Channel related
 	s.ErrorIs(WrapErrChannelNotFound("test_Channel", "failed to get Channel"), ErrChannelNotFound)
+	s.ErrorIs(WrapErrChannelLack("test_Channel", "failed to get Channel"), ErrChannelLack)
+	s.ErrorIs(WrapErrChannelReduplicate("test_Channel", "failed to get Channel"), ErrChannelReduplicate)
 
 	// Segment related
 	s.ErrorIs(WrapErrSegmentNotFound(1, "failed to get Segment"), ErrSegmentNotFound)
 	s.ErrorIs(WrapErrSegmentNotLoaded(1, "failed to query"), ErrSegmentNotLoaded)
 	s.ErrorIs(WrapErrSegmentLack(1, "lack of segment"), ErrSegmentLack)
+	s.ErrorIs(WrapErrSegmentReduplicate(1, "redundancy of segment"), ErrSegmentReduplicate)
 
 	// Index related
 	s.ErrorIs(WrapErrIndexNotFound("failed to get Index"), ErrIndexNotFound)


### PR DESCRIPTION
/kind bug
related #22758 
- Fix scheduler may leak tasks if all QueryNodes down
- Simplify status of task
- Remove retry mechanism in scheduler
- Use new errors