### PR TITLE
decrease default value of group max nq

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -243,7 +243,7 @@ queryNode:
     memoryLimit: 2147483648 # 2 GB, 2 * 1024 *1024 *1024
   grouping:
     enabled: true
-    maxNQ: 50000
+    maxNQ: 1000
     topKMergeRatio: 20
   scheduler:
     receiveChanSize: 10240

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -1694,7 +1694,7 @@ Max read concurrency must greater than or equal to 1, and less than or equal to 
 	p.MaxGroupNQ = ParamItem{
 		Key:          "queryNode.grouping.maxNQ",
 		Version:      "2.0.0",
-		DefaultValue: "50000",
+		DefaultValue: "1000",
 		Export:       true,
 	}
 	p.MaxGroupNQ.Init(base.mgr)


### PR DESCRIPTION
Signed-off-by: Wei Liu <wei.liu@zilliz.com>
in cpu cluster, too large nq search after nq merge will got a worse search latency. so we recommand to use a reasonable max nq limit, such as 1000.  
also, in gpu cluster, it's recommanded to use a larger max nq limit.
/kind improvement