### PR TITLE
fix: Fix disk quota check for import

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -503,6 +503,7 @@ dataCoord:
     checkIntervalLow: 120 # The interval for checking import, measured in seconds, is set to a low frequency for the import checker.
     maxImportFileNumPerReq: 1024 # The maximum number of files allowed per single import request.
     waitForIndex: true # Indicates whether the import operation waits for the completion of index building.
+    compressionRatio: 4.0 # The compression ratio (uncompressed size/compressed size) of binlogs, which is used to estimate the disk usage and disk quota for imported data. This value should typically be set slightly higher than the actual compression ratio.
   gracefulStopTimeout: 5 # seconds. force stop node without graceful stop
   ip:  # if not specified, use the first unicastable address
   port: 13333

--- a/internal/datacoord/import_util_test.go
+++ b/internal/datacoord/import_util_test.go
@@ -259,8 +259,8 @@ func TestImportUtil_CheckDiskQuota(t *testing.T) {
 			JobID:  job.GetJobID(),
 			TaskID: 1,
 			FileStats: []*datapb.ImportFileStats{
-				{TotalMemorySize: 1000 * 1024 * 1024},
-				{TotalMemorySize: 2000 * 1024 * 1024},
+				{TotalMemorySize: 50 * 1024 * 1024},
+				{TotalMemorySize: 50 * 1024 * 1024},
 			},
 		},
 	}
@@ -274,26 +274,30 @@ func TestImportUtil_CheckDiskQuota(t *testing.T) {
 
 	segment := &SegmentInfo{
 		SegmentInfo: &datapb.SegmentInfo{ID: 5, CollectionID: 100, State: commonpb.SegmentState_Flushed},
-		size:        *atomic.NewInt64(3000 * 1024 * 1024),
+		size:        *atomic.NewInt64(25 * 1024 * 1024),
 	}
 	err = meta.AddSegment(context.Background(), segment)
 	assert.NoError(t, err)
 
 	Params.Save(Params.QuotaConfig.DiskProtectionEnabled.Key, "true")
-	Params.Save(Params.QuotaConfig.DiskQuota.Key, "10000")
-	Params.Save(Params.QuotaConfig.DiskQuotaPerCollection.Key, "10000")
+	Params.Save(Params.QuotaConfig.DiskQuota.Key, "100")
+	Params.Save(Params.QuotaConfig.DiskQuotaPerCollection.Key, "100")
+	Params.Save(Params.DataCoordCfg.ImportCompressionRatio.Key, "4")
 	defer Params.Reset(Params.QuotaConfig.DiskQuota.Key)
 	defer Params.Reset(Params.QuotaConfig.DiskQuotaPerCollection.Key)
+	defer Params.Reset(Params.DataCoordCfg.ImportCompressionRatio.Key)
+
+	compressionRatio := Params.DataCoordCfg.ImportCompressionRatio.GetAsFloat()
 	requestSize, err := CheckDiskQuota(job, meta, imeta)
 	assert.NoError(t, err)
-	assert.Equal(t, int64(3000*1024*1024), requestSize)
+	assert.Equal(t, int64(100*1024*1024/compressionRatio), requestSize)
 
-	Params.Save(Params.QuotaConfig.DiskQuota.Key, "5000")
+	Params.Save(Params.QuotaConfig.DiskQuota.Key, "30")
 	_, err = CheckDiskQuota(job, meta, imeta)
 	assert.True(t, errors.Is(err, merr.ErrServiceQuotaExceeded))
 
-	Params.Save(Params.QuotaConfig.DiskQuota.Key, "10000")
-	Params.Save(Params.QuotaConfig.DiskQuotaPerCollection.Key, "5000")
+	Params.Save(Params.QuotaConfig.DiskQuota.Key, "100")
+	Params.Save(Params.QuotaConfig.DiskQuotaPerCollection.Key, "30")
 	_, err = CheckDiskQuota(job, meta, imeta)
 	assert.True(t, errors.Is(err, merr.ErrServiceQuotaExceeded))
 }

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -2882,6 +2882,7 @@ type dataCoordConfig struct {
 	ImportCheckIntervalLow   ParamItem `refreshable:"true"`
 	MaxFilesPerImportReq     ParamItem `refreshable:"true"`
 	WaitForIndex             ParamItem `refreshable:"true"`
+	ImportCompressionRatio   ParamItem `refreshable:"true"`
 
 	GracefulStopTimeout ParamItem `refreshable:"true"`
 }
@@ -3624,6 +3625,18 @@ During compaction, the size of segment # of rows is able to exceed segment max #
 		Export:       true,
 	}
 	p.WaitForIndex.Init(base.mgr)
+
+	p.ImportCompressionRatio = ParamItem{
+		Key:     "dataCoord.import.compressionRatio",
+		Version: "2.4.5",
+		Doc: "The compression ratio (uncompressed size/compressed size) of binlogs, " +
+			"which is used to estimate the disk usage and disk quota for imported data. " +
+			"This value should typically be set slightly higher than the actual compression ratio.",
+		DefaultValue: "4",
+		PanicIfEmpty: false,
+		Export:       true,
+	}
+	p.ImportCompressionRatio.Init(base.mgr)
 
 	p.GracefulStopTimeout = ParamItem{
 		Key:          "dataCoord.gracefulStopTimeout",

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -436,6 +436,7 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, 120*time.Second, Params.ImportCheckIntervalLow.GetAsDuration(time.Second))
 		assert.Equal(t, 1024, Params.MaxFilesPerImportReq.GetAsInt())
 		assert.Equal(t, true, Params.WaitForIndex.GetAsBool())
+		assert.Equal(t, 4.0, Params.ImportCompressionRatio.GetAsFloat())
 
 		params.Save("datacoord.gracefulStopTimeout", "100")
 		assert.Equal(t, 100*time.Second, Params.GracefulStopTimeout.GetAsDuration(time.Second))


### PR DESCRIPTION
Add a compression ratio parameter to estimate the disk usage for import data.

issue: https://github.com/milvus-io/milvus/issues/33753