### PR TITLE
enhance: add 3 builtin roles

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/klauspost/compress v1.16.7
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
-	github.com/milvus-io/milvus-proto/go-api/v2 v2.3.4-0.20231114080011-9a495865219e
+	github.com/milvus-io/milvus-proto/go-api/v2 v2.3.4-0.20231208092431-02cbad30332f
 	github.com/milvus-io/milvus/pkg v0.0.1
 	github.com/minio/minio-go/v7 v7.0.61
 	github.com/prometheus/client_golang v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -583,6 +583,8 @@ github.com/milvus-io/gorocksdb v0.0.0-20220624081344-8c5f4212846b h1:TfeY0NxYxZz
 github.com/milvus-io/gorocksdb v0.0.0-20220624081344-8c5f4212846b/go.mod h1:iwW+9cWfIzzDseEBCCeDSN5SD16Tidvy8cwQ7ZY8Qj4=
 github.com/milvus-io/milvus-proto/go-api/v2 v2.3.4-0.20231114080011-9a495865219e h1:IH1WAXwEF8vbwahPdupi4zzRNWViT4B7fZzIjtRLpG4=
 github.com/milvus-io/milvus-proto/go-api/v2 v2.3.4-0.20231114080011-9a495865219e/go.mod h1:1OIl0v5PQeNxIJhCvY+K55CBUOYDZevw9g9380u1Wek=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.3.4-0.20231208092431-02cbad30332f h1:0cAMN9OsgBxlEUY8i1e1ocrBZ/cpu/Kdguz4JWz9fUc=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.3.4-0.20231208092431-02cbad30332f/go.mod h1:1OIl0v5PQeNxIJhCvY+K55CBUOYDZevw9g9380u1Wek=
 github.com/milvus-io/milvus-storage/go v0.0.0-20231109072809-1cd7b0866092 h1:UYJ7JB+QlMOoFHNdd8mUa3/lV63t9dnBX7ILXmEEWPY=
 github.com/milvus-io/milvus-storage/go v0.0.0-20231109072809-1cd7b0866092/go.mod h1:GPETMcTZq1gLY1WA6Na5kiNAKnq8SEMMiVKUZrM3sho=
 github.com/milvus-io/pulsar-client-go v0.6.10 h1:eqpJjU+/QX0iIhEo3nhOqMNXL+TyInAs1IAHZCrCM/A=

--- a/internal/distributed/proxy/service.go
+++ b/internal/distributed/proxy/service.go
@@ -821,6 +821,11 @@ func (s *Server) CreateIndex(ctx context.Context, request *milvuspb.CreateIndexR
 	return s.proxy.CreateIndex(ctx, request)
 }
 
+func (s *Server) AlterIndex(ctx context.Context, request *milvuspb.AlterIndexRequest) (*commonpb.Status, error) {
+	// Todo
+	return nil, nil
+}
+
 // DropIndex notifies Proxy to drop index
 func (s *Server) DropIndex(ctx context.Context, request *milvuspb.DropIndexRequest) (*commonpb.Status, error) {
 	return s.proxy.DropIndex(ctx, request)
@@ -863,6 +868,11 @@ func (s *Server) Upsert(ctx context.Context, request *milvuspb.UpsertRequest) (*
 
 func (s *Server) Search(ctx context.Context, request *milvuspb.SearchRequest) (*milvuspb.SearchResults, error) {
 	return s.proxy.Search(ctx, request)
+}
+
+func (s *Server) SearchV2(ctx context.Context, request *milvuspb.SearchRequestV2) (*milvuspb.SearchResults, error) {
+	// Todo
+	return nil, nil
 }
 
 func (s *Server) Flush(ctx context.Context, request *milvuspb.FlushRequest) (*milvuspb.FlushResponse, error) {

--- a/internal/mocks/mock_proxy.go
+++ b/internal/mocks/mock_proxy.go
@@ -639,6 +639,11 @@ func (_c *MockProxy_CreateIndex_Call) RunAndReturn(run func(context.Context, *mi
 	return _c
 }
 
+func (_m *MockProxy) AlterIndex(_a0 context.Context, _a1 *milvuspb.AlterIndexRequest) (*commonpb.Status, error) {
+	// Todo
+	return nil, nil
+}
+
 // CreatePartition provides a mock function with given fields: _a0, _a1
 func (_m *MockProxy) CreatePartition(_a0 context.Context, _a1 *milvuspb.CreatePartitionRequest) (*commonpb.Status, error) {
 	ret := _m.Called(_a0, _a1)
@@ -4553,6 +4558,11 @@ func (_c *MockProxy_Search_Call) Return(_a0 *milvuspb.SearchResults, _a1 error) 
 func (_c *MockProxy_Search_Call) RunAndReturn(run func(context.Context, *milvuspb.SearchRequest) (*milvuspb.SearchResults, error)) *MockProxy_Search_Call {
 	_c.Call.Return(run)
 	return _c
+}
+
+func (_m *MockProxy) SearchV2(_a0 context.Context, _a1 *milvuspb.SearchRequestV2) (*milvuspb.SearchResults, error) {
+	// Todo
+	return nil, nil
 }
 
 // SelectGrant provides a mock function with given fields: _a0, _a1

--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -1814,6 +1814,11 @@ func (node *Proxy) CreateIndex(ctx context.Context, request *milvuspb.CreateInde
 	return cit.result, nil
 }
 
+func (node *Proxy) AlterIndex(ctx context.Context, request *milvuspb.AlterIndexRequest) (*commonpb.Status, error) {
+	// Todo
+	return nil, nil
+}
+
 // DescribeIndex get the meta information of index, such as index state, index id and etc.
 func (node *Proxy) DescribeIndex(ctx context.Context, request *milvuspb.DescribeIndexRequest) (*milvuspb.DescribeIndexResponse, error) {
 	if err := merr.CheckHealthy(node.GetStateCode()); err != nil {
@@ -2647,6 +2652,11 @@ func (node *Proxy) Search(ctx context.Context, request *milvuspb.SearchRequest) 
 		rateCol.Add(metricsinfo.ReadResultThroughput, float64(sentSize))
 	}
 	return qt.result, nil
+}
+
+func (node *Proxy) SearchV2(ctx context.Context, request *milvuspb.SearchRequestV2) (*milvuspb.SearchResults, error) {
+	// Todo
+	return nil, nil
 }
 
 func (node *Proxy) getVectorPlaceholderGroupForSearchByPks(ctx context.Context, request *milvuspb.SearchRequest) ([]byte, error) {
@@ -4223,7 +4233,7 @@ func (node *Proxy) DropRole(ctx context.Context, req *milvuspb.DropRoleRequest) 
 		return merr.Status(err), nil
 	}
 	if IsDefaultRole(req.RoleName) {
-		err := merr.WrapErrPrivilegeNotPermitted("the role[%s] is a default role, which can't be droped", req.GetRoleName())
+		err := merr.WrapErrPrivilegeNotPermitted("the role[%s] is a default role, which can't be dropped", req.GetRoleName())
 		return merr.Status(err), nil
 	}
 	result, err := node.rootCoord.DropRole(ctx, req)

--- a/internal/proxy/privilege_interceptor.go
+++ b/internal/proxy/privilege_interceptor.go
@@ -168,7 +168,7 @@ func PrivilegeInterceptor(ctx context.Context, req interface{}) (context.Context
 	}
 
 	log.Info("permission deny", zap.Strings("roles", roleNames))
-	return ctx, status.Error(codes.PermissionDenied, fmt.Sprintf("%s: permission deny", objectPrivilege))
+	return ctx, status.Error(codes.PermissionDenied, fmt.Sprintf("%s: permission deny to %s", objectPrivilege, username))
 }
 
 // isCurUserObject Determine whether it is an Object of type User that operates on its own user information,

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/klauspost/compress v1.16.5
 	github.com/lingdor/stackerror v0.0.0-20191119040541-976d8885ed76
-	github.com/milvus-io/milvus-proto/go-api/v2 v2.3.4-0.20231114080011-9a495865219e
+	github.com/milvus-io/milvus-proto/go-api/v2 v2.3.4-0.20231208092431-02cbad30332f
 	github.com/nats-io/nats-server/v2 v2.9.17
 	github.com/nats-io/nats.go v1.24.0
 	github.com/panjf2000/ants/v2 v2.7.2

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -481,6 +481,8 @@ github.com/milvus-io/milvus-proto/go-api/v2 v2.3.2-0.20231008032233-5d64d443769d
 github.com/milvus-io/milvus-proto/go-api/v2 v2.3.2-0.20231008032233-5d64d443769d/go.mod h1:1OIl0v5PQeNxIJhCvY+K55CBUOYDZevw9g9380u1Wek=
 github.com/milvus-io/milvus-proto/go-api/v2 v2.3.4-0.20231114080011-9a495865219e h1:IH1WAXwEF8vbwahPdupi4zzRNWViT4B7fZzIjtRLpG4=
 github.com/milvus-io/milvus-proto/go-api/v2 v2.3.4-0.20231114080011-9a495865219e/go.mod h1:1OIl0v5PQeNxIJhCvY+K55CBUOYDZevw9g9380u1Wek=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.3.4-0.20231208092431-02cbad30332f h1:0cAMN9OsgBxlEUY8i1e1ocrBZ/cpu/Kdguz4JWz9fUc=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.3.4-0.20231208092431-02cbad30332f/go.mod h1:1OIl0v5PQeNxIJhCvY+K55CBUOYDZevw9g9380u1Wek=
 github.com/milvus-io/pulsar-client-go v0.6.10 h1:eqpJjU+/QX0iIhEo3nhOqMNXL+TyInAs1IAHZCrCM/A=
 github.com/milvus-io/pulsar-client-go v0.6.10/go.mod h1:lQqCkgwDF8YFYjKA+zOheTk1tev2B+bKj5j7+nm8M1w=
 github.com/minio/highwayhash v1.0.2 h1:Aak5U0nElisjDCfPSG79Tgzkn2gl66NxOMspRrKnA/g=

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -61,6 +61,12 @@ const (
 
 	IdentifierKey = "identifier"
 	HeaderDBName  = "dbName"
+
+	RoleConfigPrivileges = "privileges"
+	RoleConfigObjectType = "object_type"
+	RoleConfigObjectName = "object_name"
+	RoleConfigDBName     = "db_name"
+	RoleConfigPrivilege  = "privilege"
 )
 
 const (
@@ -70,6 +76,7 @@ const (
 
 var (
 	DefaultRoles = []string{RoleAdmin, RolePublic}
+	BuiltinRoles = []string{}
 
 	ObjectPrivileges = map[string][]string{
 		commonpb.ObjectType_Collection.String(): {
@@ -118,6 +125,12 @@ var (
 			MetaStore2API(commonpb.ObjectPrivilege_PrivilegeCreateDatabase.String()),
 			MetaStore2API(commonpb.ObjectPrivilege_PrivilegeDropDatabase.String()),
 			MetaStore2API(commonpb.ObjectPrivilege_PrivilegeListDatabases.String()),
+
+			MetaStore2API(commonpb.ObjectPrivilege_PrivilegeCreatePartition.String()),
+			MetaStore2API(commonpb.ObjectPrivilege_PrivilegeDropPartition.String()),
+			MetaStore2API(commonpb.ObjectPrivilege_PrivilegeShowPartitions.String()),
+			MetaStore2API(commonpb.ObjectPrivilege_PrivilegeHasPartition.String()),
+			MetaStore2API(commonpb.ObjectPrivilege_PrivilegeGetFlushState.String()),
 		},
 		commonpb.ObjectType_User.String(): {
 			MetaStore2API(commonpb.ObjectPrivilege_PrivilegeUpdateUser.String()),
@@ -168,4 +181,13 @@ func PrivilegeNameForMetastore(name string) string {
 
 func IsAnyWord(word string) bool {
 	return word == AnyWord
+}
+
+func IsBuiltinRole(roleName string) bool {
+	for _, builtinRole := range BuiltinRoles {
+		if builtinRole == roleName {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/util/funcutil/policy_test.go
+++ b/pkg/util/funcutil/policy_test.go
@@ -20,7 +20,7 @@ func Test_GetPrivilegeExtObj(t *testing.T) {
 	assert.Equal(t, commonpb.ObjectPrivilege_PrivilegeLoad, privilegeExt.ObjectPrivilege)
 	assert.Equal(t, int32(3), privilegeExt.ObjectNameIndex)
 
-	request2 := &milvuspb.CreatePartitionRequest{}
+	request2 := &milvuspb.GetPartitionStatisticsRequest{}
 	_, err = GetPrivilegeExtObj(request2)
 	assert.Error(t, err)
 }

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -69,6 +69,7 @@ type ComponentParam struct {
 	IndexNodeCfg  indexNodeConfig
 	HTTPCfg       httpConfig
 	LogCfg        logConfig
+	RoleCfg       roleConfig
 
 	RootCoordGrpcServerCfg  GrpcServerConfig
 	ProxyGrpcServerCfg      GrpcServerConfig
@@ -116,6 +117,7 @@ func (p *ComponentParam) init(bt *BaseTable) {
 	p.IndexNodeCfg.init(bt)
 	p.HTTPCfg.init(bt)
 	p.LogCfg.init(bt)
+	p.RoleCfg.init(bt)
 
 	p.RootCoordGrpcServerCfg.Init("rootCoord", bt)
 	p.ProxyGrpcServerCfg.Init("proxy", bt)

--- a/pkg/util/paramtable/param_item.go
+++ b/pkg/util/paramtable/param_item.go
@@ -141,6 +141,10 @@ func (pi *ParamItem) GetAsJSONMap() map[string]string {
 	return getAndConvert(pi.GetValue(), funcutil.JSONToMap, nil)
 }
 
+func (pi *ParamItem) GetAsRoleDetails() map[string](map[string]([](map[string]string))) {
+	return getAndConvert(pi.GetValue(), funcutil.JSONToRoleDetails, nil)
+}
+
 type CompositeParamItem struct {
 	Items  []*ParamItem
 	Format func(map[string]string) string

--- a/pkg/util/paramtable/role_param.go
+++ b/pkg/util/paramtable/role_param.go
@@ -1,0 +1,45 @@
+package paramtable
+
+import (
+	"github.com/milvus-io/milvus/pkg/config"
+	"github.com/milvus-io/milvus/pkg/util/funcutil"
+)
+
+type roleConfig struct {
+	Enabled ParamItem `refreshable:"false"`
+	Roles   ParamItem `refreshable:"false"`
+}
+
+func (p *roleConfig) init(base *BaseTable) {
+	p.Enabled = ParamItem{
+		Key:          "builtinRoles.enable",
+		DefaultValue: "false",
+		Version:      "2.3.4",
+		Doc:          "Whether to init builtin roles",
+		Export:       true,
+	}
+	p.Enabled.Init(base.mgr)
+
+	p.Roles = ParamItem{
+		Key:          "builtinRoles.roles",
+		DefaultValue: `{}`,
+		Version:      "2.3.4",
+		Doc:          "what builtin roles should be init",
+		Export:       true,
+	}
+	p.Roles.Init(base.mgr)
+
+	p.panicIfNotValid(base.mgr)
+}
+
+func (p *roleConfig) panicIfNotValid(mgr *config.Manager) {
+	if p.Enabled.GetAsBool() {
+		m := p.Roles.GetAsRoleDetails()
+		if m == nil {
+			panic("builtinRoles.roles not invalid, should be json format")
+		}
+
+		j := funcutil.RoleDetailsToJSON(m)
+		mgr.SetConfig("builtinRoles.roles", string(j))
+	}
+}

--- a/pkg/util/paramtable/role_param_test.go
+++ b/pkg/util/paramtable/role_param_test.go
@@ -1,0 +1,57 @@
+package paramtable
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/pkg/config"
+)
+
+func TestRoleConfig_Init(t *testing.T) {
+	params := ComponentParam{}
+	params.Init(NewBaseTable(SkipRemote(true)))
+	cfg := &params.RoleCfg
+	assert.Equal(t, cfg.Enabled.GetAsBool(), false)
+	assert.Equal(t, cfg.Roles.GetValue(), "{}")
+	assert.Equal(t, len(cfg.Roles.GetAsJSONMap()), 0)
+}
+
+func TestRoleConfig_Invalid(t *testing.T) {
+	t.Run("valid roles", func(t *testing.T) {
+		mgr := config.NewManager()
+		mgr.SetConfig("builtinRoles.enable", "true")
+		mgr.SetConfig("builtinRoles.roles", `{"db_admin": {"privileges": [{"object_type": "Global", "object_name": "*", "privilege": "CreateCollection", "db_name": "*"}]}}`)
+		p := &roleConfig{
+			Enabled: ParamItem{
+				Key: "builtinRoles.enable",
+			},
+			Roles: ParamItem{
+				Key: "builtinRoles.roles",
+			},
+		}
+		p.Enabled.Init(mgr)
+		p.Roles.Init(mgr)
+		assert.NotPanics(t, func() {
+			p.panicIfNotValid(mgr)
+		})
+	})
+	t.Run("invalid roles", func(t *testing.T) {
+		mgr := config.NewManager()
+		mgr.SetConfig("builtinRoles.enable", "true")
+		mgr.SetConfig("builtinRoles.roles", `{"db_admin": {"privileges": {"object_type": "Global", "object_name": "*", "privilege": "CreateCollection", "db_name": "*"}}}`)
+		p := &roleConfig{
+			Enabled: ParamItem{
+				Key: "builtinRoles.enable",
+			},
+			Roles: ParamItem{
+				Key: "builtinRoles.roles",
+			},
+		}
+		p.Enabled.Init(mgr)
+		p.Roles.Init(mgr)
+		assert.Panics(t, func() {
+			p.panicIfNotValid(mgr)
+		})
+	})
+}


### PR DESCRIPTION
issue: #28960 [milvus-proto #212](https://github.com/milvus-io/milvus-proto/issues/212) #29243

add new configuration: builtinRoles
user can define roles in config file: `milvus.yaml`

there is an example:
1. db_ro, only have read privileges, include load
2. db_rw, read and write privileges, include create/drop/rename collection
3. db_admin, not only read and write privileges, but also user administration