### PR TITLE
enhance: changes to propagate traceid from client

### DIFF
--- a/pkg/util/logutil/grpc_interceptor.go
+++ b/pkg/util/logutil/grpc_interceptor.go
@@ -66,6 +66,8 @@ func withLevelAndTrace(ctx context.Context) context.Context {
 		if len(requestID) >= 1 {
 			// inject traceid in order to pass client request id
 			newctx = metadata.AppendToOutgoingContext(newctx, clientRequestIDKey, requestID[0])
+			// inject traceid from client for info/debug/warn/error logs
+			newctx = log.WithTraceID(newctx, requestID[0])
 		}
 	}
 	if !traceID.IsValid() {

--- a/pkg/util/logutil/grpc_interceptor_test.go
+++ b/pkg/util/logutil/grpc_interceptor_test.go
@@ -54,6 +54,10 @@ func TestCtxWithLevelAndTrace(t *testing.T) {
 		assert.True(t, ok)
 		assert.Equal(t, "client-req-id", md.Get(clientRequestIDKey)[0])
 		assert.Equal(t, zapcore.ErrorLevel.String(), md.Get(logLevelRPCMetaKey)[0])
+		expectedctx := context.TODO()
+		expectedctx = log.WithErrorLevel(expectedctx)
+		expectedctx = log.WithTraceID(expectedctx, md.Get(clientRequestIDKey)[0])
+		assert.Equal(t, log.Ctx(expectedctx), log.Ctx(newctx))
 	})
 }
 


### PR DESCRIPTION
https://github.com/milvus-io/milvus/issues/32321

Issue Description:
Tracing is an important means of identifying bottleneck points in a system and is crucial for debugging production issues. Milvus(or any DB) is generally the most downstream system for an user call -- a user call can originate from UI and pass through multiple components, in micro-services architecture, before reaching Milvus.
So, when an user experiences a glitch, one would debug the call trace via logs using a common trace id. As of now, Milvus generates a new trace id for every call and this request is to make sure client can pass the trace id which will be used for all the logs across the Milvus sub-components so that one can fetch logs for a user call across the components -- including Milvus.