### PR TITLE
fix: Fix exception info is missing

### DIFF
--- a/internal/core/src/common/Channel.h
+++ b/internal/core/src/common/Channel.h
@@ -14,6 +14,7 @@
 #include <atomic>
 #include <exception>
 #include <optional>
+#include "Exception.h"
 
 namespace milvus {
 template <typename T>
@@ -55,7 +56,7 @@ class Channel {
     }
 
     void
-    close(std::optional<std::exception> ex = std::nullopt) {
+    close(std::optional<MilvusException> ex = std::nullopt) {
         if (ex.has_value()) {
             ex_ = std::move(ex);
         }
@@ -64,6 +65,6 @@ class Channel {
 
  private:
     oneapi::tbb::concurrent_bounded_queue<std::optional<T>> inner_{};
-    std::optional<std::exception> ex_{};
+    std::optional<MilvusException> ex_{};
 };
 }  // namespace milvus

--- a/internal/core/src/common/Exception.h
+++ b/internal/core/src/common/Exception.h
@@ -20,6 +20,22 @@
 
 namespace milvus {
 
+class MilvusException : public std::exception {
+ public:
+    explicit MilvusException(const std::string& msg)
+        : std::exception(), exception_message_(msg) {
+    }
+    const char*
+    what() const noexcept {
+        return exception_message_.c_str();
+    }
+    virtual ~MilvusException() {
+    }
+
+ private:
+    std::string exception_message_;
+};
+
 class NotImplementedException : public std::exception {
  public:
     explicit NotImplementedException(const std::string& msg)

--- a/internal/core/src/segcore/Utils.cpp
+++ b/internal/core/src/segcore/Utils.cpp
@@ -820,7 +820,7 @@ LoadFieldDatasFromRemote(const std::vector<std::string>& remote_files,
         channel->close();
     } catch (std::exception& e) {
         LOG_INFO("failed to load data from remote: {}", e.what());
-        channel->close(std::move(e));
+        channel->close(MilvusException(e.what()));
     }
 }
 


### PR DESCRIPTION
Replace based std::exception to prevent "object slicing"

issue: https://github.com/milvus-io/milvus/issues/33392