### PR TITLE
add autoID to varchar dataType

### DIFF
--- a/internal/proxy/util_test.go
+++ b/internal/proxy/util_test.go
@@ -309,7 +309,7 @@ func TestValidatePrimaryKey(t *testing.T) {
 
 	// test collection with varChar field as primary and autoID = true
 	VarCharField.AutoID = true
-	assert.Error(t, validatePrimaryKey(&schemapb.CollectionSchema{
+	assert.Nil(t, validatePrimaryKey(&schemapb.CollectionSchema{
 		Name:        "coll1",
 		Description: "",
 		AutoID:      true,

--- a/tests/python_client/testcases/test_collection.py
+++ b/tests/python_client/testcases/test_collection.py
@@ -3754,7 +3754,7 @@ class TestCollectionString(TestcaseBase):
         """
         target: test create collection with string field 
         method: create collection with string field, the string field primary and auto id are true
-        expected: Raise exception
+        expected: Create collection successfully
         """
         self._connect()
         int_field = cf.gen_int64_field()
@@ -3762,9 +3762,11 @@ class TestCollectionString(TestcaseBase):
         string_field = cf.gen_string_field(is_primary=True, auto_id=True)
         fields = [int_field, string_field, vec_field]
         schema, _ = self.collection_schema_wrap.init_collection_schema(fields=fields)
-        error = {ct.err_code: 0, ct.err_msg: "autoID is not supported when the VarChar field is the primary key"}
-        self.collection_wrap.init_collection(name=cf.gen_unique_str(prefix), schema=schema,
-                                             check_task=CheckTasks.err_res, check_items=error)
+#         error = {ct.err_code: 0, ct.err_msg: "autoID is not supported when the VarChar field is the primary key"}
+        c_name = cf.gen_unique_str(prefix)
+        self.collection_wrap.init_collection(name=c_name, schema=schema,
+                                             check_task=CheckTasks.check_collection_property, 
+                                             check_items={exp_name: c_name, exp_schema: schema})
         
 
 class TestCollectionJSON(TestcaseBase):


### PR DESCRIPTION
issues: https://github.com/milvus-io/milvus/issues/24641


1. annotation code to avoid return error when `pktype = varchar & autoID = true`
2. just cast int64 to a varchar as pk when insertData.

