### PR TITLE
enhance: Add back BF lazy load logic for datanode watch channel

### DIFF
--- a/internal/datanode/compaction/l0_compactor.go
+++ b/internal/datanode/compaction/l0_compactor.go
@@ -30,7 +30,7 @@ import (
 
 	"github.com/milvus-io/milvus/internal/allocator"
 	"github.com/milvus-io/milvus/internal/flushcommon/io"
-	"github.com/milvus-io/milvus/internal/flushcommon/metacache"
+	"github.com/milvus-io/milvus/internal/flushcommon/metacache/pkoracle"
 	"github.com/milvus-io/milvus/internal/metastore/kv/binlog"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
 	"github.com/milvus-io/milvus/internal/storage"
@@ -240,7 +240,7 @@ func (t *LevelZeroCompactionTask) serializeUpload(ctx context.Context, segmentWr
 func (t *LevelZeroCompactionTask) splitDelta(
 	ctx context.Context,
 	allDelta *storage.DeleteData,
-	segmentBfs map[int64]*metacache.BloomFilterSet,
+	segmentBfs map[int64]*pkoracle.BloomFilterSet,
 ) map[int64]*SegmentDeltaWriter {
 	traceCtx, span := otel.Tracer(typeutil.DataNodeRole).Start(ctx, "L0Compact splitDelta")
 	defer span.End()
@@ -281,7 +281,7 @@ type BatchApplyRet = struct {
 	Segment2Hits map[int64][]bool
 }
 
-func (t *LevelZeroCompactionTask) applyBFInParallel(ctx context.Context, deltaData *storage.DeleteData, pool *conc.Pool[any], segmentBfs map[int64]*metacache.BloomFilterSet) *typeutil.ConcurrentMap[int, *BatchApplyRet] {
+func (t *LevelZeroCompactionTask) applyBFInParallel(ctx context.Context, deltaData *storage.DeleteData, pool *conc.Pool[any], segmentBfs map[int64]*pkoracle.BloomFilterSet) *typeutil.ConcurrentMap[int, *BatchApplyRet] {
 	_, span := otel.Tracer(typeutil.DataNodeRole).Start(ctx, "L0Compact applyBFInParallel")
 	defer span.End()
 	batchSize := paramtable.Get().CommonCfg.BloomFilterApplyBatchSize.GetAsInt()
@@ -418,7 +418,7 @@ func (t *LevelZeroCompactionTask) loadDelta(ctx context.Context, deltaLogs []str
 	return dData, nil
 }
 
-func (t *LevelZeroCompactionTask) loadBF(ctx context.Context, targetSegments []*datapb.CompactionSegmentBinlogs) (map[int64]*metacache.BloomFilterSet, error) {
+func (t *LevelZeroCompactionTask) loadBF(ctx context.Context, targetSegments []*datapb.CompactionSegmentBinlogs) (map[int64]*pkoracle.BloomFilterSet, error) {
 	_, span := otel.Tracer(typeutil.DataNodeRole).Start(ctx, "L0Compact loadBF")
 	defer span.End()
 
@@ -427,7 +427,7 @@ func (t *LevelZeroCompactionTask) loadBF(ctx context.Context, targetSegments []*
 		pool    = io.GetOrCreateStatsPool()
 
 		mu  = &sync.Mutex{}
-		bfs = make(map[int64]*metacache.BloomFilterSet)
+		bfs = make(map[int64]*pkoracle.BloomFilterSet)
 	)
 
 	for _, segment := range targetSegments {
@@ -445,7 +445,7 @@ func (t *LevelZeroCompactionTask) loadBF(ctx context.Context, targetSegments []*
 					zap.Error(err))
 				return err, err
 			}
-			bf := metacache.NewBloomFilterSet(pks...)
+			bf := pkoracle.NewBloomFilterSet(pks...)
 			mu.Lock()
 			defer mu.Unlock()
 			bfs[segment.GetSegmentID()] = bf

--- a/internal/datanode/compaction/l0_compactor_test.go
+++ b/internal/datanode/compaction/l0_compactor_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/datanode/allocator"
 	"github.com/milvus-io/milvus/internal/flushcommon/io"
-	"github.com/milvus-io/milvus/internal/flushcommon/metacache"
+	"github.com/milvus-io/milvus/internal/flushcommon/metacache/pkoracle"
 	"github.com/milvus-io/milvus/internal/mocks"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
 	"github.com/milvus-io/milvus/internal/storage"
@@ -494,15 +494,15 @@ func (s *LevelZeroCompactionTaskSuite) TestSerializeUpload() {
 }
 
 func (s *LevelZeroCompactionTaskSuite) TestSplitDelta() {
-	bfs1 := metacache.NewBloomFilterSetWithBatchSize(100)
+	bfs1 := pkoracle.NewBloomFilterSetWithBatchSize(100)
 	bfs1.UpdatePKRange(&storage.Int64FieldData{Data: []int64{1, 3}})
-	bfs2 := metacache.NewBloomFilterSetWithBatchSize(100)
+	bfs2 := pkoracle.NewBloomFilterSetWithBatchSize(100)
 	bfs2.UpdatePKRange(&storage.Int64FieldData{Data: []int64{3}})
-	bfs3 := metacache.NewBloomFilterSetWithBatchSize(100)
+	bfs3 := pkoracle.NewBloomFilterSetWithBatchSize(100)
 	bfs3.UpdatePKRange(&storage.Int64FieldData{Data: []int64{3}})
 
 	predicted := []int64{100, 101, 102}
-	segmentBFs := map[int64]*metacache.BloomFilterSet{
+	segmentBFs := map[int64]*pkoracle.BloomFilterSet{
 		100: bfs1,
 		101: bfs2,
 		102: bfs3,

--- a/internal/datanode/compaction/mix_compactor_test.go
+++ b/internal/datanode/compaction/mix_compactor_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/milvus-io/milvus/internal/allocator"
 	"github.com/milvus-io/milvus/internal/flushcommon/io"
 	"github.com/milvus-io/milvus/internal/flushcommon/metacache"
+	"github.com/milvus-io/milvus/internal/flushcommon/metacache/pkoracle"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
 	"github.com/milvus-io/milvus/internal/proto/etcdpb"
 	"github.com/milvus-io/milvus/internal/storage"
@@ -214,7 +215,7 @@ func (s *MixCompactionTaskSuite) TestCompactTwoToOne() {
 		PartitionID:  PartitionID,
 		ID:           99999,
 		NumOfRows:    0,
-	}, metacache.NewBloomFilterSet())
+	}, pkoracle.NewBloomFilterSet())
 
 	s.plan.SegmentBinlogs = append(s.plan.SegmentBinlogs, &datapb.CompactionSegmentBinlogs{
 		SegmentID: seg.SegmentID(),

--- a/internal/datanode/importv2/util.go
+++ b/internal/datanode/importv2/util.go
@@ -30,6 +30,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/allocator"
 	"github.com/milvus-io/milvus/internal/flushcommon/metacache"
+	"github.com/milvus-io/milvus/internal/flushcommon/metacache/pkoracle"
 	"github.com/milvus-io/milvus/internal/flushcommon/syncmgr"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
 	"github.com/milvus-io/milvus/internal/storage"
@@ -59,8 +60,8 @@ func NewSyncTask(ctx context.Context,
 			CollectionID:  collectionID,
 			PartitionID:   partitionID,
 			InsertChannel: vchannel,
-		}, func(info *datapb.SegmentInfo) *metacache.BloomFilterSet {
-			bfs := metacache.NewBloomFilterSet()
+		}, func(info *datapb.SegmentInfo) pkoracle.PkStat {
+			bfs := pkoracle.NewBloomFilterSet()
 			return bfs
 		})
 	}
@@ -240,8 +241,8 @@ func NewMetaCache(req *datapb.ImportRequest) map[string]metacache.MetaCache {
 			},
 			Schema: schema,
 		}
-		metaCache := metacache.NewMetaCache(info, func(segment *datapb.SegmentInfo) *metacache.BloomFilterSet {
-			return metacache.NewBloomFilterSet()
+		metaCache := metacache.NewMetaCache(info, func(segment *datapb.SegmentInfo) pkoracle.PkStat {
+			return pkoracle.NewBloomFilterSet()
 		})
 		metaCaches[channel] = metaCache
 	}

--- a/internal/datanode/services_test.go
+++ b/internal/datanode/services_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/milvus-io/milvus/internal/datanode/compaction"
 	"github.com/milvus-io/milvus/internal/flushcommon/broker"
 	"github.com/milvus-io/milvus/internal/flushcommon/metacache"
+	"github.com/milvus-io/milvus/internal/flushcommon/metacache/pkoracle"
 	"github.com/milvus-io/milvus/internal/flushcommon/pipeline"
 	"github.com/milvus-io/milvus/internal/flushcommon/util"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
@@ -372,7 +373,7 @@ func (s *DataNodeServicesSuite) TestFlushSegments() {
 		PartitionID:   2,
 		State:         commonpb.SegmentState_Growing,
 		StartPosition: &msgpb.MsgPosition{},
-	}, func(_ *datapb.SegmentInfo) *metacache.BloomFilterSet { return metacache.NewBloomFilterSet() })
+	}, func(_ *datapb.SegmentInfo) pkoracle.PkStat { return pkoracle.NewBloomFilterSet() })
 
 	s.Run("service_not_ready", func() {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -634,8 +635,8 @@ func (s *DataNodeServicesSuite) TestSyncSegments() {
 				},
 			},
 			Vchan: &datapb.VchannelInfo{},
-		}, func(*datapb.SegmentInfo) *metacache.BloomFilterSet {
-			return metacache.NewBloomFilterSet()
+		}, func(*datapb.SegmentInfo) pkoracle.PkStat {
+			return pkoracle.NewBloomFilterSet()
 		})
 		cache.AddSegment(&datapb.SegmentInfo{
 			ID:            100,
@@ -645,8 +646,8 @@ func (s *DataNodeServicesSuite) TestSyncSegments() {
 			NumOfRows:     0,
 			State:         commonpb.SegmentState_Growing,
 			Level:         datapb.SegmentLevel_L0,
-		}, func(*datapb.SegmentInfo) *metacache.BloomFilterSet {
-			return metacache.NewBloomFilterSet()
+		}, func(*datapb.SegmentInfo) pkoracle.PkStat {
+			return pkoracle.NewBloomFilterSet()
 		})
 		cache.AddSegment(&datapb.SegmentInfo{
 			ID:            101,
@@ -656,8 +657,8 @@ func (s *DataNodeServicesSuite) TestSyncSegments() {
 			NumOfRows:     0,
 			State:         commonpb.SegmentState_Flushed,
 			Level:         datapb.SegmentLevel_L1,
-		}, func(*datapb.SegmentInfo) *metacache.BloomFilterSet {
-			return metacache.NewBloomFilterSet()
+		}, func(*datapb.SegmentInfo) pkoracle.PkStat {
+			return pkoracle.NewBloomFilterSet()
 		})
 		cache.AddSegment(&datapb.SegmentInfo{
 			ID:            102,
@@ -667,8 +668,8 @@ func (s *DataNodeServicesSuite) TestSyncSegments() {
 			NumOfRows:     0,
 			State:         commonpb.SegmentState_Flushed,
 			Level:         datapb.SegmentLevel_L0,
-		}, func(*datapb.SegmentInfo) *metacache.BloomFilterSet {
-			return metacache.NewBloomFilterSet()
+		}, func(*datapb.SegmentInfo) pkoracle.PkStat {
+			return pkoracle.NewBloomFilterSet()
 		})
 		cache.AddSegment(&datapb.SegmentInfo{
 			ID:            103,
@@ -678,8 +679,8 @@ func (s *DataNodeServicesSuite) TestSyncSegments() {
 			NumOfRows:     0,
 			State:         commonpb.SegmentState_Flushed,
 			Level:         datapb.SegmentLevel_L0,
-		}, func(*datapb.SegmentInfo) *metacache.BloomFilterSet {
-			return metacache.NewBloomFilterSet()
+		}, func(*datapb.SegmentInfo) pkoracle.PkStat {
+			return pkoracle.NewBloomFilterSet()
 		})
 		mockFlowgraphManager := pipeline.NewMockFlowgraphManager(s.T())
 		mockFlowgraphManager.EXPECT().GetFlowgraphService(mock.Anything).
@@ -754,8 +755,8 @@ func (s *DataNodeServicesSuite) TestSyncSegments() {
 				},
 			},
 			Vchan: &datapb.VchannelInfo{},
-		}, func(*datapb.SegmentInfo) *metacache.BloomFilterSet {
-			return metacache.NewBloomFilterSet()
+		}, func(*datapb.SegmentInfo) pkoracle.PkStat {
+			return pkoracle.NewBloomFilterSet()
 		})
 		cache.AddSegment(&datapb.SegmentInfo{
 			ID:            100,
@@ -765,8 +766,8 @@ func (s *DataNodeServicesSuite) TestSyncSegments() {
 			NumOfRows:     0,
 			State:         commonpb.SegmentState_Flushed,
 			Level:         datapb.SegmentLevel_L1,
-		}, func(*datapb.SegmentInfo) *metacache.BloomFilterSet {
-			return metacache.NewBloomFilterSet()
+		}, func(*datapb.SegmentInfo) pkoracle.PkStat {
+			return pkoracle.NewBloomFilterSet()
 		})
 		cache.AddSegment(&datapb.SegmentInfo{
 			ID:            101,
@@ -776,8 +777,8 @@ func (s *DataNodeServicesSuite) TestSyncSegments() {
 			NumOfRows:     0,
 			State:         commonpb.SegmentState_Flushed,
 			Level:         datapb.SegmentLevel_L1,
-		}, func(*datapb.SegmentInfo) *metacache.BloomFilterSet {
-			return metacache.NewBloomFilterSet()
+		}, func(*datapb.SegmentInfo) pkoracle.PkStat {
+			return pkoracle.NewBloomFilterSet()
 		})
 		mockFlowgraphManager := pipeline.NewMockFlowgraphManager(s.T())
 		mockFlowgraphManager.EXPECT().GetFlowgraphService(mock.Anything).
@@ -840,8 +841,8 @@ func (s *DataNodeServicesSuite) TestSyncSegments() {
 				},
 			},
 			Vchan: &datapb.VchannelInfo{},
-		}, func(*datapb.SegmentInfo) *metacache.BloomFilterSet {
-			return metacache.NewBloomFilterSet()
+		}, func(*datapb.SegmentInfo) pkoracle.PkStat {
+			return pkoracle.NewBloomFilterSet()
 		})
 		cache.AddSegment(&datapb.SegmentInfo{
 			ID:            100,
@@ -851,8 +852,8 @@ func (s *DataNodeServicesSuite) TestSyncSegments() {
 			NumOfRows:     0,
 			State:         commonpb.SegmentState_Growing,
 			Level:         datapb.SegmentLevel_L1,
-		}, func(*datapb.SegmentInfo) *metacache.BloomFilterSet {
-			return metacache.NewBloomFilterSet()
+		}, func(*datapb.SegmentInfo) pkoracle.PkStat {
+			return pkoracle.NewBloomFilterSet()
 		})
 		cache.AddSegment(&datapb.SegmentInfo{
 			ID:            101,
@@ -862,8 +863,8 @@ func (s *DataNodeServicesSuite) TestSyncSegments() {
 			NumOfRows:     0,
 			State:         commonpb.SegmentState_Flushing,
 			Level:         datapb.SegmentLevel_L1,
-		}, func(*datapb.SegmentInfo) *metacache.BloomFilterSet {
-			return metacache.NewBloomFilterSet()
+		}, func(*datapb.SegmentInfo) pkoracle.PkStat {
+			return pkoracle.NewBloomFilterSet()
 		})
 		mockFlowgraphManager := pipeline.NewMockFlowgraphManager(s.T())
 		mockFlowgraphManager.EXPECT().GetFlowgraphService(mock.Anything).
@@ -926,8 +927,8 @@ func (s *DataNodeServicesSuite) TestSyncSegments() {
 				},
 			},
 			Vchan: &datapb.VchannelInfo{},
-		}, func(*datapb.SegmentInfo) *metacache.BloomFilterSet {
-			return metacache.NewBloomFilterSet()
+		}, func(*datapb.SegmentInfo) pkoracle.PkStat {
+			return pkoracle.NewBloomFilterSet()
 		})
 		cache.AddSegment(&datapb.SegmentInfo{
 			ID:            100,
@@ -937,8 +938,8 @@ func (s *DataNodeServicesSuite) TestSyncSegments() {
 			NumOfRows:     0,
 			State:         commonpb.SegmentState_Growing,
 			Level:         datapb.SegmentLevel_L1,
-		}, func(*datapb.SegmentInfo) *metacache.BloomFilterSet {
-			return metacache.NewBloomFilterSet()
+		}, func(*datapb.SegmentInfo) pkoracle.PkStat {
+			return pkoracle.NewBloomFilterSet()
 		})
 		cache.AddSegment(&datapb.SegmentInfo{
 			ID:            101,
@@ -948,8 +949,8 @@ func (s *DataNodeServicesSuite) TestSyncSegments() {
 			NumOfRows:     0,
 			State:         commonpb.SegmentState_Flushing,
 			Level:         datapb.SegmentLevel_L1,
-		}, func(*datapb.SegmentInfo) *metacache.BloomFilterSet {
-			return metacache.NewBloomFilterSet()
+		}, func(*datapb.SegmentInfo) pkoracle.PkStat {
+			return pkoracle.NewBloomFilterSet()
 		})
 		cache.AddSegment(&datapb.SegmentInfo{
 			ID:            102,
@@ -959,8 +960,8 @@ func (s *DataNodeServicesSuite) TestSyncSegments() {
 			NumOfRows:     0,
 			State:         commonpb.SegmentState_Flushed,
 			Level:         datapb.SegmentLevel_L1,
-		}, func(*datapb.SegmentInfo) *metacache.BloomFilterSet {
-			return metacache.NewBloomFilterSet()
+		}, func(*datapb.SegmentInfo) pkoracle.PkStat {
+			return pkoracle.NewBloomFilterSet()
 		})
 		mockFlowgraphManager := pipeline.NewMockFlowgraphManager(s.T())
 		mockFlowgraphManager.EXPECT().GetFlowgraphService(mock.Anything).
@@ -1017,8 +1018,8 @@ func (s *DataNodeServicesSuite) TestSyncSegments() {
 				},
 			},
 			Vchan: &datapb.VchannelInfo{},
-		}, func(*datapb.SegmentInfo) *metacache.BloomFilterSet {
-			return metacache.NewBloomFilterSet()
+		}, func(*datapb.SegmentInfo) pkoracle.PkStat {
+			return pkoracle.NewBloomFilterSet()
 		})
 		cache.AddSegment(&datapb.SegmentInfo{
 			ID:            100,
@@ -1028,8 +1029,8 @@ func (s *DataNodeServicesSuite) TestSyncSegments() {
 			NumOfRows:     0,
 			State:         commonpb.SegmentState_Flushed,
 			Level:         datapb.SegmentLevel_L0,
-		}, func(*datapb.SegmentInfo) *metacache.BloomFilterSet {
-			return metacache.NewBloomFilterSet()
+		}, func(*datapb.SegmentInfo) pkoracle.PkStat {
+			return pkoracle.NewBloomFilterSet()
 		})
 		cache.AddSegment(&datapb.SegmentInfo{
 			ID:            101,
@@ -1039,8 +1040,8 @@ func (s *DataNodeServicesSuite) TestSyncSegments() {
 			NumOfRows:     0,
 			State:         commonpb.SegmentState_Flushing,
 			Level:         datapb.SegmentLevel_L1,
-		}, func(*datapb.SegmentInfo) *metacache.BloomFilterSet {
-			return metacache.NewBloomFilterSet()
+		}, func(*datapb.SegmentInfo) pkoracle.PkStat {
+			return pkoracle.NewBloomFilterSet()
 		})
 		mockFlowgraphManager := pipeline.NewMockFlowgraphManager(s.T())
 		mockFlowgraphManager.EXPECT().GetFlowgraphService(mock.Anything).
@@ -1097,8 +1098,8 @@ func (s *DataNodeServicesSuite) TestSyncSegments() {
 				},
 			},
 			Vchan: &datapb.VchannelInfo{},
-		}, func(*datapb.SegmentInfo) *metacache.BloomFilterSet {
-			return metacache.NewBloomFilterSet()
+		}, func(*datapb.SegmentInfo) pkoracle.PkStat {
+			return pkoracle.NewBloomFilterSet()
 		})
 		mockFlowgraphManager := pipeline.NewMockFlowgraphManager(s.T())
 		mockFlowgraphManager.EXPECT().GetFlowgraphService(mock.Anything).

--- a/internal/flushcommon/metacache/meta_cache.go
+++ b/internal/flushcommon/metacache/meta_cache.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/flushcommon/metacache/pkoracle"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/pkg/log"
@@ -52,12 +53,12 @@ type MetaCache interface {
 	// DetectMissingSegments returns the segment ids which is missing in datanode.
 	DetectMissingSegments(segments map[int64]struct{}) []int64
 	// UpdateSegmentView updates the segments BF from datacoord view.
-	UpdateSegmentView(partitionID int64, newSegments []*datapb.SyncSegmentInfo, newSegmentsBF []*BloomFilterSet, allSegments map[int64]struct{})
+	UpdateSegmentView(partitionID int64, newSegments []*datapb.SyncSegmentInfo, newSegmentsBF []*pkoracle.BloomFilterSet, allSegments map[int64]struct{})
 }
 
 var _ MetaCache = (*metaCacheImpl)(nil)
 
-type PkStatsFactory func(vchannel *datapb.SegmentInfo) *BloomFilterSet
+type PkStatsFactory func(vchannel *datapb.SegmentInfo) pkoracle.PkStat
 
 type metaCacheImpl struct {
 	collectionID int64
@@ -266,7 +267,7 @@ func (c *metaCacheImpl) DetectMissingSegments(segments map[int64]struct{}) []int
 
 func (c *metaCacheImpl) UpdateSegmentView(partitionID int64,
 	newSegments []*datapb.SyncSegmentInfo,
-	newSegmentsBF []*BloomFilterSet,
+	newSegmentsBF []*pkoracle.BloomFilterSet,
 	allSegments map[int64]struct{},
 ) {
 	c.mu.Lock()

--- a/internal/flushcommon/metacache/meta_cache_test.go
+++ b/internal/flushcommon/metacache/meta_cache_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/flushcommon/metacache/pkoracle"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/pkg/common"
@@ -56,8 +57,8 @@ func (s *MetaCacheSuite) SetupSuite() {
 	s.growingSegments = []int64{5, 6, 7, 8}
 	s.newSegments = []int64{9, 10, 11, 12}
 	s.invaliedSeg = 111
-	s.bfsFactory = func(*datapb.SegmentInfo) *BloomFilterSet {
-		return NewBloomFilterSet()
+	s.bfsFactory = func(*datapb.SegmentInfo) pkoracle.PkStat {
+		return pkoracle.NewBloomFilterSet()
 	}
 	s.collSchema = &schemapb.CollectionSchema{
 		Name: "test_collection",
@@ -110,8 +111,8 @@ func (s *MetaCacheSuite) TestAddSegment() {
 			ID:          segID,
 			PartitionID: 10,
 		}
-		s.cache.AddSegment(info, func(info *datapb.SegmentInfo) *BloomFilterSet {
-			return NewBloomFilterSet()
+		s.cache.AddSegment(info, func(info *datapb.SegmentInfo) pkoracle.PkStat {
+			return pkoracle.NewBloomFilterSet()
 		}, UpdateState(commonpb.SegmentState_Flushed))
 	}
 
@@ -208,8 +209,8 @@ func (s *MetaCacheSuite) Test_UpdateSegmentView() {
 			NumOfRows:  10240,
 		},
 	}
-	addSegmentsBF := []*BloomFilterSet{
-		NewBloomFilterSet(),
+	addSegmentsBF := []*pkoracle.BloomFilterSet{
+		pkoracle.NewBloomFilterSet(),
 	}
 	segments := map[int64]struct{}{
 		1: {}, 2: {}, 3: {}, 4: {}, 5: {}, 6: {}, 7: {}, 8: {}, 100: {},
@@ -259,8 +260,8 @@ func BenchmarkGetSegmentsBy(b *testing.B) {
 		Vchan: &datapb.VchannelInfo{
 			FlushedSegments: flushSegmentInfos,
 		},
-	}, func(*datapb.SegmentInfo) *BloomFilterSet {
-		return NewBloomFilterSet()
+	}, func(*datapb.SegmentInfo) pkoracle.PkStat {
+		return pkoracle.NewBloomFilterSet()
 	})
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -291,8 +292,8 @@ func BenchmarkGetSegmentsByWithoutIDs(b *testing.B) {
 		Vchan: &datapb.VchannelInfo{
 			FlushedSegments: flushSegmentInfos,
 		},
-	}, func(*datapb.SegmentInfo) *BloomFilterSet {
-		return NewBloomFilterSet()
+	}, func(*datapb.SegmentInfo) pkoracle.PkStat {
+		return pkoracle.NewBloomFilterSet()
 	})
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/internal/flushcommon/metacache/mock_meta_cache.go
+++ b/internal/flushcommon/metacache/mock_meta_cache.go
@@ -6,6 +6,8 @@ import (
 	datapb "github.com/milvus-io/milvus/internal/proto/datapb"
 	mock "github.com/stretchr/testify/mock"
 
+	pkoracle "github.com/milvus-io/milvus/internal/flushcommon/metacache/pkoracle"
+
 	schemapb "github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 
 	storage "github.com/milvus-io/milvus/internal/storage"
@@ -511,7 +513,7 @@ func (_c *MockMetaCache_Schema_Call) RunAndReturn(run func() *schemapb.Collectio
 }
 
 // UpdateSegmentView provides a mock function with given fields: partitionID, newSegments, newSegmentsBF, allSegments
-func (_m *MockMetaCache) UpdateSegmentView(partitionID int64, newSegments []*datapb.SyncSegmentInfo, newSegmentsBF []*BloomFilterSet, allSegments map[int64]struct{}) {
+func (_m *MockMetaCache) UpdateSegmentView(partitionID int64, newSegments []*datapb.SyncSegmentInfo, newSegmentsBF []*pkoracle.BloomFilterSet, allSegments map[int64]struct{}) {
 	_m.Called(partitionID, newSegments, newSegmentsBF, allSegments)
 }
 
@@ -523,15 +525,15 @@ type MockMetaCache_UpdateSegmentView_Call struct {
 // UpdateSegmentView is a helper method to define mock.On call
 //   - partitionID int64
 //   - newSegments []*datapb.SyncSegmentInfo
-//   - newSegmentsBF []*BloomFilterSet
+//   - newSegmentsBF []*pkoracle.BloomFilterSet
 //   - allSegments map[int64]struct{}
 func (_e *MockMetaCache_Expecter) UpdateSegmentView(partitionID interface{}, newSegments interface{}, newSegmentsBF interface{}, allSegments interface{}) *MockMetaCache_UpdateSegmentView_Call {
 	return &MockMetaCache_UpdateSegmentView_Call{Call: _e.mock.On("UpdateSegmentView", partitionID, newSegments, newSegmentsBF, allSegments)}
 }
 
-func (_c *MockMetaCache_UpdateSegmentView_Call) Run(run func(partitionID int64, newSegments []*datapb.SyncSegmentInfo, newSegmentsBF []*BloomFilterSet, allSegments map[int64]struct{})) *MockMetaCache_UpdateSegmentView_Call {
+func (_c *MockMetaCache_UpdateSegmentView_Call) Run(run func(partitionID int64, newSegments []*datapb.SyncSegmentInfo, newSegmentsBF []*pkoracle.BloomFilterSet, allSegments map[int64]struct{})) *MockMetaCache_UpdateSegmentView_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(int64), args[1].([]*datapb.SyncSegmentInfo), args[2].([]*BloomFilterSet), args[3].(map[int64]struct{}))
+		run(args[0].(int64), args[1].([]*datapb.SyncSegmentInfo), args[2].([]*pkoracle.BloomFilterSet), args[3].(map[int64]struct{}))
 	})
 	return _c
 }
@@ -541,7 +543,7 @@ func (_c *MockMetaCache_UpdateSegmentView_Call) Return() *MockMetaCache_UpdateSe
 	return _c
 }
 
-func (_c *MockMetaCache_UpdateSegmentView_Call) RunAndReturn(run func(int64, []*datapb.SyncSegmentInfo, []*BloomFilterSet, map[int64]struct{})) *MockMetaCache_UpdateSegmentView_Call {
+func (_c *MockMetaCache_UpdateSegmentView_Call) RunAndReturn(run func(int64, []*datapb.SyncSegmentInfo, []*pkoracle.BloomFilterSet, map[int64]struct{})) *MockMetaCache_UpdateSegmentView_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/flushcommon/metacache/pkoracle/README.md
+++ b/internal/flushcommon/metacache/pkoracle/README.md
@@ -1,0 +1,13 @@
+# pkoracle package
+
+This package defines the interface and implementations for segments bloom filter sets of flushcommon metacache.
+
+## BloomFilterSet
+
+The basic implementation with segment statslog. A group of bloom filter to perdict whethe some pks exists in the segment.
+
+## LazyPkStats
+
+A wrapper for lazy loading PkStats. The inner PkStats could be added async.
+
+*CANNOT* be used for growing segment.

--- a/internal/flushcommon/metacache/pkoracle/bloom_filter_set.go
+++ b/internal/flushcommon/metacache/pkoracle/bloom_filter_set.go
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package metacache
+package pkoracle
 
 import (
 	"sync"
@@ -25,6 +25,8 @@ import (
 	"github.com/milvus-io/milvus/internal/util/bloomfilter"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 )
+
+var _ PkStat = (*BloomFilterSet)(nil)
 
 // BloomFilterSet is a struct with multiple `storage.PkStatstics`.
 // it maintains bloom filter generated from segment primary keys.

--- a/internal/flushcommon/metacache/pkoracle/bloom_filter_set_test.go
+++ b/internal/flushcommon/metacache/pkoracle/bloom_filter_set_test.go
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package metacache
+package pkoracle
 
 import (
 	"testing"

--- a/internal/flushcommon/metacache/pkoracle/lazy_pk_stats.go
+++ b/internal/flushcommon/metacache/pkoracle/lazy_pk_stats.go
@@ -1,0 +1,83 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkoracle
+
+import (
+	"github.com/samber/lo"
+	"go.uber.org/atomic"
+
+	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/pkg/util/merr"
+)
+
+var _ PkStat = (*LazyPkStats)(nil)
+
+// LazyPkStats
+type LazyPkStats struct {
+	inner atomic.Pointer[PkStat]
+}
+
+func NewLazyPkstats() *LazyPkStats {
+	return &LazyPkStats{}
+}
+
+func (s *LazyPkStats) SetPkStats(pk PkStat) {
+	if pk != nil {
+		s.inner.Store(&pk)
+	}
+}
+
+func (s *LazyPkStats) PkExists(lc *storage.LocationsCache) bool {
+	inner := s.inner.Load()
+	if inner == nil {
+		return true
+	}
+	return (*inner).PkExists(lc)
+}
+
+func (s *LazyPkStats) BatchPkExist(lc *storage.BatchLocationsCache) []bool {
+	inner := s.inner.Load()
+	if inner == nil {
+		return lo.RepeatBy(lc.Size(), func(_ int) bool {
+			return true
+		})
+	}
+	return (*inner).BatchPkExist(lc)
+}
+
+func (s *LazyPkStats) BatchPkExistWithHits(lc *storage.BatchLocationsCache, hits []bool) []bool {
+	inner := s.inner.Load()
+	if inner == nil {
+		return lo.RepeatBy(lc.Size(), func(_ int) bool {
+			return true
+		})
+	}
+	return (*inner).BatchPkExistWithHits(lc, hits)
+}
+
+func (s *LazyPkStats) UpdatePKRange(ids storage.FieldData) error {
+	return merr.WrapErrServiceInternal("UpdatePKRange shall never be called on LazyPkStats")
+}
+
+func (s *LazyPkStats) Roll(newStats ...*storage.PrimaryKeyStats) {
+	merr.WrapErrServiceInternal("Roll shall never be called on LazyPkStats")
+}
+
+func (s *LazyPkStats) GetHistory() []*storage.PkStatistics {
+	// GetHistory shall never be called on LazyPkStats
+	return nil
+}

--- a/internal/flushcommon/metacache/pkoracle/pk_stats.go
+++ b/internal/flushcommon/metacache/pkoracle/pk_stats.go
@@ -1,0 +1,29 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkoracle
+
+import "github.com/milvus-io/milvus/internal/storage"
+
+// PK stat is the interface for pk statistics.
+type PkStat interface {
+	PkExists(lc *storage.LocationsCache) bool
+	BatchPkExist(lc *storage.BatchLocationsCache) []bool
+	BatchPkExistWithHits(lc *storage.BatchLocationsCache, hits []bool) []bool
+	UpdatePKRange(ids storage.FieldData) error
+	Roll(newStats ...*storage.PrimaryKeyStats)
+	GetHistory() []*storage.PkStatistics
+}

--- a/internal/flushcommon/metacache/segment.go
+++ b/internal/flushcommon/metacache/segment.go
@@ -19,6 +19,7 @@ package metacache
 import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
+	"github.com/milvus-io/milvus/internal/flushcommon/metacache/pkoracle"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
 	"github.com/milvus-io/milvus/internal/storage"
 )
@@ -33,7 +34,7 @@ type SegmentInfo struct {
 	flushedRows      int64
 	bufferRows       int64
 	syncingRows      int64
-	bfs              *BloomFilterSet
+	bfs              pkoracle.PkStat
 	level            datapb.SegmentLevel
 	syncingTasks     int32
 }
@@ -73,7 +74,7 @@ func (s *SegmentInfo) GetHistory() []*storage.PkStatistics {
 	return s.bfs.GetHistory()
 }
 
-func (s *SegmentInfo) GetBloomFilterSet() *BloomFilterSet {
+func (s *SegmentInfo) GetBloomFilterSet() pkoracle.PkStat {
 	return s.bfs
 }
 
@@ -98,7 +99,7 @@ func (s *SegmentInfo) Clone() *SegmentInfo {
 	}
 }
 
-func NewSegmentInfo(info *datapb.SegmentInfo, bfs *BloomFilterSet) *SegmentInfo {
+func NewSegmentInfo(info *datapb.SegmentInfo, bfs pkoracle.PkStat) *SegmentInfo {
 	level := info.GetLevel()
 	if level == datapb.SegmentLevel_Legacy {
 		level = datapb.SegmentLevel_L1

--- a/internal/flushcommon/metacache/segment_test.go
+++ b/internal/flushcommon/metacache/segment_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/milvus-io/milvus/internal/flushcommon/metacache/pkoracle"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
 )
 
@@ -31,7 +32,7 @@ type SegmentSuite struct {
 }
 
 func (s *SegmentSuite) TestBasic() {
-	bfs := NewBloomFilterSet()
+	bfs := pkoracle.NewBloomFilterSet()
 	segment := NewSegmentInfo(s.info, bfs)
 	s.Equal(s.info.GetID(), segment.SegmentID())
 	s.Equal(s.info.GetPartitionID(), segment.PartitionID())
@@ -43,7 +44,7 @@ func (s *SegmentSuite) TestBasic() {
 }
 
 func (s *SegmentSuite) TestClone() {
-	bfs := NewBloomFilterSet()
+	bfs := pkoracle.NewBloomFilterSet()
 	segment := NewSegmentInfo(s.info, bfs)
 	cloned := segment.Clone()
 	s.Equal(segment.SegmentID(), cloned.SegmentID())

--- a/internal/flushcommon/pipeline/testutils_test.go
+++ b/internal/flushcommon/pipeline/testutils_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
-	"github.com/milvus-io/milvus/internal/flushcommon/metacache"
+	"github.com/milvus-io/milvus/internal/flushcommon/metacache/pkoracle"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
 	"github.com/milvus-io/milvus/internal/proto/etcdpb"
 	"github.com/milvus-io/milvus/internal/proto/rootcoordpb"
@@ -939,8 +939,8 @@ func (s *MockDataSuiteBase) PrepareData() {
 	}
 }
 
-func EmptyBfsFactory(info *datapb.SegmentInfo) *metacache.BloomFilterSet {
-	return metacache.NewBloomFilterSet()
+func EmptyBfsFactory(info *datapb.SegmentInfo) pkoracle.PkStat {
+	return pkoracle.NewBloomFilterSet()
 }
 
 func GetWatchInfoByOpID(opID typeutil.UniqueID, channel string, state datapb.ChannelWatchState) *datapb.ChannelWatchInfo {

--- a/internal/flushcommon/syncmgr/meta_writer_test.go
+++ b/internal/flushcommon/syncmgr/meta_writer_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/milvus-io/milvus/internal/flushcommon/broker"
 	"github.com/milvus-io/milvus/internal/flushcommon/metacache"
+	"github.com/milvus-io/milvus/internal/flushcommon/metacache/pkoracle"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/util/retry"
@@ -39,7 +40,7 @@ func (s *MetaWriterSuite) TestNormalSave() {
 	defer cancel()
 	s.broker.EXPECT().SaveBinlogPaths(mock.Anything, mock.Anything).Return(nil)
 
-	bfs := metacache.NewBloomFilterSet()
+	bfs := pkoracle.NewBloomFilterSet()
 	seg := metacache.NewSegmentInfo(&datapb.SegmentInfo{}, bfs)
 	metacache.UpdateNumOfRows(1000)(seg)
 	s.metacache.EXPECT().GetSegmentsBy(mock.Anything, mock.Anything).Return([]*metacache.SegmentInfo{seg})
@@ -56,7 +57,7 @@ func (s *MetaWriterSuite) TestReturnError() {
 	defer cancel()
 	s.broker.EXPECT().SaveBinlogPaths(mock.Anything, mock.Anything).Return(errors.New("mocked"))
 
-	bfs := metacache.NewBloomFilterSet()
+	bfs := pkoracle.NewBloomFilterSet()
 	seg := metacache.NewSegmentInfo(&datapb.SegmentInfo{}, bfs)
 	metacache.UpdateNumOfRows(1000)(seg)
 	s.metacache.EXPECT().GetSegmentByID(mock.Anything).Return(seg, true)

--- a/internal/flushcommon/syncmgr/storage_serializer_test.go
+++ b/internal/flushcommon/syncmgr/storage_serializer_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/allocator"
 	"github.com/milvus-io/milvus/internal/flushcommon/metacache"
+	"github.com/milvus-io/milvus/internal/flushcommon/metacache/pkoracle"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/pkg/common"
@@ -150,8 +151,8 @@ func (s *StorageV1SerializerSuite) getBasicPack() *SyncPack {
 	return pack
 }
 
-func (s *StorageV1SerializerSuite) getBfs() *metacache.BloomFilterSet {
-	bfs := metacache.NewBloomFilterSet()
+func (s *StorageV1SerializerSuite) getBfs() *pkoracle.BloomFilterSet {
+	bfs := pkoracle.NewBloomFilterSet()
 	fd, err := storage.NewFieldData(schemapb.DataType_Int64, &schemapb.FieldSchema{
 		FieldID:      101,
 		Name:         "ID",

--- a/internal/flushcommon/syncmgr/sync_manager_test.go
+++ b/internal/flushcommon/syncmgr/sync_manager_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/milvus-io/milvus/internal/allocator"
 	"github.com/milvus-io/milvus/internal/flushcommon/broker"
 	"github.com/milvus-io/milvus/internal/flushcommon/metacache"
+	"github.com/milvus-io/milvus/internal/flushcommon/metacache/pkoracle"
 	"github.com/milvus-io/milvus/internal/mocks"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
 	"github.com/milvus-io/milvus/internal/storage"
@@ -153,7 +154,7 @@ func (s *SyncManagerSuite) getSuiteSyncTask() *SyncTask {
 
 func (s *SyncManagerSuite) TestSubmit() {
 	s.broker.EXPECT().SaveBinlogPaths(mock.Anything, mock.Anything).Return(nil)
-	bfs := metacache.NewBloomFilterSet()
+	bfs := pkoracle.NewBloomFilterSet()
 	seg := metacache.NewSegmentInfo(&datapb.SegmentInfo{}, bfs)
 	metacache.UpdateNumOfRows(1000)(seg)
 	s.metacache.EXPECT().GetSegmentByID(s.segmentID).Return(seg, true)
@@ -182,7 +183,7 @@ func (s *SyncManagerSuite) TestCompacted() {
 	s.broker.EXPECT().SaveBinlogPaths(mock.Anything, mock.Anything).Run(func(_ context.Context, req *datapb.SaveBinlogPathsRequest) {
 		segmentID.Store(req.GetSegmentID())
 	}).Return(nil)
-	bfs := metacache.NewBloomFilterSet()
+	bfs := pkoracle.NewBloomFilterSet()
 	seg := metacache.NewSegmentInfo(&datapb.SegmentInfo{}, bfs)
 	metacache.UpdateNumOfRows(1000)(seg)
 	s.metacache.EXPECT().GetSegmentByID(s.segmentID).Return(seg, true)

--- a/internal/flushcommon/syncmgr/task_test.go
+++ b/internal/flushcommon/syncmgr/task_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/milvus-io/milvus/internal/allocator"
 	"github.com/milvus-io/milvus/internal/flushcommon/broker"
 	"github.com/milvus-io/milvus/internal/flushcommon/metacache"
+	"github.com/milvus-io/milvus/internal/flushcommon/metacache/pkoracle"
 	"github.com/milvus-io/milvus/internal/mocks"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
 	"github.com/milvus-io/milvus/internal/storage"
@@ -168,7 +169,7 @@ func (s *SyncTaskSuite) TestRunNormal() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	s.broker.EXPECT().SaveBinlogPaths(mock.Anything, mock.Anything).Return(nil)
-	bfs := metacache.NewBloomFilterSet()
+	bfs := pkoracle.NewBloomFilterSet()
 	fd, err := storage.NewFieldData(schemapb.DataType_Int64, &schemapb.FieldSchema{
 		FieldID:      101,
 		Name:         "ID",
@@ -271,7 +272,7 @@ func (s *SyncTaskSuite) TestRunL0Segment() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	s.broker.EXPECT().SaveBinlogPaths(mock.Anything, mock.Anything).Return(nil)
-	bfs := metacache.NewBloomFilterSet()
+	bfs := pkoracle.NewBloomFilterSet()
 	seg := metacache.NewSegmentInfo(&datapb.SegmentInfo{Level: datapb.SegmentLevel_L0}, bfs)
 	s.metacache.EXPECT().GetSegmentByID(s.segmentID).Return(seg, true)
 	s.metacache.EXPECT().GetSegmentsBy(mock.Anything, mock.Anything).Return([]*metacache.SegmentInfo{seg})
@@ -313,7 +314,7 @@ func (s *SyncTaskSuite) TestRunError() {
 	})
 
 	s.metacache.ExpectedCalls = nil
-	seg := metacache.NewSegmentInfo(&datapb.SegmentInfo{}, metacache.NewBloomFilterSet())
+	seg := metacache.NewSegmentInfo(&datapb.SegmentInfo{}, pkoracle.NewBloomFilterSet())
 	metacache.UpdateNumOfRows(1000)(seg)
 	s.metacache.EXPECT().GetSegmentByID(s.segmentID).Return(seg, true)
 	s.metacache.EXPECT().GetSegmentsBy(mock.Anything, mock.Anything).Return([]*metacache.SegmentInfo{seg})

--- a/internal/flushcommon/writebuffer/bf_write_buffer_test.go
+++ b/internal/flushcommon/writebuffer/bf_write_buffer_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/flushcommon/broker"
 	"github.com/milvus-io/milvus/internal/flushcommon/metacache"
+	"github.com/milvus-io/milvus/internal/flushcommon/metacache/pkoracle"
 	"github.com/milvus-io/milvus/internal/flushcommon/syncmgr"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
 	"github.com/milvus-io/milvus/internal/storage"
@@ -198,7 +199,7 @@ func (s *BFWriteBufferSuite) TestBufferData() {
 		wb, err := NewBFWriteBuffer(s.channelName, s.metacacheInt64, s.syncMgr, &writeBufferOption{})
 		s.NoError(err)
 
-		seg := metacache.NewSegmentInfo(&datapb.SegmentInfo{ID: 1000}, metacache.NewBloomFilterSet())
+		seg := metacache.NewSegmentInfo(&datapb.SegmentInfo{ID: 1000}, pkoracle.NewBloomFilterSet())
 		s.metacacheInt64.EXPECT().GetSegmentsBy(mock.Anything, mock.Anything).Return([]*metacache.SegmentInfo{seg})
 		s.metacacheInt64.EXPECT().GetSegmentByID(int64(1000)).Return(nil, false)
 		s.metacacheInt64.EXPECT().AddSegment(mock.Anything, mock.Anything, mock.Anything).Return()
@@ -225,7 +226,7 @@ func (s *BFWriteBufferSuite) TestBufferData() {
 		wb, err := NewBFWriteBuffer(s.channelName, s.metacacheVarchar, s.syncMgr, &writeBufferOption{})
 		s.NoError(err)
 
-		seg := metacache.NewSegmentInfo(&datapb.SegmentInfo{ID: 1000}, metacache.NewBloomFilterSet())
+		seg := metacache.NewSegmentInfo(&datapb.SegmentInfo{ID: 1000}, pkoracle.NewBloomFilterSet())
 		s.metacacheVarchar.EXPECT().GetSegmentsBy(mock.Anything, mock.Anything).Return([]*metacache.SegmentInfo{seg})
 		s.metacacheVarchar.EXPECT().GetSegmentByID(int64(1000)).Return(nil, false)
 		s.metacacheVarchar.EXPECT().AddSegment(mock.Anything, mock.Anything, mock.Anything).Return()
@@ -247,7 +248,7 @@ func (s *BFWriteBufferSuite) TestBufferData() {
 		wb, err := NewBFWriteBuffer(s.channelName, s.metacacheInt64, s.syncMgr, &writeBufferOption{})
 		s.NoError(err)
 
-		seg := metacache.NewSegmentInfo(&datapb.SegmentInfo{ID: 1000}, metacache.NewBloomFilterSet())
+		seg := metacache.NewSegmentInfo(&datapb.SegmentInfo{ID: 1000}, pkoracle.NewBloomFilterSet())
 		s.metacacheInt64.EXPECT().GetSegmentsBy(mock.Anything, mock.Anything).Return([]*metacache.SegmentInfo{seg})
 		s.metacacheInt64.EXPECT().GetSegmentByID(int64(1000)).Return(nil, false)
 		s.metacacheInt64.EXPECT().AddSegment(mock.Anything, mock.Anything, mock.Anything).Return()
@@ -265,7 +266,7 @@ func (s *BFWriteBufferSuite) TestBufferData() {
 		wb, err := NewBFWriteBuffer(s.channelName, s.metacacheVarchar, s.syncMgr, &writeBufferOption{})
 		s.NoError(err)
 
-		seg := metacache.NewSegmentInfo(&datapb.SegmentInfo{ID: 1000}, metacache.NewBloomFilterSet())
+		seg := metacache.NewSegmentInfo(&datapb.SegmentInfo{ID: 1000}, pkoracle.NewBloomFilterSet())
 		s.metacacheVarchar.EXPECT().GetSegmentsBy(mock.Anything, mock.Anything).Return([]*metacache.SegmentInfo{seg})
 		s.metacacheVarchar.EXPECT().GetSegmentByID(int64(1000)).Return(nil, false)
 		s.metacacheVarchar.EXPECT().AddSegment(mock.Anything, mock.Anything, mock.Anything).Return()
@@ -293,8 +294,8 @@ func (s *BFWriteBufferSuite) TestAutoSync() {
 		})
 		s.NoError(err)
 
-		seg := metacache.NewSegmentInfo(&datapb.SegmentInfo{ID: 1000}, metacache.NewBloomFilterSet())
-		seg1 := metacache.NewSegmentInfo(&datapb.SegmentInfo{ID: 1002}, metacache.NewBloomFilterSet())
+		seg := metacache.NewSegmentInfo(&datapb.SegmentInfo{ID: 1000}, pkoracle.NewBloomFilterSet())
+		seg1 := metacache.NewSegmentInfo(&datapb.SegmentInfo{ID: 1002}, pkoracle.NewBloomFilterSet())
 		s.metacacheInt64.EXPECT().GetSegmentsBy(mock.Anything, mock.Anything).Return([]*metacache.SegmentInfo{seg})
 		s.metacacheInt64.EXPECT().GetSegmentByID(int64(1000)).Return(nil, false).Once()
 		s.metacacheInt64.EXPECT().GetSegmentByID(int64(1000)).Return(seg, true).Once()

--- a/internal/flushcommon/writebuffer/l0_write_buffer.go
+++ b/internal/flushcommon/writebuffer/l0_write_buffer.go
@@ -11,6 +11,7 @@ import (
 	"github.com/milvus-io/milvus/internal/allocator"
 	"github.com/milvus-io/milvus/internal/flushcommon/io"
 	"github.com/milvus-io/milvus/internal/flushcommon/metacache"
+	"github.com/milvus-io/milvus/internal/flushcommon/metacache/pkoracle"
 	"github.com/milvus-io/milvus/internal/flushcommon/syncmgr"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
 	"github.com/milvus-io/milvus/internal/storage"
@@ -211,7 +212,7 @@ func (wb *l0WriteBuffer) getL0SegmentID(partitionID int64, startPos *msgpb.MsgPo
 			StartPosition: startPos,
 			State:         commonpb.SegmentState_Growing,
 			Level:         datapb.SegmentLevel_L0,
-		}, func(_ *datapb.SegmentInfo) *metacache.BloomFilterSet { return metacache.NewBloomFilterSet() }, metacache.SetStartPosRecorded(false))
+		}, func(_ *datapb.SegmentInfo) pkoracle.PkStat { return pkoracle.NewBloomFilterSet() }, metacache.SetStartPosRecorded(false))
 		log.Info("Add a new level zero segment",
 			zap.Int64("segmentID", segmentID),
 			zap.String("level", datapb.SegmentLevel_L0.String()),

--- a/internal/flushcommon/writebuffer/l0_write_buffer_test.go
+++ b/internal/flushcommon/writebuffer/l0_write_buffer_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/allocator"
 	"github.com/milvus-io/milvus/internal/flushcommon/metacache"
+	"github.com/milvus-io/milvus/internal/flushcommon/metacache/pkoracle"
 	"github.com/milvus-io/milvus/internal/flushcommon/syncmgr"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
 	"github.com/milvus-io/milvus/internal/storage"
@@ -176,7 +177,7 @@ func (s *L0WriteBufferSuite) TestBufferData() {
 		pks, msg := s.composeInsertMsg(1000, 10, 128, schemapb.DataType_Int64)
 		delMsg := s.composeDeleteMsg(lo.Map(pks, func(id int64, _ int) storage.PrimaryKey { return storage.NewInt64PrimaryKey(id) }))
 
-		seg := metacache.NewSegmentInfo(&datapb.SegmentInfo{ID: 1000}, metacache.NewBloomFilterSet())
+		seg := metacache.NewSegmentInfo(&datapb.SegmentInfo{ID: 1000}, pkoracle.NewBloomFilterSet())
 		s.metacache.EXPECT().GetSegmentsBy(mock.Anything, mock.Anything).Return([]*metacache.SegmentInfo{seg})
 		s.metacache.EXPECT().GetSegmentByID(int64(1000)).Return(nil, false).Once()
 		s.metacache.EXPECT().AddSegment(mock.Anything, mock.Anything, mock.Anything).Return()
@@ -205,7 +206,7 @@ func (s *L0WriteBufferSuite) TestBufferData() {
 		pks, msg := s.composeInsertMsg(1000, 10, 128, schemapb.DataType_VarChar)
 		delMsg := s.composeDeleteMsg(lo.Map(pks, func(id int64, _ int) storage.PrimaryKey { return storage.NewInt64PrimaryKey(id) }))
 
-		seg := metacache.NewSegmentInfo(&datapb.SegmentInfo{ID: 1000}, metacache.NewBloomFilterSet())
+		seg := metacache.NewSegmentInfo(&datapb.SegmentInfo{ID: 1000}, pkoracle.NewBloomFilterSet())
 		s.metacache.EXPECT().GetSegmentsBy(mock.Anything, mock.Anything).Return([]*metacache.SegmentInfo{seg})
 		s.metacache.EXPECT().AddSegment(mock.Anything, mock.Anything, mock.Anything).Return()
 		s.metacache.EXPECT().UpdateSegments(mock.Anything, mock.Anything).Return()

--- a/internal/flushcommon/writebuffer/write_buffer.go
+++ b/internal/flushcommon/writebuffer/write_buffer.go
@@ -14,6 +14,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/flushcommon/metacache"
+	"github.com/milvus-io/milvus/internal/flushcommon/metacache/pkoracle"
 	"github.com/milvus-io/milvus/internal/flushcommon/syncmgr"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
 	"github.com/milvus-io/milvus/internal/storage"
@@ -535,8 +536,8 @@ func (wb *writeBufferBase) bufferInsert(inData *inData, startPos, endPos *msgpb.
 			InsertChannel: wb.channelName,
 			StartPosition: startPos,
 			State:         commonpb.SegmentState_Growing,
-		}, func(_ *datapb.SegmentInfo) *metacache.BloomFilterSet {
-			return metacache.NewBloomFilterSetWithBatchSize(wb.getEstBatchSize())
+		}, func(_ *datapb.SegmentInfo) pkoracle.PkStat {
+			return pkoracle.NewBloomFilterSetWithBatchSize(wb.getEstBatchSize())
 		}, metacache.SetStartPosRecorded(false))
 		log.Info("add growing segment", zap.Int64("segmentID", inData.segmentID), zap.String("channel", wb.channelName))
 	}

--- a/internal/flushcommon/writebuffer/write_buffer_test.go
+++ b/internal/flushcommon/writebuffer/write_buffer_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/allocator"
 	"github.com/milvus-io/milvus/internal/flushcommon/metacache"
+	"github.com/milvus-io/milvus/internal/flushcommon/metacache/pkoracle"
 	"github.com/milvus-io/milvus/internal/flushcommon/syncmgr"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/common"
@@ -52,8 +53,8 @@ func (s *WriteBufferSuite) SetupTest() {
 	s.metacache.EXPECT().Collection().Return(s.collID).Maybe()
 	var err error
 	s.wb, err = newWriteBufferBase(s.channelName, s.metacache, s.syncMgr, &writeBufferOption{
-		pkStatsFactory: func(vchannel *datapb.SegmentInfo) *metacache.BloomFilterSet {
-			return metacache.NewBloomFilterSet()
+		pkStatsFactory: func(vchannel *datapb.SegmentInfo) pkoracle.PkStat {
+			return pkoracle.NewBloomFilterSet()
 		},
 	})
 	s.Require().NoError(err)
@@ -263,8 +264,8 @@ func (s *WriteBufferSuite) TestGetCheckpoint() {
 
 func (s *WriteBufferSuite) TestSyncSegmentsError() {
 	wb, err := newWriteBufferBase(s.channelName, s.metacache, s.syncMgr, &writeBufferOption{
-		pkStatsFactory: func(vchannel *datapb.SegmentInfo) *metacache.BloomFilterSet {
-			return metacache.NewBloomFilterSet()
+		pkStatsFactory: func(vchannel *datapb.SegmentInfo) pkoracle.PkStat {
+			return pkoracle.NewBloomFilterSet()
 		},
 	})
 	s.Require().NoError(err)
@@ -296,8 +297,8 @@ func (s *WriteBufferSuite) TestSyncSegmentsError() {
 
 func (s *WriteBufferSuite) TestEvictBuffer() {
 	wb, err := newWriteBufferBase(s.channelName, s.metacache, s.syncMgr, &writeBufferOption{
-		pkStatsFactory: func(vchannel *datapb.SegmentInfo) *metacache.BloomFilterSet {
-			return metacache.NewBloomFilterSet()
+		pkStatsFactory: func(vchannel *datapb.SegmentInfo) pkoracle.PkStat {
+			return pkoracle.NewBloomFilterSet()
 		},
 	})
 	s.Require().NoError(err)
@@ -365,8 +366,8 @@ func (s *WriteBufferSuite) TestEvictBuffer() {
 
 func (s *WriteBufferSuite) TestDropPartitions() {
 	wb, err := newWriteBufferBase(s.channelName, s.metacache, s.syncMgr, &writeBufferOption{
-		pkStatsFactory: func(vchannel *datapb.SegmentInfo) *metacache.BloomFilterSet {
-			return metacache.NewBloomFilterSet()
+		pkStatsFactory: func(vchannel *datapb.SegmentInfo) pkoracle.PkStat {
+			return pkoracle.NewBloomFilterSet()
 		},
 	})
 	s.Require().NoError(err)


### PR DESCRIPTION
Add back lazy loading statslog when watch dml channel on datanode.

Related to #22994 #27675