### PR TITLE
Fix atomic.Int64 not found in go 1.18

### DIFF
--- a/internal/datanode/syncmgr/sync_manager_test.go
+++ b/internal/datanode/syncmgr/sync_manager_test.go
@@ -3,13 +3,13 @@ package syncmgr
 import (
 	"context"
 	"math/rand"
-	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/atomic"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/msgpb"


### PR DESCRIPTION
/kind improvement