### PR TITLE
Fix gofumpt issue in scann_checker_test.go

### DIFF
--- a/pkg/util/indexparamcheck/scann_checker_test.go
+++ b/pkg/util/indexparamcheck/scann_checker_test.go
@@ -4,10 +4,10 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/pkg/util/metric"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_scaNNChecker_CheckTrain(t *testing.T) {
@@ -99,7 +99,6 @@ func Test_scaNNChecker_CheckTrain(t *testing.T) {
 }
 
 func Test_scaNNChecker_CheckValidDataType(t *testing.T) {
-
 	cases := []struct {
 		dType    schemapb.DataType
 		errIsNil bool


### PR DESCRIPTION
See also #27275
```
Running static-check check
util/indexparamcheck/scann_checker_test.go:6: File is not `gci`-ed with --skip-generated -s standard -s default -s prefix(github.com/milvus-io) --custom-order (gci)

util/indexparamcheck/scann_checker_test.go:9: File is not `gci`-ed with --skip-generated -s standard -s default -s prefix(github.com/milvus-io) --custom-order (gci)

	"github.com/stretchr/testify/assert"
util/indexparamcheck/scann_checker_test.go:102: File is not `gofumpt`-ed (gofumpt)

util/indexparamcheck/scann_checker_test.go:101: unnecessary leading newline (whitespace)
func Test_scaNNChecker_CheckValidDataType(t *testing.T) {
```
/kind improvement