### PR TITLE
fix: channel meta mergeFlushSegment not idempotent cause data loss

### DIFF
--- a/internal/datanode/channel_meta.go
+++ b/internal/datanode/channel_meta.go
@@ -697,6 +697,12 @@ func (c *ChannelMeta) mergeFlushedSegments(ctx context.Context, seg *Segment, pl
 
 	c.segMu.Lock()
 	defer c.segMu.Unlock()
+
+	if _, ok := c.segments[seg.segmentID]; ok {
+		log.Info("merge flushed segments exist, return")
+		return nil
+	}
+
 	var inValidSegments []UniqueID
 	for _, segID := range compactedFrom {
 		seg, ok := c.segments[segID]


### PR DESCRIPTION
fix channel meta mergeFlushSegment not idempotent may cause data loss when update compacted segment buffer, because may update buffer to segment which has been covered.
relate: https://github.com/milvus-io/milvus/issues/31548