### PR TITLE
enhance: add index after load succeeded (#30015)

### DIFF
--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -287,7 +287,7 @@ func (s *LocalSegment) LastDeltaTimestamp() uint64 {
 	return s.lastDeltaTimestamp.Load()
 }
 
-func (s *LocalSegment) AddIndex(fieldID int64, info *IndexedFieldInfo) {
+func (s *LocalSegment) addIndex(fieldID int64, info *IndexedFieldInfo) {
 	s.fieldIndexes.Insert(fieldID, info)
 }
 
@@ -942,6 +942,13 @@ func (s *LocalSegment) UpdateIndexInfo(ctx context.Context, indexInfo *querypb.F
 		zap.Int64("fieldID", indexInfo.FieldID)); err != nil {
 		return err
 	}
+
+	s.addIndex(indexInfo.GetFieldID(), &IndexedFieldInfo{
+		FieldBinlog: &datapb.FieldBinlog{
+			FieldID: indexInfo.GetFieldID(),
+		},
+		IndexInfo: indexInfo,
+	})
 	log.Info("updateSegmentIndex done")
 	return nil
 }

--- a/internal/querynodev2/segments/segment_interface.go
+++ b/internal/querynodev2/segments/segment_interface.go
@@ -46,7 +46,6 @@ type Segment interface {
 	MemSize() int64
 
 	// Index related
-	AddIndex(fieldID int64, index *IndexedFieldInfo)
 	GetIndex(fieldID int64) *IndexedFieldInfo
 	ExistIndex(fieldID int64) bool
 	Indexes() []*IndexedFieldInfo

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -702,8 +702,6 @@ func (loader *segmentLoader) loadFieldsIndex(ctx context.Context,
 			zap.Int32("current_index_version", fieldInfo.IndexInfo.GetCurrentIndexVersion()),
 		)
 
-		segment.AddIndex(fieldID, fieldInfo)
-
 		// set average row data size of variable field
 		field, err := schemaHelper.GetFieldFromID(fieldID)
 		if err != nil {
@@ -1109,17 +1107,13 @@ func (loader *segmentLoader) LoadIndex(ctx context.Context, segment *LocalSegmen
 
 			fieldInfo, ok := fieldInfos[info.GetFieldID()]
 			if !ok {
-				return merr.WrapErrParameterInvalid("index info with corresponding  field info", "missing field info", strconv.FormatInt(fieldInfo.GetFieldID(), 10))
+				return merr.WrapErrParameterInvalid("index info with corresponding field info", "missing field info", strconv.FormatInt(fieldInfo.GetFieldID(), 10))
 			}
 			err := loader.loadFieldIndex(ctx, segment, info)
 			if err != nil {
 				log.Warn("failed to load index for segment", zap.Error(err))
 				return err
 			}
-			segment.AddIndex(info.FieldID, &IndexedFieldInfo{
-				IndexInfo:   info,
-				FieldBinlog: fieldInfo,
-			})
 		}
 		loader.notifyLoadFinish(loadInfo)
 	}


### PR DESCRIPTION
this avoids a corner case: after load index failed, this index can be never loaded as it has been added into the segment's index map

pr: #30015