### PR TITLE
fix: Add retry on unimplemented error for datacoord

### DIFF
--- a/internal/querycoordv2/meta/coordinator_broker.go
+++ b/internal/querycoordv2/meta/coordinator_broker.go
@@ -18,10 +18,10 @@ package meta
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
+	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"

--- a/internal/querycoordv2/meta/coordinator_broker.go
+++ b/internal/querycoordv2/meta/coordinator_broker.go
@@ -18,6 +18,7 @@ package meta
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -34,6 +35,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/util/commonpbutil"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/util/retry"
 	. "github.com/milvus-io/milvus/pkg/util/typeutil"
 )
 
@@ -190,9 +192,20 @@ func (broker *CoordinatorBroker) GetIndexInfo(ctx context.Context, collectionID 
 		zap.Int64("segmentID", segmentID),
 	)
 
-	resp, err := broker.dataCoord.GetIndexInfos(ctx, &indexpb.GetIndexInfoRequest{
-		CollectionID: collectionID,
-		SegmentIDs:   []int64{segmentID},
+	// during rolling upgrade, query coord may connect to datacoord with version 2.2, which will return merr.ErrServiceUnimplemented
+	// we add retry here to retry the request until context done, and if new data coord start up, it will success
+	var resp *indexpb.GetIndexInfoResponse
+	var err error
+	retry.Do(ctx, func() error {
+		resp, err = broker.dataCoord.GetIndexInfos(ctx, &indexpb.GetIndexInfoRequest{
+			CollectionID: collectionID,
+			SegmentIDs:   []int64{segmentID},
+		})
+
+		if errors.Is(err, merr.ErrServiceUnimplemented) {
+			return err
+		}
+		return nil
 	})
 
 	if err := merr.CheckRPCCall(resp, err); err != nil {
@@ -236,8 +249,18 @@ func (broker *CoordinatorBroker) DescribeIndex(ctx context.Context, collectionID
 	ctx, cancel := context.WithTimeout(ctx, paramtable.Get().QueryCoordCfg.BrokerTimeout.GetAsDuration(time.Millisecond))
 	defer cancel()
 
-	resp, err := broker.dataCoord.DescribeIndex(ctx, &indexpb.DescribeIndexRequest{
-		CollectionID: collectionID,
+	// during rolling upgrade, query coord may connect to datacoord with version 2.2, which will return merr.ErrServiceUnimplemented
+	// we add retry here to retry the request until context done, and if new data coord start up, it will success
+	var resp *indexpb.DescribeIndexResponse
+	var err error
+	retry.Do(ctx, func() error {
+		resp, err = broker.dataCoord.DescribeIndex(ctx, &indexpb.DescribeIndexRequest{
+			CollectionID: collectionID,
+		})
+		if errors.Is(err, merr.ErrServiceUnimplemented) {
+			return err
+		}
+		return nil
 	})
 
 	if err := merr.CheckRPCCall(resp, err); err != nil {


### PR DESCRIPTION
issue: #30553

when datacoord with version 2.2 and querycoord with version 2.3 coexist during rolling upgrade, `DescribeIndex/GetIndexInfo` will return `unimplemented` error
This PR add retry on `DescribeIndex/GetIndexInfo`, to prevent load collection failed during rolling upgrade from milvus 2.2 to 2.3.