### PR TITLE
fix: Add jitter in GetSyncStaleBufferPolicy

### DIFF
--- a/internal/datanode/writebuffer/sync_policy.go
+++ b/internal/datanode/writebuffer/sync_policy.go
@@ -1,6 +1,7 @@
 package writebuffer
 
 import (
+	"math/rand"
 	"time"
 
 	"github.com/samber/lo"
@@ -60,8 +61,8 @@ func GetSyncStaleBufferPolicy(staleDuration time.Duration) SyncPolicy {
 		return lo.FilterMap(buffers, func(buf *segmentBuffer, _ int) (int64, bool) {
 			minTs := buf.MinTimestamp()
 			start := tsoutil.PhysicalTime(minTs)
-
-			return buf.segmentID, current.Sub(start) > staleDuration
+			jitter := time.Duration(rand.Float64() * 0.1 * float64(staleDuration))
+			return buf.segmentID, current.Sub(start) > staleDuration+jitter
 		})
 	}, "buffer stale")
 }


### PR DESCRIPTION
related to #28427
Add a jitter in syncStatleBuffer policy so all segments won't flush at the same time