### PR TITLE
fix: Remove unnecessary deleteSession operation

### DIFF
--- a/internal/util/sessionutil/session_util.go
+++ b/internal/util/sessionutil/session_util.go
@@ -930,24 +930,10 @@ func (s *Session) cancelKeepAlive() {
 	}
 }
 
-func (s *Session) deleteSession() bool {
-	if s.etcdCli == nil {
-		log.Error("failed to delete session due to nil etcdCli!")
-		return false
-	}
-	_, err := s.etcdCli.Delete(context.Background(), s.getCompleteKey())
-	if err != nil {
-		log.Warn("failed to delete session", zap.Error(err))
-		return false
-	}
-	return true
-}
-
 func (s *Session) Stop() {
 	s.isStopped.Store(true)
 	s.Revoke(time.Second)
 	s.cancelKeepAlive()
-	s.deleteSession()
 	s.wg.Wait()
 }
 

--- a/internal/util/sessionutil/session_util_test.go
+++ b/internal/util/sessionutil/session_util_test.go
@@ -448,42 +448,6 @@ func TestSesssionMarshal(t *testing.T) {
 	assert.Equal(t, s.Version.String(), s2.Version.String())
 }
 
-func TestSesssionDelete(t *testing.T) {
-	paramtable.Init()
-	params := paramtable.Get()
-	endpoints := params.EtcdCfg.Endpoints.GetValue()
-	etcdEndpoints := strings.Split(endpoints, ",")
-	etcdCli, err := etcd.GetRemoteEtcdClient(etcdEndpoints)
-	require.NoError(t, err)
-	defer etcdCli.Close()
-
-	// Empty etcdCli
-	s := &Session{
-		SessionRaw: SessionRaw{
-			ServerID:   1,
-			ServerName: "test",
-			Address:    "localhost",
-		},
-		Version: common.Version,
-	}
-	res := s.deleteSession()
-	assert.False(t, res)
-
-	// Closed etcdCli
-	s = &Session{
-		SessionRaw: SessionRaw{
-			ServerID:   1,
-			ServerName: "test",
-			Address:    "localhost",
-		},
-		Version: common.Version,
-	}
-	s.etcdCli = etcdCli
-	etcdCli.Close()
-	res = s.deleteSession()
-	assert.False(t, res)
-}
-
 func TestSessionUnmarshal(t *testing.T) {
 	t.Run("json failure", func(t *testing.T) {
 		s := &Session{}


### PR DESCRIPTION
See also #31628

The `Revoke` operation shall delete all keys related to the lease attaching to. This `deleteSession` operation may also remove the session key in next epoch by mistake and cause chaos session status