### PR TITLE
enhance: [2.4] Utilize coll2replica mapping when getting rg by collection (#32892)

### DIFF
--- a/internal/querycoordv2/meta/replica_manager.go
+++ b/internal/querycoordv2/meta/replica_manager.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 
 	"github.com/cockroachdb/errors"
+	"github.com/samber/lo"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/internal/metastore"
@@ -406,15 +407,7 @@ func (m *ReplicaManager) RemoveNode(replicaID typeutil.UniqueID, nodes ...typeut
 }
 
 func (m *ReplicaManager) GetResourceGroupByCollection(collection typeutil.UniqueID) typeutil.Set[string] {
-	m.rwmutex.Lock()
-	defer m.rwmutex.Unlock()
-
-	ret := typeutil.NewSet[string]()
-	for _, r := range m.replicas {
-		if r.GetCollectionID() == collection {
-			ret.Insert(r.GetResourceGroup())
-		}
-	}
-
+	replicas := m.GetByCollection(collection)
+	ret := typeutil.NewSet(lo.Map(replicas, func(r *Replica, _ int) string { return r.GetResourceGroup() })...)
 	return ret
 }


### PR DESCRIPTION
Cherry-pick from master
pr: #32892
See also #32165

In old `GetResourceGroupByCollection` implementation, it iterates all replicas to match collection id, which is slow and CPU time consuming. This PR make it utilize the coll2Replicas mapping by calling `GetByCollection` and mapping replicas into resource group.