### PR TITLE
fix: make compactor inject done called no more than once

### DIFF
--- a/internal/datanode/compactor_test.go
+++ b/internal/datanode/compactor_test.go
@@ -1095,3 +1095,24 @@ func TestCompactorInterfaceMethods(t *testing.T) {
 		assert.NotEmpty(t, segment.Field2StatslogPaths)
 	})
 }
+
+func TestInjectDone(t *testing.T) {
+	syncMgr := syncmgr.NewMockSyncManager(t)
+
+	segmentIDs := []int64{100, 200, 300}
+	task := &compactionTask{
+		plan: &datapb.CompactionPlan{
+			SegmentBinlogs: lo.Map(segmentIDs, func(id int64, _ int) *datapb.CompactionSegmentBinlogs {
+				return &datapb.CompactionSegmentBinlogs{SegmentID: id}
+			}),
+		},
+		syncMgr: syncMgr,
+	}
+
+	for _, segmentID := range segmentIDs {
+		syncMgr.EXPECT().Unblock(segmentID).Return().Once()
+	}
+
+	task.injectDone()
+	task.injectDone()
+}


### PR DESCRIPTION
See also #30571

When `compactionExecutor` stops one compaction task, the `stop` method will case `injectDone` called.

However in `executeTask` when `compact` method returns error, it shall also invoke `injectDone` as well. That the reason `Unlock of unlocked RWMutex` panicking happened.

This PR add sync.Once to make sure that `injectDone` is called only once. We did not remove any of the `injectDone` since removal any of those invocation may cause logic problem.