### PR TITLE
fix: segment may never get flushed if sealed before watch

### DIFF
--- a/internal/datanode/metacache/meta_cache.go
+++ b/internal/datanode/metacache/meta_cache.go
@@ -84,6 +84,8 @@ func (c *metaCacheImpl) init(vchannel *datapb.VchannelInfo, factory PkStatsFacto
 	}
 
 	for _, seg := range vchannel.UnflushedSegments {
+		// segment state could be sealed for growing segment if flush request processed before datanode watch
+		seg.State = commonpb.SegmentState_Growing
 		c.segmentInfos[seg.GetID()] = NewSegmentInfo(seg, factory(seg))
 	}
 }


### PR DESCRIPTION
See also #29092

`FlushSegments` transfer only `Growing` segment to flushing, if the segment is in `Sealed` state before Datanode watch channel, the state will never got satisfied for a segment be selected to be flushed.