### PR TITLE
adjust default value of queryNode.enableDisk

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -248,7 +248,7 @@ queryNode:
       nlist: 128 # growing segment index nlist
       nprobe: 16 # nprobe to search growing segment, based on your accuracy requirement, must smaller than nlist
   loadMemoryUsageFactor: 1 # The multiply factor of calculating the memory usage while loading segments
-  enableDisk: true # enable querynode load disk index, and search on disk index
+  enableDisk: false # enable querynode load disk index, and search on disk index
   maxDiskUsagePercentage: 95
   cache:
     enabled: true


### PR DESCRIPTION
 Signed-off-by: Wei Liu <wei.liu@zilliz.com>
 
for memory index, set `queryNode.enableDisk` to false, will get a better search latency
 /kind improvement