### PR TITLE
fix: Download and install cmake for the current platform, not x86_64 only

### DIFF
--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -48,7 +48,7 @@ function install_linux_deps() {
   cmake_version=$(echo "$(cmake --version | head -1)" | grep -o '[0-9][\.][0-9]*')
   if [ ! $cmake_version ] || [ `expr $cmake_version \>= 3.26` -eq 0 ]; then
     echo "cmake version $cmake_version is less than 3.26, wait to installing ..."
-    wget -qO- "https://cmake.org/files/v3.26/cmake-3.26.5-linux-x86_64.tar.gz" | sudo tar --strip-components=1 -xz -C /usr/local
+    wget -qO- "https://cmake.org/files/v3.26/cmake-3.26.5-linux-$(uname -m).tar.gz" | sudo tar --strip-components=1 -xz -C /usr/local
   else
     echo "cmake version is $cmake_version"
   fi


### PR DESCRIPTION
issue #32476 

tested on x86_64 and aarch64. I'm not sure what needs to be done on some exotic architectures.
