### PR TITLE
fix: bypass growing index if no index meta (#28791)

### DIFF
--- a/internal/core/src/segcore/FieldIndexing.h
+++ b/internal/core/src/segcore/FieldIndexing.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <optional>
 #include <map>
 #include <memory>
@@ -24,6 +25,7 @@
 #include "common/Schema.h"
 #include "common/IndexMeta.h"
 #include "IndexConfigGenerator.h"
+#include "log/Log.h"
 #include "segcore/SegcoreConfig.h"
 #include "index/VectorIndex.h"
 
@@ -246,6 +248,12 @@ class IndexingRecord {
                 segcore_config_.get_enable_growing_segment_index()) {
                 // TODO: skip binary small index now, reenable after config.yaml is ready
                 if (field_meta.get_data_type() == DataType::VECTOR_BINARY) {
+                    continue;
+                }
+
+                if (index_meta_ == nullptr) {
+                    LOG_SEGCORE_INFO_
+                        << "miss index meta for growing interim index";
                     continue;
                 }
                 //Small-Index enabled, create index for vector field only

--- a/internal/core/unittest/test_growing_index.cpp
+++ b/internal/core/unittest/test_growing_index.cpp
@@ -125,6 +125,20 @@ TEST(GrowingIndex, Correctness) {
     }
 }
 
+TEST(GrowingIndex, MissIndexMeta) {
+    auto schema = std::make_shared<Schema>();
+    auto pk = schema->AddDebugField("pk", DataType::INT64);
+    auto random = schema->AddDebugField("random", DataType::DOUBLE);
+    auto vec = schema->AddDebugField(
+        "embeddings", DataType::VECTOR_FLOAT, 128, knowhere::metric::L2);
+    schema->set_primary_field_id(pk);
+
+    auto& config = SegcoreConfig::default_config();
+    config.set_chunk_rows(1024);
+    config.set_enable_interim_segment_index(true);
+    auto segment = CreateGrowingSegment(schema, nullptr);
+}
+
 using Param = const char*;
 
 class GrowingIndexGetVectorTest : public ::testing::TestWithParam<Param> {

--- a/internal/core/unittest/test_growing_index.cpp
+++ b/internal/core/unittest/test_growing_index.cpp
@@ -135,7 +135,7 @@ TEST(GrowingIndex, MissIndexMeta) {
 
     auto& config = SegcoreConfig::default_config();
     config.set_chunk_rows(1024);
-    config.set_enable_interim_segment_index(true);
+    config.set_enable_growing_segment_index(true);
     auto segment = CreateGrowingSegment(schema, nullptr);
 }
 


### PR DESCRIPTION
we shouldn't panic if no index meta, just skip building it
fix #28022
pr: #28791 