### PR TITLE
enhance: access log support get sdk type by user agent

### DIFF
--- a/internal/proxy/accesslog/info.go
+++ b/internal/proxy/accesslog/info.go
@@ -291,7 +291,7 @@ func getSdkVersionByUserAgent(ctx context.Context) string {
 		return unknownString
 	}
 
-	SdkType, ok := getSdkTypeByUserAgent(UserAgent[0])
+	SdkType, ok := getSdkTypeByUserAgent(UserAgent)
 	if !ok {
 		return unknownString
 	}

--- a/internal/proxy/accesslog/info.go
+++ b/internal/proxy/accesslog/info.go
@@ -32,6 +32,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/milvus-io/milvus/internal/proxy/connection"
+	"github.com/milvus-io/milvus/pkg/util"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/util/requestutil"
@@ -277,7 +278,25 @@ func getSdkVersion(i *GrpcAccessInfo) string {
 		return req.GetClientInfo().GetSdkType() + "-" + req.GetClientInfo().GetSdkVersion()
 	}
 
-	return unknownString
+	return getSdkVersionByUserAgent(i.ctx)
+}
+
+func getSdkVersionByUserAgent(ctx context.Context) string {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return unknownString
+	}
+	UserAgent, ok := md[util.HeaderUserAgent]
+	if !ok {
+		return unknownString
+	}
+
+	SdkType, ok := getSdkTypeByUserAgent(UserAgent[0])
+	if !ok {
+		return unknownString
+	}
+
+	return SdkType + "-" + unknownString
 }
 
 func getClusterPrefix(i *GrpcAccessInfo) string {

--- a/internal/proxy/accesslog/info_test.go
+++ b/internal/proxy/accesslog/info_test.go
@@ -122,6 +122,24 @@ func (s *GrpcAccessInfoSuite) TestSdkInfo() {
 	result := s.info.Get("$sdk_version")
 	s.Equal(unknownString, result[0])
 
+	md := metadata.MD{}
+	ctx = metadata.NewIncomingContext(ctx, md)
+	s.info.ctx = ctx
+	result = s.info.Get("$sdk_version")
+	s.Equal(unknownString, result[0])
+
+	md = metadata.MD{util.HeaderUserAgent: []string{"invalid"}}
+	ctx = metadata.NewIncomingContext(ctx, md)
+	s.info.ctx = ctx
+	result = s.info.Get("$sdk_version")
+	s.Equal(unknownString, result[0])
+
+	md = metadata.MD{util.HeaderUserAgent: []string{"grpc-go.test"}}
+	ctx = metadata.NewIncomingContext(ctx, md)
+	s.info.ctx = ctx
+	result = s.info.Get("$sdk_version")
+	s.Equal("Golang"+"-"+unknownString, result[0])
+
 	s.info.req = &milvuspb.ConnectRequest{
 		ClientInfo: clientInfo,
 	}
@@ -129,7 +147,7 @@ func (s *GrpcAccessInfoSuite) TestSdkInfo() {
 	s.Equal(clientInfo.SdkType+"-"+clientInfo.SdkVersion, result[0])
 
 	identifier := 11111
-	md := metadata.MD{util.IdentifierKey: []string{fmt.Sprint(identifier)}}
+	md = metadata.MD{util.IdentifierKey: []string{fmt.Sprint(identifier)}}
 	ctx = metadata.NewIncomingContext(ctx, md)
 	connection.GetManager().Register(ctx, int64(identifier), clientInfo)
 

--- a/internal/proxy/accesslog/util.go
+++ b/internal/proxy/accesslog/util.go
@@ -86,3 +86,18 @@ func getCurUserFromContext(ctx context.Context) (string, error) {
 	username := secrets[0]
 	return username, nil
 }
+
+func getSdkTypeByUserAgent(userAgent string) (string, bool) {
+	switch {
+	case strings.HasPrefix(userAgent, "grpc-node-js"):
+		return "nodejs", true
+	case strings.HasPrefix(userAgent, "grpc-python"):
+		return "Python", true
+	case strings.HasPrefix(userAgent, "grpc-go"):
+		return "Golang", true
+	case strings.HasPrefix(userAgent, "grpc-java"):
+		return "Java", true
+	default:
+		return "", false
+	}
+}

--- a/internal/proxy/accesslog/util.go
+++ b/internal/proxy/accesslog/util.go
@@ -87,7 +87,12 @@ func getCurUserFromContext(ctx context.Context) (string, error) {
 	return username, nil
 }
 
-func getSdkTypeByUserAgent(userAgent string) (string, bool) {
+func getSdkTypeByUserAgent(userAgents []string) (string, bool) {
+	if len(userAgents) == 0 {
+		return "", false
+	}
+
+	userAgent := userAgents[0]
 	switch {
 	case strings.HasPrefix(userAgent, "grpc-node-js"):
 		return "nodejs", true

--- a/internal/proxy/accesslog/util_test.go
+++ b/internal/proxy/accesslog/util_test.go
@@ -26,3 +26,27 @@ func TestJoin(t *testing.T) {
 	assert.Equal(t, "a/b", join("a", "b"))
 	assert.Equal(t, "a/b", join("a/", "b"))
 }
+
+func TestGetSdkTypeByUserAgent(t *testing.T) {
+	_, ok := getSdkTypeByUserAgent([]string{})
+	assert.False(t, ok)
+
+	sdk, ok := getSdkTypeByUserAgent([]string{"grpc-node-js.test"})
+	assert.True(t, ok)
+	assert.Equal(t, "nodejs", sdk)
+
+	sdk, ok = getSdkTypeByUserAgent([]string{"grpc-python.test"})
+	assert.True(t, ok)
+	assert.Equal(t, "Python", sdk)
+
+	sdk, ok = getSdkTypeByUserAgent([]string{"grpc-go.test"})
+	assert.True(t, ok)
+	assert.Equal(t, "Golang", sdk)
+
+	sdk, ok = getSdkTypeByUserAgent([]string{"grpc-java.test"})
+	assert.True(t, ok)
+	assert.Equal(t, "Java", sdk)
+
+	_, ok = getSdkTypeByUserAgent([]string{"invalid_type"})
+	assert.False(t, ok)
+}

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -60,7 +60,9 @@ const (
 	AnyWord       = "*"
 
 	IdentifierKey = "identifier"
-	HeaderDBName  = "dbName"
+
+	HeaderUserAgent = "user-agent"
+	HeaderDBName    = "dbName"
 
 	RoleConfigPrivileges = "privileges"
 	RoleConfigObjectType = "object_type"


### PR DESCRIPTION
Support get sdk type by user agent when we can't get sdk version by connection in access log.