### PR TITLE
enhance: remove lock in bloom filter set

### DIFF
--- a/internal/querynodev2/pkoracle/bloom_filter_set_test.go
+++ b/internal/querynodev2/pkoracle/bloom_filter_set_test.go
@@ -1,0 +1,88 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkoracle
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/pkg/util/paramtable"
+)
+
+func TestInt64Pk(t *testing.T) {
+	paramtable.Init()
+	bf := NewBloomFilterSet(1, 1, commonpb.SegmentState_Sealed)
+
+	batch := 1000
+	pks := make([]storage.PrimaryKey, 0)
+	for i := 0; i < batch; i++ {
+		pks = append(pks, storage.NewInt64PrimaryKey(int64(i)))
+	}
+
+	bf.UpdateBloomFilter(pks)
+
+	for i := 0; i < batch; i++ {
+		assert.True(t, bf.MayPkExist(pks[i]))
+	}
+
+	assert.Equal(t, int64(1), bf.ID())
+	assert.Equal(t, int64(1), bf.Partition())
+	assert.Equal(t, commonpb.SegmentState_Sealed, bf.Type())
+}
+
+func TestVarCharPk(t *testing.T) {
+	paramtable.Init()
+	bf := NewBloomFilterSet(1, 1, commonpb.SegmentState_Sealed)
+
+	batch := 1000
+	pks := make([]storage.PrimaryKey, 0)
+	for i := 0; i < batch; i++ {
+		pks = append(pks, storage.NewVarCharPrimaryKey(strconv.FormatInt(int64(i), 10)))
+	}
+
+	bf.UpdateBloomFilter(pks)
+
+	for i := 0; i < batch; i++ {
+		assert.True(t, bf.MayPkExist(pks[i]))
+	}
+}
+
+func TestHistoricalStat(t *testing.T) {
+	paramtable.Init()
+	bf := NewBloomFilterSet(1, 1, commonpb.SegmentState_Sealed)
+
+	batch := 1000
+	pks := make([]storage.PrimaryKey, 0)
+	for i := 0; i < batch; i++ {
+		pks = append(pks, storage.NewVarCharPrimaryKey(strconv.FormatInt(int64(i), 10)))
+	}
+
+	bf.UpdateBloomFilter(pks)
+
+	// hack historical stat
+	bf.AddHistoricalStats(bf.currentStat)
+	bf.AddHistoricalStats(bf.currentStat)
+	bf.currentStat = nil
+
+	for i := 0; i < batch; i++ {
+		assert.True(t, bf.MayPkExist(pks[i]))
+	}
+}

--- a/internal/util/pipeline/node.go
+++ b/internal/util/pipeline/node.go
@@ -17,12 +17,6 @@
 package pipeline
 
 import (
-	"fmt"
-	"sync"
-
-	"go.uber.org/zap"
-
-	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/util/timerecord"
 )
 
@@ -35,63 +29,16 @@ type Node interface {
 }
 
 type nodeCtx struct {
-	node Node
-
+	node         Node
 	inputChannel chan Msg
-
-	next    *nodeCtx
-	checker *timerecord.GroupChecker
-
-	closeCh chan struct{} // notify work to exit
-	closeWg sync.WaitGroup
-}
-
-func (c *nodeCtx) Start() {
-	c.closeWg.Add(1)
-	c.node.Start()
-	go c.work()
-}
-
-func (c *nodeCtx) Close() {
-	close(c.closeCh)
-	c.closeWg.Wait()
-}
-
-func (c *nodeCtx) work() {
-	defer c.closeWg.Done()
-	name := fmt.Sprintf("nodeCtxTtChecker-%s", c.node.Name())
-	if c.checker != nil {
-		c.checker.Check(name)
-		defer c.checker.Remove(name)
-	}
-
-	for {
-		select {
-		// close
-		case <-c.closeCh:
-			c.node.Close()
-			close(c.inputChannel)
-			log.Debug("pipeline node closed", zap.String("nodeName", c.node.Name()))
-			return
-		case input := <-c.inputChannel:
-			var output Msg
-			output = c.node.Operate(input)
-			if c.checker != nil {
-				c.checker.Check(name)
-			}
-			if c.next != nil && output != nil {
-				c.next.inputChannel <- output
-			}
-		}
-	}
+	next         *nodeCtx
+	checker      *timerecord.GroupChecker
 }
 
 func newNodeCtx(node Node) *nodeCtx {
 	return &nodeCtx{
 		node:         node,
 		inputChannel: make(chan Msg, node.MaxQueueLength()),
-		closeCh:      make(chan struct{}),
-		closeWg:      sync.WaitGroup{},
 	}
 }
 

--- a/internal/util/pipeline/pipeline_test.go
+++ b/internal/util/pipeline/pipeline_test.go
@@ -17,6 +17,7 @@
 package pipeline
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -31,8 +32,9 @@ type testNode struct {
 
 func (t *testNode) Operate(in Msg) Msg {
 	msg := in.(*msgstream.MsgPack)
-	msg.BeginTs++
-	t.outChannel <- msg.BeginTs
+	if t.outChannel != nil {
+		t.outChannel <- msg.BeginTs
+	}
 	return msg
 }
 
@@ -48,11 +50,27 @@ func (suite *PipelineSuite) SetupTest() {
 		nodes:           []*nodeCtx{},
 		nodeTtInterval:  0,
 		enableTtChecker: false,
+		closeCh:         make(chan struct{}),
+		closeWg:         sync.WaitGroup{},
 	}
 
 	suite.pipeline.addNode(&testNode{
 		BaseNode: &BaseNode{
-			name:           "test-node",
+			name:           "test-node1",
+			maxQueueLength: 8,
+		},
+	})
+
+	suite.pipeline.addNode(&testNode{
+		BaseNode: &BaseNode{
+			name:           "test-node2",
+			maxQueueLength: 8,
+		},
+	})
+
+	suite.pipeline.addNode(&testNode{
+		BaseNode: &BaseNode{
+			name:           "test-node3",
 			maxQueueLength: 8,
 		},
 		outChannel: suite.outChannel,
@@ -62,10 +80,12 @@ func (suite *PipelineSuite) SetupTest() {
 func (suite *PipelineSuite) TestBasic() {
 	suite.pipeline.Start()
 	defer suite.pipeline.Close()
-	suite.pipeline.inputChannel <- &msgstream.MsgPack{}
 
-	output := <-suite.outChannel
-	suite.Equal(msgstream.Timestamp(1), output)
+	for i := 0; i < 100; i++ {
+		suite.pipeline.inputChannel <- &msgstream.MsgPack{BeginTs: msgstream.Timestamp(i)}
+		output := <-suite.outChannel
+		suite.Equal(i, int(output))
+	}
 }
 
 func TestPipeline(t *testing.T) {

--- a/internal/util/pipeline/stream_pipeline.go
+++ b/internal/util/pipeline/stream_pipeline.go
@@ -111,6 +111,8 @@ func NewPipelineWithStream(dispatcher msgdispatcher.Client, nodeTtInterval time.
 			nodes:           []*nodeCtx{},
 			nodeTtInterval:  nodeTtInterval,
 			enableTtChecker: enableTtChecker,
+			closeCh:         make(chan struct{}),
+			closeWg:         sync.WaitGroup{},
 		},
 		dispatcher: dispatcher,
 		vChannel:   vChannel,

--- a/internal/util/pipeline/stream_pipeline_test.go
+++ b/internal/util/pipeline/stream_pipeline_test.go
@@ -68,11 +68,11 @@ func (suite *StreamPipelineSuite) TestBasic() {
 
 	suite.pipeline.Start()
 	defer suite.pipeline.Close()
-	suite.inChannel <- &msgstream.MsgPack{}
+	suite.inChannel <- &msgstream.MsgPack{BeginTs: 100}
 
 	for i := 1; i <= suite.length; i++ {
 		output := <-suite.outChannel
-		suite.Equal(msgstream.Timestamp(i), output)
+		suite.Equal(msgstream.Timestamp(100), output)
 	}
 }
 


### PR DESCRIPTION
issue: #32530 

to optimize delegator ProcessDelete performance, This PR make pipeline execute `ProcessDelete` and `ProcessInsert` in serial, which remove the race condition in bloom filter set, then remove the lock in bloom filter set.