### PR TITLE
enhance: Refine channelCpUpdater field & test

### DIFF
--- a/internal/datanode/data_node.go
+++ b/internal/datanode/data_node.go
@@ -289,7 +289,7 @@ func (node *DataNode) Init() error {
 
 		node.importTaskMgr = importv2.NewTaskManager()
 		node.importScheduler = importv2.NewScheduler(node.importTaskMgr, node.syncMgr, node.chunkManager)
-		node.channelCheckpointUpdater = newChannelCheckpointUpdater(node)
+		node.channelCheckpointUpdater = newChannelCheckpointUpdater(node.broker)
 		node.flowgraphManager = newFlowgraphManager()
 
 		if paramtable.Get().DataCoordCfg.EnableBalanceChannelWithRPC.GetAsBool() {

--- a/internal/datanode/data_sync_service_test.go
+++ b/internal/datanode/data_sync_service_test.go
@@ -397,7 +397,7 @@ func (s *DataSyncServiceSuite) SetupTest() {
 		},
 	}
 	s.node.ctx = context.Background()
-	s.node.channelCheckpointUpdater = newChannelCheckpointUpdater(s.node)
+	s.node.channelCheckpointUpdater = newChannelCheckpointUpdater(s.node.broker)
 	paramtable.Get().Save(paramtable.Get().DataNodeCfg.ChannelCheckpointUpdateTickInSeconds.Key, "0.01")
 	defer paramtable.Get().Save(paramtable.Get().DataNodeCfg.ChannelCheckpointUpdateTickInSeconds.Key, "10")
 	go s.node.channelCheckpointUpdater.start()


### PR DESCRIPTION
Avoid passing datanode around preparing datanode code directory
refactory.

Also refine unit test code for same component. The `Await` shall return
first before checking the counter number since when lock cost is heavy
(using deadlock.RWMutex See PR #33069.) case may fail due to long
running time submitting tasks.

Signed-off-by: Congqi Xia <congqi.xia@zilliz.com>