### PR TITLE
Fix the compile command doesn't respect the CC version

### DIFF
--- a/scripts/core_build.sh
+++ b/scripts/core_build.sh
@@ -204,8 +204,8 @@ case "${unameOut}" in
   Linux*)
     echo "Running on ${OS_NAME}"
     export CPU_TARGET=avx
-    GCC_VERSION=`gcc -dumpversion`
-    if [[ `gcc -v 2>&1 | sed -n 's/.*\(--with-default-libstdcxx-abi\)=\(\w*\).*/\2/p'` == "gcc4" ]]; then
+    GCC_VERSION=`$CC -dumpversion`
+    if [[ `$CC -v 2>&1 | sed -n 's/.*\(--with-default-libstdcxx-abi\)=\(\w*\).*/\2/p'` == "gcc4" ]]; then
       conan install ${CPP_SRC_DIR} --install-folder conan --build=missing -s compiler.version=${GCC_VERSION} || { echo 'conan install failed'; exit 1; }
     else 
       conan install ${CPP_SRC_DIR} --install-folder conan --build=missing -s compiler.version=${GCC_VERSION} -s compiler.libcxx=libstdc++11 || { echo 'conan install failed'; exit 1; }


### PR DESCRIPTION
/kind improvement
With multiple gcc compilers, the build commands always use `gcc` to specify the version, even user export `CC` and `CXX` env vars