### PR TITLE
fix: Fix global rate limit is not working

### DIFF
--- a/internal/proxy/simple_rate_limiter.go
+++ b/internal/proxy/simple_rate_limiter.go
@@ -78,7 +78,6 @@ func (m *SimpleLimiter) Check(dbID int64, collectionIDToPartIDs map[int64][]int6
 	ret := clusterRateLimiters.Check(rt, n)
 
 	if ret != nil {
-		clusterRateLimiters.Cancel(rt, n)
 		return ret
 	}
 


### PR DESCRIPTION
If the request is limited by rate limiter, limiter should not "Cancel". This is because, if limited, tokens are not deducted; instead, "Cancel" operation would increase the token count.

issue: https://github.com/milvus-io/milvus/issues/31705