### PR TITLE
Replace shared_ptr with unique_ptr.

### DIFF
--- a/internal/core/src/index/ScalarIndexSort-inl.h
+++ b/internal/core/src/index/ScalarIndexSort-inl.h
@@ -66,10 +66,10 @@ ScalarIndexSort<T>::Serialize(const Config& config) {
     AssertInfo(is_built_, "index has not been built");
 
     auto index_data_size = data_.size() * sizeof(IndexStructure<T>);
-    std::shared_ptr<uint8_t[]> index_data(new uint8_t[index_data_size]);
+    std::unique_ptr<uint8_t[]> index_data(new uint8_t[index_data_size]);
     memcpy(index_data.get(), data_.data(), index_data_size);
 
-    std::shared_ptr<uint8_t[]> index_length(new uint8_t[sizeof(size_t)]);
+    std::unique_ptr<uint8_t[]> index_length(new uint8_t[sizeof(size_t)]);
     auto index_size = data_.size();
     memcpy(index_length.get(), &index_size, sizeof(size_t));
 


### PR DESCRIPTION
shared_ptrs are extremely inefficient due to use of atomic reference counters and extra overhead for control block maintenance. unique_ptr is practically the same as using raw pointer bug with auto-free capability. Note, that `make_unique` (or `make_shared` for the previous version) should be used instead of `new` to make sure the memory is freed even in case of raised exception during construction, but I couldn't find the C++ standard milvus uses, so I didn't know if `make_unique` is allowed.