### PR TITLE
enhance: add graceful stop timeout to avoid node stop hang under extreme cases

### DIFF
--- a/cmd/components/data_coord.go
+++ b/cmd/components/data_coord.go
@@ -18,6 +18,7 @@ package components
 
 import (
 	"context"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -26,6 +27,7 @@ import (
 	grpcdatacoordclient "github.com/milvus-io/milvus/internal/distributed/datacoord"
 	"github.com/milvus-io/milvus/internal/util/dependency"
 	"github.com/milvus-io/milvus/pkg/log"
+	"github.com/milvus-io/milvus/pkg/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
 
@@ -57,10 +59,8 @@ func (s *DataCoord) Run() error {
 
 // Stop terminates service
 func (s *DataCoord) Stop() error {
-	if err := s.svr.Stop(); err != nil {
-		return err
-	}
-	return nil
+	timeout := paramtable.Get().DataCoordCfg.GracefulStopTimeout.GetAsDuration(time.Second)
+	return stopWithTimeout(s.svr.Stop, timeout)
 }
 
 // GetComponentStates returns DataCoord's states

--- a/cmd/components/data_coord.go
+++ b/cmd/components/data_coord.go
@@ -60,7 +60,7 @@ func (s *DataCoord) Run() error {
 // Stop terminates service
 func (s *DataCoord) Stop() error {
 	timeout := paramtable.Get().DataCoordCfg.GracefulStopTimeout.GetAsDuration(time.Second)
-	return stopWithTimeout(s.svr.Stop, timeout)
+	return exitWhenStopTimeout(s.svr.Stop, timeout)
 }
 
 // GetComponentStates returns DataCoord's states

--- a/cmd/components/data_node.go
+++ b/cmd/components/data_node.go
@@ -63,7 +63,7 @@ func (d *DataNode) Run() error {
 // Stop terminates service
 func (d *DataNode) Stop() error {
 	timeout := paramtable.Get().DataNodeCfg.GracefulStopTimeout.GetAsDuration(time.Second)
-	return stopWithTimeout(d.svr.Stop, timeout)
+	return exitWhenStopTimeout(d.svr.Stop, timeout)
 }
 
 // GetComponentStates returns DataNode's states

--- a/cmd/components/data_node.go
+++ b/cmd/components/data_node.go
@@ -18,6 +18,7 @@ package components
 
 import (
 	"context"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -26,6 +27,7 @@ import (
 	grpcdatanode "github.com/milvus-io/milvus/internal/distributed/datanode"
 	"github.com/milvus-io/milvus/internal/util/dependency"
 	"github.com/milvus-io/milvus/pkg/log"
+	"github.com/milvus-io/milvus/pkg/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
 
@@ -60,10 +62,8 @@ func (d *DataNode) Run() error {
 
 // Stop terminates service
 func (d *DataNode) Stop() error {
-	if err := d.svr.Stop(); err != nil {
-		return err
-	}
-	return nil
+	timeout := paramtable.Get().DataNodeCfg.GracefulStopTimeout.GetAsDuration(time.Second)
+	return stopWithTimeout(d.svr.Stop, timeout)
 }
 
 // GetComponentStates returns DataNode's states

--- a/cmd/components/index_node.go
+++ b/cmd/components/index_node.go
@@ -61,7 +61,7 @@ func (n *IndexNode) Run() error {
 // Stop terminates service
 func (n *IndexNode) Stop() error {
 	timeout := paramtable.Get().IndexNodeCfg.GracefulStopTimeout.GetAsDuration(time.Second)
-	return stopWithTimeout(n.svr.Stop, timeout)
+	return exitWhenStopTimeout(n.svr.Stop, timeout)
 }
 
 // GetComponentStates returns IndexNode's states

--- a/cmd/components/index_node.go
+++ b/cmd/components/index_node.go
@@ -18,6 +18,7 @@ package components
 
 import (
 	"context"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -26,6 +27,7 @@ import (
 	grpcindexnode "github.com/milvus-io/milvus/internal/distributed/indexnode"
 	"github.com/milvus-io/milvus/internal/util/dependency"
 	"github.com/milvus-io/milvus/pkg/log"
+	"github.com/milvus-io/milvus/pkg/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
 
@@ -58,10 +60,8 @@ func (n *IndexNode) Run() error {
 
 // Stop terminates service
 func (n *IndexNode) Stop() error {
-	if err := n.svr.Stop(); err != nil {
-		return err
-	}
-	return nil
+	timeout := paramtable.Get().IndexNodeCfg.GracefulStopTimeout.GetAsDuration(time.Second)
+	return stopWithTimeout(n.svr.Stop, timeout)
 }
 
 // GetComponentStates returns IndexNode's states

--- a/cmd/components/proxy.go
+++ b/cmd/components/proxy.go
@@ -18,6 +18,7 @@ package components
 
 import (
 	"context"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -26,6 +27,7 @@ import (
 	grpcproxy "github.com/milvus-io/milvus/internal/distributed/proxy"
 	"github.com/milvus-io/milvus/internal/util/dependency"
 	"github.com/milvus-io/milvus/pkg/log"
+	"github.com/milvus-io/milvus/pkg/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
 
@@ -59,10 +61,8 @@ func (n *Proxy) Run() error {
 
 // Stop terminates service
 func (n *Proxy) Stop() error {
-	if err := n.svr.Stop(); err != nil {
-		return err
-	}
-	return nil
+	timeout := paramtable.Get().ProxyCfg.GracefulStopTimeout.GetAsDuration(time.Second)
+	return stopWithTimeout(n.svr.Stop, timeout)
 }
 
 // GetComponentStates returns Proxy's states

--- a/cmd/components/proxy.go
+++ b/cmd/components/proxy.go
@@ -62,7 +62,7 @@ func (n *Proxy) Run() error {
 // Stop terminates service
 func (n *Proxy) Stop() error {
 	timeout := paramtable.Get().ProxyCfg.GracefulStopTimeout.GetAsDuration(time.Second)
-	return stopWithTimeout(n.svr.Stop, timeout)
+	return exitWhenStopTimeout(n.svr.Stop, timeout)
 }
 
 // GetComponentStates returns Proxy's states

--- a/cmd/components/query_coord.go
+++ b/cmd/components/query_coord.go
@@ -63,7 +63,7 @@ func (qs *QueryCoord) Run() error {
 // Stop terminates service
 func (qs *QueryCoord) Stop() error {
 	timeout := paramtable.Get().QueryCoordCfg.GracefulStopTimeout.GetAsDuration(time.Second)
-	return stopWithTimeout(qs.svr.Stop, timeout)
+	return exitWhenStopTimeout(qs.svr.Stop, timeout)
 }
 
 // GetComponentStates returns QueryCoord's states

--- a/cmd/components/query_coord.go
+++ b/cmd/components/query_coord.go
@@ -18,6 +18,7 @@ package components
 
 import (
 	"context"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -26,6 +27,7 @@ import (
 	grpcquerycoord "github.com/milvus-io/milvus/internal/distributed/querycoord"
 	"github.com/milvus-io/milvus/internal/util/dependency"
 	"github.com/milvus-io/milvus/pkg/log"
+	"github.com/milvus-io/milvus/pkg/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
 
@@ -60,10 +62,8 @@ func (qs *QueryCoord) Run() error {
 
 // Stop terminates service
 func (qs *QueryCoord) Stop() error {
-	if err := qs.svr.Stop(); err != nil {
-		return err
-	}
-	return nil
+	timeout := paramtable.Get().QueryCoordCfg.GracefulStopTimeout.GetAsDuration(time.Second)
+	return stopWithTimeout(qs.svr.Stop, timeout)
 }
 
 // GetComponentStates returns QueryCoord's states

--- a/cmd/components/query_node.go
+++ b/cmd/components/query_node.go
@@ -18,6 +18,7 @@ package components
 
 import (
 	"context"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -26,6 +27,7 @@ import (
 	grpcquerynode "github.com/milvus-io/milvus/internal/distributed/querynode"
 	"github.com/milvus-io/milvus/internal/util/dependency"
 	"github.com/milvus-io/milvus/pkg/log"
+	"github.com/milvus-io/milvus/pkg/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
 
@@ -60,10 +62,8 @@ func (q *QueryNode) Run() error {
 
 // Stop terminates service
 func (q *QueryNode) Stop() error {
-	if err := q.svr.Stop(); err != nil {
-		return err
-	}
-	return nil
+	timeout := paramtable.Get().QueryNodeCfg.GracefulStopTimeout.GetAsDuration(time.Second)
+	return stopWithTimeout(q.svr.Stop, timeout)
 }
 
 // GetComponentStates returns QueryNode's states

--- a/cmd/components/query_node.go
+++ b/cmd/components/query_node.go
@@ -63,7 +63,7 @@ func (q *QueryNode) Run() error {
 // Stop terminates service
 func (q *QueryNode) Stop() error {
 	timeout := paramtable.Get().QueryNodeCfg.GracefulStopTimeout.GetAsDuration(time.Second)
-	return stopWithTimeout(q.svr.Stop, timeout)
+	return exitWhenStopTimeout(q.svr.Stop, timeout)
 }
 
 // GetComponentStates returns QueryNode's states

--- a/cmd/components/root_coord.go
+++ b/cmd/components/root_coord.go
@@ -18,6 +18,7 @@ package components
 
 import (
 	"context"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -26,6 +27,7 @@ import (
 	rc "github.com/milvus-io/milvus/internal/distributed/rootcoord"
 	"github.com/milvus-io/milvus/internal/util/dependency"
 	"github.com/milvus-io/milvus/pkg/log"
+	"github.com/milvus-io/milvus/pkg/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
 
@@ -59,10 +61,8 @@ func (rc *RootCoord) Run() error {
 
 // Stop terminates service
 func (rc *RootCoord) Stop() error {
-	if rc.svr != nil {
-		return rc.svr.Stop()
-	}
-	return nil
+	timeout := paramtable.Get().RootCoordCfg.GracefulStopTimeout.GetAsDuration(time.Second)
+	return stopWithTimeout(rc.svr.Stop, timeout)
 }
 
 // GetComponentStates returns RootCoord's states

--- a/cmd/components/root_coord.go
+++ b/cmd/components/root_coord.go
@@ -62,7 +62,7 @@ func (rc *RootCoord) Run() error {
 // Stop terminates service
 func (rc *RootCoord) Stop() error {
 	timeout := paramtable.Get().RootCoordCfg.GracefulStopTimeout.GetAsDuration(time.Second)
-	return stopWithTimeout(rc.svr.Stop, timeout)
+	return exitWhenStopTimeout(rc.svr.Stop, timeout)
 }
 
 // GetComponentStates returns RootCoord's states

--- a/cmd/components/util.go
+++ b/cmd/components/util.go
@@ -1,0 +1,25 @@
+package components
+
+import (
+	"context"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/milvus-io/milvus/pkg/util/conc"
+)
+
+// stopWithTimeout stops a component with timeout.
+func stopWithTimeout(stop func() error, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	future := conc.Go(func() (struct{}, error) {
+		return struct{}{}, stop()
+	})
+	select {
+	case <-future.Inner():
+		return errors.Wrap(future.Err(), "failed to stop component")
+	case <-ctx.Done():
+		return errors.Wrap(ctx.Err(), "timeout when stopping component")
+	}
+}

--- a/cmd/components/util_test.go
+++ b/cmd/components/util_test.go
@@ -1,0 +1,38 @@
+package components
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExitWithTimeout(t *testing.T) {
+	// only normal path can be tested.
+	targetErr := errors.New("stop error")
+	err := exitWhenStopTimeout(func() error {
+		time.Sleep(1 * time.Second)
+		return targetErr
+	}, 5*time.Second)
+	assert.ErrorIs(t, err, targetErr)
+}
+
+func TestStopWithTimeout(t *testing.T) {
+	ch := make(chan struct{})
+	stop := func() error {
+		<-ch
+		return nil
+	}
+
+	err := stopWithTimeout(stop, 1*time.Second)
+	assert.ErrorIs(t, err, errStopTimeout)
+
+	targetErr := errors.New("stop error")
+	stop = func() error {
+		return targetErr
+	}
+
+	err = stopWithTimeout(stop, 1*time.Second)
+	assert.ErrorIs(t, err, targetErr)
+}

--- a/internal/datacoord/server.go
+++ b/internal/datacoord/server.go
@@ -1041,15 +1041,23 @@ func (s *Server) Stop() error {
 		return nil
 	}
 	logutil.Logger(s.ctx).Info("server shutdown")
-	s.cluster.Close()
 	s.garbageCollector.close()
-	s.stopServerLoop()
+	logutil.Logger(s.ctx).Info("datacoord garbage collector stopped")
 
 	if Params.DataCoordCfg.EnableCompaction.GetAsBool() {
 		s.stopCompactionTrigger()
 		s.stopCompactionHandler()
 	}
+	logutil.Logger(s.ctx).Info("datacoord compaction stopped")
+
 	s.indexBuilder.Stop()
+	logutil.Logger(s.ctx).Info("datacoord index builder stopped")
+
+	s.cluster.Close()
+	logutil.Logger(s.ctx).Info("index builder stopped")
+
+	s.stopServerLoop()
+	logutil.Logger(s.ctx).Info("serverloop stopped")
 
 	if s.session != nil {
 		s.session.Stop()
@@ -1058,6 +1066,7 @@ func (s *Server) Stop() error {
 	if s.icSession != nil {
 		s.icSession.Stop()
 	}
+	logutil.Logger(s.ctx).Warn("datacoord stop successful")
 
 	return nil
 }

--- a/internal/datacoord/server.go
+++ b/internal/datacoord/server.go
@@ -269,16 +269,7 @@ func (s *Server) Register() error {
 
 	s.session.LivenessCheck(s.serverLoopCtx, func() {
 		logutil.Logger(s.ctx).Error("disconnected from etcd and exited", zap.Int64("serverID", s.session.GetServerID()))
-		if err := s.Stop(); err != nil {
-			logutil.Logger(s.ctx).Fatal("failed to stop server", zap.Error(err))
-		}
-		metrics.NumNodes.WithLabelValues(fmt.Sprint(paramtable.GetNodeID()), typeutil.DataCoordRole).Dec()
-		// manually send signal to starter goroutine
-		if s.session.IsTriggerKill() {
-			if p, err := os.FindProcess(os.Getpid()); err == nil {
-				p.Signal(syscall.SIGINT)
-			}
-		}
+		os.Exit(1)
 	})
 	return nil
 }

--- a/internal/datanode/data_node.go
+++ b/internal/datanode/data_node.go
@@ -27,7 +27,6 @@ import (
 	"os"
 	"sync"
 	"sync/atomic"
-	"syscall"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -188,16 +187,7 @@ func (node *DataNode) Register() error {
 	// Start liveness check
 	node.session.LivenessCheck(node.ctx, func() {
 		log.Error("Data Node disconnected from etcd, process will exit", zap.Int64("Server Id", node.GetSession().ServerID))
-		if err := node.Stop(); err != nil {
-			log.Fatal("failed to stop server", zap.Error(err))
-		}
-		metrics.NumNodes.WithLabelValues(fmt.Sprint(paramtable.GetNodeID()), typeutil.DataNodeRole).Dec()
-		// manually send signal to starter goroutine
-		if node.session.TriggerKill {
-			if p, err := os.FindProcess(os.Getpid()); err == nil {
-				p.Signal(syscall.SIGINT)
-			}
-		}
+		os.Exit(1)
 	})
 
 	return nil

--- a/internal/distributed/datacoord/service.go
+++ b/internal/distributed/datacoord/service.go
@@ -218,10 +218,14 @@ func (s *Server) start() error {
 
 // Stop stops the DataCoord server gracefully.
 // Need to call the GracefulStop interface of grpc server and call the stop method of the inner DataCoord object.
-func (s *Server) Stop() error {
+func (s *Server) Stop() (err error) {
 	Params := &paramtable.Get().DataCoordGrpcServerCfg
-	log.Debug("Datacoord stop", zap.String("Address", Params.GetAddress()))
-	var err error
+	logger := log.With(zap.String("address", Params.GetAddress()))
+	logger.Info("Datacoord stopping")
+	defer func() {
+		logger.Info("Datacoord stopped", zap.Error(err))
+	}()
+
 	s.cancel()
 
 	if s.etcdCli != nil {

--- a/internal/distributed/datanode/service.go
+++ b/internal/distributed/datanode/service.go
@@ -198,9 +198,14 @@ func (s *Server) Run() error {
 }
 
 // Stop stops Datanode's grpc service.
-func (s *Server) Stop() error {
+func (s *Server) Stop() (err error) {
 	Params := &paramtable.Get().DataNodeGrpcServerCfg
-	log.Debug("Datanode stop", zap.String("Address", Params.GetAddress()))
+	logger := log.With(zap.String("address", Params.GetAddress()))
+	logger.Info("Datanode stopping")
+	defer func() {
+		logger.Info("Datanode stopped", zap.Error(err))
+	}()
+
 	s.cancel()
 	if s.etcdCli != nil {
 		defer s.etcdCli.Close()
@@ -209,7 +214,7 @@ func (s *Server) Stop() error {
 		utils.GracefulStopGRPCServer(s.grpcServer)
 	}
 
-	err := s.datanode.Stop()
+	err = s.datanode.Stop()
 	if err != nil {
 		return err
 	}

--- a/internal/distributed/indexnode/service.go
+++ b/internal/distributed/indexnode/service.go
@@ -208,9 +208,14 @@ func (s *Server) start() error {
 }
 
 // Stop stops IndexNode's grpc service.
-func (s *Server) Stop() error {
+func (s *Server) Stop() (err error) {
 	Params := &paramtable.Get().IndexNodeGrpcServerCfg
-	log.Debug("IndexNode stop", zap.String("Address", Params.GetAddress()))
+	logger := log.With(zap.String("address", Params.GetAddress()))
+	logger.Info("IndexNode stopping")
+	defer func() {
+		logger.Info("IndexNode stopped", zap.Error(err))
+	}()
+
 	if s.indexnode != nil {
 		s.indexnode.Stop()
 	}

--- a/internal/distributed/proxy/service.go
+++ b/internal/distributed/proxy/service.go
@@ -662,9 +662,13 @@ func (s *Server) start() error {
 }
 
 // Stop stop the Proxy Server
-func (s *Server) Stop() error {
+func (s *Server) Stop() (err error) {
 	Params := &paramtable.Get().ProxyGrpcServerCfg
-	log.Debug("Proxy stop", zap.String("internal address", Params.GetInternalAddress()), zap.String("external address", Params.GetInternalAddress()))
+	logger := log.With(zap.String("internal address", Params.GetInternalAddress()), zap.String("external address", Params.GetInternalAddress()))
+	logger.Info("Proxy stopping")
+	defer func() {
+		logger.Info("Proxy stopped", zap.Error(err))
+	}()
 
 	if s.etcdCli != nil {
 		defer s.etcdCli.Close()
@@ -708,7 +712,7 @@ func (s *Server) Stop() error {
 
 	s.wg.Wait()
 
-	err := s.proxy.Stop()
+	err = s.proxy.Stop()
 	if err != nil {
 		return err
 	}

--- a/internal/distributed/querycoord/service.go
+++ b/internal/distributed/querycoord/service.go
@@ -269,9 +269,14 @@ func (s *Server) start() error {
 }
 
 // Stop stops QueryCoord's grpc service.
-func (s *Server) Stop() error {
+func (s *Server) Stop() (err error) {
 	Params := &paramtable.Get().QueryCoordGrpcServerCfg
-	log.Debug("QueryCoord stop", zap.String("Address", Params.GetAddress()))
+	logger := log.With(zap.String("address", Params.GetAddress()))
+	logger.Info("QueryCoord stopping")
+	defer func() {
+		logger.Info("QueryCoord stopped", zap.Error(err))
+	}()
+
 	if s.etcdCli != nil {
 		defer s.etcdCli.Close()
 	}
@@ -279,9 +284,7 @@ func (s *Server) Stop() error {
 	if s.grpcServer != nil {
 		utils.GracefulStopGRPCServer(s.grpcServer)
 	}
-	err := s.queryCoord.Stop()
-
-	return err
+	return s.queryCoord.Stop()
 }
 
 // SetRootCoord sets root coordinator's client

--- a/internal/distributed/querynode/service.go
+++ b/internal/distributed/querynode/service.go
@@ -233,10 +233,15 @@ func (s *Server) Run() error {
 }
 
 // Stop stops QueryNode's grpc service.
-func (s *Server) Stop() error {
+func (s *Server) Stop() (err error) {
 	Params := &paramtable.Get().QueryNodeGrpcServerCfg
-	log.Debug("QueryNode stop", zap.String("Address", Params.GetAddress()))
-	err := s.querynode.Stop()
+	logger := log.With(zap.String("address", Params.GetAddress()))
+	logger.Info("QueryNode stopping")
+	defer func() {
+		logger.Info("QueryNode stopped", zap.Error(err))
+	}()
+
+	err = s.querynode.Stop()
 	if err != nil {
 		return err
 	}

--- a/internal/distributed/rootcoord/service.go
+++ b/internal/distributed/rootcoord/service.go
@@ -312,9 +312,14 @@ func (s *Server) start() error {
 	return nil
 }
 
-func (s *Server) Stop() error {
+func (s *Server) Stop() (err error) {
 	Params := &paramtable.Get().RootCoordGrpcServerCfg
-	log.Debug("Rootcoord stop", zap.String("Address", Params.GetAddress()))
+	logger := log.With(zap.String("address", Params.GetAddress()))
+	logger.Info("Rootcoord stopping")
+	defer func() {
+		logger.Info("Rootcoord stopped", zap.Error(err))
+	}()
+
 	if s.etcdCli != nil {
 		defer s.etcdCli.Close()
 	}

--- a/internal/indexnode/indexnode.go
+++ b/internal/indexnode/indexnode.go
@@ -35,7 +35,6 @@ import (
 	"path"
 	"path/filepath"
 	"sync"
-	"syscall"
 	"time"
 	"unsafe"
 
@@ -139,16 +138,7 @@ func (i *IndexNode) Register() error {
 	// start liveness check
 	i.session.LivenessCheck(i.loopCtx, func() {
 		log.Error("Index Node disconnected from etcd, process will exit", zap.Int64("Server Id", i.session.ServerID))
-		if err := i.Stop(); err != nil {
-			log.Fatal("failed to stop server", zap.Error(err))
-		}
-		metrics.NumNodes.WithLabelValues(fmt.Sprint(paramtable.GetNodeID()), typeutil.IndexNodeRole).Dec()
-		// manually send signal to starter goroutine
-		if i.session.TriggerKill {
-			if p, err := os.FindProcess(os.Getpid()); err == nil {
-				p.Signal(syscall.SIGINT)
-			}
-		}
+		os.Exit(1)
 	})
 	return nil
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"strconv"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -166,15 +165,7 @@ func (node *Proxy) Register() error {
 	log.Info("Proxy Register Finished")
 	node.session.LivenessCheck(node.ctx, func() {
 		log.Error("Proxy disconnected from etcd, process will exit", zap.Int64("Server Id", node.session.ServerID))
-		if err := node.Stop(); err != nil {
-			log.Fatal("failed to stop server", zap.Error(err))
-		}
-		metrics.NumNodes.WithLabelValues(fmt.Sprint(paramtable.GetNodeID()), typeutil.ProxyRole).Dec()
-		if node.session.TriggerKill {
-			if p, err := os.FindProcess(os.Getpid()); err == nil {
-				p.Signal(syscall.SIGINT)
-			}
-		}
+		os.Exit(1)
 	})
 	// TODO Reset the logger
 	// Params.initLogCfg()

--- a/internal/querycoordv2/server.go
+++ b/internal/querycoordv2/server.go
@@ -151,16 +151,7 @@ func (s *Server) Register() error {
 	metrics.NumNodes.WithLabelValues(fmt.Sprint(paramtable.GetNodeID()), typeutil.QueryCoordRole).Inc()
 	s.session.LivenessCheck(s.ctx, func() {
 		log.Error("QueryCoord disconnected from etcd, process will exit", zap.Int64("serverID", s.session.GetServerID()))
-		if err := s.Stop(); err != nil {
-			log.Fatal("failed to stop server", zap.Error(err))
-		}
-		metrics.NumNodes.WithLabelValues(fmt.Sprint(paramtable.GetNodeID()), typeutil.QueryCoordRole).Dec()
-		// manually send signal to starter goroutine
-		if s.session.IsTriggerKill() {
-			if p, err := os.FindProcess(os.Getpid()); err == nil {
-				p.Signal(syscall.SIGINT)
-			}
-		}
+		os.Exit(1)
 	})
 	return nil
 }

--- a/internal/rootcoord/root_coord.go
+++ b/internal/rootcoord/root_coord.go
@@ -22,7 +22,6 @@ import (
 	"math/rand"
 	"os"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -280,16 +279,7 @@ func (c *Core) Register() error {
 	log.Info("RootCoord Register Finished")
 	c.session.LivenessCheck(c.ctx, func() {
 		log.Error("Root Coord disconnected from etcd, process will exit", zap.Int64("Server Id", c.session.ServerID))
-		if err := c.Stop(); err != nil {
-			log.Fatal("failed to stop server", zap.Error(err))
-		}
-		metrics.NumNodes.WithLabelValues(fmt.Sprint(paramtable.GetNodeID()), typeutil.RootCoordRole).Dec()
-		// manually send signal to starter goroutine
-		if c.session.TriggerKill {
-			if p, err := os.FindProcess(os.Getpid()); err == nil {
-				p.Signal(syscall.SIGINT)
-			}
-		}
+		os.Exit(1)
 	})
 
 	return nil

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -34,7 +34,8 @@ const (
 	DefaultIndexSliceSize                      = 16
 	DefaultConsistencyLevelUsedInDelete        = commonpb.ConsistencyLevel_Bounded
 	DefaultGracefulTime                        = 5000 // ms
-	DefaultGracefulStopTimeout                 = 900  // s, for node
+	DefaultGracefulStopTimeout                 = 1800 // s, for node
+	DefaultProxyGracefulStopTimeout            = 30   // s，for proxy
 	DefaultCoordGracefulStopTimeout            = 5    // s，for coord
 	DefaultHighPriorityThreadCoreCoefficient   = 10
 	DefaultMiddlePriorityThreadCoreCoefficient = 5
@@ -1268,7 +1269,7 @@ please adjust in embedded Milvus: false`,
 	p.GracefulStopTimeout = ParamItem{
 		Key:          "proxy.gracefulStopTimeout",
 		Version:      "2.3.7",
-		DefaultValue: strconv.Itoa(DefaultGracefulStopTimeout),
+		DefaultValue: strconv.Itoa(DefaultProxyGracefulStopTimeout),
 		Doc:          "seconds. force stop node without graceful stop",
 		Export:       true,
 	}

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -34,7 +34,8 @@ const (
 	DefaultIndexSliceSize                      = 16
 	DefaultConsistencyLevelUsedInDelete        = commonpb.ConsistencyLevel_Bounded
 	DefaultGracefulTime                        = 5000 // ms
-	DefaultGracefulStopTimeout                 = 1800 // s
+	DefaultGracefulStopTimeout                 = 900  // s, for node
+	DefaultCoordGracefulStopTimeout            = 5    // s，for coord
 	DefaultHighPriorityThreadCoreCoefficient   = 10
 	DefaultMiddlePriorityThreadCoreCoefficient = 5
 	DefaultLowPriorityThreadCoreCoefficient    = 1
@@ -819,6 +820,7 @@ type rootCoordConfig struct {
 	EnableActiveStandby         ParamItem `refreshable:"false"`
 	MaxDatabaseNum              ParamItem `refreshable:"false"`
 	MaxGeneralCapacity          ParamItem `refreshable:"true"`
+	GracefulStopTimeout         ParamItem `refreshable:"true"`
 }
 
 func (p *rootCoordConfig) init(base *BaseTable) {
@@ -913,6 +915,15 @@ func (p *rootCoordConfig) init(base *BaseTable) {
 		},
 	}
 	p.MaxGeneralCapacity.Init(base.mgr)
+
+	p.GracefulStopTimeout = ParamItem{
+		Key:          "rootCoord.gracefulStopTimeout",
+		Version:      "2.3.7",
+		DefaultValue: strconv.Itoa(DefaultCoordGracefulStopTimeout),
+		Doc:          "seconds. force stop node without graceful stop",
+		Export:       true,
+	}
+	p.GracefulStopTimeout.Init(base.mgr)
 }
 
 // /////////////////////////////////////////////////////////////////////////////
@@ -959,6 +970,8 @@ type proxyConfig struct {
 	PartitionNameRegexp          ParamItem `refreshable:"true"`
 
 	AccessLog AccessLogConfig
+
+	GracefulStopTimeout ParamItem `refreshable:"true"`
 }
 
 func (p *proxyConfig) init(base *BaseTable) {
@@ -1251,6 +1264,15 @@ please adjust in embedded Milvus: false`,
 		Doc:          "switch for whether proxy shall use partition name as regexp when searching",
 	}
 	p.PartitionNameRegexp.Init(base.mgr)
+
+	p.GracefulStopTimeout = ParamItem{
+		Key:          "proxy.gracefulStopTimeout",
+		Version:      "2.3.7",
+		DefaultValue: strconv.Itoa(DefaultGracefulStopTimeout),
+		Doc:          "seconds. force stop node without graceful stop",
+		Export:       true,
+	}
+	p.GracefulStopTimeout.Init(base.mgr)
 }
 
 // /////////////////////////////////////////////////////////////////////////////
@@ -1314,6 +1336,7 @@ type queryCoordConfig struct {
 	ObserverTaskParallel           ParamItem `refreshable:"false"`
 	CheckAutoBalanceConfigInterval ParamItem `refreshable:"false"`
 	CheckNodeSessionInterval       ParamItem `refreshable:"false"`
+	GracefulStopTimeout            ParamItem `refreshable:"true"`
 }
 
 func (p *queryCoordConfig) init(base *BaseTable) {
@@ -1702,6 +1725,15 @@ func (p *queryCoordConfig) init(base *BaseTable) {
 		Export:       true,
 	}
 	p.HeartBeatWarningLag.Init(base.mgr)
+
+	p.GracefulStopTimeout = ParamItem{
+		Key:          "queryCoord.gracefulStopTimeout",
+		Version:      "2.3.7",
+		DefaultValue: strconv.Itoa(DefaultCoordGracefulStopTimeout),
+		Doc:          "seconds. force stop node without graceful stop",
+		Export:       true,
+	}
+	p.GracefulStopTimeout.Init(base.mgr)
 }
 
 // /////////////////////////////////////////////////////////////////////////////
@@ -2243,6 +2275,8 @@ type dataCoordConfig struct {
 	// auto balance channel on datanode
 	AutoBalance                    ParamItem `refreshable:"true"`
 	CheckAutoBalanceConfigInterval ParamItem `refreshable:"false"`
+
+	GracefulStopTimeout ParamItem `refreshable:"true"`
 }
 
 func (p *dataCoordConfig) init(base *BaseTable) {
@@ -2637,6 +2671,15 @@ During compaction, the size of segment # of rows is able to exceed segment max #
 		Export:       true,
 	}
 	p.AutoUpgradeSegmentIndex.Init(base.mgr)
+
+	p.GracefulStopTimeout = ParamItem{
+		Key:          "dataCoord.gracefulStopTimeout",
+		Version:      "2.3.7",
+		DefaultValue: strconv.Itoa(DefaultCoordGracefulStopTimeout),
+		Doc:          "seconds. force stop node without graceful stop",
+		Export:       true,
+	}
+	p.GracefulStopTimeout.Init(base.mgr)
 }
 
 // /////////////////////////////////////////////////////////////////////////////
@@ -2687,6 +2730,8 @@ type dataNodeConfig struct {
 	ChannelWorkPoolSize ParamItem `refreshable:"true"`
 
 	UpdateChannelCheckpointMaxParallel ParamItem `refreshable:"true"`
+
+	GracefulStopTimeout ParamItem `refreshable:"true"`
 }
 
 func (p *dataNodeConfig) init(base *BaseTable) {
@@ -2903,6 +2948,15 @@ func (p *dataNodeConfig) init(base *BaseTable) {
 		DefaultValue: "1000",
 	}
 	p.UpdateChannelCheckpointMaxParallel.Init(base.mgr)
+
+	p.GracefulStopTimeout = ParamItem{
+		Key:          "datanode.gracefulStopTimeout",
+		Version:      "2.3.7",
+		DefaultValue: strconv.Itoa(DefaultGracefulStopTimeout),
+		Doc:          "seconds. force stop node without graceful stop",
+		Export:       true,
+	}
+	p.GracefulStopTimeout.Init(base.mgr)
 }
 
 // /////////////////////////////////////////////////////////////////////////////
@@ -2914,7 +2968,7 @@ type indexNodeConfig struct {
 	DiskCapacityLimit      ParamItem `refreshable:"true"`
 	MaxDiskUsagePercentage ParamItem `refreshable:"true"`
 
-	GracefulStopTimeout ParamItem `refreshable:"false"`
+	GracefulStopTimeout ParamItem `refreshable:"true"`
 }
 
 func (p *indexNodeConfig) init(base *BaseTable) {
@@ -2969,6 +3023,7 @@ func (p *indexNodeConfig) init(base *BaseTable) {
 		Key:          "indexNode.gracefulStopTimeout",
 		Version:      "2.2.1",
 		FallbackKeys: []string{"common.gracefulStopTimeout"},
+		Doc:          "seconds. force stop node without graceful stop",
 		Export:       true,
 	}
 	p.GracefulStopTimeout.Init(base.mgr)

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -125,6 +125,9 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, Params.EnableActiveStandby.GetAsBool(), false)
 		t.Logf("rootCoord EnableActiveStandby = %t", Params.EnableActiveStandby.GetAsBool())
 
+		params.Save("rootCoord.gracefulStopTimeout", "100")
+		assert.Equal(t, 100*time.Second, Params.GracefulStopTimeout.GetAsDuration(time.Second))
+
 		SetCreateTime(time.Now())
 		SetUpdateTime(time.Now())
 	})
@@ -167,6 +170,9 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, Params.CostMetricsExpireTime.GetAsInt(), 1000)
 		assert.Equal(t, Params.RetryTimesOnReplica.GetAsInt(), 2)
 		assert.EqualValues(t, Params.HealthCheckTimeout.GetAsInt64(), 3000)
+
+		params.Save("proxy.gracefulStopTimeout", "100")
+		assert.Equal(t, 100*time.Second, Params.GracefulStopTimeout.GetAsDuration(time.Second))
 	})
 
 	// t.Run("test proxyConfig panic", func(t *testing.T) {
@@ -285,6 +291,9 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, true, Params.AutoBalance.GetAsBool())
 		assert.Equal(t, true, Params.AutoBalanceChannel.GetAsBool())
 		assert.Equal(t, 10, Params.CheckAutoBalanceConfigInterval.GetAsInt())
+
+		params.Save("queryCoord.gracefulStopTimeout", "100")
+		assert.Equal(t, 100*time.Second, Params.GracefulStopTimeout.GetAsDuration(time.Second))
 	})
 
 	t.Run("test queryNodeConfig", func(t *testing.T) {
@@ -350,6 +359,9 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, int64(100), gracefulStopTimeout.GetAsInt64())
 
 		assert.Equal(t, false, Params.EnableWorkerSQCostMetrics.GetAsBool())
+
+		params.Save("querynode.gracefulStopTimeout", "100")
+		assert.Equal(t, 100*time.Second, Params.GracefulStopTimeout.GetAsDuration(time.Second))
 	})
 
 	t.Run("test dataCoordConfig", func(t *testing.T) {
@@ -362,6 +374,9 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, true, Params.AutoBalance.GetAsBool())
 		assert.Equal(t, 10, Params.CheckAutoBalanceConfigInterval.GetAsInt())
 		assert.Equal(t, false, Params.AutoUpgradeSegmentIndex.GetAsBool())
+
+		params.Save("datacoord.gracefulStopTimeout", "100")
+		assert.Equal(t, 100*time.Second, Params.GracefulStopTimeout.GetAsDuration(time.Second))
 	})
 
 	t.Run("test dataNodeConfig", func(t *testing.T) {
@@ -408,12 +423,18 @@ func TestComponentParam(t *testing.T) {
 		updateChannelCheckpointMaxParallel := Params.UpdateChannelCheckpointMaxParallel.GetAsInt()
 		t.Logf("updateChannelCheckpointMaxParallel: %d", updateChannelCheckpointMaxParallel)
 		assert.Equal(t, 1000, Params.UpdateChannelCheckpointMaxParallel.GetAsInt())
+
+		params.Save("datanode.gracefulStopTimeout", "100")
+		assert.Equal(t, 100*time.Second, Params.GracefulStopTimeout.GetAsDuration(time.Second))
 	})
 
 	t.Run("test indexNodeConfig", func(t *testing.T) {
 		Params := &params.IndexNodeCfg
 		params.Save(Params.GracefulStopTimeout.Key, "50")
 		assert.Equal(t, Params.GracefulStopTimeout.GetAsInt64(), int64(50))
+
+		params.Save("indexnode.gracefulStopTimeout", "100")
+		assert.Equal(t, 100*time.Second, Params.GracefulStopTimeout.GetAsDuration(time.Second))
 	})
 
 	t.Run("channel config priority", func(t *testing.T) {


### PR DESCRIPTION
1. add coordinator and proxy graceful stop timeout to 5s.
3. add other work node graceful stop timeout to 900s, and we should potentially change this to 600s when graceful stop is smooth
4. change the order of datacoord component while stop.
5. `LivenessCheck` do not perform graceful shutdown now. 

issue: https://github.com/milvus-io/milvus/issues/30310
pr: #30317
also see: https://github.com/milvus-io/milvus/pull/30306
