### PR TITLE
fix: query node may stuck at stopping progress (#33104)

### DIFF
--- a/internal/querycoordv2/balance/channel_level_score_balancer_test.go
+++ b/internal/querycoordv2/balance/channel_level_score_balancer_test.go
@@ -1162,8 +1162,13 @@ func (suite *ChannelLevelScoreBalancerTestSuite) TestExclusiveChannelBalance_Nod
 		},
 	}...)
 
-	suite.balancer.nodeManager.Stopping(ch1Nodes[0])
-	suite.balancer.nodeManager.Stopping(ch2Nodes[0])
+	balancer.nodeManager.Stopping(ch1Nodes[0])
+	balancer.nodeManager.Stopping(ch2Nodes[0])
+	suite.balancer.meta.ResourceManager.HandleNodeStopping(ch1Nodes[0])
+	suite.balancer.meta.ResourceManager.HandleNodeStopping(ch2Nodes[0])
+	utils.RecoverAllCollection(balancer.meta)
+
+	replica = balancer.meta.ReplicaManager.Get(replica.GetID())
 	sPlans, cPlans := balancer.BalanceReplica(replica)
 	suite.Len(sPlans, 0)
 	suite.Len(cPlans, 2)

--- a/internal/querycoordv2/balance/multi_target_balance.go
+++ b/internal/querycoordv2/balance/multi_target_balance.go
@@ -466,67 +466,49 @@ func (b *MultiTargetBalancer) BalanceReplica(replica *meta.Replica) ([]SegmentAs
 		return nil, nil
 	}
 
-	onlineNodes := make([]int64, 0)
-	offlineNodes := make([]int64, 0)
+	rwNodes := replica.GetRWNodes()
+	roNodes := replica.GetRONodes()
 
-	// read only nodes is offline in current replica.
-	if replica.RONodesCount() > 0 {
-		// if node is stop or transfer to other rg
-		log.RatedInfo(10, "meet read only node, try to move out all segment/channel", zap.Int64s("node", replica.GetRONodes()))
-		offlineNodes = append(offlineNodes, replica.GetRONodes()...)
-	}
-
-	for _, nid := range replica.GetNodes() {
-		if isStopping, err := b.nodeManager.IsStoppingNode(nid); err != nil {
-			log.Info("not existed node", zap.Int64("nid", nid), zap.Error(err))
-			continue
-		} else if isStopping {
-			offlineNodes = append(offlineNodes, nid)
-		} else {
-			onlineNodes = append(onlineNodes, nid)
-		}
-	}
-
-	if len(onlineNodes) == 0 {
+	if len(rwNodes) == 0 {
 		// no available nodes to balance
 		return nil, nil
 	}
 
 	// print current distribution before generating plans
 	segmentPlans, channelPlans := make([]SegmentAssignPlan, 0), make([]ChannelAssignPlan, 0)
-	if len(offlineNodes) != 0 {
+	if len(roNodes) != 0 {
 		if !paramtable.Get().QueryCoordCfg.EnableStoppingBalance.GetAsBool() {
-			log.RatedInfo(10, "stopping balance is disabled!", zap.Int64s("stoppingNode", offlineNodes))
+			log.RatedInfo(10, "stopping balance is disabled!", zap.Int64s("stoppingNode", roNodes))
 			return nil, nil
 		}
 
 		log.Info("Handle stopping nodes",
-			zap.Any("stopping nodes", offlineNodes),
-			zap.Any("available nodes", onlineNodes),
+			zap.Any("stopping nodes", roNodes),
+			zap.Any("available nodes", rwNodes),
 		)
 		// handle stopped nodes here, have to assign segments on stopping nodes to nodes with the smallest score
-		channelPlans = append(channelPlans, b.genStoppingChannelPlan(replica, onlineNodes, offlineNodes)...)
+		channelPlans = append(channelPlans, b.genStoppingChannelPlan(replica, rwNodes, roNodes)...)
 		if len(channelPlans) == 0 {
-			segmentPlans = append(segmentPlans, b.genStoppingSegmentPlan(replica, onlineNodes, offlineNodes)...)
+			segmentPlans = append(segmentPlans, b.genStoppingSegmentPlan(replica, rwNodes, roNodes)...)
 		}
 	} else {
 		if paramtable.Get().QueryCoordCfg.AutoBalanceChannel.GetAsBool() {
-			channelPlans = append(channelPlans, b.genChannelPlan(replica, onlineNodes)...)
+			channelPlans = append(channelPlans, b.genChannelPlan(replica, rwNodes)...)
 		}
 
 		if len(channelPlans) == 0 {
-			segmentPlans = b.genSegmentPlan(replica)
+			segmentPlans = b.genSegmentPlan(replica, rwNodes)
 		}
 	}
 
 	return segmentPlans, channelPlans
 }
 
-func (b *MultiTargetBalancer) genSegmentPlan(replica *meta.Replica) []SegmentAssignPlan {
+func (b *MultiTargetBalancer) genSegmentPlan(replica *meta.Replica, rwNodes []int64) []SegmentAssignPlan {
 	// get segments distribution on replica level and global level
 	nodeSegments := make(map[int64][]*meta.Segment)
 	globalNodeSegments := make(map[int64][]*meta.Segment)
-	for _, node := range replica.GetNodes() {
+	for _, node := range rwNodes {
 		dist := b.dist.SegmentDistManager.GetByFilter(meta.WithCollectionID(replica.GetCollectionID()), meta.WithNodeID(node))
 		segments := lo.Filter(dist, func(segment *meta.Segment, _ int) bool {
 			return b.targetMgr.GetSealedSegment(segment.GetCollectionID(), segment.GetID(), meta.CurrentTarget) != nil &&

--- a/internal/querycoordv2/balance/score_based_balancer_test.go
+++ b/internal/querycoordv2/balance/score_based_balancer_test.go
@@ -439,6 +439,7 @@ func (suite *ScoreBasedBalancerTestSuite) TestBalanceOneRound() {
 				suite.balancer.nodeManager.Add(nodeInfo)
 				suite.balancer.meta.ResourceManager.HandleNodeUp(c.nodes[i])
 			}
+			utils.RecoverAllCollection(balancer.meta)
 
 			// 4. balance and verify result
 			segmentPlans, channelPlans := suite.getCollectionBalancePlans(balancer, c.collectionID)

--- a/internal/querycoordv2/checkers/balance_checker.go
+++ b/internal/querycoordv2/checkers/balance_checker.go
@@ -101,12 +101,8 @@ func (b *BalanceChecker) replicasToBalance() []int64 {
 			}
 			replicas := b.meta.ReplicaManager.GetByCollection(cid)
 			for _, replica := range replicas {
-				for _, nodeID := range replica.GetNodes() {
-					isStopping, _ := b.nodeManager.IsStoppingNode(nodeID)
-					if isStopping {
-						stoppingReplicas = append(stoppingReplicas, replica.GetID())
-						break
-					}
+				if replica.RONodesCount() > 0 {
+					stoppingReplicas = append(stoppingReplicas, replica.GetID())
 				}
 			}
 		}

--- a/internal/querycoordv2/checkers/balance_checker_test.go
+++ b/internal/querycoordv2/checkers/balance_checker_test.go
@@ -278,6 +278,14 @@ func (suite *BalanceCheckerTestSuite) TestStoppingBalance() {
 	suite.targetMgr.UpdateCollectionNextTarget(int64(cid2))
 	suite.targetMgr.UpdateCollectionCurrentTarget(int64(cid2))
 
+	mr1 := replica1.CopyForWrite()
+	mr1.AddRONode(1)
+	suite.checker.meta.ReplicaManager.Put(mr1.IntoReplica())
+
+	mr2 := replica2.CopyForWrite()
+	mr2.AddRONode(1)
+	suite.checker.meta.ReplicaManager.Put(mr2.IntoReplica())
+
 	// test stopping balance
 	idsToBalance := []int64{int64(replicaID1), int64(replicaID2)}
 	replicasToBalance := suite.checker.replicasToBalance()
@@ -347,6 +355,14 @@ func (suite *BalanceCheckerTestSuite) TestTargetNotReady() {
 	partition2 := utils.CreateTestPartition(int64(cid2), int64(partitionID2))
 	suite.checker.meta.CollectionManager.PutCollection(collection2, partition2)
 	suite.checker.meta.ReplicaManager.Put(replica2)
+
+	mr1 := replica1.CopyForWrite()
+	mr1.AddRONode(1)
+	suite.checker.meta.ReplicaManager.Put(mr1.IntoReplica())
+
+	mr2 := replica2.CopyForWrite()
+	mr2.AddRONode(1)
+	suite.checker.meta.ReplicaManager.Put(mr2.IntoReplica())
 
 	// test stopping balance
 	idsToBalance := []int64{int64(replicaID1)}

--- a/internal/querycoordv2/checkers/channel_checker.go
+++ b/internal/querycoordv2/checkers/channel_checker.go
@@ -130,7 +130,7 @@ func (c *ChannelChecker) getDmChannelDiff(collectionID int64,
 		return
 	}
 
-	dist := c.getChannelDist(replica)
+	dist := c.dist.ChannelDistManager.GetByCollectionAndFilter(replica.GetCollectionID(), meta.WithReplica2Channel(replica))
 	distMap := typeutil.NewSet[string]()
 	for _, ch := range dist {
 		distMap.Insert(ch.GetChannelName())
@@ -159,14 +159,6 @@ func (c *ChannelChecker) getDmChannelDiff(collectionID int64,
 	return
 }
 
-func (c *ChannelChecker) getChannelDist(replica *meta.Replica) []*meta.DmChannel {
-	dist := make([]*meta.DmChannel, 0)
-	for _, nodeID := range replica.GetNodes() {
-		dist = append(dist, c.dist.ChannelDistManager.GetByCollectionAndFilter(replica.GetCollectionID(), meta.WithNodeID2Channel(nodeID))...)
-	}
-	return dist
-}
-
 func (c *ChannelChecker) findRepeatedChannels(ctx context.Context, replicaID int64) []*meta.DmChannel {
 	log := log.Ctx(ctx).WithRateGroup("ChannelChecker.findRepeatedChannels", 1, 60)
 	replica := c.meta.Get(replicaID)
@@ -176,7 +168,7 @@ func (c *ChannelChecker) findRepeatedChannels(ctx context.Context, replicaID int
 		log.Info("replica does not exist, skip it")
 		return ret
 	}
-	dist := c.getChannelDist(replica)
+	dist := c.dist.ChannelDistManager.GetByCollectionAndFilter(replica.GetCollectionID(), meta.WithReplica2Channel(replica))
 
 	targets := c.targetMgr.GetSealedSegmentsByCollection(replica.GetCollectionID(), meta.CurrentTarget)
 	versionsMap := make(map[string]*meta.DmChannel)
@@ -221,7 +213,7 @@ func (c *ChannelChecker) createChannelLoadTask(ctx context.Context, channels []*
 	for _, ch := range channels {
 		rwNodes := replica.GetChannelRWNodes(ch.GetChannelName())
 		if len(rwNodes) == 0 {
-			rwNodes = replica.GetNodes()
+			rwNodes = replica.GetRWNodes()
 		}
 		plan := c.balancer.AssignChannel([]*meta.DmChannel{ch}, rwNodes, false)
 		plans = append(plans, plan...)

--- a/internal/querycoordv2/checkers/index_checker_test.go
+++ b/internal/querycoordv2/checkers/index_checker_test.go
@@ -134,9 +134,12 @@ func (suite *IndexCheckerSuite) TestLoadIndex() {
 	suite.Equal(task.ActionTypeUpdate, action.Type())
 	suite.EqualValues(2, action.SegmentID())
 
-	// test skip load index for stopping node
+	// test skip load index for read only node
 	suite.nodeMgr.Stopping(1)
 	suite.nodeMgr.Stopping(2)
+	suite.meta.ResourceManager.HandleNodeStopping(1)
+	suite.meta.ResourceManager.HandleNodeStopping(2)
+	utils.RecoverAllCollection(suite.meta)
 	tasks = checker.Check(context.Background())
 	suite.Require().Len(tasks, 0)
 }

--- a/internal/querycoordv2/checkers/leader_checker.go
+++ b/internal/querycoordv2/checkers/leader_checker.go
@@ -93,12 +93,7 @@ func (c *LeaderChecker) Check(ctx context.Context) []task.Task {
 
 		replicas := c.meta.ReplicaManager.GetByCollection(collectionID)
 		for _, replica := range replicas {
-			for _, node := range replica.GetNodes() {
-				if ok, _ := c.nodeMgr.IsStoppingNode(node); ok {
-					// no need to correct leader's view which is loaded on stopping node
-					continue
-				}
-
+			for _, node := range replica.GetRWNodes() {
 				leaderViews := c.dist.LeaderViewManager.GetByFilter(meta.WithCollectionID2LeaderView(replica.GetCollectionID()), meta.WithNodeID2LeaderView(node))
 				for _, leaderView := range leaderViews {
 					dist := c.dist.SegmentDistManager.GetByFilter(meta.WithChannel(leaderView.Channel), meta.WithReplica(replica))

--- a/internal/querycoordv2/handlers.go
+++ b/internal/querycoordv2/handlers.go
@@ -46,7 +46,7 @@ import (
 func (s *Server) checkAnyReplicaAvailable(collectionID int64) bool {
 	for _, replica := range s.meta.ReplicaManager.GetByCollection(collectionID) {
 		isAvailable := true
-		for _, node := range replica.GetNodes() {
+		for _, node := range replica.GetRONodes() {
 			if s.nodeMgr.Get(node) == nil {
 				isAvailable = false
 				break

--- a/internal/querycoordv2/job/job_load.go
+++ b/internal/querycoordv2/job/job_load.go
@@ -159,15 +159,11 @@ func (job *LoadCollectionJob) Execute() error {
 
 		// API of LoadCollection is wired, we should use map[resourceGroupNames]replicaNumber as input, to keep consistency with `TransferReplica` API.
 		// Then we can implement dynamic replica changed in different resource group independently.
-		replicas, err = utils.SpawnReplicasWithRG(job.meta, req.GetCollectionID(), req.GetResourceGroups(), req.GetReplicaNumber(), collectionInfo.GetVirtualChannelNames())
+		_, err = utils.SpawnReplicasWithRG(job.meta, req.GetCollectionID(), req.GetResourceGroups(), req.GetReplicaNumber(), collectionInfo.GetVirtualChannelNames())
 		if err != nil {
 			msg := "failed to spawn replica for collection"
 			log.Warn(msg, zap.Error(err))
 			return errors.Wrap(err, msg)
-		}
-		for _, replica := range replicas {
-			log.Info("replica created", zap.Int64("replicaID", replica.GetID()),
-				zap.Int64s("nodes", replica.GetNodes()), zap.String("resourceGroup", replica.GetResourceGroup()))
 		}
 		job.undo.IsReplicaCreated = true
 	}
@@ -346,15 +342,11 @@ func (job *LoadPartitionJob) Execute() error {
 		if err != nil {
 			return err
 		}
-		replicas, err = utils.SpawnReplicasWithRG(job.meta, req.GetCollectionID(), req.GetResourceGroups(), req.GetReplicaNumber(), collectionInfo.GetVirtualChannelNames())
+		_, err = utils.SpawnReplicasWithRG(job.meta, req.GetCollectionID(), req.GetResourceGroups(), req.GetReplicaNumber(), collectionInfo.GetVirtualChannelNames())
 		if err != nil {
 			msg := "failed to spawn replica for collection"
 			log.Warn(msg, zap.Error(err))
 			return errors.Wrap(err, msg)
-		}
-		for _, replica := range replicas {
-			log.Info("replica created", zap.Int64("replicaID", replica.GetID()),
-				zap.Int64s("nodes", replica.GetNodes()), zap.String("resourceGroup", replica.GetResourceGroup()))
 		}
 		job.undo.IsReplicaCreated = true
 	}

--- a/internal/querycoordv2/meta/replica_manager.go
+++ b/internal/querycoordv2/meta/replica_manager.go
@@ -195,7 +195,7 @@ func (m *ReplicaManager) TransferReplica(collectionID typeutil.UniqueID, srcRGNa
 	// Node Change will be executed by replica_observer in background.
 	replicas := make([]*Replica, 0, replicaNum)
 	for i := 0; i < replicaNum; i++ {
-		mutableReplica := srcReplicas[i].copyForWrite()
+		mutableReplica := srcReplicas[i].CopyForWrite()
 		mutableReplica.SetResourceGroup(dstRGName)
 		replicas = append(replicas, mutableReplica.IntoReplica())
 	}
@@ -350,7 +350,7 @@ func (m *ReplicaManager) RecoverNodesInCollection(collectionID typeutil.UniqueID
 				// nothing to do.
 				return
 			}
-			mutableReplica := m.replicas[assignment.GetReplicaID()].copyForWrite()
+			mutableReplica := m.replicas[assignment.GetReplicaID()].CopyForWrite()
 			mutableReplica.AddRONode(roNodes...)          // rw -> ro
 			mutableReplica.AddRWNode(recoverableNodes...) // ro -> rw
 			mutableReplica.AddRWNode(incomingNode...)     // unused -> rw
@@ -414,7 +414,7 @@ func (m *ReplicaManager) RemoveNode(replicaID typeutil.UniqueID, nodes ...typeut
 		return merr.WrapErrReplicaNotFound(replicaID)
 	}
 
-	mutableReplica := replica.copyForWrite()
+	mutableReplica := replica.CopyForWrite()
 	mutableReplica.RemoveNode(nodes...) // ro -> unused
 	return m.put(mutableReplica.IntoReplica())
 }

--- a/internal/querycoordv2/meta/replica_test.go
+++ b/internal/querycoordv2/meta/replica_test.go
@@ -30,13 +30,13 @@ func (suite *ReplicaSuite) TestReadOperations() {
 	r := newReplica(suite.replicaPB)
 	suite.testRead(r)
 	// keep same after clone.
-	mutableReplica := r.copyForWrite()
+	mutableReplica := r.CopyForWrite()
 	suite.testRead(mutableReplica.IntoReplica())
 }
 
 func (suite *ReplicaSuite) TestClone() {
 	r := newReplica(suite.replicaPB)
-	r2 := r.copyForWrite()
+	r2 := r.CopyForWrite()
 	suite.testRead(r)
 
 	// after apply write operation on copy, the original should not be affected.
@@ -68,7 +68,7 @@ func (suite *ReplicaSuite) TestRange() {
 	})
 	suite.Equal(1, count)
 
-	mr := r.copyForWrite()
+	mr := r.CopyForWrite()
 	mr.AddRONode(1)
 
 	count = 0
@@ -81,7 +81,7 @@ func (suite *ReplicaSuite) TestRange() {
 
 func (suite *ReplicaSuite) TestWriteOperation() {
 	r := newReplica(suite.replicaPB)
-	mr := r.copyForWrite()
+	mr := r.CopyForWrite()
 
 	// test add available node.
 	suite.False(mr.Contains(5))
@@ -158,7 +158,7 @@ func (suite *ReplicaSuite) testRead(r *Replica) {
 	suite.Equal(suite.replicaPB.GetResourceGroup(), r.GetResourceGroup())
 
 	// Test GetNodes()
-	suite.ElementsMatch(suite.replicaPB.GetNodes(), r.GetNodes())
+	suite.ElementsMatch(suite.replicaPB.GetNodes(), r.GetRWNodes())
 
 	// Test GetRONodes()
 	suite.ElementsMatch(suite.replicaPB.GetRoNodes(), r.GetRONodes())
@@ -195,7 +195,7 @@ func (suite *ReplicaSuite) TestChannelExclusiveMode() {
 		},
 	})
 
-	mutableReplica := r.copyForWrite()
+	mutableReplica := r.CopyForWrite()
 	// add 10 rw nodes, exclusive mode is false.
 	for i := 0; i < 10; i++ {
 		mutableReplica.AddRWNode(int64(i))
@@ -205,7 +205,7 @@ func (suite *ReplicaSuite) TestChannelExclusiveMode() {
 		suite.Equal(0, len(channelNodeInfo.GetRwNodes()))
 	}
 
-	mutableReplica = r.copyForWrite()
+	mutableReplica = r.CopyForWrite()
 	// add 10 rw nodes, exclusive mode is true.
 	for i := 10; i < 20; i++ {
 		mutableReplica.AddRWNode(int64(i))
@@ -216,7 +216,7 @@ func (suite *ReplicaSuite) TestChannelExclusiveMode() {
 	}
 
 	// 4 node become read only, exclusive mode still be true
-	mutableReplica = r.copyForWrite()
+	mutableReplica = r.CopyForWrite()
 	for i := 0; i < 4; i++ {
 		mutableReplica.AddRONode(int64(i))
 	}
@@ -226,7 +226,7 @@ func (suite *ReplicaSuite) TestChannelExclusiveMode() {
 	}
 
 	// 4 node has been removed, exclusive mode back to false
-	mutableReplica = r.copyForWrite()
+	mutableReplica = r.CopyForWrite()
 	for i := 4; i < 8; i++ {
 		mutableReplica.RemoveNode(int64(i))
 	}

--- a/internal/querycoordv2/meta/resource_manager_test.go
+++ b/internal/querycoordv2/meta/resource_manager_test.go
@@ -524,16 +524,6 @@ func (suite *ResourceManagerSuite) TestAutoRecover() {
 	suite.Equal(80, suite.manager.GetResourceGroup("rg2").NodeNum())
 	suite.Equal(5, suite.manager.GetResourceGroup("rg3").NodeNum())
 	suite.Equal(5, suite.manager.GetResourceGroup(DefaultResourceGroupName).NodeNum())
-
-	// Test down all nodes.
-	for i := 1; i <= 100; i++ {
-		suite.manager.nodeMgr.Remove(int64(i))
-	}
-	suite.manager.RemoveAllDownNode()
-	suite.Zero(suite.manager.GetResourceGroup("rg1").NodeNum())
-	suite.Zero(suite.manager.GetResourceGroup("rg2").NodeNum())
-	suite.Zero(suite.manager.GetResourceGroup("rg3").NodeNum())
-	suite.Zero(suite.manager.GetResourceGroup(DefaultResourceGroupName).NodeNum())
 }
 
 func (suite *ResourceManagerSuite) testTransferNode() {

--- a/internal/querycoordv2/observers/replica_observer.go
+++ b/internal/querycoordv2/observers/replica_observer.go
@@ -100,6 +100,7 @@ func (ob *ReplicaObserver) checkNodesInReplica() {
 		replicas := ob.meta.ReplicaManager.GetByCollection(collectionID)
 		for _, replica := range replicas {
 			roNodes := replica.GetRONodes()
+			rwNodes := replica.GetRWNodes()
 			if len(roNodes) == 0 {
 				continue
 			}
@@ -124,7 +125,7 @@ func (ob *ReplicaObserver) checkNodesInReplica() {
 				zap.Int64("replicaID", replica.GetID()),
 				zap.Int64s("removedNodes", removeNodes),
 				zap.Int64s("roNodes", roNodes),
-				zap.Int64s("availableNodes", replica.GetNodes()),
+				zap.Int64s("rwNodes", rwNodes),
 			)
 			if err := ob.meta.ReplicaManager.RemoveNode(replica.GetID(), removeNodes...); err != nil {
 				logger.Warn("fail to remove node from replica", zap.Error(err))

--- a/internal/querycoordv2/observers/resource_observer.go
+++ b/internal/querycoordv2/observers/resource_observer.go
@@ -98,10 +98,6 @@ func (ob *ResourceObserver) checkAndRecoverResourceGroup() {
 		manager.AssignPendingIncomingNode()
 	}
 
-	// Remove all down nodes in resource group manager.
-	log.Debug("remove all down nodes in resource group manager...")
-	ob.meta.RemoveAllDownNode()
-
 	log.Debug("recover resource groups...")
 	// Recover all resource group into expected configuration.
 	for _, rgName := range rgNames {

--- a/internal/querycoordv2/observers/resource_observer_test.go
+++ b/internal/querycoordv2/observers/resource_observer_test.go
@@ -136,6 +136,7 @@ func (suite *ResourceObserverSuite) TestObserverRecoverOperation() {
 	suite.NoError(suite.meta.ResourceManager.MeetRequirement("rg2"))
 	suite.NoError(suite.meta.ResourceManager.MeetRequirement("rg3"))
 	// new node is down, rg3 cannot use that node anymore.
+	suite.meta.ResourceManager.HandleNodeDown(10)
 	suite.observer.checkAndRecoverResourceGroup()
 	suite.NoError(suite.meta.ResourceManager.MeetRequirement("rg1"))
 	suite.NoError(suite.meta.ResourceManager.MeetRequirement("rg2"))

--- a/internal/querycoordv2/ops_services.go
+++ b/internal/querycoordv2/ops_services.go
@@ -276,7 +276,7 @@ func (s *Server) TransferSegment(ctx context.Context, req *querypb.TransferSegme
 		// when no dst node specified, default to use all other nodes in same
 		dstNodeSet := typeutil.NewUniqueSet()
 		if req.GetToAllNodes() {
-			dstNodeSet.Insert(replica.GetNodes()...)
+			dstNodeSet.Insert(replica.GetRWNodes()...)
 		} else {
 			// check whether dstNode is healthy
 			if err := s.isStoppingNode(req.GetTargetNodeID()); err != nil {
@@ -348,7 +348,7 @@ func (s *Server) TransferChannel(ctx context.Context, req *querypb.TransferChann
 		// when no dst node specified, default to use all other nodes in same
 		dstNodeSet := typeutil.NewUniqueSet()
 		if req.GetToAllNodes() {
-			dstNodeSet.Insert(replica.GetNodes()...)
+			dstNodeSet.Insert(replica.GetRWNodes()...)
 		} else {
 			// check whether dstNode is healthy
 			if err := s.isStoppingNode(req.GetTargetNodeID()); err != nil {

--- a/internal/querycoordv2/services_test.go
+++ b/internal/querycoordv2/services_test.go
@@ -432,7 +432,8 @@ func (suite *ServiceSuite) TestResourceGroup() {
 	server.meta.ReplicaManager.Put(meta.NewReplica(&querypb.Replica{
 		ID:            1,
 		CollectionID:  1,
-		Nodes:         []int64{1011, 1013},
+		Nodes:         []int64{1011},
+		RoNodes:       []int64{1013},
 		ResourceGroup: "rg11",
 	},
 		typeutil.NewUniqueSet(1011, 1013)),
@@ -440,7 +441,8 @@ func (suite *ServiceSuite) TestResourceGroup() {
 	server.meta.ReplicaManager.Put(meta.NewReplica(&querypb.Replica{
 		ID:            2,
 		CollectionID:  2,
-		Nodes:         []int64{1012, 1014},
+		Nodes:         []int64{1014},
+		RoNodes:       []int64{1012},
 		ResourceGroup: "rg12",
 	},
 		typeutil.NewUniqueSet(1012, 1014)),

--- a/internal/querycoordv2/utils/meta.go
+++ b/internal/querycoordv2/utils/meta.go
@@ -22,7 +22,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/internal/querycoordv2/meta"
-	"github.com/milvus-io/milvus/internal/querycoordv2/session"
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
@@ -34,19 +33,6 @@ var (
 	ErrReplicasInconsistent = errors.New("all replicas should belong to same collection during assign nodes")
 	ErrUseWrongNumRG        = errors.New("resource group num can only be 0, 1 or same as replica number")
 )
-
-func GetReplicaNodesInfo(replicaMgr *meta.ReplicaManager, nodeMgr *session.NodeManager, replicaID int64) []*session.NodeInfo {
-	replica := replicaMgr.Get(replicaID)
-	if replica == nil {
-		return nil
-	}
-
-	nodes := make([]*session.NodeInfo, 0, len(replica.GetNodes()))
-	for _, node := range replica.GetNodes() {
-		nodes = append(nodes, nodeMgr.Get(node))
-	}
-	return nodes
-}
 
 func GetPartitions(collectionMgr *meta.CollectionManager, collectionID int64) ([]int64, error) {
 	collection := collectionMgr.GetCollection(collectionID)


### PR DESCRIPTION
issue: #33103 
pr: #33104
when try to do stopping balance for stopping query node, balancer will try to get node list from replica.GetNodes, then check whether node is stopping, if so, stopping balance will be triggered for this replica.

after the replica refactor, replica.GetNodes only return rwNodes, and the stopping node maintains in roNodes, so balancer couldn't find replica which contains stopping node, and stopping balance for replica won't be triggered, then query node will stuck forever due to segment/channel doesn't move out.

---------