### PR TITLE
enhance: [2.3] Cache formatted key for param item (#31388)

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/errors"
+
+	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
 
 var (
@@ -51,6 +53,14 @@ func Init(opts ...Option) (*Manager, error) {
 	return sourceManager, nil
 }
 
+var formattedKeys = typeutil.NewConcurrentMap[string, string]()
+
 func formatKey(key string) string {
-	return strings.NewReplacer("/", "", "_", "", ".", "").Replace(strings.ToLower(key))
+	cached, ok := formattedKeys.Get(key)
+	if ok {
+		return cached
+	}
+	result := strings.NewReplacer("/", "", "_", "", ".", "").Replace(strings.ToLower(key))
+	formattedKeys.Insert(key, result)
+	return result
 }


### PR DESCRIPTION
Cherry-pick from master
pr: #31388 
See also #30806

`formatKey` may cost lots of CPU on string processing under high QPS scenario, this PR adds a formattedKeys cache preventing string operation in each param get value.

---------