### PR TITLE
enable config shard level cost metrics whether contains worker's cost

### DIFF
--- a/internal/querynodev2/tasks/query_task.go
+++ b/internal/querynodev2/tasks/query_task.go
@@ -123,6 +123,9 @@ func (t *QueryTask) Execute() error {
 	}
 
 	t.result = &internalpb.RetrieveResults{
+		Base: &commonpb.MsgBase{
+			SourceID: paramtable.GetNodeID(),
+		},
 		Status:     &commonpb.Status{ErrorCode: commonpb.ErrorCode_Success},
 		Ids:        reducedResult.Ids,
 		FieldsData: reducedResult.FieldsData,

--- a/internal/querynodev2/tasks/task.go
+++ b/internal/querynodev2/tasks/task.go
@@ -159,6 +159,9 @@ func (t *SearchTask) Execute() error {
 			}
 
 			task.result = &internalpb.SearchResults{
+				Base: &commonpb.MsgBase{
+					SourceID: paramtable.GetNodeID(),
+				},
 				Status:         &commonpb.Status{ErrorCode: commonpb.ErrorCode_Success},
 				MetricType:     req.GetReq().GetMetricType(),
 				NumQueries:     t.originNqs[i],
@@ -212,6 +215,9 @@ func (t *SearchTask) Execute() error {
 			Observe(float64(reduceLatency.Milliseconds()))
 
 		task.result = &internalpb.SearchResults{
+			Base: &commonpb.MsgBase{
+				SourceID: paramtable.GetNodeID(),
+			},
 			Status:         util.WrapStatus(commonpb.ErrorCode_Success, ""),
 			MetricType:     req.GetReq().GetMetricType(),
 			NumQueries:     t.originNqs[i],

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -1645,6 +1645,8 @@ type queryNodeConfig struct {
 
 	// CGOPoolSize ratio to MaxReadConcurrency
 	CGOPoolSizeRatio ParamItem `refreshable:"false"`
+
+	EnableWorkerSQCostMetrics ParamItem `refreshable:"true"`
 }
 
 func (p *queryNodeConfig) init(base *BaseTable) {
@@ -2007,6 +2009,14 @@ Max read concurrency must greater than or equal to 1, and less than or equal to 
 		Doc:          "cgo pool size ratio to max read concurrency",
 	}
 	p.CGOPoolSizeRatio.Init(base.mgr)
+
+	p.EnableWorkerSQCostMetrics = ParamItem{
+		Key:          "queryNode.enableWorkerSQCostMetrics",
+		Version:      "2.3.0",
+		DefaultValue: "false",
+		Doc:          "whether use worker's cost to measure delegator's workload",
+	}
+	p.EnableWorkerSQCostMetrics.Init(base.mgr)
 }
 
 // /////////////////////////////////////////////////////////////////////////////

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -359,6 +359,8 @@ func TestComponentParam(t *testing.T) {
 		params.Save("queryNode.gracefulStopTimeout", "100")
 		gracefulStopTimeout := Params.GracefulStopTimeout
 		assert.Equal(t, int64(100), gracefulStopTimeout.GetAsInt64())
+
+		assert.Equal(t, false, Params.EnableWorkerSQCostMetrics.GetAsBool())
 	})
 
 	t.Run("test dataCoordConfig", func(t *testing.T) {


### PR DESCRIPTION
 Signed-off-by: Wei Liu <wei.liu@zilliz.com>
 
 in look aside balancer, if a shard have crossed multi qn, we can choose two ways wo measure shard's workload 
 
 1. only shard leader's query node
 2. include all worker and shard leader together