### PR TITLE
Fix grpcclient may return double nil for service call

### DIFF
--- a/internal/util/grpcclient/client.go
+++ b/internal/util/grpcclient/client.go
@@ -405,7 +405,7 @@ func (c *ClientBase[T]) call(ctx context.Context, caller func(client T) (any, er
 	defer cancel()
 	_ = retry.Do(innerCtx, func() error {
 		if generic.IsZero(client) {
-			callErr = errors.Wrap(clientErr, "empty grpc client")
+			callErr = errors.Wrap(ErrConnect, "empty grpc client")
 			log.Warn("grpc client is nil, maybe fail to get client in the retry state")
 			resetClientFunc()
 			return callErr


### PR DESCRIPTION
Related to #27041
/kind improvement
See modified line, if `clientErr` is nil, the wrapped error will be nil as well