### PR TITLE
fix sync distribution with wrong version

### DIFF
--- a/internal/querycoordv2/observers/collection_observer_test.go
+++ b/internal/querycoordv2/observers/collection_observer_test.go
@@ -185,7 +185,8 @@ func (suite *CollectionObserverSuite) SetupTest() {
 
 	// Dependencies
 	suite.dist = meta.NewDistributionManager()
-	suite.meta = meta.NewMeta(suite.idAllocator, suite.store, session.NewNodeManager())
+	nodeMgr := session.NewNodeManager()
+	suite.meta = meta.NewMeta(suite.idAllocator, suite.store, nodeMgr)
 	suite.broker = meta.NewMockBroker(suite.T())
 	suite.targetMgr = meta.NewTargetManager(suite.broker, suite.meta)
 	suite.targetObserver = NewTargetObserver(suite.meta,
@@ -196,7 +197,7 @@ func (suite *CollectionObserverSuite) SetupTest() {
 	suite.checkerController = &checkers.CheckerController{}
 
 	mockCluster := session.NewMockCluster(suite.T())
-	suite.leaderObserver = NewLeaderObserver(suite.dist, suite.meta, suite.targetMgr, suite.broker, mockCluster)
+	suite.leaderObserver = NewLeaderObserver(suite.dist, suite.meta, suite.targetMgr, suite.broker, mockCluster, nodeMgr)
 	mockCluster.EXPECT().SyncDistribution(mock.Anything, mock.Anything, mock.Anything).Return(merr.Success(), nil).Maybe()
 
 	// Test object

--- a/internal/querycoordv2/observers/leader_observer_test.go
+++ b/internal/querycoordv2/observers/leader_observer_test.go
@@ -71,7 +71,8 @@ func (suite *LeaderObserverTestSuite) SetupTest() {
 	// meta
 	store := querycoord.NewCatalog(suite.kv)
 	idAllocator := RandomIncrementIDAllocator()
-	suite.meta = meta.NewMeta(idAllocator, store, session.NewNodeManager())
+	nodeMgr := session.NewNodeManager()
+	suite.meta = meta.NewMeta(idAllocator, store, nodeMgr)
 	suite.broker = meta.NewMockBroker(suite.T())
 
 	suite.mockCluster = session.NewMockCluster(suite.T())
@@ -80,7 +81,7 @@ func (suite *LeaderObserverTestSuite) SetupTest() {
 	// }, nil).Maybe()
 	distManager := meta.NewDistributionManager()
 	targetManager := meta.NewTargetManager(suite.broker, suite.meta)
-	suite.observer = NewLeaderObserver(distManager, suite.meta, targetManager, suite.broker, suite.mockCluster)
+	suite.observer = NewLeaderObserver(distManager, suite.meta, targetManager, suite.broker, suite.mockCluster, nodeMgr)
 }
 
 func (suite *LeaderObserverTestSuite) TearDownTest() {

--- a/internal/querycoordv2/server.go
+++ b/internal/querycoordv2/server.go
@@ -362,6 +362,7 @@ func (s *Server) initObserver() {
 		s.targetMgr,
 		s.broker,
 		s.cluster,
+		s.nodeMgr,
 	)
 	s.targetObserver = observers.NewTargetObserver(
 		s.meta,


### PR DESCRIPTION
issue: #28129

/kind bug

1. `leader_observer` shouldn't change the leader view on stopping node
2. when sync distribution, we should use the segment's version, not the sync request's version. to achieve this, we need to call `LoadSegment` once for each segment in `SyncDistribution`, and to speed up,  we call it in parallel 