### PR TITLE
fix: speed up lookup via collection id in datacoord

### DIFF
--- a/internal/datacoord/channel_store_v2.go
+++ b/internal/datacoord/channel_store_v2.go
@@ -402,19 +402,21 @@ func (c *StateChannelStore) GetNodesChannels() []*NodeChannelInfo {
 	return ret
 }
 
-func (c *StateChannelStore) GetNodeChannelsByCollectionID(collectionID UniqueID) map[UniqueID][]string {
-	nodeChs := make(map[UniqueID][]string)
+func (c *StateChannelStore) GetNodeChannelsByCollectionID(collectionID UniqueID, allowBufferNode bool) map[UniqueID][]RWChannel {
+	nodeChs := make(map[UniqueID][]RWChannel)
 	for id, info := range c.channelsInfo {
-		if id == bufferID {
+		if (!allowBufferNode) && id == bufferID {
 			continue
 		}
-		var channelNames []string
-		for name, ch := range info.Channels {
+		var channels []RWChannel
+		for _, ch := range info.Channels {
 			if ch.GetCollectionID() == collectionID {
-				channelNames = append(channelNames, name)
+				channels = append(channels, ch)
 			}
 		}
-		nodeChs[id] = channelNames
+		if len(channels) > 0 {
+			nodeChs[id] = channels
+		}
 	}
 	return nodeChs
 }

--- a/internal/datacoord/mock_channel_store.go
+++ b/internal/datacoord/mock_channel_store.go
@@ -179,16 +179,16 @@ func (_c *MockRWChannelStore_GetNodeChannelCount_Call) RunAndReturn(run func(int
 	return _c
 }
 
-// GetNodeChannelsByCollectionID provides a mock function with given fields: collectionID
-func (_m *MockRWChannelStore) GetNodeChannelsByCollectionID(collectionID int64) map[int64][]string {
-	ret := _m.Called(collectionID)
+// GetNodeChannelsByCollectionID provides a mock function with given fields: collectionID, allowBufferNode
+func (_m *MockRWChannelStore) GetNodeChannelsByCollectionID(collectionID int64, allowBufferNode bool) map[int64][]RWChannel {
+	ret := _m.Called(collectionID, allowBufferNode)
 
-	var r0 map[int64][]string
-	if rf, ok := ret.Get(0).(func(int64) map[int64][]string); ok {
-		r0 = rf(collectionID)
+	var r0 map[int64][]RWChannel
+	if rf, ok := ret.Get(0).(func(int64, bool) map[int64][]RWChannel); ok {
+		r0 = rf(collectionID, allowBufferNode)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(map[int64][]string)
+			r0 = ret.Get(0).(map[int64][]RWChannel)
 		}
 	}
 
@@ -202,23 +202,24 @@ type MockRWChannelStore_GetNodeChannelsByCollectionID_Call struct {
 
 // GetNodeChannelsByCollectionID is a helper method to define mock.On call
 //   - collectionID int64
-func (_e *MockRWChannelStore_Expecter) GetNodeChannelsByCollectionID(collectionID interface{}) *MockRWChannelStore_GetNodeChannelsByCollectionID_Call {
-	return &MockRWChannelStore_GetNodeChannelsByCollectionID_Call{Call: _e.mock.On("GetNodeChannelsByCollectionID", collectionID)}
+//   - allowBufferNode bool
+func (_e *MockRWChannelStore_Expecter) GetNodeChannelsByCollectionID(collectionID interface{}, allowBufferNode interface{}) *MockRWChannelStore_GetNodeChannelsByCollectionID_Call {
+	return &MockRWChannelStore_GetNodeChannelsByCollectionID_Call{Call: _e.mock.On("GetNodeChannelsByCollectionID", collectionID, allowBufferNode)}
 }
 
-func (_c *MockRWChannelStore_GetNodeChannelsByCollectionID_Call) Run(run func(collectionID int64)) *MockRWChannelStore_GetNodeChannelsByCollectionID_Call {
+func (_c *MockRWChannelStore_GetNodeChannelsByCollectionID_Call) Run(run func(collectionID int64, allowBufferNode bool)) *MockRWChannelStore_GetNodeChannelsByCollectionID_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(int64))
+		run(args[0].(int64), args[1].(bool))
 	})
 	return _c
 }
 
-func (_c *MockRWChannelStore_GetNodeChannelsByCollectionID_Call) Return(_a0 map[int64][]string) *MockRWChannelStore_GetNodeChannelsByCollectionID_Call {
+func (_c *MockRWChannelStore_GetNodeChannelsByCollectionID_Call) Return(_a0 map[int64][]RWChannel) *MockRWChannelStore_GetNodeChannelsByCollectionID_Call {
 	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *MockRWChannelStore_GetNodeChannelsByCollectionID_Call) RunAndReturn(run func(int64) map[int64][]string) *MockRWChannelStore_GetNodeChannelsByCollectionID_Call {
+func (_c *MockRWChannelStore_GetNodeChannelsByCollectionID_Call) RunAndReturn(run func(int64, bool) map[int64][]RWChannel) *MockRWChannelStore_GetNodeChannelsByCollectionID_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/datacoord/mock_channelmanager.go
+++ b/internal/datacoord/mock_channelmanager.go
@@ -244,13 +244,13 @@ func (_c *MockChannelManager_GetChannel_Call) RunAndReturn(run func(int64, strin
 	return _c
 }
 
-// GetChannelNamesByCollectionID provides a mock function with given fields: collectionID
-func (_m *MockChannelManager) GetChannelNamesByCollectionID(collectionID int64) []string {
-	ret := _m.Called(collectionID)
+// GetChannelNamesByCollectionID provides a mock function with given fields: collectionID, allowBufferNode
+func (_m *MockChannelManager) GetChannelNamesByCollectionID(collectionID int64, allowBufferNode bool) []string {
+	ret := _m.Called(collectionID, allowBufferNode)
 
 	var r0 []string
-	if rf, ok := ret.Get(0).(func(int64) []string); ok {
-		r0 = rf(collectionID)
+	if rf, ok := ret.Get(0).(func(int64, bool) []string); ok {
+		r0 = rf(collectionID, allowBufferNode)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]string)
@@ -267,13 +267,14 @@ type MockChannelManager_GetChannelNamesByCollectionID_Call struct {
 
 // GetChannelNamesByCollectionID is a helper method to define mock.On call
 //   - collectionID int64
-func (_e *MockChannelManager_Expecter) GetChannelNamesByCollectionID(collectionID interface{}) *MockChannelManager_GetChannelNamesByCollectionID_Call {
-	return &MockChannelManager_GetChannelNamesByCollectionID_Call{Call: _e.mock.On("GetChannelNamesByCollectionID", collectionID)}
+//   - allowBufferNode bool
+func (_e *MockChannelManager_Expecter) GetChannelNamesByCollectionID(collectionID interface{}, allowBufferNode interface{}) *MockChannelManager_GetChannelNamesByCollectionID_Call {
+	return &MockChannelManager_GetChannelNamesByCollectionID_Call{Call: _e.mock.On("GetChannelNamesByCollectionID", collectionID, allowBufferNode)}
 }
 
-func (_c *MockChannelManager_GetChannelNamesByCollectionID_Call) Run(run func(collectionID int64)) *MockChannelManager_GetChannelNamesByCollectionID_Call {
+func (_c *MockChannelManager_GetChannelNamesByCollectionID_Call) Run(run func(collectionID int64, allowBufferNode bool)) *MockChannelManager_GetChannelNamesByCollectionID_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(int64))
+		run(args[0].(int64), args[1].(bool))
 	})
 	return _c
 }
@@ -283,18 +284,18 @@ func (_c *MockChannelManager_GetChannelNamesByCollectionID_Call) Return(_a0 []st
 	return _c
 }
 
-func (_c *MockChannelManager_GetChannelNamesByCollectionID_Call) RunAndReturn(run func(int64) []string) *MockChannelManager_GetChannelNamesByCollectionID_Call {
+func (_c *MockChannelManager_GetChannelNamesByCollectionID_Call) RunAndReturn(run func(int64, bool) []string) *MockChannelManager_GetChannelNamesByCollectionID_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetChannelsByCollectionID provides a mock function with given fields: collectionID
-func (_m *MockChannelManager) GetChannelsByCollectionID(collectionID int64) []RWChannel {
-	ret := _m.Called(collectionID)
+// GetChannelsByCollectionID provides a mock function with given fields: collectionID, allowBufferNode
+func (_m *MockChannelManager) GetChannelsByCollectionID(collectionID int64, allowBufferNode bool) []RWChannel {
+	ret := _m.Called(collectionID, allowBufferNode)
 
 	var r0 []RWChannel
-	if rf, ok := ret.Get(0).(func(int64) []RWChannel); ok {
-		r0 = rf(collectionID)
+	if rf, ok := ret.Get(0).(func(int64, bool) []RWChannel); ok {
+		r0 = rf(collectionID, allowBufferNode)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]RWChannel)
@@ -311,13 +312,14 @@ type MockChannelManager_GetChannelsByCollectionID_Call struct {
 
 // GetChannelsByCollectionID is a helper method to define mock.On call
 //   - collectionID int64
-func (_e *MockChannelManager_Expecter) GetChannelsByCollectionID(collectionID interface{}) *MockChannelManager_GetChannelsByCollectionID_Call {
-	return &MockChannelManager_GetChannelsByCollectionID_Call{Call: _e.mock.On("GetChannelsByCollectionID", collectionID)}
+//   - allowBufferNode bool
+func (_e *MockChannelManager_Expecter) GetChannelsByCollectionID(collectionID interface{}, allowBufferNode interface{}) *MockChannelManager_GetChannelsByCollectionID_Call {
+	return &MockChannelManager_GetChannelsByCollectionID_Call{Call: _e.mock.On("GetChannelsByCollectionID", collectionID, allowBufferNode)}
 }
 
-func (_c *MockChannelManager_GetChannelsByCollectionID_Call) Run(run func(collectionID int64)) *MockChannelManager_GetChannelsByCollectionID_Call {
+func (_c *MockChannelManager_GetChannelsByCollectionID_Call) Run(run func(collectionID int64, allowBufferNode bool)) *MockChannelManager_GetChannelsByCollectionID_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(int64))
+		run(args[0].(int64), args[1].(bool))
 	})
 	return _c
 }
@@ -327,18 +329,18 @@ func (_c *MockChannelManager_GetChannelsByCollectionID_Call) Return(_a0 []RWChan
 	return _c
 }
 
-func (_c *MockChannelManager_GetChannelsByCollectionID_Call) RunAndReturn(run func(int64) []RWChannel) *MockChannelManager_GetChannelsByCollectionID_Call {
+func (_c *MockChannelManager_GetChannelsByCollectionID_Call) RunAndReturn(run func(int64, bool) []RWChannel) *MockChannelManager_GetChannelsByCollectionID_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetNodeChannelsByCollectionID provides a mock function with given fields: collectionID
-func (_m *MockChannelManager) GetNodeChannelsByCollectionID(collectionID int64) map[int64][]string {
-	ret := _m.Called(collectionID)
+// GetNodeChannelsByCollectionID provides a mock function with given fields: collectionID, allowBufferNode
+func (_m *MockChannelManager) GetNodeChannelsByCollectionID(collectionID int64, allowBufferNode bool) map[int64][]string {
+	ret := _m.Called(collectionID, allowBufferNode)
 
 	var r0 map[int64][]string
-	if rf, ok := ret.Get(0).(func(int64) map[int64][]string); ok {
-		r0 = rf(collectionID)
+	if rf, ok := ret.Get(0).(func(int64, bool) map[int64][]string); ok {
+		r0 = rf(collectionID, allowBufferNode)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[int64][]string)
@@ -355,13 +357,14 @@ type MockChannelManager_GetNodeChannelsByCollectionID_Call struct {
 
 // GetNodeChannelsByCollectionID is a helper method to define mock.On call
 //   - collectionID int64
-func (_e *MockChannelManager_Expecter) GetNodeChannelsByCollectionID(collectionID interface{}) *MockChannelManager_GetNodeChannelsByCollectionID_Call {
-	return &MockChannelManager_GetNodeChannelsByCollectionID_Call{Call: _e.mock.On("GetNodeChannelsByCollectionID", collectionID)}
+//   - allowBufferNode bool
+func (_e *MockChannelManager_Expecter) GetNodeChannelsByCollectionID(collectionID interface{}, allowBufferNode interface{}) *MockChannelManager_GetNodeChannelsByCollectionID_Call {
+	return &MockChannelManager_GetNodeChannelsByCollectionID_Call{Call: _e.mock.On("GetNodeChannelsByCollectionID", collectionID, allowBufferNode)}
 }
 
-func (_c *MockChannelManager_GetNodeChannelsByCollectionID_Call) Run(run func(collectionID int64)) *MockChannelManager_GetNodeChannelsByCollectionID_Call {
+func (_c *MockChannelManager_GetNodeChannelsByCollectionID_Call) Run(run func(collectionID int64, allowBufferNode bool)) *MockChannelManager_GetNodeChannelsByCollectionID_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(int64))
+		run(args[0].(int64), args[1].(bool))
 	})
 	return _c
 }
@@ -371,7 +374,7 @@ func (_c *MockChannelManager_GetNodeChannelsByCollectionID_Call) Return(_a0 map[
 	return _c
 }
 
-func (_c *MockChannelManager_GetNodeChannelsByCollectionID_Call) RunAndReturn(run func(int64) map[int64][]string) *MockChannelManager_GetNodeChannelsByCollectionID_Call {
+func (_c *MockChannelManager_GetNodeChannelsByCollectionID_Call) RunAndReturn(run func(int64, bool) map[int64][]string) *MockChannelManager_GetNodeChannelsByCollectionID_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -136,7 +136,7 @@ func (s *Server) Flush(ctx context.Context, req *datapb.FlushRequest) (*datapb.F
 
 	var isUnimplemented bool
 	err = retry.Do(ctx, func() error {
-		nodeChannels := s.channelManager.GetNodeChannelsByCollectionID(req.GetCollectionID())
+		nodeChannels := s.channelManager.GetNodeChannelsByCollectionID(req.GetCollectionID(), false)
 
 		for nodeID, channelNames := range nodeChannels {
 			err = s.cluster.FlushChannels(ctx, nodeID, ts, channelNames)
@@ -825,7 +825,7 @@ func (s *Server) GetRecoveryInfoV2(ctx context.Context, req *datapb.GetRecoveryI
 			Status: merr.Status(err),
 		}, nil
 	}
-	channels := s.channelManager.GetChannelsByCollectionID(collectionID)
+	channels := s.channelManager.GetChannelsByCollectionID(collectionID, true)
 	channelInfos := make([]*datapb.VchannelInfo, 0, len(channels))
 	flushedIDs := make(typeutil.UniqueSet)
 	for _, ch := range channels {
@@ -1293,7 +1293,7 @@ func (s *Server) GetFlushState(ctx context.Context, req *datapb.GetFlushStateReq
 		}
 	}
 
-	channels := s.channelManager.GetChannelsByCollectionID(req.GetCollectionID())
+	channels := s.channelManager.GetChannelsByCollectionID(req.GetCollectionID(), true)
 	if len(channels) == 0 { // For compatibility with old client
 		resp.Flushed = true
 

--- a/internal/datacoord/services_test.go
+++ b/internal/datacoord/services_test.go
@@ -264,7 +264,7 @@ func (s *ServerSuite) TestDataNodeTtChannel_FlushWithDiffChan() {
 	s.testServer.cluster = mockCluster
 
 	s.mockChMgr.EXPECT().Match(sourceID, chanName).Return(true).Once()
-	s.mockChMgr.EXPECT().GetNodeChannelsByCollectionID(collID).Return(map[int64][]string{
+	s.mockChMgr.EXPECT().GetNodeChannelsByCollectionID(collID, false).Return(map[int64][]string{
 		sourceID: {chanName},
 	})
 
@@ -344,7 +344,7 @@ func (s *ServerSuite) TestDataNodeTtChannel_SegmentFlushAfterTt() {
 	s.testServer.cluster = mockCluster
 
 	s.mockChMgr.EXPECT().Match(sourceID, chanName).Return(true).Once()
-	s.mockChMgr.EXPECT().GetNodeChannelsByCollectionID(collID).Return(map[int64][]string{
+	s.mockChMgr.EXPECT().GetNodeChannelsByCollectionID(collID, false).Return(map[int64][]string{
 		sourceID: {chanName},
 	})
 
@@ -394,10 +394,10 @@ func (s *ServerSuite) TestDataNodeTtChannel_SegmentFlushAfterTt() {
 }
 
 func (s *ServerSuite) TestGetFlushState_ByFlushTs() {
-	s.mockChMgr.EXPECT().GetChannelsByCollectionID(int64(0)).
+	s.mockChMgr.EXPECT().GetChannelsByCollectionID(int64(0), true).
 		Return([]RWChannel{&channelMeta{Name: "ch1", CollectionID: 0}}).Times(3)
 
-	s.mockChMgr.EXPECT().GetChannelsByCollectionID(int64(1)).Return(nil).Times(1)
+	s.mockChMgr.EXPECT().GetChannelsByCollectionID(int64(1), true).Return(nil).Times(1)
 	tests := []struct {
 		description string
 		inTs        Timestamp
@@ -434,7 +434,7 @@ func (s *ServerSuite) TestGetFlushState_ByFlushTs() {
 }
 
 func (s *ServerSuite) TestGetFlushState_BySegment() {
-	s.mockChMgr.EXPECT().GetChannelsByCollectionID(mock.Anything).
+	s.mockChMgr.EXPECT().GetChannelsByCollectionID(mock.Anything, true).
 		Return([]RWChannel{&channelMeta{Name: "ch1", CollectionID: 0}}).Times(3)
 
 	tests := []struct {
@@ -762,7 +762,7 @@ func (s *ServerSuite) TestFlush_NormalCase() {
 		CollectionID: 0,
 	}
 
-	s.mockChMgr.EXPECT().GetNodeChannelsByCollectionID(mock.Anything).Return(map[int64][]string{
+	s.mockChMgr.EXPECT().GetNodeChannelsByCollectionID(mock.Anything, false).Return(map[int64][]string{
 		1: {"channel-1"},
 	})
 
@@ -851,7 +851,7 @@ func (s *ServerSuite) TestFlush_RollingUpgrade() {
 	mockCluster.EXPECT().Close().Maybe()
 	s.testServer.cluster = mockCluster
 	s.testServer.meta.AddCollection(&collectionInfo{ID: 0})
-	s.mockChMgr.EXPECT().GetNodeChannelsByCollectionID(mock.Anything).Return(map[int64][]string{
+	s.mockChMgr.EXPECT().GetNodeChannelsByCollectionID(mock.Anything, false).Return(map[int64][]string{
 		1: {"channel-1"},
 	}).Once()
 


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/33342
The GetNodeChannelsBy() call costs 10% cpu time when there are 10K collection (analysis based on image PR-33573-20240603-bc0955bf2)