### PR TITLE
Add SetMetricType and set metric only for shard leader

### DIFF
--- a/internal/querycoordv2/task/executor.go
+++ b/internal/querycoordv2/task/executor.go
@@ -254,21 +254,9 @@ func (ex *Executor) loadSegment(task *SegmentTask, step int) error {
 		return err
 	}
 
-	// TODO: improve this, queryCoord should keep index and schema in memory to save RPC.
-	indexInfo, err := ex.broker.DescribeIndex(ctx, task.CollectionID())
-	if err != nil {
-		log.Warn("fail to get index meta of collection")
-		return err
-	}
-	metricType, err := getMetricType(indexInfo, schema)
-	if err != nil {
-		log.Warn("failed to get metric type", zap.Error(err))
-		return err
-	}
-
 	loadMeta := packLoadMeta(
 		ex.meta.GetLoadType(task.CollectionID()),
-		metricType,
+		"",
 		task.CollectionID(),
 		partitions...,
 	)

--- a/internal/querycoordv2/task/task_test.go
+++ b/internal/querycoordv2/task/task_test.go
@@ -386,18 +386,6 @@ func (suite *TaskSuite) TestLoadSegmentTask() {
 		}, nil)
 		suite.broker.EXPECT().GetIndexInfo(mock.Anything, suite.collection, segment).Return(nil, nil)
 	}
-	suite.broker.EXPECT().DescribeIndex(mock.Anything, suite.collection).Return([]*indexpb.IndexInfo{
-		{
-			CollectionID: suite.collection,
-			FieldID:      100,
-			IndexParams: []*commonpb.KeyValuePair{
-				{
-					Key:   common.MetricTypeKey,
-					Value: "L2",
-				},
-			},
-		},
-	}, nil)
 	suite.cluster.EXPECT().LoadSegments(mock.Anything, targetNode, mock.Anything).Return(utils.WrapStatus(commonpb.ErrorCode_Success, ""), nil)
 
 	// Test load segment task
@@ -483,18 +471,6 @@ func (suite *TaskSuite) TestLoadSegmentTaskFailed() {
 		}, nil)
 		suite.broker.EXPECT().GetIndexInfo(mock.Anything, suite.collection, segment).Return(nil, errors.New("index not ready"))
 	}
-	suite.broker.EXPECT().DescribeIndex(mock.Anything, suite.collection).Return([]*indexpb.IndexInfo{
-		{
-			CollectionID: suite.collection,
-			FieldID:      100,
-			IndexParams: []*commonpb.KeyValuePair{
-				{
-					Key:   common.MetricTypeKey,
-					Value: "L2",
-				},
-			},
-		},
-	}, nil)
 
 	// Test load segment task
 	suite.dist.ChannelDistManager.Update(targetNode, meta.DmChannelFromVChannel(&datapb.VchannelInfo{
@@ -691,18 +667,6 @@ func (suite *TaskSuite) TestMoveSegmentTask() {
 		}, nil)
 		suite.broker.EXPECT().GetIndexInfo(mock.Anything, suite.collection, segment).Return(nil, nil)
 	}
-	suite.broker.EXPECT().DescribeIndex(mock.Anything, suite.collection).Return([]*indexpb.IndexInfo{
-		{
-			CollectionID: suite.collection,
-			FieldID:      100,
-			IndexParams: []*commonpb.KeyValuePair{
-				{
-					Key:   common.MetricTypeKey,
-					Value: "L2",
-				},
-			},
-		},
-	}, nil)
 	suite.cluster.EXPECT().LoadSegments(mock.Anything, leader, mock.Anything).Return(utils.WrapStatus(commonpb.ErrorCode_Success, ""), nil)
 	suite.cluster.EXPECT().ReleaseSegments(mock.Anything, leader, mock.Anything).Return(utils.WrapStatus(commonpb.ErrorCode_Success, ""), nil)
 
@@ -803,18 +767,6 @@ func (suite *TaskSuite) TestTaskCanceled() {
 		}, nil)
 		suite.broker.EXPECT().GetIndexInfo(mock.Anything, suite.collection, segment).Return(nil, nil)
 	}
-	suite.broker.EXPECT().DescribeIndex(mock.Anything, suite.collection).Return([]*indexpb.IndexInfo{
-		{
-			CollectionID: suite.collection,
-			FieldID:      100,
-			IndexParams: []*commonpb.KeyValuePair{
-				{
-					Key:   common.MetricTypeKey,
-					Value: "L2",
-				},
-			},
-		},
-	}, nil)
 	suite.cluster.EXPECT().LoadSegments(mock.Anything, targetNode, mock.Anything).Return(utils.WrapStatus(commonpb.ErrorCode_Success, ""), nil)
 
 	// Test load segment task
@@ -894,18 +846,6 @@ func (suite *TaskSuite) TestSegmentTaskStale() {
 		}, nil)
 		suite.broker.EXPECT().GetIndexInfo(mock.Anything, suite.collection, segment).Return(nil, nil)
 	}
-	suite.broker.EXPECT().DescribeIndex(mock.Anything, suite.collection).Return([]*indexpb.IndexInfo{
-		{
-			CollectionID: suite.collection,
-			FieldID:      100,
-			IndexParams: []*commonpb.KeyValuePair{
-				{
-					Key:   common.MetricTypeKey,
-					Value: "L2",
-				},
-			},
-		},
-	}, nil)
 	suite.cluster.EXPECT().LoadSegments(mock.Anything, targetNode, mock.Anything).Return(utils.WrapStatus(commonpb.ErrorCode_Success, ""), nil)
 
 	// Test load segment task

--- a/internal/querynodev2/segments/plan.go
+++ b/internal/querynodev2/segments/plan.go
@@ -42,7 +42,7 @@ type SearchPlan struct {
 }
 
 // createSearchPlan returns a new SearchPlan and error
-func createSearchPlan(col *Collection, dsl string) (*SearchPlan, error) {
+func createSearchPlan(col *Collection, dsl string, metricType string) (*SearchPlan, error) {
 	if col.collectionPtr == nil {
 		return nil, errors.New("nil collection ptr, collectionID = " + fmt.Sprintln(col.id))
 	}
@@ -58,11 +58,15 @@ func createSearchPlan(col *Collection, dsl string) (*SearchPlan, error) {
 	}
 
 	var newPlan = &SearchPlan{cSearchPlan: cPlan}
-	newPlan.setMetricType(col.GetMetricType())
+	if len(metricType) != 0 {
+		newPlan.setMetricType(metricType)
+	} else {
+		newPlan.setMetricType(col.GetMetricType())
+	}
 	return newPlan, nil
 }
 
-func createSearchPlanByExpr(col *Collection, expr []byte) (*SearchPlan, error) {
+func createSearchPlanByExpr(col *Collection, expr []byte, metricType string) (*SearchPlan, error) {
 	if col.collectionPtr == nil {
 		return nil, errors.New("nil collection ptr, collectionID = " + fmt.Sprintln(col.id))
 	}
@@ -75,7 +79,11 @@ func createSearchPlanByExpr(col *Collection, expr []byte) (*SearchPlan, error) {
 	}
 
 	var newPlan = &SearchPlan{cSearchPlan: cPlan}
-	newPlan.setMetricType(col.GetMetricType())
+	if len(metricType) != 0 {
+		newPlan.setMetricType(metricType)
+	} else {
+		newPlan.setMetricType(col.GetMetricType())
+	}
 	return newPlan, nil
 }
 
@@ -112,15 +120,16 @@ type SearchRequest struct {
 func NewSearchRequest(collection *Collection, req *querypb.SearchRequest, placeholderGrp []byte) (*SearchRequest, error) {
 	var err error
 	var plan *SearchPlan
+	metricType := req.GetReq().GetMetricType()
 	if req.Req.GetDslType() == commonpb.DslType_BoolExprV1 {
 		expr := req.Req.SerializedExprPlan
-		plan, err = createSearchPlanByExpr(collection, expr)
+		plan, err = createSearchPlanByExpr(collection, expr, metricType)
 		if err != nil {
 			return nil, err
 		}
 	} else {
 		dsl := req.Req.GetDsl()
-		plan, err = createSearchPlan(collection, dsl)
+		plan, err = createSearchPlan(collection, dsl, metricType)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/querynodev2/segments/plan_test.go
+++ b/internal/querynodev2/segments/plan_test.go
@@ -56,7 +56,7 @@ func (suite *PlanSuite) TearDownTest() {
 func (suite *PlanSuite) TestPlanDSL() {
 	dslString := "{\"bool\": { \n\"vector\": {\n \"floatVectorField\": {\n \"metric_type\": \"L2\", \n \"params\": {\n \"nprobe\": 10 \n},\n \"query\": \"$0\",\n \"topk\": 10 \n,\"round_decimal\": 6\n } \n } \n } \n }"
 
-	plan, err := createSearchPlan(suite.collection, dslString)
+	plan, err := createSearchPlan(suite.collection, dslString, "")
 	defer plan.delete()
 	suite.NoError(err)
 	suite.NotEqual(plan, nil)
@@ -73,7 +73,7 @@ func (suite *PlanSuite) TestPlanCreateByExpr() {
 	expr, err := proto.Marshal(planNode)
 	suite.NoError(err)
 
-	_, err = createSearchPlanByExpr(suite.collection, expr)
+	_, err = createSearchPlanByExpr(suite.collection, expr, "")
 	suite.Error(err)
 }
 
@@ -82,16 +82,16 @@ func (suite *PlanSuite) TestPlanFail() {
 		id: -1,
 	}
 
-	_, err := createSearchPlan(collection, "")
+	_, err := createSearchPlan(collection, "", "")
 	suite.Error(err)
 
-	_, err = createSearchPlanByExpr(collection, nil)
+	_, err = createSearchPlanByExpr(collection, nil, "")
 	suite.Error(err)
 }
 
 func (suite *PlanSuite) TestPlanPlaceholderGroup() {
 	dslString := "{\"bool\": { \n\"vector\": {\n \"floatVectorField\": {\n \"metric_type\": \"L2\", \n \"params\": {\n \"nprobe\": 10 \n},\n \"query\": \"$0\",\n \"topk\": 10 \n,\"round_decimal\": 6\n } \n } \n } \n }"
-	plan, err := createSearchPlan(suite.collection, dslString)
+	plan, err := createSearchPlan(suite.collection, dslString, "")
 	suite.NoError(err)
 	suite.NotNil(plan)
 

--- a/internal/querynodev2/segments/reduce_test.go
+++ b/internal/querynodev2/segments/reduce_test.go
@@ -147,7 +147,7 @@ func (suite *ReduceSuite) TestReduceAllFunc() {
 
 	dslString := "{\"bool\": { \n\"vector\": {\n \"floatVectorField\": {\n \"metric_type\": \"L2\", \n \"params\": {\n \"nprobe\": 10 \n},\n \"query\": \"$0\",\n \"topk\": 10 \n,\"round_decimal\": 6\n } \n } \n } \n }"
 
-	plan, err := createSearchPlan(suite.collection, dslString)
+	plan, err := createSearchPlan(suite.collection, dslString, "")
 	suite.NoError(err)
 	searchReq, err := parseSearchRequest(plan, placeGroupByte)
 	searchReq.timestamp = 0

--- a/internal/querynodev2/services.go
+++ b/internal/querynodev2/services.go
@@ -256,6 +256,8 @@ func (node *QueryNode) WatchDmChannels(ctx context.Context, req *querypb.WatchDm
 		IndexMetas:       fieldIndexMetas,
 		MaxIndexRowCount: maxIndexRecordPerSegment,
 	}, req.GetLoadMeta())
+	collection := node.manager.Collection.Get(req.GetCollectionID())
+	collection.SetMetricType(req.GetLoadMeta().GetMetricType())
 	delegator, err := delegator.NewShardDelegator(req.GetCollectionID(), req.GetReplicaID(), channel.GetChannelName(), req.GetVersion(),
 		node.clusterManager, node.manager, node.tSafeManager, node.loader, node.factory, channel.GetSeekPosition().GetTimestamp())
 	if err != nil {
@@ -433,11 +435,6 @@ func (node *QueryNode) LoadPartitions(ctx context.Context, req *querypb.LoadPart
 	if err != nil {
 		return merr.Status(err), nil
 	}
-	// check metric type
-	if metricType == "" {
-		err := fmt.Errorf("empty metric type, collection = %d", req.GetCollectionID())
-		return merr.Status(err), nil
-	}
 	node.manager.Collection.Put(req.GetCollectionID(), req.GetSchema(), &segcorepb.CollectionIndexMeta{
 		IndexMetas:       fieldIndexMetas,
 		MaxIndexRowCount: maxIndexRecordPerSegment,
@@ -502,11 +499,6 @@ func (node *QueryNode) LoadSegments(ctx context.Context, req *querypb.LoadSegmen
 
 	if req.GetLoadScope() == querypb.LoadScope_Delta {
 		return node.loadDeltaLogs(ctx, req), nil
-	}
-	// check metric type
-	if req.GetLoadMeta().GetMetricType() == "" {
-		err := fmt.Errorf("empty metric type, collection = %d", req.GetCollectionID())
-		return merr.Status(err), nil
 	}
 
 	node.manager.Collection.Put(req.GetCollectionID(), req.GetSchema(), nil, req.GetLoadMeta())

--- a/internal/querynodev2/services_test.go
+++ b/internal/querynodev2/services_test.go
@@ -514,9 +514,6 @@ func (suite *ServiceSuite) TestLoadSegments_Int64() {
 		Schema:         schema,
 		DeltaPositions: []*msgpb.MsgPosition{{Timestamp: 20000}},
 		NeedTransfer:   true,
-		LoadMeta: &querypb.LoadMetaInfo{
-			MetricType: defaultMetricType,
-		},
 	}
 
 	// LoadSegment
@@ -534,7 +531,6 @@ func (suite *ServiceSuite) TestLoadSegments_VarChar() {
 		LoadType:     querypb.LoadType_LoadCollection,
 		CollectionID: suite.collectionID,
 		PartitionIDs: suite.partitionIDs,
-		MetricType:   defaultMetricType,
 	}
 	suite.node.manager.Collection = segments.NewCollectionManager()
 	suite.node.manager.Collection.Put(suite.collectionID, schema, nil, loadMeta)
@@ -574,9 +570,6 @@ func (suite *ServiceSuite) TestLoadDeltaInt64() {
 		Schema:       schema,
 		NeedTransfer: true,
 		LoadScope:    querypb.LoadScope_Delta,
-		LoadMeta: &querypb.LoadMetaInfo{
-			MetricType: defaultMetricType,
-		},
 	}
 
 	// LoadSegment
@@ -601,9 +594,6 @@ func (suite *ServiceSuite) TestLoadDeltaVarchar() {
 		Schema:       schema,
 		NeedTransfer: true,
 		LoadScope:    querypb.LoadScope_Delta,
-		LoadMeta: &querypb.LoadMetaInfo{
-			MetricType: defaultMetricType,
-		},
 	}
 
 	// LoadSegment
@@ -626,9 +616,6 @@ func (suite *ServiceSuite) TestLoadSegments_Failed() {
 		Infos:        suite.genSegmentLoadInfos(schema),
 		Schema:       schema,
 		NeedTransfer: true,
-		LoadMeta: &querypb.LoadMetaInfo{
-			MetricType: defaultMetricType,
-		},
 	}
 
 	// Delegator not found
@@ -648,14 +635,6 @@ func (suite *ServiceSuite) TestLoadSegments_Failed() {
 	status, err = suite.node.LoadSegments(ctx, req)
 	suite.NoError(err)
 	suite.Equal(commonpb.ErrorCode_NotReadyServe, status.GetErrorCode())
-
-	// no metric type
-	req.LoadMeta = nil
-	req.Base.TargetID = paramtable.GetNodeID()
-	suite.node.UpdateStateCode(commonpb.StateCode_Healthy)
-	status, err = suite.node.LoadSegments(ctx, req)
-	suite.NoError(err)
-	suite.Equal(commonpb.ErrorCode_UnexpectedError, status.GetErrorCode())
 }
 
 func (suite *ServiceSuite) TestLoadSegments_Transfer() {
@@ -679,9 +658,6 @@ func (suite *ServiceSuite) TestLoadSegments_Transfer() {
 			Infos:        suite.genSegmentLoadInfos(schema),
 			Schema:       schema,
 			NeedTransfer: true,
-			LoadMeta: &querypb.LoadMetaInfo{
-				MetricType: defaultMetricType,
-			},
 		}
 
 		// LoadSegment
@@ -703,9 +679,6 @@ func (suite *ServiceSuite) TestLoadSegments_Transfer() {
 			Infos:        suite.genSegmentLoadInfos(schema),
 			Schema:       schema,
 			NeedTransfer: true,
-			LoadMeta: &querypb.LoadMetaInfo{
-				MetricType: defaultMetricType,
-			},
 		}
 
 		// LoadSegment
@@ -732,9 +705,6 @@ func (suite *ServiceSuite) TestLoadSegments_Transfer() {
 			Infos:        suite.genSegmentLoadInfos(schema),
 			Schema:       schema,
 			NeedTransfer: true,
-			LoadMeta: &querypb.LoadMetaInfo{
-				MetricType: defaultMetricType,
-			},
 		}
 
 		// LoadSegment
@@ -1591,23 +1561,6 @@ func (suite *ServiceSuite) TestLoadPartition() {
 	status, err = suite.node.LoadPartitions(ctx, req)
 	suite.NoError(err)
 	suite.Equal(commonpb.ErrorCode_UnexpectedError, status.GetErrorCode())
-
-	// empty metric type
-	req.IndexInfoList = []*indexpb.IndexInfo{
-		{
-			CollectionID: suite.collectionID,
-			FieldID:      vecField.GetFieldID(),
-			IndexParams: []*commonpb.KeyValuePair{
-				{
-					Key:   common.MetricTypeKey,
-					Value: "",
-				},
-			},
-		},
-	}
-	status, err = suite.node.LoadPartitions(ctx, req)
-	suite.NoError(err)
-	suite.Equal(commonpb.ErrorCode_UnexpectedError, status.ErrorCode)
 
 	// collection not exist and schema is not nil
 	req.IndexInfoList = []*indexpb.IndexInfo{


### PR DESCRIPTION
/kind improvement

The primary objectives of this PR are:
1. To save DescribeIndex RPC each time querycoord wraps LoadSegmentTask;
2. Let the metric type logic remain consistent with the 2.2.x version;