### PR TITLE
Remove invalid offset check while filling data

### DIFF
--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -469,9 +469,7 @@ SegmentGrowingImpl::bulk_subscript_impl(const VectorBase* vec_raw,
     auto output = reinterpret_cast<T*>(output_raw);
     for (int64_t i = 0; i < count; ++i) {
         auto offset = seg_offsets[i];
-        if (offset != INVALID_SEG_OFFSET) {
-            output[i] = vec[offset];
-        }
+        output[i] = vec[offset];
     }
 }
 

--- a/internal/core/src/segcore/SegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/SegmentSealedImpl.cpp
@@ -739,9 +739,7 @@ SegmentSealedImpl::bulk_subscript_impl(const void* src_raw,
 
     for (int64_t i = 0; i < count; ++i) {
         auto offset = seg_offsets[i];
-        if (offset != INVALID_SEG_OFFSET) {
-            dst[i] = src[offset];
-        }
+        dst[i] = src[offset];
     }
 }
 
@@ -755,9 +753,7 @@ SegmentSealedImpl::bulk_subscript_impl(const ColumnBase* column,
     auto dst = reinterpret_cast<T*>(dst_raw);
     for (int64_t i = 0; i < count; ++i) {
         auto offset = seg_offsets[i];
-        if (offset != INVALID_SEG_OFFSET) {
-            dst[i] = std::move(T(field->RawAt(offset)));
-        }
+        dst[i] = std::move(T(field->RawAt(offset)));
     }
 }
 
@@ -772,13 +768,8 @@ SegmentSealedImpl::bulk_subscript_impl(int64_t element_sizeof,
     auto dst_vec = reinterpret_cast<char*>(dst_raw);
     for (int64_t i = 0; i < count; ++i) {
         auto offset = seg_offsets[i];
+        auto src = src_vec + element_sizeof * offset;
         auto dst = dst_vec + i * element_sizeof;
-        const char* src = (offset == INVALID_SEG_OFFSET
-                               ? nullptr
-                               : (src_vec + element_sizeof * offset));
-        if (!src) {
-            continue;
-        }
         memcpy(dst, src, element_sizeof);
     }
 }


### PR DESCRIPTION
/kind improvement
There are 3 paths to filling data:
- reduce
- retrieve
- growing index

- for reduce, we have filtered out the invalid offsets
- for retrieve, the results never contain invalid offset
- for growing index, this directly interacts with Knowhere, so we keep the check

this makes it possible to enable SIMD for compiler while filling scalar data