### PR TITLE
enhance: Remove duplicated collectionID label for task latency

### DIFF
--- a/internal/querycoordv2/task/scheduler.go
+++ b/internal/querycoordv2/task/scheduler.go
@@ -798,7 +798,7 @@ func (scheduler *taskScheduler) remove(task Task) {
 
 	scheduler.updateTaskMetrics()
 	log.Info("task removed")
-	metrics.QueryCoordTaskLatency.WithLabelValues(scheduler.getTaskMetricsLabel(task), fmt.Sprint(task.CollectionID()), task.Shard()).Observe(float64(task.GetTaskLatency()))
+	metrics.QueryCoordTaskLatency.WithLabelValues(scheduler.getTaskMetricsLabel(task), task.Shard()).Observe(float64(task.GetTaskLatency()))
 }
 
 func (scheduler *taskScheduler) getTaskMetricsLabel(task Task) string {

--- a/pkg/metrics/querycoord_metrics.go
+++ b/pkg/metrics/querycoord_metrics.go
@@ -129,7 +129,7 @@ var (
 			Name:      "task_latency",
 			Help:      "latency of all kind of task in query coord scheduler scheduler",
 			Buckets:   longTaskBuckets,
-		}, []string{taskTypeLabel, collectionIDLabelName, channelNameLabelName})
+		}, []string{taskTypeLabel, channelNameLabelName})
 )
 
 // RegisterQueryCoord registers QueryCoord metrics


### PR DESCRIPTION
`CollectionID` already exists in channel name, so remove it to save metrics traffic.