### PR TITLE
fix: Skip unstable `TestMultiLogicalExprsOptimization` case

### DIFF
--- a/internal/core/unittest/test_expr.cpp
+++ b/internal/core/unittest/test_expr.cpp
@@ -1245,6 +1245,7 @@ TEST_P(ExprTest, TestCompareExpr) {
 }
 
 TEST_P(ExprTest, TestMultiLogicalExprsOptimization) {
+    GTEST_SKIP() << "Skip unstable case, see also https://github.com/milvus-io/milvus/issues/31586";
     auto schema = std::make_shared<Schema>();
     auto vec_fid = schema->AddDebugField("fakevec", data_type, 16, metric_type);
     auto int64_fid = schema->AddDebugField("int64", DataType::INT64);

--- a/internal/core/unittest/test_expr.cpp
+++ b/internal/core/unittest/test_expr.cpp
@@ -1245,7 +1245,8 @@ TEST_P(ExprTest, TestCompareExpr) {
 }
 
 TEST_P(ExprTest, TestMultiLogicalExprsOptimization) {
-    GTEST_SKIP() << "Skip unstable case, see also https://github.com/milvus-io/milvus/issues/31586";
+    GTEST_SKIP() << "Skip unstable case, see also "
+                    "https://github.com/milvus-io/milvus/issues/31586";
     auto schema = std::make_shared<Schema>();
     auto vec_fid = schema->AddDebugField("fakevec", data_type, 16, metric_type);
     auto int64_fid = schema->AddDebugField("int64", DataType::INT64);


### PR DESCRIPTION
See also #31586