### PR TITLE
fix: speed up segment lookup via channel name in datacoord

### DIFF
--- a/internal/datacoord/handler.go
+++ b/internal/datacoord/handler.go
@@ -57,9 +57,7 @@ func newServerHandler(s *Server) *ServerHandler {
 
 // GetDataVChanPositions gets vchannel latest positions with provided dml channel names for DataNode.
 func (h *ServerHandler) GetDataVChanPositions(channel RWChannel, partitionID UniqueID) *datapb.VchannelInfo {
-	segments := h.s.meta.SelectSegments(SegmentFilterFunc(func(s *SegmentInfo) bool {
-		return s.InsertChannel == channel.GetName() && !s.GetIsFake()
-	}))
+	segments := h.s.meta.GetRealSegmentsForChannel(channel.GetName())
 	log.Info("GetDataVChanPositions",
 		zap.Int64("collectionID", channel.GetCollectionID()),
 		zap.String("channel", channel.GetName()),
@@ -105,9 +103,7 @@ func (h *ServerHandler) GetDataVChanPositions(channel RWChannel, partitionID Uni
 // the unflushed segments are actually the segments without index, even they are flushed.
 func (h *ServerHandler) GetQueryVChanPositions(channel RWChannel, partitionIDs ...UniqueID) *datapb.VchannelInfo {
 	// cannot use GetSegmentsByChannel since dropped segments are needed here
-	segments := h.s.meta.SelectSegments(SegmentFilterFunc(func(s *SegmentInfo) bool {
-		return s.InsertChannel == channel.GetName() && !s.GetIsFake()
-	}))
+	segments := h.s.meta.GetRealSegmentsForChannel(channel.GetName())
 	segmentInfos := make(map[int64]*SegmentInfo)
 	indexedSegments := FilterInIndexedSegments(h, h.s.meta, segments...)
 	indexed := make(typeutil.UniqueSet)

--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -1118,6 +1118,12 @@ func (m *meta) SelectSegments(filters ...SegmentFilter) []*SegmentInfo {
 	return m.segments.GetSegmentsBySelector(filters...)
 }
 
+func (m *meta) GetRealSegmentsForChannel(channel string) []*SegmentInfo {
+	m.RLock()
+	defer m.RUnlock()
+	return m.segments.GetRealSegmentsForChannel(channel)
+}
+
 // AddAllocation add allocation in segment
 func (m *meta) AddAllocation(segmentID UniqueID, allocation *Allocation) error {
 	log.Debug("meta update: add allocation",

--- a/internal/datacoord/segment_info.go
+++ b/internal/datacoord/segment_info.go
@@ -144,6 +144,17 @@ func (s *SegmentsInfo) GetSegmentsBySelector(filters ...SegmentFilter) []*Segmen
 	return result
 }
 
+func (s *SegmentsInfo) GetRealSegmentsForChannel(channel string) []*SegmentInfo {
+	channelSegments := s.secondaryIndexes.channel2Segments[channel]
+	var result []*SegmentInfo
+	for _, segment := range channelSegments {
+		if !segment.GetIsFake() {
+			result = append(result, segment)
+		}
+	}
+	return result
+}
+
 // GetCompactionTo returns the segment that the provided segment is compacted to.
 // Return (nil, false) if given segmentID can not found in the meta.
 // Return (nil, true) if given segmentID can be found not no compaction to.


### PR DESCRIPTION
issue: #33342