### PR TITLE
fix: Fix load segment may cause long tSafe latency

### DIFF
--- a/internal/querynodev2/delegator/delegator.go
+++ b/internal/querynodev2/delegator/delegator.go
@@ -114,7 +114,6 @@ type shardDelegator struct {
 	pkOracle       pkoracle.PkOracle
 	level0Mut      sync.RWMutex
 	// stream delete buffer
-	deleteMut    sync.RWMutex
 	deleteBuffer deletebuffer.DeleteBuffer[*deletebuffer.Item]
 	// dispatcherClient msgdispatcher.Client
 	factory msgstream.Factory

--- a/internal/querynodev2/delegator/deletebuffer/delete_buffer_test.go
+++ b/internal/querynodev2/delegator/deletebuffer/delete_buffer_test.go
@@ -74,8 +74,10 @@ func (s *DoubleCacheBufferSuite) TestCache() {
 		},
 	})
 
-	s.Equal(2, len(buffer.ListAfter(11)))
-	s.Equal(1, len(buffer.ListAfter(12)))
+	deleteRecords, _ := buffer.ListAfter(11)
+	s.Equal(2, len(deleteRecords))
+	deleteRecords, _ = buffer.ListAfter(12)
+	s.Equal(1, len(deleteRecords))
 }
 
 func TestDoubleCacheDeleteBuffer(t *testing.T) {

--- a/internal/querynodev2/delegator/deletebuffer/list_delete_buffer.go
+++ b/internal/querynodev2/delegator/deletebuffer/list_delete_buffer.go
@@ -53,7 +53,7 @@ func (b *listDeleteBuffer[T]) Put(entry T) {
 	}
 }
 
-func (b *listDeleteBuffer[T]) ListAfter(ts uint64) []T {
+func (b *listDeleteBuffer[T]) ListAfter(ts uint64) ([]T, uint64) {
 	b.mut.RLock()
 	defer b.mut.RUnlock()
 
@@ -61,7 +61,7 @@ func (b *listDeleteBuffer[T]) ListAfter(ts uint64) []T {
 	for _, block := range b.list {
 		result = append(result, block.ListAfter(ts)...)
 	}
-	return result
+	return result, b.safeTs
 }
 
 func (b *listDeleteBuffer[T]) SafeTs() uint64 {

--- a/internal/querynodev2/delegator/deletebuffer/list_delete_buffer_test.go
+++ b/internal/querynodev2/delegator/deletebuffer/list_delete_buffer_test.go
@@ -60,8 +60,10 @@ func (s *ListDeleteBufferSuite) TestCache() {
 		},
 	})
 
-	s.Equal(2, len(buffer.ListAfter(11)))
-	s.Equal(1, len(buffer.ListAfter(12)))
+	deleteRecords, _ := buffer.ListAfter(11)
+	s.Equal(2, len(deleteRecords))
+	deleteRecords, _ = buffer.ListAfter(12)
+	s.Equal(1, len(deleteRecords))
 }
 
 func (s *ListDeleteBufferSuite) TestTryDiscard() {
@@ -94,19 +96,24 @@ func (s *ListDeleteBufferSuite) TestTryDiscard() {
 		},
 	})
 
-	s.Equal(2, len(buffer.ListAfter(10)))
+	deleteRecords, _ := buffer.ListAfter(10)
+	s.Equal(2, len(deleteRecords))
 
 	buffer.TryDiscard(10)
-	s.Equal(2, len(buffer.ListAfter(10)), "equal ts shall not discard block")
+	deleteRecords, _ = buffer.ListAfter(10)
+	s.Equal(2, len(deleteRecords), "equal ts shall not discard block")
 
 	buffer.TryDiscard(9)
-	s.Equal(2, len(buffer.ListAfter(10)), "history ts shall not discard any block")
+	deleteRecords, _ = buffer.ListAfter(9)
+	s.Equal(2, len(deleteRecords), "history ts shall not discard any block")
 
 	buffer.TryDiscard(20)
-	s.Equal(1, len(buffer.ListAfter(10)), "first block shall be discarded")
+	deleteRecords, _ = buffer.ListAfter(10)
+	s.Equal(1, len(deleteRecords), "first block shall be discarded")
 
 	buffer.TryDiscard(20)
-	s.Equal(1, len(buffer.ListAfter(10)), "discard will not happen if there is only one block")
+	deleteRecords, _ = buffer.ListAfter(10)
+	s.Equal(1, len(deleteRecords), "discard will not happen if there is only one block")
 }
 
 func TestListDeleteBuffer(t *testing.T) {


### PR DESCRIPTION
issue: #35070
cause load segment will hold delete buffer lock to consume msg from stream, which may block process delete for a few seconds, and cause a peek in tSafe latency.

this PR remove the unnecessary delete buffer lock to avoid the unexpected tSafe latency.