### PR TITLE
Add ctx control for observer manual check methods

### DIFF
--- a/internal/querycoordv2/observers/leader_observer_test.go
+++ b/internal/querycoordv2/observers/leader_observer_test.go
@@ -591,6 +591,44 @@ func (suite *LeaderObserverTestSuite) TestSyncTargetVersion() {
 	suite.Len(action.SealedInTarget, 1)
 }
 
+func (suite *LeaderObserverTestSuite) TestCheckTargetVersion() {
+	collectionID := int64(1001)
+	observer := suite.observer
+
+	suite.Run("check_channel_blocked", func() {
+		oldCh := observer.manualCheck
+		defer func() {
+			observer.manualCheck = oldCh
+		}()
+
+		// zero-length channel
+		observer.manualCheck = make(chan checkRequest)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		// cancel context, make test return fast
+		cancel()
+
+		result := observer.CheckTargetVersion(ctx, collectionID)
+		suite.False(result)
+	})
+
+	suite.Run("check_return_ctx_timeout", func() {
+		oldCh := observer.manualCheck
+		defer func() {
+			observer.manualCheck = oldCh
+		}()
+
+		// make channel length = 1, task received
+		observer.manualCheck = make(chan checkRequest, 1)
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*200)
+		defer cancel()
+
+		result := observer.CheckTargetVersion(ctx, collectionID)
+		suite.False(result)
+	})
+}
+
 func TestLeaderObserverSuite(t *testing.T) {
 	suite.Run(t, new(LeaderObserverTestSuite))
 }


### PR DESCRIPTION
See also #27494
This PR shall fix querycoord stuck in `Stop` procedure in collection observer
/kind improvement