### PR TITLE
Enlarge compact testcase timeout

### DIFF
--- a/internal/rootcoord/proxy_manager_test.go
+++ b/internal/rootcoord/proxy_manager_test.go
@@ -121,7 +121,7 @@ func TestProxyManager_ErrCompacted(t *testing.T) {
 		Params.EtcdCfg.EtcdTLSMinVersion.GetValue())
 	assert.NoError(t, err)
 	defer etcdCli.Close()
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 	defer cancel()
 
 	sessKey := path.Join(Params.EtcdCfg.MetaRootPath.GetValue(), sessionutil.DefaultServiceRoot)


### PR DESCRIPTION
`etcdCli.Compact(ctx, 10)` might take a lot of time for github runner. Enlarge timeout for stable running.
See also #24337
/kind improvement
