### PR TITLE
Enhance newDataSyncService

### DIFF
--- a/internal/datanode/data_node.go
+++ b/internal/datanode/data_node.go
@@ -75,8 +75,7 @@ var Params *paramtable.ComponentParam = paramtable.Get()
 //	`etcdCli`   is a connection of etcd
 //	`rootCoord` is a grpc client of root coordinator.
 //	`dataCoord` is a grpc client of data service.
-//	`NodeID` is unique to each datanode.
-//	`State` is current statement of this data node, indicating whether it's healthy.
+//	`stateCode` is current statement of this data node, indicating whether it's healthy.
 //
 //	`clearSignal` is a signal channel for releasing the flowgraph resources.
 //	`segmentCache` stores all flushing and flushed segments.

--- a/internal/datanode/data_node_test.go
+++ b/internal/datanode/data_node_test.go
@@ -197,7 +197,7 @@ func TestDataNode(t *testing.T) {
 		}
 
 		for _, test := range testDataSyncs {
-			err = node.flowgraphManager.addAndStart(node, &datapb.VchannelInfo{CollectionID: 1, ChannelName: test.dmChannelName}, nil, genTestTickler())
+			err = node.flowgraphManager.addAndStartWithEtcdTickler(node, &datapb.VchannelInfo{CollectionID: 1, ChannelName: test.dmChannelName}, nil, genTestTickler())
 			assert.NoError(t, err)
 			vchanNameCh <- test.dmChannelName
 		}

--- a/internal/datanode/event_manager_test.go
+++ b/internal/datanode/event_manager_test.go
@@ -432,7 +432,7 @@ func TestEventTickler(t *testing.T) {
 	kv.RemoveWithPrefix(etcdPrefix)
 	defer kv.RemoveWithPrefix(etcdPrefix)
 
-	tickler := newTickler(0, path.Join(etcdPrefix, channelName), &datapb.ChannelWatchInfo{
+	tickler := newEtcdTickler(0, path.Join(etcdPrefix, channelName), &datapb.ChannelWatchInfo{
 		Vchan: &datapb.VchannelInfo{
 			ChannelName: channelName,
 		},

--- a/internal/datanode/flow_graph_delete_node.go
+++ b/internal/datanode/flow_graph_delete_node.go
@@ -198,8 +198,8 @@ func (dn *deleteNode) filterSegmentByPK(partID UniqueID, pks []primaryKey, tss [
 
 func newDeleteNode(ctx context.Context, fm flushManager, manager *DeltaBufferManager, sig chan<- string, config *nodeConfig) (*deleteNode, error) {
 	baseNode := BaseNode{}
-	baseNode.SetMaxQueueLength(config.maxQueueLength)
-	baseNode.SetMaxParallelism(config.maxParallelism)
+	baseNode.SetMaxQueueLength(Params.DataNodeCfg.FlowGraphMaxQueueLength.GetAsInt32())
+	baseNode.SetMaxParallelism(Params.DataNodeCfg.FlowGraphMaxParallelism.GetAsInt32())
 
 	return &deleteNode{
 		ctx:              ctx,

--- a/internal/datanode/flow_graph_dmstream_input_node.go
+++ b/internal/datanode/flow_graph_dmstream_input_node.go
@@ -66,8 +66,8 @@ func newDmInputNode(initCtx context.Context, dispatcherClient msgdispatcher.Clie
 	node := flowgraph.NewInputNode(
 		input,
 		name,
-		dmNodeConfig.maxQueueLength,
-		dmNodeConfig.maxParallelism,
+		Params.DataNodeCfg.FlowGraphMaxQueueLength.GetAsInt32(),
+		Params.DataNodeCfg.FlowGraphMaxParallelism.GetAsInt32(),
 		typeutil.DataNodeRole,
 		paramtable.GetNodeID(),
 		dmNodeConfig.collectionID,

--- a/internal/datanode/flow_graph_dmstream_input_node_test.go
+++ b/internal/datanode/flow_graph_dmstream_input_node_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
+	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/util/dependency"
 	"github.com/milvus-io/milvus/pkg/mq/msgdispatcher"
 	"github.com/milvus-io/milvus/pkg/mq/msgstream"
 	"github.com/milvus-io/milvus/pkg/mq/msgstream/mqwrapper"
@@ -36,13 +38,14 @@ type mockMsgStreamFactory struct {
 	NewMsgStreamNoError bool
 }
 
-var _ msgstream.Factory = &mockMsgStreamFactory{}
+var (
+	_ msgstream.Factory  = &mockMsgStreamFactory{}
+	_ dependency.Factory = (*mockMsgStreamFactory)(nil)
+)
 
-func (mm *mockMsgStreamFactory) Init(params *paramtable.ComponentParam) error {
-	if !mm.InitReturnNil {
-		return errors.New("Init Error")
-	}
-	return nil
+func (mm *mockMsgStreamFactory) Init(params *paramtable.ComponentParam) {}
+func (mm *mockMsgStreamFactory) NewPersistentStorageChunkManager(ctx context.Context) (storage.ChunkManager, error) {
+	return nil, nil
 }
 
 func (mm *mockMsgStreamFactory) NewMsgStream(ctx context.Context) (msgstream.MsgStream, error) {

--- a/internal/datanode/flow_graph_insert_buffer_node_test.go
+++ b/internal/datanode/flow_graph_insert_buffer_node_test.go
@@ -120,7 +120,7 @@ func TestFlowGraphInsertBufferNodeCreate(t *testing.T) {
 
 	dataCoord := &DataCoordFactory{}
 	atimeTickSender := newTimeTickSender(dataCoord, 0)
-	iBNode, err := newInsertBufferNode(ctx, collMeta.ID, delBufManager, flushChan, resendTTChan, fm, newCache(), c, atimeTickSender)
+	iBNode, err := newInsertBufferNode(ctx, flushChan, resendTTChan, delBufManager, fm, newCache(), atimeTickSender, c)
 	assert.NotNil(t, iBNode)
 	require.NoError(t, err)
 }
@@ -221,7 +221,7 @@ func TestFlowGraphInsertBufferNode_Operate(t *testing.T) {
 
 	dataCoord := &DataCoordFactory{}
 	atimeTickSender := newTimeTickSender(dataCoord, 0)
-	iBNode, err := newInsertBufferNode(ctx, collMeta.ID, delBufManager, flushChan, resendTTChan, fm, newCache(), c, atimeTickSender)
+	iBNode, err := newInsertBufferNode(ctx, flushChan, resendTTChan, delBufManager, fm, newCache(), atimeTickSender, c)
 	require.NoError(t, err)
 
 	flushChan <- flushMsg{
@@ -387,6 +387,7 @@ func TestFlowGraphInsertBufferNode_AutoFlush(t *testing.T) {
 	flushChan := make(chan flushMsg, 100)
 	resendTTChan := make(chan resendTTMsg, 100)
 	c := &nodeConfig{
+		collectionID: collMeta.GetID(),
 		channel:      channel,
 		msFactory:    factory,
 		allocator:    alloc,
@@ -398,7 +399,7 @@ func TestFlowGraphInsertBufferNode_AutoFlush(t *testing.T) {
 	}
 	dataCoord := &DataCoordFactory{}
 	atimeTickSender := newTimeTickSender(dataCoord, 0)
-	iBNode, err := newInsertBufferNode(ctx, collMeta.ID, delBufManager, flushChan, resendTTChan, fm, newCache(), c, atimeTickSender)
+	iBNode, err := newInsertBufferNode(ctx, flushChan, resendTTChan, delBufManager, fm, newCache(), atimeTickSender, c)
 	require.NoError(t, err)
 
 	// Auto flush number of rows set to 2
@@ -632,6 +633,7 @@ func TestInsertBufferNodeRollBF(t *testing.T) {
 	flushChan := make(chan flushMsg, 100)
 	resendTTChan := make(chan resendTTMsg, 100)
 	c := &nodeConfig{
+		collectionID: collMeta.ID,
 		channel:      channel,
 		msFactory:    factory,
 		allocator:    alloc,
@@ -644,7 +646,7 @@ func TestInsertBufferNodeRollBF(t *testing.T) {
 
 	dataCoord := &DataCoordFactory{}
 	atimeTickSender := newTimeTickSender(dataCoord, 0)
-	iBNode, err := newInsertBufferNode(ctx, collMeta.ID, delBufManager, flushChan, resendTTChan, fm, newCache(), c, atimeTickSender)
+	iBNode, err := newInsertBufferNode(ctx, flushChan, resendTTChan, delBufManager, fm, newCache(), atimeTickSender, c)
 	require.NoError(t, err)
 
 	// Auto flush number of rows set to 2
@@ -1012,6 +1014,7 @@ func TestInsertBufferNode_bufferInsertMsg(t *testing.T) {
 		flushChan := make(chan flushMsg, 100)
 		resendTTChan := make(chan resendTTMsg, 100)
 		c := &nodeConfig{
+			collectionID: collMeta.ID,
 			channel:      channel,
 			msFactory:    factory,
 			allocator:    alloc,
@@ -1024,7 +1027,7 @@ func TestInsertBufferNode_bufferInsertMsg(t *testing.T) {
 
 		dataCoord := &DataCoordFactory{}
 		atimeTickSender := newTimeTickSender(dataCoord, 0)
-		iBNode, err := newInsertBufferNode(ctx, collMeta.ID, delBufManager, flushChan, resendTTChan, fm, newCache(), c, atimeTickSender)
+		iBNode, err := newInsertBufferNode(ctx, flushChan, resendTTChan, delBufManager, fm, newCache(), atimeTickSender, c)
 		require.NoError(t, err)
 
 		inMsg := genFlowGraphInsertMsg(insertChannelName)

--- a/internal/datanode/flow_graph_manager_test.go
+++ b/internal/datanode/flow_graph_manager_test.go
@@ -64,7 +64,7 @@ func TestFlowGraphManager(t *testing.T) {
 		}
 		require.False(t, fm.exist(vchanName))
 
-		err := fm.addAndStart(node, vchan, nil, genTestTickler())
+		err := fm.addAndStartWithEtcdTickler(node, vchan, nil, genTestTickler())
 		assert.NoError(t, err)
 		assert.True(t, fm.exist(vchanName))
 
@@ -79,7 +79,7 @@ func TestFlowGraphManager(t *testing.T) {
 		}
 		require.False(t, fm.exist(vchanName))
 
-		err := fm.addAndStart(node, vchan, nil, genTestTickler())
+		err := fm.addAndStartWithEtcdTickler(node, vchan, nil, genTestTickler())
 		assert.NoError(t, err)
 		assert.True(t, fm.exist(vchanName))
 
@@ -97,7 +97,7 @@ func TestFlowGraphManager(t *testing.T) {
 		}
 		require.False(t, fm.exist(vchanName))
 
-		err := fm.addAndStart(node, vchan, nil, genTestTickler())
+		err := fm.addAndStartWithEtcdTickler(node, vchan, nil, genTestTickler())
 		assert.NoError(t, err)
 		assert.True(t, fm.exist(vchanName))
 		fg, ok := fm.getFlowgraphService(vchanName)
@@ -147,7 +147,7 @@ func TestFlowGraphManager(t *testing.T) {
 		}
 		require.False(t, fm.exist(vchanName))
 
-		err := fm.addAndStart(node, vchan, nil, genTestTickler())
+		err := fm.addAndStartWithEtcdTickler(node, vchan, nil, genTestTickler())
 		assert.NoError(t, err)
 		assert.True(t, fm.exist(vchanName))
 
@@ -226,7 +226,7 @@ func TestFlowGraphManager(t *testing.T) {
 				vchan := &datapb.VchannelInfo{
 					ChannelName: vchannel,
 				}
-				err = fm.addAndStart(node, vchan, nil, genTestTickler())
+				err = fm.addAndStartWithEtcdTickler(node, vchan, nil, genTestTickler())
 				assert.NoError(t, err)
 				fg, ok := fm.flowgraphs.Get(vchannel)
 				assert.True(t, ok)

--- a/internal/datanode/flush_manager.go
+++ b/internal/datanode/flush_manager.go
@@ -746,7 +746,7 @@ func dropVirtualChannelFunc(dsService *dataSyncService, opts ...retry.Option) fl
 			Base: commonpbutil.NewMsgBase(
 				commonpbutil.WithMsgType(0), // TODO msg type
 				commonpbutil.WithMsgID(0),   // TODO msg id
-				commonpbutil.WithSourceID(paramtable.GetNodeID()),
+				commonpbutil.WithSourceID(dsService.serverID),
 			),
 			ChannelName: dsService.vchannelName,
 		}
@@ -900,7 +900,7 @@ func flushNotifyFunc(dsService *dataSyncService, opts ...retry.Option) notifyMet
 			Base: commonpbutil.NewMsgBase(
 				commonpbutil.WithMsgType(0),
 				commonpbutil.WithMsgID(0),
-				commonpbutil.WithSourceID(dsService.serverID),
+				commonpbutil.WithSourceID(paramtable.GetNodeID()),
 			),
 			SegmentID:           pack.segmentID,
 			CollectionID:        dsService.collectionID,

--- a/internal/datanode/mock_test.go
+++ b/internal/datanode/mock_test.go
@@ -92,6 +92,7 @@ func newIDLEDataNodeMock(ctx context.Context, pkType schemapb.DataType) *DataNod
 
 	ds := &DataCoordFactory{}
 	node.dataCoord = ds
+	node.timeTickSender = newTimeTickSender(node.dataCoord, 0)
 
 	return node
 }
@@ -312,7 +313,8 @@ func (ds *DataCoordFactory) GetSegmentInfo(ctx context.Context, req *datapb.GetS
 			segmentInfos = append(segmentInfos, segInfo)
 		} else {
 			segmentInfos = append(segmentInfos, &datapb.SegmentInfo{
-				ID: segmentID,
+				ID:           segmentID,
+				CollectionID: 1,
 			})
 		}
 	}
@@ -1257,6 +1259,6 @@ func genTimestamp() typeutil.Timestamp {
 	return tsoutil.ComposeTSByTime(gb, 0)
 }
 
-func genTestTickler() *tickler {
-	return newTickler(0, "", nil, nil, 0)
+func genTestTickler() *etcdTickler {
+	return newEtcdTickler(0, "", nil, nil, 0)
 }

--- a/internal/datanode/services_test.go
+++ b/internal/datanode/services_test.go
@@ -190,7 +190,7 @@ func (s *DataNodeServicesSuite) TestFlushSegments() {
 		FlushedSegmentIds:   []int64{},
 	}
 
-	err := s.node.flowgraphManager.addAndStart(s.node, vchan, nil, genTestTickler())
+	err := s.node.flowgraphManager.addAndStartWithEtcdTickler(s.node, vchan, nil, genTestTickler())
 	s.Require().NoError(err)
 
 	fgservice, ok := s.node.flowgraphManager.getFlowgraphService(dmChannelName)
@@ -394,14 +394,14 @@ func (s *DataNodeServicesSuite) TestImport() {
 
 		chName1 := "fake-by-dev-rootcoord-dml-testimport-1"
 		chName2 := "fake-by-dev-rootcoord-dml-testimport-2"
-		err := s.node.flowgraphManager.addAndStart(s.node, &datapb.VchannelInfo{
+		err := s.node.flowgraphManager.addAndStartWithEtcdTickler(s.node, &datapb.VchannelInfo{
 			CollectionID:        100,
 			ChannelName:         chName1,
 			UnflushedSegmentIds: []int64{},
 			FlushedSegmentIds:   []int64{},
 		}, nil, genTestTickler())
 		s.Require().Nil(err)
-		err = s.node.flowgraphManager.addAndStart(s.node, &datapb.VchannelInfo{
+		err = s.node.flowgraphManager.addAndStartWithEtcdTickler(s.node, &datapb.VchannelInfo{
 			CollectionID:        100,
 			ChannelName:         chName2,
 			UnflushedSegmentIds: []int64{},
@@ -472,14 +472,14 @@ func (s *DataNodeServicesSuite) TestImport() {
 	s.Run("Test Import bad flow graph", func() {
 		chName1 := "fake-by-dev-rootcoord-dml-testimport-1-badflowgraph"
 		chName2 := "fake-by-dev-rootcoord-dml-testimport-2-badflowgraph"
-		err := s.node.flowgraphManager.addAndStart(s.node, &datapb.VchannelInfo{
+		err := s.node.flowgraphManager.addAndStartWithEtcdTickler(s.node, &datapb.VchannelInfo{
 			CollectionID:        100,
 			ChannelName:         chName1,
 			UnflushedSegmentIds: []int64{},
 			FlushedSegmentIds:   []int64{},
 		}, nil, genTestTickler())
 		s.Require().Nil(err)
-		err = s.node.flowgraphManager.addAndStart(s.node, &datapb.VchannelInfo{
+		err = s.node.flowgraphManager.addAndStartWithEtcdTickler(s.node, &datapb.VchannelInfo{
 			CollectionID:        999, // wrong collection ID.
 			ChannelName:         chName2,
 			UnflushedSegmentIds: []int64{},
@@ -620,14 +620,14 @@ func (s *DataNodeServicesSuite) TestAddImportSegment() {
 
 		chName1 := "fake-by-dev-rootcoord-dml-testaddsegment-1"
 		chName2 := "fake-by-dev-rootcoord-dml-testaddsegment-2"
-		err := s.node.flowgraphManager.addAndStart(s.node, &datapb.VchannelInfo{
+		err := s.node.flowgraphManager.addAndStartWithEtcdTickler(s.node, &datapb.VchannelInfo{
 			CollectionID:        100,
 			ChannelName:         chName1,
 			UnflushedSegmentIds: []int64{},
 			FlushedSegmentIds:   []int64{},
 		}, nil, genTestTickler())
 		s.Require().NoError(err)
-		err = s.node.flowgraphManager.addAndStart(s.node, &datapb.VchannelInfo{
+		err = s.node.flowgraphManager.addAndStartWithEtcdTickler(s.node, &datapb.VchannelInfo{
 			CollectionID:        100,
 			ChannelName:         chName2,
 			UnflushedSegmentIds: []int64{},
@@ -670,7 +670,8 @@ func (s *DataNodeServicesSuite) TestAddImportSegment() {
 func (s *DataNodeServicesSuite) TestSyncSegments() {
 	chanName := "fake-by-dev-rootcoord-dml-test-syncsegments-1"
 
-	err := s.node.flowgraphManager.addAndStart(s.node, &datapb.VchannelInfo{
+	err := s.node.flowgraphManager.addAndStartWithEtcdTickler(s.node, &datapb.VchannelInfo{
+		CollectionID:        1,
 		ChannelName:         chanName,
 		UnflushedSegmentIds: []int64{},
 		FlushedSegmentIds:   []int64{100, 200, 300},
@@ -679,9 +680,9 @@ func (s *DataNodeServicesSuite) TestSyncSegments() {
 	fg, ok := s.node.flowgraphManager.getFlowgraphService(chanName)
 	s.Assert().True(ok)
 
-	s1 := Segment{segmentID: 100}
-	s2 := Segment{segmentID: 200}
-	s3 := Segment{segmentID: 300}
+	s1 := Segment{segmentID: 100, collectionID: 1}
+	s2 := Segment{segmentID: 200, collectionID: 1}
+	s3 := Segment{segmentID: 300, collectionID: 1}
 	s1.setType(datapb.SegmentType_Flushed)
 	s2.setType(datapb.SegmentType_Flushed)
 	s3.setType(datapb.SegmentType_Flushed)
@@ -762,7 +763,7 @@ func (s *DataNodeServicesSuite) TestResendSegmentStats() {
 		FlushedSegmentIds:   []int64{},
 	}
 
-	err := s.node.flowgraphManager.addAndStart(s.node, vChan, nil, genTestTickler())
+	err := s.node.flowgraphManager.addAndStartWithEtcdTickler(s.node, vChan, nil, genTestTickler())
 	s.Require().Nil(err)
 
 	fgService, ok := s.node.flowgraphManager.getFlowgraphService(dmChannelName)
@@ -831,7 +832,7 @@ func (s *DataNodeServicesSuite) TestFlushChannels() {
 		FlushedSegmentIds:   []int64{},
 	}
 
-	err := s.node.flowgraphManager.addAndStart(s.node, vChan, nil, genTestTickler())
+	err := s.node.flowgraphManager.addAndStartWithEtcdTickler(s.node, vChan, nil, genTestTickler())
 	s.Require().NoError(err)
 
 	fgService, ok := s.node.flowgraphManager.getFlowgraphService(dmChannelName)

--- a/internal/util/flowgraph/flow_graph.go
+++ b/internal/util/flowgraph/flow_graph.go
@@ -18,6 +18,7 @@ package flowgraph
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/cockroachdb/errors"
@@ -124,4 +125,22 @@ func NewTimeTickedFlowGraph(ctx context.Context) *TimeTickedFlowGraph {
 	}
 
 	return &flowGraph
+}
+
+func (fg *TimeTickedFlowGraph) AssembleNodes(orderedNodes ...Node) error {
+	for _, node := range orderedNodes {
+		fg.AddNode(node)
+	}
+
+	for i, node := range orderedNodes {
+		// Set edge to the next node
+		if i < len(orderedNodes)-1 {
+			err := fg.SetEdges(node.Name(), []string{orderedNodes[i+1].Name()})
+			if err != nil {
+				errMsg := fmt.Sprintf("set edges failed for flow graph, node=%s", node.Name())
+				return errors.New(errMsg)
+			}
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
- Add flowgraph.Assemble assembles nodes in flowgraph.go
- remove fgCtx in newDataSyncService
- Add newServiceWithEtcdTickler func, reduce param numbers to 3
- Remove unnecessary params
  - node.Session.serverID
  - config.maxQueueLength, config.maxParallelish

See also: https://github.com/milvus-io/milvus/issues/27207