### PR TITLE
[cherry-pick]Release before remove when releasing flowgraphs (#27191)

### DIFF
--- a/internal/datanode/flow_graph_manager_test.go
+++ b/internal/datanode/flow_graph_manager_test.go
@@ -55,6 +55,7 @@ func TestFlowGraphManager(t *testing.T) {
 	defer func() {
 		fm.dropAll()
 	}()
+
 	t.Run("Test addAndStart", func(t *testing.T) {
 		vchanName := "by-dev-rootcoord-dml-test-flowgraphmanager-addAndStart"
 		vchan := &datapb.VchannelInfo{

--- a/internal/datanode/metrics_info.go
+++ b/internal/datanode/metrics_info.go
@@ -50,15 +50,6 @@ func (node *DataNode) getQuotaMetrics() (*metricsinfo.DataNodeQuotaMetrics, erro
 		return nil, err
 	}
 
-	getAllCollections := func() []int64 {
-		collectionSet := typeutil.UniqueSet{}
-		node.flowgraphManager.flowgraphs.Range(func(key string, fg *dataSyncService) bool {
-			collectionSet.Insert(fg.channel.getCollectionID())
-			return true
-		})
-
-		return collectionSet.Collect()
-	}
 	minFGChannel, minFGTt := rateCol.getMinFlowGraphTt()
 	return &metricsinfo.DataNodeQuotaMetrics{
 		Hms: metricsinfo.HardwareMetrics{},
@@ -70,7 +61,7 @@ func (node *DataNode) getQuotaMetrics() (*metricsinfo.DataNodeQuotaMetrics, erro
 		},
 		Effect: metricsinfo.NodeEffect{
 			NodeID:        node.GetSession().ServerID,
-			CollectionIDs: getAllCollections(),
+			CollectionIDs: node.flowgraphManager.collections(),
 		},
 	}, nil
 }

--- a/pkg/util/typeutil/map.go
+++ b/pkg/util/typeutil/map.go
@@ -101,6 +101,14 @@ func (m *ConcurrentMap[K, V]) GetAndRemove(key K) (V, bool) {
 	return value.(V), true
 }
 
+// Remove removes the `key`, `value` set if `key` is in the map,
+// does nothing if `key` not in the map.
+func (m *ConcurrentMap[K, V]) Remove(key K) {
+	if _, loaded := m.inner.LoadAndDelete(key); loaded {
+		m.len.Dec()
+	}
+}
+
 func (m *ConcurrentMap[K, V]) Len() int {
 	return int(m.len.Load())
 }

--- a/pkg/util/typeutil/map_test.go
+++ b/pkg/util/typeutil/map_test.go
@@ -127,6 +127,23 @@ func (suite *MapUtilSuite) TestConcurrentMap() {
 		suite.FailNow("empty map range")
 		return false
 	})
+
+	suite.Run("TestRemove", func() {
+		currMap := NewConcurrentMap[int64, string]()
+		suite.Equal(0, currMap.Len())
+
+		currMap.Remove(100)
+		suite.Equal(0, currMap.Len())
+
+		suite.Equal(currMap.Len(), 0)
+		v, loaded := currMap.GetOrInsert(100, "v-100")
+		suite.Equal("v-100", v)
+		suite.Equal(false, loaded)
+		suite.Equal(1, currMap.Len())
+
+		currMap.Remove(100)
+		suite.Equal(0, currMap.Len())
+	})
 }
 
 func TestMapUtil(t *testing.T) {


### PR DESCRIPTION
GetAndRemove removes the fg from manager immediately, while the flowgraph is still releasing. This PR will remove the fg from flowgraphManager AFTER flowgraphs released.

- Add Remove for ConcurrentMap
- Move collections() into flowgraph manager

pr: #27191