### PR TITLE
enhance: improve reducing results when many segments are filtered

### DIFF
--- a/internal/core/src/query/visitors/ExecPlanNodeVisitor.cpp
+++ b/internal/core/src/query/visitors/ExecPlanNodeVisitor.cpp
@@ -65,14 +65,8 @@ class ExecPlanNodeVisitor : PlanNodeVisitor {
 static SearchResult
 empty_search_result(int64_t num_queries, SearchInfo& search_info) {
     SearchResult final_result;
-    SubSearchResult result(num_queries,
-                           search_info.topk_,
-                           search_info.metric_type_,
-                           search_info.round_decimal_);
     final_result.total_nq_ = num_queries;
-    final_result.unity_topK_ = search_info.topk_;
-    final_result.seg_offsets_ = std::move(result.mutable_seg_offsets());
-    final_result.distances_ = std::move(result.mutable_distances());
+    final_result.unity_topK_ = 0;  // no result
     return final_result;
 }
 

--- a/internal/core/src/segcore/Reduce.cpp
+++ b/internal/core/src/segcore/Reduce.cpp
@@ -123,6 +123,10 @@ ReduceHelper::FillPrimaryKey() {
     // get primary keys for duplicates removal
     uint32_t valid_index = 0;
     for (auto& search_result : search_results_) {
+        // skip when results num is 0
+        if (search_result->unity_topK_ == 0) {
+            continue;
+        }
         FilterInvalidSearchResult(search_result);
         LOG_SEGCORE_DEBUG_ << "the size of search result"
                            << search_result->seg_offsets_.size();

--- a/internal/core/unittest/test_query.cpp
+++ b/internal/core/unittest/test_query.cpp
@@ -315,8 +315,14 @@ TEST(Query, ExecTerm) {
                                     predicates: <
                                       term_expr: <
                                         column_info: <
-                                          field_id: 101
-                                          data_type: Float
+                                          field_id: 102
+                                          data_type: Int64
+                                        >
+                                        values: <
+                                          int64_val: 1
+                                        >
+                                        values: <
+                                          int64_val: 2
                                         >
                                       >
                                     >
@@ -347,7 +353,6 @@ TEST(Query, ExecTerm) {
         ParsePlaceholderGroup(plan.get(), ph_group_raw.SerializeAsString());
 
     auto sr = segment->Search(plan.get(), ph_group.get());
-    std::vector<std::vector<std::string>> results;
     int topk = 5;
     auto json = SearchResultToJson(*sr);
     ASSERT_EQ(sr->total_nq_, num_queries);
@@ -383,6 +388,7 @@ TEST(Query, ExecEmpty) {
 
     auto sr = segment->Search(plan.get(), ph_group.get());
     std::cout << SearchResultToJson(*sr);
+    ASSERT_EQ(sr->unity_topK_, 0);
 
     for (auto i : sr->seg_offsets_) {
         ASSERT_EQ(i, -1);

--- a/internal/core/unittest/test_sealed.cpp
+++ b/internal/core/unittest/test_sealed.cpp
@@ -373,7 +373,7 @@ TEST(Sealed, with_predicate_filter_all) {
     hnsw_sealed_segment->LoadIndex(hnsw_load_info);
 
     auto sr2 = hnsw_sealed_segment->Search(plan.get(), ph_group.get());
-    EXPECT_EQ(sr->unity_topK_, 0);
+    EXPECT_EQ(sr2->unity_topK_, 0);
     EXPECT_EQ(sr2->get_total_result_count(), 0);
 }
 

--- a/internal/core/unittest/test_sealed.cpp
+++ b/internal/core/unittest/test_sealed.cpp
@@ -338,6 +338,7 @@ TEST(Sealed, with_predicate_filter_all) {
     ivf_sealed_segment->LoadIndex(load_info);
 
     auto sr = ivf_sealed_segment->Search(plan.get(), ph_group.get());
+    EXPECT_EQ(sr->unity_topK_, 0);
     EXPECT_EQ(sr->get_total_result_count(), 0);
 
     auto hnsw_conf =
@@ -372,6 +373,7 @@ TEST(Sealed, with_predicate_filter_all) {
     hnsw_sealed_segment->LoadIndex(hnsw_load_info);
 
     auto sr2 = hnsw_sealed_segment->Search(plan.get(), ph_group.get());
+    EXPECT_EQ(sr->unity_topK_, 0);
     EXPECT_EQ(sr2->get_total_result_count(), 0);
 }
 


### PR DESCRIPTION
Do not fill the invalid ids for the empty results, it will incur useless memory overhead and reduce overhead when nq and topk is large.