### PR TITLE
fix search failed when empty segment exist

### DIFF
--- a/internal/querynodev2/segments/retrieve_test.go
+++ b/internal/querynodev2/segments/retrieve_test.go
@@ -235,7 +235,7 @@ func (suite *RetrieveSuite) TestRetrieveNonExistSegment() {
 	}
 
 	res, segments, err := Retrieve(context.TODO(), suite.manager, plan, req)
-	suite.Error(err)
+	suite.ErrorIs(err, merr.ErrSegmentNotLoaded)
 	suite.Len(res, 0)
 	suite.manager.Segment.Unpin(segments)
 }
@@ -255,7 +255,7 @@ func (suite *RetrieveSuite) TestRetrieveNilSegment() {
 	}
 
 	res, segments, err := Retrieve(context.TODO(), suite.manager, plan, req)
-	suite.ErrorIs(err, merr.ErrSegmentNotLoaded)
+	suite.NoError(err)
 	suite.Len(res, 0)
 	suite.manager.Segment.Unpin(segments)
 }


### PR DESCRIPTION
issue: #27913

the skip empty logic will return `SegmentNotLoaded` when meet empty segment, fix it
/kind bug