### PR TITLE
Move revision api to WatchKV

### DIFF
--- a/internal/datanode/event_manager.go
+++ b/internal/datanode/event_manager.go
@@ -109,7 +109,7 @@ type tickler struct {
 	progress *atomic.Int32
 	version  int64
 
-	kv        kv.MetaKv
+	kv        kv.WatchKV
 	path      string
 	watchInfo *datapb.ChannelWatchInfo
 
@@ -179,7 +179,7 @@ func (t *tickler) stop() {
 	t.closeWg.Wait()
 }
 
-func newTickler(version int64, path string, watchInfo *datapb.ChannelWatchInfo, kv kv.MetaKv, interval time.Duration) *tickler {
+func newTickler(version int64, path string, watchInfo *datapb.ChannelWatchInfo, kv kv.WatchKV, interval time.Duration) *tickler {
 	return &tickler{
 		progress:  atomic.NewInt32(0),
 		path:      path,

--- a/internal/kv/kv.go
+++ b/internal/kv/kv.go
@@ -69,7 +69,6 @@ type MetaKv interface {
 	TxnKV
 	GetPath(key string) string
 	LoadWithPrefix(key string) ([]string, []string, error)
-	CompareVersionAndSwap(key string, version int64, target string) (bool, error)
 	WalkWithPrefix(prefix string, paginationSize int, fn func([]byte, []byte) error) error
 }
 
@@ -78,6 +77,7 @@ type MetaKv interface {
 //go:generate mockery --name=WatchKV --with-expecter
 type WatchKV interface {
 	MetaKv
+	CompareVersionAndSwap(key string, version int64, target string) (bool, error)
 	Watch(key string) clientv3.WatchChan
 	WatchWithPrefix(key string) clientv3.WatchChan
 	WatchWithRevision(key string, revision int64) clientv3.WatchChan

--- a/internal/kv/mocks/MetaKv.go
+++ b/internal/kv/mocks/MetaKv.go
@@ -49,60 +49,6 @@ func (_c *MetaKv_Close_Call) RunAndReturn(run func()) *MetaKv_Close_Call {
 	return _c
 }
 
-// CompareVersionAndSwap provides a mock function with given fields: key, version, target
-func (_m *MetaKv) CompareVersionAndSwap(key string, version int64, target string) (bool, error) {
-	ret := _m.Called(key, version, target)
-
-	var r0 bool
-	var r1 error
-	if rf, ok := ret.Get(0).(func(string, int64, string) (bool, error)); ok {
-		return rf(key, version, target)
-	}
-	if rf, ok := ret.Get(0).(func(string, int64, string) bool); ok {
-		r0 = rf(key, version, target)
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-
-	if rf, ok := ret.Get(1).(func(string, int64, string) error); ok {
-		r1 = rf(key, version, target)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// MetaKv_CompareVersionAndSwap_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CompareVersionAndSwap'
-type MetaKv_CompareVersionAndSwap_Call struct {
-	*mock.Call
-}
-
-// CompareVersionAndSwap is a helper method to define mock.On call
-//   - key string
-//   - version int64
-//   - target string
-func (_e *MetaKv_Expecter) CompareVersionAndSwap(key interface{}, version interface{}, target interface{}) *MetaKv_CompareVersionAndSwap_Call {
-	return &MetaKv_CompareVersionAndSwap_Call{Call: _e.mock.On("CompareVersionAndSwap", key, version, target)}
-}
-
-func (_c *MetaKv_CompareVersionAndSwap_Call) Run(run func(key string, version int64, target string)) *MetaKv_CompareVersionAndSwap_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(int64), args[2].(string))
-	})
-	return _c
-}
-
-func (_c *MetaKv_CompareVersionAndSwap_Call) Return(_a0 bool, _a1 error) *MetaKv_CompareVersionAndSwap_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *MetaKv_CompareVersionAndSwap_Call) RunAndReturn(run func(string, int64, string) (bool, error)) *MetaKv_CompareVersionAndSwap_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // GetPath provides a mock function with given fields: key
 func (_m *MetaKv) GetPath(key string) string {
 	ret := _m.Called(key)


### PR DESCRIPTION
Move CompareVersionAndSwap from MetaKv to WatchKV since it's coupled with Watch().

Issue: #24694