### PR TITLE
enhance: Set correct role for non-standalone deployment

### DIFF
--- a/cmd/milvus/util.go
+++ b/cmd/milvus/util.go
@@ -128,6 +128,7 @@ func GetMilvusRoles(args []string, flags *flag.FlagSet) *roles.MilvusRoles {
 	serverType := args[2]
 	role := roles.NewMilvusRoles()
 	role.Alias = alias
+	role.ServerType = serverType
 
 	switch serverType {
 	case typeutil.RootCoordRole:
@@ -166,7 +167,6 @@ func GetMilvusRoles(args []string, flags *flag.FlagSet) *roles.MilvusRoles {
 		role.EnableDataNode = enableDataNode
 		role.EnableIndexNode = enableIndexNode
 		role.EnableProxy = enableProxy
-		role.Mixture = true
 	default:
 		fmt.Fprintf(os.Stderr, "Unknown server type = %s\n%s", serverType, getHelp())
 		os.Exit(-1)

--- a/cmd/roles/roles.go
+++ b/cmd/roles/roles.go
@@ -137,7 +137,8 @@ type MilvusRoles struct {
 	Local    bool
 	Alias    string
 	Embedded bool
-	Mixture  bool
+
+	ServerType string
 
 	closed chan struct{}
 	once   sync.Once
@@ -334,9 +335,7 @@ func (mr *MilvusRoles) Run() {
 			log.Error("Failed to set deploy mode: ", zap.Error(err))
 		}
 		paramtable.Init()
-		if mr.Mixture {
-			paramtable.SetRole(typeutil.MixtureRole)
-		}
+		paramtable.SetRole(mr.ServerType)
 	}
 
 	expr.Init()


### PR DESCRIPTION
See also #30211

After fix initialization problem, distributed components do no have their role set. This will cause logger & tracing miss component service info when recording information.