### PR TITLE
enhance: ban groupby on binary vector(#31134)

### DIFF
--- a/internal/core/src/query/GroupByOperator.h
+++ b/internal/core/src/query/GroupByOperator.h
@@ -157,9 +157,8 @@ PrepareVectorIteratorsFromIndex(const SearchInfo& search_info,
                 "group_by operation will be terminated",
                 e.what());
             throw std::runtime_error(
-                "Failed to groupBy, please check the index type, trying to "
-                "groupBy on unsupported index type will fail, currently only "
-                "support ivf-flat, ivf_cc and HNSW");
+                "Failed to groupBy, current index:" + index.GetIndexType() +
+                " doesn't support search_group_by");
         }
         return true;
     }

--- a/pkg/util/typeutil/schema.go
+++ b/pkg/util/typeutil/schema.go
@@ -1075,6 +1075,12 @@ func GetField(schema *schemapb.CollectionSchema, fieldID int64) *schemapb.FieldS
 	})
 }
 
+func GetFieldByName(schema *schemapb.CollectionSchema, fieldName string) *schemapb.FieldSchema {
+	return lo.FindOrElse(schema.GetFields(), nil, func(field *schemapb.FieldSchema) bool {
+		return field.GetName() == fieldName
+	})
+}
+
 func IsPrimaryFieldDataExist(datas []*schemapb.FieldData, primaryFieldSchema *schemapb.FieldSchema) bool {
 	primaryFieldID := primaryFieldSchema.FieldID
 	primaryFieldName := primaryFieldSchema.Name


### PR DESCRIPTION
Cherry-pick from master
pr: https://github.com/milvus-io/milvus/pull/31659
See also: https://github.com/milvus-io/milvus/issues/31134

Currently, don't support brute force search iterator for binary_vector so group_by in such cases will fail and to avoid inconsistent behavior, we ban groupby on binary vector for the time being.