### PR TITLE
set sealed segment to unreadable before sync target version

### DIFF
--- a/internal/querynodev2/delegator/delegator_data_test.go
+++ b/internal/querynodev2/delegator/delegator_data_test.go
@@ -377,9 +377,10 @@ func (s *DelegatorDataSuite) TestLoadSegments() {
 		s.Equal(int64(1), sealed[0].NodeID)
 		s.ElementsMatch([]SegmentEntry{
 			{
-				SegmentID:   100,
-				NodeID:      1,
-				PartitionID: 500,
+				SegmentID:     100,
+				NodeID:        1,
+				PartitionID:   500,
+				TargetVersion: unreadableTargetVersion,
 			},
 		}, sealed[0].Segments)
 	})
@@ -453,14 +454,16 @@ func (s *DelegatorDataSuite) TestLoadSegments() {
 		s.Equal(int64(1), sealed[0].NodeID)
 		s.ElementsMatch([]SegmentEntry{
 			{
-				SegmentID:   100,
-				NodeID:      1,
-				PartitionID: 500,
+				SegmentID:     100,
+				NodeID:        1,
+				PartitionID:   500,
+				TargetVersion: unreadableTargetVersion,
 			},
 			{
-				SegmentID:   200,
-				NodeID:      1,
-				PartitionID: 500,
+				SegmentID:     200,
+				NodeID:        1,
+				PartitionID:   500,
+				TargetVersion: unreadableTargetVersion,
 			},
 		}, sealed[0].Segments)
 	})
@@ -657,9 +660,10 @@ func (s *DelegatorDataSuite) TestReleaseSegment() {
 	s.Equal(int64(1), sealed[0].NodeID)
 	s.ElementsMatch([]SegmentEntry{
 		{
-			SegmentID:   1000,
-			NodeID:      1,
-			PartitionID: 500,
+			SegmentID:     1000,
+			NodeID:        1,
+			PartitionID:   500,
+			TargetVersion: unreadableTargetVersion,
 		},
 	}, sealed[0].Segments)
 

--- a/internal/querynodev2/delegator/delegator_test.go
+++ b/internal/querynodev2/delegator/delegator_test.go
@@ -192,10 +192,11 @@ func (s *DelegatorSuite) TestGetSegmentInfo() {
 			NodeID: 1,
 			Segments: []SegmentEntry{
 				{
-					NodeID:      1,
-					SegmentID:   1001,
-					PartitionID: 500,
-					Version:     2001,
+					NodeID:        1,
+					SegmentID:     1001,
+					PartitionID:   500,
+					Version:       2001,
+					TargetVersion: unreadableTargetVersion,
 				},
 			},
 		},

--- a/internal/querynodev2/delegator/distribution.go
+++ b/internal/querynodev2/delegator/distribution.go
@@ -35,6 +35,9 @@ const (
 
 	// for growing segment which not exist in target, and it's start position < max sealed dml position
 	redundantTargetVersion = int64(-1)
+
+	// for sealed segment which loaded by load segment request, should become readable after sync target version
+	unreadableTargetVersion = int64(-2)
 )
 
 var (
@@ -186,6 +189,9 @@ func (d *distribution) AddDistributions(entries ...SegmentEntry) {
 		if ok {
 			// remain the target version for already loaded segment to void skipping this segment when executing search
 			entry.TargetVersion = oldEntry.TargetVersion
+		} else {
+			// waiting for sync target version, to become readable
+			entry.TargetVersion = unreadableTargetVersion
 		}
 		d.sealedSegments[entry.SegmentID] = entry
 		d.offlines.Remove(entry.SegmentID)

--- a/internal/querynodev2/delegator/distribution_test.go
+++ b/internal/querynodev2/delegator/distribution_test.go
@@ -64,12 +64,14 @@ func (s *DistributionSuite) TestAddDistribution() {
 					NodeID: 1,
 					Segments: []SegmentEntry{
 						{
-							NodeID:    1,
-							SegmentID: 1,
+							NodeID:        1,
+							SegmentID:     1,
+							TargetVersion: unreadableTargetVersion,
 						},
 						{
-							NodeID:    1,
-							SegmentID: 2,
+							NodeID:        1,
+							SegmentID:     2,
+							TargetVersion: unreadableTargetVersion,
 						},
 					},
 				},
@@ -93,8 +95,9 @@ func (s *DistributionSuite) TestAddDistribution() {
 					NodeID: 1,
 					Segments: []SegmentEntry{
 						{
-							NodeID:    1,
-							SegmentID: 1,
+							NodeID:        1,
+							SegmentID:     1,
+							TargetVersion: unreadableTargetVersion,
 						},
 					},
 				},
@@ -122,13 +125,15 @@ func (s *DistributionSuite) TestAddDistribution() {
 					NodeID: 1,
 					Segments: []SegmentEntry{
 						{
-							NodeID:    1,
-							SegmentID: 1,
+							NodeID:        1,
+							SegmentID:     1,
+							TargetVersion: unreadableTargetVersion,
 						},
 
 						{
-							NodeID:    1,
-							SegmentID: 3,
+							NodeID:        1,
+							SegmentID:     3,
+							TargetVersion: unreadableTargetVersion,
 						},
 					},
 				},
@@ -136,8 +141,9 @@ func (s *DistributionSuite) TestAddDistribution() {
 					NodeID: 2,
 					Segments: []SegmentEntry{
 						{
-							NodeID:    2,
-							SegmentID: 2,
+							NodeID:        2,
+							SegmentID:     2,
+							TargetVersion: unreadableTargetVersion,
 						},
 					},
 				},
@@ -157,8 +163,8 @@ func (s *DistributionSuite) TestAddDistribution() {
 				{
 					NodeID: 1,
 					Segments: []SegmentEntry{
-						{NodeID: 1, SegmentID: 1},
-						{NodeID: 1, SegmentID: 2},
+						{NodeID: 1, SegmentID: 1, TargetVersion: unreadableTargetVersion},
+						{NodeID: 1, SegmentID: 2, TargetVersion: unreadableTargetVersion},
 					},
 				},
 			},
@@ -287,13 +293,13 @@ func (s *DistributionSuite) TestRemoveDistribution() {
 				{
 					NodeID: 1,
 					Segments: []SegmentEntry{
-						{NodeID: 1, SegmentID: 3},
+						{NodeID: 1, SegmentID: 3, TargetVersion: unreadableTargetVersion},
 					},
 				},
 				{
 					NodeID: 2,
 					Segments: []SegmentEntry{
-						{NodeID: 2, SegmentID: 2},
+						{NodeID: 2, SegmentID: 2, TargetVersion: unreadableTargetVersion},
 					},
 				},
 			},
@@ -322,14 +328,14 @@ func (s *DistributionSuite) TestRemoveDistribution() {
 				{
 					NodeID: 1,
 					Segments: []SegmentEntry{
-						{NodeID: 1, SegmentID: 1},
-						{NodeID: 1, SegmentID: 3},
+						{NodeID: 1, SegmentID: 1, TargetVersion: unreadableTargetVersion},
+						{NodeID: 1, SegmentID: 3, TargetVersion: unreadableTargetVersion},
 					},
 				},
 				{
 					NodeID: 2,
 					Segments: []SegmentEntry{
-						{NodeID: 2, SegmentID: 2},
+						{NodeID: 2, SegmentID: 2, TargetVersion: unreadableTargetVersion},
 					},
 				},
 			},
@@ -358,13 +364,13 @@ func (s *DistributionSuite) TestRemoveDistribution() {
 				{
 					NodeID: 1,
 					Segments: []SegmentEntry{
-						{NodeID: 1, SegmentID: 3},
+						{NodeID: 1, SegmentID: 3, TargetVersion: unreadableTargetVersion},
 					},
 				},
 				{
 					NodeID: 2,
 					Segments: []SegmentEntry{
-						{NodeID: 2, SegmentID: 2},
+						{NodeID: 2, SegmentID: 2, TargetVersion: unreadableTargetVersion},
 					},
 				},
 			},
@@ -395,13 +401,21 @@ func (s *DistributionSuite) TestRemoveDistribution() {
 				{
 					NodeID: 1,
 					Segments: []SegmentEntry{
-						{NodeID: 1, SegmentID: 3},
+						{
+							NodeID:        1,
+							SegmentID:     3,
+							TargetVersion: unreadableTargetVersion,
+						},
 					},
 				},
 				{
 					NodeID: 2,
 					Segments: []SegmentEntry{
-						{NodeID: 2, SegmentID: 2},
+						{
+							NodeID:        2,
+							SegmentID:     2,
+							TargetVersion: unreadableTargetVersion,
+						},
 					},
 				},
 			},
@@ -476,12 +490,14 @@ func (s *DistributionSuite) TestPeek() {
 					NodeID: 1,
 					Segments: []SegmentEntry{
 						{
-							NodeID:    1,
-							SegmentID: 1,
+							NodeID:        1,
+							SegmentID:     1,
+							TargetVersion: unreadableTargetVersion,
 						},
 						{
-							NodeID:    1,
-							SegmentID: 2,
+							NodeID:        1,
+							SegmentID:     2,
+							TargetVersion: unreadableTargetVersion,
 						},
 					},
 				},
@@ -508,13 +524,15 @@ func (s *DistributionSuite) TestPeek() {
 					NodeID: 1,
 					Segments: []SegmentEntry{
 						{
-							NodeID:    1,
-							SegmentID: 1,
+							NodeID:        1,
+							SegmentID:     1,
+							TargetVersion: unreadableTargetVersion,
 						},
 
 						{
-							NodeID:    1,
-							SegmentID: 3,
+							NodeID:        1,
+							SegmentID:     3,
+							TargetVersion: unreadableTargetVersion,
 						},
 					},
 				},
@@ -522,8 +540,9 @@ func (s *DistributionSuite) TestPeek() {
 					NodeID: 2,
 					Segments: []SegmentEntry{
 						{
-							NodeID:    2,
-							SegmentID: 2,
+							NodeID:        2,
+							SegmentID:     2,
+							TargetVersion: unreadableTargetVersion,
 						},
 					},
 				},


### PR DESCRIPTION
Signed-off-by: Wei Liu <wei.liu@zilliz.com>
issue: #26249
 
 make sealed segment unreadable before sync target version