### PR TITLE
Retrieve page size by getpagesize()

### DIFF
--- a/internal/core/src/common/Utils.h
+++ b/internal/core/src/common/Utils.h
@@ -15,6 +15,7 @@
 #include <fmt/core.h>
 #include <google/protobuf/text_format.h>
 #include <sys/mman.h>
+#include <unistd.h>
 
 #include <filesystem>
 #include <memory>
@@ -398,10 +399,10 @@ CreateMap(int64_t segment_id,
 
 #ifndef MAP_POPULATE
     // Manually access the mapping to populate it
-    const size_t PAGE_SIZE = 4 << 10;  // 4KiB
+    const size_t page_size = getpagesize();
     char* begin = (char*)map;
     char* end = begin + written;
-    for (char* page = begin; page < end; page += PAGE_SIZE) {
+    for (char* page = begin; page < end; page += page_size) {
         char value = page[0];
     }
 #endif


### PR DESCRIPTION
/kind improvement
fix #23560 
this also fixes that the mmap part may be not able to compile if the system defines the `PAGE_SIZE`