### PR TITLE
fix: Avoid acquire index meta's lock for each segment (#31723)

### DIFF
--- a/internal/datacoord/index_meta.go
+++ b/internal/datacoord/index_meta.go
@@ -35,6 +35,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/metrics"
 	"github.com/milvus-io/milvus/pkg/util/timerecord"
+	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
 
 type indexMeta struct {
@@ -365,40 +366,39 @@ func (m *indexMeta) GetSegmentIndexState(collID, segmentID UniqueID) IndexState 
 	return state
 }
 
-func (m *indexMeta) GetSegmentIndexStateOnField(collID, segmentID, fieldID UniqueID) IndexState {
+func (m *indexMeta) GetIndexedSegments(collectionID int64, fieldIDs []UniqueID) []int64 {
 	m.RLock()
 	defer m.RUnlock()
 
-	state := IndexState{
-		state:      commonpb.IndexState_IndexStateNone,
-		failReason: "",
-	}
-	fieldIndexes, ok := m.indexes[collID]
+	fieldIndexes, ok := m.indexes[collectionID]
 	if !ok {
-		state.failReason = fmt.Sprintf("collection not exist with ID: %d", collID)
-		return state
+		return nil
 	}
 
-	indexes, ok := m.segmentIndexes[segmentID]
-	if !ok {
-		state.failReason = fmt.Sprintf("segment index not exist with ID: %d", segmentID)
-		state.state = commonpb.IndexState_Unissued
-		return state
-	}
-
-	for indexID, index := range fieldIndexes {
-		if index.FieldID == fieldID && !index.IsDeleted {
-			if segIdx, ok := indexes[indexID]; ok {
-				state.state = segIdx.IndexState
-				state.failReason = segIdx.FailReason
-				return state
+	fieldIDSet := typeutil.NewUniqueSet(fieldIDs...)
+	checkSegmentState := func(indexes map[int64]*model.SegmentIndex) bool {
+		indexedFields := 0
+		for indexID, index := range fieldIndexes {
+			if !fieldIDSet.Contain(index.FieldID) || index.IsDeleted {
+				continue
 			}
-			state.state = commonpb.IndexState_Unissued
-			return state
+
+			if segIdx, ok := indexes[indexID]; ok && segIdx.IndexState == commonpb.IndexState_Finished {
+				indexedFields += 1
+			}
+		}
+
+		return indexedFields == fieldIDSet.Len()
+	}
+
+	ret := make([]int64, 0)
+	for sid, indexes := range m.segmentIndexes {
+		if checkSegmentState(indexes) {
+			ret = append(ret, sid)
 		}
 	}
-	state.failReason = fmt.Sprintf("there is no index on fieldID: %d", fieldID)
-	return state
+
+	return ret
 }
 
 // GetIndexesForCollection gets all indexes info with the specified collection.

--- a/internal/datacoord/index_meta_test.go
+++ b/internal/datacoord/index_meta_test.go
@@ -532,7 +532,7 @@ func TestMeta_GetSegmentIndexState(t *testing.T) {
 	})
 }
 
-func TestMeta_GetSegmentIndexStateOnField(t *testing.T) {
+func TestMeta_GetIndexedSegment(t *testing.T) {
 	var (
 		collID     = UniqueID(1)
 		partID     = UniqueID(2)
@@ -613,23 +613,18 @@ func TestMeta_GetSegmentIndexStateOnField(t *testing.T) {
 	}
 
 	t.Run("success", func(t *testing.T) {
-		state := m.GetSegmentIndexStateOnField(collID, segID, fieldID)
-		assert.Equal(t, commonpb.IndexState_Finished, state.state)
+		segments := m.GetIndexedSegments(collID, []int64{fieldID})
+		assert.Len(t, segments, 1)
 	})
 
 	t.Run("no index on field", func(t *testing.T) {
-		state := m.GetSegmentIndexStateOnField(collID, segID, fieldID+1)
-		assert.Equal(t, commonpb.IndexState_IndexStateNone, state.state)
+		segments := m.GetIndexedSegments(collID, []int64{fieldID + 1})
+		assert.Len(t, segments, 0)
 	})
 
 	t.Run("no index", func(t *testing.T) {
-		state := m.GetSegmentIndexStateOnField(collID+1, segID, fieldID+1)
-		assert.Equal(t, commonpb.IndexState_IndexStateNone, state.state)
-	})
-
-	t.Run("segment not exist", func(t *testing.T) {
-		state := m.GetSegmentIndexStateOnField(collID, segID+1, fieldID)
-		assert.Equal(t, commonpb.IndexState_Unissued, state.state)
+		segments := m.GetIndexedSegments(collID+1, []int64{fieldID})
+		assert.Len(t, segments, 0)
 	})
 }
 


### PR DESCRIPTION
issue: #31662 #31409
pr: #31723

during FilterIndexedSegment in GetRecoveryInfo, it try to acquire index meta's read lock for every segment. when a collection has thousands of segments, which may blocked for more than 10 seconds and even longer. cause `AddSegmentIndex` may also triggered frequently, which try to get the write lock.

This PR avoid acquire index meta's lock for each segment