### PR TITLE
enhance: Add lint rule to forbid gogo protobuf

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -121,6 +121,8 @@ linters-settings:
             desc: not allowed, use github.com/tikv/client-go/v2/txnkv
           - pkg: "github.com/tikv/client-go/v2/rawkv"
             desc: not allowed, use github.com/tikv/client-go/v2/txnkv
+          - pkg: "github.com/gogo/protobuf"
+            desc: "not allowed, gogo protobuf is deprecated"
   forbidigo:
     forbid:
       - '^time\.Tick$'

--- a/internal/querynodev2/services_test.go
+++ b/internal/querynodev2/services_test.go
@@ -27,7 +27,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
-	"github.com/gogo/protobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"

--- a/internal/storage/insert_data.go
+++ b/internal/storage/insert_data.go
@@ -20,7 +20,7 @@ import (
 	"encoding/binary"
 	"fmt"
 
-	"github.com/gogo/protobuf/proto"
+	"github.com/golang/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/pkg/common"


### PR DESCRIPTION
github.com/gogo/protobuf is deprecated and could be error prune after upgrade protobuf message to v2.