### PR TITLE
fix: Return err for conc.Future in sync manager (#31790)

### DIFF
--- a/internal/datanode/syncmgr/sync_manager.go
+++ b/internal/datanode/syncmgr/sync_manager.go
@@ -127,7 +127,7 @@ func (mgr *syncManager) safeSubmitTask(task Task) *conc.Future[error] {
 		for {
 			targetID, err := task.CalcTargetSegment()
 			if err != nil {
-				return err, nil
+				return err, err
 			}
 			log.Info("task calculated target segment id",
 				zap.Int64("targetID", targetID),
@@ -142,7 +142,7 @@ func (mgr *syncManager) safeSubmitTask(task Task) *conc.Future[error] {
 				log.Info("target updated during submitting", zap.Error(err))
 				continue
 			}
-			return err, nil
+			return err, err
 		}
 	})
 }


### PR DESCRIPTION
Should not return `err, nil` when using conc.Future, as the error will be lost/ignored when using `AwaitAll` to wait for the future.

issue: https://github.com/milvus-io/milvus/issues/31788

pr: https://github.com/milvus-io/milvus/pull/31790