### PR TITLE
enhance: [2.4] Use map instead of slice to maintain channel info (#32273)

### DIFF
--- a/internal/datacoord/channel_store_test.go
+++ b/internal/datacoord/channel_store_test.go
@@ -40,10 +40,7 @@ func genNodeChannelInfos(id int64, num int) *NodeChannelInfo {
 		name := fmt.Sprintf("ch%d", i)
 		channels = append(channels, &channelMeta{Name: name, CollectionID: 1, WatchInfo: &datapb.ChannelWatchInfo{}})
 	}
-	return &NodeChannelInfo{
-		NodeID:   id,
-		Channels: channels,
-	}
+	return NewNodeChannelInfo(id, channels...)
 }
 
 func genChannelOperations(from, to int64, num int) *ChannelOpSet {
@@ -85,7 +82,7 @@ func TestChannelStore_Update(t *testing.T) {
 				txnKv,
 				map[int64]*NodeChannelInfo{
 					1: genNodeChannelInfos(1, 500),
-					2: {NodeID: 2},
+					2: NewNodeChannelInfo(2),
 				},
 			},
 			args{

--- a/internal/datacoord/policy_test.go
+++ b/internal/datacoord/policy_test.go
@@ -33,8 +33,8 @@ func TestBufferChannelAssignPolicy(t *testing.T) {
 	store := &ChannelStore{
 		store: kv,
 		channelsInfo: map[int64]*NodeChannelInfo{
-			1:        {1, []RWChannel{}},
-			bufferID: {bufferID, channels},
+			1:        NewNodeChannelInfo(1),
+			bufferID: NewNodeChannelInfo(bufferID, channels...),
 		},
 	}
 
@@ -86,7 +86,7 @@ func TestAverageAssignPolicy(t *testing.T) {
 				&ChannelStore{
 					memkv.NewMemoryKV(),
 					map[int64]*NodeChannelInfo{
-						1: {1, []RWChannel{getChannel("chan1", 1)}},
+						1: NewNodeChannelInfo(1, getChannel("chan1", 1)),
 					},
 				},
 				[]RWChannel{getChannel("chan1", 1)},
@@ -99,8 +99,8 @@ func TestAverageAssignPolicy(t *testing.T) {
 				&ChannelStore{
 					memkv.NewMemoryKV(),
 					map[int64]*NodeChannelInfo{
-						1: {1, []RWChannel{getChannel("chan1", 1), getChannel("chan2", 1)}},
-						2: {2, []RWChannel{getChannel("chan3", 1)}},
+						1: NewNodeChannelInfo(1, getChannel("chan", 1), getChannel("chan2", 1)),
+						2: NewNodeChannelInfo(2, getChannel("chan3", 1)),
 					},
 				},
 				[]RWChannel{getChannel("chan4", 1)},
@@ -132,7 +132,7 @@ func TestAvgAssignUnregisteredChannels(t *testing.T) {
 				&ChannelStore{
 					memkv.NewMemoryKV(),
 					map[int64]*NodeChannelInfo{
-						1: {1, []RWChannel{getChannel("chan1", 1)}},
+						1: NewNodeChannelInfo(1, getChannel("chan1", 1)),
 					},
 				},
 				1,
@@ -148,9 +148,9 @@ func TestAvgAssignUnregisteredChannels(t *testing.T) {
 				&ChannelStore{
 					memkv.NewMemoryKV(),
 					map[int64]*NodeChannelInfo{
-						1: {1, []RWChannel{getChannel("chan1", 1)}},
-						2: {2, []RWChannel{getChannel("chan2", 1)}},
-						3: {3, []RWChannel{}},
+						1: NewNodeChannelInfo(1, getChannel("chan1", 1)),
+						2: NewNodeChannelInfo(2, getChannel("chan2", 1)),
+						3: NewNodeChannelInfo(3),
 					},
 				},
 				2,
@@ -176,53 +176,50 @@ func TestBgCheckForChannelBalance(t *testing.T) {
 	}
 
 	tests := []struct {
-		name    string
-		args    args
-		want    []*NodeChannelInfo
+		name string
+		args args
+		// want    []*NodeChannelInfo
+		want    int
 		wantErr error
 	}{
 		{
 			"test even distribution",
 			args{
 				[]*NodeChannelInfo{
-					{1, []RWChannel{getChannel("chan1", 1), getChannel("chan2", 1)}},
-					{2, []RWChannel{getChannel("chan1", 2), getChannel("chan2", 2)}},
-					{3, []RWChannel{getChannel("chan1", 3), getChannel("chan2", 3)}},
+					NewNodeChannelInfo(1, getChannel("chan1", 1), getChannel("chan2", 1)),
+					NewNodeChannelInfo(2, getChannel("chan1", 2), getChannel("chan2", 2)),
+					NewNodeChannelInfo(3, getChannel("chan1", 3), getChannel("chan2", 3)),
 				},
 				time.Now(),
 			},
 			// there should be no reallocate
-			[]*NodeChannelInfo{},
+			0,
 			nil,
 		},
 		{
 			"test uneven with conservative effect",
 			args{
 				[]*NodeChannelInfo{
-					{1, []RWChannel{getChannel("chan1", 1), getChannel("chan2", 1)}},
-					{2, []RWChannel{}},
+					NewNodeChannelInfo(1, getChannel("chan1", 1), getChannel("chan2", 1)),
+					NewNodeChannelInfo(2),
 				},
 				time.Now(),
 			},
 			// as we deem that the node having only one channel more than average as even, so there's no reallocation
 			// for this test case
-			[]*NodeChannelInfo{},
+			0,
 			nil,
 		},
 		{
 			"test uneven with zero",
 			args{
 				[]*NodeChannelInfo{
-					{1, []RWChannel{
-						getChannel("chan1", 1),
-						getChannel("chan2", 1),
-						getChannel("chan3", 1),
-					}},
-					{2, []RWChannel{}},
+					NewNodeChannelInfo(1, getChannel("chan1", 1), getChannel("chan2", 1), getChannel("chan3", 1)),
+					NewNodeChannelInfo(2),
 				},
 				time.Now(),
 			},
-			[]*NodeChannelInfo{{1, []RWChannel{getChannel("chan1", 1)}}},
+			1,
 			nil,
 		},
 	}
@@ -231,7 +228,7 @@ func TestBgCheckForChannelBalance(t *testing.T) {
 			policy := BgBalanceCheck
 			got, err := policy(tt.args.channels, tt.args.timestamp)
 			assert.Equal(t, tt.wantErr, err)
-			assert.EqualValues(t, tt.want, got)
+			assert.EqualValues(t, tt.want, len(got))
 		})
 	}
 }
@@ -252,10 +249,10 @@ func TestAvgReassignPolicy(t *testing.T) {
 				&ChannelStore{
 					memkv.NewMemoryKV(),
 					map[int64]*NodeChannelInfo{
-						1: {1, []RWChannel{getChannel("chan1", 1)}},
+						1: NewNodeChannelInfo(1, getChannel("chan1", 1)),
 					},
 				},
-				[]*NodeChannelInfo{{1, []RWChannel{getChannel("chan1", 1)}}},
+				[]*NodeChannelInfo{NewNodeChannelInfo(1, getChannel("chan1", 1))},
 			},
 			// as there's no available nodes except the input node, there's no reassign plan generated
 			NewChannelOpSet(),
@@ -266,13 +263,13 @@ func TestAvgReassignPolicy(t *testing.T) {
 				&ChannelStore{
 					memkv.NewMemoryKV(),
 					map[int64]*NodeChannelInfo{
-						1: {1, []RWChannel{getChannel("chan1", 1)}},
-						2: {2, []RWChannel{}},
-						3: {2, []RWChannel{}},
-						4: {2, []RWChannel{}},
+						1: NewNodeChannelInfo(1, getChannel("chan1", 1)),
+						2: NewNodeChannelInfo(2),
+						3: NewNodeChannelInfo(3),
+						4: NewNodeChannelInfo(4),
 					},
 				},
-				[]*NodeChannelInfo{{1, []RWChannel{getChannel("chan1", 1)}}},
+				[]*NodeChannelInfo{NewNodeChannelInfo(1, getChannel("chan1", 1))},
 			},
 			// as we use ceil to calculate the wanted average number, there should be one reassign
 			// though the average num less than 1
@@ -287,11 +284,11 @@ func TestAvgReassignPolicy(t *testing.T) {
 				&ChannelStore{
 					memkv.NewMemoryKV(),
 					map[int64]*NodeChannelInfo{
-						1: {1, []RWChannel{getChannel("chan1", 1), getChannel("chan2", 1)}},
-						2: {2, []RWChannel{}},
+						1: NewNodeChannelInfo(1, getChannel("chan1", 1), getChannel("chan2", 1)),
+						2: NewNodeChannelInfo(2),
 					},
 				},
-				[]*NodeChannelInfo{{1, []RWChannel{getChannel("chan1", 1), getChannel("chan2", 1)}}},
+				[]*NodeChannelInfo{NewNodeChannelInfo(1, getChannel("chan1", 1), getChannel("chan2", 1))},
 			},
 			NewChannelOpSet(
 				NewDeleteOp(1, getChannel("chan1", 1), getChannel("chan2", 1)),
@@ -304,22 +301,19 @@ func TestAvgReassignPolicy(t *testing.T) {
 				&ChannelStore{
 					memkv.NewMemoryKV(),
 					map[int64]*NodeChannelInfo{
-						1: {1, []RWChannel{
-							getChannel("chan1", 1),
+						1: NewNodeChannelInfo(1, getChannel("chan1", 1),
 							getChannel("chan2", 1),
 							getChannel("chan3", 1),
-							getChannel("chan4", 1),
-						}},
-						2: {2, []RWChannel{}},
-						3: {3, []RWChannel{}},
-						4: {4, []RWChannel{}},
+							getChannel("chan4", 1)),
+						2: NewNodeChannelInfo(2),
+						3: NewNodeChannelInfo(3),
+						4: NewNodeChannelInfo(4),
 					},
 				},
-				[]*NodeChannelInfo{{1, []RWChannel{
-					getChannel("chan1", 1),
+				[]*NodeChannelInfo{NewNodeChannelInfo(1, getChannel("chan1", 1),
 					getChannel("chan2", 1),
 					getChannel("chan3", 1),
-				}}},
+					getChannel("chan4", 1))},
 			},
 			NewChannelOpSet(
 				NewDeleteOp(1, []RWChannel{
@@ -338,7 +332,7 @@ func TestAvgReassignPolicy(t *testing.T) {
 				&ChannelStore{
 					memkv.NewMemoryKV(),
 					map[int64]*NodeChannelInfo{
-						1: {1, []RWChannel{
+						1: NewNodeChannelInfo(1,
 							getChannel("chan1", 1),
 							getChannel("chan2", 1),
 							getChannel("chan3", 1),
@@ -350,17 +344,15 @@ func TestAvgReassignPolicy(t *testing.T) {
 							getChannel("chan9", 1),
 							getChannel("chan10", 1),
 							getChannel("chan11", 1),
-							getChannel("chan12", 1),
-						}},
-						2: {2, []RWChannel{
+							getChannel("chan12", 1)),
+						2: NewNodeChannelInfo(2,
 							getChannel("chan13", 1),
-							getChannel("chan14", 1),
-						}},
-						3: {3, []RWChannel{getChannel("chan15", 1)}},
-						4: {4, []RWChannel{}},
+							getChannel("chan14", 1)),
+						3: NewNodeChannelInfo(3, getChannel("chan15", 1)),
+						4: NewNodeChannelInfo(4),
 					},
 				},
-				[]*NodeChannelInfo{{1, []RWChannel{
+				[]*NodeChannelInfo{NewNodeChannelInfo(1,
 					getChannel("chan1", 1),
 					getChannel("chan2", 1),
 					getChannel("chan3", 1),
@@ -372,8 +364,7 @@ func TestAvgReassignPolicy(t *testing.T) {
 					getChannel("chan9", 1),
 					getChannel("chan10", 1),
 					getChannel("chan11", 1),
-					getChannel("chan12", 1),
-				}}},
+					getChannel("chan12", 1))},
 			},
 			NewChannelOpSet(
 				NewDeleteOp(1, []RWChannel{
@@ -430,7 +421,7 @@ func TestAvgBalanceChannelPolicy(t *testing.T) {
 	tests := []struct {
 		name string
 		args args
-		want *ChannelOpSet
+		want int
 	}{
 		{
 			"test_only_one_node",
@@ -438,26 +429,24 @@ func TestAvgBalanceChannelPolicy(t *testing.T) {
 				&ChannelStore{
 					memkv.NewMemoryKV(),
 					map[int64]*NodeChannelInfo{
-						1: {
-							1, []RWChannel{
-								getChannel("chan1", 1),
-								getChannel("chan2", 1),
-								getChannel("chan3", 1),
-								getChannel("chan4", 1),
-							},
-						},
-						2: {2, []RWChannel{}},
+						1: NewNodeChannelInfo(1,
+							getChannel("chan1", 1),
+							getChannel("chan2", 1),
+							getChannel("chan3", 1),
+							getChannel("chan4", 1),
+						),
+						2: NewNodeChannelInfo(2),
 					},
 				},
 			},
-			NewChannelOpSet(NewAddOp(1, getChannel("chan1", 1))),
+			1,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := AvgBalanceChannelPolicy(tt.args.store, time.Now())
-			assert.EqualValues(t, tt.want.Collect(), got.Collect())
+			assert.EqualValues(t, tt.want, len(got.Collect()))
 		})
 	}
 }
@@ -468,10 +457,13 @@ func TestAvgAssignRegisterPolicy(t *testing.T) {
 		nodeID int64
 	}
 	tests := []struct {
-		name            string
-		args            args
-		bufferedUpdates *ChannelOpSet
-		balanceUpdates  *ChannelOpSet
+		name               string
+		args               args
+		bufferedUpdates    *ChannelOpSet
+		balanceUpdates     *ChannelOpSet
+		exact              bool
+		bufferedUpdatesNum int
+		balanceUpdatesNum  int
 	}{
 		{
 			"test empty",
@@ -479,13 +471,16 @@ func TestAvgAssignRegisterPolicy(t *testing.T) {
 				&ChannelStore{
 					memkv.NewMemoryKV(),
 					map[int64]*NodeChannelInfo{
-						1: {NodeID: 1, Channels: make([]RWChannel, 0)},
+						1: NewNodeChannelInfo(1),
 					},
 				},
 				1,
 			},
 			NewChannelOpSet(),
 			NewChannelOpSet(),
+			true,
+			0,
+			0,
 		},
 		{
 			"test with buffer channel",
@@ -493,8 +488,8 @@ func TestAvgAssignRegisterPolicy(t *testing.T) {
 				&ChannelStore{
 					memkv.NewMemoryKV(),
 					map[int64]*NodeChannelInfo{
-						bufferID: {bufferID, []RWChannel{getChannel("ch1", 1)}},
-						1:        {NodeID: 1, Channels: []RWChannel{}},
+						bufferID: NewNodeChannelInfo(bufferID, getChannel("ch1", 1)),
+						1:        NewNodeChannelInfo(1),
 					},
 				},
 				1,
@@ -504,6 +499,9 @@ func TestAvgAssignRegisterPolicy(t *testing.T) {
 				NewAddOp(1, getChannel("ch1", 1)),
 			),
 			NewChannelOpSet(),
+			true,
+			0,
+			0,
 		},
 		{
 			"test with avg assign",
@@ -511,14 +509,17 @@ func TestAvgAssignRegisterPolicy(t *testing.T) {
 				&ChannelStore{
 					memkv.NewMemoryKV(),
 					map[int64]*NodeChannelInfo{
-						1: {1, []RWChannel{getChannel("ch1", 1), getChannel("ch2", 1)}},
-						3: {3, []RWChannel{}},
+						1: NewNodeChannelInfo(1, getChannel("ch1", 1), getChannel("ch2", 1)),
+						3: NewNodeChannelInfo(3),
 					},
 				},
 				3,
 			},
 			NewChannelOpSet(),
 			NewChannelOpSet(NewAddOp(1, getChannel("ch1", 1))),
+			false,
+			0,
+			1,
 		},
 		{
 			"test with avg equals to zero",
@@ -526,38 +527,49 @@ func TestAvgAssignRegisterPolicy(t *testing.T) {
 				&ChannelStore{
 					memkv.NewMemoryKV(),
 					map[int64]*NodeChannelInfo{
-						1: {1, []RWChannel{getChannel("ch1", 1)}},
-						2: {2, []RWChannel{getChannel("ch3", 1)}},
-						3: {3, []RWChannel{}},
+						1: NewNodeChannelInfo(1, getChannel("ch1", 1)),
+						2: NewNodeChannelInfo(2, getChannel("ch3", 1)),
+						3: NewNodeChannelInfo(3),
 					},
 				},
 				3,
 			},
 			NewChannelOpSet(),
 			NewChannelOpSet(),
+			true,
+			0,
+			0,
 		},
 		{
-			"test node with empty channel",
+			"test_node_with_empty_channel",
 			args{
 				&ChannelStore{
 					memkv.NewMemoryKV(),
 					map[int64]*NodeChannelInfo{
-						1: {1, []RWChannel{getChannel("ch1", 1), getChannel("ch2", 1), getChannel("ch3", 1)}},
-						2: {2, []RWChannel{}},
-						3: {3, []RWChannel{}},
+						1: NewNodeChannelInfo(1, getChannel("ch1", 1), getChannel("ch2", 1), getChannel("ch3", 1)),
+						2: NewNodeChannelInfo(2),
+						3: NewNodeChannelInfo(3),
 					},
 				},
 				3,
 			},
 			NewChannelOpSet(),
 			NewChannelOpSet(NewAddOp(1, getChannel("ch1", 1))),
+			false,
+			0,
+			1,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			bufferedUpdates, balanceUpdates := AvgAssignRegisterPolicy(tt.args.store, tt.args.nodeID)
-			assert.EqualValues(t, tt.bufferedUpdates.Collect(), bufferedUpdates.Collect())
-			assert.EqualValues(t, tt.balanceUpdates.Collect(), balanceUpdates.Collect())
+			if tt.exact {
+				assert.EqualValues(t, tt.bufferedUpdates.Collect(), bufferedUpdates.Collect())
+				assert.EqualValues(t, tt.balanceUpdates.Collect(), balanceUpdates.Collect())
+			} else {
+				assert.Equal(t, tt.bufferedUpdatesNum, len(bufferedUpdates.Collect()))
+				assert.Equal(t, tt.balanceUpdatesNum, len(balanceUpdates.Collect()))
+			}
 		})
 	}
 }


### PR DESCRIPTION
Cherry-pick from master
pr: #32273
See also #32165

`ChannelManager.Match` is a frequent operation for datacoord. When the collection number is large, iteration over all channels will cost lots of CPU time and time consuming.

This PR change the data structure storing datanode-channel info to map avoiding this iteration when checking channel existence.

---------