### PR TITLE
fix: [2.4] Remove group checker when closing qn pipeline (#33443)

### DIFF
--- a/internal/util/pipeline/pipeline.go
+++ b/internal/util/pipeline/pipeline.go
@@ -74,7 +74,9 @@ func (p *pipeline) Start() error {
 
 func (p *pipeline) Close() {
 	for _, node := range p.nodes {
-		node.checker.Remove(p.checkerNames[node.node.Name()])
+		if node.checker != nil {
+			node.checker.Remove(p.checkerNames[node.node.Name()])
+		}
 	}
 }
 

--- a/internal/util/pipeline/pipeline.go
+++ b/internal/util/pipeline/pipeline.go
@@ -73,6 +73,11 @@ func (p *pipeline) Start() error {
 }
 
 func (p *pipeline) Close() {
+	for _, node := range p.nodes {
+		if node.Checker != nil {
+			node.Checker.Close()
+		}
+	}
 }
 
 func (p *pipeline) process() {

--- a/internal/util/pipeline/pipeline.go
+++ b/internal/util/pipeline/pipeline.go
@@ -74,9 +74,7 @@ func (p *pipeline) Start() error {
 
 func (p *pipeline) Close() {
 	for _, node := range p.nodes {
-		if node.Checker != nil {
-			node.Checker.Close()
-		}
+		node.checker.Remove(p.checkerNames[node.node.Name()])
 	}
 }
 


### PR DESCRIPTION
Cherry-pick from master
pr: #33443
See also #33442

This fix shall prevent group checker keep printing "some node(s) haven't received input" err message after collection released