### PR TITLE
fix: written file size is over the int32 range and raises error (#30057)

### DIFF
--- a/internal/core/src/segcore/SegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/SegmentSealedImpl.cpp
@@ -412,18 +412,21 @@ SegmentSealedImpl::MapFieldData(const FieldId field_id, FieldDataInfo& data) {
     auto data_type = field_meta.get_data_type();
 
     // write the field data to disk
-    size_t total_written{0};
-    auto data_size = 0;
     std::vector<uint64_t> indices{};
     std::vector<std::vector<uint64_t>> element_indices{};
     storage::FieldDataPtr field_data;
+    size_t total_written = 0;
     while (data.channel->pop(field_data)) {
-        data_size += field_data->Size();
         auto written =
             WriteFieldData(file, data_type, field_data, element_indices);
-        if (written != field_data->Size()) {
-            break;
-        }
+
+        AssertInfo(written == field_data->Size(),
+                   fmt::format("failed to write data file {}, written {} but "
+                               "total {}, err: {}",
+                               filepath.c_str(),
+                               written,
+                               field_data->Size(),
+                               strerror(errno)));
 
         for (auto i = 0; i < field_data->get_num_rows(); i++) {
             auto size = field_data->Size(i);
@@ -431,14 +434,6 @@ SegmentSealedImpl::MapFieldData(const FieldId field_id, FieldDataInfo& data) {
             total_written += size;
         }
     }
-    AssertInfo(
-        total_written == data_size,
-        fmt::format(
-            "failed to write data file {}, written {} but total {}, err: {}",
-            filepath.c_str(),
-            total_written,
-            data_size,
-            strerror(errno)));
 
     auto num_rows = data.row_count;
     std::shared_ptr<ColumnBase> column{};


### PR DESCRIPTION
we sum the total data size in int32, which could lead to an overflow error
related #30056

pr: #30057 