### PR TITLE
enhance: reduce SyncTask AllocID call and refine code

### DIFF
--- a/internal/datanode/syncmgr/task.go
+++ b/internal/datanode/syncmgr/task.go
@@ -254,7 +254,6 @@ func (t *SyncTask) processStatsBlob() {
 
 func (t *SyncTask) processDeltaBlob() {
 	if t.deltaBlob != nil {
-
 		value := t.deltaBlob.GetValue()
 		data := &datapb.Binlog{}
 


### PR DESCRIPTION
See also #27675

`Allocator.Alloc` and `Allocator.AllocOne` might be invoked multiple times if there were multiple blobs set in one sync task.

This PR add pre-fetch logic for all blobs and cache logIDs in sync task so that at most only one call of the allocator is needed.