### PR TITLE
fix: [Cherry-pick] Use correct ticker for gc work defer (#31456)

### DIFF
--- a/internal/datacoord/garbage_collector.go
+++ b/internal/datacoord/garbage_collector.go
@@ -151,7 +151,7 @@ func (gc *garbageCollector) work() {
 	ticker := time.NewTicker(gc.option.checkInterval)
 	defer ticker.Stop()
 	scanTicker := time.NewTicker(gc.option.scanInterval)
-	defer ticker.Stop()
+	defer scanTicker.Stop()
 	for {
 		select {
 		case <-ticker.C:


### PR DESCRIPTION
Cherry-pick from master
pr: #31456
See also #31362

Fix the second defer using same ticker var.