### PR TITLE
fix: [Cherry-pick] Add scope limit for querynode DeleteRequest

### DIFF
--- a/internal/proto/query_coord.proto
+++ b/internal/proto/query_coord.proto
@@ -634,4 +634,5 @@ message DeleteRequest {
   int64 segment_id = 5;
   schema.IDs primary_keys = 6;
   repeated uint64 timestamps = 7; 
+  DataScope scope = 8;
 }

--- a/internal/querynodev2/services_test.go
+++ b/internal/querynodev2/services_test.go
@@ -1950,6 +1950,7 @@ func (suite *ServiceSuite) TestDelete_Int64() {
 		SegmentId:    suite.validSegmentIDs[0],
 		VchannelName: suite.vchannel,
 		Timestamps:   []uint64{0},
+		Scope:        querypb.DataScope_Historical,
 	}
 
 	// type int
@@ -2023,9 +2024,15 @@ func (suite *ServiceSuite) TestDelete_Failed() {
 		},
 	}
 
+	// segment not found
+	req.Scope = querypb.DataScope_Streaming
+	status, err := suite.node.Delete(ctx, req)
+	suite.NoError(err)
+	suite.False(merr.Ok(status))
+
 	// target not match
 	req.Base.TargetID = -1
-	status, err := suite.node.Delete(ctx, req)
+	status, err = suite.node.Delete(ctx, req)
 	suite.NoError(err)
 	suite.Equal(commonpb.ErrorCode_NodeIDNotMatch, status.GetErrorCode())
 


### PR DESCRIPTION
Cherry-pick from master
pr: #29474 
See also #27515

When Delegator processes delete data, it forwards delete data with only segment id specified. When two segments has same segment id but one is growing and the other is sealed, the delete will be applied to both segments which causes delete data out of order when concurrent load segment occurs.