### PR TITLE
fix: Fix get binary vector from chunk cache (#28866)

### DIFF
--- a/internal/core/src/segcore/SegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/SegmentSealedImpl.cpp
@@ -736,8 +736,7 @@ SegmentSealedImpl::get_vector(FieldId field_id,
         }
 
         // assign to data array
-        auto dim = field_meta.get_dim();
-        auto row_bytes = field_meta.is_vector() ? dim * 4 : dim / 8;
+        auto row_bytes = field_meta.get_sizeof();
         auto buf = std::vector<char>(count * row_bytes);
         for (auto i = 0; i < count; i++) {
             AssertInfo(id_to_data_path.count(ids[i]) != 0, "id not found");


### PR DESCRIPTION
The way of getting binary vector size is wrong. This PR will fix it.

issue: https://github.com/milvus-io/milvus/issues/28865

pr: https://github.com/milvus-io/milvus/pull/28866