### PR TITLE
fix: [2.4] Make querycoord panick when rg metastore sync fail (#34106)

### DIFF
--- a/internal/querycoordv2/meta/resource_manager.go
+++ b/internal/querycoordv2/meta/resource_manager.go
@@ -820,12 +820,11 @@ func (rm *ResourceManager) unassignNode(node int64) (string, error) {
 		mrg.UnassignNode(node)
 		rg := mrg.ToResourceGroup()
 		if err := rm.catalog.SaveResourceGroup(rg.GetMeta()); err != nil {
-			log.Warn("unassign node from resource group",
+			log.Fatal("unassign node from resource group",
 				zap.String("rgName", rg.GetName()),
 				zap.Int64("node", node),
 				zap.Error(err),
 			)
-			return "", merr.WrapErrResourceGroupServiceAvailable()
 		}
 
 		// Commit updates to memory.


### PR DESCRIPTION
Cherry-pick from master
pr: #34106
See also #34047

When `unassignNode` sync resource group with node removed failed