### PR TITLE
fix: Set & Return correct SegmentLevel in querynode segment manager

### DIFF
--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -98,7 +98,7 @@ func (sd *shardDelegator) ProcessInsert(insertRecords map[int64]*InsertData) {
 				0,
 				insertData.StartPosition,
 				insertData.StartPosition,
-				datapb.SegmentLevel_Legacy,
+				datapb.SegmentLevel_L1,
 			)
 			if err != nil {
 				log.Error("failed to create new segment",

--- a/internal/querynodev2/segments/segment_l0.go
+++ b/internal/querynodev2/segments/segment_l0.go
@@ -62,7 +62,7 @@ func NewL0Segment(collection *Collection,
 		zap.String("segmentType", segmentType.String()))
 
 	segment := &L0Segment{
-		baseSegment: newBaseSegment(segmentID, partitionID, collectionID, shard, segmentType, version, startPosition),
+		baseSegment: newBaseSegment(segmentID, partitionID, collectionID, shard, segmentType, datapb.SegmentLevel_L0, version, startPosition),
 	}
 
 	return segment, nil


### PR DESCRIPTION
See also #27349

The segment level label in querynode used `Legacy` before segment level was correctly passed in Load request. Now this attribute is still using legacy so the metrics does not look right.

This PR add paramter for `NewSegment` and passes corrent values for each invocation.