### PR TITLE
fix: Upgrade from 2.2 should update CollectionLoadInfo

### DIFF
--- a/internal/querycoordv2/meta/collection_manager_test.go
+++ b/internal/querycoordv2/meta/collection_manager_test.go
@@ -501,6 +501,11 @@ func (suite *CollectionManagerSuite) TestUpgradeRecover() {
 	err := mgr.Recover(suite.broker)
 	suite.NoError(err)
 	suite.checkLoadResult()
+
+	for i, collection := range suite.collections {
+		newColl := mgr.GetCollection(collection)
+		suite.Equal(suite.loadTypes[i], newColl.GetLoadType())
+	}
 }
 
 func (suite *CollectionManagerSuite) loadAll() {


### PR DESCRIPTION

milvus branch 2.3 add `loadType` in CollectionLoadInfo, so for collection meta upgrade from 2.2, we should add `loadType` to CollectionLoadInfo. This PR update CollectionLoadInfo with `loadType` when meet a old version CollectionLoadInfo