### PR TITLE
Optimize load segment, make load fields concurrent

### DIFF
--- a/internal/core/src/segcore/InsertRecord.h
+++ b/internal/core/src/segcore/InsertRecord.h
@@ -13,6 +13,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -264,6 +265,7 @@ struct InsertRecord {
 
     void
     seal_pks() {
+        std::lock_guard lck(shared_mutex_);
         pk2offset_->seal();
     }
 


### PR DESCRIPTION
/kind improvement
fix #22105 
As the ConcurrentVector doesn't provide move constructor, I can't make load row ID and timestamp columns concurrent