### PR TITLE
enhance: Add open telemetry tracing for compaction

### DIFF
--- a/internal/datacoord/mock_session_manager.go
+++ b/internal/datacoord/mock_session_manager.go
@@ -241,13 +241,13 @@ func (_c *MockSessionManager_Close_Call) RunAndReturn(run func()) *MockSessionMa
 	return _c
 }
 
-// Compaction provides a mock function with given fields: nodeID, plan
-func (_m *MockSessionManager) Compaction(nodeID int64, plan *datapb.CompactionPlan) error {
-	ret := _m.Called(nodeID, plan)
+// Compaction provides a mock function with given fields: ctx, nodeID, plan
+func (_m *MockSessionManager) Compaction(ctx context.Context, nodeID int64, plan *datapb.CompactionPlan) error {
+	ret := _m.Called(ctx, nodeID, plan)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(int64, *datapb.CompactionPlan) error); ok {
-		r0 = rf(nodeID, plan)
+	if rf, ok := ret.Get(0).(func(context.Context, int64, *datapb.CompactionPlan) error); ok {
+		r0 = rf(ctx, nodeID, plan)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -261,15 +261,16 @@ type MockSessionManager_Compaction_Call struct {
 }
 
 // Compaction is a helper method to define mock.On call
+//   - ctx context.Context
 //   - nodeID int64
 //   - plan *datapb.CompactionPlan
-func (_e *MockSessionManager_Expecter) Compaction(nodeID interface{}, plan interface{}) *MockSessionManager_Compaction_Call {
-	return &MockSessionManager_Compaction_Call{Call: _e.mock.On("Compaction", nodeID, plan)}
+func (_e *MockSessionManager_Expecter) Compaction(ctx interface{}, nodeID interface{}, plan interface{}) *MockSessionManager_Compaction_Call {
+	return &MockSessionManager_Compaction_Call{Call: _e.mock.On("Compaction", ctx, nodeID, plan)}
 }
 
-func (_c *MockSessionManager_Compaction_Call) Run(run func(nodeID int64, plan *datapb.CompactionPlan)) *MockSessionManager_Compaction_Call {
+func (_c *MockSessionManager_Compaction_Call) Run(run func(ctx context.Context, nodeID int64, plan *datapb.CompactionPlan)) *MockSessionManager_Compaction_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(int64), args[1].(*datapb.CompactionPlan))
+		run(args[0].(context.Context), args[1].(int64), args[2].(*datapb.CompactionPlan))
 	})
 	return _c
 }
@@ -279,7 +280,7 @@ func (_c *MockSessionManager_Compaction_Call) Return(_a0 error) *MockSessionMana
 	return _c
 }
 
-func (_c *MockSessionManager_Compaction_Call) RunAndReturn(run func(int64, *datapb.CompactionPlan) error) *MockSessionManager_Compaction_Call {
+func (_c *MockSessionManager_Compaction_Call) RunAndReturn(run func(context.Context, int64, *datapb.CompactionPlan) error) *MockSessionManager_Compaction_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/datacoord/session_manager.go
+++ b/internal/datacoord/session_manager.go
@@ -55,7 +55,7 @@ type SessionManager interface {
 
 	Flush(ctx context.Context, nodeID int64, req *datapb.FlushSegmentsRequest)
 	FlushChannels(ctx context.Context, nodeID int64, req *datapb.FlushChannelsRequest) error
-	Compaction(nodeID int64, plan *datapb.CompactionPlan) error
+	Compaction(ctx context.Context, nodeID int64, plan *datapb.CompactionPlan) error
 	SyncSegments(nodeID int64, req *datapb.SyncSegmentsRequest) error
 	Import(ctx context.Context, nodeID int64, itr *datapb.ImportTaskRequest)
 	GetCompactionPlansResults() map[int64]*datapb.CompactionPlanResult
@@ -186,8 +186,8 @@ func (c *SessionManagerImpl) execFlush(ctx context.Context, nodeID int64, req *d
 }
 
 // Compaction is a grpc interface. It will send request to DataNode with provided `nodeID` synchronously.
-func (c *SessionManagerImpl) Compaction(nodeID int64, plan *datapb.CompactionPlan) error {
-	ctx, cancel := context.WithTimeout(context.Background(), Params.DataCoordCfg.CompactionRPCTimeout.GetAsDuration(time.Second))
+func (c *SessionManagerImpl) Compaction(ctx context.Context, nodeID int64, plan *datapb.CompactionPlan) error {
+	ctx, cancel := context.WithTimeout(ctx, Params.DataCoordCfg.CompactionRPCTimeout.GetAsDuration(time.Second))
 	defer cancel()
 	cli, err := c.getClient(ctx, nodeID)
 	if err != nil {

--- a/internal/datanode/binlog_io.go
+++ b/internal/datanode/binlog_io.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
+	"go.opentelemetry.io/otel"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/internal/datanode/allocator"
@@ -33,6 +34,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/util/conc"
 	"github.com/milvus-io/milvus/pkg/util/metautil"
+	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
 
 var (
@@ -72,6 +74,8 @@ var (
 )
 
 func (b *binlogIO) download(ctx context.Context, paths []string) ([]*Blob, error) {
+	ctx, span := otel.Tracer(typeutil.DataNodeRole).Start(ctx, "download")
+	defer span.End()
 	log.Debug("down load", zap.Strings("path", paths))
 	resp := make([]*Blob, len(paths))
 	if len(paths) == 0 {
@@ -248,6 +252,8 @@ func (b *binlogIO) uploadStatsLog(
 	totRows int64,
 	meta *etcdpb.CollectionMeta,
 ) (map[UniqueID]*datapb.FieldBinlog, map[UniqueID]*datapb.FieldBinlog, error) {
+	ctx, span := otel.Tracer(typeutil.DataNodeRole).Start(ctx, "UploadStatslog")
+	defer span.End()
 	var inPaths map[int64]*datapb.FieldBinlog
 	var err error
 
@@ -285,6 +291,8 @@ func (b *binlogIO) uploadInsertLog(
 	iData *InsertData,
 	meta *etcdpb.CollectionMeta,
 ) (map[UniqueID]*datapb.FieldBinlog, error) {
+	ctx, span := otel.Tracer(typeutil.DataNodeRole).Start(ctx, "UploadInsertLog")
+	defer span.End()
 	iCodec := storage.NewInsertCodecWithSchema(meta)
 	kvs := make(map[string][]byte)
 
@@ -316,6 +324,8 @@ func (b *binlogIO) uploadDeltaLog(
 	dData *DeleteData,
 	meta *etcdpb.CollectionMeta,
 ) ([]*datapb.FieldBinlog, error) {
+	ctx, span := otel.Tracer(typeutil.DataNodeRole).Start(ctx, "UploadDeltaLog")
+	defer span.End()
 	var (
 		deltaInfo = make([]*datapb.FieldBinlog, 0)
 		kvs       = make(map[string][]byte)

--- a/internal/datanode/compactor.go
+++ b/internal/datanode/compactor.go
@@ -430,7 +430,6 @@ func (t *compactionTask) merge(
 }
 
 func (t *compactionTask) compact() (*datapb.CompactionPlanResult, error) {
-	// span := trace.
 	ctx, span := otel.Tracer(typeutil.DataNodeRole).Start(t.ctx, fmt.Sprintf("Compact-%d", t.getPlanID()))
 	defer span.End()
 	log := log.With(zap.Int64("planID", t.plan.GetPlanID()))

--- a/internal/datanode/l0_compactor.go
+++ b/internal/datanode/l0_compactor.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/samber/lo"
+	"go.opentelemetry.io/otel"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
@@ -40,6 +41,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/util/metautil"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/util/timerecord"
+	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
 
 type levelZeroCompactionTask struct {
@@ -107,15 +109,17 @@ func (t *levelZeroCompactionTask) getCollection() int64 {
 func (t *levelZeroCompactionTask) injectDone() {}
 
 func (t *levelZeroCompactionTask) compact() (*datapb.CompactionPlanResult, error) {
+	ctx, span := otel.Tracer(typeutil.DataNodeRole).Start(t.ctx, "L0Compact")
+	defer span.End()
 	log := log.With(zap.Int64("planID", t.plan.GetPlanID()), zap.String("type", t.plan.GetType().String()))
 	log.Info("L0 compaction", zap.Duration("wait in queue elapse", t.tr.RecordSpan()))
 
-	if !funcutil.CheckCtxValid(t.ctx) {
+	if !funcutil.CheckCtxValid(ctx) {
 		log.Warn("compact wrong, task context done or timeout")
 		return nil, errContext
 	}
 
-	ctxTimeout, cancelAll := context.WithTimeout(t.ctx, time.Duration(t.plan.GetTimeoutInSeconds())*time.Second)
+	ctxTimeout, cancelAll := context.WithTimeout(ctx, time.Duration(t.plan.GetTimeoutInSeconds())*time.Second)
 	defer cancelAll()
 
 	l0Segments := lo.Filter(t.plan.GetSegmentBinlogs(), func(s *datapb.CompactionSegmentBinlogs, _ int) bool {


### PR DESCRIPTION
Resolves #30167

This PR add tracing for all compaction from the task start in datacoord and execution procedures in datanode.