### PR TITLE
enhance: [2.4] Refine frequent log in datacoord (#33449)

### DIFF
--- a/internal/datacoord/index_service.go
+++ b/internal/datacoord/index_service.go
@@ -917,7 +917,7 @@ func (s *Server) ListIndexes(ctx context.Context, req *indexpb.ListIndexesReques
 			UserIndexParams: index.UserIndexParams,
 		}
 	})
-	log.Info("List index success")
+	log.Debug("List index success")
 	return &indexpb.ListIndexesResponse{
 		Status:     merr.Success(),
 		IndexInfos: indexInfos,

--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -399,6 +399,7 @@ func (m *meta) GetCollectionIndexFilesSize() uint64 {
 	m.RLock()
 	defer m.RUnlock()
 	var total uint64
+
 	for _, segmentIdx := range m.indexMeta.GetAllSegIndexes() {
 		coll, ok := m.collections[segmentIdx.CollectionID]
 		if ok {


### PR DESCRIPTION
Cherry-pick from master
pr: #33449
This PR changes:
- Frequent `ListIndexes` success log to debug level
- Aggregate collection missing log after collection dropped in `meta.GetCollectionIndexFilesSize`