### PR TITLE
fix: [cherry-pick] bulkinsert binlog didn't consider ts order when processing delta data

### DIFF
--- a/internal/util/importutil/binlog_file_test.go
+++ b/internal/util/importutil/binlog_file_test.go
@@ -331,7 +331,7 @@ func Test_BinlogFileBool(t *testing.T) {
 	binlogFile.Close()
 
 	// wrong log type
-	chunkManager.readBuf["dummy"] = createDeltalogBuf(t, []int64{1}, false)
+	chunkManager.readBuf["dummy"] = createDeltalogBuf(t, []int64{1}, false, baseTimestamp)
 	err = binlogFile.Open("dummy")
 	assert.NoError(t, err)
 
@@ -388,7 +388,7 @@ func Test_BinlogFileInt8(t *testing.T) {
 	binlogFile.Close()
 
 	// wrong log type
-	chunkManager.readBuf["dummy"] = createDeltalogBuf(t, []int64{1}, false)
+	chunkManager.readBuf["dummy"] = createDeltalogBuf(t, []int64{1}, false, baseTimestamp)
 	err = binlogFile.Open("dummy")
 	assert.NoError(t, err)
 
@@ -446,7 +446,7 @@ func Test_BinlogFileInt16(t *testing.T) {
 	binlogFile.Close()
 
 	// wrong log type
-	chunkManager.readBuf["dummy"] = createDeltalogBuf(t, []int64{1}, false)
+	chunkManager.readBuf["dummy"] = createDeltalogBuf(t, []int64{1}, false, baseTimestamp)
 	err = binlogFile.Open("dummy")
 	assert.NoError(t, err)
 
@@ -503,7 +503,7 @@ func Test_BinlogFileInt32(t *testing.T) {
 	binlogFile.Close()
 
 	// wrong log type
-	chunkManager.readBuf["dummy"] = createDeltalogBuf(t, []int64{1}, false)
+	chunkManager.readBuf["dummy"] = createDeltalogBuf(t, []int64{1}, false, baseTimestamp)
 	err = binlogFile.Open("dummy")
 	assert.NoError(t, err)
 
@@ -560,7 +560,7 @@ func Test_BinlogFileInt64(t *testing.T) {
 	binlogFile.Close()
 
 	// wrong log type
-	chunkManager.readBuf["dummy"] = createDeltalogBuf(t, []int64{1}, false)
+	chunkManager.readBuf["dummy"] = createDeltalogBuf(t, []int64{1}, false, baseTimestamp)
 	err = binlogFile.Open("dummy")
 	assert.NoError(t, err)
 
@@ -617,7 +617,7 @@ func Test_BinlogFileFloat(t *testing.T) {
 	binlogFile.Close()
 
 	// wrong log type
-	chunkManager.readBuf["dummy"] = createDeltalogBuf(t, []int64{1}, false)
+	chunkManager.readBuf["dummy"] = createDeltalogBuf(t, []int64{1}, false, baseTimestamp)
 	err = binlogFile.Open("dummy")
 	assert.NoError(t, err)
 
@@ -674,7 +674,7 @@ func Test_BinlogFileDouble(t *testing.T) {
 	binlogFile.Close()
 
 	// wrong log type
-	chunkManager.readBuf["dummy"] = createDeltalogBuf(t, []int64{1}, false)
+	chunkManager.readBuf["dummy"] = createDeltalogBuf(t, []int64{1}, false, baseTimestamp)
 	err = binlogFile.Open("dummy")
 	assert.NoError(t, err)
 
@@ -778,7 +778,7 @@ func Test_BinlogFileJSON(t *testing.T) {
 	binlogFile.Close()
 
 	// wrong log type
-	chunkManager.readBuf["dummy"] = createDeltalogBuf(t, []int64{1}, false)
+	chunkManager.readBuf["dummy"] = createDeltalogBuf(t, []int64{1}, false, baseTimestamp)
 	err = binlogFile.Open("dummy")
 	assert.NoError(t, err)
 
@@ -858,7 +858,7 @@ func Test_BinlogFileArray(t *testing.T) {
 	binlogFile.Close()
 
 	// wrong log type
-	chunkManager.readBuf["dummy"] = createDeltalogBuf(t, []int64{1}, false)
+	chunkManager.readBuf["dummy"] = createDeltalogBuf(t, []int64{1}, false, baseTimestamp)
 	err = binlogFile.Open("dummy")
 	assert.NoError(t, err)
 
@@ -937,7 +937,7 @@ func Test_BinlogFileBinaryVector(t *testing.T) {
 	binlogFile.Close()
 
 	// wrong log type
-	chunkManager.readBuf["dummy"] = createDeltalogBuf(t, []int64{1}, false)
+	chunkManager.readBuf["dummy"] = createDeltalogBuf(t, []int64{1}, false, baseTimestamp)
 	err = binlogFile.Open("dummy")
 	assert.NoError(t, err)
 
@@ -1004,7 +1004,7 @@ func Test_BinlogFileFloatVector(t *testing.T) {
 	binlogFile.Close()
 
 	// wrong log type
-	chunkManager.readBuf["dummy"] = createDeltalogBuf(t, []int64{1}, false)
+	chunkManager.readBuf["dummy"] = createDeltalogBuf(t, []int64{1}, false, baseTimestamp)
 	err = binlogFile.Open("dummy")
 	assert.NoError(t, err)
 
@@ -1072,7 +1072,7 @@ func Test_BinlogFileFloat16Vector(t *testing.T) {
 	binlogFile.Close()
 
 	// wrong log type
-	chunkManager.readBuf["dummy"] = createDeltalogBuf(t, []int64{1}, false)
+	chunkManager.readBuf["dummy"] = createDeltalogBuf(t, []int64{1}, false, baseTimestamp)
 	err = binlogFile.Open("dummy")
 	assert.NoError(t, err)
 

--- a/internal/util/importutil/binlog_parser_test.go
+++ b/internal/util/importutil/binlog_parser_test.go
@@ -321,7 +321,7 @@ func Test_BinlogParserParse(t *testing.T) {
 
 	// progress
 	rowCount := 100
-	fieldsData := createFieldsData(sampleSchema(), rowCount)
+	fieldsData := createFieldsData(sampleSchema(), rowCount, baseTimestamp)
 	chunkManager.listResult["deltaPath"] = []string{}
 	chunkManager.listResult["insertPath"] = []string{
 		"123/0/a",

--- a/internal/util/importutil/import_util_test.go
+++ b/internal/util/importutil/import_util_test.go
@@ -240,7 +240,7 @@ func jsonNumber(value string) json.Number {
 	return json.Number(value)
 }
 
-func createFieldsData(collectionSchema *schemapb.CollectionSchema, rowCount int) map[storage.FieldID]interface{} {
+func createFieldsData(collectionSchema *schemapb.CollectionSchema, rowCount int, startTimestamp int64) map[storage.FieldID]interface{} {
 	fieldsData := make(map[storage.FieldID]interface{})
 
 	// internal fields
@@ -248,7 +248,7 @@ func createFieldsData(collectionSchema *schemapb.CollectionSchema, rowCount int)
 	timestampData := make([]int64, 0)
 	for i := 0; i < rowCount; i++ {
 		rowIDData = append(rowIDData, int64(i))
-		timestampData = append(timestampData, baseTimestamp+int64(i))
+		timestampData = append(timestampData, startTimestamp+int64(i))
 	}
 	fieldsData[0] = rowIDData
 	fieldsData[1] = timestampData
@@ -1083,7 +1083,7 @@ func Test_TryFlushBlocks(t *testing.T) {
 
 	// prepare flush data, 3 shards, each shard 10 rows
 	rowCount := 10
-	fieldsData := createFieldsData(schema, rowCount)
+	fieldsData := createFieldsData(schema, rowCount, baseTimestamp)
 	shardsData := createShardsData(schema, fieldsData, shardNum, []int64{partitionID})
 
 	t.Run("non-force flush", func(t *testing.T) {

--- a/internal/util/importutil/import_wrapper_test.go
+++ b/internal/util/importutil/import_wrapper_test.go
@@ -991,7 +991,7 @@ func Test_ImportWrapperFlushFunc(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	fieldsData := createFieldsData(schema, 5)
+	fieldsData := createFieldsData(schema, 5, baseTimestamp)
 	blockData := createBlockData(schema, fieldsData)
 	t.Run("fieldsData is not empty", func(t *testing.T) {
 		err = wrapper.flushFunc(blockData, shardID, partitionID)

--- a/internal/util/importutil/json_handler_test.go
+++ b/internal/util/importutil/json_handler_test.go
@@ -207,7 +207,7 @@ func Test_JSONRowConsumerHandleIntPK(t *testing.T) {
 		consumer.rowIDAllocator = newIDAllocator(ctx, t, errors.New("error"))
 
 		waitFlushRowCount := 10
-		fieldsData := createFieldsData(schema, waitFlushRowCount)
+		fieldsData := createFieldsData(schema, waitFlushRowCount, baseTimestamp)
 		consumer.shardsData = createShardsData(schema, fieldsData, shardNum, []int64{partitionID})
 
 		// nil input will trigger force flush, flushErrFunc returns error

--- a/internal/util/importutil/numpy_parser_test.go
+++ b/internal/util/importutil/numpy_parser_test.go
@@ -824,7 +824,7 @@ func Test_NumpyParserSplitFieldsData(t *testing.T) {
 	}
 
 	t.Run("shards number mismatch", func(t *testing.T) {
-		fieldsData := createFieldsData(sampleSchema(), 0)
+		fieldsData := createFieldsData(sampleSchema(), 0, baseTimestamp)
 		shards := createShardsData(sampleSchema(), fieldsData, 1, []int64{1})
 		segmentData := genFieldsDataFunc()
 		parser.autoIDRange, err = splitFieldsData(parser.collectionInfo, segmentData, shards, parser.rowIDAllocator)
@@ -861,7 +861,7 @@ func Test_NumpyParserSplitFieldsData(t *testing.T) {
 		}
 		parser.collectionInfo.resetSchema(schema)
 		parser.collectionInfo.ShardNum = 2
-		fieldsData := createFieldsData(schema, 0)
+		fieldsData := createFieldsData(schema, 0, baseTimestamp)
 		shards := createShardsData(schema, fieldsData, 2, []int64{1})
 		parser.autoIDRange, err = splitFieldsData(parser.collectionInfo, segmentData, shards, parser.rowIDAllocator)
 		assert.Error(t, err)
@@ -871,7 +871,7 @@ func Test_NumpyParserSplitFieldsData(t *testing.T) {
 		ctx := context.Background()
 		parser.rowIDAllocator = newIDAllocator(ctx, t, errors.New("dummy error"))
 		parser.collectionInfo.resetSchema(sampleSchema())
-		fieldsData := createFieldsData(sampleSchema(), 0)
+		fieldsData := createFieldsData(sampleSchema(), 0, baseTimestamp)
 		shards := createShardsData(sampleSchema(), fieldsData, 2, []int64{1})
 		segmentData := genFieldsDataFunc()
 		parser.autoIDRange, err = splitFieldsData(parser.collectionInfo, segmentData, shards, parser.rowIDAllocator)
@@ -885,7 +885,7 @@ func Test_NumpyParserSplitFieldsData(t *testing.T) {
 		schema.AutoID = true
 
 		partitionID := int64(1)
-		fieldsData := createFieldsData(sampleSchema(), 0)
+		fieldsData := createFieldsData(sampleSchema(), 0, baseTimestamp)
 		shards := createShardsData(sampleSchema(), fieldsData, 2, []int64{partitionID})
 		segmentData := genFieldsDataFunc()
 		parser.autoIDRange, err = splitFieldsData(parser.collectionInfo, segmentData, shards, parser.rowIDAllocator)
@@ -929,7 +929,7 @@ func Test_NumpyParserSplitFieldsData(t *testing.T) {
 			},
 		}
 		parser.collectionInfo.resetSchema(schema)
-		fieldsData := createFieldsData(schema, 0)
+		fieldsData := createFieldsData(schema, 0, baseTimestamp)
 		shards := createShardsData(schema, fieldsData, 2, []int64{1})
 		segmentData := make(BlockData)
 		segmentData[101] = &storage.Int64FieldData{
@@ -1198,7 +1198,7 @@ func Test_NumpyParserHashToPartition(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, parser)
 
-	fieldsData := createFieldsData(schema, 5)
+	fieldsData := createFieldsData(schema, 5, baseTimestamp)
 	blockData := createBlockData(schema, fieldsData)
 
 	// no partition key, partition ID list greater than 1, return error


### PR DESCRIPTION
issue: #29162
pr: #29163
