### PR TITLE
fix: [2.3] Return record with largest timestamp for entires with same PK(#33936)

### DIFF
--- a/internal/core/src/segcore/InsertRecord.h
+++ b/internal/core/src/segcore/InsertRecord.h
@@ -112,10 +112,6 @@ class OffsetOrderedMap : public OffsetMap {
                bool false_filtered_out) const override {
         std::shared_lock<std::shared_mutex> lck(mtx_);
 
-        // if (limit == Unlimited || limit == NoLimit) {
-        //     limit = map_.size();
-        // }
-
         // TODO: we can't retrieve pk by offset very conveniently.
         //      Selectivity should be done outside.
         return find_first_by_index(limit, bitset, false_filtered_out);

--- a/internal/core/src/segcore/InsertRecord.h
+++ b/internal/core/src/segcore/InsertRecord.h
@@ -112,9 +112,9 @@ class OffsetOrderedMap : public OffsetMap {
                bool false_filtered_out) const override {
         std::shared_lock<std::shared_mutex> lck(mtx_);
 
-        if (limit == Unlimited || limit == NoLimit) {
-            limit = map_.size();
-        }
+        // if (limit == Unlimited || limit == NoLimit) {
+        //     limit = map_.size();
+        // }
 
         // TODO: we can't retrieve pk by offset very conveniently.
         //      Selectivity should be done outside.
@@ -131,6 +131,9 @@ class OffsetOrderedMap : public OffsetMap {
         auto size = bitset.size();
         if (!false_filtered_out) {
             cnt = size - bitset.count();
+        }
+        if (limit == Unlimited || limit == NoLimit) {
+            limit = cnt;
         }
         limit = std::min(limit, cnt);
         std::vector<int64_t> seg_offsets;

--- a/internal/querynodev2/segments/reducer.go
+++ b/internal/querynodev2/segments/reducer.go
@@ -3,10 +3,15 @@ package segments
 import (
 	"context"
 
+	"github.com/samber/lo"
+
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/proto/internalpb"
 	"github.com/milvus-io/milvus/internal/proto/querypb"
 	"github.com/milvus-io/milvus/internal/proto/segcorepb"
+	"github.com/milvus-io/milvus/pkg/common"
+	"github.com/milvus-io/milvus/pkg/util/merr"
+	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
 
 type internalReducer interface {
@@ -29,4 +34,47 @@ func CreateSegCoreReducer(req *querypb.QueryRequest, schema *schemapb.Collection
 		return &cntReducerSegCore{}
 	}
 	return newDefaultLimitReducerSegcore(req, schema)
+}
+
+type TimestampedRetrieveResult[T interface {
+	typeutil.ResultWithID
+	GetFieldsData() []*schemapb.FieldData
+}] struct {
+	Result     T
+	Timestamps []int64
+}
+
+func (r *TimestampedRetrieveResult[T]) GetIds() *schemapb.IDs {
+	return r.Result.GetIds()
+}
+
+func (r *TimestampedRetrieveResult[T]) GetHasMoreResult() bool {
+	return r.Result.GetHasMoreResult()
+}
+
+func (r *TimestampedRetrieveResult[T]) GetTimestamps() []int64 {
+	return r.Timestamps
+}
+
+func NewTimestampedRetrieveResult[T interface {
+	typeutil.ResultWithID
+	GetFieldsData() []*schemapb.FieldData
+}](result T) (*TimestampedRetrieveResult[T], error) {
+	tsField, has := lo.Find(result.GetFieldsData(), func(fd *schemapb.FieldData) bool {
+		return fd.GetFieldId() == common.TimeStampField
+	})
+	if !has {
+		return nil, merr.WrapErrServiceInternal("RetrieveResult does not have timestamp field")
+	}
+	timestamps := tsField.GetScalars().GetLongData().GetData()
+	idSize := typeutil.GetSizeOfIDs(result.GetIds())
+
+	if idSize != len(timestamps) {
+		return nil, merr.WrapErrServiceInternal("id length is not equal to timestamp length")
+	}
+
+	return &TimestampedRetrieveResult[T]{
+		Result:     result,
+		Timestamps: timestamps,
+	}, nil
 }

--- a/internal/querynodev2/segments/result.go
+++ b/internal/querynodev2/segments/result.go
@@ -260,14 +260,18 @@ func MergeInternalRetrieveResult(ctx context.Context, retrieveResults []*interna
 		loopEnd    int
 	)
 
-	validRetrieveResults := []*internalpb.RetrieveResults{}
+	validRetrieveResults := []*TimestampedRetrieveResult[*internalpb.RetrieveResults]{}
 	hasMoreResult := false
 	for _, r := range retrieveResults {
 		size := typeutil.GetSizeOfIDs(r.GetIds())
 		if r == nil || len(r.GetFieldsData()) == 0 || size == 0 {
 			continue
 		}
-		validRetrieveResults = append(validRetrieveResults, r)
+		tr, err := NewTimestampedRetrieveResult(r)
+		if err != nil {
+			return nil, err
+		}
+		validRetrieveResults = append(validRetrieveResults, tr)
 		loopEnd += size
 		hasMoreResult = hasMoreResult || r.GetHasMoreResult()
 	}
@@ -281,23 +285,23 @@ func MergeInternalRetrieveResult(ctx context.Context, retrieveResults []*interna
 		loopEnd = int(param.limit)
 	}
 
-	ret.FieldsData = make([]*schemapb.FieldData, len(validRetrieveResults[0].GetFieldsData()))
-	idTsMap := make(map[interface{}]uint64)
+	ret.FieldsData = make([]*schemapb.FieldData, len(validRetrieveResults[0].Result.GetFieldsData()))
+	idTsMap := make(map[interface{}]int64)
 	cursors := make([]int64, len(validRetrieveResults))
 
 	var retSize int64
 	maxOutputSize := paramtable.Get().QuotaConfig.MaxOutputSize.GetAsInt64()
 	for j := 0; j < loopEnd; {
-		sel, drainOneResult := typeutil.SelectMinPK(validRetrieveResults, cursors)
+		sel, drainOneResult := typeutil.SelectMinPKWithTimestamp(validRetrieveResults, cursors)
 		if sel == -1 || (param.mergeStopForBest && drainOneResult) {
 			break
 		}
 
 		pk := typeutil.GetPK(validRetrieveResults[sel].GetIds(), cursors[sel])
-		ts := getTS(validRetrieveResults[sel], cursors[sel])
+		ts := validRetrieveResults[sel].Timestamps[cursors[sel]]
 		if _, ok := idTsMap[pk]; !ok {
 			typeutil.AppendPKs(ret.Ids, pk)
-			retSize += typeutil.AppendFieldData(ret.FieldsData, validRetrieveResults[sel].GetFieldsData(), cursors[sel])
+			retSize += typeutil.AppendFieldData(ret.FieldsData, validRetrieveResults[sel].Result.GetFieldsData(), cursors[sel])
 			idTsMap[pk] = ts
 			j++
 		} else {
@@ -306,7 +310,7 @@ func MergeInternalRetrieveResult(ctx context.Context, retrieveResults []*interna
 			if ts != 0 && ts > idTsMap[pk] {
 				idTsMap[pk] = ts
 				typeutil.DeleteFieldData(ret.FieldsData)
-				retSize += typeutil.AppendFieldData(ret.FieldsData, validRetrieveResults[sel].GetFieldsData(), cursors[sel])
+				retSize += typeutil.AppendFieldData(ret.FieldsData, validRetrieveResults[sel].Result.GetFieldsData(), cursors[sel])
 			}
 		}
 
@@ -366,7 +370,9 @@ func MergeSegcoreRetrieveResults(ctx context.Context, retrieveResults []*segcore
 		loopEnd    int
 	)
 
-	validRetrieveResults := []*segcorepb.RetrieveResults{}
+	validRetrieveResults := []*TimestampedRetrieveResult[*segcorepb.RetrieveResults]{}
+	selectedOffsets := make([][]int64, 0, len(retrieveResults))
+	selectedIndexes := make([][]int64, 0, len(retrieveResults))
 	hasMoreResult := false
 	for _, r := range retrieveResults {
 		size := typeutil.GetSizeOfIDs(r.GetIds())
@@ -374,7 +380,13 @@ func MergeSegcoreRetrieveResults(ctx context.Context, retrieveResults []*segcore
 			log.Ctx(ctx).Debug("filter out invalid retrieve result")
 			continue
 		}
-		validRetrieveResults = append(validRetrieveResults, r)
+		tr, err := NewTimestampedRetrieveResult(r)
+		if err != nil {
+			return nil, err
+		}
+		validRetrieveResults = append(validRetrieveResults, tr)
+		selectedOffsets = append(selectedOffsets, make([]int64, 0, len(r.GetOffset())))
+		selectedIndexes = append(selectedIndexes, make([]int64, 0, len(r.GetOffset())))
 		loopEnd += size
 		hasMoreResult = r.GetHasMoreResult() || hasMoreResult
 	}
@@ -390,28 +402,34 @@ func MergeSegcoreRetrieveResults(ctx context.Context, retrieveResults []*segcore
 		limit = int(param.limit)
 	}
 
-	ret.FieldsData = make([]*schemapb.FieldData, len(validRetrieveResults[0].GetFieldsData()))
-	idSet := make(map[interface{}]struct{})
 	cursors := make([]int64, len(validRetrieveResults))
+	idTsMap := make(map[any]int64)
 
 	var availableCount int
 	var retSize int64
 	maxOutputSize := paramtable.Get().QuotaConfig.MaxOutputSize.GetAsInt64()
 	for j := 0; j < loopEnd && (limit == -1 || availableCount < limit); j++ {
-		sel, drainOneResult := typeutil.SelectMinPK(validRetrieveResults, cursors)
+		sel, drainOneResult := typeutil.SelectMinPKWithTimestamp(validRetrieveResults, cursors)
 		if sel == -1 || (param.mergeStopForBest && drainOneResult) {
 			break
 		}
 
 		pk := typeutil.GetPK(validRetrieveResults[sel].GetIds(), cursors[sel])
-		if _, ok := idSet[pk]; !ok {
+		ts := validRetrieveResults[sel].Timestamps[cursors[sel]]
+		if _, ok := idTsMap[pk]; !ok {
 			typeutil.AppendPKs(ret.Ids, pk)
-			retSize += typeutil.AppendFieldData(ret.FieldsData, validRetrieveResults[sel].GetFieldsData(), cursors[sel])
-			idSet[pk] = struct{}{}
+			selectedOffsets[sel] = append(selectedOffsets[sel], validRetrieveResults[sel].Result.GetOffset()[cursors[sel]])
+			selectedIndexes[sel] = append(selectedIndexes[sel], cursors[sel])
+			idTsMap[pk] = ts
 			availableCount++
 		} else {
 			// primary keys duplicate
 			skipDupCnt++
+			if ts != 0 && ts > idTsMap[pk] {
+				idTsMap[pk] = ts
+				selectedOffsets[sel][len(selectedOffsets[sel])-1] = validRetrieveResults[sel].Result.GetOffset()[cursors[sel]]
+				selectedIndexes[sel][len(selectedIndexes[sel])-1] = cursors[sel]
+			}
 		}
 
 		// limit retrieve result to avoid oom
@@ -426,6 +444,10 @@ func MergeSegcoreRetrieveResults(ctx context.Context, retrieveResults []*segcore
 		log.Ctx(ctx).Debug("skip duplicated query result while reducing segcore.RetrieveResults", zap.Int64("dupCount", skipDupCnt))
 	}
 
+	if err := typeutil2.FillRetrieveResultIfEmpty(typeutil2.NewSegcoreResults(ret), param.outputFieldsId, param.schema); err != nil {
+		return nil, fmt.Errorf("failed to fill internal retrieve results: %s", err.Error())
+	}
+
 	return ret, nil
 }
 
@@ -437,10 +459,6 @@ func mergeInternalRetrieveResultsAndFillIfEmpty(
 	mergedResult, err := MergeInternalRetrieveResult(ctx, retrieveResults, param)
 	if err != nil {
 		return nil, err
-	}
-
-	if err := typeutil2.FillRetrieveResultIfEmpty(typeutil2.NewInternalResult(mergedResult), param.outputFieldsId, param.schema); err != nil {
-		return nil, fmt.Errorf("failed to fill internal retrieve results: %s", err.Error())
 	}
 
 	return mergedResult, nil

--- a/internal/querynodev2/segments/result_test.go
+++ b/internal/querynodev2/segments/result_test.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
@@ -32,6 +33,15 @@ import (
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
+
+func getFieldData[T interface {
+	GetFieldsData() []*schemapb.FieldData
+}](rs T, fieldID int64) (*schemapb.FieldData, bool) {
+	fd, has := lo.Find(rs.GetFieldsData(), func(fd *schemapb.FieldData) bool {
+		return fd.GetFieldId() == fieldID
+	})
+	return fd, has
+}
 
 type ResultSuite struct {
 	suite.Suite
@@ -49,10 +59,12 @@ func (suite *ResultSuite) TestResult_MergeSegcoreRetrieveResults() {
 	FloatVector := []float32{1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 11.0, 22.0, 33.0, 44.0, 55.0, 66.0, 77.0, 88.0}
 
 	var fieldDataArray1 []*schemapb.FieldData
+	fieldDataArray1 = append(fieldDataArray1, genFieldData(common.TimeStampFieldName, common.TimeStampField, schemapb.DataType_Int64, []int64{1000, 2000}, 1))
 	fieldDataArray1 = append(fieldDataArray1, genFieldData(Int64FieldName, Int64FieldID, schemapb.DataType_Int64, Int64Array[0:2], 1))
 	fieldDataArray1 = append(fieldDataArray1, genFieldData(FloatVectorFieldName, FloatVectorFieldID, schemapb.DataType_FloatVector, FloatVector[0:16], Dim))
 
 	var fieldDataArray2 []*schemapb.FieldData
+	fieldDataArray2 = append(fieldDataArray2, genFieldData(common.TimeStampFieldName, common.TimeStampField, schemapb.DataType_Int64, []int64{2000, 3000}, 1))
 	fieldDataArray2 = append(fieldDataArray2, genFieldData(Int64FieldName, Int64FieldID, schemapb.DataType_Int64, Int64Array[0:2], 1))
 	fieldDataArray2 = append(fieldDataArray2, genFieldData(FloatVectorFieldName, FloatVectorFieldID, schemapb.DataType_FloatVector, FloatVector[0:16], Dim))
 
@@ -83,10 +95,14 @@ func (suite *ResultSuite) TestResult_MergeSegcoreRetrieveResults() {
 		result, err := MergeSegcoreRetrieveResults(context.Background(), []*segcorepb.RetrieveResults{result1, result2},
 			NewMergeParam(typeutil.Unlimited, make([]int64, 0), nil, false))
 		suite.NoError(err)
-		suite.Equal(2, len(result.GetFieldsData()))
+		suite.Equal(3, len(result.GetFieldsData()))
 		suite.Equal([]int64{0, 1}, result.GetIds().GetIntId().GetData())
-		suite.Equal(Int64Array, result.GetFieldsData()[0].GetScalars().GetLongData().Data)
-		suite.InDeltaSlice(FloatVector, result.FieldsData[1].GetVectors().GetFloatVector().Data, 10e-10)
+		intFieldData, has := getFieldData(result, Int64FieldID)
+		suite.Require().True(has)
+		suite.Equal(Int64Array, intFieldData.GetScalars().GetLongData().Data)
+		vectorFieldData, has := getFieldData(result, FloatVectorFieldID)
+		suite.Require().True(has)
+		suite.InDeltaSlice(FloatVector, vectorFieldData.GetVectors().GetFloatVector().Data, 10e-10)
 	})
 
 	suite.Run("test nil results", func() {
@@ -163,11 +179,15 @@ func (suite *ResultSuite) TestResult_MergeSegcoreRetrieveResults() {
 				suite.Run(test.description, func() {
 					result, err := MergeSegcoreRetrieveResults(context.Background(), []*segcorepb.RetrieveResults{r1, r2},
 						NewMergeParam(test.limit, make([]int64, 0), nil, false))
-					suite.Equal(2, len(result.GetFieldsData()))
+					suite.Equal(3, len(result.GetFieldsData()))
 					suite.Equal(int(test.limit), len(result.GetIds().GetIntId().GetData()))
 					suite.Equal(resultIDs[0:test.limit], result.GetIds().GetIntId().GetData())
-					suite.Equal(resultField0[0:test.limit], result.GetFieldsData()[0].GetScalars().GetLongData().Data)
-					suite.InDeltaSlice(resultFloat[0:test.limit*Dim], result.FieldsData[1].GetVectors().GetFloatVector().Data, 10e-10)
+					intFieldData, has := getFieldData(result, Int64FieldID)
+					suite.Require().True(has)
+					suite.Equal(resultField0[0:test.limit], intFieldData.GetScalars().GetLongData().Data)
+					vectorFieldData, has := getFieldData(result, FloatVectorFieldID)
+					suite.Require().True(has)
+					suite.InDeltaSlice(resultFloat[0:test.limit*Dim], vectorFieldData.GetVectors().GetFloatVector().Data, 10e-10)
 					suite.NoError(err)
 				})
 			}
@@ -206,10 +226,14 @@ func (suite *ResultSuite) TestResult_MergeSegcoreRetrieveResults() {
 		suite.Run("test int ID", func() {
 			result, err := MergeSegcoreRetrieveResults(context.Background(), []*segcorepb.RetrieveResults{r1, r2},
 				NewMergeParam(typeutil.Unlimited, make([]int64, 0), nil, false))
-			suite.Equal(2, len(result.GetFieldsData()))
+			suite.Equal(3, len(result.GetFieldsData()))
 			suite.Equal([]int64{1, 2, 3, 4}, result.GetIds().GetIntId().GetData())
-			suite.Equal([]int64{11, 11, 22, 22}, result.GetFieldsData()[0].GetScalars().GetLongData().Data)
-			suite.InDeltaSlice(resultFloat, result.FieldsData[1].GetVectors().GetFloatVector().Data, 10e-10)
+			intFieldData, has := getFieldData(result, Int64FieldID)
+			suite.Require().True(has)
+			suite.Equal([]int64{11, 11, 22, 22}, intFieldData.GetScalars().GetLongData().Data)
+			vectorFieldData, has := getFieldData(result, FloatVectorFieldID)
+			suite.Require().True(has)
+			suite.InDeltaSlice(resultFloat, vectorFieldData.GetVectors().GetFloatVector().Data, 10e-10)
 			suite.NoError(err)
 		})
 
@@ -233,10 +257,14 @@ func (suite *ResultSuite) TestResult_MergeSegcoreRetrieveResults() {
 			result, err := MergeSegcoreRetrieveResults(context.Background(), []*segcorepb.RetrieveResults{r1, r2},
 				NewMergeParam(typeutil.Unlimited, make([]int64, 0), nil, false))
 			suite.NoError(err)
-			suite.Equal(2, len(result.GetFieldsData()))
+			suite.Equal(3, len(result.GetFieldsData()))
 			suite.Equal([]string{"a", "b", "c", "d"}, result.GetIds().GetStrId().GetData())
-			suite.Equal([]int64{11, 11, 22, 22}, result.GetFieldsData()[0].GetScalars().GetLongData().Data)
-			suite.InDeltaSlice(resultFloat, result.FieldsData[1].GetVectors().GetFloatVector().Data, 10e-10)
+			intFieldData, has := getFieldData(result, Int64FieldID)
+			suite.Require().True(has)
+			suite.Equal([]int64{11, 11, 22, 22}, intFieldData.GetScalars().GetLongData().Data)
+			vectorFieldData, has := getFieldData(result, FloatVectorFieldID)
+			suite.Require().True(has)
+			suite.InDeltaSlice(resultFloat, vectorFieldData.GetVectors().GetFloatVector().Data, 10e-10)
 			suite.NoError(err)
 		})
 	})
@@ -254,10 +282,12 @@ func (suite *ResultSuite) TestResult_MergeInternalRetrieveResults() {
 	FloatVector := []float32{1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 11.0, 22.0, 33.0, 44.0, 55.0, 66.0, 77.0, 88.0}
 
 	var fieldDataArray1 []*schemapb.FieldData
+	fieldDataArray1 = append(fieldDataArray1, genFieldData(common.TimeStampFieldName, common.TimeStampField, schemapb.DataType_Int64, []int64{1000, 2000}, 1))
 	fieldDataArray1 = append(fieldDataArray1, genFieldData(Int64FieldName, Int64FieldID, schemapb.DataType_Int64, Int64Array[0:2], 1))
 	fieldDataArray1 = append(fieldDataArray1, genFieldData(FloatVectorFieldName, FloatVectorFieldID, schemapb.DataType_FloatVector, FloatVector[0:16], Dim))
 
 	var fieldDataArray2 []*schemapb.FieldData
+	fieldDataArray2 = append(fieldDataArray2, genFieldData(common.TimeStampFieldName, common.TimeStampField, schemapb.DataType_Int64, []int64{2000, 3000}, 1))
 	fieldDataArray2 = append(fieldDataArray2, genFieldData(Int64FieldName, Int64FieldID, schemapb.DataType_Int64, Int64Array[0:2], 1))
 	fieldDataArray2 = append(fieldDataArray2, genFieldData(FloatVectorFieldName, FloatVectorFieldID, schemapb.DataType_FloatVector, FloatVector[0:16], Dim))
 
@@ -286,10 +316,14 @@ func (suite *ResultSuite) TestResult_MergeInternalRetrieveResults() {
 		result, err := MergeInternalRetrieveResult(context.Background(), []*internalpb.RetrieveResults{result1, result2},
 			NewMergeParam(typeutil.Unlimited, make([]int64, 0), nil, false))
 		suite.NoError(err)
-		suite.Equal(2, len(result.GetFieldsData()))
+		suite.Equal(3, len(result.GetFieldsData()))
 		suite.Equal([]int64{0, 1}, result.GetIds().GetIntId().GetData())
-		suite.Equal(Int64Array, result.GetFieldsData()[0].GetScalars().GetLongData().Data)
-		suite.InDeltaSlice(FloatVector, result.FieldsData[1].GetVectors().GetFloatVector().Data, 10e-10)
+		intFieldData, has := getFieldData(result, Int64FieldID)
+		suite.Require().True(has)
+		suite.Equal(Int64Array, intFieldData.GetScalars().GetLongData().GetData())
+		vectorFieldData, has := getFieldData(result, FloatVectorFieldID)
+		suite.Require().True(has)
+		suite.InDeltaSlice(FloatVector, vectorFieldData.GetVectors().GetFloatVector().Data, 10e-10)
 	})
 
 	suite.Run("test nil results", func() {
@@ -384,11 +418,16 @@ func (suite *ResultSuite) TestResult_MergeInternalRetrieveResults() {
 				suite.Run(test.description, func() {
 					result, err := MergeInternalRetrieveResult(context.Background(), []*internalpb.RetrieveResults{r1, r2},
 						NewMergeParam(test.limit, make([]int64, 0), nil, false))
-					suite.Equal(2, len(result.GetFieldsData()))
+					suite.Equal(3, len(result.GetFieldsData()))
 					suite.Equal(int(test.limit), len(result.GetIds().GetIntId().GetData()))
 					suite.Equal(resultIDs[0:test.limit], result.GetIds().GetIntId().GetData())
-					suite.Equal(resultField0[0:test.limit], result.GetFieldsData()[0].GetScalars().GetLongData().Data)
-					suite.InDeltaSlice(resultFloat[0:test.limit*Dim], result.FieldsData[1].GetVectors().GetFloatVector().Data, 10e-10)
+
+					intFieldData, has := getFieldData(result, Int64FieldID)
+					suite.Require().True(has)
+					suite.Equal(resultField0[0:test.limit], intFieldData.GetScalars().GetLongData().Data)
+					vectorFieldData, has := getFieldData(result, FloatVectorFieldID)
+					suite.Require().True(has)
+					suite.InDeltaSlice(resultFloat[0:test.limit*Dim], vectorFieldData.GetVectors().GetFloatVector().Data, 10e-10)
 					suite.NoError(err)
 				})
 			}
@@ -425,10 +464,15 @@ func (suite *ResultSuite) TestResult_MergeInternalRetrieveResults() {
 		suite.Run("test int ID", func() {
 			result, err := MergeInternalRetrieveResult(context.Background(), []*internalpb.RetrieveResults{r1, r2},
 				NewMergeParam(typeutil.Unlimited, make([]int64, 0), nil, false))
-			suite.Equal(2, len(result.GetFieldsData()))
+			suite.Equal(3, len(result.GetFieldsData()))
 			suite.Equal([]int64{1, 2, 3, 4}, result.GetIds().GetIntId().GetData())
-			suite.Equal([]int64{11, 11, 22, 22}, result.GetFieldsData()[0].GetScalars().GetLongData().Data)
-			suite.InDeltaSlice(resultFloat, result.FieldsData[1].GetVectors().GetFloatVector().Data, 10e-10)
+
+			intFieldData, has := getFieldData(result, Int64FieldID)
+			suite.Require().True(has)
+			suite.Equal([]int64{11, 11, 22, 22}, intFieldData.GetScalars().GetLongData().Data)
+			vectorFieldData, has := getFieldData(result, FloatVectorFieldID)
+			suite.Require().True(has)
+			suite.InDeltaSlice(resultFloat, vectorFieldData.GetVectors().GetFloatVector().Data, 10e-10)
 			suite.NoError(err)
 		})
 
@@ -452,10 +496,14 @@ func (suite *ResultSuite) TestResult_MergeInternalRetrieveResults() {
 			result, err := MergeInternalRetrieveResult(context.Background(), []*internalpb.RetrieveResults{r1, r2},
 				NewMergeParam(typeutil.Unlimited, make([]int64, 0), nil, false))
 			suite.NoError(err)
-			suite.Equal(2, len(result.GetFieldsData()))
+			suite.Equal(3, len(result.GetFieldsData()))
 			suite.Equal([]string{"a", "b", "c", "d"}, result.GetIds().GetStrId().GetData())
-			suite.Equal([]int64{11, 11, 22, 22}, result.GetFieldsData()[0].GetScalars().GetLongData().Data)
-			suite.InDeltaSlice(resultFloat, result.FieldsData[1].GetVectors().GetFloatVector().Data, 10e-10)
+			intFieldData, has := getFieldData(result, Int64FieldID)
+			suite.Require().True(has)
+			suite.Equal([]int64{11, 11, 22, 22}, intFieldData.GetScalars().GetLongData().Data)
+			vectorFieldData, has := getFieldData(result, FloatVectorFieldID)
+			suite.Require().True(has)
+			suite.InDeltaSlice(resultFloat, vectorFieldData.GetVectors().GetFloatVector().Data, 10e-10)
 			suite.NoError(err)
 		})
 	})
@@ -473,12 +521,14 @@ func (suite *ResultSuite) TestResult_MergeStopForBestResult() {
 	FloatVector := []float32{1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 11.0, 22.0, 33.0, 44.0}
 
 	var fieldDataArray1 []*schemapb.FieldData
+	fieldDataArray1 = append(fieldDataArray1, genFieldData(common.TimeStampFieldName, common.TimeStampField, schemapb.DataType_Int64, []int64{1000, 2000, 3000}, 1))
 	fieldDataArray1 = append(fieldDataArray1, genFieldData(Int64FieldName, Int64FieldID,
 		schemapb.DataType_Int64, Int64Array[0:3], 1))
 	fieldDataArray1 = append(fieldDataArray1, genFieldData(FloatVectorFieldName, FloatVectorFieldID,
 		schemapb.DataType_FloatVector, FloatVector[0:12], Dim))
 
 	var fieldDataArray2 []*schemapb.FieldData
+	fieldDataArray2 = append(fieldDataArray2, genFieldData(common.TimeStampFieldName, common.TimeStampField, schemapb.DataType_Int64, []int64{2000, 3000, 4000}, 1))
 	fieldDataArray2 = append(fieldDataArray2, genFieldData(Int64FieldName, Int64FieldID,
 		schemapb.DataType_Int64, Int64Array[0:3], 1))
 	fieldDataArray2 = append(fieldDataArray2, genFieldData(FloatVectorFieldName, FloatVectorFieldID,
@@ -513,13 +563,17 @@ func (suite *ResultSuite) TestResult_MergeStopForBestResult() {
 			result, err := MergeSegcoreRetrieveResults(context.Background(), []*segcorepb.RetrieveResults{result1, result2},
 				NewMergeParam(3, make([]int64, 0), nil, true))
 			suite.NoError(err)
-			suite.Equal(2, len(result.GetFieldsData()))
+			suite.Equal(3, len(result.GetFieldsData()))
 			// has more result both, stop reduce when draining one result
 			// here, we can only get best result from 0 to 4 without 6, because result1 has more results
 			suite.Equal([]int64{0, 1, 2, 3, 4}, result.GetIds().GetIntId().GetData())
-			suite.Equal([]int64{11, 22, 11, 22, 33}, result.GetFieldsData()[0].GetScalars().GetLongData().Data)
+			intFieldData, has := getFieldData(result, Int64FieldID)
+			suite.Require().True(has)
+			suite.Equal([]int64{11, 22, 11, 22, 33}, intFieldData.GetScalars().GetLongData().Data)
+			vectorFieldData, has := getFieldData(result, FloatVectorFieldID)
+			suite.Require().True(has)
 			suite.InDeltaSlice([]float32{1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 11, 22, 33, 44},
-				result.FieldsData[1].GetVectors().GetFloatVector().Data, 10e-10)
+				vectorFieldData.GetVectors().GetFloatVector().Data, 10e-10)
 		})
 		suite.Run("merge stop unlimited", func() {
 			result1.HasMoreResult = false
@@ -527,13 +581,17 @@ func (suite *ResultSuite) TestResult_MergeStopForBestResult() {
 			result, err := MergeSegcoreRetrieveResults(context.Background(), []*segcorepb.RetrieveResults{result1, result2},
 				NewMergeParam(typeutil.Unlimited, make([]int64, 0), nil, true))
 			suite.NoError(err)
-			suite.Equal(2, len(result.GetFieldsData()))
+			suite.Equal(3, len(result.GetFieldsData()))
 			// as result1 and result2 don't have better results neither
 			// we can reduce all available result into the reduced result
 			suite.Equal([]int64{0, 1, 2, 3, 4, 6}, result.GetIds().GetIntId().GetData())
-			suite.Equal([]int64{11, 22, 11, 22, 33, 33}, result.GetFieldsData()[0].GetScalars().GetLongData().Data)
+			intFieldData, has := getFieldData(result, Int64FieldID)
+			suite.Require().True(has)
+			suite.Equal([]int64{11, 22, 11, 22, 33, 33}, intFieldData.GetScalars().GetLongData().Data)
+			vectorFieldData, has := getFieldData(result, FloatVectorFieldID)
+			suite.Require().True(has)
 			suite.InDeltaSlice([]float32{1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 11, 22, 33, 44, 11, 22, 33, 44},
-				result.FieldsData[1].GetVectors().GetFloatVector().Data, 10e-10)
+				vectorFieldData.GetVectors().GetFloatVector().Data, 10e-10)
 		})
 		suite.Run("merge stop one limited", func() {
 			result1.HasMoreResult = true
@@ -541,12 +599,16 @@ func (suite *ResultSuite) TestResult_MergeStopForBestResult() {
 			result, err := MergeSegcoreRetrieveResults(context.Background(), []*segcorepb.RetrieveResults{result1, result2},
 				NewMergeParam(typeutil.Unlimited, make([]int64, 0), nil, true))
 			suite.NoError(err)
-			suite.Equal(2, len(result.GetFieldsData()))
+			suite.Equal(3, len(result.GetFieldsData()))
 			// as result1 may have better results, stop reducing when draining it
 			suite.Equal([]int64{0, 1, 2, 3, 4}, result.GetIds().GetIntId().GetData())
-			suite.Equal([]int64{11, 22, 11, 22, 33}, result.GetFieldsData()[0].GetScalars().GetLongData().Data)
+			intFieldData, has := getFieldData(result, Int64FieldID)
+			suite.Require().True(has)
+			suite.Equal([]int64{11, 22, 11, 22, 33}, intFieldData.GetScalars().GetLongData().Data)
+			vectorFieldData, has := getFieldData(result, FloatVectorFieldID)
+			suite.Require().True(has)
 			suite.InDeltaSlice([]float32{1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 11, 22, 33, 44},
-				result.FieldsData[1].GetVectors().GetFloatVector().Data, 10e-10)
+				vectorFieldData.GetVectors().GetFloatVector().Data, 10e-10)
 		})
 	})
 
@@ -576,11 +638,15 @@ func (suite *ResultSuite) TestResult_MergeStopForBestResult() {
 		result, err := MergeInternalRetrieveResult(context.Background(), []*internalpb.RetrieveResults{result1, result2},
 			NewMergeParam(3, make([]int64, 0), nil, true))
 		suite.NoError(err)
-		suite.Equal(2, len(result.GetFieldsData()))
+		suite.Equal(3, len(result.GetFieldsData()))
 		suite.Equal([]int64{0, 2, 4, 6, 7}, result.GetIds().GetIntId().GetData())
-		suite.Equal([]int64{11, 11, 22, 22, 33}, result.GetFieldsData()[0].GetScalars().GetLongData().Data)
+		intFieldData, has := getFieldData(result, Int64FieldID)
+		suite.Require().True(has)
+		suite.Equal([]int64{11, 11, 22, 22, 33}, intFieldData.GetScalars().GetLongData().Data)
+		vectorFieldData, has := getFieldData(result, FloatVectorFieldID)
+		suite.Require().True(has)
 		suite.InDeltaSlice([]float32{1, 2, 3, 4, 1, 2, 3, 4, 5, 6, 7, 8, 5, 6, 7, 8, 11, 22, 33, 44},
-			result.FieldsData[1].GetVectors().GetFloatVector().Data, 10e-10)
+			vectorFieldData.GetVectors().GetFloatVector().Data, 10e-10)
 	})
 
 	suite.Run("test stop internal merge for best with early termination", func() {
@@ -594,6 +660,12 @@ func (suite *ResultSuite) TestResult_MergeStopForBestResult() {
 			},
 			FieldsData: fieldDataArray1,
 		}
+		var drainDataArray2 []*schemapb.FieldData
+		drainDataArray2 = append(drainDataArray2, genFieldData(common.TimeStampFieldName, common.TimeStampField, schemapb.DataType_Int64, []int64{2000}, 1))
+		drainDataArray2 = append(drainDataArray2, genFieldData(Int64FieldName, Int64FieldID,
+			schemapb.DataType_Int64, Int64Array[0:1], 1))
+		drainDataArray2 = append(drainDataArray2, genFieldData(FloatVectorFieldName, FloatVectorFieldID,
+			schemapb.DataType_FloatVector, FloatVector[0:4], Dim))
 		result2 := &internalpb.RetrieveResults{
 			Ids: &schemapb.IDs{
 				IdField: &schemapb.IDs_IntId{
@@ -602,7 +674,7 @@ func (suite *ResultSuite) TestResult_MergeStopForBestResult() {
 					},
 				},
 			},
-			FieldsData: fieldDataArray2,
+			FieldsData: drainDataArray2,
 		}
 		suite.Run("test drain one result without more results", func() {
 			result1.HasMoreResult = false
@@ -610,7 +682,7 @@ func (suite *ResultSuite) TestResult_MergeStopForBestResult() {
 			result, err := MergeInternalRetrieveResult(context.Background(), []*internalpb.RetrieveResults{result1, result2},
 				NewMergeParam(3, make([]int64, 0), nil, true))
 			suite.NoError(err)
-			suite.Equal(2, len(result.GetFieldsData()))
+			suite.Equal(3, len(result.GetFieldsData()))
 			suite.Equal([]int64{0, 2, 4, 7}, result.GetIds().GetIntId().GetData())
 		})
 		suite.Run("test drain one result with more results", func() {
@@ -619,7 +691,7 @@ func (suite *ResultSuite) TestResult_MergeStopForBestResult() {
 			result, err := MergeInternalRetrieveResult(context.Background(), []*internalpb.RetrieveResults{result1, result2},
 				NewMergeParam(3, make([]int64, 0), nil, true))
 			suite.NoError(err)
-			suite.Equal(2, len(result.GetFieldsData()))
+			suite.Equal(3, len(result.GetFieldsData()))
 			suite.Equal([]int64{0, 2}, result.GetIds().GetIntId().GetData())
 		})
 	})

--- a/pkg/util/typeutil/schema.go
+++ b/pkg/util/typeutil/schema.go
@@ -1097,6 +1097,10 @@ type ResultWithID interface {
 	GetHasMoreResult() bool
 }
 
+type ResultWithTimestamp interface {
+	GetTimestamps() []int64
+}
+
 // SelectMinPK select the index of the minPK in results T of the cursors.
 func SelectMinPK[T ResultWithID](results []T, cursors []int64) (int, bool) {
 	var (
@@ -1127,6 +1131,54 @@ func SelectMinPK[T ResultWithID](results []T, cursors []int64) (int, bool) {
 			if pk < minIntPK {
 				minIntPK = pk
 				sel = i
+			}
+		default:
+			continue
+		}
+	}
+
+	return sel, drainResult
+}
+
+func SelectMinPKWithTimestamp[T interface {
+	ResultWithID
+	ResultWithTimestamp
+}](results []T, cursors []int64) (int, bool) {
+	var (
+		sel                = -1
+		drainResult        = false
+		maxTimestamp int64 = 0
+		minIntPK     int64 = math.MaxInt64
+
+		firstStr = true
+		minStrPK string
+	)
+	for i, cursor := range cursors {
+		timestamps := results[i].GetTimestamps()
+		// if cursor has run out of all results from one result and this result has more matched results
+		// in this case we have tell reduce to stop because better results may be retrieved in the following iteration
+		if int(cursor) >= GetSizeOfIDs(results[i].GetIds()) && (results[i].GetHasMoreResult()) {
+			drainResult = true
+			continue
+		}
+
+		pkInterface := GetPK(results[i].GetIds(), cursor)
+
+		switch pk := pkInterface.(type) {
+		case string:
+			ts := timestamps[cursor]
+			if firstStr || pk < minStrPK || (pk == minStrPK && ts > maxTimestamp) {
+				firstStr = false
+				minStrPK = pk
+				sel = i
+				maxTimestamp = ts
+			}
+		case int64:
+			ts := timestamps[cursor]
+			if pk < minIntPK || (pk == minIntPK && ts > maxTimestamp) {
+				minIntPK = pk
+				sel = i
+				maxTimestamp = ts
 			}
 		default:
 			continue


### PR DESCRIPTION
Cherry-pick from master
pr: #33936
See also #33883