### PR TITLE
enhance: Remove target id from querynode

### DIFF
--- a/internal/distributed/querynode/client/client.go
+++ b/internal/distributed/querynode/client/client.go
@@ -31,7 +31,6 @@ import (
 	"github.com/milvus-io/milvus/internal/util/grpcclient"
 	"github.com/milvus-io/milvus/internal/util/sessionutil"
 	"github.com/milvus-io/milvus/pkg/log"
-	"github.com/milvus-io/milvus/pkg/util/commonpbutil"
 	"github.com/milvus-io/milvus/pkg/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
@@ -122,10 +121,6 @@ func (c *Client) GetStatisticsChannel(ctx context.Context, req *internalpb.GetSt
 
 // WatchDmChannels watches the channels about data manipulation.
 func (c *Client) WatchDmChannels(ctx context.Context, req *querypb.WatchDmChannelsRequest, _ ...grpc.CallOption) (*commonpb.Status, error) {
-	req = typeutil.Clone(req)
-	commonpbutil.UpdateMsgBase(
-		req.GetBase(),
-		commonpbutil.FillMsgBaseFromClient(c.nodeID))
 	return wrapGrpcCall(ctx, c, func(client querypb.QueryNodeClient) (*commonpb.Status, error) {
 		return client.WatchDmChannels(ctx, req)
 	})
@@ -133,10 +128,6 @@ func (c *Client) WatchDmChannels(ctx context.Context, req *querypb.WatchDmChanne
 
 // UnsubDmChannel unsubscribes the channels about data manipulation.
 func (c *Client) UnsubDmChannel(ctx context.Context, req *querypb.UnsubDmChannelRequest, _ ...grpc.CallOption) (*commonpb.Status, error) {
-	req = typeutil.Clone(req)
-	commonpbutil.UpdateMsgBase(
-		req.GetBase(),
-		commonpbutil.FillMsgBaseFromClient(c.nodeID))
 	return wrapGrpcCall(ctx, c, func(client querypb.QueryNodeClient) (*commonpb.Status, error) {
 		return client.UnsubDmChannel(ctx, req)
 	})
@@ -144,10 +135,6 @@ func (c *Client) UnsubDmChannel(ctx context.Context, req *querypb.UnsubDmChannel
 
 // LoadSegments loads the segments to search.
 func (c *Client) LoadSegments(ctx context.Context, req *querypb.LoadSegmentsRequest, _ ...grpc.CallOption) (*commonpb.Status, error) {
-	req = typeutil.Clone(req)
-	commonpbutil.UpdateMsgBase(
-		req.GetBase(),
-		commonpbutil.FillMsgBaseFromClient(c.nodeID))
 	return wrapGrpcCall(ctx, c, func(client querypb.QueryNodeClient) (*commonpb.Status, error) {
 		return client.LoadSegments(ctx, req)
 	})
@@ -155,10 +142,6 @@ func (c *Client) LoadSegments(ctx context.Context, req *querypb.LoadSegmentsRequ
 
 // ReleaseCollection releases the data of the specified collection in QueryNode.
 func (c *Client) ReleaseCollection(ctx context.Context, req *querypb.ReleaseCollectionRequest, _ ...grpc.CallOption) (*commonpb.Status, error) {
-	req = typeutil.Clone(req)
-	commonpbutil.UpdateMsgBase(
-		req.GetBase(),
-		commonpbutil.FillMsgBaseFromClient(c.nodeID))
 	return wrapGrpcCall(ctx, c, func(client querypb.QueryNodeClient) (*commonpb.Status, error) {
 		return client.ReleaseCollection(ctx, req)
 	})
@@ -166,10 +149,6 @@ func (c *Client) ReleaseCollection(ctx context.Context, req *querypb.ReleaseColl
 
 // LoadPartitions updates partitions meta info in QueryNode.
 func (c *Client) LoadPartitions(ctx context.Context, req *querypb.LoadPartitionsRequest, _ ...grpc.CallOption) (*commonpb.Status, error) {
-	req = typeutil.Clone(req)
-	commonpbutil.UpdateMsgBase(
-		req.GetBase(),
-		commonpbutil.FillMsgBaseFromClient(c.nodeID))
 	return wrapGrpcCall(ctx, c, func(client querypb.QueryNodeClient) (*commonpb.Status, error) {
 		return client.LoadPartitions(ctx, req)
 	})
@@ -177,10 +156,6 @@ func (c *Client) LoadPartitions(ctx context.Context, req *querypb.LoadPartitions
 
 // ReleasePartitions releases the data of the specified partitions in QueryNode.
 func (c *Client) ReleasePartitions(ctx context.Context, req *querypb.ReleasePartitionsRequest, _ ...grpc.CallOption) (*commonpb.Status, error) {
-	req = typeutil.Clone(req)
-	commonpbutil.UpdateMsgBase(
-		req.GetBase(),
-		commonpbutil.FillMsgBaseFromClient(c.nodeID))
 	return wrapGrpcCall(ctx, c, func(client querypb.QueryNodeClient) (*commonpb.Status, error) {
 		return client.ReleasePartitions(ctx, req)
 	})
@@ -188,10 +163,6 @@ func (c *Client) ReleasePartitions(ctx context.Context, req *querypb.ReleasePart
 
 // ReleaseSegments releases the data of the specified segments in QueryNode.
 func (c *Client) ReleaseSegments(ctx context.Context, req *querypb.ReleaseSegmentsRequest, _ ...grpc.CallOption) (*commonpb.Status, error) {
-	req = typeutil.Clone(req)
-	commonpbutil.UpdateMsgBase(
-		req.GetBase(),
-		commonpbutil.FillMsgBaseFromClient(c.nodeID))
 	return wrapGrpcCall(ctx, c, func(client querypb.QueryNodeClient) (*commonpb.Status, error) {
 		return client.ReleaseSegments(ctx, req)
 	})
@@ -253,10 +224,6 @@ func (c *Client) QueryStreamSegments(ctx context.Context, req *querypb.QueryRequ
 
 // GetSegmentInfo gets the information of the specified segments in QueryNode.
 func (c *Client) GetSegmentInfo(ctx context.Context, req *querypb.GetSegmentInfoRequest, _ ...grpc.CallOption) (*querypb.GetSegmentInfoResponse, error) {
-	req = typeutil.Clone(req)
-	commonpbutil.UpdateMsgBase(
-		req.GetBase(),
-		commonpbutil.FillMsgBaseFromClient(c.nodeID))
 	return wrapGrpcCall(ctx, c, func(client querypb.QueryNodeClient) (*querypb.GetSegmentInfoResponse, error) {
 		return client.GetSegmentInfo(ctx, req)
 	})
@@ -264,10 +231,6 @@ func (c *Client) GetSegmentInfo(ctx context.Context, req *querypb.GetSegmentInfo
 
 // SyncReplicaSegments syncs replica node segments information to shard leaders.
 func (c *Client) SyncReplicaSegments(ctx context.Context, req *querypb.SyncReplicaSegmentsRequest, _ ...grpc.CallOption) (*commonpb.Status, error) {
-	req = typeutil.Clone(req)
-	commonpbutil.UpdateMsgBase(
-		req.GetBase(),
-		commonpbutil.FillMsgBaseFromClient(c.nodeID))
 	return wrapGrpcCall(ctx, c, func(client querypb.QueryNodeClient) (*commonpb.Status, error) {
 		return client.SyncReplicaSegments(ctx, req)
 	})
@@ -275,10 +238,6 @@ func (c *Client) SyncReplicaSegments(ctx context.Context, req *querypb.SyncRepli
 
 // ShowConfigurations gets specified configurations para of QueryNode
 func (c *Client) ShowConfigurations(ctx context.Context, req *internalpb.ShowConfigurationsRequest, _ ...grpc.CallOption) (*internalpb.ShowConfigurationsResponse, error) {
-	req = typeutil.Clone(req)
-	commonpbutil.UpdateMsgBase(
-		req.GetBase(),
-		commonpbutil.FillMsgBaseFromClient(c.nodeID))
 	return wrapGrpcCall(ctx, c, func(client querypb.QueryNodeClient) (*internalpb.ShowConfigurationsResponse, error) {
 		return client.ShowConfigurations(ctx, req)
 	})
@@ -286,10 +245,6 @@ func (c *Client) ShowConfigurations(ctx context.Context, req *internalpb.ShowCon
 
 // GetMetrics gets the metrics information of QueryNode.
 func (c *Client) GetMetrics(ctx context.Context, req *milvuspb.GetMetricsRequest, _ ...grpc.CallOption) (*milvuspb.GetMetricsResponse, error) {
-	req = typeutil.Clone(req)
-	commonpbutil.UpdateMsgBase(
-		req.GetBase(),
-		commonpbutil.FillMsgBaseFromClient(c.nodeID))
 	return wrapGrpcCall(ctx, c, func(client querypb.QueryNodeClient) (*milvuspb.GetMetricsResponse, error) {
 		return client.GetMetrics(ctx, req)
 	})
@@ -302,20 +257,12 @@ func (c *Client) GetStatistics(ctx context.Context, request *querypb.GetStatisti
 }
 
 func (c *Client) GetDataDistribution(ctx context.Context, req *querypb.GetDataDistributionRequest, _ ...grpc.CallOption) (*querypb.GetDataDistributionResponse, error) {
-	req = typeutil.Clone(req)
-	commonpbutil.UpdateMsgBase(
-		req.GetBase(),
-		commonpbutil.FillMsgBaseFromClient(c.nodeID))
 	return wrapGrpcCall(ctx, c, func(client querypb.QueryNodeClient) (*querypb.GetDataDistributionResponse, error) {
 		return client.GetDataDistribution(ctx, req)
 	})
 }
 
 func (c *Client) SyncDistribution(ctx context.Context, req *querypb.SyncDistributionRequest, _ ...grpc.CallOption) (*commonpb.Status, error) {
-	req = typeutil.Clone(req)
-	commonpbutil.UpdateMsgBase(
-		req.GetBase(),
-		commonpbutil.FillMsgBaseFromClient(c.nodeID))
 	return wrapGrpcCall(ctx, c, func(client querypb.QueryNodeClient) (*commonpb.Status, error) {
 		return client.SyncDistribution(ctx, req)
 	})
@@ -323,11 +270,6 @@ func (c *Client) SyncDistribution(ctx context.Context, req *querypb.SyncDistribu
 
 // Delete is used to forward delete message between delegator and workers.
 func (c *Client) Delete(ctx context.Context, req *querypb.DeleteRequest, _ ...grpc.CallOption) (*commonpb.Status, error) {
-	req = typeutil.Clone(req)
-	commonpbutil.UpdateMsgBase(
-		req.GetBase(),
-		commonpbutil.FillMsgBaseFromClient(c.nodeID),
-	)
 	return wrapGrpcCall(ctx, c, func(client querypb.QueryNodeClient) (*commonpb.Status, error) {
 		return client.Delete(ctx, req)
 	})

--- a/internal/proxy/task_hybrid_search.go
+++ b/internal/proxy/task_hybrid_search.go
@@ -230,13 +230,11 @@ func (t *hybridSearchTask) PreExecute(ctx context.Context) error {
 }
 
 func (t *hybridSearchTask) hybridSearchShard(ctx context.Context, nodeID int64, qn types.QueryNodeClient, channel string) error {
-	hybridSearchReq := typeutil.Clone(t.HybridSearchRequest)
-	hybridSearchReq.GetBase().TargetID = nodeID
 	if t.partitionKeyMode {
 		t.PartitionIDs = t.partitionIDsSet.Collect()
 	}
 	req := &querypb.HybridSearchRequest{
-		Req:             hybridSearchReq,
+		Req:             t.HybridSearchRequest,
 		DmlChannels:     []string{channel},
 		TotalChannelNum: int32(1),
 	}

--- a/internal/proxy/task_query.go
+++ b/internal/proxy/task_query.go
@@ -523,14 +523,12 @@ func (t *queryTask) queryShard(ctx context.Context, nodeID int64, qn types.Query
 		}
 	}
 
-	retrieveReq := typeutil.Clone(t.RetrieveRequest)
-	retrieveReq.GetBase().TargetID = nodeID
 	if needOverrideMvcc && mvccTs > 0 {
-		retrieveReq.MvccTimestamp = mvccTs
+		t.RetrieveRequest.MvccTimestamp = mvccTs
 	}
 
 	req := &querypb.QueryRequest{
-		Req:         retrieveReq,
+		Req:         t.RetrieveRequest,
 		DmlChannels: []string{channel},
 		Scope:       querypb.DataScope_All,
 	}

--- a/internal/proxy/task_search.go
+++ b/internal/proxy/task_search.go
@@ -490,10 +490,8 @@ func (t *searchTask) PostExecute(ctx context.Context) error {
 }
 
 func (t *searchTask) searchShard(ctx context.Context, nodeID int64, qn types.QueryNodeClient, channel string) error {
-	searchReq := typeutil.Clone(t.SearchRequest)
-	searchReq.GetBase().TargetID = nodeID
 	req := &querypb.SearchRequest{
-		Req:             searchReq,
+		Req:             t.SearchRequest,
 		DmlChannels:     []string{channel},
 		Scope:           querypb.DataScope_All,
 		TotalChannelNum: int32(1),

--- a/internal/proxy/task_statistic.go
+++ b/internal/proxy/task_statistic.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 
 	"github.com/cockroachdb/errors"
-	"github.com/golang/protobuf/proto"
 	"go.opentelemetry.io/otel"
 	"go.uber.org/zap"
 
@@ -275,10 +274,8 @@ func (g *getStatisticsTask) getStatisticsFromQueryNode(ctx context.Context) erro
 }
 
 func (g *getStatisticsTask) getStatisticsShard(ctx context.Context, nodeID int64, qn types.QueryNodeClient, channel string) error {
-	nodeReq := proto.Clone(g.GetStatisticsRequest).(*internalpb.GetStatisticsRequest)
-	nodeReq.Base.TargetID = nodeID
 	req := &querypb.GetStatisticsRequest{
-		Req:         nodeReq,
+		Req:         g.GetStatisticsRequest,
 		DmlChannels: []string{channel},
 		Scope:       querypb.DataScope_All,
 	}

--- a/internal/querynodev2/cluster/worker.go
+++ b/internal/querynodev2/cluster/worker.go
@@ -88,9 +88,7 @@ func (w *remoteWorker) ReleaseSegments(ctx context.Context, req *querypb.Release
 }
 
 func (w *remoteWorker) Delete(ctx context.Context, req *querypb.DeleteRequest) error {
-	log := log.Ctx(ctx).With(
-		zap.Int64("workerID", req.GetBase().GetTargetID()),
-	)
+	log := log.Ctx(ctx)
 	status, err := w.client.Delete(ctx, req)
 	if err := merr.CheckRPCCall(status, err); err != nil {
 		if errors.Is(err, merr.ErrServiceUnimplemented) {

--- a/internal/querynodev2/delegator/delegator.go
+++ b/internal/querynodev2/delegator/delegator.go
@@ -174,7 +174,6 @@ func (sd *shardDelegator) SyncDistribution(ctx context.Context, entries ...Segme
 func (sd *shardDelegator) modifySearchRequest(req *querypb.SearchRequest, scope querypb.DataScope, segmentIDs []int64, targetID int64) *querypb.SearchRequest {
 	nodeReq := proto.Clone(req).(*querypb.SearchRequest)
 	nodeReq.Scope = scope
-	nodeReq.Req.Base.TargetID = targetID
 	nodeReq.SegmentIDs = segmentIDs
 	nodeReq.FromShardLeader = true
 	nodeReq.DmlChannels = []string{sd.vchannelName}
@@ -184,7 +183,6 @@ func (sd *shardDelegator) modifySearchRequest(req *querypb.SearchRequest, scope 
 func (sd *shardDelegator) modifyQueryRequest(req *querypb.QueryRequest, scope querypb.DataScope, segmentIDs []int64, targetID int64) *querypb.QueryRequest {
 	nodeReq := proto.Clone(req).(*querypb.QueryRequest)
 	nodeReq.Scope = scope
-	nodeReq.Req.Base.TargetID = targetID
 	nodeReq.SegmentIDs = segmentIDs
 	nodeReq.FromShardLeader = true
 	nodeReq.DmlChannels = []string{sd.vchannelName}
@@ -563,7 +561,6 @@ func (sd *shardDelegator) GetStatistics(ctx context.Context, req *querypb.GetSta
 
 	tasks, err := organizeSubTask(ctx, req, sealed, growing, sd, func(req *querypb.GetStatisticsRequest, scope querypb.DataScope, segmentIDs []int64, targetID int64) *querypb.GetStatisticsRequest {
 		nodeReq := proto.Clone(req).(*querypb.GetStatisticsRequest)
-		nodeReq.GetReq().GetBase().TargetID = targetID
 		nodeReq.Scope = scope
 		nodeReq.SegmentIDs = segmentIDs
 		nodeReq.FromShardLeader = true

--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -279,7 +279,7 @@ func (sd *shardDelegator) applyDelete(ctx context.Context, nodeID int64, worker 
 				}
 
 				err := worker.Delete(ctx, &querypb.DeleteRequest{
-					Base:         commonpbutil.NewMsgBase(commonpbutil.WithTargetID(nodeID)),
+					Base:         commonpbutil.NewMsgBase(),
 					CollectionId: sd.collectionID,
 					PartitionId:  segmentEntry.PartitionID,
 					VchannelName: sd.vchannelName,
@@ -408,7 +408,6 @@ func (sd *shardDelegator) LoadSegments(ctx context.Context, req *querypb.LoadSeg
 		return err
 	}
 
-	req.Base.TargetID = req.GetDstNodeID()
 	log.Debug("worker loads segments...")
 
 	sLoad := func(ctx context.Context, req *querypb.LoadSegmentsRequest) error {
@@ -620,7 +619,7 @@ func (sd *shardDelegator) loadStreamDelete(ctx context.Context,
 				zap.Int64("deleteRowNum", deleteData.RowCount),
 			)
 			err := worker.Delete(ctx, &querypb.DeleteRequest{
-				Base:         commonpbutil.NewMsgBase(commonpbutil.WithTargetID(targetNodeID)),
+				Base:         commonpbutil.NewMsgBase(),
 				CollectionId: info.GetCollectionID(),
 				PartitionId:  info.GetPartitionID(),
 				SegmentId:    info.GetSegmentID(),
@@ -667,7 +666,7 @@ func (sd *shardDelegator) loadStreamDelete(ctx context.Context,
 		if deleteData.RowCount > 0 {
 			log.Info("forward delete to worker...", zap.Int64("deleteRowNum", deleteData.RowCount))
 			err := worker.Delete(ctx, &querypb.DeleteRequest{
-				Base:         commonpbutil.NewMsgBase(commonpbutil.WithTargetID(targetNodeID)),
+				Base:         commonpbutil.NewMsgBase(),
 				CollectionId: info.GetCollectionID(),
 				PartitionId:  info.GetPartitionID(),
 				SegmentId:    info.GetSegmentID(),
@@ -843,7 +842,6 @@ func (sd *shardDelegator) ReleaseSegments(ctx context.Context, req *querypb.Rele
 			)
 			return err
 		}
-		req.Base.TargetID = targetNodeID
 		err = worker.ReleaseSegments(ctx, req)
 		if err != nil {
 			log.Warn("worker failed to release segments",

--- a/internal/querynodev2/delegator/delegator_data_test.go
+++ b/internal/querynodev2/delegator/delegator_data_test.go
@@ -971,7 +971,6 @@ func (s *DelegatorDataSuite) TestReleaseSegment() {
 		Scope:        querypb.DataScope_All,
 		NeedTransfer: true,
 	}
-	req.Base.TargetID = 1
 	err = s.delegator.ReleaseSegments(ctx, req, false)
 	s.NoError(err)
 }

--- a/internal/querynodev2/delegator/delegator_test.go
+++ b/internal/querynodev2/delegator/delegator_test.go
@@ -273,7 +273,6 @@ func (s *DelegatorSuite) TestSearch() {
 
 		worker1.EXPECT().SearchSegments(mock.Anything, mock.AnythingOfType("*querypb.SearchRequest")).
 			Run(func(_ context.Context, req *querypb.SearchRequest) {
-				s.EqualValues(1, req.Req.GetBase().GetTargetID())
 				s.True(req.GetFromShardLeader())
 				if req.GetScope() == querypb.DataScope_Streaming {
 					s.EqualValues([]string{s.vchannelName}, req.GetDmlChannels())
@@ -286,7 +285,6 @@ func (s *DelegatorSuite) TestSearch() {
 			}).Return(&internalpb.SearchResults{}, nil)
 		worker2.EXPECT().SearchSegments(mock.Anything, mock.AnythingOfType("*querypb.SearchRequest")).
 			Run(func(_ context.Context, req *querypb.SearchRequest) {
-				s.EqualValues(2, req.Req.GetBase().GetTargetID())
 				s.True(req.GetFromShardLeader())
 				s.Equal(querypb.DataScope_Historical, req.GetScope())
 				s.EqualValues([]string{s.vchannelName}, req.GetDmlChannels())
@@ -341,7 +339,6 @@ func (s *DelegatorSuite) TestSearch() {
 		worker1.EXPECT().SearchSegments(mock.Anything, mock.AnythingOfType("*querypb.SearchRequest")).Return(nil, errors.New("mock error"))
 		worker2.EXPECT().SearchSegments(mock.Anything, mock.AnythingOfType("*querypb.SearchRequest")).
 			Run(func(_ context.Context, req *querypb.SearchRequest) {
-				s.EqualValues(2, req.Req.GetBase().GetTargetID())
 				s.True(req.GetFromShardLeader())
 				s.Equal(querypb.DataScope_Historical, req.GetScope())
 				s.EqualValues([]string{s.vchannelName}, req.GetDmlChannels())
@@ -381,7 +378,6 @@ func (s *DelegatorSuite) TestSearch() {
 		}, nil)
 		worker2.EXPECT().SearchSegments(mock.Anything, mock.AnythingOfType("*querypb.SearchRequest")).
 			Run(func(_ context.Context, req *querypb.SearchRequest) {
-				s.EqualValues(2, req.Req.GetBase().GetTargetID())
 				s.True(req.GetFromShardLeader())
 				s.Equal(querypb.DataScope_Historical, req.GetScope())
 				s.EqualValues([]string{s.vchannelName}, req.GetDmlChannels())
@@ -494,7 +490,6 @@ func (s *DelegatorSuite) TestHybridSearch() {
 
 		worker1.EXPECT().SearchSegments(mock.Anything, mock.AnythingOfType("*querypb.SearchRequest")).
 			Run(func(_ context.Context, req *querypb.SearchRequest) {
-				s.EqualValues(1, req.Req.GetBase().GetTargetID())
 				s.True(req.GetFromShardLeader())
 				if req.GetScope() == querypb.DataScope_Streaming {
 					s.EqualValues([]string{s.vchannelName}, req.GetDmlChannels())
@@ -507,7 +502,6 @@ func (s *DelegatorSuite) TestHybridSearch() {
 			}).Return(&internalpb.SearchResults{}, nil)
 		worker2.EXPECT().SearchSegments(mock.Anything, mock.AnythingOfType("*querypb.SearchRequest")).
 			Run(func(_ context.Context, req *querypb.SearchRequest) {
-				s.EqualValues(2, req.Req.GetBase().GetTargetID())
 				s.True(req.GetFromShardLeader())
 				s.Equal(querypb.DataScope_Historical, req.GetScope())
 				s.EqualValues([]string{s.vchannelName}, req.GetDmlChannels())
@@ -568,7 +562,6 @@ func (s *DelegatorSuite) TestHybridSearch() {
 		worker1.EXPECT().SearchSegments(mock.Anything, mock.AnythingOfType("*querypb.SearchRequest")).Return(nil, errors.New("mock error"))
 		worker2.EXPECT().SearchSegments(mock.Anything, mock.AnythingOfType("*querypb.SearchRequest")).
 			Run(func(_ context.Context, req *querypb.SearchRequest) {
-				s.EqualValues(2, req.Req.GetBase().GetTargetID())
 				s.True(req.GetFromShardLeader())
 				s.Equal(querypb.DataScope_Historical, req.GetScope())
 				s.EqualValues([]string{s.vchannelName}, req.GetDmlChannels())
@@ -615,7 +608,6 @@ func (s *DelegatorSuite) TestHybridSearch() {
 		}, nil)
 		worker2.EXPECT().SearchSegments(mock.Anything, mock.AnythingOfType("*querypb.SearchRequest")).
 			Run(func(_ context.Context, req *querypb.SearchRequest) {
-				s.EqualValues(2, req.Req.GetBase().GetTargetID())
 				s.True(req.GetFromShardLeader())
 				s.Equal(querypb.DataScope_Historical, req.GetScope())
 				s.EqualValues([]string{s.vchannelName}, req.GetDmlChannels())
@@ -739,7 +731,6 @@ func (s *DelegatorSuite) TestQuery() {
 
 		worker1.EXPECT().QuerySegments(mock.Anything, mock.AnythingOfType("*querypb.QueryRequest")).
 			Run(func(_ context.Context, req *querypb.QueryRequest) {
-				s.EqualValues(1, req.Req.GetBase().GetTargetID())
 				s.True(req.GetFromShardLeader())
 				if req.GetScope() == querypb.DataScope_Streaming {
 					s.EqualValues([]string{s.vchannelName}, req.GetDmlChannels())
@@ -752,7 +743,6 @@ func (s *DelegatorSuite) TestQuery() {
 			}).Return(&internalpb.RetrieveResults{}, nil)
 		worker2.EXPECT().QuerySegments(mock.Anything, mock.AnythingOfType("*querypb.QueryRequest")).
 			Run(func(_ context.Context, req *querypb.QueryRequest) {
-				s.EqualValues(2, req.Req.GetBase().GetTargetID())
 				s.True(req.GetFromShardLeader())
 				s.Equal(querypb.DataScope_Historical, req.GetScope())
 				s.EqualValues([]string{s.vchannelName}, req.GetDmlChannels())
@@ -806,7 +796,6 @@ func (s *DelegatorSuite) TestQuery() {
 		worker1.EXPECT().QuerySegments(mock.Anything, mock.AnythingOfType("*querypb.QueryRequest")).Return(nil, errors.New("mock error"))
 		worker2.EXPECT().QuerySegments(mock.Anything, mock.AnythingOfType("*querypb.QueryRequest")).
 			Run(func(_ context.Context, req *querypb.QueryRequest) {
-				s.EqualValues(2, req.Req.GetBase().GetTargetID())
 				s.True(req.GetFromShardLeader())
 				s.Equal(querypb.DataScope_Historical, req.GetScope())
 				s.EqualValues([]string{s.vchannelName}, req.GetDmlChannels())
@@ -843,7 +832,6 @@ func (s *DelegatorSuite) TestQuery() {
 		}, nil)
 		worker2.EXPECT().QuerySegments(mock.Anything, mock.AnythingOfType("*querypb.QueryRequest")).
 			Run(func(_ context.Context, req *querypb.QueryRequest) {
-				s.EqualValues(2, req.Req.GetBase().GetTargetID())
 				s.True(req.GetFromShardLeader())
 				s.Equal(querypb.DataScope_Historical, req.GetScope())
 				s.EqualValues([]string{s.vchannelName}, req.GetDmlChannels())
@@ -936,7 +924,6 @@ func (s *DelegatorSuite) TestQueryStream() {
 
 		worker1.EXPECT().QueryStreamSegments(mock.Anything, mock.AnythingOfType("*querypb.QueryRequest"), mock.Anything).
 			Run(func(ctx context.Context, req *querypb.QueryRequest, srv streamrpc.QueryStreamServer) {
-				s.EqualValues(1, req.Req.GetBase().GetTargetID())
 				s.True(req.GetFromShardLeader())
 				if req.GetScope() == querypb.DataScope_Streaming {
 					s.EqualValues([]string{s.vchannelName}, req.GetDmlChannels())
@@ -959,7 +946,6 @@ func (s *DelegatorSuite) TestQueryStream() {
 
 		worker2.EXPECT().QueryStreamSegments(mock.Anything, mock.AnythingOfType("*querypb.QueryRequest"), mock.Anything).
 			Run(func(ctx context.Context, req *querypb.QueryRequest, srv streamrpc.QueryStreamServer) {
-				s.EqualValues(2, req.Req.GetBase().GetTargetID())
 				s.True(req.GetFromShardLeader())
 				s.Equal(querypb.DataScope_Historical, req.GetScope())
 				s.EqualValues([]string{s.vchannelName}, req.GetDmlChannels())
@@ -1092,7 +1078,6 @@ func (s *DelegatorSuite) TestQueryStream() {
 
 		worker2.EXPECT().QueryStreamSegments(mock.Anything, mock.AnythingOfType("*querypb.QueryRequest"), mock.Anything).
 			Run(func(ctx context.Context, req *querypb.QueryRequest, srv streamrpc.QueryStreamServer) {
-				s.EqualValues(2, req.Req.GetBase().GetTargetID())
 				s.True(req.GetFromShardLeader())
 				s.Equal(querypb.DataScope_Historical, req.GetScope())
 				s.EqualValues([]string{s.vchannelName}, req.GetDmlChannels())
@@ -1212,7 +1197,6 @@ func (s *DelegatorSuite) TestGetStats() {
 
 		worker1.EXPECT().GetStatistics(mock.Anything, mock.AnythingOfType("*querypb.GetStatisticsRequest")).
 			Run(func(_ context.Context, req *querypb.GetStatisticsRequest) {
-				s.EqualValues(1, req.Req.GetBase().GetTargetID())
 				s.True(req.GetFromShardLeader())
 				if req.GetScope() == querypb.DataScope_Streaming {
 					s.EqualValues([]string{s.vchannelName}, req.GetDmlChannels())
@@ -1225,7 +1209,6 @@ func (s *DelegatorSuite) TestGetStats() {
 			}).Return(&internalpb.GetStatisticsResponse{}, nil)
 		worker2.EXPECT().GetStatistics(mock.Anything, mock.AnythingOfType("*querypb.GetStatisticsRequest")).
 			Run(func(_ context.Context, req *querypb.GetStatisticsRequest) {
-				s.EqualValues(2, req.Req.GetBase().GetTargetID())
 				s.True(req.GetFromShardLeader())
 				s.Equal(querypb.DataScope_Historical, req.GetScope())
 				s.EqualValues([]string{s.vchannelName}, req.GetDmlChannels())
@@ -1261,7 +1244,6 @@ func (s *DelegatorSuite) TestGetStats() {
 		worker1.EXPECT().GetStatistics(mock.Anything, mock.AnythingOfType("*querypb.GetStatisticsRequest")).Return(nil, errors.New("mock error"))
 		worker2.EXPECT().GetStatistics(mock.Anything, mock.AnythingOfType("*querypb.GetStatisticsRequest")).
 			Run(func(_ context.Context, req *querypb.GetStatisticsRequest) {
-				s.EqualValues(2, req.Req.GetBase().GetTargetID())
 				s.True(req.GetFromShardLeader())
 				s.Equal(querypb.DataScope_Historical, req.GetScope())
 				s.EqualValues([]string{s.vchannelName}, req.GetDmlChannels())
@@ -1298,7 +1280,6 @@ func (s *DelegatorSuite) TestGetStats() {
 		}, nil)
 		worker2.EXPECT().GetStatistics(mock.Anything, mock.AnythingOfType("*querypb.GetStatisticsRequest")).
 			Run(func(_ context.Context, req *querypb.GetStatisticsRequest) {
-				s.EqualValues(2, req.Req.GetBase().GetTargetID())
 				s.True(req.GetFromShardLeader())
 				s.Equal(querypb.DataScope_Historical, req.GetScope())
 				s.EqualValues([]string{s.vchannelName}, req.GetDmlChannels())

--- a/internal/querynodev2/local_worker_test.go
+++ b/internal/querynodev2/local_worker_test.go
@@ -115,9 +115,7 @@ func (suite *LocalWorkerTestSuite) TestLoadSegment() {
 	// load empty
 	schema := segments.GenTestCollectionSchema(suite.collectionName, schemapb.DataType_Int64, true)
 	req := &querypb.LoadSegmentsRequest{
-		Base: &commonpb.MsgBase{
-			TargetID: suite.node.session.GetServerID(),
-		},
+		Base:         &commonpb.MsgBase{},
 		CollectionID: suite.collectionID,
 		Infos: lo.Map(suite.segmentIDs, func(segID int64, _ int) *querypb.SegmentLoadInfo {
 			return &querypb.SegmentLoadInfo{
@@ -135,9 +133,7 @@ func (suite *LocalWorkerTestSuite) TestLoadSegment() {
 
 func (suite *LocalWorkerTestSuite) TestReleaseSegment() {
 	req := &querypb.ReleaseSegmentsRequest{
-		Base: &commonpb.MsgBase{
-			TargetID: suite.node.session.GetServerID(),
-		},
+		Base:         &commonpb.MsgBase{},
 		CollectionID: suite.collectionID,
 		SegmentIDs:   suite.segmentIDs,
 	}

--- a/internal/querynodev2/services_test.go
+++ b/internal/querynodev2/services_test.go
@@ -147,8 +147,7 @@ func (suite *ServiceSuite) TearDownTest() {
 	// ReleaseSegment, avoid throwing an instance of 'std::system_error' when stop node
 	resp, err := suite.node.ReleaseSegments(ctx, &querypb.ReleaseSegmentsRequest{
 		Base: &commonpb.MsgBase{
-			MsgType:  commonpb.MsgType_ReleaseSegments,
-			TargetID: suite.node.session.ServerID,
+			MsgType: commonpb.MsgType_ReleaseSegments,
 		},
 		CollectionID: suite.collectionID,
 		PartitionIDs: suite.partitionIDs,
@@ -203,9 +202,8 @@ func (suite *ServiceSuite) TestGetStatistics_Normal() {
 	req := &querypb.GetStatisticsRequest{
 		Req: &internalpb.GetStatisticsRequest{
 			Base: &commonpb.MsgBase{
-				MsgType:  commonpb.MsgType_WatchDmChannels,
-				MsgID:    rand.Int63(),
-				TargetID: suite.node.session.ServerID,
+				MsgType: commonpb.MsgType_WatchDmChannels,
+				MsgID:   rand.Int63(),
 			},
 			CollectionID: suite.collectionID,
 			PartitionIDs: []int64{},
@@ -228,9 +226,8 @@ func (suite *ServiceSuite) TestGetStatistics_Failed() {
 	req := &querypb.GetStatisticsRequest{
 		Req: &internalpb.GetStatisticsRequest{
 			Base: &commonpb.MsgBase{
-				MsgType:  commonpb.MsgType_WatchDmChannels,
-				MsgID:    rand.Int63(),
-				TargetID: suite.node.session.ServerID,
+				MsgType: commonpb.MsgType_WatchDmChannels,
+				MsgID:   rand.Int63(),
 			},
 			CollectionID: suite.collectionID,
 			PartitionIDs: []int64{},
@@ -260,9 +257,8 @@ func (suite *ServiceSuite) TestWatchDmChannelsInt64() {
 
 	req := &querypb.WatchDmChannelsRequest{
 		Base: &commonpb.MsgBase{
-			MsgType:  commonpb.MsgType_WatchDmChannels,
-			MsgID:    rand.Int63(),
-			TargetID: suite.node.session.ServerID,
+			MsgType: commonpb.MsgType_WatchDmChannels,
+			MsgID:   rand.Int63(),
 		},
 		NodeID:       suite.node.session.ServerID,
 		CollectionID: suite.collectionID,
@@ -322,9 +318,8 @@ func (suite *ServiceSuite) TestWatchDmChannelsVarchar() {
 
 	req := &querypb.WatchDmChannelsRequest{
 		Base: &commonpb.MsgBase{
-			MsgType:  commonpb.MsgType_WatchDmChannels,
-			MsgID:    rand.Int63(),
-			TargetID: suite.node.session.ServerID,
+			MsgType: commonpb.MsgType_WatchDmChannels,
+			MsgID:   rand.Int63(),
 		},
 		NodeID:       suite.node.session.ServerID,
 		CollectionID: suite.collectionID,
@@ -390,9 +385,8 @@ func (suite *ServiceSuite) TestWatchDmChannels_Failed() {
 
 	req := &querypb.WatchDmChannelsRequest{
 		Base: &commonpb.MsgBase{
-			MsgType:  commonpb.MsgType_WatchDmChannels,
-			MsgID:    rand.Int63(),
-			TargetID: suite.node.session.ServerID,
+			MsgType: commonpb.MsgType_WatchDmChannels,
+			MsgID:   rand.Int63(),
 		},
 		NodeID:       suite.node.session.ServerID,
 		CollectionID: suite.collectionID,
@@ -481,9 +475,8 @@ func (suite *ServiceSuite) TestUnsubDmChannels_Normal() {
 	// data
 	req := &querypb.UnsubDmChannelRequest{
 		Base: &commonpb.MsgBase{
-			MsgType:  commonpb.MsgType_UnsubDmChannel,
-			MsgID:    rand.Int63(),
-			TargetID: suite.node.session.ServerID,
+			MsgType: commonpb.MsgType_UnsubDmChannel,
+			MsgID:   rand.Int63(),
 		},
 		NodeID:       suite.node.session.ServerID,
 		CollectionID: suite.collectionID,
@@ -506,9 +499,8 @@ func (suite *ServiceSuite) TestUnsubDmChannels_Failed() {
 	// data
 	req := &querypb.UnsubDmChannelRequest{
 		Base: &commonpb.MsgBase{
-			MsgType:  commonpb.MsgType_UnsubDmChannel,
-			MsgID:    rand.Int63(),
-			TargetID: suite.node.session.ServerID,
+			MsgType: commonpb.MsgType_UnsubDmChannel,
+			MsgID:   rand.Int63(),
 		},
 		NodeID:       suite.node.session.ServerID,
 		CollectionID: suite.collectionID,
@@ -588,8 +580,7 @@ func (suite *ServiceSuite) TestLoadSegments_Int64() {
 	for _, info := range infos {
 		req := &querypb.LoadSegmentsRequest{
 			Base: &commonpb.MsgBase{
-				MsgID:    rand.Int63(),
-				TargetID: suite.node.session.ServerID,
+				MsgID: rand.Int63(),
 			},
 			CollectionID:   suite.collectionID,
 			DstNodeID:      suite.node.session.ServerID,
@@ -624,8 +615,7 @@ func (suite *ServiceSuite) TestLoadSegments_VarChar() {
 	for _, info := range infos {
 		req := &querypb.LoadSegmentsRequest{
 			Base: &commonpb.MsgBase{
-				MsgID:    rand.Int63(),
-				TargetID: suite.node.session.ServerID,
+				MsgID: rand.Int63(),
 			},
 			CollectionID:   suite.collectionID,
 			DstNodeID:      suite.node.session.ServerID,
@@ -651,8 +641,7 @@ func (suite *ServiceSuite) TestLoadDeltaInt64() {
 	schema := segments.GenTestCollectionSchema(suite.collectionName, schemapb.DataType_Int64, false)
 	req := &querypb.LoadSegmentsRequest{
 		Base: &commonpb.MsgBase{
-			MsgID:    rand.Int63(),
-			TargetID: suite.node.session.ServerID,
+			MsgID: rand.Int63(),
 		},
 		CollectionID:  suite.collectionID,
 		DstNodeID:     suite.node.session.ServerID,
@@ -676,8 +665,7 @@ func (suite *ServiceSuite) TestLoadDeltaVarchar() {
 	schema := segments.GenTestCollectionSchema(suite.collectionName, schemapb.DataType_Int64, false)
 	req := &querypb.LoadSegmentsRequest{
 		Base: &commonpb.MsgBase{
-			MsgID:    rand.Int63(),
-			TargetID: suite.node.session.ServerID,
+			MsgID: rand.Int63(),
 		},
 		CollectionID:  suite.collectionID,
 		DstNodeID:     suite.node.session.ServerID,
@@ -714,8 +702,7 @@ func (suite *ServiceSuite) TestLoadIndex_Success() {
 
 	req := &querypb.LoadSegmentsRequest{
 		Base: &commonpb.MsgBase{
-			MsgID:    rand.Int63(),
-			TargetID: suite.node.session.ServerID,
+			MsgID: rand.Int63(),
 		},
 		CollectionID:  suite.collectionID,
 		DstNodeID:     suite.node.session.ServerID,
@@ -739,8 +726,7 @@ func (suite *ServiceSuite) TestLoadIndex_Success() {
 
 	req = &querypb.LoadSegmentsRequest{
 		Base: &commonpb.MsgBase{
-			MsgID:    rand.Int63(),
-			TargetID: suite.node.session.ServerID,
+			MsgID: rand.Int63(),
 		},
 		CollectionID:  suite.collectionID,
 		DstNodeID:     suite.node.session.ServerID,
@@ -785,8 +771,7 @@ func (suite *ServiceSuite) TestLoadIndex_Failed() {
 		})
 		req := &querypb.LoadSegmentsRequest{
 			Base: &commonpb.MsgBase{
-				MsgID:    rand.Int63(),
-				TargetID: suite.node.session.ServerID,
+				MsgID: rand.Int63(),
 			},
 			CollectionID:  suite.collectionID,
 			DstNodeID:     suite.node.session.ServerID,
@@ -819,8 +804,7 @@ func (suite *ServiceSuite) TestLoadIndex_Failed() {
 		infos := suite.genSegmentLoadInfos(schema, indexInfos)
 		req := &querypb.LoadSegmentsRequest{
 			Base: &commonpb.MsgBase{
-				MsgID:    rand.Int63(),
-				TargetID: suite.node.session.ServerID,
+				MsgID: rand.Int63(),
 			},
 			CollectionID:  suite.collectionID,
 			DstNodeID:     suite.node.session.ServerID,
@@ -844,8 +828,7 @@ func (suite *ServiceSuite) TestLoadSegments_Failed() {
 	schema := segments.GenTestCollectionSchema(suite.collectionName, schemapb.DataType_Int64, false)
 	req := &querypb.LoadSegmentsRequest{
 		Base: &commonpb.MsgBase{
-			MsgID:    rand.Int63(),
-			TargetID: suite.node.session.ServerID,
+			MsgID: rand.Int63(),
 		},
 		CollectionID: suite.collectionID,
 		DstNodeID:    suite.node.session.ServerID,
@@ -889,8 +872,7 @@ func (suite *ServiceSuite) TestLoadSegments_Transfer() {
 		schema := segments.GenTestCollectionSchema(suite.collectionName, schemapb.DataType_Int64, false)
 		req := &querypb.LoadSegmentsRequest{
 			Base: &commonpb.MsgBase{
-				MsgID:    rand.Int63(),
-				TargetID: suite.node.session.ServerID,
+				MsgID: rand.Int63(),
 			},
 			CollectionID:  suite.collectionID,
 			DstNodeID:     suite.node.session.ServerID,
@@ -911,8 +893,7 @@ func (suite *ServiceSuite) TestLoadSegments_Transfer() {
 		schema := segments.GenTestCollectionSchema(suite.collectionName, schemapb.DataType_Int64, false)
 		req := &querypb.LoadSegmentsRequest{
 			Base: &commonpb.MsgBase{
-				MsgID:    rand.Int63(),
-				TargetID: suite.node.session.ServerID,
+				MsgID: rand.Int63(),
 			},
 			CollectionID:  suite.collectionID,
 			DstNodeID:     suite.node.session.ServerID,
@@ -938,8 +919,7 @@ func (suite *ServiceSuite) TestLoadSegments_Transfer() {
 		schema := segments.GenTestCollectionSchema(suite.collectionName, schemapb.DataType_Int64, false)
 		req := &querypb.LoadSegmentsRequest{
 			Base: &commonpb.MsgBase{
-				MsgID:    rand.Int63(),
-				TargetID: suite.node.session.ServerID,
+				MsgID: rand.Int63(),
 			},
 			CollectionID:  suite.collectionID,
 			DstNodeID:     suite.node.session.ServerID,
@@ -1009,8 +989,7 @@ func (suite *ServiceSuite) TestReleaseSegments_Normal() {
 
 	req := &querypb.ReleaseSegmentsRequest{
 		Base: &commonpb.MsgBase{
-			MsgID:    rand.Int63(),
-			TargetID: suite.node.session.ServerID,
+			MsgID: rand.Int63(),
 		},
 		CollectionID: suite.collectionID,
 		SegmentIDs:   suite.validSegmentIDs,
@@ -1027,8 +1006,7 @@ func (suite *ServiceSuite) TestReleaseSegments_Failed() {
 
 	req := &querypb.ReleaseSegmentsRequest{
 		Base: &commonpb.MsgBase{
-			MsgID:    rand.Int63(),
-			TargetID: suite.node.session.ServerID,
+			MsgID: rand.Int63(),
 		},
 		CollectionID: suite.collectionID,
 		SegmentIDs:   suite.validSegmentIDs,
@@ -1047,8 +1025,7 @@ func (suite *ServiceSuite) TestReleaseSegments_Transfer() {
 		defer cancel()
 		req := &querypb.ReleaseSegmentsRequest{
 			Base: &commonpb.MsgBase{
-				MsgID:    rand.Int63(),
-				TargetID: suite.node.session.ServerID,
+				MsgID: rand.Int63(),
 			},
 			Shard:        suite.vchannel,
 			CollectionID: suite.collectionID,
@@ -1069,8 +1046,7 @@ func (suite *ServiceSuite) TestReleaseSegments_Transfer() {
 		suite.TestLoadSegments_Int64()
 		req := &querypb.ReleaseSegmentsRequest{
 			Base: &commonpb.MsgBase{
-				MsgID:    rand.Int63(),
-				TargetID: suite.node.session.ServerID,
+				MsgID: rand.Int63(),
 			},
 			Shard:        suite.vchannel,
 			CollectionID: suite.collectionID,
@@ -1096,8 +1072,7 @@ func (suite *ServiceSuite) TestReleaseSegments_Transfer() {
 
 		req := &querypb.ReleaseSegmentsRequest{
 			Base: &commonpb.MsgBase{
-				MsgID:    rand.Int63(),
-				TargetID: suite.node.session.ServerID,
+				MsgID: rand.Int63(),
 			},
 			Shard:        suite.vchannel,
 			CollectionID: suite.collectionID,
@@ -1154,9 +1129,8 @@ func (suite *ServiceSuite) genCSearchRequest(nq int64, dataType schemapb.DataTyp
 	}
 	return &internalpb.SearchRequest{
 		Base: &commonpb.MsgBase{
-			MsgType:  commonpb.MsgType_Search,
-			MsgID:    rand.Int63(),
-			TargetID: suite.node.session.ServerID,
+			MsgType: commonpb.MsgType_Search,
+			MsgID:   rand.Int63(),
 		},
 		CollectionID:       suite.collectionID,
 		PartitionIDs:       suite.partitionIDs,
@@ -1259,8 +1233,7 @@ func (suite *ServiceSuite) TestSearch_Failed() {
 	// sync segment data
 	syncReq := &querypb.SyncDistributionRequest{
 		Base: &commonpb.MsgBase{
-			MsgID:    rand.Int63(),
-			TargetID: suite.node.session.ServerID,
+			MsgID: rand.Int63(),
 		},
 		CollectionID: suite.collectionID,
 		Channel:      suite.vchannel,
@@ -1354,8 +1327,7 @@ func (suite *ServiceSuite) TestHybridSearch_Concurrent() {
 			req := &querypb.HybridSearchRequest{
 				Req: &internalpb.HybridSearchRequest{
 					Base: &commonpb.MsgBase{
-						MsgID:    rand.Int63(),
-						TargetID: suite.node.session.ServerID,
+						MsgID: rand.Int63(),
 					},
 					CollectionID:  suite.collectionID,
 					PartitionIDs:  suite.partitionIDs,
@@ -1407,9 +1379,8 @@ func (suite *ServiceSuite) genCQueryRequest(nq int64, indexType string, schema *
 
 	return &internalpb.RetrieveRequest{
 		Base: &commonpb.MsgBase{
-			MsgType:  commonpb.MsgType_Retrieve,
-			MsgID:    rand.Int63(),
-			TargetID: suite.node.session.ServerID,
+			MsgType: commonpb.MsgType_Retrieve,
+			MsgID:   rand.Int63(),
 		},
 		CollectionID: suite.collectionID,
 		PartitionIDs: suite.partitionIDs,
@@ -1689,8 +1660,7 @@ func (suite *ServiceSuite) TestShowConfigurations_Normal() {
 	ctx := context.Background()
 	req := &internalpb.ShowConfigurationsRequest{
 		Base: &commonpb.MsgBase{
-			MsgID:    rand.Int63(),
-			TargetID: suite.node.session.ServerID,
+			MsgID: rand.Int63(),
 		},
 		Pattern: "Cache.enabled",
 	}
@@ -1705,8 +1675,7 @@ func (suite *ServiceSuite) TestShowConfigurations_Failed() {
 	ctx := context.Background()
 	req := &internalpb.ShowConfigurationsRequest{
 		Base: &commonpb.MsgBase{
-			MsgID:    rand.Int63(),
-			TargetID: suite.node.session.ServerID,
+			MsgID: rand.Int63(),
 		},
 		Pattern: "Cache.enabled",
 	}
@@ -1727,8 +1696,7 @@ func (suite *ServiceSuite) TestGetMetric_Normal() {
 
 	req := &milvuspb.GetMetricsRequest{
 		Base: &commonpb.MsgBase{
-			MsgID:    rand.Int63(),
-			TargetID: suite.node.session.ServerID,
+			MsgID: rand.Int63(),
 		},
 		Request: string(mReq),
 	}
@@ -1748,8 +1716,7 @@ func (suite *ServiceSuite) TestGetMetric_Failed() {
 
 	req := &milvuspb.GetMetricsRequest{
 		Base: &commonpb.MsgBase{
-			MsgID:    rand.Int63(),
-			TargetID: suite.node.session.ServerID,
+			MsgID: rand.Int63(),
 		},
 		Request: string(mReq),
 	}
@@ -1779,8 +1746,7 @@ func (suite *ServiceSuite) TestGetDataDistribution_Normal() {
 
 	req := &querypb.GetDataDistributionRequest{
 		Base: &commonpb.MsgBase{
-			MsgID:    rand.Int63(),
-			TargetID: suite.node.session.ServerID,
+			MsgID: rand.Int63(),
 		},
 	}
 
@@ -1793,8 +1759,7 @@ func (suite *ServiceSuite) TestGetDataDistribution_Failed() {
 	ctx := context.Background()
 	req := &querypb.GetDataDistributionRequest{
 		Base: &commonpb.MsgBase{
-			MsgID:    rand.Int63(),
-			TargetID: suite.node.session.ServerID,
+			MsgID: rand.Int63(),
 		},
 	}
 
@@ -1815,8 +1780,7 @@ func (suite *ServiceSuite) TestSyncDistribution_Normal() {
 	// data
 	req := &querypb.SyncDistributionRequest{
 		Base: &commonpb.MsgBase{
-			MsgID:    rand.Int63(),
-			TargetID: suite.node.session.ServerID,
+			MsgID: rand.Int63(),
 		},
 		CollectionID: suite.collectionID,
 		Channel:      suite.vchannel,
@@ -1901,8 +1865,7 @@ func (suite *ServiceSuite) TestSyncDistribution_ReleaseResultCheck() {
 	// data
 	req := &querypb.SyncDistributionRequest{
 		Base: &commonpb.MsgBase{
-			MsgID:    rand.Int63(),
-			TargetID: suite.node.session.ServerID,
+			MsgID: rand.Int63(),
 		},
 		CollectionID: suite.collectionID,
 		Channel:      suite.vchannel,
@@ -1947,8 +1910,7 @@ func (suite *ServiceSuite) TestSyncDistribution_Failed() {
 	// data
 	req := &querypb.SyncDistributionRequest{
 		Base: &commonpb.MsgBase{
-			MsgID:    rand.Int63(),
-			TargetID: suite.node.session.ServerID,
+			MsgID: rand.Int63(),
 		},
 		CollectionID: suite.collectionID,
 		Channel:      suite.vchannel,
@@ -1969,8 +1931,7 @@ func (suite *ServiceSuite) TestDelete_Int64() {
 	// data
 	req := &querypb.DeleteRequest{
 		Base: &commonpb.MsgBase{
-			MsgID:    rand.Int63(),
-			TargetID: suite.node.session.ServerID,
+			MsgID: rand.Int63(),
 		},
 		CollectionId: suite.collectionID,
 		PartitionId:  suite.partitionIDs[0],
@@ -2001,8 +1962,7 @@ func (suite *ServiceSuite) TestDelete_VarChar() {
 	// data
 	req := &querypb.DeleteRequest{
 		Base: &commonpb.MsgBase{
-			MsgID:    rand.Int63(),
-			TargetID: suite.node.session.ServerID,
+			MsgID: rand.Int63(),
 		},
 		CollectionId: suite.collectionID,
 		PartitionId:  suite.partitionIDs[0],
@@ -2032,8 +1992,7 @@ func (suite *ServiceSuite) TestDelete_Failed() {
 	// data
 	req := &querypb.DeleteRequest{
 		Base: &commonpb.MsgBase{
-			MsgID:    rand.Int63(),
-			TargetID: suite.node.session.ServerID,
+			MsgID: rand.Int63(),
 		},
 		CollectionId: suite.collectionID,
 		PartitionId:  suite.partitionIDs[0],
@@ -2068,8 +2027,7 @@ func (suite *ServiceSuite) TestLoadPartition() {
 	ctx := context.Background()
 	req := &querypb.LoadPartitionsRequest{
 		Base: &commonpb.MsgBase{
-			MsgID:    rand.Int63(),
-			TargetID: suite.node.session.ServerID,
+			MsgID: rand.Int63(),
 		},
 		CollectionID: suite.collectionID,
 		PartitionIDs: suite.partitionIDs,


### PR DESCRIPTION
issue: #31109

targetID in pb msg base used to check rpc's server id, which duplicated with server_id_interceptor.

This PR deprecate usage of targetID in querynode