### PR TITLE
fix: [cherry-pick] Sync the sealed and flushed segments to datanode (#34301)

### DIFF
--- a/internal/datacoord/sync_segments_scheduler.go
+++ b/internal/datacoord/sync_segments_scheduler.go
@@ -98,7 +98,7 @@ func (sss *SyncSegmentsScheduler) SyncSegmentsForCollections() {
 				continue
 			}
 			for _, partitionID := range collInfo.Partitions {
-				if err := sss.SyncFlushedSegments(collID, partitionID, channelName, nodeID, pkField.GetFieldID()); err != nil {
+				if err := sss.SyncSegments(collID, partitionID, channelName, nodeID, pkField.GetFieldID()); err != nil {
 					log.Warn("sync segment with channel failed, retry next ticker",
 						zap.Int64("collectionID", collID),
 						zap.Int64("partitionID", partitionID),
@@ -111,11 +111,14 @@ func (sss *SyncSegmentsScheduler) SyncSegmentsForCollections() {
 	}
 }
 
-func (sss *SyncSegmentsScheduler) SyncFlushedSegments(collectionID, partitionID int64, channelName string, nodeID, pkFieldID int64) error {
+func (sss *SyncSegmentsScheduler) SyncSegments(collectionID, partitionID int64, channelName string, nodeID, pkFieldID int64) error {
 	log := log.With(zap.Int64("collectionID", collectionID), zap.Int64("partitionID", partitionID),
 		zap.String("channelName", channelName), zap.Int64("nodeID", nodeID))
-	segments := sss.meta.SelectSegments(WithCollection(collectionID), WithChannel(channelName), SegmentFilterFunc(func(info *SegmentInfo) bool {
-		return info.GetPartitionID() == partitionID && isFlush(info)
+	// sync all healthy segments, but only check flushed segments on datanode. Because L0 growing segments may not in datacoord's meta.
+	// upon receiving the SyncSegments request, the datanode's segment state may have already transitioned from Growing/Flushing
+	// to Flushed, so the view must include this segment.
+	segments := sss.meta.SelectSegments(WithChannel(channelName), SegmentFilterFunc(func(info *SegmentInfo) bool {
+		return info.GetPartitionID() == partitionID && isSegmentHealthy(info)
 	}))
 	req := &datapb.SyncSegmentsRequest{
 		ChannelName:  channelName,

--- a/internal/datanode/metacache/meta_cache.go
+++ b/internal/datanode/metacache/meta_cache.go
@@ -268,8 +268,10 @@ func (c *metaCacheImpl) UpdateSegmentView(partitionID int64,
 	}
 
 	for segID, info := range c.segmentInfos {
-		if info.partitionID != partitionID ||
-			(info.state != commonpb.SegmentState_Flushed && info.state != commonpb.SegmentState_Flushing) {
+		// only check flushed segments
+		// 1. flushing may be compacted on datacoord
+		// 2. growing may doesn't have stats log, it won't include in sync views
+		if info.partitionID != partitionID || info.state != commonpb.SegmentState_Flushed {
 			continue
 		}
 		if _, ok := allSegments[segID]; !ok {

--- a/internal/datanode/services_test.go
+++ b/internal/datanode/services_test.go
@@ -697,9 +697,10 @@ func (s *DataNodeServicesSuite) TestSyncSegments() {
 		}, func(*datapb.SegmentInfo) *metacache.BloomFilterSet {
 			return metacache.NewBloomFilterSet()
 		})
-		mockFlowgraphManager := pipeline.NewMockFlowgraphManager(s.T())
-		mockFlowgraphManager.EXPECT().GetFlowgraphService(mock.Anything).
-			Return(pipeline.NewDataSyncServiceWithMetaCache(cache), true)
+		mockFlowgraphManager := NewMockFlowgraphManager(s.T())
+		mockFlowgraphManager.EXPECT().GetFlowgraphService(mock.Anything).Return(&dataSyncService{
+			metacache: cache,
+		}, true)
 		s.node.flowgraphManager = mockFlowgraphManager
 		ctx := context.Background()
 		req := &datapb.SyncSegmentsRequest{
@@ -783,9 +784,10 @@ func (s *DataNodeServicesSuite) TestSyncSegments() {
 		}, func(*datapb.SegmentInfo) *metacache.BloomFilterSet {
 			return metacache.NewBloomFilterSet()
 		})
-		mockFlowgraphManager := pipeline.NewMockFlowgraphManager(s.T())
-		mockFlowgraphManager.EXPECT().GetFlowgraphService(mock.Anything).
-			Return(pipeline.NewDataSyncServiceWithMetaCache(cache), true)
+		mockFlowgraphManager := NewMockFlowgraphManager(s.T())
+		mockFlowgraphManager.EXPECT().GetFlowgraphService(mock.Anything).Return(&dataSyncService{
+			metacache: cache,
+		}, true)
 		s.node.flowgraphManager = mockFlowgraphManager
 		ctx := context.Background()
 		req := &datapb.SyncSegmentsRequest{
@@ -880,9 +882,10 @@ func (s *DataNodeServicesSuite) TestSyncSegments() {
 		}, func(*datapb.SegmentInfo) *metacache.BloomFilterSet {
 			return metacache.NewBloomFilterSet()
 		})
-		mockFlowgraphManager := pipeline.NewMockFlowgraphManager(s.T())
-		mockFlowgraphManager.EXPECT().GetFlowgraphService(mock.Anything).
-			Return(pipeline.NewDataSyncServiceWithMetaCache(cache), true)
+		mockFlowgraphManager := NewMockFlowgraphManager(s.T())
+		mockFlowgraphManager.EXPECT().GetFlowgraphService(mock.Anything).Return(&dataSyncService{
+			metacache: cache,
+		}, true)
 		s.node.flowgraphManager = mockFlowgraphManager
 		ctx := context.Background()
 		req := &datapb.SyncSegmentsRequest{
@@ -960,9 +963,10 @@ func (s *DataNodeServicesSuite) TestSyncSegments() {
 		}, func(*datapb.SegmentInfo) *metacache.BloomFilterSet {
 			return metacache.NewBloomFilterSet()
 		})
-		mockFlowgraphManager := pipeline.NewMockFlowgraphManager(s.T())
-		mockFlowgraphManager.EXPECT().GetFlowgraphService(mock.Anything).
-			Return(pipeline.NewDataSyncServiceWithMetaCache(cache), true)
+		mockFlowgraphManager := NewMockFlowgraphManager(s.T())
+		mockFlowgraphManager.EXPECT().GetFlowgraphService(mock.Anything).Return(&dataSyncService{
+			metacache: cache,
+		}, true)
 		s.node.flowgraphManager = mockFlowgraphManager
 		ctx := context.Background()
 		req := &datapb.SyncSegmentsRequest{


### PR DESCRIPTION
issue: #33696

master pr: #34301 