### PR TITLE
enhance: Revert (#30197 #30690 #30415)

### DIFF
--- a/internal/core/src/storage/MemFileManagerImpl.cpp
+++ b/internal/core/src/storage/MemFileManagerImpl.cpp
@@ -98,8 +98,7 @@ MemFileManagerImpl::LoadIndexToMemory(
         for (size_t idx = 0; idx < batch_files.size(); ++idx) {
             auto file_name =
                 batch_files[idx].substr(batch_files[idx].find_last_of('/') + 1);
-            file_to_index_data[file_name] =
-                index_datas[idx].get()->GetFieldData();
+            file_to_index_data[file_name] = index_datas[idx];
         }
     };
 
@@ -138,7 +137,7 @@ MemFileManagerImpl::CacheRawDataToMemory(
     auto FetchRawData = [&]() {
         auto raw_datas = GetObjectData(rcm_.get(), batch_files);
         for (auto& data : raw_datas) {
-            field_datas.emplace_back(data.get()->GetFieldData());
+            field_datas.emplace_back(data);
         }
     };
 

--- a/internal/core/src/storage/ThreadPool.h
+++ b/internal/core/src/storage/ThreadPool.h
@@ -41,13 +41,10 @@ class ThreadPool {
         max_threads_size_ = CPU_NUM * thread_core_coefficient;
 
         // only IO pool will set large limit, but the CPU helps nothing to IO operations,
-        // we need to limit the max thread num, each thread will download 16~64 MiB data,
-        // according to our benchmark, 16 threads is enough to saturate the network bandwidth.
-        if (min_threads_size_ > 16) {
-            min_threads_size_ = 16;
-        }
-        if (max_threads_size_ > 16) {
-            max_threads_size_ = 16;
+        // we need to limit the max thread num, each thread will download 16 MiB data,
+        // it should be not greater than 256 (4GiB data) to avoid OOM and send too many requests to object storage
+        if (max_threads_size_ > 256) {
+            max_threads_size_ = 256;
         }
         LOG_SEGCORE_INFO_ << "Init thread pool:" << name_
                           << " with min worker num:" << min_threads_size_

--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -447,17 +447,62 @@ EncodeAndUploadFieldSlice(ChunkManager* chunk_manager,
     return std::make_pair(std::move(object_key), serialized_index_size);
 }
 
-std::vector<std::future<std::unique_ptr<DataCodec>>>
+// /**
+//  * Returns the current resident set size (physical memory use) measured
+//  * in bytes, or zero if the value cannot be determined on this OS.
+//  */
+// size_t
+// getCurrentRSS() {
+// #if defined(_WIN32)
+//     /* Windows -------------------------------------------------- */
+//     PROCESS_MEMORY_COUNTERS info;
+//     GetProcessMemoryInfo(GetCurrentProcess(), &info, sizeof(info));
+//     return (size_t)info.WorkingSetSize;
+
+// #elif defined(__APPLE__) && defined(__MACH__)
+//     /* OSX ------------------------------------------------------ */
+//     struct mach_task_basic_info info;
+//     mach_msg_type_number_t infoCount = MACH_TASK_BASIC_INFO_COUNT;
+//     if (task_info(mach_task_self(), MACH_TASK_BASIC_INFO, (task_info_t)&info, &infoCount) != KERN_SUCCESS)
+//         return (size_t)0L; /* Can't access? */
+//     return (size_t)info.resident_size;
+
+// #elif defined(__linux__) || defined(__linux) || defined(linux) || defined(__gnu_linux__)
+//     /* Linux ---------------------------------------------------- */
+//     long rss = 0L;
+//     FILE* fp = NULL;
+//     if ((fp = fopen("/proc/self/statm", "r")) == NULL)
+//         return (size_t)0L; /* Can't open? */
+//     if (fscanf(fp, "%*s%ld", &rss) != 1) {
+//         fclose(fp);
+//         return (size_t)0L; /* Can't read? */
+//     }
+//     fclose(fp);
+//     return (size_t)rss * (size_t)sysconf(_SC_PAGESIZE);
+
+// #else
+//     /* AIX, BSD, Solaris, and Unknown OS ------------------------ */
+//     return (size_t)0L; /* Unsupported. */
+// #endif
+// }
+
+std::vector<FieldDataPtr>
 GetObjectData(ChunkManager* remote_chunk_manager,
               const std::vector<std::string>& remote_files) {
     auto& pool = ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::HIGH);
     std::vector<std::future<std::unique_ptr<DataCodec>>> futures;
-    futures.reserve(remote_files.size());
     for (auto& file : remote_files) {
         futures.emplace_back(pool.Submit(
             DownloadAndDecodeRemoteFile, remote_chunk_manager, file));
     }
-    return futures;
+
+    std::vector<FieldDataPtr> datas;
+    for (int i = 0; i < futures.size(); ++i) {
+        auto res = futures[i].get();
+        datas.emplace_back(res->GetFieldData());
+    }
+    ReleaseArrowUnused();
+    return datas;
 }
 
 std::map<std::string, int64_t>

--- a/internal/core/src/storage/Util.h
+++ b/internal/core/src/storage/Util.h
@@ -19,7 +19,6 @@
 #include <memory>
 #include <string>
 #include <vector>
-#include <future>
 
 #include "storage/FieldData.h"
 #include "storage/PayloadStream.h"
@@ -103,7 +102,7 @@ EncodeAndUploadFieldSlice(ChunkManager* chunk_manager,
                           const FieldMeta& field_meta,
                           std::string object_key);
 
-std::vector<std::future<std::unique_ptr<DataCodec>>>
+std::vector<FieldDataPtr>
 GetObjectData(ChunkManager* remote_chunk_manager,
               const std::vector<std::string>& remote_files);
 

--- a/internal/querynodev2/segments/pool.go
+++ b/internal/querynodev2/segments/pool.go
@@ -71,13 +71,8 @@ func initDynamicPool() {
 
 func initLoadPool() {
 	loadOnce.Do(func() {
-		pt := paramtable.Get()
-		poolSize := hardware.GetCPUNum() * pt.CommonCfg.MiddlePriorityThreadCoreCoefficient.GetAsInt()
-		if poolSize > 16 {
-			poolSize = 16
-		}
 		pool := conc.NewPool[any](
-			poolSize,
+			hardware.GetCPUNum()*paramtable.Get().CommonCfg.MiddlePriorityThreadCoreCoefficient.GetAsInt(),
 			conc.WithPreAlloc(false),
 			conc.WithDisablePurge(false),
 			conc.WithPreHandler(runtime.LockOSThread), // lock os thread for cgo thread disposal


### PR DESCRIPTION
Revert "enhance: reduce many I/O operations while loading disk index (#30189) (#30690)" This reverts commit d4c4bf946b15bc537acd170dfd1d938bea237c7a.

Revert "enhance: limit the max pool size to 16 (#30371) (#30415)" This reverts commit 52ac0718f059d4aa45c5908ec8507e6045b24e1f.

Revert "enhance: convert the `GetObject` util to async (#30166) (#30197)" This reverts commit 4b7c5baab773366aa8084762e7321130c4f894b7.