### PR TITLE
enhance: Use estimated batch size to initalize BF

### DIFF
--- a/internal/datanode/metacache/bloom_filter_set.go
+++ b/internal/datanode/metacache/bloom_filter_set.go
@@ -26,15 +26,32 @@ import (
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 )
 
+// BloomFilterSet is a struct with multiple `storage.PkStatstics`.
+// it maintains bloom filter generated from segment primary keys.
+// it may be updated with new insert FieldData when serving growing segments.
 type BloomFilterSet struct {
-	mut     sync.Mutex
-	current *storage.PkStatistics
-	history []*storage.PkStatistics
+	mut       sync.Mutex
+	batchSize uint
+	current   *storage.PkStatistics
+	history   []*storage.PkStatistics
 }
 
+// NewBloomFilterSet returns a BloomFilterSet with provided historyEntries.
+// Shall serve Flushed segments only. For growing segments, use `NewBloomFilterSetWithBatchSize` instead.
 func NewBloomFilterSet(historyEntries ...*storage.PkStatistics) *BloomFilterSet {
 	return &BloomFilterSet{
-		history: historyEntries,
+		batchSize: paramtable.Get().CommonCfg.BloomFilterSize.GetAsUint(),
+		history:   historyEntries,
+	}
+}
+
+// NewBloomFilterSetWithBatchSize returns a BloomFilterSet.
+// The batchSize paramter is used to initialize new bloom filter.
+// It shall be the estimated row count per batch for segment to sync with.
+func NewBloomFilterSetWithBatchSize(batchSize uint, historyEntries ...*storage.PkStatistics) *BloomFilterSet {
+	return &BloomFilterSet{
+		batchSize: batchSize,
+		history:   historyEntries,
 	}
 }
 
@@ -59,7 +76,7 @@ func (bfs *BloomFilterSet) UpdatePKRange(ids storage.FieldData) error {
 
 	if bfs.current == nil {
 		bfs.current = &storage.PkStatistics{
-			PkFilter: bloom.NewWithEstimates(paramtable.Get().CommonCfg.BloomFilterSize.GetAsUint(),
+			PkFilter: bloom.NewWithEstimates(bfs.batchSize,
 				paramtable.Get().CommonCfg.MaxBloomFalsePositive.GetAsFloat()),
 		}
 	}

--- a/internal/datanode/metacache/bloom_filter_set.go
+++ b/internal/datanode/metacache/bloom_filter_set.go
@@ -46,7 +46,7 @@ func NewBloomFilterSet(historyEntries ...*storage.PkStatistics) *BloomFilterSet 
 }
 
 // NewBloomFilterSetWithBatchSize returns a BloomFilterSet.
-// The batchSize paramter is used to initialize new bloom filter.
+// The batchSize parameter is used to initialize new bloom filter.
 // It shall be the estimated row count per batch for segment to sync with.
 func NewBloomFilterSetWithBatchSize(batchSize uint, historyEntries ...*storage.PkStatistics) *BloomFilterSet {
 	return &BloomFilterSet{

--- a/internal/datanode/writebuffer/write_buffer.go
+++ b/internal/datanode/writebuffer/write_buffer.go
@@ -76,12 +76,13 @@ type writeBufferBase struct {
 	collectionID int64
 	channelName  string
 
-	metaWriter syncmgr.MetaWriter
-	collSchema *schemapb.CollectionSchema
-	metaCache  metacache.MetaCache
-	syncMgr    syncmgr.SyncManager
-	broker     broker.Broker
-	serializer syncmgr.Serializer
+	metaWriter       syncmgr.MetaWriter
+	collSchema       *schemapb.CollectionSchema
+	estSizePerRecord int
+	metaCache        metacache.MetaCache
+	syncMgr          syncmgr.SyncManager
+	broker           broker.Broker
+	serializer       syncmgr.Serializer
 
 	buffers map[int64]*segmentBuffer // segmentID => segmentBuffer
 


### PR DESCRIPTION
See also: #27675

The bloom filter set initialized new BF with fixed configured `n`. This value is always larger than the actual batch size and causes generated BF using more memory.

This PR make write buffer to initialize BF with estimated batch size from schema & configuration value.