### PR TITLE
fix: add request resource timeout for lazy load, refactor context usage in cache

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -358,7 +358,10 @@ queryNode:
       maxPendingTaskPerUser: 1024 # 50 by default, max pending task in scheduler per user.
   mmap:
     mmapEnabled: false # enable mmap global, if set true, will use mmap to load segment data
-  lazyloadEnabled: false
+  lazyloadEnabled: false # Enable lazyload for loading data
+  lazyloadWaitTimeout: 30000 # max wait timeout duration in milliseconds before start to do lazyload search and retrieve
+  lazyLoadRequestResourceTimeout: 5000 # max timeout in milliseconds for waiting request resource for lazy load, 5s by default
+  lazyLoadRequestResourceRetryInterval: 2000 # retry interval in milliseconds for waiting request resource for lazy load, 2s by default
   useStreamComputing: false
 
   # can specify ip for example

--- a/internal/querynodev2/segments/manager.go
+++ b/internal/querynodev2/segments/manager.go
@@ -156,7 +156,7 @@ type Manager struct {
 }
 
 func NewManager() *Manager {
-	diskCap := paramtable.Get().QueryNodeCfg.DiskCacheCapacityLimit.GetAsInt64()
+	diskCap := paramtable.Get().QueryNodeCfg.DiskCacheCapacityLimit.GetAsSize()
 
 	segMgr := NewSegmentManager()
 	sf := singleflight.Group{}

--- a/internal/querynodev2/segments/retrieve.go
+++ b/internal/querynodev2/segments/retrieve.go
@@ -82,6 +82,9 @@ func retrieveOnSegments(ctx context.Context, mgr *Manager, segments []Segment, s
 				if missing {
 					accessRecord.CacheMissing()
 				}
+				if err != nil {
+					log.Warn("failed to do query disk cache", zap.Int64("segID", seg.ID()), zap.Error(err))
+				}
 				return err
 			}
 			return retriever(ctx, seg)

--- a/internal/querynodev2/segments/search.go
+++ b/internal/querynodev2/segments/search.go
@@ -87,6 +87,9 @@ func searchSegments(ctx context.Context, mgr *Manager, segments []Segment, segTy
 				if missing {
 					accessRecord.CacheMissing()
 				}
+				if err != nil {
+					log.Warn("failed to do search for disk cache", zap.Int64("segID", seg.ID()), zap.Error(err))
+				}
 				return err
 			}
 			return searcher(ctx, seg)
@@ -175,7 +178,7 @@ func searchSegmentsStreamly(ctx context.Context,
 					accessRecord.CacheMissing()
 				}
 				if err != nil {
-					log.Error("failed to do search for disk cache", zap.Int64("seg_id", seg.ID()), zap.Error(err))
+					log.Warn("failed to do search for disk cache", zap.Int64("segID", seg.ID()), zap.Error(err))
 				}
 				log.Debug("after doing stream search in DiskCache", zap.Int64("segID", seg.ID()), zap.Error(err))
 				return err

--- a/pkg/util/cache/cache.go
+++ b/pkg/util/cache/cache.go
@@ -25,7 +25,6 @@ import (
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
 
-	"github.com/cockroachdb/errors"
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/merr"
@@ -258,9 +257,6 @@ func (c *lruCache[K, V]) Do(ctx context.Context, key K, doer func(context.Contex
 		if err == nil {
 			defer c.Unpin(key)
 			return missing, doer(ctx, item.value)
-		} else if errors.Is(err, merr.ErrServiceResourceInsufficient) {
-			log.Warn("Failed to load segment for insufficient resource")
-			return true, err
 		} else if err != ErrNotEnoughSpace {
 			return true, err
 		}

--- a/pkg/util/cache/cache_test.go
+++ b/pkg/util/cache/cache_test.go
@@ -2,15 +2,19 @@ package cache
 
 import (
 	"context"
-	"github.com/milvus-io/milvus/pkg/util/merr"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/milvus-io/milvus/pkg/util/contextutil"
+	"github.com/milvus-io/milvus/pkg/util/merr"
 
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/atomic"
 )
+
+var errTimeout = errors.New("timeout")
 
 func TestLRUCache(t *testing.T) {
 	cacheBuilder := NewCacheBuilder[int, int]().WithLoader(func(ctx context.Context, key int) (int, error) {
@@ -22,7 +26,7 @@ func TestLRUCache(t *testing.T) {
 		cache := cacheBuilder.WithCapacity(int64(size)).Build()
 
 		for i := 0; i < size; i++ {
-			missing, err := cache.Do(context.Background(), i, func(v int) error {
+			missing, err := cache.Do(context.Background(), i, func(_ context.Context, v int) error {
 				assert.Equal(t, i, v)
 				return nil
 			})
@@ -40,7 +44,7 @@ func TestLRUCache(t *testing.T) {
 		}).Build()
 
 		for i := 0; i < size*2; i++ {
-			missing, err := cache.Do(context.Background(), i, func(v int) error {
+			missing, err := cache.Do(context.Background(), i, func(_ context.Context, v int) error {
 				assert.Equal(t, i, v)
 				return nil
 			})
@@ -51,7 +55,7 @@ func TestLRUCache(t *testing.T) {
 
 		// Hit the cache again, there should be no swap-out
 		for i := size; i < size*2; i++ {
-			missing, err := cache.Do(context.Background(), i, func(v int) error {
+			missing, err := cache.Do(context.Background(), i, func(_ context.Context, v int) error {
 				assert.Equal(t, i, v)
 				return nil
 			})
@@ -72,7 +76,7 @@ func TestLRUCache(t *testing.T) {
 		}).Build()
 
 		for i := 0; i < 20; i++ {
-			missing, err := cache.Do(context.Background(), i, func(v int) error {
+			missing, err := cache.Do(context.Background(), i, func(_ context.Context, v int) error {
 				assert.Equal(t, i, v)
 				return nil
 			})
@@ -85,7 +89,7 @@ func TestLRUCache(t *testing.T) {
 	t.Run("test do negative", func(t *testing.T) {
 		cache := cacheBuilder.Build()
 		theErr := errors.New("error")
-		missing, err := cache.Do(context.Background(), -1, func(v int) error {
+		missing, err := cache.Do(context.Background(), -1, func(_ context.Context, v int) error {
 			return theErr
 		})
 		assert.True(t, missing)
@@ -103,7 +107,7 @@ func TestLRUCache(t *testing.T) {
 		}).Build()
 
 		for i := 0; i < 20; i++ {
-			missing, err := cache.Do(context.Background(), i, func(v int) error {
+			missing, err := cache.Do(context.Background(), i, func(_ context.Context, v int) error {
 				assert.Equal(t, i, v)
 				return nil
 			})
@@ -111,11 +115,15 @@ func TestLRUCache(t *testing.T) {
 			assert.NoError(t, err)
 		}
 		assert.Equal(t, []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18}, finalizeSeq)
-		missing, err := cache.Do(context.Background(), 100, func(v int) error {
+		ctx, cancel := contextutil.WithTimeoutCause(context.Background(), time.Second, errTimeout)
+		defer cancel()
+
+		missing, err := cache.Do(ctx, 100, func(_ context.Context, v int) error {
 			return nil
 		})
 		assert.True(t, missing)
-		assert.Equal(t, ErrNotEnoughSpace, err)
+		assert.ErrorIs(t, err, context.Canceled)
+		assert.ErrorIs(t, context.Cause(ctx), errTimeout)
 	})
 
 	t.Run("test load negative", func(t *testing.T) {
@@ -125,27 +133,27 @@ func TestLRUCache(t *testing.T) {
 			}
 			return key, nil
 		}).Build()
-		missing, err := cache.Do(context.Background(), 0, func(v int) error {
+		missing, err := cache.Do(context.Background(), 0, func(_ context.Context, v int) error {
 			return nil
 		})
 		assert.True(t, missing)
 		assert.NoError(t, err)
-		missing, err = cache.Do(context.Background(), -1, func(v int) error {
+		missing, err = cache.Do(context.Background(), -1, func(_ context.Context, v int) error {
 			return nil
 		})
 		assert.True(t, missing)
-		assert.Equal(t, ErrNoSuchItem, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
 	})
 
 	t.Run("test reloader", func(t *testing.T) {
 		cache := cacheBuilder.WithReloader(func(ctx context.Context, key int) (int, error) {
 			return -key, nil
 		}).Build()
-		_, err := cache.Do(context.Background(), 1, func(i int) error { return nil })
+		_, err := cache.Do(context.Background(), 1, func(_ context.Context, i int) error { return nil })
 		assert.NoError(t, err)
 		exist := cache.MarkItemNeedReload(context.Background(), 1)
 		assert.True(t, exist)
-		cache.Do(context.Background(), 1, func(i int) error {
+		cache.Do(context.Background(), 1, func(_ context.Context, i int) error {
 			assert.Equal(t, -1, i)
 			return nil
 		})
@@ -155,7 +163,7 @@ func TestLRUCache(t *testing.T) {
 		cache := cacheBuilder.WithCapacity(1).Build()
 		exist := cache.MarkItemNeedReload(context.Background(), 1)
 		assert.False(t, exist)
-		_, err := cache.Do(context.Background(), 1, func(i int) error { return nil })
+		_, err := cache.Do(context.Background(), 1, func(_ context.Context, i int) error { return nil })
 		assert.NoError(t, err)
 		exist = cache.MarkItemNeedReload(context.Background(), 1)
 		assert.True(t, exist)
@@ -180,7 +188,7 @@ func TestStats(t *testing.T) {
 		assert.Equal(t, uint64(0), stats.LoadFailCount.Load())
 
 		for i := 0; i < size; i++ {
-			_, err := cache.Do(context.Background(), i, func(v int) error {
+			_, err := cache.Do(context.Background(), i, func(_ context.Context, v int) error {
 				assert.Equal(t, i, v)
 				return nil
 			})
@@ -195,7 +203,7 @@ func TestStats(t *testing.T) {
 		assert.Equal(t, uint64(0), stats.LoadFailCount.Load())
 
 		for i := 0; i < size; i++ {
-			_, err := cache.Do(context.Background(), i, func(v int) error {
+			_, err := cache.Do(context.Background(), i, func(_ context.Context, v int) error {
 				assert.Equal(t, i, v)
 				return nil
 			})
@@ -209,7 +217,7 @@ func TestStats(t *testing.T) {
 		assert.Equal(t, uint64(0), stats.LoadFailCount.Load())
 
 		for i := size; i < size*2; i++ {
-			_, err := cache.Do(context.Background(), i, func(v int) error {
+			_, err := cache.Do(context.Background(), i, func(_ context.Context, v int) error {
 				assert.Equal(t, i, v)
 				return nil
 			})
@@ -240,7 +248,7 @@ func TestLRUCacheConcurrency(t *testing.T) {
 			go func(i int) {
 				defer wg.Done()
 				for j := 0; j < 100; j++ {
-					_, err := cache.Do(context.Background(), j, func(v int) error {
+					_, err := cache.Do(context.Background(), j, func(_ context.Context, v int) error {
 						return nil
 					})
 					assert.NoError(t, err)
@@ -261,17 +269,21 @@ func TestLRUCacheConcurrency(t *testing.T) {
 		var wg1 sync.WaitGroup // Make sure goroutine is started
 		wg.Add(1)
 		wg1.Add(1)
-		go cache.Do(context.Background(), 1000, func(v int) error {
+		go cache.Do(context.Background(), 1000, func(_ context.Context, v int) error {
 			wg1.Done()
 			wg.Wait()
 			return nil
 		})
 		wg1.Wait()
-		_, err := cache.Do(context.Background(), 1001, func(v int) error {
+
+		ctx, cancel := contextutil.WithTimeoutCause(context.Background(), time.Second, errTimeout)
+		defer cancel()
+		_, err := cache.Do(ctx, 1001, func(_ context.Context, v int) error {
 			return nil
 		})
 		wg.Done()
-		assert.Equal(t, ErrNotEnoughSpace, err)
+		assert.ErrorIs(t, err, context.Canceled)
+		assert.ErrorIs(t, context.Cause(ctx), errTimeout)
 	})
 
 	t.Run("test time out", func(t *testing.T) {
@@ -285,18 +297,22 @@ func TestLRUCacheConcurrency(t *testing.T) {
 		var wg1 sync.WaitGroup // Make sure goroutine is started
 		wg.Add(1)
 		wg1.Add(1)
-		go cache.Do(context.Background(), 1000, func(v int) error {
+		go cache.Do(context.Background(), 1000, func(_ context.Context, v int) error {
 			wg1.Done()
 			wg.Wait()
 			return nil
 		})
 		wg1.Wait()
-		missing, err := cache.DoWait(context.Background(), 1001, time.Nanosecond, func(ctx context.Context, v int) error {
+
+		ctx, cancel := contextutil.WithTimeoutCause(context.Background(), time.Nanosecond, errTimeout)
+		defer cancel()
+		missing, err := cache.Do(ctx, 1001, func(ctx context.Context, v int) error {
 			return nil
 		})
 		wg.Done()
 		assert.True(t, missing)
-		assert.Equal(t, ErrTimeOut, err)
+		assert.ErrorIs(t, err, context.Canceled)
+		assert.ErrorIs(t, context.Cause(ctx), errTimeout)
 	})
 
 	t.Run("test wait", func(t *testing.T) {
@@ -309,13 +325,16 @@ func TestLRUCacheConcurrency(t *testing.T) {
 		var wg1 sync.WaitGroup // Make sure goroutine is started
 
 		wg1.Add(1)
-		go cache.Do(context.Background(), 1000, func(v int) error {
+		go cache.Do(context.Background(), 1000, func(_ context.Context, v int) error {
 			wg1.Done()
 			time.Sleep(time.Second)
 			return nil
 		})
 		wg1.Wait()
-		missing, err := cache.DoWait(context.Background(), 1001, time.Second*2, func(ctx context.Context, v int) error {
+
+		ctx, cancel := contextutil.WithTimeoutCause(context.Background(), time.Second*2, errTimeout)
+		defer cancel()
+		missing, err := cache.Do(ctx, 1001, func(ctx context.Context, v int) error {
 			return nil
 		})
 		assert.True(t, missing)
@@ -337,7 +356,9 @@ func TestLRUCacheConcurrency(t *testing.T) {
 			go func(i int) {
 				defer wg.Done()
 				for j := 0; j < 100; j++ {
-					_, err := cache.DoWait(context.Background(), j, 2*time.Second, func(ctx context.Context, v int) error {
+					ctx, cancel := contextutil.WithTimeoutCause(context.Background(), 2*time.Second, errTimeout)
+					defer cancel()
+					_, err := cache.Do(ctx, j, func(_ context.Context, v int) error {
 						return nil
 					})
 					assert.NoError(t, err)
@@ -357,7 +378,9 @@ func TestLRUCacheConcurrency(t *testing.T) {
 		}).Build()
 
 		for i := 0; i < 100; i++ {
-			cache.DoWait(context.Background(), i, 2*time.Second, func(ctx context.Context, v int) error { return nil })
+			ctx, cancel := contextutil.WithTimeoutCause(context.Background(), 2*time.Second, errTimeout)
+			defer cancel()
+			cache.Do(ctx, i, func(ctx context.Context, v int) error { return nil })
 		}
 		var wg sync.WaitGroup
 		wg.Add(2)
@@ -374,7 +397,9 @@ func TestLRUCacheConcurrency(t *testing.T) {
 			defer wg.Done()
 			for i := 0; i < 10; i++ {
 				for j := 0; j < 100; j++ {
-					cache.DoWait(context.Background(), j, 2*time.Second, func(ctx context.Context, v int) error { return nil })
+					ctx, cancel := contextutil.WithTimeoutCause(context.Background(), 2*time.Second, errTimeout)
+					defer cancel()
+					cache.Do(ctx, j, func(ctx context.Context, v int) error { return nil })
 				}
 			}
 		}()
@@ -391,7 +416,9 @@ func TestLRUCacheConcurrency(t *testing.T) {
 		}).Build()
 
 		for i := 0; i < 100; i++ {
-			cache.DoWait(context.Background(), i, 2*time.Second, func(ctx context.Context, v int) error { return nil })
+			ctx, cancel := contextutil.WithTimeoutCause(context.Background(), 2*time.Second, errTimeout)
+			defer cancel()
+			cache.Do(ctx, i, func(ctx context.Context, v int) error { return nil })
 		}
 
 		evicted := 0
@@ -404,14 +431,19 @@ func TestLRUCacheConcurrency(t *testing.T) {
 
 		// all item shouldn't be evicted if they are in used.
 		for i := 0; i < 5; i++ {
-			cache.DoWait(context.Background(), i, 2*time.Second, func(ctx context.Context, v int) error { return nil })
+			ctx, cancel := contextutil.WithTimeoutCause(context.Background(), 2*time.Second, errTimeout)
+			defer cancel()
+			cache.Do(ctx, i, func(ctx context.Context, v int) error { return nil })
 		}
 		wg := sync.WaitGroup{}
 		wg.Add(5)
 		for i := 0; i < 5; i++ {
 			go func(i int) {
 				defer wg.Done()
-				cache.DoWait(context.Background(), i, 2*time.Second, func(ctx context.Context, v int) error {
+				ctx, cancel := contextutil.WithTimeoutCause(context.Background(), 2*time.Second, errTimeout)
+				defer cancel()
+
+				cache.Do(ctx, i, func(ctx context.Context, v int) error {
 					time.Sleep(2 * time.Second)
 					return nil
 				})

--- a/pkg/util/contextutil/context_util.go
+++ b/pkg/util/contextutil/context_util.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"google.golang.org/grpc/metadata"
 
@@ -83,4 +84,34 @@ func GetCurUserFromContext(ctx context.Context) (string, error) {
 	}
 	username := secrets[0]
 	return username, nil
+}
+
+// TODO: use context.WithTimeoutCause instead in go 1.21.0, then deprecated this function
+// !!! We cannot keep same implementation with context.WithDeadlineCause.
+// if cancel happens, context.WithTimeoutCause will return context.Err() == context.Timeout and context.Cause(ctx) == err.
+// if cancel happens, WithTimeoutCause will return context.Err() == context.Canceled and context.Cause(ctx) == err.
+func WithTimeoutCause(parent context.Context, timeout time.Duration, err error) (context.Context, context.CancelFunc) {
+	return WithDeadlineCause(parent, time.Now().Add(timeout), err)
+}
+
+// TODO: use context.WithDeadlineCause instead in go 1.21.0, then deprecated this function
+// !!! We cannot keep same implementation with context.WithDeadlineCause.
+// if cancel happens, context.WithDeadlineCause will return context.Err() == context.DeadlineExceeded and context.Cause(ctx) == err.
+// if cancel happens, WithDeadlineCause will return context.Err() == context.Canceled and context.Cause(ctx) == err.
+func WithDeadlineCause(parent context.Context, deadline time.Time, err error) (context.Context, context.CancelFunc) {
+	if parent == nil {
+		panic("cannot create context from nil parent")
+	}
+	if parentDeadline, ok := parent.Deadline(); ok && parentDeadline.Before(deadline) {
+		// The current deadline is already sooner than the new one.
+		return context.WithCancel(parent)
+	}
+	ctx, cancel := context.WithCancelCause(parent)
+	time.AfterFunc(time.Until(deadline), func() {
+		cancel(err)
+	})
+
+	return ctx, func() {
+		cancel(context.Canceled)
+	}
 }

--- a/pkg/util/merr/errors.go
+++ b/pkg/util/merr/errors.go
@@ -169,7 +169,7 @@ var (
 	ErrClusteringCompactionCollectionNotSupport   = newMilvusError("collection not support clustering compaction", 2302, false)
 	ErrClusteringCompactionCollectionIsCompacting = newMilvusError("collection is compacting", 2303, false)
 
-	//General
+	// General
 	ErrOperationNotSupported = newMilvusError("unsupported operation", 3000, false)
 )
 

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -1967,8 +1967,10 @@ type queryNodeConfig struct {
 	MmapDirPath      ParamItem `refreshable:"false"`
 	MmapEnabled      ParamItem `refreshable:"false"`
 
-	LazyLoadEnabled     ParamItem `refreshable:"false"`
-	LazyLoadWaitTimeout ParamItem `refreshable:"false"`
+	LazyLoadEnabled                      ParamItem `refreshable:"false"`
+	LazyLoadWaitTimeout                  ParamItem `refreshable:"true"`
+	LazyLoadRequestResourceTimeout       ParamItem `refreshable:"true"`
+	LazyLoadRequestResourceRetryInterval ParamItem `refreshable:"true"`
 
 	// chunk cache
 	ReadAheadPolicy     ParamItem `refreshable:"false"`
@@ -2205,18 +2207,36 @@ func (p *queryNodeConfig) init(base *BaseTable) {
 
 	p.LazyLoadEnabled = ParamItem{
 		Key:          "queryNode.lazyloadEnabled",
-		Version:      "2.4.0",
+		Version:      "2.4.2",
 		DefaultValue: "false",
 		Doc:          "Enable lazyload for loading data",
+		Export:       true,
 	}
 	p.LazyLoadEnabled.Init(base.mgr)
 	p.LazyLoadWaitTimeout = ParamItem{
 		Key:          "queryNode.lazyloadWaitTimeout",
-		Version:      "2.4.0",
+		Version:      "2.4.2",
 		DefaultValue: "30000",
 		Doc:          "max wait timeout duration in milliseconds before start to do lazyload search and retrieve",
+		Export:       true,
 	}
 	p.LazyLoadWaitTimeout.Init(base.mgr)
+	p.LazyLoadRequestResourceTimeout = ParamItem{
+		Key:          "queryNode.lazyLoadRequestResourceTimeout",
+		Version:      "2.4.2",
+		DefaultValue: "5000",
+		Doc:          "max timeout in milliseconds for waiting request resource for lazy load, 5s by default",
+		Export:       true,
+	}
+	p.LazyLoadRequestResourceTimeout.Init(base.mgr)
+	p.LazyLoadRequestResourceRetryInterval = ParamItem{
+		Key:          "queryNode.lazyLoadRequestResourceRetryInterval",
+		Version:      "2.4.2",
+		DefaultValue: "2000",
+		Doc:          "retry interval in milliseconds for waiting request resource for lazy load, 2s by default",
+		Export:       true,
+	}
+	p.LazyLoadRequestResourceRetryInterval.Init(base.mgr)
 
 	p.ReadAheadPolicy = ParamItem{
 		Key:          "queryNode.cache.readAheadPolicy",

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -366,9 +366,27 @@ func TestComponentParam(t *testing.T) {
 		params.Save("queryNode.memoryIndexLoadPredictMemoryUsageFactor", "2.0")
 		assert.Equal(t, 2.0, Params.MemoryIndexLoadPredictMemoryUsageFactor.GetAsFloat())
 
-		assert.NotZero(t, Params.DiskCacheCapacityLimit.GetAsInt64())
+		assert.NotZero(t, Params.DiskCacheCapacityLimit.GetAsSize())
 		params.Save("queryNode.diskCacheCapacityLimit", "70")
-		assert.Equal(t, int64(70), Params.DiskCacheCapacityLimit.GetAsInt64())
+		assert.Equal(t, int64(70), Params.DiskCacheCapacityLimit.GetAsSize())
+		params.Save("queryNode.diskCacheCapacityLimit", "70m")
+		assert.Equal(t, int64(70*1024*1024), Params.DiskCacheCapacityLimit.GetAsSize())
+
+		assert.False(t, Params.LazyLoadEnabled.GetAsBool())
+		params.Save("queryNode.lazyloadEnabled", "true")
+		assert.True(t, Params.LazyLoadEnabled.GetAsBool())
+
+		assert.Equal(t, 30*time.Second, Params.LazyLoadWaitTimeout.GetAsDuration(time.Millisecond))
+		params.Save("queryNode.lazyloadWaitTimeout", "100")
+		assert.Equal(t, 100*time.Millisecond, Params.LazyLoadWaitTimeout.GetAsDuration(time.Millisecond))
+
+		assert.Equal(t, 5*time.Second, Params.LazyLoadRequestResourceTimeout.GetAsDuration(time.Millisecond))
+		params.Save("queryNode.lazyLoadRequestResourceTimeout", "100")
+		assert.Equal(t, 100*time.Millisecond, Params.LazyLoadRequestResourceTimeout.GetAsDuration(time.Millisecond))
+
+		assert.Equal(t, 2*time.Second, Params.LazyLoadRequestResourceRetryInterval.GetAsDuration(time.Millisecond))
+		params.Save("queryNode.lazyLoadRequestResourceRetryInterval", "3000")
+		assert.Equal(t, 3*time.Second, Params.LazyLoadRequestResourceRetryInterval.GetAsDuration(time.Millisecond))
 	})
 
 	t.Run("test dataCoordConfig", func(t *testing.T) {


### PR DESCRIPTION
issue: #32663

- use new param to control request resource timeout for lazy load。
- remove the timeout parameter of `Do`, remove `DoWait`. use `context` to control the timeout.
- use `VersionedNotifier` to avoid notify event lost and broadcast, remove the redundant goroutine in cache.