### PR TITLE
fix: add request resource timeout for lazy load, refactor context usage in cache

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -102,7 +102,9 @@ minio:
   region:  # Specify minio storage system location region
   useVirtualHost: false # Whether use virtual host mode for bucket
   requestTimeoutMs: 10000 # minio timeout for request time in milliseconds
-  listObjectsMaxKeys: 0 # The maximum number of objects requested per batch in minio ListObjects rpc, 0 means using oss client by default, decrease these configration if ListObjects timeout
+  # The maximum number of objects requested per batch in minio ListObjects rpc, 
+  # 0 means using oss client by default, decrease these configration if ListObjects timeout
+  listObjectsMaxKeys: 0
 
 # Milvus supports four MQ: rocksmq(based on RockDB), natsmq(embedded nats-server), Pulsar and Kafka.
 # You can change your mq by setting mq.type field.
@@ -214,6 +216,7 @@ proxy:
   ginLogging: true
   ginLogSkipPaths: / # skip url path for gin log
   maxTaskNum: 1024 # max task number of proxy task queue
+  mustUsePartitionKey: false # switch for whether proxy must use partition key for the collection
   accessLog:
     enable: false # if use access log
     minioEnable: false # if upload sealed access log file to minio
@@ -335,6 +338,9 @@ queryNode:
     mmapEnabled: false # Enable mmap for loading data
   mmapEnabled: false # Enable mmap for loading data
   lazyloadEnabled: false # Enable lazyload for loading data
+  lazyloadWaitTimeout: 30000 # max wait timeout duration in milliseconds before start to do lazyload search and retrieve
+  lazyLoadRequestResourceTimeout: 5000 # max timeout in milliseconds for waiting request resource for lazy load, 5s by default
+  lazyLoadRequestResourceRetryInterval: 2000 # retry interval in milliseconds for waiting request resource for lazy load, 2s by default
   grouping:
     enabled: true
     maxNQ: 1000
@@ -367,7 +373,6 @@ queryNode:
       maxQueueLength: 16 # Maximum length of task queue in flowgraph
       maxParallelism: 1024 # Maximum number of tasks executed in parallel in the flowgraph
   enableSegmentPrune: false # use partition prune function on shard delegator
-  useStreamComputing: false
   ip:  # if not specified, use the first unicastable address
   port: 21123
   grpc:
@@ -717,6 +722,7 @@ quotaAndLimits:
   limits:
     maxCollectionNum: 65536
     maxCollectionNumPerDB: 65536
+    maxInsertSize: -1 # maximum size of a single insert request, in bytes, -1 means no limit
     maxResourceGroupNumOfQueryNode: 1024 # maximum number of resource groups of query nodes
   limitWriting:
     # forceDeny false means dml requests are allowed (except for some

--- a/internal/querynodev2/segments/manager.go
+++ b/internal/querynodev2/segments/manager.go
@@ -156,7 +156,7 @@ type Manager struct {
 }
 
 func NewManager() *Manager {
-	diskCap := paramtable.Get().QueryNodeCfg.DiskCacheCapacityLimit.GetAsInt64()
+	diskCap := paramtable.Get().QueryNodeCfg.DiskCacheCapacityLimit.GetAsSize()
 
 	segMgr := NewSegmentManager()
 	sf := singleflight.Group{}

--- a/internal/querynodev2/segments/search.go
+++ b/internal/querynodev2/segments/search.go
@@ -20,18 +20,15 @@ import (
 	"context"
 	"fmt"
 	"sync"
-	"time"
 
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
-	"github.com/milvus-io/milvus/internal/querycoordv2/params"
 	"github.com/milvus-io/milvus/internal/querynodev2/segments/metricsutil"
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/metrics"
-	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/util/timerecord"
 )
@@ -82,15 +79,16 @@ func searchSegments(ctx context.Context, mgr *Manager, segments []Segment, segTy
 			}()
 
 			if seg.IsLazyLoad() {
-				var timeout time.Duration
-				timeout, err = lazyloadWaitTimeout(ctx)
-				if err != nil {
-					return err
-				}
+				ctx, cancel := withLazyLoadTimeoutContext(ctx)
+				defer cancel()
+
 				var missing bool
-				missing, err = mgr.DiskCache.DoWait(ctx, seg.ID(), timeout, searcher)
+				missing, err = mgr.DiskCache.Do(ctx, seg.ID(), searcher)
 				if missing {
 					accessRecord.CacheMissing()
+				}
+				if err != nil {
+					log.Warn("failed to do search for disk cache", zap.Int64("segID", seg.ID()), zap.Error(err))
 				}
 				return err
 			}
@@ -171,18 +169,16 @@ func searchSegmentsStreamly(ctx context.Context,
 			}()
 			if seg.IsLazyLoad() {
 				log.Debug("before doing stream search in DiskCache", zap.Int64("segID", seg.ID()))
-				var timeout time.Duration
-				timeout, err = lazyloadWaitTimeout(ctx)
-				if err != nil {
-					return err
-				}
+				ctx, cancel := withLazyLoadTimeoutContext(ctx)
+				defer cancel()
+
 				var missing bool
-				missing, err = mgr.DiskCache.DoWait(ctx, seg.ID(), timeout, searcher)
+				missing, err = mgr.DiskCache.Do(ctx, seg.ID(), searcher)
 				if missing {
 					accessRecord.CacheMissing()
 				}
 				if err != nil {
-					log.Error("failed to do search for disk cache", zap.Int64("seg_id", seg.ID()), zap.Error(err))
+					log.Warn("failed to do search for disk cache", zap.Int64("segID", seg.ID()), zap.Error(err))
 				}
 				log.Debug("after doing stream search in DiskCache", zap.Int64("segID", seg.ID()), zap.Error(err))
 				return err
@@ -201,20 +197,6 @@ func searchSegmentsStreamly(ctx context.Context,
 		metrics.StreamReduce).Observe(float64(sumReduceDuration.Load().Milliseconds()))
 	log.Debug("stream reduce sum duration:", zap.Duration("duration", sumReduceDuration.Load()))
 	return nil
-}
-
-func lazyloadWaitTimeout(ctx context.Context) (time.Duration, error) {
-	timeout := params.Params.QueryNodeCfg.LazyLoadWaitTimeout.GetAsDuration(time.Millisecond)
-	deadline, ok := ctx.Deadline()
-	if ok {
-		remain := time.Until(deadline)
-		if remain <= 0 {
-			return -1, merr.WrapErrServiceInternal("search context deadline exceeded")
-		} else if remain < timeout {
-			timeout = remain
-		}
-	}
-	return timeout, nil
 }
 
 // search will search on the historical segments the target segments in historical.

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -54,6 +54,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/metrics"
 	"github.com/milvus-io/milvus/pkg/util/conc"
+	"github.com/milvus-io/milvus/pkg/util/contextutil"
 	"github.com/milvus-io/milvus/pkg/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/util/hardware"
 	"github.com/milvus-io/milvus/pkg/util/merr"
@@ -1119,15 +1120,35 @@ func (loader *segmentLoader) LoadLazySegment(ctx context.Context,
 	segment *LocalSegment,
 	loadInfo *querypb.SegmentLoadInfo,
 ) (err error) {
-	infos := []*querypb.SegmentLoadInfo{loadInfo}
-	resource, _, err := loader.requestResource(ctx, infos...)
-	log := log.Ctx(ctx)
+	resource, _, err := loader.requestResourceWithTimeout(ctx, loadInfo)
 	if err != nil {
-		log.Warn("request resource failed", zap.Error(err))
-		return merr.ErrServiceResourceInsufficient
+		log.Ctx(ctx).Warn("request resource failed", zap.Error(err))
+		return err
 	}
 	defer loader.freeRequest(resource)
+
 	return loader.LoadSegment(ctx, segment, loadInfo)
+}
+
+// requestResourceWithTimeout requests memory & storage to load segments with a timeout and retry.
+func (loader *segmentLoader) requestResourceWithTimeout(ctx context.Context, infos ...*querypb.SegmentLoadInfo) (LoadResource, int, error) {
+	timeout := paramtable.Get().QueryNodeCfg.LazyLoadRequestResourceTimeout.GetAsDuration(time.Millisecond)
+	retryInterval := paramtable.Get().QueryNodeCfg.LazyLoadRequestResourceRetryInterval.GetAsDuration(time.Millisecond)
+
+	// TODO: use context.WithTimeoutCause instead of contextutil.WithTimeoutCause in go1.21
+	ctx, cancel := contextutil.WithTimeoutCause(ctx, timeout, merr.ErrServiceResourceInsufficient)
+	defer cancel()
+	for {
+		resource, concurrencyLevel, err := loader.requestResource(ctx, infos...)
+		if err == nil {
+			return resource, concurrencyLevel, nil
+		}
+		select {
+		case <-ctx.Done():
+			return LoadResource{}, -1, context.Cause(ctx)
+		case <-time.After(retryInterval):
+		}
+	}
 }
 
 func (loader *segmentLoader) filterPKStatsBinlogs(fieldBinlogs []*datapb.FieldBinlog, pkFieldID int64) ([]string, storage.StatsLogType) {

--- a/internal/querynodev2/segments/utils.go
+++ b/internal/querynodev2/segments/utils.go
@@ -13,10 +13,12 @@ import "C"
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"fmt"
 	"io"
 	"strconv"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -27,8 +29,13 @@ import (
 	"github.com/milvus-io/milvus/pkg/common"
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/mq/msgstream"
+	"github.com/milvus-io/milvus/pkg/util/contextutil"
+	"github.com/milvus-io/milvus/pkg/util/merr"
+	"github.com/milvus-io/milvus/pkg/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
+
+var errLazyLoadTimeout = merr.WrapErrServiceInternal("lazy load time out")
 
 func GetPkField(schema *schemapb.CollectionSchema) *schemapb.FieldSchema {
 	for _, field := range schema.GetFields() {
@@ -191,4 +198,11 @@ func FilterZeroValuesFromSlice(intVals []int64) []int64 {
 		}
 	}
 	return result
+}
+
+// withLazyLoadTimeoutContext returns a new context with lazy load timeout.
+func withLazyLoadTimeoutContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	lazyLoadTimeout := paramtable.Get().QueryNodeCfg.LazyLoadWaitTimeout.GetAsDuration(time.Millisecond)
+	// TODO: use context.WithTimeoutCause instead of contextutil.WithTimeoutCause in go1.21
+	return contextutil.WithTimeoutCause(ctx, lazyLoadTimeout, errLazyLoadTimeout)
 }

--- a/pkg/util/cache/cache.go
+++ b/pkg/util/cache/cache.go
@@ -28,12 +28,12 @@ import (
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/merr"
+	"github.com/milvus-io/milvus/pkg/util/syncutil"
 )
 
 var (
 	ErrNoSuchItem     = merr.WrapErrServiceInternal("no such item")
 	ErrNotEnoughSpace = merr.WrapErrServiceInternal("not enough space")
-	ErrTimeOut        = merr.WrapErrServiceInternal("time out")
 )
 
 type cacheItem[K comparable, V any] struct {
@@ -145,13 +145,8 @@ type Cache[K comparable, V any] interface {
 	// Do the operation `doer` on the given key `key`. The key is kept in the cache until the operation
 	// completes.
 	// Throws `ErrNoSuchItem` if the key is not found or not able to be loaded from given loader.
-	// Throws `ErrNotEnoughSpace` if there is no room for the operation.
-	Do(ctx context.Context, key K, doer func(V) error) (missing bool, err error)
-	// Do the operation `doer` on the given key `key`. The key is kept in the cache until the operation
-	// completes. The function waits for `timeout` if there is not enough space for the given key.
-	// Throws `ErrNoSuchItem` if the key is not found or not able to be loaded from given loader.
-	// Throws `ErrTimeOut` if timed out.
-	DoWait(ctx context.Context, key K, timeout time.Duration, doer func(context.Context, V) error) (missing bool, err error)
+	Do(ctx context.Context, key K, doer func(context.Context, V) error) (missing bool, err error)
+
 	// Get stats
 	Stats() *Stats
 
@@ -163,18 +158,6 @@ type Cache[K comparable, V any] interface {
 	Expire(ctx context.Context, key K) (evicted bool)
 }
 
-type Waiter[K comparable] struct {
-	key K
-	c   *sync.Cond
-}
-
-func newWaiter[K comparable](key K) Waiter[K] {
-	return Waiter[K]{
-		key: key,
-		c:   sync.NewCond(&sync.Mutex{}),
-	}
-}
-
 // lruCache extends the ccache library to provide pinning and unpinning of items.
 type lruCache[K comparable, V any] struct {
 	rwlock sync.RWMutex
@@ -183,7 +166,7 @@ type lruCache[K comparable, V any] struct {
 	accessList     *list.List
 	loaderKeyLocks *lock.KeyLock[K]
 	stats          *Stats
-	waitQueue      *list.List
+	waitNotifier   *syncutil.VersionedNotifier
 
 	loader    Loader[K, V]
 	finalizer Finalizer[K, V]
@@ -254,7 +237,7 @@ func newLRUCache[K comparable, V any](
 	return &lruCache[K, V]{
 		items:          make(map[K]*list.Element),
 		accessList:     list.New(),
-		waitQueue:      list.New(),
+		waitNotifier:   syncutil.NewVersionedNotifier(),
 		loaderKeyLocks: lock.NewKeyLock[K](),
 		stats:          new(Stats),
 		loader:         loader,
@@ -264,75 +247,24 @@ func newLRUCache[K comparable, V any](
 	}
 }
 
-// Do picks up an item from cache and executes doer. The entry of interest is garented in the cache when doer is executing.
-func (c *lruCache[K, V]) Do(ctx context.Context, key K, doer func(V) error) (bool, error) {
-	item, missing, err := c.getAndPin(ctx, key)
-	if err != nil {
-		return missing, err
-	}
-	defer c.Unpin(key)
-	return missing, doer(item.value)
-}
-
-func (c *lruCache[K, V]) DoWait(ctx context.Context, key K, timeout time.Duration, doer func(context.Context, V) error) (bool, error) {
-	timedWait := func(cond *sync.Cond, timeout time.Duration) error {
-		if timeout <= 0 {
-			return ErrTimeOut // timed out
-		}
-		c := make(chan struct{})
-		go func() {
-			cond.L.Lock()
-			defer cond.L.Unlock()
-			defer close(c)
-			cond.Wait()
-		}()
-		select {
-		case <-c:
-			return nil // completed normally
-		case <-time.After(timeout):
-			return ErrTimeOut // timed out
-		case <-ctx.Done():
-			return ctx.Err() // context timeout
-		}
-	}
-
-	var ele *list.Element
-	defer func() {
-		if ele != nil {
-			c.rwlock.Lock()
-			c.waitQueue.Remove(ele)
-			c.rwlock.Unlock()
-		}
-	}()
-	start := time.Now()
+func (c *lruCache[K, V]) Do(ctx context.Context, key K, doer func(context.Context, V) error) (bool, error) {
 	log := log.Ctx(ctx).With(zap.Any("key", key))
 	for {
+		// Get a listener before getAndPin to avoid missing the notification.
+		listener := c.waitNotifier.Listen(syncutil.VersionedListenAtLatest)
+
 		item, missing, err := c.getAndPin(ctx, key)
 		if err == nil {
 			defer c.Unpin(key)
 			return missing, doer(ctx, item.value)
-		} else if err == ErrNotEnoughSpace {
-			log.Warn("Failed to get disk cache for segment, wait and try again")
-		} else if err == merr.ErrServiceResourceInsufficient {
-			log.Warn("Failed to load segment for insufficient resource, wait and try later")
-		} else if err != nil {
+		} else if err != ErrNotEnoughSpace {
 			return true, err
 		}
-		if ele == nil {
-			// If no enough space, enqueue the key
-			c.rwlock.Lock()
-			waiter := newWaiter(key)
-			ele = c.waitQueue.PushBack(&waiter)
-			log.Info("push waiter into waiter queue", zap.Any("key", key))
-			c.rwlock.Unlock()
-		}
-		// Wait for the key to be available
-		timeLeft := time.Until(start.Add(timeout))
-		if err = timedWait(ele.Value.(*Waiter[K]).c, timeLeft); err != nil {
-			log.Warn("failed to get item for key",
-				zap.Any("key", key),
-				zap.Int("wait_len", c.waitQueue.Len()),
-				zap.Error(err))
+		log.Warn("Failed to get disk cache for segment, wait and try again", zap.Error(err))
+
+		// wait for the listener to be notified.
+		if err := listener.Wait(ctx); err != nil {
+			log.Warn("failed to get item for key with timeout", zap.Error(context.Cause(ctx)))
 			return true, err
 		}
 	}
@@ -353,20 +285,11 @@ func (c *lruCache[K, V]) Unpin(key K) {
 	item.pinCount.Dec()
 
 	log := log.With(zap.Any("UnPinedKey", key))
-	if item.pinCount.Load() == 0 && c.waitQueue.Len() > 0 {
+	if item.pinCount.Load() == 0 {
 		log.Debug("Unpin item to zero ref, trigger activating waiters")
-		// Notify waiters
-		// collector := c.scavenger.Spare(key)
-		for e := c.waitQueue.Front(); e != nil; e = e.Next() {
-			w := e.Value.(*Waiter[K])
-			log.Info("try to activate waiter", zap.Any("activated_waiter_key", w.key))
-			w.c.Broadcast()
-			// we try best to activate as many waiters as possible every time
-		}
+		c.waitNotifier.NotifyAll()
 	} else {
-		log.Debug("Miss to trigger activating waiters",
-			zap.Int32("PinCount", item.pinCount.Load()),
-			zap.Int("wait_len", c.waitQueue.Len()))
+		log.Debug("Miss to trigger activating waiters", zap.Int32("PinCount", item.pinCount.Load()))
 	}
 }
 

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -1994,8 +1994,10 @@ type queryNodeConfig struct {
 	MmapDirPath      ParamItem `refreshable:"false"`
 	MmapEnabled      ParamItem `refreshable:"false"`
 
-	LazyLoadEnabled     ParamItem `refreshable:"false"`
-	LazyLoadWaitTimeout ParamItem `refreshable:"false"`
+	LazyLoadEnabled                      ParamItem `refreshable:"false"`
+	LazyLoadWaitTimeout                  ParamItem `refreshable:"true"`
+	LazyLoadRequestResourceTimeout       ParamItem `refreshable:"true"`
+	LazyLoadRequestResourceRetryInterval ParamItem `refreshable:"true"`
 
 	// chunk cache
 	ReadAheadPolicy     ParamItem `refreshable:"false"`
@@ -2233,7 +2235,7 @@ func (p *queryNodeConfig) init(base *BaseTable) {
 
 	p.LazyLoadEnabled = ParamItem{
 		Key:          "queryNode.lazyloadEnabled",
-		Version:      "2.4.0",
+		Version:      "2.4.2",
 		DefaultValue: "false",
 		Doc:          "Enable lazyload for loading data",
 		Export:       true,
@@ -2241,11 +2243,28 @@ func (p *queryNodeConfig) init(base *BaseTable) {
 	p.LazyLoadEnabled.Init(base.mgr)
 	p.LazyLoadWaitTimeout = ParamItem{
 		Key:          "queryNode.lazyloadWaitTimeout",
-		Version:      "2.4.0",
+		Version:      "2.4.2",
 		DefaultValue: "30000",
 		Doc:          "max wait timeout duration in milliseconds before start to do lazyload search and retrieve",
+		Export:       true,
 	}
 	p.LazyLoadWaitTimeout.Init(base.mgr)
+	p.LazyLoadRequestResourceTimeout = ParamItem{
+		Key:          "queryNode.lazyLoadRequestResourceTimeout",
+		Version:      "2.4.2",
+		DefaultValue: "5000",
+		Doc:          "max timeout in milliseconds for waiting request resource for lazy load, 5s by default",
+		Export:       true,
+	}
+	p.LazyLoadRequestResourceTimeout.Init(base.mgr)
+	p.LazyLoadRequestResourceRetryInterval = ParamItem{
+		Key:          "queryNode.lazyLoadRequestResourceRetryInterval",
+		Version:      "2.4.2",
+		DefaultValue: "2000",
+		Doc:          "retry interval in milliseconds for waiting request resource for lazy load, 2s by default",
+		Export:       true,
+	}
+	p.LazyLoadRequestResourceRetryInterval.Init(base.mgr)
 
 	p.ReadAheadPolicy = ParamItem{
 		Key:          "queryNode.cache.readAheadPolicy",

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -378,9 +378,27 @@ func TestComponentParam(t *testing.T) {
 		params.Save("queryNode.memoryIndexLoadPredictMemoryUsageFactor", "2.0")
 		assert.Equal(t, 2.0, Params.MemoryIndexLoadPredictMemoryUsageFactor.GetAsFloat())
 
-		assert.NotZero(t, Params.DiskCacheCapacityLimit.GetAsInt64())
+		assert.NotZero(t, Params.DiskCacheCapacityLimit.GetAsSize())
 		params.Save("queryNode.diskCacheCapacityLimit", "70")
-		assert.Equal(t, int64(70), Params.DiskCacheCapacityLimit.GetAsInt64())
+		assert.Equal(t, int64(70), Params.DiskCacheCapacityLimit.GetAsSize())
+		params.Save("queryNode.diskCacheCapacityLimit", "70m")
+		assert.Equal(t, int64(70*1024*1024), Params.DiskCacheCapacityLimit.GetAsSize())
+
+		assert.False(t, Params.LazyLoadEnabled.GetAsBool())
+		params.Save("queryNode.lazyloadEnabled", "true")
+		assert.True(t, Params.LazyLoadEnabled.GetAsBool())
+
+		assert.Equal(t, 30*time.Second, Params.LazyLoadWaitTimeout.GetAsDuration(time.Millisecond))
+		params.Save("queryNode.lazyloadWaitTimeout", "100")
+		assert.Equal(t, 100*time.Millisecond, Params.LazyLoadWaitTimeout.GetAsDuration(time.Millisecond))
+
+		assert.Equal(t, 5*time.Second, Params.LazyLoadRequestResourceTimeout.GetAsDuration(time.Millisecond))
+		params.Save("queryNode.lazyLoadRequestResourceTimeout", "100")
+		assert.Equal(t, 100*time.Millisecond, Params.LazyLoadRequestResourceTimeout.GetAsDuration(time.Millisecond))
+
+		assert.Equal(t, 2*time.Second, Params.LazyLoadRequestResourceRetryInterval.GetAsDuration(time.Millisecond))
+		params.Save("queryNode.lazyLoadRequestResourceRetryInterval", "3000")
+		assert.Equal(t, 3*time.Second, Params.LazyLoadRequestResourceRetryInterval.GetAsDuration(time.Millisecond))
 	})
 
 	t.Run("test dataCoordConfig", func(t *testing.T) {

--- a/pkg/util/paramtable/param_item.go
+++ b/pkg/util/paramtable/param_item.go
@@ -223,6 +223,34 @@ func (pi *ParamItem) GetAsRoleDetails() map[string](map[string]([](map[string]st
 	return getAndConvert(pi.GetValue(), funcutil.JSONToRoleDetails, nil)
 }
 
+func (pi *ParamItem) GetAsSize() int64 {
+	valueStr := strings.ToLower(pi.GetValue())
+	if strings.HasSuffix(valueStr, "g") || strings.HasSuffix(valueStr, "gb") {
+		size, err := strconv.ParseInt(strings.Split(valueStr, "g")[0], 10, 64)
+		if err != nil {
+			return 0
+		}
+		return size * 1024 * 1024 * 1024
+	} else if strings.HasSuffix(valueStr, "m") || strings.HasSuffix(valueStr, "mb") {
+		size, err := strconv.ParseInt(strings.Split(valueStr, "m")[0], 10, 64)
+		if err != nil {
+			return 0
+		}
+		return size * 1024 * 1024
+	} else if strings.HasSuffix(valueStr, "k") || strings.HasSuffix(valueStr, "kb") {
+		size, err := strconv.ParseInt(strings.Split(valueStr, "k")[0], 10, 64)
+		if err != nil {
+			return 0
+		}
+		return size * 1024
+	}
+	size, err := strconv.ParseInt(valueStr, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return size
+}
+
 type CompositeParamItem struct {
 	Items  []*ParamItem
 	Format func(map[string]string) string


### PR DESCRIPTION
issue: #32663

- Use new param to control request resource timeout for lazy load.

- Remove the timeout parameter of `Do`, remove `DoWait`. use `context` to control the timeout.

- Use `VersionedNotifier` to avoid notify event lost and broadcast, remove the redundant goroutine in cache.

related dev pr: #32684