### PR TITLE
[MetaKV refactory part 1]clean up meta interface

### DIFF
--- a/docs/developer_guides/appendix_a_basic_components.md
+++ b/docs/developer_guides/appendix_a_basic_components.md
@@ -426,15 +426,9 @@ type MetaKv interface {
 	TxnKV
 	GetPath(key string) string
 	LoadWithPrefix(key string) ([]string, []string, error)
-	LoadWithPrefix2(key string) ([]string, []string, []int64, error)
-	LoadWithRevision(key string) ([]string, []string, int64, error)
 	Watch(key string) clientv3.WatchChan
 	WatchWithPrefix(key string) clientv3.WatchChan
 	WatchWithRevision(key string, revision int64) clientv3.WatchChan
-	SaveWithLease(key, value string, id clientv3.LeaseID) error
-	Grant(ttl int64) (id clientv3.LeaseID, err error)
-	KeepAlive(id clientv3.LeaseID) (<-chan *clientv3.LeaseKeepAliveResponse, error)
-	CompareValueAndSwap(key, value, target string, opts ...clientv3.OpOption) error
 	CompareVersionAndSwap(key string, version int64, target string, opts ...clientv3.OpOption) error
 }
 

--- a/internal/datacoord/mock_test.go
+++ b/internal/datacoord/mock_test.go
@@ -67,18 +67,6 @@ func (mm *metaMemoryKV) GetPath(key string) string {
 	panic("implement me")
 }
 
-func (mm *metaMemoryKV) LoadWithPrefix2(key string) ([]string, []string, []int64, error) {
-	panic("implement me")
-}
-
-func (mm *metaMemoryKV) LoadWithRevisionAndVersions(key string) ([]string, []string, []int64, int64, error) {
-	panic("implement me")
-}
-
-func (mm *metaMemoryKV) LoadWithRevision(key string) ([]string, []string, int64, error) {
-	panic("implement me")
-}
-
 func (mm *metaMemoryKV) Watch(key string) clientv3.WatchChan {
 	panic("implement me")
 }
@@ -88,26 +76,6 @@ func (mm *metaMemoryKV) WatchWithPrefix(key string) clientv3.WatchChan {
 }
 
 func (mm *metaMemoryKV) WatchWithRevision(key string, revision int64) clientv3.WatchChan {
-	panic("implement me")
-}
-
-func (mm *metaMemoryKV) SaveWithLease(key, value string, id clientv3.LeaseID) error {
-	panic("implement me")
-}
-
-func (mm *metaMemoryKV) SaveWithIgnoreLease(key, value string) error {
-	panic("implement me")
-}
-
-func (mm *metaMemoryKV) Grant(ttl int64) (id clientv3.LeaseID, err error) {
-	panic("implement me")
-}
-
-func (mm *metaMemoryKV) KeepAlive(id clientv3.LeaseID) (<-chan *clientv3.LeaseKeepAliveResponse, error) {
-	panic("implement me")
-}
-
-func (mm *metaMemoryKV) CompareValueAndSwap(key, value, target string, opts ...clientv3.OpOption) (bool, error) {
 	panic("implement me")
 }
 

--- a/internal/datacoord/server.go
+++ b/internal/datacoord/server.go
@@ -38,6 +38,7 @@ import (
 	datanodeclient "github.com/milvus-io/milvus/internal/distributed/datanode/client"
 	indexnodeclient "github.com/milvus-io/milvus/internal/distributed/indexnode/client"
 	rootcoordclient "github.com/milvus-io/milvus/internal/distributed/rootcoord/client"
+	"github.com/milvus-io/milvus/internal/kv"
 	etcdkv "github.com/milvus-io/milvus/internal/kv/etcd"
 	"github.com/milvus-io/milvus/internal/metastore/kv/datacoord"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
@@ -105,7 +106,7 @@ type Server struct {
 
 	etcdCli          *clientv3.Client
 	address          string
-	kvClient         *etcdkv.EtcdKV
+	kvClient         kv.MetaKv
 	meta             *meta
 	segmentManager   Manager
 	allocator        allocator

--- a/internal/indexnode/task_test.go
+++ b/internal/indexnode/task_test.go
@@ -134,10 +134,6 @@ package indexnode
 // 	loadWithPrefix2 func(key string) ([]string, []string, []int64, error)
 // }
 
-// func (mk *mockETCDKV) LoadWithPrefix2(key string) ([]string, []string, []int64, error) {
-// 	return mk.loadWithPrefix2(key)
-// }
-
 // func TestIndexBuildTask_loadIndexMeta(t *testing.T) {
 // 	t.Run("load empty meta", func(t *testing.T) {
 // 		indexTask := &IndexBuildTask{

--- a/internal/kv/etcd/embed_etcd_kv.go
+++ b/internal/kv/etcd/embed_etcd_kv.go
@@ -159,49 +159,6 @@ func (kv *EmbedEtcdKV) LoadBytesWithPrefix(key string) ([]string, [][]byte, erro
 	return keys, values, nil
 }
 
-// LoadWithPrefix2 returns all the keys and values with versions by the given key prefix
-func (kv *EmbedEtcdKV) LoadWithPrefix2(key string) ([]string, []string, []int64, error) {
-	key = path.Join(kv.rootPath, key)
-	log.Debug("LoadWithPrefix ", zap.String("prefix", key))
-	ctx, cancel := context.WithTimeout(context.TODO(), RequestTimeout)
-	defer cancel()
-	resp, err := kv.client.Get(ctx, key, clientv3.WithPrefix(),
-		clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend))
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	keys := make([]string, 0, resp.Count)
-	values := make([]string, 0, resp.Count)
-	versions := make([]int64, 0, resp.Count)
-	for _, kv := range resp.Kvs {
-		keys = append(keys, string(kv.Key))
-		values = append(values, string(kv.Value))
-		versions = append(versions, kv.Version)
-	}
-	return keys, values, versions, nil
-}
-
-func (kv *EmbedEtcdKV) LoadWithRevisionAndVersions(key string) ([]string, []string, []int64, int64, error) {
-	key = path.Join(kv.rootPath, key)
-	log.Debug("LoadWithPrefix ", zap.String("prefix", key))
-	ctx, cancel := context.WithTimeout(context.TODO(), RequestTimeout)
-	defer cancel()
-	resp, err := kv.client.Get(ctx, key, clientv3.WithPrefix(),
-		clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend))
-	if err != nil {
-		return nil, nil, nil, 0, err
-	}
-	keys := make([]string, 0, resp.Count)
-	values := make([]string, 0, resp.Count)
-	versions := make([]int64, 0, resp.Count)
-	for _, kv := range resp.Kvs {
-		keys = append(keys, string(kv.Key))
-		values = append(values, string(kv.Value))
-		versions = append(versions, kv.Version)
-	}
-	return keys, values, versions, resp.Header.Revision, nil
-}
-
 // LoadBytesWithPrefix2 returns all the keys and values with versions by the given key prefix
 func (kv *EmbedEtcdKV) LoadBytesWithPrefix2(key string) ([]string, [][]byte, []int64, error) {
 	key = path.Join(kv.rootPath, key)
@@ -328,26 +285,6 @@ func (kv *EmbedEtcdKV) MultiLoadBytes(keys []string) ([][]byte, error) {
 	return result, nil
 }
 
-// LoadWithRevision returns keys, values and revision with given key prefix.
-func (kv *EmbedEtcdKV) LoadWithRevision(key string) ([]string, []string, int64, error) {
-	key = path.Join(kv.rootPath, key)
-	log.Debug("LoadWithPrefix ", zap.String("prefix", key))
-	ctx, cancel := context.WithTimeout(context.TODO(), RequestTimeout)
-	defer cancel()
-	resp, err := kv.client.Get(ctx, key, clientv3.WithPrefix(),
-		clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend))
-	if err != nil {
-		return nil, nil, 0, err
-	}
-	keys := make([]string, 0, resp.Count)
-	values := make([]string, 0, resp.Count)
-	for _, kv := range resp.Kvs {
-		keys = append(keys, string(kv.Key))
-		values = append(values, string(kv.Value))
-	}
-	return keys, values, resp.Header.Revision, nil
-}
-
 // LoadBytesWithRevision returns keys, values and revision with given key prefix.
 func (kv *EmbedEtcdKV) LoadBytesWithRevision(key string) ([]string, [][]byte, int64, error) {
 	key = path.Join(kv.rootPath, key)
@@ -383,26 +320,6 @@ func (kv *EmbedEtcdKV) SaveBytes(key string, value []byte) error {
 	ctx, cancel := context.WithTimeout(context.TODO(), RequestTimeout)
 	defer cancel()
 	_, err := kv.client.Put(ctx, key, string(value))
-	return err
-}
-
-// SaveWithLease is a function to put value in etcd with etcd lease options.
-func (kv *EmbedEtcdKV) SaveWithLease(key, value string, id clientv3.LeaseID) error {
-	log.Debug("Embedded Etcd saving with lease", zap.String("etcd_key", key))
-	key = path.Join(kv.rootPath, key)
-	ctx, cancel := context.WithTimeout(context.TODO(), RequestTimeout)
-	defer cancel()
-	_, err := kv.client.Put(ctx, key, value, clientv3.WithLease(id))
-	return err
-}
-
-// SaveWithIgnoreLease updates the key without changing its current lease.
-func (kv *EmbedEtcdKV) SaveWithIgnoreLease(key, value string) error {
-	log.Debug("Embedded Etcd saving with ignore lease", zap.String("etcd_key", key))
-	key = path.Join(kv.rootPath, key)
-	ctx, cancel := context.WithTimeout(context.TODO(), RequestTimeout)
-	defer cancel()
-	_, err := kv.client.Put(ctx, key, value, clientv3.WithIgnoreLease())
 	return err
 }
 
@@ -578,56 +495,6 @@ func (kv *EmbedEtcdKV) MultiSaveBytesAndRemoveWithPrefix(saves map[string][]byte
 
 	_, err := kv.client.Txn(ctx).If().Then(ops...).Commit()
 	return err
-}
-
-// Grant creates a new lease implemented in etcd grant interface.
-func (kv *EmbedEtcdKV) Grant(ttl int64) (id clientv3.LeaseID, err error) {
-	resp, err := kv.client.Grant(context.Background(), ttl)
-	return resp.ID, err
-}
-
-// KeepAlive keeps the lease alive forever with leaseID.
-// Implemented in etcd interface.
-func (kv *EmbedEtcdKV) KeepAlive(id clientv3.LeaseID) (<-chan *clientv3.LeaseKeepAliveResponse, error) {
-	ch, err := kv.client.KeepAlive(context.Background(), id)
-	if err != nil {
-		return nil, err
-	}
-	return ch, nil
-}
-
-// CompareValueAndSwap compares the existing value with compare, and if they are
-// equal, the target is stored in etcd.
-func (kv *EmbedEtcdKV) CompareValueAndSwap(key, value, target string, opts ...clientv3.OpOption) (bool, error) {
-	ctx, cancel := context.WithTimeout(context.TODO(), RequestTimeout)
-	defer cancel()
-	resp, err := kv.client.Txn(ctx).If(
-		clientv3.Compare(
-			clientv3.Value(path.Join(kv.rootPath, key)),
-			"=",
-			value)).
-		Then(clientv3.OpPut(path.Join(kv.rootPath, key), target, opts...)).Commit()
-	if err != nil {
-		return false, err
-	}
-	return resp.Succeeded, nil
-}
-
-// CompareValueAndSwapBytes compares the existing value with compare, and if they are
-// equal, the target is stored in etcd.
-func (kv *EmbedEtcdKV) CompareValueAndSwapBytes(key string, value, target []byte, opts ...clientv3.OpOption) (bool, error) {
-	ctx, cancel := context.WithTimeout(context.TODO(), RequestTimeout)
-	defer cancel()
-	resp, err := kv.client.Txn(ctx).If(
-		clientv3.Compare(
-			clientv3.Value(path.Join(kv.rootPath, key)),
-			"=",
-			string(value))).
-		Then(clientv3.OpPut(path.Join(kv.rootPath, key), string(target), opts...)).Commit()
-	if err != nil {
-		return false, err
-	}
-	return resp.Succeeded, nil
 }
 
 // CompareVersionAndSwap compares the existing key-value's version with version, and if

--- a/internal/kv/kv.go
+++ b/internal/kv/kv.go
@@ -67,17 +67,9 @@ type MetaKv interface {
 	TxnKV
 	GetPath(key string) string
 	LoadWithPrefix(key string) ([]string, []string, error)
-	LoadWithPrefix2(key string) ([]string, []string, []int64, error)
-	LoadWithRevisionAndVersions(key string) ([]string, []string, []int64, int64, error)
-	LoadWithRevision(key string) ([]string, []string, int64, error)
 	Watch(key string) clientv3.WatchChan
 	WatchWithPrefix(key string) clientv3.WatchChan
 	WatchWithRevision(key string, revision int64) clientv3.WatchChan
-	SaveWithLease(key, value string, id clientv3.LeaseID) error
-	SaveWithIgnoreLease(key, value string) error
-	Grant(ttl int64) (id clientv3.LeaseID, err error)
-	KeepAlive(id clientv3.LeaseID) (<-chan *clientv3.LeaseKeepAliveResponse, error)
-	CompareValueAndSwap(key, value, target string, opts ...clientv3.OpOption) (bool, error)
 	CompareVersionAndSwap(key string, version int64, target string, opts ...clientv3.OpOption) (bool, error)
 	WalkWithPrefix(prefix string, paginationSize int, fn func([]byte, []byte) error) error
 }

--- a/internal/querynodev2/server.go
+++ b/internal/querynodev2/server.go
@@ -45,7 +45,6 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/commonpb"
 	grpcquerynodeclient "github.com/milvus-io/milvus/internal/distributed/querynode/client"
-	etcdkv "github.com/milvus-io/milvus/internal/kv/etcd"
 	"github.com/milvus-io/milvus/internal/querynodev2/cluster"
 	"github.com/milvus-io/milvus/internal/querynodev2/delegator"
 	"github.com/milvus-io/milvus/internal/querynodev2/pipeline"
@@ -118,7 +117,6 @@ type QueryNode struct {
 
 	cacheChunkManager storage.ChunkManager
 	vectorStorage     storage.ChunkManager
-	etcdKV            *etcdkv.EtcdKV
 
 	/*
 		// Pool for search/query
@@ -274,7 +272,6 @@ func (node *QueryNode) Init() error {
 			return
 		}
 
-		node.etcdKV = etcdkv.NewEtcdKV(node.etcdCli, paramtable.Get().EtcdCfg.MetaRootPath.GetValue())
 		log.Info("queryNode try to connect etcd success", zap.String("MetaRootPath", paramtable.Get().EtcdCfg.MetaRootPath.GetValue()))
 
 		node.scheduler = tasks.NewScheduler()


### PR DESCRIPTION
1. remove unused EtcdKV
-  internal/querynodev2/server.go

3. replace EtcdKV with interface MetaKv
- internal/datacoord/server.go

4. remove unused methods from MetaKv interface 
- internal/kv/kv.go
- etc

Issue: #24694
