### PR TITLE
fix: fix dynamic update config doesn't works for some param (#35572)

### DIFF
--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -132,19 +132,15 @@ func (m *Manager) CASCachedValue(key string, origin string, value interface{}) b
 func (m *Manager) EvictCachedValue(key string) {
 	m.cacheMutex.Lock()
 	defer m.cacheMutex.Unlock()
-	delete(m.configCache, key)
+	// cause param'value may rely on other params, so we need to evict all the cached value when config is changed
+	clear(m.configCache)
 }
 
 func (m *Manager) EvictCacheValueByFormat(keys ...string) {
 	m.cacheMutex.Lock()
 	defer m.cacheMutex.Unlock()
-
-	set := typeutil.NewSet(keys...)
-	for key := range m.configCache {
-		if set.Contain(formatKey(key)) {
-			delete(m.configCache, key)
-		}
-	}
+	// cause param'value may rely on other params, so we need to evict all the cached value when config is changed
+	clear(m.configCache)
 }
 
 func (m *Manager) GetConfig(key string) (string, error) {

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -630,4 +630,12 @@ func TestCachedParam(t *testing.T) {
 
 	assert.Equal(t, 1*time.Hour, params.DataCoordCfg.GCInterval.GetAsDuration(time.Second))
 	assert.Equal(t, 1*time.Hour, params.DataCoordCfg.GCInterval.GetAsDuration(time.Second))
+
+	params.Save(params.QuotaConfig.DiskQuota.Key, "192")
+	assert.Equal(t, float64(192*1024*1024), params.QuotaConfig.DiskQuota.GetAsFloat())
+	assert.Equal(t, float64(192*1024*1024), params.QuotaConfig.DiskQuotaPerCollection.GetAsFloat())
+	params.Save(params.QuotaConfig.DiskQuota.Key, "256")
+	assert.Equal(t, float64(256*1024*1024), params.QuotaConfig.DiskQuota.GetAsFloat())
+	assert.Equal(t, float64(256*1024*1024), params.QuotaConfig.DiskQuotaPerCollection.GetAsFloat())
+	params.Save(params.QuotaConfig.DiskQuota.Key, "192")
 }


### PR DESCRIPTION
issue: #35570
pr: #35572
milvus support config cache to spped up config access, but only evict param's cache when param has been updated. but milvus's param may rely on other param's value, let's say ParamsA relys on paramsB, when paramsB updated, it will evict paramB's cache, but the paramA's cache still keep the old value.

This PR evict all config cache to solve the above issue, cause dynamic update config won't be much frequetly.