### PR TITLE
fix: Prevent dispatcher merging if curTs is 0

### DIFF
--- a/pkg/mq/msgdispatcher/manager.go
+++ b/pkg/mq/msgdispatcher/manager.go
@@ -182,7 +182,7 @@ func (c *dispatcherManager) tryMerge() {
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if c.mainDispatcher == nil {
+	if c.mainDispatcher == nil || c.mainDispatcher.CurTs() == 0 {
 		return
 	}
 	candidates := make(map[string]struct{})

--- a/pkg/mq/msgdispatcher/manager_test.go
+++ b/pkg/mq/msgdispatcher/manager_test.go
@@ -74,6 +74,12 @@ func TestManager(t *testing.T) {
 		_, err = c.Add(ctx, "mock_vchannel_2", nil, common.SubscriptionPositionUnknown)
 		assert.NoError(t, err)
 		assert.Equal(t, 3, c.Num())
+		c.(*dispatcherManager).mainDispatcher.curTs.Store(1000)
+		c.(*dispatcherManager).mu.RLock()
+		for _, d := range c.(*dispatcherManager).soloDispatchers {
+			d.curTs.Store(1000)
+		}
+		c.(*dispatcherManager).mu.RUnlock()
 
 		c.(*dispatcherManager).tryMerge()
 		assert.Equal(t, 1, c.Num())
@@ -99,6 +105,12 @@ func TestManager(t *testing.T) {
 		_, err = c.Add(ctx, "mock_vchannel_2", nil, common.SubscriptionPositionUnknown)
 		assert.NoError(t, err)
 		assert.Equal(t, 3, c.Num())
+		c.(*dispatcherManager).mainDispatcher.curTs.Store(1000)
+		c.(*dispatcherManager).mu.RLock()
+		for _, d := range c.(*dispatcherManager).soloDispatchers {
+			d.curTs.Store(1000)
+		}
+		c.(*dispatcherManager).mu.RUnlock()
 
 		checkIntervalK := paramtable.Get().MQCfg.MergeCheckInterval.Key
 		paramtable.Get().Save(checkIntervalK, "0.01")


### PR DESCRIPTION
When the main dispatcher has not yet consumed data, curTs is 0. During this time, merging dispatchers should not be allowed; otherwise, the data of the solo dispatcher will be skipped.

issue: https://github.com/milvus-io/milvus/issues/34255