### PR TITLE
enhance: Enable balance channel in querycoord (#28469)

### DIFF
--- a/internal/querycoordv2/balance/rowcount_based_balancer_test.go
+++ b/internal/querycoordv2/balance/rowcount_based_balancer_test.go
@@ -248,34 +248,25 @@ func (suite *RowCountBasedBalancerTestSuite) TestBalance() {
 				{Channel: &meta.DmChannel{VchannelInfo: &datapb.VchannelInfo{CollectionID: 1, ChannelName: "v3"}, Node: 3}, From: 3, To: 1, ReplicaID: 1},
 			},
 		},
-		// {
-		// 	name:        "balance channel",
-		// 	nodes:       []int64{2, 3},
-		// 	segmentCnts: []int{2, 2},
-		// 	states:      []session.State{session.NodeStateNormal, session.NodeStateNormal},
-		// 	shouldMock:  true,
-		// 	distributions: map[int64][]*meta.Segment{
-		// 		2: {
-		// 			{SegmentInfo: &datapb.SegmentInfo{ID: 2, CollectionID: 1, NumOfRows: 20}, Node: 2},
-		// 			{SegmentInfo: &datapb.SegmentInfo{ID: 3, CollectionID: 1, NumOfRows: 30}, Node: 2},
-		// 		},
-		// 		3: {
-		// 			{SegmentInfo: &datapb.SegmentInfo{ID: 4, CollectionID: 1, NumOfRows: 10}, Node: 3},
-		// 			{SegmentInfo: &datapb.SegmentInfo{ID: 5, CollectionID: 1, NumOfRows: 10}, Node: 3},
-		// 		},
-		// 	},
-		// 	distributionChannels: map[int64][]*meta.DmChannel{
-		// 		2: {
-		// 			{VchannelInfo: &datapb.VchannelInfo{CollectionID: 1, ChannelName: "v2"}, Node: 2},
-		// 			{VchannelInfo: &datapb.VchannelInfo{CollectionID: 1, ChannelName: "v3"}, Node: 2},
-		// 		},
-		// 		3: {},
-		// 	},
-		// 	expectPlans: []SegmentAssignPlan{},
-		// 	expectChannelPlans: []ChannelAssignPlan{
-		// 		{Channel: &meta.DmChannel{VchannelInfo: &datapb.VchannelInfo{CollectionID: 1, ChannelName: "v2"}, Node: 2}, From: 2, To: 3, ReplicaID: 1},
-		// 	},
-		// },
+		{
+			name:          "balance channel",
+			nodes:         []int64{2, 3},
+			segmentCnts:   []int{2, 2},
+			states:        []session.State{session.NodeStateNormal, session.NodeStateNormal},
+			shouldMock:    true,
+			distributions: map[int64][]*meta.Segment{},
+			distributionChannels: map[int64][]*meta.DmChannel{
+				2: {
+					{VchannelInfo: &datapb.VchannelInfo{CollectionID: 1, ChannelName: "v2"}, Node: 2},
+					{VchannelInfo: &datapb.VchannelInfo{CollectionID: 1, ChannelName: "v3"}, Node: 2},
+				},
+				3: {},
+			},
+			expectPlans: []SegmentAssignPlan{},
+			expectChannelPlans: []ChannelAssignPlan{
+				{Channel: &meta.DmChannel{VchannelInfo: &datapb.VchannelInfo{CollectionID: 1, ChannelName: "v3"}, Node: 2}, From: 2, To: 3, ReplicaID: 1},
+			},
+		},
 		{
 			name:          "unbalance stable view",
 			nodes:         []int64{1, 2, 3},
@@ -298,26 +289,26 @@ func (suite *RowCountBasedBalancerTestSuite) TestBalance() {
 			expectPlans:        []SegmentAssignPlan{},
 			expectChannelPlans: []ChannelAssignPlan{},
 		},
-		// {
-		// 	name:          "balance unstable view",
-		// 	nodes:         []int64{1, 2, 3},
-		// 	segmentCnts:   []int{0, 0, 0},
-		// 	states:        []session.State{session.NodeStateNormal, session.NodeStateNormal, session.NodeStateNormal},
-		// 	shouldMock:    true,
-		// 	distributions: map[int64][]*meta.Segment{},
-		// 	distributionChannels: map[int64][]*meta.DmChannel{
-		// 		1: {
-		// 			{VchannelInfo: &datapb.VchannelInfo{CollectionID: 1, ChannelName: "v1"}, Node: 1},
-		// 			{VchannelInfo: &datapb.VchannelInfo{CollectionID: 1, ChannelName: "v2"}, Node: 1},
-		// 		},
-		// 		2: {},
-		// 		3: {},
-		// 	},
-		// 	expectPlans: []SegmentAssignPlan{},
-		// 	expectChannelPlans: []ChannelAssignPlan{
-		// 		{Channel: &meta.DmChannel{VchannelInfo: &datapb.VchannelInfo{CollectionID: 1, ChannelName: "v1"}, Node: 1}, From: 1, To: 2, ReplicaID: 1},
-		// 	},
-		// },
+		{
+			name:          "balance unstable view",
+			nodes:         []int64{1, 2, 3},
+			segmentCnts:   []int{0, 0, 0},
+			states:        []session.State{session.NodeStateNormal, session.NodeStateNormal, session.NodeStateNormal},
+			shouldMock:    true,
+			distributions: map[int64][]*meta.Segment{},
+			distributionChannels: map[int64][]*meta.DmChannel{
+				1: {
+					{VchannelInfo: &datapb.VchannelInfo{CollectionID: 1, ChannelName: "v1"}, Node: 1},
+					{VchannelInfo: &datapb.VchannelInfo{CollectionID: 1, ChannelName: "v2"}, Node: 1},
+				},
+				2: {},
+				3: {},
+			},
+			expectPlans: []SegmentAssignPlan{},
+			expectChannelPlans: []ChannelAssignPlan{
+				{Channel: &meta.DmChannel{VchannelInfo: &datapb.VchannelInfo{CollectionID: 1, ChannelName: "v2"}, Node: 1}, From: 1, To: 2, ReplicaID: 1},
+			},
+		},
 		{
 			name:            "already balanced",
 			nodes:           []int64{11, 22},
@@ -377,7 +368,7 @@ func (suite *RowCountBasedBalancerTestSuite) TestBalance() {
 			balancer.targetMgr.UpdateCollectionNextTarget(int64(1))
 			balancer.targetMgr.UpdateCollectionCurrentTarget(1)
 			balancer.targetMgr.UpdateCollectionNextTarget(int64(1))
-			suite.mockScheduler.Mock.On("GetNodeChannelDelta", mock.Anything).Return(0)
+			suite.mockScheduler.Mock.On("GetNodeChannelDelta", mock.Anything).Return(0).Maybe()
 			for node, s := range c.distributions {
 				balancer.dist.SegmentDistManager.Update(node, s...)
 			}
@@ -396,6 +387,14 @@ func (suite *RowCountBasedBalancerTestSuite) TestBalance() {
 			segmentPlans, channelPlans := suite.getCollectionBalancePlans(balancer, 1)
 			suite.ElementsMatch(c.expectChannelPlans, channelPlans)
 			suite.ElementsMatch(c.expectPlans, segmentPlans)
+
+			// clear distribution
+			for node := range c.distributions {
+				balancer.dist.SegmentDistManager.Update(node)
+			}
+			for node := range c.distributionChannels {
+				balancer.dist.ChannelDistManager.Update(node)
+			}
 		})
 	}
 }
@@ -576,7 +575,7 @@ func (suite *RowCountBasedBalancerTestSuite) TestBalanceOnPartStopping() {
 			suite.broker.ExpectedCalls = nil
 			suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(nil, c.segmentInNext, nil)
 			balancer.targetMgr.UpdateCollectionNextTarget(int64(1))
-			suite.mockScheduler.Mock.On("GetNodeChannelDelta", mock.Anything).Return(0)
+			suite.mockScheduler.Mock.On("GetNodeChannelDelta", mock.Anything).Return(0).Maybe()
 			for node, s := range c.distributions {
 				balancer.dist.SegmentDistManager.Update(node, s...)
 			}
@@ -646,7 +645,7 @@ func (suite *RowCountBasedBalancerTestSuite) TestBalanceOutboundNodes() {
 		},
 	}
 
-	suite.mockScheduler.Mock.On("GetNodeChannelDelta", mock.Anything).Return(0)
+	suite.mockScheduler.Mock.On("GetNodeChannelDelta", mock.Anything).Return(0).Maybe()
 	for _, c := range cases {
 		suite.Run(c.name, func() {
 			suite.SetupSuite()

--- a/internal/querycoordv2/balance/score_based_balancer.go
+++ b/internal/querycoordv2/balance/score_based_balancer.go
@@ -189,11 +189,11 @@ func (b *ScoreBasedBalancer) BalanceReplica(replica *meta.Replica) ([]SegmentAss
 		)
 		// handle stopped nodes here, have to assign segments on stopping nodes to nodes with the smallest score
 		segmentPlans = append(segmentPlans, b.getStoppedSegmentPlan(replica, nodesSegments, stoppingNodesSegments)...)
-		channelPlans = append(channelPlans, b.genChannelPlan(replica, lo.Keys(nodesSegments), lo.Keys(stoppingNodesSegments))...)
+		channelPlans = append(channelPlans, b.genStoppingChannelPlan(replica, lo.Keys(nodesSegments), lo.Keys(stoppingNodesSegments))...)
 	} else {
 		// normal balance, find segments from largest score nodes and transfer to smallest score nodes.
 		segmentPlans = append(segmentPlans, b.getNormalSegmentPlan(replica, nodesSegments)...)
-		channelPlans = append(channelPlans, b.genChannelPlan(replica, lo.Keys(nodesSegments), nil)...)
+		channelPlans = append(channelPlans, b.genChannelPlan(replica, lo.Keys(nodesSegments))...)
 	}
 	if len(segmentPlans) != 0 || len(channelPlans) != 0 {
 		PrintCurrentReplicaDist(replica, stoppingNodesSegments, nodesSegments, b.dist.ChannelDistManager, b.dist.SegmentDistManager)

--- a/internal/querycoordv2/balance/score_based_balancer_test.go
+++ b/internal/querycoordv2/balance/score_based_balancer_test.go
@@ -586,7 +586,7 @@ func (suite *ScoreBasedBalancerTestSuite) TestStoppedBalance() {
 	for i, c := range cases {
 		suite.Run(c.name, func() {
 			if i == 0 {
-				suite.mockScheduler.Mock.On("GetNodeChannelDelta", mock.Anything).Return(0)
+				suite.mockScheduler.Mock.On("GetNodeChannelDelta", mock.Anything).Return(0).Maybe()
 			}
 			suite.SetupSuite()
 			defer suite.TearDownTest()


### PR DESCRIPTION
issue: #23726
pr: #28469

1. enable auto balance channel between nodes in querycoord
2. make `genSegmentPlan` reuse the `AssignSegment` logic
3. make `genChannelPlan` reuse the `AssignChannel` logic

---------