### PR TITLE
enhance: refactor leader_observer to leader_checker (#29454)

### DIFF
--- a/internal/querycoordv2/checkers/balance_checker.go
+++ b/internal/querycoordv2/checkers/balance_checker.go
@@ -30,6 +30,7 @@ import (
 	. "github.com/milvus-io/milvus/internal/querycoordv2/params"
 	"github.com/milvus-io/milvus/internal/querycoordv2/session"
 	"github.com/milvus-io/milvus/internal/querycoordv2/task"
+	"github.com/milvus-io/milvus/internal/querycoordv2/utils"
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
@@ -53,8 +54,8 @@ func NewBalanceChecker(meta *meta.Meta, balancer balance.Balance, nodeMgr *sessi
 	}
 }
 
-func (b *BalanceChecker) ID() task.Source {
-	return balanceChecker
+func (b *BalanceChecker) ID() utils.CheckerType {
+	return utils.BalanceChecker
 }
 
 func (b *BalanceChecker) Description() string {

--- a/internal/querycoordv2/checkers/channel_checker.go
+++ b/internal/querycoordv2/checkers/channel_checker.go
@@ -55,8 +55,8 @@ func NewChannelChecker(
 	}
 }
 
-func (c *ChannelChecker) ID() task.Source {
-	return channelChecker
+func (c *ChannelChecker) ID() utils.CheckerType {
+	return utils.ChannelChecker
 }
 
 func (c *ChannelChecker) Description() string {

--- a/internal/querycoordv2/checkers/checker.go
+++ b/internal/querycoordv2/checkers/checker.go
@@ -20,10 +20,11 @@ import (
 	"context"
 
 	"github.com/milvus-io/milvus/internal/querycoordv2/task"
+	"github.com/milvus-io/milvus/internal/querycoordv2/utils"
 )
 
 type Checker interface {
-	ID() task.Source
+	ID() utils.CheckerType
 	Description() string
 	Check(ctx context.Context) []task.Task
 }

--- a/internal/querycoordv2/checkers/controller.go
+++ b/internal/querycoordv2/checkers/controller.go
@@ -18,10 +18,10 @@ package checkers
 
 import (
 	"context"
-	"errors"
 	"sync"
 	"time"
 
+	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/internal/querycoordv2/balance"
@@ -107,7 +107,7 @@ func getCheckerInterval(checker utils.CheckerType) time.Duration {
 	case utils.IndexChecker:
 		return Params.QueryCoordCfg.IndexCheckInterval.GetAsDuration(time.Millisecond)
 	case utils.LeaderChecker:
-		return Params.QueryCoordCfg.LeaderViewUpdateInterval.GetAsDuration(time.Millisecond)
+		return Params.QueryCoordCfg.LeaderViewUpdateInterval.GetAsDuration(time.Second)
 	default:
 		return Params.QueryCoordCfg.CheckInterval.GetAsDuration(time.Millisecond)
 	}

--- a/internal/querycoordv2/checkers/index_checker.go
+++ b/internal/querycoordv2/checkers/index_checker.go
@@ -28,6 +28,7 @@ import (
 	"github.com/milvus-io/milvus/internal/querycoordv2/params"
 	"github.com/milvus-io/milvus/internal/querycoordv2/session"
 	"github.com/milvus-io/milvus/internal/querycoordv2/task"
+	"github.com/milvus-io/milvus/internal/querycoordv2/utils"
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
@@ -56,8 +57,8 @@ func NewIndexChecker(
 	}
 }
 
-func (c *IndexChecker) ID() task.Source {
-	return indexChecker
+func (c *IndexChecker) ID() utils.CheckerType {
+	return utils.IndexChecker
 }
 
 func (c *IndexChecker) Description() string {

--- a/internal/querycoordv2/checkers/leader_checker.go
+++ b/internal/querycoordv2/checkers/leader_checker.go
@@ -1,0 +1,199 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checkers
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/milvus-io/milvus/internal/proto/querypb"
+	"github.com/milvus-io/milvus/internal/querycoordv2/meta"
+	"github.com/milvus-io/milvus/internal/querycoordv2/params"
+	"github.com/milvus-io/milvus/internal/querycoordv2/session"
+	"github.com/milvus-io/milvus/internal/querycoordv2/task"
+	"github.com/milvus-io/milvus/internal/querycoordv2/utils"
+	"github.com/milvus-io/milvus/pkg/log"
+	"github.com/milvus-io/milvus/pkg/util/paramtable"
+)
+
+var _ Checker = (*LeaderChecker)(nil)
+
+// LeaderChecker perform segment index check.
+type LeaderChecker struct {
+	meta    *meta.Meta
+	dist    *meta.DistributionManager
+	target  *meta.TargetManager
+	nodeMgr *session.NodeManager
+}
+
+func NewLeaderChecker(
+	meta *meta.Meta,
+	dist *meta.DistributionManager,
+	target *meta.TargetManager,
+	nodeMgr *session.NodeManager,
+) *LeaderChecker {
+	return &LeaderChecker{
+		meta:    meta,
+		dist:    dist,
+		target:  target,
+		nodeMgr: nodeMgr,
+	}
+}
+
+func (c *LeaderChecker) ID() utils.CheckerType {
+	return utils.LeaderChecker
+}
+
+func (c *LeaderChecker) Description() string {
+	return "LeaderChecker checks the difference of leader view between dist, and try to correct it"
+}
+
+func (c *LeaderChecker) Check(ctx context.Context) []task.Task {
+	collectionIDs := c.meta.CollectionManager.GetAll()
+	tasks := make([]task.Task, 0)
+
+	for _, collectionID := range collectionIDs {
+		collection := c.meta.CollectionManager.GetCollection(collectionID)
+		if collection == nil {
+			log.Warn("collection released during check leader", zap.Int64("collection", collectionID))
+			continue
+		}
+
+		replicas := c.meta.ReplicaManager.GetByCollection(collectionID)
+		for _, replica := range replicas {
+			for _, node := range replica.GetNodes() {
+				if ok, _ := c.nodeMgr.IsStoppingNode(node); ok {
+					// no need to correct leader's view which is loaded on stopping node
+					continue
+				}
+
+				leaderViews := c.dist.LeaderViewManager.GetByCollectionAndNode(replica.GetCollectionID(), node)
+				for ch, leaderView := range leaderViews {
+					dist := c.dist.SegmentDistManager.GetByShardWithReplica(ch, replica)
+					tasks = append(tasks, c.findNeedLoadedSegments(ctx, replica.ID, leaderView, dist)...)
+					tasks = append(tasks, c.findNeedRemovedSegments(ctx, replica.ID, leaderView, dist)...)
+				}
+			}
+		}
+	}
+
+	return tasks
+}
+
+func (c *LeaderChecker) findNeedLoadedSegments(ctx context.Context, replica int64, leaderView *meta.LeaderView, dist []*meta.Segment) []task.Task {
+	log := log.Ctx(ctx).With(
+		zap.Int64("collectionID", leaderView.CollectionID),
+		zap.Int64("replica", replica),
+		zap.String("channel", leaderView.Channel),
+		zap.Int64("leaderViewID", leaderView.ID),
+	)
+	ret := make([]task.Task, 0)
+	dist = utils.FindMaxVersionSegments(dist)
+	for _, s := range dist {
+		version, ok := leaderView.Segments[s.GetID()]
+		currentTarget := c.target.GetSealedSegment(s.CollectionID, s.GetID(), meta.CurrentTarget)
+		existInCurrentTarget := currentTarget != nil
+		existInNextTarget := c.target.GetSealedSegment(s.CollectionID, s.GetID(), meta.NextTarget) != nil
+
+		if !existInCurrentTarget && !existInNextTarget {
+			continue
+		}
+
+		leaderWithOldVersion := version.GetVersion() < s.Version
+		// leader has newer version, but the query node which loaded the newer version has been shutdown
+		leaderWithDirtyVersion := version.GetVersion() > s.Version && c.nodeMgr.Get(version.GetNodeID()) == nil
+
+		if !ok || leaderWithOldVersion || leaderWithDirtyVersion {
+			log.Debug("leader checker append a segment to set",
+				zap.Int64("segmentID", s.GetID()),
+				zap.Int64("nodeID", s.Node))
+			action := task.NewSegmentActionWithScope(s.Node, task.ActionTypeGrow, s.GetInsertChannel(), s.GetID(), querypb.DataScope_Historical)
+			t, err := task.NewSegmentTask(
+				ctx,
+				params.Params.QueryCoordCfg.SegmentTaskTimeout.GetAsDuration(time.Millisecond),
+				c.ID(),
+				s.GetCollectionID(),
+				replica,
+				action,
+			)
+			if err != nil {
+				log.Warn("create segment update task failed",
+					zap.Int64("segmentID", s.GetID()),
+					zap.Int64("node", s.Node),
+					zap.Error(err),
+				)
+				continue
+			}
+			// index task shall have lower or equal priority than balance task
+			t.SetPriority(task.TaskPriorityHigh)
+			t.SetReason("add segment to leader view")
+			ret = append(ret, t)
+		}
+	}
+	return ret
+}
+
+func (c *LeaderChecker) findNeedRemovedSegments(ctx context.Context, replica int64, leaderView *meta.LeaderView, dists []*meta.Segment) []task.Task {
+	log := log.Ctx(ctx).With(
+		zap.Int64("collectionID", leaderView.CollectionID),
+		zap.Int64("replica", replica),
+		zap.String("channel", leaderView.Channel),
+		zap.Int64("leaderViewID", leaderView.ID),
+	)
+
+	ret := make([]task.Task, 0)
+	distMap := make(map[int64]struct{})
+	for _, s := range dists {
+		distMap[s.GetID()] = struct{}{}
+	}
+
+	for sid, s := range leaderView.Segments {
+		_, ok := distMap[sid]
+		existInCurrentTarget := c.target.GetSealedSegment(leaderView.CollectionID, sid, meta.CurrentTarget) != nil
+		existInNextTarget := c.target.GetSealedSegment(leaderView.CollectionID, sid, meta.NextTarget) != nil
+		if ok || existInCurrentTarget || existInNextTarget {
+			continue
+		}
+		log.Debug("leader checker append a segment to remove",
+			zap.Int64("segmentID", sid),
+			zap.Int64("nodeID", s.NodeID))
+
+		action := task.NewSegmentActionWithScope(leaderView.ID, task.ActionTypeReduce, leaderView.Channel, sid, querypb.DataScope_Historical)
+		t, err := task.NewSegmentTask(
+			ctx,
+			paramtable.Get().QueryCoordCfg.SegmentTaskTimeout.GetAsDuration(time.Millisecond),
+			c.ID(),
+			leaderView.CollectionID,
+			replica,
+			action,
+		)
+		if err != nil {
+			log.Warn("create segment reduce task failed",
+				zap.Int64("segmentID", sid),
+				zap.Int64("nodeID", s.NodeID),
+				zap.Error(err))
+			continue
+		}
+
+		t.SetPriority(task.TaskPriorityHigh)
+		t.SetReason("remove segment from leader view")
+		ret = append(ret, t)
+	}
+	return ret
+}

--- a/internal/querycoordv2/checkers/leader_checker_test.go
+++ b/internal/querycoordv2/checkers/leader_checker_test.go
@@ -1,0 +1,368 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checkers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/milvus-io/milvus/internal/kv"
+	etcdkv "github.com/milvus-io/milvus/internal/kv/etcd"
+	"github.com/milvus-io/milvus/internal/metastore/kv/querycoord"
+	"github.com/milvus-io/milvus/internal/proto/datapb"
+	"github.com/milvus-io/milvus/internal/proto/querypb"
+	"github.com/milvus-io/milvus/internal/querycoordv2/meta"
+	. "github.com/milvus-io/milvus/internal/querycoordv2/params"
+	"github.com/milvus-io/milvus/internal/querycoordv2/session"
+	"github.com/milvus-io/milvus/internal/querycoordv2/task"
+	"github.com/milvus-io/milvus/internal/querycoordv2/utils"
+	"github.com/milvus-io/milvus/pkg/util/etcd"
+	"github.com/milvus-io/milvus/pkg/util/paramtable"
+)
+
+type LeaderCheckerTestSuite struct {
+	suite.Suite
+	checker *LeaderChecker
+	kv      kv.MetaKv
+
+	meta    *meta.Meta
+	broker  *meta.MockBroker
+	nodeMgr *session.NodeManager
+}
+
+func (suite *LeaderCheckerTestSuite) SetupSuite() {
+	paramtable.Init()
+}
+
+func (suite *LeaderCheckerTestSuite) SetupTest() {
+	var err error
+	config := GenerateEtcdConfig()
+	cli, err := etcd.GetEtcdClient(
+		config.UseEmbedEtcd.GetAsBool(),
+		config.EtcdUseSSL.GetAsBool(),
+		config.Endpoints.GetAsStrings(),
+		config.EtcdTLSCert.GetValue(),
+		config.EtcdTLSKey.GetValue(),
+		config.EtcdTLSCACert.GetValue(),
+		config.EtcdTLSMinVersion.GetValue())
+	suite.Require().NoError(err)
+	suite.kv = etcdkv.NewEtcdKV(cli, config.MetaRootPath.GetValue())
+
+	// meta
+	store := querycoord.NewCatalog(suite.kv)
+	idAllocator := RandomIncrementIDAllocator()
+	suite.nodeMgr = session.NewNodeManager()
+	suite.meta = meta.NewMeta(idAllocator, store, suite.nodeMgr)
+	suite.broker = meta.NewMockBroker(suite.T())
+
+	distManager := meta.NewDistributionManager()
+	targetManager := meta.NewTargetManager(suite.broker, suite.meta)
+	suite.checker = NewLeaderChecker(suite.meta, distManager, targetManager, suite.nodeMgr)
+}
+
+func (suite *LeaderCheckerTestSuite) TearDownTest() {
+	suite.kv.Close()
+}
+
+func (suite *LeaderCheckerTestSuite) TestSyncLoadedSegments() {
+	observer := suite.checker
+	observer.meta.CollectionManager.PutCollection(utils.CreateTestCollection(1, 1))
+	observer.meta.CollectionManager.PutPartition(utils.CreateTestPartition(1, 1))
+	observer.meta.ReplicaManager.Put(utils.CreateTestReplica(1, 1, []int64{1, 2}))
+	segments := []*datapb.SegmentInfo{
+		{
+			ID:            1,
+			PartitionID:   1,
+			InsertChannel: "test-insert-channel",
+		},
+	}
+	channels := []*datapb.VchannelInfo{
+		{
+			CollectionID: 1,
+			ChannelName:  "test-insert-channel",
+		},
+	}
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
+		channels, segments, nil)
+	observer.target.UpdateCollectionNextTarget(int64(1))
+	observer.target.UpdateCollectionCurrentTarget(1)
+	observer.dist.SegmentDistManager.Update(1, utils.CreateTestSegment(1, 1, 1, 2, 1, "test-insert-channel"))
+	observer.dist.ChannelDistManager.Update(2, utils.CreateTestChannel(1, 2, 1, "test-insert-channel"))
+	view := utils.CreateTestLeaderView(2, 1, "test-insert-channel", map[int64]int64{}, map[int64]*meta.Segment{})
+	view.TargetVersion = observer.target.GetCollectionTargetVersion(1, meta.CurrentTarget)
+	observer.dist.LeaderViewManager.Update(2, view)
+
+	tasks := suite.checker.Check(context.TODO())
+	suite.Len(tasks, 1)
+	suite.Equal(tasks[0].Source(), utils.LeaderChecker)
+	suite.Len(tasks[0].Actions(), 1)
+	suite.Equal(tasks[0].Actions()[0].Type(), task.ActionTypeGrow)
+	suite.Equal(tasks[0].Actions()[0].Node(), int64(1))
+	suite.Equal(tasks[0].Actions()[0].(*task.SegmentAction).SegmentID(), int64(1))
+	suite.Equal(tasks[0].Priority(), task.TaskPriorityHigh)
+}
+
+func (suite *LeaderCheckerTestSuite) TestStoppingNode() {
+	observer := suite.checker
+	observer.meta.CollectionManager.PutCollection(utils.CreateTestCollection(1, 1))
+	observer.meta.CollectionManager.PutPartition(utils.CreateTestPartition(1, 1))
+	observer.meta.ReplicaManager.Put(utils.CreateTestReplica(1, 1, []int64{1, 2}))
+	segments := []*datapb.SegmentInfo{
+		{
+			ID:            1,
+			PartitionID:   1,
+			InsertChannel: "test-insert-channel",
+		},
+	}
+	channels := []*datapb.VchannelInfo{
+		{
+			CollectionID: 1,
+			ChannelName:  "test-insert-channel",
+		},
+	}
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
+		channels, segments, nil)
+	observer.target.UpdateCollectionNextTarget(int64(1))
+	observer.target.UpdateCollectionCurrentTarget(1)
+	observer.dist.SegmentDistManager.Update(1, utils.CreateTestSegment(1, 1, 1, 2, 1, "test-insert-channel"))
+	observer.dist.ChannelDistManager.Update(2, utils.CreateTestChannel(1, 2, 1, "test-insert-channel"))
+	view := utils.CreateTestLeaderView(2, 1, "test-insert-channel", map[int64]int64{}, map[int64]*meta.Segment{})
+	view.TargetVersion = observer.target.GetCollectionTargetVersion(1, meta.CurrentTarget)
+	observer.dist.LeaderViewManager.Update(2, view)
+
+	suite.nodeMgr.Add(session.NewNodeInfo(2, "localhost"))
+	suite.nodeMgr.Stopping(2)
+
+	tasks := suite.checker.Check(context.TODO())
+	suite.Len(tasks, 0)
+}
+
+func (suite *LeaderCheckerTestSuite) TestIgnoreSyncLoadedSegments() {
+	observer := suite.checker
+	observer.meta.CollectionManager.PutCollection(utils.CreateTestCollection(1, 1))
+	observer.meta.CollectionManager.PutPartition(utils.CreateTestPartition(1, 1))
+	observer.meta.ReplicaManager.Put(utils.CreateTestReplica(1, 1, []int64{1, 2}))
+	segments := []*datapb.SegmentInfo{
+		{
+			ID:            1,
+			PartitionID:   1,
+			InsertChannel: "test-insert-channel",
+		},
+	}
+	channels := []*datapb.VchannelInfo{
+		{
+			CollectionID: 1,
+			ChannelName:  "test-insert-channel",
+		},
+	}
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
+		channels, segments, nil)
+	observer.target.UpdateCollectionNextTarget(int64(1))
+	observer.target.UpdateCollectionCurrentTarget(1)
+	observer.target.UpdateCollectionNextTarget(int64(1))
+	observer.dist.SegmentDistManager.Update(1, utils.CreateTestSegment(1, 1, 1, 2, 1, "test-insert-channel"),
+		utils.CreateTestSegment(1, 1, 2, 2, 1, "test-insert-channel"))
+	observer.dist.ChannelDistManager.Update(2, utils.CreateTestChannel(1, 2, 1, "test-insert-channel"))
+	view := utils.CreateTestLeaderView(2, 1, "test-insert-channel", map[int64]int64{}, map[int64]*meta.Segment{})
+	view.TargetVersion = observer.target.GetCollectionTargetVersion(1, meta.CurrentTarget)
+	observer.dist.LeaderViewManager.Update(2, view)
+
+	tasks := suite.checker.Check(context.TODO())
+	suite.Len(tasks, 1)
+	suite.Equal(tasks[0].Source(), utils.LeaderChecker)
+	suite.Len(tasks[0].Actions(), 1)
+	suite.Equal(tasks[0].Actions()[0].Type(), task.ActionTypeGrow)
+	suite.Equal(tasks[0].Actions()[0].Node(), int64(1))
+	suite.Equal(tasks[0].Actions()[0].(*task.SegmentAction).SegmentID(), int64(1))
+	suite.Equal(tasks[0].Priority(), task.TaskPriorityHigh)
+}
+
+func (suite *LeaderCheckerTestSuite) TestIgnoreBalancedSegment() {
+	observer := suite.checker
+	observer.meta.CollectionManager.PutCollection(utils.CreateTestCollection(1, 1))
+	observer.meta.CollectionManager.PutPartition(utils.CreateTestPartition(1, 1))
+	observer.meta.ReplicaManager.Put(utils.CreateTestReplica(1, 1, []int64{1, 2}))
+	segments := []*datapb.SegmentInfo{
+		{
+			ID:            1,
+			PartitionID:   1,
+			InsertChannel: "test-insert-channel",
+		},
+	}
+	channels := []*datapb.VchannelInfo{
+		{
+			CollectionID: 1,
+			ChannelName:  "test-insert-channel",
+		},
+	}
+
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
+		channels, segments, nil)
+	observer.target.UpdateCollectionNextTarget(int64(1))
+	observer.target.UpdateCollectionCurrentTarget(1)
+	observer.dist.SegmentDistManager.Update(1, utils.CreateTestSegment(1, 1, 1, 1, 1, "test-insert-channel"))
+	observer.dist.ChannelDistManager.Update(2, utils.CreateTestChannel(1, 2, 1, "test-insert-channel"))
+
+	// dist with older version and leader view with newer version
+	leaderView := utils.CreateTestLeaderView(2, 1, "test-insert-channel", map[int64]int64{}, map[int64]*meta.Segment{})
+	leaderView.Segments[1] = &querypb.SegmentDist{
+		NodeID:  2,
+		Version: 2,
+	}
+	leaderView.TargetVersion = observer.target.GetCollectionTargetVersion(1, meta.CurrentTarget)
+	observer.dist.LeaderViewManager.Update(2, leaderView)
+
+	// test querynode-1 and querynode-2 exist
+	suite.nodeMgr.Add(session.NewNodeInfo(1, "localhost"))
+	suite.nodeMgr.Add(session.NewNodeInfo(2, "localhost"))
+	tasks := suite.checker.Check(context.TODO())
+	suite.Len(tasks, 0)
+
+	// test querynode-2 crash
+	suite.nodeMgr.Remove(2)
+	tasks = suite.checker.Check(context.TODO())
+	suite.Len(tasks, 1)
+	suite.Equal(tasks[0].Source(), utils.LeaderChecker)
+	suite.Len(tasks[0].Actions(), 1)
+	suite.Equal(tasks[0].Actions()[0].Type(), task.ActionTypeGrow)
+	suite.Equal(tasks[0].Actions()[0].Node(), int64(1))
+	suite.Equal(tasks[0].Actions()[0].(*task.SegmentAction).SegmentID(), int64(1))
+	suite.Equal(tasks[0].Priority(), task.TaskPriorityHigh)
+}
+
+func (suite *LeaderCheckerTestSuite) TestSyncLoadedSegmentsWithReplicas() {
+	observer := suite.checker
+	observer.meta.CollectionManager.PutCollection(utils.CreateTestCollection(1, 2))
+	observer.meta.CollectionManager.PutPartition(utils.CreateTestPartition(1, 1))
+	observer.meta.ReplicaManager.Put(utils.CreateTestReplica(1, 1, []int64{1, 2}))
+	observer.meta.ReplicaManager.Put(utils.CreateTestReplica(2, 1, []int64{3, 4}))
+	segments := []*datapb.SegmentInfo{
+		{
+			ID:            1,
+			PartitionID:   1,
+			InsertChannel: "test-insert-channel",
+		},
+	}
+	channels := []*datapb.VchannelInfo{
+		{
+			CollectionID: 1,
+			ChannelName:  "test-insert-channel",
+		},
+	}
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
+		channels, segments, nil)
+	observer.target.UpdateCollectionNextTarget(int64(1))
+	observer.target.UpdateCollectionCurrentTarget(1)
+	observer.dist.SegmentDistManager.Update(1, utils.CreateTestSegment(1, 1, 1, 1, 0, "test-insert-channel"))
+	observer.dist.SegmentDistManager.Update(4, utils.CreateTestSegment(1, 1, 1, 4, 0, "test-insert-channel"))
+	observer.dist.ChannelDistManager.Update(2, utils.CreateTestChannel(1, 2, 1, "test-insert-channel"))
+	observer.dist.ChannelDistManager.Update(4, utils.CreateTestChannel(1, 4, 2, "test-insert-channel"))
+	view := utils.CreateTestLeaderView(2, 1, "test-insert-channel", map[int64]int64{}, map[int64]*meta.Segment{})
+	view.TargetVersion = observer.target.GetCollectionTargetVersion(1, meta.CurrentTarget)
+	observer.dist.LeaderViewManager.Update(2, view)
+	view2 := utils.CreateTestLeaderView(4, 1, "test-insert-channel", map[int64]int64{1: 4}, map[int64]*meta.Segment{})
+	view.TargetVersion = observer.target.GetCollectionTargetVersion(1, meta.CurrentTarget)
+	observer.dist.LeaderViewManager.Update(4, view2)
+
+	tasks := suite.checker.Check(context.TODO())
+	suite.Len(tasks, 1)
+	suite.Equal(tasks[0].Source(), utils.LeaderChecker)
+	suite.Equal(tasks[0].ReplicaID(), int64(1))
+	suite.Len(tasks[0].Actions(), 1)
+	suite.Equal(tasks[0].Actions()[0].Type(), task.ActionTypeGrow)
+	suite.Equal(tasks[0].Actions()[0].Node(), int64(1))
+	suite.Equal(tasks[0].Actions()[0].(*task.SegmentAction).SegmentID(), int64(1))
+	suite.Equal(tasks[0].Priority(), task.TaskPriorityHigh)
+}
+
+func (suite *LeaderCheckerTestSuite) TestSyncRemovedSegments() {
+	observer := suite.checker
+	observer.meta.CollectionManager.PutCollection(utils.CreateTestCollection(1, 1))
+	observer.meta.CollectionManager.PutPartition(utils.CreateTestPartition(1, 1))
+	observer.meta.ReplicaManager.Put(utils.CreateTestReplica(1, 1, []int64{1, 2}))
+
+	channels := []*datapb.VchannelInfo{
+		{
+			CollectionID: 1,
+			ChannelName:  "test-insert-channel",
+		},
+	}
+
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
+		channels, nil, nil)
+	observer.target.UpdateCollectionNextTarget(int64(1))
+	observer.target.UpdateCollectionCurrentTarget(1)
+
+	observer.dist.ChannelDistManager.Update(2, utils.CreateTestChannel(1, 2, 1, "test-insert-channel"))
+	view := utils.CreateTestLeaderView(2, 1, "test-insert-channel", map[int64]int64{3: 2}, map[int64]*meta.Segment{})
+	view.TargetVersion = observer.target.GetCollectionTargetVersion(1, meta.CurrentTarget)
+	observer.dist.LeaderViewManager.Update(2, view)
+
+	tasks := suite.checker.Check(context.TODO())
+	suite.Len(tasks, 1)
+	suite.Equal(tasks[0].Source(), utils.LeaderChecker)
+	suite.Equal(tasks[0].ReplicaID(), int64(1))
+	suite.Len(tasks[0].Actions(), 1)
+	suite.Equal(tasks[0].Actions()[0].Type(), task.ActionTypeReduce)
+	suite.Equal(tasks[0].Actions()[0].Node(), int64(2))
+	suite.Equal(tasks[0].Actions()[0].(*task.SegmentAction).SegmentID(), int64(3))
+	suite.Equal(tasks[0].Priority(), task.TaskPriorityHigh)
+}
+
+func (suite *LeaderCheckerTestSuite) TestIgnoreSyncRemovedSegments() {
+	observer := suite.checker
+	observer.meta.CollectionManager.PutCollection(utils.CreateTestCollection(1, 1))
+	observer.meta.CollectionManager.PutPartition(utils.CreateTestPartition(1, 1))
+	observer.meta.ReplicaManager.Put(utils.CreateTestReplica(1, 1, []int64{1, 2}))
+
+	segments := []*datapb.SegmentInfo{
+		{
+			ID:            2,
+			PartitionID:   1,
+			InsertChannel: "test-insert-channel",
+		},
+	}
+	channels := []*datapb.VchannelInfo{
+		{
+			CollectionID: 1,
+			ChannelName:  "test-insert-channel",
+		},
+	}
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
+		channels, segments, nil)
+	observer.target.UpdateCollectionNextTarget(int64(1))
+
+	observer.dist.ChannelDistManager.Update(2, utils.CreateTestChannel(1, 2, 1, "test-insert-channel"))
+	observer.dist.LeaderViewManager.Update(2, utils.CreateTestLeaderView(2, 1, "test-insert-channel", map[int64]int64{3: 2, 2: 2}, map[int64]*meta.Segment{}))
+
+	tasks := suite.checker.Check(context.TODO())
+	suite.Len(tasks, 1)
+	suite.Equal(tasks[0].Source(), utils.LeaderChecker)
+	suite.Equal(tasks[0].ReplicaID(), int64(1))
+	suite.Len(tasks[0].Actions(), 1)
+	suite.Equal(tasks[0].Actions()[0].Type(), task.ActionTypeReduce)
+	suite.Equal(tasks[0].Actions()[0].Node(), int64(2))
+	suite.Equal(tasks[0].Actions()[0].(*task.SegmentAction).SegmentID(), int64(3))
+	suite.Equal(tasks[0].Priority(), task.TaskPriorityHigh)
+}
+
+func TestLeaderCheckerSuite(t *testing.T) {
+	suite.Run(t, new(LeaderCheckerTestSuite))
+}

--- a/internal/querycoordv2/checkers/segment_checker.go
+++ b/internal/querycoordv2/checkers/segment_checker.go
@@ -60,8 +60,8 @@ func NewSegmentChecker(
 	}
 }
 
-func (c *SegmentChecker) ID() task.Source {
-	return segmentChecker
+func (c *SegmentChecker) ID() utils.CheckerType {
+	return utils.SegmentChecker
 }
 
 func (c *SegmentChecker) Description() string {

--- a/internal/querycoordv2/observers/collection_observer.go
+++ b/internal/querycoordv2/observers/collection_observer.go
@@ -41,7 +41,6 @@ type CollectionObserver struct {
 	meta                 *meta.Meta
 	targetMgr            *meta.TargetManager
 	targetObserver       *TargetObserver
-	leaderObserver       *LeaderObserver
 	checkerController    *checkers.CheckerController
 	partitionLoadedCount map[int64]int
 
@@ -53,7 +52,6 @@ func NewCollectionObserver(
 	meta *meta.Meta,
 	targetMgr *meta.TargetManager,
 	targetObserver *TargetObserver,
-	leaderObserver *LeaderObserver,
 	checherController *checkers.CheckerController,
 ) *CollectionObserver {
 	return &CollectionObserver{
@@ -61,7 +59,6 @@ func NewCollectionObserver(
 		meta:                 meta,
 		targetMgr:            targetMgr,
 		targetObserver:       targetObserver,
-		leaderObserver:       leaderObserver,
 		checkerController:    checherController,
 		partitionLoadedCount: make(map[int64]int),
 	}

--- a/internal/querycoordv2/observers/collection_observer_test.go
+++ b/internal/querycoordv2/observers/collection_observer_test.go
@@ -66,7 +66,6 @@ type CollectionObserverSuite struct {
 	meta              *meta.Meta
 	targetMgr         *meta.TargetManager
 	targetObserver    *TargetObserver
-	leaderObserver    *LeaderObserver
 	checkerController *checkers.CheckerController
 
 	// Test object
@@ -200,7 +199,6 @@ func (suite *CollectionObserverSuite) SetupTest() {
 	suite.checkerController = &checkers.CheckerController{}
 
 	mockCluster := session.NewMockCluster(suite.T())
-	suite.leaderObserver = NewLeaderObserver(suite.dist, suite.meta, suite.targetMgr, suite.broker, mockCluster, nodeMgr)
 	mockCluster.EXPECT().SyncDistribution(mock.Anything, mock.Anything, mock.Anything).Return(merr.Success(), nil).Maybe()
 
 	// Test object
@@ -209,7 +207,6 @@ func (suite *CollectionObserverSuite) SetupTest() {
 		suite.meta,
 		suite.targetMgr,
 		suite.targetObserver,
-		suite.leaderObserver,
 		suite.checkerController,
 	)
 
@@ -217,7 +214,6 @@ func (suite *CollectionObserverSuite) SetupTest() {
 		suite.broker.EXPECT().GetPartitions(mock.Anything, collection).Return(suite.partitions[collection], nil).Maybe()
 	}
 	suite.targetObserver.Start()
-	suite.leaderObserver.Start()
 	suite.ob.Start()
 	suite.loadAll()
 }

--- a/internal/querycoordv2/server.go
+++ b/internal/querycoordv2/server.go
@@ -110,7 +110,6 @@ type Server struct {
 
 	// Observers
 	collectionObserver *observers.CollectionObserver
-	leaderObserver     *observers.LeaderObserver
 	targetObserver     *observers.TargetObserver
 	replicaObserver    *observers.ReplicaObserver
 	resourceObserver   *observers.ResourceObserver
@@ -363,14 +362,6 @@ func (s *Server) initMeta() error {
 
 func (s *Server) initObserver() {
 	log.Info("init observers")
-	s.leaderObserver = observers.NewLeaderObserver(
-		s.dist,
-		s.meta,
-		s.targetMgr,
-		s.broker,
-		s.cluster,
-		s.nodeMgr,
-	)
 	s.targetObserver = observers.NewTargetObserver(
 		s.meta,
 		s.targetMgr,
@@ -383,7 +374,6 @@ func (s *Server) initObserver() {
 		s.meta,
 		s.targetMgr,
 		s.targetObserver,
-		s.leaderObserver,
 		s.checkerController,
 	)
 
@@ -451,7 +441,6 @@ func (s *Server) startServerLoop() {
 
 	log.Info("start observers...")
 	s.collectionObserver.Start()
-	s.leaderObserver.Start()
 	s.targetObserver.Start()
 	s.replicaObserver.Start()
 	s.resourceObserver.Start()
@@ -494,9 +483,6 @@ func (s *Server) Stop() error {
 	log.Info("stop observers...")
 	if s.collectionObserver != nil {
 		s.collectionObserver.Stop()
-	}
-	if s.leaderObserver != nil {
-		s.leaderObserver.Stop()
 	}
 	if s.targetObserver != nil {
 		s.targetObserver.Stop()

--- a/internal/querycoordv2/server_test.go
+++ b/internal/querycoordv2/server_test.go
@@ -582,7 +582,6 @@ func (suite *ServerSuite) hackServer() {
 		suite.server.meta,
 		suite.server.targetMgr,
 		suite.server.targetObserver,
-		suite.server.leaderObserver,
 		suite.server.checkerController,
 	)
 

--- a/internal/querycoordv2/services_test.go
+++ b/internal/querycoordv2/services_test.go
@@ -196,7 +196,6 @@ func (suite *ServiceSuite) SetupTest() {
 		suite.server.meta,
 		suite.server.targetMgr,
 		suite.targetObserver,
-		suite.server.leaderObserver,
 		&checkers.CheckerController{},
 	)
 

--- a/internal/querycoordv2/task/scheduler.go
+++ b/internal/querycoordv2/task/scheduler.go
@@ -329,14 +329,7 @@ func (scheduler *taskScheduler) preAdd(task Task) error {
 
 		taskType := GetTaskType(task)
 
-		if taskType == TaskTypeGrow {
-			leaderSegmentDist := scheduler.distMgr.LeaderViewManager.GetSealedSegmentDist(task.SegmentID())
-			nodeSegmentDist := scheduler.distMgr.SegmentDistManager.GetSegmentDist(task.SegmentID())
-			if lo.Contains(leaderSegmentDist, task.Actions()[0].Node()) &&
-				lo.Contains(nodeSegmentDist, task.Actions()[0].Node()) {
-				return merr.WrapErrServiceInternal("segment loaded, it can be only balanced")
-			}
-		} else if taskType == TaskTypeMove {
+		if taskType == TaskTypeMove {
 			leaderSegmentDist := scheduler.distMgr.LeaderViewManager.GetSealedSegmentDist(task.SegmentID())
 			nodeSegmentDist := scheduler.distMgr.SegmentDistManager.GetSegmentDist(task.SegmentID())
 			if !lo.Contains(leaderSegmentDist, task.Actions()[1].Node()) ||

--- a/internal/querycoordv2/utils/checker.go
+++ b/internal/querycoordv2/utils/checker.go
@@ -21,6 +21,36 @@ import (
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
 
+const (
+	SegmentCheckerName = "segment_checker"
+	ChannelCheckerName = "channel_checker"
+	BalanceCheckerName = "balance_checker"
+	IndexCheckerName   = "index_checker"
+	LeaderCheckerName  = "leader_checker"
+)
+
+type CheckerType int32
+
+const (
+	ChannelChecker CheckerType = iota + 1
+	SegmentChecker
+	BalanceChecker
+	IndexChecker
+	LeaderChecker
+)
+
+var checkerNames = map[CheckerType]string{
+	SegmentChecker: SegmentCheckerName,
+	ChannelChecker: ChannelCheckerName,
+	BalanceChecker: BalanceCheckerName,
+	IndexChecker:   IndexCheckerName,
+	LeaderChecker:  LeaderCheckerName,
+}
+
+func (s CheckerType) String() string {
+	return checkerNames[s]
+}
+
 func FilterReleased[E interface{ GetCollectionID() int64 }](elems []E, collections []int64) []E {
 	collectionSet := typeutil.NewUniqueSet(collections...)
 	ret := make([]E, 0, len(elems))


### PR DESCRIPTION
issue: #29453
pr: #29452
sync distribution by rpc will also call loadSegment/releaseSegment, which may cause all kinds of concurrent case on same segment, such as concurrent load and release on one segment.
This PR add leader_checker which generate load/release task to correct the leader view, instead of calling sync distribution by rpc

---------