### PR TITLE
fix: Add retry on unimplemented error for datacoord (#30554)

### DIFF
--- a/internal/querycoordv2/meta/coordinator_broker_test.go
+++ b/internal/querycoordv2/meta/coordinator_broker_test.go
@@ -294,6 +294,26 @@ func (s *CoordinatorBrokerDataCoordSuite) TestDescribeIndex() {
 		s.Error(err)
 		s.resetMock()
 	})
+
+	s.Run("datacoord_return_unimplemented", func() {
+		// mock old version datacoord return unimplemented
+		s.datacoord.EXPECT().DescribeIndex(mock.Anything, mock.Anything).
+			Return(nil, merr.ErrServiceUnimplemented).Times(1)
+
+		// mock retry on new version datacoord return success
+		indexIDs := []int64{1, 2}
+		s.datacoord.EXPECT().DescribeIndex(mock.Anything, mock.Anything).
+			Return(&indexpb.DescribeIndexResponse{
+				Status: merr.Status(nil),
+				IndexInfos: lo.Map(indexIDs, func(id int64, _ int) *indexpb.IndexInfo {
+					return &indexpb.IndexInfo{IndexID: id}
+				}),
+			}, nil)
+
+		_, err := s.broker.DescribeIndex(ctx, collectionID)
+		s.NoError(err)
+		s.resetMock()
+	})
 }
 
 func (s *CoordinatorBrokerDataCoordSuite) TestSegmentInfo() {
@@ -383,6 +403,31 @@ func (s *CoordinatorBrokerDataCoordSuite) TestGetIndexInfo() {
 
 		_, err := s.broker.GetIndexInfo(ctx, collectionID, segmentID)
 		s.Error(err)
+		s.resetMock()
+	})
+
+	s.Run("datacoord_return_unimplemented", func() {
+		// mock old version datacoord return unimplemented
+		s.datacoord.EXPECT().GetIndexInfos(mock.Anything, mock.Anything).
+			Return(nil, merr.ErrServiceUnimplemented).Times(1)
+
+		// mock retry on new version datacoord return success
+		indexIDs := []int64{1, 2, 3}
+		s.datacoord.EXPECT().GetIndexInfos(mock.Anything, mock.Anything).
+			Return(&indexpb.GetIndexInfoResponse{
+				Status: merr.Status(nil),
+				SegmentInfo: map[int64]*indexpb.SegmentInfo{
+					segmentID: {
+						SegmentID: segmentID,
+						IndexInfos: lo.Map(indexIDs, func(id int64, _ int) *indexpb.IndexFilePathInfo {
+							return &indexpb.IndexFilePathInfo{IndexID: id}
+						}),
+					},
+				},
+			}, nil)
+
+		_, err := s.broker.GetIndexInfo(ctx, collectionID, segmentID)
+		s.NoError(err)
 		s.resetMock()
 	})
 }


### PR DESCRIPTION
issue: #30553
pr: #30554 

when datacoord with version 2.2 and querycoord with version 2.3 coexist during rolling upgrade, `DescribeIndex/GetIndexInfo` will return `unimplemented` error
This PR add retry on `DescribeIndex/GetIndexInfo`, to prevent load collection failed during rolling upgrade from milvus 2.2 to 2.3.

---------