### PR TITLE
fix: querynode num entity metric is broken by illegal label

### DIFF
--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -126,7 +126,7 @@ func (sd *shardDelegator) ProcessInsert(insertRecords map[int64]*InsertData) {
 			fmt.Sprint(growing.Collection()),
 			fmt.Sprint(growing.Partition()),
 			growing.Type().String(),
-			fmt.Sprint(0),
+			"0",
 		).Add(float64(len(insertData.RowIDs)))
 		growing.UpdateBloomFilter(insertData.PrimaryKeys)
 

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -29,6 +29,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strconv"
 	"sync"
 	"unsafe"
 
@@ -1194,7 +1195,7 @@ func (s *LocalSegment) Release() {
 		fmt.Sprint(s.Collection()),
 		fmt.Sprint(s.Partition()),
 		s.Type().String(),
-		fmt.Sprint(len(s.Indexes())),
+		strconv.FormatInt(int64(len(s.Indexes())), 10),
 	).Sub(float64(s.InsertCount()))
 
 	log.Info("delete segment from memory",

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -1007,7 +1007,7 @@ func (loader *segmentLoader) loadSegment(ctx context.Context,
 		fmt.Sprint(segment.Collection()),
 		fmt.Sprint(segment.Partition()),
 		segment.Type().String(),
-		fmt.Sprint(segment.Indexes()),
+		strconv.FormatInt(int64(len(segment.Indexes())), 10),
 	).Add(float64(loadInfo.GetNumOfRows()))
 
 	log.Info("loading delta...")


### PR DESCRIPTION
issue: #29766
also see pr: #29825