### PR TITLE
enhance: Remove deprecated timeout param in segment/channel task

### DIFF
--- a/internal/querycoordv2/balance/utils.go
+++ b/internal/querycoordv2/balance/utils.go
@@ -19,7 +19,6 @@ package balance
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"go.uber.org/zap"
 
@@ -34,7 +33,7 @@ const (
 	DistInfoPrefix = "Balance-Dists:"
 )
 
-func CreateSegmentTasksFromPlans(ctx context.Context, source task.Source, timeout time.Duration, plans []SegmentAssignPlan) []task.Task {
+func CreateSegmentTasksFromPlans(ctx context.Context, source task.Source, plans []SegmentAssignPlan) []task.Task {
 	ret := make([]task.Task, 0)
 	for _, p := range plans {
 		actions := make([]task.Action, 0)
@@ -48,7 +47,6 @@ func CreateSegmentTasksFromPlans(ctx context.Context, source task.Source, timeou
 		}
 		t, err := task.NewSegmentTask(
 			ctx,
-			timeout,
 			source,
 			p.Segment.GetCollectionID(),
 			p.ReplicaID,
@@ -86,7 +84,7 @@ func CreateSegmentTasksFromPlans(ctx context.Context, source task.Source, timeou
 	return ret
 }
 
-func CreateChannelTasksFromPlans(ctx context.Context, source task.Source, timeout time.Duration, plans []ChannelAssignPlan) []task.Task {
+func CreateChannelTasksFromPlans(ctx context.Context, source task.Source, plans []ChannelAssignPlan) []task.Task {
 	ret := make([]task.Task, 0, len(plans))
 	for _, p := range plans {
 		actions := make([]task.Action, 0)
@@ -98,7 +96,7 @@ func CreateChannelTasksFromPlans(ctx context.Context, source task.Source, timeou
 			action := task.NewChannelAction(p.From, task.ActionTypeReduce, p.Channel.GetChannelName())
 			actions = append(actions, action)
 		}
-		t, err := task.NewChannelTask(ctx, timeout, source, p.Channel.GetCollectionID(), p.ReplicaID, actions...)
+		t, err := task.NewChannelTask(ctx, source, p.Channel.GetCollectionID(), p.ReplicaID, actions...)
 		if err != nil {
 			log.Warn("create channel task failed",
 				zap.Int64("collection", p.Channel.GetCollectionID()),

--- a/internal/querycoordv2/checkers/balance_checker.go
+++ b/internal/querycoordv2/checkers/balance_checker.go
@@ -19,7 +19,6 @@ package checkers
 import (
 	"context"
 	"sort"
-	"time"
 
 	"github.com/samber/lo"
 	"go.uber.org/zap"
@@ -154,12 +153,12 @@ func (b *BalanceChecker) Check(ctx context.Context) []task.Task {
 	replicasToBalance := b.replicasToBalance()
 	segmentPlans, channelPlans := b.balanceReplicas(replicasToBalance)
 
-	tasks := balance.CreateSegmentTasksFromPlans(ctx, b.ID(), Params.QueryCoordCfg.SegmentTaskTimeout.GetAsDuration(time.Millisecond), segmentPlans)
+	tasks := balance.CreateSegmentTasksFromPlans(ctx, b.ID(), segmentPlans)
 	task.SetPriority(task.TaskPriorityLow, tasks...)
 	task.SetReason("segment unbalanced", tasks...)
 	ret = append(ret, tasks...)
 
-	tasks = balance.CreateChannelTasksFromPlans(ctx, b.ID(), Params.QueryCoordCfg.ChannelTaskTimeout.GetAsDuration(time.Millisecond), channelPlans)
+	tasks = balance.CreateChannelTasksFromPlans(ctx, b.ID(), channelPlans)
 	task.SetReason("channel unbalanced", tasks...)
 	ret = append(ret, tasks...)
 	return ret

--- a/internal/querycoordv2/checkers/channel_checker.go
+++ b/internal/querycoordv2/checkers/channel_checker.go
@@ -18,14 +18,12 @@ package checkers
 
 import (
 	"context"
-	"time"
 
 	"github.com/samber/lo"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/internal/querycoordv2/balance"
 	"github.com/milvus-io/milvus/internal/querycoordv2/meta"
-	. "github.com/milvus-io/milvus/internal/querycoordv2/params"
 	"github.com/milvus-io/milvus/internal/querycoordv2/task"
 	"github.com/milvus-io/milvus/internal/querycoordv2/utils"
 	"github.com/milvus-io/milvus/pkg/log"
@@ -200,14 +198,14 @@ func (c *ChannelChecker) createChannelLoadTask(ctx context.Context, channels []*
 		plans[i].ReplicaID = replica.GetID()
 	}
 
-	return balance.CreateChannelTasksFromPlans(ctx, c.ID(), Params.QueryCoordCfg.ChannelTaskTimeout.GetAsDuration(time.Millisecond), plans)
+	return balance.CreateChannelTasksFromPlans(ctx, c.ID(), plans)
 }
 
 func (c *ChannelChecker) createChannelReduceTasks(ctx context.Context, channels []*meta.DmChannel, replicaID int64) []task.Task {
 	ret := make([]task.Task, 0, len(channels))
 	for _, ch := range channels {
 		action := task.NewChannelAction(ch.Node, task.ActionTypeReduce, ch.GetChannelName())
-		task, err := task.NewChannelTask(ctx, Params.QueryCoordCfg.ChannelTaskTimeout.GetAsDuration(time.Millisecond), c.ID(), ch.GetCollectionID(), replicaID, action)
+		task, err := task.NewChannelTask(ctx, c.ID(), ch.GetCollectionID(), replicaID, action)
 		if err != nil {
 			log.Warn("create channel reduce task failed",
 				zap.Int64("collection", ch.GetCollectionID()),

--- a/internal/querycoordv2/checkers/index_checker.go
+++ b/internal/querycoordv2/checkers/index_checker.go
@@ -18,14 +18,12 @@ package checkers
 
 import (
 	"context"
-	"time"
 
 	"github.com/samber/lo"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/internal/proto/querypb"
 	"github.com/milvus-io/milvus/internal/querycoordv2/meta"
-	"github.com/milvus-io/milvus/internal/querycoordv2/params"
 	"github.com/milvus-io/milvus/internal/querycoordv2/session"
 	"github.com/milvus-io/milvus/internal/querycoordv2/task"
 	"github.com/milvus-io/milvus/pkg/log"
@@ -161,7 +159,6 @@ func (c *IndexChecker) createSegmentUpdateTask(ctx context.Context, segment *met
 	action := task.NewSegmentActionWithScope(segment.Node, task.ActionTypeUpdate, segment.GetInsertChannel(), segment.GetID(), querypb.DataScope_Historical)
 	t, err := task.NewSegmentTask(
 		ctx,
-		params.Params.QueryCoordCfg.SegmentTaskTimeout.GetAsDuration(time.Millisecond),
 		c.ID(),
 		segment.GetCollectionID(),
 		replica.GetID(),

--- a/internal/querycoordv2/checkers/segment_checker.go
+++ b/internal/querycoordv2/checkers/segment_checker.go
@@ -19,7 +19,6 @@ package checkers
 import (
 	"context"
 	"sort"
-	"time"
 
 	"github.com/samber/lo"
 	"go.uber.org/zap"
@@ -28,7 +27,6 @@ import (
 	"github.com/milvus-io/milvus/internal/proto/querypb"
 	"github.com/milvus-io/milvus/internal/querycoordv2/balance"
 	"github.com/milvus-io/milvus/internal/querycoordv2/meta"
-	. "github.com/milvus-io/milvus/internal/querycoordv2/params"
 	"github.com/milvus-io/milvus/internal/querycoordv2/session"
 	"github.com/milvus-io/milvus/internal/querycoordv2/task"
 	"github.com/milvus-io/milvus/internal/querycoordv2/utils"
@@ -381,7 +379,7 @@ func (c *SegmentChecker) createSegmentLoadTasks(ctx context.Context, segments []
 		plans = append(plans, shardPlans...)
 	}
 
-	return balance.CreateSegmentTasksFromPlans(ctx, c.ID(), Params.QueryCoordCfg.SegmentTaskTimeout.GetAsDuration(time.Millisecond), plans)
+	return balance.CreateSegmentTasksFromPlans(ctx, c.ID(), plans)
 }
 
 func (c *SegmentChecker) createSegmentReduceTasks(ctx context.Context, segments []*meta.Segment, replicaID int64, scope querypb.DataScope) []task.Task {
@@ -390,7 +388,6 @@ func (c *SegmentChecker) createSegmentReduceTasks(ctx context.Context, segments 
 		action := task.NewSegmentActionWithScope(s.Node, task.ActionTypeReduce, s.GetInsertChannel(), s.GetID(), scope)
 		task, err := task.NewSegmentTask(
 			ctx,
-			Params.QueryCoordCfg.SegmentTaskTimeout.GetAsDuration(time.Millisecond),
 			c.ID(),
 			s.GetCollectionID(),
 			replicaID,

--- a/internal/querycoordv2/handlers.go
+++ b/internal/querycoordv2/handlers.go
@@ -141,7 +141,6 @@ func (s *Server) balanceSegments(ctx context.Context, req *querypb.LoadBalanceRe
 			zap.Int64("segmentID", plan.Segment.GetID()),
 		)
 		task, err := task.NewSegmentTask(ctx,
-			Params.QueryCoordCfg.SegmentTaskTimeout.GetAsDuration(time.Millisecond),
 			task.WrapIDSource(req.GetBase().GetMsgID()),
 			req.GetCollectionID(),
 			replica.GetID(),

--- a/internal/querycoordv2/task/task.go
+++ b/internal/querycoordv2/task/task.go
@@ -19,7 +19,6 @@ package task
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/cockroachdb/errors"
 	"go.opentelemetry.io/otel"
@@ -285,7 +284,6 @@ type SegmentTask struct {
 // all actions must process the same segment,
 // empty actions is not allowed
 func NewSegmentTask(ctx context.Context,
-	timeout time.Duration,
 	source Source,
 	collectionID,
 	replicaID UniqueID,
@@ -342,7 +340,6 @@ type ChannelTask struct {
 // all actions must process the same channel, and the same type of channel
 // empty actions is not allowed
 func NewChannelTask(ctx context.Context,
-	timeout time.Duration,
 	source Source,
 	collectionID,
 	replicaID UniqueID,

--- a/internal/querycoordv2/task/task_test.go
+++ b/internal/querycoordv2/task/task_test.go
@@ -244,7 +244,6 @@ func (suite *TaskSuite) TestSubscribeChannelTask() {
 		})
 		task, err := NewChannelTask(
 			ctx,
-			timeout,
 			WrapIDSource(0),
 			suite.collection,
 			suite.replica,
@@ -286,14 +285,12 @@ func (suite *TaskSuite) TestSubscribeChannelTask() {
 
 func (suite *TaskSuite) TestSubmitDuplicateSubscribeChannelTask() {
 	ctx := context.Background()
-	timeout := 10 * time.Second
 	targetNode := int64(3)
 
 	tasks := []Task{}
 	for _, channel := range suite.subChannels {
 		task, err := NewChannelTask(
 			ctx,
-			timeout,
 			WrapIDSource(0),
 			suite.collection,
 			suite.replica,
@@ -322,7 +319,6 @@ func (suite *TaskSuite) TestSubmitDuplicateSubscribeChannelTask() {
 
 func (suite *TaskSuite) TestUnsubscribeChannelTask() {
 	ctx := context.Background()
-	timeout := 10 * time.Second
 	targetNode := int64(1)
 
 	// Expect
@@ -338,7 +334,6 @@ func (suite *TaskSuite) TestUnsubscribeChannelTask() {
 		})
 		task, err := NewChannelTask(
 			ctx,
-			timeout,
 			WrapIDSource(0),
 			suite.collection,
 			-1,
@@ -378,7 +373,6 @@ func (suite *TaskSuite) TestUnsubscribeChannelTask() {
 
 func (suite *TaskSuite) TestLoadSegmentTask() {
 	ctx := context.Background()
-	timeout := 10 * time.Second
 	targetNode := int64(3)
 	partition := int64(100)
 	channel := &datapb.VchannelInfo{
@@ -430,7 +424,6 @@ func (suite *TaskSuite) TestLoadSegmentTask() {
 		})
 		task, err := NewSegmentTask(
 			ctx,
-			timeout,
 			WrapIDSource(0),
 			suite.collection,
 			suite.replica,
@@ -476,7 +469,6 @@ func (suite *TaskSuite) TestLoadSegmentTask() {
 
 func (suite *TaskSuite) TestLoadSegmentTaskNotIndex() {
 	ctx := context.Background()
-	timeout := 10 * time.Second
 	targetNode := int64(3)
 	partition := int64(100)
 	channel := &datapb.VchannelInfo{
@@ -528,7 +520,6 @@ func (suite *TaskSuite) TestLoadSegmentTaskNotIndex() {
 		})
 		task, err := NewSegmentTask(
 			ctx,
-			timeout,
 			WrapIDSource(0),
 			suite.collection,
 			suite.replica,
@@ -620,7 +611,6 @@ func (suite *TaskSuite) TestLoadSegmentTaskFailed() {
 		})
 		task, err := NewSegmentTask(
 			ctx,
-			timeout,
 			WrapIDSource(0),
 			suite.collection,
 			suite.replica,
@@ -653,7 +643,6 @@ func (suite *TaskSuite) TestLoadSegmentTaskFailed() {
 
 func (suite *TaskSuite) TestReleaseSegmentTask() {
 	ctx := context.Background()
-	timeout := 10 * time.Second
 	targetNode := int64(3)
 	partition := int64(100)
 	channel := &datapb.VchannelInfo{
@@ -685,7 +674,6 @@ func (suite *TaskSuite) TestReleaseSegmentTask() {
 		view.Segments[segment] = &querypb.SegmentDist{NodeID: targetNode, Version: 0}
 		task, err := NewSegmentTask(
 			ctx,
-			timeout,
 			WrapIDSource(0),
 			suite.collection,
 			suite.replica,
@@ -719,7 +707,6 @@ func (suite *TaskSuite) TestReleaseSegmentTask() {
 
 func (suite *TaskSuite) TestReleaseGrowingSegmentTask() {
 	ctx := context.Background()
-	timeout := 10 * time.Second
 	targetNode := int64(3)
 
 	// Expect
@@ -729,7 +716,6 @@ func (suite *TaskSuite) TestReleaseGrowingSegmentTask() {
 	for _, segment := range suite.releaseSegments {
 		task, err := NewSegmentTask(
 			ctx,
-			timeout,
 			WrapIDSource(0),
 			suite.collection,
 			suite.replica,
@@ -772,7 +758,6 @@ func (suite *TaskSuite) TestReleaseGrowingSegmentTask() {
 
 func (suite *TaskSuite) TestMoveSegmentTask() {
 	ctx := context.Background()
-	timeout := 10 * time.Second
 	leader := int64(1)
 	sourceNode := int64(2)
 	targetNode := int64(3)
@@ -837,7 +822,6 @@ func (suite *TaskSuite) TestMoveSegmentTask() {
 
 		task, err := NewSegmentTask(
 			ctx,
-			timeout,
 			WrapIDSource(0),
 			suite.collection,
 			suite.replica,
@@ -889,7 +873,6 @@ func (suite *TaskSuite) TestMoveSegmentTask() {
 
 func (suite *TaskSuite) TestMoveSegmentTaskStale() {
 	ctx := context.Background()
-	timeout := 10 * time.Second
 	leader := int64(1)
 	sourceNode := int64(2)
 	targetNode := int64(3)
@@ -921,7 +904,6 @@ func (suite *TaskSuite) TestMoveSegmentTaskStale() {
 
 		task, err := NewSegmentTask(
 			ctx,
-			timeout,
 			WrapIDSource(0),
 			suite.collection,
 			suite.replica,
@@ -946,7 +928,6 @@ func (suite *TaskSuite) TestMoveSegmentTaskStale() {
 
 func (suite *TaskSuite) TestTaskCanceled() {
 	ctx := context.Background()
-	timeout := 10 * time.Second
 	targetNode := int64(3)
 	partition := int64(100)
 	channel := &datapb.VchannelInfo{
@@ -998,7 +979,6 @@ func (suite *TaskSuite) TestTaskCanceled() {
 		})
 		task, err := NewSegmentTask(
 			ctx,
-			timeout,
 			WrapIDSource(0),
 			suite.collection,
 			suite.replica,
@@ -1035,7 +1015,6 @@ func (suite *TaskSuite) TestTaskCanceled() {
 
 func (suite *TaskSuite) TestSegmentTaskStale() {
 	ctx := context.Background()
-	timeout := 10 * time.Second
 	targetNode := int64(3)
 	partition := int64(100)
 	channel := &datapb.VchannelInfo{
@@ -1088,7 +1067,6 @@ func (suite *TaskSuite) TestSegmentTaskStale() {
 		})
 		task, err := NewSegmentTask(
 			ctx,
-			timeout,
 			WrapIDSource(0),
 			suite.collection,
 			suite.replica,
@@ -1156,13 +1134,11 @@ func (suite *TaskSuite) TestSegmentTaskStale() {
 
 func (suite *TaskSuite) TestChannelTaskReplace() {
 	ctx := context.Background()
-	timeout := 10 * time.Second
 	targetNode := int64(3)
 
 	for _, channel := range suite.subChannels {
 		task, err := NewChannelTask(
 			ctx,
-			timeout,
 			WrapIDSource(0),
 			suite.collection,
 			suite.replica,
@@ -1179,7 +1155,6 @@ func (suite *TaskSuite) TestChannelTaskReplace() {
 	for _, channel := range suite.subChannels {
 		task, err := NewChannelTask(
 			ctx,
-			timeout,
 			WrapIDSource(0),
 			suite.collection,
 			suite.replica,
@@ -1198,7 +1173,6 @@ func (suite *TaskSuite) TestChannelTaskReplace() {
 	for _, channel := range suite.subChannels {
 		task, err := NewChannelTask(
 			ctx,
-			timeout,
 			WrapIDSource(0),
 			suite.collection,
 			suite.replica,
@@ -1214,47 +1188,45 @@ func (suite *TaskSuite) TestChannelTaskReplace() {
 }
 
 func (suite *TaskSuite) TestCreateTaskBehavior() {
-	chanelTask, err := NewChannelTask(context.TODO(), 5*time.Second, WrapIDSource(0), 0, 0)
+	chanelTask, err := NewChannelTask(context.TODO(), WrapIDSource(0), 0, 0)
 	suite.ErrorIs(err, merr.ErrParameterInvalid)
 	suite.Nil(chanelTask)
 
 	action := NewSegmentAction(0, 0, "", 0)
-	chanelTask, err = NewChannelTask(context.TODO(), 5*time.Second, WrapIDSource(0), 0, 0, action)
+	chanelTask, err = NewChannelTask(context.TODO(), WrapIDSource(0), 0, 0, action)
 	suite.ErrorIs(err, merr.ErrParameterInvalid)
 	suite.Nil(chanelTask)
 
 	action1 := NewChannelAction(0, 0, "fake-channel1")
 	action2 := NewChannelAction(0, 0, "fake-channel2")
-	chanelTask, err = NewChannelTask(context.TODO(), 5*time.Second, WrapIDSource(0), 0, 0, action1, action2)
+	chanelTask, err = NewChannelTask(context.TODO(), WrapIDSource(0), 0, 0, action1, action2)
 	suite.ErrorIs(err, merr.ErrParameterInvalid)
 	suite.Nil(chanelTask)
 
-	segmentTask, err := NewSegmentTask(context.TODO(), 5*time.Second, WrapIDSource(0), 0, 0)
+	segmentTask, err := NewSegmentTask(context.TODO(), WrapIDSource(0), 0, 0)
 	suite.ErrorIs(err, merr.ErrParameterInvalid)
 	suite.Nil(segmentTask)
 
 	channelAction := NewChannelAction(0, 0, "fake-channel1")
-	segmentTask, err = NewSegmentTask(context.TODO(), 5*time.Second, WrapIDSource(0), 0, 0, channelAction)
+	segmentTask, err = NewSegmentTask(context.TODO(), WrapIDSource(0), 0, 0, channelAction)
 	suite.ErrorIs(err, merr.ErrParameterInvalid)
 	suite.Nil(segmentTask)
 
 	segmentAction1 := NewSegmentAction(0, 0, "", 0)
 	segmentAction2 := NewSegmentAction(0, 0, "", 1)
 
-	segmentTask, err = NewSegmentTask(context.TODO(), 5*time.Second, WrapIDSource(0), 0, 0, segmentAction1, segmentAction2)
+	segmentTask, err = NewSegmentTask(context.TODO(), WrapIDSource(0), 0, 0, segmentAction1, segmentAction2)
 	suite.ErrorIs(err, merr.ErrParameterInvalid)
 	suite.Nil(segmentTask)
 }
 
 func (suite *TaskSuite) TestSegmentTaskReplace() {
 	ctx := context.Background()
-	timeout := 10 * time.Second
 	targetNode := int64(3)
 
 	for _, segment := range suite.loadSegments {
 		task, err := NewSegmentTask(
 			ctx,
-			timeout,
 			WrapIDSource(0),
 			suite.collection,
 			suite.replica,
@@ -1271,7 +1243,6 @@ func (suite *TaskSuite) TestSegmentTaskReplace() {
 	for _, segment := range suite.loadSegments {
 		task, err := NewSegmentTask(
 			ctx,
-			timeout,
 			WrapIDSource(0),
 			suite.collection,
 			suite.replica,
@@ -1290,7 +1261,6 @@ func (suite *TaskSuite) TestSegmentTaskReplace() {
 	for _, segment := range suite.loadSegments {
 		task, err := NewSegmentTask(
 			ctx,
-			timeout,
 			WrapIDSource(0),
 			suite.collection,
 			suite.replica,
@@ -1307,7 +1277,6 @@ func (suite *TaskSuite) TestSegmentTaskReplace() {
 
 func (suite *TaskSuite) TestNoExecutor() {
 	ctx := context.Background()
-	timeout := 10 * time.Second
 	targetNode := int64(-1)
 	channel := &datapb.VchannelInfo{
 		CollectionID: suite.collection,
@@ -1331,7 +1300,6 @@ func (suite *TaskSuite) TestNoExecutor() {
 		})
 		task, err := NewSegmentTask(
 			ctx,
-			timeout,
 			WrapIDSource(0),
 			suite.collection,
 			suite.replica,
@@ -1462,7 +1430,6 @@ func (suite *TaskSuite) TestBalanceChannelTask() {
 		Channel:      channel,
 	})
 	task, err := NewChannelTask(context.Background(),
-		10*time.Second,
 		WrapIDSource(2),
 		collectionID,
 		1,

--- a/internal/querycoordv2/task/utils_test.go
+++ b/internal/querycoordv2/task/utils_test.go
@@ -19,7 +19,6 @@ package task
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/suite"
 
@@ -92,7 +91,6 @@ func (s *UtilsSuite) TestPackLoadSegmentRequest() {
 	action := NewSegmentAction(1, ActionTypeGrow, "test-ch", 100)
 	task, err := NewSegmentTask(
 		ctx,
-		time.Second,
 		nil,
 		1,
 		10,
@@ -145,7 +143,6 @@ func (s *UtilsSuite) TestPackLoadSegmentRequestMmap() {
 	action := NewSegmentAction(1, ActionTypeGrow, "test-ch", 100)
 	task, err := NewSegmentTask(
 		ctx,
-		time.Second,
 		nil,
 		1,
 		10,


### PR DESCRIPTION
This PR removed the deprecated timeout param in segment/channel task