### PR TITLE
enhance: Check Segment equal before releasing old version segment

### DIFF
--- a/internal/querynodev2/segments/manager.go
+++ b/internal/querynodev2/segments/manager.go
@@ -274,7 +274,9 @@ func (mgr *segmentManager) Put(segmentType SegmentType, segments ...Segment) {
 					zap.Int64("newVersion", segment.Version()),
 				)
 				// delete redundant segment
-				segment.Release()
+				if segment != oldSegment {
+					segment.Release()
+				}
 				continue
 			}
 			replacedSegment = append(replacedSegment, oldSegment)

--- a/internal/querynodev2/segments/manager_test.go
+++ b/internal/querynodev2/segments/manager_test.go
@@ -97,6 +97,19 @@ func (s *ManagerSuite) TestGetAndPin() {
 	s.Equal(len(segments), 0)
 }
 
+func (s *ManagerSuite) TestPutAgain() {
+	for i, segmentID := range s.segmentIDs {
+		segment := s.mgr.Get(segmentID)
+		s.mgr.Put(s.types[i], segment)
+		localSegment, ok := segment.(*LocalSegment)
+		if ok {
+			localSegment.ptrLock.RLock()
+			s.NotNil(localSegment.ptr)
+			localSegment.ptrLock.RUnlock()
+		}
+	}
+}
+
 func (s *ManagerSuite) TestRemoveGrowing() {
 	for i, id := range s.segmentIDs {
 		isGrowing := s.types[i] == SegmentTypeGrowing


### PR DESCRIPTION
Segment manager check segment manager when replacing segment with same id. If the new segment has lower or equal version comparing to the existing one, the new segment will be released.

This PR prevent releasing the segment whe putting the same segment into segment manager.