### PR TITLE
enhance: Solve channel unbalance on datanode

### DIFF
--- a/internal/datacoord/policy.go
+++ b/internal/datacoord/policy.go
@@ -90,8 +90,8 @@ func AvgBalanceChannelPolicy(cluster Assignments) *ChannelOpSet {
 	}
 	channelCountPerNode := totalChannelNum / avaNodeNum
 	maxChannelCountPerNode := channelCountPerNode
-	reminder := totalChannelNum % avaNodeNum
-	if reminder > 0 {
+	remainder := totalChannelNum % avaNodeNum
+	if remainder > 0 {
 		maxChannelCountPerNode += 1
 	}
 	for _, nChannels := range cluster {
@@ -101,8 +101,8 @@ func AvgBalanceChannelPolicy(cluster Assignments) *ChannelOpSet {
 		}
 
 		toReleaseCount := chCount - channelCountPerNode
-		if reminder > 0 && chCount >= maxChannelCountPerNode {
-			reminder -= 1
+		if remainder > 0 && chCount >= maxChannelCountPerNode {
+			remainder -= 1
 			toReleaseCount = chCount - maxChannelCountPerNode
 		}
 

--- a/internal/datacoord/policy_test.go
+++ b/internal/datacoord/policy_test.go
@@ -71,16 +71,16 @@ func (s *PolicySuite) TestAvgBalanceChannelPolicy() {
 		s.Nil(opSet)
 	})
 	s.Run("test uneven with conservative effect", func() {
-		// as we deem that the node having only one channel more than average as even, so there's no reallocation
-		// for this test case
-		// even distribution should have not results
 		uneven := []*NodeChannelInfo{
 			{100, getChannels(map[string]int64{"ch1": 1, "ch2": 1})},
 			{NodeID: 101},
 		}
 
 		opSet := AvgBalanceChannelPolicy(uneven)
-		s.Nil(opSet)
+		s.Equal(opSet.Len(), 1)
+		for _, op := range opSet.Collect() {
+			s.True(lo.Contains([]string{"ch1", "ch2"}, op.GetChannelNames()[0]))
+		}
 	})
 	s.Run("test uneven with zero", func() {
 		uneven := []*NodeChannelInfo{


### PR DESCRIPTION
issue: #33583
the old policy permit datanode has at most 2 more channels than other datanode. so if milvus has 2 datanode and 2 channels, both 2 channels will be assign to 1 datanode, left another datanode empty.

This PR refine the balance policy to solve channel unbalance on datanode