### PR TITLE
enhance: Make datanode exit and case `TestProxy` faster

### DIFF
--- a/internal/datanode/data_node.go
+++ b/internal/datanode/data_node.go
@@ -434,6 +434,7 @@ func (node *DataNode) Stop() error {
 		// https://github.com/milvus-io/milvus/issues/12282
 		node.UpdateStateCode(commonpb.StateCode_Abnormal)
 
+		node.flowgraphManager.Close()
 		node.eventManager.CloseAll()
 
 		if node.writeBufferManager != nil {


### PR DESCRIPTION
/kind improvement
issue: #32219