### PR TITLE
fix: Query may return deleted records

### DIFF
--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"math/rand"
 	"runtime"
-	"sort"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -592,10 +591,6 @@ func (sd *shardDelegator) GetLevel0Deletions(partitionID int64, candidate pkorac
 			}
 		}
 	}
-
-	sort.Slice(pks, func(i, j int) bool {
-		return tss[i] < tss[j]
-	})
 
 	return pks, tss
 }


### PR DESCRIPTION
issue: #34500
cause the sort in `GetLevel0Deletions` will broken the corresponed order between pks and tss, then the pks and tss will be sorted in segment.Delete() interface.

This PR remove this uncessary and incorrect sort progress to avoid query may return deleted records.