### PR TITLE
Fix datanode panic due to concurrent compaction and delete processing

### DIFF
--- a/internal/datanode/channel_meta_test.go
+++ b/internal/datanode/channel_meta_test.go
@@ -676,12 +676,7 @@ func TestChannelMeta_InterfaceMethod(t *testing.T) {
 				require.False(t, channel.hasSegment(3, true))
 
 				// tests start
-				err := channel.mergeFlushedSegments(context.Background(), test.inSeg, 100, test.inCompactedFrom)
-				if test.isValid {
-					assert.NoError(t, err)
-				} else {
-					assert.Error(t, err)
-				}
+				channel.mergeFlushedSegments(context.Background(), test.inSeg, 100, test.inCompactedFrom)
 
 				if test.stored {
 					assert.True(t, channel.hasSegment(3, true))

--- a/internal/datanode/data_node.go
+++ b/internal/datanode/data_node.go
@@ -60,15 +60,8 @@ import (
 )
 
 const (
-	// RPCConnectionTimeout is used to set the timeout for rpc request
-	RPCConnectionTimeout = 30 * time.Second
-
 	// ConnectEtcdMaxRetryTime is used to limit the max retry time for connection etcd
 	ConnectEtcdMaxRetryTime = 100
-
-	// ImportCallTimeout is the timeout used in Import() method calls
-	// This value is equal to RootCoord's task expire time
-	ImportCallTimeout = 15 * 60 * time.Second
 )
 
 var getFlowGraphServiceAttempts = uint(50)

--- a/internal/datanode/flow_graph_delete_node.go
+++ b/internal/datanode/flow_graph_delete_node.go
@@ -100,6 +100,7 @@ func (dn *deleteNode) Operate(in []Msg) []Msg {
 		log.Debug("Buffer delete request in DataNode", zap.String("traceID", traceID))
 		tmpSegIDs, err := dn.bufferDeleteMsg(msg, fgMsg.timeRange, fgMsg.startPositions[0], fgMsg.endPositions[0])
 		if err != nil {
+			// should not happen
 			// error occurs only when deleteMsg is misaligned, should not happen
 			log.Fatal("failed to buffer delete msg", zap.String("traceID", traceID), zap.Error(err))
 		}

--- a/internal/datanode/flush_manager.go
+++ b/internal/datanode/flush_manager.go
@@ -578,7 +578,7 @@ func (m *rendezvousFlushManager) injectFlush(injection *taskInjection, segments 
 // fetch meta info for segment
 func (m *rendezvousFlushManager) getSegmentMeta(segmentID UniqueID, pos *msgpb.MsgPosition) (UniqueID, UniqueID, *etcdpb.CollectionMeta, error) {
 	if !m.hasSegment(segmentID, true) {
-		return -1, -1, nil, fmt.Errorf("no such segment %d in the channel", segmentID)
+		return -1, -1, nil, merr.WrapErrSegmentNotFound(segmentID, "segment not found during flush")
 	}
 
 	// fetch meta information of segment

--- a/internal/datanode/services.go
+++ b/internal/datanode/services.go
@@ -362,12 +362,19 @@ func (node *DataNode) SyncSegments(ctx context.Context, req *datapb.SyncSegments
 		oneSegment int64
 		channel    Channel
 		err        error
+		ds         *dataSyncService
+		ok         bool
 	)
 
 	for _, fromSegment := range req.GetCompactedFrom() {
 		channel, err = node.flowgraphManager.getChannel(fromSegment)
 		if err != nil {
 			log.Ctx(ctx).Warn("fail to get the channel", zap.Int64("segment", fromSegment), zap.Error(err))
+			continue
+		}
+		ds, ok = node.flowgraphManager.getFlowgraphService(channel.getChannelName(fromSegment))
+		if !ok {
+			log.Ctx(ctx).Warn("fail to find flow graph service", zap.Int64("segment", fromSegment))
 			continue
 		}
 		oneSegment = fromSegment
@@ -392,9 +399,9 @@ func (node *DataNode) SyncSegments(ctx context.Context, req *datapb.SyncSegments
 		return merr.Status(err), nil
 	}
 
-	if err := channel.mergeFlushedSegments(ctx, targetSeg, req.GetPlanID(), req.GetCompactedFrom()); err != nil {
-		return merr.Status(err), nil
-	}
+	ds.fg.Blockall()
+	defer ds.fg.Unblock()
+	channel.mergeFlushedSegments(ctx, targetSeg, req.GetPlanID(), req.GetCompactedFrom())
 	node.compactionExecutor.injectDone(req.GetPlanID(), true)
 	return merr.Status(nil), nil
 }

--- a/internal/datanode/services_test.go
+++ b/internal/datanode/services_test.go
@@ -701,13 +701,7 @@ func (s *DataNodeServicesSuite) TestSyncSegments() {
 			CompactedTo:   102,
 			NumOfRows:     100,
 		}
-		cancelCtx, cancel := context.WithCancel(context.Background())
-		cancel()
-		status, err := s.node.SyncSegments(cancelCtx, req)
-		s.Assert().NoError(err)
-		s.Assert().False(merr.Ok(status))
-
-		status, err = s.node.SyncSegments(s.ctx, req)
+		status, err := s.node.SyncSegments(s.ctx, req)
 		s.Assert().NoError(err)
 		s.Assert().True(merr.Ok(status))
 

--- a/internal/util/flowgraph/node.go
+++ b/internal/util/flowgraph/node.go
@@ -31,6 +31,8 @@ const (
 	// TODO: better to be configured
 	nodeCtxTtInterval = 2 * time.Minute
 	enableTtChecker   = true
+	// blockAll should wait no more than 10 seconds
+	blockAllWait = 10 * time.Second
 )
 
 // Node is the interface defines the behavior of flowgraph
@@ -74,7 +76,13 @@ func (nodeCtx *nodeCtx) Start() {
 func (nodeCtx *nodeCtx) Block() {
 	// input node operate function will be blocking
 	if !nodeCtx.node.IsInputNode() {
+		startTs := time.Now()
 		nodeCtx.blockMutex.Lock()
+		if time.Since(startTs) >= blockAllWait {
+			log.Warn("flow graph wait for long time",
+				zap.String("name", nodeCtx.node.Name()),
+				zap.Duration("wait time", time.Since(startTs)))
+		}
 	}
 }
 

--- a/pkg/util/retry/retry_test.go
+++ b/pkg/util/retry/retry_test.go
@@ -134,3 +134,13 @@ func TestContextCancel(t *testing.T) {
 	assert.True(t, merr.IsCanceledOrTimeout(err))
 	t.Log(err)
 }
+
+func TestWrap(t *testing.T) {
+	err := merr.WrapErrSegmentNotFound(1, "failed to get Segment")
+	assert.True(t, errors.Is(err, merr.ErrSegmentNotFound))
+	assert.True(t, IsRecoverable(err))
+	err2 := Unrecoverable(err)
+	fmt.Println(err2)
+	assert.True(t, errors.Is(err2, merr.ErrSegmentNotFound))
+	assert.False(t, IsRecoverable(err2))
+}


### PR DESCRIPTION
fix https://github.com/milvus-io/milvus/issues/27145

the datanode processing delete while compaction happened so flush can not succeed.
For fixing:

1. bring back blockall, ,make sure compaction sync segments and delete processing are mutexed.
2. change ttNode handle updateCheckPoint async, make sure all the flowgraph node is processed fast.
3. change some error handling

see also: https://github.com/milvus-io/milvus/pull/27158