### PR TITLE
enhance: disallow tikv/rawkv usages

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -106,6 +106,10 @@ linters-settings:
             desc: not allowed, use github.com/cockroachdb/errors
           - pkg: "io/ioutil"
             desc: ioutil is deprecated after 1.16, 1.17, use os and io package instead
+          - pkg: "github.com/tikv/client-go/rawkv"
+            desc: not allowed, use github.com/tikv/client-go/v2/txnkv
+          - pkg: "github.com/tikv/client-go/v2/rawkv"
+            desc: not allowed, use github.com/tikv/client-go/v2/txnkv
   forbidigo:
     forbid:
       - '^time\.Tick$'

--- a/internal/kv/tikv/main_test.go
+++ b/internal/kv/tikv/main_test.go
@@ -17,11 +17,9 @@
 package tikv
 
 import (
-	"context"
 	"os"
 	"testing"
 
-	"github.com/tikv/client-go/v2/rawkv"
 	"github.com/tikv/client-go/v2/testutils"
 	tilib "github.com/tikv/client-go/v2/tikv"
 	"github.com/tikv/client-go/v2/txnkv"
@@ -29,15 +27,11 @@ import (
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 )
 
-var (
-	txnClient *txnkv.Client
-	rawClient *rawkv.Client
-)
+var txnClient *txnkv.Client
 
 // creates a local TiKV Store for testing purpose.
 func setupLocalTiKV() {
 	setupLocalTxn()
-	setupLocalRaw()
 }
 
 func setupLocalTxn() {
@@ -53,28 +47,11 @@ func setupLocalTxn() {
 	txnClient = &txnkv.Client{KVStore: store}
 }
 
-func setupLocalRaw() {
-	client, cluster, pdClient, err := testutils.NewMockTiKV("", nil)
-	if err != nil {
-		panic(err)
-	}
-	testutils.BootstrapWithSingleStore(cluster)
-	rawClient = &rawkv.Client{}
-	p := rawkv.ClientProbe{Client: rawClient}
-	p.SetPDClient(pdClient)
-	p.SetRegionCache(tilib.NewRegionCache(pdClient))
-	p.SetRPCClient(client)
-}
-
 // Connects to a remote TiKV service for testing purpose. By default, it assumes the TiKV is from localhost.
 func setupRemoteTiKV() {
 	pdsn := "127.0.0.1:2379"
 	var err error
 	txnClient, err = txnkv.NewClient([]string{pdsn})
-	if err != nil {
-		panic(err)
-	}
-	rawClient, err = rawkv.NewClientWithOpts(context.Background(), []string{pdsn})
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Data write through rawkv API may pollute tikv data. It should be disallowed.
We will add this check to all repos that involves metadata access.
In the longer term, we should have a metadata service that implements access control.

relate: #30029