### PR TITLE
fix: [2.4] Write padding into mmap file in case of SIGBUS (#34443)

### DIFF
--- a/internal/core/src/mmap/Column.h
+++ b/internal/core/src/mmap/Column.h
@@ -129,7 +129,9 @@ class ColumnBase {
 
         size_ = size;
         cap_size_ = size;
-        size_t mapped_size = cap_size_ + padding_;
+        // use exactly same size of file, padding shall be written in file already
+        // see also https://github.com/milvus-io/milvus/issues/34442
+        size_t mapped_size = cap_size_;
         data_ = static_cast<char*>(mmap(
             nullptr, mapped_size, PROT_READ, MAP_SHARED, file.Descriptor(), 0));
         AssertInfo(data_ != MAP_FAILED,
@@ -156,7 +158,9 @@ class ColumnBase {
           mapping_type_(MappingType::MAP_WITH_FILE) {
         SetPaddingSize(data_type);
 
-        size_t mapped_size = cap_size_ + padding_;
+        // use exact same size of file, padding shall be written in file already
+        // see also https://github.com/milvus-io/milvus/issues/34442
+        size_t mapped_size = cap_size_;
         data_ = static_cast<char*>(mmap(
             nullptr, mapped_size, PROT_READ, MAP_SHARED, file.Descriptor(), 0));
         AssertInfo(data_ != MAP_FAILED,


### PR DESCRIPTION
Cherry-pick from master
pr: #34443
See also #34442