### PR TITLE
enhance: add sparse float vector support to restful v2

### DIFF
--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -848,7 +848,10 @@ func generatePlaceholderGroup(ctx context.Context, body string, collSchema *sche
 	if vectorField == nil {
 		return nil, errors.New("cannot find a vector field named: " + fieldName)
 	}
-	dim, _ := getDim(vectorField)
+	dim := int64(0)
+	if !typeutil.IsSparseFloatVectorType(vectorField.DataType) {
+		dim, _ = getDim(vectorField)
+	}
 	phv, err := convertVectors2Placeholder(body, vectorField.DataType, dim)
 	if err != nil {
 		return nil, err

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -248,6 +248,15 @@ func checkAndSetData(body string, collSchema *schemapb.CollectionSchema) (error,
 						return merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)], dataString, err.Error()), reallyDataArray
 					}
 					reallyData[fieldName] = vectorArray
+				case schemapb.DataType_SparseFloatVector:
+					if dataString == "" {
+						return merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)], "", "missing vector field: "+fieldName), reallyDataArray
+					}
+					sparseVec, err := typeutil.CreateSparseFloatRowFromJSON([]byte(dataString))
+					if err != nil {
+						return merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)], dataString, err.Error()), reallyDataArray
+					}
+					reallyData[fieldName] = sparseVec
 				case schemapb.DataType_Float16Vector:
 					if dataString == "" {
 						return merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)], "", "missing vector field: "+fieldName), reallyDataArray
@@ -638,6 +647,9 @@ func anyToColumns(rows []map[string]interface{}, sch *schemapb.CollectionSchema)
 			data = make([][]byte, 0, rowsLen)
 			dim, _ := getDim(field)
 			nameDims[field.Name] = dim
+		case schemapb.DataType_SparseFloatVector:
+			data = make([][]byte, 0, rowsLen)
+			nameDims[field.Name] = int64(0)
 		default:
 			return nil, fmt.Errorf("the type(%v) of field(%v) is not supported, use other sdk please", field.DataType, field.Name)
 		}
@@ -704,6 +716,13 @@ func anyToColumns(rows []map[string]interface{}, sch *schemapb.CollectionSchema)
 				nameColumns[field.Name] = append(nameColumns[field.Name].([][]byte), candi.v.Interface().([]byte))
 			case schemapb.DataType_BFloat16Vector:
 				nameColumns[field.Name] = append(nameColumns[field.Name].([][]byte), candi.v.Interface().([]byte))
+			case schemapb.DataType_SparseFloatVector:
+				content := candi.v.Interface().([]byte)
+				rowSparseDim := typeutil.SparseFloatRowDim(content)
+				if rowSparseDim > nameDims[field.Name] {
+					nameDims[field.Name] = rowSparseDim
+				}
+				nameColumns[field.Name] = append(nameColumns[field.Name].([][]byte), content)
 			default:
 				return nil, fmt.Errorf("the type(%v) of field(%v) is not supported, use other sdk please", field.DataType, field.Name)
 			}
@@ -895,6 +914,18 @@ func anyToColumns(rows []map[string]interface{}, sch *schemapb.CollectionSchema)
 					},
 				},
 			}
+		case schemapb.DataType_SparseFloatVector:
+			colData.Field = &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Dim: nameDims[name],
+					Data: &schemapb.VectorField_SparseFloatVector{
+						SparseFloatVector: &schemapb.SparseFloatArray{
+							Dim:      nameDims[name],
+							Contents: column.([][]byte),
+						},
+					},
+				},
+			}
 		default:
 			return nil, fmt.Errorf("the type(%v) of field(%v) is not supported, use other sdk please", colData.Type, name)
 		}
@@ -963,6 +994,19 @@ func serializeByteVectors(vectorStr string, dataType schemapb.DataType, dimensio
 	return values, nil
 }
 
+func serializeSparseFloatVectors(vectors []gjson.Result, dataType schemapb.DataType) ([][]byte, error) {
+	values := make([][]byte, 0)
+	for _, vector := range vectors {
+		vectorBytes := []byte(vector.String())
+		sparseVector, err := typeutil.CreateSparseFloatRowFromJSON(vectorBytes)
+		if err != nil {
+			return nil, merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(dataType)], vector.String(), err.Error())
+		}
+		values = append(values, sparseVector)
+	}
+	return values, nil
+}
+
 func convertVectors2Placeholder(body string, dataType schemapb.DataType, dimension int64) (*commonpb.PlaceholderValue, error) {
 	var valueType commonpb.PlaceholderType
 	var values [][]byte
@@ -980,6 +1024,9 @@ func convertVectors2Placeholder(body string, dataType schemapb.DataType, dimensi
 	case schemapb.DataType_BFloat16Vector:
 		valueType = commonpb.PlaceholderType_BFloat16Vector
 		values, err = serializeByteVectors(gjson.Get(body, HTTPRequestData).Raw, dataType, dimension, dimension*2)
+	case schemapb.DataType_SparseFloatVector:
+		valueType = commonpb.PlaceholderType_SparseFloatVector
+		values, err = serializeSparseFloatVectors(gjson.Get(body, HTTPRequestData).Array(), dataType)
 	}
 	if err != nil {
 		return nil, err
@@ -1070,6 +1117,8 @@ func buildQueryResp(rowsNum int64, needFields []string, fieldDataList []*schemap
 				rowsNum = int64(len(fieldDataList[0].GetVectors().GetFloat16Vector())/2) / fieldDataList[0].GetVectors().GetDim()
 			case schemapb.DataType_BFloat16Vector:
 				rowsNum = int64(len(fieldDataList[0].GetVectors().GetBfloat16Vector())/2) / fieldDataList[0].GetVectors().GetDim()
+			case schemapb.DataType_SparseFloatVector:
+				rowsNum = int64(len(fieldDataList[0].GetVectors().GetSparseFloatVector().Contents))
 			default:
 				return nil, fmt.Errorf("the type(%v) of field(%v) is not supported, use other sdk please", fieldDataList[0].Type, fieldDataList[0].FieldName)
 			}
@@ -1125,6 +1174,8 @@ func buildQueryResp(rowsNum int64, needFields []string, fieldDataList []*schemap
 					row[fieldDataList[j].FieldName] = fieldDataList[j].GetVectors().GetFloat16Vector()[i*(fieldDataList[j].GetVectors().GetDim()*2) : (i+1)*(fieldDataList[j].GetVectors().GetDim()*2)]
 				case schemapb.DataType_BFloat16Vector:
 					row[fieldDataList[j].FieldName] = fieldDataList[j].GetVectors().GetBfloat16Vector()[i*(fieldDataList[j].GetVectors().GetDim()*2) : (i+1)*(fieldDataList[j].GetVectors().GetDim()*2)]
+				case schemapb.DataType_SparseFloatVector:
+					row[fieldDataList[j].FieldName] = typeutil.SparseFloatBytesToMap(fieldDataList[j].GetVectors().GetSparseFloatVector().Contents[i])
 				case schemapb.DataType_Array:
 					row[fieldDataList[j].FieldName] = fieldDataList[j].GetScalars().GetArrayData().Data[i]
 				case schemapb.DataType_JSON:

--- a/internal/distributed/proxy/httpserver/wrap_request_test.go
+++ b/internal/distributed/proxy/httpserver/wrap_request_test.go
@@ -219,6 +219,101 @@ func TestFieldData_AsSchemapb(t *testing.T) {
 		_, err := fieldData.AsSchemapb()
 		assert.Error(t, err)
 	})
+
+	t.Run("sparsefloatvector_ok_1", func(t *testing.T) {
+		fieldData := FieldData{
+			Type: schemapb.DataType_SparseFloatVector,
+			Field: []byte(`[
+				{"1": 0.1, "2": 0.2},
+				{"3": 0.1, "5": 0.2},
+				{"4": 0.1, "6": 0.2}
+			]`),
+		}
+		raw, _ := json.Marshal(fieldData)
+		json.Unmarshal(raw, &fieldData)
+		_, err := fieldData.AsSchemapb()
+		assert.NoError(t, err)
+	})
+
+	t.Run("sparsefloatvector_ok_2", func(t *testing.T) {
+		fieldData := FieldData{
+			Type: schemapb.DataType_SparseFloatVector,
+			Field: []byte(`[
+				{"indices": [1, 2], "values": [0.1, 0.2]},
+				{"indices": [3, 5], "values": [0.1, 0.2]},
+				{"indices": [4, 6], "values": [0.1, 0.2]}
+			]`),
+		}
+		raw, _ := json.Marshal(fieldData)
+		json.Unmarshal(raw, &fieldData)
+		_, err := fieldData.AsSchemapb()
+		assert.NoError(t, err)
+	})
+
+	t.Run("sparsefloatvector_ok_3", func(t *testing.T) {
+		fieldData := FieldData{
+			Type: schemapb.DataType_SparseFloatVector,
+			Field: []byte(`[
+				{"indices": [1, 2], "values": [0.1, 0.2]},
+				{"3": 0.1, "5": 0.2},
+				{"indices": [4, 6], "values": [0.1, 0.2]}
+			]`),
+		}
+		raw, _ := json.Marshal(fieldData)
+		json.Unmarshal(raw, &fieldData)
+		_, err := fieldData.AsSchemapb()
+		assert.NoError(t, err)
+	})
+
+	t.Run("sparsefloatvector_empty_err", func(t *testing.T) {
+		fieldData := FieldData{
+			Type:  schemapb.DataType_SparseFloatVector,
+			Field: []byte(`[]`),
+		}
+		raw, _ := json.Marshal(fieldData)
+		json.Unmarshal(raw, &fieldData)
+		_, err := fieldData.AsSchemapb()
+		assert.Error(t, err)
+	})
+
+	t.Run("sparsefloatvector_invalid_json_err", func(t *testing.T) {
+		fieldData := FieldData{
+			Type: schemapb.DataType_SparseFloatVector,
+			Field: []byte(`[
+				{"3": 0.1, : 0.2}
+			]`),
+		}
+		raw, _ := json.Marshal(fieldData)
+		json.Unmarshal(raw, &fieldData)
+		_, err := fieldData.AsSchemapb()
+		assert.Error(t, err)
+	})
+
+	t.Run("sparsefloatvector_invalid_row_1_err", func(t *testing.T) {
+		fieldData := FieldData{
+			Type: schemapb.DataType_SparseFloatVector,
+			Field: []byte(`[
+				{"indices": [1, 2], "values": [-0.1, 0.2]},
+			]`),
+		}
+		raw, _ := json.Marshal(fieldData)
+		json.Unmarshal(raw, &fieldData)
+		_, err := fieldData.AsSchemapb()
+		assert.Error(t, err)
+	})
+
+	t.Run("sparsefloatvector_invalid_row_2_err", func(t *testing.T) {
+		fieldData := FieldData{
+			Type: schemapb.DataType_SparseFloatVector,
+			Field: []byte(`[
+				{"indices": [1, -2], "values": [0.1, 0.2]},
+			]`),
+		}
+		raw, _ := json.Marshal(fieldData)
+		json.Unmarshal(raw, &fieldData)
+		_, err := fieldData.AsSchemapb()
+		assert.Error(t, err)
+	})
 }
 
 func Test_vector2Bytes(t *testing.T) {

--- a/pkg/util/typeutil/schema_test.go
+++ b/pkg/util/typeutil/schema_test.go
@@ -18,6 +18,7 @@ package typeutil
 
 import (
 	"encoding/binary"
+	"fmt"
 	"math"
 	"reflect"
 	"testing"
@@ -2140,7 +2141,7 @@ func TestParseJsonSparseFloatRow(t *testing.T) {
 		assert.Equal(t, CreateSparseFloatRow([]uint32{1, 3, 5}, []float32{1.0, 2.0, 3.0}), res)
 	})
 
-	t.Run("valid row 3", func(t *testing.T) {
+	t.Run("valid row 4", func(t *testing.T) {
 		row := map[string]interface{}{"indices": []interface{}{math.MaxInt32 + 1}, "values": []interface{}{1.0}}
 		res, err := CreateSparseFloatRowFromMap(row)
 		assert.NoError(t, err)
@@ -2173,6 +2174,30 @@ func TestParseJsonSparseFloatRow(t *testing.T) {
 
 	t.Run("invalid row 5", func(t *testing.T) {
 		row := map[string]interface{}{"indices": []interface{}{3.1}, "values": []interface{}{0.2}}
+		_, err := CreateSparseFloatRowFromMap(row)
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid row 6", func(t *testing.T) {
+		row := map[string]interface{}{"indices": []interface{}{-1}, "values": []interface{}{0.2}}
+		_, err := CreateSparseFloatRowFromMap(row)
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid row 7", func(t *testing.T) {
+		row := map[string]interface{}{"indices": []interface{}{math.MaxUint32}, "values": []interface{}{1.0}}
+		_, err := CreateSparseFloatRowFromMap(row)
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid row 8", func(t *testing.T) {
+		row := map[string]interface{}{"indices": []interface{}{math.MaxUint32 + 10}, "values": []interface{}{1.0}}
+		_, err := CreateSparseFloatRowFromMap(row)
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid row 9", func(t *testing.T) {
+		row := map[string]interface{}{"indices": []interface{}{10}, "values": []interface{}{float64(math.MaxFloat32) * 2}}
 		_, err := CreateSparseFloatRowFromMap(row)
 		assert.Error(t, err)
 	})
@@ -2228,7 +2253,19 @@ func TestParseJsonSparseFloatRow(t *testing.T) {
 	})
 
 	t.Run("invalid dict row 7", func(t *testing.T) {
-		row := map[string]interface{}{"1.1": 1.0, "3": 2.0, "5": 3.0}
+		row := map[string]interface{}{fmt.Sprint(math.MaxUint32): 1.0, "3": 2.0, "5": 3.0}
+		_, err := CreateSparseFloatRowFromMap(row)
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid dict row 8", func(t *testing.T) {
+		row := map[string]interface{}{fmt.Sprint(math.MaxUint32 + 10): 1.0, "3": 2.0, "5": 3.0}
+		_, err := CreateSparseFloatRowFromMap(row)
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid dict row 8", func(t *testing.T) {
+		row := map[string]interface{}{fmt.Sprint(math.MaxUint32 + 10): 1.0, "3": 2.0, "5": float64(math.MaxFloat32) * 2}
 		_, err := CreateSparseFloatRowFromMap(row)
 		assert.Error(t, err)
 	})


### PR DESCRIPTION
issue: #29419
also re-enabled an e2e test using restful api, which is previously disabled due to https://github.com/milvus-io/milvus/issues/32214.

In restful api, the accepted json formats of sparse float vector are:

* `{"indices": [1, 100, 1000], "values": [0.1, 0.2, 0.3]}`
* {"1": 0.1, "100": 0.2, "1000": 0.3}

for accepted indice and value range, see https://milvus.io/docs/sparse_vector.md#FAQ
