### PR TITLE
fix: [2.4] Check nodeID before update channel checkpoint (#31473)

### DIFF
--- a/internal/datacoord/server_test.go
+++ b/internal/datacoord/server_test.go
@@ -3312,43 +3312,96 @@ func TestDataCoord_UnsetIsImportingState(t *testing.T) {
 
 func TestDataCoordServer_UpdateChannelCheckpoint(t *testing.T) {
 	mockVChannel := "fake-by-dev-rootcoord-dml-1-testchannelcp-v0"
-	mockPChannel := "fake-by-dev-rootcoord-dml-1"
 
-	t.Run("UpdateChannelCheckpoint", func(t *testing.T) {
+	t.Run("UpdateChannelCheckpoint_Success", func(t *testing.T) {
 		svr := newTestServer(t, nil)
 		defer closeTestServer(t, svr)
 
+		datanodeID := int64(1)
+		channelManager := NewMockChannelManager(t)
+		channelManager.EXPECT().Match(datanodeID, mockVChannel).Return(true)
+
+		svr.channelManager = channelManager
 		req := &datapb.UpdateChannelCheckpointRequest{
 			Base: &commonpb.MsgBase{
-				SourceID: paramtable.GetNodeID(),
+				SourceID: datanodeID,
 			},
 			VChannel: mockVChannel,
 			Position: &msgpb.MsgPosition{
-				ChannelName: mockPChannel,
+				ChannelName: mockVChannel,
 				Timestamp:   1000,
 				MsgID:       []byte{0, 0, 0, 0, 0, 0, 0, 0},
 			},
 		}
 
 		resp, err := svr.UpdateChannelCheckpoint(context.TODO(), req)
-		assert.NoError(t, err)
-		assert.EqualValues(t, commonpb.ErrorCode_Success, resp.ErrorCode)
+		assert.NoError(t, merr.CheckRPCCall(resp, err))
+
+		cp := svr.meta.GetChannelCheckpoint(mockVChannel)
+		assert.NotNil(t, cp)
+		svr.meta.DropChannelCheckpoint(mockVChannel)
 
 		req = &datapb.UpdateChannelCheckpointRequest{
 			Base: &commonpb.MsgBase{
-				SourceID: paramtable.GetNodeID(),
+				SourceID: datanodeID,
 			},
 			VChannel: mockVChannel,
 			ChannelCheckpoints: []*msgpb.MsgPosition{{
-				ChannelName: mockPChannel,
+				ChannelName: mockVChannel,
 				Timestamp:   1000,
 				MsgID:       []byte{0, 0, 0, 0, 0, 0, 0, 0},
 			}},
 		}
 
 		resp, err = svr.UpdateChannelCheckpoint(context.TODO(), req)
-		assert.NoError(t, err)
-		assert.EqualValues(t, commonpb.ErrorCode_Success, resp.ErrorCode)
+		assert.NoError(t, merr.CheckRPCCall(resp, err))
+		cp = svr.meta.GetChannelCheckpoint(mockVChannel)
+		assert.NotNil(t, cp)
+	})
+
+	t.Run("UpdateChannelCheckpoint_NodeNotMatch", func(t *testing.T) {
+		svr := newTestServer(t, nil)
+		defer closeTestServer(t, svr)
+
+		datanodeID := int64(1)
+		channelManager := NewMockChannelManager(t)
+		channelManager.EXPECT().Match(datanodeID, mockVChannel).Return(false)
+
+		svr.channelManager = channelManager
+		req := &datapb.UpdateChannelCheckpointRequest{
+			Base: &commonpb.MsgBase{
+				SourceID: datanodeID,
+			},
+			VChannel: mockVChannel,
+			Position: &msgpb.MsgPosition{
+				ChannelName: mockVChannel,
+				Timestamp:   1000,
+				MsgID:       []byte{0, 0, 0, 0, 0, 0, 0, 0},
+			},
+		}
+
+		resp, err := svr.UpdateChannelCheckpoint(context.TODO(), req)
+		assert.Error(t, merr.CheckRPCCall(resp, err))
+		assert.ErrorIs(t, merr.CheckRPCCall(resp, err), merr.ErrChannelNotFound)
+		cp := svr.meta.GetChannelCheckpoint(mockVChannel)
+		assert.Nil(t, cp)
+
+		req = &datapb.UpdateChannelCheckpointRequest{
+			Base: &commonpb.MsgBase{
+				SourceID: datanodeID,
+			},
+			VChannel: mockVChannel,
+			ChannelCheckpoints: []*msgpb.MsgPosition{{
+				ChannelName: mockVChannel,
+				Timestamp:   1000,
+				MsgID:       []byte{0, 0, 0, 0, 0, 0, 0, 0},
+			}},
+		}
+
+		resp, err = svr.UpdateChannelCheckpoint(context.TODO(), req)
+		assert.NoError(t, merr.CheckRPCCall(resp, err))
+		cp = svr.meta.GetChannelCheckpoint(mockVChannel)
+		assert.Nil(t, cp)
 	})
 }
 


### PR DESCRIPTION
Cherry-pick from master
pr: #31473
See also #31470 #31506

This PR adds nodeID assignment verification before updating channel checkpoints.