### PR TITLE
fix: Check err is ErrKeyNotFound when CASCachedValue

### DIFF
--- a/pkg/config/env_source.go
+++ b/pkg/config/env_source.go
@@ -16,10 +16,10 @@
 package config
 
 import (
-	"fmt"
 	"os"
 	"strings"
 
+	"github.com/cockroachdb/errors"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
 
@@ -51,7 +51,7 @@ func (es EnvSource) GetConfigurationByKey(key string) (string, error) {
 	value, ok := es.configs.Get(key)
 
 	if !ok {
-		return "", fmt.Errorf("key not found: %s", key)
+		return "", errors.Wrap(ErrKeyNotFound, key) // fmt.Errorf("key not found: %s", key)
 	}
 
 	return value, nil

--- a/pkg/config/etcd_source.go
+++ b/pkg/config/etcd_source.go
@@ -18,12 +18,12 @@ package config
 
 import (
 	"context"
-	"fmt"
 	"path"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
@@ -80,7 +80,7 @@ func (es *EtcdSource) GetConfigurationByKey(key string) (string, error) {
 	v, ok := es.currentConfigs[key]
 	es.RUnlock()
 	if !ok {
-		return "", fmt.Errorf("key not found: %s", key)
+		return "", errors.Wrap(ErrKeyNotFound, key) // fmt.Errorf("key not found: %s", key)
 	}
 	return v, nil
 }

--- a/pkg/config/file_source.go
+++ b/pkg/config/file_source.go
@@ -17,7 +17,6 @@
 package config
 
 import (
-	"fmt"
 	"os"
 	"sync"
 
@@ -55,7 +54,7 @@ func (fs *FileSource) GetConfigurationByKey(key string) (string, error) {
 	v, ok := fs.configs[key]
 	fs.RUnlock()
 	if !ok {
-		return "", fmt.Errorf("key not found: %s", key)
+		return "", errors.Wrap(ErrKeyNotFound, key) // fmt.Errorf("key not found: %s", key)
 	}
 	return v, nil
 }

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -119,7 +119,7 @@ func (m *Manager) CASCachedValue(key string, origin string, value interface{}) b
 	m.cacheMutex.Lock()
 	defer m.cacheMutex.Unlock()
 	current, err := m.GetConfig(key)
-	if err != nil {
+	if err != nil && !errors.Is(err, ErrKeyNotFound) {
 		return false
 	}
 	if current != origin {
@@ -149,13 +149,13 @@ func (m *Manager) GetConfig(key string) (string, error) {
 	v, ok := m.overlays.Get(realKey)
 	if ok {
 		if v == TombValue {
-			return "", fmt.Errorf("key not found %s", key)
+			return "", errors.Wrap(ErrKeyNotFound, key) // fmt.Errorf("key not found %s", key)
 		}
 		return v, nil
 	}
 	sourceName, ok := m.keySourceMap.Get(realKey)
 	if !ok {
-		return "", fmt.Errorf("key not found: %s", key)
+		return "", errors.Wrap(ErrKeyNotFound, key) // fmt.Errorf("key not found: %s", key)
 	}
 	return m.getConfigValueBySource(realKey, sourceName)
 }

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -239,7 +239,7 @@ func TestCachedConfig(t *testing.T) {
 		assert.False(t, exist)
 		mgr.CASCachedValue("cd", "", "xxx")
 		_, exist = mgr.GetCachedValue("cd")
-		assert.False(t, exist)
+		assert.True(t, exist)
 
 		// after refresh, the cached value should be reset
 		ctx := context.Background()


### PR DESCRIPTION
See also #33785

When config item is not present in paramtable, CAS fails due to GetConfig returns error.

This PR make this returned err instance of ErrKeyNotFound and check error type in \`CASCachedValue\` methods.