### PR TITLE
Set enableDisk to false by default

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -207,7 +207,7 @@ queryNode:
   cacheSize: 32 # GB, default 32 GB, `cacheSize` is the memory used for caching data for faster query. The `cacheSize` must be less than system memory size.
   port: 21123
   loadMemoryUsageFactor: 3 # The multiply factor of calculating the memory usage while loading segments
-  enableDisk: true # enable querynode load disk index, and search on disk index
+  enableDisk: false # enable querynode load disk index, and search on disk index
   maxDiskUsagePercentage: 95
   gracefulStopTimeout: 30
 
@@ -282,7 +282,7 @@ indexCoord:
 
 indexNode:
   port: 21121
-  enableDisk: true # enable index node build disk vector index
+  enableDisk: false # enable index node build disk vector index
   maxDiskUsagePercentage: 95
   gracefulStopTimeout: 30
 


### PR DESCRIPTION
When `enableDisk` is set to true, knowhere will use a thread pool of size 4 times as the hardware thread count. If only in memory index is used in such a case too many threads lead to more context switches between queries and is harmful to the performance, thus disabling it by default. User should explicitly enable it if DiskANN index is used.