### PR TITLE
enhance: Cache formatted key for param item

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/errors"
+
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
 
@@ -52,16 +53,14 @@ func Init(opts ...Option) (*Manager, error) {
 	return sourceManager, nil
 }
 
-var (
-	formatedKeys = typeutil.NewConcurrentMap[string, string]()
-)
+var formattedKeys = typeutil.NewConcurrentMap[string, string]()
 
 func formatKey(key string) string {
-	cached, ok := formatedKeys.Get(key)
+	cached, ok := formattedKeys.Get(key)
 	if ok {
 		return cached
 	}
 	result := strings.NewReplacer("/", "", "_", "", ".", "").Replace(strings.ToLower(key))
-	formatedKeys.Insert(key, result)
+	formattedKeys.Insert(key, result)
 	return result
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/errors"
+	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
 
 var (
@@ -51,6 +52,16 @@ func Init(opts ...Option) (*Manager, error) {
 	return sourceManager, nil
 }
 
+var (
+	formatedKeys = typeutil.NewConcurrentMap[string, string]()
+)
+
 func formatKey(key string) string {
-	return strings.NewReplacer("/", "", "_", "", ".", "").Replace(strings.ToLower(key))
+	cached, ok := formatedKeys.Get(key)
+	if ok {
+		return cached
+	}
+	result := strings.NewReplacer("/", "", "_", "", ".", "").Replace(strings.ToLower(key))
+	formatedKeys.Insert(key, result)
+	return result
 }


### PR DESCRIPTION
See also #30806

`formatKey` may cost lots of CPU on string processing under high QPS scenario, this PR adds a formattedKeys cache preventing string operation in each param get value.