### PR TITLE
enhance: hint the invalid metric type in error message

### DIFF
--- a/pkg/util/indexparamcheck/bin_ivf_flat_checker.go
+++ b/pkg/util/indexparamcheck/bin_ivf_flat_checker.go
@@ -10,7 +10,7 @@ type binIVFFlatChecker struct {
 
 func (c binIVFFlatChecker) StaticCheck(params map[string]string) error {
 	if !CheckStrByValues(params, Metric, BinIvfMetrics) {
-		return fmt.Errorf("metric type not found or not supported, supported: %v", BinIvfMetrics)
+		return fmt.Errorf("metric type %s not found or not supported, supported: %v", params[Metric], BinIvfMetrics)
 	}
 
 	if !CheckIntByRange(params, NLIST, MinNList, MaxNList) {

--- a/pkg/util/indexparamcheck/binary_vector_base_checker.go
+++ b/pkg/util/indexparamcheck/binary_vector_base_checker.go
@@ -13,7 +13,7 @@ type binaryVectorBaseChecker struct {
 
 func (c binaryVectorBaseChecker) staticCheck(params map[string]string) error {
 	if !CheckStrByValues(params, Metric, BinIDMapMetrics) {
-		return fmt.Errorf("metric type not found or not supported, supported: %v", BinIDMapMetrics)
+		return fmt.Errorf("metric type %s not found or not supported, supported: %v", params[Metric], BinIDMapMetrics)
 	}
 
 	return nil

--- a/pkg/util/indexparamcheck/float_vector_base_checker.go
+++ b/pkg/util/indexparamcheck/float_vector_base_checker.go
@@ -13,7 +13,7 @@ type floatVectorBaseChecker struct {
 
 func (c floatVectorBaseChecker) staticCheck(params map[string]string) error {
 	if !CheckStrByValues(params, Metric, METRICS) {
-		return fmt.Errorf("metric type not found or not supported, supported: %v", METRICS)
+		return fmt.Errorf("metric type %s not found or not supported, supported: %v", params[Metric], METRICS)
 	}
 
 	return nil

--- a/pkg/util/indexparamcheck/hnsw_checker.go
+++ b/pkg/util/indexparamcheck/hnsw_checker.go
@@ -18,7 +18,7 @@ func (c hnswChecker) StaticCheck(params map[string]string) error {
 		return errOutOfRange(HNSWM, HNSWMinM, HNSWMaxM)
 	}
 	if !CheckStrByValues(params, Metric, HnswMetrics) {
-		return fmt.Errorf("metric type not found or not supported, supported: %v", HnswMetrics)
+		return fmt.Errorf("metric type %s not found or not supported, supported: %v", params[Metric], HnswMetrics)
 	}
 	return nil
 }

--- a/tests/python_client/testcases/test_collection.py
+++ b/tests/python_client/testcases/test_collection.py
@@ -3384,7 +3384,7 @@ class TestLoadPartition(TestcaseBase):
         binary_index["metric_type"] = metric_type
         if binary_index["index_type"] == "BIN_IVF_FLAT" and metric_type in ct.structure_metrics:
             error = {ct.err_code: 65535,
-                     ct.err_msg: "metric type not found or not supported, supported: [HAMMING JACCARD]"}
+                     ct.err_msg: f"metric type {metric_type} not found or not supported, supported: [HAMMING JACCARD]"}
             collection_w.create_index(ct.default_binary_vec_field_name, binary_index,
                                       check_task=CheckTasks.err_res, check_items=error)
             collection_w.create_index(ct.default_binary_vec_field_name, ct.default_bin_flat_index)

--- a/tests/python_client/testcases/test_high_level_api.py
+++ b/tests/python_client/testcases/test_high_level_api.py
@@ -125,7 +125,7 @@ class TestHighLevelApi(TestcaseBase):
         collection_name = cf.gen_unique_str(prefix)
         # 1. create collection
         error = {ct.err_code: 65535,
-                 ct.err_msg: "metric type not found or not supported, supported: [L2 IP COSINE HAMMING JACCARD]"}
+                 ct.err_msg: "metric type invalid not found or not supported, supported: [L2 IP COSINE HAMMING JACCARD]"}
         client_w.create_collection(client, collection_name, default_dim, metric_type="invalid",
                                    check_task=CheckTasks.err_res, check_items=error)
 

--- a/tests/python_client/testcases/test_index.py
+++ b/tests/python_client/testcases/test_index.py
@@ -1168,7 +1168,7 @@ class TestNewIndexBinary(TestcaseBase):
         collection_w.create_index(default_binary_vec_field_name, binary_index_params,
                                   index_name=binary_field_name, check_task=CheckTasks.err_res,
                                   check_items={ct.err_code: 65535,
-                                               ct.err_msg: "metric type not found or not supported, supported: "
+                                               ct.err_msg: "metric type L2 not found or not supported, supported: "
                                                            "[HAMMING JACCARD SUBSTRUCTURE SUPERSTRUCTURE]"})
 
     @pytest.mark.tags(CaseLabel.L2)

--- a/tests/python_client/testcases/test_search.py
+++ b/tests/python_client/testcases/test_search.py
@@ -1280,7 +1280,7 @@ class TestCollectionSearchInvalid(TestcaseBase):
         collection_w.create_index("binary_vector", default_index,
                                   check_task=CheckTasks.err_res,
                                   check_items={"err_code": 1,
-                                               "err_msg": "metric type not found or not supported, "
+                                               "err_msg": f"metric type {metric} not found or not supported, "
                                                           "supported: [HAMMING JACCARD]"})
 
     @pytest.mark.tags(CaseLabel.L1)


### PR DESCRIPTION
this hints the user passed invalid metric type in error message, so users could know what's wrong