### PR TITLE
enhance: Solve channel unbalance on datanode (#34984)

### DIFF
--- a/internal/datacoord/policy.go
+++ b/internal/datacoord/policy.go
@@ -332,17 +332,32 @@ func AvgBalanceChannelPolicy(cluster Assignments) *ChannelOpSet {
 		totalChannelNum += len(nodeChs.Channels)
 	}
 	channelCountPerNode := totalChannelNum / avaNodeNum
+	maxChannelCountPerNode := channelCountPerNode
+	remainder := totalChannelNum % avaNodeNum
+	if remainder > 0 {
+		maxChannelCountPerNode += 1
+	}
 	for _, nChannels := range cluster {
 		chCount := len(nChannels.Channels)
-		if chCount <= channelCountPerNode+1 {
+		if chCount == 0 {
+			continue
+		}
+
+		toReleaseCount := chCount - channelCountPerNode
+		if remainder > 0 && chCount >= maxChannelCountPerNode {
+			remainder -= 1
+			toReleaseCount = chCount - maxChannelCountPerNode
+		}
+
+		if toReleaseCount == 0 {
 			log.Info("node channel count is not much larger than average, skip reallocate",
 				zap.Int64("nodeID", nChannels.NodeID),
 				zap.Int("channelCount", chCount),
 				zap.Int("channelCountPerNode", channelCountPerNode))
 			continue
 		}
+
 		reallocate := NewNodeChannelInfo(nChannels.NodeID)
-		toReleaseCount := chCount - channelCountPerNode - 1
 		for _, ch := range nChannels.Channels {
 			reallocate.AddChannel(ch)
 			toReleaseCount--
@@ -377,6 +392,7 @@ func AvgAssignByCountPolicy(currentCluster Assignments, toAssign *NodeChannelInf
 			fromCluster = append(fromCluster, info)
 			channelNum += len(info.Channels)
 			nodeToAvg.Insert(info.NodeID)
+			return
 		}
 
 		// Get toCluster by filtering out execlusive nodes
@@ -385,6 +401,7 @@ func AvgAssignByCountPolicy(currentCluster Assignments, toAssign *NodeChannelInf
 		}
 
 		toCluster = append(toCluster, info)
+		channelNum += len(info.Channels)
 		nodeToAvg.Insert(info.NodeID)
 	})
 


### PR DESCRIPTION
issue: #33583
pr: #34984
the old policy permit datanode has at most 2 more channels than other datanode. so if milvus has 2 datanode and 2 channels, both 2 channels will be assign to 1 datanode, left another datanode empty.

This PR refine the balance policy to solve channel unbalance on datanode

---------