### PR TITLE
enhance: Add metrics for task latency in querycoord scheduler

### DIFF
--- a/internal/querycoordv2/task/scheduler.go
+++ b/internal/querycoordv2/task/scheduler.go
@@ -796,7 +796,7 @@ func (scheduler *taskScheduler) remove(task Task) {
 
 	scheduler.updateTaskMetrics()
 	log.Info("task removed")
-	metrics.QueryCoordTaskLatency.WithLabelValues(scheduler.getTaskMetricsLabel(task)).Observe(float64(task.GetTaskLatency()))
+	metrics.QueryCoordTaskLatency.WithLabelValues(scheduler.getTaskMetricsLabel(task), fmt.Sprint(task.CollectionID()), task.Shard()).Observe(float64(task.GetTaskLatency()))
 }
 
 func (scheduler *taskScheduler) getTaskMetricsLabel(task Task) string {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -103,6 +103,8 @@ const (
 	// entities label
 	LoadedLabel         = "loaded"
 	NumEntitiesAllLabel = "all"
+
+	taskTypeLabel = "task_type"
 )
 
 var (

--- a/pkg/metrics/querycoord_metrics.go
+++ b/pkg/metrics/querycoord_metrics.go
@@ -129,7 +129,7 @@ var (
 			Name:      "task_latency",
 			Help:      "latency of all kind of task in query coord scheduler scheduler",
 			Buckets:   longTaskBuckets,
-		}, []string{taskTypeLabel})
+		}, []string{taskTypeLabel, collectionIDLabelName, channelNameLabelName})
 )
 
 // RegisterQueryCoord registers QueryCoord metrics

--- a/pkg/metrics/querycoord_metrics.go
+++ b/pkg/metrics/querycoord_metrics.go
@@ -26,10 +26,16 @@ const (
 	SegmentGrowTaskLabel   = "segment_grow"
 	SegmentReduceTaskLabel = "segment_reduce"
 	SegmentMoveTaskLabel   = "segment_move"
+	SegmentUpdateTaskLabel = "segment_update"
 
 	ChannelGrowTaskLabel   = "channel_grow"
 	ChannelReduceTaskLabel = "channel_reduce"
 	ChannelMoveTaskLabel   = "channel_move"
+
+	LeaderGrowTaskLabel   = "leader_grow"
+	LeaderReduceTaskLabel = "leader_reduce"
+
+	UnknownTaskLabel = "unknown"
 
 	QueryCoordTaskType = "querycoord_task_type"
 )
@@ -115,6 +121,15 @@ var (
 			nodeIDLabelName,
 			channelNameLabelName,
 		})
+
+	QueryCoordTaskLatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.QueryCoordRole,
+			Name:      "task_latency",
+			Help:      "latency of all kind of task in query coord scheduler scheduler",
+			Buckets:   longTaskBuckets,
+		}, []string{taskTypeLabel})
 )
 
 // RegisterQueryCoord registers QueryCoord metrics
@@ -128,4 +143,5 @@ func RegisterQueryCoord(registry *prometheus.Registry) {
 	registry.MustRegister(QueryCoordTaskNum)
 	registry.MustRegister(QueryCoordNumQueryNodes)
 	registry.MustRegister(QueryCoordCurrentTargetCheckpointUnixSeconds)
+	registry.MustRegister(QueryCoordTaskLatency)
 }


### PR DESCRIPTION
This PR add metrics for task latency in querycoord scheduler, so if any kind of task stuck, it's easy to figure out by metrics