### PR TITLE
fix:  fix miss makezero bug

### DIFF
--- a/cmd/tools/migration/meta/210_to_220.go
+++ b/cmd/tools/migration/meta/210_to_220.go
@@ -59,7 +59,7 @@ func getLatestFieldIndexes(colls map[Timestamp]*pb.CollectionInfo) *FieldIndexes
 		coll *pb.CollectionInfo
 	}
 	l := len(colls)
-	pairs := make([]pair, l)
+	pairs := make([]pair, 0, l)
 	for ts, coll := range colls {
 		pairs = append(pairs, pair{ts: ts, coll: coll})
 	}

--- a/internal/rootcoord/broker.go
+++ b/internal/rootcoord/broker.go
@@ -237,7 +237,7 @@ func (b *ServerBroker) BroadcastAlteredCollection(ctx context.Context, req *milv
 		return err
 	}
 
-	partitionIDs := make([]int64, len(colMeta.Partitions))
+	partitionIDs := make([]int64, 0, len(colMeta.Partitions))
 	for _, p := range colMeta.Partitions {
 		partitionIDs = append(partitionIDs, p.PartitionID)
 	}

--- a/tests/integration/minicluster_v2.go
+++ b/tests/integration/minicluster_v2.go
@@ -252,7 +252,7 @@ func StartMiniClusterV2(ctx context.Context, opts ...OptionV2) (*MiniClusterV2, 
 }
 
 func (cluster *MiniClusterV2) AddQueryNodes(k int) []*grpcquerynode.Server {
-	servers := make([]*grpcquerynode.Server, k)
+	servers := make([]*grpcquerynode.Server, 0, k)
 	for i := 0; i < k; i++ {
 		servers = append(servers, cluster.AddQueryNode())
 	}


### PR DESCRIPTION
I was running  github actions to run linter  [`makezero`](https://github.com/ashanbrown/makezero) for top github golang repos.

see issues https://github.com/alingse/go-linter-runner/issues/1 

and the github actions output https://github.com/alingse/go-linter-runner/actions/runs/9241746915/job/25423640197
```
====================================================================================================
append to slice `partitionIDs` with non-zero initialized length at https://github.com/milvus-io/milvus/blob/master/internal/rootcoord/broker.go#L242:18
append to slice `pairs` with non-zero initialized length at https://github.com/milvus-io/milvus/blob/master/cmd/tools/migration/meta/2[10](https://github.com/alingse/go-linter-runner/actions/runs/9241746915/job/25423640197#step:4:11)_to_220.go#L64:11
append to slice `servers` with non-zero initialized length at https://github.com/milvus-io/milvus/blob/master/tests/integration/minicluster_v2.go#L257:13
====================================================================================================
Report issue: https://github.com/milvus-io/milvus/issues
```

