### PR TITLE
Fix deleted data is still visible

### DIFF
--- a/internal/querynode/flow_graph_insert_node_test.go
+++ b/internal/querynode/flow_graph_insert_node_test.go
@@ -91,9 +91,6 @@ func genFlowGraphDeleteData() (*deleteData, error) {
 		deleteTimestamps: map[UniqueID][]Timestamp{
 			defaultSegmentID: deleteMsg.Timestamps,
 		},
-		deleteOffset: map[UniqueID]int64{
-			defaultSegmentID: 0,
-		},
 	}
 	return dData, nil
 }

--- a/internal/querynode/load_segment_task_test.go
+++ b/internal/querynode/load_segment_task_test.go
@@ -339,12 +339,8 @@ func TestTask_loadSegmentsTask(t *testing.T) {
 		assert.NoError(t, err)
 		err = task.Execute(ctx)
 		assert.NoError(t, err)
-		segment, err := node.metaReplica.getSegmentByID(defaultSegmentID, segmentTypeSealed)
+		_, err := node.metaReplica.getSegmentByID(defaultSegmentID, segmentTypeSealed)
 		assert.NoError(t, err)
-
-		// has reload 3 delete log from dm channel, so next delete offset should be 3
-		offset := segment.segmentPreDelete(1)
-		assert.Equal(t, int64(3), offset)
 	})
 
 	t.Run("test load with partial success", func(t *testing.T) {


### PR DESCRIPTION
/kind bug
related #24234 
- Write all delete records to a buffer instead of segment
- After all delta logs and delete records between checkpoint and the latest position are buffered, flush all buffered delete records into segment
- After the delete buffer flushed, all coming delete records will be written to the segment directly