### PR TITLE
enhance: Skip update collection next target if segment/channel list doesn't change

### DIFF
--- a/internal/querycoordv2/balance/channel_level_score_balancer_test.go
+++ b/internal/querycoordv2/balance/channel_level_score_balancer_test.go
@@ -429,9 +429,9 @@ func (suite *ChannelLevelScoreBalancerTestSuite) TestBalanceOneRound() {
 			balancer.meta.CollectionManager.PutCollection(collection)
 			balancer.meta.CollectionManager.PutPartition(utils.CreateTestPartition(c.collectionID, c.collectionID))
 			balancer.meta.ReplicaManager.Put(utils.CreateTestReplica(c.replicaID, c.collectionID, c.nodes))
-			balancer.targetMgr.UpdateCollectionNextTarget(c.collectionID)
+			balancer.targetMgr.ForceUpdateCollectionNextTarget(c.collectionID)
 			balancer.targetMgr.UpdateCollectionCurrentTarget(c.collectionID)
-			balancer.targetMgr.UpdateCollectionNextTarget(c.collectionID)
+			balancer.targetMgr.ForceUpdateCollectionNextTarget(c.collectionID)
 
 			// 2. set up target for distribution for multi collections
 			for node, s := range c.distributions {
@@ -550,9 +550,9 @@ func (suite *ChannelLevelScoreBalancerTestSuite) TestBalanceMultiRound() {
 		balancer.meta.CollectionManager.PutPartition(utils.CreateTestPartition(balanceCase.collectionIDs[i], balanceCase.collectionIDs[i]))
 		balancer.meta.ReplicaManager.Put(utils.CreateTestReplica(balanceCase.replicaIDs[i], balanceCase.collectionIDs[i],
 			append(balanceCase.nodes, balanceCase.notExistedNodes...)))
-		balancer.targetMgr.UpdateCollectionNextTarget(balanceCase.collectionIDs[i])
+		balancer.targetMgr.ForceUpdateCollectionNextTarget(balanceCase.collectionIDs[i])
 		balancer.targetMgr.UpdateCollectionCurrentTarget(balanceCase.collectionIDs[i])
-		balancer.targetMgr.UpdateCollectionNextTarget(balanceCase.collectionIDs[i])
+		balancer.targetMgr.ForceUpdateCollectionNextTarget(balanceCase.collectionIDs[i])
 	}
 
 	// 2. set up target for distribution for multi collections
@@ -709,9 +709,9 @@ func (suite *ChannelLevelScoreBalancerTestSuite) TestStoppedBalance() {
 			balancer.meta.CollectionManager.PutCollection(collection)
 			balancer.meta.CollectionManager.PutPartition(utils.CreateTestPartition(c.collectionID, c.collectionID))
 			balancer.meta.ReplicaManager.Put(utils.CreateTestReplica(c.replicaID, c.collectionID, c.nodes))
-			balancer.targetMgr.UpdateCollectionNextTarget(c.collectionID)
+			balancer.targetMgr.ForceUpdateCollectionNextTarget(c.collectionID)
 			balancer.targetMgr.UpdateCollectionCurrentTarget(c.collectionID)
-			balancer.targetMgr.UpdateCollectionNextTarget(c.collectionID)
+			balancer.targetMgr.ForceUpdateCollectionNextTarget(c.collectionID)
 
 			// 2. set up target for distribution for multi collections
 			for node, s := range c.distributions {
@@ -829,9 +829,9 @@ func (suite *ChannelLevelScoreBalancerTestSuite) TestMultiReplicaBalance() {
 			for replicaID, nodes := range c.replicaWithNodes {
 				balancer.meta.ReplicaManager.Put(utils.CreateTestReplica(replicaID, c.collectionID, nodes))
 			}
-			balancer.targetMgr.UpdateCollectionNextTarget(c.collectionID)
+			balancer.targetMgr.ForceUpdateCollectionNextTarget(c.collectionID)
 			balancer.targetMgr.UpdateCollectionCurrentTarget(c.collectionID)
-			balancer.targetMgr.UpdateCollectionNextTarget(c.collectionID)
+			balancer.targetMgr.ForceUpdateCollectionNextTarget(c.collectionID)
 
 			// 2. set up target for distribution for multi collections
 			for node, s := range c.segmentDist {
@@ -922,9 +922,9 @@ func (suite *ChannelLevelScoreBalancerTestSuite) TestExclusiveChannelBalance_Cha
 	balancer.meta.CollectionManager.PutCollection(collection)
 	balancer.meta.CollectionManager.PutPartition(utils.CreateTestPartition(collectionID, partitionID))
 	balancer.meta.ReplicaManager.Spawn(1, map[string]int{meta.DefaultResourceGroupName: 1}, []string{"channel1", "channel2"})
-	balancer.targetMgr.UpdateCollectionNextTarget(collectionID)
+	balancer.targetMgr.ForceUpdateCollectionNextTarget(collectionID)
 	balancer.targetMgr.UpdateCollectionCurrentTarget(collectionID)
-	balancer.targetMgr.UpdateCollectionNextTarget(collectionID)
+	balancer.targetMgr.ForceUpdateCollectionNextTarget(collectionID)
 
 	// 3. set up nodes info and resourceManager for balancer
 	nodeCount := 4
@@ -997,9 +997,9 @@ func (suite *ChannelLevelScoreBalancerTestSuite) TestExclusiveChannelBalance_Seg
 	balancer.meta.CollectionManager.PutCollection(collection)
 	balancer.meta.CollectionManager.PutPartition(utils.CreateTestPartition(collectionID, partitionID))
 	balancer.meta.ReplicaManager.Spawn(1, map[string]int{meta.DefaultResourceGroupName: 1}, []string{"channel1", "channel2"})
-	balancer.targetMgr.UpdateCollectionNextTarget(collectionID)
+	balancer.targetMgr.ForceUpdateCollectionNextTarget(collectionID)
 	balancer.targetMgr.UpdateCollectionCurrentTarget(collectionID)
-	balancer.targetMgr.UpdateCollectionNextTarget(collectionID)
+	balancer.targetMgr.ForceUpdateCollectionNextTarget(collectionID)
 
 	// 3. set up nodes info and resourceManager for balancer
 	nodeCount := 4
@@ -1095,9 +1095,9 @@ func (suite *ChannelLevelScoreBalancerTestSuite) TestExclusiveChannelBalance_Nod
 	balancer.meta.CollectionManager.PutCollection(collection)
 	balancer.meta.CollectionManager.PutPartition(utils.CreateTestPartition(collectionID, partitionID))
 	balancer.meta.ReplicaManager.Spawn(1, map[string]int{meta.DefaultResourceGroupName: 1}, []string{"channel1", "channel2"})
-	balancer.targetMgr.UpdateCollectionNextTarget(collectionID)
+	balancer.targetMgr.ForceUpdateCollectionNextTarget(collectionID)
 	balancer.targetMgr.UpdateCollectionCurrentTarget(collectionID)
-	balancer.targetMgr.UpdateCollectionNextTarget(collectionID)
+	balancer.targetMgr.ForceUpdateCollectionNextTarget(collectionID)
 
 	// 3. set up nodes info and resourceManager for balancer
 	nodeCount := 4
@@ -1220,9 +1220,9 @@ func (suite *ChannelLevelScoreBalancerTestSuite) TestExclusiveChannelBalance_Seg
 	balancer.meta.CollectionManager.PutCollection(collection)
 	balancer.meta.CollectionManager.PutPartition(utils.CreateTestPartition(collectionID, partitionID))
 	balancer.meta.ReplicaManager.Spawn(1, map[string]int{meta.DefaultResourceGroupName: 1}, []string{"channel1", "channel2"})
-	balancer.targetMgr.UpdateCollectionNextTarget(collectionID)
+	balancer.targetMgr.ForceUpdateCollectionNextTarget(collectionID)
 	balancer.targetMgr.UpdateCollectionCurrentTarget(collectionID)
-	balancer.targetMgr.UpdateCollectionNextTarget(collectionID)
+	balancer.targetMgr.ForceUpdateCollectionNextTarget(collectionID)
 
 	// 3. set up nodes info and resourceManager for balancer
 	nodeCount := 4

--- a/internal/querycoordv2/balance/rowcount_based_balancer_test.go
+++ b/internal/querycoordv2/balance/rowcount_based_balancer_test.go
@@ -461,9 +461,9 @@ func (suite *RowCountBasedBalancerTestSuite) TestBalance() {
 			balancer.meta.ReplicaManager.Put(utils.CreateTestReplica(1, 1, c.nodes))
 			suite.broker.ExpectedCalls = nil
 			suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(nil, segments, nil)
-			balancer.targetMgr.UpdateCollectionNextTarget(int64(1))
+			balancer.targetMgr.ForceUpdateCollectionNextTarget(int64(1))
 			balancer.targetMgr.UpdateCollectionCurrentTarget(1)
-			balancer.targetMgr.UpdateCollectionNextTarget(int64(1))
+			balancer.targetMgr.ForceUpdateCollectionNextTarget(int64(1))
 			for node, s := range c.distributions {
 				balancer.dist.SegmentDistManager.Update(node, s...)
 			}
@@ -672,11 +672,11 @@ func (suite *RowCountBasedBalancerTestSuite) TestBalanceOnPartStopping() {
 			balancer.meta.CollectionManager.PutPartition(utils.CreateTestPartition(1, 1))
 			balancer.meta.ReplicaManager.Put(utils.CreateTestReplica(1, 1, append(c.nodes, c.notExistedNodes...)))
 			suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(nil, c.segmentInCurrent, nil)
-			balancer.targetMgr.UpdateCollectionNextTarget(int64(1))
+			balancer.targetMgr.ForceUpdateCollectionNextTarget(int64(1))
 			balancer.targetMgr.UpdateCollectionCurrentTarget(1)
 			suite.broker.ExpectedCalls = nil
 			suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(nil, c.segmentInNext, nil)
-			balancer.targetMgr.UpdateCollectionNextTarget(int64(1))
+			balancer.targetMgr.ForceUpdateCollectionNextTarget(int64(1))
 			for node, s := range c.distributions {
 				balancer.dist.SegmentDistManager.Update(node, s...)
 			}
@@ -817,9 +817,9 @@ func (suite *RowCountBasedBalancerTestSuite) TestBalanceOutboundNodes() {
 			balancer.meta.CollectionManager.PutPartition(utils.CreateTestPartition(1, 1))
 			balancer.meta.ReplicaManager.Put(utils.CreateTestReplica(1, 1, append(c.nodes, c.notExistedNodes...)))
 			suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(nil, segments, nil)
-			balancer.targetMgr.UpdateCollectionNextTarget(int64(1))
+			balancer.targetMgr.ForceUpdateCollectionNextTarget(int64(1))
 			balancer.targetMgr.UpdateCollectionCurrentTarget(1)
-			balancer.targetMgr.UpdateCollectionNextTarget(int64(1))
+			balancer.targetMgr.ForceUpdateCollectionNextTarget(int64(1))
 			for node, s := range c.distributions {
 				balancer.dist.SegmentDistManager.Update(node, s...)
 			}
@@ -1049,9 +1049,9 @@ func (suite *RowCountBasedBalancerTestSuite) TestDisableBalanceChannel() {
 			balancer.meta.ReplicaManager.Put(utils.CreateTestReplica(1, 1, append(c.nodes, c.notExistedNodes...)))
 			suite.broker.ExpectedCalls = nil
 			suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(nil, segments, nil)
-			balancer.targetMgr.UpdateCollectionNextTarget(int64(1))
+			balancer.targetMgr.ForceUpdateCollectionNextTarget(int64(1))
 			balancer.targetMgr.UpdateCollectionCurrentTarget(1)
-			balancer.targetMgr.UpdateCollectionNextTarget(int64(1))
+			balancer.targetMgr.ForceUpdateCollectionNextTarget(int64(1))
 			for node, s := range c.distributions {
 				balancer.dist.SegmentDistManager.Update(node, s...)
 			}
@@ -1176,9 +1176,9 @@ func (suite *RowCountBasedBalancerTestSuite) TestMultiReplicaBalance() {
 			for replicaID, nodes := range c.replicaWithNodes {
 				balancer.meta.ReplicaManager.Put(utils.CreateTestReplica(replicaID, c.collectionID, nodes))
 			}
-			balancer.targetMgr.UpdateCollectionNextTarget(c.collectionID)
+			balancer.targetMgr.ForceUpdateCollectionNextTarget(c.collectionID)
 			balancer.targetMgr.UpdateCollectionCurrentTarget(c.collectionID)
-			balancer.targetMgr.UpdateCollectionNextTarget(c.collectionID)
+			balancer.targetMgr.ForceUpdateCollectionNextTarget(c.collectionID)
 
 			// 2. set up target for distribution for multi collections
 			for node, s := range c.segmentDist {

--- a/internal/querycoordv2/balance/score_based_balancer_test.go
+++ b/internal/querycoordv2/balance/score_based_balancer_test.go
@@ -433,9 +433,9 @@ func (suite *ScoreBasedBalancerTestSuite) TestBalanceOneRound() {
 			balancer.meta.CollectionManager.PutCollection(collection)
 			balancer.meta.CollectionManager.PutPartition(utils.CreateTestPartition(c.collectionID, c.collectionID))
 			balancer.meta.ReplicaManager.Put(utils.CreateTestReplica(c.replicaID, c.collectionID, c.nodes))
-			balancer.targetMgr.UpdateCollectionNextTarget(c.collectionID)
+			balancer.targetMgr.ForceUpdateCollectionNextTarget(c.collectionID)
 			balancer.targetMgr.UpdateCollectionCurrentTarget(c.collectionID)
-			balancer.targetMgr.UpdateCollectionNextTarget(c.collectionID)
+			balancer.targetMgr.ForceUpdateCollectionNextTarget(c.collectionID)
 
 			// 2. set up target for distribution for multi collections
 			for node, s := range c.distributions {
@@ -628,9 +628,9 @@ func (suite *ScoreBasedBalancerTestSuite) TestBalanceWithExecutingTask() {
 			balancer.meta.CollectionManager.PutCollection(collection)
 			balancer.meta.CollectionManager.PutPartition(utils.CreateTestPartition(c.collectionID, c.collectionID))
 			balancer.meta.ReplicaManager.Put(utils.CreateTestReplica(c.replicaID, c.collectionID, c.nodes))
-			balancer.targetMgr.UpdateCollectionNextTarget(c.collectionID)
+			balancer.targetMgr.ForceUpdateCollectionNextTarget(c.collectionID)
 			balancer.targetMgr.UpdateCollectionCurrentTarget(c.collectionID)
-			balancer.targetMgr.UpdateCollectionNextTarget(c.collectionID)
+			balancer.targetMgr.ForceUpdateCollectionNextTarget(c.collectionID)
 
 			// 2. set up target for distribution for multi collections
 			for node, s := range c.distributions {
@@ -751,9 +751,9 @@ func (suite *ScoreBasedBalancerTestSuite) TestBalanceMultiRound() {
 		balancer.meta.CollectionManager.PutPartition(utils.CreateTestPartition(balanceCase.collectionIDs[i], balanceCase.collectionIDs[i]))
 		balancer.meta.ReplicaManager.Put(utils.CreateTestReplica(balanceCase.replicaIDs[i], balanceCase.collectionIDs[i],
 			append(balanceCase.nodes, balanceCase.notExistedNodes...)))
-		balancer.targetMgr.UpdateCollectionNextTarget(balanceCase.collectionIDs[i])
+		balancer.targetMgr.ForceUpdateCollectionNextTarget(balanceCase.collectionIDs[i])
 		balancer.targetMgr.UpdateCollectionCurrentTarget(balanceCase.collectionIDs[i])
-		balancer.targetMgr.UpdateCollectionNextTarget(balanceCase.collectionIDs[i])
+		balancer.targetMgr.ForceUpdateCollectionNextTarget(balanceCase.collectionIDs[i])
 	}
 
 	// 2. set up target for distribution for multi collections
@@ -894,9 +894,9 @@ func (suite *ScoreBasedBalancerTestSuite) TestStoppedBalance() {
 			balancer.meta.CollectionManager.PutCollection(collection)
 			balancer.meta.CollectionManager.PutPartition(utils.CreateTestPartition(c.collectionID, c.collectionID))
 			balancer.meta.ReplicaManager.Put(utils.CreateTestReplica(c.replicaID, c.collectionID, c.nodes))
-			balancer.targetMgr.UpdateCollectionNextTarget(c.collectionID)
+			balancer.targetMgr.ForceUpdateCollectionNextTarget(c.collectionID)
 			balancer.targetMgr.UpdateCollectionCurrentTarget(c.collectionID)
-			balancer.targetMgr.UpdateCollectionNextTarget(c.collectionID)
+			balancer.targetMgr.ForceUpdateCollectionNextTarget(c.collectionID)
 
 			// 2. set up target for distribution for multi collections
 			for node, s := range c.distributions {
@@ -1014,9 +1014,9 @@ func (suite *ScoreBasedBalancerTestSuite) TestMultiReplicaBalance() {
 			for replicaID, nodes := range c.replicaWithNodes {
 				balancer.meta.ReplicaManager.Put(utils.CreateTestReplica(replicaID, c.collectionID, nodes))
 			}
-			balancer.targetMgr.UpdateCollectionNextTarget(c.collectionID)
+			balancer.targetMgr.ForceUpdateCollectionNextTarget(c.collectionID)
 			balancer.targetMgr.UpdateCollectionCurrentTarget(c.collectionID)
-			balancer.targetMgr.UpdateCollectionNextTarget(c.collectionID)
+			balancer.targetMgr.ForceUpdateCollectionNextTarget(c.collectionID)
 
 			// 2. set up target for distribution for multi collections
 			for node, s := range c.segmentDist {

--- a/internal/querycoordv2/checkers/leader_checker_test.go
+++ b/internal/querycoordv2/checkers/leader_checker_test.go
@@ -159,7 +159,7 @@ func (suite *LeaderCheckerTestSuite) TestSyncLoadedSegments() {
 	// test skip sync l0 segment
 	segments = []*datapb.SegmentInfo{
 		{
-			ID:            1,
+			ID:            1111,
 			PartitionID:   1,
 			InsertChannel: "test-insert-channel",
 			Level:         datapb.SegmentLevel_L0,

--- a/internal/querycoordv2/checkers/segment_checker_test.go
+++ b/internal/querycoordv2/checkers/segment_checker_test.go
@@ -266,11 +266,13 @@ func (suite *SegmentCheckerTestSuite) TestReleaseL0Segments() {
 		NodeID:   1,
 		Address:  "localhost",
 		Hostname: "localhost",
+		Version:  common.Version,
 	}))
 	suite.nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{
 		NodeID:   2,
 		Address:  "localhost",
 		Hostname: "localhost",
+		Version:  common.Version,
 	}))
 	checker.meta.ResourceManager.HandleNodeUp(1)
 	checker.meta.ResourceManager.HandleNodeUp(2)
@@ -299,7 +301,9 @@ func (suite *SegmentCheckerTestSuite) TestReleaseL0Segments() {
 
 	// set dist
 	checker.dist.ChannelDistManager.Update(2, utils.CreateTestChannel(1, 2, 1, "test-insert-channel"))
-	checker.dist.LeaderViewManager.Update(2, utils.CreateTestLeaderView(2, 1, "test-insert-channel", map[int64]int64{}, map[int64]*meta.Segment{}))
+	view := utils.CreateTestLeaderView(2, 1, "test-insert-channel", map[int64]int64{}, map[int64]*meta.Segment{})
+	view.Version = checker.targetMgr.GetCollectionTargetVersion(int64(1), meta.CurrentTargetFirst)
+	checker.dist.LeaderViewManager.Update(2, view)
 
 	// seg l0 segment exist on a non delegator node
 	checker.dist.SegmentDistManager.Update(1, utils.CreateTestSegment(1, 1, 1, 1, 1, "test-insert-channel"))

--- a/internal/querycoordv2/meta/mock_target_manager.go
+++ b/internal/querycoordv2/meta/mock_target_manager.go
@@ -3,6 +3,8 @@
 package meta
 
 import (
+	context "context"
+
 	metastore "github.com/milvus-io/milvus/internal/metastore"
 	datapb "github.com/milvus-io/milvus/internal/proto/datapb"
 
@@ -919,13 +921,20 @@ func (_c *MockTargetManager_UpdateCollectionCurrentTarget_Call) RunAndReturn(run
 	return _c
 }
 
-// UpdateCollectionNextTarget provides a mock function with given fields: collectionID
-func (_m *MockTargetManager) UpdateCollectionNextTarget(collectionID int64) error {
-	ret := _m.Called(collectionID)
+// UpdateCollectionNextTarget provides a mock function with given fields: collectionID, checkFunc
+func (_m *MockTargetManager) UpdateCollectionNextTarget(collectionID int64, checkFunc ...func(context.Context, int64) bool) error {
+	_va := make([]interface{}, len(checkFunc))
+	for _i := range checkFunc {
+		_va[_i] = checkFunc[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, collectionID)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(int64) error); ok {
-		r0 = rf(collectionID)
+	if rf, ok := ret.Get(0).(func(int64, ...func(context.Context, int64) bool) error); ok {
+		r0 = rf(collectionID, checkFunc...)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -940,13 +949,21 @@ type MockTargetManager_UpdateCollectionNextTarget_Call struct {
 
 // UpdateCollectionNextTarget is a helper method to define mock.On call
 //   - collectionID int64
-func (_e *MockTargetManager_Expecter) UpdateCollectionNextTarget(collectionID interface{}) *MockTargetManager_UpdateCollectionNextTarget_Call {
-	return &MockTargetManager_UpdateCollectionNextTarget_Call{Call: _e.mock.On("UpdateCollectionNextTarget", collectionID)}
+//   - checkFunc ...func(context.Context , int64) bool
+func (_e *MockTargetManager_Expecter) UpdateCollectionNextTarget(collectionID interface{}, checkFunc ...interface{}) *MockTargetManager_UpdateCollectionNextTarget_Call {
+	return &MockTargetManager_UpdateCollectionNextTarget_Call{Call: _e.mock.On("UpdateCollectionNextTarget",
+		append([]interface{}{collectionID}, checkFunc...)...)}
 }
 
-func (_c *MockTargetManager_UpdateCollectionNextTarget_Call) Run(run func(collectionID int64)) *MockTargetManager_UpdateCollectionNextTarget_Call {
+func (_c *MockTargetManager_UpdateCollectionNextTarget_Call) Run(run func(collectionID int64, checkFunc ...func(context.Context, int64) bool)) *MockTargetManager_UpdateCollectionNextTarget_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(int64))
+		variadicArgs := make([]func(context.Context, int64) bool, len(args)-1)
+		for i, a := range args[1:] {
+			if a != nil {
+				variadicArgs[i] = a.(func(context.Context, int64) bool)
+			}
+		}
+		run(args[0].(int64), variadicArgs...)
 	})
 	return _c
 }
@@ -956,7 +973,7 @@ func (_c *MockTargetManager_UpdateCollectionNextTarget_Call) Return(_a0 error) *
 	return _c
 }
 
-func (_c *MockTargetManager_UpdateCollectionNextTarget_Call) RunAndReturn(run func(int64) error) *MockTargetManager_UpdateCollectionNextTarget_Call {
+func (_c *MockTargetManager_UpdateCollectionNextTarget_Call) RunAndReturn(run func(int64, ...func(context.Context, int64) bool) error) *MockTargetManager_UpdateCollectionNextTarget_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/querycoordv2/meta/target.go
+++ b/internal/querycoordv2/meta/target.go
@@ -128,6 +128,27 @@ func (p *CollectionTarget) toPbMsg() *querypb.CollectionTarget {
 	}
 }
 
+// this impl won't compare channel's cp
+func (p *CollectionTarget) Equal(other *CollectionTarget) bool {
+	if len(p.dmChannels) != len(other.dmChannels) || len(p.segments) != len(other.segments) {
+		return false
+	}
+
+	for chName := range other.dmChannels {
+		if _, ok := p.dmChannels[chName]; !ok {
+			return false
+		}
+	}
+
+	for sid := range other.segments {
+		if _, ok := p.segments[sid]; !ok {
+			return false
+		}
+	}
+
+	return true
+}
+
 func (p *CollectionTarget) GetAllSegments() map[int64]*datapb.SegmentInfo {
 	return p.segments
 }

--- a/internal/querycoordv2/meta/target_manager_test.go
+++ b/internal/querycoordv2/meta/target_manager_test.go
@@ -178,6 +178,11 @@ func (suite *TargetManagerSuite) TestUpdateCurrentTarget() {
 	suite.assertSegments(suite.getAllSegment(collectionID, suite.partitions[collectionID]),
 		suite.mgr.GetSealedSegmentsByCollection(collectionID, CurrentTarget))
 	suite.assertChannels(suite.channels[collectionID], suite.mgr.GetDmChannelsByCollection(collectionID, CurrentTarget))
+
+	// try to update current target with same segments and channels
+	err := suite.mgr.UpdateCollectionNextTarget(collectionID)
+	suite.ErrorIs(err, merr.ErrCollectionTargetNotChanged)
+	suite.Nil(suite.mgr.next.getCollectionTarget(collectionID))
 }
 
 func (suite *TargetManagerSuite) TestUpdateNextTarget() {

--- a/internal/querycoordv2/observers/collection_observer_test.go
+++ b/internal/querycoordv2/observers/collection_observer_test.go
@@ -259,7 +259,7 @@ func (suite *CollectionObserverSuite) TestObserve() {
 	suite.True(ok)
 	view2 := &meta.LeaderView{
 		ID:           3,
-		CollectionID: 13,
+		CollectionID: 103,
 		Channel:      "103-dmc0",
 		Segments:     make(map[int64]*querypb.SegmentDist),
 	}
@@ -384,9 +384,9 @@ func (suite *CollectionObserverSuite) loadAll() {
 		suite.load(collection)
 	}
 	suite.targetMgr.UpdateCollectionCurrentTarget(suite.collections[0])
-	suite.targetMgr.UpdateCollectionNextTarget(suite.collections[0])
+	suite.targetMgr.UpdateCollectionNextTarget(suite.collections[0], suite.targetObserver.checkDistributionReady)
 	suite.targetMgr.UpdateCollectionCurrentTarget(suite.collections[2])
-	suite.targetMgr.UpdateCollectionNextTarget(suite.collections[2])
+	suite.targetMgr.UpdateCollectionNextTarget(suite.collections[2], suite.targetObserver.checkDistributionReady)
 }
 
 func (suite *CollectionObserverSuite) load(collection int64) {
@@ -441,7 +441,7 @@ func (suite *CollectionObserverSuite) load(collection int64) {
 	}
 
 	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, collection).Return(dmChannels, allSegments, nil)
-	suite.targetMgr.UpdateCollectionNextTarget(collection)
+	suite.targetMgr.UpdateCollectionNextTarget(collection, suite.targetObserver.checkDistributionReady)
 
 	suite.ob.LoadCollection(context.Background(), collection)
 }

--- a/internal/querycoordv2/services_test.go
+++ b/internal/querycoordv2/services_test.go
@@ -139,6 +139,9 @@ func (suite *ServiceSuite) SetupTest() {
 	suite.Require().NoError(err)
 	suite.kv = etcdkv.NewEtcdKV(cli, config.MetaRootPath.GetValue())
 
+	suite.cluster = session.NewMockCluster(suite.T())
+	suite.cluster.EXPECT().SyncDistribution(mock.Anything, mock.Anything, mock.Anything).Return(merr.Success(), nil).Maybe()
+
 	suite.store = querycoord.NewCatalog(suite.kv)
 	suite.dist = meta.NewDistributionManager()
 	suite.nodeMgr = session.NewNodeManager()
@@ -161,8 +164,7 @@ func (suite *ServiceSuite) SetupTest() {
 		}))
 		suite.meta.ResourceManager.HandleNodeUp(node)
 	}
-	suite.cluster = session.NewMockCluster(suite.T())
-	suite.cluster.EXPECT().SyncDistribution(mock.Anything, mock.Anything, mock.Anything).Return(merr.Success(), nil).Maybe()
+
 	suite.jobScheduler = job.NewScheduler()
 	suite.taskScheduler = task.NewMockScheduler(suite.T())
 	suite.taskScheduler.EXPECT().GetSegmentTaskDelta(mock.Anything, mock.Anything).Return(0).Maybe()

--- a/pkg/util/merr/errors.go
+++ b/pkg/util/merr/errors.go
@@ -70,6 +70,7 @@ var (
 	ErrCollectionIllegalSchema                 = newMilvusError("illegal collection schema", 105, false)
 	ErrCollectionOnRecovering                  = newMilvusError("collection on recovering", 106, true)
 	ErrCollectionVectorClusteringKeyNotAllowed = newMilvusError("vector clustering key not allowed", 107, false)
+	ErrCollectionTargetNotChanged              = newMilvusError("collection target not changed", 108, false)
 
 	// Partition related
 	ErrPartitionNotFound       = newMilvusError("partition not found", 200, false)

--- a/pkg/util/merr/errors_test.go
+++ b/pkg/util/merr/errors_test.go
@@ -88,6 +88,7 @@ func (s *ErrSuite) TestWrap() {
 	s.ErrorIs(WrapErrCollectionNotLoaded("test_collection", "failed to alter index %s", "hnsw"), ErrCollectionNotLoaded)
 	s.ErrorIs(WrapErrCollectionOnRecovering("test_collection", "channel lost %s", "dev"), ErrCollectionOnRecovering)
 	s.ErrorIs(WrapErrCollectionVectorClusteringKeyNotAllowed("test_collection", "field"), ErrCollectionVectorClusteringKeyNotAllowed)
+	s.ErrorIs(WrapErrCollectionTargetNotChanged("test_collection"), ErrCollectionTargetNotChanged)
 
 	// Partition related
 	s.ErrorIs(WrapErrPartitionNotFound("test_partition", "failed to get partition"), ErrPartitionNotFound)

--- a/pkg/util/merr/utils.go
+++ b/pkg/util/merr/utils.go
@@ -545,6 +545,15 @@ func WrapErrCollectionVectorClusteringKeyNotAllowed(collection any, msgAndArgs .
 	return err
 }
 
+func WrapErrCollectionTargetNotChanged(collection any, msgAndArgs ...any) error {
+	err := wrapFields(ErrCollectionTargetNotChanged, value("collection", collection))
+	if len(msgAndArgs) > 0 {
+		msg := msgAndArgs[0].(string)
+		err = errors.Wrapf(err, msg, msgAndArgs[1:]...)
+	}
+	return err
+}
+
 func WrapErrAliasNotFound(db any, alias any, msg ...string) error {
 	err := wrapFields(ErrAliasNotFound,
 		value("database", db),


### PR DESCRIPTION
issue: #34715

if querycoord update next target with same segment/channel list, then it will be apply to current target immediately. and target version will change when update current target, which will trigger SyncDistribution every 10 seconds.

This PR add the check logic to skip update collection next target if segment/channel list doesn't changes.