### PR TITLE
[Fixup] TsMsg context access data race when dispatch non-dml msg to multiple vchannel by msgdispatcher

### DIFF
--- a/internal/mq/msgstream/mqwrapper/rmq/rocksmq_msgstream_test.go
+++ b/internal/mq/msgstream/mqwrapper/rmq/rocksmq_msgstream_test.go
@@ -357,7 +357,6 @@ func TestStream_RmqTtMsgStream_Insert(t *testing.T) {
 }
 
 func TestStream_RmqTtMsgStream_DuplicatedIDs(t *testing.T) {
-
 	c1 := funcutil.RandomString(8)
 	producerChannels := []string{c1}
 	consumerChannels := []string{c1}
@@ -416,7 +415,6 @@ func TestStream_RmqTtMsgStream_DuplicatedIDs(t *testing.T) {
 }
 
 func TestStream_RmqTtMsgStream_Seek(t *testing.T) {
-
 	c1 := funcutil.RandomString(8)
 	producerChannels := []string{c1}
 	consumerChannels := []string{c1}
@@ -627,11 +625,6 @@ func getTimeTickMsgPack(reqID msgstream.UniqueID) *msgstream.MsgPack {
 func getTsMsg(msgType msgstream.MsgType, reqID msgstream.UniqueID) msgstream.TsMsg {
 	hashValue := uint32(reqID)
 	time := uint64(reqID)
-	baseMsg := msgstream.BaseMsg{
-		BeginTimestamp: 0,
-		EndTimestamp:   0,
-		HashValues:     []uint32{hashValue},
-	}
 	switch msgType {
 	case commonpb.MsgType_Insert:
 		insertRequest := msgpb.InsertRequest{
@@ -650,7 +643,11 @@ func getTsMsg(msgType msgstream.MsgType, reqID msgstream.UniqueID) msgstream.TsM
 			RowData:        []*commonpb.Blob{{}},
 		}
 		insertMsg := &msgstream.InsertMsg{
-			BaseMsg:       baseMsg,
+			BaseMsg: msgstream.BaseMsg{
+				BeginTimestamp: 0,
+				EndTimestamp:   0,
+				HashValues:     []uint32{hashValue},
+			},
 			InsertRequest: insertRequest,
 		}
 		return insertMsg
@@ -673,7 +670,11 @@ func getTsMsg(msgType msgstream.MsgType, reqID msgstream.UniqueID) msgstream.TsM
 			PhysicalChannelNames: []string{},
 		}
 		createCollectionMsg := &msgstream.CreateCollectionMsg{
-			BaseMsg:                 baseMsg,
+			BaseMsg: msgstream.BaseMsg{
+				BeginTimestamp: 0,
+				EndTimestamp:   0,
+				HashValues:     []uint32{hashValue},
+			},
 			CreateCollectionRequest: createCollectionRequest,
 		}
 		return createCollectionMsg
@@ -684,11 +685,6 @@ func getTsMsg(msgType msgstream.MsgType, reqID msgstream.UniqueID) msgstream.TsM
 func getTimeTickMsg(reqID msgstream.UniqueID) msgstream.TsMsg {
 	hashValue := uint32(reqID)
 	time := uint64(reqID)
-	baseMsg := msgstream.BaseMsg{
-		BeginTimestamp: 0,
-		EndTimestamp:   0,
-		HashValues:     []uint32{hashValue},
-	}
 	timeTickResult := msgpb.TimeTickMsg{
 		Base: &commonpb.MsgBase{
 			MsgType:   commonpb.MsgType_TimeTick,
@@ -698,7 +694,11 @@ func getTimeTickMsg(reqID msgstream.UniqueID) msgstream.TsMsg {
 		},
 	}
 	timeTickMsg := &msgstream.TimeTickMsg{
-		BaseMsg:     baseMsg,
+		BaseMsg: msgstream.BaseMsg{
+			BeginTimestamp: 0,
+			EndTimestamp:   0,
+			HashValues:     []uint32{hashValue},
+		},
 		TimeTickMsg: timeTickResult,
 	}
 	return timeTickMsg

--- a/internal/rootcoord/create_collection_task.go
+++ b/internal/rootcoord/create_collection_task.go
@@ -304,7 +304,7 @@ func (t *createCollectionTask) assignPartitionIDs() error {
 
 func (t *createCollectionTask) assignChannels() error {
 	vchanNames := make([]string, t.Req.GetShardsNum())
-	//physical channel names
+	// physical channel names
 	chanNames := t.core.chanTimeTick.getDmlChannelNames(int(t.Req.GetShardsNum()))
 
 	if int32(len(chanNames)) < t.Req.GetShardsNum() {
@@ -359,14 +359,13 @@ func (t *createCollectionTask) genCreateCollectionMsg(ctx context.Context) *ms.M
 	vChannels := t.channels.virtualChannels
 
 	msgPack := ms.MsgPack{}
-	baseMsg := ms.BaseMsg{
-		Ctx:            ctx,
-		BeginTimestamp: ts,
-		EndTimestamp:   ts,
-		HashValues:     []uint32{0},
-	}
 	msg := &ms.CreateCollectionMsg{
-		BaseMsg: baseMsg,
+		BaseMsg: ms.BaseMsg{
+			Ctx:            ctx,
+			BeginTimestamp: ts,
+			EndTimestamp:   ts,
+			HashValues:     []uint32{0},
+		},
 		CreateCollectionRequest: msgpb.CreateCollectionRequest{
 			Base: commonpbutil.NewMsgBase(
 				commonpbutil.WithMsgType(commonpb.MsgType_CreateCollection),

--- a/internal/rootcoord/garbage_collector.go
+++ b/internal/rootcoord/garbage_collector.go
@@ -166,14 +166,13 @@ func (c *bgGarbageCollector) notifyCollectionGc(ctx context.Context, coll *model
 	}
 
 	msgPack := ms.MsgPack{}
-	baseMsg := ms.BaseMsg{
-		Ctx:            ctx,
-		BeginTimestamp: ts,
-		EndTimestamp:   ts,
-		HashValues:     []uint32{0},
-	}
 	msg := &ms.DropCollectionMsg{
-		BaseMsg: baseMsg,
+		BaseMsg: ms.BaseMsg{
+			Ctx:            ctx,
+			BeginTimestamp: ts,
+			EndTimestamp:   ts,
+			HashValues:     []uint32{0},
+		},
 		DropCollectionRequest: msgpb.DropCollectionRequest{
 			Base: commonpbutil.NewMsgBase(
 				commonpbutil.WithMsgType(commonpb.MsgType_DropCollection),
@@ -199,14 +198,13 @@ func (c *bgGarbageCollector) notifyPartitionGc(ctx context.Context, pChannels []
 	}
 
 	msgPack := ms.MsgPack{}
-	baseMsg := ms.BaseMsg{
-		Ctx:            ctx,
-		BeginTimestamp: ts,
-		EndTimestamp:   ts,
-		HashValues:     []uint32{0},
-	}
 	msg := &ms.DropPartitionMsg{
-		BaseMsg: baseMsg,
+		BaseMsg: ms.BaseMsg{
+			Ctx:            ctx,
+			BeginTimestamp: ts,
+			EndTimestamp:   ts,
+			HashValues:     []uint32{0},
+		},
 		DropPartitionRequest: msgpb.DropPartitionRequest{
 			Base: commonpbutil.NewMsgBase(
 				commonpbutil.WithMsgType(commonpb.MsgType_DropPartition),

--- a/internal/rootcoord/timeticksync.go
+++ b/internal/rootcoord/timeticksync.go
@@ -58,7 +58,6 @@ func newTtHistogram() *ttHistogram {
 
 func (h *ttHistogram) update(channel string, ts Timestamp) {
 	h.Insert(channel, ts)
-
 }
 
 func (h *ttHistogram) get(channel string) Timestamp {
@@ -328,11 +327,6 @@ func (t *timetickSync) sendTimeTickToChannel(chanNames []string, ts typeutil.Tim
 	}()
 
 	msgPack := msgstream.MsgPack{}
-	baseMsg := msgstream.BaseMsg{
-		BeginTimestamp: ts,
-		EndTimestamp:   ts,
-		HashValues:     []uint32{0},
-	}
 	timeTickResult := msgpb.TimeTickMsg{
 		Base: commonpbutil.NewMsgBase(
 			commonpbutil.WithMsgType(commonpb.MsgType_TimeTick),
@@ -342,7 +336,11 @@ func (t *timetickSync) sendTimeTickToChannel(chanNames []string, ts typeutil.Tim
 		),
 	}
 	timeTickMsg := &msgstream.TimeTickMsg{
-		BaseMsg:     baseMsg,
+		BaseMsg: msgstream.BaseMsg{
+			BeginTimestamp: ts,
+			EndTimestamp:   ts,
+			HashValues:     []uint32{0},
+		},
 		TimeTickMsg: timeTickResult,
 	}
 	msgPack.Msgs = append(msgPack.Msgs, timeTickMsg)

--- a/internal/util/flowgraph/node_test.go
+++ b/internal/util/flowgraph/node_test.go
@@ -34,11 +34,7 @@ import (
 
 func generateMsgPack() msgstream.MsgPack {
 	msgPack := msgstream.MsgPack{}
-	baseMsg := msgstream.BaseMsg{
-		BeginTimestamp: uint64(time.Now().Unix()),
-		EndTimestamp:   uint64(time.Now().Unix() + 1),
-		HashValues:     []uint32{0},
-	}
+
 	timeTickResult := msgpb.TimeTickMsg{
 		Base: &commonpb.MsgBase{
 			MsgType:   commonpb.MsgType_TimeTick,
@@ -48,7 +44,11 @@ func generateMsgPack() msgstream.MsgPack {
 		},
 	}
 	timeTickMsg := &msgstream.TimeTickMsg{
-		BaseMsg:     baseMsg,
+		BaseMsg: msgstream.BaseMsg{
+			BeginTimestamp: uint64(time.Now().Unix()),
+			EndTimestamp:   uint64(time.Now().Unix() + 1),
+			HashValues:     []uint32{0},
+		},
 		TimeTickMsg: timeTickResult,
 	}
 	msgPack.Msgs = append(msgPack.Msgs, timeTickMsg)

--- a/pkg/mq/msgdispatcher/dispatcher.go
+++ b/pkg/mq/msgdispatcher/dispatcher.go
@@ -209,7 +209,7 @@ func (d *Dispatcher) work() {
 			targetPacks := d.groupingMsgs(pack)
 			for vchannel, p := range targetPacks {
 				var err error
-				var t = d.targets[vchannel]
+				t := d.targets[vchannel]
 				if d.isMain {
 					// for main dispatcher, split target if err occurs
 					err = t.send(p)
@@ -263,6 +263,8 @@ func (d *Dispatcher) groupingMsgs(pack *MsgPack) map[string]*MsgPack {
 			// for non-dml msg, such as CreateCollection, DropCollection, ...
 			// we need to dispatch it to all the vchannels.
 			for k := range targetPacks {
+				// TODO: There's data race when non-dml msg is sent to different flow graph.
+				// Wrong open-trancing information is generated, Fix in future.
 				targetPacks[k].Msgs = append(targetPacks[k].Msgs, msg)
 			}
 			continue

--- a/pkg/mq/msgstream/factory_stream_test.go
+++ b/pkg/mq/msgstream/factory_stream_test.go
@@ -89,12 +89,6 @@ func testInsertWithRepack(t *testing.T, f []Factory) {
 }
 
 func testInsertRepackFuncWithDifferentClient(t *testing.T, f []Factory) {
-	baseMsg := BaseMsg{
-		BeginTimestamp: 0,
-		EndTimestamp:   0,
-		HashValues:     []uint32{1, 3},
-	}
-
 	insertRequest := msgpb.InsertRequest{
 		Base: &commonpb.MsgBase{
 			MsgType:   commonpb.MsgType_Insert,
@@ -111,7 +105,11 @@ func testInsertRepackFuncWithDifferentClient(t *testing.T, f []Factory) {
 		RowData:        []*commonpb.Blob{{}, {}},
 	}
 	insertMsg := &InsertMsg{
-		BaseMsg:       baseMsg,
+		BaseMsg: BaseMsg{
+			BeginTimestamp: 0,
+			EndTimestamp:   0,
+			HashValues:     []uint32{1, 3},
+		},
 		InsertRequest: insertRequest,
 	}
 	msgPack := MsgPack{}
@@ -120,12 +118,6 @@ func testInsertRepackFuncWithDifferentClient(t *testing.T, f []Factory) {
 }
 
 func testDeleteRepackFuncWithDifferentClient(t *testing.T, f []Factory) {
-	baseMsg := BaseMsg{
-		BeginTimestamp: 0,
-		EndTimestamp:   0,
-		HashValues:     []uint32{1},
-	}
-
 	deleteRequest := msgpb.DeleteRequest{
 		Base: &commonpb.MsgBase{
 			MsgType:   commonpb.MsgType_Delete,
@@ -140,7 +132,11 @@ func testDeleteRepackFuncWithDifferentClient(t *testing.T, f []Factory) {
 		NumRows:          1,
 	}
 	deleteMsg := &DeleteMsg{
-		BaseMsg:       baseMsg,
+		BaseMsg: BaseMsg{
+			BeginTimestamp: 0,
+			EndTimestamp:   0,
+			HashValues:     []uint32{1},
+		},
 		DeleteRequest: deleteRequest,
 	}
 

--- a/pkg/mq/msgstream/mq_msgstream_test.go
+++ b/pkg/mq/msgstream/mq_msgstream_test.go
@@ -214,11 +214,6 @@ func TestStream_PulsarMsgStream_InsertRepackFunc(t *testing.T) {
 	producerChannels := []string{c1, c2}
 	consumerChannels := []string{c1, c2}
 	consumerSubName := funcutil.RandomString(8)
-	baseMsg := BaseMsg{
-		BeginTimestamp: 0,
-		EndTimestamp:   0,
-		HashValues:     []uint32{1, 3},
-	}
 
 	insertRequest := msgpb.InsertRequest{
 		Base: &commonpb.MsgBase{
@@ -236,7 +231,11 @@ func TestStream_PulsarMsgStream_InsertRepackFunc(t *testing.T) {
 		RowData:        []*commonpb.Blob{{}, {}},
 	}
 	insertMsg := &InsertMsg{
-		BaseMsg:       baseMsg,
+		BaseMsg: BaseMsg{
+			BeginTimestamp: 0,
+			EndTimestamp:   0,
+			HashValues:     []uint32{1, 3},
+		},
 		InsertRequest: insertRequest,
 	}
 
@@ -270,12 +269,6 @@ func TestStream_PulsarMsgStream_DeleteRepackFunc(t *testing.T) {
 	consumerChannels := []string{c1, c2}
 	consumerSubName := funcutil.RandomString(8)
 
-	baseMsg := BaseMsg{
-		BeginTimestamp: 0,
-		EndTimestamp:   0,
-		HashValues:     []uint32{1},
-	}
-
 	deleteRequest := msgpb.DeleteRequest{
 		Base: &commonpb.MsgBase{
 			MsgType:   commonpb.MsgType_Delete,
@@ -290,7 +283,11 @@ func TestStream_PulsarMsgStream_DeleteRepackFunc(t *testing.T) {
 		NumRows:          1,
 	}
 	deleteMsg := &DeleteMsg{
-		BaseMsg:       baseMsg,
+		BaseMsg: BaseMsg{
+			BeginTimestamp: 0,
+			EndTimestamp:   0,
+			HashValues:     []uint32{1},
+		},
 		DeleteRequest: deleteRequest,
 	}
 
@@ -901,7 +898,6 @@ func TestStream_MqMsgStream_Seek(t *testing.T) {
 		assert.Equal(t, result.Msgs[0].ID(), int64(i))
 	}
 	outputStream2.Close()
-
 }
 
 func TestStream_MqMsgStream_SeekInvalidMessage(t *testing.T) {
@@ -1129,11 +1125,6 @@ func repackFunc(msgs []TsMsg, hashKeys [][]int32) (map[int32]*MsgPack, error) {
 func getTsMsg(msgType MsgType, reqID UniqueID) TsMsg {
 	hashValue := uint32(reqID)
 	time := uint64(reqID)
-	baseMsg := BaseMsg{
-		BeginTimestamp: 0,
-		EndTimestamp:   0,
-		HashValues:     []uint32{hashValue},
-	}
 	switch msgType {
 	case commonpb.MsgType_Insert:
 		insertRequest := msgpb.InsertRequest{
@@ -1152,7 +1143,11 @@ func getTsMsg(msgType MsgType, reqID UniqueID) TsMsg {
 			RowData:        []*commonpb.Blob{{}},
 		}
 		insertMsg := &InsertMsg{
-			BaseMsg:       baseMsg,
+			BaseMsg: BaseMsg{
+				BeginTimestamp: 0,
+				EndTimestamp:   0,
+				HashValues:     []uint32{hashValue},
+			},
 			InsertRequest: insertRequest,
 		}
 		return insertMsg
@@ -1171,7 +1166,11 @@ func getTsMsg(msgType MsgType, reqID UniqueID) TsMsg {
 			NumRows:          1,
 		}
 		deleteMsg := &DeleteMsg{
-			BaseMsg:       baseMsg,
+			BaseMsg: BaseMsg{
+				BeginTimestamp: 0,
+				EndTimestamp:   0,
+				HashValues:     []uint32{hashValue},
+			},
 			DeleteRequest: deleteRequest,
 		}
 		return deleteMsg
@@ -1194,7 +1193,11 @@ func getTsMsg(msgType MsgType, reqID UniqueID) TsMsg {
 			PhysicalChannelNames: []string{},
 		}
 		createCollectionMsg := &CreateCollectionMsg{
-			BaseMsg:                 baseMsg,
+			BaseMsg: BaseMsg{
+				BeginTimestamp: 0,
+				EndTimestamp:   0,
+				HashValues:     []uint32{hashValue},
+			},
 			CreateCollectionRequest: createCollectionRequest,
 		}
 		return createCollectionMsg
@@ -1208,7 +1211,11 @@ func getTsMsg(msgType MsgType, reqID UniqueID) TsMsg {
 			},
 		}
 		timeTickMsg := &TimeTickMsg{
-			BaseMsg:     baseMsg,
+			BaseMsg: BaseMsg{
+				BeginTimestamp: 0,
+				EndTimestamp:   0,
+				HashValues:     []uint32{hashValue},
+			},
 			TimeTickMsg: timeTickResult,
 		}
 		return timeTickMsg
@@ -1219,11 +1226,6 @@ func getTsMsg(msgType MsgType, reqID UniqueID) TsMsg {
 func getTimeTickMsg(reqID UniqueID) TsMsg {
 	hashValue := uint32(reqID)
 	time := uint64(reqID)
-	baseMsg := BaseMsg{
-		BeginTimestamp: 0,
-		EndTimestamp:   0,
-		HashValues:     []uint32{hashValue},
-	}
 	timeTickResult := msgpb.TimeTickMsg{
 		Base: &commonpb.MsgBase{
 			MsgType:   commonpb.MsgType_TimeTick,
@@ -1233,7 +1235,11 @@ func getTimeTickMsg(reqID UniqueID) TsMsg {
 		},
 	}
 	timeTickMsg := &TimeTickMsg{
-		BaseMsg:     baseMsg,
+		BaseMsg: BaseMsg{
+			BeginTimestamp: 0,
+			EndTimestamp:   0,
+			HashValues:     []uint32{hashValue},
+		},
 		TimeTickMsg: timeTickResult,
 	}
 	return timeTickMsg
@@ -1249,7 +1255,7 @@ func getRandInsertMsgPack(num int, start int, end int) *MsgPack {
 		_, ok := set[reqID]
 		if !ok {
 			set[reqID] = true
-			msgPack.Msgs = append(msgPack.Msgs, getInsertMsgUniqueID(int64(reqID))) //getTsMsg(commonpb.MsgType_Insert, int64(reqID)))
+			msgPack.Msgs = append(msgPack.Msgs, getInsertMsgUniqueID(int64(reqID))) // getTsMsg(commonpb.MsgType_Insert, int64(reqID)))
 		}
 	}
 	return &msgPack
@@ -1258,7 +1264,7 @@ func getRandInsertMsgPack(num int, start int, end int) *MsgPack {
 func getInsertMsgPack(ts []int) *MsgPack {
 	msgPack := MsgPack{}
 	for i := 0; i < len(ts); i++ {
-		msgPack.Msgs = append(msgPack.Msgs, getInsertMsgUniqueID(int64(ts[i]))) //getTsMsg(commonpb.MsgType_Insert, int64(ts[i])))
+		msgPack.Msgs = append(msgPack.Msgs, getInsertMsgUniqueID(int64(ts[i]))) // getTsMsg(commonpb.MsgType_Insert, int64(ts[i])))
 	}
 	return &msgPack
 }
@@ -1268,11 +1274,6 @@ var idCounter atomic.Int64
 func getInsertMsgUniqueID(ts UniqueID) TsMsg {
 	hashValue := uint32(ts)
 	time := uint64(ts)
-	baseMsg := BaseMsg{
-		BeginTimestamp: 0,
-		EndTimestamp:   0,
-		HashValues:     []uint32{hashValue},
-	}
 
 	insertRequest := msgpb.InsertRequest{
 		Base: &commonpb.MsgBase{
@@ -1290,11 +1291,14 @@ func getInsertMsgUniqueID(ts UniqueID) TsMsg {
 		RowData:        []*commonpb.Blob{{}},
 	}
 	insertMsg := &InsertMsg{
-		BaseMsg:       baseMsg,
+		BaseMsg: BaseMsg{
+			BeginTimestamp: 0,
+			EndTimestamp:   0,
+			HashValues:     []uint32{hashValue},
+		},
 		InsertRequest: insertRequest,
 	}
 	return insertMsg
-
 }
 
 func getTimeTickMsgPack(reqID UniqueID) *MsgPack {

--- a/pkg/mq/msgstream/mqwrapper/nmq/nmq_consumer.go
+++ b/pkg/mq/msgstream/mqwrapper/nmq/nmq_consumer.go
@@ -121,8 +121,11 @@ func (nc *Consumer) Ack(message mqwrapper.Message) {
 // Close is used to free the resources of this consumer
 func (nc *Consumer) Close() {
 	nc.closeOnce.Do(func() {
+		if nc.sub == nil {
+			return
+		}
 		if err := nc.sub.Unsubscribe(); err != nil {
-			log.Warn("failed to unsubscribe subscription of nmq", zap.String("topic", nc.topic))
+			log.Warn("failed to unsubscribe subscription of nmq", zap.String("topic", nc.topic), zap.Error(err))
 		}
 		close(nc.closeChan)
 		nc.wg.Wait()

--- a/pkg/mq/msgstream/mqwrapper/nmq/nmq_producer.go
+++ b/pkg/mq/msgstream/mqwrapper/nmq/nmq_producer.go
@@ -56,7 +56,7 @@ func (np *nmqProducer) Send(ctx context.Context, message *mqwrapper.ProducerMess
 	}
 
 	// publish to nats-server
-	pa, err := np.js.PublishMsg(msg)
+	pa, err := np.js.PublishMsg(msg, nats.Context(ctx))
 	if err != nil {
 		metrics.MsgStreamOpCounter.WithLabelValues(metrics.SendMsgLabel, metrics.FailLabel).Inc()
 		log.Warn("failed to publish message by nmq", zap.String("topic", np.topic), zap.Error(err), zap.Int("payload_size", len(message.Payload)))


### PR DESCRIPTION
related issue: #26421

- fix data race.
- add error log and context for nats.