### PR TITLE
Fix deleted data is still visible

### DIFF
--- a/internal/core/src/segcore/InsertRecord.h
+++ b/internal/core/src/segcore/InsertRecord.h
@@ -332,6 +332,16 @@ struct InsertRecord {
         fields_data_.erase(field_id);
     }
 
+    const ConcurrentVector<Timestamp>&
+    timestamps() const {
+        return timestamps_;
+    }
+
+    int64_t
+    size() const {
+        return ack_responder_.GetAck();
+    }
+
  private:
     //    std::vector<std::unique_ptr<VectorBase>> fields_data_;
     std::unordered_map<FieldId, std::unique_ptr<VectorBase>> fields_data_{};

--- a/internal/core/src/segcore/Record.h
+++ b/internal/core/src/segcore/Record.h
@@ -16,9 +16,9 @@ namespace milvus::segcore {
 template <typename RecordType>
 inline int64_t
 get_barrier(const RecordType& record, Timestamp timestamp) {
-    auto& vec = record.timestamps_;
+    auto& vec = record.timestamps();
     int64_t beg = 0;
-    int64_t end = record.ack_responder_.GetAck();
+    int64_t end = record.size();
     while (beg < end) {
         auto mid = (beg + end) / 2;
         if (vec[mid] <= timestamp) {

--- a/internal/core/src/segcore/SegmentGrowingImpl.h
+++ b/internal/core/src/segcore/SegmentGrowingImpl.h
@@ -49,9 +49,6 @@ class SegmentGrowingImpl : public SegmentGrowing {
            const Timestamp* timestamps,
            const InsertData* insert_data) override;
 
-    int64_t
-    PreDelete(int64_t size) override;
-
     // TODO: add id into delete log, possibly bitmap
     Status
     Delete(int64_t reserved_offset,
@@ -132,7 +129,7 @@ class SegmentGrowingImpl : public SegmentGrowing {
 
     int64_t
     get_deleted_count() const override {
-        return deleted_record_.ack_responder_.GetAck();
+        return deleted_record_.size();
     }
 
     int64_t

--- a/internal/core/src/segcore/SegmentInterface.h
+++ b/internal/core/src/segcore/SegmentInterface.h
@@ -71,8 +71,8 @@ class SegmentInterface {
     virtual int64_t
     get_real_count() const = 0;
 
-    virtual int64_t
-    PreDelete(int64_t size) = 0;
+    //  virtual int64_t
+    //  PreDelete(int64_t size) = 0;
 
     virtual Status
     Delete(int64_t reserved_offset,

--- a/internal/core/src/segcore/SegmentSealedImpl.h
+++ b/internal/core/src/segcore/SegmentSealedImpl.h
@@ -98,9 +98,6 @@ class SegmentSealedImpl : public SegmentSealed {
     std::string
     debug() const override;
 
-    int64_t
-    PreDelete(int64_t size) override;
-
     Status
     Delete(int64_t reserved_offset,
            int64_t size,

--- a/internal/core/src/segcore/Utils.h
+++ b/internal/core/src/segcore/Utils.h
@@ -101,8 +101,8 @@ get_deleted_bitmap(int64_t del_barrier,
     // Avoid invalid calculations when there are a lot of repeated delete pks
     std::unordered_map<PkType, Timestamp> delete_timestamps;
     for (auto del_index = start; del_index < end; ++del_index) {
-        auto pk = delete_record.pks_[del_index];
-        auto timestamp = delete_record.timestamps_[del_index];
+        auto pk = delete_record.pks()[del_index];
+        auto timestamp = delete_record.timestamps()[del_index];
 
         delete_timestamps[pk] = timestamp > delete_timestamps[pk]
                                     ? timestamp

--- a/internal/core/src/segcore/segment_c.cpp
+++ b/internal/core/src/segcore/segment_c.cpp
@@ -207,7 +207,7 @@ PreInsert(CSegmentInterface c_segment, int64_t size, int64_t* offset) {
 
 CStatus
 Delete(CSegmentInterface c_segment,
-       int64_t reserved_offset,
+       int64_t reserved_offset,  // deprecated
        int64_t size,
        const uint8_t* ids,
        const uint64_t ids_size,
@@ -223,13 +223,6 @@ Delete(CSegmentInterface c_segment,
     } catch (std::exception& e) {
         return milvus::FailureCStatus(UnexpectedError, e.what());
     }
-}
-
-int64_t
-PreDelete(CSegmentInterface c_segment, int64_t size) {
-    auto segment = static_cast<milvus::segcore::SegmentInterface*>(c_segment);
-
-    return segment->PreDelete(size);
 }
 
 //////////////////////////////    interfaces for sealed segment    //////////////////////////////

--- a/internal/core/src/segcore/segment_c.h
+++ b/internal/core/src/segcore/segment_c.h
@@ -111,8 +111,6 @@ Delete(CSegmentInterface c_segment,
        const uint64_t ids_size,
        const uint64_t* timestamps);
 
-int64_t
-PreDelete(CSegmentInterface c_segment, int64_t size);
 #ifdef __cplusplus
 }
 #endif

--- a/internal/core/unittest/test_c_api.cpp
+++ b/internal/core/unittest/test_c_api.cpp
@@ -355,8 +355,7 @@ TEST(CApiTest, DeleteTest) {
     auto delete_data = serialize(ids.get());
     uint64_t delete_timestamps[] = {0, 0, 0};
 
-    auto offset = PreDelete(segment, 3);
-
+    auto offset = 0;
     auto del_res = Delete(segment,
                           offset,
                           3,
@@ -397,7 +396,7 @@ TEST(CApiTest, MultiDeleteGrowingSegment) {
                                                delete_pks.end());
     auto delete_data = serialize(ids.get());
     std::vector<uint64_t> delete_timestamps(1, dataset.timestamps_[N - 1]);
-    offset = PreDelete(segment, 1);
+    offset = 0;
     auto del_res = Delete(segment,
                           offset,
                           1,
@@ -419,10 +418,10 @@ TEST(CApiTest, MultiDeleteGrowingSegment) {
     plan->plan_node_->predicate_ = std::move(term_expr);
     std::vector<FieldId> target_field_ids{FieldId(100), FieldId(101)};
     plan->field_ids_ = target_field_ids;
+    auto max_ts = dataset.timestamps_[N - 1] + 10;
 
     CRetrieveResult retrieve_result;
-    res = Retrieve(
-        segment, plan.get(), {}, dataset.timestamps_[N - 1], &retrieve_result);
+    res = Retrieve(segment, plan.get(), {}, max_ts, &retrieve_result);
     ASSERT_EQ(res.error_code, Success);
     auto query_result = std::make_unique<proto::segcore::RetrieveResults>();
     auto suc = query_result->ParseFromArray(retrieve_result.proto_blob,
@@ -439,8 +438,7 @@ TEST(CApiTest, MultiDeleteGrowingSegment) {
         retrive_pks,
         proto::plan::GenericValue::kInt64Val);
     plan->plan_node_->predicate_ = std::move(term_expr);
-    res = Retrieve(
-        segment, plan.get(), {}, dataset.timestamps_[N - 1], &retrieve_result);
+    res = Retrieve(segment, plan.get(), {}, max_ts, &retrieve_result);
     ASSERT_EQ(res.error_code, Success);
     suc = query_result->ParseFromArray(retrieve_result.proto_blob,
                                        retrieve_result.proto_size);
@@ -454,7 +452,8 @@ TEST(CApiTest, MultiDeleteGrowingSegment) {
     ids->mutable_int_id()->mutable_data()->Add(delete_pks.begin(),
                                                delete_pks.end());
     delete_data = serialize(ids.get());
-    offset = PreDelete(segment, 1);
+    delete_timestamps[0]++;
+    offset = 0;
     del_res = Delete(segment,
                      offset,
                      1,
@@ -464,8 +463,7 @@ TEST(CApiTest, MultiDeleteGrowingSegment) {
     ASSERT_EQ(del_res.error_code, Success);
 
     // retrieve pks in {2}
-    res = Retrieve(
-        segment, plan.get(), {}, dataset.timestamps_[N - 1], &retrieve_result);
+    res = Retrieve(segment, plan.get(), {}, max_ts, &retrieve_result);
     ASSERT_EQ(res.error_code, Success);
     suc = query_result->ParseFromArray(retrieve_result.proto_blob,
                                        retrieve_result.proto_size);
@@ -534,7 +532,7 @@ TEST(CApiTest, MultiDeleteSealedSegment) {
                                                delete_pks.end());
     auto delete_data = serialize(ids.get());
     std::vector<uint64_t> delete_timestamps(1, dataset.timestamps_[N - 1]);
-    auto offset = PreDelete(segment, 1);
+    auto offset = 0;
     auto del_res = Delete(segment,
                           offset,
                           1,
@@ -556,10 +554,10 @@ TEST(CApiTest, MultiDeleteSealedSegment) {
     plan->plan_node_->predicate_ = std::move(term_expr);
     std::vector<FieldId> target_field_ids{FieldId(100), FieldId(101)};
     plan->field_ids_ = target_field_ids;
+    auto max_ts = dataset.timestamps_[N - 1] + 10;
 
     CRetrieveResult retrieve_result;
-    res = Retrieve(
-        segment, plan.get(), {}, dataset.timestamps_[N - 1], &retrieve_result);
+    res = Retrieve(segment, plan.get(), {}, max_ts, &retrieve_result);
     ASSERT_EQ(res.error_code, Success);
     auto query_result = std::make_unique<proto::segcore::RetrieveResults>();
     auto suc = query_result->ParseFromArray(retrieve_result.proto_blob,
@@ -576,8 +574,7 @@ TEST(CApiTest, MultiDeleteSealedSegment) {
         retrive_pks,
         proto::plan::GenericValue::kInt64Val);
     plan->plan_node_->predicate_ = std::move(term_expr);
-    res = Retrieve(
-        segment, plan.get(), {}, dataset.timestamps_[N - 1], &retrieve_result);
+    res = Retrieve(segment, plan.get(), {}, max_ts, &retrieve_result);
     ASSERT_EQ(res.error_code, Success);
     suc = query_result->ParseFromArray(retrieve_result.proto_blob,
                                        retrieve_result.proto_size);
@@ -591,7 +588,8 @@ TEST(CApiTest, MultiDeleteSealedSegment) {
     ids->mutable_int_id()->mutable_data()->Add(delete_pks.begin(),
                                                delete_pks.end());
     delete_data = serialize(ids.get());
-    offset = PreDelete(segment, 1);
+    delete_timestamps[0]++;
+    offset = 0;
     del_res = Delete(segment,
                      offset,
                      1,
@@ -601,8 +599,7 @@ TEST(CApiTest, MultiDeleteSealedSegment) {
     ASSERT_EQ(del_res.error_code, Success);
 
     // retrieve pks in {2}
-    res = Retrieve(
-        segment, plan.get(), {}, dataset.timestamps_[N - 1], &retrieve_result);
+    res = Retrieve(segment, plan.get(), {}, max_ts, &retrieve_result);
     ASSERT_EQ(res.error_code, Success);
     suc = query_result->ParseFromArray(retrieve_result.proto_blob,
                                        retrieve_result.proto_size);
@@ -682,7 +679,7 @@ TEST(CApiTest, DeleteRepeatedPksFromGrowingSegment) {
     auto delete_data = serialize(ids.get());
     std::vector<uint64_t> delete_timestamps(3, dataset.timestamps_[N - 1]);
 
-    offset = PreDelete(segment, 3);
+    offset = 0;
     auto del_res = Delete(segment,
                           offset,
                           3,
@@ -787,7 +784,7 @@ TEST(CApiTest, DeleteRepeatedPksFromSealedSegment) {
     auto delete_data = serialize(ids.get());
     std::vector<uint64_t> delete_timestamps(3, dataset.timestamps_[N - 1]);
 
-    auto offset = PreDelete(segment, 3);
+    auto offset = 0;
 
     auto del_res = Delete(segment,
                           offset,
@@ -845,7 +842,7 @@ TEST(CApiTest, InsertSamePkAfterDeleteOnGrowingSegment) {
     auto delete_data = serialize(ids.get());
     std::vector<uint64_t> delete_timestamps(3, dataset.timestamps_[N - 1]);
 
-    offset = PreDelete(segment, 3);
+    offset = 0;
 
     auto del_res = Delete(segment,
                           offset,
@@ -966,7 +963,7 @@ TEST(CApiTest, InsertSamePkAfterDeleteOnSealedSegment) {
     auto delete_data = serialize(ids.get());
     std::vector<uint64_t> delete_timestamps(3, dataset.timestamps_[4]);
 
-    auto offset = PreDelete(segment, 3);
+    auto offset = 0;
 
     auto del_res = Delete(segment,
                           offset,
@@ -1231,7 +1228,7 @@ TEST(CApiTest, GetDeletedCountTest) {
     auto delete_data = serialize(ids.get());
     uint64_t delete_timestamps[] = {0, 0, 0};
 
-    auto offset = PreDelete(segment, 3);
+    auto offset = 0;
 
     auto del_res = Delete(segment,
                           offset,
@@ -1308,7 +1305,7 @@ TEST(CApiTest, GetRealCount) {
                                     dataset.timestamps_[N - 1] + 2,
                                     dataset.timestamps_[N - 1] + 3};
 
-    auto del_offset = PreDelete(segment, 3);
+    auto del_offset = 0;
 
     auto del_res = Delete(segment,
                           del_offset,

--- a/internal/core/unittest/test_growing.cpp
+++ b/internal/core/unittest/test_growing.cpp
@@ -27,8 +27,7 @@ TEST(Growing, DeleteCount) {
     auto segment = CreateGrowingSegment(schema, empty_index_meta);
 
     int64_t c = 10;
-    auto offset = segment->PreDelete(c);
-    ASSERT_EQ(offset, 0);
+    auto offset = 0;
 
     Timestamp begin_ts = 100;
     auto tss = GenTss(c, begin_ts);
@@ -47,8 +46,7 @@ TEST(Growing, RealCount) {
     auto segment = CreateGrowingSegment(schema, empty_index_meta);
 
     int64_t c = 10;
-    auto offset = segment->PreInsert(c);
-    ASSERT_EQ(offset, 0);
+    auto offset = 0;
     auto dataset = DataGen(schema, c);
     auto pks = dataset.get_col<int64_t>(pk);
     segment->Insert(offset,
@@ -62,8 +60,7 @@ TEST(Growing, RealCount) {
 
     // delete half.
     auto half = c / 2;
-    auto del_offset1 = segment->PreDelete(half);
-    ASSERT_EQ(del_offset1, 0);
+    auto del_offset1 = 0;
     auto del_ids1 = GenPKs(pks.begin(), pks.begin() + half);
     auto del_tss1 = GenTss(half, c);
     auto status =
@@ -72,7 +69,7 @@ TEST(Growing, RealCount) {
     ASSERT_EQ(c - half, segment->get_real_count());
 
     // delete duplicate.
-    auto del_offset2 = segment->PreDelete(half);
+    auto del_offset2 = segment->get_deleted_count();
     ASSERT_EQ(del_offset2, half);
     auto del_tss2 = GenTss(half, c + half);
     status =
@@ -81,7 +78,7 @@ TEST(Growing, RealCount) {
     ASSERT_EQ(c - half, segment->get_real_count());
 
     // delete all.
-    auto del_offset3 = segment->PreDelete(c);
+    auto del_offset3 = segment->get_deleted_count();
     ASSERT_EQ(del_offset3, half * 2);
     auto del_ids3 = GenPKs(pks.begin(), pks.end());
     auto del_tss3 = GenTss(c, c + half * 2);

--- a/internal/core/unittest/test_retrieve.cpp
+++ b/internal/core/unittest/test_retrieve.cpp
@@ -389,7 +389,7 @@ TEST(Retrieve, Delete) {
     auto ids = std::make_unique<IdArray>();
     ids->mutable_int_id()->mutable_data()->Add(new_pks.begin(), new_pks.end());
     std::vector<idx_t> new_timestamps{10, 10, 10, 10, 10, 10};
-    auto reserved_offset = segment->PreDelete(new_count);
+    auto reserved_offset = segment->get_deleted_count();
     ASSERT_EQ(reserved_offset, row_count);
     segment->Delete(reserved_offset,
                     new_count,

--- a/internal/core/unittest/test_sealed.cpp
+++ b/internal/core/unittest/test_sealed.cpp
@@ -753,7 +753,7 @@ TEST(Sealed, Delete) {
     new_ids->mutable_int_id()->mutable_data()->Add(new_pks.begin(),
                                                    new_pks.end());
     std::vector<idx_t> new_timestamps{10, 10, 10};
-    auto reserved_offset = segment->PreDelete(new_count);
+    auto reserved_offset = segment->get_deleted_count();
     ASSERT_EQ(reserved_offset, row_count);
     segment->Delete(reserved_offset,
                     new_count,
@@ -1009,7 +1009,7 @@ TEST(Sealed, DeleteCount) {
     auto segment = CreateSealedSegment(schema);
 
     int64_t c = 10;
-    auto offset = segment->PreDelete(c);
+    auto offset = segment->get_deleted_count();
     ASSERT_EQ(offset, 0);
 
     Timestamp begin_ts = 100;
@@ -1040,7 +1040,7 @@ TEST(Sealed, RealCount) {
 
     // delete half.
     auto half = c / 2;
-    auto del_offset1 = segment->PreDelete(half);
+    auto del_offset1 = segment->get_deleted_count();
     ASSERT_EQ(del_offset1, 0);
     auto del_ids1 = GenPKs(pks.begin(), pks.begin() + half);
     auto del_tss1 = GenTss(half, c);
@@ -1050,7 +1050,7 @@ TEST(Sealed, RealCount) {
     ASSERT_EQ(c - half, segment->get_real_count());
 
     // delete duplicate.
-    auto del_offset2 = segment->PreDelete(half);
+    auto del_offset2 = segment->get_deleted_count();
     ASSERT_EQ(del_offset2, half);
     auto del_tss2 = GenTss(half, c + half);
     status =
@@ -1059,7 +1059,7 @@ TEST(Sealed, RealCount) {
     ASSERT_EQ(c - half, segment->get_real_count());
 
     // delete all.
-    auto del_offset3 = segment->PreDelete(c);
+    auto del_offset3 = segment->get_deleted_count();
     ASSERT_EQ(del_offset3, half * 2);
     auto del_ids3 = GenPKs(pks.begin(), pks.end());
     auto del_tss3 = GenTss(c, c + half * 2);

--- a/internal/core/unittest/test_segcore.cpp
+++ b/internal/core/unittest/test_segcore.cpp
@@ -59,7 +59,6 @@ TEST(SegmentCoreTest, NormalDistributionTest) {
     auto [raw_data, timestamps, uids] = generate_data(N);
     auto segment = CreateGrowingSegment(schema, empty_index_meta);
     segment->PreInsert(N);
-    segment->PreDelete(N);
 }
 
 // Test insert column-based data

--- a/internal/core/unittest/test_utils.cpp
+++ b/internal/core/unittest/test_utils.cpp
@@ -71,10 +71,7 @@ TEST(Util, GetDeleteBitmap) {
     // test case delete pk1(ts = 0) -> insert repeated pk1 (ts = {1 ... N}) -> query (ts = N)
     std::vector<Timestamp> delete_ts = {0};
     std::vector<PkType> delete_pk = {1};
-    auto offset = delete_record.reserved.fetch_add(1);
-    delete_record.timestamps_.set_data_raw(offset, delete_ts.data(), 1);
-    delete_record.pks_.set_data_raw(offset, delete_pk.data(), 1);
-    delete_record.ack_responder_.AddSegment(offset, offset + 1);
+    delete_record.push(delete_pk, delete_ts.data());
 
     auto query_timestamp = tss[N - 1];
     auto del_barrier = get_barrier(delete_record, query_timestamp);
@@ -89,10 +86,7 @@ TEST(Util, GetDeleteBitmap) {
     // test case insert repeated pk1 (ts = {1 ... N}) -> delete pk1 (ts = N) -> query (ts = N)
     delete_ts = {uint64_t(N)};
     delete_pk = {1};
-    offset = delete_record.reserved.fetch_add(1);
-    delete_record.timestamps_.set_data_raw(offset, delete_ts.data(), 1);
-    delete_record.pks_.set_data_raw(offset, delete_pk.data(), 1);
-    delete_record.ack_responder_.AddSegment(offset, offset + 1);
+    delete_record.push(delete_pk, delete_ts.data());
 
     del_barrier = get_barrier(delete_record, query_timestamp);
     res_bitmap = get_deleted_bitmap(del_barrier,

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -524,19 +524,6 @@ func (s *LocalSegment) preInsert(numOfRecords int) (int64, error) {
 	return offset, nil
 }
 
-func (s *LocalSegment) preDelete(numOfRecords int) int64 {
-	/*
-		long int
-		PreDelete(CSegmentInterface c_segment, long int size);
-	*/
-	var offset C.int64_t
-	GetPool().Submit(func() (any, error) {
-		offset = C.PreDelete(s.ptr, C.int64_t(int64(numOfRecords)))
-		return nil, nil
-	}).Await()
-	return int64(offset)
-}
-
 func (s *LocalSegment) Insert(rowIDs []int64, timestamps []typeutil.Timestamp, record *segcorepb.InsertRecord) error {
 	if s.Type() != SegmentTypeGrowing {
 		return fmt.Errorf("unexpected segmentType when segmentInsert, segmentType = %s", s.typ.String())
@@ -608,9 +595,7 @@ func (s *LocalSegment) Delete(primaryKeys []storage.PrimaryKey, timestamps []typ
 		return WrapSegmentReleased(s.segmentID)
 	}
 
-	offset := s.preDelete(len(primaryKeys))
-
-	var cOffset = C.int64_t(offset)
+	var cOffset = C.int64_t(0) // depre
 	var cSize = C.int64_t(len(primaryKeys))
 	var cTimestampsPtr = (*C.uint64_t)(&(timestamps)[0])
 

--- a/internal/querynodev2/services.go
+++ b/internal/querynodev2/services.go
@@ -1253,6 +1253,7 @@ func (node *QueryNode) SyncDistribution(ctx context.Context, req *querypb.SyncDi
 			DstNodeID:    nodeID,
 			Version:      req.GetVersion(),
 			NeedTransfer: false,
+			LoadScope:    querypb.LoadScope_Delta,
 		})
 		if err != nil {
 			return util.WrapStatus(commonpb.ErrorCode_UnexpectedError, "failed to sync(load) segment", err), nil


### PR DESCRIPTION
/kind bug
fix #23429 
related https://github.com/milvus-io/milvus/issues/24234
related #23726 
- trim overlapping prefix for coming delete records
- make all delete operations serialized to make sure they can calculate the overlapping correctly

This won't slow query/search down as query/search doesn't need to acquire the lock for delete op