### PR TITLE
Fix rootcoord histgram metrics uses default buckets

### DIFF
--- a/pkg/metrics/rootcoord_metrics.go
+++ b/pkg/metrics/rootcoord_metrics.go
@@ -43,6 +43,7 @@ var (
 			Subsystem: typeutil.RootCoordRole,
 			Name:      "ddl_req_latency",
 			Help:      "latency of each DDL operations",
+			Buckets:   buckets,
 		}, []string{functionLabelName})
 
 	// RootCoordSyncTimeTickLatency records the latency of sync time tick.
@@ -52,6 +53,7 @@ var (
 			Subsystem: typeutil.RootCoordRole,
 			Name:      "sync_timetick_latency",
 			Help:      "latency of synchronizing timetick message",
+			Buckets:   buckets,
 		})
 
 	// RootCoordIDAllocCounter records the number of global ID allocations.


### PR DESCRIPTION
Some rootcoord metrics uses defBuckets, which has a max value of 10ms
This pr changes the buckets to global pre-defined one.
/kind improvement