### PR TITLE
Fix check segment loaded logic on querynode

### DIFF
--- a/internal/querynode/impl.go
+++ b/internal/querynode/impl.go
@@ -486,8 +486,10 @@ func (node *QueryNode) LoadSegments(ctx context.Context, in *querypb.LoadSegment
 
 	alreadyLoaded := true
 	for _, info := range in.Infos {
+		// notice: segment is loaded when segment has been add to meta replica and removed from loading list
+		loading := node.metaReplica.isSegmentStillLoading(info.SegmentID)
 		has, _ := node.metaReplica.hasSegment(info.SegmentID, segmentTypeSealed)
-		if !has {
+		if loading || !has {
 			alreadyLoaded = false
 		}
 	}

--- a/internal/querynode/meta_replica_test.go
+++ b/internal/querynode/meta_replica_test.go
@@ -416,7 +416,11 @@ func TestMetaReplica_BlackList(t *testing.T) {
 	segments = replica.getGrowingSegments()
 	assert.Equal(t, 1, len(segments))
 
+	assert.True(t, replica.isSegmentStillLoading(1))
+	assert.True(t, replica.isSegmentStillLoading(2))
 	replica.removeSegmentsLoadingList([]UniqueID{1, 2, 3})
+	assert.False(t, replica.isSegmentStillLoading(1))
+	assert.False(t, replica.isSegmentStillLoading(2))
 
 	segments = replica.getSealedSegments()
 	assert.Equal(t, 2, len(segments))
@@ -432,7 +436,6 @@ func TestMetaReplica_BlackList(t *testing.T) {
 
 	segments = replica.getGrowingSegments()
 	assert.Equal(t, 1, len(segments))
-
 }
 
 func TestMetaReplica_removeCollectionVDeltaChannel(t *testing.T) {


### PR DESCRIPTION
issue: #28338

in pr #28088, we add logic to skip submit load segment task to querynode's scheulder, if segment already loaded.

but for branch 2.2 implementation, segment is loaded which has two requests:
1. segment exist in meta replica
2. segment has been removed from meta replica's loading list.