### PR TITLE
fix: add configuration disk capacity config for lru and fix some bug

### DIFF
--- a/internal/core/src/segcore/InsertRecord.h
+++ b/internal/core/src/segcore/InsertRecord.h
@@ -244,6 +244,7 @@ class OffsetOrderedArray : public OffsetMap {
     void
     clear() override {
         array_.clear();
+        is_sealed = false;
     }
 
  private:

--- a/internal/core/src/segcore/SegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/SegmentSealedImpl.cpp
@@ -1125,9 +1125,9 @@ SegmentSealedImpl::bulk_subscript_impl(int64_t element_sizeof,
 
 void
 SegmentSealedImpl::ClearData() {
-    field_data_ready_bitset_.clear();
-    index_ready_bitset_.clear();
-    binlog_index_bitset_.clear();
+    field_data_ready_bitset_.reset();
+    index_ready_bitset_.reset();
+    binlog_index_bitset_.reset();
     system_ready_count_ = 0;
     num_rows_ = 0;
     scalar_indexings_.clear();

--- a/internal/querynodev2/segments/manager.go
+++ b/internal/querynodev2/segments/manager.go
@@ -162,7 +162,7 @@ type Manager struct {
 }
 
 func NewManager() *Manager {
-	diskCap := paramtable.Get().QueryNodeCfg.DiskCapacityLimit.GetAsInt64()
+	diskCap := paramtable.Get().QueryNodeCfg.DiskCacheCapacityLimit.GetAsInt64()
 
 	segMgr := NewSegmentManager()
 	sf := singleflight.Group{}

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -1940,6 +1940,7 @@ type queryNodeConfig struct {
 	EnableDisk             ParamItem `refreshable:"true"`
 	DiskCapacityLimit      ParamItem `refreshable:"true"`
 	MaxDiskUsagePercentage ParamItem `refreshable:"true"`
+	DiskCacheCapacityLimit ParamItem `refreshable:"true"`
 
 	// cache limit
 	CacheEnabled     ParamItem `refreshable:"false"`
@@ -2333,6 +2334,18 @@ Max read concurrency must greater than or equal to 1, and less than or equal to 
 		Export: true,
 	}
 	p.MaxDiskUsagePercentage.Init(base.mgr)
+
+	p.DiskCacheCapacityLimit = ParamItem{
+		Key:     "queryNode.diskCacheCapacityLimit",
+		Version: "2.4.1",
+		Formatter: func(v string) string {
+			if len(v) == 0 {
+				return strconv.FormatInt(int64(float64(p.DiskCapacityLimit.GetAsInt64())*p.MaxDiskUsagePercentage.GetAsFloat()), 10)
+			}
+			return v
+		},
+	}
+	p.DiskCacheCapacityLimit.Init(base.mgr)
 
 	p.MaxTimestampLag = ParamItem{
 		Key:          "queryNode.scheduler.maxTimestampLag",

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -365,6 +365,10 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, 2.5, Params.MemoryIndexLoadPredictMemoryUsageFactor.GetAsFloat())
 		params.Save("queryNode.memoryIndexLoadPredictMemoryUsageFactor", "2.0")
 		assert.Equal(t, 2.0, Params.MemoryIndexLoadPredictMemoryUsageFactor.GetAsFloat())
+
+		assert.NotZero(t, Params.DiskCacheCapacityLimit.GetAsInt64())
+		params.Save("queryNode.diskCacheCapacityLimit", "70")
+		assert.Equal(t, int64(70), Params.DiskCacheCapacityLimit.GetAsInt64())
 	})
 
 	t.Run("test dataCoordConfig", func(t *testing.T) {


### PR DESCRIPTION
issue: #30361

- Add configurable disk capacity limit

- fix bitset reset logic

- make insert record reinsert after clear