### PR TITLE
fix: Fix channel manager bg checker exit when disable auto balance

### DIFF
--- a/internal/datacoord/channel_manager.go
+++ b/internal/datacoord/channel_manager.go
@@ -262,7 +262,8 @@ func (c *ChannelManager) bgCheckChannelsWork(ctx context.Context) {
 			return
 		case <-ticker.C:
 			if !Params.DataCoordCfg.AutoBalance.GetAsBool() {
-				return
+				log.Info("auto balance disabled, skip auto bg check balance")
+				continue
 			}
 
 			c.mu.Lock()

--- a/internal/datacoord/channel_manager_test.go
+++ b/internal/datacoord/channel_manager_test.go
@@ -1239,6 +1239,7 @@ func TestChannelManager_HelperFunc(t *testing.T) {
 }
 
 func TestChannelManager_BackgroundChannelChecker(t *testing.T) {
+	Params.Save(Params.DataCoordCfg.AutoBalance.Key, "false")
 	Params.Save(Params.DataCoordCfg.ChannelBalanceInterval.Key, "1")
 	Params.Save(Params.DataCoordCfg.ChannelBalanceSilentDuration.Key, "1")
 
@@ -1279,7 +1280,6 @@ func TestChannelManager_BackgroundChannelChecker(t *testing.T) {
 	go c.bgCheckChannelsWork(ctx)
 
 	updateCounter := atomic.NewInt64(0)
-
 	mockStore.EXPECT().Update(mock.Anything).Run(func(op *ChannelOpSet) {
 		updateCounter.Inc()
 	}).Return(nil).Maybe()


### PR DESCRIPTION
issue: #28454