### PR TITLE
fix: [cherry-pick] [restful v1] bug list

### DIFF
--- a/internal/distributed/proxy/httpserver/constant.go
+++ b/internal/distributed/proxy/httpserver/constant.go
@@ -29,15 +29,16 @@ const (
 	HTTPReturnMessage    = "message"
 	HTTPReturnData       = "data"
 
-	HTTPReturnFieldName       = "name"
-	HTTPReturnFieldType       = "type"
-	HTTPReturnFieldPrimaryKey = "primaryKey"
-	HTTPReturnFieldAutoID     = "autoId"
-	HTTPReturnDescription     = "description"
+	HTTPReturnFieldName         = "name"
+	HTTPReturnFieldType         = "type"
+	HTTPReturnFieldPrimaryKey   = "primaryKey"
+	HTTPReturnFieldPartitionKey = "partitionKey"
+	HTTPReturnFieldAutoID       = "autoId"
+	HTTPReturnDescription       = "description"
 
-	HTTPReturnIndexName        = "indexName"
-	HTTPReturnIndexField       = "fieldName"
-	HTTPReturnIndexMetricsType = "metricType"
+	HTTPIndexName             = "indexName"
+	HTTPIndexField            = "fieldName"
+	HTTPReturnIndexMetricType = "metricType"
 
 	HTTPReturnDistance = "distance"
 

--- a/internal/distributed/proxy/httpserver/handler_v1.go
+++ b/internal/distributed/proxy/httpserver/handler_v1.go
@@ -320,8 +320,7 @@ func (h *HandlersV1) getCollectionDetails(c *gin.Context) {
 	}
 	vectorField := ""
 	for _, field := range coll.Schema.Fields {
-		if field.DataType == schemapb.DataType_BinaryVector || field.DataType == schemapb.DataType_FloatVector ||
-			field.DataType == schemapb.DataType_Float16Vector || field.DataType == schemapb.DataType_BFloat16Vector {
+		if IsVectorField(field) {
 			vectorField = field.Name
 			break
 		}

--- a/internal/distributed/proxy/httpserver/handler_v1.go
+++ b/internal/distributed/proxy/httpserver/handler_v1.go
@@ -320,7 +320,8 @@ func (h *HandlersV1) getCollectionDetails(c *gin.Context) {
 	}
 	vectorField := ""
 	for _, field := range coll.Schema.Fields {
-		if field.DataType == schemapb.DataType_BinaryVector || field.DataType == schemapb.DataType_FloatVector {
+		if field.DataType == schemapb.DataType_BinaryVector || field.DataType == schemapb.DataType_FloatVector ||
+			field.DataType == schemapb.DataType_Float16Vector || field.DataType == schemapb.DataType_BFloat16Vector {
 			vectorField = field.Name
 			break
 		}

--- a/internal/distributed/proxy/httpserver/handler_v1_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v1_test.go
@@ -53,7 +53,7 @@ var DefaultShowCollectionsResp = milvuspb.ShowCollectionsResponse{
 
 var DefaultDescCollectionResp = milvuspb.DescribeCollectionResponse{
 	CollectionName: DefaultCollectionName,
-	Schema:         generateCollectionSchema(schemapb.DataType_Int64, false),
+	Schema:         generateCollectionSchema(schemapb.DataType_Int64),
 	ShardsNum:      ShardNumDefault,
 	Status:         &StatusSuccess,
 }
@@ -267,7 +267,7 @@ func TestVectorCollectionsDescribe(t *testing.T) {
 		name:         "get load status fail",
 		mp:           mp2,
 		exceptCode:   http.StatusOK,
-		expectedBody: "{\"code\":200,\"data\":{\"collectionName\":\"" + DefaultCollectionName + "\",\"description\":\"\",\"enableDynamicField\":true,\"fields\":[{\"autoId\":false,\"description\":\"\",\"name\":\"book_id\",\"primaryKey\":true,\"type\":\"Int64\"},{\"autoId\":false,\"description\":\"\",\"name\":\"word_count\",\"primaryKey\":false,\"type\":\"Int64\"},{\"autoId\":false,\"description\":\"\",\"name\":\"book_intro\",\"primaryKey\":false,\"type\":\"FloatVector(2)\"}],\"indexes\":[{\"fieldName\":\"book_intro\",\"indexName\":\"" + DefaultIndexName + "\",\"metricType\":\"L2\"}],\"load\":\"\",\"shardsNum\":1}}",
+		expectedBody: "{\"code\":200,\"data\":{\"collectionName\":\"" + DefaultCollectionName + "\",\"description\":\"\",\"enableDynamicField\":true,\"fields\":[{\"autoId\":false,\"description\":\"\",\"name\":\"book_id\",\"partitionKey\":false,\"primaryKey\":true,\"type\":\"Int64\"},{\"autoId\":false,\"description\":\"\",\"name\":\"word_count\",\"partitionKey\":false,\"primaryKey\":false,\"type\":\"Int64\"},{\"autoId\":false,\"description\":\"\",\"name\":\"book_intro\",\"partitionKey\":false,\"primaryKey\":false,\"type\":\"FloatVector(2)\"}],\"indexes\":[{\"fieldName\":\"book_intro\",\"indexName\":\"" + DefaultIndexName + "\",\"metricType\":\"L2\"}],\"load\":\"\",\"shardsNum\":1}}",
 	})
 
 	mp3 := mocks.NewMockProxy(t)
@@ -278,7 +278,7 @@ func TestVectorCollectionsDescribe(t *testing.T) {
 		name:         "get indexes fail",
 		mp:           mp3,
 		exceptCode:   http.StatusOK,
-		expectedBody: "{\"code\":200,\"data\":{\"collectionName\":\"" + DefaultCollectionName + "\",\"description\":\"\",\"enableDynamicField\":true,\"fields\":[{\"autoId\":false,\"description\":\"\",\"name\":\"book_id\",\"primaryKey\":true,\"type\":\"Int64\"},{\"autoId\":false,\"description\":\"\",\"name\":\"word_count\",\"primaryKey\":false,\"type\":\"Int64\"},{\"autoId\":false,\"description\":\"\",\"name\":\"book_intro\",\"primaryKey\":false,\"type\":\"FloatVector(2)\"}],\"indexes\":[],\"load\":\"LoadStateLoaded\",\"shardsNum\":1}}",
+		expectedBody: "{\"code\":200,\"data\":{\"collectionName\":\"" + DefaultCollectionName + "\",\"description\":\"\",\"enableDynamicField\":true,\"fields\":[{\"autoId\":false,\"description\":\"\",\"name\":\"book_id\",\"partitionKey\":false,\"primaryKey\":true,\"type\":\"Int64\"},{\"autoId\":false,\"description\":\"\",\"name\":\"word_count\",\"partitionKey\":false,\"primaryKey\":false,\"type\":\"Int64\"},{\"autoId\":false,\"description\":\"\",\"name\":\"book_intro\",\"partitionKey\":false,\"primaryKey\":false,\"type\":\"FloatVector(2)\"}],\"indexes\":[],\"load\":\"LoadStateLoaded\",\"shardsNum\":1}}",
 	})
 
 	mp4 := mocks.NewMockProxy(t)
@@ -289,7 +289,7 @@ func TestVectorCollectionsDescribe(t *testing.T) {
 		name:         "show collection details success",
 		mp:           mp4,
 		exceptCode:   http.StatusOK,
-		expectedBody: "{\"code\":200,\"data\":{\"collectionName\":\"" + DefaultCollectionName + "\",\"description\":\"\",\"enableDynamicField\":true,\"fields\":[{\"autoId\":false,\"description\":\"\",\"name\":\"book_id\",\"primaryKey\":true,\"type\":\"Int64\"},{\"autoId\":false,\"description\":\"\",\"name\":\"word_count\",\"primaryKey\":false,\"type\":\"Int64\"},{\"autoId\":false,\"description\":\"\",\"name\":\"book_intro\",\"primaryKey\":false,\"type\":\"FloatVector(2)\"}],\"indexes\":[{\"fieldName\":\"book_intro\",\"indexName\":\"" + DefaultIndexName + "\",\"metricType\":\"L2\"}],\"load\":\"LoadStateLoaded\",\"shardsNum\":1}}",
+		expectedBody: "{\"code\":200,\"data\":{\"collectionName\":\"" + DefaultCollectionName + "\",\"description\":\"\",\"enableDynamicField\":true,\"fields\":[{\"autoId\":false,\"description\":\"\",\"name\":\"book_id\",\"partitionKey\":false,\"primaryKey\":true,\"type\":\"Int64\"},{\"autoId\":false,\"description\":\"\",\"name\":\"word_count\",\"partitionKey\":false,\"primaryKey\":false,\"type\":\"Int64\"},{\"autoId\":false,\"description\":\"\",\"name\":\"book_intro\",\"partitionKey\":false,\"primaryKey\":false,\"type\":\"FloatVector(2)\"}],\"indexes\":[{\"fieldName\":\"book_intro\",\"indexName\":\"" + DefaultIndexName + "\",\"metricType\":\"L2\"}],\"load\":\"LoadStateLoaded\",\"shardsNum\":1}}",
 	})
 
 	for _, tt := range testCases {
@@ -757,10 +757,9 @@ func TestInsertForDataType(t *testing.T) {
 	paramtable.Init()
 	paramtable.Get().Save(proxy.Params.HTTPCfg.AcceptTypeAllowInt64.Key, "true")
 	schemas := map[string]*schemapb.CollectionSchema{
-		"[success]kinds of data type": newCollectionSchema(generateCollectionSchema(schemapb.DataType_Int64, false)),
-		"[success]use binary vector":  newCollectionSchema(generateCollectionSchema(schemapb.DataType_Int64, true)),
-		"[success]with dynamic field": withDynamicField(newCollectionSchema(generateCollectionSchema(schemapb.DataType_Int64, false))),
-		"[success]with array fields":  withArrayField(newCollectionSchema(generateCollectionSchema(schemapb.DataType_Int64, false))),
+		"[success]kinds of data type": newCollectionSchema(generateCollectionSchema(schemapb.DataType_Int64)),
+		"[success]with dynamic field": withDynamicField(newCollectionSchema(generateCollectionSchema(schemapb.DataType_Int64))),
+		"[success]with array fields":  withArrayField(newCollectionSchema(generateCollectionSchema(schemapb.DataType_Int64))),
 	}
 	for name, schema := range schemas {
 		t.Run(name, func(t *testing.T) {
@@ -831,7 +830,7 @@ func TestReturnInt64(t *testing.T) {
 	}
 	for _, dataType := range schemas {
 		t.Run("[insert]httpCfg.allow: false", func(t *testing.T) {
-			schema := newCollectionSchema(generateCollectionSchema(dataType, false))
+			schema := newCollectionSchema(generateCollectionSchema(dataType))
 			mp := mocks.NewMockProxy(t)
 			mp.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(&milvuspb.DescribeCollectionResponse{
 				CollectionName: DefaultCollectionName,
@@ -862,7 +861,7 @@ func TestReturnInt64(t *testing.T) {
 
 	for _, dataType := range schemas {
 		t.Run("[upsert]httpCfg.allow: false", func(t *testing.T) {
-			schema := newCollectionSchema(generateCollectionSchema(dataType, false))
+			schema := newCollectionSchema(generateCollectionSchema(dataType))
 			mp := mocks.NewMockProxy(t)
 			mp.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(&milvuspb.DescribeCollectionResponse{
 				CollectionName: DefaultCollectionName,
@@ -893,7 +892,7 @@ func TestReturnInt64(t *testing.T) {
 
 	for _, dataType := range schemas {
 		t.Run("[insert]httpCfg.allow: false, Accept-Type-Allow-Int64: true", func(t *testing.T) {
-			schema := newCollectionSchema(generateCollectionSchema(dataType, false))
+			schema := newCollectionSchema(generateCollectionSchema(dataType))
 			mp := mocks.NewMockProxy(t)
 			mp.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(&milvuspb.DescribeCollectionResponse{
 				CollectionName: DefaultCollectionName,
@@ -925,7 +924,7 @@ func TestReturnInt64(t *testing.T) {
 
 	for _, dataType := range schemas {
 		t.Run("[upsert]httpCfg.allow: false, Accept-Type-Allow-Int64: true", func(t *testing.T) {
-			schema := newCollectionSchema(generateCollectionSchema(dataType, false))
+			schema := newCollectionSchema(generateCollectionSchema(dataType))
 			mp := mocks.NewMockProxy(t)
 			mp.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(&milvuspb.DescribeCollectionResponse{
 				CollectionName: DefaultCollectionName,
@@ -958,7 +957,7 @@ func TestReturnInt64(t *testing.T) {
 	paramtable.Get().Save(proxy.Params.HTTPCfg.AcceptTypeAllowInt64.Key, "true")
 	for _, dataType := range schemas {
 		t.Run("[insert]httpCfg.allow: true", func(t *testing.T) {
-			schema := newCollectionSchema(generateCollectionSchema(dataType, false))
+			schema := newCollectionSchema(generateCollectionSchema(dataType))
 			mp := mocks.NewMockProxy(t)
 			mp.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(&milvuspb.DescribeCollectionResponse{
 				CollectionName: DefaultCollectionName,
@@ -989,7 +988,7 @@ func TestReturnInt64(t *testing.T) {
 
 	for _, dataType := range schemas {
 		t.Run("[upsert]httpCfg.allow: true", func(t *testing.T) {
-			schema := newCollectionSchema(generateCollectionSchema(dataType, false))
+			schema := newCollectionSchema(generateCollectionSchema(dataType))
 			mp := mocks.NewMockProxy(t)
 			mp.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(&milvuspb.DescribeCollectionResponse{
 				CollectionName: DefaultCollectionName,
@@ -1020,7 +1019,7 @@ func TestReturnInt64(t *testing.T) {
 
 	for _, dataType := range schemas {
 		t.Run("[insert]httpCfg.allow: true, Accept-Type-Allow-Int64: false", func(t *testing.T) {
-			schema := newCollectionSchema(generateCollectionSchema(dataType, false))
+			schema := newCollectionSchema(generateCollectionSchema(dataType))
 			mp := mocks.NewMockProxy(t)
 			mp.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(&milvuspb.DescribeCollectionResponse{
 				CollectionName: DefaultCollectionName,
@@ -1052,7 +1051,7 @@ func TestReturnInt64(t *testing.T) {
 
 	for _, dataType := range schemas {
 		t.Run("[upsert]httpCfg.allow: true, Accept-Type-Allow-Int64: false", func(t *testing.T) {
-			schema := newCollectionSchema(generateCollectionSchema(dataType, false))
+			schema := newCollectionSchema(generateCollectionSchema(dataType))
 			mp := mocks.NewMockProxy(t)
 			mp.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(&milvuspb.DescribeCollectionResponse{
 				CollectionName: DefaultCollectionName,

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -204,6 +204,9 @@ func checkAndSetData(body string, collSchema *schemapb.CollectionSchema) (error,
 
 				switch fieldType {
 				case schemapb.DataType_FloatVector:
+					if dataString == "" {
+						return merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)], "", "missing vector field: "+fieldName), reallyDataArray
+					}
 					var vectorArray []float32
 					err := json.Unmarshal([]byte(dataString), &vectorArray)
 					if err != nil {
@@ -211,6 +214,9 @@ func checkAndSetData(body string, collSchema *schemapb.CollectionSchema) (error,
 					}
 					reallyData[fieldName] = vectorArray
 				case schemapb.DataType_BinaryVector:
+					if dataString == "" {
+						return merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)], "", "missing vector field: "+fieldName), reallyDataArray
+					}
 					vectorStr := gjson.Get(data.Raw, fieldName).Raw
 					var vectorArray []byte
 					err := json.Unmarshal([]byte(vectorStr), &vectorArray)
@@ -219,6 +225,9 @@ func checkAndSetData(body string, collSchema *schemapb.CollectionSchema) (error,
 					}
 					reallyData[fieldName] = vectorArray
 				case schemapb.DataType_Float16Vector:
+					if dataString == "" {
+						return merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)], "", "missing vector field: "+fieldName), reallyDataArray
+					}
 					vectorStr := gjson.Get(data.Raw, fieldName).Raw
 					var vectorArray []byte
 					err := json.Unmarshal([]byte(vectorStr), &vectorArray)
@@ -227,6 +236,9 @@ func checkAndSetData(body string, collSchema *schemapb.CollectionSchema) (error,
 					}
 					reallyData[fieldName] = vectorArray
 				case schemapb.DataType_BFloat16Vector:
+					if dataString == "" {
+						return merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)], "", "missing vector field: "+fieldName), reallyDataArray
+					}
 					vectorStr := gjson.Get(data.Raw, fieldName).Raw
 					var vectorArray []byte
 					err := json.Unmarshal([]byte(vectorStr), &vectorArray)

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/cockroachdb/errors"
 	"github.com/gin-gonic/gin"
 	"github.com/golang/protobuf/proto"
 	"github.com/spf13/cast"
@@ -113,7 +112,7 @@ func convertRange(field *schemapb.FieldSchema, result gjson.Result) (string, err
 func checkGetPrimaryKey(coll *schemapb.CollectionSchema, idResult gjson.Result) (string, error) {
 	primaryField, ok := getPrimaryField(coll)
 	if !ok {
-		return "", errors.New("fail to find primary key from collection description")
+		return "", fmt.Errorf("collection: %s has no primary field", coll.Name)
 	}
 	resultStr, err := convertRange(primaryField, idResult)
 	if err != nil {
@@ -128,12 +127,14 @@ func printFields(fields []*schemapb.FieldSchema) []gin.H {
 	var res []gin.H
 	for _, field := range fields {
 		fieldDetail := gin.H{
-			HTTPReturnFieldName:       field.Name,
-			HTTPReturnFieldPrimaryKey: field.IsPrimaryKey,
-			HTTPReturnFieldAutoID:     field.AutoID,
-			HTTPReturnDescription:     field.Description,
+			HTTPReturnFieldName:         field.Name,
+			HTTPReturnFieldPrimaryKey:   field.IsPrimaryKey,
+			HTTPReturnFieldPartitionKey: field.IsPartitionKey,
+			HTTPReturnFieldAutoID:       field.AutoID,
+			HTTPReturnDescription:       field.Description,
 		}
-		if field.DataType == schemapb.DataType_BinaryVector || field.DataType == schemapb.DataType_FloatVector {
+		if field.DataType == schemapb.DataType_BinaryVector || field.DataType == schemapb.DataType_FloatVector ||
+			field.DataType == schemapb.DataType_Float16Vector || field.DataType == schemapb.DataType_BFloat16Vector {
 			dim, _ := getDim(field)
 			fieldDetail[HTTPReturnFieldType] = field.DataType.String() + "(" + strconv.FormatInt(dim, 10) + ")"
 		} else if field.DataType == schemapb.DataType_VarChar {
@@ -162,9 +163,9 @@ func printIndexes(indexes []*milvuspb.IndexDescription) []gin.H {
 	var res []gin.H
 	for _, index := range indexes {
 		res = append(res, gin.H{
-			HTTPReturnIndexName:        index.IndexName,
-			HTTPReturnIndexField:       index.FieldName,
-			HTTPReturnIndexMetricsType: getMetricType(index.Params),
+			HTTPIndexName:             index.IndexName,
+			HTTPIndexField:            index.FieldName,
+			HTTPReturnIndexMetricType: getMetricType(index.Params),
 		})
 	}
 	return res
@@ -187,8 +188,6 @@ func checkAndSetData(body string, collSchema *schemapb.CollectionSchema) (error,
 
 	for _, data := range dataResultArray {
 		reallyData := map[string]interface{}{}
-		var vectorArray []float32
-		var binaryArray []byte
 		if data.Type == gjson.JSON {
 			for _, field := range collSchema.Fields {
 				fieldType := field.DataType
@@ -205,15 +204,36 @@ func checkAndSetData(body string, collSchema *schemapb.CollectionSchema) (error,
 
 				switch fieldType {
 				case schemapb.DataType_FloatVector:
-					for _, vector := range gjson.Get(data.Raw, fieldName).Array() {
-						vectorArray = append(vectorArray, cast.ToFloat32(vector.Num))
+					var vectorArray []float32
+					err := json.Unmarshal([]byte(dataString), &vectorArray)
+					if err != nil {
+						return merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)], dataString, err.Error()), reallyDataArray
 					}
 					reallyData[fieldName] = vectorArray
 				case schemapb.DataType_BinaryVector:
-					for _, vector := range gjson.Get(data.Raw, fieldName).Array() {
-						binaryArray = append(binaryArray, cast.ToUint8(vector.Num))
+					vectorStr := gjson.Get(data.Raw, fieldName).Raw
+					var vectorArray []byte
+					err := json.Unmarshal([]byte(vectorStr), &vectorArray)
+					if err != nil {
+						return merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)], dataString, err.Error()), reallyDataArray
 					}
-					reallyData[fieldName] = binaryArray
+					reallyData[fieldName] = vectorArray
+				case schemapb.DataType_Float16Vector:
+					vectorStr := gjson.Get(data.Raw, fieldName).Raw
+					var vectorArray []byte
+					err := json.Unmarshal([]byte(vectorStr), &vectorArray)
+					if err != nil {
+						return merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)], dataString, err.Error()), reallyDataArray
+					}
+					reallyData[fieldName] = vectorArray
+				case schemapb.DataType_BFloat16Vector:
+					vectorStr := gjson.Get(data.Raw, fieldName).Raw
+					var vectorArray []byte
+					err := json.Unmarshal([]byte(vectorStr), &vectorArray)
+					if err != nil {
+						return merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)], dataString, err.Error()), reallyDataArray
+					}
+					reallyData[fieldName] = vectorArray
 				case schemapb.DataType_Bool:
 					result, err := cast.ToBoolE(dataString)
 					if err != nil {
@@ -239,7 +259,7 @@ func checkAndSetData(body string, collSchema *schemapb.CollectionSchema) (error,
 					}
 					reallyData[fieldName] = result
 				case schemapb.DataType_Int64:
-					result, err := cast.ToInt64E(dataString)
+					result, err := json.Number(dataString).Int64()
 					if err != nil {
 						return merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)], dataString, err.Error()), reallyDataArray
 					}
@@ -250,7 +270,8 @@ func checkAndSetData(body string, collSchema *schemapb.CollectionSchema) (error,
 						arr := make([]bool, 0)
 						err := json.Unmarshal([]byte(dataString), &arr)
 						if err != nil {
-							return merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)], dataString, err.Error()), reallyDataArray
+							return merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)]+
+								" of "+schemapb.DataType_name[int32(field.ElementType)], dataString, err.Error()), reallyDataArray
 						}
 						reallyData[fieldName] = &schemapb.ScalarField{
 							Data: &schemapb.ScalarField_BoolData{
@@ -263,7 +284,8 @@ func checkAndSetData(body string, collSchema *schemapb.CollectionSchema) (error,
 						arr := make([]int32, 0)
 						err := json.Unmarshal([]byte(dataString), &arr)
 						if err != nil {
-							return merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)], dataString, err.Error()), reallyDataArray
+							return merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)]+
+								" of "+schemapb.DataType_name[int32(field.ElementType)], dataString, err.Error()), reallyDataArray
 						}
 						reallyData[fieldName] = &schemapb.ScalarField{
 							Data: &schemapb.ScalarField_IntData{
@@ -276,7 +298,8 @@ func checkAndSetData(body string, collSchema *schemapb.CollectionSchema) (error,
 						arr := make([]int32, 0)
 						err := json.Unmarshal([]byte(dataString), &arr)
 						if err != nil {
-							return merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)], dataString, err.Error()), reallyDataArray
+							return merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)]+
+								" of "+schemapb.DataType_name[int32(field.ElementType)], dataString, err.Error()), reallyDataArray
 						}
 						reallyData[fieldName] = &schemapb.ScalarField{
 							Data: &schemapb.ScalarField_IntData{
@@ -289,7 +312,8 @@ func checkAndSetData(body string, collSchema *schemapb.CollectionSchema) (error,
 						arr := make([]int32, 0)
 						err := json.Unmarshal([]byte(dataString), &arr)
 						if err != nil {
-							return merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)], dataString, err.Error()), reallyDataArray
+							return merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)]+
+								" of "+schemapb.DataType_name[int32(field.ElementType)], dataString, err.Error()), reallyDataArray
 						}
 						reallyData[fieldName] = &schemapb.ScalarField{
 							Data: &schemapb.ScalarField_IntData{
@@ -300,9 +324,18 @@ func checkAndSetData(body string, collSchema *schemapb.CollectionSchema) (error,
 						}
 					case schemapb.DataType_Int64:
 						arr := make([]int64, 0)
-						err := json.Unmarshal([]byte(dataString), &arr)
+						numArr := make([]json.Number, 0)
+						err := json.Unmarshal([]byte(dataString), &numArr)
 						if err != nil {
-							return merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)], dataString, err.Error()), reallyDataArray
+							return merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)]+
+								" of "+schemapb.DataType_name[int32(field.ElementType)], dataString, err.Error()), reallyDataArray
+						}
+						for _, num := range numArr {
+							intVal, err := num.Int64()
+							if err != nil {
+								return merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)], dataString, err.Error()), reallyDataArray
+							}
+							arr = append(arr, intVal)
 						}
 						reallyData[fieldName] = &schemapb.ScalarField{
 							Data: &schemapb.ScalarField_LongData{
@@ -315,7 +348,8 @@ func checkAndSetData(body string, collSchema *schemapb.CollectionSchema) (error,
 						arr := make([]float32, 0)
 						err := json.Unmarshal([]byte(dataString), &arr)
 						if err != nil {
-							return merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)], dataString, err.Error()), reallyDataArray
+							return merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)]+
+								" of "+schemapb.DataType_name[int32(field.ElementType)], dataString, err.Error()), reallyDataArray
 						}
 						reallyData[fieldName] = &schemapb.ScalarField{
 							Data: &schemapb.ScalarField_FloatData{
@@ -328,7 +362,8 @@ func checkAndSetData(body string, collSchema *schemapb.CollectionSchema) (error,
 						arr := make([]float64, 0)
 						err := json.Unmarshal([]byte(dataString), &arr)
 						if err != nil {
-							return merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)], dataString, err.Error()), reallyDataArray
+							return merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)]+
+								" of "+schemapb.DataType_name[int32(field.ElementType)], dataString, err.Error()), reallyDataArray
 						}
 						reallyData[fieldName] = &schemapb.ScalarField{
 							Data: &schemapb.ScalarField_DoubleData{
@@ -341,7 +376,8 @@ func checkAndSetData(body string, collSchema *schemapb.CollectionSchema) (error,
 						arr := make([]string, 0)
 						err := json.Unmarshal([]byte(dataString), &arr)
 						if err != nil {
-							return merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)], dataString, err.Error()), reallyDataArray
+							return merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)]+
+								" of "+schemapb.DataType_name[int32(field.ElementType)], dataString, err.Error()), reallyDataArray
 						}
 						reallyData[fieldName] = &schemapb.ScalarField{
 							Data: &schemapb.ScalarField_StringData{
@@ -434,7 +470,8 @@ func convertFloatVectorToArray(vector [][]float32, dim int64) ([]float32, error)
 	floatArray := make([]float32, 0)
 	for _, arr := range vector {
 		if int64(len(arr)) != dim {
-			return nil, errors.New("vector length diff from dimension")
+			return nil, fmt.Errorf("[]float32 size %d doesn't equal to vector dimension %d of %s",
+				len(arr), dim, schemapb.DataType_name[int32(schemapb.DataType_FloatVector)])
 		}
 		for i := int64(0); i < dim; i++ {
 			floatArray = append(floatArray, arr[i])
@@ -443,12 +480,21 @@ func convertFloatVectorToArray(vector [][]float32, dim int64) ([]float32, error)
 	return floatArray, nil
 }
 
-func convertBinaryVectorToArray(vector [][]byte, dim int64) ([]byte, error) {
+func convertBinaryVectorToArray(vector [][]byte, dim int64, dataType schemapb.DataType) ([]byte, error) {
 	binaryArray := make([]byte, 0)
-	bytesLen := dim / 8
+	var bytesLen int64
+	switch dataType {
+	case schemapb.DataType_BinaryVector:
+		bytesLen = dim / 8
+	case schemapb.DataType_Float16Vector:
+		bytesLen = dim * 2
+	case schemapb.DataType_BFloat16Vector:
+		bytesLen = dim * 2
+	}
 	for _, arr := range vector {
 		if int64(len(arr)) != bytesLen {
-			return nil, errors.New("vector length diff from dimension")
+			return nil, fmt.Errorf("[]byte size %d doesn't equal to vector dimension %d of %s",
+				len(arr), dim, schemapb.DataType_name[int32(dataType)])
 		}
 		for i := int64(0); i < bytesLen; i++ {
 			binaryArray = append(binaryArray, arr[i])
@@ -503,13 +549,13 @@ func convertToIntArray(dataType schemapb.DataType, arr interface{}) []int32 {
 func anyToColumns(rows []map[string]interface{}, sch *schemapb.CollectionSchema) ([]*schemapb.FieldData, error) {
 	rowsLen := len(rows)
 	if rowsLen == 0 {
-		return []*schemapb.FieldData{}, errors.New("0 length column")
+		return []*schemapb.FieldData{}, fmt.Errorf("no row need to be convert to columns")
 	}
 
 	isDynamic := sch.EnableDynamicField
-	var dim int64
 
 	nameColumns := make(map[string]interface{})
+	nameDims := make(map[string]int64)
 	fieldData := make(map[string]*schemapb.FieldData)
 	for _, field := range sch.Fields {
 		// skip auto id pk field
@@ -542,10 +588,20 @@ func anyToColumns(rows []map[string]interface{}, sch *schemapb.CollectionSchema)
 			data = make([][]byte, 0, rowsLen)
 		case schemapb.DataType_FloatVector:
 			data = make([][]float32, 0, rowsLen)
-			dim, _ = getDim(field)
+			dim, _ := getDim(field)
+			nameDims[field.Name] = dim
 		case schemapb.DataType_BinaryVector:
 			data = make([][]byte, 0, rowsLen)
-			dim, _ = getDim(field)
+			dim, _ := getDim(field)
+			nameDims[field.Name] = dim
+		case schemapb.DataType_Float16Vector:
+			data = make([][]byte, 0, rowsLen)
+			dim, _ := getDim(field)
+			nameDims[field.Name] = dim
+		case schemapb.DataType_BFloat16Vector:
+			data = make([][]byte, 0, rowsLen)
+			dim, _ := getDim(field)
+			nameDims[field.Name] = dim
 		default:
 			return nil, fmt.Errorf("the type(%v) of field(%v) is not supported, use other sdk please", field.DataType, field.Name)
 		}
@@ -557,8 +613,8 @@ func anyToColumns(rows []map[string]interface{}, sch *schemapb.CollectionSchema)
 			IsDynamic: field.IsDynamic,
 		}
 	}
-	if dim == 0 {
-		return nil, errors.New("cannot find dimension")
+	if len(nameDims) == 0 {
+		return nil, fmt.Errorf("collection: %s has no vector field", sch.Name)
 	}
 
 	dynamicCol := make([][]byte, 0, rowsLen)
@@ -607,6 +663,10 @@ func anyToColumns(rows []map[string]interface{}, sch *schemapb.CollectionSchema)
 			case schemapb.DataType_FloatVector:
 				nameColumns[field.Name] = append(nameColumns[field.Name].([][]float32), candi.v.Interface().([]float32))
 			case schemapb.DataType_BinaryVector:
+				nameColumns[field.Name] = append(nameColumns[field.Name].([][]byte), candi.v.Interface().([]byte))
+			case schemapb.DataType_Float16Vector:
+				nameColumns[field.Name] = append(nameColumns[field.Name].([][]byte), candi.v.Interface().([]byte))
+			case schemapb.DataType_BFloat16Vector:
 				nameColumns[field.Name] = append(nameColumns[field.Name].([][]byte), candi.v.Interface().([]byte))
 			default:
 				return nil, fmt.Errorf("the type(%v) of field(%v) is not supported, use other sdk please", field.DataType, field.Name)
@@ -742,6 +802,7 @@ func anyToColumns(rows []map[string]interface{}, sch *schemapb.CollectionSchema)
 				},
 			}
 		case schemapb.DataType_FloatVector:
+			dim := nameDims[name]
 			arr, err := convertFloatVectorToArray(column.([][]float32), dim)
 			if err != nil {
 				return nil, err
@@ -757,7 +818,8 @@ func anyToColumns(rows []map[string]interface{}, sch *schemapb.CollectionSchema)
 				},
 			}
 		case schemapb.DataType_BinaryVector:
-			arr, err := convertBinaryVectorToArray(column.([][]byte), dim)
+			dim := nameDims[name]
+			arr, err := convertBinaryVectorToArray(column.([][]byte), dim, colData.Type)
 			if err != nil {
 				return nil, err
 			}
@@ -766,6 +828,34 @@ func anyToColumns(rows []map[string]interface{}, sch *schemapb.CollectionSchema)
 					Dim: dim,
 					Data: &schemapb.VectorField_BinaryVector{
 						BinaryVector: arr,
+					},
+				},
+			}
+		case schemapb.DataType_Float16Vector:
+			dim := nameDims[name]
+			arr, err := convertBinaryVectorToArray(column.([][]byte), dim, colData.Type)
+			if err != nil {
+				return nil, err
+			}
+			colData.Field = &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Dim: dim,
+					Data: &schemapb.VectorField_Float16Vector{
+						Float16Vector: arr,
+					},
+				},
+			}
+		case schemapb.DataType_BFloat16Vector:
+			dim := nameDims[name]
+			arr, err := convertBinaryVectorToArray(column.([][]byte), dim, colData.Type)
+			if err != nil {
+				return nil, err
+			}
+			colData.Field = &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Dim: dim,
+					Data: &schemapb.VectorField_Bfloat16Vector{
+						Bfloat16Vector: arr,
 					},
 				},
 			}
@@ -876,6 +966,10 @@ func buildQueryResp(rowsNum int64, needFields []string, fieldDataList []*schemap
 				rowsNum = int64(len(fieldDataList[0].GetVectors().GetBinaryVector())*8) / fieldDataList[0].GetVectors().GetDim()
 			case schemapb.DataType_FloatVector:
 				rowsNum = int64(len(fieldDataList[0].GetVectors().GetFloatVector().Data)) / fieldDataList[0].GetVectors().GetDim()
+			case schemapb.DataType_Float16Vector:
+				rowsNum = int64(len(fieldDataList[0].GetVectors().GetFloat16Vector())/2) / fieldDataList[0].GetVectors().GetDim()
+			case schemapb.DataType_BFloat16Vector:
+				rowsNum = int64(len(fieldDataList[0].GetVectors().GetBfloat16Vector())/2) / fieldDataList[0].GetVectors().GetDim()
 			default:
 				return nil, fmt.Errorf("the type(%v) of field(%v) is not supported, use other sdk please", fieldDataList[0].Type, fieldDataList[0].FieldName)
 			}
@@ -927,6 +1021,10 @@ func buildQueryResp(rowsNum int64, needFields []string, fieldDataList []*schemap
 					row[fieldDataList[j].FieldName] = fieldDataList[j].GetVectors().GetBinaryVector()[i*(fieldDataList[j].GetVectors().GetDim()/8) : (i+1)*(fieldDataList[j].GetVectors().GetDim()/8)]
 				case schemapb.DataType_FloatVector:
 					row[fieldDataList[j].FieldName] = fieldDataList[j].GetVectors().GetFloatVector().Data[i*fieldDataList[j].GetVectors().GetDim() : (i+1)*fieldDataList[j].GetVectors().GetDim()]
+				case schemapb.DataType_Float16Vector:
+					row[fieldDataList[j].FieldName] = fieldDataList[j].GetVectors().GetBinaryVector()[i*(fieldDataList[j].GetVectors().GetDim()*2) : (i+1)*(fieldDataList[j].GetVectors().GetDim()*2)]
+				case schemapb.DataType_BFloat16Vector:
+					row[fieldDataList[j].FieldName] = fieldDataList[j].GetVectors().GetBinaryVector()[i*(fieldDataList[j].GetVectors().GetDim()*2) : (i+1)*(fieldDataList[j].GetVectors().GetDim()*2)]
 				case schemapb.DataType_Array:
 					row[fieldDataList[j].FieldName] = fieldDataList[j].GetScalars().GetArrayData().Data[i]
 				case schemapb.DataType_JSON:

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -123,6 +123,15 @@ func checkGetPrimaryKey(coll *schemapb.CollectionSchema, idResult gjson.Result) 
 }
 
 // --------------------- collection details --------------------- //
+
+func IsVectorField(field *schemapb.FieldSchema) bool {
+	switch field.DataType {
+	case schemapb.DataType_BinaryVector, schemapb.DataType_FloatVector, schemapb.DataType_Float16Vector, schemapb.DataType_BFloat16Vector:
+		return true
+	}
+	return false
+}
+
 func printFields(fields []*schemapb.FieldSchema) []gin.H {
 	var res []gin.H
 	for _, field := range fields {
@@ -133,8 +142,7 @@ func printFields(fields []*schemapb.FieldSchema) []gin.H {
 			HTTPReturnFieldAutoID:       field.AutoID,
 			HTTPReturnDescription:       field.Description,
 		}
-		if field.DataType == schemapb.DataType_BinaryVector || field.DataType == schemapb.DataType_FloatVector ||
-			field.DataType == schemapb.DataType_Float16Vector || field.DataType == schemapb.DataType_BFloat16Vector {
+		if IsVectorField(field) {
 			dim, _ := getDim(field)
 			fieldDetail[HTTPReturnFieldType] = field.DataType.String() + "(" + strconv.FormatInt(dim, 10) + ")"
 		} else if field.DataType == schemapb.DataType_VarChar {
@@ -1034,9 +1042,9 @@ func buildQueryResp(rowsNum int64, needFields []string, fieldDataList []*schemap
 				case schemapb.DataType_FloatVector:
 					row[fieldDataList[j].FieldName] = fieldDataList[j].GetVectors().GetFloatVector().Data[i*fieldDataList[j].GetVectors().GetDim() : (i+1)*fieldDataList[j].GetVectors().GetDim()]
 				case schemapb.DataType_Float16Vector:
-					row[fieldDataList[j].FieldName] = fieldDataList[j].GetVectors().GetBinaryVector()[i*(fieldDataList[j].GetVectors().GetDim()*2) : (i+1)*(fieldDataList[j].GetVectors().GetDim()*2)]
+					row[fieldDataList[j].FieldName] = fieldDataList[j].GetVectors().GetFloat16Vector()[i*(fieldDataList[j].GetVectors().GetDim()*2) : (i+1)*(fieldDataList[j].GetVectors().GetDim()*2)]
 				case schemapb.DataType_BFloat16Vector:
-					row[fieldDataList[j].FieldName] = fieldDataList[j].GetVectors().GetBinaryVector()[i*(fieldDataList[j].GetVectors().GetDim()*2) : (i+1)*(fieldDataList[j].GetVectors().GetDim()*2)]
+					row[fieldDataList[j].FieldName] = fieldDataList[j].GetVectors().GetBfloat16Vector()[i*(fieldDataList[j].GetVectors().GetDim()*2) : (i+1)*(fieldDataList[j].GetVectors().GetDim()*2)]
 				case schemapb.DataType_Array:
 					row[fieldDataList[j].FieldName] = fieldDataList[j].GetScalars().GetArrayData().Data[i]
 				case schemapb.DataType_JSON:

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -416,6 +416,57 @@ func TestInsertWithDynamicFields(t *testing.T) {
 	assert.Equal(t, "{\"classified\":false,\"id\":0}", string(fieldsData[len(fieldsData)-1].GetScalars().GetJsonData().GetData()[0]))
 }
 
+func TestInsertWithoutVector(t *testing.T) {
+	body := "{\"data\": {}}"
+	var err error
+	primaryField := generatePrimaryField(schemapb.DataType_Int64)
+	primaryField.AutoID = true
+	floatVectorField := generateVectorFieldSchema(schemapb.DataType_FloatVector)
+	floatVectorField.Name = "floatVector"
+	binaryVectorField := generateVectorFieldSchema(schemapb.DataType_BinaryVector)
+	binaryVectorField.Name = "binaryVector"
+	float16VectorField := generateVectorFieldSchema(schemapb.DataType_Float16Vector)
+	float16VectorField.Name = "float16Vector"
+	bfloat16VectorField := generateVectorFieldSchema(schemapb.DataType_BFloat16Vector)
+	bfloat16VectorField.Name = "bfloat16Vector"
+	err, _ = checkAndSetData(body, &schemapb.CollectionSchema{
+		Name: DefaultCollectionName,
+		Fields: []*schemapb.FieldSchema{
+			&primaryField, &floatVectorField,
+		},
+		EnableDynamicField: true,
+	})
+	assert.Error(t, err)
+	assert.Equal(t, true, strings.HasPrefix(err.Error(), "missing vector field"))
+	err, _ = checkAndSetData(body, &schemapb.CollectionSchema{
+		Name: DefaultCollectionName,
+		Fields: []*schemapb.FieldSchema{
+			&primaryField, &binaryVectorField,
+		},
+		EnableDynamicField: true,
+	})
+	assert.Error(t, err)
+	assert.Equal(t, true, strings.HasPrefix(err.Error(), "missing vector field"))
+	err, _ = checkAndSetData(body, &schemapb.CollectionSchema{
+		Name: DefaultCollectionName,
+		Fields: []*schemapb.FieldSchema{
+			&primaryField, &float16VectorField,
+		},
+		EnableDynamicField: true,
+	})
+	assert.Error(t, err)
+	assert.Equal(t, true, strings.HasPrefix(err.Error(), "missing vector field"))
+	err, _ = checkAndSetData(body, &schemapb.CollectionSchema{
+		Name: DefaultCollectionName,
+		Fields: []*schemapb.FieldSchema{
+			&primaryField, &bfloat16VectorField,
+		},
+		EnableDynamicField: true,
+	})
+	assert.Error(t, err)
+	assert.Equal(t, true, strings.HasPrefix(err.Error(), "missing vector field"))
+}
+
 func TestInsertWithInt64(t *testing.T) {
 	arrayFieldName := "array-int64"
 	body := "{\"data\": {\"book_id\": 9999999999999999, \"book_intro\": [0.1, 0.2], \"word_count\": 2, \"" + arrayFieldName + "\": [9999999999999999]}}"


### PR DESCRIPTION
master pr: #30871 issue: #30870
fix: vector field cannot be empty while insert
did a check whether the vector field is empty in advance

master pr: #30740
fix:
1. spelling mistake about metricsType #30643
2. int64 percious #20415
3. insert into collection which has multi vector fields #30674

enhance: support dataType: Float16Vector & BFloat16Vector #22837 #30980(master pr: #30969)
enhance: describe collection will show the field is partition key or not #30789