### PR TITLE
enhance: [skip e2e][cp] Make "fix:" prefix work for 2.4 branch (#31384)

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -440,7 +440,7 @@ pull_request_rules:
     conditions:
       - or:
         - base=master
-        - base~=^2\.3(\.\d+){0,1}$
+        - base~=^2(\.\d+){1,2}$
       - 'title~=^fix:'
     actions:
       label:


### PR DESCRIPTION
Cherry-pick from master
pr: #31384 
Other prefixes, say enhance, doc, etc., works for branch 2.4 now, but "fix" prefix does not, this PR sync "fix: " branch selector to other prefixes.