### PR TITLE
enhance: ban changed-files action, always on ASAN for now

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,7 +18,7 @@ on:
       - go.mod
       - '!**.md'
       - '!build/ci/jenkins/**'
-  pull_request_target:
+  pull_request:
     # file paths to consider in the event. Optional; defaults to all.
     paths:
       - 'scripts/**'


### PR DESCRIPTION
after using pull_request_target, the action tj-actions/changed-files behave abnormal. 

below is the error from it:
Unable to locate the previous commit in the local history for pull_request_target event. Falling back to the previous commit in the local history.