### PR TITLE
Limit the num of concurrent sync tasks and allow only one sync task for same segment (#24881)

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -340,6 +340,7 @@ dataNode:
     flowGraph:
       maxQueueLength: 1024 # Maximum length of task queue in flowgraph
       maxParallelism: 1024 # Maximum number of tasks executed in parallel in the flowgraph
+    maxParallelSyncTaskNum: 2 # Maximum number of sync tasks executed in parallel in each flush manager
   segment:
     # Max buffer size to flush for a single segment.
     insertBufSize: 16777216 # Bytes, 16 MB

--- a/internal/datanode/channel_meta.go
+++ b/internal/datanode/channel_meta.go
@@ -70,6 +70,7 @@ type Channel interface {
 	transferNewSegments(segmentIDs []UniqueID)
 	updateSegmentPKRange(segID UniqueID, ids storage.FieldData)
 	mergeFlushedSegments(ctx context.Context, seg *Segment, planID UniqueID, compactedFrom []UniqueID) error
+	getSegment(segID UniqueID) *Segment
 	hasSegment(segID UniqueID, countFlushed bool) bool
 	removeSegments(segID ...UniqueID)
 	listCompactedSegmentIDs() map[UniqueID][]UniqueID
@@ -249,6 +250,17 @@ func (c *ChannelMeta) addSegment(req addSegmentReq) error {
 	c.segments[req.segID] = seg
 	c.segMu.Unlock()
 	return nil
+}
+
+func (c *ChannelMeta) getSegment(segID UniqueID) *Segment {
+	c.segMu.RLock()
+	defer c.segMu.RUnlock()
+
+	seg, ok := c.segments[segID]
+	if !ok {
+		return nil
+	}
+	return seg
 }
 
 func (c *ChannelMeta) listCompactedSegmentIDs() map[UniqueID][]UniqueID {

--- a/internal/datanode/compactor_test.go
+++ b/internal/datanode/compactor_test.go
@@ -866,6 +866,7 @@ type mockFlushManager struct {
 	returnError      bool
 	recordFlushedSeg bool
 	flushedSegIDs    []UniqueID
+	full             bool
 	injectOverCount  struct {
 		sync.RWMutex
 		value int
@@ -889,6 +890,10 @@ func (mfm *mockFlushManager) flushDelData(data *DelDataBuf, segmentID UniqueID, 
 		mfm.flushedSegIDs = append(mfm.flushedSegIDs, segmentID)
 	}
 	return nil
+}
+
+func (mfm *mockFlushManager) isFull() bool {
+	return mfm.full
 }
 
 func (mfm *mockFlushManager) injectFlush(injection *taskInjection, segments ...UniqueID) {

--- a/internal/datanode/flow_graph_insert_buffer_node.go
+++ b/internal/datanode/flow_graph_insert_buffer_node.go
@@ -466,14 +466,26 @@ func (ibNode *insertBufferNode) Sync(fgMsg *flowGraphMsg, seg2Upload []UniqueID,
 	ibNode.channel.(*ChannelMeta).needToSync.Store(false)
 
 	for _, task := range syncTasks {
-		log.Info("insertBufferNode syncing BufferData",
-			zap.Int64("segmentID", task.segmentID),
+		log := log.With(zap.Int64("segmentID", task.segmentID),
 			zap.Bool("flushed", task.flushed),
 			zap.Bool("dropped", task.dropped),
 			zap.Bool("auto", task.auto),
 			zap.Any("position", endPosition),
 			zap.String("channel", ibNode.channelName),
 		)
+		// check if task pool is full
+		if !task.dropped && !task.flushed && ibNode.flushManager.isFull() {
+			log.RatedWarn(10, "task pool is full, skip it")
+			continue
+		}
+		// check if segment is syncing
+		segment := ibNode.channel.getSegment(task.segmentID)
+		if !task.dropped && !task.flushed && segment.isSyncing() {
+			log.RatedInfo(10, "segment is syncing, skip it")
+			continue
+		}
+		segment.setSyncing(true)
+		log.Info("insertBufferNode syncing BufferData")
 		// use the flushed pk stats to take current stat
 		var pkStats []*storage.PrimaryKeyStats
 		// TODO, this has to be async flush, no need to block here.

--- a/internal/datanode/flow_graph_insert_buffer_node_test.go
+++ b/internal/datanode/flow_graph_insert_buffer_node_test.go
@@ -266,6 +266,8 @@ func TestFlowGraphInsertBufferNode_Operate(t *testing.T) {
 	assert.Panics(t, func() { iBNode.Operate([]flowgraph.Msg{&inMsg}) })
 
 	// test flushBufferData failed
+	segment := channel.getSegment(UniqueID(1))
+	segment.setSyncing(false)
 	setFlowGraphRetryOpt(retry.Attempts(1))
 	inMsg = genFlowGraphInsertMsg(insertChannelName)
 	iBNode.flushManager = &mockFlushManager{returnError: true}
@@ -1149,4 +1151,58 @@ func TestInsertBufferNode_collectSegmentsToSync(t *testing.T) {
 			assert.Equal(t, test.expectedOutNum, len(flushedSegs)+len(staleSegs))
 		})
 	}
+}
+
+func TestInsertBufferNode_task_pool_is_full(t *testing.T) {
+	ctx := context.Background()
+	flushCh := make(chan flushMsg, 100)
+
+	cm := storage.NewLocalChunkManager(storage.RootPath(insertNodeTestDir))
+	defer func() {
+		err := cm.RemoveWithPrefix(ctx, cm.RootPath())
+		assert.NoError(t, err)
+	}()
+
+	channelName := "test_task_pool_is_full_mock_ch1"
+	collection := UniqueID(0)
+	segmentID := UniqueID(100)
+
+	channel := newChannel(channelName, collection, nil, &RootCoordFactory{pkType: schemapb.DataType_Int64}, cm)
+	err := channel.addSegment(addSegmentReq{
+		segType:  datapb.SegmentType_New,
+		segID:    segmentID,
+		collID:   collection,
+		startPos: new(internalpb.MsgPosition),
+		endPos:   new(internalpb.MsgPosition),
+	})
+	assert.NoError(t, err)
+	channel.setCurInsertBuffer(segmentID, &BufferData{size: 100})
+
+	fManager := &mockFlushManager{
+		full: true,
+	}
+
+	dManager := &DeltaBufferManager{
+		channel:    channel,
+		delBufHeap: &PriorityQueue{},
+	}
+
+	node := &insertBufferNode{
+		flushChan:        flushCh,
+		channelName:      channelName,
+		channel:          channel,
+		flushManager:     fManager,
+		delBufferManager: dManager,
+	}
+	inMsg := genFlowGraphInsertMsg(channelName)
+	inMsg.BaseMsg = flowgraph.NewBaseMsg(true) // trigger sync task
+
+	segmentsToSync := node.Sync(&inMsg, []UniqueID{segmentID}, nil)
+	assert.Len(t, segmentsToSync, 0)
+
+	fManager.full = false
+	segment := channel.getSegment(segmentID)
+	segment.setSyncing(true)
+	segmentsToSync = node.Sync(&inMsg, []UniqueID{segmentID}, nil)
+	assert.Len(t, segmentsToSync, 0)
 }

--- a/internal/datanode/segment.go
+++ b/internal/datanode/segment.go
@@ -55,6 +55,23 @@ type Segment struct {
 	lastSyncTs  Timestamp
 	startPos    *internalpb.MsgPosition // TODO readonly
 	lazyLoading atomic.Value
+	syncing     atomic.Value
+}
+
+func (s *Segment) isSyncing() bool {
+	if s != nil {
+		b, ok := s.syncing.Load().(bool)
+		if ok {
+			return b
+		}
+	}
+	return false
+}
+
+func (s *Segment) setSyncing(syncing bool) {
+	if s != nil {
+		s.syncing.Store(syncing)
+	}
 }
 
 type addSegmentReq struct {

--- a/internal/util/paramtable/component_param.go
+++ b/internal/util/paramtable/component_param.go
@@ -1687,6 +1687,7 @@ type dataNodeConfig struct {
 	Port                    int
 	FlowGraphMaxQueueLength int32
 	FlowGraphMaxParallelism int32
+	MaxParallelSyncTaskNum  int
 
 	// segment
 	FlushInsertBufferSize  int64
@@ -1726,6 +1727,7 @@ func (p *dataNodeConfig) init(base *BaseTable) {
 	p.initWatchEventTicklerInterval()
 	p.initFlowGraphMaxQueueLength()
 	p.initFlowGraphMaxParallelism()
+	p.initMaxParallelSyncTaskNum()
 	p.initFlushInsertBufferSize()
 	p.initFlushDeleteBufferSize()
 	p.initBinlogMaxSize()
@@ -1757,6 +1759,10 @@ func (p *dataNodeConfig) initFlowGraphMaxQueueLength() {
 
 func (p *dataNodeConfig) initFlowGraphMaxParallelism() {
 	p.FlowGraphMaxParallelism = p.Base.ParseInt32WithDefault("dataNode.dataSync.flowGraph.maxParallelism", 1024)
+}
+
+func (p *dataNodeConfig) initMaxParallelSyncTaskNum() {
+	p.MaxParallelSyncTaskNum = p.Base.ParseIntWithDefault("dataNode.dataSync.maxParallelSyncTaskNum", 2)
 }
 
 func (p *dataNodeConfig) initFlushInsertBufferSize() {

--- a/internal/util/paramtable/component_param_test.go
+++ b/internal/util/paramtable/component_param_test.go
@@ -413,6 +413,9 @@ func TestComponentParam(t *testing.T) {
 		maxParallelism := Params.FlowGraphMaxParallelism
 		t.Logf("flowGraphMaxParallelism: %d", maxParallelism)
 
+		maxParallelSyncTaskNum := Params.MaxParallelSyncTaskNum
+		t.Logf("maxParallelSyncTaskNum: %d", maxParallelSyncTaskNum)
+
 		size := Params.FlushInsertBufferSize
 		t.Logf("FlushInsertBufferSize: %d", size)
 


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/24813

/kind bug