### PR TITLE
enhance: add skip 3rdparty env var

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -195,7 +195,19 @@ To build the Milvus project, run the following command:
 $ make
 ```
 
-If this command succeed, you will now have an executable at `bin/milvus` off of your Milvus project directory.
+Milvus uses `conan` to manage 3rd-party dependencies. `conan` will check the consistency of these dependencies every time you run `make`. This process can take a considerable amount of time, especially if the network is poor. If you make sure that the 3rd-party dependencies are consistent, you can use the following command to skip this step:
+
+```shell
+$ make SKIP_3RDPARTY=1
+```
+
+If this command succeeds, you will now have an executable at `bin/milvus` in your Milvus project directory.
+
+If you want to run the `bin/milvus` executable on the host machine, you need to set `LD_LIBRARY_PATH` temporarily:
+
+```shell
+$ LD_LIBRARY_PATH=./internal/core/output/lib:lib:$LD_LIBRARY_PATH ./bin/milvus
+```
 
 If you want to update proto file before `make`, we can use the following command:
 

--- a/scripts/3rdparty_build.sh
+++ b/scripts/3rdparty_build.sh
@@ -16,6 +16,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Skip the installation and compilation of third-party code, 
+# if the developer is certain that it has already been done.
+if [[ ${SKIP_3RDPARTY} -eq 1 ]]; then
+  exit 0
+fi
+
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
   DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"


### PR DESCRIPTION
issue: #35611
pr: #35736

- call `conan install` is too slow for developer, add option to skip it.