### PR TITLE
enhance: add graceful stop timeout to avoid coordinator stop hang under extreme cases

### DIFF
--- a/internal/core/conanfile.py
+++ b/internal/core/conanfile.py
@@ -76,7 +76,7 @@ class MilvusConan(ConanFile):
             # Macos M1 cannot use jemalloc
             if self.settings.arch not in ("x86_64", "x86"):
                 del self.options["folly"].use_sse4_2
-
+            self.options["abseil"].shared = True
             self.options["arrow"].with_jemalloc = False
         if self.settings.arch == "armv8":
             self.options["openblas"].dynamic_arch = False

--- a/internal/querycoordv2/server.go
+++ b/internal/querycoordv2/server.go
@@ -59,6 +59,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/metrics"
 	"github.com/milvus-io/milvus/pkg/util"
 	"github.com/milvus-io/milvus/pkg/util/expr"
+	"github.com/milvus-io/milvus/pkg/util/logutil"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/metricsinfo"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
@@ -467,6 +468,11 @@ func (s *Server) startServerLoop() {
 }
 
 func (s *Server) Stop() error {
+	if !s.status.CompareAndSwap(int32(commonpb.StateCode_Healthy), int32(commonpb.StateCode_Abnormal)) {
+		return nil
+	}
+	logutil.Logger(s.ctx).Warn("server shutdown")
+
 	// stop the components from outside to inside,
 	// to make the dependencies stopped working properly,
 	// cancel the server context first to stop receiving requests
@@ -476,54 +482,70 @@ func (s *Server) Stop() error {
 	// job scheduler -> checker controller -> task scheduler -> dist controller -> cluster -> session
 	// observers -> dist controller
 
-	if s.jobScheduler != nil {
-		log.Info("stop job scheduler...")
-		s.jobScheduler.Stop()
-	}
+	ctx, cancel := context.WithTimeout(context.Background(), Params.CommonCfg.CoordGracefulStopTimeout.GetAsDuration(time.Second))
+	defer cancel()
 
-	if s.checkerController != nil {
-		log.Info("stop checker controller...")
-		s.checkerController.Stop()
-	}
+	done := make(chan struct{})
 
-	if s.taskScheduler != nil {
-		log.Info("stop task scheduler...")
-		s.taskScheduler.Stop()
-	}
+	go func() {
+		defer close(done)
+		if s.jobScheduler != nil {
+			log.Info("stop job scheduler...")
+			s.jobScheduler.Stop()
+		}
 
-	log.Info("stop observers...")
-	if s.collectionObserver != nil {
-		s.collectionObserver.Stop()
-	}
-	if s.leaderObserver != nil {
-		s.leaderObserver.Stop()
-	}
-	if s.targetObserver != nil {
-		s.targetObserver.Stop()
-	}
-	if s.replicaObserver != nil {
-		s.replicaObserver.Stop()
-	}
-	if s.resourceObserver != nil {
-		s.resourceObserver.Stop()
-	}
+		if s.checkerController != nil {
+			log.Info("stop checker controller...")
+			s.checkerController.Stop()
+		}
 
-	if s.distController != nil {
-		log.Info("stop dist controller...")
-		s.distController.Stop()
-	}
+		if s.taskScheduler != nil {
+			log.Info("stop task scheduler...")
+			s.taskScheduler.Stop()
+		}
 
-	if s.cluster != nil {
-		log.Info("stop cluster...")
-		s.cluster.Stop()
-	}
+		log.Info("stop observers...")
+		if s.collectionObserver != nil {
+			s.collectionObserver.Stop()
+		}
+		if s.leaderObserver != nil {
+			s.leaderObserver.Stop()
+		}
+		if s.targetObserver != nil {
+			s.targetObserver.Stop()
+		}
+		if s.replicaObserver != nil {
+			s.replicaObserver.Stop()
+		}
+		if s.resourceObserver != nil {
+			s.resourceObserver.Stop()
+		}
 
-	if s.session != nil {
-		s.session.Stop()
+		if s.distController != nil {
+			log.Info("stop dist controller...")
+			s.distController.Stop()
+		}
+
+		if s.cluster != nil {
+			log.Info("stop cluster...")
+			s.cluster.Stop()
+		}
+
+		if s.session != nil {
+			s.session.Stop()
+		}
+		s.wg.Wait()
+	}()
+
+	select {
+	case <-ctx.Done():
+		// direct stop after certain time
+		panic("stopping querycoord took too long")
+	case <-done:
+		logutil.Logger(s.ctx).Warn("querycoord stop successfully")
 	}
 
 	s.wg.Wait()
-	log.Info("QueryCoord stop successfully")
 	return nil
 }
 

--- a/internal/rootcoord/root_coord.go
+++ b/internal/rootcoord/root_coord.go
@@ -788,18 +788,42 @@ func (c *Core) revokeSession() {
 
 // Stop stops rootCoord.
 func (c *Core) Stop() error {
-	c.UpdateStateCode(commonpb.StateCode_Abnormal)
-	c.stopExecutor()
-	c.stopScheduler()
-	if c.proxyManager != nil {
-		c.proxyManager.Stop()
+	if !c.stateCode.CompareAndSwap(int32(commonpb.StateCode_Healthy), int32(commonpb.StateCode_Abnormal)) {
+		return nil
 	}
-	c.cancelIfNotNil()
-	if c.quotaCenter != nil {
-		c.quotaCenter.stop()
+	logutil.Logger(c.ctx).Warn("server shutdown")
+
+	ctx, cancel := context.WithTimeout(context.Background(), Params.CommonCfg.CoordGracefulStopTimeout.GetAsDuration(time.Second))
+	defer cancel()
+
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		c.stopExecutor()
+		logutil.Logger(c.ctx).Warn("stop executor successfully")
+		c.stopScheduler()
+		logutil.Logger(c.ctx).Warn("stop scheduler successfully")
+		if c.proxyManager != nil {
+			c.proxyManager.Stop()
+		}
+		logutil.Logger(c.ctx).Warn("stop proxy manager successfully")
+		c.cancelIfNotNil()
+		if c.quotaCenter != nil {
+			c.quotaCenter.stop()
+		}
+		logutil.Logger(c.ctx).Warn("stop quotacenter successfully")
+		c.wg.Wait()
+		c.revokeSession()
+	}()
+
+	select {
+	case <-ctx.Done():
+		// direct stop after certain time
+		panic("stopping rootcoord took too long")
+	case <-done:
+		logutil.Logger(c.ctx).Warn("rootcoord stop successfully")
 	}
-	c.wg.Wait()
-	c.revokeSession()
 	return nil
 }
 

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -34,7 +34,8 @@ const (
 	DefaultIndexSliceSize                      = 16
 	DefaultConsistencyLevelUsedInDelete        = commonpb.ConsistencyLevel_Bounded
 	DefaultGracefulTime                        = 5000 // ms
-	DefaultGracefulStopTimeout                 = 1800 // s
+	DefaultGracefulStopTimeout                 = 900  // s
+	DefaultCoordGracefulStopTimeout            = 5    // s
 	DefaultHighPriorityThreadCoreCoefficient   = 10
 	DefaultMiddlePriorityThreadCoreCoefficient = 5
 	DefaultLowPriorityThreadCoreCoefficient    = 1
@@ -200,6 +201,7 @@ type commonConfig struct {
 	ConsistencyLevelUsedInDelete        ParamItem `refreshable:"true"`
 	GracefulTime                        ParamItem `refreshable:"true"`
 	GracefulStopTimeout                 ParamItem `refreshable:"true"`
+	CoordGracefulStopTimeout            ParamItem `refreshable:"true"`
 
 	StorageType ParamItem `refreshable:"false"`
 	SimdType    ParamItem `refreshable:"false"`
@@ -497,6 +499,15 @@ This configuration is only used by querynode and indexnode, it selects CPU instr
 		Export:       true,
 	}
 	p.GracefulStopTimeout.Init(base.mgr)
+
+	p.CoordGracefulStopTimeout = ParamItem{
+		Key:          "common.coord.gracefulStopTimeout",
+		Version:      "2.3.7",
+		DefaultValue: strconv.Itoa(DefaultCoordGracefulStopTimeout),
+		Doc:          "seconds. it will force quit the server if the graceful stop process is not completed during this time.",
+		Export:       true,
+	}
+	p.CoordGracefulStopTimeout.Init(base.mgr)
 
 	p.StorageType = ParamItem{
 		Key:          "common.storageType",


### PR DESCRIPTION
1. add coordinator graceful stop timeout to 5s
2. change the order of datacoord component while stop
3. change querynode grace stop timeout to 900s, and we should potentially change this to 600s when graceful stop is smooth

related to #30310
master pr #30312