### PR TITLE
Fix ineffectual assignment in rootcoord unittest

### DIFF
--- a/internal/distributed/utils/util.go
+++ b/internal/distributed/utils/util.go
@@ -3,9 +3,10 @@ package utils
 import (
 	"time"
 
+	"google.golang.org/grpc"
+
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
-	"google.golang.org/grpc"
 )
 
 func GracefulStopGRPCServer(s *grpc.Server) {

--- a/internal/distributed/utils/util_test.go
+++ b/internal/distributed/utils/util_test.go
@@ -3,8 +3,9 @@ package utils
 import (
 	"testing"
 
-	"github.com/milvus-io/milvus/pkg/util/paramtable"
 	"google.golang.org/grpc"
+
+	"github.com/milvus-io/milvus/pkg/util/paramtable"
 )
 
 func TestGracefulStopGrpcServer(t *testing.T) {

--- a/internal/rootcoord/root_coord_test.go
+++ b/internal/rootcoord/root_coord_test.go
@@ -19,7 +19,6 @@ package rootcoord
 import (
 	"context"
 	"fmt"
-	"github.com/milvus-io/milvus/pkg/common"
 	"math/rand"
 	"os"
 	"sync"
@@ -47,6 +46,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/dependency"
 	"github.com/milvus-io/milvus/internal/util/importutil"
 	"github.com/milvus-io/milvus/internal/util/sessionutil"
+	"github.com/milvus-io/milvus/pkg/common"
 	"github.com/milvus-io/milvus/pkg/util/etcd"
 	"github.com/milvus-io/milvus/pkg/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/util/merr"
@@ -1216,6 +1216,7 @@ func TestCore_Import(t *testing.T) {
 				},
 			},
 		})
+		assert.NoError(t, err)
 		assert.ErrorIs(t, merr.Error(resp2.GetStatus()), merr.ErrBulkInsertPartitionNotFound)
 	})
 }


### PR DESCRIPTION
Fix recent pr introduced issue:
```
internal/rootcoord/root_coord_test.go:1209:10: ineffectual assignment to err (ineffassign)
resp2, err := c.Import(ctx, &milvuspb.ImportRequest{
```
/kind improvement