### PR TITLE
fix: Wrong behavior of CurrentTargetFirst/NextTargetFirst in target manager(#31379)

### DIFF
--- a/internal/querycoordv2/meta/target_manager_test.go
+++ b/internal/querycoordv2/meta/target_manager_test.go
@@ -413,6 +413,10 @@ func (suite *TargetManagerSuite) TestGetSegmentByChannel() {
 	suite.Len(suite.mgr.GetGrowingSegmentsByChannel(collectionID, "channel-1", NextTarget), 4)
 	suite.Len(suite.mgr.GetGrowingSegmentsByChannel(collectionID, "channel-2", NextTarget), 1)
 	suite.Len(suite.mgr.GetDroppedSegmentsByChannel(collectionID, "channel-1", NextTarget), 3)
+	suite.Len(suite.mgr.GetGrowingSegmentsByCollection(collectionID, NextTarget), 5)
+	suite.Len(suite.mgr.GetSealedSegmentsByPartition(collectionID, 1, NextTarget), 2)
+	suite.NotNil(suite.mgr.GetSealedSegment(collectionID, 11, NextTarget))
+	suite.NotNil(suite.mgr.GetDmChannel(collectionID, "channel-1", NextTarget))
 }
 
 func (suite *TargetManagerSuite) TestGetTarget() {
@@ -420,7 +424,7 @@ func (suite *TargetManagerSuite) TestGetTarget() {
 		tag          string
 		mgr          *TargetManager
 		scope        TargetScope
-		expectTarget *CollectionTarget
+		expectTarget int
 	}
 
 	current := &CollectionTarget{}
@@ -434,7 +438,7 @@ func (suite *TargetManagerSuite) TestGetTarget() {
 		},
 		next: &target{
 			collectionTargetMap: map[int64]*CollectionTarget{
-				1000: current,
+				1000: next,
 			},
 		},
 	}
@@ -457,89 +461,90 @@ func (suite *TargetManagerSuite) TestGetTarget() {
 
 	cases := []testCase{
 		{
-			tag:          "both_scope_unknown",
-			mgr:          bothMgr,
-			scope:        -1,
-			expectTarget: nil,
+			tag:   "both_scope_unknown",
+			mgr:   bothMgr,
+			scope: -1,
+
+			expectTarget: 0,
 		},
 		{
 			tag:          "both_scope_current",
 			mgr:          bothMgr,
 			scope:        CurrentTarget,
-			expectTarget: current,
+			expectTarget: 1,
 		},
 		{
 			tag:          "both_scope_next",
 			mgr:          bothMgr,
 			scope:        NextTarget,
-			expectTarget: next,
+			expectTarget: 1,
 		},
 		{
 			tag:          "both_scope_current_first",
 			mgr:          bothMgr,
 			scope:        CurrentTargetFirst,
-			expectTarget: current,
+			expectTarget: 2,
 		},
 		{
 			tag:          "both_scope_next_first",
 			mgr:          bothMgr,
 			scope:        NextTargetFirst,
-			expectTarget: next,
+			expectTarget: 2,
 		},
 		{
 			tag:          "next_scope_current",
 			mgr:          nextMgr,
 			scope:        CurrentTarget,
-			expectTarget: nil,
+			expectTarget: 0,
 		},
 		{
 			tag:          "next_scope_next",
 			mgr:          nextMgr,
 			scope:        NextTarget,
-			expectTarget: next,
+			expectTarget: 1,
 		},
 		{
 			tag:          "next_scope_current_first",
 			mgr:          nextMgr,
 			scope:        CurrentTargetFirst,
-			expectTarget: next,
+			expectTarget: 1,
 		},
 		{
 			tag:          "next_scope_next_first",
 			mgr:          nextMgr,
 			scope:        NextTargetFirst,
-			expectTarget: next,
+			expectTarget: 1,
 		},
 		{
 			tag:          "current_scope_current",
 			mgr:          currentMgr,
 			scope:        CurrentTarget,
-			expectTarget: current,
+			expectTarget: 1,
 		},
 		{
 			tag:          "current_scope_next",
 			mgr:          currentMgr,
 			scope:        NextTarget,
-			expectTarget: nil,
+			expectTarget: 0,
 		},
 		{
 			tag:          "current_scope_current_first",
 			mgr:          currentMgr,
 			scope:        CurrentTargetFirst,
-			expectTarget: current,
+			expectTarget: 1,
 		},
 		{
 			tag:          "current_scope_next_first",
 			mgr:          currentMgr,
 			scope:        NextTargetFirst,
-			expectTarget: current,
+			expectTarget: 1,
 		},
 	}
 
 	for _, tc := range cases {
 		suite.Run(tc.tag, func() {
-			target := tc.mgr.getCollectionTarget(tc.scope, 1000)
-			suite.Equal(tc.expectTarget, target)
+			targets := tc.mgr.getCollectionTarget(tc.scope, 1000)
+			suite.Equal(tc.expectTarget, len(targets))
 		})
 	}
 }


### PR DESCRIPTION
issue: #31162
pr: #31379

when give scope CurrentTargetFirst/NextTargetFirst, it's expected to scan both current and next target.

This PR fixed wrong behavior of CurrentTargetFirst/NextTargetFirst in target manager, which may cause unexpected task generated, and load collection may stuck forever due to dirty leader view.