### PR TITLE
[skip e2e] Fix mergify rules for branch 2.3

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -4,7 +4,7 @@ pull_request_rules:
       - or:
           - base=master
           - base=sql_beta
-          - base~=^2(\.\d+){2}$
+          - base~=^2(\.\d+){1,2}$
       - -status-success=DCO
     actions:
       label:
@@ -20,7 +20,7 @@ pull_request_rules:
     conditions:
       - or:
           - base=master
-          - base~=^2(\.\d+){2}$
+          - base~=^2(\.\d+){1,2}$
           - base=sql_beta
       - status-success=DCO
     actions:
@@ -35,7 +35,7 @@ pull_request_rules:
       - or:
           - base=sql_beta
           - base=master
-          - base~=^2\.3\.\d+$
+          - base~=^2\.3\(.\d+){0,1}$
       - 'status-success=Build and test AMD64 Ubuntu 20.04'
       - 'status-success=Code Checker AMD64 Ubuntu 20.04'
       - 'status-success=Code Checker MacOS 12'
@@ -67,7 +67,7 @@ pull_request_rules:
       - or:
           - base=master
           - base=sql_beta
-          - base~=^2(\.\d+){2}$
+          - base~=^2(\.\d+){1,2}$
       - -files~=^(?!tests\/python_client).+
       - 'status-success=cpu-e2e'
     actions:
@@ -80,7 +80,7 @@ pull_request_rules:
       - or:
           - base=master
           - base=sql_beta
-          - base~=^2(\.\d+){2}$
+          - base~=^2(\.\d+){1,2}$
       - -files~=^(?!.*\.(md)).*$
     actions:
       label:
@@ -92,7 +92,7 @@ pull_request_rules:
       - or:
           - base=master
           - base=sql_beta
-          - base~=^2(\.\d+){2}$
+          - base~=^2(\.\d+){1,2}$
       - -files~=^(?=.*((\.(go|h|cpp)|CMakeLists.txt|conanfile\.*))).*$
       - 'status-success=cpu-e2e'
     actions:
@@ -105,7 +105,7 @@ pull_request_rules:
       - or:
           - base=master
           - base=sql_beta
-          - base~=^2\.3\.\d+$
+          - base~=^2\.3(\.\d+){0,1}$
       - 'status-success=Build and test AMD64 Ubuntu 20.04'
       - 'status-success=Code Checker AMD64 Ubuntu 20.04'
       - 'status-success=Code Checker MacOS 12'
@@ -137,7 +137,7 @@ pull_request_rules:
       - or:
           - base=master
           - base=sql_beta
-          - base~=^2(\.\d+){2}$
+          - base~=^2(\.\d+){1,2}$
       - -files~=^(?!\.github\/mergify\.yml).*$
     actions:
       label:
@@ -149,7 +149,7 @@ pull_request_rules:
       - or:
           - base=master
           - base=sql_beta
-          - base~=^2(\.\d+){2}$
+          - base~=^2(\.\d+){1,2}$
       - title~=\[skip e2e\]
       - label=kind/improvement
       - -files~=^(?=.*((\.(go|h|cpp)|CMakeLists.txt))).*$
@@ -163,7 +163,7 @@ pull_request_rules:
       - or:
           - base=master
           - base=sql_beta
-          - base~=^2(\.\d+){2}$
+          - base~=^2(\.\d+){1,2}$
       - and:
           - -body~=\#[0-9]{1,6}(\s+|$)
           - -body~=https://github.com/milvus-io/milvus/issues/[0-9]{1,6}(\s+|$)
@@ -184,7 +184,7 @@ pull_request_rules:
               - or:
                   - base=master
                   - base=sql_beta
-                  - base~=^2(\.\d+){2}$
+                  - base~=^2(\.\d+){1,2}$
               - or:
                   - body~=\#[0-9]{1,6}(\s+|$)
                   - body~=https://github.com/milvus-io/milvus/issues/[0-9]{1,6}(\s+|$)
@@ -192,7 +192,7 @@ pull_request_rules:
               - or:
                   - base=master
                   - base=sql_beta
-                  - base~=^2(\.\d+){2}$
+                  - base~=^2(\.\d+){1,2}$
               - label=kind/improvement
     actions:
       label:
@@ -201,7 +201,7 @@ pull_request_rules:
 
   - name: Blocking PR if missing a related master PR or doesn't have kind/branch-feature label
     conditions:
-      - base~=^2(\.\d+){2}$
+      - base~=^2(\.\d+){1,2}$
       - and:
           - -body~=pr\:\ \#[0-9]{1,6}(\s+|$)
           - -body~=https://github.com/milvus-io/milvus/pull/[0-9]{1,6}(\s+|$)
@@ -217,7 +217,7 @@ pull_request_rules:
 
   - name: Dismiss block label if related pr be added into PR
     conditions:
-      - base~=^2(\.\d+){2}$
+      - base~=^2(\.\d+){1,2}$
       - or:
           - body~=pr\:\ \#[0-9]{1,6}(\s+|$)
           - body~=https://github.com/milvus-io/milvus/pull/[0-9]{1,6}(\s+|$)
@@ -232,7 +232,7 @@ pull_request_rules:
       - or:
           - base=master
           - base=sql_beta
-          - base~=^2(\.\d+){2}$
+          - base~=^2(\.\d+){1,2}$
       - title~=\[automated\]
     actions:
       label:
@@ -245,7 +245,7 @@ pull_request_rules:
       - or:
           - base=master
           - base=sql_beta
-          - base~=^2\.3\.\d+$
+          - base~=^2\.3(\.\d+){0,1}$
       - title~=\[skip e2e\]
       - 'status-success=Code Checker AMD64 Ubuntu 20.04'
       - 'status-success=Build and test AMD64 Ubuntu 20.04'
@@ -277,7 +277,7 @@ pull_request_rules:
       - or:
           - base=master
           - base=sql_beta
-          - base~=^2\.3\.\d+$
+          - base~=^2\.3(\.\d+){0,1}$
       - files~=^(?=.*((\.(go|h|cpp)|CMakeLists.txt))).*$
       - or:
           - 'status-success!=Code Checker AMD64 Ubuntu 20.04'
@@ -310,7 +310,7 @@ pull_request_rules:
       - or:
           - base=master
           - base=sql_beta
-          - base~=^2(\.\d+){2}$
+          - base~=^2(\.\d+){1,2}$
       - -title~=\[skip e2e\]
       - files~=^(?!(.*_test\.go|.*\.md)).*$
       - 'status-success!=cpu-e2e'
@@ -324,7 +324,7 @@ pull_request_rules:
       - or:
           - base=master
           - base=sql_beta
-          - base~=^2(\.\d+){2}$
+          - base~=^2(\.\d+){1,2}$
       - 'check-failure=cpu-e2e'
     actions:
       comment:
@@ -335,6 +335,7 @@ pull_request_rules:
     conditions:
       - or:
           - base=master
+          - base~=^2\.3(\.\d+){0,1}$
           - base=sql_beta
       - or:
           - 'check-failure=Code Checker AMD64 Ubuntu 20.04'
@@ -360,7 +361,7 @@ pull_request_rules:
       - or:
           - base=master
           - base=sql_beta
-          - base~=^2(\.\d+){2}$
+          - base~=^2(\.\d+){1,2}$
       - '#commits>1'
     actions:
       comment:
@@ -375,7 +376,7 @@ pull_request_rules:
       - or:
           - base=master
           - base=sql_beta
-          - base~=^2(\.\d+){2}$
+          - base~=^2(\.\d+){1,2}$
       - '#commits=1'
     actions:
       label:


### PR DESCRIPTION
Change mergify rules since new development branch for 2.3.x is `2.3`
/kind improvement