### PR TITLE
fix: Fix import segment size is uneven (#33605)

### DIFF
--- a/internal/datanode/importv2/task_import.go
+++ b/internal/datanode/importv2/task_import.go
@@ -224,7 +224,6 @@ func (t *ImportTask) sync(task *ImportTask, hashedData HashedData) ([]*conc.Futu
 	log.Info("start to sync import data", WrapLogFields(task)...)
 	futures := make([]*conc.Future[struct{}], 0)
 	syncTasks := make([]syncmgr.Task, 0)
-	segmentImportedSizes := make(map[int64]int)
 	for channelIdx, datas := range hashedData {
 		channel := task.GetVchannels()[channelIdx]
 		for partitionIdx, data := range datas {
@@ -232,13 +231,11 @@ func (t *ImportTask) sync(task *ImportTask, hashedData HashedData) ([]*conc.Futu
 				continue
 			}
 			partitionID := task.GetPartitionIDs()[partitionIdx]
-			size := data.GetMemorySize()
-			segmentID := PickSegment(task, segmentImportedSizes, channel, partitionID, size)
+			segmentID := PickSegment(task, channel, partitionID)
 			syncTask, err := NewSyncTask(task.ctx, task, segmentID, partitionID, channel, data)
 			if err != nil {
 				return nil, nil, err
 			}
-			segmentImportedSizes[segmentID] += size
 			future := t.syncMgr.SyncData(task.ctx, syncTask)
 			futures = append(futures, future)
 			syncTasks = append(syncTasks, syncTask)


### PR DESCRIPTION
The data coordinator computed the appropriate number of import segments, thus when importing in the data node, one can randomly select a segment.

issue: https://github.com/milvus-io/milvus/issues/33604

pr: https://github.com/milvus-io/milvus/pull/33605