### PR TITLE
remove pull target rpc from lock

### DIFF
--- a/internal/querycoordv2/balance/score_based_balancer_test.go
+++ b/internal/querycoordv2/balance/score_based_balancer_test.go
@@ -296,12 +296,13 @@ func (suite *ScoreBasedBalancerTestSuite) TestBalanceOneRound() {
 			suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, c.collectionID).Return(
 				nil, c.collectionsSegments, nil)
 			suite.broker.EXPECT().GetPartitions(mock.Anything, c.collectionID).Return([]int64{c.collectionID}, nil).Maybe()
-			balancer.targetMgr.UpdateCollectionNextTargetWithPartitions(c.collectionID, c.collectionID)
-			balancer.targetMgr.UpdateCollectionCurrentTarget(c.collectionID, c.collectionID)
 			collection.LoadPercentage = 100
 			collection.Status = querypb.LoadStatus_Loaded
 			balancer.meta.CollectionManager.PutCollection(collection)
+			balancer.meta.CollectionManager.PutPartition(utils.CreateTestPartition(c.collectionID, c.collectionID))
 			balancer.meta.ReplicaManager.Put(utils.CreateTestReplica(c.replicaID, c.collectionID, c.nodes))
+			balancer.targetMgr.UpdateCollectionNextTarget(c.collectionID)
+			balancer.targetMgr.UpdateCollectionCurrentTarget(c.collectionID)
 
 			//2. set up target for distribution for multi collections
 			for node, s := range c.distributions {
@@ -401,14 +402,16 @@ func (suite *ScoreBasedBalancerTestSuite) TestBalanceMultiRound() {
 		collections = append(collections, collection)
 		suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, balanceCase.collectionIDs[i]).Return(
 			nil, balanceCase.collectionsSegments[i], nil)
-		balancer.targetMgr.UpdateCollectionNextTargetWithPartitions(balanceCase.collectionIDs[i], balanceCase.collectionIDs[i])
-		balancer.targetMgr.UpdateCollectionCurrentTarget(balanceCase.collectionIDs[i], balanceCase.collectionIDs[i])
+
 		collection.LoadPercentage = 100
 		collection.Status = querypb.LoadStatus_Loaded
 		collection.LoadType = querypb.LoadType_LoadCollection
 		balancer.meta.CollectionManager.PutCollection(collection)
+		balancer.meta.CollectionManager.PutPartition(utils.CreateTestPartition(balanceCase.collectionIDs[i], balanceCase.collectionIDs[i]))
 		balancer.meta.ReplicaManager.Put(utils.CreateTestReplica(balanceCase.replicaIDs[i], balanceCase.collectionIDs[i],
 			append(balanceCase.nodes, balanceCase.notExistedNodes...)))
+		balancer.targetMgr.UpdateCollectionNextTarget(balanceCase.collectionIDs[i])
+		balancer.targetMgr.UpdateCollectionCurrentTarget(balanceCase.collectionIDs[i])
 	}
 
 	//2. set up target for distribution for multi collections
@@ -539,12 +542,13 @@ func (suite *ScoreBasedBalancerTestSuite) TestStoppedBalance() {
 			suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, c.collectionID).Return(
 				nil, c.collectionsSegments, nil)
 			suite.broker.EXPECT().GetPartitions(mock.Anything, c.collectionID).Return([]int64{c.collectionID}, nil).Maybe()
-			balancer.targetMgr.UpdateCollectionNextTargetWithPartitions(c.collectionID, c.collectionID)
-			balancer.targetMgr.UpdateCollectionCurrentTarget(c.collectionID, c.collectionID)
 			collection.LoadPercentage = 100
 			collection.Status = querypb.LoadStatus_Loaded
 			balancer.meta.CollectionManager.PutCollection(collection)
+			balancer.meta.CollectionManager.PutPartition(utils.CreateTestPartition(c.collectionID, c.collectionID))
 			balancer.meta.ReplicaManager.Put(utils.CreateTestReplica(c.replicaID, c.collectionID, c.nodes))
+			balancer.targetMgr.UpdateCollectionNextTarget(c.collectionID)
+			balancer.targetMgr.UpdateCollectionCurrentTarget(c.collectionID)
 
 			//2. set up target for distribution for multi collections
 			for node, s := range c.distributions {

--- a/internal/querycoordv2/checkers/channel_checker_test.go
+++ b/internal/querycoordv2/checkers/channel_checker_test.go
@@ -105,6 +105,7 @@ func (suite *ChannelCheckerTestSuite) createMockBalancer() balance.Balance {
 func (suite *ChannelCheckerTestSuite) TestLoadChannel() {
 	checker := suite.checker
 	checker.meta.CollectionManager.PutCollection(utils.CreateTestCollection(1, 1))
+	suite.meta.CollectionManager.PutPartition(utils.CreateTestPartition(1, 1))
 	checker.meta.ReplicaManager.Put(utils.CreateTestReplica(1, 1, []int64{1}))
 	suite.nodeMgr.Add(session.NewNodeInfo(1, "localhost"))
 	checker.meta.ResourceManager.AssignNode(meta.DefaultResourceGroupName, 1)
@@ -118,7 +119,7 @@ func (suite *ChannelCheckerTestSuite) TestLoadChannel() {
 
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
 		channels, nil, nil)
-	checker.targetMgr.UpdateCollectionNextTargetWithPartitions(int64(1), int64(1))
+	checker.targetMgr.UpdateCollectionNextTarget(int64(1))
 
 	tasks := checker.Check(context.TODO())
 	suite.Len(tasks, 1)
@@ -151,6 +152,7 @@ func (suite *ChannelCheckerTestSuite) TestReduceChannel() {
 func (suite *ChannelCheckerTestSuite) TestRepeatedChannels() {
 	checker := suite.checker
 	err := checker.meta.CollectionManager.PutCollection(utils.CreateTestCollection(1, 1))
+	suite.meta.CollectionManager.PutPartition(utils.CreateTestPartition(1, 1))
 	suite.NoError(err)
 	err = checker.meta.ReplicaManager.Put(utils.CreateTestReplica(1, 1, []int64{1, 2}))
 	suite.NoError(err)
@@ -170,7 +172,7 @@ func (suite *ChannelCheckerTestSuite) TestRepeatedChannels() {
 	}
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
 		channels, segments, nil)
-	checker.targetMgr.UpdateCollectionNextTargetWithPartitions(int64(1), int64(1))
+	checker.targetMgr.UpdateCollectionNextTarget(int64(1))
 	checker.dist.ChannelDistManager.Update(1, utils.CreateTestChannel(1, 1, 1, "test-insert-channel"))
 	checker.dist.ChannelDistManager.Update(2, utils.CreateTestChannel(1, 2, 2, "test-insert-channel"))
 

--- a/internal/querycoordv2/checkers/controller_test.go
+++ b/internal/querycoordv2/checkers/controller_test.go
@@ -87,6 +87,7 @@ func (suite *CheckerControllerSuite) TestBasic() {
 
 	// set meta
 	suite.meta.CollectionManager.PutCollection(utils.CreateTestCollection(1, 1))
+	suite.meta.CollectionManager.PutPartition(utils.CreateTestPartition(1, 1))
 	suite.meta.ReplicaManager.Put(utils.CreateTestReplica(1, 1, []int64{1, 2}))
 	suite.nodeMgr.Add(session.NewNodeInfo(1, "localhost"))
 	suite.nodeMgr.Add(session.NewNodeInfo(2, "localhost"))
@@ -103,7 +104,7 @@ func (suite *CheckerControllerSuite) TestBasic() {
 	}
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
 		nil, segments, nil)
-	suite.targetManager.UpdateCollectionNextTargetWithPartitions(int64(1), int64(1))
+	suite.targetManager.UpdateCollectionNextTarget(int64(1))
 
 	// set dist
 	suite.dist.ChannelDistManager.Update(2, utils.CreateTestChannel(1, 2, 1, "test-insert-channel"))

--- a/internal/querycoordv2/job/job_test.go
+++ b/internal/querycoordv2/job/job_test.go
@@ -412,7 +412,7 @@ func (suite *JobSuite) TestLoadCollectionWithDiffIndex() {
 		err := job.Wait()
 		suite.NoError(err)
 		suite.EqualValues(1, suite.meta.GetReplicaNumber(collection))
-		suite.targetMgr.UpdateCollectionCurrentTarget(collection, suite.partitions[collection]...)
+		suite.targetMgr.UpdateCollectionCurrentTarget(collection)
 		suite.assertCollectionLoaded(collection)
 	}
 
@@ -473,7 +473,7 @@ func (suite *JobSuite) TestLoadPartition() {
 		err := job.Wait()
 		suite.NoError(err)
 		suite.EqualValues(1, suite.meta.GetReplicaNumber(collection))
-		suite.targetMgr.UpdateCollectionCurrentTarget(collection, suite.partitions[collection]...)
+		suite.targetMgr.UpdateCollectionCurrentTarget(collection)
 		suite.assertCollectionLoaded(collection)
 	}
 
@@ -809,7 +809,7 @@ func (suite *JobSuite) TestLoadPartitionWithDiffIndex() {
 		err := job.Wait()
 		suite.NoError(err)
 		suite.EqualValues(1, suite.meta.GetReplicaNumber(collection))
-		suite.targetMgr.UpdateCollectionCurrentTarget(collection, suite.partitions[collection]...)
+		suite.targetMgr.UpdateCollectionCurrentTarget(collection)
 		suite.assertCollectionLoaded(collection)
 	}
 

--- a/internal/querycoordv2/meta/collection_manager.go
+++ b/internal/querycoordv2/meta/collection_manager.go
@@ -482,10 +482,6 @@ func (m *CollectionManager) UpdateLoadPercent(partitionID int64, loadPercent int
 		return 0, merr.WrapErrPartitionNotFound(partitionID)
 	}
 
-	if loadPercent <= oldPartition.LoadPercentage {
-		return m.calculateLoadPercentage(oldPartition.GetCollectionID()), nil
-	}
-
 	// update partition load percentage
 	newPartition := oldPartition.Clone()
 	newPartition.LoadPercentage = loadPercent
@@ -508,9 +504,6 @@ func (m *CollectionManager) UpdateLoadPercent(partitionID int64, loadPercent int
 		return 0, merr.WrapErrCollectionNotFound(newPartition.CollectionID)
 	}
 	collectionPercent := m.calculateLoadPercentage(oldCollection.CollectionID)
-	if collectionPercent <= oldCollection.LoadPercentage {
-		return m.calculateLoadPercentage(oldPartition.GetCollectionID()), nil
-	}
 	newCollection := oldCollection.Clone()
 	newCollection.LoadPercentage = collectionPercent
 	saveCollection := false

--- a/internal/querycoordv2/meta/collection_manager_test.go
+++ b/internal/querycoordv2/meta/collection_manager_test.go
@@ -433,15 +433,6 @@ func (suite *CollectionManagerSuite) TestUpdateLoadPercentage() {
 	collection := mgr.GetCollection(1)
 	suite.Equal(int32(15), collection.LoadPercentage)
 	suite.Equal(querypb.LoadStatus_Loading, collection.Status)
-	// expect nothing changed
-	mgr.UpdateLoadPercent(1, 15)
-	partition = mgr.GetPartition(1)
-	suite.Equal(int32(30), partition.LoadPercentage)
-	suite.Equal(querypb.LoadStatus_Loading, partition.Status)
-	collection = mgr.GetCollection(1)
-	suite.Equal(int32(15), collection.LoadPercentage)
-	suite.Equal(querypb.LoadStatus_Loading, collection.Status)
-	suite.Equal(querypb.LoadStatus_Loading, mgr.CalculateLoadStatus(collection.CollectionID))
 	// test update partition load percentage to 100
 	mgr.UpdateLoadPercent(1, 100)
 	partition = mgr.GetPartition(1)

--- a/internal/querycoordv2/meta/target.go
+++ b/internal/querycoordv2/meta/target.go
@@ -75,6 +75,10 @@ func newTarget() *target {
 }
 
 func (t *target) updateCollectionTarget(collectionID int64, target *CollectionTarget) {
+	if t.collectionTargetMap[collectionID] != nil && target.GetTargetVersion() <= t.collectionTargetMap[collectionID].GetTargetVersion() {
+		return
+	}
+
 	t.collectionTargetMap[collectionID] = target
 }
 

--- a/internal/querycoordv2/observers/leader_observer_test.go
+++ b/internal/querycoordv2/observers/leader_observer_test.go
@@ -90,6 +90,7 @@ func (suite *LeaderObserverTestSuite) TearDownTest() {
 func (suite *LeaderObserverTestSuite) TestSyncLoadedSegments() {
 	observer := suite.observer
 	observer.meta.CollectionManager.PutCollection(utils.CreateTestCollection(1, 1))
+	observer.meta.CollectionManager.PutPartition(utils.CreateTestPartition(1, 1))
 	observer.meta.ReplicaManager.Put(utils.CreateTestReplica(1, 1, []int64{1, 2}))
 	segments := []*datapb.SegmentInfo{
 		{
@@ -119,7 +120,7 @@ func (suite *LeaderObserverTestSuite) TestSyncLoadedSegments() {
 		&datapb.GetSegmentInfoResponse{Infos: []*datapb.SegmentInfo{info}}, nil)
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
 		channels, segments, nil)
-	observer.target.UpdateCollectionNextTargetWithPartitions(int64(1), int64(1))
+	observer.target.UpdateCollectionNextTarget(int64(1))
 	observer.target.UpdateCollectionCurrentTarget(1)
 	observer.dist.SegmentDistManager.Update(1, utils.CreateTestSegment(1, 1, 1, 2, 1, "test-insert-channel"))
 	observer.dist.ChannelDistManager.Update(2, utils.CreateTestChannel(1, 2, 1, "test-insert-channel"))
@@ -149,7 +150,7 @@ func (suite *LeaderObserverTestSuite) TestSyncLoadedSegments() {
 			Schema: schema,
 			LoadMeta: &querypb.LoadMetaInfo{
 				CollectionID: 1,
-				PartitionIDs: []int64{},
+				PartitionIDs: []int64{1},
 			},
 			Version: version,
 		}
@@ -179,6 +180,7 @@ func (suite *LeaderObserverTestSuite) TestSyncLoadedSegments() {
 func (suite *LeaderObserverTestSuite) TestIgnoreSyncLoadedSegments() {
 	observer := suite.observer
 	observer.meta.CollectionManager.PutCollection(utils.CreateTestCollection(1, 1))
+	observer.meta.CollectionManager.PutPartition(utils.CreateTestPartition(1, 1))
 	observer.meta.ReplicaManager.Put(utils.CreateTestReplica(1, 1, []int64{1, 2}))
 	segments := []*datapb.SegmentInfo{
 		{
@@ -208,7 +210,7 @@ func (suite *LeaderObserverTestSuite) TestIgnoreSyncLoadedSegments() {
 		&datapb.GetSegmentInfoResponse{Infos: []*datapb.SegmentInfo{info}}, nil)
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
 		channels, segments, nil)
-	observer.target.UpdateCollectionNextTargetWithPartitions(int64(1), int64(1))
+	observer.target.UpdateCollectionNextTarget(int64(1))
 	observer.target.UpdateCollectionCurrentTarget(1)
 	observer.dist.SegmentDistManager.Update(1, utils.CreateTestSegment(1, 1, 1, 2, 1, "test-insert-channel"),
 		utils.CreateTestSegment(1, 1, 2, 2, 1, "test-insert-channel"))
@@ -239,7 +241,7 @@ func (suite *LeaderObserverTestSuite) TestIgnoreSyncLoadedSegments() {
 			Schema: schema,
 			LoadMeta: &querypb.LoadMetaInfo{
 				CollectionID: 1,
-				PartitionIDs: []int64{},
+				PartitionIDs: []int64{1},
 			},
 			Version: version,
 		}
@@ -267,6 +269,7 @@ func (suite *LeaderObserverTestSuite) TestIgnoreSyncLoadedSegments() {
 func (suite *LeaderObserverTestSuite) TestIgnoreBalancedSegment() {
 	observer := suite.observer
 	observer.meta.CollectionManager.PutCollection(utils.CreateTestCollection(1, 1))
+	observer.meta.CollectionManager.PutPartition(utils.CreateTestPartition(1, 1))
 	observer.meta.ReplicaManager.Put(utils.CreateTestReplica(1, 1, []int64{1, 2}))
 	segments := []*datapb.SegmentInfo{
 		{
@@ -284,7 +287,7 @@ func (suite *LeaderObserverTestSuite) TestIgnoreBalancedSegment() {
 
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
 		channels, segments, nil)
-	observer.target.UpdateCollectionNextTargetWithPartitions(int64(1), int64(1))
+	observer.target.UpdateCollectionNextTarget(int64(1))
 	observer.target.UpdateCollectionCurrentTarget(1)
 	observer.dist.SegmentDistManager.Update(1, utils.CreateTestSegment(1, 1, 1, 1, 1, "test-insert-channel"))
 	observer.dist.ChannelDistManager.Update(2, utils.CreateTestChannel(1, 2, 1, "test-insert-channel"))
@@ -307,6 +310,7 @@ func (suite *LeaderObserverTestSuite) TestIgnoreBalancedSegment() {
 func (suite *LeaderObserverTestSuite) TestSyncLoadedSegmentsWithReplicas() {
 	observer := suite.observer
 	observer.meta.CollectionManager.PutCollection(utils.CreateTestCollection(1, 2))
+	observer.meta.CollectionManager.PutPartition(utils.CreateTestPartition(1, 1))
 	observer.meta.ReplicaManager.Put(utils.CreateTestReplica(1, 1, []int64{1, 2}))
 	observer.meta.ReplicaManager.Put(utils.CreateTestReplica(2, 1, []int64{3, 4}))
 	segments := []*datapb.SegmentInfo{
@@ -337,7 +341,7 @@ func (suite *LeaderObserverTestSuite) TestSyncLoadedSegmentsWithReplicas() {
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
 		channels, segments, nil)
 	suite.broker.EXPECT().GetCollectionSchema(mock.Anything, int64(1)).Return(schema, nil)
-	observer.target.UpdateCollectionNextTargetWithPartitions(int64(1), int64(1))
+	observer.target.UpdateCollectionNextTarget(int64(1))
 	observer.target.UpdateCollectionCurrentTarget(1)
 	observer.dist.SegmentDistManager.Update(1, utils.CreateTestSegment(1, 1, 1, 1, 1, "test-insert-channel"))
 	observer.dist.SegmentDistManager.Update(4, utils.CreateTestSegment(1, 1, 1, 4, 2, "test-insert-channel"))
@@ -371,7 +375,7 @@ func (suite *LeaderObserverTestSuite) TestSyncLoadedSegmentsWithReplicas() {
 			Schema: schema,
 			LoadMeta: &querypb.LoadMetaInfo{
 				CollectionID: 1,
-				PartitionIDs: []int64{},
+				PartitionIDs: []int64{1},
 			},
 			Version: version,
 		}
@@ -400,6 +404,7 @@ func (suite *LeaderObserverTestSuite) TestSyncLoadedSegmentsWithReplicas() {
 func (suite *LeaderObserverTestSuite) TestSyncRemovedSegments() {
 	observer := suite.observer
 	observer.meta.CollectionManager.PutCollection(utils.CreateTestCollection(1, 1))
+	observer.meta.CollectionManager.PutPartition(utils.CreateTestPartition(1, 1))
 	observer.meta.ReplicaManager.Put(utils.CreateTestReplica(1, 1, []int64{1, 2}))
 
 	observer.dist.ChannelDistManager.Update(2, utils.CreateTestChannel(1, 2, 1, "test-insert-channel"))
@@ -426,7 +431,7 @@ func (suite *LeaderObserverTestSuite) TestSyncRemovedSegments() {
 			Schema: schema,
 			LoadMeta: &querypb.LoadMetaInfo{
 				CollectionID: 1,
-				PartitionIDs: []int64{},
+				PartitionIDs: []int64{1},
 			},
 			Version: version,
 		}
@@ -453,6 +458,7 @@ func (suite *LeaderObserverTestSuite) TestIgnoreSyncRemovedSegments() {
 
 	observer := suite.observer
 	observer.meta.CollectionManager.PutCollection(utils.CreateTestCollection(1, 1))
+	observer.meta.CollectionManager.PutPartition(utils.CreateTestPartition(1, 1))
 	observer.meta.ReplicaManager.Put(utils.CreateTestReplica(1, 1, []int64{1, 2}))
 
 	segments := []*datapb.SegmentInfo{
@@ -472,7 +478,7 @@ func (suite *LeaderObserverTestSuite) TestIgnoreSyncRemovedSegments() {
 	suite.broker.EXPECT().GetCollectionSchema(mock.Anything, int64(1)).Return(schema, nil)
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
 		channels, segments, nil)
-	observer.target.UpdateCollectionNextTargetWithPartitions(int64(1), int64(1))
+	observer.target.UpdateCollectionNextTarget(int64(1))
 
 	observer.dist.ChannelDistManager.Update(2, utils.CreateTestChannel(1, 2, 1, "test-insert-channel"))
 	observer.dist.LeaderViewManager.Update(2, utils.CreateTestLeaderView(2, 1, "test-insert-channel", map[int64]int64{3: 2, 2: 2}, map[int64]*meta.Segment{}))
@@ -495,7 +501,7 @@ func (suite *LeaderObserverTestSuite) TestIgnoreSyncRemovedSegments() {
 			Schema: schema,
 			LoadMeta: &querypb.LoadMetaInfo{
 				CollectionID: 1,
-				PartitionIDs: []int64{},
+				PartitionIDs: []int64{1},
 			},
 			Version: version,
 		}
@@ -523,6 +529,7 @@ func (suite *LeaderObserverTestSuite) TestSyncTargetVersion() {
 
 	observer := suite.observer
 	observer.meta.CollectionManager.PutCollection(utils.CreateTestCollection(collectionID, 1))
+	observer.meta.CollectionManager.PutPartition(utils.CreateTestPartition(collectionID, 1))
 	observer.meta.ReplicaManager.Put(utils.CreateTestReplica(1, collectionID, []int64{1, 2}))
 
 	nextTargetChannels := []*datapb.VchannelInfo{
@@ -552,7 +559,7 @@ func (suite *LeaderObserverTestSuite) TestSyncTargetVersion() {
 	}
 
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, collectionID).Return(nextTargetChannels, nextTargetSegments, nil)
-	suite.observer.target.UpdateCollectionNextTargetWithPartitions(collectionID, 1)
+	suite.observer.target.UpdateCollectionNextTarget(collectionID)
 	suite.observer.target.UpdateCollectionCurrentTarget(collectionID)
 	TargetVersion := suite.observer.target.GetCollectionTargetVersion(collectionID, meta.CurrentTarget)
 

--- a/internal/querycoordv2/observers/target_observer.go
+++ b/internal/querycoordv2/observers/target_observer.go
@@ -37,7 +37,6 @@ type checkRequest struct {
 
 type targetUpdateRequest struct {
 	CollectionID  int64
-	PartitionIDs  []int64
 	Notifier      chan error
 	ReadyNotifier chan struct{}
 }
@@ -109,7 +108,7 @@ func (ob *TargetObserver) schedule(ctx context.Context) {
 			req.Notifier <- ob.targetMgr.IsCurrentTargetExist(req.CollectionID)
 
 		case req := <-ob.updateChan:
-			err := ob.updateNextTarget(req.CollectionID, req.PartitionIDs...)
+			err := ob.updateNextTarget(req.CollectionID)
 			if err != nil {
 				close(req.ReadyNotifier)
 			} else {
@@ -154,14 +153,13 @@ func (ob *TargetObserver) check(collectionID int64) {
 // UpdateNextTarget updates the next target,
 // returns a channel which will be closed when the next target is ready,
 // or returns error if failed to pull target
-func (ob *TargetObserver) UpdateNextTarget(collectionID int64, partitionIDs ...int64) (chan struct{}, error) {
+func (ob *TargetObserver) UpdateNextTarget(collectionID int64) (chan struct{}, error) {
 	notifier := make(chan error)
 	readyCh := make(chan struct{})
 	defer close(notifier)
 
 	ob.updateChan <- targetUpdateRequest{
 		CollectionID:  collectionID,
-		PartitionIDs:  partitionIDs,
 		Notifier:      notifier,
 		ReadyNotifier: readyCh,
 	}
@@ -215,16 +213,11 @@ func (ob *TargetObserver) isNextTargetExpired(collectionID int64) bool {
 	return time.Since(ob.nextTargetLastUpdate[collectionID]) > params.Params.QueryCoordCfg.NextTargetSurviveTime.GetAsDuration(time.Second)
 }
 
-func (ob *TargetObserver) updateNextTarget(collectionID int64, partitionIDs ...int64) error {
-	log := log.With(zap.Int64("collectionID", collectionID), zap.Int64s("partIDs", partitionIDs))
+func (ob *TargetObserver) updateNextTarget(collectionID int64) error {
+	log := log.With(zap.Int64("collectionID", collectionID))
 
 	log.Info("observer trigger update next target")
-	var err error
-	if len(partitionIDs) == 0 {
-		err = ob.targetMgr.UpdateCollectionNextTarget(collectionID)
-	} else {
-		err = ob.targetMgr.UpdateCollectionNextTargetWithPartitions(collectionID, partitionIDs...)
-	}
+	err := ob.targetMgr.UpdateCollectionNextTarget(collectionID)
 	if err != nil {
 		log.Error("failed to update next target for collection",
 			zap.Error(err))

--- a/internal/querycoordv2/task/task_test.go
+++ b/internal/querycoordv2/task/task_test.go
@@ -159,6 +159,7 @@ func (suite *TaskSuite) BeforeTest(suiteName, testName string) {
 
 	switch testName {
 	case "TestSubscribeChannelTask",
+		"TestUnsubscribeChannelTask",
 		"TestLoadSegmentTask",
 		"TestLoadSegmentTaskNotIndex",
 		"TestLoadSegmentTaskFailed",
@@ -173,6 +174,12 @@ func (suite *TaskSuite) BeforeTest(suiteName, testName string) {
 				CollectionID:  suite.collection,
 				ReplicaNumber: 1,
 				Status:        querypb.LoadStatus_Loading,
+			},
+		})
+		suite.meta.PutPartition(&meta.Partition{
+			PartitionLoadInfo: &querypb.PartitionLoadInfo{
+				CollectionID: suite.collection,
+				PartitionID:  1,
 			},
 		})
 		suite.meta.ReplicaManager.Put(
@@ -242,7 +249,7 @@ func (suite *TaskSuite) TestSubscribeChannelTask() {
 		suite.NoError(err)
 	}
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection).Return(dmChannels, nil, nil)
-	suite.target.UpdateCollectionNextTargetWithPartitions(suite.collection, int64(1))
+	suite.target.UpdateCollectionNextTarget(suite.collection)
 	suite.AssertTaskNum(0, len(suite.subChannels), len(suite.subChannels), 0)
 
 	// Process tasks
@@ -337,7 +344,7 @@ func (suite *TaskSuite) TestUnsubscribeChannelTask() {
 		suite.NoError(err)
 	}
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection).Return(dmChannels, nil, nil)
-	suite.target.UpdateCollectionNextTargetWithPartitions(suite.collection, int64(1))
+	suite.target.UpdateCollectionNextTarget(suite.collection)
 
 	// Only first channel exists
 	suite.dist.LeaderViewManager.Update(targetNode, &meta.LeaderView{
@@ -424,7 +431,7 @@ func (suite *TaskSuite) TestLoadSegmentTask() {
 		suite.NoError(err)
 	}
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection).Return(nil, segments, nil)
-	suite.target.UpdateCollectionNextTargetWithPartitions(suite.collection, int64(1))
+	suite.target.UpdateCollectionNextTarget(suite.collection)
 	segmentsNum := len(suite.loadSegments)
 	suite.AssertTaskNum(0, segmentsNum, 0, segmentsNum)
 
@@ -518,7 +525,7 @@ func (suite *TaskSuite) TestLoadSegmentTaskNotIndex() {
 		suite.NoError(err)
 	}
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection).Return(nil, segments, nil)
-	suite.target.UpdateCollectionNextTargetWithPartitions(suite.collection, int64(1))
+	suite.target.UpdateCollectionNextTarget(suite.collection)
 	segmentsNum := len(suite.loadSegments)
 	suite.AssertTaskNum(0, segmentsNum, 0, segmentsNum)
 
@@ -606,7 +613,7 @@ func (suite *TaskSuite) TestLoadSegmentTaskFailed() {
 		suite.NoError(err)
 	}
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection).Return(nil, segments, nil)
-	suite.target.UpdateCollectionNextTargetWithPartitions(suite.collection, int64(1))
+	suite.target.UpdateCollectionNextTarget(suite.collection)
 	segmentsNum := len(suite.loadSegments)
 	suite.AssertTaskNum(0, segmentsNum, 0, segmentsNum)
 
@@ -820,8 +827,8 @@ func (suite *TaskSuite) TestMoveSegmentTask() {
 		suite.NoError(err)
 	}
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection).Return([]*datapb.VchannelInfo{vchannel}, segmentInfos, nil)
-	suite.target.UpdateCollectionNextTargetWithPartitions(suite.collection, int64(1))
-	suite.target.UpdateCollectionCurrentTarget(suite.collection, int64(1))
+	suite.target.UpdateCollectionNextTarget(suite.collection)
+	suite.target.UpdateCollectionCurrentTarget(suite.collection)
 	suite.dist.SegmentDistManager.Update(sourceNode, segments...)
 	suite.dist.LeaderViewManager.Update(leader, view)
 	segmentsNum := len(suite.moveSegments)
@@ -918,7 +925,8 @@ func (suite *TaskSuite) TestTaskCanceled() {
 	segmentsNum := len(suite.loadSegments)
 	suite.AssertTaskNum(0, segmentsNum, 0, segmentsNum)
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection).Return(nil, segmentInfos, nil)
-	suite.target.UpdateCollectionNextTargetWithPartitions(suite.collection, partition)
+	suite.meta.CollectionManager.PutPartition(utils.CreateTestPartition(suite.collection, partition))
+	suite.target.UpdateCollectionNextTarget(suite.collection)
 
 	// Process tasks
 	suite.dispatchAndWait(targetNode)
@@ -1001,7 +1009,8 @@ func (suite *TaskSuite) TestSegmentTaskStale() {
 		suite.NoError(err)
 	}
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection).Return(nil, segments, nil)
-	suite.target.UpdateCollectionNextTargetWithPartitions(suite.collection, int64(1))
+	suite.meta.CollectionManager.PutPartition(utils.CreateTestPartition(suite.collection, partition))
+	suite.target.UpdateCollectionNextTarget(suite.collection)
 	segmentsNum := len(suite.loadSegments)
 	suite.AssertTaskNum(0, segmentsNum, 0, segmentsNum)
 
@@ -1036,7 +1045,9 @@ func (suite *TaskSuite) TestSegmentTaskStale() {
 	suite.broker.AssertExpectations(suite.T())
 	suite.broker.ExpectedCalls = suite.broker.ExpectedCalls[:0]
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection).Return(nil, segments, nil)
-	suite.target.UpdateCollectionNextTargetWithPartitions(suite.collection, int64(2))
+
+	suite.meta.CollectionManager.PutPartition(utils.CreateTestPartition(suite.collection, 2))
+	suite.target.UpdateCollectionNextTarget(suite.collection)
 	suite.dispatchAndWait(targetNode)
 	suite.AssertTaskNum(0, 0, 0, 0)
 
@@ -1240,7 +1251,7 @@ func (suite *TaskSuite) TestNoExecutor() {
 		suite.NoError(err)
 	}
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection).Return(nil, segments, nil)
-	suite.target.UpdateCollectionNextTargetWithPartitions(suite.collection, int64(1))
+	suite.target.UpdateCollectionNextTarget(suite.collection)
 	segmentsNum := len(suite.loadSegments)
 	suite.AssertTaskNum(0, segmentsNum, 0, segmentsNum)
 


### PR DESCRIPTION
Signed-off-by: Wei Liu <wei.liu@zilliz.com>

remove pull target rpc from target manager's  lock, to avoid hold lock in whole rpc progress.

/kind improvement 