### PR TITLE
fix: [2.2]parse logID from logPath if copyDeltalog find logID not provided

### DIFF
--- a/internal/datacoord/meta_test.go
+++ b/internal/datacoord/meta_test.go
@@ -1004,3 +1004,70 @@ func Test_meta_GcConfirm(t *testing.T) {
 
 	assert.False(t, m.GcConfirm(context.TODO(), 100, 10000))
 }
+
+func TestGetDeltaLogID(t *testing.T) {
+	type testCase struct {
+		tag       string
+		rootPath  string
+		binlog    *datapb.Binlog
+		expectErr bool
+		expectID  int64
+	}
+
+	cases := []testCase{
+		{
+			tag:      "has_log_id",
+			rootPath: "files",
+			binlog: &datapb.Binlog{
+				LogID: 446329278451403166,
+			},
+			expectErr: false,
+			expectID:  446329278451403166,
+		},
+		{
+			tag:      "parse_normal_logPath",
+			rootPath: "files",
+			binlog: &datapb.Binlog{
+				LogPath: "files/delta_log/446329278451203130/446329278451203131/446329278451403142/446329278451403166",
+			},
+			expectErr: false,
+			expectID:  446329278451403166,
+		},
+		{
+			tag:      "invalid_rootpath_prefix",
+			rootPath: "files",
+			binlog: &datapb.Binlog{
+				LogPath: "file/delta_log/446329278451203130/446329278451203131/446329278451403142/446329278451403166",
+			},
+			expectErr: true,
+		},
+		{
+			tag:      "invalid_deltalog_path",
+			rootPath: "files",
+			binlog: &datapb.Binlog{
+				LogPath: "files/delta_log/446329278451403166",
+			},
+			expectErr: true,
+		},
+		{
+			tag:      "invalid_logID",
+			rootPath: "files",
+			binlog: &datapb.Binlog{
+				LogPath: "files/delta_log/446329278451203130/446329278451203131/446329278451403142/meta_files",
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.tag, func(t *testing.T) {
+			logID, err := getDeltaLogID(tc.rootPath, tc.binlog)
+			if tc.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectID, logID)
+			}
+		})
+	}
+}

--- a/internal/datacoord/meta_test.go
+++ b/internal/datacoord/meta_test.go
@@ -1071,3 +1071,94 @@ func TestGetDeltaLogID(t *testing.T) {
 		})
 	}
 }
+
+func Test_meta_copyDeltaFiles(t *testing.T) {
+	cm := mocks.NewChunkManager(t)
+	cm.EXPECT().RootPath().Return("files").Maybe()
+	m := &meta{
+		chunkManager: cm,
+	}
+
+	type testCase struct {
+		tag          string
+		binlogs      []*datapb.FieldBinlog
+		collectionID int64
+		partitionID  int64
+		segmentID    int64
+
+		expectResult []*datapb.FieldBinlog
+		expectErr    bool
+	}
+
+	cases := []*testCase{
+		{
+			tag: "normal_logID",
+			binlogs: []*datapb.FieldBinlog{
+				{
+					Binlogs: []*datapb.Binlog{
+						{LogID: 446329278451403166},
+					},
+				},
+			},
+			collectionID: 446329278451203130,
+			partitionID:  446329278451203131,
+			segmentID:    446329278451403143,
+			expectResult: []*datapb.FieldBinlog{
+				{
+					Binlogs: []*datapb.Binlog{
+						{LogID: 446329278451403166, LogPath: "files/delta_log/446329278451203130/446329278451203131/446329278451403143/446329278451403166"},
+					},
+				},
+			},
+		},
+		{
+			tag: "normal_logPath",
+			binlogs: []*datapb.FieldBinlog{
+				{
+					Binlogs: []*datapb.Binlog{
+						{LogPath: "files/delta_log/446329278451203130/446329278451203131/446329278451403142/446329278451403166"},
+					},
+				},
+			},
+			collectionID: 446329278451203130,
+			partitionID:  446329278451203131,
+			segmentID:    446329278451403143,
+			expectResult: []*datapb.FieldBinlog{
+				{
+					Binlogs: []*datapb.Binlog{
+						{LogPath: "files/delta_log/446329278451203130/446329278451203131/446329278451403143/446329278451403166"},
+					},
+				},
+			},
+		},
+		{
+			tag: "bad_logPath",
+			binlogs: []*datapb.FieldBinlog{
+				{
+					Binlogs: []*datapb.Binlog{
+						{LogPath: "other_prefix/delta_log/446329278451203130/446329278451203131/446329278451403142/446329278451403166"},
+					},
+				},
+			},
+			collectionID: 446329278451203130,
+			partitionID:  446329278451203131,
+			segmentID:    446329278451403143,
+			expectErr:    true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.tag, func(t *testing.T) {
+			cm.EXPECT().Read(mock.Anything, mock.Anything).Return([]byte("test"), nil).Maybe()
+			cm.EXPECT().Write(mock.Anything, mock.Anything, []byte("test")).Return(nil).Maybe()
+
+			result, err := m.copyDeltaFiles(tc.binlogs, tc.collectionID, tc.partitionID, tc.segmentID)
+			if tc.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectResult, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Cherry-pick from master
pr: #29273
See also: #29272

This PR add `getDeltaLogID` to safely return logID when Binlog struct has zero value logID. It parses logID from logPath if the format is valid. Otherwise, this function shall return error.