### PR TITLE
enhance: add graceful stop timeout to avoid coordinator stop hang under extreme cases

### DIFF
--- a/internal/datacoord/server.go.orig
+++ b/internal/datacoord/server.go.orig
@@ -1092,48 +1092,23 @@ func (s *Server) Stop() error {
 	if !s.stateCode.CompareAndSwap(commonpb.StateCode_Healthy, commonpb.StateCode_Abnormal) {
 		return nil
 	}
-	logutil.Logger(s.ctx).Warn("server shutdown")
+	logutil.Logger(s.ctx).Info("server shutdown")
+	s.cluster.Close()
+	s.garbageCollector.close()
+	s.stopServerLoop()
 
-	ctx, cancel := context.WithTimeout(context.Background(), Params.CommonCfg.CoordGracefulStopTimeout.GetAsDuration(time.Second))
-	defer cancel()
+	if Params.DataCoordCfg.EnableCompaction.GetAsBool() {
+		s.stopCompactionTrigger()
+		s.stopCompactionHandler()
+	}
+	s.indexBuilder.Stop()
 
-	done := make(chan struct{})
+	if s.session != nil {
+		s.session.Stop()
+	}
 
-	go func() {
-		defer close(done)
-		s.garbageCollector.close()
-		logutil.Logger(s.ctx).Info("datacoord garbage collector stopped")
-
-		if Params.DataCoordCfg.EnableCompaction.GetAsBool() {
-			s.stopCompactionTrigger()
-			s.stopCompactionHandler()
-		}
-		logutil.Logger(s.ctx).Info("datacoord compaction stopped")
-
-		s.indexBuilder.Stop()
-		logutil.Logger(s.ctx).Info("datacoord index builder stopped")
-
-		s.cluster.Close()
-		logutil.Logger(s.ctx).Info("index builder stopped")
-
-		s.stopServerLoop()
-		logutil.Logger(s.ctx).Info("serverloop stopped")
-
-		if s.session != nil {
-			s.session.Stop()
-		}
-
-		if s.icSession != nil {
-			s.icSession.Stop()
-		}
-	}()
-
-	select {
-	case <-ctx.Done():
-		// direct stop after certain time
-		panic("stopping datacoord took too long")
-	case <-done:
-		logutil.Logger(s.ctx).Warn("datacoord stop sucessfully")
+	if s.icSession != nil {
+		s.icSession.Stop()
 	}
 
 	return nil

--- a/internal/querycoordv2/server.go
+++ b/internal/querycoordv2/server.go
@@ -59,6 +59,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/metrics"
 	"github.com/milvus-io/milvus/pkg/util"
 	"github.com/milvus-io/milvus/pkg/util/expr"
+	"github.com/milvus-io/milvus/pkg/util/logutil"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/metricsinfo"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
@@ -456,60 +457,82 @@ func (s *Server) startServerLoop() {
 }
 
 func (s *Server) Stop() error {
+	if !s.status.CompareAndSwap(int32(commonpb.StateCode_Healthy), int32(commonpb.StateCode_Abnormal)) {
+		return nil
+	}
+	logutil.Logger(s.ctx).Warn("server shutdown")
+
 	// stop the components from outside to inside,
 	// to make the dependencies stopped working properly,
 	// cancel the server context first to stop receiving requests
 	s.cancel()
 
-	// FOLLOW the dependence graph:
-	// job scheduler -> checker controller -> task scheduler -> dist controller -> cluster -> session
-	// observers -> dist controller
+	ctx, cancel := context.WithTimeout(context.Background(), Params.CommonCfg.CoordGracefulStopTimeout.GetAsDuration(time.Second))
+	defer cancel()
 
-	if s.jobScheduler != nil {
-		log.Info("stop job scheduler...")
-		s.jobScheduler.Stop()
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		// FOLLOW the dependence graph:
+		// job scheduler -> checker controller -> task scheduler -> dist controller -> cluster -> session
+		// observers -> dist controller
+
+		if s.jobScheduler != nil {
+			log.Info("stop job scheduler...")
+			s.jobScheduler.Stop()
+		}
+
+		if s.checkerController != nil {
+			log.Info("stop checker controller...")
+			s.checkerController.Stop()
+		}
+
+		if s.taskScheduler != nil {
+			log.Info("stop task scheduler...")
+			s.taskScheduler.Stop()
+		}
+
+		log.Info("stop observers...")
+		if s.collectionObserver != nil {
+			s.collectionObserver.Stop()
+		}
+		if s.targetObserver != nil {
+			s.targetObserver.Stop()
+		}
+		if s.replicaObserver != nil {
+			s.replicaObserver.Stop()
+		}
+		if s.resourceObserver != nil {
+			s.resourceObserver.Stop()
+		}
+
+		if s.distController != nil {
+			log.Info("stop dist controller...")
+			s.distController.Stop()
+		}
+
+		if s.cluster != nil {
+			log.Info("stop cluster...")
+			s.cluster.Stop()
+		}
+
+		if s.session != nil {
+			s.session.Stop()
+		}
+
+		s.wg.Wait()
+	}()
+
+	select {
+	case <-ctx.Done():
+		// direct stop after certain time
+		panic("stopping querycoord took too long")
+	case <-done:
+		logutil.Logger(s.ctx).Warn("querycoord stop sucessfully")
 	}
 
-	if s.checkerController != nil {
-		log.Info("stop checker controller...")
-		s.checkerController.Stop()
-	}
-
-	if s.taskScheduler != nil {
-		log.Info("stop task scheduler...")
-		s.taskScheduler.Stop()
-	}
-
-	log.Info("stop observers...")
-	if s.collectionObserver != nil {
-		s.collectionObserver.Stop()
-	}
-	if s.targetObserver != nil {
-		s.targetObserver.Stop()
-	}
-	if s.replicaObserver != nil {
-		s.replicaObserver.Stop()
-	}
-	if s.resourceObserver != nil {
-		s.resourceObserver.Stop()
-	}
-
-	if s.distController != nil {
-		log.Info("stop dist controller...")
-		s.distController.Stop()
-	}
-
-	if s.cluster != nil {
-		log.Info("stop cluster...")
-		s.cluster.Stop()
-	}
-
-	if s.session != nil {
-		s.session.Stop()
-	}
-
-	s.wg.Wait()
-	log.Info("QueryCoord stop successfully")
 	return nil
 }
 

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -32,7 +32,8 @@ const (
 	// DefaultIndexSliceSize defines the default slice size of index file when serializing.
 	DefaultIndexSliceSize                      = 16
 	DefaultGracefulTime                        = 5000 // ms
-	DefaultGracefulStopTimeout                 = 1800 // s
+	DefaultGracefulStopTimeout                 = 900  // s
+	DefaultCoordGracefulStopTimeout            = 5    // s
 	DefaultHighPriorityThreadCoreCoefficient   = 10
 	DefaultMiddlePriorityThreadCoreCoefficient = 5
 	DefaultLowPriorityThreadCoreCoefficient    = 1
@@ -200,6 +201,7 @@ type commonConfig struct {
 	BeamWidthRatio                      ParamItem `refreshable:"true"`
 	GracefulTime                        ParamItem `refreshable:"true"`
 	GracefulStopTimeout                 ParamItem `refreshable:"true"`
+	CoordGracefulStopTimeout            ParamItem `refreshable:"true"`
 
 	StorageType ParamItem `refreshable:"false"`
 	SimdType    ParamItem `refreshable:"false"`
@@ -504,6 +506,15 @@ This configuration is only used by querynode and indexnode, it selects CPU instr
 		Export:       true,
 	}
 	p.GracefulStopTimeout.Init(base.mgr)
+
+	p.CoordGracefulStopTimeout = ParamItem{
+		Key:          "common.coord.gracefulStopTimeout",
+		Version:      "2.3.7",
+		DefaultValue: strconv.Itoa(DefaultCoordGracefulStopTimeout),
+		Doc:          "seconds. it will force quit the server if the graceful stop process is not completed during this time.",
+		Export:       true,
+	}
+	p.CoordGracefulStopTimeout.Init(base.mgr)
 
 	p.StorageType = ParamItem{
 		Key:          "common.storageType",


### PR DESCRIPTION
1. add coordinator graceful stop timeout to 5s
2. change the order of datacoord component while stop
3. change querynode grace stop timeout to 900s, and we should potentially change this to 600s when graceful stop is smooth
related to #30310