### PR TITLE
enhance: Support retriving file size from importutilv2.Reader (#31533)

### DIFF
--- a/internal/datanode/importv2/executor_test.go
+++ b/internal/datanode/importv2/executor_test.go
@@ -464,13 +464,10 @@ func (s *ExecutorSuite) TestExecutor_ReadFileStat() {
 		Paths: []string{"dummy.json"},
 	}
 
-	cm := mocks.NewChunkManager(s.T())
-	cm.EXPECT().Size(mock.Anything, mock.Anything).Return(1024, nil)
-	s.executor.cm = cm
-
 	var once sync.Once
 	data := createInsertData(s.T(), s.schema, s.numRows)
 	s.reader = importutilv2.NewMockReader(s.T())
+	s.reader.EXPECT().Size().Return(1024, nil)
 	s.reader.EXPECT().Read().RunAndReturn(func() (*storage.InsertData, error) {
 		var res *storage.InsertData
 		once.Do(func() {
@@ -492,7 +489,7 @@ func (s *ExecutorSuite) TestExecutor_ReadFileStat() {
 	}
 	preimportTask := NewPreImportTask(preimportReq)
 	s.manager.Add(preimportTask)
-	err := s.executor.readFileStat(s.reader, preimportTask, 0, importFile)
+	err := s.executor.readFileStat(s.reader, preimportTask, 0)
 	s.NoError(err)
 }
 

--- a/internal/datanode/importv2/util.go
+++ b/internal/datanode/importv2/util.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"time"
 
 	"github.com/samber/lo"
 	"go.uber.org/zap"
@@ -30,10 +29,8 @@ import (
 	"github.com/milvus-io/milvus/internal/datanode/metacache"
 	"github.com/milvus-io/milvus/internal/datanode/syncmgr"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
-	"github.com/milvus-io/milvus/internal/proto/internalpb"
 	"github.com/milvus-io/milvus/internal/querycoordv2/params"
 	"github.com/milvus-io/milvus/internal/storage"
-	"github.com/milvus-io/milvus/internal/util/importutilv2"
 	"github.com/milvus-io/milvus/pkg/common"
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/util/merr"
@@ -202,43 +199,6 @@ func GetInsertDataRowCount(data *storage.InsertData, schema *schemapb.Collection
 		}
 	}
 	return 0
-}
-
-func GetFileSize(file *internalpb.ImportFile, cm storage.ChunkManager, task Task) (int64, error) {
-	paths := file.GetPaths()
-	if importutilv2.IsBackup(task.GetOptions()) {
-		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
-		defer cancel()
-		paths = make([]string, 0)
-		for _, prefix := range file.GetPaths() {
-			binlogs, _, err := cm.ListWithPrefix(ctx, prefix, true)
-			if err != nil {
-				return 0, err
-			}
-			paths = append(paths, binlogs...)
-		}
-	}
-
-	fn := func(path string) (int64, error) {
-		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
-		defer cancel()
-		return cm.Size(ctx, path)
-	}
-	var totalSize int64 = 0
-	for _, path := range paths {
-		size, err := fn(path)
-		if err != nil {
-			return 0, err
-		}
-		totalSize += size
-	}
-	maxSize := paramtable.Get().DataNodeCfg.MaxImportFileSizeInGB.GetAsFloat() * 1024 * 1024 * 1024
-	if totalSize > int64(maxSize) {
-		return 0, merr.WrapErrImportFailed(fmt.Sprintf(
-			"The import file size has reached the maximum limit allowed for importing, "+
-				"fileSize=%d, maxSize=%d", totalSize, int64(maxSize)))
-	}
-	return totalSize, nil
 }
 
 func LogStats(manager TaskManager) {

--- a/internal/storage/utils.go
+++ b/internal/storage/utils.go
@@ -18,6 +18,7 @@ package storage
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -1246,4 +1247,16 @@ func Min(a, b int64) int64 {
 		return a
 	}
 	return b
+}
+
+func GetFilesSize(ctx context.Context, paths []string, cm ChunkManager) (int64, error) {
+	totalSize := int64(0)
+	for _, filePath := range paths {
+		size, err := cm.Size(ctx, filePath)
+		if err != nil {
+			return 0, err
+		}
+		totalSize += size
+	}
+	return totalSize, nil
 }

--- a/internal/util/importutilv2/binlog/reader.go
+++ b/internal/util/importutilv2/binlog/reader.go
@@ -23,6 +23,9 @@ import (
 	"io"
 	"math"
 
+	"github.com/samber/lo"
+	"go.uber.org/atomic"
+
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/pkg/util/merr"
@@ -34,6 +37,7 @@ type reader struct {
 	cm     storage.ChunkManager
 	schema *schemapb.CollectionSchema
 
+	fileSize   *atomic.Int64
 	deleteData *storage.DeleteData
 	insertLogs map[int64][]string // fieldID -> binlogs
 
@@ -50,9 +54,10 @@ func NewReader(ctx context.Context,
 ) (*reader, error) {
 	schema = typeutil.AppendSystemFields(schema)
 	r := &reader{
-		ctx:    ctx,
-		cm:     cm,
-		schema: schema,
+		ctx:      ctx,
+		cm:       cm,
+		schema:   schema,
+		fileSize: atomic.NewInt64(0),
 	}
 	err := r.init(paths, tsStart, tsEnd)
 	if err != nil {
@@ -198,6 +203,18 @@ OUTER:
 		}
 	}
 	return result, nil
+}
+
+func (r *reader) Size() (int64, error) {
+	if size := r.fileSize.Load(); size != 0 {
+		return size, nil
+	}
+	size, err := storage.GetFilesSize(r.ctx, lo.Flatten(lo.Values(r.insertLogs)), r.cm)
+	if err != nil {
+		return 0, err
+	}
+	r.fileSize.Store(size)
+	return size, nil
 }
 
 func (r *reader) Close() {}

--- a/internal/util/importutilv2/mock_reader.go
+++ b/internal/util/importutilv2/mock_reader.go
@@ -105,6 +105,57 @@ func (_c *MockReader_Read_Call) RunAndReturn(run func() (*storage.InsertData, er
 	return _c
 }
 
+// Size provides a mock function with given fields:
+func (_m *MockReader) Size() (int64, error) {
+	ret := _m.Called()
+
+	var r0 int64
+	var r1 error
+	if rf, ok := ret.Get(0).(func() (int64, error)); ok {
+		return rf()
+	}
+	if rf, ok := ret.Get(0).(func() int64); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockReader_Size_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Size'
+type MockReader_Size_Call struct {
+	*mock.Call
+}
+
+// Size is a helper method to define mock.On call
+func (_e *MockReader_Expecter) Size() *MockReader_Size_Call {
+	return &MockReader_Size_Call{Call: _e.mock.On("Size")}
+}
+
+func (_c *MockReader_Size_Call) Run(run func()) *MockReader_Size_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockReader_Size_Call) Return(_a0 int64, _a1 error) *MockReader_Size_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockReader_Size_Call) RunAndReturn(run func() (int64, error)) *MockReader_Size_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewMockReader creates a new instance of MockReader. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewMockReader(t interface {

--- a/internal/util/importutilv2/numpy/util.go
+++ b/internal/util/importutilv2/numpy/util.go
@@ -251,7 +251,7 @@ func fillDynamicData(data *storage.InsertData, schema *schemapb.CollectionSchema
 	if dynamicField == nil {
 		return nil
 	}
-	rowNum := GetInsertDataRowNum(data, schema)
+	rowNum := getInsertDataRowNum(data, schema)
 	dynamicData := data.Data[dynamicField.GetFieldID()]
 	jsonFD := dynamicData.(*storage.JSONFieldData)
 	bs := []byte("{}")
@@ -262,7 +262,7 @@ func fillDynamicData(data *storage.InsertData, schema *schemapb.CollectionSchema
 	return nil
 }
 
-func GetInsertDataRowNum(data *storage.InsertData, schema *schemapb.CollectionSchema) int {
+func getInsertDataRowNum(data *storage.InsertData, schema *schemapb.CollectionSchema) int {
 	fields := lo.KeyBy(schema.GetFields(), func(field *schemapb.FieldSchema) int64 {
 		return field.GetFieldID()
 	})

--- a/internal/util/importutilv2/parquet/reader_test.go
+++ b/internal/util/importutilv2/parquet/reader_test.go
@@ -413,9 +413,7 @@ func (s *ReaderSuite) run(dt schemapb.DataType) {
 	f := storage.NewChunkManagerFactory("local", storage.RootPath("/tmp/milvus_test/test_parquet_reader/"))
 	cm, err := f.NewPersistentStorageChunkManager(ctx)
 	assert.NoError(s.T(), err)
-	cmReader, err := cm.Reader(ctx, filePath)
-	assert.NoError(s.T(), err)
-	reader, err := NewReader(ctx, schema, cmReader, 64*1024*1024)
+	reader, err := NewReader(ctx, cm, schema, filePath, 64*1024*1024)
 	s.NoError(err)
 
 	checkFn := func(actualInsertData *storage.InsertData, offsetBegin, expectRows int) {
@@ -494,9 +492,7 @@ func (s *ReaderSuite) failRun(dt schemapb.DataType, isDynamic bool) {
 	f := storage.NewChunkManagerFactory("local", storage.RootPath("/tmp/milvus_test/test_parquet_reader/"))
 	cm, err := f.NewPersistentStorageChunkManager(ctx)
 	assert.NoError(s.T(), err)
-	cmReader, err := cm.Reader(ctx, filePath)
-	assert.NoError(s.T(), err)
-	reader, err := NewReader(ctx, schema, cmReader, 64*1024*1024)
+	reader, err := NewReader(ctx, cm, schema, filePath, 64*1024*1024)
 	s.NoError(err)
 
 	_, err = reader.Read()

--- a/internal/util/importutilv2/util.go
+++ b/internal/util/importutilv2/util.go
@@ -50,10 +50,6 @@ func (f FileType) String() string {
 	return FileTypeName[int(f)]
 }
 
-func WrapReadFileError(file string, err error) error {
-	return merr.WrapErrImportFailed(fmt.Sprintf("failed to read the file '%s', error: %s", file, err.Error()))
-}
-
 func GetFileType(file *internalpb.ImportFile) (FileType, error) {
 	if len(file.GetPaths()) == 0 {
 		return Invalid, merr.WrapErrImportFailed("no file to import")


### PR DESCRIPTION
To reduce the overhead caused by listing the S3 objects, add an interface to importutil.Reader to retrieve file sizes.

issue: https://github.com/milvus-io/milvus/issues/31532, https://github.com/milvus-io/milvus/issues/28521

pr: https://github.com/milvus-io/milvus/pull/31533