### PR TITLE
enhance: calculate the accuracy memory usage while loading segment

### DIFF
--- a/internal/core/src/segcore/load_index_c.cpp
+++ b/internal/core/src/segcore/load_index_c.cpp
@@ -25,6 +25,11 @@
 #include "storage/RemoteChunkManagerSingleton.h"
 #include "storage/LocalChunkManagerSingleton.h"
 
+bool
+IsLoadWithDisk(const char* index_type, int index_engine_version) {
+    return knowhere::UseDiskLoad(index_type, index_engine_version);
+}
+
 CStatus
 NewLoadIndexInfo(CLoadIndexInfo* c_load_index_info) {
     try {

--- a/internal/core/src/segcore/load_index_c.h
+++ b/internal/core/src/segcore/load_index_c.h
@@ -23,6 +23,9 @@ extern "C" {
 
 typedef void* CLoadIndexInfo;
 
+bool
+IsLoadWithDisk(const char* index_type, int index_engine_version);
+
 CStatus
 NewLoadIndexInfo(CLoadIndexInfo* c_load_index_info);
 

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -16,6 +16,13 @@
 
 package segments
 
+/*
+#cgo pkg-config: milvus_segcore
+
+#include "segcore/load_index_c.h"
+*/
+import "C"
+
 import (
 	"context"
 	"fmt"
@@ -25,6 +32,7 @@ import (
 	"strconv"
 	"sync"
 	"time"
+	"unsafe"
 
 	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
@@ -1326,7 +1334,22 @@ func GetIndexResourceUsage(indexInfo *querypb.FieldIndexInfo) (uint64, uint64, e
 		return uint64(neededMemSize), uint64(neededDiskSize), nil
 	}
 
-	return uint64(indexInfo.IndexSize), 0, nil
+	factor := uint64(1)
+
+	var isLoadWithDisk bool
+	GetDynamicPool().Submit(func() (any, error) {
+		cIndexType := C.CString(indexType)
+		defer C.free(unsafe.Pointer(cIndexType))
+		cEngineVersion := C.int32_t(indexInfo.GetCurrentIndexVersion())
+		isLoadWithDisk = bool(C.IsLoadWithDisk(cIndexType, cEngineVersion))
+		return nil, nil
+	}).Await()
+
+	if !isLoadWithDisk {
+		factor = 2
+	}
+
+	return uint64(indexInfo.IndexSize) * factor, 0, nil
 }
 
 // checkSegmentSize checks whether the memory & disk is sufficient to load the segments


### PR DESCRIPTION
the old version Knowhere would copy the index data while loading, we need to consider this to avoid OOM.

Knowhere provides a util function to indicate whether it will load the index with disk, if not, we need to double the memory usage prediction for index data