### PR TITLE
fix: Check nodeID wildcard when removing pkOracle

### DIFF
--- a/internal/querynodev2/pkoracle/candidate.go
+++ b/internal/querynodev2/pkoracle/candidate.go
@@ -52,7 +52,8 @@ func WithSegmentType(typ commonpb.SegmentState) CandidateFilter {
 // WithWorkerID returns CandidateFilter with provided worker id.
 func WithWorkerID(workerID int64) CandidateFilter {
 	return func(candidate candidateWithWorker) bool {
-		return candidate.workerID == workerID
+		return candidate.workerID == workerID ||
+			workerID == -1 // wildcard for offline node
 	}
 }
 


### PR DESCRIPTION
See also #33894