### PR TITLE
Conditionally log warning when DropSegment fails (#25775)

### DIFF
--- a/internal/datacoord/garbage_collector.go
+++ b/internal/datacoord/garbage_collector.go
@@ -267,8 +267,9 @@ func (gc *garbageCollector) clearEtcd() {
 		logs := getLogs(segment)
 		log.Info("GC segment", zap.Int64("segmentID", segment.GetID()))
 		if gc.removeLogs(logs) {
-			err := gc.meta.DropSegment(segment.GetID())
-			log.Warn("failed to drop segment", zap.Int64("segmentID", segment.GetID()), zap.Error(err))
+			if err := gc.meta.DropSegment(segment.GetID()); err != nil {
+				log.Warn("failed to drop segment", zap.Int64("segmentID", segment.GetID()), zap.Error(err))
+			}
 		}
 		if segList := gc.meta.GetSegmentsByChannel(segInsertChannel); len(segList) == 0 &&
 			!gc.meta.catalog.ChannelExists(context.Background(), segInsertChannel) {


### PR DESCRIPTION
fix #25775
This PR checks the return from `DropSegment` and logs warning if the return value indicates error.