### PR TITLE
enhance: enable to set load config in cluster level

### DIFF
--- a/internal/querycoordv2/meta/coordinator_broker.go
+++ b/internal/querycoordv2/meta/coordinator_broker.go
@@ -151,6 +151,22 @@ func (broker *CoordinatorBroker) GetCollectionLoadInfo(ctx context.Context, coll
 		}
 	}
 
+	if replicaNum <= 0 || len(rgs) == 0 {
+		if replicaNum <= 0 {
+			replicaNum = paramtable.Get().QueryCoordCfg.ClusterLevelLoadReplicaNumber.GetAsInt64()
+			if replicaNum > 0 {
+				log.Info("get cluster level load info", zap.Int64("collectionID", collectionID), zap.Int64("replica_num", replicaNum))
+			}
+		}
+
+		if len(rgs) == 0 {
+			rgs = paramtable.Get().QueryCoordCfg.ClusterLevelLoadResourceGroups.GetAsStrings()
+			if len(rgs) > 0 {
+				log.Info("get cluster level load info", zap.Int64("collectionID", collectionID), zap.Strings("resource_groups", rgs))
+			}
+		}
+	}
+
 	return rgs, replicaNum, nil
 }
 

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -1702,6 +1702,8 @@ type queryCoordConfig struct {
 	CheckExecutedFlagInterval          ParamItem `refreshable:"false"`
 	CollectionBalanceSegmentBatchSize  ParamItem `refreshable:"true"`
 	UpdateCollectionLoadStatusInterval ParamItem `refreshable:"false"`
+	ClusterLevelLoadReplicaNumber      ParamItem `refreshable:"true"`
+	ClusterLevelLoadResourceGroups     ParamItem `refreshable:"true"`
 }
 
 func (p *queryCoordConfig) init(base *BaseTable) {
@@ -2238,6 +2240,24 @@ If this parameter is set false, Milvus simply searches the growing segments with
 		Export:       false,
 	}
 	p.CollectionBalanceSegmentBatchSize.Init(base.mgr)
+
+	p.ClusterLevelLoadReplicaNumber = ParamItem{
+		Key:          "queryCoord.clusterLevelLoadReplicaNumber",
+		Version:      "2.4.7",
+		DefaultValue: "0",
+		Doc:          "the cluster level default value for load replica number",
+		Export:       false,
+	}
+	p.ClusterLevelLoadReplicaNumber.Init(base.mgr)
+
+	p.ClusterLevelLoadResourceGroups = ParamItem{
+		Key:          "queryCoord.clusterLevelLoadResourceGroups",
+		Version:      "2.4.7",
+		DefaultValue: "",
+		Doc:          "resource group names for load collection should be at least equal to queryCoord.clusterLevelLoadReplicaNumber, separate with commas",
+		Export:       false,
+	}
+	p.ClusterLevelLoadResourceGroups.Init(base.mgr)
 }
 
 // /////////////////////////////////////////////////////////////////////////////

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -108,7 +108,7 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, "defaultMilvus", Params.DefaultRootPassword.GetValue())
 
 		params.Save("common.security.superUsers", "")
-		assert.Equal(t, []string{""}, Params.SuperUsers.GetAsStrings())
+		assert.Equal(t, []string{}, Params.SuperUsers.GetAsStrings())
 
 		assert.Equal(t, false, Params.PreCreatedTopicEnabled.GetAsBool())
 
@@ -345,6 +345,9 @@ func TestComponentParam(t *testing.T) {
 
 		assert.Equal(t, 0.1, Params.DelegatorMemoryOverloadFactor.GetAsFloat())
 		assert.Equal(t, 5, Params.CollectionBalanceSegmentBatchSize.GetAsInt())
+
+		assert.Equal(t, 0, Params.ClusterLevelLoadReplicaNumber.GetAsInt())
+		assert.Len(t, Params.ClusterLevelLoadResourceGroups.GetAsStrings(), 0)
 	})
 
 	t.Run("test queryNodeConfig", func(t *testing.T) {

--- a/pkg/util/paramtable/param_item.go
+++ b/pkg/util/paramtable/param_item.go
@@ -331,6 +331,9 @@ func ParseAsStings(v string) []string {
 }
 
 func getAsStrings(v string) []string {
+	if len(v) == 0 {
+		return []string{}
+	}
 	return getAndConvert(v, func(value string) ([]string, error) {
 		return strings.Split(value, ","), nil
 	}, []string{})


### PR DESCRIPTION
issue: #35170
This PR enable to set load configs in cluster level, such as replicas and resource groups. then when load collections will use the load config.