### PR TITLE
enhance: add metric with database and resource group label at querynode.

### DIFF
--- a/internal/querynodev2/segments/manager.go
+++ b/internal/querynodev2/segments/manager.go
@@ -35,6 +35,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
 	"github.com/milvus-io/milvus/internal/proto/querypb"
+	"github.com/milvus-io/milvus/internal/querynodev2/segments/metricsutil"
 	"github.com/milvus-io/milvus/pkg/eventlog"
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/metrics"
@@ -185,22 +186,35 @@ func NewManager() *Manager {
 		}
 
 		info := segment.LoadInfo()
-		_, err, _ := sf.Do(fmt.Sprint(segment.ID()), func() (interface{}, error) {
+		_, err, _ := sf.Do(fmt.Sprint(segment.ID()), func() (nop interface{}, err error) {
+			cacheLoadRecord := metricsutil.NewCacheLoadRecord(getSegmentMetricLabel(segment))
+			defer func() {
+				cacheLoadRecord.Finish(err)
+			}()
+
 			collection := manager.Collection.Get(segment.Collection())
 			if collection == nil {
 				return nil, merr.WrapErrCollectionNotLoaded(segment.Collection(), "failed to load segment fields")
 			}
-			err := manager.Loader.LoadSegment(context.Background(), segment.(*LocalSegment), info, LoadStatusMapped)
+			err = manager.Loader.LoadSegment(context.Background(), segment.(*LocalSegment), info, LoadStatusMapped)
+
+			cacheLoadRecord.WithBytes(segment.ResourceUsageEstimate().DiskSize)
+			observeResourceEstimate(segment)
 			return nil, err
 		})
 		if err != nil {
 			log.Warn("cache sealed segment failed", zap.Error(err))
 			return nil, false
 		}
+
 		return segment, true
 	}).WithFinalizer(func(key int64, segment Segment) error {
 		log.Debug("evict segment from cache", zap.Int64("segmentID", key))
+		cacheEvictRecord := metricsutil.NewCacheEvictRecord(getSegmentMetricLabel(segment))
+		defer cacheEvictRecord.Finish(nil)
+
 		segment.Release(WithReleaseScope(ReleaseScopeData))
+		clearResourceEstimate(segment)
 		return nil
 	}).Build()
 	return manager

--- a/internal/querynodev2/segments/metricsutil/active_segment_metric_manager.go
+++ b/internal/querynodev2/segments/metricsutil/active_segment_metric_manager.go
@@ -1,0 +1,157 @@
+package metricsutil
+
+import (
+	"github.com/cockroachdb/errors"
+	"github.com/expr-lang/expr"
+	"github.com/expr-lang/expr/vm"
+	"go.uber.org/zap"
+
+	"github.com/milvus-io/milvus/pkg/log"
+	"github.com/milvus-io/milvus/pkg/metrics"
+	"github.com/milvus-io/milvus/pkg/util/paramtable"
+)
+
+var _ metricManager = &activeSegmentMetricManager{}
+
+// databaseLabel is the label of the active segment metric.
+type databaseLabel struct {
+	database      string
+	resourceGroup string
+}
+
+// newActiveSegmentMetricManager creates a new active segment metric manager.
+func newActiveSegmentMetricManager(nodeID string) *activeSegmentMetricManager {
+	return &activeSegmentMetricManager{
+		nodeID:    nodeID,
+		lastUsage: make(map[databaseLabel]*ResourceUsageMetrics),
+	}
+}
+
+// activeSegmentMetricManager is the active segment metric manager.
+type activeSegmentMetricManager struct {
+	nodeID      string
+	lastExpr    string
+	enabledExpr string
+	exprProgram *vm.Program
+	lastUsage   map[databaseLabel]*ResourceUsageMetrics
+}
+
+// Apply update the active segment metric.
+func (m *activeSegmentMetricManager) Apply(s *sampler) {
+	// update the active segment predicate expression if needed.
+	m.updateActiveSegmentPredicate()
+	usage, err := m.aggregateSegments(s)
+	if err != nil {
+		log.Warn("failed to aggregate active segments", zap.Error(err))
+		return
+	}
+	m.overwriteMetrics(usage)
+}
+
+// overwriteMetrics overwrites the active segment metrics.
+func (m *activeSegmentMetricManager) overwriteMetrics(usages map[databaseLabel]*ResourceUsageMetrics) {
+	for label, usage := range usages {
+		metrics.QueryNodeActiveSegmentMemoryBytes.WithLabelValues(m.nodeID, label.database, label.resourceGroup).Set(float64(usage.MemUsage))
+		metrics.QueryNodeActiveSegmentDiskBytes.WithLabelValues(m.nodeID, label.database, label.resourceGroup).Set(float64(usage.DiskUsage))
+	}
+	// Remove the metrics of the active segments that are not active now.
+	for label := range m.lastUsage {
+		if _, ok := usages[label]; !ok {
+			metrics.QueryNodeActiveSegmentMemoryBytes.DeleteLabelValues(m.nodeID, label.database, label.resourceGroup)
+			metrics.QueryNodeActiveSegmentDiskBytes.DeleteLabelValues(m.nodeID, label.database, label.resourceGroup)
+		}
+	}
+	m.lastUsage = usages
+}
+
+// updateActiveSegmentPredicate updates the active segment predicate expression.
+func (m *activeSegmentMetricManager) updateActiveSegmentPredicate() {
+	newExpr := paramtable.Get().QueryNodeCfg.ActiveSegmentPredicateExpr.GetValue()
+	if newExpr == m.lastExpr {
+		return
+	}
+
+	m.lastExpr = newExpr
+	program, err := m.compileExpr(newExpr)
+	if err != nil {
+		log.Warn("failed to update active segment predicate, use old one", zap.Error(err), zap.String("oldExpr", m.enabledExpr), zap.String("newExpr", newExpr))
+		return
+	}
+	log.Info("update active segment predicate expression", zap.String("oldExpr", m.enabledExpr), zap.String("newExpr", newExpr))
+	m.enabledExpr = newExpr
+	m.exprProgram = program
+}
+
+// aggregateSegments aggregates the active segments.
+func (m *activeSegmentMetricManager) aggregateSegments(s *sampler) (map[databaseLabel]*ResourceUsageMetrics, error) {
+	if m.exprProgram == nil {
+		return nil, errors.New("active segment predicate expression is nil")
+	}
+
+	// aggregate the active segments.
+	history := s.GetHistory()
+	usages := make(map[databaseLabel]*ResourceUsageMetrics, len(history))
+	for label, h := range history {
+		l := databaseLabel{
+			database:      label.DatabaseName,
+			resourceGroup: label.ResourceGroup,
+		}
+		if h.Len() <= 1 {
+			// skip the segment with only one snapsactive or no snapsactive.
+			continue
+		}
+		// Skip no resource usage segment.
+		if h.latestResourceUsage.IsZero() {
+			continue
+		}
+
+		ok, err := m.runPredicate(h)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to run active segment predicate expression on label %v, history count: %d", label, h.Len())
+		}
+		// update the active metric if predicate success.
+		if ok {
+			if usage, ok := usages[l]; !ok {
+				usages[l] = &ResourceUsageMetrics{
+					MemUsage:  h.latestResourceUsage.MemUsage,
+					DiskUsage: h.latestResourceUsage.DiskUsage,
+				}
+			} else {
+				usage.MemUsage += h.latestResourceUsage.MemUsage
+				usage.DiskUsage += h.latestResourceUsage.DiskUsage
+			}
+		}
+	}
+	return usages, nil
+}
+
+// compileExpr compiles the expression.
+func (m *activeSegmentMetricManager) compileExpr(newExpr string) (*vm.Program, error) {
+	program, err := expr.Compile(newExpr)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to compile active segment predicate expression")
+	}
+
+	output, err := expr.Run(program, getTestSegmentHistory())
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to test active segment predicate on test case")
+	}
+	_, ok := output.(bool)
+	if !ok {
+		return nil, errors.New("failed to convert output to bool on test case")
+	}
+	return program, nil
+}
+
+// runPredicate runs the predicate expression.
+func (m *activeSegmentMetricManager) runPredicate(h *segmentHistory) (bool, error) {
+	output, err := expr.Run(m.exprProgram, h)
+	if err != nil {
+		return false, err
+	}
+	b, ok := output.(bool)
+	if !ok {
+		return false, errors.New("failed to convert output to bool")
+	}
+	return b, nil
+}

--- a/internal/querynodev2/segments/metricsutil/active_segment_metric_manager_test.go
+++ b/internal/querynodev2/segments/metricsutil/active_segment_metric_manager_test.go
@@ -1,0 +1,105 @@
+package metricsutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/pkg/util/paramtable"
+)
+
+func TestActiveSegmentMetricManagerWithDefaultPredicate(t *testing.T) {
+	sampler := newSampler()
+
+	paramtable.Get().Save("queryNode.activeSegmentPredicateExpr", "len(Snapshots) >= 4 && (((Snapshots[-1].AccessCount() - Snapshots[-4].AccessCount()) / (Snapshots[-1].Time.Sub(Snapshots[-4].Time).Seconds())) > 0.1)")
+	manager := newActiveSegmentMetricManager("1")
+	newLabel := testLabel
+	newLabel.SegmentID = 10086
+	NewResourceEstimateRecord(testLabel).
+		WithDiskUsage(2048).
+		WithMemUsage(1024).Finish(nil)
+
+	NewResourceEstimateRecord(newLabel).
+		WithDiskUsage(4096).
+		WithMemUsage(2048).Finish(nil)
+
+	// only one snapshot, no metrics should be updated.
+	sampler.Scrape()
+	manager.Apply(sampler)
+	assert.Empty(t, manager.lastUsage)
+	// small qps
+	for i := 0; i < 100; i++ {
+		NewQuerySegmentAccessRecord(testLabel).Finish(nil)
+		NewQuerySegmentAccessRecord(newLabel).Finish(nil)
+		if i%25 == 0 {
+			sampler.Scrape()
+		}
+	}
+
+	manager.Apply(sampler)
+	assert.NotEmpty(t, manager.lastUsage)
+	l := databaseLabel{
+		database:      testLabel.DatabaseName,
+		resourceGroup: testLabel.ResourceGroup,
+	}
+	assert.Equal(t, uint64(6144), manager.lastUsage[l].DiskUsage)
+	assert.Equal(t, uint64(3072), manager.lastUsage[l].MemUsage)
+
+	// high qps limit
+	paramtable.Get().Save("queryNode.activeSegmentPredicateExpr", "len(Snapshots) >= 4 && (((Snapshots[-1].AccessCount() - Snapshots[-4].AccessCount()) / (Snapshots[-1].Time.Sub(Snapshots[-4].Time).Seconds())) > 1000000)")
+	for i := 0; i < 10; i++ {
+		NewQuerySegmentAccessRecord(testLabel).Finish(nil)
+		time.Sleep(100 * time.Millisecond)
+		sampler.Scrape()
+	}
+
+	manager.Apply(sampler)
+	assert.Empty(t, manager.lastUsage)
+}
+
+func TestPredicateUpdate(t *testing.T) {
+	expr := "len(Snapshots) >= 5 && (((Snapshots[-1].AccessCount() - Snapshots[0].AccessCount()) / (Snapshots[-1].Time.Sub(Snapshots[0].Time).Seconds())) > 0.1)"
+	paramtable.Get().Save("queryNode.activeSegmentPredicateExpr", expr)
+
+	m := newActiveSegmentMetricManager("1")
+	assert.Empty(t, m.lastExpr)
+	assert.Empty(t, m.enabledExpr)
+	assert.Nil(t, m.exprProgram)
+
+	m.updateActiveSegmentPredicate()
+	assert.Equal(t, expr, m.lastExpr)
+	assert.Equal(t, expr, m.enabledExpr)
+	assert.NotNil(t, m.exprProgram)
+
+	// illegal expr, using old one.
+	expr2 := "....*..."
+	paramtable.Get().Save("queryNode.activeSegmentPredicateExpr", expr2)
+	m.updateActiveSegmentPredicate()
+	assert.Equal(t, expr2, m.lastExpr)
+	assert.Equal(t, expr, m.enabledExpr)
+	assert.NotNil(t, m.exprProgram)
+
+	// cannot pass the testing.
+	expr2 = "Snapshots.Get()"
+	paramtable.Get().Save("queryNode.activeSegmentPredicateExpr", expr2)
+	m.updateActiveSegmentPredicate()
+	assert.Equal(t, expr2, m.lastExpr)
+	assert.Equal(t, expr, m.enabledExpr)
+	assert.NotNil(t, m.exprProgram)
+
+	// not bool expression.
+	expr2 = "1"
+	paramtable.Get().Save("queryNode.activeSegmentPredicateExpr", expr2)
+	m.updateActiveSegmentPredicate()
+	assert.Equal(t, expr2, m.lastExpr)
+	assert.Equal(t, expr, m.enabledExpr)
+	assert.NotNil(t, m.exprProgram)
+
+	expr = "len(Snapshots) >= 5"
+	paramtable.Get().Save("queryNode.activeSegmentPredicateExpr", expr)
+	m.updateActiveSegmentPredicate()
+	assert.Equal(t, expr, m.lastExpr)
+	assert.Equal(t, expr, m.enabledExpr)
+	assert.NotNil(t, m.exprProgram)
+}

--- a/internal/querynodev2/segments/metricsutil/history.go
+++ b/internal/querynodev2/segments/metricsutil/history.go
@@ -1,0 +1,53 @@
+package metricsutil
+
+import (
+	"time"
+)
+
+const (
+	maxSampleCount = 50
+)
+
+// newSegmentHistory creates a new segmentPredicateEnv.
+func newSegmentHistory() *segmentHistory {
+	return &segmentHistory{
+		Snapshots: make([]SegmentObserverSnapshot, 0, 2*maxSampleCount),
+	}
+}
+
+// segmentHistory is the environment for segment predicate.
+type segmentHistory struct {
+	latestResourceUsage ResourceUsageMetrics
+	Snapshots           []SegmentObserverSnapshot
+}
+
+// Len returns the length of the series.
+// !!! don't move these method, it will be used in hot segment predicate.
+func (h *segmentHistory) Len() int {
+	return len(h.Snapshots)
+}
+
+// Append appends a new snapshot to the series.
+func (h *segmentHistory) Append(snapshot SegmentObserverSnapshot) {
+	h.Snapshots = append(h.Snapshots, snapshot)
+	h.latestResourceUsage = snapshot.ResourceUsage
+}
+
+// Shrink removes old snapshots.
+func (h *segmentHistory) Shrink(expireAt time.Time) {
+	// keep snapshot small.
+	offset := len(h.Snapshots) - maxSampleCount
+	if offset > 0 {
+		h.Snapshots = h.Snapshots[offset:]
+	}
+
+	// expire by time, keep snapshot set small.
+	k := -1
+	for i := 0; i < len(h.Snapshots); i++ {
+		if h.Snapshots[i].Time.After(expireAt) {
+			break
+		}
+		k = i
+	}
+	h.Snapshots = h.Snapshots[k+1:]
+}

--- a/internal/querynodev2/segments/metricsutil/history_test.go
+++ b/internal/querynodev2/segments/metricsutil/history_test.go
@@ -1,0 +1,58 @@
+package metricsutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHistory(t *testing.T) {
+	h := newSegmentHistory()
+	g := newSegmentObserver("1", SegmentLabel{
+		SegmentID:     1,
+		DatabaseName:  "db1",
+		ResourceGroup: "rg1",
+	})
+
+	h.Append(g.Snapshot())
+	assert.Equal(t, 1, h.Len())
+
+	for i := 0; i < 99; i++ {
+		g = newSegmentObserver("1", SegmentLabel{
+			SegmentID:     1,
+			DatabaseName:  "db1",
+			ResourceGroup: "rg1",
+		})
+		h.Append(g.Snapshot())
+	}
+	assert.Equal(t, 100, h.Len())
+	h.Shrink(time.Now().Add(-snapshotExpire))
+	assert.Equal(t, 50, h.Len())
+	h.Shrink(time.Now())
+	assert.Equal(t, 0, h.Len())
+}
+
+func TestHistoryGetSnapshot(t *testing.T) {
+	h := newSegmentHistory()
+
+	g := newSegmentObserver("1", SegmentLabel{
+		SegmentID:     1,
+		DatabaseName:  "db1",
+		ResourceGroup: "rg1",
+	})
+
+	snapshot := g.Snapshot()
+	now := snapshot.Time
+	h.Append(snapshot)
+
+	snapshot = g.Snapshot()
+	snapshot.Time = now.Add(time.Second)
+	h.Append(snapshot)
+
+	snapshot = g.Snapshot()
+	snapshot.Time = now.Add(2 * time.Second)
+	h.Append(snapshot)
+
+	assert.Len(t, h.Snapshots, 3)
+}

--- a/internal/querynodev2/segments/metricsutil/loaded_segment_metric_manager.go
+++ b/internal/querynodev2/segments/metricsutil/loaded_segment_metric_manager.go
@@ -1,0 +1,83 @@
+package metricsutil
+
+import (
+	"github.com/milvus-io/milvus/pkg/metrics"
+)
+
+var _ metricManager = &loadedSegmentMetricManager{}
+
+// ResourceUsageMetrics records the estimate resource usage of the segment.
+type ResourceUsageMetrics struct {
+	MemUsage  uint64
+	DiskUsage uint64
+	RowNum    uint64
+}
+
+func (m *ResourceUsageMetrics) IsZero() bool {
+	return m.MemUsage == 0 && m.DiskUsage == 0
+}
+
+// newLoadedSegmentMetricManager creates a new active segment metric manager.
+func newLoadedSegmentMetricManager(nodeID string) *loadedSegmentMetricManager {
+	return &loadedSegmentMetricManager{
+		nodeID:    nodeID,
+		lastUsage: make(map[databaseLabel]*ResourceUsageMetrics),
+	}
+}
+
+// loadedSegmentMetricManager is the active segment metric manager.
+type loadedSegmentMetricManager struct {
+	nodeID    string
+	lastUsage map[databaseLabel]*ResourceUsageMetrics
+}
+
+// Apply update the active segment metric.
+func (m *loadedSegmentMetricManager) Apply(s *sampler) {
+	usage := m.aggregateSegments(s)
+	m.overwriteMetrics(usage)
+}
+
+// aggregateSegments aggregates the segments.
+func (m *loadedSegmentMetricManager) aggregateSegments(s *sampler) map[databaseLabel]*ResourceUsageMetrics {
+	// aggregate the hot segments.
+	history := s.GetHistory()
+
+	usages := make(map[databaseLabel]*ResourceUsageMetrics, len(history))
+	for label, h := range history {
+		// Skip no resource usage segment.
+		if h.latestResourceUsage.IsZero() {
+			continue
+		}
+
+		l := databaseLabel{
+			database:      label.DatabaseName,
+			resourceGroup: label.ResourceGroup,
+		}
+		if usage, ok := usages[l]; !ok {
+			usages[l] = &ResourceUsageMetrics{
+				MemUsage:  h.latestResourceUsage.MemUsage,
+				DiskUsage: h.latestResourceUsage.DiskUsage,
+			}
+		} else {
+			usage.MemUsage += h.latestResourceUsage.MemUsage
+			usage.DiskUsage += h.latestResourceUsage.DiskUsage
+		}
+	}
+	return usages
+}
+
+// overwriteMetrics overwrites the hot segment metrics.
+func (m *loadedSegmentMetricManager) overwriteMetrics(usages map[databaseLabel]*ResourceUsageMetrics) {
+	for label, usage := range usages {
+		metrics.QueryNodeLoadedSegmentMemoryBytes.WithLabelValues(m.nodeID, label.database, label.resourceGroup).Set(float64(usage.MemUsage))
+		metrics.QueryNodeLoadedSegmentDiskBytes.WithLabelValues(m.nodeID, label.database, label.resourceGroup).Set(float64(usage.DiskUsage))
+	}
+	// Remove the metrics of the hot segments that are not hot now.
+	for label := range m.lastUsage {
+		if _, ok := usages[label]; !ok {
+			metrics.QueryNodeLoadedSegmentMemoryBytes.DeleteLabelValues(m.nodeID, label.database, label.resourceGroup)
+			metrics.QueryNodeLoadedSegmentDiskBytes.DeleteLabelValues(m.nodeID, label.database, label.resourceGroup)
+		}
+	}
+	m.lastUsage = usages
+}

--- a/internal/querynodev2/segments/metricsutil/loaded_segment_metric_manager_test.go
+++ b/internal/querynodev2/segments/metricsutil/loaded_segment_metric_manager_test.go
@@ -1,0 +1,76 @@
+package metricsutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// deprecated: only for test.
+func resetGlobalObserver() {
+	globalObserver = newSegmentsObserver()
+}
+
+func TestLoadedSegmentMetricManager(t *testing.T) {
+	resetGlobalObserver()
+	sampler := newSampler()
+	NewResourceEstimateRecord(testLabel).
+		WithDiskUsage(2048).
+		WithMemUsage(1024).Finish(nil)
+	sampler.Scrape()
+
+	manager := newLoadedSegmentMetricManager("1")
+	manager.Apply(sampler)
+
+	l := databaseLabel{
+		database:      testLabel.DatabaseName,
+		resourceGroup: testLabel.ResourceGroup,
+	}
+	assert.NotEmpty(t, manager.lastUsage)
+	assert.Equal(t, uint64(1024), manager.lastUsage[l].MemUsage)
+	assert.Equal(t, uint64(2048), manager.lastUsage[l].DiskUsage)
+
+	// no new segment incoming, nothing changed.
+	sampler.Scrape()
+	manager.Apply(sampler)
+	assert.NotEmpty(t, manager.lastUsage)
+	assert.Equal(t, uint64(1024), manager.lastUsage[l].MemUsage)
+	assert.Equal(t, uint64(2048), manager.lastUsage[l].DiskUsage)
+
+	// new segment incoming, update the metrics.
+	newLabel := testLabel
+	newLabel.SegmentID = 19
+	NewResourceEstimateRecord(newLabel).
+		WithDiskUsage(4096).
+		WithMemUsage(2048).Finish(nil)
+	sampler.Scrape()
+	manager.Apply(sampler)
+	assert.NotEmpty(t, manager.lastUsage)
+	assert.Equal(t, uint64(3072), manager.lastUsage[l].MemUsage)
+	assert.Equal(t, uint64(6144), manager.lastUsage[l].DiskUsage)
+
+	// new database incoming.
+	newLabel = testLabel
+	newLabel.DatabaseName = "db13"
+	l2 := databaseLabel{
+		database:      newLabel.DatabaseName,
+		resourceGroup: newLabel.ResourceGroup,
+	}
+	NewResourceEstimateRecord(newLabel).
+		WithDiskUsage(4096).
+		WithMemUsage(2048).Finish(nil)
+	sampler.Scrape()
+	manager.Apply(sampler)
+
+	assert.Equal(t, uint64(2048), manager.lastUsage[l2].MemUsage)
+	assert.Equal(t, uint64(4096), manager.lastUsage[l2].DiskUsage)
+	// do not change old one.
+	assert.Equal(t, uint64(3072), manager.lastUsage[l].MemUsage)
+	assert.Equal(t, uint64(6144), manager.lastUsage[l].DiskUsage)
+
+	// test expired
+	sampler.historyExpiration(time.Now())
+	manager.Apply(sampler)
+	assert.Empty(t, manager.lastUsage)
+}

--- a/internal/querynodev2/segments/metricsutil/observer.go
+++ b/internal/querynodev2/segments/metricsutil/observer.go
@@ -1,0 +1,331 @@
+package metricsutil
+
+import (
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/atomic"
+
+	"github.com/milvus-io/milvus/pkg/metrics"
+	"github.com/milvus-io/milvus/pkg/util/metricsutil"
+	"github.com/milvus-io/milvus/pkg/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/util/typeutil"
+)
+
+// labeledRecord is a labeled sample point.
+type labeledRecord interface {
+	// Label of the access metric.
+	Label() SegmentLabel
+
+	// Finish finishes the record.
+	Finish(err error)
+
+	// getError returns the error of the record.
+	// current metric system simply reject the error operation.
+	getError() error
+}
+
+// globalObserver is the global resource groups observer.
+var (
+	once           sync.Once
+	globalObserver *segmentsObserver
+)
+
+func getGlobalObserver() *segmentsObserver {
+	once.Do(func() {
+		globalObserver = newSegmentsObserver()
+	})
+	return globalObserver
+}
+
+// newSegmentsObserver creates a new segmentsObserver.
+// Used to check if a segment is hot or cold.
+func newSegmentsObserver() *segmentsObserver {
+	return &segmentsObserver{
+		nodeID:   strconv.FormatInt(paramtable.GetNodeID(), 10),
+		segments: typeutil.NewConcurrentMap[SegmentLabel, *segmentObserver](),
+	}
+}
+
+// segmentsObserver is a observer all segments metrics.
+type segmentsObserver struct {
+	nodeID   string
+	segments *typeutil.ConcurrentMap[SegmentLabel, *segmentObserver] // map segment id to observer.
+	// one segment can be removed from one query node, for balancing or compacting.
+	// no more search operation will be performed on the segment after it is removed.
+	// all related metric should be expired after a while.
+	// may be a huge map with 100000+ entries.
+}
+
+// Observe records a new metric
+func (o *segmentsObserver) Observe(m labeledRecord) {
+	if m.getError() != nil {
+		return // reject error record.
+		// TODO: add error as a label of metrics.
+	}
+	// fast path.
+	label := m.Label()
+	observer, ok := o.segments.Get(label)
+	if !ok {
+		// slow path.
+		newObserver := newSegmentObserver(o.nodeID, label)
+		observer, _ = o.segments.GetOrInsert(label, newObserver)
+	}
+	// do a observer.
+	observer.Observe(m)
+}
+
+// ExpireAndObserve expire all expired observer and observe all non-expired observer.
+func (o *segmentsObserver) ExpireAndObserve(observer func(label SegmentLabel, snapshot SegmentObserverSnapshot), expiredAt time.Time) {
+	o.segments.Range(func(label SegmentLabel, value *segmentObserver) bool {
+		if value.IsExpired(expiredAt) {
+			o.segments.Remove(label)
+			value.Clear()
+			return true
+		}
+		observer(label, value.Snapshot())
+		return true
+	})
+}
+
+// newSegmentObserver creates a new segmentObserver.
+func newSegmentObserver(nodeID string, label SegmentLabel) *segmentObserver {
+	now := time.Now()
+	return &segmentObserver{
+		label:         label,
+		prom:          newPromObserver(nodeID, label),
+		cache:         newSegmentCacheObserver(),
+		searchAccess:  newSegmentAccessObserver(),
+		queryAccess:   newSegmentAccessObserver(),
+		lastUpdates:   atomic.NewPointer[time.Time](&now),
+		resourceUsage: atomic.NewPointer[ResourceUsageMetrics](&ResourceUsageMetrics{}),
+	}
+}
+
+// segmentObserver is a observer for segment metrics.
+type segmentObserver struct {
+	label SegmentLabel // never updates
+
+	// observers.
+	prom         promMetricsObserver   // prometheus metrics observer.
+	cache        segmentCacheObserver  // cache metrics observer.
+	searchAccess segmentAccessObserver // search metrics observer.
+	queryAccess  segmentAccessObserver // query metrics observer.
+
+	// resource usage.
+	resourceUsage *atomic.Pointer[ResourceUsageMetrics] // resource usage observer.
+	// for expiration.
+	lastUpdates *atomic.Pointer[time.Time] // update every access.
+}
+
+// Observe observe a new
+func (o *segmentObserver) Observe(m labeledRecord) {
+	now := time.Now()
+	o.lastUpdates.Store(&now)
+
+	switch mm := m.(type) {
+	case *CacheLoadRecord:
+		o.prom.ObserveLoad(mm)
+		o.cache.ObserveLoad(mm)
+	case *CacheEvictRecord:
+		o.prom.ObserveEvict(mm)
+		o.cache.ObserveEvict(mm)
+	case QuerySegmentAccessRecord:
+		o.prom.ObserveQueryAccess(mm)
+		o.queryAccess.Observe(mm.segmentAccessRecord)
+	case SearchSegmentAccessRecord:
+		o.prom.ObserveSearchAccess(mm)
+		o.searchAccess.Observe(mm.segmentAccessRecord)
+	case *ResourceEstimateRecord:
+		o.resourceUsage.Store(mm.ResourceUsageMetrics)
+	default:
+		panic("unknown segment access metric")
+	}
+}
+
+// IsExpired checks if the segment observer is expired.
+func (o *segmentObserver) IsExpired(expireAt time.Time) bool {
+	return o.lastUpdates.Load().Before(expireAt)
+}
+
+// Snapshot returns a snapshot of the observer.
+func (o *segmentObserver) Snapshot() SegmentObserverSnapshot {
+	return SegmentObserverSnapshot{
+		Time:          time.Now(),
+		Label:         o.label,
+		ResourceUsage: *o.resourceUsage.Load(),
+		Cache:         o.cache.Snapshot(),
+		SearchAccess:  o.searchAccess.Snapshot(),
+		QueryAccess:   o.queryAccess.Snapshot(),
+	}
+}
+
+func (o *segmentObserver) Clear() {
+	o.prom.Clear()
+}
+
+// newSegmentCacheObserver creates a new segmentCacheObserver.
+func newSegmentCacheObserver() segmentCacheObserver {
+	return segmentCacheObserver{
+		loadTotal:    metricsutil.NewCounter(),
+		loadDuration: metricsutil.NewDuration(),
+	}
+}
+
+// segmentCacheObserver is a observer for segment cache metrics.
+type segmentCacheObserver struct {
+	loadTotal    metricsutil.Counter  // real load data count.
+	loadDuration metricsutil.Duration // real load data time cost.
+}
+
+// ObserveLoad records a new load.
+func (o *segmentCacheObserver) ObserveLoad(r *CacheLoadRecord) {
+	o.loadTotal.Inc()
+	o.loadDuration.Add(r.getDuration())
+}
+
+// ObserveLoad records a new load.
+func (o *segmentCacheObserver) ObserveEvict(r *CacheEvictRecord) {
+	o.loadTotal.Inc()
+	o.loadDuration.Add(r.getDuration())
+}
+
+// Snapshot returns a snapshot of the observer.
+func (o *segmentCacheObserver) Snapshot() CacheObserverSnapshot {
+	return CacheObserverSnapshot{
+		LoadTotal:    int64(o.loadTotal.Get()),
+		LoadDuration: o.loadDuration.Get(),
+	}
+}
+
+// newSegmentAccessObserver creates a new segmentAccessObserver.
+func newSegmentAccessObserver() segmentAccessObserver {
+	return segmentAccessObserver{
+		total:            metricsutil.NewCounter(),
+		duration:         metricsutil.NewDuration(),
+		waitLoadTotal:    metricsutil.NewCounter(),
+		waitLoadDuration: metricsutil.NewDuration(),
+	}
+}
+
+// segmentAccessObserver is a observer for segment access metrics.
+type segmentAccessObserver struct {
+	total            metricsutil.Counter  // total access count.
+	duration         metricsutil.Duration // search or query time cost.
+	waitLoadTotal    metricsutil.Counter  // cache missing count.
+	waitLoadDuration metricsutil.Duration // search or query may blocked by loading data when cache miss, total time cost.
+}
+
+// recordAccess records a new access.
+func (o *segmentAccessObserver) Observe(r *segmentAccessRecord) {
+	o.total.Inc()
+	o.duration.Add(r.getDuration())
+	if r.isCacheMiss {
+		o.waitLoadTotal.Inc()
+		o.waitLoadDuration.Add(r.getWaitLoadDuration())
+	}
+}
+
+// Snapshot returns a snapshot of the observer.
+func (o *segmentAccessObserver) Snapshot() AccessObserverSnapshot {
+	return AccessObserverSnapshot{
+		Total:            int64(o.total.Get()),
+		Duration:         o.duration.Get(),
+		WaitLoadTotal:    int64(o.waitLoadTotal.Get()),
+		WaitLoadDuration: o.waitLoadDuration.Get(),
+	}
+}
+
+// newPromObserver creates a new promMetrics.
+func newPromObserver(nodeID string, label SegmentLabel) promMetricsObserver {
+	return promMetricsObserver{
+		nodeID:                               nodeID,
+		label:                                label,
+		DiskCacheLoadTotal:                   metrics.QueryNodeDiskCacheLoadTotal.WithLabelValues(nodeID, label.DatabaseName, label.ResourceGroup),
+		DiskCacheLoadDuration:                metrics.QueryNodeDiskCacheLoadDuration.WithLabelValues(nodeID, label.DatabaseName, label.ResourceGroup),
+		DiskCacheLoadBytes:                   metrics.QueryNodeDiskCacheLoadBytes.WithLabelValues(nodeID, label.DatabaseName, label.ResourceGroup),
+		DiskCacheEvictTotal:                  metrics.QueryNodeDiskCacheEvictTotal.WithLabelValues(nodeID, label.DatabaseName, label.ResourceGroup),
+		DiskCacheEvictDuration:               metrics.QueryNodeDiskCacheEvictDuration.WithLabelValues(nodeID, label.DatabaseName, label.ResourceGroup),
+		QuerySegmentAccessTotal:              metrics.QueryNodeSegmentAccessTotal.WithLabelValues(nodeID, label.DatabaseName, label.ResourceGroup, metrics.QueryLabel),
+		QuerySegmentAccessDuration:           metrics.QueryNodeSegmentAccessDuration.WithLabelValues(nodeID, label.DatabaseName, label.ResourceGroup, metrics.QueryLabel),
+		QuerySegmentAccessWaitCacheTotal:     metrics.QueryNodeSegmentAccessWaitCacheTotal.WithLabelValues(nodeID, label.DatabaseName, label.ResourceGroup, metrics.QueryLabel),
+		QuerySegmentAccessWaitCacheDuration:  metrics.QueryNodeSegmentAccessWaitCacheDuration.WithLabelValues(nodeID, label.DatabaseName, label.ResourceGroup, metrics.QueryLabel),
+		SearchSegmentAccessTotal:             metrics.QueryNodeSegmentAccessTotal.WithLabelValues(nodeID, label.DatabaseName, label.ResourceGroup, metrics.SearchLabel),
+		SearchSegmentAccessDuration:          metrics.QueryNodeSegmentAccessDuration.WithLabelValues(nodeID, label.DatabaseName, label.ResourceGroup, metrics.SearchLabel),
+		SearchSegmentAccessWaitCacheTotal:    metrics.QueryNodeSegmentAccessWaitCacheTotal.WithLabelValues(nodeID, label.DatabaseName, label.ResourceGroup, metrics.SearchLabel),
+		SearchSegmentAccessWaitCacheDuration: metrics.QueryNodeSegmentAccessWaitCacheDuration.WithLabelValues(nodeID, label.DatabaseName, label.ResourceGroup, metrics.SearchLabel),
+	}
+}
+
+// promMetricsObserver is a observer for prometheus metrics.
+type promMetricsObserver struct {
+	nodeID string
+	label  SegmentLabel // never updates
+
+	DiskCacheLoadTotal                   prometheus.Counter
+	DiskCacheLoadDuration                prometheus.Counter
+	DiskCacheLoadBytes                   prometheus.Counter
+	DiskCacheEvictTotal                  prometheus.Counter
+	DiskCacheEvictDuration               prometheus.Counter
+	QuerySegmentAccessTotal              prometheus.Counter
+	QuerySegmentAccessDuration           prometheus.Counter
+	QuerySegmentAccessWaitCacheTotal     prometheus.Counter
+	QuerySegmentAccessWaitCacheDuration  prometheus.Counter
+	SearchSegmentAccessTotal             prometheus.Counter
+	SearchSegmentAccessDuration          prometheus.Counter
+	SearchSegmentAccessWaitCacheTotal    prometheus.Counter
+	SearchSegmentAccessWaitCacheDuration prometheus.Counter
+}
+
+// RecordAccess records a new access.
+func (o *promMetricsObserver) ObserveLoad(r *CacheLoadRecord) {
+	o.DiskCacheLoadTotal.Inc()
+	o.DiskCacheLoadDuration.Add(r.getSeconds())
+	o.DiskCacheLoadBytes.Add(r.getBytes())
+}
+
+// RecordAccess records a new access.
+func (o *promMetricsObserver) ObserveEvict(r *CacheEvictRecord) {
+	o.DiskCacheEvictTotal.Inc()
+	o.DiskCacheEvictDuration.Add(r.getSeconds())
+}
+
+func (o *promMetricsObserver) ObserveQueryAccess(r QuerySegmentAccessRecord) {
+	o.QuerySegmentAccessTotal.Inc()
+	o.QuerySegmentAccessDuration.Add(r.getSeconds())
+	if r.isCacheMiss {
+		o.QuerySegmentAccessWaitCacheTotal.Inc()
+		o.QuerySegmentAccessWaitCacheDuration.Add(r.getWaitLoadSeconds())
+	}
+}
+
+func (o *promMetricsObserver) ObserveSearchAccess(r SearchSegmentAccessRecord) {
+	o.SearchSegmentAccessTotal.Inc()
+	o.SearchSegmentAccessDuration.Add(r.getSeconds())
+	if r.isCacheMiss {
+		o.SearchSegmentAccessWaitCacheTotal.Inc()
+		o.SearchSegmentAccessWaitCacheDuration.Add(r.getWaitLoadSeconds())
+	}
+}
+
+func (o *promMetricsObserver) Clear() {
+	label := o.label
+
+	metrics.QueryNodeDiskCacheLoadTotal.DeleteLabelValues(o.nodeID, label.DatabaseName, label.ResourceGroup)
+	metrics.QueryNodeDiskCacheLoadBytes.DeleteLabelValues(o.nodeID, label.DatabaseName, label.ResourceGroup)
+	metrics.QueryNodeDiskCacheLoadDuration.DeleteLabelValues(o.nodeID, label.DatabaseName, label.ResourceGroup)
+	metrics.QueryNodeDiskCacheEvictTotal.DeleteLabelValues(o.nodeID, label.DatabaseName, label.ResourceGroup)
+	metrics.QueryNodeDiskCacheEvictDuration.DeleteLabelValues(o.nodeID, label.DatabaseName, label.ResourceGroup)
+
+	metrics.QueryNodeSegmentAccessTotal.DeleteLabelValues(o.nodeID, label.DatabaseName, label.ResourceGroup, metrics.SearchLabel)
+	metrics.QueryNodeSegmentAccessTotal.DeleteLabelValues(o.nodeID, label.DatabaseName, label.ResourceGroup, metrics.QueryLabel)
+	metrics.QueryNodeSegmentAccessDuration.DeleteLabelValues(o.nodeID, label.DatabaseName, label.ResourceGroup, metrics.SearchLabel)
+	metrics.QueryNodeSegmentAccessDuration.DeleteLabelValues(o.nodeID, label.DatabaseName, label.ResourceGroup, metrics.QueryLabel)
+
+	metrics.QueryNodeSegmentAccessWaitCacheTotal.DeleteLabelValues(o.nodeID, label.DatabaseName, label.ResourceGroup, metrics.SearchLabel)
+	metrics.QueryNodeSegmentAccessWaitCacheTotal.DeleteLabelValues(o.nodeID, label.DatabaseName, label.ResourceGroup, metrics.QueryLabel)
+	metrics.QueryNodeSegmentAccessWaitCacheDuration.DeleteLabelValues(o.nodeID, label.DatabaseName, label.ResourceGroup, metrics.SearchLabel)
+	metrics.QueryNodeSegmentAccessWaitCacheDuration.DeleteLabelValues(o.nodeID, label.DatabaseName, label.ResourceGroup, metrics.QueryLabel)
+}

--- a/internal/querynodev2/segments/metricsutil/observer_test.go
+++ b/internal/querynodev2/segments/metricsutil/observer_test.go
@@ -1,0 +1,177 @@
+package metricsutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSegmentAccessGather(t *testing.T) {
+	g := newSegmentAccessObserver()
+	snapshot := g.Snapshot()
+	assert.Zero(t, snapshot.Total)
+	assert.Zero(t, snapshot.Duration)
+	assert.Zero(t, snapshot.WaitLoadDuration)
+	g.Observe(newCacheMissingMetric())
+	snapshot = g.Snapshot()
+	assert.Equal(t, int64(1), snapshot.Total)
+	assert.NotZero(t, snapshot.Duration)
+	assert.NotZero(t, snapshot.WaitLoadTotal)
+	assert.NotZero(t, snapshot.WaitLoadDuration)
+}
+
+func TestSegmentCacheGather(t *testing.T) {
+	g := newSegmentCacheObserver()
+	snapshot := g.Snapshot()
+	assert.Zero(t, snapshot.LoadTotal)
+	assert.Zero(t, snapshot.LoadDuration)
+	g.ObserveLoad(newCacheLoadMetric())
+	snapshot = g.Snapshot()
+	assert.NotZero(t, snapshot.LoadTotal)
+	assert.NotZero(t, snapshot.LoadDuration)
+}
+
+func TestSegmentGather(t *testing.T) {
+	g := newSegmentObserver("1", SegmentLabel{
+		SegmentID:     1,
+		DatabaseName:  "db1",
+		ResourceGroup: "rg1",
+	})
+	snapshot := g.Snapshot()
+	assert.Zero(t, snapshot.Cache.LoadTotal)
+	assert.Zero(t, snapshot.Cache.LoadDuration)
+	assert.Zero(t, snapshot.SearchAccess.Total)
+	assert.Zero(t, snapshot.SearchAccess.Duration)
+	assert.Zero(t, snapshot.SearchAccess.WaitLoadTotal)
+	assert.Zero(t, snapshot.SearchAccess.WaitLoadDuration)
+	assert.Zero(t, snapshot.QueryAccess.Total)
+	assert.Zero(t, snapshot.QueryAccess.Duration)
+	assert.Zero(t, snapshot.QueryAccess.WaitLoadTotal)
+	assert.Zero(t, snapshot.QueryAccess.WaitLoadDuration)
+	g.Observe(newCacheLoadMetric())
+	snapshot = g.Snapshot()
+	assert.NotZero(t, snapshot.Cache.LoadTotal)
+	assert.NotZero(t, snapshot.Cache.LoadDuration)
+	assert.Zero(t, snapshot.SearchAccess.Total)
+	assert.Zero(t, snapshot.SearchAccess.Duration)
+	assert.Zero(t, snapshot.SearchAccess.WaitLoadTotal)
+	assert.Zero(t, snapshot.SearchAccess.WaitLoadDuration)
+	assert.Zero(t, snapshot.QueryAccess.Total)
+	assert.Zero(t, snapshot.QueryAccess.Duration)
+	assert.Zero(t, snapshot.QueryAccess.WaitLoadTotal)
+	assert.Zero(t, snapshot.QueryAccess.WaitLoadDuration)
+
+	g.Observe(SearchSegmentAccessRecord{
+		segmentAccessRecord: newCacheMissingMetric(),
+	})
+	snapshot = g.Snapshot()
+	assert.NotZero(t, snapshot.Cache.LoadTotal)
+	assert.NotZero(t, snapshot.Cache.LoadDuration)
+	assert.NotZero(t, snapshot.SearchAccess.Total)
+	assert.NotZero(t, snapshot.SearchAccess.Duration)
+	assert.NotZero(t, snapshot.SearchAccess.WaitLoadTotal)
+	assert.NotZero(t, snapshot.SearchAccess.WaitLoadDuration)
+	assert.Zero(t, snapshot.QueryAccess.Total)
+	assert.Zero(t, snapshot.QueryAccess.Duration)
+	assert.Zero(t, snapshot.QueryAccess.WaitLoadTotal)
+	assert.Zero(t, snapshot.QueryAccess.WaitLoadDuration)
+
+	g.Observe(QuerySegmentAccessRecord{
+		segmentAccessRecord: newCacheMissingMetric(),
+	})
+	snapshot = g.Snapshot()
+	assert.NotZero(t, snapshot.Cache.LoadTotal)
+	assert.NotZero(t, snapshot.Cache.LoadDuration)
+	assert.NotZero(t, snapshot.SearchAccess.Total)
+	assert.NotZero(t, snapshot.SearchAccess.Duration)
+	assert.NotZero(t, snapshot.SearchAccess.WaitLoadTotal)
+	assert.NotZero(t, snapshot.SearchAccess.WaitLoadDuration)
+	assert.NotZero(t, snapshot.QueryAccess.Total)
+	assert.NotZero(t, snapshot.QueryAccess.Duration)
+	assert.NotZero(t, snapshot.QueryAccess.WaitLoadTotal)
+	assert.NotZero(t, snapshot.QueryAccess.WaitLoadDuration)
+
+	assert.False(t, g.IsExpired(time.Now().Add(-time.Minute)))
+	assert.True(t, g.IsExpired(time.Now()))
+
+	assert.Panics(t, func() {
+		g.Observe(&QuerySegmentAccessRecord{})
+	})
+}
+
+func TestSegmentsGather(t *testing.T) {
+	g := newSegmentsObserver()
+	m := NewSearchSegmentAccessRecord(SegmentLabel{
+		SegmentID:     1,
+		ResourceGroup: "rg1",
+		DatabaseName:  "db1",
+	})
+	m.Finish(nil)
+
+	g.Observe(m)
+	assert.Equal(t, 1, g.segments.Len())
+	g.Observe(m)
+	assert.Equal(t, 1, g.segments.Len())
+
+	m2 := NewQuerySegmentAccessRecord(SegmentLabel{
+		SegmentID:     1,
+		ResourceGroup: "rg1",
+		DatabaseName:  "db1",
+	})
+	m2.Finish(nil)
+	g.Observe(m2)
+	assert.Equal(t, 1, g.segments.Len())
+
+	m3 := NewSearchSegmentAccessRecord(SegmentLabel{
+		SegmentID:     1,
+		ResourceGroup: "rg2",
+		DatabaseName:  "db1",
+	})
+	m3.Finish(nil)
+	g.Observe(m3)
+	assert.Equal(t, 2, g.segments.Len())
+
+	cnt := 0
+	g.ExpireAndObserve(func(label SegmentLabel, snapshot SegmentObserverSnapshot) {
+		cnt++
+	}, time.Now().Add(-time.Minute))
+	assert.Equal(t, 2, cnt)
+
+	cnt = 0
+	g.ExpireAndObserve(func(label SegmentLabel, snapshot SegmentObserverSnapshot) {
+		cnt++
+	}, time.Now())
+	assert.Zero(t, cnt)
+}
+
+func newCacheMissingMetric() *segmentAccessRecord {
+	m := newSegmentAccessRecord(SegmentLabel{
+		SegmentID:     1,
+		DatabaseName:  "db1",
+		ResourceGroup: "rg1",
+	})
+	m.CacheMissing()
+	m.finish(nil)
+	return m
+}
+
+func newCacheHitMetric() *segmentAccessRecord {
+	m := newSegmentAccessRecord(SegmentLabel{
+		SegmentID:     1,
+		DatabaseName:  "db1",
+		ResourceGroup: "rg1",
+	})
+	m.finish(nil)
+	return m
+}
+
+func newCacheLoadMetric() *CacheLoadRecord {
+	m := NewCacheLoadRecord(SegmentLabel{
+		SegmentID:     1,
+		DatabaseName:  "db1",
+		ResourceGroup: "rg1",
+	})
+	m.Finish(nil)
+	return m
+}

--- a/internal/querynodev2/segments/metricsutil/record.go
+++ b/internal/querynodev2/segments/metricsutil/record.go
@@ -1,0 +1,212 @@
+package metricsutil
+
+import (
+	"time"
+
+	"github.com/milvus-io/milvus/pkg/util/timerecord"
+)
+
+var (
+	_ labeledRecord = QuerySegmentAccessRecord{}
+	_ labeledRecord = SearchSegmentAccessRecord{}
+	_ labeledRecord = &ResourceEstimateRecord{}
+	_ labeledRecord = &CacheLoadRecord{}
+	_ labeledRecord = &CacheEvictRecord{}
+)
+
+// CacheLoadRecord records the metrics of a cache load.
+type CacheLoadRecord struct {
+	bytes uint64
+	baseRecord
+}
+
+// NewCacheLoadRecord creates a new CacheLoadRecord.
+func NewCacheLoadRecord(label SegmentLabel) *CacheLoadRecord {
+	return &CacheLoadRecord{
+		baseRecord: newBaseRecord(label),
+	}
+}
+
+func (r *CacheLoadRecord) WithBytes(bytes uint64) *CacheLoadRecord {
+	r.bytes = bytes
+	return r
+}
+
+func (r *CacheLoadRecord) getBytes() float64 {
+	return float64(r.bytes)
+}
+
+// Finish finishes the record.
+func (r *CacheLoadRecord) Finish(err error) {
+	r.baseRecord.finish(err)
+	getGlobalObserver().Observe(r)
+}
+
+type CacheEvictRecord struct {
+	baseRecord
+}
+
+// NewCacheEvictRecord creates a new CacheEvictRecord.
+func NewCacheEvictRecord(label SegmentLabel) *CacheEvictRecord {
+	return &CacheEvictRecord{
+		baseRecord: newBaseRecord(label),
+	}
+}
+
+// Finish finishes the record.
+func (r *CacheEvictRecord) Finish(err error) {
+	r.baseRecord.finish(err)
+	getGlobalObserver().Observe(r)
+}
+
+// NewResourceEstimateRecord creates a new ResourceEstimateRecord.
+func NewResourceEstimateRecord(label SegmentLabel) *ResourceEstimateRecord {
+	return &ResourceEstimateRecord{
+		label:                label,
+		ResourceUsageMetrics: &ResourceUsageMetrics{},
+	}
+}
+
+// ResourceEstimateRecord records the resource usage of a segment.
+// It is just a estimate of the resource usage.
+type ResourceEstimateRecord struct {
+	label SegmentLabel
+	*ResourceUsageMetrics
+}
+
+// Label returns the label of the recorder.
+func (r *ResourceEstimateRecord) Label() SegmentLabel {
+	return r.label
+}
+
+// WithMemUsage sets the memory usage of the segment.
+func (r *ResourceEstimateRecord) WithMemUsage(memUsage uint64) *ResourceEstimateRecord {
+	r.MemUsage = memUsage
+	return r
+}
+
+// WithDiskUsage sets the disk usage of the segment.
+func (r *ResourceEstimateRecord) WithDiskUsage(diskUsage uint64) *ResourceEstimateRecord {
+	r.DiskUsage = diskUsage
+	return r
+}
+
+// WithRowNum sets the row number of the segment.
+func (r *ResourceEstimateRecord) WithRowNum(rowNum uint64) *ResourceEstimateRecord {
+	r.RowNum = rowNum
+	return r
+}
+
+func (r *ResourceEstimateRecord) getError() error {
+	return nil
+}
+
+func (r *ResourceEstimateRecord) Finish(_ error) {
+	getGlobalObserver().Observe(r)
+}
+
+// NewQuerySegmentAccessRecord creates a new QuerySegmentMetricRecorder.
+func NewQuerySegmentAccessRecord(label SegmentLabel) QuerySegmentAccessRecord {
+	return QuerySegmentAccessRecord{
+		segmentAccessRecord: newSegmentAccessRecord(label),
+	}
+}
+
+// NewSearchSegmentAccessRecord creates a new SearchSegmentMetricRecorder.
+func NewSearchSegmentAccessRecord(label SegmentLabel) SearchSegmentAccessRecord {
+	return SearchSegmentAccessRecord{
+		segmentAccessRecord: newSegmentAccessRecord(label),
+	}
+}
+
+// QuerySegmentAccessRecord records the metrics of a query segment.
+type QuerySegmentAccessRecord struct {
+	*segmentAccessRecord
+}
+
+func (r QuerySegmentAccessRecord) Finish(err error) {
+	r.finish(err)
+	getGlobalObserver().Observe(r)
+}
+
+// SearchSegmentAccessRecord records the metrics of a search segment.
+type SearchSegmentAccessRecord struct {
+	*segmentAccessRecord
+}
+
+func (r SearchSegmentAccessRecord) Finish(err error) {
+	r.finish(err)
+	getGlobalObserver().Observe(r)
+}
+
+// segmentAccessRecord records the metrics of the segment.
+type segmentAccessRecord struct {
+	isCacheMiss  bool          // whether the access is a cache miss.
+	waitLoadCost time.Duration // time cost of waiting for loading data.
+	baseRecord
+}
+
+// newSegmentAccessRecord creates a new accessMetricRecorder.
+func newSegmentAccessRecord(label SegmentLabel) *segmentAccessRecord {
+	return &segmentAccessRecord{
+		baseRecord: newBaseRecord(label),
+	}
+}
+
+// CacheMissing records the cache missing.
+func (r *segmentAccessRecord) CacheMissing() {
+	r.isCacheMiss = true
+	r.waitLoadCost = r.timeRecorder.RecordSpan()
+}
+
+// getWaitLoadSeconds returns the wait load seconds of the recorder.
+func (r *segmentAccessRecord) getWaitLoadSeconds() float64 {
+	return r.waitLoadCost.Seconds()
+}
+
+// getWaitLoadDuration returns the wait load duration of the recorder.
+func (r *segmentAccessRecord) getWaitLoadDuration() time.Duration {
+	return r.waitLoadCost
+}
+
+// newBaseRecord returns a new baseRecord.
+func newBaseRecord(label SegmentLabel) baseRecord {
+	return baseRecord{
+		label:        label,
+		timeRecorder: timerecord.NewTimeRecorder(""),
+	}
+}
+
+// baseRecord records the metrics of the segment.
+type baseRecord struct {
+	label        SegmentLabel
+	duration     time.Duration
+	err          error
+	timeRecorder *timerecord.TimeRecorder
+}
+
+// Label returns the label of the recorder.
+func (r *baseRecord) Label() SegmentLabel {
+	return r.label
+}
+
+// getError returns the error of the recorder.
+func (r *baseRecord) getError() error {
+	return r.err
+}
+
+// getDuration returns the duration of the recorder.
+func (r *baseRecord) getDuration() time.Duration {
+	return r.duration
+}
+
+// getSeconds returns the duration of the recorder in seconds.
+func (r *baseRecord) getSeconds() float64 {
+	return r.duration.Seconds()
+}
+
+// finish finishes the record.
+func (r *baseRecord) finish(err error) {
+	r.err = err
+	r.duration = r.timeRecorder.ElapseSpan()
+}

--- a/internal/querynodev2/segments/metricsutil/record_test.go
+++ b/internal/querynodev2/segments/metricsutil/record_test.go
@@ -1,0 +1,117 @@
+package metricsutil
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/pkg/util/paramtable"
+)
+
+var testLabel = SegmentLabel{
+	SegmentID:     1,
+	DatabaseName:  "db",
+	ResourceGroup: "rg",
+}
+
+func TestMain(m *testing.M) {
+	paramtable.Init()
+	os.Exit(m.Run())
+}
+
+func TestBaseRecord(t *testing.T) {
+	r := newBaseRecord(testLabel)
+	assert.Equal(t, testLabel, r.Label())
+	err := errors.New("test")
+	r.finish(err)
+	assert.Equal(t, err, r.getError())
+	assert.NotZero(t, r.getDuration())
+	assert.NotZero(t, r.getSeconds())
+}
+
+func TestSegmentAccessRecorder(t *testing.T) {
+	mr := newSegmentAccessRecord(SegmentLabel{
+		SegmentID:     1,
+		DatabaseName:  "db1",
+		ResourceGroup: "rg1",
+	})
+	assert.Equal(t, mr.Label(), SegmentLabel{
+		SegmentID:     1,
+		DatabaseName:  "db1",
+		ResourceGroup: "rg1",
+	})
+	assert.False(t, mr.isCacheMiss)
+	assert.Zero(t, mr.waitLoadCost)
+	assert.Zero(t, mr.getDuration())
+	mr.CacheMissing()
+	assert.True(t, mr.isCacheMiss)
+	assert.NotZero(t, mr.waitLoadCost)
+	assert.Zero(t, mr.getDuration())
+	mr.finish(nil)
+	assert.NotZero(t, mr.getDuration())
+
+	mr = newSegmentAccessRecord(SegmentLabel{
+		SegmentID:     1,
+		DatabaseName:  "db1",
+		ResourceGroup: "rg1",
+	})
+	mr.CacheMissing()
+	assert.True(t, mr.isCacheMiss)
+	assert.NotZero(t, mr.waitLoadCost)
+	assert.Zero(t, mr.getDuration())
+	mr.finish(nil)
+	assert.NotZero(t, mr.getDuration())
+
+	mr = newSegmentAccessRecord(SegmentLabel{
+		SegmentID:     1,
+		DatabaseName:  "db1",
+		ResourceGroup: "rg1",
+	})
+	mr.finish(nil)
+	assert.False(t, mr.isCacheMiss)
+	assert.Zero(t, mr.waitLoadCost)
+	assert.NotZero(t, mr.getDuration())
+}
+
+func TestSearchSegmentAccessMetric(t *testing.T) {
+	m := NewSearchSegmentAccessRecord(SegmentLabel{
+		SegmentID:     1,
+		DatabaseName:  "db1",
+		ResourceGroup: "rg1",
+	})
+	m.CacheMissing()
+	m.Finish(nil)
+	assert.NotZero(t, m.getDuration())
+}
+
+func TestQuerySegmentAccessMetric(t *testing.T) {
+	m := NewQuerySegmentAccessRecord(SegmentLabel{
+		SegmentID:     1,
+		DatabaseName:  "db1",
+		ResourceGroup: "rg1",
+	})
+	m.CacheMissing()
+	m.Finish(nil)
+	assert.NotZero(t, m.getDuration())
+}
+
+func TestResourceEstimateRecord(t *testing.T) {
+	r := NewResourceEstimateRecord(testLabel)
+	assert.Equal(t, testLabel, r.Label())
+	r.WithDiskUsage(1).WithMemUsage(2).WithRowNum(100)
+	assert.Equal(t, uint64(1), r.DiskUsage)
+	assert.Equal(t, uint64(2), r.MemUsage)
+	assert.Equal(t, uint64(100), r.RowNum)
+	r.Finish(nil)
+}
+
+func TestCacheRecord(t *testing.T) {
+	r1 := NewCacheLoadRecord(testLabel)
+	r1.WithBytes(1)
+	assert.Equal(t, float64(1), r1.getBytes())
+	r1.Finish(nil)
+	r2 := NewCacheEvictRecord(testLabel)
+	r2.Finish(nil)
+}

--- a/internal/querynodev2/segments/metricsutil/sampler.go
+++ b/internal/querynodev2/segments/metricsutil/sampler.go
@@ -1,0 +1,66 @@
+package metricsutil
+
+import (
+	"time"
+)
+
+const (
+	metricExpire   = 30 * time.Minute
+	snapshotExpire = 5 * time.Minute
+)
+
+// newSampler creates a new sampler.
+func newSampler() *sampler {
+	return &sampler{
+		history: make(map[SegmentLabel]*segmentHistory),
+	}
+}
+
+// sampler observes the metrics in global observer, sample a snapshot, and update the metrics output.
+type sampler struct {
+	history map[SegmentLabel]*segmentHistory // history may be a large map with 100000+ entries.
+}
+
+// GetHistory returns the history of the sampler.
+func (o *sampler) GetHistory() map[SegmentLabel]*segmentHistory {
+	return o.history
+}
+
+// Scrape scrapes the metrics.
+func (o *sampler) Scrape() {
+	now := time.Now()
+	o.scrapeMetricSamples(now.Add(-metricExpire))
+	o.historyExpiration(now.Add(-snapshotExpire))
+}
+
+// scrapeMetricSamples observes the metrics, and updates the history.
+func (o *sampler) scrapeMetricSamples(expireAt time.Time) {
+	getGlobalObserver().ExpireAndObserve(func(label SegmentLabel, snapshot SegmentObserverSnapshot) {
+		if _, ok := o.history[label]; !ok {
+			o.history[label] = newSegmentHistory()
+		}
+		o.history[label].Append(snapshot)
+	}, expireAt)
+}
+
+// historyExpiration shrinks the snapshots.
+func (o *sampler) historyExpiration(expireAt time.Time) {
+	for label, h := range o.history {
+		h.Shrink(expireAt)
+		if h.Len() == 0 {
+			delete(o.history, label)
+		}
+	}
+}
+
+// getTestSegmentHistory returns a test segment history.
+func getTestSegmentHistory() *segmentHistory {
+	testSegmentHistory := newSegmentHistory()
+	testSegmentHistory.Append(SegmentObserverSnapshot{
+		Time: time.Now(),
+	})
+	testSegmentHistory.Append(SegmentObserverSnapshot{
+		Time: time.Now(),
+	})
+	return testSegmentHistory
+}

--- a/internal/querynodev2/segments/metricsutil/sampler_test.go
+++ b/internal/querynodev2/segments/metricsutil/sampler_test.go
@@ -1,0 +1,29 @@
+package metricsutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSampler(t *testing.T) {
+	sampler := newSampler()
+	assert.Equal(t, 0, len(sampler.GetHistory()))
+
+	NewResourceEstimateRecord(testLabel).
+		WithDiskUsage(10086).
+		WithMemUsage(2048).
+		Finish(nil)
+	sampler.Scrape()
+	assert.NotZero(t, len(sampler.GetHistory()))
+	assert.NotNil(t, sampler.GetHistory()[testLabel])
+	h := sampler.GetHistory()[testLabel]
+	assert.NotNil(t, h.Snapshots[0])
+	assert.Equal(t, uint64(10086), h.Snapshots[0].ResourceUsage.DiskUsage)
+	assert.Equal(t, uint64(2048), h.Snapshots[0].ResourceUsage.MemUsage)
+
+	// test expire.
+	sampler.historyExpiration(time.Now())
+	assert.Zero(t, len(sampler.GetHistory()))
+}

--- a/internal/querynodev2/segments/metricsutil/scheduler.go
+++ b/internal/querynodev2/segments/metricsutil/scheduler.go
@@ -1,0 +1,75 @@
+package metricsutil
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/milvus-io/milvus/pkg/util/paramtable"
+)
+
+var schedulerOnce sync.Once
+
+// StartScheduler starts the scheduler.
+func StartScheduler() {
+	schedulerOnce.Do(func() {
+		newScheduler().Run()
+	})
+}
+
+type metricManager interface {
+	Apply(*sampler)
+}
+
+// scheduler is the scheduler of the metric package, organizing the metric managers and sampler together.
+// Some metric is too large to be handled at prometheus,
+// so we need to sample the metrics and aggregate them, then put them to prometheus.
+type scheduler struct {
+	ctx            context.Context
+	cancel         context.CancelFunc
+	metricManagers []metricManager
+	sampler        *sampler
+}
+
+// newScheduler creates a new scheduler.
+func newScheduler() *scheduler {
+	nodeID := strconv.FormatInt(paramtable.GetNodeID(), 10)
+	ctx, cancel := context.WithCancel(context.Background())
+	return &scheduler{
+		ctx:    ctx,
+		cancel: cancel,
+		metricManagers: []metricManager{
+			newLoadedSegmentMetricManager(nodeID), // active segment metric aggregation.
+			newActiveSegmentMetricManager(nodeID), // hot segment metric aggregation.
+		},
+		sampler: newSampler(),
+	}
+}
+
+// Run runs the scheduler.
+func (s *scheduler) Run() {
+	go func() {
+		for {
+			interval := paramtable.Get().QueryNodeCfg.MetricScrapeInterval.GetAsDuration(time.Second)
+
+			select {
+			case <-s.ctx.Done():
+				return
+			case <-time.After(interval):
+			}
+
+			// scrape the metrics and apply to all metric managers.
+			s.sampler.Scrape()
+			for _, m := range s.metricManagers {
+				m.Apply(s.sampler)
+			}
+		}
+	}()
+}
+
+// Stop stops the scheduler.
+// It seems that the scheduler need not to be stopped.
+func (s *scheduler) Stop() {
+	s.cancel()
+}

--- a/internal/querynodev2/segments/metricsutil/scheduler_test.go
+++ b/internal/querynodev2/segments/metricsutil/scheduler_test.go
@@ -1,0 +1,24 @@
+package metricsutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/milvus-io/milvus/pkg/util/paramtable"
+)
+
+func TestScheduler(t *testing.T) {
+	paramtable.Get().Save("queryNode.metricScrapeInterval", "0.1")
+	scheduler := newScheduler()
+	scheduler.Run()
+
+	// small qps
+	for i := 0; i < 1000; i++ {
+		NewQuerySegmentAccessRecord(testLabel).Finish(nil)
+		time.Sleep(1 * time.Millisecond)
+	}
+
+	scheduler.Stop()
+
+	StartScheduler()
+}

--- a/internal/querynodev2/segments/metricsutil/snapshot.go
+++ b/internal/querynodev2/segments/metricsutil/snapshot.go
@@ -1,0 +1,57 @@
+package metricsutil
+
+import (
+	"time"
+
+	"github.com/milvus-io/milvus/pkg/util/typeutil"
+)
+
+// SegmentLabel is the label of a segment.
+type SegmentLabel struct {
+	SegmentID     typeutil.UniqueID `expr:"SegmentID"`
+	DatabaseName  string            `expr:"DatabaseName"`
+	ResourceGroup string            `expr:"ResourceGroup"`
+}
+
+// snapshot returns a snapshot of the segment gather.
+// !!! All these fields and type should be exported for expr-lang predicate.
+type SegmentObserverSnapshot struct {
+	Time          time.Time              `expr:"Time"`
+	Label         SegmentLabel           `expr:"Label"`
+	ResourceUsage ResourceUsageMetrics   `expr:"ResourceUsage"`
+	Cache         CacheObserverSnapshot  `expr:"Cache"`
+	SearchAccess  AccessObserverSnapshot `expr:"SearchAccess"`
+	QueryAccess   AccessObserverSnapshot `expr:"QueryAccess"`
+}
+
+func (s SegmentObserverSnapshot) AccessCount() int64 {
+	return s.SearchAccess.Total + s.QueryAccess.Total
+}
+
+// CacheObserverSnapshot is a snapshot of segmentCacheGather.
+// !!! All these fields and type should be exported for expr-lang predicate.
+type CacheObserverSnapshot struct {
+	LoadTotal    int64         `expr:"LoadTotal"`
+	LoadDuration time.Duration `expr:"LoadDuration"`
+}
+
+func (c *CacheObserverSnapshot) Add(snapshot CacheObserverSnapshot) {
+	c.LoadTotal += snapshot.LoadTotal
+	c.LoadDuration += snapshot.LoadDuration
+}
+
+// AccessObserverSnapshot is a snapshot of segmentAccessGather.
+// !!! All these fields and type should be exported for expr-lang predicate.
+type AccessObserverSnapshot struct {
+	Total            int64         `expr:"Total"`
+	Duration         time.Duration `expr:"Duration"`
+	WaitLoadTotal    int64         `expr:"WaitLoadTotal"`
+	WaitLoadDuration time.Duration `expr:"WaitLoadDuration"`
+}
+
+func (a *AccessObserverSnapshot) Add(snapshot AccessObserverSnapshot) {
+	a.Total += snapshot.Total
+	a.Duration += snapshot.Duration
+	a.WaitLoadTotal += snapshot.WaitLoadTotal
+	a.WaitLoadDuration += snapshot.WaitLoadDuration
+}

--- a/internal/querynodev2/segments/metricsutil/snapshot_test.go
+++ b/internal/querynodev2/segments/metricsutil/snapshot_test.go
@@ -1,0 +1,27 @@
+package metricsutil
+
+import "testing"
+
+func TestCacheObserverSnapshot(t *testing.T) {
+	snapshot := CacheObserverSnapshot{}
+	snapshot.Add(CacheObserverSnapshot{
+		LoadTotal:    1,
+		LoadDuration: 1,
+	})
+	if snapshot.LoadTotal != 1 || snapshot.LoadDuration != 1 {
+		t.Error("cacheObserverSnapshot Add failed")
+	}
+}
+
+func TestAccessObserverSnapshot(t *testing.T) {
+	snapshot := AccessObserverSnapshot{}
+	snapshot.Add(AccessObserverSnapshot{
+		Total:            1,
+		Duration:         1,
+		WaitLoadTotal:    1,
+		WaitLoadDuration: 1,
+	})
+	if snapshot.Total != 1 || snapshot.Duration != 1 || snapshot.WaitLoadTotal != 1 || snapshot.WaitLoadDuration != 1 {
+		t.Error("accessObserverSnapshot Add failed")
+	}
+}

--- a/internal/querynodev2/segments/mock_segment.go
+++ b/internal/querynodev2/segments/mock_segment.go
@@ -117,6 +117,47 @@ func (_c *MockSegment_Collection_Call) RunAndReturn(run func() int64) *MockSegme
 	return _c
 }
 
+// DatabaseName provides a mock function with given fields:
+func (_m *MockSegment) DatabaseName() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// MockSegment_DatabaseName_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DatabaseName'
+type MockSegment_DatabaseName_Call struct {
+	*mock.Call
+}
+
+// DatabaseName is a helper method to define mock.On call
+func (_e *MockSegment_Expecter) DatabaseName() *MockSegment_DatabaseName_Call {
+	return &MockSegment_DatabaseName_Call{Call: _e.mock.On("DatabaseName")}
+}
+
+func (_c *MockSegment_DatabaseName_Call) Run(run func()) *MockSegment_DatabaseName_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockSegment_DatabaseName_Call) Return(_a0 string) *MockSegment_DatabaseName_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockSegment_DatabaseName_Call) RunAndReturn(run func() string) *MockSegment_DatabaseName_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Delete provides a mock function with given fields: ctx, primaryKeys, timestamps
 func (_m *MockSegment) Delete(ctx context.Context, primaryKeys []storage.PrimaryKey, timestamps []uint64) error {
 	ret := _m.Called(ctx, primaryKeys, timestamps)
@@ -948,6 +989,47 @@ func (_c *MockSegment_Release_Call) Return() *MockSegment_Release_Call {
 }
 
 func (_c *MockSegment_Release_Call) RunAndReturn(run func(...releaseOption)) *MockSegment_Release_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ResourceGroup provides a mock function with given fields:
+func (_m *MockSegment) ResourceGroup() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// MockSegment_ResourceGroup_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ResourceGroup'
+type MockSegment_ResourceGroup_Call struct {
+	*mock.Call
+}
+
+// ResourceGroup is a helper method to define mock.On call
+func (_e *MockSegment_Expecter) ResourceGroup() *MockSegment_ResourceGroup_Call {
+	return &MockSegment_ResourceGroup_Call{Call: _e.mock.On("ResourceGroup")}
+}
+
+func (_c *MockSegment_ResourceGroup_Call) Run(run func()) *MockSegment_ResourceGroup_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockSegment_ResourceGroup_Call) Return(_a0 string) *MockSegment_ResourceGroup_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockSegment_ResourceGroup_Call) RunAndReturn(run func() string) *MockSegment_ResourceGroup_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/querynodev2/segments/search.go
+++ b/internal/querynodev2/segments/search.go
@@ -24,6 +24,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus/internal/querynodev2/segments/metricsutil"
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/metrics"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
@@ -77,8 +78,16 @@ func searchSegments(ctx context.Context, mgr *Manager, segments []Segment, segTy
 				mu.Unlock()
 			}
 			var err error
+			accessRecord := metricsutil.NewSearchSegmentAccessRecord(getSegmentMetricLabel(seg))
+			defer func() {
+				accessRecord.Finish(err)
+			}()
 			if seg.IsLazyLoad() {
-				err = mgr.DiskCache.Do(seg.ID(), searcher)
+				var missing bool
+				missing, err = mgr.DiskCache.Do(seg.ID(), searcher)
+				if missing {
+					accessRecord.CacheMissing()
+				}
 			} else {
 				err = searcher(seg)
 			}

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -120,6 +120,14 @@ func (s *baseSegment) Partition() int64 {
 	return s.loadInfo.GetPartitionID()
 }
 
+func (s *baseSegment) DatabaseName() string {
+	return s.collection.GetDBName()
+}
+
+func (s *baseSegment) ResourceGroup() string {
+	return s.collection.GetResourceGroup()
+}
+
 func (s *baseSegment) Shard() string {
 	return s.loadInfo.GetInsertChannel()
 }
@@ -1396,4 +1404,6 @@ func (s *LocalSegment) Release(opts ...releaseOption) {
 		zap.String("segmentType", s.segmentType.String()),
 		zap.Int64("insertCount", s.InsertCount()),
 	)
+	// set segment resource estimate to zero.
+	clearResourceEstimate(s)
 }

--- a/internal/querynodev2/segments/segment_interface.go
+++ b/internal/querynodev2/segments/segment_interface.go
@@ -50,6 +50,8 @@ type Segment interface {
 
 	// Properties
 	ID() int64
+	DatabaseName() string
+	ResourceGroup() string
 	Collection() int64
 	Partition() int64
 	Shard() string

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -1064,7 +1064,12 @@ func (loader *segmentLoader) LoadSegment(ctx context.Context,
 	).Add(float64(loadInfo.GetNumOfRows()))
 
 	log.Info("loading delta...")
-	return loader.LoadDeltaLogs(ctx, segment, loadInfo.Deltalogs)
+	if err := loader.LoadDeltaLogs(ctx, segment, loadInfo.Deltalogs); err != nil {
+		return err
+	}
+
+	observeResourceEstimate(segment)
+	return nil
 }
 
 func (loader *segmentLoader) filterPKStatsBinlogs(fieldBinlogs []*datapb.FieldBinlog, pkFieldID int64) ([]string, storage.StatsLogType) {

--- a/internal/querynodev2/server.go
+++ b/internal/querynodev2/server.go
@@ -51,6 +51,7 @@ import (
 	"github.com/milvus-io/milvus/internal/querynodev2/optimizers"
 	"github.com/milvus-io/milvus/internal/querynodev2/pipeline"
 	"github.com/milvus-io/milvus/internal/querynodev2/segments"
+	"github.com/milvus-io/milvus/internal/querynodev2/segments/metricsutil"
 	"github.com/milvus-io/milvus/internal/querynodev2/tasks"
 	"github.com/milvus-io/milvus/internal/querynodev2/tsafe"
 	"github.com/milvus-io/milvus/internal/registry"
@@ -295,6 +296,9 @@ func (node *QueryNode) Init() error {
 				return
 			}
 		}
+
+		// init metrics collector scheduler.
+		metricsutil.StartScheduler()
 
 		node.factory.Init(paramtable.Get())
 

--- a/internal/querynodev2/tasks/query_task.go
+++ b/internal/querynodev2/tasks/query_task.go
@@ -71,8 +71,11 @@ func (t *QueryTask) PreExecute() error {
 	// Update in queue metric for prometheus.
 	metrics.QueryNodeSQLatencyInQueue.WithLabelValues(
 		nodeID,
-		metrics.QueryLabel).
-		Observe(float64(inQueueDuration.Milliseconds()))
+		metrics.QueryLabel,
+		t.collection.GetDBName(),
+		t.collection.GetResourceGroup(), // TODO: resource group and db name may be removed at runtime.
+		// should be refactor into metricsutil.observer in the future.
+	).Observe(float64(inQueueDuration.Milliseconds()))
 
 	username := t.Username()
 	metrics.QueryNodeSQPerUserLatencyInQueue.WithLabelValues(

--- a/internal/querynodev2/tasks/task.go
+++ b/internal/querynodev2/tasks/task.go
@@ -102,8 +102,12 @@ func (t *SearchTask) PreExecute() error {
 	// Update in queue metric for prometheus.
 	metrics.QueryNodeSQLatencyInQueue.WithLabelValues(
 		nodeID,
-		metrics.SearchLabel).
-		Observe(float64(inQueueDuration.Milliseconds()))
+		metrics.SearchLabel,
+		t.collection.GetDBName(),
+		t.collection.GetResourceGroup(),
+		// TODO: resource group and db name may be removed at runtime,
+		// should be refactor into metricsutil.observer in the future.
+	).Observe(float64(inQueueDuration.Milliseconds()))
 
 	username := t.Username()
 	metrics.QueryNodeSQPerUserLatencyInQueue.WithLabelValues(

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -81,6 +81,8 @@ const (
 	functionLabelName        = "function_name"
 	queryTypeLabelName       = "query_type"
 	collectionName           = "collection_name"
+	databaseLabelName        = "db_name"
+	resourceGroupLabelName   = "rg"
 	indexName                = "index_name"
 	isVectorIndex            = "is_vector_index"
 	segmentStateLabelName    = "segment_state"

--- a/pkg/metrics/querynode_metrics.go
+++ b/pkg/metrics/querynode_metrics.go
@@ -175,6 +175,8 @@ var (
 		}, []string{
 			nodeIDLabelName,
 			queryTypeLabelName,
+			databaseLabelName,
+			resourceGroupLabelName,
 		})
 
 	QueryNodeSQPerUserLatencyInQueue = prometheus.NewHistogramVec(
@@ -501,6 +503,168 @@ var (
 		}, []string{
 			nodeIDLabelName,
 		})
+	// QueryNodeSegmentAccessTotal records the total number of search or query segments accessed.
+	QueryNodeSegmentAccessTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.QueryNodeRole,
+			Name:      "segment_access_total",
+		}, []string{
+			nodeIDLabelName,
+			databaseLabelName,
+			resourceGroupLabelName,
+			queryTypeLabelName,
+		},
+	)
+
+	// QueryNodeSegmentAccessDuration records the total time cost of accessing segments including cache loads.
+	QueryNodeSegmentAccessDuration = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.QueryNodeRole,
+			Name:      "segment_access_duration",
+		}, []string{
+			nodeIDLabelName,
+			databaseLabelName,
+			resourceGroupLabelName,
+			queryTypeLabelName,
+		},
+	)
+
+	// QueryNodeSegmentAccessWaitCacheTotal records the number of search or query segments that have to wait for loading access.
+	QueryNodeSegmentAccessWaitCacheTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.QueryNodeRole,
+			Name:      "segment_access_wait_cache_total",
+		}, []string{
+			nodeIDLabelName,
+			databaseLabelName,
+			resourceGroupLabelName,
+			queryTypeLabelName,
+		})
+
+	// QueryNodeSegmentAccessWaitCacheDuration records the total time cost of waiting for loading access.
+	QueryNodeSegmentAccessWaitCacheDuration = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.QueryNodeRole,
+			Name:      "segment_access_wait_cache_duration",
+		}, []string{
+			nodeIDLabelName,
+			databaseLabelName,
+			resourceGroupLabelName,
+			queryTypeLabelName,
+		})
+
+	// QueryNodeDiskCacheLoadTotal records the number of real segments loaded from disk cache.
+	QueryNodeDiskCacheLoadTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.QueryNodeRole,
+			Name:      "disk_cache_load_total",
+		}, []string{
+			nodeIDLabelName,
+			databaseLabelName,
+			resourceGroupLabelName,
+		})
+
+	QueryNodeDiskCacheLoadBytes = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.QueryNodeRole,
+			Name:      "disk_cache_load_bytes",
+		}, []string{
+			nodeIDLabelName,
+			databaseLabelName,
+			resourceGroupLabelName,
+		})
+
+	// QueryNodeDiskCacheLoadDuration records the total time cost of loading segments from disk cache.
+	QueryNodeDiskCacheLoadDuration = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.QueryNodeRole,
+			Name:      "disk_cache_load_duration",
+		}, []string{
+			nodeIDLabelName,
+			databaseLabelName,
+			resourceGroupLabelName,
+		})
+
+	// QueryNodeDiskCacheEvictTotal records the number of real segments evicted from disk cache.
+	QueryNodeDiskCacheEvictTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.QueryNodeRole,
+			Name:      "disk_cache_evict_total",
+		}, []string{
+			nodeIDLabelName,
+			databaseLabelName,
+			resourceGroupLabelName,
+		})
+
+	// QueryNodeDiskCacheEvictDuration records the total time cost of evicting segments from disk cache.
+	QueryNodeDiskCacheEvictDuration = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.QueryNodeRole,
+			Name:      "disk_cache_evict_duration",
+		}, []string{
+			nodeIDLabelName,
+			databaseLabelName,
+			resourceGroupLabelName,
+		})
+
+	// QueryNodeActiveSegmentDiskBytes records the disk usage of hot segments.
+	QueryNodeActiveSegmentDiskBytes = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.QueryNodeRole,
+			Name:      "active_segment_disk_bytes",
+		}, []string{
+			nodeIDLabelName,
+			databaseLabelName,
+			resourceGroupLabelName,
+		})
+
+	// QueryNodeActiveSegmentMemoryBytes records the memory usage of hot segments.
+	QueryNodeActiveSegmentMemoryBytes = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.QueryNodeRole,
+			Name:      "active_segment_memory_bytes",
+		}, []string{
+			nodeIDLabelName,
+			databaseLabelName,
+			resourceGroupLabelName,
+		})
+
+	// QueryNodeLoadedSegmentDiskBytes records the disk size of active segments.
+	QueryNodeLoadedSegmentDiskBytes = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.QueryNodeRole,
+			Name:      "loaded_segment_disk_bytes",
+		}, []string{
+			nodeIDLabelName,
+			databaseLabelName,
+			resourceGroupLabelName,
+		},
+	)
+
+	// QueryNodeLoadedSegmentMemoryBytes records the memory size of active segments.
+	QueryNodeLoadedSegmentMemoryBytes = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.QueryNodeRole,
+			Name:      "loaded_segment_memory_bytes",
+		}, []string{
+			nodeIDLabelName,
+			databaseLabelName,
+			resourceGroupLabelName,
+		},
+	)
 )
 
 // RegisterQueryNode registers QueryNode metrics
@@ -548,6 +712,19 @@ func RegisterQueryNode(registry *prometheus.Registry) {
 	registry.MustRegister(StoppingBalanceSegmentNum)
 	registry.MustRegister(QueryNodeLoadSegmentConcurrency)
 	registry.MustRegister(QueryNodeLoadIndexLatency)
+	registry.MustRegister(QueryNodeSegmentAccessTotal)
+	registry.MustRegister(QueryNodeSegmentAccessDuration)
+	registry.MustRegister(QueryNodeSegmentAccessWaitCacheTotal)
+	registry.MustRegister(QueryNodeSegmentAccessWaitCacheDuration)
+	registry.MustRegister(QueryNodeDiskCacheLoadTotal)
+	registry.MustRegister(QueryNodeDiskCacheLoadDuration)
+	registry.MustRegister(QueryNodeDiskCacheLoadBytes)
+	registry.MustRegister(QueryNodeDiskCacheEvictTotal)
+	registry.MustRegister(QueryNodeDiskCacheEvictDuration)
+	registry.MustRegister(QueryNodeActiveSegmentDiskBytes)
+	registry.MustRegister(QueryNodeActiveSegmentMemoryBytes)
+	registry.MustRegister(QueryNodeLoadedSegmentDiskBytes)
+	registry.MustRegister(QueryNodeLoadedSegmentMemoryBytes)
 }
 
 func CleanupQueryNodeCollectionMetrics(nodeID int64, collectionID int64) {

--- a/pkg/util/cache/cache.go
+++ b/pkg/util/cache/cache.go
@@ -88,7 +88,7 @@ func (s *LazyScavenger[K]) Spare(key K) func(K) bool {
 }
 
 type Cache[K comparable, V any] interface {
-	Do(key K, doer func(V) error) error
+	Do(key K, doer func(V) error) (bool, error)
 	DoWait(key K, timeout time.Duration, doer func(V) error) error
 }
 
@@ -184,13 +184,13 @@ func newLRUCache[K comparable, V any](
 }
 
 // Do picks up an item from cache and executes doer. The entry of interest is garented in the cache when doer is executing.
-func (c *lruCache[K, V]) Do(key K, doer func(V) error) error {
-	item, err := c.getAndPin(key)
+func (c *lruCache[K, V]) Do(key K, doer func(V) error) (bool, error) {
+	item, missing, err := c.getAndPin(key)
 	if err != nil {
-		return err
+		return missing, err
 	}
 	defer c.Unpin(key)
-	return doer(item.value)
+	return missing, doer(item.value)
 }
 
 func (c *lruCache[K, V]) DoWait(key K, timeout time.Duration, doer func(V) error) error {
@@ -213,7 +213,7 @@ func (c *lruCache[K, V]) DoWait(key K, timeout time.Duration, doer func(V) error
 	var ele *list.Element
 	start := time.Now()
 	for {
-		item, err := c.getAndPin(key)
+		item, _, err := c.getAndPin(key)
 		if err == nil {
 			if ele != nil {
 				c.rwlock.Lock()
@@ -277,16 +277,16 @@ func (c *lruCache[K, V]) peekAndPin(key K) *cacheItem[K, V] {
 }
 
 // GetAndPin gets and pins the given key if it exists
-func (c *lruCache[K, V]) getAndPin(key K) (*cacheItem[K, V], error) {
+func (c *lruCache[K, V]) getAndPin(key K) (*cacheItem[K, V], bool, error) {
 	if item := c.peekAndPin(key); item != nil {
-		return item, nil
+		return item, false, nil
 	}
 
 	if c.loader != nil {
 		// Try scavenge if there is room. If not, fail fast.
 		//	Note that the test is not accurate since we are not locking `loader` here.
 		if _, ok := c.tryScavenge(key); !ok {
-			return nil, ErrNotEnoughSpace
+			return nil, true, ErrNotEnoughSpace
 		}
 
 		strKey := fmt.Sprint(key)
@@ -308,12 +308,12 @@ func (c *lruCache[K, V]) getAndPin(key K) (*cacheItem[K, V], error) {
 		})
 
 		if err == nil {
-			return item.(*cacheItem[K, V]), nil
+			return item.(*cacheItem[K, V]), true, nil
 		}
-		return nil, err
+		return nil, true, err
 	}
 
-	return nil, ErrNoSuchItem
+	return nil, true, ErrNoSuchItem
 }
 
 func (c *lruCache[K, V]) tryScavenge(key K) ([]K, bool) {

--- a/pkg/util/metricsutil/counter.go
+++ b/pkg/util/metricsutil/counter.go
@@ -1,0 +1,64 @@
+package metricsutil
+
+import (
+	"math"
+
+	"github.com/cockroachdb/errors"
+	"go.uber.org/atomic"
+)
+
+var _ Counter = &counter{}
+
+// NewCounter creates a new Counter.
+func NewCounter() Counter {
+	return &counter{}
+}
+
+// Counter is a metric that represents a single numerical value that only ever goes up.
+// Reference: github.com/prometheus/client_golang/prometheus.
+type Counter interface {
+	// Add adds the given value to the counter. It panics if the value is negative.
+	Add(float64)
+
+	// Inc increments the counter by 1.
+	Inc()
+
+	// Get returns the current value of the counter.
+	Get() float64
+}
+
+// counter is a Counter implementation.
+type counter struct {
+	valInt  atomic.Uint64
+	valBits atomic.Uint64
+}
+
+func (c *counter) Add(v float64) {
+	if v < 0 {
+		panic(errors.New("counter cannot decrease in value"))
+	}
+
+	ival := uint64(v)
+	if float64(ival) == v {
+		c.valInt.Add(ival)
+		return
+	}
+
+	for {
+		oldBits := c.valBits.Load()
+		newBits := math.Float64bits(math.Float64frombits(oldBits) + v)
+		if c.valBits.CompareAndSwap(oldBits, newBits) {
+			return
+		}
+	}
+}
+
+func (c *counter) Inc() {
+	c.valInt.Inc()
+}
+
+func (c *counter) Get() float64 {
+	fval := math.Float64frombits(c.valBits.Load())
+	ival := c.valInt.Load()
+	return fval + float64(ival)
+}

--- a/pkg/util/metricsutil/counter_test.go
+++ b/pkg/util/metricsutil/counter_test.go
@@ -1,0 +1,37 @@
+package metricsutil
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCounter(t *testing.T) {
+	c := NewCounter()
+	c.Add(1)
+	assert.Equal(t, 1, int(c.Get()))
+	c.Add(1)
+	assert.Equal(t, 2, int(c.Get()))
+	c.Inc()
+	assert.Equal(t, 3, int(c.Get()))
+	c.Add(2.5)
+	assert.True(t, c.Get()-5.5 < 1e-6)
+
+	c = NewCounter()
+	wg := sync.WaitGroup{}
+	wg.Add(100)
+	cnt := 0.0
+	for i := 0; i < 100; i++ {
+		go func(i int) {
+			c.Add(float64(i) * 1.5)
+			wg.Done()
+		}(i)
+		cnt += float64(i) * 1.5
+	}
+	wg.Wait()
+	assert.True(t, c.Get()-cnt < 1e-6)
+	assert.Panics(t, func() {
+		c.Add(-1)
+	})
+}

--- a/pkg/util/metricsutil/duration.go
+++ b/pkg/util/metricsutil/duration.go
@@ -1,0 +1,35 @@
+package metricsutil
+
+import (
+	"time"
+
+	"go.uber.org/atomic"
+)
+
+// NewDuration creates a new Duration.
+func NewDuration() Duration {
+	return &duration{}
+}
+
+// Duration is a metric that represents a single numerical value that only ever goes up.
+type Duration interface {
+	// Add adds the given value to the duration. It panics if the value is negative.
+	Add(d time.Duration)
+
+	// Get returns the current value of the duration.
+	Get() time.Duration
+}
+
+// duration is a Duration implementation.
+type duration struct {
+	valInt atomic.Int64
+}
+
+func (d *duration) Add(v time.Duration) {
+	d.valInt.Add(v.Nanoseconds())
+}
+
+func (d *duration) Get() time.Duration {
+	c := d.valInt.Load()
+	return time.Duration(c) * time.Nanosecond
+}

--- a/pkg/util/metricsutil/duration_test.go
+++ b/pkg/util/metricsutil/duration_test.go
@@ -1,0 +1,17 @@
+package metricsutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDuration(t *testing.T) {
+	d := NewDuration()
+	assert.Equal(t, time.Duration(0), d.Get())
+	d.Add(time.Second)
+	assert.Equal(t, time.Second, d.Get())
+	d.Add(time.Minute)
+	assert.Equal(t, time.Second+time.Minute, d.Get())
+}

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -365,6 +365,14 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, 2.5, Params.MemoryIndexLoadPredictMemoryUsageFactor.GetAsFloat())
 		params.Save("queryNode.memoryIndexLoadPredictMemoryUsageFactor", "2.0")
 		assert.Equal(t, 2.0, Params.MemoryIndexLoadPredictMemoryUsageFactor.GetAsFloat())
+
+		assert.Equal(t, 15, Params.MetricScrapeInterval.GetAsInt())
+		params.Save("queryNode.metricScrapeInterval", "10")
+		assert.Equal(t, 10, Params.MetricScrapeInterval.GetAsInt())
+
+		assert.Equal(t, "len(Snapshots) >= 4 && (((Snapshots[-1].AccessCount() - Snapshots[0].AccessCount()) / (Snapshots[-1].Time.Sub(Snapshots[0].Time).Seconds())) > 0.1)", Params.ActiveSegmentPredicateExpr.GetValue())
+		params.Save("queryNode.activeSegmentPredicateExpr", "0 == 0")
+		assert.Equal(t, "0 == 0", Params.ActiveSegmentPredicateExpr.GetValue())
 	})
 
 	t.Run("test dataCoordConfig", func(t *testing.T) {


### PR DESCRIPTION
issue: #30931

- add background task to collect cache or search metrics in resource group and database level.

- add active segment predicate to check if a segment is an active segment.

- add resource group and database level metric of in-queue-time.