### PR TITLE
enhance: remove flushed segmentInfo in WatchChannelRequest

### DIFF
--- a/internal/querycoordv2/task/utils.go
+++ b/internal/querycoordv2/task/utils.go
@@ -199,7 +199,6 @@ func fillSubChannelRequest(
 	segmentIDs := typeutil.NewUniqueSet()
 	for _, vchannel := range req.GetInfos() {
 		segmentIDs.Insert(vchannel.GetFlushedSegmentIds()...)
-		segmentIDs.Insert(vchannel.GetUnflushedSegmentIds()...)
 	}
 
 	if segmentIDs.Len() == 0 {

--- a/internal/querycoordv2/task/utils.go
+++ b/internal/querycoordv2/task/utils.go
@@ -198,7 +198,7 @@ func fillSubChannelRequest(
 ) error {
 	segmentIDs := typeutil.NewUniqueSet()
 	for _, vchannel := range req.GetInfos() {
-		segmentIDs.Insert(vchannel.GetFlushedSegmentIds()...)
+		segmentIDs.Insert(vchannel.GetUnflushedSegmentIds()...)
 	}
 
 	if segmentIDs.Len() == 0 {


### PR DESCRIPTION
`WatchDmChannel` only need growing segment info, this PR removes fetch segmentInfos when fill watch dml channel request.