### PR TITLE
fix: Fix unstable msg dispatcher ut

### DIFF
--- a/pkg/mq/msgdispatcher/manager_test.go
+++ b/pkg/mq/msgdispatcher/manager_test.go
@@ -101,7 +101,7 @@ func TestManager(t *testing.T) {
 		go c.Run()
 		assert.Eventually(t, func() bool {
 			return c.Num() == 1 // expected merged
-		}, 300*time.Millisecond, 10*time.Millisecond)
+		}, 3*time.Second, 10*time.Millisecond)
 
 		assert.NotPanics(t, func() {
 			c.Close()


### PR DESCRIPTION
This fix will not augment the execution time of unit tests, but solely enhances tolerance for waiting for failure.

issue: https://github.com/milvus-io/milvus/issues/29921