### PR TITLE
fix: fix wrong log file name when running as mixture type

### DIFF
--- a/cmd/milvus/run.go
+++ b/cmd/milvus/run.go
@@ -19,7 +19,7 @@ import (
 type run struct{}
 
 func init() {
-  paramtable.Init()
+	paramtable.Init()
 }
 
 func (c *run) execute(args []string, flags *flag.FlagSet) {

--- a/cmd/milvus/run.go
+++ b/cmd/milvus/run.go
@@ -13,9 +13,14 @@ import (
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/util/hardware"
 	"github.com/milvus-io/milvus/pkg/util/metricsinfo"
+	"github.com/milvus-io/milvus/pkg/util/paramtable"
 )
 
 type run struct{}
+
+func init() {
+  paramtable.Init()
+}
 
 func (c *run) execute(args []string, flags *flag.FlagSet) {
 	if len(args) < 3 {

--- a/cmd/milvus/util.go
+++ b/cmd/milvus/util.go
@@ -24,6 +24,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/util/etcd"
 	"github.com/milvus-io/milvus/pkg/util/hardware"
+	"github.com/milvus-io/milvus/pkg/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
 
@@ -171,6 +172,7 @@ func GetMilvusRoles(args []string, flags *flag.FlagSet) *roles.MilvusRoles {
 		os.Exit(-1)
 	}
 
+	paramtable.SetRole(serverType)
 	return role
 }
 

--- a/cmd/roles/roles.go
+++ b/cmd/roles/roles.go
@@ -103,11 +103,6 @@ func runComponent[T component](ctx context.Context,
 		factory := dependency.NewFactory(localMsg)
 		var err error
 		role, err = creator(ctx, factory)
-		if localMsg {
-			paramtable.SetRole(typeutil.StandaloneRole)
-		} else {
-			paramtable.SetRole(role.GetName())
-		}
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
See also: #25323, #29969
many users reported log file name is incorrect when starting in mixture type.