### PR TITLE
update current target only when next target changed

### DIFF
--- a/internal/querycoordv2/balance/rowcount_based_balancer.go
+++ b/internal/querycoordv2/balance/rowcount_based_balancer.go
@@ -97,8 +97,8 @@ func (b *RowCountBasedBalancer) BalanceReplica(replica *meta.Replica) ([]Segment
 		segments := b.dist.SegmentDistManager.GetByCollectionAndNode(replica.GetCollectionID(), nid)
 		// Only balance segments in targets
 		segments = lo.Filter(segments, func(segment *meta.Segment, _ int) bool {
-			return b.targetMgr.GetHistoricalSegment(segment.GetCollectionID(), segment.GetID(), meta.CurrentTarget) != nil &&
-				b.targetMgr.GetHistoricalSegment(segment.GetCollectionID(), segment.GetID(), meta.NextTarget) != nil
+			return b.targetMgr.GetSealedSegment(segment.GetCollectionID(), segment.GetID(), meta.CurrentTarget) != nil &&
+				b.targetMgr.GetSealedSegment(segment.GetCollectionID(), segment.GetID(), meta.NextTarget) != nil
 		})
 
 		if isStopping, err := b.nodeManager.IsStoppingNode(nid); err != nil {

--- a/internal/querycoordv2/balance/rowcount_based_balancer_test.go
+++ b/internal/querycoordv2/balance/rowcount_based_balancer_test.go
@@ -336,6 +336,11 @@ func (suite *RowCountBasedBalancerTestSuite) TestBalance() {
 		},
 	}
 
+	channels := []*datapb.VchannelInfo{
+		{CollectionID: 1, ChannelName: "v2"},
+		{CollectionID: 1, ChannelName: "v3"},
+	}
+
 	for _, c := range cases {
 		suite.Run(c.name, func() {
 			suite.SetupSuite()
@@ -363,7 +368,7 @@ func (suite *RowCountBasedBalancerTestSuite) TestBalance() {
 					PartitionID: 1,
 				},
 			}
-			suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(nil, segments, nil)
+			suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(channels, segments, nil)
 			collection := utils.CreateTestCollection(1, 1)
 			collection.LoadPercentage = 100
 			collection.Status = querypb.LoadStatus_Loaded
@@ -372,10 +377,10 @@ func (suite *RowCountBasedBalancerTestSuite) TestBalance() {
 			balancer.meta.CollectionManager.PutPartition(utils.CreateTestPartition(1, 1))
 			balancer.meta.ReplicaManager.Put(utils.CreateTestReplica(1, 1, append(c.nodes, c.notExistedNodes...)))
 			suite.broker.ExpectedCalls = nil
-			suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(nil, segments, nil)
-			balancer.targetMgr.UpdateCollectionNextTarget(int64(1))
-			balancer.targetMgr.UpdateCollectionCurrentTarget(1)
-			balancer.targetMgr.UpdateCollectionNextTarget(int64(1))
+			suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(channels, segments, nil)
+			balancer.targetMgr.UpdateNextTarget(int64(1))
+			balancer.targetMgr.UpdateCurrentTarget(1)
+			balancer.targetMgr.UpdateNextTarget(int64(1))
 			suite.mockScheduler.Mock.On("GetNodeChannelDelta", mock.Anything).Return(0)
 			for node, s := range c.distributions {
 				balancer.dist.SegmentDistManager.Update(node, s...)
@@ -556,6 +561,11 @@ func (suite *RowCountBasedBalancerTestSuite) TestBalanceOnPartStopping() {
 		},
 	}
 
+	channels := []*datapb.VchannelInfo{
+		{CollectionID: 1, ChannelName: "v2"},
+		{CollectionID: 1, ChannelName: "v3"},
+	}
+
 	for _, c := range cases {
 		suite.Run(c.name, func() {
 			suite.SetupSuite()
@@ -569,12 +579,12 @@ func (suite *RowCountBasedBalancerTestSuite) TestBalanceOnPartStopping() {
 			balancer.meta.CollectionManager.PutCollection(collection)
 			balancer.meta.CollectionManager.PutPartition(utils.CreateTestPartition(1, 1))
 			balancer.meta.ReplicaManager.Put(utils.CreateTestReplica(1, 1, append(c.nodes, c.notExistedNodes...)))
-			suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(nil, c.segmentInCurrent, nil)
-			balancer.targetMgr.UpdateCollectionNextTarget(int64(1))
-			balancer.targetMgr.UpdateCollectionCurrentTarget(1)
+			suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(channels, c.segmentInCurrent, nil)
+			balancer.targetMgr.UpdateNextTarget(int64(1))
+			balancer.targetMgr.UpdateCurrentTarget(1)
 			suite.broker.ExpectedCalls = nil
-			suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(nil, c.segmentInNext, nil)
-			balancer.targetMgr.UpdateCollectionNextTarget(int64(1))
+			suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(channels, c.segmentInNext, nil)
+			balancer.targetMgr.UpdateNextTarget(int64(1))
 			suite.mockScheduler.Mock.On("GetNodeChannelDelta", mock.Anything).Return(0)
 			for node, s := range c.distributions {
 				balancer.dist.SegmentDistManager.Update(node, s...)
@@ -675,16 +685,21 @@ func (suite *RowCountBasedBalancerTestSuite) TestBalanceOutboundNodes() {
 				},
 			}
 
+			channels := []*datapb.VchannelInfo{
+				{CollectionID: 1, ChannelName: "v2"},
+				{CollectionID: 1, ChannelName: "v3"},
+			}
+
 			collection.LoadPercentage = 100
 			collection.Status = querypb.LoadStatus_Loaded
 			collection.LoadType = querypb.LoadType_LoadCollection
 			balancer.meta.CollectionManager.PutCollection(collection)
 			balancer.meta.CollectionManager.PutPartition(utils.CreateTestPartition(1, 1))
 			balancer.meta.ReplicaManager.Put(utils.CreateTestReplica(1, 1, append(c.nodes, c.notExistedNodes...)))
-			suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(nil, segments, nil)
-			balancer.targetMgr.UpdateCollectionNextTarget(int64(1))
-			balancer.targetMgr.UpdateCollectionCurrentTarget(1)
-			balancer.targetMgr.UpdateCollectionNextTarget(int64(1))
+			suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(channels, segments, nil)
+			balancer.targetMgr.UpdateNextTarget(int64(1))
+			balancer.targetMgr.UpdateCurrentTarget(1)
+			balancer.targetMgr.UpdateNextTarget(int64(1))
 			for node, s := range c.distributions {
 				balancer.dist.SegmentDistManager.Update(node, s...)
 			}

--- a/internal/querycoordv2/balance/score_based_balancer.go
+++ b/internal/querycoordv2/balance/score_based_balancer.go
@@ -122,7 +122,7 @@ func (b *ScoreBasedBalancer) BalanceReplica(replica *meta.Replica) ([]SegmentAss
 		segments := b.dist.SegmentDistManager.GetByCollectionAndNode(replica.GetCollectionID(), nid)
 		// Only balance segments in targets
 		segments = lo.Filter(segments, func(segment *meta.Segment, _ int) bool {
-			return b.targetMgr.GetHistoricalSegment(segment.GetCollectionID(), segment.GetID(), meta.CurrentTarget) != nil
+			return b.targetMgr.GetSealedSegment(segment.GetCollectionID(), segment.GetID(), meta.CurrentTarget) != nil
 		})
 
 		if isStopping, err := b.nodeManager.IsStoppingNode(nid); err != nil {

--- a/internal/querycoordv2/balance/score_based_balancer_test.go
+++ b/internal/querycoordv2/balance/score_based_balancer_test.go
@@ -308,8 +308,8 @@ func (suite *ScoreBasedBalancerTestSuite) TestBalanceOneRound() {
 			balancer.meta.CollectionManager.PutCollection(collection)
 			balancer.meta.CollectionManager.PutPartition(utils.CreateTestPartition(c.collectionID, c.collectionID))
 			balancer.meta.ReplicaManager.Put(utils.CreateTestReplica(c.replicaID, c.collectionID, c.nodes))
-			balancer.targetMgr.UpdateCollectionNextTarget(c.collectionID)
-			balancer.targetMgr.UpdateCollectionCurrentTarget(c.collectionID)
+			balancer.targetMgr.UpdateNextTarget(c.collectionID)
+			balancer.targetMgr.UpdateCurrentTarget(c.collectionID)
 
 			// 2. set up target for distribution for multi collections
 			for node, s := range c.distributions {
@@ -418,8 +418,8 @@ func (suite *ScoreBasedBalancerTestSuite) TestBalanceMultiRound() {
 		balancer.meta.CollectionManager.PutPartition(utils.CreateTestPartition(balanceCase.collectionIDs[i], balanceCase.collectionIDs[i]))
 		balancer.meta.ReplicaManager.Put(utils.CreateTestReplica(balanceCase.replicaIDs[i], balanceCase.collectionIDs[i],
 			append(balanceCase.nodes, balanceCase.notExistedNodes...)))
-		balancer.targetMgr.UpdateCollectionNextTarget(balanceCase.collectionIDs[i])
-		balancer.targetMgr.UpdateCollectionCurrentTarget(balanceCase.collectionIDs[i])
+		balancer.targetMgr.UpdateNextTarget(balanceCase.collectionIDs[i])
+		balancer.targetMgr.UpdateCurrentTarget(balanceCase.collectionIDs[i])
 	}
 
 	// 2. set up target for distribution for multi collections
@@ -540,6 +540,11 @@ func (suite *ScoreBasedBalancerTestSuite) TestStoppedBalance() {
 			expectChannelPlans: []ChannelAssignPlan{},
 		},
 	}
+
+	channels := []*datapb.VchannelInfo{
+		{CollectionID: 1, ChannelName: "v2"},
+		{CollectionID: 1, ChannelName: "v3"},
+	}
 	for i, c := range cases {
 		suite.Run(c.name, func() {
 			if i == 0 {
@@ -552,15 +557,15 @@ func (suite *ScoreBasedBalancerTestSuite) TestStoppedBalance() {
 			// 1. set up target for multi collections
 			collection := utils.CreateTestCollection(c.collectionID, int32(c.replicaID))
 			suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, c.collectionID).Return(
-				nil, c.collectionsSegments, nil)
+				channels, c.collectionsSegments, nil)
 			suite.broker.EXPECT().GetPartitions(mock.Anything, c.collectionID).Return([]int64{c.collectionID}, nil).Maybe()
 			collection.LoadPercentage = 100
 			collection.Status = querypb.LoadStatus_Loaded
 			balancer.meta.CollectionManager.PutCollection(collection)
 			balancer.meta.CollectionManager.PutPartition(utils.CreateTestPartition(c.collectionID, c.collectionID))
 			balancer.meta.ReplicaManager.Put(utils.CreateTestReplica(c.replicaID, c.collectionID, c.nodes))
-			balancer.targetMgr.UpdateCollectionNextTarget(c.collectionID)
-			balancer.targetMgr.UpdateCollectionCurrentTarget(c.collectionID)
+			balancer.targetMgr.UpdateNextTarget(c.collectionID)
+			balancer.targetMgr.UpdateCurrentTarget(c.collectionID)
 
 			// 2. set up target for distribution for multi collections
 			for node, s := range c.distributions {

--- a/internal/querycoordv2/checkers/channel_checker.go
+++ b/internal/querycoordv2/checkers/channel_checker.go
@@ -61,7 +61,7 @@ func (c *ChannelChecker) Description() string {
 
 func (c *ChannelChecker) readyToCheck(collectionID int64) bool {
 	metaExist := (c.meta.GetCollection(collectionID) != nil)
-	targetExist := c.targetMgr.IsNextTargetExist(collectionID) || c.targetMgr.IsCurrentTargetExist(collectionID)
+	targetExist := c.targetMgr.IsTargetExist(collectionID, meta.NextTarget) || c.targetMgr.IsTargetExist(collectionID, meta.CurrentTarget)
 
 	return metaExist && targetExist
 }

--- a/internal/querycoordv2/checkers/channel_checker_test.go
+++ b/internal/querycoordv2/checkers/channel_checker_test.go
@@ -120,7 +120,7 @@ func (suite *ChannelCheckerTestSuite) TestLoadChannel() {
 
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
 		channels, nil, nil)
-	checker.targetMgr.UpdateCollectionNextTarget(int64(1))
+	checker.targetMgr.UpdateNextTarget(int64(1))
 
 	tasks := checker.Check(context.TODO())
 	suite.Len(tasks, 1)
@@ -147,8 +147,8 @@ func (suite *ChannelCheckerTestSuite) TestReduceChannel() {
 	}
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
 		channels, nil, nil)
-	checker.targetMgr.UpdateCollectionNextTarget(int64(1))
-	checker.targetMgr.UpdateCollectionCurrentTarget(int64(1))
+	checker.targetMgr.UpdateNextTarget(int64(1))
+	checker.targetMgr.UpdateCurrentTarget(int64(1))
 
 	checker.dist.ChannelDistManager.Update(1, utils.CreateTestChannel(1, 1, 1, "test-insert-channel1"))
 	checker.dist.ChannelDistManager.Update(1, utils.CreateTestChannel(1, 1, 1, "test-insert-channel2"))
@@ -186,7 +186,7 @@ func (suite *ChannelCheckerTestSuite) TestRepeatedChannels() {
 	}
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
 		channels, segments, nil)
-	checker.targetMgr.UpdateCollectionNextTarget(int64(1))
+	checker.targetMgr.UpdateNextTarget(int64(1))
 	checker.dist.ChannelDistManager.Update(1, utils.CreateTestChannel(1, 1, 1, "test-insert-channel"))
 	checker.dist.ChannelDistManager.Update(2, utils.CreateTestChannel(1, 2, 2, "test-insert-channel"))
 

--- a/internal/querycoordv2/checkers/controller_test.go
+++ b/internal/querycoordv2/checkers/controller_test.go
@@ -111,7 +111,7 @@ func (suite *CheckerControllerSuite) TestBasic() {
 	}
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
 		channels, segments, nil)
-	suite.targetManager.UpdateCollectionNextTarget(int64(1))
+	suite.targetManager.UpdateNextTarget(int64(1))
 
 	// set dist
 	suite.dist.ChannelDistManager.Update(2, utils.CreateTestChannel(1, 2, 1, "test-insert-channel"))

--- a/internal/querycoordv2/checkers/segment_checker_test.go
+++ b/internal/querycoordv2/checkers/segment_checker_test.go
@@ -132,7 +132,7 @@ func (suite *SegmentCheckerTestSuite) TestLoadSegments() {
 
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
 		channels, segments, nil)
-	checker.targetMgr.UpdateCollectionNextTarget(int64(1))
+	checker.targetMgr.UpdateNextTarget(int64(1))
 
 	// set dist
 	checker.dist.ChannelDistManager.Update(2, utils.CreateTestChannel(1, 2, 1, "test-insert-channel"))
@@ -177,7 +177,7 @@ func (suite *SegmentCheckerTestSuite) TestSkipCheckReplica() {
 	}
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
 		channels, segments, nil)
-	checker.targetMgr.UpdateCollectionNextTarget(int64(1))
+	checker.targetMgr.UpdateNextTarget(int64(1))
 
 	// set dist
 	checker.dist.ChannelDistManager.Update(1, utils.CreateTestChannel(1, 1, 1, "test-insert-channel"))
@@ -205,7 +205,7 @@ func (suite *SegmentCheckerTestSuite) TestReleaseSegments() {
 	}
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
 		channels, nil, nil)
-	checker.targetMgr.UpdateCollectionNextTarget(int64(1))
+	checker.targetMgr.UpdateNextTarget(int64(1))
 
 	// set dist
 	checker.dist.ChannelDistManager.Update(2, utils.CreateTestChannel(1, 2, 1, "test-insert-channel"))
@@ -246,7 +246,7 @@ func (suite *SegmentCheckerTestSuite) TestReleaseRepeatedSegments() {
 	}
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
 		channels, segments, nil)
-	checker.targetMgr.UpdateCollectionNextTarget(int64(1))
+	checker.targetMgr.UpdateNextTarget(int64(1))
 
 	// set dist
 	checker.dist.ChannelDistManager.Update(2, utils.CreateTestChannel(1, 2, 1, "test-insert-channel"))
@@ -293,8 +293,8 @@ func (suite *SegmentCheckerTestSuite) TestSkipReleaseSealedSegments() {
 	segments := []*datapb.SegmentInfo{}
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
 		channels, segments, nil)
-	checker.targetMgr.UpdateCollectionNextTarget(collectionID)
-	checker.targetMgr.UpdateCollectionCurrentTarget(collectionID)
+	checker.targetMgr.UpdateNextTarget(collectionID)
+	checker.targetMgr.UpdateCurrentTarget(collectionID)
 	readableVersion := checker.targetMgr.GetCollectionTargetVersion(collectionID, meta.CurrentTarget)
 
 	// set dist
@@ -349,8 +349,8 @@ func (suite *SegmentCheckerTestSuite) TestReleaseGrowingSegments() {
 	}
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
 		channels, segments, nil)
-	checker.targetMgr.UpdateCollectionNextTarget(int64(1))
-	checker.targetMgr.UpdateCollectionCurrentTarget(int64(1))
+	checker.targetMgr.UpdateNextTarget(int64(1))
+	checker.targetMgr.UpdateCurrentTarget(int64(1))
 
 	growingSegments := make(map[int64]*meta.Segment)
 	growingSegments[2] = utils.CreateTestSegment(1, 1, 2, 2, 0, "test-insert-channel")
@@ -408,8 +408,8 @@ func (suite *SegmentCheckerTestSuite) TestSkipReleaseGrowingSegments() {
 	}
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
 		channels, segments, nil)
-	checker.targetMgr.UpdateCollectionNextTarget(int64(1))
-	checker.targetMgr.UpdateCollectionCurrentTarget(int64(1))
+	checker.targetMgr.UpdateNextTarget(int64(1))
+	checker.targetMgr.UpdateCurrentTarget(int64(1))
 
 	growingSegments := make(map[int64]*meta.Segment)
 	growingSegments[2] = utils.CreateTestSegment(1, 1, 2, 2, 0, "test-insert-channel")

--- a/internal/querycoordv2/dist/dist_handler.go
+++ b/internal/querycoordv2/dist/dist_handler.go
@@ -114,10 +114,10 @@ func (dh *distHandler) updateSegmentsDistribution(resp *querypb.GetDataDistribut
 	updates := make([]*meta.Segment, 0, len(resp.GetSegments()))
 	for _, s := range resp.GetSegments() {
 		// for collection which is already loaded
-		segmentInfo := dh.target.GetHistoricalSegment(s.GetCollection(), s.GetID(), meta.CurrentTarget)
+		segmentInfo := dh.target.GetSealedSegment(s.GetCollection(), s.GetID(), meta.CurrentTarget)
 		if segmentInfo == nil {
 			// for collection which is loading
-			segmentInfo = dh.target.GetHistoricalSegment(s.GetCollection(), s.GetID(), meta.NextTarget)
+			segmentInfo = dh.target.GetSealedSegment(s.GetCollection(), s.GetID(), meta.NextTarget)
 		}
 		var segment *meta.Segment
 		if segmentInfo == nil {

--- a/internal/querycoordv2/handlers.go
+++ b/internal/querycoordv2/handlers.go
@@ -62,7 +62,7 @@ func (s *Server) checkAnyReplicaAvailable(collectionID int64) bool {
 
 func (s *Server) getCollectionSegmentInfo(collection int64) []*querypb.SegmentInfo {
 	segments := s.dist.SegmentDistManager.GetByCollection(collection)
-	currentTargetSegmentsMap := s.targetMgr.GetHistoricalSegmentsByCollection(collection, meta.CurrentTarget)
+	currentTargetSegmentsMap := s.targetMgr.GetSealedSegmentByCollection(collection, meta.CurrentTarget)
 	infos := make(map[int64]*querypb.SegmentInfo)
 	for _, segment := range segments {
 		if _, existCurrentTarget := currentTargetSegmentsMap[segment.GetID()]; !existCurrentTarget {
@@ -109,7 +109,7 @@ func (s *Server) balanceSegments(ctx context.Context, req *querypb.LoadBalanceRe
 	// Only balance segments in targets
 	segments := s.dist.SegmentDistManager.GetByCollectionAndNode(req.GetCollectionID(), srcNode)
 	segments = lo.Filter(segments, func(segment *meta.Segment, _ int) bool {
-		return s.targetMgr.GetHistoricalSegment(segment.GetCollectionID(), segment.GetID(), meta.CurrentTarget) != nil
+		return s.targetMgr.GetSealedSegment(segment.GetCollectionID(), segment.GetID(), meta.CurrentTarget) != nil
 	})
 	allSegments := make(map[int64]*meta.Segment)
 	for _, segment := range segments {

--- a/internal/querycoordv2/observers/collection_observer.go
+++ b/internal/querycoordv2/observers/collection_observer.go
@@ -149,7 +149,7 @@ func (ob *CollectionObserver) observeTimeout() {
 
 func (ob *CollectionObserver) readyToObserve(collectionID int64) bool {
 	metaExist := (ob.meta.GetCollection(collectionID) != nil)
-	targetExist := ob.targetMgr.IsNextTargetExist(collectionID) || ob.targetMgr.IsCurrentTargetExist(collectionID)
+	targetExist := ob.targetMgr.IsTargetExist(collectionID, meta.NextTarget) || ob.targetMgr.IsTargetExist(collectionID, meta.CurrentTarget)
 
 	return metaExist && targetExist
 }
@@ -182,7 +182,7 @@ func (ob *CollectionObserver) observePartitionLoadStatus(ctx context.Context, pa
 		zap.Int64("partitionID", partition.GetPartitionID()),
 	)
 
-	segmentTargets := ob.targetMgr.GetHistoricalSegmentsByPartition(partition.GetCollectionID(), partition.GetPartitionID(), meta.NextTarget)
+	segmentTargets := ob.targetMgr.GetSealedSegmentByPartition(partition.GetCollectionID(), partition.GetPartitionID(), meta.NextTarget)
 	channelTargets := ob.targetMgr.GetDmChannelsByCollection(partition.GetCollectionID(), meta.NextTarget)
 
 	targetNum := len(segmentTargets) + len(channelTargets)

--- a/internal/querycoordv2/observers/leader_observer.go
+++ b/internal/querycoordv2/observers/leader_observer.go
@@ -99,7 +99,7 @@ func (o *LeaderObserver) observe(ctx context.Context) {
 
 func (o *LeaderObserver) readyToObserve(collectionID int64) bool {
 	metaExist := (o.meta.GetCollection(collectionID) != nil)
-	targetExist := o.target.IsNextTargetExist(collectionID) || o.target.IsCurrentTargetExist(collectionID)
+	targetExist := o.target.IsTargetExist(collectionID, meta.CurrentTarget) || o.target.IsTargetExist(collectionID, meta.NextTarget)
 
 	return metaExist && targetExist
 }
@@ -184,8 +184,8 @@ func (o *LeaderObserver) checkNeedUpdateTargetVersion(ctx context.Context, leade
 		zap.Int64("newVersion", targetVersion),
 	)
 
-	sealedSegments := o.target.GetHistoricalSegmentsByChannel(leaderView.CollectionID, leaderView.Channel, meta.CurrentTarget)
-	growingSegments := o.target.GetStreamingSegmentsByChannel(leaderView.CollectionID, leaderView.Channel, meta.CurrentTarget)
+	sealedSegments := o.target.GetSealedSegmentByChannel(leaderView.CollectionID, leaderView.Channel, meta.CurrentTarget)
+	growingSegments := o.target.GetGrowingSegmentsByChannel(leaderView.CollectionID, leaderView.Channel, meta.CurrentTarget)
 	droppedSegments := o.target.GetDroppedSegmentsByChannel(leaderView.CollectionID, leaderView.Channel, meta.CurrentTarget)
 
 	return &querypb.SyncAction{
@@ -202,9 +202,9 @@ func (o *LeaderObserver) findNeedLoadedSegments(leaderView *meta.LeaderView, dis
 	dists = utils.FindMaxVersionSegments(dists)
 	for _, s := range dists {
 		version, ok := leaderView.Segments[s.GetID()]
-		currentTarget := o.target.GetHistoricalSegment(s.CollectionID, s.GetID(), meta.CurrentTarget)
+		currentTarget := o.target.GetSealedSegment(s.CollectionID, s.GetID(), meta.CurrentTarget)
 		existInCurrentTarget := currentTarget != nil
-		existInNextTarget := o.target.GetHistoricalSegment(s.CollectionID, s.GetID(), meta.NextTarget) != nil
+		existInNextTarget := o.target.GetSealedSegment(s.CollectionID, s.GetID(), meta.NextTarget) != nil
 
 		if !existInCurrentTarget && !existInNextTarget {
 			continue
@@ -246,8 +246,8 @@ func (o *LeaderObserver) findNeedRemovedSegments(leaderView *meta.LeaderView, di
 	}
 	for sid, s := range leaderView.Segments {
 		_, ok := distMap[sid]
-		existInCurrentTarget := o.target.GetHistoricalSegment(leaderView.CollectionID, sid, meta.CurrentTarget) != nil
-		existInNextTarget := o.target.GetHistoricalSegment(leaderView.CollectionID, sid, meta.NextTarget) != nil
+		existInCurrentTarget := o.target.GetSealedSegment(leaderView.CollectionID, sid, meta.CurrentTarget) != nil
+		existInNextTarget := o.target.GetSealedSegment(leaderView.CollectionID, sid, meta.NextTarget) != nil
 		if ok || existInCurrentTarget || existInNextTarget {
 			continue
 		}

--- a/internal/querycoordv2/observers/leader_observer_test.go
+++ b/internal/querycoordv2/observers/leader_observer_test.go
@@ -121,8 +121,8 @@ func (suite *LeaderObserverTestSuite) TestSyncLoadedSegments() {
 		&datapb.GetSegmentInfoResponse{Infos: []*datapb.SegmentInfo{info}}, nil)
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
 		channels, segments, nil)
-	observer.target.UpdateCollectionNextTarget(int64(1))
-	observer.target.UpdateCollectionCurrentTarget(1)
+	observer.target.UpdateNextTarget(int64(1))
+	observer.target.UpdateCurrentTarget(1)
 	observer.dist.SegmentDistManager.Update(1, utils.CreateTestSegment(1, 1, 1, 2, 1, "test-insert-channel"))
 	observer.dist.ChannelDistManager.Update(2, utils.CreateTestChannel(1, 2, 1, "test-insert-channel"))
 	view := utils.CreateTestLeaderView(2, 1, "test-insert-channel", map[int64]int64{}, map[int64]*meta.Segment{})
@@ -211,9 +211,9 @@ func (suite *LeaderObserverTestSuite) TestIgnoreSyncLoadedSegments() {
 		&datapb.GetSegmentInfoResponse{Infos: []*datapb.SegmentInfo{info}}, nil)
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
 		channels, segments, nil)
-	observer.target.UpdateCollectionNextTarget(int64(1))
-	observer.target.UpdateCollectionCurrentTarget(1)
-	observer.target.UpdateCollectionNextTarget(int64(1))
+	observer.target.UpdateNextTarget(int64(1))
+	observer.target.UpdateCurrentTarget(1)
+	observer.target.UpdateNextTarget(int64(1))
 	observer.dist.SegmentDistManager.Update(1, utils.CreateTestSegment(1, 1, 1, 2, 1, "test-insert-channel"),
 		utils.CreateTestSegment(1, 1, 2, 2, 1, "test-insert-channel"))
 	observer.dist.ChannelDistManager.Update(2, utils.CreateTestChannel(1, 2, 1, "test-insert-channel"))
@@ -289,8 +289,8 @@ func (suite *LeaderObserverTestSuite) TestIgnoreBalancedSegment() {
 
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
 		channels, segments, nil)
-	observer.target.UpdateCollectionNextTarget(int64(1))
-	observer.target.UpdateCollectionCurrentTarget(1)
+	observer.target.UpdateNextTarget(int64(1))
+	observer.target.UpdateCurrentTarget(1)
 	observer.dist.SegmentDistManager.Update(1, utils.CreateTestSegment(1, 1, 1, 1, 1, "test-insert-channel"))
 	observer.dist.ChannelDistManager.Update(2, utils.CreateTestChannel(1, 2, 1, "test-insert-channel"))
 
@@ -343,8 +343,8 @@ func (suite *LeaderObserverTestSuite) TestSyncLoadedSegmentsWithReplicas() {
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
 		channels, segments, nil)
 	suite.broker.EXPECT().GetCollectionSchema(mock.Anything, int64(1)).Return(schema, nil)
-	observer.target.UpdateCollectionNextTarget(int64(1))
-	observer.target.UpdateCollectionCurrentTarget(1)
+	observer.target.UpdateNextTarget(int64(1))
+	observer.target.UpdateCurrentTarget(1)
 	observer.dist.SegmentDistManager.Update(1, utils.CreateTestSegment(1, 1, 1, 1, 1, "test-insert-channel"))
 	observer.dist.SegmentDistManager.Update(4, utils.CreateTestSegment(1, 1, 1, 4, 2, "test-insert-channel"))
 	observer.dist.ChannelDistManager.Update(2, utils.CreateTestChannel(1, 2, 1, "test-insert-channel"))
@@ -421,8 +421,8 @@ func (suite *LeaderObserverTestSuite) TestSyncRemovedSegments() {
 
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
 		channels, nil, nil)
-	observer.target.UpdateCollectionNextTarget(int64(1))
-	observer.target.UpdateCollectionCurrentTarget(1)
+	observer.target.UpdateNextTarget(int64(1))
+	observer.target.UpdateCurrentTarget(1)
 
 	observer.dist.ChannelDistManager.Update(2, utils.CreateTestChannel(1, 2, 1, "test-insert-channel"))
 	view := utils.CreateTestLeaderView(2, 1, "test-insert-channel", map[int64]int64{3: 2}, map[int64]*meta.Segment{})
@@ -493,7 +493,7 @@ func (suite *LeaderObserverTestSuite) TestIgnoreSyncRemovedSegments() {
 	suite.broker.EXPECT().GetCollectionSchema(mock.Anything, int64(1)).Return(schema, nil)
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
 		channels, segments, nil)
-	observer.target.UpdateCollectionNextTarget(int64(1))
+	observer.target.UpdateNextTarget(int64(1))
 
 	observer.dist.ChannelDistManager.Update(2, utils.CreateTestChannel(1, 2, 1, "test-insert-channel"))
 	observer.dist.LeaderViewManager.Update(2, utils.CreateTestLeaderView(2, 1, "test-insert-channel", map[int64]int64{3: 2, 2: 2}, map[int64]*meta.Segment{}))
@@ -574,8 +574,8 @@ func (suite *LeaderObserverTestSuite) TestSyncTargetVersion() {
 	}
 
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, collectionID).Return(nextTargetChannels, nextTargetSegments, nil)
-	suite.observer.target.UpdateCollectionNextTarget(collectionID)
-	suite.observer.target.UpdateCollectionCurrentTarget(collectionID)
+	suite.observer.target.UpdateNextTarget(collectionID)
+	suite.observer.target.UpdateCurrentTarget(collectionID)
 	TargetVersion := suite.observer.target.GetCollectionTargetVersion(collectionID, meta.CurrentTarget)
 
 	view := utils.CreateTestLeaderView(1, collectionID, "channel-1", nil, nil)

--- a/internal/querycoordv2/observers/target_observer_test.go
+++ b/internal/querycoordv2/observers/target_observer_test.go
@@ -126,7 +126,7 @@ func (suite *TargetObserverSuite) SetupTest() {
 
 func (suite *TargetObserverSuite) TestTriggerUpdateTarget() {
 	suite.Eventually(func() bool {
-		return len(suite.targetMgr.GetHistoricalSegmentsByCollection(suite.collectionID, meta.NextTarget)) == 2 &&
+		return len(suite.targetMgr.GetSealedSegmentByCollection(suite.collectionID, meta.NextTarget)) == 2 &&
 			len(suite.targetMgr.GetDmChannelsByCollection(suite.collectionID, meta.NextTarget)) == 2
 	}, 5*time.Second, 1*time.Second)
 
@@ -161,14 +161,14 @@ func (suite *TargetObserverSuite) TestTriggerUpdateTarget() {
 		PartitionID:   suite.partitionID,
 		InsertChannel: "channel-1",
 	})
-	suite.targetMgr.UpdateCollectionCurrentTarget(suite.collectionID)
+	// suite.targetMgr.UpdateCurrentTarget(suite.collectionID)
 
 	// Pull next again
 	suite.broker.EXPECT().
 		GetRecoveryInfoV2(mock.Anything, mock.Anything).
 		Return(suite.nextTargetChannels, suite.nextTargetSegments, nil)
 	suite.Eventually(func() bool {
-		return len(suite.targetMgr.GetHistoricalSegmentsByCollection(suite.collectionID, meta.NextTarget)) == 3 &&
+		return len(suite.targetMgr.GetSealedSegmentByCollection(suite.collectionID, meta.NextTarget)) == 3 &&
 			len(suite.targetMgr.GetDmChannelsByCollection(suite.collectionID, meta.NextTarget)) == 2
 	}, 7*time.Second, 1*time.Second)
 	suite.broker.AssertExpectations(suite.T())
@@ -206,7 +206,7 @@ func (suite *TargetObserverSuite) TestTriggerUpdateTarget() {
 		default:
 		}
 		return isReady &&
-			len(suite.targetMgr.GetHistoricalSegmentsByCollection(suite.collectionID, meta.CurrentTarget)) == 3 &&
+			len(suite.targetMgr.GetSealedSegmentByCollection(suite.collectionID, meta.CurrentTarget)) == 3 &&
 			len(suite.targetMgr.GetDmChannelsByCollection(suite.collectionID, meta.CurrentTarget)) == 2
 	}, 7*time.Second, 1*time.Second)
 }

--- a/internal/querycoordv2/services.go
+++ b/internal/querycoordv2/services.go
@@ -876,7 +876,7 @@ func (s *Server) GetShardLeaders(ctx context.Context, req *querypb.GetShardLeade
 		return resp, nil
 	}
 
-	currentTargets := s.targetMgr.GetHistoricalSegmentsByCollection(req.GetCollectionID(), meta.CurrentTarget)
+	currentTargets := s.targetMgr.GetSealedSegmentByCollection(req.GetCollectionID(), meta.CurrentTarget)
 	for _, channel := range channels {
 		log := log.With(zap.String("channel", channel.GetChannelName()))
 

--- a/internal/querycoordv2/services_test.go
+++ b/internal/querycoordv2/services_test.go
@@ -1623,7 +1623,7 @@ func (suite *ServiceSuite) loadAll() {
 			suite.EqualValues(suite.replicaNumber[collection], suite.meta.GetReplicaNumber(collection))
 			suite.True(suite.meta.Exist(collection))
 			suite.NotNil(suite.meta.GetCollection(collection))
-			suite.targetMgr.UpdateCollectionCurrentTarget(collection)
+			suite.targetMgr.UpdateCurrentTarget(collection)
 		} else {
 			req := &querypb.LoadPartitionsRequest{
 				CollectionID:  collection,
@@ -1647,7 +1647,7 @@ func (suite *ServiceSuite) loadAll() {
 			suite.EqualValues(suite.replicaNumber[collection], suite.meta.GetReplicaNumber(collection))
 			suite.True(suite.meta.Exist(collection))
 			suite.NotNil(suite.meta.GetPartitionsByCollection(collection))
-			suite.targetMgr.UpdateCollectionCurrentTarget(collection)
+			suite.targetMgr.UpdateCurrentTarget(collection)
 		}
 	}
 }
@@ -1659,7 +1659,7 @@ func (suite *ServiceSuite) assertLoaded(collection int64) {
 	}
 	for _, partitions := range suite.segments[collection] {
 		for _, segment := range partitions {
-			suite.NotNil(suite.targetMgr.GetHistoricalSegment(collection, segment, meta.NextTarget))
+			suite.NotNil(suite.targetMgr.GetSealedSegment(collection, segment, meta.NextTarget))
 		}
 	}
 }
@@ -1675,7 +1675,7 @@ func (suite *ServiceSuite) assertPartitionLoaded(collection int64, partitions ..
 			continue
 		}
 		for _, segment := range segments {
-			suite.NotNil(suite.targetMgr.GetHistoricalSegment(collection, segment, meta.CurrentTarget))
+			suite.NotNil(suite.targetMgr.GetSealedSegment(collection, segment, meta.CurrentTarget))
 		}
 	}
 }
@@ -1687,8 +1687,8 @@ func (suite *ServiceSuite) assertReleased(collection int64) {
 	}
 	for _, partitions := range suite.segments[collection] {
 		for _, segment := range partitions {
-			suite.Nil(suite.targetMgr.GetHistoricalSegment(collection, segment, meta.CurrentTarget))
-			suite.Nil(suite.targetMgr.GetHistoricalSegment(collection, segment, meta.NextTarget))
+			suite.Nil(suite.targetMgr.GetSealedSegment(collection, segment, meta.CurrentTarget))
+			suite.Nil(suite.targetMgr.GetSealedSegment(collection, segment, meta.NextTarget))
 		}
 	}
 }

--- a/internal/querycoordv2/task/scheduler.go
+++ b/internal/querycoordv2/task/scheduler.go
@@ -502,7 +502,7 @@ func (scheduler *taskScheduler) GetNodeSegmentCntDelta(nodeID int64) int {
 				continue
 			}
 			segmentAction := action.(*SegmentAction)
-			segment := scheduler.targetMgr.GetHistoricalSegment(task.CollectionID(), segmentAction.SegmentID(), meta.NextTarget)
+			segment := scheduler.targetMgr.GetSealedSegment(task.CollectionID(), segmentAction.SegmentID(), meta.NextTarget)
 			if action.Type() == ActionTypeGrow {
 				delta += int(segment.GetNumOfRows())
 			} else {
@@ -586,9 +586,9 @@ func (scheduler *taskScheduler) isRelated(task Task, node int64) bool {
 			taskType := GetTaskType(task)
 			var segment *datapb.SegmentInfo
 			if taskType == TaskTypeMove || taskType == TaskTypeUpdate {
-				segment = scheduler.targetMgr.GetHistoricalSegment(task.CollectionID(), task.SegmentID(), meta.CurrentTarget)
+				segment = scheduler.targetMgr.GetSealedSegment(task.CollectionID(), task.SegmentID(), meta.CurrentTarget)
 			} else {
-				segment = scheduler.targetMgr.GetHistoricalSegment(task.CollectionID(), task.SegmentID(), meta.NextTarget)
+				segment = scheduler.targetMgr.GetSealedSegment(task.CollectionID(), task.SegmentID(), meta.NextTarget)
 			}
 			if segment == nil {
 				continue
@@ -779,9 +779,9 @@ func (scheduler *taskScheduler) checkSegmentTaskStale(task *SegmentTask) error {
 			taskType := GetTaskType(task)
 			var segment *datapb.SegmentInfo
 			if taskType == TaskTypeMove || taskType == TaskTypeUpdate {
-				segment = scheduler.targetMgr.GetHistoricalSegment(task.CollectionID(), task.SegmentID(), meta.CurrentTarget)
+				segment = scheduler.targetMgr.GetSealedSegment(task.CollectionID(), task.SegmentID(), meta.CurrentTarget)
 			} else {
-				segment = scheduler.targetMgr.GetHistoricalSegment(task.CollectionID(), task.SegmentID(), meta.NextTarget)
+				segment = scheduler.targetMgr.GetSealedSegment(task.CollectionID(), task.SegmentID(), meta.NextTarget)
 			}
 			if segment == nil {
 				log.Warn("task stale due to the segment to load not exists in targets",

--- a/internal/querycoordv2/task/task_test.go
+++ b/internal/querycoordv2/task/task_test.go
@@ -253,7 +253,7 @@ func (suite *TaskSuite) TestSubscribeChannelTask() {
 		suite.NoError(err)
 	}
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection).Return(dmChannels, nil, nil)
-	suite.target.UpdateCollectionNextTarget(suite.collection)
+	suite.target.UpdateNextTarget(suite.collection)
 	suite.AssertTaskNum(0, len(suite.subChannels), len(suite.subChannels), 0)
 
 	// Process tasks
@@ -348,7 +348,7 @@ func (suite *TaskSuite) TestUnsubscribeChannelTask() {
 		suite.NoError(err)
 	}
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection).Return(dmChannels, nil, nil)
-	suite.target.UpdateCollectionNextTarget(suite.collection)
+	suite.target.UpdateNextTarget(suite.collection)
 
 	// Only first channel exists
 	suite.dist.LeaderViewManager.Update(targetNode, &meta.LeaderView{
@@ -437,7 +437,7 @@ func (suite *TaskSuite) TestLoadSegmentTask() {
 		suite.NoError(err)
 	}
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection).Return(nil, segments, nil)
-	suite.target.UpdateCollectionNextTarget(suite.collection)
+	suite.target.UpdateNextTarget(suite.collection)
 	segmentsNum := len(suite.loadSegments)
 	suite.AssertTaskNum(0, segmentsNum, 0, segmentsNum)
 
@@ -533,7 +533,7 @@ func (suite *TaskSuite) TestLoadSegmentTaskNotIndex() {
 		suite.NoError(err)
 	}
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection).Return(nil, segments, nil)
-	suite.target.UpdateCollectionNextTarget(suite.collection)
+	suite.target.UpdateNextTarget(suite.collection)
 	segmentsNum := len(suite.loadSegments)
 	suite.AssertTaskNum(0, segmentsNum, 0, segmentsNum)
 
@@ -623,7 +623,7 @@ func (suite *TaskSuite) TestLoadSegmentTaskFailed() {
 		suite.NoError(err)
 	}
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection).Return(nil, segments, nil)
-	suite.target.UpdateCollectionNextTarget(suite.collection)
+	suite.target.UpdateNextTarget(suite.collection)
 	segmentsNum := len(suite.loadSegments)
 	suite.AssertTaskNum(0, segmentsNum, 0, segmentsNum)
 
@@ -837,8 +837,8 @@ func (suite *TaskSuite) TestMoveSegmentTask() {
 		tasks = append(tasks, task)
 	}
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection).Return([]*datapb.VchannelInfo{vchannel}, segmentInfos, nil)
-	suite.target.UpdateCollectionNextTarget(suite.collection)
-	suite.target.UpdateCollectionCurrentTarget(suite.collection)
+	suite.target.UpdateNextTarget(suite.collection)
+	suite.target.UpdateCurrentTarget(suite.collection)
 	suite.dist.SegmentDistManager.Update(sourceNode, segments...)
 	suite.dist.LeaderViewManager.Update(leader, view)
 	for _, task := range tasks {
@@ -921,8 +921,8 @@ func (suite *TaskSuite) TestMoveSegmentTaskStale() {
 		tasks = append(tasks, task)
 	}
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection).Return([]*datapb.VchannelInfo{vchannel}, segmentInfos, nil)
-	suite.target.UpdateCollectionNextTarget(suite.collection)
-	suite.target.UpdateCollectionCurrentTarget(suite.collection)
+	suite.target.UpdateNextTarget(suite.collection)
+	suite.target.UpdateCurrentTarget(suite.collection)
 	suite.dist.LeaderViewManager.Update(leader, view)
 	for _, task := range tasks {
 		err := suite.scheduler.Add(task)
@@ -1000,7 +1000,7 @@ func (suite *TaskSuite) TestTaskCanceled() {
 	suite.AssertTaskNum(0, segmentsNum, 0, segmentsNum)
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection).Return(nil, segmentInfos, nil)
 	suite.meta.CollectionManager.PutPartition(utils.CreateTestPartition(suite.collection, partition))
-	suite.target.UpdateCollectionNextTarget(suite.collection)
+	suite.target.UpdateNextTarget(suite.collection)
 
 	// Process tasks
 	suite.dispatchAndWait(targetNode)
@@ -1086,7 +1086,7 @@ func (suite *TaskSuite) TestSegmentTaskStale() {
 	}
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection).Return(nil, segments, nil)
 	suite.meta.CollectionManager.PutPartition(utils.CreateTestPartition(suite.collection, partition))
-	suite.target.UpdateCollectionNextTarget(suite.collection)
+	suite.target.UpdateNextTarget(suite.collection)
 	segmentsNum := len(suite.loadSegments)
 	suite.AssertTaskNum(0, segmentsNum, 0, segmentsNum)
 
@@ -1123,7 +1123,7 @@ func (suite *TaskSuite) TestSegmentTaskStale() {
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection).Return(nil, segments, nil)
 
 	suite.meta.CollectionManager.PutPartition(utils.CreateTestPartition(suite.collection, 2))
-	suite.target.UpdateCollectionNextTarget(suite.collection)
+	suite.target.UpdateNextTarget(suite.collection)
 	suite.dispatchAndWait(targetNode)
 	suite.AssertTaskNum(0, 0, 0, 0)
 
@@ -1327,7 +1327,7 @@ func (suite *TaskSuite) TestNoExecutor() {
 		suite.NoError(err)
 	}
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection).Return(nil, segments, nil)
-	suite.target.UpdateCollectionNextTarget(suite.collection)
+	suite.target.UpdateNextTarget(suite.collection)
 	segmentsNum := len(suite.loadSegments)
 	suite.AssertTaskNum(0, segmentsNum, 0, segmentsNum)
 


### PR DESCRIPTION
Signed-off-by: Wei Liu <wei.liu@zilliz.com>
issue: #27720

1. if next target has same content with current target, skip update it to current target.
2. refine target_manager code style
    a. `StreamingSegment` to `GrowingSegment`
    b. `HistoricalSegment` to `SealedSegment`
