### PR TITLE
fix: Fix disk quota check for import (#33754)

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -478,6 +478,7 @@ dataCoord:
     checkIntervalLow: 120 # The interval for checking import, measured in seconds, is set to a low frequency for the import checker.
     maxImportFileNumPerReq: 1024 # The maximum number of files allowed per single import request.
     waitForIndex: true # Indicates whether the import operation waits for the completion of index building.
+    compressionRatio: 4.0 # The compression ratio (uncompressed size/compressed size) of binlogs, which is used to estimate the disk usage and disk quota for imported data. This value should typically be set slightly higher than the actual compression ratio.
   gracefulStopTimeout: 5 # seconds. force stop node without graceful stop
   ip:  # if not specified, use the first unicastable address
   port: 13333

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -2779,6 +2779,7 @@ type dataCoordConfig struct {
 	ImportCheckIntervalLow   ParamItem `refreshable:"true"`
 	MaxFilesPerImportReq     ParamItem `refreshable:"true"`
 	WaitForIndex             ParamItem `refreshable:"true"`
+	ImportCompressionRatio   ParamItem `refreshable:"true"`
 
 	GracefulStopTimeout ParamItem `refreshable:"true"`
 }
@@ -3355,6 +3356,18 @@ During compaction, the size of segment # of rows is able to exceed segment max #
 		Export:       true,
 	}
 	p.WaitForIndex.Init(base.mgr)
+
+	p.ImportCompressionRatio = ParamItem{
+		Key:     "dataCoord.import.compressionRatio",
+		Version: "2.4.5",
+		Doc: "The compression ratio (uncompressed size/compressed size) of binlogs, " +
+			"which is used to estimate the disk usage and disk quota for imported data. " +
+			"This value should typically be set slightly higher than the actual compression ratio.",
+		DefaultValue: "4",
+		PanicIfEmpty: false,
+		Export:       true,
+	}
+	p.ImportCompressionRatio.Init(base.mgr)
 
 	p.GracefulStopTimeout = ParamItem{
 		Key:          "dataCoord.gracefulStopTimeout",

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -436,6 +436,7 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, 120*time.Second, Params.ImportCheckIntervalLow.GetAsDuration(time.Second))
 		assert.Equal(t, 1024, Params.MaxFilesPerImportReq.GetAsInt())
 		assert.Equal(t, true, Params.WaitForIndex.GetAsBool())
+		assert.Equal(t, 4.0, Params.ImportCompressionRatio.GetAsFloat())
 
 		params.Save("datacoord.gracefulStopTimeout", "100")
 		assert.Equal(t, 100*time.Second, Params.GracefulStopTimeout.GetAsDuration(time.Second))


### PR DESCRIPTION
Add a compression ratio parameter to estimate the disk usage for import data.

issue: https://github.com/milvus-io/milvus/issues/33753

pr: https://github.com/milvus-io/milvus/pull/33754