### PR TITLE
fix: lose partitionIDs when scalar pruning and refine segment prune ratio metrics(#30376)

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -76,6 +76,7 @@ const (
 
 	compactionTypeLabelName  = "compaction_type"
 	isVectorFieldLabelName   = "is_vector_field"
+	segmentPruneLabelName    = "segment_prune_label"
 	stageLabelName           = "compaction_stage"
 	nodeIDLabelName          = "node_id"
 	statusLabelName          = "status"

--- a/pkg/metrics/querynode_metrics.go
+++ b/pkg/metrics/querynode_metrics.go
@@ -362,16 +362,28 @@ var (
 			nodeIDLabelName,
 		})
 
-	QueryNodeSegmentPruneRatio = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
+	QueryNodeSegmentPruneRatio = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
 			Namespace: milvusNamespace,
 			Subsystem: typeutil.QueryNodeRole,
 			Name:      "segment_prune_ratio",
-			Help:      "latency of compaction operation",
-			Buckets:   buckets,
+			Help:      "ratio of segments pruned by segment_pruner",
 		}, []string{
+			nodeIDLabelName,
 			collectionIDLabelName,
-			isVectorFieldLabelName,
+			segmentPruneLabelName,
+		})
+
+	QueryNodeSegmentPruneBias = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.QueryNodeRole,
+			Name:      "segment_prune_bias",
+			Help:      "bias of workload when enabling segment prune",
+		}, []string{
+			nodeIDLabelName,
+			collectionIDLabelName,
+			segmentPruneLabelName,
 		})
 
 	QueryNodeSegmentPruneLatency = prometheus.NewHistogramVec(
@@ -382,8 +394,9 @@ var (
 			Help:      "latency of segment prune",
 			Buckets:   buckets,
 		}, []string{
+			nodeIDLabelName,
 			collectionIDLabelName,
-			isVectorFieldLabelName,
+			segmentPruneLabelName,
 		})
 
 	QueryNodeEvictedReadReqCount = prometheus.NewCounterVec(
@@ -803,6 +816,7 @@ func RegisterQueryNode(registry *prometheus.Registry) {
 	registry.MustRegister(QueryNodeDiskCacheEvictGlobalDuration)
 	registry.MustRegister(QueryNodeSegmentPruneRatio)
 	registry.MustRegister(QueryNodeSegmentPruneLatency)
+	registry.MustRegister(QueryNodeSegmentPruneBias)
 	registry.MustRegister(QueryNodeApplyBFCost)
 	registry.MustRegister(QueryNodeForwardDeleteCost)
 	// Add cgo metrics


### PR DESCRIPTION
related: #30376
fix: paritionIDs lost when no setting paritions
enhance: refine metrics for segment prune