### PR TITLE
fix:[cherry-pick] Reset flushed row num after pack segment for clustering compaction

### DIFF
--- a/internal/datanode/compaction/clustering_compactor.go
+++ b/internal/datanode/compaction/clustering_compactor.go
@@ -831,6 +831,8 @@ func (t *clusteringCompactionTask) packBufferToSegment(ctx context.Context, buff
 		zap.Int64("segID", seg.GetSegmentID()),
 		zap.Int64("row num", seg.GetNumOfRows()))
 
+	// reset
+	buffer.flushedRowNum.Store(0)
 	// set old writer nil
 	writer = nil
 	return nil


### PR DESCRIPTION
issue: #34703 
master pr: #34702 