### PR TITLE
fix: [skip-e2e] use zstd-sys 2.0.9

### DIFF
--- a/internal/core/thirdparty/tantivy/tantivy-binding/Cargo.toml
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/Cargo.toml
@@ -6,10 +6,11 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tantivy = "0.21.0"
+tantivy = "=0.21.1"
 futures = "0.3.21"
 libc = "0.2"
 scopeguard = "1.2"
+zstd-sys = "=2.0.9"
 
 [build-dependencies]
 cbindgen = "0.26.0"


### PR DESCRIPTION
fix: #31681 
/kind improvement