### PR TITLE
fix: allow datanode's server id to be updated

### DIFF
--- a/internal/datacoord/server.go
+++ b/internal/datacoord/server.go
@@ -466,6 +466,13 @@ func (s *Server) startDataCoord() {
 	sessionutil.SaveServerInfo(typeutil.DataCoordRole, s.session.GetServerID())
 }
 
+func (s *Server) GetServerID() int64 {
+	if s.session != nil {
+		return s.session.GetServerID()
+	}
+	return paramtable.GetNodeID()
+}
+
 func (s *Server) afterStart() {}
 
 func (s *Server) initCluster() error {

--- a/internal/datanode/event_manager.go
+++ b/internal/datanode/event_manager.go
@@ -92,7 +92,7 @@ func (node *DataNode) StartWatchChannels(ctx context.Context) {
 // serves the corner case for etcd connection lost and missing some events
 func (node *DataNode) checkWatchedList() error {
 	// REF MEP#7 watch path should be [prefix]/channel/{node_id}/{channel_name}
-	prefix := path.Join(Params.CommonCfg.DataCoordWatchSubPath.GetValue(), fmt.Sprintf("%d", node.serverID))
+	prefix := path.Join(Params.CommonCfg.DataCoordWatchSubPath.GetValue(), fmt.Sprintf("%d", node.GetNodeID()))
 	keys, values, err := node.watchKv.LoadWithPrefix(prefix)
 	if err != nil {
 		return err

--- a/internal/datanode/mock_test.go
+++ b/internal/datanode/mock_test.go
@@ -83,7 +83,7 @@ var segID2SegInfo = map[int64]*datapb.SegmentInfo{
 
 func newIDLEDataNodeMock(ctx context.Context, pkType schemapb.DataType) *DataNode {
 	factory := dependency.NewDefaultFactory(true)
-	node := NewDataNode(ctx, factory, 1)
+	node := NewDataNode(ctx, factory)
 	node.SetSession(&sessionutil.Session{SessionRaw: sessionutil.SessionRaw{ServerID: 1}})
 	node.dispClient = msgdispatcher.NewClient(factory, typeutil.DataNodeRole, paramtable.GetNodeID())
 

--- a/internal/distributed/datacoord/service.go
+++ b/internal/distributed/datacoord/service.go
@@ -180,7 +180,7 @@ func (s *Server) startGrpcLoop(grpcPort int) {
 			interceptor.ClusterValidationUnaryServerInterceptor(),
 			interceptor.ServerIDValidationUnaryServerInterceptor(func() int64 {
 				if s.serverID.Load() == 0 {
-					s.serverID.Store(paramtable.GetNodeID())
+					s.serverID.Store(s.dataCoord.(*datacoord.Server).GetServerID())
 				}
 				return s.serverID.Load()
 			}),
@@ -191,7 +191,7 @@ func (s *Server) startGrpcLoop(grpcPort int) {
 			interceptor.ClusterValidationStreamServerInterceptor(),
 			interceptor.ServerIDValidationStreamServerInterceptor(func() int64 {
 				if s.serverID.Load() == 0 {
-					s.serverID.Store(paramtable.GetNodeID())
+					s.serverID.Store(s.dataCoord.(*datacoord.Server).GetServerID())
 				}
 				return s.serverID.Load()
 			}),

--- a/internal/distributed/datanode/service.go
+++ b/internal/distributed/datanode/service.go
@@ -91,7 +91,7 @@ func NewServer(ctx context.Context, factory dependency.Factory) (*Server, error)
 	}
 
 	s.serverID.Store(paramtable.GetNodeID())
-	s.datanode = dn.NewDataNode(s.ctx, s.factory, s.serverID.Load())
+	s.datanode = dn.NewDataNode(s.ctx, s.factory)
 	return s, nil
 }
 


### PR DESCRIPTION
issue: #31516

background: the server id field in data node is redundant. session id already provides the source of truth.