### PR TITLE
fix: load gets stuck  probably

### DIFF
--- a/internal/querycoordv2/observers/task_dispatcher.go
+++ b/internal/querycoordv2/observers/task_dispatcher.go
@@ -96,12 +96,12 @@ func (d *taskDispatcher[K]) schedule(ctx context.Context) {
 		case <-d.notifyCh:
 			d.tasks.Range(func(k K, submitted bool) bool {
 				if !submitted {
+					d.tasks.Insert(k, true)
 					d.pool.Submit(func() (any, error) {
 						d.taskRunner(ctx, k)
 						d.tasks.Remove(k)
 						return struct{}{}, nil
 					})
-					d.tasks.Insert(k, true)
 				}
 				return true
 			})


### PR DESCRIPTION
we found the load got stuck probably, and reviewed the logs.

the target observer seems not working, the reason is the taskDispatcher removes the task in a goroutine, and modifies the task status after committing the task into the goroutine pool, but this may happen after the task removed, which leads to the task will never be removed

related #29086