### PR TITLE
enhance: Rename Compaction to CompactionV2

### DIFF
--- a/internal/datacoord/mock_test.go
+++ b/internal/datacoord/mock_test.go
@@ -265,7 +265,7 @@ func (c *mockDataNodeClient) GetMetrics(ctx context.Context, req *milvuspb.GetMe
 	}, nil
 }
 
-func (c *mockDataNodeClient) Compaction(ctx context.Context, req *datapb.CompactionPlan, opts ...grpc.CallOption) (*commonpb.Status, error) {
+func (c *mockDataNodeClient) CompactionV2(ctx context.Context, req *datapb.CompactionPlan, opts ...grpc.CallOption) (*commonpb.Status, error) {
 	if c.ch != nil {
 		c.ch <- struct{}{}
 		if c.compactionResp != nil {

--- a/internal/datacoord/session_manager.go
+++ b/internal/datacoord/session_manager.go
@@ -213,7 +213,7 @@ func (c *SessionManagerImpl) Compaction(ctx context.Context, nodeID int64, plan 
 		return err
 	}
 
-	resp, err := cli.Compaction(ctx, plan)
+	resp, err := cli.CompactionV2(ctx, plan)
 	if err := VerifyResponse(resp, err); err != nil {
 		log.Warn("failed to execute compaction", zap.Int64("node", nodeID), zap.Error(err), zap.Int64("planID", plan.GetPlanID()))
 		return err

--- a/internal/datanode/services.go
+++ b/internal/datanode/services.go
@@ -200,9 +200,9 @@ func (node *DataNode) GetMetrics(ctx context.Context, req *milvuspb.GetMetricsRe
 	}, nil
 }
 
-// Compaction handles compaction request from DataCoord
+// CompactionV2 handles compaction request from DataCoord
 // returns status as long as compaction task enqueued or invalid
-func (node *DataNode) Compaction(ctx context.Context, req *datapb.CompactionPlan) (*commonpb.Status, error) {
+func (node *DataNode) CompactionV2(ctx context.Context, req *datapb.CompactionPlan) (*commonpb.Status, error) {
 	log := log.Ctx(ctx).With(zap.Int64("planID", req.GetPlanID()))
 	if err := merr.CheckHealthy(node.GetStateCode()); err != nil {
 		log.Warn("DataNode.Compaction failed", zap.Int64("nodeId", node.GetNodeID()), zap.Error(err))

--- a/internal/datanode/services_test.go
+++ b/internal/datanode/services_test.go
@@ -221,7 +221,7 @@ func (s *DataNodeServicesSuite) TestCompaction() {
 			Channel: dmChannelName,
 		}
 
-		resp, err := node.Compaction(ctx, req)
+		resp, err := node.CompactionV2(ctx, req)
 		s.NoError(err)
 		s.False(merr.Ok(resp))
 	})
@@ -240,7 +240,7 @@ func (s *DataNodeServicesSuite) TestCompaction() {
 			},
 		}
 
-		resp, err := node.Compaction(ctx, req)
+		resp, err := node.CompactionV2(ctx, req)
 		s.NoError(err)
 		s.False(merr.Ok(resp))
 	})
@@ -260,7 +260,7 @@ func (s *DataNodeServicesSuite) TestCompaction() {
 			Type: datapb.CompactionType_ClusteringCompaction,
 		}
 
-		_, err := node.Compaction(ctx, req)
+		_, err := node.CompactionV2(ctx, req)
 		s.NoError(err)
 	})
 }

--- a/internal/distributed/datanode/client/client.go
+++ b/internal/distributed/datanode/client/client.go
@@ -173,10 +173,10 @@ func (c *Client) GetMetrics(ctx context.Context, req *milvuspb.GetMetricsRequest
 	})
 }
 
-// Compaction return compaction by given plan
-func (c *Client) Compaction(ctx context.Context, req *datapb.CompactionPlan, opts ...grpc.CallOption) (*commonpb.Status, error) {
+// CompactionV2 return compaction by given plan
+func (c *Client) CompactionV2(ctx context.Context, req *datapb.CompactionPlan, opts ...grpc.CallOption) (*commonpb.Status, error) {
 	return wrapGrpcCall(ctx, c, func(client datapb.DataNodeClient) (*commonpb.Status, error) {
-		return client.Compaction(ctx, req)
+		return client.CompactionV2(ctx, req)
 	})
 }
 

--- a/internal/distributed/datanode/client/client_test.go
+++ b/internal/distributed/datanode/client/client_test.go
@@ -66,7 +66,7 @@ func Test_NewClient(t *testing.T) {
 		r5, err := client.GetMetrics(ctx, nil)
 		retCheck(retNotNil, r5, err)
 
-		r6, err := client.Compaction(ctx, nil)
+		r6, err := client.CompactionV2(ctx, nil)
 		retCheck(retNotNil, r6, err)
 
 		r8, err := client.ResendSegmentStats(ctx, nil)

--- a/internal/distributed/datanode/service.go
+++ b/internal/distributed/datanode/service.go
@@ -354,8 +354,8 @@ func (s *Server) GetMetrics(ctx context.Context, request *milvuspb.GetMetricsReq
 	return s.datanode.GetMetrics(ctx, request)
 }
 
-func (s *Server) Compaction(ctx context.Context, request *datapb.CompactionPlan) (*commonpb.Status, error) {
-	return s.datanode.Compaction(ctx, request)
+func (s *Server) CompactionV2(ctx context.Context, request *datapb.CompactionPlan) (*commonpb.Status, error) {
+	return s.datanode.CompactionV2(ctx, request)
 }
 
 // GetCompactionState gets the Compaction tasks state of DataNode

--- a/internal/distributed/datanode/service_test.go
+++ b/internal/distributed/datanode/service_test.go
@@ -126,7 +126,7 @@ func (m *MockDataNode) GetMetrics(ctx context.Context, request *milvuspb.GetMetr
 	return m.metricResp, m.err
 }
 
-func (m *MockDataNode) Compaction(ctx context.Context, req *datapb.CompactionPlan) (*commonpb.Status, error) {
+func (m *MockDataNode) CompactionV2(ctx context.Context, req *datapb.CompactionPlan) (*commonpb.Status, error) {
 	return m.status, m.err
 }
 
@@ -289,7 +289,7 @@ func Test_NewServer(t *testing.T) {
 		server.datanode = &MockDataNode{
 			status: &commonpb.Status{},
 		}
-		resp, err := server.Compaction(ctx, nil)
+		resp, err := server.CompactionV2(ctx, nil)
 		assert.NoError(t, err)
 		assert.NotNil(t, resp)
 	})

--- a/internal/mocks/mock_datanode.go
+++ b/internal/mocks/mock_datanode.go
@@ -64,8 +64,8 @@ type MockDataNode_CheckChannelOperationProgress_Call struct {
 }
 
 // CheckChannelOperationProgress is a helper method to define mock.On call
-//   - _a0 context.Context
-//   - _a1 *datapb.ChannelWatchInfo
+//  - _a0 context.Context
+//  - _a1 *datapb.ChannelWatchInfo
 func (_e *MockDataNode_Expecter) CheckChannelOperationProgress(_a0 interface{}, _a1 interface{}) *MockDataNode_CheckChannelOperationProgress_Call {
 	return &MockDataNode_CheckChannelOperationProgress_Call{Call: _e.mock.On("CheckChannelOperationProgress", _a0, _a1)}
 }
@@ -87,8 +87,8 @@ func (_c *MockDataNode_CheckChannelOperationProgress_Call) RunAndReturn(run func
 	return _c
 }
 
-// Compaction provides a mock function with given fields: _a0, _a1
-func (_m *MockDataNode) Compaction(_a0 context.Context, _a1 *datapb.CompactionPlan) (*commonpb.Status, error) {
+// CompactionV2 provides a mock function with given fields: _a0, _a1
+func (_m *MockDataNode) CompactionV2(_a0 context.Context, _a1 *datapb.CompactionPlan) (*commonpb.Status, error) {
 	ret := _m.Called(_a0, _a1)
 
 	var r0 *commonpb.Status
@@ -113,31 +113,31 @@ func (_m *MockDataNode) Compaction(_a0 context.Context, _a1 *datapb.CompactionPl
 	return r0, r1
 }
 
-// MockDataNode_Compaction_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Compaction'
-type MockDataNode_Compaction_Call struct {
+// MockDataNode_CompactionV2_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CompactionV2'
+type MockDataNode_CompactionV2_Call struct {
 	*mock.Call
 }
 
-// Compaction is a helper method to define mock.On call
-//   - _a0 context.Context
-//   - _a1 *datapb.CompactionPlan
-func (_e *MockDataNode_Expecter) Compaction(_a0 interface{}, _a1 interface{}) *MockDataNode_Compaction_Call {
-	return &MockDataNode_Compaction_Call{Call: _e.mock.On("Compaction", _a0, _a1)}
+// CompactionV2 is a helper method to define mock.On call
+//  - _a0 context.Context
+//  - _a1 *datapb.CompactionPlan
+func (_e *MockDataNode_Expecter) CompactionV2(_a0 interface{}, _a1 interface{}) *MockDataNode_CompactionV2_Call {
+	return &MockDataNode_CompactionV2_Call{Call: _e.mock.On("CompactionV2", _a0, _a1)}
 }
 
-func (_c *MockDataNode_Compaction_Call) Run(run func(_a0 context.Context, _a1 *datapb.CompactionPlan)) *MockDataNode_Compaction_Call {
+func (_c *MockDataNode_CompactionV2_Call) Run(run func(_a0 context.Context, _a1 *datapb.CompactionPlan)) *MockDataNode_CompactionV2_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run(args[0].(context.Context), args[1].(*datapb.CompactionPlan))
 	})
 	return _c
 }
 
-func (_c *MockDataNode_Compaction_Call) Return(_a0 *commonpb.Status, _a1 error) *MockDataNode_Compaction_Call {
+func (_c *MockDataNode_CompactionV2_Call) Return(_a0 *commonpb.Status, _a1 error) *MockDataNode_CompactionV2_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockDataNode_Compaction_Call) RunAndReturn(run func(context.Context, *datapb.CompactionPlan) (*commonpb.Status, error)) *MockDataNode_Compaction_Call {
+func (_c *MockDataNode_CompactionV2_Call) RunAndReturn(run func(context.Context, *datapb.CompactionPlan) (*commonpb.Status, error)) *MockDataNode_CompactionV2_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -174,8 +174,8 @@ type MockDataNode_DropCompactionPlan_Call struct {
 }
 
 // DropCompactionPlan is a helper method to define mock.On call
-//   - _a0 context.Context
-//   - _a1 *datapb.DropCompactionPlanRequest
+//  - _a0 context.Context
+//  - _a1 *datapb.DropCompactionPlanRequest
 func (_e *MockDataNode_Expecter) DropCompactionPlan(_a0 interface{}, _a1 interface{}) *MockDataNode_DropCompactionPlan_Call {
 	return &MockDataNode_DropCompactionPlan_Call{Call: _e.mock.On("DropCompactionPlan", _a0, _a1)}
 }
@@ -229,8 +229,8 @@ type MockDataNode_DropImport_Call struct {
 }
 
 // DropImport is a helper method to define mock.On call
-//   - _a0 context.Context
-//   - _a1 *datapb.DropImportRequest
+//  - _a0 context.Context
+//  - _a1 *datapb.DropImportRequest
 func (_e *MockDataNode_Expecter) DropImport(_a0 interface{}, _a1 interface{}) *MockDataNode_DropImport_Call {
 	return &MockDataNode_DropImport_Call{Call: _e.mock.On("DropImport", _a0, _a1)}
 }
@@ -284,8 +284,8 @@ type MockDataNode_FlushChannels_Call struct {
 }
 
 // FlushChannels is a helper method to define mock.On call
-//   - _a0 context.Context
-//   - _a1 *datapb.FlushChannelsRequest
+//  - _a0 context.Context
+//  - _a1 *datapb.FlushChannelsRequest
 func (_e *MockDataNode_Expecter) FlushChannels(_a0 interface{}, _a1 interface{}) *MockDataNode_FlushChannels_Call {
 	return &MockDataNode_FlushChannels_Call{Call: _e.mock.On("FlushChannels", _a0, _a1)}
 }
@@ -339,8 +339,8 @@ type MockDataNode_FlushSegments_Call struct {
 }
 
 // FlushSegments is a helper method to define mock.On call
-//   - _a0 context.Context
-//   - _a1 *datapb.FlushSegmentsRequest
+//  - _a0 context.Context
+//  - _a1 *datapb.FlushSegmentsRequest
 func (_e *MockDataNode_Expecter) FlushSegments(_a0 interface{}, _a1 interface{}) *MockDataNode_FlushSegments_Call {
 	return &MockDataNode_FlushSegments_Call{Call: _e.mock.On("FlushSegments", _a0, _a1)}
 }
@@ -435,8 +435,8 @@ type MockDataNode_GetCompactionState_Call struct {
 }
 
 // GetCompactionState is a helper method to define mock.On call
-//   - _a0 context.Context
-//   - _a1 *datapb.CompactionStateRequest
+//  - _a0 context.Context
+//  - _a1 *datapb.CompactionStateRequest
 func (_e *MockDataNode_Expecter) GetCompactionState(_a0 interface{}, _a1 interface{}) *MockDataNode_GetCompactionState_Call {
 	return &MockDataNode_GetCompactionState_Call{Call: _e.mock.On("GetCompactionState", _a0, _a1)}
 }
@@ -490,8 +490,8 @@ type MockDataNode_GetComponentStates_Call struct {
 }
 
 // GetComponentStates is a helper method to define mock.On call
-//   - _a0 context.Context
-//   - _a1 *milvuspb.GetComponentStatesRequest
+//  - _a0 context.Context
+//  - _a1 *milvuspb.GetComponentStatesRequest
 func (_e *MockDataNode_Expecter) GetComponentStates(_a0 interface{}, _a1 interface{}) *MockDataNode_GetComponentStates_Call {
 	return &MockDataNode_GetComponentStates_Call{Call: _e.mock.On("GetComponentStates", _a0, _a1)}
 }
@@ -545,8 +545,8 @@ type MockDataNode_GetMetrics_Call struct {
 }
 
 // GetMetrics is a helper method to define mock.On call
-//   - _a0 context.Context
-//   - _a1 *milvuspb.GetMetricsRequest
+//  - _a0 context.Context
+//  - _a1 *milvuspb.GetMetricsRequest
 func (_e *MockDataNode_Expecter) GetMetrics(_a0 interface{}, _a1 interface{}) *MockDataNode_GetMetrics_Call {
 	return &MockDataNode_GetMetrics_Call{Call: _e.mock.On("GetMetrics", _a0, _a1)}
 }
@@ -682,8 +682,8 @@ type MockDataNode_GetStatisticsChannel_Call struct {
 }
 
 // GetStatisticsChannel is a helper method to define mock.On call
-//   - _a0 context.Context
-//   - _a1 *internalpb.GetStatisticsChannelRequest
+//  - _a0 context.Context
+//  - _a1 *internalpb.GetStatisticsChannelRequest
 func (_e *MockDataNode_Expecter) GetStatisticsChannel(_a0 interface{}, _a1 interface{}) *MockDataNode_GetStatisticsChannel_Call {
 	return &MockDataNode_GetStatisticsChannel_Call{Call: _e.mock.On("GetStatisticsChannel", _a0, _a1)}
 }
@@ -737,8 +737,8 @@ type MockDataNode_ImportV2_Call struct {
 }
 
 // ImportV2 is a helper method to define mock.On call
-//   - _a0 context.Context
-//   - _a1 *datapb.ImportRequest
+//  - _a0 context.Context
+//  - _a1 *datapb.ImportRequest
 func (_e *MockDataNode_Expecter) ImportV2(_a0 interface{}, _a1 interface{}) *MockDataNode_ImportV2_Call {
 	return &MockDataNode_ImportV2_Call{Call: _e.mock.On("ImportV2", _a0, _a1)}
 }
@@ -833,8 +833,8 @@ type MockDataNode_NotifyChannelOperation_Call struct {
 }
 
 // NotifyChannelOperation is a helper method to define mock.On call
-//   - _a0 context.Context
-//   - _a1 *datapb.ChannelOperationsRequest
+//  - _a0 context.Context
+//  - _a1 *datapb.ChannelOperationsRequest
 func (_e *MockDataNode_Expecter) NotifyChannelOperation(_a0 interface{}, _a1 interface{}) *MockDataNode_NotifyChannelOperation_Call {
 	return &MockDataNode_NotifyChannelOperation_Call{Call: _e.mock.On("NotifyChannelOperation", _a0, _a1)}
 }
@@ -888,8 +888,8 @@ type MockDataNode_PreImport_Call struct {
 }
 
 // PreImport is a helper method to define mock.On call
-//   - _a0 context.Context
-//   - _a1 *datapb.PreImportRequest
+//  - _a0 context.Context
+//  - _a1 *datapb.PreImportRequest
 func (_e *MockDataNode_Expecter) PreImport(_a0 interface{}, _a1 interface{}) *MockDataNode_PreImport_Call {
 	return &MockDataNode_PreImport_Call{Call: _e.mock.On("PreImport", _a0, _a1)}
 }
@@ -943,8 +943,8 @@ type MockDataNode_QueryImport_Call struct {
 }
 
 // QueryImport is a helper method to define mock.On call
-//   - _a0 context.Context
-//   - _a1 *datapb.QueryImportRequest
+//  - _a0 context.Context
+//  - _a1 *datapb.QueryImportRequest
 func (_e *MockDataNode_Expecter) QueryImport(_a0 interface{}, _a1 interface{}) *MockDataNode_QueryImport_Call {
 	return &MockDataNode_QueryImport_Call{Call: _e.mock.On("QueryImport", _a0, _a1)}
 }
@@ -998,8 +998,8 @@ type MockDataNode_QueryPreImport_Call struct {
 }
 
 // QueryPreImport is a helper method to define mock.On call
-//   - _a0 context.Context
-//   - _a1 *datapb.QueryPreImportRequest
+//  - _a0 context.Context
+//  - _a1 *datapb.QueryPreImportRequest
 func (_e *MockDataNode_Expecter) QueryPreImport(_a0 interface{}, _a1 interface{}) *MockDataNode_QueryPreImport_Call {
 	return &MockDataNode_QueryPreImport_Call{Call: _e.mock.On("QueryPreImport", _a0, _a1)}
 }
@@ -1053,8 +1053,8 @@ type MockDataNode_QuerySlot_Call struct {
 }
 
 // QuerySlot is a helper method to define mock.On call
-//   - _a0 context.Context
-//   - _a1 *datapb.QuerySlotRequest
+//  - _a0 context.Context
+//  - _a1 *datapb.QuerySlotRequest
 func (_e *MockDataNode_Expecter) QuerySlot(_a0 interface{}, _a1 interface{}) *MockDataNode_QuerySlot_Call {
 	return &MockDataNode_QuerySlot_Call{Call: _e.mock.On("QuerySlot", _a0, _a1)}
 }
@@ -1149,8 +1149,8 @@ type MockDataNode_ResendSegmentStats_Call struct {
 }
 
 // ResendSegmentStats is a helper method to define mock.On call
-//   - _a0 context.Context
-//   - _a1 *datapb.ResendSegmentStatsRequest
+//  - _a0 context.Context
+//  - _a1 *datapb.ResendSegmentStatsRequest
 func (_e *MockDataNode_Expecter) ResendSegmentStats(_a0 interface{}, _a1 interface{}) *MockDataNode_ResendSegmentStats_Call {
 	return &MockDataNode_ResendSegmentStats_Call{Call: _e.mock.On("ResendSegmentStats", _a0, _a1)}
 }
@@ -1183,7 +1183,7 @@ type MockDataNode_SetAddress_Call struct {
 }
 
 // SetAddress is a helper method to define mock.On call
-//   - address string
+//  - address string
 func (_e *MockDataNode_Expecter) SetAddress(address interface{}) *MockDataNode_SetAddress_Call {
 	return &MockDataNode_SetAddress_Call{Call: _e.mock.On("SetAddress", address)}
 }
@@ -1225,7 +1225,7 @@ type MockDataNode_SetDataCoordClient_Call struct {
 }
 
 // SetDataCoordClient is a helper method to define mock.On call
-//   - dataCoord types.DataCoordClient
+//  - dataCoord types.DataCoordClient
 func (_e *MockDataNode_Expecter) SetDataCoordClient(dataCoord interface{}) *MockDataNode_SetDataCoordClient_Call {
 	return &MockDataNode_SetDataCoordClient_Call{Call: _e.mock.On("SetDataCoordClient", dataCoord)}
 }
@@ -1258,7 +1258,7 @@ type MockDataNode_SetEtcdClient_Call struct {
 }
 
 // SetEtcdClient is a helper method to define mock.On call
-//   - etcdClient *clientv3.Client
+//  - etcdClient *clientv3.Client
 func (_e *MockDataNode_Expecter) SetEtcdClient(etcdClient interface{}) *MockDataNode_SetEtcdClient_Call {
 	return &MockDataNode_SetEtcdClient_Call{Call: _e.mock.On("SetEtcdClient", etcdClient)}
 }
@@ -1300,7 +1300,7 @@ type MockDataNode_SetRootCoordClient_Call struct {
 }
 
 // SetRootCoordClient is a helper method to define mock.On call
-//   - rootCoord types.RootCoordClient
+//  - rootCoord types.RootCoordClient
 func (_e *MockDataNode_Expecter) SetRootCoordClient(rootCoord interface{}) *MockDataNode_SetRootCoordClient_Call {
 	return &MockDataNode_SetRootCoordClient_Call{Call: _e.mock.On("SetRootCoordClient", rootCoord)}
 }
@@ -1354,8 +1354,8 @@ type MockDataNode_ShowConfigurations_Call struct {
 }
 
 // ShowConfigurations is a helper method to define mock.On call
-//   - _a0 context.Context
-//   - _a1 *internalpb.ShowConfigurationsRequest
+//  - _a0 context.Context
+//  - _a1 *internalpb.ShowConfigurationsRequest
 func (_e *MockDataNode_Expecter) ShowConfigurations(_a0 interface{}, _a1 interface{}) *MockDataNode_ShowConfigurations_Call {
 	return &MockDataNode_ShowConfigurations_Call{Call: _e.mock.On("ShowConfigurations", _a0, _a1)}
 }
@@ -1491,8 +1491,8 @@ type MockDataNode_SyncSegments_Call struct {
 }
 
 // SyncSegments is a helper method to define mock.On call
-//   - _a0 context.Context
-//   - _a1 *datapb.SyncSegmentsRequest
+//  - _a0 context.Context
+//  - _a1 *datapb.SyncSegmentsRequest
 func (_e *MockDataNode_Expecter) SyncSegments(_a0 interface{}, _a1 interface{}) *MockDataNode_SyncSegments_Call {
 	return &MockDataNode_SyncSegments_Call{Call: _e.mock.On("SyncSegments", _a0, _a1)}
 }
@@ -1525,7 +1525,7 @@ type MockDataNode_UpdateStateCode_Call struct {
 }
 
 // UpdateStateCode is a helper method to define mock.On call
-//   - stateCode commonpb.StateCode
+//  - stateCode commonpb.StateCode
 func (_e *MockDataNode_Expecter) UpdateStateCode(stateCode interface{}) *MockDataNode_UpdateStateCode_Call {
 	return &MockDataNode_UpdateStateCode_Call{Call: _e.mock.On("UpdateStateCode", stateCode)}
 }
@@ -1579,8 +1579,8 @@ type MockDataNode_WatchDmChannels_Call struct {
 }
 
 // WatchDmChannels is a helper method to define mock.On call
-//   - _a0 context.Context
-//   - _a1 *datapb.WatchDmChannelsRequest
+//  - _a0 context.Context
+//  - _a1 *datapb.WatchDmChannelsRequest
 func (_e *MockDataNode_Expecter) WatchDmChannels(_a0 interface{}, _a1 interface{}) *MockDataNode_WatchDmChannels_Call {
 	return &MockDataNode_WatchDmChannels_Call{Call: _e.mock.On("WatchDmChannels", _a0, _a1)}
 }

--- a/internal/mocks/mock_datanode_client.go
+++ b/internal/mocks/mock_datanode_client.go
@@ -70,9 +70,9 @@ type MockDataNodeClient_CheckChannelOperationProgress_Call struct {
 }
 
 // CheckChannelOperationProgress is a helper method to define mock.On call
-//   - ctx context.Context
-//   - in *datapb.ChannelWatchInfo
-//   - opts ...grpc.CallOption
+//  - ctx context.Context
+//  - in *datapb.ChannelWatchInfo
+//  - opts ...grpc.CallOption
 func (_e *MockDataNodeClient_Expecter) CheckChannelOperationProgress(ctx interface{}, in interface{}, opts ...interface{}) *MockDataNodeClient_CheckChannelOperationProgress_Call {
 	return &MockDataNodeClient_CheckChannelOperationProgress_Call{Call: _e.mock.On("CheckChannelOperationProgress",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -142,8 +142,8 @@ func (_c *MockDataNodeClient_Close_Call) RunAndReturn(run func() error) *MockDat
 	return _c
 }
 
-// Compaction provides a mock function with given fields: ctx, in, opts
-func (_m *MockDataNodeClient) Compaction(ctx context.Context, in *datapb.CompactionPlan, opts ...grpc.CallOption) (*commonpb.Status, error) {
+// CompactionV2 provides a mock function with given fields: ctx, in, opts
+func (_m *MockDataNodeClient) CompactionV2(ctx context.Context, in *datapb.CompactionPlan, opts ...grpc.CallOption) (*commonpb.Status, error) {
 	_va := make([]interface{}, len(opts))
 	for _i := range opts {
 		_va[_i] = opts[_i]
@@ -175,21 +175,21 @@ func (_m *MockDataNodeClient) Compaction(ctx context.Context, in *datapb.Compact
 	return r0, r1
 }
 
-// MockDataNodeClient_Compaction_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Compaction'
-type MockDataNodeClient_Compaction_Call struct {
+// MockDataNodeClient_CompactionV2_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CompactionV2'
+type MockDataNodeClient_CompactionV2_Call struct {
 	*mock.Call
 }
 
-// Compaction is a helper method to define mock.On call
-//   - ctx context.Context
-//   - in *datapb.CompactionPlan
-//   - opts ...grpc.CallOption
-func (_e *MockDataNodeClient_Expecter) Compaction(ctx interface{}, in interface{}, opts ...interface{}) *MockDataNodeClient_Compaction_Call {
-	return &MockDataNodeClient_Compaction_Call{Call: _e.mock.On("Compaction",
+// CompactionV2 is a helper method to define mock.On call
+//  - ctx context.Context
+//  - in *datapb.CompactionPlan
+//  - opts ...grpc.CallOption
+func (_e *MockDataNodeClient_Expecter) CompactionV2(ctx interface{}, in interface{}, opts ...interface{}) *MockDataNodeClient_CompactionV2_Call {
+	return &MockDataNodeClient_CompactionV2_Call{Call: _e.mock.On("CompactionV2",
 		append([]interface{}{ctx, in}, opts...)...)}
 }
 
-func (_c *MockDataNodeClient_Compaction_Call) Run(run func(ctx context.Context, in *datapb.CompactionPlan, opts ...grpc.CallOption)) *MockDataNodeClient_Compaction_Call {
+func (_c *MockDataNodeClient_CompactionV2_Call) Run(run func(ctx context.Context, in *datapb.CompactionPlan, opts ...grpc.CallOption)) *MockDataNodeClient_CompactionV2_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		variadicArgs := make([]grpc.CallOption, len(args)-2)
 		for i, a := range args[2:] {
@@ -202,12 +202,12 @@ func (_c *MockDataNodeClient_Compaction_Call) Run(run func(ctx context.Context, 
 	return _c
 }
 
-func (_c *MockDataNodeClient_Compaction_Call) Return(_a0 *commonpb.Status, _a1 error) *MockDataNodeClient_Compaction_Call {
+func (_c *MockDataNodeClient_CompactionV2_Call) Return(_a0 *commonpb.Status, _a1 error) *MockDataNodeClient_CompactionV2_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockDataNodeClient_Compaction_Call) RunAndReturn(run func(context.Context, *datapb.CompactionPlan, ...grpc.CallOption) (*commonpb.Status, error)) *MockDataNodeClient_Compaction_Call {
+func (_c *MockDataNodeClient_CompactionV2_Call) RunAndReturn(run func(context.Context, *datapb.CompactionPlan, ...grpc.CallOption) (*commonpb.Status, error)) *MockDataNodeClient_CompactionV2_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -251,9 +251,9 @@ type MockDataNodeClient_DropCompactionPlan_Call struct {
 }
 
 // DropCompactionPlan is a helper method to define mock.On call
-//   - ctx context.Context
-//   - in *datapb.DropCompactionPlanRequest
-//   - opts ...grpc.CallOption
+//  - ctx context.Context
+//  - in *datapb.DropCompactionPlanRequest
+//  - opts ...grpc.CallOption
 func (_e *MockDataNodeClient_Expecter) DropCompactionPlan(ctx interface{}, in interface{}, opts ...interface{}) *MockDataNodeClient_DropCompactionPlan_Call {
 	return &MockDataNodeClient_DropCompactionPlan_Call{Call: _e.mock.On("DropCompactionPlan",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -321,9 +321,9 @@ type MockDataNodeClient_DropImport_Call struct {
 }
 
 // DropImport is a helper method to define mock.On call
-//   - ctx context.Context
-//   - in *datapb.DropImportRequest
-//   - opts ...grpc.CallOption
+//  - ctx context.Context
+//  - in *datapb.DropImportRequest
+//  - opts ...grpc.CallOption
 func (_e *MockDataNodeClient_Expecter) DropImport(ctx interface{}, in interface{}, opts ...interface{}) *MockDataNodeClient_DropImport_Call {
 	return &MockDataNodeClient_DropImport_Call{Call: _e.mock.On("DropImport",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -391,9 +391,9 @@ type MockDataNodeClient_FlushChannels_Call struct {
 }
 
 // FlushChannels is a helper method to define mock.On call
-//   - ctx context.Context
-//   - in *datapb.FlushChannelsRequest
-//   - opts ...grpc.CallOption
+//  - ctx context.Context
+//  - in *datapb.FlushChannelsRequest
+//  - opts ...grpc.CallOption
 func (_e *MockDataNodeClient_Expecter) FlushChannels(ctx interface{}, in interface{}, opts ...interface{}) *MockDataNodeClient_FlushChannels_Call {
 	return &MockDataNodeClient_FlushChannels_Call{Call: _e.mock.On("FlushChannels",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -461,9 +461,9 @@ type MockDataNodeClient_FlushSegments_Call struct {
 }
 
 // FlushSegments is a helper method to define mock.On call
-//   - ctx context.Context
-//   - in *datapb.FlushSegmentsRequest
-//   - opts ...grpc.CallOption
+//  - ctx context.Context
+//  - in *datapb.FlushSegmentsRequest
+//  - opts ...grpc.CallOption
 func (_e *MockDataNodeClient_Expecter) FlushSegments(ctx interface{}, in interface{}, opts ...interface{}) *MockDataNodeClient_FlushSegments_Call {
 	return &MockDataNodeClient_FlushSegments_Call{Call: _e.mock.On("FlushSegments",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -531,9 +531,9 @@ type MockDataNodeClient_GetCompactionState_Call struct {
 }
 
 // GetCompactionState is a helper method to define mock.On call
-//   - ctx context.Context
-//   - in *datapb.CompactionStateRequest
-//   - opts ...grpc.CallOption
+//  - ctx context.Context
+//  - in *datapb.CompactionStateRequest
+//  - opts ...grpc.CallOption
 func (_e *MockDataNodeClient_Expecter) GetCompactionState(ctx interface{}, in interface{}, opts ...interface{}) *MockDataNodeClient_GetCompactionState_Call {
 	return &MockDataNodeClient_GetCompactionState_Call{Call: _e.mock.On("GetCompactionState",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -601,9 +601,9 @@ type MockDataNodeClient_GetComponentStates_Call struct {
 }
 
 // GetComponentStates is a helper method to define mock.On call
-//   - ctx context.Context
-//   - in *milvuspb.GetComponentStatesRequest
-//   - opts ...grpc.CallOption
+//  - ctx context.Context
+//  - in *milvuspb.GetComponentStatesRequest
+//  - opts ...grpc.CallOption
 func (_e *MockDataNodeClient_Expecter) GetComponentStates(ctx interface{}, in interface{}, opts ...interface{}) *MockDataNodeClient_GetComponentStates_Call {
 	return &MockDataNodeClient_GetComponentStates_Call{Call: _e.mock.On("GetComponentStates",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -671,9 +671,9 @@ type MockDataNodeClient_GetMetrics_Call struct {
 }
 
 // GetMetrics is a helper method to define mock.On call
-//   - ctx context.Context
-//   - in *milvuspb.GetMetricsRequest
-//   - opts ...grpc.CallOption
+//  - ctx context.Context
+//  - in *milvuspb.GetMetricsRequest
+//  - opts ...grpc.CallOption
 func (_e *MockDataNodeClient_Expecter) GetMetrics(ctx interface{}, in interface{}, opts ...interface{}) *MockDataNodeClient_GetMetrics_Call {
 	return &MockDataNodeClient_GetMetrics_Call{Call: _e.mock.On("GetMetrics",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -741,9 +741,9 @@ type MockDataNodeClient_GetStatisticsChannel_Call struct {
 }
 
 // GetStatisticsChannel is a helper method to define mock.On call
-//   - ctx context.Context
-//   - in *internalpb.GetStatisticsChannelRequest
-//   - opts ...grpc.CallOption
+//  - ctx context.Context
+//  - in *internalpb.GetStatisticsChannelRequest
+//  - opts ...grpc.CallOption
 func (_e *MockDataNodeClient_Expecter) GetStatisticsChannel(ctx interface{}, in interface{}, opts ...interface{}) *MockDataNodeClient_GetStatisticsChannel_Call {
 	return &MockDataNodeClient_GetStatisticsChannel_Call{Call: _e.mock.On("GetStatisticsChannel",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -811,9 +811,9 @@ type MockDataNodeClient_ImportV2_Call struct {
 }
 
 // ImportV2 is a helper method to define mock.On call
-//   - ctx context.Context
-//   - in *datapb.ImportRequest
-//   - opts ...grpc.CallOption
+//  - ctx context.Context
+//  - in *datapb.ImportRequest
+//  - opts ...grpc.CallOption
 func (_e *MockDataNodeClient_Expecter) ImportV2(ctx interface{}, in interface{}, opts ...interface{}) *MockDataNodeClient_ImportV2_Call {
 	return &MockDataNodeClient_ImportV2_Call{Call: _e.mock.On("ImportV2",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -881,9 +881,9 @@ type MockDataNodeClient_NotifyChannelOperation_Call struct {
 }
 
 // NotifyChannelOperation is a helper method to define mock.On call
-//   - ctx context.Context
-//   - in *datapb.ChannelOperationsRequest
-//   - opts ...grpc.CallOption
+//  - ctx context.Context
+//  - in *datapb.ChannelOperationsRequest
+//  - opts ...grpc.CallOption
 func (_e *MockDataNodeClient_Expecter) NotifyChannelOperation(ctx interface{}, in interface{}, opts ...interface{}) *MockDataNodeClient_NotifyChannelOperation_Call {
 	return &MockDataNodeClient_NotifyChannelOperation_Call{Call: _e.mock.On("NotifyChannelOperation",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -951,9 +951,9 @@ type MockDataNodeClient_PreImport_Call struct {
 }
 
 // PreImport is a helper method to define mock.On call
-//   - ctx context.Context
-//   - in *datapb.PreImportRequest
-//   - opts ...grpc.CallOption
+//  - ctx context.Context
+//  - in *datapb.PreImportRequest
+//  - opts ...grpc.CallOption
 func (_e *MockDataNodeClient_Expecter) PreImport(ctx interface{}, in interface{}, opts ...interface{}) *MockDataNodeClient_PreImport_Call {
 	return &MockDataNodeClient_PreImport_Call{Call: _e.mock.On("PreImport",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -1021,9 +1021,9 @@ type MockDataNodeClient_QueryImport_Call struct {
 }
 
 // QueryImport is a helper method to define mock.On call
-//   - ctx context.Context
-//   - in *datapb.QueryImportRequest
-//   - opts ...grpc.CallOption
+//  - ctx context.Context
+//  - in *datapb.QueryImportRequest
+//  - opts ...grpc.CallOption
 func (_e *MockDataNodeClient_Expecter) QueryImport(ctx interface{}, in interface{}, opts ...interface{}) *MockDataNodeClient_QueryImport_Call {
 	return &MockDataNodeClient_QueryImport_Call{Call: _e.mock.On("QueryImport",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -1091,9 +1091,9 @@ type MockDataNodeClient_QueryPreImport_Call struct {
 }
 
 // QueryPreImport is a helper method to define mock.On call
-//   - ctx context.Context
-//   - in *datapb.QueryPreImportRequest
-//   - opts ...grpc.CallOption
+//  - ctx context.Context
+//  - in *datapb.QueryPreImportRequest
+//  - opts ...grpc.CallOption
 func (_e *MockDataNodeClient_Expecter) QueryPreImport(ctx interface{}, in interface{}, opts ...interface{}) *MockDataNodeClient_QueryPreImport_Call {
 	return &MockDataNodeClient_QueryPreImport_Call{Call: _e.mock.On("QueryPreImport",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -1161,9 +1161,9 @@ type MockDataNodeClient_QuerySlot_Call struct {
 }
 
 // QuerySlot is a helper method to define mock.On call
-//   - ctx context.Context
-//   - in *datapb.QuerySlotRequest
-//   - opts ...grpc.CallOption
+//  - ctx context.Context
+//  - in *datapb.QuerySlotRequest
+//  - opts ...grpc.CallOption
 func (_e *MockDataNodeClient_Expecter) QuerySlot(ctx interface{}, in interface{}, opts ...interface{}) *MockDataNodeClient_QuerySlot_Call {
 	return &MockDataNodeClient_QuerySlot_Call{Call: _e.mock.On("QuerySlot",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -1231,9 +1231,9 @@ type MockDataNodeClient_ResendSegmentStats_Call struct {
 }
 
 // ResendSegmentStats is a helper method to define mock.On call
-//   - ctx context.Context
-//   - in *datapb.ResendSegmentStatsRequest
-//   - opts ...grpc.CallOption
+//  - ctx context.Context
+//  - in *datapb.ResendSegmentStatsRequest
+//  - opts ...grpc.CallOption
 func (_e *MockDataNodeClient_Expecter) ResendSegmentStats(ctx interface{}, in interface{}, opts ...interface{}) *MockDataNodeClient_ResendSegmentStats_Call {
 	return &MockDataNodeClient_ResendSegmentStats_Call{Call: _e.mock.On("ResendSegmentStats",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -1301,9 +1301,9 @@ type MockDataNodeClient_ShowConfigurations_Call struct {
 }
 
 // ShowConfigurations is a helper method to define mock.On call
-//   - ctx context.Context
-//   - in *internalpb.ShowConfigurationsRequest
-//   - opts ...grpc.CallOption
+//  - ctx context.Context
+//  - in *internalpb.ShowConfigurationsRequest
+//  - opts ...grpc.CallOption
 func (_e *MockDataNodeClient_Expecter) ShowConfigurations(ctx interface{}, in interface{}, opts ...interface{}) *MockDataNodeClient_ShowConfigurations_Call {
 	return &MockDataNodeClient_ShowConfigurations_Call{Call: _e.mock.On("ShowConfigurations",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -1371,9 +1371,9 @@ type MockDataNodeClient_SyncSegments_Call struct {
 }
 
 // SyncSegments is a helper method to define mock.On call
-//   - ctx context.Context
-//   - in *datapb.SyncSegmentsRequest
-//   - opts ...grpc.CallOption
+//  - ctx context.Context
+//  - in *datapb.SyncSegmentsRequest
+//  - opts ...grpc.CallOption
 func (_e *MockDataNodeClient_Expecter) SyncSegments(ctx interface{}, in interface{}, opts ...interface{}) *MockDataNodeClient_SyncSegments_Call {
 	return &MockDataNodeClient_SyncSegments_Call{Call: _e.mock.On("SyncSegments",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -1441,9 +1441,9 @@ type MockDataNodeClient_WatchDmChannels_Call struct {
 }
 
 // WatchDmChannels is a helper method to define mock.On call
-//   - ctx context.Context
-//   - in *datapb.WatchDmChannelsRequest
-//   - opts ...grpc.CallOption
+//  - ctx context.Context
+//  - in *datapb.WatchDmChannelsRequest
+//  - opts ...grpc.CallOption
 func (_e *MockDataNodeClient_Expecter) WatchDmChannels(ctx interface{}, in interface{}, opts ...interface{}) *MockDataNodeClient_WatchDmChannels_Call {
 	return &MockDataNodeClient_WatchDmChannels_Call{Call: _e.mock.On("WatchDmChannels",
 		append([]interface{}{ctx, in}, opts...)...)}

--- a/internal/proto/data_coord.proto
+++ b/internal/proto/data_coord.proto
@@ -110,7 +110,7 @@ service DataNode {
   // https://wiki.lfaidata.foundation/display/MIL/MEP+8+--+Add+metrics+for+proxy
   rpc GetMetrics(milvus.GetMetricsRequest) returns (milvus.GetMetricsResponse) {}
 
-  rpc Compaction(CompactionPlan) returns (common.Status) {}
+  rpc CompactionV2(CompactionPlan) returns (common.Status) {}
   rpc GetCompactionState(CompactionStateRequest) returns (CompactionStateResponse) {}
   rpc SyncSegments(SyncSegmentsRequest) returns (common.Status) {}
 

--- a/internal/util/mock/grpc_datanode_client.go
+++ b/internal/util/mock/grpc_datanode_client.go
@@ -57,7 +57,7 @@ func (m *GrpcDataNodeClient) GetMetrics(ctx context.Context, in *milvuspb.GetMet
 	return &milvuspb.GetMetricsResponse{}, m.Err
 }
 
-func (m *GrpcDataNodeClient) Compaction(ctx context.Context, req *datapb.CompactionPlan, opts ...grpc.CallOption) (*commonpb.Status, error) {
+func (m *GrpcDataNodeClient) CompactionV2(ctx context.Context, req *datapb.CompactionPlan, opts ...grpc.CallOption) (*commonpb.Status, error) {
 	return &commonpb.Status{}, m.Err
 }
 


### PR DESCRIPTION
Due to the removal of injection and syncSegments from the compaction, we need to ensure that no compaction is successfully executed during the rolling upgrade. This PR renames Compaction to CompactionV2, with the following effects:
- New datacoord + old datanode: Utilizes the CompactionV2 interface, resulting in the datanode error "CompactionV2 not implemented," causing compaction to fail;
- Old datacoord + new datanode: Utilizes the CompactionV1 interface, resulting in the datanode error "CompactionV1 not implemented," causing compaction to fail.

issue: https://github.com/milvus-io/milvus/issues/32809





