### PR TITLE
fix: make balance channel/segment execute in parallel

### DIFF
--- a/internal/querycoordv2/balance/multi_target_balance.go
+++ b/internal/querycoordv2/balance/multi_target_balance.go
@@ -504,17 +504,13 @@ func (b *MultiTargetBalancer) BalanceReplica(replica *meta.Replica) ([]SegmentAs
 		)
 		// handle stopped nodes here, have to assign segments on stopping nodes to nodes with the smallest score
 		channelPlans = append(channelPlans, b.genStoppingChannelPlan(replica, onlineNodes, offlineNodes)...)
-		if len(channelPlans) == 0 {
-			segmentPlans = append(segmentPlans, b.genStoppingSegmentPlan(replica, onlineNodes, offlineNodes)...)
-		}
+		segmentPlans = append(segmentPlans, b.genStoppingSegmentPlan(replica, onlineNodes, offlineNodes)...)
 	} else {
 		if paramtable.Get().QueryCoordCfg.AutoBalanceChannel.GetAsBool() {
 			channelPlans = append(channelPlans, b.genChannelPlan(replica, onlineNodes)...)
 		}
 
-		if len(channelPlans) == 0 {
-			segmentPlans = b.genSegmentPlan(replica)
-		}
+		segmentPlans = b.genSegmentPlan(replica)
 	}
 
 	return segmentPlans, channelPlans

--- a/internal/querycoordv2/balance/rowcount_based_balancer.go
+++ b/internal/querycoordv2/balance/rowcount_based_balancer.go
@@ -206,17 +206,13 @@ func (b *RowCountBasedBalancer) BalanceReplica(replica *meta.Replica) ([]Segment
 		)
 		// handle stopped nodes here, have to assign segments on stopping nodes to nodes with the smallest score
 		channelPlans = append(channelPlans, b.genStoppingChannelPlan(replica, onlineNodes, offlineNodes)...)
-		if len(channelPlans) == 0 {
-			segmentPlans = append(segmentPlans, b.genStoppingSegmentPlan(replica, onlineNodes, offlineNodes)...)
-		}
+		segmentPlans = append(segmentPlans, b.genStoppingSegmentPlan(replica, onlineNodes, offlineNodes)...)
 	} else {
 		if paramtable.Get().QueryCoordCfg.AutoBalanceChannel.GetAsBool() {
 			channelPlans = append(channelPlans, b.genChannelPlan(replica, onlineNodes)...)
 		}
 
-		if len(channelPlans) == 0 {
-			segmentPlans = append(segmentPlans, b.genSegmentPlan(replica, onlineNodes)...)
-		}
+		segmentPlans = append(segmentPlans, b.genSegmentPlan(replica, onlineNodes)...)
 	}
 
 	return segmentPlans, channelPlans

--- a/internal/querycoordv2/balance/rowcount_based_balancer_test.go
+++ b/internal/querycoordv2/balance/rowcount_based_balancer_test.go
@@ -302,41 +302,13 @@ func (suite *RowCountBasedBalancerTestSuite) TestBalance() {
 					{VchannelInfo: &datapb.VchannelInfo{CollectionID: 1, ChannelName: "v3"}, Node: 3},
 				},
 			},
-			expectPlans: []SegmentAssignPlan{},
-			expectChannelPlans: []ChannelAssignPlan{
-				{Channel: &meta.DmChannel{VchannelInfo: &datapb.VchannelInfo{CollectionID: 1, ChannelName: "v3"}, Node: 3}, From: 3, To: 1, Replica: newReplicaDefaultRG(1)},
-			},
-		},
-		{
-			name:        "part stopping balance segment",
-			nodes:       []int64{1, 2, 3},
-			segmentCnts: []int{1, 2, 2},
-			states:      []session.State{session.NodeStateNormal, session.NodeStateNormal, session.NodeStateStopping},
-			shouldMock:  true,
-			distributions: map[int64][]*meta.Segment{
-				1: {{SegmentInfo: &datapb.SegmentInfo{ID: 1, CollectionID: 1, NumOfRows: 10}, Node: 1}},
-				2: {
-					{SegmentInfo: &datapb.SegmentInfo{ID: 2, CollectionID: 1, NumOfRows: 20}, Node: 2},
-					{SegmentInfo: &datapb.SegmentInfo{ID: 3, CollectionID: 1, NumOfRows: 30}, Node: 2},
-				},
-				3: {
-					{SegmentInfo: &datapb.SegmentInfo{ID: 4, CollectionID: 1, NumOfRows: 10}, Node: 3},
-					{SegmentInfo: &datapb.SegmentInfo{ID: 5, CollectionID: 1, NumOfRows: 10}, Node: 3},
-				},
-			},
-			distributionChannels: map[int64][]*meta.DmChannel{
-				2: {
-					{VchannelInfo: &datapb.VchannelInfo{CollectionID: 1, ChannelName: "v2"}, Node: 2},
-				},
-				1: {
-					{VchannelInfo: &datapb.VchannelInfo{CollectionID: 1, ChannelName: "v3"}, Node: 1},
-				},
-			},
 			expectPlans: []SegmentAssignPlan{
 				{Segment: &meta.Segment{SegmentInfo: &datapb.SegmentInfo{ID: 4, CollectionID: 1, NumOfRows: 10}, Node: 3}, From: 3, To: 1, Replica: newReplicaDefaultRG(1)},
 				{Segment: &meta.Segment{SegmentInfo: &datapb.SegmentInfo{ID: 5, CollectionID: 1, NumOfRows: 10}, Node: 3}, From: 3, To: 1, Replica: newReplicaDefaultRG(1)},
 			},
-			expectChannelPlans: []ChannelAssignPlan{},
+			expectChannelPlans: []ChannelAssignPlan{
+				{Channel: &meta.DmChannel{VchannelInfo: &datapb.VchannelInfo{CollectionID: 1, ChannelName: "v3"}, Node: 3}, From: 3, To: 1, Replica: newReplicaDefaultRG(1)},
+			},
 		},
 		{
 			name:          "balance channel",
@@ -735,41 +707,13 @@ func (suite *RowCountBasedBalancerTestSuite) TestBalanceOutboundNodes() {
 					{VchannelInfo: &datapb.VchannelInfo{CollectionID: 1, ChannelName: "v3"}, Node: 3},
 				},
 			},
-			expectPlans: []SegmentAssignPlan{},
-			expectChannelPlans: []ChannelAssignPlan{
-				{Channel: &meta.DmChannel{VchannelInfo: &datapb.VchannelInfo{CollectionID: 1, ChannelName: "v3"}, Node: 3}, From: 3, To: 1, Replica: newReplicaDefaultRG(1)},
-			},
-		},
-		{
-			name:        "balance segment with outbound node",
-			nodes:       []int64{1, 2, 3},
-			segmentCnts: []int{1, 2, 2},
-			states:      []session.State{session.NodeStateNormal, session.NodeStateNormal, session.NodeStateNormal},
-			shouldMock:  true,
-			distributions: map[int64][]*meta.Segment{
-				1: {{SegmentInfo: &datapb.SegmentInfo{ID: 1, CollectionID: 1, NumOfRows: 10}, Node: 1}},
-				2: {
-					{SegmentInfo: &datapb.SegmentInfo{ID: 2, CollectionID: 1, NumOfRows: 20}, Node: 2},
-					{SegmentInfo: &datapb.SegmentInfo{ID: 3, CollectionID: 1, NumOfRows: 30}, Node: 2},
-				},
-				3: {
-					{SegmentInfo: &datapb.SegmentInfo{ID: 4, CollectionID: 1, NumOfRows: 10}, Node: 3},
-					{SegmentInfo: &datapb.SegmentInfo{ID: 5, CollectionID: 1, NumOfRows: 10}, Node: 3},
-				},
-			},
-			distributionChannels: map[int64][]*meta.DmChannel{
-				2: {
-					{VchannelInfo: &datapb.VchannelInfo{CollectionID: 1, ChannelName: "v2"}, Node: 2},
-				},
-				1: {
-					{VchannelInfo: &datapb.VchannelInfo{CollectionID: 1, ChannelName: "v3"}, Node: 1},
-				},
-			},
 			expectPlans: []SegmentAssignPlan{
 				{Segment: &meta.Segment{SegmentInfo: &datapb.SegmentInfo{ID: 4, CollectionID: 1, NumOfRows: 10}, Node: 3}, From: 3, To: 1, Replica: newReplicaDefaultRG(1)},
 				{Segment: &meta.Segment{SegmentInfo: &datapb.SegmentInfo{ID: 5, CollectionID: 1, NumOfRows: 10}, Node: 3}, From: 3, To: 1, Replica: newReplicaDefaultRG(1)},
 			},
-			expectChannelPlans: []ChannelAssignPlan{},
+			expectChannelPlans: []ChannelAssignPlan{
+				{Channel: &meta.DmChannel{VchannelInfo: &datapb.VchannelInfo{CollectionID: 1, ChannelName: "v3"}, Node: 3}, From: 3, To: 1, Replica: newReplicaDefaultRG(1)},
+			},
 		},
 	}
 
@@ -1197,19 +1141,8 @@ func (suite *RowCountBasedBalancerTestSuite) TestMultiReplicaBalance() {
 
 			// expected to balance channel first
 			segmentPlans, channelPlans := suite.getCollectionBalancePlans(balancer, c.collectionID)
-			suite.Len(segmentPlans, 0)
-			suite.Len(channelPlans, 2)
-
-			// mock new distribution after channel balance
-			balancer.dist.ChannelDistManager.Update(1, &meta.DmChannel{VchannelInfo: &datapb.VchannelInfo{CollectionID: 1, ChannelName: "channel1"}, Node: 1})
-			balancer.dist.ChannelDistManager.Update(2, &meta.DmChannel{VchannelInfo: &datapb.VchannelInfo{CollectionID: 1, ChannelName: "channel2"}, Node: 2})
-			balancer.dist.ChannelDistManager.Update(3, &meta.DmChannel{VchannelInfo: &datapb.VchannelInfo{CollectionID: 1, ChannelName: "channel3"}, Node: 3})
-			balancer.dist.ChannelDistManager.Update(4, &meta.DmChannel{VchannelInfo: &datapb.VchannelInfo{CollectionID: 1, ChannelName: "channel4"}, Node: 4})
-
-			// expected to balance segment
-			segmentPlans, channelPlans = suite.getCollectionBalancePlans(balancer, c.collectionID)
 			suite.Len(segmentPlans, 2)
-			suite.Len(channelPlans, 0)
+			suite.Len(channelPlans, 2)
 		})
 	}
 }

--- a/internal/querycoordv2/balance/score_based_balancer.go
+++ b/internal/querycoordv2/balance/score_based_balancer.go
@@ -233,17 +233,13 @@ func (b *ScoreBasedBalancer) BalanceReplica(replica *meta.Replica) ([]SegmentAss
 		)
 		// handle stopped nodes here, have to assign segments on stopping nodes to nodes with the smallest score
 		channelPlans = append(channelPlans, b.genStoppingChannelPlan(replica, onlineNodes, offlineNodes)...)
-		if len(channelPlans) == 0 {
-			segmentPlans = append(segmentPlans, b.genStoppingSegmentPlan(replica, onlineNodes, offlineNodes)...)
-		}
+		segmentPlans = append(segmentPlans, b.genStoppingSegmentPlan(replica, onlineNodes, offlineNodes)...)
 	} else {
 		if paramtable.Get().QueryCoordCfg.AutoBalanceChannel.GetAsBool() {
 			channelPlans = append(channelPlans, b.genChannelPlan(replica, onlineNodes)...)
 		}
 
-		if len(channelPlans) == 0 {
-			segmentPlans = append(segmentPlans, b.genSegmentPlan(replica, onlineNodes)...)
-		}
+		segmentPlans = append(segmentPlans, b.genSegmentPlan(replica, onlineNodes)...)
 	}
 
 	return segmentPlans, channelPlans

--- a/internal/querycoordv2/balance/score_based_balancer_test.go
+++ b/internal/querycoordv2/balance/score_based_balancer_test.go
@@ -822,19 +822,8 @@ func (suite *ScoreBasedBalancerTestSuite) TestMultiReplicaBalance() {
 
 			// expected to balance channel first
 			segmentPlans, channelPlans := suite.getCollectionBalancePlans(balancer, c.collectionID)
-			suite.Len(segmentPlans, 0)
-			suite.Len(channelPlans, 2)
-
-			// mock new distribution after channel balance
-			balancer.dist.ChannelDistManager.Update(1, &meta.DmChannel{VchannelInfo: &datapb.VchannelInfo{CollectionID: 1, ChannelName: "channel1"}, Node: 1})
-			balancer.dist.ChannelDistManager.Update(2, &meta.DmChannel{VchannelInfo: &datapb.VchannelInfo{CollectionID: 1, ChannelName: "channel2"}, Node: 2})
-			balancer.dist.ChannelDistManager.Update(3, &meta.DmChannel{VchannelInfo: &datapb.VchannelInfo{CollectionID: 1, ChannelName: "channel3"}, Node: 3})
-			balancer.dist.ChannelDistManager.Update(4, &meta.DmChannel{VchannelInfo: &datapb.VchannelInfo{CollectionID: 1, ChannelName: "channel4"}, Node: 4})
-
-			// expected to balance segment
-			segmentPlans, channelPlans = suite.getCollectionBalancePlans(balancer, c.collectionID)
 			suite.Len(segmentPlans, 2)
-			suite.Len(channelPlans, 0)
+			suite.Len(channelPlans, 2)
 		})
 	}
 }

--- a/internal/querycoordv2/checkers/leader_checker.go
+++ b/internal/querycoordv2/checkers/leader_checker.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/samber/lo"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/internal/proto/datapb"
@@ -122,12 +121,7 @@ func (c *LeaderChecker) findNeedLoadedSegments(ctx context.Context, replica *met
 	)
 	ret := make([]task.Task, 0)
 
-	// skip set segment on stopping node to leader view
-	aliveNodeDist := lo.Filter(dist, func(s *meta.Segment, _ int) bool {
-		nodeInfo := c.nodeMgr.Get(s.Node)
-		return nodeInfo != nil && nodeInfo.GetState() != session.NodeStateStopping
-	})
-	latestNodeDist := utils.FindMaxVersionSegments(aliveNodeDist)
+	latestNodeDist := utils.FindMaxVersionSegments(dist)
 	for _, s := range latestNodeDist {
 		segment := c.target.GetSealedSegment(leaderView.CollectionID, s.GetID(), meta.CurrentTargetFirst)
 		existInTarget := segment != nil

--- a/internal/querycoordv2/task/action.go
+++ b/internal/querycoordv2/task/action.go
@@ -191,6 +191,10 @@ func (action *LeaderAction) Version() typeutil.UniqueID {
 	return action.version
 }
 
+func (action *LeaderAction) GetLeaderID() typeutil.UniqueID {
+	return action.leaderID
+}
+
 func (action *LeaderAction) IsFinished(distMgr *meta.DistributionManager) bool {
 	views := distMgr.LeaderViewManager.GetLeaderView(action.leaderID)
 	view := views[action.Shard()]

--- a/internal/querycoordv2/task/scheduler.go
+++ b/internal/querycoordv2/task/scheduler.go
@@ -966,7 +966,7 @@ func (scheduler *taskScheduler) checkLeaderTaskStale(task *LeaderTask) error {
 	for _, action := range task.Actions() {
 		switch action.Type() {
 		case ActionTypeGrow:
-			if ok, _ := scheduler.nodeMgr.IsStoppingNode(action.Node()); ok {
+			if ok, _ := scheduler.nodeMgr.IsStoppingNode(action.(*LeaderAction).GetLeaderID()); ok {
 				log.Warn("task stale due to node offline", zap.Int64("segment", task.segmentID))
 				return merr.WrapErrNodeOffline(action.Node())
 			}


### PR DESCRIPTION
issue: #30816

this PR remove two unnecessary constraints:
1. balance channel first, then balance segment. which will slow the whole stopping balance progress.
2. skip set segment on stopping node to leader view, which will slow the balance channel progress in stopping balance 