### PR TITLE
Refine sigpipe handling

### DIFF
--- a/cmd/milvus/run.go
+++ b/cmd/milvus/run.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"go.uber.org/zap"
 
@@ -49,6 +51,9 @@ func (c *run) execute(args []string, flags *flag.FlagSet) {
 	}
 	c.serverType = args[2]
 	c.formatFlags(args, flags)
+
+	// make go ignore SIGPIPE when all cgo thread set mask SIGPIPE
+	signal.Ignore(syscall.SIGPIPE)
 
 	var local = false
 	role := roles.MilvusRoles{}

--- a/internal/core/src/storage/MinioChunkManager.cpp
+++ b/internal/core/src/storage/MinioChunkManager.cpp
@@ -49,13 +49,18 @@ std::mutex MinioChunkManager::client_mutex_;
 
 static void
 SwallowHandler(int signal) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-result"
     switch (signal) {
         case SIGPIPE:
-            LOG_SERVER_WARNING_ << "SIGPIPE Swallowed" << std::endl;
+            // cannot use log or stdio
+            write(1, "SIGPIPE Swallowed\n", 18);
             break;
         default:
-            LOG_SERVER_ERROR_ << "Unexpected signal in SIGPIPE handler: " << signal << std::endl;
+            // cannot use log or stdio
+            write(2, "Unexpected signal\n", 18);
     }
+#pragma GCC diagnostic pop
 }
 
 /**
@@ -104,6 +109,7 @@ MinioChunkManager::InitSDKAPI(RemoteStorageType type) {
             };
         }
 #endif
+        sdk_options_.loggingOptions.logLevel = Aws::Utils::Logging::LogLevel::Info;
         Aws::InitAPI(sdk_options_);
     }
 }


### PR DESCRIPTION
By POSIX standard, no stdio call is allow in signal handler, so make handler use `write` instead of Log.
Also make go runtime ignore SIGPIPE in case of all cgo threads mask SIGPIPE
/kind improvement