### PR TITLE
[Cherry-Pick] Fix confusing log while plugin is not enabled

### DIFF
--- a/internal/querynodev2/server.go
+++ b/internal/querynodev2/server.go
@@ -238,9 +238,9 @@ func (node *QueryNode) Init() error {
 
 		err = node.initHook()
 		if err != nil {
-			log.Error("QueryNode init hook failed", zap.Error(err))
 			// auto index cannot work if hook init failed
 			if paramtable.Get().AutoIndexConfig.Enable.GetAsBool() {
+				log.Error("QueryNode init hook failed", zap.Error(err))
 				initError = err
 				return
 			}


### PR DESCRIPTION
`QueryNode` prints error log when plugin is not set even `autoindex` is not enabled
Move this error log to branch where `autoindex` is enabled
/kind improvement