### PR TITLE
fix: Unstable `TestDataSyncService/TestStartStop` unit test

### DIFF
--- a/internal/datanode/data_sync_service_test.go
+++ b/internal/datanode/data_sync_service_test.go
@@ -499,7 +499,7 @@ func (s *DataSyncServiceSuite) TestStartStop() {
 
 	s.wbManager.EXPECT().BufferData(insertChannelName, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	s.wbManager.EXPECT().GetCheckpoint(insertChannelName).Return(&msgpb.MsgPosition{Timestamp: msgTs}, true, nil)
-	s.wbManager.EXPECT().NotifyCheckpointUpdated(insertChannelName, msgTs).Return()
+	s.wbManager.EXPECT().NotifyCheckpointUpdated(insertChannelName, msgTs).Return().Maybe()
 
 	ch := make(chan struct{})
 


### PR DESCRIPTION
fix #29290

Change EXPECT `NotifyCheckpointUpdated` call to `Maybe` expectation