### PR TITLE
enhance: Use primitive type for vectorType

### DIFF
--- a/internal/querynodev2/optimizers/query_hook.go
+++ b/internal/querynodev2/optimizers/query_hook.go
@@ -62,7 +62,7 @@ func OptimizeSearchParams(ctx context.Context, req *querypb.SearchRequest, query
 			common.SearchParamKey:  queryInfo.GetSearchParams(),
 			common.SegmentNumKey:   estSegmentNum,
 			common.WithFilterKey:   withFilter,
-			common.DataTypeKey:     plan.GetVectorAnns().GetVectorType(),
+			common.DataTypeKey:     int32(plan.GetVectorAnns().GetVectorType()),
 			common.WithOptimizeKey: paramtable.Get().AutoIndexConfig.EnableOptimize.GetAsBool(),
 			common.CollectionKey:   req.GetReq().GetCollectionID(),
 		}


### PR DESCRIPTION
issue: #22837 
pr: #33868 

Use primitive type instead of proto enum type for queryHook to recognize