### PR TITLE
Refine delegator lifetime control

### DIFF
--- a/pkg/util/lifetime/lifetime.go
+++ b/pkg/util/lifetime/lifetime.go
@@ -23,6 +23,7 @@ import (
 
 // Lifetime interface for lifetime control.
 type Lifetime[T any] interface {
+	SafeChan
 	// SetState is the method to change lifetime state.
 	SetState(state T)
 	// GetState returns current state.
@@ -43,13 +44,15 @@ var _ Lifetime[any] = (*lifetime[any])(nil)
 // NewLifetime returns a new instance of Lifetime with init state and isHealthy logic.
 func NewLifetime[T any](initState T) Lifetime[T] {
 	return &lifetime[T]{
-		state: initState,
+		safeChan: newSafeChan(),
+		state:    initState,
 	}
 }
 
 // lifetime implementation of Lifetime.
 // users shall not care about the internal fields of this struct.
 type lifetime[T any] struct {
+	*safeChan
 	// wg is used for keeping record each running task.
 	wg sync.WaitGroup
 	// state is the "atomic" value to store component state.

--- a/pkg/util/lifetime/safe_chan.go
+++ b/pkg/util/lifetime/safe_chan.go
@@ -1,0 +1,45 @@
+package lifetime
+
+import (
+	"sync"
+
+	"github.com/milvus-io/milvus/pkg/util/typeutil"
+)
+
+// SafeChan is the utility type combining chan struct{} & sync.Once.
+// It provides double close protection internally.
+type SafeChan interface {
+	IsClosed() bool
+	CloseCh() <-chan struct{}
+	Close()
+}
+
+type safeChan struct {
+	closed chan struct{}
+	once   sync.Once
+}
+
+// NewSafeChan returns a SafeChan with internal channel initialized
+func NewSafeChan() SafeChan {
+	return newSafeChan()
+}
+
+func newSafeChan() *safeChan {
+	return &safeChan{
+		closed: make(chan struct{}),
+	}
+}
+
+func (sc *safeChan) CloseCh() <-chan struct{} {
+	return sc.closed
+}
+
+func (sc *safeChan) IsClosed() bool {
+	return typeutil.IsChanClosed(sc.closed)
+}
+
+func (sc *safeChan) Close() {
+	sc.once.Do(func() {
+		close(sc.closed)
+	})
+}

--- a/pkg/util/lifetime/safe_chan_test.go
+++ b/pkg/util/lifetime/safe_chan_test.go
@@ -1,0 +1,37 @@
+package lifetime
+
+import (
+	"testing"
+
+	"github.com/milvus-io/milvus/pkg/util/typeutil"
+	"github.com/stretchr/testify/suite"
+)
+
+type SafeChanSuite struct {
+	suite.Suite
+}
+
+func (s *SafeChanSuite) TestClose() {
+	sc := NewSafeChan()
+
+	s.False(sc.IsClosed(), "IsClosed() shall return false before Close()")
+	s.False(typeutil.IsChanClosed(sc.CloseCh()), "CloseCh() returned channel shall not be closed before Close()")
+
+	s.NotPanics(func() {
+		sc.Close()
+	}, "SafeChan shall not panic during first close")
+
+	s.True(sc.IsClosed(), "IsClosed() shall return true after Close()")
+	s.True(typeutil.IsChanClosed(sc.CloseCh()), "CloseCh() returned channel shall be closed after Close()")
+
+	s.NotPanics(func() {
+		sc.Close()
+	}, "SafeChan shall not panic during second close")
+
+	s.True(sc.IsClosed(), "IsClosed() shall return true after double Close()")
+	s.True(typeutil.IsChanClosed(sc.CloseCh()), "CloseCh() returned channel shall be still closed after double Close()")
+}
+
+func TestSafeChan(t *testing.T) {
+	suite.Run(t, new(SafeChanSuite))
+}

--- a/pkg/util/typeutil/chan.go
+++ b/pkg/util/typeutil/chan.go
@@ -1,0 +1,12 @@
+package typeutil
+
+// IsChanClosed returns whether input signal channel is closed or not.
+// this method accept `chan struct{}` type only in case of passing msg channels by mistake.
+func IsChanClosed(ch <-chan struct{}) bool {
+	select {
+	case <-ch:
+		return true
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
- Add SafeChan interface in lifetime package
- Embed SafeChan into `lifetime.Lifetime` interface
- Replace private lifetime struct in delegator package with `lifetime.Lifetime`
- Refine delegator on-going task lifetime control and wait all accepted task done
- Fix potential goroutine leakage from `waitTSafe` if delegator closed concurrently

/kind improvement