### PR TITLE
fix: add build-tags at golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,9 @@ run:
     - cmake_build
   skip-files:
     - partial_search_test.go
+  build-tags:
+    - dynamic
+    - test
 
 linters:
   disable-all: true


### PR DESCRIPTION
issue: #33132

caused by introducing conditional compile file in async cgo. 