### PR TITLE
fix: Fix binlog import

### DIFF
--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -5631,11 +5631,15 @@ func (node *Proxy) ImportV2(ctx context.Context, req *internalpb.ImportRequest) 
 		resp.Status = merr.Status(merr.WrapErrParameterInvalidMsg("import request is empty"))
 		return resp, nil
 	}
-	for _, file := range req.GetFiles() {
-		_, err = importutilv2.GetFileType(file)
-		if err != nil {
-			resp.Status = merr.Status(err)
-			return resp, nil
+	isBackup := importutilv2.IsBackup(req.GetOptions())
+	if !isBackup {
+		// check file type
+		for _, file := range req.GetFiles() {
+			_, err = importutilv2.GetFileType(file)
+			if err != nil {
+				resp.Status = merr.Status(err)
+				return resp, nil
+			}
 		}
 	}
 	importRequest := &internalpb.ImportRequestInternal{

--- a/internal/util/importutilv2/binlog/reader.go
+++ b/internal/util/importutilv2/binlog/reader.go
@@ -48,6 +48,7 @@ func NewReader(ctx context.Context,
 	tsStart,
 	tsEnd uint64,
 ) (*reader, error) {
+	schema = typeutil.AppendSystemFields(schema)
 	r := &reader{
 		ctx:    ctx,
 		cm:     cm,


### PR DESCRIPTION
1. File type validation is omitted during binlog import.
2. System fields are appended to the schema during binlog import.

issue: https://github.com/milvus-io/milvus/issues/28521