### PR TITLE
enhance: [2.3] Use different interval for gc scan (#31363)

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -432,6 +432,7 @@ dataCoord:
   enableGarbageCollection: true
   gc:
     interval: 3600 # gc interval in seconds
+    scanInterval: 168 #gc residual file scan interval in hours
     missingTolerance: 3600 # file meta missing tolerance duration in seconds, 3600
     dropTolerance: 10800 # file belongs to dropped entity tolerance duration in seconds. 10800
   enableActiveStandby: false

--- a/internal/datacoord/garbage_collector_test.go
+++ b/internal/datacoord/garbage_collector_test.go
@@ -67,6 +67,7 @@ func Test_garbageCollector_basic(t *testing.T) {
 			cli:              cli,
 			enabled:          true,
 			checkInterval:    time.Millisecond * 10,
+			scanInterval:     time.Hour * 7 * 24,
 			missingTolerance: time.Hour * 24,
 			dropTolerance:    time.Hour * 24,
 		})
@@ -83,6 +84,7 @@ func Test_garbageCollector_basic(t *testing.T) {
 			cli:              nil,
 			enabled:          true,
 			checkInterval:    time.Millisecond * 10,
+			scanInterval:     time.Hour * 7 * 24,
 			missingTolerance: time.Hour * 24,
 			dropTolerance:    time.Hour * 24,
 		})
@@ -119,6 +121,7 @@ func Test_garbageCollector_scan(t *testing.T) {
 			cli:              cli,
 			enabled:          true,
 			checkInterval:    time.Minute * 30,
+			scanInterval:     time.Hour * 7 * 24,
 			missingTolerance: time.Hour * 24,
 			dropTolerance:    time.Hour * 24,
 		})
@@ -136,6 +139,7 @@ func Test_garbageCollector_scan(t *testing.T) {
 			cli:              cli,
 			enabled:          true,
 			checkInterval:    time.Minute * 30,
+			scanInterval:     time.Hour * 7 * 24,
 			missingTolerance: time.Hour * 24,
 			dropTolerance:    time.Hour * 24,
 		})
@@ -161,6 +165,7 @@ func Test_garbageCollector_scan(t *testing.T) {
 			cli:              cli,
 			enabled:          true,
 			checkInterval:    time.Minute * 30,
+			scanInterval:     time.Hour * 7 * 24,
 			missingTolerance: time.Hour * 24,
 			dropTolerance:    time.Hour * 24,
 		})
@@ -189,6 +194,7 @@ func Test_garbageCollector_scan(t *testing.T) {
 			cli:              cli,
 			enabled:          true,
 			checkInterval:    time.Minute * 30,
+			scanInterval:     time.Hour * 7 * 24,
 			missingTolerance: time.Hour * 24,
 			dropTolerance:    0,
 		})
@@ -205,6 +211,7 @@ func Test_garbageCollector_scan(t *testing.T) {
 			cli:              cli,
 			enabled:          true,
 			checkInterval:    time.Minute * 30,
+			scanInterval:     time.Hour * 7 * 24,
 			missingTolerance: 0,
 			dropTolerance:    0,
 		})
@@ -226,6 +233,7 @@ func Test_garbageCollector_scan(t *testing.T) {
 			cli:              cli,
 			enabled:          true,
 			checkInterval:    time.Minute * 30,
+			scanInterval:     time.Hour * 7 * 24,
 			missingTolerance: 0,
 			dropTolerance:    0,
 		})
@@ -1480,6 +1488,7 @@ func (s *GarbageCollectorSuite) TestPauseResume() {
 			cli:              s.cli,
 			enabled:          false,
 			checkInterval:    time.Millisecond * 10,
+			scanInterval:     time.Hour * 24 * 7,
 			missingTolerance: time.Hour * 24,
 			dropTolerance:    time.Hour * 24,
 		})
@@ -1501,6 +1510,7 @@ func (s *GarbageCollectorSuite) TestPauseResume() {
 			cli:              s.cli,
 			enabled:          true,
 			checkInterval:    time.Millisecond * 10,
+			scanInterval:     time.Hour * 7 * 24,
 			missingTolerance: time.Hour * 24,
 			dropTolerance:    time.Hour * 24,
 		})
@@ -1525,6 +1535,7 @@ func (s *GarbageCollectorSuite) TestPauseResume() {
 			cli:              s.cli,
 			enabled:          true,
 			checkInterval:    time.Millisecond * 10,
+			scanInterval:     time.Hour * 7 * 24,
 			missingTolerance: time.Hour * 24,
 			dropTolerance:    time.Hour * 24,
 		})
@@ -1552,6 +1563,7 @@ func (s *GarbageCollectorSuite) TestPauseResume() {
 			cli:              s.cli,
 			enabled:          true,
 			checkInterval:    time.Millisecond * 10,
+			scanInterval:     time.Hour * 7 * 24,
 			missingTolerance: time.Hour * 24,
 			dropTolerance:    time.Hour * 24,
 		})

--- a/internal/datacoord/server.go
+++ b/internal/datacoord/server.go
@@ -487,6 +487,7 @@ func (s *Server) initGarbageCollection(cli storage.ChunkManager) {
 		cli:              cli,
 		enabled:          Params.DataCoordCfg.EnableGarbageCollection.GetAsBool(),
 		checkInterval:    Params.DataCoordCfg.GCInterval.GetAsDuration(time.Second),
+		scanInterval:     Params.DataCoordCfg.GCScanIntervalInHour.GetAsDuration(time.Hour),
 		missingTolerance: Params.DataCoordCfg.GCMissingTolerance.GetAsDuration(time.Second),
 		dropTolerance:    Params.DataCoordCfg.GCDropTolerance.GetAsDuration(time.Second),
 	})

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -2332,6 +2332,7 @@ type dataCoordConfig struct {
 	GCMissingTolerance      ParamItem `refreshable:"false"`
 	GCDropTolerance         ParamItem `refreshable:"false"`
 	GCRemoveConcurrent      ParamItem `refreshable:"false"`
+	GCScanIntervalInHour    ParamItem `refreshable:"false"`
 	EnableActiveStandby     ParamItem `refreshable:"false"`
 
 	BindIndexNodeMode          ParamItem `refreshable:"false"`
@@ -2627,6 +2628,15 @@ During compaction, the size of segment # of rows is able to exceed segment max #
 		Export:       true,
 	}
 	p.GCInterval.Init(base.mgr)
+
+	p.GCScanIntervalInHour = ParamItem{
+		Key:          "dataCoord.gc.scanInterval",
+		Version:      "2.4.0",
+		DefaultValue: "168", // hours, default 7 * 24 hours
+		Doc:          "garbage collection scan residue interval in hours",
+		Export:       true,
+	}
+	p.GCScanIntervalInHour.Init(base.mgr)
 
 	// Do not set this to incredible small value, make sure this to be more than 10 minutes at least
 	p.GCMissingTolerance = ParamItem{


### PR DESCRIPTION
Cherry-pick from master
pr: #31363
See also #31362

This PR make datacoord garbage collection scan operation using differet interval than other opeartion.

This interval is a newly added param item, which default value is 7*24 hours.