### PR TITLE
fix: [2.3] Make coordinator `Register` not blocked on ProcessActiveStandby(#32069)

### DIFF
--- a/internal/querycoordv2/server.go
+++ b/internal/querycoordv2/server.go
@@ -142,17 +142,24 @@ func NewQueryCoord(ctx context.Context) (*Server, error) {
 
 func (s *Server) Register() error {
 	s.session.Register()
-	if s.enableActiveStandBy {
-		if err := s.session.ProcessActiveStandBy(s.activateFunc); err != nil {
-			log.Error("failed to activate standby server", zap.Error(err))
-			return err
-		}
+	afterRegister := func() {
+		metrics.NumNodes.WithLabelValues(fmt.Sprint(paramtable.GetNodeID()), typeutil.QueryCoordRole).Inc()
+		s.session.LivenessCheck(s.ctx, func() {
+			log.Error("QueryCoord disconnected from etcd, process will exit", zap.Int64("serverID", s.session.GetServerID()))
+			os.Exit(1)
+		})
 	}
-	metrics.NumNodes.WithLabelValues(fmt.Sprint(paramtable.GetNodeID()), typeutil.QueryCoordRole).Inc()
-	s.session.LivenessCheck(s.ctx, func() {
-		log.Error("QueryCoord disconnected from etcd, process will exit", zap.Int64("serverID", s.session.GetServerID()))
-		os.Exit(1)
-	})
+	if s.enableActiveStandBy {
+		go func() {
+			if err := s.session.ProcessActiveStandBy(s.activateFunc); err != nil {
+				log.Error("failed to activate standby server", zap.Error(err))
+				return
+			}
+			afterRegister()
+		}()
+	} else {
+		afterRegister()
+	}
 	return nil
 }
 

--- a/internal/rootcoord/root_coord.go
+++ b/internal/rootcoord/root_coord.go
@@ -270,17 +270,25 @@ func (c *Core) SetQueryCoordClient(s types.QueryCoordClient) error {
 // Register register rootcoord at etcd
 func (c *Core) Register() error {
 	c.session.Register()
-	if c.enableActiveStandBy {
-		if err := c.session.ProcessActiveStandBy(c.activateFunc); err != nil {
-			return err
-		}
+	afterRegister := func() {
+		metrics.NumNodes.WithLabelValues(fmt.Sprint(paramtable.GetNodeID()), typeutil.RootCoordRole).Inc()
+		log.Info("RootCoord Register Finished")
+		c.session.LivenessCheck(c.ctx, func() {
+			log.Error("Root Coord disconnected from etcd, process will exit", zap.Int64("Server Id", c.session.ServerID))
+			os.Exit(1)
+		})
 	}
-	metrics.NumNodes.WithLabelValues(fmt.Sprint(paramtable.GetNodeID()), typeutil.RootCoordRole).Inc()
-	log.Info("RootCoord Register Finished")
-	c.session.LivenessCheck(c.ctx, func() {
-		log.Error("Root Coord disconnected from etcd, process will exit", zap.Int64("Server Id", c.session.ServerID))
-		os.Exit(1)
-	})
+	if c.enableActiveStandBy {
+		go func() {
+			if err := c.session.ProcessActiveStandBy(c.activateFunc); err != nil {
+				log.Warn("failed to activate standby rootcoord server", zap.Error(err))
+				return
+			}
+			afterRegister()
+		}()
+	} else {
+		afterRegister()
+	}
 
 	return nil
 }

--- a/internal/util/sessionutil/session_util.go
+++ b/internal/util/sessionutil/session_util.go
@@ -1149,7 +1149,7 @@ func (s *Session) ForceActiveStandby(activateFunc func() error) error {
 				0)).
 			Then(clientv3.OpPut(s.activeKey, string(sessionJSON), clientv3.WithLease(*s.LeaseID))).Commit()
 
-		if !resp.Succeeded {
+		if err != nil || !resp.Succeeded {
 			msg := fmt.Sprintf("failed to force register ACTIVE %s", s.ServerName)
 			log.Error(msg, zap.Error(err), zap.Any("resp", resp))
 			return errors.New(msg)


### PR DESCRIPTION
Cherry-pick from master
pr: #32069
See also #32066

This PR make coordinator register successful and let `ProcessActiveStandBy` run async. And roles may receive stop signal and notify servers.

---------