### PR TITLE
Add -g flag to compile with debug info

### DIFF
--- a/internal/core/CMakeLists.txt
+++ b/internal/core/CMakeLists.txt
@@ -46,6 +46,8 @@ else ()
     message(FATAL_ERROR "Unsupported platform!" )
 endif ()
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
+
 if (CMAKE_COMPILER_IS_GNUCC)
     if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 11.99)
         # ignore deprecated declarations for gcc>=12


### PR DESCRIPTION
/kind improvement
According to https://gcc.gnu.org/onlinedocs/gcc/Debugging-Options.html, this doesn't produce a slower program, just a larger program. It's hard to debug without stack