### PR TITLE
Fix RemoteChunkManager not thread-safe

### DIFF
--- a/internal/core/src/storage/RemoteChunkManagerFactory.h
+++ b/internal/core/src/storage/RemoteChunkManagerFactory.h
@@ -68,6 +68,7 @@ class RemoteChunkManagerFactory {
 
     RemoteChunkManagerPtr
     GetRemoteChunkManager() {
+        std::shared_lock lck(mutex_);
         return rcm_;
     }
 


### PR DESCRIPTION
/kind bug
fix #25068 
maybe related #25060 