### PR TITLE
enhance: [Cherry-pick] Use newer checkpoint when packing LoadSegmentRequest (#29922)

### DIFF
--- a/internal/querycoordv2/utils/types.go
+++ b/internal/querycoordv2/utils/types.go
@@ -72,8 +72,12 @@ func MergeMetaSegmentIntoSegmentInfo(info *querypb.SegmentInfo, segments ...*met
 
 // packSegmentLoadInfo packs SegmentLoadInfo for given segment,
 // packs with index if withIndex is true, this fetch indexes from IndexCoord
-func PackSegmentLoadInfo(resp *datapb.GetSegmentInfoResponse, checkpoint *msgpb.MsgPosition, indexes []*querypb.FieldIndexInfo) *querypb.SegmentLoadInfo {
+func PackSegmentLoadInfo(resp *datapb.GetSegmentInfoResponse, channelCheckpoint *msgpb.MsgPosition, indexes []*querypb.FieldIndexInfo) *querypb.SegmentLoadInfo {
 	segment := resp.GetInfos()[0]
+	checkpoint := segment.GetDmlPosition()
+	if channelCheckpoint.GetTimestamp() > checkpoint.GetTimestamp() {
+		checkpoint = channelCheckpoint
+	}
 
 	posTime := tsoutil.PhysicalTime(checkpoint.GetTimestamp())
 	tsLag := time.Since(posTime)

--- a/internal/querycoordv2/utils/types_test.go
+++ b/internal/querycoordv2/utils/types_test.go
@@ -51,6 +51,10 @@ func Test_packLoadSegmentRequest(t *testing.T) {
 			ChannelName: mockPChannel,
 			Timestamp:   t1,
 		},
+		DmlPosition: &msgpb.MsgPosition{
+			ChannelName: mockPChannel,
+			Timestamp:   t1,
+		},
 	}
 
 	t.Run("test set deltaPosition from channel", func(t *testing.T) {
@@ -68,7 +72,10 @@ func Test_packLoadSegmentRequest(t *testing.T) {
 	t.Run("test channel cp after segment dml position", func(t *testing.T) {
 		channel := proto.Clone(channel).(*datapb.VchannelInfo)
 		channel.SeekPosition.Timestamp = t3
-		req := PackSegmentLoadInfo(segmentInfo, channel.GetSeekPosition(), nil)
+		resp := &datapb.GetSegmentInfoResponse{
+			Infos: []*datapb.SegmentInfo{segmentInfo},
+		}
+		req := PackSegmentLoadInfo(resp, channel.GetSeekPosition(), nil)
 		assert.NotNil(t, req.GetDeltaPosition())
 		assert.Equal(t, mockPChannel, req.GetDeltaPosition().ChannelName)
 		assert.Equal(t, t3, req.GetDeltaPosition().Timestamp)


### PR DESCRIPTION
Cherry-pick from master
pr: #29922 
See also: #29650

Either segment dml position & channel checkpoint could be newer in some
cases. This PR make PackLoadSegments use the newer one improving load
performance during cases where there are lots of upsert.
