### PR TITLE
enhance: Refine C.NewSegment response and handle exception

### DIFF
--- a/internal/core/src/common/type_c.h
+++ b/internal/core/src/common/type_c.h
@@ -54,6 +54,8 @@ enum CDataType {
 };
 typedef enum CDataType CDataType;
 
+typedef void* CSegmentInterface;
+
 typedef struct CStatus {
     int error_code;
     const char* error_msg;
@@ -102,6 +104,11 @@ typedef struct CTraceContext {
     const uint8_t* spanID;
     uint8_t flag;
 } CTraceContext;
+
+typedef struct CNewSegmentResult {
+    CStatus status;
+    CSegmentInterface segmentPtr;
+} CNewSegmentResult;
 #ifdef __cplusplus
 }
 

--- a/internal/core/src/segcore/segment_c.h
+++ b/internal/core/src/segcore/segment_c.h
@@ -29,8 +29,11 @@ typedef void* CSearchResult;
 typedef CProto CRetrieveResult;
 
 //////////////////////////////    common interfaces    //////////////////////////////
-CNewSegmentResult
-NewSegment(CCollection collection, SegmentType seg_type, int64_t segment_id);
+CStatus
+NewSegment(CCollection collection,
+           SegmentType seg_type,
+           int64_t segment_id,
+           CSegmentInterface* newSegment);
 
 void
 DeleteSegment(CSegmentInterface c_segment);

--- a/internal/core/src/segcore/segment_c.h
+++ b/internal/core/src/segcore/segment_c.h
@@ -24,12 +24,12 @@ extern "C" {
 #include "segcore/load_index_c.h"
 #include "segcore/load_field_data_c.h"
 
-typedef void* CSegmentInterface;
+// typedef void* CSegmentInterface;
 typedef void* CSearchResult;
 typedef CProto CRetrieveResult;
 
 //////////////////////////////    common interfaces    //////////////////////////////
-CSegmentInterface
+CNewSegmentResult
 NewSegment(CCollection collection, SegmentType seg_type, int64_t segment_id);
 
 void

--- a/internal/core/src/segcore/segment_c.h
+++ b/internal/core/src/segcore/segment_c.h
@@ -24,7 +24,6 @@ extern "C" {
 #include "segcore/load_index_c.h"
 #include "segcore/load_field_data_c.h"
 
-// typedef void* CSegmentInterface;
 typedef void* CSearchResult;
 typedef CProto CRetrieveResult;
 

--- a/internal/core/unittest/test_c_api.cpp
+++ b/internal/core/unittest/test_c_api.cpp
@@ -22,6 +22,7 @@
 #include <unordered_set>
 
 #include "boost/container/vector.hpp"
+#include "common/EasyAssert.h"
 #include "common/LoadInfo.h"
 #include "common/Types.h"
 #include "common/type_c.h"
@@ -307,6 +308,9 @@ TEST(CApiTest, SegmentTest) {
     CSegmentInterface segment;
     auto status = NewSegment(collection, Growing, -1, &segment);
     ASSERT_EQ(status.error_code, Success);
+    CSegmentInterface a_segment;
+    status = NewSegment(collection, Invalid, -1, &a_segment);
+    ASSERT_NE(status.error_code, Success);
     DeleteCollection(collection);
     DeleteSegment(segment);
 }

--- a/internal/core/unittest/test_c_api.cpp
+++ b/internal/core/unittest/test_c_api.cpp
@@ -313,6 +313,7 @@ TEST(CApiTest, SegmentTest) {
     ASSERT_NE(status.error_code, Success);
     DeleteCollection(collection);
     DeleteSegment(segment);
+    free((char *)status.error_msg);
 }
 
 TEST(CApiTest, CPlan) {

--- a/internal/core/unittest/test_c_api.cpp
+++ b/internal/core/unittest/test_c_api.cpp
@@ -304,7 +304,9 @@ TEST(CApiTest, GetCollectionNameTest) {
 
 TEST(CApiTest, SegmentTest) {
     auto collection = NewCollection(get_default_schema_config());
-    auto segment = NewSegment(collection, Growing, -1);
+    CSegmentInterface segment;
+    auto status = NewSegment(collection, Growing, -1, &segment);
+    ASSERT_EQ(status.error_code, Success);
     DeleteCollection(collection);
     DeleteSegment(segment);
 }
@@ -367,7 +369,9 @@ TEST(CApiTest, CPlan) {
 
 TEST(CApiTest, InsertTest) {
     auto c_collection = NewCollection(get_default_schema_config());
-    auto segment = NewSegment(c_collection, Growing, -1);
+    CSegmentInterface segment;
+    auto status = NewSegment(c_collection, Growing, -1, &segment);
+    ASSERT_EQ(status.error_code, Success);
     auto col = (milvus::segcore::Collection*)c_collection;
 
     int N = 10000;
@@ -392,7 +396,9 @@ TEST(CApiTest, InsertTest) {
 
 TEST(CApiTest, DeleteTest) {
     auto collection = NewCollection(get_default_schema_config());
-    auto segment = NewSegment(collection, Growing, -1);
+    CSegmentInterface segment;
+    auto status = NewSegment(collection, Growing, -1, &segment);
+    ASSERT_EQ(status.error_code, Success);
 
     std::vector<int64_t> delete_row_ids = {100000, 100001, 100002};
     auto ids = std::make_unique<IdArray>();
@@ -416,7 +422,9 @@ TEST(CApiTest, DeleteTest) {
 
 TEST(CApiTest, MultiDeleteGrowingSegment) {
     auto collection = NewCollection(get_default_schema_config());
-    auto segment = NewSegment(collection, Growing, -1);
+    CSegmentInterface segment;
+    auto status = NewSegment(collection, Growing, -1, &segment);
+    ASSERT_EQ(status.error_code, Success);
     auto col = (milvus::segcore::Collection*)collection;
 
     int N = 10;
@@ -525,7 +533,9 @@ TEST(CApiTest, MultiDeleteGrowingSegment) {
 
 TEST(CApiTest, MultiDeleteSealedSegment) {
     auto collection = NewCollection(get_default_schema_config());
-    auto segment = NewSegment(collection, Sealed, -1);
+    CSegmentInterface segment;
+    auto status = NewSegment(collection, Sealed, -1, &segment);
+    ASSERT_EQ(status.error_code, Success);
     auto col = (milvus::segcore::Collection*)collection;
 
     int N = 10;
@@ -625,7 +635,9 @@ TEST(CApiTest, MultiDeleteSealedSegment) {
 
 TEST(CApiTest, DeleteRepeatedPksFromGrowingSegment) {
     auto collection = NewCollection(get_default_schema_config());
-    auto segment = NewSegment(collection, Growing, -1);
+    CSegmentInterface segment;
+    auto status = NewSegment(collection, Growing, -1, &segment);
+    ASSERT_EQ(status.error_code, Success);
     auto col = (milvus::segcore::Collection*)collection;
 
     int N = 10;
@@ -718,7 +730,9 @@ TEST(CApiTest, DeleteRepeatedPksFromGrowingSegment) {
 
 TEST(CApiTest, DeleteRepeatedPksFromSealedSegment) {
     auto collection = NewCollection(get_default_schema_config());
-    auto segment = NewSegment(collection, Sealed, -1);
+    CSegmentInterface segment;
+    auto status = NewSegment(collection, Sealed, -1, &segment);
+    ASSERT_EQ(status.error_code, Success);
     auto col = (milvus::segcore::Collection*)collection;
 
     int N = 20;
@@ -791,7 +805,9 @@ TEST(CApiTest, DeleteRepeatedPksFromSealedSegment) {
 
 TEST(CApiTest, InsertSamePkAfterDeleteOnGrowingSegment) {
     auto collection = NewCollection(get_default_schema_config());
-    auto segment = NewSegment(collection, Growing, -1);
+    CSegmentInterface segment;
+    auto status = NewSegment(collection, Growing, -1, &segment);
+    ASSERT_EQ(status.error_code, Success);
     auto col = (milvus::segcore::Collection*)collection;
 
     int N = 10;
@@ -888,7 +904,9 @@ TEST(CApiTest, InsertSamePkAfterDeleteOnGrowingSegment) {
 
 TEST(CApiTest, InsertSamePkAfterDeleteOnSealedSegment) {
     auto collection = NewCollection(get_default_schema_config());
-    auto segment = NewSegment(collection, Sealed, -1);
+    CSegmentInterface segment;
+    auto status = NewSegment(collection, Sealed, -1, &segment);
+    ASSERT_EQ(status.error_code, Success);
     auto col = (milvus::segcore::Collection*)collection;
 
     int N = 10;
@@ -950,7 +968,9 @@ TEST(CApiTest, InsertSamePkAfterDeleteOnSealedSegment) {
 
 TEST(CApiTest, SearchTest) {
     auto c_collection = NewCollection(get_default_schema_config());
-    auto segment = NewSegment(c_collection, Growing, -1);
+    CSegmentInterface segment;
+    auto status = NewSegment(c_collection, Growing, -1, &segment);
+    ASSERT_EQ(status.error_code, Success);
     auto col = (milvus::segcore::Collection*)c_collection;
 
     int N = 10000;
@@ -986,7 +1006,7 @@ TEST(CApiTest, SearchTest) {
     auto blob = generate_query_data(num_queries);
 
     void* plan = nullptr;
-    auto status = CreateSearchPlanByExpr(
+    status = CreateSearchPlanByExpr(
         c_collection, plan_str.data(), plan_str.size(), &plan);
     ASSERT_EQ(status.error_code, Success);
 
@@ -1016,7 +1036,9 @@ TEST(CApiTest, SearchTest) {
 
 TEST(CApiTest, SearchTestWithExpr) {
     auto c_collection = NewCollection(get_default_schema_config());
-    auto segment = NewSegment(c_collection, Growing, -1);
+    CSegmentInterface segment;
+    auto status = NewSegment(c_collection, Growing, -1, &segment);
+    ASSERT_EQ(status.error_code, Success);
     auto col = (milvus::segcore::Collection*)c_collection;
 
     int N = 10000;
@@ -1050,7 +1072,7 @@ TEST(CApiTest, SearchTestWithExpr) {
 
     void* plan = nullptr;
     auto binary_plan = translate_text_plan_to_binary_plan(serialized_expr_plan);
-    auto status = CreateSearchPlanByExpr(
+    status = CreateSearchPlanByExpr(
         c_collection, binary_plan.data(), binary_plan.size(), &plan);
     ASSERT_EQ(status.error_code, Success);
 
@@ -1077,7 +1099,9 @@ TEST(CApiTest, SearchTestWithExpr) {
 
 TEST(CApiTest, RetrieveTestWithExpr) {
     auto collection = NewCollection(get_default_schema_config());
-    auto segment = NewSegment(collection, Growing, -1);
+    CSegmentInterface segment;
+    auto status = NewSegment(collection, Growing, -1, &segment);
+    ASSERT_EQ(status.error_code, Success);
     auto schema = ((milvus::segcore::Collection*)collection)->get_schema();
     auto plan = std::make_unique<query::RetrievePlan>(*schema);
 
@@ -1123,7 +1147,9 @@ TEST(CApiTest, RetrieveTestWithExpr) {
 
 TEST(CApiTest, GetMemoryUsageInBytesTest) {
     auto collection = NewCollection(get_default_schema_config());
-    auto segment = NewSegment(collection, Growing, -1);
+    CSegmentInterface segment;
+    auto status = NewSegment(collection, Growing, -1, &segment);
+    ASSERT_EQ(status.error_code, Success);
 
     auto old_memory_usage_size = GetMemoryUsageInBytes(segment);
     // std::cout << "old_memory_usage_size = " << old_memory_usage_size << std::endl;
@@ -1152,7 +1178,9 @@ TEST(CApiTest, GetMemoryUsageInBytesTest) {
 
 TEST(CApiTest, GetDeletedCountTest) {
     auto collection = NewCollection(get_default_schema_config());
-    auto segment = NewSegment(collection, Growing, -1);
+    CSegmentInterface segment;
+    auto status = NewSegment(collection, Growing, -1, &segment);
+    ASSERT_EQ(status.error_code, Success);
 
     std::vector<int64_t> delete_row_ids = {100000, 100001, 100002};
     auto ids = std::make_unique<IdArray>();
@@ -1181,7 +1209,9 @@ TEST(CApiTest, GetDeletedCountTest) {
 
 TEST(CApiTest, GetRowCountTest) {
     auto collection = NewCollection(get_default_schema_config());
-    auto segment = NewSegment(collection, Growing, -1);
+    CSegmentInterface segment;
+    auto status = NewSegment(collection, Growing, -1, &segment);
+    ASSERT_EQ(status.error_code, Success);
 
     auto schema = ((milvus::segcore::Collection*)collection)->get_schema();
     int N = 10000;
@@ -1209,7 +1239,9 @@ TEST(CApiTest, GetRowCountTest) {
 
 TEST(CApiTest, GetRealCount) {
     auto collection = NewCollection(get_default_schema_config());
-    auto segment = NewSegment(collection, Growing, -1);
+    CSegmentInterface segment;
+    auto status = NewSegment(collection, Growing, -1, &segment);
+    ASSERT_EQ(status.error_code, Success);
 
     auto schema = ((milvus::segcore::Collection*)collection)->get_schema();
     int N = 10000;
@@ -1278,7 +1310,9 @@ CheckSearchResultDuplicate(const std::vector<CSearchResult>& results) {
 
 TEST(CApiTest, ReudceNullResult) {
     auto collection = NewCollection(get_default_schema_config());
-    auto segment = NewSegment(collection, Growing, -1);
+    CSegmentInterface segment;
+    auto status = NewSegment(collection, Growing, -1, &segment);
+    ASSERT_EQ(status.error_code, Success);
     auto schema = ((milvus::segcore::Collection*)collection)->get_schema();
     int N = 10000;
     auto dataset = DataGen(schema, N);
@@ -1312,7 +1346,7 @@ TEST(CApiTest, ReudceNullResult) {
     auto blob = generate_max_float_query_data(num_queries, num_queries / 2);
 
     void* plan = nullptr;
-    auto status = CreateSearchPlanByExpr(
+    status = CreateSearchPlanByExpr(
         collection, plan_str.data(), plan_str.size(), &plan);
     ASSERT_EQ(status.error_code, Success);
 
@@ -1360,7 +1394,9 @@ TEST(CApiTest, ReudceNullResult) {
 
 TEST(CApiTest, ReduceRemoveDuplicates) {
     auto collection = NewCollection(get_default_schema_config());
-    auto segment = NewSegment(collection, Growing, -1);
+    CSegmentInterface segment;
+    auto status = NewSegment(collection, Growing, -1, &segment);
+    ASSERT_EQ(status.error_code, Success);
 
     auto schema = ((milvus::segcore::Collection*)collection)->get_schema();
     int N = 10000;
@@ -1397,7 +1433,7 @@ TEST(CApiTest, ReduceRemoveDuplicates) {
     auto blob = generate_query_data(num_queries);
 
     void* plan = nullptr;
-    auto status = CreateSearchPlanByExpr(
+    status = CreateSearchPlanByExpr(
         collection, plan_str.data(), plan_str.size(), &plan);
     ASSERT_EQ(status.error_code, Success);
 
@@ -1486,7 +1522,9 @@ testReduceSearchWithExpr(int N, int topK, int num_queries) {
               << num_queries << ")" << std::endl;
 
     auto collection = NewCollection(get_default_schema_config());
-    auto segment = NewSegment(collection, Growing, -1);
+    CSegmentInterface segment;
+    auto status = NewSegment(collection, Growing, -1, &segment);
+    ASSERT_EQ(status.error_code, Success);
 
     auto schema = ((milvus::segcore::Collection*)collection)->get_schema();
     auto dataset = DataGen(schema, N);
@@ -1521,7 +1559,7 @@ testReduceSearchWithExpr(int N, int topK, int num_queries) {
     void* plan = nullptr;
     auto binary_plan =
         translate_text_plan_to_binary_plan(serialized_expr_plan.data());
-    auto status = CreateSearchPlanByExpr(
+    status = CreateSearchPlanByExpr(
         collection, binary_plan.data(), binary_plan.size(), &plan);
     ASSERT_EQ(status.error_code, Success);
 
@@ -1710,7 +1748,9 @@ TEST(CApiTest, Indexing_Without_Predicate) {
         generate_collection_schema(knowhere::metric::L2, DIM, false);
     auto collection = NewCollection(schema_string.c_str());
     auto schema = ((segcore::Collection*)collection)->get_schema();
-    auto segment = NewSegment(collection, Growing, -1);
+    CSegmentInterface segment;
+    auto status = NewSegment(collection, Growing, -1, &segment);
+    ASSERT_EQ(status.error_code, Success);
 
     auto N = ROW_COUNT;
     auto dataset = DataGen(schema, N);
@@ -1750,7 +1790,7 @@ TEST(CApiTest, Indexing_Without_Predicate) {
 
     // search on segment's small index
     void* plan = nullptr;
-    auto status = CreateSearchPlanByExpr(
+    status = CreateSearchPlanByExpr(
         collection, plan_str.data(), plan_str.size(), &plan);
     ASSERT_EQ(status.error_code, Success);
 
@@ -1852,7 +1892,9 @@ TEST(CApiTest, Indexing_Expr_Without_Predicate) {
         generate_collection_schema(knowhere::metric::L2, DIM, false);
     auto collection = NewCollection(schema_string.c_str());
     auto schema = ((segcore::Collection*)collection)->get_schema();
-    auto segment = NewSegment(collection, Growing, -1);
+    CSegmentInterface segment;
+    auto status = NewSegment(collection, Growing, -1, &segment);
+    ASSERT_EQ(status.error_code, Success);
 
     auto N = ROW_COUNT;
     auto dataset = DataGen(schema, N);
@@ -1892,7 +1934,7 @@ TEST(CApiTest, Indexing_Expr_Without_Predicate) {
     // search on segment's small index
     void* plan = nullptr;
     auto binary_plan = translate_text_plan_to_binary_plan(serialized_expr_plan);
-    auto status = CreateSearchPlanByExpr(
+    status = CreateSearchPlanByExpr(
         collection, binary_plan.data(), binary_plan.size(), &plan);
     ASSERT_EQ(status.error_code, Success);
 
@@ -1995,7 +2037,9 @@ TEST(CApiTest, Indexing_With_float_Predicate_Range) {
         generate_collection_schema(knowhere::metric::L2, DIM, false);
     auto collection = NewCollection(schema_string.c_str());
     auto schema = ((segcore::Collection*)collection)->get_schema();
-    auto segment = NewSegment(collection, Growing, -1);
+    CSegmentInterface segment;
+    auto status = NewSegment(collection, Growing, -1, &segment);
+    ASSERT_EQ(status.error_code, Success);
 
     auto N = ROW_COUNT;
     auto dataset = DataGen(schema, N);
@@ -2064,7 +2108,7 @@ TEST(CApiTest, Indexing_With_float_Predicate_Range) {
 
     // search on segment's small index
     void* plan = nullptr;
-    auto status = CreateSearchPlanByExpr(
+    status = CreateSearchPlanByExpr(
         collection, plan_str.data(), plan_str.size(), &plan);
     ASSERT_EQ(status.error_code, Success);
 
@@ -2167,7 +2211,9 @@ TEST(CApiTest, Indexing_Expr_With_float_Predicate_Range) {
         generate_collection_schema(knowhere::metric::L2, DIM, false);
     auto collection = NewCollection(schema_string.c_str());
     auto schema = ((segcore::Collection*)collection)->get_schema();
-    auto segment = NewSegment(collection, Growing, -1);
+   CSegmentInterface segment;
+    auto status = NewSegment(collection, Growing, -1, &segment);
+    ASSERT_EQ(status.error_code, Success);
 
     auto N = 1000 * 10;
     auto dataset = DataGen(schema, N);
@@ -2238,7 +2284,7 @@ TEST(CApiTest, Indexing_Expr_With_float_Predicate_Range) {
     // search on segment's small index
     void* plan = nullptr;
     auto binary_plan = translate_text_plan_to_binary_plan(serialized_expr_plan);
-    auto status = CreateSearchPlanByExpr(
+    status = CreateSearchPlanByExpr(
         collection, binary_plan.data(), binary_plan.size(), &plan);
     ASSERT_EQ(status.error_code, Success);
 
@@ -2341,7 +2387,9 @@ TEST(CApiTest, Indexing_With_float_Predicate_Term) {
         generate_collection_schema(knowhere::metric::L2, DIM, false);
     auto collection = NewCollection(schema_string.c_str());
     auto schema = ((segcore::Collection*)collection)->get_schema();
-    auto segment = NewSegment(collection, Growing, -1);
+    CSegmentInterface segment;
+    auto status = NewSegment(collection, Growing, -1, &segment);
+    ASSERT_EQ(status.error_code, Success);
 
     auto N = ROW_COUNT;
     auto dataset = DataGen(schema, N);
@@ -2404,7 +2452,7 @@ TEST(CApiTest, Indexing_With_float_Predicate_Term) {
 
     // search on segment's small index
     void* plan = nullptr;
-    auto status = CreateSearchPlanByExpr(
+    status = CreateSearchPlanByExpr(
         collection, plan_str.data(), plan_str.size(), &plan);
     ASSERT_EQ(status.error_code, Success);
 
@@ -2507,7 +2555,9 @@ TEST(CApiTest, Indexing_Expr_With_float_Predicate_Term) {
         generate_collection_schema(knowhere::metric::L2, DIM, false);
     auto collection = NewCollection(schema_string.c_str());
     auto schema = ((segcore::Collection*)collection)->get_schema();
-    auto segment = NewSegment(collection, Growing, -1);
+    CSegmentInterface segment;
+    auto status = NewSegment(collection, Growing, -1, &segment);
+    ASSERT_EQ(status.error_code, Success);
 
     auto N = 1000 * 10;
     auto dataset = DataGen(schema, N);
@@ -2571,7 +2621,7 @@ TEST(CApiTest, Indexing_Expr_With_float_Predicate_Term) {
     // search on segment's small index
     void* plan = nullptr;
     auto binary_plan = translate_text_plan_to_binary_plan(serialized_expr_plan);
-    auto status = CreateSearchPlanByExpr(
+    status = CreateSearchPlanByExpr(
         collection, binary_plan.data(), binary_plan.size(), &plan);
     ASSERT_EQ(status.error_code, Success);
 
@@ -2674,7 +2724,9 @@ TEST(CApiTest, Indexing_With_binary_Predicate_Range) {
         generate_collection_schema(knowhere::metric::JACCARD, DIM, true);
     auto collection = NewCollection(schema_string.c_str());
     auto schema = ((segcore::Collection*)collection)->get_schema();
-    auto segment = NewSegment(collection, Growing, -1);
+    CSegmentInterface segment;
+    auto status = NewSegment(collection, Growing, -1, &segment);
+    ASSERT_EQ(status.error_code, Success);
 
     auto N = ROW_COUNT;
     auto dataset = DataGen(schema, N);
@@ -2743,7 +2795,7 @@ TEST(CApiTest, Indexing_With_binary_Predicate_Range) {
 
     // search on segment's small index
     void* plan = nullptr;
-    auto status = CreateSearchPlanByExpr(
+    status = CreateSearchPlanByExpr(
         collection, plan_str.data(), plan_str.size(), &plan);
     ASSERT_EQ(status.error_code, Success);
 
@@ -2847,7 +2899,9 @@ TEST(CApiTest, Indexing_Expr_With_binary_Predicate_Range) {
         generate_collection_schema(knowhere::metric::JACCARD, DIM, true);
     auto collection = NewCollection(schema_string.c_str());
     auto schema = ((segcore::Collection*)collection)->get_schema();
-    auto segment = NewSegment(collection, Growing, -1);
+    CSegmentInterface segment;
+    auto status = NewSegment(collection, Growing, -1, &segment);
+    ASSERT_EQ(status.error_code, Success);
 
     auto N = ROW_COUNT;
     auto dataset = DataGen(schema, N);
@@ -2916,7 +2970,7 @@ TEST(CApiTest, Indexing_Expr_With_binary_Predicate_Range) {
     // search on segment's small index
     void* plan = nullptr;
     auto binary_plan = translate_text_plan_to_binary_plan(serialized_expr_plan);
-    auto status = CreateSearchPlanByExpr(
+    status = CreateSearchPlanByExpr(
         collection, binary_plan.data(), binary_plan.size(), &plan);
     ASSERT_EQ(status.error_code, Success);
 
@@ -3020,7 +3074,9 @@ TEST(CApiTest, Indexing_With_binary_Predicate_Term) {
         generate_collection_schema(knowhere::metric::JACCARD, DIM, true);
     auto collection = NewCollection(schema_string.c_str());
     auto schema = ((segcore::Collection*)collection)->get_schema();
-    auto segment = NewSegment(collection, Growing, -1);
+    CSegmentInterface segment;
+    auto status = NewSegment(collection, Growing, -1, &segment);
+    ASSERT_EQ(status.error_code, Success);
 
     auto N = ROW_COUNT;
     auto dataset = DataGen(schema, N);
@@ -3084,7 +3140,7 @@ TEST(CApiTest, Indexing_With_binary_Predicate_Term) {
 
     // search on segment's small index
     void* plan = nullptr;
-    auto status = CreateSearchPlanByExpr(
+    status = CreateSearchPlanByExpr(
         collection, plan_str.data(), plan_str.size(), &plan);
     ASSERT_EQ(status.error_code, Success);
 
@@ -3209,7 +3265,9 @@ TEST(CApiTest, Indexing_Expr_With_binary_Predicate_Term) {
         generate_collection_schema(knowhere::metric::JACCARD, DIM, true);
     auto collection = NewCollection(schema_string.c_str());
     auto schema = ((segcore::Collection*)collection)->get_schema();
-    auto segment = NewSegment(collection, Growing, -1);
+    CSegmentInterface segment;
+    auto status = NewSegment(collection, Growing, -1, &segment);
+    ASSERT_EQ(status.error_code, Success);
 
     auto N = ROW_COUNT;
     auto dataset = DataGen(schema, N);
@@ -3273,7 +3331,7 @@ TEST(CApiTest, Indexing_Expr_With_binary_Predicate_Term) {
     // search on segment's small index
     void* plan = nullptr;
     auto binary_plan = translate_text_plan_to_binary_plan(serialized_expr_plan);
-    auto status = CreateSearchPlanByExpr(
+    status = CreateSearchPlanByExpr(
         collection, binary_plan.data(), binary_plan.size(), &plan);
     ASSERT_EQ(status.error_code, Success);
 
@@ -3390,7 +3448,9 @@ TEST(CApiTest, Indexing_Expr_With_binary_Predicate_Term) {
 
 TEST(CApiTest, SealedSegmentTest) {
     auto collection = NewCollection(get_default_schema_config());
-    auto segment = NewSegment(collection, Sealed, -1);
+    CSegmentInterface segment;
+    auto status = NewSegment(collection, Sealed, -1, &segment);
+    ASSERT_EQ(status.error_code, Success);
 
     int N = 1000;
     std::default_random_engine e(67);
@@ -3414,7 +3474,9 @@ TEST(CApiTest, SealedSegment_search_float_Predicate_Range) {
         generate_collection_schema(knowhere::metric::L2, DIM, false);
     auto collection = NewCollection(schema_string.c_str());
     auto schema = ((segcore::Collection*)collection)->get_schema();
-    auto segment = NewSegment(collection, Sealed, -1);
+    CSegmentInterface segment;
+    auto status = NewSegment(collection, Sealed, -1, &segment);
+    ASSERT_EQ(status.error_code, Success);
 
     auto N = ROW_COUNT;
     auto dataset = DataGen(schema, N);
@@ -3472,7 +3534,7 @@ TEST(CApiTest, SealedSegment_search_float_Predicate_Range) {
 
     // search on segment's small index
     void* plan = nullptr;
-    auto status = CreateSearchPlanByExpr(
+    status = CreateSearchPlanByExpr(
         collection, plan_str.data(), plan_str.size(), &plan);
     ASSERT_EQ(status.error_code, Success);
 
@@ -3565,7 +3627,9 @@ TEST(CApiTest, SealedSegment_search_without_predicates) {
         generate_collection_schema(knowhere::metric::L2, DIM, false);
     auto collection = NewCollection(schema_string.c_str());
     auto schema = ((segcore::Collection*)collection)->get_schema();
-    auto segment = NewSegment(collection, Sealed, -1);
+    CSegmentInterface segment;
+    auto status = NewSegment(collection, Sealed, -1, &segment);
+    ASSERT_EQ(status.error_code, Success);
 
     auto N = ROW_COUNT;
     uint64_t ts_offset = 1000;
@@ -3590,7 +3654,7 @@ TEST(CApiTest, SealedSegment_search_without_predicates) {
         >)";
     auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
 
-    auto status = LoadFieldRawData(segment, 100, vec_data.data(), N);
+    status = LoadFieldRawData(segment, 100, vec_data.data(), N);
     ASSERT_EQ(status.error_code, Success);
 
     status = LoadFieldRawData(segment, 101, counter_col.data(), N);
@@ -3641,7 +3705,9 @@ TEST(CApiTest, SealedSegment_search_float_With_Expr_Predicate_Range) {
         generate_collection_schema(knowhere::metric::L2, DIM, false);
     auto collection = NewCollection(schema_string.c_str());
     auto schema = ((segcore::Collection*)collection)->get_schema();
-    auto segment = NewSegment(collection, Sealed, -1);
+    CSegmentInterface segment;
+    auto status = NewSegment(collection, Sealed, -1, &segment);
+    ASSERT_EQ(status.error_code, Success);
 
     auto N = ROW_COUNT;
     auto dataset = DataGen(schema, N);
@@ -3699,7 +3765,7 @@ TEST(CApiTest, SealedSegment_search_float_With_Expr_Predicate_Range) {
     // search on segment's small index
     void* plan = nullptr;
     auto binary_plan = translate_text_plan_to_binary_plan(serialized_expr_plan);
-    auto status = CreateSearchPlanByExpr(
+    status = CreateSearchPlanByExpr(
         collection, binary_plan.data(), binary_plan.size(), &plan);
     ASSERT_EQ(status.error_code, Success);
 
@@ -4012,7 +4078,9 @@ TEST(CApiTest, RetriveScalarFieldFromSealedSegmentWithIndex) {
 
 TEST(CApiTest, RANGE_SEARCH_WITH_RADIUS_WHEN_IP) {
     auto c_collection = NewCollection(get_default_schema_config());
-    auto segment = NewSegment(c_collection, Growing, -1);
+    CSegmentInterface segment;
+    auto status = NewSegment(c_collection, Growing, -1, &segment);
+    ASSERT_EQ(status.error_code, Success);
     auto col = (milvus::segcore::Collection*)c_collection;
 
     int N = 10000;
@@ -4048,7 +4116,7 @@ TEST(CApiTest, RANGE_SEARCH_WITH_RADIUS_WHEN_IP) {
     auto blob = generate_query_data(num_queries);
 
     void* plan = nullptr;
-    auto status = CreateSearchPlanByExpr(
+    status = CreateSearchPlanByExpr(
         c_collection, plan_str.data(), plan_str.size(), &plan);
     ASSERT_EQ(status.error_code, Success);
 
@@ -4073,7 +4141,9 @@ TEST(CApiTest, RANGE_SEARCH_WITH_RADIUS_WHEN_IP) {
 
 TEST(CApiTest, RANGE_SEARCH_WITH_RADIUS_AND_RANGE_FILTER_WHEN_IP) {
     auto c_collection = NewCollection(get_default_schema_config());
-    auto segment = NewSegment(c_collection, Growing, -1);
+    CSegmentInterface segment;
+    auto status = NewSegment(c_collection, Growing, -1, &segment);
+    ASSERT_EQ(status.error_code, Success);
     auto col = (milvus::segcore::Collection*)c_collection;
 
     int N = 10000;
@@ -4109,7 +4179,7 @@ TEST(CApiTest, RANGE_SEARCH_WITH_RADIUS_AND_RANGE_FILTER_WHEN_IP) {
     auto blob = generate_query_data(num_queries);
 
     void* plan = nullptr;
-    auto status = CreateSearchPlanByExpr(
+    status = CreateSearchPlanByExpr(
         c_collection, plan_str.data(), plan_str.size(), &plan);
     ASSERT_EQ(status.error_code, Success);
 
@@ -4134,7 +4204,9 @@ TEST(CApiTest, RANGE_SEARCH_WITH_RADIUS_AND_RANGE_FILTER_WHEN_IP) {
 
 TEST(CApiTest, RANGE_SEARCH_WITH_RADIUS_WHEN_L2) {
     auto c_collection = NewCollection(get_default_schema_config());
-    auto segment = NewSegment(c_collection, Growing, -1);
+    CSegmentInterface segment;
+    auto status = NewSegment(c_collection, Growing, -1, &segment);
+    ASSERT_EQ(status.error_code, Success);
     auto col = (milvus::segcore::Collection*)c_collection;
 
     int N = 10000;
@@ -4170,7 +4242,7 @@ TEST(CApiTest, RANGE_SEARCH_WITH_RADIUS_WHEN_L2) {
     auto blob = generate_query_data(num_queries);
 
     void* plan = nullptr;
-    auto status = CreateSearchPlanByExpr(
+    status = CreateSearchPlanByExpr(
         c_collection, plan_str.data(), plan_str.size(), &plan);
     ASSERT_EQ(status.error_code, Success);
 
@@ -4195,7 +4267,9 @@ TEST(CApiTest, RANGE_SEARCH_WITH_RADIUS_WHEN_L2) {
 
 TEST(CApiTest, RANGE_SEARCH_WITH_RADIUS_AND_RANGE_FILTER_WHEN_L2) {
     auto c_collection = NewCollection(get_default_schema_config());
-    auto segment = NewSegment(c_collection, Growing, -1);
+    CSegmentInterface segment;
+    auto status = NewSegment(c_collection, Growing, -1, &segment);
+    ASSERT_EQ(status.error_code, Success);
     auto col = (milvus::segcore::Collection*)c_collection;
 
     int N = 10000;
@@ -4231,7 +4305,7 @@ TEST(CApiTest, RANGE_SEARCH_WITH_RADIUS_AND_RANGE_FILTER_WHEN_L2) {
     auto blob = generate_query_data(num_queries);
 
     void* plan = nullptr;
-    auto status = CreateSearchPlanByExpr(
+    status = CreateSearchPlanByExpr(
         c_collection, plan_str.data(), plan_str.size(), &plan);
     ASSERT_EQ(status.error_code, Success);
 

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -185,9 +185,8 @@ func NewSegment(collection *Collection,
 		return nil, fmt.Errorf("illegal segment type %d when create segment %d", segmentType, segmentID)
 	}
 
-	result := C.NewSegment(collection.collectionPtr, cSegType, C.int64_t(segmentID))
-	status := result.status
-	segmentPtr := result.segmentPtr
+	var newPtr C.CSegmentInterface
+	status := C.NewSegment(collection.collectionPtr, cSegType, C.int64_t(segmentID), &newPtr)
 
 	if err := HandleCStatus(&status, "NewSegmentFailed"); err != nil {
 		return nil, err
@@ -201,7 +200,7 @@ func NewSegment(collection *Collection,
 
 	segment := &LocalSegment{
 		baseSegment:        newBaseSegment(segmentID, partitionID, collectionID, shard, segmentType, version, startPosition),
-		ptr:                segmentPtr,
+		ptr:                newPtr,
 		lastDeltaTimestamp: atomic.NewUint64(0),
 		fieldIndexes:       typeutil.NewConcurrentMap[int64, *IndexedFieldInfo](),
 

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -169,8 +169,8 @@ func NewSegment(collection *Collection,
 	level datapb.SegmentLevel,
 ) (Segment, error) {
 	/*
-		CNewSegmentResult
-		NewSegment(CCollection collection, uint64_t segment_id, SegmentType seg_type);
+		CStatus
+		NewSegment(CCollection collection, uint64_t segment_id, SegmentType seg_type, CSegmentInterface* newSegment);
 	*/
 	if level == datapb.SegmentLevel_L0 {
 		return NewL0Segment(collection, segmentID, partitionID, collectionID, shard, segmentType, version, startPosition, deltaPosition)


### PR DESCRIPTION
See also #28795

Orignal `C.NewSegment` may panic if some condition is not met, this pr changes response struct to `CNewSegmentResult`, which contains `C.CStatus` and may return catched exception