### PR TITLE
[Cherry-Pick] Fix releasing non-loaded partition blocks forever

### DIFF
--- a/internal/querycoordv2/job/job_release.go
+++ b/internal/querycoordv2/job/job_release.go
@@ -137,6 +137,11 @@ func (job *ReleasePartitionJob) Execute() error {
 		return partition.GetPartitionID(), lo.Contains(req.GetPartitionIDs(), partition.GetPartitionID())
 	})
 
+	if len(toRelease) == 0 {
+		log.Warn("releasing partition(s) not loaded")
+		return nil
+	}
+
 	// If all partitions are released and LoadType is LoadPartition, clear all
 	if len(toRelease) == len(loadedPartitions) &&
 		job.meta.GetLoadType(req.GetCollectionID()) == querypb.LoadType_LoadPartition {


### PR DESCRIPTION
Cherry pick from 2.2.0 branch
Related to #23176 
/kind bug