### PR TITLE
enhance: [cherry-pick]Use channel manager interface in server_test  (…

### DIFF
--- a/internal/datacoord/cluster.go
+++ b/internal/datacoord/cluster.go
@@ -92,7 +92,7 @@ func (c *ClusterImpl) Watch(ctx context.Context, ch string, collectionID UniqueI
 	return c.channelManager.Watch(ctx, &channelMeta{Name: ch, CollectionID: collectionID})
 }
 
-// Flush sends flush requests to dataNodes specified
+// Flush sends async FlushSegments requests to dataNodes
 // which also according to channels where segments are assigned to.
 func (c *ClusterImpl) Flush(ctx context.Context, nodeID int64, channel string, segments []*datapb.SegmentInfo) error {
 	if !c.channelManager.Match(nodeID, channel) {

--- a/internal/datacoord/metrics_info_test.go
+++ b/internal/datacoord/metrics_info_test.go
@@ -56,7 +56,7 @@ func (m *mockMetricIndexNodeClient) GetMetrics(ctx context.Context, req *milvusp
 }
 
 func TestGetDataNodeMetrics(t *testing.T) {
-	svr := newTestServer(t, nil)
+	svr := newTestServer(t)
 	defer closeTestServer(t, svr)
 
 	ctx := context.Background()
@@ -123,7 +123,7 @@ func TestGetDataNodeMetrics(t *testing.T) {
 }
 
 func TestGetIndexNodeMetrics(t *testing.T) {
-	svr := newTestServer(t, nil)
+	svr := newTestServer(t)
 	defer closeTestServer(t, svr)
 
 	ctx := context.Background()

--- a/internal/datacoord/server.go
+++ b/internal/datacoord/server.go
@@ -53,14 +53,12 @@ import (
 	"github.com/milvus-io/milvus/pkg/mq/msgstream/mqwrapper"
 	"github.com/milvus-io/milvus/pkg/util"
 	"github.com/milvus-io/milvus/pkg/util/expr"
-	"github.com/milvus-io/milvus/pkg/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/util/logutil"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/metricsinfo"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/util/retry"
 	"github.com/milvus-io/milvus/pkg/util/timerecord"
-	"github.com/milvus-io/milvus/pkg/util/tsoutil"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
 
@@ -666,11 +664,12 @@ func (s *Server) initIndexNodeManager() {
 }
 
 func (s *Server) startServerLoop() {
-	s.serverLoopWg.Add(2)
 	if !Params.DataNodeCfg.DataNodeTimeTickByRPC.GetAsBool() {
 		s.serverLoopWg.Add(1)
 		s.startDataNodeTtLoop(s.serverLoopCtx)
 	}
+
+	s.serverLoopWg.Add(2)
 	s.startWatchService(s.serverLoopCtx)
 	s.startFlushLoop(s.serverLoopCtx)
 	s.startIndexService(s.serverLoopCtx)
@@ -743,7 +742,7 @@ func (s *Server) handleDataNodeTimetickMsgstream(ctx context.Context, ttMsgStrea
 					checker.Check()
 				}
 
-				if err := s.handleTimetickMessage(ctx, ttMsg); err != nil {
+				if err := s.handleDataNodeTtMsg(ctx, &ttMsg.DataNodeTtMsg); err != nil {
 					log.Warn("failed to handle timetick message", zap.Error(err))
 					continue
 				}
@@ -751,62 +750,6 @@ func (s *Server) handleDataNodeTimetickMsgstream(ctx context.Context, ttMsgStrea
 			s.helper.eventAfterHandleDataNodeTt()
 		}
 	}
-}
-
-func (s *Server) handleTimetickMessage(ctx context.Context, ttMsg *msgstream.DataNodeTtMsg) error {
-	log := log.Ctx(ctx).WithRateGroup("dc.handleTimetick", 1, 60)
-	ch := ttMsg.GetChannelName()
-	ts := ttMsg.GetTimestamp()
-	physical, _ := tsoutil.ParseTS(ts)
-	if time.Since(physical).Minutes() > 1 {
-		// if lag behind, log every 1 mins about
-		log.RatedWarn(60.0, "time tick lag behind for more than 1 minutes", zap.String("channel", ch), zap.Time("timetick", physical))
-	}
-	// ignore report from a different node
-	if !s.channelManager.Match(ttMsg.GetBase().GetSourceID(), ch) {
-		log.Warn("node is not matched with channel", zap.String("channel", ch), zap.Int64("nodeID", ttMsg.GetBase().GetSourceID()))
-		return nil
-	}
-
-	sub := tsoutil.SubByNow(ts)
-	pChannelName := funcutil.ToPhysicalChannel(ch)
-	metrics.DataCoordConsumeDataNodeTimeTickLag.
-		WithLabelValues(fmt.Sprint(paramtable.GetNodeID()), pChannelName).
-		Set(float64(sub))
-
-	s.updateSegmentStatistics(ttMsg.GetSegmentsStats())
-
-	if err := s.segmentManager.ExpireAllocations(ch, ts); err != nil {
-		return fmt.Errorf("expire allocations: %w", err)
-	}
-
-	flushableIDs, err := s.segmentManager.GetFlushableSegments(ctx, ch, ts)
-	if err != nil {
-		return fmt.Errorf("get flushable segments: %w", err)
-	}
-	flushableSegments := s.getFlushableSegmentsInfo(flushableIDs)
-
-	if len(flushableSegments) == 0 {
-		return nil
-	}
-
-	log.Info("start flushing segments",
-		zap.Int64s("segment IDs", flushableIDs))
-	// update segment last update triggered time
-	// it's ok to fail flushing, since next timetick after duration will re-trigger
-	s.setLastFlushTime(flushableSegments)
-
-	finfo := make([]*datapb.SegmentInfo, 0, len(flushableSegments))
-	for _, info := range flushableSegments {
-		finfo = append(finfo, info.SegmentInfo)
-	}
-	err = s.cluster.Flush(s.ctx, ttMsg.GetBase().GetSourceID(), ch, finfo)
-	if err != nil {
-		log.Warn("failed to handle flush", zap.Int64("source", ttMsg.GetBase().GetSourceID()), zap.Error(err))
-		return err
-	}
-
-	return nil
 }
 
 func (s *Server) updateSegmentStatistics(stats []*commonpb.SegmentStats) {

--- a/internal/datacoord/server_test.go
+++ b/internal/datacoord/server_test.go
@@ -50,11 +50,9 @@ import (
 	"github.com/milvus-io/milvus/internal/proto/rootcoordpb"
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/dependency"
-	grpcmock "github.com/milvus-io/milvus/internal/util/mock"
 	"github.com/milvus-io/milvus/internal/util/sessionutil"
 	"github.com/milvus-io/milvus/pkg/common"
 	"github.com/milvus-io/milvus/pkg/log"
-	"github.com/milvus-io/milvus/pkg/mq/msgstream"
 	"github.com/milvus-io/milvus/pkg/util/etcd"
 	"github.com/milvus-io/milvus/pkg/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/util/merr"
@@ -107,39 +105,8 @@ func (r *mockRootCoord) DescribeCollectionInternal(ctx context.Context, req *mil
 	return r.RootCoordClient.DescribeCollection(ctx, req)
 }
 
-// func TestGetComponentStates(t *testing.T) {
-// svr := newTestServer(t)
-// defer closeTestServer(t, svr)
-// cli := newMockDataNodeClient(1)
-// err := cli.Init()
-// assert.NoError(t, err)
-// err = cli.Start()
-// assert.NoError(t, err)
-
-//err = svr.cluster.Register(&dataNode{
-//id: 1,
-//address: struct {
-//ip   string
-//port int64
-//}{
-//ip:   "",
-//port: 0,
-//},
-//client:     cli,
-//channelNum: 0,
-//})
-//assert.NoError(t, err)
-
-//resp, err := svr.GetComponentStates(context.TODO())
-//assert.NoError(t, err)
-//assert.EqualValues(t, commonpb.ErrorCode_Success, resp.GetStatus().GetErrorCode())
-//assert.EqualValues(t, commonpb.StateCode_Healthy, resp.State.StateCode)
-//assert.EqualValues(t, 1, len(resp.SubcomponentStates))
-//assert.EqualValues(t, commonpb.StateCode_Healthy, resp.SubcomponentStates[0].StateCode)
-//}
-
 func TestGetTimeTickChannel(t *testing.T) {
-	svr := newTestServer(t, nil)
+	svr := newTestServer(t)
 	defer closeTestServer(t, svr)
 	resp, err := svr.GetTimeTickChannel(context.TODO(), nil)
 	assert.NoError(t, err)
@@ -149,7 +116,7 @@ func TestGetTimeTickChannel(t *testing.T) {
 
 func TestGetSegmentStates(t *testing.T) {
 	t.Run("normal cases", func(t *testing.T) {
-		svr := newTestServer(t, nil)
+		svr := newTestServer(t)
 		defer closeTestServer(t, svr)
 		segment := &datapb.SegmentInfo{
 			ID:            1000,
@@ -200,7 +167,7 @@ func TestGetSegmentStates(t *testing.T) {
 	})
 
 	t.Run("with closed server", func(t *testing.T) {
-		svr := newTestServer(t, nil)
+		svr := newTestServer(t)
 		closeTestServer(t, svr)
 		resp, err := svr.GetSegmentStates(context.TODO(), &datapb.GetSegmentStatesRequest{
 			Base: &commonpb.MsgBase{
@@ -218,7 +185,7 @@ func TestGetSegmentStates(t *testing.T) {
 
 func TestGetInsertBinlogPaths(t *testing.T) {
 	t.Run("normal case", func(t *testing.T) {
-		svr := newTestServer(t, nil)
+		svr := newTestServer(t)
 		defer closeTestServer(t, svr)
 
 		info := &datapb.SegmentInfo{
@@ -249,7 +216,7 @@ func TestGetInsertBinlogPaths(t *testing.T) {
 	})
 
 	t.Run("with invalid segmentID", func(t *testing.T) {
-		svr := newTestServer(t, nil)
+		svr := newTestServer(t)
 		defer closeTestServer(t, svr)
 
 		info := &datapb.SegmentInfo{
@@ -281,7 +248,7 @@ func TestGetInsertBinlogPaths(t *testing.T) {
 	})
 
 	t.Run("with closed server", func(t *testing.T) {
-		svr := newTestServer(t, nil)
+		svr := newTestServer(t)
 		closeTestServer(t, svr)
 		resp, err := svr.GetInsertBinlogPaths(context.TODO(), &datapb.GetInsertBinlogPathsRequest{
 			SegmentID: 0,
@@ -293,7 +260,7 @@ func TestGetInsertBinlogPaths(t *testing.T) {
 
 func TestGetCollectionStatistics(t *testing.T) {
 	t.Run("normal case", func(t *testing.T) {
-		svr := newTestServer(t, nil)
+		svr := newTestServer(t)
 		defer closeTestServer(t, svr)
 
 		req := &datapb.GetCollectionStatisticsRequest{
@@ -304,7 +271,7 @@ func TestGetCollectionStatistics(t *testing.T) {
 		assert.EqualValues(t, commonpb.ErrorCode_Success, resp.GetStatus().GetErrorCode())
 	})
 	t.Run("with closed server", func(t *testing.T) {
-		svr := newTestServer(t, nil)
+		svr := newTestServer(t)
 		closeTestServer(t, svr)
 		resp, err := svr.GetCollectionStatistics(context.Background(), &datapb.GetCollectionStatisticsRequest{
 			CollectionID: 0,
@@ -316,7 +283,7 @@ func TestGetCollectionStatistics(t *testing.T) {
 
 func TestGetPartitionStatistics(t *testing.T) {
 	t.Run("normal cases", func(t *testing.T) {
-		svr := newTestServer(t, nil)
+		svr := newTestServer(t)
 		defer closeTestServer(t, svr)
 
 		req := &datapb.GetPartitionStatisticsRequest{
@@ -328,7 +295,7 @@ func TestGetPartitionStatistics(t *testing.T) {
 		assert.EqualValues(t, commonpb.ErrorCode_Success, resp.GetStatus().GetErrorCode())
 	})
 	t.Run("with closed server", func(t *testing.T) {
-		svr := newTestServer(t, nil)
+		svr := newTestServer(t)
 		closeTestServer(t, svr)
 		resp, err := svr.GetPartitionStatistics(context.Background(), &datapb.GetPartitionStatisticsRequest{})
 		assert.NoError(t, err)
@@ -338,7 +305,7 @@ func TestGetPartitionStatistics(t *testing.T) {
 
 func TestGetSegmentInfo(t *testing.T) {
 	t.Run("normal case", func(t *testing.T) {
-		svr := newTestServer(t, nil)
+		svr := newTestServer(t)
 		defer closeTestServer(t, svr)
 
 		segInfo := &datapb.SegmentInfo{
@@ -379,7 +346,7 @@ func TestGetSegmentInfo(t *testing.T) {
 		assert.EqualValues(t, commonpb.ErrorCode_Success, resp.GetStatus().GetErrorCode())
 	})
 	t.Run("with wrong segmentID", func(t *testing.T) {
-		svr := newTestServer(t, nil)
+		svr := newTestServer(t)
 		defer closeTestServer(t, svr)
 
 		segInfo := &datapb.SegmentInfo{
@@ -397,7 +364,7 @@ func TestGetSegmentInfo(t *testing.T) {
 		assert.ErrorIs(t, merr.Error(resp.GetStatus()), merr.ErrSegmentNotFound)
 	})
 	t.Run("with closed server", func(t *testing.T) {
-		svr := newTestServer(t, nil)
+		svr := newTestServer(t)
 		closeTestServer(t, svr)
 		resp, err := svr.GetSegmentInfo(context.Background(), &datapb.GetSegmentInfoRequest{
 			SegmentIDs: []int64{},
@@ -406,7 +373,7 @@ func TestGetSegmentInfo(t *testing.T) {
 		assert.ErrorIs(t, merr.Error(resp.GetStatus()), merr.ErrServiceNotReady)
 	})
 	t.Run("with dropped segment", func(t *testing.T) {
-		svr := newTestServer(t, nil)
+		svr := newTestServer(t)
 		defer closeTestServer(t, svr)
 
 		segInfo := &datapb.SegmentInfo{
@@ -443,7 +410,7 @@ func TestGetSegmentInfo(t *testing.T) {
 			Timestamp:   1000,
 		}
 
-		svr := newTestServer(t, nil)
+		svr := newTestServer(t)
 		defer closeTestServer(t, svr)
 
 		segInfo := &datapb.SegmentInfo{
@@ -513,7 +480,7 @@ func TestGetComponentStates(t *testing.T) {
 
 func TestGetFlushedSegments(t *testing.T) {
 	t.Run("normal case", func(t *testing.T) {
-		svr := newTestServer(t, nil)
+		svr := newTestServer(t)
 		defer closeTestServer(t, svr)
 		type testCase struct {
 			collID            int64
@@ -592,7 +559,7 @@ func TestGetFlushedSegments(t *testing.T) {
 
 	t.Run("with closed server", func(t *testing.T) {
 		t.Run("with closed server", func(t *testing.T) {
-			svr := newTestServer(t, nil)
+			svr := newTestServer(t)
 			closeTestServer(t, svr)
 			resp, err := svr.GetFlushedSegments(context.Background(), &datapb.GetFlushedSegmentsRequest{})
 			assert.NoError(t, err)
@@ -603,7 +570,7 @@ func TestGetFlushedSegments(t *testing.T) {
 
 func TestGetSegmentsByStates(t *testing.T) {
 	t.Run("normal case", func(t *testing.T) {
-		svr := newTestServer(t, nil)
+		svr := newTestServer(t)
 		defer closeTestServer(t, svr)
 		type testCase struct {
 			collID          int64
@@ -696,7 +663,7 @@ func TestGetSegmentsByStates(t *testing.T) {
 
 	t.Run("with closed server", func(t *testing.T) {
 		t.Run("with closed server", func(t *testing.T) {
-			svr := newTestServer(t, nil)
+			svr := newTestServer(t)
 			closeTestServer(t, svr)
 			resp, err := svr.GetSegmentsByStates(context.Background(), &datapb.GetSegmentsByStatesRequest{})
 			assert.NoError(t, err)
@@ -760,136 +727,8 @@ func TestService_WatchServices(t *testing.T) {
 	assert.True(t, flag)
 }
 
-//func TestServer_watchCoord(t *testing.T) {
-//	Params.Init()
-//	etcdCli, err := etcd.GetEtcdClient(&Params.EtcdCfg)
-//	assert.NoError(t, err)
-//	etcdKV := etcdkv.NewEtcdKV(etcdCli, Params.EtcdCfg.MetaRootPath)
-//	assert.NotNil(t, etcdKV)
-//	factory := dependency.NewDefaultFactory(true)
-//	svr := CreateServer(context.TODO(), factory)
-//	svr.session = &sessionutil.Session{
-//		TriggerKill: true,
-//	}
-//	svr.kvClient = etcdKV
-//
-//	dnCh := make(chan *sessionutil.SessionEvent)
-//	//icCh := make(chan *sessionutil.SessionEvent)
-//	qcCh := make(chan *sessionutil.SessionEvent)
-//	rcCh := make(chan *sessionutil.SessionEvent)
-//
-//	svr.dnEventCh = dnCh
-//	//svr.icEventCh = icCh
-//	svr.qcEventCh = qcCh
-//	svr.rcEventCh = rcCh
-//
-//	segRefer, err := NewSegmentReferenceManager(etcdKV, nil)
-//	assert.NoError(t, err)
-//	assert.NotNil(t, segRefer)
-//	svr.segReferManager = segRefer
-//
-//	sc := make(chan os.Signal, 1)
-//	signal.Notify(sc, syscall.SIGINT)
-//	defer signal.Reset(syscall.SIGINT)
-//	closed := false
-//	sigQuit := make(chan struct{}, 1)
-//
-//	svr.serverLoopWg.Add(1)
-//	go func() {
-//		svr.watchService(context.Background())
-//	}()
-//
-//	go func() {
-//		<-sc
-//		closed = true
-//		sigQuit <- struct{}{}
-//	}()
-//
-//	icCh <- &sessionutil.SessionEvent{
-//		EventType: sessionutil.SessionAddEvent,
-//		Session: &sessionutil.Session{
-//			ServerID: 1,
-//		},
-//	}
-//	icCh <- &sessionutil.SessionEvent{
-//		EventType: sessionutil.SessionDelEvent,
-//		Session: &sessionutil.Session{
-//			ServerID: 1,
-//		},
-//	}
-//	close(icCh)
-//	<-sigQuit
-//	svr.serverLoopWg.Wait()
-//	assert.True(t, closed)
-//}
-
-//func TestServer_watchQueryCoord(t *testing.T) {
-//	Params.Init()
-//	etcdCli, err := etcd.GetEtcdClient(
-//		Params.EtcdCfg.UseEmbedEtcd.GetAsBool(),
-//		Params.EtcdCfg.EtcdUseSSL.GetAsBool(),
-//		Params.EtcdCfg.Endpoints.GetAsStrings(),
-//		Params.EtcdCfg.EtcdTLSCert.GetValue(),
-//		Params.EtcdCfg.EtcdTLSKey.GetValue(),
-//		Params.EtcdCfg.EtcdTLSCACert.GetValue(),
-//		Params.EtcdCfg.EtcdTLSMinVersion.GetValue())
-//	assert.NoError(t, err)
-//	etcdKV := etcdkv.NewEtcdKV(etcdCli, Params.EtcdCfg.MetaRootPath.GetValue())
-//	assert.NotNil(t, etcdKV)
-//	factory := dependency.NewDefaultFactory(true)
-//	svr := CreateServer(context.TODO(), factory)
-//	svr.session = &sessionutil.Session{
-//		TriggerKill: true,
-//	}
-//	svr.kvClient = etcdKV
-//
-//	dnCh := make(chan *sessionutil.SessionEvent)
-//	//icCh := make(chan *sessionutil.SessionEvent)
-//	qcCh := make(chan *sessionutil.SessionEvent)
-//
-//	svr.dnEventCh = dnCh
-//
-//	segRefer, err := NewSegmentReferenceManager(etcdKV, nil)
-//	assert.NoError(t, err)
-//	assert.NotNil(t, segRefer)
-//
-//	sc := make(chan os.Signal, 1)
-//	signal.Notify(sc, syscall.SIGINT)
-//	defer signal.Reset(syscall.SIGINT)
-//	closed := false
-//	sigQuit := make(chan struct{}, 1)
-//
-//	svr.serverLoopWg.Add(1)
-//	go func() {
-//		svr.watchService(context.Background())
-//	}()
-//
-//	go func() {
-//		<-sc
-//		closed = true
-//		sigQuit <- struct{}{}
-//	}()
-//
-//	qcCh <- &sessionutil.SessionEvent{
-//		EventType: sessionutil.SessionAddEvent,
-//		Session: &sessionutil.Session{
-//			ServerID: 2,
-//		},
-//	}
-//	qcCh <- &sessionutil.SessionEvent{
-//		EventType: sessionutil.SessionDelEvent,
-//		Session: &sessionutil.Session{
-//			ServerID: 2,
-//		},
-//	}
-//	close(qcCh)
-//	<-sigQuit
-//	svr.serverLoopWg.Wait()
-//	assert.True(t, closed)
-//}
-
 func TestServer_ShowConfigurations(t *testing.T) {
-	svr := newTestServer(t, nil)
+	svr := newTestServer(t)
 	defer closeTestServer(t, svr)
 	pattern := "datacoord.Port"
 	req := &internalpb.ShowConfigurationsRequest{
@@ -918,7 +757,7 @@ func TestServer_ShowConfigurations(t *testing.T) {
 }
 
 func TestServer_GetMetrics(t *testing.T) {
-	svr := newTestServer(t, nil)
+	svr := newTestServer(t)
 	defer closeTestServer(t, svr)
 
 	var err error
@@ -959,7 +798,7 @@ func TestServer_GetMetrics(t *testing.T) {
 }
 
 func TestServer_getSystemInfoMetrics(t *testing.T) {
-	svr := newTestServer(t, nil)
+	svr := newTestServer(t)
 	defer closeTestServer(t, svr)
 
 	req, err := metricsinfo.ConstructRequestByMetricType(metricsinfo.SystemInfoMetrics)
@@ -1031,7 +870,7 @@ func (s *spySegmentManager) DropSegmentsOfChannel(ctx context.Context, channel s
 func TestDropVirtualChannel(t *testing.T) {
 	t.Run("normal DropVirtualChannel", func(t *testing.T) {
 		spyCh := make(chan struct{}, 1)
-		svr := newTestServer(t, nil, WithSegmentManager(&spySegmentManager{spyCh: spyCh}))
+		svr := newTestServer(t, WithSegmentManager(&spySegmentManager{spyCh: spyCh}))
 
 		defer closeTestServer(t, svr)
 
@@ -1089,16 +928,17 @@ func TestDropVirtualChannel(t *testing.T) {
 		svr.meta.AddSegment(context.TODO(), NewSegmentInfo(os))
 
 		ctx := context.Background()
-		err := svr.channelManager.AddNode(0)
-		require.Nil(t, err)
-		err = svr.channelManager.Watch(ctx, &channelMeta{Name: "ch1", CollectionID: 0})
-		require.Nil(t, err)
+		chanName := "ch1"
+		mockChManager := NewMockChannelManager(t)
+		mockChManager.EXPECT().Match(mock.Anything, mock.Anything).Return(true).Twice()
+		mockChManager.EXPECT().Release(mock.Anything, chanName).Return(nil).Twice()
+		svr.channelManager = mockChManager
 
 		req := &datapb.DropVirtualChannelRequest{
 			Base: &commonpb.MsgBase{
 				Timestamp: uint64(time.Now().Unix()),
 			},
-			ChannelName: "ch1",
+			ChannelName: chanName,
 			Segments:    make([]*datapb.DropVirtualChannelSegment, 0, maxOperationsPerTxn),
 		}
 		for _, segment := range segments {
@@ -1163,9 +1003,6 @@ func TestDropVirtualChannel(t *testing.T) {
 
 		<-spyCh
 
-		err = svr.channelManager.Watch(ctx, &channelMeta{Name: "ch1", CollectionID: 0})
-		require.Nil(t, err)
-
 		// resend
 		resp, err = svr.DropVirtualChannel(ctx, req)
 		assert.NoError(t, err)
@@ -1173,12 +1010,11 @@ func TestDropVirtualChannel(t *testing.T) {
 	})
 
 	t.Run("with channel not matched", func(t *testing.T) {
-		svr := newTestServer(t, nil)
+		svr := newTestServer(t)
 		defer closeTestServer(t, svr)
-		err := svr.channelManager.AddNode(0)
-		require.Nil(t, err)
-		err = svr.channelManager.Watch(context.TODO(), &channelMeta{Name: "ch1", CollectionID: 0})
-		require.Nil(t, err)
+		mockChManager := NewMockChannelManager(t)
+		mockChManager.EXPECT().Match(mock.Anything, mock.Anything).Return(false).Once()
+		svr.channelManager = mockChManager
 
 		resp, err := svr.DropVirtualChannel(context.Background(), &datapb.DropVirtualChannelRequest{
 			ChannelName: "ch2",
@@ -1188,7 +1024,7 @@ func TestDropVirtualChannel(t *testing.T) {
 	})
 
 	t.Run("with closed server", func(t *testing.T) {
-		svr := newTestServer(t, nil)
+		svr := newTestServer(t)
 		closeTestServer(t, svr)
 		resp, err := svr.DropVirtualChannel(context.Background(), &datapb.DropVirtualChannelRequest{})
 		assert.NoError(t, err)
@@ -1261,7 +1097,7 @@ func TestGetChannelSeekPosition(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.testName, func(t *testing.T) {
-			svr := newTestServer(t, nil)
+			svr := newTestServer(t)
 			defer closeTestServer(t, svr)
 			schema := newTestSchema()
 			if test.collStartPos != nil {
@@ -1303,7 +1139,7 @@ func TestGetChannelSeekPosition(t *testing.T) {
 }
 
 func TestGetDataVChanPositions(t *testing.T) {
-	svr := newTestServer(t, nil)
+	svr := newTestServer(t)
 	defer closeTestServer(t, svr)
 	schema := newTestSchema()
 	svr.meta.AddCollection(&collectionInfo{
@@ -1419,7 +1255,7 @@ func TestGetDataVChanPositions(t *testing.T) {
 }
 
 func TestGetQueryVChanPositions(t *testing.T) {
-	svr := newTestServer(t, nil)
+	svr := newTestServer(t)
 	defer closeTestServer(t, svr)
 	schema := newTestSchema()
 	svr.meta.AddCollection(&collectionInfo{
@@ -1603,7 +1439,7 @@ func TestGetQueryVChanPositions(t *testing.T) {
 
 func TestGetQueryVChanPositions_Retrieve_unIndexed(t *testing.T) {
 	t.Run("ab GC-ed, cde unIndexed", func(t *testing.T) {
-		svr := newTestServer(t, nil)
+		svr := newTestServer(t)
 		defer closeTestServer(t, svr)
 		schema := newTestSchema()
 		svr.meta.AddCollection(&collectionInfo{
@@ -1673,7 +1509,7 @@ func TestGetQueryVChanPositions_Retrieve_unIndexed(t *testing.T) {
 	})
 
 	t.Run("a GC-ed, bcde unIndexed", func(t *testing.T) {
-		svr := newTestServer(t, nil)
+		svr := newTestServer(t)
 		defer closeTestServer(t, svr)
 		schema := newTestSchema()
 		svr.meta.AddCollection(&collectionInfo{
@@ -1759,7 +1595,7 @@ func TestGetQueryVChanPositions_Retrieve_unIndexed(t *testing.T) {
 	})
 
 	t.Run("ab GC-ed, c unIndexed, de indexed", func(t *testing.T) {
-		svr := newTestServer(t, nil)
+		svr := newTestServer(t)
 		defer closeTestServer(t, svr)
 		schema := newTestSchema()
 		svr.meta.AddCollection(&collectionInfo{
@@ -1868,7 +1704,7 @@ func TestShouldDropChannel(t *testing.T) {
 		Count:  1,
 	}, nil)
 
-	svr := newTestServer(t, nil)
+	svr := newTestServer(t)
 	defer closeTestServer(t, svr)
 	schema := newTestSchema()
 	svr.meta.AddCollection(&collectionInfo{
@@ -1905,7 +1741,7 @@ func TestShouldDropChannel(t *testing.T) {
 
 func TestGetRecoveryInfo(t *testing.T) {
 	t.Run("test get recovery info with no segments", func(t *testing.T) {
-		svr := newTestServer(t, nil)
+		svr := newTestServer(t)
 		defer closeTestServer(t, svr)
 
 		svr.rootCoordClientCreator = func(ctx context.Context) (types.RootCoordClient, error) {
@@ -1949,7 +1785,7 @@ func TestGetRecoveryInfo(t *testing.T) {
 	}
 
 	t.Run("test get earliest position of flushed segments as seek position", func(t *testing.T) {
-		svr := newTestServer(t, nil)
+		svr := newTestServer(t)
 		defer closeTestServer(t, svr)
 
 		svr.rootCoordClientCreator = func(ctx context.Context) (types.RootCoordClient, error) {
@@ -2054,7 +1890,7 @@ func TestGetRecoveryInfo(t *testing.T) {
 	})
 
 	t.Run("test get recovery of unflushed segments ", func(t *testing.T) {
-		svr := newTestServer(t, nil)
+		svr := newTestServer(t)
 		defer closeTestServer(t, svr)
 
 		svr.rootCoordClientCreator = func(ctx context.Context) (types.RootCoordClient, error) {
@@ -2129,7 +1965,7 @@ func TestGetRecoveryInfo(t *testing.T) {
 	})
 
 	t.Run("test get binlogs", func(t *testing.T) {
-		svr := newTestServer(t, nil)
+		svr := newTestServer(t)
 		defer closeTestServer(t, svr)
 
 		svr.meta.AddCollection(&collectionInfo{
@@ -2205,11 +2041,6 @@ func TestGetRecoveryInfo(t *testing.T) {
 		})
 		assert.NoError(t, err)
 
-		err = svr.channelManager.AddNode(0)
-		assert.NoError(t, err)
-		err = svr.channelManager.Watch(context.TODO(), &channelMeta{Name: "vchan1", CollectionID: 0})
-		assert.NoError(t, err)
-
 		sResp, err := svr.SaveBinlogPaths(context.TODO(), binlogReq)
 		assert.NoError(t, err)
 		assert.EqualValues(t, commonpb.ErrorCode_Success, sResp.ErrorCode)
@@ -2233,7 +2064,7 @@ func TestGetRecoveryInfo(t *testing.T) {
 		}
 	})
 	t.Run("with dropped segments", func(t *testing.T) {
-		svr := newTestServer(t, nil)
+		svr := newTestServer(t)
 		defer closeTestServer(t, svr)
 
 		svr.rootCoordClientCreator = func(ctx context.Context) (types.RootCoordClient, error) {
@@ -2275,7 +2106,7 @@ func TestGetRecoveryInfo(t *testing.T) {
 	})
 
 	t.Run("with fake segments", func(t *testing.T) {
-		svr := newTestServer(t, nil)
+		svr := newTestServer(t)
 		defer closeTestServer(t, svr)
 
 		svr.rootCoordClientCreator = func(ctx context.Context) (types.RootCoordClient, error) {
@@ -2316,7 +2147,7 @@ func TestGetRecoveryInfo(t *testing.T) {
 	})
 
 	t.Run("with continuous compaction", func(t *testing.T) {
-		svr := newTestServer(t, nil)
+		svr := newTestServer(t)
 		defer closeTestServer(t, svr)
 
 		svr.rootCoordClientCreator = func(ctx context.Context) (types.RootCoordClient, error) {
@@ -2398,7 +2229,7 @@ func TestGetRecoveryInfo(t *testing.T) {
 	})
 
 	t.Run("with closed server", func(t *testing.T) {
-		svr := newTestServer(t, nil)
+		svr := newTestServer(t)
 		closeTestServer(t, svr)
 		resp, err := svr.GetRecoveryInfo(context.TODO(), &datapb.GetRecoveryInfoRequest{})
 		assert.NoError(t, err)
@@ -2575,7 +2406,7 @@ func TestOptions(t *testing.T) {
 	}()
 
 	t.Run("WithRootCoordCreator", func(t *testing.T) {
-		svr := newTestServer(t, nil)
+		svr := newTestServer(t)
 		defer closeTestServer(t, svr)
 		var crt rootCoordCreatorFunc = func(ctx context.Context) (types.RootCoordClient, error) {
 			return nil, errors.New("dummy")
@@ -2600,7 +2431,7 @@ func TestOptions(t *testing.T) {
 		assert.NoError(t, err)
 		opt := WithCluster(cluster)
 		assert.NotNil(t, opt)
-		svr := newTestServer(t, nil, opt)
+		svr := newTestServer(t, opt)
 		defer closeTestServer(t, svr)
 
 		assert.Same(t, cluster, svr.cluster)
@@ -2647,9 +2478,10 @@ func TestHandleSessionEvent(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 
+	sessionManager := NewSessionManagerImpl()
 	channelManager, err := NewChannelManager(kv, newMockHandler(), withFactory(&mockPolicyFactory{}))
 	assert.NoError(t, err)
-	sessionManager := NewSessionManagerImpl()
+
 	cluster := NewClusterImpl(sessionManager, channelManager)
 	assert.NoError(t, err)
 
@@ -2657,7 +2489,7 @@ func TestHandleSessionEvent(t *testing.T) {
 	assert.NoError(t, err)
 	defer cluster.Close()
 
-	svr := newTestServer(t, nil, WithCluster(cluster))
+	svr := newTestServer(t, WithCluster(cluster))
 	defer closeTestServer(t, svr)
 	t.Run("handle events", func(t *testing.T) {
 		// None event
@@ -2732,7 +2564,7 @@ func (rc *rootCoordSegFlushComplete) SegmentFlushCompleted(ctx context.Context, 
 
 func TestPostFlush(t *testing.T) {
 	t.Run("segment not found", func(t *testing.T) {
-		svr := newTestServer(t, nil)
+		svr := newTestServer(t)
 		defer closeTestServer(t, svr)
 
 		err := svr.postFlush(context.Background(), 1)
@@ -2740,7 +2572,7 @@ func TestPostFlush(t *testing.T) {
 	})
 
 	t.Run("success post flush", func(t *testing.T) {
-		svr := newTestServer(t, nil)
+		svr := newTestServer(t)
 		defer closeTestServer(t, svr)
 		svr.rootCoordClient = &rootCoordSegFlushComplete{flag: true}
 
@@ -2952,7 +2784,7 @@ func TestGetFlushAllStateWithDB(t *testing.T) {
 
 func TestDataCoordServer_SetSegmentState(t *testing.T) {
 	t.Run("normal case", func(t *testing.T) {
-		svr := newTestServer(t, nil)
+		svr := newTestServer(t)
 		defer closeTestServer(t, svr)
 		segment := &datapb.SegmentInfo{
 			ID:            1000,
@@ -2994,7 +2826,7 @@ func TestDataCoordServer_SetSegmentState(t *testing.T) {
 	t.Run("dataCoord meta set state not exists", func(t *testing.T) {
 		meta, err := newMemoryMeta()
 		assert.NoError(t, err)
-		svr := newTestServerWithMeta(t, nil, meta)
+		svr := newTestServer(t, WithMeta(meta))
 		defer closeTestServer(t, svr)
 		// Set segment state.
 		svr.SetSegmentState(context.TODO(), &datapb.SetSegmentStateRequest{
@@ -3018,7 +2850,7 @@ func TestDataCoordServer_SetSegmentState(t *testing.T) {
 	})
 
 	t.Run("with closed server", func(t *testing.T) {
-		svr := newTestServer(t, nil)
+		svr := newTestServer(t)
 		closeTestServer(t, svr)
 		resp, err := svr.SetSegmentState(context.TODO(), &datapb.SetSegmentStateRequest{
 			SegmentId: 1000,
@@ -3031,7 +2863,7 @@ func TestDataCoordServer_SetSegmentState(t *testing.T) {
 
 func TestDataCoord_SegmentStatistics(t *testing.T) {
 	t.Run("test update imported segment stat", func(t *testing.T) {
-		svr := newTestServer(t, nil)
+		svr := newTestServer(t)
 
 		seg1 := &datapb.SegmentInfo{
 			ID:        100,
@@ -3058,7 +2890,7 @@ func TestDataCoord_SegmentStatistics(t *testing.T) {
 	})
 
 	t.Run("test update flushed segment stat", func(t *testing.T) {
-		svr := newTestServer(t, nil)
+		svr := newTestServer(t)
 
 		seg1 := &datapb.SegmentInfo{
 			ID:        100,
@@ -3089,7 +2921,7 @@ func TestDataCoordServer_UpdateChannelCheckpoint(t *testing.T) {
 	mockVChannel := "fake-by-dev-rootcoord-dml-1-testchannelcp-v0"
 
 	t.Run("UpdateChannelCheckpoint_Success", func(t *testing.T) {
-		svr := newTestServer(t, nil)
+		svr := newTestServer(t)
 		defer closeTestServer(t, svr)
 
 		datanodeID := int64(1)
@@ -3135,7 +2967,7 @@ func TestDataCoordServer_UpdateChannelCheckpoint(t *testing.T) {
 	})
 
 	t.Run("UpdateChannelCheckpoint_NodeNotMatch", func(t *testing.T) {
-		svr := newTestServer(t, nil)
+		svr := newTestServer(t)
 		defer closeTestServer(t, svr)
 
 		datanodeID := int64(1)
@@ -3182,7 +3014,13 @@ func TestDataCoordServer_UpdateChannelCheckpoint(t *testing.T) {
 
 var globalTestTikv = tikv.SetupLocalTxn()
 
-func newTestServer(t *testing.T, receiveCh chan any, opts ...Option) *Server {
+func WithMeta(meta *meta) Option {
+	return func(svr *Server) {
+		svr.meta = meta
+	}
+}
+
+func newTestServer(t *testing.T, opts ...Option) *Server {
 	var err error
 	paramtable.Get().Save(Params.CommonCfg.DataCoordTimeTick.Key, Params.CommonCfg.DataCoordTimeTick.GetValue()+strconv.Itoa(rand.Int()))
 	paramtable.Get().Save(Params.RocksmqCfg.CompressionTypes.Key, "0,0,0,0,0")
@@ -3205,14 +3043,10 @@ func newTestServer(t *testing.T, receiveCh chan any, opts ...Option) *Server {
 	svr.SetTiKVClient(globalTestTikv)
 
 	svr.dataNodeCreator = func(ctx context.Context, addr string, nodeID int64) (types.DataNodeClient, error) {
-		return newMockDataNodeClient(0, receiveCh)
+		return newMockDataNodeClient(0, nil)
 	}
 	svr.rootCoordClientCreator = func(ctx context.Context) (types.RootCoordClient, error) {
 		return newMockRootCoordClient(), nil
-	}
-
-	for _, opt := range opts {
-		opt(svr)
 	}
 
 	err = svr.Init()
@@ -3236,6 +3070,11 @@ func newTestServer(t *testing.T, receiveCh chan any, opts ...Option) *Server {
 		assert.Equal(t, commonpb.StateCode_Initializing, svr.stateCode.Load().(commonpb.StateCode))
 		close(signal)
 	}
+
+	for _, opt := range opts {
+		opt(svr)
+	}
+
 	err = svr.Register()
 	assert.NoError(t, err)
 	<-signal
@@ -3246,112 +3085,12 @@ func newTestServer(t *testing.T, receiveCh chan any, opts ...Option) *Server {
 	return svr
 }
 
-func newTestServerWithMeta(t *testing.T, receiveCh chan any, meta *meta, opts ...Option) *Server {
-	var err error
-	paramtable.Get().Save(Params.CommonCfg.DataCoordTimeTick.Key, Params.CommonCfg.DataCoordTimeTick.GetValue()+strconv.Itoa(rand.Int()))
-	factory := dependency.NewDefaultFactory(true)
-
-	etcdCli, err := etcd.GetEtcdClient(
-		Params.EtcdCfg.UseEmbedEtcd.GetAsBool(),
-		Params.EtcdCfg.EtcdUseSSL.GetAsBool(),
-		Params.EtcdCfg.Endpoints.GetAsStrings(),
-		Params.EtcdCfg.EtcdTLSCert.GetValue(),
-		Params.EtcdCfg.EtcdTLSKey.GetValue(),
-		Params.EtcdCfg.EtcdTLSCACert.GetValue(),
-		Params.EtcdCfg.EtcdTLSMinVersion.GetValue())
-	assert.NoError(t, err)
-	sessKey := path.Join(Params.EtcdCfg.MetaRootPath.GetValue(), sessionutil.DefaultServiceRoot)
-	_, err = etcdCli.Delete(context.Background(), sessKey, clientv3.WithPrefix())
-	assert.NoError(t, err)
-
-	svr := CreateServer(context.TODO(), factory, opts...)
-	svr.SetEtcdClient(etcdCli)
-	svr.SetTiKVClient(globalTestTikv)
-
-	svr.dataNodeCreator = func(ctx context.Context, addr string, nodeID int64) (types.DataNodeClient, error) {
-		return newMockDataNodeClient(0, receiveCh)
-	}
-	svr.rootCoordClientCreator = func(ctx context.Context) (types.RootCoordClient, error) {
-		return newMockRootCoordClient(), nil
-	}
-	// indexCoord := mocks.NewMockIndexCoord(t)
-	// indexCoord.EXPECT().GetIndexInfos(mock.Anything, mock.Anything).Return(nil, nil).Maybe()
-	// svr.indexCoord = indexCoord
-
-	err = svr.Init()
-	assert.NoError(t, err)
-	svr.meta = meta
-
-	err = svr.Start()
-	assert.NoError(t, err)
-	err = svr.Register()
-	assert.NoError(t, err)
-
-	// Stop channal watch state watcher in tests
-	if svr.channelManager != nil {
-		impl, ok := svr.channelManager.(*ChannelManagerImpl)
-		if ok && impl.stopChecker != nil {
-			impl.stopChecker()
-		}
-	}
-
-	return svr
-}
-
 func closeTestServer(t *testing.T, svr *Server) {
 	err := svr.Stop()
 	assert.NoError(t, err)
 	err = svr.CleanMeta()
 	assert.NoError(t, err)
 	paramtable.Get().Reset(Params.CommonCfg.DataCoordTimeTick.Key)
-}
-
-func newTestServer2(t *testing.T, receiveCh chan any, opts ...Option) *Server {
-	var err error
-	paramtable.Init()
-	paramtable.Get().Save(Params.CommonCfg.DataCoordTimeTick.Key, Params.CommonCfg.DataCoordTimeTick.GetValue()+strconv.Itoa(rand.Int()))
-	factory := dependency.NewDefaultFactory(true)
-
-	etcdCli, err := etcd.GetEtcdClient(
-		Params.EtcdCfg.UseEmbedEtcd.GetAsBool(),
-		Params.EtcdCfg.EtcdUseSSL.GetAsBool(),
-		Params.EtcdCfg.Endpoints.GetAsStrings(),
-		Params.EtcdCfg.EtcdTLSCert.GetValue(),
-		Params.EtcdCfg.EtcdTLSKey.GetValue(),
-		Params.EtcdCfg.EtcdTLSCACert.GetValue(),
-		Params.EtcdCfg.EtcdTLSMinVersion.GetValue())
-	assert.NoError(t, err)
-	sessKey := path.Join(Params.EtcdCfg.MetaRootPath.GetValue(), sessionutil.DefaultServiceRoot)
-	_, err = etcdCli.Delete(context.Background(), sessKey, clientv3.WithPrefix())
-	assert.NoError(t, err)
-
-	svr := CreateServer(context.TODO(), factory, opts...)
-	svr.SetEtcdClient(etcdCli)
-	svr.SetTiKVClient(globalTestTikv)
-
-	svr.dataNodeCreator = func(ctx context.Context, addr string, nodeID int64) (types.DataNodeClient, error) {
-		return newMockDataNodeClient(0, receiveCh)
-	}
-	svr.rootCoordClientCreator = func(ctx context.Context) (types.RootCoordClient, error) {
-		return newMockRootCoordClient(), nil
-	}
-
-	err = svr.Init()
-	assert.NoError(t, err)
-	err = svr.Start()
-	assert.NoError(t, err)
-	err = svr.Register()
-	assert.NoError(t, err)
-
-	// Stop channal watch state watcher in tests
-	if svr.channelManager != nil {
-		impl, ok := svr.channelManager.(*ChannelManagerImpl)
-		if ok && impl.stopChecker != nil {
-			impl.stopChecker()
-		}
-	}
-
-	return svr
 }
 
 func Test_CheckHealth(t *testing.T) {
@@ -3417,48 +3156,8 @@ func Test_CheckHealth(t *testing.T) {
 	})
 }
 
-//func Test_initServiceDiscovery(t *testing.T) {
-//	server := newTestServer2(t, nil)
-//	assert.NotNil(t, server)
-//
-//	segmentID := rand.Int63()
-//	err := server.meta.AddSegment(&SegmentInfo{
-//		SegmentInfo: &datapb.SegmentInfo{
-//			ID:           segmentID,
-//			CollectionID: rand.Int63(),
-//			PartitionID:  rand.Int63(),
-//			NumOfRows:    100,
-//		},
-//		currRows: 100,
-//	})
-//	assert.NoError(t, err)
-//
-//	qcSession := sessionutil.NewSession(context.Background(), Params.EtcdCfg.MetaRootPath.GetValue(), server.etcdCli)
-//	qcSession.Init(typeutil.QueryCoordRole, "localhost:19532", true, true)
-//	qcSession.Register()
-//	//req := &datapb.AcquireSegmentLockRequest{
-//	//	NodeID:     qcSession.ServerID,
-//	//	SegmentIDs: []UniqueID{segmentID},
-//	//}
-//	//resp, err := server.AcquireSegmentLock(context.TODO(), req)
-//	//assert.NoError(t, err)
-//	//assert.Equal(t, commonpb.ErrorCode_Success, resp.GetErrorCode())
-//
-//	sessKey := path.Join(Params.EtcdCfg.MetaRootPath.GetValue(), sessionutil.DefaultServiceRoot, typeutil.QueryCoordRole)
-//	_, err = server.etcdCli.Delete(context.Background(), sessKey, clientv3.WithPrefix())
-//	assert.NoError(t, err)
-//
-//	//for {
-//	//	if !server.segReferManager.HasSegmentLock(segmentID) {
-//	//		break
-//	//	}
-//	//}
-//
-//	closeTestServer(t, server)
-//}
-
 func Test_newChunkManagerFactory(t *testing.T) {
-	server := newTestServer2(t, nil)
+	server := newTestServer(t)
 	paramtable.Get().Save(Params.DataCoordCfg.EnableGarbageCollection.Key, "true")
 	defer closeTestServer(t, server)
 
@@ -3485,7 +3184,7 @@ func Test_initGarbageCollection(t *testing.T) {
 	paramtable.Get().Save(Params.DataCoordCfg.EnableGarbageCollection.Key, "true")
 	defer paramtable.Get().Reset(Params.DataCoordCfg.EnableGarbageCollection.Key)
 
-	server := newTestServer2(t, nil)
+	server := newTestServer(t)
 	defer closeTestServer(t, server)
 
 	t.Run("ok", func(t *testing.T) {
@@ -3505,316 +3204,19 @@ func Test_initGarbageCollection(t *testing.T) {
 	})
 }
 
-func testDataCoordBase(t *testing.T, opts ...Option) *Server {
-	var err error
-	paramtable.Get().Save(Params.CommonCfg.DataCoordTimeTick.Key, Params.CommonCfg.DataCoordTimeTick.GetValue()+strconv.Itoa(rand.Int()))
-	factory := dependency.NewDefaultFactory(true)
-
-	ctx := context.Background()
-	etcdCli, err := etcd.GetEtcdClient(
-		Params.EtcdCfg.UseEmbedEtcd.GetAsBool(),
-		Params.EtcdCfg.EtcdUseSSL.GetAsBool(),
-		Params.EtcdCfg.Endpoints.GetAsStrings(),
-		Params.EtcdCfg.EtcdTLSCert.GetValue(),
-		Params.EtcdCfg.EtcdTLSKey.GetValue(),
-		Params.EtcdCfg.EtcdTLSCACert.GetValue(),
-		Params.EtcdCfg.EtcdTLSMinVersion.GetValue())
-	assert.NoError(t, err)
-	sessKey := path.Join(Params.EtcdCfg.MetaRootPath.GetValue(), sessionutil.DefaultServiceRoot)
-	_, err = etcdCli.Delete(ctx, sessKey, clientv3.WithPrefix())
-	assert.NoError(t, err)
-
-	svr := CreateServer(ctx, factory, opts...)
-	svr.SetEtcdClient(etcdCli)
-	svr.SetTiKVClient(globalTestTikv)
-
-	svr.SetDataNodeCreator(func(ctx context.Context, addr string, nodeID int64) (types.DataNodeClient, error) {
-		return newMockDataNodeClient(0, nil)
-	})
-	svr.SetIndexNodeCreator(func(ctx context.Context, addr string, nodeID int64) (types.IndexNodeClient, error) {
-		return &grpcmock.GrpcIndexNodeClient{Err: nil}, nil
-	})
-	svr.SetRootCoordClient(newMockRootCoordClient())
-
-	err = svr.Init()
-	assert.NoError(t, err)
-
-	signal := make(chan struct{})
-	if Params.DataCoordCfg.EnableActiveStandby.GetAsBool() {
-		assert.Equal(t, commonpb.StateCode_StandBy, svr.stateCode.Load().(commonpb.StateCode))
-		activateFunc := svr.activateFunc
-		svr.activateFunc = func() error {
-			defer func() {
-				close(signal)
-			}()
-			var err error
-			if activateFunc != nil {
-				err = activateFunc()
-			}
-			return err
-		}
-	} else {
-		assert.Equal(t, commonpb.StateCode_Initializing, svr.stateCode.Load().(commonpb.StateCode))
-		close(signal)
-	}
-	err = svr.Register()
-	assert.NoError(t, err)
-	<-signal
-
-	err = svr.Start()
-	assert.NoError(t, err)
-
-	resp, err := svr.GetComponentStates(context.Background(), nil)
-	assert.NoError(t, err)
-	assert.True(t, merr.Ok(resp.GetStatus()))
-	assert.Equal(t, commonpb.StateCode_Healthy, resp.GetState().GetStateCode())
-
-	// stop channal watch state watcher in tests
-	if svr.channelManager != nil {
-		impl, ok := svr.channelManager.(*ChannelManagerImpl)
-		if ok && impl.stopChecker != nil {
-			impl.stopChecker()
-		}
-	}
-
-	return svr
-}
-
 func TestDataCoord_DisableActiveStandby(t *testing.T) {
 	paramtable.Get().Save(Params.DataCoordCfg.EnableActiveStandby.Key, "false")
 	defer paramtable.Get().Reset(Params.DataCoordCfg.EnableActiveStandby.Key)
-	svr := testDataCoordBase(t)
-	defer closeTestServer(t, svr)
+	svr := newTestServer(t)
+	closeTestServer(t, svr)
 }
 
 // make sure the main functions work well when EnableActiveStandby=true
 func TestDataCoord_EnableActiveStandby(t *testing.T) {
 	paramtable.Get().Save(Params.DataCoordCfg.EnableActiveStandby.Key, "true")
 	defer paramtable.Get().Reset(Params.DataCoordCfg.EnableActiveStandby.Key)
-	svr := testDataCoordBase(t)
+	svr := newTestServer(t)
 	defer closeTestServer(t, svr)
-}
-
-func TestDataNodeTtChannel(t *testing.T) {
-	paramtable.Get().Save(Params.DataNodeCfg.DataNodeTimeTickByRPC.Key, "false")
-	defer paramtable.Get().Reset(Params.DataNodeCfg.DataNodeTimeTickByRPC.Key)
-	genMsg := func(msgType commonpb.MsgType, ch string, t Timestamp) *msgstream.DataNodeTtMsg {
-		return &msgstream.DataNodeTtMsg{
-			BaseMsg: msgstream.BaseMsg{
-				HashValues: []uint32{0},
-			},
-			DataNodeTtMsg: msgpb.DataNodeTtMsg{
-				Base: &commonpb.MsgBase{
-					MsgType:   msgType,
-					MsgID:     0,
-					Timestamp: t,
-					SourceID:  0,
-				},
-				ChannelName: ch,
-				Timestamp:   t,
-			},
-		}
-	}
-	t.Run("Test segment flush after tt", func(t *testing.T) {
-		ch := make(chan any, 1)
-		svr := newTestServer(t, ch)
-		defer closeTestServer(t, svr)
-
-		svr.meta.AddCollection(&collectionInfo{
-			ID:         0,
-			Schema:     newTestSchema(),
-			Partitions: []int64{0},
-		})
-
-		ttMsgStream, err := svr.factory.NewMsgStream(context.TODO())
-		assert.NoError(t, err)
-		ttMsgStream.AsProducer([]string{Params.CommonCfg.DataCoordTimeTick.GetValue()})
-		defer ttMsgStream.Close()
-		info := &NodeInfo{
-			Address: "localhost:7777",
-			NodeID:  0,
-		}
-		err = svr.cluster.Register(info)
-		assert.NoError(t, err)
-
-		resp, err := svr.AssignSegmentID(context.TODO(), &datapb.AssignSegmentIDRequest{
-			NodeID:   0,
-			PeerRole: "",
-			SegmentIDRequests: []*datapb.SegmentIDRequest{
-				{
-					CollectionID: 0,
-					PartitionID:  0,
-					ChannelName:  "ch-1",
-					Count:        100,
-				},
-			},
-		})
-
-		assert.NoError(t, err)
-		assert.EqualValues(t, commonpb.ErrorCode_Success, resp.GetStatus().GetErrorCode())
-		assert.EqualValues(t, 1, len(resp.SegIDAssignments))
-		assign := resp.SegIDAssignments[0]
-
-		resp2, err := svr.Flush(context.TODO(), &datapb.FlushRequest{
-			Base: &commonpb.MsgBase{
-				MsgType:   commonpb.MsgType_Flush,
-				MsgID:     0,
-				Timestamp: 0,
-				SourceID:  0,
-			},
-			DbID:         0,
-			CollectionID: 0,
-		})
-		assert.NoError(t, err)
-		assert.EqualValues(t, commonpb.ErrorCode_Success, resp2.GetStatus().GetErrorCode())
-
-		msgPack := msgstream.MsgPack{}
-		msg := genMsg(commonpb.MsgType_DataNodeTt, "ch-1", assign.ExpireTime)
-		msg.SegmentsStats = append(msg.SegmentsStats, &commonpb.SegmentStats{
-			SegmentID: assign.GetSegID(),
-			NumRows:   1,
-		})
-		msgPack.Msgs = append(msgPack.Msgs, msg)
-		err = ttMsgStream.Produce(&msgPack)
-		assert.NoError(t, err)
-
-		flushMsg := <-ch
-		flushReq := flushMsg.(*datapb.FlushSegmentsRequest)
-		assert.EqualValues(t, 1, len(flushReq.SegmentIDs))
-		assert.EqualValues(t, assign.SegID, flushReq.SegmentIDs[0])
-	})
-
-	t.Run("flush segment with different channels", func(t *testing.T) {
-		ch := make(chan any, 1)
-		svr := newTestServer(t, ch)
-		defer closeTestServer(t, svr)
-		svr.meta.AddCollection(&collectionInfo{
-			ID:         0,
-			Schema:     newTestSchema(),
-			Partitions: []int64{0},
-		})
-		ttMsgStream, err := svr.factory.NewMsgStream(context.TODO())
-		assert.NoError(t, err)
-		ttMsgStream.AsProducer([]string{Params.CommonCfg.DataCoordTimeTick.GetValue()})
-		defer ttMsgStream.Close()
-		info := &NodeInfo{
-			Address: "localhost:7777",
-			NodeID:  0,
-		}
-		err = svr.cluster.Register(info)
-		assert.NoError(t, err)
-		resp, err := svr.AssignSegmentID(context.TODO(), &datapb.AssignSegmentIDRequest{
-			NodeID:   0,
-			PeerRole: "",
-			SegmentIDRequests: []*datapb.SegmentIDRequest{
-				{
-					CollectionID: 0,
-					PartitionID:  0,
-					ChannelName:  "ch-1",
-					Count:        100,
-				},
-				{
-					CollectionID: 0,
-					PartitionID:  0,
-					ChannelName:  "ch-2",
-					Count:        100,
-				},
-			},
-		})
-		assert.NoError(t, err)
-		assert.EqualValues(t, commonpb.ErrorCode_Success, resp.GetStatus().GetErrorCode())
-		assert.EqualValues(t, 2, len(resp.SegIDAssignments))
-		var assign *datapb.SegmentIDAssignment
-		for _, segment := range resp.SegIDAssignments {
-			if segment.GetChannelName() == "ch-1" {
-				assign = segment
-				break
-			}
-		}
-		assert.NotNil(t, assign)
-		resp2, err := svr.Flush(context.TODO(), &datapb.FlushRequest{
-			Base: &commonpb.MsgBase{
-				MsgType:   commonpb.MsgType_Flush,
-				MsgID:     0,
-				Timestamp: 0,
-				SourceID:  0,
-			},
-			DbID:         0,
-			CollectionID: 0,
-		})
-		assert.NoError(t, err)
-		assert.EqualValues(t, commonpb.ErrorCode_Success, resp2.GetStatus().GetErrorCode())
-
-		msgPack := msgstream.MsgPack{}
-		msg := genMsg(commonpb.MsgType_DataNodeTt, "ch-1", assign.ExpireTime)
-		msg.SegmentsStats = append(msg.SegmentsStats, &commonpb.SegmentStats{
-			SegmentID: assign.GetSegID(),
-			NumRows:   1,
-		})
-		msgPack.Msgs = append(msgPack.Msgs, msg)
-		err = ttMsgStream.Produce(&msgPack)
-		assert.NoError(t, err)
-		flushMsg := <-ch
-		flushReq := flushMsg.(*datapb.FlushSegmentsRequest)
-		assert.EqualValues(t, 1, len(flushReq.SegmentIDs))
-		assert.EqualValues(t, assign.SegID, flushReq.SegmentIDs[0])
-	})
-
-	t.Run("test expire allocation after receiving tt msg", func(t *testing.T) {
-		ch := make(chan any, 1)
-		helper := ServerHelper{
-			eventAfterHandleDataNodeTt: func() { ch <- struct{}{} },
-		}
-		svr := newTestServer(t, nil, WithServerHelper(helper))
-		defer closeTestServer(t, svr)
-
-		svr.meta.AddCollection(&collectionInfo{
-			ID:         0,
-			Schema:     newTestSchema(),
-			Partitions: []int64{0},
-		})
-
-		ttMsgStream, err := svr.factory.NewMsgStream(context.TODO())
-		assert.NoError(t, err)
-		ttMsgStream.AsProducer([]string{Params.CommonCfg.DataCoordTimeTick.GetValue()})
-		defer ttMsgStream.Close()
-		node := &NodeInfo{
-			NodeID:  0,
-			Address: "localhost:7777",
-		}
-		err = svr.cluster.Register(node)
-		assert.NoError(t, err)
-
-		resp, err := svr.AssignSegmentID(context.TODO(), &datapb.AssignSegmentIDRequest{
-			NodeID:   0,
-			PeerRole: "",
-			SegmentIDRequests: []*datapb.SegmentIDRequest{
-				{
-					CollectionID: 0,
-					PartitionID:  0,
-					ChannelName:  "ch-1",
-					Count:        100,
-				},
-			},
-		})
-		assert.NoError(t, err)
-		assert.EqualValues(t, commonpb.ErrorCode_Success, resp.GetStatus().GetErrorCode())
-		assert.EqualValues(t, 1, len(resp.SegIDAssignments))
-
-		assignedSegmentID := resp.SegIDAssignments[0].SegID
-		segment := svr.meta.GetHealthySegment(assignedSegmentID)
-		assert.EqualValues(t, 1, len(segment.allocations))
-
-		msgPack := msgstream.MsgPack{}
-		msg := genMsg(commonpb.MsgType_DataNodeTt, "ch-1", resp.SegIDAssignments[0].ExpireTime)
-		msgPack.Msgs = append(msgPack.Msgs, msg)
-		err = ttMsgStream.Produce(&msgPack)
-		assert.NoError(t, err)
-
-		<-ch
-		segment = svr.meta.GetHealthySegment(assignedSegmentID)
-		assert.EqualValues(t, 0, len(segment.allocations))
-	})
 }
 
 func TestUpdateAutoBalanceConfigLoop(t *testing.T) {

--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -189,9 +189,6 @@ func (s *Server) AssignSegmentID(ctx context.Context, req *datapb.AssignSegmentI
 			log.Warn("cannot get collection schema", zap.Error(err))
 		}
 
-		// Add the channel to cluster for watching.
-		s.cluster.Watch(ctx, r.ChannelName, r.CollectionID)
-
 		// Have segment manager allocate and return the segment allocation info.
 		segmentAllocations, err := s.segmentManager.AllocSegment(ctx,
 			r.CollectionID, r.PartitionID, r.ChannelName, int64(r.Count))
@@ -1413,7 +1410,7 @@ func (s *Server) UpdateChannelCheckpoint(ctx context.Context, req *datapb.Update
 	return merr.Success(), nil
 }
 
-// ReportDataNodeTtMsgs send datenode timetick messages to dataCoord.
+// ReportDataNodeTtMsgs gets timetick messages from datanode.
 func (s *Server) ReportDataNodeTtMsgs(ctx context.Context, req *datapb.ReportDataNodeTtMsgsRequest) (*commonpb.Status, error) {
 	log := log.Ctx(ctx)
 	if err := merr.CheckHealthy(s.GetStateCode()); err != nil {
@@ -1425,7 +1422,7 @@ func (s *Server) ReportDataNodeTtMsgs(ctx context.Context, req *datapb.ReportDat
 		metrics.DataCoordConsumeDataNodeTimeTickLag.
 			WithLabelValues(fmt.Sprint(paramtable.GetNodeID()), ttMsg.GetChannelName()).
 			Set(float64(sub))
-		err := s.handleRPCTimetickMessage(ctx, ttMsg)
+		err := s.handleDataNodeTtMsg(ctx, ttMsg)
 		if err != nil {
 			log.Error("fail to handle Datanode Timetick Msg",
 				zap.Int64("sourceID", ttMsg.GetBase().GetSourceID()),
@@ -1438,49 +1435,64 @@ func (s *Server) ReportDataNodeTtMsgs(ctx context.Context, req *datapb.ReportDat
 	return merr.Success(), nil
 }
 
-func (s *Server) handleRPCTimetickMessage(ctx context.Context, ttMsg *msgpb.DataNodeTtMsg) error {
-	log := log.Ctx(ctx)
-	ch := ttMsg.GetChannelName()
-	ts := ttMsg.GetTimestamp()
+func (s *Server) handleDataNodeTtMsg(ctx context.Context, ttMsg *msgpb.DataNodeTtMsg) error {
+	var (
+		channel      = ttMsg.GetChannelName()
+		ts           = ttMsg.GetTimestamp()
+		sourceID     = ttMsg.GetBase().GetSourceID()
+		segmentStats = ttMsg.GetSegmentsStats()
+	)
 
-	// ignore to handle RPC Timetick message since it's no longer the leader
-	if !s.channelManager.Match(ttMsg.GetBase().GetSourceID(), ch) {
-		log.Warn("node is not matched with channel",
-			zap.String("channelName", ch),
-			zap.Int64("nodeID", ttMsg.GetBase().GetSourceID()),
-		)
+	physical, _ := tsoutil.ParseTS(ts)
+	log := log.Ctx(ctx).WithRateGroup("dc.handleTimetick", 1, 60).With(
+		zap.String("channel", channel),
+		zap.Int64("sourceID", sourceID),
+		zap.Any("ts", ts),
+	)
+	if time.Since(physical).Minutes() > 1 {
+		// if lag behind, log every 1 mins about
+		log.RatedWarn(60.0, "time tick lag behind for more than 1 minutes")
+	}
+	// ignore report from a different node
+	if !s.channelManager.Match(sourceID, channel) {
+		log.Warn("node is not matched with channel")
 		return nil
 	}
 
-	s.updateSegmentStatistics(ttMsg.GetSegmentsStats())
+	sub := tsoutil.SubByNow(ts)
+	pChannelName := funcutil.ToPhysicalChannel(channel)
+	metrics.DataCoordConsumeDataNodeTimeTickLag.
+		WithLabelValues(fmt.Sprint(paramtable.GetNodeID()), pChannelName).
+		Set(float64(sub))
 
-	if err := s.segmentManager.ExpireAllocations(ch, ts); err != nil {
-		return fmt.Errorf("expire allocations: %w", err)
+	s.updateSegmentStatistics(segmentStats)
+
+	if err := s.segmentManager.ExpireAllocations(channel, ts); err != nil {
+		log.Warn("failed to expire allocations", zap.Error(err))
+		return err
 	}
 
-	flushableIDs, err := s.segmentManager.GetFlushableSegments(ctx, ch, ts)
+	flushableIDs, err := s.segmentManager.GetFlushableSegments(ctx, channel, ts)
 	if err != nil {
-		return fmt.Errorf("get flushable segments: %w", err)
+		log.Warn("failed to get flushable segments", zap.Error(err))
+		return err
 	}
 	flushableSegments := s.getFlushableSegmentsInfo(flushableIDs)
-
 	if len(flushableSegments) == 0 {
 		return nil
 	}
 
-	log.Info("start flushing segments",
-		zap.Int64s("segment IDs", flushableIDs))
+	log.Info("start flushing segments", zap.Int64s("segmentIDs", flushableIDs))
 	// update segment last update triggered time
 	// it's ok to fail flushing, since next timetick after duration will re-trigger
 	s.setLastFlushTime(flushableSegments)
 
-	finfo := make([]*datapb.SegmentInfo, 0, len(flushableSegments))
-	for _, info := range flushableSegments {
-		finfo = append(finfo, info.SegmentInfo)
-	}
-	err = s.cluster.Flush(s.ctx, ttMsg.GetBase().GetSourceID(), ch, finfo)
+	infos := lo.Map(flushableSegments, func(info *SegmentInfo, _ int) *datapb.SegmentInfo {
+		return info.SegmentInfo
+	})
+	err = s.cluster.Flush(s.ctx, sourceID, channel, infos)
 	if err != nil {
-		log.Warn("failed to handle flush", zap.Any("source", ttMsg.GetBase().GetSourceID()), zap.Error(err))
+		log.Warn("failed to call Flush", zap.Error(err))
 		return err
 	}
 

--- a/internal/datacoord/services_test.go
+++ b/internal/datacoord/services_test.go
@@ -2,6 +2,7 @@ package datacoord
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -27,9 +28,11 @@ import (
 	"github.com/milvus-io/milvus/internal/proto/internalpb"
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/pkg/log"
+	"github.com/milvus-io/milvus/pkg/mq/msgstream"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/metautil"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/util/tsoutil"
 )
 
 type ServerSuite struct {
@@ -39,16 +42,20 @@ type ServerSuite struct {
 	mockChMgr  *MockChannelManager
 }
 
+func WithChannelManager(cm ChannelManager) Option {
+	return func(svr *Server) {
+		svr.channelManager = cm
+	}
+}
+
 func (s *ServerSuite) SetupTest() {
-	s.testServer = newTestServer(s.T(), nil)
+	s.mockChMgr = NewMockChannelManager(s.T())
+	s.mockChMgr.EXPECT().Startup(mock.Anything, mock.Anything).Return(nil).Maybe()
+	s.mockChMgr.EXPECT().Close().Maybe()
+
+	s.testServer = newTestServer(s.T(), WithChannelManager(s.mockChMgr))
 	if s.testServer.channelManager != nil {
 		s.testServer.channelManager.Close()
-	}
-
-	s.mockChMgr = NewMockChannelManager(s.T())
-	s.testServer.channelManager = s.mockChMgr
-	if s.mockChMgr != nil {
-		s.mockChMgr.EXPECT().Close().Maybe()
 	}
 }
 
@@ -61,6 +68,327 @@ func (s *ServerSuite) TearDownTest() {
 
 func TestServerSuite(t *testing.T) {
 	suite.Run(t, new(ServerSuite))
+}
+
+func genMsg(msgType commonpb.MsgType, ch string, t Timestamp, sourceID int64) *msgstream.DataNodeTtMsg {
+	return &msgstream.DataNodeTtMsg{
+		BaseMsg: msgstream.BaseMsg{
+			HashValues: []uint32{0},
+		},
+		DataNodeTtMsg: msgpb.DataNodeTtMsg{
+			Base: &commonpb.MsgBase{
+				MsgType:   msgType,
+				Timestamp: t,
+				SourceID:  sourceID,
+			},
+			ChannelName:   ch,
+			Timestamp:     t,
+			SegmentsStats: []*commonpb.SegmentStats{{SegmentID: 2, NumRows: 100}},
+		},
+	}
+}
+
+func (s *ServerSuite) TestHandleDataNodeTtMsg() {
+	var (
+		chanName       = "ch-1"
+		collID   int64 = 100
+		sourceID int64 = 1
+	)
+	s.testServer.meta.AddCollection(&collectionInfo{
+		ID:         collID,
+		Schema:     newTestSchema(),
+		Partitions: []int64{10},
+	})
+	resp, err := s.testServer.AssignSegmentID(context.TODO(), &datapb.AssignSegmentIDRequest{
+		NodeID: sourceID,
+		SegmentIDRequests: []*datapb.SegmentIDRequest{
+			{
+				CollectionID: collID,
+				PartitionID:  10,
+				ChannelName:  chanName,
+				Count:        100,
+			},
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().True(merr.Ok(resp.GetStatus()))
+	s.Equal(1, len(resp.GetSegIDAssignments()))
+	assign := resp.GetSegIDAssignments()[0]
+
+	assignedSegmentID := resp.SegIDAssignments[0].SegID
+	segment := s.testServer.meta.GetHealthySegment(assignedSegmentID)
+	s.Require().NotNil(segment)
+	s.Equal(1, len(segment.allocations))
+
+	ts := tsoutil.AddPhysicalDurationOnTs(assign.ExpireTime, -3*time.Minute)
+	msg := genMsg(commonpb.MsgType_DataNodeTt, chanName, ts, sourceID)
+	msg.SegmentsStats = append(msg.SegmentsStats, &commonpb.SegmentStats{
+		SegmentID: assign.GetSegID(),
+		NumRows:   1,
+	})
+	mockCluster := NewMockCluster(s.T())
+	mockCluster.EXPECT().Close().Once()
+	mockCluster.EXPECT().Flush(mock.Anything, sourceID, chanName, mock.Anything).RunAndReturn(
+		func(ctx context.Context, nodeID int64, channel string, segments []*datapb.SegmentInfo) error {
+			s.EqualValues(chanName, channel)
+			s.EqualValues(sourceID, nodeID)
+			s.Equal(1, len(segments))
+			s.EqualValues(2, segments[0].GetID())
+
+			return fmt.Errorf("mock error")
+		}).Once()
+	s.testServer.cluster = mockCluster
+	s.mockChMgr.EXPECT().Match(sourceID, chanName).Return(true).Twice()
+
+	err = s.testServer.handleDataNodeTtMsg(context.TODO(), &msg.DataNodeTtMsg)
+	s.NoError(err)
+
+	tt := tsoutil.AddPhysicalDurationOnTs(assign.ExpireTime, 48*time.Hour)
+	msg = genMsg(commonpb.MsgType_DataNodeTt, chanName, tt, sourceID)
+	msg.SegmentsStats = append(msg.SegmentsStats, &commonpb.SegmentStats{
+		SegmentID: assign.GetSegID(),
+		NumRows:   1,
+	})
+
+	err = s.testServer.handleDataNodeTtMsg(context.TODO(), &msg.DataNodeTtMsg)
+	s.Error(err)
+}
+
+// restart the server for config DataNodeTimeTickByRPC=false
+func (s *ServerSuite) initSuiteForTtChannel() {
+	s.testServer.serverLoopWg.Add(1)
+	s.testServer.startDataNodeTtLoop(s.testServer.serverLoopCtx)
+
+	s.testServer.meta.AddCollection(&collectionInfo{
+		ID:         1,
+		Schema:     newTestSchema(),
+		Partitions: []int64{10},
+	})
+}
+
+func (s *ServerSuite) TestDataNodeTtChannel_ExpireAfterTt() {
+	s.initSuiteForTtChannel()
+
+	ctx := context.TODO()
+	ttMsgStream, err := s.testServer.factory.NewMsgStream(ctx)
+	s.Require().NoError(err)
+
+	ttMsgStream.AsProducer([]string{paramtable.Get().CommonCfg.DataCoordTimeTick.GetValue()})
+	defer ttMsgStream.Close()
+
+	var (
+		sourceID int64 = 9997
+		chanName       = "ch-1"
+		signal         = make(chan struct{})
+		collID   int64 = 1
+	)
+	mockCluster := NewMockCluster(s.T())
+	mockCluster.EXPECT().Close().Once()
+	mockCluster.EXPECT().Flush(mock.Anything, sourceID, chanName, mock.Anything).RunAndReturn(
+		func(ctx context.Context, nodeID int64, channel string, segments []*datapb.SegmentInfo) error {
+			s.EqualValues(chanName, channel)
+			s.EqualValues(sourceID, nodeID)
+			s.Equal(1, len(segments))
+			s.EqualValues(2, segments[0].GetID())
+
+			signal <- struct{}{}
+			return nil
+		}).Once()
+	s.testServer.cluster = mockCluster
+	s.mockChMgr.EXPECT().Match(sourceID, chanName).Return(true).Once()
+
+	resp, err := s.testServer.AssignSegmentID(context.TODO(), &datapb.AssignSegmentIDRequest{
+		NodeID: sourceID,
+		SegmentIDRequests: []*datapb.SegmentIDRequest{
+			{
+				CollectionID: collID,
+				PartitionID:  10,
+				ChannelName:  chanName,
+				Count:        100,
+			},
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().True(merr.Ok(resp.GetStatus()))
+	s.Equal(1, len(resp.GetSegIDAssignments()))
+
+	assignedSegmentID := resp.SegIDAssignments[0].SegID
+	segment := s.testServer.meta.GetHealthySegment(assignedSegmentID)
+	s.Require().NotNil(segment)
+	s.Equal(1, len(segment.allocations))
+
+	msgPack := msgstream.MsgPack{}
+	tt := tsoutil.AddPhysicalDurationOnTs(resp.SegIDAssignments[0].ExpireTime, 48*time.Hour)
+	msg := genMsg(commonpb.MsgType_DataNodeTt, "ch-1", tt, sourceID)
+	msgPack.Msgs = append(msgPack.Msgs, msg)
+	err = ttMsgStream.Produce(&msgPack)
+	s.Require().NoError(err)
+
+	<-signal
+	segment = s.testServer.meta.GetHealthySegment(assignedSegmentID)
+	s.NotNil(segment)
+	s.Equal(0, len(segment.allocations))
+}
+
+func (s *ServerSuite) TestDataNodeTtChannel_FlushWithDiffChan() {
+	s.initSuiteForTtChannel()
+
+	ctx := context.TODO()
+	ttMsgStream, err := s.testServer.factory.NewMsgStream(ctx)
+	s.Require().NoError(err)
+
+	ttMsgStream.AsProducer([]string{paramtable.Get().CommonCfg.DataCoordTimeTick.GetValue()})
+	defer ttMsgStream.Close()
+
+	var (
+		sourceID int64 = 9998
+		chanName       = "ch-1"
+		signal         = make(chan struct{})
+		collID   int64 = 1
+	)
+
+	mockCluster := NewMockCluster(s.T())
+	mockCluster.EXPECT().Close().Once()
+	mockCluster.EXPECT().Flush(mock.Anything, sourceID, chanName, mock.Anything).RunAndReturn(
+		func(ctx context.Context, nodeID int64, channel string, segments []*datapb.SegmentInfo) error {
+			s.EqualValues(chanName, channel)
+			s.EqualValues(sourceID, nodeID)
+			s.Equal(1, len(segments))
+
+			signal <- struct{}{}
+			return nil
+		}).Once()
+	mockCluster.EXPECT().FlushChannels(mock.Anything, sourceID, mock.Anything, []string{chanName}).Return(nil).Once()
+	s.testServer.cluster = mockCluster
+
+	s.mockChMgr.EXPECT().Match(sourceID, chanName).Return(true).Once()
+	s.mockChMgr.EXPECT().GetNodeChannelsByCollectionID(collID).Return(map[int64][]string{
+		sourceID: {chanName},
+	})
+
+	resp, err := s.testServer.AssignSegmentID(ctx, &datapb.AssignSegmentIDRequest{
+		NodeID: sourceID,
+		SegmentIDRequests: []*datapb.SegmentIDRequest{
+			{
+				CollectionID: collID,
+				PartitionID:  10,
+				ChannelName:  chanName,
+				Count:        100,
+			},
+			{
+				CollectionID: collID,
+				PartitionID:  10,
+				ChannelName:  "ch-2",
+				Count:        100,
+			},
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().True(merr.Ok(resp.GetStatus()))
+	s.Equal(2, len(resp.GetSegIDAssignments()))
+	var assign *datapb.SegmentIDAssignment
+	for _, segment := range resp.SegIDAssignments {
+		if segment.GetChannelName() == chanName {
+			assign = segment
+			break
+		}
+	}
+	s.Require().NotNil(assign)
+
+	resp2, err := s.testServer.Flush(ctx, &datapb.FlushRequest{
+		Base: &commonpb.MsgBase{
+			MsgType:  commonpb.MsgType_Flush,
+			SourceID: sourceID,
+		},
+		CollectionID: collID,
+	})
+	s.Require().NoError(err)
+	s.Require().True(merr.Ok(resp2.GetStatus()))
+
+	msgPack := msgstream.MsgPack{}
+	msg := genMsg(commonpb.MsgType_DataNodeTt, chanName, assign.ExpireTime, sourceID)
+	msg.SegmentsStats = append(msg.SegmentsStats, &commonpb.SegmentStats{
+		SegmentID: assign.GetSegID(),
+		NumRows:   1,
+	})
+	msgPack.Msgs = append(msgPack.Msgs, msg)
+	err = ttMsgStream.Produce(&msgPack)
+	s.NoError(err)
+
+	<-signal
+}
+
+func (s *ServerSuite) TestDataNodeTtChannel_SegmentFlushAfterTt() {
+	s.initSuiteForTtChannel()
+
+	var (
+		sourceID int64 = 9999
+		chanName       = "ch-1"
+		signal         = make(chan struct{})
+		collID   int64 = 1
+	)
+	mockCluster := NewMockCluster(s.T())
+	mockCluster.EXPECT().Close().Once()
+	mockCluster.EXPECT().Flush(mock.Anything, sourceID, chanName, mock.Anything).RunAndReturn(
+		func(ctx context.Context, nodeID int64, channel string, segments []*datapb.SegmentInfo) error {
+			s.EqualValues(chanName, channel)
+			s.EqualValues(sourceID, nodeID)
+			s.Equal(1, len(segments))
+
+			signal <- struct{}{}
+			return nil
+		}).Once()
+	mockCluster.EXPECT().FlushChannels(mock.Anything, sourceID, mock.Anything, []string{chanName}).Return(nil).Once()
+	s.testServer.cluster = mockCluster
+
+	s.mockChMgr.EXPECT().Match(sourceID, chanName).Return(true).Once()
+	s.mockChMgr.EXPECT().GetNodeChannelsByCollectionID(collID).Return(map[int64][]string{
+		sourceID: {chanName},
+	})
+
+	ctx := context.TODO()
+	ttMsgStream, err := s.testServer.factory.NewMsgStream(ctx)
+	s.Require().NoError(err)
+
+	ttMsgStream.AsProducer([]string{paramtable.Get().CommonCfg.DataCoordTimeTick.GetValue()})
+	defer ttMsgStream.Close()
+
+	resp, err := s.testServer.AssignSegmentID(context.TODO(), &datapb.AssignSegmentIDRequest{
+		SegmentIDRequests: []*datapb.SegmentIDRequest{
+			{
+				CollectionID: 1,
+				PartitionID:  10,
+				ChannelName:  chanName,
+				Count:        100,
+			},
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().True(merr.Ok(resp.GetStatus()))
+	s.Require().Equal(1, len(resp.GetSegIDAssignments()))
+
+	assign := resp.GetSegIDAssignments()[0]
+
+	resp2, err := s.testServer.Flush(ctx, &datapb.FlushRequest{
+		Base: &commonpb.MsgBase{
+			MsgType: commonpb.MsgType_Flush,
+		},
+		CollectionID: 1,
+	})
+	s.Require().NoError(err)
+	s.Require().True(merr.Ok(resp2.GetStatus()))
+
+	msgPack := msgstream.MsgPack{}
+	msg := genMsg(commonpb.MsgType_DataNodeTt, "ch-1", assign.ExpireTime, 9999)
+	msg.SegmentsStats = append(msg.SegmentsStats, &commonpb.SegmentStats{
+		SegmentID: assign.GetSegID(),
+		NumRows:   1,
+	})
+	msgPack.Msgs = append(msgPack.Msgs, msg)
+	err = ttMsgStream.Produce(&msgPack)
+	s.Require().NoError(err)
+
+	<-signal
 }
 
 func (s *ServerSuite) TestGetFlushState_ByFlushTs() {
@@ -706,7 +1034,7 @@ func TestServer_GcConfirm(t *testing.T) {
 
 func TestGetRecoveryInfoV2(t *testing.T) {
 	t.Run("test get recovery info with no segments", func(t *testing.T) {
-		svr := newTestServer(t, nil)
+		svr := newTestServer(t)
 		defer closeTestServer(t, svr)
 
 		svr.rootCoordClientCreator = func(ctx context.Context) (types.RootCoordClient, error) {
@@ -748,7 +1076,7 @@ func TestGetRecoveryInfoV2(t *testing.T) {
 	}
 
 	t.Run("test get earliest position of flushed segments as seek position", func(t *testing.T) {
-		svr := newTestServer(t, nil)
+		svr := newTestServer(t)
 		defer closeTestServer(t, svr)
 
 		svr.rootCoordClientCreator = func(ctx context.Context) (types.RootCoordClient, error) {
@@ -856,7 +1184,7 @@ func TestGetRecoveryInfoV2(t *testing.T) {
 	})
 
 	t.Run("test get recovery of unflushed segments ", func(t *testing.T) {
-		svr := newTestServer(t, nil)
+		svr := newTestServer(t)
 		defer closeTestServer(t, svr)
 
 		svr.rootCoordClientCreator = func(ctx context.Context) (types.RootCoordClient, error) {
@@ -933,7 +1261,7 @@ func TestGetRecoveryInfoV2(t *testing.T) {
 	})
 
 	t.Run("test get binlogs", func(t *testing.T) {
-		svr := newTestServer(t, nil)
+		svr := newTestServer(t)
 		defer closeTestServer(t, svr)
 
 		svr.meta.AddCollection(&collectionInfo{
@@ -1031,7 +1359,7 @@ func TestGetRecoveryInfoV2(t *testing.T) {
 		assert.EqualValues(t, 0, len(resp.GetSegments()[0].GetBinlogs()))
 	})
 	t.Run("with dropped segments", func(t *testing.T) {
-		svr := newTestServer(t, nil)
+		svr := newTestServer(t)
 		defer closeTestServer(t, svr)
 
 		svr.rootCoordClientCreator = func(ctx context.Context) (types.RootCoordClient, error) {
@@ -1076,7 +1404,7 @@ func TestGetRecoveryInfoV2(t *testing.T) {
 	})
 
 	t.Run("with fake segments", func(t *testing.T) {
-		svr := newTestServer(t, nil)
+		svr := newTestServer(t)
 		defer closeTestServer(t, svr)
 
 		svr.rootCoordClientCreator = func(ctx context.Context) (types.RootCoordClient, error) {
@@ -1120,7 +1448,7 @@ func TestGetRecoveryInfoV2(t *testing.T) {
 	})
 
 	t.Run("with continuous compaction", func(t *testing.T) {
-		svr := newTestServer(t, nil)
+		svr := newTestServer(t)
 		defer closeTestServer(t, svr)
 
 		svr.rootCoordClientCreator = func(ctx context.Context) (types.RootCoordClient, error) {
@@ -1205,7 +1533,7 @@ func TestGetRecoveryInfoV2(t *testing.T) {
 	})
 
 	t.Run("with closed server", func(t *testing.T) {
-		svr := newTestServer(t, nil)
+		svr := newTestServer(t)
 		closeTestServer(t, svr)
 		resp, err := svr.GetRecoveryInfoV2(context.TODO(), &datapb.GetRecoveryInfoRequestV2{})
 		assert.NoError(t, err)
@@ -1408,7 +1736,7 @@ type GcControlServiceSuite struct {
 }
 
 func (s *GcControlServiceSuite) SetupTest() {
-	s.server = newTestServer(s.T(), nil)
+	s.server = newTestServer(s.T())
 }
 
 func (s *GcControlServiceSuite) TearDownTest() {

--- a/internal/datacoord/session_manager.go
+++ b/internal/datacoord/session_manager.go
@@ -171,9 +171,10 @@ func (c *SessionManagerImpl) Flush(ctx context.Context, nodeID int64, req *datap
 }
 
 func (c *SessionManagerImpl) execFlush(ctx context.Context, nodeID int64, req *datapb.FlushSegmentsRequest) {
+	log := log.Ctx(ctx).With(zap.Int64("nodeID", nodeID), zap.String("channel", req.GetChannelName()))
 	cli, err := c.getClient(ctx, nodeID)
 	if err != nil {
-		log.Warn("failed to get dataNode client", zap.Int64("dataNode ID", nodeID), zap.Error(err))
+		log.Warn("failed to get dataNode client", zap.Error(err))
 		return
 	}
 	ctx, cancel := context.WithTimeout(ctx, flushTimeout)
@@ -181,9 +182,9 @@ func (c *SessionManagerImpl) execFlush(ctx context.Context, nodeID int64, req *d
 
 	resp, err := cli.FlushSegments(ctx, req)
 	if err := VerifyResponse(resp, err); err != nil {
-		log.Error("flush call (perhaps partially) failed", zap.Int64("dataNode ID", nodeID), zap.Error(err))
+		log.Error("flush call (perhaps partially) failed", zap.Error(err))
 	} else {
-		log.Info("flush call succeeded", zap.Int64("dataNode ID", nodeID))
+		log.Info("flush call succeeded")
 	}
 }
 


### PR DESCRIPTION
…#31621)

Tidy the following test codes

    - Remove channel in newTestServer
    - Remove newTestServerWithMeta
    - Remove newTestServer2
    - Remove testDataCoordBase
    - Use the same func for handleTTmsg and handleRPCTTmsg

See also: #31620
pr: #31621

---------