### PR TITLE
fix: Prevent ChunkCache use absolute path in All-in-one mode

### DIFF
--- a/internal/core/src/storage/ChunkCache.h
+++ b/internal/core/src/storage/ChunkCache.h
@@ -56,6 +56,9 @@ class ChunkCache {
     std::shared_ptr<ColumnBase>
     Mmap(const std::filesystem::path& path, const FieldDataPtr& field_data);
 
+    std::string
+    CachePath(const std::string& filepath);
+
  private:
     using ColumnTable =
         std::unordered_map<std::string, std::shared_ptr<ColumnBase>>;

--- a/internal/core/unittest/test_storage.cpp
+++ b/internal/core/unittest/test_storage.cpp
@@ -155,9 +155,9 @@ TEST_F(StorageTest, GetStorageMetrics) {
 }
 
 TEST_F(StorageTest, CachePath) {
-    auto rcm = RemoteChunkManagerSingleton::GetInstance().GetRemoteChunkManager();
-    auto cc_ = ChunkCache(
-                "tmp/mmap/chunk_cache", "willneed", rcm);
+    auto rcm =
+        RemoteChunkManagerSingleton::GetInstance().GetRemoteChunkManager();
+    auto cc_ = ChunkCache("tmp/mmap/chunk_cache", "willneed", rcm);
     auto relative_result = cc_.CachePath("abc");
     EXPECT_EQ("tmp/mmap/chunk_cache/abc", relative_result);
     auto absolute_result = cc_.CachePath("/var/lib/milvus/abc");

--- a/internal/core/unittest/test_storage.cpp
+++ b/internal/core/unittest/test_storage.cpp
@@ -21,6 +21,9 @@
 #include "storage/RemoteChunkManagerSingleton.h"
 #include "storage/storage_c.h"
 
+#define private public
+#include "storage/ChunkCache.h"
+
 using namespace std;
 using namespace milvus;
 using namespace milvus::storage;
@@ -149,4 +152,14 @@ TEST_F(StorageTest, GetStorageMetrics) {
         EXPECT_EQ(
             0, strncmp(currentLine, familyName.c_str(), familyName.length()));
     }
+}
+
+TEST_F(StorageTest, CachePath) {
+    auto rcm = RemoteChunkManagerSingleton::GetInstance().GetRemoteChunkManager();
+    auto cc_ = ChunkCache(
+                "tmp/mmap/chunk_cache", "willneed", rcm);
+    auto relative_result = cc_.CachePath("abc");
+    EXPECT_EQ("tmp/mmap/chunk_cache/abc", relative_result);
+    auto absolute_result = cc_.CachePath("/var/lib/milvus/abc");
+    EXPECT_EQ("tmp/mmap/chunk_cache/var/lib/milvus/abc", absolute_result);
 }


### PR DESCRIPTION
See also #30651

Append operator of `std::filesystem::path` will replace whole path when the param of "/" operation is an absolute path.

In "All-in-one" mode, this shall cause ChunkCache removing the original vector data file when building chunk cache during/after load procedure.

This PR changes the ChunkCache path generation logic to a separate function in which will check whether the file path is absolute or not. If the file path is absolute, it removes the root path prefix and return concatenated file path.