### PR TITLE
fix: Fill in info in CompactionSegmentBinlogs

### DIFF
--- a/internal/datacoord/compaction.go
+++ b/internal/datacoord/compaction.go
@@ -316,8 +316,10 @@ func (c *compactionPlanHandler) RefreshPlan(task *compactionTask) {
 
 		sealedSegBinlogs := lo.Map(sealedSegments, func(info *SegmentInfo, _ int) *datapb.CompactionSegmentBinlogs {
 			return &datapb.CompactionSegmentBinlogs{
-				SegmentID: info.GetID(),
-				Level:     datapb.SegmentLevel_L1,
+				SegmentID:    info.GetID(),
+				Level:        datapb.SegmentLevel_L1,
+				CollectionID: info.GetCollectionID(),
+				PartitionID:  info.GetPartitionID(),
 			}
 		})
 

--- a/internal/datacoord/compaction_trigger.go
+++ b/internal/datacoord/compaction_trigger.go
@@ -701,6 +701,9 @@ func (t *compactionTrigger) generatePlans(segments []*SegmentInfo, force bool, i
 					FieldBinlogs:        s.GetBinlogs(),
 					Field2StatslogPaths: s.GetStatslogs(),
 					Deltalogs:           s.GetDeltalogs(),
+					Level:               s.GetLevel(),
+					CollectionID:        s.GetCollectionID(),
+					PartitionID:         s.GetPartitionID(),
 				}
 				plan.TotalRows += s.GetNumOfRows()
 				plan.SegmentBinlogs = append(plan.SegmentBinlogs, segmentBinLogs)

--- a/internal/datacoord/compaction_trigger_v2.go
+++ b/internal/datacoord/compaction_trigger_v2.go
@@ -89,14 +89,14 @@ func (m *CompactionTriggerManager) Notify(taskID UniqueID, eventType CompactionT
 
 func (m *CompactionTriggerManager) BuildLevelZeroCompactionPlan(view CompactionView) *datapb.CompactionPlan {
 	var segmentBinlogs []*datapb.CompactionSegmentBinlogs
-	levelZeroSegs := lo.Map(view.GetSegmentsView(), func(v *SegmentView, _ int) *datapb.CompactionSegmentBinlogs {
-		s := m.meta.GetSegment(v.ID)
+	levelZeroSegs := lo.Map(view.GetSegmentsView(), func(segView *SegmentView, _ int) *datapb.CompactionSegmentBinlogs {
+		s := m.meta.GetSegment(segView.ID)
 		return &datapb.CompactionSegmentBinlogs{
-			SegmentID:    s.GetID(),
+			SegmentID:    segView.ID,
 			Deltalogs:    s.GetDeltalogs(),
 			Level:        datapb.SegmentLevel_L0,
-			CollectionID: s.GetCollectionID(),
-			PartitionID:  s.GetPartitionID(),
+			CollectionID: view.GetGroupLabel().CollectionID,
+			PartitionID:  view.GetGroupLabel().PartitionID,
 		}
 	})
 	segmentBinlogs = append(segmentBinlogs, levelZeroSegs...)


### PR DESCRIPTION
After #28873, PartitionID and CollectionID should be filled in CompactionSegmentBinlog so that DataNode can compose
the correct logPath. However There're some places left forgotten to fill in the information, causing Datanode downloading `xxx/0/0/xxxx/xxxx` binlogs during compaction

See also: #30213