### PR TITLE
enhance: [2.3] Use a non-blocking method to trigger compaction when saveBinlogPath is executed

### DIFF
--- a/internal/datacoord/compaction_trigger_test.go
+++ b/internal/datacoord/compaction_trigger_test.go
@@ -17,7 +17,9 @@
 package datacoord
 
 import (
+	"context"
 	"sort"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1986,6 +1988,78 @@ func Test_compactionTrigger_getCompactTime(t *testing.T) {
 	ct, err := got.getCompactTime(now, coll)
 	assert.NoError(t, err)
 	assert.NotNil(t, ct)
+}
+
+func Test_triggerSingleCompaction(t *testing.T) {
+	originValue := Params.DataCoordCfg.EnableAutoCompaction.GetValue()
+	Params.Save(Params.DataCoordCfg.EnableAutoCompaction.Key, "true")
+	defer func() {
+		Params.Save(Params.DataCoordCfg.EnableAutoCompaction.Key, originValue)
+	}()
+	m := &meta{segments: NewSegmentsInfo(), collections: make(map[UniqueID]*collectionInfo)}
+	got := newCompactionTrigger(m, &compactionPlanHandler{}, newMockAllocator(),
+		&ServerHandler{
+			&Server{
+				meta: m,
+			},
+		}, newMockVersionManager())
+	got.signals = make(chan *compactionSignal, 1)
+	{
+		err := got.triggerSingleCompaction(1, 1, 1, "a", false)
+		assert.NoError(t, err)
+	}
+	{
+		err := got.triggerSingleCompaction(2, 2, 2, "b", false)
+		assert.NoError(t, err)
+	}
+	var i atomic.Value
+	i.Store(0)
+	check := func() {
+		for {
+			select {
+			case signal := <-got.signals:
+				x := i.Load().(int)
+				i.Store(x + 1)
+				assert.EqualValues(t, 1, signal.collectionID)
+			default:
+				return
+			}
+		}
+	}
+	check()
+	assert.Equal(t, 1, i.Load().(int))
+
+	{
+		err := got.triggerSingleCompaction(3, 3, 3, "c", true)
+		assert.NoError(t, err)
+	}
+	var j atomic.Value
+	j.Store(0)
+	go func() {
+		timeoutCtx, cancelFunc := context.WithTimeout(context.Background(), time.Second)
+		defer cancelFunc()
+		for {
+			select {
+			case signal := <-got.signals:
+				x := j.Load().(int)
+				j.Store(x + 1)
+				if x == 0 {
+					assert.EqualValues(t, 3, signal.collectionID)
+				} else if x == 1 {
+					assert.EqualValues(t, 4, signal.collectionID)
+				}
+			case <-timeoutCtx.Done():
+				return
+			}
+		}
+	}()
+	{
+		err := got.triggerSingleCompaction(4, 4, 4, "d", true)
+		assert.NoError(t, err)
+	}
+	assert.Eventually(t, func() bool {
+		return j.Load().(int) == 2
+	}, 2*time.Second, 500*time.Millisecond)
 }
 
 type CompactionTriggerSuite struct {

--- a/internal/datacoord/mock_test.go
+++ b/internal/datacoord/mock_test.go
@@ -671,7 +671,7 @@ func (t *mockCompactionTrigger) triggerCompaction() error {
 }
 
 // triggerSingleCompaction trigerr a compaction bundled with collection-partiiton-channel-segment
-func (t *mockCompactionTrigger) triggerSingleCompaction(collectionID, partitionID, segmentID int64, channel string) error {
+func (t *mockCompactionTrigger) triggerSingleCompaction(collectionID, partitionID, segmentID int64, channel string, blockToSendSignal bool) error {
 	if f, ok := t.methods["triggerSingleCompaction"]; ok {
 		if ff, ok := f.(func(collectionID int64, partitionID int64, segmentID int64, channel string) error); ok {
 			return ff(collectionID, partitionID, segmentID, channel)

--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -492,8 +492,7 @@ func (s *Server) SaveBinlogPaths(ctx context.Context, req *datapb.SaveBinlogPath
 		s.flushCh <- req.SegmentID
 
 		if !req.Importing && Params.DataCoordCfg.EnableCompaction.GetAsBool() {
-			err = s.compactionTrigger.triggerSingleCompaction(segment.GetCollectionID(), segment.GetPartitionID(),
-				segmentID, segment.GetInsertChannel())
+			err = s.compactionTrigger.triggerSingleCompaction(segment.GetCollectionID(), segment.GetPartitionID(), segmentID, segment.GetInsertChannel(), false)
 			if err != nil {
 				log.Warn("failed to trigger single compaction")
 			} else {


### PR DESCRIPTION
/kind improvement
issue: #28924
pr: #28941