### PR TITLE
fix: CollectionSchema.autoID is deprecated

### DIFF
--- a/internal/distributed/proxy/httpserver/request.go
+++ b/internal/distributed/proxy/httpserver/request.go
@@ -1,13 +1,14 @@
 package httpserver
 
 type CreateCollectionReq struct {
-	DbName         string `json:"dbName"`
-	CollectionName string `json:"collectionName" validate:"required"`
-	Dimension      int32  `json:"dimension" validate:"required"`
-	Description    string `json:"description"`
-	MetricType     string `json:"metricType"`
-	PrimaryField   string `json:"primaryField"`
-	VectorField    string `json:"vectorField"`
+	DbName             string `json:"dbName"`
+	CollectionName     string `json:"collectionName" validate:"required"`
+	Dimension          int32  `json:"dimension" validate:"required"`
+	Description        string `json:"description"`
+	MetricType         string `json:"metricType"`
+	PrimaryField       string `json:"primaryField"`
+	VectorField        string `json:"vectorField"`
+	EnableDynamicField bool   `json:"enableDynamicField"`
 }
 
 type DropCollectionReq struct {

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -196,7 +196,7 @@ func checkAndSetData(body string, collSchema *schemapb.CollectionSchema) (error,
 
 				dataString := gjson.Get(data.Raw, fieldName).String()
 
-				if field.IsPrimaryKey && collSchema.AutoID {
+				if field.IsPrimaryKey && field.AutoID {
 					if dataString != "" {
 						return merr.WrapErrParameterInvalid("", "set primary key but autoID == true"), reallyDataArray
 					}

--- a/internal/proxy/meta_cache.go
+++ b/internal/proxy/meta_cache.go
@@ -1066,6 +1066,8 @@ func (m *MetaCache) RemoveDatabase(ctx context.Context, database string) {
 }
 
 func (m *MetaCache) HasDatabase(ctx context.Context, database string) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	_, ok := m.collInfo[database]
 	return ok
 }


### PR DESCRIPTION
issue: #30000
related to: [milvus-proto #202](https://github.com/milvus-io/milvus-proto/pull/202)

1. replace collSchema.AutoID with primaryField.AutoID
2. show `enableDynamic` & `enableDynamicField` at the same time
3. avoid data race about the access to metacache