### PR TITLE
fix: Return time tick delay error and refine quota error messages (#29289)

### DIFF
--- a/internal/proxy/multi_rate_limiter_test.go
+++ b/internal/proxy/multi_rate_limiter_test.go
@@ -283,8 +283,8 @@ func TestRateLimiter(t *testing.T) {
 			},
 		})
 		assert.NoError(t, err)
-		assert.ErrorIs(t, limiter.getError(internalpb.RateType_DQLQuery), merr.ErrServiceForceDeny)
-		assert.Equal(t, limiter.getError(internalpb.RateType_DMLInsert), merr.ErrServiceDiskLimitExceeded)
+		assert.Error(t, limiter.getQuotaExceededError(internalpb.RateType_DQLQuery))
+		assert.Error(t, limiter.getQuotaExceededError(internalpb.RateType_DMLInsert))
 	})
 
 	t.Run("tests refresh rate by config", func(t *testing.T) {

--- a/pkg/util/merr/errors.go
+++ b/pkg/util/merr/errors.go
@@ -40,8 +40,9 @@ var (
 	ErrServiceCrossClusterRouting  = newMilvusError("cross cluster routing", 6, false)
 	ErrServiceDiskLimitExceeded    = newMilvusError("disk limit exceeded", 7, false)
 	ErrServiceRateLimit            = newMilvusError("rate limit exceeded", 8, true)
-	ErrServiceForceDeny            = newMilvusError("force deny", 9, false)
+	ErrServiceQuotaExceeded        = newMilvusError("quota exceeded", 9, false)
 	ErrServiceUnimplemented        = newMilvusError("service unimplemented", 10, false)
+	ErrServiceTimeTickLongDelay    = newMilvusError("time tick long delay", 11, false)
 
 	// Collection related
 	ErrCollectionNotFound         = newMilvusError("collection not found", 100, false)

--- a/pkg/util/merr/errors_test.go
+++ b/pkg/util/merr/errors_test.go
@@ -149,7 +149,7 @@ func (s *ErrSuite) TestOldCode() {
 	s.ErrorIs(OldCodeToMerr(commonpb.ErrorCode_MemoryQuotaExhausted), ErrServiceMemoryLimitExceeded)
 	s.ErrorIs(OldCodeToMerr(commonpb.ErrorCode_DiskQuotaExhausted), ErrServiceDiskLimitExceeded)
 	s.ErrorIs(OldCodeToMerr(commonpb.ErrorCode_RateLimit), ErrServiceRateLimit)
-	s.ErrorIs(OldCodeToMerr(commonpb.ErrorCode_ForceDeny), ErrServiceForceDeny)
+	s.ErrorIs(OldCodeToMerr(commonpb.ErrorCode_ForceDeny), ErrServiceQuotaExceeded)
 	s.ErrorIs(OldCodeToMerr(commonpb.ErrorCode_UnexpectedError), errUnexpected)
 }
 

--- a/pkg/util/merr/utils.go
+++ b/pkg/util/merr/utils.go
@@ -153,10 +153,16 @@ func oldCode(code int32) commonpb.ErrorCode {
 	case ErrServiceMemoryLimitExceeded.code():
 		return commonpb.ErrorCode_InsufficientMemoryToLoad
 
+	case ErrServiceDiskLimitExceeded.code():
+		return commonpb.ErrorCode_DiskQuotaExhausted
+
+	case ErrServiceTimeTickLongDelay.code():
+		return commonpb.ErrorCode_TimeTickLongDelay
+
 	case ErrServiceRateLimit.code():
 		return commonpb.ErrorCode_RateLimit
 
-	case ErrServiceForceDeny.code():
+	case ErrServiceQuotaExceeded.code():
 		return commonpb.ErrorCode_ForceDeny
 
 	case ErrIndexNotFound.code():
@@ -193,11 +199,14 @@ func OldCodeToMerr(code commonpb.ErrorCode) error {
 	case commonpb.ErrorCode_DiskQuotaExhausted:
 		return ErrServiceDiskLimitExceeded
 
+	case commonpb.ErrorCode_TimeTickLongDelay:
+		return ErrServiceTimeTickLongDelay
+
 	case commonpb.ErrorCode_RateLimit:
 		return ErrServiceRateLimit
 
 	case commonpb.ErrorCode_ForceDeny:
-		return ErrServiceForceDeny
+		return ErrServiceQuotaExceeded
 
 	case commonpb.ErrorCode_IndexNotExist:
 		return ErrIndexNotFound
@@ -358,16 +367,20 @@ func WrapErrServiceDiskLimitExceeded(predict, limit float32, msg ...string) erro
 	return err
 }
 
-func WrapErrServiceRateLimit(rate float64) error {
-	return wrapFields(ErrServiceRateLimit, value("rate", rate))
+func WrapErrServiceRateLimit(rate float64, msg ...string) error {
+	err := wrapFields(ErrServiceRateLimit, value("rate", rate))
+	if len(msg) > 0 {
+		err = errors.Wrap(err, strings.Join(msg, "->"))
+	}
+	return err
 }
 
-func WrapErrServiceForceDeny(op string, reason error, method string) error {
-	return wrapFieldsWithDesc(ErrServiceForceDeny,
-		reason.Error(),
-		value("op", op),
-		value("req", method),
-	)
+func WrapErrServiceQuotaExceeded(reason string, msg ...string) error {
+	err := wrapFields(ErrServiceQuotaExceeded, value("reason", reason))
+	if len(msg) > 0 {
+		err = errors.Wrap(err, strings.Join(msg, "->"))
+	}
+	return err
 }
 
 func WrapErrServiceUnimplemented(grpcErr error) error {


### PR DESCRIPTION
This pr:
Handles the time tick delay error when converting old error codes to milvus errors.
Enhances quota error messages by eliminating "force deny" and substituting it with "quota exceeded."

pr: https://github.com/milvus-io/milvus/pull/29289
issue: https://github.com/milvus-io/milvus/issues/29288