### PR TITLE
enhance: speed up GetByCollectionAndNode

### DIFF
--- a/internal/querycoordv2/meta/replica_manager.go
+++ b/internal/querycoordv2/meta/replica_manager.go
@@ -241,9 +241,12 @@ func (m *ReplicaManager) GetByCollectionAndNode(collectionID, nodeID typeutil.Un
 	m.rwmutex.RLock()
 	defer m.rwmutex.RUnlock()
 
-	for _, replica := range m.replicas {
-		if replica.GetCollectionID() == collectionID && replica.Contains(nodeID) {
-			return replica
+	if m.collIDToReplicaIDs[collectionID] != nil {
+		for replicaID := range m.collIDToReplicaIDs[collectionID] {
+			replica := m.replicas[replicaID]
+			if replica.Contains(nodeID) {
+				return replica
+			}
 		}
 	}
 


### PR DESCRIPTION
Related to https://github.com/milvus-io/milvus/issues/32165

Avoid iterating through all replicas/collections if possible. Iteration is expensive when there are large number of replicas/collections.