### PR TITLE
enhance: Add segment id short cut for WithSegmentID filter

### DIFF
--- a/internal/datanode/compactor_test.go
+++ b/internal/datanode/compactor_test.go
@@ -533,7 +533,6 @@ func TestCompactionTaskInnerMethods(t *testing.T) {
 				Schema: meta.GetSchema(),
 			}, dm)
 			assert.Error(t, err)
-			t.Log(err)
 		})
 
 		t.Run("Merge with meta error", func(t *testing.T) {

--- a/internal/datanode/metacache/actions_test.go
+++ b/internal/datanode/metacache/actions_test.go
@@ -35,29 +35,29 @@ func (s *SegmentFilterSuite) TestFilters() {
 	partitionID := int64(1001)
 	filter := WithPartitionID(partitionID)
 	info.partitionID = partitionID + 1
-	s.False(filter(info))
+	s.False(filter.Filter(info))
 	info.partitionID = partitionID
-	s.True(filter(info))
+	s.True(filter.Filter(info))
 
 	segmentID := int64(10001)
 	filter = WithSegmentIDs(segmentID)
 	info.segmentID = segmentID + 1
-	s.False(filter(info))
+	s.False(filter.Filter(info))
 	info.segmentID = segmentID
-	s.True(filter(info))
+	s.True(filter.Filter(info))
 
 	state := commonpb.SegmentState_Growing
 	filter = WithSegmentState(state)
 	info.state = commonpb.SegmentState_Flushed
-	s.False(filter(info))
+	s.False(filter.Filter(info))
 	info.state = state
-	s.True(filter(info))
+	s.True(filter.Filter(info))
 
 	filter = WithStartPosNotRecorded()
 	info.startPosRecorded = true
-	s.False(filter(info))
+	s.False(filter.Filter(info))
 	info.startPosRecorded = false
-	s.True(filter(info))
+	s.True(filter.Filter(info))
 }
 
 func TestFilters(t *testing.T) {


### PR DESCRIPTION
See also #31143

This PR add short cut for datanoe metacache `WithSegmentIDs` filter, which could just fetch segment from map with provided segmentIDs. Also add benchmark for new implementation vs old one.