### PR TITLE
enhance: [cherry-pick] Use zap.Stringer for large log field (#29143)

### DIFF
--- a/internal/proxy/segment.go
+++ b/internal/proxy/segment.go
@@ -317,7 +317,7 @@ func (sa *segIDAssigner) syncSegments() (bool, error) {
 		strconv.FormatInt(paramtable.GetNodeID(), 10)).Observe(float64(len(sa.segReqs)))
 	sa.segReqs = nil
 
-	log.Debug("syncSegments call dataCoord.AssignSegmentID", zap.String("request", req.String()))
+	log.Debug("syncSegments call dataCoord.AssignSegmentID", zap.Stringer("request", req))
 
 	resp, err := sa.dataCoord.AssignSegmentID(context.Background(), req)
 	if err != nil {

--- a/internal/proxy/task_search.go
+++ b/internal/proxy/task_search.go
@@ -349,7 +349,7 @@ func (t *searchTask) PreExecute(ctx context.Context) error {
 
 		log.Debug("Proxy::searchTask::PreExecute",
 			zap.Int64s("plan.OutputFieldIds", plan.GetOutputFieldIds()),
-			zap.String("plan", plan.String())) // may be very large if large term passed.
+			zap.Stringer("plan", plan)) // may be very large if large term passed.
 	}
 
 	// translate partition name to partition ids. Use regex-pattern to match partition name.


### PR DESCRIPTION
Cherry pick from master
pr: #29143
See also #29113
Using zap.Stringer log field will evaluate log field value only when log level meets the configuration, which could save some CPU time in search route