### PR TITLE
enhance: Skip timestamp allocation when search/query consistency level is eventually

### DIFF
--- a/internal/proxy/mock_cache.go
+++ b/internal/proxy/mock_cache.go
@@ -24,6 +24,58 @@ func (_m *MockCache) EXPECT() *MockCache_Expecter {
 	return &MockCache_Expecter{mock: &_m.Mock}
 }
 
+// AllocID provides a mock function with given fields: ctx
+func (_m *MockCache) AllocID(ctx context.Context) (int64, error) {
+	ret := _m.Called(ctx)
+
+	var r0 int64
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context) (int64, error)); ok {
+		return rf(ctx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context) int64); ok {
+		r0 = rf(ctx)
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockCache_AllocID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AllocID'
+type MockCache_AllocID_Call struct {
+	*mock.Call
+}
+
+// AllocID is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *MockCache_Expecter) AllocID(ctx interface{}) *MockCache_AllocID_Call {
+	return &MockCache_AllocID_Call{Call: _e.mock.On("AllocID", ctx)}
+}
+
+func (_c *MockCache_AllocID_Call) Run(run func(ctx context.Context)) *MockCache_AllocID_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context))
+	})
+	return _c
+}
+
+func (_c *MockCache_AllocID_Call) Return(_a0 int64, _a1 error) *MockCache_AllocID_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockCache_AllocID_Call) RunAndReturn(run func(context.Context) (int64, error)) *MockCache_AllocID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // DeprecateShardCache provides a mock function with given fields: database, collectionName
 func (_m *MockCache) DeprecateShardCache(database string, collectionName string) {
 	_m.Called(database, collectionName)
@@ -819,41 +871,6 @@ func (_c *MockCache_RefreshPolicyInfo_Call) Return(_a0 error) *MockCache_Refresh
 }
 
 func (_c *MockCache_RefreshPolicyInfo_Call) RunAndReturn(run func(typeutil.CacheOp) error) *MockCache_RefreshPolicyInfo_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// RemoveAlias provides a mock function with given fields: ctx, database, alias
-func (_m *MockCache) RemoveAlias(ctx context.Context, database string, alias string) {
-	_m.Called(ctx, database, alias)
-}
-
-// MockCache_RemoveAlias_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RemoveAlias'
-type MockCache_RemoveAlias_Call struct {
-	*mock.Call
-}
-
-// RemoveAlias is a helper method to define mock.On call
-//   - ctx context.Context
-//   - database string
-//   - alias string
-func (_e *MockCache_Expecter) RemoveAlias(ctx interface{}, database interface{}, alias interface{}) *MockCache_RemoveAlias_Call {
-	return &MockCache_RemoveAlias_Call{Call: _e.mock.On("RemoveAlias", ctx, database, alias)}
-}
-
-func (_c *MockCache_RemoveAlias_Call) Run(run func(ctx context.Context, database string, alias string)) *MockCache_RemoveAlias_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string))
-	})
-	return _c
-}
-
-func (_c *MockCache_RemoveAlias_Call) Return() *MockCache_RemoveAlias_Call {
-	_c.Call.Return()
-	return _c
-}
-
-func (_c *MockCache_RemoveAlias_Call) RunAndReturn(run func(context.Context, string, string)) *MockCache_RemoveAlias_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/proxy/mock_test.go
+++ b/internal/proxy/mock_test.go
@@ -103,6 +103,10 @@ type mockTask struct {
 	ts    Timestamp
 }
 
+func (m *mockTask) CanSkipAllocTimestamp() bool {
+	return false
+}
+
 func (m *mockTask) TraceCtx() context.Context {
 	return m.TaskCondition.ctx
 }

--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -112,6 +112,13 @@ type task interface {
 	PostExecute(ctx context.Context) error
 	WaitToFinish() error
 	Notify(err error)
+	CanSkipAllocTimestamp() bool
+}
+
+type baseTask struct{}
+
+func (bt *baseTask) CanSkipAllocTimestamp() bool {
+	return false
 }
 
 type dmlTask interface {
@@ -123,6 +130,7 @@ type dmlTask interface {
 type BaseInsertTask = msgstream.InsertMsg
 
 type createCollectionTask struct {
+	baseTask
 	Condition
 	*milvuspb.CreateCollectionRequest
 	ctx       context.Context
@@ -361,6 +369,7 @@ func (t *createCollectionTask) PostExecute(ctx context.Context) error {
 }
 
 type dropCollectionTask struct {
+	baseTask
 	Condition
 	*milvuspb.DropCollectionRequest
 	ctx       context.Context
@@ -430,6 +439,7 @@ func (t *dropCollectionTask) PostExecute(ctx context.Context) error {
 }
 
 type hasCollectionTask struct {
+	baseTask
 	Condition
 	*milvuspb.HasCollectionRequest
 	ctx       context.Context
@@ -504,6 +514,7 @@ func (t *hasCollectionTask) PostExecute(ctx context.Context) error {
 }
 
 type describeCollectionTask struct {
+	baseTask
 	Condition
 	*milvuspb.DescribeCollectionRequest
 	ctx       context.Context
@@ -639,6 +650,7 @@ func (t *describeCollectionTask) PostExecute(ctx context.Context) error {
 }
 
 type showCollectionsTask struct {
+	baseTask
 	Condition
 	*milvuspb.ShowCollectionsRequest
 	ctx        context.Context
@@ -798,6 +810,7 @@ func (t *showCollectionsTask) PostExecute(ctx context.Context) error {
 }
 
 type alterCollectionTask struct {
+	baseTask
 	Condition
 	*milvuspb.AlterCollectionRequest
 	ctx        context.Context
@@ -882,6 +895,7 @@ func (t *alterCollectionTask) PostExecute(ctx context.Context) error {
 }
 
 type createPartitionTask struct {
+	baseTask
 	Condition
 	*milvuspb.CreatePartitionRequest
 	ctx       context.Context
@@ -969,6 +983,7 @@ func (t *createPartitionTask) PostExecute(ctx context.Context) error {
 }
 
 type dropPartitionTask struct {
+	baseTask
 	Condition
 	*milvuspb.DropPartitionRequest
 	ctx        context.Context
@@ -1083,6 +1098,7 @@ func (t *dropPartitionTask) PostExecute(ctx context.Context) error {
 }
 
 type hasPartitionTask struct {
+	baseTask
 	Condition
 	*milvuspb.HasPartitionRequest
 	ctx       context.Context
@@ -1159,6 +1175,7 @@ func (t *hasPartitionTask) PostExecute(ctx context.Context) error {
 }
 
 type showPartitionsTask struct {
+	baseTask
 	Condition
 	*milvuspb.ShowPartitionsRequest
 	ctx        context.Context
@@ -1321,6 +1338,7 @@ func (t *showPartitionsTask) PostExecute(ctx context.Context) error {
 }
 
 type flushTask struct {
+	baseTask
 	Condition
 	*milvuspb.FlushRequest
 	ctx       context.Context
@@ -1422,6 +1440,7 @@ func (t *flushTask) PostExecute(ctx context.Context) error {
 }
 
 type loadCollectionTask struct {
+	baseTask
 	Condition
 	*milvuspb.LoadCollectionRequest
 	ctx        context.Context
@@ -1579,6 +1598,7 @@ func (t *loadCollectionTask) PostExecute(ctx context.Context) error {
 }
 
 type releaseCollectionTask struct {
+	baseTask
 	Condition
 	*milvuspb.ReleaseCollectionRequest
 	ctx        context.Context
@@ -1671,6 +1691,7 @@ func (t *releaseCollectionTask) PostExecute(ctx context.Context) error {
 }
 
 type loadPartitionsTask struct {
+	baseTask
 	Condition
 	*milvuspb.LoadPartitionsRequest
 	ctx        context.Context
@@ -1821,6 +1842,7 @@ func (t *loadPartitionsTask) PostExecute(ctx context.Context) error {
 }
 
 type releasePartitionsTask struct {
+	baseTask
 	Condition
 	*milvuspb.ReleasePartitionsRequest
 	ctx        context.Context
@@ -1928,6 +1950,7 @@ func (t *releasePartitionsTask) PostExecute(ctx context.Context) error {
 }
 
 type CreateResourceGroupTask struct {
+	baseTask
 	Condition
 	*milvuspb.CreateResourceGroupRequest
 	ctx        context.Context
@@ -1992,6 +2015,7 @@ func (t *CreateResourceGroupTask) PostExecute(ctx context.Context) error {
 }
 
 type DropResourceGroupTask struct {
+	baseTask
 	Condition
 	*milvuspb.DropResourceGroupRequest
 	ctx        context.Context
@@ -2056,6 +2080,7 @@ func (t *DropResourceGroupTask) PostExecute(ctx context.Context) error {
 }
 
 type DescribeResourceGroupTask struct {
+	baseTask
 	Condition
 	*milvuspb.DescribeResourceGroupRequest
 	ctx        context.Context
@@ -2177,6 +2202,7 @@ func (t *DescribeResourceGroupTask) PostExecute(ctx context.Context) error {
 }
 
 type TransferNodeTask struct {
+	baseTask
 	Condition
 	*milvuspb.TransferNodeRequest
 	ctx        context.Context
@@ -2241,6 +2267,7 @@ func (t *TransferNodeTask) PostExecute(ctx context.Context) error {
 }
 
 type TransferReplicaTask struct {
+	baseTask
 	Condition
 	*milvuspb.TransferReplicaRequest
 	ctx        context.Context
@@ -2314,6 +2341,7 @@ func (t *TransferReplicaTask) PostExecute(ctx context.Context) error {
 }
 
 type ListResourceGroupsTask struct {
+	baseTask
 	Condition
 	*milvuspb.ListResourceGroupsRequest
 	ctx        context.Context

--- a/internal/proxy/task_alias.go
+++ b/internal/proxy/task_alias.go
@@ -28,6 +28,7 @@ import (
 
 // CreateAliasTask contains task information of CreateAlias
 type CreateAliasTask struct {
+	baseTask
 	Condition
 	*milvuspb.CreateAliasRequest
 	ctx       context.Context
@@ -115,6 +116,7 @@ func (t *CreateAliasTask) PostExecute(ctx context.Context) error {
 
 // DropAliasTask is the task to drop alias
 type DropAliasTask struct {
+	baseTask
 	Condition
 	*milvuspb.DropAliasRequest
 	ctx       context.Context
@@ -187,6 +189,7 @@ func (t *DropAliasTask) PostExecute(ctx context.Context) error {
 
 // AlterAliasTask is the task to alter alias
 type AlterAliasTask struct {
+	baseTask
 	Condition
 	*milvuspb.AlterAliasRequest
 	ctx       context.Context
@@ -263,6 +266,7 @@ func (t *AlterAliasTask) PostExecute(ctx context.Context) error {
 
 // DescribeAliasTask is the task to describe alias
 type DescribeAliasTask struct {
+	baseTask
 	Condition
 	nodeID UniqueID
 	*milvuspb.DescribeAliasRequest
@@ -326,6 +330,7 @@ func (a *DescribeAliasTask) PostExecute(ctx context.Context) error {
 
 // ListAliasesTask is the task to list aliases
 type ListAliasesTask struct {
+	baseTask
 	Condition
 	nodeID UniqueID
 	*milvuspb.ListAliasesRequest

--- a/internal/proxy/task_database.go
+++ b/internal/proxy/task_database.go
@@ -12,6 +12,7 @@ import (
 )
 
 type createDatabaseTask struct {
+	baseTask
 	Condition
 	*milvuspb.CreateDatabaseRequest
 	ctx       context.Context
@@ -80,6 +81,7 @@ func (cdt *createDatabaseTask) PostExecute(ctx context.Context) error {
 }
 
 type dropDatabaseTask struct {
+	baseTask
 	Condition
 	*milvuspb.DropDatabaseRequest
 	ctx       context.Context
@@ -150,6 +152,7 @@ func (ddt *dropDatabaseTask) PostExecute(ctx context.Context) error {
 }
 
 type listDatabaseTask struct {
+	baseTask
 	Condition
 	*milvuspb.ListDatabasesRequest
 	ctx       context.Context

--- a/internal/proxy/task_delete.go
+++ b/internal/proxy/task_delete.go
@@ -34,6 +34,7 @@ import (
 type BaseDeleteTask = msgstream.DeleteMsg
 
 type deleteTask struct {
+	baseTask
 	Condition
 	ctx context.Context
 	tr  *timerecord.TimeRecorder

--- a/internal/proxy/task_hybrid_search.go
+++ b/internal/proxy/task_hybrid_search.go
@@ -31,6 +31,7 @@ const (
 )
 
 type hybridSearchTask struct {
+	baseTask
 	Condition
 	ctx context.Context
 	*internalpb.HybridSearchRequest

--- a/internal/proxy/task_index.go
+++ b/internal/proxy/task_index.go
@@ -53,6 +53,7 @@ const (
 )
 
 type createIndexTask struct {
+	baseTask
 	Condition
 	req       *milvuspb.CreateIndexRequest
 	ctx       context.Context
@@ -435,6 +436,7 @@ func (cit *createIndexTask) PostExecute(ctx context.Context) error {
 }
 
 type alterIndexTask struct {
+	baseTask
 	Condition
 	req        *milvuspb.AlterIndexRequest
 	ctx        context.Context
@@ -554,6 +556,7 @@ func (t *alterIndexTask) PostExecute(ctx context.Context) error {
 }
 
 type describeIndexTask struct {
+	baseTask
 	Condition
 	*milvuspb.DescribeIndexRequest
 	ctx       context.Context
@@ -677,6 +680,7 @@ func (dit *describeIndexTask) PostExecute(ctx context.Context) error {
 }
 
 type getIndexStatisticsTask struct {
+	baseTask
 	Condition
 	*milvuspb.GetIndexStatisticsRequest
 	ctx       context.Context
@@ -793,6 +797,7 @@ func (dit *getIndexStatisticsTask) PostExecute(ctx context.Context) error {
 }
 
 type dropIndexTask struct {
+	baseTask
 	Condition
 	ctx context.Context
 	*milvuspb.DropIndexRequest
@@ -913,6 +918,7 @@ func (dit *dropIndexTask) PostExecute(ctx context.Context) error {
 
 // Deprecated: use describeIndexTask instead
 type getIndexBuildProgressTask struct {
+	baseTask
 	Condition
 	*milvuspb.GetIndexBuildProgressRequest
 	ctx       context.Context
@@ -1002,6 +1008,7 @@ func (gibpt *getIndexBuildProgressTask) PostExecute(ctx context.Context) error {
 
 // Deprecated: use describeIndexTask instead
 type getIndexStateTask struct {
+	baseTask
 	Condition
 	*milvuspb.GetIndexStateRequest
 	ctx       context.Context

--- a/internal/proxy/task_insert.go
+++ b/internal/proxy/task_insert.go
@@ -22,6 +22,7 @@ import (
 )
 
 type insertTask struct {
+	baseTask
 	// req *milvuspb.InsertRequest
 	Condition
 	insertMsg *BaseInsertTask

--- a/internal/proxy/task_statistic.go
+++ b/internal/proxy/task_statistic.go
@@ -34,6 +34,7 @@ const (
 type getStatisticsTask struct {
 	request *milvuspb.GetStatisticsRequest
 	result  *milvuspb.GetStatisticsResponse
+	baseTask
 	Condition
 	collectionName string
 	partitionNames []string
@@ -590,6 +591,7 @@ func reduceStatisticResponse(results []map[string]string) ([]*commonpb.KeyValueP
 // old version of get statistics
 // please remove it after getStatisticsTask below is stable
 type getCollectionStatisticsTask struct {
+	baseTask
 	Condition
 	*milvuspb.GetCollectionStatisticsRequest
 	ctx       context.Context
@@ -675,6 +677,7 @@ func (g *getCollectionStatisticsTask) PostExecute(ctx context.Context) error {
 }
 
 type getPartitionStatisticsTask struct {
+	baseTask
 	Condition
 	*milvuspb.GetPartitionStatisticsRequest
 	ctx       context.Context

--- a/internal/proxy/task_upsert.go
+++ b/internal/proxy/task_upsert.go
@@ -41,6 +41,7 @@ import (
 )
 
 type upsertTask struct {
+	baseTask
 	Condition
 
 	upsertMsg *msgstream.UpsertMsg


### PR DESCRIPTION
issue: #29772 
1. Skip timestamp allocation when search/query consistency level is eventually.