### PR TITLE
[cherry-pick]Fix external grpc server doesn't graceful stop

### DIFF
--- a/internal/distributed/proxy/service.go
+++ b/internal/distributed/proxy/service.go
@@ -649,18 +649,25 @@ func (s *Server) Stop() error {
 	gracefulWg.Add(1)
 	go func() {
 		defer gracefulWg.Done()
-		if s.grpcInternalServer != nil {
-			utils.GracefulStopGRPCServer(s.grpcInternalServer)
-		}
+
 		if s.tcpServer != nil {
-			log.Info("Graceful stop Proxy tcp server...")
+			log.Info("Proxy stop tcp server...")
 			s.tcpServer.Close()
-		} else if s.grpcExternalServer != nil {
+		}
+
+		if s.grpcExternalServer != nil {
+			log.Info("Proxy stop external grpc server")
 			utils.GracefulStopGRPCServer(s.grpcExternalServer)
-			if s.httpServer != nil {
-				log.Info("Graceful stop grpc http server...")
-				s.httpServer.Close()
-			}
+		}
+
+		if s.httpServer != nil {
+			log.Info("Proxy stop http server...")
+			s.httpServer.Close()
+		}
+
+		if s.grpcInternalServer != nil {
+			log.Info("Proxy stop internal grpc server")
+			utils.GracefulStopGRPCServer(s.grpcInternalServer)
 		}
 	}()
 	gracefulWg.Wait()


### PR DESCRIPTION
issue: #28313
pr: #28309

/kind improvement

if tcpServer isn't `nil`, external grpc server won't call `GracefulStop`. then call `proxy.Stop` directly may cause some pending rpc request stuck at proxy until timeout

to fix this, close server in order:  tpcServer -> external grpc server -> http server -> internal grpc server