### PR TITLE
fix: comparision operations between incompatible operands

### DIFF
--- a/internal/parser/planparserv2/parser_visitor.go
+++ b/internal/parser/planparserv2/parser_visitor.go
@@ -334,14 +334,19 @@ func (v *ParserVisitor) VisitEquality(ctx *parser.EqualityContext) interface{} {
 
 	leftValue, rightValue := getGenericValue(left), getGenericValue(right)
 	if leftValue != nil && rightValue != nil {
+		var ret *ExprWithType
 		switch ctx.GetOp().GetTokenType() {
 		case parser.PlanParserEQ:
-			return Equal(leftValue, rightValue)
+			ret = Equal(leftValue, rightValue)
 		case parser.PlanParserNE:
-			return NotEqual(leftValue, rightValue)
+			ret = NotEqual(leftValue, rightValue)
 		default:
 			return fmt.Errorf("unexpected op: %s", ctx.GetOp().GetText())
 		}
+		if ret == nil {
+			return fmt.Errorf("comparison operations cannot be applied to two incompatible operands: %s", ctx.GetText())
+		}
+		return ret
 	}
 
 	var leftExpr *ExprWithType
@@ -383,18 +388,23 @@ func (v *ParserVisitor) VisitRelational(ctx *parser.RelationalContext) interface
 	leftValue, rightValue := getGenericValue(left), getGenericValue(right)
 
 	if leftValue != nil && rightValue != nil {
+		var ret *ExprWithType
 		switch ctx.GetOp().GetTokenType() {
 		case parser.PlanParserLT:
-			return Less(leftValue, rightValue)
+			ret = Less(leftValue, rightValue)
 		case parser.PlanParserLE:
-			return LessEqual(leftValue, rightValue)
+			ret = LessEqual(leftValue, rightValue)
 		case parser.PlanParserGT:
-			return Greater(leftValue, rightValue)
+			ret = Greater(leftValue, rightValue)
 		case parser.PlanParserGE:
-			return GreaterEqual(leftValue, rightValue)
+			ret = GreaterEqual(leftValue, rightValue)
 		default:
 			return fmt.Errorf("unexpected op: %s", ctx.GetOp().GetText())
 		}
+		if ret == nil {
+			return fmt.Errorf("comparison operations cannot be applied to two incompatible operands: %s", ctx.GetText())
+		}
+		return ret
 	}
 
 	var leftExpr *ExprWithType

--- a/internal/parser/planparserv2/plan_parser_v2_test.go
+++ b/internal/parser/planparserv2/plan_parser_v2_test.go
@@ -500,6 +500,15 @@ func TestExpr_Invalid(t *testing.T) {
 		//`1 < JSONField`,
 		`ArrayField > 2`,
 		`2 < ArrayField`,
+		// https://github.com/milvus-io/milvus/issues/34139
+		"\"Int64Field\" > 500 && \"Int64Field\" < 1000",
+		"\"Int64Field\" == 500 || \"Int64Field\" != 1000",
+		`"str" < 100`,
+		`"str" <= 100`,
+		`"str" > 100`,
+		`"str" >= 100`,
+		`"str" == 100`,
+		`"str" != 100`,
 		// ------------------------ like ------------------------
 		`(VarCharField % 2) like "prefix%"`,
 		`FloatField like "prefix%"`,


### PR DESCRIPTION
fix: #34139 