### PR TITLE
enhance: Optimize grow slice cost during query

### DIFF
--- a/internal/proxy/task_query.go
+++ b/internal/proxy/task_query.go
@@ -603,7 +603,11 @@ func reduceRetrieveResults(ctx context.Context, retrieveResults []*internalpb.Re
 		return ret, nil
 	}
 
-	ret.FieldsData = make([]*schemapb.FieldData, len(validRetrieveResults[0].GetFieldsData()))
+	if len(validRetrieveResults) == 1 {
+		ret.FieldsData = validRetrieveResults[0].GetFieldsData()
+		return ret, nil
+	}
+
 	idSet := make(map[interface{}]struct{})
 	cursors := make([]int64, len(validRetrieveResults))
 
@@ -626,6 +630,7 @@ func reduceRetrieveResults(ctx context.Context, retrieveResults []*internalpb.Re
 		}
 	}
 
+	ret.FieldsData = typeutil.PrepareResultFieldData(validRetrieveResults[0].GetFieldsData(), int64(loopEnd))
 	var retSize int64
 	maxOutputSize := paramtable.Get().QuotaConfig.MaxOutputSize.GetAsInt64()
 	for j := 0; j < loopEnd; {

--- a/internal/proxy/task_query.go
+++ b/internal/proxy/task_query.go
@@ -603,11 +603,6 @@ func reduceRetrieveResults(ctx context.Context, retrieveResults []*internalpb.Re
 		return ret, nil
 	}
 
-	if len(validRetrieveResults) == 1 {
-		ret.FieldsData = validRetrieveResults[0].GetFieldsData()
-		return ret, nil
-	}
-
 	idSet := make(map[interface{}]struct{})
 	cursors := make([]int64, len(validRetrieveResults))
 

--- a/internal/proxy/task_query_test.go
+++ b/internal/proxy/task_query_test.go
@@ -565,7 +565,7 @@ func TestTaskQuery_functions(t *testing.T) {
 					FieldsData: []*schemapb.FieldData{fieldData},
 				}
 
-				_, err := reduceRetrieveResults(context.Background(), []*internalpb.RetrieveResults{result}, &queryParams{limit: typeutil.Unlimited})
+				_, err := reduceRetrieveResults(context.Background(), []*internalpb.RetrieveResults{result, result}, &queryParams{limit: typeutil.Unlimited})
 				assert.Error(t, err)
 				paramtable.Get().Save(paramtable.Get().QuotaConfig.MaxOutputSize.Key, "1104857600")
 			})

--- a/internal/proxy/task_query_test.go
+++ b/internal/proxy/task_query_test.go
@@ -565,7 +565,7 @@ func TestTaskQuery_functions(t *testing.T) {
 					FieldsData: []*schemapb.FieldData{fieldData},
 				}
 
-				_, err := reduceRetrieveResults(context.Background(), []*internalpb.RetrieveResults{result, result}, &queryParams{limit: typeutil.Unlimited})
+				_, err := reduceRetrieveResults(context.Background(), []*internalpb.RetrieveResults{result}, &queryParams{limit: typeutil.Unlimited})
 				assert.Error(t, err)
 				paramtable.Get().Save(paramtable.Get().QuotaConfig.MaxOutputSize.Key, "1104857600")
 			})

--- a/internal/querynodev2/segments/result.go
+++ b/internal/querynodev2/segments/result.go
@@ -427,7 +427,7 @@ func MergeInternalRetrieveResult(ctx context.Context, retrieveResults []*interna
 		loopEnd = int(param.limit)
 	}
 
-	ret.FieldsData = make([]*schemapb.FieldData, len(validRetrieveResults[0].Result.GetFieldsData()))
+	ret.FieldsData = typeutil.PrepareResultFieldData(validRetrieveResults[0].Result.GetFieldsData(), int64(loopEnd))
 	idTsMap := make(map[interface{}]int64)
 	cursors := make([]int64, len(validRetrieveResults))
 
@@ -556,6 +556,7 @@ func MergeSegcoreRetrieveResults(ctx context.Context, retrieveResults []*segcore
 		limit = int(param.limit)
 	}
 
+	ret.FieldsData = typeutil.PrepareResultFieldData(validRetrieveResults[0].Result.GetFieldsData(), int64(loopEnd))
 	cursors := make([]int64, len(validRetrieveResults))
 	idTsMap := make(map[any]int64)
 


### PR DESCRIPTION
issue: #32252
pr: #34253

This PR try to pre-allocate FieldData for Reduce operations in the Query chain using typeutil.PrepareResultFieldData to avoid the overhead of dynamically growing the slice during appendFieldData process.