### PR TITLE
feat: enable balance based on growing segment row count (#28623)

### DIFF
--- a/internal/proto/query_coord.proto
+++ b/internal/proto/query_coord.proto
@@ -501,6 +501,7 @@ message LeaderView {
   repeated int64 growing_segmentIDs = 4;
   map<int64, msg.MsgPosition> growing_segments = 5;
   int64 TargetVersion = 6;
+  int64 num_of_growing_rows = 7;
 }
 
 message SegmentDist {

--- a/internal/querycoordv2/balance/score_based_balancer_test.go
+++ b/internal/querycoordv2/balance/score_based_balancer_test.go
@@ -18,6 +18,7 @@ package balance
 import (
 	"testing"
 
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
@@ -231,6 +232,48 @@ func (suite *ScoreBasedBalancerTestSuite) TestAssignSegment() {
 				suite.ElementsMatch(c.expectPlans[i], plans)
 			}
 		})
+	}
+}
+
+func (suite *ScoreBasedBalancerTestSuite) TestAssignSegmentWithGrowing() {
+	suite.SetupSuite()
+	defer suite.TearDownTest()
+	balancer := suite.balancer
+
+	distributions := map[int64][]*meta.Segment{
+		1: {
+			{SegmentInfo: &datapb.SegmentInfo{ID: 1, NumOfRows: 20, CollectionID: 1}, Node: 1},
+		},
+		2: {
+			{SegmentInfo: &datapb.SegmentInfo{ID: 2, NumOfRows: 20, CollectionID: 1}, Node: 2},
+		},
+	}
+	for node, s := range distributions {
+		balancer.dist.SegmentDistManager.Update(node, s...)
+	}
+
+	for _, node := range lo.Keys(distributions) {
+		nodeInfo := session.NewNodeInfo(node, "127.0.0.1:0")
+		nodeInfo.UpdateStats(session.WithSegmentCnt(20))
+		nodeInfo.SetState(session.NodeStateNormal)
+		suite.balancer.nodeManager.Add(nodeInfo)
+	}
+
+	toAssign := []*meta.Segment{
+		{SegmentInfo: &datapb.SegmentInfo{ID: 3, NumOfRows: 10, CollectionID: 1}, Node: 3},
+		{SegmentInfo: &datapb.SegmentInfo{ID: 4, NumOfRows: 10, CollectionID: 1}, Node: 3},
+	}
+
+	// mock 50 growing row count in node 1, which is delegator, expect all segment assign to node 2
+	leaderView := &meta.LeaderView{
+		ID:               1,
+		CollectionID:     1,
+		NumOfGrowingRows: 50,
+	}
+	suite.balancer.dist.LeaderViewManager.Update(1, leaderView)
+	plans := balancer.AssignSegment(1, toAssign, lo.Keys(distributions))
+	for _, p := range plans {
+		suite.Equal(int64(2), p.To)
 	}
 }
 

--- a/internal/querycoordv2/dist/dist_handler.go
+++ b/internal/querycoordv2/dist/dist_handler.go
@@ -197,13 +197,14 @@ func (dh *distHandler) updateLeaderView(resp *querypb.GetDataDistributionRespons
 		}
 
 		view := &meta.LeaderView{
-			ID:              resp.GetNodeID(),
-			CollectionID:    lview.GetCollection(),
-			Channel:         lview.GetChannel(),
-			Version:         version,
-			Segments:        lview.GetSegmentDist(),
-			GrowingSegments: segments,
-			TargetVersion:   lview.TargetVersion,
+			ID:               resp.GetNodeID(),
+			CollectionID:     lview.GetCollection(),
+			Channel:          lview.GetChannel(),
+			Version:          version,
+			Segments:         lview.GetSegmentDist(),
+			GrowingSegments:  segments,
+			TargetVersion:    lview.TargetVersion,
+			NumOfGrowingRows: lview.GetNumOfGrowingRows(),
 		}
 		updates = append(updates, view)
 	}

--- a/internal/querycoordv2/meta/leader_view_manager_test.go
+++ b/internal/querycoordv2/meta/leader_view_manager_test.go
@@ -137,6 +137,10 @@ func (suite *LeaderViewManagerSuite) TestGetDist() {
 			suite.AssertChannelDist(shard, nodes)
 		}
 	}
+
+	// test get growing segments
+	segments := mgr.GetGrowingSegments(101, 1)
+	suite.Len(segments, 1)
 }
 
 func (suite *LeaderViewManagerSuite) TestGetLeader() {
@@ -156,6 +160,10 @@ func (suite *LeaderViewManagerSuite) TestGetLeader() {
 			suite.Equal(view, views[leader])
 		}
 	}
+
+	// Test GetByCollectionAndNode
+	leaders := mgr.GetByCollectionAndNode(101, 1)
+	suite.Len(leaders, 1)
 }
 
 func (suite *LeaderViewManagerSuite) AssertSegmentDist(segment int64, nodes []int64) bool {

--- a/internal/querynodev2/services.go
+++ b/internal/querynodev2/services.go
@@ -1283,6 +1283,7 @@ func (node *QueryNode) GetDataDistribution(ctx context.Context, req *querypb.Get
 			}
 		}
 
+		numOfGrowingRows := int64(0)
 		growingSegments := make(map[int64]*msgpb.MsgPosition)
 		for _, entry := range growing {
 			segment := node.manager.Segment.GetWithType(entry.SegmentID, segments.SegmentTypeGrowing)
@@ -1292,14 +1293,16 @@ func (node *QueryNode) GetDataDistribution(ctx context.Context, req *querypb.Get
 				continue
 			}
 			growingSegments[entry.SegmentID] = segment.StartPosition()
+			numOfGrowingRows += segment.InsertCount()
 		}
 
 		leaderViews = append(leaderViews, &querypb.LeaderView{
-			Collection:      delegator.Collection(),
-			Channel:         key,
-			SegmentDist:     sealedSegments,
-			GrowingSegments: growingSegments,
-			TargetVersion:   delegator.GetTargetVersion(),
+			Collection:       delegator.Collection(),
+			Channel:          key,
+			SegmentDist:      sealedSegments,
+			GrowingSegments:  growingSegments,
+			TargetVersion:    delegator.GetTargetVersion(),
+			NumOfGrowingRows: numOfGrowingRows,
 		})
 		return true
 	})


### PR DESCRIPTION
issue: #28622 
pr: #28623
query node with delegator will has more rows than other query node due to delgator loads all growing rows.
This PR enable the balance segment which based on the num of growing rows in leader view.