### PR TITLE
Fix test structure for rmq

### DIFF
--- a/internal/mq/mqimpl/rocksmq/server/global_rmq.go
+++ b/internal/mq/mqimpl/rocksmq/server/global_rmq.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 
-	"github.com/milvus-io/milvus/internal/allocator"
 	"github.com/milvus-io/milvus/pkg/log"
 )
 
@@ -32,13 +31,6 @@ var Rmq *rocksmq
 
 // once is used to init global rocksmq
 var once sync.Once
-
-// InitRmq is deprecate implementation of global rocksmq. will be removed later
-func InitRmq(rocksdbName string, idAllocator allocator.Interface) error {
-	var err error
-	Rmq, err = NewRocksMQ(rocksdbName, idAllocator)
-	return err
-}
 
 // InitRocksMQ init global rocksmq single instance
 func InitRocksMQ(path string) error {

--- a/internal/mq/mqimpl/rocksmq/server/global_rmq_test.go
+++ b/internal/mq/mqimpl/rocksmq/server/global_rmq_test.go
@@ -12,43 +12,12 @@
 package server
 
 import (
-	"log"
 	"os"
-	"strings"
 	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/milvus-io/milvus/internal/allocator"
-	etcdkv "github.com/milvus-io/milvus/internal/kv/etcd"
-	"github.com/milvus-io/milvus/pkg/util/etcd"
 )
-
-func Test_InitRmq(t *testing.T) {
-	name := "/tmp/rmq_init"
-	defer os.RemoveAll("/tmp/rmq_init")
-	endpoints := os.Getenv("ETCD_ENDPOINTS")
-	if endpoints == "" {
-		endpoints = "localhost:2379"
-	}
-	etcdEndpoints := strings.Split(endpoints, ",")
-	etcdCli, err := etcd.GetRemoteEtcdClient(etcdEndpoints)
-	defer etcdCli.Close()
-	if err != nil {
-		log.Fatalf("New clientv3 error = %v", err)
-	}
-	etcdKV := etcdkv.NewEtcdKV(etcdCli, "/etcd/test/root")
-	idAllocator := allocator.NewGlobalIDAllocator("dummy", etcdKV)
-	_ = idAllocator.Initialize()
-
-	defer os.RemoveAll(name + kvSuffix)
-	defer os.RemoveAll(name)
-	err = InitRmq(name, idAllocator)
-	defer Rmq.stopRetention()
-	assert.NoError(t, err)
-	defer CloseRocksMQ()
-}
 
 func Test_InitRocksMQ(t *testing.T) {
 	rmqPath := "/tmp/milvus/rdb_data_global"


### PR DESCRIPTION
Issue #24877
As we discussed in another PR, the current test case structure in `rmq` folder is bad and sometimes triggers nil reference panic.

1. The root cause is we only have 1 global rmq server, and it shouldn't be initialize multiple times
2. But previously in the test file [rocksmq_msgstream_test.go](https://github.com/milvus-io/milvus/blob/master/internal/mq/msgstream/mqwrapper/rmq/rocksmq_msgstream_test.go#L68), we manually initialize it several times. This leads to race conditions in the global rmq server instance
3. In [rmq_client_test.go](https://github.com/milvus-io/milvus/blob/master/internal/mq/msgstream/mqwrapper/rmq/rmq_client_test.go#L38), we have a TestMain function which controls the initialization and destruction of the global rmq server instance
4. I remove our manual instance initialization code and delegate all the duties to the TestMain function

Now everything works well. No errors in test cases.