### PR TITLE
enhance: Add EnableLevelZeroCompaction config

### DIFF
--- a/internal/datacoord/compaction.go
+++ b/internal/datacoord/compaction.go
@@ -34,6 +34,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/tracer"
 	"github.com/milvus-io/milvus/pkg/util/conc"
 	"github.com/milvus-io/milvus/pkg/util/merr"
+	"github.com/milvus-io/milvus/pkg/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/util/tsoutil"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
@@ -165,6 +166,19 @@ func (c *compactionPlanHandler) GetCurrentTS() (Timestamp, error) {
 }
 
 func (c *compactionPlanHandler) schedule() {
+	if !paramtable.Get().DataCoordCfg.EnableLevelZeroCompaction.GetAsBool() {
+		// remove pipelining L0 tasks
+		pipeliningTasks := c.getTasksByState(pipelining)
+		for _, task := range pipeliningTasks {
+			if task.plan.GetType() == datapb.CompactionType_Level0DeleteCompaction {
+				c.updateTask(task.plan.PlanID, setState(failed), endSpan())
+				c.setSegmentsCompacting(task.plan, true)
+				c.scheduler.Finish(task.dataNodeID, task.plan)
+				log.Warn("Discard LevelZeore compaction plans for LevelZero compaction disabled", zap.Int64("planID", task.plan.GetPlanID()))
+			}
+		}
+	}
+
 	// schedule queuing tasks
 	tasks := c.scheduler.Schedule()
 	if len(tasks) > 0 {
@@ -277,6 +291,12 @@ func (c *compactionPlanHandler) updateTask(planID int64, opts ...compactionTaskO
 }
 
 func (c *compactionPlanHandler) enqueuePlan(signal *compactionSignal, plan *datapb.CompactionPlan) error {
+	if !paramtable.Get().DataCoordCfg.EnableLevelZeroCompaction.GetAsBool() &&
+		plan.GetType() == datapb.CompactionType_Level0DeleteCompaction {
+		log.Error("failed to enqueuePlan, level zero compaction disabled", zap.Int64("planID", plan.GetPlanID()))
+		return errors.New("levelzero compaction is not enabled")
+	}
+
 	nodeID, err := c.chManager.FindWatcher(plan.GetChannel())
 	if err != nil {
 		log.Error("failed to find watcher", zap.Int64("planID", plan.GetPlanID()), zap.Error(err))
@@ -548,6 +568,7 @@ func (c *compactionPlanHandler) updateCompaction(ts Timestamp) error {
 
 		if nodePlan, ok := planStates[planID]; ok {
 			planResult := nodePlan.B
+
 			switch planResult.GetState() {
 			case commonpb.CompactionState_Completed:
 				log.Info("start to complete compaction")
@@ -574,6 +595,20 @@ func (c *compactionPlanHandler) updateCompaction(ts Timestamp) error {
 				}
 
 			case commonpb.CompactionState_Executing:
+				// Discard l0 plans executing in DataNode when disabled level zero compaction
+				if !paramtable.Get().DataCoordCfg.EnableLevelZeroCompaction.GetAsBool() &&
+					task.plan.GetType() == datapb.CompactionType_Level0DeleteCompaction {
+					log.Warn("compaction failed for level zero compaction disabled")
+					if err := c.sessions.SyncSegments(task.dataNodeID, &datapb.SyncSegmentsRequest{PlanID: planID}); err != nil {
+						log.Warn("compaction failed to sync segments with node", zap.Error(err))
+						continue
+					}
+					c.plans[planID] = c.plans[planID].shadowClone(setState(failed), endSpan())
+					c.setSegmentsCompacting(task.plan, false)
+					c.scheduler.Finish(task.dataNodeID, task.plan)
+					continue
+				}
+
 				if c.isTimeout(ts, task.plan.GetStartTime(), task.plan.GetTimeoutInSeconds()) {
 					log.Warn("compaction timeout",
 						zap.Int32("timeout in seconds", task.plan.GetTimeoutInSeconds()),
@@ -623,11 +658,12 @@ func (c *compactionPlanHandler) updateCompaction(ts Timestamp) error {
 		return planState.B.GetState() == commonpb.CompactionState_Completed
 	})
 
-	unkonwnPlansInWorker, _ := lo.Difference(lo.Keys(completedPlans), cachedPlans)
-	for _, planID := range unkonwnPlansInWorker {
-		if nodeUnkonwnPlan, ok := completedPlans[planID]; ok {
-			nodeID, plan := nodeUnkonwnPlan.A, nodeUnkonwnPlan.B
-			log := log.With(zap.Int64("planID", planID), zap.Int64("nodeID", nodeID), zap.String("channel", plan.GetChannel()))
+	unknownPlansInWorker, _ := lo.Difference(lo.Keys(completedPlans), cachedPlans)
+
+	for _, planID := range unknownPlansInWorker {
+		if nodeUnknownPlan, ok := completedPlans[planID]; ok {
+			nodeID, plan := nodeUnknownPlan.A, nodeUnknownPlan.B
+			log := log.With(zap.Int64("planID", planID), zap.String("type", plan.GetType().String()), zap.Int64("nodeID", nodeID), zap.String("channel", plan.GetChannel()))
 
 			// Sync segments without CompactionFrom segmentsIDs to make sure DN clear the task
 			// without changing the meta

--- a/internal/datacoord/compaction_trigger_v2.go
+++ b/internal/datacoord/compaction_trigger_v2.go
@@ -103,11 +103,12 @@ func (m *CompactionTriggerManager) SubmitL0ViewToScheduler(taskID int64, outView
 
 	// TODO, remove handler, use scheduler
 	// m.scheduler.Submit(plan)
-	m.handler.execCompactionPlan(signal, plan)
+	err := m.handler.execCompactionPlan(signal, plan)
 	log.Info("Finish to submit a LevelZeroCompaction plan",
 		zap.Int64("taskID", taskID),
 		zap.Int64("planID", plan.GetPlanID()),
 		zap.String("type", plan.GetType().String()),
+		zap.Error(err),
 	)
 }
 

--- a/internal/datanode/services.go
+++ b/internal/datanode/services.go
@@ -302,6 +302,9 @@ func (node *DataNode) SyncSegments(ctx context.Context, req *datapb.SyncSegments
 
 	if len(req.GetCompactedFrom()) <= 0 {
 		log.Info("SyncSegments with empty compactedFrom, clearing the plan")
+		// remove from executing
+		node.compactionExecutor.stopTask(req.GetPlanID())
+		// remove from completing
 		node.compactionExecutor.injectDone(req.GetPlanID())
 		return merr.Success(), nil
 	}

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -2693,6 +2693,7 @@ type dataCoordConfig struct {
 
 	// LevelZero Segment
 	EnableLevelZeroSegment                   ParamItem `refreshable:"false"`
+	EnableLevelZeroCompaction                ParamItem `refreshable:"true"`
 	LevelZeroCompactionTriggerMinSize        ParamItem `refreshable:"true"`
 	LevelZeroCompactionTriggerMaxSize        ParamItem `refreshable:"true"`
 	LevelZeroCompactionTriggerDeltalogMinNum ParamItem `refreshable:"true"`
@@ -3034,10 +3035,18 @@ During compaction, the size of segment # of rows is able to exceed segment max #
 	p.EnableLevelZeroSegment = ParamItem{
 		Key:          "dataCoord.segment.enableLevelZero",
 		Version:      "2.4.0",
-		Doc:          "Whether to enable LevelZeroCompaction",
+		Doc:          "Whether to enable LevelZero Segment",
 		DefaultValue: "true",
 	}
 	p.EnableLevelZeroSegment.Init(base.mgr)
+
+	p.EnableLevelZeroCompaction = ParamItem{
+		Key:          "dataCoord.compaction.enableLevelZeroCompaction",
+		Version:      "2.4.0",
+		Doc:          "Whether to enable LevelZeroCompaction",
+		DefaultValue: "true",
+	}
+	p.EnableLevelZeroCompaction.Init(base.mgr)
 
 	p.LevelZeroCompactionTriggerMinSize = ParamItem{
 		Key:          "dataCoord.compaction.levelzero.forceTrigger.minSize",


### PR DESCRIPTION
Enabled by default and to make it dynamic, when disabled:

1. Skip to trigger L0 compaction
2. Check and skip submitting L0 compaction when enqueuePlans
3. Check and clear pipelining L0 compaction when schedule
4. Discard executing L0 compaction plans in DN

See also: #32817 