### PR TITLE
fix: always sync level zero segments as flushed

### DIFF
--- a/internal/datanode/writebuffer/write_buffer.go
+++ b/internal/datanode/writebuffer/write_buffer.go
@@ -403,7 +403,8 @@ func (wb *writeBufferBase) getSyncTask(ctx context.Context, segmentID int64) (sy
 		WithCheckpoint(wb.checkpoint).
 		WithBatchSize(batchSize)
 
-	if segmentInfo.State() == commonpb.SegmentState_Flushing {
+	if segmentInfo.State() == commonpb.SegmentState_Flushing ||
+		segmentInfo.Level() == datapb.SegmentLevel_L0 { // Level zero segment will always be sync as flushed
 		pack.WithFlush()
 	}
 


### PR DESCRIPTION
See also #27675

For now, Level zero segments shall always be synced as `Flushed` ones. This PR fixes when level zero segments selected by policies other than flush ts policy will be synced as growing state.