### PR TITLE
enhance: only buffer delete if it match insert has smaller timestamp

### DIFF
--- a/internal/datanode/writebuffer/bf_write_buffer.go
+++ b/internal/datanode/writebuffer/bf_write_buffer.go
@@ -28,30 +28,8 @@ func NewBFWriteBuffer(channel string, metacache metacache.MetaCache, storageV2Ca
 	}, nil
 }
 
-func (wb *bfWriteBuffer) BufferData(insertMsgs []*msgstream.InsertMsg, deleteMsgs []*msgstream.DeleteMsg, startPos, endPos *msgpb.MsgPosition) error {
-	wb.mut.Lock()
-	defer wb.mut.Unlock()
-
-	// process insert msgs
-	pkData, err := wb.bufferInsert(insertMsgs, startPos, endPos)
-	if err != nil {
-		return err
-	}
-
-	// update pk oracle
-	for segmentID, dataList := range pkData {
-		segments := wb.metaCache.GetSegmentsBy(metacache.WithSegmentIDs(segmentID))
-		for _, segment := range segments {
-			for _, fieldData := range dataList {
-				err := segment.GetBloomFilterSet().UpdatePKRange(fieldData)
-				if err != nil {
-					return err
-				}
-			}
-		}
-	}
-
-	// distribute delete msg
+func (wb *bfWriteBuffer) dispatchDeleteMsgs(groups []*inData, deleteMsgs []*msgstream.DeleteMsg, startPos, endPos *msgpb.MsgPosition) {
+	// distribute delete msg for previous data
 	for _, delMsg := range deleteMsgs {
 		pks := storage.ParseIDs2PrimaryKeys(delMsg.GetPrimaryKeys())
 		segments := wb.metaCache.GetSegmentsBy(metacache.WithPartitionID(delMsg.PartitionID),
@@ -70,6 +48,57 @@ func (wb *bfWriteBuffer) BufferData(insertMsgs []*msgstream.InsertMsg, deleteMsg
 			}
 			if len(deletePks) > 0 {
 				wb.bufferDelete(segment.SegmentID(), deletePks, deleteTss, startPos, endPos)
+			}
+		}
+
+		for _, inData := range groups {
+			var deletePks []storage.PrimaryKey
+			var deleteTss []typeutil.Timestamp
+			for idx, pk := range pks {
+				ts := delMsg.GetTimestamps()[idx]
+				if inData.pkExists(pk, ts) {
+					deletePks = append(deletePks, pk)
+					deleteTss = append(deleteTss, delMsg.GetTimestamps()[idx])
+				}
+			}
+			if len(deletePks) > 0 {
+				wb.bufferDelete(inData.segmentID, deletePks, deleteTss, startPos, endPos)
+			}
+		}
+	}
+}
+
+func (wb *bfWriteBuffer) BufferData(insertMsgs []*msgstream.InsertMsg, deleteMsgs []*msgstream.DeleteMsg, startPos, endPos *msgpb.MsgPosition) error {
+	wb.mut.Lock()
+	defer wb.mut.Unlock()
+
+	groups, err := wb.prepareInsert(insertMsgs)
+	if err != nil {
+		return err
+	}
+
+	// buffer insert data and add segment if not exists
+	for _, inData := range groups {
+		err := wb.bufferInsert(inData, startPos, endPos)
+		if err != nil {
+			return err
+		}
+	}
+
+	// distribute delete msg
+	// bf write buffer check bloom filter of segment and current insert batch to decide which segment to write delete data
+	wb.dispatchDeleteMsgs(groups, deleteMsgs, startPos, endPos)
+
+	// update pk oracle
+	for _, inData := range groups {
+		// segment shall always exists after buffer insert
+		segments := wb.metaCache.GetSegmentsBy(metacache.WithSegmentIDs(inData.segmentID))
+		for _, segment := range segments {
+			for _, fieldData := range inData.pkField {
+				err := segment.GetBloomFilterSet().UpdatePKRange(fieldData)
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/internal/datanode/writebuffer/bf_write_buffer_test.go
+++ b/internal/datanode/writebuffer/bf_write_buffer_test.go
@@ -142,7 +142,7 @@ func (s *BFWriteBufferSuite) composeDeleteMsg(pks []storage.PrimaryKey) *msgstre
 	delMsg := &msgstream.DeleteMsg{
 		DeleteRequest: msgpb.DeleteRequest{
 			PrimaryKeys: storage.ParsePrimaryKeys2IDs(pks),
-			Timestamps:  lo.RepeatBy(len(pks), func(idx int) uint64 { return tsoutil.ComposeTSByTime(time.Now(), int64(idx)) }),
+			Timestamps:  lo.RepeatBy(len(pks), func(idx int) uint64 { return tsoutil.ComposeTSByTime(time.Now(), int64(idx+1)) }),
 		},
 	}
 	return delMsg

--- a/internal/datanode/writebuffer/l0_write_buffer.go
+++ b/internal/datanode/writebuffer/l0_write_buffer.go
@@ -16,6 +16,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/mq/msgstream"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/retry"
+	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
 
 type l0WriteBuffer struct {
@@ -45,37 +46,78 @@ func NewL0WriteBuffer(channel string, metacache metacache.MetaCache, storageV2Ca
 	}, nil
 }
 
+func (wb *l0WriteBuffer) dispatchDeleteMsgs(groups []*inData, deleteMsgs []*msgstream.DeleteMsg, startPos, endPos *msgpb.MsgPosition) {
+	for _, delMsg := range deleteMsgs {
+		l0SegmentID := wb.getL0SegmentID(delMsg.GetPartitionID(), startPos)
+		pks := storage.ParseIDs2PrimaryKeys(delMsg.GetPrimaryKeys())
+		segments := wb.metaCache.GetSegmentsBy(metacache.WithPartitionID(delMsg.PartitionID),
+			metacache.WithSegmentState(commonpb.SegmentState_Growing, commonpb.SegmentState_Flushing, commonpb.SegmentState_Flushed))
+		for _, segment := range segments {
+			if segment.CompactTo() != 0 {
+				continue
+			}
+			var deletePks []storage.PrimaryKey
+			var deleteTss []typeutil.Timestamp
+			for idx, pk := range pks {
+				if segment.GetBloomFilterSet().PkExists(pk) {
+					deletePks = append(deletePks, pk)
+					deleteTss = append(deleteTss, delMsg.GetTimestamps()[idx])
+				}
+			}
+			if len(deletePks) > 0 {
+				wb.bufferDelete(l0SegmentID, deletePks, deleteTss, startPos, endPos)
+			}
+		}
+
+		for _, inData := range groups {
+			var deletePks []storage.PrimaryKey
+			var deleteTss []typeutil.Timestamp
+			for idx, pk := range pks {
+				ts := delMsg.GetTimestamps()[idx]
+				if inData.pkExists(pk, ts) {
+					deletePks = append(deletePks, pk)
+					deleteTss = append(deleteTss, delMsg.GetTimestamps()[idx])
+				}
+			}
+			if len(deletePks) > 0 {
+				wb.bufferDelete(l0SegmentID, deletePks, deleteTss, startPos, endPos)
+			}
+		}
+	}
+}
+
 func (wb *l0WriteBuffer) BufferData(insertMsgs []*msgstream.InsertMsg, deleteMsgs []*msgstream.DeleteMsg, startPos, endPos *msgpb.MsgPosition) error {
 	wb.mut.Lock()
 	defer wb.mut.Unlock()
 
-	// process insert msgs
-	pkData, err := wb.bufferInsert(insertMsgs, startPos, endPos)
+	groups, err := wb.prepareInsert(insertMsgs)
 	if err != nil {
-		log.Warn("failed to buffer insert data", zap.Error(err))
 		return err
 	}
 
+	// buffer insert data and add segment if not exists
+	for _, inData := range groups {
+		err := wb.bufferInsert(inData, startPos, endPos)
+		if err != nil {
+			return err
+		}
+	}
+
+	// distribute delete msg
+	// bf write buffer check bloom filter of segment and current insert batch to decide which segment to write delete data
+	wb.dispatchDeleteMsgs(groups, deleteMsgs, startPos, endPos)
+
 	// update pk oracle
-	for segmentID, dataList := range pkData {
-		segments := wb.metaCache.GetSegmentsBy(metacache.WithSegmentIDs(segmentID))
+	for _, inData := range groups {
+		// segment shall always exists after buffer insert
+		segments := wb.metaCache.GetSegmentsBy(metacache.WithSegmentIDs(inData.segmentID))
 		for _, segment := range segments {
-			for _, fieldData := range dataList {
+			for _, fieldData := range inData.pkField {
 				err := segment.GetBloomFilterSet().UpdatePKRange(fieldData)
 				if err != nil {
 					return err
 				}
 			}
-		}
-	}
-
-	for _, msg := range deleteMsgs {
-		l0SegmentID := wb.getL0SegmentID(msg.GetPartitionID(), startPos)
-		pks := storage.ParseIDs2PrimaryKeys(msg.GetPrimaryKeys())
-		err := wb.bufferDelete(l0SegmentID, pks, msg.GetTimestamps(), startPos, endPos)
-		if err != nil {
-			log.Warn("failed to buffer delete data", zap.Error(err))
-			return err
 		}
 	}
 

--- a/internal/datanode/writebuffer/write_buffer.go
+++ b/internal/datanode/writebuffer/write_buffer.go
@@ -355,7 +355,7 @@ func (id *inData) pkExists(pk storage.PrimaryKey, ts uint64) bool {
 	for batchIdx, timestamps := range id.tsField {
 		ids := id.pkField[batchIdx]
 		var primaryKey storage.PrimaryKey
-		switch ids.GetDataType() {
+		switch pk.Type() {
 		case schemapb.DataType_Int64:
 			primaryKey = storage.NewInt64PrimaryKey(0)
 		case schemapb.DataType_VarChar:

--- a/internal/datanode/writebuffer/write_buffer.go
+++ b/internal/datanode/writebuffer/write_buffer.go
@@ -380,13 +380,13 @@ func (id *inData) pkExists(pk storage.PrimaryKey, ts uint64) bool {
 // also returns primary key field data
 func (wb *writeBufferBase) prepareInsert(insertMsgs []*msgstream.InsertMsg) ([]*inData, error) {
 	groups := lo.GroupBy(insertMsgs, func(msg *msgstream.InsertMsg) int64 { return msg.SegmentID })
-	segmentPartiton := lo.SliceToMap(insertMsgs, func(msg *msgstream.InsertMsg) (int64, int64) { return msg.GetSegmentID(), msg.GetPartitionID() })
+	segmentPartition := lo.SliceToMap(insertMsgs, func(msg *msgstream.InsertMsg) (int64, int64) { return msg.GetSegmentID(), msg.GetPartitionID() })
 
 	result := make([]*inData, 0, len(groups))
 	for segment, msgs := range groups {
 		inData := &inData{
 			segmentID:   segment,
-			partitionID: segmentPartiton[segment],
+			partitionID: segmentPartition[segment],
 			data:        make([]*storage.InsertData, 0, len(msgs)),
 			pkField:     make([]storage.FieldData, 0, len(msgs)),
 		}
@@ -409,7 +409,7 @@ func (wb *writeBufferBase) prepareInsert(insertMsgs []*msgstream.InsertMsg) ([]*
 			if err != nil {
 				return nil, err
 			}
-			if pkFieldData.RowNum() != data.GetRowNum() {
+			if tsFieldData.RowNum() != data.GetRowNum() {
 				return nil, merr.WrapErrServiceInternal("timestamp column row num not match")
 			}
 


### PR DESCRIPTION
See also: #30121 #27675

This PR changes the delete buffering logic:
- Write buffer shall buffer insert first
- Then the delete messages shall be evaluated
  - Whether PK matches previous Bloom filter, which ts is always smaller
  - Whether PK matches insert data which has smaller timestamp
- Then the segment bloom filter is updates by the newly buffered pk rows