### PR TITLE
enhance: [Cherry-pick] remove flushed segmentInfo in WatchChannelRequest

### DIFF
--- a/internal/querycoordv2/task/utils.go
+++ b/internal/querycoordv2/task/utils.go
@@ -186,7 +186,6 @@ func fillSubChannelRequest(
 	segmentIDs := typeutil.NewUniqueSet()
 	for _, vchannel := range req.GetInfos() {
 		segmentIDs.Insert(vchannel.GetFlushedSegmentIds()...)
-		segmentIDs.Insert(vchannel.GetUnflushedSegmentIds()...)
 	}
 
 	if segmentIDs.Len() == 0 {

--- a/internal/querycoordv2/task/utils.go
+++ b/internal/querycoordv2/task/utils.go
@@ -185,7 +185,7 @@ func fillSubChannelRequest(
 ) error {
 	segmentIDs := typeutil.NewUniqueSet()
 	for _, vchannel := range req.GetInfos() {
-		segmentIDs.Insert(vchannel.GetFlushedSegmentIds()...)
+		segmentIDs.Insert(vchannel.GetUnflushedSegmentIds()...)
 	}
 
 	if segmentIDs.Len() == 0 {


### PR DESCRIPTION
Cherry-pick from master
pr: #29526
`WatchDmChannel` only need growing segment info, this PR removes fetch segmentInfos when fill watch dml channel request.