### PR TITLE
Refine querynode scheduler lifetime

### DIFF
--- a/internal/querynodev2/delegator/delegator_test.go
+++ b/internal/querynodev2/delegator/delegator_test.go
@@ -1050,14 +1050,14 @@ func TestDelegatorWatchTsafe(t *testing.T) {
 	sd := &shardDelegator{
 		tsafeManager: tsafeManager,
 		vchannelName: channelName,
-		lifetime:     lifetime.NewLifetime(initializing),
+		lifetime:     lifetime.NewLifetime(lifetime.Initializing),
 		latestTsafe:  atomic.NewUint64(0),
 	}
 	defer sd.Close()
 
 	m := sync.Mutex{}
 	sd.tsCond = sync.NewCond(&m)
-	if sd.lifetime.Add(notStopped) {
+	if sd.lifetime.Add(lifetime.NotStopped) {
 		go sd.watchTSafe()
 	}
 
@@ -1077,7 +1077,7 @@ func TestDelegatorTSafeListenerClosed(t *testing.T) {
 	sd := &shardDelegator{
 		tsafeManager: tsafeManager,
 		vchannelName: channelName,
-		lifetime:     lifetime.NewLifetime(initializing),
+		lifetime:     lifetime.NewLifetime(lifetime.Initializing),
 		latestTsafe:  atomic.NewUint64(0),
 	}
 	defer sd.Close()
@@ -1085,7 +1085,7 @@ func TestDelegatorTSafeListenerClosed(t *testing.T) {
 	m := sync.Mutex{}
 	sd.tsCond = sync.NewCond(&m)
 	signal := make(chan struct{})
-	if sd.lifetime.Add(notStopped) {
+	if sd.lifetime.Add(lifetime.NotStopped) {
 		go func() {
 			sd.watchTSafe()
 			close(signal)

--- a/internal/querynodev2/server.go
+++ b/internal/querynodev2/server.go
@@ -388,7 +388,7 @@ func (node *QueryNode) Init() error {
 // Start mainly start QueryNode's query service.
 func (node *QueryNode) Start() error {
 	node.startOnce.Do(func() {
-		node.scheduler.Start(node.ctx)
+		node.scheduler.Start()
 
 		paramtable.SetCreateTime(time.Now())
 		paramtable.SetUpdateTime(time.Now())
@@ -452,6 +452,9 @@ func (node *QueryNode) Stop() error {
 		node.UpdateStateCode(commonpb.StateCode_Abnormal)
 		node.lifetime.Wait()
 		node.cancel()
+		if node.scheduler != nil {
+			node.scheduler.Stop()
+		}
 		if node.pipelineManager != nil {
 			node.pipelineManager.Close()
 		}

--- a/internal/querynodev2/tasks/concurrent_safe_scheduler_test.go
+++ b/internal/querynodev2/tasks/concurrent_safe_scheduler_test.go
@@ -21,12 +21,31 @@ func TestScheduler(t *testing.T) {
 	t.Run("fifo", func(t *testing.T) {
 		testScheduler(t, newFIFOPolicy())
 	})
+	t.Run("scheduler_not_working", func(t *testing.T) {
+		scheduler := newScheduler(newFIFOPolicy())
+
+		task := newMockTask(mockTaskConfig{
+			nq:          1,
+			executeCost: 10 * time.Millisecond,
+			execution: func(ctx context.Context) error {
+				return nil
+			},
+		})
+
+		err := scheduler.Add(task)
+		assert.Error(t, err)
+
+		scheduler.Stop()
+
+		err = scheduler.Add(task)
+		assert.Error(t, err)
+	})
 }
 
 func testScheduler(t *testing.T, policy schedulePolicy) {
 	// start a new scheduler
 	scheduler := newScheduler(policy)
-	go scheduler.Start(context.Background())
+	scheduler.Start()
 
 	var cnt atomic.Int32
 	n := 100

--- a/internal/querynodev2/tasks/tasks.go
+++ b/internal/querynodev2/tasks/tasks.go
@@ -1,9 +1,5 @@
 package tasks
 
-import (
-	"context"
-)
-
 const (
 	schedulePolicyNameFIFO            = "fifo"
 	schedulePolicyNameUserTaskPolling = "user-task-polling"
@@ -44,9 +40,12 @@ type Scheduler interface {
 	Add(task Task) error
 
 	// Start schedule the owned task asynchronously and continuously.
-	// 1. Stop processing until ctx.Cancel() is called.
-	// 2. Only call once.
-	Start(ctx context.Context)
+	// Shall be called only once
+	Start()
+
+	// Stop make scheduler deny all incoming tasks
+	// and cleans up all related resources
+	Stop()
 
 	// GetWaitingTaskTotalNQ
 	GetWaitingTaskTotalNQ() int64

--- a/pkg/util/lifetime/state.go
+++ b/pkg/util/lifetime/state.go
@@ -1,0 +1,45 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lifetime
+
+// Singal alias for chan struct{}.
+type Signal chan struct{}
+
+// BiState provides pre-defined simple binary state - normal or closed.
+type BiState int32
+
+const (
+	Normal BiState = 0
+	Closed BiState = 1
+)
+
+// State provides pre-defined three stage state.
+type State int32
+
+const (
+	Initializing State = iota
+	Working
+	Stopped
+)
+
+func NotStopped(state State) bool {
+	return state != Stopped
+}
+
+func IsWorking(state State) bool {
+	return state == Working
+}


### PR DESCRIPTION
This PR refines scheduler lifetime control:
- Move private tri-state into lifetime package
- Make scheduler block incoming "Add" task
- Make scheduler Stop wait until all previously accepted task done

/kind improvement