### PR TITLE
fix:[skip e2e] make more retries on codecov uploader

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -267,21 +267,14 @@ jobs:
           ls -lah
       - name: Upload coverage to Codecov
         if: ${{ github.repository == 'milvus-io/milvus' }}
-        uses: codecov/codecov-action@v4
-        id: upload_cov
+        uses: Wandalen/wretry.action@v3.5.0
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./go_coverage.txt,./lcov_output.info,./it_coverage.txt
-          name: ubuntu-20.04-unittests
-          fail_ci_if_error: true
-          disable_safe_directory: true
-      - name: Retry Upload coverage to Codecov
-        if: ${{ failure()  && github.repository == 'milvus-io/milvus' }}
-        uses: codecov/codecov-action@v4
-        id: retry_upload_cov
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./go_coverage.txt,./lcov_output.info,./it_coverage.txt
-          name: ubuntu-20.04-unittests
-          fail_ci_if_error: true
-          disable_safe_directory: true
+          action: codecov/codecov-action@v4
+          with: |
+            token: ${{ secrets.CODECOV_TOKEN }}
+            files: ./go_coverage.txt,./lcov_output.info,./it_coverage.txt
+            name: ubuntu-20.04-unittests
+            fail_ci_if_error: true
+            disable_safe_directory: true
+          attempt_limit: 10
+          attempt_delay: 30000


### PR DESCRIPTION
fix #32235

inspired by https://github.com/Kong/kubernetes-testing-framework/blob/main/.github/workflows/tests.yaml#L53-L69

### What is changing:
Introducing the [wretry.action](https://github.com/Wandalen/wretry.action) to automatically retry the [codecov-action](https://github.com/codecov/codecov-action) in our CI/CD pipeline. This change is intended to enhance the robustness of our workflow by mitigating transient failures in the codecov-action.

### Follow-up changes needed:
This retry mechanism will be removed once the issue [codecov/codecov-action#926](https://github.com/codecov/codecov-action/issues/926) is resolved or if GitHub Actions provides a built-in retry feature for actions.

