### PR TITLE
fix: Skip set node unreachable when get shard client failed

### DIFF
--- a/internal/proxy/look_aside_balancer.go
+++ b/internal/proxy/look_aside_balancer.go
@@ -221,9 +221,8 @@ func (b *LookAsideBalancer) checkQueryNodeHealthLoop(ctx context.Context) {
 
 						qn, err := b.clientMgr.GetClient(ctx, node)
 						if err != nil {
-							if b.trySetQueryNodeUnReachable(node, err) {
-								log.Warn("get client failed, set node unreachable", zap.Int64("node", node), zap.Error(err))
-							}
+							// get client from clientMgr failed, which means this qn isn't a shard leader anymore, skip it's health check
+							log.RatedInfo(10, "get client failed", zap.Int64("node", node), zap.Error(err))
 							return struct{}{}, nil
 						}
 


### PR DESCRIPTION
issue: #30531

cause get client from `shardClientMgr`, doesn't means query node is unavailable. because of the ref counter policy in `shardClientMgr`, which will clean the client, if no collection use qn as shard leader.

This PR fix that set node unreachable when get shard client failed.