### PR TITLE
enhance: Skip manual stopped component during health check (#34953)

### DIFF
--- a/cmd/roles/roles.go
+++ b/cmd/roles/roles.go
@@ -434,6 +434,9 @@ func (mr *MilvusRoles) Run() {
 		if len(role) == 0 || componentMap[role] == nil {
 			return fmt.Errorf("stop component [%s] in [%s] is not supported", role, mr.ServerType)
 		}
+
+		log.Info("unregister component before stop", zap.String("role", role))
+		healthz.UnRegister(role)
 		return componentMap[role].Stop()
 	})
 


### PR DESCRIPTION
pr: #34953
after manual stop component by management restful api, `healthz` may return unhealthy state. k8s may restart the pod to save the unhealthy sate, and the manual stop operation will got unexpected result.

to solve this, we make `healthz` API skip the manual stopped component.

---------