### PR TITLE
test:skip a bulk insert testcase temporarily

### DIFF
--- a/tests/python_client/testcases/test_bulk_insert.py
+++ b/tests/python_client/testcases/test_bulk_insert.py
@@ -857,6 +857,7 @@ class TestBulkInsert(TestcaseBaseBulkInsert):
     @pytest.mark.parametrize("dim", [13])
     @pytest.mark.parametrize("entities", [150])
     @pytest.mark.parametrize("file_nums", [10])
+    @pytest.mark.skip(reason="issue #28209")
     def test_partition_key_on_multi_numpy_files(
             self, auto_id, dim, entities, file_nums
     ):


### PR DESCRIPTION
skip a bulk insert test case temporarily.
It is a known issue but needs more time to solve. skip the test case is for not blocking other PR