### PR TITLE
Remove deprecated io/ioutil usage

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -95,15 +95,17 @@ linters-settings:
       main:
         deny:
           - pkg: "errors"
-            desc: not allowd, use github.com/cockroachdb/errors
+            desc: not allowed, use github.com/cockroachdb/errors
           - pkg: "github.com/pkg/errors"
-            desc: not allowd, use github.com/cockroachdb/errors
+            desc: not allowed, use github.com/cockroachdb/errors
           - pkg: "github.com/pingcap/errors"
-            desc: not allowd, use github.com/cockroachdb/errors
+            desc: not allowed, use github.com/cockroachdb/errors
           - pkg: "golang.org/x/xerrors"
-            desc: not allowd, use github.com/cockroachdb/errors
+            desc: not allowed, use github.com/cockroachdb/errors
           - pkg: "github.com/go-errors/errors"
-            desc: not allowd, use github.com/cockroachdb/errors
+            desc: not allowed, use github.com/cockroachdb/errors
+          - pkg: "io/ioutil"
+            desc: ioutil is deprecated after 1.16, 1.17, use os and io package instead
   forbidigo:
     forbid:
       - '^time\.Tick$'

--- a/cmd/milvus/util.go
+++ b/cmd/milvus/util.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"runtime"
@@ -32,7 +31,7 @@ func makeRuntimeDir(dir string) error {
 		return fmt.Errorf("create runtime dir %s failed, err: %s", dir, err.Error())
 	}
 
-	tmpFile, err := ioutil.TempFile(dir, "tmp")
+	tmpFile, err := os.CreateTemp(dir, "tmp")
 	if err != nil {
 		return err
 	}

--- a/cmd/tools/migration/backend/etcd210.go
+++ b/cmd/tools/migration/backend/etcd210.go
@@ -3,7 +3,7 @@ package backend
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"strconv"
 	"strings"
@@ -432,7 +432,7 @@ func (b etcd210) Backup(meta *meta.Meta, backupFile string) error {
 		return err
 	}
 	console.Warning(fmt.Sprintf("backup to: %s", backupFile))
-	return ioutil.WriteFile(backupFile, backup, 0o600)
+	return os.WriteFile(backupFile, backup, 0o600)
 }
 
 func (b etcd210) BackupV2(file string) error {
@@ -487,11 +487,11 @@ func (b etcd210) BackupV2(file string) error {
 	}
 
 	console.Warning(fmt.Sprintf("backup to: %s", file))
-	return ioutil.WriteFile(file, backup, 0o600)
+	return os.WriteFile(file, backup, 0o600)
 }
 
 func (b etcd210) Restore(backupFile string) error {
-	backup, err := ioutil.ReadFile(backupFile)
+	backup, err := os.ReadFile(backupFile)
 	if err != nil {
 		return err
 	}

--- a/internal/allocator/global_id_allocator_test.go
+++ b/internal/allocator/global_id_allocator_test.go
@@ -17,7 +17,6 @@
 package allocator
 
 import (
-	"io/ioutil"
 	"net/url"
 	"os"
 	"testing"
@@ -37,7 +36,7 @@ var Params paramtable.ComponentParam
 var embedEtcdServer *embed.Etcd
 
 func startEmbedEtcdServer() (*embed.Etcd, error) {
-	dir, err := ioutil.TempDir(os.TempDir(), "milvus_ut")
+	dir, err := os.MkdirTemp(os.TempDir(), "milvus_ut")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/distributed/proxy/service.go
+++ b/internal/distributed/proxy/service.go
@@ -22,7 +22,6 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -246,7 +245,7 @@ func (s *Server) startExternalGrpc(grpcPort int, errChan chan error) {
 		}
 
 		certPool := x509.NewCertPool()
-		rootBuf, err := ioutil.ReadFile(Params.CaPemPath.GetValue())
+		rootBuf, err := os.ReadFile(Params.CaPemPath.GetValue())
 		if err != nil {
 			log.Warn("failed read ca pem", zap.Error(err))
 			errChan <- err
@@ -467,7 +466,7 @@ func (s *Server) init() error {
 				}
 
 				certPool := x509.NewCertPool()
-				rootBuf, err := ioutil.ReadFile(Params.CaPemPath.GetValue())
+				rootBuf, err := os.ReadFile(Params.CaPemPath.GetValue())
 				if err != nil {
 					log.Error("failed read ca pem", zap.Error(err))
 					return err

--- a/internal/http/server_test.go
+++ b/internal/http/server_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -84,7 +84,7 @@ func (suite *HTTPServerTestSuite) TestDefaultLogHandler() {
 	suite.Require().NoError(err)
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	suite.Require().NoError(err)
 	suite.Equal("{\"level\":\"error\"}\n", string(body))
 	suite.Equal(zap.ErrorLevel, log.GetLevel())
@@ -100,7 +100,7 @@ func (suite *HTTPServerTestSuite) TestHealthzHandler() {
 	resp, err := client.Do(req)
 	suite.Nil(err)
 	defer resp.Body.Close()
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 	suite.Equal("OK", string(body))
 
 	req, _ = http.NewRequest(http.MethodGet, url, nil)
@@ -108,7 +108,7 @@ func (suite *HTTPServerTestSuite) TestHealthzHandler() {
 	resp, err = client.Do(req)
 	suite.Nil(err)
 	defer resp.Body.Close()
-	body, _ = ioutil.ReadAll(resp.Body)
+	body, _ = io.ReadAll(resp.Body)
 	suite.Equal("{\"state\":\"OK\",\"detail\":[{\"name\":\"m1\",\"code\":1}]}", string(body))
 
 	healthz.Register(&MockIndicator{"m2", commonpb.StateCode_Abnormal})
@@ -117,7 +117,7 @@ func (suite *HTTPServerTestSuite) TestHealthzHandler() {
 	resp, err = client.Do(req)
 	suite.Nil(err)
 	defer resp.Body.Close()
-	body, _ = ioutil.ReadAll(resp.Body)
+	body, _ = io.ReadAll(resp.Body)
 	suite.Equal("{\"state\":\"component m2 state is Abnormal\",\"detail\":[{\"name\":\"m1\",\"code\":1},{\"name\":\"m2\",\"code\":2}]}", string(body))
 }
 

--- a/internal/indexnode/etcd_mock.go
+++ b/internal/indexnode/etcd_mock.go
@@ -2,7 +2,6 @@ package indexnode
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"sync"
@@ -25,7 +24,7 @@ var (
 
 func startEmbedEtcd() {
 	startSvr.Do(func() {
-		dir, err := ioutil.TempDir(os.TempDir(), "milvus_ut_etcd")
+		dir, err := os.MkdirTemp(os.TempDir(), "milvus_ut_etcd")
 		if err != nil {
 			panic(err)
 		}

--- a/internal/proxy/accesslog/log_writer.go
+++ b/internal/proxy/accesslog/log_writer.go
@@ -19,7 +19,6 @@ package accesslog
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"sync"
@@ -320,7 +319,7 @@ func (l *RotateLogger) newBackupName() string {
 }
 
 func (l *RotateLogger) oldLogFiles() ([]logInfo, error) {
-	files, err := ioutil.ReadDir(l.dir())
+	files, err := os.ReadDir(l.dir())
 	if err != nil {
 		return nil, fmt.Errorf("can't read log file directory: %s", err)
 	}

--- a/internal/storage/local_chunk_manager.go
+++ b/internal/storage/local_chunk_manager.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -97,7 +96,7 @@ func (lcm *LocalChunkManager) Write(ctx context.Context, filePath string, conten
 			return err
 		}
 	}
-	return ioutil.WriteFile(filePath, content, os.ModePerm)
+	return os.WriteFile(filePath, content, os.ModePerm)
 }
 
 // MultiWrite writes the data to local storage.
@@ -134,7 +133,7 @@ func (lcm *LocalChunkManager) Read(ctx context.Context, filePath string) ([]byte
 		return nil, fmt.Errorf("file not exist: %s", filePath)
 	}
 
-	return ioutil.ReadFile(filePath)
+	return os.ReadFile(filePath)
 }
 
 // MultiRead reads the local storage data if exists.

--- a/internal/storage/print_binlog_test.go
+++ b/internal/storage/print_binlog_test.go
@@ -18,7 +18,6 @@ package storage
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -73,7 +72,7 @@ func TestPrintBinlogFilesInt64(t *testing.T) {
 	assert.NoError(t, err)
 	w.Close()
 
-	fd, err := ioutil.TempFile("", "binlog_int64.db")
+	fd, err := os.CreateTemp("", "binlog_int64.db")
 	defer os.RemoveAll(fd.Name())
 	assert.NoError(t, err)
 	num, err := fd.Write(buf)

--- a/internal/util/importutil/numpy_adapter.go
+++ b/internal/util/importutil/numpy_adapter.go
@@ -21,7 +21,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"regexp"
@@ -589,7 +588,7 @@ func (n *NumpyAdapter) ReadString(count int) ([]string, error) {
 			// the character "a" occupys 2*4=8 bytes(0x97,0x00,0x00,0x00,0x00,0x00,0x00,0x00),
 			// the "bb" occupys 8 bytes(0x97,0x00,0x00,0x00,0x98,0x00,0x00,0x00)
 			// for non-ascii characters, the unicode could be 1 ~ 4 bytes, each character occupys 4 bytes, too
-			raw, err := ioutil.ReadAll(io.LimitReader(n.reader, utf8.UTFMax*int64(maxLen)*int64(batchRead)))
+			raw, err := io.ReadAll(io.LimitReader(n.reader, utf8.UTFMax*int64(maxLen)*int64(batchRead)))
 			if err != nil {
 				log.Warn("Numpy adapter: failed to read utf32 bytes from numpy file",
 					zap.Int("readDone", readDone), zap.Error(err))
@@ -610,7 +609,7 @@ func (n *NumpyAdapter) ReadString(count int) ([]string, error) {
 		} else {
 			// in the numpy file with ansi encoding, the dType could be like "S2", maxLen is 2, each string occupys 2 bytes
 			// bytes.Index(buf, []byte{0}) tell us which position is the end of the string
-			buf, err := ioutil.ReadAll(io.LimitReader(n.reader, int64(maxLen)*int64(batchRead)))
+			buf, err := io.ReadAll(io.LimitReader(n.reader, int64(maxLen)*int64(batchRead)))
 			if err != nil {
 				log.Warn("Numpy adapter: failed to read ascii bytes from numpy file",
 					zap.Int("readDone", readDone), zap.Error(err))

--- a/internal/util/sessionutil/session_util_test.go
+++ b/internal/util/sessionutil/session_util_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"net/url"
 	"os"
@@ -448,7 +447,7 @@ type SessionWithVersionSuite struct {
 
 // SetupSuite setup suite env
 func (suite *SessionWithVersionSuite) SetupSuite() {
-	dir, err := ioutil.TempDir(os.TempDir(), "milvus_ut")
+	dir, err := os.MkdirTemp(os.TempDir(), "milvus_ut")
 	suite.Require().NoError(err)
 	suite.tmpDir = dir
 	suite.T().Log("using tmp dir:", dir)
@@ -782,7 +781,7 @@ type SessionSuite struct {
 
 func (s *SessionSuite) SetupSuite() {
 	paramtable.Init()
-	dir, err := ioutil.TempDir(os.TempDir(), "milvus_ut")
+	dir, err := os.MkdirTemp(os.TempDir(), "milvus_ut")
 	s.Require().NoError(err)
 	s.tmpDir = dir
 	s.T().Log("using tmp dir:", dir)

--- a/pkg/eventlog/handler_test.go
+++ b/pkg/eventlog/handler_test.go
@@ -18,7 +18,7 @@ package eventlog
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -55,7 +55,7 @@ func (s *HandlerSuite) TestServerHTTP() {
 
 	res := w.Result()
 	defer res.Body.Close()
-	data, err := ioutil.ReadAll(res.Body)
+	data, err := io.ReadAll(res.Body)
 	s.Require().NoError(err)
 
 	resp := eventLogResponse{}

--- a/pkg/log/zap_log_test.go
+++ b/pkg/log/zap_log_test.go
@@ -32,9 +32,9 @@ package log
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math"
 	"net"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -226,7 +226,7 @@ func TestRotateLog(t *testing.T) {
 				logger.Info(string(data))
 				data = data[:0]
 			}
-			files, _ := ioutil.ReadDir(tempDir)
+			files, _ := os.ReadDir(tempDir)
 			assert.Len(t, files, c.expectedFileNum)
 		})
 	}

--- a/pkg/util/etcd/etcd_util.go
+++ b/pkg/util/etcd/etcd_util.go
@@ -20,7 +20,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"time"
@@ -75,7 +74,7 @@ func GetRemoteEtcdSSLClient(endpoints []string, certFile string, keyFile string,
 	if err != nil {
 		return nil, errors.Wrap(err, "load etcd cert key pair error")
 	}
-	caCert, err := ioutil.ReadFile(caCertFile)
+	caCert, err := os.ReadFile(caCertFile)
 	if err != nil {
 		return nil, errors.Wrapf(err, "load etcd CACert file error, filename = %s", caCertFile)
 	}
@@ -182,7 +181,7 @@ func buildKvGroup(keys, values []string) (map[string]string, error) {
 // StartTestEmbedEtcdServer returns a newly created embed etcd server.
 // ### USED FOR UNIT TEST ONLY ###
 func StartTestEmbedEtcdServer() (*embed.Etcd, string, error) {
-	dir, err := ioutil.TempDir(os.TempDir(), "milvus_ut")
+	dir, err := os.MkdirTemp(os.TempDir(), "milvus_ut")
 	if err != nil {
 		return nil, "", err
 	}


### PR DESCRIPTION
`io/ioutil` package is deprecated, use `io`,`os` package replacement 
also added golangci-lint rule to block future reference
/kind improvement