### PR TITLE
speed up shard leader cache update frequency

### DIFF
--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -1087,7 +1087,7 @@ please adjust in embedded Milvus: false`,
 	p.ShardLeaderCacheInterval = ParamItem{
 		Key:          "proxy.shardLeaderCacheInterval",
 		Version:      "2.2.4",
-		DefaultValue: "10",
+		DefaultValue: "3",
 		Doc:          "time interval to update shard leader cache, in seconds",
 	}
 	p.ShardLeaderCacheInterval.Init(base.mgr)


### PR DESCRIPTION
Signed-off-by: Wei Liu <wei.liu@zilliz.com>

speed up shard leader cache update frequency, so when querynode down  or channel balanced, proxy will know the changes in time.

/kind improvement