### PR TITLE
Add back `gocritic` linter and fix related issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,7 +30,7 @@ linters:
     - gci
     - whitespace
     - gofumpt
-      #    - gocritic
+    - gocritic
 
 linters-settings:
   gci:

--- a/internal/storage/azure_object_storage.go
+++ b/internal/storage/azure_object_storage.go
@@ -111,10 +111,10 @@ func (AzureObjectStorage *AzureObjectStorage) PutObject(ctx context.Context, buc
 
 func (AzureObjectStorage *AzureObjectStorage) StatObject(ctx context.Context, bucketName, objectName string) (int64, error) {
 	info, err := AzureObjectStorage.Client.NewContainerClient(bucketName).NewBlockBlobClient(objectName).GetProperties(ctx, &blob.GetPropertiesOptions{})
-	if err == nil {
-		return *info.ContentLength, err
+	if err != nil {
+		return 0, err
 	}
-	return 0, err
+	return *info.ContentLength, nil
 }
 
 func (AzureObjectStorage *AzureObjectStorage) ListObjects(ctx context.Context, bucketName string, prefix string, recursive bool) (map[string]time.Time, error) {

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -124,6 +124,7 @@ require (
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.42.0 // indirect
 	github.com/prometheus/procfs v0.9.0 // indirect
+	github.com/quasilyte/go-ruleguard/dsl v0.3.22 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 // indirect
 	github.com/rogpeppe/go-internal v1.8.1 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -209,6 +209,7 @@ github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vb
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
+github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.3 h1:2DntVwHkVopvECVRSlL5PSo9eG+cAkDCuckLubN+rq0=
 github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -415,6 +416,7 @@ github.com/kataras/iris/v12 v12.1.8/go.mod h1:LMYy4VlP67TQ3Zgriz8RE2h2kMZV2SgMYb
 github.com/kataras/neffos v0.0.14/go.mod h1:8lqADm8PnbeFfL7CLXh1WHw53dG27MC3pgi2R1rmoTE=
 github.com/kataras/pio v0.0.2/go.mod h1:hAoW0t9UmXi4R5Oyq5Z4irTbaTsOemSrDGUtaTl7Dro=
 github.com/kataras/sitemap v0.0.5/go.mod h1:KY2eugMKiPwsJgx7+U103YZehfvNGOXURubcGyk0Bz8=
+github.com/keybase/go-keychain v0.0.0-20190712205309-48d3d31d256d/go.mod h1:JJNrCn9otv/2QP4D7SMJBgaleKpOf66PnW6F5WGNRIc=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
@@ -605,6 +607,8 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.9.0 h1:wzCHvIvM5SxWqYvwgVL7yJY8Lz3PKn49KQtpgMYJfhI=
 github.com/prometheus/procfs v0.9.0/go.mod h1:+pB4zwohETzFnmlpe6yd2lSc+0/46IYZRB/chUwxUZY=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/quasilyte/go-ruleguard/dsl v0.3.22 h1:wd8zkOhSNr+I+8Qeciml08ivDt1pSXe60+5DqOpCjPE=
+github.com/quasilyte/go-ruleguard/dsl v0.3.22/go.mod h1:KeCP03KrjuSO0H1kTuZQCWlQPulDV6YMIXmpQss17rU=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 h1:OdAsTTz6OkFY5QxjkYwrChwuRruF69c169dPK26NUlk=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/clock v0.0.0-20190514195947-2896927a307a/go.mod h1:4r5QyqhjIWCcK8DO4KMclc5Iknq5qVBAlbYYzAbUScQ=

--- a/pkg/rules.go
+++ b/pkg/rules.go
@@ -1,0 +1,409 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gorules
+
+import (
+	"github.com/quasilyte/go-ruleguard/dsl"
+)
+
+// This is a collection of rules for ruleguard: https://github.com/quasilyte/go-ruleguard
+
+// Remove extra conversions: mdempsky/unconvert
+func unconvert(m dsl.Matcher) {
+	m.Match("int($x)").Where(m["x"].Type.Is("int") && !m["x"].Const).Report("unnecessary conversion").Suggest("$x")
+
+	m.Match("float32($x)").Where(m["x"].Type.Is("float32") && !m["x"].Const).Report("unnecessary conversion").Suggest("$x")
+	m.Match("float64($x)").Where(m["x"].Type.Is("float64") && !m["x"].Const).Report("unnecessary conversion").Suggest("$x")
+
+	// m.Match("byte($x)").Where(m["x"].Type.Is("byte")).Report("unnecessary conversion").Suggest("$x")
+	// m.Match("rune($x)").Where(m["x"].Type.Is("rune")).Report("unnecessary conversion").Suggest("$x")
+	m.Match("bool($x)").Where(m["x"].Type.Is("bool") && !m["x"].Const).Report("unnecessary conversion").Suggest("$x")
+
+	m.Match("int8($x)").Where(m["x"].Type.Is("int8") && !m["x"].Const).Report("unnecessary conversion").Suggest("$x")
+	m.Match("int16($x)").Where(m["x"].Type.Is("int16") && !m["x"].Const).Report("unnecessary conversion").Suggest("$x")
+	m.Match("int32($x)").Where(m["x"].Type.Is("int32") && !m["x"].Const).Report("unnecessary conversion").Suggest("$x")
+	m.Match("int64($x)").Where(m["x"].Type.Is("int64") && !m["x"].Const).Report("unnecessary conversion").Suggest("$x")
+
+	m.Match("uint8($x)").Where(m["x"].Type.Is("uint8") && !m["x"].Const).Report("unnecessary conversion").Suggest("$x")
+	m.Match("uint16($x)").Where(m["x"].Type.Is("uint16") && !m["x"].Const).Report("unnecessary conversion").Suggest("$x")
+	m.Match("uint32($x)").Where(m["x"].Type.Is("uint32") && !m["x"].Const).Report("unnecessary conversion").Suggest("$x")
+	m.Match("uint64($x)").Where(m["x"].Type.Is("uint64") && !m["x"].Const).Report("unnecessary conversion").Suggest("$x")
+
+	m.Match("time.Duration($x)").Where(m["x"].Type.Is("time.Duration") && !m["x"].Text.Matches("^[0-9]*$")).Report("unnecessary conversion").Suggest("$x")
+}
+
+// Don't use == or != with time.Time
+// https://github.com/dominikh/go-tools/issues/47 : Wontfix
+func timeeq(m dsl.Matcher) {
+	m.Match("$t0 == $t1").Where(m["t0"].Type.Is("time.Time")).Report("using == with time.Time")
+	m.Match("$t0 != $t1").Where(m["t0"].Type.Is("time.Time")).Report("using != with time.Time")
+	m.Match(`map[$k]$v`).Where(m["k"].Type.Is("time.Time")).Report("map with time.Time keys are easy to misuse")
+}
+
+// err but no an error
+func errnoterror(m dsl.Matcher) {
+	// Would be easier to check for all err identifiers instead, but then how do we get the type from m[] ?
+
+	m.Match(
+		"if $*_, err := $x; $err != nil { $*_ } else if $_ { $*_ }",
+		"if $*_, err := $x; $err != nil { $*_ } else { $*_ }",
+		"if $*_, err := $x; $err != nil { $*_ }",
+
+		"if $*_, err = $x; $err != nil { $*_ } else if $_ { $*_ }",
+		"if $*_, err = $x; $err != nil { $*_ } else { $*_ }",
+		"if $*_, err = $x; $err != nil { $*_ }",
+
+		"$*_, err := $x; if $err != nil { $*_ } else if $_ { $*_ }",
+		"$*_, err := $x; if $err != nil { $*_ } else { $*_ }",
+		"$*_, err := $x; if $err != nil { $*_ }",
+
+		"$*_, err = $x; if $err != nil { $*_ } else if $_ { $*_ }",
+		"$*_, err = $x; if $err != nil { $*_ } else { $*_ }",
+		"$*_, err = $x; if $err != nil { $*_ }",
+	).
+		Where(m["err"].Text == "err" && !m["err"].Type.Is("error") && m["x"].Text != "recover()").
+		Report("err variable not error type")
+}
+
+// Identical if and else bodies
+func ifbodythenbody(m dsl.Matcher) {
+	m.Match("if $*_ { $body } else { $body }").
+		Report("identical if and else bodies")
+
+	// Lots of false positives.
+	// m.Match("if $*_ { $body } else if $*_ { $body }").
+	//	Report("identical if and else bodies")
+}
+
+// Odd inequality: A - B < 0 instead of !=
+// Too many false positives.
+/*
+func subtractnoteq(m dsl.Matcher) {
+	m.Match("$a - $b < 0").Report("consider $a != $b")
+	m.Match("$a - $b > 0").Report("consider $a != $b")
+	m.Match("0 < $a - $b").Report("consider $a != $b")
+	m.Match("0 > $a - $b").Report("consider $a != $b")
+}
+*/
+
+// Self-assignment
+func selfassign(m dsl.Matcher) {
+	m.Match("$x = $x").Report("useless self-assignment")
+}
+
+// Odd nested ifs
+func oddnestedif(m dsl.Matcher) {
+	m.Match("if $x { if $x { $*_ }; $*_ }",
+		"if $x == $y { if $x != $y {$*_ }; $*_ }",
+		"if $x != $y { if $x == $y {$*_ }; $*_ }",
+		"if $x { if !$x { $*_ }; $*_ }",
+		"if !$x { if $x { $*_ }; $*_ }").
+		Report("odd nested ifs")
+
+	m.Match("for $x { if $x { $*_ }; $*_ }",
+		"for $x == $y { if $x != $y {$*_ }; $*_ }",
+		"for $x != $y { if $x == $y {$*_ }; $*_ }",
+		"for $x { if !$x { $*_ }; $*_ }",
+		"for !$x { if $x { $*_ }; $*_ }").
+		Report("odd nested for/ifs")
+}
+
+// odd bitwise expressions
+func oddbitwise(m dsl.Matcher) {
+	m.Match("$x | $x",
+		"$x | ^$x",
+		"^$x | $x").
+		Report("odd bitwise OR")
+
+	m.Match("$x & $x",
+		"$x & ^$x",
+		"^$x & $x").
+		Report("odd bitwise AND")
+
+	m.Match("$x &^ $x").
+		Report("odd bitwise AND-NOT")
+}
+
+// odd sequence of if tests with return
+func ifreturn(m dsl.Matcher) {
+	m.Match("if $x { return $*_ }; if $x {$*_ }").Report("odd sequence of if test")
+	m.Match("if $x { return $*_ }; if !$x {$*_ }").Report("odd sequence of if test")
+	m.Match("if !$x { return $*_ }; if $x {$*_ }").Report("odd sequence of if test")
+	m.Match("if $x == $y { return $*_ }; if $x != $y {$*_ }").Report("odd sequence of if test")
+	m.Match("if $x != $y { return $*_ }; if $x == $y {$*_ }").Report("odd sequence of if test")
+}
+
+func oddifsequence(m dsl.Matcher) {
+	/*
+		m.Match("if $x { $*_ }; if $x {$*_ }").Report("odd sequence of if test")
+
+		m.Match("if $x == $y { $*_ }; if $y == $x {$*_ }").Report("odd sequence of if tests")
+		m.Match("if $x != $y { $*_ }; if $y != $x {$*_ }").Report("odd sequence of if tests")
+
+		m.Match("if $x < $y { $*_ }; if $y > $x {$*_ }").Report("odd sequence of if tests")
+		m.Match("if $x <= $y { $*_ }; if $y >= $x {$*_ }").Report("odd sequence of if tests")
+
+		m.Match("if $x > $y { $*_ }; if $y < $x {$*_ }").Report("odd sequence of if tests")
+		m.Match("if $x >= $y { $*_ }; if $y <= $x {$*_ }").Report("odd sequence of if tests")
+	*/
+}
+
+// odd sequence of nested if tests
+func nestedifsequence(m dsl.Matcher) {
+	/*
+		m.Match("if $x < $y { if $x >= $y {$*_ }; $*_ }").Report("odd sequence of nested if tests")
+		m.Match("if $x <= $y { if $x > $y {$*_ }; $*_ }").Report("odd sequence of nested if tests")
+		m.Match("if $x > $y { if $x <= $y {$*_ }; $*_ }").Report("odd sequence of nested if tests")
+		m.Match("if $x >= $y { if $x < $y {$*_ }; $*_ }").Report("odd sequence of nested if tests")
+	*/
+}
+
+// odd sequence of assignments
+func identicalassignments(m dsl.Matcher) {
+	m.Match("$x  = $y; $y = $x").Report("odd sequence of assignments")
+}
+
+func oddcompoundop(m dsl.Matcher) {
+	m.Match("$x += $x + $_",
+		"$x += $x - $_").
+		Report("odd += expression")
+
+	m.Match("$x -= $x + $_",
+		"$x -= $x - $_").
+		Report("odd -= expression")
+}
+
+func constswitch(m dsl.Matcher) {
+	m.Match("switch $x { $*_ }", "switch $*_; $x { $*_ }").
+		Where(m["x"].Const && !m["x"].Text.Matches(`^runtime\.`)).
+		Report("constant switch")
+}
+
+func oddcomparisons(m dsl.Matcher) {
+	m.Match(
+		"$x - $y == 0",
+		"$x - $y != 0",
+		"$x - $y < 0",
+		"$x - $y <= 0",
+		"$x - $y > 0",
+		"$x - $y >= 0",
+		"$x ^ $y == 0",
+		"$x ^ $y != 0",
+	).Report("odd comparison")
+}
+
+func oddmathbits(m dsl.Matcher) {
+	m.Match(
+		"64 - bits.LeadingZeros64($x)",
+		"32 - bits.LeadingZeros32($x)",
+		"16 - bits.LeadingZeros16($x)",
+		"8 - bits.LeadingZeros8($x)",
+	).Report("odd math/bits expression: use bits.Len*() instead?")
+}
+
+// func floateq(m dsl.Matcher) {
+// 	m.Match(
+// 		"$x == $y",
+// 		"$x != $y",
+// 	).
+// 		Where(m["x"].Type.Is("float32") && !m["x"].Const && !m["y"].Text.Matches("0(.0+)?") && !m.File().Name.Matches("floating_comparision.go")).
+// 		Report("floating point tested for equality")
+
+// 	m.Match(
+// 		"$x == $y",
+// 		"$x != $y",
+// 	).
+// 		Where(m["x"].Type.Is("float64") && !m["x"].Const && !m["y"].Text.Matches("0(.0+)?") && !m.File().Name.Matches("floating_comparision.go")).
+// 		Report("floating point tested for equality")
+
+// 	m.Match("switch $x { $*_ }", "switch $*_; $x { $*_ }").
+// 		Where(m["x"].Type.Is("float32")).
+// 		Report("floating point as switch expression")
+
+// 	m.Match("switch $x { $*_ }", "switch $*_; $x { $*_ }").
+// 		Where(m["x"].Type.Is("float64")).
+// 		Report("floating point as switch expression")
+
+// }
+
+func badexponent(m dsl.Matcher) {
+	m.Match(
+		"2 ^ $x",
+		"10 ^ $x",
+	).
+		Report("caret (^) is not exponentiation")
+}
+
+func floatloop(m dsl.Matcher) {
+	m.Match(
+		"for $i := $x; $i < $y; $i += $z { $*_ }",
+		"for $i = $x; $i < $y; $i += $z { $*_ }",
+	).
+		Where(m["i"].Type.Is("float64")).
+		Report("floating point for loop counter")
+
+	m.Match(
+		"for $i := $x; $i < $y; $i += $z { $*_ }",
+		"for $i = $x; $i < $y; $i += $z { $*_ }",
+	).
+		Where(m["i"].Type.Is("float32")).
+		Report("floating point for loop counter")
+}
+
+func urlredacted(m dsl.Matcher) {
+	m.Match(
+		"log.Println($x, $*_)",
+		"log.Println($*_, $x, $*_)",
+		"log.Println($*_, $x)",
+		"log.Printf($*_, $x, $*_)",
+		"log.Printf($*_, $x)",
+
+		"log.Println($x, $*_)",
+		"log.Println($*_, $x, $*_)",
+		"log.Println($*_, $x)",
+		"log.Printf($*_, $x, $*_)",
+		"log.Printf($*_, $x)",
+	).
+		Where(m["x"].Type.Is("*url.URL")).
+		Report("consider $x.Redacted() when outputting URLs")
+}
+
+func sprinterr(m dsl.Matcher) {
+	m.Match(`fmt.Sprint($err)`,
+		`fmt.Sprintf("%s", $err)`,
+		`fmt.Sprintf("%v", $err)`,
+	).
+		Where(m["err"].Type.Is("error")).
+		Report("maybe call $err.Error() instead of fmt.Sprint()?")
+}
+
+// disable this check, because it can not apply to generic type
+//func largeloopcopy(m dsl.Matcher) {
+//	m.Match(
+//		`for $_, $v := range $_ { $*_ }`,
+//	).
+//		Where(m["v"].Type.Size > 1024).
+//		Report(`loop copies large value each iteration`)
+//}
+
+func joinpath(m dsl.Matcher) {
+	m.Match(
+		`strings.Join($_, "/")`,
+		`strings.Join($_, "\\")`,
+		"strings.Join($_, `\\`)",
+	).
+		Report(`did you mean path.Join() or filepath.Join() ?`)
+}
+
+func readfull(m dsl.Matcher) {
+	m.Match(`$n, $err := io.ReadFull($_, $slice)
+                 if $err != nil || $n != len($slice) {
+                              $*_
+		 }`,
+		`$n, $err := io.ReadFull($_, $slice)
+                 if $n != len($slice) || $err != nil {
+                              $*_
+		 }`,
+		`$n, $err = io.ReadFull($_, $slice)
+                 if $err != nil || $n != len($slice) {
+                              $*_
+		 }`,
+		`$n, $err = io.ReadFull($_, $slice)
+                 if $n != len($slice) || $err != nil {
+                              $*_
+		 }`,
+		`if $n, $err := io.ReadFull($_, $slice); $n != len($slice) || $err != nil {
+                              $*_
+		 }`,
+		`if $n, $err := io.ReadFull($_, $slice); $err != nil || $n != len($slice) {
+                              $*_
+		 }`,
+		`if $n, $err = io.ReadFull($_, $slice); $n != len($slice) || $err != nil {
+                              $*_
+		 }`,
+		`if $n, $err = io.ReadFull($_, $slice); $err != nil || $n != len($slice) {
+                              $*_
+		 }`,
+	).Report("io.ReadFull() returns err == nil iff n == len(slice)")
+}
+
+func nilerr(m dsl.Matcher) {
+	m.Match(
+		`if err == nil { return err }`,
+		`if err == nil { return $*_, err }`,
+	).
+		Report(`return nil error instead of nil value`)
+}
+
+func mailaddress(m dsl.Matcher) {
+	m.Match(
+		"fmt.Sprintf(`\"%s\" <%s>`, $NAME, $EMAIL)",
+		"fmt.Sprintf(`\"%s\"<%s>`, $NAME, $EMAIL)",
+		"fmt.Sprintf(`%s <%s>`, $NAME, $EMAIL)",
+		"fmt.Sprintf(`%s<%s>`, $NAME, $EMAIL)",
+		`fmt.Sprintf("\"%s\"<%s>", $NAME, $EMAIL)`,
+		`fmt.Sprintf("\"%s\" <%s>", $NAME, $EMAIL)`,
+		`fmt.Sprintf("%s<%s>", $NAME, $EMAIL)`,
+		`fmt.Sprintf("%s <%s>", $NAME, $EMAIL)`,
+	).
+		Report("use net/mail Address.String() instead of fmt.Sprintf()").
+		Suggest("(&mail.Address{Name:$NAME, Address:$EMAIL}).String()")
+}
+
+func errnetclosed(m dsl.Matcher) {
+	m.Match(
+		`strings.Contains($err.Error(), $text)`,
+	).
+		Where(m["text"].Text.Matches("\".*closed network connection.*\"")).
+		Report(`String matching against error texts is fragile; use net.ErrClosed instead`).
+		Suggest(`errors.Is($err, net.ErrClosed)`)
+}
+
+func httpheaderadd(m dsl.Matcher) {
+	m.Match(
+		`$H.Add($KEY, $VALUE)`,
+	).
+		Where(m["H"].Type.Is("http.Header")).
+		Report("use http.Header.Set method instead of Add to overwrite all existing header values").
+		Suggest(`$H.Set($KEY, $VALUE)`)
+}
+
+func hmacnew(m dsl.Matcher) {
+	m.Match("hmac.New(func() hash.Hash { return $x }, $_)",
+		`$f := func() hash.Hash { return $x }
+	$*_
+	hmac.New($f, $_)`,
+	).Where(m["x"].Pure).
+		Report("invalid hash passed to hmac.New()")
+}
+
+func writestring(m dsl.Matcher) {
+	m.Match(`io.WriteString($w, string($b))`).
+		Where(m["b"].Type.Is("[]byte")).
+		Suggest("$w.Write($b)")
+}
+
+func badlock(m dsl.Matcher) {
+	// Shouldn't give many false positives without type filter
+	// as Lock+Unlock pairs in combination with defer gives us pretty
+	// a good chance to guess correctly. If we constrain the type to sync.Mutex
+	// then it'll be harder to match embedded locks and custom methods
+	// that may forward the call to the sync.Mutex (or other synchronization primitive).
+
+	m.Match(`$mu.Lock(); defer $mu.RUnlock()`).Report(`maybe $mu.RLock() was intended?`)
+	m.Match(`$mu.RLock(); defer $mu.Unlock()`).Report(`maybe $mu.Lock() was intended?`)
+}

--- a/tests/integration/minicluster.go
+++ b/tests/integration/minicluster.go
@@ -256,57 +256,38 @@ func StartMiniCluster(ctx context.Context, opts ...Option) (cluster *MiniCluster
 		cluster.Proxy = proxy
 	}
 
-	// cluster.dataCoord.SetIndexCoord(cluster.indexCoord)
 	cluster.DataCoord.SetRootCoord(cluster.RootCoord)
-
 	err = cluster.RootCoord.SetDataCoord(cluster.DataCoord)
 	if err != nil {
-		return
-	}
-	//err = cluster.rootCoord.SetIndexCoord(cluster.indexCoord)
-	//if err != nil {
-	//	return
-	//}
-	err = cluster.RootCoord.SetQueryCoord(cluster.QueryCoord)
-	if err != nil {
-		return
+		return nil, err
 	}
 
-	// err = cluster.queryCoord.SetIndexCoord(cluster.indexCoord)
+	err = cluster.RootCoord.SetQueryCoord(cluster.QueryCoord)
 	if err != nil {
-		return
+		return nil, err
 	}
+
 	err = cluster.QueryCoord.SetDataCoord(cluster.DataCoord)
 	if err != nil {
-		return
+		return nil, err
 	}
 	err = cluster.QueryCoord.SetRootCoord(cluster.RootCoord)
 	if err != nil {
-		return
+		return nil, err
 	}
-
-	//err = cluster.indexCoord.SetDataCoord(cluster.dataCoord)
-	//if err != nil {
-	//	return
-	//}
-	//err = cluster.indexCoord.SetRootCoord(cluster.rootCoord)
-	//if err != nil {
-	//	return
-	//}
 
 	for _, dataNode := range cluster.DataNodes {
 		err = dataNode.SetDataCoord(cluster.DataCoord)
 		if err != nil {
-			return
+			return nil, err
 		}
 		err = dataNode.SetRootCoord(cluster.RootCoord)
 		if err != nil {
-			return
+			return nil, err
 		}
 	}
 
 	cluster.Proxy.SetDataCoordClient(cluster.DataCoord)
-	// cluster.proxy.SetIndexCoordClient(cluster.indexCoord)
 	cluster.Proxy.SetQueryCoordClient(cluster.QueryCoord)
 	cluster.Proxy.SetRootCoordClient(cluster.RootCoord)
 


### PR DESCRIPTION
`gocritic` was disabled in #21606 since the golangci-lint could not check could codes with generic then
this pr adds back this linter and fix existing issues
/kind improvement