### PR TITLE
enhance: [2.4] Manual release pool after save targets (#32358)

### DIFF
--- a/internal/querycoordv2/meta/target_manager.go
+++ b/internal/querycoordv2/meta/target_manager.go
@@ -599,6 +599,7 @@ func (mgr *TargetManager) SaveCurrentTarget(catalog metastore.QueryCoordCatalog)
 	if mgr.current != nil {
 		// use pool here to control maximal writer used by save target
 		pool := conc.NewPool[any](runtime.GOMAXPROCS(0) * 2)
+		defer pool.Release()
 		// use batch write in case of the number of collections is large
 		batchSize := 16
 		var wg sync.WaitGroup


### PR DESCRIPTION
Cherry-pick from master
pr: #32358 
See also #31632

Release conc.Pool after usage to clean worker and stop background purge and ticktock.