### PR TITLE
enhance: Reduce ListImportTasks log content

### DIFF
--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -3954,7 +3954,9 @@ func (node *Proxy) ListImportTasks(ctx context.Context, req *milvuspb.ListImport
 
 	log.Debug("successfully received list import tasks response",
 		zap.String("collection", req.CollectionName),
-		zap.Any("tasks", resp.Tasks))
+		zap.Any("tasks", lo.SliceToMap(resp.GetTasks(), func(state *milvuspb.GetImportStateResponse) (int64, commonpb.ImportState) {
+			return state.GetId(), state.GetState()
+		})))
 	metrics.ProxyFunctionCall.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), method, metrics.SuccessLabel).Inc()
 	metrics.ProxyReqLatency.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), method).Observe(float64(tr.ElapseSpan().Milliseconds()))
 	return resp, err


### PR DESCRIPTION
In proxy `ListImportTasks` may print all task information from rootcoord, this may cause log content too large to process 
This PR make this log print taskID and importState only