### PR TITLE
enhance: Avoid execute load segment task twice

### DIFF
--- a/internal/querycoordv2/task/action.go
+++ b/internal/querycoordv2/task/action.go
@@ -117,8 +117,15 @@ func (action *SegmentAction) IsFinished(distMgr *meta.DistributionManager) bool 
 		}
 
 		// segment found in leader view
+		existInLeader := false
 		views := distMgr.LeaderViewManager.GetByFilter(meta.WithSegment2LeaderView(action.segmentID, false))
-		if len(views) == 0 {
+		for _, view := range views {
+			if view.Segments[action.segmentID] != nil && view.Segments[action.segmentID].GetNodeID() == action.Node() {
+				existInLeader = true
+				break
+			}
+		}
+		if !existInLeader {
 			return false
 		}
 


### PR DESCRIPTION
After the executor finishes executing a task, there can be a maximum interval of 500ms before the QC observes the new leader view. During this 500ms interval, the task won't be flagged as finished by the scheduler. However, the scheduler might resubmit this task, which remains in the "started" state, as soon as the QC detects the new leader view while the executor is in the process of executing the task, the task will be marked as "finished" triggering the scheduler to cancel it.

This PR block load segment task's finish until qc saw the new leader view, to avoid execute load segment task twice.