### PR TITLE
enhance: fix copying hits of inverted index twice (#33968)

### DIFF
--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/index_reader.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/index_reader.rs
@@ -56,11 +56,7 @@ impl IndexReaderWrapper {
     fn search(&self, q: &dyn Query) -> Vec<u32> {
         let searcher = self.reader.searcher();
         let hits = searcher.search(q, &VecCollector).unwrap();
-        let mut ret = Vec::with_capacity(hits.len());
-        for address in hits {
-            ret.push(address);
-        }
-        ret
+        hits
     }
 
     pub fn term_query_i64(&self, term: i64) -> Vec<u32> {


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/29793
pr: https://github.com/milvus-io/milvus/pull/33968
The custom `VecCollector` have already transformed the results into vector of offsets, no need to copy them twice.