### PR TITLE
Disable release partition when drop partition

### DIFF
--- a/internal/rootcoord/drop_partition_task.go
+++ b/internal/rootcoord/drop_partition_task.go
@@ -83,12 +83,6 @@ func (t *dropPartitionTask) Execute(ctx context.Context) error {
 		ts:           t.GetTs(),
 	})
 
-	redoTask.AddAsyncStep(&releasePartitionsStep{
-		baseStep:     baseStep{core: t.core},
-		collectionID: t.collMeta.CollectionID,
-		partitionIDs: []int64{partID},
-	})
-
 	redoTask.AddAsyncStep(&deletePartitionDataStep{
 		baseStep: baseStep{core: t.core},
 		pchans:   t.collMeta.PhysicalChannelNames,


### PR DESCRIPTION
/kind improvement

As a result of the limitation that requires the user to release the partition before dropping it (refer to https://github.com/milvus-io/milvus/pull/23732), the inclusion of the `releasePartitionStep` in the `DropPartitionTask` becomes redundant.