### PR TITLE
Implement `Injection` for SyncManager with block and meta transition

### DIFF
--- a/internal/datanode/metacache/actions.go
+++ b/internal/datanode/metacache/actions.go
@@ -73,6 +73,12 @@ func RollStats() SegmentAction {
 	}
 }
 
+func CompactTo(compactTo int64) SegmentAction {
+	return func(info *SegmentInfo) {
+		info.compactTo = compactTo
+	}
+}
+
 // MergeSegmentAction is the util function to merge multiple SegmentActions into one.
 func MergeSegmentAction(actions ...SegmentAction) SegmentAction {
 	return func(info *SegmentInfo) {

--- a/internal/datanode/metacache/actions_test.go
+++ b/internal/datanode/metacache/actions_test.go
@@ -89,6 +89,11 @@ func (s *SegmentActionSuite) TestActions() {
 	action = UpdateNumOfRows(numOfRows)
 	action(info)
 	s.Equal(numOfRows, info.NumOfRows())
+
+	compactTo := int64(1002)
+	action = CompactTo(compactTo)
+	action(info)
+	s.Equal(compactTo, info.CompactTo())
 }
 
 func (s *SegmentActionSuite) TestMergeActions() {

--- a/internal/datanode/metacache/segment.go
+++ b/internal/datanode/metacache/segment.go
@@ -32,6 +32,7 @@ type SegmentInfo struct {
 	startPosRecorded bool
 	numOfRows        int64
 	bfs              *BloomFilterSet
+	compactTo        int64
 }
 
 func (s *SegmentInfo) SegmentID() int64 {
@@ -62,6 +63,10 @@ func (s *SegmentInfo) GetHistory() []*storage.PkStatistics {
 	return s.bfs.GetHistory()
 }
 
+func (s *SegmentInfo) CompactTo() int64 {
+	return s.compactTo
+}
+
 func (s *SegmentInfo) Clone() *SegmentInfo {
 	return &SegmentInfo{
 		segmentID:        s.segmentID,
@@ -72,6 +77,7 @@ func (s *SegmentInfo) Clone() *SegmentInfo {
 		startPosRecorded: s.startPosRecorded,
 		numOfRows:        s.numOfRows,
 		bfs:              s.bfs,
+		compactTo:        s.compactTo,
 	}
 }
 

--- a/internal/datanode/syncmgr/sync_manager.go
+++ b/internal/datanode/syncmgr/sync_manager.go
@@ -34,6 +34,8 @@ type SyncMeta struct {
 
 type SyncManager interface {
 	SyncData(ctx context.Context, task *SyncTask) error
+	Block(segmentID int64)
+	Unblock(segmentID int64)
 }
 
 type syncManager struct {
@@ -61,4 +63,12 @@ func (mgr syncManager) SyncData(ctx context.Context, task *SyncTask) error {
 	mgr.Submit(task.segmentID, task)
 
 	return nil
+}
+
+func (mgr syncManager) Block(segmentID int64) {
+	mgr.keyLock.Lock(segmentID)
+}
+
+func (mgr syncManager) Unblock(segmentID int64) {
+	mgr.keyLock.Unlock(segmentID)
 }


### PR DESCRIPTION
To replace complex injection in flush manager, sync manager could do the same with thing with:

- Block segment sync
- Unblock segment sync
- Update segment task id to compactTo segment

See also #27675
/kind enhancement