### PR TITLE
enhance: support retry search when topk is reduced and result not enough

### DIFF
--- a/internal/proto/internal.proto
+++ b/internal/proto/internal.proto
@@ -126,6 +126,7 @@ message SearchRequest {
   int64 group_by_field_id = 23;
   int64 group_size = 24;
   int64 field_id = 25;
+  bool is_topk_reduce = 26;
 }
 
 message SubSearchResults {
@@ -161,6 +162,7 @@ message SearchResults {
   repeated SubSearchResults sub_results = 15;
   bool is_advanced = 16;
   int64 all_search_count = 17;
+  bool is_topk_reduce = 18;
 }
 
 message CostAggregation {

--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -2912,6 +2912,7 @@ func (node *Proxy) Search(ctx context.Context, request *milvuspb.SearchRequest) 
 				metrics.SearchLabel,
 				request.GetCollectionName(),
 			).Inc()
+			// result size still insufficient
 			if resultSizeInsufficient {
 				metrics.ProxyRetrySearchResultInsufficientCount.WithLabelValues(
 					strconv.FormatInt(paramtable.GetNodeID(), 10),
@@ -3140,13 +3141,14 @@ func (node *Proxy) HybridSearch(ctx context.Context, request *milvuspb.HybridSea
 			rsp, resultSizeInsufficient, isTopkReduce, err = node.hybridSearch(ctx, request, optimizedSearch)
 			metrics.ProxyRetrySearchCount.WithLabelValues(
 				strconv.FormatInt(paramtable.GetNodeID(), 10),
-				metrics.SearchLabel,
+				metrics.HybridSearchLabel,
 				request.GetCollectionName(),
 			).Inc()
+			// result size still insufficient
 			if resultSizeInsufficient {
 				metrics.ProxyRetrySearchResultInsufficientCount.WithLabelValues(
 					strconv.FormatInt(paramtable.GetNodeID(), 10),
-					metrics.SearchLabel,
+					metrics.HybridSearchLabel,
 					request.GetCollectionName(),
 				).Inc()
 			}

--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -2897,9 +2897,21 @@ func (node *Proxy) Search(ctx context.Context, request *milvuspb.SearchRequest) 
 	rsp := &milvuspb.SearchResults{
 		Status: merr.Success(),
 	}
+
+	optimizedSearch := true
+	resultSizeNotMeetLimit := false
 	err2 := retry.Handle(ctx, func() (bool, error) {
-		rsp, err = node.
-			search(ctx, request)
+		rsp, resultSizeNotMeetLimit, err = node.search(ctx, request, optimizedSearch)
+		if merr.Ok(rsp.GetStatus()) && resultSizeNotMeetLimit && optimizedSearch && paramtable.Get().AutoIndexConfig.EnableResultLimitCheck.GetAsBool() {
+			// without optimize search
+			optimizedSearch = false
+			rsp, resultSizeNotMeetLimit, err = node.search(ctx, request, optimizedSearch)
+			metrics.ProxyRetrySearchCount.WithLabelValues(
+				strconv.FormatInt(paramtable.GetNodeID(), 10),
+				metrics.SearchLabel,
+				request.GetCollectionName(),
+			).Inc()
+		}
 		if errors.Is(merr.Error(rsp.GetStatus()), merr.ErrInconsistentRequery) {
 			return true, merr.Error(rsp.GetStatus())
 		}
@@ -2911,7 +2923,7 @@ func (node *Proxy) Search(ctx context.Context, request *milvuspb.SearchRequest) 
 	return rsp, err
 }
 
-func (node *Proxy) search(ctx context.Context, request *milvuspb.SearchRequest) (*milvuspb.SearchResults, error) {
+func (node *Proxy) search(ctx context.Context, request *milvuspb.SearchRequest, optimizedSearch bool) (*milvuspb.SearchResults, bool, error) {
 	metrics.GetStats(ctx).
 		SetNodeID(paramtable.GetNodeID()).
 		SetInboundLabel(metrics.SearchLabel).
@@ -2926,7 +2938,7 @@ func (node *Proxy) search(ctx context.Context, request *milvuspb.SearchRequest) 
 	if err := merr.CheckHealthy(node.GetStateCode()); err != nil {
 		return &milvuspb.SearchResults{
 			Status: merr.Status(err),
-		}, nil
+		}, false, nil
 	}
 
 	method := "Search"
@@ -2947,7 +2959,7 @@ func (node *Proxy) search(ctx context.Context, request *milvuspb.SearchRequest) 
 		if err != nil {
 			return &milvuspb.SearchResults{
 				Status: merr.Status(err),
-			}, nil
+			}, false, nil
 		}
 
 		request.PlaceholderGroup = placeholderGroupBytes
@@ -2961,7 +2973,8 @@ func (node *Proxy) search(ctx context.Context, request *milvuspb.SearchRequest) 
 				commonpbutil.WithMsgType(commonpb.MsgType_Search),
 				commonpbutil.WithSourceID(paramtable.GetNodeID()),
 			),
-			ReqID: paramtable.GetNodeID(),
+			ReqID:        paramtable.GetNodeID(),
+			IsTopkReduce: optimizedSearch,
 		},
 		request:                request,
 		tr:                     timerecord.NewTimeRecorder("search"),
@@ -3015,7 +3028,7 @@ func (node *Proxy) search(ctx context.Context, request *milvuspb.SearchRequest) 
 
 		return &milvuspb.SearchResults{
 			Status: merr.Status(err),
-		}, nil
+		}, false, nil
 	}
 	tr.CtxRecord(ctx, "search request enqueue")
 
@@ -3041,7 +3054,7 @@ func (node *Proxy) search(ctx context.Context, request *milvuspb.SearchRequest) 
 
 		return &milvuspb.SearchResults{
 			Status: merr.Status(err),
-		}, nil
+		}, false, nil
 	}
 
 	span := tr.CtxRecord(ctx, "wait search result")
@@ -3098,7 +3111,7 @@ func (node *Proxy) search(ctx context.Context, request *milvuspb.SearchRequest) 
 			metrics.ProxyReportValue.WithLabelValues(nodeID, hookutil.OpTypeSearch, dbName, username).Add(float64(v))
 		}
 	}
-	return qt.result, nil
+	return qt.result, qt.resultSizeNotMeetLimit, nil
 }
 
 func (node *Proxy) HybridSearch(ctx context.Context, request *milvuspb.HybridSearchRequest) (*milvuspb.SearchResults, error) {
@@ -3106,8 +3119,20 @@ func (node *Proxy) HybridSearch(ctx context.Context, request *milvuspb.HybridSea
 	rsp := &milvuspb.SearchResults{
 		Status: merr.Success(),
 	}
+	optimizedSearch := true
+	resultSizeNotMeetLimit := false
 	err2 := retry.Handle(ctx, func() (bool, error) {
-		rsp, err = node.hybridSearch(ctx, request)
+		rsp, resultSizeNotMeetLimit, err = node.hybridSearch(ctx, request, optimizedSearch)
+		if merr.Ok(rsp.GetStatus()) && resultSizeNotMeetLimit && optimizedSearch && paramtable.Get().AutoIndexConfig.EnableResultLimitCheck.GetAsBool() {
+			// without optimize search
+			optimizedSearch = false
+			rsp, resultSizeNotMeetLimit, err = node.hybridSearch(ctx, request, optimizedSearch)
+			metrics.ProxyRetrySearchCount.WithLabelValues(
+				strconv.FormatInt(paramtable.GetNodeID(), 10),
+				metrics.HybridSearchLabel,
+				request.GetCollectionName(),
+			).Inc()
+		}
 		if errors.Is(merr.Error(rsp.GetStatus()), merr.ErrInconsistentRequery) {
 			return true, merr.Error(rsp.GetStatus())
 		}
@@ -3119,7 +3144,7 @@ func (node *Proxy) HybridSearch(ctx context.Context, request *milvuspb.HybridSea
 	return rsp, err
 }
 
-func (node *Proxy) hybridSearch(ctx context.Context, request *milvuspb.HybridSearchRequest) (*milvuspb.SearchResults, error) {
+func (node *Proxy) hybridSearch(ctx context.Context, request *milvuspb.HybridSearchRequest, optimizedSearch bool) (*milvuspb.SearchResults, bool, error) {
 	metrics.GetStats(ctx).
 		SetNodeID(paramtable.GetNodeID()).
 		SetInboundLabel(metrics.HybridSearchLabel).
@@ -3128,7 +3153,7 @@ func (node *Proxy) hybridSearch(ctx context.Context, request *milvuspb.HybridSea
 	if err := merr.CheckHealthy(node.GetStateCode()); err != nil {
 		return &milvuspb.SearchResults{
 			Status: merr.Status(err),
-		}, nil
+		}, false, nil
 	}
 
 	method := "HybridSearch"
@@ -3152,7 +3177,8 @@ func (node *Proxy) hybridSearch(ctx context.Context, request *milvuspb.HybridSea
 				commonpbutil.WithMsgType(commonpb.MsgType_Search),
 				commonpbutil.WithSourceID(paramtable.GetNodeID()),
 			),
-			ReqID: paramtable.GetNodeID(),
+			ReqID:        paramtable.GetNodeID(),
+			IsTopkReduce: optimizedSearch,
 		},
 		request:             newSearchReq,
 		tr:                  timerecord.NewTimeRecorder(method),
@@ -3201,7 +3227,7 @@ func (node *Proxy) hybridSearch(ctx context.Context, request *milvuspb.HybridSea
 
 		return &milvuspb.SearchResults{
 			Status: merr.Status(err),
-		}, nil
+		}, false, nil
 	}
 	tr.CtxRecord(ctx, "hybrid search request enqueue")
 
@@ -3226,7 +3252,7 @@ func (node *Proxy) hybridSearch(ctx context.Context, request *milvuspb.HybridSea
 
 		return &milvuspb.SearchResults{
 			Status: merr.Status(err),
-		}, nil
+		}, false, nil
 	}
 
 	span := tr.CtxRecord(ctx, "wait hybrid search result")
@@ -3283,7 +3309,7 @@ func (node *Proxy) hybridSearch(ctx context.Context, request *milvuspb.HybridSea
 			metrics.ProxyReportValue.WithLabelValues(nodeID, hookutil.OpTypeHybridSearch, dbName, username).Add(float64(v))
 		}
 	}
-	return qt.result, nil
+	return qt.result, qt.resultSizeNotMeetLimit, nil
 }
 
 func (node *Proxy) getVectorPlaceholderGroupForSearchByPks(ctx context.Context, request *milvuspb.SearchRequest) ([]byte, error) {

--- a/internal/proxy/task_search.go
+++ b/internal/proxy/task_search.go
@@ -62,7 +62,8 @@ type searchTask struct {
 	partitionKeyMode       bool
 	enableMaterializedView bool
 	mustUsePartitionKey    bool
-	resultSizeNotMeetLimit bool
+	resultSizeInsufficient bool
+	isTopkReduce           bool
 
 	userOutputFields  []string
 	userDynamicFields []string
@@ -714,17 +715,15 @@ func (t *searchTask) PostExecute(ctx context.Context) error {
 
 	// reduce done, get final result
 	limit := t.SearchRequest.GetTopk() - t.SearchRequest.GetOffset()
-	resultSizeNotMeetLimit := false
-	// only when topk reduced optimization is on, we will check results size for possible further re-search
-	if isTopkReduce {
-		for _, topk := range t.result.Results.Topks {
-			if topk < limit {
-				resultSizeNotMeetLimit = true
-				break
-			}
+	resultSizeInsufficient := false
+	for _, topk := range t.result.Results.Topks {
+		if topk < limit {
+			resultSizeInsufficient = true
+			break
 		}
 	}
-	t.resultSizeNotMeetLimit = resultSizeNotMeetLimit
+	t.resultSizeInsufficient = resultSizeInsufficient
+	t.isTopkReduce = isTopkReduce
 	t.result.CollectionName = t.collectionName
 	t.fillInFieldInfo()
 

--- a/internal/proxy/task_search_test.go
+++ b/internal/proxy/task_search_test.go
@@ -72,7 +72,9 @@ func TestSearchTask_PostExecute(t *testing.T) {
 		task := &searchTask{
 			ctx:            ctx,
 			collectionName: collName,
-			SearchRequest:  &internalpb.SearchRequest{},
+			SearchRequest: &internalpb.SearchRequest{
+				IsTopkReduce: true,
+			},
 			request: &milvuspb.SearchRequest{
 				CollectionName: collName,
 				Nq:             1,
@@ -98,6 +100,7 @@ func TestSearchTask_PostExecute(t *testing.T) {
 		err := qt.PostExecute(context.TODO())
 		assert.NoError(t, err)
 		assert.Equal(t, qt.result.GetStatus().GetErrorCode(), commonpb.ErrorCode_Success)
+		assert.Equal(t, qt.resultSizeNotMeetLimit, false)
 	})
 }
 

--- a/internal/proxy/task_search_test.go
+++ b/internal/proxy/task_search_test.go
@@ -100,7 +100,8 @@ func TestSearchTask_PostExecute(t *testing.T) {
 		err := qt.PostExecute(context.TODO())
 		assert.NoError(t, err)
 		assert.Equal(t, qt.result.GetStatus().GetErrorCode(), commonpb.ErrorCode_Success)
-		assert.Equal(t, qt.resultSizeNotMeetLimit, false)
+		assert.Equal(t, qt.resultSizeInsufficient, true)
+		assert.Equal(t, qt.isTopkReduce, false)
 	})
 }
 

--- a/internal/querynodev2/delegator/delegator.go
+++ b/internal/querynodev2/delegator/delegator.go
@@ -358,6 +358,7 @@ func (sd *shardDelegator) Search(ctx context.Context, req *querypb.SearchRequest
 				GroupByFieldId:     subReq.GetGroupByFieldId(),
 				GroupSize:          subReq.GetGroupSize(),
 				FieldId:            subReq.GetFieldId(),
+				IsTopkReduce:       req.GetReq().GetIsTopkReduce(),
 			}
 			future := conc.Go(func() (*internalpb.SearchResults, error) {
 				searchReq := &querypb.SearchRequest{

--- a/internal/querynodev2/segments/result.go
+++ b/internal/querynodev2/segments/result.go
@@ -139,51 +139,10 @@ func ReduceAdvancedSearchResults(ctx context.Context, results []*internalpb.Sear
 		IsAdvanced: true,
 	}
 
-	for _, result := range results {
-		relatedDataSize += result.GetCostAggregation().GetTotalRelatedDataSize()
-		for ch, ts := range result.GetChannelsMvcc() {
-			channelsMvcc[ch] = ts
-		}
+	for index, result := range results {
 		if result.GetIsTopkReduce() {
 			isTopkReduce = true
 		}
-		if !result.GetIsAdvanced() {
-			continue
-		}
-		// we just append here, no need to split subResult and reduce
-		// defer this reduce to proxy
-		searchResults.SubResults = append(searchResults.SubResults, result.GetSubResults()...)
-		searchResults.NumQueries = result.GetNumQueries()
-	}
-	searchResults.ChannelsMvcc = channelsMvcc
-	requestCosts := lo.FilterMap(results, func(result *internalpb.SearchResults, _ int) (*internalpb.CostAggregation, bool) {
-		if paramtable.Get().QueryNodeCfg.EnableWorkerSQCostMetrics.GetAsBool() {
-			return result.GetCostAggregation(), true
-		}
-
-		if result.GetBase().GetSourceID() == paramtable.GetNodeID() {
-			return result.GetCostAggregation(), true
-		}
-
-		return nil, false
-	})
-	searchResults.CostAggregation = mergeRequestCost(requestCosts)
-	if searchResults.CostAggregation == nil {
-		searchResults.CostAggregation = &internalpb.CostAggregation{}
-	}
-	searchResults.CostAggregation.TotalRelatedDataSize = relatedDataSize
-	searchResults.IsTopkReduce = isTopkReduce
-	return searchResults, nil
-}
-
-func MergeToAdvancedResults(ctx context.Context, results []*internalpb.SearchResults) (*internalpb.SearchResults, error) {
-	searchResults := &internalpb.SearchResults{
-		IsAdvanced: true,
-	}
-
-	channelsMvcc := make(map[string]uint64)
-	relatedDataSize := int64(0)
-	for index, result := range results {
 		relatedDataSize += result.GetCostAggregation().GetTotalRelatedDataSize()
 		for ch, ts := range result.GetChannelsMvcc() {
 			channelsMvcc[ch] = ts
@@ -219,6 +178,7 @@ func MergeToAdvancedResults(ctx context.Context, results []*internalpb.SearchRes
 		searchResults.CostAggregation = &internalpb.CostAggregation{}
 	}
 	searchResults.CostAggregation.TotalRelatedDataSize = relatedDataSize
+	searchResults.IsTopkReduce = isTopkReduce
 	return searchResults, nil
 }
 

--- a/internal/querynodev2/services.go
+++ b/internal/querynodev2/services.go
@@ -720,6 +720,9 @@ func (node *QueryNode) SearchSegments(ctx context.Context, req *querypb.SearchRe
 	resp = task.SearchResult()
 	resp.GetCostAggregation().ResponseTime = tr.ElapseSpan().Milliseconds()
 	resp.GetCostAggregation().TotalNQ = node.scheduler.GetWaitingTaskTotalNQ()
+	if req.GetReq().GetIsTopkReduce() {
+		resp.IsTopkReduce = true
+	}
 	return resp, nil
 }
 

--- a/pkg/metrics/proxy_metrics.go
+++ b/pkg/metrics/proxy_metrics.go
@@ -389,6 +389,14 @@ var (
 			Name:      "max_insert_rate",
 			Help:      "max insert rate",
 		}, []string{"node_id", "scope"})
+
+	ProxyRetrySearchCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.ProxyRole,
+			Name:      "retry_search_cnt",
+			Help:      "counter of retry search",
+		}, []string{nodeIDLabelName, queryTypeLabelName, collectionName})
 )
 
 // RegisterProxy registers Proxy metrics
@@ -447,6 +455,7 @@ func RegisterProxy(registry *prometheus.Registry) {
 	registry.MustRegister(ProxyReqInQueueLatency)
 
 	registry.MustRegister(MaxInsertRate)
+	registry.MustRegister(ProxyRetrySearchCount)
 
 	RegisterStreamingServiceClient(registry)
 }
@@ -551,5 +560,10 @@ func CleanupProxyCollectionMetrics(nodeID int64, collection string) {
 	ProxyReceiveBytes.Delete(prometheus.Labels{
 		nodeIDLabelName:  strconv.FormatInt(nodeID, 10),
 		msgTypeLabelName: UpsertLabel, collectionName: collection,
+	})
+	ProxyRetrySearchCount.Delete(prometheus.Labels{
+		nodeIDLabelName:    strconv.FormatInt(nodeID, 10),
+		queryTypeLabelName: QueryLabel,
+		collectionName:     collection,
 	})
 }

--- a/pkg/metrics/proxy_metrics.go
+++ b/pkg/metrics/proxy_metrics.go
@@ -390,12 +390,23 @@ var (
 			Help:      "max insert rate",
 		}, []string{"node_id", "scope"})
 
+	// ProxyRetrySearchCount records the retry search count when result count does not meet limit and topk reduce is on
 	ProxyRetrySearchCount = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: milvusNamespace,
 			Subsystem: typeutil.ProxyRole,
 			Name:      "retry_search_cnt",
 			Help:      "counter of retry search",
+		}, []string{nodeIDLabelName, queryTypeLabelName, collectionName})
+
+	// ProxyRetrySearchResultInsufficientCount records the retry search without reducing topk that still not meet result limit
+	// there are more likely some non-index-related reasons like we do not have enough entities for very big k, duplicate pks, etc
+	ProxyRetrySearchResultInsufficientCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.ProxyRole,
+			Name:      "retry_search_result_insufficient_cnt",
+			Help:      "counter of retry search which does not have enough results",
 		}, []string{nodeIDLabelName, queryTypeLabelName, collectionName})
 )
 
@@ -456,7 +467,8 @@ func RegisterProxy(registry *prometheus.Registry) {
 
 	registry.MustRegister(MaxInsertRate)
 	registry.MustRegister(ProxyRetrySearchCount)
-
+	registry.MustRegister(ProxyRetrySearchResultInsufficientCount)
+	
 	RegisterStreamingServiceClient(registry)
 }
 
@@ -563,7 +575,22 @@ func CleanupProxyCollectionMetrics(nodeID int64, collection string) {
 	})
 	ProxyRetrySearchCount.Delete(prometheus.Labels{
 		nodeIDLabelName:    strconv.FormatInt(nodeID, 10),
-		queryTypeLabelName: QueryLabel,
+		queryTypeLabelName: SearchLabel,
+		collectionName:     collection,
+	})
+	ProxyRetrySearchCount.Delete(prometheus.Labels{
+		nodeIDLabelName:    strconv.FormatInt(nodeID, 10),
+		queryTypeLabelName: HybridSearchLabel,
+		collectionName:     collection,
+	})
+	ProxyRetrySearchResultInsufficientCount.Delete(prometheus.Labels{
+		nodeIDLabelName:    strconv.FormatInt(nodeID, 10),
+		queryTypeLabelName: SearchLabel,
+		collectionName:     collection,
+	})
+	ProxyRetrySearchResultInsufficientCount.Delete(prometheus.Labels{
+		nodeIDLabelName:    strconv.FormatInt(nodeID, 10),
+		queryTypeLabelName: HybridSearchLabel,
 		collectionName:     collection,
 	})
 }

--- a/pkg/metrics/proxy_metrics.go
+++ b/pkg/metrics/proxy_metrics.go
@@ -468,7 +468,7 @@ func RegisterProxy(registry *prometheus.Registry) {
 	registry.MustRegister(MaxInsertRate)
 	registry.MustRegister(ProxyRetrySearchCount)
 	registry.MustRegister(ProxyRetrySearchResultInsufficientCount)
-	
+
 	RegisterStreamingServiceClient(registry)
 }
 

--- a/pkg/util/paramtable/autoindex_param.go
+++ b/pkg/util/paramtable/autoindex_param.go
@@ -30,8 +30,9 @@ import (
 // /////////////////////////////////////////////////////////////////////////////
 // --- common ---
 type autoIndexConfig struct {
-	Enable         ParamItem `refreshable:"true"`
-	EnableOptimize ParamItem `refreshable:"true"`
+	Enable                 ParamItem `refreshable:"true"`
+	EnableOptimize         ParamItem `refreshable:"true"`
+	EnableResultLimitCheck ParamItem `refreshable:"true"`
 
 	IndexParams           ParamItem  `refreshable:"true"`
 	SparseIndexParams     ParamItem  `refreshable:"true"`
@@ -75,6 +76,14 @@ func (p *autoIndexConfig) init(base *BaseTable) {
 		PanicIfEmpty: true,
 	}
 	p.EnableOptimize.Init(base.mgr)
+
+	p.EnableResultLimitCheck = ParamItem{
+		Key:          "autoIndex.resultLimitCheck",
+		Version:      "2.5.0",
+		DefaultValue: "true",
+		PanicIfEmpty: true,
+	}
+	p.EnableResultLimitCheck.Init(base.mgr)
 
 	p.IndexParams = ParamItem{
 		Key:          "autoIndex.params.build",


### PR DESCRIPTION
issue: #35576 

This pr is to cover those cases when queryHook optimize search params and make the result size insufficient, add retry search mechanism and add related metrics for alarming. 