### PR TITLE
fix: Fix backup channel meta is empty

### DIFF
--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -199,6 +199,7 @@ func (s *Server) Flush(ctx context.Context, req *datapb.FlushRequest) (*datapb.F
 		TimeOfSeal:      timeOfSeal.Unix(),
 		FlushSegmentIDs: flushSegmentIDs,
 		FlushTs:         ts,
+		ChannelCps:      channelCPs,
 	}, nil
 }
 


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/34061
pr: https://github.com/milvus-io/milvus/pull/32044
/kind bug