### PR TITLE
fix: disk cache related fixup patch

### DIFF
--- a/internal/querynodev2/delegator/mock_delegator.go
+++ b/internal/querynodev2/delegator/mock_delegator.go
@@ -28,6 +28,39 @@ func (_m *MockShardDelegator) EXPECT() *MockShardDelegator_Expecter {
 	return &MockShardDelegator_Expecter{mock: &_m.Mock}
 }
 
+// AddExcludedSegments provides a mock function with given fields: excludeInfo
+func (_m *MockShardDelegator) AddExcludedSegments(excludeInfo map[int64]uint64) {
+	_m.Called(excludeInfo)
+}
+
+// MockShardDelegator_AddExcludedSegments_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddExcludedSegments'
+type MockShardDelegator_AddExcludedSegments_Call struct {
+	*mock.Call
+}
+
+// AddExcludedSegments is a helper method to define mock.On call
+//   - excludeInfo map[int64]uint64
+func (_e *MockShardDelegator_Expecter) AddExcludedSegments(excludeInfo interface{}) *MockShardDelegator_AddExcludedSegments_Call {
+	return &MockShardDelegator_AddExcludedSegments_Call{Call: _e.mock.On("AddExcludedSegments", excludeInfo)}
+}
+
+func (_c *MockShardDelegator_AddExcludedSegments_Call) Run(run func(excludeInfo map[int64]uint64)) *MockShardDelegator_AddExcludedSegments_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(map[int64]uint64))
+	})
+	return _c
+}
+
+func (_c *MockShardDelegator_AddExcludedSegments_Call) Return() *MockShardDelegator_AddExcludedSegments_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockShardDelegator_AddExcludedSegments_Call) RunAndReturn(run func(map[int64]uint64)) *MockShardDelegator_AddExcludedSegments_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Close provides a mock function with given fields:
 func (_m *MockShardDelegator) Close() {
 	_m.Called()
@@ -249,39 +282,6 @@ func (_c *MockShardDelegator_GetTargetVersion_Call) Return(_a0 int64) *MockShard
 }
 
 func (_c *MockShardDelegator_GetTargetVersion_Call) RunAndReturn(run func() int64) *MockShardDelegator_GetTargetVersion_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// AddExcludedSegments provides a mock function with given fields: excludeInfo
-func (_m *MockShardDelegator) AddExcludedSegments(excludeInfo map[int64]uint64) {
-	_m.Called(excludeInfo)
-}
-
-// MockShardDelegator_AddExcludedSegments_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddExcludedSegments'
-type MockShardDelegator_AddExcludedSegments_Call struct {
-	*mock.Call
-}
-
-// AddExcludedSegments is a helper method to define mock.On call
-//   - excludeInfo map[int64]uint64
-func (_e *MockShardDelegator_Expecter) AddExcludedSegments(excludeInfo interface{}) *MockShardDelegator_AddExcludedSegments_Call {
-	return &MockShardDelegator_AddExcludedSegments_Call{Call: _e.mock.On("AddExcludedSegments", excludeInfo)}
-}
-
-func (_c *MockShardDelegator_AddExcludedSegments_Call) Run(run func(excludeInfo map[int64]uint64)) *MockShardDelegator_AddExcludedSegments_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(map[int64]uint64))
-	})
-	return _c
-}
-
-func (_c *MockShardDelegator_AddExcludedSegments_Call) Return() *MockShardDelegator_AddExcludedSegments_Call {
-	_c.Call.Return()
-	return _c
-}
-
-func (_c *MockShardDelegator_AddExcludedSegments_Call) RunAndReturn(run func(map[int64]uint64)) *MockShardDelegator_AddExcludedSegments_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/querynodev2/segments/mock_loader.go
+++ b/internal/querynodev2/segments/mock_loader.go
@@ -261,13 +261,13 @@ func (_c *MockLoader_LoadIndex_Call) RunAndReturn(run func(context.Context, *Loc
 	return _c
 }
 
-// LoadSegment provides a mock function with given fields: ctx, segment, loadInfo, loadStatus
-func (_m *MockLoader) LoadSegment(ctx context.Context, segment *LocalSegment, loadInfo *querypb.SegmentLoadInfo, loadStatus LoadStatus) error {
-	ret := _m.Called(ctx, segment, loadInfo, loadStatus)
+// LoadSegment provides a mock function with given fields: ctx, segment, loadInfo
+func (_m *MockLoader) LoadSegment(ctx context.Context, segment *LocalSegment, loadInfo *querypb.SegmentLoadInfo) error {
+	ret := _m.Called(ctx, segment, loadInfo)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, *LocalSegment, *querypb.SegmentLoadInfo, LoadStatus) error); ok {
-		r0 = rf(ctx, segment, loadInfo, loadStatus)
+	if rf, ok := ret.Get(0).(func(context.Context, *LocalSegment, *querypb.SegmentLoadInfo) error); ok {
+		r0 = rf(ctx, segment, loadInfo)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -284,14 +284,13 @@ type MockLoader_LoadSegment_Call struct {
 //   - ctx context.Context
 //   - segment *LocalSegment
 //   - loadInfo *querypb.SegmentLoadInfo
-//   - loadStatus LoadStatus
-func (_e *MockLoader_Expecter) LoadSegment(ctx interface{}, segment interface{}, loadInfo interface{}, loadStatus interface{}) *MockLoader_LoadSegment_Call {
-	return &MockLoader_LoadSegment_Call{Call: _e.mock.On("LoadSegment", ctx, segment, loadInfo, loadStatus)}
+func (_e *MockLoader_Expecter) LoadSegment(ctx interface{}, segment interface{}, loadInfo interface{}) *MockLoader_LoadSegment_Call {
+	return &MockLoader_LoadSegment_Call{Call: _e.mock.On("LoadSegment", ctx, segment, loadInfo)}
 }
 
-func (_c *MockLoader_LoadSegment_Call) Run(run func(ctx context.Context, segment *LocalSegment, loadInfo *querypb.SegmentLoadInfo, loadStatus LoadStatus)) *MockLoader_LoadSegment_Call {
+func (_c *MockLoader_LoadSegment_Call) Run(run func(ctx context.Context, segment *LocalSegment, loadInfo *querypb.SegmentLoadInfo)) *MockLoader_LoadSegment_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*LocalSegment), args[2].(*querypb.SegmentLoadInfo), args[3].(LoadStatus))
+		run(args[0].(context.Context), args[1].(*LocalSegment), args[2].(*querypb.SegmentLoadInfo))
 	})
 	return _c
 }
@@ -301,7 +300,7 @@ func (_c *MockLoader_LoadSegment_Call) Return(_a0 error) *MockLoader_LoadSegment
 	return _c
 }
 
-func (_c *MockLoader_LoadSegment_Call) RunAndReturn(run func(context.Context, *LocalSegment, *querypb.SegmentLoadInfo, LoadStatus) error) *MockLoader_LoadSegment_Call {
+func (_c *MockLoader_LoadSegment_Call) RunAndReturn(run func(context.Context, *LocalSegment, *querypb.SegmentLoadInfo) error) *MockLoader_LoadSegment_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/querynodev2/segments/mock_segment.go
+++ b/internal/querynodev2/segments/mock_segment.go
@@ -847,61 +847,29 @@ func (_m *MockSegment) PinIfNotReleased() error {
 	return r0
 }
 
-// MockSegment_RLock_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RLock'
-type MockSegment_RLock_Call struct {
+// MockSegment_PinIfNotReleased_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PinIfNotReleased'
+type MockSegment_PinIfNotReleased_Call struct {
 	*mock.Call
 }
 
-// RLock is a helper method to define mock.On call
-func (_e *MockSegment_Expecter) RLock() *MockSegment_RLock_Call {
-	return &MockSegment_RLock_Call{Call: _e.mock.On("RLock")}
+// PinIfNotReleased is a helper method to define mock.On call
+func (_e *MockSegment_Expecter) PinIfNotReleased() *MockSegment_PinIfNotReleased_Call {
+	return &MockSegment_PinIfNotReleased_Call{Call: _e.mock.On("PinIfNotReleased")}
 }
 
-func (_c *MockSegment_RLock_Call) Run(run func()) *MockSegment_RLock_Call {
+func (_c *MockSegment_PinIfNotReleased_Call) Run(run func()) *MockSegment_PinIfNotReleased_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run()
 	})
 	return _c
 }
 
-func (_c *MockSegment_RLock_Call) Return(_a0 error) *MockSegment_RLock_Call {
+func (_c *MockSegment_PinIfNotReleased_Call) Return(_a0 error) *MockSegment_PinIfNotReleased_Call {
 	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *MockSegment_RLock_Call) RunAndReturn(run func() error) *MockSegment_RLock_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// Unpin provides a mock function with given fields:
-func (_m *MockSegment) Unpin() {
-	_m.Called()
-}
-
-// MockSegment_RUnlock_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RUnlock'
-type MockSegment_RUnlock_Call struct {
-	*mock.Call
-}
-
-// RUnlock is a helper method to define mock.On call
-func (_e *MockSegment_Expecter) RUnlock() *MockSegment_RUnlock_Call {
-	return &MockSegment_RUnlock_Call{Call: _e.mock.On("RUnlock")}
-}
-
-func (_c *MockSegment_RUnlock_Call) Run(run func()) *MockSegment_RUnlock_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *MockSegment_RUnlock_Call) Return() *MockSegment_RUnlock_Call {
-	_c.Call.Return()
-	return _c
-}
-
-func (_c *MockSegment_RUnlock_Call) RunAndReturn(run func()) *MockSegment_RUnlock_Call {
+func (_c *MockSegment_PinIfNotReleased_Call) RunAndReturn(run func() error) *MockSegment_PinIfNotReleased_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -948,39 +916,6 @@ func (_c *MockSegment_Release_Call) Return() *MockSegment_Release_Call {
 }
 
 func (_c *MockSegment_Release_Call) RunAndReturn(run func(...releaseOption)) *MockSegment_Release_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// ResetIndexesLazyLoad provides a mock function with given fields: lazyState
-func (_m *MockSegment) ResetIndexesLazyLoad(lazyState bool) {
-	_m.Called(lazyState)
-}
-
-// MockSegment_ResetIndexesLazyLoad_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ResetIndexesLazyLoad'
-type MockSegment_ResetIndexesLazyLoad_Call struct {
-	*mock.Call
-}
-
-// ResetIndexesLazyLoad is a helper method to define mock.On call
-//   - lazyState bool
-func (_e *MockSegment_Expecter) ResetIndexesLazyLoad(lazyState interface{}) *MockSegment_ResetIndexesLazyLoad_Call {
-	return &MockSegment_ResetIndexesLazyLoad_Call{Call: _e.mock.On("ResetIndexesLazyLoad", lazyState)}
-}
-
-func (_c *MockSegment_ResetIndexesLazyLoad_Call) Run(run func(lazyState bool)) *MockSegment_ResetIndexesLazyLoad_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(bool))
-	})
-	return _c
-}
-
-func (_c *MockSegment_ResetIndexesLazyLoad_Call) Return() *MockSegment_ResetIndexesLazyLoad_Call {
-	_c.Call.Return()
-	return _c
-}
-
-func (_c *MockSegment_ResetIndexesLazyLoad_Call) RunAndReturn(run func(bool)) *MockSegment_ResetIndexesLazyLoad_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1339,6 +1274,38 @@ func (_c *MockSegment_Type_Call) Return(_a0 commonpb.SegmentState) *MockSegment_
 }
 
 func (_c *MockSegment_Type_Call) RunAndReturn(run func() commonpb.SegmentState) *MockSegment_Type_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// Unpin provides a mock function with given fields:
+func (_m *MockSegment) Unpin() {
+	_m.Called()
+}
+
+// MockSegment_Unpin_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Unpin'
+type MockSegment_Unpin_Call struct {
+	*mock.Call
+}
+
+// Unpin is a helper method to define mock.On call
+func (_e *MockSegment_Expecter) Unpin() *MockSegment_Unpin_Call {
+	return &MockSegment_Unpin_Call{Call: _e.mock.On("Unpin")}
+}
+
+func (_c *MockSegment_Unpin_Call) Run(run func()) *MockSegment_Unpin_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockSegment_Unpin_Call) Return() *MockSegment_Unpin_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockSegment_Unpin_Call) RunAndReturn(run func()) *MockSegment_Unpin_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/querynodev2/segments/mock_segment.go
+++ b/internal/querynodev2/segments/mock_segment.go
@@ -709,47 +709,6 @@ func (_c *MockSegment_LoadInfo_Call) RunAndReturn(run func() *querypb.SegmentLoa
 	return _c
 }
 
-// LoadStatus provides a mock function with given fields:
-func (_m *MockSegment) LoadStatus() LoadStatus {
-	ret := _m.Called()
-
-	var r0 LoadStatus
-	if rf, ok := ret.Get(0).(func() LoadStatus); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(LoadStatus)
-	}
-
-	return r0
-}
-
-// MockSegment_LoadStatus_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'LoadStatus'
-type MockSegment_LoadStatus_Call struct {
-	*mock.Call
-}
-
-// LoadStatus is a helper method to define mock.On call
-func (_e *MockSegment_Expecter) LoadStatus() *MockSegment_LoadStatus_Call {
-	return &MockSegment_LoadStatus_Call{Call: _e.mock.On("LoadStatus")}
-}
-
-func (_c *MockSegment_LoadStatus_Call) Run(run func()) *MockSegment_LoadStatus_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *MockSegment_LoadStatus_Call) Return(_a0 LoadStatus) *MockSegment_LoadStatus_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockSegment_LoadStatus_Call) RunAndReturn(run func() LoadStatus) *MockSegment_LoadStatus_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // MayPkExist provides a mock function with given fields: pk
 func (_m *MockSegment) MayPkExist(pk storage.PrimaryKey) bool {
 	ret := _m.Called(pk)

--- a/internal/querynodev2/segments/reduce_test.go
+++ b/internal/querynodev2/segments/reduce_test.go
@@ -83,6 +83,7 @@ func (suite *ReduceSuite) SetupTest() {
 			CollectionID:  suite.collectionID,
 			PartitionID:   suite.partitionID,
 			InsertChannel: "dml",
+			NumOfRows:     int64(msgLength),
 			Level:         datapb.SegmentLevel_Legacy,
 		},
 	)

--- a/internal/querynodev2/segments/retrieve_test.go
+++ b/internal/querynodev2/segments/retrieve_test.go
@@ -92,6 +92,7 @@ func (suite *RetrieveSuite) SetupTest() {
 			CollectionID:  suite.collectionID,
 			PartitionID:   suite.partitionID,
 			InsertChannel: "dml",
+			NumOfRows:     int64(msgLength),
 			Level:         datapb.SegmentLevel_Legacy,
 		},
 	)

--- a/internal/querynodev2/segments/search_test.go
+++ b/internal/querynodev2/segments/search_test.go
@@ -83,6 +83,7 @@ func (suite *SearchSuite) SetupTest() {
 			CollectionID:  suite.collectionID,
 			PartitionID:   suite.partitionID,
 			InsertChannel: "dml",
+			NumOfRows:     int64(msgLength),
 			Level:         datapb.SegmentLevel_Legacy,
 		},
 	)

--- a/internal/querynodev2/segments/segment_interface.go
+++ b/internal/querynodev2/segments/segment_interface.go
@@ -88,5 +88,4 @@ type Segment interface {
 	Search(ctx context.Context, searchReq *SearchRequest) (*SearchResult, error)
 	Retrieve(ctx context.Context, plan *RetrievePlan) (*segcorepb.RetrieveResults, error)
 	IsLazyLoad() bool
-	ResetIndexesLazyLoad(lazyState bool)
 }

--- a/internal/querynodev2/segments/segment_interface.go
+++ b/internal/querynodev2/segments/segment_interface.go
@@ -27,14 +27,6 @@ import (
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
 
-type LoadStatus string
-
-const (
-	LoadStatusMeta     LoadStatus = "meta"
-	LoadStatusMapped   LoadStatus = "mapped"
-	LoadStatusInMemory LoadStatus = "in_memory"
-)
-
 // ResourceUsage is used to estimate the resource usage of a sealed segment.
 type ResourceUsage struct {
 	MemorySize     uint64
@@ -60,7 +52,6 @@ type Segment interface {
 	StartPosition() *msgpb.MsgPosition
 	Type() SegmentType
 	Level() datapb.SegmentLevel
-	LoadStatus() LoadStatus
 	LoadInfo() *querypb.SegmentLoadInfo
 	// PinIfNotReleased the segment to prevent it from being released
 	PinIfNotReleased() error

--- a/internal/querynodev2/segments/segment_l0.go
+++ b/internal/querynodev2/segments/segment_l0.go
@@ -115,9 +115,6 @@ func (s *L0Segment) Indexes() []*IndexedFieldInfo {
 	return nil
 }
 
-func (s *L0Segment) ResetIndexesLazyLoad(lazyState bool) {
-}
-
 func (s *L0Segment) Type() SegmentType {
 	return s.segmentType
 }

--- a/internal/querynodev2/segments/segment_l0.go
+++ b/internal/querynodev2/segments/segment_l0.go
@@ -63,8 +63,6 @@ func NewL0Segment(collection *Collection,
 	}
 
 	// level 0 segments are always in memory
-	segment.loadStatus.Store(string(LoadStatusInMemory))
-
 	return segment, nil
 }
 

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -973,6 +973,24 @@ func separateIndexAndBinlog(loadInfo *querypb.SegmentLoadInfo) (map[int64]*Index
 }
 
 func (loader *segmentLoader) loadSealedSegment(ctx context.Context, loadInfo *querypb.SegmentLoadInfo, segment *LocalSegment) error {
+	// TODO: we should create a transaction-like api to load segment for segment interface,
+	// but not do many things in segment loader.
+	stateLockGuard, err := segment.StartLoadData()
+	// segment can not do load now.
+	if err != nil {
+		return err
+	}
+	if stateLockGuard == nil {
+		return nil
+	}
+	defer func() {
+		if err != nil {
+			// Release partial loaded segment data if load failed.
+			segment.ReleaseSegmentData()
+		}
+		stateLockGuard.Done(err)
+	}()
+
 	collection := segment.GetCollection()
 
 	indexedFieldInfos, fieldBinlogs := separateIndexAndBinlog(loadInfo)
@@ -1023,24 +1041,6 @@ func (loader *segmentLoader) LoadSegment(ctx context.Context,
 	segment *LocalSegment,
 	loadInfo *querypb.SegmentLoadInfo,
 ) (err error) {
-	// TODO: we should create a transaction-like api to load segment for segment interface,
-	// but not do many things in segment loader.
-	stateLockGuard, err := segment.StartLoadData()
-	// segment can not do load now.
-	if err != nil {
-		return err
-	}
-	if stateLockGuard == nil {
-		return nil
-	}
-	defer func() {
-		if err != nil {
-			// Release partial loaded segment data if load failed.
-			segment.ReleaseSegmentData()
-		}
-		stateLockGuard.Done(err)
-	}()
-
 	log := log.Ctx(ctx).With(
 		zap.Int64("collectionID", segment.Collection()),
 		zap.Int64("partitionID", segment.Partition()),

--- a/internal/querynodev2/segments/segment_loader_test.go
+++ b/internal/querynodev2/segments/segment_loader_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/apache/arrow/go/v12/arrow/memory"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/atomic"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
@@ -459,7 +460,6 @@ func (suite *SegmentLoaderSuite) TestLoadDupDeltaLogs() {
 
 func (suite *SegmentLoaderSuite) TestLoadIndex() {
 	ctx := context.Background()
-	segment := &LocalSegment{}
 	loadInfo := &querypb.SegmentLoadInfo{
 		SegmentID:    1,
 		PartitionID:  suite.partitionID,
@@ -468,6 +468,11 @@ func (suite *SegmentLoaderSuite) TestLoadIndex() {
 			{
 				IndexFilePaths: []string{},
 			},
+		},
+	}
+	segment := &LocalSegment{
+		baseSegment: baseSegment{
+			loadInfo: atomic.NewPointer[querypb.SegmentLoadInfo](loadInfo),
 		},
 	}
 

--- a/internal/querynodev2/segments/segment_test.go
+++ b/internal/querynodev2/segments/segment_test.go
@@ -140,7 +140,7 @@ func (suite *SegmentSuite) TestLoadInfo() {
 	// sealed segment has load info
 	suite.NotNil(suite.sealed.LoadInfo())
 	// growing segment has no load info
-	suite.Nil(suite.growing.LoadInfo())
+	suite.NotNil(suite.growing.LoadInfo())
 }
 
 func (suite *SegmentSuite) TestResourceUsageEstimate() {

--- a/internal/querynodev2/segments/segment_test.go
+++ b/internal/querynodev2/segments/segment_test.go
@@ -71,6 +71,7 @@ func (suite *SegmentSuite) SetupTest() {
 			PartitionID:   suite.partitionID,
 			InsertChannel: "dml",
 			Level:         datapb.SegmentLevel_Legacy,
+			NumOfRows:     int64(msgLength),
 			BinlogPaths: []*datapb.FieldBinlog{
 				{
 					FieldID: 101,


### PR DESCRIPTION
issue: #30361 

- Fix dead lock of LRU Cache.

- `LoadSegment` interface is used to load segment into queryable status, remove `LoadStatus`. 

- Skip `LoadSegment` when first loading if segment is a lazy load segment.

- Fix inconsistent between state lock and load state to LoadSegment.

- Init `fieldIndexes`, `fields` when create segment.

- Fix wrong metric when interacting with disk cache.

- Call `ClearData` when load segment fails to keep `LoadSegment` idempotent.

related dev pr: #32370, #32350, #32171, #32438, #32436, #32460, #32499