### PR TITLE
enhance: make not retry when build index but data type invalid

### DIFF
--- a/internal/util/indexcgowrapper/helper.go
+++ b/internal/util/indexcgowrapper/helper.go
@@ -69,7 +69,7 @@ func HandleCStatus(status *C.CStatus, extraInfo string) error {
 
 	logMsg := fmt.Sprintf("%s, C Runtime Exception: %s\n", extraInfo, errorMsg)
 	log.Warn(logMsg)
-	if errorCode == 2003 {
+	if errorCode == 2003 || errorCode == 2007 {
 		return merr.WrapErrSegcoreUnsupported(int32(errorCode), logMsg)
 	}
 	return merr.WrapErrSegcore(int32(errorCode), logMsg)


### PR DESCRIPTION
<img width="914" alt="image" src="https://github.com/milvus-io/milvus/assets/64083300/c6fa5fea-61a8-48ee-9ac6-03230cdab7e7">
if err is dataType invalid, no need to to retry here.
so if code is dataTypeInvalid(2007 in segcore), wrap it as SegcoreUnsupported.