### PR TITLE
enhance: Release blobs in sync task once sync is completed (#31661)

### DIFF
--- a/internal/datanode/syncmgr/task.go
+++ b/internal/datanode/syncmgr/task.go
@@ -216,6 +216,13 @@ func (t *SyncTask) Run() (err error) {
 		metrics.DataNodeAutoFlushBufferCount.WithLabelValues(fmt.Sprint(paramtable.GetNodeID()), metrics.SuccessLabel, t.level.String()).Inc()
 	}
 	metrics.DataNodeFlushBufferCount.WithLabelValues(fmt.Sprint(paramtable.GetNodeID()), metrics.SuccessLabel, t.level.String()).Inc()
+
+	// free blobs and data
+	t.binlogBlobs = nil
+	t.deltaBlob = nil
+	t.mergedStatsBlob = nil
+	t.batchStatsBlob = nil
+	t.segmentData = nil
 	return nil
 }
 


### PR DESCRIPTION
Once the synchronization of the sync task is completed, it's necessary to release the blob within the sync task, as the caller may continue to reference it.

issue: https://github.com/milvus-io/milvus/issues/31545

pr: #31661