### PR TITLE
fix: Fix Seg Faults in c api unit tests caused by empty index meta

### DIFF
--- a/internal/core/src/segcore/SegmentGrowingImpl.h
+++ b/internal/core/src/segcore/SegmentGrowingImpl.h
@@ -278,6 +278,7 @@ class SegmentGrowingImpl : public SegmentGrowing {
     void
     check_search(const query::Plan* plan) const override {
         Assert(plan);
+        AssertInfo(index_meta_.get(), "index_meta is nullptr");
         check_metric_type(plan, index_meta_);
     }
 

--- a/internal/core/src/segcore/SegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/SegmentSealedImpl.cpp
@@ -930,7 +930,7 @@ SegmentSealedImpl::check_search(const query::Plan* plan) const {
     AssertInfo(plan, "Search plan is null");
     AssertInfo(plan->extra_info_opt_.has_value(),
                "Extra info of search plan doesn't have value");
-
+    AssertInfo(col_index_meta_.get(), "col_index_meta_ is nullptr");
     check_metric_type(plan, col_index_meta_);
 
     if (!is_system_field_ready()) {

--- a/internal/core/unittest/test_utils/c_api_test_utils.h
+++ b/internal/core/unittest/test_utils/c_api_test_utils.h
@@ -37,31 +37,6 @@ using namespace milvus;
 using namespace milvus::segcore;
 
 namespace {
-const char*
-get_default_schema_config() {
-    static std::string conf = R"(name: "default-collection"
-                                fields: <
-                                  fieldID: 100
-                                  name: "fakevec"
-                                  data_type: FloatVector
-                                  type_params: <
-                                    key: "dim"
-                                    value: "16"
-                                  >
-                                  index_params: <
-                                    key: "metric_type"
-                                    value: "L2"
-                                  >
-                                >
-                                fields: <
-                                  fieldID: 101
-                                  name: "age"
-                                  data_type: Int64
-                                  is_primary_key: true
-                                >)";
-    static std::string fake_conf = "";
-    return conf.c_str();
-}
 
 std::string
 generate_max_float_query_data(int all_nq, int max_float_nq) {


### PR DESCRIPTION
/kind bug

https://github.com/milvus-io/milvus/issues/30192

Before this PR, when running `make test-cpp` the test program will crash before most tests run. Most unit tests in `test_c_api.cpp` even if ran alone will fail and hit seg fault.

This PR fixes such tests caused by empty segment index meta. There are still unfixed tests that are more complex and I don't currently have cycles to dig into them.

For root cause see https://github.com/milvus-io/milvus/issues/30192#issuecomment-1907319015.

Tests in `test_c_api.cpp` that are still failing after this PR:

```
[  FAILED  ] 5 tests, listed below:
[  FAILED  ] CApiTest.GrowingSegment_Load_Field_Data
[  FAILED  ] CApiTest.RANGE_SEARCH_WITH_RADIUS_WHEN_IP
[  FAILED  ] CApiTest.RANGE_SEARCH_WITH_RADIUS_AND_RANGE_FILTER_WHEN_IP
[  FAILED  ] CApiTest.RANGE_SEARCH_WITH_RADIUS_AND_RANGE_FILTER_WHEN_IP_FLOAT16
[  FAILED  ] CApiTest.RANGE_SEARCH_WITH_RADIUS_AND_RANGE_FILTER_WHEN_IP_BFLOAT16
```