### PR TITLE
fix: Make SyncManager callback func ignore nil error

### DIFF
--- a/internal/datanode/syncmgr/sync_manager.go
+++ b/internal/datanode/syncmgr/sync_manager.go
@@ -134,6 +134,9 @@ func (mgr *syncManager) safeSubmitTask(task Task) *conc.Future[struct{}] {
 
 func (mgr *syncManager) submit(key int64, task Task) *conc.Future[struct{}] {
 	handler := func(err error) error {
+		if err == nil {
+			return nil
+		}
 		// unexpected error
 		if !errors.Is(err, errTargetSegmentNotMatch) {
 			task.HandleError(err)

--- a/internal/datanode/syncmgr/sync_manager_test.go
+++ b/internal/datanode/syncmgr/sync_manager_test.go
@@ -318,7 +318,6 @@ func (s *SyncManagerSuite) TestTargetUpdated() {
 	task.EXPECT().CalcTargetSegment().Return(1001, nil).Once()
 	task.EXPECT().Run().Return(errTargetSegmentNotMatch).Once()
 	task.EXPECT().Run().Return(nil).Once()
-	task.EXPECT().HandleError(mock.Anything)
 
 	f := manager.SyncData(context.Background(), task)
 	_, err = f.Await()


### PR DESCRIPTION
introduced by #32865

sync manager callback handler panicked when error is nil