### PR TITLE
fix: Fix exception info is missing (#33393)

### DIFF
--- a/internal/core/src/common/Channel.h
+++ b/internal/core/src/common/Channel.h
@@ -14,6 +14,7 @@
 #include <atomic>
 #include <exception>
 #include <optional>
+#include "Exception.h"
 
 namespace milvus {
 template <typename T>
@@ -55,7 +56,7 @@ class Channel {
     }
 
     void
-    close(std::optional<std::exception> ex = std::nullopt) {
+    close(std::optional<MilvusException> ex = std::nullopt) {
         if (ex.has_value()) {
             ex_ = std::move(ex);
         }
@@ -64,6 +65,6 @@ class Channel {
 
  private:
     oneapi::tbb::concurrent_bounded_queue<std::optional<T>> inner_{};
-    std::optional<std::exception> ex_{};
+    std::optional<MilvusException> ex_{};
 };
 }  // namespace milvus

--- a/internal/core/src/common/Exception.h
+++ b/internal/core/src/common/Exception.h
@@ -1,0 +1,38 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <iostream>
+
+namespace milvus {
+
+class MilvusException : public std::exception {
+ public:
+    explicit MilvusException(const std::string& msg)
+        : std::exception(), exception_message_(msg) {
+    }
+    const char*
+    what() const noexcept {
+        return exception_message_.c_str();
+    }
+    virtual ~MilvusException() {
+    }
+
+ private:
+    std::string exception_message_;
+};
+}  // namespace milvus

--- a/internal/core/src/segcore/Utils.cpp
+++ b/internal/core/src/segcore/Utils.cpp
@@ -709,7 +709,7 @@ LoadFieldDatasFromRemote(const std::vector<std::string>& remote_files,
         channel->close();
     } catch (std::exception& e) {
         LOG_SEGCORE_INFO_ << "failed to load data from remote: " << e.what();
-        channel->close(std::move(e));
+        channel->close(MilvusException(e.what()));
     }
 }
 


### PR DESCRIPTION
Replace based std::exception to prevent "object slicing"

issue: https://github.com/milvus-io/milvus/issues/33392

pr: https://github.com/milvus-io/milvus/pull/33393