### PR TITLE
fix: Set legacy level to l0 segment after qc restart (#35197)

### DIFF
--- a/internal/proto/query_coord.proto
+++ b/internal/proto/query_coord.proto
@@ -626,6 +626,7 @@ message SegmentVersionInfo {
     int64 version = 5;
     uint64 last_delta_timestamp = 6;
     map<int64, FieldIndexInfo> index_info = 7;
+    data.SegmentLevel level = 8; 
 }
 
 message ChannelVersionInfo {

--- a/internal/querycoordv2/balance/multi_target_balance.go
+++ b/internal/querycoordv2/balance/multi_target_balance.go
@@ -9,7 +9,6 @@ import (
 	"github.com/samber/lo"
 	"go.uber.org/zap"
 
-	"github.com/milvus-io/milvus/internal/proto/datapb"
 	"github.com/milvus-io/milvus/internal/querycoordv2/meta"
 	"github.com/milvus-io/milvus/internal/querycoordv2/params"
 	"github.com/milvus-io/milvus/internal/querycoordv2/session"
@@ -511,9 +510,7 @@ func (b *MultiTargetBalancer) genSegmentPlan(replica *meta.Replica, rwNodes []in
 	for _, node := range rwNodes {
 		dist := b.dist.SegmentDistManager.GetByFilter(meta.WithCollectionID(replica.GetCollectionID()), meta.WithNodeID(node))
 		segments := lo.Filter(dist, func(segment *meta.Segment, _ int) bool {
-			return b.targetMgr.GetSealedSegment(segment.GetCollectionID(), segment.GetID(), meta.CurrentTarget) != nil &&
-				b.targetMgr.GetSealedSegment(segment.GetCollectionID(), segment.GetID(), meta.NextTarget) != nil &&
-				segment.GetLevel() != datapb.SegmentLevel_L0
+			return b.targetMgr.CanSegmentBeMoved(segment.GetCollectionID(), segment.GetID())
 		})
 		nodeSegments[node] = segments
 		globalNodeSegments[node] = b.dist.SegmentDistManager.GetByFilter(meta.WithNodeID(node))

--- a/internal/querycoordv2/meta/mock_target_manager.go
+++ b/internal/querycoordv2/meta/mock_target_manager.go
@@ -24,6 +24,49 @@ func (_m *MockTargetManager) EXPECT() *MockTargetManager_Expecter {
 	return &MockTargetManager_Expecter{mock: &_m.Mock}
 }
 
+// CanSegmentBeMoved provides a mock function with given fields: collectionID, segmentID
+func (_m *MockTargetManager) CanSegmentBeMoved(collectionID int64, segmentID int64) bool {
+	ret := _m.Called(collectionID, segmentID)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(int64, int64) bool); ok {
+		r0 = rf(collectionID, segmentID)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
+// MockTargetManager_CanSegmentBeMoved_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CanSegmentBeMoved'
+type MockTargetManager_CanSegmentBeMoved_Call struct {
+	*mock.Call
+}
+
+// CanSegmentBeMoved is a helper method to define mock.On call
+//   - collectionID int64
+//   - segmentID int64
+func (_e *MockTargetManager_Expecter) CanSegmentBeMoved(collectionID interface{}, segmentID interface{}) *MockTargetManager_CanSegmentBeMoved_Call {
+	return &MockTargetManager_CanSegmentBeMoved_Call{Call: _e.mock.On("CanSegmentBeMoved", collectionID, segmentID)}
+}
+
+func (_c *MockTargetManager_CanSegmentBeMoved_Call) Run(run func(collectionID int64, segmentID int64)) *MockTargetManager_CanSegmentBeMoved_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(int64), args[1].(int64))
+	})
+	return _c
+}
+
+func (_c *MockTargetManager_CanSegmentBeMoved_Call) Return(_a0 bool) *MockTargetManager_CanSegmentBeMoved_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockTargetManager_CanSegmentBeMoved_Call) RunAndReturn(run func(int64, int64) bool) *MockTargetManager_CanSegmentBeMoved_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetCollectionTargetVersion provides a mock function with given fields: collectionID, scope
 func (_m *MockTargetManager) GetCollectionTargetVersion(collectionID int64, scope int32) int64 {
 	ret := _m.Called(collectionID, scope)

--- a/internal/querycoordv2/meta/target_manager.go
+++ b/internal/querycoordv2/meta/target_manager.go
@@ -71,6 +71,7 @@ type TargetManagerInterface interface {
 	IsNextTargetExist(collectionID int64) bool
 	SaveCurrentTarget(catalog metastore.QueryCoordCatalog)
 	Recover(catalog metastore.QueryCoordCatalog) error
+	CanSegmentBeMoved(collectionID, segmentID int64) bool
 }
 
 type TargetManager struct {
@@ -689,4 +690,21 @@ func (mgr *TargetManager) Recover(catalog metastore.QueryCoordCatalog) error {
 	}
 
 	return nil
+}
+
+// if segment isn't l0 segment, and exist in current/next target, then it can be moved
+func (mgr *TargetManager) CanSegmentBeMoved(collectionID, segmentID int64) bool {
+	mgr.rwMutex.Lock()
+	defer mgr.rwMutex.Unlock()
+	current := mgr.current.getCollectionTarget(collectionID)
+	if current != nil && current.segments[segmentID] != nil && current.segments[segmentID].GetLevel() != datapb.SegmentLevel_L0 {
+		return true
+	}
+
+	next := mgr.next.getCollectionTarget(collectionID)
+	if next != nil && next.segments[segmentID] != nil && next.segments[segmentID].GetLevel() != datapb.SegmentLevel_L0 {
+		return true
+	}
+
+	return false
 }

--- a/internal/querynodev2/services.go
+++ b/internal/querynodev2/services.go
@@ -1208,6 +1208,7 @@ func (node *QueryNode) GetDataDistribution(ctx context.Context, req *querypb.Get
 			Partition:          s.Partition(),
 			Channel:            s.Shard().VirtualName(),
 			Version:            s.Version(),
+			Level:              s.Level(),
 			LastDeltaTimestamp: s.LastDeltaTimestamp(),
 			IndexInfo: lo.SliceToMap(s.Indexes(), func(info *segments.IndexedFieldInfo) (int64, *querypb.FieldIndexInfo) {
 				return info.IndexInfo.FieldID, info.IndexInfo


### PR DESCRIPTION
issue: #35087
pr: #35197
after qc restarts, and target is not ready yet, if dist_handler try to update segment dist, it will set legacy level to l0 segment, which may cause l0 segment be moved to other node, cause search/query failed.