### PR TITLE
[2.2] Fix load partition timeout logic still using createdAt

### DIFF
--- a/internal/querycoordv2/observers/collection_observer.go
+++ b/internal/querycoordv2/observers/collection_observer.go
@@ -120,7 +120,7 @@ func (ob *CollectionObserver) observeTimeout() {
 		)
 		for _, partition := range partitions {
 			if partition.GetStatus() != querypb.LoadStatus_Loading ||
-				time.Now().Before(partition.CreatedAt.Add(Params.QueryCoordCfg.LoadTimeoutSeconds)) {
+				time.Now().Before(partition.UpdatedAt.Add(Params.QueryCoordCfg.LoadTimeoutSeconds)) {
 				continue
 			}
 


### PR DESCRIPTION
Load timeout shall be defined as : "No any progress change in `loadTimeoutPeriod`"
This PR fixes load partition logic not synced

/kind improvement