### PR TITLE
fix: Leader checker can't update segment's load version

### DIFF
--- a/internal/querycoordv2/checkers/leader_checker.go
+++ b/internal/querycoordv2/checkers/leader_checker.go
@@ -121,24 +121,17 @@ func (c *LeaderChecker) findNeedLoadedSegments(ctx context.Context, replica int6
 	ret := make([]task.Task, 0)
 	dist = utils.FindMaxVersionSegments(dist)
 	for _, s := range dist {
-		version, ok := leaderView.Segments[s.GetID()]
-		currentTarget := c.target.GetSealedSegment(s.CollectionID, s.GetID(), meta.CurrentTarget)
-		existInCurrentTarget := currentTarget != nil
-		existInNextTarget := c.target.GetSealedSegment(s.CollectionID, s.GetID(), meta.NextTarget) != nil
-
-		if !existInCurrentTarget && !existInNextTarget {
+		existInTarget := c.target.GetSealedSegment(leaderView.CollectionID, s.GetID(), meta.CurrentTargetFirst) != nil
+		if !existInTarget {
 			continue
 		}
 
-		leaderWithOldVersion := version.GetVersion() < s.Version
-		// leader has newer version, but the query node which loaded the newer version has been shutdown
-		leaderWithDirtyVersion := version.GetVersion() > s.Version && c.nodeMgr.Get(version.GetNodeID()) == nil
-
-		if !ok || leaderWithOldVersion || leaderWithDirtyVersion {
+		version, ok := leaderView.Segments[s.GetID()]
+		if !ok || version.GetVersion() < s.Version {
 			log.RatedDebug(10, "leader checker append a segment to set",
 				zap.Int64("segmentID", s.GetID()),
 				zap.Int64("nodeID", s.Node))
-			action := task.NewLeaderAction(leaderView.ID, s.Node, task.ActionTypeGrow, s.GetInsertChannel(), s.GetID())
+			action := task.NewLeaderAction(leaderView.ID, s.Node, task.ActionTypeGrow, s.GetInsertChannel(), s.GetID(), s.Version)
 			t := task.NewLeaderTask(
 				ctx,
 				params.Params.QueryCoordCfg.SegmentTaskTimeout.GetAsDuration(time.Millisecond),
@@ -173,15 +166,14 @@ func (c *LeaderChecker) findNeedRemovedSegments(ctx context.Context, replica int
 
 	for sid, s := range leaderView.Segments {
 		_, ok := distMap[sid]
-		existInCurrentTarget := c.target.GetSealedSegment(leaderView.CollectionID, sid, meta.CurrentTarget) != nil
-		existInNextTarget := c.target.GetSealedSegment(leaderView.CollectionID, sid, meta.NextTarget) != nil
-		if ok || existInCurrentTarget || existInNextTarget {
+		existInTarget := c.target.GetSealedSegment(leaderView.CollectionID, sid, meta.CurrentTargetFirst) != nil
+		if ok || existInTarget {
 			continue
 		}
 		log.Debug("leader checker append a segment to remove",
 			zap.Int64("segmentID", sid),
 			zap.Int64("nodeID", s.NodeID))
-		action := task.NewLeaderAction(leaderView.ID, s.NodeID, task.ActionTypeReduce, leaderView.Channel, sid)
+		action := task.NewLeaderAction(leaderView.ID, s.NodeID, task.ActionTypeReduce, leaderView.Channel, sid, 0)
 		t := task.NewLeaderTask(
 			ctx,
 			paramtable.Get().QueryCoordCfg.SegmentTaskTimeout.GetAsDuration(time.Millisecond),

--- a/internal/querycoordv2/task/action.go
+++ b/internal/querycoordv2/task/action.go
@@ -166,16 +166,18 @@ type LeaderAction struct {
 
 	leaderID  typeutil.UniqueID
 	segmentID typeutil.UniqueID
+	version   typeutil.UniqueID // segment load ts, 0 means not set
 
 	rpcReturned atomic.Bool
 }
 
-func NewLeaderAction(leaderID, workerID typeutil.UniqueID, typ ActionType, shard string, segmentID typeutil.UniqueID) *LeaderAction {
+func NewLeaderAction(leaderID, workerID typeutil.UniqueID, typ ActionType, shard string, segmentID typeutil.UniqueID, version typeutil.UniqueID) *LeaderAction {
 	action := &LeaderAction{
 		BaseAction: NewBaseAction(workerID, typ, shard),
 
 		leaderID:  leaderID,
 		segmentID: segmentID,
+		version:   version,
 	}
 	action.rpcReturned.Store(false)
 	return action
@@ -183,6 +185,10 @@ func NewLeaderAction(leaderID, workerID typeutil.UniqueID, typ ActionType, shard
 
 func (action *LeaderAction) SegmentID() typeutil.UniqueID {
 	return action.segmentID
+}
+
+func (action *LeaderAction) Version() typeutil.UniqueID {
+	return action.version
 }
 
 func (action *LeaderAction) IsFinished(distMgr *meta.DistributionManager) bool {

--- a/internal/querycoordv2/task/executor.go
+++ b/internal/querycoordv2/task/executor.go
@@ -471,6 +471,7 @@ func (ex *Executor) setDistribution(task *LeaderTask, step int) error {
 				SegmentID:   action.SegmentID(),
 				NodeID:      action.Node(),
 				Info:        loadInfo,
+				Version:     action.Version(),
 			},
 		},
 		IndexInfoList: indexInfo,

--- a/internal/querycoordv2/task/task_test.go
+++ b/internal/querycoordv2/task/task_test.go
@@ -1290,7 +1290,7 @@ func (suite *TaskSuite) TestLeaderTaskSet() {
 			suite.collection,
 			suite.replica,
 			targetNode,
-			NewLeaderAction(targetNode, targetNode, ActionTypeGrow, channel.GetChannelName(), segment),
+			NewLeaderAction(targetNode, targetNode, ActionTypeGrow, channel.GetChannelName(), segment, 0),
 		)
 		tasks = append(tasks, task)
 		err := suite.scheduler.Add(task)
@@ -1370,7 +1370,7 @@ func (suite *TaskSuite) TestCreateTaskBehavior() {
 	suite.ErrorIs(err, merr.ErrParameterInvalid)
 	suite.Nil(segmentTask)
 
-	leaderAction := NewLeaderAction(1, 2, ActionTypeGrow, "fake-channel1", 100)
+	leaderAction := NewLeaderAction(1, 2, ActionTypeGrow, "fake-channel1", 100, 0)
 	leaderTask := NewLeaderTask(context.TODO(), 5*time.Second, WrapIDSource(0), 0, 0, 1, leaderAction)
 	suite.NotNil(leaderTask)
 }
@@ -1555,7 +1555,7 @@ func (suite *TaskSuite) TestLeaderTaskRemove() {
 			suite.collection,
 			suite.replica,
 			targetNode,
-			NewLeaderAction(targetNode, targetNode, ActionTypeReduce, channel.GetChannelName(), segment),
+			NewLeaderAction(targetNode, targetNode, ActionTypeReduce, channel.GetChannelName(), segment, 0),
 		)
 		tasks = append(tasks, task)
 		err := suite.scheduler.Add(task)


### PR DESCRIPTION
issue: #30890

when leader checker find that leader view has an older load version of segment, it will try to correct leader view. but the sync action doesn't specify the latest load version. so the update operation will failed.

This PR fix leader checker can't update segment's load version and keeping generate same task to scheduler.