### PR TITLE
enhance: reduce datacoord lock granularity

### DIFF
--- a/internal/datacoord/SegmentMetricMutation.go
+++ b/internal/datacoord/SegmentMetricMutation.go
@@ -1,0 +1,68 @@
+package datacoord
+
+import (
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus/internal/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/metrics"
+	"sync"
+)
+
+// A local cache of segment metric update. Must call commit() to take effect.
+type SegMetricMutation struct {
+	sync.RWMutex
+	stateChange       map[string]map[string]int // segment state, seg level -> state change count (to increase or decrease).
+	rowCountChange    int64                     // Change in # of rows.
+	rowCountAccChange int64                     // Total # of historical added rows, accumulated.
+}
+
+// addNewSeg update metrics update for a new segment.
+func (s *SegMetricMutation) addNewSeg(state commonpb.SegmentState, level datapb.SegmentLevel, rowCount int64) {
+	s.Lock()
+	defer s.Lock()
+	if _, ok := s.stateChange[level.String()]; !ok {
+		s.stateChange[level.String()] = make(map[string]int)
+	}
+	s.stateChange[level.String()][state.String()] += 1
+
+	s.rowCountChange += rowCount
+	s.rowCountAccChange += rowCount
+}
+
+// commit persists all updates in current segMetricMutation, should and must be called AFTER segment state change
+// has persisted in Etcd.
+func (s *SegMetricMutation) commit() {
+	s.Lock()
+	defer s.Lock()
+	for level, submap := range s.stateChange {
+		for state, change := range submap {
+			metrics.DataCoordNumSegments.WithLabelValues(state, level).Add(float64(change))
+		}
+	}
+	metrics.DataCoordNumStoredRowsCounter.WithLabelValues().Add(float64(s.rowCountAccChange))
+}
+
+// append updates current segMetricMutation when segment state change happens.
+func (s *SegMetricMutation) append(oldState, newState commonpb.SegmentState, level datapb.SegmentLevel, rowCountUpdate int64) {
+	s.Lock()
+	defer s.Lock()
+	if oldState != newState {
+		if _, ok := s.stateChange[level.String()]; !ok {
+			s.stateChange[level.String()] = make(map[string]int)
+		}
+		s.stateChange[level.String()][oldState.String()] -= 1
+		s.stateChange[level.String()][newState.String()] += 1
+	}
+	// Update # of rows on new flush operations and drop operations.
+	if isFlushState(newState) && !isFlushState(oldState) {
+		// If new flush.
+		s.rowCountChange += rowCountUpdate
+		s.rowCountAccChange += rowCountUpdate
+	} else if newState == commonpb.SegmentState_Dropped && oldState != newState {
+		// If new drop.
+		s.rowCountChange -= rowCountUpdate
+	}
+}
+
+func isFlushState(state commonpb.SegmentState) bool {
+	return state == commonpb.SegmentState_Flushing || state == commonpb.SegmentState_Flushed
+}

--- a/internal/datacoord/compaction.go
+++ b/internal/datacoord/compaction.go
@@ -80,7 +80,7 @@ type CompactionMeta interface {
 	UpdateSegmentsInfo(operators ...UpdateOperator) error
 	SetSegmentCompacting(segmentID int64, compacting bool)
 
-	CompleteCompactionMutation(plan *datapb.CompactionPlan, result *datapb.CompactionPlanResult) ([]*SegmentInfo, *segMetricMutation, error)
+	CompleteCompactionMutation(plan *datapb.CompactionPlan, result *datapb.CompactionPlanResult) ([]*SegmentInfo, *SegMetricMutation, error)
 }
 
 var _ CompactionMeta = (*meta)(nil)

--- a/internal/datacoord/compaction_test.go
+++ b/internal/datacoord/compaction_test.go
@@ -374,7 +374,7 @@ func (s *CompactionPlanHandlerSuite) TestHandleMergeCompactionResult() {
 		segment := NewSegmentInfo(&datapb.SegmentInfo{ID: 100})
 		s.mockMeta.EXPECT().CompleteCompactionMutation(mock.Anything, mock.Anything).Return(
 			[]*SegmentInfo{segment},
-			&segMetricMutation{}, nil).Once()
+			&SegMetricMutation{}, nil).Once()
 		s.mockSessMgr.EXPECT().SyncSegments(mock.Anything, mock.Anything).Return(errors.New("mock error")).Once()
 
 		handler := newCompactionPlanHandler(s.mockSessMgr, s.mockCm, s.mockMeta, s.mockAlloc)
@@ -413,7 +413,7 @@ func (s *CompactionPlanHandlerSuite) TestCompleteCompaction() {
 		segment := NewSegmentInfo(&datapb.SegmentInfo{ID: 100})
 		s.mockMeta.EXPECT().CompleteCompactionMutation(mock.Anything, mock.Anything).Return(
 			[]*SegmentInfo{segment},
-			&segMetricMutation{}, nil).Once()
+			&SegMetricMutation{}, nil).Once()
 		s.mockSch.EXPECT().Finish(mock.Anything, mock.Anything).Return()
 
 		dataNodeID := UniqueID(111)

--- a/internal/datacoord/mock_compaction_meta.go
+++ b/internal/datacoord/mock_compaction_meta.go
@@ -21,13 +21,13 @@ func (_m *MockCompactionMeta) EXPECT() *MockCompactionMeta_Expecter {
 }
 
 // CompleteCompactionMutation provides a mock function with given fields: plan, result
-func (_m *MockCompactionMeta) CompleteCompactionMutation(plan *datapb.CompactionPlan, result *datapb.CompactionPlanResult) ([]*SegmentInfo, *segMetricMutation, error) {
+func (_m *MockCompactionMeta) CompleteCompactionMutation(plan *datapb.CompactionPlan, result *datapb.CompactionPlanResult) ([]*SegmentInfo, *SegMetricMutation, error) {
 	ret := _m.Called(plan, result)
 
 	var r0 []*SegmentInfo
-	var r1 *segMetricMutation
+	var r1 *SegMetricMutation
 	var r2 error
-	if rf, ok := ret.Get(0).(func(*datapb.CompactionPlan, *datapb.CompactionPlanResult) ([]*SegmentInfo, *segMetricMutation, error)); ok {
+	if rf, ok := ret.Get(0).(func(*datapb.CompactionPlan, *datapb.CompactionPlanResult) ([]*SegmentInfo, *SegMetricMutation, error)); ok {
 		return rf(plan, result)
 	}
 	if rf, ok := ret.Get(0).(func(*datapb.CompactionPlan, *datapb.CompactionPlanResult) []*SegmentInfo); ok {
@@ -38,11 +38,11 @@ func (_m *MockCompactionMeta) CompleteCompactionMutation(plan *datapb.Compaction
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(*datapb.CompactionPlan, *datapb.CompactionPlanResult) *segMetricMutation); ok {
+	if rf, ok := ret.Get(1).(func(*datapb.CompactionPlan, *datapb.CompactionPlanResult) *SegMetricMutation); ok {
 		r1 = rf(plan, result)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(*segMetricMutation)
+			r1 = ret.Get(1).(*SegMetricMutation)
 		}
 	}
 
@@ -74,12 +74,12 @@ func (_c *MockCompactionMeta_CompleteCompactionMutation_Call) Run(run func(plan 
 	return _c
 }
 
-func (_c *MockCompactionMeta_CompleteCompactionMutation_Call) Return(_a0 []*SegmentInfo, _a1 *segMetricMutation, _a2 error) *MockCompactionMeta_CompleteCompactionMutation_Call {
+func (_c *MockCompactionMeta_CompleteCompactionMutation_Call) Return(_a0 []*SegmentInfo, _a1 *SegMetricMutation, _a2 error) *MockCompactionMeta_CompleteCompactionMutation_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *MockCompactionMeta_CompleteCompactionMutation_Call) RunAndReturn(run func(*datapb.CompactionPlan, *datapb.CompactionPlanResult) ([]*SegmentInfo, *segMetricMutation, error)) *MockCompactionMeta_CompleteCompactionMutation_Call {
+func (_c *MockCompactionMeta_CompleteCompactionMutation_Call) RunAndReturn(run func(*datapb.CompactionPlan, *datapb.CompactionPlanResult) ([]*SegmentInfo, *SegMetricMutation, error)) *MockCompactionMeta_CompleteCompactionMutation_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -573,7 +573,7 @@ func (s *Server) SaveBinlogPaths(ctx context.Context, req *datapb.SaveBinlogPath
 			err := s.compactionTrigger.triggerSingleCompaction(req.GetCollectionID(), req.GetPartitionID(),
 				req.GetSegmentID(), req.GetChannel(), false)
 			if err != nil {
-				log.Warn("failed to trigger single compaction")
+				log.Warn("failed to trigger single compaction", zap.Error(err))
 			}
 		}
 	}

--- a/internal/datanode/SegmentMetricMutation.go
+++ b/internal/datanode/SegmentMetricMutation.go
@@ -1,0 +1,68 @@
+package datanode
+
+import (
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus/internal/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/metrics"
+	"sync"
+)
+
+// A local cache of segment metric update. Must call commit() to take effect.
+type SegMetricMutation struct {
+	sync.RWMutex
+	stateChange       map[string]map[string]int // segment state, seg level -> state change count (to increase or decrease).
+	rowCountChange    int64                     // Change in # of rows.
+	rowCountAccChange int64                     // Total # of historical added rows, accumulated.
+}
+
+// addNewSeg update metrics update for a new segment.
+func (s *SegMetricMutation) addNewSeg(state commonpb.SegmentState, level datapb.SegmentLevel, rowCount int64) {
+	s.Lock()
+	defer s.Lock()
+	if _, ok := s.stateChange[level.String()]; !ok {
+		s.stateChange[level.String()] = make(map[string]int)
+	}
+	s.stateChange[level.String()][state.String()] += 1
+
+	s.rowCountChange += rowCount
+	s.rowCountAccChange += rowCount
+}
+
+// commit persists all updates in current segMetricMutation, should and must be called AFTER segment state change
+// has persisted in Etcd.
+func (s *SegMetricMutation) commit() {
+	s.Lock()
+	defer s.Lock()
+	for level, submap := range s.stateChange {
+		for state, change := range submap {
+			metrics.DataCoordNumSegments.WithLabelValues(state, level).Add(float64(change))
+		}
+	}
+	metrics.DataCoordNumStoredRowsCounter.WithLabelValues().Add(float64(s.rowCountAccChange))
+}
+
+// append updates current segMetricMutation when segment state change happens.
+func (s *SegMetricMutation) append(oldState, newState commonpb.SegmentState, level datapb.SegmentLevel, rowCountUpdate int64) {
+	s.Lock()
+	defer s.Lock()
+	if oldState != newState {
+		if _, ok := s.stateChange[level.String()]; !ok {
+			s.stateChange[level.String()] = make(map[string]int)
+		}
+		s.stateChange[level.String()][oldState.String()] -= 1
+		s.stateChange[level.String()][newState.String()] += 1
+	}
+	// Update # of rows on new flush operations and drop operations.
+	if isFlushState(newState) && !isFlushState(oldState) {
+		// If new flush.
+		s.rowCountChange += rowCountUpdate
+		s.rowCountAccChange += rowCountUpdate
+	} else if newState == commonpb.SegmentState_Dropped && oldState != newState {
+		// If new drop.
+		s.rowCountChange -= rowCountUpdate
+	}
+}
+
+func isFlushState(state commonpb.SegmentState) bool {
+	return state == commonpb.SegmentState_Flushing || state == commonpb.SegmentState_Flushed
+}

--- a/internal/mocks/mock_datacoord.go
+++ b/internal/mocks/mock_datacoord.go
@@ -68,8 +68,8 @@ type MockDataCoord_AlterIndex_Call struct {
 }
 
 // AlterIndex is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *indexpb.AlterIndexRequest
+//   - _a0 context.Context
+//   - _a1 *indexpb.AlterIndexRequest
 func (_e *MockDataCoord_Expecter) AlterIndex(_a0 interface{}, _a1 interface{}) *MockDataCoord_AlterIndex_Call {
 	return &MockDataCoord_AlterIndex_Call{Call: _e.mock.On("AlterIndex", _a0, _a1)}
 }
@@ -123,8 +123,8 @@ type MockDataCoord_AssignSegmentID_Call struct {
 }
 
 // AssignSegmentID is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.AssignSegmentIDRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.AssignSegmentIDRequest
 func (_e *MockDataCoord_Expecter) AssignSegmentID(_a0 interface{}, _a1 interface{}) *MockDataCoord_AssignSegmentID_Call {
 	return &MockDataCoord_AssignSegmentID_Call{Call: _e.mock.On("AssignSegmentID", _a0, _a1)}
 }
@@ -178,8 +178,8 @@ type MockDataCoord_BroadcastAlteredCollection_Call struct {
 }
 
 // BroadcastAlteredCollection is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.AlterCollectionRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.AlterCollectionRequest
 func (_e *MockDataCoord_Expecter) BroadcastAlteredCollection(_a0 interface{}, _a1 interface{}) *MockDataCoord_BroadcastAlteredCollection_Call {
 	return &MockDataCoord_BroadcastAlteredCollection_Call{Call: _e.mock.On("BroadcastAlteredCollection", _a0, _a1)}
 }
@@ -233,8 +233,8 @@ type MockDataCoord_CheckHealth_Call struct {
 }
 
 // CheckHealth is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.CheckHealthRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.CheckHealthRequest
 func (_e *MockDataCoord_Expecter) CheckHealth(_a0 interface{}, _a1 interface{}) *MockDataCoord_CheckHealth_Call {
 	return &MockDataCoord_CheckHealth_Call{Call: _e.mock.On("CheckHealth", _a0, _a1)}
 }
@@ -288,8 +288,8 @@ type MockDataCoord_CreateIndex_Call struct {
 }
 
 // CreateIndex is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *indexpb.CreateIndexRequest
+//   - _a0 context.Context
+//   - _a1 *indexpb.CreateIndexRequest
 func (_e *MockDataCoord_Expecter) CreateIndex(_a0 interface{}, _a1 interface{}) *MockDataCoord_CreateIndex_Call {
 	return &MockDataCoord_CreateIndex_Call{Call: _e.mock.On("CreateIndex", _a0, _a1)}
 }
@@ -343,8 +343,8 @@ type MockDataCoord_DescribeIndex_Call struct {
 }
 
 // DescribeIndex is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *indexpb.DescribeIndexRequest
+//   - _a0 context.Context
+//   - _a1 *indexpb.DescribeIndexRequest
 func (_e *MockDataCoord_Expecter) DescribeIndex(_a0 interface{}, _a1 interface{}) *MockDataCoord_DescribeIndex_Call {
 	return &MockDataCoord_DescribeIndex_Call{Call: _e.mock.On("DescribeIndex", _a0, _a1)}
 }
@@ -398,8 +398,8 @@ type MockDataCoord_DropIndex_Call struct {
 }
 
 // DropIndex is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *indexpb.DropIndexRequest
+//   - _a0 context.Context
+//   - _a1 *indexpb.DropIndexRequest
 func (_e *MockDataCoord_Expecter) DropIndex(_a0 interface{}, _a1 interface{}) *MockDataCoord_DropIndex_Call {
 	return &MockDataCoord_DropIndex_Call{Call: _e.mock.On("DropIndex", _a0, _a1)}
 }
@@ -453,8 +453,8 @@ type MockDataCoord_DropVirtualChannel_Call struct {
 }
 
 // DropVirtualChannel is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.DropVirtualChannelRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.DropVirtualChannelRequest
 func (_e *MockDataCoord_Expecter) DropVirtualChannel(_a0 interface{}, _a1 interface{}) *MockDataCoord_DropVirtualChannel_Call {
 	return &MockDataCoord_DropVirtualChannel_Call{Call: _e.mock.On("DropVirtualChannel", _a0, _a1)}
 }
@@ -508,8 +508,8 @@ type MockDataCoord_Flush_Call struct {
 }
 
 // Flush is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.FlushRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.FlushRequest
 func (_e *MockDataCoord_Expecter) Flush(_a0 interface{}, _a1 interface{}) *MockDataCoord_Flush_Call {
 	return &MockDataCoord_Flush_Call{Call: _e.mock.On("Flush", _a0, _a1)}
 }
@@ -563,8 +563,8 @@ type MockDataCoord_GcConfirm_Call struct {
 }
 
 // GcConfirm is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.GcConfirmRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.GcConfirmRequest
 func (_e *MockDataCoord_Expecter) GcConfirm(_a0 interface{}, _a1 interface{}) *MockDataCoord_GcConfirm_Call {
 	return &MockDataCoord_GcConfirm_Call{Call: _e.mock.On("GcConfirm", _a0, _a1)}
 }
@@ -618,8 +618,8 @@ type MockDataCoord_GcControl_Call struct {
 }
 
 // GcControl is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.GcControlRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.GcControlRequest
 func (_e *MockDataCoord_Expecter) GcControl(_a0 interface{}, _a1 interface{}) *MockDataCoord_GcControl_Call {
 	return &MockDataCoord_GcControl_Call{Call: _e.mock.On("GcControl", _a0, _a1)}
 }
@@ -673,8 +673,8 @@ type MockDataCoord_GetCollectionStatistics_Call struct {
 }
 
 // GetCollectionStatistics is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.GetCollectionStatisticsRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.GetCollectionStatisticsRequest
 func (_e *MockDataCoord_Expecter) GetCollectionStatistics(_a0 interface{}, _a1 interface{}) *MockDataCoord_GetCollectionStatistics_Call {
 	return &MockDataCoord_GetCollectionStatistics_Call{Call: _e.mock.On("GetCollectionStatistics", _a0, _a1)}
 }
@@ -728,8 +728,8 @@ type MockDataCoord_GetCompactionState_Call struct {
 }
 
 // GetCompactionState is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.GetCompactionStateRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.GetCompactionStateRequest
 func (_e *MockDataCoord_Expecter) GetCompactionState(_a0 interface{}, _a1 interface{}) *MockDataCoord_GetCompactionState_Call {
 	return &MockDataCoord_GetCompactionState_Call{Call: _e.mock.On("GetCompactionState", _a0, _a1)}
 }
@@ -783,8 +783,8 @@ type MockDataCoord_GetCompactionStateWithPlans_Call struct {
 }
 
 // GetCompactionStateWithPlans is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.GetCompactionPlansRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.GetCompactionPlansRequest
 func (_e *MockDataCoord_Expecter) GetCompactionStateWithPlans(_a0 interface{}, _a1 interface{}) *MockDataCoord_GetCompactionStateWithPlans_Call {
 	return &MockDataCoord_GetCompactionStateWithPlans_Call{Call: _e.mock.On("GetCompactionStateWithPlans", _a0, _a1)}
 }
@@ -838,8 +838,8 @@ type MockDataCoord_GetComponentStates_Call struct {
 }
 
 // GetComponentStates is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.GetComponentStatesRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.GetComponentStatesRequest
 func (_e *MockDataCoord_Expecter) GetComponentStates(_a0 interface{}, _a1 interface{}) *MockDataCoord_GetComponentStates_Call {
 	return &MockDataCoord_GetComponentStates_Call{Call: _e.mock.On("GetComponentStates", _a0, _a1)}
 }
@@ -893,8 +893,8 @@ type MockDataCoord_GetFlushAllState_Call struct {
 }
 
 // GetFlushAllState is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.GetFlushAllStateRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.GetFlushAllStateRequest
 func (_e *MockDataCoord_Expecter) GetFlushAllState(_a0 interface{}, _a1 interface{}) *MockDataCoord_GetFlushAllState_Call {
 	return &MockDataCoord_GetFlushAllState_Call{Call: _e.mock.On("GetFlushAllState", _a0, _a1)}
 }
@@ -948,8 +948,8 @@ type MockDataCoord_GetFlushState_Call struct {
 }
 
 // GetFlushState is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.GetFlushStateRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.GetFlushStateRequest
 func (_e *MockDataCoord_Expecter) GetFlushState(_a0 interface{}, _a1 interface{}) *MockDataCoord_GetFlushState_Call {
 	return &MockDataCoord_GetFlushState_Call{Call: _e.mock.On("GetFlushState", _a0, _a1)}
 }
@@ -1003,8 +1003,8 @@ type MockDataCoord_GetFlushedSegments_Call struct {
 }
 
 // GetFlushedSegments is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.GetFlushedSegmentsRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.GetFlushedSegmentsRequest
 func (_e *MockDataCoord_Expecter) GetFlushedSegments(_a0 interface{}, _a1 interface{}) *MockDataCoord_GetFlushedSegments_Call {
 	return &MockDataCoord_GetFlushedSegments_Call{Call: _e.mock.On("GetFlushedSegments", _a0, _a1)}
 }
@@ -1058,8 +1058,8 @@ type MockDataCoord_GetImportProgress_Call struct {
 }
 
 // GetImportProgress is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *internalpb.GetImportProgressRequest
+//   - _a0 context.Context
+//   - _a1 *internalpb.GetImportProgressRequest
 func (_e *MockDataCoord_Expecter) GetImportProgress(_a0 interface{}, _a1 interface{}) *MockDataCoord_GetImportProgress_Call {
 	return &MockDataCoord_GetImportProgress_Call{Call: _e.mock.On("GetImportProgress", _a0, _a1)}
 }
@@ -1113,8 +1113,8 @@ type MockDataCoord_GetIndexBuildProgress_Call struct {
 }
 
 // GetIndexBuildProgress is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *indexpb.GetIndexBuildProgressRequest
+//   - _a0 context.Context
+//   - _a1 *indexpb.GetIndexBuildProgressRequest
 func (_e *MockDataCoord_Expecter) GetIndexBuildProgress(_a0 interface{}, _a1 interface{}) *MockDataCoord_GetIndexBuildProgress_Call {
 	return &MockDataCoord_GetIndexBuildProgress_Call{Call: _e.mock.On("GetIndexBuildProgress", _a0, _a1)}
 }
@@ -1168,8 +1168,8 @@ type MockDataCoord_GetIndexInfos_Call struct {
 }
 
 // GetIndexInfos is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *indexpb.GetIndexInfoRequest
+//   - _a0 context.Context
+//   - _a1 *indexpb.GetIndexInfoRequest
 func (_e *MockDataCoord_Expecter) GetIndexInfos(_a0 interface{}, _a1 interface{}) *MockDataCoord_GetIndexInfos_Call {
 	return &MockDataCoord_GetIndexInfos_Call{Call: _e.mock.On("GetIndexInfos", _a0, _a1)}
 }
@@ -1223,8 +1223,8 @@ type MockDataCoord_GetIndexState_Call struct {
 }
 
 // GetIndexState is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *indexpb.GetIndexStateRequest
+//   - _a0 context.Context
+//   - _a1 *indexpb.GetIndexStateRequest
 func (_e *MockDataCoord_Expecter) GetIndexState(_a0 interface{}, _a1 interface{}) *MockDataCoord_GetIndexState_Call {
 	return &MockDataCoord_GetIndexState_Call{Call: _e.mock.On("GetIndexState", _a0, _a1)}
 }
@@ -1278,8 +1278,8 @@ type MockDataCoord_GetIndexStatistics_Call struct {
 }
 
 // GetIndexStatistics is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *indexpb.GetIndexStatisticsRequest
+//   - _a0 context.Context
+//   - _a1 *indexpb.GetIndexStatisticsRequest
 func (_e *MockDataCoord_Expecter) GetIndexStatistics(_a0 interface{}, _a1 interface{}) *MockDataCoord_GetIndexStatistics_Call {
 	return &MockDataCoord_GetIndexStatistics_Call{Call: _e.mock.On("GetIndexStatistics", _a0, _a1)}
 }
@@ -1333,8 +1333,8 @@ type MockDataCoord_GetInsertBinlogPaths_Call struct {
 }
 
 // GetInsertBinlogPaths is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.GetInsertBinlogPathsRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.GetInsertBinlogPathsRequest
 func (_e *MockDataCoord_Expecter) GetInsertBinlogPaths(_a0 interface{}, _a1 interface{}) *MockDataCoord_GetInsertBinlogPaths_Call {
 	return &MockDataCoord_GetInsertBinlogPaths_Call{Call: _e.mock.On("GetInsertBinlogPaths", _a0, _a1)}
 }
@@ -1388,8 +1388,8 @@ type MockDataCoord_GetMetrics_Call struct {
 }
 
 // GetMetrics is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.GetMetricsRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.GetMetricsRequest
 func (_e *MockDataCoord_Expecter) GetMetrics(_a0 interface{}, _a1 interface{}) *MockDataCoord_GetMetrics_Call {
 	return &MockDataCoord_GetMetrics_Call{Call: _e.mock.On("GetMetrics", _a0, _a1)}
 }
@@ -1443,8 +1443,8 @@ type MockDataCoord_GetPartitionStatistics_Call struct {
 }
 
 // GetPartitionStatistics is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.GetPartitionStatisticsRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.GetPartitionStatisticsRequest
 func (_e *MockDataCoord_Expecter) GetPartitionStatistics(_a0 interface{}, _a1 interface{}) *MockDataCoord_GetPartitionStatistics_Call {
 	return &MockDataCoord_GetPartitionStatistics_Call{Call: _e.mock.On("GetPartitionStatistics", _a0, _a1)}
 }
@@ -1498,8 +1498,8 @@ type MockDataCoord_GetRecoveryInfo_Call struct {
 }
 
 // GetRecoveryInfo is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.GetRecoveryInfoRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.GetRecoveryInfoRequest
 func (_e *MockDataCoord_Expecter) GetRecoveryInfo(_a0 interface{}, _a1 interface{}) *MockDataCoord_GetRecoveryInfo_Call {
 	return &MockDataCoord_GetRecoveryInfo_Call{Call: _e.mock.On("GetRecoveryInfo", _a0, _a1)}
 }
@@ -1553,8 +1553,8 @@ type MockDataCoord_GetRecoveryInfoV2_Call struct {
 }
 
 // GetRecoveryInfoV2 is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.GetRecoveryInfoRequestV2
+//   - _a0 context.Context
+//   - _a1 *datapb.GetRecoveryInfoRequestV2
 func (_e *MockDataCoord_Expecter) GetRecoveryInfoV2(_a0 interface{}, _a1 interface{}) *MockDataCoord_GetRecoveryInfoV2_Call {
 	return &MockDataCoord_GetRecoveryInfoV2_Call{Call: _e.mock.On("GetRecoveryInfoV2", _a0, _a1)}
 }
@@ -1608,8 +1608,8 @@ type MockDataCoord_GetSegmentIndexState_Call struct {
 }
 
 // GetSegmentIndexState is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *indexpb.GetSegmentIndexStateRequest
+//   - _a0 context.Context
+//   - _a1 *indexpb.GetSegmentIndexStateRequest
 func (_e *MockDataCoord_Expecter) GetSegmentIndexState(_a0 interface{}, _a1 interface{}) *MockDataCoord_GetSegmentIndexState_Call {
 	return &MockDataCoord_GetSegmentIndexState_Call{Call: _e.mock.On("GetSegmentIndexState", _a0, _a1)}
 }
@@ -1663,8 +1663,8 @@ type MockDataCoord_GetSegmentInfo_Call struct {
 }
 
 // GetSegmentInfo is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.GetSegmentInfoRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.GetSegmentInfoRequest
 func (_e *MockDataCoord_Expecter) GetSegmentInfo(_a0 interface{}, _a1 interface{}) *MockDataCoord_GetSegmentInfo_Call {
 	return &MockDataCoord_GetSegmentInfo_Call{Call: _e.mock.On("GetSegmentInfo", _a0, _a1)}
 }
@@ -1718,8 +1718,8 @@ type MockDataCoord_GetSegmentInfoChannel_Call struct {
 }
 
 // GetSegmentInfoChannel is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.GetSegmentInfoChannelRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.GetSegmentInfoChannelRequest
 func (_e *MockDataCoord_Expecter) GetSegmentInfoChannel(_a0 interface{}, _a1 interface{}) *MockDataCoord_GetSegmentInfoChannel_Call {
 	return &MockDataCoord_GetSegmentInfoChannel_Call{Call: _e.mock.On("GetSegmentInfoChannel", _a0, _a1)}
 }
@@ -1773,8 +1773,8 @@ type MockDataCoord_GetSegmentStates_Call struct {
 }
 
 // GetSegmentStates is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.GetSegmentStatesRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.GetSegmentStatesRequest
 func (_e *MockDataCoord_Expecter) GetSegmentStates(_a0 interface{}, _a1 interface{}) *MockDataCoord_GetSegmentStates_Call {
 	return &MockDataCoord_GetSegmentStates_Call{Call: _e.mock.On("GetSegmentStates", _a0, _a1)}
 }
@@ -1828,8 +1828,8 @@ type MockDataCoord_GetSegmentsByStates_Call struct {
 }
 
 // GetSegmentsByStates is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.GetSegmentsByStatesRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.GetSegmentsByStatesRequest
 func (_e *MockDataCoord_Expecter) GetSegmentsByStates(_a0 interface{}, _a1 interface{}) *MockDataCoord_GetSegmentsByStates_Call {
 	return &MockDataCoord_GetSegmentsByStates_Call{Call: _e.mock.On("GetSegmentsByStates", _a0, _a1)}
 }
@@ -1883,8 +1883,8 @@ type MockDataCoord_GetStatisticsChannel_Call struct {
 }
 
 // GetStatisticsChannel is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *internalpb.GetStatisticsChannelRequest
+//   - _a0 context.Context
+//   - _a1 *internalpb.GetStatisticsChannelRequest
 func (_e *MockDataCoord_Expecter) GetStatisticsChannel(_a0 interface{}, _a1 interface{}) *MockDataCoord_GetStatisticsChannel_Call {
 	return &MockDataCoord_GetStatisticsChannel_Call{Call: _e.mock.On("GetStatisticsChannel", _a0, _a1)}
 }
@@ -1938,8 +1938,8 @@ type MockDataCoord_GetTimeTickChannel_Call struct {
 }
 
 // GetTimeTickChannel is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *internalpb.GetTimeTickChannelRequest
+//   - _a0 context.Context
+//   - _a1 *internalpb.GetTimeTickChannelRequest
 func (_e *MockDataCoord_Expecter) GetTimeTickChannel(_a0 interface{}, _a1 interface{}) *MockDataCoord_GetTimeTickChannel_Call {
 	return &MockDataCoord_GetTimeTickChannel_Call{Call: _e.mock.On("GetTimeTickChannel", _a0, _a1)}
 }
@@ -1993,8 +1993,8 @@ type MockDataCoord_Import_Call struct {
 }
 
 // Import is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.ImportTaskRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.ImportTaskRequest
 func (_e *MockDataCoord_Expecter) Import(_a0 interface{}, _a1 interface{}) *MockDataCoord_Import_Call {
 	return &MockDataCoord_Import_Call{Call: _e.mock.On("Import", _a0, _a1)}
 }
@@ -2048,8 +2048,8 @@ type MockDataCoord_ImportV2_Call struct {
 }
 
 // ImportV2 is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *internalpb.ImportRequestInternal
+//   - _a0 context.Context
+//   - _a1 *internalpb.ImportRequestInternal
 func (_e *MockDataCoord_Expecter) ImportV2(_a0 interface{}, _a1 interface{}) *MockDataCoord_ImportV2_Call {
 	return &MockDataCoord_ImportV2_Call{Call: _e.mock.On("ImportV2", _a0, _a1)}
 }
@@ -2144,8 +2144,8 @@ type MockDataCoord_ListImports_Call struct {
 }
 
 // ListImports is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *internalpb.ListImportsRequestInternal
+//   - _a0 context.Context
+//   - _a1 *internalpb.ListImportsRequestInternal
 func (_e *MockDataCoord_Expecter) ListImports(_a0 interface{}, _a1 interface{}) *MockDataCoord_ListImports_Call {
 	return &MockDataCoord_ListImports_Call{Call: _e.mock.On("ListImports", _a0, _a1)}
 }
@@ -2199,8 +2199,8 @@ type MockDataCoord_ManualCompaction_Call struct {
 }
 
 // ManualCompaction is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.ManualCompactionRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.ManualCompactionRequest
 func (_e *MockDataCoord_Expecter) ManualCompaction(_a0 interface{}, _a1 interface{}) *MockDataCoord_ManualCompaction_Call {
 	return &MockDataCoord_ManualCompaction_Call{Call: _e.mock.On("ManualCompaction", _a0, _a1)}
 }
@@ -2254,8 +2254,8 @@ type MockDataCoord_MarkSegmentsDropped_Call struct {
 }
 
 // MarkSegmentsDropped is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.MarkSegmentsDroppedRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.MarkSegmentsDroppedRequest
 func (_e *MockDataCoord_Expecter) MarkSegmentsDropped(_a0 interface{}, _a1 interface{}) *MockDataCoord_MarkSegmentsDropped_Call {
 	return &MockDataCoord_MarkSegmentsDropped_Call{Call: _e.mock.On("MarkSegmentsDropped", _a0, _a1)}
 }
@@ -2350,8 +2350,8 @@ type MockDataCoord_ReportDataNodeTtMsgs_Call struct {
 }
 
 // ReportDataNodeTtMsgs is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.ReportDataNodeTtMsgsRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.ReportDataNodeTtMsgsRequest
 func (_e *MockDataCoord_Expecter) ReportDataNodeTtMsgs(_a0 interface{}, _a1 interface{}) *MockDataCoord_ReportDataNodeTtMsgs_Call {
 	return &MockDataCoord_ReportDataNodeTtMsgs_Call{Call: _e.mock.On("ReportDataNodeTtMsgs", _a0, _a1)}
 }
@@ -2405,8 +2405,8 @@ type MockDataCoord_SaveBinlogPaths_Call struct {
 }
 
 // SaveBinlogPaths is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.SaveBinlogPathsRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.SaveBinlogPathsRequest
 func (_e *MockDataCoord_Expecter) SaveBinlogPaths(_a0 interface{}, _a1 interface{}) *MockDataCoord_SaveBinlogPaths_Call {
 	return &MockDataCoord_SaveBinlogPaths_Call{Call: _e.mock.On("SaveBinlogPaths", _a0, _a1)}
 }
@@ -2460,8 +2460,8 @@ type MockDataCoord_SaveImportSegment_Call struct {
 }
 
 // SaveImportSegment is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.SaveImportSegmentRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.SaveImportSegmentRequest
 func (_e *MockDataCoord_Expecter) SaveImportSegment(_a0 interface{}, _a1 interface{}) *MockDataCoord_SaveImportSegment_Call {
 	return &MockDataCoord_SaveImportSegment_Call{Call: _e.mock.On("SaveImportSegment", _a0, _a1)}
 }
@@ -2494,7 +2494,7 @@ type MockDataCoord_SetAddress_Call struct {
 }
 
 // SetAddress is a helper method to define mock.On call
-//  - address string
+//   - address string
 func (_e *MockDataCoord_Expecter) SetAddress(address interface{}) *MockDataCoord_SetAddress_Call {
 	return &MockDataCoord_SetAddress_Call{Call: _e.mock.On("SetAddress", address)}
 }
@@ -2527,7 +2527,7 @@ type MockDataCoord_SetDataNodeCreator_Call struct {
 }
 
 // SetDataNodeCreator is a helper method to define mock.On call
-//  - _a0 func(context.Context , string , int64)(types.DataNodeClient , error)
+//   - _a0 func(context.Context , string , int64)(types.DataNodeClient , error)
 func (_e *MockDataCoord_Expecter) SetDataNodeCreator(_a0 interface{}) *MockDataCoord_SetDataNodeCreator_Call {
 	return &MockDataCoord_SetDataNodeCreator_Call{Call: _e.mock.On("SetDataNodeCreator", _a0)}
 }
@@ -2560,7 +2560,7 @@ type MockDataCoord_SetEtcdClient_Call struct {
 }
 
 // SetEtcdClient is a helper method to define mock.On call
-//  - etcdClient *clientv3.Client
+//   - etcdClient *clientv3.Client
 func (_e *MockDataCoord_Expecter) SetEtcdClient(etcdClient interface{}) *MockDataCoord_SetEtcdClient_Call {
 	return &MockDataCoord_SetEtcdClient_Call{Call: _e.mock.On("SetEtcdClient", etcdClient)}
 }
@@ -2593,7 +2593,7 @@ type MockDataCoord_SetIndexNodeCreator_Call struct {
 }
 
 // SetIndexNodeCreator is a helper method to define mock.On call
-//  - _a0 func(context.Context , string , int64)(types.IndexNodeClient , error)
+//   - _a0 func(context.Context , string , int64)(types.IndexNodeClient , error)
 func (_e *MockDataCoord_Expecter) SetIndexNodeCreator(_a0 interface{}) *MockDataCoord_SetIndexNodeCreator_Call {
 	return &MockDataCoord_SetIndexNodeCreator_Call{Call: _e.mock.On("SetIndexNodeCreator", _a0)}
 }
@@ -2626,7 +2626,7 @@ type MockDataCoord_SetRootCoordClient_Call struct {
 }
 
 // SetRootCoordClient is a helper method to define mock.On call
-//  - rootCoord types.RootCoordClient
+//   - rootCoord types.RootCoordClient
 func (_e *MockDataCoord_Expecter) SetRootCoordClient(rootCoord interface{}) *MockDataCoord_SetRootCoordClient_Call {
 	return &MockDataCoord_SetRootCoordClient_Call{Call: _e.mock.On("SetRootCoordClient", rootCoord)}
 }
@@ -2680,8 +2680,8 @@ type MockDataCoord_SetSegmentState_Call struct {
 }
 
 // SetSegmentState is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.SetSegmentStateRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.SetSegmentStateRequest
 func (_e *MockDataCoord_Expecter) SetSegmentState(_a0 interface{}, _a1 interface{}) *MockDataCoord_SetSegmentState_Call {
 	return &MockDataCoord_SetSegmentState_Call{Call: _e.mock.On("SetSegmentState", _a0, _a1)}
 }
@@ -2714,7 +2714,7 @@ type MockDataCoord_SetTiKVClient_Call struct {
 }
 
 // SetTiKVClient is a helper method to define mock.On call
-//  - client *txnkv.Client
+//   - client *txnkv.Client
 func (_e *MockDataCoord_Expecter) SetTiKVClient(client interface{}) *MockDataCoord_SetTiKVClient_Call {
 	return &MockDataCoord_SetTiKVClient_Call{Call: _e.mock.On("SetTiKVClient", client)}
 }
@@ -2768,8 +2768,8 @@ type MockDataCoord_ShowConfigurations_Call struct {
 }
 
 // ShowConfigurations is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *internalpb.ShowConfigurationsRequest
+//   - _a0 context.Context
+//   - _a1 *internalpb.ShowConfigurationsRequest
 func (_e *MockDataCoord_Expecter) ShowConfigurations(_a0 interface{}, _a1 interface{}) *MockDataCoord_ShowConfigurations_Call {
 	return &MockDataCoord_ShowConfigurations_Call{Call: _e.mock.On("ShowConfigurations", _a0, _a1)}
 }
@@ -2905,8 +2905,8 @@ type MockDataCoord_UnsetIsImportingState_Call struct {
 }
 
 // UnsetIsImportingState is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.UnsetIsImportingStateRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.UnsetIsImportingStateRequest
 func (_e *MockDataCoord_Expecter) UnsetIsImportingState(_a0 interface{}, _a1 interface{}) *MockDataCoord_UnsetIsImportingState_Call {
 	return &MockDataCoord_UnsetIsImportingState_Call{Call: _e.mock.On("UnsetIsImportingState", _a0, _a1)}
 }
@@ -2960,8 +2960,8 @@ type MockDataCoord_UpdateChannelCheckpoint_Call struct {
 }
 
 // UpdateChannelCheckpoint is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.UpdateChannelCheckpointRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.UpdateChannelCheckpointRequest
 func (_e *MockDataCoord_Expecter) UpdateChannelCheckpoint(_a0 interface{}, _a1 interface{}) *MockDataCoord_UpdateChannelCheckpoint_Call {
 	return &MockDataCoord_UpdateChannelCheckpoint_Call{Call: _e.mock.On("UpdateChannelCheckpoint", _a0, _a1)}
 }
@@ -3015,8 +3015,8 @@ type MockDataCoord_UpdateSegmentStatistics_Call struct {
 }
 
 // UpdateSegmentStatistics is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.UpdateSegmentStatisticsRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.UpdateSegmentStatisticsRequest
 func (_e *MockDataCoord_Expecter) UpdateSegmentStatistics(_a0 interface{}, _a1 interface{}) *MockDataCoord_UpdateSegmentStatistics_Call {
 	return &MockDataCoord_UpdateSegmentStatistics_Call{Call: _e.mock.On("UpdateSegmentStatistics", _a0, _a1)}
 }
@@ -3070,8 +3070,8 @@ type MockDataCoord_WatchChannels_Call struct {
 }
 
 // WatchChannels is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.WatchChannelsRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.WatchChannelsRequest
 func (_e *MockDataCoord_Expecter) WatchChannels(_a0 interface{}, _a1 interface{}) *MockDataCoord_WatchChannels_Call {
 	return &MockDataCoord_WatchChannels_Call{Call: _e.mock.On("WatchChannels", _a0, _a1)}
 }

--- a/internal/mocks/mock_datacoord_client.go
+++ b/internal/mocks/mock_datacoord_client.go
@@ -72,9 +72,9 @@ type MockDataCoordClient_AlterIndex_Call struct {
 }
 
 // AlterIndex is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *indexpb.AlterIndexRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *indexpb.AlterIndexRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) AlterIndex(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_AlterIndex_Call {
 	return &MockDataCoordClient_AlterIndex_Call{Call: _e.mock.On("AlterIndex",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -142,9 +142,9 @@ type MockDataCoordClient_AssignSegmentID_Call struct {
 }
 
 // AssignSegmentID is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.AssignSegmentIDRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.AssignSegmentIDRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) AssignSegmentID(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_AssignSegmentID_Call {
 	return &MockDataCoordClient_AssignSegmentID_Call{Call: _e.mock.On("AssignSegmentID",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -212,9 +212,9 @@ type MockDataCoordClient_BroadcastAlteredCollection_Call struct {
 }
 
 // BroadcastAlteredCollection is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.AlterCollectionRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.AlterCollectionRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) BroadcastAlteredCollection(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_BroadcastAlteredCollection_Call {
 	return &MockDataCoordClient_BroadcastAlteredCollection_Call{Call: _e.mock.On("BroadcastAlteredCollection",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -282,9 +282,9 @@ type MockDataCoordClient_CheckHealth_Call struct {
 }
 
 // CheckHealth is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *milvuspb.CheckHealthRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *milvuspb.CheckHealthRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) CheckHealth(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_CheckHealth_Call {
 	return &MockDataCoordClient_CheckHealth_Call{Call: _e.mock.On("CheckHealth",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -393,9 +393,9 @@ type MockDataCoordClient_CreateIndex_Call struct {
 }
 
 // CreateIndex is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *indexpb.CreateIndexRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *indexpb.CreateIndexRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) CreateIndex(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_CreateIndex_Call {
 	return &MockDataCoordClient_CreateIndex_Call{Call: _e.mock.On("CreateIndex",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -463,9 +463,9 @@ type MockDataCoordClient_DescribeIndex_Call struct {
 }
 
 // DescribeIndex is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *indexpb.DescribeIndexRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *indexpb.DescribeIndexRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) DescribeIndex(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_DescribeIndex_Call {
 	return &MockDataCoordClient_DescribeIndex_Call{Call: _e.mock.On("DescribeIndex",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -533,9 +533,9 @@ type MockDataCoordClient_DropIndex_Call struct {
 }
 
 // DropIndex is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *indexpb.DropIndexRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *indexpb.DropIndexRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) DropIndex(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_DropIndex_Call {
 	return &MockDataCoordClient_DropIndex_Call{Call: _e.mock.On("DropIndex",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -603,9 +603,9 @@ type MockDataCoordClient_DropVirtualChannel_Call struct {
 }
 
 // DropVirtualChannel is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.DropVirtualChannelRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.DropVirtualChannelRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) DropVirtualChannel(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_DropVirtualChannel_Call {
 	return &MockDataCoordClient_DropVirtualChannel_Call{Call: _e.mock.On("DropVirtualChannel",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -673,9 +673,9 @@ type MockDataCoordClient_Flush_Call struct {
 }
 
 // Flush is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.FlushRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.FlushRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) Flush(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_Flush_Call {
 	return &MockDataCoordClient_Flush_Call{Call: _e.mock.On("Flush",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -743,9 +743,9 @@ type MockDataCoordClient_GcConfirm_Call struct {
 }
 
 // GcConfirm is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.GcConfirmRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.GcConfirmRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GcConfirm(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GcConfirm_Call {
 	return &MockDataCoordClient_GcConfirm_Call{Call: _e.mock.On("GcConfirm",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -813,9 +813,9 @@ type MockDataCoordClient_GcControl_Call struct {
 }
 
 // GcControl is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.GcControlRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.GcControlRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GcControl(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GcControl_Call {
 	return &MockDataCoordClient_GcControl_Call{Call: _e.mock.On("GcControl",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -883,9 +883,9 @@ type MockDataCoordClient_GetCollectionStatistics_Call struct {
 }
 
 // GetCollectionStatistics is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.GetCollectionStatisticsRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.GetCollectionStatisticsRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GetCollectionStatistics(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GetCollectionStatistics_Call {
 	return &MockDataCoordClient_GetCollectionStatistics_Call{Call: _e.mock.On("GetCollectionStatistics",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -953,9 +953,9 @@ type MockDataCoordClient_GetCompactionState_Call struct {
 }
 
 // GetCompactionState is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *milvuspb.GetCompactionStateRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *milvuspb.GetCompactionStateRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GetCompactionState(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GetCompactionState_Call {
 	return &MockDataCoordClient_GetCompactionState_Call{Call: _e.mock.On("GetCompactionState",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -1023,9 +1023,9 @@ type MockDataCoordClient_GetCompactionStateWithPlans_Call struct {
 }
 
 // GetCompactionStateWithPlans is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *milvuspb.GetCompactionPlansRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *milvuspb.GetCompactionPlansRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GetCompactionStateWithPlans(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GetCompactionStateWithPlans_Call {
 	return &MockDataCoordClient_GetCompactionStateWithPlans_Call{Call: _e.mock.On("GetCompactionStateWithPlans",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -1093,9 +1093,9 @@ type MockDataCoordClient_GetComponentStates_Call struct {
 }
 
 // GetComponentStates is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *milvuspb.GetComponentStatesRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *milvuspb.GetComponentStatesRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GetComponentStates(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GetComponentStates_Call {
 	return &MockDataCoordClient_GetComponentStates_Call{Call: _e.mock.On("GetComponentStates",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -1163,9 +1163,9 @@ type MockDataCoordClient_GetFlushAllState_Call struct {
 }
 
 // GetFlushAllState is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *milvuspb.GetFlushAllStateRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *milvuspb.GetFlushAllStateRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GetFlushAllState(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GetFlushAllState_Call {
 	return &MockDataCoordClient_GetFlushAllState_Call{Call: _e.mock.On("GetFlushAllState",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -1233,9 +1233,9 @@ type MockDataCoordClient_GetFlushState_Call struct {
 }
 
 // GetFlushState is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.GetFlushStateRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.GetFlushStateRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GetFlushState(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GetFlushState_Call {
 	return &MockDataCoordClient_GetFlushState_Call{Call: _e.mock.On("GetFlushState",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -1303,9 +1303,9 @@ type MockDataCoordClient_GetFlushedSegments_Call struct {
 }
 
 // GetFlushedSegments is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.GetFlushedSegmentsRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.GetFlushedSegmentsRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GetFlushedSegments(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GetFlushedSegments_Call {
 	return &MockDataCoordClient_GetFlushedSegments_Call{Call: _e.mock.On("GetFlushedSegments",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -1373,9 +1373,9 @@ type MockDataCoordClient_GetImportProgress_Call struct {
 }
 
 // GetImportProgress is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *internalpb.GetImportProgressRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *internalpb.GetImportProgressRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GetImportProgress(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GetImportProgress_Call {
 	return &MockDataCoordClient_GetImportProgress_Call{Call: _e.mock.On("GetImportProgress",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -1443,9 +1443,9 @@ type MockDataCoordClient_GetIndexBuildProgress_Call struct {
 }
 
 // GetIndexBuildProgress is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *indexpb.GetIndexBuildProgressRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *indexpb.GetIndexBuildProgressRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GetIndexBuildProgress(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GetIndexBuildProgress_Call {
 	return &MockDataCoordClient_GetIndexBuildProgress_Call{Call: _e.mock.On("GetIndexBuildProgress",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -1513,9 +1513,9 @@ type MockDataCoordClient_GetIndexInfos_Call struct {
 }
 
 // GetIndexInfos is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *indexpb.GetIndexInfoRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *indexpb.GetIndexInfoRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GetIndexInfos(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GetIndexInfos_Call {
 	return &MockDataCoordClient_GetIndexInfos_Call{Call: _e.mock.On("GetIndexInfos",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -1583,9 +1583,9 @@ type MockDataCoordClient_GetIndexState_Call struct {
 }
 
 // GetIndexState is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *indexpb.GetIndexStateRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *indexpb.GetIndexStateRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GetIndexState(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GetIndexState_Call {
 	return &MockDataCoordClient_GetIndexState_Call{Call: _e.mock.On("GetIndexState",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -1653,9 +1653,9 @@ type MockDataCoordClient_GetIndexStatistics_Call struct {
 }
 
 // GetIndexStatistics is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *indexpb.GetIndexStatisticsRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *indexpb.GetIndexStatisticsRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GetIndexStatistics(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GetIndexStatistics_Call {
 	return &MockDataCoordClient_GetIndexStatistics_Call{Call: _e.mock.On("GetIndexStatistics",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -1723,9 +1723,9 @@ type MockDataCoordClient_GetInsertBinlogPaths_Call struct {
 }
 
 // GetInsertBinlogPaths is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.GetInsertBinlogPathsRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.GetInsertBinlogPathsRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GetInsertBinlogPaths(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GetInsertBinlogPaths_Call {
 	return &MockDataCoordClient_GetInsertBinlogPaths_Call{Call: _e.mock.On("GetInsertBinlogPaths",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -1793,9 +1793,9 @@ type MockDataCoordClient_GetMetrics_Call struct {
 }
 
 // GetMetrics is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *milvuspb.GetMetricsRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *milvuspb.GetMetricsRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GetMetrics(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GetMetrics_Call {
 	return &MockDataCoordClient_GetMetrics_Call{Call: _e.mock.On("GetMetrics",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -1863,9 +1863,9 @@ type MockDataCoordClient_GetPartitionStatistics_Call struct {
 }
 
 // GetPartitionStatistics is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.GetPartitionStatisticsRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.GetPartitionStatisticsRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GetPartitionStatistics(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GetPartitionStatistics_Call {
 	return &MockDataCoordClient_GetPartitionStatistics_Call{Call: _e.mock.On("GetPartitionStatistics",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -1933,9 +1933,9 @@ type MockDataCoordClient_GetRecoveryInfo_Call struct {
 }
 
 // GetRecoveryInfo is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.GetRecoveryInfoRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.GetRecoveryInfoRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GetRecoveryInfo(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GetRecoveryInfo_Call {
 	return &MockDataCoordClient_GetRecoveryInfo_Call{Call: _e.mock.On("GetRecoveryInfo",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -2003,9 +2003,9 @@ type MockDataCoordClient_GetRecoveryInfoV2_Call struct {
 }
 
 // GetRecoveryInfoV2 is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.GetRecoveryInfoRequestV2
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.GetRecoveryInfoRequestV2
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GetRecoveryInfoV2(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GetRecoveryInfoV2_Call {
 	return &MockDataCoordClient_GetRecoveryInfoV2_Call{Call: _e.mock.On("GetRecoveryInfoV2",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -2073,9 +2073,9 @@ type MockDataCoordClient_GetSegmentIndexState_Call struct {
 }
 
 // GetSegmentIndexState is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *indexpb.GetSegmentIndexStateRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *indexpb.GetSegmentIndexStateRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GetSegmentIndexState(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GetSegmentIndexState_Call {
 	return &MockDataCoordClient_GetSegmentIndexState_Call{Call: _e.mock.On("GetSegmentIndexState",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -2143,9 +2143,9 @@ type MockDataCoordClient_GetSegmentInfo_Call struct {
 }
 
 // GetSegmentInfo is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.GetSegmentInfoRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.GetSegmentInfoRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GetSegmentInfo(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GetSegmentInfo_Call {
 	return &MockDataCoordClient_GetSegmentInfo_Call{Call: _e.mock.On("GetSegmentInfo",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -2213,9 +2213,9 @@ type MockDataCoordClient_GetSegmentInfoChannel_Call struct {
 }
 
 // GetSegmentInfoChannel is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.GetSegmentInfoChannelRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.GetSegmentInfoChannelRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GetSegmentInfoChannel(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GetSegmentInfoChannel_Call {
 	return &MockDataCoordClient_GetSegmentInfoChannel_Call{Call: _e.mock.On("GetSegmentInfoChannel",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -2283,9 +2283,9 @@ type MockDataCoordClient_GetSegmentStates_Call struct {
 }
 
 // GetSegmentStates is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.GetSegmentStatesRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.GetSegmentStatesRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GetSegmentStates(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GetSegmentStates_Call {
 	return &MockDataCoordClient_GetSegmentStates_Call{Call: _e.mock.On("GetSegmentStates",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -2353,9 +2353,9 @@ type MockDataCoordClient_GetSegmentsByStates_Call struct {
 }
 
 // GetSegmentsByStates is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.GetSegmentsByStatesRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.GetSegmentsByStatesRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GetSegmentsByStates(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GetSegmentsByStates_Call {
 	return &MockDataCoordClient_GetSegmentsByStates_Call{Call: _e.mock.On("GetSegmentsByStates",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -2423,9 +2423,9 @@ type MockDataCoordClient_GetStatisticsChannel_Call struct {
 }
 
 // GetStatisticsChannel is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *internalpb.GetStatisticsChannelRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *internalpb.GetStatisticsChannelRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GetStatisticsChannel(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GetStatisticsChannel_Call {
 	return &MockDataCoordClient_GetStatisticsChannel_Call{Call: _e.mock.On("GetStatisticsChannel",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -2493,9 +2493,9 @@ type MockDataCoordClient_GetTimeTickChannel_Call struct {
 }
 
 // GetTimeTickChannel is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *internalpb.GetTimeTickChannelRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *internalpb.GetTimeTickChannelRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GetTimeTickChannel(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GetTimeTickChannel_Call {
 	return &MockDataCoordClient_GetTimeTickChannel_Call{Call: _e.mock.On("GetTimeTickChannel",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -2563,9 +2563,9 @@ type MockDataCoordClient_Import_Call struct {
 }
 
 // Import is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.ImportTaskRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.ImportTaskRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) Import(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_Import_Call {
 	return &MockDataCoordClient_Import_Call{Call: _e.mock.On("Import",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -2633,9 +2633,9 @@ type MockDataCoordClient_ImportV2_Call struct {
 }
 
 // ImportV2 is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *internalpb.ImportRequestInternal
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *internalpb.ImportRequestInternal
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) ImportV2(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_ImportV2_Call {
 	return &MockDataCoordClient_ImportV2_Call{Call: _e.mock.On("ImportV2",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -2703,9 +2703,9 @@ type MockDataCoordClient_ListImports_Call struct {
 }
 
 // ListImports is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *internalpb.ListImportsRequestInternal
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *internalpb.ListImportsRequestInternal
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) ListImports(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_ListImports_Call {
 	return &MockDataCoordClient_ListImports_Call{Call: _e.mock.On("ListImports",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -2773,9 +2773,9 @@ type MockDataCoordClient_ManualCompaction_Call struct {
 }
 
 // ManualCompaction is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *milvuspb.ManualCompactionRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *milvuspb.ManualCompactionRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) ManualCompaction(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_ManualCompaction_Call {
 	return &MockDataCoordClient_ManualCompaction_Call{Call: _e.mock.On("ManualCompaction",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -2843,9 +2843,9 @@ type MockDataCoordClient_MarkSegmentsDropped_Call struct {
 }
 
 // MarkSegmentsDropped is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.MarkSegmentsDroppedRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.MarkSegmentsDroppedRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) MarkSegmentsDropped(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_MarkSegmentsDropped_Call {
 	return &MockDataCoordClient_MarkSegmentsDropped_Call{Call: _e.mock.On("MarkSegmentsDropped",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -2913,9 +2913,9 @@ type MockDataCoordClient_ReportDataNodeTtMsgs_Call struct {
 }
 
 // ReportDataNodeTtMsgs is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.ReportDataNodeTtMsgsRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.ReportDataNodeTtMsgsRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) ReportDataNodeTtMsgs(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_ReportDataNodeTtMsgs_Call {
 	return &MockDataCoordClient_ReportDataNodeTtMsgs_Call{Call: _e.mock.On("ReportDataNodeTtMsgs",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -2983,9 +2983,9 @@ type MockDataCoordClient_SaveBinlogPaths_Call struct {
 }
 
 // SaveBinlogPaths is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.SaveBinlogPathsRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.SaveBinlogPathsRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) SaveBinlogPaths(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_SaveBinlogPaths_Call {
 	return &MockDataCoordClient_SaveBinlogPaths_Call{Call: _e.mock.On("SaveBinlogPaths",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -3053,9 +3053,9 @@ type MockDataCoordClient_SaveImportSegment_Call struct {
 }
 
 // SaveImportSegment is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.SaveImportSegmentRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.SaveImportSegmentRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) SaveImportSegment(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_SaveImportSegment_Call {
 	return &MockDataCoordClient_SaveImportSegment_Call{Call: _e.mock.On("SaveImportSegment",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -3123,9 +3123,9 @@ type MockDataCoordClient_SetSegmentState_Call struct {
 }
 
 // SetSegmentState is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.SetSegmentStateRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.SetSegmentStateRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) SetSegmentState(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_SetSegmentState_Call {
 	return &MockDataCoordClient_SetSegmentState_Call{Call: _e.mock.On("SetSegmentState",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -3193,9 +3193,9 @@ type MockDataCoordClient_ShowConfigurations_Call struct {
 }
 
 // ShowConfigurations is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *internalpb.ShowConfigurationsRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *internalpb.ShowConfigurationsRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) ShowConfigurations(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_ShowConfigurations_Call {
 	return &MockDataCoordClient_ShowConfigurations_Call{Call: _e.mock.On("ShowConfigurations",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -3263,9 +3263,9 @@ type MockDataCoordClient_UnsetIsImportingState_Call struct {
 }
 
 // UnsetIsImportingState is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.UnsetIsImportingStateRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.UnsetIsImportingStateRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) UnsetIsImportingState(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_UnsetIsImportingState_Call {
 	return &MockDataCoordClient_UnsetIsImportingState_Call{Call: _e.mock.On("UnsetIsImportingState",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -3333,9 +3333,9 @@ type MockDataCoordClient_UpdateChannelCheckpoint_Call struct {
 }
 
 // UpdateChannelCheckpoint is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.UpdateChannelCheckpointRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.UpdateChannelCheckpointRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) UpdateChannelCheckpoint(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_UpdateChannelCheckpoint_Call {
 	return &MockDataCoordClient_UpdateChannelCheckpoint_Call{Call: _e.mock.On("UpdateChannelCheckpoint",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -3403,9 +3403,9 @@ type MockDataCoordClient_UpdateSegmentStatistics_Call struct {
 }
 
 // UpdateSegmentStatistics is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.UpdateSegmentStatisticsRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.UpdateSegmentStatisticsRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) UpdateSegmentStatistics(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_UpdateSegmentStatistics_Call {
 	return &MockDataCoordClient_UpdateSegmentStatistics_Call{Call: _e.mock.On("UpdateSegmentStatistics",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -3473,9 +3473,9 @@ type MockDataCoordClient_WatchChannels_Call struct {
 }
 
 // WatchChannels is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.WatchChannelsRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.WatchChannelsRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) WatchChannels(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_WatchChannels_Call {
 	return &MockDataCoordClient_WatchChannels_Call{Call: _e.mock.On("WatchChannels",
 		append([]interface{}{ctx, in}, opts...)...)}

--- a/internal/mocks/mock_proxy.go
+++ b/internal/mocks/mock_proxy.go
@@ -66,8 +66,8 @@ type MockProxy_AllocTimestamp_Call struct {
 }
 
 // AllocTimestamp is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.AllocTimestampRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.AllocTimestampRequest
 func (_e *MockProxy_Expecter) AllocTimestamp(_a0 interface{}, _a1 interface{}) *MockProxy_AllocTimestamp_Call {
 	return &MockProxy_AllocTimestamp_Call{Call: _e.mock.On("AllocTimestamp", _a0, _a1)}
 }
@@ -121,8 +121,8 @@ type MockProxy_AlterAlias_Call struct {
 }
 
 // AlterAlias is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.AlterAliasRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.AlterAliasRequest
 func (_e *MockProxy_Expecter) AlterAlias(_a0 interface{}, _a1 interface{}) *MockProxy_AlterAlias_Call {
 	return &MockProxy_AlterAlias_Call{Call: _e.mock.On("AlterAlias", _a0, _a1)}
 }
@@ -176,8 +176,8 @@ type MockProxy_AlterCollection_Call struct {
 }
 
 // AlterCollection is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.AlterCollectionRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.AlterCollectionRequest
 func (_e *MockProxy_Expecter) AlterCollection(_a0 interface{}, _a1 interface{}) *MockProxy_AlterCollection_Call {
 	return &MockProxy_AlterCollection_Call{Call: _e.mock.On("AlterCollection", _a0, _a1)}
 }
@@ -231,8 +231,8 @@ type MockProxy_AlterIndex_Call struct {
 }
 
 // AlterIndex is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.AlterIndexRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.AlterIndexRequest
 func (_e *MockProxy_Expecter) AlterIndex(_a0 interface{}, _a1 interface{}) *MockProxy_AlterIndex_Call {
 	return &MockProxy_AlterIndex_Call{Call: _e.mock.On("AlterIndex", _a0, _a1)}
 }
@@ -286,8 +286,8 @@ type MockProxy_CalcDistance_Call struct {
 }
 
 // CalcDistance is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.CalcDistanceRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.CalcDistanceRequest
 func (_e *MockProxy_Expecter) CalcDistance(_a0 interface{}, _a1 interface{}) *MockProxy_CalcDistance_Call {
 	return &MockProxy_CalcDistance_Call{Call: _e.mock.On("CalcDistance", _a0, _a1)}
 }
@@ -341,8 +341,8 @@ type MockProxy_CheckHealth_Call struct {
 }
 
 // CheckHealth is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.CheckHealthRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.CheckHealthRequest
 func (_e *MockProxy_Expecter) CheckHealth(_a0 interface{}, _a1 interface{}) *MockProxy_CheckHealth_Call {
 	return &MockProxy_CheckHealth_Call{Call: _e.mock.On("CheckHealth", _a0, _a1)}
 }
@@ -396,8 +396,8 @@ type MockProxy_Connect_Call struct {
 }
 
 // Connect is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.ConnectRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.ConnectRequest
 func (_e *MockProxy_Expecter) Connect(_a0 interface{}, _a1 interface{}) *MockProxy_Connect_Call {
 	return &MockProxy_Connect_Call{Call: _e.mock.On("Connect", _a0, _a1)}
 }
@@ -451,8 +451,8 @@ type MockProxy_CreateAlias_Call struct {
 }
 
 // CreateAlias is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.CreateAliasRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.CreateAliasRequest
 func (_e *MockProxy_Expecter) CreateAlias(_a0 interface{}, _a1 interface{}) *MockProxy_CreateAlias_Call {
 	return &MockProxy_CreateAlias_Call{Call: _e.mock.On("CreateAlias", _a0, _a1)}
 }
@@ -506,8 +506,8 @@ type MockProxy_CreateCollection_Call struct {
 }
 
 // CreateCollection is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.CreateCollectionRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.CreateCollectionRequest
 func (_e *MockProxy_Expecter) CreateCollection(_a0 interface{}, _a1 interface{}) *MockProxy_CreateCollection_Call {
 	return &MockProxy_CreateCollection_Call{Call: _e.mock.On("CreateCollection", _a0, _a1)}
 }
@@ -561,8 +561,8 @@ type MockProxy_CreateCredential_Call struct {
 }
 
 // CreateCredential is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.CreateCredentialRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.CreateCredentialRequest
 func (_e *MockProxy_Expecter) CreateCredential(_a0 interface{}, _a1 interface{}) *MockProxy_CreateCredential_Call {
 	return &MockProxy_CreateCredential_Call{Call: _e.mock.On("CreateCredential", _a0, _a1)}
 }
@@ -616,8 +616,8 @@ type MockProxy_CreateDatabase_Call struct {
 }
 
 // CreateDatabase is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.CreateDatabaseRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.CreateDatabaseRequest
 func (_e *MockProxy_Expecter) CreateDatabase(_a0 interface{}, _a1 interface{}) *MockProxy_CreateDatabase_Call {
 	return &MockProxy_CreateDatabase_Call{Call: _e.mock.On("CreateDatabase", _a0, _a1)}
 }
@@ -671,8 +671,8 @@ type MockProxy_CreateIndex_Call struct {
 }
 
 // CreateIndex is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.CreateIndexRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.CreateIndexRequest
 func (_e *MockProxy_Expecter) CreateIndex(_a0 interface{}, _a1 interface{}) *MockProxy_CreateIndex_Call {
 	return &MockProxy_CreateIndex_Call{Call: _e.mock.On("CreateIndex", _a0, _a1)}
 }
@@ -726,8 +726,8 @@ type MockProxy_CreatePartition_Call struct {
 }
 
 // CreatePartition is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.CreatePartitionRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.CreatePartitionRequest
 func (_e *MockProxy_Expecter) CreatePartition(_a0 interface{}, _a1 interface{}) *MockProxy_CreatePartition_Call {
 	return &MockProxy_CreatePartition_Call{Call: _e.mock.On("CreatePartition", _a0, _a1)}
 }
@@ -781,8 +781,8 @@ type MockProxy_CreateResourceGroup_Call struct {
 }
 
 // CreateResourceGroup is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.CreateResourceGroupRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.CreateResourceGroupRequest
 func (_e *MockProxy_Expecter) CreateResourceGroup(_a0 interface{}, _a1 interface{}) *MockProxy_CreateResourceGroup_Call {
 	return &MockProxy_CreateResourceGroup_Call{Call: _e.mock.On("CreateResourceGroup", _a0, _a1)}
 }
@@ -836,8 +836,8 @@ type MockProxy_CreateRole_Call struct {
 }
 
 // CreateRole is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.CreateRoleRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.CreateRoleRequest
 func (_e *MockProxy_Expecter) CreateRole(_a0 interface{}, _a1 interface{}) *MockProxy_CreateRole_Call {
 	return &MockProxy_CreateRole_Call{Call: _e.mock.On("CreateRole", _a0, _a1)}
 }
@@ -891,8 +891,8 @@ type MockProxy_Delete_Call struct {
 }
 
 // Delete is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.DeleteRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.DeleteRequest
 func (_e *MockProxy_Expecter) Delete(_a0 interface{}, _a1 interface{}) *MockProxy_Delete_Call {
 	return &MockProxy_Delete_Call{Call: _e.mock.On("Delete", _a0, _a1)}
 }
@@ -946,8 +946,8 @@ type MockProxy_DeleteCredential_Call struct {
 }
 
 // DeleteCredential is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.DeleteCredentialRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.DeleteCredentialRequest
 func (_e *MockProxy_Expecter) DeleteCredential(_a0 interface{}, _a1 interface{}) *MockProxy_DeleteCredential_Call {
 	return &MockProxy_DeleteCredential_Call{Call: _e.mock.On("DeleteCredential", _a0, _a1)}
 }
@@ -1001,8 +1001,8 @@ type MockProxy_DescribeAlias_Call struct {
 }
 
 // DescribeAlias is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.DescribeAliasRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.DescribeAliasRequest
 func (_e *MockProxy_Expecter) DescribeAlias(_a0 interface{}, _a1 interface{}) *MockProxy_DescribeAlias_Call {
 	return &MockProxy_DescribeAlias_Call{Call: _e.mock.On("DescribeAlias", _a0, _a1)}
 }
@@ -1056,8 +1056,8 @@ type MockProxy_DescribeCollection_Call struct {
 }
 
 // DescribeCollection is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.DescribeCollectionRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.DescribeCollectionRequest
 func (_e *MockProxy_Expecter) DescribeCollection(_a0 interface{}, _a1 interface{}) *MockProxy_DescribeCollection_Call {
 	return &MockProxy_DescribeCollection_Call{Call: _e.mock.On("DescribeCollection", _a0, _a1)}
 }
@@ -1111,8 +1111,8 @@ type MockProxy_DescribeIndex_Call struct {
 }
 
 // DescribeIndex is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.DescribeIndexRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.DescribeIndexRequest
 func (_e *MockProxy_Expecter) DescribeIndex(_a0 interface{}, _a1 interface{}) *MockProxy_DescribeIndex_Call {
 	return &MockProxy_DescribeIndex_Call{Call: _e.mock.On("DescribeIndex", _a0, _a1)}
 }
@@ -1166,8 +1166,8 @@ type MockProxy_DescribeResourceGroup_Call struct {
 }
 
 // DescribeResourceGroup is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.DescribeResourceGroupRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.DescribeResourceGroupRequest
 func (_e *MockProxy_Expecter) DescribeResourceGroup(_a0 interface{}, _a1 interface{}) *MockProxy_DescribeResourceGroup_Call {
 	return &MockProxy_DescribeResourceGroup_Call{Call: _e.mock.On("DescribeResourceGroup", _a0, _a1)}
 }
@@ -1221,8 +1221,8 @@ type MockProxy_DescribeSegmentIndexData_Call struct {
 }
 
 // DescribeSegmentIndexData is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *federpb.DescribeSegmentIndexDataRequest
+//   - _a0 context.Context
+//   - _a1 *federpb.DescribeSegmentIndexDataRequest
 func (_e *MockProxy_Expecter) DescribeSegmentIndexData(_a0 interface{}, _a1 interface{}) *MockProxy_DescribeSegmentIndexData_Call {
 	return &MockProxy_DescribeSegmentIndexData_Call{Call: _e.mock.On("DescribeSegmentIndexData", _a0, _a1)}
 }
@@ -1276,8 +1276,8 @@ type MockProxy_DropAlias_Call struct {
 }
 
 // DropAlias is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.DropAliasRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.DropAliasRequest
 func (_e *MockProxy_Expecter) DropAlias(_a0 interface{}, _a1 interface{}) *MockProxy_DropAlias_Call {
 	return &MockProxy_DropAlias_Call{Call: _e.mock.On("DropAlias", _a0, _a1)}
 }
@@ -1331,8 +1331,8 @@ type MockProxy_DropCollection_Call struct {
 }
 
 // DropCollection is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.DropCollectionRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.DropCollectionRequest
 func (_e *MockProxy_Expecter) DropCollection(_a0 interface{}, _a1 interface{}) *MockProxy_DropCollection_Call {
 	return &MockProxy_DropCollection_Call{Call: _e.mock.On("DropCollection", _a0, _a1)}
 }
@@ -1386,8 +1386,8 @@ type MockProxy_DropDatabase_Call struct {
 }
 
 // DropDatabase is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.DropDatabaseRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.DropDatabaseRequest
 func (_e *MockProxy_Expecter) DropDatabase(_a0 interface{}, _a1 interface{}) *MockProxy_DropDatabase_Call {
 	return &MockProxy_DropDatabase_Call{Call: _e.mock.On("DropDatabase", _a0, _a1)}
 }
@@ -1441,8 +1441,8 @@ type MockProxy_DropIndex_Call struct {
 }
 
 // DropIndex is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.DropIndexRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.DropIndexRequest
 func (_e *MockProxy_Expecter) DropIndex(_a0 interface{}, _a1 interface{}) *MockProxy_DropIndex_Call {
 	return &MockProxy_DropIndex_Call{Call: _e.mock.On("DropIndex", _a0, _a1)}
 }
@@ -1496,8 +1496,8 @@ type MockProxy_DropPartition_Call struct {
 }
 
 // DropPartition is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.DropPartitionRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.DropPartitionRequest
 func (_e *MockProxy_Expecter) DropPartition(_a0 interface{}, _a1 interface{}) *MockProxy_DropPartition_Call {
 	return &MockProxy_DropPartition_Call{Call: _e.mock.On("DropPartition", _a0, _a1)}
 }
@@ -1551,8 +1551,8 @@ type MockProxy_DropResourceGroup_Call struct {
 }
 
 // DropResourceGroup is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.DropResourceGroupRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.DropResourceGroupRequest
 func (_e *MockProxy_Expecter) DropResourceGroup(_a0 interface{}, _a1 interface{}) *MockProxy_DropResourceGroup_Call {
 	return &MockProxy_DropResourceGroup_Call{Call: _e.mock.On("DropResourceGroup", _a0, _a1)}
 }
@@ -1606,8 +1606,8 @@ type MockProxy_DropRole_Call struct {
 }
 
 // DropRole is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.DropRoleRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.DropRoleRequest
 func (_e *MockProxy_Expecter) DropRole(_a0 interface{}, _a1 interface{}) *MockProxy_DropRole_Call {
 	return &MockProxy_DropRole_Call{Call: _e.mock.On("DropRole", _a0, _a1)}
 }
@@ -1661,8 +1661,8 @@ type MockProxy_Dummy_Call struct {
 }
 
 // Dummy is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.DummyRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.DummyRequest
 func (_e *MockProxy_Expecter) Dummy(_a0 interface{}, _a1 interface{}) *MockProxy_Dummy_Call {
 	return &MockProxy_Dummy_Call{Call: _e.mock.On("Dummy", _a0, _a1)}
 }
@@ -1716,8 +1716,8 @@ type MockProxy_Flush_Call struct {
 }
 
 // Flush is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.FlushRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.FlushRequest
 func (_e *MockProxy_Expecter) Flush(_a0 interface{}, _a1 interface{}) *MockProxy_Flush_Call {
 	return &MockProxy_Flush_Call{Call: _e.mock.On("Flush", _a0, _a1)}
 }
@@ -1771,8 +1771,8 @@ type MockProxy_FlushAll_Call struct {
 }
 
 // FlushAll is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.FlushAllRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.FlushAllRequest
 func (_e *MockProxy_Expecter) FlushAll(_a0 interface{}, _a1 interface{}) *MockProxy_FlushAll_Call {
 	return &MockProxy_FlushAll_Call{Call: _e.mock.On("FlushAll", _a0, _a1)}
 }
@@ -1867,8 +1867,8 @@ type MockProxy_GetCollectionStatistics_Call struct {
 }
 
 // GetCollectionStatistics is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.GetCollectionStatisticsRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.GetCollectionStatisticsRequest
 func (_e *MockProxy_Expecter) GetCollectionStatistics(_a0 interface{}, _a1 interface{}) *MockProxy_GetCollectionStatistics_Call {
 	return &MockProxy_GetCollectionStatistics_Call{Call: _e.mock.On("GetCollectionStatistics", _a0, _a1)}
 }
@@ -1922,8 +1922,8 @@ type MockProxy_GetCompactionState_Call struct {
 }
 
 // GetCompactionState is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.GetCompactionStateRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.GetCompactionStateRequest
 func (_e *MockProxy_Expecter) GetCompactionState(_a0 interface{}, _a1 interface{}) *MockProxy_GetCompactionState_Call {
 	return &MockProxy_GetCompactionState_Call{Call: _e.mock.On("GetCompactionState", _a0, _a1)}
 }
@@ -1977,8 +1977,8 @@ type MockProxy_GetCompactionStateWithPlans_Call struct {
 }
 
 // GetCompactionStateWithPlans is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.GetCompactionPlansRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.GetCompactionPlansRequest
 func (_e *MockProxy_Expecter) GetCompactionStateWithPlans(_a0 interface{}, _a1 interface{}) *MockProxy_GetCompactionStateWithPlans_Call {
 	return &MockProxy_GetCompactionStateWithPlans_Call{Call: _e.mock.On("GetCompactionStateWithPlans", _a0, _a1)}
 }
@@ -2032,8 +2032,8 @@ type MockProxy_GetComponentStates_Call struct {
 }
 
 // GetComponentStates is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.GetComponentStatesRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.GetComponentStatesRequest
 func (_e *MockProxy_Expecter) GetComponentStates(_a0 interface{}, _a1 interface{}) *MockProxy_GetComponentStates_Call {
 	return &MockProxy_GetComponentStates_Call{Call: _e.mock.On("GetComponentStates", _a0, _a1)}
 }
@@ -2087,8 +2087,8 @@ type MockProxy_GetDdChannel_Call struct {
 }
 
 // GetDdChannel is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *internalpb.GetDdChannelRequest
+//   - _a0 context.Context
+//   - _a1 *internalpb.GetDdChannelRequest
 func (_e *MockProxy_Expecter) GetDdChannel(_a0 interface{}, _a1 interface{}) *MockProxy_GetDdChannel_Call {
 	return &MockProxy_GetDdChannel_Call{Call: _e.mock.On("GetDdChannel", _a0, _a1)}
 }
@@ -2142,8 +2142,8 @@ type MockProxy_GetFlushAllState_Call struct {
 }
 
 // GetFlushAllState is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.GetFlushAllStateRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.GetFlushAllStateRequest
 func (_e *MockProxy_Expecter) GetFlushAllState(_a0 interface{}, _a1 interface{}) *MockProxy_GetFlushAllState_Call {
 	return &MockProxy_GetFlushAllState_Call{Call: _e.mock.On("GetFlushAllState", _a0, _a1)}
 }
@@ -2197,8 +2197,8 @@ type MockProxy_GetFlushState_Call struct {
 }
 
 // GetFlushState is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.GetFlushStateRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.GetFlushStateRequest
 func (_e *MockProxy_Expecter) GetFlushState(_a0 interface{}, _a1 interface{}) *MockProxy_GetFlushState_Call {
 	return &MockProxy_GetFlushState_Call{Call: _e.mock.On("GetFlushState", _a0, _a1)}
 }
@@ -2252,8 +2252,8 @@ type MockProxy_GetImportProgress_Call struct {
 }
 
 // GetImportProgress is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *internalpb.GetImportProgressRequest
+//   - _a0 context.Context
+//   - _a1 *internalpb.GetImportProgressRequest
 func (_e *MockProxy_Expecter) GetImportProgress(_a0 interface{}, _a1 interface{}) *MockProxy_GetImportProgress_Call {
 	return &MockProxy_GetImportProgress_Call{Call: _e.mock.On("GetImportProgress", _a0, _a1)}
 }
@@ -2307,8 +2307,8 @@ type MockProxy_GetImportState_Call struct {
 }
 
 // GetImportState is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.GetImportStateRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.GetImportStateRequest
 func (_e *MockProxy_Expecter) GetImportState(_a0 interface{}, _a1 interface{}) *MockProxy_GetImportState_Call {
 	return &MockProxy_GetImportState_Call{Call: _e.mock.On("GetImportState", _a0, _a1)}
 }
@@ -2362,8 +2362,8 @@ type MockProxy_GetIndexBuildProgress_Call struct {
 }
 
 // GetIndexBuildProgress is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.GetIndexBuildProgressRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.GetIndexBuildProgressRequest
 func (_e *MockProxy_Expecter) GetIndexBuildProgress(_a0 interface{}, _a1 interface{}) *MockProxy_GetIndexBuildProgress_Call {
 	return &MockProxy_GetIndexBuildProgress_Call{Call: _e.mock.On("GetIndexBuildProgress", _a0, _a1)}
 }
@@ -2417,8 +2417,8 @@ type MockProxy_GetIndexState_Call struct {
 }
 
 // GetIndexState is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.GetIndexStateRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.GetIndexStateRequest
 func (_e *MockProxy_Expecter) GetIndexState(_a0 interface{}, _a1 interface{}) *MockProxy_GetIndexState_Call {
 	return &MockProxy_GetIndexState_Call{Call: _e.mock.On("GetIndexState", _a0, _a1)}
 }
@@ -2472,8 +2472,8 @@ type MockProxy_GetIndexStatistics_Call struct {
 }
 
 // GetIndexStatistics is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.GetIndexStatisticsRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.GetIndexStatisticsRequest
 func (_e *MockProxy_Expecter) GetIndexStatistics(_a0 interface{}, _a1 interface{}) *MockProxy_GetIndexStatistics_Call {
 	return &MockProxy_GetIndexStatistics_Call{Call: _e.mock.On("GetIndexStatistics", _a0, _a1)}
 }
@@ -2527,8 +2527,8 @@ type MockProxy_GetLoadState_Call struct {
 }
 
 // GetLoadState is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.GetLoadStateRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.GetLoadStateRequest
 func (_e *MockProxy_Expecter) GetLoadState(_a0 interface{}, _a1 interface{}) *MockProxy_GetLoadState_Call {
 	return &MockProxy_GetLoadState_Call{Call: _e.mock.On("GetLoadState", _a0, _a1)}
 }
@@ -2582,8 +2582,8 @@ type MockProxy_GetLoadingProgress_Call struct {
 }
 
 // GetLoadingProgress is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.GetLoadingProgressRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.GetLoadingProgressRequest
 func (_e *MockProxy_Expecter) GetLoadingProgress(_a0 interface{}, _a1 interface{}) *MockProxy_GetLoadingProgress_Call {
 	return &MockProxy_GetLoadingProgress_Call{Call: _e.mock.On("GetLoadingProgress", _a0, _a1)}
 }
@@ -2637,8 +2637,8 @@ type MockProxy_GetMetrics_Call struct {
 }
 
 // GetMetrics is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.GetMetricsRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.GetMetricsRequest
 func (_e *MockProxy_Expecter) GetMetrics(_a0 interface{}, _a1 interface{}) *MockProxy_GetMetrics_Call {
 	return &MockProxy_GetMetrics_Call{Call: _e.mock.On("GetMetrics", _a0, _a1)}
 }
@@ -2692,8 +2692,8 @@ type MockProxy_GetPartitionStatistics_Call struct {
 }
 
 // GetPartitionStatistics is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.GetPartitionStatisticsRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.GetPartitionStatisticsRequest
 func (_e *MockProxy_Expecter) GetPartitionStatistics(_a0 interface{}, _a1 interface{}) *MockProxy_GetPartitionStatistics_Call {
 	return &MockProxy_GetPartitionStatistics_Call{Call: _e.mock.On("GetPartitionStatistics", _a0, _a1)}
 }
@@ -2747,8 +2747,8 @@ type MockProxy_GetPersistentSegmentInfo_Call struct {
 }
 
 // GetPersistentSegmentInfo is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.GetPersistentSegmentInfoRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.GetPersistentSegmentInfoRequest
 func (_e *MockProxy_Expecter) GetPersistentSegmentInfo(_a0 interface{}, _a1 interface{}) *MockProxy_GetPersistentSegmentInfo_Call {
 	return &MockProxy_GetPersistentSegmentInfo_Call{Call: _e.mock.On("GetPersistentSegmentInfo", _a0, _a1)}
 }
@@ -2802,8 +2802,8 @@ type MockProxy_GetProxyMetrics_Call struct {
 }
 
 // GetProxyMetrics is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.GetMetricsRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.GetMetricsRequest
 func (_e *MockProxy_Expecter) GetProxyMetrics(_a0 interface{}, _a1 interface{}) *MockProxy_GetProxyMetrics_Call {
 	return &MockProxy_GetProxyMetrics_Call{Call: _e.mock.On("GetProxyMetrics", _a0, _a1)}
 }
@@ -2857,8 +2857,8 @@ type MockProxy_GetQuerySegmentInfo_Call struct {
 }
 
 // GetQuerySegmentInfo is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.GetQuerySegmentInfoRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.GetQuerySegmentInfoRequest
 func (_e *MockProxy_Expecter) GetQuerySegmentInfo(_a0 interface{}, _a1 interface{}) *MockProxy_GetQuerySegmentInfo_Call {
 	return &MockProxy_GetQuerySegmentInfo_Call{Call: _e.mock.On("GetQuerySegmentInfo", _a0, _a1)}
 }
@@ -2965,8 +2965,8 @@ type MockProxy_GetReplicas_Call struct {
 }
 
 // GetReplicas is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.GetReplicasRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.GetReplicasRequest
 func (_e *MockProxy_Expecter) GetReplicas(_a0 interface{}, _a1 interface{}) *MockProxy_GetReplicas_Call {
 	return &MockProxy_GetReplicas_Call{Call: _e.mock.On("GetReplicas", _a0, _a1)}
 }
@@ -3020,8 +3020,8 @@ type MockProxy_GetStatisticsChannel_Call struct {
 }
 
 // GetStatisticsChannel is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *internalpb.GetStatisticsChannelRequest
+//   - _a0 context.Context
+//   - _a1 *internalpb.GetStatisticsChannelRequest
 func (_e *MockProxy_Expecter) GetStatisticsChannel(_a0 interface{}, _a1 interface{}) *MockProxy_GetStatisticsChannel_Call {
 	return &MockProxy_GetStatisticsChannel_Call{Call: _e.mock.On("GetStatisticsChannel", _a0, _a1)}
 }
@@ -3075,8 +3075,8 @@ type MockProxy_GetVersion_Call struct {
 }
 
 // GetVersion is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.GetVersionRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.GetVersionRequest
 func (_e *MockProxy_Expecter) GetVersion(_a0 interface{}, _a1 interface{}) *MockProxy_GetVersion_Call {
 	return &MockProxy_GetVersion_Call{Call: _e.mock.On("GetVersion", _a0, _a1)}
 }
@@ -3130,8 +3130,8 @@ type MockProxy_HasCollection_Call struct {
 }
 
 // HasCollection is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.HasCollectionRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.HasCollectionRequest
 func (_e *MockProxy_Expecter) HasCollection(_a0 interface{}, _a1 interface{}) *MockProxy_HasCollection_Call {
 	return &MockProxy_HasCollection_Call{Call: _e.mock.On("HasCollection", _a0, _a1)}
 }
@@ -3185,8 +3185,8 @@ type MockProxy_HasPartition_Call struct {
 }
 
 // HasPartition is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.HasPartitionRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.HasPartitionRequest
 func (_e *MockProxy_Expecter) HasPartition(_a0 interface{}, _a1 interface{}) *MockProxy_HasPartition_Call {
 	return &MockProxy_HasPartition_Call{Call: _e.mock.On("HasPartition", _a0, _a1)}
 }
@@ -3240,8 +3240,8 @@ type MockProxy_HybridSearch_Call struct {
 }
 
 // HybridSearch is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.HybridSearchRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.HybridSearchRequest
 func (_e *MockProxy_Expecter) HybridSearch(_a0 interface{}, _a1 interface{}) *MockProxy_HybridSearch_Call {
 	return &MockProxy_HybridSearch_Call{Call: _e.mock.On("HybridSearch", _a0, _a1)}
 }
@@ -3295,8 +3295,8 @@ type MockProxy_Import_Call struct {
 }
 
 // Import is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.ImportRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.ImportRequest
 func (_e *MockProxy_Expecter) Import(_a0 interface{}, _a1 interface{}) *MockProxy_Import_Call {
 	return &MockProxy_Import_Call{Call: _e.mock.On("Import", _a0, _a1)}
 }
@@ -3350,8 +3350,8 @@ type MockProxy_ImportV2_Call struct {
 }
 
 // ImportV2 is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *internalpb.ImportRequest
+//   - _a0 context.Context
+//   - _a1 *internalpb.ImportRequest
 func (_e *MockProxy_Expecter) ImportV2(_a0 interface{}, _a1 interface{}) *MockProxy_ImportV2_Call {
 	return &MockProxy_ImportV2_Call{Call: _e.mock.On("ImportV2", _a0, _a1)}
 }
@@ -3446,8 +3446,8 @@ type MockProxy_Insert_Call struct {
 }
 
 // Insert is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.InsertRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.InsertRequest
 func (_e *MockProxy_Expecter) Insert(_a0 interface{}, _a1 interface{}) *MockProxy_Insert_Call {
 	return &MockProxy_Insert_Call{Call: _e.mock.On("Insert", _a0, _a1)}
 }
@@ -3501,8 +3501,8 @@ type MockProxy_InvalidateCollectionMetaCache_Call struct {
 }
 
 // InvalidateCollectionMetaCache is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *proxypb.InvalidateCollMetaCacheRequest
+//   - _a0 context.Context
+//   - _a1 *proxypb.InvalidateCollMetaCacheRequest
 func (_e *MockProxy_Expecter) InvalidateCollectionMetaCache(_a0 interface{}, _a1 interface{}) *MockProxy_InvalidateCollectionMetaCache_Call {
 	return &MockProxy_InvalidateCollectionMetaCache_Call{Call: _e.mock.On("InvalidateCollectionMetaCache", _a0, _a1)}
 }
@@ -3556,8 +3556,8 @@ type MockProxy_InvalidateCredentialCache_Call struct {
 }
 
 // InvalidateCredentialCache is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *proxypb.InvalidateCredCacheRequest
+//   - _a0 context.Context
+//   - _a1 *proxypb.InvalidateCredCacheRequest
 func (_e *MockProxy_Expecter) InvalidateCredentialCache(_a0 interface{}, _a1 interface{}) *MockProxy_InvalidateCredentialCache_Call {
 	return &MockProxy_InvalidateCredentialCache_Call{Call: _e.mock.On("InvalidateCredentialCache", _a0, _a1)}
 }
@@ -3611,8 +3611,8 @@ type MockProxy_ListAliases_Call struct {
 }
 
 // ListAliases is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.ListAliasesRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.ListAliasesRequest
 func (_e *MockProxy_Expecter) ListAliases(_a0 interface{}, _a1 interface{}) *MockProxy_ListAliases_Call {
 	return &MockProxy_ListAliases_Call{Call: _e.mock.On("ListAliases", _a0, _a1)}
 }
@@ -3666,8 +3666,8 @@ type MockProxy_ListClientInfos_Call struct {
 }
 
 // ListClientInfos is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *proxypb.ListClientInfosRequest
+//   - _a0 context.Context
+//   - _a1 *proxypb.ListClientInfosRequest
 func (_e *MockProxy_Expecter) ListClientInfos(_a0 interface{}, _a1 interface{}) *MockProxy_ListClientInfos_Call {
 	return &MockProxy_ListClientInfos_Call{Call: _e.mock.On("ListClientInfos", _a0, _a1)}
 }
@@ -3721,8 +3721,8 @@ type MockProxy_ListCredUsers_Call struct {
 }
 
 // ListCredUsers is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.ListCredUsersRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.ListCredUsersRequest
 func (_e *MockProxy_Expecter) ListCredUsers(_a0 interface{}, _a1 interface{}) *MockProxy_ListCredUsers_Call {
 	return &MockProxy_ListCredUsers_Call{Call: _e.mock.On("ListCredUsers", _a0, _a1)}
 }
@@ -3776,8 +3776,8 @@ type MockProxy_ListDatabases_Call struct {
 }
 
 // ListDatabases is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.ListDatabasesRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.ListDatabasesRequest
 func (_e *MockProxy_Expecter) ListDatabases(_a0 interface{}, _a1 interface{}) *MockProxy_ListDatabases_Call {
 	return &MockProxy_ListDatabases_Call{Call: _e.mock.On("ListDatabases", _a0, _a1)}
 }
@@ -3831,8 +3831,8 @@ type MockProxy_ListImportTasks_Call struct {
 }
 
 // ListImportTasks is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.ListImportTasksRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.ListImportTasksRequest
 func (_e *MockProxy_Expecter) ListImportTasks(_a0 interface{}, _a1 interface{}) *MockProxy_ListImportTasks_Call {
 	return &MockProxy_ListImportTasks_Call{Call: _e.mock.On("ListImportTasks", _a0, _a1)}
 }
@@ -3886,8 +3886,8 @@ type MockProxy_ListImports_Call struct {
 }
 
 // ListImports is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *internalpb.ListImportsRequest
+//   - _a0 context.Context
+//   - _a1 *internalpb.ListImportsRequest
 func (_e *MockProxy_Expecter) ListImports(_a0 interface{}, _a1 interface{}) *MockProxy_ListImports_Call {
 	return &MockProxy_ListImports_Call{Call: _e.mock.On("ListImports", _a0, _a1)}
 }
@@ -3941,8 +3941,8 @@ type MockProxy_ListIndexedSegment_Call struct {
 }
 
 // ListIndexedSegment is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *federpb.ListIndexedSegmentRequest
+//   - _a0 context.Context
+//   - _a1 *federpb.ListIndexedSegmentRequest
 func (_e *MockProxy_Expecter) ListIndexedSegment(_a0 interface{}, _a1 interface{}) *MockProxy_ListIndexedSegment_Call {
 	return &MockProxy_ListIndexedSegment_Call{Call: _e.mock.On("ListIndexedSegment", _a0, _a1)}
 }
@@ -3996,8 +3996,8 @@ type MockProxy_ListResourceGroups_Call struct {
 }
 
 // ListResourceGroups is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.ListResourceGroupsRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.ListResourceGroupsRequest
 func (_e *MockProxy_Expecter) ListResourceGroups(_a0 interface{}, _a1 interface{}) *MockProxy_ListResourceGroups_Call {
 	return &MockProxy_ListResourceGroups_Call{Call: _e.mock.On("ListResourceGroups", _a0, _a1)}
 }
@@ -4051,8 +4051,8 @@ type MockProxy_LoadBalance_Call struct {
 }
 
 // LoadBalance is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.LoadBalanceRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.LoadBalanceRequest
 func (_e *MockProxy_Expecter) LoadBalance(_a0 interface{}, _a1 interface{}) *MockProxy_LoadBalance_Call {
 	return &MockProxy_LoadBalance_Call{Call: _e.mock.On("LoadBalance", _a0, _a1)}
 }
@@ -4106,8 +4106,8 @@ type MockProxy_LoadCollection_Call struct {
 }
 
 // LoadCollection is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.LoadCollectionRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.LoadCollectionRequest
 func (_e *MockProxy_Expecter) LoadCollection(_a0 interface{}, _a1 interface{}) *MockProxy_LoadCollection_Call {
 	return &MockProxy_LoadCollection_Call{Call: _e.mock.On("LoadCollection", _a0, _a1)}
 }
@@ -4161,8 +4161,8 @@ type MockProxy_LoadPartitions_Call struct {
 }
 
 // LoadPartitions is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.LoadPartitionsRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.LoadPartitionsRequest
 func (_e *MockProxy_Expecter) LoadPartitions(_a0 interface{}, _a1 interface{}) *MockProxy_LoadPartitions_Call {
 	return &MockProxy_LoadPartitions_Call{Call: _e.mock.On("LoadPartitions", _a0, _a1)}
 }
@@ -4216,8 +4216,8 @@ type MockProxy_ManualCompaction_Call struct {
 }
 
 // ManualCompaction is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.ManualCompactionRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.ManualCompactionRequest
 func (_e *MockProxy_Expecter) ManualCompaction(_a0 interface{}, _a1 interface{}) *MockProxy_ManualCompaction_Call {
 	return &MockProxy_ManualCompaction_Call{Call: _e.mock.On("ManualCompaction", _a0, _a1)}
 }
@@ -4271,8 +4271,8 @@ type MockProxy_OperatePrivilege_Call struct {
 }
 
 // OperatePrivilege is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.OperatePrivilegeRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.OperatePrivilegeRequest
 func (_e *MockProxy_Expecter) OperatePrivilege(_a0 interface{}, _a1 interface{}) *MockProxy_OperatePrivilege_Call {
 	return &MockProxy_OperatePrivilege_Call{Call: _e.mock.On("OperatePrivilege", _a0, _a1)}
 }
@@ -4326,8 +4326,8 @@ type MockProxy_OperateUserRole_Call struct {
 }
 
 // OperateUserRole is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.OperateUserRoleRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.OperateUserRoleRequest
 func (_e *MockProxy_Expecter) OperateUserRole(_a0 interface{}, _a1 interface{}) *MockProxy_OperateUserRole_Call {
 	return &MockProxy_OperateUserRole_Call{Call: _e.mock.On("OperateUserRole", _a0, _a1)}
 }
@@ -4381,8 +4381,8 @@ type MockProxy_Query_Call struct {
 }
 
 // Query is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.QueryRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.QueryRequest
 func (_e *MockProxy_Expecter) Query(_a0 interface{}, _a1 interface{}) *MockProxy_Query_Call {
 	return &MockProxy_Query_Call{Call: _e.mock.On("Query", _a0, _a1)}
 }
@@ -4436,8 +4436,8 @@ type MockProxy_RefreshPolicyInfoCache_Call struct {
 }
 
 // RefreshPolicyInfoCache is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *proxypb.RefreshPolicyInfoCacheRequest
+//   - _a0 context.Context
+//   - _a1 *proxypb.RefreshPolicyInfoCacheRequest
 func (_e *MockProxy_Expecter) RefreshPolicyInfoCache(_a0 interface{}, _a1 interface{}) *MockProxy_RefreshPolicyInfoCache_Call {
 	return &MockProxy_RefreshPolicyInfoCache_Call{Call: _e.mock.On("RefreshPolicyInfoCache", _a0, _a1)}
 }
@@ -4532,8 +4532,8 @@ type MockProxy_RegisterLink_Call struct {
 }
 
 // RegisterLink is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.RegisterLinkRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.RegisterLinkRequest
 func (_e *MockProxy_Expecter) RegisterLink(_a0 interface{}, _a1 interface{}) *MockProxy_RegisterLink_Call {
 	return &MockProxy_RegisterLink_Call{Call: _e.mock.On("RegisterLink", _a0, _a1)}
 }
@@ -4587,8 +4587,8 @@ type MockProxy_ReleaseCollection_Call struct {
 }
 
 // ReleaseCollection is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.ReleaseCollectionRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.ReleaseCollectionRequest
 func (_e *MockProxy_Expecter) ReleaseCollection(_a0 interface{}, _a1 interface{}) *MockProxy_ReleaseCollection_Call {
 	return &MockProxy_ReleaseCollection_Call{Call: _e.mock.On("ReleaseCollection", _a0, _a1)}
 }
@@ -4642,8 +4642,8 @@ type MockProxy_ReleasePartitions_Call struct {
 }
 
 // ReleasePartitions is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.ReleasePartitionsRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.ReleasePartitionsRequest
 func (_e *MockProxy_Expecter) ReleasePartitions(_a0 interface{}, _a1 interface{}) *MockProxy_ReleasePartitions_Call {
 	return &MockProxy_ReleasePartitions_Call{Call: _e.mock.On("ReleasePartitions", _a0, _a1)}
 }
@@ -4697,8 +4697,8 @@ type MockProxy_RenameCollection_Call struct {
 }
 
 // RenameCollection is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.RenameCollectionRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.RenameCollectionRequest
 func (_e *MockProxy_Expecter) RenameCollection(_a0 interface{}, _a1 interface{}) *MockProxy_RenameCollection_Call {
 	return &MockProxy_RenameCollection_Call{Call: _e.mock.On("RenameCollection", _a0, _a1)}
 }
@@ -4752,8 +4752,8 @@ type MockProxy_ReplicateMessage_Call struct {
 }
 
 // ReplicateMessage is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.ReplicateMessageRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.ReplicateMessageRequest
 func (_e *MockProxy_Expecter) ReplicateMessage(_a0 interface{}, _a1 interface{}) *MockProxy_ReplicateMessage_Call {
 	return &MockProxy_ReplicateMessage_Call{Call: _e.mock.On("ReplicateMessage", _a0, _a1)}
 }
@@ -4807,8 +4807,8 @@ type MockProxy_Search_Call struct {
 }
 
 // Search is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.SearchRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.SearchRequest
 func (_e *MockProxy_Expecter) Search(_a0 interface{}, _a1 interface{}) *MockProxy_Search_Call {
 	return &MockProxy_Search_Call{Call: _e.mock.On("Search", _a0, _a1)}
 }
@@ -4862,8 +4862,8 @@ type MockProxy_SelectGrant_Call struct {
 }
 
 // SelectGrant is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.SelectGrantRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.SelectGrantRequest
 func (_e *MockProxy_Expecter) SelectGrant(_a0 interface{}, _a1 interface{}) *MockProxy_SelectGrant_Call {
 	return &MockProxy_SelectGrant_Call{Call: _e.mock.On("SelectGrant", _a0, _a1)}
 }
@@ -4917,8 +4917,8 @@ type MockProxy_SelectRole_Call struct {
 }
 
 // SelectRole is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.SelectRoleRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.SelectRoleRequest
 func (_e *MockProxy_Expecter) SelectRole(_a0 interface{}, _a1 interface{}) *MockProxy_SelectRole_Call {
 	return &MockProxy_SelectRole_Call{Call: _e.mock.On("SelectRole", _a0, _a1)}
 }
@@ -4972,8 +4972,8 @@ type MockProxy_SelectUser_Call struct {
 }
 
 // SelectUser is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.SelectUserRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.SelectUserRequest
 func (_e *MockProxy_Expecter) SelectUser(_a0 interface{}, _a1 interface{}) *MockProxy_SelectUser_Call {
 	return &MockProxy_SelectUser_Call{Call: _e.mock.On("SelectUser", _a0, _a1)}
 }
@@ -5006,7 +5006,7 @@ type MockProxy_SetAddress_Call struct {
 }
 
 // SetAddress is a helper method to define mock.On call
-//  - address string
+//   - address string
 func (_e *MockProxy_Expecter) SetAddress(address interface{}) *MockProxy_SetAddress_Call {
 	return &MockProxy_SetAddress_Call{Call: _e.mock.On("SetAddress", address)}
 }
@@ -5039,7 +5039,7 @@ type MockProxy_SetDataCoordClient_Call struct {
 }
 
 // SetDataCoordClient is a helper method to define mock.On call
-//  - dataCoord types.DataCoordClient
+//   - dataCoord types.DataCoordClient
 func (_e *MockProxy_Expecter) SetDataCoordClient(dataCoord interface{}) *MockProxy_SetDataCoordClient_Call {
 	return &MockProxy_SetDataCoordClient_Call{Call: _e.mock.On("SetDataCoordClient", dataCoord)}
 }
@@ -5072,7 +5072,7 @@ type MockProxy_SetEtcdClient_Call struct {
 }
 
 // SetEtcdClient is a helper method to define mock.On call
-//  - etcdClient *clientv3.Client
+//   - etcdClient *clientv3.Client
 func (_e *MockProxy_Expecter) SetEtcdClient(etcdClient interface{}) *MockProxy_SetEtcdClient_Call {
 	return &MockProxy_SetEtcdClient_Call{Call: _e.mock.On("SetEtcdClient", etcdClient)}
 }
@@ -5105,7 +5105,7 @@ type MockProxy_SetQueryCoordClient_Call struct {
 }
 
 // SetQueryCoordClient is a helper method to define mock.On call
-//  - queryCoord types.QueryCoordClient
+//   - queryCoord types.QueryCoordClient
 func (_e *MockProxy_Expecter) SetQueryCoordClient(queryCoord interface{}) *MockProxy_SetQueryCoordClient_Call {
 	return &MockProxy_SetQueryCoordClient_Call{Call: _e.mock.On("SetQueryCoordClient", queryCoord)}
 }
@@ -5138,7 +5138,7 @@ type MockProxy_SetQueryNodeCreator_Call struct {
 }
 
 // SetQueryNodeCreator is a helper method to define mock.On call
-//  - _a0 func(context.Context , string , int64)(types.QueryNodeClient , error)
+//   - _a0 func(context.Context , string , int64)(types.QueryNodeClient , error)
 func (_e *MockProxy_Expecter) SetQueryNodeCreator(_a0 interface{}) *MockProxy_SetQueryNodeCreator_Call {
 	return &MockProxy_SetQueryNodeCreator_Call{Call: _e.mock.On("SetQueryNodeCreator", _a0)}
 }
@@ -5192,8 +5192,8 @@ type MockProxy_SetRates_Call struct {
 }
 
 // SetRates is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *proxypb.SetRatesRequest
+//   - _a0 context.Context
+//   - _a1 *proxypb.SetRatesRequest
 func (_e *MockProxy_Expecter) SetRates(_a0 interface{}, _a1 interface{}) *MockProxy_SetRates_Call {
 	return &MockProxy_SetRates_Call{Call: _e.mock.On("SetRates", _a0, _a1)}
 }
@@ -5226,7 +5226,7 @@ type MockProxy_SetRootCoordClient_Call struct {
 }
 
 // SetRootCoordClient is a helper method to define mock.On call
-//  - rootCoord types.RootCoordClient
+//   - rootCoord types.RootCoordClient
 func (_e *MockProxy_Expecter) SetRootCoordClient(rootCoord interface{}) *MockProxy_SetRootCoordClient_Call {
 	return &MockProxy_SetRootCoordClient_Call{Call: _e.mock.On("SetRootCoordClient", rootCoord)}
 }
@@ -5280,8 +5280,8 @@ type MockProxy_ShowCollections_Call struct {
 }
 
 // ShowCollections is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.ShowCollectionsRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.ShowCollectionsRequest
 func (_e *MockProxy_Expecter) ShowCollections(_a0 interface{}, _a1 interface{}) *MockProxy_ShowCollections_Call {
 	return &MockProxy_ShowCollections_Call{Call: _e.mock.On("ShowCollections", _a0, _a1)}
 }
@@ -5335,8 +5335,8 @@ type MockProxy_ShowPartitions_Call struct {
 }
 
 // ShowPartitions is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.ShowPartitionsRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.ShowPartitionsRequest
 func (_e *MockProxy_Expecter) ShowPartitions(_a0 interface{}, _a1 interface{}) *MockProxy_ShowPartitions_Call {
 	return &MockProxy_ShowPartitions_Call{Call: _e.mock.On("ShowPartitions", _a0, _a1)}
 }
@@ -5472,8 +5472,8 @@ type MockProxy_TransferNode_Call struct {
 }
 
 // TransferNode is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.TransferNodeRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.TransferNodeRequest
 func (_e *MockProxy_Expecter) TransferNode(_a0 interface{}, _a1 interface{}) *MockProxy_TransferNode_Call {
 	return &MockProxy_TransferNode_Call{Call: _e.mock.On("TransferNode", _a0, _a1)}
 }
@@ -5527,8 +5527,8 @@ type MockProxy_TransferReplica_Call struct {
 }
 
 // TransferReplica is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.TransferReplicaRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.TransferReplicaRequest
 func (_e *MockProxy_Expecter) TransferReplica(_a0 interface{}, _a1 interface{}) *MockProxy_TransferReplica_Call {
 	return &MockProxy_TransferReplica_Call{Call: _e.mock.On("TransferReplica", _a0, _a1)}
 }
@@ -5582,8 +5582,8 @@ type MockProxy_UpdateCredential_Call struct {
 }
 
 // UpdateCredential is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.UpdateCredentialRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.UpdateCredentialRequest
 func (_e *MockProxy_Expecter) UpdateCredential(_a0 interface{}, _a1 interface{}) *MockProxy_UpdateCredential_Call {
 	return &MockProxy_UpdateCredential_Call{Call: _e.mock.On("UpdateCredential", _a0, _a1)}
 }
@@ -5637,8 +5637,8 @@ type MockProxy_UpdateCredentialCache_Call struct {
 }
 
 // UpdateCredentialCache is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *proxypb.UpdateCredCacheRequest
+//   - _a0 context.Context
+//   - _a1 *proxypb.UpdateCredCacheRequest
 func (_e *MockProxy_Expecter) UpdateCredentialCache(_a0 interface{}, _a1 interface{}) *MockProxy_UpdateCredentialCache_Call {
 	return &MockProxy_UpdateCredentialCache_Call{Call: _e.mock.On("UpdateCredentialCache", _a0, _a1)}
 }
@@ -5726,7 +5726,7 @@ type MockProxy_UpdateStateCode_Call struct {
 }
 
 // UpdateStateCode is a helper method to define mock.On call
-//  - stateCode commonpb.StateCode
+//   - stateCode commonpb.StateCode
 func (_e *MockProxy_Expecter) UpdateStateCode(stateCode interface{}) *MockProxy_UpdateStateCode_Call {
 	return &MockProxy_UpdateStateCode_Call{Call: _e.mock.On("UpdateStateCode", stateCode)}
 }
@@ -5780,8 +5780,8 @@ type MockProxy_Upsert_Call struct {
 }
 
 // Upsert is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.UpsertRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.UpsertRequest
 func (_e *MockProxy_Expecter) Upsert(_a0 interface{}, _a1 interface{}) *MockProxy_Upsert_Call {
 	return &MockProxy_Upsert_Call{Call: _e.mock.On("Upsert", _a0, _a1)}
 }

--- a/internal/mocks/mock_proxy_client.go
+++ b/internal/mocks/mock_proxy_client.go
@@ -111,9 +111,9 @@ type MockProxyClient_GetComponentStates_Call struct {
 }
 
 // GetComponentStates is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *milvuspb.GetComponentStatesRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *milvuspb.GetComponentStatesRequest
+//   - opts ...grpc.CallOption
 func (_e *MockProxyClient_Expecter) GetComponentStates(ctx interface{}, in interface{}, opts ...interface{}) *MockProxyClient_GetComponentStates_Call {
 	return &MockProxyClient_GetComponentStates_Call{Call: _e.mock.On("GetComponentStates",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -181,9 +181,9 @@ type MockProxyClient_GetDdChannel_Call struct {
 }
 
 // GetDdChannel is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *internalpb.GetDdChannelRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *internalpb.GetDdChannelRequest
+//   - opts ...grpc.CallOption
 func (_e *MockProxyClient_Expecter) GetDdChannel(ctx interface{}, in interface{}, opts ...interface{}) *MockProxyClient_GetDdChannel_Call {
 	return &MockProxyClient_GetDdChannel_Call{Call: _e.mock.On("GetDdChannel",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -251,9 +251,9 @@ type MockProxyClient_GetImportProgress_Call struct {
 }
 
 // GetImportProgress is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *internalpb.GetImportProgressRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *internalpb.GetImportProgressRequest
+//   - opts ...grpc.CallOption
 func (_e *MockProxyClient_Expecter) GetImportProgress(ctx interface{}, in interface{}, opts ...interface{}) *MockProxyClient_GetImportProgress_Call {
 	return &MockProxyClient_GetImportProgress_Call{Call: _e.mock.On("GetImportProgress",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -321,9 +321,9 @@ type MockProxyClient_GetProxyMetrics_Call struct {
 }
 
 // GetProxyMetrics is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *milvuspb.GetMetricsRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *milvuspb.GetMetricsRequest
+//   - opts ...grpc.CallOption
 func (_e *MockProxyClient_Expecter) GetProxyMetrics(ctx interface{}, in interface{}, opts ...interface{}) *MockProxyClient_GetProxyMetrics_Call {
 	return &MockProxyClient_GetProxyMetrics_Call{Call: _e.mock.On("GetProxyMetrics",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -391,9 +391,9 @@ type MockProxyClient_GetStatisticsChannel_Call struct {
 }
 
 // GetStatisticsChannel is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *internalpb.GetStatisticsChannelRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *internalpb.GetStatisticsChannelRequest
+//   - opts ...grpc.CallOption
 func (_e *MockProxyClient_Expecter) GetStatisticsChannel(ctx interface{}, in interface{}, opts ...interface{}) *MockProxyClient_GetStatisticsChannel_Call {
 	return &MockProxyClient_GetStatisticsChannel_Call{Call: _e.mock.On("GetStatisticsChannel",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -461,9 +461,9 @@ type MockProxyClient_ImportV2_Call struct {
 }
 
 // ImportV2 is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *internalpb.ImportRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *internalpb.ImportRequest
+//   - opts ...grpc.CallOption
 func (_e *MockProxyClient_Expecter) ImportV2(ctx interface{}, in interface{}, opts ...interface{}) *MockProxyClient_ImportV2_Call {
 	return &MockProxyClient_ImportV2_Call{Call: _e.mock.On("ImportV2",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -531,9 +531,9 @@ type MockProxyClient_InvalidateCollectionMetaCache_Call struct {
 }
 
 // InvalidateCollectionMetaCache is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *proxypb.InvalidateCollMetaCacheRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *proxypb.InvalidateCollMetaCacheRequest
+//   - opts ...grpc.CallOption
 func (_e *MockProxyClient_Expecter) InvalidateCollectionMetaCache(ctx interface{}, in interface{}, opts ...interface{}) *MockProxyClient_InvalidateCollectionMetaCache_Call {
 	return &MockProxyClient_InvalidateCollectionMetaCache_Call{Call: _e.mock.On("InvalidateCollectionMetaCache",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -601,9 +601,9 @@ type MockProxyClient_InvalidateCredentialCache_Call struct {
 }
 
 // InvalidateCredentialCache is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *proxypb.InvalidateCredCacheRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *proxypb.InvalidateCredCacheRequest
+//   - opts ...grpc.CallOption
 func (_e *MockProxyClient_Expecter) InvalidateCredentialCache(ctx interface{}, in interface{}, opts ...interface{}) *MockProxyClient_InvalidateCredentialCache_Call {
 	return &MockProxyClient_InvalidateCredentialCache_Call{Call: _e.mock.On("InvalidateCredentialCache",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -671,9 +671,9 @@ type MockProxyClient_ListClientInfos_Call struct {
 }
 
 // ListClientInfos is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *proxypb.ListClientInfosRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *proxypb.ListClientInfosRequest
+//   - opts ...grpc.CallOption
 func (_e *MockProxyClient_Expecter) ListClientInfos(ctx interface{}, in interface{}, opts ...interface{}) *MockProxyClient_ListClientInfos_Call {
 	return &MockProxyClient_ListClientInfos_Call{Call: _e.mock.On("ListClientInfos",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -741,9 +741,9 @@ type MockProxyClient_ListImports_Call struct {
 }
 
 // ListImports is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *internalpb.ListImportsRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *internalpb.ListImportsRequest
+//   - opts ...grpc.CallOption
 func (_e *MockProxyClient_Expecter) ListImports(ctx interface{}, in interface{}, opts ...interface{}) *MockProxyClient_ListImports_Call {
 	return &MockProxyClient_ListImports_Call{Call: _e.mock.On("ListImports",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -811,9 +811,9 @@ type MockProxyClient_RefreshPolicyInfoCache_Call struct {
 }
 
 // RefreshPolicyInfoCache is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *proxypb.RefreshPolicyInfoCacheRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *proxypb.RefreshPolicyInfoCacheRequest
+//   - opts ...grpc.CallOption
 func (_e *MockProxyClient_Expecter) RefreshPolicyInfoCache(ctx interface{}, in interface{}, opts ...interface{}) *MockProxyClient_RefreshPolicyInfoCache_Call {
 	return &MockProxyClient_RefreshPolicyInfoCache_Call{Call: _e.mock.On("RefreshPolicyInfoCache",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -881,9 +881,9 @@ type MockProxyClient_SetRates_Call struct {
 }
 
 // SetRates is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *proxypb.SetRatesRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *proxypb.SetRatesRequest
+//   - opts ...grpc.CallOption
 func (_e *MockProxyClient_Expecter) SetRates(ctx interface{}, in interface{}, opts ...interface{}) *MockProxyClient_SetRates_Call {
 	return &MockProxyClient_SetRates_Call{Call: _e.mock.On("SetRates",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -951,9 +951,9 @@ type MockProxyClient_UpdateCredentialCache_Call struct {
 }
 
 // UpdateCredentialCache is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *proxypb.UpdateCredCacheRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *proxypb.UpdateCredCacheRequest
+//   - opts ...grpc.CallOption
 func (_e *MockProxyClient_Expecter) UpdateCredentialCache(ctx interface{}, in interface{}, opts ...interface{}) *MockProxyClient_UpdateCredentialCache_Call {
 	return &MockProxyClient_UpdateCredentialCache_Call{Call: _e.mock.On("UpdateCredentialCache",
 		append([]interface{}{ctx, in}, opts...)...)}


### PR DESCRIPTION
use a segment level key lock when mutate on meta.
otherwise global should only be hold on in memory operations
fix #31056