### PR TITLE
enhance: Remove useless ops when there is no write

### DIFF
--- a/internal/querynodev2/pipeline/delete_node.go
+++ b/internal/querynodev2/pipeline/delete_node.go
@@ -66,14 +66,13 @@ func (dNode *deleteNode) Operate(in Msg) Msg {
 	metrics.QueryNodeWaitProcessingMsgCount.WithLabelValues(fmt.Sprint(paramtable.GetNodeID()), metrics.DeleteLabel).Dec()
 	nodeMsg := in.(*deleteNodeMsg)
 
-	// partition id = > DeleteData
-	deleteDatas := make(map[UniqueID]*delegator.DeleteData)
+	if len(nodeMsg.deleteMsgs) > 0 {
+		// partition id = > DeleteData
+		deleteDatas := make(map[UniqueID]*delegator.DeleteData)
 
-	for _, msg := range nodeMsg.deleteMsgs {
-		dNode.addDeleteData(deleteDatas, msg)
-	}
-
-	if len(deleteDatas) > 0 {
+		for _, msg := range nodeMsg.deleteMsgs {
+			dNode.addDeleteData(deleteDatas, msg)
+		}
 		// do Delete, use ts range max as ts
 		dNode.delegator.ProcessDelete(lo.Values(deleteDatas), nodeMsg.timeRange.timestampMax)
 	}


### PR DESCRIPTION
Related to #33235

THe querynode pipeline will make map & call ProcessInsert when there is no write messages. So querynodes will have high CPU usage even when there is no workload.

This PR check msg length before composing data struct and calling method