### PR TITLE
enhance: [2.3] make Load process traceable in querynode & segcore

### DIFF
--- a/internal/core/src/common/Tracer.cpp
+++ b/internal/core/src/common/Tracer.cpp
@@ -85,7 +85,7 @@ GetTracer() {
 }
 
 std::shared_ptr<trace::Span>
-StartSpan(std::string name, TraceContext* parentCtx) {
+StartSpan(const std::string& name, TraceContext* parentCtx) {
     trace::StartSpanOptions opts;
     if (enable_trace && parentCtx != nullptr && parentCtx->traceID != nullptr &&
         parentCtx->spanID != nullptr) {

--- a/internal/core/src/common/Tracer.h
+++ b/internal/core/src/common/Tracer.h
@@ -9,6 +9,8 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
+#pragma once
+
 #include <memory>
 #include <string>
 
@@ -41,7 +43,7 @@ std::shared_ptr<trace::Tracer>
 GetTracer();
 
 std::shared_ptr<trace::Span>
-StartSpan(std::string name, TraceContext* ctx = nullptr);
+StartSpan(const std::string& name, TraceContext* ctx = nullptr);
 
 void
 SetRootSpan(std::shared_ptr<trace::Span> span);

--- a/internal/core/src/index/Index.h
+++ b/internal/core/src/index/Index.h
@@ -21,6 +21,7 @@
 #include "common/EasyAssert.h"
 #include "knowhere/comp/index_param.h"
 #include "knowhere/dataset.h"
+#include "common/Tracer.h"
 #include "common/Types.h"
 
 const std::string kMmapFilepath = "mmap_filepath";
@@ -40,7 +41,7 @@ class IndexBase {
     Load(const BinarySet& binary_set, const Config& config = {}) = 0;
 
     virtual void
-    Load(const Config& config = {}) = 0;
+    Load(milvus::tracer::TraceContext ctx, const Config& config = {}) = 0;
 
     virtual void
     BuildWithRawData(size_t n,

--- a/internal/core/src/index/ScalarIndexSort-inl.h
+++ b/internal/core/src/index/ScalarIndexSort-inl.h
@@ -166,7 +166,8 @@ ScalarIndexSort<T>::Load(const BinarySet& index_binary, const Config& config) {
 
 template <typename T>
 inline void
-ScalarIndexSort<T>::Load(const Config& config) {
+ScalarIndexSort<T>::Load(milvus::tracer::TraceContext ctx,
+                         const Config& config) {
     auto index_files =
         GetValueFromConfig<std::vector<std::string>>(config, "index_files");
     AssertInfo(index_files.has_value(),

--- a/internal/core/src/index/ScalarIndexSort.h
+++ b/internal/core/src/index/ScalarIndexSort.h
@@ -43,7 +43,7 @@ class ScalarIndexSort : public ScalarIndex<T> {
     Load(const BinarySet& index_binary, const Config& config = {}) override;
 
     void
-    Load(const Config& config = {}) override;
+    Load(milvus::tracer::TraceContext ctx, const Config& config = {}) override;
 
     int64_t
     Count() override {

--- a/internal/core/src/index/StringIndexMarisa.cpp
+++ b/internal/core/src/index/StringIndexMarisa.cpp
@@ -202,7 +202,8 @@ StringIndexMarisa::Load(const BinarySet& set, const Config& config) {
 }
 
 void
-StringIndexMarisa::Load(const Config& config) {
+StringIndexMarisa::Load(milvus::tracer::TraceContext ctx,
+                        const Config& config) {
     auto index_files =
         GetValueFromConfig<std::vector<std::string>>(config, "index_files");
     AssertInfo(index_files.has_value(),

--- a/internal/core/src/index/StringIndexMarisa.h
+++ b/internal/core/src/index/StringIndexMarisa.h
@@ -42,7 +42,7 @@ class StringIndexMarisa : public StringIndex {
     Load(const BinarySet& set, const Config& config = {}) override;
 
     void
-    Load(const Config& config = {}) override;
+    Load(milvus::tracer::TraceContext ctx, const Config& config = {}) override;
 
     int64_t
     Count() override {

--- a/internal/core/src/index/VectorDiskIndex.h
+++ b/internal/core/src/index/VectorDiskIndex.h
@@ -57,7 +57,7 @@ class VectorDiskAnnIndex : public VectorIndex {
          const Config& config = {}) override;
 
     void
-    Load(const Config& config = {}) override;
+    Load(milvus::tracer::TraceContext ctx, const Config& config = {}) override;
 
     void
     BuildWithDataset(const DatasetPtr& dataset,

--- a/internal/core/src/index/VectorMemIndex.h
+++ b/internal/core/src/index/VectorMemIndex.h
@@ -43,7 +43,7 @@ class VectorMemIndex : public VectorIndex {
     Load(const BinarySet& binary_set, const Config& config = {}) override;
 
     void
-    Load(const Config& config = {}) override;
+    Load(milvus::tracer::TraceContext ctx, const Config& config = {}) override;
 
     void
     BuildWithDataset(const DatasetPtr& dataset,

--- a/internal/core/src/segcore/load_index_c.h
+++ b/internal/core/src/segcore/load_index_c.h
@@ -56,7 +56,7 @@ CStatus
 AppendIndexFilePath(CLoadIndexInfo c_load_index_info, const char* file_path);
 
 CStatus
-AppendIndexV2(CLoadIndexInfo c_load_index_info);
+AppendIndexV2(CTraceContext c_trace, CLoadIndexInfo c_load_index_info);
 
 CStatus
 AppendIndexEngineVersionToLoadInfo(CLoadIndexInfo c_load_index_info,

--- a/internal/core/unittest/test_indexing.cpp
+++ b/internal/core/unittest/test_indexing.cpp
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include "common/EasyAssert.h"
+#include "common/Tracer.h"
 #include "common/Types.h"
 #include "knowhere/comp/index_param.h"
 #include "nlohmann/json.hpp"
@@ -418,7 +419,7 @@ TEST_P(IndexTest, BuildAndQuery) {
     }
     load_conf = generate_load_conf(index_type, metric_type, 0);
     load_conf["index_files"] = index_files;
-    ASSERT_NO_THROW(vec_index->Load(load_conf));
+    ASSERT_NO_THROW(vec_index->Load(milvus::tracer::TraceContext{}, load_conf));
     EXPECT_EQ(vec_index->Count(), NB);
     EXPECT_EQ(vec_index->GetDim(), DIM);
 
@@ -476,7 +477,7 @@ TEST_P(IndexTest, Mmap) {
     load_conf = generate_load_conf(index_type, metric_type, 0);
     load_conf["index_files"] = index_files;
     load_conf["mmap_filepath"] = "mmap/test_index_mmap_" + index_type;
-    vec_index->Load(load_conf);
+    vec_index->Load(milvus::tracer::TraceContext{}, load_conf);
     EXPECT_EQ(vec_index->Count(), NB);
     EXPECT_EQ(vec_index->GetDim(), DIM);
 
@@ -533,7 +534,7 @@ TEST_P(IndexTest, GetVector) {
         vec_index->Load(binary_set, load_conf);
         EXPECT_EQ(vec_index->Count(), NB);
     } else {
-        vec_index->Load(load_conf);
+        vec_index->Load(milvus::tracer::TraceContext{}, load_conf);
     }
     EXPECT_EQ(vec_index->GetDim(), DIM);
     EXPECT_EQ(vec_index->Count(), NB);
@@ -630,7 +631,7 @@ TEST(Indexing, SearchDiskAnnWithInvalidParam) {
     }
     auto load_conf = generate_load_conf(index_type, metric_type, NB);
     load_conf["index_files"] = index_files;
-    vec_index->Load(load_conf);
+    vec_index->Load(milvus::tracer::TraceContext{}, load_conf);
     EXPECT_EQ(vec_index->Count(), NB);
 
     // search disk index with search_list == limit

--- a/internal/core/unittest/test_utils/DataGen.h
+++ b/internal/core/unittest/test_utils/DataGen.h
@@ -932,7 +932,7 @@ GenVecIndexing(int64_t N, int64_t dim, const float* vec) {
     conf["index_files"] = index_files;
     // we need a load stage to use index as the producation does
     // knowhere would do some data preparation in this stage
-    indexing->Load(conf);
+    indexing->Load(milvus::tracer::TraceContext{}, conf);
     return indexing;
 }
 

--- a/internal/querynodev2/segments/load_index_info.go
+++ b/internal/querynodev2/segments/load_index_info.go
@@ -28,13 +28,14 @@ import (
 	"context"
 	"unsafe"
 
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/util/indexparamcheck"
 	"github.com/milvus-io/milvus/pkg/util/indexparams"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
-	"go.opentelemetry.io/otel/trace"
 )
 
 // LoadIndexInfo is a wrapper of the underlying C-structure C.CLoadIndexInfo

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/golang/protobuf/proto"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
@@ -672,6 +673,8 @@ func (s *LocalSegment) LoadMultiFieldData(ctx context.Context, rowCount int64, f
 func (s *LocalSegment) LoadFieldData(ctx context.Context, fieldID int64, rowCount int64, field *datapb.FieldBinlog) error {
 	s.ptrLock.RLock()
 	defer s.ptrLock.RUnlock()
+	ctx, sp := otel.Tracer(typeutil.QueryNodeRole).Start(ctx, fmt.Sprintf("LoadFieldData-%d-%d", s.segmentID, fieldID))
+	defer sp.End()
 
 	if s.ptr == nil {
 		return merr.WrapErrSegmentNotLoaded(s.segmentID, "segment released")
@@ -859,6 +862,9 @@ func (s *LocalSegment) LoadDeltaData(ctx context.Context, deltaData *storage.Del
 }
 
 func (s *LocalSegment) LoadIndex(ctx context.Context, indexInfo *querypb.FieldIndexInfo, fieldType schemapb.DataType) error {
+	ctx, sp := otel.Tracer(typeutil.QueryNodeRole).Start(ctx, fmt.Sprintf("LoadIndex-%d-%d", s.segmentID, indexInfo.GetFieldID()))
+	defer sp.End()
+
 	log := log.Ctx(ctx).With(
 		zap.Int64("collectionID", s.Collection()),
 		zap.Int64("partitionID", s.Partition()),

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -38,6 +38,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
+	"go.opentelemetry.io/otel"
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
@@ -788,6 +789,9 @@ func (loader *segmentLoader) loadBloomFilter(ctx context.Context, segmentID int6
 }
 
 func (loader *segmentLoader) LoadDeltaLogs(ctx context.Context, segment *LocalSegment, deltaLogs []*datapb.FieldBinlog) error {
+	ctx, sp := otel.Tracer(typeutil.QueryNodeRole).Start(ctx, fmt.Sprintf("LoadDeltalogs-%d", segment.ID()))
+	defer sp.End()
+
 	log := log.Ctx(ctx).With(
 		zap.Int64("segmentID", segment.ID()),
 	)


### PR DESCRIPTION
Cherry-pick from master, modified some files since branching
pr: #29858
See also #29803

This PR:
- Add trace span for LoadIndex & LoadFieldData in segment loader
- Add TraceCtx parameter for Index.Load in segcore
- Add span for ReadFiles & Engine Load for Memory/Disk Vector index