### PR TITLE
fix:diskann search crash when search list = 9999999999

### DIFF
--- a/internal/core/src/index/VectorDiskIndex.cpp
+++ b/internal/core/src/index/VectorDiskIndex.cpp
@@ -310,13 +310,11 @@ VectorDiskAnnIndex<T>::Query(const DatasetPtr dataset,
     search_config[knowhere::meta::TOPK] = topk;
     search_config[knowhere::meta::METRIC_TYPE] = GetMetricType();
 
-    // set search list size
-    auto search_list_size = GetValueFromConfig<uint32_t>(
-        search_info.search_params_, DISK_ANN_QUERY_LIST);
-
     if (GetIndexType() == knowhere::IndexEnum::INDEX_DISKANN) {
-        if (search_list_size.has_value()) {
-            search_config[DISK_ANN_SEARCH_LIST_SIZE] = search_list_size.value();
+        // set search list size
+        if (CheckKeyInConfig(search_info.search_params_, DISK_ANN_QUERY_LIST)) {
+            search_config[DISK_ANN_SEARCH_LIST_SIZE] =
+                search_info.search_params_[DISK_ANN_QUERY_LIST];
         }
         // set beamwidth
         search_config[DISK_ANN_QUERY_BEAMWIDTH] = int(search_beamwidth_);


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/29020
Json can't not pass a max_int32 value to int32_t, so let knowhere check value range by itself.
After fix this, pymilvus will report:
pymilvus.exceptions.MilvusException: <MilvusException: (code=65535, message=fail to search on QueryNode 6: worker(6) query failed:  => failed to search: arithmetic overflow: param search_list_size should be at most 2147483647)>