### PR TITLE
fix: Delete record may lost in qn worker after partial L0 compact

### DIFF
--- a/internal/datacoord/compaction_l0_view.go
+++ b/internal/datacoord/compaction_l0_view.go
@@ -2,6 +2,7 @@ package datacoord
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/samber/lo"
 
@@ -80,6 +81,11 @@ func (v *LevelZeroSegmentsView) ForceTrigger() (CompactionView, string) {
 		return view.dmlPos.GetTimestamp() < v.earliestGrowingSegmentPos.GetTimestamp()
 	})
 
+	// sort l0 segment by dml position, to make sure the order of delete record is consistent
+	sort.Slice(validSegments, func(i, j int) bool {
+		return validSegments[i].dmlPos.GetTimestamp() < validSegments[j].dmlPos.GetTimestamp()
+	})
+
 	targetViews, reason := v.forceTrigger(validSegments)
 	if len(targetViews) > 0 {
 		return &LevelZeroSegmentsView{
@@ -97,6 +103,11 @@ func (v *LevelZeroSegmentsView) Trigger() (CompactionView, string) {
 	// Only choose segments with position less than the earliest growing segment position
 	validSegments := lo.Filter(v.segments, func(view *SegmentView, _ int) bool {
 		return view.dmlPos.GetTimestamp() < v.earliestGrowingSegmentPos.GetTimestamp()
+	})
+
+	// sort l0 segment by dml position, to make sure the order of delete record is consistent
+	sort.Slice(validSegments, func(i, j int) bool {
+		return validSegments[i].dmlPos.GetTimestamp() < validSegments[j].dmlPos.GetTimestamp()
 	})
 
 	targetViews, reason := v.minCountSizeTrigger(validSegments)


### PR DESCRIPTION
issue: #34500
l0 compact will pick some l0 segment to compact, then dispatch it to l1 segments, but it doesn't choose the segment by dml position, which broken the order of delete records in delta logs.

then delegator try to forward the others l0 segments's delete records to l1 segments, but it will be filter out by l1 segments's ts.

This PR sort l0 segment by dml position to make sure the order of delete record is consitent.