### PR TITLE
fix CollectionNotExist on describe rg

### DIFF
--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -2211,11 +2211,16 @@ func (t *DescribeResourceGroupTask) Execute(ctx context.Context) error {
 	getCollectionName := func(collections map[int64]int32) (map[string]int32, error) {
 		ret := make(map[string]int32)
 		for key, value := range collections {
-			name, err := globalMetaCache.GetCollectionName(ctx, GetCurDBNameFromContextOrDefault(ctx), key)
+			name, err := globalMetaCache.GetCollectionName(ctx, "", key)
 			if err != nil {
 				log.Warn("failed to get collection name",
 					zap.Int64("collectionID", key),
 					zap.Error(err))
+
+				// if collection has been dropped, skip it
+				if common.IsCollectionNotExistError(err) {
+					continue
+				}
 				return nil, err
 			}
 			ret[name] = value

--- a/internal/proxy/task_test.go
+++ b/internal/proxy/task_test.go
@@ -3115,7 +3115,9 @@ func TestDescribeResourceGroupTaskFailed(t *testing.T) {
 		},
 	}, nil)
 	err = task.Execute(ctx)
-	assert.Error(t, err)
+	assert.NoError(t, err)
+	assert.Len(t, task.result.ResourceGroup.NumOutgoingNode, 0)
+	assert.Len(t, task.result.ResourceGroup.NumIncomingNode, 0)
 }
 
 func TestCreateCollectionTaskWithPartitionKey(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Wei Liu <wei.liu@zilliz.com>

issue: #26494 

for now, describe rg will show collection name which loaded in rg, but due to collection list diff between qc and rc. if we can't    get collection name from rc, we regard it as dropped. and skip this collection in rg info