### PR TITLE
fix: [2.4] Re-read value after `once` initialization

### DIFF
--- a/internal/proxy/privilege_cache.go
+++ b/internal/proxy/privilege_cache.go
@@ -41,12 +41,14 @@ func getPriCache() *PrivilegeCache {
 		priCacheInitOnce.Do(func() {
 			priCacheMut.Lock()
 			defer priCacheMut.Unlock()
-			c = &PrivilegeCache{
+			priCache = &PrivilegeCache{
 				version: ver.Inc(),
 				values:  typeutil.ConcurrentMap[string, bool]{},
 			}
-			priCache = c
 		})
+		priCacheMut.RLock()
+		defer priCacheMut.RUnlock()
+		c = priCache
 	}
 
 	return c


### PR DESCRIPTION
Cherry-pick from master
pr: #35642
Related to #35641
See also #35271