### PR TITLE
enhance: [Cherry-pick] make integration test case timeout configurable (#30073)

### DIFF
--- a/scripts/run_intergration_test.sh
+++ b/scripts/run_intergration_test.sh
@@ -31,7 +31,7 @@ beginTime=`date +%s`
 
 for d in $(go list ./tests/integration/...); do
     echo "$d"
-    go test -race -tags dynamic -v -coverpkg=./... -coverprofile=profile.out -covermode=atomic "$d" -timeout=20m
+    go test -race -tags dynamic -v -coverpkg=./... -coverprofile=profile.out -covermode=atomic "$d" -caseTimeout=15m -timeout=30m
     if [ -f profile.out ]; then
         grep -v kafka profile.out | grep -v planparserv2/generated | grep -v mocks | sed '1d' >> ${FILE_COVERAGE_INFO}
         rm profile.out

--- a/tests/integration/suite.go
+++ b/tests/integration/suite.go
@@ -18,7 +18,7 @@ package integration
 
 import (
 	"context"
-	"math/rand"
+	"flag"
 	"os"
 	"strings"
 	"time"
@@ -29,6 +29,12 @@ import (
 	"github.com/milvus-io/milvus/pkg/util/etcd"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 )
+
+var caseTimeout time.Duration
+
+func init() {
+	flag.DurationVar(&caseTimeout, "caseTimeout", 10*time.Minute, "timeout duration for single case")
+}
 
 // EmbedEtcdSuite contains embed setup & teardown related logic
 type EmbedEtcdSuite struct {
@@ -66,7 +72,6 @@ type MiniClusterSuite struct {
 }
 
 func (s *MiniClusterSuite) SetupSuite() {
-	rand.Seed(time.Now().UnixNano())
 	s.Require().NoError(s.SetupEmbedEtcd())
 }
 
@@ -84,7 +89,8 @@ func (s *MiniClusterSuite) SetupTest() {
 
 	params = paramtable.Get()
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*180)
+	s.T().Log("Setup case timeout", caseTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), caseTimeout)
 	s.cancelFunc = cancel
 	c, err := StartMiniCluster(ctx, func(c *MiniCluster) {
 		// change config etcd endpoints


### PR DESCRIPTION
Cherry-pick from master
pr: #30073

currently integration test may timeout if any case run time is above 3 minutes. This duration was hard coded.

This PR change this duration into a customized parameter and could be passed via test running commands.

---------