### PR TITLE
fix: Add length check for `storage.NewPrimaryKeyStats`

### DIFF
--- a/internal/datanode/compactor.go
+++ b/internal/datanode/compactor.go
@@ -356,7 +356,10 @@ func (t *compactionTask) merge(
 		return nil, nil, 0, err
 	}
 
-	stats := storage.NewPrimaryKeyStats(pkID, int64(pkType), oldRowNums)
+	stats, err := storage.NewPrimaryKeyStats(pkID, int64(pkType), oldRowNums)
+	if err != nil {
+		return nil, nil, 0, err
+	}
 	// initial timestampFrom, timestampTo = -1, -1 is an illegal value, only to mark initial state
 	var (
 		timestampTo   int64 = -1

--- a/internal/datanode/mock_test.go
+++ b/internal/datanode/mock_test.go
@@ -1117,7 +1117,8 @@ func genTestStat(meta *etcdpb.CollectionMeta) *storage.PrimaryKeyStats {
 			pkFieldType = int64(field.DataType)
 		}
 	}
-	return storage.NewPrimaryKeyStats(pkFieldID, pkFieldType, 0)
+	stats, _ := storage.NewPrimaryKeyStats(pkFieldID, pkFieldType, 100)
+	return stats
 }
 
 func genInsertData() *InsertData {

--- a/internal/storage/stats.go
+++ b/internal/storage/stats.go
@@ -190,12 +190,15 @@ func (stats *PrimaryKeyStats) UpdateMinMax(pk PrimaryKey) {
 	}
 }
 
-func NewPrimaryKeyStats(fieldID, pkType, rowNum int64) *PrimaryKeyStats {
+func NewPrimaryKeyStats(fieldID, pkType, rowNum int64) (*PrimaryKeyStats, error) {
+	if rowNum <= 0 {
+		return nil, merr.WrapErrParameterInvalidMsg("non zero & non negative row num", rowNum)
+	}
 	return &PrimaryKeyStats{
 		FieldID: fieldID,
 		PkType:  pkType,
 		BF:      bloom.NewWithEstimates(uint(rowNum), MaxBloomFalsePositive),
-	}
+	}, nil
 }
 
 // StatsWriter writes stats to buffer


### PR DESCRIPTION
See also #28575
Add zero-length check for `storage.NewPrimaryKeyStats`. This function shall return error when non-positive rowNum passed.