### PR TITLE
fix: frequent flush cause minio rate limit 

### DIFF
--- a/internal/datanode/channel_meta.go
+++ b/internal/datanode/channel_meta.go
@@ -288,6 +288,10 @@ func (c *ChannelMeta) listSegmentIDsToSync(ts Timestamp) []UniqueID {
 		if !seg.isValid() {
 			continue
 		}
+		// ignore all segments under syncing
+		if seg.isSyncing() {
+			continue
+		}
 		validSegs = append(validSegs, seg)
 	}
 

--- a/internal/datanode/flush_manager.go
+++ b/internal/datanode/flush_manager.go
@@ -687,6 +687,7 @@ func (t *flushBufferInsertTask) flushInsertData() error {
 				metrics.DataNodeFlushedSize.WithLabelValues(fmt.Sprint(paramtable.GetNodeID()), metrics.InsertLabel).Add(float64(len(d)))
 			}
 		}
+		log.Warn("failed to flush insert data", zap.Error(err))
 		return err
 	}
 	return nil
@@ -710,6 +711,7 @@ func (t *flushBufferDeleteTask) flushDeleteData() error {
 				metrics.DataNodeFlushedSize.WithLabelValues(fmt.Sprint(paramtable.GetNodeID()), metrics.DeleteLabel).Add(float64(len(d)))
 			}
 		}
+		log.Warn("failed to flush delete data", zap.Error(err))
 		return err
 	}
 	return nil

--- a/internal/datanode/segment_sync_policy_test.go
+++ b/internal/datanode/segment_sync_policy_test.go
@@ -31,6 +31,8 @@ import (
 func TestSyncPeriodically(t *testing.T) {
 	t0 := time.Now()
 
+	maxTime := time.Duration(1.2 * float64(Params.DataNodeCfg.SyncPeriod.GetAsDuration(time.Second)))
+	minTime := time.Duration(0.5 * float64(Params.DataNodeCfg.SyncPeriod.GetAsDuration(time.Second)))
 	tests := []struct {
 		testName      string
 		bufferTs      time.Time
@@ -39,8 +41,8 @@ func TestSyncPeriodically(t *testing.T) {
 		shouldSyncNum int
 	}{
 		{"test buffer empty", t0, t0.Add(Params.DataNodeCfg.SyncPeriod.GetAsDuration(time.Second)), true, 0},
-		{"test buffer not empty and stale", t0, t0.Add(Params.DataNodeCfg.SyncPeriod.GetAsDuration(time.Second)), false, 1},
-		{"test buffer not empty and not stale", t0, t0.Add(Params.DataNodeCfg.SyncPeriod.GetAsDuration(time.Second) / 2), false, 0},
+		{"test buffer not empty and stale", t0, t0.Add(maxTime), false, 1},
+		{"test buffer not empty and not stale", t0, t0.Add(minTime), false, 0},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
related to #28549
pr: #28626

1. avoid duplicated sync segments under syncing states
2. add jitter to avoid sync segments at the same time
