### PR TITLE
Improve the metric of binlog size to the level of collection and segment

### DIFF
--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -257,7 +257,6 @@ func (m *meta) GetCollectionBinlogSize() (int64, map[UniqueID]int64) {
 	m.RLock()
 	defer m.RUnlock()
 	collectionBinlogSize := make(map[UniqueID]int64)
-	sizesOfStates := make(map[commonpb.SegmentState]int64)
 	segments := m.segments.GetSegments()
 	var total int64
 	for _, segment := range segments {
@@ -266,10 +265,8 @@ func (m *meta) GetCollectionBinlogSize() (int64, map[UniqueID]int64) {
 			total += segmentSize
 			collectionBinlogSize[segment.GetCollectionID()] += segmentSize
 		}
-		sizesOfStates[segment.GetState()] += segmentSize
-	}
-	for state, size := range sizesOfStates {
-		metrics.DataCoordStoredBinlogSize.WithLabelValues(state.String()).Set(float64(size))
+		metrics.DataCoordStoredBinlogSize.WithLabelValues(
+			fmt.Sprint(segment.GetCollectionID()), fmt.Sprint(segment.GetID())).Set(float64(segmentSize))
 	}
 	return total, collectionBinlogSize
 }

--- a/pkg/metrics/datacoord_metrics.go
+++ b/pkg/metrics/datacoord_metrics.go
@@ -96,7 +96,10 @@ var (
 			Subsystem: typeutil.DataCoordRole,
 			Name:      "stored_binlog_size",
 			Help:      "binlog size of segments",
-		}, []string{segmentStateLabelName})
+		}, []string{
+			collectionIDLabelName,
+			segmentIDLabelName,
+		})
 
 	DataCoordSegmentBinLogFileCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -204,4 +207,8 @@ func CleanupDataCoordSegmentMetrics(collectionID int64, segmentID int64) {
 				collectionIDLabelName: fmt.Sprint(collectionID),
 				segmentIDLabelName:    fmt.Sprint(segmentID),
 			})
+	DataCoordStoredBinlogSize.Delete(prometheus.Labels{
+		collectionIDLabelName: fmt.Sprint(collectionID),
+		segmentIDLabelName:    fmt.Sprint(segmentID),
+	})
 }


### PR DESCRIPTION
/kind improvement

No need to modify Prometheus dashboard, because dashboard shows the sum of binlogs size in the whole cluster.