### PR TITLE
enhance: upgrade images golang version from 1.20 to 1.21

### DIFF
--- a/build/docker/builder/cpu/rockylinux8/Dockerfile
+++ b/build/docker/builder/cpu/rockylinux8/Dockerfile
@@ -43,7 +43,7 @@ RUN dnf -y update && \
 
 
 RUN pip3 install conan==1.61.0
-RUN mkdir -p /usr/local/go && wget -qO- "https://go.dev/dl/go1.20.7.linux-$TARGETARCH.tar.gz" | tar --strip-components=1 -xz -C /usr/local/go 
+RUN mkdir -p /usr/local/go && wget -qO- "https://go.dev/dl/go1.21.10.linux-$TARGETARCH.tar.gz" | tar --strip-components=1 -xz -C /usr/local/go 
 RUN curl https://sh.rustup.rs -sSf | \
     sh -s -- --default-toolchain=1.73 -y
 

--- a/build/docker/builder/cpu/ubuntu20.04/Dockerfile
+++ b/build/docker/builder/cpu/ubuntu20.04/Dockerfile
@@ -40,7 +40,7 @@ ENV GOPATH /go
 ENV GOROOT /usr/local/go
 ENV GO111MODULE on
 ENV PATH $GOPATH/bin:$GOROOT/bin:$PATH
-RUN mkdir -p /usr/local/go && wget -qO- "https://go.dev/dl/go1.20.7.linux-$TARGETARCH.tar.gz" | tar --strip-components=1 -xz -C /usr/local/go && \
+RUN mkdir -p /usr/local/go && wget -qO- "https://go.dev/dl/go1.21.10.linux-$TARGETARCH.tar.gz" | tar --strip-components=1 -xz -C /usr/local/go && \
     mkdir -p "$GOPATH/src" "$GOPATH/bin" && \
     go clean --modcache && \
     chmod -R 777 "$GOPATH" && chmod -R a+w $(go env GOTOOLDIR)

--- a/build/docker/builder/gpu/ubuntu20.04/Dockerfile
+++ b/build/docker/builder/gpu/ubuntu20.04/Dockerfile
@@ -51,7 +51,7 @@ ENV GOPATH /go
 ENV GOROOT /usr/local/go
 ENV GO111MODULE on
 ENV PATH $GOPATH/bin:$GOROOT/bin:$PATH
-RUN mkdir -p /usr/local/go && wget -qO- "https://go.dev/dl/go1.20.7.linux-$TARGETARCH.tar.gz" | tar --strip-components=1 -xz -C /usr/local/go && \
+RUN mkdir -p /usr/local/go && wget -qO- "https://go.dev/dl/go1.21.10.linux-$TARGETARCH.tar.gz" | tar --strip-components=1 -xz -C /usr/local/go && \
     mkdir -p "$GOPATH/src" "$GOPATH/bin" && \
     curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ${GOROOT}/bin v1.46.2 && \
     # export GO111MODULE=on && go get github.com/quasilyte/go-ruleguard/cmd/ruleguard@v0.2.1 && \

--- a/build/docker/builder/gpu/ubuntu22.04/Dockerfile
+++ b/build/docker/builder/gpu/ubuntu22.04/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends wget curl ca-ce
 
 
 # Install go
-RUN mkdir -p /usr/local/go && wget -qO- "https://go.dev/dl/go1.20.7.linux-$TARGETARCH.tar.gz" | tar --strip-components=1 -xz -C /usr/local/go
+RUN mkdir -p /usr/local/go && wget -qO- "https://go.dev/dl/go1.21.10.linux-$TARGETARCH.tar.gz" | tar --strip-components=1 -xz -C /usr/local/go
 # Install conan
 RUN pip3 install conan==1.61.0
 # Install rust

--- a/build/docker/meta-migration/builder/Dockerfile
+++ b/build/docker/meta-migration/builder/Dockerfile
@@ -1,2 +1,2 @@
-FROM golang:1.20.4-alpine3.17
+FROM golang:1.21.10-alpine3.19
 RUN apk add --no-cache make bash


### PR DESCRIPTION
Signed-off-by: shaoting-huang [shaoting-huang@zilliz.com]

issue: https://github.com/milvus-io/milvus/issues/32982

Go 1.21 introduces several improvements and changes over Go 1.20, which is quite stable now. This PR is mainly for upgrading images Golang version from 1.20 to 1.21.
