### PR TITLE
[Cherry-Pick] Make datanode load statslog lazy if SkipBFStatsLog is true

### DIFF
--- a/internal/datanode/data_sync_service.go
+++ b/internal/datanode/data_sync_service.go
@@ -168,6 +168,7 @@ func (dsService *dataSyncService) close() {
 		close(dsService.flushCh)
 		dsService.flushManager.close()
 		dsService.cancelFn()
+		dsService.channel.close()
 	})
 }
 


### PR DESCRIPTION
Cherry-pick from branch 2.2.0
See also #22994
Related to #23477
/kind improvement