### PR TITLE
fix: [2.4] Write padding at end of mmap file not chunk

### DIFF
--- a/internal/core/src/mmap/Utils.h
+++ b/internal/core/src/mmap/Utils.h
@@ -48,7 +48,7 @@ namespace milvus {
 constexpr size_t FILE_STRING_PADDING = 1;
 constexpr size_t FILE_ARRAY_PADDING = 1;
 
-inline size_t 
+inline size_t
 PaddingSize(const DataType& type) {
     switch (type) {
         case DataType::JSON:
@@ -64,6 +64,21 @@ PaddingSize(const DataType& type) {
             break;
     }
     return 0;
+}
+
+inline void
+WriteFieldPadding(File& file, DataType data_type, uint64_t& total_written) {
+    // write padding 0 in file content directly
+    // see also https://github.com/milvus-io/milvus/issues/34442
+    auto padding_size = PaddingSize(data_type);
+    if (padding_size > 0) {
+        std::vector<char> padding(padding_size, 0);
+        ssize_t written = file.Write(padding.data(), padding_size);
+        if (written < padding_size) {
+            THROW_FILE_WRITE_ERROR
+        }
+        total_written += written;
+    }
 }
 
 inline void
@@ -154,18 +169,6 @@ WriteFieldData(File& file,
             indices.emplace_back(total_written);
             total_written += data->Size(i);
         }
-    }
-
-    // write padding 0 in file content directly
-    // see also https://github.com/milvus-io/milvus/issues/34442
-    auto padding_size = PaddingSize(data_type);
-    if (padding_size > 0 ) {
-        std::vector<char> padding(padding_size, 0);
-        ssize_t written = file.Write(padding.data(), padding_size);
-        if (written < padding_size) {
-            THROW_FILE_WRITE_ERROR
-        }
-        total_written += written;
     }
 }
 }  // namespace milvus

--- a/internal/core/src/segcore/SegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/SegmentSealedImpl.cpp
@@ -538,6 +538,7 @@ SegmentSealedImpl::MapFieldData(const FieldId field_id, FieldDataInfo& data) {
                        indices,
                        element_indices);
     }
+    WriteFieldPadding(file, data_type, total_written);
 
     auto num_rows = data.row_count;
     std::shared_ptr<ColumnBase> column{};


### PR DESCRIPTION
Cherry-pick from master
pr: #34529
Related to #34508

The padding bytes shall be written only at the end of the mmap file not the chunk of each field data file.