### PR TITLE
fix: SealedIndexingEntry in SealedIndexingRecord may leak without smart pointer protect.

### DIFF
--- a/internal/core/src/query/SearchOnSealed.cpp
+++ b/internal/core/src/query/SearchOnSealed.cpp
@@ -37,6 +37,7 @@ SearchOnSealedIndex(const Schema& schema,
     auto dim = field.get_dim();
 
     AssertInfo(record.is_ready(field_id), "[SearchOnSealed]Record isn't ready");
+    // Keep the field_indexing smart pointer, until all reference by raw dropped.
     auto field_indexing = record.get_field_indexing(field_id);
     AssertInfo(field_indexing->metric_type_ == search_info.metric_type_,
                "Metric type of field index isn't the same with search info");

--- a/internal/core/src/segcore/SealedIndexingRecord.h
+++ b/internal/core/src/segcore/SealedIndexingRecord.h
@@ -29,7 +29,7 @@ struct SealedIndexingEntry {
     index::IndexBasePtr indexing_;
 };
 
-using SealedIndexingEntryPtr = std::unique_ptr<SealedIndexingEntry>;
+using SealedIndexingEntryPtr = std::shared_ptr<SealedIndexingEntry>;
 
 struct SealedIndexingRecord {
     void
@@ -43,11 +43,11 @@ struct SealedIndexingRecord {
         field_indexings_[field_id] = std::move(ptr);
     }
 
-    const SealedIndexingEntry*
+    const SealedIndexingEntryPtr
     get_field_indexing(FieldId field_id) const {
         std::shared_lock lck(mutex_);
         AssertInfo(field_indexings_.count(field_id), "field_id not found");
-        return field_indexings_.at(field_id).get();
+        return field_indexings_.at(field_id);
     }
 
     void


### PR DESCRIPTION
may related issue: #29828