### PR TITLE
Fix queryHook ut data race

### DIFF
--- a/internal/querynodev2/server_test.go
+++ b/internal/querynodev2/server_test.go
@@ -161,7 +161,6 @@ func (suite *QueryNodeSuite) TestInit_QueryHook() {
 	mockHook := &MockQueryHook{}
 	suite.node.queryHook = mockHook
 	suite.node.handleQueryHookEvent()
-	defer func() { suite.node.queryHook = nil }()
 
 	yamlWriter := viper.New()
 	yamlWriter.SetConfigFile("../../configs/milvus.yaml")


### PR DESCRIPTION
Fix #25301 
QueryHook will only be set value in querynode init step, will not cause race condition, just fix this ut case.