### PR TITLE
enhance: Decrease bloom filter fp rate to reduce delete impact (#33301)

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -610,7 +610,7 @@ common:
   ttMsgEnabled: true # Whether the instance disable sending ts messages
   traceLogMode: 0 # trace request info
   bloomFilterSize: 100000 # bloom filter initial size
-  maxBloomFalsePositive: 0.05 # max false positive rate for bloom filter
+  maxBloomFalsePositive: 0.001 # max false positive rate for bloom filter
 
 # QuotaConfig, configurations of Milvus quota and limits.
 # By default, we enable:

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -728,7 +728,7 @@ like the old password verification when updating the credential`,
 	p.MaxBloomFalsePositive = ParamItem{
 		Key:          "common.maxBloomFalsePositive",
 		Version:      "2.3.2",
-		DefaultValue: "0.05",
+		DefaultValue: "0.001",
 		Doc:          "max false positive rate for bloom filter",
 		Export:       true,
 	}


### PR DESCRIPTION
pr: #33301
when milvus process delete record, it need to find record's corresponded segment by bloom filter, and higher bloom filter fp rate will cause delete record forwards to wrong segments.

This PR Decrease bloom filter's default fp to 0.001.