### PR TITLE
fix: wrong segment binlog path cause load segment failed #30726

### DIFF
--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -418,6 +418,8 @@ func (s *Server) GetSegmentInfo(ctx context.Context, req *datapb.GetSegmentInfoR
 			child := s.meta.GetCompactionTo(id)
 			clonedInfo := info.Clone()
 			if child != nil {
+				// child segment should decompress binlog path
+				binlog.DecompressBinLog(storage.DeleteBinlog, child.GetCollectionID(), child.GetPartitionID(), child.GetID(), child.GetDeltalogs())
 				clonedInfo.Deltalogs = append(clonedInfo.Deltalogs, child.GetDeltalogs()...)
 				clonedInfo.DmlPosition = child.GetDmlPosition()
 			}

--- a/internal/datacoord/services_test.go
+++ b/internal/datacoord/services_test.go
@@ -603,6 +603,32 @@ func (s *ServerSuite) TestGetSegmentInfoChannel() {
 	s.EqualValues(Params.CommonCfg.DataCoordSegmentInfo.GetValue(), resp.Value)
 }
 
+func (s *ServerSuite) TestGetSegmentInfo() {
+	testSegmentID := int64(1)
+	s.testServer.meta.AddSegment(context.TODO(), &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:        1,
+			Deltalogs: []*datapb.FieldBinlog{{FieldID: 100, Binlogs: []*datapb.Binlog{{LogID: 100}}}},
+		},
+	})
+
+	s.testServer.meta.AddSegment(context.TODO(), &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:             2,
+			Deltalogs:      []*datapb.FieldBinlog{{FieldID: 100, Binlogs: []*datapb.Binlog{{LogID: 101}}}},
+			CompactionFrom: []int64{1},
+		},
+	})
+
+	resp, err := s.testServer.GetSegmentInfo(context.TODO(), &datapb.GetSegmentInfoRequest{
+		SegmentIDs:       []int64{testSegmentID},
+		IncludeUnHealthy: true,
+	})
+	s.NoError(err)
+	log.Info("test--", zap.Any("resp", resp))
+	s.EqualValues(2, len(resp.Infos[0].Deltalogs))
+}
+
 func (s *ServerSuite) TestAssignSegmentID() {
 	s.TearDownTest()
 	const collID = 100


### PR DESCRIPTION
DataCoord GetSegmentInfo should return binlog info with logpath instead logid when segment merge child segment's
binlog.
relate: https://github.com/milvus-io/milvus/issues/30366 https://github.com/milvus-io/milvus/issues/30165 https://github.com/milvus-io/milvus/issues/30550