### PR TITLE
fix: Fix datanode cannot watch channel

### DIFF
--- a/internal/datanode/event_manager.go
+++ b/internal/datanode/event_manager.go
@@ -56,7 +56,7 @@ func (node *DataNode) StartWatchChannels(ctx context.Context) {
 	err := node.checkWatchedList()
 	if err != nil {
 		log.Warn("StartWatchChannels failed", zap.Error(err))
-		return
+		panic(err)
 	}
 	for {
 		select {


### PR DESCRIPTION
Panic when `checkWatchedList` failed, this can avoid unnoticed quit of the channel watch goroutine.

issue: https://github.com/milvus-io/milvus/issues/35135