### PR TITLE
enhance: update pymilvus version and update cases

### DIFF
--- a/tests/python_client/requirements.txt
+++ b/tests/python_client/requirements.txt
@@ -12,7 +12,7 @@ allure-pytest==2.7.0
 pytest-print==0.2.1
 pytest-level==0.1.1
 pytest-xdist==2.5.0
-pymilvus==2.4.0rc19
+pymilvus==2.4.0rc24
 pytest-rerunfailures==9.1.1
 git+https://github.com/Projectplace/pytest-tags
 ndg-httpsclient

--- a/tests/python_client/testcases/test_collection.py
+++ b/tests/python_client/testcases/test_collection.py
@@ -1258,13 +1258,15 @@ class TestCollectionOperation(TestcaseBase):
         fields = []
         for k, v in DataType.__members__.items():
             if v and v != DataType.UNKNOWN and v != DataType.STRING \
-            and v != DataType.VARCHAR and v != DataType.FLOAT_VECTOR \
-            and v != DataType.BINARY_VECTOR and v != DataType.ARRAY:
+                    and v != DataType.VARCHAR and v != DataType.FLOAT_VECTOR \
+                    and v != DataType.BINARY_VECTOR and v != DataType.ARRAY \
+                    and v != DataType.FLOAT16_VECTOR and v != DataType.BFLOAT16_VECTOR:
                 field, _ = self.field_schema_wrap.init_field_schema(name=k.lower(), dtype=v)
                 fields.append(field)
         fields.append(cf.gen_float_vec_field())
         schema, _ = self.collection_schema_wrap.init_collection_schema(fields,
                                                                        primary_field=ct.default_int64_field_name)
+        log.info(schema)
         c_name = cf.gen_unique_str(prefix)
         self.collection_wrap.init_collection(c_name, schema=schema, check_task=CheckTasks.check_collection_property,
                                              check_items={exp_name: c_name, exp_schema: schema})

--- a/tests/python_client/testcases/test_search.py
+++ b/tests/python_client/testcases/test_search.py
@@ -4464,7 +4464,7 @@ class TestCollectionSearch(TestcaseBase):
         res1 = collection_w.search(vector, default_search_field, search_params, limit)[0]
         res2 = collection_w.search(vector, default_search_field, search_params, limit * 2)[0]
         for i in range(default_nq):
-            assert res1[i].ids == res2[i].ids[limit:]
+            assert res1[i].ids == res2[i].ids[:limit]
 
 
 class TestSearchBase(TestcaseBase):


### PR DESCRIPTION
1. modify test case: test_search_repeatedly_ivf_index_different_limit
2. update pymilvus version from 2.4.0rc19 to 2.4.0rc24
3. Before, insert will return a pk list. In the latest milvus client, insert will return a number that is inserted successfully
4. In the latest milvus client, flush and num_entities have been removed
5. Before, the default consistency level of a new collection is strong. In the latest milvus client, it becomes bounded. So related cases have been modified correspondingly, or immediate search after insert will return no results.
6. In the latest pymilvus, new data type FLOAT16_VECTOR and BFLOAT16_VECTOR have been added.