### PR TITLE
fix: Add IndexList check for load segment request

### DIFF
--- a/internal/querynodev2/services.go
+++ b/internal/querynodev2/services.go
@@ -446,6 +446,12 @@ func (node *QueryNode) LoadSegments(ctx context.Context, req *querypb.LoadSegmen
 		return merr.Status(err), nil
 	}
 
+	// check index
+	if len(req.GetIndexInfoList()) == 0 {
+		err := merr.WrapErrIndexNotFoundForCollection(req.GetSchema().GetName())
+		return merr.Status(err), nil
+	}
+
 	// Delegates request to workers
 	if req.GetNeedTransfer() {
 		delegator, ok := node.delegators.Get(segment.GetInsertChannel())

--- a/internal/querynodev2/services_test.go
+++ b/internal/querynodev2/services_test.go
@@ -840,7 +840,6 @@ func (suite *ServiceSuite) TestLoadSegments_Failed() {
 	status, err = suite.node.LoadSegments(ctx, req)
 	suite.NoError(err)
 	suite.ErrorIs(merr.Error(status), merr.ErrServiceNotReady)
-
 }
 
 func (suite *ServiceSuite) TestLoadSegments_Transfer() {

--- a/internal/querynodev2/services_test.go
+++ b/internal/querynodev2/services_test.go
@@ -606,6 +606,7 @@ func (suite *ServiceSuite) TestLoadSegments_VarChar() {
 			DeltaPositions: []*msgpb.MsgPosition{{Timestamp: 20000}},
 			NeedTransfer:   true,
 			LoadMeta:       loadMeta,
+			IndexInfoList:  []*indexpb.IndexInfo{{}},
 		}
 
 		// LoadSegment
@@ -625,12 +626,13 @@ func (suite *ServiceSuite) TestLoadDeltaInt64() {
 			MsgID:    rand.Int63(),
 			TargetID: suite.node.session.ServerID,
 		},
-		CollectionID: suite.collectionID,
-		DstNodeID:    suite.node.session.ServerID,
-		Infos:        suite.genSegmentLoadInfos(schema),
-		Schema:       schema,
-		NeedTransfer: true,
-		LoadScope:    querypb.LoadScope_Delta,
+		CollectionID:  suite.collectionID,
+		DstNodeID:     suite.node.session.ServerID,
+		Infos:         suite.genSegmentLoadInfos(schema),
+		Schema:        schema,
+		NeedTransfer:  true,
+		LoadScope:     querypb.LoadScope_Delta,
+		IndexInfoList: []*indexpb.IndexInfo{{}},
 	}
 
 	// LoadSegment
@@ -649,12 +651,13 @@ func (suite *ServiceSuite) TestLoadDeltaVarchar() {
 			MsgID:    rand.Int63(),
 			TargetID: suite.node.session.ServerID,
 		},
-		CollectionID: suite.collectionID,
-		DstNodeID:    suite.node.session.ServerID,
-		Infos:        suite.genSegmentLoadInfos(schema),
-		Schema:       schema,
-		NeedTransfer: true,
-		LoadScope:    querypb.LoadScope_Delta,
+		CollectionID:  suite.collectionID,
+		DstNodeID:     suite.node.session.ServerID,
+		Infos:         suite.genSegmentLoadInfos(schema),
+		Schema:        schema,
+		NeedTransfer:  true,
+		LoadScope:     querypb.LoadScope_Delta,
+		IndexInfoList: []*indexpb.IndexInfo{{}},
 	}
 
 	// LoadSegment

--- a/internal/querynodev2/services_test.go
+++ b/internal/querynodev2/services_test.go
@@ -567,6 +567,9 @@ func (suite *ServiceSuite) TestLoadSegments_Int64() {
 			Schema:         schema,
 			DeltaPositions: []*msgpb.MsgPosition{{Timestamp: 20000}},
 			NeedTransfer:   true,
+			IndexInfoList: []*indexpb.IndexInfo{
+				{},
+			},
 		}
 
 		// LoadSegment
@@ -810,12 +813,21 @@ func (suite *ServiceSuite) TestLoadSegments_Failed() {
 		Infos:        suite.genSegmentLoadInfos(schema),
 		Schema:       schema,
 		NeedTransfer: true,
+		IndexInfoList: []*indexpb.IndexInfo{
+			{},
+		},
 	}
 
 	// Delegator not found
 	status, err := suite.node.LoadSegments(ctx, req)
 	suite.NoError(err)
 	suite.ErrorIs(merr.Error(status), merr.ErrChannelNotFound)
+
+	// IndexIndex not found
+	nonIndexReq := typeutil.Clone(req)
+	nonIndexReq.IndexInfoList = nil
+	suite.NoError(err)
+	suite.ErrorIs(merr.Error(status), merr.ErrIndexNotFound)
 
 	// target not match
 	req.Base.TargetID = -1
@@ -828,6 +840,7 @@ func (suite *ServiceSuite) TestLoadSegments_Failed() {
 	status, err = suite.node.LoadSegments(ctx, req)
 	suite.NoError(err)
 	suite.ErrorIs(merr.Error(status), merr.ErrServiceNotReady)
+
 }
 
 func (suite *ServiceSuite) TestLoadSegments_Transfer() {

--- a/internal/querynodev2/services_test.go
+++ b/internal/querynodev2/services_test.go
@@ -687,12 +687,13 @@ func (suite *ServiceSuite) TestLoadIndex_Success() {
 			MsgID:    rand.Int63(),
 			TargetID: suite.node.session.ServerID,
 		},
-		CollectionID: suite.collectionID,
-		DstNodeID:    suite.node.session.ServerID,
-		Infos:        rawInfo,
-		Schema:       schema,
-		NeedTransfer: false,
-		LoadScope:    querypb.LoadScope_Full,
+		CollectionID:  suite.collectionID,
+		DstNodeID:     suite.node.session.ServerID,
+		Infos:         rawInfo,
+		Schema:        schema,
+		NeedTransfer:  false,
+		LoadScope:     querypb.LoadScope_Full,
+		IndexInfoList: []*indexpb.IndexInfo{{}},
 	}
 
 	// Load segment
@@ -711,12 +712,13 @@ func (suite *ServiceSuite) TestLoadIndex_Success() {
 			MsgID:    rand.Int63(),
 			TargetID: suite.node.session.ServerID,
 		},
-		CollectionID: suite.collectionID,
-		DstNodeID:    suite.node.session.ServerID,
-		Infos:        infos,
-		Schema:       schema,
-		NeedTransfer: false,
-		LoadScope:    querypb.LoadScope_Index,
+		CollectionID:  suite.collectionID,
+		DstNodeID:     suite.node.session.ServerID,
+		Infos:         infos,
+		Schema:        schema,
+		NeedTransfer:  false,
+		LoadScope:     querypb.LoadScope_Index,
+		IndexInfoList: []*indexpb.IndexInfo{{}},
 	}
 
 	// Load segment
@@ -755,12 +757,13 @@ func (suite *ServiceSuite) TestLoadIndex_Failed() {
 				MsgID:    rand.Int63(),
 				TargetID: suite.node.session.ServerID,
 			},
-			CollectionID: suite.collectionID,
-			DstNodeID:    suite.node.session.ServerID,
-			Infos:        rawInfo,
-			Schema:       schema,
-			NeedTransfer: false,
-			LoadScope:    querypb.LoadScope_Index,
+			CollectionID:  suite.collectionID,
+			DstNodeID:     suite.node.session.ServerID,
+			Infos:         rawInfo,
+			Schema:        schema,
+			NeedTransfer:  false,
+			LoadScope:     querypb.LoadScope_Index,
+			IndexInfoList: []*indexpb.IndexInfo{{}},
 		}
 
 		// Load segment
@@ -787,12 +790,13 @@ func (suite *ServiceSuite) TestLoadIndex_Failed() {
 				MsgID:    rand.Int63(),
 				TargetID: suite.node.session.ServerID,
 			},
-			CollectionID: suite.collectionID,
-			DstNodeID:    suite.node.session.ServerID,
-			Infos:        infos,
-			Schema:       schema,
-			NeedTransfer: false,
-			LoadScope:    querypb.LoadScope_Index,
+			CollectionID:  suite.collectionID,
+			DstNodeID:     suite.node.session.ServerID,
+			Infos:         infos,
+			Schema:        schema,
+			NeedTransfer:  false,
+			LoadScope:     querypb.LoadScope_Index,
+			IndexInfoList: []*indexpb.IndexInfo{{}},
 		}
 
 		// Load segment
@@ -829,6 +833,7 @@ func (suite *ServiceSuite) TestLoadSegments_Failed() {
 	// IndexIndex not found
 	nonIndexReq := typeutil.Clone(req)
 	nonIndexReq.IndexInfoList = nil
+	status, err = suite.node.LoadSegments(ctx, nonIndexReq)
 	suite.NoError(err)
 	suite.ErrorIs(merr.Error(status), merr.ErrIndexNotFound)
 
@@ -836,6 +841,7 @@ func (suite *ServiceSuite) TestLoadSegments_Failed() {
 	req.Base.TargetID = -1
 	status, err = suite.node.LoadSegments(ctx, req)
 	suite.NoError(err)
+	suite.T().Log(merr.Error(status))
 	suite.ErrorIs(merr.Error(status), merr.ErrNodeNotMatch)
 
 	// node not healthy
@@ -861,11 +867,12 @@ func (suite *ServiceSuite) TestLoadSegments_Transfer() {
 				MsgID:    rand.Int63(),
 				TargetID: suite.node.session.ServerID,
 			},
-			CollectionID: suite.collectionID,
-			DstNodeID:    suite.node.session.ServerID,
-			Infos:        suite.genSegmentLoadInfos(schema),
-			Schema:       schema,
-			NeedTransfer: true,
+			CollectionID:  suite.collectionID,
+			DstNodeID:     suite.node.session.ServerID,
+			Infos:         suite.genSegmentLoadInfos(schema),
+			Schema:        schema,
+			NeedTransfer:  true,
+			IndexInfoList: []*indexpb.IndexInfo{{}},
 		}
 
 		// LoadSegment
@@ -882,11 +889,12 @@ func (suite *ServiceSuite) TestLoadSegments_Transfer() {
 				MsgID:    rand.Int63(),
 				TargetID: suite.node.session.ServerID,
 			},
-			CollectionID: suite.collectionID,
-			DstNodeID:    suite.node.session.ServerID,
-			Infos:        suite.genSegmentLoadInfos(schema),
-			Schema:       schema,
-			NeedTransfer: true,
+			CollectionID:  suite.collectionID,
+			DstNodeID:     suite.node.session.ServerID,
+			Infos:         suite.genSegmentLoadInfos(schema),
+			Schema:        schema,
+			NeedTransfer:  true,
+			IndexInfoList: []*indexpb.IndexInfo{{}},
 		}
 
 		// LoadSegment
@@ -908,14 +916,14 @@ func (suite *ServiceSuite) TestLoadSegments_Transfer() {
 				MsgID:    rand.Int63(),
 				TargetID: suite.node.session.ServerID,
 			},
-			CollectionID: suite.collectionID,
-			DstNodeID:    suite.node.session.ServerID,
-			Infos:        suite.genSegmentLoadInfos(schema),
-			Schema:       schema,
-			NeedTransfer: true,
+			CollectionID:  suite.collectionID,
+			DstNodeID:     suite.node.session.ServerID,
+			Infos:         suite.genSegmentLoadInfos(schema),
+			Schema:        schema,
+			NeedTransfer:  true,
+			IndexInfoList: []*indexpb.IndexInfo{{}},
 		}
 
-		// LoadSegment
 		// LoadSegment
 		status, err := suite.node.LoadSegments(ctx, req)
 		suite.NoError(err)


### PR DESCRIPTION
See also #28022 #28034
The load segment may reaches before watch dml channel, so the index meta may be empty as well