### PR TITLE
fix: [Cherry-pick] Use mutex protection when accessing pks of l0 segments (#31505)

### DIFF
--- a/internal/querynodev2/segments/segment_l0.go
+++ b/internal/querynodev2/segments/segment_l0.go
@@ -81,6 +81,8 @@ func (s *L0Segment) RowNum() int64 {
 }
 
 func (s *L0Segment) MemSize() int64 {
+	s.dataGuard.RLock()
+	defer s.dataGuard.RUnlock()
 	return lo.SumBy(s.pks, func(pk storage.PrimaryKey) int64 {
 		return pk.Size() + 8
 	})


### PR DESCRIPTION
Cherry-pick from master
pr: #31505
See also #31504