### PR TITLE
fix: update ubuntu base image version

### DIFF
--- a/build/docker/milvus/ubuntu20.04/Dockerfile
+++ b/build/docker/milvus/ubuntu20.04/Dockerfile
@@ -9,7 +9,7 @@
 # is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 # or implied. See the License for the specific language governing permissions and limitations under the License.
 
-FROM ubuntu:focal-20240427
+FROM ubuntu:focal-20240530
 
 ARG TARGETARCH
 


### PR DESCRIPTION
related to #33945
FIX CVEs of milvus base image: MEDIUM: 8, **Total FIX: 8** for master branch
![image](https://github.com/milvus-io/milvus/assets/27683687/71708028-265e-4f20-8732-56b7e76864fc)
