### PR TITLE
enhance: Preserve fixed-size memory in delegator node for growing segment.

### DIFF
--- a/internal/querycoordv2/balance/channel_level_score_balancer_test.go
+++ b/internal/querycoordv2/balance/channel_level_score_balancer_test.go
@@ -303,14 +303,12 @@ func (suite *ChannelLevelScoreBalancerTestSuite) TestAssignSegmentWithGrowing() 
 	defer suite.TearDownTest()
 	balancer := suite.balancer
 
-	paramtable.Get().Save(paramtable.Get().QueryCoordCfg.EnableEstimateGrowingRowCount.Key, "false")
-
 	distributions := map[int64][]*meta.Segment{
 		1: {
-			{SegmentInfo: &datapb.SegmentInfo{ID: 1, NumOfRows: 20, CollectionID: 1}, Node: 1},
+			{SegmentInfo: &datapb.SegmentInfo{ID: 1, NumOfRows: 100, CollectionID: 1}, Node: 1},
 		},
 		2: {
-			{SegmentInfo: &datapb.SegmentInfo{ID: 2, NumOfRows: 20, CollectionID: 1}, Node: 2},
+			{SegmentInfo: &datapb.SegmentInfo{ID: 2, NumOfRows: 100, CollectionID: 1}, Node: 2},
 		},
 	}
 	for node, s := range distributions {
@@ -335,9 +333,8 @@ func (suite *ChannelLevelScoreBalancerTestSuite) TestAssignSegmentWithGrowing() 
 
 	// mock 50 growing row count in node 1, which is delegator, expect all segment assign to node 2
 	leaderView := &meta.LeaderView{
-		ID:               1,
-		CollectionID:     1,
-		NumOfGrowingRows: 50,
+		ID:           1,
+		CollectionID: 1,
 	}
 	suite.balancer.dist.LeaderViewManager.Update(1, leaderView)
 	plans := balancer.AssignSegment(1, toAssign, lo.Keys(distributions), false)

--- a/internal/querycoordv2/balance/channel_level_score_balancer_test.go
+++ b/internal/querycoordv2/balance/channel_level_score_balancer_test.go
@@ -303,6 +303,8 @@ func (suite *ChannelLevelScoreBalancerTestSuite) TestAssignSegmentWithGrowing() 
 	defer suite.TearDownTest()
 	balancer := suite.balancer
 
+	paramtable.Get().Save(paramtable.Get().QueryCoordCfg.EnableEstimateGrowingRowCount.Key, "false")
+
 	distributions := map[int64][]*meta.Segment{
 		1: {
 			{SegmentInfo: &datapb.SegmentInfo{ID: 1, NumOfRows: 20, CollectionID: 1}, Node: 1},

--- a/internal/querycoordv2/balance/score_based_balancer.go
+++ b/internal/querycoordv2/balance/score_based_balancer.go
@@ -159,8 +159,21 @@ func (b *ScoreBasedBalancer) calculateScore(collectionID, nodeID int64) int {
 
 	// calculate global growing segment row count
 	views := b.dist.LeaderViewManager.GetByFilter(meta.WithNodeID2LeaderView(nodeID))
-	for _, view := range views {
-		nodeRowCount += int(float64(view.NumOfGrowingRows) * params.Params.QueryCoordCfg.GrowingRowCountWeight.GetAsFloat())
+	if paramtable.Get().QueryCoordCfg.EnableEstimateGrowingRowCount.GetAsBool() {
+		collectionViews := lo.GroupBy(views, func(v *meta.LeaderView) int64 { return v.CollectionID })
+		for cid, vs := range collectionViews {
+			partitionNum := len(b.meta.GetPartitionsByCollection(cid))
+			estimateRowCount := paramtable.Get().QueryCoordCfg.EstimateGrowingRowCountPerSegment.GetAsInt()
+			growingFactor := params.Params.QueryCoordCfg.GrowingRowCountWeight.GetAsFloat()
+
+			// there will be at most (2* partition_num) growing segments, and each segment will have estimateRowCount rows
+			// for each growing row on qn, we need move out growingFactor sealed rows
+			nodeRowCount += int(float64(2*partitionNum*estimateRowCount)*growingFactor) * len(vs)
+		}
+	} else {
+		for _, view := range views {
+			nodeRowCount += int(float64(view.NumOfGrowingRows) * params.Params.QueryCoordCfg.GrowingRowCountWeight.GetAsFloat())
+		}
 	}
 
 	// calculate executing task cost in scheduler
@@ -175,8 +188,18 @@ func (b *ScoreBasedBalancer) calculateScore(collectionID, nodeID int64) int {
 
 	// calculate collection growing segment row count
 	collectionViews := b.dist.LeaderViewManager.GetByFilter(meta.WithCollectionID2LeaderView(collectionID), meta.WithNodeID2LeaderView(nodeID))
-	for _, view := range collectionViews {
-		collectionRowCount += int(float64(view.NumOfGrowingRows) * params.Params.QueryCoordCfg.GrowingRowCountWeight.GetAsFloat())
+	if paramtable.Get().QueryCoordCfg.EnableEstimateGrowingRowCount.GetAsBool() {
+		partitionNum := len(b.meta.GetPartitionsByCollection(collectionID))
+		estimateRowCount := paramtable.Get().QueryCoordCfg.EstimateGrowingRowCountPerSegment.GetAsInt()
+		growingFactor := params.Params.QueryCoordCfg.GrowingRowCountWeight.GetAsFloat()
+
+		// there will be at most (2* partition_num) growing segments, and each segment will have estimateRowCount rows
+		// for each growing row on qn, we need move out growingFactor sealed rows
+		collectionRowCount += int(float64(2*partitionNum*estimateRowCount)*growingFactor) * len(collectionViews)
+	} else {
+		for _, view := range collectionViews {
+			collectionRowCount += int(float64(view.NumOfGrowingRows) * params.Params.QueryCoordCfg.GrowingRowCountWeight.GetAsFloat())
+		}
 	}
 
 	// calculate executing task cost in scheduler

--- a/internal/querycoordv2/balance/score_based_balancer_test.go
+++ b/internal/querycoordv2/balance/score_based_balancer_test.go
@@ -303,7 +303,7 @@ func (suite *ScoreBasedBalancerTestSuite) TestAssignSegmentWithGrowing() {
 	defer suite.TearDownTest()
 	balancer := suite.balancer
 
-	paramtable.Get().Save(paramtable.Get().QueryCoordCfg.EnableEstimateGrowingRowCount.Key, "false")
+	paramtable.Get().Save(paramtable.Get().QueryCoordCfg.DelegatorMemoryOverloadFactor.Key, "0.3")
 	suite.balancer.meta.PutCollection(&meta.Collection{
 		CollectionLoadInfo: &querypb.CollectionLoadInfo{
 			CollectionID: 1,
@@ -315,10 +315,10 @@ func (suite *ScoreBasedBalancerTestSuite) TestAssignSegmentWithGrowing() {
 	})
 	distributions := map[int64][]*meta.Segment{
 		1: {
-			{SegmentInfo: &datapb.SegmentInfo{ID: 1, NumOfRows: 20, CollectionID: 1}, Node: 1},
+			{SegmentInfo: &datapb.SegmentInfo{ID: 1, NumOfRows: 100, CollectionID: 1}, Node: 1},
 		},
 		2: {
-			{SegmentInfo: &datapb.SegmentInfo{ID: 2, NumOfRows: 20, CollectionID: 1}, Node: 2},
+			{SegmentInfo: &datapb.SegmentInfo{ID: 2, NumOfRows: 100, CollectionID: 1}, Node: 2},
 		},
 	}
 	for node, s := range distributions {
@@ -343,24 +343,11 @@ func (suite *ScoreBasedBalancerTestSuite) TestAssignSegmentWithGrowing() {
 
 	// mock 50 growing row count in node 1, which is delegator, expect all segment assign to node 2
 	leaderView := &meta.LeaderView{
-		ID:               1,
-		CollectionID:     1,
-		NumOfGrowingRows: 50,
-	}
-	suite.balancer.dist.LeaderViewManager.Update(1, leaderView)
-	plans := balancer.AssignSegment(1, toAssign, lo.Keys(distributions), false)
-	for _, p := range plans {
-		suite.Equal(int64(2), p.To)
-	}
-
-	// test enable estimate growing row count
-	paramtable.Get().Save(paramtable.Get().QueryCoordCfg.EnableEstimateGrowingRowCount.Key, "true")
-	leaderView = &meta.LeaderView{
 		ID:           1,
 		CollectionID: 1,
 	}
 	suite.balancer.dist.LeaderViewManager.Update(1, leaderView)
-	plans = balancer.AssignSegment(1, toAssign, lo.Keys(distributions), false)
+	plans := balancer.AssignSegment(1, toAssign, lo.Keys(distributions), false)
 	for _, p := range plans {
 		suite.Equal(int64(2), p.To)
 	}

--- a/internal/querycoordv2/balance/score_based_balancer_test.go
+++ b/internal/querycoordv2/balance/score_based_balancer_test.go
@@ -303,6 +303,16 @@ func (suite *ScoreBasedBalancerTestSuite) TestAssignSegmentWithGrowing() {
 	defer suite.TearDownTest()
 	balancer := suite.balancer
 
+	paramtable.Get().Save(paramtable.Get().QueryCoordCfg.EnableEstimateGrowingRowCount.Key, "false")
+	suite.balancer.meta.PutCollection(&meta.Collection{
+		CollectionLoadInfo: &querypb.CollectionLoadInfo{
+			CollectionID: 1,
+		},
+	}, &meta.Partition{
+		PartitionLoadInfo: &querypb.PartitionLoadInfo{
+			PartitionID: 1,
+		},
+	})
 	distributions := map[int64][]*meta.Segment{
 		1: {
 			{SegmentInfo: &datapb.SegmentInfo{ID: 1, NumOfRows: 20, CollectionID: 1}, Node: 1},
@@ -339,6 +349,18 @@ func (suite *ScoreBasedBalancerTestSuite) TestAssignSegmentWithGrowing() {
 	}
 	suite.balancer.dist.LeaderViewManager.Update(1, leaderView)
 	plans := balancer.AssignSegment(1, toAssign, lo.Keys(distributions), false)
+	for _, p := range plans {
+		suite.Equal(int64(2), p.To)
+	}
+
+	// test enable estimate growing row count
+	paramtable.Get().Save(paramtable.Get().QueryCoordCfg.EnableEstimateGrowingRowCount.Key, "true")
+	leaderView = &meta.LeaderView{
+		ID:           1,
+		CollectionID: 1,
+	}
+	suite.balancer.dist.LeaderViewManager.Update(1, leaderView)
+	plans = balancer.AssignSegment(1, toAssign, lo.Keys(distributions), false)
 	for _, p := range plans {
 		suite.Equal(int64(2), p.To)
 	}

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -1554,6 +1554,8 @@ type queryCoordConfig struct {
 	RowCountMaxSteps                    ParamItem `refreshable:"true"`
 	RandomMaxSteps                      ParamItem `refreshable:"true"`
 	GrowingRowCountWeight               ParamItem `refreshable:"true"`
+	EnableEstimateGrowingRowCount       ParamItem `refreshable:"true"`
+	EstimateGrowingRowCountPerSegment   ParamItem `refreshable:"true"`
 	BalanceCostThreshold                ParamItem `refreshable:"true"`
 
 	SegmentCheckInterval       ParamItem `refreshable:"true"`
@@ -1787,6 +1789,26 @@ func (p *queryCoordConfig) init(base *BaseTable) {
 		Export:       true,
 	}
 	p.GrowingRowCountWeight.Init(base.mgr)
+
+	p.EnableEstimateGrowingRowCount = ParamItem{
+		Key:          "queryCoord.enableEstimateGrowingRowCount",
+		Version:      "2.3.19",
+		DefaultValue: "true",
+		PanicIfEmpty: true,
+		Doc:          "whether enable to estimate max row count of growing segment",
+		Export:       true,
+	}
+	p.EnableEstimateGrowingRowCount.Init(base.mgr)
+
+	p.EstimateGrowingRowCountPerSegment = ParamItem{
+		Key:          "queryCoord.estimateGrowingRowCountPerSegment",
+		Version:      "2.3.19",
+		DefaultValue: "10000",
+		PanicIfEmpty: true,
+		Doc:          "the estimate max row count of growing segment",
+		Export:       true,
+	}
+	p.EstimateGrowingRowCountPerSegment.Init(base.mgr)
 
 	p.BalanceCostThreshold = ParamItem{
 		Key:          "queryCoord.balanceCostThreshold",

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -1554,8 +1554,7 @@ type queryCoordConfig struct {
 	RowCountMaxSteps                    ParamItem `refreshable:"true"`
 	RandomMaxSteps                      ParamItem `refreshable:"true"`
 	GrowingRowCountWeight               ParamItem `refreshable:"true"`
-	EnableEstimateGrowingRowCount       ParamItem `refreshable:"true"`
-	EstimateGrowingRowCountPerSegment   ParamItem `refreshable:"true"`
+	DelegatorMemoryOverloadFactor       ParamItem `refreshable:"true`
 	BalanceCostThreshold                ParamItem `refreshable:"true"`
 
 	SegmentCheckInterval       ParamItem `refreshable:"true"`
@@ -1790,25 +1789,15 @@ func (p *queryCoordConfig) init(base *BaseTable) {
 	}
 	p.GrowingRowCountWeight.Init(base.mgr)
 
-	p.EnableEstimateGrowingRowCount = ParamItem{
-		Key:          "queryCoord.enableEstimateGrowingRowCount",
+	p.DelegatorMemoryOverloadFactor = ParamItem{
+		Key:          "queryCoord.delegatorMemoryOverloadFactor",
 		Version:      "2.3.19",
-		DefaultValue: "true",
+		DefaultValue: "0.3",
 		PanicIfEmpty: true,
-		Doc:          "whether enable to estimate max row count of growing segment",
+		Doc:          "the factor of delegator overloaded memory",
 		Export:       true,
 	}
-	p.EnableEstimateGrowingRowCount.Init(base.mgr)
-
-	p.EstimateGrowingRowCountPerSegment = ParamItem{
-		Key:          "queryCoord.estimateGrowingRowCountPerSegment",
-		Version:      "2.3.19",
-		DefaultValue: "10000",
-		PanicIfEmpty: true,
-		Doc:          "the estimate max row count of growing segment",
-		Export:       true,
-	}
-	p.EstimateGrowingRowCountPerSegment.Init(base.mgr)
+	p.DelegatorMemoryOverloadFactor.Init(base.mgr)
 
 	p.BalanceCostThreshold = ParamItem{
 		Key:          "queryCoord.balanceCostThreshold",

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -320,8 +320,7 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, 200, Params.CheckExecutedFlagInterval.GetAsInt())
 		params.Reset("queryCoord.checkExecutedFlagInterval")
 
-		assert.Equal(t, true, Params.EnableEstimateGrowingRowCount.GetAsBool())
-		assert.Equal(t, 10000, Params.EstimateGrowingRowCountPerSegment.GetAsInt())
+		assert.Equal(t, 0.3, Params.DelegatorMemoryOverloadFactor.GetAsFloat())
 	})
 
 	t.Run("test queryNodeConfig", func(t *testing.T) {

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -319,6 +319,9 @@ func TestComponentParam(t *testing.T) {
 		params.Save("queryCoord.checkExecutedFlagInterval", "200")
 		assert.Equal(t, 200, Params.CheckExecutedFlagInterval.GetAsInt())
 		params.Reset("queryCoord.checkExecutedFlagInterval")
+
+		assert.Equal(t, true, Params.EnableEstimateGrowingRowCount.GetAsBool())
+		assert.Equal(t, 10000, Params.EstimateGrowingRowCountPerSegment.GetAsInt())
 	})
 
 	t.Run("test queryNodeConfig", func(t *testing.T) {

--- a/tests/integration/replicas/balance/replica_test.go
+++ b/tests/integration/replicas/balance/replica_test.go
@@ -50,8 +50,6 @@ func (s *ReplicaTestSuit) SetupSuite() {
 	paramtable.Init()
 	paramtable.Get().Save(paramtable.Get().QueryCoordCfg.BalanceCheckInterval.Key, "1000")
 	paramtable.Get().Save(paramtable.Get().QueryNodeCfg.GracefulStopTimeout.Key, "1")
-	paramtable.Get().Save(paramtable.Get().QueryCoordCfg.EnableEstimateGrowingRowCount.Key, "false")
-
 	s.Require().NoError(s.SetupEmbedEtcd())
 }
 

--- a/tests/integration/replicas/balance/replica_test.go
+++ b/tests/integration/replicas/balance/replica_test.go
@@ -50,6 +50,7 @@ func (s *ReplicaTestSuit) SetupSuite() {
 	paramtable.Init()
 	paramtable.Get().Save(paramtable.Get().QueryCoordCfg.BalanceCheckInterval.Key, "1000")
 	paramtable.Get().Save(paramtable.Get().QueryNodeCfg.GracefulStopTimeout.Key, "1")
+	paramtable.Get().Save(paramtable.Get().QueryCoordCfg.EnableEstimateGrowingRowCount.Key, "false")
 
 	s.Require().NoError(s.SetupEmbedEtcd())
 }


### PR DESCRIPTION
issue: #34595
When consuming insert data on the delegator node, QueryCoord will move out some sealed segments to manage its memory usage. After the growing segment gets flushed, some sealed segments from other workers will be moved back to the delegator node. To avoid the frequent movement of segments, we estimate the maximum growing row count and preserve a fixed-size memory in the delegator node.