### PR TITLE
enhance: [2.3] Print UseDefaultConsistency param in read requests (#33617)

### DIFF
--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -2575,6 +2575,7 @@ func (node *Proxy) Search(ctx context.Context, request *milvuspb.SearchRequest) 
 		zap.Any("OutputFields", request.OutputFields),
 		zap.Any("search_params", request.SearchParams),
 		zap.Uint64("guarantee_timestamp", guaranteeTs),
+		zap.Bool("useDefaultConsistency", request.GetUseDefaultConsistency()),
 	)
 
 	defer func() {
@@ -2840,6 +2841,7 @@ func (node *Proxy) query(ctx context.Context, qt *queryTask) (*milvuspb.QueryRes
 		zap.String("db", request.DbName),
 		zap.String("collection", request.CollectionName),
 		zap.Strings("partitions", request.PartitionNames),
+		zap.Bool("useDefaultConsistency", request.GetUseDefaultConsistency()),
 	)
 
 	defer func() {


### PR DESCRIPTION
Cherry-pick from master
pr: #33617
`UseDefaultConsistency` param is crucial for debugging slow query problems. It could be confusing when guarantee timestamp is 1 while this param is not logged