### PR TITLE
fix: Watch channel task may stuck forever until qn become offline

### DIFF
--- a/internal/querycoordv2/dist/dist_handler.go
+++ b/internal/querycoordv2/dist/dist_handler.go
@@ -98,7 +98,7 @@ func (dh *distHandler) handleDistResp(resp *querypb.GetDataDistributionResponse)
 	node.SetLastHeartbeat(time.Now())
 
 	// skip  update dist if no distribution change happens in query node
-	if resp.GetLastModifyTs() <= dh.lastUpdateTs {
+	if resp.GetLastModifyTs() != 0 && resp.GetLastModifyTs() <= dh.lastUpdateTs {
 		log.RatedInfo(30, "skip update dist due to no distribution change", zap.Int64("lastModifyTs", resp.GetLastModifyTs()), zap.Int64("lastUpdateTs", dh.lastUpdateTs))
 	} else {
 		dh.lastUpdateTs = resp.GetLastModifyTs()


### PR DESCRIPTION
issue: #32901
pr #32814 introduce the compatible issue, when upgrade to milvus latest, the query coord may skip update dist due to the lastModifyTs doesn't changes. but for old version querynode, the lastModifyTs in GetDataDistritbuionResponse is always 0, which makes qc skip update dist. then qc will keep retry the task to watch channel again and again.

this PR add compatible with old version querynode, when lastModifyTs is 0, qc will update it's data distribution.