### PR TITLE
fix: skip the empty partition name in the rate limit interceptor

### DIFF
--- a/internal/proxy/rate_limit_interceptor.go
+++ b/internal/proxy/rate_limit_interceptor.go
@@ -86,6 +86,9 @@ func getCollectionAndPartitionID(ctx context.Context, r reqPartName) (int64, map
 	if err != nil {
 		return 0, nil, err
 	}
+	if r.GetPartitionName() == "" {
+		return db.dbID, map[int64][]int64{collectionID: {}}, nil
+	}
 	part, err := globalMetaCache.GetPartitionInfo(ctx, r.GetDbName(), r.GetCollectionName(), r.GetPartitionName())
 	if err != nil {
 		return 0, nil, err


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/30577