### PR TITLE
fix: correctly set search params when using knowhere iterator

### DIFF
--- a/internal/core/src/query/groupby/SearchGroupByOperator.h
+++ b/internal/core/src/query/groupby/SearchGroupByOperator.h
@@ -133,7 +133,7 @@ PrepareVectorIteratorsFromIndex(const SearchInfo& search_info,
                                 const index::VectorIndex& index) {
     if (search_info.group_by_field_id_.has_value()) {
         try {
-            auto search_conf = search_info.search_params_;
+            auto search_conf = index.PrepareSearchParams(search_info);
             knowhere::expected<std::vector<knowhere::IndexNode::IteratorPtr>>
                 iterators_val =
                     index.VectorIterators(dataset, search_conf, bitset);


### PR DESCRIPTION
issue: #34730

