### PR TITLE
fix: [Cherry-pick] in milvus check sparse index to be less than uint32 max

### DIFF
--- a/pkg/util/typeutil/schema.go
+++ b/pkg/util/typeutil/schema.go
@@ -1461,7 +1461,11 @@ func ValidateSparseFloatRows(rows ...[]byte) error {
 			return fmt.Errorf("invalid data length in sparse float vector: %d", len(row))
 		}
 		for i := 0; i < SparseFloatRowElementCount(row); i++ {
-			if i > 0 && SparseFloatRowIndexAt(row, i) < SparseFloatRowIndexAt(row, i-1) {
+			idx := SparseFloatRowIndexAt(row, i)
+			if idx == math.MaxUint32 {
+				return errors.New("invalid index in sparse float vector: must be less than 2^32-1")
+			}
+			if i > 0 && idx < SparseFloatRowIndexAt(row, i-1) {
 				return errors.New("unsorted indices in sparse float vector")
 			}
 			VerifyFloat(float64(SparseFloatRowValueAt(row, i)))

--- a/pkg/util/typeutil/schema_test.go
+++ b/pkg/util/typeutil/schema_test.go
@@ -18,6 +18,7 @@ package typeutil
 
 import (
 	"encoding/binary"
+	"math"
 	"reflect"
 	"testing"
 
@@ -2055,6 +2056,14 @@ func TestValidateSparseFloatRows(t *testing.T) {
 	t.Run("unordered index", func(t *testing.T) {
 		rows := [][]byte{
 			testutils.CreateSparseFloatRow([]uint32{100, 2000, 500}, []float32{1.0, 2.0, 3.0}),
+		}
+		err := ValidateSparseFloatRows(rows...)
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid index", func(t *testing.T) {
+		rows := [][]byte{
+			testutils.CreateSparseFloatRow([]uint32{3, 5, math.MaxUint32}, []float32{1.0, 2.0, 3.0}),
 		}
 		err := ValidateSparseFloatRows(rows...)
 		assert.Error(t, err)


### PR DESCRIPTION
issue: #29419
pr: #32199 