### PR TITLE
fix:[cherry-pick] minor fixs for major compaction

### DIFF
--- a/internal/datacoord/compaction.go
+++ b/internal/datacoord/compaction.go
@@ -535,9 +535,6 @@ func (c *compactionPlanHandler) getCompactionTask(planID int64) CompactionTask {
 
 func (c *compactionPlanHandler) enqueueCompaction(task *datapb.CompactionTask) error {
 	log := log.With(zap.Int64("planID", task.GetPlanID()), zap.Int64("triggerID", task.GetTriggerID()), zap.Int64("collectionID", task.GetCollectionID()), zap.String("type", task.GetType().String()))
-	if c.isFull() {
-		return errCompactionBusy
-	}
 	t, err := c.createCompactTask(task)
 	if err != nil {
 		return err

--- a/internal/datacoord/compaction.go
+++ b/internal/datacoord/compaction.go
@@ -568,12 +568,11 @@ func (c *compactionPlanHandler) createCompactTask(t *datapb.CompactionTask) (Com
 		}
 	case datapb.CompactionType_ClusteringCompaction:
 		task = &clusteringCompactionTask{
-			CompactionTask:      t,
-			meta:                c.meta,
-			sessions:            c.sessions,
-			handler:             c.handler,
-			analyzeScheduler:    c.analyzeScheduler,
-			lastUpdateStateTime: time.Now().UnixMilli(),
+			CompactionTask:   t,
+			meta:             c.meta,
+			sessions:         c.sessions,
+			handler:          c.handler,
+			analyzeScheduler: c.analyzeScheduler,
 		}
 	default:
 		return nil, merr.WrapErrIllegalCompactionPlan("illegal compaction type")

--- a/internal/datacoord/compaction_task.go
+++ b/internal/datacoord/compaction_task.go
@@ -100,3 +100,15 @@ func setStartTime(startTime int64) compactionTaskOpt {
 		task.StartTime = startTime
 	}
 }
+
+func setRetryTimes(retryTimes int32) compactionTaskOpt {
+	return func(task *datapb.CompactionTask) {
+		task.RetryTimes = retryTimes
+	}
+}
+
+func setLastStateStartTime(lastStateStartTime int64) compactionTaskOpt {
+	return func(task *datapb.CompactionTask) {
+		task.LastStateStartTime = lastStateStartTime
+	}
+}

--- a/internal/datacoord/compaction_test.go
+++ b/internal/datacoord/compaction_test.go
@@ -528,7 +528,7 @@ func (s *CompactionPlanHandlerSuite) TestGetCompactionTask() {
 
 func (s *CompactionPlanHandlerSuite) TestExecCompactionPlan() {
 	s.SetupTest()
-	s.mockMeta.EXPECT().CheckAndSetSegmentsCompacting(mock.Anything).Return(true, true).Once()
+	s.mockMeta.EXPECT().CheckAndSetSegmentsCompacting(mock.Anything).Return(true, true).Maybe()
 	s.mockMeta.EXPECT().SaveCompactionTask(mock.Anything).Return(nil)
 	handler := newCompactionPlanHandler(nil, s.mockSessMgr, s.mockCm, s.mockMeta, s.mockAlloc, nil, nil)
 
@@ -545,7 +545,7 @@ func (s *CompactionPlanHandlerSuite) TestExecCompactionPlan() {
 	s.handler.taskNumber.Add(1000)
 	task.PlanID = 2
 	err = s.handler.enqueueCompaction(task)
-	s.Error(err)
+	s.NoError(err)
 }
 
 func (s *CompactionPlanHandlerSuite) TestCheckCompaction() {

--- a/internal/datacoord/compaction_trigger_v2.go
+++ b/internal/datacoord/compaction_trigger_v2.go
@@ -289,6 +289,7 @@ func (m *CompactionTriggerManager) SubmitClusteringViewToScheduler(ctx context.C
 		PreferSegmentRows:  preferSegmentRows,
 		TotalRows:          totalRows,
 		AnalyzeTaskID:      taskID + 1,
+		LastStateStartTime: time.Now().UnixMilli(),
 	}
 	err = m.compactionHandler.enqueueCompaction(task)
 	if err != nil {

--- a/internal/proto/data_coord.proto
+++ b/internal/proto/data_coord.proto
@@ -913,6 +913,7 @@ message CompactionTask{
   int64 prefer_segment_rows = 22;
   int64 analyzeTaskID = 23;
   int64 analyzeVersion = 24;
+  int64 lastStateStartTime = 25;
 }
 
 message PartitionStatsInfo {


### PR DESCRIPTION
This PR cherry-picks the following commits:

- fix: Avoid datarace in clustering compaction #34288
- fix: remove isFull check in compaction.enqueue #34338

issue: #30633 
pr: #34288 #34338