### PR TITLE
fix: Fix minio latency monitoring for get operation

### DIFF
--- a/internal/storage/minio_chunk_manager.go
+++ b/internal/storage/minio_chunk_manager.go
@@ -166,6 +166,7 @@ func (mcm *MinioChunkManager) Exist(ctx context.Context, filePath string) (bool,
 
 // Read reads the minio storage data if exists.
 func (mcm *MinioChunkManager) Read(ctx context.Context, filePath string) ([]byte, error) {
+	start := time.Now()
 	object, err := mcm.getMinioObject(ctx, mcm.bucketName, filePath, minio.GetObjectOptions{})
 	if err != nil {
 		log.Warn("failed to get object", zap.String("bucket", mcm.bucketName), zap.String("path", filePath), zap.Error(err))
@@ -196,6 +197,7 @@ func (mcm *MinioChunkManager) Read(ctx context.Context, filePath string) ([]byte
 		return nil, err
 	}
 	metrics.PersistentDataKvSize.WithLabelValues(metrics.DataGetLabel).Observe(float64(objectInfo.Size))
+	metrics.PersistentDataRequestLatency.WithLabelValues(metrics.DataGetLabel).Observe(float64(time.Since(start).Milliseconds()))
 	return data, nil
 }
 
@@ -236,6 +238,7 @@ func (mcm *MinioChunkManager) ReadAt(ctx context.Context, filePath string, off i
 		return nil, io.EOF
 	}
 
+	start := time.Now()
 	opts := minio.GetObjectOptions{}
 	err := opts.SetRange(off, off+length-1)
 	if err != nil {
@@ -257,6 +260,7 @@ func (mcm *MinioChunkManager) ReadAt(ctx context.Context, filePath string, off i
 		return nil, err
 	}
 	metrics.PersistentDataKvSize.WithLabelValues(metrics.DataGetLabel).Observe(float64(length))
+	metrics.PersistentDataRequestLatency.WithLabelValues(metrics.DataGetLabel).Observe(float64(time.Since(start).Milliseconds()))
 	return data, nil
 }
 

--- a/internal/storage/remote_chunk_manager.go
+++ b/internal/storage/remote_chunk_manager.go
@@ -315,13 +315,9 @@ func (mcm *RemoteChunkManager) ListWithPrefix(ctx context.Context, prefix string
 func (mcm *RemoteChunkManager) getObject(ctx context.Context, bucketName, objectName string,
 	offset int64, size int64,
 ) (FileReader, error) {
-	start := timerecord.NewTimeRecorder("getObject")
-
 	reader, err := mcm.client.GetObject(ctx, bucketName, objectName, offset, size)
 	metrics.PersistentDataOpCounter.WithLabelValues(metrics.DataGetLabel, metrics.TotalLabel).Inc()
 	if err == nil && reader != nil {
-		metrics.PersistentDataRequestLatency.WithLabelValues(metrics.DataGetLabel).
-			Observe(float64(start.ElapseSpan().Milliseconds()))
 		metrics.PersistentDataOpCounter.WithLabelValues(metrics.DataGetLabel, metrics.SuccessLabel).Inc()
 	} else {
 		metrics.PersistentDataOpCounter.WithLabelValues(metrics.DataGetLabel, metrics.FailLabel).Inc()


### PR DESCRIPTION
see also: https://github.com/milvus-io/milvus/issues/28509

Currently Minio latency monitoring for get operation only collects the duration of getting object (which just returns an io.Reader and does not really read from minio), this pr will correct this behavior.