### PR TITLE
fix: Init paramtable after milvus role setup

### DIFF
--- a/cmd/milvus/help.go
+++ b/cmd/milvus/help.go
@@ -8,8 +8,7 @@ import (
 )
 
 const (
-	RunCmd      = "run"
-	RoleMixture = "mixture"
+	RunCmd = "run"
 )
 
 var (

--- a/cmd/milvus/run.go
+++ b/cmd/milvus/run.go
@@ -13,14 +13,9 @@ import (
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/util/hardware"
 	"github.com/milvus-io/milvus/pkg/util/metricsinfo"
-	"github.com/milvus-io/milvus/pkg/util/paramtable"
 )
 
 type run struct{}
-
-func init() {
-	paramtable.Init()
-}
 
 func (c *run) execute(args []string, flags *flag.FlagSet) {
 	if len(args) < 3 {

--- a/cmd/milvus/util.go
+++ b/cmd/milvus/util.go
@@ -24,7 +24,6 @@ import (
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/util/etcd"
 	"github.com/milvus-io/milvus/pkg/util/hardware"
-	"github.com/milvus-io/milvus/pkg/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
 
@@ -158,7 +157,7 @@ func GetMilvusRoles(args []string, flags *flag.FlagSet) *roles.MilvusRoles {
 		role.EnableIndexNode = true
 		role.Local = true
 		role.Embedded = serverType == typeutil.EmbeddedRole
-	case RoleMixture:
+	case typeutil.MixtureRole:
 		role.EnableRootCoord = enableRootCoord
 		role.EnableQueryCoord = enableQueryCoord
 		role.EnableDataCoord = enableDataCoord
@@ -167,12 +166,12 @@ func GetMilvusRoles(args []string, flags *flag.FlagSet) *roles.MilvusRoles {
 		role.EnableDataNode = enableDataNode
 		role.EnableIndexNode = enableIndexNode
 		role.EnableProxy = enableProxy
+		role.Mixture = true
 	default:
 		fmt.Fprintf(os.Stderr, "Unknown server type = %s\n%s", serverType, getHelp())
 		os.Exit(-1)
 	}
 
-	paramtable.SetRole(serverType)
 	return role
 }
 

--- a/cmd/roles/roles.go
+++ b/cmd/roles/roles.go
@@ -137,6 +137,7 @@ type MilvusRoles struct {
 	Local    bool
 	Alias    string
 	Embedded bool
+	Mixture  bool
 
 	closed chan struct{}
 	once   sync.Once
@@ -333,6 +334,9 @@ func (mr *MilvusRoles) Run() {
 			log.Error("Failed to set deploy mode: ", zap.Error(err))
 		}
 		paramtable.Init()
+		if mr.Mixture {
+			paramtable.SetRole(typeutil.MixtureRole)
+		}
 	}
 
 	expr.Init()

--- a/pkg/util/typeutil/type.go
+++ b/pkg/util/typeutil/type.go
@@ -46,6 +46,8 @@ const (
 	DataNodeRole = "datanode"
 	// IndexNodeRole is a constant represent IndexNode
 	IndexNodeRole = "indexnode"
+	// MixtureRole is a constant represents Mixture running modtoe
+	MixtureRole = "mixture"
 )
 
 var (


### PR DESCRIPTION
See also #30176

Move paramtable.Init after env setup in roles.Run. Also introduced a flag for mixture run to set role correctly for mixture mode.