### PR TITLE
fix: [2.4] Skip l0 segments when syncing segments to datanodes

### DIFF
--- a/internal/datacoord/sync_segments_scheduler.go
+++ b/internal/datacoord/sync_segments_scheduler.go
@@ -118,7 +118,7 @@ func (sss *SyncSegmentsScheduler) SyncSegments(collectionID, partitionID int64, 
 	// upon receiving the SyncSegments request, the datanode's segment state may have already transitioned from Growing/Flushing
 	// to Flushed, so the view must include this segment.
 	segments := sss.meta.SelectSegments(WithChannel(channelName), SegmentFilterFunc(func(info *SegmentInfo) bool {
-		return info.GetPartitionID() == partitionID && isSegmentHealthy(info)
+		return info.GetPartitionID() == partitionID && info.GetLevel() != datapb.SegmentLevel_L0 && isSegmentHealthy(info)
 	}))
 	req := &datapb.SyncSegmentsRequest{
 		ChannelName:  channelName,


### PR DESCRIPTION
Cherry-pick from master
pr: #34388
See also #34387