### PR TITLE
fix: remove date in the end of ubuntu base image version

### DIFF
--- a/build/docker/milvus/ubuntu20.04/Dockerfile
+++ b/build/docker/milvus/ubuntu20.04/Dockerfile
@@ -9,7 +9,7 @@
 # is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 # or implied. See the License for the specific language governing permissions and limitations under the License.
 
-FROM ubuntu:focal-20220426
+FROM ubuntu:focal
 
 ARG TARGETARCH
 

--- a/build/docker/milvus/ubuntu20.04/Dockerfile
+++ b/build/docker/milvus/ubuntu20.04/Dockerfile
@@ -9,7 +9,7 @@
 # is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 # or implied. See the License for the specific language governing permissions and limitations under the License.
 
-FROM ubuntu:focal
+FROM ubuntu:focal-20240427
 
 ARG TARGETARCH
 


### PR DESCRIPTION
CVE issues https://github.com/milvus-io/milvus/issues/31997
This PR will fix **32** LOW and **42** MEDIUM CVEs

**ubuntu:focal-20220426 (ubuntu 20.04)**
Total: 99 (UNKNOWN: 0, LOW: 55, MEDIUM: 44, HIGH: 0, CRITICAL: 0)
**ubuntu:focal (ubuntu 20.04)**
Total: 25 (UNKNOWN: 0, LOW: 23, MEDIUM: 2, HIGH: 0, CRITICAL: 0)
![image](https://github.com/milvus-io/milvus/assets/27683687/49719035-8e28-498a-b00d-9c862d531c19)
![image](https://github.com/milvus-io/milvus/assets/27683687/7efc76c0-d333-4569-9455-4aa1a1aa3619)
