### PR TITLE
enhance: resource estimate improvement

### DIFF
--- a/docs/design_docs/segcore/segment_interface.md
+++ b/docs/design_docs/segcore/segment_interface.md
@@ -4,7 +4,7 @@
 
 1. `get_row_count`: Get the number of entities in the segment
 2. `get_schema`: Get the corresponding collection schema in the segment
-3. `GetMemoryUsageInBytes`: Get memory usage of a segment
+3. `GetResourceUsage`: Get memory and disk usage of a segment.
 4. `Search(plan, placeholderGroup, timestamp) -> QueryResult`: Perform search operations according to the plan containing search parameters and predicate conditions, and return search results. Ensure that the time of all search results is before the specified timestamp(MVCC)
 5. `FillTargetEntry(plan, &queryResult)`: Fill the missing column data for search results based on target columns in the plan
 

--- a/internal/core/src/common/File.h
+++ b/internal/core/src/common/File.h
@@ -35,26 +35,61 @@ class File {
     static File
     Open(const std::string_view filepath, int flags) {
         int fd = open(filepath.data(), flags, S_IRUSR | S_IWUSR);
-        AssertInfo(fd != -1,
-                   "failed to create mmap file {}: {}",
-                   filepath,
-                   strerror(errno));
+        if (fd < 0) {
+            throw SegcoreError(ErrorCode::UnistdError,
+                               fmt::format("failed to open file at {}: {}",
+                                           filepath,
+                                           strerror(errno)));
+        }
         return File(fd);
     }
 
     int
     Descriptor() const {
+        if (fd_ < 0) {
+            throw SegcoreError(ErrorCode::UnistdError,
+                               "file descriptor is invalid");
+        }
         return fd_;
     }
 
     ssize_t
     Write(const void* buf, size_t size) {
-        return write(fd_, buf, size);
+        if (fd_ < 0) {
+            throw SegcoreError(ErrorCode::UnistdError,
+                               "file descriptor is invalid when writing file");
+        }
+
+        ssize_t cnt = write(fd_, buf, size);
+        if (cnt < 0) {
+            throw SegcoreError(ErrorCode::UnistdError,
+                               fmt::format("failed to write file: stderror: {}",
+                                           strerror(errno)));
+        }
+        if (cnt != size) {
+            throw SegcoreError(
+                ErrorCode::UnistdError,
+                fmt::format("short write to file: written: {}, expected: {}",
+                            cnt,
+                            size));
+        }
+        return cnt;
     }
 
     offset_t
     Seek(offset_t offset, int whence) {
-        return lseek(fd_, offset, whence);
+        if (fd_ < 0) {
+            throw SegcoreError(ErrorCode::UnistdError,
+                               "file descriptor is invalid when seek file");
+        }
+
+        offset_t position = lseek(fd_, offset, whence);
+        if (position < 0) {
+            throw SegcoreError(ErrorCode::UnistdError,
+                               fmt::format("failed to seek file: stderror: {}",
+                                           strerror(errno)));
+        }
+        return position;
     }
 
     void

--- a/internal/core/src/common/Types.h
+++ b/internal/core/src/common/Types.h
@@ -507,6 +507,11 @@ struct TypeTraits<DataType::VECTOR_FLOAT> {
     static constexpr const char* Name = "VECTOR_FLOAT";
 };
 
+struct ResourceUsage {
+    size_t mem_size;
+    size_t disk_size;
+};
+
 }  // namespace milvus
 template <>
 struct fmt::formatter<milvus::DataType> : formatter<string_view> {

--- a/internal/core/src/common/type_c.h
+++ b/internal/core/src/common/type_c.h
@@ -16,6 +16,7 @@
 
 #pragma once
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -62,6 +63,12 @@ typedef struct CStatus {
     int error_code;
     const char* error_msg;
 } CStatus;
+
+// CSegmentResourceUsage is used to represent the resource usage of a segment, and used by CGO.
+typedef struct CSegmentResourceUsage {
+    size_t mem_size;
+    size_t disk_size;
+} CSegmentResourceUsage;
 
 typedef struct CProto {
     const void* proto_blob;

--- a/internal/core/src/index/Index.h
+++ b/internal/core/src/index/Index.h
@@ -89,6 +89,9 @@ class IndexBase {
         return index_type_;
     }
 
+    virtual ResourceUsage
+    GetResourceUsage() const = 0;
+
  protected:
     explicit IndexBase(IndexType index_type)
         : index_type_(std::move(index_type)) {

--- a/internal/core/src/index/InvertedIndexTantivy.cpp
+++ b/internal/core/src/index/InvertedIndexTantivy.cpp
@@ -447,6 +447,14 @@ InvertedIndexTantivy<T>::BuildWithRawData(size_t n,
     }
 }
 
+template <typename T>
+ResourceUsage
+InvertedIndexTantivy<T>::GetResourceUsage() const {
+    // TODO: we can't get the memory usage of inverted index now.
+    auto disk_size = disk_file_manager_->GetLocalFileSize();
+    return ResourceUsage{0, disk_size};
+}
+
 template class InvertedIndexTantivy<bool>;
 template class InvertedIndexTantivy<int8_t>;
 template class InvertedIndexTantivy<int16_t>;

--- a/internal/core/src/index/InvertedIndexTantivy.h
+++ b/internal/core/src/index/InvertedIndexTantivy.h
@@ -156,6 +156,9 @@ class InvertedIndexTantivy : public ScalarIndex<T> {
     const TargetBitmap
     RegexQuery(const std::string& pattern) override;
 
+    ResourceUsage
+    GetResourceUsage() const override;
+
  private:
     void
     finish();

--- a/internal/core/src/index/ScalarIndexSort.cpp
+++ b/internal/core/src/index/ScalarIndexSort.cpp
@@ -479,6 +479,15 @@ ScalarIndexSort<T>::ShouldSkip(const T lower_value,
     return true;
 }
 
+template <typename T>
+ResourceUsage
+ScalarIndexSort<T>::GetResourceUsage() const {
+    auto mem_size = data_.capacity() * sizeof(IndexStructure<T>) +
+                    idx_to_offsets_.capacity() * sizeof(int32_t);
+    // TODO: after enabling mmap, move the mem_size as disk_size.
+    return ResourceUsage{mem_size, 0};
+}
+
 template class ScalarIndexSort<bool>;
 template class ScalarIndexSort<int8_t>;
 template class ScalarIndexSort<int16_t>;

--- a/internal/core/src/index/ScalarIndexSort.h
+++ b/internal/core/src/index/ScalarIndexSort.h
@@ -100,6 +100,9 @@ class ScalarIndexSort : public ScalarIndex<T> {
         return true;
     }
 
+    ResourceUsage
+    GetResourceUsage() const override;
+
  private:
     bool
     ShouldSkip(const T lower_value, const T upper_value, const OpType op);

--- a/internal/core/src/index/StringIndexMarisa.cpp
+++ b/internal/core/src/index/StringIndexMarisa.cpp
@@ -37,6 +37,7 @@
 #include "index/Index.h"
 #include "storage/Util.h"
 #include "storage/space.h"
+#include "storage/LocalChunkManagerSingleton.h"
 
 namespace milvus::index {
 
@@ -256,18 +257,21 @@ StringIndexMarisa::LoadWithoutAssemble(const BinarySet& set,
     auto len = index->size;
 
     auto file = File::Open(file_name, O_RDWR | O_CREAT | O_EXCL);
-    auto written = file.Write(index->data.get(), len);
-    if (written != len) {
+    try {
+        auto written = file.Write(index->data.get(), len);
+    } catch (const SegcoreError& e) {
         file.Close();
         remove(file_name.c_str());
-        throw SegcoreError(
-            ErrorCode::UnistdError,
-            fmt::format("write index to fd error: {}", strerror(errno)));
+        throw;
     }
 
     file.Seek(0, SEEK_SET);
     if (config.contains(kEnableMmap)) {
         trie_.mmap(file_name.c_str());
+        auto local_chunk_manager =
+            milvus::storage::LocalChunkManagerSingleton::GetInstance()
+                .GetChunkManager();
+        resource_usage_.disk_size += local_chunk_manager->Size(file_name);
     } else {
         trie_.read(file.Descriptor());
     }
@@ -561,6 +565,12 @@ StringIndexMarisa::Reverse_Lookup(size_t offset) const {
     agent.set_query(str_ids_[offset]);
     trie_.reverse_lookup(agent);
     return std::string(agent.key().ptr(), agent.key().length());
+}
+
+ResourceUsage
+StringIndexMarisa::GetResourceUsage() const {
+    // TODO: we cannot estimate the memory usage of marisa trie.
+    return resource_usage_;
 }
 
 }  // namespace milvus::index

--- a/internal/core/src/index/StringIndexMarisa.h
+++ b/internal/core/src/index/StringIndexMarisa.h
@@ -98,6 +98,9 @@ class StringIndexMarisa : public StringIndex {
         return true;
     }
 
+    ResourceUsage
+    GetResourceUsage() const override;
+
  private:
     void
     fill_str_ids(size_t n, const std::string* values);
@@ -123,6 +126,7 @@ class StringIndexMarisa : public StringIndex {
     bool built_ = false;
     std::shared_ptr<storage::MemFileManagerImpl> file_manager_;
     std::shared_ptr<milvus_storage::Space> space_;
+    ResourceUsage resource_usage_;
 };
 
 using StringIndexMarisaPtr = std::unique_ptr<StringIndexMarisa>;

--- a/internal/core/src/index/StringIndexMarisa.h
+++ b/internal/core/src/index/StringIndexMarisa.h
@@ -126,7 +126,7 @@ class StringIndexMarisa : public StringIndex {
     bool built_ = false;
     std::shared_ptr<storage::MemFileManagerImpl> file_manager_;
     std::shared_ptr<milvus_storage::Space> space_;
-    ResourceUsage resource_usage_;
+    ResourceUsage resource_usage_{};
 };
 
 using StringIndexMarisaPtr = std::unique_ptr<StringIndexMarisa>;

--- a/internal/core/src/index/VectorDiskIndex.cpp
+++ b/internal/core/src/index/VectorDiskIndex.cpp
@@ -510,6 +510,14 @@ VectorDiskAnnIndex<T>::update_load_json(const Config& config) {
     return load_config;
 }
 
+template <typename T>
+ResourceUsage
+VectorDiskAnnIndex<T>::GetResourceUsage() const {
+    // TODO: we can't get the memory usage of vector index now.
+    auto disk_size = file_manager_->GetLocalFileSize();
+    return ResourceUsage{0, disk_size};
+}
+
 template class VectorDiskAnnIndex<float>;
 template class VectorDiskAnnIndex<float16>;
 template class VectorDiskAnnIndex<bfloat16>;

--- a/internal/core/src/index/VectorDiskIndex.h
+++ b/internal/core/src/index/VectorDiskIndex.h
@@ -105,8 +105,7 @@ class VectorDiskAnnIndex : public VectorIndex {
                   "get sparse vector not supported for disk index");
     }
 
-    void
-    CleanLocalData() override;
+    void CleanLocalData() override;
 
     knowhere::expected<
         std::vector<std::shared_ptr<knowhere::IndexNode::iterator>>>

--- a/internal/core/src/index/VectorDiskIndex.h
+++ b/internal/core/src/index/VectorDiskIndex.h
@@ -19,6 +19,7 @@
 #include <memory>
 #include <vector>
 
+#include "common/Types.h"
 #include "index/VectorIndex.h"
 #include "storage/DiskFileManagerImpl.h"
 #include "storage/space.h"
@@ -104,13 +105,17 @@ class VectorDiskAnnIndex : public VectorIndex {
                   "get sparse vector not supported for disk index");
     }
 
-    void CleanLocalData() override;
+    void
+    CleanLocalData() override;
 
     knowhere::expected<
         std::vector<std::shared_ptr<knowhere::IndexNode::iterator>>>
     VectorIterators(const DatasetPtr dataset,
                     const knowhere::Json& json,
                     const BitsetView& bitset) const override;
+
+    ResourceUsage
+    GetResourceUsage() const override;
 
  private:
     knowhere::Json

--- a/internal/core/src/index/VectorMemIndex.cpp
+++ b/internal/core/src/index/VectorMemIndex.cpp
@@ -697,8 +697,7 @@ VectorMemIndex<T>::GetSparseVector(const DatasetPtr dataset) const {
 }
 
 template <typename T>
-void
-VectorMemIndex<T>::LoadFromFile(const Config& config) {
+void VectorMemIndex<T>::LoadFromFile(const Config& config) {
     auto filepath = GetValueFromConfig<std::string>(config, kMmapFilepath);
     AssertInfo(filepath.has_value(), "mmap filepath is empty when load index");
 

--- a/internal/core/src/index/VectorMemIndex.cpp
+++ b/internal/core/src/index/VectorMemIndex.cpp
@@ -47,6 +47,7 @@
 #include "log/Log.h"
 #include "storage/DataCodec.h"
 #include "storage/MemFileManagerImpl.h"
+#include "storage/LocalChunkManagerSingleton.h"
 #include "storage/ThreadPools.h"
 #include "storage/space.h"
 #include "storage/Util.h"
@@ -696,7 +697,8 @@ VectorMemIndex<T>::GetSparseVector(const DatasetPtr dataset) const {
 }
 
 template <typename T>
-void VectorMemIndex<T>::LoadFromFile(const Config& config) {
+void
+VectorMemIndex<T>::LoadFromFile(const Config& config) {
     auto filepath = GetValueFromConfig<std::string>(config, kMmapFilepath);
     AssertInfo(filepath.has_value(), "mmap filepath is empty when load index");
 
@@ -760,14 +762,9 @@ void VectorMemIndex<T>::LoadFromFile(const Config& config) {
                                "lost index slice data");
                     auto data = batch_data[file_name];
                     auto start_write_file = std::chrono::system_clock::now();
-                    auto written = file.Write(data->Data(), data->Size());
+                    file.Write(data->Data(), data->Size());
                     write_disk_duration_sum +=
                         (std::chrono::system_clock::now() - start_write_file);
-                    AssertInfo(
-                        written == data->Size(),
-                        fmt::format("failed to write index data to disk {}: {}",
-                                    filepath->data(),
-                                    strerror(errno)));
                 }
                 for (auto& file : batch) {
                     pending_index_files.erase(file);
@@ -830,6 +827,11 @@ void VectorMemIndex<T>::LoadFromFile(const Config& config) {
 
     auto dim = index_.Dim();
     this->SetDim(index_.Dim());
+
+    auto local_chunk_manager =
+        milvus::storage::LocalChunkManagerSingleton::GetInstance()
+            .GetChunkManager();
+    resource_usage_.disk_size += local_chunk_manager->Size(filepath.value());
 
     auto ok = unlink(filepath->data());
     AssertInfo(ok == 0,
@@ -953,6 +955,14 @@ VectorMemIndex<T>::LoadFromFileV2(const Config& config) {
                strerror(errno));
     LOG_INFO("load vector index done");
 }
+
+template <typename T>
+ResourceUsage
+VectorMemIndex<T>::GetResourceUsage() const {
+    // TODO: we can't get the memory usage of vector index now.
+    return resource_usage_;
+}
+
 template class VectorMemIndex<float>;
 template class VectorMemIndex<uint8_t>;
 template class VectorMemIndex<float16>;

--- a/internal/core/src/index/VectorMemIndex.h
+++ b/internal/core/src/index/VectorMemIndex.h
@@ -117,7 +117,7 @@ class VectorMemIndex : public VectorIndex {
  protected:
     Config config_;
 
-    ResourceUsage resource_usage_;
+    ResourceUsage resource_usage_{};
     knowhere::Index<knowhere::IndexNode> index_;
     std::shared_ptr<storage::MemFileManagerImpl> file_manager_;
     std::shared_ptr<milvus_storage::Space> space_;

--- a/internal/core/src/index/VectorMemIndex.h
+++ b/internal/core/src/index/VectorMemIndex.h
@@ -111,8 +111,13 @@ class VectorMemIndex : public VectorIndex {
     void
     LoadFromFileV2(const Config& config);
 
+    ResourceUsage
+    GetResourceUsage() const override;
+
  protected:
     Config config_;
+
+    ResourceUsage resource_usage_;
     knowhere::Index<knowhere::IndexNode> index_;
     std::shared_ptr<storage::MemFileManagerImpl> file_manager_;
     std::shared_ptr<milvus_storage::Space> space_;

--- a/internal/core/src/mmap/Column.h
+++ b/internal/core/src/mmap/Column.h
@@ -535,6 +535,7 @@ class VariableColumn : public ColumnBase {
  protected:
     void
     ConstructViews() {
+        views_.reserve(indices_.size());
         for (size_t i = 0; i < indices_.size() - 1; i++) {
             views_.emplace_back(data_ + indices_[i],
                                 indices_[i + 1] - indices_[i]);

--- a/internal/core/src/segcore/ConcurrentVector.h
+++ b/internal/core/src/segcore/ConcurrentVector.h
@@ -42,47 +42,46 @@ class ThreadSafeVector {
     void
     emplace_to_at_least(int64_t size, Args... args) {
         std::lock_guard lck(mutex_);
-        if (size <= size_) {
+        if (size <= vec_.size()) {
             return;
         }
         while (vec_.size() < size) {
             vec_.emplace_back(std::forward<Args...>(args...));
-            ++size_;
         }
     }
     const Type&
     operator[](int64_t index) const {
         std::shared_lock lck(mutex_);
-        AssertInfo(index < size_,
-                   fmt::format(
-                       "index out of range, index={}, size_={}", index, size_));
+        AssertInfo(
+            index < vec_.size(),
+            fmt::format(
+                "index out of range, index={}, size={}", index, vec_.size()));
         return vec_[index];
     }
 
     Type&
     operator[](int64_t index) {
         std::shared_lock lck(mutex_);
-        AssertInfo(index < size_,
-                   fmt::format(
-                       "index out of range, index={}, size_={}", index, size_));
+        AssertInfo(
+            index < vec_.size(),
+            fmt::format(
+                "index out of range, index={}, size={}", index, vec_.size()));
         return vec_[index];
     }
 
     int64_t
     size() const {
-        std::lock_guard lck(mutex_);
-        return size_;
+        std::shared_lock lck(mutex_);
+        return vec_.size();
     }
 
     void
     clear() {
         std::lock_guard lck(mutex_);
-        size_ = 0;
         vec_.clear();
     }
 
  private:
-    int64_t size_ = 0;
     std::deque<Type> vec_;
     mutable std::shared_mutex mutex_;
 };
@@ -255,6 +254,15 @@ class ConcurrentVectorImpl : public VectorBase {
         auto chunk_id = element_index / size_per_chunk_;
         auto chunk_offset = element_index % size_per_chunk_;
         return get_chunk(chunk_id).data() + chunk_offset * elements_per_row_;
+    }
+
+    size_t
+    num_of_element() const {
+        size_t num = 0;
+        for (size_t i = 0; i < chunks_.size(); i++) {
+            num += chunks_[i].size();
+        }
+        return num;
     }
 
     const Type&

--- a/internal/core/src/segcore/SealedIndexingRecord.h
+++ b/internal/core/src/segcore/SealedIndexingRecord.h
@@ -68,6 +68,17 @@ struct SealedIndexingRecord {
         field_indexings_.clear();
     }
 
+    void
+    range_over(std::function<bool(const FieldId&, const SealedIndexingEntryPtr)>
+                   f) const {
+        std::shared_lock lck(mutex_);
+        for (auto& kv : field_indexings_) {
+            if (!f(kv.first, kv.second)) {
+                return;
+            }
+        }
+    }
+
  private:
     // field_offset -> SealedIndexingEntry
     std::unordered_map<FieldId, SealedIndexingEntryPtr> field_indexings_;

--- a/internal/core/src/segcore/SegmentGrowingImpl.h
+++ b/internal/core/src/segcore/SegmentGrowingImpl.h
@@ -130,9 +130,10 @@ class SegmentGrowingImpl : public SegmentGrowing {
     try_remove_chunks(FieldId fieldId);
 
  public:
-    size_t
-    GetMemoryUsageInBytes() const override {
-        return stats_.mem_size.load() + deleted_record_.mem_size();
+    milvus::ResourceUsage
+    GetResourceUsage() const override {
+        auto mem_size = stats_.mem_size.load() + deleted_record_.mem_size();
+        return milvus::ResourceUsage{mem_size, 0};
     }
 
     int64_t

--- a/internal/core/src/segcore/SegmentInterface.h
+++ b/internal/core/src/segcore/SegmentInterface.h
@@ -43,6 +43,7 @@ struct SegmentStats {
     // we stat the memory size used by the segment,
     // including the insert data and delete data.
     std::atomic<size_t> mem_size{};
+    std::atomic<size_t> disk_size{};
 };
 
 // common interface of SegmentSealed and SegmentGrowing used by C API
@@ -77,8 +78,8 @@ class SegmentInterface {
              const int64_t* offsets,
              int64_t size) const = 0;
 
-    virtual size_t
-    GetMemoryUsageInBytes() const = 0;
+    virtual milvus::ResourceUsage
+    GetResourceUsage() const = 0;
 
     virtual int64_t
     get_row_count() const = 0;

--- a/internal/core/src/segcore/SegmentInterface.h
+++ b/internal/core/src/segcore/SegmentInterface.h
@@ -43,7 +43,6 @@ struct SegmentStats {
     // we stat the memory size used by the segment,
     // including the insert data and delete data.
     std::atomic<size_t> mem_size{};
-    std::atomic<size_t> disk_size{};
 };
 
 // common interface of SegmentSealed and SegmentGrowing used by C API

--- a/internal/core/src/segcore/SegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/SegmentSealedImpl.cpp
@@ -363,7 +363,6 @@ SegmentSealedImpl::LoadFieldData(FieldId field_id, FieldDataInfo& data) {
             insert_record_.timestamp_index_ = std::move(index);
             AssertInfo(insert_record_.timestamps_.num_chunk() == 1,
                        "num chunk not equal to 1 for sealed segment");
-            stats_.mem_size += sizeof(Timestamp) * data.row_count;
         } else {
             AssertInfo(system_field_type == SystemFieldType::RowId,
                        "System field type of id column is not RowId");
@@ -376,7 +375,6 @@ SegmentSealedImpl::LoadFieldData(FieldId field_id, FieldDataInfo& data) {
             insert_record_.row_ids_.fill_chunk_data(field_data);
             AssertInfo(insert_record_.row_ids_.num_chunk() == 1,
                        "num chunk not equal to 1 for sealed segment");
-            stats_.mem_size += sizeof(idx_t) * data.row_count;
         }
         ++system_ready_count_;
     } else {
@@ -1140,7 +1138,7 @@ SegmentSealedImpl::GetResourceUsage() const {
         usage.disk_size += indexResourceUsage.disk_size;
     }
     vector_indexings_.range_over(
-        [&](const auto& field_id, const auto& indexEntry) {
+        [&usage](const auto& field_id, const auto& indexEntry) {
             auto indexResourceUsage = indexEntry->indexing_->GetResourceUsage();
             usage.mem_size += indexResourceUsage.mem_size;
             usage.disk_size += indexResourceUsage.disk_size;
@@ -1174,7 +1172,6 @@ SegmentSealedImpl::ClearData() {
         insert_record_.clear();
         fields_.clear();
         variable_fields_avg_size_.clear();
-        stats_.mem_size = 0;
     }
     auto cc = storage::ChunkCacheSingleton::GetInstance().GetChunkCache();
     if (cc == nullptr) {

--- a/internal/core/src/segcore/SegmentSealedImpl.h
+++ b/internal/core/src/segcore/SegmentSealedImpl.h
@@ -308,8 +308,6 @@ class SegmentSealedImpl : public SegmentSealed {
     SegcoreConfig segcore_config_;
     std::unordered_map<FieldId, std::unique_ptr<VecIndexConfig>>
         vec_binlog_config_;
-
-    SegmentStats stats_{};
 };
 
 inline SegmentSealedUPtr

--- a/internal/core/src/segcore/SegmentSealedImpl.h
+++ b/internal/core/src/segcore/SegmentSealedImpl.h
@@ -92,10 +92,8 @@ class SegmentSealedImpl : public SegmentSealed {
     RemoveFieldFile(const FieldId field_id);
 
  public:
-    size_t
-    GetMemoryUsageInBytes() const override {
-        return stats_.mem_size.load() + deleted_record_.mem_size();
-    }
+    milvus::ResourceUsage
+    GetResourceUsage() const override;
 
     int64_t
     get_row_count() const override;

--- a/internal/core/src/segcore/segment_c.cpp
+++ b/internal/core/src/segcore/segment_c.cpp
@@ -190,11 +190,11 @@ RetrieveByOffsets(CTraceContext c_trace,
     }
 }
 
-int64_t
-GetMemoryUsageInBytes(CSegmentInterface c_segment) {
+CSegmentResourceUsage
+GetResourceUsageOfSegment(CSegmentInterface c_segment) {
     auto segment = static_cast<milvus::segcore::SegmentInterface*>(c_segment);
-    auto mem_size = segment->GetMemoryUsageInBytes();
-    return mem_size;
+    auto usage = segment->GetResourceUsage();
+    return CSegmentResourceUsage{usage.mem_size, usage.disk_size};
 }
 
 int64_t

--- a/internal/core/src/segcore/segment_c.h
+++ b/internal/core/src/segcore/segment_c.h
@@ -71,8 +71,8 @@ RetrieveByOffsets(CTraceContext c_trace,
                   int64_t* offsets,
                   int64_t len);
 
-int64_t
-GetMemoryUsageInBytes(CSegmentInterface c_segment);
+CSegmentResourceUsage
+GetResourceUsageOfSegment(CSegmentInterface c_segment);
 
 int64_t
 GetRowCount(CSegmentInterface c_segment);

--- a/internal/core/src/storage/DiskFileManagerImpl.cpp
+++ b/internal/core/src/storage/DiskFileManagerImpl.cpp
@@ -282,6 +282,18 @@ DiskFileManagerImpl::CacheIndexToDisk() {
     }
 }
 
+size_t
+DiskFileManagerImpl::GetLocalFileSize() const {
+    auto local_chunk_manager =
+        LocalChunkManagerSingleton::GetInstance().GetChunkManager();
+    size_t local_file_size = 0;
+    for (auto& file : local_paths_) {
+        auto size = local_chunk_manager->Size(file);
+        local_file_size += size;
+    }
+    return local_file_size;
+}
+
 void
 DiskFileManagerImpl::CacheIndexToDisk(
     const std::vector<std::string>& remote_files) {

--- a/internal/core/src/storage/DiskFileManagerImpl.h
+++ b/internal/core/src/storage/DiskFileManagerImpl.h
@@ -74,6 +74,9 @@ class DiskFileManagerImpl : public FileManagerImpl {
         return local_paths_;
     }
 
+    size_t
+    GetLocalFileSize() const;
+
     void
     CacheIndexToDisk(const std::vector<std::string>& remote_files);
 

--- a/internal/core/unittest/test_bitmap.cpp
+++ b/internal/core/unittest/test_bitmap.cpp
@@ -42,4 +42,17 @@ TEST(Bitmap, Naive) {
         }
         ASSERT_NEAR(count / N, 0.682, 0.01);
     }
+
+    {
+        auto binary_set = sort_index->Serialize(nullptr);
+        auto new_index = std::make_shared<index::ScalarIndexSort<float>>();
+        auto usage = new_index->GetResourceUsage();
+        ASSERT_EQ(usage.mem_size, 0);
+        ASSERT_EQ(usage.disk_size, 0);
+
+        new_index->Load(binary_set);
+        usage = new_index->GetResourceUsage();
+        ASSERT_GT(usage.mem_size, N * sizeof(float));
+        ASSERT_EQ(usage.disk_size, 0);
+    }
 }

--- a/internal/core/unittest/test_concurrent_vector.cpp
+++ b/internal/core/unittest/test_concurrent_vector.cpp
@@ -44,6 +44,9 @@ TEST(ConcurrentVector, TestSingle) {
             ASSERT_EQ(c_vec.get_element(i)[d], std_data);
         }
     }
+
+    auto num_of_element = c_vec.num_of_element();
+    ASSERT_GT(num_of_element, 32 * c_vec.num_chunk());
 }
 
 TEST(ConcurrentVector, TestMultithreads) {

--- a/internal/core/unittest/test_disk_file_manager_test.cpp
+++ b/internal/core/unittest/test_disk_file_manager_test.cpp
@@ -112,6 +112,10 @@ TEST_F(DiskAnnFileManagerTest, AddFilePositiveParallel) {
         EXPECT_EQ(rawData[4], data[4]);
     }
 
+    // Test file size.
+    auto local_file_size = diskAnnFileManager->GetLocalFileSize();
+    EXPECT_GT(local_file_size, 0);
+
     for (auto file : local_files) {
         cm_->Remove(file);
     }

--- a/internal/core/unittest/test_inverted_index.cpp
+++ b/internal/core/unittest/test_inverted_index.cpp
@@ -169,7 +169,18 @@ test_run() {
 
         auto index =
             index::IndexFactory::GetInstance().CreateIndex(index_info, ctx);
+
+        // There should no resource usage before Load.
+        auto usage = index->GetResourceUsage();
+        ASSERT_EQ(usage.mem_size, 0);
+        ASSERT_EQ(usage.disk_size, 0);
+
         index->Load(milvus::tracer::TraceContext{}, config);
+
+        // There should be some disk usage after load.
+        usage = index->GetResourceUsage();
+        ASSERT_EQ(usage.mem_size, 0);
+        ASSERT_GT(usage.disk_size, 0);
 
         auto cnt = index->Count();
         ASSERT_EQ(cnt, nb);
@@ -370,7 +381,18 @@ test_string() {
 
         auto index =
             index::IndexFactory::GetInstance().CreateIndex(index_info, ctx);
+
+        // There should no resource usage before Load.
+        auto usage = index->GetResourceUsage();
+        ASSERT_EQ(usage.mem_size, 0);
+        ASSERT_EQ(usage.disk_size, 0);
+
         index->Load(milvus::tracer::TraceContext{}, config);
+
+        // There should be some disk usage after Load.
+        usage = index->GetResourceUsage();
+        ASSERT_EQ(usage.mem_size, 0);
+        ASSERT_GT(usage.disk_size, 0);
 
         auto cnt = index->Count();
         ASSERT_EQ(cnt, nb);

--- a/internal/core/unittest/test_sealed.cpp
+++ b/internal/core/unittest/test_sealed.cpp
@@ -639,10 +639,19 @@ TEST(Sealed, ClearData) {
     std::cout << json.dump(1);
 
     auto sealed_segment = (SegmentSealedImpl*)segment.get();
+
+    auto usage = sealed_segment->GetResourceUsage();
+    ASSERT_GT(usage.mem_size, 0);
+    ASSERT_EQ(usage.disk_size, 0);
+
     sealed_segment->ClearData();
     ASSERT_EQ(sealed_segment->get_row_count(), 0);
     ASSERT_EQ(sealed_segment->get_real_count(), 0);
     ASSERT_ANY_THROW(segment->Search(plan.get(), ph_group.get(), timestamp));
+
+    usage = sealed_segment->GetResourceUsage();
+    ASSERT_EQ(usage.mem_size, 0);
+    ASSERT_EQ(usage.disk_size, 0);
 }
 
 TEST(Sealed, LoadFieldDataMmap) {

--- a/internal/querynodev2/metrics_info.go
+++ b/internal/querynodev2/metrics_info.go
@@ -116,7 +116,7 @@ func getQuotaMetrics(node *QueryNode) (*metricsinfo.QueryNodeQuotaMetrics, error
 	for _, collection := range collections {
 		segs := growingGroupByCollection[collection]
 		size := lo.SumBy(segs, func(seg segments.Segment) int64 {
-			return seg.MemSize()
+			return int64(seg.ResourceUsageEstimate().InUsed.MemorySize)
 		})
 		totalGrowingSize += size
 		metrics.QueryNodeEntitiesSize.WithLabelValues(nodeID, fmt.Sprint(collection),
@@ -147,7 +147,7 @@ func getQuotaMetrics(node *QueryNode) (*metricsinfo.QueryNodeQuotaMetrics, error
 	for _, collection := range collections {
 		segs := sealedGroupByCollection[collection]
 		size := lo.SumBy(segs, func(seg segments.Segment) int64 {
-			return seg.MemSize()
+			return int64(seg.ResourceUsageEstimate().InUsed.MemorySize)
 		})
 		metrics.QueryNodeEntitiesSize.WithLabelValues(fmt.Sprint(node.GetNodeID()),
 			fmt.Sprint(collection), segments.SegmentTypeSealed.String()).Set(float64(size))

--- a/internal/querynodev2/segments/manager.go
+++ b/internal/querynodev2/segments/manager.go
@@ -180,7 +180,7 @@ func NewManager() *Manager {
 		if segment == nil {
 			return 0
 		}
-		return int64(segment.ResourceUsageEstimate().DiskSize)
+		return int64(segment.ResourceUsageEstimate().Predict.DiskSize)
 	}, diskCap).WithLoader(func(ctx context.Context, key int64) (Segment, error) {
 		log.Debug("cache missed segment", zap.Int64("segmentID", key))
 		segment := segMgr.GetWithType(key, SegmentTypeSealed)
@@ -192,7 +192,7 @@ func NewManager() *Manager {
 		info := segment.LoadInfo()
 		_, err, _ := sf.Do(fmt.Sprint(segment.ID()), func() (nop interface{}, err error) {
 			cacheLoadRecord := metricsutil.NewCacheLoadRecord(getSegmentMetricLabel(segment))
-			cacheLoadRecord.WithBytes(segment.ResourceUsageEstimate().DiskSize)
+			cacheLoadRecord.WithBytes(segment.ResourceUsageEstimate().Predict.DiskSize)
 			defer func() {
 				cacheLoadRecord.Finish(err)
 			}()
@@ -213,7 +213,7 @@ func NewManager() *Manager {
 	}).WithFinalizer(func(ctx context.Context, key int64, segment Segment) error {
 		log.Ctx(ctx).Debug("evict segment from cache", zap.Int64("segmentID", key))
 		cacheEvictRecord := metricsutil.NewCacheEvictRecord(getSegmentMetricLabel(segment))
-		cacheEvictRecord.WithBytes(segment.ResourceUsageEstimate().DiskSize)
+		cacheEvictRecord.WithBytes(segment.ResourceUsageEstimate().Predict.DiskSize)
 		defer cacheEvictRecord.Finish(nil)
 		segment.Release(ctx, WithReleaseScope(ReleaseScopeData))
 		return nil

--- a/internal/querynodev2/segments/manager.go
+++ b/internal/querynodev2/segments/manager.go
@@ -29,13 +29,13 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 	"golang.org/x/sync/singleflight"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
 	"github.com/milvus-io/milvus/internal/proto/querypb"
-	"github.com/milvus-io/milvus/internal/querynodev2/segments/metricsutil"
 	"github.com/milvus-io/milvus/pkg/eventlog"
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/metrics"
@@ -44,7 +44,6 @@ import (
 	"github.com/milvus-io/milvus/pkg/util/metautil"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 // TODO maybe move to manager and change segment constructor
@@ -192,12 +191,6 @@ func NewManager() *Manager {
 		}
 		info := segment.LoadInfo()
 		_, err, _ := sf.Do(fmt.Sprint(segment.ID()), func() (nop interface{}, err error) {
-			cacheLoadRecord := metricsutil.NewCacheLoadRecord(getSegmentMetricLabel(segment))
-			cacheLoadRecord.WithBytes(segment.ResourceUsageEstimate().GetInuseOrPredictDiskUsage())
-			defer func() {
-				cacheLoadRecord.Finish(err)
-			}()
-
 			collection := manager.Collection.Get(segment.Collection())
 			if collection == nil {
 				return nil, merr.WrapErrCollectionNotLoaded(segment.Collection(), "failed to load segment fields")
@@ -213,10 +206,6 @@ func NewManager() *Manager {
 		return segment, nil
 	}).WithFinalizer(func(ctx context.Context, key int64, segment Segment) error {
 		log.Ctx(ctx).Debug("evict segment from cache", zap.Int64("segmentID", key))
-		cacheEvictRecord := metricsutil.NewCacheEvictRecord(getSegmentMetricLabel(segment))
-		cacheEvictRecord.WithBytes(segment.ResourceUsageEstimate().GetInuseOrPredictDiskUsage())
-		defer cacheEvictRecord.Finish(nil)
-
 		segment.Release(ctx, WithReleaseScope(ReleaseScopeData))
 		return nil
 	}).WithReloader(func(ctx context.Context, key int64) (Segment, error) {
@@ -243,6 +232,7 @@ func NewManager() *Manager {
 
 	// register the lru cache metrics.
 	cache.RegisterLRUCacheMetrics(
+		metrics.GetRegisterer(),
 		manager.DiskCache,
 		typeutil.Milvus,
 		typeutil.QueryNodeRole,

--- a/internal/querynodev2/segments/metricsutil/observer.go
+++ b/internal/querynodev2/segments/metricsutil/observer.go
@@ -165,8 +165,6 @@ func newPromObserver(nodeID string, label SegmentLabel) promMetricsObserver {
 		SearchSegmentAccessWaitCacheTotal:    metrics.QueryNodeSegmentAccessWaitCacheTotal.WithLabelValues(nodeID, label.DatabaseName, label.ResourceGroup, metrics.SearchLabel),
 		SearchSegmentAccessWaitCacheDuration: metrics.QueryNodeSegmentAccessWaitCacheDuration.WithLabelValues(nodeID, label.DatabaseName, label.ResourceGroup, metrics.SearchLabel),
 
-		DiskCacheLoadGlobalDuration:                metrics.QueryNodeDiskCacheLoadGlobalDuration.WithLabelValues(nodeID),
-		DiskCacheEvictGlobalDuration:               metrics.QueryNodeDiskCacheEvictGlobalDuration.WithLabelValues(nodeID),
 		QuerySegmentAccessGlobalDuration:           metrics.QueryNodeSegmentAccessGlobalDuration.WithLabelValues(nodeID, metrics.QueryLabel),
 		SearchSegmentAccessGlobalDuration:          metrics.QueryNodeSegmentAccessGlobalDuration.WithLabelValues(nodeID, metrics.SearchLabel),
 		QuerySegmentAccessWaitCacheGlobalDuration:  metrics.QueryNodeSegmentAccessWaitCacheGlobalDuration.WithLabelValues(nodeID, metrics.QueryLabel),
@@ -194,8 +192,6 @@ type promMetricsObserver struct {
 	SearchSegmentAccessWaitCacheTotal    prometheus.Counter
 	SearchSegmentAccessWaitCacheDuration prometheus.Counter
 
-	DiskCacheLoadGlobalDuration                prometheus.Observer
-	DiskCacheEvictGlobalDuration               prometheus.Observer
 	QuerySegmentAccessGlobalDuration           prometheus.Observer
 	SearchSegmentAccessGlobalDuration          prometheus.Observer
 	QuerySegmentAccessWaitCacheGlobalDuration  prometheus.Observer
@@ -208,7 +204,6 @@ func (o *promMetricsObserver) ObserveCacheLoad(r *CacheLoadRecord) {
 	o.DiskCacheLoadBytes.Add(r.getBytes())
 	d := r.getMilliseconds()
 	o.DiskCacheLoadDuration.Add(d)
-	o.DiskCacheLoadGlobalDuration.Observe(d)
 }
 
 // ObserveCacheEvict records a new cache evict.
@@ -217,7 +212,6 @@ func (o *promMetricsObserver) ObserveCacheEvict(r *CacheEvictRecord) {
 	o.DiskCacheEvictBytes.Add(r.getBytes())
 	d := r.getMilliseconds()
 	o.DiskCacheEvictDuration.Add(d)
-	o.DiskCacheEvictGlobalDuration.Observe(d)
 }
 
 // ObserveQueryAccess records a new query access.

--- a/internal/querynodev2/segments/metricsutil/observer_test.go
+++ b/internal/querynodev2/segments/metricsutil/observer_test.go
@@ -14,12 +14,6 @@ func TestSegmentGather(t *testing.T) {
 	}
 	g := newSegmentObserver("1", l)
 
-	r1 := NewCacheLoadRecord(l)
-	g.Observe(r1)
-
-	r2 := NewCacheEvictRecord(l)
-	g.Observe(r2)
-
 	r3 := NewQuerySegmentAccessRecord(l)
 	g.Observe(r3)
 

--- a/internal/querynodev2/segments/metricsutil/record.go
+++ b/internal/querynodev2/segments/metricsutil/record.go
@@ -9,73 +9,12 @@ import (
 var (
 	_ labeledRecord = QuerySegmentAccessRecord{}
 	_ labeledRecord = SearchSegmentAccessRecord{}
-	_ labeledRecord = &CacheLoadRecord{}
-	_ labeledRecord = &CacheEvictRecord{}
 )
 
 // SegmentLabel is the label of a segment.
 type SegmentLabel struct {
 	DatabaseName  string `expr:"DatabaseName"`
 	ResourceGroup string `expr:"ResourceGroup"`
-}
-
-// CacheLoadRecord records the metrics of a cache load.
-type CacheLoadRecord struct {
-	numBytes uint64
-	baseRecord
-}
-
-// NewCacheLoadRecord creates a new CacheLoadRecord.
-func NewCacheLoadRecord(label SegmentLabel) *CacheLoadRecord {
-	return &CacheLoadRecord{
-		baseRecord: newBaseRecord(label),
-	}
-}
-
-// WithBytes sets the bytes of the record.
-func (r *CacheLoadRecord) WithBytes(bytes uint64) *CacheLoadRecord {
-	r.numBytes = bytes
-	return r
-}
-
-// getBytes returns the bytes of the record.
-func (r *CacheLoadRecord) getBytes() float64 {
-	return float64(r.numBytes)
-}
-
-// Finish finishes the record.
-func (r *CacheLoadRecord) Finish(err error) {
-	r.baseRecord.finish(err)
-	getGlobalObserver().Observe(r)
-}
-
-type CacheEvictRecord struct {
-	bytes uint64
-	baseRecord
-}
-
-// NewCacheEvictRecord creates a new CacheEvictRecord.
-func NewCacheEvictRecord(label SegmentLabel) *CacheEvictRecord {
-	return &CacheEvictRecord{
-		baseRecord: newBaseRecord(label),
-	}
-}
-
-// WithBytes sets the bytes of the record.
-func (r *CacheEvictRecord) WithBytes(bytes uint64) *CacheEvictRecord {
-	r.bytes = bytes
-	return r
-}
-
-// getBytes returns the bytes of the record.
-func (r *CacheEvictRecord) getBytes() float64 {
-	return float64(r.bytes)
-}
-
-// Finish finishes the record.
-func (r *CacheEvictRecord) Finish(err error) {
-	r.baseRecord.finish(err)
-	getGlobalObserver().Observe(r)
 }
 
 // NewQuerySegmentAccessRecord creates a new QuerySegmentMetricRecorder.

--- a/internal/querynodev2/segments/metricsutil/record_test.go
+++ b/internal/querynodev2/segments/metricsutil/record_test.go
@@ -89,12 +89,3 @@ func TestQuerySegmentAccessMetric(t *testing.T) {
 	m.Finish(nil)
 	assert.NotZero(t, m.getDuration())
 }
-
-func TestCacheRecord(t *testing.T) {
-	r1 := NewCacheLoadRecord(testLabel)
-	r1.WithBytes(1)
-	assert.Equal(t, float64(1), r1.getBytes())
-	r1.Finish(nil)
-	r2 := NewCacheEvictRecord(testLabel)
-	r2.Finish(nil)
-}

--- a/internal/querynodev2/segments/mock_segment.go
+++ b/internal/querynodev2/segments/mock_segment.go
@@ -794,47 +794,6 @@ func (_c *MockSegment_MayPkExist_Call) RunAndReturn(run func(storage.PrimaryKey)
 	return _c
 }
 
-// MemSize provides a mock function with given fields:
-func (_m *MockSegment) MemSize() int64 {
-	ret := _m.Called()
-
-	var r0 int64
-	if rf, ok := ret.Get(0).(func() int64); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(int64)
-	}
-
-	return r0
-}
-
-// MockSegment_MemSize_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MemSize'
-type MockSegment_MemSize_Call struct {
-	*mock.Call
-}
-
-// MemSize is a helper method to define mock.On call
-func (_e *MockSegment_Expecter) MemSize() *MockSegment_MemSize_Call {
-	return &MockSegment_MemSize_Call{Call: _e.mock.On("MemSize")}
-}
-
-func (_c *MockSegment_MemSize_Call) Run(run func()) *MockSegment_MemSize_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *MockSegment_MemSize_Call) Return(_a0 int64) *MockSegment_MemSize_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockSegment_MemSize_Call) RunAndReturn(run func() int64) *MockSegment_MemSize_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // NeedUpdatedVersion provides a mock function with given fields:
 func (_m *MockSegment) NeedUpdatedVersion() int64 {
 	ret := _m.Called()
@@ -1122,14 +1081,14 @@ func (_c *MockSegment_ResourceGroup_Call) RunAndReturn(run func() string) *MockS
 }
 
 // ResourceUsageEstimate provides a mock function with given fields:
-func (_m *MockSegment) ResourceUsageEstimate() ResourceUsage {
+func (_m *MockSegment) ResourceUsageEstimate() SegmentResourceUsage {
 	ret := _m.Called()
 
-	var r0 ResourceUsage
-	if rf, ok := ret.Get(0).(func() ResourceUsage); ok {
+	var r0 SegmentResourceUsage
+	if rf, ok := ret.Get(0).(func() SegmentResourceUsage); ok {
 		r0 = rf()
 	} else {
-		r0 = ret.Get(0).(ResourceUsage)
+		r0 = ret.Get(0).(SegmentResourceUsage)
 	}
 
 	return r0
@@ -1152,12 +1111,12 @@ func (_c *MockSegment_ResourceUsageEstimate_Call) Run(run func()) *MockSegment_R
 	return _c
 }
 
-func (_c *MockSegment_ResourceUsageEstimate_Call) Return(_a0 ResourceUsage) *MockSegment_ResourceUsageEstimate_Call {
+func (_c *MockSegment_ResourceUsageEstimate_Call) Return(_a0 SegmentResourceUsage) *MockSegment_ResourceUsageEstimate_Call {
 	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *MockSegment_ResourceUsageEstimate_Call) RunAndReturn(run func() ResourceUsage) *MockSegment_ResourceUsageEstimate_Call {
+func (_c *MockSegment_ResourceUsageEstimate_Call) RunAndReturn(run func() SegmentResourceUsage) *MockSegment_ResourceUsageEstimate_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/querynodev2/segments/reduce_test.go
+++ b/internal/querynodev2/segments/reduce_test.go
@@ -99,10 +99,14 @@ func (suite *ReduceSuite) SetupTest() {
 		suite.chunkManager,
 	)
 	suite.Require().NoError(err)
+
+	guard, err := suite.segment.(*LocalSegment).StartLoadData()
+	suite.Require().NoError(err)
 	for _, binlog := range binlogs {
 		err = suite.segment.(*LocalSegment).LoadFieldData(ctx, binlog.FieldID, int64(msgLength), binlog)
 		suite.Require().NoError(err)
 	}
+	guard.Done(nil)
 }
 
 func (suite *ReduceSuite) TearDownTest() {

--- a/internal/querynodev2/segments/retrieve.go
+++ b/internal/querynodev2/segments/retrieve.go
@@ -140,13 +140,18 @@ func retrieveOnSegmentsWithStream(ctx context.Context, segments []Segment, segTy
 				return
 			}
 
+			relatedDataSize := int64(segment.ResourceUsageEstimate().InUsed.MemorySize)
+			if segment.Type() == SegmentTypeSealed {
+				relatedDataSize = int64(segment.ResourceUsageEstimate().BinLogSizeAtOSS)
+			}
+
 			if len(result.GetOffset()) != 0 {
 				if err = svr.Send(&internalpb.RetrieveResults{
 					Status:     merr.Success(),
 					Ids:        result.GetIds(),
 					FieldsData: result.GetFieldsData(),
 					CostAggregation: &internalpb.CostAggregation{
-						TotalRelatedDataSize: segment.MemSize(),
+						TotalRelatedDataSize: relatedDataSize,
 					},
 					AllRetrieveCount: result.GetAllRetrieveCount(),
 				}); err != nil {

--- a/internal/querynodev2/segments/retrieve_test.go
+++ b/internal/querynodev2/segments/retrieve_test.go
@@ -108,10 +108,14 @@ func (suite *RetrieveSuite) SetupTest() {
 		suite.chunkManager,
 	)
 	suite.Require().NoError(err)
+
+	guard, err := suite.sealed.(*LocalSegment).StartLoadData()
+	suite.Require().NoError(err)
 	for _, binlog := range binlogs {
 		err = suite.sealed.(*LocalSegment).LoadFieldData(ctx, binlog.FieldID, int64(msgLength), binlog)
 		suite.Require().NoError(err)
 	}
+	guard.Done(nil)
 
 	suite.growing, err = NewSegment(ctx,
 		suite.collection,

--- a/internal/querynodev2/segments/search_test.go
+++ b/internal/querynodev2/segments/search_test.go
@@ -99,10 +99,14 @@ func (suite *SearchSuite) SetupTest() {
 		suite.chunkManager,
 	)
 	suite.Require().NoError(err)
+
+	guard, err := suite.sealed.(*LocalSegment).StartLoadData()
+	suite.Require().NoError(err)
 	for _, binlog := range binlogs {
 		err = suite.sealed.(*LocalSegment).LoadFieldData(ctx, binlog.FieldID, int64(msgLength), binlog)
 		suite.Require().NoError(err)
 	}
+	guard.Done(nil)
 
 	suite.growing, err = NewSegment(ctx,
 		suite.collection,

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -366,6 +366,9 @@ func NewSegmentV2(
 		space:              space,
 		rowNum:             atomic.NewInt64(-1),
 		insertCount:        atomic.NewInt64(0),
+
+		predictResourceUsageCache: atomic.NewPointer[ResourceUsage](nil),
+		inUseResourceUsageCache:   atomic.NewPointer[ResourceUsage](nil),
 	}
 
 	if err := segment.initializeSegment(); err != nil {

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -90,8 +90,6 @@ type baseSegment struct {
 	isLazyLoad     bool
 	channel        metautil.Channel
 
-	resourceUsageCache *atomic.Pointer[ResourceUsage]
-
 	needUpdatedVersion *atomic.Int64 // only for lazy load mode update index
 }
 
@@ -109,7 +107,6 @@ func newBaseSegment(collection *Collection, segmentType SegmentType, version int
 		channel:        channel,
 		isLazyLoad:     isLazyLoad(collection, segmentType),
 
-		resourceUsageCache: atomic.NewPointer[ResourceUsage](nil),
 		needUpdatedVersion: atomic.NewInt64(0),
 	}
 	return bs, nil
@@ -195,42 +192,12 @@ func (s *baseSegment) GetHashFuncNum() uint {
 	return s.bloomFilterSet.GetHashFuncNum()
 }
 
-// ResourceUsageEstimate returns the estimated resource usage of the segment.
-func (s *baseSegment) ResourceUsageEstimate() ResourceUsage {
-	if s.segmentType == SegmentTypeGrowing {
-		// Growing segment cannot do resource usage estimate.
-		return ResourceUsage{}
-	}
-	cache := s.resourceUsageCache.Load()
-	if cache != nil {
-		return *cache
-	}
-
-	usage, err := getResourceUsageEstimateOfSegment(s.collection.Schema(), s.LoadInfo(), resourceEstimateFactor{
-		memoryUsageFactor:        1.0,
-		memoryIndexUsageFactor:   1.0,
-		enableTempSegmentIndex:   false,
-		deltaDataExpansionFactor: paramtable.Get().QueryNodeCfg.DeltaDataExpansionRate.GetAsFloat(),
-	})
-	if err != nil {
-		// Should never failure, if failed, segment should never be loaded.
-		log.Warn("unreachable: failed to get resource usage estimate of segment", zap.Error(err), zap.Int64("collectionID", s.Collection()), zap.Int64("segmentID", s.ID()))
-		return ResourceUsage{}
-	}
-	s.resourceUsageCache.Store(usage)
-	return *usage
-}
-
 func (s *baseSegment) IsLazyLoad() bool {
 	return s.isLazyLoad
 }
 
 func (s *baseSegment) NeedUpdatedVersion() int64 {
 	return s.needUpdatedVersion.Load()
-}
-
-func (s *baseSegment) SetLoadInfo(loadInfo *querypb.SegmentLoadInfo) {
-	s.loadInfo.Store(loadInfo)
 }
 
 func (s *baseSegment) SetNeedUpdatedVersion(version int64) {
@@ -251,9 +218,10 @@ type LocalSegment struct {
 	ptr     C.CSegmentInterface
 
 	// cached results, to avoid too many CGO calls
-	memSize     *atomic.Int64
-	rowNum      *atomic.Int64
-	insertCount *atomic.Int64
+	predictResourceUsageCache *atomic.Pointer[ResourceUsage]
+	inUseResourceUsageCache   *atomic.Pointer[ResourceUsage]
+	rowNum                    *atomic.Int64
+	insertCount               *atomic.Int64
 
 	lastDeltaTimestamp *atomic.Uint64
 	fields             *typeutil.ConcurrentMap[int64, *FieldInfo]
@@ -324,9 +292,11 @@ func NewSegment(ctx context.Context,
 		fields:             typeutil.NewConcurrentMap[int64, *FieldInfo](),
 		fieldIndexes:       typeutil.NewConcurrentMap[int64, *IndexedFieldInfo](),
 
-		memSize:     atomic.NewInt64(-1),
 		rowNum:      atomic.NewInt64(-1),
 		insertCount: atomic.NewInt64(0),
+
+		predictResourceUsageCache: atomic.NewPointer[ResourceUsage](nil),
+		inUseResourceUsageCache:   atomic.NewPointer[ResourceUsage](nil),
 	}
 
 	if err := segment.initializeSegment(); err != nil {
@@ -394,7 +364,6 @@ func NewSegmentV2(
 		fields:             typeutil.NewConcurrentMap[int64, *FieldInfo](),
 		fieldIndexes:       typeutil.NewConcurrentMap[int64, *IndexedFieldInfo](),
 		space:              space,
-		memSize:            atomic.NewInt64(-1),
 		rowNum:             atomic.NewInt64(-1),
 		insertCount:        atomic.NewInt64(0),
 	}
@@ -472,8 +441,7 @@ func (s *LocalSegment) InsertCount() int64 {
 
 func (s *LocalSegment) RowNum() int64 {
 	// if segment is not loaded, return 0 (maybe not loaded or release by lru)
-	if !s.ptrLock.RLockIf(state.IsDataLoaded) {
-		log.Warn("segment is not valid", zap.Int64("segmentID", s.ID()))
+	if _, locked := s.ptrLock.RLockIf(state.IsDataLoaded); !locked {
 		return 0
 	}
 	defer s.ptrLock.RUnlock()
@@ -492,24 +460,93 @@ func (s *LocalSegment) RowNum() int64 {
 	return rowNum
 }
 
-func (s *LocalSegment) MemSize() int64 {
-	if !s.ptrLock.RLockIf(state.IsNotReleased) {
-		return 0
+// ResourceUsageEstimate estimates the resource usage of a segment.
+func (s *LocalSegment) ResourceUsageEstimate() SegmentResourceUsage {
+	predictResourceUsage := s.predictResourceUsageEstimate()
+	inUseResourceUsage := s.inUseResourceUsageEstimate()
+	segmentSize := s.LoadInfo().GetSegmentSize()
+
+	usage := SegmentResourceUsage{
+		BinLogSizeAtOSS: uint64(segmentSize),
+	}
+	if predictResourceUsage != nil {
+		usage.Predict = *predictResourceUsage
+	}
+	if inUseResourceUsage != nil {
+		usage.InUsed = *inUseResourceUsage
+	}
+	return usage
+}
+
+// inUseResourceUsageEstimate estimates the resource usage of a sealed segment based on loaded.
+func (s *LocalSegment) inUseResourceUsageEstimate() *ResourceUsage {
+	cachedUsage := s.inUseResourceUsageCache.Load()
+	if cachedUsage != nil {
+		return cachedUsage
+	}
+
+	if _, locked := s.ptrLock.RLockIf(state.IsDataLoaded); !locked {
+		return &ResourceUsage{}
 	}
 	defer s.ptrLock.RUnlock()
 
-	memSize := s.memSize.Load()
-	if memSize < 0 {
-		var cMemSize C.int64_t
-		GetDynamicPool().Submit(func() (any, error) {
-			cMemSize = C.GetMemoryUsageInBytes(s.ptr)
-			s.memSize.Store(int64(cMemSize))
-			return nil, nil
-		}).Await()
+	// Get the resource usage of the segment from C side.
+	var resourceUsage *ResourceUsage
+	GetDynamicPool().Submit(func() (any, error) {
+		usage := C.GetResourceUsageOfSegment(s.ptr)
+		resourceUsage = &ResourceUsage{
+			MemorySize: uint64(usage.mem_size),
+			DiskSize:   uint64(usage.disk_size),
+		}
+		return nil, nil
+	})
 
-		memSize = int64(cMemSize)
+	// vector' bin log size need to be include if vector index doesn't has raw data.
+	// we can calculate on go side, because the bin log size may be not loaded (Warmup or search) when we start to estimate the disk usage.
+	// scalar has been included at C side, so don't need to include here.
+	binLogDiskSize := uint64(0)
+	for _, fieldSchema := range s.collection.Schema().GetFields() {
+		if typeutil.IsVectorType(fieldSchema.GetDataType()) {
+			if fieldIndexInfo, ok := s.fieldIndexes.Get(fieldSchema.GetFieldID()); ok && fieldIndexInfo.IsLoaded && !s.HasRawData(fieldSchema.FieldID) {
+				for _, binlog := range fieldIndexInfo.FieldBinlog.GetBinlogs() {
+					binLogDiskSize += uint64(binlog.GetLogSize())
+				}
+			}
+		}
 	}
-	return memSize
+	// always mmap here, so it's a disk size but not a mem size.
+	resourceUsage.DiskSize += binLogDiskSize
+
+	s.inUseResourceUsageCache.Store(resourceUsage)
+	return resourceUsage
+}
+
+// predictResourceUsageEstimate estimates the resource usage of a sealed segment based on meta info.
+func (s *LocalSegment) predictResourceUsageEstimate() *ResourceUsage {
+	if s.segmentType == SegmentTypeGrowing {
+		// Growing segment cannot do resource usage estimate.
+		return &ResourceUsage{}
+	}
+
+	cachedUsage := s.predictResourceUsageCache.Load()
+	if cachedUsage != nil {
+		return cachedUsage
+	}
+
+	usage, _, err := getResourceUsageEstimateOfSegment(s.collection.Schema(), s.LoadInfo(), resourceEstimateFactor{
+		memoryUsageFactor:        1.0,
+		memoryIndexUsageFactor:   1.0,
+		enableTempSegmentIndex:   false,
+		deltaDataExpansionFactor: paramtable.Get().QueryNodeCfg.DeltaDataExpansionRate.GetAsFloat(),
+	})
+	if err != nil {
+		// Should never failure, if failed, segment should never be loaded.
+		log.Warn("unreachable: failed to get resource usage estimate of segment", zap.Error(err), zap.Int64("collectionID", s.Collection()), zap.Int64("segmentID", s.ID()))
+		return nil
+	}
+
+	s.predictResourceUsageCache.Store(usage)
+	return usage
 }
 
 func (s *LocalSegment) LastDeltaTimestamp() uint64 {
@@ -530,7 +567,7 @@ func (s *LocalSegment) ExistIndex(fieldID int64) bool {
 }
 
 func (s *LocalSegment) HasRawData(fieldID int64) bool {
-	if !s.ptrLock.RLockIf(state.IsNotReleased) {
+	if _, locked := s.ptrLock.RLockIf(state.IsNotReleased); !locked {
 		return false
 	}
 	defer s.ptrLock.RUnlock()
@@ -569,8 +606,7 @@ func (s *LocalSegment) Search(ctx context.Context, searchReq *SearchRequest) (*S
 		zap.Int64("segmentID", s.ID()),
 		zap.String("segmentType", s.segmentType.String()),
 	)
-	if !s.ptrLock.RLockIf(state.IsNotReleased) {
-		// TODO: check if the segment is readable but not released. too many related logic need to be refactor.
+	if _, locked := s.ptrLock.RLockIf(state.IsDataLoaded); !locked {
 		return nil, merr.WrapErrSegmentNotLoaded(s.ID(), "segment released")
 	}
 	defer s.ptrLock.RUnlock()
@@ -607,8 +643,7 @@ func (s *LocalSegment) Search(ctx context.Context, searchReq *SearchRequest) (*S
 }
 
 func (s *LocalSegment) Retrieve(ctx context.Context, plan *RetrievePlan) (*segcorepb.RetrieveResults, error) {
-	if !s.ptrLock.RLockIf(state.IsNotReleased) {
-		// TODO: check if the segment is readable but not released. too many related logic need to be refactor.
+	if _, locked := s.ptrLock.RLockIf(state.IsDataLoaded); !locked {
 		return nil, merr.WrapErrSegmentNotLoaded(s.ID(), "segment released")
 	}
 	defer s.ptrLock.RUnlock()
@@ -672,15 +707,10 @@ func (s *LocalSegment) Retrieve(ctx context.Context, plan *RetrievePlan) (*segco
 }
 
 func (s *LocalSegment) RetrieveByOffsets(ctx context.Context, plan *RetrievePlan, offsets []int64) (*segcorepb.RetrieveResults, error) {
-	if !s.ptrLock.RLockIf(state.IsNotReleased) {
-		// TODO: check if the segment is readable but not released. too many related logic need to be refactor.
+	if _, locked := s.ptrLock.RLockIf(state.IsDataLoaded); !locked {
 		return nil, merr.WrapErrSegmentNotLoaded(s.ID(), "segment released")
 	}
 	defer s.ptrLock.RUnlock()
-
-	if s.ptr == nil {
-		return nil, merr.WrapErrSegmentNotLoaded(s.ID(), "segment released")
-	}
 
 	if len(offsets) == 0 {
 		return nil, merr.WrapErrParameterInvalid("segment offsets", "empty offsets")
@@ -770,7 +800,7 @@ func (s *LocalSegment) Insert(ctx context.Context, rowIDs []int64, timestamps []
 	if s.Type() != SegmentTypeGrowing {
 		return fmt.Errorf("unexpected segmentType when segmentInsert, segmentType = %s", s.segmentType.String())
 	}
-	if !s.ptrLock.RLockIf(state.IsNotReleased) {
+	if _, locked := s.ptrLock.RLockIf(state.IsNotReleased); !locked {
 		return merr.WrapErrSegmentNotLoaded(s.ID(), "segment released")
 	}
 	defer s.ptrLock.RUnlock()
@@ -819,7 +849,7 @@ func (s *LocalSegment) Insert(ctx context.Context, rowIDs []int64, timestamps []
 	).Add(float64(numOfRow))
 
 	s.rowNum.Store(-1)
-	s.memSize.Store(-1)
+	s.inUseResourceUsageCache.Store(nil)
 	return nil
 }
 
@@ -836,10 +866,13 @@ func (s *LocalSegment) Delete(ctx context.Context, primaryKeys []storage.Primary
 	if len(primaryKeys) == 0 {
 		return nil
 	}
-	if !s.ptrLock.RLockIf(state.IsNotReleased) {
+	if _, locked := s.ptrLock.RLockIf(state.IsNotReleased); !locked {
 		return merr.WrapErrSegmentNotLoaded(s.ID(), "segment released")
 	}
-	defer s.ptrLock.RUnlock()
+	defer func() {
+		s.inUseResourceUsageCache.Store(nil)
+		s.ptrLock.RUnlock()
+	}()
 
 	cOffset := C.int64_t(0) // depre
 	cSize := C.int64_t(len(primaryKeys))
@@ -904,7 +937,7 @@ func (s *LocalSegment) LoadMultiFieldData(ctx context.Context) error {
 	rowCount := loadInfo.GetNumOfRows()
 	fields := loadInfo.GetBinlogPaths()
 
-	if !s.ptrLock.RLockIf(state.IsNotReleased) {
+	if _, locked := s.ptrLock.RLockIf(state.IsNotReleased); !locked {
 		return merr.WrapErrSegmentNotLoaded(s.ID(), "segment released")
 	}
 	defer s.ptrLock.RUnlock()
@@ -969,7 +1002,7 @@ func (s *LocalSegment) LoadMultiFieldData(ctx context.Context) error {
 }
 
 func (s *LocalSegment) LoadFieldData(ctx context.Context, fieldID int64, rowCount int64, field *datapb.FieldBinlog) error {
-	if !s.ptrLock.RLockIf(state.IsNotReleased) {
+	if _, locked := s.ptrLock.RLockIf(state.IsNotReleased); !locked {
 		return merr.WrapErrSegmentNotLoaded(s.ID(), "segment released")
 	}
 	defer s.ptrLock.RUnlock()
@@ -1132,7 +1165,7 @@ func (s *LocalSegment) LoadDeltaData2(ctx context.Context, schema *schemapb.Coll
 }
 
 func (s *LocalSegment) AddFieldDataInfo(ctx context.Context, rowCount int64, fields []*datapb.FieldBinlog) error {
-	if !s.ptrLock.RLockIf(state.IsNotReleased) {
+	if _, locked := s.ptrLock.RLockIf(state.IsNotReleased); !locked {
 		return merr.WrapErrSegmentNotLoaded(s.ID(), "segment released")
 	}
 	defer s.ptrLock.RUnlock()
@@ -1185,7 +1218,7 @@ func (s *LocalSegment) LoadDeltaData(ctx context.Context, deltaData *storage.Del
 	pks, tss := deltaData.Pks, deltaData.Tss
 	rowNum := deltaData.RowCount
 
-	if !s.ptrLock.RLockIf(state.IsNotReleased) {
+	if _, locked := s.ptrLock.RLockIf(state.IsNotReleased); !locked {
 		return merr.WrapErrSegmentNotLoaded(s.ID(), "segment released")
 	}
 	defer s.ptrLock.RUnlock()
@@ -1277,7 +1310,10 @@ func (s *LocalSegment) LoadIndex(ctx context.Context, indexInfo *querypb.FieldIn
 	}
 
 	ctx, sp := otel.Tracer(typeutil.QueryNodeRole).Start(ctx, fmt.Sprintf("LoadIndex-%d-%d", s.ID(), indexInfo.GetFieldID()))
-	defer sp.End()
+	defer func() {
+		s.inUseResourceUsageCache.Store(nil)
+		sp.End()
+	}()
 
 	tr := timerecord.NewTimeRecorder("loadIndex")
 	// 1.
@@ -1340,7 +1376,7 @@ func (s *LocalSegment) UpdateIndexInfo(ctx context.Context, indexInfo *querypb.F
 		zap.Int64("segmentID", s.ID()),
 		zap.Int64("fieldID", indexInfo.FieldID),
 	)
-	if !s.ptrLock.RLockIf(state.IsNotReleased) {
+	if _, locked := s.ptrLock.RLockIf(state.IsNotReleased); !locked {
 		return merr.WrapErrSegmentNotLoaded(s.ID(), "segment released")
 	}
 	defer s.ptrLock.RUnlock()
@@ -1377,7 +1413,7 @@ func (s *LocalSegment) WarmupChunkCache(ctx context.Context, fieldID int64) {
 		zap.Int64("segmentID", s.ID()),
 		zap.Int64("fieldID", fieldID),
 	)
-	if !s.ptrLock.RLockIf(state.IsNotReleased) {
+	if _, locked := s.ptrLock.RLockIf(state.IsNotReleased); !locked {
 		return
 	}
 	defer s.ptrLock.RUnlock()
@@ -1399,7 +1435,7 @@ func (s *LocalSegment) WarmupChunkCache(ctx context.Context, fieldID int64) {
 		}).Await()
 	case "async":
 		GetLoadPool().Submit(func() (any, error) {
-			if !s.ptrLock.RLockIf(state.IsNotReleased) {
+			if _, locked := s.ptrLock.RLockIf(state.IsNotReleased); !locked {
 				return nil, nil
 			}
 			defer s.ptrLock.RUnlock()
@@ -1556,4 +1592,11 @@ func (s *LocalSegment) indexNeedLoadRawData(schema *schemapb.CollectionSchema, i
 		return false, err
 	}
 	return !typeutil.IsVectorType(fieldSchema.DataType) && s.HasRawData(indexInfo.IndexInfo.FieldID), nil
+}
+
+// SetLoadInfo sets the load info of the segment.
+func (s *LocalSegment) SetLoadInfo(loadInfo *querypb.SegmentLoadInfo) {
+	s.loadInfo.Store(loadInfo)
+	s.inUseResourceUsageCache.Store(nil)
+	s.predictResourceUsageCache.Store(nil)
 }

--- a/internal/querynodev2/segments/segment_interface.go
+++ b/internal/querynodev2/segments/segment_interface.go
@@ -38,8 +38,17 @@ type SegmentResourceUsage struct {
 	// include stat_log, insert_log and delta_log, not include any index files.
 }
 
+// GetInuseOrPredictDiskUsage return the inused disk usage.
+// if the inused disk usage is 0,return the predicted disk usage.
+func (sru SegmentResourceUsage) GetInuseOrPredictDiskUsage() uint64 {
+	if sru.InUsed.DiskSize != 0 {
+		return sru.InUsed.DiskSize
+	}
+	return sru.Predict.DiskSize
+}
+
 // String returns a string representation of the SegmentResourceUsage.
-func (sru *SegmentResourceUsage) String() string {
+func (sru SegmentResourceUsage) String() string {
 	return fmt.Sprintf("Predict: %s, InUsed: %s, BinLogSizeAtOSS: %d", sru.Predict.String(), sru.InUsed.String(), sru.BinLogSizeAtOSS)
 }
 

--- a/internal/querynodev2/segments/segment_interface.go
+++ b/internal/querynodev2/segments/segment_interface.go
@@ -60,7 +60,7 @@ type ResourceUsage struct {
 
 // String returns a string representation of the ResourceUsage.
 func (ru *ResourceUsage) String() string {
-	return fmt.Sprintf("MemorySize: %d, DiskSize: %d", ru.MemorySize, ru.DiskSize)
+	return fmt.Sprintf("Mem: %d, Disk: %d", ru.MemorySize, ru.DiskSize)
 }
 
 // Segment is the interface of a segment implementation.

--- a/internal/querynodev2/segments/segment_interface_test.go
+++ b/internal/querynodev2/segments/segment_interface_test.go
@@ -1,0 +1,20 @@
+package segments
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TsetSegmentResourceUsage(t *testing.T) {
+	usage := SegmentResourceUsage{}
+	assert.Equal(t, uint64(0), usage.GetInuseOrPredictDiskUsage())
+	assert.Equal(t, uint64(0), usage.BinLogSizeAtOSS)
+	assert.Equal(t, "Predict: (Mem: 0, Disk: 0), InUsed: (Mem: 0, Disk: 0), BinLogSizeAtOSS: (0)", usage.String())
+
+	usage.Predict.DiskSize = 100
+	assert.Equal(t, uint64(100), usage.GetInuseOrPredictDiskUsage())
+
+	usage.InUsed.DiskSize = 200
+	assert.Equal(t, uint64(200), usage.GetInuseOrPredictDiskUsage())
+}

--- a/internal/querynodev2/segments/segment_l0.go
+++ b/internal/querynodev2/segments/segment_l0.go
@@ -85,12 +85,24 @@ func (s *L0Segment) RowNum() int64 {
 	return 0
 }
 
-func (s *L0Segment) MemSize() int64 {
+func (s *L0Segment) ResourceUsageEstimate() SegmentResourceUsage {
 	s.dataGuard.RLock()
 	defer s.dataGuard.RUnlock()
-	return lo.SumBy(s.pks, func(pk storage.PrimaryKey) int64 {
+
+	memSize := lo.SumBy(s.pks, func(pk storage.PrimaryKey) int64 {
 		return pk.Size() + 8
 	})
+	return SegmentResourceUsage{
+		Predict: ResourceUsage{
+			MemorySize: uint64(memSize),
+			DiskSize:   0,
+		},
+		InUsed: ResourceUsage{
+			MemorySize: uint64(memSize),
+			DiskSize:   0,
+		},
+		BinLogSizeAtOSS: uint64(s.LoadInfo().GetSegmentSize()),
+	}
 }
 
 func (s *L0Segment) LastDeltaTimestamp() uint64 {

--- a/internal/querynodev2/segments/segment_test.go
+++ b/internal/querynodev2/segments/segment_test.go
@@ -148,13 +148,12 @@ func (suite *SegmentSuite) TestResourceUsageEstimate() {
 	// growing segment has resource usage
 	// growing segment can not estimate resource usage
 	usage := suite.growing.ResourceUsageEstimate()
-	suite.Zero(usage.MemorySize)
-	suite.Zero(usage.DiskSize)
+	suite.Zero(usage.Predict.MemorySize)
+	suite.Zero(usage.Predict.DiskSize)
 	// growing segment has no resource usage
 	usage = suite.sealed.ResourceUsageEstimate()
-	suite.NotZero(usage.MemorySize)
-	suite.Zero(usage.DiskSize)
-	suite.Zero(usage.MmapFieldCount)
+	suite.NotZero(usage.Predict.MemorySize)
+	suite.Zero(usage.Predict.DiskSize)
 }
 
 func (suite *SegmentSuite) TestDelete() {
@@ -216,7 +215,7 @@ func (suite *SegmentSuite) TestSegmentReleased() {
 
 	suite.False(sealed.ptrLock.PinIfNotReleased())
 	suite.EqualValues(0, sealed.RowNum())
-	suite.EqualValues(0, sealed.MemSize())
+	suite.EqualValues(0, sealed.ResourceUsageEstimate().InUsed.MemorySize)
 	suite.False(sealed.HasRawData(101))
 }
 

--- a/internal/querynodev2/segments/segment_test.go
+++ b/internal/querynodev2/segments/segment_test.go
@@ -96,6 +96,7 @@ func (suite *SegmentSuite) SetupTest() {
 		suite.chunkManager,
 	)
 	suite.Require().NoError(err)
+
 	g, err := suite.sealed.(*LocalSegment).StartLoadData()
 	suite.Require().NoError(err)
 	for _, binlog := range binlogs {

--- a/internal/querynodev2/segments/state/load_state_lock.go
+++ b/internal/querynodev2/segments/state/load_state_lock.go
@@ -68,14 +68,14 @@ type LoadStateLock struct {
 	// We need it to be modified when lock is
 }
 
-// RLockIfNotReleased locks the segment if the state is not released.
-func (ls *LoadStateLock) RLockIf(pred StatePredicate) bool {
+// RLockIf locks the segment if pred is true, and return the current state.
+func (ls *LoadStateLock) RLockIf(pred StatePredicate) (loadStateEnum, bool) {
 	ls.mu.RLock()
 	if !pred(ls.state) {
 		ls.mu.RUnlock()
-		return false
+		return ls.state, false
 	}
-	return true
+	return ls.state, true
 }
 
 // RUnlock unlocks the segment.

--- a/internal/querynodev2/segments/state/load_state_lock_test.go
+++ b/internal/querynodev2/segments/state/load_state_lock_test.go
@@ -171,22 +171,22 @@ func TestRLock(t *testing.T) {
 	assert.True(t, locked)
 	assert.Equal(t, LoadStateOnlyMeta, state)
 	l.RUnlock()
-	state, locked = l.RLockIf(IsDataLoaded)
+	_, locked = l.RLockIf(IsDataLoaded)
 	assert.False(t, locked)
 
 	l = NewLoadStateLock(LoadStateDataLoaded)
-	state, locked = l.RLockIf(IsNotReleased)
+	_, locked = l.RLockIf(IsNotReleased)
 	assert.True(t, locked)
 	l.RUnlock()
-	state, locked = l.RLockIf(IsDataLoaded)
+	_, locked = l.RLockIf(IsDataLoaded)
 	assert.True(t, locked)
 	l.RUnlock()
 
 	l = NewLoadStateLock(LoadStateOnlyMeta)
 	l.StartReleaseAll().Done(nil)
-	state, locked = l.RLockIf(IsNotReleased)
+	_, locked = l.RLockIf(IsNotReleased)
 	assert.False(t, locked)
-	state, locked = l.RLockIf(IsDataLoaded)
+	_, locked = l.RLockIf(IsDataLoaded)
 	assert.False(t, locked)
 }
 

--- a/internal/querynodev2/segments/state/load_state_lock_test.go
+++ b/internal/querynodev2/segments/state/load_state_lock_test.go
@@ -167,20 +167,27 @@ func TestStartReleaseAll(t *testing.T) {
 
 func TestRLock(t *testing.T) {
 	l := NewLoadStateLock(LoadStateOnlyMeta)
-	assert.True(t, l.RLockIf(IsNotReleased))
+	state, locked := l.RLockIf(IsNotReleased)
+	assert.True(t, locked)
+	assert.Equal(t, LoadStateOnlyMeta, state)
 	l.RUnlock()
-	assert.False(t, l.RLockIf(IsDataLoaded))
+	state, locked = l.RLockIf(IsDataLoaded)
+	assert.False(t, locked)
 
 	l = NewLoadStateLock(LoadStateDataLoaded)
-	assert.True(t, l.RLockIf(IsNotReleased))
+	state, locked = l.RLockIf(IsNotReleased)
+	assert.True(t, locked)
 	l.RUnlock()
-	assert.True(t, l.RLockIf(IsDataLoaded))
+	state, locked = l.RLockIf(IsDataLoaded)
+	assert.True(t, locked)
 	l.RUnlock()
 
 	l = NewLoadStateLock(LoadStateOnlyMeta)
 	l.StartReleaseAll().Done(nil)
-	assert.False(t, l.RLockIf(IsNotReleased))
-	assert.False(t, l.RLockIf(IsDataLoaded))
+	state, locked = l.RLockIf(IsNotReleased)
+	assert.False(t, locked)
+	state, locked = l.RLockIf(IsDataLoaded)
+	assert.False(t, locked)
 }
 
 func TestPin(t *testing.T) {

--- a/internal/querynodev2/services.go
+++ b/internal/querynodev2/services.go
@@ -603,7 +603,7 @@ func (node *QueryNode) GetSegmentInfo(ctx context.Context, in *querypb.GetSegmen
 			CollectionID: segment.Collection(),
 			NodeID:       node.GetNodeID(),
 			NodeIds:      []int64{node.GetNodeID()},
-			MemSize:      segment.MemSize(),
+			MemSize:      int64(segment.ResourceUsageEstimate().InUsed.MemorySize),
 			NumRows:      segment.InsertCount(),
 			IndexName:    indexName,
 			IndexID:      indexID,

--- a/internal/querynodev2/tasks/query_task.go
+++ b/internal/querynodev2/tasks/query_task.go
@@ -144,7 +144,10 @@ func (t *QueryTask) Execute() error {
 	}
 
 	relatedDataSize := lo.Reduce(querySegments, func(acc int64, seg segments.Segment, _ int) int64 {
-		return acc + seg.MemSize()
+		if seg.Type() == segments.SegmentTypeSealed {
+			return acc + int64(seg.ResourceUsageEstimate().BinLogSizeAtOSS)
+		}
+		return acc + int64(seg.ResourceUsageEstimate().InUsed.MemorySize)
 	}, 0)
 
 	t.result = &internalpb.RetrieveResults{

--- a/internal/querynodev2/tasks/search_task.go
+++ b/internal/querynodev2/tasks/search_task.go
@@ -215,7 +215,10 @@ func (t *SearchTask) Execute() error {
 	}
 
 	relatedDataSize := lo.Reduce(searchedSegments, func(acc int64, seg segments.Segment, _ int) int64 {
-		return acc + seg.MemSize()
+		if seg.Type() == segments.SegmentTypeSealed {
+			return acc + int64(seg.ResourceUsageEstimate().BinLogSizeAtOSS)
+		}
+		return acc + int64(seg.ResourceUsageEstimate().InUsed.MemorySize)
 	}, 0)
 
 	tr.RecordSpan()

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -21,10 +21,12 @@ import (
 	_ "net/http/pprof"
 
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
 
 const (
-	milvusNamespace = "milvus"
+	milvusNamespace = typeutil.Milvus
 
 	AbandonLabel = "abandon"
 	SuccessLabel = "success"

--- a/pkg/metrics/querynode_metrics.go
+++ b/pkg/metrics/querynode_metrics.go
@@ -631,18 +631,6 @@ var (
 			resourceGroupLabelName,
 		})
 
-	// QueryNodeDiskCacheLoadGlobalDuration records the global time cost of loading segments from disk cache.
-	QueryNodeDiskCacheLoadGlobalDuration = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Namespace: milvusNamespace,
-			Subsystem: typeutil.QueryNodeRole,
-			Name:      "disk_cache_load_global_duration",
-			Help:      "global duration of loading segments from disk cache",
-			Buckets:   longTaskBuckets,
-		}, []string{
-			nodeIDLabelName,
-		})
-
 	// QueryNodeDiskCacheEvictTotal records the number of real segments evicted from disk cache.
 	QueryNodeDiskCacheEvictTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -680,18 +668,6 @@ var (
 			nodeIDLabelName,
 			databaseLabelName,
 			resourceGroupLabelName,
-		})
-
-	// QueryNodeDiskCacheEvictGlobalDuration records the global time cost of evicting segments from disk cache.
-	QueryNodeDiskCacheEvictGlobalDuration = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Namespace: milvusNamespace,
-			Subsystem: typeutil.QueryNodeRole,
-			Name:      "disk_cache_evict_global_duration",
-			Help:      "global duration of evicting segments from disk cache",
-			Buckets:   longTaskBuckets,
-		}, []string{
-			nodeIDLabelName,
 		})
 )
 
@@ -749,11 +725,9 @@ func RegisterQueryNode(registry *prometheus.Registry) {
 	registry.MustRegister(QueryNodeDiskCacheLoadTotal)
 	registry.MustRegister(QueryNodeDiskCacheLoadBytes)
 	registry.MustRegister(QueryNodeDiskCacheLoadDuration)
-	registry.MustRegister(QueryNodeDiskCacheLoadGlobalDuration)
 	registry.MustRegister(QueryNodeDiskCacheEvictTotal)
 	registry.MustRegister(QueryNodeDiskCacheEvictBytes)
 	registry.MustRegister(QueryNodeDiskCacheEvictDuration)
-	registry.MustRegister(QueryNodeDiskCacheEvictGlobalDuration)
 }
 
 func CleanupQueryNodeCollectionMetrics(nodeID int64, collectionID int64) {

--- a/pkg/metrics/querynode_metrics.go
+++ b/pkg/metrics/querynode_metrics.go
@@ -590,85 +590,6 @@ var (
 			nodeIDLabelName,
 			queryTypeLabelName,
 		})
-
-	// QueryNodeDiskCacheLoadTotal records the number of real segments loaded from disk cache.
-	QueryNodeDiskCacheLoadTotal = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: milvusNamespace,
-			Subsystem: typeutil.QueryNodeRole,
-			Help:      "number of segments loaded from disk cache",
-			Name:      "disk_cache_load_total",
-		}, []string{
-			nodeIDLabelName,
-			databaseLabelName,
-			resourceGroupLabelName,
-		})
-
-	// QueryNodeDiskCacheLoadBytes records the number of bytes loaded from disk cache.
-	QueryNodeDiskCacheLoadBytes = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: milvusNamespace,
-			Subsystem: typeutil.QueryNodeRole,
-			Help:      "number of bytes loaded from disk cache",
-			Name:      "disk_cache_load_bytes",
-		}, []string{
-			nodeIDLabelName,
-			databaseLabelName,
-			resourceGroupLabelName,
-		})
-
-	// QueryNodeDiskCacheLoadDuration records the total time cost of loading segments from disk cache.
-	// With db and resource group labels.
-	QueryNodeDiskCacheLoadDuration = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: milvusNamespace,
-			Subsystem: typeutil.QueryNodeRole,
-			Help:      "total time cost of loading segments from disk cache",
-			Name:      "disk_cache_load_duration",
-		}, []string{
-			nodeIDLabelName,
-			databaseLabelName,
-			resourceGroupLabelName,
-		})
-
-	// QueryNodeDiskCacheEvictTotal records the number of real segments evicted from disk cache.
-	QueryNodeDiskCacheEvictTotal = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: milvusNamespace,
-			Subsystem: typeutil.QueryNodeRole,
-			Name:      "disk_cache_evict_total",
-			Help:      "number of segments evicted from disk cache",
-		}, []string{
-			nodeIDLabelName,
-			databaseLabelName,
-			resourceGroupLabelName,
-		})
-
-	// QueryNodeDiskCacheEvictBytes records the number of bytes evicted from disk cache.
-	QueryNodeDiskCacheEvictBytes = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: milvusNamespace,
-			Subsystem: typeutil.QueryNodeRole,
-			Name:      "disk_cache_evict_bytes",
-			Help:      "number of bytes evicted from disk cache",
-		}, []string{
-			nodeIDLabelName,
-			databaseLabelName,
-			resourceGroupLabelName,
-		})
-
-	// QueryNodeDiskCacheEvictDuration records the total time cost of evicting segments from disk cache.
-	QueryNodeDiskCacheEvictDuration = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: milvusNamespace,
-			Subsystem: typeutil.QueryNodeRole,
-			Name:      "disk_cache_evict_duration",
-			Help:      "total time cost of evicting segments from disk cache",
-		}, []string{
-			nodeIDLabelName,
-			databaseLabelName,
-			resourceGroupLabelName,
-		})
 )
 
 // RegisterQueryNode registers QueryNode metrics
@@ -722,12 +643,6 @@ func RegisterQueryNode(registry *prometheus.Registry) {
 	registry.MustRegister(QueryNodeSegmentAccessWaitCacheTotal)
 	registry.MustRegister(QueryNodeSegmentAccessWaitCacheDuration)
 	registry.MustRegister(QueryNodeSegmentAccessWaitCacheGlobalDuration)
-	registry.MustRegister(QueryNodeDiskCacheLoadTotal)
-	registry.MustRegister(QueryNodeDiskCacheLoadBytes)
-	registry.MustRegister(QueryNodeDiskCacheLoadDuration)
-	registry.MustRegister(QueryNodeDiskCacheEvictTotal)
-	registry.MustRegister(QueryNodeDiskCacheEvictBytes)
-	registry.MustRegister(QueryNodeDiskCacheEvictDuration)
 }
 
 func CleanupQueryNodeCollectionMetrics(nodeID int64, collectionID int64) {

--- a/pkg/util/cache/cache_test.go
+++ b/pkg/util/cache/cache_test.go
@@ -182,6 +182,8 @@ func TestStats(t *testing.T) {
 			WithReloader(func(ctx context.Context, key int) (int, error) { return 0, nil }).
 			Build()
 		stats := cache.Stats()
+		assert.Zero(t, cache.Size())
+		assert.Equal(t, int64(size), cache.Capacity())
 		assert.Equal(t, uint64(0), stats.HitCount.Load())
 		assert.Equal(t, uint64(0), stats.MissCount.Load())
 		assert.Equal(t, uint64(0), stats.EvictionCount.Load())
@@ -197,6 +199,8 @@ func TestStats(t *testing.T) {
 			})
 			assert.NoError(t, err)
 		}
+		assert.Equal(t, int64(size), cache.Size())
+		assert.Equal(t, int64(size), cache.Capacity())
 		assert.Equal(t, uint64(0), stats.HitCount.Load())
 		assert.Equal(t, uint64(size), stats.MissCount.Load())
 		assert.Equal(t, uint64(0), stats.EvictionCount.Load())
@@ -213,6 +217,8 @@ func TestStats(t *testing.T) {
 			})
 			assert.NoError(t, err)
 		}
+		assert.Equal(t, int64(size), cache.Size())
+		assert.Equal(t, int64(size), cache.Capacity())
 		assert.Equal(t, uint64(size), stats.HitCount.Load())
 		assert.Equal(t, uint64(size), stats.MissCount.Load())
 		assert.Equal(t, uint64(0), stats.EvictionCount.Load())
@@ -228,6 +234,8 @@ func TestStats(t *testing.T) {
 			})
 			assert.NoError(t, err)
 		}
+		assert.Equal(t, int64(size), cache.Size())
+		assert.Equal(t, int64(size), cache.Capacity())
 		assert.Equal(t, uint64(size), stats.HitCount.Load())
 		assert.Equal(t, uint64(size*2), stats.MissCount.Load())
 		assert.Equal(t, uint64(size), stats.EvictionCount.Load())
@@ -244,6 +252,8 @@ func TestStats(t *testing.T) {
 		})
 		assert.Greater(t, stats.TotalReloadCount.Load(), uint64(0))
 		assert.Greater(t, stats.TotalFinalizeDuration.Load(), float64(0))
+		assert.Equal(t, int64(size), cache.Size())
+		assert.Equal(t, int64(size), cache.Capacity())
 	})
 }
 

--- a/pkg/util/cache/cache_test.go
+++ b/pkg/util/cache/cache_test.go
@@ -177,13 +177,16 @@ func TestStats(t *testing.T) {
 
 	t.Run("test loader", func(t *testing.T) {
 		size := 10
-		cache := cacheBuilder.WithCapacity(int64(size)).Build()
+		cache := cacheBuilder.WithCapacity(int64(size)).
+			WithFinalizer(func(ctx context.Context, key, value int) error { return nil }).
+			WithReloader(func(ctx context.Context, key int) (int, error) { return 0, nil }).
+			Build()
 		stats := cache.Stats()
 		assert.Equal(t, uint64(0), stats.HitCount.Load())
 		assert.Equal(t, uint64(0), stats.MissCount.Load())
 		assert.Equal(t, uint64(0), stats.EvictionCount.Load())
-		assert.Equal(t, uint64(0), stats.TotalLoadTimeMs.Load())
-		assert.Equal(t, uint64(0), stats.TotalFinalizeTimeMs.Load())
+		assert.Equal(t, float64(0), stats.TotalLoadDuration.Load())
+		assert.Equal(t, float64(0), stats.TotalFinalizeDuration.Load())
 		assert.Equal(t, uint64(0), stats.LoadSuccessCount.Load())
 		assert.Equal(t, uint64(0), stats.LoadFailCount.Load())
 
@@ -197,8 +200,9 @@ func TestStats(t *testing.T) {
 		assert.Equal(t, uint64(0), stats.HitCount.Load())
 		assert.Equal(t, uint64(size), stats.MissCount.Load())
 		assert.Equal(t, uint64(0), stats.EvictionCount.Load())
-		// assert.True(t, stats.TotalLoadTimeMs.Load() > 0)
-		assert.Equal(t, uint64(0), stats.TotalFinalizeTimeMs.Load())
+		assert.Greater(t, stats.TotalLoadDuration.Load(), float64(0))
+		assert.Equal(t, float64(0), stats.TotalFinalizeDuration.Load())
+		assert.Equal(t, uint64(0), stats.TotalFinalizeCount.Load())
 		assert.Equal(t, uint64(size), stats.LoadSuccessCount.Load())
 		assert.Equal(t, uint64(0), stats.LoadFailCount.Load())
 
@@ -212,7 +216,8 @@ func TestStats(t *testing.T) {
 		assert.Equal(t, uint64(size), stats.HitCount.Load())
 		assert.Equal(t, uint64(size), stats.MissCount.Load())
 		assert.Equal(t, uint64(0), stats.EvictionCount.Load())
-		assert.Equal(t, uint64(0), stats.TotalFinalizeTimeMs.Load())
+		assert.Equal(t, float64(0), stats.TotalFinalizeDuration.Load())
+		assert.Equal(t, uint64(0), stats.TotalFinalizeCount.Load())
 		assert.Equal(t, uint64(size), stats.LoadSuccessCount.Load())
 		assert.Equal(t, uint64(0), stats.LoadFailCount.Load())
 
@@ -226,9 +231,19 @@ func TestStats(t *testing.T) {
 		assert.Equal(t, uint64(size), stats.HitCount.Load())
 		assert.Equal(t, uint64(size*2), stats.MissCount.Load())
 		assert.Equal(t, uint64(size), stats.EvictionCount.Load())
-		// assert.True(t, stats.TotalFinalizeTimeMs.Load() > 0)
+		assert.Greater(t, stats.TotalFinalizeDuration.Load(), float64(0))
+		assert.Greater(t, stats.TotalFinalizeCount.Load(), uint64(0))
 		assert.Equal(t, uint64(size*2), stats.LoadSuccessCount.Load())
 		assert.Equal(t, uint64(0), stats.LoadFailCount.Load())
+		assert.Equal(t, uint64(0), stats.TotalReloadCount.Load())
+		assert.Equal(t, float64(0), stats.TotalReloadDuration.Load())
+
+		cache.MarkItemNeedReload(context.Background(), size+1)
+		cache.Do(context.Background(), size+1, func(_ context.Context, v int) error {
+			return nil
+		})
+		assert.Greater(t, stats.TotalReloadCount.Load(), uint64(0))
+		assert.Greater(t, stats.TotalFinalizeDuration.Load(), float64(0))
 	})
 }
 

--- a/pkg/util/cache/monitor_test.go
+++ b/pkg/util/cache/monitor_test.go
@@ -1,0 +1,24 @@
+package cache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func TestRegisterLRUCacheMetrics(t *testing.T) {
+	cacheBuilder := NewCacheBuilder[int, int]().WithLoader(func(ctx context.Context, key int) (int, error) {
+		return key, nil
+	})
+	RegisterLRUCacheMetrics[int, int](
+		prometheus.NewRegistry(),
+		cacheBuilder.Build(),
+		"namespace",
+		"subsystem",
+		"prefix",
+		prometheus.Labels{
+			"label": "value",
+		},
+	)
+}

--- a/pkg/util/resource/resource_manager_test.go
+++ b/pkg/util/resource/resource_manager_test.go
@@ -61,8 +61,6 @@ func TestResourceManager(t *testing.T) {
 	{
 		res := manager.Delete("test", "foo")
 		assert.Equal(t, "foo2", res.Get())
-		res = manager.Delete("test", "foo")
-		assert.Equal(t, "foo2", res.Get())
 		assert.Eventually(t, func() bool {
 			return manager.Delete("test", "foo") == nil
 		}, time.Second*5, time.Millisecond*500)

--- a/pkg/util/typeutil/type.go
+++ b/pkg/util/typeutil/type.go
@@ -26,6 +26,8 @@ type IntPrimaryKey = int64
 type UniqueID = int64
 
 const (
+	Milvus = "milvus"
+
 	// EmbeddedRole is for embedded Milvus.
 	EmbeddedRole = "embedded"
 	// StandaloneRole is a constant represent Standalone


### PR DESCRIPTION
issue: #32963

- Add Exception to file class to avoid exception ignore.

- Add GetResourceUsage method for index, column and segment.

- Use bin log size but not mem size in CU of search and query.

- Use in-use disk size in disk cache weight if segment is loaded.

- Enable cache metric itself, remove redundant metric at search/query path.