### PR TITLE
enhance: Change sync manager parallel config item

### DIFF
--- a/internal/datanode/data_node.go
+++ b/internal/datanode/data_node.go
@@ -273,7 +273,7 @@ func (node *DataNode) Init() error {
 		}
 
 		node.chunkManager = chunkManager
-		syncMgr, err := syncmgr.NewSyncManager(paramtable.Get().DataNodeCfg.MaxParallelSyncTaskNum.GetAsInt(),
+		syncMgr, err := syncmgr.NewSyncManager(paramtable.Get().DataNodeCfg.MaxParallelSyncMgrTasks.GetAsInt(),
 			node.chunkManager, node.allocator)
 		if err != nil {
 			initError = err

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -2589,6 +2589,7 @@ type dataNodeConfig struct {
 	FlowGraphMaxQueueLength ParamItem `refreshable:"false"`
 	FlowGraphMaxParallelism ParamItem `refreshable:"false"`
 	MaxParallelSyncTaskNum  ParamItem `refreshable:"false"`
+	MaxParallelSyncMgrTasks ParamItem `refreshable:"false"`
 
 	// skip mode
 	FlowGraphSkipModeEnable   ParamItem `refreshable:"true"`
@@ -2686,10 +2687,19 @@ func (p *dataNodeConfig) init(base *BaseTable) {
 		Key:          "dataNode.dataSync.maxParallelSyncTaskNum",
 		Version:      "2.3.0",
 		DefaultValue: "6",
-		Doc:          "Maximum number of sync tasks executed in parallel in each flush manager",
+		Doc:          "deprecated, legacy flush manager max conurrency number",
 		Export:       true,
 	}
 	p.MaxParallelSyncTaskNum.Init(base.mgr)
+
+	p.MaxParallelSyncMgrTasks = ParamItem{
+		Key:          "dataNode.dataSync.maxParallelSyncMgrTasks",
+		Version:      "2.3.4",
+		DefaultValue: "64",
+		Doc:          "The max concurrent sync task number of datanode sync mgr globally",
+		Export:       true,
+	}
+	p.MaxParallelSyncMgrTasks.Init(base.mgr)
 
 	p.FlushInsertBufferSize = ParamItem{
 		Key:          "dataNode.segment.insertBufSize",


### PR DESCRIPTION
Since the sync manager is global in datanode now, the old `maxParallelSyncTaskNum` does not fit into current implementation anymore.

This PR add a new param item for sync mgr parallel control and enlarge default value