### PR TITLE
fix: [2.3] Use server ctx instead of loopCtx for datacoord LivenessCheck (#31691)

### DIFF
--- a/internal/datacoord/server.go
+++ b/internal/datacoord/server.go
@@ -267,7 +267,7 @@ func (s *Server) Register() error {
 	metrics.NumNodes.WithLabelValues(fmt.Sprint(paramtable.GetNodeID()), typeutil.DataCoordRole).Inc()
 	log.Info("DataCoord Register Finished")
 
-	s.session.LivenessCheck(s.serverLoopCtx, func() {
+	s.session.LivenessCheck(s.ctx, func() {
 		logutil.Logger(s.ctx).Error("disconnected from etcd and exited", zap.Int64("serverID", s.session.GetServerID()))
 		os.Exit(1)
 	})


### PR DESCRIPTION
Cherry-pick from master
pr: #31691
See also #31689