### PR TITLE
fix: update ubuntu base image version

### DIFF
--- a/build/docker/milvus/ubuntu20.04/Dockerfile
+++ b/build/docker/milvus/ubuntu20.04/Dockerfile
@@ -9,7 +9,7 @@
 # is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 # or implied. See the License for the specific language governing permissions and limitations under the License.
 
-FROM ubuntu:focal-20220426
+FROM ubuntu:focal-20240530
 
 ARG TARGETARCH
 


### PR DESCRIPTION
related to #33945
FIX CVEs of milvus base image: LOW: 32,  MEDIUM: 50, **Total FIX: 82**
![image](https://github.com/milvus-io/milvus/assets/27683687/020fbb73-9a1f-42cb-8224-a595179b3533)
![image](https://github.com/milvus-io/milvus/assets/27683687/fef403a5-c658-4ee6-baf4-ace3a0387799)
