### PR TITLE
doc: improve VSCode setup in dev docs

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -71,22 +71,22 @@ You can use Vscode to integrate C++ and Go together. Please replace user.setting
 ```bash
 {
     "go.toolsEnvVars": {
-        "PKG_CONFIG_PATH": "/Users/zilliz/milvus/internal/core/output/lib/pkgconfig:/Users/zilliz/workspace/milvus/internal/core/output/lib64/pkgconfig",
-        "LD_LIBRARY_PATH": "/Users/zilliz/workspace/milvus/internal/core/output/lib:/Users/zilliz/workspace/milvus/internal/core/output/lib64",
-        "RPATH": "/Users/zilliz/workspace/milvus/internal/core/output/lib:/Users/zilliz/workspace/milvus/internal/core/output/lib64"
+        "PKG_CONFIG_PATH": "${env:PKG_CONFIG_PATH}:${workspaceFolder}/internal/core/output/lib/pkgconfig:${workspaceFolder}/internal/core/output/lib64/pkgconfig",
+        "LD_LIBRARY_PATH": "${env:LD_LIBRARY_PATH}:${workspaceFolder}/internal/core/output/lib:${workspaceFolder}/internal/core/output/lib64",
+        "RPATH": "${env:RPATH}:${workspaceFolder}/internal/core/output/lib:${workspaceFolder}/internal/core/output/lib64",
     },
     "go.testEnvVars": {
-        "PKG_CONFIG_PATH": "/Users/zilliz/workspace/milvus/internal/core/output/lib/pkgconfig:/Users/zilliz/workspace/milvus/internal/core/output/lib64/pkgconfig",
-        "LD_LIBRARY_PATH": "/Users/zilliz/workspace/milvus/internal/core/output/lib:/Users/zilliz/workspace/milvus/internal/core/output/lib64",
-        "RPATH": "/Users/zilliz/workspace/milvus/internal/core/output/lib:/Users/zilliz/workspace/milvus/internal/core/output/lib64"
+        "PKG_CONFIG_PATH": "${env:PKG_CONFIG_PATH}:${workspaceFolder}/internal/core/output/lib/pkgconfig:${workspaceFolder}/internal/core/output/lib64/pkgconfig",
+        "LD_LIBRARY_PATH": "${env:LD_LIBRARY_PATH}:${workspaceFolder}/internal/core/output/lib:${workspaceFolder}/internal/core/output/lib64",
+        "RPATH": "${env:RPATH}:${workspaceFolder}/internal/core/output/lib:${workspaceFolder}/internal/core/output/lib64",
     },
     "go.buildFlags": [
-        "-ldflags=-r /Users/zilliz/workspace/milvus/internal/core/output/lib"
+        "-ldflags=-r=/Users/zilliz/workspace/milvus/internal/core/output/lib"
     ],
     "terminal.integrated.env.linux": {
-        "PKG_CONFIG_PATH": "/Users/zilliz/workspace/milvus/internal/core/output/lib/pkgconfig:/Users/zilliz/workspace/milvus/internal/core/output/lib64/pkgconfig",
-        "LD_LIBRARY_PATH": "/Users/zilliz/workspace/milvus/internal/core/output/lib:/Users/zilliz/workspace/milvus/internal/core/output/lib64",
-        "RPATH": "/Users/zilliz/workspace/milvus/internal/core/output/lib:/Users/zilliz/workspace/milvus/internal/core/output/lib64"
+        "PKG_CONFIG_PATH": "${env:PKG_CONFIG_PATH}:${workspaceFolder}/internal/core/output/lib/pkgconfig:${workspaceFolder}/internal/core/output/lib64/pkgconfig",
+        "LD_LIBRARY_PATH": "${env:LD_LIBRARY_PATH}:${workspaceFolder}/internal/core/output/lib:${workspaceFolder}/internal/core/output/lib64",
+        "RPATH": "${env:RPATH}:${workspaceFolder}/internal/core/output/lib:${workspaceFolder}/internal/core/output/lib64",
     },
     "go.useLanguageServer": true,
     "gopls": {
@@ -94,7 +94,7 @@ You can use Vscode to integrate C++ and Go together. Please replace user.setting
     },
     "go.formatTool": "gofumpt",
     "go.lintTool": "golangci-lint",
-    "go.testTags": "dynamic",
+    "go.testTags": "test,dynamic",
     "go.testTimeout": "10m"
 }
 ```


### PR DESCRIPTION
The developer documentation contains instructions for setting up a dev environment in VSCode. This PR improves on the below two issues:

1. With the current settings, you cannot run and debug Go unit tests through the VSCode UI. The `tags` and `ldflags` parameters need to be modified slightly to make this work.

<img width="436" alt="Screenshot 2024-08-23 at 4 37 37 PM" src="https://github.com/user-attachments/assets/78bae0b9-5abe-4e48-90cf-e844ad9ef292">

2. Users need to replace all occurrences of `/Users/zilliz/workspace/milvus` with the actual folder path where they've cloned Milvus. This is not necessary when using the `${workspaceFolder}` variable, which VSCode will substitute automatically.