### PR TITLE
fix: Skip release duplicate l0 segment (#31540)

### DIFF
--- a/internal/querycoordv2/checkers/segment_checker_test.go
+++ b/internal/querycoordv2/checkers/segment_checker_test.go
@@ -240,22 +240,17 @@ func (suite *SegmentCheckerTestSuite) TestLoadL0Segments() {
 	// seg l0 segment exist on a non delegator node
 	checker.targetMgr.UpdateCollectionNextTarget(int64(1))
 	checker.dist.SegmentDistManager.Update(1, utils.CreateTestSegment(1, 1, 1, 1, 1, "test-insert-channel"))
-	// test load l0 segments to delegator and release the one on non delegator
+	// test load l0 segments to delegator
 	tasks = checker.Check(context.TODO())
-	suite.Len(tasks, 2)
-	for _, t := range tasks {
-		suite.Len(t.Actions(), 1)
-		action, ok = t.Actions()[0].(*task.SegmentAction)
-		suite.True(ok)
-		suite.EqualValues(1, tasks[0].ReplicaID())
-		suite.EqualValues(1, action.SegmentID())
-		suite.Equal(t.Priority(), task.TaskPriorityNormal)
-		if action.Type() == task.ActionTypeGrow {
-			suite.EqualValues(2, action.Node())
-		} else {
-			suite.EqualValues(1, action.Node())
-		}
-	}
+	suite.Len(tasks, 1)
+	suite.Len(tasks[0].Actions(), 1)
+	action, ok = tasks[0].Actions()[0].(*task.SegmentAction)
+	suite.True(ok)
+	suite.EqualValues(1, tasks[0].ReplicaID())
+	suite.Equal(task.ActionTypeGrow, action.Type())
+	suite.EqualValues(1, action.SegmentID())
+	suite.EqualValues(2, action.Node())
+	suite.Equal(tasks[0].Priority(), task.TaskPriorityNormal)
 }
 
 func (suite *SegmentCheckerTestSuite) TestReleaseL0Segments() {
@@ -309,6 +304,18 @@ func (suite *SegmentCheckerTestSuite) TestReleaseL0Segments() {
 
 	// release duplicate l0 segment
 	tasks := checker.Check(context.TODO())
+	suite.Len(tasks, 0)
+
+	checker.dist.SegmentDistManager.Update(1)
+
+	// test release l0 segment which doesn't exist in target
+	suite.broker.ExpectedCalls = nil
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
+		channels, nil, nil)
+	checker.targetMgr.UpdateCollectionNextTarget(int64(1))
+	checker.targetMgr.UpdateCollectionCurrentTarget(int64(1))
+
+	tasks = checker.Check(context.TODO())
 	suite.Len(tasks, 1)
 	suite.Len(tasks[0].Actions(), 1)
 	action, ok := tasks[0].Actions()[0].(*task.SegmentAction)
@@ -316,7 +323,7 @@ func (suite *SegmentCheckerTestSuite) TestReleaseL0Segments() {
 	suite.EqualValues(1, tasks[0].ReplicaID())
 	suite.Equal(task.ActionTypeReduce, action.Type())
 	suite.EqualValues(1, action.SegmentID())
-	suite.EqualValues(1, action.Node())
+	suite.EqualValues(2, action.Node())
 	suite.Equal(tasks[0].Priority(), task.TaskPriorityNormal)
 
 	checker.dist.SegmentDistManager.Update(1)

--- a/internal/querycoordv2/task/task_test.go
+++ b/internal/querycoordv2/task/task_test.go
@@ -429,6 +429,7 @@ func (suite *TaskSuite) TestLoadSegmentTask() {
 		CollectionID: suite.collection,
 		ChannelName:  channel.ChannelName,
 	}))
+	suite.dist.LeaderViewManager.Update(targetNode, utils.CreateTestLeaderView(targetNode, suite.collection, channel.ChannelName, map[int64]int64{}, map[int64]*meta.Segment{}))
 	tasks := []Task{}
 	segments := make([]*datapb.SegmentInfo, 0)
 	for _, segment := range suite.loadSegments {
@@ -529,6 +530,7 @@ func (suite *TaskSuite) TestLoadSegmentTaskNotIndex() {
 		CollectionID: suite.collection,
 		ChannelName:  channel.ChannelName,
 	}))
+	suite.dist.LeaderViewManager.Update(targetNode, utils.CreateTestLeaderView(targetNode, suite.collection, channel.ChannelName, map[int64]int64{}, map[int64]*meta.Segment{}))
 	tasks := []Task{}
 	segments := make([]*datapb.SegmentInfo, 0)
 	for _, segment := range suite.loadSegments {
@@ -623,6 +625,7 @@ func (suite *TaskSuite) TestLoadSegmentTaskFailed() {
 		CollectionID: suite.collection,
 		ChannelName:  channel.ChannelName,
 	}))
+	suite.dist.LeaderViewManager.Update(targetNode, utils.CreateTestLeaderView(targetNode, suite.collection, channel.ChannelName, map[int64]int64{}, map[int64]*meta.Segment{}))
 	tasks := []Task{}
 	segments := make([]*datapb.SegmentInfo, 0)
 	for _, segment := range suite.loadSegments {
@@ -1005,6 +1008,7 @@ func (suite *TaskSuite) TestTaskCanceled() {
 		CollectionID: suite.collection,
 		ChannelName:  channel.ChannelName,
 	}))
+	suite.dist.LeaderViewManager.Update(targetNode, utils.CreateTestLeaderView(targetNode, suite.collection, channel.ChannelName, map[int64]int64{}, map[int64]*meta.Segment{}))
 	tasks := []Task{}
 	segmentInfos := []*datapb.SegmentInfo{}
 	for _, segment := range suite.loadSegments {
@@ -1097,6 +1101,7 @@ func (suite *TaskSuite) TestSegmentTaskStale() {
 		CollectionID: suite.collection,
 		ChannelName:  channel.ChannelName,
 	}))
+	suite.dist.LeaderViewManager.Update(targetNode, utils.CreateTestLeaderView(targetNode, suite.collection, channel.ChannelName, map[int64]int64{}, map[int64]*meta.Segment{}))
 	tasks := []Task{}
 	segments := make([]*datapb.SegmentInfo, 0)
 	for _, segment := range suite.loadSegments {

--- a/tests/integration/balance/balance_test.go
+++ b/tests/integration/balance/balance_test.go
@@ -188,17 +188,18 @@ func (s *BalanceTestSuit) TestBalanceOnSingleReplica() {
 		return len(resp.Channels) == 1 && len(resp.Segments) >= 2
 	}, 30*time.Second, 1*time.Second)
 
-	// check total segment number
+	// check total segment number and total channel number
 	s.Eventually(func() bool {
-		count := 0
+		segNum, chNum := 0, 0
 		for _, node := range s.Cluster.GetAllQueryNodes() {
 			resp1, err := node.GetDataDistribution(ctx, &querypb.GetDataDistributionRequest{})
 			s.NoError(err)
 			s.True(merr.Ok(resp1.GetStatus()))
-			count += len(resp1.Segments)
+			segNum += len(resp1.Segments)
+			chNum += len(resp1.Channels)
 		}
-		return count == 8
-	}, 10*time.Second, 1*time.Second)
+		return segNum == 8 && chNum == 2
+	}, 30*time.Second, 1*time.Second)
 }
 
 func (s *BalanceTestSuit) TestBalanceOnMultiReplica() {
@@ -244,17 +245,18 @@ func (s *BalanceTestSuit) TestBalanceOnMultiReplica() {
 		return len(resp.Channels) == 1 && len(resp.Segments) >= 2
 	}, 30*time.Second, 1*time.Second)
 
-	// check total segment num
+	// check total segment number and total channel number
 	s.Eventually(func() bool {
-		count := 0
+		segNum, chNum := 0, 0
 		for _, node := range s.Cluster.GetAllQueryNodes() {
 			resp1, err := node.GetDataDistribution(ctx, &querypb.GetDataDistributionRequest{})
 			s.NoError(err)
 			s.True(merr.Ok(resp1.GetStatus()))
-			count += len(resp1.Segments)
+			segNum += len(resp1.Segments)
+			chNum += len(resp1.Channels)
 		}
-		return count == 16
-	}, 10*time.Second, 1*time.Second)
+		return segNum == 16 && chNum == 4
+	}, 30*time.Second, 1*time.Second)
 }
 
 func (s *BalanceTestSuit) TestNodeDown() {


### PR DESCRIPTION
issue: #31480 #31481
pr: #31540

release duplicate l0 segment task, which execute on old delegator may cause segment lack, and execute on new delegator may break new delegator's leader view.

This PR skip release duplicate l0 segment by segment_checker, cause l0 segment will be released with unsub channel

---------