### PR TITLE
fix: save current target after target observer stop

### DIFF
--- a/internal/querycoordv2/server.go
+++ b/internal/querycoordv2/server.go
@@ -459,11 +459,6 @@ func (s *Server) startServerLoop() {
 }
 
 func (s *Server) Stop() error {
-	// save target to meta store, after querycoord restart, make it fast to recover current target
-	if s.targetMgr != nil {
-		s.targetMgr.SaveCurrentTarget(s.store)
-	}
-
 	// FOLLOW the dependence graph:
 	// job scheduler -> checker controller -> task scheduler -> dist controller -> cluster -> session
 	// observers -> dist controller
@@ -490,6 +485,13 @@ func (s *Server) Stop() error {
 	if s.targetObserver != nil {
 		s.targetObserver.Stop()
 	}
+
+	// save target to meta store, after querycoord restart, make it fast to recover current target
+	// should save target after target observer stop, incase of target changed
+	if s.targetMgr != nil {
+		s.targetMgr.SaveCurrentTarget(s.store)
+	}
+
 	if s.replicaObserver != nil {
 		s.replicaObserver.Stop()
 	}


### PR DESCRIPTION
issue: #28491

should save target to meta store after target observer stop, incase of target changed 