### PR TITLE
enhance: add channel num for queryHook optimization

### DIFF
--- a/internal/querynodev2/optimizers/query_hook.go
+++ b/internal/querynodev2/optimizers/query_hook.go
@@ -66,6 +66,9 @@ func OptimizeSearchParams(ctx context.Context, req *querypb.SearchRequest, query
 			common.WithOptimizeKey: paramtable.Get().AutoIndexConfig.EnableOptimize.GetAsBool(),
 			common.CollectionKey:   req.GetReq().GetCollectionID(),
 		}
+		if withFilter && channelNum > 1 {
+			params[common.ChannelNumKey] = channelNum
+		}
 		err := queryHook.Run(params)
 		if err != nil {
 			log.Warn("failed to execute queryHook", zap.Error(err))

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -109,6 +109,7 @@ const (
 	SegmentNumKey   = "segment_num"
 	WithFilterKey   = "with_filter"
 	DataTypeKey     = "data_type"
+	ChannelNumKey   = "channel_num"
 	WithOptimizeKey = "with_optimize"
 	CollectionKey   = "collection"
 


### PR DESCRIPTION
At most cases, data in each channel is almost evenly distributed, we could utilize the channel num info to optimize searh param in queryHook