### PR TITLE
fix: fix permissions on /milvus for OpenShift compatibility

### DIFF
--- a/build/docker/milvus/amazonlinux2023/Dockerfile
+++ b/build/docker/milvus/amazonlinux2023/Dockerfile
@@ -22,6 +22,9 @@ COPY ./configs/ /milvus/configs/
 
 COPY ./lib/ /milvus/lib/
 
+RUN chgrp -R root /milvus && \
+    chmod -R g+rwx /milvus
+
 ENV PATH=/milvus/bin:$PATH
 ENV LD_LIBRARY_PATH=/milvus/lib:$LD_LIBRARY_PATH:/usr/lib
 ENV LD_PRELOAD=/milvus/lib/libjemalloc.so

--- a/build/docker/milvus/gpu/ubuntu20.04/Dockerfile
+++ b/build/docker/milvus/gpu/ubuntu20.04/Dockerfile
@@ -18,6 +18,9 @@ COPY ./configs/ /milvus/configs/
 
 COPY ./lib/ /milvus/lib/
 
+RUN chgrp -R root /milvus && \
+    chmod -R g+rwx /milvus
+
 ENV PATH=/milvus/bin:$PATH
 ENV LD_LIBRARY_PATH=/milvus/lib:$LD_LIBRARY_PATH:/usr/lib
 ENV LD_PRELOAD=/milvus/lib/libjemalloc.so

--- a/build/docker/milvus/ubuntu20.04/Dockerfile
+++ b/build/docker/milvus/ubuntu20.04/Dockerfile
@@ -24,6 +24,9 @@ COPY ./configs/ /milvus/configs/
 
 COPY ./lib/ /milvus/lib/
 
+RUN chgrp -R root /milvus && \
+    chmod -R g+rwx /milvus
+
 ENV PATH=/milvus/bin:$PATH
 ENV LD_LIBRARY_PATH=/milvus/lib:$LD_LIBRARY_PATH:/usr/lib
 ENV LD_PRELOAD=/milvus/lib/libjemalloc.so


### PR DESCRIPTION
OpenShift runs Pods with a random uid and gid 0.
As Milvus needs to write into the /milvus directory, this fix modifies the group permissions to allow the root group (gid 0) to write into it.
This is a simple solution that allows to run Milvus on OpenShift without adding security constraints, use special ServiceAccounts or whatever. This should also not impact any other kubernetes platform as it's a simple group permission change, nothing regarding the userid.

Note: Other actions are necessary to properly deploy the full stack (Minio, Pulsar,...) on OpenShift. I will document them in the helm chart project.

Fixes #25565