### PR TITLE
fix: Set indexInfo when try to set segment to leader view

### DIFF
--- a/internal/querycoordv2/task/executor.go
+++ b/internal/querycoordv2/task/executor.go
@@ -433,7 +433,7 @@ func (ex *Executor) setDistribution(task *LeaderTask, step int) error {
 		return err
 	}
 
-	loadInfo, _, err := ex.getLoadInfo(ctx, task.CollectionID(), action.SegmentID(), channel)
+	loadInfo, indexInfo, err := ex.getLoadInfo(ctx, task.CollectionID(), action.SegmentID(), channel)
 	if err != nil {
 		return err
 	}
@@ -457,6 +457,7 @@ func (ex *Executor) setDistribution(task *LeaderTask, step int) error {
 				Info:        loadInfo,
 			},
 		},
+		IndexInfoList: indexInfo,
 	}
 
 	startTs := time.Now()


### PR DESCRIPTION
issue: #30150
see also: #30258

cause `SyncDataDistribution` will try to load delta for segment. if miss indexInfo in request, sync action will failed due to lack of index info.

This PR set indexinfo when try to set segment to leader view
