### PR TITLE
Add rate limit ratio monitoring

### DIFF
--- a/internal/rootcoord/quota_center.go
+++ b/internal/rootcoord/quota_center.go
@@ -456,6 +456,7 @@ func (q *QuotaCenter) calculateWriteRates() error {
 	updateCollectionFactor(growingSegFactors)
 
 	for collection, factor := range collectionFactors {
+		metrics.RootCoordRateLimitRatio.WithLabelValues(fmt.Sprint(collection)).Set(1 - factor)
 		if factor <= 0 {
 			if _, ok := ttFactors[collection]; ok && factor == ttFactors[collection] {
 				// factor comes from ttFactor

--- a/pkg/metrics/rootcoord_metrics.go
+++ b/pkg/metrics/rootcoord_metrics.go
@@ -169,6 +169,15 @@ var (
 			"quota_states",
 		})
 
+	// RootCoordRateLimitRatio reflects the ratio of rate limit.
+	RootCoordRateLimitRatio = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.RootCoordRole,
+			Name:      "rate_limit_ratio",
+			Help:      "",
+		}, []string{collectionIDLabelName})
+
 	RootCoordDDLReqLatencyInQueue = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: milvusNamespace,
@@ -208,5 +217,6 @@ func RegisterRootCoord(registry *prometheus.Registry) {
 	registry.MustRegister(RootCoordNumOfRoles)
 	registry.MustRegister(RootCoordTtDelay)
 	registry.MustRegister(RootCoordQuotaStates)
+	registry.MustRegister(RootCoordRateLimitRatio)
 	registry.MustRegister(RootCoordDDLReqLatencyInQueue)
 }


### PR DESCRIPTION
/kind improvement

From 0 to 1, the greater the value, the stronger the rate is limited. For instance, 0 denotes no backpressure, while 1 denotes deny writing.
![fadkaU6Es8](https://github.com/milvus-io/milvus/assets/42060877/deaacbe4-6423-4737-8a5b-738c2f540b9d)
