### PR TITLE
Refactor storage.MergeInsertData() to optimize data merge

### DIFF
--- a/internal/datanode/flow_graph_insert_buffer_node.go
+++ b/internal/datanode/flow_graph_insert_buffer_node.go
@@ -604,7 +604,7 @@ func (ibNode *insertBufferNode) bufferInsertMsg(msg *msgstream.InsertMsg, startP
 	}
 
 	// Maybe there are large write zoom if frequent insert requests are met.
-	buffer.buffer = storage.MergeInsertData(buffer.buffer, addedBuffer)
+	storage.MergeInsertData(buffer.buffer, addedBuffer)
 
 	tsData, err := storage.GetTimestampFromInsertData(addedBuffer)
 	if err != nil {

--- a/internal/storage/utils.go
+++ b/internal/storage/utils.go
@@ -731,23 +731,23 @@ func MergeFieldData(data *InsertData, fid FieldID, field FieldData) {
 	}
 }
 
-// MergeInsertData merge insert datas. Maybe there are large write zoom if frequent inserts are met.
-func MergeInsertData(datas ...*InsertData) *InsertData {
-	ret := &InsertData{
-		Data:  make(map[FieldID]FieldData),
-		Infos: nil,
+// MergeInsertData append the insert datas to the original buffer.
+func MergeInsertData(buffer *InsertData, datas ...*InsertData) {
+	if buffer == nil {
+		log.Warn("Attempt to merge data into a nil buffer, skip the data merge.")
+		return
 	}
+
 	for _, data := range datas {
 		if data != nil {
 			for fid, field := range data.Data {
-				MergeFieldData(ret, fid, field)
+				MergeFieldData(buffer, fid, field)
 			}
 
 			// TODO: handle storage.InsertData.Infos
-			ret.Infos = append(ret.Infos, data.Infos...)
+			buffer.Infos = append(buffer.Infos, data.Infos...)
 		}
 	}
-	return ret
 }
 
 // TODO: string type.

--- a/internal/storage/utils_test.go
+++ b/internal/storage/utils_test.go
@@ -1034,62 +1034,62 @@ func TestMergeInsertData(t *testing.T) {
 		Infos: nil,
 	}
 
-	merged := MergeInsertData(d1, d2)
+	MergeInsertData(d1, d2)
 
-	f, ok := merged.Data[common.RowIDField]
+	f, ok := d1.Data[common.RowIDField]
 	assert.True(t, ok)
 	assert.Equal(t, []int64{1, 2}, f.(*Int64FieldData).Data)
 
-	f, ok = merged.Data[common.TimeStampField]
+	f, ok = d1.Data[common.TimeStampField]
 	assert.True(t, ok)
 	assert.Equal(t, []int64{1, 2}, f.(*Int64FieldData).Data)
 
-	f, ok = merged.Data[BoolField]
+	f, ok = d1.Data[BoolField]
 	assert.True(t, ok)
 	assert.Equal(t, []bool{true, false}, f.(*BoolFieldData).Data)
 
-	f, ok = merged.Data[Int8Field]
+	f, ok = d1.Data[Int8Field]
 	assert.True(t, ok)
 	assert.Equal(t, []int8{1, 2}, f.(*Int8FieldData).Data)
 
-	f, ok = merged.Data[Int16Field]
+	f, ok = d1.Data[Int16Field]
 	assert.True(t, ok)
 	assert.Equal(t, []int16{1, 2}, f.(*Int16FieldData).Data)
 
-	f, ok = merged.Data[Int32Field]
+	f, ok = d1.Data[Int32Field]
 	assert.True(t, ok)
 	assert.Equal(t, []int32{1, 2}, f.(*Int32FieldData).Data)
 
-	f, ok = merged.Data[Int64Field]
+	f, ok = d1.Data[Int64Field]
 	assert.True(t, ok)
 	assert.Equal(t, []int64{1, 2}, f.(*Int64FieldData).Data)
 
-	f, ok = merged.Data[FloatField]
+	f, ok = d1.Data[FloatField]
 	assert.True(t, ok)
 	assert.Equal(t, []float32{0, 0}, f.(*FloatFieldData).Data)
 
-	f, ok = merged.Data[DoubleField]
+	f, ok = d1.Data[DoubleField]
 	assert.True(t, ok)
 	assert.Equal(t, []float64{0, 0}, f.(*DoubleFieldData).Data)
 
-	f, ok = merged.Data[StringField]
+	f, ok = d1.Data[StringField]
 	assert.True(t, ok)
 	assert.Equal(t, []string{"1", "2"}, f.(*StringFieldData).Data)
 
-	f, ok = merged.Data[BinaryVectorField]
+	f, ok = d1.Data[BinaryVectorField]
 	assert.True(t, ok)
 	assert.Equal(t, []byte{0, 0}, f.(*BinaryVectorFieldData).Data)
 
-	f, ok = merged.Data[FloatVectorField]
+	f, ok = d1.Data[FloatVectorField]
 	assert.True(t, ok)
 	assert.Equal(t, []float32{0, 0}, f.(*FloatVectorFieldData).Data)
 
-	f, ok = merged.Data[ArrayField]
+	f, ok = d1.Data[ArrayField]
 	assert.True(t, ok)
 	assert.Equal(t, []int32{1, 2, 3}, f.(*ArrayFieldData).Data[0].GetIntData().GetData())
 	assert.Equal(t, []int32{4, 5, 6}, f.(*ArrayFieldData).Data[1].GetIntData().GetData())
 
-	f, ok = merged.Data[JSONField]
+	f, ok = d1.Data[JSONField]
 	assert.True(t, ok)
 	assert.EqualValues(t, [][]byte{[]byte(`{"key":"value"}`), []byte(`{"hello":"world"}`)}, f.(*JSONFieldData).Data)
 }


### PR DESCRIPTION
Benchmark Milvus with https://github.com/qdrant/vector-db-benchmark and specify the datasets as 'deep-image-96-angular'. Meanwhile, do perf profiling during 'upload + index' stage of vector-db-benchmark and see the following hot spots.

```
39.59%--github.com/milvus-io/milvus/internal/storage.MergeInsertData
        |
        |--21.43%--github.com/milvus-io/milvus/internal/storage.MergeFieldData
        |          |
        |          |--17.22%--runtime.memmove
        |                     |
        |                     |--1.53%--asm_exc_page_fault
        |                     ......
        |
        |--18.16%--runtime.memmove
                   |
                   |--1.66%--asm_exc_page_fault
                   ......
```

The hot code path is in storage.MergeInsertData() which updates buffer.buffer by creating a new 'InsertData' instance and merging both the old buffer.buffer and addedBuffer into it. When it calls golang runtime.memmove to move buffer.buffer which is with big size (>1M), the hot spots appear.

To avoid the above overhead, update storage.MergeInsertData() by appending addedBuffer to buffer.buffer, instead of moving buffer.buffer and addedBuffer to a new 'InsertData'. This change removes the hot spots 'runtime.memmove' from perf profiling output. Additionally, the 'upload + index' time, which is one performance metric of vector-db-benchmark, is reduced around 60% with this change.

issue #26838