### PR TITLE
fix: [restful]use default search parameter `nq: 0`

### DIFF
--- a/internal/distributed/proxy/httpserver/constant.go
+++ b/internal/distributed/proxy/httpserver/constant.go
@@ -81,6 +81,7 @@ const (
 	DefaultAliasName         = "the_alias"
 	DefaultOutputFields      = "*"
 	HTTPHeaderAllowInt64     = "Accept-Type-Allow-Int64"
+	HTTPHeaderDBName         = "DB-Name"
 	HTTPHeaderRequestTimeout = "Request-Timeout"
 	HTTPDefaultTimeout       = 30 * time.Second
 	HTTPReturnCode           = "code"

--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -885,7 +885,6 @@ func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbN
 		PartitionNames:     httpReq.PartitionNames,
 		SearchParams:       searchParams,
 		GuaranteeTimestamp: BoundedTimestamp,
-		Nq:                 int64(1),
 	}
 	resp, err := wrapperProxy(ctx, c, req, h.checkAuth, false, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.Search(reqCtx, req.(*milvuspb.SearchRequest))
@@ -954,7 +953,6 @@ func (h *HandlersV2) advancedSearch(ctx context.Context, c *gin.Context, anyReq 
 			PartitionNames:     httpReq.PartitionNames,
 			SearchParams:       searchParams,
 			GuaranteeTimestamp: BoundedTimestamp,
-			Nq:                 int64(1),
 		}
 		req.Requests = append(req.Requests, searchReq)
 	}

--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -175,7 +175,10 @@ func wrapperPost(newReq newReqFunc, v2 handlerFuncV2) gin.HandlerFunc {
 			dbName = getter.GetDbName()
 		}
 		if dbName == "" {
-			dbName = DefaultDbName
+			dbName = c.Request.Header.Get(HTTPHeaderDBName)
+			if dbName == "" {
+				dbName = DefaultDbName
+			}
 		}
 		username, _ := c.Get(ContextUsername)
 		ctx, span := otel.Tracer(typeutil.ProxyRole).Start(context.Background(), c.Request.URL.Path)

--- a/internal/distributed/proxy/httpserver/request_v2.go
+++ b/internal/distributed/proxy/httpserver/request_v2.go
@@ -329,6 +329,8 @@ type AliasReq struct {
 	AliasName string `json:"aliasName" binding:"required"`
 }
 
+func (req *AliasReq) GetDbName() string { return req.DbName }
+
 func (req *AliasReq) GetAliasName() string {
 	return req.AliasName
 }


### PR DESCRIPTION
issue: #32225 #31978 #32360

1. v1 can only accept one vector, but v2 accept list of vectors #32225
2. cannot get dbName from AliasReq #31978
3. enhance: [restful v2]support config DB-Name in the http header #32360