### PR TITLE
[Cherry-Pick] Refine sigpipe handling

### DIFF
--- a/cmd/milvus/run.go
+++ b/cmd/milvus/run.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"go.uber.org/zap"
 
@@ -49,6 +51,9 @@ func (c *run) execute(args []string, flags *flag.FlagSet) {
 	}
 	c.serverType = args[2]
 	c.formatFlags(args, flags)
+
+	// make go ignore SIGPIPE when all cgo threads set mask of SIGPIPE
+	signal.Ignore(syscall.SIGPIPE)
 
 	var local = false
 	role := roles.MilvusRoles{}


### PR DESCRIPTION
Cherry pick from 2.2 #24862

By POSIX standard, no stdio call is allow in signal handler, so make handler use write instead of Log.
Also make go runtime ignore SIGPIPE in case of all cgo threads mask SIGPIPE

/kind improvement