### PR TITLE
Update Knowhere to 1.3.16 & Check HNSW config before search

### DIFF
--- a/internal/core/src/index/VectorDiskIndex.cpp
+++ b/internal/core/src/index/VectorDiskIndex.cpp
@@ -152,7 +152,9 @@ VectorDiskAnnIndex<T>::Query(const DatasetPtr dataset, const SearchInfo& search_
 
     // set search list
     auto search_list_size = GetValueFromConfig<uint32_t>(search_info.search_params_, DISK_ANN_QUERY_LIST);
-    query_config.search_list_size = search_list_size.has_value() ? search_list_size.value() : 0;
+    if (search_list_size.has_value()) {
+        query_config.search_list_size = search_list_size.value();
+    }
 
     // set beamwidth
     query_config.beamwidth = search_beamwidth_;

--- a/internal/core/src/index/VectorMemIndex.cpp
+++ b/internal/core/src/index/VectorMemIndex.cpp
@@ -163,6 +163,11 @@ VectorMemIndex::Query(const DatasetPtr dataset, const SearchInfo& search_info, c
         knowhere::SetMetaMetricType(search_conf, GetMetricType());
         auto index_type = GetIndexType();
         auto adapter = knowhere::AdapterMgr::GetInstance().GetAdapter(index_type);
+        try {
+            adapter->CheckSearch(search_conf, index_type, GetIndexMode());
+        } catch (std::exception& e) {
+            AssertInfo(false, e.what());
+        }
         return index_->Query(dataset, search_conf, bitset);
     }();
 

--- a/internal/core/thirdparty/knowhere/CMakeLists.txt
+++ b/internal/core/thirdparty/knowhere/CMakeLists.txt
@@ -11,8 +11,8 @@
 # or implied. See the License for the specific language governing permissions and limitations under the License.
 #-------------------------------------------------------------------------------
 
-set(KNOWHERE_VERSION v1.3.15)
-set(KNOWHERE_SOURCE_MD5 "e7f0d153d5f60dc95167820d7bd2e478")
+set(KNOWHERE_VERSION v1.3.16)
+set(KNOWHERE_SOURCE_MD5 "f0ded5a77b39ca7db7047191234ec6d7")
 
 if (DEFINED ENV{MILVUS_KNOWHERE_URL})
     set(KNOWHERE_SOURCE_URL "$ENV{MILVUS_KNOWHERE_URL}")


### PR DESCRIPTION
1. Upgrade Knowhere to 1.3.16 which allows default parameters in search. https://github.com/milvus-io/knowhere/releases/tag/v1.3.16
2. Validate HNSW config before doing search.
3. Don't set default value to DiskANN `search_list`, and allow Knowhere to handle it.