### PR TITLE
enhance: [skip e2e] Check 'Build and Test' steps success for mergify

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -41,6 +41,9 @@ pull_request_rules:
           - base=master
           - base~=^2(\.\d+){1,2}$
       - 'status-success=Build and test AMD64 Ubuntu 20.04'
+      - 'status-success=UT for Cpp'
+      - 'status-success=UT for Go'
+      - 'status-success=Integration Test'
       # - 'status-success=Code Checker AMD64 Ubuntu 20.04'
       # - 'status-success=Code Checker MacOS 12'
       # - 'status-success=Code Checker Amazonlinux 2023'
@@ -56,6 +59,9 @@ pull_request_rules:
       - base~=^2(\.\d+){2}$
       # - 'status-success=Code Checker AMD64 Ubuntu 20.04'
       - 'status-success=Build and test AMD64 Ubuntu 20.04'
+      - 'status-success=UT for Cpp'
+      - 'status-success=UT for Go'
+      - 'status-success=Integration Test'
       # - 'status-success=Code Checker MacOS 12'
       # - 'status-success=Code Checker CentOS 7'
       - 'status-success=cpu-e2e'
@@ -256,6 +262,9 @@ pull_request_rules:
       - title~=\[skip e2e\]
       # - 'status-success=Code Checker AMD64 Ubuntu 20.04'
       - 'status-success=Build and test AMD64 Ubuntu 20.04'
+      - 'status-success=UT for Cpp'
+      - 'status-success=UT for Go'
+      - 'status-success=Integration Test'
       # - 'status-success=Code Checker MacOS 12'
       # - 'status-success=Code Checker Amazonlinux 2023'
       - *source_code_files
@@ -270,6 +279,9 @@ pull_request_rules:
       - title~=\[skip e2e\]
       # - 'status-success=Code Checker AMD64 Ubuntu 20.04'
       - 'status-success=Build and test AMD64 Ubuntu 20.04'
+      - 'status-success=UT for Cpp'
+      - 'status-success=UT for Go'
+      - 'status-success=Integration Test'
       # - 'status-success=Code Checker MacOS 12'
       - *source_code_files
     actions:
@@ -302,6 +314,9 @@ pull_request_rules:
       - or:
           # - 'status-success!=Code Checker AMD64 Ubuntu 20.04'
           - 'status-success!=Build and test AMD64 Ubuntu 20.04'
+          - 'status-success!=UT for Cpp'
+          - 'status-success!=UT for Go'
+          - 'status-success!=Integration Test'
           # - 'status-success!=Code Checker MacOS 12'
           # - 'status-success!=Code Checker Amazonlinux 2023'
     actions:
@@ -317,6 +332,9 @@ pull_request_rules:
       - or:
           # - 'status-success!=Code Checker AMD64 Ubuntu 20.04'
           - 'status-success!=Build and test AMD64 Ubuntu 20.04'
+          - 'status-success!=UT for Cpp'
+          - 'status-success!=UT for Go'
+          - 'status-success!=Integration Test'
           # - 'status-success!=Code Checker MacOS 12'
           # - 'status-success!=Code Checker CentOS 7'
     actions:


### PR DESCRIPTION
Since 'Build and test' action is separated into several steps, each failure/success status shall cause different behavior for mergify rule

This PR check cpp/go ut and intergration tests for 'Build & test' actions to add or remove labels.