### PR TITLE
enhance: Unify data type check APIs under internal/core

### DIFF
--- a/internal/core/src/bitset/CMakeLists.txt
+++ b/internal/core/src/bitset/CMakeLists.txt
@@ -1,3 +1,14 @@
+# Copyright (C) 2019-2020 Zilliz. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under the License
+
 set(BITSET_SRCS
     detail/platform/dynamic.cpp
 )

--- a/internal/core/src/common/Array.h
+++ b/internal/core/src/common/Array.h
@@ -126,7 +126,7 @@ class Array {
         delete[] data_;
         data_ = new char[size];
         std::copy(data, data + size, data_);
-        if (datatype_is_variable(element_type_)) {
+        if (IsVariableDataType(element_type_)) {
             length_ = offsets_.size();
         } else {
             // int8, int16, int32 are all promoted to int32
@@ -134,7 +134,7 @@ class Array {
                 element_type_ == DataType::INT16) {
                 length_ = size / sizeof(int32_t);
             } else {
-                length_ = size / datatype_sizeof(element_type_);
+                length_ = size / GetDataTypeSize(element_type_);
             }
         }
     }
@@ -445,7 +445,7 @@ class ArrayView {
           element_type_(element_type),
           offsets_(std::move(element_offsets)) {
         data_ = data;
-        if (datatype_is_variable(element_type_)) {
+        if (IsVariableDataType(element_type_)) {
             length_ = offsets_.size();
         } else {
             // int8, int16, int32 are all promoted to int32
@@ -453,7 +453,7 @@ class ArrayView {
                 element_type_ == DataType::INT16) {
                 length_ = size / sizeof(int32_t);
             } else {
-                length_ = size / datatype_sizeof(element_type_);
+                length_ = size / GetDataTypeSize(element_type_);
             }
         }
     }

--- a/internal/core/src/common/FieldData.cpp
+++ b/internal/core/src/common/FieldData.cpp
@@ -175,7 +175,7 @@ FieldDataImpl<Type, is_type_entire_row>::FillFieldData(
             throw SegcoreError(DataTypeInvalid,
                                GetName() + "::FillFieldData" +
                                    " not support data type " +
-                                   datatype_name(data_type_));
+                                   GetDataTypeName(data_type_));
         }
     }
 }
@@ -225,7 +225,7 @@ InitScalarFieldData(const DataType& type, int64_t cap_rows) {
         default:
             throw NotSupportedDataTypeException(
                 "InitScalarFieldData not support data type " +
-                datatype_name(type));
+                GetDataTypeName(type));
     }
 }
 

--- a/internal/core/src/common/Schema.cpp
+++ b/internal/core/src/common/Schema.cpp
@@ -50,12 +50,12 @@ Schema::ParseFrom(const milvus::proto::schema::CollectionSchema& schema_proto) {
 
         auto data_type = DataType(child.data_type());
 
-        if (datatype_is_vector(data_type)) {
+        if (IsVectorDataType(data_type)) {
             auto type_map = RepeatedKeyValToMap(child.type_params());
             auto index_map = RepeatedKeyValToMap(child.index_params());
 
             int64_t dim = 0;
-            if (!datatype_is_sparse_vector(data_type)) {
+            if (!IsSparseFloatVectorDataType(data_type)) {
                 AssertInfo(type_map.count("dim"), "dim not found");
                 dim = boost::lexical_cast<int64_t>(type_map.at("dim"));
             }
@@ -65,13 +65,13 @@ Schema::ParseFrom(const milvus::proto::schema::CollectionSchema& schema_proto) {
                 auto metric_type = index_map.at("metric_type");
                 schema->AddField(name, field_id, data_type, dim, metric_type);
             }
-        } else if (datatype_is_string(data_type)) {
+        } else if (IsStringDataType(data_type)) {
             auto type_map = RepeatedKeyValToMap(child.type_params());
             AssertInfo(type_map.count(MAX_LENGTH), "max_length not found");
             auto max_len =
                 boost::lexical_cast<int64_t>(type_map.at(MAX_LENGTH));
             schema->AddField(name, field_id, data_type, max_len);
-        } else if (datatype_is_array(data_type)) {
+        } else if (IsArrayDataType(data_type)) {
             schema->AddField(
                 name, field_id, data_type, DataType(child.element_type()));
         } else {

--- a/internal/core/src/exec/expression/JsonContainsExpr.cpp
+++ b/internal/core/src/exec/expression/JsonContainsExpr.cpp
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 #include "JsonContainsExpr.h"
+#include "common/Types.h"
 
 namespace milvus {
 namespace exec {
@@ -45,7 +46,7 @@ PhyJsonContainsFilterExpr::EvalJsonContainsForDataSegment() {
     switch (expr_->op_) {
         case proto::plan::JSONContainsExpr_JSONOp_Contains:
         case proto::plan::JSONContainsExpr_JSONOp_ContainsAny: {
-            if (datatype_is_array(data_type)) {
+            if (IsArrayDataType(data_type)) {
                 auto val_type = expr_->vals_[0].val_case();
                 switch (val_type) {
                     case proto::plan::GenericValue::kBoolVal: {
@@ -96,7 +97,7 @@ PhyJsonContainsFilterExpr::EvalJsonContainsForDataSegment() {
             break;
         }
         case proto::plan::JSONContainsExpr_JSONOp_ContainsAll: {
-            if (datatype_is_array(data_type)) {
+            if (IsArrayDataType(data_type)) {
                 auto val_type = expr_->vals_[0].val_case();
                 switch (val_type) {
                     case proto::plan::GenericValue::kBoolVal: {

--- a/internal/core/src/index/IndexFactory.cpp
+++ b/internal/core/src/index/IndexFactory.cpp
@@ -16,6 +16,7 @@
 
 #include "index/IndexFactory.h"
 #include "common/EasyAssert.h"
+#include "common/Types.h"
 #include "index/VectorMemIndex.h"
 #include "index/Utils.h"
 #include "index/Meta.h"
@@ -110,7 +111,7 @@ IndexBasePtr
 IndexFactory::CreateIndex(
     const CreateIndexInfo& create_index_info,
     const storage::FileManagerContext& file_manager_context) {
-    if (datatype_is_vector(create_index_info.field_type)) {
+    if (IsVectorDataType(create_index_info.field_type)) {
         return CreateVectorIndex(create_index_info, file_manager_context);
     }
 
@@ -122,7 +123,7 @@ IndexFactory::CreateIndex(
     const CreateIndexInfo& create_index_info,
     const storage::FileManagerContext& file_manager_context,
     std::shared_ptr<milvus_storage::Space> space) {
-    if (datatype_is_vector(create_index_info.field_type)) {
+    if (IsVectorDataType(create_index_info.field_type)) {
         return CreateVectorIndex(
             create_index_info, file_manager_context, space);
     }

--- a/internal/core/src/indexbuilder/index_c.cpp
+++ b/internal/core/src/indexbuilder/index_c.cpp
@@ -107,7 +107,7 @@ CreateIndex(CIndex* res_index, CBuildIndexInfo c_build_index_info) {
             std::to_string(engine_version);
 
         // get metric type
-        if (milvus::datatype_is_vector(field_type)) {
+        if (milvus::IsVectorDataType(field_type)) {
             auto metric_type = milvus::index::GetValueFromConfig<std::string>(
                 config, "metric_type");
             AssertInfo(metric_type.has_value(), "metric type is empty");
@@ -170,7 +170,7 @@ CreateIndexV2(CIndex* res_index, CBuildIndexInfo c_build_index_info) {
             std::to_string(engine_version);
 
         // get metric type
-        if (milvus::datatype_is_vector(field_type)) {
+        if (milvus::IsVectorDataType(field_type)) {
             auto metric_type = milvus::index::GetValueFromConfig<std::string>(
                 config, "metric_type");
             AssertInfo(metric_type.has_value(), "metric type is empty");

--- a/internal/core/src/mmap/Column.h
+++ b/internal/core/src/mmap/Column.h
@@ -55,13 +55,13 @@ class ColumnBase {
  public:
     // memory mode ctor
     ColumnBase(size_t reserve, const FieldMeta& field_meta)
-        : type_size_(datatype_is_sparse_vector(field_meta.get_data_type())
+        : type_size_(IsSparseFloatVectorDataType(field_meta.get_data_type())
                          ? 1
                          : field_meta.get_sizeof()),
           is_map_anonymous_(true) {
         SetPaddingSize(field_meta.get_data_type());
 
-        if (datatype_is_variable(field_meta.get_data_type())) {
+        if (IsVariableDataType(field_meta.get_data_type())) {
             return;
         }
 
@@ -85,7 +85,7 @@ class ColumnBase {
 
     // mmap mode ctor
     ColumnBase(const File& file, size_t size, const FieldMeta& field_meta)
-        : type_size_(datatype_is_sparse_vector(field_meta.get_data_type())
+        : type_size_(IsSparseFloatVectorDataType(field_meta.get_data_type())
                          ? 1
                          : field_meta.get_sizeof()),
           is_map_anonymous_(false),
@@ -110,8 +110,8 @@ class ColumnBase {
                size_t size,
                int dim,
                const DataType& data_type)
-        : type_size_(datatype_sizeof(data_type, dim)),
-          num_rows_(size / datatype_sizeof(data_type, dim)),
+        : type_size_(GetDataTypeSize(data_type, dim)),
+          num_rows_(size / GetDataTypeSize(data_type, dim)),
           size_(size),
           cap_size_(size),
           is_map_anonymous_(false) {

--- a/internal/core/src/mmap/Utils.h
+++ b/internal/core/src/mmap/Utils.h
@@ -13,6 +13,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 #pragma once
 
 #include <fcntl.h>
@@ -25,6 +26,7 @@
 #include <vector>
 
 #include "common/FieldMeta.h"
+#include "common/Types.h"
 #include "mmap/Types.h"
 #include "storage/Util.h"
 #include "common/File.h"
@@ -37,7 +39,7 @@ WriteFieldData(File& file,
                const FieldDataPtr& data,
                std::vector<std::vector<uint64_t>>& element_indices) {
     size_t total_written{0};
-    if (datatype_is_variable(data_type)) {
+    if (IsVariableDataType(data_type)) {
         switch (data_type) {
             case DataType::VARCHAR:
             case DataType::STRING: {
@@ -87,7 +89,7 @@ WriteFieldData(File& file,
             default:
                 PanicInfo(DataTypeInvalid,
                           "not supported data type {}",
-                          datatype_name(data_type));
+                          GetDataTypeName(data_type));
         }
     } else {
         total_written += file.Write(data->Data(), data->Size());

--- a/internal/core/src/query/ScalarIndex.h
+++ b/internal/core/src/query/ScalarIndex.h
@@ -18,6 +18,7 @@
 
 #include "common/FieldMeta.h"
 #include "common/Span.h"
+#include "common/Types.h"
 
 namespace milvus::query {
 
@@ -39,7 +40,7 @@ generate_scalar_index(Span<std::string> data) {
 
 inline index::IndexBasePtr
 generate_scalar_index(SpanBase data, DataType data_type) {
-    Assert(!datatype_is_vector(data_type));
+    Assert(!IsVectorDataType(data_type));
     switch (data_type) {
         case DataType::BOOL:
             return generate_scalar_index(Span<bool>(data));

--- a/internal/core/src/query/SearchBruteForce.cpp
+++ b/internal/core/src/query/SearchBruteForce.cpp
@@ -19,6 +19,7 @@
 #include "common/RangeSearchHelper.h"
 #include "common/Utils.h"
 #include "common/Tracer.h"
+#include "common/Types.h"
 #include "knowhere/comp/brute_force.h"
 #include "knowhere/comp/index_param.h"
 #include "knowhere/index_node.h"
@@ -32,14 +33,11 @@ CheckBruteForceSearchParam(const FieldMeta& field,
     auto data_type = field.get_data_type();
     auto& metric_type = search_info.metric_type_;
 
-    AssertInfo(datatype_is_vector(data_type),
+    AssertInfo(IsVectorDataType(data_type),
                "[BruteForceSearch] Data type isn't vector type");
-    bool is_float_data_type = (data_type == DataType::VECTOR_FLOAT ||
-                               data_type == DataType::VECTOR_FLOAT16 ||
-                               data_type == DataType::VECTOR_BFLOAT16 ||
-                               data_type == DataType::VECTOR_SPARSE_FLOAT);
+    bool is_float_vec_data_type = IsFloatVectorDataType(data_type);
     bool is_float_metric_type = IsFloatMetricType(metric_type);
-    AssertInfo(is_float_data_type == is_float_metric_type,
+    AssertInfo(is_float_vec_data_type == is_float_metric_type,
                "[BruteForceSearch] Data type and metric type miss-match");
 }
 

--- a/internal/core/src/query/SearchOnGrowing.cpp
+++ b/internal/core/src/query/SearchOnGrowing.cpp
@@ -9,10 +9,10 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
-#include <cstddef>
 #include "common/BitsetView.h"
 #include "common/QueryInfo.h"
 #include "common/Tracer.h"
+#include "common/Types.h"
 #include "SearchOnGrowing.h"
 #include "query/SearchBruteForce.h"
 #include "query/SearchOnIndex.h"
@@ -82,7 +82,7 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
     CheckBruteForceSearchParam(field, info);
 
     auto data_type = field.get_data_type();
-    AssertInfo(datatype_is_vector(data_type),
+    AssertInfo(IsVectorDataType(data_type),
                "[SearchOnGrowing]Data type isn't vector type");
 
     auto topk = info.topk_;

--- a/internal/core/src/query/visitors/ExecExprVisitor.cpp
+++ b/internal/core/src/query/visitors/ExecExprVisitor.cpp
@@ -3393,7 +3393,7 @@ ExecExprVisitor::visit(JsonContainsExpr& expr) {
     switch (expr.op_) {
         case proto::plan::JSONContainsExpr_JSONOp_Contains:
         case proto::plan::JSONContainsExpr_JSONOp_ContainsAny: {
-            if (datatype_is_array(data_type)) {
+            if (IsArrayDataType(data_type)) {
                 switch (expr.val_case_) {
                     case proto::plan::GenericValue::kBoolVal: {
                         res = ExecArrayContains<bool>(expr);
@@ -3451,7 +3451,7 @@ ExecExprVisitor::visit(JsonContainsExpr& expr) {
             break;
         }
         case proto::plan::JSONContainsExpr_JSONOp_ContainsAll: {
-            if (datatype_is_array(data_type)) {
+            if (IsArrayDataType(data_type)) {
                 switch (expr.val_case_) {
                     case proto::plan::GenericValue::kBoolVal: {
                         res = ExecArrayContainsAll<bool>(expr);

--- a/internal/core/src/query/visitors/ShowExprVisitor.cpp
+++ b/internal/core/src/query/visitors/ShowExprVisitor.cpp
@@ -11,10 +11,10 @@
 
 #include <utility>
 
+#include "common/Types.h"
 #include "query/ExprImpl.h"
 #include "query/Plan.h"
 #include "query/generated/ShowExprVisitor.h"
-#include "common/Types.h"
 
 namespace milvus::query {
 using Json = nlohmann::json;
@@ -115,7 +115,7 @@ void
 ShowExprVisitor::visit(TermExpr& expr) {
     AssertInfo(!json_opt_.has_value(),
                "[ShowExprVisitor]Ret json already has value before visit");
-    AssertInfo(datatype_is_vector(expr.column_.data_type) == false,
+    AssertInfo(IsVectorDataType(expr.column_.data_type) == false,
                "[ShowExprVisitor]Data type of expr isn't vector type");
     auto terms = [&] {
         switch (expr.column_.data_type) {
@@ -144,7 +144,7 @@ ShowExprVisitor::visit(TermExpr& expr) {
 
     Json res{{"expr_type", "Term"},
              {"field_id", expr.column_.field_id.get()},
-             {"data_type", datatype_name(expr.column_.data_type)},
+             {"data_type", GetDataTypeName(expr.column_.data_type)},
              {"terms", std::move(terms)}};
 
     json_opt_ = res;
@@ -161,7 +161,7 @@ UnaryRangeExtract(const UnaryRangeExpr& expr_raw) {
         "[ShowExprVisitor]UnaryRangeExpr cast to UnaryRangeExprImpl failed");
     Json res{{"expr_type", "UnaryRange"},
              {"field_id", expr->column_.field_id.get()},
-             {"data_type", datatype_name(expr->column_.data_type)},
+             {"data_type", GetDataTypeName(expr->column_.data_type)},
              {"op", OpType_Name(static_cast<OpType>(expr->op_type_))},
              {"value", expr->value_}};
     return res;
@@ -171,7 +171,7 @@ void
 ShowExprVisitor::visit(UnaryRangeExpr& expr) {
     AssertInfo(!json_opt_.has_value(),
                "[ShowExprVisitor]Ret json already has value before visit");
-    AssertInfo(datatype_is_vector(expr.column_.data_type) == false,
+    AssertInfo(IsVectorDataType(expr.column_.data_type) == false,
                "[ShowExprVisitor]Data type of expr isn't vector type");
     switch (expr.column_.data_type) {
         case DataType::BOOL:
@@ -213,7 +213,7 @@ BinaryRangeExtract(const BinaryRangeExpr& expr_raw) {
         "[ShowExprVisitor]BinaryRangeExpr cast to BinaryRangeExprImpl failed");
     Json res{{"expr_type", "BinaryRange"},
              {"field_id", expr->column_.field_id.get()},
-             {"data_type", datatype_name(expr->column_.data_type)},
+             {"data_type", GetDataTypeName(expr->column_.data_type)},
              {"lower_inclusive", expr->lower_inclusive_},
              {"upper_inclusive", expr->upper_inclusive_},
              {"lower_value", expr->lower_value_},
@@ -225,7 +225,7 @@ void
 ShowExprVisitor::visit(BinaryRangeExpr& expr) {
     AssertInfo(!json_opt_.has_value(),
                "[ShowExprVisitor]Ret json already has value before visit");
-    AssertInfo(datatype_is_vector(expr.column_.data_type) == false,
+    AssertInfo(IsVectorDataType(expr.column_.data_type) == false,
                "[ShowExprVisitor]Data type of expr isn't vector type");
     switch (expr.column_.data_type) {
         case DataType::BOOL:
@@ -268,9 +268,9 @@ ShowExprVisitor::visit(CompareExpr& expr) {
 
     Json res{{"expr_type", "Compare"},
              {"left_field_id", expr.left_field_id_.get()},
-             {"left_data_type", datatype_name(expr.left_data_type_)},
+             {"left_data_type", GetDataTypeName(expr.left_data_type_)},
              {"right_field_id", expr.right_field_id_.get()},
-             {"right_data_type", datatype_name(expr.right_data_type_)},
+             {"right_data_type", GetDataTypeName(expr.right_data_type_)},
              {"op", OpType_Name(static_cast<OpType>(expr.op_type_))}};
     json_opt_ = res;
 }
@@ -291,7 +291,7 @@ BinaryArithOpEvalRangeExtract(const BinaryArithOpEvalRangeExpr& expr_raw) {
 
     Json res{{"expr_type", "BinaryArithOpEvalRange"},
              {"field_offset", expr->column_.field_id.get()},
-             {"data_type", datatype_name(expr->column_.data_type)},
+             {"data_type", GetDataTypeName(expr->column_.data_type)},
              {"arith_op",
               ArithOpType_Name(static_cast<ArithOpType>(expr->arith_op_))},
              {"right_operand", expr->right_operand_},
@@ -304,7 +304,7 @@ void
 ShowExprVisitor::visit(BinaryArithOpEvalRangeExpr& expr) {
     AssertInfo(!json_opt_.has_value(),
                "[ShowExprVisitor]Ret json already has value before visit");
-    AssertInfo(datatype_is_vector(expr.column_.data_type) == false,
+    AssertInfo(IsVectorDataType(expr.column_.data_type) == false,
                "[ShowExprVisitor]Data type of expr isn't vector type");
     switch (expr.column_.data_type) {
         // see also: https://github.com/milvus-io/milvus/issues/23646.

--- a/internal/core/src/segcore/FieldIndexing.cpp
+++ b/internal/core/src/segcore/FieldIndexing.cpp
@@ -259,7 +259,7 @@ VectorFieldIndexing::AppendSegmentIndexDense(int64_t reserved_offset,
 knowhere::Json
 VectorFieldIndexing::get_build_params() const {
     auto config = config_->GetBuildBaseParams();
-    if (!datatype_is_sparse_vector(field_meta_.get_data_type())) {
+    if (!IsSparseFloatVectorDataType(field_meta_.get_data_type())) {
         config[knowhere::meta::DIM] = std::to_string(field_meta_.get_dim());
     }
     config[knowhere::meta::NUM_BUILD_THREAD] = std::to_string(1);

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -143,7 +143,7 @@ SegmentGrowingImpl::Insert(int64_t reserved_offset,
             &insert_record_proto->fields_data(data_offset),
             field_meta,
             num_rows);
-        if (datatype_is_variable(field_meta.get_data_type())) {
+        if (IsVariableDataType(field_meta.get_data_type())) {
             SegmentInternalInterface::set_field_avg_size(
                 field_id, num_rows, field_data_size);
         }
@@ -249,7 +249,7 @@ SegmentGrowingImpl::LoadFieldData(const LoadFieldDataInfo& infos) {
 
         // update average row data size
         auto field_meta = (*schema_)[field_id];
-        if (datatype_is_variable(field_meta.get_data_type())) {
+        if (IsVariableDataType(field_meta.get_data_type())) {
             SegmentInternalInterface::set_field_avg_size(
                 field_id,
                 num_rows,
@@ -338,7 +338,7 @@ SegmentGrowingImpl::LoadFieldDataV2(const LoadFieldDataInfo& infos) {
 
         // update average row data size
         auto field_meta = (*schema_)[field_id];
-        if (datatype_is_variable(field_meta.get_data_type())) {
+        if (IsVariableDataType(field_meta.get_data_type())) {
             SegmentInternalInterface::set_field_avg_size(
                 field_id,
                 num_rows,

--- a/internal/core/src/segcore/SegmentGrowingImpl.h
+++ b/internal/core/src/segcore/SegmentGrowingImpl.h
@@ -28,10 +28,10 @@
 #include "InsertRecord.h"
 #include "SealedIndexingRecord.h"
 #include "SegmentGrowing.h"
-#include "common/Types.h"
 #include "common/EasyAssert.h"
-#include "query/PlanNode.h"
 #include "common/IndexMeta.h"
+#include "common/Types.h"
+#include "query/PlanNode.h"
 
 namespace milvus::segcore {
 
@@ -239,7 +239,7 @@ class SegmentGrowingImpl : public SegmentGrowing {
     bool
     HasIndex(FieldId field_id) const override {
         auto& field_meta = schema_->operator[](field_id);
-        if (datatype_is_vector(field_meta.get_data_type()) &&
+        if (IsVectorDataType(field_meta.get_data_type()) &&
             indexing_record_.SyncDataWithIndex(field_id)) {
             return true;
         }

--- a/internal/core/src/segcore/SegmentInterface.cpp
+++ b/internal/core/src/segcore/SegmentInterface.cpp
@@ -218,7 +218,7 @@ SegmentInternalInterface::get_field_avg_size(FieldId field_id) const {
     auto data_type = field_meta.get_data_type();
 
     std::shared_lock lck(mutex_);
-    if (datatype_is_variable(data_type)) {
+    if (IsVariableDataType(data_type)) {
         if (variable_fields_avg_size_.find(field_id) ==
             variable_fields_avg_size_.end()) {
             return 0;
@@ -241,7 +241,7 @@ SegmentInternalInterface::set_field_avg_size(FieldId field_id,
     auto data_type = field_meta.get_data_type();
 
     std::unique_lock lck(mutex_);
-    if (datatype_is_variable(data_type)) {
+    if (IsVariableDataType(data_type)) {
         AssertInfo(num_rows > 0,
                    "The num rows of field data should be greater than 0");
         if (variable_fields_avg_size_.find(field_id) ==

--- a/internal/core/src/segcore/SegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/SegmentSealedImpl.cpp
@@ -26,29 +26,29 @@
 
 #include "Utils.h"
 #include "Types.h"
+#include "common/Array.h"
+#include "common/Consts.h"
+#include "common/EasyAssert.h"
+#include "common/FieldData.h"
+#include "common/FieldMeta.h"
+#include "common/File.h"
 #include "common/Json.h"
 #include "common/LoadInfo.h"
-#include "common/EasyAssert.h"
-#include "common/Array.h"
-#include "google/protobuf/message_lite.h"
-#include "mmap/Column.h"
-#include "common/Consts.h"
-#include "common/FieldMeta.h"
-#include "common/FieldData.h"
+#include "common/Tracer.h"
 #include "common/Types.h"
-#include "log/Log.h"
+#include "google/protobuf/message_lite.h"
+#include "index/VectorMemIndex.h"
+#include "mmap/Column.h"
 #include "mmap/Utils.h"
-#include "pb/schema.pb.h"
 #include "mmap/Types.h"
+#include "log/Log.h"
+#include "pb/schema.pb.h"
 #include "query/ScalarIndex.h"
 #include "query/SearchBruteForce.h"
 #include "query/SearchOnSealed.h"
 #include "storage/Util.h"
 #include "storage/ThreadPools.h"
 #include "storage/ChunkCacheSingleton.h"
-#include "common/File.h"
-#include "common/Tracer.h"
-#include "index/VectorMemIndex.h"
 
 namespace milvus::segcore {
 
@@ -382,7 +382,7 @@ SegmentSealedImpl::LoadFieldData(FieldId field_id, FieldDataInfo& data) {
         //                   "field data can't be loaded when indexing exists");
 
         std::shared_ptr<ColumnBase> column{};
-        if (datatype_is_variable(data_type)) {
+        if (IsVariableDataType(data_type)) {
             int64_t field_data_size = 0;
             switch (data_type) {
                 case milvus::DataType::STRING:
@@ -552,7 +552,7 @@ SegmentSealedImpl::MapFieldData(const FieldId field_id, FieldDataInfo& data) {
 
     auto num_rows = data.row_count;
     std::shared_ptr<ColumnBase> column{};
-    if (datatype_is_variable(data_type)) {
+    if (IsVariableDataType(data_type)) {
         switch (data_type) {
             case milvus::DataType::STRING:
             case milvus::DataType::VARCHAR: {
@@ -1149,7 +1149,7 @@ SegmentSealedImpl::ClearData() {
 std::unique_ptr<DataArray>
 SegmentSealedImpl::fill_with_empty(FieldId field_id, int64_t count) const {
     auto& field_meta = schema_->operator[](field_id);
-    if (datatype_is_vector(field_meta.get_data_type())) {
+    if (IsVectorDataType(field_meta.get_data_type())) {
         return CreateVectorDataArray(count, field_meta);
     }
     return CreateScalarDataArray(count, field_meta);
@@ -1339,7 +1339,7 @@ SegmentSealedImpl::bulk_subscript(FieldId field_id,
 
     if (HasIndex(field_id)) {
         // if field has load scalar index, reverse raw data from index
-        if (!datatype_is_vector(field_meta.get_data_type())) {
+        if (!IsVectorDataType(field_meta.get_data_type())) {
             AssertInfo(num_chunk() == 1,
                        "num chunk not equal to 1 for sealed segment");
             auto index = chunk_index_impl(field_id, 0);
@@ -1379,7 +1379,7 @@ SegmentSealedImpl::HasRawData(int64_t field_id) const {
     std::shared_lock lck(mutex_);
     auto fieldID = FieldId(field_id);
     const auto& field_meta = schema_->operator[](fieldID);
-    if (datatype_is_vector(field_meta.get_data_type())) {
+    if (IsVectorDataType(field_meta.get_data_type())) {
         if (get_bit(index_ready_bitset_, fieldID) |
             get_bit(binlog_index_bitset_, fieldID)) {
             AssertInfo(vector_indexings_.is_ready(fieldID),

--- a/internal/core/src/segcore/Utils.cpp
+++ b/internal/core/src/segcore/Utils.cpp
@@ -18,12 +18,11 @@
 
 #include "common/Common.h"
 #include "common/FieldData.h"
+#include "common/Types.h"
 #include "index/ScalarIndex.h"
-#include "log/Log.h"
 #include "mmap/Utils.h"
-#include "common/FieldData.h"
+#include "log/Log.h"
 #include "storage/RemoteChunkManagerSingleton.h"
-#include "common/Common.h"
 #include "storage/ThreadPools.h"
 #include "storage/Util.h"
 
@@ -126,7 +125,7 @@ GetRawDataSizeOfDataArray(const DataArray* data,
                           int64_t num_rows) {
     int64_t result = 0;
     auto data_type = field_meta.get_data_type();
-    if (!datatype_is_variable(data_type)) {
+    if (!IsVariableDataType(data_type)) {
         result = field_meta.get_sizeof() * num_rows;
     } else {
         switch (data_type) {
@@ -460,7 +459,7 @@ CreateVectorDataArrayFrom(const void* data_raw,
 
     auto vector_array = data_array->mutable_vectors();
     auto dim = 0;
-    if (!datatype_is_sparse_vector(data_type)) {
+    if (!IsSparseFloatVectorDataType(data_type)) {
         dim = field_meta.get_dim();
         vector_array->set_dim(dim);
     }
@@ -522,7 +521,7 @@ CreateDataArrayFrom(const void* data_raw,
                     const FieldMeta& field_meta) {
     auto data_type = field_meta.get_data_type();
 
-    if (!datatype_is_vector(data_type)) {
+    if (!IsVectorDataType(data_type)) {
         return CreateScalarDataArrayFrom(data_raw, count, field_meta);
     }
 
@@ -549,7 +548,7 @@ MergeDataArray(
         if (field_meta.is_vector()) {
             auto vector_array = data_array->mutable_vectors();
             auto dim = 0;
-            if (!datatype_is_sparse_vector(data_type)) {
+            if (!IsSparseFloatVectorDataType(data_type)) {
                 dim = field_meta.get_dim();
                 vector_array->set_dim(dim);
             }

--- a/internal/core/src/segcore/load_index_c.cpp
+++ b/internal/core/src/segcore/load_index_c.cpp
@@ -13,6 +13,7 @@
 
 #include "common/FieldMeta.h"
 #include "common/EasyAssert.h"
+#include "common/Types.h"
 #include "common/type_c.h"
 #include "index/Index.h"
 #include "index/IndexFactory.h"
@@ -206,7 +207,7 @@ CStatus
 AppendIndex(CLoadIndexInfo c_load_index_info, CBinarySet c_binary_set) {
     auto load_index_info = (milvus::segcore::LoadIndexInfo*)c_load_index_info;
     auto field_type = load_index_info->field_type;
-    if (milvus::datatype_is_vector(field_type)) {
+    if (milvus::IsVectorDataType(field_type)) {
         return appendVecIndex(c_load_index_info, c_binary_set);
     }
     return appendScalarIndex(c_load_index_info, c_binary_set);
@@ -246,7 +247,7 @@ AppendIndexV2(CTraceContext c_trace, CLoadIndexInfo c_load_index_info) {
         index_info.index_type = index_params.at("index_type");
 
         // get metric type
-        if (milvus::datatype_is_vector(field_type)) {
+        if (milvus::IsVectorDataType(field_type)) {
             AssertInfo(index_params.find("metric_type") != index_params.end(),
                        "metric type is empty for vector index");
             index_info.metric_type = index_params.at("metric_type");
@@ -332,7 +333,7 @@ AppendIndexV3(CLoadIndexInfo c_load_index_info) {
         index_info.index_type = index_params.at("index_type");
 
         // get metric type
-        if (milvus::datatype_is_vector(field_type)) {
+        if (milvus::IsVectorDataType(field_type)) {
             AssertInfo(index_params.find("metric_type") != index_params.end(),
                        "metric type is empty for vector index");
             index_info.metric_type = index_params.at("metric_type");

--- a/internal/core/src/segcore/segment_c.cpp
+++ b/internal/core/src/segcore/segment_c.cpp
@@ -306,8 +306,8 @@ LoadFieldRawData(CSegmentInterface c_segment,
             auto field_meta = segment->get_schema()[milvus::FieldId(field_id)];
             data_type = field_meta.get_data_type();
 
-            if (milvus::datatype_is_vector(data_type) &&
-                !milvus::datatype_is_sparse_vector(data_type)) {
+            if (milvus::IsVectorDataType(data_type) &&
+                !milvus::IsSparseFloatVectorDataType(data_type)) {
                 dim = field_meta.get_dim();
             }
         }

--- a/internal/core/src/storage/ChunkCache.cpp
+++ b/internal/core/src/storage/ChunkCache.cpp
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 #include "ChunkCache.h"
+#include "common/Types.h"
 #include "mmap/Utils.h"
 
 namespace milvus::storage {
@@ -99,7 +100,7 @@ ChunkCache::Mmap(const std::filesystem::path& path,
 
     std::shared_ptr<ColumnBase> column{};
 
-    if (datatype_is_variable(data_type)) {
+    if (IsVariableDataType(data_type)) {
         AssertInfo(
             false, "TODO: unimplemented for variable data type: {}", data_type);
     } else {

--- a/internal/core/src/storage/Event.cpp
+++ b/internal/core/src/storage/Event.cpp
@@ -14,16 +14,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "storage/Event.h"
+#include "common/Array.h"
+#include "common/Consts.h"
+#include "common/EasyAssert.h"
+#include "common/FieldMeta.h"
+#include "common/Json.h"
 #include "fmt/format.h"
 #include "nlohmann/json.hpp"
+#include "storage/Event.h"
 #include "storage/PayloadReader.h"
 #include "storage/PayloadWriter.h"
-#include "common/EasyAssert.h"
-#include "common/Json.h"
-#include "common/Consts.h"
-#include "common/FieldMeta.h"
-#include "common/Array.h"
 
 namespace milvus::storage {
 
@@ -215,8 +215,8 @@ std::vector<uint8_t>
 BaseEventData::Serialize() {
     auto data_type = field_data->get_data_type();
     std::shared_ptr<PayloadWriter> payload_writer;
-    if (milvus::datatype_is_vector(data_type) &&
-        data_type != DataType::VECTOR_SPARSE_FLOAT) {
+    if (IsVectorDataType(data_type) &&
+        !IsSparseFloatVectorDataType(data_type)) {
         payload_writer =
             std::make_unique<PayloadWriter>(data_type, field_data->get_dim());
     } else {

--- a/internal/core/src/storage/PayloadReader.cpp
+++ b/internal/core/src/storage/PayloadReader.cpp
@@ -14,13 +14,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "storage/PayloadReader.h"
-#include "common/EasyAssert.h"
-#include "storage/Util.h"
-#include "parquet/column_reader.h"
 #include "arrow/io/api.h"
 #include "arrow/status.h"
+#include "common/EasyAssert.h"
+#include "common/Types.h"
 #include "parquet/arrow/reader.h"
+#include "parquet/column_reader.h"
+#include "storage/PayloadReader.h"
+#include "storage/Util.h"
 
 namespace milvus::storage {
 
@@ -60,8 +61,8 @@ PayloadReader::init(std::shared_ptr<arrow::io::BufferReader> input) {
     auto file_meta = arrow_reader->parquet_reader()->metadata();
 
     // dim is unused for sparse float vector
-    dim_ = (datatype_is_vector(column_type_) &&
-            column_type_ != DataType::VECTOR_SPARSE_FLOAT)
+    dim_ = (IsVectorDataType(column_type_) &&
+            !IsSparseFloatVectorDataType(column_type_))
                ? GetDimensionFromFileMetaData(
                      file_meta->schema()->Column(column_index), column_type_)
                : 1;

--- a/internal/core/src/storage/PayloadWriter.cpp
+++ b/internal/core/src/storage/PayloadWriter.cpp
@@ -14,9 +14,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "storage/PayloadWriter.h"
 #include "common/EasyAssert.h"
 #include "common/FieldMeta.h"
+#include "common/Types.h"
+#include "storage/PayloadWriter.h"
 #include "storage/Util.h"
 
 namespace milvus::storage {
@@ -53,7 +54,7 @@ PayloadWriter::init_dimension(int dim) {
 void
 PayloadWriter::add_one_string_payload(const char* str, int str_size) {
     AssertInfo(output_ == nullptr, "payload writer has been finished");
-    AssertInfo(milvus::datatype_is_string(column_type_), "mismatch data type");
+    AssertInfo(milvus::IsStringDataType(column_type_), "mismatch data type");
     AddOneStringToArrowBuilder(builder_, str, str_size);
     rows_.fetch_add(1);
 }
@@ -61,8 +62,8 @@ PayloadWriter::add_one_string_payload(const char* str, int str_size) {
 void
 PayloadWriter::add_one_binary_payload(const uint8_t* data, int length) {
     AssertInfo(output_ == nullptr, "payload writer has been finished");
-    AssertInfo(milvus::datatype_is_binary(column_type_) ||
-                   milvus::datatype_is_sparse_vector(column_type_),
+    AssertInfo(milvus::IsBinaryDataType(column_type_) ||
+                   milvus::IsSparseFloatVectorDataType(column_type_),
                "mismatch data type");
     AddOneBinaryToArrowBuilder(builder_, data, length);
     rows_.fetch_add(1);
@@ -73,7 +74,7 @@ PayloadWriter::add_payload(const Payload& raw_data) {
     AssertInfo(output_ == nullptr, "payload writer has been finished");
     AssertInfo(column_type_ == raw_data.data_type, "mismatch data type");
     AssertInfo(builder_ != nullptr, "empty arrow builder");
-    if (milvus::datatype_is_vector(column_type_)) {
+    if (milvus::IsVectorDataType(column_type_)) {
         AssertInfo(dimension_.has_value(), "dimension has not been inited");
         AssertInfo(dimension_ == raw_data.dimension, "inconsistent dimension");
     }

--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -767,9 +767,9 @@ CreateFieldData(const DataType& type, int64_t dim, int64_t total_num_rows) {
             return std::make_shared<FieldData<SparseFloatVector>>(
                 type, total_num_rows);
         default:
-            throw SegcoreError(
-                DataTypeInvalid,
-                "CreateFieldData not support data type " + datatype_name(type));
+            throw SegcoreError(DataTypeInvalid,
+                               "CreateFieldData not support data type " +
+                                   GetDataTypeName(type));
     }
 }
 

--- a/internal/core/unittest/test_expr.cpp
+++ b/internal/core/unittest/test_expr.cpp
@@ -1300,21 +1300,21 @@ TEST(Expr, TestExprPerformance) {
 
     auto build_unary_range_expr = [&](DataType data_type,
                                       int64_t value) -> expr::TypedExprPtr {
-        if (IsIntegral(data_type)) {
+        if (IsIntegerDataType(data_type)) {
             proto::plan::GenericValue val;
             val.set_int64_val(value);
             return std::make_shared<expr::UnaryRangeFilterExpr>(
                 expr::ColumnInfo(fids[data_type], data_type),
                 proto::plan::OpType::LessThan,
                 val);
-        } else if (IsFloat(data_type)) {
+        } else if (IsFloatDataType(data_type)) {
             proto::plan::GenericValue val;
             val.set_float_val(float(value));
             return std::make_shared<expr::UnaryRangeFilterExpr>(
                 expr::ColumnInfo(fids[data_type], data_type),
                 proto::plan::OpType::LessThan,
                 val);
-        } else if (IsString(data_type)) {
+        } else if (IsStringDataType(data_type)) {
             proto::plan::GenericValue val;
             val.set_string_val(std::to_string(value));
             return std::make_shared<expr::UnaryRangeFilterExpr>(
@@ -1329,7 +1329,7 @@ TEST(Expr, TestExprPerformance) {
     auto build_binary_range_expr = [&](DataType data_type,
                                        int64_t low,
                                        int64_t high) -> expr::TypedExprPtr {
-        if (IsIntegral(data_type)) {
+        if (IsIntegerDataType(data_type)) {
             proto::plan::GenericValue val1;
             val1.set_int64_val(low);
             proto::plan::GenericValue val2;
@@ -1340,7 +1340,7 @@ TEST(Expr, TestExprPerformance) {
                 val2,
                 true,
                 true);
-        } else if (IsFloat(data_type)) {
+        } else if (IsFloatDataType(data_type)) {
             proto::plan::GenericValue val1;
             val1.set_float_val(float(low));
             proto::plan::GenericValue val2;
@@ -1351,7 +1351,7 @@ TEST(Expr, TestExprPerformance) {
                 val2,
                 true,
                 true);
-        } else if (IsString(data_type)) {
+        } else if (IsStringDataType(data_type)) {
             proto::plan::GenericValue val1;
             val1.set_string_val(std::to_string(low));
             proto::plan::GenericValue val2;
@@ -1370,7 +1370,7 @@ TEST(Expr, TestExprPerformance) {
     auto build_term_expr =
         [&](DataType data_type,
             std::vector<int64_t> in_vals) -> expr::TypedExprPtr {
-        if (IsIntegral(data_type)) {
+        if (IsIntegerDataType(data_type)) {
             std::vector<proto::plan::GenericValue> vals;
             for (auto& v : in_vals) {
                 proto::plan::GenericValue val;
@@ -1379,7 +1379,7 @@ TEST(Expr, TestExprPerformance) {
             }
             return std::make_shared<expr::TermFilterExpr>(
                 expr::ColumnInfo(fids[data_type], data_type), vals, false);
-        } else if (IsFloat(data_type)) {
+        } else if (IsFloatDataType(data_type)) {
             std::vector<proto::plan::GenericValue> vals;
             for (auto& v : in_vals) {
                 proto::plan::GenericValue val;
@@ -1388,7 +1388,7 @@ TEST(Expr, TestExprPerformance) {
             }
             return std::make_shared<expr::TermFilterExpr>(
                 expr::ColumnInfo(fids[data_type], data_type), vals, false);
-        } else if (IsString(data_type)) {
+        } else if (IsStringDataType(data_type)) {
             std::vector<proto::plan::GenericValue> vals;
             for (auto& v : in_vals) {
                 proto::plan::GenericValue val;
@@ -1403,8 +1403,8 @@ TEST(Expr, TestExprPerformance) {
     };
 
     auto build_compare_expr = [&](DataType data_type) -> expr::TypedExprPtr {
-        if (IsIntegral(data_type) || IsFloat(data_type) ||
-            IsString(data_type)) {
+        if (IsIntegerDataType(data_type) || IsFloatDataType(data_type) ||
+            IsStringDataType(data_type)) {
             return std::make_shared<expr::CompareExpr>(
                 fids[data_type],
                 fids[data_type],
@@ -1450,7 +1450,7 @@ TEST(Expr, TestExprPerformance) {
     auto build_arith_op_expr = [&](DataType data_type,
                                    int64_t right_val,
                                    int64_t val) -> expr::TypedExprPtr {
-        if (IsIntegral(data_type)) {
+        if (IsIntegerDataType(data_type)) {
             proto::plan::GenericValue val1;
             val1.set_int64_val(right_val);
             proto::plan::GenericValue val2;
@@ -1461,7 +1461,7 @@ TEST(Expr, TestExprPerformance) {
                 proto::plan::ArithOpType::Add,
                 val1,
                 val2);
-        } else if (IsFloat(data_type)) {
+        } else if (IsFloatDataType(data_type)) {
             proto::plan::GenericValue val1;
             val1.set_float_val(float(right_val));
             proto::plan::GenericValue val2;

--- a/internal/core/unittest/test_retrieve.cpp
+++ b/internal/core/unittest/test_retrieve.cpp
@@ -14,9 +14,7 @@
 #include "common/Types.h"
 #include "knowhere/comp/index_param.h"
 #include "query/Expr.h"
-#include "query/ExprImpl.h"
 #include "test_utils/DataGen.h"
-#include "exec/expression/Expr.h"
 #include "plan/PlanNode.h"
 
 using namespace milvus;
@@ -35,10 +33,8 @@ class RetrieveTest : public ::testing::TestWithParam<Param> {
     void
     SetUp() override {
         data_type = GetParam();
-        metric_type = datatype_is_sparse_vector(data_type)
-                          ? knowhere::metric::IP
-                          : knowhere::metric::L2;
-        is_sparse = datatype_is_sparse_vector(data_type);
+        is_sparse = IsSparseFloatVectorDataType(data_type);
+        metric_type = is_sparse ? knowhere::metric::IP : knowhere::metric::L2;
     }
 
     DataType data_type;


### PR DESCRIPTION
Issue: #22837 

Move and rename following C++ APIs:
datatype_sizeof() ==> GetDataTypeSize()
datatype_name() ==> GetDataTypeName()
datatype_is_vector() / IsVectorType() ==> IsVectorDataType()
datatype_is_variable() ==> IsVariableDataType()
datatype_is_sparse_vector() ==> IsSparseFloatVectorDataType()
datatype_is_string() / IsString() ==> IsDataTypeString()
datatype_is_floating() / IsFloat() ==> IsDataTypeFloat()
datatype_is_binary() ==> IsDataTypeBinary()
datatype_is_json() ==> IsDataTypeJson()
datatype_is_array() ==> IsDataTypeArray()
datatype_is_variable() == IsDataTypeVariable()
datatype_is_integer() / IsIntegral() ==> IsDataTypeInteger()