### PR TITLE
feat: add config to config server http2 maxstream

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -592,6 +592,7 @@ grpc:
   log:
     level: WARNING
   gracefulStopTimeout: 10 # second, time to wait graceful stop finish
+  maxConcurrentStreams: 1000 # each http2 can serve 1000 concurrent request
   client:
     compressionEnabled: false
     dialTimeout: 200

--- a/internal/distributed/datacoord/service.go
+++ b/internal/distributed/datacoord/service.go
@@ -176,6 +176,7 @@ func (s *Server) startGrpcLoop(grpcPort int) {
 		grpc.KeepaliveParams(kasp),
 		grpc.MaxRecvMsgSize(Params.ServerMaxRecvSize.GetAsInt()),
 		grpc.MaxSendMsgSize(Params.ServerMaxSendSize.GetAsInt()),
+		grpc.MaxConcurrentStreams(Params.MaxConcurrentStreams.GetAsUint32()),
 		grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(
 			otelgrpc.UnaryServerInterceptor(opts...),
 			logutil.UnaryTraceLoggerInterceptor,

--- a/internal/distributed/datanode/service.go
+++ b/internal/distributed/datanode/service.go
@@ -137,6 +137,7 @@ func (s *Server) startGrpcLoop(grpcPort int) {
 		grpc.KeepaliveParams(kasp),
 		grpc.MaxRecvMsgSize(Params.ServerMaxRecvSize.GetAsInt()),
 		grpc.MaxSendMsgSize(Params.ServerMaxSendSize.GetAsInt()),
+		grpc.MaxConcurrentStreams(Params.MaxConcurrentStreams.GetAsUint32()),
 		grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(
 			otelgrpc.UnaryServerInterceptor(opts...),
 			logutil.UnaryTraceLoggerInterceptor,

--- a/internal/distributed/indexnode/service.go
+++ b/internal/distributed/indexnode/service.go
@@ -111,6 +111,7 @@ func (s *Server) startGrpcLoop(grpcPort int) {
 		grpc.KeepaliveParams(kasp),
 		grpc.MaxRecvMsgSize(Params.ServerMaxRecvSize.GetAsInt()),
 		grpc.MaxSendMsgSize(Params.ServerMaxSendSize.GetAsInt()),
+		grpc.MaxConcurrentStreams(Params.MaxConcurrentStreams.GetAsUint32()),
 		grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(
 			otelgrpc.UnaryServerInterceptor(opts...),
 			logutil.UnaryTraceLoggerInterceptor,

--- a/internal/distributed/querycoord/service.go
+++ b/internal/distributed/querycoord/service.go
@@ -232,6 +232,7 @@ func (s *Server) startGrpcLoop(grpcPort int) {
 		grpc.KeepaliveParams(kasp),
 		grpc.MaxRecvMsgSize(Params.ServerMaxRecvSize.GetAsInt()),
 		grpc.MaxSendMsgSize(Params.ServerMaxSendSize.GetAsInt()),
+		grpc.MaxConcurrentStreams(Params.MaxConcurrentStreams.GetAsUint32()),
 		grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(
 			otelgrpc.UnaryServerInterceptor(opts...),
 			logutil.UnaryTraceLoggerInterceptor,

--- a/internal/distributed/querynode/service.go
+++ b/internal/distributed/querynode/service.go
@@ -192,6 +192,7 @@ func (s *Server) startGrpcLoop(grpcPort int) {
 		grpc.KeepaliveParams(kasp),
 		grpc.MaxRecvMsgSize(Params.ServerMaxRecvSize.GetAsInt()),
 		grpc.MaxSendMsgSize(Params.ServerMaxSendSize.GetAsInt()),
+		grpc.MaxConcurrentStreams(Params.MaxConcurrentStreams.GetAsUint32()),
 		grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(
 			otelgrpc.UnaryServerInterceptor(opts...),
 			logutil.UnaryTraceLoggerInterceptor,

--- a/internal/distributed/rootcoord/service.go
+++ b/internal/distributed/rootcoord/service.go
@@ -278,6 +278,7 @@ func (s *Server) startGrpcLoop(port int) {
 		grpc.KeepaliveParams(kasp),
 		grpc.MaxRecvMsgSize(Params.ServerMaxRecvSize.GetAsInt()),
 		grpc.MaxSendMsgSize(Params.ServerMaxSendSize.GetAsInt()),
+		grpc.MaxConcurrentStreams(Params.MaxConcurrentStreams.GetAsUint32()),
 		grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(
 			otelgrpc.UnaryServerInterceptor(opts...),
 			logutil.UnaryTraceLoggerInterceptor,

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -307,6 +307,7 @@ func (s *proxyTestServer) startGrpc(ctx context.Context, wg *sync.WaitGroup, p *
 		grpc.KeepaliveParams(kasp),
 		grpc.MaxRecvMsgSize(p.ServerMaxRecvSize.GetAsInt()),
 		grpc.MaxSendMsgSize(p.ServerMaxSendSize.GetAsInt()),
+		grpc.MaxConcurrentStreams(p.MaxConcurrentStreams.GetAsUint32()),
 		grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(
 			otelgrpc.UnaryServerInterceptor(opts...),
 			RateLimitInterceptor(s.simpleLimiter),

--- a/pkg/util/paramtable/grpc_param.go
+++ b/pkg/util/paramtable/grpc_param.go
@@ -37,6 +37,9 @@ const (
 	// DefaultServerMaxRecvSize defines the maximum size of data per grpc request can receive by server side.
 	DefaultServerMaxRecvSize = 256 * 1024 * 1024
 
+	// DefaultMaxConcurrentStreams defines the maximum number of concurrent calls on a http2 stream
+	DefaultMaxConcurrentStreams = 1000
+
 	// DefaultClientMaxSendSize defines the maximum size of data per grpc request can send by client side.
 	DefaultClientMaxSendSize = 256 * 1024 * 1024
 
@@ -147,7 +150,8 @@ type GrpcServerConfig struct {
 	ServerMaxSendSize ParamItem `refreshable:"false"`
 	ServerMaxRecvSize ParamItem `refreshable:"false"`
 
-	GracefulStopTimeout ParamItem `refreshable:"true"`
+	MaxConcurrentStreams ParamItem `refreshable:"false"`
+	GracefulStopTimeout  ParamItem `refreshable:"true"`
 }
 
 func (p *GrpcServerConfig) Init(domain string, base *BaseTable) {
@@ -196,6 +200,27 @@ func (p *GrpcServerConfig) Init(domain string, base *BaseTable) {
 		Export: true,
 	}
 	p.ServerMaxRecvSize.Init(base.mgr)
+
+	maxConcurrentStream := strconv.FormatInt(DefaultMaxConcurrentStreams, 10)
+	p.MaxConcurrentStreams = ParamItem{
+		Key:     "grpc.maxConcurrentStreams",
+		Version: "2.4.8",
+		Formatter: func(v string) string {
+			if v == "" {
+				return maxConcurrentStream
+			}
+			_, err := strconv.Atoi(v)
+			if err != nil {
+				log.Warn("Failed to convert int when parsing grpc.maxConcurrentStreams, set to default",
+					zap.String("role", p.Domain),
+					zap.String("grpc.maxConcurrentStreams", v))
+				return maxConcurrentStream
+			}
+			return v
+		},
+		Export: true,
+	}
+	p.MaxConcurrentStreams.Init(base.mgr)
 
 	p.GracefulStopTimeout = ParamItem{
 		Key:          "grpc.gracefulStopTimeout",

--- a/pkg/util/paramtable/grpc_param_test.go
+++ b/pkg/util/paramtable/grpc_param_test.go
@@ -52,6 +52,9 @@ func TestGrpcServerParams(t *testing.T) {
 	base.Remove("grpc.serverMaxRecvSize")
 	assert.Equal(t, serverConfig.ServerMaxRecvSize.GetAsInt(), DefaultServerMaxRecvSize)
 
+	base.Remove("grpc.serverMaxRecvSize")
+	assert.Equal(t, serverConfig.MaxConcurrentStreams.GetAsInt(), DefaultMaxConcurrentStreams)
+
 	base.Save("grpc.serverMaxRecvSize", "a")
 	assert.Equal(t, serverConfig.ServerMaxRecvSize.GetAsInt(), DefaultServerMaxRecvSize)
 


### PR DESCRIPTION
fix #35000
add a config to set http2 maxstream and set it to 1000 by default