### PR TITLE
fix: meta cache in datanode incorrectly tracking row nums

### DIFF
--- a/internal/datanode/metacache/meta_cache.go
+++ b/internal/datanode/metacache/meta_cache.go
@@ -125,6 +125,7 @@ func (c *metaCacheImpl) CompactSegments(newSegmentID, partitionID int64, numOfRo
 				segmentID:        newSegmentID,
 				partitionID:      partitionID,
 				state:            commonpb.SegmentState_Flushed,
+				flushedRows:      numOfRows,
 				startPosRecorded: true,
 				bfs:              bfs,
 			}

--- a/internal/datanode/metacache/meta_cache_test.go
+++ b/internal/datanode/metacache/meta_cache_test.go
@@ -111,6 +111,7 @@ func (s *MetaCacheSuite) TestCompactSegments() {
 		for _, seg := range segs {
 			if seg.SegmentID() == s.newSegments[i] {
 				s.Equal(commonpb.SegmentState_Flushed, seg.State())
+				s.Equal(int64(100), seg.NumOfRows())
 			}
 			if seg.SegmentID() == s.flushedSegments[i] {
 				s.Equal(s.newSegments[i], seg.CompactTo())


### PR DESCRIPTION
... of compacted segments

issue: #29816
