### PR TITLE
[Cherry-Pick] Fix concurrent loading diskann index timeout

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -180,7 +180,7 @@ queryCoord:
   segmentTaskTimeout: 120000 # 2 minute
   distPullInterval: 500
   heartbeatAvailableInterval: 10000 # 10s, Only QueryNodes which fetched heartbeats within the duration are available
-  loadTimeoutSeconds: 600
+  loadTimeoutSeconds: 1800
   checkHandoffInterval: 5000
   enableActiveStandby: false
   port: 19531

--- a/internal/util/paramtable/component_param.go
+++ b/internal/util/paramtable/component_param.go
@@ -1214,7 +1214,7 @@ func (p *queryCoordConfig) init(base *BaseTable) {
 	p.LoadTimeoutSeconds = ParamItem{
 		Key:          "queryCoord.loadTimeoutSeconds",
 		Version:      "2.0.0",
-		DefaultValue: "600",
+		DefaultValue: "1800",
 		PanicIfEmpty: true,
 		Export:       true,
 	}


### PR DESCRIPTION
Cherry pick from https://github.com/milvus-io/milvus/pull/22548
fix issue: https://github.com/milvus-io/milvus/issues/22330
/kind bug

This fix can only reduce the probability of load diskann index timeout, and needs to be fixed in the knowhere project
Signed-off-by: xige-16 <xi.ge@zilliz.com>