### PR TITLE
fix: Check exclude segment before add new growing segment (#31803)

### DIFF
--- a/internal/querynodev2/delegator/delegator.go
+++ b/internal/querynodev2/delegator/delegator.go
@@ -75,6 +75,11 @@ type ShardDelegator interface {
 	SyncTargetVersion(newVersion int64, growingInTarget []int64, sealedInTarget []int64, droppedInTarget []int64, checkpoint *msgpb.MsgPosition)
 	GetTargetVersion() int64
 
+	// manage exclude segments
+	AddExcludedSegments(excludeInfo map[int64]uint64)
+	VerifyExcludedSegments(segmentID int64, ts uint64) bool
+	TryCleanExcludedSegments(ts uint64)
+
 	// control
 	Serviceable() bool
 	Start()
@@ -115,6 +120,11 @@ type shardDelegator struct {
 	latestTsafe *atomic.Uint64
 	// queryHook
 	queryHook optimizers.QueryHook
+
+	excludedSegments *ExcludedSegments
+	// cause growing segment meta has been stored in segmentManager/distribution/pkOracle/excludeSegments
+	// in order to make add/remove growing be atomic, need lock before modify these meta info
+	growingSegmentLock sync.RWMutex
 }
 
 // getLogger returns the zap logger with pre-defined shard attributes.
@@ -759,24 +769,27 @@ func NewShardDelegator(ctx context.Context, collectionID UniqueID, replicaID Uni
 	sizePerBlock := paramtable.Get().QueryNodeCfg.DeleteBufferBlockSize.GetAsInt64()
 	log.Info("Init delete cache with list delete buffer", zap.Int64("sizePerBlock", sizePerBlock), zap.Time("startTime", tsoutil.PhysicalTime(startTs)))
 
+	excludedSegments := NewExcludedSegments(paramtable.Get().QueryNodeCfg.CleanExcludeSegInterval.GetAsDuration(time.Second))
+
 	sd := &shardDelegator{
-		collectionID:    collectionID,
-		replicaID:       replicaID,
-		vchannelName:    channel,
-		version:         version,
-		collection:      collection,
-		segmentManager:  manager.Segment,
-		workerManager:   workerManager,
-		lifetime:        lifetime.NewLifetime(lifetime.Initializing),
-		distribution:    NewDistribution(),
-		level0Deletions: make(map[int64]*storage.DeleteData),
-		deleteBuffer:    deletebuffer.NewListDeleteBuffer[*deletebuffer.Item](startTs, sizePerBlock),
-		pkOracle:        pkoracle.NewPkOracle(),
-		tsafeManager:    tsafeManager,
-		latestTsafe:     atomic.NewUint64(startTs),
-		loader:          loader,
-		factory:         factory,
-		queryHook:       queryHook,
+		collectionID:     collectionID,
+		replicaID:        replicaID,
+		vchannelName:     channel,
+		version:          version,
+		collection:       collection,
+		segmentManager:   manager.Segment,
+		workerManager:    workerManager,
+		lifetime:         lifetime.NewLifetime(lifetime.Initializing),
+		distribution:     NewDistribution(),
+		level0Deletions:  make(map[int64]*storage.DeleteData),
+		deleteBuffer:     deletebuffer.NewListDeleteBuffer[*deletebuffer.Item](startTs, sizePerBlock),
+		pkOracle:         pkoracle.NewPkOracle(),
+		tsafeManager:     tsafeManager,
+		latestTsafe:      atomic.NewUint64(startTs),
+		loader:           loader,
+		factory:          factory,
+		queryHook:        queryHook,
+		excludedSegments: excludedSegments,
 	}
 	m := sync.Mutex{}
 	sd.tsCond = sync.NewCond(&m)

--- a/internal/querynodev2/delegator/delegator_data_test.go
+++ b/internal/querynodev2/delegator/delegator_data_test.go
@@ -19,6 +19,7 @@ package delegator
 import (
 	"context"
 	"testing"
+	"time"
 
 	bloom "github.com/bits-and-blooms/bloom/v3"
 	"github.com/cockroachdb/errors"
@@ -64,6 +65,11 @@ type DelegatorDataSuite struct {
 func (s *DelegatorDataSuite) SetupSuite() {
 	paramtable.Init()
 	paramtable.SetNodeID(1)
+	paramtable.Get().Save(paramtable.Get().QueryNodeCfg.CleanExcludeSegInterval.Key, "1")
+}
+
+func (s *DelegatorDataSuite) TearDownSuite() {
+	paramtable.Get().Reset(paramtable.Get().QueryNodeCfg.CleanExcludeSegInterval.Key)
 }
 
 func (s *DelegatorDataSuite) SetupTest() {
@@ -998,6 +1004,20 @@ func (s *DelegatorDataSuite) TestReadDeleteFromMsgstream() {
 	result, err := s.delegator.readDeleteFromMsgstream(ctx, &msgpb.MsgPosition{Timestamp: 0}, 10, oracle)
 	s.NoError(err)
 	s.Equal(2, len(result.Pks))
+}
+
+func (s *DelegatorDataSuite) TestDelegatorData_ExcludeSegments() {
+	s.delegator.AddExcludedSegments(map[int64]uint64{
+		1: 3,
+	})
+
+	s.False(s.delegator.VerifyExcludedSegments(1, 1))
+	s.True(s.delegator.VerifyExcludedSegments(1, 5))
+
+	time.Sleep(time.Second * 1)
+	s.delegator.TryCleanExcludedSegments(4)
+	s.True(s.delegator.VerifyExcludedSegments(1, 1))
+	s.True(s.delegator.VerifyExcludedSegments(1, 5))
 }
 
 func TestDelegatorDataSuite(t *testing.T) {

--- a/internal/querynodev2/delegator/exclude_info.go
+++ b/internal/querynodev2/delegator/exclude_info.go
@@ -1,0 +1,88 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package delegator
+
+import (
+	"sync"
+	"time"
+
+	"go.uber.org/atomic"
+	"go.uber.org/zap"
+
+	"github.com/milvus-io/milvus/pkg/log"
+)
+
+type ExcludedSegments struct {
+	mu            sync.RWMutex
+	segments      map[int64]uint64 // segmentID -> Excluded TS
+	lastClean     atomic.Time
+	cleanInterval time.Duration
+}
+
+func NewExcludedSegments(cleanInterval time.Duration) *ExcludedSegments {
+	return &ExcludedSegments{
+		segments:      make(map[int64]uint64),
+		cleanInterval: cleanInterval,
+	}
+}
+
+func (s *ExcludedSegments) Insert(excludeInfo map[int64]uint64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for segmentID, ts := range excludeInfo {
+		log.Debug("add exclude info",
+			zap.Int64("segmentID", segmentID),
+			zap.Uint64("ts", ts),
+		)
+		s.segments[segmentID] = ts
+	}
+}
+
+// return false if segment has been excluded
+func (s *ExcludedSegments) Verify(segmentID int64, ts uint64) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if excludeTs, ok := s.segments[segmentID]; ok && ts <= excludeTs {
+		return false
+	}
+	return true
+}
+
+func (s *ExcludedSegments) CleanInvalid(ts uint64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	invalidExcludedInfos := []int64{}
+	for segmentsID, excludeTs := range s.segments {
+		if excludeTs < ts {
+			invalidExcludedInfos = append(invalidExcludedInfos, segmentsID)
+		}
+	}
+
+	for _, segmentID := range invalidExcludedInfos {
+		delete(s.segments, segmentID)
+		log.Info("remove segment from exclude info", zap.Int64("segmentID", segmentID))
+	}
+	s.lastClean.Store(time.Now())
+}
+
+func (s *ExcludedSegments) ShouldClean() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return time.Since(s.lastClean.Load()) > s.cleanInterval
+}

--- a/internal/querynodev2/delegator/exclude_info_test.go
+++ b/internal/querynodev2/delegator/exclude_info_test.go
@@ -1,0 +1,56 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package delegator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type ExcludedInfoSuite struct {
+	suite.Suite
+
+	excludedSegments ExcludedSegments
+}
+
+func (s *ExcludedInfoSuite) SetupSuite() {
+	s.excludedSegments = *NewExcludedSegments(1 * time.Second)
+}
+
+func (s *ExcludedInfoSuite) TestBasic() {
+	s.excludedSegments.Insert(map[int64]uint64{
+		1: 3,
+	})
+
+	s.False(s.excludedSegments.Verify(1, 1))
+	s.True(s.excludedSegments.Verify(1, 4))
+
+	time.Sleep(1 * time.Second)
+
+	s.True(s.excludedSegments.ShouldClean())
+	s.excludedSegments.CleanInvalid(5)
+	s.Len(s.excludedSegments.segments, 0)
+
+	s.True(s.excludedSegments.Verify(1, 1))
+	s.True(s.excludedSegments.Verify(1, 4))
+}
+
+func TestExcludedInfoSuite(t *testing.T) {
+	suite.Run(t, new(ExcludedInfoSuite))
+}

--- a/internal/querynodev2/delegator/mock_delegator.go
+++ b/internal/querynodev2/delegator/mock_delegator.go
@@ -253,6 +253,39 @@ func (_c *MockShardDelegator_GetTargetVersion_Call) RunAndReturn(run func() int6
 	return _c
 }
 
+// AddExcludedSegments provides a mock function with given fields: excludeInfo
+func (_m *MockShardDelegator) AddExcludedSegments(excludeInfo map[int64]uint64) {
+	_m.Called(excludeInfo)
+}
+
+// MockShardDelegator_AddExcludedSegments_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddExcludedSegments'
+type MockShardDelegator_AddExcludedSegments_Call struct {
+	*mock.Call
+}
+
+// AddExcludedSegments is a helper method to define mock.On call
+//   - excludeInfo map[int64]uint64
+func (_e *MockShardDelegator_Expecter) AddExcludedSegments(excludeInfo interface{}) *MockShardDelegator_AddExcludedSegments_Call {
+	return &MockShardDelegator_AddExcludedSegments_Call{Call: _e.mock.On("AddExcludedSegments", excludeInfo)}
+}
+
+func (_c *MockShardDelegator_AddExcludedSegments_Call) Run(run func(excludeInfo map[int64]uint64)) *MockShardDelegator_AddExcludedSegments_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(map[int64]uint64))
+	})
+	return _c
+}
+
+func (_c *MockShardDelegator_AddExcludedSegments_Call) Return() *MockShardDelegator_AddExcludedSegments_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockShardDelegator_AddExcludedSegments_Call) RunAndReturn(run func(map[int64]uint64)) *MockShardDelegator_AddExcludedSegments_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // LoadGrowing provides a mock function with given fields: ctx, infos, version
 func (_m *MockShardDelegator) LoadGrowing(ctx context.Context, infos []*querypb.SegmentLoadInfo, version int64) error {
 	ret := _m.Called(ctx, infos, version)
@@ -759,6 +792,82 @@ func (_c *MockShardDelegator_SyncTargetVersion_Call) Return() *MockShardDelegato
 }
 
 func (_c *MockShardDelegator_SyncTargetVersion_Call) RunAndReturn(run func(int64, []int64, []int64, []int64, *msgpb.MsgPosition)) *MockShardDelegator_SyncTargetVersion_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// TryCleanExcludedSegments provides a mock function with given fields: ts
+func (_m *MockShardDelegator) TryCleanExcludedSegments(ts uint64) {
+	_m.Called(ts)
+}
+
+// MockShardDelegator_TryCleanExcludedSegments_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'TryCleanExcludedSegments'
+type MockShardDelegator_TryCleanExcludedSegments_Call struct {
+	*mock.Call
+}
+
+// TryCleanExcludedSegments is a helper method to define mock.On call
+//   - ts uint64
+func (_e *MockShardDelegator_Expecter) TryCleanExcludedSegments(ts interface{}) *MockShardDelegator_TryCleanExcludedSegments_Call {
+	return &MockShardDelegator_TryCleanExcludedSegments_Call{Call: _e.mock.On("TryCleanExcludedSegments", ts)}
+}
+
+func (_c *MockShardDelegator_TryCleanExcludedSegments_Call) Run(run func(ts uint64)) *MockShardDelegator_TryCleanExcludedSegments_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(uint64))
+	})
+	return _c
+}
+
+func (_c *MockShardDelegator_TryCleanExcludedSegments_Call) Return() *MockShardDelegator_TryCleanExcludedSegments_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockShardDelegator_TryCleanExcludedSegments_Call) RunAndReturn(run func(uint64)) *MockShardDelegator_TryCleanExcludedSegments_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// VerifyExcludedSegments provides a mock function with given fields: segmentID, ts
+func (_m *MockShardDelegator) VerifyExcludedSegments(segmentID int64, ts uint64) bool {
+	ret := _m.Called(segmentID, ts)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(int64, uint64) bool); ok {
+		r0 = rf(segmentID, ts)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
+// MockShardDelegator_VerifyExcludedSegments_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'VerifyExcludedSegments'
+type MockShardDelegator_VerifyExcludedSegments_Call struct {
+	*mock.Call
+}
+
+// VerifyExcludedSegments is a helper method to define mock.On call
+//   - segmentID int64
+//   - ts uint64
+func (_e *MockShardDelegator_Expecter) VerifyExcludedSegments(segmentID interface{}, ts interface{}) *MockShardDelegator_VerifyExcludedSegments_Call {
+	return &MockShardDelegator_VerifyExcludedSegments_Call{Call: _e.mock.On("VerifyExcludedSegments", segmentID, ts)}
+}
+
+func (_c *MockShardDelegator_VerifyExcludedSegments_Call) Run(run func(segmentID int64, ts uint64)) *MockShardDelegator_VerifyExcludedSegments_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(int64), args[1].(uint64))
+	})
+	return _c
+}
+
+func (_c *MockShardDelegator_VerifyExcludedSegments_Call) Return(_a0 bool) *MockShardDelegator_VerifyExcludedSegments_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockShardDelegator_VerifyExcludedSegments_Call) RunAndReturn(run func(int64, uint64) bool) *MockShardDelegator_VerifyExcludedSegments_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/querynodev2/pipeline/pipeline_test.go
+++ b/internal/querynodev2/pipeline/pipeline_test.go
@@ -119,6 +119,10 @@ func (suite *PipelineTestSuite) TestBasic() {
 	suite.msgDispatcher.EXPECT().Deregister(suite.channel)
 
 	//	mock delegator
+	suite.delegator.EXPECT().AddExcludedSegments(mock.Anything).Maybe()
+	suite.delegator.EXPECT().VerifyExcludedSegments(mock.Anything, mock.Anything).Return(true).Maybe()
+	suite.delegator.EXPECT().TryCleanExcludedSegments(mock.Anything).Maybe()
+
 	suite.delegator.EXPECT().ProcessInsert(mock.Anything).Run(
 		func(insertRecords map[int64]*delegator.InsertData) {
 			for segmentID := range insertRecords {

--- a/internal/querynodev2/services.go
+++ b/internal/querynodev2/services.go
@@ -290,17 +290,17 @@ func (node *QueryNode) WatchDmChannels(ctx context.Context, req *querypb.WatchDm
 		info := req.GetSegmentInfos()[id]
 		return id, info.GetDmlPosition().GetTimestamp()
 	})
-	pipeline.ExcludedSegments(growingInfo)
+	delegator.AddExcludedSegments(growingInfo)
 
 	flushedInfo := lo.SliceToMap(channel.GetFlushedSegmentIds(), func(id int64) (int64, uint64) {
 		return id, typeutil.MaxTimestamp
 	})
-	pipeline.ExcludedSegments(flushedInfo)
+	delegator.AddExcludedSegments(flushedInfo)
 	for _, channelInfo := range req.GetInfos() {
 		droppedInfos := lo.SliceToMap(channelInfo.GetDroppedSegmentIds(), func(id int64) (int64, uint64) {
 			return id, typeutil.MaxTimestamp
 		})
-		pipeline.ExcludedSegments(droppedInfos)
+		delegator.AddExcludedSegments(droppedInfos)
 	}
 
 	err = loadL0Segments(ctx, delegator, req)
@@ -542,16 +542,6 @@ func (node *QueryNode) ReleaseSegments(ctx context.Context, req *querypb.Release
 			log.Warn(msg)
 			err := merr.WrapErrChannelNotFound(req.GetShard())
 			return merr.Status(err), nil
-		}
-
-		// when we try to release a segment, add it to pipeline's exclude list first
-		// in case of consumed it's growing segment again
-		pipeline := node.pipelineManager.Get(req.GetShard())
-		if pipeline != nil {
-			droppedInfos := lo.SliceToMap(req.GetSegmentIDs(), func(id int64) (int64, uint64) {
-				return id, typeutil.MaxTimestamp
-			})
-			pipeline.ExcludedSegments(droppedInfos)
 		}
 
 		req.NeedTransfer = false
@@ -1314,14 +1304,10 @@ func (node *QueryNode) SyncDistribution(ctx context.Context, req *querypb.SyncDi
 			})
 		case querypb.SyncType_UpdateVersion:
 			log.Info("sync action", zap.Int64("TargetVersion", action.GetTargetVersion()))
-			pipeline := node.pipelineManager.Get(req.GetChannel())
-			if pipeline != nil {
-				droppedInfos := lo.SliceToMap(action.GetDroppedInTarget(), func(id int64) (int64, uint64) {
-					return id, typeutil.MaxTimestamp
-				})
-
-				pipeline.ExcludedSegments(droppedInfos)
-			}
+			droppedInfos := lo.SliceToMap(action.GetDroppedInTarget(), func(id int64) (int64, uint64) {
+				return id, typeutil.MaxTimestamp
+			})
+			shardDelegator.AddExcludedSegments(droppedInfos)
 			shardDelegator.SyncTargetVersion(action.GetTargetVersion(), action.GetGrowingInTarget(),
 				action.GetSealedInTarget(), action.GetDroppedInTarget(), action.GetCheckpoint())
 		default:

--- a/internal/querynodev2/services_test.go
+++ b/internal/querynodev2/services_test.go
@@ -883,8 +883,10 @@ func (suite *ServiceSuite) TestLoadSegments_Transfer() {
 		suite.node.delegators.Insert(suite.vchannel, delegator)
 		defer suite.node.delegators.GetAndRemove(suite.vchannel)
 
-		delegator.EXPECT().LoadSegments(mock.Anything, mock.AnythingOfType("*querypb.LoadSegmentsRequest")).
-			Return(nil)
+		delegator.EXPECT().AddExcludedSegments(mock.Anything).Maybe()
+		delegator.EXPECT().VerifyExcludedSegments(mock.Anything, mock.Anything).Return(true).Maybe()
+		delegator.EXPECT().TryCleanExcludedSegments(mock.Anything).Maybe()
+		delegator.EXPECT().LoadSegments(mock.Anything, mock.AnythingOfType("*querypb.LoadSegmentsRequest")).Return(nil)
 		// data
 		schema := segments.GenTestCollectionSchema(suite.collectionName, schemapb.DataType_Int64, false)
 		req := &querypb.LoadSegmentsRequest{
@@ -932,6 +934,9 @@ func (suite *ServiceSuite) TestLoadSegments_Transfer() {
 		delegator := &delegator.MockShardDelegator{}
 		suite.node.delegators.Insert(suite.vchannel, delegator)
 		defer suite.node.delegators.GetAndRemove(suite.vchannel)
+		delegator.EXPECT().AddExcludedSegments(mock.Anything).Maybe()
+		delegator.EXPECT().VerifyExcludedSegments(mock.Anything, mock.Anything).Return(true).Maybe()
+		delegator.EXPECT().TryCleanExcludedSegments(mock.Anything).Maybe()
 		delegator.EXPECT().LoadSegments(mock.Anything, mock.AnythingOfType("*querypb.LoadSegmentsRequest")).
 			Return(errors.New("mocked error"))
 		// data
@@ -1091,6 +1096,9 @@ func (suite *ServiceSuite) TestReleaseSegments_Transfer() {
 		suite.node.delegators.Insert(suite.vchannel, delegator)
 		defer suite.node.delegators.GetAndRemove(suite.vchannel)
 
+		delegator.EXPECT().AddExcludedSegments(mock.Anything).Maybe()
+		delegator.EXPECT().VerifyExcludedSegments(mock.Anything, mock.Anything).Return(true).Maybe()
+		delegator.EXPECT().TryCleanExcludedSegments(mock.Anything).Maybe()
 		delegator.EXPECT().ReleaseSegments(mock.Anything, mock.AnythingOfType("*querypb.ReleaseSegmentsRequest"), false).
 			Return(errors.New("mocked error"))
 


### PR DESCRIPTION
issue: #31479 #31797
pr: #31803

milvus will add released segment to excluded info, and filter out it's stream data in filter_node. but for data buffered in insert_node's channel, if it belongs to growing segment which already be released, then it will all the growing segment back again.

This PR maintain `excluded segments` in delegator, and check excluded segment before new growing segment.

---------