### PR TITLE
implement MetaKv interface with TiKV

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,8 +42,8 @@ require (
 	go.opentelemetry.io/otel/trace v1.13.0
 	go.uber.org/atomic v1.10.0
 	go.uber.org/automaxprocs v1.5.2
-	go.uber.org/multierr v1.6.0
-	go.uber.org/zap v1.17.0
+	go.uber.org/multierr v1.7.0
+	go.uber.org/zap v1.20.0
 	golang.org/x/crypto v0.9.0
 	golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17
 	golang.org/x/oauth2 v0.6.0
@@ -58,8 +58,11 @@ require (
 require (
 	github.com/BurntSushi/toml v1.2.1 // indirect
 	github.com/apache/thrift v0.15.0 // indirect
+	github.com/benbjohnson/clock v1.1.0 // indirect
 	github.com/bytedance/sonic v1.9.1 // indirect
 	github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 // indirect
+	github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548 // indirect
+	github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 // indirect
 	github.com/facebookgo/ensure v0.0.0-20200202191622-63f1cf65ac4c // indirect
 	github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 // indirect
 	github.com/facebookgo/subset v0.0.0-20200203212716-c811ad88dec4 // indirect
@@ -69,9 +72,21 @@ require (
 	github.com/nats-io/jwt/v2 v2.4.1 // indirect
 	github.com/nats-io/nkeys v0.4.4 // indirect
 	github.com/nats-io/nuid v1.0.1 // indirect
+	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.8 // indirect
 	github.com/pierrec/lz4/v4 v4.1.12 // indirect
+	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c // indirect
+	github.com/pingcap/failpoint v0.0.0-20210918120811-547c13e3eb00 // indirect
+	github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989 // indirect
+	github.com/pingcap/kvproto v0.0.0-20221129023506-621ec37aac7a // indirect
+	github.com/pingcap/log v1.1.1-0.20221015072633-39906604fb81 // indirect
+	github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 // indirect
+	github.com/stathat/consistent v1.0.0 // indirect
+	github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a // indirect
+	github.com/tikv/client-go/v2 v2.0.4 // indirect
+	github.com/tikv/pd/client v0.0.0-20221031025758-80f0d8ca4d07 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
+	github.com/twmb/murmur3 v1.1.3 // indirect
 	golang.org/x/arch v0.3.0 // indirect
 	google.golang.org/genproto v0.0.0-20230331144136-dcfb400f0633 // indirect
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.3.0 // indirect
@@ -121,7 +136,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/golang/snappy v0.0.4 // indirect
-	github.com/google/btree v1.0.1
+	github.com/google/btree v1.1.2
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -86,6 +86,7 @@ github.com/aliyun/credentials-go v1.2.6 h1:dSMxpj4uXZj0MYOsEyljlssHzfdHw/M84iQ5Q
 github.com/aliyun/credentials-go v1.2.6/go.mod h1:/KowD1cfGSLrLsH28Jr8W+xwoId0ywIy5lNzDz6O1vw=
 github.com/andybalholm/brotli v1.0.4 h1:V7DdXeJtZscaqfNuAdSRuRFzuiKlHSC/Zh3zl9qY3JY=
 github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
+github.com/antihax/optional v0.0.0-20180407024304-ca021399b1a6/go.mod h1:V8iCPQYkqmusNa815XgQio277wI47sdRh1dUOLdyC6Q=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20210826220005-b48c857c3a0e h1:GCzyKMDDjSGnlpl3clrdAK7I1AaVoaiKDOYkUzChZzg=
 github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20210826220005-b48c857c3a0e/go.mod h1:F7bn7fEU90QkQ3tnmaTx3LTKLEDqnwWODIYppRQ5hnY=
@@ -104,6 +105,8 @@ github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmV
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/aws/aws-sdk-go v1.32.6/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
+github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
+github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benesch/cgosymbolizer v0.0.0-20190515212042-bec6fe6e597b h1:5JgaFtHFRnOPReItxvhMDXbvuBkjSWE+9glJyF466yw=
 github.com/benesch/cgosymbolizer v0.0.0-20190515212042-bec6fe6e597b/go.mod h1:eMD2XUcPsHYbakFEocKrWZp47G0MRJYoC60qFblGjpA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -186,6 +189,8 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548 h1:iwZdTE0PVqJCos1vaoKsclOGD3ADKpshg3SRtYBbwso=
+github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548/go.mod h1:e6NPNENfs9mPDVNRekM7lKScauxd5kXTr1Mfyig6TDM=
 github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuAyr0=
 github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=
 github.com/davecgh/go-spew v0.0.0-20161028175848-04cdfd42973b/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -194,6 +199,7 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgraph-io/badger v1.6.0/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dimfeld/httptreemux v5.0.1+incompatible h1:Qj3gVcDNoOthBAqftuD596rm4wg/adLLz5xh5CmpiCA=
@@ -271,6 +277,7 @@ github.com/go-latex/latex v0.0.0-20210118124228-b3d85cf34e07/go.mod h1:CO1AlKB2C
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
+github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-logr/logr v0.4.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.3 h1:2DntVwHkVopvECVRSlL5PSo9eG+cAkDCuckLubN+rq0=
@@ -362,6 +369,8 @@ github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Z
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.1 h1:gK4Kx5IaGY9CD5sPJ36FHiBJ6ZXl0kilRiiCj+jdYp4=
 github.com/google/btree v1.0.1/go.mod h1:xXMiIv4Fb/0kKde4SpL7qlzvu5cMJDRkFDxJfI9uaxA=
+github.com/google/btree v1.1.2 h1:xf4v41cLI2Z6FxbKm+8Bu+m8ifhj15JuZ9sa0jZCMUU=
+github.com/google/btree v1.1.2/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
 github.com/google/flatbuffers v2.0.5+incompatible h1:ANsW0idDAXIY+mNHzIHxWRfabV2x5LUEEIIWcwsYgB8=
 github.com/google/flatbuffers v2.0.5+incompatible/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
@@ -418,6 +427,7 @@ github.com/grpc-ecosystem/go-grpc-middleware v1.3.0/go.mod h1:z0ButlSOZa5vEBq9m2
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
+github.com/grpc-ecosystem/grpc-gateway v1.12.1/go.mod h1:8XEsbTttt/W+VvjtQhLACqCisSPWTxCZ7sBRjU6iH9c=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 h1:BZHcxBETFHIdVyhyEfOvn/RdU/QGdLI4y34qQGjGWO0=
@@ -503,6 +513,7 @@ github.com/kataras/iris/v12 v12.1.8/go.mod h1:LMYy4VlP67TQ3Zgriz8RE2h2kMZV2SgMYb
 github.com/kataras/neffos v0.0.14/go.mod h1:8lqADm8PnbeFfL7CLXh1WHw53dG27MC3pgi2R1rmoTE=
 github.com/kataras/pio v0.0.2/go.mod h1:hAoW0t9UmXi4R5Oyq5Z4irTbaTsOemSrDGUtaTl7Dro=
 github.com/kataras/sitemap v0.0.5/go.mod h1:KY2eugMKiPwsJgx7+U103YZehfvNGOXURubcGyk0Bz8=
+github.com/keybase/go-keychain v0.0.0-20190712205309-48d3d31d256d/go.mod h1:JJNrCn9otv/2QP4D7SMJBgaleKpOf66PnW6F5WGNRIc=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
@@ -660,6 +671,7 @@ github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9
 github.com/opencontainers/runtime-spec v1.0.2 h1:UfAcuLBJB9Coz72x1hgl8O5RVzTdNiaglX6v2DM6FI0=
 github.com/opencontainers/runtime-spec v1.0.2/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
+github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/panjf2000/ants/v2 v2.7.2 h1:2NUt9BaZFO5kQzrieOmK/wdb/tQ/K+QHaxN8sOgD63U=
 github.com/panjf2000/ants/v2 v2.7.2/go.mod h1:KIBmYG9QQX5U2qzFP/yQJaq/nSb6rahS9iEHkrCMgM8=
@@ -676,8 +688,20 @@ github.com/pierrec/lz4 v2.5.2+incompatible h1:WCjObylUIOlKy/+7Abdn34TLIkXiA4UWUM
 github.com/pierrec/lz4 v2.5.2+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pierrec/lz4/v4 v4.1.12 h1:44l88ehTZAUGW4VlO1QC4zkilL99M6Y9MXNwEs0uzP8=
 github.com/pierrec/lz4/v4 v4.1.12/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
+github.com/pingcap/errors v0.11.0/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
 github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
+github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c h1:xpW9bvK+HuuTmyFqUwr+jcCvpVkK7sumiz+ko5H9eq4=
+github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c/go.mod h1:X2r9ueLEUZgtx2cIogM0v4Zj5uvvzhuuiu7Pn8HzMPg=
+github.com/pingcap/failpoint v0.0.0-20210918120811-547c13e3eb00 h1:C3N3itkduZXDZFh4N3vQ5HEtld3S+Y+StULhWVvumU0=
+github.com/pingcap/failpoint v0.0.0-20210918120811-547c13e3eb00/go.mod h1:4qGtCB0QK0wBzKtFEGDhxXnSnbQApw1gc9siScUl8ew=
+github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989 h1:surzm05a8C9dN8dIUmo4Be2+pMRb6f55i+UIYrluu2E=
+github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989/go.mod h1:O17XtbryoCJhkKGbT62+L2OlrniwqiGLSqrmdHCMzZw=
+github.com/pingcap/kvproto v0.0.0-20221026112947-f8d61344b172/go.mod h1:OYtxs0786qojVTmkVeufx93xe+jUgm56GUYRIKnmaGI=
+github.com/pingcap/kvproto v0.0.0-20221129023506-621ec37aac7a h1:LzIZsQpXQlj8yF7+yvyOg680OaPq7bmPuDuszgXfHsw=
+github.com/pingcap/kvproto v0.0.0-20221129023506-621ec37aac7a/go.mod h1:OYtxs0786qojVTmkVeufx93xe+jUgm56GUYRIKnmaGI=
+github.com/pingcap/log v1.1.1-0.20221015072633-39906604fb81 h1:URLoJ61DmmY++Sa/yyPEQHG2s/ZBeV1FbIswHEMrdoY=
+github.com/pingcap/log v1.1.1-0.20221015072633-39906604fb81/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -695,6 +719,7 @@ github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXP
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
+github.com/prometheus/client_golang v1.11.0/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
 github.com/prometheus/client_golang v1.11.1/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
 github.com/prometheus/client_golang v1.14.0 h1:nJdhIvne2eSX/XRAFV9PcvFFRbrjbcTUj0VP62TMhnw=
 github.com/prometheus/client_golang v1.14.0/go.mod h1:8vpkKitgIVNcqrRBWh1C4TIUQgYNtG/XQE4E/Zae36Y=
@@ -721,6 +746,8 @@ github.com/prometheus/procfs v0.9.0/go.mod h1:+pB4zwohETzFnmlpe6yd2lSc+0/46IYZRB
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/quasilyte/go-ruleguard/dsl v0.3.22 h1:wd8zkOhSNr+I+8Qeciml08ivDt1pSXe60+5DqOpCjPE=
 github.com/quasilyte/go-ruleguard/dsl v0.3.22/go.mod h1:KeCP03KrjuSO0H1kTuZQCWlQPulDV6YMIXmpQss17rU=
+github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 h1:OdAsTTz6OkFY5QxjkYwrChwuRruF69c169dPK26NUlk=
+github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rivo/tview v0.0.0-20200219210816-cd38d7432498/go.mod h1:6lkG1x+13OShEf0EaOCaTQYyB7d5nSbb181KtjlS+84=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/clock v0.0.0-20190514195947-2896927a307a/go.mod h1:4r5QyqhjIWCcK8DO4KMclc5Iknq5qVBAlbYYzAbUScQ=
@@ -748,6 +775,7 @@ github.com/sbinet/npyio v0.6.0/go.mod h1:/q3BNr6dJOy+t6h7RZchTJ0nwRJO52mivaem29W
 github.com/schollz/closestmatch v2.1.0+incompatible/go.mod h1:RtP1ddjLong6gTkbtmuhtR2uUrrJOpYzYRvbcPAid+g=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
+github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shirou/gopsutil/v3 v3.22.9 h1:yibtJhIVEMcdw+tCTbOPiF1VcsuDeTE4utJ8Dm4c5eA=
 github.com/shirou/gopsutil/v3 v3.22.9/go.mod h1:bBYl1kjgEJpWpxeHmLI+dVHWtyAwfcmSBLDsp2TNT8A=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
@@ -788,6 +816,8 @@ github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DM
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/spf13/viper v1.8.1 h1:Kq1fyeebqsBfbjZj4EL7gj2IO0mMaiyjYUWcUsl2O44=
 github.com/spf13/viper v1.8.1/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH9Ns=
+github.com/stathat/consistent v1.0.0 h1:ZFJ1QTRn8npNBKW065raSZ8xfOqhpb8vLOkfp4CcL/U=
+github.com/stathat/consistent v1.0.0/go.mod h1:uajTPbgSygZBJ+V+0mY7meZ8i0XAcZs7AQ6V121XSxw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
@@ -812,6 +842,12 @@ github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/thoas/go-funk v0.9.1 h1:O549iLZqPpTUQ10ykd26sZhzD+rmR5pWhuElrhbC20M=
+github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a h1:J/YdBZ46WKpXsxsW93SG+q0F8KI+yFrcIDT4c/RNoc4=
+github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a/go.mod h1:h4xBhSNtOeEosLJ4P7JyKXX7Cabg7AVkWCK5gV2vOrM=
+github.com/tikv/client-go/v2 v2.0.4 h1:cPtMXTExqjzk8L40qhrgB/mXiBXKP5LRU0vwjtI2Xxo=
+github.com/tikv/client-go/v2 v2.0.4/go.mod h1:v52O5zDtv2BBus4lm5yrSQhxGW4Z4RaXWfg0U1Kuyqo=
+github.com/tikv/pd/client v0.0.0-20221031025758-80f0d8ca4d07 h1:ckPpxKcl75mO2N6a4cJXiZH43hvcHPpqc9dh1TmH1nc=
+github.com/tikv/pd/client v0.0.0-20221031025758-80f0d8ca4d07/go.mod h1:CipBxPfxPUME+BImx9MUYXCnAVLS3VJUr3mnSJwh40A=
 github.com/tklauser/go-sysconf v0.3.10 h1:IJ1AZGZRWbY8T5Vfk04D9WOA5WSejdflXxP03OUqALw=
 github.com/tklauser/go-sysconf v0.3.10/go.mod h1:C8XykCvCb+Gn0oNCWPIlcb0RuglQTYaQ2hGm7jmxEFk=
 github.com/tklauser/numcpus v0.4.0 h1:E53Dm1HjH1/R2/aoCtXtPgzmElmn51aOkhCFSuZq//o=
@@ -821,6 +857,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802 h1:uruHq4
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
+github.com/twmb/murmur3 v1.1.3 h1:D83U0XYKcHRYwYIpBKf3Pks91Z0Byda/9SJ8B6EMRcA=
+github.com/twmb/murmur3 v1.1.3/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=
 github.com/uber/jaeger-client-go v2.30.0+incompatible h1:D6wyKGCecFaSRUpo8lCVbaOOb6ThwMmTEbhRwtKR97o=
 github.com/uber/jaeger-client-go v2.30.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
@@ -922,20 +960,28 @@ go.opentelemetry.io/proto/otlp v0.19.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/atomic v1.10.0 h1:9qC72Qh0+3MqyJbAn8YU5xVq1frD8bn3JtD2oXtafVQ=
 go.uber.org/atomic v1.10.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/automaxprocs v1.5.2 h1:2LxUOGiR3O6tw8ui5sZa2LAaHnsviZdVOUZw4fvbnME=
 go.uber.org/automaxprocs v1.5.2/go.mod h1:eRbA25aqJrxAbsLO0xy5jVwPt7FQnRgjW+efnwa1WM0=
+go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
+go.uber.org/goleak v1.1.11/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/goleak v1.2.0 h1:xqgm/S+aQvhWFTtR0XK3Jvg7z8kGV8P4X14IzwN3Eqk=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.5.0/go.mod h1:FeouvMocqHpRaaGuG9EjoKcStLC43Zu/fmqdUMPcKYU=
 go.uber.org/multierr v1.6.0 h1:y6IPFStTAIT5Ytl7/XYmHvzXQ7S3g/IeZW9hyZ5thw4=
 go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
+go.uber.org/multierr v1.7.0 h1:zaiO/rmgFjbmCXdSYJWQcdvOCsthmdaHfr3Gm2Kx4Ec=
+go.uber.org/multierr v1.7.0/go.mod h1:7EAYxJLBy9rStEaz58O2t4Uvip6FSURkq8/ppBp95ak=
 go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee/go.mod h1:vJERXedbb3MVM5f9Ejo0C68/HhF8uaILCdgjnY+goOA=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.16.0/go.mod h1:MA8QOfq0BHJwdXa996Y4dYkAqRKB8/1K1QMMZVaNZjQ=
 go.uber.org/zap v1.17.0 h1:MTjgFu6ZLKvY6Pvaqk97GlxNBuMpV4Hy/3P6tRGlI2U=
 go.uber.org/zap v1.17.0/go.mod h1:MXVU+bhUf/A7Xi2HNOnopQOrmycQ5Ih87HtOu4q5SSo=
+go.uber.org/zap v1.19.0/go.mod h1:xg/QME4nWcxGxrpdeYfq7UvYrLh66cuVKdrbD1XF/NI=
+go.uber.org/zap v1.20.0 h1:N4oPlghZwYG55MlU6LXk/Zp00FVNE9X9wrYO8CEs4lc=
+go.uber.org/zap v1.20.0/go.mod h1:wjWOCqI0f2ZZrJF/UufIOkiC8ii6tm1iqIsLo76RfJw=
 golang.org/x/arch v0.0.0-20210923205945-b76863e36670/go.mod h1:5om86z9Hs0C8fWVUuoMHwpExlXzs5Tkyp9hOrfG7pp8=
 golang.org/x/arch v0.3.0 h1:02VY4/ZcO/gBOH6PUaoiptASxtXU10jazRCP865E97k=
 golang.org/x/arch v0.3.0/go.mod h1:5om86z9Hs0C8fWVUuoMHwpExlXzs5Tkyp9hOrfG7pp8=
@@ -1032,6 +1078,7 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190628185345-da137c7871d7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190724013045-ca1201d0de80/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20191002035440-2ec189313ef0/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -1225,6 +1272,7 @@ golang.org/x/tools v0.0.0-20190927191325-030b2cf1153e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191029041327-9cc4af7d6b2c/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191108193012-7d206e10da11/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191112195655-aa38f8e97acc/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191113191852-77e3bb0ad9e7/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191115202509-3a792d9c32b2/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
@@ -1264,6 +1312,7 @@ golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.3/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.8-0.20211029000441-d6a9af8af023/go.mod h1:nABZi5QlRsZVlzPpHl034qft6wpY4eDcsTt5AaioBiU=
 golang.org/x/tools v0.1.9/go.mod h1:nABZi5QlRsZVlzPpHl034qft6wpY4eDcsTt5AaioBiU=
 golang.org/x/tools v0.7.0 h1:W4OVu8VVOaIO0yzWMNdepAulS7YfoS3Zabrm8DOXXU4=
@@ -1321,6 +1370,7 @@ google.golang.org/genproto v0.0.0-20190502173448-54afdca5d873/go.mod h1:VzzqZJRn
 google.golang.org/genproto v0.0.0-20190801165951-fa694d86fc64/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20190911173649-1774047e7e51/go.mod h1:IbNlFCBrqXvoKpeg0TB2l7cyZUmoaFKYIwrEpbDKLA8=
+google.golang.org/genproto v0.0.0-20190927181202-20e1ac93f88c/go.mod h1:IbNlFCBrqXvoKpeg0TB2l7cyZUmoaFKYIwrEpbDKLA8=
 google.golang.org/genproto v0.0.0-20191108220845-16a3f7862a1a/go.mod h1:n3cpQtvxv34hfy77yVDNjmbRyujviMdxYliBSkLhpCc=
 google.golang.org/genproto v0.0.0-20191115194625-c23dd37a84c9/go.mod h1:n3cpQtvxv34hfy77yVDNjmbRyujviMdxYliBSkLhpCc=
 google.golang.org/genproto v0.0.0-20191216164720-4f79533eabd1/go.mod h1:n3cpQtvxv34hfy77yVDNjmbRyujviMdxYliBSkLhpCc=
@@ -1367,6 +1417,7 @@ google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZi
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
+google.golang.org/grpc v1.24.0/go.mod h1:XDChyiUovWa60DnaeDeZmSW86xtLtjtZbwvSiRnRtcA=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
@@ -1387,6 +1438,7 @@ google.golang.org/grpc v1.38.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQ
 google.golang.org/grpc v1.40.0/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
 google.golang.org/grpc v1.41.0/go.mod h1:U3l9uK9J0sini8mHphKoXyaqDA/8VyGnDee1zzIUK6k=
 google.golang.org/grpc v1.42.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
+google.golang.org/grpc v1.43.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
 google.golang.org/grpc v1.44.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
 google.golang.org/grpc v1.46.0/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
 google.golang.org/grpc v1.54.0 h1:EhTqbhiYeixwWQtAEZAxmV9MGqcjEU2mFx52xCzNyag=

--- a/internal/kv/tikv/main_test.go
+++ b/internal/kv/tikv/main_test.go
@@ -1,0 +1,94 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tikv
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/tikv/client-go/v2/rawkv"
+	"github.com/tikv/client-go/v2/testutils"
+	tilib "github.com/tikv/client-go/v2/tikv"
+	"github.com/tikv/client-go/v2/txnkv"
+
+	"github.com/milvus-io/milvus/pkg/util/paramtable"
+)
+
+var TestParams paramtable.ComponentParam
+var txnClient *txnkv.Client
+var rawClient *rawkv.Client
+
+// creates a local TiKV Store for testing purpose.
+func setupLocalTiKV() {
+	setupLocalTxn()
+	setupLocalRaw()
+}
+func setupLocalTxn() {
+	client, cluster, pdClient, err := testutils.NewMockTiKV("", nil)
+	if err != nil {
+		panic(err)
+	}
+	testutils.BootstrapWithSingleStore(cluster)
+	store, err := tilib.NewTestTiKVStore(client, pdClient, nil, nil, 0)
+	if err != nil {
+		panic(err)
+	}
+	txnClient = &txnkv.Client{KVStore: store}
+}
+
+func setupLocalRaw() {
+	client, cluster, pdClient, err := testutils.NewMockTiKV("", nil)
+	if err != nil {
+		panic(err)
+	}
+	testutils.BootstrapWithSingleStore(cluster)
+	rawClient = &rawkv.Client{}
+	p := rawkv.ClientProbe{Client: rawClient}
+	p.SetPDClient(pdClient)
+	p.SetRegionCache(tilib.NewRegionCache(pdClient))
+	p.SetRPCClient(client)
+}
+
+// Connects to a remote TiKV service for testing purpose. By default, it assumes the TiKV is from localhost.
+func setupRemoteTiKV() {
+	pdsn := "127.0.0.1:2379"
+	var err error
+	txnClient, err = txnkv.NewClient([]string{pdsn})
+	if err != nil {
+		panic(err)
+	}
+	rawClient, err = rawkv.NewClientWithOpts(context.Background(), []string{pdsn})
+	if err != nil {
+		panic(err)
+	}
+}
+
+func setupTiKV(use_remote bool) {
+	if use_remote {
+		setupRemoteTiKV()
+	} else {
+		setupLocalTiKV()
+	}
+}
+
+func TestMain(m *testing.M) {
+	TestParams.Init()
+	setupTiKV(false)
+	code := m.Run()
+	os.Exit(code)
+}

--- a/internal/kv/tikv/raw_tikv.go
+++ b/internal/kv/tikv/raw_tikv.go
@@ -1,0 +1,347 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tikv
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	tikv "github.com/tikv/client-go/v2/kv"
+	"github.com/tikv/client-go/v2/rawkv"
+	"go.uber.org/zap"
+
+	"github.com/milvus-io/milvus/internal/kv"
+	"github.com/milvus-io/milvus/pkg/common"
+	"github.com/milvus-io/milvus/pkg/log"
+	"github.com/milvus-io/milvus/pkg/metrics"
+	"github.com/milvus-io/milvus/pkg/util/timerecord"
+)
+
+const (
+	MaxScanLimit = 10240
+)
+
+// implementation assertion
+var _ kv.MetaKv = (*rawTiKV)(nil)
+
+// rawTiKV implements MetaKv (non-TxnKV part) interface. It supports processing multiple kvs in a batch(not transaction) manner.
+type rawTiKV struct {
+	client   *rawkv.Client
+	rootPath string
+}
+
+// NewRawTiKV creates a new rawTiKV client.
+func NewRawTiKV(rawkv *rawkv.Client, rootPath string) *rawTiKV {
+	kv := &rawTiKV{
+		client:   rawkv,
+		rootPath: rootPath,
+	}
+	return kv
+}
+
+// Close closes the connection to TiKV.
+func (kv *rawTiKV) Close() {
+	log.Debug("rawTiKV closed", zap.String("path", kv.rootPath))
+}
+
+// GetPath returns the path of the key/prefix.
+func (kv *rawTiKV) GetPath(key string) string {
+	return path.Join(kv.rootPath, key)
+}
+
+// Has returns if a key exists.
+func (kv *rawTiKV) Has(key string) (bool, error) {
+	start := time.Now()
+	key = path.Join(kv.rootPath, key)
+	ctx, cancel := context.WithTimeout(context.Background(), RequestTimeout)
+	defer cancel()
+
+	val, err := kv.client.Get(ctx, []byte(key))
+	if err != nil {
+		if strings.HasPrefix(err.Error(), "Failed to get value for key") {
+			return false, nil
+		} else {
+			return false, errors.Wrap(err, fmt.Sprintf("Failed to check Has for key %s", key))
+		}
+	}
+	if len(val) == 0 {
+		return false, nil
+	}
+	CheckElapseAndWarn(start, "Slow rawTiKV operation Has()", zap.String("key", key))
+	return true, nil
+}
+
+// HasPrefix returns if a key prefix exists.
+func (kv *rawTiKV) HasPrefix(prefix string) (bool, error) {
+	start := time.Now()
+	prefix = path.Join(kv.rootPath, prefix)
+	ctx, cancel := context.WithTimeout(context.Background(), RequestTimeout)
+	defer cancel()
+
+	// Retrieve key-value pairs with the specified prefix
+	startKey := []byte(prefix)
+	endKey := tikv.PrefixNextKey([]byte(prefix))
+	keys, _, err := kv.client.Scan(ctx, startKey, endKey, 1, rawkv.ScanKeyOnly())
+	if err != nil {
+		log.Warn("rawTiKV HasPrefix error", zap.String("prefix", prefix), zap.Error(err))
+		err = errors.Wrap(err, fmt.Sprintf("Failed to check HasPrefix for prefix %s", prefix))
+	}
+	r := len(keys) > 0
+	CheckElapseAndWarn(start, "Slow load with HasPrefix", zap.String("prefix", prefix))
+	return r, err
+}
+
+// Load returns value of the key.
+func (kv *rawTiKV) Load(key string) (string, error) {
+	start := time.Now()
+	key = path.Join(kv.rootPath, key)
+	ctx, cancel := context.WithTimeout(context.Background(), RequestTimeout)
+	defer cancel()
+	v, err := kv.client.Get(ctx, []byte(key))
+	value := string(v)
+	if err != nil {
+		return "", errors.Wrap(err, fmt.Sprintf("Failed to load key %s", key))
+	}
+	if len(value) == 0 {
+		return "", common.NewKeyNotExistError(key)
+	}
+	CheckElapseAndWarn(start, "Slow rawTiKV operation load", zap.String("key", key))
+	return value, nil
+}
+
+// Helper function to convert a slice of strings to a slice of byte slices.
+func toByteKeys(keys []string, rootPath string) [][]byte {
+	bytesSlice := make([][]byte, len(keys))
+	for i, key := range keys {
+		bytesSlice[i] = []byte(path.Join(rootPath, key))
+	}
+	return bytesSlice
+}
+
+// Helper function to convert a slice of byte slices to a slice of strings.
+func toStringSlice(bytes [][]byte) []string {
+	r := make([]string, len(bytes))
+	for i, b := range bytes {
+		if b == nil {
+			r[i] = ""
+		} else {
+			r[i] = string(b)
+		}
+	}
+	return r
+}
+
+// MultiLoad gets the values of input keys in a transaction.
+func (kv *rawTiKV) MultiLoad(keys []string) ([]string, error) {
+	start := time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), RequestTimeout)
+	defer cancel()
+	bytes, err := kv.client.BatchGet(ctx, toByteKeys(keys, kv.rootPath))
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to MultiLoad keys")
+	}
+	r := make([]string, len(bytes))
+	invalid := make([]string, 0, len(keys))
+	for i, b := range bytes {
+		if b == nil {
+			invalid = append(invalid, keys[i])
+			r[i] = ""
+		} else {
+			r[i] = string(b)
+		}
+	}
+	if len(invalid) != 0 {
+		log.Warn("MultiLoad: there are invalid keys", zap.Strings("keys", invalid))
+		return r, fmt.Errorf("there are invalid keys: %s", invalid)
+	}
+	CheckElapseAndWarn(start, "Slow rawTiKV operation multi load", zap.Any("keys", keys))
+	return r, nil
+}
+
+// LoadWithPrefix returns all the keys and values for the given key prefix.
+func (kv *rawTiKV) LoadWithPrefix(prefix string) ([]string, []string, error) {
+	start := time.Now()
+	prefix = path.Join(kv.rootPath, prefix)
+	ctx, cancel := context.WithTimeout(context.Background(), RequestTimeout)
+	defer cancel()
+
+	// Retrieve key-value pairs with the specified prefix
+	startKey := []byte(prefix)
+	endKey := tikv.PrefixNextKey([]byte(prefix))
+	keys, values, err := kv.client.Scan(ctx, startKey, endKey, MaxScanLimit)
+	if err != nil {
+		log.Warn("rawTiKV LoadWithPrefix error", zap.String("prefix", prefix), zap.Error(err))
+		return nil, nil, errors.Wrap(err, fmt.Sprintf("Failed to LoadWithPrefix for prefix %s", prefix))
+	}
+	strKeys := toStringSlice(keys)
+	CheckElapseAndWarn(start, "Slow rawTiKV operation load with prefix", zap.Strings("keys", strKeys))
+	return strKeys, toStringSlice(values), nil
+}
+
+// Save saves the input key-value pair.
+func (kv *rawTiKV) Save(key, value string) error {
+	start := time.Now()
+	rs := timerecord.NewTimeRecorder("putTiKVMeta")
+	key = path.Join(kv.rootPath, key)
+	ctx, cancel := context.WithTimeout(context.Background(), RequestTimeout)
+	defer cancel()
+
+	elapsed := rs.ElapseSpan()
+	err := kv.client.Put(ctx, []byte(key), []byte(value))
+
+	metrics.MetaOpCounter.WithLabelValues(metrics.MetaPutLabel, metrics.TotalLabel).Inc()
+	if err == nil {
+		metrics.MetaKvSize.WithLabelValues(metrics.MetaPutLabel).Observe(float64(len(value)))
+		metrics.MetaRequestLatency.WithLabelValues(metrics.MetaPutLabel).Observe(float64(elapsed.Milliseconds()))
+		metrics.MetaOpCounter.WithLabelValues(metrics.MetaPutLabel, metrics.SuccessLabel).Inc()
+	} else {
+		metrics.MetaOpCounter.WithLabelValues(metrics.MetaPutLabel, metrics.FailLabel).Inc()
+		err = errors.Wrap(err, fmt.Sprintf("Failed to save key %s", key))
+	}
+	CheckElapseAndWarn(start, "Slow rawTiKV operation save", zap.String("key", key))
+	return err
+}
+
+// MultiSave saves the input key-value pairs in transaction manner.
+func (kv *rawTiKV) MultiSave(kvs map[string]string) error {
+	start := time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), RequestTimeout)
+	defer cancel()
+
+	keys := make([][]byte, len(kvs))
+	values := make([][]byte, len(kvs))
+	for key, value := range kvs {
+		key = path.Join(kv.rootPath, key)
+		keys = append(keys, []byte(key))
+		values = append(values, []byte(value))
+	}
+	err := kv.client.BatchPut(ctx, keys, values)
+	if err != nil {
+		log.Warn("rawTiKV MultiSave error", zap.Any("kvs", kvs), zap.Int("len", len(kvs)), zap.Error(err))
+		err = errors.Wrap(err, "Failed to MultiSave")
+	}
+
+	CheckElapseAndWarn(start, "Slow rawTiKV operation multi save", zap.Any("kvs", kvs))
+	return err
+}
+
+// Remove removes the input key.
+func (kv *rawTiKV) Remove(key string) error {
+	start := time.Now()
+	key = path.Join(kv.rootPath, key)
+	ctx, cancel := context.WithTimeout(context.Background(), RequestTimeout)
+	defer cancel()
+
+	rs := timerecord.NewTimeRecorder("removeTiKVMeta")
+	err := kv.client.Delete(ctx, []byte(key))
+	elapsed := rs.ElapseSpan()
+	metrics.MetaOpCounter.WithLabelValues(metrics.MetaRemoveLabel, metrics.TotalLabel).Inc()
+
+	if err == nil {
+		metrics.MetaRequestLatency.WithLabelValues(metrics.MetaRemoveLabel).Observe(float64(elapsed.Milliseconds()))
+		metrics.MetaOpCounter.WithLabelValues(metrics.MetaRemoveLabel, metrics.SuccessLabel).Inc()
+	} else {
+		metrics.MetaOpCounter.WithLabelValues(metrics.MetaRemoveLabel, metrics.FailLabel).Inc()
+		err = errors.Wrap(err, fmt.Sprintf("Failed to Remove key %s", key))
+	}
+
+	CheckElapseAndWarn(start, "Slow rawTiKV operation remove", zap.String("key", key))
+	return err
+}
+
+// MultiRemove removes the input keys in transaction manner.
+func (kv *rawTiKV) MultiRemove(keys []string) error {
+	start := time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), RequestTimeout)
+	defer cancel()
+
+	err := kv.client.BatchDelete(ctx, toByteKeys(keys, kv.rootPath))
+	if err != nil {
+		log.Warn("rawTiKV MultiRemove error", zap.Strings("keys", keys), zap.Int("len", len(keys)), zap.Error(err))
+		return errors.Wrap(err, "Failed to MultiRemove keys")
+	}
+	CheckElapseAndWarn(start, "Slow rawTiKV operation multi remove", zap.Strings("keys", keys))
+	return nil
+}
+
+// RemoveWithPrefix removes the keys for the given prefix.
+func (kv *rawTiKV) RemoveWithPrefix(prefix string) error {
+	start := time.Now()
+	prefix = path.Join(kv.rootPath, prefix)
+	ctx, cancel := context.WithTimeout(context.Background(), RequestTimeout)
+	defer cancel()
+
+	// Retrieve key-value pairs with the specified prefix
+	startKey := []byte(prefix)
+	endKey := tikv.PrefixNextKey([]byte(prefix))
+	keys, _, err := kv.client.Scan(ctx, startKey, endKey, MaxScanLimit, rawkv.ScanKeyOnly())
+	if err != nil {
+		log.Warn("rawTiKV RemoveWithPrefix error", zap.String("prefix", prefix), zap.Error(err))
+		return errors.Wrap(err, fmt.Sprintf("Failed to RemoveWithPrefix %s", prefix))
+	}
+	err = kv.client.BatchDelete(ctx, keys)
+	if err != nil {
+		log.Warn("rawTiKV RemoveWithPrefix error", zap.String("prefix", prefix), zap.Error(err))
+		return errors.Wrap(err, fmt.Sprintf("Failed to BatchDelete for RemoveWithPrefix %s", prefix))
+	}
+	CheckElapseAndWarn(start, "Slow rawTiKV operation remove with prefix", zap.String("prefix", prefix))
+	return nil
+}
+
+// WalkWithPrefix visits each kv with input prefix and apply given fn to it.
+func (kv *rawTiKV) WalkWithPrefix(prefix string, paginationSize int, fn func([]byte, []byte) error) error {
+	start := time.Now()
+	prefix = path.Join(kv.rootPath, prefix)
+	ctx, cancel := context.WithTimeout(context.Background(), RequestTimeout)
+	defer cancel()
+
+	// Retrieve key-value pairs with the specified prefix
+	startKey := []byte(prefix)
+	endKey := tikv.PrefixNextKey([]byte(prefix))
+	keys, values, err := kv.client.Scan(ctx, startKey, endKey, MaxScanLimit)
+	if err != nil {
+		return errors.Wrap(err, "Failed to scan for WalkWithPagination")
+	}
+	for i, key := range keys {
+		if err = fn(key, values[i]); err != nil {
+			log.Warn("rawTiKV WalkWithPagination error", zap.String("prefix", prefix), zap.Error(err))
+			return errors.Wrap(err, fmt.Sprintf("Failed to apply fn to (%s, %s) for RemoveWithPrefix", string(key), string(values[i])))
+		}
+	}
+	CheckElapseAndWarn(start, "Slow rawTiKV operation(WalkWithPagination)", zap.String("prefix", prefix))
+	return nil
+}
+
+func (kv *rawTiKV) MultiSaveAndRemove(saves map[string]string, removals []string) error {
+	return fmt.Errorf("Unimplemented! MultiSaveAndRemove is not supported by rawTiKV.")
+}
+
+func (kv *rawTiKV) MultiRemoveWithPrefix(prefixes []string) error {
+	return fmt.Errorf("Unimplemented! MultiRemoveWithPrefix is not supported by rawTiKV.")
+}
+
+func (kv *rawTiKV) MultiSaveAndRemoveWithPrefix(saves map[string]string, removals []string) error {
+	return fmt.Errorf("Unimplemented! MultiSaveAndRemoveWithPrefix is not supported by rawTiKV.")
+}
+
+func (kv *rawTiKV) CompareVersionAndSwap(key string, version int64, target string) (bool, error) {
+	return false, fmt.Errorf("Unimplemented! CompareVersionAndSwap is under deprecation")
+}

--- a/internal/kv/tikv/raw_tikv_test.go
+++ b/internal/kv/tikv/raw_tikv_test.go
@@ -1,0 +1,372 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tikv
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/maps"
+)
+
+func TestRawTiKVLoad(te *testing.T) {
+	te.Run("kv SaveAndLoad", func(t *testing.T) {
+		rootPath := "/tikv/test/root/saveandload"
+		kv := NewRawTiKV(rawClient, rootPath)
+		err := kv.RemoveWithPrefix("")
+		require.NoError(t, err)
+
+		defer kv.Close()
+		defer kv.RemoveWithPrefix("")
+
+		saveAndLoadTests := []struct {
+			key   string
+			value string
+		}{
+			{"test1", "value1"},
+			{"test2", "value2"},
+			{"test1/a", "value_a"},
+			{"test1/b", "value_b"},
+		}
+
+		for i, test := range saveAndLoadTests {
+			if i < 4 {
+				err = kv.Save(test.key, test.value)
+				assert.NoError(t, err)
+			}
+
+			val, err := kv.Load(test.key)
+			assert.NoError(t, err)
+			assert.Equal(t, test.value, val)
+		}
+
+		invalidLoadTests := []struct {
+			invalidKey string
+		}{
+			{"t"},
+			{"a"},
+			{"test1a"},
+		}
+
+		for _, test := range invalidLoadTests {
+			val, err := kv.Load(test.invalidKey)
+			assert.Error(t, err)
+			assert.Zero(t, val)
+		}
+
+		loadPrefixTests := []struct {
+			prefix string
+
+			expectedKeys   []string
+			expectedValues []string
+			expectedError  error
+		}{
+			{"test", []string{
+				kv.GetPath("test1"),
+				kv.GetPath("test2"),
+				kv.GetPath("test1/a"),
+				kv.GetPath("test1/b")}, []string{"value1", "value2", "value_a", "value_b"}, nil},
+			{"test1", []string{
+				kv.GetPath("test1"),
+				kv.GetPath("test1/a"),
+				kv.GetPath("test1/b")}, []string{"value1", "value_a", "value_b"}, nil},
+			{"test2", []string{kv.GetPath("test2")}, []string{"value2"}, nil},
+			{"", []string{
+				kv.GetPath("test1"),
+				kv.GetPath("test2"),
+				kv.GetPath("test1/a"),
+				kv.GetPath("test1/b")}, []string{"value1", "value2", "value_a", "value_b"}, nil},
+			{"test1/a", []string{kv.GetPath("test1/a")}, []string{"value_a"}, nil},
+			{"a", []string{}, []string{}, nil},
+			{"root", []string{}, []string{}, nil},
+			{"/tikv/test/root", []string{}, []string{}, nil},
+		}
+
+		for _, test := range loadPrefixTests {
+			actualKeys, actualValues, err := kv.LoadWithPrefix(test.prefix)
+			assert.ElementsMatch(t, test.expectedKeys, actualKeys)
+			assert.ElementsMatch(t, test.expectedValues, actualValues)
+			assert.Equal(t, test.expectedError, err)
+		}
+
+		removeTests := []struct {
+			validKey   string
+			invalidKey string
+		}{
+			{"test1", "abc"},
+			{"test1/a", "test1/lskfjal"},
+			{"test1/b", "test1/b"},
+			{"test2", "-"},
+		}
+
+		for _, test := range removeTests {
+			err = kv.Remove(test.validKey)
+			assert.NoError(t, err)
+
+			_, err = kv.Load(test.validKey)
+			assert.Error(t, err)
+
+			err = kv.Remove(test.validKey)
+			assert.NoError(t, err)
+			err = kv.Remove(test.invalidKey)
+			assert.NoError(t, err)
+		}
+	})
+
+	te.Run("kv MultiSaveAndMultiLoad", func(t *testing.T) {
+		rootPath := "/tikv/test/root/multi_save_and_multi_load"
+		kv := NewRawTiKV(rawClient, rootPath)
+
+		defer kv.Close()
+		defer kv.RemoveWithPrefix("")
+
+		multiSaveTests := map[string]string{
+			"key_1":      "value_1",
+			"key_2":      "value_2",
+			"key_3/a":    "value_3a",
+			"multikey_1": "multivalue_1",
+			"multikey_2": "multivalue_2",
+			"_":          "other",
+		}
+
+		err := kv.MultiSave(multiSaveTests)
+		assert.NoError(t, err)
+		for k, v := range multiSaveTests {
+			actualV, err := kv.Load(k)
+			assert.NoError(t, err)
+			assert.Equal(t, v, actualV)
+		}
+
+		multiLoadTests := []struct {
+			inputKeys      []string
+			expectedValues []string
+		}{
+			{[]string{"key_1"}, []string{"value_1"}},
+			{[]string{"key_1", "key_2", "key_3/a"}, []string{"value_1", "value_2", "value_3a"}},
+			{[]string{"multikey_1", "multikey_2"}, []string{"multivalue_1", "multivalue_2"}},
+			{[]string{"_"}, []string{"other"}},
+		}
+
+		for _, test := range multiLoadTests {
+			vs, err := kv.MultiLoad(test.inputKeys)
+			assert.NoError(t, err)
+			assert.Equal(t, test.expectedValues, vs)
+		}
+
+		invalidMultiLoad := []struct {
+			invalidKeys    []string
+			expectedValues []string
+		}{
+			{[]string{"a", "key_1"}, []string{"", "value_1"}},
+			{[]string{".....", "key_1"}, []string{"", "value_1"}},
+			{[]string{"*********"}, []string{""}},
+			{[]string{"key_1", "1"}, []string{"value_1", ""}},
+		}
+
+		for _, test := range invalidMultiLoad {
+			vs, _ := kv.MultiLoad(test.invalidKeys)
+			assert.Equal(t, test.expectedValues, vs)
+		}
+
+		removeWithPrefixTests := []string{
+			"key_1",
+			"multi",
+		}
+
+		for _, k := range removeWithPrefixTests {
+			err = kv.RemoveWithPrefix(k)
+			assert.NoError(t, err)
+
+			ks, vs, err := kv.LoadWithPrefix(k)
+			assert.Empty(t, ks)
+			assert.Empty(t, vs)
+			assert.NoError(t, err)
+		}
+
+		multiRemoveTests := []string{
+			"key_2",
+			"key_3/a",
+			"multikey_2",
+			"_",
+		}
+
+		err = kv.MultiRemove(multiRemoveTests)
+		assert.NoError(t, err)
+
+		ks, vs, err := kv.LoadWithPrefix("")
+		assert.NoError(t, err)
+		assert.Empty(t, ks)
+		assert.Empty(t, vs)
+	})
+}
+
+func TestRawWalkWithPagination(t *testing.T) {
+	rootPath := "/tikv/test/root/pagination"
+	kv := NewRawTiKV(rawClient, rootPath)
+
+	defer kv.Close()
+	defer kv.RemoveWithPrefix("")
+
+	kvs := map[string]string{
+		"A/100":    "v1",
+		"AA/100":   "v2",
+		"AB/100":   "v3",
+		"AB/2/100": "v4",
+		"B/100":    "v5",
+	}
+
+	err := kv.MultiSave(kvs)
+	assert.NoError(t, err)
+	for k, v := range kvs {
+		actualV, err := kv.Load(k)
+		assert.NoError(t, err)
+		assert.Equal(t, v, actualV)
+	}
+
+	t.Run("apply function error ", func(t *testing.T) {
+		err = kv.WalkWithPrefix("A", 5, func(key []byte, value []byte) error {
+			return errors.New("error")
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("get with non-exist prefix ", func(t *testing.T) {
+		err = kv.WalkWithPrefix("non-exist-prefix", 5, func(key []byte, value []byte) error {
+			return nil
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("with different pagination", func(t *testing.T) {
+		testFn := func(pagination int) {
+			expected := map[string]string{
+				"A/100":    "v1",
+				"AA/100":   "v2",
+				"AB/100":   "v3",
+				"AB/2/100": "v4",
+			}
+
+			expectedKeys := maps.Keys(expected)
+			sort.Strings(expectedKeys)
+
+			ret := make(map[string]string)
+			actualKeys := make([]string, 0)
+
+			err = kv.WalkWithPrefix("A", pagination, func(key []byte, value []byte) error {
+				k := string(key)
+				k = k[len(rootPath)+1:]
+				ret[k] = string(value)
+				actualKeys = append(actualKeys, k)
+				return nil
+			})
+
+			assert.NoError(t, err)
+			assert.Equal(t, expected, ret, fmt.Errorf("pagination: %d", pagination))
+			// Ignore the order.
+			assert.ElementsMatch(t, expectedKeys, actualKeys, fmt.Errorf("pagination: %d", pagination))
+		}
+
+		for p := -1; p < 6; p++ {
+			testFn(p)
+		}
+		testFn(-100)
+		testFn(100)
+	})
+}
+
+func TestRawTiKVHas(t *testing.T) {
+	rootPath := "/tikv/test/root/pagination"
+	kv := NewRawTiKV(rawClient, rootPath)
+	err := kv.RemoveWithPrefix("")
+	require.NoError(t, err)
+
+	defer kv.Close()
+	defer kv.RemoveWithPrefix("")
+
+	has, err := kv.Has("key1")
+	assert.NoError(t, err)
+	assert.False(t, has)
+
+	err = kv.Save("key1", "value1")
+	assert.NoError(t, err)
+
+	has, err = kv.Has("key1")
+	assert.NoError(t, err)
+	assert.True(t, has)
+
+	err = kv.Remove("key1")
+	assert.NoError(t, err)
+
+	has, err = kv.Has("key1")
+	assert.NoError(t, err)
+	assert.False(t, has)
+}
+
+func TestRawTiKVHasPrefix(t *testing.T) {
+	rootPath := "/etcd/test/root/hasprefix"
+	kv := NewRawTiKV(rawClient, rootPath)
+	err := kv.RemoveWithPrefix("")
+	require.NoError(t, err)
+
+	defer kv.Close()
+	defer kv.RemoveWithPrefix("")
+
+	has, err := kv.HasPrefix("key")
+	assert.NoError(t, err)
+	assert.False(t, has)
+
+	err = kv.Save("key1", "value1")
+	assert.NoError(t, err)
+
+	has, err = kv.HasPrefix("key")
+	assert.NoError(t, err)
+	assert.True(t, has)
+
+	err = kv.Remove("key1")
+	assert.NoError(t, err)
+
+	has, err = kv.HasPrefix("key")
+	assert.NoError(t, err)
+	assert.False(t, has)
+}
+
+func TestRawTiKVUnimplemented(t *testing.T) {
+	kv := NewRawTiKV(rawClient, "/")
+	err := kv.RemoveWithPrefix("")
+	require.NoError(t, err)
+
+	defer kv.Close()
+	defer kv.RemoveWithPrefix("")
+
+	var kvs map[string]string
+	var vals []string
+	err = kv.MultiSaveAndRemove(kvs, vals)
+	assert.Error(t, err)
+
+	err = kv.MultiRemoveWithPrefix(vals)
+	assert.Error(t, err)
+
+	err = kv.MultiSaveAndRemoveWithPrefix(kvs, vals)
+	assert.Error(t, err)
+
+	_, err = kv.CompareVersionAndSwap("k", 1, "target")
+	assert.Error(t, err)
+}

--- a/internal/kv/tikv/txn_tikv.go
+++ b/internal/kv/tikv/txn_tikv.go
@@ -1,0 +1,700 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tikv
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	tikv "github.com/tikv/client-go/v2/kv"
+	"github.com/tikv/client-go/v2/txnkv"
+	"github.com/tikv/client-go/v2/txnkv/transaction"
+	"go.uber.org/zap"
+
+	"github.com/milvus-io/milvus/internal/kv"
+	"github.com/milvus-io/milvus/pkg/common"
+	"github.com/milvus-io/milvus/pkg/log"
+	"github.com/milvus-io/milvus/pkg/metrics"
+	"github.com/milvus-io/milvus/pkg/util/timerecord"
+)
+
+const (
+	// RequestTimeout is the default timeout for tikv request.
+	RequestTimeout = 10 * time.Second
+)
+
+func tiTxnBegin(txn *txnkv.Client) (*transaction.KVTxn, error) {
+	return txn.Begin()
+}
+
+func tiTxnCommit(txn *transaction.KVTxn, ctx context.Context) error {
+	return txn.Commit(ctx)
+}
+
+var beginTxn = tiTxnBegin
+var commitTxn = tiTxnCommit
+
+// implementation assertion
+var _ kv.MetaKv = (*txnTiKV)(nil)
+
+// txnTiKV implements MetaKv and TxnKV interface. It supports processing multiple kvs within one transaction.
+type txnTiKV struct {
+	txn      *txnkv.Client
+	rootPath string
+}
+
+// NewTiKV creates a new txnTiKV client.
+func NewTiKV(txn *txnkv.Client, rootPath string) *txnTiKV {
+	kv := &txnTiKV{
+		txn:      txn,
+		rootPath: rootPath,
+	}
+	return kv
+}
+
+// Close closes the connection to TiKV.
+func (kv *txnTiKV) Close() {
+	log.Debug("txnTiKV closed", zap.String("path", kv.rootPath))
+}
+
+// GetPath returns the path of the key/prefix.
+func (kv *txnTiKV) GetPath(key string) string {
+	return path.Join(kv.rootPath, key)
+}
+
+func logWarnOnFailure(err error, msg string, fields ...zap.Field) {
+	if err != nil {
+		log.Warn(msg, fields...)
+	}
+}
+
+// Has returns if a key exists.
+func (kv *txnTiKV) Has(key string) (bool, error) {
+	start := time.Now()
+	key = path.Join(kv.rootPath, key)
+	ctx, cancel := context.WithTimeout(context.Background(), RequestTimeout)
+	defer cancel()
+	_, err := kv.getTiKVMeta(ctx, key)
+	if err != nil {
+		if strings.HasPrefix(err.Error(), "Failed to get value for key") {
+			return false, nil
+		} else {
+			return false, errors.Wrap(err, fmt.Sprintf("Failed to create txn for Has of key %s", key))
+		}
+	}
+	CheckElapseAndWarn(start, "Slow tikv operation Has()", zap.String("key", key))
+	return true, nil
+}
+
+func rollbackOnFailure(err error, txn *transaction.KVTxn) {
+	if err != nil {
+		txn.Rollback()
+	}
+}
+
+// HasPrefix returns if a key prefix exists.
+func (kv *txnTiKV) HasPrefix(prefix string) (bool, error) {
+	start := time.Now()
+	prefix = path.Join(kv.rootPath, prefix)
+	ctx, cancel := context.WithTimeout(context.Background(), RequestTimeout)
+	defer cancel()
+
+	var err error
+	defer logWarnOnFailure(err, "txnTiKV HasPrefix error", zap.String("prefix", prefix), zap.Error(err))
+
+	var txn *transaction.KVTxn
+	txn, err = beginTxn(kv.txn)
+	if err != nil {
+		return false, errors.Wrap(err, fmt.Sprintf("Failed to create txn for HasPrefix of prefix %s", prefix))
+	}
+
+	// Defer a rollback only if the transaction hasn't been committed
+	defer rollbackOnFailure(err, txn)
+
+	// Retrieve key-value pairs with the specified prefix
+	startKey := []byte(prefix)
+	endKey := tikv.PrefixNextKey([]byte(prefix))
+	iter, err := txn.Iter(startKey, endKey)
+	if err != nil {
+		return false, errors.Wrap(err, fmt.Sprintf("Failed to iterate for HasPrefix of prefix %s", prefix))
+	}
+	defer iter.Close()
+
+	r := false
+	// Iterater only needs to check the first key-value pair
+	if iter.Valid() {
+		r = true
+	}
+	if err = kv.executeTxn(txn, ctx); err != nil {
+		return false, errors.Wrap(err, fmt.Sprintf("Failed to commit txn for HasPrefix of prefix %s", prefix))
+	}
+	CheckElapseAndWarn(start, "Slow load with HasPrefix", zap.String("prefix", prefix))
+	return r, nil
+}
+
+// Load returns value of the key.
+func (kv *txnTiKV) Load(key string) (string, error) {
+	start := time.Now()
+	key = path.Join(kv.rootPath, key)
+	ctx, cancel := context.WithTimeout(context.Background(), RequestTimeout)
+	defer cancel()
+
+	var err error
+	defer logWarnOnFailure(err, "txnTiKV Load error", zap.String("key", key), zap.Error(err))
+
+	var val string
+	val, err = kv.getTiKVMeta(ctx, key)
+	if len(val) == 0 {
+		return "", common.NewKeyNotExistError(key)
+	}
+	if err != nil {
+		return "", errors.Wrap(err, fmt.Sprintf("Failed to read key %s", key))
+	}
+	CheckElapseAndWarn(start, "Slow tikv operation load", zap.String("key", key))
+	return val, nil
+}
+
+// MultiLoad gets the values of input keys in a transaction.
+func (kv *txnTiKV) MultiLoad(keys []string) ([]string, error) {
+	start := time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), RequestTimeout)
+	defer cancel()
+
+	var err error
+	defer logWarnOnFailure(err, "txnTiKV MultiLoad error", zap.Strings("keys", keys), zap.Error(err))
+
+	txn, err := beginTxn(kv.txn)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to build transaction for MultiLoad")
+	}
+
+	// Defer a rollback only if the transaction hasn't been committed
+	defer rollbackOnFailure(err, txn)
+
+	var values []string
+	invalid := make([]string, 0, len(keys))
+	for _, key := range keys {
+		key = path.Join(kv.rootPath, key)
+		value, err := txn.Get(ctx, []byte(key))
+		if err != nil {
+			invalid = append(invalid, key)
+		}
+		values = append(values, string(value))
+	}
+	err = kv.executeTxn(txn, ctx)
+
+	if len(invalid) != 0 {
+		err = fmt.Errorf("there are invalid keys: %s", invalid)
+	}
+	CheckElapseAndWarn(start, "Slow tikv operation multi load", zap.Any("keys", keys))
+	return values, err
+}
+
+// LoadWithPrefix returns all the keys and values for the given key prefix.
+func (kv *txnTiKV) LoadWithPrefix(prefix string) ([]string, []string, error) {
+	start := time.Now()
+	prefix = path.Join(kv.rootPath, prefix)
+	ctx, cancel := context.WithTimeout(context.Background(), RequestTimeout)
+	defer cancel()
+
+	var err error
+	defer logWarnOnFailure(err, "txnTiKV LoadWithPrefix error", zap.String("prefix", prefix), zap.Error(err))
+
+	txn, err := beginTxn(kv.txn)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, fmt.Sprintf("Failed to create txn for LoadWithPrefix %s", prefix))
+	}
+
+	// Defer a rollback only if the transaction hasn't been committed
+	defer rollbackOnFailure(err, txn)
+
+	// Retrieve key-value pairs with the specified prefix
+	startKey := []byte(prefix)
+	endKey := tikv.PrefixNextKey([]byte(prefix))
+	iter, err := txn.Iter(startKey, endKey)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, fmt.Sprintf("Failed to create iterater for LoadWithPrefix %s", prefix))
+	}
+	defer iter.Close()
+
+	var keys []string
+	var values []string
+	// Iterate over the key-value pairs
+	for iter.Valid() {
+		keys = append(keys, string(iter.Key()))
+		values = append(values, string(iter.Value()))
+		err = iter.Next()
+		if err != nil {
+			return nil, nil, errors.Wrap(err, fmt.Sprintf("Failed to iterate for LoadWithPrefix %s", prefix))
+		}
+	}
+	err = kv.executeTxn(txn, ctx)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, fmt.Sprintf("Failed to commit txn for LoadWithPrefix %s", prefix))
+	}
+	CheckElapseAndWarn(start, "Slow LoadWithPrefix", zap.String("prefix", prefix))
+	return keys, values, nil
+}
+
+// Save saves the input key-value pair.
+func (kv *txnTiKV) Save(key, value string) error {
+	key = path.Join(kv.rootPath, key)
+	ctx, cancel := context.WithTimeout(context.Background(), RequestTimeout)
+	defer cancel()
+
+	var err error
+	defer logWarnOnFailure(err, "txnTiKV Save error", zap.String("key", key), zap.String("value", value), zap.Error(err))
+
+	err = kv.putTiKVMeta(ctx, key, value)
+	return err
+}
+
+// MultiSave saves the input key-value pairs in transaction manner.
+func (kv *txnTiKV) MultiSave(kvs map[string]string) error {
+	start := time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), RequestTimeout)
+	defer cancel()
+
+	var err error
+	defer logWarnOnFailure(err, "txnTiKV MultiSave error", zap.Any("kvs", kvs), zap.Int("len", len(kvs)), zap.Error(err))
+
+	txn, err := beginTxn(kv.txn)
+	if err != nil {
+		return errors.Wrap(err, "Failed to create txn for MultiSave")
+	}
+
+	// Defer a rollback only if the transaction hasn't been committed
+	defer rollbackOnFailure(err, txn)
+
+	for key, value := range kvs {
+		key = path.Join(kv.rootPath, key)
+		err = txn.Set([]byte(key), []byte(value))
+		if err != nil {
+			return errors.Wrap(err, fmt.Sprintf("Failed to set (%s:%s) for MultiSave", key, value))
+		}
+	}
+
+	err = kv.executeTxn(txn, ctx)
+	if err != nil {
+		return errors.Wrap(err, "Failed to commit for MultiSave")
+	}
+
+	CheckElapseAndWarn(start, "Slow tikv operation MultiSave", zap.Any("kvs", kvs))
+	return nil
+}
+
+// Remove removes the input key.
+func (kv *txnTiKV) Remove(key string) error {
+	key = path.Join(kv.rootPath, key)
+	ctx, cancel := context.WithTimeout(context.Background(), RequestTimeout)
+	defer cancel()
+
+	var err error
+	defer logWarnOnFailure(err, "txnTiKV Remove error", zap.String("key", key), zap.Error(err))
+
+	err = kv.removeTiKVMeta(ctx, key)
+	return err
+}
+
+// MultiRemove removes the input keys in transaction manner.
+func (kv *txnTiKV) MultiRemove(keys []string) error {
+	start := time.Now()
+
+	ctx, cancel := context.WithTimeout(context.Background(), RequestTimeout)
+	defer cancel()
+
+	var err error
+	defer logWarnOnFailure(err, "txnTiKV MultiRemove error", zap.Strings("keys", keys), zap.Int("len", len(keys)), zap.Error(err))
+
+	txn, err := beginTxn(kv.txn)
+	if err != nil {
+		return errors.Wrap(err, "Failed to create txn for MultiRemove")
+	}
+
+	// Defer a rollback only if the transaction hasn't been committed
+	defer rollbackOnFailure(err, txn)
+
+	for _, key := range keys {
+		key = path.Join(kv.rootPath, key)
+		err = txn.Delete([]byte(key))
+		if err != nil {
+			return errors.Wrap(err, fmt.Sprintf("Failed to delete %s for MultiRemove", key))
+		}
+	}
+
+	err = kv.executeTxn(txn, ctx)
+	if err != nil {
+		return errors.Wrap(err, "Failed to commit for MultiRemove")
+	}
+	CheckElapseAndWarn(start, "Slow tikv operation MultiRemove", zap.Strings("keys", keys))
+	return nil
+}
+
+// RemoveWithPrefix removes the keys for the given prefix.
+func (kv *txnTiKV) RemoveWithPrefix(prefix string) error {
+	start := time.Now()
+	prefix = path.Join(kv.rootPath, prefix)
+	ctx, cancel := context.WithTimeout(context.Background(), RequestTimeout)
+	defer cancel()
+
+	var err error
+	defer logWarnOnFailure(err, "txnTiKV RemoveWithPrefix error", zap.String("prefix", prefix), zap.Error(err))
+
+	startKey := []byte(prefix)
+	endKey := tikv.PrefixNextKey(startKey)
+	_, err = kv.txn.DeleteRange(ctx, startKey, endKey, 1)
+	if err != nil {
+		return errors.Wrap(err, "Failed to DeleteRange for RemoveWithPrefix")
+	}
+	CheckElapseAndWarn(start, "Slow tikv operation remove with prefix", zap.String("prefix", prefix))
+	return nil
+}
+
+// MultiSaveAndRemove saves the key-value pairs and removes the keys in a transaction.
+func (kv *txnTiKV) MultiSaveAndRemove(saves map[string]string, removals []string) error {
+	start := time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), RequestTimeout)
+	defer cancel()
+
+	var err error
+	defer logWarnOnFailure(err, "txnTiKV MultiSaveAndRemove error", zap.Any("saves", saves), zap.Strings("removes", removals), zap.Int("saveLength", len(saves)), zap.Int("removeLength", len(removals)), zap.Error(err))
+
+	txn, err := beginTxn(kv.txn)
+	if err != nil {
+		return errors.Wrap(err, "Failed to create txn for MultiSaveAndRemove")
+	}
+
+	// Defer a rollback only if the transaction hasn't been committed
+	defer rollbackOnFailure(err, txn)
+
+	for key, value := range saves {
+		key = path.Join(kv.rootPath, key)
+		if err = txn.Set([]byte(key), []byte(value)); err != nil {
+			return errors.Wrap(err, fmt.Sprintf("Failed to set (%s:%s) for MultiSaveAndRemove", key, value))
+		}
+	}
+
+	for _, key := range removals {
+		key = path.Join(kv.rootPath, key)
+		if err = txn.Delete([]byte(key)); err != nil {
+			return errors.Wrap(err, fmt.Sprintf("Failed to delete %s for MultiSaveAndRemove", key))
+		}
+	}
+
+	err = kv.executeTxn(txn, ctx)
+	if err != nil {
+		return errors.Wrap(err, "Failed to commit for MultiSaveAndRemove")
+	}
+	CheckElapseAndWarn(start, "Slow tikv operation multi save and remove", zap.Any("saves", saves), zap.Strings("removals", removals))
+	return nil
+}
+
+// MultiRemoveWithPrefix removes the keys with given prefix.
+func (kv *txnTiKV) MultiRemoveWithPrefix(prefixes []string) error {
+	start := time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), RequestTimeout)
+	defer cancel()
+
+	var err error
+	defer logWarnOnFailure(err, "txnTiKV MultiRemoveWithPrefix error", zap.Strings("keys", prefixes), zap.Int("len", len(prefixes)), zap.Error(err))
+
+	txn, err := beginTxn(kv.txn)
+	if err != nil {
+		return errors.Wrap(err, "Failed to create txn for MultiRemoveWithPrefix")
+	}
+
+	// Defer a rollback only if the transaction hasn't been committed
+	defer rollbackOnFailure(err, txn)
+
+	for _, prefix := range prefixes {
+		prefix = path.Join(kv.rootPath, prefix)
+		// Get the start and end keys for the prefix range
+		startKey := []byte(prefix)
+		endKey := tikv.PrefixNextKey([]byte(prefix))
+
+		// Use Scan to iterate over keys in the prefix range
+		iter, err := txn.Iter(startKey, endKey)
+		if err != nil {
+			return errors.Wrap(err, "Failed to create iterater for MultiRemoveWithPrefix")
+		}
+
+		// Iterate over keys and delete them
+		for iter.Valid() {
+			key := iter.Key()
+			err = txn.Delete(key)
+			if err != nil {
+				return errors.Wrap(err, fmt.Sprintf("Failed to delete %s for MultiRemoveWithPrefix", string(key)))
+			}
+
+			// Move the iterator to the next key
+			err = iter.Next()
+			if err != nil {
+				return errors.Wrap(err, fmt.Sprintf("Failed to move Iterator after key %s for MultiRemoveWithPrefix", string(key)))
+			}
+		}
+	}
+
+	err = kv.executeTxn(txn, ctx)
+	if err != nil {
+		return errors.Wrap(err, "Failed to commit for MultiRemoveWithPrefix")
+	}
+	CheckElapseAndWarn(start, "Slow tikv operation multi remove with prefix", zap.Strings("keys", prefixes))
+	return nil
+}
+
+// MultiSaveAndRemoveWithPrefix saves kv in @saves and removes the keys with given prefix in @removals.
+func (kv *txnTiKV) MultiSaveAndRemoveWithPrefix(saves map[string]string, removals []string) error {
+	start := time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), RequestTimeout)
+	defer cancel()
+
+	var err error
+	defer logWarnOnFailure(err, "txnTiKV MultiSaveAndRemoveWithPrefix error", zap.Any("saves", saves), zap.Strings("removes", removals), zap.Int("saveLength", len(saves)), zap.Int("removeLength", len(removals)), zap.Error(err))
+
+	txn, err := beginTxn(kv.txn)
+	if err != nil {
+		return errors.Wrap(err, "Failed to create txn for MultiSaveAndRemoveWithPrefix")
+	}
+
+	// Defer a rollback only if the transaction hasn't been committed
+	defer rollbackOnFailure(err, txn)
+
+	// Save key-value pairs
+	for key, value := range saves {
+		key = path.Join(kv.rootPath, key)
+		err = txn.Set([]byte(key), []byte(value))
+		if err != nil {
+			return errors.Wrap(err, fmt.Sprintf("Failed to set (%s:%s) for MultiSaveAndRemoveWithPrefix", key, value))
+		}
+	}
+
+	// Remove keys with prefix
+	for _, prefix := range removals {
+		prefix = path.Join(kv.rootPath, prefix)
+		// Get the start and end keys for the prefix range
+		startKey := []byte(prefix)
+		endKey := tikv.PrefixNextKey([]byte(prefix))
+
+		// Use Scan to iterate over keys in the prefix range
+		iter, err := txn.Iter(startKey, endKey)
+		if err != nil {
+			return errors.Wrap(err, fmt.Sprintf("Failed to create iterater for %s during MultiSaveAndRemoveWithPrefix", prefix))
+		}
+
+		// Iterate over keys and delete them
+		for iter.Valid() {
+			key := iter.Key()
+			err = txn.Delete(key)
+			if err != nil {
+				return errors.Wrap(err, fmt.Sprintf("Failed to delete %s for MultiSaveAndRemoveWithPrefix", string(key)))
+			}
+
+			// Move the iterator to the next key
+			err = iter.Next()
+			if err != nil {
+				return errors.Wrap(err, fmt.Sprintf("Failed to move Iterator after key %s for MultiSaveAndRemoveWithPrefix", string(key)))
+			}
+		}
+	}
+
+	err = kv.executeTxn(txn, ctx)
+	if err != nil {
+		return errors.Wrap(err, "Failed to commit for MultiSaveAndRemoveWithPrefix")
+	}
+	CheckElapseAndWarn(start, "Slow tikv operation multi save and move with prefix", zap.Any("saves", saves), zap.Strings("removals", removals))
+	return nil
+}
+
+// WalkWithPrefix visits each kv with input prefix and apply given fn to it.
+func (kv *txnTiKV) WalkWithPrefix(prefix string, paginationSize int, fn func([]byte, []byte) error) error {
+	start := time.Now()
+	prefix = path.Join(kv.rootPath, prefix)
+	ctx, cancel := context.WithTimeout(context.Background(), RequestTimeout)
+	defer cancel()
+
+	var err error
+	defer logWarnOnFailure(err, "txnTiKV WalkWithPagination error", zap.String("prefix", prefix), zap.Error(err))
+
+	txn, err := beginTxn(kv.txn)
+	if err != nil {
+		return errors.Wrap(err, "Failed to create txn for WalkWithPrefix")
+	}
+
+	// Defer a rollback only if the transaction hasn't been committed
+	defer rollbackOnFailure(err, txn)
+
+	// Retrieve key-value pairs with the specified prefix
+	startKey := []byte(prefix)
+	endKey := tikv.PrefixNextKey([]byte(prefix))
+	iter, err := txn.Iter(startKey, endKey)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("Failed to create iterater for %s during WalkWithPrefix", prefix))
+	}
+	defer iter.Close()
+
+	// Iterate over the key-value pairs
+	for iter.Valid() {
+		err = fn(iter.Key(), iter.Value())
+		if err != nil {
+			return errors.Wrap(err, fmt.Sprintf("Failed to apply fn to (%s;%s)", string(iter.Key()), string(iter.Value())))
+		}
+		err = iter.Next()
+		if err != nil {
+			return errors.Wrap(err, fmt.Sprintf("Failed to move Iterator after key %s for WalkWithPrefix", string(iter.Key())))
+		}
+	}
+	err = kv.executeTxn(txn, ctx)
+	if err != nil {
+		return errors.Wrap(err, "Failed to commit for WalkWithPagination")
+	}
+
+	CheckElapseAndWarn(start, "Slow tikv operation(WalkWithPagination)", zap.String("prefix", prefix))
+	return nil
+}
+
+// CheckElapseAndWarn checks the elapsed time and warns if it is too long.
+func CheckElapseAndWarn(start time.Time, message string, fields ...zap.Field) bool {
+	elapsed := time.Since(start)
+	if elapsed.Milliseconds() > 2000 {
+		log.Warn(message, append([]zap.Field{zap.String("time spent", elapsed.String())}, fields...)...)
+		return true
+	}
+	return false
+}
+
+func (kv *txnTiKV) executeTxn(txn *transaction.KVTxn, ctx context.Context) error {
+	start := timerecord.NewTimeRecorder("executeTxn")
+
+	elapsed := start.ElapseSpan()
+	metrics.MetaOpCounter.WithLabelValues(metrics.MetaTxnLabel, metrics.TotalLabel).Inc()
+	err := commitTxn(txn, ctx)
+	if err == nil {
+		metrics.MetaRequestLatency.WithLabelValues(metrics.MetaTxnLabel).Observe(float64(elapsed.Milliseconds()))
+		metrics.MetaOpCounter.WithLabelValues(metrics.MetaTxnLabel, metrics.SuccessLabel).Inc()
+	} else {
+		metrics.MetaOpCounter.WithLabelValues(metrics.MetaTxnLabel, metrics.FailLabel).Inc()
+	}
+
+	return err
+}
+
+func (kv *txnTiKV) getTiKVMeta(ctx context.Context, key string) (string, error) {
+	ctx1, cancel := context.WithTimeout(ctx, RequestTimeout)
+	defer cancel()
+
+	start := timerecord.NewTimeRecorder("getTiKVMeta")
+
+	txn, err := beginTxn(kv.txn)
+	if err != nil {
+		return "", errors.Wrap(err, "Failed to build transaction for getTiKVMeta")
+	}
+	// Defer a rollback only if the transaction hasn't been committed
+	defer rollbackOnFailure(err, txn)
+
+	val, err := txn.Get(ctx1, []byte(key))
+	if err != nil {
+		return "", errors.Wrap(err, fmt.Sprintf("Failed to get value for key %s in getTiKVMeta", key))
+	}
+	err = commitTxn(txn, ctx1)
+
+	elapsed := start.ElapseSpan()
+	metrics.MetaOpCounter.WithLabelValues(metrics.MetaGetLabel, metrics.TotalLabel).Inc()
+
+	// cal meta kv size
+	if err == nil {
+		totalSize := binary.Size(val)
+		metrics.MetaKvSize.WithLabelValues(metrics.MetaGetLabel).Observe(float64(totalSize))
+		metrics.MetaRequestLatency.WithLabelValues(metrics.MetaGetLabel).Observe(float64(elapsed.Milliseconds()))
+		metrics.MetaOpCounter.WithLabelValues(metrics.MetaGetLabel, metrics.SuccessLabel).Inc()
+	} else {
+		metrics.MetaOpCounter.WithLabelValues(metrics.MetaGetLabel, metrics.FailLabel).Inc()
+	}
+	return string(val), err
+}
+
+func (kv *txnTiKV) putTiKVMeta(ctx context.Context, key, val string) error {
+	ctx1, cancel := context.WithTimeout(ctx, RequestTimeout)
+	defer cancel()
+
+	start := timerecord.NewTimeRecorder("putTiKVMeta")
+
+	txn, err := beginTxn(kv.txn)
+	if err != nil {
+		return errors.Wrap(err, "Failed to build transaction for putTiKVMeta")
+	}
+	// Defer a rollback only if the transaction hasn't been committed
+	defer rollbackOnFailure(err, txn)
+
+	err = txn.Set([]byte(key), []byte(val))
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("Failed to get value for key %s in putTiKVMeta", key))
+	}
+	err = commitTxn(txn, ctx1)
+
+	elapsed := start.ElapseSpan()
+	metrics.MetaOpCounter.WithLabelValues(metrics.MetaPutLabel, metrics.TotalLabel).Inc()
+	if err == nil {
+		metrics.MetaKvSize.WithLabelValues(metrics.MetaPutLabel).Observe(float64(len(val)))
+		metrics.MetaRequestLatency.WithLabelValues(metrics.MetaPutLabel).Observe(float64(elapsed.Milliseconds()))
+		metrics.MetaOpCounter.WithLabelValues(metrics.MetaPutLabel, metrics.SuccessLabel).Inc()
+	} else {
+		metrics.MetaOpCounter.WithLabelValues(metrics.MetaPutLabel, metrics.FailLabel).Inc()
+	}
+
+	return err
+}
+
+func (kv *txnTiKV) removeTiKVMeta(ctx context.Context, key string) error {
+	ctx1, cancel := context.WithTimeout(ctx, RequestTimeout)
+	defer cancel()
+
+	start := timerecord.NewTimeRecorder("removeTiKVMeta")
+
+	txn, err := beginTxn(kv.txn)
+	if err != nil {
+		return errors.Wrap(err, "Failed to build transaction for putTiKVMeta")
+	}
+	// Defer a rollback only if the transaction hasn't been committed
+	defer rollbackOnFailure(err, txn)
+
+	err = txn.Delete([]byte(key))
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("Failed to get value for key %s in putTiKVMeta", key))
+	}
+	err = commitTxn(txn, ctx1)
+
+	elapsed := start.ElapseSpan()
+	metrics.MetaOpCounter.WithLabelValues(metrics.MetaRemoveLabel, metrics.TotalLabel).Inc()
+
+	if err == nil {
+		metrics.MetaRequestLatency.WithLabelValues(metrics.MetaRemoveLabel).Observe(float64(elapsed.Milliseconds()))
+		metrics.MetaOpCounter.WithLabelValues(metrics.MetaRemoveLabel, metrics.SuccessLabel).Inc()
+	} else {
+		metrics.MetaOpCounter.WithLabelValues(metrics.MetaRemoveLabel, metrics.FailLabel).Inc()
+	}
+
+	return err
+}
+
+func (kv *txnTiKV) CompareVersionAndSwap(key string, version int64, target string) (bool, error) {
+	return false, fmt.Errorf("Unimplemented! CompareVersionAndSwap is under deprecation")
+}

--- a/internal/kv/tikv/txn_tikv_test.go
+++ b/internal/kv/tikv/txn_tikv_test.go
@@ -1,0 +1,560 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tikv
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tikv/client-go/v2/txnkv"
+	"github.com/tikv/client-go/v2/txnkv/transaction"
+	"golang.org/x/exp/maps"
+)
+
+func TestTiKVLoad(te *testing.T) {
+	te.Run("kv SaveAndLoad", func(t *testing.T) {
+		rootPath := "/tikv/test/root/saveandload"
+		kv := NewTiKV(txnClient, rootPath)
+		err := kv.RemoveWithPrefix("")
+		require.NoError(t, err)
+
+		defer kv.Close()
+		defer kv.RemoveWithPrefix("")
+
+		// Disallow empty value
+		err = kv.Save("keyh2", "")
+		assert.Error(t, err)
+
+		saveAndLoadTests := []struct {
+			key   string
+			value string
+		}{
+			{"test1", "value1"},
+			{"test2", "value2"},
+			{"test1/a", "value_a"},
+			{"test1/b", "value_b"},
+		}
+
+		for i, test := range saveAndLoadTests {
+			if i < 4 {
+				err = kv.Save(test.key, test.value)
+				assert.NoError(t, err)
+			}
+
+			val, err := kv.Load(test.key)
+			assert.NoError(t, err)
+			assert.Equal(t, test.value, val)
+		}
+
+		invalidLoadTests := []struct {
+			invalidKey string
+		}{
+			{"t"},
+			{"a"},
+			{"test1a"},
+		}
+
+		for _, test := range invalidLoadTests {
+			val, err := kv.Load(test.invalidKey)
+			assert.Error(t, err)
+			assert.Zero(t, val)
+		}
+
+		loadPrefixTests := []struct {
+			prefix string
+
+			expectedKeys   []string
+			expectedValues []string
+			expectedError  error
+		}{
+			{"test", []string{
+				kv.GetPath("test1"),
+				kv.GetPath("test2"),
+				kv.GetPath("test1/a"),
+				kv.GetPath("test1/b")}, []string{"value1", "value2", "value_a", "value_b"}, nil},
+			{"test1", []string{
+				kv.GetPath("test1"),
+				kv.GetPath("test1/a"),
+				kv.GetPath("test1/b")}, []string{"value1", "value_a", "value_b"}, nil},
+			{"test2", []string{kv.GetPath("test2")}, []string{"value2"}, nil},
+			{"", []string{
+				kv.GetPath("test1"),
+				kv.GetPath("test2"),
+				kv.GetPath("test1/a"),
+				kv.GetPath("test1/b")}, []string{"value1", "value2", "value_a", "value_b"}, nil},
+			{"test1/a", []string{kv.GetPath("test1/a")}, []string{"value_a"}, nil},
+			{"a", []string{}, []string{}, nil},
+			{"root", []string{}, []string{}, nil},
+			{"/tikv/test/root", []string{}, []string{}, nil},
+		}
+
+		for _, test := range loadPrefixTests {
+			actualKeys, actualValues, err := kv.LoadWithPrefix(test.prefix)
+			assert.ElementsMatch(t, test.expectedKeys, actualKeys)
+			assert.ElementsMatch(t, test.expectedValues, actualValues)
+			assert.Equal(t, test.expectedError, err)
+		}
+
+		removeTests := []struct {
+			validKey   string
+			invalidKey string
+		}{
+			{"test1", "abc"},
+			{"test1/a", "test1/lskfjal"},
+			{"test1/b", "test1/b"},
+			{"test2", "-"},
+		}
+
+		for _, test := range removeTests {
+			err = kv.Remove(test.validKey)
+			assert.NoError(t, err)
+
+			_, err = kv.Load(test.validKey)
+			assert.Error(t, err)
+
+			err = kv.Remove(test.validKey)
+			assert.NoError(t, err)
+			err = kv.Remove(test.invalidKey)
+			assert.NoError(t, err)
+		}
+	})
+
+	te.Run("kv MultiSaveAndMultiLoad", func(t *testing.T) {
+		rootPath := "/tikv/test/root/multi_save_and_multi_load"
+		kv := NewTiKV(txnClient, rootPath)
+
+		defer kv.Close()
+		defer kv.RemoveWithPrefix("")
+
+		multiSaveTests := map[string]string{
+			"key_1":      "value_1",
+			"key_2":      "value_2",
+			"key_3/a":    "value_3a",
+			"multikey_1": "multivalue_1",
+			"multikey_2": "multivalue_2",
+			"_":          "other",
+		}
+
+		err := kv.MultiSave(multiSaveTests)
+		assert.NoError(t, err)
+		for k, v := range multiSaveTests {
+			actualV, err := kv.Load(k)
+			assert.NoError(t, err)
+			assert.Equal(t, v, actualV)
+		}
+
+		multiLoadTests := []struct {
+			inputKeys      []string
+			expectedValues []string
+		}{
+			{[]string{"key_1"}, []string{"value_1"}},
+			{[]string{"key_1", "key_2", "key_3/a"}, []string{"value_1", "value_2", "value_3a"}},
+			{[]string{"multikey_1", "multikey_2"}, []string{"multivalue_1", "multivalue_2"}},
+			{[]string{"_"}, []string{"other"}},
+		}
+
+		for _, test := range multiLoadTests {
+			vs, err := kv.MultiLoad(test.inputKeys)
+			assert.NoError(t, err)
+			assert.Equal(t, test.expectedValues, vs)
+		}
+
+		invalidMultiLoad := []struct {
+			invalidKeys    []string
+			expectedValues []string
+		}{
+			{[]string{"a", "key_1"}, []string{"", "value_1"}},
+			{[]string{".....", "key_1"}, []string{"", "value_1"}},
+			{[]string{"*********"}, []string{""}},
+			{[]string{"key_1", "1"}, []string{"value_1", ""}},
+		}
+
+		for _, test := range invalidMultiLoad {
+			vs, err := kv.MultiLoad(test.invalidKeys)
+			assert.Error(t, err)
+			assert.Equal(t, test.expectedValues, vs)
+		}
+
+		removeWithPrefixTests := []string{
+			"key_1",
+			"multi",
+		}
+
+		for _, k := range removeWithPrefixTests {
+			err = kv.RemoveWithPrefix(k)
+			assert.NoError(t, err)
+
+			ks, vs, err := kv.LoadWithPrefix(k)
+			assert.Empty(t, ks)
+			assert.Empty(t, vs)
+			assert.NoError(t, err)
+		}
+
+		multiRemoveTests := []string{
+			"key_2",
+			"key_3/a",
+			"multikey_2",
+			"_",
+		}
+
+		err = kv.MultiRemove(multiRemoveTests)
+		assert.NoError(t, err)
+
+		ks, vs, err := kv.LoadWithPrefix("")
+		assert.NoError(t, err)
+		assert.Empty(t, ks)
+		assert.Empty(t, vs)
+
+		multiSaveAndRemoveTests := []struct {
+			multiSaves   map[string]string
+			multiRemoves []string
+		}{
+			{map[string]string{"key_1": "value_1"}, []string{}},
+			{map[string]string{"key_2": "value_2"}, []string{"key_1"}},
+			{map[string]string{"key_3/a": "value_3a"}, []string{"key_2"}},
+			{map[string]string{"multikey_1": "multivalue_1"}, []string{}},
+			{map[string]string{"multikey_2": "multivalue_2"}, []string{"multikey_1", "key_3/a"}},
+			{make(map[string]string), []string{"multikey_2"}},
+		}
+		for _, test := range multiSaveAndRemoveTests {
+			err = kv.MultiSaveAndRemove(test.multiSaves, test.multiRemoves)
+			assert.NoError(t, err)
+		}
+
+		ks, vs, err = kv.LoadWithPrefix("")
+		assert.NoError(t, err)
+		assert.Empty(t, ks)
+		assert.Empty(t, vs)
+	})
+
+	te.Run("kv MultiRemoveWithPrefix", func(t *testing.T) {
+		rootPath := "/tikv/test/root/multi_remove_with_prefix"
+		kv := NewTiKV(txnClient, rootPath)
+		defer kv.Close()
+		defer kv.RemoveWithPrefix("")
+
+		prepareTests := map[string]string{
+			"x/abc/1": "1",
+			"x/abc/2": "2",
+			"x/def/1": "10",
+			"x/def/2": "20",
+			"x/den/1": "100",
+			"x/den/2": "200",
+		}
+
+		err := kv.MultiSave(prepareTests)
+		require.NoError(t, err)
+
+		multiRemoveWithPrefixTests := []struct {
+			prefix []string
+
+			testKey       string
+			expectedValue string
+		}{
+			{[]string{"x/abc"}, "x/abc/1", ""},
+			{[]string{}, "x/abc/2", ""},
+			{[]string{}, "x/def/1", "10"},
+			{[]string{}, "x/def/2", "20"},
+			{[]string{}, "x/den/1", "100"},
+			{[]string{}, "x/den/2", "200"},
+			{[]string{}, "not-exist", ""},
+			{[]string{"x/def", "x/den"}, "x/def/1", ""},
+			{[]string{}, "x/def/1", ""},
+			{[]string{}, "x/def/2", ""},
+			{[]string{}, "x/den/1", ""},
+			{[]string{}, "x/den/2", ""},
+			{[]string{}, "not-exist", ""},
+		}
+
+		for _, test := range multiRemoveWithPrefixTests {
+			if len(test.prefix) > 0 {
+				err = kv.MultiRemoveWithPrefix(test.prefix)
+				assert.NoError(t, err)
+			}
+
+			v, _ := kv.Load(test.testKey)
+			assert.Equal(t, test.expectedValue, v)
+		}
+
+		k, v, err := kv.LoadWithPrefix("/")
+		assert.NoError(t, err)
+		assert.Zero(t, len(k))
+		assert.Zero(t, len(v))
+
+		// MultiSaveAndRemoveWithPrefix
+		err = kv.MultiSave(prepareTests)
+		require.NoError(t, err)
+		multiSaveAndRemoveWithPrefixTests := []struct {
+			multiSave map[string]string
+			prefix    []string
+
+			loadPrefix         string
+			lengthBeforeRemove int
+			lengthAfterRemove  int
+		}{
+			{map[string]string{}, []string{"x/abc", "x/def", "x/den"}, "x", 6, 0},
+			{map[string]string{"y/a": "vvv", "y/b": "vvv"}, []string{}, "y", 0, 2},
+			{map[string]string{"y/c": "vvv"}, []string{}, "y", 2, 3},
+			{map[string]string{"p/a": "vvv"}, []string{"y/a", "y"}, "y", 3, 0},
+			{map[string]string{}, []string{"p"}, "p", 1, 0},
+		}
+
+		for _, test := range multiSaveAndRemoveWithPrefixTests {
+			k, _, err = kv.LoadWithPrefix(test.loadPrefix)
+			assert.NoError(t, err)
+			assert.Equal(t, test.lengthBeforeRemove, len(k))
+
+			err = kv.MultiSaveAndRemoveWithPrefix(test.multiSave, test.prefix)
+			assert.NoError(t, err)
+
+			k, _, err = kv.LoadWithPrefix(test.loadPrefix)
+			assert.NoError(t, err)
+			assert.Equal(t, test.lengthAfterRemove, len(k))
+		}
+	})
+
+	te.Run("kv failed to start txn", func(t *testing.T) {
+		rootPath := "/tikv/test/root/start_exn"
+		kv := NewTiKV(txnClient, rootPath)
+		defer kv.Close()
+
+		beginTxn = func(txn *txnkv.Client) (*transaction.KVTxn, error) {
+			return nil, fmt.Errorf("bad txn!")
+		}
+		defer func() {
+			beginTxn = tiTxnBegin
+		}()
+		err := kv.Save("key1", "v1")
+		assert.Error(t, err)
+		_, err = kv.Has("key")
+		assert.Error(t, err)
+		_, err = kv.Load("key")
+		assert.Error(t, err)
+		_, err = kv.HasPrefix("key")
+		assert.Error(t, err)
+		_, err = kv.MultiLoad([]string{"key_1", "key_2"})
+		assert.Error(t, err)
+		_, _, err = kv.LoadWithPrefix("/")
+		assert.Error(t, err)
+		err = kv.MultiSave(map[string]string{"A/100": "v1"})
+		assert.Error(t, err)
+		err = kv.Remove("key1")
+		assert.Error(t, err)
+		err = kv.MultiRemove([]string{"key_1", "key_2"})
+		assert.Error(t, err)
+		err = kv.MultiSaveAndRemove(map[string]string{"key_1": "value_1"}, []string{})
+		assert.Error(t, err)
+		err = kv.MultiSaveAndRemoveWithPrefix(map[string]string{"y/c": "vvv"}, []string{"/"})
+		assert.Error(t, err)
+		err = kv.MultiRemoveWithPrefix([]string{"x/def", "x/den"})
+		assert.Error(t, err)
+	})
+
+	te.Run("kv failed to commit txn", func(t *testing.T) {
+		rootPath := "/tikv/test/root/commit_txn"
+		kv := NewTiKV(txnClient, rootPath)
+		defer kv.Close()
+
+		commitTxn = func(txn *transaction.KVTxn, ctx context.Context) error {
+			return fmt.Errorf("bad txn commit!")
+		}
+		defer func() {
+			commitTxn = tiTxnCommit
+		}()
+		var err error
+		err = kv.Save("key1", "v1")
+		assert.Error(t, err)
+		_, err = kv.Load("key")
+		assert.Error(t, err)
+		_, err = kv.HasPrefix("key")
+		assert.Error(t, err)
+		_, err = kv.MultiLoad([]string{"key_1", "key_2"})
+		assert.Error(t, err)
+		_, _, err = kv.LoadWithPrefix("/")
+		assert.Error(t, err)
+		err = kv.MultiSave(map[string]string{"A/100": "v1"})
+		assert.Error(t, err)
+		err = kv.Remove("key1")
+		assert.Error(t, err)
+		err = kv.MultiRemove([]string{"key_1", "key_2"})
+		assert.Error(t, err)
+		err = kv.MultiSaveAndRemove(map[string]string{"key_1": "value_1"}, []string{})
+		assert.Error(t, err)
+		err = kv.MultiSaveAndRemoveWithPrefix(map[string]string{"y/c": "vvv"}, []string{"/"})
+		assert.Error(t, err)
+		err = kv.MultiRemoveWithPrefix([]string{"x/def", "x/den"})
+		assert.Error(t, err)
+	})
+}
+
+func TestWalkWithPagination(t *testing.T) {
+	rootPath := "/tikv/test/root/pagination"
+	kv := NewTiKV(txnClient, rootPath)
+
+	defer kv.Close()
+	defer kv.RemoveWithPrefix("")
+
+	kvs := map[string]string{
+		"A/100":    "v1",
+		"AA/100":   "v2",
+		"AB/100":   "v3",
+		"AB/2/100": "v4",
+		"B/100":    "v5",
+	}
+
+	err := kv.MultiSave(kvs)
+	assert.NoError(t, err)
+	for k, v := range kvs {
+		actualV, err := kv.Load(k)
+		assert.NoError(t, err)
+		assert.Equal(t, v, actualV)
+	}
+
+	t.Run("apply function error ", func(t *testing.T) {
+		err = kv.WalkWithPrefix("A", 5, func(key []byte, value []byte) error {
+			return errors.New("error")
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("get with non-exist prefix ", func(t *testing.T) {
+		err = kv.WalkWithPrefix("non-exist-prefix", 5, func(key []byte, value []byte) error {
+			return nil
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("with different pagination", func(t *testing.T) {
+		testFn := func(pagination int) {
+			expected := map[string]string{
+				"A/100":    "v1",
+				"AA/100":   "v2",
+				"AB/100":   "v3",
+				"AB/2/100": "v4",
+			}
+
+			expectedKeys := maps.Keys(expected)
+			sort.Strings(expectedKeys)
+
+			ret := make(map[string]string)
+			actualKeys := make([]string, 0)
+
+			err = kv.WalkWithPrefix("A", pagination, func(key []byte, value []byte) error {
+				k := string(key)
+				k = k[len(rootPath)+1:]
+				ret[k] = string(value)
+				actualKeys = append(actualKeys, k)
+				return nil
+			})
+
+			assert.NoError(t, err)
+			assert.Equal(t, expected, ret, fmt.Errorf("pagination: %d", pagination))
+			// Ignore the order.
+			assert.ElementsMatch(t, expectedKeys, actualKeys, fmt.Errorf("pagination: %d", pagination))
+		}
+
+		for p := -1; p < 6; p++ {
+			testFn(p)
+		}
+		testFn(-100)
+		testFn(100)
+	})
+}
+
+func TestElapse(t *testing.T) {
+	start := time.Now()
+	isElapse := CheckElapseAndWarn(start, "err message")
+	assert.Equal(t, isElapse, false)
+
+	time.Sleep(2001 * time.Millisecond)
+	isElapse = CheckElapseAndWarn(start, "err message")
+	assert.Equal(t, isElapse, true)
+}
+
+func TestHas(t *testing.T) {
+	rootPath := "/tikv/test/root/pagination"
+	kv := NewTiKV(txnClient, rootPath)
+	err := kv.RemoveWithPrefix("")
+	require.NoError(t, err)
+
+	defer kv.Close()
+	defer kv.RemoveWithPrefix("")
+
+	has, err := kv.Has("key1")
+	assert.NoError(t, err)
+	assert.False(t, has)
+
+	err = kv.Save("key1", "value1")
+	assert.NoError(t, err)
+
+	has, err = kv.Has("key1")
+	assert.NoError(t, err)
+	assert.True(t, has)
+
+	err = kv.Remove("key1")
+	assert.NoError(t, err)
+
+	has, err = kv.Has("key1")
+	assert.NoError(t, err)
+	assert.False(t, has)
+}
+
+func TestHasPrefix(t *testing.T) {
+	rootPath := "/etcd/test/root/hasprefix"
+	kv := NewTiKV(txnClient, rootPath)
+	err := kv.RemoveWithPrefix("")
+	require.NoError(t, err)
+
+	defer kv.Close()
+	defer kv.RemoveWithPrefix("")
+
+	has, err := kv.HasPrefix("key")
+	assert.NoError(t, err)
+	assert.False(t, has)
+
+	err = kv.Save("key1", "value1")
+	assert.NoError(t, err)
+
+	has, err = kv.HasPrefix("key")
+	assert.NoError(t, err)
+	assert.True(t, has)
+
+	err = kv.Remove("key1")
+	assert.NoError(t, err)
+
+	has, err = kv.HasPrefix("key")
+	assert.NoError(t, err)
+	assert.False(t, has)
+}
+
+func TestTiKVUnimplemented(t *testing.T) {
+	kv := NewTiKV(txnClient, "/")
+	err := kv.RemoveWithPrefix("")
+	require.NoError(t, err)
+
+	defer kv.Close()
+	defer kv.RemoveWithPrefix("")
+
+	_, err = kv.CompareVersionAndSwap("k", 1, "target")
+	assert.Error(t, err)
+}


### PR DESCRIPTION
Implement metakv with tikv lib.
Notice that txn api and rawkv api [can NOT be mix-used](https://github.com/tikv/tikv/issues/3922) within the same tikv cluster.
Thus, we are implementing metakv with txn api and raw kv api separately. The integration will pick the right version based on whether the key space needs transaction support.

Integration of tikv into milvus will be done in a separate PR. [Prototype can be found here](https://github.com/milvus-io/milvus/pull/26003).

issue: #25506