### PR TITLE
fix: avoid using request ctx to init grpc

### DIFF
--- a/internal/allocator/id_allocator.go
+++ b/internal/allocator/id_allocator.go
@@ -90,6 +90,7 @@ func (ia *IDAllocator) syncID() (bool, error) {
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 	req := &rootcoordpb.AllocIDRequest{
 		Base: commonpbutil.NewMsgBase(
 			commonpbutil.WithMsgType(commonpb.MsgType_RequestID),
@@ -99,7 +100,6 @@ func (ia *IDAllocator) syncID() (bool, error) {
 	}
 	resp, err := ia.remoteAllocator.AllocID(ctx, req)
 
-	cancel()
 	if err != nil {
 		return false, fmt.Errorf("syncID Failed:%w", err)
 	}

--- a/internal/proxy/timestamp.go
+++ b/internal/proxy/timestamp.go
@@ -47,7 +47,7 @@ func newTimestampAllocator(tso timestampAllocatorInterface, peerID UniqueID) (*t
 
 func (ta *timestampAllocator) alloc(ctx context.Context, count uint32) ([]Timestamp, error) {
 	tr := timerecord.NewTimeRecorder("applyTimestamp")
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	req := &rootcoordpb.AllocTimestampRequest{
 		Base: commonpbutil.NewMsgBase(

--- a/internal/util/grpcclient/client.go
+++ b/internal/util/grpcclient/client.go
@@ -198,7 +198,7 @@ func (c *ClientBase[T]) GetGrpcClient(ctx context.Context) (*clientConnWrapper[T
 	c.grpcClientMtx.RLock()
 
 	if !generic.IsZero(c.grpcClient) {
-		defer c.grpcClientMtx.RUnlock()
+		c.grpcClientMtx.RUnlock()
 		return c.grpcClient, nil
 	}
 	c.grpcClientMtx.RUnlock()
@@ -251,7 +251,8 @@ func (c *ClientBase[T]) connect(ctx context.Context) error {
 	}
 
 	opts := tracer.GetInterceptorOpts()
-	dialContext, cancel := context.WithTimeout(ctx, c.DialTimeout)
+	// do not use request timeout when as parent when create connection
+	dialContext, cancel := context.WithTimeout(context.Background(), c.DialTimeout)
 
 	var conn *grpc.ClientConn
 	compress := None


### PR DESCRIPTION
fix #30833
should not use request context when init grpc