### PR TITLE
fix:Check stopping node during start qc (#27859)

### DIFF
--- a/internal/querycoordv2/server.go
+++ b/internal/querycoordv2/server.go
@@ -399,6 +399,10 @@ func (s *Server) startQueryCoord() error {
 	for _, node := range sessions {
 		s.nodeMgr.Add(session.NewNodeInfo(node.ServerID, node.Address))
 		s.taskScheduler.AddExecutor(node.ServerID)
+
+		if node.Stopping {
+			s.nodeMgr.Stopping(node.ServerID)
+		}
 	}
 	for _, node := range sessions {
 		s.handleNodeUp(node.ServerID)

--- a/internal/querycoordv2/server_test.go
+++ b/internal/querycoordv2/server_test.go
@@ -141,6 +141,10 @@ func (suite *ServerSuite) TestRecover() {
 	err := suite.server.Stop()
 	suite.NoError(err)
 
+	//  stopping querynode
+	downNode := suite.nodes[0]
+	downNode.Stopping()
+
 	suite.server, err = suite.newQueryCoord()
 	suite.NoError(err)
 	suite.hackServer()
@@ -150,6 +154,8 @@ func (suite *ServerSuite) TestRecover() {
 	for _, collection := range suite.collections {
 		suite.assertLoaded(collection)
 	}
+
+	suite.True(suite.server.nodeMgr.IsStoppingNode(suite.nodes[0].ID))
 }
 
 func (suite *ServerSuite) TestNodeUp() {


### PR DESCRIPTION
pr: #27859

This PR checks query node's stopping state during start progress