### PR TITLE
enhance: Remove querycoord task priority policy

### DIFF
--- a/internal/querycoordv2/balance/utils.go
+++ b/internal/querycoordv2/balance/utils.go
@@ -75,13 +75,6 @@ func CreateSegmentTasksFromPlans(ctx context.Context, source task.Source, timeou
 			zap.String("level", p.Segment.GetLevel().String()),
 			zap.Int64("from", p.From),
 			zap.Int64("to", p.To))
-		if task.GetTaskType(t) == task.TaskTypeMove {
-			// from balance checker
-			t.SetPriority(task.TaskPriorityLow)
-		} else {
-			// from segment checker
-			t.SetPriority(task.TaskPriorityNormal)
-		}
 		ret = append(ret, t)
 	}
 	return ret
@@ -118,7 +111,6 @@ func CreateChannelTasksFromPlans(ctx context.Context, source task.Source, timeou
 			zap.String("channel", p.Channel.GetChannelName()),
 			zap.Int64("from", p.From),
 			zap.Int64("to", p.To))
-		t.SetPriority(task.TaskPriorityHigh)
 		ret = append(ret, t)
 	}
 	return ret

--- a/internal/querycoordv2/checkers/balance_checker.go
+++ b/internal/querycoordv2/checkers/balance_checker.go
@@ -173,7 +173,6 @@ func (b *BalanceChecker) Check(ctx context.Context) []task.Task {
 	segmentPlans, channelPlans := b.balanceReplicas(replicasToBalance)
 
 	tasks := balance.CreateSegmentTasksFromPlans(ctx, b.ID(), Params.QueryCoordCfg.SegmentTaskTimeout.GetAsDuration(time.Millisecond), segmentPlans)
-	task.SetPriority(task.TaskPriorityLow, tasks...)
 	task.SetReason("segment unbalanced", tasks...)
 	ret = append(ret, tasks...)
 

--- a/internal/querycoordv2/checkers/channel_checker.go
+++ b/internal/querycoordv2/checkers/channel_checker.go
@@ -116,8 +116,6 @@ func (c *ChannelChecker) checkReplica(ctx context.Context, replica *meta.Replica
 	task.SetReason("redundancies of channel", tasks...)
 	ret = append(ret, tasks...)
 
-	// All channel related tasks should be with high priority
-	task.SetPriority(task.TaskPriorityHigh, tasks...)
 	return ret
 }
 

--- a/internal/querycoordv2/checkers/index_checker.go
+++ b/internal/querycoordv2/checkers/index_checker.go
@@ -190,8 +190,6 @@ func (c *IndexChecker) createSegmentUpdateTask(ctx context.Context, segment *met
 		)
 		return nil, false
 	}
-	// index task shall have lower or equal priority than balance task
-	t.SetPriority(task.TaskPriorityLow)
 	t.SetReason("missing index")
 	return t, true
 }

--- a/internal/querycoordv2/checkers/leader_checker.go
+++ b/internal/querycoordv2/checkers/leader_checker.go
@@ -135,8 +135,6 @@ func (c *LeaderChecker) findNeedSyncPartitionStats(ctx context.Context, replica 
 			action,
 		)
 
-		// leader task shouldn't replace executing segment task
-		t.SetPriority(task.TaskPriorityLow)
 		t.SetReason("sync partition stats versions")
 		ret = append(ret, t)
 	}
@@ -180,8 +178,6 @@ func (c *LeaderChecker) findNeedLoadedSegments(ctx context.Context, replica *met
 				action,
 			)
 
-			// leader task shouldn't replace executing segment task
-			t.SetPriority(task.TaskPriorityLow)
 			t.SetReason("add segment to leader view")
 			ret = append(ret, t)
 		}
@@ -226,8 +222,6 @@ func (c *LeaderChecker) findNeedRemovedSegments(ctx context.Context, replica *me
 			action,
 		)
 
-		// leader task shouldn't replace executing segment task
-		t.SetPriority(task.TaskPriorityLow)
 		t.SetReason("remove segment from leader view")
 		ret = append(ret, t)
 	}

--- a/internal/querycoordv2/checkers/leader_checker_test.go
+++ b/internal/querycoordv2/checkers/leader_checker_test.go
@@ -135,7 +135,6 @@ func (suite *LeaderCheckerTestSuite) TestSyncLoadedSegments() {
 	suite.Equal(tasks[0].Actions()[0].Type(), task.ActionTypeGrow)
 	suite.Equal(tasks[0].Actions()[0].Node(), int64(1))
 	suite.Equal(tasks[0].Actions()[0].(*task.LeaderAction).SegmentID(), int64(1))
-	suite.Equal(tasks[0].Priority(), task.TaskPriorityLow)
 
 	// test segment's version in leader view doesn't match segment's version in dist
 	observer.dist.SegmentDistManager.Update(1, utils.CreateTestSegment(1, 1, 1, 2, 1, "test-insert-channel"))
@@ -154,7 +153,6 @@ func (suite *LeaderCheckerTestSuite) TestSyncLoadedSegments() {
 	suite.Equal(tasks[0].Actions()[0].Type(), task.ActionTypeGrow)
 	suite.Equal(tasks[0].Actions()[0].Node(), int64(1))
 	suite.Equal(tasks[0].Actions()[0].(*task.LeaderAction).SegmentID(), int64(1))
-	suite.Equal(tasks[0].Priority(), task.TaskPriorityLow)
 
 	// test skip sync l0 segment
 	segments = []*datapb.SegmentInfo{
@@ -230,7 +228,6 @@ func (suite *LeaderCheckerTestSuite) TestActivation() {
 	suite.Equal(tasks[0].Actions()[0].Type(), task.ActionTypeGrow)
 	suite.Equal(tasks[0].Actions()[0].Node(), int64(1))
 	suite.Equal(tasks[0].Actions()[0].(*task.LeaderAction).SegmentID(), int64(1))
-	suite.Equal(tasks[0].Priority(), task.TaskPriorityLow)
 }
 
 func (suite *LeaderCheckerTestSuite) TestStoppingNode() {
@@ -318,7 +315,6 @@ func (suite *LeaderCheckerTestSuite) TestIgnoreSyncLoadedSegments() {
 	suite.Equal(tasks[0].Actions()[0].Type(), task.ActionTypeGrow)
 	suite.Equal(tasks[0].Actions()[0].Node(), int64(1))
 	suite.Equal(tasks[0].Actions()[0].(*task.LeaderAction).SegmentID(), int64(1))
-	suite.Equal(tasks[0].Priority(), task.TaskPriorityLow)
 }
 
 func (suite *LeaderCheckerTestSuite) TestSyncLoadedSegmentsWithReplicas() {
@@ -375,7 +371,6 @@ func (suite *LeaderCheckerTestSuite) TestSyncLoadedSegmentsWithReplicas() {
 	suite.Equal(tasks[0].Actions()[0].Type(), task.ActionTypeGrow)
 	suite.Equal(tasks[0].Actions()[0].Node(), int64(1))
 	suite.Equal(tasks[0].Actions()[0].(*task.LeaderAction).SegmentID(), int64(1))
-	suite.Equal(tasks[0].Priority(), task.TaskPriorityLow)
 }
 
 func (suite *LeaderCheckerTestSuite) TestSyncRemovedSegments() {
@@ -410,7 +405,6 @@ func (suite *LeaderCheckerTestSuite) TestSyncRemovedSegments() {
 	suite.Equal(tasks[0].Actions()[0].Node(), int64(2))
 	suite.Equal(tasks[0].Actions()[0].(*task.LeaderAction).SegmentID(), int64(3))
 	suite.Equal(tasks[0].Actions()[0].(*task.LeaderAction).Version(), int64(0))
-	suite.Equal(tasks[0].Priority(), task.TaskPriorityLow)
 
 	// skip sync l0 segments
 	segments := []*datapb.SegmentInfo{
@@ -471,7 +465,6 @@ func (suite *LeaderCheckerTestSuite) TestIgnoreSyncRemovedSegments() {
 	suite.Equal(tasks[0].Actions()[0].Type(), task.ActionTypeReduce)
 	suite.Equal(tasks[0].Actions()[0].Node(), int64(2))
 	suite.Equal(tasks[0].Actions()[0].(*task.LeaderAction).SegmentID(), int64(3))
-	suite.Equal(tasks[0].Priority(), task.TaskPriorityLow)
 }
 
 func (suite *LeaderCheckerTestSuite) TestUpdatePartitionStats() {

--- a/internal/querycoordv2/checkers/segment_checker.go
+++ b/internal/querycoordv2/checkers/segment_checker.go
@@ -102,7 +102,6 @@ func (c *SegmentChecker) Check(ctx context.Context) []task.Task {
 	reduceTasks := c.createSegmentReduceTasks(ctx, released, meta.NilReplica, querypb.DataScope_Historical)
 	task.SetReason("collection released", reduceTasks...)
 	results = append(results, reduceTasks...)
-	task.SetPriority(task.TaskPriorityNormal, results...)
 	return results
 }
 

--- a/internal/querycoordv2/checkers/segment_checker_test.go
+++ b/internal/querycoordv2/checkers/segment_checker_test.go
@@ -155,7 +155,6 @@ func (suite *SegmentCheckerTestSuite) TestLoadSegments() {
 	suite.EqualValues(1, tasks[0].ReplicaID())
 	suite.Equal(task.ActionTypeGrow, action.Type())
 	suite.EqualValues(1, action.SegmentID())
-	suite.Equal(tasks[0].Priority(), task.TaskPriorityNormal)
 
 	// test activation
 	checker.Deactivate()
@@ -225,7 +224,6 @@ func (suite *SegmentCheckerTestSuite) TestLoadL0Segments() {
 	suite.Equal(task.ActionTypeGrow, action.Type())
 	suite.EqualValues(1, action.SegmentID())
 	suite.EqualValues(2, action.Node())
-	suite.Equal(tasks[0].Priority(), task.TaskPriorityNormal)
 
 	checker.targetMgr.UpdateCollectionCurrentTarget(int64(1))
 	// test load l0 segments in current target
@@ -238,7 +236,6 @@ func (suite *SegmentCheckerTestSuite) TestLoadL0Segments() {
 	suite.Equal(task.ActionTypeGrow, action.Type())
 	suite.EqualValues(1, action.SegmentID())
 	suite.EqualValues(2, action.Node())
-	suite.Equal(tasks[0].Priority(), task.TaskPriorityNormal)
 
 	// seg l0 segment exist on a non delegator node
 	checker.targetMgr.UpdateCollectionNextTarget(int64(1))
@@ -253,7 +250,6 @@ func (suite *SegmentCheckerTestSuite) TestLoadL0Segments() {
 	suite.Equal(task.ActionTypeGrow, action.Type())
 	suite.EqualValues(1, action.SegmentID())
 	suite.EqualValues(2, action.Node())
-	suite.Equal(tasks[0].Priority(), task.TaskPriorityNormal)
 }
 
 func (suite *SegmentCheckerTestSuite) TestReleaseL0Segments() {
@@ -327,7 +323,6 @@ func (suite *SegmentCheckerTestSuite) TestReleaseL0Segments() {
 	suite.Equal(task.ActionTypeReduce, action.Type())
 	suite.EqualValues(1, action.SegmentID())
 	suite.EqualValues(2, action.Node())
-	suite.Equal(tasks[0].Priority(), task.TaskPriorityNormal)
 }
 
 func (suite *SegmentCheckerTestSuite) TestSkipLoadSegments() {
@@ -405,7 +400,6 @@ func (suite *SegmentCheckerTestSuite) TestReleaseSegments() {
 	suite.EqualValues(1, tasks[0].ReplicaID())
 	suite.Equal(task.ActionTypeReduce, action.Type())
 	suite.EqualValues(2, action.SegmentID())
-	suite.Equal(tasks[0].Priority(), task.TaskPriorityNormal)
 }
 
 func (suite *SegmentCheckerTestSuite) TestReleaseRepeatedSegments() {
@@ -448,7 +442,6 @@ func (suite *SegmentCheckerTestSuite) TestReleaseRepeatedSegments() {
 	suite.Equal(task.ActionTypeReduce, action.Type())
 	suite.EqualValues(1, action.SegmentID())
 	suite.EqualValues(1, action.Node())
-	suite.Equal(tasks[0].Priority(), task.TaskPriorityNormal)
 
 	// test less version exist on leader
 	checker.dist.LeaderViewManager.Update(2, utils.CreateTestLeaderView(2, 1, "test-insert-channel", map[int64]int64{1: 1}, map[int64]*meta.Segment{}))
@@ -506,7 +499,6 @@ func (suite *SegmentCheckerTestSuite) TestSkipReleaseSealedSegments() {
 	suite.Equal(task.ActionTypeReduce, action.Type())
 	suite.EqualValues(segmentID, action.SegmentID())
 	suite.EqualValues(nodeID, action.Node())
-	suite.Equal(tasks[0].Priority(), task.TaskPriorityNormal)
 
 	// test leader with initialTargetVersion, meet segment doesn't exit in target, segment should be released
 	view = utils.CreateTestLeaderView(nodeID, collectionID, "test-insert-channel", map[int64]int64{1: 3}, map[int64]*meta.Segment{})
@@ -521,7 +513,6 @@ func (suite *SegmentCheckerTestSuite) TestSkipReleaseSealedSegments() {
 	suite.Equal(task.ActionTypeReduce, action.Type())
 	suite.EqualValues(segmentID, action.SegmentID())
 	suite.EqualValues(nodeID, action.Node())
-	suite.Equal(tasks[0].Priority(), task.TaskPriorityNormal)
 }
 
 func (suite *SegmentCheckerTestSuite) TestReleaseGrowingSegments() {
@@ -579,7 +570,6 @@ func (suite *SegmentCheckerTestSuite) TestReleaseGrowingSegments() {
 	suite.Equal(task.ActionTypeReduce, action.Type())
 	suite.EqualValues(2, action.SegmentID())
 	suite.EqualValues(2, action.Node())
-	suite.Equal(tasks[0].Priority(), task.TaskPriorityNormal)
 
 	suite.Len(tasks[1].Actions(), 1)
 	action, ok = tasks[1].Actions()[0].(*task.SegmentAction)
@@ -588,7 +578,6 @@ func (suite *SegmentCheckerTestSuite) TestReleaseGrowingSegments() {
 	suite.Equal(task.ActionTypeReduce, action.Type())
 	suite.EqualValues(3, action.SegmentID())
 	suite.EqualValues(2, action.Node())
-	suite.Equal(tasks[1].Priority(), task.TaskPriorityNormal)
 }
 
 func (suite *SegmentCheckerTestSuite) TestSkipReleaseGrowingSegments() {
@@ -635,7 +624,6 @@ func (suite *SegmentCheckerTestSuite) TestSkipReleaseGrowingSegments() {
 	suite.Equal(task.ActionTypeReduce, action.Type())
 	suite.EqualValues(2, action.SegmentID())
 	suite.EqualValues(2, action.Node())
-	suite.Equal(tasks[0].Priority(), task.TaskPriorityNormal)
 }
 
 func (suite *SegmentCheckerTestSuite) TestReleaseDroppedSegments() {
@@ -650,7 +638,6 @@ func (suite *SegmentCheckerTestSuite) TestReleaseDroppedSegments() {
 	suite.Equal(task.ActionTypeReduce, action.Type())
 	suite.EqualValues(1, action.SegmentID())
 	suite.EqualValues(1, action.Node())
-	suite.Equal(tasks[0].Priority(), task.TaskPriorityNormal)
 }
 
 func TestSegmentCheckerSuite(t *testing.T) {

--- a/internal/querycoordv2/task/utils.go
+++ b/internal/querycoordv2/task/utils.go
@@ -65,12 +65,6 @@ func Wait(ctx context.Context, timeout time.Duration, tasks ...Task) error {
 	return err
 }
 
-func SetPriority(priority Priority, tasks ...Task) {
-	for i := range tasks {
-		tasks[i].SetPriority(priority)
-	}
-}
-
 func SetReason(reason string, tasks ...Task) {
 	for i := range tasks {
 		tasks[i].SetReason(reason)


### PR DESCRIPTION
issue: #34798 

query coord can only executing one task for specified segment/channel, and set proirity for each task, so task will higher priority could replace the lower, which make a lot of concurrent and task canceled issue.

This PR remove querycoord task priority policy, to make every task could be executed and avoid task canceled issues.