### PR TITLE
fix: Match int8_t and int16_t in Array::get_data

### DIFF
--- a/internal/core/src/common/Array.h
+++ b/internal/core/src/common/Array.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -246,6 +247,7 @@ class Array {
             return T(data_ + offsets_[index], element_length);
         }
         if constexpr (std::is_same_v<T, int> || std::is_same_v<T, int64_t> ||
+                      std::is_same_v<T, int8_t> || std::is_same_v<T, int16_t> ||
                       std::is_same_v<T, float> || std::is_same_v<T, double>) {
             switch (element_type_) {
                 case DataType::INT8:


### PR DESCRIPTION
Related to #35578

Previously int16/int8 bitmap index may read int32 array as int16, which may cause build index with half of the data(if array is full) and half zeros. This causes BITMAP index lost information.

This PR matches int8_t & int16_t while `get_data` when building index.