### PR TITLE
Refine datanode Timetick Sender

### DIFF
--- a/internal/datanode/data_node.go
+++ b/internal/datanode/data_node.go
@@ -355,8 +355,9 @@ func (node *DataNode) Start() error {
 		go node.compactionExecutor.start(node.ctx)
 
 		if Params.DataNodeCfg.DataNodeTimeTickByRPC.GetAsBool() {
-			node.timeTickSender = newTimeTickSender(node.broker, node.session.ServerID)
-			go node.timeTickSender.start(node.ctx)
+			node.timeTickSender = newTimeTickSender(node.broker, node.session.ServerID,
+				retry.Attempts(20), retry.Sleep(time.Millisecond*100))
+			node.timeTickSender.start()
 		}
 
 		node.stopWaiter.Add(1)
@@ -418,6 +419,10 @@ func (node *DataNode) Stop() error {
 
 		if node.session != nil {
 			node.session.Stop()
+		}
+
+		if node.timeTickSender != nil {
+			node.timeTickSender.Stop()
 		}
 
 		node.stopWaiter.Wait()

--- a/internal/datanode/event_manager_test.go
+++ b/internal/datanode/event_manager_test.go
@@ -71,6 +71,7 @@ func TestWatchChannel(t *testing.T) {
 
 	node.broker = broker
 
+	node.timeTickSender.Stop()
 	node.timeTickSender = newTimeTickSender(node.broker, 0)
 
 	t.Run("test watch channel", func(t *testing.T) {


### PR DESCRIPTION
- Use explicit lifetime control methods: `Start` and `Stop`
- Allow control retry option
- Make sure tt sender worker exit after `Stop` return