### PR TITLE
enhance: [2.4] Add lint rule to forbid gogo protobuf (#34594)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -118,6 +118,8 @@ linters-settings:
             desc: not allowed, use github.com/tikv/client-go/v2/txnkv
           - pkg: "github.com/tikv/client-go/v2/rawkv"
             desc: not allowed, use github.com/tikv/client-go/v2/txnkv
+          - pkg: "github.com/gogo/protobuf"
+            desc: "not allowed, gogo protobuf is deprecated"
   forbidigo:
     forbid:
       - '^time\.Tick$'

--- a/internal/datacoord/channel.go
+++ b/internal/datacoord/channel.go
@@ -19,7 +19,7 @@ package datacoord
 import (
 	"fmt"
 
-	"github.com/gogo/protobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"

--- a/internal/querynodev2/services_test.go
+++ b/internal/querynodev2/services_test.go
@@ -27,7 +27,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
-	"github.com/gogo/protobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"

--- a/internal/storage/insert_data.go
+++ b/internal/storage/insert_data.go
@@ -20,7 +20,7 @@ import (
 	"encoding/binary"
 	"fmt"
 
-	"github.com/gogo/protobuf/proto"
+	"github.com/golang/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/pkg/common"


### PR DESCRIPTION
Cherry pick from master
pr: #34594
github.com/gogo/protobuf is deprecated and could be error prune after upgrade protobuf message to v2.