### PR TITLE
enhance: [cherry-pick] change cp metric to absolute unix ts (#29328)

### DIFF
--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -1290,8 +1290,8 @@ func (m *meta) UpdateChannelCheckpoint(vChannel string, pos *msgpb.MsgPosition) 
 			zap.Uint64("ts", pos.GetTimestamp()),
 			zap.ByteString("msgID", pos.GetMsgID()),
 			zap.Time("time", ts))
-		metrics.DataCoordCheckpointLag.WithLabelValues(fmt.Sprint(paramtable.GetNodeID()), vChannel).
-			Set(float64(time.Since(ts).Milliseconds()))
+		metrics.DataCoordCheckpointUnixSeconds.WithLabelValues(fmt.Sprint(paramtable.GetNodeID()), vChannel).
+			Set(float64(ts.Unix()))
 	}
 	return nil
 }

--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -559,7 +559,7 @@ func (s *Server) DropVirtualChannel(ctx context.Context, req *datapb.DropVirtual
 	s.segmentManager.DropSegmentsOfChannel(ctx, channel)
 
 	metrics.CleanupDataCoordNumStoredRows(collectionID)
-	metrics.DataCoordCheckpointLag.DeleteLabelValues(fmt.Sprint(paramtable.GetNodeID()), channel)
+	metrics.DataCoordCheckpointUnixSeconds.DeleteLabelValues(fmt.Sprint(paramtable.GetNodeID()), channel)
 
 	// no compaction triggered in Drop procedure
 	return resp, nil

--- a/pkg/metrics/datacoord_metrics.go
+++ b/pkg/metrics/datacoord_metrics.go
@@ -100,12 +100,12 @@ var (
 			channelNameLabelName,
 		})
 
-	DataCoordCheckpointLag = prometheus.NewGaugeVec(
+	DataCoordCheckpointUnixSeconds = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: milvusNamespace,
 			Subsystem: typeutil.DataCoordRole,
-			Name:      "channel_checkpoint_ts_lag_ms",
-			Help:      "channel checkpoint timestamp lag in milliseconds",
+			Name:      "channel_checkpoint_unix_seconds",
+			Help:      "channel checkpoint timestamp in unix seconds",
 		}, []string{
 			nodeIDLabelName,
 			channelNameLabelName,
@@ -261,7 +261,7 @@ func RegisterDataCoord(registry *prometheus.Registry) {
 	registry.MustRegister(DataCoordNumStoredRows)
 	registry.MustRegister(DataCoordNumStoredRowsCounter)
 	registry.MustRegister(DataCoordConsumeDataNodeTimeTickLag)
-	registry.MustRegister(DataCoordCheckpointLag)
+	registry.MustRegister(DataCoordCheckpointUnixSeconds)
 	registry.MustRegister(DataCoordStoredBinlogSize)
 	registry.MustRegister(DataCoordSegmentBinLogFileCount)
 	registry.MustRegister(DataCoordDmlChannelNum)


### PR DESCRIPTION
Cherry pick from master
pr: #29328 

See also #29327

Change channel checkpoint metrics to unix seconds instead of checkpoint timestamp lag value