### PR TITLE
fix: [2.4] reset the RootCoordQuotaStates metric before recording this metric

### DIFF
--- a/internal/rootcoord/quota_center.go
+++ b/internal/rootcoord/quota_center.go
@@ -1487,6 +1487,7 @@ func (q *QuotaCenter) sendRatesToProxy() error {
 
 // recordMetrics records metrics of quota states.
 func (q *QuotaCenter) recordMetrics() {
+	metrics.RootCoordQuotaStates.Reset()
 	dbIDs := make(map[int64]string, q.dbs.Len())
 	collectionIDs := make(map[int64]string, q.collections.Len())
 	q.dbs.Range(func(name string, id int64) bool {


### PR DESCRIPTION
- issue: #33539
- pr: #33553