### PR TITLE
enhance: calculate the accuracy memory usage while loading segment (#30473)

### DIFF
--- a/internal/core/src/segcore/load_index_c.cpp
+++ b/internal/core/src/segcore/load_index_c.cpp
@@ -19,12 +19,18 @@
 #include "index/IndexFactory.h"
 #include "index/Meta.h"
 #include "index/Utils.h"
+#include "knowhere/utils.h"
 #include "log/Log.h"
 #include "storage/FileManager.h"
 #include "segcore/Types.h"
 #include "storage/Util.h"
 #include "storage/RemoteChunkManagerSingleton.h"
 #include "storage/LocalChunkManagerSingleton.h"
+
+bool
+IsLoadWithDisk(const char* index_type, int index_engine_version) {
+    return knowhere::UseDiskLoad(index_type, index_engine_version);
+}
 
 CStatus
 NewLoadIndexInfo(CLoadIndexInfo* c_load_index_info) {

--- a/internal/core/src/segcore/load_index_c.h
+++ b/internal/core/src/segcore/load_index_c.h
@@ -23,6 +23,9 @@ extern "C" {
 
 typedef void* CLoadIndexInfo;
 
+bool
+IsLoadWithDisk(const char* index_type, int index_engine_version);
+
 CStatus
 NewLoadIndexInfo(CLoadIndexInfo* c_load_index_info);
 


### PR DESCRIPTION
the old version Knowhere would copy the index data while loading, we need to consider this to avoid OOM.

Knowhere provides a util function to indicate whether it will load the index with disk, if not, we need to double the memory usage prediction for index data

pr: #30473 