### PR TITLE
fix: patching search cache param when index meta does not hold one

### DIFF
--- a/internal/core/thirdparty/knowhere/CMakeLists.txt
+++ b/internal/core/thirdparty/knowhere/CMakeLists.txt
@@ -15,7 +15,7 @@
 set( KNOWHERE_VERSION v2.2.3 )
 set( GIT_REPOSITORY  "https://github.com/zilliztech/knowhere.git")
 if ( INDEX_ENGINE STREQUAL "cardinal" )
-    set( KNOWHERE_VERSION 2.2.3 )
+    set( KNOWHERE_VERSION 2.2.3-hotfix )
     set( GIT_REPOSITORY  "https://github.com/zilliztech/knowhere-cloud.git")
 endif()
 message(STATUS "Knowhere repo: ${GIT_REPOSITORY}")

--- a/internal/datacoord/index_builder.go
+++ b/internal/datacoord/index_builder.go
@@ -30,6 +30,7 @@ import (
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/pkg/common"
 	"github.com/milvus-io/milvus/pkg/log"
+	"github.com/milvus-io/milvus/pkg/util/indexparams"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 )
 
@@ -297,6 +298,14 @@ func (ib *indexBuilder) process(buildID UniqueID) bool {
 				UseVirtualHost:   Params.MinioCfg.UseVirtualHost.GetAsBool(),
 				CloudProvider:    Params.MinioCfg.CloudProvider.GetValue(),
 				RequestTimeoutMs: Params.MinioCfg.RequestTimeoutMs.GetAsInt64(),
+			}
+		}
+		if isDiskANNIndex(getIndexType(indexParams)) {
+			var err error
+			indexParams, err = indexparams.AppendDiskIndexBuildParams(Params, indexParams)
+			if err != nil {
+				log.Ctx(ib.ctx).Warn("failed to append index build params", zap.Int64("buildID", buildID),
+					zap.Int64("nodeID", nodeID), zap.Error(err))
 			}
 		}
 		req := &indexpb.CreateJobRequest{

--- a/internal/datacoord/util.go
+++ b/internal/datacoord/util.go
@@ -182,6 +182,10 @@ func isFlatIndex(indexType string) bool {
 	return indexType == flatIndex || indexType == binFlatIndex
 }
 
+func isDiskANNIndex(indexType string) bool {
+	return indexType == diskAnnIndex
+}
+
 func parseBuildIDFromFilePath(key string) (UniqueID, error) {
 	ss := strings.Split(key, "/")
 	if strings.HasSuffix(key, "/") {


### PR DESCRIPTION
patch search cache param from index configs when index meta could not get the search cache size key

issue: #30113 
pr: #30119