### PR TITLE
fix: Trigger leader checker too frequency

### DIFF
--- a/internal/querycoordv2/checkers/controller.go
+++ b/internal/querycoordv2/checkers/controller.go
@@ -107,7 +107,7 @@ func getCheckerInterval(checker utils.CheckerType) time.Duration {
 	case utils.IndexChecker:
 		return Params.QueryCoordCfg.IndexCheckInterval.GetAsDuration(time.Millisecond)
 	case utils.LeaderChecker:
-		return Params.QueryCoordCfg.LeaderViewUpdateInterval.GetAsDuration(time.Millisecond)
+		return Params.QueryCoordCfg.LeaderViewUpdateInterval.GetAsDuration(time.Second)
 	default:
 		return Params.QueryCoordCfg.CheckInterval.GetAsDuration(time.Millisecond)
 	}


### PR DESCRIPTION
issue: #29841
This PR fix leader checker use wrong check interval, which causes leader checker trigger too frequency