### PR TITLE
fix: [Cherry-pick] Proxy restful api doesn't register (#30072)

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -411,6 +411,9 @@ func (node *Proxy) Start() error {
 	log.Debug("update state code", zap.String("role", typeutil.ProxyRole), zap.String("State", commonpb.StateCode_Healthy.String()))
 	node.UpdateStateCode(commonpb.StateCode_Healthy)
 
+	// register devops api
+	RegisterMgrRoute(node)
+
 	return nil
 }
 


### PR DESCRIPTION
Cherry-pick from master
pr: #30072
issue: #30074
This PR fix that management restful api in proxy doesn't register to http service