### PR TITLE
Introduce simdjson

### DIFF
--- a/internal/core/src/common/CMakeLists.txt
+++ b/internal/core/src/common/CMakeLists.txt
@@ -30,6 +30,7 @@ target_link_libraries(milvus_common
         milvus_log
         yaml-cpp
         boost_bitset_ext
+        simdjson
         ${CONAN_LIBS}
         )
 

--- a/internal/core/src/common/Json.h
+++ b/internal/core/src/common/Json.h
@@ -1,0 +1,107 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstddef>
+#include <optional>
+#include <string_view>
+
+#include "exceptions/EasyAssert.h"
+#include "simdjson.h"
+#include "fmt/core.h"
+
+namespace milvus {
+
+class Json {
+ public:
+    Json() = default;
+
+    explicit Json(simdjson::padded_string data) : own_data_(std::move(data)) {
+        data_ = own_data_.value();
+    }
+
+    explicit Json(simdjson::padded_string_view data) : data_(data) {
+    }
+
+    Json(const char* data, size_t len, size_t cap) : data_(data, len) {
+        AssertInfo(len + simdjson::SIMDJSON_PADDING <= cap,
+                   fmt::format("create json without enough memory size for "
+                               "SIMD, len={}, cap={}",
+                               len,
+                               cap));
+    }
+
+    // WARN: this is used for fast non-copy construction,
+    // MUST make sure that the data points to a memory that
+    // with size at least len + SIMDJSON_PADDING
+    Json(const char* data, size_t len) : data_(data, len) {
+    }
+
+    Json(Json&& json) = default;
+
+    Json&
+    operator=(const Json& json) {
+        if (json.own_data_.has_value()) {
+            own_data_ = simdjson::padded_string(
+                json.own_data_.value().data(), json.own_data_.value().length());
+        }
+
+        data_ = json.data_;
+        return *this;
+    }
+
+    operator std::string_view() const {
+        return data_;
+    }
+
+    void
+    parse(simdjson::padded_string_view data) {
+        data_ = data;
+    }
+
+    auto
+    doc() const {
+        thread_local simdjson::ondemand::parser parser;
+
+        // it's always safe to add the padding,
+        // as we have allocated the memory with this padding
+        auto doc =
+            parser.iterate(data_, data_.size() + simdjson::SIMDJSON_PADDING);
+        return doc.get_object();
+    }
+
+    auto
+    operator[](const std::string_view field) const {
+        return doc()[field];
+    }
+
+    auto
+    at_pointer(const std::string_view pointer) const {
+        return doc().at_pointer(pointer);
+    }
+
+    std::string_view
+    data() const {
+        return data_;
+    }
+
+ private:
+    std::optional<simdjson::padded_string>
+        own_data_;  // this could be empty, then the Json will be just s view on bytes
+    simdjson::padded_string_view data_;
+};
+}  // namespace milvus

--- a/internal/core/src/common/Types.h
+++ b/internal/core/src/common/Types.h
@@ -18,15 +18,16 @@
 
 #include <tbb/concurrent_unordered_map.h>
 #include <tbb/concurrent_unordered_set.h>
-
 #include <nlohmann/json.hpp>
 #include <NamedType/named_type.hpp>
 #include <boost/align/aligned_allocator.hpp>
 #include <boost/container/vector.hpp>
 #include <boost/dynamic_bitset.hpp>
+
 #include <limits>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <utility>
 #include <variant>
@@ -35,10 +36,11 @@
 #include "knowhere/binaryset.h"
 #include "knowhere/comp/index_param.h"
 #include "knowhere/dataset.h"
-#include "nlohmann/json.hpp"
+#include "simdjson.h"
 #include "pb/plan.pb.h"
 #include "pb/schema.pb.h"
 #include "pb/segcore.pb.h"
+#include "Json.h"
 
 namespace milvus {
 
@@ -79,7 +81,6 @@ using VectorArray = proto::schema::VectorField;
 using IdArray = proto::schema::IDs;
 using InsertData = proto::segcore::InsertRecord;
 using PkType = std::variant<std::monostate, int64_t, std::string>;
-using Json = nlohmann::json;
 
 inline bool
 IsPrimaryKeyDataType(DataType data_type) {
@@ -153,5 +154,4 @@ struct LargeType {
     int64_t x, y, z;
 };
 static_assert(std::is_same_v<LargeType&, Parameter<LargeType>>);
-
 }  // namespace milvus

--- a/internal/core/src/query/visitors/ExecExprVisitor.cpp
+++ b/internal/core/src/query/visitors/ExecExprVisitor.cpp
@@ -197,7 +197,7 @@ ExecExprVisitor::ExecRangeVisitorImpl(FieldId field_id,
             auto x = data[index];
             result[index] = element_func(x);
         }
-        AssertInfo(result.size() == this_size, "");
+
         results.emplace_back(std::move(result));
     }
     auto final_result = Assemble(results);

--- a/internal/core/src/segcore/ConcurrentVector.cpp
+++ b/internal/core/src/segcore/ConcurrentVector.cpp
@@ -13,6 +13,7 @@
 #include "common/Types.h"
 #include "common/Utils.h"
 #include "nlohmann/json.hpp"
+#include "simdjson.h"
 
 namespace milvus::segcore {
 
@@ -74,10 +75,10 @@ VectorBase::set_data_raw(ssize_t element_offset,
             return set_data_raw(element_offset, data_raw.data(), element_count);
         }
         case DataType::JSON: {
-            auto json_data = FIELD_DATA(data, json);
+            auto& json_data = FIELD_DATA(data, json);
             std::vector<Json> data_raw(json_data.size());
             for (auto& json_bytes : json_data) {
-                data_raw.emplace_back(Json::parse(json_bytes));
+                data_raw.emplace_back(simdjson::padded_string(json_bytes));
             }
             return set_data_raw(element_offset, data_raw.data(), element_count);
         }
@@ -155,7 +156,7 @@ VectorBase::fill_chunk_data(ssize_t element_count,
 
             size_t index = 0;
             for (auto& str : FIELD_DATA(data, json)) {
-                chunk[index++] = str;
+                chunk[index++] = Json(simdjson::padded_string(str));
             }
             return;
         }

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -350,11 +350,7 @@ SegmentGrowingImpl::bulk_subscript_impl(const VectorBase& vec_raw,
     for (int64_t i = 0; i < count; ++i) {
         auto offset = seg_offsets[i];
         if (offset != INVALID_SEG_OFFSET) {
-            if constexpr (std::is_same_v<S, Json>) {
-                output[i] = vec[offset].dump();
-            } else {
-                output[i] = vec[offset];
-            }
+            output[i] = vec[offset];
         }
     }
 }

--- a/internal/core/src/segcore/SegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/SegmentSealedImpl.cpp
@@ -20,12 +20,12 @@
 #include <string_view>
 
 #include "Utils.h"
+#include "Types.h"
 #include "common/Column.h"
 #include "common/Consts.h"
 #include "common/FieldMeta.h"
 #include "common/Types.h"
 #include "log/Log.h"
-#include "nlohmann/json.hpp"
 #include "query/ScalarIndex.h"
 #include "query/SearchBruteForce.h"
 #include "query/SearchOnSealed.h"
@@ -240,25 +240,12 @@ SegmentSealedImpl::LoadFieldData(const LoadFieldDataInfo& info) {
                 case milvus::DataType::STRING:
                 case milvus::DataType::VARCHAR: {
                     column = std::make_unique<VariableColumn<std::string>>(
-                        get_segment_id(),
-                        field_meta,
-                        info,
-                        [](const char* data, size_t len) {
-                            return std::string_view(data, len);
-                        });
+                        get_segment_id(), field_meta, info);
                     break;
                 }
                 case milvus::DataType::JSON: {
                     column = std::make_unique<VariableColumn<Json>>(
-                        get_segment_id(),
-                        field_meta,
-                        info,
-                        [](const char* data, size_t len) {
-                            if (len > 0) {
-                                return Json::parse(data, data + len);
-                            }
-                            return Json{};
-                        });
+                        get_segment_id(), field_meta, info);
                 }
                 default: {
                 }
@@ -267,7 +254,7 @@ SegmentSealedImpl::LoadFieldData(const LoadFieldDataInfo& info) {
             std::unique_lock lck(mutex_);
             variable_fields_.emplace(field_id, std::move(column));
         } else {
-            auto column = FixedColumn(get_segment_id(), field_meta, info);
+            auto column = Column(get_segment_id(), field_meta, info);
             size = column.size();
             std::unique_lock lck(mutex_);
             fixed_fields_.emplace(field_id, std::move(column));
@@ -728,7 +715,7 @@ SegmentSealedImpl::bulk_subscript(FieldId field_id,
 
             default:
                 PanicInfo(
-                    fmt::format("unsupported data type: {}",
+                    fmt::format("718 unsupported data type: {}",
                                 datatype_name(field_meta.get_data_type())));
         }
     }

--- a/internal/core/src/segcore/SegmentSealedImpl.h
+++ b/internal/core/src/segcore/SegmentSealedImpl.h
@@ -235,7 +235,7 @@ class SegmentSealedImpl : public SegmentSealed {
 
     SchemaPtr schema_;
     int64_t id_;
-    std::unordered_map<FieldId, FixedColumn> fixed_fields_;
+    std::unordered_map<FieldId, Column> fixed_fields_;
     std::unordered_map<FieldId, std::unique_ptr<ColumnBase>> variable_fields_;
 };
 

--- a/internal/core/src/segcore/Utils.cpp
+++ b/internal/core/src/segcore/Utils.cpp
@@ -10,7 +10,9 @@
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
 #include "segcore/Utils.h"
+#include <string>
 
+#include "common/Utils.h"
 #include "index/ScalarIndex.h"
 
 namespace milvus::segcore {
@@ -125,6 +127,13 @@ CreateScalarDataArray(int64_t count, const FieldMeta& field_meta) {
                 *(obj->mutable_data()->Add()) = std::string();
             }
             break;
+        }
+        case DataType::JSON: {
+            auto obj = scalar_array->mutable_json_data();
+            obj->mutable_data()->Reserve(count);
+            for (int i = 0; i < count; i++) {
+                *(obj->mutable_data()->Add()) = std::string();
+            }
         }
         default: {
             PanicInfo("unsupported datatype");
@@ -341,7 +350,7 @@ MergeDataArray(
                 auto data = FIELD_DATA(src_field_data, bool).data();
                 auto obj = scalar_array->mutable_bool_data();
                 *(obj->mutable_data()->Add()) = data[src_offset];
-                continue;
+                break;
             }
             case DataType::INT8:
             case DataType::INT16:
@@ -349,34 +358,40 @@ MergeDataArray(
                 auto data = FIELD_DATA(src_field_data, int).data();
                 auto obj = scalar_array->mutable_int_data();
                 *(obj->mutable_data()->Add()) = data[src_offset];
-                continue;
+                break;
             }
             case DataType::INT64: {
                 auto data = FIELD_DATA(src_field_data, long).data();
                 auto obj = scalar_array->mutable_long_data();
                 *(obj->mutable_data()->Add()) = data[src_offset];
-                continue;
+                break;
             }
             case DataType::FLOAT: {
                 auto data = FIELD_DATA(src_field_data, float).data();
                 auto obj = scalar_array->mutable_float_data();
                 *(obj->mutable_data()->Add()) = data[src_offset];
-                continue;
+                break;
             }
             case DataType::DOUBLE: {
                 auto data = FIELD_DATA(src_field_data, double).data();
                 auto obj = scalar_array->mutable_double_data();
                 *(obj->mutable_data()->Add()) = data[src_offset];
-                continue;
+                break;
             }
             case DataType::VARCHAR: {
-                auto& data = src_field_data->scalars().string_data();
+                auto& data = FIELD_DATA(src_field_data, string);
                 auto obj = scalar_array->mutable_string_data();
-                *(obj->mutable_data()->Add()) = data.data(src_offset);
-                continue;
+                *(obj->mutable_data()->Add()) = data[src_offset];
+                break;
+            }
+            case DataType::JSON: {
+                auto& data = FIELD_DATA(src_field_data, json);
+                auto obj = scalar_array->mutable_json_data();
+                *(obj->mutable_data()->Add()) = data[src_offset];
+                break;
             }
             default: {
-                PanicInfo("unsupported datatype");
+                PanicInfo(fmt::format("unsupported data type {}", data_type));
             }
         }
     }

--- a/internal/core/thirdparty/CMakeLists.txt
+++ b/internal/core/thirdparty/CMakeLists.txt
@@ -42,7 +42,9 @@ add_subdirectory(knowhere)
 
 add_subdirectory(boost_ext)
 add_subdirectory(rocksdb)
+add_subdirectory(simdjson)
 
 if (LINUX)
     add_subdirectory(jemalloc)
 endif()
+

--- a/internal/core/thirdparty/simdjson/CMakeLists.txt
+++ b/internal/core/thirdparty/simdjson/CMakeLists.txt
@@ -1,0 +1,19 @@
+#-------------------------------------------------------------------------------
+# Copyright (C) 2019-2020 Zilliz. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under the License.
+#-------------------------------------------------------------------------------
+
+FetchContent_Declare(
+    simdjson
+    GIT_REPOSITORY https://github.com/simdjson/simdjson.git
+    GIT_TAG        v3.1.7
+)
+FetchContent_MakeAvailable(simdjson)

--- a/internal/core/unittest/test_query.cpp
+++ b/internal/core/unittest/test_query.cpp
@@ -194,7 +194,7 @@ TEST(Query, ExecWithPredicateLoader) {
     auto sr = segment->Search(plan.get(), ph_group.get(), time);
     int topk = 5;
 
-    Json json = SearchResultToJson(*sr);
+    query::Json json = SearchResultToJson(*sr);
 #ifdef __linux__
     auto ref = json::parse(R"(
 [
@@ -278,7 +278,7 @@ TEST(Query, ExecWithPredicateSmallN) {
     auto sr = segment->Search(plan.get(), ph_group.get(), time);
     int topk = 5;
 
-    Json json = SearchResultToJson(*sr);
+    query::Json json = SearchResultToJson(*sr);
     std::cout << json.dump(2);
 }
 
@@ -338,7 +338,7 @@ TEST(Query, ExecWithPredicate) {
     auto sr = segment->Search(plan.get(), ph_group.get(), time);
     int topk = 5;
 
-    Json json = SearchResultToJson(*sr);
+    query::Json json = SearchResultToJson(*sr);
 #ifdef __linux__
     auto ref = json::parse(R"(
 [
@@ -874,7 +874,7 @@ TEST(Query, ExecWithPredicateBinary) {
     auto sr = segment->Search(plan.get(), ph_group.get(), time);
     int topk = 5;
 
-    Json json = SearchResultToJson(*sr);
+    query::Json json = SearchResultToJson(*sr);
     std::cout << json.dump(2);
     // ASSERT_EQ(json.dump(2), ref.dump(2));
 }


### PR DESCRIPTION
Use simdjson to process json

To enable mmap and reach least memory usage, we won't store the parsed json doc in memory.
Each doc will be parsed while querying on it, the cost to construct a parser is heavy, so this uses thread local parsers to avoid creating parser each time. 

**This requires to not spawn too many threads in segcore, and reuse the threads but always spawn new ones** 

related #23389 