### PR TITLE
Low the predicting memory usage factor to 1

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -240,7 +240,7 @@ queryNode:
       enableIndex: true
       nlist: 128 # growing segment index nlist
       nprobe: 16 # nprobe to search growing segment, based on your accuracy requirement, must smaller than nlist
-  loadMemoryUsageFactor: 2 # The multiply factor of calculating the memory usage while loading segments
+  loadMemoryUsageFactor: 1 # The multiply factor of calculating the memory usage while loading segments
   enableDisk: true # enable querynode load disk index, and search on disk index
   maxDiskUsagePercentage: 95
   cache:


### PR DESCRIPTION
/kind improvement
related #25857 
As loading data and index are both optimized (#25212 #25698), now the loading peak memory usage are totally 1x + buffer, so we can low the predicting memory usage factor to 1