### PR TITLE
fix: Skip statslog generation flushing empty L0 segment

### DIFF
--- a/internal/datanode/writebuffer/l0_write_buffer_test.go
+++ b/internal/datanode/writebuffer/l0_write_buffer_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/milvus-io/milvus/internal/allocator"
 	"github.com/milvus-io/milvus/internal/datanode/metacache"
 	"github.com/milvus-io/milvus/internal/datanode/syncmgr"
+	"github.com/milvus-io/milvus/internal/proto/datapb"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/pkg/common"
 	"github.com/milvus-io/milvus/pkg/mq/msgstream"
@@ -153,6 +154,8 @@ func (s *L0WriteBufferSuite) TestBufferData() {
 	pks, msg := s.composeInsertMsg(1000, 10, 128)
 	delMsg := s.composeDeleteMsg(lo.Map(pks, func(id int64, _ int) storage.PrimaryKey { return storage.NewInt64PrimaryKey(id) }))
 
+	seg := metacache.NewSegmentInfo(&datapb.SegmentInfo{ID: 1000}, metacache.NewBloomFilterSet())
+	s.metacache.EXPECT().GetSegmentsBy(mock.Anything, mock.Anything).Return([]*metacache.SegmentInfo{seg})
 	s.metacache.EXPECT().GetSegmentByID(int64(1000)).Return(nil, false)
 	s.metacache.EXPECT().AddSegment(mock.Anything, mock.Anything, mock.Anything).Return()
 	s.metacache.EXPECT().UpdateSegments(mock.Anything, mock.Anything).Return()

--- a/internal/storage/data_codec.go
+++ b/internal/storage/data_codec.go
@@ -28,6 +28,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/proto/etcdpb"
 	"github.com/milvus-io/milvus/pkg/common"
+	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
 
@@ -144,7 +145,7 @@ func (insertCodec *InsertCodec) SerializePkStats(stats *PrimaryKeyStats, rowNum 
 // Serialize Pk stats list to one blob
 func (insertCodec *InsertCodec) SerializePkStatsList(stats []*PrimaryKeyStats, rowNum int64) (*Blob, error) {
 	if len(stats) == 0 {
-		return nil, nil
+		return nil, merr.WrapErrServiceInternal("shall not serialize zero length statslog list")
 	}
 
 	blobKey := fmt.Sprintf("%d", stats[0].FieldID)

--- a/internal/storage/data_codec_test.go
+++ b/internal/storage/data_codec_test.go
@@ -417,6 +417,9 @@ func TestInsertCodec(t *testing.T) {
 	assert.NoError(t, err)
 	_, err = DeserializeStats([]*Blob{statsBlob2})
 	assert.NoError(t, err)
+
+	_, err = insertCodec.SerializePkStatsList([]*PrimaryKeyStats{}, 0)
+	assert.Error(t, err, "SerializePkStatsList zero length pkstats list shall return error")
 }
 
 func TestDeleteCodec(t *testing.T) {


### PR DESCRIPTION
See also #27675

When L0 segment contains only delta data, merged statslog shall be skiped when performing sync task