### PR TITLE
enhance: Utilize `TestLocations` ability to accelerate write & compaction

### DIFF
--- a/internal/datanode/l0_compactor.go
+++ b/internal/datanode/l0_compactor.go
@@ -278,8 +278,9 @@ func (t *levelZeroCompactionTask) splitDelta(
 	// segments shall be safe to read outside
 	segments := t.metacache.GetSegmentsBy(metacache.WithSegmentIDs(targetSegIDs...))
 	split := func(pk storage.PrimaryKey) []int64 {
+		lc := storage.NewLocationsCache(pk)
 		return lo.FilterMap(segments, func(segment *metacache.SegmentInfo, _ int) (int64, bool) {
-			return segment.SegmentID(), segment.GetBloomFilterSet().PkExists(pk)
+			return segment.SegmentID(), segment.GetBloomFilterSet().PkExists(lc)
 		})
 	}
 

--- a/internal/datanode/metacache/bloom_filter_set.go
+++ b/internal/datanode/metacache/bloom_filter_set.go
@@ -55,15 +55,15 @@ func NewBloomFilterSetWithBatchSize(batchSize uint, historyEntries ...*storage.P
 	}
 }
 
-func (bfs *BloomFilterSet) PkExists(pk storage.PrimaryKey) bool {
+func (bfs *BloomFilterSet) PkExists(lc storage.LocationsCache) bool {
 	bfs.mut.RLock()
 	defer bfs.mut.RUnlock()
-	if bfs.current != nil && bfs.current.PkExist(pk) {
+	if bfs.current != nil && bfs.current.TestLocationCache(lc) {
 		return true
 	}
 
 	for _, bf := range bfs.history {
-		if bf.PkExist(pk) {
+		if bf.TestLocationCache(lc) {
 			return true
 		}
 	}

--- a/internal/datanode/metacache/bloom_filter_set_test.go
+++ b/internal/datanode/metacache/bloom_filter_set_test.go
@@ -59,14 +59,14 @@ func (s *BloomFilterSetSuite) GetFieldData(ids []int64) storage.FieldData {
 func (s *BloomFilterSetSuite) TestWriteRead() {
 	ids := []int64{1, 2, 3, 4, 5}
 	for _, id := range ids {
-		s.False(s.bfs.PkExists(storage.NewInt64PrimaryKey(id)), "pk shall not exist before update")
+		s.False(s.bfs.PkExists(storage.NewLocationsCache(storage.NewInt64PrimaryKey(id))), "pk shall not exist before update")
 	}
 
 	err := s.bfs.UpdatePKRange(s.GetFieldData(ids))
 	s.NoError(err)
 
 	for _, id := range ids {
-		s.True(s.bfs.PkExists(storage.NewInt64PrimaryKey(id)), "pk shall return exist after update")
+		s.True(s.bfs.PkExists(storage.NewLocationsCache(storage.NewInt64PrimaryKey(id))), "pk shall return exist after update")
 	}
 }
 

--- a/internal/datanode/metacache/meta_cache.go
+++ b/internal/datanode/metacache/meta_cache.go
@@ -212,9 +212,10 @@ func (c *metaCacheImpl) UpdateSegments(action SegmentAction, filters ...SegmentF
 
 func (c *metaCacheImpl) PredictSegments(pk storage.PrimaryKey, filters ...SegmentFilter) ([]int64, bool) {
 	var predicts []int64
+	lc := storage.NewLocationsCache(pk)
 	segments := c.GetSegmentsBy(filters...)
 	for _, segment := range segments {
-		if segment.GetBloomFilterSet().PkExists(pk) {
+		if segment.GetBloomFilterSet().PkExists(lc) {
 			predicts = append(predicts, segment.segmentID)
 		}
 	}

--- a/internal/datanode/writebuffer/bf_write_buffer.go
+++ b/internal/datanode/writebuffer/bf_write_buffer.go
@@ -1,6 +1,8 @@
 package writebuffer
 
 import (
+	"github.com/samber/lo"
+
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
 	"github.com/milvus-io/milvus/internal/datanode/metacache"
@@ -9,7 +11,6 @@ import (
 	"github.com/milvus-io/milvus/pkg/common"
 	"github.com/milvus-io/milvus/pkg/mq/msgstream"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
-	"github.com/samber/lo"
 )
 
 type bfWriteBuffer struct {

--- a/internal/datanode/writebuffer/l0_write_buffer.go
+++ b/internal/datanode/writebuffer/l0_write_buffer.go
@@ -3,6 +3,7 @@ package writebuffer
 import (
 	"context"
 
+	"github.com/samber/lo"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
@@ -18,7 +19,6 @@ import (
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/retry"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
-	"github.com/samber/lo"
 )
 
 type l0WriteBuffer struct {

--- a/internal/storage/pk_statistics.go
+++ b/internal/storage/pk_statistics.go
@@ -139,3 +139,42 @@ func (st *PkStatistics) TestLocations(pk PrimaryKey, locs []uint64) bool {
 	// check pk range first, ugly but key it for now
 	return st.MinPK.LE(pk) && st.MaxPK.GE(pk)
 }
+
+func (st *PkStatistics) TestLocationCache(lc LocationsCache) bool {
+	// empty pkStatics
+	if st.MinPK == nil || st.MaxPK == nil || st.PkFilter == nil {
+		return false
+	}
+
+	// check bf first, TestLocation just do some bitset compute, cost is cheaper
+	if !st.PkFilter.TestLocations(lc.Locations(st.PkFilter.K())) {
+		return false
+	}
+
+	// check pk range after
+	return st.MinPK.LE(lc.pk) && st.MaxPK.GE(lc.pk)
+}
+
+// LocationsCache is a helper struct caching pk bloom filter locations.
+// Note that this helper is not concurrent safe and shall be used in same goroutine.
+type LocationsCache struct {
+	pk        PrimaryKey
+	locations map[uint][]uint64
+}
+
+func (lc LocationsCache) Locations(k uint) []uint64 {
+	locs, ok := lc.locations[k]
+	if ok {
+		return locs
+	}
+	locs = Locations(lc.pk, k)
+	lc.locations[k] = locs
+	return locs
+}
+
+func NewLocationsCache(pk PrimaryKey) LocationsCache {
+	return LocationsCache{
+		pk:        pk,
+		locations: make(map[uint][]uint64),
+	}
+}


### PR DESCRIPTION
See also #32642

This PR reuses hash locations for bloom filter prediction utilizing `storage.Location`, like enhancement #32642.

Also adds a utility struct in storage: `LocationCache` to storage locations for variable K (numbers of hash functions)