### PR TITLE
fix: flushTs is never reset in channelMeta

### DIFF
--- a/internal/datanode/flow_graph_time_tick_node.go
+++ b/internal/datanode/flow_graph_time_tick_node.go
@@ -18,6 +18,7 @@ package datanode
 
 import (
 	"fmt"
+	"math"
 	"reflect"
 	"time"
 
@@ -115,6 +116,10 @@ func (ttn *ttNode) updateChannelCP(channelPos *msgpb.MsgPosition, curTs time.Tim
 			zap.String("channel", ttn.vChannelName),
 			zap.Uint64("cpTs", channelPos.GetTimestamp()),
 			zap.Time("cpTime", channelCPTs))
+		// channelPos ts > flushTs means we could stop flush.
+		if channelPos.GetTimestamp() >= ttn.channel.getFlushTs() {
+			ttn.channel.setFlushTs(math.MaxUint64)
+		}
 		return nil
 	}
 


### PR DESCRIPTION
See also #29156
FlushTs need to to be reset to MaxUint64 after channel checkpoint is after this timestamp. Otherwise, the segment will be shattered and flush queue will be filled with tasks