### PR TITLE
fix: Add more throughput in related metrics

### DIFF
--- a/internal/datanode/compactor.go
+++ b/internal/datanode/compactor.go
@@ -570,6 +570,7 @@ func (t *compactionTask) compact() (*datapb.CompactionPlanResult, error) {
 		State:    commonpb.CompactionState_Completed,
 		PlanID:   t.getPlanID(),
 		Segments: []*datapb.CompactionSegment{pack},
+		Type:     t.plan.GetType(),
 	}
 
 	return planResult, nil

--- a/internal/datanode/flow_graph_dd_node.go
+++ b/internal/datanode/flow_graph_dd_node.go
@@ -199,6 +199,10 @@ func (ddn *ddNode) Operate(in []Msg) []Msg {
 				WithLabelValues(fmt.Sprint(paramtable.GetNodeID()), metrics.InsertLabel, fmt.Sprint(ddn.collectionID)).
 				Inc()
 
+			metrics.DataNodeConsumeMsgRowsCount.
+				WithLabelValues(fmt.Sprint(paramtable.GetNodeID()), metrics.InsertLabel).
+				Add(float64(imsg.GetNumRows()))
+
 			log.Debug("DDNode receive insert messages",
 				zap.Int("numRows", len(imsg.GetRowIDs())),
 				zap.String("vChannelName", ddn.vChannelName))
@@ -225,6 +229,10 @@ func (ddn *ddNode) Operate(in []Msg) []Msg {
 			metrics.DataNodeConsumeMsgCount.
 				WithLabelValues(fmt.Sprint(paramtable.GetNodeID()), metrics.DeleteLabel, fmt.Sprint(ddn.collectionID)).
 				Inc()
+
+			metrics.DataNodeConsumeMsgRowsCount.
+				WithLabelValues(fmt.Sprint(paramtable.GetNodeID()), metrics.DeleteLabel).
+				Add(float64(dmsg.GetNumRows()))
 			fgMsg.deleteMessages = append(fgMsg.deleteMessages, dmsg)
 		}
 	}

--- a/internal/datanode/l0_compactor.go
+++ b/internal/datanode/l0_compactor.go
@@ -227,6 +227,7 @@ func (t *levelZeroCompactionTask) compact() (*datapb.CompactionPlanResult, error
 		State:    commonpb.CompactionState_Completed,
 		Segments: resultSegments,
 		Channel:  t.plan.GetChannel(),
+		Type:     t.plan.GetType(),
 	}
 
 	metrics.DataNodeCompactionLatency.WithLabelValues(fmt.Sprint(paramtable.GetNodeID()), t.plan.GetType().String()).

--- a/internal/datanode/services.go
+++ b/internal/datanode/services.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
-	"github.com/samber/lo"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
@@ -308,13 +307,6 @@ func (node *DataNode) GetCompactionState(ctx context.Context, req *datapb.Compac
 		}, nil
 	}
 	results := node.compactionExecutor.getAllCompactionResults()
-
-	if len(results) > 0 {
-		planIDs := lo.Map(results, func(result *datapb.CompactionPlanResult, i int) UniqueID {
-			return result.GetPlanID()
-		})
-		log.Info("Compaction results", zap.Int64s("planIDs", planIDs))
-	}
 	return &datapb.CompactionStateResponse{
 		Status:  merr.Success(),
 		Results: results,

--- a/internal/proto/data_coord.proto
+++ b/internal/proto/data_coord.proto
@@ -538,6 +538,7 @@ message CompactionPlanResult {
   common.CompactionState state = 2;
   repeated CompactionSegment segments = 3;
   string channel = 4;
+  CompactionType type = 5;
 }
 
 message CompactionStateResponse {

--- a/pkg/metrics/datanode_metrics.go
+++ b/pkg/metrics/datanode_metrics.go
@@ -192,7 +192,7 @@ var (
 		prometheus.CounterOpts{
 			Namespace: milvusNamespace,
 			Subsystem: typeutil.DataNodeRole,
-			Name:      "consume_counter",
+			Name:      "consume_bytes_count",
 			Help:      "",
 		}, []string{nodeIDLabelName, msgTypeLabelName})
 


### PR DESCRIPTION
This PR also fixes bugs in l0 compactor where
l0 results would never be removed from datanode

See also: #30099 