### PR TITLE
enhance: add syncutil type ContextCond and VersionedNotifier

### DIFF
--- a/pkg/util/syncutil/context_condition_variable.go
+++ b/pkg/util/syncutil/context_condition_variable.go
@@ -1,0 +1,77 @@
+package syncutil
+
+import (
+	"context"
+	"sync"
+)
+
+// NewContextCond creates a new condition variable that can be used with context.
+// Broadcast is implemented using a channel, so the performance may not be as good as sync.Cond.
+func NewContextCond(l sync.Locker) *ContextCond {
+	return &ContextCond{L: l}
+}
+
+// ContextCond is a condition variable implementation that can be used with context.
+type ContextCond struct {
+	noCopy noCopy
+
+	L  sync.Locker
+	ch chan struct{}
+}
+
+// LockAndBroadcast locks the underlying locker and performs a broadcast.
+// It notifies all goroutines waiting on the condition variable.
+//
+//	c.LockAndBroadcast()
+//	... make some change ...
+//	c.L.Unlock()
+func (cv *ContextCond) LockAndBroadcast() {
+	cv.L.Lock()
+	if cv.ch != nil {
+		close(cv.ch)
+		cv.ch = nil
+	}
+}
+
+// Wait waits for a broadcast or context timeout.
+// It blocks until either a broadcast is received or the context is canceled or times out.
+// Returns an error if the context is canceled or times out.
+//
+//	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+//	defer cancel()
+//	c.L.Lock()
+//	for !condition() {
+//	    if err := c.Wait(ctx); err != nil {
+//	           return err
+//	       }
+//	   }
+//	... make use of condition ...
+//	c.L.Unlock()
+func (cv *ContextCond) Wait(ctx context.Context) error {
+	if cv.ch == nil {
+		cv.ch = make(chan struct{})
+	}
+	ch := cv.ch
+	cv.L.Unlock()
+
+	select {
+	case <-ch:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	cv.L.Lock()
+	return nil
+}
+
+// noCopy may be added to structs which must not be copied
+// after the first use.
+//
+// See https://golang.org/issues/8005#issuecomment-190753527
+// for details.
+//
+// Note that it must not be embedded, due to the Lock and Unlock methods.
+type noCopy struct{}
+
+// Lock is a no-op used by -copylocks checker from `go vet`.
+func (*noCopy) Lock()   {}
+func (*noCopy) Unlock() {}

--- a/pkg/util/syncutil/context_condition_variable_test.go
+++ b/pkg/util/syncutil/context_condition_variable_test.go
@@ -1,0 +1,39 @@
+package syncutil
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContextCond(t *testing.T) {
+	cv := NewContextCond(&sync.Mutex{})
+	cv.L.Lock()
+	go func() {
+		time.Sleep(1 * time.Second)
+		cv.LockAndBroadcast()
+		cv.L.Unlock()
+	}()
+	// Acquire lock before wait.
+	assert.NoError(t, cv.Wait(context.Background()))
+	cv.L.Unlock()
+
+	cv.L.Lock()
+	go func() {
+		time.Sleep(1 * time.Second)
+		cv.LockAndBroadcast()
+		cv.L.Unlock()
+	}()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	// Acquire no lock if wait returns error.
+	assert.Error(t, cv.Wait(ctx))
+
+	cv.L.Lock()
+	assert.NoError(t, cv.Wait(context.Background()))
+	cv.L.Unlock()
+}

--- a/pkg/util/syncutil/versioned_notifier.go
+++ b/pkg/util/syncutil/versioned_notifier.go
@@ -1,0 +1,80 @@
+package syncutil
+
+import (
+	"context"
+	"sync"
+)
+
+const (
+	VersionedListenAtEarliest versionedListenAt = -1
+	VersionedListenAtLatest   versionedListenAt = -2
+)
+
+// versionedListenerAt is the position where the listener starts to listen.
+type versionedListenAt int
+
+// NewVersionedNotifier creates a new VersionedNotifier.
+func NewVersionedNotifier() *VersionedNotifier {
+	return &VersionedNotifier{
+		inner: &versionedSignal{
+			version: 0,
+			cond:    NewContextCond(&sync.Mutex{}),
+		},
+	}
+}
+
+// versionedSignal is a signal with version.
+type versionedSignal struct {
+	version int
+	cond    *ContextCond
+}
+
+// VersionedNotifier is a notifier with version.
+// A version-based notifier, any change of version could be seen by all listeners without lost.
+type VersionedNotifier struct {
+	inner *versionedSignal
+}
+
+// NotifyAll notifies all listeners.
+func (vn *VersionedNotifier) NotifyAll() {
+	vn.inner.cond.LockAndBroadcast()
+	vn.inner.version++
+	vn.inner.cond.L.Unlock()
+}
+
+// Listen creates a listener at given position.
+func (vn *VersionedNotifier) Listen(at versionedListenAt) *VersionedListener {
+	var last int
+	if at == VersionedListenAtEarliest {
+		last = -1
+	} else if at == VersionedListenAtLatest {
+		vn.inner.cond.L.Lock()
+		last = vn.inner.version
+		vn.inner.cond.L.Unlock()
+	}
+	return &VersionedListener{
+		lastNotifiedVersion: last,
+		inner:               vn.inner,
+	}
+}
+
+// VersionedListener is a listener with version.
+type VersionedListener struct {
+	lastNotifiedVersion int
+	inner               *versionedSignal
+}
+
+// Wait waits for the next notification.
+// If the context is canceled, it returns the error.
+// Otherwise it will block until the next notification.
+func (vl *VersionedListener) Wait(ctx context.Context) error {
+	vl.inner.cond.L.Lock()
+	for vl.lastNotifiedVersion >= vl.inner.version {
+		if err := vl.inner.cond.Wait(ctx); err != nil {
+			return err
+		}
+	}
+	vl.lastNotifiedVersion = vl.inner.version
+	vl.inner.cond.L.Unlock()
+	return nil
+}

--- a/pkg/util/syncutil/versioned_notifier_test.go
+++ b/pkg/util/syncutil/versioned_notifier_test.go
@@ -1,0 +1,82 @@
+package syncutil
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLatestVersionedNotifier(t *testing.T) {
+	vn := NewVersionedNotifier()
+
+	// Create a listener at the latest version
+	listener := vn.Listen(VersionedListenAtLatest)
+
+	// Start a goroutine to wait for the notification
+	done := make(chan struct{})
+	go func() {
+		err := listener.Wait(context.Background())
+		if err != nil {
+			t.Errorf("Wait returned an error: %v", err)
+		}
+		close(done)
+	}()
+
+	// Should be blocked.
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	select {
+	case <-done:
+		t.Errorf("Wait returned before NotifyAll")
+	case <-ctx.Done():
+	}
+
+	// Notify all listeners
+	vn.NotifyAll()
+
+	// Wait for the goroutine to finish
+	<-done
+}
+
+func TestEarliestVersionedNotifier(t *testing.T) {
+	vn := NewVersionedNotifier()
+
+	// Create a listener at the latest version
+	listener := vn.Listen(VersionedListenAtEarliest)
+
+	// Should be non-blocked.
+	err := listener.Wait(context.Background())
+	assert.NoError(t, err)
+
+	// Start a goroutine to wait for the notification
+	done := make(chan struct{})
+	go func() {
+		err := listener.Wait(context.Background())
+		if err != nil {
+			t.Errorf("Wait returned an error: %v", err)
+		}
+		close(done)
+	}()
+
+	// Should be blocked.
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	select {
+	case <-done:
+		t.Errorf("Wait returned before NotifyAll")
+	case <-ctx.Done():
+	}
+}
+
+func TestTimeoutListeningVersionedNotifier(t *testing.T) {
+	vn := NewVersionedNotifier()
+
+	listener := vn.Listen(VersionedListenAtLatest)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	err := listener.Wait(ctx)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}


### PR DESCRIPTION
issue: #30647

- ContextCond is a broadcast-only condition variable which can be canceled by context.

- VersionedNotifier is a version-based notifier-listener implementation, which promise no change can be ignored.