### PR TITLE
enhance: [Cherry-pick] Shuffle candidates before channel assignment (#30066)

### DIFF
--- a/internal/querycoordv2/balance/rowcount_based_balancer.go
+++ b/internal/querycoordv2/balance/rowcount_based_balancer.go
@@ -76,6 +76,7 @@ func (b *RowCountBasedBalancer) AssignSegment(collectionID int64, segments []*me
 // try to make every query node has channel count
 func (b *RowCountBasedBalancer) AssignChannel(channels []*meta.DmChannel, nodes []int64) []ChannelAssignPlan {
 	nodeItems := b.convertToNodeItemsByChannel(nodes)
+	nodeItems = lo.Shuffle(nodeItems)
 	if len(nodeItems) == 0 {
 		return nil
 	}


### PR DESCRIPTION
Cherry-pick from master
pr: #30066

Shuffle candidates to reduce scenario that some channel allocated into same node