### PR TITLE
Write all data into the same buffer to reduce copy

### DIFF
--- a/internal/core/src/storage/PayloadReader.cpp
+++ b/internal/core/src/storage/PayloadReader.cpp
@@ -47,7 +47,7 @@ PayloadReader::init(std::shared_ptr<arrow::io::BufferReader> input) {
 
     parquet::arrow::FileReaderBuilder reader_builder;
     auto st = reader_builder.Open(input, reader_properties);
-    AssertInfo(st.ok(), "file to read file");
+    AssertInfo(st.ok(), st.message());
     reader_builder.memory_pool(pool);
     reader_builder.properties(arrow_reader_props);
 

--- a/internal/storage/binlog_reader.go
+++ b/internal/storage/binlog_reader.go
@@ -24,6 +24,8 @@ import (
 	"io"
 
 	"github.com/milvus-io/milvus/internal/common"
+	"github.com/milvus-io/milvus/internal/log"
+	"go.uber.org/zap"
 )
 
 // BinlogReader is an object to read binlog file. Binlog file's format can be
@@ -117,6 +119,8 @@ func NewBinlogReader(data []byte) (*BinlogReader, error) {
 		buffer:  bytes.NewBuffer(data),
 		isClose: false,
 	}
+
+	log.Info("yah01: binlog reader", zap.Int("size", reader.buffer.Len()))
 
 	if _, err := reader.readMagicNumber(); err != nil {
 		return nil, err

--- a/internal/storage/binlog_test.go
+++ b/internal/storage/binlog_test.go
@@ -1482,7 +1482,7 @@ func (e *testEvent) GetMemoryUsageInBytes() (int32, error) {
 	}
 	return 0, nil
 }
-func (e *testEvent) GetPayloadLengthFromWriter() (int, error) {
+func (e *testEvent) Length() (int, error) {
 	if e.getPayloadLengthError {
 		return -1, fmt.Errorf("getPayloadLength error")
 	}

--- a/internal/storage/binlog_writer.go
+++ b/internal/storage/binlog_writer.go
@@ -23,7 +23,9 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/common"
+	"github.com/milvus-io/milvus/internal/log"
 	"github.com/milvus-io/milvus/internal/util/typeutil"
+	"go.uber.org/zap"
 )
 
 // BinlogType is to distinguish different files saving different data.
@@ -53,10 +55,11 @@ type baseBinlogWriter struct {
 	eventWriters []EventWriter
 	buffer       *bytes.Buffer
 	length       int32
+	closed       bool
 }
 
 func (writer *baseBinlogWriter) isClosed() bool {
-	return writer.buffer != nil
+	return writer.closed
 }
 
 // GetEventNums returns the number of event writers
@@ -72,7 +75,7 @@ func (writer *baseBinlogWriter) GetRowNums() (int32, error) {
 
 	length := 0
 	for _, e := range writer.eventWriters {
-		rows, err := e.GetPayloadLengthFromWriter()
+		rows, err := e.Length()
 		if err != nil {
 			return 0, err
 		}
@@ -88,7 +91,7 @@ func (writer *baseBinlogWriter) GetBinlogType() BinlogType {
 
 // GetBuffer gets binlog buffer. Return nil if binlog is not finished yet.
 func (writer *baseBinlogWriter) GetBuffer() ([]byte, error) {
-	if writer.buffer == nil {
+	if !writer.closed {
 		return nil, fmt.Errorf("please close binlog before get buffer")
 	}
 	return writer.buffer.Bytes(), nil
@@ -96,15 +99,16 @@ func (writer *baseBinlogWriter) GetBuffer() ([]byte, error) {
 
 // Finish allocates buffer and releases resource
 func (writer *baseBinlogWriter) Finish() error {
-	if writer.buffer != nil {
+	if writer.closed {
 		return nil
 	}
+	writer.closed = true
+
 	if writer.StartTimestamp == 0 || writer.EndTimestamp == 0 {
 		return fmt.Errorf("invalid start/end timestamp")
 	}
 
 	var offset int32
-	writer.buffer = new(bytes.Buffer)
 	if err := binary.Write(writer.buffer, common.Endian, MagicNumber); err != nil {
 		return err
 	}
@@ -120,20 +124,29 @@ func (writer *baseBinlogWriter) Finish() error {
 		if err := w.Finish(); err != nil {
 			return err
 		}
-		if err := w.Write(writer.buffer); err != nil {
-			return err
-		}
-		length, err := w.GetMemoryUsageInBytes()
+		size, err := w.GetMemoryUsageInBytes()
 		if err != nil {
 			return err
 		}
-		offset += length
-		rows, err := w.GetPayloadLengthFromWriter()
+		if offset+size != w.Header().NextPosition {
+			panic(fmt.Sprintf("offset %d + size %d != NextPosition %d",
+				offset,
+				size,
+				w.Header().NextPosition,
+			))
+		}
+		if w.Header().EventLength != size {
+			panic(fmt.Sprintf("event length %d != %d", w.Header().EventLength, size))
+		}
+		offset += size
+		rows, err := w.Length()
 		if err != nil {
 			return err
 		}
 		writer.length += int32(rows)
 	}
+
+	log.Info("yah01: binlog write done", zap.Int("size", writer.buffer.Len()))
 	return nil
 }
 
@@ -141,6 +154,7 @@ func (writer *baseBinlogWriter) Close() {
 	for _, e := range writer.eventWriters {
 		e.Close()
 	}
+	writer.closed = true
 }
 
 // InsertBinlogWriter is an object to write binlog file which saves insert data.
@@ -156,14 +170,15 @@ func (writer *InsertBinlogWriter) NextInsertEventWriter(dim ...int) (*insertEven
 
 	var event *insertEventWriter
 	var err error
+	vecDim := 1
 	if typeutil.IsVectorType(writer.PayloadDataType) {
 		if len(dim) != 1 {
 			return nil, fmt.Errorf("incorrect input numbers")
 		}
-		event, err = newInsertEventWriter(writer.PayloadDataType, dim[0])
-	} else {
-		event, err = newInsertEventWriter(writer.PayloadDataType)
+		vecDim = dim[0]
 	}
+
+	event, err = newInsertEventWriter(writer.PayloadDataType, writer.buffer, vecDim)
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +197,7 @@ func (writer *DeleteBinlogWriter) NextDeleteEventWriter() (*deleteEventWriter, e
 	if writer.isClosed() {
 		return nil, fmt.Errorf("binlog has closed")
 	}
-	event, err := newDeleteEventWriter(writer.PayloadDataType)
+	event, err := newDeleteEventWriter(writer.PayloadDataType, writer.buffer)
 	if err != nil {
 		return nil, err
 	}
@@ -201,7 +216,7 @@ func (writer *DDLBinlogWriter) NextCreateCollectionEventWriter() (*createCollect
 	if writer.isClosed() {
 		return nil, fmt.Errorf("binlog has closed")
 	}
-	event, err := newCreateCollectionEventWriter(writer.PayloadDataType)
+	event, err := newCreateCollectionEventWriter(writer.PayloadDataType, writer.buffer)
 	if err != nil {
 		return nil, err
 	}
@@ -215,7 +230,7 @@ func (writer *DDLBinlogWriter) NextDropCollectionEventWriter() (*dropCollectionE
 	if writer.isClosed() {
 		return nil, fmt.Errorf("binlog has closed")
 	}
-	event, err := newDropCollectionEventWriter(writer.PayloadDataType)
+	event, err := newDropCollectionEventWriter(writer.PayloadDataType, writer.buffer)
 	if err != nil {
 		return nil, err
 	}
@@ -229,7 +244,7 @@ func (writer *DDLBinlogWriter) NextCreatePartitionEventWriter() (*createPartitio
 	if writer.isClosed() {
 		return nil, fmt.Errorf("binlog has closed")
 	}
-	event, err := newCreatePartitionEventWriter(writer.PayloadDataType)
+	event, err := newCreatePartitionEventWriter(writer.PayloadDataType, writer.buffer)
 	if err != nil {
 		return nil, err
 	}
@@ -243,7 +258,7 @@ func (writer *DDLBinlogWriter) NextDropPartitionEventWriter() (*dropPartitionEve
 	if writer.isClosed() {
 		return nil, fmt.Errorf("binlog has closed")
 	}
-	event, err := newDropPartitionEventWriter(writer.PayloadDataType)
+	event, err := newDropPartitionEventWriter(writer.PayloadDataType, writer.buffer)
 	if err != nil {
 		return nil, err
 	}
@@ -261,7 +276,7 @@ func (writer *IndexFileBinlogWriter) NextIndexFileEventWriter() (*indexFileEvent
 	if writer.isClosed() {
 		return nil, fmt.Errorf("binlog has closed")
 	}
-	event, err := newIndexFileEventWriter(writer.PayloadDataType)
+	event, err := newIndexFileEventWriter(writer.PayloadDataType, writer.buffer)
 	if err != nil {
 		return nil, err
 	}
@@ -284,7 +299,7 @@ func NewInsertBinlogWriter(dataType schemapb.DataType, collectionID, partitionID
 			magicNumber:     MagicNumber,
 			binlogType:      InsertBinlog,
 			eventWriters:    make([]EventWriter, 0),
-			buffer:          nil,
+			buffer:          new(bytes.Buffer),
 		},
 	}
 
@@ -304,7 +319,7 @@ func NewDeleteBinlogWriter(dataType schemapb.DataType, collectionID, partitionID
 			magicNumber:     MagicNumber,
 			binlogType:      DeleteBinlog,
 			eventWriters:    make([]EventWriter, 0),
-			buffer:          nil,
+			buffer:          new(bytes.Buffer),
 		},
 	}
 	return w
@@ -321,7 +336,7 @@ func NewDDLBinlogWriter(dataType schemapb.DataType, collectionID int64) *DDLBinl
 			magicNumber:     MagicNumber,
 			binlogType:      DDLBinlog,
 			eventWriters:    make([]EventWriter, 0),
-			buffer:          nil,
+			buffer:          new(bytes.Buffer),
 		},
 	}
 	return w

--- a/internal/storage/event_test.go
+++ b/internal/storage/event_test.go
@@ -177,7 +177,7 @@ func TestInsertEvent(t *testing.T) {
 	}
 
 	t.Run("insert_bool", func(t *testing.T) {
-		w, err := newInsertEventWriter(schemapb.DataType_Bool)
+		w, err := newInsertEventWriter(schemapb.DataType_Bool, new(bytes.Buffer))
 		assert.Nil(t, err)
 		insertT(t, schemapb.DataType_Bool, w,
 			func(w *insertEventWriter) error {
@@ -193,7 +193,7 @@ func TestInsertEvent(t *testing.T) {
 	})
 
 	t.Run("insert_int8", func(t *testing.T) {
-		w, err := newInsertEventWriter(schemapb.DataType_Int8)
+		w, err := newInsertEventWriter(schemapb.DataType_Int8, new(bytes.Buffer))
 		assert.Nil(t, err)
 		insertT(t, schemapb.DataType_Int8, w,
 			func(w *insertEventWriter) error {
@@ -209,7 +209,7 @@ func TestInsertEvent(t *testing.T) {
 	})
 
 	t.Run("insert_int16", func(t *testing.T) {
-		w, err := newInsertEventWriter(schemapb.DataType_Int16)
+		w, err := newInsertEventWriter(schemapb.DataType_Int16, new(bytes.Buffer))
 		assert.Nil(t, err)
 		insertT(t, schemapb.DataType_Int16, w,
 			func(w *insertEventWriter) error {
@@ -225,7 +225,7 @@ func TestInsertEvent(t *testing.T) {
 	})
 
 	t.Run("insert_int32", func(t *testing.T) {
-		w, err := newInsertEventWriter(schemapb.DataType_Int32)
+		w, err := newInsertEventWriter(schemapb.DataType_Int32, new(bytes.Buffer))
 		assert.Nil(t, err)
 		insertT(t, schemapb.DataType_Int32, w,
 			func(w *insertEventWriter) error {
@@ -241,7 +241,7 @@ func TestInsertEvent(t *testing.T) {
 	})
 
 	t.Run("insert_int64", func(t *testing.T) {
-		w, err := newInsertEventWriter(schemapb.DataType_Int64)
+		w, err := newInsertEventWriter(schemapb.DataType_Int64, new(bytes.Buffer))
 		assert.Nil(t, err)
 		insertT(t, schemapb.DataType_Int64, w,
 			func(w *insertEventWriter) error {
@@ -257,7 +257,7 @@ func TestInsertEvent(t *testing.T) {
 	})
 
 	t.Run("insert_float32", func(t *testing.T) {
-		w, err := newInsertEventWriter(schemapb.DataType_Float)
+		w, err := newInsertEventWriter(schemapb.DataType_Float, new(bytes.Buffer))
 		assert.Nil(t, err)
 		insertT(t, schemapb.DataType_Float, w,
 			func(w *insertEventWriter) error {
@@ -273,7 +273,7 @@ func TestInsertEvent(t *testing.T) {
 	})
 
 	t.Run("insert_float64", func(t *testing.T) {
-		w, err := newInsertEventWriter(schemapb.DataType_Double)
+		w, err := newInsertEventWriter(schemapb.DataType_Double, new(bytes.Buffer))
 		assert.Nil(t, err)
 		insertT(t, schemapb.DataType_Double, w,
 			func(w *insertEventWriter) error {
@@ -289,7 +289,7 @@ func TestInsertEvent(t *testing.T) {
 	})
 
 	t.Run("insert_binary_vector", func(t *testing.T) {
-		w, err := newInsertEventWriter(schemapb.DataType_BinaryVector, 16)
+		w, err := newInsertEventWriter(schemapb.DataType_BinaryVector, new(bytes.Buffer), 16)
 		assert.Nil(t, err)
 		insertT(t, schemapb.DataType_BinaryVector, w,
 			func(w *insertEventWriter) error {
@@ -305,7 +305,7 @@ func TestInsertEvent(t *testing.T) {
 	})
 
 	t.Run("insert_float_vector", func(t *testing.T) {
-		w, err := newInsertEventWriter(schemapb.DataType_FloatVector, 2)
+		w, err := newInsertEventWriter(schemapb.DataType_FloatVector, new(bytes.Buffer), 2)
 		assert.Nil(t, err)
 		insertT(t, schemapb.DataType_FloatVector, w,
 			func(w *insertEventWriter) error {
@@ -321,7 +321,7 @@ func TestInsertEvent(t *testing.T) {
 	})
 
 	t.Run("insert_string", func(t *testing.T) {
-		w, err := newInsertEventWriter(schemapb.DataType_String)
+		w, err := newInsertEventWriter(schemapb.DataType_String, new(bytes.Buffer))
 		assert.Nil(t, err)
 		w.SetEventTimestamp(tsoutil.ComposeTS(10, 0), tsoutil.ComposeTS(100, 0))
 		err = w.AddDataToPayload("1234")
@@ -375,7 +375,7 @@ func TestInsertEvent(t *testing.T) {
 // delete data will always be saved as string(pk + ts) to binlog
 func TestDeleteEvent(t *testing.T) {
 	t.Run("delete_string", func(t *testing.T) {
-		w, err := newDeleteEventWriter(schemapb.DataType_String)
+		w, err := newDeleteEventWriter(schemapb.DataType_String, new(bytes.Buffer))
 		assert.Nil(t, err)
 		w.SetEventTimestamp(tsoutil.ComposeTS(10, 0), tsoutil.ComposeTS(100, 0))
 		err = w.AddDataToPayload("1234")
@@ -429,13 +429,13 @@ func TestDeleteEvent(t *testing.T) {
 /* #nosec G103 */
 func TestCreateCollectionEvent(t *testing.T) {
 	t.Run("create_event", func(t *testing.T) {
-		w, err := newCreateCollectionEventWriter(schemapb.DataType_Float)
+		w, err := newCreateCollectionEventWriter(schemapb.DataType_Float, new(bytes.Buffer))
 		assert.NotNil(t, err)
 		assert.Nil(t, w)
 	})
 
 	t.Run("create_collection_timestamp", func(t *testing.T) {
-		w, err := newCreateCollectionEventWriter(schemapb.DataType_Int64)
+		w, err := newCreateCollectionEventWriter(schemapb.DataType_Int64, new(bytes.Buffer))
 		assert.Nil(t, err)
 		w.SetEventTimestamp(tsoutil.ComposeTS(10, 0), tsoutil.ComposeTS(100, 0))
 		err = w.AddDataToPayload([]int64{1, 2, 3})
@@ -477,7 +477,7 @@ func TestCreateCollectionEvent(t *testing.T) {
 	})
 
 	t.Run("create_collection_string", func(t *testing.T) {
-		w, err := newCreateCollectionEventWriter(schemapb.DataType_String)
+		w, err := newCreateCollectionEventWriter(schemapb.DataType_String, new(bytes.Buffer))
 		assert.Nil(t, err)
 		w.SetEventTimestamp(tsoutil.ComposeTS(10, 0), tsoutil.ComposeTS(100, 0))
 		err = w.AddDataToPayload("1234")
@@ -531,13 +531,13 @@ func TestCreateCollectionEvent(t *testing.T) {
 /* #nosec G103 */
 func TestDropCollectionEvent(t *testing.T) {
 	t.Run("drop_event", func(t *testing.T) {
-		w, err := newDropCollectionEventWriter(schemapb.DataType_Float)
+		w, err := newDropCollectionEventWriter(schemapb.DataType_Float, new(bytes.Buffer))
 		assert.NotNil(t, err)
 		assert.Nil(t, w)
 	})
 
 	t.Run("drop_collection_timestamp", func(t *testing.T) {
-		w, err := newDropCollectionEventWriter(schemapb.DataType_Int64)
+		w, err := newDropCollectionEventWriter(schemapb.DataType_Int64, new(bytes.Buffer))
 		assert.Nil(t, err)
 		w.SetEventTimestamp(tsoutil.ComposeTS(10, 0), tsoutil.ComposeTS(100, 0))
 		err = w.AddDataToPayload([]int64{1, 2, 3})
@@ -579,7 +579,7 @@ func TestDropCollectionEvent(t *testing.T) {
 	})
 
 	t.Run("drop_collection_string", func(t *testing.T) {
-		w, err := newDropCollectionEventWriter(schemapb.DataType_String)
+		w, err := newDropCollectionEventWriter(schemapb.DataType_String, new(bytes.Buffer))
 		assert.Nil(t, err)
 		w.SetEventTimestamp(tsoutil.ComposeTS(10, 0), tsoutil.ComposeTS(100, 0))
 		err = w.AddDataToPayload("1234")
@@ -633,13 +633,13 @@ func TestDropCollectionEvent(t *testing.T) {
 /* #nosec G103 */
 func TestCreatePartitionEvent(t *testing.T) {
 	t.Run("create_event", func(t *testing.T) {
-		w, err := newCreatePartitionEventWriter(schemapb.DataType_Float)
+		w, err := newCreatePartitionEventWriter(schemapb.DataType_Float, new(bytes.Buffer))
 		assert.NotNil(t, err)
 		assert.Nil(t, w)
 	})
 
 	t.Run("create_partition_timestamp", func(t *testing.T) {
-		w, err := newCreatePartitionEventWriter(schemapb.DataType_Int64)
+		w, err := newCreatePartitionEventWriter(schemapb.DataType_Int64, new(bytes.Buffer))
 		assert.Nil(t, err)
 		w.SetEventTimestamp(tsoutil.ComposeTS(10, 0), tsoutil.ComposeTS(100, 0))
 		err = w.AddDataToPayload([]int64{1, 2, 3})
@@ -681,7 +681,7 @@ func TestCreatePartitionEvent(t *testing.T) {
 	})
 
 	t.Run("create_partition_string", func(t *testing.T) {
-		w, err := newCreatePartitionEventWriter(schemapb.DataType_String)
+		w, err := newCreatePartitionEventWriter(schemapb.DataType_String, new(bytes.Buffer))
 		assert.Nil(t, err)
 		w.SetEventTimestamp(tsoutil.ComposeTS(10, 0), tsoutil.ComposeTS(100, 0))
 		err = w.AddDataToPayload("1234")
@@ -735,13 +735,13 @@ func TestCreatePartitionEvent(t *testing.T) {
 /* #nosec G103 */
 func TestDropPartitionEvent(t *testing.T) {
 	t.Run("drop_event", func(t *testing.T) {
-		w, err := newDropPartitionEventWriter(schemapb.DataType_Float)
+		w, err := newDropPartitionEventWriter(schemapb.DataType_Float, new(bytes.Buffer))
 		assert.NotNil(t, err)
 		assert.Nil(t, w)
 	})
 
 	t.Run("drop_partition_timestamp", func(t *testing.T) {
-		w, err := newDropPartitionEventWriter(schemapb.DataType_Int64)
+		w, err := newDropPartitionEventWriter(schemapb.DataType_Int64, new(bytes.Buffer))
 		assert.Nil(t, err)
 		w.SetEventTimestamp(tsoutil.ComposeTS(10, 0), tsoutil.ComposeTS(100, 0))
 		err = w.AddDataToPayload([]int64{1, 2, 3})
@@ -783,7 +783,7 @@ func TestDropPartitionEvent(t *testing.T) {
 	})
 
 	t.Run("drop_partition_string", func(t *testing.T) {
-		w, err := newDropPartitionEventWriter(schemapb.DataType_String)
+		w, err := newDropPartitionEventWriter(schemapb.DataType_String, new(bytes.Buffer))
 		assert.Nil(t, err)
 		w.SetEventTimestamp(tsoutil.ComposeTS(10, 0), tsoutil.ComposeTS(100, 0))
 		err = w.AddDataToPayload("1234")
@@ -838,7 +838,7 @@ func TestDropPartitionEvent(t *testing.T) {
 /* #nosec G103 */
 func TestIndexFileEvent(t *testing.T) {
 	t.Run("index_file_string", func(t *testing.T) {
-		w, err := newIndexFileEventWriter(schemapb.DataType_String)
+		w, err := newIndexFileEventWriter(schemapb.DataType_String, new(bytes.Buffer))
 		assert.Nil(t, err)
 		w.SetEventTimestamp(tsoutil.ComposeTS(10, 0), tsoutil.ComposeTS(100, 0))
 
@@ -875,7 +875,7 @@ func TestIndexFileEvent(t *testing.T) {
 	})
 
 	t.Run("index_file_int8", func(t *testing.T) {
-		w, err := newIndexFileEventWriter(schemapb.DataType_Int8)
+		w, err := newIndexFileEventWriter(schemapb.DataType_Int8, new(bytes.Buffer))
 		assert.Nil(t, err)
 		w.SetEventTimestamp(tsoutil.ComposeTS(10, 0), tsoutil.ComposeTS(100, 0))
 
@@ -909,7 +909,7 @@ func TestIndexFileEvent(t *testing.T) {
 	})
 
 	t.Run("index_file_int8_large", func(t *testing.T) {
-		w, err := newIndexFileEventWriter(schemapb.DataType_Int8)
+		w, err := newIndexFileEventWriter(schemapb.DataType_Int8, new(bytes.Buffer))
 		assert.Nil(t, err)
 		w.SetEventTimestamp(tsoutil.ComposeTS(10, 0), tsoutil.ComposeTS(100, 0))
 
@@ -1085,7 +1085,7 @@ func TestEventReaderError(t *testing.T) {
 }
 
 func TestEventClose(t *testing.T) {
-	w, err := newInsertEventWriter(schemapb.DataType_String)
+	w, err := newInsertEventWriter(schemapb.DataType_String, new(bytes.Buffer))
 	assert.Nil(t, err)
 	w.SetEventTimestamp(tsoutil.ComposeTS(10, 0), tsoutil.ComposeTS(100, 0))
 	err = w.AddDataToPayload("1234")

--- a/internal/storage/event_writer_test.go
+++ b/internal/storage/event_writer_test.go
@@ -58,11 +58,11 @@ func TestSizeofStruct(t *testing.T) {
 }
 
 func TestEventWriter(t *testing.T) {
-	insertEvent, err := newInsertEventWriter(schemapb.DataType_Int32)
+	insertEvent, err := newInsertEventWriter(schemapb.DataType_Int32, new(bytes.Buffer))
 	assert.Nil(t, err)
 	insertEvent.Close()
 
-	insertEvent, err = newInsertEventWriter(schemapb.DataType_Int32)
+	insertEvent, err = newInsertEventWriter(schemapb.DataType_Int32, new(bytes.Buffer))
 	assert.Nil(t, err)
 	defer insertEvent.Close()
 
@@ -70,7 +70,7 @@ func TestEventWriter(t *testing.T) {
 	assert.NotNil(t, err)
 	err = insertEvent.AddInt32ToPayload([]int32{1, 2, 3})
 	assert.Nil(t, err)
-	nums, err := insertEvent.GetPayloadLengthFromWriter()
+	nums, err := insertEvent.Length()
 	assert.Nil(t, err)
 	assert.EqualValues(t, 3, nums)
 	err = insertEvent.Finish()

--- a/internal/storage/payload_cgo_test.go
+++ b/internal/storage/payload_cgo_test.go
@@ -17,6 +17,7 @@
 package storage
 
 import (
+	"bytes"
 	"fmt"
 	"testing"
 
@@ -29,7 +30,7 @@ import (
 func TestPayload_CGO_ReaderandWriter(t *testing.T) {
 
 	t.Run("TestBool", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Bool)
+		w, err := NewPayloadWriter(schemapb.DataType_Bool, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -40,14 +41,12 @@ func TestPayload_CGO_ReaderandWriter(t *testing.T) {
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
 
-		length, err := w.GetPayloadLengthFromWriter()
+		length, err := w.Length()
 		assert.Nil(t, err)
 		assert.Equal(t, 8, length)
 		defer w.ReleasePayloadWriter()
 
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		r, err := NewPayloadReaderCgo(schemapb.DataType_Bool, buffer)
 		require.Nil(t, err)
 		length, err = r.GetPayloadLengthFromReader()
@@ -65,7 +64,7 @@ func TestPayload_CGO_ReaderandWriter(t *testing.T) {
 	})
 
 	t.Run("TestInt8", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Int8)
+		w, err := NewPayloadWriter(schemapb.DataType_Int8, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -76,14 +75,12 @@ func TestPayload_CGO_ReaderandWriter(t *testing.T) {
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
 
-		length, err := w.GetPayloadLengthFromWriter()
+		length, err := w.Length()
 		assert.Nil(t, err)
 		assert.Equal(t, 6, length)
 		defer w.ReleasePayloadWriter()
 
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		r, err := NewPayloadReaderCgo(schemapb.DataType_Int8, buffer)
 		require.Nil(t, err)
 		length, err = r.GetPayloadLengthFromReader()
@@ -103,7 +100,7 @@ func TestPayload_CGO_ReaderandWriter(t *testing.T) {
 	})
 
 	t.Run("TestInt16", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Int16)
+		w, err := NewPayloadWriter(schemapb.DataType_Int16, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -114,14 +111,12 @@ func TestPayload_CGO_ReaderandWriter(t *testing.T) {
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
 
-		length, err := w.GetPayloadLengthFromWriter()
+		length, err := w.Length()
 		assert.Nil(t, err)
 		assert.Equal(t, 6, length)
 		defer w.ReleasePayloadWriter()
 
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		r, err := NewPayloadReaderCgo(schemapb.DataType_Int16, buffer)
 		require.Nil(t, err)
 		length, err = r.GetPayloadLengthFromReader()
@@ -139,7 +134,7 @@ func TestPayload_CGO_ReaderandWriter(t *testing.T) {
 	})
 
 	t.Run("TestInt32", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Int32)
+		w, err := NewPayloadWriter(schemapb.DataType_Int32, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -150,14 +145,12 @@ func TestPayload_CGO_ReaderandWriter(t *testing.T) {
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
 
-		length, err := w.GetPayloadLengthFromWriter()
+		length, err := w.Length()
 		assert.Nil(t, err)
 		assert.Equal(t, 6, length)
 		defer w.ReleasePayloadWriter()
 
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		r, err := NewPayloadReaderCgo(schemapb.DataType_Int32, buffer)
 		require.Nil(t, err)
 		length, err = r.GetPayloadLengthFromReader()
@@ -176,7 +169,7 @@ func TestPayload_CGO_ReaderandWriter(t *testing.T) {
 	})
 
 	t.Run("TestInt64", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Int64)
+		w, err := NewPayloadWriter(schemapb.DataType_Int64, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -187,14 +180,12 @@ func TestPayload_CGO_ReaderandWriter(t *testing.T) {
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
 
-		length, err := w.GetPayloadLengthFromWriter()
+		length, err := w.Length()
 		assert.Nil(t, err)
 		assert.Equal(t, 6, length)
 		defer w.ReleasePayloadWriter()
 
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		r, err := NewPayloadReaderCgo(schemapb.DataType_Int64, buffer)
 		require.Nil(t, err)
 		length, err = r.GetPayloadLengthFromReader()
@@ -213,7 +204,7 @@ func TestPayload_CGO_ReaderandWriter(t *testing.T) {
 	})
 
 	t.Run("TestFloat32", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Float)
+		w, err := NewPayloadWriter(schemapb.DataType_Float, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -224,14 +215,12 @@ func TestPayload_CGO_ReaderandWriter(t *testing.T) {
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
 
-		length, err := w.GetPayloadLengthFromWriter()
+		length, err := w.Length()
 		assert.Nil(t, err)
 		assert.Equal(t, 6, length)
 		defer w.ReleasePayloadWriter()
 
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		r, err := NewPayloadReaderCgo(schemapb.DataType_Float, buffer)
 		require.Nil(t, err)
 		length, err = r.GetPayloadLengthFromReader()
@@ -250,7 +239,7 @@ func TestPayload_CGO_ReaderandWriter(t *testing.T) {
 	})
 
 	t.Run("TestDouble", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Double)
+		w, err := NewPayloadWriter(schemapb.DataType_Double, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -261,14 +250,12 @@ func TestPayload_CGO_ReaderandWriter(t *testing.T) {
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
 
-		length, err := w.GetPayloadLengthFromWriter()
+		length, err := w.Length()
 		assert.Nil(t, err)
 		assert.Equal(t, 6, length)
 		defer w.ReleasePayloadWriter()
 
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		r, err := NewPayloadReaderCgo(schemapb.DataType_Double, buffer)
 		require.Nil(t, err)
 		length, err = r.GetPayloadLengthFromReader()
@@ -287,7 +274,7 @@ func TestPayload_CGO_ReaderandWriter(t *testing.T) {
 	})
 
 	t.Run("TestAddString", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_String)
+		w, err := NewPayloadWriter(schemapb.DataType_String, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -301,12 +288,10 @@ func TestPayload_CGO_ReaderandWriter(t *testing.T) {
 		assert.Nil(t, err)
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
-		length, err := w.GetPayloadLengthFromWriter()
+		length, err := w.Length()
 		assert.Nil(t, err)
 		assert.Equal(t, length, 4)
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		r, err := NewPayloadReaderCgo(schemapb.DataType_String, buffer)
 		assert.Nil(t, err)
 		length, err = r.GetPayloadLengthFromReader()
@@ -333,7 +318,7 @@ func TestPayload_CGO_ReaderandWriter(t *testing.T) {
 	})
 
 	t.Run("TestBinaryVector", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_BinaryVector, 8)
+		w, err := NewPayloadWriter(schemapb.DataType_BinaryVector, new(bytes.Buffer), 8)
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -353,14 +338,12 @@ func TestPayload_CGO_ReaderandWriter(t *testing.T) {
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
 
-		length, err := w.GetPayloadLengthFromWriter()
+		length, err := w.Length()
 		assert.Nil(t, err)
 		assert.Equal(t, 24, length)
 		defer w.ReleasePayloadWriter()
 
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		r, err := NewPayloadReaderCgo(schemapb.DataType_BinaryVector, buffer)
 		require.Nil(t, err)
 		length, err = r.GetPayloadLengthFromReader()
@@ -382,7 +365,7 @@ func TestPayload_CGO_ReaderandWriter(t *testing.T) {
 	})
 
 	t.Run("TestFloatVector", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_FloatVector, 1)
+		w, err := NewPayloadWriter(schemapb.DataType_FloatVector, new(bytes.Buffer), 1)
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -393,14 +376,12 @@ func TestPayload_CGO_ReaderandWriter(t *testing.T) {
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
 
-		length, err := w.GetPayloadLengthFromWriter()
+		length, err := w.Length()
 		assert.Nil(t, err)
 		assert.Equal(t, 4, length)
 		defer w.ReleasePayloadWriter()
 
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		r, err := NewPayloadReaderCgo(schemapb.DataType_FloatVector, buffer)
 		require.Nil(t, err)
 		length, err = r.GetPayloadLengthFromReader()
@@ -423,7 +404,7 @@ func TestPayload_CGO_ReaderandWriter(t *testing.T) {
 	})
 
 	// t.Run("TestAddDataToPayload", func(t *testing.T) {
-	// 	w, err := NewPayloadWriter(schemapb.DataType_Bool)
+	// 	w, err := NewPayloadWriter(schemapb.DataType_Bool, new(bytes.Buffer))
 	// 	w.colType = 999
 	// 	require.Nil(t, err)
 	// 	require.NotNil(t, w)
@@ -446,12 +427,9 @@ func TestPayload_CGO_ReaderandWriter(t *testing.T) {
 	// })
 
 	t.Run("TestAddBoolAfterFinish", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Bool)
+		w, err := NewPayloadWriter(schemapb.DataType_Bool, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
-
-		_, err = w.GetPayloadBufferFromWriter()
-		assert.NotNil(t, err)
 
 		err = w.AddBoolToPayload([]bool{})
 		assert.NotNil(t, err)
@@ -462,13 +440,10 @@ func TestPayload_CGO_ReaderandWriter(t *testing.T) {
 	})
 
 	t.Run("TestAddInt8AfterFinish", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Int8)
+		w, err := NewPayloadWriter(schemapb.DataType_Int8, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 		defer w.Close()
-
-		_, err = w.GetPayloadBufferFromWriter()
-		assert.NotNil(t, err)
 
 		err = w.AddInt8ToPayload([]int8{})
 		assert.NotNil(t, err)
@@ -478,13 +453,10 @@ func TestPayload_CGO_ReaderandWriter(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 	t.Run("TestAddInt16AfterFinish", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Int16)
+		w, err := NewPayloadWriter(schemapb.DataType_Int16, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 		defer w.Close()
-
-		_, err = w.GetPayloadBufferFromWriter()
-		assert.NotNil(t, err)
 
 		err = w.AddInt16ToPayload([]int16{})
 		assert.NotNil(t, err)
@@ -494,13 +466,10 @@ func TestPayload_CGO_ReaderandWriter(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 	t.Run("TestAddInt32AfterFinish", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Int32)
+		w, err := NewPayloadWriter(schemapb.DataType_Int32, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 		defer w.Close()
-
-		_, err = w.GetPayloadBufferFromWriter()
-		assert.NotNil(t, err)
 
 		err = w.AddInt32ToPayload([]int32{})
 		assert.NotNil(t, err)
@@ -510,13 +479,10 @@ func TestPayload_CGO_ReaderandWriter(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 	t.Run("TestAddInt64AfterFinish", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Int64)
+		w, err := NewPayloadWriter(schemapb.DataType_Int64, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 		defer w.Close()
-
-		_, err = w.GetPayloadBufferFromWriter()
-		assert.NotNil(t, err)
 
 		err = w.AddInt64ToPayload([]int64{})
 		assert.NotNil(t, err)
@@ -526,13 +492,10 @@ func TestPayload_CGO_ReaderandWriter(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 	t.Run("TestAddFloatAfterFinish", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Float)
+		w, err := NewPayloadWriter(schemapb.DataType_Float, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 		defer w.Close()
-
-		_, err = w.GetPayloadBufferFromWriter()
-		assert.NotNil(t, err)
 
 		err = w.AddFloatToPayload([]float32{})
 		assert.NotNil(t, err)
@@ -542,13 +505,10 @@ func TestPayload_CGO_ReaderandWriter(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 	t.Run("TestAddDoubleAfterFinish", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Double)
+		w, err := NewPayloadWriter(schemapb.DataType_Double, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 		defer w.Close()
-
-		_, err = w.GetPayloadBufferFromWriter()
-		assert.NotNil(t, err)
 
 		err = w.AddDoubleToPayload([]float64{})
 		assert.NotNil(t, err)
@@ -558,13 +518,10 @@ func TestPayload_CGO_ReaderandWriter(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 	t.Run("TestAddOneStringAfterFinish", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_String)
+		w, err := NewPayloadWriter(schemapb.DataType_String, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 		defer w.Close()
-
-		_, err = w.GetPayloadBufferFromWriter()
-		assert.NotNil(t, err)
 
 		err = w.AddOneStringToPayload("")
 		assert.Nil(t, err)
@@ -574,13 +531,10 @@ func TestPayload_CGO_ReaderandWriter(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 	t.Run("TestAddBinVectorAfterFinish", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_BinaryVector, 8)
+		w, err := NewPayloadWriter(schemapb.DataType_BinaryVector, new(bytes.Buffer), 8)
 		require.Nil(t, err)
 		require.NotNil(t, w)
 		defer w.Close()
-
-		_, err = w.GetPayloadBufferFromWriter()
-		assert.NotNil(t, err)
 
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
@@ -598,7 +552,7 @@ func TestPayload_CGO_ReaderandWriter(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 	t.Run("TestAddFloatVectorAfterFinish", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_FloatVector, 8)
+		w, err := NewPayloadWriter(schemapb.DataType_FloatVector, new(bytes.Buffer), 8)
 		require.Nil(t, err)
 		require.NotNil(t, w)
 		defer w.Close()
@@ -633,7 +587,7 @@ func TestPayload_CGO_ReaderandWriter(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 	t.Run("TestGetBoolError", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Int8)
+		w, err := NewPayloadWriter(schemapb.DataType_Int8, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -643,14 +597,12 @@ func TestPayload_CGO_ReaderandWriter(t *testing.T) {
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
 
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		_, err = NewPayloadReaderCgo(schemapb.DataType_Bool, buffer)
 		assert.NotNil(t, err)
 	})
 	t.Run("TestGetInt8Error", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Bool)
+		w, err := NewPayloadWriter(schemapb.DataType_Bool, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -660,14 +612,12 @@ func TestPayload_CGO_ReaderandWriter(t *testing.T) {
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
 
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		_, err = NewPayloadReaderCgo(schemapb.DataType_Int8, buffer)
 		assert.NotNil(t, err)
 	})
 	t.Run("TestGetInt16Error", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Bool)
+		w, err := NewPayloadWriter(schemapb.DataType_Bool, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -677,14 +627,12 @@ func TestPayload_CGO_ReaderandWriter(t *testing.T) {
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
 
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		_, err = NewPayloadReaderCgo(schemapb.DataType_Int16, buffer)
 		assert.NotNil(t, err)
 	})
 	t.Run("TestGetInt32Error", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Bool)
+		w, err := NewPayloadWriter(schemapb.DataType_Bool, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -694,14 +642,12 @@ func TestPayload_CGO_ReaderandWriter(t *testing.T) {
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
 
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		_, err = NewPayloadReaderCgo(schemapb.DataType_Int32, buffer)
 		assert.NotNil(t, err)
 	})
 	t.Run("TestGetInt64Error", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Bool)
+		w, err := NewPayloadWriter(schemapb.DataType_Bool, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -711,14 +657,12 @@ func TestPayload_CGO_ReaderandWriter(t *testing.T) {
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
 
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		_, err = NewPayloadReaderCgo(schemapb.DataType_Int64, buffer)
 		assert.NotNil(t, err)
 	})
 	t.Run("TestGetFloatError", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Bool)
+		w, err := NewPayloadWriter(schemapb.DataType_Bool, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -728,14 +672,12 @@ func TestPayload_CGO_ReaderandWriter(t *testing.T) {
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
 
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		_, err = NewPayloadReaderCgo(schemapb.DataType_Float, buffer)
 		assert.NotNil(t, err)
 	})
 	t.Run("TestGetDoubleError", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Bool)
+		w, err := NewPayloadWriter(schemapb.DataType_Bool, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -745,14 +687,12 @@ func TestPayload_CGO_ReaderandWriter(t *testing.T) {
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
 
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		_, err = NewPayloadReaderCgo(schemapb.DataType_Double, buffer)
 		assert.NotNil(t, err)
 	})
 	t.Run("TestGetStringError", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Bool)
+		w, err := NewPayloadWriter(schemapb.DataType_Bool, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -762,14 +702,12 @@ func TestPayload_CGO_ReaderandWriter(t *testing.T) {
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
 
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		_, err = NewPayloadReaderCgo(schemapb.DataType_String, buffer)
 		assert.NotNil(t, err)
 	})
 	t.Run("TestGetBinaryVectorError", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Bool)
+		w, err := NewPayloadWriter(schemapb.DataType_Bool, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -779,14 +717,12 @@ func TestPayload_CGO_ReaderandWriter(t *testing.T) {
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
 
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		_, err = NewPayloadReaderCgo(schemapb.DataType_BinaryVector, buffer)
 		assert.NotNil(t, err)
 	})
 	t.Run("TestGetFloatVectorError", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Bool)
+		w, err := NewPayloadWriter(schemapb.DataType_Bool, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -796,9 +732,7 @@ func TestPayload_CGO_ReaderandWriter(t *testing.T) {
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
 
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		_, err = NewPayloadReaderCgo(schemapb.DataType_FloatVector, buffer)
 		assert.NotNil(t, err)
 	})
@@ -811,16 +745,13 @@ func TestPayload_CGO_ReaderandWriter(t *testing.T) {
 			vec = append(vec, 1)
 		}
 
-		w, err := NewPayloadWriter(schemapb.DataType_FloatVector, 128)
+		w, err := NewPayloadWriter(schemapb.DataType_FloatVector, new(bytes.Buffer), 128)
 		assert.Nil(t, err)
 
 		err = w.AddFloatVectorToPayload(vec, 128)
 		assert.Nil(t, err)
 
 		err = w.FinishPayloadWriter()
-		assert.Nil(t, err)
-
-		_, err = w.GetPayloadBufferFromWriter()
 		assert.Nil(t, err)
 
 		w.ReleasePayloadWriter()

--- a/internal/storage/payload_test.go
+++ b/internal/storage/payload_test.go
@@ -17,6 +17,7 @@
 package storage
 
 import (
+	"bytes"
 	"fmt"
 	"testing"
 
@@ -29,7 +30,7 @@ import (
 func TestPayload_ReaderAndWriter(t *testing.T) {
 
 	t.Run("TestBool", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Bool)
+		w, err := NewPayloadWriter(schemapb.DataType_Bool, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -40,14 +41,12 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
 
-		length, err := w.GetPayloadLengthFromWriter()
+		length, err := w.Length()
 		assert.Nil(t, err)
 		assert.Equal(t, 8, length)
 		defer w.ReleasePayloadWriter()
 
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		r, err := NewPayloadReader(schemapb.DataType_Bool, buffer)
 		require.Nil(t, err)
 		length, err = r.GetPayloadLengthFromReader()
@@ -65,7 +64,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 	})
 
 	t.Run("TestInt8", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Int8)
+		w, err := NewPayloadWriter(schemapb.DataType_Int8, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -76,14 +75,12 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
 
-		length, err := w.GetPayloadLengthFromWriter()
+		length, err := w.Length()
 		assert.Nil(t, err)
 		assert.Equal(t, 6, length)
 		defer w.ReleasePayloadWriter()
 
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		r, err := NewPayloadReader(schemapb.DataType_Int8, buffer)
 		require.Nil(t, err)
 		length, err = r.GetPayloadLengthFromReader()
@@ -103,7 +100,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 	})
 
 	t.Run("TestInt16", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Int16)
+		w, err := NewPayloadWriter(schemapb.DataType_Int16, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -114,14 +111,12 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
 
-		length, err := w.GetPayloadLengthFromWriter()
+		length, err := w.Length()
 		assert.Nil(t, err)
 		assert.Equal(t, 6, length)
 		defer w.ReleasePayloadWriter()
 
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		r, err := NewPayloadReader(schemapb.DataType_Int16, buffer)
 		require.Nil(t, err)
 		length, err = r.GetPayloadLengthFromReader()
@@ -139,7 +134,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 	})
 
 	t.Run("TestInt32", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Int32)
+		w, err := NewPayloadWriter(schemapb.DataType_Int32, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -150,14 +145,12 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
 
-		length, err := w.GetPayloadLengthFromWriter()
+		length, err := w.Length()
 		assert.Nil(t, err)
 		assert.Equal(t, 6, length)
 		defer w.ReleasePayloadWriter()
 
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		r, err := NewPayloadReader(schemapb.DataType_Int32, buffer)
 		require.Nil(t, err)
 		length, err = r.GetPayloadLengthFromReader()
@@ -176,7 +169,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 	})
 
 	t.Run("TestInt64", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Int64)
+		w, err := NewPayloadWriter(schemapb.DataType_Int64, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -187,14 +180,12 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
 
-		length, err := w.GetPayloadLengthFromWriter()
+		length, err := w.Length()
 		assert.Nil(t, err)
 		assert.Equal(t, 6, length)
 		defer w.ReleasePayloadWriter()
 
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		r, err := NewPayloadReader(schemapb.DataType_Int64, buffer)
 		require.Nil(t, err)
 		length, err = r.GetPayloadLengthFromReader()
@@ -213,7 +204,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 	})
 
 	t.Run("TestFloat32", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Float)
+		w, err := NewPayloadWriter(schemapb.DataType_Float, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -224,14 +215,12 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
 
-		length, err := w.GetPayloadLengthFromWriter()
+		length, err := w.Length()
 		assert.Nil(t, err)
 		assert.Equal(t, 6, length)
 		defer w.ReleasePayloadWriter()
 
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		r, err := NewPayloadReader(schemapb.DataType_Float, buffer)
 		require.Nil(t, err)
 		length, err = r.GetPayloadLengthFromReader()
@@ -250,7 +239,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 	})
 
 	t.Run("TestDouble", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Double)
+		w, err := NewPayloadWriter(schemapb.DataType_Double, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -261,14 +250,12 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
 
-		length, err := w.GetPayloadLengthFromWriter()
+		length, err := w.Length()
 		assert.Nil(t, err)
 		assert.Equal(t, 6, length)
 		defer w.ReleasePayloadWriter()
 
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		r, err := NewPayloadReader(schemapb.DataType_Double, buffer)
 		require.Nil(t, err)
 		length, err = r.GetPayloadLengthFromReader()
@@ -287,7 +274,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 	})
 
 	t.Run("TestAddString", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_String)
+		w, err := NewPayloadWriter(schemapb.DataType_String, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -301,12 +288,10 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		assert.Nil(t, err)
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
-		length, err := w.GetPayloadLengthFromWriter()
+		length, err := w.Length()
 		assert.Nil(t, err)
 		assert.Equal(t, length, 4)
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		r, err := NewPayloadReader(schemapb.DataType_String, buffer)
 		assert.Nil(t, err)
 		length, err = r.GetPayloadLengthFromReader()
@@ -333,7 +318,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 	})
 
 	t.Run("TestAddArray", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Array)
+		w, err := NewPayloadWriter(schemapb.DataType_Array, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -371,12 +356,10 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		assert.Nil(t, err)
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
-		length, err := w.GetPayloadLengthFromWriter()
+		length, err := w.Length()
 		assert.Nil(t, err)
 		assert.Equal(t, length, 4)
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		r, err := NewPayloadReader(schemapb.DataType_Array, buffer)
 		assert.Nil(t, err)
 		length, err = r.GetPayloadLengthFromReader()
@@ -403,7 +386,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 	})
 
 	t.Run("TestAddJSON", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_JSON)
+		w, err := NewPayloadWriter(schemapb.DataType_JSON, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -417,12 +400,10 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		assert.Nil(t, err)
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
-		length, err := w.GetPayloadLengthFromWriter()
+		length, err := w.Length()
 		assert.Nil(t, err)
 		assert.Equal(t, length, 4)
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		r, err := NewPayloadReader(schemapb.DataType_JSON, buffer)
 		assert.Nil(t, err)
 		length, err = r.GetPayloadLengthFromReader()
@@ -449,7 +430,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 	})
 
 	t.Run("TestBinaryVector", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_BinaryVector, 8)
+		w, err := NewPayloadWriter(schemapb.DataType_BinaryVector, new(bytes.Buffer), 8)
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -469,14 +450,12 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
 
-		length, err := w.GetPayloadLengthFromWriter()
+		length, err := w.Length()
 		assert.Nil(t, err)
 		assert.Equal(t, 24, length)
 		defer w.ReleasePayloadWriter()
 
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		r, err := NewPayloadReader(schemapb.DataType_BinaryVector, buffer)
 		require.Nil(t, err)
 		length, err = r.GetPayloadLengthFromReader()
@@ -498,7 +477,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 	})
 
 	t.Run("TestFloatVector", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_FloatVector, 1)
+		w, err := NewPayloadWriter(schemapb.DataType_FloatVector, new(bytes.Buffer), 1)
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -509,14 +488,12 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
 
-		length, err := w.GetPayloadLengthFromWriter()
+		length, err := w.Length()
 		assert.Nil(t, err)
 		assert.Equal(t, 4, length)
 		defer w.ReleasePayloadWriter()
 
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		r, err := NewPayloadReader(schemapb.DataType_FloatVector, buffer)
 		require.Nil(t, err)
 		length, err = r.GetPayloadLengthFromReader()
@@ -539,7 +516,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 	})
 
 	// t.Run("TestAddDataToPayload", func(t *testing.T) {
-	// 	w, err := NewPayloadWriter(schemapb.DataType_Bool)
+	// 	w, err := NewPayloadWriter(schemapb.DataType_Bool, new(bytes.Buffer))
 	// 	w.colType = 999
 	// 	require.Nil(t, err)
 	// 	require.NotNil(t, w)
@@ -562,12 +539,9 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 	// })
 
 	t.Run("TestAddBoolAfterFinish", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Bool)
+		w, err := NewPayloadWriter(schemapb.DataType_Bool, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
-
-		_, err = w.GetPayloadBufferFromWriter()
-		assert.NotNil(t, err)
 
 		err = w.AddBoolToPayload([]bool{})
 		assert.NotNil(t, err)
@@ -578,13 +552,10 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 	})
 
 	t.Run("TestAddInt8AfterFinish", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Int8)
+		w, err := NewPayloadWriter(schemapb.DataType_Int8, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 		defer w.Close()
-
-		_, err = w.GetPayloadBufferFromWriter()
-		assert.NotNil(t, err)
 
 		err = w.AddInt8ToPayload([]int8{})
 		assert.NotNil(t, err)
@@ -594,13 +565,10 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 	t.Run("TestAddInt16AfterFinish", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Int16)
+		w, err := NewPayloadWriter(schemapb.DataType_Int16, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 		defer w.Close()
-
-		_, err = w.GetPayloadBufferFromWriter()
-		assert.NotNil(t, err)
 
 		err = w.AddInt16ToPayload([]int16{})
 		assert.NotNil(t, err)
@@ -610,13 +578,10 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 	t.Run("TestAddInt32AfterFinish", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Int32)
+		w, err := NewPayloadWriter(schemapb.DataType_Int32, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 		defer w.Close()
-
-		_, err = w.GetPayloadBufferFromWriter()
-		assert.NotNil(t, err)
 
 		err = w.AddInt32ToPayload([]int32{})
 		assert.NotNil(t, err)
@@ -626,13 +591,10 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 	t.Run("TestAddInt64AfterFinish", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Int64)
+		w, err := NewPayloadWriter(schemapb.DataType_Int64, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 		defer w.Close()
-
-		_, err = w.GetPayloadBufferFromWriter()
-		assert.NotNil(t, err)
 
 		err = w.AddInt64ToPayload([]int64{})
 		assert.NotNil(t, err)
@@ -642,13 +604,10 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 	t.Run("TestAddFloatAfterFinish", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Float)
+		w, err := NewPayloadWriter(schemapb.DataType_Float, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 		defer w.Close()
-
-		_, err = w.GetPayloadBufferFromWriter()
-		assert.NotNil(t, err)
 
 		err = w.AddFloatToPayload([]float32{})
 		assert.NotNil(t, err)
@@ -658,13 +617,10 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 	t.Run("TestAddDoubleAfterFinish", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Double)
+		w, err := NewPayloadWriter(schemapb.DataType_Double, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 		defer w.Close()
-
-		_, err = w.GetPayloadBufferFromWriter()
-		assert.NotNil(t, err)
 
 		err = w.AddDoubleToPayload([]float64{})
 		assert.NotNil(t, err)
@@ -674,13 +630,10 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 	t.Run("TestAddOneStringAfterFinish", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_String)
+		w, err := NewPayloadWriter(schemapb.DataType_String, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 		defer w.Close()
-
-		_, err = w.GetPayloadBufferFromWriter()
-		assert.NotNil(t, err)
 
 		err = w.AddOneStringToPayload("")
 		assert.Nil(t, err)
@@ -690,13 +643,10 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 	t.Run("TestAddBinVectorAfterFinish", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_BinaryVector, 8)
+		w, err := NewPayloadWriter(schemapb.DataType_BinaryVector, new(bytes.Buffer), 8)
 		require.Nil(t, err)
 		require.NotNil(t, w)
 		defer w.Close()
-
-		_, err = w.GetPayloadBufferFromWriter()
-		assert.NotNil(t, err)
 
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
@@ -714,7 +664,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 	t.Run("TestAddFloatVectorAfterFinish", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_FloatVector, 8)
+		w, err := NewPayloadWriter(schemapb.DataType_FloatVector, new(bytes.Buffer), 8)
 		require.Nil(t, err)
 		require.NotNil(t, w)
 		defer w.Close()
@@ -749,7 +699,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 	t.Run("TestGetBoolError", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Int8)
+		w, err := NewPayloadWriter(schemapb.DataType_Int8, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -759,9 +709,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
 
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		r, err := NewPayloadReader(schemapb.DataType_Bool, buffer)
 		assert.Nil(t, err)
 
@@ -773,7 +721,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 	t.Run("TestGetBoolError2", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Bool)
+		w, err := NewPayloadWriter(schemapb.DataType_Bool, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -783,9 +731,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
 
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		r, err := NewPayloadReader(schemapb.DataType_Bool, buffer)
 		assert.Nil(t, err)
 
@@ -794,7 +740,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 	t.Run("TestGetInt8Error", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Bool)
+		w, err := NewPayloadWriter(schemapb.DataType_Bool, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -804,9 +750,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
 
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		r, err := NewPayloadReader(schemapb.DataType_Int8, buffer)
 		assert.Nil(t, err)
 
@@ -818,7 +762,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 	t.Run("TestGetInt8Error2", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Int8)
+		w, err := NewPayloadWriter(schemapb.DataType_Int8, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -828,9 +772,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
 
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		r, err := NewPayloadReader(schemapb.DataType_Int8, buffer)
 		assert.Nil(t, err)
 
@@ -839,7 +781,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 	t.Run("TestGetInt16Error", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Bool)
+		w, err := NewPayloadWriter(schemapb.DataType_Bool, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -849,9 +791,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
 
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		r, err := NewPayloadReader(schemapb.DataType_Int16, buffer)
 		assert.Nil(t, err)
 
@@ -863,7 +803,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 	t.Run("TestGetInt16Error2", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Int16)
+		w, err := NewPayloadWriter(schemapb.DataType_Int16, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -873,9 +813,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
 
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		r, err := NewPayloadReader(schemapb.DataType_Int16, buffer)
 		assert.Nil(t, err)
 
@@ -884,7 +822,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 	t.Run("TestGetInt32Error", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Bool)
+		w, err := NewPayloadWriter(schemapb.DataType_Bool, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -894,9 +832,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
 
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		r, err := NewPayloadReader(schemapb.DataType_Int32, buffer)
 		assert.Nil(t, err)
 
@@ -908,7 +844,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 	t.Run("TestGetInt32Error2", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Int32)
+		w, err := NewPayloadWriter(schemapb.DataType_Int32, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -918,9 +854,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
 
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		r, err := NewPayloadReader(schemapb.DataType_Int32, buffer)
 		assert.Nil(t, err)
 
@@ -929,7 +863,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 	t.Run("TestGetInt64Error", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Bool)
+		w, err := NewPayloadWriter(schemapb.DataType_Bool, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -939,9 +873,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
 
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		r, err := NewPayloadReader(schemapb.DataType_Int64, buffer)
 		assert.Nil(t, err)
 
@@ -953,7 +885,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 	t.Run("TestGetInt64Error2", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Int64)
+		w, err := NewPayloadWriter(schemapb.DataType_Int64, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -963,9 +895,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
 
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		r, err := NewPayloadReader(schemapb.DataType_Int64, buffer)
 		assert.Nil(t, err)
 
@@ -974,7 +904,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 	t.Run("TestGetFloatError", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Bool)
+		w, err := NewPayloadWriter(schemapb.DataType_Bool, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -984,9 +914,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
 
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		r, err := NewPayloadReader(schemapb.DataType_Float, buffer)
 		assert.Nil(t, err)
 
@@ -998,7 +926,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 	t.Run("TestGetFloatError2", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Float)
+		w, err := NewPayloadWriter(schemapb.DataType_Float, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -1008,9 +936,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
 
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		r, err := NewPayloadReader(schemapb.DataType_Float, buffer)
 		assert.Nil(t, err)
 
@@ -1019,7 +945,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 	t.Run("TestGetDoubleError", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Bool)
+		w, err := NewPayloadWriter(schemapb.DataType_Bool, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -1029,9 +955,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
 
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		r, err := NewPayloadReader(schemapb.DataType_Double, buffer)
 		assert.Nil(t, err)
 
@@ -1043,7 +967,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 	t.Run("TestGetDoubleError2", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Double)
+		w, err := NewPayloadWriter(schemapb.DataType_Double, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -1053,9 +977,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
 
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		r, err := NewPayloadReader(schemapb.DataType_Double, buffer)
 		assert.Nil(t, err)
 
@@ -1064,7 +986,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 	t.Run("TestGetStringError", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Bool)
+		w, err := NewPayloadWriter(schemapb.DataType_Bool, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -1074,9 +996,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
 
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		r, err := NewPayloadReader(schemapb.DataType_String, buffer)
 		assert.Nil(t, err)
 
@@ -1088,7 +1008,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 	t.Run("TestGetStringError2", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_String)
+		w, err := NewPayloadWriter(schemapb.DataType_String, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -1102,9 +1022,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
 
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		r, err := NewPayloadReader(schemapb.DataType_String, buffer)
 		assert.Nil(t, err)
 
@@ -1113,7 +1031,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 	t.Run("TestGetBinaryVectorError", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Bool)
+		w, err := NewPayloadWriter(schemapb.DataType_Bool, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -1123,9 +1041,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
 
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		r, err := NewPayloadReader(schemapb.DataType_BinaryVector, buffer)
 		assert.Nil(t, err)
 
@@ -1137,7 +1053,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 	t.Run("TestGetBinaryVectorError2", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_BinaryVector, 8)
+		w, err := NewPayloadWriter(schemapb.DataType_BinaryVector, new(bytes.Buffer), 8)
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -1147,9 +1063,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
 
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		r, err := NewPayloadReader(schemapb.DataType_BinaryVector, buffer)
 		assert.Nil(t, err)
 
@@ -1158,7 +1072,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 	t.Run("TestGetFloatVectorError", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_Bool)
+		w, err := NewPayloadWriter(schemapb.DataType_Bool, new(bytes.Buffer))
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -1168,9 +1082,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
 
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		r, err := NewPayloadReader(schemapb.DataType_FloatVector, buffer)
 		assert.Nil(t, err)
 
@@ -1182,7 +1094,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 	t.Run("TestGetFloatVectorError2", func(t *testing.T) {
-		w, err := NewPayloadWriter(schemapb.DataType_FloatVector, 8)
+		w, err := NewPayloadWriter(schemapb.DataType_FloatVector, new(bytes.Buffer), 8)
 		require.Nil(t, err)
 		require.NotNil(t, w)
 
@@ -1192,9 +1104,7 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 		err = w.FinishPayloadWriter()
 		assert.Nil(t, err)
 
-		buffer, err := w.GetPayloadBufferFromWriter()
-		assert.Nil(t, err)
-
+		buffer := w.Buffer()
 		r, err := NewPayloadReader(schemapb.DataType_FloatVector, buffer)
 		assert.Nil(t, err)
 
@@ -1211,16 +1121,13 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 			vec = append(vec, 1)
 		}
 
-		w, err := NewPayloadWriter(schemapb.DataType_FloatVector)
+		w, err := NewPayloadWriter(schemapb.DataType_FloatVector, new(bytes.Buffer))
 		assert.Nil(t, err)
 
 		err = w.AddFloatVectorToPayload(vec, 128)
 		assert.Nil(t, err)
 
 		err = w.FinishPayloadWriter()
-		assert.Nil(t, err)
-
-		_, err = w.GetPayloadBufferFromWriter()
 		assert.Nil(t, err)
 
 		w.ReleasePayloadWriter()


### PR DESCRIPTION
/kind improvement
Let the payload writer use the same buffer of binlog writer, so we don't need to copy the payload again, this may reduce the memory usage of flushing data by about 50%