### PR TITLE
fix: Save traceID and spanID as std::vector into search config

### DIFF
--- a/internal/core/src/common/Tracer.cpp
+++ b/internal/core/src/common/Tracer.cpp
@@ -14,6 +14,7 @@
 
 #include <iomanip>
 #include <iostream>
+#include <vector>
 #include <utility>
 
 #include "opentelemetry/exporters/jaeger/jaeger_exporter_factory.h"
@@ -150,43 +151,23 @@ EmptySpanID(const TraceContext* ctx) {
     return isEmptyID(ctx->spanID, trace::SpanId::kSize);
 }
 
-std::string
-BytesToHex(const uint8_t* input, const size_t len) {
-    std::stringstream ss;
-    ss << std::hex << std::setfill('0');
-    for (size_t i = 0; i < len; i++) {
-        ss << std::setw(2) << static_cast<int>(input[i]);
-    }
-    return ss.str();
-}
-
-std::string
-HexToString(const std::string& input) {
-    std::string output;
-    std::stringstream ss;
-    for (size_t i = 0; i < input.length(); i += 2) {
-        std::string byteString = input.substr(i, 2);
-        char byte = static_cast<char>(std::stoi(byteString, nullptr, 16));
-        output += byte;
-    }
-    return output;
-}
-
-std::string
-GetTraceIDAsHex(const TraceContext* ctx) {
+std::vector<uint8_t>
+GetTraceIDAsVector(const TraceContext* ctx) {
     if (ctx != nullptr && !EmptyTraceID(ctx)) {
-        return BytesToHex(ctx->traceID, opentelemetry::trace::TraceId::kSize);
+        return std::vector<uint8_t>(
+            ctx->traceID, ctx->traceID + opentelemetry::trace::TraceId::kSize);
     } else {
-        return std::string();
+        return {};
     }
 }
 
-std::string
-GetSpanIDAsHex(const TraceContext* ctx) {
+std::vector<uint8_t>
+GetSpanIDAsVector(const TraceContext* ctx) {
     if (ctx != nullptr && !EmptySpanID(ctx)) {
-        return BytesToHex(ctx->spanID, opentelemetry::trace::SpanId::kSize);
+        return std::vector<uint8_t>(
+            ctx->spanID, ctx->spanID + opentelemetry::trace::SpanId::kSize);
     } else {
-        return std::string();
+        return {};
     }
 }
 

--- a/internal/core/src/common/Tracer.h
+++ b/internal/core/src/common/Tracer.h
@@ -61,16 +61,10 @@ EmptyTraceID(const TraceContext* ctx);
 bool
 EmptySpanID(const TraceContext* ctx);
 
-std::string
-BytesToHex(const uint8_t* input, const size_t len);
+std::vector<uint8_t>
+GetTraceIDAsVector(const TraceContext* ctx);
 
-std::string
-HexToString(const std::string& input);
-
-std::string
-GetTraceIDAsHex(const TraceContext* ctx);
-
-std::string
-GetSpanIDAsHex(const TraceContext* ctx);
+std::vector<uint8_t>
+GetSpanIDAsVector(const TraceContext* ctx);
 
 }  // namespace milvus::tracer

--- a/internal/core/src/index/VectorIndex.h
+++ b/internal/core/src/index/VectorIndex.h
@@ -123,16 +123,15 @@ class VectorIndex : public IndexBase {
         search_cfg[knowhere::meta::TOPK] = search_info.topk_;
 
         // save trace context into search conf
-        // TODO caiyd: will enable this after adding switch for trace
-        // if (search_info.trace_ctx_.traceID != nullptr &&
-        //     search_info.trace_ctx_.spanID != nullptr) {
-        //     search_cfg[knowhere::meta::TRACE_ID] =
-        //         tracer::GetTraceIDAsHex(&search_info.trace_ctx_);
-        //     search_cfg[knowhere::meta::SPAN_ID] =
-        //         tracer::GetSpanIDAsHex(&search_info.trace_ctx_);
-        //     search_cfg[knowhere::meta::TRACE_FLAGS] =
-        //         search_info.trace_ctx_.traceFlags;
-        // }
+        if (search_info.trace_ctx_.traceID != nullptr &&
+            search_info.trace_ctx_.spanID != nullptr) {
+            search_cfg[knowhere::meta::TRACE_ID] =
+                tracer::GetTraceIDAsVector(&search_info.trace_ctx_);
+            search_cfg[knowhere::meta::SPAN_ID] =
+                tracer::GetSpanIDAsVector(&search_info.trace_ctx_);
+            search_cfg[knowhere::meta::TRACE_FLAGS] =
+                search_info.trace_ctx_.traceFlags;
+        }
 
         return search_cfg;
     }

--- a/internal/core/src/query/SearchBruteForce.cpp
+++ b/internal/core/src/query/SearchBruteForce.cpp
@@ -51,16 +51,15 @@ PrepareBFSearchParams(const SearchInfo& search_info) {
     search_cfg[knowhere::meta::TOPK] = search_info.topk_;
 
     // save trace context into search conf
-    // TODO caiyd: will enable this after adding switch for trace
-    // if (search_info.trace_ctx_.traceID != nullptr &&
-    //     search_info.trace_ctx_.spanID != nullptr) {
-    //     search_cfg[knowhere::meta::TRACE_ID] =
-    //         tracer::GetTraceIDAsHex(&search_info.trace_ctx_);
-    //     search_cfg[knowhere::meta::SPAN_ID] =
-    //         tracer::GetSpanIDAsHex(&search_info.trace_ctx_);
-    //     search_cfg[knowhere::meta::TRACE_FLAGS] =
-    //         search_info.trace_ctx_.traceFlags;
-    // }
+    if (search_info.trace_ctx_.traceID != nullptr &&
+        search_info.trace_ctx_.spanID != nullptr) {
+        search_cfg[knowhere::meta::TRACE_ID] =
+            tracer::GetTraceIDAsVector(&search_info.trace_ctx_);
+        search_cfg[knowhere::meta::SPAN_ID] =
+            tracer::GetSpanIDAsVector(&search_info.trace_ctx_);
+        search_cfg[knowhere::meta::TRACE_FLAGS] =
+            search_info.trace_ctx_.traceFlags;
+    }
 
     return search_cfg;
 }

--- a/internal/core/unittest/test_tracer.cpp
+++ b/internal/core/unittest/test_tracer.cpp
@@ -16,6 +16,7 @@
 
 #include "common/Tracer.h"
 #include "common/EasyAssert.h"
+#include "common/Tracer.h"
 #include "knowhere/comp/index_param.h"
 #include "knowhere/config.h"
 
@@ -46,71 +47,74 @@ TEST(Tracer, Span) {
     config->nodeID = 1;
     initTelemetry(*config);
 
+    const auto trace_id_vec = std::vector<uint8_t>({0x01,
+                                                    0x23,
+                                                    0x45,
+                                                    0x67,
+                                                    0x89,
+                                                    0xab,
+                                                    0xcd,
+                                                    0xef,
+                                                    0xfe,
+                                                    0xdc,
+                                                    0xba,
+                                                    0x98,
+                                                    0x76,
+                                                    0x54,
+                                                    0x32,
+                                                    0x10});
+    const auto span_id_vec =
+        std::vector<uint8_t>({0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef});
+
     auto ctx = std::make_shared<TraceContext>();
-    ctx->traceID = new uint8_t[16]{0x01,
-                                   0x23,
-                                   0x45,
-                                   0x67,
-                                   0x89,
-                                   0xab,
-                                   0xcd,
-                                   0xef,
-                                   0xfe,
-                                   0xdc,
-                                   0xba,
-                                   0x98,
-                                   0x76,
-                                   0x54,
-                                   0x32,
-                                   0x10};
-    ctx->spanID =
-        new uint8_t[8]{0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef};
+    ctx->traceID = trace_id_vec.data();
+    ctx->spanID = span_id_vec.data();
     ctx->traceFlags = 1;
     auto span = StartSpan("test", ctx.get());
 
     ASSERT_TRUE(span->GetContext().trace_id() ==
                 trace::TraceId({ctx->traceID, 16}));
-
-    delete[] ctx->traceID;
-    delete[] ctx->spanID;
 }
 
-TEST(Tracer, Hex) {
+TEST(Tracer, Config) {
+    const auto trace_id_vec = std::vector<uint8_t>({0x01,
+                                                    0x23,
+                                                    0x45,
+                                                    0x67,
+                                                    0x89,
+                                                    0xab,
+                                                    0xcd,
+                                                    0xef,
+                                                    0xfe,
+                                                    0xdc,
+                                                    0xba,
+                                                    0x98,
+                                                    0x76,
+                                                    0x54,
+                                                    0x32,
+                                                    0x10});
+    const auto span_id_vec =
+        std::vector<uint8_t>({0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef});
+
     auto ctx = std::make_shared<TraceContext>();
-    ctx->traceID = new uint8_t[16]{0x01,
-                                   0x23,
-                                   0x45,
-                                   0x67,
-                                   0x89,
-                                   0xab,
-                                   0xcd,
-                                   0xef,
-                                   0xfe,
-                                   0xdc,
-                                   0xba,
-                                   0x98,
-                                   0x76,
-                                   0x54,
-                                   0x32,
-                                   0x10};
-    ctx->spanID =
-        new uint8_t[8]{0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef};
+    ctx->traceID = trace_id_vec.data();
+    ctx->spanID = span_id_vec.data();
     ctx->traceFlags = 1;
 
     knowhere::Json search_cfg = {};
 
     // save trace context into search conf
-    search_cfg[knowhere::meta::TRACE_ID] = tracer::GetTraceIDAsHex(ctx.get());
-    search_cfg[knowhere::meta::SPAN_ID] = tracer::GetSpanIDAsHex(ctx.get());
+    search_cfg[knowhere::meta::TRACE_ID] =
+        tracer::GetTraceIDAsVector(ctx.get());
+    search_cfg[knowhere::meta::SPAN_ID] = tracer::GetSpanIDAsVector(ctx.get());
     search_cfg[knowhere::meta::TRACE_FLAGS] = ctx->traceFlags;
     std::cout << "search config: " << search_cfg.dump() << std::endl;
 
-    auto trace_id_str = HexToString(search_cfg[knowhere::meta::TRACE_ID]);
-    auto span_id_str = HexToString(search_cfg[knowhere::meta::SPAN_ID]);
+    auto trace_id_cfg =
+        search_cfg[knowhere::meta::TRACE_ID].get<std::vector<uint8_t>>();
+    auto span_id_cfg =
+        search_cfg[knowhere::meta::SPAN_ID].get<std::vector<uint8_t>>();
 
-    ASSERT_TRUE(strncmp((char*)ctx->traceID, trace_id_str.c_str(), 16) == 0);
-    ASSERT_TRUE(strncmp((char*)ctx->spanID, span_id_str.c_str(), 8) == 0);
-
-    delete[] ctx->traceID;
-    delete[] ctx->spanID;
+    ASSERT_TRUE(memcmp(ctx->traceID, trace_id_cfg.data(), 16) == 0);
+    ASSERT_TRUE(memcmp(ctx->spanID, span_id_cfg.data(), 8) == 0);
 }


### PR DESCRIPTION
Issue: #30961 