### PR TITLE
fix: [2.4] Clone child segment info before decompress its deltalog (#31792)

### DIFF
--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -383,10 +383,11 @@ func (s *Server) GetSegmentInfo(ctx context.Context, req *datapb.GetSegmentInfoR
 
 			clonedInfo := info.Clone()
 			if child != nil {
+				clonedChild := child.Clone()
 				// child segment should decompress binlog path
-				binlog.DecompressBinLog(storage.DeleteBinlog, child.GetCollectionID(), child.GetPartitionID(), child.GetID(), child.GetDeltalogs())
-				clonedInfo.Deltalogs = append(clonedInfo.Deltalogs, child.GetDeltalogs()...)
-				clonedInfo.DmlPosition = child.GetDmlPosition()
+				binlog.DecompressBinLog(storage.DeleteBinlog, clonedChild.GetCollectionID(), clonedChild.GetPartitionID(), clonedChild.GetID(), clonedChild.GetDeltalogs())
+				clonedInfo.Deltalogs = append(clonedInfo.Deltalogs, clonedChild.GetDeltalogs()...)
+				clonedInfo.DmlPosition = clonedChild.GetDmlPosition()
 			}
 			segmentutil.ReCalcRowCount(info.SegmentInfo, clonedInfo.SegmentInfo)
 			infos = append(infos, clonedInfo.SegmentInfo)


### PR DESCRIPTION
Cherry-pick from master
pr: #31792
Related to #31791

This segment meta is implemented in COW pattern. All modification on segment info shall happen on the copied version of it.

This PR clones the child segment info for `GetSegmentInfo` in case data race problem.

---------