### PR TITLE
[test]Refine health checker in test

### DIFF
--- a/tests/python_client/chaos/chaos_commons.py
+++ b/tests/python_client/chaos/chaos_commons.py
@@ -37,10 +37,22 @@ def gen_experiment_config(yaml):
 
 def start_monitor_threads(checkers={}):
     """start the threads by checkers"""
+    tasks = []
     for k, ch in checkers.items():
         ch._keep_running = True
         t = threading.Thread(target=ch.keep_running, args=(), name=k, daemon=True)
         t.start()
+        tasks.append(t)
+    return tasks
+
+
+def check_thread_status(tasks):
+    """check the status of all threads"""
+    for t in tasks:
+        if t.is_alive():
+            log.info(f"thread {t.name} is still running")
+        else:
+            log.info(f"thread {t.name} is not running")
 
 
 def get_env_variable_by_name(name):

--- a/tests/python_client/chaos/testcases/test_single_request_operation.py
+++ b/tests/python_client/chaos/testcases/test_single_request_operation.py
@@ -82,7 +82,7 @@ class TestOperations(TestBase):
         event_records.insert("init_health_checkers", "start")
         self.init_health_checkers(collection_name=c_name)
         event_records.insert("init_health_checkers", "finished")
-        cc.start_monitor_threads(self.health_checkers)
+        tasks = cc.start_monitor_threads(self.health_checkers)
         log.info("*********************Load Start**********************")
         # wait request_duration
         request_duration = request_duration.replace("h", "*3600+").replace("m", "*60+").replace("s", "")
@@ -102,6 +102,7 @@ class TestOperations(TestBase):
         # wait all pod ready
         wait_pods_ready(self.milvus_ns, f"app.kubernetes.io/instance={self.release_name}")
         time.sleep(60)
+        cc.check_thread_status(tasks)
         for k, v in self.health_checkers.items():
             v.pause()
         ra = ResultAnalyzer()


### PR DESCRIPTION
The following features have been added:
1. check if the health checker thread is still running before the end of the test.
2. add collection pool for drop checker, create the collection that needs to be dropped in advance, to avoid the need to create collection for drop operation in chaos.


/kind improvement
/assign @yanliang567 