### PR TITLE
fix: Prevent clone when selecting segments from meta

### DIFF
--- a/internal/datacoord/compaction_trigger.go
+++ b/internal/datacoord/compaction_trigger.go
@@ -343,7 +343,7 @@ func (t *compactionTrigger) updateSegmentMaxSize(segments []*SegmentInfo) (bool,
 				log.Info("segment max row recalculated",
 					zap.Int64("segmentID", segmentInfo.GetID()),
 					zap.Int64("old max rows", segmentInfo.GetMaxRowNum()),
-					zap.Int64("new max rows", int64(newMaxRows)),
+					zap.Int64("new max rows", newMaxRows),
 					zap.Bool("isDiskANN", isDiskAnn),
 				)
 				err := t.meta.UpdateSegment(segmentInfo.GetID(), SetMaxRowCount(newMaxRows))

--- a/internal/datacoord/meta_test.go
+++ b/internal/datacoord/meta_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/milvus-io/milvus/internal/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/common"
 	"github.com/milvus-io/milvus/pkg/metrics"
+	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/util/testutils"
 )
@@ -319,6 +320,93 @@ func (suite *MetaBasicSuite) TestCompleteCompactionMutation() {
 	suite.Equal(2, len(mutation.stateChange[datapb.SegmentLevel_L1.String()]))
 	suite.EqualValues(-2, mutation.rowCountChange)
 	suite.EqualValues(2, mutation.rowCountAccChange)
+}
+
+func (suite *MetaBasicSuite) TestSetSegment() {
+	meta := suite.meta
+	catalog := mocks.NewDataCoordCatalog(suite.T())
+	meta.catalog = catalog
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	suite.Run("normal", func() {
+		segmentID := int64(1000)
+		catalog.EXPECT().AddSegment(mock.Anything, mock.Anything).Return(nil).Once()
+		segment := NewSegmentInfo(&datapb.SegmentInfo{
+			ID:            segmentID,
+			MaxRowNum:     30000,
+			CollectionID:  suite.collID,
+			InsertChannel: suite.channelName,
+			State:         commonpb.SegmentState_Flushed,
+		})
+		err := meta.AddSegment(ctx, segment)
+		suite.Require().NoError(err)
+
+		noOp := func(segment *SegmentInfo) bool {
+			return true
+		}
+
+		catalog.EXPECT().AlterSegments(mock.Anything, mock.Anything).Return(nil).Once()
+
+		err = meta.UpdateSegment(segmentID, noOp)
+		suite.NoError(err)
+	})
+
+	suite.Run("not_updated", func() {
+		segmentID := int64(1001)
+		catalog.EXPECT().AddSegment(mock.Anything, mock.Anything).Return(nil).Once()
+		segment := NewSegmentInfo(&datapb.SegmentInfo{
+			ID:            segmentID,
+			MaxRowNum:     30000,
+			CollectionID:  suite.collID,
+			InsertChannel: suite.channelName,
+			State:         commonpb.SegmentState_Flushed,
+		})
+		err := meta.AddSegment(ctx, segment)
+		suite.Require().NoError(err)
+
+		noOp := func(segment *SegmentInfo) bool {
+			return false
+		}
+
+		err = meta.UpdateSegment(segmentID, noOp)
+		suite.NoError(err)
+	})
+
+	suite.Run("catalog_error", func() {
+		segmentID := int64(1002)
+		catalog.EXPECT().AddSegment(mock.Anything, mock.Anything).Return(nil).Once()
+		segment := NewSegmentInfo(&datapb.SegmentInfo{
+			ID:            segmentID,
+			MaxRowNum:     30000,
+			CollectionID:  suite.collID,
+			InsertChannel: suite.channelName,
+			State:         commonpb.SegmentState_Flushed,
+		})
+		err := meta.AddSegment(ctx, segment)
+		suite.Require().NoError(err)
+
+		noOp := func(segment *SegmentInfo) bool {
+			return true
+		}
+
+		catalog.EXPECT().AlterSegments(mock.Anything, mock.Anything).Return(errors.New("mocked")).Once()
+
+		err = meta.UpdateSegment(segmentID, noOp)
+		suite.Error(err)
+	})
+
+	suite.Run("segment_not_found", func() {
+		segmentID := int64(1003)
+
+		noOp := func(segment *SegmentInfo) bool {
+			return true
+		}
+
+		err := meta.UpdateSegment(segmentID, noOp)
+		suite.Error(err)
+		suite.ErrorIs(err, merr.ErrSegmentNotFound)
+	})
 }
 
 func TestMeta(t *testing.T) {

--- a/internal/datacoord/segment_operator.go
+++ b/internal/datacoord/segment_operator.go
@@ -1,0 +1,30 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datacoord
+
+// SegmentOperator is function type to update segment info.
+type SegmentOperator func(segment *SegmentInfo) bool
+
+func SetMaxRowCount(maxRow int64) SegmentOperator {
+	return func(segment *SegmentInfo) bool {
+		if segment.MaxRowNum == maxRow {
+			return false
+		}
+		segment.MaxRowNum = maxRow
+		return true
+	}
+}

--- a/internal/datacoord/segment_operator_test.go
+++ b/internal/datacoord/segment_operator_test.go
@@ -1,0 +1,48 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datacoord
+
+import (
+	"testing"
+
+	"github.com/milvus-io/milvus/internal/proto/datapb"
+	"github.com/stretchr/testify/suite"
+)
+
+type TestSegmentOperatorSuite struct {
+	suite.Suite
+}
+
+func (s *TestSegmentOperatorSuite) TestSetMaxRowCount() {
+	segment := &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			MaxRowNum: 300,
+		},
+	}
+
+	ops := SetMaxRowCount(20000)
+	updated := ops(segment)
+	s.Require().True(updated)
+	s.EqualValues(20000, segment.GetMaxRowNum())
+
+	updated = ops(segment)
+	s.False(updated)
+}
+
+func TestSegmentOperators(t *testing.T) {
+	suite.Run(t, new(TestSegmentOperatorSuite))
+}

--- a/internal/datacoord/segment_operator_test.go
+++ b/internal/datacoord/segment_operator_test.go
@@ -19,8 +19,9 @@ package datacoord
 import (
 	"testing"
 
-	"github.com/milvus-io/milvus/internal/proto/datapb"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/milvus-io/milvus/internal/proto/datapb"
 )
 
 type TestSegmentOperatorSuite struct {

--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -304,6 +304,8 @@ func (s *Server) GetInsertBinlogPaths(ctx context.Context, req *datapb.GetInsert
 		}, nil
 	}
 
+	segment = segment.Clone()
+
 	err := binlog.DecompressBinLog(storage.InsertBinlog, segment.GetCollectionID(), segment.GetPartitionID(), segment.GetID(), segment.GetBinlogs())
 	if err != nil {
 		return &datapb.GetInsertBinlogPathsResponse{


### PR DESCRIPTION
See also #30538

Previously the `SelectSegments` changed to clone all return value preventing possible update to returned info.

Since meta is implemented following COW rules, this shall not happen and any update on segment shall have copy before it.

This PR:
- Remove clone for read-only Get segment info
- Add Segment Operator abstraction for changing segment
- Implemnt COW for updating MaxRowNum