### PR TITLE
fix: Remove metrics after flowgraph closed

### DIFF
--- a/internal/datanode/data_sync_service.go
+++ b/internal/datanode/data_sync_service.go
@@ -40,6 +40,8 @@ import (
 	"github.com/milvus-io/milvus/pkg/mq/msgdispatcher"
 	"github.com/milvus-io/milvus/pkg/mq/msgstream"
 	"github.com/milvus-io/milvus/pkg/util/conc"
+	"github.com/milvus-io/milvus/pkg/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
 
@@ -102,6 +104,10 @@ func (dsService *dataSyncService) GracefullyClose() {
 		log.Info("dataSyncService gracefully closing flowgraph")
 		dsService.fg.SetCloseMethod(flowgraph.CloseGracefully)
 		dsService.close()
+
+		// clean up metrics
+		pChan := funcutil.ToPhysicalChannel(dsService.vchannelName)
+		metrics.CleanupDataNodeCollectionMetrics(paramtable.GetNodeID(), dsService.collectionID, pChan)
 	}
 }
 

--- a/internal/datanode/data_sync_service.go
+++ b/internal/datanode/data_sync_service.go
@@ -104,10 +104,6 @@ func (dsService *dataSyncService) GracefullyClose() {
 		log.Info("dataSyncService gracefully closing flowgraph")
 		dsService.fg.SetCloseMethod(flowgraph.CloseGracefully)
 		dsService.close()
-
-		// clean up metrics
-		pChan := funcutil.ToPhysicalChannel(dsService.vchannelName)
-		metrics.CleanupDataNodeCollectionMetrics(paramtable.GetNodeID(), dsService.collectionID, pChan)
 	}
 }
 
@@ -125,6 +121,10 @@ func (dsService *dataSyncService) close() {
 		}
 
 		dsService.cancelFn()
+
+		// clean up metrics
+		pChan := funcutil.ToPhysicalChannel(dsService.vchannelName)
+		metrics.CleanupDataNodeCollectionMetrics(paramtable.GetNodeID(), dsService.collectionID, pChan)
 
 		log.Info("dataSyncService closed")
 	})

--- a/internal/datanode/flow_graph_dd_node.go
+++ b/internal/datanode/flow_graph_dd_node.go
@@ -33,7 +33,6 @@ import (
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/metrics"
 	"github.com/milvus-io/milvus/pkg/mq/msgstream"
-	"github.com/milvus-io/milvus/pkg/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/util/metricsinfo"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 )
@@ -156,9 +155,6 @@ func (ddn *ddNode) Operate(in []Msg) []Msg {
 				log.Info("Stop compaction of vChannel", zap.String("vChannelName", ddn.vChannelName))
 				ddn.compactionExecutor.discardByDroppedChannel(ddn.vChannelName)
 				fgMsg.dropCollection = true
-
-				pChan := funcutil.ToPhysicalChannel(ddn.vChannelName)
-				metrics.CleanupDataNodeCollectionMetrics(paramtable.GetNodeID(), ddn.collectionID, pChan)
 			}
 
 		case commonpb.MsgType_DropPartition:


### PR DESCRIPTION
See also #32403

`fg_buffer_size` was decreased after metrics removed in flowgraph ddnode, which make metrics value negative.

This PR move remove metrics logic into `dataSyncService.Close`