### PR TITLE
enhance: Add `ListIndexes` API from datacoord

### DIFF
--- a/internal/datacoord/index_service.go
+++ b/internal/datacoord/index_service.go
@@ -879,3 +879,37 @@ func (s *Server) GetIndexInfos(ctx context.Context, req *indexpb.GetIndexInfoReq
 
 	return ret, nil
 }
+
+// ListIndexes returns all indexes created on provided collection.
+func (s *Server) ListIndexes(ctx context.Context, req *indexpb.ListIndexesRequest) (*indexpb.ListIndexesResponse, error) {
+	log := log.Ctx(ctx).With(
+		zap.Int64("collectionID", req.GetCollectionID()),
+	)
+
+	if err := merr.CheckHealthy(s.GetStateCode()); err != nil {
+		log.Warn(msgDataCoordIsUnhealthy(paramtable.GetNodeID()), zap.Error(err))
+		return &indexpb.ListIndexesResponse{
+			Status: merr.Status(err),
+		}, nil
+	}
+
+	indexes := s.meta.indexMeta.GetIndexesForCollection(req.GetCollectionID(), "")
+
+	indexInfos := lo.Map(indexes, func(index *model.Index, _ int) *indexpb.IndexInfo {
+		return &indexpb.IndexInfo{
+			CollectionID:    index.CollectionID,
+			FieldID:         index.FieldID,
+			IndexName:       index.IndexName,
+			IndexID:         index.IndexID,
+			TypeParams:      index.TypeParams,
+			IndexParams:     index.IndexParams,
+			IsAutoIndex:     index.IsAutoIndex,
+			UserIndexParams: index.UserIndexParams,
+		}
+	})
+	log.Info("List index success")
+	return &indexpb.ListIndexesResponse{
+		Status:     merr.Success(),
+		IndexInfos: indexInfos,
+	}, nil
+}

--- a/internal/distributed/datacoord/client/client.go
+++ b/internal/distributed/datacoord/client/client.go
@@ -779,3 +779,9 @@ func (c *Client) ListImports(ctx context.Context, in *internalpb.ListImportsRequ
 		return client.ListImports(ctx, in)
 	})
 }
+
+func (c *Client) ListIndexes(ctx context.Context, in *indexpb.ListIndexesRequest, opts ...grpc.CallOption) (*indexpb.ListIndexesResponse, error) {
+	return wrapGrpcCall(ctx, c, func(client datapb.DataCoordClient) (*indexpb.ListIndexesResponse, error) {
+		return client.ListIndexes(ctx, in)
+	})
+}

--- a/internal/distributed/datacoord/service.go
+++ b/internal/distributed/datacoord/service.go
@@ -501,3 +501,7 @@ func (s *Server) GetImportProgress(ctx context.Context, in *internalpb.GetImport
 func (s *Server) ListImports(ctx context.Context, in *internalpb.ListImportsRequestInternal) (*internalpb.ListImportsResponse, error) {
 	return s.dataCoord.ListImports(ctx, in)
 }
+
+func (s *Server) ListIndexes(ctx context.Context, in *indexpb.ListIndexesRequest) (*indexpb.ListIndexesResponse, error) {
+	return s.dataCoord.ListIndexes(ctx, in)
+}

--- a/internal/distributed/datacoord/service_test.go
+++ b/internal/distributed/datacoord/service_test.go
@@ -331,6 +331,15 @@ func Test_NewServer(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, ret)
 	})
+
+	t.Run("ListIndex", func(t *testing.T) {
+		mockDataCoord.EXPECT().ListIndexes(mock.Anything, mock.Anything).Return(&indexpb.ListIndexesResponse{
+			Status: merr.Success(),
+		}, nil)
+		ret, err := server.ListIndexes(ctx, &indexpb.ListIndexesRequest{})
+		assert.NoError(t, err)
+		assert.True(t, merr.Ok(ret.GetStatus()))
+	})
 }
 
 func Test_Run(t *testing.T) {

--- a/internal/mocks/mock_datacoord.go
+++ b/internal/mocks/mock_datacoord.go
@@ -68,8 +68,8 @@ type MockDataCoord_AlterIndex_Call struct {
 }
 
 // AlterIndex is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *indexpb.AlterIndexRequest
+//   - _a0 context.Context
+//   - _a1 *indexpb.AlterIndexRequest
 func (_e *MockDataCoord_Expecter) AlterIndex(_a0 interface{}, _a1 interface{}) *MockDataCoord_AlterIndex_Call {
 	return &MockDataCoord_AlterIndex_Call{Call: _e.mock.On("AlterIndex", _a0, _a1)}
 }
@@ -123,8 +123,8 @@ type MockDataCoord_AssignSegmentID_Call struct {
 }
 
 // AssignSegmentID is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.AssignSegmentIDRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.AssignSegmentIDRequest
 func (_e *MockDataCoord_Expecter) AssignSegmentID(_a0 interface{}, _a1 interface{}) *MockDataCoord_AssignSegmentID_Call {
 	return &MockDataCoord_AssignSegmentID_Call{Call: _e.mock.On("AssignSegmentID", _a0, _a1)}
 }
@@ -178,8 +178,8 @@ type MockDataCoord_BroadcastAlteredCollection_Call struct {
 }
 
 // BroadcastAlteredCollection is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.AlterCollectionRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.AlterCollectionRequest
 func (_e *MockDataCoord_Expecter) BroadcastAlteredCollection(_a0 interface{}, _a1 interface{}) *MockDataCoord_BroadcastAlteredCollection_Call {
 	return &MockDataCoord_BroadcastAlteredCollection_Call{Call: _e.mock.On("BroadcastAlteredCollection", _a0, _a1)}
 }
@@ -233,8 +233,8 @@ type MockDataCoord_CheckHealth_Call struct {
 }
 
 // CheckHealth is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.CheckHealthRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.CheckHealthRequest
 func (_e *MockDataCoord_Expecter) CheckHealth(_a0 interface{}, _a1 interface{}) *MockDataCoord_CheckHealth_Call {
 	return &MockDataCoord_CheckHealth_Call{Call: _e.mock.On("CheckHealth", _a0, _a1)}
 }
@@ -288,8 +288,8 @@ type MockDataCoord_CreateIndex_Call struct {
 }
 
 // CreateIndex is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *indexpb.CreateIndexRequest
+//   - _a0 context.Context
+//   - _a1 *indexpb.CreateIndexRequest
 func (_e *MockDataCoord_Expecter) CreateIndex(_a0 interface{}, _a1 interface{}) *MockDataCoord_CreateIndex_Call {
 	return &MockDataCoord_CreateIndex_Call{Call: _e.mock.On("CreateIndex", _a0, _a1)}
 }
@@ -343,8 +343,8 @@ type MockDataCoord_DescribeIndex_Call struct {
 }
 
 // DescribeIndex is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *indexpb.DescribeIndexRequest
+//   - _a0 context.Context
+//   - _a1 *indexpb.DescribeIndexRequest
 func (_e *MockDataCoord_Expecter) DescribeIndex(_a0 interface{}, _a1 interface{}) *MockDataCoord_DescribeIndex_Call {
 	return &MockDataCoord_DescribeIndex_Call{Call: _e.mock.On("DescribeIndex", _a0, _a1)}
 }
@@ -398,8 +398,8 @@ type MockDataCoord_DropIndex_Call struct {
 }
 
 // DropIndex is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *indexpb.DropIndexRequest
+//   - _a0 context.Context
+//   - _a1 *indexpb.DropIndexRequest
 func (_e *MockDataCoord_Expecter) DropIndex(_a0 interface{}, _a1 interface{}) *MockDataCoord_DropIndex_Call {
 	return &MockDataCoord_DropIndex_Call{Call: _e.mock.On("DropIndex", _a0, _a1)}
 }
@@ -453,8 +453,8 @@ type MockDataCoord_DropVirtualChannel_Call struct {
 }
 
 // DropVirtualChannel is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.DropVirtualChannelRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.DropVirtualChannelRequest
 func (_e *MockDataCoord_Expecter) DropVirtualChannel(_a0 interface{}, _a1 interface{}) *MockDataCoord_DropVirtualChannel_Call {
 	return &MockDataCoord_DropVirtualChannel_Call{Call: _e.mock.On("DropVirtualChannel", _a0, _a1)}
 }
@@ -508,8 +508,8 @@ type MockDataCoord_Flush_Call struct {
 }
 
 // Flush is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.FlushRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.FlushRequest
 func (_e *MockDataCoord_Expecter) Flush(_a0 interface{}, _a1 interface{}) *MockDataCoord_Flush_Call {
 	return &MockDataCoord_Flush_Call{Call: _e.mock.On("Flush", _a0, _a1)}
 }
@@ -563,8 +563,8 @@ type MockDataCoord_GcConfirm_Call struct {
 }
 
 // GcConfirm is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.GcConfirmRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.GcConfirmRequest
 func (_e *MockDataCoord_Expecter) GcConfirm(_a0 interface{}, _a1 interface{}) *MockDataCoord_GcConfirm_Call {
 	return &MockDataCoord_GcConfirm_Call{Call: _e.mock.On("GcConfirm", _a0, _a1)}
 }
@@ -618,8 +618,8 @@ type MockDataCoord_GcControl_Call struct {
 }
 
 // GcControl is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.GcControlRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.GcControlRequest
 func (_e *MockDataCoord_Expecter) GcControl(_a0 interface{}, _a1 interface{}) *MockDataCoord_GcControl_Call {
 	return &MockDataCoord_GcControl_Call{Call: _e.mock.On("GcControl", _a0, _a1)}
 }
@@ -673,8 +673,8 @@ type MockDataCoord_GetCollectionStatistics_Call struct {
 }
 
 // GetCollectionStatistics is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.GetCollectionStatisticsRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.GetCollectionStatisticsRequest
 func (_e *MockDataCoord_Expecter) GetCollectionStatistics(_a0 interface{}, _a1 interface{}) *MockDataCoord_GetCollectionStatistics_Call {
 	return &MockDataCoord_GetCollectionStatistics_Call{Call: _e.mock.On("GetCollectionStatistics", _a0, _a1)}
 }
@@ -728,8 +728,8 @@ type MockDataCoord_GetCompactionState_Call struct {
 }
 
 // GetCompactionState is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.GetCompactionStateRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.GetCompactionStateRequest
 func (_e *MockDataCoord_Expecter) GetCompactionState(_a0 interface{}, _a1 interface{}) *MockDataCoord_GetCompactionState_Call {
 	return &MockDataCoord_GetCompactionState_Call{Call: _e.mock.On("GetCompactionState", _a0, _a1)}
 }
@@ -783,8 +783,8 @@ type MockDataCoord_GetCompactionStateWithPlans_Call struct {
 }
 
 // GetCompactionStateWithPlans is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.GetCompactionPlansRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.GetCompactionPlansRequest
 func (_e *MockDataCoord_Expecter) GetCompactionStateWithPlans(_a0 interface{}, _a1 interface{}) *MockDataCoord_GetCompactionStateWithPlans_Call {
 	return &MockDataCoord_GetCompactionStateWithPlans_Call{Call: _e.mock.On("GetCompactionStateWithPlans", _a0, _a1)}
 }
@@ -838,8 +838,8 @@ type MockDataCoord_GetComponentStates_Call struct {
 }
 
 // GetComponentStates is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.GetComponentStatesRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.GetComponentStatesRequest
 func (_e *MockDataCoord_Expecter) GetComponentStates(_a0 interface{}, _a1 interface{}) *MockDataCoord_GetComponentStates_Call {
 	return &MockDataCoord_GetComponentStates_Call{Call: _e.mock.On("GetComponentStates", _a0, _a1)}
 }
@@ -893,8 +893,8 @@ type MockDataCoord_GetFlushAllState_Call struct {
 }
 
 // GetFlushAllState is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.GetFlushAllStateRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.GetFlushAllStateRequest
 func (_e *MockDataCoord_Expecter) GetFlushAllState(_a0 interface{}, _a1 interface{}) *MockDataCoord_GetFlushAllState_Call {
 	return &MockDataCoord_GetFlushAllState_Call{Call: _e.mock.On("GetFlushAllState", _a0, _a1)}
 }
@@ -948,8 +948,8 @@ type MockDataCoord_GetFlushState_Call struct {
 }
 
 // GetFlushState is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.GetFlushStateRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.GetFlushStateRequest
 func (_e *MockDataCoord_Expecter) GetFlushState(_a0 interface{}, _a1 interface{}) *MockDataCoord_GetFlushState_Call {
 	return &MockDataCoord_GetFlushState_Call{Call: _e.mock.On("GetFlushState", _a0, _a1)}
 }
@@ -1003,8 +1003,8 @@ type MockDataCoord_GetFlushedSegments_Call struct {
 }
 
 // GetFlushedSegments is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.GetFlushedSegmentsRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.GetFlushedSegmentsRequest
 func (_e *MockDataCoord_Expecter) GetFlushedSegments(_a0 interface{}, _a1 interface{}) *MockDataCoord_GetFlushedSegments_Call {
 	return &MockDataCoord_GetFlushedSegments_Call{Call: _e.mock.On("GetFlushedSegments", _a0, _a1)}
 }
@@ -1058,8 +1058,8 @@ type MockDataCoord_GetImportProgress_Call struct {
 }
 
 // GetImportProgress is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *internalpb.GetImportProgressRequest
+//   - _a0 context.Context
+//   - _a1 *internalpb.GetImportProgressRequest
 func (_e *MockDataCoord_Expecter) GetImportProgress(_a0 interface{}, _a1 interface{}) *MockDataCoord_GetImportProgress_Call {
 	return &MockDataCoord_GetImportProgress_Call{Call: _e.mock.On("GetImportProgress", _a0, _a1)}
 }
@@ -1113,8 +1113,8 @@ type MockDataCoord_GetIndexBuildProgress_Call struct {
 }
 
 // GetIndexBuildProgress is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *indexpb.GetIndexBuildProgressRequest
+//   - _a0 context.Context
+//   - _a1 *indexpb.GetIndexBuildProgressRequest
 func (_e *MockDataCoord_Expecter) GetIndexBuildProgress(_a0 interface{}, _a1 interface{}) *MockDataCoord_GetIndexBuildProgress_Call {
 	return &MockDataCoord_GetIndexBuildProgress_Call{Call: _e.mock.On("GetIndexBuildProgress", _a0, _a1)}
 }
@@ -1168,8 +1168,8 @@ type MockDataCoord_GetIndexInfos_Call struct {
 }
 
 // GetIndexInfos is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *indexpb.GetIndexInfoRequest
+//   - _a0 context.Context
+//   - _a1 *indexpb.GetIndexInfoRequest
 func (_e *MockDataCoord_Expecter) GetIndexInfos(_a0 interface{}, _a1 interface{}) *MockDataCoord_GetIndexInfos_Call {
 	return &MockDataCoord_GetIndexInfos_Call{Call: _e.mock.On("GetIndexInfos", _a0, _a1)}
 }
@@ -1223,8 +1223,8 @@ type MockDataCoord_GetIndexState_Call struct {
 }
 
 // GetIndexState is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *indexpb.GetIndexStateRequest
+//   - _a0 context.Context
+//   - _a1 *indexpb.GetIndexStateRequest
 func (_e *MockDataCoord_Expecter) GetIndexState(_a0 interface{}, _a1 interface{}) *MockDataCoord_GetIndexState_Call {
 	return &MockDataCoord_GetIndexState_Call{Call: _e.mock.On("GetIndexState", _a0, _a1)}
 }
@@ -1278,8 +1278,8 @@ type MockDataCoord_GetIndexStatistics_Call struct {
 }
 
 // GetIndexStatistics is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *indexpb.GetIndexStatisticsRequest
+//   - _a0 context.Context
+//   - _a1 *indexpb.GetIndexStatisticsRequest
 func (_e *MockDataCoord_Expecter) GetIndexStatistics(_a0 interface{}, _a1 interface{}) *MockDataCoord_GetIndexStatistics_Call {
 	return &MockDataCoord_GetIndexStatistics_Call{Call: _e.mock.On("GetIndexStatistics", _a0, _a1)}
 }
@@ -1333,8 +1333,8 @@ type MockDataCoord_GetInsertBinlogPaths_Call struct {
 }
 
 // GetInsertBinlogPaths is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.GetInsertBinlogPathsRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.GetInsertBinlogPathsRequest
 func (_e *MockDataCoord_Expecter) GetInsertBinlogPaths(_a0 interface{}, _a1 interface{}) *MockDataCoord_GetInsertBinlogPaths_Call {
 	return &MockDataCoord_GetInsertBinlogPaths_Call{Call: _e.mock.On("GetInsertBinlogPaths", _a0, _a1)}
 }
@@ -1388,8 +1388,8 @@ type MockDataCoord_GetMetrics_Call struct {
 }
 
 // GetMetrics is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.GetMetricsRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.GetMetricsRequest
 func (_e *MockDataCoord_Expecter) GetMetrics(_a0 interface{}, _a1 interface{}) *MockDataCoord_GetMetrics_Call {
 	return &MockDataCoord_GetMetrics_Call{Call: _e.mock.On("GetMetrics", _a0, _a1)}
 }
@@ -1443,8 +1443,8 @@ type MockDataCoord_GetPartitionStatistics_Call struct {
 }
 
 // GetPartitionStatistics is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.GetPartitionStatisticsRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.GetPartitionStatisticsRequest
 func (_e *MockDataCoord_Expecter) GetPartitionStatistics(_a0 interface{}, _a1 interface{}) *MockDataCoord_GetPartitionStatistics_Call {
 	return &MockDataCoord_GetPartitionStatistics_Call{Call: _e.mock.On("GetPartitionStatistics", _a0, _a1)}
 }
@@ -1498,8 +1498,8 @@ type MockDataCoord_GetRecoveryInfo_Call struct {
 }
 
 // GetRecoveryInfo is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.GetRecoveryInfoRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.GetRecoveryInfoRequest
 func (_e *MockDataCoord_Expecter) GetRecoveryInfo(_a0 interface{}, _a1 interface{}) *MockDataCoord_GetRecoveryInfo_Call {
 	return &MockDataCoord_GetRecoveryInfo_Call{Call: _e.mock.On("GetRecoveryInfo", _a0, _a1)}
 }
@@ -1553,8 +1553,8 @@ type MockDataCoord_GetRecoveryInfoV2_Call struct {
 }
 
 // GetRecoveryInfoV2 is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.GetRecoveryInfoRequestV2
+//   - _a0 context.Context
+//   - _a1 *datapb.GetRecoveryInfoRequestV2
 func (_e *MockDataCoord_Expecter) GetRecoveryInfoV2(_a0 interface{}, _a1 interface{}) *MockDataCoord_GetRecoveryInfoV2_Call {
 	return &MockDataCoord_GetRecoveryInfoV2_Call{Call: _e.mock.On("GetRecoveryInfoV2", _a0, _a1)}
 }
@@ -1608,8 +1608,8 @@ type MockDataCoord_GetSegmentIndexState_Call struct {
 }
 
 // GetSegmentIndexState is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *indexpb.GetSegmentIndexStateRequest
+//   - _a0 context.Context
+//   - _a1 *indexpb.GetSegmentIndexStateRequest
 func (_e *MockDataCoord_Expecter) GetSegmentIndexState(_a0 interface{}, _a1 interface{}) *MockDataCoord_GetSegmentIndexState_Call {
 	return &MockDataCoord_GetSegmentIndexState_Call{Call: _e.mock.On("GetSegmentIndexState", _a0, _a1)}
 }
@@ -1663,8 +1663,8 @@ type MockDataCoord_GetSegmentInfo_Call struct {
 }
 
 // GetSegmentInfo is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.GetSegmentInfoRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.GetSegmentInfoRequest
 func (_e *MockDataCoord_Expecter) GetSegmentInfo(_a0 interface{}, _a1 interface{}) *MockDataCoord_GetSegmentInfo_Call {
 	return &MockDataCoord_GetSegmentInfo_Call{Call: _e.mock.On("GetSegmentInfo", _a0, _a1)}
 }
@@ -1718,8 +1718,8 @@ type MockDataCoord_GetSegmentInfoChannel_Call struct {
 }
 
 // GetSegmentInfoChannel is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.GetSegmentInfoChannelRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.GetSegmentInfoChannelRequest
 func (_e *MockDataCoord_Expecter) GetSegmentInfoChannel(_a0 interface{}, _a1 interface{}) *MockDataCoord_GetSegmentInfoChannel_Call {
 	return &MockDataCoord_GetSegmentInfoChannel_Call{Call: _e.mock.On("GetSegmentInfoChannel", _a0, _a1)}
 }
@@ -1773,8 +1773,8 @@ type MockDataCoord_GetSegmentStates_Call struct {
 }
 
 // GetSegmentStates is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.GetSegmentStatesRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.GetSegmentStatesRequest
 func (_e *MockDataCoord_Expecter) GetSegmentStates(_a0 interface{}, _a1 interface{}) *MockDataCoord_GetSegmentStates_Call {
 	return &MockDataCoord_GetSegmentStates_Call{Call: _e.mock.On("GetSegmentStates", _a0, _a1)}
 }
@@ -1828,8 +1828,8 @@ type MockDataCoord_GetSegmentsByStates_Call struct {
 }
 
 // GetSegmentsByStates is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.GetSegmentsByStatesRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.GetSegmentsByStatesRequest
 func (_e *MockDataCoord_Expecter) GetSegmentsByStates(_a0 interface{}, _a1 interface{}) *MockDataCoord_GetSegmentsByStates_Call {
 	return &MockDataCoord_GetSegmentsByStates_Call{Call: _e.mock.On("GetSegmentsByStates", _a0, _a1)}
 }
@@ -1883,8 +1883,8 @@ type MockDataCoord_GetStatisticsChannel_Call struct {
 }
 
 // GetStatisticsChannel is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *internalpb.GetStatisticsChannelRequest
+//   - _a0 context.Context
+//   - _a1 *internalpb.GetStatisticsChannelRequest
 func (_e *MockDataCoord_Expecter) GetStatisticsChannel(_a0 interface{}, _a1 interface{}) *MockDataCoord_GetStatisticsChannel_Call {
 	return &MockDataCoord_GetStatisticsChannel_Call{Call: _e.mock.On("GetStatisticsChannel", _a0, _a1)}
 }
@@ -1938,8 +1938,8 @@ type MockDataCoord_GetTimeTickChannel_Call struct {
 }
 
 // GetTimeTickChannel is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *internalpb.GetTimeTickChannelRequest
+//   - _a0 context.Context
+//   - _a1 *internalpb.GetTimeTickChannelRequest
 func (_e *MockDataCoord_Expecter) GetTimeTickChannel(_a0 interface{}, _a1 interface{}) *MockDataCoord_GetTimeTickChannel_Call {
 	return &MockDataCoord_GetTimeTickChannel_Call{Call: _e.mock.On("GetTimeTickChannel", _a0, _a1)}
 }
@@ -1993,8 +1993,8 @@ type MockDataCoord_Import_Call struct {
 }
 
 // Import is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.ImportTaskRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.ImportTaskRequest
 func (_e *MockDataCoord_Expecter) Import(_a0 interface{}, _a1 interface{}) *MockDataCoord_Import_Call {
 	return &MockDataCoord_Import_Call{Call: _e.mock.On("Import", _a0, _a1)}
 }
@@ -2048,8 +2048,8 @@ type MockDataCoord_ImportV2_Call struct {
 }
 
 // ImportV2 is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *internalpb.ImportRequestInternal
+//   - _a0 context.Context
+//   - _a1 *internalpb.ImportRequestInternal
 func (_e *MockDataCoord_Expecter) ImportV2(_a0 interface{}, _a1 interface{}) *MockDataCoord_ImportV2_Call {
 	return &MockDataCoord_ImportV2_Call{Call: _e.mock.On("ImportV2", _a0, _a1)}
 }
@@ -2144,8 +2144,8 @@ type MockDataCoord_ListImports_Call struct {
 }
 
 // ListImports is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *internalpb.ListImportsRequestInternal
+//   - _a0 context.Context
+//   - _a1 *internalpb.ListImportsRequestInternal
 func (_e *MockDataCoord_Expecter) ListImports(_a0 interface{}, _a1 interface{}) *MockDataCoord_ListImports_Call {
 	return &MockDataCoord_ListImports_Call{Call: _e.mock.On("ListImports", _a0, _a1)}
 }
@@ -2163,6 +2163,61 @@ func (_c *MockDataCoord_ListImports_Call) Return(_a0 *internalpb.ListImportsResp
 }
 
 func (_c *MockDataCoord_ListImports_Call) RunAndReturn(run func(context.Context, *internalpb.ListImportsRequestInternal) (*internalpb.ListImportsResponse, error)) *MockDataCoord_ListImports_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ListIndexes provides a mock function with given fields: _a0, _a1
+func (_m *MockDataCoord) ListIndexes(_a0 context.Context, _a1 *indexpb.ListIndexesRequest) (*indexpb.ListIndexesResponse, error) {
+	ret := _m.Called(_a0, _a1)
+
+	var r0 *indexpb.ListIndexesResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *indexpb.ListIndexesRequest) (*indexpb.ListIndexesResponse, error)); ok {
+		return rf(_a0, _a1)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *indexpb.ListIndexesRequest) *indexpb.ListIndexesResponse); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*indexpb.ListIndexesResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *indexpb.ListIndexesRequest) error); ok {
+		r1 = rf(_a0, _a1)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockDataCoord_ListIndexes_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListIndexes'
+type MockDataCoord_ListIndexes_Call struct {
+	*mock.Call
+}
+
+// ListIndexes is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *indexpb.ListIndexesRequest
+func (_e *MockDataCoord_Expecter) ListIndexes(_a0 interface{}, _a1 interface{}) *MockDataCoord_ListIndexes_Call {
+	return &MockDataCoord_ListIndexes_Call{Call: _e.mock.On("ListIndexes", _a0, _a1)}
+}
+
+func (_c *MockDataCoord_ListIndexes_Call) Run(run func(_a0 context.Context, _a1 *indexpb.ListIndexesRequest)) *MockDataCoord_ListIndexes_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*indexpb.ListIndexesRequest))
+	})
+	return _c
+}
+
+func (_c *MockDataCoord_ListIndexes_Call) Return(_a0 *indexpb.ListIndexesResponse, _a1 error) *MockDataCoord_ListIndexes_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockDataCoord_ListIndexes_Call) RunAndReturn(run func(context.Context, *indexpb.ListIndexesRequest) (*indexpb.ListIndexesResponse, error)) *MockDataCoord_ListIndexes_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -2199,8 +2254,8 @@ type MockDataCoord_ManualCompaction_Call struct {
 }
 
 // ManualCompaction is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *milvuspb.ManualCompactionRequest
+//   - _a0 context.Context
+//   - _a1 *milvuspb.ManualCompactionRequest
 func (_e *MockDataCoord_Expecter) ManualCompaction(_a0 interface{}, _a1 interface{}) *MockDataCoord_ManualCompaction_Call {
 	return &MockDataCoord_ManualCompaction_Call{Call: _e.mock.On("ManualCompaction", _a0, _a1)}
 }
@@ -2254,8 +2309,8 @@ type MockDataCoord_MarkSegmentsDropped_Call struct {
 }
 
 // MarkSegmentsDropped is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.MarkSegmentsDroppedRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.MarkSegmentsDroppedRequest
 func (_e *MockDataCoord_Expecter) MarkSegmentsDropped(_a0 interface{}, _a1 interface{}) *MockDataCoord_MarkSegmentsDropped_Call {
 	return &MockDataCoord_MarkSegmentsDropped_Call{Call: _e.mock.On("MarkSegmentsDropped", _a0, _a1)}
 }
@@ -2350,8 +2405,8 @@ type MockDataCoord_ReportDataNodeTtMsgs_Call struct {
 }
 
 // ReportDataNodeTtMsgs is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.ReportDataNodeTtMsgsRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.ReportDataNodeTtMsgsRequest
 func (_e *MockDataCoord_Expecter) ReportDataNodeTtMsgs(_a0 interface{}, _a1 interface{}) *MockDataCoord_ReportDataNodeTtMsgs_Call {
 	return &MockDataCoord_ReportDataNodeTtMsgs_Call{Call: _e.mock.On("ReportDataNodeTtMsgs", _a0, _a1)}
 }
@@ -2405,8 +2460,8 @@ type MockDataCoord_SaveBinlogPaths_Call struct {
 }
 
 // SaveBinlogPaths is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.SaveBinlogPathsRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.SaveBinlogPathsRequest
 func (_e *MockDataCoord_Expecter) SaveBinlogPaths(_a0 interface{}, _a1 interface{}) *MockDataCoord_SaveBinlogPaths_Call {
 	return &MockDataCoord_SaveBinlogPaths_Call{Call: _e.mock.On("SaveBinlogPaths", _a0, _a1)}
 }
@@ -2460,8 +2515,8 @@ type MockDataCoord_SaveImportSegment_Call struct {
 }
 
 // SaveImportSegment is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.SaveImportSegmentRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.SaveImportSegmentRequest
 func (_e *MockDataCoord_Expecter) SaveImportSegment(_a0 interface{}, _a1 interface{}) *MockDataCoord_SaveImportSegment_Call {
 	return &MockDataCoord_SaveImportSegment_Call{Call: _e.mock.On("SaveImportSegment", _a0, _a1)}
 }
@@ -2494,7 +2549,7 @@ type MockDataCoord_SetAddress_Call struct {
 }
 
 // SetAddress is a helper method to define mock.On call
-//  - address string
+//   - address string
 func (_e *MockDataCoord_Expecter) SetAddress(address interface{}) *MockDataCoord_SetAddress_Call {
 	return &MockDataCoord_SetAddress_Call{Call: _e.mock.On("SetAddress", address)}
 }
@@ -2527,7 +2582,7 @@ type MockDataCoord_SetDataNodeCreator_Call struct {
 }
 
 // SetDataNodeCreator is a helper method to define mock.On call
-//  - _a0 func(context.Context , string , int64)(types.DataNodeClient , error)
+//   - _a0 func(context.Context , string , int64)(types.DataNodeClient , error)
 func (_e *MockDataCoord_Expecter) SetDataNodeCreator(_a0 interface{}) *MockDataCoord_SetDataNodeCreator_Call {
 	return &MockDataCoord_SetDataNodeCreator_Call{Call: _e.mock.On("SetDataNodeCreator", _a0)}
 }
@@ -2560,7 +2615,7 @@ type MockDataCoord_SetEtcdClient_Call struct {
 }
 
 // SetEtcdClient is a helper method to define mock.On call
-//  - etcdClient *clientv3.Client
+//   - etcdClient *clientv3.Client
 func (_e *MockDataCoord_Expecter) SetEtcdClient(etcdClient interface{}) *MockDataCoord_SetEtcdClient_Call {
 	return &MockDataCoord_SetEtcdClient_Call{Call: _e.mock.On("SetEtcdClient", etcdClient)}
 }
@@ -2593,7 +2648,7 @@ type MockDataCoord_SetIndexNodeCreator_Call struct {
 }
 
 // SetIndexNodeCreator is a helper method to define mock.On call
-//  - _a0 func(context.Context , string , int64)(types.IndexNodeClient , error)
+//   - _a0 func(context.Context , string , int64)(types.IndexNodeClient , error)
 func (_e *MockDataCoord_Expecter) SetIndexNodeCreator(_a0 interface{}) *MockDataCoord_SetIndexNodeCreator_Call {
 	return &MockDataCoord_SetIndexNodeCreator_Call{Call: _e.mock.On("SetIndexNodeCreator", _a0)}
 }
@@ -2626,7 +2681,7 @@ type MockDataCoord_SetRootCoordClient_Call struct {
 }
 
 // SetRootCoordClient is a helper method to define mock.On call
-//  - rootCoord types.RootCoordClient
+//   - rootCoord types.RootCoordClient
 func (_e *MockDataCoord_Expecter) SetRootCoordClient(rootCoord interface{}) *MockDataCoord_SetRootCoordClient_Call {
 	return &MockDataCoord_SetRootCoordClient_Call{Call: _e.mock.On("SetRootCoordClient", rootCoord)}
 }
@@ -2680,8 +2735,8 @@ type MockDataCoord_SetSegmentState_Call struct {
 }
 
 // SetSegmentState is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.SetSegmentStateRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.SetSegmentStateRequest
 func (_e *MockDataCoord_Expecter) SetSegmentState(_a0 interface{}, _a1 interface{}) *MockDataCoord_SetSegmentState_Call {
 	return &MockDataCoord_SetSegmentState_Call{Call: _e.mock.On("SetSegmentState", _a0, _a1)}
 }
@@ -2714,7 +2769,7 @@ type MockDataCoord_SetTiKVClient_Call struct {
 }
 
 // SetTiKVClient is a helper method to define mock.On call
-//  - client *txnkv.Client
+//   - client *txnkv.Client
 func (_e *MockDataCoord_Expecter) SetTiKVClient(client interface{}) *MockDataCoord_SetTiKVClient_Call {
 	return &MockDataCoord_SetTiKVClient_Call{Call: _e.mock.On("SetTiKVClient", client)}
 }
@@ -2768,8 +2823,8 @@ type MockDataCoord_ShowConfigurations_Call struct {
 }
 
 // ShowConfigurations is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *internalpb.ShowConfigurationsRequest
+//   - _a0 context.Context
+//   - _a1 *internalpb.ShowConfigurationsRequest
 func (_e *MockDataCoord_Expecter) ShowConfigurations(_a0 interface{}, _a1 interface{}) *MockDataCoord_ShowConfigurations_Call {
 	return &MockDataCoord_ShowConfigurations_Call{Call: _e.mock.On("ShowConfigurations", _a0, _a1)}
 }
@@ -2905,8 +2960,8 @@ type MockDataCoord_UnsetIsImportingState_Call struct {
 }
 
 // UnsetIsImportingState is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.UnsetIsImportingStateRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.UnsetIsImportingStateRequest
 func (_e *MockDataCoord_Expecter) UnsetIsImportingState(_a0 interface{}, _a1 interface{}) *MockDataCoord_UnsetIsImportingState_Call {
 	return &MockDataCoord_UnsetIsImportingState_Call{Call: _e.mock.On("UnsetIsImportingState", _a0, _a1)}
 }
@@ -2960,8 +3015,8 @@ type MockDataCoord_UpdateChannelCheckpoint_Call struct {
 }
 
 // UpdateChannelCheckpoint is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.UpdateChannelCheckpointRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.UpdateChannelCheckpointRequest
 func (_e *MockDataCoord_Expecter) UpdateChannelCheckpoint(_a0 interface{}, _a1 interface{}) *MockDataCoord_UpdateChannelCheckpoint_Call {
 	return &MockDataCoord_UpdateChannelCheckpoint_Call{Call: _e.mock.On("UpdateChannelCheckpoint", _a0, _a1)}
 }
@@ -3015,8 +3070,8 @@ type MockDataCoord_UpdateSegmentStatistics_Call struct {
 }
 
 // UpdateSegmentStatistics is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.UpdateSegmentStatisticsRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.UpdateSegmentStatisticsRequest
 func (_e *MockDataCoord_Expecter) UpdateSegmentStatistics(_a0 interface{}, _a1 interface{}) *MockDataCoord_UpdateSegmentStatistics_Call {
 	return &MockDataCoord_UpdateSegmentStatistics_Call{Call: _e.mock.On("UpdateSegmentStatistics", _a0, _a1)}
 }
@@ -3070,8 +3125,8 @@ type MockDataCoord_WatchChannels_Call struct {
 }
 
 // WatchChannels is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *datapb.WatchChannelsRequest
+//   - _a0 context.Context
+//   - _a1 *datapb.WatchChannelsRequest
 func (_e *MockDataCoord_Expecter) WatchChannels(_a0 interface{}, _a1 interface{}) *MockDataCoord_WatchChannels_Call {
 	return &MockDataCoord_WatchChannels_Call{Call: _e.mock.On("WatchChannels", _a0, _a1)}
 }

--- a/internal/mocks/mock_datacoord_client.go
+++ b/internal/mocks/mock_datacoord_client.go
@@ -72,9 +72,9 @@ type MockDataCoordClient_AlterIndex_Call struct {
 }
 
 // AlterIndex is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *indexpb.AlterIndexRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *indexpb.AlterIndexRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) AlterIndex(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_AlterIndex_Call {
 	return &MockDataCoordClient_AlterIndex_Call{Call: _e.mock.On("AlterIndex",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -142,9 +142,9 @@ type MockDataCoordClient_AssignSegmentID_Call struct {
 }
 
 // AssignSegmentID is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.AssignSegmentIDRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.AssignSegmentIDRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) AssignSegmentID(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_AssignSegmentID_Call {
 	return &MockDataCoordClient_AssignSegmentID_Call{Call: _e.mock.On("AssignSegmentID",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -212,9 +212,9 @@ type MockDataCoordClient_BroadcastAlteredCollection_Call struct {
 }
 
 // BroadcastAlteredCollection is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.AlterCollectionRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.AlterCollectionRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) BroadcastAlteredCollection(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_BroadcastAlteredCollection_Call {
 	return &MockDataCoordClient_BroadcastAlteredCollection_Call{Call: _e.mock.On("BroadcastAlteredCollection",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -282,9 +282,9 @@ type MockDataCoordClient_CheckHealth_Call struct {
 }
 
 // CheckHealth is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *milvuspb.CheckHealthRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *milvuspb.CheckHealthRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) CheckHealth(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_CheckHealth_Call {
 	return &MockDataCoordClient_CheckHealth_Call{Call: _e.mock.On("CheckHealth",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -393,9 +393,9 @@ type MockDataCoordClient_CreateIndex_Call struct {
 }
 
 // CreateIndex is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *indexpb.CreateIndexRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *indexpb.CreateIndexRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) CreateIndex(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_CreateIndex_Call {
 	return &MockDataCoordClient_CreateIndex_Call{Call: _e.mock.On("CreateIndex",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -463,9 +463,9 @@ type MockDataCoordClient_DescribeIndex_Call struct {
 }
 
 // DescribeIndex is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *indexpb.DescribeIndexRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *indexpb.DescribeIndexRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) DescribeIndex(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_DescribeIndex_Call {
 	return &MockDataCoordClient_DescribeIndex_Call{Call: _e.mock.On("DescribeIndex",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -533,9 +533,9 @@ type MockDataCoordClient_DropIndex_Call struct {
 }
 
 // DropIndex is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *indexpb.DropIndexRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *indexpb.DropIndexRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) DropIndex(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_DropIndex_Call {
 	return &MockDataCoordClient_DropIndex_Call{Call: _e.mock.On("DropIndex",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -603,9 +603,9 @@ type MockDataCoordClient_DropVirtualChannel_Call struct {
 }
 
 // DropVirtualChannel is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.DropVirtualChannelRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.DropVirtualChannelRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) DropVirtualChannel(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_DropVirtualChannel_Call {
 	return &MockDataCoordClient_DropVirtualChannel_Call{Call: _e.mock.On("DropVirtualChannel",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -673,9 +673,9 @@ type MockDataCoordClient_Flush_Call struct {
 }
 
 // Flush is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.FlushRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.FlushRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) Flush(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_Flush_Call {
 	return &MockDataCoordClient_Flush_Call{Call: _e.mock.On("Flush",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -743,9 +743,9 @@ type MockDataCoordClient_GcConfirm_Call struct {
 }
 
 // GcConfirm is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.GcConfirmRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.GcConfirmRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GcConfirm(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GcConfirm_Call {
 	return &MockDataCoordClient_GcConfirm_Call{Call: _e.mock.On("GcConfirm",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -813,9 +813,9 @@ type MockDataCoordClient_GcControl_Call struct {
 }
 
 // GcControl is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.GcControlRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.GcControlRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GcControl(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GcControl_Call {
 	return &MockDataCoordClient_GcControl_Call{Call: _e.mock.On("GcControl",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -883,9 +883,9 @@ type MockDataCoordClient_GetCollectionStatistics_Call struct {
 }
 
 // GetCollectionStatistics is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.GetCollectionStatisticsRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.GetCollectionStatisticsRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GetCollectionStatistics(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GetCollectionStatistics_Call {
 	return &MockDataCoordClient_GetCollectionStatistics_Call{Call: _e.mock.On("GetCollectionStatistics",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -953,9 +953,9 @@ type MockDataCoordClient_GetCompactionState_Call struct {
 }
 
 // GetCompactionState is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *milvuspb.GetCompactionStateRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *milvuspb.GetCompactionStateRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GetCompactionState(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GetCompactionState_Call {
 	return &MockDataCoordClient_GetCompactionState_Call{Call: _e.mock.On("GetCompactionState",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -1023,9 +1023,9 @@ type MockDataCoordClient_GetCompactionStateWithPlans_Call struct {
 }
 
 // GetCompactionStateWithPlans is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *milvuspb.GetCompactionPlansRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *milvuspb.GetCompactionPlansRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GetCompactionStateWithPlans(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GetCompactionStateWithPlans_Call {
 	return &MockDataCoordClient_GetCompactionStateWithPlans_Call{Call: _e.mock.On("GetCompactionStateWithPlans",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -1093,9 +1093,9 @@ type MockDataCoordClient_GetComponentStates_Call struct {
 }
 
 // GetComponentStates is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *milvuspb.GetComponentStatesRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *milvuspb.GetComponentStatesRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GetComponentStates(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GetComponentStates_Call {
 	return &MockDataCoordClient_GetComponentStates_Call{Call: _e.mock.On("GetComponentStates",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -1163,9 +1163,9 @@ type MockDataCoordClient_GetFlushAllState_Call struct {
 }
 
 // GetFlushAllState is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *milvuspb.GetFlushAllStateRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *milvuspb.GetFlushAllStateRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GetFlushAllState(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GetFlushAllState_Call {
 	return &MockDataCoordClient_GetFlushAllState_Call{Call: _e.mock.On("GetFlushAllState",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -1233,9 +1233,9 @@ type MockDataCoordClient_GetFlushState_Call struct {
 }
 
 // GetFlushState is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.GetFlushStateRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.GetFlushStateRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GetFlushState(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GetFlushState_Call {
 	return &MockDataCoordClient_GetFlushState_Call{Call: _e.mock.On("GetFlushState",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -1303,9 +1303,9 @@ type MockDataCoordClient_GetFlushedSegments_Call struct {
 }
 
 // GetFlushedSegments is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.GetFlushedSegmentsRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.GetFlushedSegmentsRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GetFlushedSegments(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GetFlushedSegments_Call {
 	return &MockDataCoordClient_GetFlushedSegments_Call{Call: _e.mock.On("GetFlushedSegments",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -1373,9 +1373,9 @@ type MockDataCoordClient_GetImportProgress_Call struct {
 }
 
 // GetImportProgress is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *internalpb.GetImportProgressRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *internalpb.GetImportProgressRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GetImportProgress(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GetImportProgress_Call {
 	return &MockDataCoordClient_GetImportProgress_Call{Call: _e.mock.On("GetImportProgress",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -1443,9 +1443,9 @@ type MockDataCoordClient_GetIndexBuildProgress_Call struct {
 }
 
 // GetIndexBuildProgress is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *indexpb.GetIndexBuildProgressRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *indexpb.GetIndexBuildProgressRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GetIndexBuildProgress(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GetIndexBuildProgress_Call {
 	return &MockDataCoordClient_GetIndexBuildProgress_Call{Call: _e.mock.On("GetIndexBuildProgress",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -1513,9 +1513,9 @@ type MockDataCoordClient_GetIndexInfos_Call struct {
 }
 
 // GetIndexInfos is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *indexpb.GetIndexInfoRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *indexpb.GetIndexInfoRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GetIndexInfos(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GetIndexInfos_Call {
 	return &MockDataCoordClient_GetIndexInfos_Call{Call: _e.mock.On("GetIndexInfos",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -1583,9 +1583,9 @@ type MockDataCoordClient_GetIndexState_Call struct {
 }
 
 // GetIndexState is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *indexpb.GetIndexStateRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *indexpb.GetIndexStateRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GetIndexState(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GetIndexState_Call {
 	return &MockDataCoordClient_GetIndexState_Call{Call: _e.mock.On("GetIndexState",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -1653,9 +1653,9 @@ type MockDataCoordClient_GetIndexStatistics_Call struct {
 }
 
 // GetIndexStatistics is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *indexpb.GetIndexStatisticsRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *indexpb.GetIndexStatisticsRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GetIndexStatistics(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GetIndexStatistics_Call {
 	return &MockDataCoordClient_GetIndexStatistics_Call{Call: _e.mock.On("GetIndexStatistics",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -1723,9 +1723,9 @@ type MockDataCoordClient_GetInsertBinlogPaths_Call struct {
 }
 
 // GetInsertBinlogPaths is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.GetInsertBinlogPathsRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.GetInsertBinlogPathsRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GetInsertBinlogPaths(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GetInsertBinlogPaths_Call {
 	return &MockDataCoordClient_GetInsertBinlogPaths_Call{Call: _e.mock.On("GetInsertBinlogPaths",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -1793,9 +1793,9 @@ type MockDataCoordClient_GetMetrics_Call struct {
 }
 
 // GetMetrics is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *milvuspb.GetMetricsRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *milvuspb.GetMetricsRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GetMetrics(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GetMetrics_Call {
 	return &MockDataCoordClient_GetMetrics_Call{Call: _e.mock.On("GetMetrics",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -1863,9 +1863,9 @@ type MockDataCoordClient_GetPartitionStatistics_Call struct {
 }
 
 // GetPartitionStatistics is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.GetPartitionStatisticsRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.GetPartitionStatisticsRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GetPartitionStatistics(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GetPartitionStatistics_Call {
 	return &MockDataCoordClient_GetPartitionStatistics_Call{Call: _e.mock.On("GetPartitionStatistics",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -1933,9 +1933,9 @@ type MockDataCoordClient_GetRecoveryInfo_Call struct {
 }
 
 // GetRecoveryInfo is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.GetRecoveryInfoRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.GetRecoveryInfoRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GetRecoveryInfo(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GetRecoveryInfo_Call {
 	return &MockDataCoordClient_GetRecoveryInfo_Call{Call: _e.mock.On("GetRecoveryInfo",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -2003,9 +2003,9 @@ type MockDataCoordClient_GetRecoveryInfoV2_Call struct {
 }
 
 // GetRecoveryInfoV2 is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.GetRecoveryInfoRequestV2
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.GetRecoveryInfoRequestV2
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GetRecoveryInfoV2(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GetRecoveryInfoV2_Call {
 	return &MockDataCoordClient_GetRecoveryInfoV2_Call{Call: _e.mock.On("GetRecoveryInfoV2",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -2073,9 +2073,9 @@ type MockDataCoordClient_GetSegmentIndexState_Call struct {
 }
 
 // GetSegmentIndexState is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *indexpb.GetSegmentIndexStateRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *indexpb.GetSegmentIndexStateRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GetSegmentIndexState(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GetSegmentIndexState_Call {
 	return &MockDataCoordClient_GetSegmentIndexState_Call{Call: _e.mock.On("GetSegmentIndexState",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -2143,9 +2143,9 @@ type MockDataCoordClient_GetSegmentInfo_Call struct {
 }
 
 // GetSegmentInfo is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.GetSegmentInfoRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.GetSegmentInfoRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GetSegmentInfo(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GetSegmentInfo_Call {
 	return &MockDataCoordClient_GetSegmentInfo_Call{Call: _e.mock.On("GetSegmentInfo",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -2213,9 +2213,9 @@ type MockDataCoordClient_GetSegmentInfoChannel_Call struct {
 }
 
 // GetSegmentInfoChannel is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.GetSegmentInfoChannelRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.GetSegmentInfoChannelRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GetSegmentInfoChannel(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GetSegmentInfoChannel_Call {
 	return &MockDataCoordClient_GetSegmentInfoChannel_Call{Call: _e.mock.On("GetSegmentInfoChannel",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -2283,9 +2283,9 @@ type MockDataCoordClient_GetSegmentStates_Call struct {
 }
 
 // GetSegmentStates is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.GetSegmentStatesRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.GetSegmentStatesRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GetSegmentStates(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GetSegmentStates_Call {
 	return &MockDataCoordClient_GetSegmentStates_Call{Call: _e.mock.On("GetSegmentStates",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -2353,9 +2353,9 @@ type MockDataCoordClient_GetSegmentsByStates_Call struct {
 }
 
 // GetSegmentsByStates is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.GetSegmentsByStatesRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.GetSegmentsByStatesRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GetSegmentsByStates(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GetSegmentsByStates_Call {
 	return &MockDataCoordClient_GetSegmentsByStates_Call{Call: _e.mock.On("GetSegmentsByStates",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -2423,9 +2423,9 @@ type MockDataCoordClient_GetStatisticsChannel_Call struct {
 }
 
 // GetStatisticsChannel is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *internalpb.GetStatisticsChannelRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *internalpb.GetStatisticsChannelRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GetStatisticsChannel(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GetStatisticsChannel_Call {
 	return &MockDataCoordClient_GetStatisticsChannel_Call{Call: _e.mock.On("GetStatisticsChannel",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -2493,9 +2493,9 @@ type MockDataCoordClient_GetTimeTickChannel_Call struct {
 }
 
 // GetTimeTickChannel is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *internalpb.GetTimeTickChannelRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *internalpb.GetTimeTickChannelRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) GetTimeTickChannel(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_GetTimeTickChannel_Call {
 	return &MockDataCoordClient_GetTimeTickChannel_Call{Call: _e.mock.On("GetTimeTickChannel",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -2563,9 +2563,9 @@ type MockDataCoordClient_Import_Call struct {
 }
 
 // Import is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.ImportTaskRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.ImportTaskRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) Import(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_Import_Call {
 	return &MockDataCoordClient_Import_Call{Call: _e.mock.On("Import",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -2633,9 +2633,9 @@ type MockDataCoordClient_ImportV2_Call struct {
 }
 
 // ImportV2 is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *internalpb.ImportRequestInternal
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *internalpb.ImportRequestInternal
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) ImportV2(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_ImportV2_Call {
 	return &MockDataCoordClient_ImportV2_Call{Call: _e.mock.On("ImportV2",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -2703,9 +2703,9 @@ type MockDataCoordClient_ListImports_Call struct {
 }
 
 // ListImports is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *internalpb.ListImportsRequestInternal
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *internalpb.ListImportsRequestInternal
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) ListImports(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_ListImports_Call {
 	return &MockDataCoordClient_ListImports_Call{Call: _e.mock.On("ListImports",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -2730,6 +2730,76 @@ func (_c *MockDataCoordClient_ListImports_Call) Return(_a0 *internalpb.ListImpor
 }
 
 func (_c *MockDataCoordClient_ListImports_Call) RunAndReturn(run func(context.Context, *internalpb.ListImportsRequestInternal, ...grpc.CallOption) (*internalpb.ListImportsResponse, error)) *MockDataCoordClient_ListImports_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ListIndexes provides a mock function with given fields: ctx, in, opts
+func (_m *MockDataCoordClient) ListIndexes(ctx context.Context, in *indexpb.ListIndexesRequest, opts ...grpc.CallOption) (*indexpb.ListIndexesResponse, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, in)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *indexpb.ListIndexesResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *indexpb.ListIndexesRequest, ...grpc.CallOption) (*indexpb.ListIndexesResponse, error)); ok {
+		return rf(ctx, in, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *indexpb.ListIndexesRequest, ...grpc.CallOption) *indexpb.ListIndexesResponse); ok {
+		r0 = rf(ctx, in, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*indexpb.ListIndexesResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *indexpb.ListIndexesRequest, ...grpc.CallOption) error); ok {
+		r1 = rf(ctx, in, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockDataCoordClient_ListIndexes_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListIndexes'
+type MockDataCoordClient_ListIndexes_Call struct {
+	*mock.Call
+}
+
+// ListIndexes is a helper method to define mock.On call
+//   - ctx context.Context
+//   - in *indexpb.ListIndexesRequest
+//   - opts ...grpc.CallOption
+func (_e *MockDataCoordClient_Expecter) ListIndexes(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_ListIndexes_Call {
+	return &MockDataCoordClient_ListIndexes_Call{Call: _e.mock.On("ListIndexes",
+		append([]interface{}{ctx, in}, opts...)...)}
+}
+
+func (_c *MockDataCoordClient_ListIndexes_Call) Run(run func(ctx context.Context, in *indexpb.ListIndexesRequest, opts ...grpc.CallOption)) *MockDataCoordClient_ListIndexes_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]grpc.CallOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(grpc.CallOption)
+			}
+		}
+		run(args[0].(context.Context), args[1].(*indexpb.ListIndexesRequest), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockDataCoordClient_ListIndexes_Call) Return(_a0 *indexpb.ListIndexesResponse, _a1 error) *MockDataCoordClient_ListIndexes_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockDataCoordClient_ListIndexes_Call) RunAndReturn(run func(context.Context, *indexpb.ListIndexesRequest, ...grpc.CallOption) (*indexpb.ListIndexesResponse, error)) *MockDataCoordClient_ListIndexes_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -2773,9 +2843,9 @@ type MockDataCoordClient_ManualCompaction_Call struct {
 }
 
 // ManualCompaction is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *milvuspb.ManualCompactionRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *milvuspb.ManualCompactionRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) ManualCompaction(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_ManualCompaction_Call {
 	return &MockDataCoordClient_ManualCompaction_Call{Call: _e.mock.On("ManualCompaction",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -2843,9 +2913,9 @@ type MockDataCoordClient_MarkSegmentsDropped_Call struct {
 }
 
 // MarkSegmentsDropped is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.MarkSegmentsDroppedRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.MarkSegmentsDroppedRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) MarkSegmentsDropped(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_MarkSegmentsDropped_Call {
 	return &MockDataCoordClient_MarkSegmentsDropped_Call{Call: _e.mock.On("MarkSegmentsDropped",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -2913,9 +2983,9 @@ type MockDataCoordClient_ReportDataNodeTtMsgs_Call struct {
 }
 
 // ReportDataNodeTtMsgs is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.ReportDataNodeTtMsgsRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.ReportDataNodeTtMsgsRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) ReportDataNodeTtMsgs(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_ReportDataNodeTtMsgs_Call {
 	return &MockDataCoordClient_ReportDataNodeTtMsgs_Call{Call: _e.mock.On("ReportDataNodeTtMsgs",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -2983,9 +3053,9 @@ type MockDataCoordClient_SaveBinlogPaths_Call struct {
 }
 
 // SaveBinlogPaths is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.SaveBinlogPathsRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.SaveBinlogPathsRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) SaveBinlogPaths(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_SaveBinlogPaths_Call {
 	return &MockDataCoordClient_SaveBinlogPaths_Call{Call: _e.mock.On("SaveBinlogPaths",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -3053,9 +3123,9 @@ type MockDataCoordClient_SaveImportSegment_Call struct {
 }
 
 // SaveImportSegment is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.SaveImportSegmentRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.SaveImportSegmentRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) SaveImportSegment(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_SaveImportSegment_Call {
 	return &MockDataCoordClient_SaveImportSegment_Call{Call: _e.mock.On("SaveImportSegment",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -3123,9 +3193,9 @@ type MockDataCoordClient_SetSegmentState_Call struct {
 }
 
 // SetSegmentState is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.SetSegmentStateRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.SetSegmentStateRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) SetSegmentState(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_SetSegmentState_Call {
 	return &MockDataCoordClient_SetSegmentState_Call{Call: _e.mock.On("SetSegmentState",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -3193,9 +3263,9 @@ type MockDataCoordClient_ShowConfigurations_Call struct {
 }
 
 // ShowConfigurations is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *internalpb.ShowConfigurationsRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *internalpb.ShowConfigurationsRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) ShowConfigurations(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_ShowConfigurations_Call {
 	return &MockDataCoordClient_ShowConfigurations_Call{Call: _e.mock.On("ShowConfigurations",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -3263,9 +3333,9 @@ type MockDataCoordClient_UnsetIsImportingState_Call struct {
 }
 
 // UnsetIsImportingState is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.UnsetIsImportingStateRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.UnsetIsImportingStateRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) UnsetIsImportingState(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_UnsetIsImportingState_Call {
 	return &MockDataCoordClient_UnsetIsImportingState_Call{Call: _e.mock.On("UnsetIsImportingState",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -3333,9 +3403,9 @@ type MockDataCoordClient_UpdateChannelCheckpoint_Call struct {
 }
 
 // UpdateChannelCheckpoint is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.UpdateChannelCheckpointRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.UpdateChannelCheckpointRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) UpdateChannelCheckpoint(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_UpdateChannelCheckpoint_Call {
 	return &MockDataCoordClient_UpdateChannelCheckpoint_Call{Call: _e.mock.On("UpdateChannelCheckpoint",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -3403,9 +3473,9 @@ type MockDataCoordClient_UpdateSegmentStatistics_Call struct {
 }
 
 // UpdateSegmentStatistics is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.UpdateSegmentStatisticsRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.UpdateSegmentStatisticsRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) UpdateSegmentStatistics(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_UpdateSegmentStatistics_Call {
 	return &MockDataCoordClient_UpdateSegmentStatistics_Call{Call: _e.mock.On("UpdateSegmentStatistics",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -3473,9 +3543,9 @@ type MockDataCoordClient_WatchChannels_Call struct {
 }
 
 // WatchChannels is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *datapb.WatchChannelsRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *datapb.WatchChannelsRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataCoordClient_Expecter) WatchChannels(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_WatchChannels_Call {
 	return &MockDataCoordClient_WatchChannels_Call{Call: _e.mock.On("WatchChannels",
 		append([]interface{}{ctx, in}, opts...)...)}

--- a/internal/proto/data_coord.proto
+++ b/internal/proto/data_coord.proto
@@ -89,6 +89,7 @@ service DataCoord {
   rpc GetIndexStatistics(index.GetIndexStatisticsRequest) returns (index.GetIndexStatisticsResponse) {}
   // Deprecated: use DescribeIndex instead
   rpc GetIndexBuildProgress(index.GetIndexBuildProgressRequest) returns (index.GetIndexBuildProgressResponse) {}
+  rpc ListIndexes(index.ListIndexesRequest) returns (index.ListIndexesResponse) {}
 
   rpc GcConfirm(GcConfirmRequest) returns (GcConfirmResponse) {}
 

--- a/internal/proto/index_coord.proto
+++ b/internal/proto/index_coord.proto
@@ -334,3 +334,12 @@ message GetIndexStatisticsResponse {
     common.Status status = 1;
     repeated IndexInfo index_infos = 2;
 }
+
+message ListIndexesRequest {
+    int64 collectionID = 1;
+}
+
+message ListIndexesResponse {
+    common.Status status = 1;
+    repeated IndexInfo index_infos = 2;
+}


### PR DESCRIPTION
See also #31103

This PR add `listIndexes` API for datacoor server to list all indexes for provided collection.
Comparing to the existing `DescribeIndex` API, the new one does NOT check the segment index building progress to ease the burden when invoking it