### PR TITLE
Retry on SyncSegment failure

### DIFF
--- a/internal/datacoord/session_manager.go
+++ b/internal/datacoord/session_manager.go
@@ -28,6 +28,7 @@ import (
 	"github.com/milvus-io/milvus/internal/proto/datapb"
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/commonpbutil"
+	"github.com/milvus-io/milvus/internal/util/retry"
 	"go.uber.org/zap"
 )
 
@@ -163,21 +164,36 @@ func (c *SessionManager) Compaction(nodeID int64, plan *datapb.CompactionPlan) e
 
 // SyncSegments is a grpc interface. It will send request to DataNode with provided `nodeID` synchronously.
 func (c *SessionManager) SyncSegments(nodeID int64, req *datapb.SyncSegmentsRequest) error {
+	log := log.With(
+		zap.Int64("nodeID", nodeID),
+		zap.Int64("planID", req.GetPlanID()),
+	)
 	ctx, cancel := context.WithTimeout(context.Background(), rpcCompactionTimeout)
 	defer cancel()
 	cli, err := c.getClient(ctx, nodeID)
 	if err != nil {
-		log.Warn("failed to get client", zap.Int64("nodeID", nodeID), zap.Error(err))
+		log.Warn("failed to get client", zap.Error(err))
 		return err
 	}
 
-	resp, err := cli.SyncSegments(ctx, req)
-	if err := VerifyResponse(resp, err); err != nil {
-		log.Warn("failed to sync segments", zap.Int64("node", nodeID), zap.Error(err), zap.Int64("planID", req.GetPlanID()))
+	err = retry.Do(context.Background(), func() error {
+		// reset timeout for each sync segments
+		ctx, cancel := context.WithTimeout(context.Background(), rpcCompactionTimeout)
+		defer cancel()
+
+		resp, err := cli.SyncSegments(ctx, req)
+		if err := VerifyResponse(resp, err); err != nil {
+			log.Warn("failed to sync segments", zap.Error(err))
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		log.Warn("failed to sync segments after retry", zap.Error(err))
 		return err
 	}
 
-	log.Info("success to sync segments", zap.Int64("node", nodeID), zap.Any("planID", req.GetPlanID()))
+	log.Info("success to sync segments")
 	return nil
 }
 

--- a/internal/datanode/flush_manager.go
+++ b/internal/datanode/flush_manager.go
@@ -849,7 +849,7 @@ func flushNotifyFunc(dsService *dataSyncService, opts ...retry.Option) notifyMet
 				log.Warn("failed to SaveBinlogPaths",
 					zap.Int64("segment ID", pack.segmentID),
 					zap.Error(errors.New(rsp.GetReason())))
-				return fmt.Errorf("segment %d not found", pack.segmentID)
+				return nil
 			}
 			// meta error, datanode handles a virtual channel does not belong here
 			if rsp.GetErrorCode() == commonpb.ErrorCode_MetaFailed {

--- a/internal/datanode/flush_manager_test.go
+++ b/internal/datanode/flush_manager_test.go
@@ -605,10 +605,10 @@ func TestFlushNotifyFunc(t *testing.T) {
 		})
 	})
 
-	t.Run("normal segment not found", func(t *testing.T) {
+	t.Run("stale segment not found", func(t *testing.T) {
 		dataCoord.SaveBinlogPathStatus = commonpb.ErrorCode_SegmentNotFound
-		assert.Panics(t, func() {
-			notifyFunc(&segmentFlushPack{flushed: true})
+		assert.NotPanics(t, func() {
+			notifyFunc(&segmentFlushPack{flushed: false})
 		})
 	})
 


### PR DESCRIPTION
Add retry logic when `SyncSegments` fail
Allow flush return `SegmentNotFound` without panicking
/kind improvement