### PR TITLE
fix: [2.4] Pass `otlpSecure` config when setup segcore tracing (#34193)

### DIFF
--- a/internal/util/initcore/init_core.go
+++ b/internal/util/initcore/init_core.go
@@ -51,6 +51,7 @@ func InitTraceConfig(params *paramtable.ComponentParam) {
 	exporter := C.CString(params.TraceCfg.Exporter.GetValue())
 	jaegerURL := C.CString(params.TraceCfg.JaegerURL.GetValue())
 	endpoint := C.CString(params.TraceCfg.OtlpEndpoint.GetValue())
+	otlpSecure := params.TraceCfg.OtlpSecure.GetAsBool()
 	defer C.free(unsafe.Pointer(exporter))
 	defer C.free(unsafe.Pointer(jaegerURL))
 	defer C.free(unsafe.Pointer(endpoint))
@@ -60,6 +61,7 @@ func InitTraceConfig(params *paramtable.ComponentParam) {
 		sampleFraction: sampleFraction,
 		jaegerURL:      jaegerURL,
 		otlpEndpoint:   endpoint,
+		oltpSecure:     (C.bool)(otlpSecure),
 		nodeID:         nodeID,
 	}
 	C.InitTrace(&config)
@@ -71,6 +73,7 @@ func ResetTraceConfig(params *paramtable.ComponentParam) {
 	exporter := C.CString(params.TraceCfg.Exporter.GetValue())
 	jaegerURL := C.CString(params.TraceCfg.JaegerURL.GetValue())
 	endpoint := C.CString(params.TraceCfg.OtlpEndpoint.GetValue())
+	otlpSecure := params.TraceCfg.OtlpSecure.GetAsBool()
 	defer C.free(unsafe.Pointer(exporter))
 	defer C.free(unsafe.Pointer(jaegerURL))
 	defer C.free(unsafe.Pointer(endpoint))
@@ -80,6 +83,7 @@ func ResetTraceConfig(params *paramtable.ComponentParam) {
 		sampleFraction: sampleFraction,
 		jaegerURL:      jaegerURL,
 		otlpEndpoint:   endpoint,
+		oltpSecure:     (C.bool)(otlpSecure),
 		nodeID:         nodeID,
 	}
 	C.SetTrace(&config)


### PR DESCRIPTION
Cherry-pick from master
pr: #34193
See also #34192