### PR TITLE
fix proxy to querynode heartbeat failed counter logic

### DIFF
--- a/internal/proxy/look_aside_balancer_test.go
+++ b/internal/proxy/look_aside_balancer_test.go
@@ -323,6 +323,11 @@ func (suite *LookAsideBalancerSuite) TestCheckHealthLoop() {
 	suite.ErrorIs(err, merr.ErrServiceUnavailable)
 	suite.Equal(int64(-1), targetNode)
 
+	suite.balancer.UpdateCostMetrics(1, &internalpb.CostAggregation{})
+	suite.Eventually(func() bool {
+		return !suite.balancer.unreachableQueryNodes.Contain(1)
+	}, 3*time.Second, 100*time.Millisecond)
+
 	suite.Eventually(func() bool {
 		return !suite.balancer.unreachableQueryNodes.Contain(2)
 	}, 5*time.Second, 100*time.Millisecond)


### PR DESCRIPTION
Signed-off-by: Wei Liu <wei.liu@zilliz.com>

issue:#25558

old behavior: proxy to qn's heartbeat got 3 failures, make it unserviceable.
new behavior: proxy to qn's heartbeat  got 3 consecutive failures, make it unserviceable.