### PR TITLE
fix: restful v2 search api supports searchParams like nprobe

### DIFF
--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -894,6 +894,9 @@ func generateSearchParams(ctx context.Context, c *gin.Context, reqParams map[str
 	params := map[string]interface{}{ // auto generated mapping
 		"level": int(commonpb.ConsistencyLevel_Bounded),
 	}
+	for k, v := range reqParams {
+            params[k] = v
+        }
 	if reqParams != nil {
 		radius, radiusOk := reqParams[ParamRadius]
 		rangeFilter, rangeFilterOk := reqParams[ParamRangeFilter]


### PR DESCRIPTION
issue: #34105 
when we define nprobe in params, the performance has no impact, it seems this param does not take effect in Rest V2.

this PR fills param map with requestParam when generating searchParams, and the searchParams will inherit all params.