### PR TITLE
fix: panic if minio port is empty

### DIFF
--- a/pkg/util/paramtable/service_param.go
+++ b/pkg/util/paramtable/service_param.go
@@ -954,6 +954,7 @@ func (p *MinioConfig) Init(base *BaseTable) {
 		DefaultValue: "9000",
 		Version:      "2.0.0",
 		Doc:          "Port of MinIO/S3",
+		PanicIfEmpty: true,
 		Export:       true,
 	}
 	p.Port.Init(base.mgr)


### PR DESCRIPTION
#28460 
pr: https://github.com/milvus-io/milvus/pull/28461