### PR TITLE
enhance: indexnode building index record collection id

### DIFF
--- a/internal/indexnode/indexnode_service.go
+++ b/internal/indexnode/indexnode_service.go
@@ -54,6 +54,7 @@ func (i *IndexNode) CreateJob(ctx context.Context, req *indexpb.CreateJobRequest
 	}
 	defer i.lifetime.Done()
 	log.Info("IndexNode building index ...",
+		zap.Int64("collectionID", req.GetCollectionID()),
 		zap.Int64("indexID", req.GetIndexID()),
 		zap.String("indexName", req.GetIndexName()),
 		zap.String("indexFilePrefix", req.GetIndexFilePrefix()),


### PR DESCRIPTION
Adding a collection id to the index node log allows you to associate an index building task with a specific collection.
If the host CPU usage is too high due to index build, you can use the collection id to quickly locate a specific collection, improving fault locating efficiency.