### PR TITLE
fix: [2.3] Check nodeID wildcard when removing pkOracle (#33895)

### DIFF
--- a/internal/querynodev2/pkoracle/candidate.go
+++ b/internal/querynodev2/pkoracle/candidate.go
@@ -52,7 +52,8 @@ func WithSegmentType(typ commonpb.SegmentState) CandidateFilter {
 // WithWorkerID returns CandidateFilter with provided worker id.
 func WithWorkerID(workerID int64) CandidateFilter {
 	return func(candidate candidateWithWorker) bool {
-		return candidate.workerID == workerID
+		return candidate.workerID == workerID ||
+			workerID == -1 // wildcard for offline node
 	}
 }
 


### PR DESCRIPTION
Cherry-pick from master
pr: #33895
See also #33894