### PR TITLE
enhance: [2.4] Exclude L0 segment from readable snapshot

### DIFF
--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -524,6 +524,7 @@ func (sd *shardDelegator) LoadSegments(ctx context.Context, req *querypb.LoadSeg
 			PartitionID: info.GetPartitionID(),
 			NodeID:      req.GetDstNodeID(),
 			Version:     req.GetVersion(),
+			Level:       info.GetLevel(),
 		}
 	})
 	if req.GetInfos()[0].GetLevel() == datapb.SegmentLevel_L0 {

--- a/internal/querynodev2/delegator/delegator_data_test.go
+++ b/internal/querynodev2/delegator/delegator_data_test.go
@@ -509,6 +509,7 @@ func (s *DelegatorDataSuite) TestLoadSegments() {
 					PartitionID:   500,
 					StartPosition: &msgpb.MsgPosition{Timestamp: 20000},
 					DeltaPosition: &msgpb.MsgPosition{Timestamp: 20000},
+					Level:         datapb.SegmentLevel_L1,
 					InsertChannel: fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", s.collectionID),
 				},
 			},
@@ -524,6 +525,7 @@ func (s *DelegatorDataSuite) TestLoadSegments() {
 				NodeID:        1,
 				PartitionID:   500,
 				TargetVersion: unreadableTargetVersion,
+				Level:         datapb.SegmentLevel_L1,
 			},
 		}, sealed[0].Segments)
 	})
@@ -599,20 +601,21 @@ func (s *DelegatorDataSuite) TestLoadSegments() {
 		})
 		s.NoError(err)
 
-		err = s.delegator.LoadSegments(ctx, &querypb.LoadSegmentsRequest{
-			Base:         commonpbutil.NewMsgBase(),
-			DstNodeID:    1,
-			CollectionID: s.collectionID,
-			Infos: []*querypb.SegmentLoadInfo{
-				{
-					SegmentID:     200,
-					PartitionID:   500,
-					StartPosition: &msgpb.MsgPosition{Timestamp: 20000},
-					DeltaPosition: &msgpb.MsgPosition{Timestamp: 20000},
-					InsertChannel: fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", s.collectionID),
-				},
-			},
-		})
+		// err = s.delegator.LoadSegments(ctx, &querypb.LoadSegmentsRequest{
+		// 	Base:         commonpbutil.NewMsgBase(),
+		// 	DstNodeID:    1,
+		// 	CollectionID: s.collectionID,
+		// 	Infos: []*querypb.SegmentLoadInfo{
+		// 		{
+		// 			SegmentID:     200,
+		// 			PartitionID:   500,
+		// 			StartPosition: &msgpb.MsgPosition{Timestamp: 20000},
+		// 			DeltaPosition: &msgpb.MsgPosition{Timestamp: 20000},
+		// 			Level:         datapb.SegmentLevel_L1,
+		// 			InsertChannel: fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", s.collectionID),
+		// 		},
+		// 	},
+		// })
 
 		s.NoError(err)
 		sealed, _ := s.delegator.GetSegmentInfo(false)
@@ -624,12 +627,14 @@ func (s *DelegatorDataSuite) TestLoadSegments() {
 				NodeID:        1,
 				PartitionID:   500,
 				TargetVersion: unreadableTargetVersion,
+				Level:         datapb.SegmentLevel_L1,
 			},
 			{
 				SegmentID:     200,
 				NodeID:        1,
 				PartitionID:   500,
 				TargetVersion: unreadableTargetVersion,
+				Level:         datapb.SegmentLevel_L0,
 			},
 		}, sealed[0].Segments)
 	})


### PR DESCRIPTION
Cherry-pick from master
pr: #35507

L0 segments now do not contain insert data and may cause confusion for query hook optimizer if counted as sealed segment number.

This PR add segment level flag in segment entry and exclude L0 segments while get readable segment snapshot