### PR TITLE
fix: Do compressBinlog to fix logID 0

### DIFF
--- a/internal/metastore/kv/datacoord/kv_catalog.go
+++ b/internal/metastore/kv/datacoord/kv_catalog.go
@@ -218,24 +218,21 @@ func (kc *Catalog) applyBinlogInfo(segments []*datapb.SegmentInfo, insertLogs, d
 		if len(segmentInfo.Binlogs) == 0 {
 			segmentInfo.Binlogs = insertLogs[segmentInfo.ID]
 		}
-		err = binlog.CompressFieldBinlogs(segmentInfo.Binlogs)
-		if err != nil {
+		if err = binlog.CompressFieldBinlogs(segmentInfo.Binlogs); err != nil {
 			return err
 		}
 
 		if len(segmentInfo.Deltalogs) == 0 {
 			segmentInfo.Deltalogs = deltaLogs[segmentInfo.ID]
 		}
-		err = binlog.CompressFieldBinlogs(segmentInfo.Deltalogs)
-		if err != nil {
+		if err = binlog.CompressFieldBinlogs(segmentInfo.Deltalogs); err != nil {
 			return err
 		}
 
 		if len(segmentInfo.Statslogs) == 0 {
 			segmentInfo.Statslogs = statsLogs[segmentInfo.ID]
 		}
-		err = binlog.CompressFieldBinlogs(segmentInfo.Statslogs)
-		if err != nil {
+		if err = binlog.CompressFieldBinlogs(segmentInfo.Statslogs); err != nil {
 			return err
 		}
 	}

--- a/internal/metastore/kv/datacoord/kv_catalog.go
+++ b/internal/metastore/kv/datacoord/kv_catalog.go
@@ -217,29 +217,26 @@ func (kc *Catalog) applyBinlogInfo(segments []*datapb.SegmentInfo, insertLogs, d
 	for _, segmentInfo := range segments {
 		if len(segmentInfo.Binlogs) == 0 {
 			segmentInfo.Binlogs = insertLogs[segmentInfo.ID]
-		} else {
-			err = binlog.CompressFieldBinlogs(segmentInfo.Binlogs)
-			if err != nil {
-				return err
-			}
+		}
+		err = binlog.CompressFieldBinlogs(segmentInfo.Binlogs)
+		if err != nil {
+			return err
 		}
 
 		if len(segmentInfo.Deltalogs) == 0 {
 			segmentInfo.Deltalogs = deltaLogs[segmentInfo.ID]
-		} else {
-			err = binlog.CompressFieldBinlogs(segmentInfo.Deltalogs)
-			if err != nil {
-				return err
-			}
+		}
+		err = binlog.CompressFieldBinlogs(segmentInfo.Deltalogs)
+		if err != nil {
+			return err
 		}
 
 		if len(segmentInfo.Statslogs) == 0 {
 			segmentInfo.Statslogs = statsLogs[segmentInfo.ID]
-		} else {
-			err = binlog.CompressFieldBinlogs(segmentInfo.Statslogs)
-			if err != nil {
-				return err
-			}
+		}
+		err = binlog.CompressFieldBinlogs(segmentInfo.Statslogs)
+		if err != nil {
+			return err
 		}
 	}
 	return nil


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/34059

Do compressBinlog to ensure that reloadFromKV will fill binlogs' logID after datacoord restarts.