### PR TITLE
Fix lint-fix command may fail when .git has new ref

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,10 @@ lint-fix: getdeps
 		echo "gofumpt v$(GOFUMPT_VERSION) already installed"; \
 	fi
 	@echo "Running gofumpt fix"
-	@$(INSTALL_PATH)/gofumpt -l -w .
+	@$(INSTALL_PATH)/gofumpt -l -w internal/
+	@$(INSTALL_PATH)/gofumpt -l -w cmd/
+	@$(INSTALL_PATH)/gofumpt -l -w pkg/
+	@$(INSTALL_PATH)/gofumpt -l -w tests/integration/
 	@echo "Running gci fix"
 	@$(INSTALL_PATH)/gci write cmd/ --skip-generated -s standard -s default -s "prefix(github.com/milvus-io)" --custom-order
 	@$(INSTALL_PATH)/gci write internal/ --skip-generated -s standard -s default -s "prefix(github.com/milvus-io)" --custom-order


### PR DESCRIPTION
make command `fix-lint` may fail if `.git` folder contains new file ref or same directory contains folder current user cannot access:
```
Running gofumpt fix
.git/logs/refs/heads/internal/querynodev2/segments/pool.go:1:1: expected 'package', found 0000000000000000000000000000000000000000
.git/logs/refs/heads/internal/querynodev2/segments/pool.go:1:105: illegal character U+0040 '@'
.git/logs/refs/heads/internal/querynodev2/segments/pool.go:1:131: invalid digit '8' in octal literal
open deployments/docker/dev/volumes/etcd/member: permission denied
```
/kind improvement