### PR TITLE
enhance: Make l0 segment mem size count timestamp size

### DIFF
--- a/internal/querynodev2/segments/segment_l0.go
+++ b/internal/querynodev2/segments/segment_l0.go
@@ -87,7 +87,7 @@ func (s *L0Segment) MemSize() int64 {
 	defer s.dataGuard.RUnlock()
 	return lo.SumBy(s.pks, func(pk storage.PrimaryKey) int64 {
 		return pk.Size() + 8
-	})
+	}) + int64(len(s.tss))*8
 }
 
 func (s *L0Segment) LastDeltaTimestamp() uint64 {


### PR DESCRIPTION
Related to #27349

The memory usage was not accurate for l0 segment since the timestamp memory was not counted