### PR TITLE
fix: [Cherry-Pick] delegator filter out all partition's delete msg when loading segment

### DIFF
--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -575,7 +575,7 @@ func (sd *shardDelegator) readDeleteFromMsgstream(ctx context.Context, position 
 			for _, tsMsg := range msgPack.Msgs {
 				if tsMsg.Type() == commonpb.MsgType_Delete {
 					dmsg := tsMsg.(*msgstream.DeleteMsg)
-					if dmsg.CollectionID != sd.collectionID || dmsg.GetPartitionID() != candidate.Partition() {
+					if dmsg.CollectionID != sd.collectionID || (dmsg.GetPartitionID() != common.InvalidPartitionID && dmsg.GetPartitionID() != candidate.Partition()) {
 						continue
 					}
 


### PR DESCRIPTION
May cause deleted data queryable a period of time.
issue : #31484 
pr: https://github.com/milvus-io/milvus/pull/31585