### PR TITLE
disable retry in grpc connect and grpc sendMsg

### DIFF
--- a/internal/util/grpcclient/client.go
+++ b/internal/util/grpcclient/client.go
@@ -222,6 +222,8 @@ func (c *ClientBase[T]) connect(ctx context.Context) error {
 				MinConnectTimeout: c.DialTimeout,
 			}),
 			grpc.WithPerRPCCredentials(&Token{Value: crypto.Base64Encode(util.MemberCredID)}),
+			grpc.WithDisableRetry(),
+			grpc.FailOnNonTempDialError(true),
 		)
 	} else {
 		conn, err = grpc.DialContext(
@@ -259,6 +261,8 @@ func (c *ClientBase[T]) connect(ctx context.Context) error {
 				MinConnectTimeout: c.DialTimeout,
 			}),
 			grpc.WithPerRPCCredentials(&Token{Value: crypto.Base64Encode(util.MemberCredID)}),
+			grpc.WithDisableRetry(),
+			grpc.FailOnNonTempDialError(true),
 		)
 	}
 


### PR DESCRIPTION
Signed-off-by: Wei Liu <wei.liu@zilliz.com>

`grpc.WithDisableRetry()` will disable retry during grpc send request
`grpc.FailOnNonTempDialError(true)` will diable retry during grpc connect which meets non-temporary error.
issue: #25025 