### PR TITLE
fix: [cherry-pick] Clear DN unknown compaction tasks

### DIFF
--- a/internal/datacoord/compaction_test.go
+++ b/internal/datacoord/compaction_test.go
@@ -795,6 +795,7 @@ func Test_compactionPlanHandler_updateCompaction(t *testing.T) {
 										{PlanID: 3, State: commonpb.CompactionState_Completed, Result: &datapb.CompactionResult{PlanID: 3}},
 										{PlanID: 4, State: commonpb.CompactionState_Executing},
 										{PlanID: 6, State: commonpb.CompactionState_Executing},
+										{PlanID: 7, State: commonpb.CompactionState_Completed, Result: &datapb.CompactionResult{PlanID: 7}},
 									},
 								},
 							}},

--- a/internal/datanode/services_test.go
+++ b/internal/datanode/services_test.go
@@ -760,19 +760,24 @@ func (s *DataNodeServicesSuite) TestSyncSegments() {
 		s3.segmentID: &s3,
 	}
 
-	s.Run("invalid compacted from", func() {
+	s.Run("empty compactedFrom", func() {
 		req := &datapb.SyncSegmentsRequest{
 			CompactedTo: 400,
 			NumOfRows:   100,
 		}
-
-		req.CompactedFrom = []UniqueID{}
 		status, err := s.node.SyncSegments(s.ctx, req)
-		s.Assert().NoError(err)
-		s.Assert().False(merr.Ok(status))
+		s.NoError(err)
+		s.True(merr.Ok(status))
+	})
 
-		req.CompactedFrom = []UniqueID{101, 201}
-		status, err = s.node.SyncSegments(s.ctx, req)
+	s.Run("invalid compacted from", func() {
+		req := &datapb.SyncSegmentsRequest{
+			CompactedTo:   400,
+			NumOfRows:     100,
+			CompactedFrom: []UniqueID{101, 201},
+		}
+
+		status, err := s.node.SyncSegments(s.ctx, req)
 		s.Assert().NoError(err)
 		s.Assert().True(merr.Ok(status))
 	})

--- a/pkg/util/typeutil/pair.go
+++ b/pkg/util/typeutil/pair.go
@@ -1,0 +1,10 @@
+package typeutil
+
+type Pair[T, U any] struct {
+	A T
+	B U
+}
+
+func NewPair[T, U any](a T, b U) Pair[T, U] {
+	return Pair[T, U]{A: a, B: b}
+}


### PR DESCRIPTION
If DC restarted,  those unkonwn compaction tasks
will never get call back in DN, so that the segments in the compaction task will be locked, unable to sync and compaction again, blocking cp advance and compaction executing.

See also: #30137
pr: #30850