### PR TITLE
fix: should update leader view when segment version not match

### DIFF
--- a/internal/querycoordv2/observers/leader_observer.go
+++ b/internal/querycoordv2/observers/leader_observer.go
@@ -144,7 +144,7 @@ func (o *LeaderObserver) findNeedLoadedSegments(leaderView *meta.LeaderView, dis
 			continue
 		}
 
-		if !ok || version.GetVersion() < s.Version { // Leader misses this segment
+		if !ok || version.GetVersion() != s.Version { // Leader misses this segment
 			ctx := context.Background()
 			resp, err := o.broker.GetSegmentInfo(ctx, s.GetID())
 			if err != nil || len(resp.GetInfos()) == 0 {
@@ -166,7 +166,7 @@ func (o *LeaderObserver) findNeedLoadedSegments(leaderView *meta.LeaderView, dis
 					PartitionID: s.GetPartitionID(),
 					SegmentID:   s.GetID(),
 					NodeID:      s.Node,
-					Version:     s.Version,
+					Version:     time.Now().Unix(),
 					Info:        loadInfo,
 				})
 			}

--- a/internal/querynodev2/handlers.go
+++ b/internal/querynodev2/handlers.go
@@ -92,7 +92,6 @@ func (node *QueryNode) loadDeltaLogs(ctx context.Context, req *querypb.LoadSegme
 			continue
 		}
 		// try to update segment version after load delta logs
-		// try to update segment version after wait segment loaded
 		node.manager.Segment.UpdateSegmentBy(segments.IncreaseVersion(req.GetVersion()), segments.WithType(segments.SegmentTypeSealed), segments.WithID(info.GetSegmentID()))
 	}
 


### PR DESCRIPTION
issue: #31468
pr: #31643