### PR TITLE
fix: expr add skip using index while index exists

### DIFF
--- a/internal/core/unittest/test_regex_query.cpp
+++ b/internal/core/unittest/test_regex_query.cpp
@@ -501,5 +501,11 @@ TEST_F(SealedSegmentRegexQueryTest, RegexQueryOnUnsupportedIndex) {
     auto segpromote = dynamic_cast<SegmentSealedImpl*>(seg.get());
     query::ExecPlanNodeVisitor visitor(*segpromote, MAX_TIMESTAMP);
     BitsetType final;
-    ASSERT_ANY_THROW(visitor.ExecuteExprNode(parsed, segpromote, N, final));
+    // regex query under this index will be executed using raw data (brute force).
+    visitor.ExecuteExprNode(parsed, segpromote, N, final);
+    ASSERT_FALSE(final[0]);
+    ASSERT_TRUE(final[1]);
+    ASSERT_TRUE(final[2]);
+    ASSERT_TRUE(final[3]);
+    ASSERT_TRUE(final[4]);
 }


### PR DESCRIPTION
This PR cherry-pick part from commit:

-  enhance: add skip using array index when some situation #33947 
-  fix: [ut] regex query under unsupported index  #34087

pr: #33947, #34087