### PR TITLE
enhance: [2.4]Assert insert data length not overflow int (#33248)

### DIFF
--- a/internal/core/src/segcore/segment_c.cpp
+++ b/internal/core/src/segcore/segment_c.cpp
@@ -12,6 +12,7 @@
 #include "segcore/segment_c.h"
 
 #include <memory>
+#include <limits>
 
 #include "common/FieldData.h"
 #include "common/LoadInfo.h"
@@ -239,6 +240,9 @@ Insert(CSegmentInterface c_segment,
        const uint8_t* data_info,
        const uint64_t data_info_len) {
     try {
+        AssertInfo(data_info_len < std::numeric_limits<int>::max(),
+                   "insert data length ({}) exceeds max int",
+                   data_info_len);
         auto segment = static_cast<milvus::segcore::SegmentGrowing*>(c_segment);
         auto insert_record_proto =
             std::make_unique<milvus::InsertRecordProto>();


### PR DESCRIPTION
Cherry-pick from master
pr: #33248 
When InsertData is too large for cpp proto unmarshalling, the error message is confusing since the length is overflowed

This PR adds assertion for insert data length.