### PR TITLE
enhance: Speed up L0 compaction

### DIFF
--- a/internal/datanode/iterators/deltalog_iterator.go
+++ b/internal/datanode/iterators/deltalog_iterator.go
@@ -23,7 +23,7 @@ type DeltalogIterator struct {
 	pos   int
 }
 
-func NewDeltalogIterator(v [][]byte, label *Label) (*DeltalogIterator, error) {
+func NewDeltalogIterator(v [][]byte, label *Label) *DeltalogIterator {
 	blobs := make([]*storage.Blob, len(v))
 	for i := range blobs {
 		blobs[i] = &storage.Blob{Value: v[i]}
@@ -33,7 +33,7 @@ func NewDeltalogIterator(v [][]byte, label *Label) (*DeltalogIterator, error) {
 		disposeCh: make(chan struct{}),
 		blobs:     blobs,
 		label:     label,
-	}, nil
+	}
 }
 
 func (d *DeltalogIterator) HasNext() bool {

--- a/internal/datanode/iterators/deltalog_iterator_test.go
+++ b/internal/datanode/iterators/deltalog_iterator_test.go
@@ -19,8 +19,10 @@ type DeltalogIteratorSuite struct {
 func (s *DeltalogIteratorSuite) TestDeltalogIteratorIntPK() {
 	s.Run("invalid blobs", func() {
 		iter, err := NewDeltalogIterator([][]byte{}, nil)
-		s.Error(err)
-		s.Nil(iter)
+
+		s.NoError(err)
+		s.NotNil(iter)
+		s.False(iter.HasNext())
 	})
 
 	testpks := []int64{1, 2, 3, 4}

--- a/internal/datanode/iterators/deltalog_iterator_test.go
+++ b/internal/datanode/iterators/deltalog_iterator_test.go
@@ -18,9 +18,8 @@ type DeltalogIteratorSuite struct {
 
 func (s *DeltalogIteratorSuite) TestDeltalogIteratorIntPK() {
 	s.Run("invalid blobs", func() {
-		iter, err := NewDeltalogIterator([][]byte{}, nil)
+		iter := NewDeltalogIterator([][]byte{}, nil)
 
-		s.NoError(err)
 		s.NotNil(iter)
 		s.False(iter.HasNext())
 	})
@@ -38,8 +37,8 @@ func (s *DeltalogIteratorSuite) TestDeltalogIteratorIntPK() {
 	s.Require().NoError(err)
 	value := [][]byte{blob.Value[:]}
 
-	iter, err := NewDeltalogIterator(value, &Label{segmentID: 100})
-	s.NoError(err)
+	iter := NewDeltalogIterator(value, &Label{segmentID: 100})
+	s.NotNil(iter)
 
 	var (
 		gotpks = []int64{}

--- a/internal/datanode/l0_compactor_test.go
+++ b/internal/datanode/l0_compactor_test.go
@@ -517,14 +517,12 @@ func (s *LevelZeroCompactionTaskSuite) TestSplitDelta() {
 	predicted := []int64{100, 101, 102}
 	s.mockMeta.EXPECT().GetSegmentsBy(mock.Anything).Return([]*metacache.SegmentInfo{segment1, segment2, segment3})
 
-	diter, err := iter.NewDeltalogIterator([][]byte{s.dBlob}, nil)
-	s.Require().NoError(err)
+	diter := iter.NewDeltalogIterator([][]byte{s.dBlob}, nil)
 	s.Require().NotNil(diter)
 
 	targetSegBuffer := make(map[int64]*storage.DeleteData)
 	targetSegIDs := predicted
-	err = s.task.splitDelta(context.TODO(), []*iter.DeltalogIterator{diter}, targetSegBuffer, targetSegIDs)
-	s.NoError(err)
+	s.task.splitDelta(context.TODO(), []*iter.DeltalogIterator{diter}, targetSegBuffer, targetSegIDs)
 
 	s.NotEmpty(targetSegBuffer)
 	s.ElementsMatch(predicted, lo.Keys(targetSegBuffer))

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -2994,8 +2994,8 @@ func (p *dataNodeConfig) init(base *BaseTable) {
 	p.FlushDeleteBufferBytes = ParamItem{
 		Key:          "dataNode.segment.deleteBufBytes",
 		Version:      "2.0.0",
-		DefaultValue: "67108864",
-		Doc:          "Max buffer size to flush del for a single channel",
+		DefaultValue: "16777216",
+		Doc:          "Max buffer size in bytes to flush del for a single channel, default as 16MB",
 		Export:       true,
 	}
 	p.FlushDeleteBufferBytes.Init(base.mgr)


### PR DESCRIPTION
This PR changes the following to speed up L0 compaction and
prevent OOM:

1. Lower deltabuf limit to 16MB by default, so that each L0 segment would be 4X smaller than before.
2. Add BatchProcess, use it if memory is sufficient
3. Iterator will Deserialize when called HasNext to avoid massive memory peek
4. Add tracing in spiltDelta

See also: #30191