### PR TITLE
Fix Get segment returns ambiguous result

### DIFF
--- a/internal/querynodev2/segments/retrieve.go
+++ b/internal/querynodev2/segments/retrieve.go
@@ -47,7 +47,7 @@ func retrieveOnSegments(ctx context.Context, manager *Manager, segType SegmentTy
 		wg.Add(1)
 		go func(segID int64, i int) {
 			defer wg.Done()
-			segment, _ := manager.Segment.Get(segID).(*LocalSegment)
+			segment, _ := manager.Segment.GetWithType(segID, segType).(*LocalSegment)
 			if segment == nil {
 				errs[i] = nil
 				return

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -234,7 +234,7 @@ func (loader *segmentLoader) Load(ctx context.Context,
 
 	// Wait for all segments loaded
 	for _, segment := range segments {
-		if loader.manager.Segment.Get(segment.GetSegmentID()) != nil {
+		if loader.manager.Segment.GetWithType(segment.GetSegmentID(), segmentType) != nil {
 			continue
 		}
 

--- a/internal/querynodev2/segments/validate.go
+++ b/internal/querynodev2/segments/validate.go
@@ -71,10 +71,11 @@ func validate(ctx context.Context, manager *Manager, collectionID int64, partiti
 	} else {
 		newSegmentIDs = segmentIDs
 		for _, segmentID := range newSegmentIDs {
-			segment := manager.Segment.Get(segmentID)
-			if segment == nil {
+			segments := manager.Segment.GetBy(WithID(segmentID), segmentFilter)
+			if len(segments) != 1 {
 				continue
 			}
+			segment := segments[0]
 			if !funcutil.SliceContain(searchPartIDs, segment.Partition()) {
 				err := fmt.Errorf("segment %d belongs to partition %d, which is not in %v", segmentID, segment.Partition(), searchPartIDs)
 				return searchPartIDs, newSegmentIDs, err

--- a/internal/querynodev2/services.go
+++ b/internal/querynodev2/services.go
@@ -1124,7 +1124,7 @@ func (node *QueryNode) GetDataDistribution(ctx context.Context, req *querypb.Get
 
 		growingSegments := make(map[int64]*msgpb.MsgPosition)
 		for _, entry := range growing {
-			segment := node.manager.Segment.Get(entry.SegmentID)
+			segment := node.manager.Segment.GetWithType(entry.SegmentID, segments.SegmentTypeGrowing)
 			if segment == nil {
 				log.Warn("leader view growing not found", zap.String("channel", key), zap.Int64("segmentID", entry.SegmentID))
 				growingSegments[entry.SegmentID] = &msgpb.MsgPosition{}


### PR DESCRIPTION
Some `segments.Get` call with out segment type may return unwanted result:
- Segment loader may failed to load when segment with same growing id exists
- LeaderView may returns sealed segment info for growing ones
- Validates logic will pass when other segment type exists
- Retrieving wrong segment type