### PR TITLE
Add Binaryset struct

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ INSTALL_PATH := $(PWD)/bin
 LIBRARY_PATH := $(PWD)/lib
 OS := $(shell uname -s)
 mode = Release
-disk_index = OFF
+disk_index = ON
 useasan = false
 ifeq (${USE_ASAN}, true)
 useasan = true

--- a/internal/core/src/common/BinarySet.h
+++ b/internal/core/src/common/BinarySet.h
@@ -1,0 +1,93 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <string>
+#include <map>
+#include <vector>
+#include "knowhere/index_sequence.h"
+namespace milvus {
+
+typedef knowhere::IndexSequence Binary;
+typedef uint8_t* BianryValuePtr;
+class BinarySet {
+ public:
+    BinarySet() = default;
+
+    const size_t
+    GetBinarySetSize() {
+        return binary_map_.size();
+    }
+
+    const std::vector<std::string>
+    GetBinarySetAllKeys() const {
+        std::vector<std::string> keys;
+        keys.reserve(binary_map_.size());
+        for (auto& kv : binary_map_) {
+            keys.push_back(kv.first);
+        }
+        return keys;
+    }
+
+    const BianryValuePtr
+    GetBinaryPtrByName(const std::string& name) const {
+        if (Contains(name)) {
+            auto& index_seq = binary_map_.at(name);
+            return index_seq.GetSeq();
+        }
+        return nullptr;
+    }
+
+    size_t
+    GetBinarySizeByName(const std::string& name) const {
+        if (Contains(name)) {
+            auto& index_seq = binary_map_.at(name);
+            return index_seq.GetSize();
+        }
+        return 0;
+    }
+
+    void
+    Append(const std::string& name, Binary&& binary) {
+        binary_map_[name] = std::move(binary);
+    }
+
+    Binary
+    Erase(const std::string& name) {
+        auto it = binary_map_.find(name);
+        if (it != binary_map_.end()) {
+            auto result = std::move(it->second);
+            binary_map_.erase(it);
+            return std::move(result);
+        } else {
+            return Binary(nullptr, 0);
+        }
+    }
+
+    void
+    clear() {
+        binary_map_.clear();
+    }
+
+    bool
+    Contains(const std::string& key) const {
+        return binary_map_.find(key) != binary_map_.end();
+    }
+
+ private:
+    std::map<std::string, Binary> binary_map_;
+};
+}  // namespace milvus

--- a/internal/core/src/common/Channel.h
+++ b/internal/core/src/common/Channel.h
@@ -1,3 +1,14 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+
 #include <oneapi/tbb/concurrent_queue.h>
 
 #include <atomic>

--- a/internal/core/src/common/Slice.cpp
+++ b/internal/core/src/common/Slice.cpp
@@ -27,7 +27,8 @@ GenSlicedFileName(const std::string& prefix, size_t slice_num) {
 
 void
 Slice(const std::string& prefix,
-      const BinaryPtr& data_src,
+      const BianryValuePtr& data_src,
+      const size_t data_size,
       const int64_t slice_len,
       BinarySet& binarySet,
       Config& ret) {
@@ -36,43 +37,44 @@ Slice(const std::string& prefix,
     }
 
     int slice_num = 0;
-    for (int64_t i = 0; i < data_src->size; ++slice_num) {
-        int64_t ri = std::min(i + slice_len, data_src->size);
+    for (int64_t i = 0; i < data_size; ++slice_num) {
+        int64_t ri = std::min(i + slice_len, (int64_t)data_size);
         auto size = static_cast<size_t>(ri - i);
-        auto slice_i = std::shared_ptr<uint8_t[]>(new uint8_t[size]);
-        memcpy(slice_i.get(), data_src->data.get() + i, size);
-        binarySet.Append(GenSlicedFileName(prefix, slice_num), slice_i, ri - i);
+        auto slice_i = std::unique_ptr<uint8_t[]>(new uint8_t[size]);
+        memcpy(slice_i.get(), data_src + i, size);
+        binarySet.Append(GenSlicedFileName(prefix, slice_num),
+                         Binary(std::move(slice_i), ri - i));
         i = ri;
     }
     ret[NAME] = prefix;
     ret[SLICE_NUM] = slice_num;
-    ret[TOTAL_LEN] = data_src->size;
+    ret[TOTAL_LEN] = data_size;
 }
 
 void
 Assemble(BinarySet& binarySet) {
     auto slice_meta = EraseSliceMeta(binarySet);
-    if (slice_meta == nullptr) {
+    if (slice_meta.GetSeq() == nullptr) {
         return;
     }
 
     Config meta_data = Config::parse(std::string(
-        reinterpret_cast<char*>(slice_meta->data.get()), slice_meta->size));
+        reinterpret_cast<char*>(slice_meta.GetSeq()), slice_meta.GetSize()));
 
     for (auto& item : meta_data[META]) {
         std::string prefix = item[NAME];
         int slice_num = item[SLICE_NUM];
         auto total_len = static_cast<size_t>(item[TOTAL_LEN]);
-        auto p_data = std::shared_ptr<uint8_t[]>(new uint8_t[total_len]);
+        auto p_data = std::unique_ptr<uint8_t[]>(new uint8_t[total_len]);
         int64_t pos = 0;
         for (auto i = 0; i < slice_num; ++i) {
             auto slice_i_sp = binarySet.Erase(GenSlicedFileName(prefix, i));
             memcpy(p_data.get() + pos,
-                   slice_i_sp->data.get(),
-                   static_cast<size_t>(slice_i_sp->size));
-            pos += slice_i_sp->size;
+                   slice_i_sp.GetSeq(),
+                   static_cast<size_t>(slice_i_sp.GetSize()));
+            pos += slice_i_sp.GetSize();
         }
-        binarySet.Append(prefix, p_data, total_len);
+        binarySet.Append(prefix, Binary(std::move(p_data), total_len));
     }
 }
 
@@ -80,23 +82,29 @@ void
 Disassemble(BinarySet& binarySet) {
     Config meta_info;
     auto slice_meta = EraseSliceMeta(binarySet);
-    if (slice_meta != nullptr) {
-        Config last_meta_data = Config::parse(std::string(
-            reinterpret_cast<char*>(slice_meta->data.get()), slice_meta->size));
+    if (slice_meta.GetSeq() != nullptr) {
+        Config last_meta_data = Config::parse(
+            std::string(reinterpret_cast<char*>(slice_meta.GetSeq()),
+                        slice_meta.GetSize()));
         for (auto& item : last_meta_data[META]) {
             meta_info[META].emplace_back(item);
         }
     }
 
+    auto all_keys_list = binarySet.GetBinarySetAllKeys();
     std::vector<std::string> slice_key_list;
-    for (auto& kv : binarySet.binary_map_) {
-        if (kv.second->size > FILE_SLICE_SIZE) {
-            slice_key_list.push_back(kv.first);
+    for (auto& key : all_keys_list) {
+        if (binarySet.GetBinarySizeByName(key) > FILE_SLICE_SIZE) {
+            slice_key_list.push_back(key);
         }
     }
     for (auto& key : slice_key_list) {
         Config slice_i;
-        Slice(key, binarySet.Erase(key), FILE_SLICE_SIZE, binarySet, slice_i);
+        auto binary = binarySet.Erase(key);
+        auto binary_ptr = binary.GetSeq();
+        auto binary_size = binary.GetSize();
+        Slice(
+            key, binary_ptr, binary_size, FILE_SLICE_SIZE, binarySet, slice_i);
         meta_info[META].emplace_back(slice_i);
     }
     if (!slice_key_list.empty()) {
@@ -108,13 +116,14 @@ void
 AppendSliceMeta(BinarySet& binarySet, const Config& meta_info) {
     auto meta_str = meta_info.dump();
     auto meta_len = meta_str.length();
-    std::shared_ptr<uint8_t[]> meta_data(new uint8_t[meta_len + 1]);
+    std::unique_ptr<uint8_t[]> meta_data(new uint8_t[meta_len + 1]);
     memcpy(meta_data.get(), meta_str.data(), meta_len);
     meta_data[meta_len] = 0;
-    binarySet.Append(INDEX_FILE_SLICE_META, meta_data, meta_len + 1);
+    binarySet.Append(INDEX_FILE_SLICE_META,
+                     Binary(std::move(meta_data), meta_len + 1));
 }
 
-BinaryPtr
+Binary
 EraseSliceMeta(BinarySet& binarySet) {
     return binarySet.Erase(INDEX_FILE_SLICE_META);
 }

--- a/internal/core/src/common/Slice.h
+++ b/internal/core/src/common/Slice.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "common/Types.h"
+#include "binary_set_c.h"
 
 namespace milvus {
 
@@ -39,7 +40,7 @@ Disassemble(BinarySet& binarySet);
 void
 AppendSliceMeta(BinarySet& binarySet, const Config& meta_info);
 
-BinaryPtr
+Binary
 EraseSliceMeta(BinarySet& binarySet);
 
 }  // namespace milvus

--- a/internal/core/src/common/Types.h
+++ b/internal/core/src/common/Types.h
@@ -35,9 +35,10 @@
 #include <variant>
 #include <vector>
 
-#include "knowhere/binaryset.h"
 #include "knowhere/comp/index_param.h"
+#include "knowhere/index_sequence.h"
 #include "knowhere/dataset.h"
+#include "BinarySet.h"
 #include "simdjson.h"
 #include "pb/plan.pb.h"
 #include "pb/schema.pb.h"
@@ -160,8 +161,7 @@ using Config = nlohmann::json;
 using TargetBitmap = FixedVector<bool>;
 using TargetBitmapPtr = std::unique_ptr<TargetBitmap>;
 
-using BinaryPtr = knowhere::BinaryPtr;
-using BinarySet = knowhere::BinarySet;
+using BinaryPtr = void*;
 using Dataset = knowhere::DataSet;
 using DatasetPtr = knowhere::DataSetPtr;
 using MetricType = knowhere::MetricType;

--- a/internal/core/src/common/Utils.h
+++ b/internal/core/src/common/Utils.h
@@ -193,7 +193,7 @@ KnowhereStatusString(knowhere::Status status) {
             return "malloc error";
         case knowhere::Status::diskann_inner_error:
             return "diskann inner error";
-        case knowhere::Status::diskann_file_error:
+        case knowhere::Status::disk_file_error:
             return "diskann file error";
         case knowhere::Status::invalid_value_in_json:
             return "invalid value in json";
@@ -201,8 +201,8 @@ KnowhereStatusString(knowhere::Status status) {
             return "arithmetic overflow";
         case knowhere::Status::raft_inner_error:
             return "raft inner error";
-        case knowhere::Status::invalid_binary_set:
-            return "invalid binary set";
+        case knowhere::Status::invalid_index_sequence:
+            return "invalid index binary sequence";
         default:
             return "unexpected status";
     }

--- a/internal/core/src/common/binary_set_c.h
+++ b/internal/core/src/common/binary_set_c.h
@@ -24,7 +24,6 @@ extern "C" {
 #include "common/type_c.h"
 
 typedef void* CBinarySet;
-
 CStatus
 NewBinarySet(CBinarySet* c_binary_set);
 

--- a/internal/core/src/index/ScalarIndexSort-inl.h
+++ b/internal/core/src/index/ScalarIndexSort-inl.h
@@ -106,16 +106,18 @@ ScalarIndexSort<T>::Serialize(const Config& config) {
     AssertInfo(is_built_, "index has not been built");
 
     auto index_data_size = data_.size() * sizeof(IndexStructure<T>);
-    std::shared_ptr<uint8_t[]> index_data(new uint8_t[index_data_size]);
+    std::unique_ptr<uint8_t[]> index_data(new uint8_t[index_data_size]);
     memcpy(index_data.get(), data_.data(), index_data_size);
 
-    std::shared_ptr<uint8_t[]> index_length(new uint8_t[sizeof(size_t)]);
+    std::unique_ptr<uint8_t[]> index_length(new uint8_t[sizeof(size_t)]);
     auto index_size = data_.size();
     memcpy(index_length.get(), &index_size, sizeof(size_t));
 
     BinarySet res_set;
-    res_set.Append("index_data", index_data, index_data_size);
-    res_set.Append("index_length", index_length, sizeof(size_t));
+    res_set.Append("index_data",
+                   Binary(std::move(index_data), index_data_size));
+    res_set.Append("index_length",
+                   Binary(std::move(index_length), sizeof(size_t)));
 
     milvus::Disassemble(res_set);
 
@@ -131,7 +133,7 @@ ScalarIndexSort<T>::Upload(const Config& config) {
     auto remote_paths_to_size = file_manager_->GetRemotePathsToFileSize();
     BinarySet ret;
     for (auto& file : remote_paths_to_size) {
-        ret.Append(file.first, nullptr, file.second);
+        ret.Append(file.first, Binary(nullptr, file.second));
     }
 
     return ret;
@@ -142,13 +144,15 @@ inline void
 ScalarIndexSort<T>::LoadWithoutAssemble(const BinarySet& index_binary,
                                         const Config& config) {
     size_t index_size;
-    auto index_length = index_binary.GetByName("index_length");
-    memcpy(&index_size, index_length->data.get(), (size_t)index_length->size);
+    auto index_length_ptr = index_binary.GetBinaryPtrByName("index_length");
+    auto index_length_size = index_binary.GetBinarySizeByName("index_length");
+    memcpy(&index_size, index_length_ptr, (size_t)index_length_size);
 
-    auto index_data = index_binary.GetByName("index_data");
+    auto index_data_ptr = index_binary.GetBinaryPtrByName("index_data");
+    auto index_data_size = index_binary.GetBinarySizeByName("index_data");
     data_.resize(index_size);
     idx_to_offsets_.resize(index_size);
-    memcpy(data_.data(), index_data->data.get(), (size_t)index_data->size);
+    memcpy(data_.data(), index_data_ptr, (size_t)index_data_size);
     for (size_t i = 0; i < data_.size(); ++i) {
         idx_to_offsets_[data_[i].idx_] = i;
     }
@@ -174,10 +178,9 @@ ScalarIndexSort<T>::Load(const Config& config) {
     BinarySet binary_set;
     for (auto& [key, data] : index_datas) {
         auto size = data->Size();
-        auto deleter = [&](uint8_t*) {};  // avoid repeated deconstruction
-        auto buf = std::shared_ptr<uint8_t[]>(
-            (uint8_t*)const_cast<void*>(data->Data()), deleter);
-        binary_set.Append(key, buf, size);
+        auto buf = std::unique_ptr<uint8_t[]>(
+            (uint8_t*)const_cast<void*>(data->Data()));
+        binary_set.Append(key, Binary(std::move(buf), size));
     }
 
     LoadWithoutAssemble(binary_set, config);

--- a/internal/core/src/index/VectorDiskIndex.cpp
+++ b/internal/core/src/index/VectorDiskIndex.cpp
@@ -54,10 +54,11 @@ VectorDiskAnnIndex<T>::VectorDiskAnnIndex(
     }
 
     local_chunk_manager->CreateDir(local_index_path_prefix);
+    auto version = knowhere::Version::GetCurrentVersion().VersionCode();
     auto diskann_index_pack =
         knowhere::Pack(std::shared_ptr<knowhere::FileManager>(file_manager));
-    index_ = knowhere::IndexFactory::Instance().Create(GetIndexType(),
-                                                       diskann_index_pack);
+    index_ = knowhere::IndexFactory::Instance().Create(
+        GetIndexType(), version, diskann_index_pack);
 }
 
 template <typename T>
@@ -78,7 +79,7 @@ VectorDiskAnnIndex<T>::Load(const Config& config) {
                "index file paths is empty when load disk ann index data");
     file_manager_->CacheIndexToDisk(index_files.value());
 
-    auto stat = index_.Deserialize(knowhere::BinarySet(), load_config);
+    auto stat = index_.Deserialize(knowhere::IndexSequence(), load_config);
     if (stat != knowhere::Status::success)
         PanicCodeInfo(
             ErrorCode::UnexpectedError,
@@ -93,7 +94,7 @@ VectorDiskAnnIndex<T>::Upload(const Config& config) {
     auto remote_paths_to_size = file_manager_->GetRemotePathsToFileSize();
     BinarySet ret;
     for (auto& file : remote_paths_to_size) {
-        ret.Append(file.first, nullptr, file.second);
+        ret.Append(file.first, Binary(nullptr, file.second));
     }
 
     return ret;

--- a/internal/core/src/index/VectorDiskIndex.h
+++ b/internal/core/src/index/VectorDiskIndex.h
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "index/VectorIndex.h"
+#include "knowhere/version.h"
 #include "storage/DiskFileManagerImpl.h"
 
 namespace milvus::index {
@@ -37,7 +38,7 @@ class VectorDiskAnnIndex : public VectorIndex {
         auto remote_paths_to_size = file_manager_->GetRemotePathsToFileSize();
         BinarySet binary_set;
         for (auto& file : remote_paths_to_size) {
-            binary_set.Append(file.first, nullptr, file.second);
+            binary_set.Append(file.first, Binary(nullptr, file.second));
         }
 
         return binary_set;

--- a/internal/core/src/index/VectorMemIndex.h
+++ b/internal/core/src/index/VectorMemIndex.h
@@ -22,7 +22,10 @@
 #include <vector>
 #include <boost/dynamic_bitset.hpp>
 #include "knowhere/factory.h"
+#include "knowhere/utils.h"
+#include "knowhere/version.h"
 #include "index/VectorIndex.h"
+#include "common/BitsetView.h"
 #include "storage/MemFileManagerImpl.h"
 
 namespace milvus::index {
@@ -74,6 +77,9 @@ class VectorMemIndex : public VectorIndex {
  protected:
     virtual void
     LoadWithoutAssemble(const BinarySet& binary_set, const Config& config);
+
+    virtual void
+    LoadWithoutAssemble(BinarySet&& binary_set, const Config& config);
 
  private:
     void

--- a/internal/core/src/indexbuilder/index_c.cpp
+++ b/internal/core/src/indexbuilder/index_c.cpp
@@ -228,7 +228,7 @@ SerializeIndexToBinarySet(CIndex index, CBinarySet* c_binary_set) {
         auto real_index =
             reinterpret_cast<milvus::indexbuilder::IndexCreatorBase*>(index);
         auto binary =
-            std::make_unique<knowhere::BinarySet>(real_index->Serialize());
+            std::make_unique<milvus::BinarySet>(real_index->Serialize());
         *c_binary_set = binary.release();
         status.error_code = Success;
         status.error_msg = "";
@@ -248,7 +248,7 @@ LoadIndexFromBinarySet(CIndex index, CBinarySet c_binary_set) {
             "failed to load index from binary set, passed index was null");
         auto real_index =
             reinterpret_cast<milvus::indexbuilder::IndexCreatorBase*>(index);
-        auto binary_set = reinterpret_cast<knowhere::BinarySet*>(c_binary_set);
+        auto binary_set = reinterpret_cast<milvus::BinarySet*>(c_binary_set);
         real_index->Load(*binary_set);
         status.error_code = Success;
         status.error_msg = "";
@@ -455,8 +455,7 @@ SerializeIndexAndUpLoad(CIndex index, CBinarySet* c_binary_set) {
             "failed to serialize index to binary set, passed index was null");
         auto real_index =
             reinterpret_cast<milvus::indexbuilder::IndexCreatorBase*>(index);
-        auto binary =
-            std::make_unique<knowhere::BinarySet>(real_index->Upload());
+        auto binary = std::make_unique<milvus::BinarySet>(real_index->Upload());
         *c_binary_set = binary.release();
         status.error_code = Success;
         status.error_msg = "";

--- a/internal/core/src/indexbuilder/index_c.h
+++ b/internal/core/src/indexbuilder/index_c.h
@@ -10,8 +10,8 @@
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
 #pragma once
-
 #ifdef __cplusplus
+#include "common/BinarySet.h"
 extern "C" {
 #endif
 

--- a/internal/core/src/segcore/load_index_c.cpp
+++ b/internal/core/src/segcore/load_index_c.cpp
@@ -10,7 +10,6 @@
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
 #include "segcore/load_index_c.h"
-
 #include "common/FieldMeta.h"
 #include "common/EasyAssert.h"
 #include "index/Index.h"
@@ -20,6 +19,7 @@
 #include "log/Log.h"
 #include "segcore/Types.h"
 #include "storage/Util.h"
+#include "common/binary_set_c.h"
 #include "storage/RemoteChunkManagerSingleton.h"
 #include "storage/LocalChunkManagerSingleton.h"
 
@@ -106,7 +106,7 @@ appendVecIndex(CLoadIndexInfo c_load_index_info, CBinarySet c_binary_set) {
     try {
         auto load_index_info =
             (milvus::segcore::LoadIndexInfo*)c_load_index_info;
-        auto binary_set = (knowhere::BinarySet*)c_binary_set;
+        auto binary_set = (milvus::BinarySet*)c_binary_set;
         auto& index_params = load_index_info->index_params;
 
         milvus::index::CreateIndexInfo index_info;
@@ -168,7 +168,7 @@ appendScalarIndex(CLoadIndexInfo c_load_index_info, CBinarySet c_binary_set) {
         auto load_index_info =
             (milvus::segcore::LoadIndexInfo*)c_load_index_info;
         auto field_type = load_index_info->field_type;
-        auto binary_set = (knowhere::BinarySet*)c_binary_set;
+        auto binary_set = (milvus::BinarySet*)c_binary_set;
         auto& index_params = load_index_info->index_params;
         bool find_index_type =
             index_params.count("index_type") > 0 ? true : false;

--- a/internal/core/src/segcore/load_index_c.h
+++ b/internal/core/src/segcore/load_index_c.h
@@ -16,7 +16,6 @@ extern "C" {
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
-
 #include "common/binary_set_c.h"
 #include "common/type_c.h"
 #include "segcore/collection_c.h"

--- a/internal/core/src/segcore/segment_c.h
+++ b/internal/core/src/segcore/segment_c.h
@@ -10,7 +10,6 @@
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
 #pragma once
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -19,10 +18,10 @@ extern "C" {
 #include <stdlib.h>
 #include <stdint.h>
 
-#include "common/type_c.h"
-#include "segcore/plan_c.h"
 #include "segcore/load_index_c.h"
 #include "segcore/load_field_data_c.h"
+#include "common/type_c.h"
+#include "segcore/plan_c.h"
 
 typedef void* CSegmentInterface;
 typedef void* CSearchResult;

--- a/internal/core/src/storage/FieldDataInterface.h
+++ b/internal/core/src/storage/FieldDataInterface.h
@@ -70,6 +70,9 @@ class FieldDataBase {
     virtual void
     Reserve(size_t cap) = 0;
 
+    virtual void*
+    Relinquish() = 0;
+
  public:
     virtual int64_t
     get_num_rows() const = 0;
@@ -173,6 +176,14 @@ class FieldDataImpl : public FieldDataBase {
             num_rows_ = cap;
             field_data_.resize(num_rows_ * dim_);
         }
+    }
+
+    void*
+    Relinquish() override {
+        std::lock_guard lck(num_rows_mutex_);
+        auto data = folly::relinquish(field_data_);
+        num_rows_ = 0;
+        return data;
     }
 
  public:

--- a/internal/core/src/storage/MemFileManagerImpl.h
+++ b/internal/core/src/storage/MemFileManagerImpl.h
@@ -22,6 +22,7 @@
 #include <vector>
 #include <memory>
 
+#include "common/BinarySet.h"
 #include "storage/IndexData.h"
 #include "storage/FileManager.h"
 #include "storage/ChunkManager.h"

--- a/internal/core/src/storage/ThreadPools.cpp
+++ b/internal/core/src/storage/ThreadPools.cpp
@@ -1,3 +1,14 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+
 //
 // Created by zilliz on 2023/7/31.
 //

--- a/internal/core/src/storage/azure-blob-storage/CMakeLists.txt
+++ b/internal/core/src/storage/azure-blob-storage/CMakeLists.txt
@@ -1,3 +1,14 @@
+# Copyright (C) 2019-2020 Zilliz. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under the License
+
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: MIT
 

--- a/internal/core/thirdparty/knowhere/CMakeLists.txt
+++ b/internal/core/thirdparty/knowhere/CMakeLists.txt
@@ -11,7 +11,7 @@
 # or implied. See the License for the specific language governing permissions and limitations under the License.
 #-------------------------------------------------------------------------------
 
-set( KNOWHERE_VERSION 7b63839 )
+set( KNOWHERE_VERSION 927aa64 )
 
 message(STATUS "Building knowhere-${KNOWHERE_SOURCE_VER} from source")
 message(STATUS ${CMAKE_BUILD_TYPE})
@@ -30,7 +30,7 @@ endif ()
 set( CMAKE_PREFIX_PATH ${CONAN_BOOST_ROOT} )
 FetchContent_Declare(
         knowhere
-        GIT_REPOSITORY  "https://github.com/zilliztech/knowhere.git"
+        GIT_REPOSITORY  "https://github.com/cqy123456/zilliztech-knowhere.git"
         GIT_TAG         ${KNOWHERE_VERSION}
         SOURCE_DIR      ${CMAKE_CURRENT_BINARY_DIR}/knowhere-src
         BINARY_DIR      ${CMAKE_CURRENT_BINARY_DIR}/knowhere-build

--- a/internal/core/unittest/test_array_expr.cpp
+++ b/internal/core/unittest/test_array_expr.cpp
@@ -678,7 +678,7 @@ TEST(Expr, TestArrayContains) {
         *seg_promote, seg_promote->get_row_count(), MAX_TIMESTAMP);
 
     std::vector<ArrayTestcase<bool>> bool_testcases{{{true, true}, {}},
-                                               {{false, false}, {}}};
+                                                    {{false, false}, {}}};
 
     for (auto testcase : bool_testcases) {
         auto check = [&](const std::vector<bool>& values) {
@@ -1236,9 +1236,7 @@ TEST(Expr, TestArrayBinaryArith) {
               value:<int64_val:10 >
         >)",
              "int",
-             [](milvus::Array& array) {
-                 return array.length() == 10;
-             }},
+             [](milvus::Array& array) { return array.length() == 10; }},
             {R"(binary_arith_op_eval_range_expr: <
               column_info: <
                 field_id: 101
@@ -1251,9 +1249,7 @@ TEST(Expr, TestArrayBinaryArith) {
               value:<int64_val:8 >
         >)",
              "int",
-             [](milvus::Array& array) {
-                 return array.length() != 8;
-             }},
+             [](milvus::Array& array) { return array.length() != 8; }},
         };
 
     std::string raw_plan_tmp = R"(vector_anns: <
@@ -1422,7 +1418,7 @@ TEST(Expr, TestArrayInTerm) {
     ExecExprVisitor visitor(
         *seg_promote, seg_promote->get_row_count(), MAX_TIMESTAMP);
 
-        std::vector<std::tuple<std::string,
+    std::vector<std::tuple<std::string,
                            std::string,
                            std::function<bool(milvus::Array & array)>>>
         testcases = {
@@ -1435,11 +1431,11 @@ TEST(Expr, TestArrayInTerm) {
               >
               values:<int64_val:1 > values:<int64_val:2 > values:<int64_val:3 >
         >)",
-       "long",
-       [](milvus::Array& array) {
-           auto val = array.get_data<int64_t>(0);
-           return val == 1 || val ==2 || val == 3;
-       }},
+             "long",
+             [](milvus::Array& array) {
+                 auto val = array.get_data<int64_t>(0);
+                 return val == 1 || val == 2 || val == 3;
+             }},
             {R"(term_expr: <
               column_info: <
                 field_id: 101
@@ -1449,9 +1445,7 @@ TEST(Expr, TestArrayInTerm) {
               >
         >)",
              "long",
-             [](milvus::Array& array) {
-                 return false;
-             }},
+             [](milvus::Array& array) { return false; }},
             {R"(term_expr: <
               column_info: <
                 field_id: 102
@@ -1475,9 +1469,7 @@ TEST(Expr, TestArrayInTerm) {
               >
         >)",
              "bool",
-             [](milvus::Array& array) {
-                 return false;
-             }},
+             [](milvus::Array& array) { return false; }},
             {R"(term_expr: <
               column_info: <
                 field_id: 103
@@ -1501,9 +1493,7 @@ TEST(Expr, TestArrayInTerm) {
               >
         >)",
              "float",
-             [](milvus::Array& array) {
-                 return false;
-             }},
+             [](milvus::Array& array) { return false; }},
             {R"(term_expr: <
               column_info: <
                 field_id: 104
@@ -1527,11 +1517,9 @@ TEST(Expr, TestArrayInTerm) {
               >
         >)",
              "string",
-             [](milvus::Array& array) {
-                 return false;
-             }},
-    };
-    
+             [](milvus::Array& array) { return false; }},
+        };
+
     std::string raw_plan_tmp = R"(vector_anns: <
                                     field_id: 100
                                     predicates: <

--- a/internal/core/unittest/test_azure_chunk_manager.cpp
+++ b/internal/core/unittest/test_azure_chunk_manager.cpp
@@ -25,7 +25,9 @@ StorageConfig
 get_default_storage_config() {
     auto endpoint = "core.windows.net";
     auto accessKey = "devstoreaccount1";
-    auto accessValue = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
+    auto accessValue =
+        "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/"
+        "K1SZFPTOtr/KBHBeksoGMGw==";
     auto rootPath = "files";
     auto useSSL = false;
     auto useIam = false;
@@ -70,7 +72,6 @@ TEST_F(AzureChunkManagerTest, BasicFunctions) {
     EXPECT_TRUE(chunk_manager_->GetName() == "AzureChunkManager");
     EXPECT_TRUE(chunk_manager_ptr_->GetName() == "AzureChunkManager");
     EXPECT_TRUE(chunk_manager_->GetRootPath() == "files");
-
 
     string path = "test";
     uint8_t readdata[20] = {0};
@@ -132,9 +133,9 @@ TEST_F(AzureChunkManagerTest, WritePositive) {
     string testBucketName = configs_.bucket_name;
     EXPECT_EQ(chunk_manager_->GetBucketName(), testBucketName);
 
-     if (!chunk_manager_->BucketExists(testBucketName)) {
-         chunk_manager_->CreateBucket(testBucketName);
-     }
+    if (!chunk_manager_->BucketExists(testBucketName)) {
+        chunk_manager_->CreateBucket(testBucketName);
+    }
     auto has_bucket = chunk_manager_->BucketExists(testBucketName);
     uint8_t data[5] = {0x17, 0x32, 0x45, 0x34, 0x23};
     string path = "1";

--- a/internal/core/unittest/test_c_api.cpp
+++ b/internal/core/unittest/test_c_api.cpp
@@ -1596,8 +1596,9 @@ TEST(CApiTest, LoadIndexInfo) {
 
     auto N = 1024 * 10;
     auto [raw_data, timestamps, uids] = generate_data(N);
+    auto version = knowhere::Version::GetCurrentVersion().VersionCode();
     auto indexing = knowhere::IndexFactory::Instance().Create(
-        knowhere::IndexEnum::INDEX_FAISS_IVFSQ8);
+        knowhere::IndexEnum::INDEX_FAISS_IVFSQ8, version);
     auto conf =
         knowhere::Json{{knowhere::meta::METRIC_TYPE, knowhere::metric::L2},
                        {knowhere::meta::DIM, DIM},
@@ -1610,8 +1611,11 @@ TEST(CApiTest, LoadIndexInfo) {
     indexing.Add(*database, conf);
     EXPECT_EQ(indexing.Count(), N);
     EXPECT_EQ(indexing.Dim(), DIM);
-    knowhere::BinarySet binary_set;
-    indexing.Serialize(binary_set);
+
+    knowhere::IndexSequence index_seq;
+    indexing.Serialize(index_seq);
+    milvus::BinarySet binary_set;
+    binary_set.Append(indexing.Type(), std::move(index_seq));
     CBinarySet c_binary_set = (CBinarySet)&binary_set;
 
     void* c_load_index_info = nullptr;
@@ -1642,8 +1646,9 @@ TEST(CApiTest, LoadIndexSearch) {
     auto N = 1024 * 10;
     auto num_query = 100;
     auto [raw_data, timestamps, uids] = generate_data(N);
+    auto version = knowhere::Version::GetCurrentVersion().VersionCode();
     auto indexing = knowhere::IndexFactory::Instance().Create(
-        knowhere::IndexEnum::INDEX_FAISS_IVFSQ8);
+        knowhere::IndexEnum::INDEX_FAISS_IVFSQ8, version);
     auto conf =
         knowhere::Json{{knowhere::meta::METRIC_TYPE, knowhere::metric::L2},
                        {knowhere::meta::DIM, DIM},
@@ -1659,8 +1664,10 @@ TEST(CApiTest, LoadIndexSearch) {
     EXPECT_EQ(indexing.Dim(), DIM);
 
     // serializ index to binarySet
-    knowhere::BinarySet binary_set;
-    indexing.Serialize(binary_set);
+    knowhere::IndexSequence index_seq;
+    indexing.Serialize(index_seq);
+    milvus::BinarySet binary_set;
+    binary_set.Append(indexing.Type(), std::move(index_seq));
 
     // fill loadIndexInfo
     milvus::segcore::LoadIndexInfo load_index_info;

--- a/internal/core/unittest/test_expr.cpp
+++ b/internal/core/unittest/test_expr.cpp
@@ -801,7 +801,7 @@ TEST(Expr, TestUnaryRangeJson) {
         proto::plan::Array val;
         std::vector<std::string> nested_path;
     };
-    
+
     proto::plan::Array arr;
     arr.set_same_type(true);
     proto::plan::GenericValue int_val1;
@@ -816,9 +816,7 @@ TEST(Expr, TestUnaryRangeJson) {
     int_val3.set_int64_val(int64_t(3));
     arr.add_array()->CopyFrom(int_val3);
 
-    std::vector<TestArrayCase> array_cases = {
-        {arr, {"array"}}
-    };
+    std::vector<TestArrayCase> array_cases = {{arr, {"array"}}};
 
     for (const auto& testcase : array_cases) {
         auto check = [&](OpType op) {
@@ -830,11 +828,12 @@ TEST(Expr, TestUnaryRangeJson) {
         for (auto& op : ops) {
             RetrievePlanNode plan;
             auto pointer = milvus::Json::pointer(testcase.nested_path);
-            plan.predicate_ = std::make_unique<UnaryRangeExprImpl<proto::plan::Array>>(
-                ColumnInfo(json_fid, DataType::JSON, testcase.nested_path),
-                op,
-                testcase.val,
-                proto::plan::GenericValue::ValCase::kArrayVal);
+            plan.predicate_ =
+                std::make_unique<UnaryRangeExprImpl<proto::plan::Array>>(
+                    ColumnInfo(json_fid, DataType::JSON, testcase.nested_path),
+                    op,
+                    testcase.val,
+                    proto::plan::GenericValue::ValCase::kArrayVal);
             auto final = visitor.call_child(*plan.predicate_.value());
             EXPECT_EQ(final.size(), N * num_iters);
 
@@ -4111,9 +4110,7 @@ TEST(Expr, TestJsonContainsArray) {
         {{sub_arr1, sub_arr2}, {"array2"}}};
 
     for (auto& testcase : diff_testcases2) {
-        auto check = [&]() {
-            return true;
-        };
+        auto check = [&]() { return true; };
         RetrievePlanNode plan;
         auto pointer = milvus::Json::pointer(testcase.nested_path);
         plan.predicate_ =
@@ -4248,11 +4245,11 @@ TEST(Expr, TestJsonContainsArray) {
     }
 }
 
-milvus::proto::plan::GenericValue generatedArrayWithFourDiffType(
-    int64_t int_val,
-    double float_val,
-    bool bool_val,
-    std::string string_val) {
+milvus::proto::plan::GenericValue
+generatedArrayWithFourDiffType(int64_t int_val,
+                               double float_val,
+                               bool bool_val,
+                               std::string string_val) {
     using namespace milvus;
 
     proto::plan::GenericValue value;
@@ -4312,11 +4309,15 @@ TEST(Expr, TestJsonContainsDiffTypeArray) {
 
     proto::plan::GenericValue int_value;
     int_value.set_int64_val(1);
-    auto diff_type_array1 = generatedArrayWithFourDiffType(1, 2.2, false, "abc");
-    auto diff_type_array2 = generatedArrayWithFourDiffType(1, 2.2, false, "def");
+    auto diff_type_array1 =
+        generatedArrayWithFourDiffType(1, 2.2, false, "abc");
+    auto diff_type_array2 =
+        generatedArrayWithFourDiffType(1, 2.2, false, "def");
     auto diff_type_array3 = generatedArrayWithFourDiffType(1, 2.2, true, "abc");
-    auto diff_type_array4 = generatedArrayWithFourDiffType(1, 3.3, false, "abc");
-    auto diff_type_array5 = generatedArrayWithFourDiffType(2, 2.2, false, "abc");
+    auto diff_type_array4 =
+        generatedArrayWithFourDiffType(1, 3.3, false, "abc");
+    auto diff_type_array5 =
+        generatedArrayWithFourDiffType(2, 2.2, false, "abc");
 
     std::vector<Testcase<proto::plan::GenericValue>> diff_testcases{
         {{diff_type_array1, int_value}, {"array3"}, true},
@@ -4327,9 +4328,7 @@ TEST(Expr, TestJsonContainsDiffTypeArray) {
     };
 
     for (auto& testcase : diff_testcases) {
-        auto check = [&]() {
-            return testcase.res;
-        };
+        auto check = [&]() { return testcase.res; };
         RetrievePlanNode plan;
         auto pointer = milvus::Json::pointer(testcase.nested_path);
         plan.predicate_ =
@@ -4355,9 +4354,7 @@ TEST(Expr, TestJsonContainsDiffTypeArray) {
     }
 
     for (auto& testcase : diff_testcases) {
-        auto check = [&]() {
-            return false;
-        };
+        auto check = [&]() { return false; };
         RetrievePlanNode plan;
         auto pointer = milvus::Json::pointer(testcase.nested_path);
         plan.predicate_ =
@@ -4433,10 +4430,13 @@ TEST(Expr, TestJsonContainsDiffType) {
     proto::plan::GenericValue int_val2;
     int_val2.set_int64_val(int64_t(1));
 
-
     std::vector<Testcase<proto::plan::GenericValue>> diff_testcases{
-        {{int_val, bool_val, float_val, string_val}, {"diff_type_array"}, false},
-        {{string_val2, bool_val2, float_val2, int_val2}, {"diff_type_array"}, true},
+        {{int_val, bool_val, float_val, string_val},
+         {"diff_type_array"},
+         false},
+        {{string_val2, bool_val2, float_val2, int_val2},
+         {"diff_type_array"},
+         true},
     };
 
     for (auto& testcase : diff_testcases) {

--- a/internal/core/unittest/test_float16.cpp
+++ b/internal/core/unittest/test_float16.cpp
@@ -11,7 +11,6 @@
 
 #include <gtest/gtest.h>
 
-
 #include "common/LoadInfo.h"
 #include "common/Types.h"
 #include "index/IndexFactory.h"
@@ -80,8 +79,8 @@ TEST(Float16, Insert) {
     auto row_count = interface.get_row_count();
     ASSERT_EQ(N, row_count);
     for (auto chunk_id = 0; chunk_id < num_chunk; ++chunk_id) {
-        auto float16_span =
-            interface.chunk_data<milvus::Float16Vector>(float16_vec_fid, chunk_id);
+        auto float16_span = interface.chunk_data<milvus::Float16Vector>(
+            float16_vec_fid, chunk_id);
         auto begin = chunk_id * size_per_chunk;
         auto end = std::min((chunk_id + 1) * size_per_chunk, N);
         auto size_of_chunk = end - begin;
@@ -150,8 +149,7 @@ TEST(Float16, ExecWithoutPredicateFlat) {
     auto vec_ptr = dataset.get_col<float16>(vec_fid);
 
     auto num_queries = 5;
-    auto ph_group_raw = CreateFloat16PlaceholderGroup(
-        num_queries, 32, 1024);
+    auto ph_group_raw = CreateFloat16PlaceholderGroup(num_queries, 32, 1024);
     auto ph_group =
         ParsePlaceholderGroup(plan.get(), ph_group_raw.SerializeAsString());
 
@@ -204,7 +202,7 @@ TEST(Float16, GetVector) {
             segment->bulk_subscript(vec, ids_ds->GetIds(), num_inserted);
 
         auto vector = result.get()->mutable_vectors()->float16_vector();
-        EXPECT_TRUE(vector.size() == num_inserted * dim * sizeof(float16));   
+        EXPECT_TRUE(vector.size() == num_inserted * dim * sizeof(float16));
         // EXPECT_TRUE(vector.size() == num_inserted * dim);
         // for (size_t i = 0; i < num_inserted; ++i) {
         //     auto id = ids_ds->GetIds()[i];
@@ -286,7 +284,8 @@ TEST(Float16, CApiCPlan) {
 
     milvus::proto::plan::PlanNode plan_node;
     auto vector_anns = plan_node.mutable_vector_anns();
-    vector_anns->set_vector_type(milvus::proto::plan::VectorType::Float16Vector);
+    vector_anns->set_vector_type(
+        milvus::proto::plan::VectorType::Float16Vector);
     vector_anns->set_placeholder_tag("$0");
     vector_anns->set_field_id(100);
     auto query_info = vector_anns->mutable_query_info();

--- a/internal/core/unittest/test_growing_index.cpp
+++ b/internal/core/unittest/test_growing_index.cpp
@@ -58,7 +58,8 @@ TEST(GrowingIndex, Correctness) {
 
     milvus::proto::plan::PlanNode range_query_plan_node;
     auto vector_range_querys = range_query_plan_node.mutable_vector_anns();
-    vector_range_querys->set_vector_type(milvus::proto::plan::VectorType::FloatVector);
+    vector_range_querys->set_vector_type(
+        milvus::proto::plan::VectorType::FloatVector);
     vector_range_querys->set_placeholder_tag("$0");
     vector_range_querys->set_field_id(102);
     auto range_query_info = vector_range_querys->mutable_query_info();

--- a/internal/core/unittest/test_index_c_api.cpp
+++ b/internal/core/unittest/test_index_c_api.cpp
@@ -199,7 +199,7 @@ TEST(CBoolIndexTest, All) {
         { DeleteBinarySet(binary_set); }
     }
 
-    delete[] (char*)(half_ds->GetTensor());
+    delete[](char*)(half_ds->GetTensor());
 }
 
 // TODO: more scalar type.
@@ -316,6 +316,6 @@ TEST(CStringIndexTest, All) {
         { DeleteBinarySet(binary_set); }
     }
 
-    delete[] (char*)(str_ds->GetTensor());
+    delete[](char*)(str_ds->GetTensor());
 }
 #endif

--- a/internal/core/unittest/test_indexing.cpp
+++ b/internal/core/unittest/test_indexing.cpp
@@ -407,10 +407,8 @@ TEST_P(IndexTest, BuildAndQuery) {
         create_index_info, file_manager);
     vec_index = dynamic_cast<milvus::index::VectorIndex*>(new_index.get());
 
-    std::vector<std::string> index_files;
-    for (auto& binary : binary_set.binary_map_) {
-        index_files.emplace_back(binary.first);
-    }
+    std::vector<std::string> index_files = binary_set.GetBinarySetAllKeys();
+
     load_conf["index_files"] = index_files;
     ASSERT_NO_THROW(vec_index->Load(load_conf));
     EXPECT_EQ(vec_index->Count(), NB);
@@ -461,10 +459,8 @@ TEST_P(IndexTest, Mmap) {
     }
     vec_index = dynamic_cast<milvus::index::VectorIndex*>(new_index.get());
 
-    std::vector<std::string> index_files;
-    for (auto& binary : binary_set.binary_map_) {
-        index_files.emplace_back(binary.first);
-    }
+    std::vector<std::string> index_files = binary_set.GetBinarySetAllKeys();
+
     load_conf["index_files"] = index_files;
     load_conf["mmap_filepath"] = "mmap/test_index_mmap_" + index_type;
     vec_index->Load(load_conf);
@@ -516,10 +512,7 @@ TEST_P(IndexTest, GetVector) {
 
         vec_index = dynamic_cast<milvus::index::VectorIndex*>(new_index.get());
 
-        std::vector<std::string> index_files;
-        for (auto& binary : binary_set.binary_map_) {
-            index_files.emplace_back(binary.first);
-        }
+        std::vector<std::string> index_files = binary_set.GetBinarySetAllKeys();
         load_conf["index_files"] = index_files;
         vec_index->Load(binary_set, load_conf);
         EXPECT_EQ(vec_index->Count(), NB);
@@ -613,10 +606,7 @@ TEST(Indexing, SearchDiskAnnWithInvalidParam) {
     auto new_index = milvus::index::IndexFactory::GetInstance().CreateIndex(
         create_index_info, file_manager);
     auto vec_index = dynamic_cast<milvus::index::VectorIndex*>(new_index.get());
-    std::vector<std::string> index_files;
-    for (auto& binary : binary_set.binary_map_) {
-        index_files.emplace_back(binary.first);
-    }
+    std::vector<std::string> index_files = binary_set.GetBinarySetAllKeys();
     auto load_conf = generate_load_conf(index_type, metric_type, NB);
     load_conf["index_files"] = index_files;
     vec_index->Load(load_conf);

--- a/internal/core/unittest/test_remote_chunk_manager.cpp
+++ b/internal/core/unittest/test_remote_chunk_manager.cpp
@@ -112,8 +112,7 @@ TEST_F(RemoteChunkManagerTest, BucketNegtive) {
     try {
         aws_chunk_manager_->CreateBucket(testBucketName);
     } catch (SegcoreError& e) {
-        EXPECT_TRUE(std::string(e.what()).find("exists") !=
-                    string::npos);
+        EXPECT_TRUE(std::string(e.what()).find("exists") != string::npos);
     }
     aws_chunk_manager_->DeleteBucket(testBucketName);
 }
@@ -138,9 +137,9 @@ TEST_F(RemoteChunkManagerTest, WritePositive) {
     aws_chunk_manager_->SetBucketName(testBucketName);
     EXPECT_EQ(aws_chunk_manager_->GetBucketName(), testBucketName);
 
-     if (!aws_chunk_manager_->BucketExists(testBucketName)) {
-         aws_chunk_manager_->CreateBucket(testBucketName);
-     }
+    if (!aws_chunk_manager_->BucketExists(testBucketName)) {
+        aws_chunk_manager_->CreateBucket(testBucketName);
+    }
     uint8_t data[5] = {0x17, 0x32, 0x45, 0x34, 0x23};
     string path = "1";
     aws_chunk_manager_->Write(path, data, sizeof(data));

--- a/internal/core/unittest/test_string_expr.cpp
+++ b/internal/core/unittest/test_string_expr.cpp
@@ -186,10 +186,7 @@ GenTermPlan(const FieldMeta& fvec_meta,
         vector_type = proto::plan::VectorType::Float16Vector;
     }
 
-    auto anns = GenAnns(expr,
-                        vector_type,
-                        fvec_meta.get_id().get(),
-                        "$0");
+    auto anns = GenAnns(expr, vector_type, fvec_meta.get_id().get(), "$0");
 
     auto plan_node = GenPlanNode();
     plan_node->set_allocated_vector_anns(anns);
@@ -232,10 +229,8 @@ GenAlwaysFalsePlan(const FieldMeta& fvec_meta, const FieldMeta& str_meta) {
     } else if (fvec_meta.get_data_type() == DataType::VECTOR_FLOAT16) {
         vector_type = proto::plan::VectorType::Float16Vector;
     }
-    auto anns = GenAnns(always_false_expr,
-                        vector_type,
-                        fvec_meta.get_id().get(),
-                        "$0");
+    auto anns =
+        GenAnns(always_false_expr, vector_type, fvec_meta.get_id().get(), "$0");
 
     auto plan_node = GenPlanNode();
     plan_node->set_allocated_vector_anns(anns);
@@ -253,10 +248,8 @@ GenAlwaysTruePlan(const FieldMeta& fvec_meta, const FieldMeta& str_meta) {
     } else if (fvec_meta.get_data_type() == DataType::VECTOR_FLOAT16) {
         vector_type = proto::plan::VectorType::Float16Vector;
     }
-    auto anns = GenAnns(always_true_expr,
-                        vector_type,
-                        fvec_meta.get_id().get(),
-                        "$0");
+    auto anns =
+        GenAnns(always_true_expr, vector_type, fvec_meta.get_id().get(), "$0");
 
     auto plan_node = GenPlanNode();
     plan_node->set_allocated_vector_anns(anns);
@@ -386,11 +379,7 @@ TEST(StringExpr, Compare) {
         } else if (fvec_meta.get_data_type() == DataType::VECTOR_FLOAT16) {
             vector_type = proto::plan::VectorType::Float16Vector;
         }
-        auto anns =
-            GenAnns(expr,
-                    vector_type,
-                    fvec_meta.get_id().get(),
-                    "$0");
+        auto anns = GenAnns(expr, vector_type, fvec_meta.get_id().get(), "$0");
 
         auto plan_node = std::make_unique<proto::plan::PlanNode>();
         plan_node->set_allocated_vector_anns(anns);
@@ -497,11 +486,7 @@ TEST(StringExpr, UnaryRange) {
         } else if (fvec_meta.get_data_type() == DataType::VECTOR_FLOAT16) {
             vector_type = proto::plan::VectorType::Float16Vector;
         }
-        auto anns =
-            GenAnns(expr,
-                    vector_type,
-                    fvec_meta.get_id().get(),
-                    "$0");
+        auto anns = GenAnns(expr, vector_type, fvec_meta.get_id().get(), "$0");
 
         auto plan_node = std::make_unique<proto::plan::PlanNode>();
         plan_node->set_allocated_vector_anns(anns);
@@ -600,11 +585,7 @@ TEST(StringExpr, BinaryRange) {
         } else if (fvec_meta.get_data_type() == DataType::VECTOR_FLOAT16) {
             vector_type = proto::plan::VectorType::Float16Vector;
         }
-        auto anns =
-            GenAnns(expr,
-                    vector_type,
-                    fvec_meta.get_id().get(),
-                    "$0");
+        auto anns = GenAnns(expr, vector_type, fvec_meta.get_id().get(), "$0");
 
         auto plan_node = std::make_unique<proto::plan::PlanNode>();
         plan_node->set_allocated_vector_anns(anns);


### PR DESCRIPTION
This PR do the following jobs:
1. Move binaryset from knowhere to milvus, and reconstructed its implementation; 
    (replace shared ptr by unique_ptr)
3. Knowhere only accept a manageable memory space but not a map of memory space；
4. Add  Relinquish() in FiledData object to transfer a block of memory, rather than copying it；
5. HNSW use zero-copy solution to load the index.
