### PR TITLE
fix: enable GetVectorFromChunkCache and WarmupChunkCache test

### DIFF
--- a/internal/core/unittest/test_sealed.cpp
+++ b/internal/core/unittest/test_sealed.cpp
@@ -1369,9 +1369,6 @@ TEST(Sealed, GetVector) {
 }
 
 TEST(Sealed, GetVectorFromChunkCache) {
-    // skip test due to mem leak from AWS::InitSDK
-    return;
-
     auto dim = 16;
     auto topK = 5;
     auto N = ROW_COUNT;
@@ -1480,9 +1477,6 @@ TEST(Sealed, GetVectorFromChunkCache) {
 }
 
 TEST(Sealed, WarmupChunkCache) {
-    // skip test due to mem leak from AWS::InitSDK
-    return;
-
     auto dim = 16;
     auto topK = 5;
     auto N = ROW_COUNT;


### PR DESCRIPTION
check to see if the mem leak from AWS::InitSDK has been fixed, if so we can re-enable the test