### PR TITLE
enhance: [2.4]Add EnableLevelZeroCompaction config

### DIFF
--- a/internal/datacoord/compaction_trigger_v2.go
+++ b/internal/datacoord/compaction_trigger_v2.go
@@ -103,11 +103,12 @@ func (m *CompactionTriggerManager) SubmitL0ViewToScheduler(taskID int64, outView
 
 	// TODO, remove handler, use scheduler
 	// m.scheduler.Submit(plan)
-	m.handler.execCompactionPlan(signal, plan)
+	err := m.handler.execCompactionPlan(signal, plan)
 	log.Info("Finish to submit a LevelZeroCompaction plan",
 		zap.Int64("taskID", taskID),
 		zap.Int64("planID", plan.GetPlanID()),
 		zap.String("type", plan.GetType().String()),
+		zap.Error(err),
 	)
 }
 

--- a/internal/datanode/services.go
+++ b/internal/datanode/services.go
@@ -302,6 +302,9 @@ func (node *DataNode) SyncSegments(ctx context.Context, req *datapb.SyncSegments
 
 	if len(req.GetCompactedFrom()) <= 0 {
 		log.Info("SyncSegments with empty compactedFrom, clearing the plan")
+		// remove from executing
+		node.compactionExecutor.stopTask(req.GetPlanID())
+		// remove from completing
 		node.compactionExecutor.injectDone(req.GetPlanID())
 		return merr.Success(), nil
 	}

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -2626,6 +2626,7 @@ type dataCoordConfig struct {
 
 	// LevelZero Segment
 	EnableLevelZeroSegment                   ParamItem `refreshable:"false"`
+	EnableLevelZeroCompaction                ParamItem `refreshable:"true"`
 	LevelZeroCompactionTriggerMinSize        ParamItem `refreshable:"true"`
 	LevelZeroCompactionTriggerMaxSize        ParamItem `refreshable:"true"`
 	LevelZeroCompactionTriggerDeltalogMinNum ParamItem `refreshable:"true"`
@@ -2949,10 +2950,18 @@ During compaction, the size of segment # of rows is able to exceed segment max #
 	p.EnableLevelZeroSegment = ParamItem{
 		Key:          "dataCoord.segment.enableLevelZero",
 		Version:      "2.4.0",
-		Doc:          "Whether to enable LevelZeroCompaction",
+		Doc:          "Whether to enable LevelZero Segment",
 		DefaultValue: "true",
 	}
 	p.EnableLevelZeroSegment.Init(base.mgr)
+
+	p.EnableLevelZeroCompaction = ParamItem{
+		Key:          "dataCoord.compaction.enableLevelZeroCompaction",
+		Version:      "2.4.0",
+		Doc:          "Whether to enable LevelZeroCompaction",
+		DefaultValue: "true",
+	}
+	p.EnableLevelZeroCompaction.Init(base.mgr)
 
 	p.LevelZeroCompactionTriggerMinSize = ParamItem{
 		Key:          "dataCoord.compaction.levelzero.forceTrigger.minSize",


### PR DESCRIPTION
Enabled by default and to make it dynamic, when disabled:

1. Skip to trigger L0 compaction
2. Check and skip submitting L0 compaction when enqueuePlans
3. Check and clear pipelining L0 compaction when schedule
4. Discard executing L0 compaction plans in DN

See also: #32817
pr: #32787 