### PR TITLE
enhance: Make l0 compactor download files in parallel

### DIFF
--- a/internal/datanode/io/binlog_io.go
+++ b/internal/datanode/io/binlog_io.go
@@ -51,6 +51,7 @@ func (b *BinlogIoImpl) Download(ctx context.Context, paths []string) ([][]byte, 
 
 	futures := make([]*conc.Future[any], 0, len(paths))
 	for _, path := range paths {
+		path := path
 		future := b.pool.Submit(func() (any, error) {
 			var val []byte
 			var err error

--- a/internal/datanode/io/binlog_io.go
+++ b/internal/datanode/io/binlog_io.go
@@ -65,7 +65,7 @@ func (b *BinlogIoImpl) Download(ctx context.Context, paths []string) ([][]byte, 
 		futures = append(futures, future)
 	}
 
-	err := conc.AwaitAll(futures...) // future.Await()
+	err := conc.AwaitAll(futures...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/datanode/io/binlog_io.go
+++ b/internal/datanode/io/binlog_io.go
@@ -20,13 +20,13 @@ import (
 	"context"
 	"path"
 
+	"github.com/samber/lo"
 	"go.opentelemetry.io/otel"
 
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/pkg/util/conc"
 	"github.com/milvus-io/milvus/pkg/util/retry"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
-	"github.com/samber/lo"
 )
 
 type BinlogIO interface {


### PR DESCRIPTION
See also #27606

`MultiRead` actually download file in sequence, which may lead to large time consumption during l0 compaction download phase.

This PR make l0 compactor download deltalogs in parallel utilizing conc package & io pool.