### PR TITLE
enhance: [2.4] Use clang-format-12 to perform cpp check

### DIFF
--- a/internal/core/run_clang_format.sh
+++ b/internal/core/run_clang_format.sh
@@ -7,7 +7,7 @@ fi
 CorePath=$1
 
 formatThis() {
-    find "$1" | grep -E "(*\.cpp|*\.h|*\.cc)$" | grep -v "gen_tools/templates" | grep -v "\.pb\." | grep -v "tantivy-binding.h" | xargs clang-format-10 -i
+    find "$1" | grep -E "(*\.cpp|*\.h|*\.cc)$" | grep -v "gen_tools/templates" | grep -v "\.pb\." | grep -v "tantivy-binding.h" | xargs clang-format-12 -i
 }
 
 formatThis "${CorePath}/src"

--- a/internal/core/src/storage/DiskFileManagerImpl.cpp
+++ b/internal/core/src/storage/DiskFileManagerImpl.cpp
@@ -491,10 +491,9 @@ DiskFileManagerImpl::CacheRawDataToDisk(std::vector<std::string> remote_files) {
             if (data_type == milvus::DataType::VECTOR_SPARSE_FLOAT) {
                 dim = std::max(
                     dim,
-                    (uint32_t)(
-                        std::dynamic_pointer_cast<FieldData<SparseFloatVector>>(
-                            field_data)
-                            ->Dim()));
+                    (uint32_t)(std::dynamic_pointer_cast<
+                                   FieldData<SparseFloatVector>>(field_data)
+                                   ->Dim()));
                 auto sparse_rows =
                     static_cast<const knowhere::sparse::SparseRow<float>*>(
                         field_data->Data());


### PR DESCRIPTION
clang-format version is 12 after upgrading to ubuntu 22.04, this PR change formating script to use clang-format-12 and fix existing problems