### PR TITLE
Fix query_coord.proto comment format caused lint issue

### DIFF
--- a/internal/proto/query_coord.proto
+++ b/internal/proto/query_coord.proto
@@ -80,7 +80,8 @@ service QueryNode {
   rpc Delete(DeleteRequest) returns (common.Status) {}
 }
 
-//--------------------QueryCoord grpc request and response proto------------------
+// --------------------QueryCoord grpc request and response proto------------------
+
 message ShowCollectionsRequest {
   common.MsgBase base = 1;
   // Not useful for now
@@ -206,7 +207,8 @@ message SyncNewCreatedPartitionRequest {
   int64 partitionID = 3;
 }
 
-//-----------------query node grpc request and response proto----------------
+// -----------------query node grpc request and response proto----------------
+
 message LoadMetaInfo {
   LoadType load_type = 1;
   int64 collectionID = 2;
@@ -351,7 +353,8 @@ message GetLoadInfoResponse {
   repeated int64 partitions = 4;
 }
 
-//----------------request auto triggered by QueryCoord-----------------
+// ----------------request auto triggered by QueryCoord-----------------
+
 message HandoffSegmentsRequest {
   common.MsgBase base = 1;
   repeated SegmentInfo segmentInfos = 2;
@@ -367,7 +370,7 @@ message LoadBalanceRequest {
   int64 collectionID = 6;
 }
 
-//-------------------- internal meta proto------------------
+// -------------------- internal meta proto------------------
 
 enum DataScope {
   UnKnown = 0;
@@ -465,7 +468,8 @@ message UnsubscribeChannelInfo {
   repeated UnsubscribeChannels collection_channels = 2;
 }
 
-//---- synchronize messages proto between QueryCoord and QueryNode -----
+// ---- synchronize messages proto between QueryCoord and QueryNode -----
+
 message SegmentChangeInfo {
   int64 online_nodeID = 1;
   repeated SegmentInfo online_segments = 2;

--- a/internal/proto/querypb/query_coord.pb.go
+++ b/internal/proto/querypb/query_coord.pb.go
@@ -251,7 +251,6 @@ func (SyncType) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_aab7cc9a69ed26e8, []int{6}
 }
 
-//--------------------QueryCoord grpc request and response proto------------------
 type ShowCollectionsRequest struct {
 	Base *commonpb.MsgBase `protobuf:"bytes,1,opt,name=base,proto3" json:"base,omitempty"`
 	// Not useful for now
@@ -1336,7 +1335,6 @@ func (m *SyncNewCreatedPartitionRequest) GetPartitionID() int64 {
 	return 0
 }
 
-//-----------------query node grpc request and response proto----------------
 type LoadMetaInfo struct {
 	LoadType             LoadType `protobuf:"varint,1,opt,name=load_type,json=loadType,proto3,enum=milvus.proto.query.LoadType" json:"load_type,omitempty"`
 	CollectionID         int64    `protobuf:"varint,2,opt,name=collectionID,proto3" json:"collectionID,omitempty"`
@@ -2504,7 +2502,6 @@ func (m *GetLoadInfoResponse) GetPartitions() []int64 {
 	return nil
 }
 
-//----------------request auto triggered by QueryCoord-----------------
 type HandoffSegmentsRequest struct {
 	Base                 *commonpb.MsgBase `protobuf:"bytes,1,opt,name=base,proto3" json:"base,omitempty"`
 	SegmentInfos         []*SegmentInfo    `protobuf:"bytes,2,rep,name=segmentInfos,proto3" json:"segmentInfos,omitempty"`
@@ -3201,7 +3198,6 @@ func (m *UnsubscribeChannelInfo) GetCollectionChannels() []*UnsubscribeChannels 
 	return nil
 }
 
-//---- synchronize messages proto between QueryCoord and QueryNode -----
 type SegmentChangeInfo struct {
 	OnlineNodeID         int64          `protobuf:"varint,1,opt,name=online_nodeID,json=onlineNodeID,proto3" json:"online_nodeID,omitempty"`
 	OnlineSegments       []*SegmentInfo `protobuf:"bytes,2,rep,name=online_segments,json=onlineSegments,proto3" json:"online_segments,omitempty"`


### PR DESCRIPTION
block comment in `query_coord.proto` has no blank line after, which caused generated .pb.go file has lint issue
/kind improvement