### PR TITLE
enhance: Check Level-zero segment memory usage as well

### DIFF
--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -735,8 +735,7 @@ func (loader *segmentLoader) requestResource(ctx context.Context, infos ...*quer
 	// we need to deal with empty infos case separately,
 	// because the following judgement for requested resources are based on current status and static config
 	// which may block empty-load operations by accident
-	if len(infos) == 0 ||
-		infos[0].GetLevel() == datapb.SegmentLevel_L0 {
+	if len(infos) == 0 {
 		return resource, 0, nil
 	}
 

--- a/internal/querynodev2/segments/segment_loader_test.go
+++ b/internal/querynodev2/segments/segment_loader_test.go
@@ -774,6 +774,16 @@ func (suite *SegmentLoaderDetailSuite) TestWaitSegmentLoadDone() {
 	})
 }
 
+func (suite *SegmentLoaderDetailSuite) TestRequestResource() {
+	suite.Run("out_of_memory_zero_info", func() {
+		paramtable.Get().Save(paramtable.Get().QueryNodeCfg.OverloadedMemoryThresholdPercentage.Key, "0")
+		defer paramtable.Get().Reset(paramtable.Get().QueryNodeCfg.OverloadedMemoryThresholdPercentage.Key)
+
+		_, _, err := suite.loader.requestResource(context.Background())
+		suite.NoError(err)
+	})
+}
+
 func TestSegmentLoader(t *testing.T) {
 	suite.Run(t, &SegmentLoaderSuite{})
 	suite.Run(t, &SegmentLoaderDetailSuite{})


### PR DESCRIPTION
Related to #30191

When loading segment, segment loader shall check memory usage for current loading task. Previously l0 segment was ignored but level zero segment may actually cost lots of memory.

This PR adds back memory resource check for Level zero segment loading.