### PR TITLE
fix: Trigger l0 compaction when l0 views don't change 

### DIFF
--- a/internal/datacoord/compaction_trigger_v2.go
+++ b/internal/datacoord/compaction_trigger_v2.go
@@ -64,7 +64,12 @@ func (m *CompactionTriggerManager) Notify(taskID UniqueID, eventType CompactionT
 
 		case TriggerTypeLevelZeroViewIDLE:
 			log.Debug("Start to trigger a level zero compaction by TriggerTypLevelZeroViewIDLE")
-			outView, reason := view.ForceTrigger()
+			outView, reason := view.Trigger()
+			if outView == nil {
+				log.Info("Start to force trigger a level zero compaction by TriggerTypLevelZeroViewIDLE")
+				outView, reason = view.ForceTrigger()
+			}
+
 			if outView != nil {
 				log.Info("Success to trigger a LevelZeroCompaction output view, try to submit",
 					zap.String("reason", reason),

--- a/internal/datacoord/compaction_trigger_v2.go
+++ b/internal/datacoord/compaction_trigger_v2.go
@@ -13,8 +13,9 @@ import (
 type CompactionTriggerType int8
 
 const (
-	TriggerTypeLevelZeroView CompactionTriggerType = iota + 1
-	TriggerTypeSegmentSizeView
+	TriggerTypeLevelZeroViewChange CompactionTriggerType = iota + 1
+	TriggerTypeLevelZeroViewIDLE
+	TriggerTypeSegmentSizeViewChange
 )
 
 type TriggerManager interface {
@@ -32,16 +33,14 @@ type TriggerManager interface {
 // 2. SystemIDLE & schedulerIDLE
 // 3. Manual Compaction
 type CompactionTriggerManager struct {
-	meta      *meta
 	scheduler Scheduler
 	handler   compactionPlanContext // TODO replace with scheduler
 
 	allocator allocator
 }
 
-func NewCompactionTriggerManager(meta *meta, alloc allocator, handler compactionPlanContext) *CompactionTriggerManager {
+func NewCompactionTriggerManager(alloc allocator, handler compactionPlanContext) *CompactionTriggerManager {
 	m := &CompactionTriggerManager{
-		meta:      meta,
 		allocator: alloc,
 		handler:   handler,
 	}
@@ -53,50 +52,64 @@ func (m *CompactionTriggerManager) Notify(taskID UniqueID, eventType CompactionT
 	log := log.With(zap.Int64("taskID", taskID))
 	for _, view := range views {
 		switch eventType {
-		case TriggerTypeLevelZeroView:
-			log.Debug("Start to trigger a level zero compaction")
+		case TriggerTypeLevelZeroViewChange:
+			log.Debug("Start to trigger a level zero compaction by TriggerTypeLevelZeroViewChange")
 			outView, reason := view.Trigger()
-			if outView == nil {
-				continue
+			if outView != nil {
+				log.Info("Success to trigger a LevelZeroCompaction output view, try to sumit",
+					zap.String("reason", reason),
+					zap.String("output view", outView.String()))
+				m.SubmitL0ViewToScheduler(taskID, outView)
 			}
 
-			plan := m.BuildLevelZeroCompactionPlan(outView)
-			if plan == nil {
-				continue
+		case TriggerTypeLevelZeroViewIDLE:
+			log.Debug("Start to trigger a level zero compaction by TriggerTypLevelZeroViewIDLE")
+			outView, reason := view.ForceTrigger()
+			if outView != nil {
+				log.Info("Success to trigger a LevelZeroCompaction output view, try to submit",
+					zap.String("reason", reason),
+					zap.String("output view", outView.String()))
+				m.SubmitL0ViewToScheduler(taskID, outView)
 			}
-
-			label := outView.GetGroupLabel()
-			signal := &compactionSignal{
-				id:           taskID,
-				isForce:      false,
-				isGlobal:     true,
-				collectionID: label.CollectionID,
-				partitionID:  label.PartitionID,
-				pos:          outView.(*LevelZeroSegmentsView).earliestGrowingSegmentPos,
-			}
-
-			// TODO, remove handler, use scheduler
-			// m.scheduler.Submit(plan)
-			m.handler.execCompactionPlan(signal, plan)
-			log.Info("Finish to trigger a LevelZeroCompaction plan",
-				zap.Int64("planID", plan.GetPlanID()),
-				zap.String("type", plan.GetType().String()),
-				zap.String("reason", reason),
-				zap.String("output view", outView.String()))
 		}
 	}
 }
 
-func (m *CompactionTriggerManager) BuildLevelZeroCompactionPlan(view CompactionView) *datapb.CompactionPlan {
+func (m *CompactionTriggerManager) SubmitL0ViewToScheduler(taskID int64, outView CompactionView) {
+	plan := m.buildL0CompactionPlan(outView)
+	if plan == nil {
+		return
+	}
+
+	label := outView.GetGroupLabel()
+	signal := &compactionSignal{
+		id:           taskID,
+		isForce:      false,
+		isGlobal:     true,
+		collectionID: label.CollectionID,
+		partitionID:  label.PartitionID,
+		pos:          outView.(*LevelZeroSegmentsView).earliestGrowingSegmentPos,
+	}
+
+	// TODO, remove handler, use scheduler
+	// m.scheduler.Submit(plan)
+	m.handler.execCompactionPlan(signal, plan)
+	log.Info("Finish to submit a LevelZeroCompaction plan",
+		zap.Int64("taskID", taskID),
+		zap.Int64("planID", plan.GetPlanID()),
+		zap.String("type", plan.GetType().String()),
+	)
+}
+
+func (m *CompactionTriggerManager) buildL0CompactionPlan(view CompactionView) *datapb.CompactionPlan {
 	var segmentBinlogs []*datapb.CompactionSegmentBinlogs
 	levelZeroSegs := lo.Map(view.GetSegmentsView(), func(segView *SegmentView, _ int) *datapb.CompactionSegmentBinlogs {
-		s := m.meta.GetSegment(segView.ID)
 		return &datapb.CompactionSegmentBinlogs{
 			SegmentID:    segView.ID,
-			Deltalogs:    s.GetDeltalogs(),
 			Level:        datapb.SegmentLevel_L0,
 			CollectionID: view.GetGroupLabel().CollectionID,
 			PartitionID:  view.GetGroupLabel().PartitionID,
+			// Deltalogs:   deltalogs are filled before executing the plan
 		}
 	})
 	segmentBinlogs = append(segmentBinlogs, levelZeroSegs...)

--- a/internal/datacoord/compaction_trigger_v2_test.go
+++ b/internal/datacoord/compaction_trigger_v2_test.go
@@ -22,6 +22,7 @@ type CompactionTriggerManagerSuite struct {
 	mockAlloc       *NMockAllocator
 	mockPlanContext *MockCompactionPlanContext
 	testLabel       *CompactionGroupLabel
+	meta            *meta
 
 	m *CompactionTriggerManager
 }
@@ -35,16 +36,16 @@ func (s *CompactionTriggerManagerSuite) SetupTest() {
 		PartitionID:  10,
 		Channel:      "ch-1",
 	}
-	meta := &meta{segments: &SegmentsInfo{
+	s.meta = &meta{segments: &SegmentsInfo{
 		segments: genSegmentsForMeta(s.testLabel),
 	}}
 
-	s.m = NewCompactionTriggerManager(meta, s.mockAlloc, s.mockPlanContext)
+	s.m = NewCompactionTriggerManager(s.mockAlloc, s.mockPlanContext)
 }
 
 func (s *CompactionTriggerManagerSuite) TestNotify() {
-	viewManager := NewCompactionViewManager(s.m.meta, s.m, s.m.allocator)
-	collSegs := s.m.meta.GetCompactableSegmentGroupByCollection()
+	viewManager := NewCompactionViewManager(s.meta, s.m, s.m.allocator)
+	collSegs := s.meta.GetCompactableSegmentGroupByCollection()
 
 	segments, found := collSegs[1]
 	s.Require().True(found)
@@ -85,5 +86,5 @@ func (s *CompactionTriggerManagerSuite) TestNotify() {
 			log.Info("generated plan", zap.Any("plan", plan))
 		}).Return(nil).Once()
 
-	s.m.Notify(19530, TriggerTypeLevelZeroView, levelZeroView)
+	s.m.Notify(19530, TriggerTypeLevelZeroViewChange, levelZeroView)
 }

--- a/internal/datacoord/compaction_trigger_v2_test.go
+++ b/internal/datacoord/compaction_trigger_v2_test.go
@@ -50,14 +50,15 @@ func (s *CompactionTriggerManagerSuite) TestNotifyByViewIDLE() {
 	segments, found := collSegs[1]
 	s.Require().True(found)
 
-	levelZeroSegments := lo.Filter(segments, func(info *SegmentInfo, _ int) bool {
-		return info.GetLevel() == datapb.SegmentLevel_L0
+	seg1, found := lo.Find(segments, func(info *SegmentInfo) bool {
+		return info.ID == int64(100) && info.GetLevel() == datapb.SegmentLevel_L0
 	})
+	s.Require().True(found)
 
 	// Prepare only 1 l0 segment that doesn't meet the Trigger minimum condition
-	// buger ViewIDLE Trigger will still forceTrigger the plan
-	latestL0Segments := GetViewsByInfo(levelZeroSegments[0])
-	expectedSegID := latestL0Segments[0].ID
+	// but ViewIDLE Trigger will still forceTrigger the plan
+	latestL0Segments := GetViewsByInfo(seg1)
+	expectedSegID := seg1.ID
 
 	s.Require().Equal(1, len(latestL0Segments))
 	levelZeroView := viewManager.getChangedLevelZeroViews(1, latestL0Segments)

--- a/internal/datacoord/compaction_view.go
+++ b/internal/datacoord/compaction_view.go
@@ -18,6 +18,7 @@ type CompactionView interface {
 	Append(segments ...*SegmentView)
 	String() string
 	Trigger() (CompactionView, string)
+	ForceTrigger() (CompactionView, string)
 }
 
 type FullViews struct {

--- a/internal/datacoord/compaction_view_manager.go
+++ b/internal/datacoord/compaction_view_manager.go
@@ -141,7 +141,7 @@ func (m *CompactionViewManager) notifyTrigger(ctx context.Context, events map[Co
 
 // Global check could take some time, we need to record the time.
 func (m *CompactionViewManager) Check(ctx context.Context) (events map[CompactionTriggerType][]CompactionView) {
-	ctx, span := otel.Tracer(typeutil.DataCoordRole).Start(ctx, "CompactionView-Check")
+	_, span := otel.Tracer(typeutil.DataCoordRole).Start(ctx, "CompactionView-Check")
 	defer span.End()
 
 	m.viewGuard.Lock()

--- a/internal/datacoord/server.go
+++ b/internal/datacoord/server.go
@@ -498,7 +498,7 @@ func (s *Server) SetIndexNodeCreator(f func(context.Context, string, int64) (typ
 
 func (s *Server) createCompactionHandler() {
 	s.compactionHandler = newCompactionPlanHandler(s.sessionManager, s.channelManager, s.meta, s.allocator)
-	triggerv2 := NewCompactionTriggerManager(s.meta, s.allocator, s.compactionHandler)
+	triggerv2 := NewCompactionTriggerManager(s.allocator, s.compactionHandler)
 	s.compactionViewManager = NewCompactionViewManager(s.meta, triggerv2, s.allocator)
 }
 


### PR DESCRIPTION
Trigger l0 compaction when l0 views don't change

So that leftover l0 segments would be compacted in the end.

1. Refresh LevelZero plans in comactionPlanHandler, remove the meta dependency
of compaction trigger v2
2. Add ForceTrigger method for CompactionView interface
3. rename mu to taskGuard
4. Add a new TriggerTypeLevelZeroViewIDLE
5. Add an idleTicker for compaction view manager

See also: #30098, #30556

Signed-off-by: yangxuan <xuan.yang@zilliz.com>