### PR TITLE
fix: deadlock in cache concurrent visit

### DIFF
--- a/pkg/util/cache/cache_test.go
+++ b/pkg/util/cache/cache_test.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"math/rand"
 	"sync"
 	"testing"
 	"time"
@@ -237,8 +238,9 @@ func TestLRUCacheConcurrency(t *testing.T) {
 			wg.Add(1)
 			go func(i int) {
 				defer wg.Done()
-				for j := 0; j < 100; j++ {
-					err := cache.DoWait(j, 2*time.Second, func(v int) error {
+				for j := 0; j < 20; j++ {
+					err := cache.DoWait(j, time.Second, func(v int) error {
+						time.Sleep(time.Duration(rand.Intn(3)))
 						return nil
 					})
 					assert.NoError(t, err)


### PR DESCRIPTION
See #31944

There is deadlock in concurrent invocation on `cache.DoWait()`. Suppose 2 callers are calling `DoWait` concurrently, the notification for cache wait queue may be limited to just 1 caller's occupation instead of them combined. 

To fix this issue, this patch is trying to notify all waiters in queue. 