### PR TITLE
fix: donot set l0 segment as growing when savebinlogs

### DIFF
--- a/internal/datacoord/compaction_trigger.go
+++ b/internal/datacoord/compaction_trigger.go
@@ -309,7 +309,7 @@ func (t *compactionTrigger) reCalcSegmentMaxNumOfRows(collectionID UniqueID, isD
 	return t.estimateNonDiskSegmentPolicy(collMeta.Schema)
 }
 
-// TODO: Update segment info should be written back to Etcd.
+// TODO: Updated segment info should be written back to meta and etcd, write in here without lock is very dangerous
 func (t *compactionTrigger) updateSegmentMaxSize(segments []*SegmentInfo) (bool, error) {
 	if len(segments) == 0 {
 		return false, nil

--- a/internal/datacoord/compaction_trigger_test.go
+++ b/internal/datacoord/compaction_trigger_test.go
@@ -500,7 +500,7 @@ func Test_compactionTrigger_force(t *testing.T) {
 			_, err := tr.forceTriggerCompaction(tt.collectionID)
 			assert.Equal(t, tt.wantErr, err != nil)
 			// expect max row num =  2048*1024*1024/(128*4) = 4194304
-			assert.EqualValues(t, 4194304, tt.fields.meta.segments.GetSegments()[0].MaxRowNum)
+			assert.EqualValues(t, 300, tt.fields.meta.segments.GetSegments()[0].MaxRowNum)
 			spy := (tt.fields.compactionHandler).(*spyCompactionHandler)
 			<-spy.spyChan
 		})

--- a/internal/datacoord/meta_test.go
+++ b/internal/datacoord/meta_test.go
@@ -878,76 +878,39 @@ func Test_meta_SetSegmentImporting(t *testing.T) {
 }
 
 func Test_meta_GetSegmentsOfCollection(t *testing.T) {
-	type fields struct {
-		segments *SegmentsInfo
-	}
-	type args struct {
-		collectionID UniqueID
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		args   args
-		expect []*SegmentInfo
-	}{
-		{
-			"test get segments",
-			fields{
-				&SegmentsInfo{
-					map[int64]*SegmentInfo{
-						1: {
-							SegmentInfo: &datapb.SegmentInfo{
-								ID:           1,
-								CollectionID: 1,
-								State:        commonpb.SegmentState_Flushed,
-							},
-						},
-						2: {
-							SegmentInfo: &datapb.SegmentInfo{
-								ID:           2,
-								CollectionID: 1,
-								State:        commonpb.SegmentState_Growing,
-							},
-						},
-						3: {
-							SegmentInfo: &datapb.SegmentInfo{
-								ID:           3,
-								CollectionID: 2,
-								State:        commonpb.SegmentState_Flushed,
-							},
-						},
-					},
+	storedSegments := &SegmentsInfo{
+		map[int64]*SegmentInfo{
+			1: {
+				SegmentInfo: &datapb.SegmentInfo{
+					ID:           1,
+					CollectionID: 1,
+					State:        commonpb.SegmentState_Flushed,
 				},
 			},
-			args{
-				collectionID: 1,
-			},
-			[]*SegmentInfo{
-				{
-					SegmentInfo: &datapb.SegmentInfo{
-						ID:           1,
-						CollectionID: 1,
-						State:        commonpb.SegmentState_Flushed,
-					},
+			2: {
+				SegmentInfo: &datapb.SegmentInfo{
+					ID:           2,
+					CollectionID: 1,
+					State:        commonpb.SegmentState_Growing,
 				},
-				{
-					SegmentInfo: &datapb.SegmentInfo{
-						ID:           2,
-						CollectionID: 1,
-						State:        commonpb.SegmentState_Growing,
-					},
+			},
+			3: {
+				SegmentInfo: &datapb.SegmentInfo{
+					ID:           3,
+					CollectionID: 2,
+					State:        commonpb.SegmentState_Flushed,
 				},
 			},
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			m := &meta{
-				segments: tt.fields.segments,
-			}
-			got := m.GetSegmentsOfCollection(tt.args.collectionID)
-			assert.ElementsMatch(t, tt.expect, got)
-		})
+	expectedSeg := map[int64]commonpb.SegmentState{1: commonpb.SegmentState_Flushed, 2: commonpb.SegmentState_Growing}
+	m := &meta{segments: storedSegments}
+	got := m.GetSegmentsOfCollection(1)
+	assert.Equal(t, len(expectedSeg), len(got))
+	for _, gotInfo := range got {
+		expected, ok := expectedSeg[gotInfo.ID]
+		assert.True(t, ok)
+		assert.Equal(t, expected, gotInfo.GetState())
 	}
 }
 

--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -530,13 +530,11 @@ func (s *Server) SaveBinlogPaths(ctx context.Context, req *datapb.SaveBinlogPath
 		s.flushCh <- req.SegmentID
 
 		// notify compaction
-		if !req.Importing && Params.DataCoordCfg.EnableCompaction.GetAsBool() {
+		if !req.Importing && paramtable.Get().DataCoordCfg.EnableCompaction.GetAsBool() {
 			err := s.compactionTrigger.triggerSingleCompaction(req.GetCollectionID(), req.GetPartitionID(),
 				req.GetSegmentID(), req.GetChannel(), false)
 			if err != nil {
 				log.Warn("failed to trigger single compaction")
-			} else {
-				log.Info("compaction triggered for segment")
 			}
 		}
 	}

--- a/internal/datacoord/services_test.go
+++ b/internal/datacoord/services_test.go
@@ -237,7 +237,6 @@ func (s *ServerSuite) TestSaveBinlogPath_SaveDroppedSegment() {
 		{"segID=1, sealed to flushing", 1, false, true, commonpb.SegmentState_Flushing},
 	}
 
-	s.testServer.flushCh = make(chan int64, 1)
 	paramtable.Get().Save(paramtable.Get().DataCoordCfg.EnableAutoCompaction.Key, "False")
 	defer paramtable.Get().Reset(paramtable.Get().DataCoordCfg.EnableAutoCompaction.Key)
 	for _, test := range tests {

--- a/internal/datacoord/services_test.go
+++ b/internal/datacoord/services_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/metautil"
+	"github.com/milvus-io/milvus/pkg/util/paramtable"
 )
 
 type ServerSuite struct {
@@ -165,7 +166,8 @@ func (s *ServerSuite) TestSaveBinlogPath_SaveUnhealthySegment() {
 	s.testServer.meta.AddCollection(&collectionInfo{ID: 0})
 
 	segments := map[int64]commonpb.SegmentState{
-		0: commonpb.SegmentState_NotExist,
+		1: commonpb.SegmentState_NotExist,
+		2: commonpb.SegmentState_Dropped,
 	}
 	for segID, state := range segments {
 		info := &datapb.SegmentInfo{
@@ -177,64 +179,89 @@ func (s *ServerSuite) TestSaveBinlogPath_SaveUnhealthySegment() {
 		s.Require().NoError(err)
 	}
 
-	ctx := context.Background()
-	resp, err := s.testServer.SaveBinlogPaths(ctx, &datapb.SaveBinlogPathsRequest{
-		Base: &commonpb.MsgBase{
-			Timestamp: uint64(time.Now().Unix()),
-		},
-		SegmentID: 1,
-		Channel:   "ch1",
-	})
-	s.NoError(err)
-	s.ErrorIs(merr.Error(resp), merr.ErrSegmentNotFound)
+	tests := []struct {
+		description string
+		inSeg       int64
 
-	resp, err = s.testServer.SaveBinlogPaths(ctx, &datapb.SaveBinlogPathsRequest{
-		Base: &commonpb.MsgBase{
-			Timestamp: uint64(time.Now().Unix()),
-		},
-		SegmentID: 2,
-		Channel:   "ch1",
-	})
-	s.NoError(err)
-	s.ErrorIs(merr.Error(resp), merr.ErrSegmentNotFound)
+		expectedError error
+	}{
+		{"segment not exist", 1, merr.ErrSegmentNotFound},
+		{"segment dropped", 2, nil},
+		{"segment not in meta", 3, merr.ErrSegmentNotFound},
+	}
+
+	for _, test := range tests {
+		s.Run(test.description, func() {
+			ctx := context.Background()
+			resp, err := s.testServer.SaveBinlogPaths(ctx, &datapb.SaveBinlogPathsRequest{
+				Base: &commonpb.MsgBase{
+					Timestamp: uint64(time.Now().Unix()),
+				},
+				SegmentID: test.inSeg,
+				Channel:   "ch1",
+			})
+			s.NoError(err)
+			s.ErrorIs(merr.Error(resp), test.expectedError)
+		})
+	}
 }
 
 func (s *ServerSuite) TestSaveBinlogPath_SaveDroppedSegment() {
 	s.mockChMgr.EXPECT().Match(int64(0), "ch1").Return(true)
 	s.testServer.meta.AddCollection(&collectionInfo{ID: 0})
 
-	segments := map[int64]int64{
-		0: 0,
-		1: 0,
+	segments := map[int64]commonpb.SegmentState{
+		0: commonpb.SegmentState_Flushed,
+		1: commonpb.SegmentState_Sealed,
 	}
-	for segID, collID := range segments {
+	for segID, state := range segments {
 		info := &datapb.SegmentInfo{
 			ID:            segID,
-			CollectionID:  collID,
 			InsertChannel: "ch1",
-			State:         commonpb.SegmentState_Dropped,
+			State:         state,
+			Level:         datapb.SegmentLevel_L1,
 		}
 		err := s.testServer.meta.AddSegment(context.TODO(), NewSegmentInfo(info))
 		s.Require().NoError(err)
 	}
 
-	ctx := context.Background()
-	resp, err := s.testServer.SaveBinlogPaths(ctx, &datapb.SaveBinlogPathsRequest{
-		Base: &commonpb.MsgBase{
-			Timestamp: uint64(time.Now().Unix()),
-		},
-		SegmentID:    1,
-		CollectionID: 0,
-		Channel:      "ch1",
-		Flushed:      false,
-	})
-	s.NoError(err)
-	s.EqualValues(resp.ErrorCode, commonpb.ErrorCode_Success)
+	tests := []struct {
+		description string
+		inSegID     int64
+		inDropped   bool
+		inFlushed   bool
 
-	segment := s.testServer.meta.GetSegment(1)
-	s.NotNil(segment)
-	s.EqualValues(0, len(segment.GetBinlogs()))
-	s.EqualValues(segment.NumOfRows, 0)
+		expectedState commonpb.SegmentState
+	}{
+		{"segID=0, flushed to dropped", 0, true, false, commonpb.SegmentState_Dropped},
+		{"segID=1, sealed to flushing", 1, false, true, commonpb.SegmentState_Flushing},
+	}
+
+	s.testServer.flushCh = make(chan int64, 1)
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.EnableAutoCompaction.Key, "False")
+	defer paramtable.Get().Reset(paramtable.Get().DataCoordCfg.EnableAutoCompaction.Key)
+	for _, test := range tests {
+		s.Run(test.description, func() {
+			ctx := context.Background()
+			resp, err := s.testServer.SaveBinlogPaths(ctx, &datapb.SaveBinlogPathsRequest{
+				Base: &commonpb.MsgBase{
+					Timestamp: uint64(time.Now().Unix()),
+				},
+				SegmentID: test.inSegID,
+				Channel:   "ch1",
+				Flushed:   test.inFlushed,
+				Dropped:   test.inDropped,
+			})
+			s.NoError(err)
+			s.EqualValues(resp.ErrorCode, commonpb.ErrorCode_Success)
+
+			segment := s.testServer.meta.GetSegment(test.inSegID)
+			s.NotNil(segment)
+			s.EqualValues(0, len(segment.GetBinlogs()))
+			s.EqualValues(segment.NumOfRows, 0)
+			s.Equal(test.expectedState, segment.GetState())
+		})
+	}
 }
 
 func (s *ServerSuite) TestSaveBinlogPath_L0Segment() {

--- a/internal/proxy/multi_rate_limiter_test.go
+++ b/internal/proxy/multi_rate_limiter_test.go
@@ -306,12 +306,12 @@ func TestRateLimiter(t *testing.T) {
 		ctx := context.Background()
 		// avoid production precision issues when comparing 0-terminated numbers
 		newRate := fmt.Sprintf("%.2f1", rand.Float64())
-		etcdCli.KV.Put(ctx, "by-dev/config/quotaAndLimits/dml/insertRate/collection/max", "8")
-		defer etcdCli.KV.Delete(ctx, "by-dev/config/quotaAndLimits/dml/insertRate/collection/max")
 		etcdCli.KV.Put(ctx, "by-dev/config/quotaAndLimits/ddl/collectionRate", newRate)
 		defer etcdCli.KV.Delete(ctx, "by-dev/config/quotaAndLimits/ddl/collectionRate")
 		etcdCli.KV.Put(ctx, "by-dev/config/quotaAndLimits/ddl/partitionRate", "invalid")
 		defer etcdCli.KV.Delete(ctx, "by-dev/config/quotaAndLimits/ddl/partitionRate")
+		etcdCli.KV.Put(ctx, "by-dev/config/quotaAndLimits/dml/insertRate/collection/max", "8")
+		defer etcdCli.KV.Delete(ctx, "by-dev/config/quotaAndLimits/dml/insertRate/collection/max")
 
 		assert.Eventually(t, func() bool {
 			limit, _ := limiter.limiters.Get(internalpb.RateType_DDLCollection)


### PR DESCRIPTION
This PR fixes negative growing L0 segments in Metrics

See also: #29204, #30441