### PR TITLE
fix: temporarily disable two-phase retrieval when lru is enabled

### DIFF
--- a/internal/querynodev2/segments/retrieve.go
+++ b/internal/querynodev2/segments/retrieve.go
@@ -47,7 +47,9 @@ func retrieveOnSegments(ctx context.Context, mgr *Manager, segments []Segment, s
 	}
 	resultCh := make(chan segmentResult, len(segments))
 
-	plan.ignoreNonPk = len(segments) > 1 && req.GetReq().GetLimit() != typeutil.Unlimited && plan.ShouldIgnoreNonPk()
+	// TODO(longjiquan): remove this limit after two-phase retrieval can be applied on lru-segment.
+	plan.ignoreNonPk = !paramtable.Get().QueryNodeCfg.UseStreamComputing.GetAsBool() &&
+		len(segments) > 1 && req.GetReq().GetLimit() != typeutil.Unlimited && plan.ShouldIgnoreNonPk()
 
 	label := metrics.SealedSegmentLabel
 	if segType == commonpb.SegmentState_Growing {


### PR DESCRIPTION
issue: #31822 