### PR TITLE
[2.2]remove unretryable error logic for search

### DIFF
--- a/internal/proxy/task_search.go
+++ b/internal/proxy/task_search.go
@@ -457,15 +457,13 @@ func (t *searchTask) Execute(ctx context.Context) error {
 	retryCtx, cancel := context.WithCancel(ctx)
 	err := retry.Do(retryCtx, func() error {
 		searchErr := executeSearch()
-		if !common.IsRetryableError(searchErr) {
-			cancel()
-		}
 		// for branch 2.2, beside the ErrorCode_NotReadyServe/ErrorCode_NotShardLeader, all other failures has been wrapped
 		// with ErrorCode_UnexpectedError, to make sure search/query has chance to deprecated shard leader cache and retry,
 		// disable the retryable error for now, let all query/search failure could retry.
 		// if !common.IsRetryableError(searchErr) {
 		// 	cancel()
 		// }
+
 		if searchErr != nil {
 			log.Warn("first search failed, updating shardleader caches and retry search", zap.Int64("msgId", t.ID()), zap.Error(searchErr))
 			globalMetaCache.DeprecateShardCache(t.request.GetDbName(), t.collectionName)

--- a/internal/util/retry/retry.go
+++ b/internal/util/retry/retry.go
@@ -24,7 +24,6 @@ import (
 // fn is the func to run.
 // Option can control the retry times and timeout.
 func Do(ctx context.Context, fn func() error, opts ...Option) error {
-
 	c := newDefaultConfig()
 
 	for _, opt := range opts {
@@ -45,6 +44,12 @@ func Do(ctx context.Context, fn func() error, opts ...Option) error {
 			el = append(el, err)
 
 			if ok := IsUnRecoverable(err); ok {
+				return el
+			}
+
+			deadline, ok := ctx.Deadline()
+			if ok && time.Until(deadline) < c.sleep {
+				// to avoid sleep until ctx done
 				return el
 			}
 

--- a/internal/util/retry/retry_test.go
+++ b/internal/util/retry/retry_test.go
@@ -59,6 +59,12 @@ func TestMaxSleepTime(t *testing.T) {
 	err := Do(ctx, testFn, Attempts(3), MaxSleepTime(200*time.Millisecond))
 	assert.NotNil(t, err)
 	fmt.Println(err)
+
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	defer cancel()
+	err = Do(ctx, testFn, Attempts(10), MaxSleepTime(200*time.Millisecond))
+	assert.Error(t, err)
+	assert.Nil(t, ctx.Err())
 }
 
 func TestSleep(t *testing.T) {


### PR DESCRIPTION
/kind improvement
/kind branch-feature

changes:

1. remove unretryable error logic for search, cause all search failure return `Unexpected` from qeury node
2. avoid sleep to ctx done in retry logic, see also #27992
3. remove unnecessary retry in `getShards`, see also #28011