### PR TITLE
enhance:don't store logPath in meta to reduce memory (#28873)

### DIFF
--- a/internal/datacoord/compaction.go
+++ b/internal/datacoord/compaction.go
@@ -307,6 +307,9 @@ func (c *compactionPlanHandler) handleMergeCompactionResult(plan *datapb.Compact
 		CompactedFrom: newSegment.GetCompactionFrom(),
 		NumOfRows:     newSegment.GetNumOfRows(),
 		StatsLogs:     newSegment.GetStatslogs(),
+		ChannelName:   plan.GetChannel(),
+		PartitionId:   newSegment.GetPartitionID(),
+		CollectionId:  newSegment.GetCollectionID(),
 	}
 
 	log.Info("handleCompactionResult: syncing segments with node", zap.Int64("nodeID", nodeID))

--- a/internal/datacoord/compaction_test.go
+++ b/internal/datacoord/compaction_test.go
@@ -294,16 +294,16 @@ func TestCompactionPlanHandler_handleMergeCompactionResult(t *testing.T) {
 
 	seg1 := &datapb.SegmentInfo{
 		ID:        1,
-		Binlogs:   []*datapb.FieldBinlog{getFieldBinlogPaths(101, getInsertLogPath("log1", 1))},
-		Statslogs: []*datapb.FieldBinlog{getFieldBinlogPaths(101, getStatsLogPath("log2", 1))},
-		Deltalogs: []*datapb.FieldBinlog{getFieldBinlogPaths(101, getDeltaLogPath("log3", 1))},
+		Binlogs:   []*datapb.FieldBinlog{getFieldBinlogIDs(101, 1)},
+		Statslogs: []*datapb.FieldBinlog{getFieldBinlogIDs(101, 2)},
+		Deltalogs: []*datapb.FieldBinlog{getFieldBinlogIDs(101, 3)},
 	}
 
 	seg2 := &datapb.SegmentInfo{
 		ID:        2,
-		Binlogs:   []*datapb.FieldBinlog{getFieldBinlogPaths(101, getInsertLogPath("log4", 2))},
-		Statslogs: []*datapb.FieldBinlog{getFieldBinlogPaths(101, getStatsLogPath("log5", 2))},
-		Deltalogs: []*datapb.FieldBinlog{getFieldBinlogPaths(101, getDeltaLogPath("log6", 2))},
+		Binlogs:   []*datapb.FieldBinlog{getFieldBinlogIDs(101, 4)},
+		Statslogs: []*datapb.FieldBinlog{getFieldBinlogIDs(101, 5)},
+		Deltalogs: []*datapb.FieldBinlog{getFieldBinlogIDs(101, 6)},
 	}
 
 	plan := &datapb.CompactionPlan{
@@ -385,18 +385,18 @@ func TestCompactionPlanHandler_handleMergeCompactionResult(t *testing.T) {
 		PlanID:              1,
 		SegmentID:           3,
 		NumOfRows:           15,
-		InsertLogs:          []*datapb.FieldBinlog{getFieldBinlogPaths(101, getInsertLogPath("log301", 3))},
-		Field2StatslogPaths: []*datapb.FieldBinlog{getFieldBinlogPaths(101, getStatsLogPath("log302", 3))},
-		Deltalogs:           []*datapb.FieldBinlog{getFieldBinlogPaths(101, getDeltaLogPath("log303", 3))},
+		InsertLogs:          []*datapb.FieldBinlog{getFieldBinlogIDs(101, 301)},
+		Field2StatslogPaths: []*datapb.FieldBinlog{getFieldBinlogIDs(101, 302)},
+		Deltalogs:           []*datapb.FieldBinlog{getFieldBinlogIDs(101, 303)},
 	}
 
 	compactionResult2 := &datapb.CompactionResult{
 		PlanID:              1,
 		SegmentID:           3,
 		NumOfRows:           0,
-		InsertLogs:          []*datapb.FieldBinlog{getFieldBinlogPaths(101, getInsertLogPath("log301", 3))},
-		Field2StatslogPaths: []*datapb.FieldBinlog{getFieldBinlogPaths(101, getStatsLogPath("log302", 3))},
-		Deltalogs:           []*datapb.FieldBinlog{getFieldBinlogPaths(101, getDeltaLogPath("log303", 3))},
+		InsertLogs:          []*datapb.FieldBinlog{getFieldBinlogIDs(101, 301)},
+		Field2StatslogPaths: []*datapb.FieldBinlog{getFieldBinlogIDs(101, 302)},
+		Deltalogs:           []*datapb.FieldBinlog{getFieldBinlogIDs(101, 303)},
 	}
 
 	has, err := c.meta.HasSegments([]UniqueID{1, 2})
@@ -453,16 +453,16 @@ func TestCompactionPlanHandler_completeCompaction(t *testing.T) {
 
 		seg1 := &datapb.SegmentInfo{
 			ID:        1,
-			Binlogs:   []*datapb.FieldBinlog{getFieldBinlogPaths(101, getInsertLogPath("log1", 1))},
-			Statslogs: []*datapb.FieldBinlog{getFieldBinlogPaths(101, getStatsLogPath("log2", 1))},
-			Deltalogs: []*datapb.FieldBinlog{getFieldBinlogPaths(101, getDeltaLogPath("log3", 1))},
+			Binlogs:   []*datapb.FieldBinlog{getFieldBinlogIDs(101, 1)},
+			Statslogs: []*datapb.FieldBinlog{getFieldBinlogIDs(101, 2)},
+			Deltalogs: []*datapb.FieldBinlog{getFieldBinlogIDs(101, 3)},
 		}
 
 		seg2 := &datapb.SegmentInfo{
 			ID:        2,
-			Binlogs:   []*datapb.FieldBinlog{getFieldBinlogPaths(101, getInsertLogPath("log4", 2))},
-			Statslogs: []*datapb.FieldBinlog{getFieldBinlogPaths(101, getStatsLogPath("log5", 2))},
-			Deltalogs: []*datapb.FieldBinlog{getFieldBinlogPaths(101, getDeltaLogPath("log6", 2))},
+			Binlogs:   []*datapb.FieldBinlog{getFieldBinlogIDs(101, 4)},
+			Statslogs: []*datapb.FieldBinlog{getFieldBinlogIDs(101, 5)},
+			Deltalogs: []*datapb.FieldBinlog{getFieldBinlogIDs(101, 6)},
 		}
 
 		plan := &datapb.CompactionPlan{
@@ -517,9 +517,9 @@ func TestCompactionPlanHandler_completeCompaction(t *testing.T) {
 			PlanID:              1,
 			SegmentID:           3,
 			NumOfRows:           15,
-			InsertLogs:          []*datapb.FieldBinlog{getFieldBinlogPaths(101, getInsertLogPath("log301", 3))},
-			Field2StatslogPaths: []*datapb.FieldBinlog{getFieldBinlogPaths(101, getStatsLogPath("log302", 3))},
-			Deltalogs:           []*datapb.FieldBinlog{getFieldBinlogPaths(101, getDeltaLogPath("log303", 3))},
+			InsertLogs:          []*datapb.FieldBinlog{getFieldBinlogIDs(101, 301)},
+			Field2StatslogPaths: []*datapb.FieldBinlog{getFieldBinlogIDs(101, 302)},
+			Deltalogs:           []*datapb.FieldBinlog{getFieldBinlogIDs(101, 303)},
 		}
 
 		flushCh := make(chan UniqueID, 1)
@@ -548,16 +548,16 @@ func TestCompactionPlanHandler_completeCompaction(t *testing.T) {
 
 		seg1 := &datapb.SegmentInfo{
 			ID:        1,
-			Binlogs:   []*datapb.FieldBinlog{getFieldBinlogPaths(101, getInsertLogPath("log1", 1))},
-			Statslogs: []*datapb.FieldBinlog{getFieldBinlogPaths(101, getStatsLogPath("log2", 1))},
-			Deltalogs: []*datapb.FieldBinlog{getFieldBinlogPaths(101, getDeltaLogPath("log3", 1))},
+			Binlogs:   []*datapb.FieldBinlog{getFieldBinlogIDs(101, 1)},
+			Statslogs: []*datapb.FieldBinlog{getFieldBinlogIDs(101, 2)},
+			Deltalogs: []*datapb.FieldBinlog{getFieldBinlogIDs(101, 3)},
 		}
 
 		seg2 := &datapb.SegmentInfo{
 			ID:        2,
-			Binlogs:   []*datapb.FieldBinlog{getFieldBinlogPaths(101, getInsertLogPath("log4", 2))},
-			Statslogs: []*datapb.FieldBinlog{getFieldBinlogPaths(101, getStatsLogPath("log5", 2))},
-			Deltalogs: []*datapb.FieldBinlog{getFieldBinlogPaths(101, getDeltaLogPath("log6", 2))},
+			Binlogs:   []*datapb.FieldBinlog{getFieldBinlogIDs(101, 4)},
+			Statslogs: []*datapb.FieldBinlog{getFieldBinlogIDs(101, 5)},
+			Deltalogs: []*datapb.FieldBinlog{getFieldBinlogIDs(101, 6)},
 		}
 
 		plan := &datapb.CompactionPlan{
@@ -618,9 +618,9 @@ func TestCompactionPlanHandler_completeCompaction(t *testing.T) {
 			PlanID:              1,
 			SegmentID:           3,
 			NumOfRows:           0,
-			InsertLogs:          []*datapb.FieldBinlog{getFieldBinlogPaths(101, getInsertLogPath("log301", 3))},
-			Field2StatslogPaths: []*datapb.FieldBinlog{getFieldBinlogPaths(101, getStatsLogPath("log302", 3))},
-			Deltalogs:           []*datapb.FieldBinlog{getFieldBinlogPaths(101, getDeltaLogPath("log303", 3))},
+			InsertLogs:          []*datapb.FieldBinlog{getFieldBinlogIDs(101, 301)},
+			Field2StatslogPaths: []*datapb.FieldBinlog{getFieldBinlogIDs(101, 302)},
+			Deltalogs:           []*datapb.FieldBinlog{getFieldBinlogIDs(101, 303)},
 		}
 
 		flushCh := make(chan UniqueID, 1)
@@ -947,6 +947,17 @@ func Test_getCompactionTasksBySignalID(t *testing.T) {
 	}
 }
 
+func getFieldBinlogIDs(id int64, logIDs ...int64) *datapb.FieldBinlog {
+	l := &datapb.FieldBinlog{
+		FieldID: id,
+		Binlogs: make([]*datapb.Binlog, 0, len(logIDs)),
+	}
+	for _, id := range logIDs {
+		l.Binlogs = append(l.Binlogs, &datapb.Binlog{LogID: id})
+	}
+	return l
+}
+
 func getFieldBinlogPaths(id int64, paths ...string) *datapb.FieldBinlog {
 	l := &datapb.FieldBinlog{
 		FieldID: id,
@@ -958,13 +969,13 @@ func getFieldBinlogPaths(id int64, paths ...string) *datapb.FieldBinlog {
 	return l
 }
 
-func getFieldBinlogPathsWithEntry(id int64, entry int64, paths ...string) *datapb.FieldBinlog {
+func getFieldBinlogIDsWithEntry(id int64, entry int64, logIDs ...int64) *datapb.FieldBinlog {
 	l := &datapb.FieldBinlog{
 		FieldID: id,
-		Binlogs: make([]*datapb.Binlog, 0, len(paths)),
+		Binlogs: make([]*datapb.Binlog, 0, len(logIDs)),
 	}
-	for _, path := range paths {
-		l.Binlogs = append(l.Binlogs, &datapb.Binlog{LogPath: path, EntriesNum: entry})
+	for _, id := range logIDs {
+		l.Binlogs = append(l.Binlogs, &datapb.Binlog{LogID: id, EntriesNum: entry})
 	}
 	return l
 }

--- a/internal/datacoord/compaction_trigger.go
+++ b/internal/datacoord/compaction_trigger.go
@@ -734,6 +734,8 @@ func segmentsToPlan(segments []*SegmentInfo, compactTime *compactTime) *datapb.C
 			FieldBinlogs:        s.GetBinlogs(),
 			Field2StatslogPaths: s.GetStatslogs(),
 			Deltalogs:           s.GetDeltalogs(),
+			CollectionID:        s.GetCollectionID(),
+			PartitionID:         s.GetPartitionID(),
 		}
 		plan.TotalRows += s.GetNumOfRows()
 		plan.SegmentBinlogs = append(plan.SegmentBinlogs, segmentBinlogs)

--- a/internal/datacoord/compaction_trigger_test.go
+++ b/internal/datacoord/compaction_trigger_test.go
@@ -118,14 +118,14 @@ func Test_compactionTrigger_force(t *testing.T) {
 									Binlogs: []*datapb.FieldBinlog{
 										{
 											Binlogs: []*datapb.Binlog{
-												{EntriesNum: 5, LogPath: "log1"},
+												{EntriesNum: 5, LogID: 1},
 											},
 										},
 									},
 									Deltalogs: []*datapb.FieldBinlog{
 										{
 											Binlogs: []*datapb.Binlog{
-												{EntriesNum: 5, LogPath: "deltalog1"},
+												{EntriesNum: 5, LogID: 1},
 											},
 										},
 									},
@@ -163,14 +163,14 @@ func Test_compactionTrigger_force(t *testing.T) {
 									Binlogs: []*datapb.FieldBinlog{
 										{
 											Binlogs: []*datapb.Binlog{
-												{EntriesNum: 5, LogPath: "log2"},
+												{EntriesNum: 5, LogID: 2},
 											},
 										},
 									},
 									Deltalogs: []*datapb.FieldBinlog{
 										{
 											Binlogs: []*datapb.Binlog{
-												{EntriesNum: 5, LogPath: "deltalog2"},
+												{EntriesNum: 5, LogID: 2},
 											},
 										},
 									},
@@ -408,7 +408,7 @@ func Test_compactionTrigger_force(t *testing.T) {
 							FieldBinlogs: []*datapb.FieldBinlog{
 								{
 									Binlogs: []*datapb.Binlog{
-										{EntriesNum: 5, LogPath: "log1"},
+										{EntriesNum: 5, LogID: 1},
 									},
 								},
 							},
@@ -416,17 +416,19 @@ func Test_compactionTrigger_force(t *testing.T) {
 							Deltalogs: []*datapb.FieldBinlog{
 								{
 									Binlogs: []*datapb.Binlog{
-										{EntriesNum: 5, LogPath: "deltalog1"},
+										{EntriesNum: 5, LogID: 1},
 									},
 								},
 							},
+							CollectionID: 2,
+							PartitionID:  1,
 						},
 						{
 							SegmentID: 2,
 							FieldBinlogs: []*datapb.FieldBinlog{
 								{
 									Binlogs: []*datapb.Binlog{
-										{EntriesNum: 5, LogPath: "log2"},
+										{EntriesNum: 5, LogID: 2},
 									},
 								},
 							},
@@ -434,10 +436,12 @@ func Test_compactionTrigger_force(t *testing.T) {
 							Deltalogs: []*datapb.FieldBinlog{
 								{
 									Binlogs: []*datapb.Binlog{
-										{EntriesNum: 5, LogPath: "deltalog2"},
+										{EntriesNum: 5, LogID: 2},
 									},
 								},
 							},
+							CollectionID: 2,
+							PartitionID:  1,
 						},
 					},
 					StartTime:        0,

--- a/internal/datacoord/garbage_collector_test.go
+++ b/internal/datacoord/garbage_collector_test.go
@@ -19,6 +19,8 @@ package datacoord
 import (
 	"bytes"
 	"context"
+	"fmt"
+	"math/rand"
 	"path"
 	"strconv"
 	"strings"
@@ -105,7 +107,7 @@ func validateMinioPrefixElements(t *testing.T, cli *minio.Client, bucketName str
 
 func Test_garbageCollector_scan(t *testing.T) {
 	bucketName := `datacoord-ut` + strings.ToLower(funcutil.RandomString(8))
-	rootPath := `gc` + funcutil.RandomString(8)
+	rootPath := paramtable.Get().MinioCfg.RootPath.GetValue()
 	// TODO change to Params
 	cli, inserts, stats, delta, others, err := initUtOSSEnv(bucketName, rootPath, 4)
 	require.NoError(t, err)
@@ -276,9 +278,9 @@ func initUtOSSEnv(bucket, root string, n int) (mcm *storage.MinioChunkManager, i
 
 		var token string
 		if i == 1 {
-			token = path.Join(strconv.Itoa(i), strconv.Itoa(i), "error-seg-id", funcutil.RandomString(8), funcutil.RandomString(8))
+			token = path.Join(strconv.Itoa(i), strconv.Itoa(i), "error-seg-id", strconv.Itoa(i), fmt.Sprint(rand.Int63()))
 		} else {
-			token = path.Join(strconv.Itoa(1+i), strconv.Itoa(10+i), strconv.Itoa(100+i), funcutil.RandomString(8), funcutil.RandomString(8))
+			token = path.Join(strconv.Itoa(1+i), strconv.Itoa(10+i), strconv.Itoa(100+i), strconv.Itoa(i), fmt.Sprint(rand.Int63()))
 		}
 		// insert
 		filePath := path.Join(root, common.SegmentInsertLogPath, token)
@@ -297,9 +299,9 @@ func initUtOSSEnv(bucket, root string, n int) (mcm *storage.MinioChunkManager, i
 
 		// delta
 		if i == 1 {
-			token = path.Join(strconv.Itoa(i), strconv.Itoa(i), "error-seg-id", funcutil.RandomString(8))
+			token = path.Join(strconv.Itoa(i), strconv.Itoa(i), "error-seg-id", fmt.Sprint(rand.Int63()))
 		} else {
-			token = path.Join(strconv.Itoa(1+i), strconv.Itoa(10+i), strconv.Itoa(100+i), funcutil.RandomString(8))
+			token = path.Join(strconv.Itoa(1+i), strconv.Itoa(10+i), strconv.Itoa(100+i), fmt.Sprint(rand.Int63()))
 		}
 		filePath = path.Join(root, common.SegmentDeltaLogPath, token)
 		info, err = cli.PutObject(context.TODO(), bucket, filePath, reader, int64(len(content)), minio.PutObjectOptions{})

--- a/internal/datacoord/index_builder.go
+++ b/internal/datacoord/index_builder.go
@@ -264,12 +264,12 @@ func (ib *indexBuilder) process(buildID UniqueID) bool {
 			return false
 		}
 
-		binLogs := make([]string, 0)
+		binlogIDs := make([]int64, 0)
 		fieldID := ib.meta.GetFieldIDByIndexID(meta.CollectionID, meta.IndexID)
 		for _, fieldBinLog := range segment.GetBinlogs() {
 			if fieldBinLog.GetFieldID() == fieldID {
 				for _, binLog := range fieldBinLog.GetBinlogs() {
-					binLogs = append(binLogs, binLog.LogPath)
+					binlogIDs = append(binlogIDs, binLog.GetLogID())
 				}
 				break
 			}
@@ -312,13 +312,17 @@ func (ib *indexBuilder) process(buildID UniqueID) bool {
 			ClusterID:           Params.CommonCfg.ClusterPrefix.GetValue(),
 			IndexFilePrefix:     path.Join(ib.chunkManager.RootPath(), common.SegmentIndexPath),
 			BuildID:             buildID,
-			DataPaths:           binLogs,
 			IndexVersion:        meta.IndexVersion + 1,
 			StorageConfig:       storageConfig,
 			IndexParams:         indexParams,
 			TypeParams:          typeParams,
 			NumRows:             meta.NumRows,
 			CurrentIndexVersion: ib.indexEngineVersionManager.GetCurrentIndexEngineVersion(),
+			DataIds:             binlogIDs,
+			CollectionID:        segment.GetCollectionID(),
+			PartitionID:         segment.GetPartitionID(),
+			SegmentID:           segment.GetID(),
+			FieldID:             fieldID,
 		}
 		if err := ib.assignTask(client, req); err != nil {
 			// need to release lock then reassign, so set task state to retry

--- a/internal/datacoord/meta_test.go
+++ b/internal/datacoord/meta_test.go
@@ -495,14 +495,14 @@ func TestUpdateFlushSegmentsInfo(t *testing.T) {
 		assert.NoError(t, err)
 
 		segment1 := &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{
-			ID: 1, State: commonpb.SegmentState_Growing, Binlogs: []*datapb.FieldBinlog{getFieldBinlogPaths(1, getInsertLogPath("binlog0", 1))},
-			Statslogs: []*datapb.FieldBinlog{getFieldBinlogPaths(1, getStatsLogPath("statslog0", 1))},
+			ID: 1, State: commonpb.SegmentState_Growing, Binlogs: []*datapb.FieldBinlog{getFieldBinlogIDs(1, 0)},
+			Statslogs: []*datapb.FieldBinlog{getFieldBinlogIDs(1, 0)},
 		}}
 		err = meta.AddSegment(context.TODO(), segment1)
 		assert.NoError(t, err)
 
-		err = meta.UpdateFlushSegmentsInfo(1, true, false, false, []*datapb.FieldBinlog{getFieldBinlogPathsWithEntry(1, 10, getInsertLogPath("binlog1", 1))},
-			[]*datapb.FieldBinlog{getFieldBinlogPaths(1, getStatsLogPath("statslog1", 1))},
+		err = meta.UpdateFlushSegmentsInfo(1, true, false, false, []*datapb.FieldBinlog{getFieldBinlogIDsWithEntry(1, 10, 1)},
+			[]*datapb.FieldBinlog{getFieldBinlogIDs(1, 1)},
 			[]*datapb.FieldBinlog{{Binlogs: []*datapb.Binlog{{EntriesNum: 1, TimestampFrom: 100, TimestampTo: 200, LogSize: 1000, LogPath: getDeltaLogPath("deltalog1", 1)}}}},
 			[]*datapb.CheckPoint{{SegmentID: 1, NumOfRows: 10}}, []*datapb.SegmentStartPosition{{SegmentID: 1, StartPosition: &msgpb.MsgPosition{MsgID: []byte{1, 2, 3}}}})
 		assert.NoError(t, err)
@@ -511,8 +511,8 @@ func TestUpdateFlushSegmentsInfo(t *testing.T) {
 		expected := &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{
 			ID: 1, State: commonpb.SegmentState_Flushing, NumOfRows: 10,
 			StartPosition: &msgpb.MsgPosition{MsgID: []byte{1, 2, 3}},
-			Binlogs:       []*datapb.FieldBinlog{getFieldBinlogPaths(1, "binlog0", "binlog1")},
-			Statslogs:     []*datapb.FieldBinlog{getFieldBinlogPaths(1, "statslog0", "statslog1")},
+			Binlogs:       []*datapb.FieldBinlog{getFieldBinlogIDs(1, 0, 1)},
+			Statslogs:     []*datapb.FieldBinlog{getFieldBinlogIDs(1, 0, 1)},
 			Deltalogs:     []*datapb.FieldBinlog{{Binlogs: []*datapb.Binlog{{EntriesNum: 1, TimestampFrom: 100, TimestampTo: 200, LogSize: 1000}}}},
 		}}
 
@@ -569,8 +569,8 @@ func TestUpdateFlushSegmentsInfo(t *testing.T) {
 		}
 		meta.segments.SetSegment(1, segmentInfo)
 
-		err = meta.UpdateFlushSegmentsInfo(1, true, false, false, []*datapb.FieldBinlog{getFieldBinlogPaths(1, getInsertLogPath("binlog", 1))},
-			[]*datapb.FieldBinlog{getFieldBinlogPaths(1, getInsertLogPath("statslog", 1))},
+		err = meta.UpdateFlushSegmentsInfo(1, true, false, false, []*datapb.FieldBinlog{getFieldBinlogIDs(1, 1)},
+			[]*datapb.FieldBinlog{getFieldBinlogIDs(1, 1)},
 			[]*datapb.FieldBinlog{{Binlogs: []*datapb.Binlog{{EntriesNum: 1, TimestampFrom: 100, TimestampTo: 200, LogSize: 1000, LogPath: getDeltaLogPath("deltalog", 1)}}}},
 			[]*datapb.CheckPoint{{SegmentID: 1, NumOfRows: 10}}, []*datapb.SegmentStartPosition{{SegmentID: 1, StartPosition: &msgpb.MsgPosition{MsgID: []byte{1, 2, 3}}}})
 		assert.Error(t, err)
@@ -617,9 +617,9 @@ func TestMeta_alterMetaStore(t *testing.T) {
 		segments: &SegmentsInfo{map[int64]*SegmentInfo{
 			1: {SegmentInfo: &datapb.SegmentInfo{
 				ID:        1,
-				Binlogs:   []*datapb.FieldBinlog{getFieldBinlogPaths(1, "log1", "log2")},
-				Statslogs: []*datapb.FieldBinlog{getFieldBinlogPaths(1, "statlog1", "statlog2")},
-				Deltalogs: []*datapb.FieldBinlog{getFieldBinlogPaths(0, "deltalog1", "deltalog2")},
+				Binlogs:   []*datapb.FieldBinlog{getFieldBinlogIDs(1, 1, 2)},
+				Statslogs: []*datapb.FieldBinlog{getFieldBinlogIDs(1, 1, 2)},
+				Deltalogs: []*datapb.FieldBinlog{getFieldBinlogIDs(1, 1, 2)},
 			}},
 		}},
 	}
@@ -638,9 +638,9 @@ func TestMeta_prepareCompactionMutation(t *testing.T) {
 				CollectionID: 100,
 				PartitionID:  10,
 				State:        commonpb.SegmentState_Flushed,
-				Binlogs:      []*datapb.FieldBinlog{getFieldBinlogPaths(1, "log1", "log2")},
-				Statslogs:    []*datapb.FieldBinlog{getFieldBinlogPaths(1, "statlog1", "statlog2")},
-				Deltalogs:    []*datapb.FieldBinlog{getFieldBinlogPaths(0, "deltalog1", "deltalog2")},
+				Binlogs:      []*datapb.FieldBinlog{getFieldBinlogIDs(1, 1, 2)},
+				Statslogs:    []*datapb.FieldBinlog{getFieldBinlogIDs(1, 1, 2)},
+				Deltalogs:    []*datapb.FieldBinlog{getFieldBinlogIDs(0, 1, 2)},
 				NumOfRows:    1,
 			}},
 			2: {SegmentInfo: &datapb.SegmentInfo{
@@ -648,9 +648,9 @@ func TestMeta_prepareCompactionMutation(t *testing.T) {
 				CollectionID: 100,
 				PartitionID:  10,
 				State:        commonpb.SegmentState_Flushed,
-				Binlogs:      []*datapb.FieldBinlog{getFieldBinlogPaths(1, "log3", "log4")},
-				Statslogs:    []*datapb.FieldBinlog{getFieldBinlogPaths(1, "statlog3", "statlog4")},
-				Deltalogs:    []*datapb.FieldBinlog{getFieldBinlogPaths(0, "deltalog3", "deltalog4")},
+				Binlogs:      []*datapb.FieldBinlog{getFieldBinlogIDs(1, 3, 4)},
+				Statslogs:    []*datapb.FieldBinlog{getFieldBinlogIDs(1, 3, 4)},
+				Deltalogs:    []*datapb.FieldBinlog{getFieldBinlogIDs(0, 3, 4)},
 				NumOfRows:    1,
 			}},
 		},
@@ -665,15 +665,15 @@ func TestMeta_prepareCompactionMutation(t *testing.T) {
 		SegmentBinlogs: []*datapb.CompactionSegmentBinlogs{
 			{
 				SegmentID:           1,
-				FieldBinlogs:        []*datapb.FieldBinlog{getFieldBinlogPaths(1, "log1", "log2")},
-				Field2StatslogPaths: []*datapb.FieldBinlog{getFieldBinlogPaths(1, "statlog1", "statlog2")},
-				Deltalogs:           []*datapb.FieldBinlog{getFieldBinlogPaths(0, "deltalog1", "deltalog2")},
+				FieldBinlogs:        []*datapb.FieldBinlog{getFieldBinlogIDs(1, 1, 2)},
+				Field2StatslogPaths: []*datapb.FieldBinlog{getFieldBinlogIDs(1, 1, 2)},
+				Deltalogs:           []*datapb.FieldBinlog{getFieldBinlogIDs(0, 1, 2)},
 			},
 			{
 				SegmentID:           2,
-				FieldBinlogs:        []*datapb.FieldBinlog{getFieldBinlogPaths(1, "log3", "log4")},
-				Field2StatslogPaths: []*datapb.FieldBinlog{getFieldBinlogPaths(1, "statlog3", "statlog4")},
-				Deltalogs:           []*datapb.FieldBinlog{getFieldBinlogPaths(0, "deltalog3", "deltalog4")},
+				FieldBinlogs:        []*datapb.FieldBinlog{getFieldBinlogIDs(1, 3, 4)},
+				Field2StatslogPaths: []*datapb.FieldBinlog{getFieldBinlogIDs(1, 3, 4)},
+				Deltalogs:           []*datapb.FieldBinlog{getFieldBinlogIDs(0, 3, 4)},
 			},
 		},
 		StartTime: 15,
@@ -681,9 +681,9 @@ func TestMeta_prepareCompactionMutation(t *testing.T) {
 
 	inCompactionResult := &datapb.CompactionResult{
 		SegmentID:           3,
-		InsertLogs:          []*datapb.FieldBinlog{getFieldBinlogPaths(1, "log5")},
-		Field2StatslogPaths: []*datapb.FieldBinlog{getFieldBinlogPaths(1, "statlog5")},
-		Deltalogs:           []*datapb.FieldBinlog{getFieldBinlogPaths(0, "deltalog5")},
+		InsertLogs:          []*datapb.FieldBinlog{getFieldBinlogIDs(1, 5)},
+		Field2StatslogPaths: []*datapb.FieldBinlog{getFieldBinlogIDs(1, 5)},
+		Deltalogs:           []*datapb.FieldBinlog{getFieldBinlogIDs(0, 5)},
 		NumOfRows:           2,
 	}
 	beforeCompact, afterCompact, newSegment, metricMutation, err := m.prepareCompactionMutation(plan, inCompactionResult)
@@ -720,7 +720,7 @@ func TestMeta_prepareCompactionMutation(t *testing.T) {
 	assert.Equal(t, uint64(15), newSegment.GetLastExpireTime())
 
 	_, _, err = m.CompleteCompactionMutation(plan, inCompactionResult)
-	assert.Error(t, err)
+	assert.NoError(t, err)
 }
 
 func Test_meta_SetSegmentCompacting(t *testing.T) {
@@ -1025,162 +1025,4 @@ func Test_meta_GcConfirm(t *testing.T) {
 		Return(false)
 
 	assert.False(t, m.GcConfirm(context.TODO(), 100, 10000))
-}
-
-func TestGetDeltaLogID(t *testing.T) {
-	type testCase struct {
-		tag       string
-		rootPath  string
-		binlog    *datapb.Binlog
-		expectErr bool
-		expectID  int64
-	}
-
-	cases := []testCase{
-		{
-			tag:      "has_log_id",
-			rootPath: "files",
-			binlog: &datapb.Binlog{
-				LogID: 446329278451403166,
-			},
-			expectErr: false,
-			expectID:  446329278451403166,
-		},
-		{
-			tag:      "parse_normal_logPath",
-			rootPath: "files",
-			binlog: &datapb.Binlog{
-				LogPath: "files/delta_log/446329278451203130/446329278451203131/446329278451403142/446329278451403166",
-			},
-			expectErr: false,
-			expectID:  446329278451403166,
-		},
-		{
-			tag:      "invalid_rootpath_prefix",
-			rootPath: "files",
-			binlog: &datapb.Binlog{
-				LogPath: "file/delta_log/446329278451203130/446329278451203131/446329278451403142/446329278451403166",
-			},
-			expectErr: true,
-		},
-		{
-			tag:      "invalid_deltalog_path",
-			rootPath: "files",
-			binlog: &datapb.Binlog{
-				LogPath: "files/delta_log/446329278451403166",
-			},
-			expectErr: true,
-		},
-		{
-			tag:      "invalid_logID",
-			rootPath: "files",
-			binlog: &datapb.Binlog{
-				LogPath: "files/delta_log/446329278451203130/446329278451203131/446329278451403142/meta_files",
-			},
-			expectErr: true,
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.tag, func(t *testing.T) {
-			logID, err := getDeltaLogID(tc.rootPath, tc.binlog)
-			if tc.expectErr {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-				assert.Equal(t, tc.expectID, logID)
-			}
-		})
-	}
-}
-
-func Test_meta_copyDeltaFiles(t *testing.T) {
-	cm := mocks.NewChunkManager(t)
-	cm.EXPECT().RootPath().Return("files").Maybe()
-	m := &meta{
-		chunkManager: cm,
-	}
-
-	type testCase struct {
-		tag          string
-		binlogs      []*datapb.FieldBinlog
-		collectionID int64
-		partitionID  int64
-		segmentID    int64
-
-		expectResult []*datapb.FieldBinlog
-		expectErr    bool
-	}
-
-	cases := []*testCase{
-		{
-			tag: "normal_logID",
-			binlogs: []*datapb.FieldBinlog{
-				{
-					Binlogs: []*datapb.Binlog{
-						{LogID: 446329278451403166},
-					},
-				},
-			},
-			collectionID: 446329278451203130,
-			partitionID:  446329278451203131,
-			segmentID:    446329278451403143,
-			expectResult: []*datapb.FieldBinlog{
-				{
-					Binlogs: []*datapb.Binlog{
-						{LogID: 446329278451403166, LogPath: "files/delta_log/446329278451203130/446329278451203131/446329278451403143/446329278451403166"},
-					},
-				},
-			},
-		},
-		{
-			tag: "normal_logPath",
-			binlogs: []*datapb.FieldBinlog{
-				{
-					Binlogs: []*datapb.Binlog{
-						{LogPath: "files/delta_log/446329278451203130/446329278451203131/446329278451403142/446329278451403166"},
-					},
-				},
-			},
-			collectionID: 446329278451203130,
-			partitionID:  446329278451203131,
-			segmentID:    446329278451403143,
-			expectResult: []*datapb.FieldBinlog{
-				{
-					Binlogs: []*datapb.Binlog{
-						{LogPath: "files/delta_log/446329278451203130/446329278451203131/446329278451403143/446329278451403166"},
-					},
-				},
-			},
-		},
-		{
-			tag: "bad_logPath",
-			binlogs: []*datapb.FieldBinlog{
-				{
-					Binlogs: []*datapb.Binlog{
-						{LogPath: "other_prefix/delta_log/446329278451203130/446329278451203131/446329278451403142/446329278451403166"},
-					},
-				},
-			},
-			collectionID: 446329278451203130,
-			partitionID:  446329278451203131,
-			segmentID:    446329278451403143,
-			expectErr:    true,
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.tag, func(t *testing.T) {
-			cm.EXPECT().Read(mock.Anything, mock.Anything).Return([]byte("test"), nil).Maybe()
-			cm.EXPECT().Write(mock.Anything, mock.Anything, []byte("test")).Return(nil).Maybe()
-
-			result, err := m.copyDeltaFiles(tc.binlogs, tc.collectionID, tc.partitionID, tc.segmentID)
-			if tc.expectErr {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-				assert.Equal(t, tc.expectResult, result)
-			}
-		})
-	}
 }

--- a/internal/datacoord/server_test.go
+++ b/internal/datacoord/server_test.go
@@ -18,7 +18,6 @@ package datacoord
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
 	"os"
 	"os/signal"
@@ -487,10 +486,10 @@ func TestGetInsertBinlogPaths(t *testing.T) {
 					FieldID: 1,
 					Binlogs: []*datapb.Binlog{
 						{
-							LogPath: "dev/datacoord/testsegment/1/part1",
+							LogID: 1,
 						},
 						{
-							LogPath: "dev/datacoord/testsegment/1/part2",
+							LogID: 2,
 						},
 					},
 				},
@@ -518,10 +517,10 @@ func TestGetInsertBinlogPaths(t *testing.T) {
 					FieldID: 1,
 					Binlogs: []*datapb.Binlog{
 						{
-							LogPath: "dev/datacoord/testsegment/1/part1",
+							LogID: 1,
 						},
 						{
-							LogPath: "dev/datacoord/testsegment/1/part2",
+							LogID: 2,
 						},
 					},
 				},
@@ -1324,11 +1323,11 @@ func TestSaveBinlogPaths(t *testing.T) {
 					FieldID: 1,
 					Binlogs: []*datapb.Binlog{
 						{
-							LogPath:    "/by-dev/test/0/1/1/1/Allo1",
+							LogPath:    "/by-dev/test/0/1/1/1/1",
 							EntriesNum: 5,
 						},
 						{
-							LogPath:    "/by-dev/test/0/1/1/1/Allo2",
+							LogPath:    "/by-dev/test/0/1/1/1/2",
 							EntriesNum: 5,
 						},
 					},
@@ -1359,8 +1358,10 @@ func TestSaveBinlogPaths(t *testing.T) {
 		assert.NotNil(t, fieldBinlogs)
 		assert.EqualValues(t, 2, len(fieldBinlogs.GetBinlogs()))
 		assert.EqualValues(t, 1, fieldBinlogs.GetFieldID())
-		assert.EqualValues(t, "/by-dev/test/0/1/1/1/Allo1", fieldBinlogs.GetBinlogs()[0].GetLogPath())
-		assert.EqualValues(t, "/by-dev/test/0/1/1/1/Allo2", fieldBinlogs.GetBinlogs()[1].GetLogPath())
+		assert.EqualValues(t, "", fieldBinlogs.GetBinlogs()[0].GetLogPath())
+		assert.EqualValues(t, "", fieldBinlogs.GetBinlogs()[1].GetLogPath())
+		assert.EqualValues(t, 1, fieldBinlogs.GetBinlogs()[0].GetLogID())
+		assert.EqualValues(t, 2, fieldBinlogs.GetBinlogs()[1].GetLogID())
 
 		assert.EqualValues(t, segment.DmlPosition.ChannelName, "ch1")
 		assert.EqualValues(t, segment.DmlPosition.MsgID, []byte{1, 2, 3})
@@ -1411,11 +1412,11 @@ func TestSaveBinlogPaths(t *testing.T) {
 					FieldID: 1,
 					Binlogs: []*datapb.Binlog{
 						{
-							LogPath:    "/by-dev/test/0/1/1/1/Allo1",
+							LogPath:    "/by-dev/test/0/1/1/1/1",
 							EntriesNum: 5,
 						},
 						{
-							LogPath:    "/by-dev/test/0/1/1/1/Allo2",
+							LogPath:    "/by-dev/test/0/1/1/1/2",
 							EntriesNum: 5,
 						},
 					},
@@ -1489,11 +1490,11 @@ func TestSaveBinlogPaths(t *testing.T) {
 					FieldID: 1,
 					Binlogs: []*datapb.Binlog{
 						{
-							LogPath:    "/by-dev/test/0/1/1/1/Allo1",
+							LogPath:    "/by-dev/test/0/1/1/1/1",
 							EntriesNum: 5,
 						},
 						{
-							LogPath:    "/by-dev/test/0/1/1/1/Allo2",
+							LogPath:    "/by-dev/test/0/1/1/1/2",
 							EntriesNum: 5,
 						},
 					},
@@ -1543,11 +1544,11 @@ func TestSaveBinlogPaths(t *testing.T) {
 					FieldID: 1,
 					Binlogs: []*datapb.Binlog{
 						{
-							LogPath:    "/by-dev/test/0/1/1/1/Allo1",
+							LogPath:    "/by-dev/test/0/1/1/1/1",
 							EntriesNum: 5,
 						},
 						{
-							LogPath:    "/by-dev/test/0/1/1/1/Allo2",
+							LogPath:    "/by-dev/test/0/1/1/1/2",
 							EntriesNum: 5,
 						},
 					},
@@ -1713,10 +1714,10 @@ func TestDropVirtualChannel(t *testing.T) {
 						FieldID: 1,
 						Binlogs: []*datapb.Binlog{
 							{
-								LogPath: "/by-dev/test/0/1/2/1/Allo1",
+								LogPath: "/by-dev/test/0/1/2/1/1",
 							},
 							{
-								LogPath: "/by-dev/test/0/1/2/1/Allo2",
+								LogPath: "/by-dev/test/0/1/2/1/2",
 							},
 						},
 					},
@@ -1726,10 +1727,10 @@ func TestDropVirtualChannel(t *testing.T) {
 						FieldID: 1,
 						Binlogs: []*datapb.Binlog{
 							{
-								LogPath: "/by-dev/test/0/1/2/1/stats1",
+								LogPath: "/by-dev/test/0/1/2/1/1",
 							},
 							{
-								LogPath: "/by-dev/test/0/1/2/1/stats2",
+								LogPath: "/by-dev/test/0/1/2/1/2",
 							},
 						},
 					},
@@ -1739,7 +1740,7 @@ func TestDropVirtualChannel(t *testing.T) {
 						Binlogs: []*datapb.Binlog{
 							{
 								EntriesNum: 1,
-								LogPath:    "/by-dev/test/0/1/2/1/delta1",
+								LogPath:    "/by-dev/test/0/1/2/1/1",
 							},
 						},
 					},
@@ -2725,10 +2726,10 @@ func TestGetRecoveryInfo(t *testing.T) {
 					FieldID: 1,
 					Binlogs: []*datapb.Binlog{
 						{
-							LogPath: "/binlog/file1",
+							LogPath: "/binlog/1",
 						},
 						{
-							LogPath: "/binlog/file2",
+							LogPath: "/binlog/2",
 						},
 					},
 				},
@@ -2738,10 +2739,10 @@ func TestGetRecoveryInfo(t *testing.T) {
 					FieldID: 1,
 					Binlogs: []*datapb.Binlog{
 						{
-							LogPath: "/stats_log/file1",
+							LogPath: "/stats_log/1",
 						},
 						{
-							LogPath: "/stats_log/file2",
+							LogPath: "/stats_log/2",
 						},
 					},
 				},
@@ -2752,7 +2753,7 @@ func TestGetRecoveryInfo(t *testing.T) {
 						{
 							TimestampFrom: 0,
 							TimestampTo:   1,
-							LogPath:       "/stats_log/file1",
+							LogPath:       "/stats_log/1",
 							LogSize:       1,
 						},
 					},
@@ -2802,8 +2803,11 @@ func TestGetRecoveryInfo(t *testing.T) {
 		assert.EqualValues(t, 0, resp.GetBinlogs()[0].GetSegmentID())
 		assert.EqualValues(t, 1, len(resp.GetBinlogs()[0].GetFieldBinlogs()))
 		assert.EqualValues(t, 1, resp.GetBinlogs()[0].GetFieldBinlogs()[0].GetFieldID())
+		for _, binlog := range resp.GetBinlogs()[0].GetFieldBinlogs()[0].GetBinlogs() {
+			assert.Equal(t, "", binlog.GetLogPath())
+		}
 		for i, binlog := range resp.GetBinlogs()[0].GetFieldBinlogs()[0].GetBinlogs() {
-			assert.Equal(t, fmt.Sprintf("/binlog/file%d", i+1), binlog.GetLogPath())
+			assert.Equal(t, int64(i+1), binlog.GetLogID())
 		}
 	})
 	t.Run("with dropped segments", func(t *testing.T) {
@@ -3964,9 +3968,9 @@ func TestDataCoord_SegmentStatistics(t *testing.T) {
 
 		seg1 := &datapb.SegmentInfo{
 			ID:        100,
-			Binlogs:   []*datapb.FieldBinlog{getFieldBinlogPathsWithEntry(101, 1, getInsertLogPath("log1", 100))},
-			Statslogs: []*datapb.FieldBinlog{getFieldBinlogPaths(101, getStatsLogPath("log2", 100))},
-			Deltalogs: []*datapb.FieldBinlog{getFieldBinlogPaths(101, getDeltaLogPath("log3", 100))},
+			Binlogs:   []*datapb.FieldBinlog{getFieldBinlogIDsWithEntry(101, 1, 1)},
+			Statslogs: []*datapb.FieldBinlog{getFieldBinlogIDs(1, 2)},
+			Deltalogs: []*datapb.FieldBinlog{getFieldBinlogIDs(1, 3)},
 			State:     commonpb.SegmentState_Importing,
 		}
 
@@ -3991,9 +3995,9 @@ func TestDataCoord_SegmentStatistics(t *testing.T) {
 
 		seg1 := &datapb.SegmentInfo{
 			ID:        100,
-			Binlogs:   []*datapb.FieldBinlog{getFieldBinlogPathsWithEntry(101, 1, getInsertLogPath("log1", 100))},
-			Statslogs: []*datapb.FieldBinlog{getFieldBinlogPaths(101, getStatsLogPath("log2", 100))},
-			Deltalogs: []*datapb.FieldBinlog{getFieldBinlogPaths(101, getDeltaLogPath("log3", 100))},
+			Binlogs:   []*datapb.FieldBinlog{getFieldBinlogIDsWithEntry(101, 1, 1)},
+			Statslogs: []*datapb.FieldBinlog{getFieldBinlogIDs(1, 2)},
+			Deltalogs: []*datapb.FieldBinlog{getFieldBinlogIDs(1, 3)},
 			State:     commonpb.SegmentState_Flushed,
 		}
 

--- a/internal/datanode/broker/datacoord.go
+++ b/internal/datanode/broker/datacoord.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
+	"github.com/milvus-io/milvus/internal/metastore/kv/binlog"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/pkg/log"
@@ -76,6 +77,11 @@ func (dc *dataCoordBroker) GetSegmentInfo(ctx context.Context, segmentIDs []int6
 	})
 	if err := merr.CheckRPCCall(infoResp, err); err != nil {
 		log.Warn("Fail to get SegmentInfo by ids from datacoord", zap.Error(err))
+		return nil, err
+	}
+	err = binlog.DecompressMultiBinLogs(infoResp.GetInfos())
+	if err != nil {
+		log.Warn("Fail to DecompressMultiBinLogs", zap.Error(err))
 		return nil, err
 	}
 

--- a/internal/datanode/compactor.go
+++ b/internal/datanode/compactor.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/datanode/allocator"
+	"github.com/milvus-io/milvus/internal/metastore/kv/binlog"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
 	"github.com/milvus-io/milvus/internal/proto/etcdpb"
 	"github.com/milvus-io/milvus/internal/storage"
@@ -460,6 +461,11 @@ func (t *compactionTask) compact() (*datapb.CompactionResult, error) {
 	}
 
 	log.Info("compact start", zap.Int32("timeout in seconds", t.plan.GetTimeoutInSeconds()))
+	err = binlog.DecompressCompactionBinlogs(t.plan.GetSegmentBinlogs())
+	if err != nil {
+		log.Warn("DecompressCompactionBinlogs fails", zap.Error(err))
+		return nil, err
+	}
 	segIDs := make([]UniqueID, 0, len(t.plan.GetSegmentBinlogs()))
 	for _, s := range t.plan.GetSegmentBinlogs() {
 		segIDs = append(segIDs, s.GetSegmentID())

--- a/internal/indexnode/task.go
+++ b/internal/indexnode/task.go
@@ -41,6 +41,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/util/indexparamcheck"
 	"github.com/milvus-io/milvus/pkg/util/indexparams"
 	"github.com/milvus-io/milvus/pkg/util/merr"
+	"github.com/milvus-io/milvus/pkg/util/metautil"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/util/timerecord"
 )
@@ -158,6 +159,12 @@ func (it *indexBuildTask) Prepare(ctx context.Context) error {
 	typeParams := make(map[string]string)
 	indexParams := make(map[string]string)
 
+	if len(it.req.DataPaths) == 0 {
+		for _, id := range it.req.GetDataIds() {
+			path := metautil.BuildInsertLogPath(it.req.GetStorageConfig().RootPath, it.req.GetCollectionID(), it.req.GetPartitionID(), it.req.GetSegmentID(), it.req.GetFieldID(), id)
+			it.req.DataPaths = append(it.req.DataPaths, path)
+		}
+	}
 	// type params can be removed
 	for _, kvPair := range it.req.GetTypeParams() {
 		key, value := kvPair.GetKey(), kvPair.GetValue()

--- a/internal/metastore/kv/binlog/binlog.go
+++ b/internal/metastore/kv/binlog/binlog.go
@@ -1,0 +1,187 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package binlog
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/milvus-io/milvus/internal/proto/datapb"
+	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/pkg/util/merr"
+	"github.com/milvus-io/milvus/pkg/util/metautil"
+	"github.com/milvus-io/milvus/pkg/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/util/typeutil"
+)
+
+func CompressSaveBinlogPaths(req *datapb.SaveBinlogPathsRequest) error {
+	err := CompressFieldBinlogs(req.GetDeltalogs())
+	if err != nil {
+		return err
+	}
+	err = CompressFieldBinlogs(req.GetField2BinlogPaths())
+	if err != nil {
+		return err
+	}
+	err = CompressFieldBinlogs(req.GetField2StatslogPaths())
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func CompressCompactionBinlogs(binlogs *datapb.CompactionResult) error {
+	err := CompressFieldBinlogs(binlogs.GetInsertLogs())
+	if err != nil {
+		return err
+	}
+	err = CompressFieldBinlogs(binlogs.GetDeltalogs())
+	if err != nil {
+		return err
+	}
+	err = CompressFieldBinlogs(binlogs.GetField2StatslogPaths())
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func CompressBinLogs(s *datapb.SegmentInfo) error {
+	err := CompressFieldBinlogs(s.GetBinlogs())
+	if err != nil {
+		return err
+	}
+	err = CompressFieldBinlogs(s.GetDeltalogs())
+	if err != nil {
+		return err
+	}
+	err = CompressFieldBinlogs(s.GetStatslogs())
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func CompressFieldBinlogs(fieldBinlogs []*datapb.FieldBinlog) error {
+	for _, fieldBinlog := range fieldBinlogs {
+		for _, binlog := range fieldBinlog.Binlogs {
+			logPath := binlog.GetLogPath()
+			if len(logPath) != 0 {
+				var logID int64
+				idx := strings.LastIndex(logPath, "/")
+				if idx == -1 {
+					return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("invalid binlog path: %s", logPath))
+				}
+				var err error
+				logPathStr := logPath[(idx + 1):]
+				logID, err = strconv.ParseInt(logPathStr, 10, 64)
+				if err != nil {
+					return err
+				}
+				binlog.LogID = logID
+				binlog.LogPath = ""
+			}
+			// remove timestamp since it's not necessary
+			binlog.TimestampFrom = 0
+			binlog.TimestampTo = 0
+		}
+	}
+	return nil
+}
+
+func DecompressMultiBinLogs(infos []*datapb.SegmentInfo) error {
+	for _, info := range infos {
+		err := DecompressBinLogs(info)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func DecompressCompactionBinlogs(binlogs []*datapb.CompactionSegmentBinlogs) error {
+	for _, binlog := range binlogs {
+		collectionID, partitionID, segmentID := binlog.GetCollectionID(), binlog.GetPartitionID(), binlog.GetSegmentID()
+		err := DecompressBinLog(storage.InsertBinlog, collectionID, partitionID, segmentID, binlog.GetFieldBinlogs())
+		if err != nil {
+			return err
+		}
+		err = DecompressBinLog(storage.DeleteBinlog, collectionID, partitionID, segmentID, binlog.GetDeltalogs())
+		if err != nil {
+			return err
+		}
+		err = DecompressBinLog(storage.StatsBinlog, collectionID, partitionID, segmentID, binlog.GetField2StatslogPaths())
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func DecompressBinLogs(s *datapb.SegmentInfo) error {
+	collectionID, partitionID, segmentID := s.GetCollectionID(), s.GetPartitionID(), s.ID
+	err := DecompressBinLog(storage.InsertBinlog, collectionID, partitionID, segmentID, s.GetBinlogs())
+	if err != nil {
+		return err
+	}
+	err = DecompressBinLog(storage.DeleteBinlog, collectionID, partitionID, segmentID, s.GetDeltalogs())
+	if err != nil {
+		return err
+	}
+	err = DecompressBinLog(storage.StatsBinlog, collectionID, partitionID, segmentID, s.GetStatslogs())
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func DecompressBinLog(binlogType storage.BinlogType, collectionID, partitionID,
+	segmentID typeutil.UniqueID, fieldBinlogs []*datapb.FieldBinlog,
+) error {
+	for _, fieldBinlog := range fieldBinlogs {
+		for _, binlog := range fieldBinlog.Binlogs {
+			if binlog.GetLogPath() == "" {
+				path, err := buildLogPath(binlogType, collectionID, partitionID,
+					segmentID, fieldBinlog.GetFieldID(), binlog.GetLogID())
+				if err != nil {
+					return err
+				}
+				binlog.LogPath = path
+			}
+		}
+	}
+	return nil
+}
+
+// build a binlog path on the storage by metadata
+func buildLogPath(binlogType storage.BinlogType, collectionID, partitionID, segmentID, fieldID, logID typeutil.UniqueID) (string, error) {
+	chunkManagerRootPath := paramtable.Get().MinioCfg.RootPath.GetValue()
+	if paramtable.Get().CommonCfg.StorageType.GetValue() == "local" {
+		chunkManagerRootPath = paramtable.Get().LocalStorageCfg.Path.GetValue()
+	}
+	switch binlogType {
+	case storage.InsertBinlog:
+		return metautil.BuildInsertLogPath(chunkManagerRootPath, collectionID, partitionID, segmentID, fieldID, logID), nil
+	case storage.DeleteBinlog:
+		return metautil.BuildDeltaLogPath(chunkManagerRootPath, collectionID, partitionID, segmentID, logID), nil
+	case storage.StatsBinlog:
+		return metautil.BuildStatsLogPath(chunkManagerRootPath, collectionID, partitionID, segmentID, fieldID, logID), nil
+	}
+	// should not happen
+	return "", merr.WrapErrParameterInvalidMsg("invalid binlog type")
+}

--- a/internal/metastore/kv/binlog/binlog_test.go
+++ b/internal/metastore/kv/binlog/binlog_test.go
@@ -1,0 +1,290 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package binlog
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus/internal/proto/datapb"
+	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/pkg/util/merr"
+	"github.com/milvus-io/milvus/pkg/util/metautil"
+	"github.com/milvus-io/milvus/pkg/util/paramtable"
+)
+
+var (
+	logID        = int64(99)
+	collectionID = int64(2)
+	partitionID  = int64(1)
+	segmentID    = int64(1)
+	segmentID2   = int64(11)
+	fieldID      = int64(1)
+	rootPath     = "a"
+
+	binlogPath   = metautil.BuildInsertLogPath(rootPath, collectionID, partitionID, segmentID, fieldID, logID)
+	deltalogPath = metautil.BuildDeltaLogPath(rootPath, collectionID, partitionID, segmentID, logID)
+	statslogPath = metautil.BuildStatsLogPath(rootPath, collectionID, partitionID, segmentID, fieldID, logID)
+
+	binlogPath2   = metautil.BuildInsertLogPath(rootPath, collectionID, partitionID, segmentID2, fieldID, logID)
+	deltalogPath2 = metautil.BuildDeltaLogPath(rootPath, collectionID, partitionID, segmentID2, logID)
+	statslogPath2 = metautil.BuildStatsLogPath(rootPath, collectionID, partitionID, segmentID2, fieldID, logID)
+
+	invalidSegment = &datapb.SegmentInfo{
+		ID:           segmentID,
+		CollectionID: collectionID,
+		PartitionID:  partitionID,
+		NumOfRows:    100,
+		State:        commonpb.SegmentState_Flushed,
+		Binlogs: []*datapb.FieldBinlog{
+			{
+				FieldID: 1,
+				Binlogs: []*datapb.Binlog{
+					{
+						EntriesNum: 5,
+						LogPath:    "badpath",
+					},
+				},
+			},
+		},
+	}
+
+	binlogs = []*datapb.FieldBinlog{
+		{
+			FieldID: 1,
+			Binlogs: []*datapb.Binlog{
+				{
+					EntriesNum: 5,
+					LogPath:    binlogPath,
+				},
+			},
+		},
+	}
+
+	deltalogs = []*datapb.FieldBinlog{
+		{
+			FieldID: 1,
+			Binlogs: []*datapb.Binlog{
+				{
+					EntriesNum: 5,
+					LogPath:    deltalogPath,
+				},
+			},
+		},
+	}
+	statslogs = []*datapb.FieldBinlog{
+		{
+			FieldID: 1,
+			Binlogs: []*datapb.Binlog{
+				{
+					EntriesNum: 5,
+					LogPath:    statslogPath,
+				},
+			},
+		},
+	}
+
+	getlogs = func(logpath string) []*datapb.FieldBinlog {
+		return []*datapb.FieldBinlog{
+			{
+				FieldID: 1,
+				Binlogs: []*datapb.Binlog{
+					{
+						EntriesNum: 5,
+						LogPath:    logpath,
+					},
+				},
+			},
+		}
+	}
+
+	segment1 = &datapb.SegmentInfo{
+		ID:           segmentID,
+		CollectionID: collectionID,
+		PartitionID:  partitionID,
+		NumOfRows:    100,
+		State:        commonpb.SegmentState_Flushed,
+		Binlogs:      binlogs,
+		Deltalogs:    deltalogs,
+		Statslogs:    statslogs,
+	}
+
+	droppedSegment = &datapb.SegmentInfo{
+		ID:           segmentID2,
+		CollectionID: collectionID,
+		PartitionID:  partitionID,
+		NumOfRows:    100,
+		State:        commonpb.SegmentState_Dropped,
+		Binlogs:      getlogs(binlogPath2),
+		Deltalogs:    getlogs(deltalogPath2),
+		Statslogs:    getlogs(statslogPath2),
+	}
+)
+
+func getSegment(rootPath string, collectionID, partitionID, segmentID, fieldID int64, binlogNum int) *datapb.SegmentInfo {
+	binLogPaths := make([]*datapb.Binlog, binlogNum)
+	for i := 0; i < binlogNum; i++ {
+		binLogPaths[i] = &datapb.Binlog{
+			EntriesNum: 10000,
+			LogPath:    metautil.BuildInsertLogPath(rootPath, collectionID, partitionID, segmentID, fieldID, int64(i)),
+		}
+	}
+	binlogs = []*datapb.FieldBinlog{
+		{
+			FieldID: fieldID,
+			Binlogs: binLogPaths,
+		},
+	}
+
+	deltalogs = []*datapb.FieldBinlog{
+		{
+			FieldID: fieldID,
+			Binlogs: []*datapb.Binlog{
+				{
+					EntriesNum: 5,
+					LogPath:    metautil.BuildDeltaLogPath(rootPath, collectionID, partitionID, segmentID, int64(rand.Int())),
+				},
+			},
+		},
+	}
+
+	statslogs = []*datapb.FieldBinlog{
+		{
+			FieldID: 1,
+			Binlogs: []*datapb.Binlog{
+				{
+					EntriesNum: 5,
+					LogPath:    metautil.BuildStatsLogPath(rootPath, collectionID, partitionID, segmentID, fieldID, int64(rand.Int())),
+				},
+			},
+		},
+	}
+
+	return &datapb.SegmentInfo{
+		ID:           segmentID,
+		CollectionID: collectionID,
+		PartitionID:  partitionID,
+		NumOfRows:    10000,
+		State:        commonpb.SegmentState_Flushed,
+		Binlogs:      binlogs,
+		Deltalogs:    deltalogs,
+		Statslogs:    statslogs,
+	}
+}
+
+func TestBinlog_Compress(t *testing.T) {
+	paramtable.Init()
+	rootPath := paramtable.Get().MinioCfg.RootPath.GetValue()
+	segmentInfo := getSegment(rootPath, 0, 1, 2, 3, 10)
+	val, err := proto.Marshal(segmentInfo)
+	assert.NoError(t, err)
+
+	compressedSegmentInfo := proto.Clone(segmentInfo).(*datapb.SegmentInfo)
+	err = CompressBinLogs(compressedSegmentInfo)
+	assert.NoError(t, err)
+
+	valCompressed, err := proto.Marshal(compressedSegmentInfo)
+	assert.NoError(t, err)
+
+	assert.True(t, len(valCompressed) < len(val))
+
+	// make sure the compact
+	unmarshaledSegmentInfo := &datapb.SegmentInfo{}
+	proto.Unmarshal(val, unmarshaledSegmentInfo)
+
+	unmarshaledSegmentInfoCompressed := &datapb.SegmentInfo{}
+	proto.Unmarshal(valCompressed, unmarshaledSegmentInfoCompressed)
+	DecompressBinLogs(unmarshaledSegmentInfoCompressed)
+
+	assert.Equal(t, len(unmarshaledSegmentInfo.GetBinlogs()), len(unmarshaledSegmentInfoCompressed.GetBinlogs()))
+	for i := 0; i < 10; i++ {
+		assert.Equal(t, unmarshaledSegmentInfo.GetBinlogs()[0].Binlogs[i].LogPath, unmarshaledSegmentInfoCompressed.GetBinlogs()[0].Binlogs[i].LogPath)
+	}
+
+	// test compress erorr path
+	fakeBinlogs := make([]*datapb.Binlog, 1)
+	fakeBinlogs[0] = &datapb.Binlog{
+		EntriesNum: 10000,
+		LogPath:    "test",
+	}
+	fieldBinLogs := make([]*datapb.FieldBinlog, 1)
+	fieldBinLogs[0] = &datapb.FieldBinlog{
+		FieldID: 106,
+		Binlogs: fakeBinlogs,
+	}
+	segmentInfo1 := &datapb.SegmentInfo{
+		Binlogs: fieldBinLogs,
+	}
+	err = CompressBinLogs(segmentInfo1)
+	assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+
+	fakeDeltalogs := make([]*datapb.Binlog, 1)
+	fakeDeltalogs[0] = &datapb.Binlog{
+		EntriesNum: 10000,
+		LogPath:    "test",
+	}
+	fieldDeltaLogs := make([]*datapb.FieldBinlog, 1)
+	fieldDeltaLogs[0] = &datapb.FieldBinlog{
+		FieldID: 106,
+		Binlogs: fakeBinlogs,
+	}
+	segmentInfo2 := &datapb.SegmentInfo{
+		Deltalogs: fieldDeltaLogs,
+	}
+	err = CompressBinLogs(segmentInfo2)
+	assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+
+	fakeStatslogs := make([]*datapb.Binlog, 1)
+	fakeStatslogs[0] = &datapb.Binlog{
+		EntriesNum: 10000,
+		LogPath:    "test",
+	}
+	fieldStatsLogs := make([]*datapb.FieldBinlog, 1)
+	fieldStatsLogs[0] = &datapb.FieldBinlog{
+		FieldID: 106,
+		Binlogs: fakeBinlogs,
+	}
+	segmentInfo3 := &datapb.SegmentInfo{
+		Statslogs: fieldDeltaLogs,
+	}
+	err = CompressBinLogs(segmentInfo3)
+	assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+
+	// test decompress error invalid Type
+	// should not happen
+	fakeBinlogs = make([]*datapb.Binlog, 1)
+	fakeBinlogs[0] = &datapb.Binlog{
+		EntriesNum: 10000,
+		LogPath:    "",
+		LogID:      1,
+	}
+	fieldBinLogs = make([]*datapb.FieldBinlog, 1)
+	fieldBinLogs[0] = &datapb.FieldBinlog{
+		FieldID: 106,
+		Binlogs: fakeBinlogs,
+	}
+	segmentInfo = &datapb.SegmentInfo{
+		Binlogs: fieldBinLogs,
+	}
+	invaildType := storage.BinlogType(100)
+	err = DecompressBinLog(invaildType, 1, 1, 1, segmentInfo.Binlogs)
+	assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+}

--- a/internal/metastore/kv/datacoord/kv_catalog.go
+++ b/internal/metastore/kv/datacoord/kv_catalog.go
@@ -32,6 +32,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
 	"github.com/milvus-io/milvus/internal/kv"
 	"github.com/milvus-io/milvus/internal/metastore"
+	"github.com/milvus-io/milvus/internal/metastore/kv/binlog"
 	"github.com/milvus-io/milvus/internal/metastore/model"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
 	"github.com/milvus-io/milvus/internal/proto/indexpb"
@@ -41,7 +42,6 @@ import (
 	"github.com/milvus-io/milvus/pkg/metrics"
 	"github.com/milvus-io/milvus/pkg/util"
 	"github.com/milvus-io/milvus/pkg/util/etcd"
-	"github.com/milvus-io/milvus/pkg/util/metautil"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
 
@@ -96,7 +96,10 @@ func (kc *Catalog) ListSegments(ctx context.Context) ([]*datapb.SegmentInfo, err
 		return nil, err
 	}
 
-	kc.applyBinlogInfo(segments, insertLogs, deltaLogs, statsLogs)
+	err = kc.applyBinlogInfo(segments, insertLogs, deltaLogs, statsLogs)
+	if err != nil {
+		return nil, err
+	}
 	return segments, nil
 }
 
@@ -185,20 +188,12 @@ func (kc *Catalog) listBinlogs(binlogType storage.BinlogType) (map[typeutil.Uniq
 			return fmt.Errorf("failed to unmarshal datapb.FieldBinlog: %d, err:%w", fieldBinlog.FieldID, err)
 		}
 
-		collectionID, partitionID, segmentID, err := kc.parseBinlogKey(string(key), prefixIdx)
+		_, _, segmentID, err := kc.parseBinlogKey(string(key), prefixIdx)
 		if err != nil {
 			return fmt.Errorf("prefix:%s, %w", path.Join(kc.metaRootpath, logPathPrefix), err)
 		}
 
-		switch binlogType {
-		case storage.InsertBinlog:
-			fillLogPathByLogID(kc.ChunkManagerRootPath, storage.InsertBinlog, collectionID, partitionID, segmentID, fieldBinlog)
-		case storage.DeleteBinlog:
-			fillLogPathByLogID(kc.ChunkManagerRootPath, storage.DeleteBinlog, collectionID, partitionID, segmentID, fieldBinlog)
-		case storage.StatsBinlog:
-			fillLogPathByLogID(kc.ChunkManagerRootPath, storage.StatsBinlog, collectionID, partitionID, segmentID, fieldBinlog)
-		}
-
+		// no need to set log path and only store log id
 		ret[segmentID] = append(ret[segmentID], fieldBinlog)
 		return nil
 	}
@@ -212,20 +207,37 @@ func (kc *Catalog) listBinlogs(binlogType storage.BinlogType) (map[typeutil.Uniq
 
 func (kc *Catalog) applyBinlogInfo(segments []*datapb.SegmentInfo, insertLogs, deltaLogs,
 	statsLogs map[typeutil.UniqueID][]*datapb.FieldBinlog,
-) {
+) error {
+	var err error
 	for _, segmentInfo := range segments {
 		if len(segmentInfo.Binlogs) == 0 {
 			segmentInfo.Binlogs = insertLogs[segmentInfo.ID]
+		} else {
+			err = binlog.CompressFieldBinlogs(segmentInfo.Binlogs)
+			if err != nil {
+				return err
+			}
 		}
 
 		if len(segmentInfo.Deltalogs) == 0 {
 			segmentInfo.Deltalogs = deltaLogs[segmentInfo.ID]
+		} else {
+			err = binlog.CompressFieldBinlogs(segmentInfo.Deltalogs)
+			if err != nil {
+				return err
+			}
 		}
 
 		if len(segmentInfo.Statslogs) == 0 {
 			segmentInfo.Statslogs = statsLogs[segmentInfo.ID]
+		} else {
+			err = binlog.CompressFieldBinlogs(segmentInfo.Statslogs)
+			if err != nil {
+				return err
+			}
 		}
 	}
+	return nil
 }
 
 func (kc *Catalog) AddSegment(ctx context.Context, segment *datapb.SegmentInfo) error {
@@ -295,6 +307,7 @@ func (kc *Catalog) AlterSegments(ctx context.Context, segments []*datapb.Segment
 		if err != nil {
 			return err
 		}
+
 		maps.Copy(kvs, binlogKvs)
 	}
 
@@ -349,20 +362,6 @@ func (kc *Catalog) SaveByBatch(kvs map[string]string) error {
 		}
 	}
 	return nil
-}
-
-func resetBinlogFields(segment *datapb.SegmentInfo) {
-	segment.Binlogs = nil
-	segment.Deltalogs = nil
-	segment.Statslogs = nil
-}
-
-func cloneLogs(binlogs []*datapb.FieldBinlog) []*datapb.FieldBinlog {
-	var res []*datapb.FieldBinlog
-	for _, log := range binlogs {
-		res = append(res, proto.Clone(log).(*datapb.FieldBinlog))
-	}
-	return res
 }
 
 func (kc *Catalog) collectMetrics(s *datapb.SegmentInfo) {
@@ -549,29 +548,7 @@ func (kc *Catalog) getBinlogsWithPrefix(binlogType storage.BinlogType, collectio
 	if err != nil {
 		return nil, nil, err
 	}
-
 	return keys, values, nil
-}
-
-// unmarshal binlog/deltalog/statslog
-func (kc *Catalog) unmarshalBinlog(binlogType storage.BinlogType, collectionID, partitionID, segmentID typeutil.UniqueID) ([]*datapb.FieldBinlog, error) {
-	_, values, err := kc.getBinlogsWithPrefix(binlogType, collectionID, partitionID, segmentID)
-	if err != nil {
-		return nil, err
-	}
-
-	result := make([]*datapb.FieldBinlog, len(values))
-	for i, value := range values {
-		fieldBinlog := &datapb.FieldBinlog{}
-		err = proto.Unmarshal([]byte(value), fieldBinlog)
-		if err != nil {
-			return nil, fmt.Errorf("failed to unmarshal datapb.FieldBinlog: %d, err:%w", fieldBinlog.FieldID, err)
-		}
-
-		fillLogPathByLogID(kc.ChunkManagerRootPath, binlogType, collectionID, partitionID, segmentID, fieldBinlog)
-		result[i] = fieldBinlog
-	}
-	return result, nil
 }
 
 func (kc *Catalog) CreateIndex(ctx context.Context, index *model.Index) error {
@@ -728,344 +705,4 @@ func (kc *Catalog) GcConfirm(ctx context.Context, collectionID, partitionID type
 		return false
 	}
 	return len(keys) == 0 && len(values) == 0
-}
-
-func fillLogPathByLogID(chunkManagerRootPath string, binlogType storage.BinlogType, collectionID, partitionID,
-	segmentID typeutil.UniqueID, fieldBinlog *datapb.FieldBinlog,
-) {
-	for _, binlog := range fieldBinlog.Binlogs {
-		path := buildLogPath(chunkManagerRootPath, binlogType, collectionID, partitionID,
-			segmentID, fieldBinlog.GetFieldID(), binlog.GetLogID())
-		binlog.LogPath = path
-	}
-}
-
-func fillLogIDByLogPath(multiFieldBinlogs ...[]*datapb.FieldBinlog) error {
-	for _, fieldBinlogs := range multiFieldBinlogs {
-		for _, fieldBinlog := range fieldBinlogs {
-			for _, binlog := range fieldBinlog.Binlogs {
-				logPath := binlog.LogPath
-				idx := strings.LastIndex(logPath, "/")
-				if idx == -1 {
-					return fmt.Errorf("invailed binlog path: %s", logPath)
-				}
-				logPathStr := logPath[(idx + 1):]
-				logID, err := strconv.ParseInt(logPathStr, 10, 64)
-				if err != nil {
-					return err
-				}
-
-				// set log path to empty and only store log id
-				binlog.LogPath = ""
-				binlog.LogID = logID
-			}
-		}
-	}
-	return nil
-}
-
-func CompressBinLog(fieldBinLogs []*datapb.FieldBinlog) ([]*datapb.FieldBinlog, error) {
-	compressedFieldBinLogs := make([]*datapb.FieldBinlog, 0)
-	for _, fieldBinLog := range fieldBinLogs {
-		compressedFieldBinLog := &datapb.FieldBinlog{}
-		compressedFieldBinLog.FieldID = fieldBinLog.FieldID
-		for _, binlog := range fieldBinLog.Binlogs {
-			logPath := binlog.LogPath
-			idx := strings.LastIndex(logPath, "/")
-			if idx == -1 {
-				return nil, fmt.Errorf("invailed binlog path: %s", logPath)
-			}
-			logPathStr := logPath[(idx + 1):]
-			logID, err := strconv.ParseInt(logPathStr, 10, 64)
-			if err != nil {
-				return nil, err
-			}
-			binlog := &datapb.Binlog{
-				EntriesNum: binlog.EntriesNum,
-				// remove timestamp since it's not necessary
-				LogSize: binlog.LogSize,
-				LogID:   logID,
-			}
-			compressedFieldBinLog.Binlogs = append(compressedFieldBinLog.Binlogs, binlog)
-		}
-		compressedFieldBinLogs = append(compressedFieldBinLogs, compressedFieldBinLog)
-	}
-	return compressedFieldBinLogs, nil
-}
-
-func DecompressBinLog(path string, info *datapb.SegmentInfo) error {
-	for _, fieldBinLogs := range info.GetBinlogs() {
-		fillLogPathByLogID(path, storage.InsertBinlog, info.CollectionID, info.PartitionID, info.ID, fieldBinLogs)
-	}
-
-	for _, deltaLogs := range info.GetDeltalogs() {
-		fillLogPathByLogID(path, storage.DeleteBinlog, info.CollectionID, info.PartitionID, info.ID, deltaLogs)
-	}
-
-	for _, statsLogs := range info.GetStatslogs() {
-		fillLogPathByLogID(path, storage.StatsBinlog, info.CollectionID, info.PartitionID, info.ID, statsLogs)
-	}
-	return nil
-}
-
-// build a binlog path on the storage by metadata
-func buildLogPath(chunkManagerRootPath string, binlogType storage.BinlogType, collectionID, partitionID, segmentID, filedID, logID typeutil.UniqueID) string {
-	switch binlogType {
-	case storage.InsertBinlog:
-		return metautil.BuildInsertLogPath(chunkManagerRootPath, collectionID, partitionID, segmentID, filedID, logID)
-	case storage.DeleteBinlog:
-		return metautil.BuildDeltaLogPath(chunkManagerRootPath, collectionID, partitionID, segmentID, logID)
-	case storage.StatsBinlog:
-		return metautil.BuildStatsLogPath(chunkManagerRootPath, collectionID, partitionID, segmentID, filedID, logID)
-	}
-	// should not happen
-	log.Panic("invalid binlog type", zap.Any("type", binlogType))
-	return ""
-}
-
-func checkBinlogs(binlogType storage.BinlogType, segmentID typeutil.UniqueID, logs []*datapb.FieldBinlog) error {
-	check := func(getSegmentID func(logPath string) typeutil.UniqueID) error {
-		for _, fieldBinlog := range logs {
-			for _, binlog := range fieldBinlog.Binlogs {
-				if segmentID != getSegmentID(binlog.LogPath) {
-					return fmt.Errorf("the segment path doesn't match the segmentID, segmentID %d, path %s", segmentID, binlog.LogPath)
-				}
-			}
-		}
-		return nil
-	}
-	switch binlogType {
-	case storage.InsertBinlog:
-		return check(metautil.GetSegmentIDFromInsertLogPath)
-	case storage.DeleteBinlog:
-		return check(metautil.GetSegmentIDFromDeltaLogPath)
-	case storage.StatsBinlog:
-		return check(metautil.GetSegmentIDFromStatsLogPath)
-	default:
-		return fmt.Errorf("the segment path doesn't match the segmentID, segmentID %d, type %d", segmentID, binlogType)
-	}
-}
-
-func hasSepcialStatslog(logs *datapb.FieldBinlog) bool {
-	for _, statslog := range logs.Binlogs {
-		_, logidx := path.Split(statslog.LogPath)
-		if logidx == storage.CompoundStatsType.LogIdx() {
-			return true
-		}
-	}
-	return false
-}
-
-func buildBinlogKvsWithLogID(collectionID, partitionID, segmentID typeutil.UniqueID,
-	binlogs, deltalogs, statslogs []*datapb.FieldBinlog, ignoreNumberCheck bool,
-) (map[string]string, error) {
-	err := checkBinlogs(storage.InsertBinlog, segmentID, binlogs)
-	if err != nil {
-		return nil, err
-	}
-	checkBinlogs(storage.DeleteBinlog, segmentID, deltalogs)
-	if err != nil {
-		return nil, err
-	}
-	checkBinlogs(storage.StatsBinlog, segmentID, statslogs)
-	if err != nil {
-		return nil, err
-	}
-	// check stats log and bin log size match
-	// num of stats log may one more than num of binlogs if segment flushed and merged stats log
-	if !ignoreNumberCheck && len(binlogs) != 0 && len(statslogs) != 0 && !hasSepcialStatslog(statslogs[0]) {
-		if len(binlogs[0].GetBinlogs()) != len(statslogs[0].GetBinlogs()) {
-			log.Warn("find invalid segment while bin log size didn't match stat log size",
-				zap.Int64("collection", collectionID),
-				zap.Int64("partition", partitionID),
-				zap.Int64("segment", segmentID),
-				zap.Any("binlogs", binlogs),
-				zap.Any("stats", statslogs),
-				zap.Any("delta", deltalogs),
-			)
-			return nil, fmt.Errorf("segment can not be saved because of binlog "+
-				"file not match stat log number: collection %v, segment %v", collectionID, segmentID)
-		}
-	}
-
-	fillLogIDByLogPath(binlogs, deltalogs, statslogs)
-	kvs, err := buildBinlogKvs(collectionID, partitionID, segmentID, binlogs, deltalogs, statslogs)
-	if err != nil {
-		return nil, err
-	}
-
-	return kvs, nil
-}
-
-func buildSegmentAndBinlogsKvs(segment *datapb.SegmentInfo) (map[string]string, error) {
-	noBinlogsSegment, binlogs, deltalogs, statslogs := CloneSegmentWithExcludeBinlogs(segment)
-	// `segment` is not mutated above. Also, `noBinlogsSegment` is a cloned version of `segment`.
-	segmentutil.ReCalcRowCount(segment, noBinlogsSegment)
-
-	// compacted segment has only one statslog
-	ignore := (len(segment.GetCompactionFrom()) > 0)
-	// save binlogs separately
-	kvs, err := buildBinlogKvsWithLogID(noBinlogsSegment.CollectionID, noBinlogsSegment.PartitionID, noBinlogsSegment.ID, binlogs, deltalogs, statslogs, ignore)
-	if err != nil {
-		return nil, err
-	}
-
-	// save segment info
-	k, v, err := buildSegmentKv(noBinlogsSegment)
-	if err != nil {
-		return nil, err
-	}
-	kvs[k] = v
-
-	return kvs, nil
-}
-
-func buildBinlogKeys(segment *datapb.SegmentInfo) []string {
-	var keys []string
-	// binlog
-	for _, binlog := range segment.Binlogs {
-		key := buildFieldBinlogPath(segment.CollectionID, segment.PartitionID, segment.ID, binlog.FieldID)
-		keys = append(keys, key)
-	}
-
-	// deltalog
-	for _, deltalog := range segment.Deltalogs {
-		key := buildFieldDeltalogPath(segment.CollectionID, segment.PartitionID, segment.ID, deltalog.FieldID)
-		keys = append(keys, key)
-	}
-
-	// statslog
-	for _, statslog := range segment.Statslogs {
-		key := buildFieldStatslogPath(segment.CollectionID, segment.PartitionID, segment.ID, statslog.FieldID)
-		keys = append(keys, key)
-	}
-	return keys
-}
-
-func buildBinlogKvs(collectionID, partitionID, segmentID typeutil.UniqueID, binlogs, deltalogs, statslogs []*datapb.FieldBinlog) (map[string]string, error) {
-	kv := make(map[string]string)
-
-	// binlog kv
-	for _, binlog := range binlogs {
-		binlogBytes, err := proto.Marshal(binlog)
-		if err != nil {
-			return nil, fmt.Errorf("marshal binlogs failed, collectionID:%d, segmentID:%d, fieldID:%d, error:%w", collectionID, segmentID, binlog.FieldID, err)
-		}
-		key := buildFieldBinlogPath(collectionID, partitionID, segmentID, binlog.FieldID)
-		kv[key] = string(binlogBytes)
-	}
-
-	// deltalog
-	for _, deltalog := range deltalogs {
-		binlogBytes, err := proto.Marshal(deltalog)
-		if err != nil {
-			return nil, fmt.Errorf("marshal deltalogs failed, collectionID:%d, segmentID:%d, fieldID:%d, error:%w", collectionID, segmentID, deltalog.FieldID, err)
-		}
-		key := buildFieldDeltalogPath(collectionID, partitionID, segmentID, deltalog.FieldID)
-		kv[key] = string(binlogBytes)
-	}
-
-	// statslog
-	for _, statslog := range statslogs {
-		binlogBytes, err := proto.Marshal(statslog)
-		if err != nil {
-			return nil, fmt.Errorf("marshal statslogs failed, collectionID:%d, segmentID:%d, fieldID:%d, error:%w", collectionID, segmentID, statslog.FieldID, err)
-		}
-		key := buildFieldStatslogPath(collectionID, partitionID, segmentID, statslog.FieldID)
-		kv[key] = string(binlogBytes)
-	}
-
-	return kv, nil
-}
-
-func CloneSegmentWithExcludeBinlogs(segment *datapb.SegmentInfo) (*datapb.SegmentInfo, []*datapb.FieldBinlog, []*datapb.FieldBinlog, []*datapb.FieldBinlog) {
-	clonedSegment := proto.Clone(segment).(*datapb.SegmentInfo)
-	binlogs := clonedSegment.Binlogs
-	deltalogs := clonedSegment.Deltalogs
-	statlogs := clonedSegment.Statslogs
-
-	clonedSegment.Binlogs = nil
-	clonedSegment.Deltalogs = nil
-	clonedSegment.Statslogs = nil
-	return clonedSegment, binlogs, deltalogs, statlogs
-}
-
-func marshalSegmentInfo(segment *datapb.SegmentInfo) (string, error) {
-	segBytes, err := proto.Marshal(segment)
-	if err != nil {
-		return "", fmt.Errorf("failed to marshal segment: %d, err: %w", segment.ID, err)
-	}
-
-	return string(segBytes), nil
-}
-
-func buildSegmentKv(segment *datapb.SegmentInfo) (string, string, error) {
-	segBytes, err := marshalSegmentInfo(segment)
-	if err != nil {
-		return "", "", err
-	}
-	key := buildSegmentPath(segment.GetCollectionID(), segment.GetPartitionID(), segment.GetID())
-	return key, segBytes, nil
-}
-
-// buildSegmentPath common logic mapping segment info to corresponding key in kv store
-func buildSegmentPath(collectionID typeutil.UniqueID, partitionID typeutil.UniqueID, segmentID typeutil.UniqueID) string {
-	return fmt.Sprintf("%s/%d/%d/%d", SegmentPrefix, collectionID, partitionID, segmentID)
-}
-
-func buildFieldBinlogPath(collectionID typeutil.UniqueID, partitionID typeutil.UniqueID, segmentID typeutil.UniqueID, fieldID typeutil.UniqueID) string {
-	return fmt.Sprintf("%s/%d/%d/%d/%d", SegmentBinlogPathPrefix, collectionID, partitionID, segmentID, fieldID)
-}
-
-// TODO: There's no need to include fieldID in the delta log path key.
-func buildFieldDeltalogPath(collectionID typeutil.UniqueID, partitionID typeutil.UniqueID, segmentID typeutil.UniqueID, fieldID typeutil.UniqueID) string {
-	return fmt.Sprintf("%s/%d/%d/%d/%d", SegmentDeltalogPathPrefix, collectionID, partitionID, segmentID, fieldID)
-}
-
-// TODO: There's no need to include fieldID in the stats log path key.
-func buildFieldStatslogPath(collectionID typeutil.UniqueID, partitionID typeutil.UniqueID, segmentID typeutil.UniqueID, fieldID typeutil.UniqueID) string {
-	return fmt.Sprintf("%s/%d/%d/%d/%d", SegmentStatslogPathPrefix, collectionID, partitionID, segmentID, fieldID)
-}
-
-// buildFlushedSegmentPath common logic mapping segment info to corresponding key of IndexCoord in kv store
-// TODO @cai.zhang: remove this
-func buildFlushedSegmentPath(collectionID typeutil.UniqueID, partitionID typeutil.UniqueID, segmentID typeutil.UniqueID) string {
-	return fmt.Sprintf("%s/%d/%d/%d", util.FlushedSegmentPrefix, collectionID, partitionID, segmentID)
-}
-
-func buildFieldBinlogPathPrefix(collectionID typeutil.UniqueID, partitionID typeutil.UniqueID, segmentID typeutil.UniqueID) string {
-	return fmt.Sprintf("%s/%d/%d/%d", SegmentBinlogPathPrefix, collectionID, partitionID, segmentID)
-}
-
-func buildFieldDeltalogPathPrefix(collectionID typeutil.UniqueID, partitionID typeutil.UniqueID, segmentID typeutil.UniqueID) string {
-	return fmt.Sprintf("%s/%d/%d/%d", SegmentDeltalogPathPrefix, collectionID, partitionID, segmentID)
-}
-
-func buildFieldStatslogPathPrefix(collectionID typeutil.UniqueID, partitionID typeutil.UniqueID, segmentID typeutil.UniqueID) string {
-	return fmt.Sprintf("%s/%d/%d/%d", SegmentStatslogPathPrefix, collectionID, partitionID, segmentID)
-}
-
-// buildChannelRemovePath builds vchannel remove flag path
-func buildChannelRemovePath(channel string) string {
-	return fmt.Sprintf("%s/%s", ChannelRemovePrefix, channel)
-}
-
-func buildChannelCPKey(vChannel string) string {
-	return fmt.Sprintf("%s/%s", ChannelCheckpointPrefix, vChannel)
-}
-
-func BuildIndexKey(collectionID, indexID int64) string {
-	return fmt.Sprintf("%s/%d/%d", util.FieldIndexPrefix, collectionID, indexID)
-}
-
-func BuildSegmentIndexKey(collectionID, partitionID, segmentID, buildID int64) string {
-	return fmt.Sprintf("%s/%d/%d/%d/%d", util.SegmentIndexPrefix, collectionID, partitionID, segmentID, buildID)
-}
-
-func buildCollectionPrefix(collectionID typeutil.UniqueID) string {
-	return fmt.Sprintf("%s/%d", SegmentPrefix, collectionID)
-}
-
-func buildPartitionPrefix(collectionID, partitionID typeutil.UniqueID) string {
-	return fmt.Sprintf("%s/%d/%d", SegmentPrefix, collectionID, partitionID)
 }

--- a/internal/metastore/kv/datacoord/util.go
+++ b/internal/metastore/kv/datacoord/util.go
@@ -1,0 +1,247 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datacoord
+
+import (
+	"fmt"
+
+	"github.com/golang/protobuf/proto"
+	"go.uber.org/zap"
+
+	"github.com/milvus-io/milvus/internal/proto/datapb"
+	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/util/segmentutil"
+	"github.com/milvus-io/milvus/pkg/log"
+	"github.com/milvus-io/milvus/pkg/util"
+	"github.com/milvus-io/milvus/pkg/util/typeutil"
+)
+
+func hasSepcialStatslog(logs *datapb.FieldBinlog) bool {
+	for _, statslog := range logs.Binlogs {
+		if fmt.Sprint(statslog.GetLogID()) == storage.CompoundStatsType.LogIdx() {
+			return true
+		}
+	}
+	return false
+}
+
+func buildBinlogKvsWithLogID(collectionID, partitionID, segmentID typeutil.UniqueID,
+	binlogs, deltalogs, statslogs []*datapb.FieldBinlog, ignoreNumberCheck bool,
+) (map[string]string, error) {
+	// check stats log and bin log size match
+	// num of stats log may one more than num of binlogs if segment flushed and merged stats log
+	if !ignoreNumberCheck && len(binlogs) != 0 && len(statslogs) != 0 && !hasSepcialStatslog(statslogs[0]) {
+		if len(binlogs[0].GetBinlogs()) != len(statslogs[0].GetBinlogs()) {
+			log.Warn("find invalid segment while bin log size didn't match stat log size",
+				zap.Int64("collection", collectionID),
+				zap.Int64("partition", partitionID),
+				zap.Int64("segment", segmentID),
+				zap.Any("binlogs", binlogs),
+				zap.Any("stats", statslogs),
+				zap.Any("delta", deltalogs),
+			)
+			return nil, fmt.Errorf("segment can not be saved because of binlog "+
+				"file not match stat log number: collection %v, segment %v", collectionID, segmentID)
+		}
+	}
+	// all the FieldBinlog will only have logid
+	kvs, err := buildBinlogKvs(collectionID, partitionID, segmentID, binlogs, deltalogs, statslogs)
+	if err != nil {
+		return nil, err
+	}
+
+	return kvs, nil
+}
+
+func buildSegmentAndBinlogsKvs(segment *datapb.SegmentInfo) (map[string]string, error) {
+	noBinlogsSegment, binlogs, deltalogs, statslogs := CloneSegmentWithExcludeBinlogs(segment)
+	// `segment` is not mutated above. Also, `noBinlogsSegment` is a cloned version of `segment`.
+	segmentutil.ReCalcRowCount(segment, noBinlogsSegment)
+
+	// save binlogs separately
+	kvs, err := buildBinlogKvsWithLogID(noBinlogsSegment.CollectionID, noBinlogsSegment.PartitionID, noBinlogsSegment.ID, binlogs, deltalogs, statslogs, true)
+	if err != nil {
+		return nil, err
+	}
+
+	// save segment info
+	k, v, err := buildSegmentKv(noBinlogsSegment)
+	if err != nil {
+		return nil, err
+	}
+	kvs[k] = v
+
+	return kvs, nil
+}
+
+func buildBinlogKeys(segment *datapb.SegmentInfo) []string {
+	var keys []string
+	// binlog
+	for _, binlog := range segment.Binlogs {
+		key := buildFieldBinlogPath(segment.CollectionID, segment.PartitionID, segment.ID, binlog.FieldID)
+		keys = append(keys, key)
+	}
+
+	// deltalog
+	for _, deltalog := range segment.Deltalogs {
+		key := buildFieldDeltalogPath(segment.CollectionID, segment.PartitionID, segment.ID, deltalog.FieldID)
+		keys = append(keys, key)
+	}
+
+	// statslog
+	for _, statslog := range segment.Statslogs {
+		key := buildFieldStatslogPath(segment.CollectionID, segment.PartitionID, segment.ID, statslog.FieldID)
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+func resetBinlogFields(segment *datapb.SegmentInfo) {
+	segment.Binlogs = nil
+	segment.Deltalogs = nil
+	segment.Statslogs = nil
+}
+
+func cloneLogs(binlogs []*datapb.FieldBinlog) []*datapb.FieldBinlog {
+	var res []*datapb.FieldBinlog
+	for _, log := range binlogs {
+		res = append(res, proto.Clone(log).(*datapb.FieldBinlog))
+	}
+	return res
+}
+
+func buildBinlogKvs(collectionID, partitionID, segmentID typeutil.UniqueID, binlogs, deltalogs, statslogs []*datapb.FieldBinlog) (map[string]string, error) {
+	kv := make(map[string]string)
+
+	// binlog kv
+	for _, binlog := range binlogs {
+		binlogBytes, err := proto.Marshal(binlog)
+		if err != nil {
+			return nil, fmt.Errorf("marshal binlogs failed, collectionID:%d, segmentID:%d, fieldID:%d, error:%w", collectionID, segmentID, binlog.FieldID, err)
+		}
+		key := buildFieldBinlogPath(collectionID, partitionID, segmentID, binlog.FieldID)
+		kv[key] = string(binlogBytes)
+	}
+
+	// deltalog
+	for _, deltalog := range deltalogs {
+		binlogBytes, err := proto.Marshal(deltalog)
+		if err != nil {
+			return nil, fmt.Errorf("marshal deltalogs failed, collectionID:%d, segmentID:%d, fieldID:%d, error:%w", collectionID, segmentID, deltalog.FieldID, err)
+		}
+		key := buildFieldDeltalogPath(collectionID, partitionID, segmentID, deltalog.FieldID)
+		kv[key] = string(binlogBytes)
+	}
+
+	// statslog
+	for _, statslog := range statslogs {
+		binlogBytes, err := proto.Marshal(statslog)
+		if err != nil {
+			return nil, fmt.Errorf("marshal statslogs failed, collectionID:%d, segmentID:%d, fieldID:%d, error:%w", collectionID, segmentID, statslog.FieldID, err)
+		}
+		key := buildFieldStatslogPath(collectionID, partitionID, segmentID, statslog.FieldID)
+		kv[key] = string(binlogBytes)
+	}
+
+	return kv, nil
+}
+
+func CloneSegmentWithExcludeBinlogs(segment *datapb.SegmentInfo) (*datapb.SegmentInfo, []*datapb.FieldBinlog, []*datapb.FieldBinlog, []*datapb.FieldBinlog) {
+	clonedSegment := proto.Clone(segment).(*datapb.SegmentInfo)
+	binlogs := clonedSegment.Binlogs
+	deltalogs := clonedSegment.Deltalogs
+	statlogs := clonedSegment.Statslogs
+
+	clonedSegment.Binlogs = nil
+	clonedSegment.Deltalogs = nil
+	clonedSegment.Statslogs = nil
+	return clonedSegment, binlogs, deltalogs, statlogs
+}
+
+func marshalSegmentInfo(segment *datapb.SegmentInfo) (string, error) {
+	segBytes, err := proto.Marshal(segment)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal segment: %d, err: %w", segment.ID, err)
+	}
+
+	return string(segBytes), nil
+}
+
+func buildSegmentKv(segment *datapb.SegmentInfo) (string, string, error) {
+	segBytes, err := marshalSegmentInfo(segment)
+	if err != nil {
+		return "", "", err
+	}
+	key := buildSegmentPath(segment.GetCollectionID(), segment.GetPartitionID(), segment.GetID())
+	return key, segBytes, nil
+}
+
+// buildSegmentPath common logic mapping segment info to corresponding key in kv store
+func buildSegmentPath(collectionID typeutil.UniqueID, partitionID typeutil.UniqueID, segmentID typeutil.UniqueID) string {
+	return fmt.Sprintf("%s/%d/%d/%d", SegmentPrefix, collectionID, partitionID, segmentID)
+}
+
+func buildFieldBinlogPath(collectionID typeutil.UniqueID, partitionID typeutil.UniqueID, segmentID typeutil.UniqueID, fieldID typeutil.UniqueID) string {
+	return fmt.Sprintf("%s/%d/%d/%d/%d", SegmentBinlogPathPrefix, collectionID, partitionID, segmentID, fieldID)
+}
+
+// TODO: There's no need to include fieldID in the delta log path key.
+func buildFieldDeltalogPath(collectionID typeutil.UniqueID, partitionID typeutil.UniqueID, segmentID typeutil.UniqueID, fieldID typeutil.UniqueID) string {
+	return fmt.Sprintf("%s/%d/%d/%d/%d", SegmentDeltalogPathPrefix, collectionID, partitionID, segmentID, fieldID)
+}
+
+// TODO: There's no need to include fieldID in the stats log path key.
+func buildFieldStatslogPath(collectionID typeutil.UniqueID, partitionID typeutil.UniqueID, segmentID typeutil.UniqueID, fieldID typeutil.UniqueID) string {
+	return fmt.Sprintf("%s/%d/%d/%d/%d", SegmentStatslogPathPrefix, collectionID, partitionID, segmentID, fieldID)
+}
+
+func buildFieldBinlogPathPrefix(collectionID typeutil.UniqueID, partitionID typeutil.UniqueID, segmentID typeutil.UniqueID) string {
+	return fmt.Sprintf("%s/%d/%d/%d", SegmentBinlogPathPrefix, collectionID, partitionID, segmentID)
+}
+
+func buildFieldDeltalogPathPrefix(collectionID typeutil.UniqueID, partitionID typeutil.UniqueID, segmentID typeutil.UniqueID) string {
+	return fmt.Sprintf("%s/%d/%d/%d", SegmentDeltalogPathPrefix, collectionID, partitionID, segmentID)
+}
+
+func buildFieldStatslogPathPrefix(collectionID typeutil.UniqueID, partitionID typeutil.UniqueID, segmentID typeutil.UniqueID) string {
+	return fmt.Sprintf("%s/%d/%d/%d", SegmentStatslogPathPrefix, collectionID, partitionID, segmentID)
+}
+
+// buildChannelRemovePath builds vchannel remove flag path
+func buildChannelRemovePath(channel string) string {
+	return fmt.Sprintf("%s/%s", ChannelRemovePrefix, channel)
+}
+
+func buildChannelCPKey(vChannel string) string {
+	return fmt.Sprintf("%s/%s", ChannelCheckpointPrefix, vChannel)
+}
+
+func BuildIndexKey(collectionID, indexID int64) string {
+	return fmt.Sprintf("%s/%d/%d", util.FieldIndexPrefix, collectionID, indexID)
+}
+
+func BuildSegmentIndexKey(collectionID, partitionID, segmentID, buildID int64) string {
+	return fmt.Sprintf("%s/%d/%d/%d/%d", util.SegmentIndexPrefix, collectionID, partitionID, segmentID, buildID)
+}
+
+func buildCollectionPrefix(collectionID typeutil.UniqueID) string {
+	return fmt.Sprintf("%s/%d", SegmentPrefix, collectionID)
+}
+
+func buildPartitionPrefix(collectionID, partitionID typeutil.UniqueID) string {
+	return fmt.Sprintf("%s/%d/%d", SegmentPrefix, collectionID, partitionID)
+}

--- a/internal/proto/data_coord.proto
+++ b/internal/proto/data_coord.proto
@@ -483,6 +483,9 @@ message SyncSegmentsRequest {
   int64 num_of_rows = 3;
   repeated int64 compacted_from = 4;
   repeated FieldBinlog stats_logs = 5;
+  string channel_name = 6;
+  int64 partition_id = 7;
+  int64 collection_id = 8;
 }
 
 message CompactionSegmentBinlogs {
@@ -491,6 +494,9 @@ message CompactionSegmentBinlogs {
   repeated FieldBinlog field2StatslogPaths = 3;
   repeated FieldBinlog deltalogs = 4;
   string insert_channel = 5;
+  SegmentLevel level = 6;
+  int64 collectionID = 7;
+  int64 partitionID = 8;
 }
 
 message CompactionPlan {

--- a/internal/proto/index_coord.proto
+++ b/internal/proto/index_coord.proto
@@ -7,6 +7,7 @@ option go_package = "github.com/milvus-io/milvus/internal/proto/indexpb";
 import "common.proto";
 import "internal.proto";
 import "milvus.proto";
+import "schema.proto";
 
 service IndexCoord {
   rpc GetComponentStates(milvus.GetComponentStatesRequest) returns (milvus.ComponentStates) {}
@@ -215,18 +216,29 @@ message StorageConfig {
 }
 
 message CreateJobRequest {
-  string clusterID = 1;
-  string index_file_prefix = 2;
-  int64 buildID = 3;
-  repeated string data_paths = 4;
-  int64 index_version = 5;
-  int64 indexID = 6;
-  string index_name = 7;
-  StorageConfig storage_config = 8;
-  repeated common.KeyValuePair index_params = 9;
-  repeated common.KeyValuePair type_params = 10;
-  int64 num_rows = 11;
-  int32 current_index_version = 12;
+    string clusterID = 1;
+    string index_file_prefix = 2;
+    int64 buildID = 3;
+    repeated string data_paths = 4;
+    int64 index_version = 5;
+    int64 indexID = 6;
+    string index_name = 7;
+    StorageConfig storage_config = 8;
+    repeated common.KeyValuePair index_params = 9;
+    repeated common.KeyValuePair type_params = 10;
+    int64 num_rows = 11;
+    int32 current_index_version = 12;
+    int64 collectionID = 13;
+    int64 partitionID = 14;
+    int64 segmentID = 15;
+    int64 fieldID = 16;
+    string field_name = 17;
+    schema.DataType field_type = 18;
+    string store_path = 19;
+    int64 store_version = 20;
+    string index_store_path = 21;
+    int64 dim = 22;
+    repeated int64 data_ids = 23;
 }
 
 message QueryJobsRequest {

--- a/internal/querycoordv2/meta/coordinator_broker.go
+++ b/internal/querycoordv2/meta/coordinator_broker.go
@@ -25,7 +25,8 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
-	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	schemapb "github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/metastore/kv/binlog"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
 	"github.com/milvus-io/milvus/internal/proto/indexpb"
 	"github.com/milvus-io/milvus/internal/proto/querypb"
@@ -170,6 +171,12 @@ func (broker *CoordinatorBroker) GetSegmentInfo(ctx context.Context, ids ...Uniq
 	if len(resp.Infos) == 0 {
 		log.Warn("No such segment in DataCoord")
 		return nil, fmt.Errorf("no such segment in DataCoord")
+	}
+
+	err = binlog.DecompressMultiBinLogs(resp.GetInfos())
+	if err != nil {
+		log.Warn("failed to DecompressMultiBinLogs", zap.Error(err))
+		return nil, err
 	}
 
 	return resp, nil

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -854,6 +854,7 @@ func (loader *segmentLoader) patchEntryNumber(ctx context.Context, segment *Loca
 
 	counts := make([]int64, 0, len(rowIDField.GetBinlogs()))
 	for _, binlog := range rowIDField.GetBinlogs() {
+		// binlog.LogPath has already been filled
 		bs, err := loader.cm.Read(ctx, binlog.LogPath)
 		if err != nil {
 			return err

--- a/pkg/eventlog/mock_logger.go
+++ b/pkg/eventlog/mock_logger.go
@@ -130,8 +130,7 @@ func (_c *MockLogger_RecordFunc_Call) RunAndReturn(run func(Level, func() Evt)) 
 func NewMockLogger(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *MockLogger {
+}) *MockLogger {
 	mock := &MockLogger{}
 	mock.Mock.Test(t)
 

--- a/pkg/mq/msgdispatcher/mock_client.go
+++ b/pkg/mq/msgdispatcher/mock_client.go
@@ -153,8 +153,7 @@ func (_c *MockClient_Register_Call) RunAndReturn(run func(context.Context, strin
 func NewMockClient(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *MockClient {
+}) *MockClient {
 	mock := &MockClient{}
 	mock.Mock.Test(t)
 

--- a/pkg/mq/msgstream/mock_msgstream.go
+++ b/pkg/mq/msgstream/mock_msgstream.go
@@ -526,8 +526,7 @@ func (_c *MockMsgStream_SetRepackFunc_Call) RunAndReturn(run func(RepackFunc)) *
 func NewMockMsgStream(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *MockMsgStream {
+}) *MockMsgStream {
 	mock := &MockMsgStream{}
 	mock.Mock.Test(t)
 

--- a/tests/integration/bulkinsert/bulkinsert_test.go
+++ b/tests/integration/bulkinsert/bulkinsert_test.go
@@ -95,6 +95,9 @@ func (s *BulkInsertSuite) TestBulkInsert() {
 	s.Equal(showCollectionsResp.GetStatus().GetErrorCode(), commonpb.ErrorCode_Success)
 	log.Info("ShowCollections result", zap.Any("showCollectionsResp", showCollectionsResp))
 
+	err = os.MkdirAll(c.ChunkManager.RootPath(), os.ModePerm)
+	s.NoError(err)
+
 	err = GenerateNumpyFile(c.ChunkManager.RootPath()+"/"+"embeddings.npy", 100, schemapb.DataType_FloatVector, []*commonpb.KeyValuePair{
 		{
 			Key:   common.DimKey,


### PR DESCRIPTION
don't store logPath in meta to reduce memory, when service get segmentinfo, generate logpath from logid.
pr:#28873
issue:#28885
also contains #30127
#30279 #30164 will not happend in 2.3 branch.