### PR TITLE
fix: Segment on stopping query node can't be release successfully

### DIFF
--- a/internal/querycoordv2/meta/replica.go
+++ b/internal/querycoordv2/meta/replica.go
@@ -100,12 +100,17 @@ func (replica *Replica) NodesCount() int {
 
 // Contains checks if the node is in rw nodes of the replica.
 func (replica *Replica) Contains(node int64) bool {
-	return replica.rwNodes.Contain(node)
+	return replica.ContainRONode(node) || replica.ContainRWNode(node)
 }
 
 // ContainRONode checks if the node is in ro nodes of the replica.
 func (replica *Replica) ContainRONode(node int64) bool {
 	return replica.roNodes.Contain(node)
+}
+
+// ContainRONode checks if the node is in ro nodes of the replica.
+func (replica *Replica) ContainRWNode(node int64) bool {
+	return replica.rwNodes.Contain(node)
 }
 
 // Deprecated: Warning, break the consistency of ReplicaManager, use `SetAvailableNodesInSameCollectionAndRG` in ReplicaManager instead.

--- a/internal/querycoordv2/meta/replica_test.go
+++ b/internal/querycoordv2/meta/replica_test.go
@@ -96,8 +96,8 @@ func (suite *ReplicaSuite) TestWriteOperation() {
 	suite.True(mr.Contains(6))
 
 	// test add ro node.
-	suite.False(mr.Contains(4))
-	suite.False(mr.Contains(7))
+	suite.False(mr.ContainRWNode(4))
+	suite.False(mr.ContainRWNode(7))
 	mr.AddRWNode(4, 7)
 	suite.Equal(3, r.RWNodesCount())
 	suite.Equal(1, r.RONodesCount())
@@ -116,8 +116,10 @@ func (suite *ReplicaSuite) TestWriteOperation() {
 	suite.Equal(5, mr.RWNodesCount())
 	suite.Equal(2, mr.RONodesCount())
 	suite.Equal(7, mr.NodesCount())
-	suite.False(mr.Contains(4))
-	suite.False(mr.Contains(7))
+	suite.False(mr.ContainRWNode(4))
+	suite.False(mr.ContainRWNode(7))
+	suite.True(mr.ContainRONode(4))
+	suite.True(mr.ContainRONode(7))
 
 	// test remove node.
 	mr.RemoveNode(4, 5, 7, 8)
@@ -164,10 +166,15 @@ func (suite *ReplicaSuite) testRead(r *Replica) {
 
 	// Test Contains()
 	suite.True(r.Contains(1))
-	suite.False(r.Contains(4))
+	suite.True(r.Contains(4))
 
 	// Test ContainRONode()
+	suite.False(r.ContainRONode(1))
 	suite.True(r.ContainRONode(4))
+
+	// Test ContainsRWNode()
+	suite.True(r.ContainRWNode(1))
+	suite.False(r.ContainRWNode(4))
 }
 
 func TestReplica(t *testing.T) {


### PR DESCRIPTION
issue: #32901
Cause release segment request need be send to delegator, but it need replica to info find segment's delegator. but the stopping query node will be marked as read only in replica, then `replica.Contains()` just return true for rwNode in replica. then it can't get replica info by stopping query node and release segment will be blocked.

This PR make `replica.Contains()` return true for both roNode and rwNode.