### PR TITLE
[Cherry-Pick] Retry on SyncSegment failure

### DIFF
--- a/internal/datanode/flush_manager.go
+++ b/internal/datanode/flush_manager.go
@@ -926,7 +926,7 @@ func flushNotifyFunc(dsService *dataSyncService, opts ...retry.Option) notifyMet
 				log.Warn("failed to SaveBinlogPaths",
 					zap.Int64("segment ID", pack.segmentID),
 					zap.Error(errors.New(rsp.GetReason())))
-				return fmt.Errorf("segment %d not found", pack.segmentID)
+				return nil
 			}
 			// meta error, datanode handles a virtual channel does not belong here
 			if rsp.GetErrorCode() == commonpb.ErrorCode_MetaFailed {

--- a/internal/datanode/flush_manager_test.go
+++ b/internal/datanode/flush_manager_test.go
@@ -698,10 +698,11 @@ func TestFlushNotifyFunc(t *testing.T) {
 			notifyFunc(&segmentFlushPack{})
 		})
 	})
-	t.Run("normal segment not found", func(t *testing.T) {
+
+	t.Run("stale segment not found", func(t *testing.T) {
 		dataCoord.SaveBinlogPathStatus = commonpb.ErrorCode_SegmentNotFound
-		assert.Panics(t, func() {
-			notifyFunc(&segmentFlushPack{flushed: true})
+		assert.NotPanics(t, func() {
+			notifyFunc(&segmentFlushPack{flushed: false})
 		})
 	})
 


### PR DESCRIPTION
Cherry pick from 2.2.0
Add retry logic when `SyncSegments` fail
Allow flush return `SegmentNotFound` without panicking
/kind improvement