### PR TITLE
fix: Failed to unmarshal field stats's bloom filter

### DIFF
--- a/internal/datanode/compaction/clustering_compactor.go
+++ b/internal/datanode/compaction/clustering_compactor.go
@@ -852,7 +852,7 @@ func (t *clusteringCompactionTask) packBufferToSegment(ctx context.Context, buff
 
 	// clear segment binlogs cache
 	delete(buffer.flushedBinlogs, writer.GetSegmentID())
-	//set old writer nil
+	// set old writer nil
 	writer = nil
 	return nil
 }

--- a/internal/storage/field_stats.go
+++ b/internal/storage/field_stats.go
@@ -48,6 +48,7 @@ func (stats *FieldStats) Clone() FieldStats {
 		Type:      stats.Type,
 		Max:       stats.Max,
 		Min:       stats.Min,
+		BFType:    stats.BFType,
 		BF:        stats.BF,
 		Centroids: stats.Centroids,
 	}


### PR DESCRIPTION

pr #34377 introduce this issue, which miss some new changes during the cherry-pick