### PR TITLE
enhance: Reduce bloom filter lock contention between insert and delete in query coord

### DIFF
--- a/internal/querynodev2/server.go
+++ b/internal/querynodev2/server.go
@@ -461,7 +461,7 @@ func (node *QueryNode) Stop() error {
 				case <-time.After(time.Second):
 					metrics.StoppingBalanceSegmentNum.WithLabelValues(fmt.Sprint(node.GetNodeID())).Set(float64(len(sealedSegments)))
 					metrics.StoppingBalanceChannelNum.WithLabelValues(fmt.Sprint(node.GetNodeID())).Set(float64(channelNum))
-					log.Info("migrate data...", zap.Int64("ServerID", paramtable.GetNodeID()),
+					log.Info("migrate data...", zap.Int64("ServerID", node.GetNodeID()),
 						zap.Int64s("sealedSegments", lo.Map(sealedSegments, func(s segments.Segment, i int) int64 {
 							return s.ID()
 						})),

--- a/internal/util/pipeline/node.go
+++ b/internal/util/pipeline/node.go
@@ -17,12 +17,6 @@
 package pipeline
 
 import (
-	"fmt"
-	"sync"
-
-	"go.uber.org/zap"
-
-	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/util/timerecord"
 )
 
@@ -35,63 +29,16 @@ type Node interface {
 }
 
 type nodeCtx struct {
-	node Node
-
+	node         Node
 	inputChannel chan Msg
-
-	next    *nodeCtx
-	checker *timerecord.GroupChecker
-
-	closeCh chan struct{} // notify work to exit
-	closeWg sync.WaitGroup
-}
-
-func (c *nodeCtx) Start() {
-	c.closeWg.Add(1)
-	c.node.Start()
-	go c.work()
-}
-
-func (c *nodeCtx) Close() {
-	close(c.closeCh)
-	c.closeWg.Wait()
-}
-
-func (c *nodeCtx) work() {
-	defer c.closeWg.Done()
-	name := fmt.Sprintf("nodeCtxTtChecker-%s", c.node.Name())
-	if c.checker != nil {
-		c.checker.Check(name)
-		defer c.checker.Remove(name)
-	}
-
-	for {
-		select {
-		// close
-		case <-c.closeCh:
-			c.node.Close()
-			close(c.inputChannel)
-			log.Debug("pipeline node closed", zap.String("nodeName", c.node.Name()))
-			return
-		case input := <-c.inputChannel:
-			var output Msg
-			output = c.node.Operate(input)
-			if c.checker != nil {
-				c.checker.Check(name)
-			}
-			if c.next != nil && output != nil {
-				c.next.inputChannel <- output
-			}
-		}
-	}
+	next         *nodeCtx
+	checker      *timerecord.GroupChecker
 }
 
 func newNodeCtx(node Node) *nodeCtx {
 	return &nodeCtx{
 		node:         node,
 		inputChannel: make(chan Msg, node.MaxQueueLength()),
-		closeCh:      make(chan struct{}),
-		closeWg:      sync.WaitGroup{},
 	}
 }
 

--- a/internal/util/pipeline/stream_pipeline_test.go
+++ b/internal/util/pipeline/stream_pipeline_test.go
@@ -68,11 +68,11 @@ func (suite *StreamPipelineSuite) TestBasic() {
 
 	suite.pipeline.Start()
 	defer suite.pipeline.Close()
-	suite.inChannel <- &msgstream.MsgPack{}
+	suite.inChannel <- &msgstream.MsgPack{BeginTs: 1001}
 
 	for i := 1; i <= suite.length; i++ {
 		output := <-suite.outChannel
-		suite.Equal(msgstream.Timestamp(i), output)
+		suite.Equal(int64(1001), int64(output))
 	}
 }
 


### PR DESCRIPTION
issue: #32530

cause ProcessDelete need to check whether pk exist in bloom filter, and ProcessInsert need to update pk to bloom filter, when execute ProcessInsert and ProcessDelete in parallel, it will cause race condition in segment's bloom filter

This PR execute ProcessInsert and ProcessDelete in serial to avoid block each other