### PR TITLE
fix: Make `ErrServiceRequestLimitExceeded` not retriable

### DIFF
--- a/pkg/util/merr/errors.go
+++ b/pkg/util/merr/errors.go
@@ -35,7 +35,7 @@ var (
 	ErrServiceNotReady             = newMilvusError("service not ready", 1, true) // This indicates the service is still in init
 	ErrServiceUnavailable          = newMilvusError("service unavailable", 2, true)
 	ErrServiceMemoryLimitExceeded  = newMilvusError("memory limit exceeded", 3, false)
-	ErrServiceRequestLimitExceeded = newMilvusError("request limit exceeded", 4, true)
+	ErrServiceRequestLimitExceeded = newMilvusError("request limit exceeded", 4, false)
 	ErrServiceInternal             = newMilvusError("service internal error", 5, false) // Never return this error out of Milvus
 	ErrServiceCrossClusterRouting  = newMilvusError("cross cluster routing", 6, false)
 	ErrServiceDiskLimitExceeded    = newMilvusError("disk limit exceeded", 7, false)


### PR DESCRIPTION
See also #28516
Now grpcclient will retry when ErrServiceRequestLimitExceeded returned 
This is not the expected behavior for segment load task execution