### PR TITLE
fix query shard inUse leak

### DIFF
--- a/internal/querynode/impl.go
+++ b/internal/querynode/impl.go
@@ -663,8 +663,8 @@ func (node *QueryNode) ReleaseSegments(ctx context.Context, in *querypb.ReleaseS
 		case querypb.DataScope_Historical:
 			delta += node.metaReplica.removeSegment(id, segmentTypeSealed)
 		case querypb.DataScope_All:
-			node.metaReplica.removeSegment(id, segmentTypeSealed)
-			delta += node.metaReplica.removeSegment(id, segmentTypeGrowing)
+			node.metaReplica.removeSegment(id, segmentTypeGrowing)
+			delta += node.metaReplica.removeSegment(id, segmentTypeSealed)
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Wei Liu <wei.liu@zilliz.com>

issue: #27764

when release segment with `DataScope=All`,  it calculate a wrong delta_value, which cause a leak in  query shard inUse. then after all channel/segment released, query shard service leak