### PR TITLE
[Cherry-Pick] Fix kafka consumer double close

### DIFF
--- a/pkg/mq/msgstream/mqwrapper/kafka/kafka_consumer.go
+++ b/pkg/mq/msgstream/mqwrapper/kafka/kafka_consumer.go
@@ -251,7 +251,6 @@ func (kc *Consumer) CheckTopicValid(topic string) error {
 func (kc *Consumer) Close() {
 	kc.closeOnce.Do(func() {
 		close(kc.closeCh)
-		kc.wg.Wait()
-		kc.c.Close()
+		kc.wg.Wait() // wait worker exist and close the client
 	})
 }


### PR DESCRIPTION
Cherry pick #25049 
Fix `c.close` called in both close and worker exit
/kind improvement