### PR TITLE
enhance: Close singleton etcd client in integration teardown

### DIFF
--- a/tests/integration/minicluster_v2.go
+++ b/tests/integration/minicluster_v2.go
@@ -47,6 +47,7 @@ import (
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/dependency"
+	kvfactory "github.com/milvus-io/milvus/internal/util/dependency/kv"
 	"github.com/milvus-io/milvus/internal/util/hookutil"
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/util/etcd"
@@ -397,6 +398,8 @@ func (cluster *MiniClusterV2) Stop() error {
 		}
 	}
 	cluster.ChunkManager.RemoveWithPrefix(cluster.ctx, cluster.ChunkManager.RootPath())
+
+	kvfactory.CloseEtcdClient()
 	return nil
 }
 


### PR DESCRIPTION
Found lots of `failed to updateTimeTick` with error `skip ChannelTimeTickMsg from un-recognized session 1` The reason was etcd client became singleton and used last root path in multiple cases are run in one suite.

This PR add close singleton client invocation to fix this problem.