### PR TITLE
fix: [Cherry-pick] Use correct pools for all CGO methods in segments pkg

### DIFF
--- a/internal/querynodev2/segments/load_field_data_info.go
+++ b/internal/querynodev2/segments/load_field_data_info.go
@@ -34,9 +34,12 @@ type LoadFieldDataInfo struct {
 }
 
 func newLoadFieldDataInfo(ctx context.Context) (*LoadFieldDataInfo, error) {
+	var status C.CStatus
 	var cLoadFieldDataInfo C.CLoadFieldDataInfo
-
-	status := C.NewLoadFieldDataInfo(&cLoadFieldDataInfo)
+	GetDynamicPool().Submit(func() (any, error) {
+		status = C.NewLoadFieldDataInfo(&cLoadFieldDataInfo)
+		return nil, nil
+	}).Await()
 	if err := HandleCStatus(ctx, &status, "newLoadFieldDataInfo failed"); err != nil {
 		return nil, err
 	}
@@ -44,30 +47,46 @@ func newLoadFieldDataInfo(ctx context.Context) (*LoadFieldDataInfo, error) {
 }
 
 func deleteFieldDataInfo(info *LoadFieldDataInfo) {
-	C.DeleteLoadFieldDataInfo(info.cLoadFieldDataInfo)
+	GetDynamicPool().Submit(func() (any, error) {
+		C.DeleteLoadFieldDataInfo(info.cLoadFieldDataInfo)
+		return nil, nil
+	}).Await()
 }
 
 func (ld *LoadFieldDataInfo) appendLoadFieldInfo(ctx context.Context, fieldID int64, rowCount int64) error {
-	cFieldID := C.int64_t(fieldID)
-	cRowCount := C.int64_t(rowCount)
+	var status C.CStatus
+	GetDynamicPool().Submit(func() (any, error) {
+		cFieldID := C.int64_t(fieldID)
+		cRowCount := C.int64_t(rowCount)
 
-	status := C.AppendLoadFieldInfo(ld.cLoadFieldDataInfo, cFieldID, cRowCount)
+		status = C.AppendLoadFieldInfo(ld.cLoadFieldDataInfo, cFieldID, cRowCount)
+		return nil, nil
+	}).Await()
+
 	return HandleCStatus(ctx, &status, "appendLoadFieldInfo failed")
 }
 
 func (ld *LoadFieldDataInfo) appendLoadFieldDataPath(ctx context.Context, fieldID int64, binlog *datapb.Binlog) error {
-	cFieldID := C.int64_t(fieldID)
-	cEntriesNum := C.int64_t(binlog.GetEntriesNum())
-	cFile := C.CString(binlog.GetLogPath())
-	defer C.free(unsafe.Pointer(cFile))
+	var status C.CStatus
+	GetDynamicPool().Submit(func() (any, error) {
+		cFieldID := C.int64_t(fieldID)
+		cEntriesNum := C.int64_t(binlog.GetEntriesNum())
+		cFile := C.CString(binlog.GetLogPath())
+		defer C.free(unsafe.Pointer(cFile))
 
-	status := C.AppendLoadFieldDataPath(ld.cLoadFieldDataInfo, cFieldID, cEntriesNum, cFile)
+		status = C.AppendLoadFieldDataPath(ld.cLoadFieldDataInfo, cFieldID, cEntriesNum, cFile)
+		return nil, nil
+	}).Await()
+
 	return HandleCStatus(ctx, &status, "appendLoadFieldDataPath failed")
 }
 
 func (ld *LoadFieldDataInfo) appendMMapDirPath(dir string) {
-	cDir := C.CString(dir)
-	defer C.free(unsafe.Pointer(cDir))
+	GetDynamicPool().Submit(func() (any, error) {
+		cDir := C.CString(dir)
+		defer C.free(unsafe.Pointer(cDir))
 
-	C.AppendMMapDirPath(ld.cLoadFieldDataInfo, cDir)
+		C.AppendMMapDirPath(ld.cLoadFieldDataInfo, cDir)
+		return nil, nil
+	}).Await()
 }

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -902,10 +902,10 @@ func (s *LocalSegment) LoadIndex(ctx context.Context, indexInfo *querypb.FieldIn
 		return errors.New(errMsg)
 	}
 
-	return s.LoadIndexInfo(ctx, indexInfo, loadIndexInfo)
+	return s.UpdateIndexInfo(ctx, indexInfo, loadIndexInfo)
 }
 
-func (s *LocalSegment) LoadIndexInfo(ctx context.Context, indexInfo *querypb.FieldIndexInfo, info *LoadIndexInfo) error {
+func (s *LocalSegment) UpdateIndexInfo(ctx context.Context, indexInfo *querypb.FieldIndexInfo, info *LoadIndexInfo) error {
 	log := log.Ctx(ctx).With(
 		zap.Int64("collectionID", s.Collection()),
 		zap.Int64("partitionID", s.Partition()),
@@ -920,7 +920,7 @@ func (s *LocalSegment) LoadIndexInfo(ctx context.Context, indexInfo *querypb.Fie
 	}
 
 	var status C.CStatus
-	GetLoadPool().Submit(func() (any, error) {
+	GetDynamicPool().Submit(func() (any, error) {
 		status = C.UpdateSealedSegmentIndex(s.ptr, info.cLoadIndexInfo)
 		return nil, nil
 	}).Await()


### PR DESCRIPTION
Cherry-pick from master
pr: #30274
See also #30273

This PR:
- Rename confusing `LoadIndexInfo` to `UpdateIndexInfo` for LocalSegment
- Use `DynamicPool` instead of `LoadPool` for `UpdateSealedSegmentIndex`
- Fix cgo call missing pool control