### PR TITLE
enhance: Avoid unnecesary syncTargetVersion func call after querycoord recover

### DIFF
--- a/internal/querycoordv2/meta/target.go
+++ b/internal/querycoordv2/meta/target.go
@@ -73,7 +73,12 @@ func FromPbCollectionTarget(target *querypb.CollectionTarget) *CollectionTarget 
 		}
 	}
 
-	return NewCollectionTarget(segments, dmChannels, partitions)
+	return &CollectionTarget{
+		segments:   segments,
+		dmChannels: dmChannels,
+		partitions: typeutil.NewSet(partitions...),
+		version:    target.GetVersion(),
+	}
 }
 
 func (p *CollectionTarget) toPbMsg() *querypb.CollectionTarget {

--- a/internal/querycoordv2/meta/target_manager_test.go
+++ b/internal/querycoordv2/meta/target_manager_test.go
@@ -608,6 +608,7 @@ func (suite *TargetManagerSuite) TestRecover() {
 	suite.mgr.SaveCurrentTarget(suite.catalog)
 
 	// clear target in memory
+	version := suite.mgr.current.getCollectionTarget(collectionID).GetTargetVersion()
 	suite.mgr.current.removeCollectionTarget(collectionID)
 	// try to recover
 	suite.mgr.Recover(suite.catalog)
@@ -616,6 +617,7 @@ func (suite *TargetManagerSuite) TestRecover() {
 	suite.NotNil(target)
 	suite.Len(target.GetAllDmChannelNames(), 2)
 	suite.Len(target.GetAllSegmentIDs(), 2)
+	suite.Equal(target.GetTargetVersion(), version)
 
 	// after recover, target info should be cleaned up
 	targets, err := suite.catalog.GetCollectionTargets()


### PR DESCRIPTION

before querycoord stop gracefully, we will save the current target to meta store and recover it after querycoord start up, to speed the querycoord's recovery time. but the target version hasn't been recovered as expected, and it use latest timestamp as current target's version, which has no effect to querycoord but an unnecessary syncTargetVersion func call.

This PR recover the correct target version to avoid unnecessary syncTargetVersion func call