### PR TITLE
fix: filter results less than topk

### DIFF
--- a/internal/core/thirdparty/knowhere/CMakeLists.txt
+++ b/internal/core/thirdparty/knowhere/CMakeLists.txt
@@ -15,7 +15,7 @@
 set( KNOWHERE_VERSION v2.2.6 )
 set( GIT_REPOSITORY  "https://github.com/zilliztech/knowhere.git")
 if ( INDEX_ENGINE STREQUAL "cardinal" )
-    set( KNOWHERE_VERSION 2.2.9 )
+    set( KNOWHERE_VERSION 2.2.10 )
     set( GIT_REPOSITORY  "https://github.com/zilliztech/knowhere-cloud.git")
 endif()
 message(STATUS "Knowhere repo: ${GIT_REPOSITORY}")


### PR DESCRIPTION
issue: #33933 
Strict filtering can affect the quality of graph-based search results. In extreme cases, it may return less than topk results. The upgraded `Knowhere` has updated strategy decision-making to address this issue.