### PR TITLE
Reduce 1x memory copy for retrieving data

### DIFF
--- a/.github/workflows/mac.yaml
+++ b/.github/workflows/mac.yaml
@@ -44,6 +44,10 @@ jobs:
           path: /var/tmp/ccache
           key: macos-ccache-${{ env.corehash }}
           restore-keys: macos-ccache-
+      - name: Setup Python environment
+        uses: actions/setup-python@v4
+        with:
+          python-version: '<3.12'
       - name: Setup Go environment
         uses: actions/setup-go@v2.2.0
         with:

--- a/internal/core/src/segcore/Utils.cpp
+++ b/internal/core/src/segcore/Utils.cpp
@@ -279,6 +279,8 @@ CreateScalarDataArray(int64_t count, const FieldMeta& field_meta) {
         case DataType::ARRAY: {
             auto obj = scalar_array->mutable_array_data();
             obj->mutable_data()->Reserve(count);
+            obj->set_element_type(static_cast<milvus::proto::schema::DataType>(
+                field_meta.get_element_type()));
             for (int i = 0; i < count; i++) {
                 *(obj->mutable_data()->Add()) = proto::schema::ScalarField();
             }
@@ -406,6 +408,8 @@ CreateScalarDataArrayFrom(const void* data_raw,
         case DataType::ARRAY: {
             auto data = reinterpret_cast<const ScalarArray*>(data_raw);
             auto obj = scalar_array->mutable_array_data();
+            obj->set_element_type(static_cast<milvus::proto::schema::DataType>(
+                field_meta.get_element_type()));
             for (auto i = 0; i < count; i++) {
                 *(obj->mutable_data()->Add()) = data[i];
             }


### PR DESCRIPTION
/kind improvement
Before this, while retrieving data (query/search), we first copy the data into a fixed vector, and then copy data from this into the proto field.
Now we can directly copy the data into the proto field.

This optimization can't be done with `int8`, `int16` due to the proto doesn't provide the two types, we store them in `int32`s

Also, this can't be done with variable length field like string, JSON, see [proto issue](https://github.com/protocolbuffers/protobuf/issues/10866). I tried but it seems proto doesn't guarantee the memory layout as we expected, it crashed