### PR TITLE
enhance: Remove timeout in load path and add more logs

### DIFF
--- a/internal/querycoordv2/balance/utils.go
+++ b/internal/querycoordv2/balance/utils.go
@@ -19,8 +19,6 @@ package balance
 import (
 	"context"
 	"fmt"
-	"time"
-
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/internal/proto/querypb"
@@ -34,7 +32,7 @@ const (
 	DistInfoPrefix = "Balance-Dists:"
 )
 
-func CreateSegmentTasksFromPlans(ctx context.Context, source task.Source, timeout time.Duration, plans []SegmentAssignPlan) []task.Task {
+func CreateSegmentTasksFromPlans(ctx context.Context, source task.Source, plans []SegmentAssignPlan) []task.Task {
 	ret := make([]task.Task, 0)
 	for _, p := range plans {
 		actions := make([]task.Action, 0)
@@ -48,7 +46,6 @@ func CreateSegmentTasksFromPlans(ctx context.Context, source task.Source, timeou
 		}
 		t, err := task.NewSegmentTask(
 			ctx,
-			timeout,
 			source,
 			p.Segment.GetCollectionID(),
 			p.ReplicaID,
@@ -86,7 +83,7 @@ func CreateSegmentTasksFromPlans(ctx context.Context, source task.Source, timeou
 	return ret
 }
 
-func CreateChannelTasksFromPlans(ctx context.Context, source task.Source, timeout time.Duration, plans []ChannelAssignPlan) []task.Task {
+func CreateChannelTasksFromPlans(ctx context.Context, source task.Source, plans []ChannelAssignPlan) []task.Task {
 	ret := make([]task.Task, 0, len(plans))
 	for _, p := range plans {
 		actions := make([]task.Action, 0)
@@ -98,7 +95,7 @@ func CreateChannelTasksFromPlans(ctx context.Context, source task.Source, timeou
 			action := task.NewChannelAction(p.From, task.ActionTypeReduce, p.Channel.GetChannelName())
 			actions = append(actions, action)
 		}
-		t, err := task.NewChannelTask(ctx, timeout, source, p.Channel.GetCollectionID(), p.ReplicaID, actions...)
+		t, err := task.NewChannelTask(ctx, source, p.Channel.GetCollectionID(), p.ReplicaID, actions...)
 		if err != nil {
 			log.Warn("create channel task failed",
 				zap.Int64("collection", p.Channel.GetCollectionID()),

--- a/internal/querycoordv2/checkers/balance_checker.go
+++ b/internal/querycoordv2/checkers/balance_checker.go
@@ -19,10 +19,6 @@ package checkers
 import (
 	"context"
 	"sort"
-	"time"
-
-	"github.com/samber/lo"
-	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/internal/proto/querypb"
 	"github.com/milvus-io/milvus/internal/querycoordv2/balance"
@@ -32,6 +28,8 @@ import (
 	"github.com/milvus-io/milvus/internal/querycoordv2/task"
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
+	"github.com/samber/lo"
+	"go.uber.org/zap"
 )
 
 // BalanceChecker checks the cluster distribution and generates balance tasks.
@@ -149,12 +147,12 @@ func (b *BalanceChecker) Check(ctx context.Context) []task.Task {
 	replicasToBalance := b.replicasToBalance()
 	segmentPlans, channelPlans := b.balanceReplicas(replicasToBalance)
 
-	tasks := balance.CreateSegmentTasksFromPlans(ctx, b.ID(), Params.QueryCoordCfg.SegmentTaskTimeout.GetAsDuration(time.Millisecond), segmentPlans)
+	tasks := balance.CreateSegmentTasksFromPlans(ctx, b.ID(), segmentPlans)
 	task.SetPriority(task.TaskPriorityLow, tasks...)
 	task.SetReason("segment unbalanced", tasks...)
 	ret = append(ret, tasks...)
 
-	tasks = balance.CreateChannelTasksFromPlans(ctx, b.ID(), Params.QueryCoordCfg.ChannelTaskTimeout.GetAsDuration(time.Millisecond), channelPlans)
+	tasks = balance.CreateChannelTasksFromPlans(ctx, b.ID(), channelPlans)
 	task.SetReason("channel unbalanced", tasks...)
 	ret = append(ret, tasks...)
 	return ret

--- a/internal/querycoordv2/checkers/channel_checker.go
+++ b/internal/querycoordv2/checkers/channel_checker.go
@@ -18,18 +18,16 @@ package checkers
 
 import (
 	"context"
-	"time"
 
-	"github.com/samber/lo"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/internal/querycoordv2/balance"
 	"github.com/milvus-io/milvus/internal/querycoordv2/meta"
-	. "github.com/milvus-io/milvus/internal/querycoordv2/params"
 	"github.com/milvus-io/milvus/internal/querycoordv2/task"
 	"github.com/milvus-io/milvus/internal/querycoordv2/utils"
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
+	"github.com/samber/lo"
 )
 
 // TODO(sunby): have too much similar codes with SegmentChecker
@@ -195,14 +193,14 @@ func (c *ChannelChecker) createChannelLoadTask(ctx context.Context, channels []*
 		plans[i].ReplicaID = replica.GetID()
 	}
 
-	return balance.CreateChannelTasksFromPlans(ctx, c.ID(), Params.QueryCoordCfg.ChannelTaskTimeout.GetAsDuration(time.Millisecond), plans)
+	return balance.CreateChannelTasksFromPlans(ctx, c.ID(), plans)
 }
 
 func (c *ChannelChecker) createChannelReduceTasks(ctx context.Context, channels []*meta.DmChannel, replicaID int64) []task.Task {
 	ret := make([]task.Task, 0, len(channels))
 	for _, ch := range channels {
 		action := task.NewChannelAction(ch.Node, task.ActionTypeReduce, ch.GetChannelName())
-		task, err := task.NewChannelTask(ctx, Params.QueryCoordCfg.ChannelTaskTimeout.GetAsDuration(time.Millisecond), c.ID(), ch.GetCollectionID(), replicaID, action)
+		task, err := task.NewChannelTask(ctx, c.ID(), ch.GetCollectionID(), replicaID, action)
 		if err != nil {
 			log.Warn("create channel reduce task failed",
 				zap.Int64("collection", ch.GetCollectionID()),

--- a/internal/querycoordv2/checkers/index_checker.go
+++ b/internal/querycoordv2/checkers/index_checker.go
@@ -18,18 +18,16 @@ package checkers
 
 import (
 	"context"
-	"time"
 
-	"github.com/samber/lo"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/internal/proto/querypb"
 	"github.com/milvus-io/milvus/internal/querycoordv2/meta"
-	"github.com/milvus-io/milvus/internal/querycoordv2/params"
 	"github.com/milvus-io/milvus/internal/querycoordv2/session"
 	"github.com/milvus-io/milvus/internal/querycoordv2/task"
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
+	"github.com/samber/lo"
 )
 
 var _ Checker = (*IndexChecker)(nil)
@@ -156,7 +154,6 @@ func (c *IndexChecker) createSegmentUpdateTask(ctx context.Context, segment *met
 	action := task.NewSegmentActionWithScope(segment.Node, task.ActionTypeUpdate, segment.GetInsertChannel(), segment.GetID(), querypb.DataScope_Historical)
 	t, err := task.NewSegmentTask(
 		ctx,
-		params.Params.QueryCoordCfg.SegmentTaskTimeout.GetAsDuration(time.Millisecond),
 		c.ID(),
 		segment.GetCollectionID(),
 		replica.GetID(),

--- a/internal/querycoordv2/checkers/segment_checker.go
+++ b/internal/querycoordv2/checkers/segment_checker.go
@@ -19,20 +19,18 @@ package checkers
 import (
 	"context"
 	"sort"
-	"time"
 
-	"github.com/samber/lo"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/internal/proto/datapb"
 	"github.com/milvus-io/milvus/internal/proto/querypb"
 	"github.com/milvus-io/milvus/internal/querycoordv2/balance"
 	"github.com/milvus-io/milvus/internal/querycoordv2/meta"
-	. "github.com/milvus-io/milvus/internal/querycoordv2/params"
 	"github.com/milvus-io/milvus/internal/querycoordv2/session"
 	"github.com/milvus-io/milvus/internal/querycoordv2/task"
 	"github.com/milvus-io/milvus/internal/querycoordv2/utils"
 	"github.com/milvus-io/milvus/pkg/log"
+	"github.com/samber/lo"
 )
 
 type SegmentChecker struct {
@@ -376,7 +374,7 @@ func (c *SegmentChecker) createSegmentLoadTasks(ctx context.Context, segments []
 		plans = append(plans, shardPlans...)
 	}
 
-	return balance.CreateSegmentTasksFromPlans(ctx, c.ID(), Params.QueryCoordCfg.SegmentTaskTimeout.GetAsDuration(time.Millisecond), plans)
+	return balance.CreateSegmentTasksFromPlans(ctx, c.ID(), plans)
 }
 
 func (c *SegmentChecker) createSegmentReduceTasks(ctx context.Context, segments []*meta.Segment, replicaID int64, scope querypb.DataScope) []task.Task {
@@ -385,7 +383,6 @@ func (c *SegmentChecker) createSegmentReduceTasks(ctx context.Context, segments 
 		action := task.NewSegmentActionWithScope(s.Node, task.ActionTypeReduce, s.GetInsertChannel(), s.GetID(), scope)
 		task, err := task.NewSegmentTask(
 			ctx,
-			Params.QueryCoordCfg.SegmentTaskTimeout.GetAsDuration(time.Millisecond),
 			c.ID(),
 			s.GetCollectionID(),
 			replicaID,

--- a/internal/querycoordv2/handlers.go
+++ b/internal/querycoordv2/handlers.go
@@ -141,7 +141,6 @@ func (s *Server) balanceSegments(ctx context.Context, req *querypb.LoadBalanceRe
 			zap.Int64("segmentID", plan.Segment.GetID()),
 		)
 		task, err := task.NewSegmentTask(ctx,
-			Params.QueryCoordCfg.SegmentTaskTimeout.GetAsDuration(time.Millisecond),
 			task.WrapIDSource(req.GetBase().GetMsgID()),
 			req.GetCollectionID(),
 			replica.GetID(),
@@ -166,7 +165,7 @@ func (s *Server) balanceSegments(ctx context.Context, req *querypb.LoadBalanceRe
 		}
 		tasks = append(tasks, task)
 	}
-	return task.Wait(ctx, Params.QueryCoordCfg.SegmentTaskTimeout.GetAsDuration(time.Millisecond), tasks...)
+	return task.BlockWait(ctx, tasks...)
 }
 
 // TODO(dragondriver): add more detail metrics

--- a/internal/querycoordv2/observers/leader_observer.go
+++ b/internal/querycoordv2/observers/leader_observer.go
@@ -30,7 +30,6 @@ import (
 	"github.com/milvus-io/milvus/internal/querycoordv2/utils"
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/util/commonpbutil"
-	"github.com/milvus-io/milvus/pkg/util/paramtable"
 )
 
 const (
@@ -243,7 +242,7 @@ func (o *LeaderObserver) sync(ctx context.Context, replicaID int64, leaderView *
 		},
 		Version: time.Now().UnixNano(),
 	}
-	ctx, cancel := context.WithTimeout(ctx, paramtable.Get().QueryCoordCfg.SegmentTaskTimeout.GetAsDuration(time.Millisecond))
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	resp, err := o.cluster.SyncDistribution(ctx, leaderView.ID, req)
 	if err != nil {

--- a/internal/querycoordv2/observers/target_observer.go
+++ b/internal/querycoordv2/observers/target_observer.go
@@ -32,7 +32,6 @@ import (
 	"github.com/milvus-io/milvus/internal/querycoordv2/utils"
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/util/commonpbutil"
-	"github.com/milvus-io/milvus/pkg/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
 
@@ -368,7 +367,7 @@ func (ob *TargetObserver) sync(ctx context.Context, replicaID int64, leaderView 
 		},
 		Version: time.Now().UnixNano(),
 	}
-	ctx, cancel := context.WithTimeout(ctx, paramtable.Get().QueryCoordCfg.SegmentTaskTimeout.GetAsDuration(time.Millisecond))
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	resp, err := ob.cluster.SyncDistribution(ctx, leaderView.ID, req)
 	if err != nil {

--- a/internal/querycoordv2/task/merger_test.go
+++ b/internal/querycoordv2/task/merger_test.go
@@ -122,7 +122,7 @@ func (suite *MergerSuite) TestMerge() {
 	ctx := context.Background()
 
 	for segmentID := int64(1); segmentID <= 3; segmentID++ {
-		task, err := NewSegmentTask(ctx, timeout, WrapIDSource(0), suite.collectionID, suite.replicaID,
+		task, err := NewSegmentTask(ctx, WrapIDSource(0), suite.collectionID, suite.replicaID,
 			NewSegmentAction(suite.nodeID, ActionTypeGrow, "", segmentID))
 		suite.NoError(err)
 		suite.merger.Add(NewLoadSegmentsTask(task, 0, suite.requests[segmentID]))

--- a/internal/querycoordv2/task/scheduler.go
+++ b/internal/querycoordv2/task/scheduler.go
@@ -702,6 +702,7 @@ func (scheduler *taskScheduler) remove(task Task) {
 		zap.Int64("replicaID", task.ReplicaID()),
 		zap.String("status", task.Status()),
 	)
+	log.Info("start to remove task")
 	task.Cancel(nil)
 	scheduler.tasks.Remove(task.ID())
 	scheduler.waitQueue.Remove(task)
@@ -725,7 +726,7 @@ func (scheduler *taskScheduler) remove(task Task) {
 	}
 
 	scheduler.updateTaskMetrics()
-	log.Info("task removed")
+	log.Info("successfully remove task")
 }
 
 func (scheduler *taskScheduler) checkStale(task Task) error {

--- a/internal/querycoordv2/task/task.go
+++ b/internal/querycoordv2/task/task.go
@@ -19,13 +19,12 @@ package task
 import (
 	"context"
 	"fmt"
-	"time"
 
-	"github.com/cockroachdb/errors"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/atomic"
 
+	"github.com/cockroachdb/errors"
 	"github.com/milvus-io/milvus/internal/proto/querypb"
 	"github.com/milvus-io/milvus/internal/querycoordv2/meta"
 	"github.com/milvus-io/milvus/pkg/util/merr"
@@ -285,7 +284,6 @@ type SegmentTask struct {
 // all actions must process the same segment,
 // empty actions is not allowed
 func NewSegmentTask(ctx context.Context,
-	timeout time.Duration,
 	source Source,
 	collectionID,
 	replicaID UniqueID,
@@ -342,7 +340,6 @@ type ChannelTask struct {
 // all actions must process the same channel, and the same type of channel
 // empty actions is not allowed
 func NewChannelTask(ctx context.Context,
-	timeout time.Duration,
 	source Source,
 	collectionID,
 	replicaID UniqueID,

--- a/internal/querycoordv2/task/utils_test.go
+++ b/internal/querycoordv2/task/utils_test.go
@@ -19,9 +19,6 @@ package task
 import (
 	"context"
 	"testing"
-	"time"
-
-	"github.com/stretchr/testify/suite"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
@@ -29,6 +26,7 @@ import (
 	"github.com/milvus-io/milvus/internal/proto/indexpb"
 	"github.com/milvus-io/milvus/internal/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/common"
+	"github.com/stretchr/testify/suite"
 )
 
 type UtilsSuite struct {
@@ -92,7 +90,6 @@ func (s *UtilsSuite) TestPackLoadSegmentRequest() {
 	action := NewSegmentAction(1, ActionTypeGrow, "test-ch", 100)
 	task, err := NewSegmentTask(
 		ctx,
-		time.Second,
 		nil,
 		1,
 		10,
@@ -145,7 +142,6 @@ func (s *UtilsSuite) TestPackLoadSegmentRequestMmap() {
 	action := NewSegmentAction(1, ActionTypeGrow, "test-ch", 100)
 	task, err := NewSegmentTask(
 		ctx,
-		time.Second,
 		nil,
 		1,
 		10,

--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -429,7 +429,7 @@ func (sd *shardDelegator) LoadSegments(ctx context.Context, req *querypb.LoadSeg
 		log.Warn("worker failed to load segments", zap.Error(err))
 		return err
 	}
-	log.Debug("work loads segments done")
+	log.Info("worker loads segments done")
 
 	// load index and L0 segment need no stream delete and distribution change
 	if req.GetLoadScope() == querypb.LoadScope_Index ||

--- a/internal/querynodev2/local_worker.go
+++ b/internal/querynodev2/local_worker.go
@@ -19,6 +19,7 @@ package querynodev2
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/samber/lo"
 	"go.uber.org/zap"
@@ -52,6 +53,7 @@ func (w *LocalWorker) LoadSegments(ctx context.Context, req *querypb.LoadSegment
 		})),
 		zap.String("loadScope", req.GetLoadScope().String()),
 	)
+	startTs := time.Now()
 	log.Info("start to load segments...")
 	loaded, err := w.node.loader.Load(ctx,
 		req.GetCollectionID(),
@@ -65,7 +67,7 @@ func (w *LocalWorker) LoadSegments(ctx context.Context, req *querypb.LoadSegment
 
 	w.node.manager.Collection.Ref(req.GetCollectionID(), uint32(len(loaded)))
 
-	log.Info("load segments done...",
+	log.Info("load segments done...", zap.Duration("time spent", time.Since(startTs)),
 		zap.Int64s("segments", lo.Map(loaded, func(s segments.Segment, _ int) int64 { return s.ID() })))
 	return err
 }

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -1200,8 +1200,6 @@ type queryCoordConfig struct {
 	ChannelCheckInterval       ParamItem `refreshable:"true"`
 	BalanceCheckInterval       ParamItem `refreshable:"true"`
 	IndexCheckInterval         ParamItem `refreshable:"true"`
-	ChannelTaskTimeout         ParamItem `refreshable:"true"`
-	SegmentTaskTimeout         ParamItem `refreshable:"true"`
 	DistPullInterval           ParamItem `refreshable:"false"`
 	HeartbeatAvailableInterval ParamItem `refreshable:"true"`
 	LoadTimeoutSeconds         ParamItem `refreshable:"true"`
@@ -1390,27 +1388,6 @@ func (p *queryCoordConfig) init(base *BaseTable) {
 		Export:       true,
 	}
 	p.IndexCheckInterval.Init(base.mgr)
-
-	p.ChannelTaskTimeout = ParamItem{
-		Key:          "queryCoord.channelTaskTimeout",
-		Version:      "2.0.0",
-		DefaultValue: "60000",
-		PanicIfEmpty: true,
-		Doc:          "1 minute",
-		Export:       true,
-	}
-	p.ChannelTaskTimeout.Init(base.mgr)
-
-	p.SegmentTaskTimeout = ParamItem{
-		Key:          "queryCoord.segmentTaskTimeout",
-		Version:      "2.0.0",
-		DefaultValue: "120000",
-		PanicIfEmpty: true,
-		Doc:          "2 minute",
-		Export:       true,
-	}
-	p.SegmentTaskTimeout.Init(base.mgr)
-
 	p.DistPullInterval = ParamItem{
 		Key:          "queryCoord.distPullInterval",
 		Version:      "2.0.0",


### PR DESCRIPTION
fix #28536

1. Add more logs in load path
2. Remove timeout configs in load segment, sync and load channel, task will still be canceled if node dead.