### PR TITLE
enhance: new knowhere param  for range_search

### DIFF
--- a/internal/core/src/index/VectorDiskIndex.cpp
+++ b/internal/core/src/index/VectorDiskIndex.cpp
@@ -371,6 +371,10 @@ VectorDiskAnnIndex<T>::Query(const DatasetPtr dataset,
             GetValueFromConfig<float>(search_info.search_params_, RADIUS);
         if (radius.has_value()) {
             search_config[RADIUS] = radius.value();
+            // `range_search_k` is only used as one of the conditions for iterator early termination.
+            // not gurantee to return exactly `range_search_k` results, which may be more or less.
+            // set it to -1 will return all results in the range.
+            search_config[knowhere::meta::RANGE_SEARCH_K] = topk;
             auto range_filter = GetValueFromConfig<float>(
                 search_info.search_params_, RANGE_FILTER);
             if (range_filter.has_value()) {

--- a/internal/core/src/index/VectorMemIndex.cpp
+++ b/internal/core/src/index/VectorMemIndex.cpp
@@ -600,6 +600,10 @@ VectorMemIndex<T>::Query(const DatasetPtr dataset,
                                       search_conf[RANGE_FILTER],
                                       GetMetricType());
             }
+            // `range_search_k` is only used as one of the conditions for iterator early termination.
+            // not gurantee to return exactly `range_search_k` results, which may be more or less.
+            // set it to -1 will return all results in the range.
+            search_conf[knowhere::meta::RANGE_SEARCH_K] = topk;
             milvus::tracer::AddEvent("start_knowhere_index_range_search");
             auto res = index_.RangeSearch(dataset, search_conf, bitset);
             milvus::tracer::AddEvent("finish_knowhere_index_range_search");

--- a/internal/core/src/query/SearchBruteForce.cpp
+++ b/internal/core/src/query/SearchBruteForce.cpp
@@ -84,6 +84,10 @@ BruteForceSearch(const dataset::SearchDataset& dataset,
         query_dataset->SetIsSparse(true);
     }
     auto search_cfg = PrepareBFSearchParams(search_info);
+    // `range_search_k` is only used as one of the conditions for iterator early termination.
+    // not gurantee to return exactly `range_search_k` results, which may be more or less.
+    // set it to -1 will return all results in the range.
+    search_cfg[knowhere::meta::RANGE_SEARCH_K] = topk;
 
     sub_result.mutable_seg_offsets().resize(nq * topk);
     sub_result.mutable_distances().resize(nq * topk);


### PR DESCRIPTION
issue: #34685 
knowhere needs a new json param `range_search_k` for RangeSearch to early terminate the iterator.