### PR TITLE
install ninja in advance for arm64

### DIFF
--- a/build/docker/builder/cpu/ubuntu20.04/Dockerfile
+++ b/build/docker/builder/cpu/ubuntu20.04/Dockerfile
@@ -13,6 +13,8 @@ FROM ubuntu:focal-20220426
 
 ARG TARGETARCH
 
+RUN if [ "$TARGETARCH" = "arm64" ]; then apt-get update && apt-get install -y ninja-build; fi
+
 RUN apt-get update && apt-get install -y --no-install-recommends wget curl ca-certificates gnupg2 \
     g++ gcc gdb gdbserver git make ccache libssl-dev zlib1g-dev zip unzip \
     clang-format-10 clang-tidy-10 lcov libtool m4 autoconf automake python3 python3-pip \

--- a/scripts/azure_build.sh
+++ b/scripts/azure_build.sh
@@ -1,5 +1,10 @@
 ROOT_DIR=$1
 
+ARCHITECTURE=$(uname -m)
+if [[ ${ARCHITECTURE} == "aarch64" ]]; then
+  export VCPKG_FORCE_SYSTEM_BINARIES="arm"
+fi
+
 AZURE_CMAKE_CMD="cmake \
 -DCMAKE_INSTALL_LIBDIR=${ROOT_DIR}/internal/core/output/lib \
 ${ROOT_DIR}/internal/core/src/storage/azure-blob-storage"

--- a/scripts/core_build.sh
+++ b/scripts/core_build.sh
@@ -214,7 +214,10 @@ if [ -z "$BUILD_WITHOUT_AZURE" ]; then
   fi
   pushd ${AZURE_BUILD_DIR}
   env bash ${ROOT_DIR}/scripts/azure_build.sh ${ROOT_DIR}
-  cat vcpkg-bootstrap.log # need to remove
+  if [ ! -e libblob-chunk-manager* ]; then
+    cat vcpkg-bootstrap.log
+    exit 1
+  fi
   popd
   SYSTEM_NAME=$(uname -s)
   if [[ ${SYSTEM_NAME} == "Darwin" ]]; then


### PR DESCRIPTION
/kind bug
to #27579

cannot build image in aarch64, because install vcpkg failed

1. from based-image (build/docker/builder/cpu/ubuntu20.04/Dockerfile)
> unable to determine a binary release of vcpkg, attempting to build from source. [see details](
https://github.com/milvus-io/vcpkg/blob/master/scripts/bootstrap.sh#L191)

2. while build from source, no CMAKE-MAKE-PROGRAM was found, so [install ninja](https://installati.one/install-ninja-build-ubuntu-20-04/?expand_article=1)

3. export VCPKG_FORCE_SYSTEM_BINARIES="arm"