### PR TITLE
fix: the config value of DataCoordTimeTick become longer and longer

### DIFF
--- a/internal/datacoord/server_test.go
+++ b/internal/datacoord/server_test.go
@@ -4309,6 +4309,7 @@ func closeTestServer(t *testing.T, svr *Server) {
 	assert.NoError(t, err)
 	err = svr.CleanMeta()
 	assert.NoError(t, err)
+	paramtable.Get().Reset(Params.CommonCfg.DataCoordTimeTick.Key)
 }
 
 func newTestServer2(t *testing.T, receiveCh chan any, opts ...Option) *Server {


### PR DESCRIPTION
#29658 