### PR TITLE
fix: Balance channel stuck forever due to logic dead lock

### DIFF
--- a/internal/querycoordv2/balance/multi_target_balance.go
+++ b/internal/querycoordv2/balance/multi_target_balance.go
@@ -493,6 +493,11 @@ func (b *MultiTargetBalancer) BalanceReplica(replica *meta.Replica) ([]SegmentAs
 	// print current distribution before generating plans
 	segmentPlans, channelPlans := make([]SegmentAssignPlan, 0), make([]ChannelAssignPlan, 0)
 	if len(offlineNodes) != 0 {
+		if !paramtable.Get().QueryCoordCfg.EnableStoppingBalance.GetAsBool() {
+			log.RatedInfo(10, "stopping balance is disabled!", zap.Int64s("stoppingNode", offlineNodes))
+			return nil, nil
+		}
+
 		log.Info("Handle stopping nodes",
 			zap.Any("stopping nodes", offlineNodes),
 			zap.Any("available nodes", onlineNodes),

--- a/internal/querycoordv2/balance/rowcount_based_balancer.go
+++ b/internal/querycoordv2/balance/rowcount_based_balancer.go
@@ -179,6 +179,11 @@ func (b *RowCountBasedBalancer) BalanceReplica(replica *meta.Replica) ([]Segment
 
 	segmentPlans, channelPlans := make([]SegmentAssignPlan, 0), make([]ChannelAssignPlan, 0)
 	if len(offlineNodes) != 0 {
+		if !paramtable.Get().QueryCoordCfg.EnableStoppingBalance.GetAsBool() {
+			log.RatedInfo(10, "stopping balance is disabled!", zap.Int64s("stoppingNode", offlineNodes))
+			return nil, nil
+		}
+
 		log.Info("Handle stopping nodes",
 			zap.Any("stopping nodes", offlineNodes),
 			zap.Any("available nodes", onlineNodes),

--- a/internal/querycoordv2/balance/score_based_balancer.go
+++ b/internal/querycoordv2/balance/score_based_balancer.go
@@ -213,6 +213,11 @@ func (b *ScoreBasedBalancer) BalanceReplica(replica *meta.Replica) ([]SegmentAss
 	// print current distribution before generating plans
 	segmentPlans, channelPlans := make([]SegmentAssignPlan, 0), make([]ChannelAssignPlan, 0)
 	if len(offlineNodes) != 0 {
+		if !paramtable.Get().QueryCoordCfg.EnableStoppingBalance.GetAsBool() {
+			log.RatedInfo(10, "stopping balance is disabled!", zap.Int64s("stoppingNode", offlineNodes))
+			return nil, nil
+		}
+
 		log.Info("Handle stopping nodes",
 			zap.Any("stopping nodes", offlineNodes),
 			zap.Any("available nodes", onlineNodes),

--- a/internal/querycoordv2/checkers/segment_checker.go
+++ b/internal/querycoordv2/checkers/segment_checker.go
@@ -105,21 +105,7 @@ func (c *SegmentChecker) Check(ctx context.Context) []task.Task {
 }
 
 func (c *SegmentChecker) checkReplica(ctx context.Context, replica *meta.Replica) []task.Task {
-	log := log.Ctx(ctx).WithRateGroup("qcv2.SegmentChecker", 1, 60).With(
-		zap.Int64("collectionID", replica.CollectionID),
-		zap.Int64("replicaID", replica.ID))
 	ret := make([]task.Task, 0)
-
-	// get channel dist by replica (ch -> node list), cause more then one delegator may exists during channel balance.
-	// if more than one delegator exist, load/release segment may causes chaos, so we can skip it until channel balance finished.
-	dist := c.dist.ChannelDistManager.GetChannelDistByReplica(replica)
-	for ch, nodes := range dist {
-		if len(nodes) > 1 {
-			log.Info("skip check segment due to two shard leader exists",
-				zap.String("channelName", ch))
-			return ret
-		}
-	}
 
 	// compare with targets to find the lack and redundancy of segments
 	lacks, redundancies := c.getSealedSegmentDiff(replica.GetCollectionID(), replica.GetID())

--- a/internal/querycoordv2/checkers/segment_checker_test.go
+++ b/internal/querycoordv2/checkers/segment_checker_test.go
@@ -196,46 +196,6 @@ func (suite *SegmentCheckerTestSuite) TestSkipLoadSegments() {
 	suite.Len(tasks, 0)
 }
 
-func (suite *SegmentCheckerTestSuite) TestSkipCheckReplica() {
-	checker := suite.checker
-	// set meta
-	checker.meta.CollectionManager.PutCollection(utils.CreateTestCollection(1, 1))
-	checker.meta.CollectionManager.PutPartition(utils.CreateTestPartition(1, 1))
-	checker.meta.ReplicaManager.Put(utils.CreateTestReplica(1, 1, []int64{1, 2}))
-	suite.nodeMgr.Add(session.NewNodeInfo(1, "localhost"))
-	suite.nodeMgr.Add(session.NewNodeInfo(2, "localhost"))
-	checker.meta.ResourceManager.AssignNode(meta.DefaultResourceGroupName, 1)
-	checker.meta.ResourceManager.AssignNode(meta.DefaultResourceGroupName, 2)
-
-	// set target
-	segments := []*datapb.SegmentInfo{
-		{
-			ID:            1,
-			PartitionID:   1,
-			InsertChannel: "test-insert-channel",
-		},
-	}
-
-	channels := []*datapb.VchannelInfo{
-		{
-			CollectionID: 1,
-			ChannelName:  "test-insert-channel",
-		},
-	}
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
-		channels, segments, nil)
-	checker.targetMgr.UpdateCollectionNextTarget(int64(1))
-
-	// set dist
-	checker.dist.ChannelDistManager.Update(1, utils.CreateTestChannel(1, 1, 1, "test-insert-channel"))
-	checker.dist.ChannelDistManager.Update(2, utils.CreateTestChannel(1, 2, 2, "test-insert-channel"))
-	checker.dist.SegmentDistManager.Update(2, utils.CreateTestSegment(1, 1, 11, 1, 1, "test-insert-channel"))
-	checker.dist.LeaderViewManager.Update(2, utils.CreateTestLeaderView(2, 1, "test-insert-channel", map[int64]int64{}, map[int64]*meta.Segment{}))
-
-	tasks := checker.Check(context.TODO())
-	suite.Len(tasks, 0)
-}
-
 func (suite *SegmentCheckerTestSuite) TestReleaseSegments() {
 	checker := suite.checker
 	// set meta

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -1467,6 +1467,7 @@ type queryCoordConfig struct {
 	CheckAutoBalanceConfigInterval ParamItem `refreshable:"false"`
 	CheckNodeSessionInterval       ParamItem `refreshable:"false"`
 	GracefulStopTimeout            ParamItem `refreshable:"true"`
+	EnableStoppingBalance          ParamItem `refreshable:"true"`
 }
 
 func (p *queryCoordConfig) init(base *BaseTable) {
@@ -1934,6 +1935,15 @@ func (p *queryCoordConfig) init(base *BaseTable) {
 		Export:       true,
 	}
 	p.GracefulStopTimeout.Init(base.mgr)
+
+	p.EnableStoppingBalance = ParamItem{
+		Key:          "queryCoord.enableStoppingBalance",
+		Version:      "2.3.13",
+		DefaultValue: "true",
+		Doc:          "whether enable stopping balance",
+		Export:       true,
+	}
+	p.EnableStoppingBalance.Init(base.mgr)
 }
 
 // /////////////////////////////////////////////////////////////////////////////

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -293,6 +293,7 @@ func TestComponentParam(t *testing.T) {
 
 		params.Save("queryCoord.gracefulStopTimeout", "100")
 		assert.Equal(t, 100*time.Second, Params.GracefulStopTimeout.GetAsDuration(time.Second))
+		assert.Equal(t, true, Params.EnableStoppingBalance.GetAsBool())
 	})
 
 	t.Run("test queryNodeConfig", func(t *testing.T) {


### PR DESCRIPTION
issue: #30816

cause balance channel will stuck until leader view catch up the current target, then start to unsub the old delegator. which make sure that the new delegator can provide search before release old delegator. but another logic in segment_checker skip loading segment during balance channel. so during balance channel, if query node crash, new delegator can't catch up target forever, then stuck forever.

This PR remove the rule that skip loading segment during balance channel to avoid the logic dead lock here.