### PR TITLE
enhance: Refine collection observer update LoadStatus logic

### DIFF
--- a/internal/querycoordv2/observers/collection_observer.go
+++ b/internal/querycoordv2/observers/collection_observer.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/samber/lo"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/internal/proto/querypb"
@@ -31,7 +32,6 @@ import (
 	"github.com/milvus-io/milvus/internal/querycoordv2/utils"
 	"github.com/milvus-io/milvus/pkg/eventlog"
 	"github.com/milvus-io/milvus/pkg/log"
-	"github.com/samber/lo"
 )
 
 type CollectionObserver struct {

--- a/internal/querycoordv2/observers/collection_observer_test.go
+++ b/internal/querycoordv2/observers/collection_observer_test.go
@@ -262,7 +262,7 @@ func (suite *CollectionObserverSuite) TestObserve() {
 	suite.True(ok)
 	view2 := &meta.LeaderView{
 		ID:           3,
-		CollectionID: 13,
+		CollectionID: 103,
 		Channel:      "103-dmc0",
 		Segments:     make(map[int64]*querypb.SegmentDist),
 	}


### PR DESCRIPTION
See also #28536

This PR:
- Separate `UpdateLoadPercentage` & `UpdateLoadStatus` methods
- Refine collection observer log
  - Use rated log when there is no percentage update
  - Use rated log for check target failed
- Refactor the load percentage & load status logic in `observePartitionLoadStatus`