### PR TITLE
[test]Fix occasional FileExistsError triggered when concurrently executing pytest

### DIFF
--- a/tests/python_client/config/log_config.py
+++ b/tests/python_client/config/log_config.py
@@ -1,5 +1,5 @@
 import os
-import datetime
+from pathlib import Path
 
 class LogConfig:
     def __init__(self):
@@ -23,10 +23,10 @@ class LogConfig:
 
     @staticmethod
     def create_path(log_path):
-        if not os.path.isdir(str(log_path)):
-            print("[create_path] folder(%s) is not exist." % log_path)
-            print("[create_path] create path now...")
-            os.makedirs(log_path)
+        print("[create_path] folder(%s) is not exist." % log_path)
+        print("[create_path] create path now...")
+        folder_path = Path(str(log_path))
+        folder_path.mkdir(parents=True, exist_ok=True)
 
     def get_default_config(self):
         """ Make sure the path exists """


### PR DESCRIPTION


/kind improvement
/assign @yanliang567 

Try to fix 
```
 [get_env_variable] failed to get environment variables : 'CI_LOG_PATH', use default path : /tmp/ci_logs
 [create_path] folder(/tmp/ci_logs) is not exist.
 [create_path] create path now...
 ImportError while loading conftest '/home/jenkins/agent/workspace/tests/python_client/conftest.py'.
 ../conftest.py:8: in <module>
     import common.common_func as cf
 ../common/common_func.py:17: in <module>
     from base.schema_wrapper import ApiCollectionSchemaWrapper, ApiFieldSchemaWrapper
 ../base/schema_wrapper.py:4: in <module>
     from check.func_check import ResponseChecker
 ../check/func_check.py:4: in <module>
     from utils.util_log import test_log as log
 ../utils/util_log.py:4: in <module>
     from config.log_config import log_config
 ../config/log_config.py:44: in <module>
     log_config = LogConfig()
 ../config/log_config.py:10: in __init__
     self.get_default_config()
 ../config/log_config.py:41: in get_default_config
     self.create_path(log_dir)
 ../config/log_config.py:29: in create_path
     os.makedirs(log_path)
 /usr/lib/python3.8/os.py:223: in makedirs
     mkdir(name, mode)
 E   FileExistsError: [Errno 17] File exists: '/tmp/ci_logs'
```