### PR TITLE
Fix multiple transferNewSegment and removeSegment causes panic

### DIFF
--- a/internal/datanode/channel_meta.go
+++ b/internal/datanode/channel_meta.go
@@ -163,8 +163,7 @@ func (c *ChannelMeta) segmentFlushed(segID UniqueID) {
 // new2NormalSegment transfers a segment from *New* to *Normal*.
 // make sure the segID is in the channel before call this func
 func (c *ChannelMeta) new2NormalSegment(segID UniqueID) {
-	seg := c.segments[segID]
-	if seg.getType() == datapb.SegmentType_New {
+	if seg, ok := c.segments[segID]; ok && seg.getType() == datapb.SegmentType_New {
 		seg.setType(datapb.SegmentType_Normal)
 	}
 }


### PR DESCRIPTION
This PR make `new2NormalSegment` check whether segment exists before change segment state
Related to #23539
/kind bug
Signed-off-by: Congqi Xia <congqi.xia@zilliz.com>