### PR TITLE
enhance: [2.4] Continue loop when reassign channel fails (#34331)

### DIFF
--- a/internal/datacoord/channel_manager_v2.go
+++ b/internal/datacoord/channel_manager_v2.go
@@ -488,6 +488,7 @@ func (m *ChannelManagerImplV2) advanceStandbys(_ context.Context, standbys []*No
 				zap.Int64("nodeID", nodeAssign.NodeID),
 				zap.Strings("channels", chNames),
 			)
+			continue
 		}
 
 		log.Info("Reassign standby channels to node",


### PR DESCRIPTION
Cherry-pick from master
pr: #34331
Log will be confusing when `Reassign` channel operation failed for both success & failure log will be printed in row. This PR continue the loop to avoid this output.