### PR TITLE
enhance: Store locations for largest K in `LocationCache`

### DIFF
--- a/internal/datanode/metacache/bloom_filter_set.go
+++ b/internal/datanode/metacache/bloom_filter_set.go
@@ -55,7 +55,7 @@ func NewBloomFilterSetWithBatchSize(batchSize uint, historyEntries ...*storage.P
 	}
 }
 
-func (bfs *BloomFilterSet) PkExists(lc storage.LocationsCache) bool {
+func (bfs *BloomFilterSet) PkExists(lc *storage.LocationsCache) bool {
 	bfs.mut.RLock()
 	defer bfs.mut.RUnlock()
 	if bfs.current != nil && bfs.current.TestLocationCache(lc) {

--- a/internal/datanode/writebuffer/bf_write_buffer.go
+++ b/internal/datanode/writebuffer/bf_write_buffer.go
@@ -35,7 +35,7 @@ func (wb *bfWriteBuffer) dispatchDeleteMsgs(groups []*inData, deleteMsgs []*msgs
 	// distribute delete msg for previous data
 	for _, delMsg := range deleteMsgs {
 		pks := storage.ParseIDs2PrimaryKeys(delMsg.GetPrimaryKeys())
-		lcs := lo.Map(pks, func(pk storage.PrimaryKey, _ int) storage.LocationsCache { return storage.NewLocationsCache(pk) })
+		lcs := lo.Map(pks, func(pk storage.PrimaryKey, _ int) *storage.LocationsCache { return storage.NewLocationsCache(pk) })
 		segments := wb.metaCache.GetSegmentsBy(metacache.WithPartitionID(delMsg.PartitionID),
 			metacache.WithSegmentState(commonpb.SegmentState_Growing, commonpb.SegmentState_Flushing, commonpb.SegmentState_Flushed))
 		for _, segment := range segments {

--- a/internal/datanode/writebuffer/l0_write_buffer.go
+++ b/internal/datanode/writebuffer/l0_write_buffer.go
@@ -51,7 +51,7 @@ func (wb *l0WriteBuffer) dispatchDeleteMsgs(groups []*inData, deleteMsgs []*msgs
 	for _, delMsg := range deleteMsgs {
 		l0SegmentID := wb.getL0SegmentID(delMsg.GetPartitionID(), startPos)
 		pks := storage.ParseIDs2PrimaryKeys(delMsg.GetPrimaryKeys())
-		lcs := lo.Map(pks, func(pk storage.PrimaryKey, _ int) storage.LocationsCache { return storage.NewLocationsCache(pk) })
+		lcs := lo.Map(pks, func(pk storage.PrimaryKey, _ int) *storage.LocationsCache { return storage.NewLocationsCache(pk) })
 		segments := wb.metaCache.GetSegmentsBy(metacache.WithPartitionID(delMsg.PartitionID),
 			metacache.WithSegmentState(commonpb.SegmentState_Growing, commonpb.SegmentState_Flushing, commonpb.SegmentState_Flushed))
 		for _, segment := range segments {

--- a/internal/storage/pk_statistics.go
+++ b/internal/storage/pk_statistics.go
@@ -165,7 +165,8 @@ type LocationsCache struct {
 
 func (lc LocationsCache) Locations(k uint) []uint64 {
 	if k > lc.k {
-		lc.locations, lc.k = Locations(lc.pk, k), k
+		lc.k = k
+		lc.locations = Locations(lc.pk, lc.k)
 	}
 
 	return lc.locations

--- a/internal/storage/pk_statistics.go
+++ b/internal/storage/pk_statistics.go
@@ -169,7 +169,7 @@ func (lc *LocationsCache) Locations(k uint) []uint64 {
 		lc.locations = Locations(lc.pk, lc.k)
 	}
 
-	return lc.locations
+	return lc.locations[:k]
 }
 
 func NewLocationsCache(pk PrimaryKey) *LocationsCache {

--- a/internal/storage/pk_statistics.go
+++ b/internal/storage/pk_statistics.go
@@ -140,7 +140,7 @@ func (st *PkStatistics) TestLocations(pk PrimaryKey, locs []uint64) bool {
 	return st.MinPK.LE(pk) && st.MaxPK.GE(pk)
 }
 
-func (st *PkStatistics) TestLocationCache(lc LocationsCache) bool {
+func (st *PkStatistics) TestLocationCache(lc *LocationsCache) bool {
 	// empty pkStatics
 	if st.MinPK == nil || st.MaxPK == nil || st.PkFilter == nil {
 		return false
@@ -163,7 +163,7 @@ type LocationsCache struct {
 	locations []uint64
 }
 
-func (lc LocationsCache) Locations(k uint) []uint64 {
+func (lc *LocationsCache) Locations(k uint) []uint64 {
 	if k > lc.k {
 		lc.k = k
 		lc.locations = Locations(lc.pk, lc.k)
@@ -172,8 +172,8 @@ func (lc LocationsCache) Locations(k uint) []uint64 {
 	return lc.locations
 }
 
-func NewLocationsCache(pk PrimaryKey) LocationsCache {
-	return LocationsCache{
+func NewLocationsCache(pk PrimaryKey) *LocationsCache {
+	return &LocationsCache{
 		pk: pk,
 	}
 }

--- a/internal/storage/pk_statistics.go
+++ b/internal/storage/pk_statistics.go
@@ -159,22 +159,20 @@ func (st *PkStatistics) TestLocationCache(lc LocationsCache) bool {
 // Note that this helper is not concurrent safe and shall be used in same goroutine.
 type LocationsCache struct {
 	pk        PrimaryKey
-	locations map[uint][]uint64
+	k         uint
+	locations []uint64
 }
 
 func (lc LocationsCache) Locations(k uint) []uint64 {
-	locs, ok := lc.locations[k]
-	if ok {
-		return locs
+	if k > lc.k {
+		lc.locations, lc.k = Locations(lc.pk, k), k
 	}
-	locs = Locations(lc.pk, k)
-	lc.locations[k] = locs
-	return locs
+
+	return lc.locations
 }
 
 func NewLocationsCache(pk PrimaryKey) LocationsCache {
 	return LocationsCache{
-		pk:        pk,
-		locations: make(map[uint][]uint64),
+		pk: pk,
 	}
 }


### PR DESCRIPTION
See also #32642

`LocationCache` used map to store different locations for different K which may cause lots of CPU time when get locations many times.

This PR change the implementation of LocationCache to store only the location for the largest K used to totally remove the map access operation.

See pprof from test of @XuanYang-cn 
![image](https://github.com/milvus-io/milvus/assets/84113973/ad17cff8-62ad-4d78-9bb0-f6df0512f4ea)
