### PR TITLE
fix: [2.2] Reject compaction task with growing segments

### DIFF
--- a/internal/datanode/channel_meta_test.go
+++ b/internal/datanode/channel_meta_test.go
@@ -200,7 +200,8 @@ func TestChannelMeta_getCollectionAndPartitionID(t *testing.T) {
 			seg.setType(test.segType)
 			channel := &ChannelMeta{
 				segments: map[UniqueID]*Segment{
-					test.segID: &seg},
+					test.segID: &seg,
+				},
 			}
 
 			collID, parID, err := channel.getCollectionAndPartitionID(test.segID)
@@ -617,39 +618,54 @@ func TestChannelMeta_InterfaceMethod(t *testing.T) {
 			outFrom         []UniqueID
 			inSeg           *Segment
 		}{
-			{"mismatch collection", false, false,
-				[]UniqueID{1, 2}, []UniqueID{},
+			{
+				"mismatch collection", false, false,
+				[]UniqueID{1, 2},
+				[]UniqueID{},
 				&Segment{
 					segmentID:    3,
 					collectionID: -1,
-				}},
-			{"no match flushed segment", true, false,
-				[]UniqueID{1, 6}, []UniqueID{1},
+				},
+			},
+			{
+				"no match flushed segment", true, false,
+				[]UniqueID{1, 6},
+				[]UniqueID{1},
 				&Segment{
 					segmentID:    3,
 					collectionID: 1,
-				}},
-			{"numRows==0", true, false,
-				[]UniqueID{1, 2}, []UniqueID{},
+				},
+			},
+			{
+				"numRows==0", true, false,
+				[]UniqueID{1, 2},
+				[]UniqueID{},
 				&Segment{
 					segmentID:    3,
 					collectionID: 1,
 					numRows:      0,
-				}},
-			{"numRows>0", true, true,
-				[]UniqueID{1, 2}, []UniqueID{1, 2},
+				},
+			},
+			{
+				"numRows>0", true, true,
+				[]UniqueID{1, 2},
+				[]UniqueID{1, 2},
 				&Segment{
 					segmentID:    3,
 					collectionID: 1,
 					numRows:      15,
-				}},
-			{"segment exists but not flushed", true, true,
-				[]UniqueID{1, 4}, []UniqueID{1},
+				},
+			},
+			{
+				"segment exists but not flushed", true, false,
+				[]UniqueID{1, 4},
+				[]UniqueID{1},
 				&Segment{
 					segmentID:    3,
 					collectionID: 1,
 					numRows:      15,
-				}},
+				},
+			},
 		}
 
 		for _, test := range tests {
@@ -697,12 +713,11 @@ func TestChannelMeta_InterfaceMethod(t *testing.T) {
 				} else {
 					assert.False(t, channel.hasSegment(3, true))
 				}
-
 			})
 		}
 	})
-
 }
+
 func TestChannelMeta_UpdatePKRange(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -759,7 +774,6 @@ func TestChannelMeta_UpdatePKRange(t *testing.T) {
 		assert.True(t, segNew.isPKExist(pk))
 		assert.True(t, segNormal.isPKExist(pk))
 	}
-
 }
 
 func TestChannelMeta_ChannelCP(t *testing.T) {
@@ -795,7 +809,8 @@ func TestChannelMeta_ChannelCP(t *testing.T) {
 	t.Run("set insertBuffer&deleteBuffer then get", func(t *testing.T) {
 		run := func(curInsertPos, curDeletePos *internalpb.MsgPosition,
 			hisInsertPoss, hisDeletePoss []*internalpb.MsgPosition,
-			ttPos, expectedPos *internalpb.MsgPosition) {
+			ttPos, expectedPos *internalpb.MsgPosition,
+		) {
 			segmentID := UniqueID(1)
 			channel := newChannel(mockVChannel, collID, nil, rc, cm)
 			channel.chunkManager = &mockDataCM{}

--- a/internal/datanode/flush_manager.go
+++ b/internal/datanode/flush_manager.go
@@ -774,6 +774,11 @@ func dropVirtualChannelFunc(dsService *dataSyncService, opts ...retry.Option) fl
 
 func flushNotifyFunc(dsService *dataSyncService, opts ...retry.Option) notifyMetaFunc {
 	return func(pack *segmentFlushPack) {
+		log := log.Ctx(context.Background()).With(
+			zap.Int64("segmentID", pack.segmentID),
+			zap.Int64("collectionID", dsService.collectionID),
+			zap.String("vchannel", dsService.vchannelName),
+		)
 		if pack.err != nil {
 			log.Error("flush pack with error, DataNode quit now", zap.Error(pack.err))
 			// TODO silverxia change to graceful stop datanode
@@ -808,13 +813,11 @@ func flushNotifyFunc(dsService *dataSyncService, opts ...retry.Option) notifyMet
 
 		log.Info("SaveBinlogPath",
 			zap.Int64("SegmentID", pack.segmentID),
-			zap.Int64("CollectionID", dsService.collectionID),
 			zap.Any("startPos", startPos),
 			zap.Any("checkPoints", checkPoints),
 			zap.Int("Length of Field2BinlogPaths", len(fieldInsert)),
 			zap.Int("Length of Field2Stats", len(fieldStats)),
 			zap.Int("Length of Field2Deltalogs", len(deltaInfos[0].GetBinlogs())),
-			zap.String("vChannelName", dsService.vchannelName),
 		)
 
 		req := &datapb.SaveBinlogPathsRequest{
@@ -847,11 +850,10 @@ func flushNotifyFunc(dsService *dataSyncService, opts ...retry.Option) notifyMet
 			// Segment not found during stale segment flush. Segment might get compacted already.
 			// Stop retry and still proceed to the end, ignoring this error.
 			if !pack.flushed && rsp.GetErrorCode() == commonpb.ErrorCode_SegmentNotFound {
-				log.Warn("stale segment not found, could be compacted",
-					zap.Int64("segment ID", pack.segmentID))
+				log.Warn("stale segment not found, could be compacted")
 				log.Warn("failed to SaveBinlogPaths",
-					zap.Int64("segment ID", pack.segmentID),
 					zap.Error(errors.New(rsp.GetReason())))
+
 				return nil
 			}
 
@@ -862,7 +864,7 @@ func flushNotifyFunc(dsService *dataSyncService, opts ...retry.Option) notifyMet
 
 			// meta error, datanode handles a virtual channel does not belong here
 			if rsp.GetErrorCode() == commonpb.ErrorCode_MetaFailed || channelNotFound() {
-				log.Warn("meta error found, skip sync and start to drop virtual channel", zap.String("channel", dsService.vchannelName))
+				log.Warn("meta error found, skip sync and start to drop virtual channel")
 				return nil
 			}
 
@@ -877,7 +879,6 @@ func flushNotifyFunc(dsService *dataSyncService, opts ...retry.Option) notifyMet
 		}, opts...)
 		if err != nil {
 			log.Warn("failed to SaveBinlogPaths",
-				zap.Int64("segment ID", pack.segmentID),
 				zap.Error(err))
 			// TODO change to graceful stop
 			panic(err)
@@ -896,5 +897,7 @@ func flushNotifyFunc(dsService *dataSyncService, opts ...retry.Option) notifyMet
 		dsService.channel.evictHistoryDeleteBuffer(req.GetSegmentID(), pack.pos)
 		segment := dsService.channel.getSegment(req.GetSegmentID())
 		segment.setSyncing(false)
+
+		log.Info("successfully save binlog")
 	}
 }


### PR DESCRIPTION
Cherry-pick from 2.3
pr: #28927
See also #28924
The compaction task generated before datanode finish SaveBinlogPath grpc call contains segments which are still in Growing state DataNode shall verify each non-levelzero segments before submit compaction task to executor