### PR TITLE
enhance: Make applyDelete work in paralell in segment level

### DIFF
--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -295,6 +295,7 @@ func (sd *shardDelegator) applyDelete(ctx context.Context, nodeID int64, worker 
 			zap.Int64("segmentID", segmentEntry.SegmentID),
 			zap.Int64("workerID", nodeID),
 		)
+		segmentEntry := segmentEntry
 		delRecord, ok := delRecords[segmentEntry.SegmentID]
 		if ok {
 			future := pool.Submit(func() (struct{}, error) {


### PR DESCRIPTION
`applyDelete` used to be serial for delete entries on each segments. This PR make it work in parallel with errgroup to improve performance