### PR TITLE
enhance: Maintain collection-patitions mapping in qc meta

### DIFF
--- a/internal/querycoordv2/meta/collection_manager.go
+++ b/internal/querycoordv2/meta/collection_manager.go
@@ -178,9 +178,11 @@ func (m *CollectionManager) Recover(broker Broker) error {
 				continue
 			}
 
-			m.partitions[partition.PartitionID] = &Partition{
-				PartitionLoadInfo: partition,
-			}
+			m.putPartition([]*Partition{
+				{
+					PartitionLoadInfo: partition,
+				},
+			}, false)
 		}
 	}
 
@@ -300,7 +302,6 @@ func (m *CollectionManager) calculateLoadPercentage(collectionID typeutil.Unique
 	_, ok := m.collections[collectionID]
 	if ok {
 		partitions := m.getPartitionsByCollection(collectionID)
-		log.Warn("CQX calc load perc", zap.Any("partitions", lo.Map(partitions, func(part *Partition, _ int) int64 { return part.GetPartitionID() })))
 		if len(partitions) > 0 {
 			return lo.SumBy(partitions, func(partition *Partition) int32 {
 				return partition.LoadPercentage


### PR DESCRIPTION
Related to #32165

Add collection to partitionIDs mapping to avoid interation on all partitions loaded when trying to get all partitions with collection id