### PR TITLE
enhance: Refine frequent log in datacoord

### DIFF
--- a/internal/datacoord/index_service.go
+++ b/internal/datacoord/index_service.go
@@ -917,7 +917,7 @@ func (s *Server) ListIndexes(ctx context.Context, req *indexpb.ListIndexesReques
 			UserIndexParams: index.UserIndexParams,
 		}
 	})
-	log.Info("List index success")
+	log.Debug("List index success")
 	return &indexpb.ListIndexesResponse{
 		Status:     merr.Success(),
 		IndexInfos: indexInfos,


### PR DESCRIPTION
This PR changes:
- Frequent `ListIndexes` success log to debug level
- Aggregate collection missing log after collection dropped in `meta.GetCollectionIndexFilesSize`

Signed-off-by: Congqi Xia <congqi.xia@zilliz.com>