### PR TITLE
fix: Disk resource is not requested for index loaded with disk

### DIFF
--- a/internal/querynodev2/segments/index_attr_cache.go
+++ b/internal/querynodev2/segments/index_attr_cache.go
@@ -1,0 +1,87 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package segments
+
+/*
+#cgo pkg-config: milvus_segcore
+
+#include "segcore/load_index_c.h"
+*/
+import "C"
+
+import (
+	"fmt"
+	"unsafe"
+
+	"github.com/milvus-io/milvus/internal/proto/querypb"
+	"github.com/milvus-io/milvus/pkg/common"
+	"github.com/milvus-io/milvus/pkg/util/conc"
+	"github.com/milvus-io/milvus/pkg/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/util/indexparamcheck"
+	"github.com/milvus-io/milvus/pkg/util/typeutil"
+)
+
+// IndexAttrCache index meta cache stores calculated attribute.
+type IndexAttrCache struct {
+	loadWithDisk *typeutil.ConcurrentMap[typeutil.Pair[string, int32], bool]
+	sf           conc.Singleflight[bool]
+}
+
+func NewIndexAttrCache() *IndexAttrCache {
+	return &IndexAttrCache{
+		loadWithDisk: typeutil.NewConcurrentMap[typeutil.Pair[string, int32], bool](),
+	}
+}
+
+func (c *IndexAttrCache) GetIndexResourceUsage(indexInfo *querypb.FieldIndexInfo) (memory uint64, disk uint64, err error) {
+	indexType, err := funcutil.GetAttrByKeyFromRepeatedKV(common.IndexTypeKey, indexInfo.IndexParams)
+	if err != nil {
+		return 0, 0, fmt.Errorf("index type not exist in index params")
+	}
+	if indexType == indexparamcheck.IndexDISKANN {
+		neededMemSize := indexInfo.IndexSize / UsedDiskMemoryRatio
+		neededDiskSize := indexInfo.IndexSize - neededMemSize
+		return uint64(neededMemSize), uint64(neededDiskSize), nil
+	}
+
+	engineVersion := indexInfo.GetCurrentIndexVersion()
+	isLoadWithDisk, has := c.loadWithDisk.Get(typeutil.NewPair[string, int32](indexType, engineVersion))
+	if !has {
+		isLoadWithDisk, _, _ = c.sf.Do(fmt.Sprintf("%s_%d", indexType, engineVersion), func() (bool, error) {
+			var result bool
+			GetDynamicPool().Submit(func() (any, error) {
+				cIndexType := C.CString(indexType)
+				defer C.free(unsafe.Pointer(cIndexType))
+				cEngineVersion := C.int32_t(indexInfo.GetCurrentIndexVersion())
+				isLoadWithDisk = bool(C.IsLoadWithDisk(cIndexType, cEngineVersion))
+				return nil, nil
+			}).Await()
+			c.loadWithDisk.Insert(typeutil.NewPair[string, int32](indexType, engineVersion), result)
+			return result, nil
+		})
+	}
+
+	factor := uint64(1)
+	diskUsage := uint64(0)
+	if !isLoadWithDisk {
+		factor = 2
+	} else {
+		diskUsage = uint64(indexInfo.IndexSize)
+	}
+
+	return uint64(indexInfo.IndexSize) * factor, diskUsage, nil
+}

--- a/internal/querynodev2/segments/index_attr_cache_test.go
+++ b/internal/querynodev2/segments/index_attr_cache_test.go
@@ -19,12 +19,13 @@ package segments
 import (
 	"testing"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus/internal/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/common"
 	"github.com/milvus-io/milvus/pkg/util/indexparamcheck"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
-	"github.com/stretchr/testify/suite"
 )
 
 type IndexAttrCacheSuite struct {

--- a/internal/querynodev2/segments/index_attr_cache_test.go
+++ b/internal/querynodev2/segments/index_attr_cache_test.go
@@ -1,0 +1,113 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package segments
+
+import (
+	"testing"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus/internal/proto/querypb"
+	"github.com/milvus-io/milvus/pkg/common"
+	"github.com/milvus-io/milvus/pkg/util/indexparamcheck"
+	"github.com/milvus-io/milvus/pkg/util/typeutil"
+	"github.com/stretchr/testify/suite"
+)
+
+type IndexAttrCacheSuite struct {
+	suite.Suite
+
+	c *IndexAttrCache
+}
+
+func (s *IndexAttrCacheSuite) SetupTest() {
+	s.c = NewIndexAttrCache()
+}
+
+func (s *IndexAttrCacheSuite) TestCacheMissing() {
+	info := &querypb.FieldIndexInfo{
+		IndexParams: []*commonpb.KeyValuePair{
+			{Key: common.IndexTypeKey, Value: "test"},
+		},
+		CurrentIndexVersion: 0,
+	}
+
+	_, _, err := s.c.GetIndexResourceUsage(info)
+	s.Require().NoError(err)
+
+	_, has := s.c.loadWithDisk.Get(typeutil.NewPair[string, int32]("test", 0))
+	s.True(has)
+}
+
+func (s *IndexAttrCacheSuite) TestDiskANN() {
+	info := &querypb.FieldIndexInfo{
+		IndexParams: []*commonpb.KeyValuePair{
+			{Key: common.IndexTypeKey, Value: indexparamcheck.IndexDISKANN},
+		},
+		CurrentIndexVersion: 0,
+		IndexSize:           100,
+	}
+
+	memory, disk, err := s.c.GetIndexResourceUsage(info)
+	s.Require().NoError(err)
+
+	_, has := s.c.loadWithDisk.Get(typeutil.NewPair[string, int32](indexparamcheck.IndexDISKANN, 0))
+	s.False(has, "DiskANN shall never be checked load with disk")
+
+	s.EqualValues(25, memory)
+	s.EqualValues(75, disk)
+}
+
+func (s *IndexAttrCacheSuite) TestLoadWithDisk() {
+	info := &querypb.FieldIndexInfo{
+		IndexParams: []*commonpb.KeyValuePair{
+			{Key: common.IndexTypeKey, Value: "test"},
+		},
+		CurrentIndexVersion: 0,
+		IndexSize:           100,
+	}
+
+	s.Run("load_with_disk", func() {
+		s.c.loadWithDisk.Insert(typeutil.NewPair[string, int32]("test", 0), true)
+		memory, disk, err := s.c.GetIndexResourceUsage(info)
+		s.Require().NoError(err)
+
+		s.EqualValues(100, memory)
+		s.EqualValues(100, disk)
+	})
+
+	s.Run("load_with_disk", func() {
+		s.c.loadWithDisk.Insert(typeutil.NewPair[string, int32]("test", 0), false)
+		memory, disk, err := s.c.GetIndexResourceUsage(info)
+		s.Require().NoError(err)
+
+		s.EqualValues(200, memory)
+		s.EqualValues(0, disk)
+	})
+
+	s.Run("corrupted_index_info", func() {
+		info := &querypb.FieldIndexInfo{
+			IndexParams: []*commonpb.KeyValuePair{},
+		}
+
+		_, _, err := s.c.GetIndexResourceUsage(info)
+		s.Error(err)
+	})
+}
+
+func TestIndexAttrCache(t *testing.T) {
+	suite.Run(t, new(IndexAttrCacheSuite))
+}

--- a/pkg/util/typeutil/pair.go
+++ b/pkg/util/typeutil/pair.go
@@ -1,0 +1,10 @@
+package typeutil
+
+type Pair[T, U any] struct {
+	A T
+	B U
+}
+
+func NewPair[T, U any](a T, b U) Pair[T, U] {
+	return Pair[T, U]{A: a, B: b}
+}


### PR DESCRIPTION
See also #30756

This PR:
- Request disk resource when index type, version loaded with disk
- Add attribute cache for index utility
- Add `typeutil.Pair`