### PR TITLE
fix: [skip e2e] Make channel balance test accept flushing segments

### DIFF
--- a/tests/integration/channel_balance/channel_balance_test.go
+++ b/tests/integration/channel_balance/channel_balance_test.go
@@ -113,7 +113,7 @@ func (s *ChannelBalanceSuite) flushCollections(collections []string) {
 			return info.GetCollectionID() == collID
 		})
 		lo.ForEach(collSegs, func(info *datapb.SegmentInfo, _ int) {
-			s.Require().Equal(commonpb.SegmentState_Flushed, info.GetState())
+			s.Require().Contains([]commonpb.SegmentState{commonpb.SegmentState_Flushed, commonpb.SegmentState_Flushing}, info.GetState())
 		})
 	}
 	log.Info("=========================Data flush done=========================")


### PR DESCRIPTION
See also #30973

Make the case stable since the segment state may be flushing when suite tries to check segment state.