### PR TITLE
fix: Clone child segment info before decompress its deltalog

### DIFF
--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -382,8 +382,8 @@ func (s *Server) GetSegmentInfo(ctx context.Context, req *datapb.GetSegmentInfoR
 			}
 
 			clonedInfo := info.Clone()
-			clonedChild := child.Clone()
 			if child != nil {
+				clonedChild := child.Clone()
 				// child segment should decompress binlog path
 				binlog.DecompressBinLog(storage.DeleteBinlog, clonedChild.GetCollectionID(), clonedChild.GetPartitionID(), clonedChild.GetID(), clonedChild.GetDeltalogs())
 				clonedInfo.Deltalogs = append(clonedInfo.Deltalogs, clonedChild.GetDeltalogs()...)

--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -382,11 +382,12 @@ func (s *Server) GetSegmentInfo(ctx context.Context, req *datapb.GetSegmentInfoR
 			}
 
 			clonedInfo := info.Clone()
+			clonedChild := child.Clone()
 			if child != nil {
 				// child segment should decompress binlog path
-				binlog.DecompressBinLog(storage.DeleteBinlog, child.GetCollectionID(), child.GetPartitionID(), child.GetID(), child.GetDeltalogs())
-				clonedInfo.Deltalogs = append(clonedInfo.Deltalogs, child.GetDeltalogs()...)
-				clonedInfo.DmlPosition = child.GetDmlPosition()
+				binlog.DecompressBinLog(storage.DeleteBinlog, clonedChild.GetCollectionID(), clonedChild.GetPartitionID(), clonedChild.GetID(), clonedChild.GetDeltalogs())
+				clonedInfo.Deltalogs = append(clonedInfo.Deltalogs, clonedChild.GetDeltalogs()...)
+				clonedInfo.DmlPosition = clonedChild.GetDmlPosition()
 			}
 			segmentutil.ReCalcRowCount(info.SegmentInfo, clonedInfo.SegmentInfo)
 			infos = append(infos, clonedInfo.SegmentInfo)


### PR DESCRIPTION
Related to #31791

This segment meta is implemented in COW pattern. All modification on segment info shall happen on the copied version of it.

This PR clones the child segment info for `GetSegmentInfo` in case data race problem.