### PR TITLE
fix: parameter check of TransferReplica and TransferNode

### DIFF
--- a/internal/querycoordv2/meta/replica_manager.go
+++ b/internal/querycoordv2/meta/replica_manager.go
@@ -162,6 +162,13 @@ func (m *ReplicaManager) putReplicaInMemory(replicas ...*Replica) {
 
 // TransferReplica transfers N replicas from srcRGName to dstRGName.
 func (m *ReplicaManager) TransferReplica(collectionID typeutil.UniqueID, srcRGName string, dstRGName string, replicaNum int) error {
+	if srcRGName == dstRGName {
+		return merr.WrapErrParameterInvalidMsg("source resource group and target resource group should not be the same, resource group: %s", srcRGName)
+	}
+	if replicaNum <= 0 {
+		return merr.WrapErrParameterInvalid("NumReplica > 0", fmt.Sprintf("invalid NumReplica %d", replicaNum))
+	}
+
 	m.rwmutex.Lock()
 	defer m.rwmutex.Unlock()
 

--- a/internal/querycoordv2/meta/replica_manager_test.go
+++ b/internal/querycoordv2/meta/replica_manager_test.go
@@ -319,21 +319,21 @@ func (suite *ReplicaManagerV2Suite) SetupSuite() {
 		"RG5": typeutil.NewUniqueSet(11, 12, 13, 14, 15),
 	}
 	suite.collections = map[int64]collectionLoadConfig{
-		// 1000: {
-		// 	spawnConfig: map[string]int{"RG1": 1},
-		// },
-		// 1001: {
-		// 	spawnConfig: map[string]int{"RG2": 2},
-		// },
-		// 1002: {
-		// 	spawnConfig: map[string]int{"RG3": 2},
-		// },
-		// 1003: {
-		// 	spawnConfig: map[string]int{"RG1": 1, "RG2": 1, "RG3": 1},
-		// },
-		// 1004: {
-		// 	spawnConfig: map[string]int{"RG4": 2, "RG5": 3},
-		// },
+		1000: {
+			spawnConfig: map[string]int{"RG1": 1},
+		},
+		1001: {
+			spawnConfig: map[string]int{"RG2": 2},
+		},
+		1002: {
+			spawnConfig: map[string]int{"RG3": 2},
+		},
+		1003: {
+			spawnConfig: map[string]int{"RG1": 1, "RG2": 1, "RG3": 1},
+		},
+		1004: {
+			spawnConfig: map[string]int{"RG4": 2, "RG5": 3},
+		},
 		1005: {
 			spawnConfig: map[string]int{"RG4": 3, "RG5": 2},
 		},
@@ -420,7 +420,16 @@ func (suite *ReplicaManagerV2Suite) testIfBalanced() {
 }
 
 func (suite *ReplicaManagerV2Suite) TestTransferReplica() {
-	suite.mgr.TransferReplica(1005, "RG4", "RG5", 1)
+	// param error
+	err := suite.mgr.TransferReplica(10086, "RG4", "RG5", 1)
+	suite.Error(err)
+	err = suite.mgr.TransferReplica(1005, "RG4", "RG5", 0)
+	suite.Error(err)
+	err = suite.mgr.TransferReplica(1005, "RG4", "RG4", 1)
+	suite.Error(err)
+
+	err = suite.mgr.TransferReplica(1005, "RG4", "RG5", 1)
+	suite.NoError(err)
 	suite.recoverReplica(2, true)
 	suite.testIfBalanced()
 }

--- a/internal/querycoordv2/meta/resource_manager.go
+++ b/internal/querycoordv2/meta/resource_manager.go
@@ -226,6 +226,13 @@ func (rm *ResourceManager) updateResourceGroups(rgs map[string]*rgpb.ResourceGro
 // go:deprecated TransferNode transfer node from source resource group to target resource group.
 // Deprecated, use Declarative API `UpdateResourceGroups` instead.
 func (rm *ResourceManager) TransferNode(sourceRGName string, targetRGName string, nodeNum int) error {
+	if sourceRGName == targetRGName {
+		return merr.WrapErrParameterInvalidMsg("source resource group and target resource group should not be the same, resource group: %s", sourceRGName)
+	}
+	if nodeNum <= 0 {
+		return merr.WrapErrParameterInvalid("NumNode > 0", fmt.Sprintf("invalid NumNode %d", nodeNum))
+	}
+
 	rm.rwmutex.Lock()
 	defer rm.rwmutex.Unlock()
 

--- a/internal/querycoordv2/services.go
+++ b/internal/querycoordv2/services.go
@@ -1089,21 +1089,6 @@ func (s *Server) TransferNode(ctx context.Context, req *milvuspb.TransferNodeReq
 		return merr.Status(err), nil
 	}
 
-	if ok := s.meta.ResourceManager.ContainResourceGroup(req.GetSourceResourceGroup()); !ok {
-		err := merr.WrapErrParameterInvalid("valid resource group", req.GetSourceResourceGroup(), "source resource group not found")
-		return merr.Status(err), nil
-	}
-
-	if ok := s.meta.ResourceManager.ContainResourceGroup(req.GetTargetResourceGroup()); !ok {
-		err := merr.WrapErrParameterInvalid("valid resource group", req.GetTargetResourceGroup(), "target resource group not found")
-		return merr.Status(err), nil
-	}
-
-	if req.GetNumNode() <= 0 {
-		err := merr.WrapErrParameterInvalid("NumNode > 0", fmt.Sprintf("invalid NumNode %d", req.GetNumNode()))
-		return merr.Status(err), nil
-	}
-
 	// Move node from source resource group to target resource group.
 	if err := s.meta.ResourceManager.TransferNode(req.GetSourceResourceGroup(), req.GetTargetResourceGroup(), int(req.GetNumNode())); err != nil {
 		log.Warn("failed to transfer node", zap.Error(err))
@@ -1139,11 +1124,6 @@ func (s *Server) TransferReplica(ctx context.Context, req *querypb.TransferRepli
 		err := merr.WrapErrResourceGroupNotFound(req.GetTargetResourceGroup())
 		return merr.Status(errors.Wrap(err,
 			fmt.Sprintf("the target resource group[%s] doesn't exist", req.GetTargetResourceGroup()))), nil
-	}
-
-	if req.GetNumReplica() <= 0 {
-		err := merr.WrapErrParameterInvalid("NumReplica > 0", fmt.Sprintf("invalid NumReplica %d", req.GetNumReplica()))
-		return merr.Status(err), nil
 	}
 
 	// Apply change into replica manager.


### PR DESCRIPTION
issue: #30647 

- Same dst and src resource group should not be allowed in `TransferReplica` and  `TransferNode`.

-  Remove redundant parameter check. 