### PR TITLE
enhance: remove reset seed for every shuffle

### DIFF
--- a/internal/proxy/meta_cache.go
+++ b/internal/proxy/meta_cache.go
@@ -151,7 +151,6 @@ type shardLeadersReader struct {
 // Shuffle returns the shuffled shard leader list.
 func (it shardLeadersReader) Shuffle() map[string][]nodeInfo {
 	result := make(map[string][]nodeInfo)
-	rand.Seed(time.Now().UnixNano())
 	for channel, leaders := range it.leaders.shardLeaders {
 		l := len(leaders)
 		// shuffle all replica at random order


### PR DESCRIPTION
See also #29113
rand.Seed is deprecated and cost noticable CPU time during heavy payload