### PR TITLE
Change task sourceID to stringer interface

### DIFF
--- a/internal/querycoordv2/balance/utils.go
+++ b/internal/querycoordv2/balance/utils.go
@@ -34,7 +34,7 @@ const (
 	DistInfoPrefix = "Balance-Dists:"
 )
 
-func CreateSegmentTasksFromPlans(ctx context.Context, checkerID int64, timeout time.Duration, plans []SegmentAssignPlan) []task.Task {
+func CreateSegmentTasksFromPlans(ctx context.Context, source task.Source, timeout time.Duration, plans []SegmentAssignPlan) []task.Task {
 	ret := make([]task.Task, 0)
 	for _, p := range plans {
 		actions := make([]task.Action, 0)
@@ -49,7 +49,7 @@ func CreateSegmentTasksFromPlans(ctx context.Context, checkerID int64, timeout t
 		t, err := task.NewSegmentTask(
 			ctx,
 			timeout,
-			checkerID,
+			source,
 			p.Segment.GetCollectionID(),
 			p.ReplicaID,
 			actions...,
@@ -86,7 +86,7 @@ func CreateSegmentTasksFromPlans(ctx context.Context, checkerID int64, timeout t
 	return ret
 }
 
-func CreateChannelTasksFromPlans(ctx context.Context, checkerID int64, timeout time.Duration, plans []ChannelAssignPlan) []task.Task {
+func CreateChannelTasksFromPlans(ctx context.Context, source task.Source, timeout time.Duration, plans []ChannelAssignPlan) []task.Task {
 	ret := make([]task.Task, 0, len(plans))
 	for _, p := range plans {
 		actions := make([]task.Action, 0)
@@ -98,7 +98,7 @@ func CreateChannelTasksFromPlans(ctx context.Context, checkerID int64, timeout t
 			action := task.NewChannelAction(p.From, task.ActionTypeReduce, p.Channel.GetChannelName())
 			actions = append(actions, action)
 		}
-		t, err := task.NewChannelTask(ctx, timeout, checkerID, p.Channel.GetCollectionID(), p.ReplicaID, actions...)
+		t, err := task.NewChannelTask(ctx, timeout, source, p.Channel.GetCollectionID(), p.ReplicaID, actions...)
 		if err != nil {
 			log.Warn("create channel task failed",
 				zap.Int64("collection", p.Channel.GetCollectionID()),

--- a/internal/querycoordv2/checkers/balance_checker.go
+++ b/internal/querycoordv2/checkers/balance_checker.go
@@ -36,7 +36,6 @@ import (
 
 // BalanceChecker checks the cluster distribution and generates balance tasks.
 type BalanceChecker struct {
-	baseChecker
 	balance.Balance
 	meta                                 *meta.Meta
 	nodeManager                          *session.NodeManager
@@ -52,6 +51,10 @@ func NewBalanceChecker(meta *meta.Meta, balancer balance.Balance, nodeMgr *sessi
 		normalBalanceCollectionsCurrentRound: typeutil.NewUniqueSet(),
 		scheduler:                            scheduler,
 	}
+}
+
+func (b *BalanceChecker) ID() task.Source {
+	return balanceChecker
 }
 
 func (b *BalanceChecker) Description() string {

--- a/internal/querycoordv2/checkers/channel_checker.go
+++ b/internal/querycoordv2/checkers/channel_checker.go
@@ -34,7 +34,6 @@ import (
 
 // TODO(sunby): have too much similar codes with SegmentChecker
 type ChannelChecker struct {
-	baseChecker
 	meta      *meta.Meta
 	dist      *meta.DistributionManager
 	targetMgr *meta.TargetManager
@@ -53,6 +52,10 @@ func NewChannelChecker(
 		targetMgr: targetMgr,
 		balancer:  balancer,
 	}
+}
+
+func (c *ChannelChecker) ID() task.Source {
+	return channelChecker
 }
 
 func (c *ChannelChecker) Description() string {

--- a/internal/querycoordv2/checkers/checker.go
+++ b/internal/querycoordv2/checkers/checker.go
@@ -23,20 +23,7 @@ import (
 )
 
 type Checker interface {
-	ID() int64
-	SetID(id int64)
+	ID() task.Source
 	Description() string
 	Check(ctx context.Context) []task.Task
-}
-
-type baseChecker struct {
-	id int64
-}
-
-func (checker *baseChecker) ID() int64 {
-	return checker.id
-}
-
-func (checker *baseChecker) SetID(id int64) {
-	checker.id = id
 }

--- a/internal/querycoordv2/checkers/index_checker.go
+++ b/internal/querycoordv2/checkers/index_checker.go
@@ -35,7 +35,6 @@ var _ Checker = (*IndexChecker)(nil)
 
 // IndexChecker perform segment index check.
 type IndexChecker struct {
-	baseChecker
 	meta   *meta.Meta
 	dist   *meta.DistributionManager
 	broker meta.Broker
@@ -51,6 +50,10 @@ func NewIndexChecker(
 		dist:   dist,
 		broker: broker,
 	}
+}
+
+func (c *IndexChecker) ID() task.Source {
+	return indexChecker
 }
 
 func (c *IndexChecker) Description() string {

--- a/internal/querycoordv2/checkers/segment_checker.go
+++ b/internal/querycoordv2/checkers/segment_checker.go
@@ -36,7 +36,6 @@ import (
 )
 
 type SegmentChecker struct {
-	baseChecker
 	meta      *meta.Meta
 	dist      *meta.DistributionManager
 	targetMgr *meta.TargetManager
@@ -58,6 +57,10 @@ func NewSegmentChecker(
 		balancer:  balancer,
 		nodeMgr:   nodeMgr,
 	}
+}
+
+func (c *SegmentChecker) ID() task.Source {
+	return segmentChecker
 }
 
 func (c *SegmentChecker) Description() string {

--- a/internal/querycoordv2/handlers.go
+++ b/internal/querycoordv2/handlers.go
@@ -142,7 +142,7 @@ func (s *Server) balanceSegments(ctx context.Context, req *querypb.LoadBalanceRe
 		)
 		task, err := task.NewSegmentTask(ctx,
 			Params.QueryCoordCfg.SegmentTaskTimeout.GetAsDuration(time.Millisecond),
-			req.GetBase().GetMsgID(),
+			task.WrapIDSource(req.GetBase().GetMsgID()),
 			req.GetCollectionID(),
 			replica.GetID(),
 			task.NewSegmentActionWithScope(plan.To, task.ActionTypeGrow, plan.Segment.GetInsertChannel(), plan.Segment.GetID(), querypb.DataScope_Historical),

--- a/internal/querycoordv2/task/executor.go
+++ b/internal/querycoordv2/task/executor.go
@@ -104,7 +104,7 @@ func (ex *Executor) Execute(task Task, step int) bool {
 		zap.Int64("collectionID", task.CollectionID()),
 		zap.Int64("replicaID", task.ReplicaID()),
 		zap.Int("step", step),
-		zap.Int64("source", task.SourceID()),
+		zap.String("source", task.Source().String()),
 	)
 
 	go func() {
@@ -169,7 +169,7 @@ func (ex *Executor) processMergeTask(mergeTask *LoadSegmentsTask) {
 		zap.String("shard", task.Shard()),
 		zap.Int64s("segmentIDs", segments),
 		zap.Int64("nodeID", action.Node()),
-		zap.Int64("source", task.SourceID()),
+		zap.String("source", task.Source().String()),
 	)
 
 	// Get shard leader for the given replica and segment
@@ -231,7 +231,7 @@ func (ex *Executor) loadSegment(task *SegmentTask, step int) error {
 		zap.Int64("replicaID", task.ReplicaID()),
 		zap.Int64("segmentID", task.segmentID),
 		zap.Int64("node", action.Node()),
-		zap.Int64("source", task.SourceID()),
+		zap.String("source", task.Source().String()),
 	)
 
 	var err error
@@ -312,7 +312,7 @@ func (ex *Executor) releaseSegment(task *SegmentTask, step int) {
 		zap.Int64("replicaID", task.ReplicaID()),
 		zap.Int64("segmentID", task.segmentID),
 		zap.Int64("node", action.Node()),
-		zap.Int64("source", task.SourceID()),
+		zap.String("source", task.Source().String()),
 	)
 
 	ctx := task.Context()
@@ -384,7 +384,7 @@ func (ex *Executor) subDmChannel(task *ChannelTask, step int) error {
 		zap.Int64("replicaID", task.ReplicaID()),
 		zap.String("channel", task.Channel()),
 		zap.Int64("node", action.Node()),
-		zap.Int64("source", task.SourceID()),
+		zap.String("source", task.Source().String()),
 	)
 
 	var err error
@@ -467,7 +467,7 @@ func (ex *Executor) unsubDmChannel(task *ChannelTask, step int) error {
 		zap.Int64("replicaID", task.ReplicaID()),
 		zap.String("channel", task.Channel()),
 		zap.Int64("node", action.Node()),
-		zap.Int64("source", task.SourceID()),
+		zap.String("source", task.Source().String()),
 	)
 
 	var err error

--- a/internal/querycoordv2/task/merger_test.go
+++ b/internal/querycoordv2/task/merger_test.go
@@ -122,7 +122,7 @@ func (suite *MergerSuite) TestMerge() {
 	ctx := context.Background()
 
 	for segmentID := int64(1); segmentID <= 3; segmentID++ {
-		task, err := NewSegmentTask(ctx, timeout, 0, suite.collectionID, suite.replicaID,
+		task, err := NewSegmentTask(ctx, timeout, WrapIDSource(0), suite.collectionID, suite.replicaID,
 			NewSegmentAction(suite.nodeID, ActionTypeGrow, "", segmentID))
 		suite.NoError(err)
 		suite.merger.Add(NewLoadSegmentsTask(task, 0, suite.requests[segmentID]))

--- a/internal/querycoordv2/task/scheduler.go
+++ b/internal/querycoordv2/task/scheduler.go
@@ -421,7 +421,7 @@ func (scheduler *taskScheduler) promote(task Task) error {
 		zap.Int64("taskID", task.ID()),
 		zap.Int64("collectionID", task.CollectionID()),
 		zap.Int64("replicaID", task.ReplicaID()),
-		zap.Int64("source", task.SourceID()),
+		zap.String("source", task.Source().String()),
 	)
 
 	if err := scheduler.check(task); err != nil {
@@ -643,7 +643,7 @@ func (scheduler *taskScheduler) process(task Task) bool {
 		zap.Int64("collectionID", task.CollectionID()),
 		zap.Int64("replicaID", task.ReplicaID()),
 		zap.String("type", GetTaskType(task).String()),
-		zap.Int64("source", task.SourceID()),
+		zap.String("source", task.Source().String()),
 	)
 
 	actions, step := task.Actions(), task.Step()
@@ -733,7 +733,7 @@ func (scheduler *taskScheduler) checkStale(task Task) error {
 		zap.Int64("taskID", task.ID()),
 		zap.Int64("collectionID", task.CollectionID()),
 		zap.Int64("replicaID", task.ReplicaID()),
-		zap.Int64("source", task.SourceID()),
+		zap.String("source", task.Source().String()),
 	)
 
 	switch task := task.(type) {
@@ -770,7 +770,7 @@ func (scheduler *taskScheduler) checkSegmentTaskStale(task *SegmentTask) error {
 		zap.Int64("taskID", task.ID()),
 		zap.Int64("collectionID", task.CollectionID()),
 		zap.Int64("replicaID", task.ReplicaID()),
-		zap.Int64("source", task.SourceID()),
+		zap.String("source", task.Source().String()),
 	)
 
 	for _, action := range task.Actions() {
@@ -814,7 +814,7 @@ func (scheduler *taskScheduler) checkChannelTaskStale(task *ChannelTask) error {
 		zap.Int64("taskID", task.ID()),
 		zap.Int64("collectionID", task.CollectionID()),
 		zap.Int64("replicaID", task.ReplicaID()),
-		zap.Int64("source", task.SourceID()),
+		zap.String("source", task.Source().String()),
 	)
 
 	for _, action := range task.Actions() {

--- a/internal/querycoordv2/task/task_test.go
+++ b/internal/querycoordv2/task/task_test.go
@@ -242,7 +242,7 @@ func (suite *TaskSuite) TestSubscribeChannelTask() {
 		task, err := NewChannelTask(
 			ctx,
 			timeout,
-			0,
+			WrapIDSource(0),
 			suite.collection,
 			suite.replica,
 			NewChannelAction(targetNode, ActionTypeGrow, channel),
@@ -291,7 +291,7 @@ func (suite *TaskSuite) TestSubmitDuplicateSubscribeChannelTask() {
 		task, err := NewChannelTask(
 			ctx,
 			timeout,
-			0,
+			WrapIDSource(0),
 			suite.collection,
 			suite.replica,
 			NewChannelAction(targetNode, ActionTypeGrow, channel),
@@ -336,7 +336,7 @@ func (suite *TaskSuite) TestUnsubscribeChannelTask() {
 		task, err := NewChannelTask(
 			ctx,
 			timeout,
-			0,
+			WrapIDSource(0),
 			suite.collection,
 			-1,
 			NewChannelAction(targetNode, ActionTypeReduce, channel),
@@ -426,7 +426,7 @@ func (suite *TaskSuite) TestLoadSegmentTask() {
 		task, err := NewSegmentTask(
 			ctx,
 			timeout,
-			0,
+			WrapIDSource(0),
 			suite.collection,
 			suite.replica,
 			NewSegmentAction(targetNode, ActionTypeGrow, channel.GetChannelName(), segment),
@@ -522,7 +522,7 @@ func (suite *TaskSuite) TestLoadSegmentTaskNotIndex() {
 		task, err := NewSegmentTask(
 			ctx,
 			timeout,
-			0,
+			WrapIDSource(0),
 			suite.collection,
 			suite.replica,
 			NewSegmentAction(targetNode, ActionTypeGrow, channel.GetChannelName(), segment),
@@ -612,7 +612,7 @@ func (suite *TaskSuite) TestLoadSegmentTaskFailed() {
 		task, err := NewSegmentTask(
 			ctx,
 			timeout,
-			0,
+			WrapIDSource(0),
 			suite.collection,
 			suite.replica,
 			NewSegmentAction(targetNode, ActionTypeGrow, channel.GetChannelName(), segment),
@@ -677,7 +677,7 @@ func (suite *TaskSuite) TestReleaseSegmentTask() {
 		task, err := NewSegmentTask(
 			ctx,
 			timeout,
-			0,
+			WrapIDSource(0),
 			suite.collection,
 			suite.replica,
 			NewSegmentAction(targetNode, ActionTypeReduce, channel.GetChannelName(), segment),
@@ -721,7 +721,7 @@ func (suite *TaskSuite) TestReleaseGrowingSegmentTask() {
 		task, err := NewSegmentTask(
 			ctx,
 			timeout,
-			0,
+			WrapIDSource(0),
 			suite.collection,
 			suite.replica,
 			NewSegmentActionWithScope(targetNode, ActionTypeReduce, "", segment, querypb.DataScope_Streaming),
@@ -827,7 +827,7 @@ func (suite *TaskSuite) TestMoveSegmentTask() {
 		task, err := NewSegmentTask(
 			ctx,
 			timeout,
-			0,
+			WrapIDSource(0),
 			suite.collection,
 			suite.replica,
 			NewSegmentAction(targetNode, ActionTypeGrow, channel.GetChannelName(), segment),
@@ -911,7 +911,7 @@ func (suite *TaskSuite) TestMoveSegmentTaskStale() {
 		task, err := NewSegmentTask(
 			ctx,
 			timeout,
-			0,
+			WrapIDSource(0),
 			suite.collection,
 			suite.replica,
 			NewSegmentAction(targetNode, ActionTypeGrow, channel.GetChannelName(), segment),
@@ -986,7 +986,7 @@ func (suite *TaskSuite) TestTaskCanceled() {
 		task, err := NewSegmentTask(
 			ctx,
 			timeout,
-			0,
+			WrapIDSource(0),
 			suite.collection,
 			suite.replica,
 			NewSegmentAction(targetNode, ActionTypeGrow, channel.GetChannelName(), segment),
@@ -1074,7 +1074,7 @@ func (suite *TaskSuite) TestSegmentTaskStale() {
 		task, err := NewSegmentTask(
 			ctx,
 			timeout,
-			0,
+			WrapIDSource(0),
 			suite.collection,
 			suite.replica,
 			NewSegmentAction(targetNode, ActionTypeGrow, channel.GetChannelName(), segment),
@@ -1148,7 +1148,7 @@ func (suite *TaskSuite) TestChannelTaskReplace() {
 		task, err := NewChannelTask(
 			ctx,
 			timeout,
-			0,
+			WrapIDSource(0),
 			suite.collection,
 			suite.replica,
 			NewChannelAction(targetNode, ActionTypeGrow, channel),
@@ -1165,7 +1165,7 @@ func (suite *TaskSuite) TestChannelTaskReplace() {
 		task, err := NewChannelTask(
 			ctx,
 			timeout,
-			0,
+			WrapIDSource(0),
 			suite.collection,
 			suite.replica,
 			NewChannelAction(targetNode, ActionTypeGrow, channel),
@@ -1184,7 +1184,7 @@ func (suite *TaskSuite) TestChannelTaskReplace() {
 		task, err := NewChannelTask(
 			ctx,
 			timeout,
-			0,
+			WrapIDSource(0),
 			suite.collection,
 			suite.replica,
 			NewChannelAction(targetNode, ActionTypeGrow, channel),
@@ -1199,34 +1199,34 @@ func (suite *TaskSuite) TestChannelTaskReplace() {
 }
 
 func (suite *TaskSuite) TestCreateTaskBehavior() {
-	chanelTask, err := NewChannelTask(context.TODO(), 5*time.Second, 0, 0, 0)
+	chanelTask, err := NewChannelTask(context.TODO(), 5*time.Second, WrapIDSource(0), 0, 0)
 	suite.ErrorIs(err, merr.ErrParameterInvalid)
 	suite.Nil(chanelTask)
 
 	action := NewSegmentAction(0, 0, "", 0)
-	chanelTask, err = NewChannelTask(context.TODO(), 5*time.Second, 0, 0, 0, action)
+	chanelTask, err = NewChannelTask(context.TODO(), 5*time.Second, WrapIDSource(0), 0, 0, action)
 	suite.ErrorIs(err, merr.ErrParameterInvalid)
 	suite.Nil(chanelTask)
 
 	action1 := NewChannelAction(0, 0, "fake-channel1")
 	action2 := NewChannelAction(0, 0, "fake-channel2")
-	chanelTask, err = NewChannelTask(context.TODO(), 5*time.Second, 0, 0, 0, action1, action2)
+	chanelTask, err = NewChannelTask(context.TODO(), 5*time.Second, WrapIDSource(0), 0, 0, action1, action2)
 	suite.ErrorIs(err, merr.ErrParameterInvalid)
 	suite.Nil(chanelTask)
 
-	segmentTask, err := NewSegmentTask(context.TODO(), 5*time.Second, 0, 0, 0)
+	segmentTask, err := NewSegmentTask(context.TODO(), 5*time.Second, WrapIDSource(0), 0, 0)
 	suite.ErrorIs(err, merr.ErrParameterInvalid)
 	suite.Nil(segmentTask)
 
 	channelAction := NewChannelAction(0, 0, "fake-channel1")
-	segmentTask, err = NewSegmentTask(context.TODO(), 5*time.Second, 0, 0, 0, channelAction)
+	segmentTask, err = NewSegmentTask(context.TODO(), 5*time.Second, WrapIDSource(0), 0, 0, channelAction)
 	suite.ErrorIs(err, merr.ErrParameterInvalid)
 	suite.Nil(segmentTask)
 
 	segmentAction1 := NewSegmentAction(0, 0, "", 0)
 	segmentAction2 := NewSegmentAction(0, 0, "", 1)
 
-	segmentTask, err = NewSegmentTask(context.TODO(), 5*time.Second, 0, 0, 0, segmentAction1, segmentAction2)
+	segmentTask, err = NewSegmentTask(context.TODO(), 5*time.Second, WrapIDSource(0), 0, 0, segmentAction1, segmentAction2)
 	suite.ErrorIs(err, merr.ErrParameterInvalid)
 	suite.Nil(segmentTask)
 }
@@ -1240,7 +1240,7 @@ func (suite *TaskSuite) TestSegmentTaskReplace() {
 		task, err := NewSegmentTask(
 			ctx,
 			timeout,
-			0,
+			WrapIDSource(0),
 			suite.collection,
 			suite.replica,
 			NewSegmentAction(targetNode, ActionTypeGrow, "", segment),
@@ -1257,7 +1257,7 @@ func (suite *TaskSuite) TestSegmentTaskReplace() {
 		task, err := NewSegmentTask(
 			ctx,
 			timeout,
-			0,
+			WrapIDSource(0),
 			suite.collection,
 			suite.replica,
 			NewSegmentAction(targetNode, ActionTypeGrow, "", segment),
@@ -1276,7 +1276,7 @@ func (suite *TaskSuite) TestSegmentTaskReplace() {
 		task, err := NewSegmentTask(
 			ctx,
 			timeout,
-			0,
+			WrapIDSource(0),
 			suite.collection,
 			suite.replica,
 			NewSegmentAction(targetNode, ActionTypeGrow, "", segment),
@@ -1317,7 +1317,7 @@ func (suite *TaskSuite) TestNoExecutor() {
 		task, err := NewSegmentTask(
 			ctx,
 			timeout,
-			0,
+			WrapIDSource(0),
 			suite.collection,
 			suite.replica,
 			NewSegmentAction(targetNode, ActionTypeGrow, channel.GetChannelName(), segment),

--- a/internal/querycoordv2/task/utils.go
+++ b/internal/querycoordv2/task/utils.go
@@ -36,6 +36,17 @@ import (
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
 
+// idSource helper type for using id as task source
+type idSource int64
+
+func (s idSource) String() string {
+	return fmt.Sprintf("ID-%d", s)
+}
+
+func WrapIDSource(id int64) Source {
+	return idSource(id)
+}
+
 func Wait(ctx context.Context, timeout time.Duration, tasks ...Task) error {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()


### PR DESCRIPTION
Task sourceID in int was hard to read and understand in log
This pr change sourceID to `Source` interface (alias of `fmt.Stringer`) and use `String()` result in log
/kind improvement