### PR TITLE
Fix confusing log while plugin is not enabled

### DIFF
--- a/internal/querynode/query_node.go
+++ b/internal/querynode/query_node.go
@@ -185,8 +185,8 @@ func NewQueryNode(ctx context.Context, factory dependency.Factory) *QueryNode {
 	var err error
 	queryNode.queryHook, err = initHook()
 	if err != nil {
-		log.Error("load queryhook failed", zap.Error(err))
 		if Params.AutoIndexConfig.Enable {
+			log.Error("load queryhook failed", zap.Error(err))
 			panic(err)
 		}
 	}


### PR DESCRIPTION
`QueryNode` prints error log when plugin is not set even `autoindex` is not enabled
Move this error log to branch where `autoindex` is enabled
/kind improvement