### PR TITLE
Add minCPUParallelTaskNumRatio config to allow better parallelism 

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -239,6 +239,13 @@ queryNode:
     # Max read concurrency must greater than or equal to 1, and less than or equal to runtime.NumCPU * 100.
     maxReadConcurrentRatio: 2.0 # (0, 100]
     cpuRatio: 10.0 # ratio used to estimate read task cpu usage.
+    # To allow better parallelism when the estimated cpu usage of a few tasks exceeds the total cpu usage,
+    # querynode task scheduler allows concurrent tasks when concurrent task num is less than
+    # runtime.NumCPU / minCPUParallelTaskNumRatio. For example: on a node with 16 cores and minCPUParallelTaskNumRatio
+    # set to 4, querynode task scheduler will send new tasks to knowhere if there are less than 4 running
+    # tasks, even if that'll cause the total estimated cpu usage of all running tasks to exceed max cpu usage.
+    # This config will be effective only when fifo scheduleReadPolicy is used.
+    minCPUParallelTaskNumRatio: 4
     # maxTimestampLag is the max ts lag between serviceable and guarantee timestamp.
     # if the lag is larger than this config, scheduler will return error without waiting.
     # the valid value is [3600, infinite)

--- a/internal/util/paramtable/component_param.go
+++ b/internal/util/paramtable/component_param.go
@@ -1132,14 +1132,15 @@ type queryNodeConfig struct {
 	CacheEnabled     bool
 	CacheMemoryLimit int64
 
-	GroupEnabled         bool
-	MaxReceiveChanSize   int32
-	MaxUnsolvedQueueSize int32
-	MaxReadConcurrency   int32
-	MaxGroupNQ           int64
-	TopKMergeRatio       float64
-	CPURatio             float64
-	MaxTimestampLag      time.Duration
+	GroupEnabled               bool
+	MaxReceiveChanSize         int32
+	MaxUnsolvedQueueSize       int32
+	MaxReadConcurrency         int32
+	MaxGroupNQ                 int64
+	TopKMergeRatio             float64
+	CPURatio                   float64
+	MinCPUParallelTaskNumRatio int32
+	MaxTimestampLag            time.Duration
 
 	// schedule
 	ScheduleReadPolicy queryNodeConfigScheduleReadPolicy
@@ -1185,6 +1186,7 @@ func (p *queryNodeConfig) init(base *BaseTable) {
 	p.initMaxGroupNQ()
 	p.initTopKMergeRatio()
 	p.initCPURatio()
+	p.initMinCPUParallelTaskNumRatio()
 	p.initEnableDisk()
 	p.initDiskCapacity()
 	p.initMaxDiskUsagePercentage()
@@ -1305,6 +1307,10 @@ func (p *queryNodeConfig) initMaxUnsolvedQueueSize() {
 
 func (p *queryNodeConfig) initCPURatio() {
 	p.CPURatio = p.Base.ParseFloatWithDefault("queryNode.scheduler.cpuRatio", 10.0)
+}
+
+func (p *queryNodeConfig) initMinCPUParallelTaskNumRatio() {
+	p.MinCPUParallelTaskNumRatio = p.Base.ParseInt32WithDefault("queryNode.scheduler.minCPUParallelTaskNumRatio", 4)
 }
 
 func (p *queryNodeConfig) initKnowhereThreadPoolSize() {


### PR DESCRIPTION
when estimated cpu usage of a single task is higher than total cpu usage

context is: on large machines with lots of segments, it's common for a single NQ merged read task to have an estimated CPU usage exceeding the system's max cpu usage, causing the read task execution to be effectively serial instead of parallel, causing the cpu utilization to be low.

For example: in a 16 core machine whose total cpu usage is 1600, with 50 segments and read tasks with nq=10 and a cpu ratio of 10, the estimated cpu usage of each read task is `min(1600, 50 * 10 * 10) = 1600`, query node task scheduler will allow only 1 read task running at any time.

The user surely can tune the cpuRatio parameter but that needs careful profiling/benchmarking case by case and is not an easy task for the user who doesn't know the system very well to find a perfect number. This new parameter is to guarantee an acceptable parallelism in the worst case.