### PR TITLE
fix: missing to support compact for Array type

### DIFF
--- a/internal/datanode/compactor.go
+++ b/internal/datanode/compactor.go
@@ -761,6 +761,24 @@ func interface2FieldData(schemaDataType schemapb.DataType, content []interface{}
 		}
 		rst = data
 
+	case schemapb.DataType_Array:
+		data := &storage.ArrayFieldData{
+			Data: make([]*schemapb.ScalarField, 0, len(content)),
+		}
+
+		if len(content) > 0 {
+			data.ElementType = content[0].(*schemapb.ScalarField).GetArrayData().GetElementType()
+		}
+
+		for _, c := range content {
+			r, ok := c.(*schemapb.ScalarField)
+			if !ok {
+				return nil, errTransferType
+			}
+			data.Data = append(data.Data, r)
+		}
+		rst = data
+
 	case schemapb.DataType_FloatVector:
 		data := &storage.FloatVectorFieldData{
 			Data: []float32{},


### PR DESCRIPTION
the array type can't be compacted, the system could continue with the inserted segments, but these segments can be never compacted

fix #29503