### PR TITLE
fix: confusing err msg when not specify the index_name

### DIFF
--- a/internal/datacoord/errors.go
+++ b/internal/datacoord/errors.go
@@ -41,6 +41,6 @@ func msgSegmentNotFound(segID UniqueID) string {
 	return fmt.Sprintf("failed to get segment %d", segID)
 }
 
-func msgAmbiguousIndexName() string {
-	return "there are multiple indexes, please specify the index_name"
+func msgAmbiguousIndexName(name string) string {
+	return fmt.Sprintf("there are multiple indexes, please specify the index_name, index_name: %s", name)
 }

--- a/internal/datacoord/index_service.go
+++ b/internal/datacoord/index_service.go
@@ -383,10 +383,9 @@ func (s *Server) GetIndexState(ctx context.Context, req *indexpb.GetIndexStateRe
 		}, nil
 	}
 	if len(indexes) > 1 {
-		log.Warn(msgAmbiguousIndexName())
-		err := merr.WrapErrIndexDuplicate(req.GetIndexName())
+		log.Warn(msgAmbiguousIndexName(req.GetIndexName()))
 		return &indexpb.GetIndexStateResponse{
-			Status: merr.Status(err),
+			Status: merr.Status(merr.WrapErrParameterInvalidMsg(msgAmbiguousIndexName(req.GetIndexName()))),
 		}, nil
 	}
 	ret := &indexpb.GetIndexStateResponse{
@@ -631,10 +630,9 @@ func (s *Server) GetIndexBuildProgress(ctx context.Context, req *indexpb.GetInde
 	}
 
 	if len(indexes) > 1 {
-		log.Warn(msgAmbiguousIndexName())
-		err := merr.WrapErrIndexDuplicate(req.GetIndexName())
+		log.Warn(msgAmbiguousIndexName(req.GetIndexName()))
 		return &indexpb.GetIndexBuildProgressResponse{
-			Status: merr.Status(err),
+			Status: merr.Status(merr.WrapErrParameterInvalidMsg(msgAmbiguousIndexName(req.GetIndexName()))),
 		}, nil
 	}
 	indexInfo := &indexpb.IndexInfo{
@@ -809,9 +807,8 @@ func (s *Server) DropIndex(ctx context.Context, req *indexpb.DropIndexRequest) (
 	}
 
 	if !req.GetDropAll() && len(indexes) > 1 {
-		log.Warn(msgAmbiguousIndexName())
-		err := merr.WrapErrIndexDuplicate(req.GetIndexName())
-		return merr.Status(err), nil
+		log.Warn(msgAmbiguousIndexName(req.GetIndexName()))
+		return merr.Status(merr.WrapErrParameterInvalidMsg(msgAmbiguousIndexName(req.GetIndexName()))), nil
 	}
 	indexIDs := make([]UniqueID, 0)
 	for _, index := range indexes {

--- a/internal/datacoord/index_service_test.go
+++ b/internal/datacoord/index_service_test.go
@@ -845,7 +845,7 @@ func TestServer_GetIndexState(t *testing.T) {
 		}
 		resp, err := s.GetIndexState(ctx, req)
 		assert.NoError(t, err)
-		assert.Equal(t, commonpb.ErrorCode_UnexpectedError, resp.GetStatus().GetErrorCode())
+		assert.Equal(t, commonpb.ErrorCode_IllegalArgument, resp.GetStatus().GetErrorCode())
 	})
 }
 
@@ -1154,7 +1154,7 @@ func TestServer_GetIndexBuildProgress(t *testing.T) {
 		}
 		resp, err := s.GetIndexBuildProgress(ctx, req)
 		assert.NoError(t, err)
-		assert.Equal(t, commonpb.ErrorCode_UnexpectedError, resp.GetStatus().GetErrorCode())
+		assert.Equal(t, commonpb.ErrorCode_IllegalArgument, resp.GetStatus().GetErrorCode())
 	})
 }
 
@@ -2139,7 +2139,7 @@ func TestServer_DropIndex(t *testing.T) {
 		}
 		resp, err := s.DropIndex(ctx, req)
 		assert.NoError(t, err)
-		assert.Equal(t, commonpb.ErrorCode_UnexpectedError, resp.GetErrorCode())
+		assert.Equal(t, commonpb.ErrorCode_IllegalArgument, resp.GetErrorCode())
 	})
 
 	t.Run("drop all indexes", func(t *testing.T) {


### PR DESCRIPTION
when indexName is "", will get all index of the collection. 
if there are multi index, throw confusing errmsg:  **index duplicates, indexName:""**
#33327 