### PR TITLE
fix: Do compressBinlog to fix logID 0 (#34060)

### DIFF
--- a/internal/metastore/kv/datacoord/kv_catalog.go
+++ b/internal/metastore/kv/datacoord/kv_catalog.go
@@ -220,24 +220,21 @@ func (kc *Catalog) applyBinlogInfo(segments []*datapb.SegmentInfo, insertLogs, d
 		if len(segmentInfo.Binlogs) == 0 {
 			segmentInfo.Binlogs = insertLogs[segmentInfo.ID]
 		}
-		err = binlog.CompressFieldBinlogs(segmentInfo.Binlogs)
-		if err != nil {
+		if err = binlog.CompressFieldBinlogs(segmentInfo.Binlogs); err != nil {
 			return err
 		}
 
 		if len(segmentInfo.Deltalogs) == 0 {
 			segmentInfo.Deltalogs = deltaLogs[segmentInfo.ID]
 		}
-		err = binlog.CompressFieldBinlogs(segmentInfo.Deltalogs)
-		if err != nil {
+		if err = binlog.CompressFieldBinlogs(segmentInfo.Deltalogs); err != nil {
 			return err
 		}
 
 		if len(segmentInfo.Statslogs) == 0 {
 			segmentInfo.Statslogs = statsLogs[segmentInfo.ID]
 		}
-		err = binlog.CompressFieldBinlogs(segmentInfo.Statslogs)
-		if err != nil {
+		if err = binlog.CompressFieldBinlogs(segmentInfo.Statslogs); err != nil {
 			return err
 		}
 	}

--- a/internal/metastore/kv/datacoord/kv_catalog.go
+++ b/internal/metastore/kv/datacoord/kv_catalog.go
@@ -219,29 +219,26 @@ func (kc *Catalog) applyBinlogInfo(segments []*datapb.SegmentInfo, insertLogs, d
 	for _, segmentInfo := range segments {
 		if len(segmentInfo.Binlogs) == 0 {
 			segmentInfo.Binlogs = insertLogs[segmentInfo.ID]
-		} else {
-			err = binlog.CompressFieldBinlogs(segmentInfo.Binlogs)
-			if err != nil {
-				return err
-			}
+		}
+		err = binlog.CompressFieldBinlogs(segmentInfo.Binlogs)
+		if err != nil {
+			return err
 		}
 
 		if len(segmentInfo.Deltalogs) == 0 {
 			segmentInfo.Deltalogs = deltaLogs[segmentInfo.ID]
-		} else {
-			err = binlog.CompressFieldBinlogs(segmentInfo.Deltalogs)
-			if err != nil {
-				return err
-			}
+		}
+		err = binlog.CompressFieldBinlogs(segmentInfo.Deltalogs)
+		if err != nil {
+			return err
 		}
 
 		if len(segmentInfo.Statslogs) == 0 {
 			segmentInfo.Statslogs = statsLogs[segmentInfo.ID]
-		} else {
-			err = binlog.CompressFieldBinlogs(segmentInfo.Statslogs)
-			if err != nil {
-				return err
-			}
+		}
+		err = binlog.CompressFieldBinlogs(segmentInfo.Statslogs)
+		if err != nil {
+			return err
 		}
 	}
 	return nil


### PR DESCRIPTION
Do compressBinlog to ensure that reloadFromKV will fill binlogs' logID after datacoord restarts.

issue: https://github.com/milvus-io/milvus/issues/34059

pr: https://github.com/milvus-io/milvus/pull/34060