### PR TITLE
fix: [cherry-pick] schema->size() check logic with system field (#28802)

### DIFF
--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -159,7 +159,7 @@ SegmentGrowingImpl::Insert(int64_t reserved_offset,
 void
 SegmentGrowingImpl::LoadFieldData(const LoadFieldDataInfo& infos) {
     // schema don't include system field
-    AssertInfo(infos.field_infos.size() == schema_->size() + 2,
+    AssertInfo(infos.field_infos.size() == schema_->size(),
                "lost some field data when load for growing segment");
     AssertInfo(infos.field_infos.find(TimestampFieldID.get()) !=
                    infos.field_infos.end(),

--- a/internal/core/unittest/test_c_api.cpp
+++ b/internal/core/unittest/test_c_api.cpp
@@ -3808,6 +3808,8 @@ TEST(CApiTest, SealedSegment_Update_Field_Size) {
 
 TEST(CApiTest, GrowingSegment_Load_Field_Data) {
     auto schema = std::make_shared<Schema>();
+    schema->AddField(FieldName("RowID"), FieldId(0), DataType::INT64);
+    schema->AddField(FieldName("Timestamp"), FieldId(1), DataType::INT64);
     auto str_fid = schema->AddDebugField("string", DataType::VARCHAR);
     auto vec_fid = schema->AddDebugField(
         "vector_float", DataType::VECTOR_FLOAT, DIM, "L2");


### PR DESCRIPTION
Cherry pick from master
pr: #28802

Now segcore load system field info as well, the growing segment assertion shall not pass with "+ 2" value
This will cause all growing segments load failure
Fix #28801
Related to #28478
See also #28524
