### PR TITLE
enhance: skip return segment/channel info if no changes happens.

### DIFF
--- a/internal/datacoord/util.go
+++ b/internal/datacoord/util.go
@@ -18,13 +18,12 @@ package datacoord
 
 import (
 	"context"
-	"crypto/md5" // #nosec
-	"sort"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/samber/lo"
+	"github.com/twmb/murmur3"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
@@ -241,7 +240,7 @@ func calculateL0SegmentSize(fields []*datapb.FieldBinlog) float64 {
 }
 
 func GenerateDataSignature(channels []*datapb.VchannelInfo) []byte {
-	d := md5.New() // #nosec
+	d := murmur3.New128()
 
 	for _, ch := range channels {
 		// write channel name
@@ -250,10 +249,6 @@ func GenerateDataSignature(channels []*datapb.VchannelInfo) []byte {
 		segmentIDs := make([]int64, 0)
 		segmentIDs = append(segmentIDs, ch.GetFlushedSegmentIds()...)
 		segmentIDs = append(segmentIDs, ch.GetLevelZeroSegmentIds()...)
-
-		sort.Slice(segmentIDs, func(i, j int) bool {
-			return segmentIDs[i] < segmentIDs[j]
-		})
 
 		// write flushed and l0 segment id
 		idInByte := make([]byte, 8)

--- a/internal/proto/data_coord.proto
+++ b/internal/proto/data_coord.proto
@@ -429,12 +429,15 @@ message GetRecoveryInfoResponseV2 {
   common.Status status = 1;
   repeated VchannelInfo channels = 2;
   repeated SegmentInfo segments = 3;
+  bytes lastModifiedVersion = 4;
 }
 
 message GetRecoveryInfoRequestV2 {
   common.MsgBase base = 1;
   int64 collectionID = 2;
   repeated int64 partitionIDs = 3;
+  bytes lastUpdatedVersion = 4;
+  bool forceUpdate = 5;
 }
 
 message GetSegmentsByStatesRequest {

--- a/internal/querycoordv2/balance/channel_level_score_balancer_test.go
+++ b/internal/querycoordv2/balance/channel_level_score_balancer_test.go
@@ -413,8 +413,8 @@ func (suite *ChannelLevelScoreBalancerTestSuite) TestBalanceOneRound() {
 
 			// 1. set up target for multi collections
 			collection := utils.CreateTestCollection(c.collectionID, int32(c.replicaID))
-			suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, c.collectionID).Return(
-				c.channels, c.segments, nil)
+			suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, c.collectionID, mock.Anything, mock.Anything, mock.Anything).Return(
+				c.channels, c.segments, nil, nil)
 			suite.broker.EXPECT().GetPartitions(mock.Anything, c.collectionID).Return([]int64{c.collectionID}, nil).Maybe()
 			collection.LoadPercentage = 100
 			collection.Status = querypb.LoadStatus_Loaded
@@ -532,8 +532,8 @@ func (suite *ChannelLevelScoreBalancerTestSuite) TestBalanceMultiRound() {
 	// 1. set up target for multi collections
 	for i := range balanceCase.collectionIDs {
 		collection := utils.CreateTestCollection(balanceCase.collectionIDs[i], int32(balanceCase.replicaIDs[i]))
-		suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, balanceCase.collectionIDs[i]).Return(
-			balanceCase.channels, balanceCase.segments[i], nil)
+		suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, balanceCase.collectionIDs[i], mock.Anything, mock.Anything, mock.Anything).Return(
+			balanceCase.channels, balanceCase.segments[i], nil, nil)
 
 		collection.LoadPercentage = 100
 		collection.Status = querypb.LoadStatus_Loaded
@@ -696,8 +696,8 @@ func (suite *ChannelLevelScoreBalancerTestSuite) TestStoppedBalance() {
 
 			// 1. set up target for multi collections
 			collection := utils.CreateTestCollection(c.collectionID, int32(c.replicaID))
-			suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, c.collectionID).Return(
-				c.channels, c.segments, nil)
+			suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, c.collectionID, mock.Anything, mock.Anything, mock.Anything).Return(
+				c.channels, c.segments, nil, nil)
 			suite.broker.EXPECT().GetPartitions(mock.Anything, c.collectionID).Return([]int64{c.collectionID}, nil).Maybe()
 			collection.LoadPercentage = 100
 			collection.Status = querypb.LoadStatus_Loaded
@@ -814,8 +814,8 @@ func (suite *ChannelLevelScoreBalancerTestSuite) TestMultiReplicaBalance() {
 
 			// 1. set up target for multi collections
 			collection := utils.CreateTestCollection(c.collectionID, int32(len(c.replicaWithNodes)))
-			suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, c.collectionID).Return(
-				c.channels, c.segments, nil)
+			suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, c.collectionID, mock.Anything, mock.Anything, mock.Anything).Return(
+				c.channels, c.segments, nil, nil)
 			suite.broker.EXPECT().GetPartitions(mock.Anything, c.collectionID).Return([]int64{c.collectionID}, nil).Maybe()
 			collection.LoadPercentage = 100
 			collection.Status = querypb.LoadStatus_Loaded
@@ -907,8 +907,8 @@ func (suite *ChannelLevelScoreBalancerTestSuite) TestExclusiveChannelBalance_Cha
 			CollectionID: 1, ChannelName: "channel2",
 		},
 	}
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, collectionID).Return(
-		channels, segments, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, collectionID, mock.Anything, mock.Anything, mock.Anything).Return(
+		channels, segments, nil, nil)
 	suite.broker.EXPECT().GetPartitions(mock.Anything, collectionID).Return([]int64{collectionID}, nil).Maybe()
 
 	collection := utils.CreateTestCollection(collectionID, int32(1))
@@ -982,8 +982,8 @@ func (suite *ChannelLevelScoreBalancerTestSuite) TestExclusiveChannelBalance_Seg
 			CollectionID: 1, ChannelName: "channel2",
 		},
 	}
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, collectionID).Return(
-		channels, segments, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, collectionID, mock.Anything, mock.Anything, mock.Anything).Return(
+		channels, segments, nil, nil)
 	suite.broker.EXPECT().GetPartitions(mock.Anything, collectionID).Return([]int64{collectionID}, nil).Maybe()
 
 	collection := utils.CreateTestCollection(collectionID, int32(1))
@@ -1080,8 +1080,8 @@ func (suite *ChannelLevelScoreBalancerTestSuite) TestExclusiveChannelBalance_Nod
 			CollectionID: 1, ChannelName: "channel2",
 		},
 	}
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, collectionID).Return(
-		channels, segments, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, collectionID, mock.Anything, mock.Anything, mock.Anything).Return(
+		channels, segments, nil, nil)
 	suite.broker.EXPECT().GetPartitions(mock.Anything, collectionID).Return([]int64{collectionID}, nil).Maybe()
 
 	collection := utils.CreateTestCollection(collectionID, int32(1))
@@ -1205,8 +1205,8 @@ func (suite *ChannelLevelScoreBalancerTestSuite) TestExclusiveChannelBalance_Seg
 			CollectionID: 1, ChannelName: "channel2",
 		},
 	}
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, collectionID).Return(
-		channels, segments, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, collectionID, mock.Anything, mock.Anything, mock.Anything).Return(
+		channels, segments, nil, nil)
 	suite.broker.EXPECT().GetPartitions(mock.Anything, collectionID).Return([]int64{collectionID}, nil).Maybe()
 
 	collection := utils.CreateTestCollection(collectionID, int32(1))

--- a/internal/querycoordv2/balance/rowcount_based_balancer_test.go
+++ b/internal/querycoordv2/balance/rowcount_based_balancer_test.go
@@ -448,7 +448,7 @@ func (suite *RowCountBasedBalancerTestSuite) TestBalance() {
 					PartitionID: 1,
 				},
 			}
-			suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(nil, segments, nil)
+			suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1), mock.Anything, mock.Anything, mock.Anything).Return(nil, segments, nil, nil)
 			collection := utils.CreateTestCollection(1, 1)
 			collection.LoadPercentage = 100
 			collection.Status = querypb.LoadStatus_Loaded
@@ -457,7 +457,7 @@ func (suite *RowCountBasedBalancerTestSuite) TestBalance() {
 			balancer.meta.CollectionManager.PutPartition(utils.CreateTestPartition(1, 1))
 			balancer.meta.ReplicaManager.Put(utils.CreateTestReplica(1, 1, c.nodes))
 			suite.broker.ExpectedCalls = nil
-			suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(nil, segments, nil)
+			suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1), mock.Anything, mock.Anything, mock.Anything).Return(nil, segments, nil, nil)
 			balancer.targetMgr.UpdateCollectionNextTarget(int64(1))
 			balancer.targetMgr.UpdateCollectionCurrentTarget(1)
 			balancer.targetMgr.UpdateCollectionNextTarget(int64(1))
@@ -669,11 +669,11 @@ func (suite *RowCountBasedBalancerTestSuite) TestBalanceOnPartStopping() {
 			balancer.meta.CollectionManager.PutCollection(collection)
 			balancer.meta.CollectionManager.PutPartition(utils.CreateTestPartition(1, 1))
 			balancer.meta.ReplicaManager.Put(utils.CreateTestReplica(1, 1, append(c.nodes, c.notExistedNodes...)))
-			suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(nil, c.segmentInCurrent, nil)
+			suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1), mock.Anything, mock.Anything, mock.Anything).Return(nil, c.segmentInCurrent, nil, nil)
 			balancer.targetMgr.UpdateCollectionNextTarget(int64(1))
 			balancer.targetMgr.UpdateCollectionCurrentTarget(1)
 			suite.broker.ExpectedCalls = nil
-			suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(nil, c.segmentInNext, nil)
+			suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1), mock.Anything, mock.Anything, mock.Anything).Return(nil, c.segmentInNext, nil, nil)
 			balancer.targetMgr.UpdateCollectionNextTarget(int64(1))
 			suite.mockScheduler.Mock.On("GetNodeChannelDelta", mock.Anything).Return(0).Maybe()
 			for node, s := range c.distributions {
@@ -816,7 +816,7 @@ func (suite *RowCountBasedBalancerTestSuite) TestBalanceOutboundNodes() {
 			balancer.meta.CollectionManager.PutCollection(collection)
 			balancer.meta.CollectionManager.PutPartition(utils.CreateTestPartition(1, 1))
 			balancer.meta.ReplicaManager.Put(utils.CreateTestReplica(1, 1, append(c.nodes, c.notExistedNodes...)))
-			suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(nil, segments, nil)
+			suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1), mock.Anything, mock.Anything, mock.Anything).Return(nil, segments, nil, nil)
 			balancer.targetMgr.UpdateCollectionNextTarget(int64(1))
 			balancer.targetMgr.UpdateCollectionCurrentTarget(1)
 			balancer.targetMgr.UpdateCollectionNextTarget(int64(1))
@@ -1039,7 +1039,7 @@ func (suite *RowCountBasedBalancerTestSuite) TestDisableBalanceChannel() {
 					PartitionID: 1,
 				},
 			}
-			suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(nil, segments, nil)
+			suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1), mock.Anything, mock.Anything, mock.Anything).Return(nil, segments, nil, nil)
 			collection := utils.CreateTestCollection(1, 1)
 			collection.LoadPercentage = 100
 			collection.Status = querypb.LoadStatus_Loaded
@@ -1048,7 +1048,7 @@ func (suite *RowCountBasedBalancerTestSuite) TestDisableBalanceChannel() {
 			balancer.meta.CollectionManager.PutPartition(utils.CreateTestPartition(1, 1))
 			balancer.meta.ReplicaManager.Put(utils.CreateTestReplica(1, 1, append(c.nodes, c.notExistedNodes...)))
 			suite.broker.ExpectedCalls = nil
-			suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(nil, segments, nil)
+			suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1), mock.Anything, mock.Anything, mock.Anything).Return(nil, segments, nil, nil)
 			balancer.targetMgr.UpdateCollectionNextTarget(int64(1))
 			balancer.targetMgr.UpdateCollectionCurrentTarget(1)
 			balancer.targetMgr.UpdateCollectionNextTarget(int64(1))
@@ -1167,8 +1167,8 @@ func (suite *RowCountBasedBalancerTestSuite) TestMultiReplicaBalance() {
 
 			// 1. set up target for multi collections
 			collection := utils.CreateTestCollection(c.collectionID, int32(len(c.replicaWithNodes)))
-			suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, c.collectionID).Return(
-				c.channels, c.segments, nil)
+			suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, c.collectionID, mock.Anything, mock.Anything, mock.Anything).Return(
+				c.channels, c.segments, nil, nil)
 			suite.broker.EXPECT().GetPartitions(mock.Anything, c.collectionID).Return([]int64{c.collectionID}, nil).Maybe()
 			collection.LoadPercentage = 100
 			collection.Status = querypb.LoadStatus_Loaded

--- a/internal/querycoordv2/balance/score_based_balancer_test.go
+++ b/internal/querycoordv2/balance/score_based_balancer_test.go
@@ -407,8 +407,8 @@ func (suite *ScoreBasedBalancerTestSuite) TestBalanceOneRound() {
 
 			// 1. set up target for multi collections
 			collection := utils.CreateTestCollection(c.collectionID, int32(c.replicaID))
-			suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, c.collectionID).Return(
-				nil, c.collectionsSegments, nil)
+			suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, c.collectionID, mock.Anything, mock.Anything, mock.Anything).Return(
+				nil, c.collectionsSegments, nil, nil)
 			suite.broker.EXPECT().GetPartitions(mock.Anything, c.collectionID).Return([]int64{c.collectionID}, nil).Maybe()
 			collection.LoadPercentage = 100
 			collection.Status = querypb.LoadStatus_Loaded
@@ -521,8 +521,8 @@ func (suite *ScoreBasedBalancerTestSuite) TestBalanceMultiRound() {
 	// 1. set up target for multi collections
 	for i := range balanceCase.collectionIDs {
 		collection := utils.CreateTestCollection(balanceCase.collectionIDs[i], int32(balanceCase.replicaIDs[i]))
-		suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, balanceCase.collectionIDs[i]).Return(
-			nil, balanceCase.collectionsSegments[i], nil)
+		suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, balanceCase.collectionIDs[i], mock.Anything, mock.Anything, mock.Anything).Return(
+			nil, balanceCase.collectionsSegments[i], nil, nil)
 
 		collection.LoadPercentage = 100
 		collection.Status = querypb.LoadStatus_Loaded
@@ -669,8 +669,8 @@ func (suite *ScoreBasedBalancerTestSuite) TestStoppedBalance() {
 
 			// 1. set up target for multi collections
 			collection := utils.CreateTestCollection(c.collectionID, int32(c.replicaID))
-			suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, c.collectionID).Return(
-				nil, c.collectionsSegments, nil)
+			suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, c.collectionID, mock.Anything, mock.Anything, mock.Anything).Return(
+				nil, c.collectionsSegments, nil, nil)
 			suite.broker.EXPECT().GetPartitions(mock.Anything, c.collectionID).Return([]int64{c.collectionID}, nil).Maybe()
 			collection.LoadPercentage = 100
 			collection.Status = querypb.LoadStatus_Loaded
@@ -787,8 +787,8 @@ func (suite *ScoreBasedBalancerTestSuite) TestMultiReplicaBalance() {
 
 			// 1. set up target for multi collections
 			collection := utils.CreateTestCollection(c.collectionID, int32(len(c.replicaWithNodes)))
-			suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, c.collectionID).Return(
-				c.channels, c.segments, nil)
+			suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, c.collectionID, mock.Anything, mock.Anything, mock.Anything).Return(
+				c.channels, c.segments, nil, nil)
 			suite.broker.EXPECT().GetPartitions(mock.Anything, c.collectionID).Return([]int64{c.collectionID}, nil).Maybe()
 			collection.LoadPercentage = 100
 			collection.Status = querypb.LoadStatus_Loaded

--- a/internal/querycoordv2/checkers/balance_checker_test.go
+++ b/internal/querycoordv2/checkers/balance_checker_test.go
@@ -115,7 +115,7 @@ func (suite *BalanceCheckerTestSuite) TestAutoBalanceConf() {
 			ChannelName:  "test-insert-channel",
 		},
 	}
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, mock.Anything).Return(channels, segments, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(channels, segments, nil, nil)
 
 	// set collections meta
 	cid1, replicaID1, partitionID1 := 1, 1, 1
@@ -191,7 +191,7 @@ func (suite *BalanceCheckerTestSuite) TestBusyScheduler() {
 			ChannelName:  "test-insert-channel",
 		},
 	}
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, mock.Anything).Return(channels, segments, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(channels, segments, nil, nil)
 
 	// set collections meta
 	cid1, replicaID1, partitionID1 := 1, 1, 1
@@ -255,7 +255,7 @@ func (suite *BalanceCheckerTestSuite) TestStoppingBalance() {
 			ChannelName:  "test-insert-channel",
 		},
 	}
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, mock.Anything).Return(channels, segments, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(channels, segments, nil, nil)
 
 	// set collections meta
 	cid1, replicaID1, partitionID1 := 1, 1, 1
@@ -335,7 +335,7 @@ func (suite *BalanceCheckerTestSuite) TestTargetNotReady() {
 			ChannelName:  "test-insert-channel",
 		},
 	}
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, mock.Anything).Return(channels, segments, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(channels, segments, nil, nil)
 
 	// set collections meta
 	cid1, replicaID1, partitionID1 := 1, 1, 1

--- a/internal/querycoordv2/checkers/channel_checker_test.go
+++ b/internal/querycoordv2/checkers/channel_checker_test.go
@@ -135,8 +135,8 @@ func (suite *ChannelCheckerTestSuite) TestLoadChannel() {
 		},
 	}
 
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
-		channels, nil, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1), mock.Anything, mock.Anything, mock.Anything).Return(
+		channels, nil, nil, nil)
 	checker.targetMgr.UpdateCollectionNextTarget(int64(1))
 
 	tasks := checker.Check(context.TODO())
@@ -162,8 +162,8 @@ func (suite *ChannelCheckerTestSuite) TestReduceChannel() {
 			ChannelName:  "test-insert-channel1",
 		},
 	}
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
-		channels, nil, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1), mock.Anything, mock.Anything, mock.Anything).Return(
+		channels, nil, nil, nil)
 	checker.targetMgr.UpdateCollectionNextTarget(int64(1))
 	checker.targetMgr.UpdateCollectionCurrentTarget(int64(1))
 
@@ -204,8 +204,8 @@ func (suite *ChannelCheckerTestSuite) TestRepeatedChannels() {
 			ChannelName:  "test-insert-channel",
 		},
 	}
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
-		channels, segments, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1), mock.Anything, mock.Anything, mock.Anything).Return(
+		channels, segments, nil, nil)
 	checker.targetMgr.UpdateCollectionNextTarget(int64(1))
 	checker.dist.ChannelDistManager.Update(1, utils.CreateTestChannel(1, 1, 1, "test-insert-channel"))
 	checker.dist.ChannelDistManager.Update(2, utils.CreateTestChannel(1, 2, 2, "test-insert-channel"))

--- a/internal/querycoordv2/checkers/controller_test.go
+++ b/internal/querycoordv2/checkers/controller_test.go
@@ -117,8 +117,8 @@ func (suite *CheckerControllerSuite) TestBasic() {
 			InsertChannel: "test-insert-channel2",
 		},
 	}
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
-		channels, segments, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1), mock.Anything, mock.Anything, mock.Anything).Return(
+		channels, segments, nil, nil)
 	suite.targetManager.UpdateCollectionNextTarget(int64(1))
 
 	// set dist

--- a/internal/querycoordv2/checkers/leader_checker_test.go
+++ b/internal/querycoordv2/checkers/leader_checker_test.go
@@ -100,8 +100,8 @@ func (suite *LeaderCheckerTestSuite) TestSyncLoadedSegments() {
 			ChannelName:  "test-insert-channel",
 		},
 	}
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
-		channels, segments, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1), mock.Anything, mock.Anything, mock.Anything).Return(
+		channels, segments, nil, nil)
 
 	// before target ready, should skip check collection
 	tasks := suite.checker.Check(context.TODO())
@@ -166,8 +166,8 @@ func (suite *LeaderCheckerTestSuite) TestSyncLoadedSegments() {
 		},
 	}
 	suite.broker.ExpectedCalls = nil
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
-		channels, segments, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1), mock.Anything, mock.Anything, mock.Anything).Return(
+		channels, segments, nil, nil)
 	observer.target.UpdateCollectionNextTarget(int64(1))
 	observer.target.UpdateCollectionCurrentTarget(1)
 	// mock l0 segment exist on non delegator node, doesn't set to leader view
@@ -198,8 +198,8 @@ func (suite *LeaderCheckerTestSuite) TestActivation() {
 			ChannelName:  "test-insert-channel",
 		},
 	}
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
-		channels, segments, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1), mock.Anything, mock.Anything, mock.Anything).Return(
+		channels, segments, nil, nil)
 
 	suite.nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{
 		NodeID:   1,
@@ -252,8 +252,8 @@ func (suite *LeaderCheckerTestSuite) TestStoppingNode() {
 			ChannelName:  "test-insert-channel",
 		},
 	}
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
-		channels, segments, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1), mock.Anything, mock.Anything, mock.Anything).Return(
+		channels, segments, nil, nil)
 	observer.target.UpdateCollectionNextTarget(int64(1))
 	observer.target.UpdateCollectionCurrentTarget(1)
 	observer.dist.SegmentDistManager.Update(1, utils.CreateTestSegment(1, 1, 1, 2, 1, "test-insert-channel"))
@@ -288,8 +288,8 @@ func (suite *LeaderCheckerTestSuite) TestIgnoreSyncLoadedSegments() {
 			ChannelName:  "test-insert-channel",
 		},
 	}
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
-		channels, segments, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1), mock.Anything, mock.Anything, mock.Anything).Return(
+		channels, segments, nil, nil)
 
 	suite.nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{
 		NodeID:   1,
@@ -340,8 +340,8 @@ func (suite *LeaderCheckerTestSuite) TestSyncLoadedSegmentsWithReplicas() {
 			ChannelName:  "test-insert-channel",
 		},
 	}
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
-		channels, segments, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1), mock.Anything, mock.Anything, mock.Anything).Return(
+		channels, segments, nil, nil)
 
 	suite.nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{
 		NodeID:   1,
@@ -391,8 +391,8 @@ func (suite *LeaderCheckerTestSuite) TestSyncRemovedSegments() {
 		},
 	}
 
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
-		channels, nil, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1), mock.Anything, mock.Anything, mock.Anything).Return(
+		channels, nil, nil, nil)
 	observer.target.UpdateCollectionNextTarget(int64(1))
 	observer.target.UpdateCollectionCurrentTarget(1)
 
@@ -422,8 +422,8 @@ func (suite *LeaderCheckerTestSuite) TestSyncRemovedSegments() {
 		},
 	}
 	suite.broker.ExpectedCalls = nil
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
-		channels, segments, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1), mock.Anything, mock.Anything, mock.Anything).Return(
+		channels, segments, nil, nil)
 
 	observer.target.UpdateCollectionNextTarget(int64(1))
 	observer.target.UpdateCollectionCurrentTarget(1)
@@ -456,8 +456,8 @@ func (suite *LeaderCheckerTestSuite) TestIgnoreSyncRemovedSegments() {
 			ChannelName:  "test-insert-channel",
 		},
 	}
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
-		channels, segments, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1), mock.Anything, mock.Anything, mock.Anything).Return(
+		channels, segments, nil, nil)
 	observer.target.UpdateCollectionNextTarget(int64(1))
 
 	observer.dist.ChannelDistManager.Update(2, utils.CreateTestChannel(1, 2, 1, "test-insert-channel"))

--- a/internal/querycoordv2/checkers/segment_checker_test.go
+++ b/internal/querycoordv2/checkers/segment_checker_test.go
@@ -139,8 +139,8 @@ func (suite *SegmentCheckerTestSuite) TestLoadSegments() {
 		},
 	}
 
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
-		channels, segments, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1), mock.Anything, mock.Anything, mock.Anything).Return(
+		channels, segments, nil, nil)
 	checker.targetMgr.UpdateCollectionNextTarget(int64(1))
 
 	// set dist
@@ -207,8 +207,8 @@ func (suite *SegmentCheckerTestSuite) TestLoadL0Segments() {
 		},
 	}
 
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
-		channels, segments, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1), mock.Anything, mock.Anything, mock.Anything).Return(
+		channels, segments, nil, nil)
 	checker.targetMgr.UpdateCollectionNextTarget(int64(1))
 
 	// set dist
@@ -292,8 +292,8 @@ func (suite *SegmentCheckerTestSuite) TestReleaseL0Segments() {
 		},
 	}
 
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
-		channels, segments, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1), mock.Anything, mock.Anything, mock.Anything).Return(
+		channels, segments, nil, nil)
 	checker.targetMgr.UpdateCollectionNextTarget(int64(1))
 	checker.targetMgr.UpdateCollectionCurrentTarget(int64(1))
 
@@ -313,8 +313,8 @@ func (suite *SegmentCheckerTestSuite) TestReleaseL0Segments() {
 
 	// test release l0 segment which doesn't exist in target
 	suite.broker.ExpectedCalls = nil
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
-		channels, nil, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1), mock.Anything, mock.Anything, mock.Anything).Return(
+		channels, nil, nil, nil)
 	checker.targetMgr.UpdateCollectionNextTarget(int64(1))
 	checker.targetMgr.UpdateCollectionCurrentTarget(int64(1))
 
@@ -365,8 +365,8 @@ func (suite *SegmentCheckerTestSuite) TestSkipLoadSegments() {
 		},
 	}
 
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
-		channels, segments, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1), mock.Anything, mock.Anything, mock.Anything).Return(
+		channels, segments, nil, nil)
 	checker.targetMgr.UpdateCollectionNextTarget(int64(1))
 
 	// when channel not subscribed, segment_checker won't generate load segment task
@@ -388,8 +388,8 @@ func (suite *SegmentCheckerTestSuite) TestReleaseSegments() {
 			ChannelName:  "test-insert-channel",
 		},
 	}
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
-		channels, nil, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1), mock.Anything, mock.Anything, mock.Anything).Return(
+		channels, nil, nil, nil)
 	checker.targetMgr.UpdateCollectionNextTarget(int64(1))
 
 	// set dist
@@ -429,8 +429,8 @@ func (suite *SegmentCheckerTestSuite) TestReleaseRepeatedSegments() {
 			ChannelName:  "test-insert-channel",
 		},
 	}
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
-		channels, segments, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1), mock.Anything, mock.Anything, mock.Anything).Return(
+		channels, segments, nil, nil)
 	checker.targetMgr.UpdateCollectionNextTarget(int64(1))
 
 	// set dist
@@ -476,8 +476,8 @@ func (suite *SegmentCheckerTestSuite) TestSkipReleaseSealedSegments() {
 		},
 	}
 	segments := []*datapb.SegmentInfo{}
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
-		channels, segments, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1), mock.Anything, mock.Anything, mock.Anything).Return(
+		channels, segments, nil, nil)
 	checker.targetMgr.UpdateCollectionNextTarget(collectionID)
 	checker.targetMgr.UpdateCollectionCurrentTarget(collectionID)
 	readableVersion := checker.targetMgr.GetCollectionTargetVersion(collectionID, meta.CurrentTarget)
@@ -546,8 +546,8 @@ func (suite *SegmentCheckerTestSuite) TestReleaseGrowingSegments() {
 			SeekPosition: &msgpb.MsgPosition{Timestamp: 10},
 		},
 	}
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
-		channels, segments, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1), mock.Anything, mock.Anything, mock.Anything).Return(
+		channels, segments, nil, nil)
 	checker.targetMgr.UpdateCollectionNextTarget(int64(1))
 	checker.targetMgr.UpdateCollectionCurrentTarget(int64(1))
 
@@ -605,8 +605,8 @@ func (suite *SegmentCheckerTestSuite) TestSkipReleaseGrowingSegments() {
 			SeekPosition: &msgpb.MsgPosition{Timestamp: 10},
 		},
 	}
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(
-		channels, segments, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1), mock.Anything, mock.Anything, mock.Anything).Return(
+		channels, segments, nil, nil)
 	checker.targetMgr.UpdateCollectionNextTarget(int64(1))
 	checker.targetMgr.UpdateCollectionCurrentTarget(int64(1))
 

--- a/internal/querycoordv2/job/job_test.go
+++ b/internal/querycoordv2/job/job_test.go
@@ -125,7 +125,7 @@ func (suite *JobSuite) SetupSuite() {
 				})
 			}
 		}
-		suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, collection).Return(vChannels, segmentBinlogs, nil).Maybe()
+		suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, collection, mock.Anything, mock.Anything, mock.Anything).Return(vChannels, segmentBinlogs, nil, nil).Maybe()
 	}
 
 	suite.broker.EXPECT().DescribeCollection(mock.Anything, mock.Anything).

--- a/internal/querycoordv2/meta/coordinator_broker_test.go
+++ b/internal/querycoordv2/meta/coordinator_broker_test.go
@@ -224,7 +224,7 @@ func (s *CoordinatorBrokerDataCoordSuite) TestGetRecoveryInfoV2() {
 				}),
 			}, nil)
 
-		vchans, segInfos, err := s.broker.GetRecoveryInfoV2(ctx, collectionID, partitionID)
+		vchans, segInfos, _, err := s.broker.GetRecoveryInfoV2(ctx, collectionID, []int64{partitionID}, nil, true)
 		s.NoError(err)
 		s.ElementsMatch(channels, lo.Map(vchans, func(info *datapb.VchannelInfo, _ int) string {
 			return info.GetChannelName()
@@ -239,7 +239,7 @@ func (s *CoordinatorBrokerDataCoordSuite) TestGetRecoveryInfoV2() {
 		s.datacoord.EXPECT().GetRecoveryInfoV2(mock.Anything, mock.Anything).
 			Return(nil, errors.New("mock"))
 
-		_, _, err := s.broker.GetRecoveryInfoV2(ctx, collectionID, partitionID)
+		_, _, _, err := s.broker.GetRecoveryInfoV2(ctx, collectionID, []int64{partitionID}, nil, true)
 		s.Error(err)
 		s.resetMock()
 	})
@@ -250,7 +250,7 @@ func (s *CoordinatorBrokerDataCoordSuite) TestGetRecoveryInfoV2() {
 				Status: merr.Status(errors.New("mocked")),
 			}, nil)
 
-		_, _, err := s.broker.GetRecoveryInfoV2(ctx, collectionID, partitionID)
+		_, _, _, err := s.broker.GetRecoveryInfoV2(ctx, collectionID, []int64{partitionID}, nil, true)
 		s.Error(err)
 		s.resetMock()
 	})

--- a/internal/querycoordv2/meta/mock_broker.go
+++ b/internal/querycoordv2/meta/mock_broker.go
@@ -259,46 +259,48 @@ func (_c *MockBroker_GetRecoveryInfo_Call) RunAndReturn(run func(context.Context
 	return _c
 }
 
-// GetRecoveryInfoV2 provides a mock function with given fields: ctx, collectionID, partitionIDs
-func (_m *MockBroker) GetRecoveryInfoV2(ctx context.Context, collectionID int64, partitionIDs ...int64) ([]*datapb.VchannelInfo, []*datapb.SegmentInfo, error) {
-	_va := make([]interface{}, len(partitionIDs))
-	for _i := range partitionIDs {
-		_va[_i] = partitionIDs[_i]
-	}
-	var _ca []interface{}
-	_ca = append(_ca, ctx, collectionID)
-	_ca = append(_ca, _va...)
-	ret := _m.Called(_ca...)
+// GetRecoveryInfoV2 provides a mock function with given fields: ctx, collectionID, partitionIDs, lastUpdateVersion, forceUpdate
+func (_m *MockBroker) GetRecoveryInfoV2(ctx context.Context, collectionID int64, partitionIDs []int64, lastUpdateVersion []byte, forceUpdate bool) ([]*datapb.VchannelInfo, []*datapb.SegmentInfo, []byte, error) {
+	ret := _m.Called(ctx, collectionID, partitionIDs, lastUpdateVersion, forceUpdate)
 
 	var r0 []*datapb.VchannelInfo
 	var r1 []*datapb.SegmentInfo
-	var r2 error
-	if rf, ok := ret.Get(0).(func(context.Context, int64, ...int64) ([]*datapb.VchannelInfo, []*datapb.SegmentInfo, error)); ok {
-		return rf(ctx, collectionID, partitionIDs...)
+	var r2 []byte
+	var r3 error
+	if rf, ok := ret.Get(0).(func(context.Context, int64, []int64, []byte, bool) ([]*datapb.VchannelInfo, []*datapb.SegmentInfo, []byte, error)); ok {
+		return rf(ctx, collectionID, partitionIDs, lastUpdateVersion, forceUpdate)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, int64, ...int64) []*datapb.VchannelInfo); ok {
-		r0 = rf(ctx, collectionID, partitionIDs...)
+	if rf, ok := ret.Get(0).(func(context.Context, int64, []int64, []byte, bool) []*datapb.VchannelInfo); ok {
+		r0 = rf(ctx, collectionID, partitionIDs, lastUpdateVersion, forceUpdate)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*datapb.VchannelInfo)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, int64, ...int64) []*datapb.SegmentInfo); ok {
-		r1 = rf(ctx, collectionID, partitionIDs...)
+	if rf, ok := ret.Get(1).(func(context.Context, int64, []int64, []byte, bool) []*datapb.SegmentInfo); ok {
+		r1 = rf(ctx, collectionID, partitionIDs, lastUpdateVersion, forceUpdate)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).([]*datapb.SegmentInfo)
 		}
 	}
 
-	if rf, ok := ret.Get(2).(func(context.Context, int64, ...int64) error); ok {
-		r2 = rf(ctx, collectionID, partitionIDs...)
+	if rf, ok := ret.Get(2).(func(context.Context, int64, []int64, []byte, bool) []byte); ok {
+		r2 = rf(ctx, collectionID, partitionIDs, lastUpdateVersion, forceUpdate)
 	} else {
-		r2 = ret.Error(2)
+		if ret.Get(2) != nil {
+			r2 = ret.Get(2).([]byte)
+		}
 	}
 
-	return r0, r1, r2
+	if rf, ok := ret.Get(3).(func(context.Context, int64, []int64, []byte, bool) error); ok {
+		r3 = rf(ctx, collectionID, partitionIDs, lastUpdateVersion, forceUpdate)
+	} else {
+		r3 = ret.Error(3)
+	}
+
+	return r0, r1, r2, r3
 }
 
 // MockBroker_GetRecoveryInfoV2_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetRecoveryInfoV2'
@@ -309,31 +311,26 @@ type MockBroker_GetRecoveryInfoV2_Call struct {
 // GetRecoveryInfoV2 is a helper method to define mock.On call
 //   - ctx context.Context
 //   - collectionID int64
-//   - partitionIDs ...int64
-func (_e *MockBroker_Expecter) GetRecoveryInfoV2(ctx interface{}, collectionID interface{}, partitionIDs ...interface{}) *MockBroker_GetRecoveryInfoV2_Call {
-	return &MockBroker_GetRecoveryInfoV2_Call{Call: _e.mock.On("GetRecoveryInfoV2",
-		append([]interface{}{ctx, collectionID}, partitionIDs...)...)}
+//   - partitionIDs []int64
+//   - lastUpdateVersion []byte
+//   - forceUpdate bool
+func (_e *MockBroker_Expecter) GetRecoveryInfoV2(ctx interface{}, collectionID interface{}, partitionIDs interface{}, lastUpdateVersion interface{}, forceUpdate interface{}) *MockBroker_GetRecoveryInfoV2_Call {
+	return &MockBroker_GetRecoveryInfoV2_Call{Call: _e.mock.On("GetRecoveryInfoV2", ctx, collectionID, partitionIDs, lastUpdateVersion, forceUpdate)}
 }
 
-func (_c *MockBroker_GetRecoveryInfoV2_Call) Run(run func(ctx context.Context, collectionID int64, partitionIDs ...int64)) *MockBroker_GetRecoveryInfoV2_Call {
+func (_c *MockBroker_GetRecoveryInfoV2_Call) Run(run func(ctx context.Context, collectionID int64, partitionIDs []int64, lastUpdateVersion []byte, forceUpdate bool)) *MockBroker_GetRecoveryInfoV2_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		variadicArgs := make([]int64, len(args)-2)
-		for i, a := range args[2:] {
-			if a != nil {
-				variadicArgs[i] = a.(int64)
-			}
-		}
-		run(args[0].(context.Context), args[1].(int64), variadicArgs...)
+		run(args[0].(context.Context), args[1].(int64), args[2].([]int64), args[3].([]byte), args[4].(bool))
 	})
 	return _c
 }
 
-func (_c *MockBroker_GetRecoveryInfoV2_Call) Return(_a0 []*datapb.VchannelInfo, _a1 []*datapb.SegmentInfo, _a2 error) *MockBroker_GetRecoveryInfoV2_Call {
-	_c.Call.Return(_a0, _a1, _a2)
+func (_c *MockBroker_GetRecoveryInfoV2_Call) Return(_a0 []*datapb.VchannelInfo, _a1 []*datapb.SegmentInfo, _a2 []byte, _a3 error) *MockBroker_GetRecoveryInfoV2_Call {
+	_c.Call.Return(_a0, _a1, _a2, _a3)
 	return _c
 }
 
-func (_c *MockBroker_GetRecoveryInfoV2_Call) RunAndReturn(run func(context.Context, int64, ...int64) ([]*datapb.VchannelInfo, []*datapb.SegmentInfo, error)) *MockBroker_GetRecoveryInfoV2_Call {
+func (_c *MockBroker_GetRecoveryInfoV2_Call) RunAndReturn(run func(context.Context, int64, []int64, []byte, bool) ([]*datapb.VchannelInfo, []*datapb.SegmentInfo, []byte, error)) *MockBroker_GetRecoveryInfoV2_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/querycoordv2/meta/mock_target_manager.go
+++ b/internal/querycoordv2/meta/mock_target_manager.go
@@ -562,41 +562,41 @@ func (_c *MockTargetManager_IsNextTargetExist_Call) RunAndReturn(run func(int64)
 	return _c
 }
 
-// PullNextTargetV1 provides a mock function with given fields: broker, collectionID, chosenPartitionIDs
-func (_m *MockTargetManager) PullNextTargetV1(broker Broker, collectionID int64, chosenPartitionIDs ...int64) (map[int64]*datapb.SegmentInfo, map[string]*DmChannel, error) {
+// PullNextTargetV1 provides a mock function with given fields: collectionID, chosenPartitionIDs
+func (_m *MockTargetManager) PullNextTargetV1(collectionID int64, chosenPartitionIDs ...int64) (map[int64]*datapb.SegmentInfo, map[string]*DmChannel, error) {
 	_va := make([]interface{}, len(chosenPartitionIDs))
 	for _i := range chosenPartitionIDs {
 		_va[_i] = chosenPartitionIDs[_i]
 	}
 	var _ca []interface{}
-	_ca = append(_ca, broker, collectionID)
+	_ca = append(_ca, collectionID)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
 
 	var r0 map[int64]*datapb.SegmentInfo
 	var r1 map[string]*DmChannel
 	var r2 error
-	if rf, ok := ret.Get(0).(func(Broker, int64, ...int64) (map[int64]*datapb.SegmentInfo, map[string]*DmChannel, error)); ok {
-		return rf(broker, collectionID, chosenPartitionIDs...)
+	if rf, ok := ret.Get(0).(func(int64, ...int64) (map[int64]*datapb.SegmentInfo, map[string]*DmChannel, error)); ok {
+		return rf(collectionID, chosenPartitionIDs...)
 	}
-	if rf, ok := ret.Get(0).(func(Broker, int64, ...int64) map[int64]*datapb.SegmentInfo); ok {
-		r0 = rf(broker, collectionID, chosenPartitionIDs...)
+	if rf, ok := ret.Get(0).(func(int64, ...int64) map[int64]*datapb.SegmentInfo); ok {
+		r0 = rf(collectionID, chosenPartitionIDs...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[int64]*datapb.SegmentInfo)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(Broker, int64, ...int64) map[string]*DmChannel); ok {
-		r1 = rf(broker, collectionID, chosenPartitionIDs...)
+	if rf, ok := ret.Get(1).(func(int64, ...int64) map[string]*DmChannel); ok {
+		r1 = rf(collectionID, chosenPartitionIDs...)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(map[string]*DmChannel)
 		}
 	}
 
-	if rf, ok := ret.Get(2).(func(Broker, int64, ...int64) error); ok {
-		r2 = rf(broker, collectionID, chosenPartitionIDs...)
+	if rf, ok := ret.Get(2).(func(int64, ...int64) error); ok {
+		r2 = rf(collectionID, chosenPartitionIDs...)
 	} else {
 		r2 = ret.Error(2)
 	}
@@ -610,23 +610,22 @@ type MockTargetManager_PullNextTargetV1_Call struct {
 }
 
 // PullNextTargetV1 is a helper method to define mock.On call
-//   - broker Broker
 //   - collectionID int64
 //   - chosenPartitionIDs ...int64
-func (_e *MockTargetManager_Expecter) PullNextTargetV1(broker interface{}, collectionID interface{}, chosenPartitionIDs ...interface{}) *MockTargetManager_PullNextTargetV1_Call {
+func (_e *MockTargetManager_Expecter) PullNextTargetV1(collectionID interface{}, chosenPartitionIDs ...interface{}) *MockTargetManager_PullNextTargetV1_Call {
 	return &MockTargetManager_PullNextTargetV1_Call{Call: _e.mock.On("PullNextTargetV1",
-		append([]interface{}{broker, collectionID}, chosenPartitionIDs...)...)}
+		append([]interface{}{collectionID}, chosenPartitionIDs...)...)}
 }
 
-func (_c *MockTargetManager_PullNextTargetV1_Call) Run(run func(broker Broker, collectionID int64, chosenPartitionIDs ...int64)) *MockTargetManager_PullNextTargetV1_Call {
+func (_c *MockTargetManager_PullNextTargetV1_Call) Run(run func(collectionID int64, chosenPartitionIDs ...int64)) *MockTargetManager_PullNextTargetV1_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		variadicArgs := make([]int64, len(args)-2)
-		for i, a := range args[2:] {
+		variadicArgs := make([]int64, len(args)-1)
+		for i, a := range args[1:] {
 			if a != nil {
 				variadicArgs[i] = a.(int64)
 			}
 		}
-		run(args[0].(Broker), args[1].(int64), variadicArgs...)
+		run(args[0].(int64), variadicArgs...)
 	})
 	return _c
 }
@@ -636,51 +635,53 @@ func (_c *MockTargetManager_PullNextTargetV1_Call) Return(_a0 map[int64]*datapb.
 	return _c
 }
 
-func (_c *MockTargetManager_PullNextTargetV1_Call) RunAndReturn(run func(Broker, int64, ...int64) (map[int64]*datapb.SegmentInfo, map[string]*DmChannel, error)) *MockTargetManager_PullNextTargetV1_Call {
+func (_c *MockTargetManager_PullNextTargetV1_Call) RunAndReturn(run func(int64, ...int64) (map[int64]*datapb.SegmentInfo, map[string]*DmChannel, error)) *MockTargetManager_PullNextTargetV1_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// PullNextTargetV2 provides a mock function with given fields: broker, collectionID, chosenPartitionIDs
-func (_m *MockTargetManager) PullNextTargetV2(broker Broker, collectionID int64, chosenPartitionIDs ...int64) (map[int64]*datapb.SegmentInfo, map[string]*DmChannel, error) {
-	_va := make([]interface{}, len(chosenPartitionIDs))
-	for _i := range chosenPartitionIDs {
-		_va[_i] = chosenPartitionIDs[_i]
-	}
-	var _ca []interface{}
-	_ca = append(_ca, broker, collectionID)
-	_ca = append(_ca, _va...)
-	ret := _m.Called(_ca...)
+// PullNextTargetV2 provides a mock function with given fields: collectionID, chosenPartitionIDs, lastUpdateVersion, forceUpdate
+func (_m *MockTargetManager) PullNextTargetV2(collectionID int64, chosenPartitionIDs []int64, lastUpdateVersion []byte, forceUpdate bool) (map[int64]*datapb.SegmentInfo, map[string]*DmChannel, []byte, error) {
+	ret := _m.Called(collectionID, chosenPartitionIDs, lastUpdateVersion, forceUpdate)
 
 	var r0 map[int64]*datapb.SegmentInfo
 	var r1 map[string]*DmChannel
-	var r2 error
-	if rf, ok := ret.Get(0).(func(Broker, int64, ...int64) (map[int64]*datapb.SegmentInfo, map[string]*DmChannel, error)); ok {
-		return rf(broker, collectionID, chosenPartitionIDs...)
+	var r2 []byte
+	var r3 error
+	if rf, ok := ret.Get(0).(func(int64, []int64, []byte, bool) (map[int64]*datapb.SegmentInfo, map[string]*DmChannel, []byte, error)); ok {
+		return rf(collectionID, chosenPartitionIDs, lastUpdateVersion, forceUpdate)
 	}
-	if rf, ok := ret.Get(0).(func(Broker, int64, ...int64) map[int64]*datapb.SegmentInfo); ok {
-		r0 = rf(broker, collectionID, chosenPartitionIDs...)
+	if rf, ok := ret.Get(0).(func(int64, []int64, []byte, bool) map[int64]*datapb.SegmentInfo); ok {
+		r0 = rf(collectionID, chosenPartitionIDs, lastUpdateVersion, forceUpdate)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[int64]*datapb.SegmentInfo)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(Broker, int64, ...int64) map[string]*DmChannel); ok {
-		r1 = rf(broker, collectionID, chosenPartitionIDs...)
+	if rf, ok := ret.Get(1).(func(int64, []int64, []byte, bool) map[string]*DmChannel); ok {
+		r1 = rf(collectionID, chosenPartitionIDs, lastUpdateVersion, forceUpdate)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(map[string]*DmChannel)
 		}
 	}
 
-	if rf, ok := ret.Get(2).(func(Broker, int64, ...int64) error); ok {
-		r2 = rf(broker, collectionID, chosenPartitionIDs...)
+	if rf, ok := ret.Get(2).(func(int64, []int64, []byte, bool) []byte); ok {
+		r2 = rf(collectionID, chosenPartitionIDs, lastUpdateVersion, forceUpdate)
 	} else {
-		r2 = ret.Error(2)
+		if ret.Get(2) != nil {
+			r2 = ret.Get(2).([]byte)
+		}
 	}
 
-	return r0, r1, r2
+	if rf, ok := ret.Get(3).(func(int64, []int64, []byte, bool) error); ok {
+		r3 = rf(collectionID, chosenPartitionIDs, lastUpdateVersion, forceUpdate)
+	} else {
+		r3 = ret.Error(3)
+	}
+
+	return r0, r1, r2, r3
 }
 
 // MockTargetManager_PullNextTargetV2_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PullNextTargetV2'
@@ -689,33 +690,27 @@ type MockTargetManager_PullNextTargetV2_Call struct {
 }
 
 // PullNextTargetV2 is a helper method to define mock.On call
-//   - broker Broker
 //   - collectionID int64
-//   - chosenPartitionIDs ...int64
-func (_e *MockTargetManager_Expecter) PullNextTargetV2(broker interface{}, collectionID interface{}, chosenPartitionIDs ...interface{}) *MockTargetManager_PullNextTargetV2_Call {
-	return &MockTargetManager_PullNextTargetV2_Call{Call: _e.mock.On("PullNextTargetV2",
-		append([]interface{}{broker, collectionID}, chosenPartitionIDs...)...)}
+//   - chosenPartitionIDs []int64
+//   - lastUpdateVersion []byte
+//   - forceUpdate bool
+func (_e *MockTargetManager_Expecter) PullNextTargetV2(collectionID interface{}, chosenPartitionIDs interface{}, lastUpdateVersion interface{}, forceUpdate interface{}) *MockTargetManager_PullNextTargetV2_Call {
+	return &MockTargetManager_PullNextTargetV2_Call{Call: _e.mock.On("PullNextTargetV2", collectionID, chosenPartitionIDs, lastUpdateVersion, forceUpdate)}
 }
 
-func (_c *MockTargetManager_PullNextTargetV2_Call) Run(run func(broker Broker, collectionID int64, chosenPartitionIDs ...int64)) *MockTargetManager_PullNextTargetV2_Call {
+func (_c *MockTargetManager_PullNextTargetV2_Call) Run(run func(collectionID int64, chosenPartitionIDs []int64, lastUpdateVersion []byte, forceUpdate bool)) *MockTargetManager_PullNextTargetV2_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		variadicArgs := make([]int64, len(args)-2)
-		for i, a := range args[2:] {
-			if a != nil {
-				variadicArgs[i] = a.(int64)
-			}
-		}
-		run(args[0].(Broker), args[1].(int64), variadicArgs...)
+		run(args[0].(int64), args[1].([]int64), args[2].([]byte), args[3].(bool))
 	})
 	return _c
 }
 
-func (_c *MockTargetManager_PullNextTargetV2_Call) Return(_a0 map[int64]*datapb.SegmentInfo, _a1 map[string]*DmChannel, _a2 error) *MockTargetManager_PullNextTargetV2_Call {
-	_c.Call.Return(_a0, _a1, _a2)
+func (_c *MockTargetManager_PullNextTargetV2_Call) Return(_a0 map[int64]*datapb.SegmentInfo, _a1 map[string]*DmChannel, _a2 []byte, _a3 error) *MockTargetManager_PullNextTargetV2_Call {
+	_c.Call.Return(_a0, _a1, _a2, _a3)
 	return _c
 }
 
-func (_c *MockTargetManager_PullNextTargetV2_Call) RunAndReturn(run func(Broker, int64, ...int64) (map[int64]*datapb.SegmentInfo, map[string]*DmChannel, error)) *MockTargetManager_PullNextTargetV2_Call {
+func (_c *MockTargetManager_PullNextTargetV2_Call) RunAndReturn(run func(int64, []int64, []byte, bool) (map[int64]*datapb.SegmentInfo, map[string]*DmChannel, []byte, error)) *MockTargetManager_PullNextTargetV2_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/querycoordv2/meta/target_manager.go
+++ b/internal/querycoordv2/meta/target_manager.go
@@ -54,8 +54,8 @@ const (
 type TargetManagerInterface interface {
 	UpdateCollectionCurrentTarget(collectionID int64) bool
 	UpdateCollectionNextTarget(collectionID int64) error
-	PullNextTargetV1(broker Broker, collectionID int64, chosenPartitionIDs ...int64) (map[int64]*datapb.SegmentInfo, map[string]*DmChannel, error)
-	PullNextTargetV2(broker Broker, collectionID int64, chosenPartitionIDs ...int64) (map[int64]*datapb.SegmentInfo, map[string]*DmChannel, error)
+	PullNextTargetV1(collectionID int64, chosenPartitionIDs ...int64) (map[int64]*datapb.SegmentInfo, map[string]*DmChannel, error)
+	PullNextTargetV2(collectionID int64, chosenPartitionIDs []int64, lastUpdateVersion []byte, forceUpdate bool) (map[int64]*datapb.SegmentInfo, map[string]*DmChannel, []byte, error)
 	RemoveCollection(collectionID int64)
 	RemovePartition(collectionID int64, partitionIDs ...int64)
 	GetGrowingSegmentsByCollection(collectionID int64, scope TargetScope) typeutil.UniqueSet

--- a/internal/querycoordv2/meta/target_manager_test.go
+++ b/internal/querycoordv2/meta/target_manager_test.go
@@ -139,7 +139,7 @@ func (suite *TargetManagerSuite) SetupTest() {
 				})
 			}
 		}
-		suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, collection).Return(dmChannels, allSegments, nil)
+		suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, collection, mock.Anything, mock.Anything, mock.Anything).Return(dmChannels, allSegments, nil, nil)
 
 		suite.meta.PutCollection(&Collection{
 			CollectionLoadInfo: &querypb.CollectionLoadInfo{
@@ -235,7 +235,7 @@ func (suite *TargetManagerSuite) TestUpdateNextTarget() {
 		},
 	}
 
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, collectionID).Return(nextTargetChannels, nextTargetSegments, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, collectionID, mock.Anything, mock.Anything, mock.Anything).Return(nextTargetChannels, nextTargetSegments, nil, nil)
 	suite.mgr.UpdateCollectionNextTarget(collectionID)
 	suite.assertSegments([]int64{11, 12}, suite.mgr.GetSealedSegmentsByCollection(collectionID, NextTarget))
 	suite.assertChannels([]string{"channel-1", "channel-2"}, suite.mgr.GetDmChannelsByCollection(collectionID, NextTarget))
@@ -244,8 +244,8 @@ func (suite *TargetManagerSuite) TestUpdateNextTarget() {
 
 	suite.broker.ExpectedCalls = nil
 	// test getRecoveryInfoV2 failed , then back to getRecoveryInfo succeed
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, collectionID).Return(
-		nil, nil, merr.WrapErrServiceUnimplemented(status.Errorf(codes.Unimplemented, "fake not found")))
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, collectionID, mock.Anything, mock.Anything, mock.Anything).Return(
+		nil, nil, nil, merr.WrapErrServiceUnimplemented(status.Errorf(codes.Unimplemented, "fake not found")))
 	suite.broker.EXPECT().GetPartitions(mock.Anything, mock.Anything).Return([]int64{1}, nil)
 	suite.broker.EXPECT().GetRecoveryInfo(mock.Anything, collectionID, int64(1)).Return(nextTargetChannels, nextTargetBinlogs, nil)
 	err := suite.mgr.UpdateCollectionNextTarget(collectionID)
@@ -253,8 +253,8 @@ func (suite *TargetManagerSuite) TestUpdateNextTarget() {
 
 	suite.broker.ExpectedCalls = nil
 	// test getRecoveryInfoV2 failed , then retry getRecoveryInfoV2 succeed
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, collectionID).Return(nil, nil, errors.New("fake error")).Times(1)
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, collectionID).Return(nextTargetChannels, nextTargetSegments, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, collectionID, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil, nil, errors.New("fake error")).Times(1)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, collectionID, mock.Anything, mock.Anything, mock.Anything).Return(nextTargetChannels, nextTargetSegments, nil, nil)
 	err = suite.mgr.UpdateCollectionNextTarget(collectionID)
 	suite.NoError(err)
 
@@ -410,7 +410,7 @@ func (suite *TargetManagerSuite) TestGetSegmentByChannel() {
 		},
 	}
 
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, collectionID).Return(nextTargetChannels, nextTargetSegments, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, collectionID, mock.Anything, mock.Anything, mock.Anything).Return(nextTargetChannels, nextTargetSegments, nil, nil)
 	suite.mgr.UpdateCollectionNextTarget(collectionID)
 	suite.Len(suite.mgr.GetSealedSegmentsByCollection(collectionID, NextTarget), 2)
 	suite.Len(suite.mgr.GetSealedSegmentsByChannel(collectionID, "channel-1", NextTarget), 1)
@@ -601,7 +601,7 @@ func (suite *TargetManagerSuite) TestRecover() {
 		},
 	}
 
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, collectionID).Return(nextTargetChannels, nextTargetSegments, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, collectionID, mock.Anything, mock.Anything, mock.Anything).Return(nextTargetChannels, nextTargetSegments, nil, nil)
 	suite.mgr.UpdateCollectionNextTarget(collectionID)
 	suite.mgr.UpdateCollectionCurrentTarget(collectionID)
 

--- a/internal/querycoordv2/observers/collection_observer_test.go
+++ b/internal/querycoordv2/observers/collection_observer_test.go
@@ -440,7 +440,7 @@ func (suite *CollectionObserverSuite) load(collection int64) {
 		})
 	}
 
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, collection).Return(dmChannels, allSegments, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, collection, mock.Anything, mock.Anything, mock.Anything).Return(dmChannels, allSegments, nil, nil)
 	suite.targetMgr.UpdateCollectionNextTarget(collection)
 
 	suite.ob.LoadCollection(context.Background(), collection)

--- a/internal/querycoordv2/observers/target_observer_test.go
+++ b/internal/querycoordv2/observers/target_observer_test.go
@@ -122,7 +122,7 @@ func (suite *TargetObserverSuite) SetupTest() {
 		},
 	}
 
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, mock.Anything).Return(suite.nextTargetChannels, suite.nextTargetSegments, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(suite.nextTargetChannels, suite.nextTargetSegments, nil, nil)
 	suite.observer.Start()
 }
 
@@ -167,8 +167,8 @@ func (suite *TargetObserverSuite) TestTriggerUpdateTarget() {
 
 	// Pull next again
 	suite.broker.EXPECT().
-		GetRecoveryInfoV2(mock.Anything, mock.Anything).
-		Return(suite.nextTargetChannels, suite.nextTargetSegments, nil)
+		GetRecoveryInfoV2(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(suite.nextTargetChannels, suite.nextTargetSegments, nil, nil)
 	suite.Eventually(func() bool {
 		return len(suite.targetMgr.GetSealedSegmentsByCollection(suite.collectionID, meta.NextTarget)) == 3 &&
 			len(suite.targetMgr.GetDmChannelsByCollection(suite.collectionID, meta.NextTarget)) == 2

--- a/internal/querycoordv2/ops_service_test.go
+++ b/internal/querycoordv2/ops_service_test.go
@@ -577,7 +577,7 @@ func (suite *OpsServiceSuite) TestTransferSegment() {
 	suite.NoError(err)
 	suite.True(merr.Ok(resp))
 
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, collectionID).Return(channels, segments, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, collectionID, mock.Anything, mock.Anything, mock.Anything).Return(channels, segments, nil, nil)
 	suite.targetMgr.UpdateCollectionNextTarget(1)
 	suite.targetMgr.UpdateCollectionCurrentTarget(1)
 	suite.dist.SegmentDistManager.Update(1, segmentInfos...)
@@ -795,7 +795,7 @@ func (suite *OpsServiceSuite) TestTransferChannel() {
 	suite.NoError(err)
 	suite.True(merr.Ok(resp))
 
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, collectionID).Return(channels, segments, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, collectionID, mock.Anything, mock.Anything, mock.Anything).Return(channels, segments, nil, nil)
 	suite.targetMgr.UpdateCollectionNextTarget(1)
 	suite.targetMgr.UpdateCollectionCurrentTarget(1)
 	suite.dist.SegmentDistManager.Update(1, segmentInfos...)

--- a/internal/querycoordv2/services_test.go
+++ b/internal/querycoordv2/services_test.go
@@ -1917,8 +1917,8 @@ func (suite *ServiceSuite) expectGetRecoverInfo(collection int64) {
 		}
 	}
 	suite.broker.EXPECT().
-		GetRecoveryInfoV2(mock.Anything, collection, mock.Anything, mock.Anything).
-		Return(vChannels, segmentBinlogs, nil).Maybe()
+		GetRecoveryInfoV2(mock.Anything, collection, mock.Anything, mock.Anything, mock.Anything).
+		Return(vChannels, segmentBinlogs, nil, nil).Maybe()
 }
 
 func (suite *ServiceSuite) expectLoadPartitions() {

--- a/internal/querycoordv2/task/task_test.go
+++ b/internal/querycoordv2/task/task_test.go
@@ -275,7 +275,7 @@ func (suite *TaskSuite) TestSubscribeChannelTask() {
 		err = suite.scheduler.Add(task)
 		suite.NoError(err)
 	}
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection).Return(dmChannels, nil, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection, mock.Anything, mock.Anything, mock.Anything).Return(dmChannels, nil, nil, nil)
 	suite.target.UpdateCollectionNextTarget(suite.collection)
 	suite.AssertTaskNum(0, len(suite.subChannels), len(suite.subChannels), 0)
 
@@ -370,7 +370,7 @@ func (suite *TaskSuite) TestUnsubscribeChannelTask() {
 		err = suite.scheduler.Add(task)
 		suite.NoError(err)
 	}
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection).Return(dmChannels, nil, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection, mock.Anything, mock.Anything, mock.Anything).Return(dmChannels, nil, nil, nil)
 	suite.target.UpdateCollectionNextTarget(suite.collection)
 
 	// Only first channel exists
@@ -464,7 +464,7 @@ func (suite *TaskSuite) TestLoadSegmentTask() {
 		err = suite.scheduler.Add(task)
 		suite.NoError(err)
 	}
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection).Return([]*datapb.VchannelInfo{channel}, segments, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection, mock.Anything, mock.Anything, mock.Anything).Return([]*datapb.VchannelInfo{channel}, segments, nil, nil)
 	suite.target.UpdateCollectionNextTarget(suite.collection)
 	segmentsNum := len(suite.loadSegments)
 	suite.AssertTaskNum(0, segmentsNum, 0, segmentsNum)
@@ -565,7 +565,7 @@ func (suite *TaskSuite) TestLoadSegmentTaskNotIndex() {
 		err = suite.scheduler.Add(task)
 		suite.NoError(err)
 	}
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection).Return([]*datapb.VchannelInfo{channel}, segments, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection, mock.Anything, mock.Anything, mock.Anything).Return([]*datapb.VchannelInfo{channel}, segments, nil, nil)
 	suite.target.UpdateCollectionNextTarget(suite.collection)
 	segmentsNum := len(suite.loadSegments)
 	suite.AssertTaskNum(0, segmentsNum, 0, segmentsNum)
@@ -660,7 +660,7 @@ func (suite *TaskSuite) TestLoadSegmentTaskFailed() {
 		err = suite.scheduler.Add(task)
 		suite.NoError(err)
 	}
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection).Return([]*datapb.VchannelInfo{channel}, segments, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection, mock.Anything, mock.Anything, mock.Anything).Return([]*datapb.VchannelInfo{channel}, segments, nil, nil)
 	suite.target.UpdateCollectionNextTarget(suite.collection)
 	segmentsNum := len(suite.loadSegments)
 	suite.AssertTaskNum(0, segmentsNum, 0, segmentsNum)
@@ -878,7 +878,7 @@ func (suite *TaskSuite) TestMoveSegmentTask() {
 		suite.NoError(err)
 		tasks = append(tasks, task)
 	}
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection).Return([]*datapb.VchannelInfo{vchannel}, segmentInfos, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection, mock.Anything, mock.Anything, mock.Anything).Return([]*datapb.VchannelInfo{vchannel}, segmentInfos, nil, nil)
 	suite.target.UpdateCollectionNextTarget(suite.collection)
 	suite.target.UpdateCollectionCurrentTarget(suite.collection)
 	suite.dist.SegmentDistManager.Update(sourceNode, segments...)
@@ -962,7 +962,7 @@ func (suite *TaskSuite) TestMoveSegmentTaskStale() {
 		suite.NoError(err)
 		tasks = append(tasks, task)
 	}
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection).Return([]*datapb.VchannelInfo{vchannel}, segmentInfos, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection, mock.Anything, mock.Anything, mock.Anything).Return([]*datapb.VchannelInfo{vchannel}, segmentInfos, nil, nil)
 	suite.target.UpdateCollectionNextTarget(suite.collection)
 	suite.target.UpdateCollectionCurrentTarget(suite.collection)
 	suite.dist.LeaderViewManager.Update(leader, view)
@@ -1045,7 +1045,7 @@ func (suite *TaskSuite) TestTaskCanceled() {
 	}
 	segmentsNum := len(suite.loadSegments)
 	suite.AssertTaskNum(0, segmentsNum, 0, segmentsNum)
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection).Return([]*datapb.VchannelInfo{channel}, segmentInfos, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection, mock.Anything, mock.Anything, mock.Anything).Return([]*datapb.VchannelInfo{channel}, segmentInfos, nil, nil)
 	suite.meta.CollectionManager.PutPartition(utils.CreateTestPartition(suite.collection, partition))
 	suite.target.UpdateCollectionNextTarget(suite.collection)
 
@@ -1136,7 +1136,7 @@ func (suite *TaskSuite) TestSegmentTaskStale() {
 		err = suite.scheduler.Add(task)
 		suite.NoError(err)
 	}
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection).Return([]*datapb.VchannelInfo{channel}, segments, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection, mock.Anything, mock.Anything, mock.Anything).Return([]*datapb.VchannelInfo{channel}, segments, nil, nil)
 	suite.meta.CollectionManager.PutPartition(utils.CreateTestPartition(suite.collection, partition))
 	suite.target.UpdateCollectionNextTarget(suite.collection)
 	segmentsNum := len(suite.loadSegments)
@@ -1172,7 +1172,7 @@ func (suite *TaskSuite) TestSegmentTaskStale() {
 	bakExpectations := suite.broker.ExpectedCalls
 	suite.broker.AssertExpectations(suite.T())
 	suite.broker.ExpectedCalls = suite.broker.ExpectedCalls[:0]
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection).Return([]*datapb.VchannelInfo{channel}, segments, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection, mock.Anything, mock.Anything, mock.Anything).Return([]*datapb.VchannelInfo{channel}, segments, nil, nil)
 
 	suite.meta.CollectionManager.PutPartition(utils.CreateTestPartition(suite.collection, 2))
 	suite.target.UpdateCollectionNextTarget(suite.collection)
@@ -1317,7 +1317,7 @@ func (suite *TaskSuite) TestLeaderTaskSet() {
 		err := suite.scheduler.Add(task)
 		suite.NoError(err)
 	}
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection).Return([]*datapb.VchannelInfo{channel}, segments, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection, mock.Anything, mock.Anything, mock.Anything).Return([]*datapb.VchannelInfo{channel}, segments, nil, nil)
 	suite.target.UpdateCollectionNextTarget(suite.collection)
 	segmentsNum := len(suite.loadSegments)
 	suite.AssertTaskNum(0, segmentsNum, 0, segmentsNum)
@@ -1490,7 +1490,7 @@ func (suite *TaskSuite) TestNoExecutor() {
 		err = suite.scheduler.Add(task)
 		suite.NoError(err)
 	}
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection).Return([]*datapb.VchannelInfo{channel}, segments, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection, mock.Anything, mock.Anything, mock.Anything).Return([]*datapb.VchannelInfo{channel}, segments, nil, nil)
 	suite.target.UpdateCollectionNextTarget(suite.collection)
 	segmentsNum := len(suite.loadSegments)
 	suite.AssertTaskNum(0, segmentsNum, 0, segmentsNum)
@@ -1658,7 +1658,7 @@ func (suite *TaskSuite) TestBalanceChannelTask() {
 	}
 	suite.meta.PutCollection(utils.CreateTestCollection(collectionID, 1), utils.CreateTestPartition(collectionID, 1))
 	suite.broker.ExpectedCalls = nil
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, mock.Anything).Return([]*datapb.VchannelInfo{vchannel}, segments, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]*datapb.VchannelInfo{vchannel}, segments, nil, nil)
 	suite.target.UpdateCollectionNextTarget(collectionID)
 	suite.target.UpdateCollectionCurrentTarget(collectionID)
 	suite.target.UpdateCollectionNextTarget(collectionID)
@@ -1747,7 +1747,7 @@ func (suite *TaskSuite) TestBalanceChannelWithL0SegmentTask() {
 	}
 	suite.meta.PutCollection(utils.CreateTestCollection(collectionID, 1), utils.CreateTestPartition(collectionID, 1))
 	suite.broker.ExpectedCalls = nil
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, mock.Anything).Return([]*datapb.VchannelInfo{vchannel}, segments, nil)
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]*datapb.VchannelInfo{vchannel}, segments, nil, nil)
 	suite.target.UpdateCollectionNextTarget(collectionID)
 	suite.target.UpdateCollectionCurrentTarget(collectionID)
 	suite.target.UpdateCollectionNextTarget(collectionID)


### PR DESCRIPTION
issue: #32244
querycoord call getRecoveryInfo to get segment/channel list for every 3s, and it will get same content if no changes happens in datacoord, which will cause a meaningless network and cpu cost.

to solve this, we compute md5 signature for segment list, and use this signature to check whether segment list changes, if no changes happens, skip return the segment info in rpc.