### PR TITLE
fix: Remove eviction operations out of lock

### DIFF
--- a/pkg/config/etcd_source.go
+++ b/pkg/config/etcd_source.go
@@ -180,10 +180,10 @@ func (es *EtcdSource) update(configs map[string]string) error {
 		return err
 	}
 	es.currentConfigs = configs
+	es.Unlock()
 	if es.manager != nil {
 		es.manager.EvictCacheValueByFormat(lo.Map(events, func(event *Event, _ int) string { return event.Key })...)
 	}
-	es.Unlock()
 
 	es.configRefresher.fireEvents(events...)
 	return nil

--- a/pkg/config/file_source.go
+++ b/pkg/config/file_source.go
@@ -181,10 +181,10 @@ func (fs *FileSource) update(configs map[string]string) error {
 		return err
 	}
 	fs.configs = configs
+	fs.Unlock()
 	if fs.manager != nil {
 		fs.manager.EvictCacheValueByFormat(lo.Map(events, func(event *Event, _ int) string { return event.Key })...)
 	}
-	fs.Unlock()
 
 	fs.configRefresher.fireEvents(events...)
 	return nil


### PR DESCRIPTION
See also #33823

`EvictCacheValueByFormat` may be block by on going `CASCacheValue` and cause possible deadlock