### PR TITLE
enhance: fast fail if search any segment failure

### DIFF
--- a/internal/querynodev2/segments/retrieve.go
+++ b/internal/querynodev2/segments/retrieve.go
@@ -63,6 +63,10 @@ func retrieveOnSegments(ctx context.Context, mgr *Manager, segments []Segment, s
 	for _, segment := range segments {
 		seg := segment
 		errGroup.Go(func() error {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+
 			// record search time and cache miss
 			var err error
 			accessRecord := metricsutil.NewQuerySegmentAccessRecord(getSegmentMetricLabel(seg))
@@ -148,6 +152,10 @@ func retrieveOnSegmentsWithStream(ctx context.Context, segments []Segment, segTy
 
 // retrieve will retrieve all the validate target segments
 func Retrieve(ctx context.Context, manager *Manager, plan *RetrievePlan, req *querypb.QueryRequest) ([]*segcorepb.RetrieveResults, []Segment, error) {
+	if ctx.Err() != nil {
+		return nil, nil, ctx.Err()
+	}
+
 	var err error
 	var SegType commonpb.SegmentState
 	var retrieveResults []*segcorepb.RetrieveResults
@@ -166,7 +174,7 @@ func Retrieve(ctx context.Context, manager *Manager, plan *RetrievePlan, req *qu
 	}
 
 	if err != nil {
-		return retrieveResults, retrieveSegments, err
+		return nil, nil, err
 	}
 
 	retrieveResults, err = retrieveOnSegments(ctx, manager, retrieveSegments, SegType, plan)

--- a/internal/querynodev2/segments/search.go
+++ b/internal/querynodev2/segments/search.go
@@ -71,6 +71,10 @@ func searchSegments(ctx context.Context, mgr *Manager, segments []Segment, segTy
 			segmentsWithoutIndex = append(segmentsWithoutIndex, seg.ID())
 		}
 		errGroup.Go(func() error {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+
 			var err error
 			accessRecord := metricsutil.NewSearchSegmentAccessRecord(getSegmentMetricLabel(seg))
 			defer func() {
@@ -156,6 +160,10 @@ func searchSegmentsStreamly(ctx context.Context,
 	for _, segment := range segments {
 		seg := segment
 		errGroup.Go(func() error {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+
 			var err error
 			accessRecord := metricsutil.NewSearchSegmentAccessRecord(getSegmentMetricLabel(seg))
 			defer func() {
@@ -214,6 +222,10 @@ func lazyloadWaitTimeout(ctx context.Context) (time.Duration, error) {
 // if segIDs is specified, it will only search on the segments specified by the segIDs.
 // if partIDs is empty, it means all the partitions of the loaded collection or all the partitions loaded.
 func SearchHistorical(ctx context.Context, manager *Manager, searchReq *SearchRequest, collID int64, partIDs []int64, segIDs []int64) ([]*SearchResult, []Segment, error) {
+	if ctx.Err() != nil {
+		return nil, nil, ctx.Err()
+	}
+
 	segments, err := validateOnHistorical(ctx, manager, collID, partIDs, segIDs)
 	if err != nil {
 		return nil, nil, err
@@ -225,6 +237,10 @@ func SearchHistorical(ctx context.Context, manager *Manager, searchReq *SearchRe
 // searchStreaming will search all the target segments in streaming
 // if partIDs is empty, it means all the partitions of the loaded collection or all the partitions loaded.
 func SearchStreaming(ctx context.Context, manager *Manager, searchReq *SearchRequest, collID int64, partIDs []int64, segIDs []int64) ([]*SearchResult, []Segment, error) {
+	if ctx.Err() != nil {
+		return nil, nil, ctx.Err()
+	}
+
 	segments, err := validateOnStream(ctx, manager, collID, partIDs, segIDs)
 	if err != nil {
 		return nil, nil, err
@@ -236,6 +252,10 @@ func SearchStreaming(ctx context.Context, manager *Manager, searchReq *SearchReq
 func SearchHistoricalStreamly(ctx context.Context, manager *Manager, searchReq *SearchRequest,
 	collID int64, partIDs []int64, segIDs []int64, streamReduce func(result *SearchResult) error,
 ) ([]Segment, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
 	segments, err := validateOnHistorical(ctx, manager, collID, partIDs, segIDs)
 	if err != nil {
 		return segments, err


### PR DESCRIPTION
issue: #32513

- Use `errgroup` to fast fail if search segment fail when calling search segments.