### PR TITLE
enhance: Add config to disable mmap index

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -410,6 +410,7 @@ queryNode:
     warmup: disable
   mmap:
     mmapEnabled: false # Enable mmap for loading data
+    vectorIndexMmapEnabled: false # Enable mmap for loading vector index
     growingMmapEnabled: false # Enable mmap for using in growing raw data
     fixedFileSizeForMmapAlloc: 1 # tmp file size for mmap chunk manager
     maxDiskUsagePercentageForMmapAlloc: 50 # disk percentage used in mmap chunk manager

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -2273,6 +2273,7 @@ type queryNodeConfig struct {
 	CacheMemoryLimit                    ParamItem `refreshable:"false"`
 	MmapDirPath                         ParamItem `refreshable:"false"`
 	MmapEnabled                         ParamItem `refreshable:"false"`
+	VectorIndexMmapEnabled              ParamItem `refreshable:"false"`
 	GrowingMmapEnabled                  ParamItem `refreshable:"false"`
 	FixedFileSizeForMmapManager         ParamItem `refreshable:"false"`
 	MaxMmapDiskPercentageForMmapManager ParamItem `refreshable:"false"`
@@ -2540,6 +2541,15 @@ This defaults to true, indicating that Milvus creates temporary index for growin
 		Export:       true,
 	}
 	p.MmapEnabled.Init(base.mgr)
+
+	p.VectorIndexMmapEnabled = ParamItem{
+		Key:          "queryNode.mmap.vectorIndexMmapEnabled",
+		Version:      "2.4.8",
+		DefaultValue: "false",
+		Doc:          "Enable mmap for loading vector index",
+		Export:       true,
+	}
+	p.VectorIndexMmapEnabled.Init(base.mgr)
 
 	p.GrowingMmapEnabled = ParamItem{
 		Key:          "queryNode.mmap.growingMmapEnabled",

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -447,6 +447,7 @@ func TestComponentParam(t *testing.T) {
 
 		assert.Equal(t, 4, Params.BloomFilterApplyParallelFactor.GetAsInt())
 		assert.Equal(t, "/var/lib/milvus/data/mmap", Params.MmapDirPath.GetValue())
+		assert.Equal(t, false, Params.VectorIndexMmapEnabled.GetAsBool())
 	})
 
 	t.Run("test dataCoordConfig", func(t *testing.T) {


### PR DESCRIPTION
this PR add config to disable mmap index. when you want to enable mmap index, you should limit the binlog size and chunk cache disk size to half of physical disk size. for example, load a collection with only vector data, suppose the vector binlog size is 10G. then chunk cache need 10G disk to mmap the vector raw data, and load index need almost another 10G disk to mmap the vector index.

so if enable mmap index, make sure that:
1. limit `quotaAndLimits.limitWriting.diskProtection.diskQuota` to less than 50% of physical disk capacity
2. set `queryNode.mmap.maxDiskUsagePercentageForMmapAlloc` eqauls to `quotaAndLimits.limitWriting.diskProtection.diskQuota`, to make chunk cache works well