### PR TITLE
enhance: [2.3] Add param item to ignore bad message id in checkpoint

### DIFF
--- a/pkg/mq/msgstream/mq_msgstream.go
+++ b/pkg/mq/msgstream/mq_msgstream.go
@@ -481,6 +481,10 @@ func (ms *mqMsgStream) Seek(ctx context.Context, msgPositions []*msgpb.MsgPositi
 		}
 		messageID, err := ms.client.BytesToMsgID(mp.MsgID)
 		if err != nil {
+			if paramtable.Get().MQCfg.IgnoreBadPosition.GetAsBool() {
+				log.Ctx(ctx).Warn("Ignoring bad message id", zap.Error(err))
+				continue
+			}
 			return err
 		}
 
@@ -848,6 +852,10 @@ func (ms *MqTtMsgStream) Seek(ctx context.Context, msgPositions []*msgpb.MsgPosi
 
 		seekMsgID, err := ms.client.BytesToMsgID(mp.MsgID)
 		if err != nil {
+			if paramtable.Get().MQCfg.IgnoreBadPosition.GetAsBool() {
+				log.Ctx(ctx).Warn("Ignoring bad message id", zap.Error(err))
+				return nil
+			}
 			return err
 		}
 		log.Info("MsgStream begin to seek start msg: ", zap.String("channel", mp.ChannelName), zap.Any("MessageID", mp.MsgID))

--- a/pkg/mq/msgstream/mq_msgstream_test.go
+++ b/pkg/mq/msgstream/mq_msgstream_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
 	"github.com/milvus-io/milvus/pkg/mq/msgstream/mqwrapper"
+	kafkawrapper "github.com/milvus-io/milvus/pkg/mq/msgstream/mqwrapper/kafka"
 	pulsarwrapper "github.com/milvus-io/milvus/pkg/mq/msgstream/mqwrapper/pulsar"
 	"github.com/milvus-io/milvus/pkg/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
@@ -996,6 +997,68 @@ func TestStream_MqMsgStream_SeekInvalidMessage(t *testing.T) {
 	assert.NoError(t, err)
 	result := consumer(ctx, outputStream2)
 	assert.Equal(t, result.Msgs[0].ID(), int64(1))
+}
+
+func TestSTream_MqMsgStream_SeekBadMessageID(t *testing.T) {
+	pulsarAddress := getPulsarAddress()
+	c := funcutil.RandomString(8)
+	producerChannels := []string{c}
+	consumerChannels := []string{c}
+
+	msgPack := &MsgPack{}
+	ctx := context.Background()
+	inputStream := getPulsarInputStream(ctx, pulsarAddress, producerChannels)
+	defer inputStream.Close()
+
+	outputStream := getPulsarOutputStream(ctx, pulsarAddress, consumerChannels, funcutil.RandomString(8))
+	defer outputStream.Close()
+
+	for i := 0; i < 10; i++ {
+		insertMsg := getTsMsg(commonpb.MsgType_Insert, int64(i))
+		msgPack.Msgs = append(msgPack.Msgs, insertMsg)
+	}
+
+	err := inputStream.Produce(msgPack)
+	assert.NoError(t, err)
+	var seekPosition *msgpb.MsgPosition
+	for i := 0; i < 10; i++ {
+		result := consumer(ctx, outputStream)
+		assert.Equal(t, result.Msgs[0].ID(), int64(i))
+		seekPosition = result.EndPositions[0]
+	}
+
+	factory := ProtoUDFactory{}
+	pulsarClient, _ := pulsarwrapper.NewClient(DefaultPulsarTenant, DefaultPulsarNamespace, pulsar.ClientOptions{URL: pulsarAddress})
+	outputStream2, _ := NewMqMsgStream(ctx, 100, 100, pulsarClient, factory.NewUnmarshalDispatcher())
+	outputStream2.AsConsumer(ctx, consumerChannels, funcutil.RandomString(8), mqwrapper.SubscriptionPositionLatest)
+	defer outputStream2.Close()
+
+	outputStream3, err := NewMqMsgStream(ctx, 100, 100, pulsarClient, factory.NewUnmarshalDispatcher())
+	outputStream3.AsConsumer(ctx, consumerChannels, funcutil.RandomString(8), mqwrapper.SubscriptionPositionLatest)
+	require.NoError(t, err)
+
+	defer paramtable.Get().Reset(paramtable.Get().MQCfg.IgnoreBadPosition.Key)
+
+	p := []*msgpb.MsgPosition{
+		{
+			ChannelName: seekPosition.ChannelName,
+			Timestamp:   seekPosition.Timestamp,
+			MsgGroup:    seekPosition.MsgGroup,
+			MsgID:       kafkawrapper.SerializeKafkaID(123),
+		},
+	}
+
+	paramtable.Get().Save(paramtable.Get().MQCfg.IgnoreBadPosition.Key, "false")
+	err = outputStream2.Seek(ctx, p)
+	assert.Error(t, err)
+	err = outputStream3.Seek(ctx, p)
+	assert.Error(t, err)
+
+	paramtable.Get().Save(paramtable.Get().MQCfg.IgnoreBadPosition.Key, "true")
+	err = outputStream2.Seek(ctx, p)
+	assert.NoError(t, err)
+	err = outputStream3.Seek(ctx, p)
+	assert.NoError(t, err)
 }
 
 func TestStream_MqMsgStream_SeekLatest(t *testing.T) {

--- a/pkg/mq/msgstream/mq_msgstream_test.go
+++ b/pkg/mq/msgstream/mq_msgstream_test.go
@@ -1027,14 +1027,20 @@ func TestSTream_MqMsgStream_SeekBadMessageID(t *testing.T) {
 		seekPosition = result.EndPositions[0]
 	}
 
+	// produce timetick for mqtt msgstream seek
+	msgPack = &MsgPack{}
+	msgPack.Msgs = append(msgPack.Msgs, getTimeTickMsg(1000))
+	err = inputStream.Produce(msgPack)
+	assert.NoError(t, err)
+
 	factory := ProtoUDFactory{}
 	pulsarClient, _ := pulsarwrapper.NewClient(DefaultPulsarTenant, DefaultPulsarNamespace, pulsar.ClientOptions{URL: pulsarAddress})
 	outputStream2, _ := NewMqMsgStream(ctx, 100, 100, pulsarClient, factory.NewUnmarshalDispatcher())
 	outputStream2.AsConsumer(ctx, consumerChannels, funcutil.RandomString(8), mqwrapper.SubscriptionPositionLatest)
 	defer outputStream2.Close()
 
-	outputStream3, err := NewMqMsgStream(ctx, 100, 100, pulsarClient, factory.NewUnmarshalDispatcher())
-	outputStream3.AsConsumer(ctx, consumerChannels, funcutil.RandomString(8), mqwrapper.SubscriptionPositionLatest)
+	outputStream3, err := NewMqTtMsgStream(ctx, 100, 100, pulsarClient, factory.NewUnmarshalDispatcher())
+	outputStream3.AsConsumer(ctx, consumerChannels, funcutil.RandomString(8), mqwrapper.SubscriptionPositionEarliest)
 	require.NoError(t, err)
 
 	defer paramtable.Get().Reset(paramtable.Get().MQCfg.IgnoreBadPosition.Key)

--- a/pkg/util/paramtable/service_param.go
+++ b/pkg/util/paramtable/service_param.go
@@ -437,8 +437,9 @@ type MQConfig struct {
 	PursuitLag        ParamItem `refreshable:"true"`
 	PursuitBufferSize ParamItem `refreshable:"true"`
 
-	MQBufSize      ParamItem `refreshable:"false"`
-	ReceiveBufSize ParamItem `refreshable:"false"`
+	MQBufSize         ParamItem `refreshable:"false"`
+	ReceiveBufSize    ParamItem `refreshable:"false"`
+	IgnoreBadPosition ParamItem `refreshable:"true"`
 }
 
 // Init initializes the MQConfig object with a BaseTable.
@@ -496,6 +497,14 @@ Valid values: [default, pulsar, kafka, rocksmq, natsmq]`,
 		Doc:          "MQ consumer chan buffer length",
 	}
 	p.ReceiveBufSize.Init(base.mgr)
+
+	p.IgnoreBadPosition = ParamItem{
+		Key:          "mq.ignoreBadPosition",
+		Version:      "2.3.16",
+		DefaultValue: "false",
+		Doc:          "A switch for ignoring message queue failing to parse message ID from checkpoint position. Usually caused by switching among different mq implementations. May caused data loss when used by mistake",
+	}
+	p.IgnoreBadPosition.Init(base.mgr)
 }
 
 // /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Cherry-pick from master
pr: #33123
See also #33122

This pr add param item `mq.ignoreBadPosition` to control behavior when mq failed to parse message id from checkpoint