### PR TITLE
fix: throw exception when upload file failed for DiskIndex

### DIFF
--- a/internal/core/src/index/VectorDiskIndex.cpp
+++ b/internal/core/src/index/VectorDiskIndex.cpp
@@ -134,7 +134,11 @@ template <typename T>
 BinarySet
 VectorDiskAnnIndex<T>::Upload(const Config& config) {
     BinarySet ret;
-    index_.Serialize(ret);
+    auto stat = index_.Serialize(ret);
+    if (stat != knowhere::Status::success) {
+        PanicInfo(ErrorCode::UnexpectedError,
+                  "failed to serialize index, " + KnowhereStatusString(stat));
+    }
     auto remote_paths_to_size = file_manager_->GetRemotePathsToFileSize();
     for (auto& file : remote_paths_to_size) {
         ret.Append(file.first, nullptr, file.second);


### PR DESCRIPTION
related to : #29417 

cardinal indexes upload index files in `Serialize` interface, and throw exception when the `Serialize` failed.