### PR TITLE
enhance: [skip e2e] Enlarge integration test timeout to 90min

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -198,7 +198,7 @@ jobs:
     name: Integration Test
     needs: Build
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - name: Maximize build space
         uses: easimon/maximize-build-space@master


### PR DESCRIPTION
The running time of integration is above 50 minutes and may surpass 60 and timeout in some cases. This PR enlarge timeout first.