### PR TITLE
fix: Skip alloc timestamp logic shall only apply for eventually level

### DIFF
--- a/internal/proxy/task_query.go
+++ b/internal/proxy/task_query.go
@@ -264,7 +264,7 @@ func (t *queryTask) CanSkipAllocTimestamp() bool {
 		consistencyLevel = collectionInfo.consistencyLevel
 	}
 
-	return consistencyLevel != commonpb.ConsistencyLevel_Strong
+	return consistencyLevel == commonpb.ConsistencyLevel_Eventually
 }
 
 func (t *queryTask) PreExecute(ctx context.Context) error {

--- a/internal/proxy/task_search.go
+++ b/internal/proxy/task_search.go
@@ -266,7 +266,7 @@ func (t *searchTask) CanSkipAllocTimestamp() bool {
 		consistencyLevel = collectionInfo.consistencyLevel
 	}
 
-	return consistencyLevel != commonpb.ConsistencyLevel_Strong
+	return consistencyLevel == commonpb.ConsistencyLevel_Eventually
 }
 
 func (t *searchTask) PreExecute(ctx context.Context) error {


### PR DESCRIPTION
See also #29773

Skip ts allocation shall only happen when consistency level is eventually, otherwise the timestamp consistency level guarantee will be broken