### PR TITLE
Fix datanode panic due to concurrent compaction and delete processing (#27167)

### DIFF
--- a/internal/datanode/channel_meta_test.go
+++ b/internal/datanode/channel_meta_test.go
@@ -683,12 +683,7 @@ func TestChannelMeta_InterfaceMethod(t *testing.T) {
 				require.False(t, channel.hasSegment(3, true))
 
 				// tests start
-				err := channel.mergeFlushedSegments(context.Background(), test.inSeg, 100, test.inCompactedFrom)
-				if test.isValid {
-					assert.NoError(t, err)
-				} else {
-					assert.Error(t, err)
-				}
+				channel.mergeFlushedSegments(context.Background(), test.inSeg, 100, test.inCompactedFrom)
 
 				if test.stored {
 					assert.True(t, channel.hasSegment(3, true))

--- a/internal/datanode/data_node_test.go
+++ b/internal/datanode/data_node_test.go
@@ -756,13 +756,7 @@ func TestDataNode(t *testing.T) {
 				CompactedTo:   101,
 				NumOfRows:     100,
 			}
-			cancelCtx, cancel := context.WithCancel(context.Background())
-			cancel()
-			status, err := node.SyncSegments(cancelCtx, req)
-			assert.NoError(t, err)
-			assert.Equal(t, commonpb.ErrorCode_UnexpectedError, status.GetErrorCode())
-
-			status, err = node.SyncSegments(ctx, req)
+			status, err := node.SyncSegments(ctx, req)
 			assert.NoError(t, err)
 			assert.Equal(t, commonpb.ErrorCode_Success, status.GetErrorCode())
 

--- a/internal/datanode/flush_manager.go
+++ b/internal/datanode/flush_manager.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/samber/lo"
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
 
@@ -40,7 +41,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/metautil"
 	"github.com/milvus-io/milvus/internal/util/retry"
 	"github.com/milvus-io/milvus/internal/util/timerecord"
-	"github.com/samber/lo"
+	"github.com/milvus-io/milvus/pkg/util/merr"
 )
 
 // flushManager defines a flush manager signature
@@ -500,7 +501,7 @@ func (m *rendezvousFlushManager) injectFlush(injection *taskInjection, segments 
 // fetch meta info for segment
 func (m *rendezvousFlushManager) getSegmentMeta(segmentID UniqueID, pos *internalpb.MsgPosition) (UniqueID, UniqueID, *etcdpb.CollectionMeta, error) {
 	if !m.hasSegment(segmentID, true) {
-		return -1, -1, nil, fmt.Errorf("no such segment %d in the channel", segmentID)
+		return -1, -1, nil, merr.WrapErrSegmentNotFound(segmentID)
 	}
 
 	// fetch meta information of segment

--- a/internal/util/flowgraph/node.go
+++ b/internal/util/flowgraph/node.go
@@ -32,6 +32,8 @@ const (
 	// TODO: better to be configured
 	nodeCtxTtInterval = 2 * time.Minute
 	enableTtChecker   = true
+	// blockAll should wait no more than 10 seconds
+	blockAllWait = 10 * time.Second
 )
 
 // Node is the interface defines the behavior of flowgraph
@@ -75,7 +77,13 @@ func (nodeCtx *nodeCtx) Start() {
 func (nodeCtx *nodeCtx) Block() {
 	// input node operate function will be blocking
 	if !nodeCtx.node.IsInputNode() {
+		startTs := time.Now()
 		nodeCtx.blockMutex.Lock()
+		if time.Since(startTs) >= blockAllWait {
+			log.Warn("flow graph wait for long time",
+				zap.String("name", nodeCtx.node.Name()),
+				zap.Duration("wait time", time.Since(startTs)))
+		}
 	}
 }
 

--- a/pkg/util/merr/errors.go
+++ b/pkg/util/merr/errors.go
@@ -17,8 +17,6 @@
 package merr
 
 import (
-	"context"
-
 	"github.com/cockroachdb/errors"
 )
 
@@ -163,25 +161,10 @@ func (e milvusError) Error() string {
 	return e.msg
 }
 
-// Code returns the error code of the given error,
-// WARN: DO NOT use this for now
-func Code(err error) int32 {
-	if err == nil {
-		return 0
-	}
-
+func (e milvusError) Is(err error) bool {
 	cause := errors.Cause(err)
-	switch cause := cause.(type) {
-	case milvusError:
-		return cause.code()
-
-	default:
-		if errors.Is(cause, context.Canceled) {
-			return CanceledCode
-		} else if errors.Is(cause, context.DeadlineExceeded) {
-			return TimeoutCode
-		} else {
-			return errUnexpected.code()
-		}
+	if cause, ok := cause.(milvusError); ok {
+		return e.errCode == cause.errCode
 	}
+	return false
 }

--- a/pkg/util/merr/util.go
+++ b/pkg/util/merr/util.go
@@ -1,0 +1,60 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package merr
+
+import (
+	"context"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+)
+
+// Code returns the error code of the given error,
+// WARN: DO NOT use this for now
+func Code(err error) int32 {
+	if err == nil {
+		return 0
+	}
+
+	cause := errors.Cause(err)
+	switch cause := cause.(type) {
+	case milvusError:
+		return cause.code()
+
+	default:
+		if errors.Is(cause, context.Canceled) {
+			return CanceledCode
+		} else if errors.Is(cause, context.DeadlineExceeded) {
+			return TimeoutCode
+		} else {
+			return errUnexpected.code()
+		}
+	}
+}
+
+// Segment related
+func WrapErrSegmentNotFound(id int64, msg ...string) error {
+	err := wrapWithField(ErrSegmentNotFound, "segment", id)
+	if len(msg) > 0 {
+		err = errors.Wrap(err, strings.Join(msg, "; "))
+	}
+	return err
+}
+
+func wrapWithField(err error, name string, value any) error {
+	return errors.Wrapf(err, "%s=%v", name, value)
+}


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/27145
pr: https://github.com/milvus-io/milvus/pull/27167

/kind bug

the datanode processing delete while compaction happened so flush can not succeed.
For fixing:

1. bring back blockall, ,make sure compaction sync segments and delete processing are mutexed.
2. change ttNode handle updateCheckPoint async, make sure all the flowgraph node is processed fast.
3. change some error handling

see also: https://github.com/milvus-io/milvus/pull/27158