### PR TITLE
fix: delete may lost when enable lru cache, some field should be reset when ReleaseData

### DIFF
--- a/internal/core/src/common/Types.h
+++ b/internal/core/src/common/Types.h
@@ -182,12 +182,12 @@ GetDataTypeName(DataType data_type) {
 }
 
 inline size_t
-CalcPksSize(const std::vector<PkType>& pks) {
+CalcPksSize(const PkType* data, size_t n) {
     size_t size = 0;
-    for (auto& pk : pks) {
-        size += sizeof(pk);
-        if (std::holds_alternative<std::string>(pk)) {
-            size += std::get<std::string>(pk).size();
+    for (size_t i = 0; i < n; ++i) {
+        size += sizeof(data[i]);
+        if (std::holds_alternative<std::string>(data[i])) {
+            size += std::get<std::string>(data[i]).size();
         }
     }
     return size;

--- a/internal/core/src/segcore/DeletedRecord.h
+++ b/internal/core/src/segcore/DeletedRecord.h
@@ -105,6 +105,8 @@ struct DeletedRecord {
         pks_.set_data_raw(n, pks.data() + divide_point, size);
         timestamps_.set_data_raw(n, timestamps + divide_point, size);
         n_ += size;
+        mem_size_ += sizeof(Timestamp) * size +
+                     CalcPksSize(pks.data() + divide_point, size);
     }
 
     const ConcurrentVector<Timestamp>&
@@ -122,12 +124,18 @@ struct DeletedRecord {
         return n_.load();
     }
 
+    size_t
+    mem_size() const {
+        return mem_size_.load();
+    }
+
  private:
     std::shared_ptr<TmpBitmap> lru_;
     std::shared_mutex shared_mutex_;
 
     std::shared_mutex buffer_mutex_;
     std::atomic<int64_t> n_ = 0;
+    std::atomic<int64_t> mem_size_ = 0;
     ConcurrentVector<Timestamp> timestamps_;
     ConcurrentVector<PkType> pks_;
 };

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -395,7 +395,6 @@ SegmentGrowingImpl::Delete(int64_t reserved_begin,
 
     // step 2: fill delete record
     deleted_record_.push(sort_pks, sort_timestamps.data());
-    stats_.mem_size += size * sizeof(Timestamp) + CalcPksSize(sort_pks);
     return SegcoreError::success();
 }
 
@@ -417,8 +416,6 @@ SegmentGrowingImpl::LoadDeletedRecord(const LoadDeletedRecordInfo& info) {
 
     // step 2: fill pks and timestamps
     deleted_record_.push(pks, timestamps);
-
-    stats_.mem_size += info.row_count * sizeof(Timestamp) + CalcPksSize(pks);
 }
 
 SpanBase

--- a/internal/core/src/segcore/SegmentGrowingImpl.h
+++ b/internal/core/src/segcore/SegmentGrowingImpl.h
@@ -130,6 +130,11 @@ class SegmentGrowingImpl : public SegmentGrowing {
     try_remove_chunks(FieldId fieldId);
 
  public:
+    size_t
+    GetMemoryUsageInBytes() const override {
+        return stats_.mem_size.load() + deleted_record_.mem_size();
+    }
+
     int64_t
     get_row_count() const override {
         return insert_record_.ack_responder_.GetAck();
@@ -305,6 +310,8 @@ class SegmentGrowingImpl : public SegmentGrowing {
     mutable DeletedRecord deleted_record_;
 
     int64_t id_;
+
+    SegmentStats stats_{};
 };
 
 const static IndexMetaPtr empty_index_meta =

--- a/internal/core/src/segcore/SegmentInterface.h
+++ b/internal/core/src/segcore/SegmentInterface.h
@@ -69,10 +69,8 @@ class SegmentInterface {
              Timestamp timestamp,
              int64_t limit_size) const = 0;
 
-    size_t
-    GetMemoryUsageInBytes() const {
-        return stats_.mem_size;
-    };
+    virtual size_t
+    GetMemoryUsageInBytes() const = 0;
 
     virtual int64_t
     get_row_count() const = 0;
@@ -120,9 +118,6 @@ class SegmentInterface {
 
     virtual bool
     HasRawData(int64_t field_id) const = 0;
-
- protected:
-    SegmentStats stats_{};
 };
 
 // internal API for DSL calculation

--- a/internal/core/src/segcore/SegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/SegmentSealedImpl.cpp
@@ -105,10 +105,6 @@ SegmentSealedImpl::LoadVecIndex(const LoadIndexInfo& info) {
                        ") than other column's row count (" +
                        std::to_string(num_rows_.value()) + ")");
     }
-    LOG_INFO(
-        "Before setting field_bit for field index, fieldID:{}. segmentID:{}, ",
-        info.field_id,
-        id_);
     if (get_bit(field_data_ready_bitset_, field_id)) {
         fields_.erase(field_id);
         set_bit(field_data_ready_bitset_, field_id, false);
@@ -122,9 +118,6 @@ SegmentSealedImpl::LoadVecIndex(const LoadIndexInfo& info) {
         metric_type,
         std::move(const_cast<LoadIndexInfo&>(info).index));
     set_bit(index_ready_bitset_, field_id, true);
-    LOG_INFO("Has load vec index done, fieldID:{}. segmentID:{}, ",
-             info.field_id,
-             id_);
 }
 
 void

--- a/internal/core/src/segcore/SegmentSealedImpl.h
+++ b/internal/core/src/segcore/SegmentSealedImpl.h
@@ -89,6 +89,11 @@ class SegmentSealedImpl : public SegmentSealed {
     GetFieldDataType(FieldId fieldId) const override;
 
  public:
+    size_t
+    GetMemoryUsageInBytes() const override {
+        return stats_.mem_size.load() + deleted_record_.mem_size();
+    }
+
     int64_t
     get_row_count() const override;
 
@@ -302,6 +307,8 @@ class SegmentSealedImpl : public SegmentSealed {
     SegcoreConfig segcore_config_;
     std::unordered_map<FieldId, std::unique_ptr<VecIndexConfig>>
         vec_binlog_config_;
+
+    SegmentStats stats_{};
 };
 
 inline SegmentSealedUPtr

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -654,35 +654,39 @@ func (loader *segmentLoader) Load(ctx context.Context,
 		newSegments.Insert(loadInfo.GetSegmentID(), segment)
 	}
 
-	loadSegmentFunc := func(idx int) error {
+	loadSegmentFunc := func(idx int) (err error) {
 		loadInfo := infos[idx]
 		partitionID := loadInfo.PartitionID
 		segmentID := loadInfo.SegmentID
 		segment, _ := newSegments.Get(segmentID)
 
+		logger := log.With(zap.Int64("partitionID", partitionID),
+			zap.Int64("segmentID", segmentID),
+			zap.String("segmentType", loadInfo.GetLevel().String()))
 		metrics.QueryNodeLoadSegmentConcurrency.WithLabelValues(fmt.Sprint(paramtable.GetNodeID()), "LoadSegment").Inc()
-		defer metrics.QueryNodeLoadSegmentConcurrency.WithLabelValues(fmt.Sprint(paramtable.GetNodeID()), "LoadSegment").Dec()
-
+		defer func() {
+			metrics.QueryNodeLoadSegmentConcurrency.WithLabelValues(fmt.Sprint(paramtable.GetNodeID()), "LoadSegment").Dec()
+			if err != nil {
+				logger.Warn("load segment failed when load data into memory", zap.Error(err))
+			}
+			logger.Info("load segment done")
+		}()
 		tr := timerecord.NewTimeRecorder("loadDurationPerSegment")
+		logger.Info("load segment...")
 
-		var err error
-		if loadInfo.GetLevel() == datapb.SegmentLevel_L0 {
-			err = loader.LoadDeltaLogs(ctx, segment, loadInfo.GetDeltalogs())
-		} else {
-			err = loader.LoadSegment(ctx, segment.(*LocalSegment), loadInfo, loadStatus)
+		// L0 segment has no index or data to be load
+		if loadInfo.GetLevel() != datapb.SegmentLevel_L0 {
+			if err = loader.LoadSegment(ctx, segment.(*LocalSegment), loadInfo, loadStatus); err != nil {
+				return errors.Wrap(err, "At LoadSegment")
+			}
 		}
-		if err != nil {
-			log.Warn("load segment failed when load data into memory",
-				zap.Int64("partitionID", partitionID),
-				zap.Int64("segmentID", segmentID),
-				zap.Error(err),
-			)
-			return err
+		if err = loader.LoadDeltaLogs(ctx, segment, loadInfo.GetDeltalogs()); err != nil {
+			return errors.Wrap(err, "At LoadDeltaLogs")
 		}
+
 		loader.manager.Segment.Put(segmentType, segment)
 		newSegments.GetAndRemove(segmentID)
 		loaded.Insert(segmentID, segment)
-		log.Info("load segment done", zap.Int64("segmentID", segmentID))
 		loader.notifyLoadFinish(loadInfo)
 
 		metrics.QueryNodeLoadSegmentLatency.WithLabelValues(fmt.Sprint(paramtable.GetNodeID())).Observe(float64(tr.ElapseSpan().Milliseconds()))
@@ -1096,8 +1100,7 @@ func (loader *segmentLoader) LoadSegment(ctx context.Context,
 		strconv.FormatInt(int64(len(segment.Indexes())), 10),
 	).Add(float64(loadInfo.GetNumOfRows()))
 
-	log.Info("loading delta...")
-	return loader.LoadDeltaLogs(ctx, segment, loadInfo.Deltalogs)
+	return nil
 }
 
 func (loader *segmentLoader) filterPKStatsBinlogs(fieldBinlogs []*datapb.FieldBinlog, pkFieldID int64) ([]string, storage.StatsLogType) {
@@ -1279,7 +1282,10 @@ func (loader *segmentLoader) LoadDeltaLogs(ctx context.Context, segment Segment,
 	defer sp.End()
 	log := log.Ctx(ctx).With(
 		zap.Int64("segmentID", segment.ID()),
+		zap.Int("deltaNum", len(deltaLogs)),
 	)
+	log.Info("loading delta...")
+
 	dCodec := storage.DeleteCodec{}
 	var blobs []*storage.Blob
 	var futures []*conc.Future[any]


### PR DESCRIPTION
issue: #30361

- Delete may be lost when segment is not data-loaded status in lru cache. skip filtering to fix it.

- `stats_` and `variable_fields_avg_size_` should be reset when `ReleaseData`

- Remove repeat load delta log operation in lru.