### PR TITLE
Fix redundant comment that cause dev container build failed

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,6 @@ services:
     build:
       context: .
       dockerfile: build/docker/builder/gpu/${OS_NAME}/Dockerfile
-      # dockerfile: build/docker/builder/cpu/${OS_NAME}/Dockerfile
       cache_from:
         - ${IMAGE_REPO}/milvus-env:${IMAGE_ARCH}-${OS_NAME}-${LATEST_DATE_VERSION}
     # user: {{ CURRENT_ID }}


### PR DESCRIPTION
/kind bug

issue: #24026

When use `./scripts/devcontainer.sh up` cmd to start containers, a `docker-compose-devcontainer.yml` file will be generated from `docker-compose.yml`. But according to the bash script [here](https://github.com/milvus-io/milvus/blob/0c99399f3553fc3c1edb7f8bb38feff61abe89a6/scripts/devcontainer.sh#L58), it only comment out 5 lines.
``` awk 'c&&c--{sub(/^/,"#")} /# Build devcontainer/{c=5} 1' $ROOT_DIR/docker-compose.yml > $ROOT_DIR/docker-compose-devcontainer.yml.tmp```

So the following [line](https://github.com/milvus-io/milvus/blob/0c99399f3553fc3c1edb7f8bb38feff61abe89a6/docker-compose.yml#L56) will be ignored, this leads to a wrong format in the yml file. The container will fail to run.
```- ${IMAGE_REPO}/milvus-env:${IMAGE_ARCH}-${OS_NAME}-${LATEST_DATE_VERSION}```

