### PR TITLE
fix: rootCoord decide the builtin role cannot be deleted

### DIFF
--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -4235,8 +4235,8 @@ func (node *Proxy) DropRole(ctx context.Context, req *milvuspb.DropRoleRequest) 
 	if err := ValidateRoleName(req.RoleName); err != nil {
 		return merr.Status(err), nil
 	}
-	if IsBuiltinRole(req.RoleName) {
-		err := merr.WrapErrPrivilegeNotPermitted("the role[%s] is a default role, which can't be droped", req.GetRoleName())
+	if IsDefaultRole(req.RoleName) {
+		err := merr.WrapErrPrivilegeNotPermitted("the role[%s] is a default role, which can't be dropped", req.GetRoleName())
 		return merr.Status(err), nil
 	}
 	result, err := node.rootCoord.DropRole(ctx, req)

--- a/internal/proxy/privilege_interceptor.go
+++ b/internal/proxy/privilege_interceptor.go
@@ -168,7 +168,7 @@ func PrivilegeInterceptor(ctx context.Context, req interface{}) (context.Context
 	}
 
 	log.Info("permission deny", zap.Strings("roles", roleNames))
-	return ctx, status.Error(codes.PermissionDenied, fmt.Sprintf("%s: permission deny", objectPrivilege))
+	return ctx, status.Error(codes.PermissionDenied, fmt.Sprintf("%s: permission deny to %s", objectPrivilege, username))
 }
 
 // isCurUserObject Determine whether it is an Object of type User that operates on its own user information,

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -835,18 +835,6 @@ func IsDefaultRole(roleName string) bool {
 	return false
 }
 
-func IsBuiltinRole(roleName string) bool {
-	if IsDefaultRole(roleName) {
-		return true
-	}
-	for _, builtinRole := range util.BuiltinRoles {
-		if builtinRole == roleName {
-			return true
-		}
-	}
-	return false
-}
-
 func ValidateObjectName(entity string) error {
 	if util.IsAnyWord(entity) {
 		return nil

--- a/internal/proxy/util_test.go
+++ b/internal/proxy/util_test.go
@@ -816,13 +816,8 @@ func TestValidateName(t *testing.T) {
 
 func TestIsDefaultRole(t *testing.T) {
 	assert.Equal(t, true, IsDefaultRole(util.RoleAdmin))
-	assert.Equal(t, true, IsBuiltinRole(util.RoleAdmin))
 	assert.Equal(t, true, IsDefaultRole(util.RolePublic))
-	assert.Equal(t, true, IsBuiltinRole(util.RolePublic))
 	assert.Equal(t, false, IsDefaultRole("manager"))
-	assert.Equal(t, false, IsBuiltinRole("manager"))
-	util.BuiltinRoles = append(util.BuiltinRoles, "manager")
-	assert.Equal(t, true, IsBuiltinRole("manager"))
 }
 
 func GetContext(ctx context.Context, originValue string) context.Context {

--- a/internal/rootcoord/root_coord.go
+++ b/internal/rootcoord/root_coord.go
@@ -2308,6 +2308,10 @@ func (c *Core) DropRole(ctx context.Context, in *milvuspb.DropRoleRequest) (*com
 	if err := merr.CheckHealthy(c.GetStateCode()); err != nil {
 		return merr.Status(err), nil
 	}
+	for util.IsBuiltinRole(in.GetRoleName()) {
+		err := merr.WrapErrPrivilegeNotPermitted("the role[%s] is a builtin role, which can't be dropped", in.GetRoleName())
+		return merr.Status(err), nil
+	}
 	if _, err := c.meta.SelectRole(util.DefaultTenant, &milvuspb.RoleEntity{Name: in.RoleName}, false); err != nil {
 		errMsg := "not found the role, maybe the role isn't existed or internal system error"
 		ctxLog.Warn(errMsg, zap.Error(err))

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -182,3 +182,12 @@ func PrivilegeNameForMetastore(name string) string {
 func IsAnyWord(word string) bool {
 	return word == AnyWord
 }
+
+func IsBuiltinRole(roleName string) bool {
+	for _, builtinRole := range BuiltinRoles {
+		if builtinRole == roleName {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
issue: #29243
pr: #28961 
only rootCoord read the configuration item `builtinRoles`, so proxy never know whether the role to be deleted is builtin.