### PR TITLE
enhance: [2.4] Refine max length exceeded error message (#34300)

### DIFF
--- a/internal/proxy/validate_util.go
+++ b/internal/proxy/validate_util.go
@@ -417,8 +417,8 @@ func (v *validateUtil) checkVarCharFieldData(field *schemapb.FieldData, fieldSch
 		}
 
 		if i, ok := verifyLengthPerRow(strArr, maxLength); !ok {
-			return merr.WrapErrParameterInvalidMsg("the length (%d) of %dth VarChar %s exceeds max length (%d)",
-				len(strArr[i]), i, fieldSchema.GetName(), i, maxLength)
+			return merr.WrapErrParameterInvalidMsg("length of varchar field %s exceeds max length, row number: %d, length: %d, max length: %d",
+				fieldSchema.GetName(), i, len(strArr[i]), maxLength)
 		}
 		return nil
 	}
@@ -629,8 +629,9 @@ func (v *validateUtil) checkArrayFieldData(field *schemapb.FieldData, fieldSchem
 		}
 		for rowCnt, row := range data.GetData() {
 			if i, ok := verifyLengthPerRow(row.GetStringData().GetData(), maxLength); !ok {
-				return merr.WrapErrParameterInvalidMsg("the length (%d) of %dth %s %s[%d] exceeds max length (%d)",
-					len(row.GetStringData().GetData()[i]), rowCnt, fieldSchema.GetDataType().String(), fieldSchema.GetName(), i, maxLength)
+				return merr.WrapErrParameterInvalidMsg("length of %s array field \"%s\" exceeds max length, row number: %d, array index: %d, length: %d, max length: %d",
+					fieldSchema.GetDataType().String(), fieldSchema.GetName(), rowCnt, i, len(row.GetStringData().GetData()[i]), maxLength,
+				)
 			}
 		}
 	}


### PR DESCRIPTION
Cherry-pick from master
pr: #34300
This PR make varchar & string array field max length exceeded error message clearer. Also fixed a minor issue that error string format and argument number not match.