### PR TITLE
enhance: add metrics for load segment progress

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -96,6 +96,7 @@ const (
 	lockSource               = "lock_source"
 	lockType                 = "lock_type"
 	lockOp                   = "lock_op"
+	loadTypeName             = "load_type"
 )
 
 var (

--- a/pkg/metrics/querynode_metrics.go
+++ b/pkg/metrics/querynode_metrics.go
@@ -496,8 +496,8 @@ var (
 			Namespace: milvusNamespace,
 			Subsystem: typeutil.QueryNodeRole,
 			Name:      "load_index_latency",
-			Help:      "latency of load per segment's index",
-			Buckets:   []float64{0.1, 0.5, 1, 5, 10, 20, 50, 100, 300, 600, 1200}, // unit seconds
+			Help:      "latency of load per segment's index, in milliseconds",
+			Buckets:   buckets, // unit milliseconds
 		}, []string{
 			nodeIDLabelName,
 		})

--- a/pkg/metrics/querynode_metrics.go
+++ b/pkg/metrics/querynode_metrics.go
@@ -235,7 +235,7 @@ var (
 			Subsystem: typeutil.QueryNodeRole,
 			Name:      "load_segment_latency",
 			Help:      "latency of load per segment",
-			Buckets:   []float64{0.1, 0.5, 1, 5, 10, 20, 50, 100, 300, 600, 1200}, // unit seconds
+			Buckets:   longTaskBuckets, // unit milliseconds
 		}, []string{
 			nodeIDLabelName,
 		})
@@ -497,7 +497,7 @@ var (
 			Subsystem: typeutil.QueryNodeRole,
 			Name:      "load_index_latency",
 			Help:      "latency of load per segment's index, in milliseconds",
-			Buckets:   buckets, // unit milliseconds
+			Buckets:   longTaskBuckets, // unit milliseconds
 		}, []string{
 			nodeIDLabelName,
 		})

--- a/pkg/metrics/querynode_metrics.go
+++ b/pkg/metrics/querynode_metrics.go
@@ -479,6 +479,28 @@ var (
 			Name:      "stopping_balance_segment_num",
 			Help:      "the number of segment which executing stopping balance",
 		}, []string{nodeIDLabelName})
+
+	QueryNodeLoadSegmentConcurrency = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.QueryNodeRole,
+			Name:      "load_segment_concurrency",
+			Help:      "number of concurrent loading segments in QueryNode",
+		}, []string{
+			nodeIDLabelName,
+			loadTypeName,
+		})
+
+	QueryNodeLoadIndexLatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.QueryNodeRole,
+			Name:      "load_index_latency",
+			Help:      "latency of load per segment's index",
+			Buckets:   []float64{0.1, 0.5, 1, 5, 10, 20, 50, 100, 300, 600, 1200}, // unit seconds
+		}, []string{
+			nodeIDLabelName,
+		})
 )
 
 // RegisterQueryNode registers QueryNode metrics
@@ -524,6 +546,8 @@ func RegisterQueryNode(registry *prometheus.Registry) {
 	registry.MustRegister(StoppingBalanceNodeNum)
 	registry.MustRegister(StoppingBalanceChannelNum)
 	registry.MustRegister(StoppingBalanceSegmentNum)
+	registry.MustRegister(QueryNodeLoadSegmentConcurrency)
+	registry.MustRegister(QueryNodeLoadIndexLatency)
 }
 
 func CleanupQueryNodeCollectionMetrics(nodeID int64, collectionID int64) {


### PR DESCRIPTION
This PR add metrics for load segment progress:
1. add metrics for load segment/index concurrency
2. add metrics for load index latency
3. change load segment latency's time unit to ms