### PR TITLE
enhance: Remove current stats after RollStats action

### DIFF
--- a/internal/datanode/metacache/bloom_filter_set.go
+++ b/internal/datanode/metacache/bloom_filter_set.go
@@ -96,6 +96,7 @@ func (bfs *BloomFilterSet) Roll(newStats ...*storage.PrimaryKeyStats) {
 				MinPK:    stats.MinPk,
 			}
 		})...)
+		bfs.current = nil
 	}
 }
 


### PR DESCRIPTION
See also #27675

BloomFilterSet.current shall be reset after RollStats, otherwise it will keep tracking whole segment data causing the false positive ratio larger than expected.