### PR TITLE
fix: Proxy crash due to shard leader cache data race

### DIFF
--- a/internal/proxy/meta_cache.go
+++ b/internal/proxy/meta_cache.go
@@ -1002,8 +1002,8 @@ func (m *MetaCache) DeprecateShardCache(database, collectionName string) {
 
 func (m *MetaCache) InvalidateShardLeaderCache(collections []int64) {
 	log.Info("Invalidate shard cache for collections", zap.Int64s("collectionIDs", collections))
-	m.mu.RLock()
-	defer m.mu.RUnlock()
+	m.leaderMut.Lock()
+	defer m.leaderMut.Unlock()
 
 	collectionSet := typeutil.NewUniqueSet(collections...)
 	for _, db := range m.collLeader {


### PR DESCRIPTION
issue: #32970
cause InvalidateShardLeaderCache use wrong lock, which may cause data race in meta cache, then proxy may crash

This PR fixed that use leaderMut when try to access shard leader cache.