### PR TITLE
enhance: [2.4] Improve datacoord segment filtering with collection (#32831)

### DIFF
--- a/internal/datacoord/broker/mock_coordinator_broker.go
+++ b/internal/datacoord/broker/mock_coordinator_broker.go
@@ -77,59 +77,6 @@ func (_c *MockBroker_DescribeCollectionInternal_Call) RunAndReturn(run func(cont
 	return _c
 }
 
-// GetDatabaseID provides a mock function with given fields: ctx, dbName
-func (_m *MockBroker) GetDatabaseID(ctx context.Context, dbName string) (int64, error) {
-	ret := _m.Called(ctx, dbName)
-
-	var r0 int64
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) (int64, error)); ok {
-		return rf(ctx, dbName)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) int64); ok {
-		r0 = rf(ctx, dbName)
-	} else {
-		r0 = ret.Get(0).(int64)
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = rf(ctx, dbName)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// MockBroker_GetDatabaseID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetDatabaseID'
-type MockBroker_GetDatabaseID_Call struct {
-	*mock.Call
-}
-
-// GetDatabaseID is a helper method to define mock.On call
-//   - ctx context.Context
-//   - dbName string
-func (_e *MockBroker_Expecter) GetDatabaseID(ctx interface{}, dbName interface{}) *MockBroker_GetDatabaseID_Call {
-	return &MockBroker_GetDatabaseID_Call{Call: _e.mock.On("GetDatabaseID", ctx, dbName)}
-}
-
-func (_c *MockBroker_GetDatabaseID_Call) Run(run func(ctx context.Context, dbName string)) *MockBroker_GetDatabaseID_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string))
-	})
-	return _c
-}
-
-func (_c *MockBroker_GetDatabaseID_Call) Return(_a0 int64, _a1 error) *MockBroker_GetDatabaseID_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *MockBroker_GetDatabaseID_Call) RunAndReturn(run func(context.Context, string) (int64, error)) *MockBroker_GetDatabaseID_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // HasCollection provides a mock function with given fields: ctx, collectionID
 func (_m *MockBroker) HasCollection(ctx context.Context, collectionID int64) (bool, error) {
 	ret := _m.Called(ctx, collectionID)

--- a/internal/datacoord/compaction_test.go
+++ b/internal/datacoord/compaction_test.go
@@ -203,7 +203,7 @@ func (s *CompactionPlanHandlerSuite) TestHandleL0CompactionResults() {
 func (s *CompactionPlanHandlerSuite) TestRefreshL0Plan() {
 	channel := "Ch-1"
 	deltalogs := []*datapb.FieldBinlog{getFieldBinlogIDs(101, 3)}
-	s.mockMeta.EXPECT().SelectSegments(mock.Anything).Return(
+	s.mockMeta.EXPECT().SelectSegments(mock.Anything, mock.Anything).Return(
 		[]*SegmentInfo{
 			{SegmentInfo: &datapb.SegmentInfo{
 				ID:            200,
@@ -310,7 +310,7 @@ func (s *CompactionPlanHandlerSuite) TestRefreshL0Plan() {
 				Deltalogs:     deltalogs,
 			}}
 		}).Times(2)
-		s.mockMeta.EXPECT().SelectSegments(mock.Anything).Return(nil).Once()
+		s.mockMeta.EXPECT().SelectSegments(mock.Anything, mock.Anything).Return(nil).Once()
 
 		// 2 l0 segments
 		plan := &datapb.CompactionPlan{

--- a/internal/datacoord/compaction_trigger_v2_test.go
+++ b/internal/datacoord/compaction_trigger_v2_test.go
@@ -36,9 +36,11 @@ func (s *CompactionTriggerManagerSuite) SetupTest() {
 		PartitionID:  10,
 		Channel:      "ch-1",
 	}
-	s.meta = &meta{segments: &SegmentsInfo{
-		segments: genSegmentsForMeta(s.testLabel),
-	}}
+	segments := genSegmentsForMeta(s.testLabel)
+	s.meta = &meta{segments: NewSegmentsInfo()}
+	for id, segment := range segments {
+		s.meta.segments.SetSegment(id, segment)
+	}
 
 	s.m = NewCompactionTriggerManager(s.mockAlloc, s.mockPlanContext)
 }

--- a/internal/datacoord/compaction_view_manager_test.go
+++ b/internal/datacoord/compaction_view_manager_test.go
@@ -80,9 +80,11 @@ func (s *CompactionViewManagerSuite) SetupTest() {
 		Channel:      "ch-1",
 	}
 
-	meta := &meta{segments: &SegmentsInfo{
-		segments: genSegmentsForMeta(s.testLabel),
-	}}
+	segments := genSegmentsForMeta(s.testLabel)
+	meta := &meta{segments: NewSegmentsInfo()}
+	for id, segment := range segments {
+		meta.segments.SetSegment(id, segment)
+	}
 
 	s.m = NewCompactionViewManager(meta, s.mockTriggerManager, s.mockAlloc)
 }

--- a/internal/datacoord/garbage_collector.go
+++ b/internal/datacoord/garbage_collector.go
@@ -411,7 +411,7 @@ func (gc *garbageCollector) recycleDroppedSegments(ctx context.Context) {
 	log.Info("start clear dropped segments...")
 	defer func() { log.Info("clear dropped segments done", zap.Duration("timeCost", time.Since(start))) }()
 
-	all := gc.meta.SelectSegments(func(si *SegmentInfo) bool { return true })
+	all := gc.meta.SelectSegments()
 	drops := make(map[int64]*SegmentInfo, 0)
 	compactTo := make(map[int64]*SegmentInfo)
 	channels := typeutil.NewSet[string]()

--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -962,23 +962,17 @@ func (m *meta) batchSaveDropSegments(channel string, modSegments map[int64]*Segm
 
 // GetSegmentsByChannel returns all segment info which insert channel equals provided `dmlCh`
 func (m *meta) GetSegmentsByChannel(channel string) []*SegmentInfo {
-	return m.SelectSegments(func(segment *SegmentInfo) bool {
-		return isSegmentHealthy(segment) && segment.InsertChannel == channel
-	})
+	return m.SelectSegments(SegmentFilterFunc(isSegmentHealthy), WithChannel(channel))
 }
 
 // GetSegmentsOfCollection get all segments of collection
 func (m *meta) GetSegmentsOfCollection(collectionID UniqueID) []*SegmentInfo {
-	return m.SelectSegments(func(segment *SegmentInfo) bool {
-		return isSegmentHealthy(segment) && segment.GetCollectionID() == collectionID
-	})
+	return m.SelectSegments(SegmentFilterFunc(isSegmentHealthy), WithCollection(collectionID))
 }
 
 // GetSegmentsIDOfCollection returns all segment ids which collection equals to provided `collectionID`
 func (m *meta) GetSegmentsIDOfCollection(collectionID UniqueID) []UniqueID {
-	segments := m.SelectSegments(func(segment *SegmentInfo) bool {
-		return isSegmentHealthy(segment) && segment.CollectionID == collectionID
-	})
+	segments := m.SelectSegments(SegmentFilterFunc(isSegmentHealthy), WithCollection(collectionID))
 
 	return lo.Map(segments, func(segment *SegmentInfo, _ int) int64 {
 		return segment.ID
@@ -987,12 +981,11 @@ func (m *meta) GetSegmentsIDOfCollection(collectionID UniqueID) []UniqueID {
 
 // GetSegmentsIDOfCollection returns all segment ids which collection equals to provided `collectionID`
 func (m *meta) GetSegmentsIDOfCollectionWithDropped(collectionID UniqueID) []UniqueID {
-	segments := m.SelectSegments(func(segment *SegmentInfo) bool {
+	segments := m.SelectSegments(WithCollection(collectionID), SegmentFilterFunc(func(segment *SegmentInfo) bool {
 		return segment != nil &&
 			segment.GetState() != commonpb.SegmentState_SegmentStateNone &&
-			segment.GetState() != commonpb.SegmentState_NotExist &&
-			segment.CollectionID == collectionID
-	})
+			segment.GetState() != commonpb.SegmentState_NotExist
+	}))
 
 	return lo.Map(segments, func(segment *SegmentInfo, _ int) int64 {
 		return segment.ID
@@ -1001,11 +994,10 @@ func (m *meta) GetSegmentsIDOfCollectionWithDropped(collectionID UniqueID) []Uni
 
 // GetSegmentsIDOfPartition returns all segments ids which collection & partition equals to provided `collectionID`, `partitionID`
 func (m *meta) GetSegmentsIDOfPartition(collectionID, partitionID UniqueID) []UniqueID {
-	segments := m.SelectSegments(func(segment *SegmentInfo) bool {
+	segments := m.SelectSegments(WithCollection(collectionID), SegmentFilterFunc(func(segment *SegmentInfo) bool {
 		return isSegmentHealthy(segment) &&
-			segment.CollectionID == collectionID &&
 			segment.PartitionID == partitionID
-	})
+	}))
 
 	return lo.Map(segments, func(segment *SegmentInfo, _ int) int64 {
 		return segment.ID
@@ -1014,12 +1006,11 @@ func (m *meta) GetSegmentsIDOfPartition(collectionID, partitionID UniqueID) []Un
 
 // GetSegmentsIDOfPartition returns all segments ids which collection & partition equals to provided `collectionID`, `partitionID`
 func (m *meta) GetSegmentsIDOfPartitionWithDropped(collectionID, partitionID UniqueID) []UniqueID {
-	segments := m.SelectSegments(func(segment *SegmentInfo) bool {
+	segments := m.SelectSegments(WithCollection(collectionID), SegmentFilterFunc(func(segment *SegmentInfo) bool {
 		return segment.GetState() != commonpb.SegmentState_SegmentStateNone &&
 			segment.GetState() != commonpb.SegmentState_NotExist &&
-			segment.CollectionID == collectionID &&
 			segment.PartitionID == partitionID
-	})
+	}))
 
 	return lo.Map(segments, func(segment *SegmentInfo, _ int) int64 {
 		return segment.ID
@@ -1031,34 +1022,34 @@ func (m *meta) GetNumRowsOfPartition(collectionID UniqueID, partitionID UniqueID
 	m.RLock()
 	defer m.RUnlock()
 	var ret int64
-	segments := m.segments.GetSegments()
+	segments := m.SelectSegments(WithCollection(collectionID), SegmentFilterFunc(func(si *SegmentInfo) bool {
+		return isSegmentHealthy(si) && si.GetPartitionID() == partitionID
+	}))
 	for _, segment := range segments {
-		if isSegmentHealthy(segment) && segment.CollectionID == collectionID && segment.PartitionID == partitionID {
-			ret += segment.NumOfRows
-		}
+		ret += segment.NumOfRows
 	}
 	return ret
 }
 
 // GetUnFlushedSegments get all segments which state is not `Flushing` nor `Flushed`
 func (m *meta) GetUnFlushedSegments() []*SegmentInfo {
-	return m.SelectSegments(func(segment *SegmentInfo) bool {
+	return m.SelectSegments(SegmentFilterFunc(func(segment *SegmentInfo) bool {
 		return segment.GetState() == commonpb.SegmentState_Growing || segment.GetState() == commonpb.SegmentState_Sealed
-	})
+	}))
 }
 
 // GetFlushingSegments get all segments which state is `Flushing`
 func (m *meta) GetFlushingSegments() []*SegmentInfo {
-	return m.SelectSegments(func(segment *SegmentInfo) bool {
+	return m.SelectSegments(SegmentFilterFunc(func(segment *SegmentInfo) bool {
 		return segment.GetState() == commonpb.SegmentState_Flushing
-	})
+	}))
 }
 
 // SelectSegments select segments with selector
-func (m *meta) SelectSegments(selector SegmentInfoSelector) []*SegmentInfo {
+func (m *meta) SelectSegments(filters ...SegmentFilter) []*SegmentInfo {
 	m.RLock()
 	defer m.RUnlock()
-	return m.segments.GetSegmentsBySelector(selector)
+	return m.segments.GetSegmentsBySelector(filters...)
 }
 
 // AddAllocation add allocation in segment
@@ -1406,12 +1397,12 @@ func (m *meta) GcConfirm(ctx context.Context, collectionID, partitionID UniqueID
 }
 
 func (m *meta) GetCompactableSegmentGroupByCollection() map[int64][]*SegmentInfo {
-	allSegs := m.SelectSegments(func(segment *SegmentInfo) bool {
+	allSegs := m.SelectSegments(SegmentFilterFunc(func(segment *SegmentInfo) bool {
 		return isSegmentHealthy(segment) &&
 			isFlush(segment) && // sealed segment
 			!segment.isCompacting && // not compacting now
 			!segment.GetIsImporting() // not importing now
-	})
+	}))
 
 	ret := make(map[int64][]*SegmentInfo)
 	for _, seg := range allSegs {
@@ -1426,12 +1417,11 @@ func (m *meta) GetCompactableSegmentGroupByCollection() map[int64][]*SegmentInfo
 }
 
 func (m *meta) GetEarliestStartPositionOfGrowingSegments(label *CompactionGroupLabel) *msgpb.MsgPosition {
-	segments := m.SelectSegments(func(segment *SegmentInfo) bool {
+	segments := m.SelectSegments(WithCollection(label.CollectionID), SegmentFilterFunc(func(segment *SegmentInfo) bool {
 		return segment.GetState() == commonpb.SegmentState_Growing &&
-			segment.GetCollectionID() == label.CollectionID &&
 			segment.GetPartitionID() == label.PartitionID &&
 			segment.GetInsertChannel() == label.Channel
-	})
+	}))
 
 	earliest := &msgpb.MsgPosition{Timestamp: math.MaxUint64}
 	for _, seg := range segments {

--- a/internal/datacoord/mock_compaction_meta.go
+++ b/internal/datacoord/mock_compaction_meta.go
@@ -128,13 +128,19 @@ func (_c *MockCompactionMeta_GetHealthySegment_Call) RunAndReturn(run func(int64
 	return _c
 }
 
-// SelectSegments provides a mock function with given fields: selector
-func (_m *MockCompactionMeta) SelectSegments(selector SegmentInfoSelector) []*SegmentInfo {
-	ret := _m.Called(selector)
+// SelectSegments provides a mock function with given fields: filters
+func (_m *MockCompactionMeta) SelectSegments(filters ...SegmentFilter) []*SegmentInfo {
+	_va := make([]interface{}, len(filters))
+	for _i := range filters {
+		_va[_i] = filters[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 []*SegmentInfo
-	if rf, ok := ret.Get(0).(func(SegmentInfoSelector) []*SegmentInfo); ok {
-		r0 = rf(selector)
+	if rf, ok := ret.Get(0).(func(...SegmentFilter) []*SegmentInfo); ok {
+		r0 = rf(filters...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*SegmentInfo)
@@ -150,14 +156,21 @@ type MockCompactionMeta_SelectSegments_Call struct {
 }
 
 // SelectSegments is a helper method to define mock.On call
-//   - selector SegmentInfoSelector
-func (_e *MockCompactionMeta_Expecter) SelectSegments(selector interface{}) *MockCompactionMeta_SelectSegments_Call {
-	return &MockCompactionMeta_SelectSegments_Call{Call: _e.mock.On("SelectSegments", selector)}
+//   - filters ...SegmentFilter
+func (_e *MockCompactionMeta_Expecter) SelectSegments(filters ...interface{}) *MockCompactionMeta_SelectSegments_Call {
+	return &MockCompactionMeta_SelectSegments_Call{Call: _e.mock.On("SelectSegments",
+		append([]interface{}{}, filters...)...)}
 }
 
-func (_c *MockCompactionMeta_SelectSegments_Call) Run(run func(selector SegmentInfoSelector)) *MockCompactionMeta_SelectSegments_Call {
+func (_c *MockCompactionMeta_SelectSegments_Call) Run(run func(filters ...SegmentFilter)) *MockCompactionMeta_SelectSegments_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(SegmentInfoSelector))
+		variadicArgs := make([]SegmentFilter, len(args)-0)
+		for i, a := range args[0:] {
+			if a != nil {
+				variadicArgs[i] = a.(SegmentFilter)
+			}
+		}
+		run(variadicArgs...)
 	})
 	return _c
 }
@@ -167,7 +180,7 @@ func (_c *MockCompactionMeta_SelectSegments_Call) Return(_a0 []*SegmentInfo) *Mo
 	return _c
 }
 
-func (_c *MockCompactionMeta_SelectSegments_Call) RunAndReturn(run func(SegmentInfoSelector) []*SegmentInfo) *MockCompactionMeta_SelectSegments_Call {
+func (_c *MockCompactionMeta_SelectSegments_Call) RunAndReturn(run func(...SegmentFilter) []*SegmentInfo) *MockCompactionMeta_SelectSegments_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/datacoord/segment_info.go
+++ b/internal/datacoord/segment_info.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/samber/lo"
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
 
@@ -32,6 +33,7 @@ import (
 // SegmentsInfo wraps a map, which maintains ID to SegmentInfo relation
 type SegmentsInfo struct {
 	segments     map[UniqueID]*SegmentInfo
+	collSegments map[UniqueID]*CollectionSegments
 	compactionTo map[UniqueID]UniqueID // map the compact relation, value is the segment which `CompactFrom` contains key.
 	// A segment can be compacted to only one segment finally in meta.
 }
@@ -68,8 +70,13 @@ func NewSegmentInfo(info *datapb.SegmentInfo) *SegmentInfo {
 func NewSegmentsInfo() *SegmentsInfo {
 	return &SegmentsInfo{
 		segments:     make(map[UniqueID]*SegmentInfo),
+		collSegments: make(map[UniqueID]*CollectionSegments),
 		compactionTo: make(map[UniqueID]UniqueID),
 	}
+}
+
+type CollectionSegments struct {
+	segments map[int64]*SegmentInfo
 }
 
 // GetSegment returns SegmentInfo
@@ -86,21 +93,33 @@ func (s *SegmentsInfo) GetSegment(segmentID UniqueID) *SegmentInfo {
 // no deep copy applied
 // the logPath in meta is empty
 func (s *SegmentsInfo) GetSegments() []*SegmentInfo {
-	segments := make([]*SegmentInfo, 0, len(s.segments))
-	for _, segment := range s.segments {
-		segments = append(segments, segment)
-	}
-	return segments
+	return lo.Values(s.segments)
 }
 
-func (s *SegmentsInfo) GetSegmentsBySelector(selector SegmentInfoSelector) []*SegmentInfo {
-	var segments []*SegmentInfo
-	for _, segment := range s.segments {
-		if selector(segment) {
-			segments = append(segments, segment)
+func (s *SegmentsInfo) GetSegmentsBySelector(filters ...SegmentFilter) []*SegmentInfo {
+	criterion := &segmentCriterion{}
+	for _, filter := range filters {
+		filter.AddFilter(criterion)
+	}
+	var result []*SegmentInfo
+	var candidates []*SegmentInfo
+	// apply criterion
+	switch {
+	case criterion.collectionID > 0:
+		collSegments, ok := s.collSegments[criterion.collectionID]
+		if !ok {
+			return nil
+		}
+		candidates = lo.Values(collSegments.segments)
+	default:
+		candidates = lo.Values(s.segments)
+	}
+	for _, segment := range candidates {
+		if criterion.Match(segment) {
+			result = append(result, segment)
 		}
 	}
-	return segments
+	return result
 }
 
 // GetCompactionTo returns the segment that the provided segment is compacted to.
@@ -125,6 +144,7 @@ func (s *SegmentsInfo) GetCompactionTo(fromSegmentID int64) (*SegmentInfo, bool)
 func (s *SegmentsInfo) DropSegment(segmentID UniqueID) {
 	if segment, ok := s.segments[segmentID]; ok {
 		s.deleteCompactTo(segment)
+		s.delCollection(segment)
 		delete(s.segments, segmentID)
 	}
 }
@@ -136,8 +156,10 @@ func (s *SegmentsInfo) SetSegment(segmentID UniqueID, segment *SegmentInfo) {
 	if segment, ok := s.segments[segmentID]; ok {
 		// Remove old segment compact to relation first.
 		s.deleteCompactTo(segment)
+		s.delCollection(segment)
 	}
 	s.segments[segmentID] = segment
+	s.addCollection(segment)
 	s.addCompactTo(segment)
 }
 
@@ -272,6 +294,30 @@ func (s *SegmentInfo) ShadowClone(opts ...SegmentInfoOption) *SegmentInfo {
 		opt(cloned)
 	}
 	return cloned
+}
+
+func (s *SegmentsInfo) addCollection(segment *SegmentInfo) {
+	collID := segment.GetCollectionID()
+	collSegment, ok := s.collSegments[collID]
+	if !ok {
+		collSegment = &CollectionSegments{
+			segments: make(map[UniqueID]*SegmentInfo),
+		}
+		s.collSegments[collID] = collSegment
+	}
+	collSegment.segments[segment.GetID()] = segment
+}
+
+func (s *SegmentsInfo) delCollection(segment *SegmentInfo) {
+	collID := segment.GetCollectionID()
+	collSegment, ok := s.collSegments[collID]
+	if !ok {
+		return
+	}
+	delete(collSegment.segments, segment.GetID())
+	if len(collSegment.segments) == 0 {
+		delete(s.collSegments, segment.GetCollectionID())
+	}
 }
 
 // addCompactTo adds the compact relation to the segment

--- a/internal/datacoord/segment_operator.go
+++ b/internal/datacoord/segment_operator.go
@@ -28,3 +28,52 @@ func SetMaxRowCount(maxRow int64) SegmentOperator {
 		return true
 	}
 }
+
+type segmentCriterion struct {
+	collectionID int64
+	others       []SegmentFilter
+}
+
+func (sc *segmentCriterion) Match(segment *SegmentInfo) bool {
+	for _, filter := range sc.others {
+		if !filter.Match(segment) {
+			return false
+		}
+	}
+	return true
+}
+
+type SegmentFilter interface {
+	Match(segment *SegmentInfo) bool
+	AddFilter(*segmentCriterion)
+}
+
+type CollectionFilter int64
+
+func (f CollectionFilter) Match(segment *SegmentInfo) bool {
+	return segment.GetCollectionID() == int64(f)
+}
+
+func (f CollectionFilter) AddFilter(criterion *segmentCriterion) {
+	criterion.collectionID = int64(f)
+}
+
+func WithCollection(collectionID int64) SegmentFilter {
+	return CollectionFilter(collectionID)
+}
+
+type SegmentFilterFunc func(*SegmentInfo) bool
+
+func (f SegmentFilterFunc) Match(segment *SegmentInfo) bool {
+	return f(segment)
+}
+
+func (f SegmentFilterFunc) AddFilter(criterion *segmentCriterion) {
+	criterion.others = append(criterion.others, f)
+}
+
+func WithChannel(channel string) SegmentFilter {
+	return SegmentFilterFunc(func(si *SegmentInfo) bool {
+		return si.GetInsertChannel() == channel
+	})
+}


### PR DESCRIPTION
Cherry-pick from master
pr: #32831 
See also #32165

This PR modify the `SelectSegments` interface to utilizing collection id information when selecting segment with provided collection

---------