### PR TITLE
enhance: diskann support fp16/bf16 and fix some segcore bugs of fp16/bf16

### DIFF
--- a/internal/core/src/index/IndexFactory.cpp
+++ b/internal/core/src/index/IndexFactory.cpp
@@ -188,15 +188,14 @@ IndexFactory::CreateVectorIndex(
                 return std::make_unique<VectorDiskAnnIndex<float>>(
                     index_type, metric_type, version, file_manager_context);
             }
-            // // Uncomment after adding diskann part
-            // case DataType::VECTOR_FLOAT16: {
-            //     return std::make_unique<VectorDiskAnnIndex<float16>>(
-            //         index_type, metric_type, version, file_manager_context);
-            // }
-            // case DataType::VECTOR_BFLOAT16: {
-            //     return std::make_unique<VectorDiskAnnIndex<bfloat16>>(
-            //         index_type, metric_type, version, file_manager_context);
-            // }
+            case DataType::VECTOR_FLOAT16: {
+                return std::make_unique<VectorDiskAnnIndex<float16>>(
+                    index_type, metric_type, version, file_manager_context);
+            }
+            case DataType::VECTOR_BFLOAT16: {
+                return std::make_unique<VectorDiskAnnIndex<bfloat16>>(
+                    index_type, metric_type, version, file_manager_context);
+            }
             default:
                 throw SegcoreError(
                     DataTypeInvalid,
@@ -295,15 +294,22 @@ IndexFactory::CreateVectorIndex(
                     space,
                     file_manager_context);
             }
-            // // Uncomment after adding diskann part
-            // case DataType::VECTOR_FLOAT16: {
-            //     return std::make_unique<VectorDiskAnnIndex<float16>>(
-            //         index_type, metric_type, version, file_manager_context);
-            // }
-            // case DataType::VECTOR_BFLOAT16: {
-            //     return std::make_unique<VectorDiskAnnIndex<bfloat16>>(
-            //         index_type, metric_type, version, file_manager_context);
-            // }
+            case DataType::VECTOR_FLOAT16: {
+                return std::make_unique<VectorDiskAnnIndex<float16>>(
+                    index_type,
+                    metric_type,
+                    version,
+                    space,
+                    file_manager_context);
+            }
+            case DataType::VECTOR_BFLOAT16: {
+                return std::make_unique<VectorDiskAnnIndex<bfloat16>>(
+                    index_type,
+                    metric_type,
+                    version,
+                    space,
+                    file_manager_context);
+            }
             default:
                 throw SegcoreError(
                     DataTypeInvalid,

--- a/internal/core/src/index/VectorDiskIndex.cpp
+++ b/internal/core/src/index/VectorDiskIndex.cpp
@@ -177,7 +177,7 @@ VectorDiskAnnIndex<T>::BuildV2(const Config& config) {
     knowhere::Json build_config;
     build_config.update(config);
 
-    auto local_data_path = file_manager_->CacheRawDataToDisk(space_);
+    auto local_data_path = file_manager_->CacheRawDataToDisk<T>(space_);
     build_config[DISK_ANN_RAW_DATA_PATH] = local_data_path;
 
     auto local_index_path_prefix = file_manager_->GetLocalIndexObjectPrefix();
@@ -224,7 +224,7 @@ VectorDiskAnnIndex<T>::Build(const Config& config) {
     AssertInfo(insert_files.has_value(),
                "insert file paths is empty when build disk ann index");
     auto local_data_path =
-        file_manager_->CacheRawDataToDisk(insert_files.value());
+        file_manager_->CacheRawDataToDisk<T>(insert_files.value());
     build_config[DISK_ANN_RAW_DATA_PATH] = local_data_path;
 
     auto local_index_path_prefix = file_manager_->GetLocalIndexObjectPrefix();

--- a/internal/core/src/segcore/Utils.cpp
+++ b/internal/core/src/segcore/Utils.cpp
@@ -558,6 +558,15 @@ MergeDataArray(
                 auto obj = vector_array->mutable_float_vector();
                 obj->mutable_data()->Add(data + src_offset * dim,
                                          data + (src_offset + 1) * dim);
+            } else if (field_meta.get_data_type() == DataType::VECTOR_FLOAT16) {
+                auto data = VEC_FIELD_DATA(src_field_data, float16);
+                auto obj = vector_array->mutable_float16_vector();
+                obj->assign(data, dim * sizeof(float16));
+            } else if (field_meta.get_data_type() ==
+                       DataType::VECTOR_BFLOAT16) {
+                auto data = VEC_FIELD_DATA(src_field_data, bfloat16);
+                auto obj = vector_array->mutable_bfloat16_vector();
+                obj->assign(data, dim * sizeof(bfloat16));
             } else if (field_meta.get_data_type() == DataType::VECTOR_BINARY) {
                 AssertInfo(
                     dim % 8 == 0,

--- a/internal/core/src/storage/DiskFileManagerImpl.cpp
+++ b/internal/core/src/storage/DiskFileManagerImpl.cpp
@@ -377,6 +377,7 @@ DiskFileManagerImpl::CacheBatchIndexFilesToDiskV2(
     }
     return offset;
 }
+template <typename DataType>
 std::string
 DiskFileManagerImpl::CacheRawDataToDisk(
     std::shared_ptr<milvus_storage::Space> space) {
@@ -413,7 +414,7 @@ DiskFileManagerImpl::CacheRawDataToDisk(
         field_data->FillFieldData(col_data);
         dim = field_data->get_dim();
         auto data_size =
-            field_data->get_num_rows() * index_meta_.dim * sizeof(float);
+            field_data->get_num_rows() * index_meta_.dim * sizeof(DataType);
         local_chunk_manager->Write(local_data_path,
                                    write_offset,
                                    const_cast<void*>(field_data->Data()),
@@ -441,7 +442,7 @@ SortByPath(std::vector<std::string>& paths) {
                          std::stol(b.substr(b.find_last_of("/") + 1));
               });
 }
-
+template <typename DataType>
 std::string
 DiskFileManagerImpl::CacheRawDataToDisk(std::vector<std::string> remote_files) {
     SortByPath(remote_files);
@@ -476,7 +477,8 @@ DiskFileManagerImpl::CacheRawDataToDisk(std::vector<std::string> remote_files) {
                        "inconsistent dim value in multi binlogs!");
             dim = field_data->get_dim();
 
-            auto data_size = field_data->get_num_rows() * dim * sizeof(float);
+            auto data_size =
+                field_data->get_num_rows() * dim * sizeof(DataType);
             local_chunk_manager->Write(local_data_path,
                                        write_offset,
                                        const_cast<void*>(field_data->Data()),
@@ -824,5 +826,24 @@ DiskFileManagerImpl::IsExisted(const std::string& file) noexcept {
     }
     return isExist;
 }
+
+template std::string
+DiskFileManagerImpl::CacheRawDataToDisk<float>(
+    std::vector<std::string> remote_files);
+template std::string
+DiskFileManagerImpl::CacheRawDataToDisk<float16>(
+    std::vector<std::string> remote_files);
+template std::string
+DiskFileManagerImpl::CacheRawDataToDisk<bfloat16>(
+    std::vector<std::string> remote_files);
+template std::string
+DiskFileManagerImpl::CacheRawDataToDisk<float>(
+    std::shared_ptr<milvus_storage::Space> space);
+template std::string
+DiskFileManagerImpl::CacheRawDataToDisk<float16>(
+    std::shared_ptr<milvus_storage::Space> space);
+template std::string
+DiskFileManagerImpl::CacheRawDataToDisk<bfloat16>(
+    std::shared_ptr<milvus_storage::Space> space);
 
 }  // namespace milvus::storage

--- a/internal/core/src/storage/DiskFileManagerImpl.h
+++ b/internal/core/src/storage/DiskFileManagerImpl.h
@@ -96,9 +96,11 @@ class DiskFileManagerImpl : public FileManagerImpl {
                        const std::vector<std::string>& remote_files,
                        const std::vector<int64_t>& remote_file_sizes);
 
+    template <typename DataType>
     std::string
     CacheRawDataToDisk(std::vector<std::string> remote_files);
 
+    template <typename DataType>
     std::string
     CacheRawDataToDisk(std::shared_ptr<milvus_storage::Space> space);
 

--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -415,6 +415,24 @@ GetDimensionFromArrowArray(std::shared_ptr<arrow::Array> data,
                 std::dynamic_pointer_cast<arrow::FixedSizeBinaryArray>(data);
             return array->byte_width() * 8;
         }
+        case DataType::VECTOR_FLOAT16: {
+            AssertInfo(
+                data->type()->id() == arrow::Type::type::FIXED_SIZE_BINARY,
+                "inconsistent data type: {}",
+                data->type_id());
+            auto array =
+                std::dynamic_pointer_cast<arrow::FixedSizeBinaryArray>(data);
+            return array->byte_width() / sizeof(float16);
+        }
+        case DataType::VECTOR_BFLOAT16: {
+            AssertInfo(
+                data->type()->id() == arrow::Type::type::FIXED_SIZE_BINARY,
+                "inconsistent data type: {}",
+                data->type_id());
+            auto array =
+                std::dynamic_pointer_cast<arrow::FixedSizeBinaryArray>(data);
+            return array->byte_width() / sizeof(bfloat16);
+        }
         default:
             PanicInfo(DataTypeInvalid, "unsupported data type {}", data_type);
     }

--- a/internal/core/unittest/test_indexing.cpp
+++ b/internal/core/unittest/test_indexing.cpp
@@ -768,85 +768,165 @@ TEST(Indexing, SearchDiskAnnWithInvalidParam) {
                  std::runtime_error);
 }
 
-// TEST(Indexing, SearchDiskAnnWithInvalidParam_Float16) {
-//     int64_t NB = 10000;
-//     IndexType index_type = knowhere::IndexEnum::INDEX_DISKANN;
-//     MetricType metric_type = knowhere::metric::L2;
-//     milvus::index::CreateIndexInfo create_index_info;
-//     create_index_info.index_type = index_type;
-//     create_index_info.metric_type = metric_type;
-//     create_index_info.field_type = milvus::DataType::VECTOR_FLOAT16;
-//     create_index_info.index_engine_version =
-//         knowhere::Version::GetCurrentVersion().VersionNumber();
+TEST(Indexing, SearchDiskAnnWithFloat16) {
+    int64_t NB = 10000;
+    IndexType index_type = knowhere::IndexEnum::INDEX_DISKANN;
+    MetricType metric_type = knowhere::metric::L2;
+    milvus::index::CreateIndexInfo create_index_info;
+    create_index_info.index_type = index_type;
+    create_index_info.metric_type = metric_type;
+    create_index_info.field_type = milvus::DataType::VECTOR_FLOAT16;
+    create_index_info.index_engine_version =
+        knowhere::Version::GetCurrentVersion().VersionNumber();
 
-//     int64_t collection_id = 1;
-//     int64_t partition_id = 2;
-//     int64_t segment_id = 3;
-//     int64_t field_id = 100;
-//     int64_t build_id = 1000;
-//     int64_t index_version = 1;
+    int64_t collection_id = 1;
+    int64_t partition_id = 2;
+    int64_t segment_id = 3;
+    int64_t field_id = 100;
+    int64_t build_id = 1000;
+    int64_t index_version = 1;
 
-//     StorageConfig storage_config = get_default_local_storage_config();
-//     milvus::storage::FieldDataMeta field_data_meta{
-//         collection_id, partition_id, segment_id, field_id};
-//     milvus::storage::IndexMeta index_meta{
-//         segment_id, field_id, build_id, index_version};
-//     auto chunk_manager = storage::CreateChunkManager(storage_config);
-//     milvus::storage::FileManagerContext file_manager_context(
-//         field_data_meta, index_meta, chunk_manager);
-//     auto index = milvus::index::IndexFactory::GetInstance().CreateIndex(
-//         create_index_info, file_manager_context);
+    StorageConfig storage_config = get_default_local_storage_config();
+    milvus::storage::FieldDataMeta field_data_meta{
+        collection_id, partition_id, segment_id, field_id};
+    milvus::storage::IndexMeta index_meta{
+        segment_id, field_id, build_id, index_version};
+    auto chunk_manager = storage::CreateChunkManager(storage_config);
+    milvus::storage::FileManagerContext file_manager_context(
+        field_data_meta, index_meta, chunk_manager);
+    auto index = milvus::index::IndexFactory::GetInstance().CreateIndex(
+        create_index_info, file_manager_context);
 
-//     auto build_conf = Config{
-//         {knowhere::meta::METRIC_TYPE, metric_type},
-//         {knowhere::meta::DIM, std::to_string(DIM)},
-//         {milvus::index::DISK_ANN_MAX_DEGREE, std::to_string(48)},
-//         {milvus::index::DISK_ANN_SEARCH_LIST_SIZE, std::to_string(128)},
-//         {milvus::index::DISK_ANN_PQ_CODE_BUDGET, std::to_string(0.001)},
-//         {milvus::index::DISK_ANN_BUILD_DRAM_BUDGET, std::to_string(2)},
-//         {milvus::index::DISK_ANN_BUILD_THREAD_NUM, std::to_string(2)},
-//     };
+    auto build_conf = Config{
+        {knowhere::meta::METRIC_TYPE, metric_type},
+        {knowhere::meta::DIM, std::to_string(DIM)},
+        {milvus::index::DISK_ANN_MAX_DEGREE, std::to_string(48)},
+        {milvus::index::DISK_ANN_SEARCH_LIST_SIZE, std::to_string(128)},
+        {milvus::index::DISK_ANN_PQ_CODE_BUDGET, std::to_string(0.001)},
+        {milvus::index::DISK_ANN_BUILD_DRAM_BUDGET, std::to_string(2)},
+        {milvus::index::DISK_ANN_BUILD_THREAD_NUM, std::to_string(2)},
+    };
 
-//     // build disk ann index
-//     auto dataset = GenDatasetWithDataType(
-//         NB, metric_type, milvus::DataType::VECTOR_FLOAT16);
-//     FixedVector<float16> xb_data =
-//         dataset.get_col<float16>(milvus::FieldId(field_id));
-//     knowhere::DataSetPtr xb_dataset =
-//         knowhere::GenDataSet(NB, DIM, xb_data.data());
-//     ASSERT_NO_THROW(index->BuildWithDataset(xb_dataset, build_conf));
+    // build disk ann index
+    auto dataset = GenDatasetWithDataType(
+        NB, metric_type, milvus::DataType::VECTOR_FLOAT16);
+    FixedVector<float16> xb_data =
+        dataset.get_col<float16>(milvus::FieldId(field_id));
+    knowhere::DataSetPtr xb_dataset =
+        knowhere::GenDataSet(NB, DIM, xb_data.data());
+    ASSERT_NO_THROW(index->BuildWithDataset(xb_dataset, build_conf));
 
-//     // serialize and load disk index, disk index can only be search after loading for now
-//     auto binary_set = index->Upload();
-//     index.reset();
+    // serialize and load disk index, disk index can only be search after loading for now
+    auto binary_set = index->Upload();
+    index.reset();
 
-//     auto new_index = milvus::index::IndexFactory::GetInstance().CreateIndex(
-//         create_index_info, file_manager_context);
-//     auto vec_index = dynamic_cast<milvus::index::VectorIndex*>(new_index.get());
-//     std::vector<std::string> index_files;
-//     for (auto& binary : binary_set.binary_map_) {
-//         index_files.emplace_back(binary.first);
-//     }
-//     auto load_conf = generate_load_conf(index_type, metric_type, NB);
-//     load_conf["index_files"] = index_files;
-//     vec_index->Load(load_conf);
-//     EXPECT_EQ(vec_index->Count(), NB);
+    auto new_index = milvus::index::IndexFactory::GetInstance().CreateIndex(
+        create_index_info, file_manager_context);
+    auto vec_index = dynamic_cast<milvus::index::VectorIndex*>(new_index.get());
+    std::vector<std::string> index_files;
+    for (auto& binary : binary_set.binary_map_) {
+        index_files.emplace_back(binary.first);
+    }
+    auto load_conf = generate_load_conf(index_type, metric_type, NB);
+    load_conf["index_files"] = index_files;
+    vec_index->Load(milvus::tracer::TraceContext{}, load_conf);
+    EXPECT_EQ(vec_index->Count(), NB);
 
-//     // search disk index with search_list == limit
-//     int query_offset = 100;
-//     knowhere::DataSetPtr xq_dataset =
-//         knowhere::GenDataSet(NQ, DIM, xb_data.data() + DIM * query_offset);
+    // search disk index with search_list == limit
+    int query_offset = 100;
+    knowhere::DataSetPtr xq_dataset =
+        knowhere::GenDataSet(NQ, DIM, xb_data.data() + DIM * query_offset);
 
-//     milvus::SearchInfo search_info;
-//     search_info.topk_ = K;
-//     search_info.metric_type_ = metric_type;
-//     search_info.search_params_ = milvus::Config{
-//         {knowhere::meta::METRIC_TYPE, metric_type},
-//         {milvus::index::DISK_ANN_QUERY_LIST, K - 1},
-//     };
-//     EXPECT_THROW(vec_index->Query(xq_dataset, search_info, nullptr),
-//                  std::runtime_error);
-// }
+    milvus::SearchInfo search_info;
+    search_info.topk_ = K;
+    search_info.metric_type_ = metric_type;
+    search_info.search_params_ = milvus::Config{
+        {knowhere::meta::METRIC_TYPE, metric_type},
+        {milvus::index::DISK_ANN_QUERY_LIST, K * 2},
+    };
+    SearchResult result;
+    EXPECT_NO_THROW(vec_index->Query(xq_dataset, search_info, nullptr, result));
+}
+
+TEST(Indexing, SearchDiskAnnWithBFloat16) {
+    int64_t NB = 10000;
+    IndexType index_type = knowhere::IndexEnum::INDEX_DISKANN;
+    MetricType metric_type = knowhere::metric::L2;
+    milvus::index::CreateIndexInfo create_index_info;
+    create_index_info.index_type = index_type;
+    create_index_info.metric_type = metric_type;
+    create_index_info.field_type = milvus::DataType::VECTOR_BFLOAT16;
+    create_index_info.index_engine_version =
+        knowhere::Version::GetCurrentVersion().VersionNumber();
+
+    int64_t collection_id = 1;
+    int64_t partition_id = 2;
+    int64_t segment_id = 3;
+    int64_t field_id = 100;
+    int64_t build_id = 1000;
+    int64_t index_version = 1;
+
+    StorageConfig storage_config = get_default_local_storage_config();
+    milvus::storage::FieldDataMeta field_data_meta{
+        collection_id, partition_id, segment_id, field_id};
+    milvus::storage::IndexMeta index_meta{
+        segment_id, field_id, build_id, index_version};
+    auto chunk_manager = storage::CreateChunkManager(storage_config);
+    milvus::storage::FileManagerContext file_manager_context(
+        field_data_meta, index_meta, chunk_manager);
+    auto index = milvus::index::IndexFactory::GetInstance().CreateIndex(
+        create_index_info, file_manager_context);
+
+    auto build_conf = Config{
+        {knowhere::meta::METRIC_TYPE, metric_type},
+        {knowhere::meta::DIM, std::to_string(DIM)},
+        {milvus::index::DISK_ANN_MAX_DEGREE, std::to_string(48)},
+        {milvus::index::DISK_ANN_SEARCH_LIST_SIZE, std::to_string(128)},
+        {milvus::index::DISK_ANN_PQ_CODE_BUDGET, std::to_string(0.001)},
+        {milvus::index::DISK_ANN_BUILD_DRAM_BUDGET, std::to_string(2)},
+        {milvus::index::DISK_ANN_BUILD_THREAD_NUM, std::to_string(2)},
+    };
+
+    // build disk ann index
+    auto dataset = GenDatasetWithDataType(
+        NB, metric_type, milvus::DataType::VECTOR_BFLOAT16);
+    FixedVector<bfloat16> xb_data =
+        dataset.get_col<bfloat16>(milvus::FieldId(field_id));
+    knowhere::DataSetPtr xb_dataset =
+        knowhere::GenDataSet(NB, DIM, xb_data.data());
+    ASSERT_NO_THROW(index->BuildWithDataset(xb_dataset, build_conf));
+
+    // serialize and load disk index, disk index can only be search after loading for now
+    auto binary_set = index->Upload();
+    index.reset();
+
+    auto new_index = milvus::index::IndexFactory::GetInstance().CreateIndex(
+        create_index_info, file_manager_context);
+    auto vec_index = dynamic_cast<milvus::index::VectorIndex*>(new_index.get());
+    std::vector<std::string> index_files;
+    for (auto& binary : binary_set.binary_map_) {
+        index_files.emplace_back(binary.first);
+    }
+    auto load_conf = generate_load_conf(index_type, metric_type, NB);
+    load_conf["index_files"] = index_files;
+    vec_index->Load(milvus::tracer::TraceContext{}, load_conf);
+    EXPECT_EQ(vec_index->Count(), NB);
+
+    // search disk index with search_list == limit
+    int query_offset = 100;
+    knowhere::DataSetPtr xq_dataset =
+        knowhere::GenDataSet(NQ, DIM, xb_data.data() + DIM * query_offset);
+
+    milvus::SearchInfo search_info;
+    search_info.topk_ = K;
+    search_info.metric_type_ = metric_type;
+    search_info.search_params_ = milvus::Config{
+        {knowhere::meta::METRIC_TYPE, metric_type},
+        {milvus::index::DISK_ANN_QUERY_LIST, K * 2},
+    };
+    SearchResult result;
+    EXPECT_NO_THROW(vec_index->Query(xq_dataset, search_info, nullptr, result));
+}
 #endif
 
 //class IndexTestV2

--- a/pkg/util/funcutil/func.go
+++ b/pkg/util/funcutil/func.go
@@ -146,11 +146,10 @@ func CheckCtxValid(ctx context.Context) bool {
 func GetVecFieldIDs(schema *schemapb.CollectionSchema) []int64 {
 	var vecFieldIDs []int64
 	for _, field := range schema.Fields {
-		if field.DataType == schemapb.DataType_BinaryVector || field.DataType == schemapb.DataType_FloatVector || field.DataType == schemapb.DataType_Float16Vector || field.DataType == schemapb.DataType_BFloat16Vector || field.DataType == schemapb.DataType_SparseFloatVector {
+		if typeutil.IsVectorType(field.DataType) {
 			vecFieldIDs = append(vecFieldIDs, field.FieldID)
 		}
 	}
-
 	return vecFieldIDs
 }
 


### PR DESCRIPTION
issue:https://github.com/milvus-io/milvus/issues/22837
some test result in sift1m
build params：

> {"index_type": "DISKANN", "metric_type": "L2", "params": {"efConstruction": 128, "M": 8}}

search params：

>  "params": {"search_list":16}, limit = 10

one segment recall:
fp32: 95%
bf16: 90%
fp16: 90%
same build parameters, fp32 compress 128d into 64dim, fp16/bf16 compress 128d into 32dim.
