### PR TITLE
enhance: allow github actions runner run on ubuntu-latest os

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -42,7 +42,7 @@ concurrency:
 jobs:
   Build:
     name: Build and test AMD64 Ubuntu ${{ matrix.ubuntu }}
-    runs-on: ubuntu-${{ matrix.ubuntu }}
+    runs-on: ubuntu-latest
     timeout-minutes: 180
     strategy:
       fail-fast: false
@@ -105,7 +105,7 @@ jobs:
   UT-Cpp:
     name: UT for Cpp
     needs: Build
-    runs-on: ubuntu-${{ matrix.ubuntu }}
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -145,7 +145,7 @@ jobs:
   UT-Go:
     name: UT for Go
     needs: Build
-    runs-on: ubuntu-${{ matrix.ubuntu }}
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -185,7 +185,7 @@ jobs:
   integration-test:
     name: Integration Test
     needs: Build
-    runs-on: ubuntu-${{ matrix.ubuntu }}
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
       fail-fast: false


### PR DESCRIPTION
since milvus's build procedure is in the responding docker enviornment, this procedure does not bind with particular host os, in turn it allows milvus build on any os , including latest ubuntu os

background:
our self hosted runner is only using ubuntu-latest os

benefit:
make this github workflow obtain the resource from the self-hosted runner