### PR TITLE
fix: Fix rate wasn't limited to the expected value

### DIFF
--- a/internal/rootcoord/quota_center.go
+++ b/internal/rootcoord/quota_center.go
@@ -1284,7 +1284,8 @@ func (q *QuotaCenter) calculateRates() error {
 }
 
 func (q *QuotaCenter) resetAllCurrentRates() error {
-	q.rateLimiter = rlinternal.NewRateLimiterTree(initInfLimiter(internalpb.RateScope_Cluster, allOps))
+	clusterLimiter := newParamLimiterFunc(internalpb.RateScope_Cluster, allOps)()
+	q.rateLimiter = rlinternal.NewRateLimiterTree(clusterLimiter)
 	initLimiters := func(sourceCollections map[int64]map[int64][]int64) {
 		for dbID, collections := range sourceCollections {
 			for collectionID, partitionIDs := range collections {

--- a/internal/rootcoord/quota_center.go
+++ b/internal/rootcoord/quota_center.go
@@ -552,6 +552,7 @@ func (q *QuotaCenter) collectMetrics() error {
 
 // forceDenyWriting sets dml rates to 0 to reject all dml requests.
 func (q *QuotaCenter) forceDenyWriting(errorCode commonpb.ErrorCode, cluster bool, dbIDs, collectionIDs []int64, col2partitionIDs map[int64][]int64) error {
+	log := log.Ctx(context.TODO()).WithRateGroup("quotaCenter.forceDenyWriting", 1.0, 60.0)
 	if cluster {
 		clusterLimiters := q.rateLimiter.GetRootLimiters()
 		updateLimiter(clusterLimiters, GetEarliestLimiter(), internalpb.RateScope_Cluster, dml)
@@ -1358,6 +1359,7 @@ func (q *QuotaCenter) getCollectionLimitProperties(collection int64) map[string]
 
 // checkDiskQuota checks if disk quota exceeded.
 func (q *QuotaCenter) checkDiskQuota(denyWritingDBs map[int64]struct{}) error {
+	log := log.Ctx(context.Background()).WithRateGroup("rootcoord.QuotaCenter", 1.0, 60.0)
 	q.diskMu.Lock()
 	defer q.diskMu.Unlock()
 	if !Params.QuotaConfig.DiskProtectionEnabled.GetAsBool() {
@@ -1371,6 +1373,7 @@ func (q *QuotaCenter) checkDiskQuota(denyWritingDBs map[int64]struct{}) error {
 	totalDiskQuota := Params.QuotaConfig.DiskQuota.GetAsFloat()
 	total := q.dataCoordMetrics.TotalBinlogSize
 	if float64(total) >= totalDiskQuota {
+		log.RatedWarn(10, "cluster disk quota exceeded", zap.Int64("disk usage", total), zap.Float64("disk quota", totalDiskQuota))
 		err := q.forceDenyWriting(commonpb.ErrorCode_DiskQuotaExhausted, true, nil, nil, nil)
 		if err != nil {
 			log.Warn("fail to force deny writing", zap.Error(err))
@@ -1432,6 +1435,7 @@ func (q *QuotaCenter) checkDiskQuota(denyWritingDBs map[int64]struct{}) error {
 }
 
 func (q *QuotaCenter) checkDBDiskQuota(dbSizeInfo map[int64]int64) []int64 {
+	log := log.Ctx(context.Background()).WithRateGroup("rootcoord.QuotaCenter", 1.0, 60.0)
 	dbIDs := make([]int64, 0)
 	checkDiskQuota := func(dbID, binlogSize int64, quota float64) {
 		if float64(binlogSize) >= quota {


### PR DESCRIPTION
Each time the rate is reset, the token bucket is fully refilled, causing the rate wasn't limited to the expected value. This PR addresses the issue by preventing the token reset.

issue: https://github.com/milvus-io/milvus/issues/35675, https://github.com/milvus-io/milvus/issues/35702