### PR TITLE
fix: limit minimal pq code size for diskann index

### DIFF
--- a/internal/core/thirdparty/knowhere/CMakeLists.txt
+++ b/internal/core/thirdparty/knowhere/CMakeLists.txt
@@ -15,7 +15,7 @@
 set( KNOWHERE_VERSION v2.2.2 )
 set( GIT_REPOSITORY  "https://github.com/zilliztech/knowhere.git")
 if ( INDEX_ENGINE STREQUAL "cardinal" )
-    set( KNOWHERE_VERSION 2.2.2 )
+    set( KNOWHERE_VERSION 2.2.2-hotfix )
     set( GIT_REPOSITORY  "https://github.com/zilliztech/knowhere-cloud.git")
 endif()
 message(STATUS "Knowhere repo: ${GIT_REPOSITORY}")


### PR DESCRIPTION
issue: #29784 
limit the minimal pq code size to avoid floating-exception