### PR TITLE
[2.2] Refine grpc Status handling: retry legacy only for Unimplemented

### DIFF
--- a/internal/querycoordv2/meta/target_manager.go
+++ b/internal/querycoordv2/meta/target_manager.go
@@ -29,6 +29,7 @@ import (
 	"github.com/samber/lo"
 	"go.uber.org/zap"
 	"golang.org/x/exp/slices"
+	"google.golang.org/grpc/codes"
 )
 
 type TargetScope = int32
@@ -206,7 +207,7 @@ func (mgr *TargetManager) PullNextTargetV2(broker Broker, collectionID int64, pa
 		segments := make(map[int64]*datapb.SegmentInfo, 0)
 		vChannelInfos, segmentInfos, err := broker.GetRecoveryInfoV2(context.TODO(), collectionID, partitionIDs...)
 		if err != nil {
-			if funcutil.IsGrpcErr(err) {
+			if funcutil.IsGrpcErr(err, codes.Unimplemented) {
 				// for rolling  upgrade, when call GetRecoveryInfoV2 failed, back to retry GetRecoveryInfo
 				target, err = mgr.PullNextTargetV1(broker, collectionID, partitionIDs...)
 				return err

--- a/internal/querycoordv2/meta/target_manager_test.go
+++ b/internal/querycoordv2/meta/target_manager_test.go
@@ -215,7 +215,7 @@ func (suite *TargetManagerSuite) TestUpdateNextTarget() {
 	suite.assertChannels([]string{}, suite.mgr.GetDmChannelsByCollection(collectionID, CurrentTarget))
 
 	suite.broker.ExpectedCalls = nil
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, collectionID, int64(1)).Return(nil, nil, status.Errorf(codes.NotFound, "fake not found"))
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, collectionID, int64(1)).Return(nil, nil, status.Errorf(codes.Unimplemented, "fake not found"))
 	suite.broker.EXPECT().GetRecoveryInfo(mock.Anything, collectionID, int64(1)).Return(nextTargetChannels, nextTargetBinlogs, nil)
 	err := suite.mgr.UpdateCollectionNextTargetWithPartitions(collectionID, int64(1))
 	suite.NoError(err)

--- a/internal/util/funcutil/func_test.go
+++ b/internal/util/funcutil/func_test.go
@@ -506,6 +506,18 @@ func TestIsGrpcErr(t *testing.T) {
 		errWrap := fmt.Errorf("wrap grpc error %w", err)
 		assert.True(t, IsGrpcErr(errWrap))
 	})
+
+	t.Run("codes_match", func(t *testing.T) {
+		err := grpcStatus.Error(grpcCodes.Unavailable, "test")
+		errWrap := fmt.Errorf("wrap grpc error %w", err)
+		assert.True(t, IsGrpcErr(errWrap, grpcCodes.Unimplemented, grpcCodes.Unavailable))
+	})
+
+	t.Run("codes_not_match", func(t *testing.T) {
+		err := grpcStatus.Error(grpcCodes.Unavailable, "test")
+		errWrap := fmt.Errorf("wrap grpc error %w", err)
+		assert.False(t, IsGrpcErr(errWrap, grpcCodes.Unimplemented))
+	})
 }
 
 func TestIsEmptyString(t *testing.T) {


### PR DESCRIPTION
cherry pick #25041 
Do retry on legacy APIs only when grpc status is `Unimplemented`
Allow `funcutil.IsGrpcErr` check grpc status code
/kind improvement