### PR TITLE
fix: [cherry-pick] delegator may mark segment offline by mistake

### DIFF
--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -265,7 +265,7 @@ func (sd *shardDelegator) applyDelete(ctx context.Context, nodeID int64, worker 
 				if errors.Is(err, merr.ErrNodeNotFound) {
 					log.Warn("try to delete data on non-exist node")
 					return retry.Unrecoverable(err)
-				} else if errors.Is(err, merr.ErrSegmentNotFound) {
+				} else if errors.IsAny(err, merr.ErrSegmentNotFound, merr.ErrSegmentNotLoaded) {
 					log.Warn("try to delete data of released segment")
 					return nil
 				} else if err != nil {


### PR DESCRIPTION
cherry-pick from master
pr: #29343
See also #29332

The segment may be released before or during the request when delegator tries to forward delete request to yet. Currently, these two situation returns different error code.

In this particular case, ErrSegmentNotLoaded and ErrSegmentNotFound shall both be ignored preventing return search service unavailable by mistake.