### PR TITLE
fix: level 0 segments not loaded

### DIFF
--- a/internal/querycoordv2/meta/target_manager.go
+++ b/internal/querycoordv2/meta/target_manager.go
@@ -24,6 +24,7 @@ import (
 	"github.com/samber/lo"
 	"go.uber.org/zap"
 
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/common"
 	"github.com/milvus-io/milvus/pkg/log"
@@ -205,6 +206,15 @@ func (mgr *TargetManager) PullNextTargetV2(broker Broker, collectionID int64, ch
 
 		for _, info := range vChannelInfos {
 			channelInfos[info.GetChannelName()] = append(channelInfos[info.GetChannelName()], info)
+			for _, segmentID := range info.GetLevelZeroSegmentIds() {
+				segments[segmentID] = &datapb.SegmentInfo{
+					ID:            segmentID,
+					CollectionID:  collectionID,
+					InsertChannel: info.GetChannelName(),
+					State:         commonpb.SegmentState_Flushed,
+					Level:         datapb.SegmentLevel_L0,
+				}
+			}
 		}
 
 		partitionSet := typeutil.NewUniqueSet(chosenPartitionIDs...)

--- a/internal/querycoordv2/task/executor.go
+++ b/internal/querycoordv2/task/executor.go
@@ -190,6 +190,7 @@ func (ex *Executor) loadSegment(task *SegmentTask, step int) error {
 		return err
 	}
 	segment := resp.GetInfos()[0]
+	log = log.With(zap.String("level", segment.GetLevel().String()))
 
 	indexes, err := ex.broker.GetIndexInfo(ctx, task.CollectionID(), segment.GetID())
 	if err != nil {
@@ -224,7 +225,7 @@ func (ex *Executor) loadSegment(task *SegmentTask, step int) error {
 		segmentIndex.IndexParams = funcutil.Map2KeyValuePair(params)
 	}
 
-	loadInfo := utils.PackSegmentLoadInfo(resp.GetInfos()[0], channel.GetSeekPosition(), indexes)
+	loadInfo := utils.PackSegmentLoadInfo(segment, channel.GetSeekPosition(), indexes)
 
 	req := packLoadSegmentRequest(
 		task,


### PR DESCRIPTION
the recent changes move the level 0 segments list to a new proto field, which leads to the QueryCoord can't see the level 0 segments, handle the new changes
fix #29907