### PR TITLE
test: remove outdated e2e test case beacause disknn support search with search list num large than 200 or 65535

### DIFF
--- a/tests/python_client/testcases/test_search.py
+++ b/tests/python_client/testcases/test_search.py
@@ -6142,13 +6142,13 @@ class TestSearchDiskann(TestcaseBase):
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("limit", [1])
-    @pytest.mark.parametrize("search_list", [-1, 0, 201])
+    @pytest.mark.parametrize("search_list", [-1, 0])
     def test_search_invalid_params_with_diskann_A(self, dim, auto_id, search_list, limit):
         """
         target: test delete after creating index
         method: 1.create collection , insert data, primary_field is int field
                 2.create diskann index 
-                3.search with invalid params, where  topk <=20, search list [topk, 200]
+                3.search with invalid params, where  topk <=20, search list [topk, 2147483647]
         expected: search report an error
         """
         # 1. initialize with data
@@ -6168,13 +6168,11 @@ class TestSearchDiskann(TestcaseBase):
                             output_fields=output_fields,
                             check_task=CheckTasks.err_res,
                             check_items={"err_code": 65535,
-                                         "err_msg": "search_list_size should be in range: [topk, "
-                                                    "max(200, topk * 10)], topk = 1, search_list_"
-                                                    "size = {}".format(search_list)})
+                                         "err_msg": "param search_list_size out of range [ 1,2147483647 ]"})
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("limit", [20])
-    @pytest.mark.parametrize("search_list", [19, 201])
+    @pytest.mark.parametrize("search_list", [19])
     def test_search_invalid_params_with_diskann_B(self, dim, auto_id, search_list, limit):
         """
         target: test delete after creating index
@@ -6200,35 +6198,6 @@ class TestSearchDiskann(TestcaseBase):
                             check_task=CheckTasks.err_res,
                             check_items={"err_code": 65538,
                                          "err_msg": "UnknownError"})
-
-    @pytest.mark.tags(CaseLabel.L2)
-    @pytest.mark.parametrize("limit", [6553])
-    @pytest.mark.parametrize("search_list", [6550, 65536])
-    def test_search_invalid_params_with_diskann_C(self, dim, auto_id, search_list, limit):
-        """
-        target: test delete after creating index
-        method: 1.create collection , insert data, primary_field is int field
-                2.create diskann index 
-                3.search with invalid params , [k, min( 10 * topk, 65535)] when k > 20
-        expected: search report an error
-        """
-        # 1. initialize with data
-        collection_w, _, _, insert_ids = \
-            self.init_collection_general(prefix, True, auto_id=auto_id, dim=dim, is_index=False)[0:4]
-        # 2. create index
-        default_index = {"index_type": "DISKANN", "metric_type": "L2", "params": {}}
-        collection_w.create_index(ct.default_float_vec_field_name, default_index)
-        collection_w.load()
-        default_search_params = {"metric_type": "L2", "params": {"search_list": search_list}}
-        vectors = [[random.random() for _ in range(dim)] for _ in range(default_nq)]
-        output_fields = [default_int64_field_name, default_float_field_name,  default_string_field_name]
-        collection_w.search(vectors[:default_nq], default_search_field,
-                            default_search_params, limit,
-                            default_search_exp,
-                            output_fields=output_fields,
-                            check_task=CheckTasks.err_res,
-                            check_items={"err_code": 65538,
-                                         "err_msg": "failed to search"})
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_search_with_diskann_with_string_pk(self, dim, enable_dynamic_field):


### PR DESCRIPTION
relate: https://github.com/milvus-io/milvus/issues/28745