### PR TITLE
enhance: Replace Mutex & RWMutex under internal to `lock` package ones

### DIFF
--- a/internal/datacoord/index_meta.go
+++ b/internal/datacoord/index_meta.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"sync"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/prometheus/client_golang/prometheus"
@@ -35,12 +34,13 @@ import (
 	"github.com/milvus-io/milvus/pkg/common"
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/metrics"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/timerecord"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
 
 type indexMeta struct {
-	sync.RWMutex
+	lock.RWMutex
 	ctx     context.Context
 	catalog metastore.DataCoordCatalog
 

--- a/internal/datacoord/index_meta_test.go
+++ b/internal/datacoord/index_meta_test.go
@@ -19,7 +19,6 @@ package datacoord
 
 import (
 	"context"
-	"sync"
 	"testing"
 
 	"github.com/cockroachdb/errors"
@@ -34,6 +33,7 @@ import (
 	"github.com/milvus-io/milvus/internal/metastore/model"
 	"github.com/milvus-io/milvus/internal/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/common"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 )
 
 func TestReloadFromKV(t *testing.T) {
@@ -264,7 +264,7 @@ func TestMeta_HasSameReq(t *testing.T) {
 
 func newSegmentIndexMeta(catalog metastore.DataCoordCatalog) *indexMeta {
 	return &indexMeta{
-		RWMutex:              sync.RWMutex{},
+		RWMutex:              lock.RWMutex{},
 		ctx:                  context.Background(),
 		catalog:              catalog,
 		indexes:              make(map[UniqueID]map[UniqueID]*model.Index),

--- a/internal/datanode/channel_checkpoint_updater.go
+++ b/internal/datanode/channel_checkpoint_updater.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
 	"github.com/milvus-io/milvus/pkg/log"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
@@ -43,7 +44,7 @@ type channelCPUpdateTask struct {
 type channelCheckpointUpdater struct {
 	dn *DataNode
 
-	mu         sync.RWMutex
+	mu         lock.RWMutex
 	tasks      map[string]*channelCPUpdateTask
 	notifyChan chan struct{}
 

--- a/internal/datanode/channel_manager.go
+++ b/internal/datanode/channel_manager.go
@@ -28,6 +28,7 @@ import (
 	"github.com/milvus-io/milvus/internal/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/util/lifetime"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
@@ -42,7 +43,7 @@ type ChannelManager interface {
 }
 
 type ChannelManagerImpl struct {
-	mu sync.RWMutex
+	mu lock.RWMutex
 	dn *DataNode
 
 	fgManager FlowgraphManager
@@ -229,7 +230,7 @@ type opRunner struct {
 	dn          *DataNode
 	releaseFunc releaseFunc
 
-	guard      sync.RWMutex
+	guard      lock.RWMutex
 	allOps     map[UniqueID]*opInfo // opID -> tickler
 	opsInQueue chan *datapb.ChannelWatchInfo
 	resultCh   chan *opState

--- a/internal/datanode/compaction_executor.go
+++ b/internal/datanode/compaction_executor.go
@@ -18,7 +18,6 @@ package datanode
 
 import (
 	"context"
-	"sync"
 
 	"github.com/samber/lo"
 	"go.uber.org/zap"
@@ -26,6 +25,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/log"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
 
@@ -42,7 +42,7 @@ type compactionExecutor struct {
 
 	// To prevent concurrency of release channel and compaction get results
 	// all released channel's compaction tasks will be discarded
-	resultGuard sync.RWMutex
+	resultGuard lock.RWMutex
 }
 
 func newCompactionExecutor() *compactionExecutor {

--- a/internal/datanode/data_node.go
+++ b/internal/datanode/data_node.go
@@ -49,6 +49,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/metrics"
 	"github.com/milvus-io/milvus/pkg/mq/msgdispatcher"
 	"github.com/milvus-io/milvus/pkg/util/expr"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/logutil"
 	"github.com/milvus-io/milvus/pkg/util/metricsinfo"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
@@ -113,7 +114,7 @@ type DataNode struct {
 	startOnce    sync.Once
 	stopOnce     sync.Once
 	stopWaiter   sync.WaitGroup
-	sessionMu    sync.Mutex // to fix data race
+	sessionMu    lock.Mutex // to fix data race
 	session      *sessionutil.Session
 	watchKv      kv.WatchKV
 	chunkManager storage.ChunkManager

--- a/internal/datanode/event_manager.go
+++ b/internal/datanode/event_manager.go
@@ -32,6 +32,7 @@ import (
 	"github.com/milvus-io/milvus/internal/kv"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/log"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/logutil"
 )
 
@@ -398,7 +399,7 @@ func GetLiteChannelWatchInfo(watchInfo *datapb.ChannelWatchInfo) *datapb.Channel
 }
 
 type EventManager struct {
-	channelGuard    sync.Mutex
+	channelGuard    lock.Mutex
 	channelManagers map[string]*channelEventManager
 }
 

--- a/internal/datanode/flow_graph_time_ticker.go
+++ b/internal/datanode/flow_graph_time_ticker.go
@@ -25,6 +25,7 @@ import (
 	"golang.org/x/exp/maps"
 
 	"github.com/milvus-io/milvus/pkg/log"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 )
 
 type sendTimeTick func(Timestamp, []int64) error
@@ -36,7 +37,7 @@ type mergedTimeTickerSender struct {
 	ts         uint64
 	segmentIDs map[int64]struct{}
 	lastSent   time.Time
-	mu         sync.Mutex
+	mu         lock.Mutex
 
 	cond *sync.Cond   // condition to send timeticker
 	send sendTimeTick // actual sender logic
@@ -55,7 +56,7 @@ func newUniqueMergedTimeTickerSender(send sendTimeTick) *mergedTimeTickerSender 
 	return &mergedTimeTickerSender{
 		ts:         0, // 0 for not tt send
 		segmentIDs: make(map[int64]struct{}),
-		cond:       sync.NewCond(&sync.Mutex{}),
+		cond:       sync.NewCond(&lock.Mutex{}),
 		send:       send,
 		closeCh:    make(chan struct{}),
 	}

--- a/internal/datanode/importv2/task_manager.go
+++ b/internal/datanode/importv2/task_manager.go
@@ -16,9 +16,7 @@
 
 package importv2
 
-import (
-	"sync"
-)
+import "github.com/milvus-io/milvus/pkg/util/lock"
 
 type TaskManager interface {
 	Add(task Task)
@@ -29,7 +27,7 @@ type TaskManager interface {
 }
 
 type taskManager struct {
-	mu    sync.RWMutex // guards tasks
+	mu    lock.RWMutex // guards tasks
 	tasks map[int64]Task
 }
 

--- a/internal/datanode/metacache/bloom_filter_set.go
+++ b/internal/datanode/metacache/bloom_filter_set.go
@@ -17,12 +17,11 @@
 package metacache
 
 import (
-	"sync"
-
 	"github.com/bits-and-blooms/bloom/v3"
 	"github.com/samber/lo"
 
 	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 )
 
@@ -30,7 +29,7 @@ import (
 // it maintains bloom filter generated from segment primary keys.
 // it may be updated with new insert FieldData when serving growing segments.
 type BloomFilterSet struct {
-	mut       sync.RWMutex
+	mut       lock.RWMutex
 	batchSize uint
 	current   *storage.PkStatistics
 	history   []*storage.PkStatistics

--- a/internal/datanode/metacache/meta_cache.go
+++ b/internal/datanode/metacache/meta_cache.go
@@ -17,8 +17,6 @@
 package metacache
 
 import (
-	"sync"
-
 	"github.com/samber/lo"
 	"go.uber.org/zap"
 
@@ -27,6 +25,7 @@ import (
 	"github.com/milvus-io/milvus/internal/proto/datapb"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/pkg/log"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
 
@@ -62,7 +61,7 @@ type metaCacheImpl struct {
 	vChannelName string
 	segmentInfos map[int64]*SegmentInfo
 	schema       *schemapb.CollectionSchema
-	mu           sync.RWMutex
+	mu           lock.RWMutex
 }
 
 func NewMetaCache(info *datapb.ChannelWatchInfo, factory PkStatsFactory) MetaCache {

--- a/internal/datanode/metacache/storagev2_cache.go
+++ b/internal/datanode/metacache/storagev2_cache.go
@@ -17,18 +17,17 @@
 package metacache
 
 import (
-	"sync"
-
 	"github.com/apache/arrow/go/v12/arrow"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	milvus_storage "github.com/milvus-io/milvus-storage/go/storage"
 	"github.com/milvus-io/milvus/internal/util/typeutil"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 )
 
 type StorageV2Cache struct {
 	arrowSchema *arrow.Schema
-	spaceMu     sync.Mutex
+	spaceMu     lock.Mutex
 	spaces      map[int64]*milvus_storage.Space
 }
 

--- a/internal/datanode/rate_collector.go
+++ b/internal/datanode/rate_collector.go
@@ -19,6 +19,7 @@ package datanode
 import (
 	"sync"
 
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/ratelimitutil"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
@@ -33,7 +34,7 @@ var (
 type rateCollector struct {
 	*ratelimitutil.RateCollector
 
-	flowGraphTtMu sync.Mutex
+	flowGraphTtMu lock.Mutex
 	flowGraphTt   map[string]Timestamp
 }
 

--- a/internal/datanode/services_test.go
+++ b/internal/datanode/services_test.go
@@ -19,7 +19,6 @@ package datanode
 import (
 	"context"
 	"math/rand"
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
@@ -42,6 +41,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/common"
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/util/etcd"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/metricsinfo"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
@@ -172,7 +172,7 @@ func (s *DataNodeServicesSuite) TestGetCompactionState() {
 		s.Assert().NoError(err)
 		s.Assert().Equal(3, len(stat.GetResults()))
 
-		var mu sync.RWMutex
+		var mu lock.RWMutex
 		cnt := 0
 		for _, v := range stat.GetResults() {
 			if v.GetState() == commonpb.CompactionState_Completed {

--- a/internal/datanode/stats_updater.go
+++ b/internal/datanode/stats_updater.go
@@ -2,7 +2,6 @@ package datanode
 
 import (
 	"fmt"
-	"sync"
 
 	"github.com/samber/lo"
 
@@ -12,6 +11,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/mq/msgstream"
 	"github.com/milvus-io/milvus/pkg/util/commonpbutil"
 	"github.com/milvus-io/milvus/pkg/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/tsoutil"
 )
 
@@ -25,7 +25,7 @@ type mqStatsUpdater struct {
 	producer msgstream.MsgStream
 	config   *nodeConfig
 
-	mut   sync.Mutex
+	mut   lock.Mutex
 	stats map[int64]int64 // segment id => row nums
 }
 

--- a/internal/datanode/timetick_sender.go
+++ b/internal/datanode/timetick_sender.go
@@ -29,6 +29,7 @@ import (
 	"github.com/milvus-io/milvus/internal/datanode/broker"
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/util/commonpbutil"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/retry"
 )
 
@@ -44,7 +45,7 @@ type timeTickSender struct {
 
 	options []retry.Option
 
-	mu         sync.RWMutex
+	mu         lock.RWMutex
 	statsCache map[string]*channelStats // channel -> channelStats
 }
 

--- a/internal/datanode/writebuffer/manager.go
+++ b/internal/datanode/writebuffer/manager.go
@@ -14,6 +14,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/mq/msgstream"
 	"github.com/milvus-io/milvus/pkg/util/hardware"
 	"github.com/milvus-io/milvus/pkg/util/lifetime"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 )
@@ -57,7 +58,7 @@ func NewManager(syncMgr syncmgr.SyncManager) BufferManager {
 type bufferManager struct {
 	syncMgr syncmgr.SyncManager
 	buffers map[string]WriteBuffer
-	mut     sync.RWMutex
+	mut     lock.RWMutex
 
 	wg sync.WaitGroup
 	ch lifetime.SafeChan

--- a/internal/datanode/writebuffer/write_buffer.go
+++ b/internal/datanode/writebuffer/write_buffer.go
@@ -3,7 +3,6 @@ package writebuffer
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"github.com/bits-and-blooms/bloom/v3"
 	"github.com/cockroachdb/errors"
@@ -24,6 +23,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/metrics"
 	"github.com/milvus-io/milvus/pkg/mq/msgstream"
 	"github.com/milvus-io/milvus/pkg/util/conc"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
@@ -76,7 +76,7 @@ func NewWriteBuffer(channel string, metacache metacache.MetaCache, storageV2Cach
 
 // writeBufferBase is the common component for buffering data
 type writeBufferBase struct {
-	mut sync.RWMutex
+	mut lock.RWMutex
 
 	collectionID int64
 	channelName  string

--- a/internal/distributed/connection_manager.go
+++ b/internal/distributed/connection_manager.go
@@ -19,7 +19,6 @@ package distributed
 import (
 	"context"
 	"os"
-	"sync"
 	"syscall"
 	"time"
 
@@ -39,6 +38,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/sessionutil"
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/tracer"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/retry"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
@@ -50,23 +50,23 @@ type ConnectionManager struct {
 	dependencies map[string]struct{}
 
 	rootCoord    rootcoordpb.RootCoordClient
-	rootCoordMu  sync.RWMutex
+	rootCoordMu  lock.RWMutex
 	queryCoord   querypb.QueryCoordClient
-	queryCoordMu sync.RWMutex
+	queryCoordMu lock.RWMutex
 	dataCoord    datapb.DataCoordClient
-	dataCoordMu  sync.RWMutex
+	dataCoordMu  lock.RWMutex
 	queryNodes   map[int64]querypb.QueryNodeClient
-	queryNodesMu sync.RWMutex
+	queryNodesMu lock.RWMutex
 	dataNodes    map[int64]datapb.DataNodeClient
-	dataNodesMu  sync.RWMutex
+	dataNodesMu  lock.RWMutex
 	indexNodes   map[int64]indexpb.IndexNodeClient
-	indexNodesMu sync.RWMutex
+	indexNodesMu lock.RWMutex
 
-	taskMu     sync.RWMutex
+	taskMu     lock.RWMutex
 	buildTasks map[int64]*buildClientTask
 	notify     chan int64
 
-	connMu      sync.RWMutex
+	connMu      lock.RWMutex
 	connections map[int64]*grpc.ClientConn
 
 	closeCh chan struct{}

--- a/internal/distributed/proxy/httpserver/timeout_middleware.go
+++ b/internal/distributed/proxy/httpserver/timeout_middleware.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+
+	"github.com/milvus-io/milvus/pkg/util/lock"
 )
 
 func defaultResponse(c *gin.Context) {
@@ -47,7 +49,7 @@ type Writer struct {
 	gin.ResponseWriter
 	body         *bytes.Buffer
 	headers      http.Header
-	mu           sync.Mutex
+	mu           lock.Mutex
 	timeout      bool
 	wroteHeaders bool
 	code         int

--- a/internal/indexnode/indexnode.go
+++ b/internal/indexnode/indexnode.go
@@ -55,6 +55,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/util/expr"
 	"github.com/milvus-io/milvus/pkg/util/hardware"
 	"github.com/milvus-io/milvus/pkg/util/lifetime"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
@@ -106,7 +107,7 @@ type IndexNode struct {
 	address string
 
 	initOnce  sync.Once
-	stateLock sync.Mutex
+	stateLock lock.Mutex
 	tasks     map[taskKey]*taskInfo
 }
 

--- a/internal/indexnode/task_scheduler.go
+++ b/internal/indexnode/task_scheduler.go
@@ -29,6 +29,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/metrics"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 )
@@ -50,8 +51,8 @@ type TaskQueue interface {
 type IndexTaskQueue struct {
 	unissuedTasks *list.List
 	activeTasks   map[string]task
-	utLock        sync.Mutex
-	atLock        sync.Mutex
+	utLock        lock.Mutex
+	atLock        lock.Mutex
 
 	// maxTaskNum should keep still
 	maxTaskNum int64

--- a/internal/indexnode/task_scheduler_test.go
+++ b/internal/indexnode/task_scheduler_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 )
 
@@ -25,7 +26,7 @@ const (
 )
 
 type stagectx struct {
-	mu           sync.Mutex
+	mu           lock.Mutex
 	curstate     fakeTaskState
 	state2cancel fakeTaskState
 	ch           chan struct{}
@@ -132,7 +133,7 @@ func (t *fakeTask) GetState() commonpb.IndexState {
 }
 
 var (
-	idLock sync.Mutex
+	idLock lock.Mutex
 	id     = 0
 )
 

--- a/internal/kv/mem/mem_kv.go
+++ b/internal/kv/mem/mem_kv.go
@@ -18,18 +18,18 @@ package memkv
 
 import (
 	"strings"
-	"sync"
 
 	"github.com/google/btree"
 
 	"github.com/milvus-io/milvus/internal/kv/predicates"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 )
 
 // MemoryKV implements BaseKv interface and relies on underling btree.BTree.
 // As its name implies, all data is stored in memory.
 type MemoryKV struct {
-	sync.RWMutex
+	lock.RWMutex
 	tree *btree.BTree
 }
 

--- a/internal/metastore/kv/rootcoord/kv_catalog_test.go
+++ b/internal/metastore/kv/rootcoord/kv_catalog_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"sync"
 	"testing"
 
 	"github.com/cockroachdb/errors"
@@ -31,6 +30,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/util"
 	"github.com/milvus-io/milvus/pkg/util/crypto"
 	"github.com/milvus-io/milvus/pkg/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
@@ -1434,7 +1434,7 @@ func TestRBAC_Credential(t *testing.T) {
 			kvmock = mocks.NewTxnKV(t)
 			c      = &Catalog{Txn: kvmock}
 
-			cmu   sync.RWMutex
+			cmu   lock.RWMutex
 			count = 0
 		)
 

--- a/internal/metastore/kv/rootcoord/suffix_snapshot.go
+++ b/internal/metastore/kv/rootcoord/suffix_snapshot.go
@@ -24,7 +24,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -34,6 +33,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/common"
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/util/etcd"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/retry"
 	"github.com/milvus-io/milvus/pkg/util/tsoutil"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
@@ -62,7 +62,7 @@ type SuffixSnapshot struct {
 	// internal kv which SuffixSnapshot based on
 	kv.MetaKv
 	// rw mutex provided range lock
-	sync.RWMutex
+	lock.RWMutex
 	// lastestTS latest timestamp for each key
 	// note that this map is lazy loaded
 	// which means if a key is never used in current session, no ts related to the key is stored

--- a/internal/mq/mqimpl/rocksmq/server/rocksmq_impl_test.go
+++ b/internal/mq/mqimpl/rocksmq/server/rocksmq_impl_test.go
@@ -32,6 +32,7 @@ import (
 	rocksdbkv "github.com/milvus-io/milvus/internal/kv/rocksdb"
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/util/etcd"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 )
@@ -89,7 +90,7 @@ func (rmq *rocksmq) produceBefore2(topicName string, messages []producerMessageB
 	if !ok {
 		return []UniqueID{}, fmt.Errorf("topic name = %s not exist", topicName)
 	}
-	lock, ok := ll.(*sync.Mutex)
+	lock, ok := ll.(*lock.Mutex)
 	if !ok {
 		return []UniqueID{}, fmt.Errorf("get mutex failed, topic name = %s", topicName)
 	}
@@ -361,7 +362,7 @@ func TestRocksmq_Dummy(t *testing.T) {
 	assert.NoError(t, err)
 
 	channelName1 := "channel_dummy"
-	topicMu.Store(channelName1, new(sync.Mutex))
+	topicMu.Store(channelName1, new(lock.Mutex))
 	err = rmq.DestroyTopic(channelName1)
 	assert.NoError(t, err)
 
@@ -1003,7 +1004,7 @@ func TestRocksmq_CheckPreTopicValid(t *testing.T) {
 	err = rmq.CreateTopic(channelName2)
 	defer rmq.DestroyTopic(channelName2)
 	assert.NoError(t, err)
-	topicMu.Store(channelName2, new(sync.Mutex))
+	topicMu.Store(channelName2, new(lock.Mutex))
 
 	pMsgs := make([]ProducerMessage, 10)
 	for i := 0; i < 10; i++ {
@@ -1023,7 +1024,7 @@ func TestRocksmq_CheckPreTopicValid(t *testing.T) {
 	defer rmq.DestroyTopic(channelName3)
 	assert.NoError(t, err)
 
-	topicMu.Store(channelName3, new(sync.Mutex))
+	topicMu.Store(channelName3, new(lock.Mutex))
 	err = rmq.CheckTopicValid(channelName3)
 	assert.NoError(t, err)
 }

--- a/internal/proxy/accesslog/global.go
+++ b/internal/proxy/accesslog/global.go
@@ -27,6 +27,7 @@ import (
 	"github.com/milvus-io/milvus/internal/proxy/accesslog/info"
 	configEvent "github.com/milvus-io/milvus/pkg/config"
 	"github.com/milvus-io/milvus/pkg/log"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 )
 
@@ -39,7 +40,7 @@ type AccessLogger struct {
 	enable     atomic.Bool
 	writer     io.Writer
 	formatters *FormatterManger
-	mu         sync.RWMutex
+	mu         lock.RWMutex
 }
 
 func NewAccessLogger() *AccessLogger {

--- a/internal/proxy/accesslog/writer.go
+++ b/internal/proxy/accesslog/writer.go
@@ -29,6 +29,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/pkg/log"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 )
 
@@ -40,7 +41,7 @@ var (
 )
 
 type CacheWriter struct {
-	mu     sync.Mutex
+	mu     lock.Mutex
 	writer io.Writer
 }
 
@@ -77,7 +78,7 @@ type RotateWriter struct {
 
 	size int64
 	file *os.File
-	mu   sync.Mutex
+	mu   lock.Mutex
 
 	millCh chan bool
 

--- a/internal/proxy/channels_mgr.go
+++ b/internal/proxy/channels_mgr.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"sync"
 
 	"go.uber.org/zap"
 
@@ -31,6 +30,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/metrics"
 	"github.com/milvus-io/milvus/pkg/mq/msgstream"
 	"github.com/milvus-io/milvus/pkg/util/commonpbutil"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 )
@@ -112,7 +112,7 @@ func getDmlChannelsFunc(ctx context.Context, rc types.RootCoordClient) getChanne
 
 type singleTypeChannelsMgr struct {
 	infos map[UniqueID]streamInfos // collection id -> stream infos
-	mu    sync.RWMutex
+	mu    lock.RWMutex
 
 	getChannelsFunc  getChannelsFuncType
 	repackFunc       repackFuncType

--- a/internal/proxy/channels_time_ticker.go
+++ b/internal/proxy/channels_time_ticker.go
@@ -24,6 +24,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/pkg/log"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
 
@@ -51,7 +52,7 @@ var _ channelsTimeTicker = (*channelsTimeTickerImpl)(nil)
 type channelsTimeTickerImpl struct {
 	interval          time.Duration       // interval to synchronize
 	minTsStatistics   map[pChan]Timestamp // pchan -> min Timestamp
-	statisticsMtx     sync.RWMutex
+	statisticsMtx     lock.RWMutex
 	getStatisticsFunc getPChanStatisticsFuncType
 	tso               tsoAllocator
 	currents          map[pChan]Timestamp

--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"os"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -52,6 +51,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/util/commonpbutil"
 	"github.com/milvus-io/milvus/pkg/util/crypto"
 	"github.com/milvus-io/milvus/pkg/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/logutil"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/metricsinfo"
@@ -5291,7 +5291,7 @@ func (node *Proxy) CheckHealth(ctx context.Context, request *milvuspb.CheckHealt
 	group, ctx := errgroup.WithContext(ctx)
 	errReasons := make([]string, 0)
 
-	mu := &sync.Mutex{}
+	mu := &lock.Mutex{}
 	fn := func(role string, resp *milvuspb.CheckHealthResponse, err error) error {
 		mu.Lock()
 		defer mu.Unlock()

--- a/internal/proxy/meta_cache.go
+++ b/internal/proxy/meta_cache.go
@@ -22,7 +22,6 @@ import (
 	"math/rand"
 	"strconv"
 	"strings"
-	"sync"
 
 	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
@@ -43,6 +42,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/util/commonpbutil"
 	"github.com/milvus-io/milvus/pkg/util/conc"
 	"github.com/milvus-io/milvus/pkg/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/util/timerecord"
@@ -258,9 +258,9 @@ type MetaCache struct {
 	credMap          map[string]*internalpb.CredentialInfo   // cache for credential, lazy load
 	privilegeInfos   map[string]struct{}                     // privileges cache
 	userToRoles      map[string]map[string]struct{}          // user to role cache
-	mu               sync.RWMutex
-	credMut          sync.RWMutex
-	leaderMut        sync.RWMutex
+	mu               lock.RWMutex
+	credMut          lock.RWMutex
+	leaderMut        lock.RWMutex
 	shardMgr         shardClientMgr
 	sfGlobal         conc.Singleflight[*collectionInfo]
 	sfDB             conc.Singleflight[*databaseInfo]
@@ -268,7 +268,7 @@ type MetaCache struct {
 	IDStart int64
 	IDCount int64
 	IDIndex int64
-	IDLock  sync.RWMutex
+	IDLock  lock.RWMutex
 }
 
 // globalMetaCache is singleton instance of Cache

--- a/internal/proxy/mock_test.go
+++ b/internal/proxy/mock_test.go
@@ -18,7 +18,6 @@ package proxy
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"google.golang.org/grpc"
@@ -30,6 +29,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/mq/msgstream"
 	"github.com/milvus-io/milvus/pkg/mq/msgstream/mqwrapper"
 	"github.com/milvus-io/milvus/pkg/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/util/testutils"
@@ -38,7 +38,7 @@ import (
 
 type mockTimestampAllocatorInterface struct {
 	lastTs Timestamp
-	mtx    sync.Mutex
+	mtx    lock.Mutex
 }
 
 func (tso *mockTimestampAllocatorInterface) AllocTimestamp(ctx context.Context, req *rootcoordpb.AllocTimestampRequest, opts ...grpc.CallOption) (*rootcoordpb.AllocTimestampResponse, error) {
@@ -65,7 +65,7 @@ func newMockTimestampAllocatorInterface() timestampAllocatorInterface {
 }
 
 type mockTsoAllocator struct {
-	mu        sync.Mutex
+	mu        lock.Mutex
 	logicPart uint32
 }
 
@@ -237,7 +237,7 @@ type simpleMockMsgStream struct {
 	msgChan chan *msgstream.MsgPack
 
 	msgCount    int
-	msgCountMtx sync.RWMutex
+	msgCountMtx lock.RWMutex
 }
 
 func (ms *simpleMockMsgStream) Close() {

--- a/internal/proxy/rootcoord_mock_test.go
+++ b/internal/proxy/rootcoord_mock_test.go
@@ -19,7 +19,6 @@ package proxy
 import (
 	"context"
 	"fmt"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -37,6 +36,7 @@ import (
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/pkg/common"
 	"github.com/milvus-io/milvus/pkg/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 	"github.com/milvus-io/milvus/pkg/util/uniquegenerator"
@@ -85,11 +85,11 @@ type RootCoordMock struct {
 	collName2ID  map[string]typeutil.UniqueID
 	collID2Meta  map[typeutil.UniqueID]collectionMeta
 	collAlias2ID map[string]typeutil.UniqueID
-	collMtx      sync.RWMutex
+	collMtx      lock.RWMutex
 
 	// TODO(dragondriver): need default partition?
 	collID2Partitions map[typeutil.UniqueID]partitionMap
-	partitionMtx      sync.RWMutex
+	partitionMtx      lock.RWMutex
 
 	describeCollectionFunc describeCollectionFuncType
 	showPartitionsFunc     showPartitionsFuncType
@@ -103,7 +103,7 @@ type RootCoordMock struct {
 	// TODO(dragondriver): TimeTick-related
 
 	lastTs          typeutil.Timestamp
-	lastTsMtx       sync.Mutex
+	lastTsMtx       lock.Mutex
 	checkHealthFunc func(ctx context.Context, req *milvuspb.CheckHealthRequest, opts ...grpc.CallOption) (*milvuspb.CheckHealthResponse, error)
 }
 

--- a/internal/proxy/segment_test.go
+++ b/internal/proxy/segment_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 )
 
@@ -120,7 +121,7 @@ func TestSegmentAllocator1(t *testing.T) {
 
 var curLastTick2 = Timestamp(200)
 
-var curLastTIck2Lock sync.Mutex
+var curLastTIck2Lock lock.Mutex
 
 func getLastTick2() Timestamp {
 	curLastTIck2Lock.Lock()
@@ -277,7 +278,7 @@ func TestSegmentAllocator6(t *testing.T) {
 		segAllocator.Close()
 	}(wg)
 	success := true
-	var sucLock sync.Mutex
+	var sucLock lock.Mutex
 	collNames := []string{"abc", "cba"}
 	reqFunc := func(i int, group *sync.WaitGroup) {
 		defer group.Done()

--- a/internal/proxy/simple_rate_limiter.go
+++ b/internal/proxy/simple_rate_limiter.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"sync"
 
 	"go.uber.org/zap"
 
@@ -32,6 +31,7 @@ import (
 	rlinternal "github.com/milvus-io/milvus/internal/util/ratelimitutil"
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/metrics"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/util/ratelimitutil"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
@@ -39,7 +39,7 @@ import (
 
 // SimpleLimiter is implemented based on Limiter interface
 type SimpleLimiter struct {
-	quotaStatesMu sync.RWMutex
+	quotaStatesMu lock.RWMutex
 	rateLimiter   *rlinternal.RateLimiterTree
 }
 

--- a/internal/proxy/task_policies_test.go
+++ b/internal/proxy/task_policies_test.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"sort"
 	"strings"
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/milvus-io/milvus/internal/types"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 )
 
 func TestRoundRobinPolicy(t *testing.T) {
@@ -52,7 +52,7 @@ func TestRoundRobinPolicy(t *testing.T) {
 }
 
 type mockQuery struct {
-	mu       sync.Mutex
+	mu       lock.Mutex
 	queryset map[UniqueID][]string
 	failset  map[UniqueID]error
 }

--- a/internal/proxy/task_scheduler.go
+++ b/internal/proxy/task_scheduler.go
@@ -28,6 +28,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/mq/msgstream"
 	"github.com/milvus-io/milvus/pkg/util/conc"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/util/tsoutil"
@@ -56,12 +57,12 @@ var _ taskQueue = (*baseTaskQueue)(nil)
 type baseTaskQueue struct {
 	unissuedTasks *list.List
 	activeTasks   map[UniqueID]task
-	utLock        sync.RWMutex
-	atLock        sync.RWMutex
+	utLock        lock.RWMutex
+	atLock        lock.RWMutex
 
 	// maxTaskNum should keep still
 	maxTaskNum    int64
-	maxTaskNumMtx sync.RWMutex
+	maxTaskNumMtx lock.RWMutex
 
 	utBufChan chan int // to block scheduler
 
@@ -211,8 +212,8 @@ func newBaseTaskQueue(tsoAllocatorIns tsoAllocator) *baseTaskQueue {
 	return &baseTaskQueue{
 		unissuedTasks:   list.New(),
 		activeTasks:     make(map[UniqueID]task),
-		utLock:          sync.RWMutex{},
-		atLock:          sync.RWMutex{},
+		utLock:          lock.RWMutex{},
+		atLock:          lock.RWMutex{},
 		maxTaskNum:      Params.ProxyCfg.MaxTaskNum.GetAsInt64(),
 		utBufChan:       make(chan int, Params.ProxyCfg.MaxTaskNum.GetAsInt()),
 		tsoAllocatorIns: tsoAllocatorIns,
@@ -221,7 +222,7 @@ func newBaseTaskQueue(tsoAllocatorIns tsoAllocator) *baseTaskQueue {
 
 type ddTaskQueue struct {
 	*baseTaskQueue
-	lock sync.Mutex
+	lock lock.Mutex
 }
 
 type pChanStatInfo struct {
@@ -232,7 +233,7 @@ type pChanStatInfo struct {
 type dmTaskQueue struct {
 	*baseTaskQueue
 
-	statsLock            sync.RWMutex
+	statsLock            lock.RWMutex
 	pChanStatisticsInfos map[pChan]*pChanStatInfo
 }
 

--- a/internal/proxy/task_scheduler_test.go
+++ b/internal/proxy/task_scheduler_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/milvus-io/milvus/internal/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/mq/msgstream"
 	"github.com/milvus-io/milvus/pkg/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 )
 
 func TestBaseTaskQueue(t *testing.T) {
@@ -314,7 +315,7 @@ func TestDmTaskQueue_TimestampStatistics2(t *testing.T) {
 	processWg.Add(1)
 	processCtx, processCancel := context.WithCancel(context.TODO())
 	processCount := insertNum
-	var processCountMut sync.RWMutex
+	var processCountMut lock.RWMutex
 	go func() {
 		defer processWg.Done()
 		var workerWg sync.WaitGroup

--- a/internal/querycoordv2/dist/dist_controller.go
+++ b/internal/querycoordv2/dist/dist_controller.go
@@ -26,6 +26,7 @@ import (
 	"github.com/milvus-io/milvus/internal/querycoordv2/session"
 	"github.com/milvus-io/milvus/internal/querycoordv2/task"
 	"github.com/milvus-io/milvus/pkg/log"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 )
 
 type Controller interface {
@@ -36,7 +37,7 @@ type Controller interface {
 }
 
 type ControllerImpl struct {
-	mu          sync.RWMutex
+	mu          lock.RWMutex
 	handlers    map[int64]*distHandler
 	client      session.Cluster
 	nodeManager *session.NodeManager

--- a/internal/querycoordv2/dist/dist_handler.go
+++ b/internal/querycoordv2/dist/dist_handler.go
@@ -35,6 +35,7 @@ import (
 	"github.com/milvus-io/milvus/internal/querycoordv2/task"
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/util/commonpbutil"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 )
@@ -48,7 +49,7 @@ type distHandler struct {
 	scheduler   task.Scheduler
 	dist        *meta.DistributionManager
 	target      *meta.TargetManager
-	mu          sync.Mutex
+	mu          lock.Mutex
 	stopOnce    sync.Once
 }
 

--- a/internal/querycoordv2/meta/channel_dist_manager.go
+++ b/internal/querycoordv2/meta/channel_dist_manager.go
@@ -17,12 +17,11 @@
 package meta
 
 import (
-	"sync"
-
 	"github.com/golang/protobuf/proto"
 	"github.com/samber/lo"
 
 	"github.com/milvus-io/milvus/internal/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
 
@@ -163,7 +162,7 @@ func composeNodeChannels(channels ...*DmChannel) nodeChannels {
 }
 
 type ChannelDistManager struct {
-	rwmutex sync.RWMutex
+	rwmutex lock.RWMutex
 
 	// NodeID -> Channels
 	channels map[typeutil.UniqueID]nodeChannels

--- a/internal/querycoordv2/meta/collection_manager.go
+++ b/internal/querycoordv2/meta/collection_manager.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/golang/protobuf/proto"
@@ -33,6 +32,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/eventlog"
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/metrics"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
@@ -44,7 +44,7 @@ type Collection struct {
 	CreatedAt      time.Time
 	UpdatedAt      time.Time
 
-	mut             sync.RWMutex
+	mut             lock.RWMutex
 	refreshNotifier chan struct{}
 	LoadSpan        trace.Span
 }
@@ -99,7 +99,7 @@ func (partition *Partition) Clone() *Partition {
 }
 
 type CollectionManager struct {
-	rwmutex sync.RWMutex
+	rwmutex lock.RWMutex
 
 	collections map[typeutil.UniqueID]*Collection
 	partitions  map[typeutil.UniqueID]*Partition

--- a/internal/querycoordv2/meta/failed_load_cache.go
+++ b/internal/querycoordv2/meta/failed_load_cache.go
@@ -17,12 +17,12 @@
 package meta
 
 import (
-	"sync"
 	"time"
 
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/pkg/log"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 )
 
@@ -37,7 +37,7 @@ type failInfo struct {
 }
 
 type FailedLoadCache struct {
-	mu sync.RWMutex
+	mu lock.RWMutex
 	// CollectionID, ErrorCode -> error
 	records map[int64]map[int32]*failInfo
 }

--- a/internal/querycoordv2/meta/leader_view_manager.go
+++ b/internal/querycoordv2/meta/leader_view_manager.go
@@ -17,11 +17,10 @@
 package meta
 
 import (
-	"sync"
-
 	"github.com/samber/lo"
 
 	"github.com/milvus-io/milvus/internal/proto/querypb"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
 
@@ -196,7 +195,7 @@ func composeNodeViews(views ...*LeaderView) nodeViews {
 type NotifyDelegatorChanges = func(collectionID ...int64)
 
 type LeaderViewManager struct {
-	rwmutex    sync.RWMutex
+	rwmutex    lock.RWMutex
 	views      map[int64]nodeViews // LeaderID -> Views (one per shard)
 	notifyFunc NotifyDelegatorChanges
 }

--- a/internal/querycoordv2/meta/replica_manager.go
+++ b/internal/querycoordv2/meta/replica_manager.go
@@ -18,7 +18,6 @@ package meta
 
 import (
 	"fmt"
-	"sync"
 
 	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
@@ -27,13 +26,14 @@ import (
 	"github.com/milvus-io/milvus/internal/metastore"
 	"github.com/milvus-io/milvus/internal/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/log"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
 
 type ReplicaManager struct {
-	rwmutex sync.RWMutex
+	rwmutex lock.RWMutex
 
 	idAllocator        func() (int64, error)
 	replicas           map[typeutil.UniqueID]*Replica

--- a/internal/querycoordv2/meta/resource_manager.go
+++ b/internal/querycoordv2/meta/resource_manager.go
@@ -18,7 +18,6 @@ package meta
 
 import (
 	"fmt"
-	"sync"
 
 	"github.com/cockroachdb/errors"
 	"github.com/golang/protobuf/proto"
@@ -30,6 +29,7 @@ import (
 	"github.com/milvus-io/milvus/internal/proto/querypb"
 	"github.com/milvus-io/milvus/internal/querycoordv2/session"
 	"github.com/milvus-io/milvus/pkg/log"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/util/syncutil"
@@ -49,7 +49,7 @@ type ResourceManager struct {
 	// All function can get latest online node without checking with node manager.
 	// so node manager is a redundant type here.
 
-	rwmutex           sync.RWMutex
+	rwmutex           lock.RWMutex
 	rgChangedNotifier *syncutil.VersionedNotifier // used to notify that resource group has been changed.
 	// resource_observer will listen this notifier to do a resource group recovery.
 	nodeChangedNotifier *syncutil.VersionedNotifier // used to notify that node distribution in resource group has been changed.
@@ -68,7 +68,7 @@ func NewResourceManager(catalog metastore.QueryCoordCatalog, nodeMgr *session.No
 		catalog:      catalog,
 		nodeMgr:      nodeMgr,
 
-		rwmutex:             sync.RWMutex{},
+		rwmutex:             lock.RWMutex{},
 		rgChangedNotifier:   syncutil.NewVersionedNotifier(),
 		nodeChangedNotifier: syncutil.NewVersionedNotifier(),
 	}

--- a/internal/querycoordv2/meta/segment_dist_manager.go
+++ b/internal/querycoordv2/meta/segment_dist_manager.go
@@ -17,13 +17,12 @@
 package meta
 
 import (
-	"sync"
-
 	"github.com/golang/protobuf/proto"
 	"github.com/samber/lo"
 
 	"github.com/milvus-io/milvus/internal/proto/datapb"
 	"github.com/milvus-io/milvus/internal/proto/querypb"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
 
@@ -139,7 +138,7 @@ func (segment *Segment) Clone() *Segment {
 }
 
 type SegmentDistManager struct {
-	rwmutex sync.RWMutex
+	rwmutex lock.RWMutex
 
 	// nodeID -> []*Segment
 	segments map[typeutil.UniqueID]nodeSegments

--- a/internal/querycoordv2/meta/target_manager.go
+++ b/internal/querycoordv2/meta/target_manager.go
@@ -34,6 +34,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/metrics"
 	"github.com/milvus-io/milvus/pkg/util/conc"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/util/retry"
@@ -51,7 +52,7 @@ const (
 )
 
 type TargetManager struct {
-	rwMutex sync.RWMutex
+	rwMutex lock.RWMutex
 	broker  Broker
 	meta    *Meta
 

--- a/internal/querycoordv2/mocks/querynode.go
+++ b/internal/querycoordv2/mocks/querynode.go
@@ -19,7 +19,6 @@ package mocks
 import (
 	"context"
 	"net"
-	"sync"
 	"testing"
 	"time"
 
@@ -33,6 +32,7 @@ import (
 	. "github.com/milvus-io/milvus/internal/querycoordv2/params"
 	"github.com/milvus-io/milvus/internal/util/sessionutil"
 	"github.com/milvus-io/milvus/pkg/log"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
@@ -47,7 +47,7 @@ type MockQueryNode struct {
 	session *sessionutil.Session
 	server  *grpc.Server
 
-	rwmutex        sync.RWMutex
+	rwmutex        lock.RWMutex
 	channels       map[int64][]string
 	channelVersion map[string]int64
 	segments       map[int64]map[string][]int64

--- a/internal/querycoordv2/observers/target_observer.go
+++ b/internal/querycoordv2/observers/target_observer.go
@@ -65,7 +65,7 @@ type TargetObserver struct {
 	// nextTargetLastUpdate map[int64]time.Time
 	nextTargetLastUpdate *typeutil.ConcurrentMap[int64, time.Time]
 	updateChan           chan targetUpdateRequest
-	mut                  sync.Mutex                // Guard readyNotifiers
+	mut                  lock.Mutex                // Guard readyNotifiers
 	readyNotifiers       map[int64][]chan struct{} // CollectionID -> Notifiers
 
 	dispatcher *taskDispatcher[int64]

--- a/internal/querycoordv2/services.go
+++ b/internal/querycoordv2/services.go
@@ -19,7 +19,6 @@ package querycoordv2
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
@@ -35,6 +34,7 @@ import (
 	"github.com/milvus-io/milvus/internal/querycoordv2/utils"
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/metrics"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/metricsinfo"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
@@ -889,7 +889,7 @@ func (s *Server) checkNodeHealth(ctx context.Context) ([]string, error) {
 	group, ctx := errgroup.WithContext(ctx)
 	errReasons := make([]string, 0)
 
-	mu := &sync.Mutex{}
+	mu := &lock.Mutex{}
 	for _, node := range s.nodeMgr.GetAll() {
 		node := node
 		group.Go(func() error {

--- a/internal/querycoordv2/session/cluster.go
+++ b/internal/querycoordv2/session/cluster.go
@@ -32,6 +32,7 @@ import (
 	"github.com/milvus-io/milvus/internal/proto/querypb"
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/pkg/log"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 )
 
@@ -273,7 +274,7 @@ func (c *QueryCluster) send(ctx context.Context, nodeID int64, fn func(cli types
 }
 
 type clients struct {
-	sync.RWMutex
+	lock.RWMutex
 	clients          map[int64]types.QueryNodeClient // nodeID -> client
 	queryNodeCreator QueryNodeCreator
 }

--- a/internal/querycoordv2/session/node_manager.go
+++ b/internal/querycoordv2/session/node_manager.go
@@ -18,7 +18,6 @@ package session
 
 import (
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/blang/semver/v4"
@@ -27,6 +26,7 @@ import (
 
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/metrics"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 )
 
@@ -42,7 +42,7 @@ type Manager interface {
 }
 
 type NodeManager struct {
-	mu    sync.RWMutex
+	mu    lock.RWMutex
 	nodes map[int64]*NodeInfo
 }
 
@@ -170,7 +170,7 @@ func (s State) String() string {
 
 type NodeInfo struct {
 	stats
-	mu            sync.RWMutex
+	mu            lock.RWMutex
 	immutableInfo ImmutableNodeInfo
 	state         State
 	lastHeartbeat *atomic.Int64

--- a/internal/querycoordv2/task/scheduler.go
+++ b/internal/querycoordv2/task/scheduler.go
@@ -19,7 +19,6 @@ package task
 import (
 	"context"
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -36,6 +35,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/metrics"
 	"github.com/milvus-io/milvus/pkg/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/util/hardware"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	. "github.com/milvus-io/milvus/pkg/util/typeutil"
 )
@@ -148,7 +148,7 @@ type Scheduler interface {
 }
 
 type taskScheduler struct {
-	rwmutex     sync.RWMutex
+	rwmutex     lock.RWMutex
 	ctx         context.Context
 	executors   map[int64]*Executor // NodeID -> Executor
 	idAllocator func() UniqueID

--- a/internal/querynodev2/collector/average.go
+++ b/internal/querynodev2/collector/average.go
@@ -17,8 +17,7 @@
 package collector
 
 import (
-	"sync"
-
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 )
 
@@ -40,7 +39,7 @@ func (v *averageData) Value() float64 {
 }
 
 type averageCollector struct {
-	sync.Mutex
+	lock.Mutex
 	averages map[string]*averageData
 }
 

--- a/internal/querynodev2/collector/counter.go
+++ b/internal/querynodev2/collector/counter.go
@@ -16,12 +16,10 @@
 
 package collector
 
-import (
-	"sync"
-)
+import "github.com/milvus-io/milvus/pkg/util/lock"
 
 type counter struct {
-	sync.Mutex
+	lock.Mutex
 	values map[string]int64
 }
 

--- a/internal/querynodev2/delegator/delegator_test.go
+++ b/internal/querynodev2/delegator/delegator_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/mq/msgstream"
 	"github.com/milvus-io/milvus/pkg/util/commonpbutil"
 	"github.com/milvus-io/milvus/pkg/util/lifetime"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/metric"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
@@ -1138,7 +1139,7 @@ func TestDelegatorWatchTsafe(t *testing.T) {
 	}
 	defer sd.Close()
 
-	m := sync.Mutex{}
+	m := lock.Mutex{}
 	sd.tsCond = sync.NewCond(&m)
 	if sd.lifetime.Add(lifetime.NotStopped) == nil {
 		go sd.watchTSafe()
@@ -1165,7 +1166,7 @@ func TestDelegatorTSafeListenerClosed(t *testing.T) {
 	}
 	defer sd.Close()
 
-	m := sync.Mutex{}
+	m := lock.Mutex{}
 	sd.tsCond = sync.NewCond(&m)
 	signal := make(chan struct{})
 	if sd.lifetime.Add(lifetime.NotStopped) == nil {

--- a/internal/querynodev2/delegator/deletebuffer/delete_buffer.go
+++ b/internal/querynodev2/delegator/deletebuffer/delete_buffer.go
@@ -18,9 +18,10 @@ package deletebuffer
 
 import (
 	"sort"
-	"sync"
 
 	"github.com/cockroachdb/errors"
+
+	"github.com/milvus-io/milvus/pkg/util/lock"
 )
 
 var errBufferFull = errors.New("buffer full")
@@ -48,7 +49,7 @@ func NewDoubleCacheDeleteBuffer[T timed](startTs uint64, maxSize int64) DeleteBu
 
 // doubleCacheBuffer implements DeleteBuffer with fixed sized double cache.
 type doubleCacheBuffer[T timed] struct {
-	mut        sync.RWMutex
+	mut        lock.RWMutex
 	head, tail *cacheBlock[T]
 	maxSize    int64
 	ts         uint64
@@ -103,7 +104,7 @@ func newCacheBlock[T timed](ts uint64, maxSize int64, elements ...T) *cacheBlock
 }
 
 type cacheBlock[T timed] struct {
-	mut     sync.RWMutex
+	mut     lock.RWMutex
 	headTs  uint64
 	size    int64
 	maxSize int64

--- a/internal/querynodev2/delegator/deletebuffer/list_delete_buffer.go
+++ b/internal/querynodev2/delegator/deletebuffer/list_delete_buffer.go
@@ -17,9 +17,9 @@
 package deletebuffer
 
 import (
-	"sync"
-
 	"github.com/cockroachdb/errors"
+
+	"github.com/milvus-io/milvus/pkg/util/lock"
 )
 
 func NewListDeleteBuffer[T timed](startTs uint64, sizePerBlock int64) DeleteBuffer[T] {
@@ -34,7 +34,7 @@ func NewListDeleteBuffer[T timed](startTs uint64, sizePerBlock int64) DeleteBuff
 // head points to the earliest block.
 // tail points to the latest block which shall be written into.
 type listDeleteBuffer[T timed] struct {
-	mut sync.RWMutex
+	mut lock.RWMutex
 
 	list []*cacheBlock[T]
 

--- a/internal/querynodev2/delegator/distribution.go
+++ b/internal/querynodev2/delegator/distribution.go
@@ -24,6 +24,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/pkg/log"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
@@ -74,7 +75,7 @@ type distribution struct {
 	// generated for each change of distribution
 	current *atomic.Pointer[snapshot]
 	// protects current & segments
-	mut sync.RWMutex
+	mut lock.RWMutex
 }
 
 // SegmentEntry stores the segment meta information.

--- a/internal/querynodev2/delegator/exclude_info.go
+++ b/internal/querynodev2/delegator/exclude_info.go
@@ -17,17 +17,17 @@
 package delegator
 
 import (
-	"sync"
 	"time"
 
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/pkg/log"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 )
 
 type ExcludedSegments struct {
-	mu            sync.RWMutex
+	mu            lock.RWMutex
 	segments      map[int64]uint64 // segmentID -> Excluded TS
 	lastClean     atomic.Time
 	cleanInterval time.Duration

--- a/internal/querynodev2/pipeline/manager.go
+++ b/internal/querynodev2/pipeline/manager.go
@@ -18,7 +18,6 @@ package pipeline
 
 import (
 	"fmt"
-	"sync"
 
 	"go.uber.org/zap"
 
@@ -26,6 +25,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/metrics"
 	"github.com/milvus-io/milvus/pkg/mq/msgdispatcher"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/util/timerecord"
@@ -49,7 +49,7 @@ type manager struct {
 
 	tSafeManager TSafeManager
 	dispatcher   msgdispatcher.Client
-	mu           sync.RWMutex
+	mu           lock.RWMutex
 }
 
 func (m *manager) Num() int {

--- a/internal/querynodev2/pkoracle/bloom_filter_set.go
+++ b/internal/querynodev2/pkoracle/bloom_filter_set.go
@@ -18,7 +18,6 @@ package pkoracle
 
 import (
 	"context"
-	"sync"
 
 	bloom "github.com/bits-and-blooms/bloom/v3"
 	"go.uber.org/zap"
@@ -28,6 +27,7 @@ import (
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/pkg/common"
 	"github.com/milvus-io/milvus/pkg/log"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 )
 
@@ -35,7 +35,7 @@ var _ Candidate = (*BloomFilterSet)(nil)
 
 // BloomFilterSet is one implementation of Candidate with bloom filter in statslog.
 type BloomFilterSet struct {
-	statsMutex   sync.RWMutex
+	statsMutex   lock.RWMutex
 	segmentID    int64
 	paritionID   int64
 	segType      commonpb.SegmentState

--- a/internal/querynodev2/pkoracle/pk_oracle.go
+++ b/internal/querynodev2/pkoracle/pk_oracle.go
@@ -19,10 +19,10 @@ package pkoracle
 
 import (
 	"fmt"
-	"sync"
 
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/pkg/log"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
 
@@ -44,7 +44,7 @@ var _ PkOracle = (*pkOracle)(nil)
 type pkOracle struct {
 	candidates *typeutil.ConcurrentMap[string, candidateWithWorker]
 
-	hashFuncNumMutex sync.RWMutex
+	hashFuncNumMutex lock.RWMutex
 	maxHashFuncNum   uint
 }
 

--- a/internal/querynodev2/segments/bloom_filter_set.go
+++ b/internal/querynodev2/segments/bloom_filter_set.go
@@ -17,8 +17,6 @@
 package segments
 
 import (
-	"sync"
-
 	bloom "github.com/bits-and-blooms/bloom/v3"
 	"go.uber.org/zap"
 
@@ -26,11 +24,12 @@ import (
 	storage "github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/pkg/common"
 	"github.com/milvus-io/milvus/pkg/log"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 )
 
 type bloomFilterSet struct {
-	statsMutex   sync.RWMutex
+	statsMutex   lock.RWMutex
 	currentStat  *storage.PkStatistics
 	historyStats []*storage.PkStatistics
 }

--- a/internal/querynodev2/segments/collection.go
+++ b/internal/querynodev2/segments/collection.go
@@ -25,7 +25,6 @@ package segments
 import "C"
 
 import (
-	"sync"
 	"unsafe"
 
 	"github.com/golang/protobuf/proto"
@@ -41,6 +40,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/metrics"
 	"github.com/milvus-io/milvus/pkg/util/indexparamcheck"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
@@ -57,7 +57,7 @@ type CollectionManager interface {
 }
 
 type collectionManager struct {
-	mut         sync.RWMutex
+	mut         lock.RWMutex
 	collections map[int64]*Collection
 }
 
@@ -132,7 +132,7 @@ func (m *collectionManager) Unref(collectionID int64, count uint32) bool {
 // Collection is a wrapper of the underlying C-structure C.CCollection
 // In a query node, `Collection` is a replica info of a collection in these query node.
 type Collection struct {
-	mu            sync.RWMutex // protects colllectionPtr
+	mu            lock.RWMutex // protects colllectionPtr
 	collectionPtr C.CCollection
 	id            int64
 	partitions    *typeutil.ConcurrentSet[int64]

--- a/internal/querynodev2/segments/manager.go
+++ b/internal/querynodev2/segments/manager.go
@@ -27,7 +27,6 @@ import "C"
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"go.uber.org/zap"
 	"golang.org/x/sync/singleflight"
@@ -40,6 +39,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/metrics"
 	"github.com/milvus-io/milvus/pkg/util/cache"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/metautil"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
@@ -285,7 +285,7 @@ var _ SegmentManager = (*segmentManager)(nil)
 
 // Manager manages all collections and segments
 type segmentManager struct {
-	mu sync.RWMutex // guards all
+	mu lock.RWMutex // guards all
 
 	growingSegments map[typeutil.UniqueID]Segment
 	sealedSegments  map[typeutil.UniqueID]Segment

--- a/internal/querynodev2/segments/search.go
+++ b/internal/querynodev2/segments/search.go
@@ -19,7 +19,6 @@ package segments
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
@@ -29,6 +28,7 @@ import (
 	"github.com/milvus-io/milvus/internal/querynodev2/segments/metricsutil"
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/metrics"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/util/timerecord"
 )
@@ -125,7 +125,7 @@ func searchSegmentsStreamly(ctx context.Context,
 ) error {
 	searchLabel := metrics.SealedSegmentLabel
 	searchResultsToClear := make([]*SearchResult, 0)
-	var reduceMutex sync.Mutex
+	var reduceMutex lock.Mutex
 	var sumReduceDuration atomic.Duration
 	searcher := func(ctx context.Context, seg Segment) error {
 		// record search time

--- a/internal/querynodev2/segments/segment_l0.go
+++ b/internal/querynodev2/segments/segment_l0.go
@@ -18,7 +18,6 @@ package segments
 
 import (
 	"context"
-	"sync"
 
 	"github.com/samber/lo"
 	"go.uber.org/zap"
@@ -28,6 +27,7 @@ import (
 	"github.com/milvus-io/milvus/internal/proto/segcorepb"
 	storage "github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/pkg/log"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
@@ -37,7 +37,7 @@ var _ Segment = (*L0Segment)(nil)
 type L0Segment struct {
 	baseSegment
 
-	dataGuard sync.RWMutex
+	dataGuard lock.RWMutex
 	pks       []storage.PrimaryKey
 	tss       []uint64
 }

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -57,6 +57,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/util/contextutil"
 	"github.com/milvus-io/milvus/pkg/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/util/hardware"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/util/syncutil"
@@ -573,7 +574,7 @@ type loadResult struct {
 func newLoadResult() *loadResult {
 	return &loadResult{
 		status: atomic.NewInt32(loading),
-		cond:   sync.NewCond(&sync.Mutex{}),
+		cond:   sync.NewCond(&lock.Mutex{}),
 	}
 }
 
@@ -587,7 +588,7 @@ type segmentLoader struct {
 	manager *Manager
 	cm      storage.ChunkManager
 
-	mut sync.Mutex
+	mut lock.Mutex
 	// The channel will be closed as the segment loaded
 	loadingSegments           *typeutil.ConcurrentMap[int64, *loadResult]
 	committedResource         LoadResource

--- a/internal/querynodev2/segments/state/load_state_lock.go
+++ b/internal/querynodev2/segments/state/load_state_lock.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"go.uber.org/atomic"
+
+	"github.com/milvus-io/milvus/pkg/util/lock"
 )
 
 type loadStateEnum int
@@ -49,7 +51,7 @@ func NewLoadStateLock(state loadStateEnum) *LoadStateLock {
 		panic(fmt.Sprintf("invalid state for construction of LoadStateLock, %s", state.String()))
 	}
 
-	mu := &sync.RWMutex{}
+	mu := &lock.RWMutex{}
 	return &LoadStateLock{
 		mu:     mu,
 		cv:     sync.Cond{L: mu},
@@ -60,7 +62,7 @@ func NewLoadStateLock(state loadStateEnum) *LoadStateLock {
 
 // LoadStateLock is the state of segment loading.
 type LoadStateLock struct {
-	mu     *sync.RWMutex
+	mu     *lock.RWMutex
 	cv     sync.Cond
 	state  loadStateEnum
 	refCnt *atomic.Int32

--- a/internal/querynodev2/services.go
+++ b/internal/querynodev2/services.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"sync"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/samber/lo"
@@ -48,6 +47,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/metrics"
 	"github.com/milvus-io/milvus/pkg/util/commonpbutil"
 	"github.com/milvus-io/milvus/pkg/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/metricsinfo"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
@@ -118,7 +118,7 @@ func (node *QueryNode) GetStatistics(ctx context.Context, req *querypb.GetStatis
 	}
 
 	var toReduceResults []*internalpb.GetStatisticsResponse
-	var mu sync.Mutex
+	var mu lock.Mutex
 	runningGp, runningCtx := errgroup.WithContext(ctx)
 	for _, ch := range req.GetDmlChannels() {
 		ch := ch

--- a/internal/querynodev2/tsafe/manager.go
+++ b/internal/querynodev2/tsafe/manager.go
@@ -19,11 +19,11 @@ package tsafe
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/pkg/log"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/tsoutil"
 	. "github.com/milvus-io/milvus/pkg/util/typeutil"
 )
@@ -42,7 +42,7 @@ type Manager interface {
 
 // tSafeManager implements `Manager` interface.
 type tSafeManager struct {
-	mu        sync.Mutex             // guards tSafes
+	mu        lock.Mutex             // guards tSafes
 	tSafes    map[string]*tSafe      // map[DMLChannel]*tSafe
 	listeners map[string][]*listener // map[DMLChannel][]*listener, key "" means all channels.
 }

--- a/internal/rootcoord/ddl_ts_lock_manager.go
+++ b/internal/rootcoord/ddl_ts_lock_manager.go
@@ -17,11 +17,10 @@
 package rootcoord
 
 import (
-	"sync"
-
 	"go.uber.org/atomic"
 
 	"github.com/milvus-io/milvus/internal/tso"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 )
 
 type DdlTsLockManager interface {
@@ -36,7 +35,7 @@ type ddlTsLockManager struct {
 	lastTs        atomic.Uint64
 	inProgressCnt atomic.Int32
 	tsoAllocator  tso.Allocator
-	mu            sync.Mutex
+	mu            lock.Mutex
 }
 
 func (c *ddlTsLockManager) GetMinDdlTs() Timestamp {
@@ -75,6 +74,6 @@ func newDdlTsLockManager(tsoAllocator tso.Allocator) *ddlTsLockManager {
 		lastTs:        *atomic.NewUint64(0),
 		inProgressCnt: *atomic.NewInt32(0),
 		tsoAllocator:  tsoAllocator,
-		mu:            sync.Mutex{},
+		mu:            lock.Mutex{},
 	}
 }

--- a/internal/rootcoord/dml_channels.go
+++ b/internal/rootcoord/dml_channels.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"sync"
 
 	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
@@ -31,13 +30,14 @@ import (
 	"github.com/milvus-io/milvus/pkg/metrics"
 	"github.com/milvus-io/milvus/pkg/mq/msgstream"
 	"github.com/milvus-io/milvus/pkg/mq/msgstream/mqwrapper"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
 
 type dmlMsgStream struct {
 	ms    msgstream.MsgStream
-	mutex sync.RWMutex
+	mutex lock.RWMutex
 
 	refcnt int64 // current in use count
 	used   int64 // total used counter in current run, not stored in meta so meant to be inaccurate
@@ -142,7 +142,7 @@ type dmlChannels struct {
 	// pool maintains channelName => dmlMsgStream mapping, stable
 	pool *typeutil.ConcurrentMap[string, *dmlMsgStream]
 	// mut protects channelsHeap only
-	mut sync.Mutex
+	mut lock.Mutex
 	// channelsHeap is the heap to pop next dms for use
 	channelsHeap channelsHeap
 }

--- a/internal/rootcoord/meta_table.go
+++ b/internal/rootcoord/meta_table.go
@@ -19,7 +19,6 @@ package rootcoord
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
@@ -37,6 +36,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/util"
 	"github.com/milvus-io/milvus/pkg/util/contextutil"
 	"github.com/milvus-io/milvus/pkg/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/timerecord"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
@@ -109,8 +109,8 @@ type MetaTable struct {
 	names   *nameDb
 	aliases *nameDb
 
-	ddLock         sync.RWMutex
-	permissionLock sync.RWMutex
+	ddLock         lock.RWMutex
+	permissionLock lock.RWMutex
 }
 
 func NewMetaTable(ctx context.Context, catalog metastore.RootCoordCatalog, tsoAllocator tso.Allocator) (*MetaTable, error) {

--- a/internal/rootcoord/quota_center.go
+++ b/internal/rootcoord/quota_center.go
@@ -43,6 +43,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/metrics"
 	"github.com/milvus-io/milvus/pkg/util/commonpbutil"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/metricsinfo"
 	"github.com/milvus-io/milvus/pkg/util/ratelimitutil"
@@ -139,7 +140,7 @@ type QuotaCenter struct {
 	queryNodeMetrics map[UniqueID]*metricsinfo.QueryNodeQuotaMetrics
 	dataNodeMetrics  map[UniqueID]*metricsinfo.DataNodeQuotaMetrics
 	proxyMetrics     map[UniqueID]*metricsinfo.ProxyQuotaMetrics
-	diskMu           sync.Mutex // guards dataCoordMetrics and totalBinlogSize
+	diskMu           lock.Mutex // guards dataCoordMetrics and totalBinlogSize
 	dataCoordMetrics *metricsinfo.DataCoordQuotaMetrics
 	totalBinlogSize  int64
 

--- a/internal/rootcoord/root_coord.go
+++ b/internal/rootcoord/root_coord.go
@@ -60,6 +60,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/util/crypto"
 	"github.com/milvus-io/milvus/pkg/util/expr"
 	"github.com/milvus-io/milvus/pkg/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/logutil"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/metricsinfo"
@@ -2764,7 +2765,7 @@ func (c *Core) CheckHealth(ctx context.Context, in *milvuspb.CheckHealthRequest)
 		}, nil
 	}
 
-	mu := &sync.Mutex{}
+	mu := &lock.Mutex{}
 	group, ctx := errgroup.WithContext(ctx)
 	errReasons := make([]string, 0, c.proxyClientManager.GetProxyCount())
 

--- a/internal/rootcoord/scheduler.go
+++ b/internal/rootcoord/scheduler.go
@@ -27,6 +27,7 @@ import (
 	"github.com/milvus-io/milvus/internal/allocator"
 	"github.com/milvus-io/milvus/internal/tso"
 	"github.com/milvus-io/milvus/pkg/log"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 )
 
 type IScheduler interface {
@@ -46,7 +47,7 @@ type scheduler struct {
 
 	taskChan chan task
 
-	lock sync.Mutex
+	lock lock.Mutex
 
 	minDdlTs atomic.Uint64
 }

--- a/internal/rootcoord/step_executor.go
+++ b/internal/rootcoord/step_executor.go
@@ -25,6 +25,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/pkg/log"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/retry"
 )
 
@@ -150,7 +151,7 @@ type bgStepExecutor struct {
 	wg            sync.WaitGroup
 	bufferedSteps map[*stepStack]struct{}
 	selector      selectStepPolicy
-	mu            sync.Mutex
+	mu            lock.Mutex
 	notifyChan    chan struct{}
 	interval      time.Duration
 }
@@ -163,7 +164,7 @@ func newBgStepExecutor(ctx context.Context, opts ...bgOpt) *bgStepExecutor {
 		wg:            sync.WaitGroup{},
 		bufferedSteps: make(map[*stepStack]struct{}),
 		selector:      defaultSelectPolicy(),
-		mu:            sync.Mutex{},
+		mu:            lock.Mutex{},
 		notifyChan:    make(chan struct{}, 1),
 		interval:      defaultBgExecutingInterval,
 	}

--- a/internal/rootcoord/timeticksync.go
+++ b/internal/rootcoord/timeticksync.go
@@ -32,6 +32,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/metrics"
 	"github.com/milvus-io/milvus/pkg/mq/msgstream"
 	"github.com/milvus-io/milvus/pkg/util/commonpbutil"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/timerecord"
 	"github.com/milvus-io/milvus/pkg/util/tsoutil"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
@@ -80,7 +81,7 @@ type timetickSync struct {
 
 	dmlChannels *dmlChannels // used for insert
 
-	lock           sync.Mutex
+	lock           lock.Mutex
 	sess2ChanTsMap map[typeutil.UniqueID]*chanTsMsg
 	sendChan       chan map[typeutil.UniqueID]*chanTsMsg
 
@@ -132,7 +133,7 @@ func newTimeTickSync(ctx context.Context, sourceID int64, factory msgstream.Fact
 
 		dmlChannels: dmlChannels,
 
-		lock:           sync.Mutex{},
+		lock:           lock.Mutex{},
 		sess2ChanTsMap: make(map[typeutil.UniqueID]*chanTsMsg),
 
 		// 1 is the most reasonable capacity. In fact, Milvus can only focus on the latest time tick.

--- a/internal/util/dependency/kv/kv_client_handler.go
+++ b/internal/util/dependency/kv/kv_client_handler.go
@@ -2,11 +2,11 @@ package kvfactory
 
 import (
 	"fmt"
-	"sync"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
 
 	"github.com/milvus-io/milvus/pkg/util/etcd"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 )
 
@@ -15,7 +15,7 @@ var clientCreator = &etcdClientCreator{}
 var getEtcdAndPathFunction = getEtcdAndPath
 
 type etcdClientCreator struct {
-	mu       sync.Mutex
+	mu       lock.Mutex
 	client   *clientv3.Client
 	rootpath *string
 }

--- a/internal/util/flowgraph/node.go
+++ b/internal/util/flowgraph/node.go
@@ -24,6 +24,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/pkg/log"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/timerecord"
 )
 
@@ -158,7 +159,7 @@ type nodeCtx struct {
 	inputChannel chan []Msg
 	downstream   *nodeCtx
 
-	blockMutex sync.RWMutex
+	blockMutex lock.RWMutex
 }
 
 func (nodeCtx *nodeCtx) Block() {

--- a/internal/util/grpcclient/client.go
+++ b/internal/util/grpcclient/client.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto/tls"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -45,6 +44,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/util/generic"
 	"github.com/milvus-io/milvus/pkg/util/interceptor"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/util/retry"
@@ -59,7 +59,7 @@ type GrpcComponent interface {
 type clientConnWrapper[T GrpcComponent] struct {
 	client T
 	conn   *grpc.ClientConn
-	mut    sync.RWMutex
+	mut    lock.RWMutex
 }
 
 func (c *clientConnWrapper[T]) Pin() {
@@ -106,7 +106,7 @@ type ClientBase[T interface {
 	encryption bool
 	addr       atomic.String
 	// conn                   *grpc.ClientConn
-	grpcClientMtx sync.RWMutex
+	grpcClientMtx lock.RWMutex
 	role          string
 	isNode        bool // pre-calculated is node flag
 

--- a/internal/util/metrics/c_registry.go
+++ b/internal/util/metrics/c_registry.go
@@ -31,7 +31,6 @@ import "C"
 import (
 	"sort"
 	"strings"
-	"sync"
 	"unsafe"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -41,6 +40,7 @@ import (
 	"golang.org/x/exp/maps"
 
 	"github.com/milvus-io/milvus/pkg/log"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 )
 
 // metricSorter is a sortable slice of *dto.Metric.
@@ -117,7 +117,7 @@ func NewCRegistry() *CRegistry {
 // only re-write the implementation of Gather()
 type CRegistry struct {
 	*prometheus.Registry
-	mtx sync.RWMutex
+	mtx lock.RWMutex
 }
 
 // Gather implements Gatherer.

--- a/internal/util/mock/grpcclient.go
+++ b/internal/util/mock/grpcclient.go
@@ -19,7 +19,6 @@ package mock
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -29,6 +28,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/tracer"
 	"github.com/milvus-io/milvus/pkg/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/util/generic"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/retry"
 )
 
@@ -38,7 +38,7 @@ type GRPCClientBase[T any] struct {
 
 	grpcClient       T
 	conn             *grpc.ClientConn
-	grpcClientMtx    sync.RWMutex
+	grpcClientMtx    lock.RWMutex
 	GetGrpcClientErr error
 	role             string
 	nodeID           int64

--- a/internal/util/proxyutil/proxy_client_manager.go
+++ b/internal/util/proxyutil/proxy_client_manager.go
@@ -19,7 +19,6 @@ package proxyutil
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
@@ -34,6 +33,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/metrics"
 	"github.com/milvus-io/milvus/pkg/util/commonpbutil"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/metricsinfo"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
@@ -295,7 +295,7 @@ func (p *ProxyClientManager) GetProxyMetrics(ctx context.Context) ([]*milvuspb.G
 	}
 
 	group := &errgroup.Group{}
-	var metricRspsMu sync.Mutex
+	var metricRspsMu lock.Mutex
 	metricRsps := make([]*milvuspb.GetMetricsResponse, 0)
 	p.proxyClient.Range(func(key int64, value types.ProxyClient) bool {
 		k, v := key, value

--- a/internal/util/proxyutil/proxy_client_manager_test.go
+++ b/internal/util/proxyutil/proxy_client_manager_test.go
@@ -19,7 +19,6 @@ package proxyutil
 import (
 	"context"
 	"fmt"
-	"sync"
 	"testing"
 
 	"github.com/cockroachdb/errors"
@@ -32,6 +31,7 @@ import (
 	"github.com/milvus-io/milvus/internal/proto/proxypb"
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/sessionutil"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 )
@@ -47,7 +47,7 @@ type proxyMock struct {
 	types.ProxyClient
 	collArray []string
 	collIDs   []UniqueID
-	mutex     sync.Mutex
+	mutex     lock.Mutex
 
 	returnError     bool
 	returnGrpcError bool

--- a/internal/util/proxyutil/proxy_watcher.go
+++ b/internal/util/proxyutil/proxy_watcher.go
@@ -33,6 +33,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/sessionutil"
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/util/lifetime"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
@@ -48,7 +49,7 @@ type ProxyWatcherInterface interface {
 // ProxyWatcher manages proxy clients
 type ProxyWatcher struct {
 	wg               errgroup.Group
-	lock             sync.Mutex
+	lock             lock.Mutex
 	etcdCli          *clientv3.Client
 	initSessionsFunc []func([]*sessionutil.Session)
 	addSessionsFunc  []func(*sessionutil.Session)
@@ -62,7 +63,7 @@ type ProxyWatcher struct {
 // fns are the custom getSessions function list
 func NewProxyWatcher(client *clientv3.Client, fns ...func([]*sessionutil.Session)) *ProxyWatcher {
 	p := &ProxyWatcher{
-		lock:    sync.Mutex{},
+		lock:    lock.Mutex{},
 		etcdCli: client,
 		closeCh: lifetime.NewSafeChan(),
 	}

--- a/internal/util/ratelimitutil/rate_limiter_tree.go
+++ b/internal/util/ratelimitutil/rate_limiter_tree.go
@@ -18,13 +18,13 @@ package ratelimitutil
 
 import (
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/milvus-io/milvus/internal/proto/internalpb"
 	"github.com/milvus-io/milvus/internal/proto/proxypb"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/ratelimitutil"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
@@ -166,7 +166,7 @@ func (rln *RateLimiterNode) GetID() int64 {
 //				-> partition levelearl
 type RateLimiterTree struct {
 	root *RateLimiterNode
-	mu   sync.RWMutex
+	mu   lock.RWMutex
 }
 
 // NewRateLimiterTree returns a new RateLimiterTree.

--- a/internal/util/sessionutil/session_util.go
+++ b/internal/util/sessionutil/session_util.go
@@ -40,6 +40,7 @@ import (
 	kvfactory "github.com/milvus-io/milvus/internal/util/dependency/kv"
 	"github.com/milvus-io/milvus/pkg/common"
 	"github.com/milvus-io/milvus/pkg/log"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/util/retry"
 )
@@ -123,7 +124,7 @@ type Session struct {
 	ctx context.Context
 	// When outside context done, Session cancels its goroutines first, then uses
 	// keepAliveCancel to cancel the etcd KeepAlive
-	keepAliveLock   sync.Mutex
+	keepAliveLock   lock.Mutex
 	keepAliveCancel context.CancelFunc
 	keepAliveCtx    context.Context
 
@@ -306,7 +307,7 @@ func (s *Session) Register() {
 	s.UpdateRegistered(true)
 }
 
-var serverIDMu sync.Mutex
+var serverIDMu lock.Mutex
 
 func (s *Session) getServerID() (int64, error) {
 	serverIDMu.Lock()

--- a/internal/util/sessionutil/session_util_test.go
+++ b/internal/util/sessionutil/session_util_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/util/etcd"
 	"github.com/milvus-io/milvus/pkg/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
@@ -55,7 +56,7 @@ func TestGetServerIDConcurrently(t *testing.T) {
 	defer etcdKV.RemoveWithPrefix("")
 
 	var wg sync.WaitGroup
-	muList := sync.Mutex{}
+	muList := lock.Mutex{}
 
 	s := NewSessionWithEtcd(ctx, metaRoot, etcdCli)
 	res := make([]int64, 0)
@@ -151,7 +152,7 @@ func TestUpdateSessions(t *testing.T) {
 	defer etcdKV.RemoveWithPrefix("")
 
 	var wg sync.WaitGroup
-	muList := sync.Mutex{}
+	muList := lock.Mutex{}
 
 	s := NewSessionWithEtcd(ctx, metaRoot, etcdCli, WithResueNodeID(false))
 

--- a/internal/util/streamrpc/streamer.go
+++ b/internal/util/streamrpc/streamer.go
@@ -8,6 +8,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/milvus-io/milvus/internal/proto/internalpb"
+	"github.com/milvus-io/milvus/pkg/util/lock"
 )
 
 type QueryStreamServer interface {
@@ -22,7 +23,7 @@ type QueryStreamClient interface {
 
 type ConcurrentQueryStreamServer struct {
 	server QueryStreamServer
-	mu     sync.Mutex
+	mu     lock.Mutex
 }
 
 func (s *ConcurrentQueryStreamServer) Send(result *internalpb.RetrieveResults) error {
@@ -38,7 +39,7 @@ func (s *ConcurrentQueryStreamServer) Context() context.Context {
 func NewConcurrentQueryStreamServer(srv QueryStreamServer) *ConcurrentQueryStreamServer {
 	return &ConcurrentQueryStreamServer{
 		server: srv,
-		mu:     sync.Mutex{},
+		mu:     lock.Mutex{},
 	}
 }
 
@@ -52,7 +53,7 @@ type LocalQueryServer struct {
 
 	finishOnce sync.Once
 	errCh      chan error
-	mu         sync.Mutex
+	mu         lock.Mutex
 }
 
 func (s *LocalQueryServer) Send(result *internalpb.RetrieveResults) error {
@@ -123,7 +124,7 @@ func (s *LocalQueryClient) CreateServer() *LocalQueryServer {
 	s.server = &LocalQueryServer{
 		resultCh: s.resultCh,
 		ctx:      s.ctx,
-		mu:       sync.Mutex{},
+		mu:       lock.Mutex{},
 		errCh:    make(chan error, 1),
 	}
 	return s.server

--- a/pkg/util/lock/key_lock.go
+++ b/pkg/util/lock/key_lock.go
@@ -25,7 +25,7 @@ import (
 )
 
 type RefLock struct {
-	mutex      sync.RWMutex
+	mutex      RWMutex
 	refCounter int
 }
 
@@ -39,7 +39,7 @@ func (m *RefLock) unref() {
 
 func newRefLock() *RefLock {
 	c := RefLock{
-		sync.RWMutex{},
+		RWMutex{},
 		0,
 	}
 	return &c

--- a/pkg/util/lock/key_lock.go
+++ b/pkg/util/lock/key_lock.go
@@ -25,7 +25,7 @@ import (
 )
 
 type RefLock struct {
-	mutex      RWMutex
+	mutex      sync.RWMutex
 	refCounter int
 }
 
@@ -39,7 +39,7 @@ func (m *RefLock) unref() {
 
 func newRefLock() *RefLock {
 	c := RefLock{
-		RWMutex{},
+		sync.RWMutex{},
 		0,
 	}
 	return &c

--- a/pkg/util/lock/metric_mutex.go
+++ b/pkg/util/lock/metric_mutex.go
@@ -1,6 +1,7 @@
 package lock
 
 import (
+	"sync"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -16,7 +17,7 @@ type MetricsLockManager struct {
 }
 
 type MetricsRWMutex struct {
-	mutex          RWMutex
+	mutex          sync.RWMutex
 	lockName       string
 	acquireTimeMap map[string]time.Time
 }

--- a/pkg/util/lock/metric_mutex.go
+++ b/pkg/util/lock/metric_mutex.go
@@ -1,7 +1,6 @@
 package lock
 
 import (
-	"sync"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -17,7 +16,7 @@ type MetricsLockManager struct {
 }
 
 type MetricsRWMutex struct {
-	mutex          sync.RWMutex
+	mutex          RWMutex
 	lockName       string
 	acquireTimeMap map[string]time.Time
 }


### PR DESCRIPTION
See also #33062 #33063

Replace all `sync.RWMutex` & `sync.Mutex` under internal pkg to
`lock.RWMutex` & `sync.Mutex`

Signed-off-by: Congqi Xia <congqi.xia@zilliz.com>