### PR TITLE
enhance: Set default pursuit mode to false

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -115,7 +115,7 @@ mq:
   # Default value: "default"
   # Valid values: [default, pulsar, kafka, rocksmq, natsmq]
   type: default
-  enablePursuitMode: true # Default value: "true"
+  enablePursuitMode: false # Speed up msgstream consumer so that msgstream can pack msgpack in larger tt range. Set to true if there're many tt msg to pursuit. Default value: "false"
   pursuitLag: 10 # time tick lag threshold to enter pursuit mode, in seconds
   pursuitBufferSize: 8388608 # pursuit mode buffer size in bytes
   mqBufSize: 16 # MQ client consumer buffer length

--- a/pkg/util/paramtable/service_param.go
+++ b/pkg/util/paramtable/service_param.go
@@ -492,8 +492,8 @@ Valid values: [default, pulsar, kafka, rocksmq, natsmq]`,
 	p.EnablePursuitMode = ParamItem{
 		Key:          "mq.enablePursuitMode",
 		Version:      "2.3.0",
-		DefaultValue: "true",
-		Doc:          `Default value: "true"`,
+		DefaultValue: "false",
+		Doc:          `Speed up msgstream consumer so that msgstream can pack msgpack in larger tt range. Set to true if there're many tt msg to pursuit. Default value: "false"`,
 		Export:       true,
 	}
 	p.EnablePursuitMode.Init(base.mgr)


### PR DESCRIPTION
When meets ttlag > 10s, msgstream will speed up consuming by entering pursuit mode to pack multiple ttrange into one package. This behaviour caused:

- Memory accumulating in msgstream & msgdispatcher
- Making it worse if ttlag is caused by BufferManager/SyncMgr

So this PR set it to false by default, please open it only when there're tones of ttmsgs to catch up.

See also: #33676