### PR TITLE
fix: [Cherry-pick] Add atomic method to get collection target

### DIFF
--- a/internal/querycoordv2/meta/target_manager_test.go
+++ b/internal/querycoordv2/meta/target_manager_test.go
@@ -415,6 +415,135 @@ func (suite *TargetManagerSuite) TestGetSegmentByChannel() {
 	suite.Len(suite.mgr.GetDroppedSegmentsByChannel(collectionID, "channel-1", NextTarget), 3)
 }
 
+func (suite *TargetManagerSuite) TestGetTarget() {
+	type testCase struct {
+		tag          string
+		mgr          *TargetManager
+		scope        TargetScope
+		expectTarget *CollectionTarget
+	}
+
+	current := &CollectionTarget{}
+	next := &CollectionTarget{}
+
+	bothMgr := &TargetManager{
+		current: &target{
+			collectionTargetMap: map[int64]*CollectionTarget{
+				1000: current,
+			},
+		},
+		next: &target{
+			collectionTargetMap: map[int64]*CollectionTarget{
+				1000: current,
+			},
+		},
+	}
+	currentMgr := &TargetManager{
+		current: &target{
+			collectionTargetMap: map[int64]*CollectionTarget{
+				1000: current,
+			},
+		},
+		next: &target{},
+	}
+	nextMgr := &TargetManager{
+		next: &target{
+			collectionTargetMap: map[int64]*CollectionTarget{
+				1000: current,
+			},
+		},
+		current: &target{},
+	}
+
+	cases := []testCase{
+		{
+			tag:          "both_scope_unknown",
+			mgr:          bothMgr,
+			scope:        -1,
+			expectTarget: nil,
+		},
+		{
+			tag:          "both_scope_current",
+			mgr:          bothMgr,
+			scope:        CurrentTarget,
+			expectTarget: current,
+		},
+		{
+			tag:          "both_scope_next",
+			mgr:          bothMgr,
+			scope:        NextTarget,
+			expectTarget: next,
+		},
+		{
+			tag:          "both_scope_current_first",
+			mgr:          bothMgr,
+			scope:        CurrentTargetFirst,
+			expectTarget: current,
+		},
+		{
+			tag:          "both_scope_next_first",
+			mgr:          bothMgr,
+			scope:        NextTargetFirst,
+			expectTarget: next,
+		},
+		{
+			tag:          "next_scope_current",
+			mgr:          nextMgr,
+			scope:        CurrentTarget,
+			expectTarget: nil,
+		},
+		{
+			tag:          "next_scope_next",
+			mgr:          nextMgr,
+			scope:        NextTarget,
+			expectTarget: next,
+		},
+		{
+			tag:          "next_scope_current_first",
+			mgr:          nextMgr,
+			scope:        CurrentTargetFirst,
+			expectTarget: next,
+		},
+		{
+			tag:          "next_scope_next_first",
+			mgr:          nextMgr,
+			scope:        NextTargetFirst,
+			expectTarget: next,
+		},
+		{
+			tag:          "current_scope_current",
+			mgr:          currentMgr,
+			scope:        CurrentTarget,
+			expectTarget: current,
+		},
+		{
+			tag:          "current_scope_next",
+			mgr:          currentMgr,
+			scope:        NextTarget,
+			expectTarget: nil,
+		},
+		{
+			tag:          "current_scope_current_first",
+			mgr:          currentMgr,
+			scope:        CurrentTargetFirst,
+			expectTarget: current,
+		},
+		{
+			tag:          "current_scope_next_first",
+			mgr:          currentMgr,
+			scope:        NextTargetFirst,
+			expectTarget: current,
+		},
+	}
+
+	for _, tc := range cases {
+		suite.Run(tc.tag, func() {
+			target := tc.mgr.getCollectionTarget(tc.scope, 1000)
+			suite.Equal(tc.expectTarget, target)
+		})
+	}
+}
+
 func TestTargetManager(t *testing.T) {
 	suite.Run(t, new(TargetManagerSuite))
 }

--- a/internal/querycoordv2/observers/leader_observer.go
+++ b/internal/querycoordv2/observers/leader_observer.go
@@ -152,26 +152,24 @@ func (o *LeaderObserver) findNeedLoadedSegments(leaderView *meta.LeaderView, dis
 				continue
 			}
 
-			channel := o.target.GetDmChannel(s.GetCollectionID(), s.GetInsertChannel(), meta.NextTarget)
-			if channel == nil {
-				channel = o.target.GetDmChannel(s.GetCollectionID(), s.GetInsertChannel(), meta.CurrentTarget)
-			}
-			loadInfo := utils.PackSegmentLoadInfo(resp, channel.GetSeekPosition(), nil)
+			if channel := o.target.GetDmChannel(s.GetCollectionID(), s.GetInsertChannel(), meta.NextTargetFirst); channel != nil {
+				loadInfo := utils.PackSegmentLoadInfo(resp, channel.GetSeekPosition(), nil)
 
-			log.Debug("leader observer append a segment to set",
-				zap.Int64("collectionID", leaderView.CollectionID),
-				zap.String("channel", leaderView.Channel),
-				zap.Int64("leaderViewID", leaderView.ID),
-				zap.Int64("segmentID", s.GetID()),
-				zap.Int64("nodeID", s.Node))
-			ret = append(ret, &querypb.SyncAction{
-				Type:        querypb.SyncType_Set,
-				PartitionID: s.GetPartitionID(),
-				SegmentID:   s.GetID(),
-				NodeID:      s.Node,
-				Version:     s.Version,
-				Info:        loadInfo,
-			})
+				log.Debug("leader observer append a segment to set",
+					zap.Int64("collectionID", leaderView.CollectionID),
+					zap.String("channel", leaderView.Channel),
+					zap.Int64("leaderViewID", leaderView.ID),
+					zap.Int64("segmentID", s.GetID()),
+					zap.Int64("nodeID", s.Node))
+				ret = append(ret, &querypb.SyncAction{
+					Type:        querypb.SyncType_Set,
+					PartitionID: s.GetPartitionID(),
+					SegmentID:   s.GetID(),
+					NodeID:      s.Node,
+					Version:     s.Version,
+					Info:        loadInfo,
+				})
+			}
 		}
 	}
 	return ret


### PR DESCRIPTION
Cherry pick from master
pr: #29577
Related to #29575

Add `getCollectionTarget` method which is atomic when scope is
`CurrentTargetFirst` or `NextTargetFirst`
Also return error when executor finds no channel in target manager