### PR TITLE
fix: add prometheus dependency for milvus_monitor

### DIFF
--- a/internal/core/src/monitor/CMakeLists.txt
+++ b/internal/core/src/monitor/CMakeLists.txt
@@ -18,4 +18,6 @@ set(MONITOR_SRC
 
 add_library(milvus_monitor SHARED ${MONITOR_SRC})
 
+target_link_libraries(milvus_monitor PUBLIC ${CONAN_LIBS})
+
 install(TARGETS milvus_monitor DESTINATION "${CMAKE_INSTALL_LIBDIR}")


### PR DESCRIPTION
add prometheus dependency for monitor module. Or else Some compilers may report a compilation failure.
issue: #35077 