### PR TITLE
fix: creating growing segments may introduce many threads

### DIFF
--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -186,9 +186,12 @@ func NewSegment(collection *Collection,
 	}
 
 	var newPtr C.CSegmentInterface
-	status := C.NewSegment(collection.collectionPtr, cSegType, C.int64_t(segmentID), &newPtr)
-
-	if err := HandleCStatus(&status, "NewSegmentFailed"); err != nil {
+	_, err := GetDynamicPool().Submit(func() (any, error) {
+		status := C.NewSegment(collection.collectionPtr, cSegType, C.int64_t(segmentID), &newPtr)
+		err := HandleCStatus(&status, "NewSegmentFailed")
+		return nil, err
+	}).Await()
+	if err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
many growing segments may be created in a short time and there is no restriction to the process, the CGO call will leave many threads

related: #29282
