### PR TITLE
fix: Move compress binlog after check result GetCompactionResult error

### DIFF
--- a/internal/datacoord/session_manager.go
+++ b/internal/datacoord/session_manager.go
@@ -287,18 +287,15 @@ func (c *SessionManagerImpl) GetCompactionPlansResults() map[int64]*datapb.Compa
 				),
 			})
 
-			// for compatibility issue, before 2.3.4, resp has only logpath
-			// try to parse path and fill logid
-			for _, result := range resp.Results {
-				binlog.CompressCompactionBinlogs(result.GetSegments())
-			}
-
 			if err := merr.CheckRPCCall(resp, err); err != nil {
 				log.Info("Get State failed", zap.Error(err))
 				return
 			}
 
 			for _, rst := range resp.GetResults() {
+				// for compatibility issue, before 2.3.4, resp has only logpath
+				// try to parse path and fill logid
+				binlog.CompressCompactionBinlogs(rst.GetSegments())
 				plans.Insert(rst.PlanID, rst)
 			}
 		}(nodeID, s)


### PR DESCRIPTION
See also: #28873

When datanode returns error or go offline during GetCompactionResult call, the compress binlog logic will panic since it was using a nil result

This PR move it after the CheckRPCCall error to prevent this case.