### PR TITLE
enhance: Reduce the goroutine in flowgraph to 2 (#28233)

### DIFF
--- a/internal/datanode/data_sync_service.go
+++ b/internal/datanode/data_sync_service.go
@@ -81,7 +81,7 @@ type nodeConfig struct {
 	serverID     UniqueID
 }
 
-// start the flow graph in datasyncservice
+// start the flow graph in dataSyncService
 func (dsService *dataSyncService) start() {
 	if dsService.fg != nil {
 		log.Info("dataSyncService starting flow graph", zap.Int64("collectionID", dsService.collectionID),

--- a/internal/datanode/event_manager.go
+++ b/internal/datanode/event_manager.go
@@ -84,7 +84,7 @@ func (node *DataNode) StartWatchChannels(ctx context.Context) {
 	}
 }
 
-// checkWatchedList list all nodes under [prefix]/channel/{node_id} and make sure all nodeds are watched
+// checkWatchedList list all nodes under [prefix]/channel/{node_id} and make sure all nodes are watched
 // serves the corner case for etcd connection lost and missing some events
 func (node *DataNode) checkWatchedList() error {
 	// REF MEP#7 watch path should be [prefix]/channel/{node_id}/{channel_name}

--- a/internal/datanode/flow_graph_dd_node.go
+++ b/internal/datanode/flow_graph_dd_node.go
@@ -276,7 +276,9 @@ func (ddn *ddNode) isDropped(segID UniqueID) bool {
 	return false
 }
 
-func (ddn *ddNode) Close() {}
+func (ddn *ddNode) Close() {
+	log.Info("Flowgraph DD Node closing")
+}
 
 func newDDNode(ctx context.Context, collID UniqueID, vChannelName string, droppedSegmentIDs []UniqueID,
 	sealedSegments []*datapb.SegmentInfo, growingSegments []*datapb.SegmentInfo, compactor *compactionExecutor,

--- a/internal/util/flowgraph/flow_graph_test.go
+++ b/internal/util/flowgraph/flow_graph_test.go
@@ -35,7 +35,7 @@ import (
 // nodeD: count c = b + 2
 
 type nodeA struct {
-	BaseNode
+	InputNode
 	inputChan chan float64
 	a         float64
 }
@@ -47,7 +47,7 @@ type nodeB struct {
 
 type nodeC struct {
 	BaseNode
-	d          float64
+	c          float64
 	outputChan chan float64
 }
 
@@ -117,8 +117,10 @@ func createExampleFlowGraph() (*TimeTickedFlowGraph, chan float64, chan float64,
 	fg := NewTimeTickedFlowGraph(ctx)
 
 	var a Node = &nodeA{
-		BaseNode: BaseNode{
-			maxQueueLength: MaxQueueLength,
+		InputNode: InputNode{
+			BaseNode: BaseNode{
+				maxQueueLength: MaxQueueLength,
+			},
 		},
 		inputChan: inputChan,
 	}
@@ -175,8 +177,10 @@ func TestTimeTickedFlowGraph_AddNode(t *testing.T) {
 	fg := NewTimeTickedFlowGraph(context.TODO())
 
 	var a Node = &nodeA{
-		BaseNode: BaseNode{
-			maxQueueLength: MaxQueueLength,
+		InputNode: InputNode{
+			BaseNode: BaseNode{
+				maxQueueLength: MaxQueueLength,
+			},
 		},
 		inputChan: inputChan,
 	}

--- a/internal/util/flowgraph/input_node.go
+++ b/internal/util/flowgraph/input_node.go
@@ -19,7 +19,6 @@ package flowgraph
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
@@ -49,7 +48,6 @@ type InputNode struct {
 	collectionID int64
 	dataType     string
 
-	closeOnce       sync.Once
 	closeGracefully *atomic.Bool
 }
 

--- a/internal/util/flowgraph/node_test.go
+++ b/internal/util/flowgraph/node_test.go
@@ -56,7 +56,7 @@ func generateMsgPack() msgstream.MsgPack {
 	return msgPack
 }
 
-func TestNodeCtx_Start(t *testing.T) {
+func TestNodeManager_Start(t *testing.T) {
 	t.Setenv("ROCKSMQ_PATH", "/tmp/MilvusTest/FlowGraph/TestNodeStart")
 	factory := dependency.NewDefaultFactory(true)
 
@@ -76,19 +76,30 @@ func TestNodeCtx_Start(t *testing.T) {
 	nodeName := "input_node"
 	inputNode := NewInputNode(msgStream.Chan(), nodeName, 100, 100, "", 0, 0, "")
 
-	node := &nodeCtx{
-		node:    inputNode,
-		closeCh: make(chan struct{}),
-		closeWg: &sync.WaitGroup{},
+	ddNode := BaseNode{}
+
+	node0 := &nodeCtx{
+		node: inputNode,
 	}
 
-	node.inputChannel = make(chan []Msg)
+	node1 := &nodeCtx{
+		node: &ddNode,
+	}
+
+	node0.downstream = node1
+
+	node0.inputChannel = make(chan []Msg)
+
+	nodeCtxManager := &nodeCtxManager{
+		inputNodeCtx: node0,
+		closeWg:      &sync.WaitGroup{},
+	}
 
 	assert.NotPanics(t, func() {
-		node.Start()
+		nodeCtxManager.Start()
 	})
 
-	node.Close()
+	nodeCtxManager.Close()
 }
 
 func TestBaseNode(t *testing.T) {


### PR DESCRIPTION
each node in flow graph alloc a goroutine, but it is actually executed sequentially and can be placed in one goroutine. InputNode will consume msg form msgstream, alloc one goroutine.
issue: #24826 
pr: #28233 