### PR TITLE
enhance: [Cherry-pick] Add `ListIndexes` API from datacoord (#31104)

### DIFF
--- a/internal/datacoord/index_service.go
+++ b/internal/datacoord/index_service.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/samber/lo"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
@@ -33,7 +34,6 @@ import (
 	"github.com/milvus-io/milvus/pkg/util/metautil"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
-	"github.com/samber/lo"
 )
 
 // serverID return the session serverID

--- a/internal/datacoord/index_service.go
+++ b/internal/datacoord/index_service.go
@@ -33,6 +33,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/util/metautil"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
+	"github.com/samber/lo"
 )
 
 // serverID return the session serverID
@@ -788,4 +789,38 @@ func (s *Server) selectSegmentIndexes(selector SegmentInfoSelector) map[int64]*i
 		ret[info.GetID()] = is
 	}
 	return ret
+}
+
+// ListIndexes returns all indexes created on provided collection.
+func (s *Server) ListIndexes(ctx context.Context, req *indexpb.ListIndexesRequest) (*indexpb.ListIndexesResponse, error) {
+	log := log.Ctx(ctx).With(
+		zap.Int64("collectionID", req.GetCollectionID()),
+	)
+
+	if err := merr.CheckHealthy(s.GetStateCode()); err != nil {
+		log.Warn(msgDataCoordIsUnhealthy(paramtable.GetNodeID()), zap.Error(err))
+		return &indexpb.ListIndexesResponse{
+			Status: merr.Status(err),
+		}, nil
+	}
+
+	indexes := s.meta.indexMeta.GetIndexesForCollection(req.GetCollectionID(), "")
+
+	indexInfos := lo.Map(indexes, func(index *model.Index, _ int) *indexpb.IndexInfo {
+		return &indexpb.IndexInfo{
+			CollectionID:    index.CollectionID,
+			FieldID:         index.FieldID,
+			IndexName:       index.IndexName,
+			IndexID:         index.IndexID,
+			TypeParams:      index.TypeParams,
+			IndexParams:     index.IndexParams,
+			IsAutoIndex:     index.IsAutoIndex,
+			UserIndexParams: index.UserIndexParams,
+		}
+	})
+	log.Info("List index success")
+	return &indexpb.ListIndexesResponse{
+		Status:     merr.Success(),
+		IndexInfos: indexInfos,
+	}, nil
 }

--- a/internal/datacoord/index_service_test.go
+++ b/internal/datacoord/index_service_test.go
@@ -1115,6 +1115,155 @@ func TestServer_DescribeIndex(t *testing.T) {
 	})
 }
 
+func TestServer_ListIndexes(t *testing.T) {
+	var (
+		collID     = UniqueID(1)
+		fieldID    = UniqueID(10)
+		indexID    = UniqueID(100)
+		indexName  = "default_idx"
+		typeParams = []*commonpb.KeyValuePair{
+			{
+				Key:   common.DimKey,
+				Value: "128",
+			},
+		}
+		indexParams = []*commonpb.KeyValuePair{
+			{
+				Key:   common.IndexTypeKey,
+				Value: "IVF_FLAT",
+			},
+		}
+		createTS = uint64(1000)
+		ctx      = context.Background()
+		req      = &indexpb.ListIndexesRequest{
+			CollectionID: collID,
+		}
+	)
+
+	catalog := catalogmocks.NewDataCoordCatalog(t)
+	s := &Server{
+		meta: &meta{
+			catalog: catalog,
+			indexMeta: &indexMeta{
+				catalog: catalog,
+				indexes: map[UniqueID]map[UniqueID]*model.Index{
+					collID: {
+						// finished
+						indexID: {
+							TenantID:        "",
+							CollectionID:    collID,
+							FieldID:         fieldID,
+							IndexID:         indexID,
+							IndexName:       indexName,
+							IsDeleted:       false,
+							CreateTime:      createTS,
+							TypeParams:      typeParams,
+							IndexParams:     indexParams,
+							IsAutoIndex:     false,
+							UserIndexParams: nil,
+						},
+						// deleted
+						indexID + 1: {
+							TenantID:        "",
+							CollectionID:    collID,
+							FieldID:         fieldID + 1,
+							IndexID:         indexID + 1,
+							IndexName:       indexName + "_1",
+							IsDeleted:       true,
+							CreateTime:      createTS,
+							TypeParams:      typeParams,
+							IndexParams:     indexParams,
+							IsAutoIndex:     false,
+							UserIndexParams: nil,
+						},
+						// unissued
+						indexID + 2: {
+							TenantID:        "",
+							CollectionID:    collID,
+							FieldID:         fieldID + 2,
+							IndexID:         indexID + 2,
+							IndexName:       indexName + "_2",
+							IsDeleted:       false,
+							CreateTime:      createTS,
+							TypeParams:      typeParams,
+							IndexParams:     indexParams,
+							IsAutoIndex:     false,
+							UserIndexParams: nil,
+						},
+						// inProgress
+						indexID + 3: {
+							TenantID:        "",
+							CollectionID:    collID,
+							FieldID:         fieldID + 3,
+							IndexID:         indexID + 3,
+							IndexName:       indexName + "_3",
+							IsDeleted:       false,
+							CreateTime:      createTS,
+							TypeParams:      typeParams,
+							IndexParams:     indexParams,
+							IsAutoIndex:     false,
+							UserIndexParams: nil,
+						},
+						// failed
+						indexID + 4: {
+							TenantID:        "",
+							CollectionID:    collID,
+							FieldID:         fieldID + 4,
+							IndexID:         indexID + 4,
+							IndexName:       indexName + "_4",
+							IsDeleted:       false,
+							CreateTime:      createTS,
+							TypeParams:      typeParams,
+							IndexParams:     indexParams,
+							IsAutoIndex:     false,
+							UserIndexParams: nil,
+						},
+						// unissued
+						indexID + 5: {
+							TenantID:        "",
+							CollectionID:    collID,
+							FieldID:         fieldID + 5,
+							IndexID:         indexID + 5,
+							IndexName:       indexName + "_5",
+							IsDeleted:       false,
+							CreateTime:      createTS,
+							TypeParams:      typeParams,
+							IndexParams:     indexParams,
+							IsAutoIndex:     false,
+							UserIndexParams: nil,
+						},
+					},
+				},
+				segmentIndexes: map[UniqueID]map[UniqueID]*model.SegmentIndex{},
+			},
+
+			segments: &SegmentsInfo{
+				compactionTo: make(map[int64]int64),
+				segments:     map[UniqueID]*SegmentInfo{},
+			},
+		},
+		allocator:       newMockAllocator(),
+		notifyIndexChan: make(chan UniqueID, 1),
+	}
+
+	t.Run("server not available", func(t *testing.T) {
+		s.stateCode.Store(commonpb.StateCode_Initializing)
+		resp, err := s.ListIndexes(ctx, req)
+		assert.NoError(t, err)
+		assert.ErrorIs(t, merr.Error(resp.GetStatus()), merr.ErrServiceNotReady)
+	})
+
+	s.stateCode.Store(commonpb.StateCode_Healthy)
+
+	t.Run("success", func(t *testing.T) {
+		resp, err := s.ListIndexes(ctx, req)
+		assert.NoError(t, err)
+
+		// assert.Equal(t, commonpb.ErrorCode_Success, resp.GetStatus().GetErrorCode())
+		assert.Equal(t, 5, len(resp.GetIndexInfos()))
+	})
+}
+
 func TestServer_GetIndexStatistics(t *testing.T) {
 	var (
 		collID       = UniqueID(1)

--- a/internal/distributed/datacoord/client/client.go
+++ b/internal/distributed/datacoord/client/client.go
@@ -751,3 +751,9 @@ func (c *Client) GcControl(ctx context.Context, req *datapb.GcControlRequest, op
 		return client.GcControl(ctx, req)
 	})
 }
+
+func (c *Client) ListIndexes(ctx context.Context, in *indexpb.ListIndexesRequest, opts ...grpc.CallOption) (*indexpb.ListIndexesResponse, error) {
+	return wrapGrpcCall(ctx, c, func(client datapb.DataCoordClient) (*indexpb.ListIndexesResponse, error) {
+		return client.ListIndexes(ctx, in)
+	})
+}

--- a/internal/distributed/datacoord/service.go
+++ b/internal/distributed/datacoord/service.go
@@ -482,3 +482,7 @@ func (s *Server) ReportDataNodeTtMsgs(ctx context.Context, req *datapb.ReportDat
 func (s *Server) GcControl(ctx context.Context, req *datapb.GcControlRequest) (*commonpb.Status, error) {
 	return s.dataCoord.GcControl(ctx, req)
 }
+
+func (s *Server) ListIndexes(ctx context.Context, in *indexpb.ListIndexesRequest) (*indexpb.ListIndexesResponse, error) {
+	return s.dataCoord.ListIndexes(ctx, in)
+}

--- a/internal/distributed/datacoord/service_test.go
+++ b/internal/distributed/datacoord/service_test.go
@@ -331,6 +331,15 @@ func Test_NewServer(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, ret)
 	})
+
+	t.Run("ListIndex", func(t *testing.T) {
+		mockDataCoord.EXPECT().ListIndexes(mock.Anything, mock.Anything).Return(&indexpb.ListIndexesResponse{
+			Status: merr.Success(),
+		}, nil)
+		ret, err := server.ListIndexes(ctx, &indexpb.ListIndexesRequest{})
+		assert.NoError(t, err)
+		assert.True(t, merr.Ok(ret.GetStatus()))
+	})
 }
 
 func Test_Run(t *testing.T) {

--- a/internal/mocks/mock_datacoord.go
+++ b/internal/mocks/mock_datacoord.go
@@ -1947,6 +1947,61 @@ func (_c *MockDataCoord_Init_Call) RunAndReturn(run func() error) *MockDataCoord
 	return _c
 }
 
+// ListIndexes provides a mock function with given fields: _a0, _a1
+func (_m *MockDataCoord) ListIndexes(_a0 context.Context, _a1 *indexpb.ListIndexesRequest) (*indexpb.ListIndexesResponse, error) {
+	ret := _m.Called(_a0, _a1)
+
+	var r0 *indexpb.ListIndexesResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *indexpb.ListIndexesRequest) (*indexpb.ListIndexesResponse, error)); ok {
+		return rf(_a0, _a1)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *indexpb.ListIndexesRequest) *indexpb.ListIndexesResponse); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*indexpb.ListIndexesResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *indexpb.ListIndexesRequest) error); ok {
+		r1 = rf(_a0, _a1)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockDataCoord_ListIndexes_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListIndexes'
+type MockDataCoord_ListIndexes_Call struct {
+	*mock.Call
+}
+
+// ListIndexes is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *indexpb.ListIndexesRequest
+func (_e *MockDataCoord_Expecter) ListIndexes(_a0 interface{}, _a1 interface{}) *MockDataCoord_ListIndexes_Call {
+	return &MockDataCoord_ListIndexes_Call{Call: _e.mock.On("ListIndexes", _a0, _a1)}
+}
+
+func (_c *MockDataCoord_ListIndexes_Call) Run(run func(_a0 context.Context, _a1 *indexpb.ListIndexesRequest)) *MockDataCoord_ListIndexes_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*indexpb.ListIndexesRequest))
+	})
+	return _c
+}
+
+func (_c *MockDataCoord_ListIndexes_Call) Return(_a0 *indexpb.ListIndexesResponse, _a1 error) *MockDataCoord_ListIndexes_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockDataCoord_ListIndexes_Call) RunAndReturn(run func(context.Context, *indexpb.ListIndexesRequest) (*indexpb.ListIndexesResponse, error)) *MockDataCoord_ListIndexes_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ManualCompaction provides a mock function with given fields: _a0, _a1
 func (_m *MockDataCoord) ManualCompaction(_a0 context.Context, _a1 *milvuspb.ManualCompactionRequest) (*milvuspb.ManualCompactionResponse, error) {
 	ret := _m.Called(_a0, _a1)

--- a/internal/mocks/mock_datacoord_client.go
+++ b/internal/mocks/mock_datacoord_client.go
@@ -2454,6 +2454,76 @@ func (_c *MockDataCoordClient_Import_Call) RunAndReturn(run func(context.Context
 	return _c
 }
 
+// ListIndexes provides a mock function with given fields: ctx, in, opts
+func (_m *MockDataCoordClient) ListIndexes(ctx context.Context, in *indexpb.ListIndexesRequest, opts ...grpc.CallOption) (*indexpb.ListIndexesResponse, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, in)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *indexpb.ListIndexesResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *indexpb.ListIndexesRequest, ...grpc.CallOption) (*indexpb.ListIndexesResponse, error)); ok {
+		return rf(ctx, in, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *indexpb.ListIndexesRequest, ...grpc.CallOption) *indexpb.ListIndexesResponse); ok {
+		r0 = rf(ctx, in, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*indexpb.ListIndexesResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *indexpb.ListIndexesRequest, ...grpc.CallOption) error); ok {
+		r1 = rf(ctx, in, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockDataCoordClient_ListIndexes_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListIndexes'
+type MockDataCoordClient_ListIndexes_Call struct {
+	*mock.Call
+}
+
+// ListIndexes is a helper method to define mock.On call
+//   - ctx context.Context
+//   - in *indexpb.ListIndexesRequest
+//   - opts ...grpc.CallOption
+func (_e *MockDataCoordClient_Expecter) ListIndexes(ctx interface{}, in interface{}, opts ...interface{}) *MockDataCoordClient_ListIndexes_Call {
+	return &MockDataCoordClient_ListIndexes_Call{Call: _e.mock.On("ListIndexes",
+		append([]interface{}{ctx, in}, opts...)...)}
+}
+
+func (_c *MockDataCoordClient_ListIndexes_Call) Run(run func(ctx context.Context, in *indexpb.ListIndexesRequest, opts ...grpc.CallOption)) *MockDataCoordClient_ListIndexes_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]grpc.CallOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(grpc.CallOption)
+			}
+		}
+		run(args[0].(context.Context), args[1].(*indexpb.ListIndexesRequest), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockDataCoordClient_ListIndexes_Call) Return(_a0 *indexpb.ListIndexesResponse, _a1 error) *MockDataCoordClient_ListIndexes_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockDataCoordClient_ListIndexes_Call) RunAndReturn(run func(context.Context, *indexpb.ListIndexesRequest, ...grpc.CallOption) (*indexpb.ListIndexesResponse, error)) *MockDataCoordClient_ListIndexes_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ManualCompaction provides a mock function with given fields: ctx, in, opts
 func (_m *MockDataCoordClient) ManualCompaction(ctx context.Context, in *milvuspb.ManualCompactionRequest, opts ...grpc.CallOption) (*milvuspb.ManualCompactionResponse, error) {
 	_va := make([]interface{}, len(opts))

--- a/internal/proto/data_coord.proto
+++ b/internal/proto/data_coord.proto
@@ -87,6 +87,7 @@ service DataCoord {
   rpc GetIndexStatistics(index.GetIndexStatisticsRequest) returns (index.GetIndexStatisticsResponse) {}
   // Deprecated: use DescribeIndex instead
   rpc GetIndexBuildProgress(index.GetIndexBuildProgressRequest) returns (index.GetIndexBuildProgressResponse) {}
+  rpc ListIndexes(index.ListIndexesRequest) returns (index.ListIndexesResponse) {}
 
   rpc GcConfirm(GcConfirmRequest) returns (GcConfirmResponse) {}
 

--- a/internal/proto/index_coord.proto
+++ b/internal/proto/index_coord.proto
@@ -285,3 +285,12 @@ message GetIndexStatisticsResponse {
   common.Status status = 1;
   repeated IndexInfo index_infos = 2;
 }
+
+message ListIndexesRequest {
+    int64 collectionID = 1;
+}
+
+message ListIndexesResponse {
+    common.Status status = 1;
+    repeated IndexInfo index_infos = 2;
+}


### PR DESCRIPTION
Cherry-pick from master
pr: #31104
See also #31103

This PR add `listIndexes` API for datacoor server to list all indexes for provided collection.
Comparing to the existing `DescribeIndex` API, the new one does NOT check the segment index building progress to ease the burden when invoking it