### PR TITLE
enhance: Preserve fixed-size memory in delegator node for growing segment

### DIFF
--- a/internal/querycoordv2/balance/score_based_balancer.go
+++ b/internal/querycoordv2/balance/score_based_balancer.go
@@ -157,8 +157,21 @@ func (b *ScoreBasedBalancer) calculateScore(collectionID, nodeID int64) int {
 
 	// calculate global growing segment row count
 	views := b.dist.GetLeaderView(nodeID)
-	for _, view := range views {
-		nodeRowCount += int(float64(view.NumOfGrowingRows) * params.Params.QueryCoordCfg.GrowingRowCountWeight.GetAsFloat())
+	if paramtable.Get().QueryCoordCfg.EnableEstimateGrowingRowCount.GetAsBool() {
+		collectionViews := lo.GroupBy(lo.Values(views), func(v *meta.LeaderView) int64 { return v.CollectionID })
+		for cid, vs := range collectionViews {
+			partitionNum := len(b.meta.GetPartitionsByCollection(cid))
+			estimateRowCount := paramtable.Get().QueryCoordCfg.EstimateGrowingRowCountPerSegment.GetAsInt()
+			growingFactor := params.Params.QueryCoordCfg.GrowingRowCountWeight.GetAsFloat()
+
+			// there will be at most (2* partition_num) growing segments, and each segment will have estimateRowCount rows
+			// for each growing row on qn, we need move out growingFactor sealed rows
+			nodeRowCount += int(float64(2*partitionNum*estimateRowCount)*growingFactor) * len(vs)
+		}
+	} else {
+		for _, view := range views {
+			nodeRowCount += int(float64(view.NumOfGrowingRows) * params.Params.QueryCoordCfg.GrowingRowCountWeight.GetAsFloat())
+		}
 	}
 
 	// calculate executing task cost in scheduler
@@ -173,8 +186,18 @@ func (b *ScoreBasedBalancer) calculateScore(collectionID, nodeID int64) int {
 
 	// calculate collection growing segment row count
 	collectionViews := b.dist.LeaderViewManager.GetByCollectionAndNode(collectionID, nodeID)
-	for _, view := range collectionViews {
-		collectionRowCount += int(float64(view.NumOfGrowingRows) * params.Params.QueryCoordCfg.GrowingRowCountWeight.GetAsFloat())
+	if paramtable.Get().QueryCoordCfg.EnableEstimateGrowingRowCount.GetAsBool() {
+		partitionNum := len(b.meta.GetPartitionsByCollection(collectionID))
+		estimateRowCount := paramtable.Get().QueryCoordCfg.EstimateGrowingRowCountPerSegment.GetAsInt()
+		growingFactor := params.Params.QueryCoordCfg.GrowingRowCountWeight.GetAsFloat()
+
+		// there will be at most (2* partition_num) growing segments, and each segment will have estimateRowCount rows
+		// for each growing row on qn, we need move out growingFactor sealed rows
+		collectionRowCount += int(float64(2*partitionNum*estimateRowCount)*growingFactor) * len(collectionViews)
+	} else {
+		for _, view := range collectionViews {
+			collectionRowCount += int(float64(view.NumOfGrowingRows) * params.Params.QueryCoordCfg.GrowingRowCountWeight.GetAsFloat())
+		}
 	}
 
 	// calculate executing task cost in scheduler

--- a/internal/querycoordv2/balance/score_based_balancer.go
+++ b/internal/querycoordv2/balance/score_based_balancer.go
@@ -148,30 +148,22 @@ func (b *ScoreBasedBalancer) convertToNodeItems(collectionID int64, nodeIDs []in
 }
 
 func (b *ScoreBasedBalancer) calculateScore(collectionID, nodeID int64) int {
+	delegatorOverloadFactor := params.Params.QueryCoordCfg.DelegatorMemoryOverloadFactor.GetAsFloat()
+
 	nodeRowCount := 0
+	nodeCollectionRowCount := make(map[int64]int)
 	// calculate global sealed segment row count
 	globalSegments := b.dist.SegmentDistManager.GetByNode(nodeID)
 	for _, s := range globalSegments {
 		nodeRowCount += int(s.GetNumOfRows())
+		nodeCollectionRowCount[s.CollectionID] += int(s.GetNumOfRows())
 	}
 
 	// calculate global growing segment row count
 	views := b.dist.GetLeaderView(nodeID)
-	if paramtable.Get().QueryCoordCfg.EnableEstimateGrowingRowCount.GetAsBool() {
-		collectionViews := lo.GroupBy(lo.Values(views), func(v *meta.LeaderView) int64 { return v.CollectionID })
-		for cid, vs := range collectionViews {
-			partitionNum := len(b.meta.GetPartitionsByCollection(cid))
-			estimateRowCount := paramtable.Get().QueryCoordCfg.EstimateGrowingRowCountPerSegment.GetAsInt()
-			growingFactor := params.Params.QueryCoordCfg.GrowingRowCountWeight.GetAsFloat()
-
-			// there will be at most (2* partition_num) growing segments, and each segment will have estimateRowCount rows
-			// for each growing row on qn, we need move out growingFactor sealed rows
-			nodeRowCount += int(float64(2*partitionNum*estimateRowCount)*growingFactor) * len(vs)
-		}
-	} else {
-		for _, view := range views {
-			nodeRowCount += int(float64(view.NumOfGrowingRows) * params.Params.QueryCoordCfg.GrowingRowCountWeight.GetAsFloat())
-		}
+	for _, view := range views {
+		nodeRowCount += int(float64(view.NumOfGrowingRows))
+		nodeRowCount += int(float64(nodeCollectionRowCount[view.CollectionID]) * delegatorOverloadFactor)
 	}
 
 	// calculate executing task cost in scheduler
@@ -186,18 +178,9 @@ func (b *ScoreBasedBalancer) calculateScore(collectionID, nodeID int64) int {
 
 	// calculate collection growing segment row count
 	collectionViews := b.dist.LeaderViewManager.GetByCollectionAndNode(collectionID, nodeID)
-	if paramtable.Get().QueryCoordCfg.EnableEstimateGrowingRowCount.GetAsBool() {
-		partitionNum := len(b.meta.GetPartitionsByCollection(collectionID))
-		estimateRowCount := paramtable.Get().QueryCoordCfg.EstimateGrowingRowCountPerSegment.GetAsInt()
-		growingFactor := params.Params.QueryCoordCfg.GrowingRowCountWeight.GetAsFloat()
-
-		// there will be at most (2* partition_num) growing segments, and each segment will have estimateRowCount rows
-		// for each growing row on qn, we need move out growingFactor sealed rows
-		collectionRowCount += int(float64(2*partitionNum*estimateRowCount)*growingFactor) * len(collectionViews)
-	} else {
-		for _, view := range collectionViews {
-			collectionRowCount += int(float64(view.NumOfGrowingRows) * params.Params.QueryCoordCfg.GrowingRowCountWeight.GetAsFloat())
-		}
+	for _, view := range collectionViews {
+		collectionRowCount += int(float64(view.NumOfGrowingRows))
+		collectionRowCount += int(float64(collectionRowCount) * delegatorOverloadFactor)
 	}
 
 	// calculate executing task cost in scheduler

--- a/internal/querycoordv2/balance/score_based_balancer_test.go
+++ b/internal/querycoordv2/balance/score_based_balancer_test.go
@@ -295,7 +295,7 @@ func (suite *ScoreBasedBalancerTestSuite) TestAssignSegmentWithGrowing() {
 	defer suite.TearDownTest()
 	balancer := suite.balancer
 
-	paramtable.Get().Save(paramtable.Get().QueryCoordCfg.EnableEstimateGrowingRowCount.Key, "false")
+	paramtable.Get().Save(paramtable.Get().QueryCoordCfg.DelegatorMemoryOverloadFactor.Key, "0.3")
 	suite.balancer.meta.PutCollection(&meta.Collection{
 		CollectionLoadInfo: &querypb.CollectionLoadInfo{
 			CollectionID: 1,
@@ -308,10 +308,10 @@ func (suite *ScoreBasedBalancerTestSuite) TestAssignSegmentWithGrowing() {
 	})
 	distributions := map[int64][]*meta.Segment{
 		1: {
-			{SegmentInfo: &datapb.SegmentInfo{ID: 1, NumOfRows: 20, CollectionID: 1}, Node: 1},
+			{SegmentInfo: &datapb.SegmentInfo{ID: 1, NumOfRows: 100, CollectionID: 1}, Node: 1},
 		},
 		2: {
-			{SegmentInfo: &datapb.SegmentInfo{ID: 2, NumOfRows: 20, CollectionID: 1}, Node: 2},
+			{SegmentInfo: &datapb.SegmentInfo{ID: 2, NumOfRows: 100, CollectionID: 1}, Node: 2},
 		},
 	}
 	for node, s := range distributions {
@@ -332,24 +332,11 @@ func (suite *ScoreBasedBalancerTestSuite) TestAssignSegmentWithGrowing() {
 
 	// mock 50 growing row count in node 1, which is delegator, expect all segment assign to node 2
 	leaderView := &meta.LeaderView{
-		ID:               1,
-		CollectionID:     1,
-		NumOfGrowingRows: 50,
-	}
-	suite.balancer.dist.LeaderViewManager.Update(1, leaderView)
-	plans := balancer.AssignSegment(1, toAssign, lo.Keys(distributions), false)
-	for _, p := range plans {
-		suite.Equal(int64(2), p.To)
-	}
-
-	// test enable estimate growing row count
-	paramtable.Get().Save(paramtable.Get().QueryCoordCfg.EnableEstimateGrowingRowCount.Key, "true")
-	leaderView = &meta.LeaderView{
 		ID:           1,
 		CollectionID: 1,
 	}
 	suite.balancer.dist.LeaderViewManager.Update(1, leaderView)
-	plans = balancer.AssignSegment(1, toAssign, lo.Keys(distributions), false)
+	plans := balancer.AssignSegment(1, toAssign, lo.Keys(distributions), false)
 	for _, p := range plans {
 		suite.Equal(int64(2), p.To)
 	}

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -1384,8 +1384,8 @@ type queryCoordConfig struct {
 	BalanceIntervalSeconds              ParamItem `refreshable:"true"`
 	MemoryUsageMaxDifferencePercentage  ParamItem `refreshable:"true"`
 	GrowingRowCountWeight               ParamItem `refreshable:"true"`
-	EnableEstimateGrowingRowCount       ParamItem `refreshable:"true"`
-	EstimateGrowingRowCountPerSegment   ParamItem `refreshable:"true"`
+	DelegatorMemoryOverloadFactor       ParamItem `refreshable:"true`
+	BalanceCostThreshold                ParamItem `refreshable:"true"`
 
 	SegmentCheckInterval       ParamItem `refreshable:"true"`
 	ChannelCheckInterval       ParamItem `refreshable:"true"`
@@ -1557,25 +1557,15 @@ func (p *queryCoordConfig) init(base *BaseTable) {
 	}
 	p.GrowingRowCountWeight.Init(base.mgr)
 
-	p.EnableEstimateGrowingRowCount = ParamItem{
-		Key:          "queryCoord.enableEstimateGrowingRowCount",
+	p.DelegatorMemoryOverloadFactor = ParamItem{
+		Key:          "queryCoord.delegatorMemoryOverloadFactor",
 		Version:      "2.3.19",
-		DefaultValue: "true",
+		DefaultValue: "0.3",
 		PanicIfEmpty: true,
-		Doc:          "whether enable to estimate max row count of growing segment",
+		Doc:          "the factor of delegator overloaded memory",
 		Export:       true,
 	}
-	p.EnableEstimateGrowingRowCount.Init(base.mgr)
-
-	p.EstimateGrowingRowCountPerSegment = ParamItem{
-		Key:          "queryCoord.estimateGrowingRowCountPerSegment",
-		Version:      "2.3.19",
-		DefaultValue: "10000",
-		PanicIfEmpty: true,
-		Doc:          "the estimate max row count of growing segment",
-		Export:       true,
-	}
-	p.EstimateGrowingRowCountPerSegment.Init(base.mgr)
+	p.DelegatorMemoryOverloadFactor.Init(base.mgr)
 
 	p.MemoryUsageMaxDifferencePercentage = ParamItem{
 		Key:          "queryCoord.memoryUsageMaxDifferencePercentage",

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -1384,6 +1384,8 @@ type queryCoordConfig struct {
 	BalanceIntervalSeconds              ParamItem `refreshable:"true"`
 	MemoryUsageMaxDifferencePercentage  ParamItem `refreshable:"true"`
 	GrowingRowCountWeight               ParamItem `refreshable:"true"`
+	EnableEstimateGrowingRowCount       ParamItem `refreshable:"true"`
+	EstimateGrowingRowCountPerSegment   ParamItem `refreshable:"true"`
 
 	SegmentCheckInterval       ParamItem `refreshable:"true"`
 	ChannelCheckInterval       ParamItem `refreshable:"true"`
@@ -1554,6 +1556,26 @@ func (p *queryCoordConfig) init(base *BaseTable) {
 		Export:       true,
 	}
 	p.GrowingRowCountWeight.Init(base.mgr)
+
+	p.EnableEstimateGrowingRowCount = ParamItem{
+		Key:          "queryCoord.enableEstimateGrowingRowCount",
+		Version:      "2.3.19",
+		DefaultValue: "true",
+		PanicIfEmpty: true,
+		Doc:          "whether enable to estimate max row count of growing segment",
+		Export:       true,
+	}
+	p.EnableEstimateGrowingRowCount.Init(base.mgr)
+
+	p.EstimateGrowingRowCountPerSegment = ParamItem{
+		Key:          "queryCoord.estimateGrowingRowCountPerSegment",
+		Version:      "2.3.19",
+		DefaultValue: "10000",
+		PanicIfEmpty: true,
+		Doc:          "the estimate max row count of growing segment",
+		Export:       true,
+	}
+	p.EstimateGrowingRowCountPerSegment.Init(base.mgr)
 
 	p.MemoryUsageMaxDifferencePercentage = ParamItem{
 		Key:          "queryCoord.memoryUsageMaxDifferencePercentage",

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -315,8 +315,7 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, 200, Params.CheckExecutedFlagInterval.GetAsInt())
 		params.Reset("queryCoord.checkExecutedFlagInterval")
 
-		assert.Equal(t, true, Params.EnableEstimateGrowingRowCount.GetAsBool())
-		assert.Equal(t, 10000, Params.EstimateGrowingRowCountPerSegment.GetAsInt())
+		assert.Equal(t, 0.3, Params.DelegatorMemoryOverloadFactor.GetAsFloat())
 	})
 
 	t.Run("test queryNodeConfig", func(t *testing.T) {

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -314,6 +314,9 @@ func TestComponentParam(t *testing.T) {
 		params.Save("queryCoord.checkExecutedFlagInterval", "200")
 		assert.Equal(t, 200, Params.CheckExecutedFlagInterval.GetAsInt())
 		params.Reset("queryCoord.checkExecutedFlagInterval")
+
+		assert.Equal(t, true, Params.EnableEstimateGrowingRowCount.GetAsBool())
+		assert.Equal(t, 10000, Params.EstimateGrowingRowCountPerSegment.GetAsInt())
 	})
 
 	t.Run("test queryNodeConfig", func(t *testing.T) {


### PR DESCRIPTION
issue: #34595
pr: #34596

When consuming insert data on the delegator node, QueryCoord will move out some sealed segments to manage its memory usage. After the growing segment gets flushed, some sealed segments from other workers will be moved back to the delegator node. To avoid the frequent movement of segments, we estimate the maximum growing row count and preserve a fixed-size memory in the delegator node.