### PR TITLE
fix: Hybrid search doesn't expire shard leader cache

### DIFF
--- a/internal/proxy/task_hybrid_search.go
+++ b/internal/proxy/task_hybrid_search.go
@@ -246,10 +246,12 @@ func (t *hybridSearchTask) hybridSearchShard(ctx context.Context, nodeID int64, 
 	result, err = qn.HybridSearch(ctx, req)
 	if err != nil {
 		log.Warn("QueryNode hybrid search return error", zap.Error(err))
+		globalMetaCache.DeprecateShardCache(t.request.GetDbName(), t.request.GetCollectionName())
 		return err
 	}
 	if result.GetStatus().GetErrorCode() == commonpb.ErrorCode_NotShardLeader {
 		log.Warn("QueryNode is not shardLeader")
+		globalMetaCache.DeprecateShardCache(t.request.GetDbName(), t.request.GetCollectionName())
 		return errInvalidShardLeaders
 	}
 	if result.GetStatus().GetErrorCode() != commonpb.ErrorCode_Success {

--- a/internal/proxy/task_search.go
+++ b/internal/proxy/task_search.go
@@ -503,10 +503,12 @@ func (t *searchTask) searchShard(ctx context.Context, nodeID int64, qn types.Que
 	result, err = qn.Search(ctx, req)
 	if err != nil {
 		log.Warn("QueryNode search return error", zap.Error(err))
+		globalMetaCache.DeprecateShardCache(t.request.GetDbName(), t.collectionName)
 		return err
 	}
 	if result.GetStatus().GetErrorCode() == commonpb.ErrorCode_NotShardLeader {
 		log.Warn("QueryNode is not shardLeader")
+		globalMetaCache.DeprecateShardCache(t.request.GetDbName(), t.collectionName)
 		return errInvalidShardLeaders
 	}
 	if result.GetStatus().GetErrorCode() != commonpb.ErrorCode_Success {

--- a/internal/proxy/task_statistic.go
+++ b/internal/proxy/task_statistic.go
@@ -302,7 +302,6 @@ func (g *getStatisticsTask) getStatisticsShard(ctx context.Context, nodeID int64
 		log.Warn("QueryNode statistic result error",
 			zap.Int64("nodeID", nodeID),
 			zap.String("reason", result.GetStatus().GetReason()))
-		globalMetaCache.DeprecateShardCache(g.request.GetDbName(), g.collectionName)
 		return errors.Wrapf(merr.Error(result.GetStatus()), "fail to get statistic on QueryNode ID=%d", nodeID)
 	}
 	g.resultBuf.Insert(result)


### PR DESCRIPTION
issue: #31351
This PR fixed that search/hybrid_search doesn't expire shard leader cache when send request to query node failed, which make every request keep trying to connect a offline query node 