### PR TITLE
fix: Dynamic update rate limit config with wrong value

### DIFF
--- a/internal/proxy/multi_rate_limiter.go
+++ b/internal/proxy/multi_rate_limiter.go
@@ -336,7 +336,7 @@ func (rl *rateLimiter) registerLimiters(globalLevel bool) {
 		rl.limiters.GetOrInsert(internalpb.RateType(rt), ratelimitutil.NewLimiter(limit, burst))
 		onEvent := func(rateType internalpb.RateType) func(*config.Event) {
 			return func(event *config.Event) {
-				f, err := strconv.ParseFloat(event.Value, 64)
+				f, err := strconv.ParseFloat(r.Formatter(event.Value), 64)
 				if err != nil {
 					log.Info("Error format for rateLimit",
 						zap.String("rateType", rateType.String()),


### PR DESCRIPTION
when apply dynamic config changes, we should format the value to proper unit
This PR fix update rate limit config with wrong value. 