### PR TITLE
fix: [cherry-pick] pymilvus hangs after calling do_bulk_insert() with a non-exist collection name

### DIFF
--- a/internal/rootcoord/root_coord.go
+++ b/internal/rootcoord/root_coord.go
@@ -1867,7 +1867,9 @@ func (c *Core) Import(ctx context.Context, req *milvuspb.ImportRequest) (*milvus
 		log.Error("failed to find collection ID from its name",
 			zap.String("collectionName", req.GetCollectionName()),
 			zap.Error(err))
-		return nil, err
+		return &milvuspb.ImportResponse{
+			Status: merr.Status(err),
+		}, nil
 	}
 
 	isBackUp := importutil.IsBackup(req.GetOptions())


### PR DESCRIPTION
resolve: https://github.com/milvus-io/milvus/issues/29342
pr: #29385