### PR TITLE
enhance: Use bufSize instead of row number in sync policy

### DIFF
--- a/internal/datanode/writebuffer/insert_buffer_test.go
+++ b/internal/datanode/writebuffer/insert_buffer_test.go
@@ -121,7 +121,7 @@ func (s *InsertBufferSuite) TestBasic() {
 		s.True(insertBuffer.IsEmpty())
 		s.False(insertBuffer.IsFull())
 
-		insertBuffer.rows = insertBuffer.rowLimit + 1
+		insertBuffer.size = insertBuffer.sizeLimit + 1
 		s.True(insertBuffer.IsFull())
 		s.False(insertBuffer.IsEmpty())
 	})

--- a/internal/datanode/writebuffer/sync_policy_test.go
+++ b/internal/datanode/writebuffer/sync_policy_test.go
@@ -42,7 +42,7 @@ func (s *SyncPolicySuite) TestSyncFullBuffer() {
 	ids := SyncFullBuffer([]*segmentBuffer{buffer}, 0)
 	s.Equal(0, len(ids), "empty buffer shall not be synced")
 
-	buffer.insertBuffer.rows = buffer.insertBuffer.rowLimit + 1
+	buffer.insertBuffer.size = buffer.insertBuffer.sizeLimit + 1
 
 	ids = SyncFullBuffer([]*segmentBuffer{buffer}, 0)
 	s.ElementsMatch([]int64{100}, ids)


### PR DESCRIPTION
See also #27675, comment from #27874

This PR changes the `IsFull` logic of insert buffer
Changing the limit from rowNum to buffer size,
this shall help form better binlog file when schema has variable-length field