### PR TITLE
Bug Fix: Sanitize variable which can be controlled by user input

### DIFF
--- a/.github/workflows/check-issue.yaml
+++ b/.github/workflows/check-issue.yaml
@@ -17,9 +17,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Check Issue
+        env:
+          ISSUE_TITLE: ${{ github.event.issue.title }}
         shell: bash
         run: |
-          echo Issue title: ${{ github.event.issue.title }}
+          echo Issue title: "$ISSUE_TITLE"
           cat >> check_title.py << EOF
           import re
           import sys
@@ -32,7 +34,7 @@ jobs:
               print("TITLE_PASSED=T")
           EOF
           
-          python3 check_title.py "${{ github.event.issue.title }}" >> "$GITHUB_ENV"
+          python3 check_title.py "$ISSUE_TITLE" >> "$GITHUB_ENV"
           cat $GITHUB_ENV
 
       - name: Check env


### PR DESCRIPTION
You are using a variable which can be controlled by user input, and it may result in command execution on your runners, and secrets extraction by malicious actors.

Since the ${{ github.event.issue.title }} value can be controlled by the user who creates the issue, a malicious actor can inject system command that will run on the GitHub runner while the workflow is in progress and fetch sensitive data which stored there such as GitHub token with write permissions.

For example:
https://github.com/milvus-io/milvus/actions/runs/6428883091/job/17456874793  You can see in this action that the system command was executed on the runner.

The best practice solution here is to use environment variables instead.

Signed-off-by: Naor Yaacov <naoryaacov@gmail.com>