### PR TITLE
fix: [cherry-pick] Fix the reference to a variable after it has been moved

### DIFF
--- a/internal/core/src/common/FieldDataInterface.h
+++ b/internal/core/src/common/FieldDataInterface.h
@@ -124,8 +124,8 @@ class FieldDataImpl : public FieldDataBase {
                            FixedVector<Type>&& field_data)
         : FieldDataBase(type), dim_(is_type_entire_row ? 1 : dim) {
         field_data_ = std::move(field_data);
-        Assert(field_data.size() % dim == 0);
-        num_rows_ = field_data.size() / dim;
+        Assert(field_data_.size() % dim == 0);
+        num_rows_ = field_data_.size() / dim;
     }
 
     void


### PR DESCRIPTION
issue: #35607 

master pr: #35605 