### PR TITLE
Reduce 1x memory copy for retrieving data (#28106)

### DIFF
--- a/internal/core/src/segcore/SegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/SegmentSealedImpl.cpp
@@ -979,7 +979,6 @@ SegmentSealedImpl::bulk_subscript(FieldId field_id,
     // we have to clone the shared pointer,
     // to make sure it won't get released if segment released
     auto column = fields_.at(field_id);
-
     if (datatype_is_variable(field_meta.get_data_type())) {
         switch (field_meta.get_data_type()) {
             case DataType::VARCHAR:
@@ -1018,10 +1017,15 @@ SegmentSealedImpl::bulk_subscript(FieldId field_id,
     auto src_vec = column->Data();
     switch (field_meta.get_data_type()) {
         case DataType::BOOL: {
-            FixedVector<bool> output(count);
-            bulk_subscript_impl<bool>(
-                src_vec, seg_offsets, count, output.data());
-            return CreateScalarDataArrayFrom(output.data(), count, field_meta);
+            auto ret = fill_with_empty(field_id, count);
+            bulk_subscript_impl<bool>(src_vec,
+                                      seg_offsets,
+                                      count,
+                                      ret->mutable_scalars()
+                                          ->mutable_bool_data()
+                                          ->mutable_data()
+                                          ->mutable_data());
+            return ret;
         }
         case DataType::INT8: {
             FixedVector<int8_t> output(count);
@@ -1036,40 +1040,81 @@ SegmentSealedImpl::bulk_subscript(FieldId field_id,
             return CreateScalarDataArrayFrom(output.data(), count, field_meta);
         }
         case DataType::INT32: {
-            FixedVector<int32_t> output(count);
-            bulk_subscript_impl<int32_t>(
-                src_vec, seg_offsets, count, output.data());
-            return CreateScalarDataArrayFrom(output.data(), count, field_meta);
+            auto ret = fill_with_empty(field_id, count);
+            bulk_subscript_impl<int32_t>(src_vec,
+                                         seg_offsets,
+                                         count,
+                                         ret->mutable_scalars()
+                                             ->mutable_int_data()
+                                             ->mutable_data()
+                                             ->mutable_data());
+            return ret;
         }
         case DataType::INT64: {
-            FixedVector<int64_t> output(count);
-            bulk_subscript_impl<int64_t>(
-                src_vec, seg_offsets, count, output.data());
-            return CreateScalarDataArrayFrom(output.data(), count, field_meta);
+            auto ret = fill_with_empty(field_id, count);
+            bulk_subscript_impl<int64_t>(src_vec,
+                                         seg_offsets,
+                                         count,
+                                         ret->mutable_scalars()
+                                             ->mutable_long_data()
+                                             ->mutable_data()
+                                             ->mutable_data());
+            return ret;
         }
         case DataType::FLOAT: {
-            FixedVector<float> output(count);
-            bulk_subscript_impl<float>(
-                src_vec, seg_offsets, count, output.data());
-            return CreateScalarDataArrayFrom(output.data(), count, field_meta);
+            auto ret = fill_with_empty(field_id, count);
+            bulk_subscript_impl<float>(src_vec,
+                                       seg_offsets,
+                                       count,
+                                       ret->mutable_scalars()
+                                           ->mutable_float_data()
+                                           ->mutable_data()
+                                           ->mutable_data());
+            return ret;
         }
         case DataType::DOUBLE: {
-            FixedVector<double> output(count);
-            bulk_subscript_impl<double>(
-                src_vec, seg_offsets, count, output.data());
-            return CreateScalarDataArrayFrom(output.data(), count, field_meta);
+            auto ret = fill_with_empty(field_id, count);
+            bulk_subscript_impl<double>(src_vec,
+                                        seg_offsets,
+                                        count,
+                                        ret->mutable_scalars()
+                                            ->mutable_double_data()
+                                            ->mutable_data()
+                                            ->mutable_data());
+            return ret;
         }
 
-        case DataType::VECTOR_FLOAT:
-        case DataType::VECTOR_FLOAT16:
-        case DataType::VECTOR_BINARY: {
-            aligned_vector<char> output(field_meta.get_sizeof() * count);
+        case DataType::VECTOR_FLOAT: {
+            auto ret = fill_with_empty(field_id, count);
             bulk_subscript_impl(field_meta.get_sizeof(),
                                 src_vec,
                                 seg_offsets,
                                 count,
-                                output.data());
-            return CreateVectorDataArrayFrom(output.data(), count, field_meta);
+                                ret->mutable_vectors()
+                                    ->mutable_float_vector()
+                                    ->mutable_data()
+                                    ->mutable_data());
+            return ret;
+        }
+        case DataType::VECTOR_FLOAT16: {
+            auto ret = fill_with_empty(field_id, count);
+            bulk_subscript_impl(
+                field_meta.get_sizeof(),
+                src_vec,
+                seg_offsets,
+                count,
+                ret->mutable_vectors()->mutable_float16_vector()->data());
+            return ret;
+        }
+        case DataType::VECTOR_BINARY: {
+            auto ret = fill_with_empty(field_id, count);
+            bulk_subscript_impl(
+                field_meta.get_sizeof(),
+                src_vec,
+                seg_offsets,
+                count,
+                ret->mutable_vectors()->mutable_binary_vector()->data());
+            return ret;
         }
 
         default: {

--- a/internal/core/src/segcore/Utils.cpp
+++ b/internal/core/src/segcore/Utils.cpp
@@ -280,6 +280,8 @@ CreateScalarDataArray(int64_t count, const FieldMeta& field_meta) {
         case DataType::ARRAY: {
             auto obj = scalar_array->mutable_array_data();
             obj->mutable_data()->Reserve(count);
+            obj->set_element_type(static_cast<milvus::proto::schema::DataType>(
+                field_meta.get_element_type()));
             for (int i = 0; i < count; i++) {
                 *(obj->mutable_data()->Add()) = proto::schema::ScalarField();
             }
@@ -407,6 +409,8 @@ CreateScalarDataArrayFrom(const void* data_raw,
         case DataType::ARRAY: {
             auto data = reinterpret_cast<const ScalarArray*>(data_raw);
             auto obj = scalar_array->mutable_array_data();
+            obj->set_element_type(static_cast<milvus::proto::schema::DataType>(
+                field_meta.get_element_type()));
             for (auto i = 0; i < count; i++) {
                 *(obj->mutable_data()->Add()) = data[i];
             }


### PR DESCRIPTION
/kind improvement
Before this, while retrieving data (query/search), we first copy the data into a fixed vector, and then copy data from this into the proto field.
Now we can directly copy the data into the proto field.

This optimization can't be done with int8, int16 due to the proto doesn't provide the two types, we store them in int32s

Also, this can't be done with variable length field like string, JSON, see https://github.com/protocolbuffers/protobuf/issues/10866. I tried but it seems proto doesn't guarantee the memory layout as we expected, it crashed
pr: #28106 