### PR TITLE
[cherry-pick]Fix retry when proxy stopped

### DIFF
--- a/internal/rootcoord/proxy_client_manager_test.go
+++ b/internal/rootcoord/proxy_client_manager_test.go
@@ -196,6 +196,20 @@ func TestProxyClientManager_InvalidateCollectionMetaCache(t *testing.T) {
 		assert.Error(t, err)
 	})
 
+	t.Run("mock proxy service down", func(t *testing.T) {
+		ctx := context.Background()
+		p1 := newMockProxy()
+		p1.InvalidateCollectionMetaCacheFunc = func(ctx context.Context, request *proxypb.InvalidateCollMetaCacheRequest) (*commonpb.Status, error) {
+			return nil, merr.ErrNodeNotFound
+		}
+		pcm := &proxyClientManager{proxyClient: map[int64]types.ProxyClient{
+			TestProxyID: p1,
+		}}
+
+		err := pcm.InvalidateCollectionMetaCache(ctx, &proxypb.InvalidateCollMetaCacheRequest{})
+		assert.NoError(t, err)
+	})
+
 	t.Run("normal case", func(t *testing.T) {
 		ctx := context.Background()
 		p1 := newMockProxy()

--- a/internal/util/grpcclient/client.go
+++ b/internal/util/grpcclient/client.go
@@ -392,9 +392,9 @@ func (c *ClientBase[T]) checkGrpcErr(ctx context.Context, err error) (needRetry,
 
 func (c *ClientBase[T]) checkNodeSessionExist(ctx context.Context) (bool, error) {
 	switch c.GetRole() {
-	case typeutil.DataNodeRole, typeutil.IndexNodeRole, typeutil.QueryNodeRole:
+	case typeutil.DataNodeRole, typeutil.IndexNodeRole, typeutil.QueryNodeRole, typeutil.ProxyRole:
 		err := c.verifySession(ctx)
-		if err != nil && errors.Is(err, merr.ErrNodeNotFound) {
+		if errors.Is(err, merr.ErrNodeNotFound) {
 			log.Warn("failed to verify node session", zap.Error(err))
 			// stop retry
 			return false, err

--- a/internal/util/grpcclient/client_test.go
+++ b/internal/util/grpcclient/client_test.go
@@ -116,12 +116,21 @@ func TestClientBase_NodeSessionNotExist(t *testing.T) {
 	})
 	assert.True(t, errors.Is(err, merr.ErrNodeNotFound))
 
-	// test node already down, but new node start up with same ip and port
+	// test querynode/datanode/indexnode/proxy already down, but new node start up with same ip and port
 	base.grpcClientMtx.Lock()
 	base.grpcClient = &mockClient{}
 	base.grpcClientMtx.Unlock()
 	_, err = base.Call(ctx, func(client *mockClient) (any, error) {
 		return struct{}{}, status.Errorf(codes.Unknown, merr.ErrNodeNotMatch.Error())
+	})
+	assert.True(t, errors.Is(err, merr.ErrNodeNotFound))
+
+	// test querynode/datanode/indexnode/proxy down, return unavailable error
+	base.grpcClientMtx.Lock()
+	base.grpcClient = &mockClient{}
+	base.grpcClientMtx.Unlock()
+	_, err = base.Call(ctx, func(client *mockClient) (any, error) {
+		return struct{}{}, status.Errorf(codes.Unavailable, "fake error")
 	})
 	assert.True(t, errors.Is(err, merr.ErrNodeNotFound))
 }


### PR DESCRIPTION
pr: #28264 
/kind bug

for querynode/indexnode/datanode/proxy, there is no need to retry  when session doesn't exist.

see also #28168