### PR TITLE
fix: Fix channel manager bg checker exit when disable auto balance (#28459)

### DIFF
--- a/internal/datacoord/channel_manager.go
+++ b/internal/datacoord/channel_manager.go
@@ -277,7 +277,8 @@ func (c *ChannelManager) bgCheckChannelsWork(ctx context.Context) {
 			return
 		case <-ticker.C:
 			if !Params.DataCoordCfg.AutoBalance.GetAsBool() {
-				return
+				log.Info("auto balance disabled, skip auto bg check balance")
+				continue
 			}
 
 			c.mu.Lock()

--- a/internal/datacoord/channel_manager_test.go
+++ b/internal/datacoord/channel_manager_test.go
@@ -1245,6 +1245,7 @@ func TestChannelManager_HelperFunc(t *testing.T) {
 }
 
 func TestChannelManager_BackgroundChannelChecker(t *testing.T) {
+	Params.Save(Params.DataCoordCfg.AutoBalance.Key, "false")
 	Params.Save(Params.DataCoordCfg.ChannelBalanceInterval.Key, "1")
 	Params.Save(Params.DataCoordCfg.ChannelBalanceSilentDuration.Key, "1")
 


### PR DESCRIPTION
issue: #28454
pr: #28459 