### PR TITLE
fix: Don't remove growing L0 segment in datanode metacache

### DIFF
--- a/internal/datacoord/sync_segments_scheduler.go
+++ b/internal/datacoord/sync_segments_scheduler.go
@@ -115,7 +115,7 @@ func (sss *SyncSegmentsScheduler) SyncSegments(collectionID, partitionID int64, 
 	log := log.With(zap.Int64("collectionID", collectionID), zap.Int64("partitionID", partitionID),
 		zap.String("channelName", channelName), zap.Int64("nodeID", nodeID))
 	segments := sss.meta.SelectSegments(WithChannel(channelName), SegmentFilterFunc(func(info *SegmentInfo) bool {
-		return info.GetPartitionID() == partitionID && isSegmentHealthy(info) && info.GetLevel() != datapb.SegmentLevel_L0
+		return info.GetPartitionID() == partitionID && isSegmentHealthy(info)
 	}))
 	req := &datapb.SyncSegmentsRequest{
 		ChannelName:  channelName,

--- a/internal/datanode/metacache/meta_cache.go
+++ b/internal/datanode/metacache/meta_cache.go
@@ -291,7 +291,8 @@ func (c *metaCacheImpl) UpdateSegmentView(partitionID int64,
 	}
 
 	for segID, info := range c.segmentInfos {
-		if info.partitionID != partitionID {
+		if info.partitionID != partitionID ||
+			(info.Level() == datapb.SegmentLevel_L0 && info.State() == commonpb.SegmentState_Growing) {
 			continue
 		}
 		if _, ok := allSegments[segID]; !ok {

--- a/internal/datanode/services.go
+++ b/internal/datanode/services.go
@@ -319,8 +319,9 @@ func (node *DataNode) SyncSegments(ctx context.Context, req *datapb.SyncSegments
 
 	for _, segID := range missingSegments {
 		segID := segID
+		newSeg := req.GetSegmentInfos()[segID]
+		newSegments = append(newSegments, newSeg)
 		future := io.GetOrCreateStatsPool().Submit(func() (any, error) {
-			newSeg := req.GetSegmentInfos()[segID]
 			var val *metacache.BloomFilterSet
 			var err error
 			err = binlog.DecompressBinLog(storage.StatsBinlog, req.GetCollectionId(), req.GetPartitionId(), newSeg.GetSegmentId(), []*datapb.FieldBinlog{newSeg.GetPkStatsLog()})


### PR DESCRIPTION
issue: #33540 
1. gorwing L0 segments is invisible to datacoord.
2. flushed L0 segments need to clean by datacoord.