### PR TITLE
Fix initialization and backward compatibility issue for GRPC compression

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -443,7 +443,7 @@ grpc:
   serverMaxSendSize: 536870912
   serverMaxRecvSize: 536870912
   client:
-    compressionEnabled: true
+    compressionEnabled: false
     dialTimeout: 200
     keepAliveTime: 10000
     keepAliveTimeout: 20000

--- a/internal/distributed/datacoord/service.go
+++ b/internal/distributed/datacoord/service.go
@@ -42,6 +42,7 @@ import (
 	"github.com/milvus-io/milvus/internal/proto/internalpb"
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/dependency"
+	_ "github.com/milvus-io/milvus/internal/util/grpcclient"
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/tracer"
 	"github.com/milvus-io/milvus/pkg/util"

--- a/internal/distributed/datanode/service.go
+++ b/internal/distributed/datanode/service.go
@@ -43,6 +43,7 @@ import (
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/componentutil"
 	"github.com/milvus-io/milvus/internal/util/dependency"
+	_ "github.com/milvus-io/milvus/internal/util/grpcclient"
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/tracer"
 	"github.com/milvus-io/milvus/pkg/util/etcd"

--- a/internal/distributed/indexnode/service.go
+++ b/internal/distributed/indexnode/service.go
@@ -40,6 +40,7 @@ import (
 	"github.com/milvus-io/milvus/internal/proto/internalpb"
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/dependency"
+	_ "github.com/milvus-io/milvus/internal/util/grpcclient"
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/tracer"
 	"github.com/milvus-io/milvus/pkg/util/etcd"

--- a/internal/distributed/proxy/service.go
+++ b/internal/distributed/proxy/service.go
@@ -61,6 +61,7 @@ import (
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/componentutil"
 	"github.com/milvus-io/milvus/internal/util/dependency"
+	_ "github.com/milvus-io/milvus/internal/util/grpcclient"
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/tracer"
 	"github.com/milvus-io/milvus/pkg/util"

--- a/internal/distributed/querycoord/service.go
+++ b/internal/distributed/querycoord/service.go
@@ -43,6 +43,7 @@ import (
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/componentutil"
 	"github.com/milvus-io/milvus/internal/util/dependency"
+	_ "github.com/milvus-io/milvus/internal/util/grpcclient"
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/tracer"
 	"github.com/milvus-io/milvus/pkg/util"

--- a/internal/distributed/querynode/service.go
+++ b/internal/distributed/querynode/service.go
@@ -40,6 +40,7 @@ import (
 	qn "github.com/milvus-io/milvus/internal/querynodev2"
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/dependency"
+	_ "github.com/milvus-io/milvus/internal/util/grpcclient"
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/tracer"
 	"github.com/milvus-io/milvus/pkg/util/etcd"

--- a/internal/distributed/rootcoord/service.go
+++ b/internal/distributed/rootcoord/service.go
@@ -43,6 +43,7 @@ import (
 	"github.com/milvus-io/milvus/internal/rootcoord"
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/dependency"
+	_ "github.com/milvus-io/milvus/internal/util/grpcclient"
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/tracer"
 	"github.com/milvus-io/milvus/pkg/util"

--- a/pkg/util/paramtable/grpc_param.go
+++ b/pkg/util/paramtable/grpc_param.go
@@ -46,7 +46,7 @@ const (
 	DefaultMaxAttempts                = 10
 	DefaultInitialBackoff     float64 = 0.2
 	DefaultMaxBackoff         float64 = 10
-	DefaultCompressionEnabled bool    = true
+	DefaultCompressionEnabled bool    = false
 
 	ProxyInternalPort = 19529
 	ProxyExternalPort = 19530


### PR DESCRIPTION
issue: #27887

RPC send fails during the rolling upgrade if client compression has already been enabled but the server doesn't config compression.