### PR TITLE
fix: reset errorListeners for reusable parser and lexer.

### DIFF
--- a/internal/parser/planparserv2/pool.go
+++ b/internal/parser/planparserv2/pool.go
@@ -72,11 +72,13 @@ func getParser(lexer *antlrparser.PlanLexer, listeners ...antlr.ErrorListener) *
 
 func putLexer(lexer *antlrparser.PlanLexer) {
 	lexer.SetInputStream(nil)
+	lexer.RemoveErrorListeners()	
 	lexerPool.ReturnObject(context.TODO(), lexer)
 }
 
 func putParser(parser *antlrparser.PlanParser) {
 	parser.SetInputStream(nil)
+	parser.RemoveErrorListeners()
 	parserPool.ReturnObject(context.TODO(), parser)
 }
 


### PR DESCRIPTION
There are too many duplicate errorListeners in a reusable parser, they should be removed in the reset method.
