### PR TITLE
enhance: Delete datanode metric after flowgraph released

### DIFF
--- a/pkg/metrics/datanode_metrics.go
+++ b/pkg/metrics/datanode_metrics.go
@@ -271,4 +271,9 @@ func CleanupDataNodeCollectionMetrics(nodeID int64, collectionID int64, channel 
 					collectionIDLabelName: fmt.Sprint(collectionID),
 				})
 	}
+
+	DataNodeFlowGraphBufferDataSize.Delete(prometheus.Labels{
+		nodeIDLabelName:       fmt.Sprint(nodeID),
+		collectionIDLabelName: fmt.Sprint(collectionID),
+	})
 }


### PR DESCRIPTION
`DataNodeFlowGraphBufferDataSize` monitoring metric is leaked. This PR resolve it.