### PR TITLE
fix: [2.4] [Cherry-pick] dynamically resolve whether SVE is available for bitset

### DIFF
--- a/internal/core/src/bitset/CMakeLists.txt
+++ b/internal/core/src/bitset/CMakeLists.txt
@@ -29,15 +29,12 @@ elseif (${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm*")
     list(APPEND BITSET_SRCS
         detail/platform/arm/neon-inst.cpp
         detail/platform/arm/sve-inst.cpp
+        detail/platform/arm/instruction_set.cpp
     )
 
     # targeting AWS graviton, 
     #  https://github.com/aws/aws-graviton-getting-started/blob/main/c-c%2B%2B.md
 
-    # let dynamic.cpp know that SVE is available
-    # comment it out for now
-    # set_source_files_properties(detail/platform/dynamic.cpp PROPERTIES COMPILE_FLAGS "-mcpu=neoverse-v1")
-    
     set_source_files_properties(detail/platform/arm/sve-inst.cpp PROPERTIES COMPILE_FLAGS "-mcpu=neoverse-v1")
 endif()
 

--- a/internal/core/src/bitset/detail/platform/arm/instruction_set.cpp
+++ b/internal/core/src/bitset/detail/platform/arm/instruction_set.cpp
@@ -1,0 +1,56 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "instruction_set.h"
+
+#ifdef __linux__
+#include <sys/auxv.h>
+#endif
+
+namespace milvus {
+namespace bitset {
+namespace detail {
+namespace arm {
+
+InstructionSet::InstructionSet() {
+}
+
+#ifdef __linux__
+
+#if defined(HWCAP_SVE)
+bool
+InstructionSet::supports_sve() {
+    const unsigned long cap = getauxval(AT_HWCAP);
+    return ((cap & HWCAP_SVE) == HWCAP_SVE);
+}
+#else
+bool
+InstructionSet::supports_sve() {
+    return false;
+}
+#endif
+
+#else
+bool
+InstructionSet::supports_sve() {
+    return false;
+}
+#endif
+
+}  // namespace arm
+}  // namespace detail
+}  // namespace bitset
+}  // namespace milvus

--- a/internal/core/src/bitset/detail/platform/arm/instruction_set.h
+++ b/internal/core/src/bitset/detail/platform/arm/instruction_set.h
@@ -1,0 +1,43 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace milvus {
+namespace bitset {
+namespace detail {
+namespace arm {
+
+class InstructionSet {
+ public:
+    static InstructionSet&
+    GetInstance() {
+        static InstructionSet inst;
+        return inst;
+    }
+
+ private:
+    InstructionSet();
+
+ public:
+    bool
+    supports_sve();
+};
+
+}  // namespace arm
+}  // namespace detail
+}  // namespace bitset
+}  // namespace milvus

--- a/internal/core/src/bitset/detail/platform/arm/neon-inst.cpp
+++ b/internal/core/src/bitset/detail/platform/arm/neon-inst.cpp
@@ -19,6 +19,7 @@
 #include "bitset/common.h"
 
 #ifndef BITSET_HEADER_ONLY
+#ifdef __ARM_NEON
 
 #include "neon-decl.h"
 #include "neon-impl.h"
@@ -196,4 +197,5 @@ ALL_ARITH_CMP_OPS(INSTANTIATE_ARITH_COMPARE_NEON, double)
 }  // namespace bitset
 }  // namespace milvus
 
+#endif
 #endif

--- a/internal/core/src/bitset/detail/platform/arm/sve-inst.cpp
+++ b/internal/core/src/bitset/detail/platform/arm/sve-inst.cpp
@@ -19,6 +19,7 @@
 #include "bitset/common.h"
 
 #ifndef BITSET_HEADER_ONLY
+#ifdef __ARM_FEATURE_SVE
 
 #include "sve-decl.h"
 #include "sve-impl.h"
@@ -196,4 +197,5 @@ ALL_ARITH_CMP_OPS(INSTANTIATE_ARITH_COMPARE_SVE, double)
 }  // namespace bitset
 }  // namespace milvus
 
+#endif
 #endif


### PR DESCRIPTION
Issue: https://github.com/milvus-io/milvus/issues/32129
pr: #32137 
This PR adds a dynamic SVE detection for ARM CPU families for the bitset code.
Also, allows the code to be compiled if the compiler does not support NEON (arm-v7).
