### PR TITLE
Optimize the performance of filter by JSON field (#24268)

### DIFF
--- a/internal/core/src/common/Json.h
+++ b/internal/core/src/common/Json.h
@@ -100,23 +100,23 @@ class Json {
     }
 
     bool
-    exist(std::vector<std::string> nested_path) const {
+    exist(std::string_view pointer) const {
+        return doc().at_pointer(pointer).error() == simdjson::SUCCESS;
+    }
+
+    static std::string
+    pointer(std::vector<std::string> nested_path) {
         std::for_each(nested_path.begin(), nested_path.end(), [](std::string& key) {
             boost::replace_all(key, "~", "~0");
             boost::replace_all(key, "/", "~1");
         });
         auto pointer = "/" + boost::algorithm::join(nested_path, "/");
-        return doc().at_pointer(pointer).error() == simdjson::SUCCESS;
+        return pointer;
     }
 
     template <typename T>
     value_result<T>
-    at(std::vector<std::string> nested_path) const {
-        std::for_each(nested_path.begin(), nested_path.end(), [](std::string& key) {
-            boost::replace_all(key, "~", "~0");
-            boost::replace_all(key, "/", "~1");
-        });
-        auto pointer = "/" + boost::algorithm::join(nested_path, "/");
+    at(std::string_view pointer) const {
         return doc().at_pointer(pointer).get<T>();
     }
 

--- a/internal/core/src/query/visitors/ExecExprVisitor.cpp
+++ b/internal/core/src/query/visitors/ExecExprVisitor.cpp
@@ -322,43 +322,43 @@ ExecExprVisitor::ExecUnaryRangeVisitorDispatcher(UnaryRangeExpr& expr_raw) -> Bi
     auto field_id = expr.column_.field_id;
     switch (op) {
         case OpType::Equal: {
-            auto index_func = [val](Index* index) { return index->In(1, &val); };
-            auto elem_func = [val](T x) { return (x == val); };
+            auto index_func = [&](Index* index) { return index->In(1, &val); };
+            auto elem_func = [&](T x) { return (x == val); };
             return ExecRangeVisitorImpl<T>(field_id, index_func, elem_func);
         }
         case OpType::NotEqual: {
-            auto index_func = [val](Index* index) { return index->NotIn(1, &val); };
-            auto elem_func = [val](T x) { return (x != val); };
+            auto index_func = [&](Index* index) { return index->NotIn(1, &val); };
+            auto elem_func = [&](T x) { return (x != val); };
             return ExecRangeVisitorImpl<T>(field_id, index_func, elem_func);
         }
         case OpType::GreaterEqual: {
-            auto index_func = [val](Index* index) { return index->Range(val, OpType::GreaterEqual); };
-            auto elem_func = [val](T x) { return (x >= val); };
+            auto index_func = [&](Index* index) { return index->Range(val, OpType::GreaterEqual); };
+            auto elem_func = [&](T x) { return (x >= val); };
             return ExecRangeVisitorImpl<T>(field_id, index_func, elem_func);
         }
         case OpType::GreaterThan: {
-            auto index_func = [val](Index* index) { return index->Range(val, OpType::GreaterThan); };
-            auto elem_func = [val](T x) { return (x > val); };
+            auto index_func = [&](Index* index) { return index->Range(val, OpType::GreaterThan); };
+            auto elem_func = [&](T x) { return (x > val); };
             return ExecRangeVisitorImpl<T>(field_id, index_func, elem_func);
         }
         case OpType::LessEqual: {
-            auto index_func = [val](Index* index) { return index->Range(val, OpType::LessEqual); };
-            auto elem_func = [val](T x) { return (x <= val); };
+            auto index_func = [&](Index* index) { return index->Range(val, OpType::LessEqual); };
+            auto elem_func = [&](T x) { return (x <= val); };
             return ExecRangeVisitorImpl<T>(field_id, index_func, elem_func);
         }
         case OpType::LessThan: {
-            auto index_func = [val](Index* index) { return index->Range(val, OpType::LessThan); };
-            auto elem_func = [val](T x) { return (x < val); };
+            auto index_func = [&](Index* index) { return index->Range(val, OpType::LessThan); };
+            auto elem_func = [&](T x) { return (x < val); };
             return ExecRangeVisitorImpl<T>(field_id, index_func, elem_func);
         }
         case OpType::PrefixMatch: {
-            auto index_func = [val](Index* index) {
+            auto index_func = [&](Index* index) {
                 auto dataset = std::make_unique<knowhere::Dataset>();
                 dataset->Set(milvus::index::OPERATOR_TYPE, OpType::PrefixMatch);
                 dataset->Set(milvus::index::PREFIX_VALUE, val);
                 return index->Query(std::move(dataset));
             };
-            auto elem_func = [val, op](T x) { return Match(x, val, op); };
+            auto elem_func = [&](T x) { return Match(x, val, op); };
             return ExecRangeVisitorImpl<T>(field_id, index_func, elem_func);
         }
         // TODO: PostfixMatch
@@ -377,66 +377,64 @@ ExecExprVisitor::ExecUnaryRangeVisitorDispatcherJson(UnaryRangeExpr& expr_raw) -
 
     auto op = expr.op_type_;
     auto val = expr.value_;
-    auto& nested_path = expr.column_.nested_path;
+    auto pointer = milvus::Json::pointer(std::move(expr.column_.nested_path));
     auto field_id = expr.column_.field_id;
     auto index_func = [=](Index* index) { return TargetBitmap{}; };
     using GetType = std::conditional_t<std::is_same_v<ExprValueType, std::string>, std::string_view, ExprValueType>;
 
-#define UnaryRangeJSONCompare(cmp)                              \
-    do {                                                        \
-        auto x = json.template at<GetType>(nested_path);        \
-        if (x.error()) {                                        \
-            if constexpr (std::is_same_v<GetType, int64_t>) {   \
-                auto x = json.template at<double>(nested_path); \
-                return !x.error() && (cmp);                     \
-            }                                                   \
-            return false;                                       \
-        }                                                       \
-        return (cmp);                                           \
+#define UnaryRangeJSONCompare(cmp)                            \
+    do {                                                      \
+        auto x = json.template at<GetType>(pointer);          \
+        if (x.error()) {                                      \
+            if constexpr (std::is_same_v<GetType, int64_t>) { \
+                auto x = json.template at<double>(pointer);   \
+                return !x.error() && (cmp);                   \
+            }                                                 \
+            return false;                                     \
+        }                                                     \
+        return (cmp);                                         \
     } while (false)
 
-#define UnaryRangeJSONCompareNotEqual(cmp)                      \
-    do {                                                        \
-        auto x = json.template at<GetType>(nested_path);        \
-        if (x.error()) {                                        \
-            if constexpr (std::is_same_v<GetType, int64_t>) {   \
-                auto x = json.template at<double>(nested_path); \
-                return x.error() || (cmp);                      \
-            }                                                   \
-            return true;                                        \
-        }                                                       \
-        return (cmp);                                           \
+#define UnaryRangeJSONCompareNotEqual(cmp)                    \
+    do {                                                      \
+        auto x = json.template at<GetType>(pointer);          \
+        if (x.error()) {                                      \
+            if constexpr (std::is_same_v<GetType, int64_t>) { \
+                auto x = json.template at<double>(pointer);   \
+                return x.error() || (cmp);                    \
+            }                                                 \
+            return true;                                      \
+        }                                                     \
+        return (cmp);                                         \
     } while (false)
 
     switch (op) {
         case OpType::Equal: {
-            auto elem_func = [val, nested_path](const milvus::Json& json) { UnaryRangeJSONCompare(x.value() == val); };
+            auto elem_func = [&](const milvus::Json& json) { UnaryRangeJSONCompare(x.value() == val); };
             return ExecRangeVisitorImpl<milvus::Json>(field_id, index_func, elem_func);
         }
         case OpType::NotEqual: {
-            auto elem_func = [val, nested_path](const milvus::Json& json) {
-                UnaryRangeJSONCompareNotEqual(x.value() != val);
-            };
+            auto elem_func = [&](const milvus::Json& json) { UnaryRangeJSONCompareNotEqual(x.value() != val); };
             return ExecRangeVisitorImpl<milvus::Json>(field_id, index_func, elem_func);
         }
         case OpType::GreaterEqual: {
-            auto elem_func = [val, nested_path](const milvus::Json& json) { UnaryRangeJSONCompare(x.value() >= val); };
+            auto elem_func = [&](const milvus::Json& json) { UnaryRangeJSONCompare(x.value() >= val); };
             return ExecRangeVisitorImpl<milvus::Json>(field_id, index_func, elem_func);
         }
         case OpType::GreaterThan: {
-            auto elem_func = [val, nested_path](const milvus::Json& json) { UnaryRangeJSONCompare(x.value() > val); };
+            auto elem_func = [&](const milvus::Json& json) { UnaryRangeJSONCompare(x.value() > val); };
             return ExecRangeVisitorImpl<milvus::Json>(field_id, index_func, elem_func);
         }
         case OpType::LessEqual: {
-            auto elem_func = [val, nested_path](const milvus::Json& json) { UnaryRangeJSONCompare(x.value() <= val); };
+            auto elem_func = [&](const milvus::Json& json) { UnaryRangeJSONCompare(x.value() <= val); };
             return ExecRangeVisitorImpl<milvus::Json>(field_id, index_func, elem_func);
         }
         case OpType::LessThan: {
-            auto elem_func = [val, nested_path](const milvus::Json& json) { UnaryRangeJSONCompare(x.value() < val); };
+            auto elem_func = [&](const milvus::Json& json) { UnaryRangeJSONCompare(x.value() < val); };
             return ExecRangeVisitorImpl<milvus::Json>(field_id, index_func, elem_func);
         }
         case OpType::PrefixMatch: {
-            auto elem_func = [val, op, nested_path](const milvus::Json& json) {
+            auto elem_func = [&](const milvus::Json& json) {
                 UnaryRangeJSONCompare(Match(ExprValueType(x.value()), val, op));
             };
             return ExecRangeVisitorImpl<milvus::Json>(field_id, index_func, elem_func);
@@ -578,32 +576,32 @@ ExecExprVisitor::ExecBinaryArithOpEvalRangeVisitorDispatcherJson(BinaryArithOpEv
     auto right_operand = expr.right_operand_;
     auto op = expr.op_type_;
     auto val = expr.value_;
-    auto& nested_path = expr.column_.nested_path;
+    auto pointer = milvus::Json::pointer(std::move(expr.column_.nested_path));
 
-#define BinaryArithRangeJSONCompare(cmp)                        \
-    do {                                                        \
-        auto x = json.template at<GetType>(nested_path);        \
-        if (x.error()) {                                        \
-            if constexpr (std::is_same_v<GetType, int64_t>) {   \
-                auto x = json.template at<double>(nested_path); \
-                return !x.error() && (cmp);                     \
-            }                                                   \
-            return false;                                       \
-        }                                                       \
-        return (cmp);                                           \
+#define BinaryArithRangeJSONCompare(cmp)                      \
+    do {                                                      \
+        auto x = json.template at<GetType>(pointer);          \
+        if (x.error()) {                                      \
+            if constexpr (std::is_same_v<GetType, int64_t>) { \
+                auto x = json.template at<double>(pointer);   \
+                return !x.error() && (cmp);                   \
+            }                                                 \
+            return false;                                     \
+        }                                                     \
+        return (cmp);                                         \
     } while (false)
 
-#define BinaryArithRangeJSONCompareNotEqual(cmp)                \
-    do {                                                        \
-        auto x = json.template at<GetType>(nested_path);        \
-        if (x.error()) {                                        \
-            if constexpr (std::is_same_v<GetType, int64_t>) {   \
-                auto x = json.template at<double>(nested_path); \
-                return x.error() || (cmp);                      \
-            }                                                   \
-            return true;                                        \
-        }                                                       \
-        return (cmp);                                           \
+#define BinaryArithRangeJSONCompareNotEqual(cmp)              \
+    do {                                                      \
+        auto x = json.template at<GetType>(pointer);          \
+        if (x.error()) {                                      \
+            if constexpr (std::is_same_v<GetType, int64_t>) { \
+                auto x = json.template at<double>(pointer);   \
+                return x.error() || (cmp);                    \
+            }                                                 \
+            return true;                                      \
+        }                                                     \
+        return (cmp);                                         \
     } while (false)
 
     switch (op) {
@@ -740,26 +738,26 @@ ExecExprVisitor::ExecBinaryRangeVisitorDispatcherJson(BinaryRangeExpr& expr_raw)
     bool upper_inclusive = expr.upper_inclusive_;
     ExprValueType val1 = expr.lower_value_;
     ExprValueType val2 = expr.upper_value_;
-    auto& nested_path = expr.column_.nested_path;
+    auto pointer = milvus::Json::pointer(std::move(expr.column_.nested_path));
 
     // no json index now
     auto index_func = [=](Index* index) { return TargetBitmap{}; };
 
-#define BinaryRangeJSONCompare(cmp)                                          \
-    do {                                                                     \
-        auto x = json.template at<GetType>(expr.column_.nested_path);        \
-        if (x.error()) {                                                     \
-            if constexpr (std::is_same_v<GetType, int64_t>) {                \
-                auto x = json.template at<double>(expr.column_.nested_path); \
-                if (!x.error()) {                                            \
-                    auto value = x.value();                                  \
-                    return (cmp);                                            \
-                }                                                            \
-            }                                                                \
-            return false;                                                    \
-        }                                                                    \
-        auto value = x.value();                                              \
-        return (cmp);                                                        \
+#define BinaryRangeJSONCompare(cmp)                           \
+    do {                                                      \
+        auto x = json.template at<GetType>(pointer);          \
+        if (x.error()) {                                      \
+            if constexpr (std::is_same_v<GetType, int64_t>) { \
+                auto x = json.template at<double>(pointer);   \
+                if (!x.error()) {                             \
+                    auto value = x.value();                   \
+                    return (cmp);                             \
+                }                                             \
+            }                                                 \
+            return false;                                     \
+        }                                                     \
+        auto value = x.value();                               \
+        return (cmp);                                         \
     } while (false)
 
     if (lower_inclusive && upper_inclusive) {
@@ -1395,7 +1393,7 @@ auto
 ExecExprVisitor::ExecTermVisitorImplTemplateJson(TermExpr& expr_raw) -> BitsetType {
     using Index = index::ScalarIndex<milvus::Json>;
     auto& expr = static_cast<TermExprImpl<ExprValueType>&>(expr_raw);
-    auto& nested_path = expr.column_.nested_path;
+    auto pointer = milvus::Json::pointer(std::move(expr.column_.nested_path));
     auto index_func = [=](Index* index) { return TargetBitmap{}; };
 
     std::unordered_set<ExprValueType> term_set(expr.terms_.begin(), expr.terms_.end());
@@ -1405,9 +1403,9 @@ ExecExprVisitor::ExecTermVisitorImplTemplateJson(TermExpr& expr_raw) -> BitsetTy
         return ExecRangeVisitorImpl<milvus::Json>(expr.column_.field_id, index_func, elem_func);
     }
 
-    auto elem_func = [&term_set, nested_path](const milvus::Json& json) {
+    auto elem_func = [&term_set, &pointer](const milvus::Json& json) {
         using GetType = std::conditional_t<std::is_same_v<ExprValueType, std::string>, std::string_view, ExprValueType>;
-        auto x = json.template at<GetType>(nested_path);
+        auto x = json.template at<GetType>(pointer);
         if (x.error()) {
             return false;
         }
@@ -1497,13 +1495,13 @@ ExecExprVisitor::visit(ExistsExpr& expr) {
     AssertInfo(expr.column_.data_type == field_meta.get_data_type(),
                "[ExecExprVisitor]DataType of expr isn't field_meta data type");
     BitsetType res;
-    auto& nested_path = expr.column_.nested_path;
+    auto pointer = milvus::Json::pointer(std::move(expr.column_.nested_path));
     switch (expr.column_.data_type) {
         case DataType::JSON: {
             using Index = index::ScalarIndex<milvus::Json>;
-            auto index_func = [=](Index* index) { return TargetBitmap{}; };
-            auto elem_func = [nested_path](const milvus::Json& json) {
-                auto x = json.exist(nested_path);
+            auto index_func = [&](Index* index) { return TargetBitmap{}; };
+            auto elem_func = [&](const milvus::Json& json) {
+                auto x = json.exist(pointer);
                 return x;
             };
             res = ExecRangeVisitorImpl<milvus::Json>(expr.column_.field_id, index_func, elem_func);


### PR DESCRIPTION
- Construct JSON pointer only once
- Avoid copying nested path for each row
/kind improvement
related [Bug]: [JSON] Search becomes slowly when searching after flush and int & json mixed expressions  #24186