### PR TITLE
feat: add collection level flush rate control

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -633,6 +633,8 @@ quotaAndLimits:
   flushRate:
     enabled: false
     max: -1 # qps, default no limit, rate for flush
+    collection:
+      max: -1 # qps, default no limit, rate for flush at collection level.
   compactionRate:
     enabled: false
     max: -1 # qps, default no limit, rate for manualCompaction

--- a/internal/proxy/rate_limit_interceptor_test.go
+++ b/internal/proxy/rate_limit_interceptor_test.go
@@ -38,7 +38,7 @@ type limiterMock struct {
 	quotaStateReasons []commonpb.ErrorCode
 }
 
-func (l *limiterMock) Check(collection int64, rt internalpb.RateType, n int) error {
+func (l *limiterMock) Check(collection []int64, rt internalpb.RateType, n int) error {
 	if l.rate == 0 {
 		return merr.ErrServiceQuotaExceeded
 	}
@@ -61,108 +61,109 @@ func TestRateLimitInterceptor(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, proto.Size(&milvuspb.InsertRequest{}), size)
 		assert.Equal(t, internalpb.RateType_DMLInsert, rt)
-		assert.Equal(t, collection, int64(0))
+		assert.ElementsMatch(t, collection, []int64{int64(0)})
 
 		collection, rt, size, err = getRequestInfo(&milvuspb.UpsertRequest{})
 		assert.NoError(t, err)
 		assert.Equal(t, proto.Size(&milvuspb.InsertRequest{}), size)
 		assert.Equal(t, internalpb.RateType_DMLUpsert, rt)
-		assert.Equal(t, collection, int64(0))
+		assert.ElementsMatch(t, collection, []int64{int64(0)})
 
 		collection, rt, size, err = getRequestInfo(&milvuspb.DeleteRequest{})
 		assert.NoError(t, err)
 		assert.Equal(t, proto.Size(&milvuspb.DeleteRequest{}), size)
 		assert.Equal(t, internalpb.RateType_DMLDelete, rt)
-		assert.Equal(t, collection, int64(0))
+		assert.ElementsMatch(t, collection, []int64{int64(0)})
 
 		collection, rt, size, err = getRequestInfo(&milvuspb.ImportRequest{})
 		assert.NoError(t, err)
 		assert.Equal(t, proto.Size(&milvuspb.ImportRequest{}), size)
 		assert.Equal(t, internalpb.RateType_DMLBulkLoad, rt)
-		assert.Equal(t, collection, int64(0))
+		assert.ElementsMatch(t, collection, []int64{int64(0)})
 
 		collection, rt, size, err = getRequestInfo(&milvuspb.SearchRequest{Nq: 5})
 		assert.NoError(t, err)
 		assert.Equal(t, 5, size)
 		assert.Equal(t, internalpb.RateType_DQLSearch, rt)
-		assert.Equal(t, collection, int64(0))
+		assert.ElementsMatch(t, collection, []int64{int64(0)})
 
 		collection, rt, size, err = getRequestInfo(&milvuspb.QueryRequest{})
 		assert.NoError(t, err)
 		assert.Equal(t, 1, size)
 		assert.Equal(t, internalpb.RateType_DQLQuery, rt)
-		assert.Equal(t, collection, int64(0))
+		assert.ElementsMatch(t, collection, []int64{int64(0)})
 
 		collection, rt, size, err = getRequestInfo(&milvuspb.CreateCollectionRequest{})
 		assert.NoError(t, err)
 		assert.Equal(t, 1, size)
 		assert.Equal(t, internalpb.RateType_DDLCollection, rt)
-		assert.Equal(t, collection, int64(0))
+		assert.ElementsMatch(t, collection, []int64{int64(0)})
 
 		collection, rt, size, err = getRequestInfo(&milvuspb.LoadCollectionRequest{})
 		assert.NoError(t, err)
 		assert.Equal(t, 1, size)
 		assert.Equal(t, internalpb.RateType_DDLCollection, rt)
-		assert.Equal(t, collection, int64(0))
+		assert.ElementsMatch(t, collection, []int64{int64(0)})
 
 		collection, rt, size, err = getRequestInfo(&milvuspb.ReleaseCollectionRequest{})
 		assert.NoError(t, err)
 		assert.Equal(t, 1, size)
 		assert.Equal(t, internalpb.RateType_DDLCollection, rt)
-		assert.Equal(t, collection, int64(0))
+		assert.ElementsMatch(t, collection, []int64{int64(0)})
 
 		collection, rt, size, err = getRequestInfo(&milvuspb.DropCollectionRequest{})
 		assert.NoError(t, err)
 		assert.Equal(t, 1, size)
 		assert.Equal(t, internalpb.RateType_DDLCollection, rt)
-		assert.Equal(t, collection, int64(0))
+		assert.ElementsMatch(t, collection, []int64{int64(0)})
 
 		collection, rt, size, err = getRequestInfo(&milvuspb.CreatePartitionRequest{})
 		assert.NoError(t, err)
 		assert.Equal(t, 1, size)
 		assert.Equal(t, internalpb.RateType_DDLPartition, rt)
-		assert.Equal(t, collection, int64(0))
+		assert.ElementsMatch(t, collection, []int64{int64(0)})
 
 		collection, rt, size, err = getRequestInfo(&milvuspb.LoadPartitionsRequest{})
 		assert.NoError(t, err)
 		assert.Equal(t, 1, size)
 		assert.Equal(t, internalpb.RateType_DDLPartition, rt)
-		assert.Equal(t, collection, int64(0))
+		assert.ElementsMatch(t, collection, []int64{int64(0)})
 
 		collection, rt, size, err = getRequestInfo(&milvuspb.ReleasePartitionsRequest{})
 		assert.NoError(t, err)
 		assert.Equal(t, 1, size)
 		assert.Equal(t, internalpb.RateType_DDLPartition, rt)
-		assert.Equal(t, collection, int64(0))
+		assert.ElementsMatch(t, collection, []int64{int64(0)})
 
 		collection, rt, size, err = getRequestInfo(&milvuspb.DropPartitionRequest{})
 		assert.NoError(t, err)
 		assert.Equal(t, 1, size)
 		assert.Equal(t, internalpb.RateType_DDLPartition, rt)
-		assert.Equal(t, collection, int64(0))
+		assert.ElementsMatch(t, collection, []int64{int64(0)})
 
 		collection, rt, size, err = getRequestInfo(&milvuspb.CreateIndexRequest{})
 		assert.NoError(t, err)
 		assert.Equal(t, 1, size)
 		assert.Equal(t, internalpb.RateType_DDLIndex, rt)
-		assert.Equal(t, collection, int64(0))
+		assert.ElementsMatch(t, collection, []int64{int64(0)})
 
 		collection, rt, size, err = getRequestInfo(&milvuspb.DropIndexRequest{})
 		assert.NoError(t, err)
 		assert.Equal(t, 1, size)
 		assert.Equal(t, internalpb.RateType_DDLIndex, rt)
-		assert.Equal(t, collection, int64(0))
+		assert.ElementsMatch(t, collection, []int64{int64(0)})
 
-		_, rt, size, err = getRequestInfo(&milvuspb.FlushRequest{})
+		collection, rt, size, err = getRequestInfo(&milvuspb.FlushRequest{})
 		assert.NoError(t, err)
 		assert.Equal(t, 1, size)
 		assert.Equal(t, internalpb.RateType_DDLFlush, rt)
+		assert.Len(t, collection, 0)
 
 		collection, rt, size, err = getRequestInfo(&milvuspb.ManualCompactionRequest{})
 		assert.NoError(t, err)
 		assert.Equal(t, 1, size)
 		assert.Equal(t, internalpb.RateType_DDLCompaction, rt)
-		assert.Equal(t, collection, int64(0))
+		assert.Len(t, collection, 0)
 	})
 
 	t.Run("test getFailedResponse", func(t *testing.T) {

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -37,7 +37,7 @@ import (
 // If Limit function return true, the request will be rejected.
 // Otherwise, the request will pass. Limit also returns limit of limiter.
 type Limiter interface {
-	Check(collectionID int64, rt internalpb.RateType, n int) error
+	Check(collectionIDs []int64, rt internalpb.RateType, n int) error
 }
 
 // Component is the interface all services implement

--- a/pkg/util/paramtable/quota_param.go
+++ b/pkg/util/paramtable/quota_param.go
@@ -54,8 +54,9 @@ type quotaConfig struct {
 	IndexLimitEnabled ParamItem `refreshable:"true"`
 	MaxIndexRate      ParamItem `refreshable:"true"`
 
-	FlushLimitEnabled ParamItem `refreshable:"true"`
-	MaxFlushRate      ParamItem `refreshable:"true"`
+	FlushLimitEnabled         ParamItem `refreshable:"true"`
+	MaxFlushRate              ParamItem `refreshable:"true"`
+	MaxFlushRatePerCollection ParamItem `refreshable:"true"`
 
 	CompactionLimitEnabled ParamItem `refreshable:"true"`
 	MaxCompactionRate      ParamItem `refreshable:"true"`
@@ -256,6 +257,25 @@ seconds, (0 ~ 65536)`,
 		Export: true,
 	}
 	p.MaxFlushRate.Init(base.mgr)
+
+	p.MaxFlushRatePerCollection = ParamItem{
+		Key:          "quotaAndLimits.flushRate.collection.max",
+		Version:      "2.3.9",
+		DefaultValue: "-1",
+		Formatter: func(v string) string {
+			if !p.FlushLimitEnabled.GetAsBool() {
+				return max
+			}
+			// [0 ~ Inf)
+			if getAsInt(v) < 0 {
+				return max
+			}
+			return v
+		},
+		Doc:    "qps, default no limit, rate for flush at collection level.",
+		Export: true,
+	}
+	p.MaxFlushRatePerCollection.Init(base.mgr)
 
 	p.CompactionLimitEnabled = ParamItem{
 		Key:          "quotaAndLimits.compactionRate.enabled",

--- a/pkg/util/paramtable/quota_param_test.go
+++ b/pkg/util/paramtable/quota_param_test.go
@@ -41,7 +41,8 @@ func TestQuotaParam(t *testing.T) {
 	t.Run("test functional params", func(t *testing.T) {
 		assert.Equal(t, false, qc.IndexLimitEnabled.GetAsBool())
 		assert.Equal(t, defaultMax, qc.MaxIndexRate.GetAsFloat())
-		assert.Equal(t, false, qc.FlushLimitEnabled.GetAsBool())
+		assert.False(t, qc.FlushLimitEnabled.GetAsBool())
+		assert.Equal(t, defaultMax, qc.MaxFlushRatePerCollection.GetAsFloat())
 		assert.Equal(t, defaultMax, qc.MaxFlushRate.GetAsFloat())
 		assert.Equal(t, false, qc.CompactionLimitEnabled.GetAsBool())
 		assert.Equal(t, defaultMax, qc.MaxCompactionRate.GetAsFloat())


### PR DESCRIPTION
flush rate control at collection level to avoid generate too much segment.
0.1 qps by default.

issue: #29477