### PR TITLE
enhance: Use single instance for mergedTimeTickerSender (#27730)

### DIFF
--- a/internal/datanode/flow_graph_insert_buffer_node.go
+++ b/internal/datanode/flow_graph_insert_buffer_node.go
@@ -743,7 +743,7 @@ func newInsertBufferNode(
 	wTtMsgStream := wTt
 	wTtMsgStream.EnableProduce(true)
 
-	mt := newMergedTimeTickerSender(func(ts Timestamp, segmentIDs []int64) error {
+	mt := getOrCreateMergedTimeTickerSender(func(ts Timestamp, segmentIDs []int64) error {
 		stats := make([]*commonpb.SegmentStats, 0, len(segmentIDs))
 		for _, sid := range segmentIDs {
 			stat, err := config.channel.getSegmentStatisticsUpdates(sid)


### PR DESCRIPTION
use single instance for mergedTimeTickerSender
issue: https://github.com/milvus-io/milvus/issues/24826
pr: https://github.com/milvus-io/milvus/pull/27730