### PR TITLE
Fix missing totalChannelNum bug

### DIFF
--- a/internal/querynodev2/services.go
+++ b/internal/querynodev2/services.go
@@ -821,6 +821,7 @@ func (node *QueryNode) Search(ctx context.Context, req *querypb.SearchRequest) (
 			SegmentIDs:      req.SegmentIDs,
 			FromShardLeader: req.FromShardLeader,
 			Scope:           req.Scope,
+			TotalChannelNum: req.TotalChannelNum,
 		}
 
 		runningGp.Go(func() error {

--- a/internal/querynodev2/services_test.go
+++ b/internal/querynodev2/services_test.go
@@ -1091,6 +1091,7 @@ func (suite *ServiceSuite) TestSearch_Normal() {
 		Req:             creq,
 		FromShardLeader: false,
 		DmlChannels:     []string{suite.vchannel},
+		TotalChannelNum: 2,
 	}
 	suite.NoError(err)
 
@@ -1117,6 +1118,7 @@ func (suite *ServiceSuite) TestSearch_Concurrent() {
 				Req:             creq,
 				FromShardLeader: false,
 				DmlChannels:     []string{suite.vchannel},
+				TotalChannelNum: 2,
 			}
 			suite.NoError(err)
 			return suite.node.Search(ctx, req)
@@ -1142,6 +1144,7 @@ func (suite *ServiceSuite) TestSearch_Failed() {
 		Req:             creq,
 		FromShardLeader: false,
 		DmlChannels:     []string{suite.vchannel},
+		TotalChannelNum: 2,
 	}
 	suite.NoError(err)
 
@@ -1201,6 +1204,7 @@ func (suite *ServiceSuite) TestSearchSegments_Normal() {
 		Req:             creq,
 		FromShardLeader: true,
 		DmlChannels:     []string{suite.vchannel},
+		TotalChannelNum: 2,
 	}
 	suite.NoError(err)
 


### PR DESCRIPTION
Fix https://github.com/milvus-io/milvus/issues/26296
/kind bug
totalChannelNum will be used for estimating whole segment num to optimize search params