### PR TITLE
enhance: Enlarge default datanode sync parallel to 256

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -435,7 +435,7 @@ dataNode:
     flowGraph:
       maxQueueLength: 16 # Maximum length of task queue in flowgraph
       maxParallelism: 1024 # Maximum number of tasks executed in parallel in the flowgraph
-    maxParallelSyncTaskNum: 6 # Maximum number of sync tasks executed in parallel in each flush manager
+    maxParallelSyncMgrTasks: 256 #The max concurrent sync task number of datanode sync mgr globally 
     skipMode:
       # when there are only timetick msg in flowgraph for a while (longer than coldTime),
       # flowGraph will turn on skip mode to skip most timeticks to reduce cost, especially there are a lot of channels

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -2874,7 +2874,7 @@ func (p *dataNodeConfig) init(base *BaseTable) {
 	p.MaxParallelSyncMgrTasks = ParamItem{
 		Key:          "dataNode.dataSync.maxParallelSyncMgrTasks",
 		Version:      "2.3.4",
-		DefaultValue: "64",
+		DefaultValue: "256",
 		Doc:          "The max concurrent sync task number of datanode sync mgr globally",
 		Export:       true,
 	}


### PR DESCRIPTION
See also #27675

After supporting control sync parallel in datanode globally, the shall change default value to a more suitable value for most use cases.