### PR TITLE
enhance: Allow empty sparse row

### DIFF
--- a/internal/core/src/common/Utils.h
+++ b/internal/core/src/common/Utils.h
@@ -224,7 +224,6 @@ CopyAndWrapSparseRow(const void* data,
     knowhere::sparse::SparseRow<float> row(num_elements);
     std::memcpy(row.data(), data, size);
     if (validate) {
-        AssertInfo(size > 0, "Sparse row data should not be empty");
         AssertInfo(
             size % knowhere::sparse::SparseRow<float>::element_size() == 0,
             "Invalid size for sparse row data");

--- a/internal/core/src/segcore/FieldIndexing.h
+++ b/internal/core/src/segcore/FieldIndexing.h
@@ -282,14 +282,14 @@ class IndexingRecord {
                 //Small-Index enabled, create index for vector field only
                 if (index_meta_->GetIndexMaxRowCount() > 0 &&
                     index_meta_->HasFiled(field_id)) {
-                    auto vec_filed_meta =
+                    auto vec_field_meta =
                         index_meta_->GetFieldIndexMeta(field_id);
                     //Disable growing index for flat
-                    if (!vec_filed_meta.IsFlatIndex()) {
+                    if (!vec_field_meta.IsFlatIndex()) {
                         field_indexings_.try_emplace(
                             field_id,
                             CreateIndex(field_meta,
-                                        vec_filed_meta,
+                                        vec_field_meta,
                                         index_meta_->GetIndexMaxRowCount(),
                                         segcore_config_));
                     }

--- a/pkg/util/typeutil/schema.go
+++ b/pkg/util/typeutil/schema.go
@@ -1540,8 +1540,8 @@ func trimSparseFloatArray(vec *schemapb.SparseFloatArray) {
 
 func ValidateSparseFloatRows(rows ...[]byte) error {
 	for _, row := range rows {
-		if len(row) == 0 {
-			return errors.New("empty sparse float vector row")
+		if row == nil {
+			return errors.New("nil sparse float vector")
 		}
 		if len(row)%8 != 0 {
 			return fmt.Errorf("invalid data length in sparse float vector: %d", len(row))
@@ -1630,7 +1630,8 @@ func CreateSparseFloatRowFromMap(input map[string]interface{}) ([]byte, error) {
 	var values []float32
 
 	if len(input) == 0 {
-		return nil, fmt.Errorf("empty JSON input")
+		// for empty json input, return empty sparse row
+		return CreateSparseFloatRow(indices, values), nil
 	}
 
 	getValue := func(key interface{}) (float32, error) {
@@ -1726,9 +1727,6 @@ func CreateSparseFloatRowFromMap(input map[string]interface{}) ([]byte, error) {
 	if len(indices) != len(values) {
 		return nil, fmt.Errorf("indices and values length mismatch")
 	}
-	if len(indices) == 0 {
-		return nil, fmt.Errorf("empty indices/values in JSON input")
-	}
 
 	sortedIndices, sortedValues := SortSparseFloatRow(indices, values)
 	row := CreateSparseFloatRow(sortedIndices, sortedValues)
@@ -1749,7 +1747,8 @@ func CreateSparseFloatRowFromJSON(input []byte) ([]byte, error) {
 	return CreateSparseFloatRowFromMap(vec)
 }
 
-// dim of a sparse float vector is the maximum/last index + 1
+// dim of a sparse float vector is the maximum/last index + 1.
+// for an empty row, dim is 0.
 func SparseFloatRowDim(row []byte) int64 {
 	if len(row) == 0 {
 		return 0

--- a/tests/integration/sparse/sparse_test.go
+++ b/tests/integration/sparse/sparse_test.go
@@ -183,7 +183,7 @@ func (s *SparseTestSuite) TestSparse_invalid_insert() {
 	s.NotEqual(insertResult.GetStatus().GetErrorCode(), commonpb.ErrorCode_Success)
 	sparseVecs.Contents[0] = sparseVecs.Contents[0][:len(sparseVecs.Contents[0])-4]
 
-	// empty row is not allowed
+	// empty row is allowed
 	sparseVecs.Contents[0] = []byte{}
 	insertResult, err = c.Proxy.Insert(ctx, &milvuspb.InsertRequest{
 		DbName:         dbName,
@@ -193,7 +193,7 @@ func (s *SparseTestSuite) TestSparse_invalid_insert() {
 		NumRows:        uint32(rowNum),
 	})
 	s.NoError(err)
-	s.NotEqual(insertResult.GetStatus().GetErrorCode(), commonpb.ErrorCode_Success)
+	s.Equal(insertResult.GetStatus().GetErrorCode(), commonpb.ErrorCode_Success)
 
 	// unsorted column index is not allowed
 	sparseVecs.Contents[0] = make([]byte, 16)


### PR DESCRIPTION
issue: #29419

* If a sparse vector with 0 non-zero value is inserted, no ANN search on this sparse vector field will return it as a result. User may retrieve this row via scalar query or ANN search on another vector field though.
* If the user uses an empty sparse vector as the query vector for a ANN search, no neighbor will be returned.