### PR TITLE
fix: revert thread safe vector modification

### DIFF
--- a/internal/core/src/segcore/ConcurrentVector.h
+++ b/internal/core/src/segcore/ConcurrentVector.h
@@ -41,10 +41,10 @@ class ThreadSafeVector {
     template <typename... Args>
     void
     emplace_to_at_least(int64_t size, Args... args) {
-        std::lock_guard lck(mutex_);
         if (size <= size_) {
             return;
         }
+        std::lock_guard lck(mutex_);
         while (vec_.size() < size) {
             vec_.emplace_back(std::forward<Args...>(args...));
             ++size_;
@@ -52,25 +52,24 @@ class ThreadSafeVector {
     }
     const Type&
     operator[](int64_t index) const {
-        std::shared_lock lck(mutex_);
         AssertInfo(index < size_,
                    fmt::format(
                        "index out of range, index={}, size_={}", index, size_));
+        std::shared_lock lck(mutex_);
         return vec_[index];
     }
 
     Type&
     operator[](int64_t index) {
-        std::shared_lock lck(mutex_);
         AssertInfo(index < size_,
                    fmt::format(
                        "index out of range, index={}, size_={}", index, size_));
+        std::shared_lock lck(mutex_);
         return vec_[index];
     }
 
     int64_t
     size() const {
-        std::lock_guard lck(mutex_);
         return size_;
     }
 
@@ -82,7 +81,7 @@ class ThreadSafeVector {
     }
 
  private:
-    int64_t size_ = 0;
+    std::atomic<int64_t> size_ = 0;
     std::deque<Type> vec_;
     mutable std::shared_mutex mutex_;
 };


### PR DESCRIPTION
issue: #31898
This reverts commit 6245b19169906c0b33e7953ea97d7412cc0d5e36. 