### PR TITLE
enhance: Deprecated shard leader cache after search/query failed

### DIFF
--- a/internal/proxy/meta_cache_test.go
+++ b/internal/proxy/meta_cache_test.go
@@ -803,7 +803,7 @@ func TestMetaCache_ExpireShardLeaderCache(t *testing.T) {
 			},
 		},
 	}, nil)
-
+	globalMetaCache.DeprecateShardCache(dbName, "collection1")
 	assert.Eventually(t, func() bool {
 		nodeInfos, err := globalMetaCache.GetShards(ctx, true, dbName, "collection1", 1)
 		assert.NoError(t, err)
@@ -821,7 +821,7 @@ func TestMetaCache_ExpireShardLeaderCache(t *testing.T) {
 			},
 		},
 	}, nil)
-
+	globalMetaCache.DeprecateShardCache(dbName, "collection1")
 	assert.Eventually(t, func() bool {
 		nodeInfos, err := globalMetaCache.GetShards(ctx, true, dbName, "collection1", 1)
 		assert.NoError(t, err)
@@ -844,7 +844,7 @@ func TestMetaCache_ExpireShardLeaderCache(t *testing.T) {
 			},
 		},
 	}, nil)
-
+	globalMetaCache.DeprecateShardCache(dbName, "collection1")
 	assert.Eventually(t, func() bool {
 		nodeInfos, err := globalMetaCache.GetShards(ctx, true, dbName, "collection1", 1)
 		assert.NoError(t, err)


### PR DESCRIPTION
issue: #28898

This PR removed the background goroutine which will deprecate shard leader cache in every 3s. and only deprecate shard leader cache after search/query meet a 'ChannelNotFound' error