### PR TITLE
enhance: add metric with database and resource group label at querynode.

### DIFF
--- a/internal/proto/query_coord.proto
+++ b/internal/proto/query_coord.proto
@@ -296,6 +296,8 @@ message LoadMetaInfo {
     int64 collectionID = 2;
     repeated int64 partitionIDs = 3;
     string metric_type = 4 [deprecated = true];
+    string dbName = 5; // Only used for metrics label.
+    string resourceGroup = 6; // Only used for metrics label.
 }
 
 message WatchDmChannelsRequest {

--- a/internal/querycoordv2/balance/balance.go
+++ b/internal/querycoordv2/balance/balance.go
@@ -26,27 +26,27 @@ import (
 )
 
 type SegmentAssignPlan struct {
-	Segment   *meta.Segment
-	ReplicaID int64
-	From      int64 // -1 if empty
-	To        int64
+	Segment *meta.Segment
+	Replica *meta.ReplicaForPlan // TODO: meta.Replica has lock now, struct is hard to use, fix it after resource group enhancement.
+	From    int64                // -1 if empty
+	To      int64
 }
 
 func (segPlan *SegmentAssignPlan) ToString() string {
 	return fmt.Sprintf("SegmentPlan:[collectionID: %d, replicaID: %d, segmentID: %d, from: %d, to: %d]\n",
-		segPlan.Segment.CollectionID, segPlan.ReplicaID, segPlan.Segment.ID, segPlan.From, segPlan.To)
+		segPlan.Segment.CollectionID, segPlan.Replica.GetID(), segPlan.Segment.ID, segPlan.From, segPlan.To)
 }
 
 type ChannelAssignPlan struct {
-	Channel   *meta.DmChannel
-	ReplicaID int64
-	From      int64
-	To        int64
+	Channel *meta.DmChannel
+	Replica *meta.ReplicaForPlan // TODO: meta.Replica has lock now, struct is hard to use, fix it after resource group enhancement.
+	From    int64
+	To      int64
 }
 
 func (chanPlan *ChannelAssignPlan) ToString() string {
 	return fmt.Sprintf("ChannelPlan:[collectionID: %d, channel: %s, replicaID: %d, from: %d, to: %d]\n",
-		chanPlan.Channel.CollectionID, chanPlan.Channel.ChannelName, chanPlan.ReplicaID, chanPlan.From, chanPlan.To)
+		chanPlan.Channel.CollectionID, chanPlan.Channel.ChannelName, chanPlan.Replica.GetID(), chanPlan.From, chanPlan.To)
 }
 
 var (

--- a/internal/querycoordv2/balance/rowcount_based_balancer.go
+++ b/internal/querycoordv2/balance/rowcount_based_balancer.go
@@ -218,7 +218,7 @@ func (b *RowCountBasedBalancer) genStoppingSegmentPlan(replica *meta.Replica, on
 		plans := b.AssignSegment(replica.CollectionID, segments, onlineNodes)
 		for i := range plans {
 			plans[i].From = nodeID
-			plans[i].ReplicaID = replica.ID
+			plans[i].Replica = replica.GetReplicaForPlan()
 		}
 		segmentPlans = append(segmentPlans, plans...)
 	}
@@ -286,7 +286,7 @@ func (b *RowCountBasedBalancer) genSegmentPlan(replica *meta.Replica, onlineNode
 	segmentPlans := b.AssignSegment(replica.CollectionID, segmentsToMove, nodesWithLessRow)
 	for i := range segmentPlans {
 		segmentPlans[i].From = segmentPlans[i].Segment.Node
-		segmentPlans[i].ReplicaID = replica.ID
+		segmentPlans[i].Replica = replica.GetReplicaForPlan()
 	}
 
 	return segmentPlans
@@ -299,7 +299,7 @@ func (b *RowCountBasedBalancer) genStoppingChannelPlan(replica *meta.Replica, on
 		plans := b.AssignChannel(dmChannels, onlineNodes)
 		for i := range plans {
 			plans[i].From = nodeID
-			plans[i].ReplicaID = replica.ID
+			plans[i].Replica = replica.GetReplicaForPlan()
 		}
 		channelPlans = append(channelPlans, plans...)
 	}
@@ -337,7 +337,7 @@ func (b *RowCountBasedBalancer) genChannelPlan(replica *meta.Replica, onlineNode
 		channelPlans := b.AssignChannel(channelsToMove, nodeWithLessChannel)
 		for i := range channelPlans {
 			channelPlans[i].From = channelPlans[i].Channel.Node
-			channelPlans[i].ReplicaID = replica.ID
+			channelPlans[i].Replica = replica.GetReplicaForPlan()
 		}
 
 		return channelPlans

--- a/internal/querycoordv2/balance/rowcount_based_balancer_test.go
+++ b/internal/querycoordv2/balance/rowcount_based_balancer_test.go
@@ -168,7 +168,7 @@ func (suite *RowCountBasedBalancerTestSuite) TestBalance() {
 				},
 			},
 			expectPlans: []SegmentAssignPlan{
-				{Segment: &meta.Segment{SegmentInfo: &datapb.SegmentInfo{ID: 2, CollectionID: 1, NumOfRows: 20}, Node: 2}, From: 2, To: 1, ReplicaID: 1},
+				{Segment: &meta.Segment{SegmentInfo: &datapb.SegmentInfo{ID: 2, CollectionID: 1, NumOfRows: 20}, Node: 2}, From: 2, To: 1, Replica: meta.NewReplicaForPlanAtDefaultRG(1)},
 			},
 			expectChannelPlans: []ChannelAssignPlan{},
 		},
@@ -248,7 +248,7 @@ func (suite *RowCountBasedBalancerTestSuite) TestBalance() {
 			},
 			expectPlans: []SegmentAssignPlan{},
 			expectChannelPlans: []ChannelAssignPlan{
-				{Channel: &meta.DmChannel{VchannelInfo: &datapb.VchannelInfo{CollectionID: 1, ChannelName: "v3"}, Node: 3}, From: 3, To: 1, ReplicaID: 1},
+				{Channel: &meta.DmChannel{VchannelInfo: &datapb.VchannelInfo{CollectionID: 1, ChannelName: "v3"}, Node: 3}, From: 3, To: 1, Replica: meta.NewReplicaForPlanAtDefaultRG(1)},
 			},
 		},
 		{
@@ -277,8 +277,8 @@ func (suite *RowCountBasedBalancerTestSuite) TestBalance() {
 				},
 			},
 			expectPlans: []SegmentAssignPlan{
-				{Segment: &meta.Segment{SegmentInfo: &datapb.SegmentInfo{ID: 4, CollectionID: 1, NumOfRows: 10}, Node: 3}, From: 3, To: 1, ReplicaID: 1},
-				{Segment: &meta.Segment{SegmentInfo: &datapb.SegmentInfo{ID: 5, CollectionID: 1, NumOfRows: 10}, Node: 3}, From: 3, To: 1, ReplicaID: 1},
+				{Segment: &meta.Segment{SegmentInfo: &datapb.SegmentInfo{ID: 4, CollectionID: 1, NumOfRows: 10}, Node: 3}, From: 3, To: 1, Replica: meta.NewReplicaForPlanAtDefaultRG(1)},
+				{Segment: &meta.Segment{SegmentInfo: &datapb.SegmentInfo{ID: 5, CollectionID: 1, NumOfRows: 10}, Node: 3}, From: 3, To: 1, Replica: meta.NewReplicaForPlanAtDefaultRG(1)},
 			},
 			expectChannelPlans: []ChannelAssignPlan{},
 		},
@@ -298,7 +298,7 @@ func (suite *RowCountBasedBalancerTestSuite) TestBalance() {
 			},
 			expectPlans: []SegmentAssignPlan{},
 			expectChannelPlans: []ChannelAssignPlan{
-				{Channel: &meta.DmChannel{VchannelInfo: &datapb.VchannelInfo{CollectionID: 1, ChannelName: "v3"}, Node: 2}, From: 2, To: 3, ReplicaID: 1},
+				{Channel: &meta.DmChannel{VchannelInfo: &datapb.VchannelInfo{CollectionID: 1, ChannelName: "v3"}, Node: 2}, From: 2, To: 3, Replica: meta.NewReplicaForPlanAtDefaultRG(1)},
 			},
 		},
 		{
@@ -340,8 +340,8 @@ func (suite *RowCountBasedBalancerTestSuite) TestBalance() {
 			},
 			expectPlans: []SegmentAssignPlan{},
 			expectChannelPlans: []ChannelAssignPlan{
-				{Channel: &meta.DmChannel{VchannelInfo: &datapb.VchannelInfo{CollectionID: 1, ChannelName: "v2"}, Node: 1}, From: 1, To: 2, ReplicaID: 1},
-				{Channel: &meta.DmChannel{VchannelInfo: &datapb.VchannelInfo{CollectionID: 1, ChannelName: "v2"}, Node: 1}, From: 1, To: 3, ReplicaID: 1},
+				{Channel: &meta.DmChannel{VchannelInfo: &datapb.VchannelInfo{CollectionID: 1, ChannelName: "v2"}, Node: 1}, From: 1, To: 2, Replica: meta.NewReplicaForPlanAtDefaultRG(1)},
+				{Channel: &meta.DmChannel{VchannelInfo: &datapb.VchannelInfo{CollectionID: 1, ChannelName: "v2"}, Node: 1}, From: 1, To: 3, Replica: meta.NewReplicaForPlanAtDefaultRG(1)},
 			},
 			multiple: true,
 		},
@@ -427,6 +427,7 @@ func (suite *RowCountBasedBalancerTestSuite) TestBalance() {
 			segmentPlans, channelPlans := suite.getCollectionBalancePlans(balancer, 1)
 			if !c.multiple {
 				suite.ElementsMatch(c.expectChannelPlans, channelPlans)
+				// TODO: mutex in segmentPlans, fix it on resource group enhancement.
 				suite.ElementsMatch(c.expectPlans, segmentPlans)
 			} else {
 				suite.Subset(c.expectPlans, segmentPlans)
@@ -527,8 +528,8 @@ func (suite *RowCountBasedBalancerTestSuite) TestBalanceOnPartStopping() {
 				},
 			},
 			expectPlans: []SegmentAssignPlan{
-				{Segment: &meta.Segment{SegmentInfo: &datapb.SegmentInfo{ID: 4, CollectionID: 1, NumOfRows: 10}, Node: 3}, From: 3, To: 1, ReplicaID: 1},
-				{Segment: &meta.Segment{SegmentInfo: &datapb.SegmentInfo{ID: 5, CollectionID: 1, NumOfRows: 10}, Node: 3}, From: 3, To: 1, ReplicaID: 1},
+				{Segment: &meta.Segment{SegmentInfo: &datapb.SegmentInfo{ID: 4, CollectionID: 1, NumOfRows: 10}, Node: 3}, From: 3, To: 1, Replica: meta.NewReplicaForPlanAtDefaultRG(1)},
+				{Segment: &meta.Segment{SegmentInfo: &datapb.SegmentInfo{ID: 5, CollectionID: 1, NumOfRows: 10}, Node: 3}, From: 3, To: 1, Replica: meta.NewReplicaForPlanAtDefaultRG(1)},
 			},
 			expectChannelPlans: []ChannelAssignPlan{},
 		},
@@ -591,7 +592,7 @@ func (suite *RowCountBasedBalancerTestSuite) TestBalanceOnPartStopping() {
 			},
 			expectPlans: []SegmentAssignPlan{},
 			expectChannelPlans: []ChannelAssignPlan{
-				{Channel: &meta.DmChannel{VchannelInfo: &datapb.VchannelInfo{CollectionID: 1, ChannelName: "v3"}, Node: 3}, From: 3, To: 1, ReplicaID: 1},
+				{Channel: &meta.DmChannel{VchannelInfo: &datapb.VchannelInfo{CollectionID: 1, ChannelName: "v3"}, Node: 3}, From: 3, To: 1, Replica: meta.NewReplicaForPlanAtDefaultRG(1)},
 			},
 		},
 	}
@@ -681,7 +682,7 @@ func (suite *RowCountBasedBalancerTestSuite) TestBalanceOutboundNodes() {
 			},
 			expectPlans: []SegmentAssignPlan{},
 			expectChannelPlans: []ChannelAssignPlan{
-				{Channel: &meta.DmChannel{VchannelInfo: &datapb.VchannelInfo{CollectionID: 1, ChannelName: "v3"}, Node: 3}, From: 3, To: 1, ReplicaID: 1},
+				{Channel: &meta.DmChannel{VchannelInfo: &datapb.VchannelInfo{CollectionID: 1, ChannelName: "v3"}, Node: 3}, From: 3, To: 1, Replica: meta.NewReplicaForPlanAtDefaultRG(1)},
 			},
 		},
 		{
@@ -710,8 +711,8 @@ func (suite *RowCountBasedBalancerTestSuite) TestBalanceOutboundNodes() {
 				},
 			},
 			expectPlans: []SegmentAssignPlan{
-				{Segment: &meta.Segment{SegmentInfo: &datapb.SegmentInfo{ID: 4, CollectionID: 1, NumOfRows: 10}, Node: 3}, From: 3, To: 1, ReplicaID: 1},
-				{Segment: &meta.Segment{SegmentInfo: &datapb.SegmentInfo{ID: 5, CollectionID: 1, NumOfRows: 10}, Node: 3}, From: 3, To: 1, ReplicaID: 1},
+				{Segment: &meta.Segment{SegmentInfo: &datapb.SegmentInfo{ID: 4, CollectionID: 1, NumOfRows: 10}, Node: 3}, From: 3, To: 1, Replica: meta.NewReplicaForPlanAtDefaultRG(1)},
+				{Segment: &meta.Segment{SegmentInfo: &datapb.SegmentInfo{ID: 5, CollectionID: 1, NumOfRows: 10}, Node: 3}, From: 3, To: 1, Replica: meta.NewReplicaForPlanAtDefaultRG(1)},
 			},
 			expectChannelPlans: []ChannelAssignPlan{},
 		},
@@ -924,7 +925,7 @@ func (suite *RowCountBasedBalancerTestSuite) TestDisableBalanceChannel() {
 			},
 			expectPlans: []SegmentAssignPlan{},
 			expectChannelPlans: []ChannelAssignPlan{
-				{Channel: &meta.DmChannel{VchannelInfo: &datapb.VchannelInfo{CollectionID: 1, ChannelName: "v3"}, Node: 2}, From: 2, To: 3, ReplicaID: 1},
+				{Channel: &meta.DmChannel{VchannelInfo: &datapb.VchannelInfo{CollectionID: 1, ChannelName: "v3"}, Node: 2}, From: 2, To: 3, Replica: meta.NewReplicaForPlanAtDefaultRG(1)},
 			},
 			enableBalanceChannel: true,
 		},

--- a/internal/querycoordv2/balance/score_based_balancer.go
+++ b/internal/querycoordv2/balance/score_based_balancer.go
@@ -252,7 +252,7 @@ func (b *ScoreBasedBalancer) genStoppingSegmentPlan(replica *meta.Replica, onlin
 		plans := b.AssignSegment(replica.CollectionID, segments, onlineNodes)
 		for i := range plans {
 			plans[i].From = nodeID
-			plans[i].ReplicaID = replica.ID
+			plans[i].Replica = replica.GetReplicaForPlan()
 		}
 		segmentPlans = append(segmentPlans, plans...)
 	}
@@ -316,7 +316,7 @@ func (b *ScoreBasedBalancer) genSegmentPlan(replica *meta.Replica, onlineNodes [
 	segmentPlans := b.AssignSegment(replica.CollectionID, segmentsToMove, onlineNodes)
 	for i := range segmentPlans {
 		segmentPlans[i].From = segmentPlans[i].Segment.Node
-		segmentPlans[i].ReplicaID = replica.ID
+		segmentPlans[i].Replica = replica.GetReplicaForPlan()
 	}
 
 	return segmentPlans

--- a/internal/querycoordv2/balance/score_based_balancer_test.go
+++ b/internal/querycoordv2/balance/score_based_balancer_test.go
@@ -316,7 +316,7 @@ func (suite *ScoreBasedBalancerTestSuite) TestBalanceOneRound() {
 				},
 			},
 			expectPlans: []SegmentAssignPlan{
-				{Segment: &meta.Segment{SegmentInfo: &datapb.SegmentInfo{ID: 2, CollectionID: 1, NumOfRows: 20}, Node: 2}, From: 2, To: 1, ReplicaID: 1},
+				{Segment: &meta.Segment{SegmentInfo: &datapb.SegmentInfo{ID: 2, CollectionID: 1, NumOfRows: 20}, Node: 2}, From: 2, To: 1, Replica: meta.NewReplicaForPlanAtDefaultRG(1)},
 			},
 			expectChannelPlans: []ChannelAssignPlan{},
 		},
@@ -450,7 +450,7 @@ func (suite *ScoreBasedBalancerTestSuite) TestBalanceMultiRound() {
 					Segment: &meta.Segment{
 						SegmentInfo: &datapb.SegmentInfo{ID: 3, CollectionID: 1, NumOfRows: 20},
 						Node:        2,
-					}, From: 2, To: 3, ReplicaID: 1,
+					}, From: 2, To: 3, Replica: meta.NewReplicaForPlanAtDefaultRG(1),
 				},
 			},
 			{},
@@ -548,11 +548,11 @@ func (suite *ScoreBasedBalancerTestSuite) TestStoppedBalance() {
 				{Segment: &meta.Segment{
 					SegmentInfo: &datapb.SegmentInfo{ID: 2, CollectionID: 1, NumOfRows: 20},
 					Node:        1,
-				}, From: 1, To: 3, ReplicaID: 1},
+				}, From: 1, To: 3, Replica: meta.NewReplicaForPlanAtDefaultRG(1)},
 				{Segment: &meta.Segment{
 					SegmentInfo: &datapb.SegmentInfo{ID: 1, CollectionID: 1, NumOfRows: 10},
 					Node:        1,
-				}, From: 1, To: 3, ReplicaID: 1},
+				}, From: 1, To: 3, Replica: meta.NewReplicaForPlanAtDefaultRG(1)},
 			},
 			expectChannelPlans: []ChannelAssignPlan{},
 		},

--- a/internal/querycoordv2/balance/utils.go
+++ b/internal/querycoordv2/balance/utils.go
@@ -51,14 +51,14 @@ func CreateSegmentTasksFromPlans(ctx context.Context, source task.Source, timeou
 			timeout,
 			source,
 			p.Segment.GetCollectionID(),
-			p.ReplicaID,
+			p.Replica,
 			actions...,
 		)
 		if err != nil {
 			log.Warn("create segment task from plan failed",
 				zap.Int64("collection", p.Segment.GetCollectionID()),
 				zap.Int64("segmentID", p.Segment.GetID()),
-				zap.Int64("replica", p.ReplicaID),
+				zap.Int64("replica", p.Replica.GetID()),
 				zap.String("channel", p.Segment.GetInsertChannel()),
 				zap.Int64("from", p.From),
 				zap.Int64("to", p.To),
@@ -70,7 +70,7 @@ func CreateSegmentTasksFromPlans(ctx context.Context, source task.Source, timeou
 		log.Info("create segment task",
 			zap.Int64("collection", p.Segment.GetCollectionID()),
 			zap.Int64("segmentID", p.Segment.GetID()),
-			zap.Int64("replica", p.ReplicaID),
+			zap.Int64("replica", p.Replica.GetID()),
 			zap.String("channel", p.Segment.GetInsertChannel()),
 			zap.Int64("from", p.From),
 			zap.Int64("to", p.To))
@@ -98,11 +98,11 @@ func CreateChannelTasksFromPlans(ctx context.Context, source task.Source, timeou
 			action := task.NewChannelAction(p.From, task.ActionTypeReduce, p.Channel.GetChannelName())
 			actions = append(actions, action)
 		}
-		t, err := task.NewChannelTask(ctx, timeout, source, p.Channel.GetCollectionID(), p.ReplicaID, actions...)
+		t, err := task.NewChannelTask(ctx, timeout, source, p.Channel.GetCollectionID(), p.Replica, actions...)
 		if err != nil {
 			log.Warn("create channel task failed",
 				zap.Int64("collection", p.Channel.GetCollectionID()),
-				zap.Int64("replica", p.ReplicaID),
+				zap.Int64("replica", p.Replica.GetID()),
 				zap.String("channel", p.Channel.GetChannelName()),
 				zap.Int64("from", p.From),
 				zap.Int64("to", p.To),
@@ -113,7 +113,7 @@ func CreateChannelTasksFromPlans(ctx context.Context, source task.Source, timeou
 
 		log.Info("create channel task",
 			zap.Int64("collection", p.Channel.GetCollectionID()),
-			zap.Int64("replica", p.ReplicaID),
+			zap.Int64("replica", p.Replica.GetID()),
 			zap.String("channel", p.Channel.GetChannelName()),
 			zap.Int64("from", p.From),
 			zap.Int64("to", p.To))

--- a/internal/querycoordv2/checkers/balance_checker_test.go
+++ b/internal/querycoordv2/checkers/balance_checker_test.go
@@ -286,10 +286,10 @@ func (suite *BalanceCheckerTestSuite) TestStoppingBalance() {
 	// checker check
 	segPlans, chanPlans := make([]balance.SegmentAssignPlan, 0), make([]balance.ChannelAssignPlan, 0)
 	mockPlan := balance.SegmentAssignPlan{
-		Segment:   utils.CreateTestSegment(1, 1, 1, 1, 1, "1"),
-		ReplicaID: 1,
-		From:      1,
-		To:        2,
+		Segment: utils.CreateTestSegment(1, 1, 1, 1, 1, "1"),
+		Replica: nil,
+		From:    1,
+		To:      2,
 	}
 	segPlans = append(segPlans, mockPlan)
 	suite.balancer.EXPECT().BalanceReplica(mock.Anything).Return(segPlans, chanPlans)

--- a/internal/querycoordv2/checkers/channel_checker_test.go
+++ b/internal/querycoordv2/checkers/channel_checker_test.go
@@ -104,10 +104,10 @@ func (suite *ChannelCheckerTestSuite) createMockBalancer() balance.Balance {
 		plans := make([]balance.ChannelAssignPlan, 0, len(channels))
 		for i, c := range channels {
 			plan := balance.ChannelAssignPlan{
-				Channel:   c,
-				From:      -1,
-				To:        nodes[i%len(nodes)],
-				ReplicaID: -1,
+				Channel: c,
+				From:    -1,
+				To:      nodes[i%len(nodes)],
+				Replica: nil,
 			}
 			plans = append(plans, plan)
 		}

--- a/internal/querycoordv2/checkers/index_checker.go
+++ b/internal/querycoordv2/checkers/index_checker.go
@@ -165,7 +165,7 @@ func (c *IndexChecker) createSegmentUpdateTask(ctx context.Context, segment *met
 		params.Params.QueryCoordCfg.SegmentTaskTimeout.GetAsDuration(time.Millisecond),
 		c.ID(),
 		segment.GetCollectionID(),
-		replica.GetID(),
+		replica.GetReplicaForPlan(),
 		action,
 	)
 	if err != nil {

--- a/internal/querycoordv2/checkers/leader_checker.go
+++ b/internal/querycoordv2/checkers/leader_checker.go
@@ -101,8 +101,8 @@ func (c *LeaderChecker) Check(ctx context.Context) []task.Task {
 				leaderViews := c.dist.LeaderViewManager.GetByCollectionAndNode(replica.GetCollectionID(), node)
 				for ch, leaderView := range leaderViews {
 					dist := c.dist.SegmentDistManager.GetByFilter(meta.WithChannel(ch), meta.WithReplica(replica))
-					tasks = append(tasks, c.findNeedLoadedSegments(ctx, replica.ID, leaderView, dist)...)
-					tasks = append(tasks, c.findNeedRemovedSegments(ctx, replica.ID, leaderView, dist)...)
+					tasks = append(tasks, c.findNeedLoadedSegments(ctx, replica, leaderView, dist)...)
+					tasks = append(tasks, c.findNeedRemovedSegments(ctx, replica, leaderView, dist)...)
 				}
 			}
 		}
@@ -111,10 +111,10 @@ func (c *LeaderChecker) Check(ctx context.Context) []task.Task {
 	return tasks
 }
 
-func (c *LeaderChecker) findNeedLoadedSegments(ctx context.Context, replica int64, leaderView *meta.LeaderView, dist []*meta.Segment) []task.Task {
+func (c *LeaderChecker) findNeedLoadedSegments(ctx context.Context, replica *meta.Replica, leaderView *meta.LeaderView, dist []*meta.Segment) []task.Task {
 	log := log.Ctx(ctx).With(
 		zap.Int64("collectionID", leaderView.CollectionID),
-		zap.Int64("replica", replica),
+		zap.Int64("replica", replica.GetID()),
 		zap.String("channel", leaderView.Channel),
 		zap.Int64("leaderViewID", leaderView.ID),
 	)
@@ -137,7 +137,7 @@ func (c *LeaderChecker) findNeedLoadedSegments(ctx context.Context, replica int6
 				params.Params.QueryCoordCfg.SegmentTaskTimeout.GetAsDuration(time.Millisecond),
 				c.ID(),
 				s.GetCollectionID(),
-				replica,
+				replica.GetReplicaForPlan(),
 				leaderView.ID,
 				action,
 			)
@@ -150,10 +150,10 @@ func (c *LeaderChecker) findNeedLoadedSegments(ctx context.Context, replica int6
 	return ret
 }
 
-func (c *LeaderChecker) findNeedRemovedSegments(ctx context.Context, replica int64, leaderView *meta.LeaderView, dists []*meta.Segment) []task.Task {
+func (c *LeaderChecker) findNeedRemovedSegments(ctx context.Context, replica *meta.Replica, leaderView *meta.LeaderView, dists []*meta.Segment) []task.Task {
 	log := log.Ctx(ctx).With(
 		zap.Int64("collectionID", leaderView.CollectionID),
-		zap.Int64("replica", replica),
+		zap.Int64("replica", replica.GetID()),
 		zap.String("channel", leaderView.Channel),
 		zap.Int64("leaderViewID", leaderView.ID),
 	)
@@ -179,7 +179,7 @@ func (c *LeaderChecker) findNeedRemovedSegments(ctx context.Context, replica int
 			paramtable.Get().QueryCoordCfg.SegmentTaskTimeout.GetAsDuration(time.Millisecond),
 			c.ID(),
 			leaderView.CollectionID,
-			replica,
+			replica.GetReplicaForPlan(),
 			leaderView.ID,
 			action,
 		)

--- a/internal/querycoordv2/checkers/segment_checker_test.go
+++ b/internal/querycoordv2/checkers/segment_checker_test.go
@@ -91,10 +91,10 @@ func (suite *SegmentCheckerTestSuite) createMockBalancer() balance.Balance {
 		plans := make([]balance.SegmentAssignPlan, 0, len(segments))
 		for i, s := range segments {
 			plan := balance.SegmentAssignPlan{
-				Segment:   s,
-				From:      -1,
-				To:        nodes[i%len(nodes)],
-				ReplicaID: -1,
+				Segment: s,
+				From:    -1,
+				To:      nodes[i%len(nodes)],
+				Replica: nil,
 			}
 			plans = append(plans, plan)
 		}

--- a/internal/querycoordv2/handlers.go
+++ b/internal/querycoordv2/handlers.go
@@ -144,7 +144,7 @@ func (s *Server) balanceSegments(ctx context.Context, req *querypb.LoadBalanceRe
 			Params.QueryCoordCfg.SegmentTaskTimeout.GetAsDuration(time.Millisecond),
 			task.WrapIDSource(req.GetBase().GetMsgID()),
 			req.GetCollectionID(),
-			replica.GetID(),
+			replica.GetReplicaForPlan(),
 			task.NewSegmentActionWithScope(plan.To, task.ActionTypeGrow, plan.Segment.GetInsertChannel(), plan.Segment.GetID(), querypb.DataScope_Historical),
 			task.NewSegmentActionWithScope(srcNode, task.ActionTypeReduce, plan.Segment.GetInsertChannel(), plan.Segment.GetID(), querypb.DataScope_Historical),
 		)

--- a/internal/querycoordv2/task/executor.go
+++ b/internal/querycoordv2/task/executor.go
@@ -317,11 +317,13 @@ func (ex *Executor) subscribeChannel(task *ChannelTask, step int) error {
 		log.Warn("fail to get index meta of collection")
 		return err
 	}
-	loadMeta := packLoadMeta(
-		ex.meta.GetLoadType(task.CollectionID()),
-		task.CollectionID(),
-		partitions...,
-	)
+	loadMeta := &querypb.LoadMetaInfo{
+		LoadType:      ex.meta.GetLoadType(task.CollectionID()),
+		CollectionID:  task.CollectionID(),
+		PartitionIDs:  partitions,
+		DbName:        collectionInfo.GetDbName(),
+		ResourceGroup: task.ResourceGroup(),
+	}
 
 	dmChannel := ex.targetMgr.GetDmChannel(task.CollectionID(), action.ChannelName(), meta.NextTarget)
 	if dmChannel == nil {
@@ -561,11 +563,14 @@ func (ex *Executor) getMetaInfo(ctx context.Context, task Task) (*milvuspb.Descr
 		return nil, nil, nil, err
 	}
 
-	loadMeta := packLoadMeta(
-		ex.meta.GetLoadType(collectionID),
-		collectionID,
-		partitions...,
-	)
+	loadMeta := &querypb.LoadMetaInfo{
+		LoadType:      ex.meta.GetLoadType(collectionID),
+		CollectionID:  collectionID,
+		PartitionIDs:  partitions,
+		DbName:        collectionInfo.GetDbName(),
+		ResourceGroup: task.ResourceGroup(),
+	}
+
 	// get channel first, in case of target updated after segment info fetched
 	channel := ex.targetMgr.GetDmChannel(collectionID, shard, meta.NextTargetFirst)
 	if channel == nil {

--- a/internal/querycoordv2/task/task.go
+++ b/internal/querycoordv2/task/task.go
@@ -71,7 +71,10 @@ type Task interface {
 	Source() Source
 	ID() typeutil.UniqueID
 	CollectionID() typeutil.UniqueID
+	// Return 0 if the task is a reduce task without given replica.
 	ReplicaID() typeutil.UniqueID
+	// Return "" if the task is a reduce task without given replica.
+	ResourceGroup() string
 	Shard() string
 	SetID(id typeutil.UniqueID)
 	Status() Status
@@ -103,9 +106,11 @@ type baseTask struct {
 
 	id           typeutil.UniqueID // Set by scheduler
 	collectionID typeutil.UniqueID
-	replicaID    typeutil.UniqueID
-	shard        string
-	loadType     querypb.LoadType
+	replica      *meta.ReplicaForPlan // May be nil if the task is a reduce task,
+	// So all replica operation should be checked before using it.
+	// TODO: change it into meta.Replica in future.
+	shard    string
+	loadType querypb.LoadType
 
 	source   Source
 	status   *atomic.String
@@ -119,14 +124,14 @@ type baseTask struct {
 	span trace.Span
 }
 
-func newBaseTask(ctx context.Context, source Source, collectionID, replicaID typeutil.UniqueID, shard string, taskTag string) *baseTask {
+func newBaseTask(ctx context.Context, source Source, collectionID typeutil.UniqueID, replica *meta.ReplicaForPlan, shard string, taskTag string) *baseTask {
 	ctx, cancel := context.WithCancel(ctx)
 	ctx, span := otel.Tracer(typeutil.QueryCoordRole).Start(ctx, taskTag)
 
 	return &baseTask{
 		source:       source,
 		collectionID: collectionID,
-		replicaID:    replicaID,
+		replica:      replica,
 		shard:        shard,
 
 		status:   atomic.NewString(TaskStatusStarted),
@@ -160,7 +165,13 @@ func (task *baseTask) CollectionID() typeutil.UniqueID {
 }
 
 func (task *baseTask) ReplicaID() typeutil.UniqueID {
-	return task.replicaID
+	// replica may be nil, 0 will be generated.
+	return task.replica.GetID()
+}
+
+func (task *baseTask) ResourceGroup() string {
+	// replica may be nil, empty string will be generated.
+	return task.replica.GetResourceGroup()
 }
 
 func (task *baseTask) Shard() string {
@@ -188,7 +199,7 @@ func (task *baseTask) SetPriority(priority Priority) {
 }
 
 func (task *baseTask) Index() string {
-	return fmt.Sprintf("[replica=%d]", task.replicaID)
+	return fmt.Sprintf("[replica=%d]", task.ReplicaID())
 }
 
 func (task *baseTask) Err() error {
@@ -267,13 +278,14 @@ func (task *baseTask) String() string {
 		}
 	}
 	return fmt.Sprintf(
-		"[id=%d] [type=%s] [source=%s] [reason=%s] [collectionID=%d] [replicaID=%d] [priority=%s] [actionsCount=%d] [actions=%s]",
+		"[id=%d] [type=%s] [source=%s] [reason=%s] [collectionID=%d] [replicaID=%d] [resourceGroup=%s] [priority=%s] [actionsCount=%d] [actions=%s]",
 		task.id,
 		GetTaskType(task).String(),
 		task.source.String(),
 		task.reason,
 		task.collectionID,
-		task.replicaID,
+		task.ReplicaID(),
+		task.ResourceGroup(),
 		task.priority.String(),
 		len(task.actions),
 		actionsStr,
@@ -292,8 +304,8 @@ type SegmentTask struct {
 func NewSegmentTask(ctx context.Context,
 	timeout time.Duration,
 	source Source,
-	collectionID,
-	replicaID typeutil.UniqueID,
+	collectionID typeutil.UniqueID,
+	replica *meta.ReplicaForPlan,
 	actions ...Action,
 ) (*SegmentTask, error) {
 	if len(actions) == 0 {
@@ -315,7 +327,7 @@ func NewSegmentTask(ctx context.Context,
 		}
 	}
 
-	base := newBaseTask(ctx, source, collectionID, replicaID, shard, fmt.Sprintf("SegmentTask-%s-%d", actions[0].Type().String(), segmentID))
+	base := newBaseTask(ctx, source, collectionID, replica, shard, fmt.Sprintf("SegmentTask-%s-%d", actions[0].Type().String(), segmentID))
 	base.actions = actions
 	return &SegmentTask{
 		baseTask:  base,
@@ -345,8 +357,8 @@ type ChannelTask struct {
 func NewChannelTask(ctx context.Context,
 	timeout time.Duration,
 	source Source,
-	collectionID,
-	replicaID typeutil.UniqueID,
+	collectionID typeutil.UniqueID,
+	replica *meta.ReplicaForPlan,
 	actions ...Action,
 ) (*ChannelTask, error) {
 	if len(actions) == 0 {
@@ -366,7 +378,7 @@ func NewChannelTask(ctx context.Context,
 		}
 	}
 
-	base := newBaseTask(ctx, source, collectionID, replicaID, channel, fmt.Sprintf("ChannelTask-%s-%s", actions[0].Type().String(), channel))
+	base := newBaseTask(ctx, source, collectionID, replica, channel, fmt.Sprintf("ChannelTask-%s-%s", actions[0].Type().String(), channel))
 	base.actions = actions
 	return &ChannelTask{
 		baseTask: base,
@@ -395,8 +407,8 @@ type LeaderTask struct {
 func NewLeaderTask(ctx context.Context,
 	timeout time.Duration,
 	source Source,
-	collectionID,
-	replicaID typeutil.UniqueID,
+	collectionID typeutil.UniqueID,
+	replicaID *meta.ReplicaForPlan,
 	leaderID int64,
 	action *LeaderAction,
 ) *LeaderTask {

--- a/internal/querycoordv2/task/task_test.go
+++ b/internal/querycoordv2/task/task_test.go
@@ -59,7 +59,7 @@ type TaskSuite struct {
 
 	// Data
 	collection      int64
-	replica         int64
+	replica         *meta.ReplicaForPlan
 	subChannels     []string
 	unsubChannels   []string
 	moveChannels    []string
@@ -86,7 +86,7 @@ type TaskSuite struct {
 func (suite *TaskSuite) SetupSuite() {
 	paramtable.Init()
 	suite.collection = 1000
-	suite.replica = 10
+	suite.replica = meta.NewReplicaForPlanAtDefaultRG(10)
 	suite.subChannels = []string{
 		"sub-0",
 		"sub-1",
@@ -191,8 +191,7 @@ func (suite *TaskSuite) BeforeTest(suiteName, testName string) {
 				PartitionID:  1,
 			},
 		})
-		suite.meta.ReplicaManager.Put(
-			utils.CreateTestReplica(suite.replica, suite.collection, []int64{1, 2, 3}))
+		suite.meta.ReplicaManager.Put(utils.CreateTestReplica(suite.replica.GetID(), suite.collection, []int64{1, 2, 3}))
 	}
 }
 
@@ -349,7 +348,7 @@ func (suite *TaskSuite) TestUnsubscribeChannelTask() {
 			timeout,
 			WrapIDSource(0),
 			suite.collection,
-			-1,
+			nil,
 			NewChannelAction(targetNode, ActionTypeReduce, channel),
 		)
 
@@ -1343,39 +1342,39 @@ func (suite *TaskSuite) TestLeaderTaskSet() {
 }
 
 func (suite *TaskSuite) TestCreateTaskBehavior() {
-	chanelTask, err := NewChannelTask(context.TODO(), 5*time.Second, WrapIDSource(0), 0, 0)
+	chanelTask, err := NewChannelTask(context.TODO(), 5*time.Second, WrapIDSource(0), 0, nil)
 	suite.ErrorIs(err, merr.ErrParameterInvalid)
 	suite.Nil(chanelTask)
 
 	action := NewSegmentAction(0, 0, "", 0)
-	chanelTask, err = NewChannelTask(context.TODO(), 5*time.Second, WrapIDSource(0), 0, 0, action)
+	chanelTask, err = NewChannelTask(context.TODO(), 5*time.Second, WrapIDSource(0), 0, nil, action)
 	suite.ErrorIs(err, merr.ErrParameterInvalid)
 	suite.Nil(chanelTask)
 
 	action1 := NewChannelAction(0, 0, "fake-channel1")
 	action2 := NewChannelAction(0, 0, "fake-channel2")
-	chanelTask, err = NewChannelTask(context.TODO(), 5*time.Second, WrapIDSource(0), 0, 0, action1, action2)
+	chanelTask, err = NewChannelTask(context.TODO(), 5*time.Second, WrapIDSource(0), 0, nil, action1, action2)
 	suite.ErrorIs(err, merr.ErrParameterInvalid)
 	suite.Nil(chanelTask)
 
-	segmentTask, err := NewSegmentTask(context.TODO(), 5*time.Second, WrapIDSource(0), 0, 0)
+	segmentTask, err := NewSegmentTask(context.TODO(), 5*time.Second, WrapIDSource(0), 0, nil)
 	suite.ErrorIs(err, merr.ErrParameterInvalid)
 	suite.Nil(segmentTask)
 
 	channelAction := NewChannelAction(0, 0, "fake-channel1")
-	segmentTask, err = NewSegmentTask(context.TODO(), 5*time.Second, WrapIDSource(0), 0, 0, channelAction)
+	segmentTask, err = NewSegmentTask(context.TODO(), 5*time.Second, WrapIDSource(0), 0, nil, channelAction)
 	suite.ErrorIs(err, merr.ErrParameterInvalid)
 	suite.Nil(segmentTask)
 
 	segmentAction1 := NewSegmentAction(0, 0, "", 0)
 	segmentAction2 := NewSegmentAction(0, 0, "", 1)
 
-	segmentTask, err = NewSegmentTask(context.TODO(), 5*time.Second, WrapIDSource(0), 0, 0, segmentAction1, segmentAction2)
+	segmentTask, err = NewSegmentTask(context.TODO(), 5*time.Second, WrapIDSource(0), 0, nil, segmentAction1, segmentAction2)
 	suite.ErrorIs(err, merr.ErrParameterInvalid)
 	suite.Nil(segmentTask)
 
 	leaderAction := NewLeaderAction(1, 2, ActionTypeGrow, "fake-channel1", 100, 0)
-	leaderTask := NewLeaderTask(context.TODO(), 5*time.Second, WrapIDSource(0), 0, 0, 1, leaderAction)
+	leaderTask := NewLeaderTask(context.TODO(), 5*time.Second, WrapIDSource(0), 0, nil, 1, leaderAction)
 	suite.NotNil(leaderTask)
 }
 
@@ -1447,8 +1446,7 @@ func (suite *TaskSuite) TestNoExecutor() {
 		ChannelName:  Params.CommonCfg.RootCoordDml.GetValue() + "-test",
 	}
 
-	suite.meta.ReplicaManager.Put(
-		utils.CreateTestReplica(suite.replica, suite.collection, []int64{1, 2, 3, -1}))
+	suite.meta.ReplicaManager.Put(utils.CreateTestReplica(suite.replica.GetID(), suite.collection, []int64{1, 2, 3, -1}))
 
 	// Test load segment task
 	suite.dist.ChannelDistManager.Update(targetNode, meta.DmChannelFromVChannel(&datapb.VchannelInfo{
@@ -1666,7 +1664,7 @@ func (suite *TaskSuite) TestBalanceChannelTask() {
 		10*time.Second,
 		WrapIDSource(2),
 		collectionID,
-		1,
+		nil,
 		NewChannelAction(1, ActionTypeGrow, channel),
 		NewChannelAction(2, ActionTypeReduce, channel),
 	)

--- a/internal/querycoordv2/task/utils.go
+++ b/internal/querycoordv2/task/utils.go
@@ -180,14 +180,6 @@ func packReleaseSegmentRequest(task *SegmentTask, action *SegmentAction) *queryp
 	}
 }
 
-func packLoadMeta(loadType querypb.LoadType, collectionID int64, partitions ...int64) *querypb.LoadMetaInfo {
-	return &querypb.LoadMetaInfo{
-		LoadType:     loadType,
-		CollectionID: collectionID,
-		PartitionIDs: partitions,
-	}
-}
-
 func packSubChannelRequest(
 	task *ChannelTask,
 	action Action,

--- a/internal/querycoordv2/task/utils_test.go
+++ b/internal/querycoordv2/task/utils_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/proto/querypb"
+	"github.com/milvus-io/milvus/internal/querycoordv2/meta"
 	"github.com/milvus-io/milvus/pkg/common"
 )
 
@@ -43,7 +44,7 @@ func (s *UtilsSuite) TestPackLoadSegmentRequest() {
 		time.Second,
 		nil,
 		1,
-		10,
+		meta.NewReplicaForPlanAtDefaultRG(10),
 		action,
 	)
 	s.NoError(err)
@@ -96,7 +97,7 @@ func (s *UtilsSuite) TestPackLoadSegmentRequestMmap() {
 		time.Second,
 		nil,
 		1,
-		10,
+		meta.NewReplicaForPlanAtDefaultRG(10),
 		action,
 	)
 	s.NoError(err)

--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -87,18 +87,22 @@ func (sd *shardDelegator) ProcessInsert(insertRecords map[int64]*InsertData) {
 		growing := sd.segmentManager.GetGrowing(segmentID)
 		if growing == nil {
 			var err error
+			// TODO: It's a wired implementation that growing segment have load info.
+			// we should separate the growing segment and sealed segment by type system.
 			growing, err = segments.NewSegment(
 				context.Background(),
 				sd.collection,
-				segmentID,
-				insertData.PartitionID,
-				sd.collectionID,
-				sd.vchannelName,
 				segments.SegmentTypeGrowing,
 				0,
-				insertData.StartPosition,
-				insertData.StartPosition,
-				datapb.SegmentLevel_L1,
+				&querypb.SegmentLoadInfo{
+					SegmentID:     segmentID,
+					PartitionID:   insertData.PartitionID,
+					CollectionID:  sd.collectionID,
+					InsertChannel: sd.vchannelName,
+					StartPosition: insertData.StartPosition,
+					DeltaPosition: insertData.StartPosition,
+					Level:         datapb.SegmentLevel_L1,
+				},
 			)
 			if err != nil {
 				log.Error("failed to create new segment",

--- a/internal/querynodev2/local_worker_test.go
+++ b/internal/querynodev2/local_worker_test.go
@@ -94,7 +94,9 @@ func (suite *LocalWorkerTestSuite) BeforeTest(suiteName, testName string) {
 
 	suite.schema = segments.GenTestCollectionSchema(suite.collectionName, schemapb.DataType_Int64, true)
 	suite.indexMeta = segments.GenTestIndexMeta(suite.collectionID, suite.schema)
-	collection := segments.NewCollection(suite.collectionID, suite.schema, suite.indexMeta, querypb.LoadType_LoadCollection)
+	collection := segments.NewCollection(suite.collectionID, suite.schema, suite.indexMeta, &querypb.LoadMetaInfo{
+		LoadType: querypb.LoadType_LoadCollection,
+	})
 	loadMata := &querypb.LoadMetaInfo{
 		LoadType:     querypb.LoadType_LoadCollection,
 		CollectionID: suite.collectionID,

--- a/internal/querynodev2/pipeline/insert_node_test.go
+++ b/internal/querynodev2/pipeline/insert_node_test.go
@@ -61,7 +61,9 @@ func (suite *InsertNodeSuite) TestBasic() {
 	schema := segments.GenTestCollectionSchema(suite.collectionName, schemapb.DataType_Int64, true)
 	in := suite.buildInsertNodeMsg(schema)
 
-	collection := segments.NewCollection(suite.collectionID, schema, segments.GenTestIndexMeta(suite.collectionID, schema), querypb.LoadType_LoadCollection)
+	collection := segments.NewCollection(suite.collectionID, schema, segments.GenTestIndexMeta(suite.collectionID, schema), &querypb.LoadMetaInfo{
+		LoadType: querypb.LoadType_LoadCollection,
+	})
 	collection.AddPartition(suite.partitionID)
 
 	// init mock
@@ -95,7 +97,9 @@ func (suite *InsertNodeSuite) TestDataTypeNotSupported() {
 	schema := segments.GenTestCollectionSchema(suite.collectionName, schemapb.DataType_Int64, true)
 	in := suite.buildInsertNodeMsg(schema)
 
-	collection := segments.NewCollection(suite.collectionID, schema, segments.GenTestIndexMeta(suite.collectionID, schema), querypb.LoadType_LoadCollection)
+	collection := segments.NewCollection(suite.collectionID, schema, segments.GenTestIndexMeta(suite.collectionID, schema), &querypb.LoadMetaInfo{
+		LoadType: querypb.LoadType_LoadCollection,
+	})
 	collection.AddPartition(suite.partitionID)
 
 	// init mock

--- a/internal/querynodev2/pipeline/pipeline_test.go
+++ b/internal/querynodev2/pipeline/pipeline_test.go
@@ -109,7 +109,9 @@ func (suite *PipelineTestSuite) TestBasic() {
 	// init mock
 	//	mock collection manager
 	schema := segments.GenTestCollectionSchema(suite.collectionName, schemapb.DataType_Int64, true)
-	collection := segments.NewCollection(suite.collectionID, schema, segments.GenTestIndexMeta(suite.collectionID, schema), querypb.LoadType_LoadCollection)
+	collection := segments.NewCollection(suite.collectionID, schema, segments.GenTestIndexMeta(suite.collectionID, schema), &querypb.LoadMetaInfo{
+		LoadType: querypb.LoadType_LoadCollection,
+	})
 	suite.collectionManager.EXPECT().Get(suite.collectionID).Return(collection)
 
 	//  mock mq factory

--- a/internal/querynodev2/segments/index_attr_cache_test.go
+++ b/internal/querynodev2/segments/index_attr_cache_test.go
@@ -51,7 +51,7 @@ func (s *IndexAttrCacheSuite) TestCacheMissing() {
 		CurrentIndexVersion: 0,
 	}
 
-	_, _, err := s.c.GetIndexResourceUsage(info)
+	_, _, err := s.c.GetIndexResourceUsage(info, paramtable.Get().QueryNodeCfg.MemoryIndexLoadPredictMemoryUsageFactor.GetAsFloat())
 	s.Require().NoError(err)
 
 	_, has := s.c.loadWithDisk.Get(typeutil.NewPair[string, int32]("test", 0))
@@ -67,7 +67,7 @@ func (s *IndexAttrCacheSuite) TestDiskANN() {
 		IndexSize:           100,
 	}
 
-	memory, disk, err := s.c.GetIndexResourceUsage(info)
+	memory, disk, err := s.c.GetIndexResourceUsage(info, paramtable.Get().QueryNodeCfg.MemoryIndexLoadPredictMemoryUsageFactor.GetAsFloat())
 	s.Require().NoError(err)
 
 	_, has := s.c.loadWithDisk.Get(typeutil.NewPair[string, int32](indexparamcheck.IndexDISKANN, 0))
@@ -88,7 +88,7 @@ func (s *IndexAttrCacheSuite) TestLoadWithDisk() {
 
 	s.Run("load_with_disk", func() {
 		s.c.loadWithDisk.Insert(typeutil.NewPair[string, int32]("test", 0), true)
-		memory, disk, err := s.c.GetIndexResourceUsage(info)
+		memory, disk, err := s.c.GetIndexResourceUsage(info, paramtable.Get().QueryNodeCfg.MemoryIndexLoadPredictMemoryUsageFactor.GetAsFloat())
 		s.Require().NoError(err)
 
 		s.EqualValues(100, memory)
@@ -97,7 +97,7 @@ func (s *IndexAttrCacheSuite) TestLoadWithDisk() {
 
 	s.Run("load_with_disk", func() {
 		s.c.loadWithDisk.Insert(typeutil.NewPair[string, int32]("test", 0), false)
-		memory, disk, err := s.c.GetIndexResourceUsage(info)
+		memory, disk, err := s.c.GetIndexResourceUsage(info, paramtable.Get().QueryNodeCfg.MemoryIndexLoadPredictMemoryUsageFactor.GetAsFloat())
 		s.Require().NoError(err)
 
 		s.Equal(uint64(250), memory)
@@ -109,7 +109,7 @@ func (s *IndexAttrCacheSuite) TestLoadWithDisk() {
 			IndexParams: []*commonpb.KeyValuePair{},
 		}
 
-		_, _, err := s.c.GetIndexResourceUsage(info)
+		_, _, err := s.c.GetIndexResourceUsage(info, paramtable.Get().QueryNodeCfg.MemoryIndexLoadPredictMemoryUsageFactor.GetAsFloat())
 		s.Error(err)
 	})
 }

--- a/internal/querynodev2/segments/manager_test.go
+++ b/internal/querynodev2/segments/manager_test.go
@@ -46,7 +46,9 @@ func (s *ManagerSuite) SetupTest() {
 		schema := GenTestCollectionSchema("manager-suite", schemapb.DataType_Int64, true)
 		segment, err := NewSegment(
 			context.Background(),
-			NewCollection(s.collectionIDs[i], schema, GenTestIndexMeta(s.collectionIDs[i], schema), querypb.LoadType_LoadCollection),
+			NewCollection(s.collectionIDs[i], schema, GenTestIndexMeta(s.collectionIDs[i], schema), &querypb.LoadMetaInfo{
+				LoadType: querypb.LoadType_LoadCollection,
+			}),
 			id,
 			s.partitionIDs[i],
 			s.collectionIDs[i],

--- a/internal/querynodev2/segments/manager_test.go
+++ b/internal/querynodev2/segments/manager_test.go
@@ -49,15 +49,15 @@ func (s *ManagerSuite) SetupTest() {
 			NewCollection(s.collectionIDs[i], schema, GenTestIndexMeta(s.collectionIDs[i], schema), &querypb.LoadMetaInfo{
 				LoadType: querypb.LoadType_LoadCollection,
 			}),
-			id,
-			s.partitionIDs[i],
-			s.collectionIDs[i],
-			s.channels[i],
 			s.types[i],
 			0,
-			nil,
-			nil,
-			s.levels[i],
+			&querypb.SegmentLoadInfo{
+				SegmentID:     id,
+				PartitionID:   s.partitionIDs[i],
+				CollectionID:  s.collectionIDs[i],
+				InsertChannel: s.channels[i],
+				Level:         s.levels[i],
+			},
 		)
 		s.Require().NoError(err)
 		s.segments = append(s.segments, segment)

--- a/internal/querynodev2/segments/metricsutil/active_segment_metric_manager.go
+++ b/internal/querynodev2/segments/metricsutil/active_segment_metric_manager.go
@@ -1,0 +1,156 @@
+package metricsutil
+
+import (
+	"github.com/cockroachdb/errors"
+	"github.com/expr-lang/expr"
+	"github.com/expr-lang/expr/vm"
+	"github.com/milvus-io/milvus/pkg/log"
+	"github.com/milvus-io/milvus/pkg/metrics"
+	"github.com/milvus-io/milvus/pkg/util/paramtable"
+	"go.uber.org/zap"
+)
+
+var _ metricManager = &activeSegmentMetricManager{}
+
+// databaseLabel is the label of the active segment metric.
+type databaseLabel struct {
+	database      string
+	resourceGroup string
+}
+
+// newActiveSegmentMetricManager creates a new active segment metric manager.
+func newActiveSegmentMetricManager(nodeID string) *activeSegmentMetricManager {
+	return &activeSegmentMetricManager{
+		nodeID:    nodeID,
+		lastUsage: make(map[databaseLabel]*ResourceUsageMetrics),
+	}
+}
+
+// activeSegmentMetricManager is the active segment metric manager.
+type activeSegmentMetricManager struct {
+	nodeID      string
+	lastExpr    string
+	enabledExpr string
+	exprProgram *vm.Program
+	lastUsage   map[databaseLabel]*ResourceUsageMetrics
+}
+
+// Apply update the active segment metric.
+func (m *activeSegmentMetricManager) Apply(s *sampler) {
+	// update the active segment predicate expression if needed.
+	m.updateActiveSegmentPredicate()
+	usage, err := m.aggregateSegments(s)
+	if err != nil {
+		log.Warn("failed to aggregate active segments", zap.Error(err))
+		return
+	}
+	m.overwriteMetrics(usage)
+}
+
+// overwriteMetrics overwrites the active segment metrics.
+func (m *activeSegmentMetricManager) overwriteMetrics(usages map[databaseLabel]*ResourceUsageMetrics) {
+	for label, usage := range usages {
+		metrics.QueryNodeActiveSegmentMemoryBytes.WithLabelValues(m.nodeID, label.database, label.resourceGroup).Set(float64(usage.MemUsage))
+		metrics.QueryNodeActiveSegmentDiskBytes.WithLabelValues(m.nodeID, label.database, label.resourceGroup).Set(float64(usage.DiskUsage))
+	}
+	// Remove the metrics of the active segments that are not active now.
+	for label := range m.lastUsage {
+		if _, ok := usages[label]; !ok {
+			metrics.QueryNodeActiveSegmentMemoryBytes.DeleteLabelValues(m.nodeID, label.database, label.resourceGroup)
+			metrics.QueryNodeActiveSegmentDiskBytes.DeleteLabelValues(m.nodeID, label.database, label.resourceGroup)
+		}
+	}
+	m.lastUsage = usages
+}
+
+// updateActiveSegmentPredicate updates the active segment predicate expression.
+func (m *activeSegmentMetricManager) updateActiveSegmentPredicate() {
+	newExpr := paramtable.Get().QueryNodeCfg.ActiveSegmentPredicateExpr.GetValue()
+	if newExpr == m.lastExpr {
+		return
+	}
+
+	m.lastExpr = newExpr
+	program, err := m.compileExpr(newExpr)
+	if err != nil {
+		log.Warn("failed to update active segment predicate, use old one", zap.Error(err), zap.String("oldExpr", m.enabledExpr), zap.String("newExpr", newExpr))
+		return
+	}
+	log.Info("update active segment predicate expression", zap.String("oldExpr", m.enabledExpr), zap.String("newExpr", newExpr))
+	m.enabledExpr = newExpr
+	m.exprProgram = program
+}
+
+// aggregateSegments aggregates the active segments.
+func (m *activeSegmentMetricManager) aggregateSegments(s *sampler) (map[databaseLabel]*ResourceUsageMetrics, error) {
+	if m.exprProgram == nil {
+		return nil, errors.New("active segment predicate expression is nil")
+	}
+
+	// aggregate the active segments.
+	history := s.GetHistory()
+	usages := make(map[databaseLabel]*ResourceUsageMetrics, len(history))
+	for label, h := range history {
+		l := databaseLabel{
+			database:      label.DatabaseName,
+			resourceGroup: label.ResourceGroup,
+		}
+		if h.Len() <= 1 {
+			// skip the segment with only one snapsactive or no snapsactive.
+			continue
+		}
+		// Skip no resource usage segment.
+		if h.latestResourceUsage.IsZero() {
+			continue
+		}
+
+		ok, err := m.runPredicate(h)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to run active segment predicate expression on label %v, history count: %d", label, h.Len())
+		}
+		// update the active metric if predicate success.
+		if ok {
+			if usage, ok := usages[l]; !ok {
+				usages[l] = &ResourceUsageMetrics{
+					MemUsage:  h.latestResourceUsage.MemUsage,
+					DiskUsage: h.latestResourceUsage.DiskUsage,
+				}
+			} else {
+				usage.MemUsage += h.latestResourceUsage.MemUsage
+				usage.DiskUsage += h.latestResourceUsage.DiskUsage
+			}
+		}
+	}
+	return usages, nil
+}
+
+// compileExpr compiles the expression.
+func (m *activeSegmentMetricManager) compileExpr(newExpr string) (*vm.Program, error) {
+	program, err := expr.Compile(newExpr)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to compile active segment predicate expression")
+	}
+
+	output, err := expr.Run(program, getTestSegmentHistory())
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to test active segment predicate on test case")
+	}
+	_, ok := output.(bool)
+	if !ok {
+		return nil, errors.New("failed to convert output to bool on test case")
+	}
+	return program, nil
+}
+
+// runPredicate runs the predicate expression.
+func (m *activeSegmentMetricManager) runPredicate(h *segmentHistory) (bool, error) {
+	output, err := expr.Run(m.exprProgram, h)
+	if err != nil {
+		return false, err
+	}
+	b, ok := output.(bool)
+	if !ok {
+		return false, errors.New("failed to convert output to bool")
+	}
+	return b, nil
+}

--- a/internal/querynodev2/segments/metricsutil/active_segment_metric_manager_test.go
+++ b/internal/querynodev2/segments/metricsutil/active_segment_metric_manager_test.go
@@ -1,0 +1,104 @@
+package metricsutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/milvus-io/milvus/pkg/util/paramtable"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestActiveSegmentMetricManagerWithDefaultPredicate(t *testing.T) {
+	sampler := newSampler()
+
+	paramtable.Get().Save("queryNode.activeSegmentPredicateExpr", "len(Snapshots) >= 4 && (((Snapshots[-1].AccessCount() - Snapshots[-4].AccessCount()) / (Snapshots[-1].Time.Sub(Snapshots[-4].Time).Seconds())) > 0.1)")
+	manager := newActiveSegmentMetricManager("1")
+	newLabel := testLabel
+	newLabel.SegmentID = 10086
+	NewResourceEstimateRecord(testLabel).
+		WithDiskUsage(2048).
+		WithMemUsage(1024).Finish(nil)
+
+	NewResourceEstimateRecord(newLabel).
+		WithDiskUsage(4096).
+		WithMemUsage(2048).Finish(nil)
+
+	// only one snapshot, no metrics should be updated.
+	sampler.Scrape()
+	manager.Apply(sampler)
+	assert.Empty(t, manager.lastUsage)
+	// small qps
+	for i := 0; i < 100; i++ {
+		NewQuerySegmentAccessRecord(testLabel).Finish(nil)
+		NewQuerySegmentAccessRecord(newLabel).Finish(nil)
+		if i%25 == 0 {
+			sampler.Scrape()
+		}
+	}
+
+	manager.Apply(sampler)
+	assert.NotEmpty(t, manager.lastUsage)
+	l := databaseLabel{
+		database:      testLabel.DatabaseName,
+		resourceGroup: testLabel.ResourceGroup,
+	}
+	assert.Equal(t, uint64(6144), manager.lastUsage[l].DiskUsage)
+	assert.Equal(t, uint64(3072), manager.lastUsage[l].MemUsage)
+
+	// high qps limit
+	paramtable.Get().Save("queryNode.activeSegmentPredicateExpr", "len(Snapshots) >= 4 && (((Snapshots[-1].AccessCount() - Snapshots[-4].AccessCount()) / (Snapshots[-1].Time.Sub(Snapshots[-4].Time).Seconds())) > 1000000)")
+	for i := 0; i < 10; i++ {
+		NewQuerySegmentAccessRecord(testLabel).Finish(nil)
+		time.Sleep(100 * time.Millisecond)
+		sampler.Scrape()
+	}
+
+	manager.Apply(sampler)
+	assert.Empty(t, manager.lastUsage)
+}
+
+func TestPredicateUpdate(t *testing.T) {
+	expr := "len(Snapshots) >= 4 && (((Snapshots[-1].AccessCount() - Snapshots[-4].AccessCount()) / (Snapshots[-1].Time.Sub(Snapshots[-4].Time).Seconds())) > 0.1)"
+	paramtable.Get().Save("queryNode.activeSegmentPredicateExpr", expr)
+
+	m := newActiveSegmentMetricManager("1")
+	assert.Empty(t, m.lastExpr)
+	assert.Empty(t, m.enabledExpr)
+	assert.Nil(t, m.exprProgram)
+
+	m.updateActiveSegmentPredicate()
+	assert.Equal(t, expr, m.lastExpr)
+	assert.Equal(t, expr, m.enabledExpr)
+	assert.NotNil(t, m.exprProgram)
+
+	// illegal expr, using old one.
+	expr2 := "....*..."
+	paramtable.Get().Save("queryNode.activeSegmentPredicateExpr", expr2)
+	m.updateActiveSegmentPredicate()
+	assert.Equal(t, expr2, m.lastExpr)
+	assert.Equal(t, expr, m.enabledExpr)
+	assert.NotNil(t, m.exprProgram)
+
+	// cannot pass the testing.
+	expr2 = "Snapshots.Get()"
+	paramtable.Get().Save("queryNode.activeSegmentPredicateExpr", expr2)
+	m.updateActiveSegmentPredicate()
+	assert.Equal(t, expr2, m.lastExpr)
+	assert.Equal(t, expr, m.enabledExpr)
+	assert.NotNil(t, m.exprProgram)
+
+	// not bool expression.
+	expr2 = "1"
+	paramtable.Get().Save("queryNode.activeSegmentPredicateExpr", expr2)
+	m.updateActiveSegmentPredicate()
+	assert.Equal(t, expr2, m.lastExpr)
+	assert.Equal(t, expr, m.enabledExpr)
+	assert.NotNil(t, m.exprProgram)
+
+	expr = "len(Snapshots) >= 5"
+	paramtable.Get().Save("queryNode.activeSegmentPredicateExpr", expr)
+	m.updateActiveSegmentPredicate()
+	assert.Equal(t, expr, m.lastExpr)
+	assert.Equal(t, expr, m.enabledExpr)
+	assert.NotNil(t, m.exprProgram)
+}

--- a/internal/querynodev2/segments/metricsutil/history.go
+++ b/internal/querynodev2/segments/metricsutil/history.go
@@ -1,0 +1,53 @@
+package metricsutil
+
+import (
+	"time"
+)
+
+const (
+	maxSampleCount = 50
+)
+
+// newSegmentHistory creates a new segmentPredicateEnv.
+func newSegmentHistory() *segmentHistory {
+	return &segmentHistory{
+		Snapshots: make([]SegmentObserverSnapshot, 0, 2*maxSampleCount),
+	}
+}
+
+// segmentHistory is the environment for segment predicate.
+type segmentHistory struct {
+	latestResourceUsage ResourceUsageMetrics
+	Snapshots           []SegmentObserverSnapshot
+}
+
+// Len returns the length of the series.
+// !!! don't move these method, it will be used in hot segment predicate.
+func (h *segmentHistory) Len() int {
+	return len(h.Snapshots)
+}
+
+// Append appends a new snapshot to the series.
+func (h *segmentHistory) Append(snapshot SegmentObserverSnapshot) {
+	h.Snapshots = append(h.Snapshots, snapshot)
+	h.latestResourceUsage = snapshot.ResourceUsage
+}
+
+// Shrink removes old snapshots.
+func (h *segmentHistory) Shrink(expireAt time.Time) {
+	// keep snapshot small.
+	offset := len(h.Snapshots) - maxSampleCount
+	if offset > 0 {
+		h.Snapshots = h.Snapshots[offset:]
+	}
+
+	// expire by time, keep snapshot set small.
+	k := -1
+	for i := 0; i < len(h.Snapshots); i++ {
+		if h.Snapshots[i].Time.After(expireAt) {
+			break
+		}
+		k = i
+	}
+	h.Snapshots = h.Snapshots[k+1:]
+}

--- a/internal/querynodev2/segments/metricsutil/history_test.go
+++ b/internal/querynodev2/segments/metricsutil/history_test.go
@@ -1,0 +1,58 @@
+package metricsutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHistory(t *testing.T) {
+	h := newSegmentHistory()
+	g := newSegmentObserver("1", SegmentLabel{
+		SegmentID:     1,
+		DatabaseName:  "db1",
+		ResourceGroup: "rg1",
+	})
+
+	h.Append(g.Snapshot())
+	assert.Equal(t, 1, h.Len())
+
+	for i := 0; i < 99; i++ {
+		g = newSegmentObserver("1", SegmentLabel{
+			SegmentID:     1,
+			DatabaseName:  "db1",
+			ResourceGroup: "rg1",
+		})
+		h.Append(g.Snapshot())
+	}
+	assert.Equal(t, 100, h.Len())
+	h.Shrink(time.Now().Add(-snapshotExpire))
+	assert.Equal(t, 50, h.Len())
+	h.Shrink(time.Now())
+	assert.Equal(t, 0, h.Len())
+}
+
+func TestHistoryGetSnapshot(t *testing.T) {
+	h := newSegmentHistory()
+
+	g := newSegmentObserver("1", SegmentLabel{
+		SegmentID:     1,
+		DatabaseName:  "db1",
+		ResourceGroup: "rg1",
+	})
+
+	snapshot := g.Snapshot()
+	now := snapshot.Time
+	h.Append(snapshot)
+
+	snapshot = g.Snapshot()
+	snapshot.Time = now.Add(time.Second)
+	h.Append(snapshot)
+
+	snapshot = g.Snapshot()
+	snapshot.Time = now.Add(2 * time.Second)
+	h.Append(snapshot)
+
+	assert.Len(t, h.Snapshots, 3)
+}

--- a/internal/querynodev2/segments/metricsutil/loaded_segment_metric_manager.go
+++ b/internal/querynodev2/segments/metricsutil/loaded_segment_metric_manager.go
@@ -1,0 +1,83 @@
+package metricsutil
+
+import (
+	"github.com/milvus-io/milvus/pkg/metrics"
+)
+
+var _ metricManager = &loadedSegmentMetricManager{}
+
+// ResourceUsageMetrics records the estimate resource usage of the segment.
+type ResourceUsageMetrics struct {
+	MemUsage  uint64
+	DiskUsage uint64
+	RowNum    uint64
+}
+
+func (m *ResourceUsageMetrics) IsZero() bool {
+	return m.MemUsage == 0 && m.DiskUsage == 0
+}
+
+// newLoadedSegmentMetricManager creates a new active segment metric manager.
+func newLoadedSegmentMetricManager(nodeID string) *loadedSegmentMetricManager {
+	return &loadedSegmentMetricManager{
+		nodeID:    nodeID,
+		lastUsage: make(map[databaseLabel]*ResourceUsageMetrics),
+	}
+}
+
+// loadedSegmentMetricManager is the active segment metric manager.
+type loadedSegmentMetricManager struct {
+	nodeID    string
+	lastUsage map[databaseLabel]*ResourceUsageMetrics
+}
+
+// Apply update the active segment metric.
+func (m *loadedSegmentMetricManager) Apply(s *sampler) {
+	usage := m.aggregateSegments(s)
+	m.overwriteMetrics(usage)
+}
+
+// aggregateSegments aggregates the segments.
+func (m *loadedSegmentMetricManager) aggregateSegments(s *sampler) map[databaseLabel]*ResourceUsageMetrics {
+	// aggregate the hot segments.
+	history := s.GetHistory()
+
+	usages := make(map[databaseLabel]*ResourceUsageMetrics, len(history))
+	for label, h := range history {
+		// Skip no resource usage segment.
+		if h.latestResourceUsage.IsZero() {
+			continue
+		}
+
+		l := databaseLabel{
+			database:      label.DatabaseName,
+			resourceGroup: label.ResourceGroup,
+		}
+		if usage, ok := usages[l]; !ok {
+			usages[l] = &ResourceUsageMetrics{
+				MemUsage:  h.latestResourceUsage.MemUsage,
+				DiskUsage: h.latestResourceUsage.DiskUsage,
+			}
+		} else {
+			usage.MemUsage += h.latestResourceUsage.MemUsage
+			usage.DiskUsage += h.latestResourceUsage.DiskUsage
+		}
+	}
+	return usages
+}
+
+// overwriteMetrics overwrites the hot segment metrics.
+func (m *loadedSegmentMetricManager) overwriteMetrics(usages map[databaseLabel]*ResourceUsageMetrics) {
+	for label, usage := range usages {
+		metrics.QueryNodeLoadedSegmentMemoryBytes.WithLabelValues(m.nodeID, label.database, label.resourceGroup).Set(float64(usage.MemUsage))
+		metrics.QueryNodeLoadedSegmentDiskBytes.WithLabelValues(m.nodeID, label.database, label.resourceGroup).Set(float64(usage.DiskUsage))
+	}
+	// Remove the metrics of the hot segments that are not hot now.
+	for label := range m.lastUsage {
+		if _, ok := usages[label]; !ok {
+			metrics.QueryNodeLoadedSegmentMemoryBytes.DeleteLabelValues(m.nodeID, label.database, label.resourceGroup)
+			metrics.QueryNodeLoadedSegmentDiskBytes.DeleteLabelValues(m.nodeID, label.database, label.resourceGroup)
+		}
+	}
+	m.lastUsage = usages
+}

--- a/internal/querynodev2/segments/metricsutil/loaded_segment_metric_manager_test.go
+++ b/internal/querynodev2/segments/metricsutil/loaded_segment_metric_manager_test.go
@@ -1,0 +1,76 @@
+package metricsutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// deprecated: only for test.
+func resetGlobalObserver() {
+	globalObserver = newSegmentsObserver()
+}
+
+func TestLoadedSegmentMetricManager(t *testing.T) {
+	resetGlobalObserver()
+	sampler := newSampler()
+	NewResourceEstimateRecord(testLabel).
+		WithDiskUsage(2048).
+		WithMemUsage(1024).Finish(nil)
+	sampler.Scrape()
+
+	manager := newLoadedSegmentMetricManager("1")
+	manager.Apply(sampler)
+
+	l := databaseLabel{
+		database:      testLabel.DatabaseName,
+		resourceGroup: testLabel.ResourceGroup,
+	}
+	assert.NotEmpty(t, manager.lastUsage)
+	assert.Equal(t, uint64(1024), manager.lastUsage[l].MemUsage)
+	assert.Equal(t, uint64(2048), manager.lastUsage[l].DiskUsage)
+
+	// no new segment incoming, nothing changed.
+	sampler.Scrape()
+	manager.Apply(sampler)
+	assert.NotEmpty(t, manager.lastUsage)
+	assert.Equal(t, uint64(1024), manager.lastUsage[l].MemUsage)
+	assert.Equal(t, uint64(2048), manager.lastUsage[l].DiskUsage)
+
+	// new segment incoming, update the metrics.
+	newLabel := testLabel
+	newLabel.SegmentID = 19
+	NewResourceEstimateRecord(newLabel).
+		WithDiskUsage(4096).
+		WithMemUsage(2048).Finish(nil)
+	sampler.Scrape()
+	manager.Apply(sampler)
+	assert.NotEmpty(t, manager.lastUsage)
+	assert.Equal(t, uint64(3072), manager.lastUsage[l].MemUsage)
+	assert.Equal(t, uint64(6144), manager.lastUsage[l].DiskUsage)
+
+	// new database incoming.
+	newLabel = testLabel
+	newLabel.DatabaseName = "db13"
+	l2 := databaseLabel{
+		database:      newLabel.DatabaseName,
+		resourceGroup: newLabel.ResourceGroup,
+	}
+	NewResourceEstimateRecord(newLabel).
+		WithDiskUsage(4096).
+		WithMemUsage(2048).Finish(nil)
+	sampler.Scrape()
+	manager.Apply(sampler)
+
+	assert.Equal(t, uint64(2048), manager.lastUsage[l2].MemUsage)
+	assert.Equal(t, uint64(4096), manager.lastUsage[l2].DiskUsage)
+	// do not change old one.
+	assert.Equal(t, uint64(3072), manager.lastUsage[l].MemUsage)
+	assert.Equal(t, uint64(6144), manager.lastUsage[l].DiskUsage)
+
+	// test expired
+	sampler.historyExpiration(time.Now())
+	manager.Apply(sampler)
+	assert.Empty(t, manager.lastUsage)
+}

--- a/internal/querynodev2/segments/metricsutil/observer.go
+++ b/internal/querynodev2/segments/metricsutil/observer.go
@@ -1,0 +1,321 @@
+package metricsutil
+
+import (
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/milvus-io/milvus/pkg/metrics"
+	"github.com/milvus-io/milvus/pkg/util/metricsutil"
+	"github.com/milvus-io/milvus/pkg/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/util/typeutil"
+	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/atomic"
+)
+
+// labeledRecord is a labeled sample point.
+type labeledRecord interface {
+	// Label of the access metric.
+	Label() SegmentLabel
+
+	Finish(err error)
+}
+
+// globalObserver is the global resource groups observer.
+var (
+	once           sync.Once
+	globalObserver *segmentsObserver
+)
+
+func getGlobalObserver() *segmentsObserver {
+	once.Do(func() {
+		globalObserver = newSegmentsObserver()
+	})
+	return globalObserver
+}
+
+// newSegmentsObserver creates a new segmentsObserver.
+// Used to check if a segment is hot or cold.
+func newSegmentsObserver() *segmentsObserver {
+	return &segmentsObserver{
+		nodeID:   strconv.FormatInt(paramtable.GetNodeID(), 10),
+		segments: typeutil.NewConcurrentMap[SegmentLabel, *segmentObserver](),
+	}
+}
+
+// segmentsObserver is a observer all segments metrics.
+type segmentsObserver struct {
+	nodeID   string
+	segments *typeutil.ConcurrentMap[SegmentLabel, *segmentObserver] // map segment id to observer.
+	// one segment can be removed from one query node, for balancing or compacting.
+	// no more search operation will be performed on the segment after it is removed.
+	// all related metric should be expired after a while.
+	// may be a huge map with 100000+ entries.
+}
+
+// Observe records a new metric
+func (o *segmentsObserver) Observe(m labeledRecord) {
+	// fast path.
+	label := m.Label()
+	observer, ok := o.segments.Get(label)
+	if !ok {
+		// slow path.
+		newObserver := newSegmentObserver(o.nodeID, label)
+		observer, _ = o.segments.GetOrInsert(label, newObserver)
+	}
+	// do a observer.
+	observer.Observe(m)
+}
+
+// ExpireAndObserve expire all expired observer and observe all non-expired observer.
+func (o *segmentsObserver) ExpireAndObserve(observer func(label SegmentLabel, snapshot SegmentObserverSnapshot), expiredAt time.Time) {
+	o.segments.Range(func(label SegmentLabel, value *segmentObserver) bool {
+		if value.IsExpired(expiredAt) {
+			o.segments.Remove(label)
+			value.Clear()
+			return true
+		}
+		observer(label, value.Snapshot())
+		return true
+	})
+}
+
+// newSegmentObserver creates a new segmentObserver.
+func newSegmentObserver(nodeID string, label SegmentLabel) *segmentObserver {
+	now := time.Now()
+	return &segmentObserver{
+		label:         label,
+		prom:          newPromObserver(nodeID, label),
+		cache:         newSegmentCacheObserver(),
+		searchAccess:  newSegmentAccessObserver(),
+		queryAccess:   newSegmentAccessObserver(),
+		lastUpdates:   atomic.NewPointer[time.Time](&now),
+		resourceUsage: atomic.NewPointer[ResourceUsageMetrics](&ResourceUsageMetrics{}),
+	}
+}
+
+// segmentObserver is a observer for segment metrics.
+type segmentObserver struct {
+	label SegmentLabel // never updates
+
+	// observers.
+	prom         promMetricsObserver   // prometheus metrics observer.
+	cache        segmentCacheObserver  // cache metrics observer.
+	searchAccess segmentAccessObserver // search metrics observer.
+	queryAccess  segmentAccessObserver // query metrics observer.
+
+	// resource usage.
+	resourceUsage *atomic.Pointer[ResourceUsageMetrics] // resource usage observer.
+	// for expiration.
+	lastUpdates *atomic.Pointer[time.Time] // update every access.
+}
+
+// Observe observe a new
+func (o *segmentObserver) Observe(m labeledRecord) {
+	now := time.Now()
+	o.lastUpdates.Store(&now)
+
+	switch m.(type) {
+	case *CacheLoadRecord:
+		o.prom.ObserveLoad(m.(*CacheLoadRecord))
+		o.cache.ObserveLoad(m.(*CacheLoadRecord))
+	case *CacheEvictRecord:
+		o.prom.ObserveEvict(m.(*CacheEvictRecord))
+		o.cache.ObserveEvict(m.(*CacheEvictRecord))
+	case QuerySegmentAccessRecord:
+		o.prom.ObserveQueryAccess(m.(QuerySegmentAccessRecord))
+		o.queryAccess.Observe(m.(QuerySegmentAccessRecord).segmentAccessRecord)
+	case SearchSegmentAccessRecord:
+		o.prom.ObserveSearchAccess(m.(SearchSegmentAccessRecord))
+		o.searchAccess.Observe(m.(SearchSegmentAccessRecord).segmentAccessRecord)
+	case *ResourceEstimateRecord:
+		o.resourceUsage.Store(m.(*ResourceEstimateRecord).ResourceUsageMetrics)
+	default:
+		panic("unknown segment access metric")
+	}
+}
+
+// IsExpired checks if the segment observer is expired.
+func (o *segmentObserver) IsExpired(expireAt time.Time) bool {
+	return o.lastUpdates.Load().Before(expireAt)
+}
+
+// Snapshot returns a snapshot of the observer.
+func (o *segmentObserver) Snapshot() SegmentObserverSnapshot {
+	return SegmentObserverSnapshot{
+		Time:          time.Now(),
+		Label:         o.label,
+		ResourceUsage: *o.resourceUsage.Load(),
+		Cache:         o.cache.Snapshot(),
+		SearchAccess:  o.searchAccess.Snapshot(),
+		QueryAccess:   o.queryAccess.Snapshot(),
+	}
+}
+
+func (o *segmentObserver) Clear() {
+	o.prom.Clear()
+}
+
+// newSegmentCacheObserver creates a new segmentCacheObserver.
+func newSegmentCacheObserver() segmentCacheObserver {
+	return segmentCacheObserver{
+		loadTotal:    metricsutil.NewCounter(),
+		loadDuration: metricsutil.NewDuration(),
+	}
+}
+
+// segmentCacheObserver is a observer for segment cache metrics.
+type segmentCacheObserver struct {
+	loadTotal    metricsutil.Counter  // real load data count.
+	loadDuration metricsutil.Duration // real load data time cost.
+}
+
+// ObserveLoad records a new load.
+func (o *segmentCacheObserver) ObserveLoad(r *CacheLoadRecord) {
+	o.loadTotal.Inc()
+	o.loadDuration.Add(r.getDuration())
+}
+
+// ObserveLoad records a new load.
+func (o *segmentCacheObserver) ObserveEvict(r *CacheEvictRecord) {
+	o.loadTotal.Inc()
+	o.loadDuration.Add(r.getDuration())
+}
+
+// Snapshot returns a snapshot of the observer.
+func (o *segmentCacheObserver) Snapshot() CacheObserverSnapshot {
+	return CacheObserverSnapshot{
+		LoadTotal:    int64(o.loadTotal.Get()),
+		LoadDuration: o.loadDuration.Get(),
+	}
+}
+
+// newSegmentAccessObserver creates a new segmentAccessObserver.
+func newSegmentAccessObserver() segmentAccessObserver {
+	return segmentAccessObserver{
+		total:            metricsutil.NewCounter(),
+		duration:         metricsutil.NewDuration(),
+		waitLoadTotal:    metricsutil.NewCounter(),
+		waitLoadDuration: metricsutil.NewDuration(),
+	}
+}
+
+// segmentAccessObserver is a observer for segment access metrics.
+type segmentAccessObserver struct {
+	total            metricsutil.Counter  // total access count.
+	duration         metricsutil.Duration // search or query time cost.
+	waitLoadTotal    metricsutil.Counter  // cache missing count.
+	waitLoadDuration metricsutil.Duration // search or query may blocked by loading data when cache miss, total time cost.
+}
+
+// recordAccess records a new access.
+func (o *segmentAccessObserver) Observe(r *segmentAccessRecord) {
+	o.total.Inc()
+	o.duration.Add(r.getDuration())
+	if r.isCacheMiss {
+		o.waitLoadTotal.Inc()
+		o.waitLoadDuration.Add(r.getWaitLoadDuration())
+	}
+}
+
+// Snapshot returns a snapshot of the observer.
+func (o *segmentAccessObserver) Snapshot() AccessObserverSnapshot {
+	return AccessObserverSnapshot{
+		Total:            int64(o.total.Get()),
+		Duration:         o.duration.Get(),
+		WaitLoadTotal:    int64(o.waitLoadTotal.Get()),
+		WaitLoadDuration: o.waitLoadDuration.Get(),
+	}
+}
+
+// newPromObserver creates a new promMetrics.
+func newPromObserver(nodeID string, label SegmentLabel) promMetricsObserver {
+	return promMetricsObserver{
+		nodeID:                               nodeID,
+		label:                                label,
+		DiskCacheLoadTotal:                   metrics.QueryNodeDiskCacheLoadTotal.WithLabelValues(nodeID, label.DatabaseName, label.ResourceGroup),
+		DiskCacheLoadDuration:                metrics.QueryNodeDiskCacheLoadDuration.WithLabelValues(nodeID, label.DatabaseName, label.ResourceGroup),
+		DiskCacheLoadBytes:                   metrics.QueryNodeDiskCacheLoadBytes.WithLabelValues(nodeID, label.DatabaseName, label.ResourceGroup),
+		DiskCacheEvictTotal:                  metrics.QueryNodeDiskCacheEvictTotal.WithLabelValues(nodeID, label.DatabaseName, label.ResourceGroup),
+		DiskCacheEvictDuration:               metrics.QueryNodeDiskCacheEvictDuration.WithLabelValues(nodeID, label.DatabaseName, label.ResourceGroup),
+		QuerySegmentAccessTotal:              metrics.QueryNodeSegmentAccessTotal.WithLabelValues(nodeID, label.DatabaseName, label.ResourceGroup, metrics.QueryLabel),
+		QuerySegmentAccessDuration:           metrics.QueryNodeSegmentAccessDuration.WithLabelValues(nodeID, label.DatabaseName, label.ResourceGroup, metrics.QueryLabel),
+		QuerySegmentAccessWaitCacheTotal:     metrics.QueryNodeSegmentAccessWaitCacheTotal.WithLabelValues(nodeID, label.DatabaseName, label.ResourceGroup, metrics.QueryLabel),
+		QuerySegmentAccessWaitCacheDuration:  metrics.QueryNodeSegmentAccessWaitCacheDuration.WithLabelValues(nodeID, label.DatabaseName, label.ResourceGroup, metrics.QueryLabel),
+		SearchSegmentAccessTotal:             metrics.QueryNodeSegmentAccessTotal.WithLabelValues(nodeID, label.DatabaseName, label.ResourceGroup, metrics.SearchLabel),
+		SearchSegmentAccessDuration:          metrics.QueryNodeSegmentAccessDuration.WithLabelValues(nodeID, label.DatabaseName, label.ResourceGroup, metrics.SearchLabel),
+		SearchSegmentAccessWaitCacheTotal:    metrics.QueryNodeSegmentAccessWaitCacheTotal.WithLabelValues(nodeID, label.DatabaseName, label.ResourceGroup, metrics.SearchLabel),
+		SearchSegmentAccessWaitCacheDuration: metrics.QueryNodeSegmentAccessWaitCacheDuration.WithLabelValues(nodeID, label.DatabaseName, label.ResourceGroup, metrics.SearchLabel),
+	}
+}
+
+// promMetricsObserver is a observer for prometheus metrics.
+type promMetricsObserver struct {
+	nodeID string
+	label  SegmentLabel // never updates
+
+	DiskCacheLoadTotal                   prometheus.Counter
+	DiskCacheLoadDuration                prometheus.Counter
+	DiskCacheLoadBytes                   prometheus.Counter
+	DiskCacheEvictTotal                  prometheus.Counter
+	DiskCacheEvictDuration               prometheus.Counter
+	QuerySegmentAccessTotal              prometheus.Counter
+	QuerySegmentAccessDuration           prometheus.Counter
+	QuerySegmentAccessWaitCacheTotal     prometheus.Counter
+	QuerySegmentAccessWaitCacheDuration  prometheus.Counter
+	SearchSegmentAccessTotal             prometheus.Counter
+	SearchSegmentAccessDuration          prometheus.Counter
+	SearchSegmentAccessWaitCacheTotal    prometheus.Counter
+	SearchSegmentAccessWaitCacheDuration prometheus.Counter
+}
+
+// RecordAccess records a new access.
+func (o *promMetricsObserver) ObserveLoad(r *CacheLoadRecord) {
+	o.DiskCacheLoadTotal.Inc()
+	o.DiskCacheLoadDuration.Add(r.getSeconds())
+	o.DiskCacheLoadBytes.Add(r.getBytes())
+}
+
+// RecordAccess records a new access.
+func (o *promMetricsObserver) ObserveEvict(r *CacheEvictRecord) {
+	o.DiskCacheEvictTotal.Inc()
+	o.DiskCacheEvictDuration.Add(r.getSeconds())
+}
+
+func (o *promMetricsObserver) ObserveQueryAccess(r QuerySegmentAccessRecord) {
+	o.QuerySegmentAccessTotal.Inc()
+	o.QuerySegmentAccessDuration.Add(r.getSeconds())
+	if r.isCacheMiss {
+		o.QuerySegmentAccessWaitCacheTotal.Inc()
+		o.QuerySegmentAccessWaitCacheDuration.Add(r.getWaitLoadSeconds())
+	}
+}
+
+func (o *promMetricsObserver) ObserveSearchAccess(r SearchSegmentAccessRecord) {
+	o.SearchSegmentAccessTotal.Inc()
+	o.SearchSegmentAccessDuration.Add(r.getSeconds())
+	if r.isCacheMiss {
+		o.SearchSegmentAccessWaitCacheTotal.Inc()
+		o.SearchSegmentAccessWaitCacheDuration.Add(r.getWaitLoadSeconds())
+	}
+}
+
+func (o *promMetricsObserver) Clear() {
+	label := o.label
+
+	metrics.QueryNodeDiskCacheLoadTotal.DeleteLabelValues(o.nodeID, label.DatabaseName, label.ResourceGroup)
+	metrics.QueryNodeDiskCacheLoadBytes.DeleteLabelValues(o.nodeID, label.DatabaseName, label.ResourceGroup)
+	metrics.QueryNodeDiskCacheLoadDuration.DeleteLabelValues(o.nodeID, label.DatabaseName, label.ResourceGroup)
+	metrics.QueryNodeDiskCacheEvictTotal.DeleteLabelValues(o.nodeID, label.DatabaseName, label.ResourceGroup)
+	metrics.QueryNodeDiskCacheEvictDuration.DeleteLabelValues(o.nodeID, label.DatabaseName, label.ResourceGroup)
+
+	metrics.QueryNodeSegmentAccessTotal.DeleteLabelValues(o.nodeID, label.DatabaseName, label.ResourceGroup, metrics.SearchLabel)
+	metrics.QueryNodeSegmentAccessTotal.DeleteLabelValues(o.nodeID, label.DatabaseName, label.ResourceGroup, metrics.QueryLabel)
+	metrics.QueryNodeSegmentAccessDuration.DeleteLabelValues(o.nodeID, label.DatabaseName, label.ResourceGroup, metrics.SearchLabel)
+	metrics.QueryNodeSegmentAccessDuration.DeleteLabelValues(o.nodeID, label.DatabaseName, label.ResourceGroup, metrics.QueryLabel)
+
+	metrics.QueryNodeSegmentAccessWaitCacheTotal.DeleteLabelValues(o.nodeID, label.DatabaseName, label.ResourceGroup, metrics.SearchLabel)
+	metrics.QueryNodeSegmentAccessWaitCacheTotal.DeleteLabelValues(o.nodeID, label.DatabaseName, label.ResourceGroup, metrics.QueryLabel)
+	metrics.QueryNodeSegmentAccessWaitCacheDuration.DeleteLabelValues(o.nodeID, label.DatabaseName, label.ResourceGroup, metrics.SearchLabel)
+	metrics.QueryNodeSegmentAccessWaitCacheDuration.DeleteLabelValues(o.nodeID, label.DatabaseName, label.ResourceGroup, metrics.QueryLabel)
+}

--- a/internal/querynodev2/segments/metricsutil/observer_test.go
+++ b/internal/querynodev2/segments/metricsutil/observer_test.go
@@ -1,0 +1,177 @@
+package metricsutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSegmentAccessGather(t *testing.T) {
+	g := newSegmentAccessObserver()
+	snapshot := g.Snapshot()
+	assert.Zero(t, snapshot.Total)
+	assert.Zero(t, snapshot.Duration)
+	assert.Zero(t, snapshot.WaitLoadDuration)
+	g.Observe(newCacheMissingMetric())
+	snapshot = g.Snapshot()
+	assert.Equal(t, int64(1), snapshot.Total)
+	assert.NotZero(t, snapshot.Duration)
+	assert.NotZero(t, snapshot.WaitLoadTotal)
+	assert.NotZero(t, snapshot.WaitLoadDuration)
+}
+
+func TestSegmentCacheGather(t *testing.T) {
+	g := newSegmentCacheObserver()
+	snapshot := g.Snapshot()
+	assert.Zero(t, snapshot.LoadTotal)
+	assert.Zero(t, snapshot.LoadDuration)
+	g.ObserveLoad(newCacheLoadMetric())
+	snapshot = g.Snapshot()
+	assert.NotZero(t, snapshot.LoadTotal)
+	assert.NotZero(t, snapshot.LoadDuration)
+}
+
+func TestSegmentGather(t *testing.T) {
+	g := newSegmentObserver("1", SegmentLabel{
+		SegmentID:     1,
+		DatabaseName:  "db1",
+		ResourceGroup: "rg1",
+	})
+	snapshot := g.Snapshot()
+	assert.Zero(t, snapshot.Cache.LoadTotal)
+	assert.Zero(t, snapshot.Cache.LoadDuration)
+	assert.Zero(t, snapshot.SearchAccess.Total)
+	assert.Zero(t, snapshot.SearchAccess.Duration)
+	assert.Zero(t, snapshot.SearchAccess.WaitLoadTotal)
+	assert.Zero(t, snapshot.SearchAccess.WaitLoadDuration)
+	assert.Zero(t, snapshot.QueryAccess.Total)
+	assert.Zero(t, snapshot.QueryAccess.Duration)
+	assert.Zero(t, snapshot.QueryAccess.WaitLoadTotal)
+	assert.Zero(t, snapshot.QueryAccess.WaitLoadDuration)
+	g.Observe(newCacheLoadMetric())
+	snapshot = g.Snapshot()
+	assert.NotZero(t, snapshot.Cache.LoadTotal)
+	assert.NotZero(t, snapshot.Cache.LoadDuration)
+	assert.Zero(t, snapshot.SearchAccess.Total)
+	assert.Zero(t, snapshot.SearchAccess.Duration)
+	assert.Zero(t, snapshot.SearchAccess.WaitLoadTotal)
+	assert.Zero(t, snapshot.SearchAccess.WaitLoadDuration)
+	assert.Zero(t, snapshot.QueryAccess.Total)
+	assert.Zero(t, snapshot.QueryAccess.Duration)
+	assert.Zero(t, snapshot.QueryAccess.WaitLoadTotal)
+	assert.Zero(t, snapshot.QueryAccess.WaitLoadDuration)
+
+	g.Observe(SearchSegmentAccessRecord{
+		segmentAccessRecord: newCacheMissingMetric(),
+	})
+	snapshot = g.Snapshot()
+	assert.NotZero(t, snapshot.Cache.LoadTotal)
+	assert.NotZero(t, snapshot.Cache.LoadDuration)
+	assert.NotZero(t, snapshot.SearchAccess.Total)
+	assert.NotZero(t, snapshot.SearchAccess.Duration)
+	assert.NotZero(t, snapshot.SearchAccess.WaitLoadTotal)
+	assert.NotZero(t, snapshot.SearchAccess.WaitLoadDuration)
+	assert.Zero(t, snapshot.QueryAccess.Total)
+	assert.Zero(t, snapshot.QueryAccess.Duration)
+	assert.Zero(t, snapshot.QueryAccess.WaitLoadTotal)
+	assert.Zero(t, snapshot.QueryAccess.WaitLoadDuration)
+
+	g.Observe(QuerySegmentAccessRecord{
+		segmentAccessRecord: newCacheMissingMetric(),
+	})
+	snapshot = g.Snapshot()
+	assert.NotZero(t, snapshot.Cache.LoadTotal)
+	assert.NotZero(t, snapshot.Cache.LoadDuration)
+	assert.NotZero(t, snapshot.SearchAccess.Total)
+	assert.NotZero(t, snapshot.SearchAccess.Duration)
+	assert.NotZero(t, snapshot.SearchAccess.WaitLoadTotal)
+	assert.NotZero(t, snapshot.SearchAccess.WaitLoadDuration)
+	assert.NotZero(t, snapshot.QueryAccess.Total)
+	assert.NotZero(t, snapshot.QueryAccess.Duration)
+	assert.NotZero(t, snapshot.QueryAccess.WaitLoadTotal)
+	assert.NotZero(t, snapshot.QueryAccess.WaitLoadDuration)
+
+	assert.False(t, g.IsExpired(time.Now().Add(-time.Minute)))
+	assert.True(t, g.IsExpired(time.Now()))
+
+	assert.Panics(t, func() {
+		g.Observe(&QuerySegmentAccessRecord{})
+	})
+}
+
+func TestSegmentsGather(t *testing.T) {
+	g := newSegmentsObserver()
+	m := NewSearchSegmentAccessRecord(SegmentLabel{
+		SegmentID:     1,
+		ResourceGroup: "rg1",
+		DatabaseName:  "db1",
+	})
+	m.Finish(nil)
+
+	g.Observe(m)
+	assert.Equal(t, 1, g.segments.Len())
+	g.Observe(m)
+	assert.Equal(t, 1, g.segments.Len())
+
+	m2 := NewQuerySegmentAccessRecord(SegmentLabel{
+		SegmentID:     1,
+		ResourceGroup: "rg1",
+		DatabaseName:  "db1",
+	})
+	m2.Finish(nil)
+	g.Observe(m2)
+	assert.Equal(t, 1, g.segments.Len())
+
+	m3 := NewSearchSegmentAccessRecord(SegmentLabel{
+		SegmentID:     1,
+		ResourceGroup: "rg2",
+		DatabaseName:  "db1",
+	})
+	m3.Finish(nil)
+	g.Observe(m3)
+	assert.Equal(t, 2, g.segments.Len())
+
+	cnt := 0
+	g.ExpireAndObserve(func(label SegmentLabel, snapshot SegmentObserverSnapshot) {
+		cnt++
+	}, time.Now().Add(-time.Minute))
+	assert.Equal(t, 2, cnt)
+
+	cnt = 0
+	g.ExpireAndObserve(func(label SegmentLabel, snapshot SegmentObserverSnapshot) {
+		cnt++
+	}, time.Now())
+	assert.Zero(t, cnt)
+}
+
+func newCacheMissingMetric() *segmentAccessRecord {
+	m := newSegmentAccessRecord(SegmentLabel{
+		SegmentID:     1,
+		DatabaseName:  "db1",
+		ResourceGroup: "rg1",
+	})
+	m.CacheMissing()
+	m.finish(nil)
+	return m
+}
+
+func newCacheHitMetric() *segmentAccessRecord {
+	m := newSegmentAccessRecord(SegmentLabel{
+		SegmentID:     1,
+		DatabaseName:  "db1",
+		ResourceGroup: "rg1",
+	})
+	m.finish(nil)
+	return m
+}
+
+func newCacheLoadMetric() *CacheLoadRecord {
+	m := NewCacheLoadRecord(SegmentLabel{
+		SegmentID:     1,
+		DatabaseName:  "db1",
+		ResourceGroup: "rg1",
+	})
+	m.Finish(nil)
+	return m
+}

--- a/internal/querynodev2/segments/metricsutil/record.go
+++ b/internal/querynodev2/segments/metricsutil/record.go
@@ -1,0 +1,208 @@
+package metricsutil
+
+import (
+	"time"
+
+	"github.com/milvus-io/milvus/pkg/util/timerecord"
+)
+
+var (
+	_ labeledRecord = QuerySegmentAccessRecord{}
+	_ labeledRecord = SearchSegmentAccessRecord{}
+	_ labeledRecord = &ResourceEstimateRecord{}
+	_ labeledRecord = &CacheLoadRecord{}
+	_ labeledRecord = &CacheEvictRecord{}
+)
+
+// CacheLoadRecord records the metrics of a cache load.
+type CacheLoadRecord struct {
+	bytes uint64
+	baseRecord
+}
+
+// NewCacheLoadRecord creates a new CacheLoadRecord.
+func NewCacheLoadRecord(label SegmentLabel) *CacheLoadRecord {
+	return &CacheLoadRecord{
+		baseRecord: newBaseRecord(label),
+	}
+}
+
+func (r *CacheLoadRecord) WithBytes(bytes uint64) *CacheLoadRecord {
+	r.bytes = bytes
+	return r
+}
+
+func (r *CacheLoadRecord) getBytes() float64 {
+	return float64(r.bytes)
+}
+
+// Finish finishes the record.
+func (r *CacheLoadRecord) Finish(err error) {
+	r.baseRecord.finish(err)
+	getGlobalObserver().Observe(r)
+}
+
+type CacheEvictRecord struct {
+	baseRecord
+}
+
+// NewCacheEvictRecord creates a new CacheEvictRecord.
+func NewCacheEvictRecord(label SegmentLabel) *CacheEvictRecord {
+	return &CacheEvictRecord{
+		baseRecord: newBaseRecord(label),
+	}
+}
+
+// Finish finishes the record.
+func (r *CacheEvictRecord) Finish(err error) {
+	r.baseRecord.finish(err)
+	getGlobalObserver().Observe(r)
+}
+
+// NewResourceEstimateRecord creates a new ResourceEstimateRecord.
+func NewResourceEstimateRecord(label SegmentLabel) *ResourceEstimateRecord {
+	return &ResourceEstimateRecord{
+		label:                label,
+		ResourceUsageMetrics: &ResourceUsageMetrics{},
+	}
+}
+
+// ResourceEstimateRecord records the resource usage of a segment.
+// It is just a estimate of the resource usage.
+type ResourceEstimateRecord struct {
+	label SegmentLabel
+	*ResourceUsageMetrics
+}
+
+// Label returns the label of the recorder.
+func (r *ResourceEstimateRecord) Label() SegmentLabel {
+	return r.label
+}
+
+// WithMemUsage sets the memory usage of the segment.
+func (r *ResourceEstimateRecord) WithMemUsage(memUsage uint64) *ResourceEstimateRecord {
+	r.MemUsage = memUsage
+	return r
+}
+
+// WithDiskUsage sets the disk usage of the segment.
+func (r *ResourceEstimateRecord) WithDiskUsage(diskUsage uint64) *ResourceEstimateRecord {
+	r.DiskUsage = diskUsage
+	return r
+}
+
+// WithRowNum sets the row number of the segment.
+func (r *ResourceEstimateRecord) WithRowNum(rowNum uint64) *ResourceEstimateRecord {
+	r.RowNum = rowNum
+	return r
+}
+
+func (r *ResourceEstimateRecord) Finish(_ error) {
+	getGlobalObserver().Observe(r)
+}
+
+// NewQuerySegmentAccessRecord creates a new QuerySegmentMetricRecorder.
+func NewQuerySegmentAccessRecord(label SegmentLabel) QuerySegmentAccessRecord {
+	return QuerySegmentAccessRecord{
+		segmentAccessRecord: newSegmentAccessRecord(label),
+	}
+}
+
+// NewSearchSegmentAccessRecord creates a new SearchSegmentMetricRecorder.
+func NewSearchSegmentAccessRecord(label SegmentLabel) SearchSegmentAccessRecord {
+	return SearchSegmentAccessRecord{
+		segmentAccessRecord: newSegmentAccessRecord(label),
+	}
+}
+
+// QuerySegmentAccessRecord records the metrics of a query segment.
+type QuerySegmentAccessRecord struct {
+	*segmentAccessRecord
+}
+
+func (r QuerySegmentAccessRecord) Finish(err error) {
+	r.finish(err)
+	getGlobalObserver().Observe(r)
+}
+
+// SearchSegmentAccessRecord records the metrics of a search segment.
+type SearchSegmentAccessRecord struct {
+	*segmentAccessRecord
+}
+
+func (r SearchSegmentAccessRecord) Finish(err error) {
+	r.finish(err)
+	getGlobalObserver().Observe(r)
+}
+
+// segmentAccessRecord records the metrics of the segment.
+type segmentAccessRecord struct {
+	isCacheMiss  bool          // whether the access is a cache miss.
+	waitLoadCost time.Duration // time cost of waiting for loading data.
+	baseRecord
+}
+
+// newSegmentAccessRecord creates a new accessMetricRecorder.
+func newSegmentAccessRecord(label SegmentLabel) *segmentAccessRecord {
+	return &segmentAccessRecord{
+		baseRecord: newBaseRecord(label),
+	}
+}
+
+// CacheMissing records the cache missing.
+func (r *segmentAccessRecord) CacheMissing() {
+	r.isCacheMiss = true
+	r.waitLoadCost = r.timeRecorder.RecordSpan()
+}
+
+// getWaitLoadSeconds returns the wait load seconds of the recorder.
+func (r *segmentAccessRecord) getWaitLoadSeconds() float64 {
+	return r.waitLoadCost.Seconds()
+}
+
+// getWaitLoadDuration returns the wait load duration of the recorder.
+func (r *segmentAccessRecord) getWaitLoadDuration() time.Duration {
+	return r.waitLoadCost
+}
+
+// newBaseRecord returns a new baseRecord.
+func newBaseRecord(label SegmentLabel) baseRecord {
+	return baseRecord{
+		label:        label,
+		timeRecorder: timerecord.NewTimeRecorder(""),
+	}
+}
+
+// baseRecord records the metrics of the segment.
+type baseRecord struct {
+	label        SegmentLabel
+	duration     time.Duration
+	err          error
+	timeRecorder *timerecord.TimeRecorder
+}
+
+// Label returns the label of the recorder.
+func (r *baseRecord) Label() SegmentLabel {
+	return r.label
+}
+
+// getError returns the error of the recorder.
+func (r *baseRecord) getError() error {
+	return r.err
+}
+
+// getDuration returns the duration of the recorder.
+func (r *baseRecord) getDuration() time.Duration {
+	return r.duration
+}
+
+// getSeconds returns the duration of the recorder in seconds.
+func (r *baseRecord) getSeconds() float64 {
+	return r.duration.Seconds()
+}
+
+// finish finishes the record.
+func (r *baseRecord) finish(err error) {
+	r.err = err
+	r.duration = r.timeRecorder.ElapseSpan()
+}

--- a/internal/querynodev2/segments/metricsutil/record_test.go
+++ b/internal/querynodev2/segments/metricsutil/record_test.go
@@ -1,0 +1,116 @@
+package metricsutil
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"github.com/milvus-io/milvus/pkg/util/paramtable"
+	"github.com/stretchr/testify/assert"
+)
+
+var testLabel = SegmentLabel{
+	SegmentID:     1,
+	DatabaseName:  "db",
+	ResourceGroup: "rg",
+}
+
+func TestMain(m *testing.M) {
+	paramtable.Init()
+	os.Exit(m.Run())
+}
+
+func TestBaseRecord(t *testing.T) {
+	r := newBaseRecord(testLabel)
+	assert.Equal(t, testLabel, r.Label())
+	err := errors.New("test")
+	r.finish(err)
+	assert.Equal(t, err, r.getError())
+	assert.NotZero(t, r.getDuration())
+	assert.NotZero(t, r.getSeconds())
+}
+
+func TestSegmentAccessRecorder(t *testing.T) {
+	mr := newSegmentAccessRecord(SegmentLabel{
+		SegmentID:     1,
+		DatabaseName:  "db1",
+		ResourceGroup: "rg1",
+	})
+	assert.Equal(t, mr.Label(), SegmentLabel{
+		SegmentID:     1,
+		DatabaseName:  "db1",
+		ResourceGroup: "rg1",
+	})
+	assert.False(t, mr.isCacheMiss)
+	assert.Zero(t, mr.waitLoadCost)
+	assert.Zero(t, mr.getDuration())
+	mr.CacheMissing()
+	assert.True(t, mr.isCacheMiss)
+	assert.NotZero(t, mr.waitLoadCost)
+	assert.Zero(t, mr.getDuration())
+	mr.finish(nil)
+	assert.NotZero(t, mr.getDuration())
+
+	mr = newSegmentAccessRecord(SegmentLabel{
+		SegmentID:     1,
+		DatabaseName:  "db1",
+		ResourceGroup: "rg1",
+	})
+	mr.CacheMissing()
+	assert.True(t, mr.isCacheMiss)
+	assert.NotZero(t, mr.waitLoadCost)
+	assert.Zero(t, mr.getDuration())
+	mr.finish(nil)
+	assert.NotZero(t, mr.getDuration())
+
+	mr = newSegmentAccessRecord(SegmentLabel{
+		SegmentID:     1,
+		DatabaseName:  "db1",
+		ResourceGroup: "rg1",
+	})
+	mr.finish(nil)
+	assert.False(t, mr.isCacheMiss)
+	assert.Zero(t, mr.waitLoadCost)
+	assert.NotZero(t, mr.getDuration())
+}
+
+func TestSearchSegmentAccessMetric(t *testing.T) {
+	m := NewSearchSegmentAccessRecord(SegmentLabel{
+		SegmentID:     1,
+		DatabaseName:  "db1",
+		ResourceGroup: "rg1",
+	})
+	m.CacheMissing()
+	m.Finish(nil)
+	assert.NotZero(t, m.getDuration())
+}
+
+func TestQuerySegmentAccessMetric(t *testing.T) {
+	m := NewQuerySegmentAccessRecord(SegmentLabel{
+		SegmentID:     1,
+		DatabaseName:  "db1",
+		ResourceGroup: "rg1",
+	})
+	m.CacheMissing()
+	m.Finish(nil)
+	assert.NotZero(t, m.getDuration())
+}
+
+func TestResourceEstimateRecord(t *testing.T) {
+	r := NewResourceEstimateRecord(testLabel)
+	assert.Equal(t, testLabel, r.Label())
+	r.WithDiskUsage(1).WithMemUsage(2).WithRowNum(100)
+	assert.Equal(t, uint64(1), r.DiskUsage)
+	assert.Equal(t, uint64(2), r.MemUsage)
+	assert.Equal(t, uint64(100), r.RowNum)
+	r.Finish(nil)
+}
+
+func TestCacheRecord(t *testing.T) {
+	r1 := NewCacheLoadRecord(testLabel)
+	r1.WithBytes(1)
+	assert.Equal(t, float64(1), r1.getBytes())
+	r1.Finish(nil)
+	r2 := NewCacheEvictRecord(testLabel)
+	r2.Finish(nil)
+}

--- a/internal/querynodev2/segments/metricsutil/sampler.go
+++ b/internal/querynodev2/segments/metricsutil/sampler.go
@@ -1,0 +1,66 @@
+package metricsutil
+
+import (
+	"time"
+)
+
+const (
+	metricExpire   = 30 * time.Minute
+	snapshotExpire = 5 * time.Minute
+)
+
+// newSampler creates a new sampler.
+func newSampler() *sampler {
+	return &sampler{
+		history: make(map[SegmentLabel]*segmentHistory),
+	}
+}
+
+// sampler observes the metrics in global observer, sample a snapshot, and update the metrics output.
+type sampler struct {
+	history map[SegmentLabel]*segmentHistory // history may be a large map with 100000+ entries.
+}
+
+// GetHistory returns the history of the sampler.
+func (o *sampler) GetHistory() map[SegmentLabel]*segmentHistory {
+	return o.history
+}
+
+// Scrape scrapes the metrics.
+func (o *sampler) Scrape() {
+	now := time.Now()
+	o.scrapeMetricSamples(now.Add(-metricExpire))
+	o.historyExpiration(now.Add(-snapshotExpire))
+}
+
+// scrapeMetricSamples observes the metrics, and updates the history.
+func (o *sampler) scrapeMetricSamples(expireAt time.Time) {
+	getGlobalObserver().ExpireAndObserve(func(label SegmentLabel, snapshot SegmentObserverSnapshot) {
+		if _, ok := o.history[label]; !ok {
+			o.history[label] = newSegmentHistory()
+		}
+		o.history[label].Append(snapshot)
+	}, expireAt)
+}
+
+// historyExpiration shrinks the snapshots.
+func (o *sampler) historyExpiration(expireAt time.Time) {
+	for label, h := range o.history {
+		h.Shrink(expireAt)
+		if h.Len() == 0 {
+			delete(o.history, label)
+		}
+	}
+}
+
+// getTestSegmentHistory returns a test segment history.
+func getTestSegmentHistory() *segmentHistory {
+	testSegmentHistory := newSegmentHistory()
+	testSegmentHistory.Append(SegmentObserverSnapshot{
+		Time: time.Now(),
+	})
+	testSegmentHistory.Append(SegmentObserverSnapshot{
+		Time: time.Now(),
+	})
+	return testSegmentHistory
+}

--- a/internal/querynodev2/segments/metricsutil/sampler_test.go
+++ b/internal/querynodev2/segments/metricsutil/sampler_test.go
@@ -1,0 +1,29 @@
+package metricsutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSampler(t *testing.T) {
+	sampler := newSampler()
+	assert.Equal(t, 0, len(sampler.GetHistory()))
+
+	NewResourceEstimateRecord(testLabel).
+		WithDiskUsage(10086).
+		WithMemUsage(2048).
+		Finish(nil)
+	sampler.Scrape()
+	assert.NotZero(t, len(sampler.GetHistory()))
+	assert.NotNil(t, sampler.GetHistory()[testLabel])
+	h := sampler.GetHistory()[testLabel]
+	assert.NotNil(t, h.Snapshots[0])
+	assert.Equal(t, uint64(10086), h.Snapshots[0].ResourceUsage.DiskUsage)
+	assert.Equal(t, uint64(2048), h.Snapshots[0].ResourceUsage.MemUsage)
+
+	// test expire.
+	sampler.historyExpiration(time.Now())
+	assert.Zero(t, len(sampler.GetHistory()))
+}

--- a/internal/querynodev2/segments/metricsutil/scheduler.go
+++ b/internal/querynodev2/segments/metricsutil/scheduler.go
@@ -1,0 +1,75 @@
+package metricsutil
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/milvus-io/milvus/pkg/util/paramtable"
+)
+
+var schedulerOnce sync.Once
+
+// StartScheduler starts the scheduler.
+func StartScheduler() {
+	schedulerOnce.Do(func() {
+		newScheduler().Run()
+	})
+}
+
+type metricManager interface {
+	Apply(*sampler)
+}
+
+// scheduler is the scheduler of the metric package, organizing the metric managers and sampler together.
+// Some metric is too large to be handled at prometheus,
+// so we need to sample the metrics and aggregate them, then put them to prometheus.
+type scheduler struct {
+	ctx            context.Context
+	cancel         context.CancelFunc
+	metricManagers []metricManager
+	sampler        *sampler
+}
+
+// newScheduler creates a new scheduler.
+func newScheduler() *scheduler {
+	nodeID := strconv.FormatInt(paramtable.GetNodeID(), 10)
+	ctx, cancel := context.WithCancel(context.Background())
+	return &scheduler{
+		ctx:    ctx,
+		cancel: cancel,
+		metricManagers: []metricManager{
+			newLoadedSegmentMetricManager(nodeID), // active segment metric aggregation.
+			newActiveSegmentMetricManager(nodeID), // hot segment metric aggregation.
+		},
+		sampler: newSampler(),
+	}
+}
+
+// Run runs the scheduler.
+func (s *scheduler) Run() {
+	go func() {
+		for {
+			interval := paramtable.Get().QueryNodeCfg.MetricScrapeInterval.GetAsDuration(time.Second)
+
+			select {
+			case <-s.ctx.Done():
+				return
+			case <-time.After(interval):
+			}
+
+			// scrape the metrics and apply to all metric managers.
+			s.sampler.Scrape()
+			for _, m := range s.metricManagers {
+				m.Apply(s.sampler)
+			}
+		}
+	}()
+}
+
+// Stop stops the scheduler.
+// It seems that the scheduler need not to be stopped.
+func (s *scheduler) Stop() {
+	s.cancel()
+}

--- a/internal/querynodev2/segments/metricsutil/scheduler_test.go
+++ b/internal/querynodev2/segments/metricsutil/scheduler_test.go
@@ -1,0 +1,24 @@
+package metricsutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/milvus-io/milvus/pkg/util/paramtable"
+)
+
+func TestScheduler(t *testing.T) {
+	paramtable.Get().Save("queryNode.metricScrapeInterval", "0.1")
+	scheduler := newScheduler()
+	scheduler.Run()
+
+	// small qps
+	for i := 0; i < 1000; i++ {
+		NewQuerySegmentAccessRecord(testLabel).Finish(nil)
+		time.Sleep(1 * time.Millisecond)
+	}
+
+	scheduler.Stop()
+
+	StartScheduler()
+}

--- a/internal/querynodev2/segments/metricsutil/snapshot.go
+++ b/internal/querynodev2/segments/metricsutil/snapshot.go
@@ -1,0 +1,57 @@
+package metricsutil
+
+import (
+	"time"
+
+	"github.com/milvus-io/milvus/pkg/util/typeutil"
+)
+
+// SegmentLabel is the label of a segment.
+type SegmentLabel struct {
+	SegmentID     typeutil.UniqueID `expr:"SegmentID"`
+	DatabaseName  string            `expr:"DatabaseName"`
+	ResourceGroup string            `expr:"ResourceGroup"`
+}
+
+// snapshot returns a snapshot of the segment gather.
+// !!! All these fields and type should be exported for expr-lang predicate.
+type SegmentObserverSnapshot struct {
+	Time          time.Time              `expr:"Time"`
+	Label         SegmentLabel           `expr:"Label"`
+	ResourceUsage ResourceUsageMetrics   `expr:"ResourceUsage"`
+	Cache         CacheObserverSnapshot  `expr:"Cache"`
+	SearchAccess  AccessObserverSnapshot `expr:"SearchAccess"`
+	QueryAccess   AccessObserverSnapshot `expr:"QueryAccess"`
+}
+
+func (s SegmentObserverSnapshot) AccessCount() int64 {
+	return s.SearchAccess.Total + s.QueryAccess.Total
+}
+
+// CacheObserverSnapshot is a snapshot of segmentCacheGather.
+// !!! All these fields and type should be exported for expr-lang predicate.
+type CacheObserverSnapshot struct {
+	LoadTotal    int64         `expr:"LoadTotal"`
+	LoadDuration time.Duration `expr:"LoadDuration"`
+}
+
+func (c *CacheObserverSnapshot) Add(snapshot CacheObserverSnapshot) {
+	c.LoadTotal += snapshot.LoadTotal
+	c.LoadDuration += snapshot.LoadDuration
+}
+
+// AccessObserverSnapshot is a snapshot of segmentAccessGather.
+// !!! All these fields and type should be exported for expr-lang predicate.
+type AccessObserverSnapshot struct {
+	Total            int64         `expr:"Total"`
+	Duration         time.Duration `expr:"Duration"`
+	WaitLoadTotal    int64         `expr:"WaitLoadTotal"`
+	WaitLoadDuration time.Duration `expr:"WaitLoadDuration"`
+}
+
+func (a *AccessObserverSnapshot) Add(snapshot AccessObserverSnapshot) {
+	a.Total += snapshot.Total
+	a.Duration += snapshot.Duration
+	a.WaitLoadTotal += snapshot.WaitLoadTotal
+	a.WaitLoadDuration += snapshot.WaitLoadDuration
+}

--- a/internal/querynodev2/segments/metricsutil/snapshot_test.go
+++ b/internal/querynodev2/segments/metricsutil/snapshot_test.go
@@ -1,0 +1,27 @@
+package metricsutil
+
+import "testing"
+
+func TestCacheObserverSnapshot(t *testing.T) {
+	snapshot := CacheObserverSnapshot{}
+	snapshot.Add(CacheObserverSnapshot{
+		LoadTotal:    1,
+		LoadDuration: 1,
+	})
+	if snapshot.LoadTotal != 1 || snapshot.LoadDuration != 1 {
+		t.Error("cacheObserverSnapshot Add failed")
+	}
+}
+
+func TestAccessObserverSnapshot(t *testing.T) {
+	snapshot := AccessObserverSnapshot{}
+	snapshot.Add(AccessObserverSnapshot{
+		Total:            1,
+		Duration:         1,
+		WaitLoadTotal:    1,
+		WaitLoadDuration: 1,
+	})
+	if snapshot.Total != 1 || snapshot.Duration != 1 || snapshot.WaitLoadTotal != 1 || snapshot.WaitLoadDuration != 1 {
+		t.Error("accessObserverSnapshot Add failed")
+	}
+}

--- a/internal/querynodev2/segments/mock_segment.go
+++ b/internal/querynodev2/segments/mock_segment.go
@@ -952,6 +952,47 @@ func (_c *MockSegment_Release_Call) RunAndReturn(run func(...releaseOption)) *Mo
 	return _c
 }
 
+// ResourceUsageEstimate provides a mock function with given fields:
+func (_m *MockSegment) ResourceUsageEstimate() ResourceUsage {
+	ret := _m.Called()
+
+	var r0 ResourceUsage
+	if rf, ok := ret.Get(0).(func() ResourceUsage); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(ResourceUsage)
+	}
+
+	return r0
+}
+
+// MockSegment_ResourceUsageEstimate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ResourceUsageEstimate'
+type MockSegment_ResourceUsageEstimate_Call struct {
+	*mock.Call
+}
+
+// ResourceUsageEstimate is a helper method to define mock.On call
+func (_e *MockSegment_Expecter) ResourceUsageEstimate() *MockSegment_ResourceUsageEstimate_Call {
+	return &MockSegment_ResourceUsageEstimate_Call{Call: _e.mock.On("ResourceUsageEstimate")}
+}
+
+func (_c *MockSegment_ResourceUsageEstimate_Call) Run(run func()) *MockSegment_ResourceUsageEstimate_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockSegment_ResourceUsageEstimate_Call) Return(_a0 ResourceUsage) *MockSegment_ResourceUsageEstimate_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockSegment_ResourceUsageEstimate_Call) RunAndReturn(run func() ResourceUsage) *MockSegment_ResourceUsageEstimate_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Retrieve provides a mock function with given fields: ctx, plan
 func (_m *MockSegment) Retrieve(ctx context.Context, plan *RetrievePlan) (*segcorepb.RetrieveResults, error) {
 	ret := _m.Called(ctx, plan)

--- a/internal/querynodev2/segments/mock_segment.go
+++ b/internal/querynodev2/segments/mock_segment.go
@@ -117,6 +117,47 @@ func (_c *MockSegment_Collection_Call) RunAndReturn(run func() int64) *MockSegme
 	return _c
 }
 
+// DatabaseName provides a mock function with given fields:
+func (_m *MockSegment) DatabaseName() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// MockSegment_DatabaseName_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DatabaseName'
+type MockSegment_DatabaseName_Call struct {
+	*mock.Call
+}
+
+// DatabaseName is a helper method to define mock.On call
+func (_e *MockSegment_Expecter) DatabaseName() *MockSegment_DatabaseName_Call {
+	return &MockSegment_DatabaseName_Call{Call: _e.mock.On("DatabaseName")}
+}
+
+func (_c *MockSegment_DatabaseName_Call) Run(run func()) *MockSegment_DatabaseName_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockSegment_DatabaseName_Call) Return(_a0 string) *MockSegment_DatabaseName_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockSegment_DatabaseName_Call) RunAndReturn(run func() string) *MockSegment_DatabaseName_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Delete provides a mock function with given fields: ctx, primaryKeys, timestamps
 func (_m *MockSegment) Delete(ctx context.Context, primaryKeys []storage.PrimaryKey, timestamps []uint64) error {
 	ret := _m.Called(ctx, primaryKeys, timestamps)
@@ -455,47 +496,6 @@ func (_c *MockSegment_InsertCount_Call) Return(_a0 int64) *MockSegment_InsertCou
 }
 
 func (_c *MockSegment_InsertCount_Call) RunAndReturn(run func() int64) *MockSegment_InsertCount_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// IsLazyLoad provides a mock function with given fields:
-func (_m *MockSegment) IsLazyLoad() bool {
-	ret := _m.Called()
-
-	var r0 bool
-	if rf, ok := ret.Get(0).(func() bool); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-
-	return r0
-}
-
-// MockSegment_IsLazyLoad_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsLazyLoad'
-type MockSegment_IsLazyLoad_Call struct {
-	*mock.Call
-}
-
-// IsLazyLoad is a helper method to define mock.On call
-func (_e *MockSegment_Expecter) IsLazyLoad() *MockSegment_IsLazyLoad_Call {
-	return &MockSegment_IsLazyLoad_Call{Call: _e.mock.On("IsLazyLoad")}
-}
-
-func (_c *MockSegment_IsLazyLoad_Call) Run(run func()) *MockSegment_IsLazyLoad_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *MockSegment_IsLazyLoad_Call) Return(_a0 bool) *MockSegment_IsLazyLoad_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockSegment_IsLazyLoad_Call) RunAndReturn(run func() bool) *MockSegment_IsLazyLoad_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -948,6 +948,47 @@ func (_c *MockSegment_Release_Call) Return() *MockSegment_Release_Call {
 }
 
 func (_c *MockSegment_Release_Call) RunAndReturn(run func(...releaseOption)) *MockSegment_Release_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ResourceGroup provides a mock function with given fields:
+func (_m *MockSegment) ResourceGroup() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// MockSegment_ResourceGroup_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ResourceGroup'
+type MockSegment_ResourceGroup_Call struct {
+	*mock.Call
+}
+
+// ResourceGroup is a helper method to define mock.On call
+func (_e *MockSegment_Expecter) ResourceGroup() *MockSegment_ResourceGroup_Call {
+	return &MockSegment_ResourceGroup_Call{Call: _e.mock.On("ResourceGroup")}
+}
+
+func (_c *MockSegment_ResourceGroup_Call) Run(run func()) *MockSegment_ResourceGroup_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockSegment_ResourceGroup_Call) Return(_a0 string) *MockSegment_ResourceGroup_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockSegment_ResourceGroup_Call) RunAndReturn(run func() string) *MockSegment_ResourceGroup_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/querynodev2/segments/plan_test.go
+++ b/internal/querynodev2/segments/plan_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/proto/planpb"
 	"github.com/milvus-io/milvus/internal/proto/querypb"
+	"github.com/milvus-io/milvus/pkg/util/paramtable"
 )
 
 type PlanSuite struct {
@@ -80,5 +81,6 @@ func (suite *PlanSuite) TestQueryPlanCollectionReleased() {
 }
 
 func TestPlan(t *testing.T) {
+	paramtable.Init()
 	suite.Run(t, new(PlanSuite))
 }

--- a/internal/querynodev2/segments/plan_test.go
+++ b/internal/querynodev2/segments/plan_test.go
@@ -43,7 +43,9 @@ func (suite *PlanSuite) SetupTest() {
 	suite.partitionID = 10
 	suite.segmentID = 1
 	schema := GenTestCollectionSchema("plan-suite", schemapb.DataType_Int64, true)
-	suite.collection = NewCollection(suite.collectionID, schema, GenTestIndexMeta(suite.collectionID, schema), querypb.LoadType_LoadCollection)
+	suite.collection = NewCollection(suite.collectionID, schema, GenTestIndexMeta(suite.collectionID, schema), &querypb.LoadMetaInfo{
+		LoadType: querypb.LoadType_LoadCollection,
+	})
 	suite.collection.AddPartition(suite.partitionID)
 }
 

--- a/internal/querynodev2/segments/reduce_test.go
+++ b/internal/querynodev2/segments/reduce_test.go
@@ -71,8 +71,9 @@ func (suite *ReduceSuite) SetupTest() {
 	suite.collection = NewCollection(suite.collectionID,
 		schema,
 		GenTestIndexMeta(suite.collectionID, schema),
-		querypb.LoadType_LoadCollection,
-	)
+		&querypb.LoadMetaInfo{
+			LoadType: querypb.LoadType_LoadCollection,
+		})
 	suite.segment, err = NewSegment(ctx,
 		suite.collection,
 		suite.segmentID,

--- a/internal/querynodev2/segments/reduce_test.go
+++ b/internal/querynodev2/segments/reduce_test.go
@@ -76,15 +76,15 @@ func (suite *ReduceSuite) SetupTest() {
 		})
 	suite.segment, err = NewSegment(ctx,
 		suite.collection,
-		suite.segmentID,
-		suite.partitionID,
-		suite.collectionID,
-		"dml",
 		SegmentTypeSealed,
 		0,
-		nil,
-		nil,
-		datapb.SegmentLevel_Legacy,
+		&querypb.SegmentLoadInfo{
+			SegmentID:     suite.segmentID,
+			CollectionID:  suite.collectionID,
+			PartitionID:   suite.partitionID,
+			InsertChannel: "dml",
+			Level:         datapb.SegmentLevel_Legacy,
+		},
 	)
 	suite.Require().NoError(err)
 

--- a/internal/querynodev2/segments/retrieve_test.go
+++ b/internal/querynodev2/segments/retrieve_test.go
@@ -85,15 +85,15 @@ func (suite *RetrieveSuite) SetupTest() {
 
 	suite.sealed, err = NewSegment(ctx,
 		suite.collection,
-		suite.segmentID,
-		suite.partitionID,
-		suite.collectionID,
-		"dml",
 		SegmentTypeSealed,
 		0,
-		nil,
-		nil,
-		datapb.SegmentLevel_Legacy,
+		&querypb.SegmentLoadInfo{
+			SegmentID:     suite.segmentID,
+			CollectionID:  suite.collectionID,
+			PartitionID:   suite.partitionID,
+			InsertChannel: "dml",
+			Level:         datapb.SegmentLevel_Legacy,
+		},
 	)
 	suite.Require().NoError(err)
 
@@ -113,15 +113,15 @@ func (suite *RetrieveSuite) SetupTest() {
 
 	suite.growing, err = NewSegment(ctx,
 		suite.collection,
-		suite.segmentID+1,
-		suite.partitionID,
-		suite.collectionID,
-		"dml",
 		SegmentTypeGrowing,
 		0,
-		nil,
-		nil,
-		datapb.SegmentLevel_Legacy,
+		&querypb.SegmentLoadInfo{
+			SegmentID:     suite.segmentID + 1,
+			CollectionID:  suite.collectionID,
+			PartitionID:   suite.partitionID,
+			InsertChannel: "dml",
+			Level:         datapb.SegmentLevel_Legacy,
+		},
 	)
 	suite.Require().NoError(err)
 

--- a/internal/querynodev2/segments/search_test.go
+++ b/internal/querynodev2/segments/search_test.go
@@ -76,15 +76,15 @@ func (suite *SearchSuite) SetupTest() {
 
 	suite.sealed, err = NewSegment(ctx,
 		suite.collection,
-		suite.segmentID,
-		suite.partitionID,
-		suite.collectionID,
-		"dml",
 		SegmentTypeSealed,
 		0,
-		nil,
-		nil,
-		datapb.SegmentLevel_Legacy,
+		&querypb.SegmentLoadInfo{
+			SegmentID:     suite.segmentID,
+			CollectionID:  suite.collectionID,
+			PartitionID:   suite.partitionID,
+			InsertChannel: "dml",
+			Level:         datapb.SegmentLevel_Legacy,
+		},
 	)
 	suite.Require().NoError(err)
 
@@ -104,15 +104,15 @@ func (suite *SearchSuite) SetupTest() {
 
 	suite.growing, err = NewSegment(ctx,
 		suite.collection,
-		suite.segmentID+1,
-		suite.partitionID,
-		suite.collectionID,
-		"dml",
 		SegmentTypeGrowing,
 		0,
-		nil,
-		nil,
-		datapb.SegmentLevel_Legacy,
+		&querypb.SegmentLoadInfo{
+			SegmentID:     suite.segmentID + 1,
+			CollectionID:  suite.collectionID,
+			PartitionID:   suite.partitionID,
+			InsertChannel: "dml",
+			Level:         datapb.SegmentLevel_Legacy,
+		},
 	)
 	suite.Require().NoError(err)
 

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -118,6 +118,14 @@ func (s *baseSegment) Partition() int64 {
 	return s.loadInfo.GetPartitionID()
 }
 
+func (s *baseSegment) DatabaseName() string {
+	return s.collection.GetDBName()
+}
+
+func (s *baseSegment) ResourceGroup() string {
+	return s.collection.GetResourceGroup()
+}
+
 func (s *baseSegment) Shard() string {
 	return s.loadInfo.GetInsertChannel()
 }
@@ -144,10 +152,6 @@ func (s *baseSegment) CASVersion(old, newVersion int64) bool {
 
 func (s *baseSegment) LoadStatus() LoadStatus {
 	return LoadStatus(s.loadStatus.Load())
-}
-
-func (s *baseSegment) IsLazyLoad() bool {
-	return s.loadInfo.GetLazyLoad()
 }
 
 func (s *baseSegment) LoadInfo() *querypb.SegmentLoadInfo {
@@ -332,7 +336,6 @@ func NewSegmentV2(
 	if err != nil {
 		return nil, err
 	}
-
 	segment := &LocalSegment{
 		baseSegment:        newBaseSegment(collection, segmentType, version, loadInfo),
 		ptr:                segmentPtr,
@@ -1390,4 +1393,6 @@ func (s *LocalSegment) Release(opts ...releaseOption) {
 		zap.String("segmentType", s.segmentType.String()),
 		zap.Int64("insertCount", s.InsertCount()),
 	)
+	// set segment resource estimate to zero.
+	clearResourceEstimate(s)
 }

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -77,67 +77,61 @@ type IndexedFieldInfo struct {
 }
 
 type baseSegment struct {
-	segmentID    int64
-	partitionID  int64
-	shard        string
-	collectionID int64
-	typ          SegmentType
-	level        datapb.SegmentLevel
-	version      *atomic.Int64
+	collection *Collection
+	version    *atomic.Int64
 
 	// the load status of the segment,
 	// only transitions below are allowed:
 	// 1. LoadStatusMeta <-> LoadStatusMapped
 	// 2. LoadStatusMeta <-> LoadStatusInMemory
 	loadStatus     *atomic.String
-	isLazyLoad     bool
-	startPosition  *msgpb.MsgPosition // for growing segment release
+	segmentType    SegmentType
 	bloomFilterSet *pkoracle.BloomFilterSet
 	loadInfo       *querypb.SegmentLoadInfo
+
+	resourceUsageCache *atomic.Pointer[ResourceUsage]
 }
 
-func newBaseSegment(id, partitionID, collectionID int64, shard string, typ SegmentType, level datapb.SegmentLevel, version int64, startPosition *msgpb.MsgPosition) baseSegment {
+func newBaseSegment(collection *Collection, segmentType SegmentType, version int64, loadInfo *querypb.SegmentLoadInfo) baseSegment {
 	return baseSegment{
-		segmentID:      id,
-		partitionID:    partitionID,
-		collectionID:   collectionID,
-		shard:          shard,
-		typ:            typ,
-		level:          level,
+		collection:     collection,
+		loadInfo:       loadInfo,
 		version:        atomic.NewInt64(version),
 		loadStatus:     atomic.NewString(string(LoadStatusMeta)),
-		startPosition:  startPosition,
-		bloomFilterSet: pkoracle.NewBloomFilterSet(id, partitionID, typ),
+		segmentType:    segmentType,
+		bloomFilterSet: pkoracle.NewBloomFilterSet(loadInfo.GetSegmentID(), loadInfo.GetPartitionID(), segmentType),
+
+		resourceUsageCache: atomic.NewPointer[ResourceUsage](nil),
 	}
 }
 
 // ID returns the identity number.
 func (s *baseSegment) ID() int64 {
-	return s.segmentID
+	return s.loadInfo.GetSegmentID()
 }
 
 func (s *baseSegment) Collection() int64 {
-	return s.collectionID
+	return s.loadInfo.GetCollectionID()
 }
 
 func (s *baseSegment) Partition() int64 {
-	return s.partitionID
+	return s.loadInfo.GetPartitionID()
 }
 
 func (s *baseSegment) Shard() string {
-	return s.shard
+	return s.loadInfo.GetInsertChannel()
 }
 
 func (s *baseSegment) Type() SegmentType {
-	return s.typ
+	return s.segmentType
 }
 
 func (s *baseSegment) Level() datapb.SegmentLevel {
-	return s.level
+	return s.loadInfo.GetLevel()
 }
 
 func (s *baseSegment) StartPosition() *msgpb.MsgPosition {
-	return s.startPosition
+	return s.loadInfo.GetStartPosition()
 }
 
 func (s *baseSegment) Version() int64 {
@@ -153,10 +147,14 @@ func (s *baseSegment) LoadStatus() LoadStatus {
 }
 
 func (s *baseSegment) IsLazyLoad() bool {
-	return s.isLazyLoad
+	return s.loadInfo.GetLazyLoad()
 }
 
 func (s *baseSegment) LoadInfo() *querypb.SegmentLoadInfo {
+	if s.segmentType == SegmentTypeGrowing {
+		// Growing segment do not have load info.
+		return nil
+	}
 	return s.loadInfo
 }
 
@@ -169,6 +167,37 @@ func (s *baseSegment) UpdateBloomFilter(pks []storage.PrimaryKey) {
 // may returns true even the PK doesn't exist actually
 func (s *baseSegment) MayPkExist(pk storage.PrimaryKey) bool {
 	return s.bloomFilterSet.MayPkExist(pk)
+}
+
+// ResourceUsageEstimate returns the estimated resource usage of the segment.
+func (s *baseSegment) ResourceUsageEstimate() ResourceUsage {
+	if s.segmentType == SegmentTypeGrowing {
+		// Growing segment cannot do resource usage estimate.
+		return ResourceUsage{}
+	}
+	cache := s.resourceUsageCache.Load()
+	if cache != nil {
+		return *cache
+	}
+
+	usage, err := getResourceUsageEstimateOfSegment(s.collection.Schema(), s.loadInfo, resourceEstimateFactor{
+		memoryUsageFactor:        1.0,
+		memoryIndexUsageFactor:   1.0,
+		enableTempSegmentIndex:   false,
+		deltaDataExpansionFactor: paramtable.Get().QueryNodeCfg.DeltaDataExpansionRate.GetAsFloat(),
+	})
+	if err != nil {
+		// Should never failure, if failed, segment should never be loaded.
+		log.Warn(
+			"unreachable: failed to get resource usage estimate of segment",
+			zap.Error(err),
+			zap.Int64("collectionID", s.Collection()),
+			zap.Int64("segmentID", s.ID()),
+		)
+		return ResourceUsage{}
+	}
+	s.resourceUsageCache.Store(usage)
+	return *usage
 }
 
 type FieldInfo struct {
@@ -197,23 +226,17 @@ type LocalSegment struct {
 
 func NewSegment(ctx context.Context,
 	collection *Collection,
-	segmentID int64,
-	partitionID int64,
-	collectionID int64,
-	shard string,
 	segmentType SegmentType,
 	version int64,
-	startPosition *msgpb.MsgPosition,
-	deltaPosition *msgpb.MsgPosition,
-	level datapb.SegmentLevel,
+	loadInfo *querypb.SegmentLoadInfo,
 ) (Segment, error) {
 	log := log.Ctx(ctx)
 	/*
 		CStatus
 		NewSegment(CCollection collection, uint64_t segment_id, SegmentType seg_type, CSegmentInterface* newSegment);
 	*/
-	if level == datapb.SegmentLevel_L0 {
-		return NewL0Segment(collection, segmentID, partitionID, collectionID, shard, segmentType, version, startPosition, deltaPosition)
+	if loadInfo.GetLevel() == datapb.SegmentLevel_L0 {
+		return NewL0Segment(collection, segmentType, version, loadInfo)
 	}
 	var cSegType C.SegmentType
 	switch segmentType {
@@ -222,16 +245,16 @@ func NewSegment(ctx context.Context,
 	case SegmentTypeGrowing:
 		cSegType = C.Growing
 	default:
-		return nil, fmt.Errorf("illegal segment type %d when create segment %d", segmentType, segmentID)
+		return nil, fmt.Errorf("illegal segment type %d when create segment %d", segmentType, loadInfo.GetSegmentID())
 	}
 
 	var newPtr C.CSegmentInterface
 	_, err := GetDynamicPool().Submit(func() (any, error) {
-		status := C.NewSegment(collection.collectionPtr, cSegType, C.int64_t(segmentID), &newPtr)
+		status := C.NewSegment(collection.collectionPtr, cSegType, C.int64_t(loadInfo.GetSegmentID()), &newPtr)
 		err := HandleCStatus(ctx, &status, "NewSegmentFailed",
-			zap.Int64("collectionID", collectionID),
-			zap.Int64("partitionID", partitionID),
-			zap.Int64("segmentID", segmentID),
+			zap.Int64("collectionID", loadInfo.GetCollectionID()),
+			zap.Int64("partitionID", loadInfo.GetPartitionID()),
+			zap.Int64("segmentID", loadInfo.GetSegmentID()),
 			zap.String("segmentType", segmentType.String()))
 		return nil, err
 	}).Await()
@@ -240,15 +263,15 @@ func NewSegment(ctx context.Context,
 	}
 
 	log.Info("create segment",
-		zap.Int64("collectionID", collectionID),
-		zap.Int64("partitionID", partitionID),
-		zap.Int64("segmentID", segmentID),
+		zap.Int64("collectionID", loadInfo.GetCollectionID()),
+		zap.Int64("partitionID", loadInfo.GetPartitionID()),
+		zap.Int64("segmentID", loadInfo.GetSegmentID()),
 		zap.String("segmentType", segmentType.String()),
-		zap.String("level", level.String()),
+		zap.String("level", loadInfo.GetLevel().String()),
 	)
 
 	segment := &LocalSegment{
-		baseSegment:        newBaseSegment(segmentID, partitionID, collectionID, shard, segmentType, level, version, startPosition),
+		baseSegment:        newBaseSegment(collection, segmentType, version, loadInfo),
 		ptr:                newPtr,
 		lastDeltaTimestamp: atomic.NewUint64(0),
 		fields:             typeutil.NewConcurrentMap[int64, *FieldInfo](),
@@ -269,33 +292,26 @@ func NewSegment(ctx context.Context,
 func NewSegmentV2(
 	ctx context.Context,
 	collection *Collection,
-	segmentID int64,
-	partitionID int64,
-	collectionID int64,
-	shard string,
 	segmentType SegmentType,
 	version int64,
-	startPosition *msgpb.MsgPosition,
-	deltaPosition *msgpb.MsgPosition,
-	storageVersion int64,
-	level datapb.SegmentLevel,
+	loadInfo *querypb.SegmentLoadInfo,
 ) (Segment, error) {
 	/*
 		CSegmentInterface
 		NewSegment(CCollection collection, uint64_t segment_id, SegmentType seg_type);
 	*/
-	if level == datapb.SegmentLevel_L0 {
-		return NewL0Segment(collection, segmentID, partitionID, collectionID, shard, segmentType, version, startPosition, deltaPosition)
+	if loadInfo.GetLevel() == datapb.SegmentLevel_L0 {
+		return NewL0Segment(collection, segmentType, version, loadInfo)
 	}
 	var segmentPtr C.CSegmentInterface
 	var status C.CStatus
 	switch segmentType {
 	case SegmentTypeSealed:
-		status = C.NewSegment(collection.collectionPtr, C.Sealed, C.int64_t(segmentID), &segmentPtr)
+		status = C.NewSegment(collection.collectionPtr, C.Sealed, C.int64_t(loadInfo.GetSegmentID()), &segmentPtr)
 	case SegmentTypeGrowing:
-		status = C.NewSegment(collection.collectionPtr, C.Growing, C.int64_t(segmentID), &segmentPtr)
+		status = C.NewSegment(collection.collectionPtr, C.Growing, C.int64_t(loadInfo.GetSegmentID()), &segmentPtr)
 	default:
-		return nil, fmt.Errorf("illegal segment type %d when create segment %d", segmentType, segmentID)
+		return nil, fmt.Errorf("illegal segment type %d when create segment %d", segmentType, loadInfo.GetSegmentID())
 	}
 
 	if err := HandleCStatus(ctx, &status, "NewSegmentFailed"); err != nil {
@@ -303,22 +319,22 @@ func NewSegmentV2(
 	}
 
 	log.Info("create segment",
-		zap.Int64("collectionID", collectionID),
-		zap.Int64("partitionID", partitionID),
-		zap.Int64("segmentID", segmentID),
+		zap.Int64("collectionID", loadInfo.GetCollectionID()),
+		zap.Int64("partitionID", loadInfo.GetPartitionID()),
+		zap.Int64("segmentID", loadInfo.GetSegmentID()),
 		zap.String("segmentType", segmentType.String()))
 
-	url, err := typeutil_internal.GetStorageURI(paramtable.Get().CommonCfg.StorageScheme.GetValue(), paramtable.Get().CommonCfg.StoragePathPrefix.GetValue(), segmentID)
+	url, err := typeutil_internal.GetStorageURI(paramtable.Get().CommonCfg.StorageScheme.GetValue(), paramtable.Get().CommonCfg.StoragePathPrefix.GetValue(), loadInfo.GetSegmentID())
 	if err != nil {
 		return nil, err
 	}
-	space, err := milvus_storage.Open(url, options.NewSpaceOptionBuilder().SetVersion(storageVersion).Build())
+	space, err := milvus_storage.Open(url, options.NewSpaceOptionBuilder().SetVersion(loadInfo.GetStorageVersion()).Build())
 	if err != nil {
 		return nil, err
 	}
 
 	segment := &LocalSegment{
-		baseSegment:        newBaseSegment(segmentID, partitionID, collectionID, shard, segmentType, level, version, startPosition),
+		baseSegment:        newBaseSegment(collection, segmentType, version, loadInfo),
 		ptr:                segmentPtr,
 		lastDeltaTimestamp: atomic.NewUint64(0),
 		fields:             typeutil.NewConcurrentMap[int64, *FieldInfo](),
@@ -461,13 +477,13 @@ func (s *LocalSegment) Search(ctx context.Context, searchReq *SearchRequest) (*S
 	log := log.Ctx(ctx).With(
 		zap.Int64("collectionID", s.Collection()),
 		zap.Int64("segmentID", s.ID()),
-		zap.String("segmentType", s.typ.String()),
+		zap.String("segmentType", s.segmentType.String()),
 	)
 	s.ptrLock.RLock()
 	defer s.ptrLock.RUnlock()
 
 	if s.ptr == nil {
-		return nil, merr.WrapErrSegmentNotLoaded(s.segmentID, "segment released")
+		return nil, merr.WrapErrSegmentNotLoaded(s.ID(), "segment released")
 	}
 
 	traceCtx := ParseCTraceContext(ctx)
@@ -493,7 +509,7 @@ func (s *LocalSegment) Search(ctx context.Context, searchReq *SearchRequest) (*S
 	if err := HandleCStatus(ctx, &status, "Search failed",
 		zap.Int64("collectionID", s.Collection()),
 		zap.Int64("segmentID", s.ID()),
-		zap.String("segmentType", s.typ.String())); err != nil {
+		zap.String("segmentType", s.segmentType.String())); err != nil {
 		return nil, err
 	}
 	log.Debug("search segment done")
@@ -505,7 +521,7 @@ func (s *LocalSegment) Retrieve(ctx context.Context, plan *RetrievePlan) (*segco
 	defer s.ptrLock.RUnlock()
 
 	if s.ptr == nil {
-		return nil, merr.WrapErrSegmentNotLoaded(s.segmentID, "segment released")
+		return nil, merr.WrapErrSegmentNotLoaded(s.ID(), "segment released")
 	}
 
 	log := log.Ctx(ctx).With(
@@ -513,7 +529,7 @@ func (s *LocalSegment) Retrieve(ctx context.Context, plan *RetrievePlan) (*segco
 		zap.Int64("partitionID", s.Partition()),
 		zap.Int64("segmentID", s.ID()),
 		zap.Int64("msgID", plan.msgID),
-		zap.String("segmentType", s.typ.String()),
+		zap.String("segmentType", s.segmentType.String()),
 	)
 
 	traceCtx := ParseCTraceContext(ctx)
@@ -542,7 +558,7 @@ func (s *LocalSegment) Retrieve(ctx context.Context, plan *RetrievePlan) (*segco
 		zap.Int64("partitionID", s.Partition()),
 		zap.Int64("segmentID", s.ID()),
 		zap.Int64("msgID", plan.msgID),
-		zap.String("segmentType", s.typ.String())); err != nil {
+		zap.String("segmentType", s.segmentType.String())); err != nil {
 		return nil, err
 	}
 
@@ -595,14 +611,14 @@ func (s *LocalSegment) preInsert(ctx context.Context, numOfRecords int) (int64, 
 
 func (s *LocalSegment) Insert(ctx context.Context, rowIDs []int64, timestamps []typeutil.Timestamp, record *segcorepb.InsertRecord) error {
 	if s.Type() != SegmentTypeGrowing {
-		return fmt.Errorf("unexpected segmentType when segmentInsert, segmentType = %s", s.typ.String())
+		return fmt.Errorf("unexpected segmentType when segmentInsert, segmentType = %s", s.segmentType.String())
 	}
 
 	s.ptrLock.RLock()
 	defer s.ptrLock.RUnlock()
 
 	if s.ptr == nil {
-		return merr.WrapErrSegmentNotLoaded(s.segmentID, "segment released")
+		return merr.WrapErrSegmentNotLoaded(s.ID(), "segment released")
 	}
 
 	offset, err := s.preInsert(ctx, len(rowIDs))
@@ -662,7 +678,7 @@ func (s *LocalSegment) Delete(ctx context.Context, primaryKeys []storage.Primary
 	defer s.ptrLock.RUnlock()
 
 	if s.ptr == nil {
-		return merr.WrapErrSegmentNotLoaded(s.segmentID, "segment released")
+		return merr.WrapErrSegmentNotLoaded(s.ID(), "segment released")
 	}
 
 	cOffset := C.int64_t(0) // depre
@@ -728,7 +744,7 @@ func (s *LocalSegment) LoadMultiFieldData(ctx context.Context, rowCount int64, f
 	defer s.ptrLock.RUnlock()
 
 	if s.ptr == nil {
-		return merr.WrapErrSegmentNotLoaded(s.segmentID, "segment released")
+		return merr.WrapErrSegmentNotLoaded(s.ID(), "segment released")
 	}
 
 	log := log.Ctx(ctx).With(
@@ -763,7 +779,7 @@ func (s *LocalSegment) LoadMultiFieldData(ctx context.Context, rowCount int64, f
 	var status C.CStatus
 	GetLoadPool().Submit(func() (any, error) {
 		if paramtable.Get().CommonCfg.EnableStorageV2.GetAsBool() {
-			uri, err := typeutil_internal.GetStorageURI(paramtable.Get().CommonCfg.StorageScheme.GetValue(), paramtable.Get().CommonCfg.StoragePathPrefix.GetValue(), s.segmentID)
+			uri, err := typeutil_internal.GetStorageURI(paramtable.Get().CommonCfg.StorageScheme.GetValue(), paramtable.Get().CommonCfg.StoragePathPrefix.GetValue(), s.ID())
 			if err != nil {
 				return nil, err
 			}
@@ -831,11 +847,11 @@ func (s *LocalSegment) LoadFieldData(ctx context.Context, fieldID int64, rowCoun
 	s.ptrLock.RLock()
 	defer s.ptrLock.RUnlock()
 
-	ctx, sp := otel.Tracer(typeutil.QueryNodeRole).Start(ctx, fmt.Sprintf("LoadFieldData-%d-%d", s.segmentID, fieldID))
+	ctx, sp := otel.Tracer(typeutil.QueryNodeRole).Start(ctx, fmt.Sprintf("LoadFieldData-%d-%d", s.ID(), fieldID))
 	defer sp.End()
 
 	if s.ptr == nil {
-		return merr.WrapErrSegmentNotLoaded(s.segmentID, "segment released")
+		return merr.WrapErrSegmentNotLoaded(s.ID(), "segment released")
 	}
 
 	log := log.Ctx(ctx).With(
@@ -875,7 +891,7 @@ func (s *LocalSegment) LoadFieldData(ctx context.Context, fieldID int64, rowCoun
 	GetLoadPool().Submit(func() (any, error) {
 		log.Info("submitted loadFieldData task to load pool")
 		if paramtable.Get().CommonCfg.EnableStorageV2.GetAsBool() {
-			uri, err := typeutil_internal.GetStorageURI(paramtable.Get().CommonCfg.StorageScheme.GetValue(), paramtable.Get().CommonCfg.StoragePathPrefix.GetValue(), s.segmentID)
+			uri, err := typeutil_internal.GetStorageURI(paramtable.Get().CommonCfg.StorageScheme.GetValue(), paramtable.Get().CommonCfg.StoragePathPrefix.GetValue(), s.ID())
 			if err != nil {
 				return nil, err
 			}
@@ -996,7 +1012,7 @@ func (s *LocalSegment) AddFieldDataInfo(ctx context.Context, rowCount int64, fie
 	defer s.ptrLock.RUnlock()
 
 	if s.ptr == nil {
-		return merr.WrapErrSegmentNotLoaded(s.segmentID, "segment released")
+		return merr.WrapErrSegmentNotLoaded(s.ID(), "segment released")
 	}
 
 	log := log.Ctx(ctx).With(
@@ -1051,7 +1067,7 @@ func (s *LocalSegment) LoadDeltaData(ctx context.Context, deltaData *storage.Del
 	defer s.ptrLock.RUnlock()
 
 	if s.ptr == nil {
-		return merr.WrapErrSegmentNotLoaded(s.segmentID, "segment released")
+		return merr.WrapErrSegmentNotLoaded(s.ID(), "segment released")
 	}
 
 	log := log.Ctx(ctx).With(
@@ -1137,7 +1153,7 @@ func (s *LocalSegment) LoadIndex(ctx context.Context, indexInfo *querypb.FieldIn
 		return nil
 	}
 
-	ctx, sp := otel.Tracer(typeutil.QueryNodeRole).Start(ctx, fmt.Sprintf("LoadIndex-%d-%d", s.segmentID, indexInfo.GetFieldID()))
+	ctx, sp := otel.Tracer(typeutil.QueryNodeRole).Start(ctx, fmt.Sprintf("LoadIndex-%d-%d", s.ID(), indexInfo.GetFieldID()))
 	defer sp.End()
 
 	log := log.Ctx(ctx).With(
@@ -1155,14 +1171,14 @@ func (s *LocalSegment) LoadIndex(ctx context.Context, indexInfo *querypb.FieldIn
 	defer deleteLoadIndexInfo(loadIndexInfo)
 
 	if paramtable.Get().CommonCfg.EnableStorageV2.GetAsBool() {
-		uri, err := typeutil_internal.GetStorageURI(paramtable.Get().CommonCfg.StorageScheme.GetValue(), paramtable.Get().CommonCfg.StoragePathPrefix.GetValue(), s.segmentID)
+		uri, err := typeutil_internal.GetStorageURI(paramtable.Get().CommonCfg.StorageScheme.GetValue(), paramtable.Get().CommonCfg.StoragePathPrefix.GetValue(), s.ID())
 		if err != nil {
 			return err
 		}
 
 		loadIndexInfo.appendStorageInfo(uri, indexInfo.IndexStoreVersion)
 	}
-	err = loadIndexInfo.appendLoadIndexInfo(ctx, indexInfo, s.collectionID, s.partitionID, s.segmentID, fieldType)
+	err = loadIndexInfo.appendLoadIndexInfo(ctx, indexInfo, s.Collection(), s.Partition(), s.ID(), fieldType)
 	if err != nil {
 		if loadIndexInfo.cleanLocalData(ctx) != nil {
 			log.Warn("failed to clean cached data on disk after append index failed",
@@ -1172,7 +1188,7 @@ func (s *LocalSegment) LoadIndex(ctx context.Context, indexInfo *querypb.FieldIn
 		return err
 	}
 	if s.Type() != SegmentTypeSealed {
-		errMsg := fmt.Sprintln("updateSegmentIndex failed, illegal segment type ", s.typ, "segmentID = ", s.ID())
+		errMsg := fmt.Sprintln("updateSegmentIndex failed, illegal segment type ", s.segmentType, "segmentID = ", s.ID())
 		return errors.New(errMsg)
 	}
 
@@ -1199,7 +1215,7 @@ func (s *LocalSegment) UpdateIndexInfo(ctx context.Context, indexInfo *querypb.F
 	defer s.ptrLock.RUnlock()
 
 	if s.ptr == nil {
-		return merr.WrapErrSegmentNotLoaded(s.segmentID, "segment released")
+		return merr.WrapErrSegmentNotLoaded(s.ID(), "segment released")
 	}
 
 	var status C.CStatus
@@ -1368,10 +1384,10 @@ func (s *LocalSegment) Release(opts ...releaseOption) {
 	}
 
 	log.Info("delete segment from memory",
-		zap.Int64("collectionID", s.collectionID),
-		zap.Int64("partitionID", s.partitionID),
+		zap.Int64("collectionID", s.Collection()),
+		zap.Int64("partitionID", s.Partition()),
 		zap.Int64("segmentID", s.ID()),
-		zap.String("segmentType", s.typ.String()),
+		zap.String("segmentType", s.segmentType.String()),
 		zap.Int64("insertCount", s.InsertCount()),
 	)
 }

--- a/internal/querynodev2/segments/segment_interface.go
+++ b/internal/querynodev2/segments/segment_interface.go
@@ -50,6 +50,8 @@ type Segment interface {
 
 	// Properties
 	ID() int64
+	DatabaseName() string
+	ResourceGroup() string
 	Collection() int64
 	Partition() int64
 	Shard() string
@@ -59,7 +61,6 @@ type Segment interface {
 	Type() SegmentType
 	Level() datapb.SegmentLevel
 	LoadStatus() LoadStatus
-	IsLazyLoad() bool
 	LoadInfo() *querypb.SegmentLoadInfo
 	RLock() error
 	RUnlock()

--- a/internal/querynodev2/segments/segment_interface.go
+++ b/internal/querynodev2/segments/segment_interface.go
@@ -35,7 +35,19 @@ const (
 	LoadStatusInMemory LoadStatus = "in_memory"
 )
 
+// ResourceUsage is used to estimate the resource usage of a sealed segment.
+type ResourceUsage struct {
+	MemorySize     uint64
+	DiskSize       uint64
+	MmapFieldCount int
+}
+
+// Segment is the interface of a segment implementation.
+// Some methods can not apply to all segment types，such as LoadInfo, ResourceUsageEstimate.
+// Add more interface to represent different segment types is a better implementation.
 type Segment interface {
+	// ResourceUsageEstimate() ResourceUsage
+
 	// Properties
 	ID() int64
 	Collection() int64
@@ -58,6 +70,8 @@ type Segment interface {
 	// RowNum returns the number of rows, it's slow, so DO NOT call it in a loop
 	RowNum() int64
 	MemSize() int64
+	// ResourceUsageEstimate returns the estimated resource usage of the segment
+	ResourceUsageEstimate() ResourceUsage
 
 	// Index related
 	GetIndex(fieldID int64) *IndexedFieldInfo

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -649,6 +649,7 @@ func (loader *segmentLoader) Load(ctx context.Context,
 			)
 			return err
 		}
+
 		loader.manager.Segment.Put(segmentType, segment)
 		newSegments.GetAndRemove(segmentID)
 		loaded.Insert(segmentID, segment)
@@ -1035,7 +1036,12 @@ func (loader *segmentLoader) loadSegment(ctx context.Context,
 	).Add(float64(loadInfo.GetNumOfRows()))
 
 	log.Info("loading delta...")
-	return loader.LoadDeltaLogs(ctx, segment, loadInfo.Deltalogs)
+	if err := loader.LoadDeltaLogs(ctx, segment, loadInfo.Deltalogs); err != nil {
+		return err
+	}
+
+	observeResourceEstimate(segment)
+	return nil
 }
 
 func (loader *segmentLoader) filterPKStatsBinlogs(fieldBinlogs []*datapb.FieldBinlog, pkFieldID int64) ([]string, storage.StatsLogType) {

--- a/internal/querynodev2/segments/segment_loader_test.go
+++ b/internal/querynodev2/segments/segment_loader_test.go
@@ -693,7 +693,7 @@ func (suite *SegmentLoaderDetailSuite) SetupTest() {
 		PartitionIDs: []int64{suite.partitionID},
 	}
 
-	collection := NewCollection(suite.collectionID, schema, indexMeta, loadMeta.GetLoadType())
+	collection := NewCollection(suite.collectionID, schema, indexMeta, loadMeta)
 	suite.collectionManager.EXPECT().Get(suite.collectionID).Return(collection).Maybe()
 }
 

--- a/internal/querynodev2/segments/segment_test.go
+++ b/internal/querynodev2/segments/segment_test.go
@@ -63,15 +63,15 @@ func (suite *SegmentSuite) SetupTest() {
 
 	suite.sealed, err = NewSegment(ctx,
 		suite.collection,
-		suite.segmentID,
-		suite.partitionID,
-		suite.collectionID,
-		"dml",
 		SegmentTypeSealed,
 		0,
-		nil,
-		nil,
-		datapb.SegmentLevel_Legacy,
+		&querypb.SegmentLoadInfo{
+			CollectionID:  suite.collectionID,
+			SegmentID:     suite.segmentID,
+			PartitionID:   suite.partitionID,
+			InsertChannel: "dml",
+			Level:         datapb.SegmentLevel_Legacy,
+		},
 	)
 	suite.Require().NoError(err)
 
@@ -91,15 +91,15 @@ func (suite *SegmentSuite) SetupTest() {
 
 	suite.growing, err = NewSegment(ctx,
 		suite.collection,
-		suite.segmentID+1,
-		suite.partitionID,
-		suite.collectionID,
-		"dml",
 		SegmentTypeGrowing,
 		0,
-		nil,
-		nil,
-		datapb.SegmentLevel_Legacy,
+		&querypb.SegmentLoadInfo{
+			SegmentID:     suite.segmentID + 1,
+			CollectionID:  suite.collectionID,
+			PartitionID:   suite.partitionID,
+			InsertChannel: "dml",
+			Level:         datapb.SegmentLevel_Legacy,
+		},
 	)
 	suite.Require().NoError(err)
 

--- a/internal/querynodev2/segments/utils.go
+++ b/internal/querynodev2/segments/utils.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/proto/internalpb"
+	"github.com/milvus-io/milvus/internal/querynodev2/segments/metricsutil"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/pkg/common"
 	"github.com/milvus-io/milvus/pkg/log"
@@ -319,4 +320,33 @@ func mergeRequestCost(requestCosts []*internalpb.CostAggregation) *internalpb.Co
 func getIndexEngineVersion() (minimal, current int32) {
 	cMinimal, cCurrent := C.GetMinimalIndexVersion(), C.GetCurrentIndexVersion()
 	return int32(cMinimal), int32(cCurrent)
+}
+
+// getSegmentMetricLabel returns the label for segment metrics.
+func getSegmentMetricLabel(segment Segment) metricsutil.SegmentLabel {
+	return metricsutil.SegmentLabel{
+		SegmentID:     segment.ID(),
+		DatabaseName:  segment.DatabaseName(),
+		ResourceGroup: segment.ResourceGroup(),
+	}
+}
+
+// observeResourceEstimate records the resource usage of a segment.
+func observeResourceEstimate(segment Segment) {
+	estimate := segment.ResourceUsageEstimate()
+	rowNum := segment.RowNum()
+	metricsutil.NewResourceEstimateRecord(getSegmentMetricLabel(segment)).
+		WithMemUsage(estimate.MemorySize).
+		WithDiskUsage(estimate.DiskSize).
+		WithRowNum(uint64(rowNum)).
+		Finish(nil)
+}
+
+// clearResourceEstimate clears the resource usage of a segment.
+func clearResourceEstimate(segment Segment) {
+	metricsutil.NewResourceEstimateRecord(getSegmentMetricLabel(segment)).
+		WithMemUsage(0).
+		WithDiskUsage(0).
+		WithRowNum(0).
+		Finish(nil)
 }

--- a/internal/querynodev2/server.go
+++ b/internal/querynodev2/server.go
@@ -51,6 +51,7 @@ import (
 	"github.com/milvus-io/milvus/internal/querynodev2/optimizers"
 	"github.com/milvus-io/milvus/internal/querynodev2/pipeline"
 	"github.com/milvus-io/milvus/internal/querynodev2/segments"
+	"github.com/milvus-io/milvus/internal/querynodev2/segments/metricsutil"
 	"github.com/milvus-io/milvus/internal/querynodev2/tasks"
 	"github.com/milvus-io/milvus/internal/querynodev2/tsafe"
 	"github.com/milvus-io/milvus/internal/registry"
@@ -295,6 +296,9 @@ func (node *QueryNode) Init() error {
 				return
 			}
 		}
+
+		// init metrics collector scheduler.
+		metricsutil.StartScheduler()
 
 		node.factory.Init(paramtable.Get())
 

--- a/internal/querynodev2/server_test.go
+++ b/internal/querynodev2/server_test.go
@@ -219,7 +219,9 @@ func (suite *QueryNodeSuite) TestStop() {
 	suite.node.manager = segments.NewManager()
 
 	schema := segments.GenTestCollectionSchema("test_stop", schemapb.DataType_Int64, true)
-	collection := segments.NewCollection(1, schema, nil, querypb.LoadType_LoadCollection)
+	collection := segments.NewCollection(1, schema, nil, &querypb.LoadMetaInfo{
+		LoadType: querypb.LoadType_LoadCollection,
+	})
 	segment, err := segments.NewSegment(
 		context.Background(),
 		collection,

--- a/internal/querynodev2/server_test.go
+++ b/internal/querynodev2/server_test.go
@@ -225,14 +225,15 @@ func (suite *QueryNodeSuite) TestStop() {
 	segment, err := segments.NewSegment(
 		context.Background(),
 		collection,
-		100,
-		10,
-		1,
-		"test_stop_channel",
 		segments.SegmentTypeSealed,
-		1, nil,
-		nil,
-		datapb.SegmentLevel_Legacy,
+		1,
+		&querypb.SegmentLoadInfo{
+			SegmentID:     100,
+			PartitionID:   10,
+			CollectionID:  1,
+			InsertChannel: "test_stop_channel",
+			Level:         datapb.SegmentLevel_Legacy,
+		},
 	)
 	suite.NoError(err)
 	suite.node.manager.Segment.Put(segments.SegmentTypeSealed, segment)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -81,6 +81,8 @@ const (
 	functionLabelName        = "function_name"
 	queryTypeLabelName       = "query_type"
 	collectionName           = "collection_name"
+	databaseLabelName        = "db"
+	resourceGroupLabelName   = "rg"
 	segmentStateLabelName    = "segment_state"
 	segmentIDLabelName       = "segment_id"
 	segmentLevelLabelName    = "segment_level"

--- a/pkg/metrics/querynode_metrics.go
+++ b/pkg/metrics/querynode_metrics.go
@@ -501,6 +501,168 @@ var (
 		}, []string{
 			nodeIDLabelName,
 		})
+	// QueryNodeSegmentAccessTotal records the total number of search or query segments accessed.
+	QueryNodeSegmentAccessTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.QueryNodeRole,
+			Name:      "segment_access_total",
+		}, []string{
+			nodeIDLabelName,
+			databaseLabelName,
+			resourceGroupLabelName,
+			queryTypeLabelName,
+		},
+	)
+
+	// QueryNodeSegmentAccessDuration records the total time cost of accessing segments including cache loads.
+	QueryNodeSegmentAccessDuration = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.QueryNodeRole,
+			Name:      "segment_access_duration",
+		}, []string{
+			nodeIDLabelName,
+			databaseLabelName,
+			resourceGroupLabelName,
+			queryTypeLabelName,
+		},
+	)
+
+	// QueryNodeSegmentAccessWaitCacheTotal records the number of search or query segments that have to wait for loading access.
+	QueryNodeSegmentAccessWaitCacheTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.QueryNodeRole,
+			Name:      "segment_access_wait_cache_total",
+		}, []string{
+			nodeIDLabelName,
+			databaseLabelName,
+			resourceGroupLabelName,
+			queryTypeLabelName,
+		})
+
+	// QueryNodeSegmentAccessWaitCacheDuration records the total time cost of waiting for loading access.
+	QueryNodeSegmentAccessWaitCacheDuration = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.QueryNodeRole,
+			Name:      "segment_access_wait_cache_duration",
+		}, []string{
+			nodeIDLabelName,
+			databaseLabelName,
+			resourceGroupLabelName,
+			queryTypeLabelName,
+		})
+
+	// QueryNodeDiskCacheLoadTotal records the number of real segments loaded from disk cache.
+	QueryNodeDiskCacheLoadTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.QueryNodeRole,
+			Name:      "disk_cache_load_total",
+		}, []string{
+			nodeIDLabelName,
+			databaseLabelName,
+			resourceGroupLabelName,
+		})
+
+	QueryNodeDiskCacheLoadBytes = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.QueryNodeRole,
+			Name:      "disk_cache_load_bytes",
+		}, []string{
+			nodeIDLabelName,
+			databaseLabelName,
+			resourceGroupLabelName,
+		})
+
+	// QueryNodeDiskCacheLoadDuration records the total time cost of loading segments from disk cache.
+	QueryNodeDiskCacheLoadDuration = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.QueryNodeRole,
+			Name:      "disk_cache_load_duration",
+		}, []string{
+			nodeIDLabelName,
+			databaseLabelName,
+			resourceGroupLabelName,
+		})
+
+	// QueryNodeDiskCacheEvictTotal records the number of real segments evicted from disk cache.
+	QueryNodeDiskCacheEvictTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.QueryNodeRole,
+			Name:      "disk_cache_evict_total",
+		}, []string{
+			nodeIDLabelName,
+			databaseLabelName,
+			resourceGroupLabelName,
+		})
+
+	// QueryNodeDiskCacheEvictDuration records the total time cost of evicting segments from disk cache.
+	QueryNodeDiskCacheEvictDuration = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.QueryNodeRole,
+			Name:      "disk_cache_evict_duration",
+		}, []string{
+			nodeIDLabelName,
+			databaseLabelName,
+			resourceGroupLabelName,
+		})
+
+	// QueryNodeActiveSegmentDiskBytes records the disk usage of hot segments.
+	QueryNodeActiveSegmentDiskBytes = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.QueryNodeRole,
+			Name:      "active_segment_disk_bytes",
+		}, []string{
+			nodeIDLabelName,
+			databaseLabelName,
+			resourceGroupLabelName,
+		})
+
+	// QueryNodeActiveSegmentMemoryBytes records the memory usage of hot segments.
+	QueryNodeActiveSegmentMemoryBytes = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.QueryNodeRole,
+			Name:      "active_segment_memory_bytes",
+		}, []string{
+			nodeIDLabelName,
+			databaseLabelName,
+			resourceGroupLabelName,
+		})
+
+	// QueryNodeLoadedSegmentDiskBytes records the disk size of active segments.
+	QueryNodeLoadedSegmentDiskBytes = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.QueryNodeRole,
+			Name:      "loaded_segment_disk_bytes",
+		}, []string{
+			nodeIDLabelName,
+			databaseLabelName,
+			resourceGroupLabelName,
+		},
+	)
+
+	// QueryNodeLoadedSegmentMemoryBytes records the memory size of active segments.
+	QueryNodeLoadedSegmentMemoryBytes = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.QueryNodeRole,
+			Name:      "loaded_segment_memory_bytes",
+		}, []string{
+			nodeIDLabelName,
+			databaseLabelName,
+			resourceGroupLabelName,
+		},
+	)
 )
 
 // RegisterQueryNode registers QueryNode metrics
@@ -548,6 +710,19 @@ func RegisterQueryNode(registry *prometheus.Registry) {
 	registry.MustRegister(StoppingBalanceSegmentNum)
 	registry.MustRegister(QueryNodeLoadSegmentConcurrency)
 	registry.MustRegister(QueryNodeLoadIndexLatency)
+	registry.MustRegister(QueryNodeSegmentAccessTotal)
+	registry.MustRegister(QueryNodeSegmentAccessDuration)
+	registry.MustRegister(QueryNodeSegmentAccessWaitCacheTotal)
+	registry.MustRegister(QueryNodeSegmentAccessWaitCacheDuration)
+	registry.MustRegister(QueryNodeDiskCacheLoadTotal)
+	registry.MustRegister(QueryNodeDiskCacheLoadDuration)
+	registry.MustRegister(QueryNodeDiskCacheLoadBytes)
+	registry.MustRegister(QueryNodeDiskCacheEvictTotal)
+	registry.MustRegister(QueryNodeDiskCacheEvictDuration)
+	registry.MustRegister(QueryNodeActiveSegmentDiskBytes)
+	registry.MustRegister(QueryNodeActiveSegmentMemoryBytes)
+	registry.MustRegister(QueryNodeLoadedSegmentDiskBytes)
+	registry.MustRegister(QueryNodeLoadedSegmentMemoryBytes)
 }
 
 func CleanupQueryNodeCollectionMetrics(nodeID int64, collectionID int64) {

--- a/pkg/util/cache/cache_test.go
+++ b/pkg/util/cache/cache_test.go
@@ -17,16 +17,26 @@ func (s *CacheSuite) TestLRUCache() {
 	}, nil)
 
 	for i := 1; i <= size; i++ {
-		item, ok := cache.GetAndPin(i)
+		item, missing, ok := cache.GetAndPin(i)
 		s.True(ok)
+		s.True(missing)
+		s.Equal(i, item.Value())
+		item.Unpin()
+	}
+
+	for i := 1; i <= size; i++ {
+		item, missing, ok := cache.GetAndPin(i)
+		s.True(ok)
+		s.False(missing)
 		s.Equal(i, item.Value())
 		item.Unpin()
 	}
 
 	s.False(cache.Contain(size + 1))
 	for i := 1; i <= size; i++ {
-		item, ok := cache.GetAndPin(size + i)
+		item, missing, ok := cache.GetAndPin(size + i)
 		s.True(ok)
+		s.True(missing)
 		s.Equal(size+i, item.Value())
 		s.False(cache.Contain(i))
 		item.Unpin()

--- a/pkg/util/metricsutil/counter.go
+++ b/pkg/util/metricsutil/counter.go
@@ -1,0 +1,64 @@
+package metricsutil
+
+import (
+	"errors"
+	"math"
+
+	"go.uber.org/atomic"
+)
+
+var _ Counter = &counter{}
+
+// NewCounter creates a new Counter.
+func NewCounter() Counter {
+	return &counter{}
+}
+
+// Counter is a metric that represents a single numerical value that only ever goes up.
+// Reference: github.com/prometheus/client_golang/prometheus.
+type Counter interface {
+	// Add adds the given value to the counter. It panics if the value is negative.
+	Add(float64)
+
+	// Inc increments the counter by 1.
+	Inc()
+
+	// Get returns the current value of the counter.
+	Get() float64
+}
+
+// counter is a Counter implementation.
+type counter struct {
+	valInt  atomic.Uint64
+	valBits atomic.Uint64
+}
+
+func (c *counter) Add(v float64) {
+	if v < 0 {
+		panic(errors.New("counter cannot decrease in value"))
+	}
+
+	ival := uint64(v)
+	if float64(ival) == v {
+		c.valInt.Add(ival)
+		return
+	}
+
+	for {
+		oldBits := c.valBits.Load()
+		newBits := math.Float64bits(math.Float64frombits(oldBits) + v)
+		if c.valBits.CompareAndSwap(oldBits, newBits) {
+			return
+		}
+	}
+}
+
+func (c *counter) Inc() {
+	c.valInt.Inc()
+}
+
+func (c *counter) Get() float64 {
+	fval := math.Float64frombits(c.valBits.Load())
+	ival := c.valInt.Load()
+	return fval + float64(ival)
+}

--- a/pkg/util/metricsutil/counter_test.go
+++ b/pkg/util/metricsutil/counter_test.go
@@ -1,0 +1,37 @@
+package metricsutil
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCounter(t *testing.T) {
+	c := NewCounter()
+	c.Add(1)
+	assert.Equal(t, 1, int(c.Get()))
+	c.Add(1)
+	assert.Equal(t, 2, int(c.Get()))
+	c.Inc()
+	assert.Equal(t, 3, int(c.Get()))
+	c.Add(2.5)
+	assert.True(t, c.Get()-5.5 < 1e-6)
+
+	c = NewCounter()
+	wg := sync.WaitGroup{}
+	wg.Add(100)
+	cnt := 0.0
+	for i := 0; i < 100; i++ {
+		go func(i int) {
+			c.Add(float64(i) * 1.5)
+			wg.Done()
+		}(i)
+		cnt += float64(i) * 1.5
+	}
+	wg.Wait()
+	assert.True(t, c.Get()-cnt < 1e-6)
+	assert.Panics(t, func() {
+		c.Add(-1)
+	})
+}

--- a/pkg/util/metricsutil/duration.go
+++ b/pkg/util/metricsutil/duration.go
@@ -1,0 +1,35 @@
+package metricsutil
+
+import (
+	"time"
+
+	"go.uber.org/atomic"
+)
+
+// NewDuration creates a new Duration.
+func NewDuration() Duration {
+	return &duration{}
+}
+
+// Duration is a metric that represents a single numerical value that only ever goes up.
+type Duration interface {
+	// Add adds the given value to the duration. It panics if the value is negative.
+	Add(d time.Duration)
+
+	// Get returns the current value of the duration.
+	Get() time.Duration
+}
+
+// duration is a Duration implementation.
+type duration struct {
+	valInt atomic.Int64
+}
+
+func (d *duration) Add(v time.Duration) {
+	d.valInt.Add(v.Nanoseconds())
+}
+
+func (d *duration) Get() time.Duration {
+	c := d.valInt.Load()
+	return time.Duration(c) * time.Nanosecond
+}

--- a/pkg/util/metricsutil/duration_test.go
+++ b/pkg/util/metricsutil/duration_test.go
@@ -1,0 +1,17 @@
+package metricsutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDuration(t *testing.T) {
+	d := NewDuration()
+	assert.Equal(t, time.Duration(0), d.Get())
+	d.Add(time.Second)
+	assert.Equal(t, time.Second, d.Get())
+	d.Add(time.Minute)
+	assert.Equal(t, time.Second+time.Minute, d.Get())
+}

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -2027,6 +2027,10 @@ type queryNodeConfig struct {
 	FlowGraphMaxParallelism ParamItem `refreshable:"false"`
 
 	MemoryIndexLoadPredictMemoryUsageFactor ParamItem `refreshable:"true"`
+
+	// Metric Collector
+	MetricScrapeInterval       ParamItem `refreshable:"true"`
+	ActiveSegmentPredicateExpr ParamItem `refreshable:"true"`
 }
 
 func (p *queryNodeConfig) init(base *BaseTable) {
@@ -2490,6 +2494,22 @@ Max read concurrency must greater than or equal to 1, and less than or equal to 
 		Doc:          "memory usage prediction factor for memory index loaded",
 	}
 	p.MemoryIndexLoadPredictMemoryUsageFactor.Init(base.mgr)
+
+	p.MetricScrapeInterval = ParamItem{
+		Key:          "queryNode.metricScrapeInterval",
+		Version:      "2.4.0",
+		DefaultValue: "15", // every xx seconds.
+		Doc:          "the interval of scrape metric in seconds",
+	}
+	p.MetricScrapeInterval.Init(base.mgr)
+
+	p.ActiveSegmentPredicateExpr = ParamItem{
+		Key:          "queryNode.activeSegmentPredicateExpr",
+		Version:      "2.4.0",
+		DefaultValue: `len(Snapshots) >= 4 && (((Snapshots[-1].AccessCount() - Snapshots[-4].AccessCount()) / (Snapshots[-1].Time.Sub(Snapshots[-4].Time).Seconds())) > 0.1)`,
+		Doc:          "the predicate expression to filter hot segment, if the segment match the predicate, it will be treated as hot segment",
+	}
+	p.ActiveSegmentPredicateExpr.Init(base.mgr)
 }
 
 // /////////////////////////////////////////////////////////////////////////////

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -367,6 +367,14 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, 2.5, Params.MemoryIndexLoadPredictMemoryUsageFactor.GetAsFloat())
 		params.Save("queryNode.memoryIndexLoadPredictMemoryUsageFactor", "2.0")
 		assert.Equal(t, 2.0, Params.MemoryIndexLoadPredictMemoryUsageFactor.GetAsFloat())
+
+		assert.Equal(t, 15, Params.MetricScrapeInterval.GetAsInt())
+		params.Save("queryNode.metricScrapeInterval", "10")
+		assert.Equal(t, 10, Params.MetricScrapeInterval.GetAsInt())
+
+		assert.Equal(t, "0 == 0", Params.ActiveSegmentPredicateExpr.GetValue())
+		params.Save("queryNode.activeSegmentPredicateExpr", "0 == 0")
+		assert.Equal(t, "0 == 0", Params.ActiveSegmentPredicateExpr.GetValue())
 	})
 
 	t.Run("test dataCoordConfig", func(t *testing.T) {


### PR DESCRIPTION
issue: #30931

- add background task to collect lru or search metrics.
- add active segment predicate to check if a segment is an active segment.