### PR TITLE
Remove explicit constructor to avoid unnecessary move.

### DIFF
--- a/internal/core/src/index/ScalarIndexSort-inl.h
+++ b/internal/core/src/index/ScalarIndexSort-inl.h
@@ -51,7 +51,7 @@ ScalarIndexSort<T>::Build(const size_t n, const T* values) {
     idx_to_offsets_.resize(n);
     T* p = const_cast<T*>(values);
     for (size_t i = 0; i < n; ++i) {
-        data_.emplace_back(IndexStructure(*p++, i));
+        data_.emplace_back(*p++, i);
     }
     std::sort(data_.begin(), data_.end());
     for (size_t i = 0; i < data_.size(); ++i) {


### PR DESCRIPTION
`emplace_back`'s main point is to perfect forward args so that the value can be constructed in-place. Using explicit constructor completely defeats its purpose, since the value is still constructed before being passed to `emplace_back`.