### PR TITLE
fix: [Cherry-pick][2.4] make milvus compilable using gcc-13

### DIFF
--- a/internal/core/src/config/ConfigKnowhere.h
+++ b/internal/core/src/config/ConfigKnowhere.h
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 #pragma once
+#include <cstdint>
 #include <string>
 
 namespace milvus::config {


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/30190
pr: https://github.com/milvus-io/milvus/pull/30149

add a missing header