### PR TITLE
Fill trailing '\0' for c metrics value

### DIFF
--- a/internal/core/src/segcore/metrics_c.cpp
+++ b/internal/core/src/segcore/metrics_c.cpp
@@ -20,5 +20,6 @@ GetKnowhereMetrics() {
     auto len = str.length();
     char* res = (char*)malloc(len + 1);
     memcpy(res, str.data(), len);
+    res[len] = '\0';
     return res;
 }


### PR DESCRIPTION
See also #26576 
/kind bug