### PR TITLE
enhance: Make compaction log has traceID

### DIFF
--- a/internal/datanode/compactor.go
+++ b/internal/datanode/compactor.go
@@ -432,7 +432,7 @@ func (t *compactionTask) merge(
 func (t *compactionTask) compact() (*datapb.CompactionPlanResult, error) {
 	ctx, span := otel.Tracer(typeutil.DataNodeRole).Start(t.ctx, fmt.Sprintf("Compact-%d", t.getPlanID()))
 	defer span.End()
-	log := log.With(zap.Int64("planID", t.plan.GetPlanID()))
+	log := log.Ctx(ctx).With(zap.Int64("planID", t.plan.GetPlanID()))
 	compactStart := time.Now()
 	if ok := funcutil.CheckCtxValid(ctx); !ok {
 		log.Warn("compact wrong, task context done or timeout")

--- a/internal/datanode/l0_compactor.go
+++ b/internal/datanode/l0_compactor.go
@@ -112,7 +112,7 @@ func (t *levelZeroCompactionTask) injectDone() {}
 func (t *levelZeroCompactionTask) compact() (*datapb.CompactionPlanResult, error) {
 	ctx, span := otel.Tracer(typeutil.DataNodeRole).Start(t.ctx, "L0Compact")
 	defer span.End()
-	log := log.With(zap.Int64("planID", t.plan.GetPlanID()), zap.String("type", t.plan.GetType().String()))
+	log := log.Ctx(t.ctx).With(zap.Int64("planID", t.plan.GetPlanID()), zap.String("type", t.plan.GetType().String()))
 	log.Info("L0 compaction", zap.Duration("wait in queue elapse", t.tr.RecordSpan()))
 
 	if !funcutil.CheckCtxValid(ctx) {

--- a/internal/datanode/services.go
+++ b/internal/datanode/services.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
-	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
@@ -46,6 +45,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/common"
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/metrics"
+	"github.com/milvus-io/milvus/pkg/tracer"
 	"github.com/milvus-io/milvus/pkg/util/commonpbutil"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/metautil"
@@ -265,9 +265,11 @@ func (node *DataNode) Compaction(ctx context.Context, req *datapb.CompactionPlan
 		}
 	}
 
-	spanCtx := trace.SpanContextFromContext(ctx)
+	/*
+		spanCtx := trace.SpanContextFromContext(ctx)
 
-	taskCtx := trace.ContextWithSpanContext(node.ctx, spanCtx)
+		taskCtx := trace.ContextWithSpanContext(node.ctx, spanCtx)*/
+	taskCtx := tracer.Propagate(ctx, node.ctx)
 
 	var task compactor
 	switch req.GetType() {

--- a/pkg/tracer/util.go
+++ b/pkg/tracer/util.go
@@ -1,0 +1,27 @@
+package tracer
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
+
+	"github.com/milvus-io/milvus/pkg/log"
+)
+
+// SetupSpan add span into ctx values.
+// Also setup logger in context with tracerID field.
+func SetupSpan(ctx context.Context, span trace.Span) context.Context {
+	ctx = trace.ContextWithSpan(ctx, span)
+	ctx = log.WithFields(ctx, zap.String("traceID", span.SpanContext().TraceID().String()))
+	return ctx
+}
+
+// Propagate passes span context into a new ctx with different lifetime.
+// Also setup logger in new context with traceID field.
+func Propagate(ctx, newRoot context.Context) context.Context {
+	spanCtx := trace.SpanContextFromContext(ctx)
+
+	newCtx := trace.ContextWithSpanContext(newRoot, spanCtx)
+	return log.WithFields(newCtx, zap.String("traceID", spanCtx.TraceID().String()))
+}

--- a/pkg/tracer/util.go
+++ b/pkg/tracer/util.go
@@ -13,7 +13,7 @@ import (
 // Also setup logger in context with tracerID field.
 func SetupSpan(ctx context.Context, span trace.Span) context.Context {
 	ctx = trace.ContextWithSpan(ctx, span)
-	ctx = log.WithFields(ctx, zap.String("traceID", span.SpanContext().TraceID().String()))
+	ctx = log.WithFields(ctx, zap.Stringer("traceID", span.SpanContext().TraceID()))
 	return ctx
 }
 
@@ -23,5 +23,5 @@ func Propagate(ctx, newRoot context.Context) context.Context {
 	spanCtx := trace.SpanContextFromContext(ctx)
 
 	newCtx := trace.ContextWithSpanContext(newRoot, spanCtx)
-	return log.WithFields(newCtx, zap.String("traceID", spanCtx.TraceID().String()))
+	return log.WithFields(newCtx, zap.Stringer("traceID", spanCtx.TraceID()))
 }


### PR DESCRIPTION
See also #30167

After support open telemetry tracing, we want to have traceID as well,
this PR adds util functions to set traceID with span & propagate traceID
between different context.