### PR TITLE
fix: [cherry-pick] querynodev2 local worker failed to maintain collection ref

### DIFF
--- a/internal/querynodev2/local_worker.go
+++ b/internal/querynodev2/local_worker.go
@@ -52,6 +52,9 @@ func (w *LocalWorker) LoadSegments(ctx context.Context, req *querypb.LoadSegment
 		})),
 		zap.String("loadScope", req.GetLoadScope().String()),
 	)
+	w.node.manager.Collection.PutOrRef(req.GetCollectionID(), req.GetSchema(),
+		w.node.composeIndexMeta(req.GetIndexInfoList(), req.GetSchema()), req.GetLoadMeta())
+	defer w.node.manager.Collection.Unref(req.GetCollectionID(), 1)
 	log.Info("start to load segments...")
 	loaded, err := w.node.loader.Load(ctx,
 		req.GetCollectionID(),

--- a/internal/querynodev2/local_worker.go
+++ b/internal/querynodev2/local_worker.go
@@ -80,9 +80,13 @@ func (w *LocalWorker) ReleaseSegments(ctx context.Context, req *querypb.ReleaseS
 		zap.String("scope", req.GetScope().String()),
 	)
 	log.Info("start to release segments")
+	sealedCount := 0
 	for _, id := range req.GetSegmentIDs() {
-		w.node.manager.Segment.Remove(id, req.GetScope())
+		_, count := w.node.manager.Segment.Remove(id, req.GetScope())
+		sealedCount += count
 	}
+	w.node.manager.Collection.Unref(req.GetCollectionID(), uint32(sealedCount))
+
 	return nil
 }
 

--- a/internal/querynodev2/local_worker_test.go
+++ b/internal/querynodev2/local_worker_test.go
@@ -25,6 +25,7 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/proto/indexpb"
 	"github.com/milvus-io/milvus/internal/proto/querypb"
 	"github.com/milvus-io/milvus/internal/proto/segcorepb"
 	"github.com/milvus-io/milvus/internal/querynodev2/segments"
@@ -109,6 +110,7 @@ func (suite *LocalWorkerTestSuite) AfterTest(suiteName, testName string) {
 
 func (suite *LocalWorkerTestSuite) TestLoadSegment() {
 	// load empty
+	schema := segments.GenTestCollectionSchema(suite.collectionName, schemapb.DataType_Int64)
 	req := &querypb.LoadSegmentsRequest{
 		CollectionID: suite.collectionID,
 		Infos: lo.Map(suite.segmentIDs, func(segID int64, _ int) *querypb.SegmentLoadInfo {
@@ -118,6 +120,8 @@ func (suite *LocalWorkerTestSuite) TestLoadSegment() {
 				SegmentID:    segID,
 			}
 		}),
+		Schema:        schema,
+		IndexInfoList: []*indexpb.IndexInfo{{}},
 	}
 	err := suite.worker.LoadSegments(suite.ctx, req)
 	suite.NoError(err)


### PR DESCRIPTION
Cherry-pick from master
pr: #28590 #28598
See also #28589 #28596 
Increase ref for collection during load and unref after load completed.
Use the same logic protection from services.go `LoadSegments`
Perform `Unref` after release sealed segments