### PR TITLE
Refine datanode metacache and implement CoW

### DIFF
--- a/internal/datanode/metacache/actions.go
+++ b/internal/datanode/metacache/actions.go
@@ -1,0 +1,83 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metacache
+
+import (
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
+)
+
+type SegmentFilter func(info *SegmentInfo) bool
+
+func WithPartitionID(partitionID int64) SegmentFilter {
+	return func(info *SegmentInfo) bool {
+		return info.partitionID == partitionID
+	}
+}
+
+func WithSegmentID(segmentID int64) SegmentFilter {
+	return func(info *SegmentInfo) bool {
+		return info.segmentID == segmentID
+	}
+}
+
+func WithSegmentState(state commonpb.SegmentState) SegmentFilter {
+	return func(info *SegmentInfo) bool {
+		return info.state == state
+	}
+}
+
+func WithStartPosNotRecorded() SegmentFilter {
+	return func(info *SegmentInfo) bool {
+		return !info.startPosRecorded
+	}
+}
+
+type SegmentAction func(info *SegmentInfo)
+
+func UpdateState(state commonpb.SegmentState) SegmentAction {
+	return func(info *SegmentInfo) {
+		info.state = state
+	}
+}
+
+func UpdateCheckpoint(checkpoint *msgpb.MsgPosition) SegmentAction {
+	return func(info *SegmentInfo) {
+		info.checkpoint = checkpoint
+	}
+}
+
+func UpdateNumOfRows(numOfRows int64) SegmentAction {
+	return func(info *SegmentInfo) {
+		info.numOfRows = numOfRows
+	}
+}
+
+func RollStats() SegmentAction {
+	return func(info *SegmentInfo) {
+		info.bfs.Roll()
+	}
+}
+
+// MergeSegmentAction is the util function to merge multiple SegmentActions into one.
+func MergeSegmentAction(actions ...SegmentAction) SegmentAction {
+	return func(info *SegmentInfo) {
+		for _, action := range actions {
+			action(info)
+		}
+	}
+}

--- a/internal/datanode/metacache/actions_test.go
+++ b/internal/datanode/metacache/actions_test.go
@@ -1,0 +1,121 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metacache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
+)
+
+type SegmentFilterSuite struct {
+	suite.Suite
+}
+
+func (s *SegmentFilterSuite) TestFilters() {
+	info := &SegmentInfo{}
+
+	partitionID := int64(1001)
+	filter := WithPartitionID(partitionID)
+	info.partitionID = partitionID + 1
+	s.False(filter(info))
+	info.partitionID = partitionID
+	s.True(filter(info))
+
+	segmentID := int64(10001)
+	filter = WithSegmentID(segmentID)
+	info.segmentID = segmentID + 1
+	s.False(filter(info))
+	info.segmentID = segmentID
+	s.True(filter(info))
+
+	state := commonpb.SegmentState_Growing
+	filter = WithSegmentState(state)
+	info.state = commonpb.SegmentState_Flushed
+	s.False(filter(info))
+	info.state = state
+	s.True(filter(info))
+
+	filter = WithStartPosNotRecorded()
+	info.startPosRecorded = true
+	s.False(filter(info))
+	info.startPosRecorded = false
+	s.True(filter(info))
+}
+
+func TestFilters(t *testing.T) {
+	suite.Run(t, new(SegmentFilterSuite))
+}
+
+type SegmentActionSuite struct {
+	suite.Suite
+}
+
+func (s *SegmentActionSuite) TestActions() {
+	info := &SegmentInfo{}
+
+	state := commonpb.SegmentState_Flushed
+	action := UpdateState(state)
+	action(info)
+	s.Equal(state, info.State())
+
+	cp := &msgpb.MsgPosition{
+		MsgID:       []byte{1, 2, 3, 4},
+		ChannelName: "channel_1",
+		Timestamp:   20000,
+	}
+	action = UpdateCheckpoint(cp)
+	action(info)
+	s.Equal(cp, info.Checkpoint())
+
+	numOfRows := int64(2048)
+	action = UpdateNumOfRows(numOfRows)
+	action(info)
+	s.Equal(numOfRows, info.NumOfRows())
+}
+
+func (s *SegmentActionSuite) TestMergeActions() {
+	info := &SegmentInfo{}
+
+	var actions []SegmentAction
+	state := commonpb.SegmentState_Flushed
+	actions = append(actions, UpdateState(state))
+
+	cp := &msgpb.MsgPosition{
+		MsgID:       []byte{1, 2, 3, 4},
+		ChannelName: "channel_1",
+		Timestamp:   20000,
+	}
+	actions = append(actions, UpdateCheckpoint(cp))
+
+	numOfRows := int64(2048)
+	actions = append(actions, UpdateNumOfRows(numOfRows))
+
+	action := MergeSegmentAction(actions...)
+	action(info)
+
+	s.Equal(state, info.State())
+	s.Equal(numOfRows, info.NumOfRows())
+	s.Equal(cp, info.Checkpoint())
+}
+
+func TestActions(t *testing.T) {
+	suite.Run(t, new(SegmentActionSuite))
+}

--- a/internal/datanode/metacache/bloom_filter_set.go
+++ b/internal/datanode/metacache/bloom_filter_set.go
@@ -1,0 +1,80 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metacache
+
+import (
+	"sync"
+
+	"github.com/bits-and-blooms/bloom/v3"
+
+	"github.com/milvus-io/milvus/internal/storage"
+)
+
+type BloomFilterSet struct {
+	mut     sync.Mutex
+	current *storage.PkStatistics
+	history []*storage.PkStatistics
+}
+
+func newBloomFilterSet() *BloomFilterSet {
+	return &BloomFilterSet{}
+}
+
+func (bfs *BloomFilterSet) PkExists(pk storage.PrimaryKey) bool {
+	bfs.mut.Lock()
+	defer bfs.mut.Unlock()
+	if bfs.current != nil && bfs.current.PkExist(pk) {
+		return true
+	}
+
+	for _, bf := range bfs.history {
+		if bf.PkExist(pk) {
+			return true
+		}
+	}
+	return false
+}
+
+func (bfs *BloomFilterSet) UpdatePKRange(ids storage.FieldData) error {
+	bfs.mut.Lock()
+	defer bfs.mut.Unlock()
+
+	if bfs.current == nil {
+		bfs.current = &storage.PkStatistics{
+			PkFilter: bloom.NewWithEstimates(storage.BloomFilterSize, storage.MaxBloomFalsePositive),
+		}
+	}
+
+	return bfs.current.UpdatePKRange(ids)
+}
+
+func (bfs *BloomFilterSet) Roll() {
+	bfs.mut.Lock()
+	defer bfs.mut.Unlock()
+
+	if bfs.current != nil {
+		bfs.history = append(bfs.history, bfs.current)
+		bfs.current = nil
+	}
+}
+
+func (bfs *BloomFilterSet) GetHistory() []*storage.PkStatistics {
+	bfs.mut.Lock()
+	defer bfs.mut.Unlock()
+
+	return bfs.history
+}

--- a/internal/datanode/metacache/bloom_filter_set_test.go
+++ b/internal/datanode/metacache/bloom_filter_set_test.go
@@ -1,0 +1,93 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metacache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/storage"
+)
+
+type BloomFilterSetSuite struct {
+	suite.Suite
+	bfs *BloomFilterSet
+}
+
+func (s *BloomFilterSetSuite) SetupTest() {
+	s.bfs = newBloomFilterSet()
+}
+
+func (s *BloomFilterSetSuite) TearDownSuite() {
+	s.bfs = nil
+}
+
+func (s *BloomFilterSetSuite) GetFieldData(ids []int64) storage.FieldData {
+	fd, err := storage.NewFieldData(schemapb.DataType_Int64, &schemapb.FieldSchema{
+		FieldID:      101,
+		Name:         "ID",
+		IsPrimaryKey: true,
+		DataType:     schemapb.DataType_Int64,
+	})
+	s.Require().NoError(err)
+
+	for _, id := range ids {
+		err = fd.AppendRow(id)
+		s.Require().NoError(err)
+	}
+	return fd
+}
+
+func (s *BloomFilterSetSuite) TestWriteRead() {
+	ids := []int64{1, 2, 3, 4, 5}
+
+	for _, id := range ids {
+		s.False(s.bfs.PkExists(storage.NewInt64PrimaryKey(id)), "pk shall not exist before update")
+	}
+
+	err := s.bfs.UpdatePKRange(s.GetFieldData(ids))
+	s.NoError(err)
+
+	for _, id := range ids {
+		s.True(s.bfs.PkExists(storage.NewInt64PrimaryKey(id)), "pk shall return exist after update")
+	}
+}
+
+func (s *BloomFilterSetSuite) TestRoll() {
+	history := s.bfs.GetHistory()
+
+	s.Equal(0, len(history), "history empty for new bfs")
+
+	ids := []int64{1, 2, 3, 4, 5}
+	err := s.bfs.UpdatePKRange(s.GetFieldData(ids))
+	s.NoError(err)
+
+	s.bfs.Roll()
+
+	history = s.bfs.GetHistory()
+	s.Equal(1, len(history), "history shall have one entry after roll with current data")
+
+	s.bfs.Roll()
+	history = s.bfs.GetHistory()
+	s.Equal(1, len(history), "history shall have one entry after empty roll")
+}
+
+func TestBloomFilterSet(t *testing.T) {
+	suite.Run(t, new(BloomFilterSetSuite))
+}

--- a/internal/datanode/metacache/segment.go
+++ b/internal/datanode/metacache/segment.go
@@ -1,0 +1,89 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metacache
+
+import (
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
+	"github.com/milvus-io/milvus/internal/proto/datapb"
+	"github.com/milvus-io/milvus/internal/storage"
+)
+
+type SegmentInfo struct {
+	segmentID        int64
+	partitionID      int64
+	state            commonpb.SegmentState
+	startPosition    *msgpb.MsgPosition
+	checkpoint       *msgpb.MsgPosition
+	startPosRecorded bool
+	numOfRows        int64
+	bfs              *BloomFilterSet
+}
+
+func (s *SegmentInfo) SegmentID() int64 {
+	return s.segmentID
+}
+
+func (s *SegmentInfo) PartitionID() int64 {
+	return s.partitionID
+}
+
+func (s *SegmentInfo) State() commonpb.SegmentState {
+	return s.state
+}
+
+func (s *SegmentInfo) NumOfRows() int64 {
+	return s.numOfRows
+}
+
+func (s *SegmentInfo) StartPosition() *msgpb.MsgPosition {
+	return s.startPosition
+}
+
+func (s *SegmentInfo) Checkpoint() *msgpb.MsgPosition {
+	return s.checkpoint
+}
+
+func (s *SegmentInfo) GetHistory() []*storage.PkStatistics {
+	return s.bfs.GetHistory()
+}
+
+func (s *SegmentInfo) Clone() *SegmentInfo {
+	return &SegmentInfo{
+		segmentID:        s.segmentID,
+		partitionID:      s.partitionID,
+		state:            s.state,
+		startPosition:    s.startPosition,
+		checkpoint:       s.checkpoint,
+		startPosRecorded: s.startPosRecorded,
+		numOfRows:        s.numOfRows,
+		bfs:              s.bfs,
+	}
+}
+
+func newSegmentInfo(info *datapb.SegmentInfo, bfs *BloomFilterSet) *SegmentInfo {
+	return &SegmentInfo{
+		segmentID:        info.GetID(),
+		partitionID:      info.GetPartitionID(),
+		state:            info.GetState(),
+		numOfRows:        info.GetNumOfRows(),
+		startPosition:    info.GetStartPosition(),
+		checkpoint:       info.GetDmlPosition(),
+		startPosRecorded: true,
+		bfs:              bfs,
+	}
+}

--- a/internal/datanode/metacache/segment_test.go
+++ b/internal/datanode/metacache/segment_test.go
@@ -1,0 +1,60 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metacache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/milvus-io/milvus/internal/proto/datapb"
+)
+
+type SegmentSuite struct {
+	suite.Suite
+
+	info *datapb.SegmentInfo
+}
+
+func (s *SegmentSuite) TestBasic() {
+	bfs := newBloomFilterSet()
+	segment := newSegmentInfo(s.info, bfs)
+	s.Equal(s.info.GetID(), segment.SegmentID())
+	s.Equal(s.info.GetPartitionID(), segment.PartitionID())
+	s.Equal(s.info.GetNumOfRows(), segment.NumOfRows())
+	s.Equal(s.info.GetStartPosition(), segment.StartPosition())
+	s.Equal(s.info.GetDmlPosition(), segment.Checkpoint())
+	s.Equal(bfs.GetHistory(), segment.GetHistory())
+	s.True(segment.startPosRecorded)
+}
+
+func (s *SegmentSuite) TestClone() {
+	bfs := newBloomFilterSet()
+	segment := newSegmentInfo(s.info, bfs)
+	cloned := segment.Clone()
+	s.Equal(segment.SegmentID(), cloned.SegmentID())
+	s.Equal(segment.PartitionID(), cloned.PartitionID())
+	s.Equal(segment.NumOfRows(), cloned.NumOfRows())
+	s.Equal(segment.StartPosition(), cloned.StartPosition())
+	s.Equal(segment.Checkpoint(), cloned.Checkpoint())
+	s.Equal(segment.GetHistory(), cloned.GetHistory())
+	s.Equal(segment.startPosRecorded, cloned.startPosRecorded)
+}
+
+func TestSegment(t *testing.T) {
+	suite.Run(t, new(SegmentSuite))
+}


### PR DESCRIPTION
Add methods for `MetaCache` for `SyncMgr` and `WriteBuffer`
Impl metacache with Copy-on-Write strategy
See also #27675
/kind improvement