### PR TITLE
fix false memory toleration calculation when loading segments on qnode

### DIFF
--- a/internal/datacoord/policy.go
+++ b/internal/datacoord/policy.go
@@ -582,7 +582,7 @@ func BgBalanceCheck(nodeChannels []*NodeChannelInfo, ts time.Time) ([]*NodeChann
 	for _, nChannels := range nodeChannels {
 		chCount := len(nChannels.Channels)
 		if chCount <= channelCountPerNode+1 {
-			log.Info("node channel count is not much larger than average, skip reallocate",
+			log.Info("node channel count is not much larger than average, skip reallocating",
 				zap.Int64("nodeID", nChannels.NodeID), zap.Int("channelCount", chCount),
 				zap.Int("channelCountPerNode", channelCountPerNode))
 			continue

--- a/internal/querycoordv2/balance/utils.go
+++ b/internal/querycoordv2/balance/utils.go
@@ -54,6 +54,7 @@ func CreateSegmentTasksFromPlans(ctx context.Context, checkerID int64, timeout t
 		log.Info("Create Segment task",
 			zap.Int64("collection", p.Segment.GetCollectionID()),
 			zap.Int64("replica", p.ReplicaID),
+			zap.Int64("segmentID", p.Segment.GetID()),
 			zap.String("channel", p.Segment.GetInsertChannel()),
 			zap.Int64("From", p.From),
 			zap.Int64("To", p.To))

--- a/internal/querynode/load_segment_task.go
+++ b/internal/querynode/load_segment_task.go
@@ -93,7 +93,7 @@ func (l *loadSegmentsTask) Execute(ctx context.Context) error {
 				l.node.metaReplica.removeSegment(segment.SegmentID, segmentTypeSealed)
 			}
 			log.Warn("failed to watch Delta channel while load segment", zap.Int64("collectionID", l.req.CollectionID),
-				zap.Int64("replicaID", l.req.ReplicaID), zap.Error(err))
+				zap.Int64("replicaID", l.req.ReplicaID), zap.Error(err), zap.Int64("msgID", l.req.Base.MsgID))
 			return err
 		}
 

--- a/internal/util/hardware/hardware_info_test.go
+++ b/internal/util/hardware/hardware_info_test.go
@@ -57,3 +57,9 @@ func Test_GetMemoryUsageRatio(t *testing.T) {
 		zap.Float64("Memory usage ratio", GetMemoryUseRatio()))
 	assert.True(t, GetMemoryUseRatio() > 0)
 }
+
+func Test_GetAvailableMemoryCount(t *testing.T) {
+	log.Info("TestGetAvailableMemoryCount",
+		zap.Uint64("Available memory count", GetAvailableMemoryCount()))
+	assert.True(t, GetAvailableMemoryCount() > 0)
+}


### PR DESCRIPTION
related: #23262 