### PR TITLE
fix: Fix deadlock on compaction when stopping datanode

### DIFF
--- a/internal/datanode/compaction_executor_test.go
+++ b/internal/datanode/compaction_executor_test.go
@@ -18,6 +18,7 @@ package datanode
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -39,7 +40,7 @@ func TestCompactionExecutor(t *testing.T) {
 		ex := newCompactionExecutor()
 		mc := newMockCompactor(true)
 		ex.executeWithState(mc)
-		ex.stopTask(UniqueID(1))
+		ex.stopTask(&sync.WaitGroup{}, UniqueID(1))
 	})
 
 	t.Run("Test start", func(t *testing.T) {

--- a/internal/datanode/compaction_executor_test.go
+++ b/internal/datanode/compaction_executor_test.go
@@ -40,7 +40,10 @@ func TestCompactionExecutor(t *testing.T) {
 		ex := newCompactionExecutor()
 		mc := newMockCompactor(true)
 		ex.executeWithState(mc)
-		ex.stopTask(&sync.WaitGroup{}, UniqueID(1))
+		wg := &sync.WaitGroup{}
+		wg.Add(1)
+		go ex.stopTask(wg, UniqueID(1))
+		wg.Wait()
 	})
 
 	t.Run("Test start", func(t *testing.T) {


### PR DESCRIPTION
Stop compaction tasks in parallel to avoid interdependencies and prevent deadlocks.

issue: https://github.com/milvus-io/milvus/issues/35198