### PR TITLE
enhance: Use `GenericValues` when pk values are isomorphic

### DIFF
--- a/internal/core/src/exec/expression/TermExpr.cpp
+++ b/internal/core/src/exec/expression/TermExpr.cpp
@@ -150,8 +150,12 @@ PhyTermFilterExpr::InitPkCacheOffset() {
                 return;
             }
             auto dst_ids = id_array->mutable_int_id();
-            for (const auto& id : expr_->vals_) {
-                dst_ids->add_data(GetValueFromProto<int64_t>(id));
+            if (expr_->isomorphic_) {
+                dst_ids->CopyFrom(expr_->iso_vals_.int64_vals());
+            } else {
+                for (const auto& id : expr_->vals_) {
+                    dst_ids->add_data(GetValueFromProto<int64_t>(id));
+                }
             }
             break;
         }
@@ -160,8 +164,12 @@ PhyTermFilterExpr::InitPkCacheOffset() {
                 return;
             }
             auto dst_ids = id_array->mutable_str_id();
-            for (const auto& id : expr_->vals_) {
-                dst_ids->add_data(GetValueFromProto<std::string>(id));
+            if (expr_->isomorphic_) {
+                dst_ids->CopyFrom(expr_->iso_vals_.string_vals());
+            } else{
+                for (const auto& id : expr_->vals_) {
+                    dst_ids->add_data(GetValueFromProto<std::string>(id));
+                }
             }
             break;
         }

--- a/internal/core/src/expr/ITypeExpr.h
+++ b/internal/core/src/expr/ITypeExpr.h
@@ -431,7 +431,21 @@ class TermFilterExpr : public ITypeFilterExpr {
         : ITypeFilterExpr(),
           column_(column),
           vals_(vals),
-          is_in_field_(is_in_field) {
+          is_in_field_(is_in_field),
+          isomorphic_(false) {
+    }
+
+    explicit TermFilterExpr(const ColumnInfo& column,
+                            const std::vector<proto::plan::GenericValue>& vals,
+                            bool is_in_field,
+                            const proto::plan::GenericValues& iso_vals,
+                            bool isomorphic)
+        : ITypeFilterExpr(),
+          column_(column),
+          vals_(vals),
+          is_in_field_(is_in_field),
+          iso_vals_(iso_vals), 
+          isomorphic_(isomorphic){
     }
 
     std::string
@@ -462,6 +476,8 @@ class TermFilterExpr : public ITypeFilterExpr {
     const ColumnInfo column_;
     const std::vector<proto::plan::GenericValue> vals_;
     const bool is_in_field_;
+    const bool isomorphic_;
+    const proto::plan::GenericValues iso_vals_; 
 };
 
 class LogicalBinaryExpr : public ITypeFilterExpr {

--- a/internal/core/src/query/PlanProto.cpp
+++ b/internal/core/src/query/PlanProto.cpp
@@ -571,7 +571,7 @@ ProtoParser::ParseTermExprs(const proto::plan::TermExpr& expr_pb) {
         values.emplace_back(expr_pb.values(i));
     }
     return std::make_shared<expr::TermFilterExpr>(
-        columnInfo, values, expr_pb.is_in_field());
+        columnInfo, values, expr_pb.is_in_field(), expr_pb.iso_values(), expr_pb.isomorphic());
 }
 
 ExprPtr

--- a/internal/core/src/segcore/InsertRecord.h
+++ b/internal/core/src/segcore/InsertRecord.h
@@ -116,10 +116,6 @@ class OffsetOrderedMap : public OffsetMap {
                bool false_filtered_out) const override {
         std::shared_lock<std::shared_mutex> lck(mtx_);
 
-        // if (limit == Unlimited || limit == NoLimit) {
-        //     limit = map_.size();
-        // }
-
         // TODO: we can't retrieve pk by offset very conveniently.
         //      Selectivity should be done outside.
         return find_first_by_index(limit, bitset, false_filtered_out);

--- a/internal/proto/plan.proto
+++ b/internal/proto/plan.proto
@@ -48,6 +48,16 @@ message GenericValue {
   };
 }
 
+message GenericValues {
+  oneof val {
+    schema.BoolArray bool_vals = 1;
+    schema.LongArray int64_vals = 2;
+    schema.DoubleArray double_vals = 3;
+    schema.StringArray string_vals = 4;
+    schema.ArrayArray array_vals = 5;
+  };
+}
+
 message Array {
   repeated GenericValue array = 1;
   bool same_type = 2;
@@ -110,6 +120,8 @@ message TermExpr {
   ColumnInfo column_info = 1;
   repeated GenericValue values = 2;
   bool is_in_field = 3;
+  GenericValues iso_values = 4;
+  bool isomorphic = 5;
 }
 
 message JSONContainsExpr {


### PR DESCRIPTION
Related to #34177
Benchmarking marshaling plan node with slice of generic values versus GenericValues struct:
```
cpu: Intel(R) Core(TM) i7-8700 CPU @ 3.20GHz
BenchmarkMarshalGVInt       1848            545205 ns/op           37520 B/op       2010 allocs/op
BenchmarkMarshalGVsInt    116082             10084 ns/op            2256 B/op         14 allocs/op
BenchmarkMarshalGVStr       2228            539477 ns/op           39056 B/op       2010 allocs/op
BenchmarkMarshalGVsStr     54520             21224 ns/op            5584 B/op         14 allocs/op
PASS
```