### PR TITLE
fix: Use size bucket for compacted segment size metric

### DIFF
--- a/internal/datacoord/util.go
+++ b/internal/datacoord/util.go
@@ -135,10 +135,12 @@ func getCollectionTTL(properties map[string]string) (time.Duration, error) {
 }
 
 func UpdateCompactionSegmentSizeMetrics(segments []*datapb.CompactionSegment) {
+	var totalSize int64
 	for _, seg := range segments {
-		size := getCompactedSegmentSize(seg)
-		metrics.DataCoordCompactedSegmentSize.WithLabelValues().Observe(float64(size))
+		totalSize += getCompactedSegmentSize(seg)
 	}
+	// observe size in bytes
+	metrics.DataCoordCompactedSegmentSize.WithLabelValues().Observe(float64(totalSize))
 }
 
 func getCompactedSegmentSize(s *datapb.CompactionSegment) int64 {

--- a/pkg/metrics/datacoord_metrics.go
+++ b/pkg/metrics/datacoord_metrics.go
@@ -161,7 +161,7 @@ var (
 			Subsystem: typeutil.DataCoordRole,
 			Name:      "compacted_segment_size",
 			Help:      "the segment size of compacted segment",
-			Buckets:   buckets,
+			Buckets:   sizeBuckets,
 		}, []string{})
 
 	DataCoordCompactionTaskNum = prometheus.NewGaugeVec(

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -106,6 +106,9 @@ var (
 	// longTaskBuckets provides long task duration in milliseconds
 	longTaskBuckets = []float64{1, 100, 500, 1000, 5000, 10000, 20000, 50000, 100000, 250000, 500000, 1000000, 3600000, 5000000, 10000000} // unit milliseconds
 
+	// size provides size in byte
+	sizeBuckets = []float64{10000, 100000, 1000000, 100000000, 500000000, 1024000000, 2048000000, 4096000000, 10000000000, 50000000000} // unit byte
+
 	NumNodes = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: milvusNamespace,


### PR DESCRIPTION
See also: #29204 