### PR TITLE
Rename RAFT_IVF_FLAT/RAFT_IVF_PQ to GPU_IVF_FLAT/GPU_IVF_PQ

### DIFF
--- a/internal/util/indexparamcheck/index_type.go
+++ b/internal/util/indexparamcheck/index_type.go
@@ -16,8 +16,8 @@ type IndexType = string
 
 // IndexType definitions
 const (
-	IndexRaftIvfFlat     IndexType = "RAFT_IVF_FLAT"
-	IndexRaftIvfPQ       IndexType = "RAFT_IVF_PQ"
+	IndexRaftIvfFlat     IndexType = "GPU_IVF_FLAT"
+	IndexRaftIvfPQ       IndexType = "GPU_IVF_PQ"
 	IndexFaissIDMap      IndexType = "FLAT" // no index is built.
 	IndexFaissIvfFlat    IndexType = "IVF_FLAT"
 	IndexFaissIvfPQ      IndexType = "IVF_PQ"

--- a/tests/python_client/common/common_func.py
+++ b/tests/python_client/common/common_func.py
@@ -486,8 +486,7 @@ def gen_invaild_search_params_type():
 
 def gen_search_param(index_type, metric_type="L2"):
     search_params = []
-    if index_type in ["FLAT", "IVF_FLAT", "IVF_SQ8", "IVF_PQ", "GPU_FLAT", "GPU_IVF_FLAT", "GPU_IVF_PQ", "GPU_IVF_SQ8",
-                      "RAFT_IVF_FLAT", "RAFT_IVF_PQ"]:
+    if index_type in ["FLAT", "IVF_FLAT", "IVF_SQ8", "IVF_PQ", "GPU_IVF_FLAT", "GPU_IVF_PQ"]:
         if index_type in ["GPU_FLAT"]:
             ivf_search_params = {"metric_type": metric_type, "params": {}}
             search_params.append(ivf_search_params)

--- a/tests/python_client/common/common_type.py
+++ b/tests/python_client/common/common_type.py
@@ -183,7 +183,7 @@ get_wrong_format_dict = [
 
 """ Specially defined list """
 all_index_types = ["FLAT", "IVF_FLAT", "IVF_SQ8", "IVF_PQ", "HNSW", "DISKANN", "BIN_FLAT", "BIN_IVF_FLAT",
-                   "RAFT_IVF_FLAT", "RAFT_IVF_PQ"]
+                   "GPU_IVF_FLAT", "GPU_IVF_PQ"]
 
 default_index_params = [{"nlist": 128}, {"nlist": 128}, {"nlist": 128}, {"nlist": 128, "m": 16, "nbits": 8},
                         {"M": 48, "efConstruction": 500}, {}, {"nlist": 128}, {"nlist": 128},


### PR DESCRIPTION
Milvus uses general index names "GPU_IVF_FLAT" and "GPU_IVF_PQ",
let knowhere decide to use "FAISS_GPU_IVF_FLAT" and "FAISS_GPU_IVF_PQ", or "RAFT_GPU_IVF_FLAT" and "RAFT_GPU_IVF_PQ".