### PR TITLE
fix: [2.3] Avoid BloomFilter returning false negatives when statslog contains multiple K values in case of delete failing to apply

### DIFF
--- a/internal/storage/pk_statistics.go
+++ b/internal/storage/pk_statistics.go
@@ -208,7 +208,7 @@ func (lc *BatchLocationsCache) Locations(k uint) [][]uint64 {
 		})
 	}
 
-	return lc.locations
+	return lo.Map(lc.locations, func(locations []uint64, _ int) []uint64 { return locations[:k] })
 }
 
 func NewBatchLocationsCache(pks []PrimaryKey) *BatchLocationsCache {


### PR DESCRIPTION
Cherry-pick from master
pr: #35380
Related to #35379