### PR TITLE
enhance: add delta log stream new format reader and writer

### DIFF
--- a/internal/storage/event_data.go
+++ b/internal/storage/event_data.go
@@ -36,6 +36,11 @@ const (
 	nullableKey     = "nullable"
 )
 
+const version = "version"
+
+// mark useMultiFieldFormat if there are multi fields in a log file
+const MULTI_FIELD = "MULTI_FIELD"
+
 type descriptorEventData struct {
 	DescriptorEventDataFixPart
 	ExtraLength       int32

--- a/internal/storage/event_writer.go
+++ b/internal/storage/event_writer.go
@@ -212,6 +212,16 @@ func newDescriptorEvent() *descriptorEvent {
 	}
 }
 
+func NewBaseDescriptorEvent(collectionID int64, partitionID int64, segmentID int64) *descriptorEvent {
+	de := newDescriptorEvent()
+	de.CollectionID = collectionID
+	de.PartitionID = partitionID
+	de.SegmentID = segmentID
+	de.StartTimestamp = 0
+	de.EndTimestamp = 0
+	return de
+}
+
 func newInsertEventWriter(dataType schemapb.DataType, nullable bool, dim ...int) (*insertEventWriter, error) {
 	var payloadWriter PayloadWriterInterface
 	var err error

--- a/internal/storage/serde.go
+++ b/internal/storage/serde.go
@@ -35,6 +35,7 @@ import (
 
 type Record interface {
 	Schema() map[FieldID]schemapb.DataType
+	ArrowSchema() *arrow.Schema
 	Column(i FieldID) arrow.Array
 	Len() int
 	Release()
@@ -81,6 +82,14 @@ func (r *compositeRecord) Release() {
 
 func (r *compositeRecord) Schema() map[FieldID]schemapb.DataType {
 	return r.schema
+}
+
+func (r *compositeRecord) ArrowSchema() *arrow.Schema {
+	var fields []arrow.Field
+	for _, rec := range r.recs {
+		fields = append(fields, rec.Schema().Field(0))
+	}
+	return arrow.NewSchema(fields, nil)
 }
 
 type serdeEntry struct {
@@ -575,6 +584,10 @@ func (r *selectiveRecord) Schema() map[FieldID]schemapb.DataType {
 	return r.schema
 }
 
+func (r *selectiveRecord) ArrowSchema() *arrow.Schema {
+	return r.r.ArrowSchema()
+}
+
 func (r *selectiveRecord) Column(i FieldID) arrow.Array {
 	if i == r.selectedFieldId {
 		return r.r.Column(i)
@@ -663,9 +676,10 @@ func (sfw *singleFieldRecordWriter) Close() {
 
 func newSingleFieldRecordWriter(fieldId FieldID, field arrow.Field, writer io.Writer) (*singleFieldRecordWriter, error) {
 	schema := arrow.NewSchema([]arrow.Field{field}, nil)
+
+	// use writer properties as same as payload writer's for now
 	fw, err := pqarrow.NewFileWriter(schema, writer,
 		parquet.NewWriterProperties(
-			parquet.WithMaxRowGroupLength(math.MaxInt64), // No additional grouping for now.
 			parquet.WithCompression(compress.Codecs.Zstd),
 			parquet.WithCompressionLevel(3)),
 		pqarrow.DefaultWriterProps())
@@ -676,6 +690,46 @@ func newSingleFieldRecordWriter(fieldId FieldID, field arrow.Field, writer io.Wr
 		fw:      fw,
 		fieldId: fieldId,
 		schema:  schema,
+	}, nil
+}
+
+var _ RecordWriter = (*multiFieldRecordWriter)(nil)
+
+type multiFieldRecordWriter struct {
+	fw       *pqarrow.FileWriter
+	fieldIds []FieldID
+	schema   *arrow.Schema
+
+	numRows int
+}
+
+func (mfw *multiFieldRecordWriter) Write(r Record) error {
+	mfw.numRows += r.Len()
+	columns := make([]arrow.Array, len(mfw.fieldIds))
+	for i, fieldId := range mfw.fieldIds {
+		columns[i] = r.Column(fieldId)
+	}
+	rec := array.NewRecord(mfw.schema, columns, int64(r.Len()))
+	defer rec.Release()
+	return mfw.fw.WriteBuffered(rec)
+}
+
+func (mfw *multiFieldRecordWriter) Close() {
+	mfw.fw.Close()
+}
+
+func newMultiFieldRecordWriter(fieldIds []FieldID, fields []arrow.Field, writer io.Writer) (*multiFieldRecordWriter, error) {
+	schema := arrow.NewSchema(fields, nil)
+	fw, err := pqarrow.NewFileWriter(schema, writer,
+		parquet.NewWriterProperties(parquet.WithMaxRowGroupLength(math.MaxInt64)), // No additional grouping for now.
+		pqarrow.DefaultWriterProps())
+	if err != nil {
+		return nil, err
+	}
+	return &multiFieldRecordWriter{
+		fw:       fw,
+		fieldIds: fieldIds,
+		schema:   schema,
 	}, nil
 }
 
@@ -771,6 +825,10 @@ func (sr *simpleArrowRecord) Len() int {
 
 func (sr *simpleArrowRecord) Release() {
 	sr.r.Release()
+}
+
+func (sr *simpleArrowRecord) ArrowSchema() *arrow.Schema {
+	return sr.r.Schema()
 }
 
 func newSimpleArrowRecord(r arrow.Record, schema map[FieldID]schemapb.DataType, field2Col map[FieldID]int) *simpleArrowRecord {

--- a/internal/storage/serde_test.go
+++ b/internal/storage/serde_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/apache/arrow/go/v12/arrow"
 	"github.com/apache/arrow/go/v12/arrow/array"
 	"github.com/apache/arrow/go/v12/arrow/memory"
 	"github.com/stretchr/testify/assert"
@@ -98,6 +99,37 @@ func TestSerDe(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestArrowSchema(t *testing.T) {
+	fields := []arrow.Field{{Name: "1", Type: arrow.BinaryTypes.String, Nullable: true}}
+	builder := array.NewBuilder(memory.DefaultAllocator, arrow.BinaryTypes.String)
+	builder.AppendValueFromString("1")
+	record := array.NewRecord(arrow.NewSchema(fields, nil), []arrow.Array{builder.NewArray()}, 1)
+	t.Run("test composite record", func(t *testing.T) {
+		cr := &compositeRecord{
+			recs:   make(map[FieldID]arrow.Record, 1),
+			schema: make(map[FieldID]schemapb.DataType, 1),
+		}
+		cr.recs[0] = record
+		cr.schema[0] = schemapb.DataType_String
+		expected := arrow.NewSchema(fields, nil)
+		assert.Equal(t, expected, cr.ArrowSchema())
+	})
+
+	t.Run("test simple arrow record", func(t *testing.T) {
+		cr := &simpleArrowRecord{
+			r:         record,
+			schema:    make(map[FieldID]schemapb.DataType, 1),
+			field2Col: make(map[FieldID]int, 1),
+		}
+		cr.schema[0] = schemapb.DataType_String
+		expected := arrow.NewSchema(fields, nil)
+		assert.Equal(t, expected, cr.ArrowSchema())
+
+		sr := newSelectiveRecord(cr, 0)
+		assert.Equal(t, expected, sr.ArrowSchema())
+	})
 }
 
 func BenchmarkDeserializeReader(b *testing.B) {


### PR DESCRIPTION
issue: #34123

Benchmark case: The benchmark run the go benchmark function `BenchmarkDeltalogFormat` which is put in the Files changed. It tests the performance of serializing and deserializing from two different data formats under a 10 million delete log dataset.

Metrics: The benchmarks measure the average time taken per operation (ns/op), memory allocated per operation (MB/op), and the number of memory allocations per operation (allocs/op).
| Test Name                       | Avg Time (ns/op) | Time Comparison | Memory Allocation (MB/op) | Memory Comparison | Allocation Count (allocs/op) | Allocation Comparison |
|---------------------------------|------------------|-----------------|---------------------------|-------------------|------------------------------|------------------------|
| one_string_format_reader        | 2,781,990,000    | Baseline        | 2,422                     | Baseline          | 20,336,539                   | Baseline               |
| pk_ts_separate_format_reader    | 480,682,639      | -82.72%         | 1,765                     | -27.14%           | 20,396,958                   | +0.30%                 |
| one_string_format_writer        | 5,483,436,041    | Baseline        | 13,900                    | Baseline          | 70,057,473                   | Baseline               |
| pk_and_ts_separate_format_writer| 798,591,584      | -85.43%         | 2,178                     | -84.34%           | 30,270,488                   | -56.78%                |

Both read and write operations show significant improvements in both speed and memory allocation.
