### PR TITLE
Revert "Consume threads of the number of nq (#24410)"

### DIFF
--- a/internal/querynodev2/tasks/task.go
+++ b/internal/querynodev2/tasks/task.go
@@ -25,7 +25,6 @@ type Task interface {
 	Done(err error)
 	Canceled() error
 	Wait() error
-	Weight() int
 }
 
 type SearchTask struct {
@@ -234,10 +233,6 @@ func (t *SearchTask) Canceled() error {
 
 func (t *SearchTask) Wait() error {
 	return <-t.notifier
-}
-
-func (t *SearchTask) Weight() int {
-	return int(t.nq)
 }
 
 func (t *SearchTask) Result() *internalpb.SearchResults {


### PR DESCRIPTION
This reverts commit 71a7fef5c52a84328a01722b902139518b4d85ff.
/kind improvement
After benchmark, the search performance slows down for some index types