### PR TITLE
enhance: Break down the granularity of collection info cache expired

### DIFF
--- a/internal/proto/proxy.proto
+++ b/internal/proto/proxy.proto
@@ -32,6 +32,7 @@ message InvalidateCollMetaCacheRequest {
   string db_name = 2;
   string collection_name = 3;
   int64 collectionID = 4;
+  string partition_name = 5;
 }
 
 message InvalidateCredCacheRequest {

--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -107,22 +107,49 @@ func (node *Proxy) InvalidateCollectionMetaCache(ctx context.Context, request *p
 		zap.String("db", request.DbName),
 		zap.String("collectionName", request.CollectionName),
 		zap.Int64("collectionID", request.CollectionID),
+		zap.String("msgType", request.GetBase().GetMsgType().String()),
+		zap.String("partitionName", request.GetPartitionName()),
 	)
 
 	log.Info("received request to invalidate collection meta cache")
 
 	collectionName := request.CollectionName
 	collectionID := request.CollectionID
-
 	var aliasName []string
+
 	if globalMetaCache != nil {
-		if collectionName != "" {
-			globalMetaCache.RemoveCollection(ctx, request.GetDbName(), collectionName) // no need to return error, though collection may be not cached
-		}
-		if request.CollectionID != UniqueID(0) {
-			aliasName = globalMetaCache.RemoveCollectionsByID(ctx, collectionID)
+		switch request.GetBase().GetMsgType() {
+		case commonpb.MsgType_DropCollection, commonpb.MsgType_RenameCollection, commonpb.MsgType_DropAlias, commonpb.MsgType_AlterAlias:
+			if collectionName != "" {
+				globalMetaCache.RemoveCollection(ctx, request.GetDbName(), collectionName) // no need to return error, though collection may be not cached
+			}
+			if request.CollectionID != UniqueID(0) {
+				aliasName = globalMetaCache.RemoveCollectionsByID(ctx, collectionID)
+			}
+			log.Info("complete to invalidate collection meta cache with collection name", zap.String("collectionName", collectionName))
+		case commonpb.MsgType_DropPartition:
+			if globalMetaCache != nil {
+				if collectionName != "" && request.GetPartitionName() != "" {
+					globalMetaCache.RemovePartition(ctx, request.GetDbName(), request.GetCollectionName(), request.GetPartitionName())
+				} else {
+					log.Warn("invalidate collection meta cache failed. collectionName or partitionName is empty",
+						zap.String("collectionName", collectionName),
+						zap.String("partitionName", request.GetPartitionName()))
+					return merr.Status(merr.WrapErrPartitionNotFound(request.GetPartitionName(), "partition name not specified")), nil
+				}
+			}
+		default:
+			log.Warn("receive unexpected msgType of invalidate collection meta cache", zap.String("msgType", request.GetBase().GetMsgType().String()))
+
+			if collectionName != "" {
+				globalMetaCache.RemoveCollection(ctx, request.GetDbName(), collectionName) // no need to return error, though collection may be not cached
+			}
+			if request.CollectionID != UniqueID(0) {
+				aliasName = globalMetaCache.RemoveCollectionsByID(ctx, collectionID)
+			}
 		}
 	}
+
 	if request.GetBase().GetMsgType() == commonpb.MsgType_DropCollection {
 		// no need to handle error, since this Proxy may not create dml stream for the collection.
 		node.chMgr.removeDMLStream(request.GetCollectionID())

--- a/internal/proxy/mock_cache.go
+++ b/internal/proxy/mock_cache.go
@@ -823,6 +823,41 @@ func (_c *MockCache_RefreshPolicyInfo_Call) RunAndReturn(run func(typeutil.Cache
 	return _c
 }
 
+// RemoveAlias provides a mock function with given fields: ctx, database, alias
+func (_m *MockCache) RemoveAlias(ctx context.Context, database string, alias string) {
+	_m.Called(ctx, database, alias)
+}
+
+// MockCache_RemoveAlias_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RemoveAlias'
+type MockCache_RemoveAlias_Call struct {
+	*mock.Call
+}
+
+// RemoveAlias is a helper method to define mock.On call
+//   - ctx context.Context
+//   - database string
+//   - alias string
+func (_e *MockCache_Expecter) RemoveAlias(ctx interface{}, database interface{}, alias interface{}) *MockCache_RemoveAlias_Call {
+	return &MockCache_RemoveAlias_Call{Call: _e.mock.On("RemoveAlias", ctx, database, alias)}
+}
+
+func (_c *MockCache_RemoveAlias_Call) Run(run func(ctx context.Context, database string, alias string)) *MockCache_RemoveAlias_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string))
+	})
+	return _c
+}
+
+func (_c *MockCache_RemoveAlias_Call) Return() *MockCache_RemoveAlias_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockCache_RemoveAlias_Call) RunAndReturn(run func(context.Context, string, string)) *MockCache_RemoveAlias_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // RemoveCollection provides a mock function with given fields: ctx, database, collectionName
 func (_m *MockCache) RemoveCollection(ctx context.Context, database string, collectionName string) {
 	_m.Called(ctx, database, collectionName)

--- a/internal/rootcoord/alter_alias_task.go
+++ b/internal/rootcoord/alter_alias_task.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
+	"github.com/milvus-io/milvus/internal/util/proxyutil"
 )
 
 type alterAliasTask struct {
@@ -36,7 +37,7 @@ func (t *alterAliasTask) Prepare(ctx context.Context) error {
 }
 
 func (t *alterAliasTask) Execute(ctx context.Context) error {
-	if err := t.core.ExpireMetaCache(ctx, t.Req.GetDbName(), []string{t.Req.GetAlias()}, InvalidCollectionID, t.GetTs()); err != nil {
+	if err := t.core.ExpireMetaCache(ctx, t.Req.GetDbName(), []string{t.Req.GetAlias()}, InvalidCollectionID, "", t.GetTs(), proxyutil.SetMsgType(commonpb.MsgType_AlterAlias)); err != nil {
 		return err
 	}
 	// alter alias is atomic enough.

--- a/internal/rootcoord/alter_collection_task.go
+++ b/internal/rootcoord/alter_collection_task.go
@@ -67,14 +67,6 @@ func (a *alterCollectionTask) Execute(ctx context.Context) error {
 		ts:       ts,
 	})
 
-	redoTask.AddSyncStep(&expireCacheStep{
-		baseStep:        baseStep{core: a.core},
-		dbName:          a.Req.GetDbName(),
-		collectionNames: []string{oldColl.Name},
-		collectionID:    oldColl.CollectionID,
-		ts:              ts,
-	})
-
 	a.Req.CollectionID = oldColl.CollectionID
 	redoTask.AddSyncStep(&BroadcastAlteredCollectionStep{
 		baseStep: baseStep{core: a.core},

--- a/internal/rootcoord/alter_collection_task_test.go
+++ b/internal/rootcoord/alter_collection_task_test.go
@@ -127,7 +127,7 @@ func Test_alterCollectionTask_Execute(t *testing.T) {
 			return errors.New("err")
 		}
 
-		core := newTestCore(withValidProxyManager(), withMeta(meta), withBroker(broker))
+		core := newTestCore(withMeta(meta), withBroker(broker))
 		task := &alterCollectionTask{
 			baseTask: newBaseTask(context.Background(), core),
 			Req: &milvuspb.AlterCollectionRequest{
@@ -161,7 +161,7 @@ func Test_alterCollectionTask_Execute(t *testing.T) {
 			return nil
 		}
 
-		core := newTestCore(withValidProxyManager(), withMeta(meta), withBroker(broker))
+		core := newTestCore(withMeta(meta), withBroker(broker))
 		task := &alterCollectionTask{
 			baseTask: newBaseTask(context.Background(), core),
 			Req: &milvuspb.AlterCollectionRequest{

--- a/internal/rootcoord/create_alias_task.go
+++ b/internal/rootcoord/create_alias_task.go
@@ -36,9 +36,6 @@ func (t *createAliasTask) Prepare(ctx context.Context) error {
 }
 
 func (t *createAliasTask) Execute(ctx context.Context) error {
-	if err := t.core.ExpireMetaCache(ctx, t.Req.GetDbName(), []string{t.Req.GetAlias(), t.Req.GetCollectionName()}, InvalidCollectionID, t.GetTs()); err != nil {
-		return err
-	}
 	// create alias is atomic enough.
 	return t.core.meta.CreateAlias(ctx, t.Req.GetDbName(), t.Req.GetAlias(), t.Req.GetCollectionName(), t.GetTs())
 }

--- a/internal/rootcoord/create_alias_task_test.go
+++ b/internal/rootcoord/create_alias_task_test.go
@@ -41,19 +41,6 @@ func Test_createAliasTask_Prepare(t *testing.T) {
 }
 
 func Test_createAliasTask_Execute(t *testing.T) {
-	t.Run("failed to expire cache", func(t *testing.T) {
-		core := newTestCore(withInvalidProxyManager())
-		task := &createAliasTask{
-			baseTask: newBaseTask(context.Background(), core),
-			Req: &milvuspb.CreateAliasRequest{
-				Base:  &commonpb.MsgBase{MsgType: commonpb.MsgType_CreateAlias},
-				Alias: "test",
-			},
-		}
-		err := task.Execute(context.Background())
-		assert.Error(t, err)
-	})
-
 	t.Run("failed to create alias", func(t *testing.T) {
 		core := newTestCore(withInvalidMeta(), withValidProxyManager())
 		task := &createAliasTask{

--- a/internal/rootcoord/create_collection_task.go
+++ b/internal/rootcoord/create_collection_task.go
@@ -31,6 +31,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/metastore/model"
 	pb "github.com/milvus-io/milvus/internal/proto/etcdpb"
+	"github.com/milvus-io/milvus/internal/util/proxyutil"
 	"github.com/milvus-io/milvus/pkg/common"
 	"github.com/milvus-io/milvus/pkg/log"
 	ms "github.com/milvus-io/milvus/pkg/mq/msgstream"
@@ -478,6 +479,7 @@ func (t *createCollectionTask) Execute(ctx context.Context) error {
 		collectionNames: []string{t.Req.GetCollectionName()},
 		collectionID:    InvalidCollectionID,
 		ts:              ts,
+		opts:            []proxyutil.ExpireCacheOpt{proxyutil.SetMsgType(commonpb.MsgType_DropCollection)},
 	}, &nullStep{})
 	undoTask.AddStep(&nullStep{}, &removeDmlChannelsStep{
 		baseStep:  baseStep{core: t.core},

--- a/internal/rootcoord/create_partition_task.go
+++ b/internal/rootcoord/create_partition_task.go
@@ -81,6 +81,7 @@ func (t *createPartitionTask) Execute(ctx context.Context) error {
 		dbName:          t.Req.GetDbName(),
 		collectionNames: []string{t.collMeta.Name},
 		collectionID:    t.collMeta.CollectionID,
+		partitionName:   t.Req.GetPartitionName(),
 		ts:              t.GetTs(),
 	}, &nullStep{})
 

--- a/internal/rootcoord/drop_alias_task.go
+++ b/internal/rootcoord/drop_alias_task.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
+	"github.com/milvus-io/milvus/internal/util/proxyutil"
 )
 
 type dropAliasTask struct {
@@ -37,7 +38,7 @@ func (t *dropAliasTask) Prepare(ctx context.Context) error {
 
 func (t *dropAliasTask) Execute(ctx context.Context) error {
 	// drop alias is atomic enough.
-	if err := t.core.ExpireMetaCache(ctx, t.Req.GetDbName(), []string{t.Req.GetAlias()}, InvalidCollectionID, t.GetTs()); err != nil {
+	if err := t.core.ExpireMetaCache(ctx, t.Req.GetDbName(), []string{t.Req.GetAlias()}, InvalidCollectionID, "", t.GetTs(), proxyutil.SetMsgType(commonpb.MsgType_DropAlias)); err != nil {
 		return err
 	}
 	return t.core.meta.DropAlias(ctx, t.Req.GetDbName(), t.Req.GetAlias(), t.GetTs())

--- a/internal/rootcoord/drop_collection_task.go
+++ b/internal/rootcoord/drop_collection_task.go
@@ -80,7 +80,7 @@ func (t *dropCollectionTask) Execute(ctx context.Context) error {
 		collectionNames: append(aliases, collMeta.Name),
 		collectionID:    collMeta.CollectionID,
 		ts:              ts,
-		opts:            []proxyutil.ExpireCacheOpt{proxyutil.ExpireCacheWithDropFlag()},
+		opts:            []proxyutil.ExpireCacheOpt{proxyutil.SetMsgType(commonpb.MsgType_DropCollection)},
 	})
 	redoTask.AddSyncStep(&changeCollectionStateStep{
 		baseStep:     baseStep{core: t.core},

--- a/internal/rootcoord/drop_partition_task.go
+++ b/internal/rootcoord/drop_partition_task.go
@@ -26,6 +26,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/milvus-io/milvus/internal/metastore/model"
 	pb "github.com/milvus-io/milvus/internal/proto/etcdpb"
+	"github.com/milvus-io/milvus/internal/util/proxyutil"
 	"github.com/milvus-io/milvus/pkg/common"
 	"github.com/milvus-io/milvus/pkg/log"
 )
@@ -73,7 +74,9 @@ func (t *dropPartitionTask) Execute(ctx context.Context) error {
 		dbName:          t.Req.GetDbName(),
 		collectionNames: []string{t.collMeta.Name},
 		collectionID:    t.collMeta.CollectionID,
+		partitionName:   t.Req.GetPartitionName(),
 		ts:              t.GetTs(),
+		opts:            []proxyutil.ExpireCacheOpt{proxyutil.SetMsgType(commonpb.MsgType_DropPartition)},
 	})
 	redoTask.AddSyncStep(&changePartitionStateStep{
 		baseStep:     baseStep{core: t.core},

--- a/internal/rootcoord/expire_cache.go
+++ b/internal/rootcoord/expire_cache.go
@@ -26,20 +26,7 @@ import (
 )
 
 // ExpireMetaCache will call invalidate collection meta cache
-func (c *Core) ExpireMetaCache(ctx context.Context, dbName string, collNames []string, collectionID UniqueID, ts typeutil.Timestamp, opts ...proxyutil.ExpireCacheOpt) error {
-	// if collectionID is specified, invalidate all the collection meta cache with the specified collectionID and return
-	if collectionID != InvalidCollectionID {
-		req := proxypb.InvalidateCollMetaCacheRequest{
-			Base: commonpbutil.NewMsgBase(
-				commonpbutil.WithTimeStamp(ts),
-				commonpbutil.WithSourceID(c.session.ServerID),
-			),
-			DbName:       dbName,
-			CollectionID: collectionID,
-		}
-		return c.proxyClientManager.InvalidateCollectionMetaCache(ctx, &req, opts...)
-	}
-
+func (c *Core) ExpireMetaCache(ctx context.Context, dbName string, collNames []string, collectionID UniqueID, partitionName string, ts typeutil.Timestamp, opts ...proxyutil.ExpireCacheOpt) error {
 	// if only collNames are specified, invalidate the collection meta cache with the specified collectionName
 	for _, collName := range collNames {
 		req := proxypb.InvalidateCollMetaCacheRequest{
@@ -49,6 +36,8 @@ func (c *Core) ExpireMetaCache(ctx context.Context, dbName string, collNames []s
 			),
 			DbName:         dbName,
 			CollectionName: collName,
+			CollectionID:   collectionID,
+			PartitionName:  partitionName,
 		}
 		err := c.proxyClientManager.InvalidateCollectionMetaCache(ctx, &req, opts...)
 		if err != nil {

--- a/internal/rootcoord/expire_cache_test.go
+++ b/internal/rootcoord/expire_cache_test.go
@@ -30,8 +30,8 @@ func Test_expireCacheConfig_apply(t *testing.T) {
 	c := proxyutil.DefaultExpireCacheConfig()
 	req := &proxypb.InvalidateCollMetaCacheRequest{}
 	c.Apply(req)
-	assert.Nil(t, req.GetBase())
-	opt := proxyutil.ExpireCacheWithDropFlag()
+	assert.Equal(t, commonpb.MsgType_Undefined, req.GetBase().GetMsgType())
+	opt := proxyutil.SetMsgType(commonpb.MsgType_DropCollection)
 	opt(&c)
 	c.Apply(req)
 	assert.Equal(t, commonpb.MsgType_DropCollection, req.GetBase().GetMsgType())

--- a/internal/rootcoord/rename_collection_task.go
+++ b/internal/rootcoord/rename_collection_task.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
+	"github.com/milvus-io/milvus/internal/util/proxyutil"
 )
 
 type renameCollectionTask struct {
@@ -36,7 +37,7 @@ func (t *renameCollectionTask) Prepare(ctx context.Context) error {
 }
 
 func (t *renameCollectionTask) Execute(ctx context.Context) error {
-	if err := t.core.ExpireMetaCache(ctx, t.Req.GetDbName(), []string{t.Req.GetOldName()}, InvalidCollectionID, t.GetTs()); err != nil {
+	if err := t.core.ExpireMetaCache(ctx, t.Req.GetDbName(), []string{t.Req.GetOldName()}, InvalidCollectionID, "", t.GetTs(), proxyutil.SetMsgType(commonpb.MsgType_RenameCollection)); err != nil {
 		return err
 	}
 	return t.core.meta.RenameCollection(ctx, t.Req.GetDbName(), t.Req.GetOldName(), t.Req.GetNewDBName(), t.Req.GetNewName(), t.GetTs())

--- a/internal/rootcoord/step.go
+++ b/internal/rootcoord/step.go
@@ -170,12 +170,13 @@ type expireCacheStep struct {
 	dbName          string
 	collectionNames []string
 	collectionID    UniqueID
+	partitionName   string
 	ts              Timestamp
 	opts            []proxyutil.ExpireCacheOpt
 }
 
 func (s *expireCacheStep) Execute(ctx context.Context) ([]nestedStep, error) {
-	err := s.core.ExpireMetaCache(ctx, s.dbName, s.collectionNames, s.collectionID, s.ts, s.opts...)
+	err := s.core.ExpireMetaCache(ctx, s.dbName, s.collectionNames, s.collectionID, s.partitionName, s.ts, s.opts...)
 	return nil, err
 }
 

--- a/internal/util/proxyutil/proxy_client_manager.go
+++ b/internal/util/proxyutil/proxy_client_manager.go
@@ -40,28 +40,25 @@ import (
 )
 
 type ExpireCacheConfig struct {
-	withDropFlag bool
+	msgType commonpb.MsgType
 }
 
 func (c ExpireCacheConfig) Apply(req *proxypb.InvalidateCollMetaCacheRequest) {
-	if !c.withDropFlag {
-		return
-	}
 	if req.GetBase() == nil {
 		req.Base = commonpbutil.NewMsgBase()
 	}
-	req.Base.MsgType = commonpb.MsgType_DropCollection
+	req.Base.MsgType = c.msgType
 }
 
 func DefaultExpireCacheConfig() ExpireCacheConfig {
-	return ExpireCacheConfig{withDropFlag: false}
+	return ExpireCacheConfig{}
 }
 
 type ExpireCacheOpt func(c *ExpireCacheConfig)
 
-func ExpireCacheWithDropFlag() ExpireCacheOpt {
+func SetMsgType(msgType commonpb.MsgType) ExpireCacheOpt {
 	return func(c *ExpireCacheConfig) {
-		c.withDropFlag = true
+		c.msgType = msgType
 	}
 }
 


### PR DESCRIPTION
issue: #29772 

1. `DropPartition` only invalidates the cache related to the partition.
2. `CreateAlias` does not invalidate the cache.