### PR TITLE
doc: fix conan version in DEVELOPMENT.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -131,7 +131,7 @@ Install Conan
 pip install conan==1.61.0
 ```
 
-Note: Conan version 2.x is not currently supported, please use version 1.58.
+Note: Conan version 2.x is not currently supported, please use version 1.61.
 
 #### Go
 


### PR DESCRIPTION
The conan version used in all the setup scripts was updated to `1.61.0` in https://github.com/milvus-io/milvus/pull/27870. However, a line in the developer documentation was left out.

Since the dependencies no longer install correctly with conan `1.58` (https://github.com/milvus-io/milvus/issues/27869), all documentation should consistently use the updated version.