### PR TITLE
test: add json and array datatype check in restful v1

### DIFF
--- a/tests/restful_client/testcases/test_restful_sdk_mix_use_scenario.py
+++ b/tests/restful_client/testcases/test_restful_sdk_mix_use_scenario.py
@@ -138,6 +138,9 @@ class TestRestfulSdkCompatibility(TestBase):
             FieldSchema(name="int64", dtype=DataType.INT64, is_primary=True),
             FieldSchema(name="float", dtype=DataType.FLOAT),
             FieldSchema(name="varchar", dtype=DataType.VARCHAR, max_length=65535),
+            FieldSchema(name="json", dtype=DataType.JSON),
+            FieldSchema(name="int_array", dtype=DataType.ARRAY, element_type=DataType.INT64, max_capacity=1024),
+            FieldSchema(name="varchar_array", dtype=DataType.ARRAY, element_type=DataType.VARCHAR, max_capacity=1024, max_length=65535),
             FieldSchema(name="float_vector", dtype=DataType.FLOAT_VECTOR, dim=128)
         ]
         default_schema = CollectionSchema(fields=default_fields, description="test collection",
@@ -149,7 +152,14 @@ class TestRestfulSdkCompatibility(TestBase):
         collection.load()
         # insert data by restful
         data = [
-            {"int64": i, "float": i, "varchar": str(i), "float_vector": [random.random() for _ in range(dim)], "age": i}
+            {"int64": i,
+             "float": i,
+             "varchar": str(i),
+             "json": {"name": "name", "age": i},
+             "int_array": [i for i in range(10)],
+             "varchar_array": [str(i) for i in range(10)],
+             "float_vector": [random.random() for _ in range(dim)],
+             "age": i}
             for i in range(nb)
         ]
         client = self.vector_client

--- a/tests/restful_client/utils/utils.py
+++ b/tests/restful_client/utils/utils.py
@@ -96,6 +96,8 @@ def get_random_json_data(uid=None):
         uid = 0
     data = {"uid": uid,  "name": fake.name(), "address": fake.address(), "text": fake.text(), "email": fake.email(),
             "phone_number": fake.phone_number(),
+            "array_int_dynamic": [random.randint(1, 100_000) for i in range(random.randint(1, 10))],
+            "array_varchar_dynamic": [fake.name() for i in range(random.randint(1, 10))],
             "json": {
                 "name": fake.name(),
                 "address": fake.address()


### PR DESCRIPTION


* When the collection is created using an SDK and includes array and JSON datatypes in the schema, data can be inserted using the RESTful API.
* When the collection is created using the RESTful API and includes JSON and array datatypes in dynamic fields, data can also be inserted using the RESTful API.