### PR TITLE
fix: Remove group checker when closing qn pipeline

### DIFF
--- a/internal/util/pipeline/pipeline.go
+++ b/internal/util/pipeline/pipeline.go
@@ -69,6 +69,11 @@ func (p *pipeline) Start() error {
 }
 
 func (p *pipeline) Close() {
+	for _, node := range p.nodes {
+		if node.Checker != nil {
+			node.Checker.Close()
+		}
+	}
 }
 
 func (p *pipeline) process() {


### PR DESCRIPTION
See also #33442

This fix shall prevent group checker keep printing "some node(s) haven't received input" err message after collection released