### PR TITLE
Refine the merge algorithm

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -216,8 +216,8 @@ queryNode:
     memoryLimit: 2147483648 # 2 GB, 2 * 1024 *1024 *1024
   grouping:
     enabled: true
-    maxNQ: 1000
-    topKMergeRatio: 10
+    maxNQ: 50000
+    topKMergeRatio: 20
   scheduler:
     receiveChanSize: 10240
     unsolvedQueueSize: 10240
@@ -226,7 +226,7 @@ queryNode:
     # It defaults to 2.0, which means max read concurrency would be the value of runtime.NumCPU * 2.
     # Max read concurrency must greater than or equal to 1, and less than or equal to runtime.NumCPU * 100.
     # (0, 100]
-    maxReadConcurrentRatio: 2
+    maxReadConcurrentRatio: 1
     cpuRatio: 10 # ratio used to estimate read task cpu usage.
     maxTimestampLag: 86400
   gracefulStopTimeout: 30

--- a/internal/querynodev2/tasks/task.go
+++ b/internal/querynodev2/tasks/task.go
@@ -182,6 +182,7 @@ func (t *SearchTask) Merge(other *SearchTask) bool {
 		otherTopk = other.req.GetReq().GetTopk()
 	)
 
+	diffTopk := topk != otherTopk
 	pre := funcutil.Min(nq*topk, otherNq*otherTopk)
 	maxTopk := funcutil.Max(topk, otherTopk)
 	after := (nq + otherNq) * maxTopk
@@ -194,7 +195,7 @@ func (t *SearchTask) Merge(other *SearchTask) bool {
 		t.req.GetReq().GetDslType() != other.req.GetReq().GetDslType() ||
 		t.req.GetDmlChannels()[0] != other.req.GetDmlChannels()[0] ||
 		nq+otherNq > paramtable.Get().QueryNodeCfg.MaxGroupNQ.GetAsInt64() ||
-		ratio > paramtable.Get().QueryNodeCfg.TopKMergeRatio.GetAsFloat() ||
+		diffTopk && ratio > paramtable.Get().QueryNodeCfg.TopKMergeRatio.GetAsFloat() ||
 		!funcutil.SliceSetEqual(t.req.GetReq().GetPartitionIDs(), other.req.GetReq().GetPartitionIDs()) ||
 		!funcutil.SliceSetEqual(t.req.GetSegmentIDs(), other.req.GetSegmentIDs()) ||
 		!bytes.Equal(t.req.GetReq().GetSerializedExprPlan(), other.req.GetReq().GetSerializedExprPlan()) {

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -1603,7 +1603,7 @@ func (p *queryNodeConfig) init(base *BaseTable) {
 	p.MaxReadConcurrency = ParamItem{
 		Key:          "queryNode.scheduler.maxReadConcurrentRatio",
 		Version:      "2.0.0",
-		DefaultValue: "2.0",
+		DefaultValue: "1.0",
 		Formatter: func(v string) string {
 			ratio := getAsFloat(v)
 			cpuNum := int64(runtime.GOMAXPROCS(0))
@@ -1635,7 +1635,7 @@ Max read concurrency must greater than or equal to 1, and less than or equal to 
 	p.MaxGroupNQ = ParamItem{
 		Key:          "queryNode.grouping.maxNQ",
 		Version:      "2.0.0",
-		DefaultValue: "1000",
+		DefaultValue: "50000",
 		Export:       true,
 	}
 	p.MaxGroupNQ.Init(base.mgr)
@@ -1643,7 +1643,7 @@ Max read concurrency must greater than or equal to 1, and less than or equal to 
 	p.TopKMergeRatio = ParamItem{
 		Key:          "queryNode.grouping.topKMergeRatio",
 		Version:      "2.0.0",
-		DefaultValue: "10.0",
+		DefaultValue: "20.0",
 		Export:       true,
 	}
 	p.TopKMergeRatio.Init(base.mgr)

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -299,9 +299,6 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, true, Params.GroupEnabled.GetAsBool())
 		assert.Equal(t, int32(10240), Params.MaxReceiveChanSize.GetAsInt32())
 		assert.Equal(t, int32(10240), Params.MaxUnsolvedQueueSize.GetAsInt32())
-		assert.Equal(t, int32(runtime.GOMAXPROCS(0)*2), Params.MaxReadConcurrency.GetAsInt32())
-		assert.Equal(t, int64(1000), Params.MaxGroupNQ.GetAsInt64())
-		assert.Equal(t, 10.0, Params.TopKMergeRatio.GetAsFloat())
 		assert.Equal(t, 10.0, Params.CPURatio.GetAsFloat())
 		assert.Equal(t, uint32(runtime.GOMAXPROCS(0)*4), Params.KnowhereThreadPoolSize.GetAsUint32())
 


### PR DESCRIPTION
For given two search tasks t1, t2:
- same topk: merge them if nq1 + nq2 <= MaxNQ
- otherwises: merge them if the merge cost doesn't exceeded merge ratio

the merge cost is defined as:
total cost - min(cost1, cost2)

/kind improvement