### PR TITLE
fix: docs for python3 and conan

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -194,7 +194,7 @@ sudo apt install -y clang-format clang-tidy ninja-build gcc g++ curl zip unzip t
 #### Install conan
 
 ```bash
-# Verify python3 version, need python3 version > 3.8
+# Verify python3 version, need python3 version > 3.8 and version <= 3.11
 python3 --version
 # pip install conan 1.61.0
 pip3 install conan==1.61.0

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Linux systems (Ubuntu 20.04 or later recommended):
 go: >= 1.20
 cmake: >= 3.26.4
 gcc: 7.5
+python: > 3.8 and  <= 3.11
 ```
 
 MacOS systems with x86_64 (Big Sur 11.5 or later recommended):
@@ -82,6 +83,7 @@ MacOS systems with x86_64 (Big Sur 11.5 or later recommended):
 go: >= 1.20
 cmake: >= 3.26.4
 llvm: >= 15
+python: > 3.8 and  <= 3.11
 ```
 
 MacOS systems with Apple Silicon (Monterey 12.0.1 or later recommended):
@@ -89,6 +91,7 @@ MacOS systems with Apple Silicon (Monterey 12.0.1 or later recommended):
 go: >= 1.20 (Arch=ARM64)
 cmake: >= 3.26.4
 llvm: >= 15
+python: > 3.8 and  <= 3.11
 ```
 
 Clone Milvus repo and build.


### PR DESCRIPTION
Conan 1.x is broken for Python 3.12, since imp is deprecated in favour of importlib, removed in 3.12.

https://github.com/milvus-io/milvus/issues/32655