### PR TITLE
enhance: Increase heartbeat timeout

### DIFF
--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -1509,7 +1509,7 @@ func (p *queryCoordConfig) init(base *BaseTable) {
 	p.CheckHealthRPCTimeout = ParamItem{
 		Key:          "queryCoord.checkHealthRPCTimeout",
 		Version:      "2.2.7",
-		DefaultValue: "100",
+		DefaultValue: "2000",
 		PanicIfEmpty: true,
 		Doc:          "100ms, the timeout of check health rpc to query node",
 		Export:       true,

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -260,7 +260,7 @@ func TestComponentParam(t *testing.T) {
 		checkHealthInterval := Params.CheckHealthInterval.GetAsInt()
 		assert.Equal(t, 3000, checkHealthInterval)
 		checkHealthRPCTimeout := Params.CheckHealthRPCTimeout.GetAsInt()
-		assert.Equal(t, 100, checkHealthRPCTimeout)
+		assert.Equal(t, 2000, checkHealthRPCTimeout)
 
 		assert.Equal(t, 0.1, Params.GlobalRowCountFactor.GetAsFloat())
 		params.Save("queryCoord.globalRowCountFactor", "0.4")


### PR DESCRIPTION
it's easy to trigger heartbeat timeout after 100ms when standalone cpu usage reach 100%.
This PR increase the heartbeat timeout param to 2000ms