### PR TITLE
fix: [Cherry-pick] Restful API use deprecate error code cause access log panic.

### DIFF
--- a/internal/distributed/proxy/httpserver/handler_v1_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v1_test.go
@@ -44,6 +44,7 @@ const (
 
 var StatusSuccess = commonpb.Status{
 	ErrorCode: commonpb.ErrorCode_Success,
+	Code:      merr.Code(nil),
 	Reason:    "",
 }
 

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -954,6 +954,7 @@ func TestMethodGet(t *testing.T) {
 
 var commonSuccessStatus = &commonpb.Status{
 	ErrorCode: commonpb.ErrorCode_Success,
+	Code:      merr.Code(nil),
 	Reason:    "",
 }
 

--- a/internal/distributed/proxy/httpserver/request_v2.go
+++ b/internal/distributed/proxy/httpserver/request_v2.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus/pkg/util/merr"
 )
 
 type DatabaseReq struct {
@@ -356,14 +357,14 @@ func (req *AliasCollectionReq) GetAliasName() string {
 }
 
 func wrapperReturnHas(has bool) gin.H {
-	return gin.H{HTTPReturnCode: commonpb.ErrorCode_Success, HTTPReturnData: gin.H{HTTPReturnHas: has}}
+	return gin.H{HTTPReturnCode: merr.Code(nil), HTTPReturnData: gin.H{HTTPReturnHas: has}}
 }
 
 func wrapperReturnList(names []string) gin.H {
 	if names == nil {
-		return gin.H{HTTPReturnCode: commonpb.ErrorCode_Success, HTTPReturnData: []string{}}
+		return gin.H{HTTPReturnCode: merr.Code(nil), HTTPReturnData: []string{}}
 	}
-	return gin.H{HTTPReturnCode: commonpb.ErrorCode_Success, HTTPReturnData: names}
+	return gin.H{HTTPReturnCode: merr.Code(nil), HTTPReturnData: names}
 }
 
 func wrapperReturnRowCount(pairs []*commonpb.KeyValuePair) gin.H {
@@ -375,15 +376,15 @@ func wrapperReturnRowCount(pairs []*commonpb.KeyValuePair) gin.H {
 	}
 	rowCount, err := strconv.ParseInt(rowCountValue, 10, 64)
 	if err != nil {
-		return gin.H{HTTPReturnCode: commonpb.ErrorCode_Success, HTTPReturnData: gin.H{HTTPReturnRowCount: rowCountValue}}
+		return gin.H{HTTPReturnCode: merr.Code(nil), HTTPReturnData: gin.H{HTTPReturnRowCount: rowCountValue}}
 	}
-	return gin.H{HTTPReturnCode: commonpb.ErrorCode_Success, HTTPReturnData: gin.H{HTTPReturnRowCount: rowCount}}
+	return gin.H{HTTPReturnCode: merr.Code(nil), HTTPReturnData: gin.H{HTTPReturnRowCount: rowCount}}
 }
 
 func wrapperReturnDefault() gin.H {
-	return gin.H{HTTPReturnCode: commonpb.ErrorCode_Success, HTTPReturnData: gin.H{}}
+	return gin.H{HTTPReturnCode: merr.Code(nil), HTTPReturnData: gin.H{}}
 }
 
 func wrapperReturnDefaultWithCost(cost int) gin.H {
-	return gin.H{HTTPReturnCode: commonpb.ErrorCode_Success, HTTPReturnData: gin.H{}, HTTPReturnCost: cost}
+	return gin.H{HTTPReturnCode: merr.Code(nil), HTTPReturnData: gin.H{}, HTTPReturnCost: cost}
 }

--- a/internal/proxy/accesslog/info/restful_info.go
+++ b/internal/proxy/accesslog/info/restful_info.go
@@ -95,11 +95,21 @@ func (i *RestfulInfo) MethodStatus() string {
 		return fmt.Sprintf("HttpError%d", i.params.StatusCode)
 	}
 
-	if code, ok := i.params.Keys[ContextReturnCode]; !ok || code.(int32) != 0 {
-		return "Failed"
+	value, ok := i.params.Keys[ContextReturnCode]
+	if !ok {
+		return Unknown
 	}
 
-	return "Successful"
+	code, ok := value.(int32)
+	if ok {
+		if code != 0 {
+			return "Failed"
+		}
+
+		return "Successful"
+	}
+
+	return Unknown
 }
 
 func (i *RestfulInfo) UserName() string {


### PR DESCRIPTION
Avoid panic when use deprecate error code and use merr code replace deprecate common code.
relate: https://github.com/milvus-io/milvus/issues/34578
pr： https://github.com/milvus-io/milvus/pull/34576