### PR TITLE
Refine  proxy component stop

### DIFF
--- a/internal/distributed/proxy/service.go
+++ b/internal/distributed/proxy/service.go
@@ -630,6 +630,7 @@ func (s *Server) start() error {
 func (s *Server) Stop() error {
 	Params := &paramtable.Get().ProxyGrpcServerCfg
 	log.Debug("Proxy stop", zap.String("internal address", Params.GetInternalAddress()), zap.String("external address", Params.GetInternalAddress()))
+	s.proxy.UpdateStateCode(commonpb.StateCode_Abnormal)
 	var err error
 
 	if s.etcdCli != nil {


### PR DESCRIPTION
/kind improvement
stopping  proxy components should follow the order below:
1.  Set status from StateCode_Healthy to StateCode_Abnormal which will reject new requests.
2. Gracefully stop GrpcServer to wait for all requests to finish and close RPC connections.
3.  Stop and close all connection resources.

It might still receive requests after stopping the proxy if the status is healthy, which needs to take a long time to stop grpc server gracefully.  

The task of creating a collection  may block into the queue on the rootcoord side while stopping the proxy(one step is to refresh the cache by PRC with  Proxy client ),  at this moment the search will be affected due to the Tsafe issue.