### PR TITLE
fix: [Cherry-pick] Make leader checker generate leader task instead of segment task

### DIFF
--- a/internal/querycoordv2/checkers/leader_checker_test.go
+++ b/internal/querycoordv2/checkers/leader_checker_test.go
@@ -119,7 +119,7 @@ func (suite *LeaderCheckerTestSuite) TestSyncLoadedSegments() {
 	suite.Len(tasks[0].Actions(), 1)
 	suite.Equal(tasks[0].Actions()[0].Type(), task.ActionTypeGrow)
 	suite.Equal(tasks[0].Actions()[0].Node(), int64(1))
-	suite.Equal(tasks[0].Actions()[0].(*task.SegmentAction).SegmentID(), int64(1))
+	suite.Equal(tasks[0].Actions()[0].(*task.LeaderAction).SegmentID(), int64(1))
 	suite.Equal(tasks[0].Priority(), task.TaskPriorityHigh)
 }
 
@@ -194,7 +194,7 @@ func (suite *LeaderCheckerTestSuite) TestIgnoreSyncLoadedSegments() {
 	suite.Len(tasks[0].Actions(), 1)
 	suite.Equal(tasks[0].Actions()[0].Type(), task.ActionTypeGrow)
 	suite.Equal(tasks[0].Actions()[0].Node(), int64(1))
-	suite.Equal(tasks[0].Actions()[0].(*task.SegmentAction).SegmentID(), int64(1))
+	suite.Equal(tasks[0].Actions()[0].(*task.LeaderAction).SegmentID(), int64(1))
 	suite.Equal(tasks[0].Priority(), task.TaskPriorityHigh)
 }
 
@@ -247,7 +247,7 @@ func (suite *LeaderCheckerTestSuite) TestIgnoreBalancedSegment() {
 	suite.Len(tasks[0].Actions(), 1)
 	suite.Equal(tasks[0].Actions()[0].Type(), task.ActionTypeGrow)
 	suite.Equal(tasks[0].Actions()[0].Node(), int64(1))
-	suite.Equal(tasks[0].Actions()[0].(*task.SegmentAction).SegmentID(), int64(1))
+	suite.Equal(tasks[0].Actions()[0].(*task.LeaderAction).SegmentID(), int64(1))
 	suite.Equal(tasks[0].Priority(), task.TaskPriorityHigh)
 }
 
@@ -292,7 +292,7 @@ func (suite *LeaderCheckerTestSuite) TestSyncLoadedSegmentsWithReplicas() {
 	suite.Len(tasks[0].Actions(), 1)
 	suite.Equal(tasks[0].Actions()[0].Type(), task.ActionTypeGrow)
 	suite.Equal(tasks[0].Actions()[0].Node(), int64(1))
-	suite.Equal(tasks[0].Actions()[0].(*task.SegmentAction).SegmentID(), int64(1))
+	suite.Equal(tasks[0].Actions()[0].(*task.LeaderAction).SegmentID(), int64(1))
 	suite.Equal(tasks[0].Priority(), task.TaskPriorityHigh)
 }
 
@@ -326,7 +326,7 @@ func (suite *LeaderCheckerTestSuite) TestSyncRemovedSegments() {
 	suite.Len(tasks[0].Actions(), 1)
 	suite.Equal(tasks[0].Actions()[0].Type(), task.ActionTypeReduce)
 	suite.Equal(tasks[0].Actions()[0].Node(), int64(1))
-	suite.Equal(tasks[0].Actions()[0].(*task.SegmentAction).SegmentID(), int64(3))
+	suite.Equal(tasks[0].Actions()[0].(*task.LeaderAction).SegmentID(), int64(3))
 	suite.Equal(tasks[0].Priority(), task.TaskPriorityHigh)
 }
 
@@ -363,7 +363,7 @@ func (suite *LeaderCheckerTestSuite) TestIgnoreSyncRemovedSegments() {
 	suite.Len(tasks[0].Actions(), 1)
 	suite.Equal(tasks[0].Actions()[0].Type(), task.ActionTypeReduce)
 	suite.Equal(tasks[0].Actions()[0].Node(), int64(2))
-	suite.Equal(tasks[0].Actions()[0].(*task.SegmentAction).SegmentID(), int64(3))
+	suite.Equal(tasks[0].Actions()[0].(*task.LeaderAction).SegmentID(), int64(3))
 	suite.Equal(tasks[0].Priority(), task.TaskPriorityHigh)
 }
 

--- a/internal/querycoordv2/task/task.go
+++ b/internal/querycoordv2/task/task.go
@@ -383,3 +383,44 @@ func (task *ChannelTask) Index() string {
 func (task *ChannelTask) String() string {
 	return fmt.Sprintf("%s [channel=%s]", task.baseTask.String(), task.Channel())
 }
+
+type LeaderTask struct {
+	*baseTask
+
+	segmentID typeutil.UniqueID
+	leaderID  int64
+}
+
+func NewLeaderTask(ctx context.Context,
+	timeout time.Duration,
+	source Source,
+	collectionID,
+	replicaID typeutil.UniqueID,
+	leaderID int64,
+	action *LeaderAction,
+) *LeaderTask {
+	segmentID := action.SegmentID()
+	base := newBaseTask(ctx, source, collectionID, replicaID, action.Shard(), fmt.Sprintf("LeaderTask-%s-%d", action.Type().String(), segmentID))
+	base.actions = []Action{action}
+	return &LeaderTask{
+		baseTask:  base,
+		segmentID: segmentID,
+		leaderID:  leaderID,
+	}
+}
+
+func (task *LeaderTask) Shard() string {
+	return task.shard
+}
+
+func (task *LeaderTask) SegmentID() typeutil.UniqueID {
+	return task.segmentID
+}
+
+func (task *LeaderTask) Index() string {
+	return fmt.Sprintf("%s[segment=%d][growing=false]", task.baseTask.Index(), task.segmentID)
+}
+
+func (task *LeaderTask) String() string {
+	return fmt.Sprintf("%s [segmentID=%d][leader=%d]", task.baseTask.String(), task.segmentID, task.leaderID)
+}


### PR DESCRIPTION
Cherry-pick from master
pr: #30258 
See also #30150

For leader view distribution with offline nodes, a release task can never be sent to querynode due to targetNode online check logic. Even the request is dispatched, normal release task does not have "force" flag when calling `delegator.ReleaseSegment`.

This PR adds a new type of querycoord task: LeaderTask, the responsibility of which is to rectify leader view distribtion.