### PR TITLE
enhance: make Load process traceable in querynode & segcore

### DIFF
--- a/internal/core/src/common/Tracer.cpp
+++ b/internal/core/src/common/Tracer.cpp
@@ -85,7 +85,7 @@ GetTracer() {
 }
 
 std::shared_ptr<trace::Span>
-StartSpan(std::string name, TraceContext* parentCtx) {
+StartSpan(const std::string& name, TraceContext* parentCtx) {
     trace::StartSpanOptions opts;
     if (enable_trace && parentCtx != nullptr && parentCtx->traceID != nullptr &&
         parentCtx->spanID != nullptr) {

--- a/internal/core/src/common/Tracer.h
+++ b/internal/core/src/common/Tracer.h
@@ -43,7 +43,7 @@ std::shared_ptr<trace::Tracer>
 GetTracer();
 
 std::shared_ptr<trace::Span>
-StartSpan(std::string name, TraceContext* ctx = nullptr);
+StartSpan(const std::string& name, TraceContext* ctx = nullptr);
 
 void
 SetRootSpan(std::shared_ptr<trace::Span> span);

--- a/internal/core/src/index/Index.h
+++ b/internal/core/src/index/Index.h
@@ -21,6 +21,7 @@
 #include "common/EasyAssert.h"
 #include "knowhere/comp/index_param.h"
 #include "knowhere/dataset.h"
+#include "common/Tracer.h"
 #include "common/Types.h"
 
 const std::string kMmapFilepath = "mmap_filepath";
@@ -40,7 +41,7 @@ class IndexBase {
     Load(const BinarySet& binary_set, const Config& config = {}) = 0;
 
     virtual void
-    Load(const Config& config = {}) = 0;
+    Load(milvus::tracer::TraceContext ctx, const Config& config = {}) = 0;
 
     virtual void
     LoadV2(const Config& config = {}) = 0;

--- a/internal/core/src/index/InvertedIndexTantivy.cpp
+++ b/internal/core/src/index/InvertedIndexTantivy.cpp
@@ -294,7 +294,8 @@ InvertedIndexTantivy<T>::BuildV2(const Config& config) {
 
 template <typename T>
 void
-InvertedIndexTantivy<T>::Load(milvus::tracer::TraceContext ctx, const Config& config) {
+InvertedIndexTantivy<T>::Load(milvus::tracer::TraceContext ctx,
+                              const Config& config) {
     auto index_files =
         GetValueFromConfig<std::vector<std::string>>(config, "index_files");
     AssertInfo(index_files.has_value(),

--- a/internal/core/src/index/InvertedIndexTantivy.cpp
+++ b/internal/core/src/index/InvertedIndexTantivy.cpp
@@ -294,7 +294,7 @@ InvertedIndexTantivy<T>::BuildV2(const Config& config) {
 
 template <typename T>
 void
-InvertedIndexTantivy<T>::Load(const Config& config) {
+InvertedIndexTantivy<T>::Load(milvus::tracer::TraceContext ctx, const Config& config) {
     auto index_files =
         GetValueFromConfig<std::vector<std::string>>(config, "index_files");
     AssertInfo(index_files.has_value(),

--- a/internal/core/src/index/InvertedIndexTantivy.h
+++ b/internal/core/src/index/InvertedIndexTantivy.h
@@ -55,7 +55,7 @@ class InvertedIndexTantivy : public ScalarIndex<T> {
     }
 
     void
-    Load(const Config& config = {}) override;
+    Load(milvus::tracer::TraceContext ctx, const Config& config = {}) override;
 
     void
     LoadV2(const Config& config = {}) override;

--- a/internal/core/src/index/ScalarIndexSort.cpp
+++ b/internal/core/src/index/ScalarIndexSort.cpp
@@ -250,7 +250,7 @@ ScalarIndexSort<T>::Load(const BinarySet& index_binary, const Config& config) {
 
 template <typename T>
 void
-ScalarIndexSort<T>::Load(const Config& config) {
+ScalarIndexSort<T>::Load(milvus::tracer::TraceContext ctx, const Config& config) {
     auto index_files =
         GetValueFromConfig<std::vector<std::string>>(config, "index_files");
     AssertInfo(index_files.has_value(),

--- a/internal/core/src/index/ScalarIndexSort.cpp
+++ b/internal/core/src/index/ScalarIndexSort.cpp
@@ -250,7 +250,8 @@ ScalarIndexSort<T>::Load(const BinarySet& index_binary, const Config& config) {
 
 template <typename T>
 void
-ScalarIndexSort<T>::Load(milvus::tracer::TraceContext ctx, const Config& config) {
+ScalarIndexSort<T>::Load(milvus::tracer::TraceContext ctx,
+                         const Config& config) {
     auto index_files =
         GetValueFromConfig<std::vector<std::string>>(config, "index_files");
     AssertInfo(index_files.has_value(),

--- a/internal/core/src/index/ScalarIndexSort.h
+++ b/internal/core/src/index/ScalarIndexSort.h
@@ -48,7 +48,7 @@ class ScalarIndexSort : public ScalarIndex<T> {
     Load(const BinarySet& index_binary, const Config& config = {}) override;
 
     void
-    Load(const Config& config = {}) override;
+    Load(milvus::tracer::TraceContext ctx, const Config& config = {}) override;
 
     void
     LoadV2(const Config& config = {}) override;

--- a/internal/core/src/index/StringIndexMarisa.cpp
+++ b/internal/core/src/index/StringIndexMarisa.cpp
@@ -287,7 +287,8 @@ StringIndexMarisa::Load(const BinarySet& set, const Config& config) {
 }
 
 void
-StringIndexMarisa::Load(milvus::tracer::TraceContext ctx, const Config& config) {
+StringIndexMarisa::Load(milvus::tracer::TraceContext ctx,
+                        const Config& config) {
     auto index_files =
         GetValueFromConfig<std::vector<std::string>>(config, "index_files");
     AssertInfo(index_files.has_value(),

--- a/internal/core/src/index/StringIndexMarisa.cpp
+++ b/internal/core/src/index/StringIndexMarisa.cpp
@@ -287,7 +287,7 @@ StringIndexMarisa::Load(const BinarySet& set, const Config& config) {
 }
 
 void
-StringIndexMarisa::Load(const Config& config) {
+StringIndexMarisa::Load(milvus::tracer::TraceContext ctx, const Config& config) {
     auto index_files =
         GetValueFromConfig<std::vector<std::string>>(config, "index_files");
     AssertInfo(index_files.has_value(),

--- a/internal/core/src/index/StringIndexMarisa.h
+++ b/internal/core/src/index/StringIndexMarisa.h
@@ -47,7 +47,7 @@ class StringIndexMarisa : public StringIndex {
     Load(const BinarySet& set, const Config& config = {}) override;
 
     void
-    Load(const Config& config = {}) override;
+    Load(milvus::tracer::TraceContext ctx, const Config& config = {}) override;
 
     void
     LoadV2(const Config& config = {}) override;

--- a/internal/core/src/index/VectorDiskIndex.cpp
+++ b/internal/core/src/index/VectorDiskIndex.cpp
@@ -16,6 +16,7 @@
 
 #include "index/VectorDiskIndex.h"
 
+#include "common/Tracer.h"
 #include "common/Utils.h"
 #include "config/ConfigKnowhere.h"
 #include "index/Meta.h"
@@ -93,24 +94,39 @@ template <typename T>
 void
 VectorDiskAnnIndex<T>::Load(const BinarySet& binary_set /* not used */,
                             const Config& config) {
-    Load(config);
+    Load(milvus::tracer::TraceContext{}, config);
 }
 
 template <typename T>
 void
-VectorDiskAnnIndex<T>::Load(const Config& config) {
+VectorDiskAnnIndex<T>::Load(milvus::tracer::TraceContext ctx,
+                            const Config& config) {
     knowhere::Json load_config = update_load_json(config);
 
-    auto index_files =
-        GetValueFromConfig<std::vector<std::string>>(config, "index_files");
-    AssertInfo(index_files.has_value(),
-               "index file paths is empty when load disk ann index data");
-    file_manager_->CacheIndexToDisk(index_files.value());
+    // start read file span with active scope
+    {
+        auto read_file_span =
+            milvus::tracer::StartSpan("SegCoreReadDiskIndexFile", &ctx);
+        auto read_scope =
+            milvus::tracer::GetTracer()->WithActiveSpan(read_file_span);
+        auto index_files =
+            GetValueFromConfig<std::vector<std::string>>(config, "index_files");
+        AssertInfo(index_files.has_value(),
+                   "index file paths is empty when load disk ann index data");
+        file_manager_->CacheIndexToDisk(index_files.value());
+        read_file_span->End();
+    }
 
+    // start engine load index span
+    auto span_load_engine =
+        milvus::tracer::StartSpan("SegCoreEngineLoadDiskIndex", &ctx);
+    auto engine_scope =
+        milvus::tracer::GetTracer()->WithActiveSpan(span_load_engine);
     auto stat = index_.Deserialize(knowhere::BinarySet(), load_config);
     if (stat != knowhere::Status::success)
         PanicInfo(ErrorCode::UnexpectedError,
                   "failed to Deserialize index, " + KnowhereStatusString(stat));
+    span_load_engine->End();
 
     SetDim(index_.Dim());
 }

--- a/internal/core/src/index/VectorDiskIndex.h
+++ b/internal/core/src/index/VectorDiskIndex.h
@@ -71,7 +71,7 @@ class VectorDiskAnnIndex : public VectorIndex {
          const Config& config = {}) override;
 
     void
-    Load(const Config& config = {}) override;
+    Load(milvus::tracer::TraceContext ctx, const Config& config = {}) override;
 
     void
     LoadV2(const Config& config = {}) override;

--- a/internal/core/src/index/VectorMemIndex.h
+++ b/internal/core/src/index/VectorMemIndex.h
@@ -50,7 +50,7 @@ class VectorMemIndex : public VectorIndex {
     Load(const BinarySet& binary_set, const Config& config = {}) override;
 
     void
-    Load(const Config& config = {}) override;
+    Load(milvus::tracer::TraceContext ctx, const Config& config = {}) override;
 
     void
     LoadV2(const Config& config = {}) override;

--- a/internal/core/src/segcore/load_index_c.h
+++ b/internal/core/src/segcore/load_index_c.h
@@ -57,7 +57,7 @@ CStatus
 AppendIndexFilePath(CLoadIndexInfo c_load_index_info, const char* file_path);
 
 CStatus
-AppendIndexV2(CLoadIndexInfo c_load_index_info);
+AppendIndexV2(CTraceContext c_trace, CLoadIndexInfo c_load_index_info);
 
 CStatus
 AppendIndexV3(CLoadIndexInfo c_load_index_info);

--- a/internal/core/unittest/test_indexing.cpp
+++ b/internal/core/unittest/test_indexing.cpp
@@ -22,6 +22,7 @@
 
 #include "arrow/type.h"
 #include "common/EasyAssert.h"
+#include "common/Tracer.h"
 #include "common/Types.h"
 #include "index/Index.h"
 #include "knowhere/comp/index_param.h"
@@ -426,7 +427,7 @@ TEST_P(IndexTest, BuildAndQuery) {
     }
     load_conf = generate_load_conf(index_type, metric_type, 0);
     load_conf["index_files"] = index_files;
-    ASSERT_NO_THROW(vec_index->Load(load_conf));
+    ASSERT_NO_THROW(vec_index->Load(milvus::tracer::TraceContext{}, load_conf));
     EXPECT_EQ(vec_index->Count(), NB);
     EXPECT_EQ(vec_index->GetDim(), DIM);
 
@@ -484,7 +485,7 @@ TEST_P(IndexTest, Mmap) {
     load_conf = generate_load_conf(index_type, metric_type, 0);
     load_conf["index_files"] = index_files;
     load_conf["mmap_filepath"] = "mmap/test_index_mmap_" + index_type;
-    vec_index->Load(load_conf);
+    vec_index->Load(milvus::tracer::TraceContext{}, load_conf);
     EXPECT_EQ(vec_index->Count(), NB);
     EXPECT_EQ(vec_index->GetDim(), DIM);
 
@@ -541,7 +542,7 @@ TEST_P(IndexTest, GetVector) {
         vec_index->Load(binary_set, load_conf);
         EXPECT_EQ(vec_index->Count(), NB);
     } else {
-        vec_index->Load(load_conf);
+        vec_index->Load(milvus::tracer::TraceContext{}, load_conf);
     }
     EXPECT_EQ(vec_index->GetDim(), DIM);
     EXPECT_EQ(vec_index->Count(), NB);
@@ -638,7 +639,7 @@ TEST(Indexing, SearchDiskAnnWithInvalidParam) {
     }
     auto load_conf = generate_load_conf(index_type, metric_type, NB);
     load_conf["index_files"] = index_files;
-    vec_index->Load(load_conf);
+    vec_index->Load(milvus::tracer::TraceContext{}, load_conf);
     EXPECT_EQ(vec_index->Count(), NB);
 
     // search disk index with search_list == limit

--- a/internal/core/unittest/test_inverted_index.cpp
+++ b/internal/core/unittest/test_inverted_index.cpp
@@ -14,6 +14,7 @@
 #include <boost/filesystem.hpp>
 #include <unordered_set>
 
+#include "common/Tracer.h"
 #include "index/InvertedIndexTantivy.h"
 #include "storage/Util.h"
 #include "storage/InsertData.h"
@@ -168,7 +169,7 @@ test_run() {
 
         auto index =
             index::IndexFactory::GetInstance().CreateIndex(index_info, ctx);
-        index->Load(config);
+        index->Load(milvus::tracer::TraceContext{}, config);
 
         auto cnt = index->Count();
         ASSERT_EQ(cnt, nb);
@@ -369,7 +370,7 @@ test_string() {
 
         auto index =
             index::IndexFactory::GetInstance().CreateIndex(index_info, ctx);
-        index->Load(config);
+        index->Load(milvus::tracer::TraceContext{}, config);
 
         auto cnt = index->Count();
         ASSERT_EQ(cnt, nb);

--- a/internal/core/unittest/test_utils/DataGen.h
+++ b/internal/core/unittest/test_utils/DataGen.h
@@ -937,7 +937,7 @@ GenVecIndexing(int64_t N,
     conf["index_files"] = index_files;
     // we need a load stage to use index as the producation does
     // knowhere would do some data preparation in this stage
-    indexing->Load(conf);
+    indexing->Load(milvus::tracer::TraceContext{}, conf);
     return indexing;
 }
 

--- a/internal/querynodev2/segments/load_index_info.go
+++ b/internal/querynodev2/segments/load_index_info.go
@@ -29,6 +29,7 @@ import (
 	"unsafe"
 
 	"github.com/pingcap/log"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
@@ -165,7 +166,17 @@ func (li *LoadIndexInfo) appendIndexData(ctx context.Context, indexKeys []string
 		}
 	}
 
-	status := C.AppendIndexV2(li.cLoadIndexInfo)
+	span := trace.SpanFromContext(ctx)
+
+	traceID := span.SpanContext().TraceID()
+	spanID := span.SpanContext().SpanID()
+	traceCtx := C.CTraceContext{
+		traceID: (*C.uint8_t)(unsafe.Pointer(&traceID[0])),
+		spanID:  (*C.uint8_t)(unsafe.Pointer(&spanID[0])),
+		flag:    C.uchar(span.SpanContext().TraceFlags()),
+	}
+
+	status := C.AppendIndexV2(traceCtx, li.cLoadIndexInfo)
 	return HandleCStatus(ctx, &status, "AppendIndex failed")
 }
 

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
+	"go.opentelemetry.io/otel"
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
@@ -801,6 +802,8 @@ func (loader *segmentLoader) loadBloomFilter(ctx context.Context, segmentID int6
 }
 
 func (loader *segmentLoader) LoadDeltaLogs(ctx context.Context, segment Segment, deltaLogs []*datapb.FieldBinlog) error {
+	ctx, sp := otel.Tracer(typeutil.QueryNodeRole).Start(ctx, fmt.Sprintf("LoadDeltalogs-%d", segment.ID()))
+	defer sp.End()
 	log := log.Ctx(ctx).With(
 		zap.Int64("segmentID", segment.ID()),
 	)


### PR DESCRIPTION
See also #29803

This PR:
- Add trace span for `LoadIndex` & `LoadFieldData` in segment loader
- Add `TraceCtx` parameter for `Index.Load` in segcore
- Add span for ReadFiles & Engine Load for Memory/Disk Vector index