### PR TITLE
Remove merr mask logic

### DIFF
--- a/internal/distributed/proxy/httpserver/handler_v1.go
+++ b/internal/distributed/proxy/httpserver/handler_v1.go
@@ -47,7 +47,7 @@ func (h *Handlers) checkDatabase(c *gin.Context, dbName string) bool {
 		c.AbortWithStatusJSON(http.StatusOK, gin.H{HTTPReturnCode: Code(err), HTTPReturnMessage: err.Error()})
 		return false
 	} else if response.Status.ErrorCode != commonpb.ErrorCode_Success {
-		c.AbortWithStatusJSON(http.StatusOK, gin.H{HTTPReturnCode: code(int32(response.Status.ErrorCode)), HTTPReturnMessage: response.Status.Reason})
+		c.AbortWithStatusJSON(http.StatusOK, gin.H{HTTPReturnCode: int32(response.Status.ErrorCode), HTTPReturnMessage: response.Status.Reason})
 		return false
 	}
 	for _, db := range response.DbNames {
@@ -74,7 +74,7 @@ func (h *Handlers) describeCollection(c *gin.Context, dbName string, collectionN
 		c.AbortWithStatusJSON(http.StatusOK, gin.H{HTTPReturnCode: Code(err), HTTPReturnMessage: err.Error()})
 		return nil, err
 	} else if response.Status.ErrorCode != commonpb.ErrorCode_Success {
-		c.AbortWithStatusJSON(http.StatusOK, gin.H{HTTPReturnCode: code(int32(response.Status.ErrorCode)), HTTPReturnMessage: response.Status.Reason})
+		c.AbortWithStatusJSON(http.StatusOK, gin.H{HTTPReturnCode: int32(response.Status.ErrorCode), HTTPReturnMessage: response.Status.Reason})
 		return nil, errors.New(response.Status.Reason)
 	}
 	primaryField, ok := getPrimaryField(response.Schema)
@@ -95,7 +95,7 @@ func (h *Handlers) hasCollection(c *gin.Context, dbName string, collectionName s
 		c.AbortWithStatusJSON(http.StatusOK, gin.H{HTTPReturnCode: Code(err), HTTPReturnMessage: err.Error()})
 		return false, err
 	} else if response.Status.ErrorCode != commonpb.ErrorCode_Success {
-		c.AbortWithStatusJSON(http.StatusOK, gin.H{HTTPReturnCode: code(int32(response.Status.ErrorCode)), HTTPReturnMessage: response.Status.Reason})
+		c.AbortWithStatusJSON(http.StatusOK, gin.H{HTTPReturnCode: int32(response.Status.ErrorCode), HTTPReturnMessage: response.Status.Reason})
 		return false, errors.New(response.Status.Reason)
 	} else {
 		return response.Value, nil
@@ -129,7 +129,7 @@ func (h *Handlers) listCollections(c *gin.Context) {
 	if err != nil {
 		c.JSON(http.StatusOK, gin.H{HTTPReturnCode: Code(err), HTTPReturnMessage: err.Error()})
 	} else if response.Status.ErrorCode != commonpb.ErrorCode_Success {
-		c.JSON(http.StatusOK, gin.H{HTTPReturnCode: code(int32(response.Status.ErrorCode)), HTTPReturnMessage: response.Status.Reason})
+		c.JSON(http.StatusOK, gin.H{HTTPReturnCode: int32(response.Status.ErrorCode), HTTPReturnMessage: response.Status.Reason})
 	} else {
 		var collections []string
 		if response.CollectionNames != nil {
@@ -208,7 +208,7 @@ func (h *Handlers) createCollection(c *gin.Context) {
 		c.AbortWithStatusJSON(http.StatusOK, gin.H{HTTPReturnCode: Code(err), HTTPReturnMessage: err.Error()})
 		return
 	} else if response.ErrorCode != commonpb.ErrorCode_Success {
-		c.AbortWithStatusJSON(http.StatusOK, gin.H{HTTPReturnCode: code(int32(response.ErrorCode)), HTTPReturnMessage: response.Reason})
+		c.AbortWithStatusJSON(http.StatusOK, gin.H{HTTPReturnCode: int32(response.ErrorCode), HTTPReturnMessage: response.Reason})
 		return
 	}
 
@@ -223,7 +223,7 @@ func (h *Handlers) createCollection(c *gin.Context) {
 		c.AbortWithStatusJSON(http.StatusOK, gin.H{HTTPReturnCode: Code(err), HTTPReturnMessage: err.Error()})
 		return
 	} else if response.ErrorCode != commonpb.ErrorCode_Success {
-		c.AbortWithStatusJSON(http.StatusOK, gin.H{HTTPReturnCode: code(int32(response.ErrorCode)), HTTPReturnMessage: response.Reason})
+		c.AbortWithStatusJSON(http.StatusOK, gin.H{HTTPReturnCode: int32(response.ErrorCode), HTTPReturnMessage: response.Reason})
 		return
 	}
 	response, err = h.proxy.LoadCollection(c, &milvuspb.LoadCollectionRequest{
@@ -234,7 +234,7 @@ func (h *Handlers) createCollection(c *gin.Context) {
 		c.AbortWithStatusJSON(http.StatusOK, gin.H{HTTPReturnCode: Code(err), HTTPReturnMessage: err.Error()})
 		return
 	} else if response.ErrorCode != commonpb.ErrorCode_Success {
-		c.AbortWithStatusJSON(http.StatusOK, gin.H{HTTPReturnCode: code(int32(response.ErrorCode)), HTTPReturnMessage: response.Reason})
+		c.AbortWithStatusJSON(http.StatusOK, gin.H{HTTPReturnCode: int32(response.ErrorCode), HTTPReturnMessage: response.Reason})
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{HTTPReturnCode: http.StatusOK, HTTPReturnData: gin.H{}})
@@ -336,7 +336,7 @@ func (h *Handlers) dropCollection(c *gin.Context) {
 	if err != nil {
 		c.JSON(http.StatusOK, gin.H{HTTPReturnCode: Code(err), HTTPReturnMessage: err.Error()})
 	} else if response.ErrorCode != commonpb.ErrorCode_Success {
-		c.JSON(http.StatusOK, gin.H{HTTPReturnCode: code(int32(response.ErrorCode)), HTTPReturnMessage: response.Reason})
+		c.JSON(http.StatusOK, gin.H{HTTPReturnCode: int32(response.ErrorCode), HTTPReturnMessage: response.Reason})
 	} else {
 		c.JSON(http.StatusOK, gin.H{HTTPReturnCode: http.StatusOK, HTTPReturnData: gin.H{}})
 	}
@@ -382,7 +382,7 @@ func (h *Handlers) query(c *gin.Context) {
 	if err != nil {
 		c.JSON(http.StatusOK, gin.H{HTTPReturnCode: Code(err), HTTPReturnMessage: err.Error()})
 	} else if response.Status.ErrorCode != commonpb.ErrorCode_Success {
-		c.JSON(http.StatusOK, gin.H{HTTPReturnCode: code(int32(response.Status.ErrorCode)), HTTPReturnMessage: response.Status.Reason})
+		c.JSON(http.StatusOK, gin.H{HTTPReturnCode: int32(response.Status.ErrorCode), HTTPReturnMessage: response.Status.Reason})
 	} else {
 		outputData, err := buildQueryResp(int64(0), response.OutputFields, response.FieldsData, nil, nil)
 		if err != nil {
@@ -436,7 +436,7 @@ func (h *Handlers) get(c *gin.Context) {
 	if err != nil {
 		c.JSON(http.StatusOK, gin.H{HTTPReturnCode: Code(err), HTTPReturnMessage: err.Error()})
 	} else if response.Status.ErrorCode != commonpb.ErrorCode_Success {
-		c.JSON(http.StatusOK, gin.H{HTTPReturnCode: code(int32(response.Status.ErrorCode)), HTTPReturnMessage: response.Status.Reason})
+		c.JSON(http.StatusOK, gin.H{HTTPReturnCode: int32(response.Status.ErrorCode), HTTPReturnMessage: response.Status.Reason})
 	} else {
 		outputData, err := buildQueryResp(int64(0), response.OutputFields, response.FieldsData, nil, nil)
 		if err != nil {
@@ -488,7 +488,7 @@ func (h *Handlers) delete(c *gin.Context) {
 	if err != nil {
 		c.JSON(http.StatusOK, gin.H{HTTPReturnCode: Code(err), HTTPReturnMessage: err.Error()})
 	} else if response.Status.ErrorCode != commonpb.ErrorCode_Success {
-		c.JSON(http.StatusOK, gin.H{HTTPReturnCode: code(int32(response.Status.ErrorCode)), HTTPReturnMessage: response.Status.Reason})
+		c.JSON(http.StatusOK, gin.H{HTTPReturnCode: int32(response.Status.ErrorCode), HTTPReturnMessage: response.Status.Reason})
 	} else {
 		c.JSON(http.StatusOK, gin.H{HTTPReturnCode: http.StatusOK, HTTPReturnData: gin.H{}})
 	}
@@ -549,7 +549,7 @@ func (h *Handlers) insert(c *gin.Context) {
 	if err != nil {
 		c.JSON(http.StatusOK, gin.H{HTTPReturnCode: Code(err), HTTPReturnMessage: err.Error()})
 	} else if response.Status.ErrorCode != commonpb.ErrorCode_Success {
-		c.JSON(http.StatusOK, gin.H{HTTPReturnCode: code(int32(response.Status.ErrorCode)), HTTPReturnMessage: response.Status.Reason})
+		c.JSON(http.StatusOK, gin.H{HTTPReturnCode: int32(response.Status.ErrorCode), HTTPReturnMessage: response.Status.Reason})
 	} else {
 		switch response.IDs.GetIdField().(type) {
 		case *schemapb.IDs_IntId:
@@ -608,7 +608,7 @@ func (h *Handlers) search(c *gin.Context) {
 	if err != nil {
 		c.JSON(http.StatusOK, gin.H{HTTPReturnCode: Code(err), HTTPReturnMessage: err.Error()})
 	} else if response.Status.ErrorCode != commonpb.ErrorCode_Success {
-		c.JSON(http.StatusOK, gin.H{HTTPReturnCode: code(int32(response.Status.ErrorCode)), HTTPReturnMessage: response.Status.Reason})
+		c.JSON(http.StatusOK, gin.H{HTTPReturnCode: int32(response.Status.ErrorCode), HTTPReturnMessage: response.Status.Reason})
 	} else {
 		if response.Results.TopK == int64(0) {
 			c.JSON(http.StatusOK, gin.H{HTTPReturnCode: http.StatusOK, HTTPReturnData: []interface{}{}})

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -859,10 +859,7 @@ func buildQueryResp(rowsNum int64, needFields []string, fieldDataList []*schemap
 }
 
 // --------------------- error code --------------------- //
-func code(code int32) int32 {
-	return code & merr.RootReasonCodeMask
-}
 
 func Code(err error) int32 {
-	return code(merr.Code(err))
+	return merr.Code(err)
 }

--- a/pkg/util/merr/errors.go
+++ b/pkg/util/merr/errors.go
@@ -19,27 +19,12 @@ package merr
 import (
 	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
-
-	"github.com/milvus-io/milvus/pkg/util/paramtable"
-	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
 
 const (
-	rootCoordBits = (iota + 1) << 16
-	dataCoordBits
-	queryCoordBits
-	dataNodeBits
-	queryNodeBits
-	indexNodeBits
-	proxyBits
-	standaloneBits
-	embededBits
-
-	retriableFlag      = 1 << 20
-	RootReasonCodeMask = (1 << 16) - 1
-
-	CanceledCode int32 = 10000
-	TimeoutCode  int32 = 10001
+	retriableFlag       = 1 << 16
+	CanceledCode  int32 = 10000
+	TimeoutCode   int32 = 10001
 )
 
 // Define leaf errors here,
@@ -143,30 +128,6 @@ var (
 	errUnexpected = newMilvusError("unexpected error", (1<<16)-1, false)
 )
 
-func maskComponentBits(code int32) int32 {
-	switch paramtable.GetRole() {
-	case typeutil.RootCoordRole:
-		return code | rootCoordBits
-	case typeutil.DataCoordRole:
-		return code | dataCoordBits
-	case typeutil.QueryCoordRole:
-		return code | queryCoordBits
-	case typeutil.DataNodeRole:
-		return code | dataNodeBits
-	case typeutil.QueryNodeRole:
-		return code | queryNodeBits
-	case typeutil.IndexNodeRole:
-		return code | indexNodeBits
-	case typeutil.ProxyRole:
-		return code | proxyBits
-	case typeutil.StandaloneRole:
-		return code | standaloneBits
-	case typeutil.EmbeddedRole:
-		return code | embededBits
-	}
-	return code
-}
-
 type milvusError struct {
 	msg     string
 	errCode int32
@@ -183,7 +144,7 @@ func newMilvusError(msg string, code int32, retriable bool) milvusError {
 }
 
 func (e milvusError) code() int32 {
-	return maskComponentBits(e.errCode)
+	return e.errCode
 }
 
 func (e milvusError) Error() string {


### PR DESCRIPTION
/kind improvement
if resp.status.code do mask with component, then can not compare it with the origin error. In the same time, the mask logic is of no use at present, so remove it. 