### PR TITLE
fix typo in  milvus-dashboard.json #24124

### DIFF
--- a/deployments/monitor/grafana/milvus-dashboard.json
+++ b/deployments/monitor/grafana/milvus-dashboard.json
@@ -12167,7 +12167,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "prometheus"
+          "uid": "$datasource"
         },
         "definition": "label_values(milvus_proxy_collection_mutation_latency_sum{namespace=\"$namespace\", app_kubernetes_io_instance=~\"$instance\",app_kubernetes_io_name=\"$app_name\"}, collection_name)",
         "hide": 0,


### PR DESCRIPTION
fix a trivial typo making a panel read a hard-coded `prometheus` datasource.

related to the https://github.com/milvus-io/milvus/issues/24124