### PR TITLE
fix: empty MetricType

### DIFF
--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -976,7 +976,7 @@ func buildQueryResp(rowsNum int64, needFields []string, fieldDataList []*schemap
 			}
 		}
 		if scores != nil && int64(len(scores)) > i {
-			row[HTTPReturnDistance] = scores[i]
+			row[HTTPReturnDistance] = scores[i] // only 8 decimal places
 		}
 		queryResp = append(queryResp, row)
 	}

--- a/internal/proxy/accesslog/util.go
+++ b/internal/proxy/accesslog/util.go
@@ -72,7 +72,7 @@ func getCurUserFromContext(ctx context.Context) (string, error) {
 	}
 	authorization, ok := md[strings.ToLower(util.HeaderAuthorize)]
 	if !ok || len(authorization) < 1 {
-		return "", fmt.Errorf("fail to get authorization from the md, authorize:[%s]", util.HeaderAuthorize)
+		return "", fmt.Errorf("fail to get authorization from the md, %s:[token]", strings.ToLower(util.HeaderAuthorize))
 	}
 	token := authorization[0]
 	rawToken, err := crypto.Base64Decode(token)

--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -1689,6 +1689,10 @@ func (node *Proxy) GetLoadState(ctx context.Context, request *milvuspb.GetLoadSt
 
 	collectionID, err := globalMetaCache.GetCollectionID(ctx, request.GetDbName(), request.CollectionName)
 	if err != nil {
+		log.Warn("failed to get collection id",
+			zap.String("dbName", request.GetDbName()),
+			zap.String("collectionName", request.CollectionName),
+			zap.Error(err))
 		successResponse.State = commonpb.LoadState_LoadStateNotExist
 		return successResponse, nil
 	}

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -876,7 +876,7 @@ func GetCurUserFromContext(ctx context.Context) (string, error) {
 	}
 	authorization, ok := md[strings.ToLower(util.HeaderAuthorize)]
 	if !ok || len(authorization) < 1 {
-		return "", fmt.Errorf("fail to get authorization from the md, authorize:[%s]", util.HeaderAuthorize)
+		return "", fmt.Errorf("fail to get authorization from the md, %s:[token]", strings.ToLower(util.HeaderAuthorize))
 	}
 	token := authorization[0]
 	rawToken, err := crypto.Base64Decode(token)

--- a/internal/querynodev2/segments/plan.go
+++ b/internal/querynodev2/segments/plan.go
@@ -68,7 +68,7 @@ func (plan *SearchPlan) setMetricType(metricType string) {
 	C.SetMetricType(plan.cSearchPlan, cmt)
 }
 
-func (plan *SearchPlan) getMetricType() string {
+func (plan *SearchPlan) GetMetricType() string {
 	cMetricType := C.GetMetricType(plan.cSearchPlan)
 	defer C.free(unsafe.Pointer(cMetricType))
 	metricType := C.GoString(cMetricType)
@@ -110,7 +110,7 @@ func NewSearchRequest(ctx context.Context, collection *Collection, req *querypb.
 		return nil, err
 	}
 
-	metricTypeInPlan := plan.getMetricType()
+	metricTypeInPlan := plan.GetMetricType()
 	if len(metricType) != 0 && metricType != metricTypeInPlan {
 		plan.delete()
 		return nil, merr.WrapErrParameterInvalid(metricTypeInPlan, metricType, "metric type not match")

--- a/internal/querynodev2/segments/result.go
+++ b/internal/querynodev2/segments/result.go
@@ -54,6 +54,10 @@ func ReduceSearchResults(ctx context.Context, results []*internalpb.SearchResult
 		for ch, ts := range r.GetChannelsMvcc() {
 			channelsMvcc[ch] = ts
 		}
+		// shouldn't let new SearchResults.MetricType to be empty, though the req.MetricType is empty
+		if metricType == "" {
+			metricType = r.MetricType
+		}
 	}
 	log := log.Ctx(ctx)
 

--- a/internal/querynodev2/tasks/task.go
+++ b/internal/querynodev2/tasks/task.go
@@ -166,6 +166,9 @@ func (t *SearchTask) Execute() error {
 	}
 	defer segments.DeleteSearchResults(results)
 
+	// plan.MetricType is accurate, though req.MetricType may be empty
+	metricType := searchReq.Plan().GetMetricType()
+
 	if len(results) == 0 {
 		for i := range t.originNqs {
 			var task *SearchTask
@@ -180,7 +183,7 @@ func (t *SearchTask) Execute() error {
 					SourceID: paramtable.GetNodeID(),
 				},
 				Status:         merr.Success(),
-				MetricType:     req.GetReq().GetMetricType(),
+				MetricType:     metricType,
 				NumQueries:     t.originNqs[i],
 				TopK:           t.originTopks[i],
 				SlicedOffset:   1,
@@ -234,7 +237,7 @@ func (t *SearchTask) Execute() error {
 				SourceID: paramtable.GetNodeID(),
 			},
 			Status:         merr.Success(),
-			MetricType:     req.GetReq().GetMetricType(),
+			MetricType:     metricType,
 			NumQueries:     t.originNqs[i],
 			TopK:           t.originTopks[i],
 			SlicedBlob:     bs,


### PR DESCRIPTION
issue: #30102 #30225

we should read MetricType from SearchResult,
because query node never
1. read metricType from LoadMeta
2. store to collection
3. set SearchRequest.MetricType