### PR TITLE
fix: clean snapshots meta

### DIFF
--- a/internal/rootcoord/meta_table.go
+++ b/internal/rootcoord/meta_table.go
@@ -456,7 +456,13 @@ func (mt *MetaTable) RemoveCollection(ctx context.Context, collectionID UniqueID
 
 	ctx1 := contextutil.WithTenantID(ctx, Params.CommonCfg.ClusterName.GetValue())
 	aliases := mt.listAliasesByID(collectionID)
-	newColl := &model.Collection{CollectionID: collectionID, Aliases: aliases, DBID: coll.DBID}
+	newColl := &model.Collection{
+		CollectionID: collectionID,
+		Partitions:   model.ClonePartitions(coll.Partitions),
+		Fields:       model.CloneFields(coll.Fields),
+		Aliases:      aliases,
+		DBID:         coll.DBID,
+	}
 	if err := mt.catalog.DropCollection(ctx1, newColl, ts); err != nil {
 		return err
 	}


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/28496
/kind bug

The input parameters collection.partitions and collection.Field are both nil, so these two metas have not been cleared.

Signed-off-by: xige-16 <xi.ge@zilliz.com>