### PR TITLE
enhance: Use newer checkpoint when packing LoadSegmentRequest

### DIFF
--- a/internal/querycoordv2/utils/types_test.go
+++ b/internal/querycoordv2/utils/types_test.go
@@ -35,6 +35,7 @@ func Test_packLoadSegmentRequest(t *testing.T) {
 	t0 := tsoutil.ComposeTSByTime(time.Now().Add(-20*time.Minute), 0)
 	t1 := tsoutil.ComposeTSByTime(time.Now().Add(-8*time.Minute), 0)
 	t2 := tsoutil.ComposeTSByTime(time.Now().Add(-5*time.Minute), 0)
+	t3 := tsoutil.ComposeTSByTime(time.Now().Add(-1*time.Minute), 0)
 
 	segmentInfo := &datapb.SegmentInfo{
 		ID:            0,
@@ -64,12 +65,21 @@ func Test_packLoadSegmentRequest(t *testing.T) {
 		assert.Equal(t, t2, req.GetDeltaPosition().Timestamp)
 	})
 
+	t.Run("test channel cp after segment dml position", func(t *testing.T) {
+		channel := proto.Clone(channel).(*datapb.VchannelInfo)
+		channel.SeekPosition.Timestamp = t3
+		req := PackSegmentLoadInfo(segmentInfo, channel.GetSeekPosition(), nil)
+		assert.NotNil(t, req.GetDeltaPosition())
+		assert.Equal(t, mockPChannel, req.GetDeltaPosition().ChannelName)
+		assert.Equal(t, t3, req.GetDeltaPosition().Timestamp)
+	})
+
 	t.Run("test tsLag > 10minutes", func(t *testing.T) {
 		channel := proto.Clone(channel).(*datapb.VchannelInfo)
 		channel.SeekPosition.Timestamp = t0
 		req := PackSegmentLoadInfo(segmentInfo, channel.GetSeekPosition(), nil)
 		assert.NotNil(t, req.GetDeltaPosition())
 		assert.Equal(t, mockPChannel, req.GetDeltaPosition().ChannelName)
-		assert.Equal(t, t0, req.GetDeltaPosition().Timestamp)
+		assert.Equal(t, segmentInfo.GetDmlPosition().GetTimestamp(), req.GetDeltaPosition().GetTimestamp())
 	})
 }


### PR DESCRIPTION
See also: #29650

Either segment dml position & channel checkpoint could be newer in some cases. This PR make PackLoadSegments use the newer one improving load performance during cases where there are lots of upsert.