### PR TITLE
[Cherry-Pick]: Fix the kafka panic when sending the message to a closed channel

### DIFF
--- a/pkg/mq/msgstream/mqwrapper/kafka/kafka_producer_test.go
+++ b/pkg/mq/msgstream/mqwrapper/kafka/kafka_producer_test.go
@@ -67,3 +67,30 @@ func TestKafkaProducer_SendFail(t *testing.T) {
 		producer.Close()
 	}
 }
+
+func TestKafkaProducer_SendFailAfterClose(t *testing.T) {
+	kafkaAddress := getKafkaBrokerList()
+	kc := NewKafkaClientInstance(kafkaAddress)
+	defer kc.Close()
+	assert.NotNil(t, kc)
+
+	rand.Seed(time.Now().UnixNano())
+	topic := fmt.Sprintf("test-topic-%d", rand.Int())
+
+	producer, err := kc.CreateProducer(mqwrapper.ProducerOptions{Topic: topic})
+	assert.Nil(t, err)
+	assert.NotNil(t, producer)
+
+	producer.Close()
+
+	kafkaProd := producer.(*kafkaProducer)
+	assert.Equal(t, kafkaProd.Topic(), topic)
+
+	msg2 := &mqwrapper.ProducerMessage{
+		Payload:    []byte{},
+		Properties: map[string]string{},
+	}
+	_, err = producer.Send(context.TODO(), msg2)
+	time.Sleep(10 * time.Second)
+	assert.NotNil(t, err)
+}


### PR DESCRIPTION
origin pr: #25116
issue: https://github.com/milvus-io/milvus/issues/24767

Here the isClosed variable is used instead of select deliveryChan. Because:

If there is a lot of unprocessed information in the kafka producer, it will lead to a longer flush time, and the deliveryChan will be closed and delayed, so there is still a risk of panic, so here when the producer close method is called, first set the isClosed variable. And before send, firstly judge the value of isClosed