### PR TITLE
fix: Remove not needed `BlockAll` call in `SyncSegments`

### DIFF
--- a/internal/datanode/services.go
+++ b/internal/datanode/services.go
@@ -325,8 +325,6 @@ func (node *DataNode) SyncSegments(ctx context.Context, req *datapb.SyncSegments
 		return merr.Status(err), nil
 	}
 	bfs := metacache.NewBloomFilterSet(pks...)
-	ds.fg.Blockall()
-	defer ds.fg.Unblock()
 	ds.metacache.CompactSegments(req.GetCompactedTo(), req.GetPartitionId(), req.GetNumOfRows(), bfs, req.GetCompactedFrom()...)
 	node.compactionExecutor.injectDone(req.GetPlanID(), true)
 	return merr.Success(), nil


### PR DESCRIPTION
See also #28628
Previous compaction task blocked the segment sync task and may block the flowgraph when sync task is generated by auto sync policy This `BlockAll` call will block forever and cause whole fg stuck