### PR TITLE
Make qcv2 target&leader observer execute in parallel

### DIFF
--- a/internal/querycoordv2/observers/collection_observer.go
+++ b/internal/querycoordv2/observers/collection_observer.go
@@ -226,7 +226,15 @@ func (ob *CollectionObserver) observePartitionLoadStatus(ctx context.Context, pa
 	}
 
 	ob.partitionLoadedCount[partition.GetPartitionID()] = loadedCount
-	if loadPercentage == 100 && ob.targetObserver.Check(ctx, partition.GetCollectionID()) && ob.leaderObserver.CheckTargetVersion(ctx, partition.GetCollectionID()) {
+	if loadPercentage == 100 {
+		if !ob.targetObserver.Check(ctx, partition.GetCollectionID()) {
+			log.Warn("failed to manual check current target, skip update load status")
+			return
+		}
+		if !ob.leaderObserver.CheckTargetVersion(ctx, partition.GetCollectionID()) {
+			log.Warn("failed to manual check leader target version ,skip update load status")
+			return
+		}
 		delete(ob.partitionLoadedCount, partition.GetPartitionID())
 	}
 	collectionPercentage, err := ob.meta.CollectionManager.UpdateLoadPercent(partition.PartitionID, loadPercentage)

--- a/internal/querycoordv2/observers/leader_observer_test.go
+++ b/internal/querycoordv2/observers/leader_observer_test.go
@@ -591,44 +591,6 @@ func (suite *LeaderObserverTestSuite) TestSyncTargetVersion() {
 	suite.Len(action.SealedInTarget, 1)
 }
 
-func (suite *LeaderObserverTestSuite) TestCheckTargetVersion() {
-	collectionID := int64(1001)
-	observer := suite.observer
-
-	suite.Run("check_channel_blocked", func() {
-		oldCh := observer.manualCheck
-		defer func() {
-			observer.manualCheck = oldCh
-		}()
-
-		// zero-length channel
-		observer.manualCheck = make(chan checkRequest)
-
-		ctx, cancel := context.WithCancel(context.Background())
-		// cancel context, make test return fast
-		cancel()
-
-		result := observer.CheckTargetVersion(ctx, collectionID)
-		suite.False(result)
-	})
-
-	suite.Run("check_return_ctx_timeout", func() {
-		oldCh := observer.manualCheck
-		defer func() {
-			observer.manualCheck = oldCh
-		}()
-
-		// make channel length = 1, task received
-		observer.manualCheck = make(chan checkRequest, 1)
-
-		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*200)
-		defer cancel()
-
-		result := observer.CheckTargetVersion(ctx, collectionID)
-		suite.False(result)
-	})
-}
-
 func TestLeaderObserverSuite(t *testing.T) {
 	suite.Run(t, new(LeaderObserverTestSuite))
 }

--- a/internal/querycoordv2/observers/target_observer_test.go
+++ b/internal/querycoordv2/observers/target_observer_test.go
@@ -273,41 +273,10 @@ func (suite *TargetObserverCheckSuite) SetupTest() {
 	suite.NoError(err)
 }
 
-func (suite *TargetObserverCheckSuite) TestCheckCtxDone() {
-	observer := suite.observer
-
-	suite.Run("check_channel_blocked", func() {
-		oldCh := observer.manualCheck
-		defer func() {
-			observer.manualCheck = oldCh
-		}()
-
-		// zero-length channel
-		observer.manualCheck = make(chan checkRequest)
-
-		ctx, cancel := context.WithCancel(context.Background())
-		// cancel context, make test return fast
-		cancel()
-
-		result := observer.Check(ctx, suite.collectionID)
-		suite.False(result)
-	})
-
-	suite.Run("check_return_ctx_timeout", func() {
-		oldCh := observer.manualCheck
-		defer func() {
-			observer.manualCheck = oldCh
-		}()
-
-		// make channel length = 1, task received
-		observer.manualCheck = make(chan checkRequest, 1)
-
-		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*200)
-		defer cancel()
-
-		result := observer.Check(ctx, suite.collectionID)
-		suite.False(result)
-	})
+func (s *TargetObserverCheckSuite) TestCheck() {
+	r := s.observer.Check(context.Background(), s.collectionID)
+	s.False(r)
+	s.True(s.observer.dispatcher.tasks.Contain(s.collectionID))
 }
 
 func TestTargetObserver(t *testing.T) {

--- a/internal/querycoordv2/observers/task_dispatcher.go
+++ b/internal/querycoordv2/observers/task_dispatcher.go
@@ -1,0 +1,104 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observers
+
+import (
+	"context"
+	"sync"
+
+	"github.com/milvus-io/milvus/pkg/util/conc"
+	"github.com/milvus-io/milvus/pkg/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/util/typeutil"
+)
+
+// taskDispatcher is the utility to provide task dedup and dispatch feature
+type taskDispatcher[K comparable] struct {
+	tasks      *typeutil.ConcurrentSet[K]
+	pool       *conc.Pool[any]
+	notifyCh   chan struct{}
+	taskRunner task[K]
+	wg         sync.WaitGroup
+	cancel     context.CancelFunc
+	stopOnce   sync.Once
+}
+
+type task[K comparable] func(context.Context, K)
+
+func newTaskDispatcher[K comparable](runner task[K]) *taskDispatcher[K] {
+	return &taskDispatcher[K]{
+		tasks:      typeutil.NewConcurrentSet[K](),
+		pool:       conc.NewPool[any](paramtable.Get().QueryCoordCfg.ObserverTaskParallel.GetAsInt()),
+		notifyCh:   make(chan struct{}, 1),
+		taskRunner: runner,
+	}
+}
+
+func (d *taskDispatcher[K]) Start() {
+	ctx, cancel := context.WithCancel(context.Background())
+	d.cancel = cancel
+
+	d.wg.Add(1)
+	go func() {
+		defer d.wg.Done()
+		d.schedule(ctx)
+	}()
+}
+
+func (d *taskDispatcher[K]) Stop() {
+	d.stopOnce.Do(func() {
+		if d.cancel != nil {
+			d.cancel()
+		}
+		d.wg.Wait()
+	})
+}
+
+func (d *taskDispatcher[K]) AddTask(keys ...K) {
+	var added bool
+	for _, key := range keys {
+		added = added || d.tasks.Insert(key)
+	}
+	if added {
+		d.notify()
+	}
+}
+
+func (d *taskDispatcher[K]) notify() {
+	select {
+	case d.notifyCh <- struct{}{}:
+	default:
+	}
+}
+
+func (d *taskDispatcher[K]) schedule(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-d.notifyCh:
+			d.tasks.Range(func(k K) bool {
+				d.tasks.Insert(k)
+				d.pool.Submit(func() (any, error) {
+					d.taskRunner(ctx, k)
+					d.tasks.Remove(k)
+					return struct{}{}, nil
+				})
+				return true
+			})
+		}
+	}
+}

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -1204,6 +1204,7 @@ type queryCoordConfig struct {
 	CheckHealthRPCTimeout       ParamItem `refreshable:"true"`
 	BrokerTimeout               ParamItem `refreshable:"false"`
 	CollectionRecoverTimesLimit ParamItem `refreshable:"true"`
+	ObserverTaskParallel        ParamItem `refreshable:"false"`
 }
 
 func (p *queryCoordConfig) init(base *BaseTable) {
@@ -1515,6 +1516,16 @@ func (p *queryCoordConfig) init(base *BaseTable) {
 		Export:       true,
 	}
 	p.CollectionRecoverTimesLimit.Init(base.mgr)
+
+	p.ObserverTaskParallel = ParamItem{
+		Key:          "queryCoord.observerTaskParallel",
+		Version:      "2.3.2",
+		DefaultValue: "16",
+		PanicIfEmpty: true,
+		Doc:          "the parallel observer dispatcher task number",
+		Export:       true,
+	}
+	p.ObserverTaskParallel.Init(base.mgr)
 }
 
 // /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
- Add `taskDispatcher` to submit and run task async safely
- Change `LeaderObeserver` and `TargetObserver` schedule and manual check action to submitting task into dispatcher
- Fix logic problem in collection observer when manual check return false

See also #27494
/kind bug