### PR TITLE
fix: [2.4] Wrap init segcore tracing with golang timeout (#33494)

### DIFF
--- a/internal/core/src/common/Tracer.cpp
+++ b/internal/core/src/common/Tracer.cpp
@@ -55,13 +55,13 @@ initTelemetry(const TraceConfig& cfg) {
         opts.transport_format = jaeger::TransportFormat::kThriftHttp;
         opts.endpoint = cfg.jaegerURL;
         exporter = jaeger::JaegerExporterFactory::Create(opts);
-        LOG_INFO("init jaeger exporter, endpoint:", opts.endpoint);
+        LOG_INFO("init jaeger exporter, endpoint: {}", opts.endpoint);
     } else if (cfg.exporter == "otlp") {
         auto opts = otlp::OtlpGrpcExporterOptions{};
         opts.endpoint = cfg.otlpEndpoint;
         opts.use_ssl_credentials = cfg.oltpSecure;
         exporter = otlp::OtlpGrpcExporterFactory::Create(opts);
-        LOG_INFO("init otlp exporter, endpoint:", opts.endpoint);
+        LOG_INFO("init otlp exporter, endpoint: {}", opts.endpoint);
     } else {
         LOG_INFO("Empty Trace");
         enable_trace = false;

--- a/internal/util/initcore/init_core_test.go
+++ b/internal/util/initcore/init_core_test.go
@@ -19,6 +19,8 @@ package initcore
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 )
 
@@ -28,4 +30,18 @@ func TestTracer(t *testing.T) {
 
 	paramtable.Get().Save(paramtable.Get().TraceCfg.Exporter.Key, "stdout")
 	ResetTraceConfig(paramtable.Get())
+}
+
+func TestOtlpHang(t *testing.T) {
+	paramtable.Init()
+	InitTraceConfig(paramtable.Get())
+
+	paramtable.Get().Save(paramtable.Get().TraceCfg.Exporter.Key, "otlp")
+	paramtable.Get().Save(paramtable.Get().TraceCfg.InitTimeoutSeconds.Key, "1")
+	defer paramtable.Get().Reset(paramtable.Get().TraceCfg.Exporter.Key)
+	defer paramtable.Get().Reset(paramtable.Get().TraceCfg.InitTimeoutSeconds.Key)
+
+	assert.Panics(t, func() {
+		ResetTraceConfig(paramtable.Get())
+	})
 }

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -777,11 +777,12 @@ func (t *gpuConfig) init(base *BaseTable) {
 }
 
 type traceConfig struct {
-	Exporter       ParamItem `refreshable:"false"`
-	SampleFraction ParamItem `refreshable:"false"`
-	JaegerURL      ParamItem `refreshable:"false"`
-	OtlpEndpoint   ParamItem `refreshable:"false"`
-	OtlpSecure     ParamItem `refreshable:"false"`
+	Exporter           ParamItem `refreshable:"false"`
+	SampleFraction     ParamItem `refreshable:"false"`
+	JaegerURL          ParamItem `refreshable:"false"`
+	OtlpEndpoint       ParamItem `refreshable:"false"`
+	OtlpSecure         ParamItem `refreshable:"false"`
+	InitTimeoutSeconds ParamItem `refreshable:"false"`
 }
 
 func (t *traceConfig) init(base *BaseTable) {
@@ -829,6 +830,15 @@ Fractions >= 1 will always sample. Fractions < 0 are treated as zero.`,
 		Export:       true,
 	}
 	t.OtlpSecure.Init(base.mgr)
+
+	t.InitTimeoutSeconds = ParamItem{
+		Key:          "trace.initTimeoutSeconds",
+		Version:      "2.4.4",
+		DefaultValue: "10",
+		Export:       true,
+		Doc:          "segcore initialization timeout in seconds, preventing otlp grpc hangs forever",
+	}
+	t.InitTimeoutSeconds.Init(base.mgr)
 }
 
 type logConfig struct {


### PR DESCRIPTION
Cherry-pick from master
pr: #33494
See also #33483

Wrap `C.InitTrace` & `C.SetTrace` with timeout preventing otlp initializtion hangs forever when endpoint is not set correctly