### PR TITLE
Fix diskann searchCache param compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,6 @@ index_engine = knowhere
 
 export GIT_BRANCH=master
 
-AZURE_OPTION := ""
 ifeq (${ENABLE_AZURE}, false)
 	AZURE_OPTION := -Z
 endif

--- a/pkg/util/indexparams/disk_index_params.go
+++ b/pkg/util/indexparams/disk_index_params.go
@@ -208,17 +208,17 @@ func SetDiskIndexBuildParams(indexParams map[string]string, fieldDataSize int64)
 	}
 
 	searchCacheBudgetGBRatioStr, ok := indexParams[SearchCacheBudgetRatioKey]
-	if !ok {
-		return fmt.Errorf("index param searchCacheBudgetGBRatio not exist")
-	}
-	SearchCacheBudgetGBRatio, err := strconv.ParseFloat(searchCacheBudgetGBRatioStr, 64)
-	if err != nil {
-		return err
+	// set generate cache size when cache ratio param set
+	if ok {
+		SearchCacheBudgetGBRatio, err := strconv.ParseFloat(searchCacheBudgetGBRatioStr, 64)
+		if err != nil {
+			return err
+		}
+		indexParams[SearchCacheBudgetKey] = fmt.Sprintf("%f", float32(fieldDataSize)*float32(SearchCacheBudgetGBRatio)/(1<<30))
 	}
 	indexParams[PQCodeBudgetKey] = fmt.Sprintf("%f", float32(fieldDataSize)*float32(pqCodeBudgetGBRatio)/(1<<30))
 	indexParams[NumBuildThreadKey] = strconv.Itoa(int(float32(hardware.GetCPUNum()) * float32(buildNumThreadsRatio)))
 	indexParams[BuildDramBudgetKey] = fmt.Sprintf("%f", float32(hardware.GetFreeMemoryCount())/(1<<30))
-	indexParams[SearchCacheBudgetKey] = fmt.Sprintf("%f", float32(fieldDataSize)*float32(SearchCacheBudgetGBRatio)/(1<<30))
 	return nil
 }
 

--- a/pkg/util/indexparams/disk_index_params_test.go
+++ b/pkg/util/indexparams/disk_index_params_test.go
@@ -133,18 +133,26 @@ func TestDiskIndexParams(t *testing.T) {
 		err := SetDiskIndexBuildParams(indexParams, 100)
 		assert.NoError(t, err)
 
+		_, ok := indexParams[SearchCacheBudgetKey]
+		assert.True(t, ok)
+
 		indexParams[SearchCacheBudgetRatioKey] = "aabb"
 		err = SetDiskIndexBuildParams(indexParams, 100)
 		assert.Error(t, err)
 
-		_, ok := indexParams[PQCodeBudgetKey]
+		delete(indexParams, SearchCacheBudgetRatioKey)
+		delete(indexParams, SearchCacheBudgetKey)
+		err = SetDiskIndexBuildParams(indexParams, 100)
+		assert.NoError(t, err)
+
+		_, ok = indexParams[PQCodeBudgetKey]
 		assert.True(t, ok)
 		_, ok = indexParams[BuildDramBudgetKey]
 		assert.True(t, ok)
 		_, ok = indexParams[NumBuildThreadKey]
 		assert.True(t, ok)
 		_, ok = indexParams[SearchCacheBudgetKey]
-		assert.True(t, ok)
+		assert.False(t, ok)
 	})
 
 	t.Run("set disk index load params without auto index param", func(t *testing.T) {


### PR DESCRIPTION
issue: #27556 

Fix the compatibility by setting the default param value when indexnode could not get the param, instead throwing exception before.