### PR TITLE
fix: fix milvus gpu compile error

### DIFF
--- a/internal/core/thirdparty/knowhere/CMakeLists.txt
+++ b/internal/core/thirdparty/knowhere/CMakeLists.txt
@@ -12,6 +12,7 @@
 #-------------------------------------------------------------------------------
 
 # Update KNOWHERE_VERSION for the first occurrence
+set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
 set( KNOWHERE_VERSION v2.3.5 )
 set( GIT_REPOSITORY  "https://github.com/zilliztech/knowhere.git")
 message(STATUS "Knowhere repo: ${GIT_REPOSITORY}")


### PR DESCRIPTION
NVIDIA RAFT uses customized versions of spdlog and fmt, which conflict with the versions provided by Conan. Therefore, it is necessary to isolate the build environment for knowhere to avoid these conflicts.
issue: #33991