### PR TITLE
fix: Make `ResourceGroup.nodes` concurrent safe

### DIFF
--- a/internal/querycoordv2/meta/resource_manager_test.go
+++ b/internal/querycoordv2/meta/resource_manager_test.go
@@ -509,7 +509,7 @@ func (suite *ResourceManagerSuite) TestStoreFailed() {
 	suite.ErrorIs(err, storeErr)
 
 	manager.groups["rg"] = &ResourceGroup{
-		nodes:    typeutil.NewUniqueSet(),
+		nodes:    typeutil.NewConcurrentSet[int64](),
 		capacity: 0,
 	}
 


### PR DESCRIPTION
See also #32158