### PR TITLE
Disable error verbose for zap logger

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -153,7 +153,7 @@ func initFileLog(cfg *FileLogConfig) (*lumberjack.Logger, error) {
 }
 
 func newStdLogger() (*zap.Logger, *ZapProperties) {
-	conf := &Config{Level: "debug", Stdout: true}
+	conf := &Config{Level: "debug", Stdout: true, DisableErrorVerbose: true}
 	lg, r, _ := InitLogger(conf)
 	return lg, r
 }


### PR DESCRIPTION
`cockroachdb/errors` wrapped error will print `errorVerbose` field in zap logger, which cause log harder to read
disable this feature in default log config
/kind improvement