### PR TITLE
fix: make milvus compilable using gcc-13

### DIFF
--- a/internal/core/src/config/ConfigKnowhere.h
+++ b/internal/core/src/config/ConfigKnowhere.h
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 #pragma once
+#include <cstdint>
 #include <string>
 
 namespace milvus::config {


### PR DESCRIPTION
add a missing header