### PR TITLE
enhance: [2.3] Utilize partition key optimization in reQuery

### DIFF
--- a/internal/proxy/task_query.go
+++ b/internal/proxy/task_query.go
@@ -63,6 +63,8 @@ type queryTask struct {
 	lb               LBPolicy
 	channelsMvcc     map[string]Timestamp
 	fastSkip         bool
+
+	reQuery bool
 }
 
 type queryParams struct {
@@ -326,23 +328,26 @@ func (t *queryTask) PreExecute(ctx context.Context) error {
 		return fmt.Errorf("empty expression should be used with limit")
 	}
 
-	partitionNames := t.request.GetPartitionNames()
-	if t.partitionKeyMode {
-		expr, err := ParseExprFromPlan(t.plan)
-		if err != nil {
-			return err
-		}
-		partitionKeys := ParsePartitionKeys(expr)
-		hashedPartitionNames, err := assignPartitionKeys(ctx, t.request.GetDbName(), t.request.CollectionName, partitionKeys)
-		if err != nil {
-			return err
-		}
+	// convert partition names only when requery is false
+	if !t.reQuery {
+		partitionNames := t.request.GetPartitionNames()
+		if t.partitionKeyMode {
+			expr, err := ParseExprFromPlan(t.plan)
+			if err != nil {
+				return err
+			}
+			partitionKeys := ParsePartitionKeys(expr)
+			hashedPartitionNames, err := assignPartitionKeys(ctx, t.request.GetDbName(), t.request.CollectionName, partitionKeys)
+			if err != nil {
+				return err
+			}
 
-		partitionNames = append(partitionNames, hashedPartitionNames...)
-	}
-	t.RetrieveRequest.PartitionIDs, err = getPartitionIDs(ctx, t.request.GetDbName(), t.request.CollectionName, partitionNames)
-	if err != nil {
-		return err
+			partitionNames = append(partitionNames, hashedPartitionNames...)
+		}
+		t.RetrieveRequest.PartitionIDs, err = getPartitionIDs(ctx, t.request.GetDbName(), t.request.CollectionName, partitionNames)
+		if err != nil {
+			return err
+		}
 	}
 
 	// count with pagination

--- a/internal/proxy/task_search.go
+++ b/internal/proxy/task_search.go
@@ -613,7 +613,8 @@ func (t *searchTask) Requery() error {
 				commonpbutil.WithMsgType(commonpb.MsgType_Retrieve),
 				commonpbutil.WithSourceID(paramtable.GetNodeID()),
 			),
-			ReqID: paramtable.GetNodeID(),
+			ReqID:        paramtable.GetNodeID(),
+			PartitionIDs: t.GetPartitionIDs(),
 		},
 		request:      queryReq,
 		plan:         plan,
@@ -621,6 +622,7 @@ func (t *searchTask) Requery() error {
 		lb:           t.node.(*Proxy).lbPolicy,
 		channelsMvcc: channelsMvcc,
 		fastSkip:     true,
+		reQuery:      true,
 	}
 	queryResult, err := t.node.(*Proxy).query(t.ctx, qt)
 	if err != nil {


### PR DESCRIPTION
Partial cherry-pick from master due to code branching
pr: #30253 
See also #30250

This PR add requery flag in query task. When reQuery flag is true, query task shall skip partition name conversion and use pre-calculated partitionIDs passed from search task.