### PR TITLE
enhance: [skip e2e] use checkout action to get ".git" for codecov

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -99,7 +99,6 @@ jobs:
             **/*
             !./.docker/**
             !./cmake_build/thirdparty/**
-            !.git
   UT-Cpp:
     name: UT for Cpp
     needs: Build
@@ -189,6 +188,7 @@ jobs:
             ./lcov_output.info
             *.info
             *.out
+            .git
   integration-test:
     name: Integration Test
     needs: Build

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -99,6 +99,7 @@ jobs:
             **/*
             !./.docker/**
             !./cmake_build/thirdparty/**
+            !.git
   UT-Cpp:
     name: UT for Cpp
     needs: Build
@@ -188,7 +189,6 @@ jobs:
             ./lcov_output.info
             *.info
             *.out
-            .git
   integration-test:
     name: Integration Test
     needs: Build
@@ -238,6 +238,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Download Cpp code coverage results
         uses: actions/download-artifact@v4.1.0
         with:


### PR DESCRIPTION
Ignoring .git may result "unusable report" in codecov. Use checkout action to get .git information in upload codecov step