### PR TITLE
fix: [GoSDK] Use varchar when row field type is string

### DIFF
--- a/client/row/data.go
+++ b/client/row/data.go
@@ -53,6 +53,9 @@ const (
 	// MilvusAutoID struct tag const for auto id indicator
 	MilvusAutoID = `AUTO_ID`
 
+	// MilvusMaxLength struct tag const for max length
+	MilvusMaxLength = `MAX_LENGTH`
+
 	// DimMax dimension max value
 	DimMax = 65535
 )
@@ -116,7 +119,7 @@ func AnyToColumns(rows []interface{}, schemas ...*entity.Schema) ([]column.Colum
 			nameColumns[field.Name] = col
 		case entity.FieldTypeString, entity.FieldTypeVarChar:
 			data := make([]string, 0, rowsLen)
-			col := column.NewColumnString(field.Name, data)
+			col := column.NewColumnVarChar(field.Name, data)
 			nameColumns[field.Name] = col
 		case entity.FieldTypeJSON:
 			data := make([][]byte, 0, rowsLen)

--- a/client/row/schema.go
+++ b/client/row/schema.go
@@ -99,7 +99,14 @@ func ParseSchema(r interface{}) (*entity.Schema, error) {
 		case reflect.Float64:
 			field.DataType = entity.FieldTypeDouble
 		case reflect.String:
-			field.DataType = entity.FieldTypeString
+			field.DataType = entity.FieldTypeVarChar
+			if maxLengthVal, has := tagSettings[MilvusMaxLength]; has {
+				maxLength, err := strconv.ParseInt(maxLengthVal, 10, 64)
+				if err != nil {
+					return nil, fmt.Errorf("max length value %s is not valued", maxLengthVal)
+				}
+				field.WithMaxLength(maxLength)
+			}
 		case reflect.Array:
 			arrayLen := ft.Len()
 			elemType := ft.Elem()


### PR DESCRIPTION
See also #33457

Also add `max_length` tag for specify varchar field max length attribute from tagging