### PR TITLE
fix: nil ptr is used as nil interface in grpc client

### DIFF
--- a/internal/distributed/datacoord/client/client.go
+++ b/internal/distributed/datacoord/client/client.go
@@ -50,7 +50,7 @@ type Client struct {
 }
 
 // NewClient creates a new client instance
-func NewClient(ctx context.Context) (*Client, error) {
+func NewClient(ctx context.Context) (types.DataCoordClient, error) {
 	sess := sessionutil.NewSession(ctx)
 	if sess == nil {
 		err := fmt.Errorf("new session error, maybe can not connect to etcd")

--- a/internal/distributed/datacoord/client/client_test.go
+++ b/internal/distributed/datacoord/client/client_test.go
@@ -83,7 +83,7 @@ func Test_GetComponentStates(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(datapb.DataCoordClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().GetComponentStates(mock.Anything, mock.Anything).Return(&milvuspb.ComponentStates{
@@ -124,7 +124,7 @@ func Test_GetTimeTickChannel(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(datapb.DataCoordClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().GetTimeTickChannel(mock.Anything, mock.Anything).Return(&milvuspb.StringResponse{
@@ -165,7 +165,7 @@ func Test_GetStatisticsChannel(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(datapb.DataCoordClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().GetStatisticsChannel(mock.Anything, mock.Anything).Return(&milvuspb.StringResponse{
@@ -207,7 +207,7 @@ func Test_Flush(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(datapb.DataCoordClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().Flush(mock.Anything, mock.Anything).Return(&datapb.FlushResponse{
@@ -248,7 +248,7 @@ func Test_AssignSegmentID(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(datapb.DataCoordClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().AssignSegmentID(mock.Anything, mock.Anything).Return(&datapb.AssignSegmentIDResponse{
@@ -290,7 +290,7 @@ func Test_GetSegmentStates(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(datapb.DataCoordClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().GetSegmentStates(mock.Anything, mock.Anything).Return(&datapb.GetSegmentStatesResponse{
@@ -332,7 +332,7 @@ func Test_GetInsertBinlogPaths(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(datapb.DataCoordClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().GetInsertBinlogPaths(mock.Anything, mock.Anything).Return(&datapb.GetInsertBinlogPathsResponse{
@@ -374,7 +374,7 @@ func Test_GetCollectionStatistics(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(datapb.DataCoordClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().GetCollectionStatistics(mock.Anything, mock.Anything).Return(&datapb.GetCollectionStatisticsResponse{
@@ -416,7 +416,7 @@ func Test_GetPartitionStatistics(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(datapb.DataCoordClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().GetPartitionStatistics(mock.Anything, mock.Anything).Return(&datapb.GetPartitionStatisticsResponse{
@@ -457,7 +457,7 @@ func Test_GetSegmentInfoChannel(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(datapb.DataCoordClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().GetSegmentInfoChannel(mock.Anything, mock.Anything).Return(&milvuspb.StringResponse{
@@ -499,7 +499,7 @@ func Test_GetSegmentInfo(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(datapb.DataCoordClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().GetSegmentInfo(mock.Anything, mock.Anything).Return(&datapb.GetSegmentInfoResponse{
@@ -541,7 +541,7 @@ func Test_SaveBinlogPaths(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(datapb.DataCoordClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().GetSegmentInfo(mock.Anything, mock.Anything).Return(&datapb.GetSegmentInfoResponse{
@@ -583,7 +583,7 @@ func Test_GetRecoveryInfo(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(datapb.DataCoordClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().GetRecoveryInfo(mock.Anything, mock.Anything).Return(&datapb.GetRecoveryInfoResponse{
@@ -624,7 +624,7 @@ func Test_GetRecoveryInfoV2(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(datapb.DataCoordClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().GetRecoveryInfoV2(mock.Anything, mock.Anything).Return(&datapb.GetRecoveryInfoResponseV2{
@@ -666,7 +666,7 @@ func Test_GetFlushedSegments(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(datapb.DataCoordClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().GetFlushedSegments(mock.Anything, mock.Anything).Return(&datapb.GetFlushedSegmentsResponse{
@@ -708,7 +708,7 @@ func Test_GetSegmentsByStates(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(datapb.DataCoordClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().GetSegmentsByStates(mock.Anything, mock.Anything).Return(&datapb.GetSegmentsByStatesResponse{
@@ -750,7 +750,7 @@ func Test_ShowConfigurations(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(datapb.DataCoordClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().ShowConfigurations(mock.Anything, mock.Anything).Return(&internalpb.ShowConfigurationsResponse{
@@ -792,7 +792,7 @@ func Test_GetMetrics(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(datapb.DataCoordClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().GetMetrics(mock.Anything, mock.Anything).Return(&milvuspb.GetMetricsResponse{
@@ -833,7 +833,7 @@ func Test_ManualCompaction(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(datapb.DataCoordClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().ManualCompaction(mock.Anything, mock.Anything).Return(&milvuspb.ManualCompactionResponse{
@@ -874,7 +874,7 @@ func Test_GetCompactionState(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(datapb.DataCoordClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().GetCompactionState(mock.Anything, mock.Anything).Return(&milvuspb.GetCompactionStateResponse{
@@ -915,7 +915,7 @@ func Test_GetCompactionStateWithPlans(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(datapb.DataCoordClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().GetCompactionStateWithPlans(mock.Anything, mock.Anything).Return(&milvuspb.GetCompactionPlansResponse{
@@ -956,7 +956,7 @@ func Test_WatchChannels(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(datapb.DataCoordClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().WatchChannels(mock.Anything, mock.Anything).Return(&datapb.WatchChannelsResponse{
@@ -997,7 +997,7 @@ func Test_GetFlushState(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(datapb.DataCoordClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().GetFlushState(mock.Anything, mock.Anything).Return(&milvuspb.GetFlushStateResponse{
@@ -1038,7 +1038,7 @@ func Test_GetFlushAllState(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(datapb.DataCoordClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().GetFlushAllState(mock.Anything, mock.Anything).Return(&milvuspb.GetFlushAllStateResponse{
@@ -1080,7 +1080,7 @@ func Test_DropVirtualChannel(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(datapb.DataCoordClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().DropVirtualChannel(mock.Anything, mock.Anything).Return(&datapb.DropVirtualChannelResponse{
@@ -1122,7 +1122,7 @@ func Test_SetSegmentState(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(datapb.DataCoordClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().SetSegmentState(mock.Anything, mock.Anything).Return(&datapb.SetSegmentStateResponse{
@@ -1164,7 +1164,7 @@ func Test_Import(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(datapb.DataCoordClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().Import(mock.Anything, mock.Anything).Return(&datapb.ImportTaskResponse{
@@ -1206,7 +1206,7 @@ func Test_UpdateSegmentStatistics(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(datapb.DataCoordClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().UpdateSegmentStatistics(mock.Anything, mock.Anything).Return(merr.Success(), nil)
@@ -1244,7 +1244,7 @@ func Test_UpdateChannelCheckpoint(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(datapb.DataCoordClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().UpdateChannelCheckpoint(mock.Anything, mock.Anything).Return(merr.Success(), nil)
@@ -1282,7 +1282,7 @@ func Test_SaveImportSegment(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(datapb.DataCoordClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().SaveImportSegment(mock.Anything, mock.Anything).Return(merr.Success(), nil)
@@ -1320,7 +1320,7 @@ func Test_UnsetIsImportingState(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(datapb.DataCoordClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().UnsetIsImportingState(mock.Anything, mock.Anything).Return(merr.Success(), nil)
@@ -1358,7 +1358,7 @@ func Test_MarkSegmentsDropped(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(datapb.DataCoordClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().MarkSegmentsDropped(mock.Anything, mock.Anything).Return(merr.Success(), nil)
@@ -1395,7 +1395,7 @@ func Test_BroadcastAlteredCollection(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(datapb.DataCoordClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().BroadcastAlteredCollection(mock.Anything, mock.Anything).Return(merr.Success(), nil)
@@ -1432,7 +1432,7 @@ func Test_CheckHealth(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(datapb.DataCoordClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().CheckHealth(mock.Anything, mock.Anything).Return(&milvuspb.CheckHealthResponse{Status: merr.Success()}, nil)
@@ -1469,7 +1469,7 @@ func Test_GcConfirm(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(datapb.DataCoordClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().GcConfirm(mock.Anything, mock.Anything).Return(&datapb.GcConfirmResponse{Status: merr.Success()}, nil)
@@ -1506,7 +1506,7 @@ func Test_CreateIndex(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(datapb.DataCoordClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().CreateIndex(mock.Anything, mock.Anything).Return(merr.Success(), nil)
@@ -1543,7 +1543,7 @@ func Test_GetSegmentIndexState(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(datapb.DataCoordClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().GetSegmentIndexState(mock.Anything, mock.Anything).Return(&indexpb.GetSegmentIndexStateResponse{Status: merr.Success()}, nil)
@@ -1580,7 +1580,7 @@ func Test_GetIndexState(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(datapb.DataCoordClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().GetIndexState(mock.Anything, mock.Anything).Return(&indexpb.GetIndexStateResponse{Status: merr.Success()}, nil)
@@ -1617,7 +1617,7 @@ func Test_GetIndexInfos(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(datapb.DataCoordClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().GetIndexInfos(mock.Anything, mock.Anything).Return(&indexpb.GetIndexInfoResponse{Status: merr.Success()}, nil)
@@ -1654,7 +1654,7 @@ func Test_DescribeIndex(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(datapb.DataCoordClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().DescribeIndex(mock.Anything, mock.Anything).Return(&indexpb.DescribeIndexResponse{Status: merr.Success()}, nil)
@@ -1691,7 +1691,7 @@ func Test_GetIndexStatistics(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(datapb.DataCoordClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().GetIndexStatistics(mock.Anything, mock.Anything).Return(&indexpb.GetIndexStatisticsResponse{Status: merr.Success()}, nil)
@@ -1728,7 +1728,7 @@ func Test_GetIndexBuildProgress(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(datapb.DataCoordClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().GetIndexBuildProgress(mock.Anything, mock.Anything).Return(&indexpb.GetIndexBuildProgressResponse{Status: merr.Success()}, nil)
@@ -1765,7 +1765,7 @@ func Test_DropIndex(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(datapb.DataCoordClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().DropIndex(mock.Anything, mock.Anything).Return(merr.Success(), nil)
@@ -1802,7 +1802,7 @@ func Test_ReportDataNodeTtMsgs(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(datapb.DataCoordClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().ReportDataNodeTtMsgs(mock.Anything, mock.Anything).Return(merr.Success(), nil)
@@ -1839,7 +1839,7 @@ func Test_GcControl(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(datapb.DataCoordClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().GcControl(mock.Anything, mock.Anything).Return(merr.Success(), nil)

--- a/internal/distributed/datanode/client/client.go
+++ b/internal/distributed/datanode/client/client.go
@@ -27,6 +27,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
 	"github.com/milvus-io/milvus/internal/proto/internalpb"
+	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/grpcclient"
 	"github.com/milvus-io/milvus/internal/util/sessionutil"
 	"github.com/milvus-io/milvus/pkg/log"
@@ -47,7 +48,7 @@ type Client struct {
 }
 
 // NewClient creates a client for DataNode.
-func NewClient(ctx context.Context, addr string, serverID int64) (*Client, error) {
+func NewClient(ctx context.Context, addr string, serverID int64) (types.DataNodeClient, error) {
 	if addr == "" {
 		return nil, fmt.Errorf("address is empty")
 	}

--- a/internal/distributed/datanode/client/client_test.go
+++ b/internal/distributed/datanode/client/client_test.go
@@ -91,18 +91,18 @@ func Test_NewClient(t *testing.T) {
 		retCheck(retNotNil, r13, err)
 	}
 
-	client.grpcClient = &mock.GRPCClientBase[datapb.DataNodeClient]{
+	client.(*Client).grpcClient = &mock.GRPCClientBase[datapb.DataNodeClient]{
 		GetGrpcClientErr: errors.New("dummy"),
 	}
 
 	newFunc1 := func(cc *grpc.ClientConn) datapb.DataNodeClient {
 		return &mock.GrpcDataNodeClient{Err: nil}
 	}
-	client.grpcClient.SetNewGrpcClientFunc(newFunc1)
+	client.(*Client).grpcClient.SetNewGrpcClientFunc(newFunc1)
 
 	checkFunc(false)
 
-	client.grpcClient = &mock.GRPCClientBase[datapb.DataNodeClient]{
+	client.(*Client).grpcClient = &mock.GRPCClientBase[datapb.DataNodeClient]{
 		GetGrpcClientErr: nil,
 	}
 
@@ -110,18 +110,18 @@ func Test_NewClient(t *testing.T) {
 		return &mock.GrpcDataNodeClient{Err: errors.New("dummy")}
 	}
 
-	client.grpcClient.SetNewGrpcClientFunc(newFunc2)
+	client.(*Client).grpcClient.SetNewGrpcClientFunc(newFunc2)
 
 	checkFunc(false)
 
-	client.grpcClient = &mock.GRPCClientBase[datapb.DataNodeClient]{
+	client.(*Client).grpcClient = &mock.GRPCClientBase[datapb.DataNodeClient]{
 		GetGrpcClientErr: nil,
 	}
 
 	newFunc3 := func(cc *grpc.ClientConn) datapb.DataNodeClient {
 		return &mock.GrpcDataNodeClient{Err: nil}
 	}
-	client.grpcClient.SetNewGrpcClientFunc(newFunc3)
+	client.(*Client).grpcClient.SetNewGrpcClientFunc(newFunc3)
 
 	checkFunc(true)
 

--- a/internal/distributed/indexnode/client/client.go
+++ b/internal/distributed/indexnode/client/client.go
@@ -27,6 +27,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/milvus-io/milvus/internal/proto/indexpb"
 	"github.com/milvus-io/milvus/internal/proto/internalpb"
+	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/grpcclient"
 	"github.com/milvus-io/milvus/internal/util/sessionutil"
 	"github.com/milvus-io/milvus/pkg/log"
@@ -46,7 +47,7 @@ type Client struct {
 }
 
 // NewClient creates a new IndexNode client.
-func NewClient(ctx context.Context, addr string, nodeID int64, encryption bool) (*Client, error) {
+func NewClient(ctx context.Context, addr string, nodeID int64, encryption bool) (types.IndexNodeClient, error) {
 	if addr == "" {
 		return nil, fmt.Errorf("address is empty")
 	}

--- a/internal/distributed/indexnode/client/client_test.go
+++ b/internal/distributed/indexnode/client/client_test.go
@@ -72,35 +72,35 @@ func Test_NewClient(t *testing.T) {
 		retCheck(retNotNil, r7, err)
 	}
 
-	client.grpcClient = &mock.GRPCClientBase[indexpb.IndexNodeClient]{
+	client.(*Client).grpcClient = &mock.GRPCClientBase[indexpb.IndexNodeClient]{
 		GetGrpcClientErr: errors.New("dummy"),
 	}
 
 	newFunc1 := func(cc *grpc.ClientConn) indexpb.IndexNodeClient {
 		return &mock.GrpcIndexNodeClient{Err: nil}
 	}
-	client.grpcClient.SetNewGrpcClientFunc(newFunc1)
+	client.(*Client).grpcClient.SetNewGrpcClientFunc(newFunc1)
 
 	checkFunc(false)
 
-	client.grpcClient = &mock.GRPCClientBase[indexpb.IndexNodeClient]{
+	client.(*Client).grpcClient = &mock.GRPCClientBase[indexpb.IndexNodeClient]{
 		GetGrpcClientErr: nil,
 	}
 
 	newFunc2 := func(cc *grpc.ClientConn) indexpb.IndexNodeClient {
 		return &mock.GrpcIndexNodeClient{Err: errors.New("dummy")}
 	}
-	client.grpcClient.SetNewGrpcClientFunc(newFunc2)
+	client.(*Client).grpcClient.SetNewGrpcClientFunc(newFunc2)
 	checkFunc(false)
 
-	client.grpcClient = &mock.GRPCClientBase[indexpb.IndexNodeClient]{
+	client.(*Client).grpcClient = &mock.GRPCClientBase[indexpb.IndexNodeClient]{
 		GetGrpcClientErr: nil,
 	}
 
 	newFunc3 := func(cc *grpc.ClientConn) indexpb.IndexNodeClient {
 		return &mock.GrpcIndexNodeClient{Err: nil}
 	}
-	client.grpcClient.SetNewGrpcClientFunc(newFunc3)
+	client.(*Client).grpcClient.SetNewGrpcClientFunc(newFunc3)
 	checkFunc(true)
 
 	err = client.Close()

--- a/internal/distributed/proxy/client/client.go
+++ b/internal/distributed/proxy/client/client.go
@@ -27,6 +27,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/milvus-io/milvus/internal/proto/internalpb"
 	"github.com/milvus-io/milvus/internal/proto/proxypb"
+	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/grpcclient"
 	"github.com/milvus-io/milvus/internal/util/sessionutil"
 	"github.com/milvus-io/milvus/pkg/log"
@@ -46,7 +47,7 @@ type Client struct {
 }
 
 // NewClient creates a new client instance
-func NewClient(ctx context.Context, addr string, nodeID int64) (*Client, error) {
+func NewClient(ctx context.Context, addr string, nodeID int64) (types.ProxyClient, error) {
 	if addr == "" {
 		return nil, fmt.Errorf("address is empty")
 	}

--- a/internal/distributed/proxy/client/client_test.go
+++ b/internal/distributed/proxy/client/client_test.go
@@ -64,7 +64,7 @@ func Test_GetComponentStates(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(proxypb.ProxyClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().GetComponentStates(mock.Anything, mock.Anything).Return(&milvuspb.ComponentStates{
@@ -105,7 +105,7 @@ func Test_GetStatisticsChannel(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(proxypb.ProxyClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().GetStatisticsChannel(mock.Anything, mock.Anything).Return(&milvuspb.StringResponse{
@@ -147,7 +147,7 @@ func Test_InvalidateCollectionMetaCache(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(proxypb.ProxyClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().InvalidateCollectionMetaCache(mock.Anything, mock.Anything).Return(merr.Success(), nil)
@@ -185,7 +185,7 @@ func Test_InvalidateCredentialCache(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(proxypb.ProxyClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().InvalidateCredentialCache(mock.Anything, mock.Anything).Return(merr.Success(), nil)
@@ -223,7 +223,7 @@ func Test_UpdateCredentialCache(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(proxypb.ProxyClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().UpdateCredentialCache(mock.Anything, mock.Anything).Return(merr.Success(), nil)
@@ -261,7 +261,7 @@ func Test_RefreshPolicyInfoCache(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(proxypb.ProxyClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().RefreshPolicyInfoCache(mock.Anything, mock.Anything).Return(merr.Success(), nil)
@@ -299,7 +299,7 @@ func Test_GetProxyMetrics(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(proxypb.ProxyClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().GetProxyMetrics(mock.Anything, mock.Anything).Return(&milvuspb.GetMetricsResponse{Status: merr.Success()}, nil)
@@ -337,7 +337,7 @@ func Test_SetRates(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(proxypb.ProxyClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().SetRates(mock.Anything, mock.Anything).Return(merr.Success(), nil)
@@ -375,7 +375,7 @@ func Test_ListClientInfos(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(proxypb.ProxyClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().ListClientInfos(mock.Anything, mock.Anything).Return(&proxypb.ListClientInfosResponse{Status: merr.Success()}, nil)
@@ -412,7 +412,7 @@ func Test_GetDdChannel(t *testing.T) {
 	mockGrpcClient.EXPECT().ReCall(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, f func(proxypb.ProxyClient) (interface{}, error)) (interface{}, error) {
 		return f(mockProxy)
 	})
-	client.grpcClient = mockGrpcClient
+	client.(*Client).grpcClient = mockGrpcClient
 
 	// test success
 	mockProxy.EXPECT().GetDdChannel(mock.Anything, mock.Anything).Return(&milvuspb.StringResponse{Status: merr.Success()}, nil)

--- a/internal/distributed/querycoord/client/client.go
+++ b/internal/distributed/querycoord/client/client.go
@@ -27,6 +27,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/milvus-io/milvus/internal/proto/internalpb"
 	"github.com/milvus-io/milvus/internal/proto/querypb"
+	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/grpcclient"
 	"github.com/milvus-io/milvus/internal/util/sessionutil"
 	"github.com/milvus-io/milvus/pkg/log"
@@ -45,7 +46,7 @@ type Client struct {
 }
 
 // NewClient creates a client for QueryCoord grpc call.
-func NewClient(ctx context.Context) (*Client, error) {
+func NewClient(ctx context.Context) (types.QueryCoordClient, error) {
 	sess := sessionutil.NewSession(ctx)
 	if sess == nil {
 		err := fmt.Errorf("new session error, maybe can not connect to etcd")

--- a/internal/distributed/querycoord/client/client_test.go
+++ b/internal/distributed/querycoord/client/client_test.go
@@ -160,18 +160,18 @@ func Test_NewClient(t *testing.T) {
 		retCheck(retNotNil, r30, err)
 	}
 
-	client.grpcClient = &mock.GRPCClientBase[querypb.QueryCoordClient]{
+	client.(*Client).grpcClient = &mock.GRPCClientBase[querypb.QueryCoordClient]{
 		GetGrpcClientErr: errors.New("dummy"),
 	}
 
 	newFunc1 := func(cc *grpc.ClientConn) querypb.QueryCoordClient {
 		return &mock.GrpcQueryCoordClient{Err: nil}
 	}
-	client.grpcClient.SetNewGrpcClientFunc(newFunc1)
+	client.(*Client).grpcClient.SetNewGrpcClientFunc(newFunc1)
 
 	checkFunc(false)
 
-	client.grpcClient = &mock.GRPCClientBase[querypb.QueryCoordClient]{
+	client.(*Client).grpcClient = &mock.GRPCClientBase[querypb.QueryCoordClient]{
 		GetGrpcClientErr: nil,
 	}
 
@@ -179,18 +179,18 @@ func Test_NewClient(t *testing.T) {
 		return &mock.GrpcQueryCoordClient{Err: errors.New("dummy")}
 	}
 
-	client.grpcClient.SetNewGrpcClientFunc(newFunc2)
+	client.(*Client).grpcClient.SetNewGrpcClientFunc(newFunc2)
 
 	checkFunc(false)
 
-	client.grpcClient = &mock.GRPCClientBase[querypb.QueryCoordClient]{
+	client.(*Client).grpcClient = &mock.GRPCClientBase[querypb.QueryCoordClient]{
 		GetGrpcClientErr: nil,
 	}
 
 	newFunc3 := func(cc *grpc.ClientConn) querypb.QueryCoordClient {
 		return &mock.GrpcQueryCoordClient{Err: nil}
 	}
-	client.grpcClient.SetNewGrpcClientFunc(newFunc3)
+	client.(*Client).grpcClient.SetNewGrpcClientFunc(newFunc3)
 
 	checkFunc(true)
 

--- a/internal/distributed/querynode/client/client.go
+++ b/internal/distributed/querynode/client/client.go
@@ -27,6 +27,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/milvus-io/milvus/internal/proto/internalpb"
 	"github.com/milvus-io/milvus/internal/proto/querypb"
+	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/grpcclient"
 	"github.com/milvus-io/milvus/internal/util/sessionutil"
 	"github.com/milvus-io/milvus/pkg/log"
@@ -45,7 +46,7 @@ type Client struct {
 }
 
 // NewClient creates a new QueryNode client.
-func NewClient(ctx context.Context, addr string, nodeID int64) (*Client, error) {
+func NewClient(ctx context.Context, addr string, nodeID int64) (types.QueryNodeClient, error) {
 	if addr == "" {
 		return nil, fmt.Errorf("addr is empty")
 	}

--- a/internal/distributed/querynode/client/client_test.go
+++ b/internal/distributed/querynode/client/client_test.go
@@ -113,18 +113,18 @@ func Test_NewClient(t *testing.T) {
 		retCheck(retNotNil, client, err)
 	}
 
-	client.grpcClient = &mock.GRPCClientBase[querypb.QueryNodeClient]{
+	client.(*Client).grpcClient = &mock.GRPCClientBase[querypb.QueryNodeClient]{
 		GetGrpcClientErr: errors.New("dummy"),
 	}
 
 	newFunc1 := func(cc *grpc.ClientConn) querypb.QueryNodeClient {
 		return &mock.GrpcQueryNodeClient{Err: nil}
 	}
-	client.grpcClient.SetNewGrpcClientFunc(newFunc1)
+	client.(*Client).grpcClient.SetNewGrpcClientFunc(newFunc1)
 
 	checkFunc(false)
 
-	client.grpcClient = &mock.GRPCClientBase[querypb.QueryNodeClient]{
+	client.(*Client).grpcClient = &mock.GRPCClientBase[querypb.QueryNodeClient]{
 		GetGrpcClientErr: nil,
 	}
 
@@ -132,26 +132,26 @@ func Test_NewClient(t *testing.T) {
 		return &mock.GrpcQueryNodeClient{Err: errors.New("dummy")}
 	}
 
-	client.grpcClient.SetNewGrpcClientFunc(newFunc2)
+	client.(*Client).grpcClient.SetNewGrpcClientFunc(newFunc2)
 
 	checkFunc(false)
 
-	client.grpcClient = &mock.GRPCClientBase[querypb.QueryNodeClient]{
+	client.(*Client).grpcClient = &mock.GRPCClientBase[querypb.QueryNodeClient]{
 		GetGrpcClientErr: nil,
 	}
 
 	newFunc3 := func(cc *grpc.ClientConn) querypb.QueryNodeClient {
 		return &mock.GrpcQueryNodeClient{Err: nil}
 	}
-	client.grpcClient.SetNewGrpcClientFunc(newFunc3)
+	client.(*Client).grpcClient.SetNewGrpcClientFunc(newFunc3)
 
 	checkFunc(true)
 
 	// ctx canceled
-	client.grpcClient = &mock.GRPCClientBase[querypb.QueryNodeClient]{
+	client.(*Client).grpcClient = &mock.GRPCClientBase[querypb.QueryNodeClient]{
 		GetGrpcClientErr: nil,
 	}
-	client.grpcClient.SetNewGrpcClientFunc(newFunc1)
+	client.(*Client).grpcClient.SetNewGrpcClientFunc(newFunc1)
 	cancel() // make context canceled
 	checkFunc(false)
 

--- a/internal/distributed/rootcoord/client/client.go
+++ b/internal/distributed/rootcoord/client/client.go
@@ -30,6 +30,7 @@ import (
 	"github.com/milvus-io/milvus/internal/proto/internalpb"
 	"github.com/milvus-io/milvus/internal/proto/proxypb"
 	"github.com/milvus-io/milvus/internal/proto/rootcoordpb"
+	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/grpcclient"
 	"github.com/milvus-io/milvus/internal/util/sessionutil"
 	"github.com/milvus-io/milvus/pkg/log"
@@ -52,7 +53,7 @@ type Client struct {
 // metaRoot is the path in etcd for root coordinator registration
 // etcdEndpoints are the address list for etcd end points
 // timeout is default setting for each grpc call
-func NewClient(ctx context.Context) (*Client, error) {
+func NewClient(ctx context.Context) (types.RootCoordClient, error) {
 	sess := sessionutil.NewSession(ctx)
 	if sess == nil {
 		err := fmt.Errorf("new session error, maybe can not connect to etcd")

--- a/internal/distributed/rootcoord/client/client_test.go
+++ b/internal/distributed/rootcoord/client/client_test.go
@@ -250,18 +250,18 @@ func Test_NewClient(t *testing.T) {
 		}
 	}
 
-	client.grpcClient = &mock.GRPCClientBase[rootcoordpb.RootCoordClient]{
+	client.(*Client).grpcClient = &mock.GRPCClientBase[rootcoordpb.RootCoordClient]{
 		GetGrpcClientErr: errors.New("dummy"),
 	}
 
 	newFunc1 := func(cc *grpc.ClientConn) rootcoordpb.RootCoordClient {
 		return &mock.GrpcRootCoordClient{Err: nil}
 	}
-	client.grpcClient.SetNewGrpcClientFunc(newFunc1)
+	client.(*Client).grpcClient.SetNewGrpcClientFunc(newFunc1)
 
 	checkFunc(false)
 
-	client.grpcClient = &mock.GRPCClientBase[rootcoordpb.RootCoordClient]{
+	client.(*Client).grpcClient = &mock.GRPCClientBase[rootcoordpb.RootCoordClient]{
 		GetGrpcClientErr: nil,
 	}
 
@@ -269,18 +269,18 @@ func Test_NewClient(t *testing.T) {
 		return &mock.GrpcRootCoordClient{Err: errors.New("dummy")}
 	}
 
-	client.grpcClient.SetNewGrpcClientFunc(newFunc2)
+	client.(*Client).grpcClient.SetNewGrpcClientFunc(newFunc2)
 
 	checkFunc(false)
 
-	client.grpcClient = &mock.GRPCClientBase[rootcoordpb.RootCoordClient]{
+	client.(*Client).grpcClient = &mock.GRPCClientBase[rootcoordpb.RootCoordClient]{
 		GetGrpcClientErr: nil,
 	}
 
 	newFunc3 := func(cc *grpc.ClientConn) rootcoordpb.RootCoordClient {
 		return &mock.GrpcRootCoordClient{Err: nil}
 	}
-	client.grpcClient.SetNewGrpcClientFunc(newFunc3)
+	client.(*Client).grpcClient.SetNewGrpcClientFunc(newFunc3)
 
 	checkFunc(true)
 

--- a/tests/integration/minicluster_v2.go
+++ b/tests/integration/minicluster_v2.go
@@ -45,6 +45,7 @@ import (
 	grpcrootcoord "github.com/milvus-io/milvus/internal/distributed/rootcoord"
 	grpcrootcoordclient "github.com/milvus-io/milvus/internal/distributed/rootcoord/client"
 	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/dependency"
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/util/etcd"
@@ -105,14 +106,14 @@ type MiniClusterV2 struct {
 	RootCoord  *grpcrootcoord.Server
 	QueryCoord *grpcquerycoord.Server
 
-	DataCoordClient  *grpcdatacoordclient.Client
-	RootCoordClient  *grpcrootcoordclient.Client
-	QueryCoordClient *grpcquerycoordclient.Client
+	DataCoordClient  types.DataCoordClient
+	RootCoordClient  types.RootCoordClient
+	QueryCoordClient types.QueryCoordClient
 
-	ProxyClient     *grpcproxyclient.Client
-	DataNodeClient  *grpcdatanodeclient.Client
-	QueryNodeClient *grpcquerynodeclient.Client
-	IndexNodeClient *grpcindexnodeclient.Client
+	ProxyClient     types.ProxyClient
+	DataNodeClient  types.DataNodeClient
+	QueryNodeClient types.QueryNodeClient
+	IndexNodeClient types.IndexNodeClient
 
 	DataNode  *grpcdatanode.Server
 	QueryNode *grpcquerynode.Server


### PR DESCRIPTION
issue: #30715

- Bug: Set nil struct pointer to describe nil interface.
   Panic with segment violation when calling method on this nil struct pointer.