### PR TITLE
fix: wrong num_entities used when mmap variable length data (#30848)

### DIFF
--- a/internal/core/src/mmap/Column.h
+++ b/internal/core/src/mmap/Column.h
@@ -326,10 +326,10 @@ class VariableColumn : public ColumnBase {
             indices_ = std::move(indices);
         }
 
+        num_rows_ = indices_.size();
+
         // for variable length memory mode only
         if (data_ == nullptr) {
-            num_rows_ = indices_.size();
-
             size_t total_size = size_;
             size_ = 0;
             Expand(total_size);


### PR DESCRIPTION
https://github.com/milvus-io/milvus/issues/30728
pr: #30848 