### PR TITLE
fix: Use pk from binlog during import (#32118)

### DIFF
--- a/internal/datanode/importv2/util.go
+++ b/internal/datanode/importv2/util.go
@@ -217,3 +217,12 @@ func LogStats(manager TaskManager) {
 	tasks = manager.GetBy(WithType(ImportTaskType))
 	logFunc(tasks, ImportTaskType)
 }
+
+func UnsetAutoID(schema *schemapb.CollectionSchema) {
+	for _, field := range schema.GetFields() {
+		if field.GetIsPrimaryKey() && field.GetAutoID() {
+			field.AutoID = false
+			return
+		}
+	}
+}

--- a/internal/datanode/importv2/util_test.go
+++ b/internal/datanode/importv2/util_test.go
@@ -89,3 +89,27 @@ func Test_AppendSystemFieldsData(t *testing.T) {
 	assert.Equal(t, count, insertData.Data[common.RowIDField].RowNum())
 	assert.Equal(t, count, insertData.Data[common.TimeStampField].RowNum())
 }
+
+func Test_UnsetAutoID(t *testing.T) {
+	pkField := &schemapb.FieldSchema{
+		FieldID:      100,
+		Name:         "pk",
+		DataType:     schemapb.DataType_Int64,
+		IsPrimaryKey: true,
+		AutoID:       true,
+	}
+	vecField := &schemapb.FieldSchema{
+		FieldID:  101,
+		Name:     "vec",
+		DataType: schemapb.DataType_FloatVector,
+	}
+
+	schema := &schemapb.CollectionSchema{}
+	schema.Fields = []*schemapb.FieldSchema{pkField, vecField}
+	UnsetAutoID(schema)
+	for _, field := range schema.GetFields() {
+		if field.GetIsPrimaryKey() {
+			assert.False(t, schema.GetFields()[0].GetAutoID())
+		}
+	}
+}


### PR DESCRIPTION
During binlog import, even if the primary key's autoID is set to true, the primary key from the binlog should be used instead of being reassigned.

issue: https://github.com/milvus-io/milvus/discussions/31943, https://github.com/milvus-io/milvus/issues/28521

pr: https://github.com/milvus-io/milvus/pull/32118