### PR TITLE
fix: [Backport] Mark channel checkpoint dropped prevent cp lag metrics leakage (#32454)

### DIFF
--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -618,6 +618,8 @@ func (s *Server) DropVirtualChannel(ctx context.Context, req *datapb.DropVirtual
 	s.segmentManager.DropSegmentsOfChannel(ctx, channel)
 	s.compactionHandler.removeTasksByChannel(channel)
 	metrics.DataCoordCheckpointUnixSeconds.DeleteLabelValues(fmt.Sprint(paramtable.GetNodeID()), channel)
+	s.meta.MarkChannelCheckpointDropped(ctx, channel)
+
 	// no compaction triggered in Drop procedure
 	return resp, nil
 }


### PR DESCRIPTION
Cherry-pick from 2.3
pr: #32454
See also #31506 #31508

---------