### PR TITLE
fix: Update segment compactTo when compactTo segment is compacted

### DIFF
--- a/internal/datanode/writebuffer/bf_write_buffer_test.go
+++ b/internal/datanode/writebuffer/bf_write_buffer_test.go
@@ -176,7 +176,7 @@ func (s *BFWriteBufferSuite) TestAutoSync() {
 	s.Run("normal_auto_sync", func() {
 		wb, err := NewBFWriteBuffer(s.channelName, s.metacache, nil, s.syncMgr, &writeBufferOption{
 			syncPolicies: []SyncPolicy{
-				SyncFullBuffer,
+				GetFullBufferPolicy(),
 				GetSyncStaleBufferPolicy(paramtable.Get().DataNodeCfg.SyncPeriod.GetAsDuration(time.Second)),
 				GetFlushingSegmentsPolicy(s.metacache),
 			},
@@ -248,7 +248,7 @@ func (s *BFWriteBufferSuite) TestAutoSyncWithStorageV2() {
 	s.Run("normal_auto_sync", func() {
 		wb, err := NewBFWriteBuffer(s.channelName, s.metacache, s.storageV2Cache, s.syncMgr, &writeBufferOption{
 			syncPolicies: []SyncPolicy{
-				SyncFullBuffer,
+				GetFullBufferPolicy(),
 				GetSyncStaleBufferPolicy(paramtable.Get().DataNodeCfg.SyncPeriod.GetAsDuration(time.Second)),
 				GetFlushingSegmentsPolicy(s.metacache),
 			},

--- a/internal/datanode/writebuffer/options.go
+++ b/internal/datanode/writebuffer/options.go
@@ -28,13 +28,15 @@ type writeBufferOption struct {
 	metaWriter     syncmgr.MetaWriter
 }
 
-func defaultWBOption() *writeBufferOption {
+func defaultWBOption(metacache metacache.MetaCache) *writeBufferOption {
 	return &writeBufferOption{
 		// TODO use l0 delta as default after implementation.
 		deletePolicy: paramtable.Get().DataNodeCfg.DeltaPolicy.GetValue(),
 		syncPolicies: []SyncPolicy{
-			SyncFullBuffer,
+			GetFullBufferPolicy(),
 			GetSyncStaleBufferPolicy(paramtable.Get().DataNodeCfg.SyncPeriod.GetAsDuration(time.Second)),
+			GetCompactedSegmentsPolicy(metacache),
+			GetFlushingSegmentsPolicy(metacache),
 		},
 	}
 }


### PR DESCRIPTION
Related to #28736 #28748
See also #27675
Previous PR: #28646

This PR fixes `SegmentNotFound` issue when compaction happens multiple times and the buffer of first generation segment is sync due to stale policy

Now the `CompactSegments` API of metacache shall update the compactTo field of segmentInfo if the compactTo segment is also compacted to keep the bloodline clean

Also, add the `CompactedSegment` SyncPolicy to sync the compacted segment asap to keep metacache clean

Now the `SyncPolicy` is an interface instead of a function type so that when it selects some segments to sync, we colud log the reason and target segment