### PR TITLE
fix: Skip generate balance task when target not ready

### DIFF
--- a/internal/querycoordv2/checkers/balance_checker.go
+++ b/internal/querycoordv2/checkers/balance_checker.go
@@ -41,12 +41,19 @@ type BalanceChecker struct {
 	nodeManager                          *session.NodeManager
 	normalBalanceCollectionsCurrentRound typeutil.UniqueSet
 	scheduler                            task.Scheduler
+	targetMgr                            *meta.TargetManager
 }
 
-func NewBalanceChecker(meta *meta.Meta, balancer balance.Balance, nodeMgr *session.NodeManager, scheduler task.Scheduler) *BalanceChecker {
+func NewBalanceChecker(meta *meta.Meta,
+	targetMgr *meta.TargetManager,
+	balancer balance.Balance,
+	nodeMgr *session.NodeManager,
+	scheduler task.Scheduler,
+) *BalanceChecker {
 	return &BalanceChecker{
 		Balance:                              balancer,
 		meta:                                 meta,
+		targetMgr:                            targetMgr,
 		nodeManager:                          nodeMgr,
 		normalBalanceCollectionsCurrentRound: typeutil.NewUniqueSet(),
 		scheduler:                            scheduler,
@@ -59,6 +66,13 @@ func (b *BalanceChecker) ID() task.Source {
 
 func (b *BalanceChecker) Description() string {
 	return "BalanceChecker checks the cluster distribution and generates balance tasks"
+}
+
+func (b *BalanceChecker) readyToCheck(collectionID int64) bool {
+	metaExist := (b.meta.GetCollection(collectionID) != nil)
+	targetExist := b.targetMgr.IsNextTargetExist(collectionID) || b.targetMgr.IsCurrentTargetExist(collectionID)
+
+	return metaExist && targetExist
 }
 
 func (b *BalanceChecker) replicasToBalance() []int64 {
@@ -76,6 +90,10 @@ func (b *BalanceChecker) replicasToBalance() []int64 {
 	// balance collections influenced by stopping nodes
 	stoppingReplicas := make([]int64, 0)
 	for _, cid := range loadedCollections {
+		// if target and meta isn't ready, skip balance this collection
+		if !b.readyToCheck(cid) {
+			continue
+		}
 		replicas := b.meta.ReplicaManager.GetByCollection(cid)
 		for _, replica := range replicas {
 			for _, nodeID := range replica.GetNodes() {

--- a/internal/querycoordv2/checkers/controller.go
+++ b/internal/querycoordv2/checkers/controller.go
@@ -89,10 +89,11 @@ func NewCheckerController(
 ) *CheckerController {
 	// CheckerController runs checkers with the order,
 	// the former checker has higher priority
+
 	checkers := map[checkerType]Checker{
 		channelChecker: NewChannelChecker(meta, dist, targetMgr, balancer),
 		segmentChecker: NewSegmentChecker(meta, dist, targetMgr, balancer, nodeMgr),
-		balanceChecker: NewBalanceChecker(meta, balancer, nodeMgr, scheduler),
+		balanceChecker: NewBalanceChecker(meta, targetMgr, balancer, nodeMgr, scheduler),
 		indexChecker:   NewIndexChecker(meta, dist, broker, nodeMgr),
 	}
 

--- a/internal/querycoordv2/task/scheduler.go
+++ b/internal/querycoordv2/task/scheduler.go
@@ -860,7 +860,7 @@ func (scheduler *taskScheduler) checkChannelTaskStale(task *ChannelTask) error {
 	for _, action := range task.Actions() {
 		switch action.Type() {
 		case ActionTypeGrow:
-			if scheduler.targetMgr.GetDmChannel(task.collectionID, task.Channel(), meta.NextTarget) == nil {
+			if scheduler.targetMgr.GetDmChannel(task.collectionID, task.Channel(), meta.NextTargetFirst) == nil {
 				log.Warn("the task is stale, the channel to subscribe not exists in targets",
 					zap.String("channel", task.Channel()))
 				return merr.WrapErrChannelReduplicate(task.Channel(), "target doesn't contain this channel")


### PR DESCRIPTION
issue: #30723
pr: #30724

This PR skip generate balance task when collection's target isn't ready. also refine the check stale logic in query coord's scheduler, if channel exist in current or next target, task won't be canceled.