### PR TITLE
fix: prevent segments got flushed multiple times

### DIFF
--- a/internal/datanode/writebuffer/bf_write_buffer_test.go
+++ b/internal/datanode/writebuffer/bf_write_buffer_test.go
@@ -313,7 +313,7 @@ func (s *BFWriteBufferSuite) TestAutoSync() {
 			syncPolicies: []SyncPolicy{
 				GetFullBufferPolicy(),
 				GetSyncStaleBufferPolicy(paramtable.Get().DataNodeCfg.SyncPeriod.GetAsDuration(time.Second)),
-				GetFlushingSegmentsPolicy(s.metacacheInt64),
+				GetSealedSegmentsPolicy(s.metacacheInt64),
 			},
 		})
 		s.NoError(err)
@@ -394,7 +394,7 @@ func (s *BFWriteBufferSuite) TestAutoSyncWithStorageV2() {
 			syncPolicies: []SyncPolicy{
 				GetFullBufferPolicy(),
 				GetSyncStaleBufferPolicy(paramtable.Get().DataNodeCfg.SyncPeriod.GetAsDuration(time.Second)),
-				GetFlushingSegmentsPolicy(s.metacacheInt64),
+				GetSealedSegmentsPolicy(s.metacacheInt64),
 			},
 		})
 		s.NoError(err)

--- a/internal/datanode/writebuffer/options.go
+++ b/internal/datanode/writebuffer/options.go
@@ -41,7 +41,7 @@ func defaultWBOption(metacache metacache.MetaCache) *writeBufferOption {
 			GetFullBufferPolicy(),
 			GetSyncStaleBufferPolicy(paramtable.Get().DataNodeCfg.SyncPeriod.GetAsDuration(time.Second)),
 			GetCompactedSegmentsPolicy(metacache),
-			GetFlushingSegmentsPolicy(metacache),
+			GetSealedSegmentsPolicy(metacache),
 		},
 	}
 }

--- a/internal/datanode/writebuffer/sync_policy_test.go
+++ b/internal/datanode/writebuffer/sync_policy_test.go
@@ -73,11 +73,12 @@ func (s *SyncPolicySuite) TestSyncStalePolicy() {
 	s.Equal(0, len(ids), "")
 }
 
-func (s *SyncPolicySuite) TestFlushingSegmentsPolicy() {
+func (s *SyncPolicySuite) TestSealedSegmentsPolicy() {
 	metacache := metacache.NewMockMetaCache(s.T())
-	policy := GetFlushingSegmentsPolicy(metacache)
+	policy := GetSealedSegmentsPolicy(metacache)
 	ids := []int64{1, 2, 3}
 	metacache.EXPECT().GetSegmentIDsBy(mock.Anything).Return(ids)
+	metacache.EXPECT().UpdateSegments(mock.Anything, mock.Anything, mock.Anything).Return()
 
 	result := policy.SelectSegments([]*segmentBuffer{}, tsoutil.ComposeTSByTime(time.Now(), 0))
 	s.ElementsMatch(ids, result)

--- a/internal/datanode/writebuffer/write_buffer.go
+++ b/internal/datanode/writebuffer/write_buffer.go
@@ -151,7 +151,7 @@ func (wb *writeBufferBase) FlushSegments(ctx context.Context, segmentIDs []int64
 	wb.mut.RLock()
 	defer wb.mut.RUnlock()
 
-	return wb.flushSegments(ctx, segmentIDs)
+	return wb.sealSegments(ctx, segmentIDs)
 }
 
 func (wb *writeBufferBase) SetFlushTimestamp(flushTs uint64) {
@@ -250,13 +250,13 @@ func (wb *writeBufferBase) cleanupCompactedSegments() {
 	}
 }
 
-func (wb *writeBufferBase) flushSegments(ctx context.Context, segmentIDs []int64) error {
+func (wb *writeBufferBase) sealSegments(ctx context.Context, segmentIDs []int64) error {
 	// mark segment flushing if segment was growing
-	wb.metaCache.UpdateSegments(metacache.UpdateState(commonpb.SegmentState_Flushing),
+	wb.metaCache.UpdateSegments(metacache.UpdateState(commonpb.SegmentState_Sealed),
 		metacache.WithSegmentIDs(segmentIDs...),
 		metacache.WithSegmentState(commonpb.SegmentState_Growing))
 	// mark segment flushing if segment was importing
-	wb.metaCache.UpdateSegments(metacache.UpdateState(commonpb.SegmentState_Flushing),
+	wb.metaCache.UpdateSegments(metacache.UpdateState(commonpb.SegmentState_Sealed),
 		metacache.WithSegmentIDs(segmentIDs...),
 		metacache.WithImporting())
 	return nil


### PR DESCRIPTION
See also #30111

Segments could be "Flushed" only by `FlushSegments` grpc call from datacoord by design. There are two possible reason to cause one segment got flushed multiple times.

- Segment is in flushing state during multiple epoch in flowgraph
- Segment is flushed by flushTs & Flush segments

So this pr fix:

- Remove state change logic form FlushTs policy
- Change Flush segment into three stage way: Sealed->Flushing->Flushed preventing multiple Flushed=true operations.