### PR TITLE
output component server id to file

### DIFF
--- a/cmd/milvus/run.go
+++ b/cmd/milvus/run.go
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/cmd/roles"
+	. "github.com/milvus-io/milvus/cmd/utils"
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/util/hardware"
 	"github.com/milvus-io/milvus/pkg/util/metricsinfo"
@@ -98,17 +99,16 @@ func (c *run) execute(args []string, flags *flag.FlagSet) {
 		os.Exit(-1)
 	}
 
-	runtimeDir := createRuntimeDir(c.serverType)
-	filename := getPidFileName(c.serverType, c.svrAlias)
-
 	c.printBanner(flags.Output())
 	c.injectVariablesToEnv()
-	lock, err := createPidFile(flags.Output(), filename, runtimeDir)
+	InitRuntimeDir(flags.Output(), c.serverType)
+	filename := GetPidFileName(c.serverType, c.svrAlias)
+	lock, err := CreateFileWithContent(GlobalRuntimeDir.GetOperationLogger(), GlobalRuntimeDir.GetDir(), filename, fmt.Sprintf("%d", os.Getgid()))
 	if err != nil {
 		panic(err)
 	}
-	defer removePidFile(lock)
-	role.Run(c.svrAlias)
+	defer RemoveFile(lock)
+	role.Run(c.serverType, c.svrAlias)
 }
 
 func (c *run) formatFlags(args []string, flags *flag.FlagSet) {

--- a/cmd/milvus/stop.go
+++ b/cmd/milvus/stop.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
 	"syscall"
 
+	. "github.com/milvus-io/milvus/cmd/utils"
 	"github.com/milvus-io/milvus/pkg/util/hardware"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
@@ -40,9 +40,9 @@ func (c *stop) execute(args []string, flags *flag.FlagSet) {
 	}
 	c.formatFlags(args, flags)
 
-	runtimeDir := createRuntimeDir(c.serverType)
-	filename := getPidFileName(c.serverType, c.svrAlias)
-	if err := c.stopPid(filename, runtimeDir); err != nil {
+	InitRuntimeDir(flags.Output(), c.serverType)
+	filename := GetPidFileName(c.serverType, c.svrAlias)
+	if err := c.stopPid(GlobalRuntimeDir.GetDir(), filename); err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n\n", err.Error())
 	}
 }
@@ -58,14 +58,14 @@ func (c *stop) formatFlags(args []string, flags *flag.FlagSet) {
 	}
 }
 
-func (c *stop) stopPid(filename string, runtimeDir string) error {
+func (c *stop) stopPid(dir string, filename string) error {
 	var pid int
 
-	fd, err := os.OpenFile(path.Join(runtimeDir, filename), os.O_RDONLY, 0o664)
+	fd, err := OpenFile(dir, filename)
 	if err != nil {
 		return err
 	}
-	defer closePidFile(fd)
+	defer CloseFile(fd)
 
 	if _, err = fmt.Fscanf(fd, "%d", &pid); err != nil {
 		return err

--- a/cmd/roles/roles.go
+++ b/cmd/roles/roles.go
@@ -32,6 +32,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/cmd/components"
+	. "github.com/milvus-io/milvus/cmd/utils"
 	"github.com/milvus-io/milvus/internal/http"
 	"github.com/milvus-io/milvus/internal/http/healthz"
 	rocksmqimpl "github.com/milvus-io/milvus/internal/mq/mqimpl/rocksmq/server"
@@ -293,7 +294,7 @@ func (mr *MilvusRoles) handleSignals() func() {
 }
 
 // Run Milvus components.
-func (mr *MilvusRoles) Run(alias string) {
+func (mr *MilvusRoles) Run(sType string, alias string) {
 	// start signal handler, defer close func
 	closeFn := mr.handleSignals()
 	defer closeFn()
@@ -382,6 +383,13 @@ func (mr *MilvusRoles) Run(alias string) {
 
 	paramtable.SetCreateTime(time.Now())
 	paramtable.SetUpdateTime(time.Now())
+
+	filename := GetServerIDFileName(sType, alias)
+	lock, err := CreateFileWithContent(GlobalRuntimeDir.GetOperationLogger(), GlobalRuntimeDir.GetDir(), filename, fmt.Sprintf("%d", paramtable.GetNodeID()))
+	if err != nil {
+		panic(err)
+	}
+	defer RemoveFile(lock)
 
 	<-mr.closed
 

--- a/cmd/utils/util_test.go
+++ b/cmd/utils/util_test.go
@@ -1,0 +1,53 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPIdBasic(t *testing.T) {
+	sType := "test"
+	alias := "alias"
+	InitRuntimeDir(os.Stdout, sType)
+
+	// create file
+	filename := GetPidFileName(sType, alias)
+	fd, err := CreateFileWithContent(GlobalRuntimeDir.GetOperationLogger(), GlobalRuntimeDir.GetDir(), filename, "1111")
+	assert.NoError(t, err)
+	defer RemoveFile(fd)
+
+	// read file
+	reader, err := OpenFile(GlobalRuntimeDir.GetDir(), filename)
+	assert.NoError(t, err)
+	defer CloseFile(reader)
+	var pid int
+	lines, err := fmt.Fscanf(reader, "%d", &pid)
+	assert.NoError(t, err)
+	assert.Equal(t, lines, 1)
+	assert.Equal(t, pid, 1111)
+}
+
+func TestSIdBasic(t *testing.T) {
+	sType := "test"
+	alias := "alias"
+	InitRuntimeDir(os.Stdout, sType)
+
+	// create file
+	filename := GetServerIDFileName(sType, alias)
+	fd, err := CreateFileWithContent(GlobalRuntimeDir.GetOperationLogger(), GlobalRuntimeDir.GetDir(), filename, "2222")
+	assert.NoError(t, err)
+	defer RemoveFile(fd)
+
+	// read file
+	reader, err := OpenFile(GlobalRuntimeDir.GetDir(), filename)
+	assert.NoError(t, err)
+	defer CloseFile(reader)
+	var pid int
+	lines, err := fmt.Fscanf(reader, "%d", &pid)
+	assert.NoError(t, err)
+	assert.Equal(t, lines, 1)
+	assert.Equal(t, pid, 2222)
+}


### PR DESCRIPTION
Signed-off-by: Wei Liu <wei.liu@zilliz.com>
issue: #27270

after milvus component start and init successfully, try to write server Id to local file, which will end with 'sid' suffix, then the outside hook could clean session if milvus component panic.