### PR TITLE
Remove constraint that cannot create index after load

### DIFF
--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -2146,7 +2146,6 @@ func (node *Proxy) CreateIndex(ctx context.Context, request *milvuspb.CreateInde
 		req:        request,
 		rootCoord:  node.rootCoord,
 		indexCoord: node.indexCoord,
-		queryCoord: node.queryCoord,
 	}
 
 	method := "CreateIndex"

--- a/internal/proxy/task_index.go
+++ b/internal/proxy/task_index.go
@@ -55,7 +55,6 @@ type createIndexTask struct {
 	ctx        context.Context
 	rootCoord  types.RootCoord
 	indexCoord types.IndexCoord
-	queryCoord types.QueryCoord
 	result     *commonpb.Status
 
 	isAutoIndex    bool
@@ -299,14 +298,6 @@ func (cit *createIndexTask) PreExecute(ctx context.Context) error {
 		return err
 	}
 
-	loaded, err := isCollectionLoaded(ctx, cit.queryCoord, collID)
-	if err != nil {
-		return err
-	}
-
-	if loaded {
-		return fmt.Errorf("create index failed, collection is loaded, please release it first")
-	}
 	return nil
 }
 

--- a/internal/proxy/task_index_test.go
+++ b/internal/proxy/task_index_test.go
@@ -245,59 +245,13 @@ func TestCreateIndexTask_PreExecute(t *testing.T) {
 			FieldName:      fieldName,
 		},
 		indexCoord:   ic,
-		queryCoord:   nil,
 		result:       nil,
 		collectionID: collectionID,
 	}
 
 	t.Run("normal", func(t *testing.T) {
-		showCollectionMock := func(ctx context.Context, request *querypb.ShowCollectionsRequest) (*querypb.ShowCollectionsResponse, error) {
-			return &querypb.ShowCollectionsResponse{
-				Status: &commonpb.Status{
-					ErrorCode: commonpb.ErrorCode_Success,
-				},
-				CollectionIDs: []int64{},
-			}, nil
-		}
-		qc := NewQueryCoordMock(withValidShardLeaders(), SetQueryCoordShowCollectionsFunc(showCollectionMock))
-		qc.updateState(commonpb.StateCode_Healthy)
-		cit.queryCoord = qc
-
 		err := cit.PreExecute(ctx)
 		assert.NoError(t, err)
-	})
-
-	t.Run("coll has been loaded", func(t *testing.T) {
-		showCollectionMock := func(ctx context.Context, request *querypb.ShowCollectionsRequest) (*querypb.ShowCollectionsResponse, error) {
-			return &querypb.ShowCollectionsResponse{
-				Status: &commonpb.Status{
-					ErrorCode: commonpb.ErrorCode_Success,
-				},
-				CollectionIDs: []int64{collectionID},
-			}, nil
-		}
-		qc := NewQueryCoordMock(withValidShardLeaders(), SetQueryCoordShowCollectionsFunc(showCollectionMock))
-		qc.updateState(commonpb.StateCode_Healthy)
-		cit.queryCoord = qc
-		err := cit.PreExecute(ctx)
-		assert.Error(t, err)
-	})
-
-	t.Run("check load error", func(t *testing.T) {
-		showCollectionMock := func(ctx context.Context, request *querypb.ShowCollectionsRequest) (*querypb.ShowCollectionsResponse, error) {
-			return &querypb.ShowCollectionsResponse{
-				Status: &commonpb.Status{
-					ErrorCode: commonpb.ErrorCode_UnexpectedError,
-					Reason:    "fail reason",
-				},
-				CollectionIDs: nil,
-			}, errors.New("error")
-		}
-		qc := NewQueryCoordMock(withValidShardLeaders(), SetQueryCoordShowCollectionsFunc(showCollectionMock))
-		qc.updateState(commonpb.StateCode_Healthy)
-		cit.queryCoord = qc
-		err := cit.PreExecute(ctx)
-		assert.Error(t, err)
 	})
 }
 
@@ -332,7 +286,6 @@ func Test_parseIndexParams(t *testing.T) {
 		ctx:            nil,
 		rootCoord:      nil,
 		indexCoord:     nil,
-		queryCoord:     nil,
 		result:         nil,
 		isAutoIndex:    false,
 		newIndexParams: nil,
@@ -418,7 +371,6 @@ func Test_parseIndexParams(t *testing.T) {
 		ctx:            nil,
 		rootCoord:      nil,
 		indexCoord:     nil,
-		queryCoord:     nil,
 		result:         nil,
 		isAutoIndex:    false,
 		newIndexParams: nil,
@@ -512,7 +464,6 @@ func Test_parseIndexParams(t *testing.T) {
 			},
 			ctx:            nil,
 			rootCoord:      nil,
-			queryCoord:     nil,
 			result:         nil,
 			isAutoIndex:    false,
 			newIndexParams: nil,

--- a/internal/proxy/task_test.go
+++ b/internal/proxy/task_test.go
@@ -2587,17 +2587,6 @@ func Test_createIndexTask_PreExecute(t *testing.T) {
 			FieldName:      fieldName,
 		},
 	}
-	showCollectionMock := func(ctx context.Context, request *querypb.ShowCollectionsRequest) (*querypb.ShowCollectionsResponse, error) {
-		return &querypb.ShowCollectionsResponse{
-			Status: &commonpb.Status{
-				ErrorCode: commonpb.ErrorCode_Success,
-			},
-			CollectionIDs: []int64{},
-		}, nil
-	}
-	qc := NewQueryCoordMock(withValidShardLeaders(), SetQueryCoordShowCollectionsFunc(showCollectionMock))
-	qc.updateState(commonpb.StateCode_Healthy)
-	cit.queryCoord = qc
 
 	t.Run("normal", func(t *testing.T) {
 		cache := NewMockCache(t)


### PR DESCRIPTION
/kind improvement
handoff is shoveled clean, so the constraint can be removed.