### PR TITLE
fix: Return specific error code when encountering incomplete requery results

### DIFF
--- a/internal/proxy/task_search.go
+++ b/internal/proxy/task_search.go
@@ -679,8 +679,8 @@ func doRequery(ctx context.Context,
 	for i := 0; i < typeutil.GetSizeOfIDs(ids); i++ {
 		id := typeutil.GetPK(ids, int64(i))
 		if _, ok := offsets[id]; !ok {
-			return fmt.Errorf("incomplete query result, missing id %s, len(searchIDs) = %d, len(queryIDs) = %d, collection=%d",
-				id, typeutil.GetSizeOfIDs(ids), len(offsets), collectionID)
+			return merr.WrapErrInconsistentRequery(fmt.Sprintf("incomplete query result, missing id %s, len(searchIDs) = %d, len(queryIDs) = %d, collection=%d",
+				id, typeutil.GetSizeOfIDs(ids), len(offsets), collectionID))
 		}
 		typeutil.AppendFieldData(result.Results.FieldsData, queryResult.GetFieldsData(), int64(offsets[id]))
 	}

--- a/pkg/util/merr/errors.go
+++ b/pkg/util/merr/errors.go
@@ -154,6 +154,9 @@ var (
 
 	// import
 	ErrImportFailed = newMilvusError("importing data failed", 2100, false)
+
+	// Search/Query related
+	ErrInconsistentRequery = newMilvusError("inconsistent requery result", 2200, true)
 )
 
 type milvusError struct {

--- a/pkg/util/merr/errors_test.go
+++ b/pkg/util/merr/errors_test.go
@@ -145,6 +145,9 @@ func (s *ErrSuite) TestWrap() {
 	// alias related
 	s.ErrorIs(WrapErrAliasNotFound("alias", "failed to get collection id"), ErrAliasNotFound)
 	s.ErrorIs(WrapErrCollectionIDOfAliasNotFound(1000, "failed to get collection id"), ErrCollectionIDOfAliasNotFound)
+
+	// Search/Query related
+	s.ErrorIs(WrapErrInconsistentRequery("unknown"), ErrInconsistentRequery)
 }
 
 func (s *ErrSuite) TestOldCode() {

--- a/pkg/util/merr/utils.go
+++ b/pkg/util/merr/utils.go
@@ -943,3 +943,11 @@ func WrapErrImportFailed(msg ...string) error {
 	}
 	return err
 }
+
+func WrapErrInconsistentRequery(msg ...string) error {
+	err := error(ErrInconsistentRequery)
+	if len(msg) > 0 {
+		err = errors.Wrap(err, strings.Join(msg, "->"))
+	}
+	return err
+}


### PR DESCRIPTION
During requery, segments may change (e.g., due to compaction), so we need to return specific error codes when encountering incomplete requery results. Clients can then retry to avoid this issue.

issue: https://github.com/milvus-io/milvus/issues/29656