### PR TITLE
Discard SyncDistribution set action from legacy querycoord

### DIFF
--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -469,7 +469,7 @@ func (loader *segmentLoader) LoadBloomFilterSet(ctx context.Context, collectionI
 	log := log.Ctx(ctx).With(
 		zap.Int64("collectionID", collectionID),
 		zap.Int64s("segmentIDs", lo.Map(infos, func(info *querypb.SegmentLoadInfo, _ int) int64 {
-			return info.SegmentID
+			return info.GetSegmentID()
 		})),
 	)
 

--- a/internal/querynodev2/services.go
+++ b/internal/querynodev2/services.go
@@ -1376,6 +1376,10 @@ func (node *QueryNode) SyncDistribution(ctx context.Context, req *querypb.SyncDi
 		case querypb.SyncType_Remove:
 			removeActions = append(removeActions, action)
 		case querypb.SyncType_Set:
+			if action.GetInfo() == nil {
+				log.Warn("sync request from legacy querycoord without load info, skip")
+				continue
+			}
 			addSegments[action.GetNodeID()] = append(addSegments[action.GetNodeID()], action.GetInfo())
 		case querypb.SyncType_UpdateVersion:
 			pipeline := node.pipelineManager.Get(req.GetChannel())

--- a/internal/querynodev2/services_test.go
+++ b/internal/querynodev2/services_test.go
@@ -1758,7 +1758,7 @@ func (suite *ServiceSuite) TestSyncDistribution_Normal() {
 	req.Actions = []*querypb.SyncAction{releaseAction, setAction}
 	status, err := suite.node.SyncDistribution(ctx, req)
 	suite.NoError(err)
-	suite.Equal(commonpb.ErrorCode_UnexpectedError, status.ErrorCode)
+	suite.Equal(commonpb.ErrorCode_Success, status.ErrorCode)
 
 	syncVersionAction := &querypb.SyncAction{
 		Type:            querypb.SyncType_UpdateVersion,


### PR DESCRIPTION
Since Milvus in lower version (< 2.3.0), there is no load info in set action
which may corrupt data integrity and cause panicking
Discard legacy in querynodev2 to prevent this from happening

/kind improvement