### PR TITLE
Refine offline segments logic in shard delegator

### DIFF
--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -186,7 +186,7 @@ func (sd *shardDelegator) ProcessDelete(deleteData []*DeleteData, ts uint64) {
 
 	offlineSegments := typeutil.NewConcurrentSet[int64]()
 
-	sealed, growing, version := sd.distribution.GetSegments(false)
+	sealed, growing, version := sd.distribution.PinOnlineSegments()
 
 	eg, ctx := errgroup.WithContext(context.Background())
 	for _, entry := range sealed {
@@ -225,7 +225,7 @@ func (sd *shardDelegator) ProcessDelete(deleteData []*DeleteData, ts uint64) {
 	// not error return in apply delete
 	_ = eg.Wait()
 
-	sd.distribution.FinishUsage(version)
+	sd.distribution.Unpin(version)
 	offlineSegIDs := offlineSegments.Collect()
 	if len(offlineSegIDs) > 0 {
 		log.Warn("failed to apply delete, mark segment offline", zap.Int64s("offlineSegments", offlineSegIDs))

--- a/internal/querynodev2/delegator/delegator_test.go
+++ b/internal/querynodev2/delegator/delegator_test.go
@@ -434,6 +434,24 @@ func (s *DelegatorSuite) TestSearch() {
 		s.Error(err)
 	})
 
+	s.Run("distribution_not_serviceable", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		sd, ok := s.delegator.(*shardDelegator)
+		s.Require().True(ok)
+		sd.distribution.AddOfflines(1001)
+
+		_, err := s.delegator.Search(ctx, &querypb.SearchRequest{
+			Req: &internalpb.SearchRequest{
+				Base: commonpbutil.NewMsgBase(),
+			},
+			DmlChannels: []string{s.vchannelName},
+		})
+
+		s.Error(err)
+	})
+
 	s.Run("cluster_not_serviceable", func() {
 		s.delegator.Close()
 
@@ -598,6 +616,22 @@ func (s *DelegatorSuite) TestQuery() {
 		_, err := s.delegator.Query(ctx, &querypb.QueryRequest{
 			Req:         &internalpb.RetrieveRequest{Base: commonpbutil.NewMsgBase()},
 			DmlChannels: []string{"non_exist_channel"},
+		})
+
+		s.Error(err)
+	})
+
+	s.Run("distribution_not_serviceable", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		sd, ok := s.delegator.(*shardDelegator)
+		s.Require().True(ok)
+		sd.distribution.AddOfflines(1001)
+
+		_, err := s.delegator.Query(ctx, &querypb.QueryRequest{
+			Req:         &internalpb.RetrieveRequest{Base: commonpbutil.NewMsgBase()},
+			DmlChannels: []string{s.vchannelName},
 		})
 
 		s.Error(err)
@@ -865,6 +899,25 @@ func (s *DelegatorSuite) TestQueryStream() {
 		s.Error(err)
 	})
 
+	s.Run("distribution_not_serviceable", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		sd, ok := s.delegator.(*shardDelegator)
+		s.Require().True(ok)
+		sd.distribution.AddOfflines(1001)
+
+		client := streamrpc.NewLocalQueryClient(ctx)
+		server := client.CreateServer()
+
+		// run stream function
+		err := s.delegator.QueryStream(ctx, &querypb.QueryRequest{
+			Req:         &internalpb.RetrieveRequest{Base: commonpbutil.NewMsgBase()},
+			DmlChannels: []string{s.vchannelName},
+		}, server)
+		s.Error(err)
+	})
+
 	s.Run("cluster_not_serviceable", func() {
 		s.delegator.Close()
 
@@ -1018,6 +1071,22 @@ func (s *DelegatorSuite) TestGetStats() {
 		_, err := s.delegator.GetStatistics(ctx, &querypb.GetStatisticsRequest{
 			Req:         &internalpb.GetStatisticsRequest{Base: commonpbutil.NewMsgBase()},
 			DmlChannels: []string{"non_exist_channel"},
+		})
+
+		s.Error(err)
+	})
+
+	s.Run("distribution_not_serviceable", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		sd, ok := s.delegator.(*shardDelegator)
+		s.Require().True(ok)
+		sd.distribution.AddOfflines(1001)
+
+		_, err := s.delegator.GetStatistics(ctx, &querypb.GetStatisticsRequest{
+			Req:         &internalpb.GetStatisticsRequest{Base: commonpbutil.NewMsgBase()},
+			DmlChannels: []string{s.vchannelName},
 		})
 
 		s.Error(err)


### PR DESCRIPTION
This PR fix offline segments logic in distribution

- Separate pin readable & online API
- Rename `FinishUsage` to `Unpin`
- Return error for `PinReadableSegments` when distribution is not serviceable
- Filter online segments for `PinOnlineSegments`

Fix #28072
/kind bug