### PR TITLE
fix: Balance param use duplicated key (#31112)

### DIFF
--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -1540,7 +1540,7 @@ func (p *queryCoordConfig) init(base *BaseTable) {
 	p.ChannelCheckInterval.Init(base.mgr)
 
 	p.BalanceCheckInterval = ParamItem{
-		Key:          "queryCoord.checkChannelInterval",
+		Key:          "queryCoord.checkBalanceInterval",
 		Version:      "2.3.0",
 		DefaultValue: "10000",
 		PanicIfEmpty: true,


### PR DESCRIPTION
pr: #31112
issue: #31115
This PR fix balance check interval  param use duplicated key