### PR TITLE
fix: [2.4] init telemetry fails when set otlp as trace exporter

### DIFF
--- a/internal/core/conanfile.py
+++ b/internal/core/conanfile.py
@@ -38,10 +38,11 @@ class MilvusConan(ConanFile):
         "prometheus-cpp/1.1.0",
         "re2/20230301",
         "folly/2023.10.30.08@milvus/dev",
-        "google-cloud-cpp/2.5.0@milvus/dev",
-        "opentelemetry-cpp/1.8.1.1@milvus/dev",
+        "google-cloud-cpp/2.5.0@milvus/2.4#b8dda0943d40adee69d7adc5fafc317d",
+        "opentelemetry-cpp/1.8.3@milvus/2.4#3b8139532791a163c8ff2819c55eb4ac",
         "librdkafka/1.9.1",
         "abseil/20230125.3",
+        "grpc/1.54.3@milvus/dev#5dfb5e1477b22c6d1e6d6b90ab5501d8",
     )
     generators = ("cmake", "cmake_find_package")
     default_options = {
@@ -75,6 +76,7 @@ class MilvusConan(ConanFile):
         "fmt:header_only": True,
         "onetbb:tbbmalloc": False,
         "onetbb:tbbproxy": False,
+        "grpc:shared": True,
     }
 
     def configure(self):

--- a/internal/util/initcore/init_core_test.go
+++ b/internal/util/initcore/init_core_test.go
@@ -41,7 +41,7 @@ func TestOtlpHang(t *testing.T) {
 	defer paramtable.Get().Reset(paramtable.Get().TraceCfg.Exporter.Key)
 	defer paramtable.Get().Reset(paramtable.Get().TraceCfg.InitTimeoutSeconds.Key)
 
-	assert.Panics(t, func() {
+	assert.NotPanics(t, func() {
 		ResetTraceConfig(paramtable.Get())
 	})
 }


### PR DESCRIPTION
issue: #35298
pr: #35301