### PR TITLE
Preserve mem on delegator24

### DIFF
--- a/internal/querycoordv2/balance/channel_level_score_balancer_test.go
+++ b/internal/querycoordv2/balance/channel_level_score_balancer_test.go
@@ -303,6 +303,8 @@ func (suite *ChannelLevelScoreBalancerTestSuite) TestAssignSegmentWithGrowing() 
 	defer suite.TearDownTest()
 	balancer := suite.balancer
 
+	paramtable.Get().Save(paramtable.Get().QueryCoordCfg.EnableEstimateGrowingRowCount.Key, "false")
+
 	distributions := map[int64][]*meta.Segment{
 		1: {
 			{SegmentInfo: &datapb.SegmentInfo{ID: 1, NumOfRows: 20, CollectionID: 1}, Node: 1},

--- a/internal/querycoordv2/balance/score_based_balancer.go
+++ b/internal/querycoordv2/balance/score_based_balancer.go
@@ -159,8 +159,21 @@ func (b *ScoreBasedBalancer) calculateScore(collectionID, nodeID int64) int {
 
 	// calculate global growing segment row count
 	views := b.dist.LeaderViewManager.GetByFilter(meta.WithNodeID2LeaderView(nodeID))
-	for _, view := range views {
-		nodeRowCount += int(float64(view.NumOfGrowingRows) * params.Params.QueryCoordCfg.GrowingRowCountWeight.GetAsFloat())
+	if paramtable.Get().QueryCoordCfg.EnableEstimateGrowingRowCount.GetAsBool() {
+		collectionViews := lo.GroupBy(views, func(v *meta.LeaderView) int64 { return v.CollectionID })
+		for cid, vs := range collectionViews {
+			partitionNum := len(b.meta.GetPartitionsByCollection(cid))
+			estimateRowCount := paramtable.Get().QueryCoordCfg.EstimateGrowingRowCountPerSegment.GetAsInt()
+			growingFactor := params.Params.QueryCoordCfg.GrowingRowCountWeight.GetAsFloat()
+
+			// there will be at most (2* partition_num) growing segments, and each segment will have estimateRowCount rows
+			// for each growing row on qn, we need move out growingFactor sealed rows
+			nodeRowCount += int(float64(2*partitionNum*estimateRowCount)*growingFactor) * len(vs)
+		}
+	} else {
+		for _, view := range views {
+			nodeRowCount += int(float64(view.NumOfGrowingRows) * params.Params.QueryCoordCfg.GrowingRowCountWeight.GetAsFloat())
+		}
 	}
 
 	// calculate executing task cost in scheduler
@@ -175,8 +188,18 @@ func (b *ScoreBasedBalancer) calculateScore(collectionID, nodeID int64) int {
 
 	// calculate collection growing segment row count
 	collectionViews := b.dist.LeaderViewManager.GetByFilter(meta.WithCollectionID2LeaderView(collectionID), meta.WithNodeID2LeaderView(nodeID))
-	for _, view := range collectionViews {
-		collectionRowCount += int(float64(view.NumOfGrowingRows) * params.Params.QueryCoordCfg.GrowingRowCountWeight.GetAsFloat())
+	if paramtable.Get().QueryCoordCfg.EnableEstimateGrowingRowCount.GetAsBool() {
+		partitionNum := len(b.meta.GetPartitionsByCollection(collectionID))
+		estimateRowCount := paramtable.Get().QueryCoordCfg.EstimateGrowingRowCountPerSegment.GetAsInt()
+		growingFactor := params.Params.QueryCoordCfg.GrowingRowCountWeight.GetAsFloat()
+
+		// there will be at most (2* partition_num) growing segments, and each segment will have estimateRowCount rows
+		// for each growing row on qn, we need move out growingFactor sealed rows
+		collectionRowCount += int(float64(2*partitionNum*estimateRowCount)*growingFactor) * len(collectionViews)
+	} else {
+		for _, view := range collectionViews {
+			collectionRowCount += int(float64(view.NumOfGrowingRows) * params.Params.QueryCoordCfg.GrowingRowCountWeight.GetAsFloat())
+		}
 	}
 
 	// calculate executing task cost in scheduler

--- a/internal/querycoordv2/balance/score_based_balancer_test.go
+++ b/internal/querycoordv2/balance/score_based_balancer_test.go
@@ -303,6 +303,16 @@ func (suite *ScoreBasedBalancerTestSuite) TestAssignSegmentWithGrowing() {
 	defer suite.TearDownTest()
 	balancer := suite.balancer
 
+	paramtable.Get().Save(paramtable.Get().QueryCoordCfg.EnableEstimateGrowingRowCount.Key, "false")
+	suite.balancer.meta.PutCollection(&meta.Collection{
+		CollectionLoadInfo: &querypb.CollectionLoadInfo{
+			CollectionID: 1,
+		},
+	}, &meta.Partition{
+		PartitionLoadInfo: &querypb.PartitionLoadInfo{
+			PartitionID: 1,
+		},
+	})
 	distributions := map[int64][]*meta.Segment{
 		1: {
 			{SegmentInfo: &datapb.SegmentInfo{ID: 1, NumOfRows: 20, CollectionID: 1}, Node: 1},
@@ -339,6 +349,18 @@ func (suite *ScoreBasedBalancerTestSuite) TestAssignSegmentWithGrowing() {
 	}
 	suite.balancer.dist.LeaderViewManager.Update(1, leaderView)
 	plans := balancer.AssignSegment(1, toAssign, lo.Keys(distributions), false)
+	for _, p := range plans {
+		suite.Equal(int64(2), p.To)
+	}
+
+	// test enable estimate growing row count
+	paramtable.Get().Save(paramtable.Get().QueryCoordCfg.EnableEstimateGrowingRowCount.Key, "true")
+	leaderView = &meta.LeaderView{
+		ID:           1,
+		CollectionID: 1,
+	}
+	suite.balancer.dist.LeaderViewManager.Update(1, leaderView)
+	plans = balancer.AssignSegment(1, toAssign, lo.Keys(distributions), false)
 	for _, p := range plans {
 		suite.Equal(int64(2), p.To)
 	}

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -1540,6 +1540,8 @@ type queryCoordConfig struct {
 	RowCountMaxSteps                    ParamItem `refreshable:"true"`
 	RandomMaxSteps                      ParamItem `refreshable:"true"`
 	GrowingRowCountWeight               ParamItem `refreshable:"true"`
+	EnableEstimateGrowingRowCount       ParamItem `refreshable:"true"`
+	EstimateGrowingRowCountPerSegment   ParamItem `refreshable:"true"`
 	BalanceCostThreshold                ParamItem `refreshable:"true"`
 
 	SegmentCheckInterval       ParamItem `refreshable:"true"`
@@ -1773,6 +1775,26 @@ func (p *queryCoordConfig) init(base *BaseTable) {
 		Export:       true,
 	}
 	p.GrowingRowCountWeight.Init(base.mgr)
+
+	p.EnableEstimateGrowingRowCount = ParamItem{
+		Key:          "queryCoord.enableEstimateGrowingRowCount",
+		Version:      "2.3.19",
+		DefaultValue: "true",
+		PanicIfEmpty: true,
+		Doc:          "whether enable to estimate max row count of growing segment",
+		Export:       true,
+	}
+	p.EnableEstimateGrowingRowCount.Init(base.mgr)
+
+	p.EstimateGrowingRowCountPerSegment = ParamItem{
+		Key:          "queryCoord.estimateGrowingRowCountPerSegment",
+		Version:      "2.3.19",
+		DefaultValue: "10000",
+		PanicIfEmpty: true,
+		Doc:          "the estimate max row count of growing segment",
+		Export:       true,
+	}
+	p.EstimateGrowingRowCountPerSegment.Init(base.mgr)
 
 	p.BalanceCostThreshold = ParamItem{
 		Key:          "queryCoord.balanceCostThreshold",

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -319,6 +319,9 @@ func TestComponentParam(t *testing.T) {
 		params.Save("queryCoord.checkExecutedFlagInterval", "200")
 		assert.Equal(t, 200, Params.CheckExecutedFlagInterval.GetAsInt())
 		params.Reset("queryCoord.checkExecutedFlagInterval")
+
+		assert.Equal(t, true, Params.EnableEstimateGrowingRowCount.GetAsBool())
+		assert.Equal(t, 10000, Params.EstimateGrowingRowCountPerSegment.GetAsInt())
 	})
 
 	t.Run("test queryNodeConfig", func(t *testing.T) {


### PR DESCRIPTION
issue: #34595
pr: #34596
When consuming insert data on the delegator node, QueryCoord will move out some sealed segments to manage its memory usage. After the growing segment gets flushed, some sealed segments from other workers will be moved back to the delegator node. To avoid the frequent movement of segments, we estimate the maximum growing row count and preserve a fixed-size memory in the delegator node.