### PR TITLE
[fix]: Improve the index ordinal in string validation error message

### DIFF
--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -1619,3 +1619,17 @@ func CheckDatabase(ctx context.Context, dbName string) bool {
 	}
 	return false
 }
+
+func convertNumberToOrdinal(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	suffixes := []string{"th", "st", "nd", "rd"}
+	lastDigit := n % 10
+	secondLastDigit := (n / 10) % 10
+
+	if secondLastDigit == 1 || lastDigit > 3 {
+		return fmt.Sprintf("%dth")
+	}
+	return fmt.Sprintf("%d%s", n, suffixes[lastDigit])
+}

--- a/internal/proxy/util_test.go
+++ b/internal/proxy/util_test.go
@@ -2089,3 +2089,20 @@ func TestSendReplicateMessagePack(t *testing.T) {
 		SendReplicateMessagePack(ctx, mockStream, &milvuspb.ReleasePartitionsRequest{})
 	})
 }
+
+func Test_convertNumberToOrdinal(t *testing.T) {
+	cases := map[int]string{
+		0:  "0th",
+		1:  "1st",
+		2:  "2nd",
+		3:  "3rd",
+		4:  "4th",
+		11: "11th",
+		21: "21st",
+	}
+
+	for n, exp := range cases {
+		res := convertNumberToOrdinal(n)
+		assert.Equal(t, exp, res)
+	}
+}

--- a/internal/proxy/validate_util.go
+++ b/internal/proxy/validate_util.go
@@ -506,7 +506,8 @@ func (v *validateUtil) checkArrayFieldData(field *schemapb.FieldData, fieldSchem
 func verifyLengthPerRow[E interface{ ~string | ~[]byte }](strArr []E, maxLength int64) error {
 	for i, s := range strArr {
 		if int64(len(s)) > maxLength {
-			msg := fmt.Sprintf("the length (%d) of %dth string exceeds max length (%d)", len(s), i, maxLength)
+			ord := convertNumberToOrdinal(i + 1)
+			msg := fmt.Sprintf("the length (%d) of %s string exceeds max length (%d)", len(s), ord, maxLength)
 			return merr.WrapErrParameterInvalid("valid length string", "string length exceeds max length", msg)
 		}
 	}


### PR DESCRIPTION
I've improved the string validation error message by using the correct ordinals for the item's index in the array. I've also introduced a function to map a number with it's respective ordinal.

Fixes #30082 