### PR TITLE
enhance: [skip e2e] give more build space for docker image build

### DIFF
--- a/.github/workflows/code-checker.yaml
+++ b/.github/workflows/code-checker.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Maximize build space
         uses: easimon/maximize-build-space@master
         with:
-          root-reserve-mb: 10240
+          root-reserve-mb: 20480
           swap-size-mb: 1024
           remove-dotnet: 'true'
           remove-android: 'true'
@@ -85,7 +85,7 @@ jobs:
       - name: Maximize build space
         uses: easimon/maximize-build-space@master
         with:
-          root-reserve-mb: 10240
+          root-reserve-mb: 20480
           swap-size-mb: 1024
           remove-dotnet: 'true'
           remove-android: 'true'

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Maximize build space
         uses: easimon/maximize-build-space@master
         with:
-          root-reserve-mb: 10240
+          root-reserve-mb: 20480
           swap-size-mb: 1024
           remove-dotnet: 'true'
           remove-android: 'true'


### PR DESCRIPTION
Since the installation of Rust in the Docker image, there is an increased requirement for disk space during the compilation process