### PR TITLE
fix: Fix no L0 compaction tasks are executed (#34537)

### DIFF
--- a/internal/datacoord/compaction_task_clustering.go
+++ b/internal/datacoord/compaction_task_clustering.go
@@ -536,7 +536,7 @@ func (t *clusteringCompactionTask) GetLabel() string {
 }
 
 func (t *clusteringCompactionTask) NeedReAssignNodeID() bool {
-	return t.GetState() == datapb.CompactionTaskState_pipelining && t.GetNodeID() == 0
+	return t.GetState() == datapb.CompactionTaskState_pipelining && (t.GetNodeID() == 0 || t.GetNodeID() == NullNodeID)
 }
 
 func (t *clusteringCompactionTask) CleanLogPath() {

--- a/internal/datacoord/compaction_task_l0.go
+++ b/internal/datacoord/compaction_task_l0.go
@@ -186,7 +186,7 @@ func (t *l0CompactionTask) SetStartTime(startTime int64) {
 }
 
 func (t *l0CompactionTask) NeedReAssignNodeID() bool {
-	return t.GetState() == datapb.CompactionTaskState_pipelining && t.GetNodeID() == NullNodeID
+	return t.GetState() == datapb.CompactionTaskState_pipelining && (t.GetNodeID() == 0 || t.GetNodeID() == NullNodeID)
 }
 
 func (t *l0CompactionTask) SetResult(result *datapb.CompactionPlanResult) {

--- a/internal/datacoord/compaction_task_mix.go
+++ b/internal/datacoord/compaction_task_mix.go
@@ -169,7 +169,7 @@ func (t *mixCompactionTask) GetLabel() string {
 }
 
 func (t *mixCompactionTask) NeedReAssignNodeID() bool {
-	return t.GetState() == datapb.CompactionTaskState_pipelining && t.GetNodeID() == NullNodeID
+	return t.GetState() == datapb.CompactionTaskState_pipelining && (t.GetNodeID() == 0 || t.GetNodeID() == NullNodeID)
 }
 
 func (t *mixCompactionTask) processCompleted() bool {


### PR DESCRIPTION
The nodeID for compaction task initialization is 0. This PR adjusts the task reassignment conditions to allow new compaction tasks to be reassigned and executed.

issue: https://github.com/milvus-io/milvus/issues/34460

pr: https://github.com/milvus-io/milvus/pull/34537