### PR TITLE
fix: pattern match use incorrect raw data

### DIFF
--- a/internal/core/src/exec/expression/UnaryExpr.h
+++ b/internal/core/src/exec/expression/UnaryExpr.h
@@ -44,7 +44,8 @@ struct UnaryElementFuncForMatch {
             // translate the pattern match in advance, which avoid computing it every loop.
             std::regex reg(TranslatePatternMatchToRegex(val));
             for (int i = 0; i < size; ++i) {
-                res[i] = std::regex_match(std::string(src[i]), reg);
+                res[i] =
+                    std::regex_match(std::begin(src[i]), std::end(src[i]), reg);
             }
         } else if constexpr (std::is_same_v<T, std::string>) {
             // translate the pattern match in advance, which avoid computing it every loop.

--- a/internal/core/src/exec/expression/UnaryExpr.h
+++ b/internal/core/src/exec/expression/UnaryExpr.h
@@ -44,7 +44,7 @@ struct UnaryElementFuncForMatch {
             // translate the pattern match in advance, which avoid computing it every loop.
             std::regex reg(TranslatePatternMatchToRegex(val));
             for (int i = 0; i < size; ++i) {
-                res[i] = std::regex_match(src[i].data(), reg);
+                res[i] = std::regex_match(std::string(src[i]), reg);
             }
         } else if constexpr (std::is_same_v<T, std::string>) {
             // translate the pattern match in advance, which avoid computing it every loop.

--- a/internal/core/unittest/test_indexing.cpp
+++ b/internal/core/unittest/test_indexing.cpp
@@ -410,19 +410,19 @@ TEST(Indexing, Iterator) {
     create_index_info.metric_type = knowhere::metric::L2;
     create_index_info.index_type = knowhere::IndexEnum::INDEX_FAISS_IVFFLAT_CC;
     create_index_info.index_engine_version =
-            knowhere::Version::GetCurrentVersion().VersionNumber();
+        knowhere::Version::GetCurrentVersion().VersionNumber();
     auto index = milvus::index::IndexFactory::GetInstance().CreateIndex(
-            create_index_info, milvus::storage::FileManagerContext());
+        create_index_info, milvus::storage::FileManagerContext());
 
     auto build_conf = knowhere::Json{
-            {knowhere::meta::METRIC_TYPE, knowhere::metric::L2},
-            {knowhere::meta::DIM, std::to_string(dim)},
-            {knowhere::indexparam::NLIST, "128"},
+        {knowhere::meta::METRIC_TYPE, knowhere::metric::L2},
+        {knowhere::meta::DIM, std::to_string(dim)},
+        {knowhere::indexparam::NLIST, "128"},
     };
 
     auto search_conf = knowhere::Json{
-            {knowhere::meta::METRIC_TYPE, knowhere::metric::L2},
-            {knowhere::indexparam::NPROBE, 4},
+        {knowhere::meta::METRIC_TYPE, knowhere::metric::L2},
+        {knowhere::indexparam::NPROBE, 4},
     };
 
     std::vector<knowhere::DataSetPtr> datasets;
@@ -452,13 +452,14 @@ TEST(Indexing, Iterator) {
     searchInfo.search_params_ = search_conf;
     auto vec_index = dynamic_cast<index::VectorIndex*>(index.get());
 
-    knowhere::expected<std::vector<std::shared_ptr<knowhere::IndexNode::iterator>>>
-            kw_iterators = vec_index->VectorIterators(query_ds, searchInfo, view);
+    knowhere::expected<
+        std::vector<std::shared_ptr<knowhere::IndexNode::iterator>>>
+        kw_iterators = vec_index->VectorIterators(query_ds, searchInfo, view);
     ASSERT_TRUE(kw_iterators.has_value());
     ASSERT_EQ(kw_iterators.value().size(), 1);
     auto iterator = kw_iterators.value()[0];
     ASSERT_TRUE(iterator->HasNext());
-    while(iterator->HasNext()){
+    while (iterator->HasNext()) {
         auto [off, dis] = iterator->Next();
         ASSERT_TRUE(off >= 0);
         ASSERT_TRUE(dis >= 0);


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/30687
We store all the varchar datas in an continuous address and use string_view to quickly find them. In this case, using string_view.data() directly will point to all rest varchar datas.