### PR TITLE
enhance: RESTFUL search api support range search

### DIFF
--- a/internal/distributed/proxy/httpserver/constant.go
+++ b/internal/distributed/proxy/httpserver/constant.go
@@ -54,5 +54,7 @@ const (
 	ParamRoundDecimal = "round_decimal"
 	ParamOffset       = "offset"
 	ParamLimit        = "limit"
+	ParamRadius       = "radius"
+	ParamRangeFilter  = "range_filter"
 	BoundedTimestamp  = 2
 )

--- a/internal/distributed/proxy/httpserver/handler_v1.go
+++ b/internal/distributed/proxy/httpserver/handler_v1.go
@@ -862,6 +862,24 @@ func (h *Handlers) search(c *gin.Context) {
 	params := map[string]interface{}{ // auto generated mapping
 		"level": int(commonpb.ConsistencyLevel_Bounded),
 	}
+	if httpReq.Params != nil {
+		radius, radiusOk := httpReq.Params[ParamRadius]
+		rangeFilter, rangeFilterOk := httpReq.Params[ParamRangeFilter]
+		if rangeFilterOk {
+			if !radiusOk {
+				log.Warn("high level restful api, search params invalid, because only " + ParamRangeFilter)
+				c.AbortWithStatusJSON(http.StatusOK, gin.H{
+					HTTPReturnCode:    merr.Code(merr.ErrIncorrectParameterFormat),
+					HTTPReturnMessage: merr.ErrIncorrectParameterFormat.Error() + ", error: invalid search params",
+				})
+				return
+			}
+			params[ParamRangeFilter] = rangeFilter
+		}
+		if radiusOk {
+			params[ParamRadius] = radius
+		}
+	}
 	bs, _ := json.Marshal(params)
 	searchParams := []*commonpb.KeyValuePair{
 		{Key: common.TopKKey, Value: strconv.FormatInt(int64(httpReq.Limit), 10)},

--- a/internal/distributed/proxy/httpserver/request.go
+++ b/internal/distributed/proxy/httpserver/request.go
@@ -63,11 +63,12 @@ type SingleUpsertReq struct {
 }
 
 type SearchReq struct {
-	DbName         string    `json:"dbName"`
-	CollectionName string    `json:"collectionName" validate:"required"`
-	Filter         string    `json:"filter"`
-	Limit          int32     `json:"limit"`
-	Offset         int32     `json:"offset"`
-	OutputFields   []string  `json:"outputFields"`
-	Vector         []float32 `json:"vector"`
+	DbName         string             `json:"dbName"`
+	CollectionName string             `json:"collectionName" validate:"required"`
+	Filter         string             `json:"filter"`
+	Limit          int32              `json:"limit"`
+	Offset         int32              `json:"offset"`
+	OutputFields   []string           `json:"outputFields"`
+	Vector         []float32          `json:"vector"`
+	Params         map[string]float64 `json:"params"`
 }


### PR DESCRIPTION
issue: #29004

add a new parameter: `params`, which is a map[string]float64;
but now only 2 valid item: radius + range_filter;