### PR TITLE
feat: [pick] Add bypassing logic for ttMsg in flowgraph of DataNode(#28756)

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -424,6 +424,12 @@ dataNode:
       maxQueueLength: 16 # Maximum length of task queue in flowgraph
       maxParallelism: 1024 # Maximum number of tasks executed in parallel in the flowgraph
     maxParallelSyncTaskNum: 6 # Maximum number of sync tasks executed in parallel in each flush manager
+    skipMode:
+      # when there are only timetick msg in flowgraph for a while (longer than coldTime),
+      # flowGraph will turn on skip mode to skip most timeticks to reduce cost, especially there are a lot of channels
+      enable: true
+      skipNum: 4
+      coldTime: 60
   segment:
     insertBufSize: 16777216 # Max buffer size to flush for a single segment.
     deleteBufBytes: 67108864 # Max buffer size to flush del for a single channel

--- a/internal/util/flowgraph/node_test.go
+++ b/internal/util/flowgraph/node_test.go
@@ -56,6 +56,22 @@ func generateMsgPack() msgstream.MsgPack {
 	return msgPack
 }
 
+func generateInsertMsgPack() msgstream.MsgPack {
+	msgPack := msgstream.MsgPack{}
+	insertMsg := &msgstream.InsertMsg{
+		BaseMsg: msgstream.BaseMsg{
+			BeginTimestamp: uint64(time.Now().Unix()),
+			EndTimestamp:   uint64(time.Now().Unix() + 1),
+			HashValues:     []uint32{0},
+		},
+		InsertRequest: msgpb.InsertRequest{
+			Base: &commonpb.MsgBase{MsgType: commonpb.MsgType_Insert},
+		},
+	}
+	msgPack.Msgs = append(msgPack.Msgs, insertMsg)
+	return msgPack
+}
+
 func TestNodeManager_Start(t *testing.T) {
 	t.Setenv("ROCKSMQ_PATH", "/tmp/MilvusTest/FlowGraph/TestNodeStart")
 	factory := dependency.NewDefaultFactory(true)

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -2466,6 +2466,11 @@ type dataNodeConfig struct {
 	FlowGraphMaxParallelism ParamItem `refreshable:"false"`
 	MaxParallelSyncTaskNum  ParamItem `refreshable:"false"`
 
+	// skip mode
+	FlowGraphSkipModeEnable   ParamItem `refreshable:"true"`
+	FlowGraphSkipModeSkipNum  ParamItem `refreshable:"true"`
+	FlowGraphSkipModeColdTime ParamItem `refreshable:"true"`
+
 	// segment
 	FlushInsertBufferSize  ParamItem `refreshable:"true"`
 	FlushDeleteBufferBytes ParamItem `refreshable:"true"`
@@ -2518,6 +2523,36 @@ func (p *dataNodeConfig) init(base *BaseTable) {
 		Export:       true,
 	}
 	p.FlowGraphMaxParallelism.Init(base.mgr)
+
+	p.FlowGraphSkipModeEnable = ParamItem{
+		Key:          "datanode.dataSync.skipMode.enable",
+		Version:      "2.3.4",
+		DefaultValue: "true",
+		PanicIfEmpty: false,
+		Doc:          "Support skip some timetick message to reduce CPU usage",
+		Export:       true,
+	}
+	p.FlowGraphSkipModeEnable.Init(base.mgr)
+
+	p.FlowGraphSkipModeSkipNum = ParamItem{
+		Key:          "datanode.dataSync.skipMode.skipNum",
+		Version:      "2.3.4",
+		DefaultValue: "5",
+		PanicIfEmpty: false,
+		Doc:          "Consume one for every n records skipped",
+		Export:       true,
+	}
+	p.FlowGraphSkipModeSkipNum.Init(base.mgr)
+
+	p.FlowGraphSkipModeColdTime = ParamItem{
+		Key:          "datanode.dataSync.skipMode.coldTime",
+		Version:      "2.3.4",
+		DefaultValue: "60",
+		PanicIfEmpty: false,
+		Doc:          "Turn on skip mode after there are only timetick msg for x seconds",
+		Export:       true,
+	}
+	p.FlowGraphSkipModeColdTime.Init(base.mgr)
 
 	p.MaxParallelSyncTaskNum = ParamItem{
 		Key:          "dataNode.dataSync.maxParallelSyncTaskNum",

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -372,6 +372,15 @@ func TestComponentParam(t *testing.T) {
 		maxParallelism := Params.FlowGraphMaxParallelism.GetAsInt()
 		t.Logf("flowGraphMaxParallelism: %d", maxParallelism)
 
+		flowGraphSkipModeEnable := Params.FlowGraphSkipModeEnable.GetAsBool()
+		t.Logf("flowGraphSkipModeEnable: %t", flowGraphSkipModeEnable)
+
+		flowGraphSkipModeSkipNum := Params.FlowGraphSkipModeSkipNum.GetAsInt()
+		t.Logf("flowGraphSkipModeSkipNum: %d", flowGraphSkipModeSkipNum)
+
+		flowGraphSkipModeColdTime := Params.FlowGraphSkipModeColdTime.GetAsInt()
+		t.Logf("flowGraphSkipModeColdTime: %d", flowGraphSkipModeColdTime)
+
 		maxParallelSyncTaskNum := Params.MaxParallelSyncTaskNum.GetAsInt()
 		t.Logf("maxParallelSyncTaskNum: %d", maxParallelSyncTaskNum)
 


### PR DESCRIPTION
In order to minimize the CPU usage of the coroutine and avoid frequent execution of time-consuming operations in the flowgraph when the message stream consists solely of "ttMsg," it is recommended to implement a mechanism for quickly bypassing the subsequent flowgraph node processing logic. 

If "ttMsg" is continuously received for a certain period of time (coldTime), the flowgraph enters skipMode. Once in skipMode, every skipNum "ttMsg" messages are merged into one for processing. If a non-"ttMsg" message is received while in skipMode, the flowgraph exits skipMode.

pr: #28756 