### PR TITLE
fix: Drop segment meta info with prefix

### DIFF
--- a/internal/datacoord/meta_test.go
+++ b/internal/datacoord/meta_test.go
@@ -333,7 +333,7 @@ func TestMeta_Basic(t *testing.T) {
 		metakv2.EXPECT().MultiRemove(mock.Anything).Return(errors.New("failed")).Maybe()
 		metakv2.EXPECT().WalkWithPrefix(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 		metakv2.EXPECT().LoadWithPrefix(mock.Anything).Return(nil, nil, nil).Maybe()
-		metakv2.EXPECT().MultiSaveAndRemoveWithPrefix(mock.Anything, mock.Anything).Return(nil)
+		metakv2.EXPECT().MultiSaveAndRemoveWithPrefix(mock.Anything, mock.Anything).Return(errors.New("failed"))
 		catalog = datacoord.NewCatalog(metakv2, "", "")
 		meta, err = newMeta(context.TODO(), catalog, nil)
 		assert.NoError(t, err)

--- a/internal/datacoord/meta_test.go
+++ b/internal/datacoord/meta_test.go
@@ -333,6 +333,7 @@ func TestMeta_Basic(t *testing.T) {
 		metakv2.EXPECT().MultiRemove(mock.Anything).Return(errors.New("failed")).Maybe()
 		metakv2.EXPECT().WalkWithPrefix(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 		metakv2.EXPECT().LoadWithPrefix(mock.Anything).Return(nil, nil, nil).Maybe()
+		metakv2.EXPECT().MultiSaveAndRemoveWithPrefix(mock.Anything, mock.Anything).Return(nil)
 		catalog = datacoord.NewCatalog(metakv2, "", "")
 		meta, err = newMeta(context.TODO(), catalog, nil)
 		assert.NoError(t, err)

--- a/internal/kv/etcd/embed_etcd_kv_test.go
+++ b/internal/kv/etcd/embed_etcd_kv_test.go
@@ -565,6 +565,7 @@ func TestEmbedEtcd(te *testing.T) {
 			{map[string]string{"y/c": "vvv"}, []string{}, "y", 2, 3},
 			{map[string]string{"p/a": "vvv"}, []string{"y/a", "y"}, "y", 3, 0},
 			{map[string]string{}, []string{"p"}, "p", 1, 0},
+			{nil, []string{"p"}, "p", 0, 0},
 		}
 
 		for _, test := range multiSaveAndRemoveWithPrefixTests {


### PR DESCRIPTION
If segment has more than 128 log fils, drop segment will exceed  etcd txn ops limit, which will failed the drop segment request
This PR drop segment meta info with prefix, to avoid drop segment meta failed  