### PR TITLE
enhance: Remove channel cp lag metrics when DropChannel

### DIFF
--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -590,6 +590,7 @@ func (s *Server) DropVirtualChannel(ctx context.Context, req *datapb.DropVirtual
 	s.segmentManager.DropSegmentsOfChannel(ctx, channel)
 
 	metrics.CleanupDataCoordNumStoredRows(collectionID)
+	metrics.DataCoordCheckpointLag.DeleteLabelValues(fmt.Sprint(paramtable.GetNodeID()), channel)
 
 	// no compaction triggered in Drop procedure
 	return resp, nil


### PR DESCRIPTION
See also #28765
Remove metric when Drop channel grpc execute succeed