### PR TITLE
fix: Leader checker canot submit load task

### DIFF
--- a/internal/querycoordv2/task/scheduler.go
+++ b/internal/querycoordv2/task/scheduler.go
@@ -329,14 +329,7 @@ func (scheduler *taskScheduler) preAdd(task Task) error {
 
 		taskType := GetTaskType(task)
 
-		if taskType == TaskTypeGrow {
-			leaderSegmentDist := scheduler.distMgr.LeaderViewManager.GetSealedSegmentDist(task.SegmentID())
-			nodeSegmentDist := scheduler.distMgr.SegmentDistManager.GetSegmentDist(task.SegmentID())
-			if lo.Contains(leaderSegmentDist, task.Actions()[0].Node()) &&
-				lo.Contains(nodeSegmentDist, task.Actions()[0].Node()) {
-				return merr.WrapErrServiceInternal("segment loaded, it can be only balanced")
-			}
-		} else if taskType == TaskTypeMove {
+		if taskType == TaskTypeMove {
 			leaderSegmentDist := scheduler.distMgr.LeaderViewManager.GetSealedSegmentDist(task.SegmentID())
 			nodeSegmentDist := scheduler.distMgr.SegmentDistManager.GetSegmentDist(task.SegmentID())
 			if !lo.Contains(leaderSegmentDist, task.Actions()[1].Node()) ||


### PR DESCRIPTION
issue: #29841
if segment loaded, submit load segment task for it isn't permitted, to avoid load segment twice. but this logic blocks the leader checker to correct leader view by `LoadSegment`

This PR remove the segment loaded check, to fix that leader checker cann't submit load task 