### PR TITLE
enhance: remove all unnecessary string formatting (#29323)

### DIFF
--- a/internal/core/src/common/FieldMeta.h
+++ b/internal/core/src/common/FieldMeta.h
@@ -95,8 +95,7 @@ datatype_name(DataType data_type) {
             return "vector_float16";
         }
         default: {
-            PanicInfo(DataTypeInvalid,
-                      fmt::format("Unsupported DataType({})", data_type));
+            PanicInfo(DataTypeInvalid, "Unsupported DataType({})", data_type);
         }
     }
 }

--- a/internal/core/src/index/VectorDiskIndex.cpp
+++ b/internal/core/src/index/VectorDiskIndex.cpp
@@ -246,9 +246,9 @@ VectorDiskAnnIndex<T>::Query(const DatasetPtr dataset,
 
             if (!res.has_value()) {
                 PanicInfo(ErrorCode::UnexpectedError,
-                          fmt::format("failed to range search: {}: {}",
-                                      KnowhereStatusString(res.error()),
-                                      res.what()));
+                          "failed to range search: {}: {}",
+                          KnowhereStatusString(res.error()),
+                          res.what());
             }
             return ReGenRangeSearchResult(
                 res.value(), topk, num_queries, GetMetricType());
@@ -256,9 +256,9 @@ VectorDiskAnnIndex<T>::Query(const DatasetPtr dataset,
             auto res = index_.Search(*dataset, search_config, bitset);
             if (!res.has_value()) {
                 PanicInfo(ErrorCode::UnexpectedError,
-                          fmt::format("failed to search: {}: {}",
-                                      KnowhereStatusString(res.error()),
-                                      res.what()));
+                          "failed to search: {}: {}",
+                          KnowhereStatusString(res.error()),
+                          res.what());
             }
             return res.value();
         }
@@ -301,9 +301,9 @@ VectorDiskAnnIndex<T>::GetVector(const DatasetPtr dataset) const {
     auto res = index_.GetVectorByIds(*dataset);
     if (!res.has_value()) {
         PanicInfo(ErrorCode::UnexpectedError,
-                  fmt::format("failed to get vector: {}: {}",
-                              KnowhereStatusString(res.error()),
-                              res.what()));
+                  "failed to get vector: {}: {}",
+                  KnowhereStatusString(res.error()),
+                  res.what());
     }
     auto index_type = GetIndexType();
     auto tensor = res.value()->GetTensor();

--- a/internal/core/src/index/VectorMemIndex.cpp
+++ b/internal/core/src/index/VectorMemIndex.cpp
@@ -312,9 +312,9 @@ VectorMemIndex::Query(const DatasetPtr dataset,
             milvus::tracer::AddEvent("finish_knowhere_index_range_search");
             if (!res.has_value()) {
                 PanicInfo(ErrorCode::UnexpectedError,
-                          fmt::format("failed to range search: {}: {}",
-                                      KnowhereStatusString(res.error()),
-                                      res.what()));
+                          "failed to range search: {}: {}",
+                          KnowhereStatusString(res.error()),
+                          res.what());
             }
             auto result = ReGenRangeSearchResult(
                 res.value(), topk, num_queries, GetMetricType());
@@ -326,9 +326,9 @@ VectorMemIndex::Query(const DatasetPtr dataset,
             milvus::tracer::AddEvent("finish_knowhere_index_search");
             if (!res.has_value()) {
                 PanicInfo(ErrorCode::UnexpectedError,
-                          fmt::format("failed to search: {}: {}",
-                                      KnowhereStatusString(res.error()),
-                                      res.what()));
+                          "failed to search: {}: {}",
+                          KnowhereStatusString(res.error()),
+                          res.what());
             }
             return res.value();
         }
@@ -487,8 +487,8 @@ VectorMemIndex::LoadFromFile(const Config& config) {
     auto stat = index_.DeserializeFromFile(filepath.value(), conf);
     if (stat != knowhere::Status::success) {
         PanicInfo(ErrorCode::UnexpectedError,
-                  fmt::format("failed to Deserialize index: {}",
-                              KnowhereStatusString(stat)));
+                  "failed to Deserialize index: {}",
+                  KnowhereStatusString(stat));
     }
 
     auto dim = index_.Dim();
@@ -496,9 +496,9 @@ VectorMemIndex::LoadFromFile(const Config& config) {
 
     auto ok = unlink(filepath->data());
     AssertInfo(ok == 0,
-               fmt::format("failed to unlink mmap index file {}: {}",
-                           filepath.value(),
-                           strerror(errno)));
+               "failed to unlink mmap index file {}: {}",
+               filepath.value(),
+               strerror(errno));
     LOG_SEGCORE_INFO_ << "load vector index done";
 }
 

--- a/internal/core/src/mmap/Utils.h
+++ b/internal/core/src/mmap/Utils.h
@@ -66,8 +66,8 @@ FillField(DataType data_type, const storage::FieldDataPtr data, void* dst) {
                 break;
             }
             default:
-                PanicInfo(DataTypeInvalid,
-                          fmt::format("not supported data type {}", data_type));
+                PanicInfo(
+                    DataTypeInvalid, "not supported data type {}", data_type);
         }
     } else {
         memcpy(dst, data->Data(), data->Size());
@@ -126,8 +126,8 @@ WriteFieldData(File& file,
             }
             default:
                 PanicInfo(DataTypeInvalid,
-                          fmt::format("not supported data type {}",
-                                      datatype_name(data_type)));
+                          "not supported data type {}",
+                          datatype_name(data_type));
         }
     } else {
         total_written += file.Write(data->Data(), data->Size());

--- a/internal/core/src/query/PlanProto.cpp
+++ b/internal/core/src/query/PlanProto.cpp
@@ -428,8 +428,8 @@ ProtoParser::ParseBinaryRangeExpr(const proto::plan::BinaryRangeExpr& expr_pb) {
             }
 
             default: {
-                PanicInfo(DataTypeInvalid,
-                          fmt::format("unsupported data type {}", data_type));
+                PanicInfo(
+                    DataTypeInvalid, "unsupported data type {}", data_type);
             }
         }
     }();
@@ -552,8 +552,8 @@ ProtoParser::ParseTermExpr(const proto::plan::TermExpr& expr_pb) {
                 }
             }
             default: {
-                PanicInfo(DataTypeInvalid,
-                          fmt::format("unsupported data type {}", data_type));
+                PanicInfo(
+                    DataTypeInvalid, "unsupported data type {}", data_type);
             }
         }
     }();
@@ -613,9 +613,8 @@ ProtoParser::ParseBinaryArithOpEvalRangeExpr(
                             field_id, data_type, expr_pb);
                     default:
                         PanicInfo(DataTypeInvalid,
-                                  fmt::format(
-                                      "unsupported data type {} in expression",
-                                      expr_pb.value().val_case()));
+                                  "unsupported data type {} in expression",
+                                  expr_pb.value().val_case());
                 }
             }
             case DataType::ARRAY: {
@@ -628,14 +627,13 @@ ProtoParser::ParseBinaryArithOpEvalRangeExpr(
                             field_id, data_type, expr_pb);
                     default:
                         PanicInfo(DataTypeInvalid,
-                                  fmt::format(
-                                      "unsupported data type {} in expression",
-                                      expr_pb.value().val_case()));
+                                  "unsupported data type {} in expression",
+                                  expr_pb.value().val_case());
                 }
             }
             default: {
-                PanicInfo(DataTypeInvalid,
-                          fmt::format("unsupported data type {}", data_type));
+                PanicInfo(
+                    DataTypeInvalid, "unsupported data type {}", data_type);
             }
         }
     }();
@@ -660,8 +658,8 @@ ProtoParser::ParseExistExpr(const proto::plan::ExistsExpr& expr_pb) {
                 return ExtractExistsExprImpl(expr_pb);
             }
             default: {
-                PanicInfo(DataTypeInvalid,
-                          fmt::format("unsupported data type {}", data_type));
+                PanicInfo(
+                    DataTypeInvalid, "unsupported data type {}", data_type);
             }
         }
     }();
@@ -793,8 +791,7 @@ ProtoParser::ParseExpr(const proto::plan::Expr& expr_pb) {
         default: {
             std::string s;
             google::protobuf::TextFormat::PrintToString(expr_pb, &s);
-            PanicInfo(ExprInvalid,
-                      fmt::format("unsupported expr proto node: {}", s));
+            PanicInfo(ExprInvalid, "unsupported expr proto node: {}", s);
         }
     }
 }

--- a/internal/core/src/query/ScalarIndex.h
+++ b/internal/core/src/query/ScalarIndex.h
@@ -58,8 +58,7 @@ generate_scalar_index(SpanBase data, DataType data_type) {
         case DataType::VARCHAR:
             return generate_scalar_index(Span<std::string>(data));
         default:
-            PanicInfo(DataTypeInvalid,
-                      fmt::format("unsupported type {}", data_type));
+            PanicInfo(DataTypeInvalid, "unsupported type {}", data_type);
     }
 }
 

--- a/internal/core/src/query/SearchBruteForce.cpp
+++ b/internal/core/src/query/SearchBruteForce.cpp
@@ -106,9 +106,9 @@ BruteForceSearch(const dataset::SearchDataset& dataset,
         milvus::tracer::AddEvent("knowhere_finish_BruteForce_RangeSearch");
         if (!res.has_value()) {
             PanicInfo(KnowhereError,
-                      fmt::format("failed to range search: {}: {}",
-                                  KnowhereStatusString(res.error()),
-                                  res.what()));
+                      "failed to range search: {}: {}",
+                      KnowhereStatusString(res.error()),
+                      res.what());
         }
         auto result =
             ReGenRangeSearchResult(res.value(), topk, nq, dataset.metric_type);

--- a/internal/core/src/query/visitors/ExecExprVisitor.cpp
+++ b/internal/core/src/query/visitors/ExecExprVisitor.cpp
@@ -118,8 +118,7 @@ ExecExprVisitor::visit(LogicalUnaryExpr& expr) {
             break;
         }
         default: {
-            PanicInfo(OpTypeInvalid,
-                      fmt::format("Invalid Unary Op {}", expr.op_type_));
+            PanicInfo(OpTypeInvalid, "Invalid Unary Op {}", expr.op_type_);
         }
     }
     AssertInfo(res.size() == row_count_,
@@ -166,8 +165,7 @@ ExecExprVisitor::visit(LogicalBinaryExpr& expr) {
             break;
         }
         default: {
-            PanicInfo(OpTypeInvalid,
-                      fmt::format("Invalid Binary Op {}", expr.op_type_));
+            PanicInfo(OpTypeInvalid, "Invalid Binary Op {}", expr.op_type_);
         }
     }
     AssertInfo(res.size() == row_count_,
@@ -443,8 +441,7 @@ ExecExprVisitor::ExecUnaryRangeVisitorDispatcherImpl(UnaryRangeExpr& expr_raw)
         }
         // TODO: PostfixMatch
         default: {
-            PanicInfo(OpTypeInvalid,
-                      fmt::format("unsupported range node {}", op));
+            PanicInfo(OpTypeInvalid, "unsupported range node {}", op);
         }
     }
 }
@@ -557,8 +554,8 @@ CompareTwoJsonArray(T arr1, const proto::plan::Array& arr2) {
             }
             default:
                 PanicInfo(DataTypeInvalid,
-                          fmt::format("unsupported data type {}",
-                                      arr2.array(i).val_case()));
+                          "unsupported data type {}",
+                          arr2.array(i).val_case());
         }
         i++;
     }
@@ -699,8 +696,7 @@ ExecExprVisitor::ExecUnaryRangeVisitorDispatcherJson(UnaryRangeExpr& expr_raw)
         }
         // TODO: PostfixMatch
         default: {
-            PanicInfo(OpTypeInvalid,
-                      fmt::format("unsupported range node {}", op));
+            PanicInfo(OpTypeInvalid, "unsupported range node {}", op);
         }
     }
 }
@@ -833,8 +829,7 @@ ExecExprVisitor::ExecUnaryRangeVisitorDispatcherArray(UnaryRangeExpr& expr_raw)
         }
         // TODO: PostfixMatch
         default: {
-            PanicInfo(OpTypeInvalid,
-                      fmt::format("unsupported range node {}", op));
+            PanicInfo(OpTypeInvalid, "unsupported range node {}", op);
         }
     }
 }
@@ -1765,8 +1760,8 @@ ExecExprVisitor::visit(UnaryRangeExpr& expr) {
         }
         default:
             PanicInfo(DataTypeInvalid,
-                      fmt::format("unsupported data type: {}",
-                                  expr.column_.data_type));
+                      "unsupported data type: {}",
+                      expr.column_.data_type);
     }
     AssertInfo(res.size() == row_count_,
                "[ExecExprVisitor]Size of results not equal row count");
@@ -1854,8 +1849,8 @@ ExecExprVisitor::visit(BinaryArithOpEvalRangeExpr& expr) {
         }
         default:
             PanicInfo(DataTypeInvalid,
-                      fmt::format("unsupported data type: {}",
-                                  expr.column_.data_type));
+                      "unsupported data type: {}",
+                      expr.column_.data_type);
     }
     AssertInfo(res.size() == row_count_,
                "[ExecExprVisitor]Size of results not equal row count");
@@ -1955,8 +1950,8 @@ ExecExprVisitor::visit(BinaryRangeExpr& expr) {
         }
         default:
             PanicInfo(DataTypeInvalid,
-                      fmt::format("unsupported data type: {}",
-                                  expr.column_.data_type));
+                      "unsupported data type: {}",
+                      expr.column_.data_type);
     }
     AssertInfo(res.size() == row_count_,
                "[ExecExprVisitor]Size of results not equal row count");
@@ -2308,8 +2303,8 @@ ExecExprVisitor::ExecCompareExprDispatcher(CompareExpr& expr, Op op)
                     }
                 }
                 default:
-                    PanicInfo(DataTypeInvalid,
-                              fmt::format("unsupported data type {}", type));
+                    PanicInfo(
+                        DataTypeInvalid, "unsupported data type {}", type);
             }
         };
         auto left = getChunkData(
@@ -2377,8 +2372,7 @@ ExecExprVisitor::visit(CompareExpr& expr) {
             // case OpType::PostfixMatch: {
             // }
         default: {
-            PanicInfo(OpTypeInvalid,
-                      fmt::format("unsupported optype {}", expr.op_type_));
+            PanicInfo(OpTypeInvalid, "unsupported optype {}", expr.op_type_);
         }
     }
     AssertInfo(res.size() == row_count_,
@@ -2759,8 +2753,8 @@ ExecExprVisitor::visit(TermExpr& expr) {
                     break;
                 default:
                     PanicInfo(DataTypeInvalid,
-                              fmt::format("unsupported data type {}",
-                                          expr.val_case_));
+                              "unsupported data type {}",
+                              expr.val_case_);
             }
             break;
         }
@@ -2790,8 +2784,8 @@ ExecExprVisitor::visit(TermExpr& expr) {
         }
         default:
             PanicInfo(DataTypeInvalid,
-                      fmt::format("unsupported data type {}",
-                                  expr.column_.data_type));
+                      "unsupported data type {}",
+                      expr.column_.data_type);
     }
     AssertInfo(res.size() == row_count_,
                "[ExecExprVisitor]Size of results not equal row count");
@@ -2819,8 +2813,8 @@ ExecExprVisitor::visit(ExistsExpr& expr) {
         }
         default:
             PanicInfo(DataTypeInvalid,
-                      fmt::format("unsupported data type {}",
-                                  expr.column_.data_type));
+                      "unsupported data type {}",
+                      expr.column_.data_type);
     }
     AssertInfo(res.size() == row_count_,
                "[ExecExprVisitor]Size of results not equal row count");
@@ -3010,8 +3004,8 @@ ExecExprVisitor::ExecJsonContainsWithDiffType(JsonContainsExpr& expr_raw)
                     }
                     default:
                         PanicInfo(DataTypeInvalid,
-                                  fmt::format("unsupported data type {}",
-                                              element.val_case()));
+                                  "unsupported data type {}",
+                                  element.val_case());
                 }
             }
         }
@@ -3224,8 +3218,8 @@ ExecExprVisitor::ExecJsonContainsAllWithDiffType(JsonContainsExpr& expr_raw)
                         }
                         default:
                             PanicInfo(DataTypeInvalid,
-                                      fmt::format("unsupported data type {}",
-                                                  element.val_case()));
+                                      "unsupported data type {}",
+                                      element.val_case());
                     }
                     if (tmp_elements_index.size() == 0) {
                         return true;
@@ -3274,8 +3268,8 @@ ExecExprVisitor::visit(JsonContainsExpr& expr) {
                     }
                     default:
                         PanicInfo(DataTypeInvalid,
-                                  fmt::format("unsupported data type {}",
-                                              expr.val_case_));
+                                  "unsupported data type {}",
+                                  expr.val_case_);
                 }
             } else {
                 if (expr.same_type_) {
@@ -3302,8 +3296,8 @@ ExecExprVisitor::visit(JsonContainsExpr& expr) {
                         }
                         default:
                             PanicInfo(Unsupported,
-                                      fmt::format("unsupported value type {}",
-                                                  expr.val_case_));
+                                      "unsupported value type {}",
+                                      expr.val_case_);
                     }
                 } else {
                     res = ExecJsonContainsWithDiffType(expr);
@@ -3332,8 +3326,8 @@ ExecExprVisitor::visit(JsonContainsExpr& expr) {
                     }
                     default:
                         PanicInfo(DataTypeInvalid,
-                                  fmt::format("unsupported data type {}",
-                                              expr.val_case_));
+                                  "unsupported data type {}",
+                                  expr.val_case_);
                 }
             } else {
                 if (expr.same_type_) {
@@ -3373,8 +3367,8 @@ ExecExprVisitor::visit(JsonContainsExpr& expr) {
         }
         default:
             PanicInfo(DataTypeInvalid,
-                      fmt::format("unsupported json contains type {}",
-                                  expr.val_case_));
+                      "unsupported json contains type {}",
+                      expr.val_case_);
     }
     AssertInfo(res.size() == row_count_,
                "[ExecExprVisitor]Size of results not equal row count");

--- a/internal/core/src/query/visitors/ShowExprVisitor.cpp
+++ b/internal/core/src/query/visitors/ShowExprVisitor.cpp
@@ -91,8 +91,7 @@ ShowExprVisitor::visit(LogicalBinaryExpr& expr) {
             case OpType::LogicalXor:
                 return "LogicalXor";
             default:
-                PanicInfo(OpTypeInvalid,
-                          fmt::format("unsupported operation {}", op));
+                PanicInfo(OpTypeInvalid, "unsupported operation {}", op);
         }
     }(expr.op_type_);
 

--- a/internal/core/src/segcore/ConcurrentVector.cpp
+++ b/internal/core/src/segcore/ConcurrentVector.cpp
@@ -99,8 +99,8 @@ VectorBase::set_data_raw(ssize_t element_offset,
         }
         default: {
             PanicInfo(DataTypeInvalid,
-                      fmt::format("unsupported datatype {}",
-                                  field_meta.get_data_type()));
+                      "unsupported datatype {}",
+                      field_meta.get_data_type());
         }
     }
 }

--- a/internal/core/src/segcore/ConcurrentVector.h
+++ b/internal/core/src/segcore/ConcurrentVector.h
@@ -53,8 +53,9 @@ class ThreadSafeVector {
     const Type&
     operator[](int64_t index) const {
         AssertInfo(index < size_,
-                   fmt::format(
-                       "index out of range, index={}, size_={}", index, size_));
+                   "index out of range, index={}, size_={}",
+                   index,
+                   size_);
         std::shared_lock lck(mutex_);
         return vec_[index];
     }
@@ -62,8 +63,9 @@ class ThreadSafeVector {
     Type&
     operator[](int64_t index) {
         AssertInfo(index < size_,
-                   fmt::format(
-                       "index out of range, index={}, size_={}", index, size_));
+                   "index out of range, index={}, size_={}",
+                   index,
+                   size_);
         std::shared_lock lck(mutex_);
         return vec_[index];
     }
@@ -298,8 +300,7 @@ class ConcurrentVectorImpl : public VectorBase {
 
     const Type&
     operator[](ssize_t element_index) const {
-        AssertInfo(Dim == 1,
-                   fmt::format("The value of Dim is not 1, Dim={}", Dim));
+        AssertInfo(Dim == 1, "The value of Dim is not 1, Dim={}", Dim);
         auto chunk_id = element_index / size_per_chunk_;
         auto chunk_offset = element_index % size_per_chunk_;
         return get_chunk(chunk_id)[chunk_offset];
@@ -382,8 +383,7 @@ class ConcurrentVector<BinaryVector>
  public:
     explicit ConcurrentVector(int64_t dim, int64_t size_per_chunk)
         : ConcurrentVectorImpl(dim / 8, size_per_chunk) {
-        AssertInfo(dim % 8 == 0,
-                   fmt::format("dim is not a multiple of 8, dim={}", dim));
+        AssertInfo(dim % 8 == 0, "dim is not a multiple of 8, dim={}", dim);
     }
 };
 

--- a/internal/core/src/segcore/FieldIndexing.cpp
+++ b/internal/core/src/segcore/FieldIndexing.cpp
@@ -253,8 +253,8 @@ CreateIndex(const FieldMeta& field_meta,
                                                          segcore_config);
         } else {
             PanicInfo(DataTypeInvalid,
-                      fmt::format("unsupported vector type in index: {}",
-                                  field_meta.get_data_type()));
+                      "unsupported vector type in index: {}",
+                      field_meta.get_data_type());
         }
     }
     switch (field_meta.get_data_type()) {
@@ -284,8 +284,8 @@ CreateIndex(const FieldMeta& field_meta,
                 field_meta, segcore_config);
         default:
             PanicInfo(DataTypeInvalid,
-                      fmt::format("unsupported scalar type in index: {}",
-                                  field_meta.get_data_type()));
+                      "unsupported scalar type in index: {}",
+                      field_meta.get_data_type());
     }
 }
 

--- a/internal/core/src/segcore/InsertRecord.h
+++ b/internal/core/src/segcore/InsertRecord.h
@@ -295,8 +295,8 @@ struct InsertRecord {
                     }
                     default: {
                         PanicInfo(DataTypeInvalid,
-                                  fmt::format("unsupported pk type",
-                                              field_meta.get_data_type()));
+                                  "unsupported pk type",
+                                  field_meta.get_data_type());
                     }
                 }
             }
@@ -317,8 +317,8 @@ struct InsertRecord {
                     continue;
                 } else {
                     PanicInfo(DataTypeInvalid,
-                              fmt::format("unsupported vector type",
-                                          field_meta.get_data_type()));
+                              "unsupported vector type",
+                              field_meta.get_data_type());
                 }
             }
             switch (field_meta.get_data_type()) {
@@ -365,8 +365,8 @@ struct InsertRecord {
                 }
                 default: {
                     PanicInfo(DataTypeInvalid,
-                              fmt::format("unsupported scalar type",
-                                          field_meta.get_data_type()));
+                              "unsupported scalar type",
+                              field_meta.get_data_type());
                 }
             }
         }
@@ -417,8 +417,8 @@ struct InsertRecord {
             }
             default: {
                 PanicInfo(DataTypeInvalid,
-                          fmt::format("unsupported primary key data type",
-                                      data_type));
+                          "unsupported primary key data type",
+                          data_type);
             }
         }
     }
@@ -449,8 +449,8 @@ struct InsertRecord {
                 }
                 default: {
                     PanicInfo(DataTypeInvalid,
-                              fmt::format("unsupported primary key data type",
-                                          data_type));
+                              "unsupported primary key data type",
+                              data_type);
                 }
             }
         }

--- a/internal/core/src/segcore/Reduce.cpp
+++ b/internal/core/src/segcore/Reduce.cpp
@@ -320,8 +320,8 @@ ReduceHelper::GetSearchResultDataSlice(int slice_index) {
             break;
         }
         default: {
-            PanicInfo(DataTypeInvalid,
-                      fmt::format("unsupported primary key type {}", pk_type));
+            PanicInfo(
+                DataTypeInvalid, "unsupported primary key type {}", pk_type);
         }
     }
 
@@ -369,8 +369,8 @@ ReduceHelper::GetSearchResultDataSlice(int slice_index) {
                     }
                     default: {
                         PanicInfo(DataTypeInvalid,
-                                  fmt::format("unsupported primary key type {}",
-                                              pk_type));
+                                  "unsupported primary key type {}",
+                                  pk_type);
                     }
                 }
 

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -83,9 +83,9 @@ SegmentGrowingImpl::Insert(int64_t reserved_offset,
                            const Timestamp* timestamps_raw,
                            const InsertData* insert_data) {
     AssertInfo(insert_data->num_rows() == num_rows,
-               fmt::format("Entities_raw count {} not equal to insert size {}",
-                           num_rows,
-                           insert_data->num_rows()));
+               "Entities_raw count {} not equal to insert size {}",
+               num_rows,
+               insert_data->num_rows());
     //    AssertInfo(insert_data->fields_data_size() == schema_->size(),
     //               "num fields of insert data not equal to num of schema fields");
     // step 1: check insert data if valid
@@ -111,7 +111,8 @@ SegmentGrowingImpl::Insert(int64_t reserved_offset,
         }
         auto it = field_id_to_offset.find(field_id);
         AssertInfo(it != field_id_to_offset.end(),
-                   fmt::format("can't find field {}", field_id.get()));
+                   "can't find field {}",
+                   field_id.get());
         auto data_offset = it->second;
         if (!indexing_record_.SyncDataWithIndex(field_id)) {
             insert_record_.get_field_data_base(field_id)->set_data_raw(
@@ -641,8 +642,8 @@ SegmentGrowingImpl::search_ids(const IdArray& id_array,
                     break;
                 }
                 default: {
-                    PanicInfo(DataTypeInvalid,
-                              fmt::format("unsupported type {}", data_type));
+                    PanicInfo(
+                        DataTypeInvalid, "unsupported type {}", data_type);
                 }
             }
             res_offsets.push_back(offset);

--- a/internal/core/src/segcore/SegmentInterface.cpp
+++ b/internal/core/src/segcore/SegmentInterface.cpp
@@ -166,8 +166,8 @@ SegmentInternalInterface::Retrieve(const query::RetrievePlan* plan,
                 }
                 default: {
                     PanicInfo(DataTypeInvalid,
-                              fmt::format("unsupported datatype {}",
-                                          field_meta.get_data_type()));
+                              "unsupported datatype {}",
+                              field_meta.get_data_type());
                 }
             }
         }

--- a/internal/core/src/segcore/SegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/SegmentSealedImpl.cpp
@@ -166,8 +166,8 @@ SegmentSealedImpl::LoadScalarIndex(const LoadIndexInfo& info) {
             }
             default: {
                 PanicInfo(DataTypeInvalid,
-                          fmt::format("unsupported primary key type {}",
-                                      field_meta.get_data_type()));
+                          "unsupported primary key type {}",
+                          field_meta.get_data_type());
             }
         }
     }
@@ -337,8 +337,8 @@ SegmentSealedImpl::LoadFieldData(FieldId field_id, FieldDataInfo& data) {
                     break;
                 }
                 default: {
-                    PanicInfo(DataTypeInvalid,
-                              fmt::format("unsupported data type", data_type));
+                    PanicInfo(
+                        DataTypeInvalid, "unsupported data type", data_type);
                 }
             }
 
@@ -354,11 +354,11 @@ SegmentSealedImpl::LoadFieldData(FieldId field_id, FieldDataInfo& data) {
         }
 
         AssertInfo(column->NumRows() == num_rows,
-                   fmt::format("data lost while loading column {}: loaded "
-                               "num rows {} but expected {}",
-                               data.field_id,
-                               column->NumRows(),
-                               num_rows));
+                   "data lost while loading column {}: loaded "
+                   "num rows {} but expected {}",
+                   data.field_id,
+                   column->NumRows(),
+                   num_rows);
 
         {
             std::unique_lock lck(mutex_);
@@ -469,8 +469,8 @@ SegmentSealedImpl::MapFieldData(const FieldId field_id, FieldDataInfo& data) {
                 break;
             }
             default: {
-                PanicInfo(DataTypeInvalid,
-                          fmt::format("unsupported data type {}", data_type));
+                PanicInfo(
+                    DataTypeInvalid, "unsupported data type {}", data_type);
             }
         }
     } else {
@@ -484,9 +484,9 @@ SegmentSealedImpl::MapFieldData(const FieldId field_id, FieldDataInfo& data) {
 
     auto ok = unlink(filepath.c_str());
     AssertInfo(ok == 0,
-               fmt::format("failed to unlink mmap data file {}, err: {}",
-                           filepath.c_str(),
-                           strerror(errno)));
+               "failed to unlink mmap data file {}, err: {}",
+               filepath.c_str(),
+               strerror(errno));
 
     // set pks to offset
     if (schema_->get_primary_field_id() == field_id) {
@@ -690,9 +690,9 @@ SegmentSealedImpl::GetFieldDataPath(FieldId field_id, int64_t offset) const {
     auto data_path = std::string();
     auto it = field_data_info_.field_infos.find(field_id.get());
     AssertInfo(it != field_data_info_.field_infos.end(),
-               fmt::format("cannot find binlog file for field: {}, seg: {}",
-                           field_id.get(),
-                           id_));
+               "cannot find binlog file for field: {}, seg: {}",
+               field_id.get(),
+               id_);
     auto field_info = it->second;
 
     for (auto i = 0; i < field_info.insert_files.size(); i++) {
@@ -787,9 +787,9 @@ SegmentSealedImpl::get_vector(FieldId field_id,
                        "column not found");
             const auto& column = path_to_column.at(data_path);
             AssertInfo(offset_in_binlog * row_bytes < column->ByteSize(),
-                       fmt::format("column idx out of range, idx: {}, size: {}",
-                                   offset_in_binlog * row_bytes,
-                                   column->ByteSize()));
+                       "column idx out of range, idx: {}, size: {}",
+                       offset_in_binlog * row_bytes,
+                       column->ByteSize());
             auto vector = &column->Data()[offset_in_binlog * row_bytes];
             std::memcpy(buf.data() + i * row_bytes, vector, row_bytes);
         }
@@ -930,8 +930,7 @@ SegmentSealedImpl::bulk_subscript(SystemFieldType system_type,
                 static_cast<int64_t*>(output));
             break;
         default:
-            PanicInfo(DataTypeInvalid,
-                      fmt::format("unknown subscript fields", system_type));
+            PanicInfo(DataTypeInvalid, "unknown subscript fields", system_type);
     }
 }
 
@@ -1178,8 +1177,8 @@ SegmentSealedImpl::bulk_subscript(FieldId field_id,
 
         default: {
             PanicInfo(DataTypeInvalid,
-                      fmt::format("unsupported data type {}",
-                                  field_meta.get_data_type()));
+                      "unsupported data type {}",
+                      field_meta.get_data_type());
         }
     }
 
@@ -1251,8 +1250,8 @@ SegmentSealedImpl::search_ids(const IdArray& id_array,
                     break;
                 }
                 default: {
-                    PanicInfo(DataTypeInvalid,
-                              fmt::format("unsupported type {}", data_type));
+                    PanicInfo(
+                        DataTypeInvalid, "unsupported type {}", data_type);
                 }
             }
             res_offsets.push_back(offset);

--- a/internal/core/src/segcore/Utils.cpp
+++ b/internal/core/src/segcore/Utils.cpp
@@ -41,8 +41,7 @@ ParsePksFromFieldData(std::vector<PkType>& pks, const DataArray& data) {
             break;
         }
         default: {
-            PanicInfo(DataTypeInvalid,
-                      fmt::format("unsupported PK {}", data_type));
+            PanicInfo(DataTypeInvalid, "unsupported PK {}", data_type);
         }
     }
 }
@@ -71,8 +70,7 @@ ParsePksFromFieldData(DataType data_type,
                 break;
             }
             default: {
-                PanicInfo(DataTypeInvalid,
-                          fmt::format("unsupported PK {}", data_type));
+                PanicInfo(DataTypeInvalid, "unsupported PK {}", data_type);
             }
         }
         offset += row_count;
@@ -96,8 +94,7 @@ ParsePksFromIDs(std::vector<PkType>& pks,
             break;
         }
         default: {
-            PanicInfo(DataTypeInvalid,
-                      fmt::format("unsupported PK {}", data_type));
+            PanicInfo(DataTypeInvalid, "unsupported PK {}", data_type);
         }
     }
 }
@@ -112,8 +109,7 @@ GetSizeOfIdArray(const IdArray& data) {
         return data.str_id().data_size();
     }
 
-    PanicInfo(DataTypeInvalid,
-              fmt::format("unsupported id {}", data.descriptor()->name()));
+    PanicInfo(DataTypeInvalid, "unsupported id {}", data.descriptor()->name());
 }
 
 int64_t
@@ -289,8 +285,7 @@ CreateScalarDataArray(int64_t count, const FieldMeta& field_meta) {
             break;
         }
         default: {
-            PanicInfo(DataTypeInvalid,
-                      fmt::format("unsupported datatype {}", data_type));
+            PanicInfo(DataTypeInvalid, "unsupported datatype {}", data_type);
         }
     }
 
@@ -330,8 +325,7 @@ CreateVectorDataArray(int64_t count, const FieldMeta& field_meta) {
             break;
         }
         default: {
-            PanicInfo(DataTypeInvalid,
-                      fmt::format("unsupported datatype {}", data_type));
+            PanicInfo(DataTypeInvalid, "unsupported datatype {}", data_type);
         }
     }
     return data_array;
@@ -418,8 +412,7 @@ CreateScalarDataArrayFrom(const void* data_raw,
             break;
         }
         default: {
-            PanicInfo(DataTypeInvalid,
-                      fmt::format("unsupported datatype {}", data_type));
+            PanicInfo(DataTypeInvalid, "unsupported datatype {}", data_type);
         }
     }
 
@@ -464,8 +457,7 @@ CreateVectorDataArrayFrom(const void* data_raw,
             break;
         }
         default: {
-            PanicInfo(DataTypeInvalid,
-                      fmt::format("unsupported datatype {}", data_type));
+            PanicInfo(DataTypeInvalid, "unsupported datatype {}", data_type);
         }
     }
     return data_array;
@@ -519,8 +511,8 @@ MergeDataArray(
                 auto obj = vector_array->mutable_binary_vector();
                 obj->assign(data + src_offset * num_bytes, num_bytes);
             } else {
-                PanicInfo(DataTypeInvalid,
-                          fmt::format("unsupported datatype {}", data_type));
+                PanicInfo(
+                    DataTypeInvalid, "unsupported datatype {}", data_type);
             }
             continue;
         }
@@ -580,8 +572,8 @@ MergeDataArray(
                 break;
             }
             default: {
-                PanicInfo(DataTypeInvalid,
-                          fmt::format("unsupported datatype {}", data_type));
+                PanicInfo(
+                    DataTypeInvalid, "unsupported datatype {}", data_type);
             }
         }
     }
@@ -692,8 +684,7 @@ ReverseDataFromIndex(const index::IndexBase* index,
             break;
         }
         default: {
-            PanicInfo(DataTypeInvalid,
-                      fmt::format("unsupported datatype {}", data_type));
+            PanicInfo(DataTypeInvalid, "unsupported datatype {}", data_type);
         }
     }
 

--- a/internal/core/src/storage/ChunkCache.cpp
+++ b/internal/core/src/storage/ChunkCache.cpp
@@ -35,9 +35,9 @@ ChunkCache::Read(const std::string& filepath) {
                 column->ByteSize(),
                 read_ahead_policy_);
     AssertInfo(ok == 0,
-               fmt::format("failed to madvise to the data file {}, err: {}",
-                           path.c_str(),
-                           strerror(errno)));
+               "failed to madvise to the data file {}, err: {}",
+               path.c_str(),
+               strerror(errno));
 
     columns_.emplace(path, column);
     return column;
@@ -62,9 +62,9 @@ ChunkCache::Prefetch(const std::string& filepath) {
                 column->ByteSize(),
                 read_ahead_policy_);
     AssertInfo(ok == 0,
-               fmt::format("failed to madvise to the data file {}, err: {}",
-                           path.c_str(),
-                           strerror(errno)));
+               "failed to madvise to the data file {}, err: {}",
+               path.c_str(),
+               strerror(errno));
 }
 
 std::shared_ptr<ColumnBase>
@@ -86,12 +86,12 @@ ChunkCache::Mmap(const std::filesystem::path& path,
     std::vector<std::vector<uint64_t>> element_indices{};
     auto written = WriteFieldData(file, data_type, field_data, element_indices);
     AssertInfo(written == data_size,
-               fmt::format("failed to write data file {}, written "
-                           "{} but total {}, err: {}",
-                           path.c_str(),
-                           written,
-                           data_size,
-                           strerror(errno)));
+               "failed to write data file {}, written "
+               "{} but total {}, err: {}",
+               path.c_str(),
+               written,
+               data_size,
+               strerror(errno));
 
     std::shared_ptr<ColumnBase> column{};
 
@@ -104,9 +104,9 @@ ChunkCache::Mmap(const std::filesystem::path& path,
     // unlink
     auto ok = unlink(path.c_str());
     AssertInfo(ok == 0,
-               fmt::format("failed to unlink mmap data file {}, err: {}",
-                           path.c_str(),
-                           strerror(errno)));
+               "failed to unlink mmap data file {}, err: {}",
+               path.c_str(),
+               strerror(errno));
 
     return column;
 }

--- a/internal/core/src/storage/ChunkCache.h
+++ b/internal/core/src/storage/ChunkCache.h
@@ -31,10 +31,10 @@ class ChunkCache {
         : path_prefix_(std::move(path)), cm_(cm) {
         auto iter = ReadAheadPolicy_Map.find(read_ahead_policy);
         AssertInfo(iter != ReadAheadPolicy_Map.end(),
-                   fmt::format("unrecognized read ahead policy: {}, "
-                               "should be one of `normal, random, sequential, "
-                               "willneed, dontneed`",
-                               read_ahead_policy));
+                   "unrecognized read ahead policy: {}, "
+                   "should be one of `normal, random, sequential, "
+                   "willneed, dontneed`",
+                   read_ahead_policy);
         read_ahead_policy_ = iter->second;
         LOG_SEGCORE_INFO_ << "Init ChunkCache with prefix: " << path_prefix_
                           << ", read_ahead_policy: " << read_ahead_policy;

--- a/internal/core/src/storage/DataCodec.cpp
+++ b/internal/core/src/storage/DataCodec.cpp
@@ -111,8 +111,8 @@ DeserializeFileData(const std::shared_ptr<uint8_t[]> input_data,
             return DeserializeLocalFileData(binlog_reader);
         }
         default:
-            PanicInfo(DataFormatBroken,
-                      fmt::format("unsupported medium type {}", medium_type));
+            PanicInfo(
+                DataFormatBroken, "unsupported medium type {}", medium_type);
     }
 }
 

--- a/internal/core/src/storage/Event.cpp
+++ b/internal/core/src/storage/Event.cpp
@@ -65,8 +65,8 @@ GetEventFixPartSize(EventType event_type) {
             return GetFixPartSize(data);
         }
         default:
-            PanicInfo(DataFormatBroken,
-                      fmt::format("unsupported event type {}", event_type));
+            PanicInfo(
+                DataFormatBroken, "unsupported event type {}", event_type);
     }
 }
 

--- a/internal/core/src/storage/IndexData.cpp
+++ b/internal/core/src/storage/IndexData.cpp
@@ -41,8 +41,7 @@ IndexData::Serialize(StorageType medium) {
         case StorageType::LocalDisk:
             return serialize_to_local_file();
         default:
-            PanicInfo(DataFormatBroken,
-                      fmt::format("unsupported medium type {}", medium));
+            PanicInfo(DataFormatBroken, "unsupported medium type {}", medium);
     }
 }
 

--- a/internal/core/src/storage/InsertData.cpp
+++ b/internal/core/src/storage/InsertData.cpp
@@ -37,8 +37,7 @@ InsertData::Serialize(StorageType medium) {
         case StorageType::LocalDisk:
             return serialize_to_local_file();
         default:
-            PanicInfo(DataFormatBroken,
-                      fmt::format("unsupported medium type {}", medium));
+            PanicInfo(DataFormatBroken, "unsupported medium type {}", medium);
     }
 }
 

--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -157,8 +157,7 @@ AddPayloadToArrowBuilder(std::shared_ptr<arrow::ArrayBuilder> builder,
             break;
         }
         default: {
-            PanicInfo(DataTypeInvalid,
-                      fmt::format("unsupported data type {}", data_type));
+            PanicInfo(DataTypeInvalid, "unsupported data type {}", data_type);
         }
     }
 }
@@ -341,8 +340,7 @@ GetDimensionFromFileMetaData(const parquet::ColumnDescriptor* schema,
             return schema->type_length() / sizeof(float16);
         }
         default:
-            PanicInfo(DataTypeInvalid,
-                      fmt::format("unsupported data type {}", data_type));
+            PanicInfo(DataTypeInvalid, "unsupported data type {}", data_type);
     }
 }
 
@@ -367,8 +365,7 @@ GetDimensionFromArrowArray(std::shared_ptr<arrow::Array> data,
             return array->byte_width() * 8;
         }
         default:
-            PanicInfo(DataTypeInvalid,
-                      fmt::format("unsupported data type {}", data_type));
+            PanicInfo(DataTypeInvalid, "unsupported data type {}", data_type);
     }
 }
 
@@ -611,8 +608,8 @@ CreateChunkManager(const StorageConfig& storage_config) {
 
         default: {
             PanicInfo(ConfigInvalid,
-                      fmt::format("unsupported storage_config.storage_type {}",
-                                  fmt::underlying(storage_type)));
+                      "unsupported storage_config.storage_type {}",
+                      fmt::underlying(storage_type));
         }
     }
 }

--- a/internal/core/unittest/test_chunk_cache.cpp
+++ b/internal/core/unittest/test_chunk_cache.cpp
@@ -76,8 +76,8 @@ TEST(ChunkCacheTest, Read) {
 
     auto actual = (float*)column->Data();
     for (auto i = 0; i < N; i++) {
-        AssertInfo(data[i] == actual[i],
-                   fmt::format("expect {}, actual {}", data[i], actual[i]));
+        AssertInfo(
+            data[i] == actual[i], "expect {}, actual {}", data[i], actual[i]);
     }
 
     cc->Remove(file_name);
@@ -143,7 +143,9 @@ TEST(ChunkCacheTest, TestMultithreads) {
         auto actual = (float*)column->Data();
         for (auto i = 0; i < N; i++) {
             AssertInfo(data[i] == actual[i],
-                       fmt::format("expect {}, actual {}", data[i], actual[i]));
+                       "expect {}, actual {}",
+                       data[i],
+                       actual[i]);
         }
     };
     std::vector<std::thread> pool;

--- a/internal/core/unittest/test_sealed.cpp
+++ b/internal/core/unittest/test_sealed.cpp
@@ -1261,8 +1261,8 @@ TEST(Sealed, GetVectorFromChunkCache) {
         for (size_t j = 0; j < dim; ++j) {
             auto expect = fakevec[id * dim + j];
             auto actual = vector[i * dim + j];
-            AssertInfo(expect == actual,
-                       fmt::format("expect {}, actual {}", expect, actual));
+            AssertInfo(
+                expect == actual, "expect {}, actual {}", expect, actual);
         }
     }
 


### PR DESCRIPTION
done by two regex expressions:

- `PanicInfo\((.+),[. \n]+fmt::format\(([.\s\S]+?)\)\)`
- `AssertInfo\((.+),[. \n]+fmt::format\(([.\s\S]+?)\)\)`

related: #28811
pr: #29323