### PR TITLE
fix: Hybrid search blocks on connecting to offline node

### DIFF
--- a/internal/proxy/lb_policy.go
+++ b/internal/proxy/lb_policy.go
@@ -161,6 +161,7 @@ func (lb *LBPolicyImpl) ExecuteWithRetry(ctx context.Context, workload ChannelWo
 			if lastErr != nil {
 				return lastErr
 			}
+			globalMetaCache.DeprecateShardCache(workload.db, workload.collectionName)
 			return err
 		}
 
@@ -173,6 +174,8 @@ func (lb *LBPolicyImpl) ExecuteWithRetry(ctx context.Context, workload ChannelWo
 
 			// cancel work load which assign to the target node
 			lb.balancer.CancelWorkload(targetNode, workload.nq)
+
+			globalMetaCache.DeprecateShardCache(workload.db, workload.collectionName)
 			lastErr = errors.Wrapf(err, "failed to get delegator %d for channel %s", targetNode, workload.channel)
 			return lastErr
 		}
@@ -184,6 +187,7 @@ func (lb *LBPolicyImpl) ExecuteWithRetry(ctx context.Context, workload ChannelWo
 				zap.Error(err))
 			excludeNodes.Insert(targetNode)
 			lb.balancer.CancelWorkload(targetNode, workload.nq)
+			globalMetaCache.DeprecateShardCache(workload.db, workload.collectionName)
 
 			lastErr = errors.Wrapf(err, "failed to search/query delegator %d for channel %s", targetNode, workload.channel)
 			return lastErr

--- a/internal/proxy/task_query.go
+++ b/internal/proxy/task_query.go
@@ -529,12 +529,10 @@ func (t *queryTask) queryShard(ctx context.Context, nodeID int64, qn types.Query
 	result, err := qn.Query(ctx, req)
 	if err != nil {
 		log.Warn("QueryNode query return error", zap.Error(err))
-		globalMetaCache.DeprecateShardCache(t.request.GetDbName(), t.collectionName)
 		return err
 	}
 	if result.GetStatus().GetErrorCode() == commonpb.ErrorCode_NotShardLeader {
 		log.Warn("QueryNode is not shardLeader")
-		globalMetaCache.DeprecateShardCache(t.request.GetDbName(), t.collectionName)
 		return errInvalidShardLeaders
 	}
 	if result.GetStatus().GetErrorCode() != commonpb.ErrorCode_Success {


### PR DESCRIPTION
issue: #31351
pr: #31365

after node has been scale in, hybrid search will try to connect to offline node, which cost some seconds, then retry to another replica and success. then every hybrid search will block on connecting to offline nodes, cause shard leader cache doesn't update as expected.

This PR call DeprecateShardLeaderCache after request failed, and instead of call DeprecateShardLeaderCache everywhere, we just call in lb_policy's ExecuteWithRetry, after any request failed, it will deprecate old shard leader cache.