### PR TITLE
Revert "Retrieve segments concurrently (#24358)"

### DIFF
--- a/internal/querynode/retrieve.go
+++ b/internal/querynode/retrieve.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 
 	"github.com/milvus-io/milvus-proto/go-api/commonpb"
 	"github.com/milvus-io/milvus/internal/metrics"
@@ -32,61 +31,34 @@ import (
 // retrieveOnSegments performs retrieve on listed segments
 // all segment ids are validated before calling this function
 func retrieveOnSegments(ctx context.Context, replica ReplicaInterface, segType segmentType, collID UniqueID, plan *RetrievePlan, segIDs []UniqueID, vcm storage.ChunkManager) ([]*segcorepb.RetrieveResults, error) {
-	var (
-		resultCh = make(chan *segcorepb.RetrieveResults, len(segIDs))
-		errs     = make([]error, len(segIDs))
-		wg       sync.WaitGroup
-	)
+	var retrieveResults []*segcorepb.RetrieveResults
 
 	queryLabel := metrics.SealedSegmentLabel
 	if segType == commonpb.SegmentState_Growing {
 		queryLabel = metrics.GrowingSegmentLabel
 	}
 
-	for i, segID := range segIDs {
-		wg.Add(1)
-		go func(segID int64, i int) {
-			defer wg.Done()
-			seg, err := replica.getSegmentByID(segID, segType)
-			if err != nil {
-				if errors.Is(err, ErrSegmentNotFound) {
-					errs[i] = nil
-					return
-				}
-				errs[i] = err
-				return
+	for _, segID := range segIDs {
+		seg, err := replica.getSegmentByID(segID, segType)
+		if err != nil {
+			if errors.Is(err, ErrSegmentNotFound) {
+				continue
 			}
-			// record retrieve time
-			tr := timerecord.NewTimeRecorder("retrieveOnSegments")
-			result, err := seg.retrieve(plan)
-			if err != nil {
-				errs[i] = err
-				return
-			}
-			if err = seg.fillIndexedFieldsData(ctx, collID, vcm, result); err != nil {
-				errs[i] = err
-				return
-			}
-			errs[i] = nil
-			resultCh <- result
-			metrics.QueryNodeSQSegmentLatency.WithLabelValues(fmt.Sprint(Params.QueryNodeCfg.GetNodeID()),
-				metrics.QueryLabel, queryLabel).Observe(float64(tr.ElapseSpan().Milliseconds()))
-		}(segID, i)
-	}
-	wg.Wait()
-	close(resultCh)
-
-	for _, err := range errs {
+			return nil, err
+		}
+		// record retrieve time
+		tr := timerecord.NewTimeRecorder("retrieveOnSegments")
+		result, err := seg.retrieve(plan)
 		if err != nil {
 			return nil, err
 		}
-	}
-
-	var retrieveResults []*segcorepb.RetrieveResults
-	for result := range resultCh {
+		if err := seg.fillIndexedFieldsData(ctx, collID, vcm, result); err != nil {
+			return nil, err
+		}
 		retrieveResults = append(retrieveResults, result)
+		metrics.QueryNodeSQSegmentLatency.WithLabelValues(fmt.Sprint(Params.QueryNodeCfg.GetNodeID()),
+			metrics.QueryLabel, queryLabel).Observe(float64(tr.ElapseSpan().Milliseconds()))
 	}
-
 	return retrieveResults, nil
 }
 

--- a/internal/querynode/retrieve_test.go
+++ b/internal/querynode/retrieve_test.go
@@ -72,24 +72,4 @@ func TestStreaming_retrieve(t *testing.T) {
 		assert.Len(t, ids, 1)
 	})
 
-	t.Run("test retrieve non-exist segment", func(t *testing.T) {
-		plan, err := genSimpleRetrievePlan(collection)
-		assert.NoError(t, err)
-
-		res, err := retrieveOnSegments(context.TODO(), streaming, segmentTypeGrowing,
-			defaultCollectionID, plan, []int64{999}, nil)
-		assert.NoError(t, err)
-		assert.Len(t, res, 0)
-	})
-
-	t.Run("test retrieve nil segment", func(t *testing.T) {
-		plan, err := genSimpleRetrievePlan(collection)
-		assert.NoError(t, err)
-
-		deleteSegment(segment)
-		res, err := retrieveOnSegments(context.TODO(), streaming, segmentTypeGrowing,
-			defaultCollectionID, plan, []int64{defaultSegmentID}, nil)
-		assert.ErrorIs(t, err, ErrSegmentUnhealthy)
-		assert.Len(t, res, 0)
-	})
 }


### PR DESCRIPTION
This reverts commit a6b82733ad60bf3b0068af18c138650ad7e6239b.
2.2.0 doesn't support GetVector, so we cannot remove the dependency of chunkmanager.

issue: https://github.com/milvus-io/milvus/issues/24244

/kind bug