### PR TITLE
fix: Set segment to delegator failed due to wrong time unit in segment version

### DIFF
--- a/internal/querycoordv2/observers/leader_observer.go
+++ b/internal/querycoordv2/observers/leader_observer.go
@@ -166,7 +166,7 @@ func (o *LeaderObserver) findNeedLoadedSegments(leaderView *meta.LeaderView, dis
 					PartitionID: s.GetPartitionID(),
 					SegmentID:   s.GetID(),
 					NodeID:      s.Node,
-					Version:     time.Now().Unix(),
+					Version:     time.Now().UnixNano(),
 					Info:        loadInfo,
 				})
 			}


### PR DESCRIPTION
issue: #31468
pr: #31643
the fix in #31643 try to update segment version when set segment to delegator, but use wrong time unit as segment version, which make set segment failed, and block the balance channel.