### PR TITLE
Optimize JoinIDPath helper on metautil

### DIFF
--- a/pkg/util/metautil/binlog.go
+++ b/pkg/util/metautil/binlog.go
@@ -54,9 +54,17 @@ func getSegmentIDFromPath(logPath string, segmentIndex int) typeutil.UniqueID {
 
 // JoinIDPath joins ids to path format.
 func JoinIDPath(ids ...typeutil.UniqueID) string {
-	idStr := make([]string, 0, len(ids))
-	for _, id := range ids {
-		idStr = append(idStr, strconv.FormatInt(id, 10))
+	var b strings.Builder
+
+	// Allocate bytes for the max positive int64 value plus the separator:
+	b.Grow(len(ids) * 20)
+
+	for n, id := range ids {
+		if n > 0 {
+			b.WriteByte('/')
+		}
+		b.WriteString(strconv.FormatInt(id, 10))
 	}
-	return path.Join(idStr...)
+
+	return b.String()
 }


### PR DESCRIPTION
- Optimize `JoinIDPath` by replacing the `append` and `path.Join` logic with `strings.Builder`.
- Did tests and benchmarks with the following code:
```go
package metautil

import (
	"testing"
)

var (
	bigInts = []int64{
		999999999999999999,
		888888888888888888,
		333333333333333333,
		222222222211111111,
		555555555555555555,
	}
	smallInts = []int64{
		100,
		1000,
		10000,
		35000,
		100000,
	}
	mixedInts = []int64{
		1,
		999999999999999999,
		100000,
		555555555555555555,
		1000,
	}
)

func BenchmarkJoinIDPath(b *testing.B) {
	b.Run("small ints", func(b *testing.B) {
		for i := 0; i < b.N; i++ {
			JoinIDPath(smallInts...)
		}
	})
	b.Run("mixed ints", func(b *testing.B) {
		for i := 0; i < b.N; i++ {
			JoinIDPath(mixedInts...)
		}
	})
	b.Run("big ints", func(b *testing.B) {
		for i := 0; i < b.N; i++ {
			JoinIDPath(bigInts...)
		}
	})
}
```
- Output reports reduced operation time and less memory use, specially with bigger ints:
```
% benchcmp old.txt new.txt 
benchmark                            old ns/op     new ns/op     delta
BenchmarkJoinIDPath/small_ints-8     212           123           -41.98%
BenchmarkJoinIDPath/small_ints-8     214           130           -39.07%
BenchmarkJoinIDPath/small_ints-8     220           126           -42.54%
BenchmarkJoinIDPath/mixed_ints-8     273           131           -52.09%
BenchmarkJoinIDPath/mixed_ints-8     271           129           -52.47%
BenchmarkJoinIDPath/mixed_ints-8     274           128           -53.25%
BenchmarkJoinIDPath/big_ints-8       408           174           -57.32%
BenchmarkJoinIDPath/big_ints-8       428           195           -54.56%
BenchmarkJoinIDPath/big_ints-8       404           178           -56.09%

benchmark                            old allocs     new allocs     delta
BenchmarkJoinIDPath/small_ints-8     8              6              -25.00%
BenchmarkJoinIDPath/small_ints-8     8              6              -25.00%
BenchmarkJoinIDPath/small_ints-8     8              6              -25.00%
BenchmarkJoinIDPath/mixed_ints-8     7              5              -28.57%
BenchmarkJoinIDPath/mixed_ints-8     7              5              -28.57%
BenchmarkJoinIDPath/mixed_ints-8     7              5              -28.57%
BenchmarkJoinIDPath/big_ints-8       8              6              -25.00%
BenchmarkJoinIDPath/big_ints-8       8              6              -25.00%
BenchmarkJoinIDPath/big_ints-8       8              6              -25.00%

benchmark                            old bytes     new bytes     delta
BenchmarkJoinIDPath/small_ints-8     170           122           -28.24%
BenchmarkJoinIDPath/small_ints-8     170           122           -28.24%
BenchmarkJoinIDPath/small_ints-8     170           122           -28.24%
BenchmarkJoinIDPath/mixed_ints-8     272           160           -41.18%
BenchmarkJoinIDPath/mixed_ints-8     272           160           -41.18%
BenchmarkJoinIDPath/mixed_ints-8     272           160           -41.18%
BenchmarkJoinIDPath/big_ints-8       392           216           -44.90%
BenchmarkJoinIDPath/big_ints-8       392           216           -44.90%
BenchmarkJoinIDPath/big_ints-8       392           216           -44.90%
```
- Should benefit the rest of the functions that rely on this helper.