### PR TITLE
enhance: Add l0 segment entry num quota

### DIFF
--- a/internal/datacoord/import_util.go
+++ b/internal/datacoord/import_util.go
@@ -284,7 +284,8 @@ func CheckDiskQuota(job ImportJob, meta *meta, imeta ImportMeta) (int64, error) 
 	}
 
 	err := merr.WrapErrServiceQuotaExceeded("disk quota exceeded, please allocate more resources")
-	totalUsage, collectionsUsage, _ := meta.GetCollectionBinlogSize()
+	quotaInfo := meta.GetQuotaInfo()
+	totalUsage, collectionsUsage := quotaInfo.TotalBinlogSize, quotaInfo.CollectionBinlogSize
 
 	tasks := imeta.GetTaskBy(WithJob(job.GetJobID()), WithType(PreImportTaskType))
 	files := make([]*datapb.ImportFileStats, 0)

--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -447,55 +447,6 @@ func (m *meta) GetQuotaInfo() *metricsinfo.DataCoordQuotaMetrics {
 	return info
 }
 
-// GetCollectionBinlogSize returns the total binlog size and binlog size of collections.
-// func (m *meta) GetCollectionBinlogSize() (int64, map[UniqueID]int64, map[UniqueID]map[UniqueID]int64) {
-// 	m.RLock()
-// 	defer m.RUnlock()
-// 	collectionBinlogSize := make(map[UniqueID]int64)
-// 	partitionBinlogSize := make(map[UniqueID]map[UniqueID]int64)
-// 	collectionRowsNum := make(map[UniqueID]map[commonpb.SegmentState]int64)
-// 	segments := m.segments.GetSegments()
-// 	var total int64
-// 	for _, segment := range segments {
-// 		segmentSize := segment.getSegmentSize()
-// 		if isSegmentHealthy(segment) && !segment.GetIsImporting() {
-// 			total += segmentSize
-// 			collectionBinlogSize[segment.GetCollectionID()] += segmentSize
-
-// 			partBinlogSize, ok := partitionBinlogSize[segment.GetCollectionID()]
-// 			if !ok {
-// 				partBinlogSize = make(map[int64]int64)
-// 				partitionBinlogSize[segment.GetCollectionID()] = partBinlogSize
-// 			}
-// 			partBinlogSize[segment.GetPartitionID()] += segmentSize
-
-// 			coll, ok := m.collections[segment.GetCollectionID()]
-// 			if ok {
-// 				metrics.DataCoordStoredBinlogSize.WithLabelValues(coll.DatabaseName,
-// 					fmt.Sprint(segment.GetCollectionID()), fmt.Sprint(segment.GetID())).Set(float64(segmentSize))
-// 			} else {
-// 				log.Warn("not found database name", zap.Int64("collectionID", segment.GetCollectionID()))
-// 			}
-
-// 			if _, ok := collectionRowsNum[segment.GetCollectionID()]; !ok {
-// 				collectionRowsNum[segment.GetCollectionID()] = make(map[commonpb.SegmentState]int64)
-// 			}
-// 			collectionRowsNum[segment.GetCollectionID()][segment.GetState()] += segment.GetNumOfRows()
-// 		}
-// 	}
-
-// 	metrics.DataCoordNumStoredRows.Reset()
-// 	for collectionID, statesRows := range collectionRowsNum {
-// 		for state, rows := range statesRows {
-// 			coll, ok := m.collections[collectionID]
-// 			if ok {
-// 				metrics.DataCoordNumStoredRows.WithLabelValues(coll.DatabaseName, fmt.Sprint(collectionID), state.String()).Set(float64(rows))
-// 			}
-// 		}
-// 	}
-// 	return total, collectionBinlogSize, partitionBinlogSize
-// }
-
 // GetCollectionIndexFilesSize returns the total index files size of all segment for each collection.
 func (m *meta) GetCollectionIndexFilesSize() uint64 {
 	m.RLock()

--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -398,7 +398,6 @@ func (m *meta) GetQuotaInfo() *metricsinfo.DataCoordQuotaMetrics {
 	var total int64
 	for _, segment := range segments {
 		segmentSize := segment.getSegmentSize()
-		log.Warn("CQX", zap.Int64("size", segmentSize))
 		if isSegmentHealthy(segment) && !segment.GetIsImporting() {
 			total += segmentSize
 			collectionBinlogSize[segment.GetCollectionID()] += segmentSize

--- a/internal/datacoord/meta_test.go
+++ b/internal/datacoord/meta_test.go
@@ -589,16 +589,16 @@ func TestMeta_Basic(t *testing.T) {
 		assert.NoError(t, err)
 
 		// check TotalBinlogSize
-		total, collectionBinlogSize, _ := meta.GetCollectionBinlogSize()
-		assert.Len(t, collectionBinlogSize, 1)
-		assert.Equal(t, int64(size0+size1), collectionBinlogSize[collID])
-		assert.Equal(t, int64(size0+size1), total)
+		quotaInfo := meta.GetQuotaInfo()
+		assert.Len(t, quotaInfo.CollectionBinlogSize, 1)
+		assert.Equal(t, int64(size0+size1), quotaInfo.CollectionBinlogSize[collID])
+		assert.Equal(t, int64(size0+size1), quotaInfo.TotalBinlogSize)
 
 		meta.collections[collID] = collInfo
-		total, collectionBinlogSize, _ = meta.GetCollectionBinlogSize()
-		assert.Len(t, collectionBinlogSize, 1)
-		assert.Equal(t, int64(size0+size1), collectionBinlogSize[collID])
-		assert.Equal(t, int64(size0+size1), total)
+		quotaInfo = meta.GetQuotaInfo()
+		assert.Len(t, quotaInfo.CollectionBinlogSize, 1)
+		assert.Equal(t, int64(size0+size1), quotaInfo.CollectionBinlogSize[collID])
+		assert.Equal(t, int64(size0+size1), quotaInfo.TotalBinlogSize)
 	})
 
 	t.Run("Test GetCollectionBinlogSize", func(t *testing.T) {

--- a/internal/datacoord/metrics_info.go
+++ b/internal/datacoord/metrics_info.go
@@ -37,14 +37,10 @@ import (
 
 // getQuotaMetrics returns DataCoordQuotaMetrics.
 func (s *Server) getQuotaMetrics() *metricsinfo.DataCoordQuotaMetrics {
-	total, colSizes, partSizes := s.meta.GetCollectionBinlogSize()
+	info := s.meta.GetQuotaInfo()
 	// Just generate the metrics data regularly
 	_ = s.meta.GetCollectionIndexFilesSize()
-	return &metricsinfo.DataCoordQuotaMetrics{
-		TotalBinlogSize:      total,
-		CollectionBinlogSize: colSizes,
-		PartitionsBinlogSize: partSizes,
-	}
+	return info
 }
 
 func (s *Server) getCollectionMetrics(ctx context.Context) *metricsinfo.DataCoordCollectionMetrics {

--- a/internal/datacoord/segment_info.go
+++ b/internal/datacoord/segment_info.go
@@ -200,7 +200,6 @@ func (s *SegmentsInfo) SetSegment(segmentID UniqueID, segment *SegmentInfo) {
 		s.removeSecondaryIndex(segment)
 	}
 	s.segments[segmentID] = segment
-	log.Info("CQX set segment", zap.Any("segment", segment))
 	s.addSecondaryIndex(segment)
 	s.addCompactTo(segment)
 }

--- a/pkg/util/metricsinfo/quota_metric.go
+++ b/pkg/util/metricsinfo/quota_metric.go
@@ -88,6 +88,8 @@ type DataCoordQuotaMetrics struct {
 	TotalBinlogSize      int64
 	CollectionBinlogSize map[int64]int64
 	PartitionsBinlogSize map[int64]map[int64]int64
+	// l0 segments
+	CollectionL0RowCount map[int64]int64
 }
 
 // DataNodeQuotaMetrics are metrics of DataNode.

--- a/pkg/util/paramtable/quota_param.go
+++ b/pkg/util/paramtable/quota_param.go
@@ -152,6 +152,9 @@ type quotaConfig struct {
 	DiskQuotaPerDB                       ParamItem `refreshable:"true"`
 	DiskQuotaPerCollection               ParamItem `refreshable:"true"`
 	DiskQuotaPerPartition                ParamItem `refreshable:"true"`
+	L0SegmentRowCountProtectionEnabled   ParamItem `refreshable:"true"`
+	L0SegmentRowCountLowWaterLevel       ParamItem `refreshable:"true"`
+	L0SegmentRowCountHighWaterLevel      ParamItem `refreshable:"true"`
 
 	// limit reading
 	ForceDenyReading               ParamItem `refreshable:"true"`
@@ -1855,6 +1858,33 @@ but the rate will not be lower than minRateRatio * dmlRate.`,
 		Export: true,
 	}
 	p.DiskQuotaPerPartition.Init(base.mgr)
+
+	p.L0SegmentRowCountProtectionEnabled = ParamItem{
+		Key:          "quotaAndLimits.limitWriting.l0SegmentsRowCountProtection.enabled",
+		Version:      "2.4.7",
+		DefaultValue: "false",
+		Doc:          "switch to enable l0 segment row count quota",
+		Export:       true,
+	}
+	p.L0SegmentRowCountHighWaterLevel.Init(base.mgr)
+
+	p.L0SegmentRowCountLowWaterLevel = ParamItem{
+		Key:          "quotaAndLimits.limitWriting.l0SegmentsRowCountProtection.lowWaterLevel",
+		Version:      "2.4.7",
+		DefaultValue: "32768",
+		Doc:          "l0 segment row count quota, low water level",
+		Export:       true,
+	}
+	p.L0SegmentRowCountHighWaterLevel.Init(base.mgr)
+
+	p.L0SegmentRowCountLowWaterLevel = ParamItem{
+		Key:          "quotaAndLimits.limitWriting.l0SegmentsRowCountProtection.highWaterLevel",
+		Version:      "2.4.7",
+		DefaultValue: "65536",
+		Doc:          "l0 segment row count quota, low water level",
+		Export:       true,
+	}
+	p.L0SegmentRowCountHighWaterLevel.Init(base.mgr)
 
 	// limit reading
 	p.ForceDenyReading = ParamItem{

--- a/pkg/util/paramtable/quota_param.go
+++ b/pkg/util/paramtable/quota_param.go
@@ -1866,7 +1866,7 @@ but the rate will not be lower than minRateRatio * dmlRate.`,
 		Doc:          "switch to enable l0 segment row count quota",
 		Export:       true,
 	}
-	p.L0SegmentRowCountHighWaterLevel.Init(base.mgr)
+	p.L0SegmentRowCountProtectionEnabled.Init(base.mgr)
 
 	p.L0SegmentRowCountLowWaterLevel = ParamItem{
 		Key:          "quotaAndLimits.limitWriting.l0SegmentsRowCountProtection.lowWaterLevel",
@@ -1875,9 +1875,9 @@ but the rate will not be lower than minRateRatio * dmlRate.`,
 		Doc:          "l0 segment row count quota, low water level",
 		Export:       true,
 	}
-	p.L0SegmentRowCountHighWaterLevel.Init(base.mgr)
+	p.L0SegmentRowCountLowWaterLevel.Init(base.mgr)
 
-	p.L0SegmentRowCountLowWaterLevel = ParamItem{
+	p.L0SegmentRowCountHighWaterLevel = ParamItem{
 		Key:          "quotaAndLimits.limitWriting.l0SegmentsRowCountProtection.highWaterLevel",
 		Version:      "2.4.7",
 		DefaultValue: "65536",


### PR DESCRIPTION
See also #34670

This PR add quota configuration for l0 segment entry number per collection. If l0 compaction cannot keep up the insertion/upsertion rate, this feature could back press the related rate.