### PR TITLE
fix: Use correct pools for all CGO methods in segments pkg

### DIFF
--- a/internal/querynodev2/segments/load_field_data_info.go
+++ b/internal/querynodev2/segments/load_field_data_info.go
@@ -34,9 +34,12 @@ type LoadFieldDataInfo struct {
 }
 
 func newLoadFieldDataInfo(ctx context.Context) (*LoadFieldDataInfo, error) {
+	var status C.CStatus
 	var cLoadFieldDataInfo C.CLoadFieldDataInfo
-
-	status := C.NewLoadFieldDataInfo(&cLoadFieldDataInfo)
+	GetDynamicPool().Submit(func() (any, error) {
+		status = C.NewLoadFieldDataInfo(&cLoadFieldDataInfo)
+		return nil, nil
+	}).Await()
 	if err := HandleCStatus(ctx, &status, "newLoadFieldDataInfo failed"); err != nil {
 		return nil, err
 	}
@@ -44,48 +47,75 @@ func newLoadFieldDataInfo(ctx context.Context) (*LoadFieldDataInfo, error) {
 }
 
 func deleteFieldDataInfo(info *LoadFieldDataInfo) {
-	C.DeleteLoadFieldDataInfo(info.cLoadFieldDataInfo)
+	GetDynamicPool().Submit(func() (any, error) {
+		C.DeleteLoadFieldDataInfo(info.cLoadFieldDataInfo)
+		return nil, nil
+	}).Await()
 }
 
 func (ld *LoadFieldDataInfo) appendLoadFieldInfo(ctx context.Context, fieldID int64, rowCount int64) error {
-	cFieldID := C.int64_t(fieldID)
-	cRowCount := C.int64_t(rowCount)
+	var status C.CStatus
+	GetDynamicPool().Submit(func() (any, error) {
+		cFieldID := C.int64_t(fieldID)
+		cRowCount := C.int64_t(rowCount)
 
-	status := C.AppendLoadFieldInfo(ld.cLoadFieldDataInfo, cFieldID, cRowCount)
+		status = C.AppendLoadFieldInfo(ld.cLoadFieldDataInfo, cFieldID, cRowCount)
+		return nil, nil
+	}).Await()
+
 	return HandleCStatus(ctx, &status, "appendLoadFieldInfo failed")
 }
 
 func (ld *LoadFieldDataInfo) appendLoadFieldDataPath(ctx context.Context, fieldID int64, binlog *datapb.Binlog) error {
-	cFieldID := C.int64_t(fieldID)
-	cEntriesNum := C.int64_t(binlog.GetEntriesNum())
-	cFile := C.CString(binlog.GetLogPath())
-	defer C.free(unsafe.Pointer(cFile))
+	var status C.CStatus
+	GetDynamicPool().Submit(func() (any, error) {
+		cFieldID := C.int64_t(fieldID)
+		cEntriesNum := C.int64_t(binlog.GetEntriesNum())
+		cFile := C.CString(binlog.GetLogPath())
+		defer C.free(unsafe.Pointer(cFile))
 
-	status := C.AppendLoadFieldDataPath(ld.cLoadFieldDataInfo, cFieldID, cEntriesNum, cFile)
+		status = C.AppendLoadFieldDataPath(ld.cLoadFieldDataInfo, cFieldID, cEntriesNum, cFile)
+		return nil, nil
+	}).Await()
+
 	return HandleCStatus(ctx, &status, "appendLoadFieldDataPath failed")
 }
 
 func (ld *LoadFieldDataInfo) enableMmap(fieldID int64, enabled bool) {
-	cFieldID := C.int64_t(fieldID)
-	cEnabled := C.bool(enabled)
+	GetDynamicPool().Submit(func() (any, error) {
+		cFieldID := C.int64_t(fieldID)
+		cEnabled := C.bool(enabled)
 
-	C.EnableMmap(ld.cLoadFieldDataInfo, cFieldID, cEnabled)
+		C.EnableMmap(ld.cLoadFieldDataInfo, cFieldID, cEnabled)
+		return nil, nil
+	}).Await()
 }
 
 func (ld *LoadFieldDataInfo) appendMMapDirPath(dir string) {
-	cDir := C.CString(dir)
-	defer C.free(unsafe.Pointer(cDir))
+	GetDynamicPool().Submit(func() (any, error) {
+		cDir := C.CString(dir)
+		defer C.free(unsafe.Pointer(cDir))
 
-	C.AppendMMapDirPath(ld.cLoadFieldDataInfo, cDir)
+		C.AppendMMapDirPath(ld.cLoadFieldDataInfo, cDir)
+		return nil, nil
+	}).Await()
 }
 
 func (ld *LoadFieldDataInfo) appendURI(uri string) {
-	cURI := C.CString(uri)
-	defer C.free(unsafe.Pointer(cURI))
-	C.SetUri(ld.cLoadFieldDataInfo, cURI)
+	GetDynamicPool().Submit(func() (any, error) {
+		cURI := C.CString(uri)
+		defer C.free(unsafe.Pointer(cURI))
+		C.SetUri(ld.cLoadFieldDataInfo, cURI)
+
+		return nil, nil
+	}).Await()
 }
 
 func (ld *LoadFieldDataInfo) appendStorageVersion(version int64) {
-	cVersion := C.int64_t(version)
-	C.SetStorageVersion(ld.cLoadFieldDataInfo, cVersion)
+	GetDynamicPool().Submit(func() (any, error) {
+		cVersion := C.int64_t(version)
+		C.SetStorageVersion(ld.cLoadFieldDataInfo, cVersion)
+
+		return nil, nil
+	}).Await()
 }

--- a/internal/querynodev2/segments/load_index_info.go
+++ b/internal/querynodev2/segments/load_index_info.go
@@ -59,7 +59,10 @@ func newLoadIndexInfo(ctx context.Context) (*LoadIndexInfo, error) {
 
 // deleteLoadIndexInfo would delete C.CLoadIndexInfo
 func deleteLoadIndexInfo(info *LoadIndexInfo) {
-	C.DeleteLoadIndexInfo(info.cLoadIndexInfo)
+	GetDynamicPool().Submit(func() (any, error) {
+		C.DeleteLoadIndexInfo(info.cLoadIndexInfo)
+		return nil, nil
+	}).Await()
 }
 
 func (li *LoadIndexInfo) appendLoadIndexInfo(ctx context.Context, indexInfo *querypb.FieldIndexInfo, collectionID int64, partitionID int64, segmentID int64, fieldType schemapb.DataType) error {
@@ -113,55 +116,79 @@ func (li *LoadIndexInfo) appendLoadIndexInfo(ctx context.Context, indexInfo *que
 
 // appendIndexParam append indexParam to index
 func (li *LoadIndexInfo) appendIndexParam(ctx context.Context, indexKey string, indexValue string) error {
-	cIndexKey := C.CString(indexKey)
-	defer C.free(unsafe.Pointer(cIndexKey))
-	cIndexValue := C.CString(indexValue)
-	defer C.free(unsafe.Pointer(cIndexValue))
-	status := C.AppendIndexParam(li.cLoadIndexInfo, cIndexKey, cIndexValue)
+	var status C.CStatus
+	GetDynamicPool().Submit(func() (any, error) {
+		cIndexKey := C.CString(indexKey)
+		defer C.free(unsafe.Pointer(cIndexKey))
+		cIndexValue := C.CString(indexValue)
+		defer C.free(unsafe.Pointer(cIndexValue))
+		status = C.AppendIndexParam(li.cLoadIndexInfo, cIndexKey, cIndexValue)
+		return nil, nil
+	}).Await()
 	return HandleCStatus(ctx, &status, "AppendIndexParam failed")
 }
 
 func (li *LoadIndexInfo) appendIndexInfo(ctx context.Context, indexID int64, buildID int64, indexVersion int64) error {
-	cIndexID := C.int64_t(indexID)
-	cBuildID := C.int64_t(buildID)
-	cIndexVersion := C.int64_t(indexVersion)
+	var status C.CStatus
+	GetDynamicPool().Submit(func() (any, error) {
+		cIndexID := C.int64_t(indexID)
+		cBuildID := C.int64_t(buildID)
+		cIndexVersion := C.int64_t(indexVersion)
 
-	status := C.AppendIndexInfo(li.cLoadIndexInfo, cIndexID, cBuildID, cIndexVersion)
+		status = C.AppendIndexInfo(li.cLoadIndexInfo, cIndexID, cBuildID, cIndexVersion)
+		return nil, nil
+	}).Await()
 	return HandleCStatus(ctx, &status, "AppendIndexInfo failed")
 }
 
 func (li *LoadIndexInfo) cleanLocalData(ctx context.Context) error {
-	status := C.CleanLoadedIndex(li.cLoadIndexInfo)
+	var status C.CStatus
+	GetDynamicPool().Submit(func() (any, error) {
+		status = C.CleanLoadedIndex(li.cLoadIndexInfo)
+		return nil, nil
+	}).Await()
 	return HandleCStatus(ctx, &status, "failed to clean cached data on disk")
 }
 
 func (li *LoadIndexInfo) appendIndexFile(ctx context.Context, filePath string) error {
-	cIndexFilePath := C.CString(filePath)
-	defer C.free(unsafe.Pointer(cIndexFilePath))
+	var status C.CStatus
+	GetDynamicPool().Submit(func() (any, error) {
+		cIndexFilePath := C.CString(filePath)
+		defer C.free(unsafe.Pointer(cIndexFilePath))
 
-	status := C.AppendIndexFilePath(li.cLoadIndexInfo, cIndexFilePath)
+		status = C.AppendIndexFilePath(li.cLoadIndexInfo, cIndexFilePath)
+		return nil, nil
+	}).Await()
 	return HandleCStatus(ctx, &status, "AppendIndexIFile failed")
 }
 
 // appendFieldInfo appends fieldID & fieldType to index
 func (li *LoadIndexInfo) appendFieldInfo(ctx context.Context, collectionID int64, partitionID int64, segmentID int64, fieldID int64, fieldType schemapb.DataType, enableMmap bool, mmapDirPath string) error {
-	cColID := C.int64_t(collectionID)
-	cParID := C.int64_t(partitionID)
-	cSegID := C.int64_t(segmentID)
-	cFieldID := C.int64_t(fieldID)
-	cintDType := uint32(fieldType)
-	cEnableMmap := C.bool(enableMmap)
-	cMmapDirPath := C.CString(mmapDirPath)
-	defer C.free(unsafe.Pointer(cMmapDirPath))
-	status := C.AppendFieldInfo(li.cLoadIndexInfo, cColID, cParID, cSegID, cFieldID, cintDType, cEnableMmap, cMmapDirPath)
+	var status C.CStatus
+	GetDynamicPool().Submit(func() (any, error) {
+		cColID := C.int64_t(collectionID)
+		cParID := C.int64_t(partitionID)
+		cSegID := C.int64_t(segmentID)
+		cFieldID := C.int64_t(fieldID)
+		cintDType := uint32(fieldType)
+		cEnableMmap := C.bool(enableMmap)
+		cMmapDirPath := C.CString(mmapDirPath)
+		defer C.free(unsafe.Pointer(cMmapDirPath))
+		status = C.AppendFieldInfo(li.cLoadIndexInfo, cColID, cParID, cSegID, cFieldID, cintDType, cEnableMmap, cMmapDirPath)
+		return nil, nil
+	}).Await()
+
 	return HandleCStatus(ctx, &status, "AppendFieldInfo failed")
 }
 
 func (li *LoadIndexInfo) appendStorageInfo(uri string, version int64) {
-	cURI := C.CString(uri)
-	defer C.free(unsafe.Pointer(cURI))
-	cVersion := C.int64_t(version)
-	C.AppendStorageInfo(li.cLoadIndexInfo, cURI, cVersion)
+	GetDynamicPool().Submit(func() (any, error) {
+		cURI := C.CString(uri)
+		defer C.free(unsafe.Pointer(cURI))
+		cVersion := C.int64_t(version)
+		C.AppendStorageInfo(li.cLoadIndexInfo, cURI, cVersion)
+		return nil, nil
+	}).Await()
 }
 
 // appendIndexData appends index path to cLoadIndexInfo and create index
@@ -174,27 +201,37 @@ func (li *LoadIndexInfo) appendIndexData(ctx context.Context, indexKeys []string
 	}
 
 	var status C.CStatus
-	if paramtable.Get().CommonCfg.EnableStorageV2.GetAsBool() {
-		status = C.AppendIndexV3(li.cLoadIndexInfo)
-	} else {
-		span := trace.SpanFromContext(ctx)
+	GetLoadPool().Submit(func() (any, error) {
+		if paramtable.Get().CommonCfg.EnableStorageV2.GetAsBool() {
+			status = C.AppendIndexV3(li.cLoadIndexInfo)
+		} else {
+			span := trace.SpanFromContext(ctx)
 
-		traceID := span.SpanContext().TraceID()
-		spanID := span.SpanContext().SpanID()
-		traceCtx := C.CTraceContext{
-			traceID: (*C.uint8_t)(unsafe.Pointer(&traceID[0])),
-			spanID:  (*C.uint8_t)(unsafe.Pointer(&spanID[0])),
-			flag:    C.uchar(span.SpanContext().TraceFlags()),
+			traceID := span.SpanContext().TraceID()
+			spanID := span.SpanContext().SpanID()
+			traceCtx := C.CTraceContext{
+				traceID: (*C.uint8_t)(unsafe.Pointer(&traceID[0])),
+				spanID:  (*C.uint8_t)(unsafe.Pointer(&spanID[0])),
+				flag:    C.uchar(span.SpanContext().TraceFlags()),
+			}
+
+			status = C.AppendIndexV2(traceCtx, li.cLoadIndexInfo)
 		}
+		return nil, nil
+	}).Await()
 
-		status = C.AppendIndexV2(traceCtx, li.cLoadIndexInfo)
-	}
 	return HandleCStatus(ctx, &status, "AppendIndex failed")
 }
 
 func (li *LoadIndexInfo) appendIndexEngineVersion(ctx context.Context, indexEngineVersion int32) error {
 	cIndexEngineVersion := C.int32_t(indexEngineVersion)
 
-	status := C.AppendIndexEngineVersionToLoadInfo(li.cLoadIndexInfo, cIndexEngineVersion)
+	var status C.CStatus
+
+	GetDynamicPool().Submit(func() (any, error) {
+		status = C.AppendIndexEngineVersionToLoadInfo(li.cLoadIndexInfo, cIndexEngineVersion)
+		return nil, nil
+	}).Await()
+
 	return HandleCStatus(ctx, &status, "AppendIndexEngineVersion failed")
 }

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -1116,7 +1116,7 @@ func (s *LocalSegment) LoadIndex(ctx context.Context, indexInfo *querypb.FieldIn
 		return errors.New(errMsg)
 	}
 
-	err = s.LoadIndexInfo(ctx, indexInfo, loadIndexInfo)
+	err = s.UpdateIndexInfo(ctx, indexInfo, loadIndexInfo)
 	if err != nil {
 		return err
 	}
@@ -1128,7 +1128,7 @@ func (s *LocalSegment) LoadIndex(ctx context.Context, indexInfo *querypb.FieldIn
 	return nil
 }
 
-func (s *LocalSegment) LoadIndexInfo(ctx context.Context, indexInfo *querypb.FieldIndexInfo, info *LoadIndexInfo) error {
+func (s *LocalSegment) UpdateIndexInfo(ctx context.Context, indexInfo *querypb.FieldIndexInfo, info *LoadIndexInfo) error {
 	log := log.Ctx(ctx).With(
 		zap.Int64("collectionID", s.Collection()),
 		zap.Int64("partitionID", s.Partition()),
@@ -1143,7 +1143,7 @@ func (s *LocalSegment) LoadIndexInfo(ctx context.Context, indexInfo *querypb.Fie
 	}
 
 	var status C.CStatus
-	GetLoadPool().Submit(func() (any, error) {
+	GetDynamicPool().Submit(func() (any, error) {
 		status = C.UpdateSealedSegmentIndex(s.ptr, info.cLoadIndexInfo)
 		return nil, nil
 	}).Await()


### PR DESCRIPTION
See also #30273

This PR:
- Rename confusing `LoadIndexInfo` to `UpdateIndexInfo` for LocalSegment
- Use `DynamicPool` instead of `LoadPool` for `UpdateSealedSegmentIndex`
- Fix cgo call missing pool control