### PR TITLE
enhance: Upgrade clang-format clang-tidy version

### DIFF
--- a/build/docker/builder/cpu/ubuntu20.04/Dockerfile
+++ b/build/docker/builder/cpu/ubuntu20.04/Dockerfile
@@ -15,7 +15,7 @@ ARG TARGETARCH
 
 RUN apt-get update && apt-get install -y --no-install-recommends wget curl ca-certificates gnupg2 \
     g++ gcc gdb gdbserver ninja-build git make ccache libssl-dev zlib1g-dev zip unzip \
-    clang-format-10 clang-tidy-10 lcov libtool m4 autoconf automake python3 python3-pip \
+    clang-format-12 clang-tidy-12 lcov libtool m4 autoconf automake python3 python3-pip \
     pkg-config uuid-dev libaio-dev libopenblas-dev && \
     apt-get remove --purge -y && \
     rm -rf /var/lib/apt/lists/*

--- a/build/docker/builder/gpu/ubuntu20.04/Dockerfile
+++ b/build/docker/builder/gpu/ubuntu20.04/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends wget curl ca-ce
     wget -qO- "https://cmake.org/files/v3.27/cmake-3.27.5-linux-`uname -m`.tar.gz" | tar --strip-components=1 -xz -C /usr/local && \
     apt-get update && apt-get install -y --no-install-recommends \
     g++ gcc gfortran git make ccache libssl-dev zlib1g-dev zip unzip \
-    clang-format-10 clang-tidy-10 lcov libtool m4 autoconf automake python3 python3-pip \
+    clang-format-12 clang-tidy-12 lcov libtool m4 autoconf automake python3 python3-pip \
     pkg-config uuid-dev libaio-dev libgoogle-perftools-dev libopenblas-dev && \
     apt-get remove --purge -y && \
     rm -rf /var/lib/apt/lists/*

--- a/docs/design_docs/segcore/scripts_and_tools.md
+++ b/docs/design_docs/segcore/scripts_and_tools.md
@@ -6,7 +6,7 @@ The following scripts and commands may be used during segcore development.
 
 - under milvus/internal/core directory
   - run `./run_clang_format .` to format cpp code
-    - to call clang-format-10, need to install `apt install clang-format-10` in advance
+    - to call clang-format-12, need to install `apt install clang-format-12` in advance
     - call `build-support/add_${lang}_license.sh` to add license info for cmake and cpp files
 - under milvus/ directory
   - use `make cppcheck` to check format, including

--- a/internal/core/cmake/FindClangTools.cmake
+++ b/internal/core/cmake/FindClangTools.cmake
@@ -78,7 +78,7 @@ if (CLANG_FORMAT_VERSION)
 else()
     find_program(CLANG_FORMAT_BIN
       NAMES
-      clang-format-10
+      clang-format-12
       clang-format
       PATHS ${ClangTools_PATH} $ENV{CLANG_TOOLS_PATH} /usr/local/bin /usr/bin
             NO_DEFAULT_PATH

--- a/internal/core/run_clang_format.sh
+++ b/internal/core/run_clang_format.sh
@@ -7,7 +7,7 @@ fi
 CorePath=$1
 
 formatThis() {
-    find "$1" | grep -E "(*\.cpp|*\.h|*\.cc)$" | grep -v "gen_tools/templates" | grep -v "\.pb\." | grep -v "tantivy-binding.h" | xargs clang-format-10 -i
+    find "$1" | grep -E "(*\.cpp|*\.h|*\.cc)$" | grep -v "gen_tools/templates" | grep -v "\.pb\." | grep -v "tantivy-binding.h" | xargs clang-format-12 -i
 }
 
 formatThis "${CorePath}/src"

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -21,7 +21,7 @@ function install_linux_deps() {
     # for Ubuntu 20.04
     sudo apt install -y wget curl ca-certificates gnupg2  \
       g++ gcc gfortran git make ccache libssl-dev zlib1g-dev zip unzip \
-      clang-format-10 clang-tidy-10 lcov libtool m4 autoconf automake python3 python3-pip \
+      clang-format-12 clang-tidy-12 lcov libtool m4 autoconf automake python3 python3-pip \
       pkg-config uuid-dev libaio-dev libopenblas-dev libgoogle-perftools-dev
 
     sudo pip3 install conan==1.61.0


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/33142

Upgrade clang-format and clang-tidy from 10 to 12, so that both Ubuntu 20.04 and 22.04 are able to run

![image](https://github.com/milvus-io/milvus/assets/6563846/db029f18-775e-4fea-a1ee-74a32026e385)


![image](https://github.com/milvus-io/milvus/assets/6563846/4a3314f0-4691-410c-852b-8e26ca9dd29f)
