### PR TITLE
enhance: Remove version from docker compose file

### DIFF
--- a/deployments/docker/dev/docker-compose-apple-silicon.yml
+++ b/deployments/docker/dev/docker-compose-apple-silicon.yml
@@ -1,4 +1,3 @@
-version: '3.5'
 
 services:
   etcd:

--- a/deployments/docker/dev/docker-compose.yml
+++ b/deployments/docker/dev/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.5'
 
 services:
   etcd:

--- a/deployments/docker/gpu/standalone/docker-compose.yml
+++ b/deployments/docker/gpu/standalone/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.5'
 
 services:
   etcd:

--- a/deployments/docker/standalone/docker-compose.yml
+++ b/deployments/docker/standalone/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.5'
 
 services:
   etcd:


### PR DESCRIPTION
When the latest docker (version  25.0.3) is used to start milvus, the warning message comes up

` WARN[0000] docker-compose.yml: `version` is obsolete`

-----

Per this doc https://github.com/compose-spec/compose-spec/blob/master/spec.md#version-top-level-element-obsolete

> The top-level version property is defined by the Compose Specification for backward compatibility. It is only informative you'll receive a warning message that it is obsolete if used.

> Compose doesn't use version to select an exact schema to validate the Compose file, but prefers the most recent schema when it's implemented.

And there is one related issue https://github.com/docker/compose/issues/11628

