### PR TITLE
feat: support chunked column for sealed segment

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -400,6 +400,7 @@ queryNode:
       nprobe: 16 # nprobe to search small index, based on your accuracy requirement, must smaller than nlist
       memExpansionRate: 1.15 # extra memory needed by building interim index
       buildParallelRate: 0.5 # the ratio of building interim index parallel matched with cpu num
+    multipleChunkedEnable: false # Enable multiple chunked search
     knowhereScoreConsistency: false # Enable knowhere strong consistency score computation logic
   loadMemoryUsageFactor: 1 # The multiply factor of calculating the memory usage while loading segments
   enableDisk: false # enable querynode load disk index, and search on disk index

--- a/internal/core/src/bitset/detail/element_wise.h
+++ b/internal/core/src/bitset/detail/element_wise.h
@@ -25,6 +25,7 @@
 #include "ctz.h"
 #include "popcount.h"
 
+#include "bitset/common.h"
 namespace milvus {
 namespace bitset {
 namespace detail {

--- a/internal/core/src/common/ChunkTarget.cpp
+++ b/internal/core/src/common/ChunkTarget.cpp
@@ -10,10 +10,13 @@
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
 #include <common/ChunkTarget.h>
+#include <algorithm>
 #include <cstring>
 #include "common/EasyAssert.h"
 #include <sys/mman.h>
+#include <unistd.h>
 
+const auto PAGE_SIZE = sysconf(_SC_PAGE_SIZE);
 namespace milvus {
 void
 MemChunkTarget::write(const void* data, size_t size, bool append) {
@@ -43,7 +46,32 @@ MemChunkTarget::tell() {
 }
 
 void
+MmapChunkTarget::flush() {
+    if (buffer_.pos == 0) {
+        return;
+    }
+
+    auto n = file_.Write(buffer_.buf, buffer_.pos);
+    AssertInfo(n != -1, "failed to write data to file");
+    buffer_.clear();
+}
+
+void
 MmapChunkTarget::write(const void* data, size_t size, bool append) {
+    if (buffer_.sufficient(size)) {
+        buffer_.write(data, size);
+        size_ += append ? size : 0;
+        return;
+    }
+
+    flush();
+
+    if (buffer_.sufficient(size)) {
+        buffer_.write(data, size);
+        size_ += append ? size : 0;
+        return;
+    }
+
     auto n = file_.Write(data, size);
     AssertInfo(n != -1, "failed to write data to file");
     size_ += append ? size : 0;
@@ -51,19 +79,35 @@ MmapChunkTarget::write(const void* data, size_t size, bool append) {
 
 void
 MmapChunkTarget::skip(size_t size) {
+    flush();
     file_.Seek(size, SEEK_CUR);
     size_ += size;
 }
 
 void
 MmapChunkTarget::seek(size_t offset) {
+    flush();
     file_.Seek(offset_ + offset, SEEK_SET);
 }
 
 std::pair<char*, size_t>
 MmapChunkTarget::get() {
+    // Write padding to align with the page size, ensuring the offset_ aligns with the page size.
+    auto padding_size =
+        (size_ / PAGE_SIZE + (size_ % PAGE_SIZE != 0)) * PAGE_SIZE - size_;
+    char padding[padding_size];
+    memset(padding, 0, sizeof(padding));
+    write(padding, padding_size);
+
+    flush();
+
     auto m = mmap(
         nullptr, size_, PROT_READ, MAP_SHARED, file_.Descriptor(), offset_);
+    AssertInfo(m != MAP_FAILED,
+               "failed to map: {}, map_size={}, offset={}",
+               strerror(errno),
+               size_,
+               offset_);
     return {(char*)m, size_};
 }
 

--- a/internal/core/src/common/Common.h
+++ b/internal/core/src/common/Common.h
@@ -17,6 +17,8 @@
 #pragma once
 
 #include <iostream>
+#include <utility>
+#include <variant>
 #include "common/Consts.h"
 
 namespace milvus {
@@ -47,11 +49,14 @@ void
 SetDefaultExecEvalExprBatchSize(int64_t val);
 
 struct BufferView {
-    char* data_;
-    size_t size_;
+    struct Element {
+        const char* data_;
+        uint64_t* offsets_;
+        int start_;
+        int end_;
+    };
 
-    BufferView(char* data_ptr, size_t size) : data_(data_ptr), size_(size) {
-    }
+    std::variant<std::vector<Element>, std::pair<char*, size_t>> data_;
 };
 
 }  // namespace milvus

--- a/internal/core/src/common/FieldData.h
+++ b/internal/core/src/common/FieldData.h
@@ -23,6 +23,7 @@
 
 #include "common/FieldDataInterface.h"
 #include "common/Channel.h"
+#include "parquet/arrow/reader.h"
 
 namespace milvus {
 
@@ -142,6 +143,21 @@ class FieldData<SparseFloatVector> : public FieldDataSparseVectorImpl {
 using FieldDataPtr = std::shared_ptr<FieldDataBase>;
 using FieldDataChannel = Channel<FieldDataPtr>;
 using FieldDataChannelPtr = std::shared_ptr<FieldDataChannel>;
+
+struct ArrowDataWrapper {
+    ArrowDataWrapper() = default;
+    ArrowDataWrapper(std::shared_ptr<arrow::RecordBatchReader> reader,
+                     std::shared_ptr<parquet::arrow::FileReader> arrow_reader,
+                     std::shared_ptr<uint8_t[]> file_data)
+        : reader(reader), arrow_reader(arrow_reader), file_data(file_data) {
+    }
+    std::shared_ptr<arrow::RecordBatchReader> reader;
+    // file reader must outlive the record batch reader
+    std::shared_ptr<parquet::arrow::FileReader> arrow_reader;
+    // underlying file data memory, must outlive the arrow reader
+    std::shared_ptr<uint8_t[]> file_data;
+};
+using ArrowReaderChannel = Channel<std::shared_ptr<milvus::ArrowDataWrapper>>;
 
 FieldDataPtr
 InitScalarFieldData(const DataType& type, bool nullable, int64_t cap_rows);

--- a/internal/core/src/common/FieldDataInterface.h
+++ b/internal/core/src/common/FieldDataInterface.h
@@ -395,21 +395,6 @@ class FieldDataImpl : public FieldDataBase {
         return &data_[offset];
     }
 
-    // std::optional<const void*>
-    // Value(ssize_t offset) {
-    //     if (!is_type_entire_row) {
-    //         return RawValue(offset);
-    //     }
-    //     AssertInfo(offset < get_num_rows(),
-    //                "field data subscript out of range");
-    //     AssertInfo(offset < length(),
-    //                "subscript position don't has valid value");
-    //     if (nullable_ && !valid_data_[offset]) {
-    //         return std::nullopt;
-    //     }
-    //     return &field_data_[offset];
-    // }
-
     int64_t
     Size() const override {
         return DataSize() + ValidDataSize();

--- a/internal/core/src/common/type_c.h
+++ b/internal/core/src/common/type_c.h
@@ -28,6 +28,7 @@ enum SegmentType {
     Growing = 1,
     Sealed = 2,
     Indexing = 3,
+    ChunkedSealed = 4,
 };
 
 typedef enum SegmentType SegmentType;

--- a/internal/core/src/exec/expression/CompareExpr.cpp
+++ b/internal/core/src/exec/expression/CompareExpr.cpp
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 #include "CompareExpr.h"
+#include "common/type_c.h"
 #include "query/Relational.h"
 
 namespace milvus {
@@ -28,13 +29,246 @@ PhyCompareFilterExpr::IsStringExpr() {
 
 int64_t
 PhyCompareFilterExpr::GetNextBatchSize() {
-    auto current_rows =
-        segment_->type() == SegmentType::Growing
-            ? current_chunk_id_ * size_per_chunk_ + current_chunk_pos_
-            : current_chunk_pos_;
+    auto current_rows = GetCurrentRows();
+
     return current_rows + batch_size_ >= active_count_
                ? active_count_ - current_rows
                : batch_size_;
+}
+
+template <typename T>
+MultipleChunkDataAccessor
+PhyCompareFilterExpr::GetChunkData(FieldId field_id,
+                                   bool index,
+                                   int64_t& current_chunk_id,
+                                   int64_t& current_chunk_pos) {
+    if (index) {
+        auto& indexing = const_cast<index::ScalarIndex<T>&>(
+            segment_->chunk_scalar_index<T>(field_id, current_chunk_id));
+        auto current_chunk_size = segment_->type() == SegmentType::Growing
+                                      ? size_per_chunk_
+                                      : active_count_;
+
+        if (indexing.HasRawData()) {
+            return [&, current_chunk_size]() -> const number {
+                if (current_chunk_pos >= current_chunk_size) {
+                    current_chunk_id++;
+                    current_chunk_pos = 0;
+                    indexing = const_cast<index::ScalarIndex<T>&>(
+                        segment_->chunk_scalar_index<T>(field_id,
+                                                        current_chunk_id));
+                }
+                return indexing.Reverse_Lookup(current_chunk_pos++);
+            };
+        }
+    }
+    auto chunk_data =
+        segment_->chunk_data<T>(field_id, current_chunk_id).data();
+    auto current_chunk_size = segment_->chunk_size(field_id, current_chunk_id);
+    return
+        [=, &current_chunk_id, &current_chunk_pos]() mutable -> const number {
+            if (current_chunk_pos >= current_chunk_size) {
+                current_chunk_id++;
+                current_chunk_pos = 0;
+                chunk_data =
+                    segment_->chunk_data<T>(field_id, current_chunk_id).data();
+                current_chunk_size =
+                    segment_->chunk_size(field_id, current_chunk_id);
+            }
+
+            return chunk_data[current_chunk_pos++];
+        };
+}
+
+template <>
+MultipleChunkDataAccessor
+PhyCompareFilterExpr::GetChunkData<std::string>(FieldId field_id,
+                                                bool index,
+                                                int64_t& current_chunk_id,
+                                                int64_t& current_chunk_pos) {
+    if (index) {
+        auto& indexing = const_cast<index::ScalarIndex<std::string>&>(
+            segment_->chunk_scalar_index<std::string>(field_id,
+                                                      current_chunk_id));
+        auto current_chunk_size = segment_->type() == SegmentType::Growing
+                                      ? size_per_chunk_
+                                      : active_count_;
+
+        if (indexing.HasRawData()) {
+            return [&, current_chunk_size]() mutable -> const number {
+                if (current_chunk_pos >= current_chunk_size) {
+                    current_chunk_id++;
+                    current_chunk_pos = 0;
+                    indexing = const_cast<index::ScalarIndex<std::string>&>(
+                        segment_->chunk_scalar_index<std::string>(
+                            field_id, current_chunk_id));
+                }
+                return indexing.Reverse_Lookup(current_chunk_pos++);
+            };
+        }
+    }
+    if (segment_->type() == SegmentType::Growing &&
+        !storage::MmapManager::GetInstance()
+             .GetMmapConfig()
+             .growing_enable_mmap) {
+        auto chunk_data =
+            segment_->chunk_data<std::string>(field_id, current_chunk_id)
+                .data();
+        auto current_chunk_size =
+            segment_->chunk_size(field_id, current_chunk_id);
+        return [=,
+                &current_chunk_id,
+                &current_chunk_pos]() mutable -> const number {
+            if (current_chunk_pos >= current_chunk_size) {
+                current_chunk_id++;
+                current_chunk_pos = 0;
+                chunk_data =
+                    segment_
+                        ->chunk_data<std::string>(field_id, current_chunk_id)
+                        .data();
+                current_chunk_size =
+                    segment_->chunk_size(field_id, current_chunk_id);
+            }
+
+            return chunk_data[current_chunk_pos++];
+        };
+    } else {
+        auto chunk_data =
+            segment_->chunk_view<std::string_view>(field_id, current_chunk_id)
+                .first.data();
+        auto current_chunk_size =
+            segment_->chunk_size(field_id, current_chunk_id);
+        return [=,
+                &current_chunk_id,
+                &current_chunk_pos]() mutable -> const number {
+            if (current_chunk_pos >= current_chunk_size) {
+                current_chunk_id++;
+                current_chunk_pos = 0;
+                chunk_data = segment_
+                                 ->chunk_view<std::string_view>(
+                                     field_id, current_chunk_id)
+                                 .first.data();
+                current_chunk_size =
+                    segment_->chunk_size(field_id, current_chunk_id);
+            }
+
+            return std::string(chunk_data[current_chunk_pos++]);
+        };
+    }
+}
+
+MultipleChunkDataAccessor
+PhyCompareFilterExpr::GetChunkData(DataType data_type,
+                                   FieldId field_id,
+                                   bool index,
+                                   int64_t& current_chunk_id,
+                                   int64_t& current_chunk_pos) {
+    switch (data_type) {
+        case DataType::BOOL:
+            return GetChunkData<bool>(
+                field_id, index, current_chunk_id, current_chunk_pos);
+        case DataType::INT8:
+            return GetChunkData<int8_t>(
+                field_id, index, current_chunk_id, current_chunk_pos);
+        case DataType::INT16:
+            return GetChunkData<int16_t>(
+                field_id, index, current_chunk_id, current_chunk_pos);
+        case DataType::INT32:
+            return GetChunkData<int32_t>(
+                field_id, index, current_chunk_id, current_chunk_pos);
+        case DataType::INT64:
+            return GetChunkData<int64_t>(
+                field_id, index, current_chunk_id, current_chunk_pos);
+        case DataType::FLOAT:
+            return GetChunkData<float>(
+                field_id, index, current_chunk_id, current_chunk_pos);
+        case DataType::DOUBLE:
+            return GetChunkData<double>(
+                field_id, index, current_chunk_id, current_chunk_pos);
+        case DataType::VARCHAR: {
+            return GetChunkData<std::string>(
+                field_id, index, current_chunk_id, current_chunk_pos);
+        }
+        default:
+            PanicInfo(DataTypeInvalid, "unsupported data type: {}", data_type);
+    }
+}
+
+template <typename OpType>
+VectorPtr
+PhyCompareFilterExpr::ExecCompareExprDispatcher(OpType op) {
+    if (segment_->is_chunked()) {
+        auto real_batch_size = GetNextBatchSize();
+        if (real_batch_size == 0) {
+            return nullptr;
+        }
+
+        auto res_vec =
+            std::make_shared<ColumnVector>(TargetBitmap(real_batch_size));
+        TargetBitmapView res(res_vec->GetRawData(), real_batch_size);
+
+        auto left = GetChunkData(expr_->left_data_type_,
+                                 expr_->left_field_id_,
+                                 is_left_indexed_,
+                                 left_current_chunk_id_,
+                                 left_current_chunk_pos_);
+        auto right = GetChunkData(expr_->right_data_type_,
+                                  expr_->right_field_id_,
+                                  is_right_indexed_,
+                                  right_current_chunk_id_,
+                                  right_current_chunk_pos_);
+        for (int i = 0; i < real_batch_size; ++i) {
+            res[i] = boost::apply_visitor(
+                milvus::query::Relational<decltype(op)>{}, left(), right());
+        }
+        return res_vec;
+    } else {
+        auto real_batch_size = GetNextBatchSize();
+        if (real_batch_size == 0) {
+            return nullptr;
+        }
+
+        auto res_vec =
+            std::make_shared<ColumnVector>(TargetBitmap(real_batch_size));
+        TargetBitmapView res(res_vec->GetRawData(), real_batch_size);
+
+        auto left_data_barrier =
+            segment_->num_chunk_data(expr_->left_field_id_);
+        auto right_data_barrier =
+            segment_->num_chunk_data(expr_->right_field_id_);
+
+        int64_t processed_rows = 0;
+        for (int64_t chunk_id = current_chunk_id_; chunk_id < num_chunk_;
+             ++chunk_id) {
+            auto chunk_size = chunk_id == num_chunk_ - 1
+                                  ? active_count_ - chunk_id * size_per_chunk_
+                                  : size_per_chunk_;
+            auto left = GetChunkData(expr_->left_data_type_,
+                                     expr_->left_field_id_,
+                                     chunk_id,
+                                     left_data_barrier);
+            auto right = GetChunkData(expr_->right_data_type_,
+                                      expr_->right_field_id_,
+                                      chunk_id,
+                                      right_data_barrier);
+
+            for (int i = chunk_id == current_chunk_id_ ? current_chunk_pos_ : 0;
+                 i < chunk_size;
+                 ++i) {
+                res[processed_rows++] = boost::apply_visitor(
+                    milvus::query::Relational<decltype(op)>{},
+                    left(i),
+                    right(i));
+
+                if (processed_rows >= batch_size_) {
+                    current_chunk_id_ = chunk_id;
+                    current_chunk_pos_ = i + 1;
+                    return res_vec;
+                }
+            }
+        }
+        return res_vec;
+    }
 }
 
 template <typename T>
@@ -111,52 +345,6 @@ PhyCompareFilterExpr::GetChunkData(DataType data_type,
         default:
             PanicInfo(DataTypeInvalid, "unsupported data type: {}", data_type);
     }
-}
-
-template <typename OpType>
-VectorPtr
-PhyCompareFilterExpr::ExecCompareExprDispatcher(OpType op) {
-    auto real_batch_size = GetNextBatchSize();
-    if (real_batch_size == 0) {
-        return nullptr;
-    }
-
-    auto res_vec =
-        std::make_shared<ColumnVector>(TargetBitmap(real_batch_size));
-    TargetBitmapView res(res_vec->GetRawData(), real_batch_size);
-
-    auto left_data_barrier = segment_->num_chunk_data(expr_->left_field_id_);
-    auto right_data_barrier = segment_->num_chunk_data(expr_->right_field_id_);
-
-    int64_t processed_rows = 0;
-    for (int64_t chunk_id = current_chunk_id_; chunk_id < num_chunk_;
-         ++chunk_id) {
-        auto chunk_size = chunk_id == num_chunk_ - 1
-                              ? active_count_ - chunk_id * size_per_chunk_
-                              : size_per_chunk_;
-        auto left = GetChunkData(expr_->left_data_type_,
-                                 expr_->left_field_id_,
-                                 chunk_id,
-                                 left_data_barrier);
-        auto right = GetChunkData(expr_->right_data_type_,
-                                  expr_->right_field_id_,
-                                  chunk_id,
-                                  right_data_barrier);
-
-        for (int i = chunk_id == current_chunk_id_ ? current_chunk_pos_ : 0;
-             i < chunk_size;
-             ++i) {
-            res[processed_rows++] = boost::apply_visitor(
-                milvus::query::Relational<decltype(op)>{}, left(i), right(i));
-
-            if (processed_rows >= batch_size_) {
-                current_chunk_id_ = chunk_id;
-                current_chunk_pos_ = i + 1;
-                return res_vec;
-            }
-        }
-    }
-    return res_vec;
 }
 
 void

--- a/internal/core/src/exec/operator/groupby/SearchGroupByOperator.h
+++ b/internal/core/src/exec/operator/groupby/SearchGroupByOperator.h
@@ -62,8 +62,7 @@ class SealedDataGetter : public DataGetter<T> {
     const index::ScalarIndex<T>* field_index_;
 
  public:
-    SealedDataGetter(const segcore::SegmentSealedImpl& segment,
-                     FieldId& field_id) {
+    SealedDataGetter(const segcore::SegmentSealed& segment, FieldId& field_id) {
         if (segment.HasFieldData(field_id)) {
             if constexpr (std::is_same_v<T, std::string>) {
                 str_field_data_ =
@@ -114,8 +113,8 @@ GetDataGetter(const segcore::SegmentInternalInterface& segment,
             dynamic_cast<const segcore::SegmentGrowingImpl*>(&segment)) {
         return std::make_shared<GrowingDataGetter<T>>(*growing_segment,
                                                       fieldId);
-    } else if (const segcore::SegmentSealedImpl* sealed_segment =
-                   dynamic_cast<const segcore::SegmentSealedImpl*>(&segment)) {
+    } else if (const segcore::SegmentSealed* sealed_segment =
+                   dynamic_cast<const segcore::SegmentSealed*>(&segment)) {
         return std::make_shared<SealedDataGetter<T>>(*sealed_segment, fieldId);
     } else {
         PanicInfo(UnexpectedError,

--- a/internal/core/src/index/SkipIndex.cpp
+++ b/internal/core/src/index/SkipIndex.cpp
@@ -111,29 +111,4 @@ SkipIndex::LoadPrimitive(milvus::FieldId field_id,
     fieldChunkMetrics_[field_id].emplace(chunk_id, std::move(chunkMetrics));
 }
 
-void
-SkipIndex::LoadString(milvus::FieldId field_id,
-                      int64_t chunk_id,
-                      const milvus::VariableColumn<std::string>& var_column) {
-    int num_rows = var_column.NumRows();
-    auto chunkMetrics = std::make_unique<FieldChunkMetrics>();
-    if (num_rows > 0) {
-        auto info = ProcessStringFieldMetrics(var_column);
-        chunkMetrics->min_ = Metrics(std::move(info.min_));
-        chunkMetrics->max_ = Metrics(std::move(info.max_));
-        chunkMetrics->null_count_ = info.null_count_;
-    }
-
-    chunkMetrics->hasValue_ =
-        chunkMetrics->null_count_ == num_rows ? false : true;
-
-    std::unique_lock lck(mutex_);
-    if (fieldChunkMetrics_.count(field_id) == 0) {
-        fieldChunkMetrics_.insert(std::make_pair(
-            field_id,
-            std::unordered_map<int64_t, std::unique_ptr<FieldChunkMetrics>>()));
-    }
-    fieldChunkMetrics_[field_id].emplace(chunk_id, std::move(chunkMetrics));
-}
-
 }  // namespace milvus

--- a/internal/core/src/mmap/ChunkedColumn.h
+++ b/internal/core/src/mmap/ChunkedColumn.h
@@ -1,0 +1,427 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <folly/io/IOBuf.h>
+#include <sys/mman.h>
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <memory>
+#include <queue>
+#include <string>
+#include <vector>
+#include <math.h>
+
+#include "common/Array.h"
+#include "common/Chunk.h"
+#include "common/Common.h"
+#include "common/EasyAssert.h"
+#include "common/File.h"
+#include "common/FieldMeta.h"
+#include "common/FieldData.h"
+#include "common/Span.h"
+#include "fmt/format.h"
+#include "log/Log.h"
+#include "mmap/Utils.h"
+#include "common/FieldData.h"
+#include "common/FieldDataInterface.h"
+#include "common/Array.h"
+#include "knowhere/dataset.h"
+#include "monitor/prometheus_client.h"
+#include "storage/MmapChunkManager.h"
+
+#include "mmap/Column.h"
+namespace milvus {
+
+class ChunkedColumnBase : public ColumnBase {
+ public:
+    ChunkedColumnBase() = default;
+    // memory mode ctor
+    ChunkedColumnBase(const FieldMeta& field_meta) {
+        if (field_meta.is_nullable()) {
+            nullable_ = true;
+        }
+    }
+
+    virtual ~ChunkedColumnBase(){};
+
+    ChunkedColumnBase(ChunkedColumnBase&& column) noexcept
+        : nullable_(column.nullable_), num_rows_(column.num_rows_) {
+        column.num_rows_ = 0;
+        column.nullable_ = false;
+    }
+
+    virtual void
+    AppendBatch(const FieldDataPtr data) override {
+        PanicInfo(ErrorCode::Unsupported, "AppendBatch not supported");
+    }
+
+    virtual const char*
+    Data(int chunk_id) const override {
+        chunks_[chunk_id]->Data();
+    }
+
+    virtual const char*
+    ValueAt(int64_t offset) const {
+        auto [chunk_id, offset_in_chunk] = GetChunkIDByOffset(offset);
+        return chunks_[chunk_id]->ValueAt(offset_in_chunk);
+    };
+
+    // MmappedData() returns the mmaped address
+    const char*
+    MmappedData() const override {
+        AssertInfo(chunks_.size() == 1,
+                   "only support one chunk, but got {} chunk(s)",
+                   chunks_.size());
+        return chunks_[0]->Data();
+    }
+
+    bool
+    IsValid(size_t offset) const {
+        if (nullable_) {
+            auto [chunk_id, offset_in_chunk] = GetChunkIDByOffset(offset);
+            return chunks_[chunk_id]->isValid(offset_in_chunk);
+        }
+        return true;
+    }
+
+    bool
+    IsNullable() const {
+        return nullable_;
+    }
+
+    size_t
+    NumRows() const {
+        return num_rows_;
+    };
+
+    int64_t
+    num_chunks() const {
+        return chunks_.size();
+    }
+
+    virtual void
+    AddChunk(std::shared_ptr<Chunk> chunk) {
+        num_rows_until_chunk_.push_back(num_rows_);
+        num_rows_ += chunk->RowNums();
+        chunks_.push_back(chunk);
+    }
+
+    virtual uint64_t
+    DataByteSize() const override {
+        auto size = 0;
+        for (auto& chunk : chunks_) {
+            size += chunk->Size();
+        }
+        return size;
+    }
+
+    int64_t
+    chunk_row_nums(int64_t chunk_id) const {
+        return chunks_[chunk_id]->RowNums();
+    }
+
+    virtual SpanBase
+    Span(int64_t chunk_id) const = 0;
+
+    // used for sequential access for search
+    virtual BufferView
+    GetBatchBuffer(int64_t start_offset, int64_t length) {
+        PanicInfo(ErrorCode::Unsupported,
+                  "GetBatchBuffer only supported for VariableColumn");
+    }
+
+    virtual std::pair<std::vector<std::string_view>, FixedVector<bool>>
+    StringViews(int64_t chunk_id) const {
+        PanicInfo(ErrorCode::Unsupported,
+                  "StringViews only supported for VariableColumn");
+    }
+
+    std::pair<size_t, size_t>
+    GetChunkIDByOffset(int64_t offset) const {
+        int chunk_id = 0;
+        for (auto& chunk : chunks_) {
+            if (offset < chunk->RowNums()) {
+                break;
+            }
+            offset -= chunk->RowNums();
+            chunk_id++;
+        }
+        return {chunk_id, offset};
+    }
+
+    int64_t
+    GetNumRowsUntilChunk(int64_t chunk_id) const {
+        return num_rows_until_chunk_[chunk_id];
+    }
+
+ protected:
+    bool nullable_{false};
+    size_t num_rows_{0};
+    std::vector<int64_t> num_rows_until_chunk_;
+
+ private:
+    // void
+    // UpdateMetricWhenMmap(size_t mmaped_size) {
+    //     UpdateMetricWhenMmap(mapping_type_, mmaped_size);
+    // }
+
+    // void
+    // UpdateMetricWhenMmap(bool is_map_anonymous, size_t mapped_size) {
+    //     if (mapping_type_ == MappingType::MAP_WITH_ANONYMOUS) {
+    //         milvus::monitor::internal_mmap_allocated_space_bytes_anon.Observe(
+    //             mapped_size);
+    //         milvus::monitor::internal_mmap_in_used_space_bytes_anon.Increment(
+    //             mapped_size);
+    //     } else {
+    //         milvus::monitor::internal_mmap_allocated_space_bytes_file.Observe(
+    //             mapped_size);
+    //         milvus::monitor::internal_mmap_in_used_space_bytes_file.Increment(
+    //             mapped_size);
+    //     }
+    // }
+
+    // void
+    // UpdateMetricWhenMunmap(size_t mapped_size) {
+    //     if (mapping_type_ == MappingType::MAP_WITH_ANONYMOUS) {
+    //         milvus::monitor::internal_mmap_in_used_space_bytes_anon.Decrement(
+    //             mapped_size);
+    //     } else {
+    //         milvus::monitor::internal_mmap_in_used_space_bytes_file.Decrement(
+    //             mapped_size);
+    //     }
+    // }
+
+ private:
+    storage::MmapChunkManagerPtr mcm_ = nullptr;
+
+ protected:
+    std::vector<std::shared_ptr<Chunk>> chunks_;
+};
+
+class ChunkedColumn : public ChunkedColumnBase {
+ public:
+    // memory mode ctor
+    ChunkedColumn(const FieldMeta& field_meta) : ChunkedColumnBase(field_meta) {
+    }
+
+    ChunkedColumn(ChunkedColumn&& column) noexcept
+        : ChunkedColumnBase(std::move(column)) {
+    }
+
+    ChunkedColumn(std::vector<std::shared_ptr<Chunk>> chunks) {
+        for (auto& chunk : chunks) {
+            AddChunk(chunk);
+        }
+    }
+
+    ~ChunkedColumn() override = default;
+
+    virtual SpanBase
+    Span(int64_t chunk_id) const override {
+        return std::dynamic_pointer_cast<FixedWidthChunk>(chunks_[chunk_id])
+            ->Span();
+    }
+};
+
+// when mmap is used, size_, data_ and num_rows_ of ColumnBase are used.
+class ChunkedSparseFloatColumn : public ChunkedColumnBase {
+ public:
+    // memory mode ctor
+    ChunkedSparseFloatColumn(const FieldMeta& field_meta)
+        : ChunkedColumnBase(field_meta) {
+    }
+
+    ChunkedSparseFloatColumn(ChunkedSparseFloatColumn&& column) noexcept
+        : ChunkedColumnBase(std::move(column)),
+          dim_(column.dim_),
+          vec_(std::move(column.vec_)) {
+    }
+
+    ChunkedSparseFloatColumn(std::vector<std::shared_ptr<Chunk>> chunks) {
+        for (auto& chunk : chunks) {
+            AddChunk(chunk);
+        }
+    }
+
+    ~ChunkedSparseFloatColumn() override = default;
+
+    void
+    AddChunk(std::shared_ptr<Chunk> chunk) override {
+        num_rows_until_chunk_.push_back(num_rows_);
+        num_rows_ += chunk->RowNums();
+        chunks_.push_back(chunk);
+        dim_ = std::max(
+            dim_,
+            std::dynamic_pointer_cast<SparseFloatVectorChunk>(chunk)->Dim());
+    }
+
+    // This is used to advice mmap prefetch, we don't currently support mmap for
+    // sparse float vector thus not implemented for now.
+    size_t
+    DataByteSize() const override {
+        PanicInfo(ErrorCode::Unsupported,
+                  "ByteSize not supported for sparse float column");
+    }
+
+    SpanBase
+    Span(int64_t chunk_id) const override {
+        PanicInfo(ErrorCode::Unsupported,
+                  "Span not supported for sparse float column");
+    }
+
+    int64_t
+    Dim() const {
+        return dim_;
+    }
+
+ private:
+    int64_t dim_ = 0;
+    std::vector<knowhere::sparse::SparseRow<float>> vec_;
+};
+
+template <typename T>
+class ChunkedVariableColumn : public ChunkedColumnBase {
+ public:
+    using ViewType =
+        std::conditional_t<std::is_same_v<T, std::string>, std::string_view, T>;
+
+    // memory mode ctor
+    ChunkedVariableColumn(const FieldMeta& field_meta)
+        : ChunkedColumnBase(field_meta) {
+    }
+
+    ChunkedVariableColumn(std::vector<std::shared_ptr<Chunk>> chunks) {
+        for (auto& chunk : chunks) {
+            AddChunk(chunk);
+        }
+    }
+
+    ChunkedVariableColumn(ChunkedVariableColumn&& column) noexcept
+        : ChunkedColumnBase(std::move(column)) {
+    }
+
+    ~ChunkedVariableColumn() override = default;
+
+    SpanBase
+    Span(int64_t chunk_id) const override {
+        PanicInfo(ErrorCode::NotImplemented,
+                  "span() interface is not implemented for variable column");
+    }
+
+    std::pair<std::vector<std::string_view>, FixedVector<bool>>
+    StringViews(int64_t chunk_id) const override {
+        return std::dynamic_pointer_cast<StringChunk>(chunks_[chunk_id])
+            ->StringViews();
+    }
+
+    BufferView
+    GetBatchBuffer(int64_t start_offset, int64_t length) override {
+        if (start_offset < 0 || start_offset > num_rows_ ||
+            start_offset + length > num_rows_) {
+            PanicInfo(ErrorCode::OutOfRange, "index out of range");
+        }
+
+        int chunk_num = chunks_.size();
+
+        auto [start_chunk_id, start_offset_in_chunk] =
+            GetChunkIDByOffset(start_offset);
+        BufferView buffer_view;
+
+        std::vector<BufferView::Element> elements;
+        for (; start_chunk_id < chunk_num && length > 0; ++start_chunk_id) {
+            int chunk_size = chunks_[start_chunk_id]->RowNums();
+            int len =
+                std::min(int64_t(chunk_size - start_offset_in_chunk), length);
+            elements.push_back(
+                {chunks_[start_chunk_id]->Data(),
+                 std::dynamic_pointer_cast<StringChunk>(chunks_[start_chunk_id])
+                     ->Offsets(),
+                 start_offset_in_chunk,
+                 start_offset_in_chunk + len});
+
+            start_offset_in_chunk = 0;
+            length -= len;
+        }
+
+        buffer_view.data_ = elements;
+        return buffer_view;
+    }
+
+    ViewType
+    operator[](const int i) const {
+        if (i < 0 || i > num_rows_) {
+            PanicInfo(ErrorCode::OutOfRange, "index out of range");
+        }
+
+        auto [chunk_id, offset_in_chunk] = GetChunkIDByOffset(i);
+        auto data = chunks_[chunk_id]->Data();
+        auto offsets = std::dynamic_pointer_cast<StringChunk>(chunks_[chunk_id])
+                           ->Offsets();
+        auto len = offsets[offset_in_chunk + 1] - offsets[offset_in_chunk];
+
+        return ViewType(data + offsets[offset_in_chunk], len);
+    }
+
+    std::string_view
+    RawAt(const int i) const {
+        return std::string_view((*this)[i]);
+    }
+};
+
+class ChunkedArrayColumn : public ChunkedColumnBase {
+ public:
+    // memory mode ctor
+    ChunkedArrayColumn(const FieldMeta& field_meta)
+        : ChunkedColumnBase(field_meta) {
+    }
+
+    ChunkedArrayColumn(ChunkedArrayColumn&& column) noexcept
+        : ChunkedColumnBase(std::move(column)) {
+    }
+
+    ChunkedArrayColumn(std::vector<std::shared_ptr<Chunk>> chunks) {
+        for (auto& chunk : chunks) {
+            AddChunk(chunk);
+        }
+    }
+
+    ~ChunkedArrayColumn() override = default;
+
+    SpanBase
+    Span(int64_t chunk_id) const override {
+        return std::dynamic_pointer_cast<ArrayChunk>(chunks_[chunk_id])->Span();
+    }
+
+    ArrayView
+    operator[](const int i) const {
+        auto [chunk_id, offset_in_chunk] = GetChunkIDByOffset(i);
+        return std::dynamic_pointer_cast<ArrayChunk>(chunks_[chunk_id])
+            ->View(offset_in_chunk);
+    }
+
+    ScalarArray
+    RawAt(const int i) const {
+        auto [chunk_id, offset_in_chunk] = GetChunkIDByOffset(i);
+        return std::dynamic_pointer_cast<ArrayChunk>(chunks_[chunk_id])
+            ->View(offset_in_chunk)
+            .output_data();
+    }
+};
+}  // namespace milvus

--- a/internal/core/src/query/SearchOnSealed.cpp
+++ b/internal/core/src/query/SearchOnSealed.cpp
@@ -9,11 +9,15 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
+#include <algorithm>
 #include <cmath>
 #include <string>
 
+#include "bitset/detail/element_wise.h"
+#include "common/BitsetView.h"
 #include "common/QueryInfo.h"
 #include "common/Types.h"
+#include "mmap/Column.h"
 #include "query/SearchBruteForce.h"
 #include "query/SearchOnSealed.h"
 #include "query/helper.h"
@@ -71,6 +75,95 @@ SearchOnSealedIndex(const Schema& schema,
     }
     search_result.total_nq_ = num_queries;
     search_result.unity_topK_ = topK;
+}
+
+void
+SearchOnSealed(const Schema& schema,
+               std::shared_ptr<ChunkedColumnBase> column,
+               const SearchInfo& search_info,
+               const void* query_data,
+               int64_t num_queries,
+               int64_t row_count,
+               const BitsetView& bitview,
+               SearchResult& result) {
+    auto field_id = search_info.field_id_;
+    auto& field = schema[field_id];
+
+    // TODO(SPARSE): see todo in PlanImpl.h::PlaceHolder.
+    auto dim = field.get_data_type() == DataType::VECTOR_SPARSE_FLOAT
+                   ? 0
+                   : field.get_dim();
+
+    query::dataset::SearchDataset dataset{search_info.metric_type_,
+                                          num_queries,
+                                          search_info.topk_,
+                                          search_info.round_decimal_,
+                                          dim,
+                                          query_data};
+
+    auto data_type = field.get_data_type();
+    CheckBruteForceSearchParam(field, search_info);
+    auto num_chunk = column->num_chunks();
+
+    SubSearchResult final_qr(num_queries,
+                             search_info.topk_,
+                             search_info.metric_type_,
+                             search_info.round_decimal_);
+
+    auto offset = 0;
+    for (int i = 0; i < num_chunk; ++i) {
+        auto vec_data = column->Data(i);
+        auto chunk_size = column->chunk_row_nums(i);
+        const uint8_t* bitset_ptr = nullptr;
+        bool aligned = false;
+        if ((offset & 0x7) == 0) {
+            bitset_ptr = bitview.data() + (offset >> 3);
+            aligned = true;
+        } else {
+            char* bitset_data = new char[(chunk_size + 7) / 8];
+            std::fill(bitset_data, bitset_data + sizeof(bitset_data), 0);
+            bitset::detail::ElementWiseBitsetPolicy<char>::op_copy(
+                reinterpret_cast<const char*>(bitview.data()),
+                offset,
+                bitset_data,
+                0,
+                chunk_size);
+            bitset_ptr = reinterpret_cast<const uint8_t*>(bitset_data);
+        }
+        offset += chunk_size;
+        BitsetView bitset_view(bitset_ptr, chunk_size);
+
+        if (search_info.group_by_field_id_.has_value()) {
+            auto sub_qr = BruteForceSearchIterators(dataset,
+                                                    vec_data,
+                                                    row_count,
+                                                    search_info,
+                                                    bitset_view,
+                                                    data_type);
+            final_qr.merge(sub_qr);
+        } else {
+            auto sub_qr = BruteForceSearch(dataset,
+                                           vec_data,
+                                           row_count,
+                                           search_info,
+                                           bitset_view,
+                                           data_type);
+            final_qr.merge(sub_qr);
+        }
+
+        if (!aligned) {
+            delete[] bitset_ptr;
+        }
+    }
+    if (search_info.group_by_field_id_.has_value()) {
+        result.AssembleChunkVectorIterators(
+            num_queries, 1, -1, final_qr.chunk_iterators());
+    } else {
+        result.distances_ = std::move(final_qr.mutable_distances());
+        result.seg_offsets_ = std::move(final_qr.mutable_seg_offsets());
+    }
+    result.unity_topK_ = dataset.topk;
+    result.total_nq_ = dataset.num_queries;
 }
 
 void

--- a/internal/core/src/query/SearchOnSealed.h
+++ b/internal/core/src/query/SearchOnSealed.h
@@ -29,6 +29,16 @@ SearchOnSealedIndex(const Schema& schema,
 
 void
 SearchOnSealed(const Schema& schema,
+               std::shared_ptr<ChunkedColumnBase> column,
+               const SearchInfo& search_info,
+               const void* query_data,
+               int64_t num_queries,
+               int64_t row_count,
+               const BitsetView& bitset,
+               SearchResult& result);
+
+void
+SearchOnSealed(const Schema& schema,
                const void* vec_data,
                const SearchInfo& search_info,
                const void* query_data,

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -9,8 +9,9 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
-#include "SegmentSealedImpl.h"
+#include "ChunkedSegmentSealedImpl.h"
 
+#include <arrow/record_batch.h>
 #include <fcntl.h>
 #include <fmt/core.h>
 #include <sys/stat.h>
@@ -21,14 +22,14 @@
 #include <memory>
 #include <string>
 #include <string_view>
-#include <tuple>
 #include <unordered_map>
 #include <vector>
-#include <boost/pointer_cast.hpp>
 
 #include "Utils.h"
 #include "Types.h"
 #include "common/Array.h"
+#include "common/Chunk.h"
+#include "common/ChunkWriter.h"
 #include "common/Consts.h"
 #include "common/EasyAssert.h"
 #include "common/FieldData.h"
@@ -40,7 +41,7 @@
 #include "common/Types.h"
 #include "google/protobuf/message_lite.h"
 #include "index/VectorMemIndex.h"
-#include "mmap/Column.h"
+#include "mmap/ChunkedColumn.h"
 #include "mmap/Utils.h"
 #include "mmap/Types.h"
 #include "log/Log.h"
@@ -48,6 +49,7 @@
 #include "query/ScalarIndex.h"
 #include "query/SearchBruteForce.h"
 #include "query/SearchOnSealed.h"
+#include "storage/DataCodec.h"
 #include "storage/Util.h"
 #include "storage/ThreadPools.h"
 #include "storage/MmapManager.h"
@@ -70,7 +72,7 @@ get_bit(const BitsetType& bitset, FieldId field_id) {
 }
 
 void
-SegmentSealedImpl::LoadIndex(const LoadIndexInfo& info) {
+ChunkedSegmentSealedImpl::LoadIndex(const LoadIndexInfo& info) {
     // print(info);
     // NOTE: lock only when data is ready to avoid starvation
     auto field_id = FieldId(info.field_id);
@@ -84,7 +86,7 @@ SegmentSealedImpl::LoadIndex(const LoadIndexInfo& info) {
 }
 
 void
-SegmentSealedImpl::LoadVecIndex(const LoadIndexInfo& info) {
+ChunkedSegmentSealedImpl::LoadVecIndex(const LoadIndexInfo& info) {
     // NOTE: lock only when data is ready to avoid starvation
     auto field_id = FieldId(info.field_id);
     auto& field_meta = schema_->operator[](field_id);
@@ -130,7 +132,8 @@ SegmentSealedImpl::LoadVecIndex(const LoadIndexInfo& info) {
 }
 
 void
-SegmentSealedImpl::WarmupChunkCache(const FieldId field_id, bool mmap_enabled) {
+ChunkedSegmentSealedImpl::WarmupChunkCache(const FieldId field_id,
+                                           bool mmap_enabled) {
     auto& field_meta = schema_->operator[](field_id);
     AssertInfo(field_meta.is_vector(), "vector field is not vector type");
 
@@ -154,18 +157,13 @@ SegmentSealedImpl::WarmupChunkCache(const FieldId field_id, bool mmap_enabled) {
     auto field_info = it->second;
 
     auto cc = storage::MmapManager::GetInstance().GetChunkCache();
-    bool mmap_rss_not_need = true;
     for (const auto& data_path : field_info.insert_files) {
-        auto column = cc->Read(data_path,
-                               mmap_descriptor_,
-                               field_meta,
-                               mmap_enabled,
-                               mmap_rss_not_need);
+        auto column = cc->Read(data_path, mmap_descriptor_, field_meta);
     }
 }
 
 void
-SegmentSealedImpl::LoadScalarIndex(const LoadIndexInfo& info) {
+ChunkedSegmentSealedImpl::LoadScalarIndex(const LoadIndexInfo& info) {
     // NOTE: lock only when data is ready to avoid starvation
     auto field_id = FieldId(info.field_id);
     auto& field_meta = schema_->operator[](field_id);
@@ -240,7 +238,7 @@ SegmentSealedImpl::LoadScalarIndex(const LoadIndexInfo& info) {
 }
 
 void
-SegmentSealedImpl::LoadFieldData(const LoadFieldDataInfo& load_info) {
+ChunkedSegmentSealedImpl::LoadFieldData(const LoadFieldDataInfo& load_info) {
     // NOTE: lock only when data is ready to avoid starvation
     // only one field for now, parallel load field data in golang
     size_t num_rows = storage::GetNumRowsForLoadInfo(load_info);
@@ -257,8 +255,8 @@ SegmentSealedImpl::LoadFieldData(const LoadFieldDataInfo& load_info) {
                              std::stol(b.substr(b.find_last_of('/') + 1));
                   });
 
-        auto field_data_info =
-            FieldDataInfo(field_id.get(), num_rows, load_info.mmap_dir_path);
+        auto field_data_info = FieldDataInfo(
+            field_id.get(), num_rows, load_info.mmap_dir_path, false);
         LOG_INFO("segment {} loads field {} with num_rows {}",
                  this->get_segment_id(),
                  field_id.get(),
@@ -266,11 +264,12 @@ SegmentSealedImpl::LoadFieldData(const LoadFieldDataInfo& load_info) {
 
         auto parallel_degree = static_cast<uint64_t>(
             DEFAULT_FIELD_MAX_MEMORY_LIMIT / FILE_SLICE_SIZE);
-        field_data_info.channel->set_capacity(parallel_degree * 2);
+        field_data_info.arrow_reader_channel->set_capacity(parallel_degree * 2);
         auto& pool =
             ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::MIDDLE);
-        pool.Submit(
-            LoadFieldDatasFromRemote, insert_files, field_data_info.channel);
+        pool.Submit(LoadArrowReaderFromRemote,
+                    insert_files,
+                    field_data_info.arrow_reader_channel);
 
         LOG_INFO("segment {} submits load field {} task to thread pool",
                  this->get_segment_id(),
@@ -291,7 +290,7 @@ SegmentSealedImpl::LoadFieldData(const LoadFieldDataInfo& load_info) {
 }
 
 void
-SegmentSealedImpl::LoadFieldData(FieldId field_id, FieldDataInfo& data) {
+ChunkedSegmentSealedImpl::LoadFieldData(FieldId field_id, FieldDataInfo& data) {
     auto num_rows = data.row_count;
     if (SystemProperty::Instance().IsSystem(field_id)) {
         auto system_field_type =
@@ -299,14 +298,25 @@ SegmentSealedImpl::LoadFieldData(FieldId field_id, FieldDataInfo& data) {
         if (system_field_type == SystemFieldType::Timestamp) {
             std::vector<Timestamp> timestamps(num_rows);
             int64_t offset = 0;
-            auto field_data = storage::CollectFieldDataChannel(data.channel);
-            for (auto& data : field_data) {
-                int64_t row_count = data->get_num_rows();
-                std::copy_n(static_cast<const Timestamp*>(data->Data()),
-                            row_count,
+            FieldMeta field_meta(
+                FieldName(""), FieldId(0), DataType::INT64, false);
+            std::shared_ptr<milvus::ArrowDataWrapper> r;
+            while (data.arrow_reader_channel->pop(r)) {
+                auto chunk = std::dynamic_pointer_cast<FixedWidthChunk>(
+                    create_chunk(field_meta, 1, r->reader));
+                std::copy_n(static_cast<const Timestamp*>(chunk->Span().data()),
+                            chunk->Span().row_count(),
                             timestamps.data() + offset);
-                offset += row_count;
+                offset += chunk->Span().row_count();
             }
+
+            // for (auto& data : field_data) {
+            //     int64_t row_count = data->get_num_rows();
+            //     std::copy_n(static_cast<const Timestamp*>(data->Data()),
+            //                 row_count,
+            //                 timestamps.data() + offset);
+            //     offset += row_count;
+            // }
 
             TimestampIndex index;
             auto min_slice_length = num_rows < 4096 ? 1 : 4096;
@@ -319,7 +329,8 @@ SegmentSealedImpl::LoadFieldData(FieldId field_id, FieldDataInfo& data) {
             // use special index
             std::unique_lock lck(mutex_);
             AssertInfo(insert_record_.timestamps_.empty(), "already exists");
-            insert_record_.timestamps_.fill_chunk_data(field_data);
+            insert_record_.timestamps_.set_data_raw(
+                0, timestamps.data(), timestamps.size());
             insert_record_.timestamp_index_ = std::move(index);
             AssertInfo(insert_record_.timestamps_.num_chunk() == 1,
                        "num chunk not equal to 1 for sealed segment");
@@ -328,7 +339,10 @@ SegmentSealedImpl::LoadFieldData(FieldId field_id, FieldDataInfo& data) {
             AssertInfo(system_field_type == SystemFieldType::RowId,
                        "System field type of id column is not RowId");
             // Consume rowid field data but not really load it
-            storage::CollectFieldDataChannel(data.channel);
+            // storage::CollectFieldDataChannel(data.arrow_reader_channel);
+            std::shared_ptr<milvus::ArrowDataWrapper> r;
+            while (data.arrow_reader_channel->pop(r)) {
+            }
         }
         ++system_ready_count_;
     } else {
@@ -345,74 +359,79 @@ SegmentSealedImpl::LoadFieldData(FieldId field_id, FieldDataInfo& data) {
                        : DEFAULT_MEM_VRCOL_BLOCK_SIZE;
         };
 
-        std::shared_ptr<SingleChunkColumnBase> column{};
+        std::shared_ptr<ChunkedColumnBase> column{};
         if (IsVariableDataType(data_type)) {
             int64_t field_data_size = 0;
             switch (data_type) {
                 case milvus::DataType::STRING:
                 case milvus::DataType::VARCHAR: {
-                    auto var_column = std::make_shared<
-                        SingleChunkVariableColumn<std::string>>(
-                        num_rows, field_meta, get_block_size());
-                    FieldDataPtr field_data;
-                    while (data.channel->pop(field_data)) {
-                        var_column->Append(std::move(field_data));
+                    auto var_column =
+                        std::make_shared<ChunkedVariableColumn<std::string>>(
+                            field_meta);
+                    std::shared_ptr<milvus::ArrowDataWrapper> r;
+                    while (data.arrow_reader_channel->pop(r)) {
+                        auto chunk = create_chunk(field_meta, 1, r->reader);
+                        var_column->AddChunk(chunk);
                     }
-                    var_column->Seal();
+                    // var_column->Seal();
                     field_data_size = var_column->DataByteSize();
-                    stats_.mem_size += var_column->MemoryUsageBytes();
+                    stats_.mem_size += var_column->DataByteSize();
                     LoadStringSkipIndex(field_id, 0, *var_column);
                     column = std::move(var_column);
                     break;
                 }
                 case milvus::DataType::JSON: {
-                    auto var_column = std::make_shared<
-                        SingleChunkVariableColumn<milvus::Json>>(
-                        num_rows, field_meta, get_block_size());
-                    FieldDataPtr field_data;
-                    while (data.channel->pop(field_data)) {
-                        var_column->Append(std::move(field_data));
+                    auto var_column =
+                        std::make_shared<ChunkedVariableColumn<milvus::Json>>(
+                            field_meta);
+                    std::shared_ptr<milvus::ArrowDataWrapper> r;
+                    while (data.arrow_reader_channel->pop(r)) {
+                        auto chunk = create_chunk(field_meta, 1, r->reader);
+                        var_column->AddChunk(chunk);
                     }
-                    var_column->Seal();
-                    stats_.mem_size += var_column->MemoryUsageBytes();
+                    // var_column->Seal();
+                    stats_.mem_size += var_column->DataByteSize();
                     field_data_size = var_column->DataByteSize();
                     column = std::move(var_column);
                     break;
                 }
                 case milvus::DataType::ARRAY: {
-                    auto var_column = std::make_shared<SingleChunkArrayColumn>(
-                        num_rows, field_meta);
-                    FieldDataPtr field_data;
-                    while (data.channel->pop(field_data)) {
-                        for (auto i = 0; i < field_data->get_num_rows(); i++) {
-                            auto rawValue = field_data->RawValue(i);
-                            auto array =
-                                static_cast<const milvus::Array*>(rawValue);
-                            if (field_data->IsNullable()) {
-                                var_column->Append(*array,
-                                                   field_data->is_valid(i));
-                            } else {
-                                var_column->Append(*array);
-                            }
+                    auto var_column =
+                        std::make_shared<ChunkedArrayColumn>(field_meta);
+                    std::shared_ptr<milvus::ArrowDataWrapper> r;
+                    while (data.arrow_reader_channel->pop(r)) {
+                        // for (auto i = 0; i < field_data->get_num_rows(); i++) {
+                        //     auto rawValue = field_data->RawValue(i);
+                        //     auto array =
+                        //         static_cast<const milvus::Array*>(rawValue);
+                        //     if (field_data->IsNullable()) {
+                        //         var_column->Append(*array,
+                        //                            field_data->is_valid(i));
+                        //     } else {
+                        //         var_column->Append(*array);
+                        //     }
 
-                            // we stores the offset for each array element, so there is a additional uint64_t for each array element
-                            field_data_size =
-                                array->byte_size() + sizeof(uint64_t);
-                            stats_.mem_size +=
-                                array->byte_size() + sizeof(uint64_t);
-                        }
+                        //     // we stores the offset for each array element, so there is a additional uint64_t for each array element
+                        //     field_data_size =
+                        //         array->byte_size() + sizeof(uint64_t);
+                        //     stats_.mem_size +=
+                        //         array->byte_size() + sizeof(uint64_t);
+                        // }
+
+                        auto chunk = create_chunk(field_meta, 1, r->reader);
+                        var_column->AddChunk(chunk);
                     }
-                    var_column->Seal();
+                    // var_column->Seal();
                     column = std::move(var_column);
                     break;
                 }
                 case milvus::DataType::VECTOR_SPARSE_FLOAT: {
-                    auto col = std::make_shared<SingleChunkSparseFloatColumn>(
-                        field_meta);
-                    FieldDataPtr field_data;
-                    while (data.channel->pop(field_data)) {
-                        stats_.mem_size += field_data->Size();
-                        col->AppendBatch(field_data);
+                    auto col =
+                        std::make_shared<ChunkedSparseFloatColumn>(field_meta);
+                    std::shared_ptr<milvus::ArrowDataWrapper> r;
+                    while (data.arrow_reader_channel->pop(r)) {
+                        auto chunk = create_chunk(field_meta, 1, r->reader);
+                        col->AddChunk(chunk);
                     }
                     column = std::move(col);
                     break;
@@ -427,18 +446,29 @@ SegmentSealedImpl::LoadFieldData(FieldId field_id, FieldDataInfo& data) {
             SegmentInternalInterface::set_field_avg_size(
                 field_id, num_rows, field_data_size);
         } else {
-            column = std::make_shared<SingleChunkColumn>(num_rows, field_meta);
-            FieldDataPtr field_data;
-            while (data.channel->pop(field_data)) {
-                column->AppendBatch(field_data);
-                stats_.mem_size += field_data->Size();
+            column = std::make_shared<ChunkedColumn>(field_meta);
+            std::shared_ptr<milvus::ArrowDataWrapper> r;
+            while (data.arrow_reader_channel->pop(r)) {
+                auto chunk =
+                    create_chunk(field_meta,
+                                 IsVectorDataType(field_meta.get_data_type())
+                                     ? field_meta.get_dim()
+                                     : 1,
+                                 r->reader);
+                // column->AppendBatch(field_data);
+                // stats_.mem_size += field_data->Size();
+                column->AddChunk(chunk);
             }
-            LoadPrimitiveSkipIndex(field_id,
-                                   0,
-                                   data_type,
-                                   column->Span().data(),
-                                   column->Span().valid_data(),
-                                   num_rows);
+
+            auto num_chunk = column->num_chunks();
+            for (int i = 0; i < num_chunk; ++i) {
+                LoadPrimitiveSkipIndex(field_id,
+                                       i,
+                                       data_type,
+                                       column->Span(i).data(),
+                                       column->Span(i).valid_data(),
+                                       column->Span(i).row_count());
+            }
         }
 
         AssertInfo(column->NumRows() == num_rows,
@@ -454,8 +484,6 @@ SegmentSealedImpl::LoadFieldData(FieldId field_id, FieldDataInfo& data) {
         }
 
         // set pks to offset
-        // if the segments are already sorted by pk, there is no need to build a pk offset index.
-        // it can directly perform a binary search on the pk column.
         if (schema_->get_primary_field_id() == field_id && !is_sorted_by_pk_) {
             AssertInfo(field_id.get() != -1, "Primary key is -1");
             AssertInfo(insert_record_.empty_pks(), "already exists");
@@ -489,8 +517,9 @@ SegmentSealedImpl::LoadFieldData(FieldId field_id, FieldDataInfo& data) {
 }
 
 void
-SegmentSealedImpl::MapFieldData(const FieldId field_id, FieldDataInfo& data) {
-    auto filepath = std::filesystem::path(data.mmap_dir_path) / "raw_data" /
+ChunkedSegmentSealedImpl::MapFieldData(const FieldId field_id,
+                                       FieldDataInfo& data) {
+    auto filepath = std::filesystem::path(data.mmap_dir_path) /
                     std::to_string(get_segment_id()) /
                     std::to_string(field_id.get());
     auto dir = filepath.parent_path();
@@ -502,60 +531,70 @@ SegmentSealedImpl::MapFieldData(const FieldId field_id, FieldDataInfo& data) {
     auto data_type = field_meta.get_data_type();
 
     // write the field data to disk
-    FieldDataPtr field_data;
     uint64_t total_written = 0;
     std::vector<uint64_t> indices{};
     std::vector<std::vector<uint64_t>> element_indices{};
-    FixedVector<bool> valid_data{};
-    while (data.channel->pop(field_data)) {
-        WriteFieldData(file,
-                       data_type,
-                       field_data,
-                       total_written,
-                       indices,
-                       element_indices,
-                       valid_data);
+    // FixedVector<bool> valid_data{};
+    std::shared_ptr<milvus::ArrowDataWrapper> r;
+
+    size_t file_offset = 0;
+    std::vector<std::shared_ptr<Chunk>> chunks;
+    while (data.arrow_reader_channel->pop(r)) {
+        // WriteFieldData(file,
+        //                data_type,
+        //                field_data,
+        //                total_written,
+        //                indices,
+        //                element_indices,
+        //                valid_data);
+        auto chunk = create_chunk(field_meta,
+                                  IsVectorDataType(field_meta.get_data_type())
+                                      ? field_meta.get_dim()
+                                      : 1,
+                                  file,
+                                  file_offset,
+                                  r->reader);
+        file_offset += chunk->Size();
+        chunks.push_back(chunk);
     }
-    WriteFieldPadding(file, data_type, total_written);
-    std::shared_ptr<SingleChunkColumnBase> column{};
+    // WriteFieldPadding(file, data_type, total_written);
+    std::shared_ptr<ChunkedColumnBase> column{};
     auto num_rows = data.row_count;
     if (IsVariableDataType(data_type)) {
         switch (data_type) {
             case milvus::DataType::STRING:
             case milvus::DataType::VARCHAR: {
+                // auto var_column = std::make_shared<VariableColumn<std::string>>(
+                //     file,
+                //     total_written,
+                //     field_meta,
+                //     DEFAULT_MMAP_VRCOL_BLOCK_SIZE);
                 auto var_column =
-                    std::make_shared<SingleChunkVariableColumn<std::string>>(
-                        file,
-                        total_written,
-                        field_meta,
-                        DEFAULT_MMAP_VRCOL_BLOCK_SIZE);
-                var_column->Seal(std::move(indices));
+                    std::make_shared<ChunkedVariableColumn<std::string>>(
+                        chunks);
+                // var_column->Seal(std::move(indices));
                 column = std::move(var_column);
                 break;
             }
             case milvus::DataType::JSON: {
                 auto var_column =
-                    std::make_shared<SingleChunkVariableColumn<milvus::Json>>(
-                        file,
-                        total_written,
-                        field_meta,
-                        DEFAULT_MMAP_VRCOL_BLOCK_SIZE);
-                var_column->Seal(std::move(indices));
+                    std::make_shared<ChunkedVariableColumn<milvus::Json>>(
+                        chunks);
+                // var_column->Seal(std::move(indices));
                 column = std::move(var_column);
                 break;
             }
             case milvus::DataType::ARRAY: {
-                auto arr_column = std::make_shared<SingleChunkArrayColumn>(
-                    file, total_written, field_meta);
-                arr_column->Seal(std::move(indices),
-                                 std::move(element_indices));
+                auto arr_column = std::make_shared<ChunkedArrayColumn>(chunks);
+                // arr_column->Seal(std::move(indices),
+                //                  std::move(element_indices));
                 column = std::move(arr_column);
                 break;
             }
             case milvus::DataType::VECTOR_SPARSE_FLOAT: {
                 auto sparse_column =
-                    std::make_shared<SingleChunkSparseFloatColumn>(
-                        file, total_written, field_meta, std::move(indices));
+                    std::make_shared<ChunkedSparseFloatColumn>(chunks);
+                // sparse_column->Seal(std::move(indices));
                 column = std::move(sparse_column);
                 break;
             }
@@ -565,11 +604,10 @@ SegmentSealedImpl::MapFieldData(const FieldId field_id, FieldDataInfo& data) {
             }
         }
     } else {
-        column = std::make_shared<SingleChunkColumn>(
-            file, total_written, field_meta);
+        column = std::make_shared<ChunkedColumn>(chunks);
     }
 
-    column->SetValidData(std::move(valid_data));
+    // column->SetValidData(std::move(valid_data));
 
     {
         std::unique_lock lck(mutex_);
@@ -584,7 +622,6 @@ SegmentSealedImpl::MapFieldData(const FieldId field_id, FieldDataInfo& data) {
                            strerror(errno)));
 
     // set pks to offset
-    // no need pk
     if (schema_->get_primary_field_id() == field_id && !is_sorted_by_pk_) {
         AssertInfo(field_id.get() != -1, "Primary key is -1");
         AssertInfo(insert_record_.empty_pks(), "already exists");
@@ -597,7 +634,7 @@ SegmentSealedImpl::MapFieldData(const FieldId field_id, FieldDataInfo& data) {
 }
 
 void
-SegmentSealedImpl::LoadDeletedRecord(const LoadDeletedRecordInfo& info) {
+ChunkedSegmentSealedImpl::LoadDeletedRecord(const LoadDeletedRecordInfo& info) {
     AssertInfo(info.row_count > 0, "The row count of deleted record is 0");
     AssertInfo(info.primary_keys, "Deleted primary keys is null");
     AssertInfo(info.timestamps, "Deleted timestamps is null");
@@ -645,7 +682,7 @@ SegmentSealedImpl::LoadDeletedRecord(const LoadDeletedRecordInfo& info) {
 }
 
 void
-SegmentSealedImpl::AddFieldDataInfoForSealed(
+ChunkedSegmentSealedImpl::AddFieldDataInfoForSealed(
     const LoadFieldDataInfo& field_data_info) {
     // copy assignment
     field_data_info_ = field_data_info;
@@ -653,7 +690,7 @@ SegmentSealedImpl::AddFieldDataInfoForSealed(
 
 // internal API: support scalar index only
 int64_t
-SegmentSealedImpl::num_chunk_index(FieldId field_id) const {
+ChunkedSegmentSealedImpl::num_chunk_index(FieldId field_id) const {
     auto& field_meta = schema_->operator[](field_id);
     if (field_meta.is_vector()) {
         return int64_t(vector_indexings_.is_ready(field_id));
@@ -663,25 +700,50 @@ SegmentSealedImpl::num_chunk_index(FieldId field_id) const {
 }
 
 int64_t
-SegmentSealedImpl::num_chunk_data(FieldId field_id) const {
-    return get_bit(field_data_ready_bitset_, field_id) ? 1 : 0;
+ChunkedSegmentSealedImpl::num_chunk_data(FieldId field_id) const {
+    return fields_.at(field_id)->num_chunks();
 }
 
 int64_t
-SegmentSealedImpl::num_chunk(FieldId field_id) const {
-    return 1;
+ChunkedSegmentSealedImpl::num_chunk(FieldId field_id) const {
+    return get_bit(field_data_ready_bitset_, field_id)
+               ? fields_.find(field_id) != fields_.end()
+                     ? fields_.at(field_id)->num_chunks()
+                     : 1
+               : 0;
 }
 
 int64_t
-SegmentSealedImpl::size_per_chunk() const {
+ChunkedSegmentSealedImpl::size_per_chunk() const {
     return get_row_count();
 }
 
+int64_t
+ChunkedSegmentSealedImpl::chunk_size(FieldId field_id, int64_t chunk_id) const {
+    return get_bit(field_data_ready_bitset_, field_id)
+               ? fields_.find(field_id) != fields_.end()
+                     ? fields_.at(field_id)->chunk_row_nums(chunk_id)
+                     : num_rows_.value()
+               : 0;
+}
+
+std::pair<int64_t, int64_t>
+ChunkedSegmentSealedImpl::get_chunk_by_offset(FieldId field_id,
+                                              int64_t offset) const {
+    return fields_.at(field_id)->GetChunkIDByOffset(offset);
+}
+
+int64_t
+ChunkedSegmentSealedImpl::num_rows_until_chunk(FieldId field_id,
+                                               int64_t chunk_id) const {
+    return fields_.at(field_id)->GetNumRowsUntilChunk(chunk_id);
+}
+
 std::pair<BufferView, FixedVector<bool>>
-SegmentSealedImpl::get_chunk_buffer(FieldId field_id,
-                                    int64_t chunk_id,
-                                    int64_t start_offset,
-                                    int64_t length) const {
+ChunkedSegmentSealedImpl::get_chunk_buffer(FieldId field_id,
+                                           int64_t chunk_id,
+                                           int64_t start_offset,
+                                           int64_t length) const {
     std::shared_lock lck(mutex_);
     AssertInfo(get_bit(field_data_ready_bitset_, field_id),
                "Can't get bitset element at " + std::to_string(field_id.get()));
@@ -703,20 +765,21 @@ SegmentSealedImpl::get_chunk_buffer(FieldId field_id,
 }
 
 bool
-SegmentSealedImpl::is_mmap_field(FieldId field_id) const {
+ChunkedSegmentSealedImpl::is_mmap_field(FieldId field_id) const {
     std::shared_lock lck(mutex_);
     return mmap_fields_.find(field_id) != mmap_fields_.end();
 }
 
 SpanBase
-SegmentSealedImpl::chunk_data_impl(FieldId field_id, int64_t chunk_id) const {
+ChunkedSegmentSealedImpl::chunk_data_impl(FieldId field_id,
+                                          int64_t chunk_id) const {
     std::shared_lock lck(mutex_);
     AssertInfo(get_bit(field_data_ready_bitset_, field_id),
                "Can't get bitset element at " + std::to_string(field_id.get()));
     auto& field_meta = schema_->operator[](field_id);
     if (auto it = fields_.find(field_id); it != fields_.end()) {
         auto& field_data = it->second;
-        return field_data->Span();
+        return field_data->Span(chunk_id);
     }
     auto field_data = insert_record_.get_data_base(field_id);
     AssertInfo(field_data->num_chunk() == 1,
@@ -726,21 +789,23 @@ SegmentSealedImpl::chunk_data_impl(FieldId field_id, int64_t chunk_id) const {
 }
 
 std::pair<std::vector<std::string_view>, FixedVector<bool>>
-SegmentSealedImpl::chunk_view_impl(FieldId field_id, int64_t chunk_id) const {
+ChunkedSegmentSealedImpl::chunk_view_impl(FieldId field_id,
+                                          int64_t chunk_id) const {
     std::shared_lock lck(mutex_);
     AssertInfo(get_bit(field_data_ready_bitset_, field_id),
                "Can't get bitset element at " + std::to_string(field_id.get()));
     auto& field_meta = schema_->operator[](field_id);
     if (auto it = fields_.find(field_id); it != fields_.end()) {
         auto& field_data = it->second;
-        return field_data->StringViews();
+        return field_data->StringViews(chunk_id);
     }
     PanicInfo(ErrorCode::UnexpectedError,
               "chunk_view_impl only used for variable column field ");
 }
 
 const index::IndexBase*
-SegmentSealedImpl::chunk_index_impl(FieldId field_id, int64_t chunk_id) const {
+ChunkedSegmentSealedImpl::chunk_index_impl(FieldId field_id,
+                                           int64_t chunk_id) const {
     AssertInfo(scalar_indexings_.find(field_id) != scalar_indexings_.end(),
                "Cannot find scalar_indexing with field_id: " +
                    std::to_string(field_id.get()));
@@ -749,24 +814,352 @@ SegmentSealedImpl::chunk_index_impl(FieldId field_id, int64_t chunk_id) const {
 }
 
 int64_t
-SegmentSealedImpl::get_row_count() const {
+ChunkedSegmentSealedImpl::get_row_count() const {
     std::shared_lock lck(mutex_);
     return num_rows_.value_or(0);
 }
 
 int64_t
-SegmentSealedImpl::get_deleted_count() const {
+ChunkedSegmentSealedImpl::get_deleted_count() const {
     std::shared_lock lck(mutex_);
     return deleted_record_.size();
 }
 
 const Schema&
-SegmentSealedImpl::get_schema() const {
+ChunkedSegmentSealedImpl::get_schema() const {
     return *schema_;
 }
 
+void
+ChunkedSegmentSealedImpl::mask_with_delete(BitsetTypeView& bitset,
+                                           int64_t ins_barrier,
+                                           Timestamp timestamp) const {
+    auto del_barrier = get_barrier(get_deleted_record(), timestamp);
+    if (del_barrier == 0) {
+        return;
+    }
+
+    auto bitmap_holder = std::shared_ptr<DeletedRecord::TmpBitmap>();
+
+    if (!is_sorted_by_pk_) {
+        bitmap_holder = get_deleted_bitmap(del_barrier,
+                                           ins_barrier,
+                                           deleted_record_,
+                                           insert_record_,
+                                           timestamp);
+    } else {
+        bitmap_holder = get_deleted_bitmap_s(
+            del_barrier, ins_barrier, deleted_record_, timestamp);
+    }
+    if (!bitmap_holder || !bitmap_holder->bitmap_ptr) {
+        return;
+    }
+    auto& delete_bitset = *bitmap_holder->bitmap_ptr;
+    AssertInfo(
+        delete_bitset.size() == bitset.size(),
+        fmt::format(
+            "Deleted bitmap size:{} not equal to filtered bitmap size:{}",
+            delete_bitset.size(),
+            bitset.size()));
+    bitset |= delete_bitset;
+}
+
+void
+ChunkedSegmentSealedImpl::vector_search(SearchInfo& search_info,
+                                        const void* query_data,
+                                        int64_t query_count,
+                                        Timestamp timestamp,
+                                        const BitsetView& bitset,
+                                        SearchResult& output) const {
+    AssertInfo(is_system_field_ready(), "System field is not ready");
+    auto field_id = search_info.field_id_;
+    auto& field_meta = schema_->operator[](field_id);
+
+    AssertInfo(field_meta.is_vector(),
+               "The meta type of vector field is not vector type");
+    if (get_bit(binlog_index_bitset_, field_id)) {
+        AssertInfo(
+            vec_binlog_config_.find(field_id) != vec_binlog_config_.end(),
+            "The binlog params is not generate.");
+        auto binlog_search_info =
+            vec_binlog_config_.at(field_id)->GetSearchConf(search_info);
+
+        AssertInfo(vector_indexings_.is_ready(field_id),
+                   "vector indexes isn't ready for field " +
+                       std::to_string(field_id.get()));
+        query::SearchOnSealedIndex(*schema_,
+                                   vector_indexings_,
+                                   binlog_search_info,
+                                   query_data,
+                                   query_count,
+                                   bitset,
+                                   output);
+        milvus::tracer::AddEvent(
+            "finish_searching_vector_temperate_binlog_index");
+    } else if (get_bit(index_ready_bitset_, field_id)) {
+        AssertInfo(vector_indexings_.is_ready(field_id),
+                   "vector indexes isn't ready for field " +
+                       std::to_string(field_id.get()));
+        query::SearchOnSealedIndex(*schema_,
+                                   vector_indexings_,
+                                   search_info,
+                                   query_data,
+                                   query_count,
+                                   bitset,
+                                   output);
+        milvus::tracer::AddEvent("finish_searching_vector_index");
+    } else {
+        AssertInfo(
+            get_bit(field_data_ready_bitset_, field_id),
+            "Field Data is not loaded: " + std::to_string(field_id.get()));
+        AssertInfo(num_rows_.has_value(), "Can't get row count value");
+        auto row_count = num_rows_.value();
+        auto vec_data = fields_.at(field_id);
+        query::SearchOnSealed(*schema_,
+                              vec_data,
+                              search_info,
+                              query_data,
+                              query_count,
+                              row_count,
+                              bitset,
+                              output);
+        milvus::tracer::AddEvent("finish_searching_vector_data");
+    }
+}
+
+std::tuple<std::string, int64_t>
+ChunkedSegmentSealedImpl::GetFieldDataPath(FieldId field_id,
+                                           int64_t offset) const {
+    auto offset_in_binlog = offset;
+    auto data_path = std::string();
+    auto it = field_data_info_.field_infos.find(field_id.get());
+    AssertInfo(it != field_data_info_.field_infos.end(),
+               fmt::format("cannot find binlog file for field: {}, seg: {}",
+                           field_id.get(),
+                           id_));
+    auto field_info = it->second;
+
+    for (auto i = 0; i < field_info.insert_files.size(); i++) {
+        if (offset_in_binlog < field_info.entries_nums[i]) {
+            data_path = field_info.insert_files[i];
+            break;
+        } else {
+            offset_in_binlog -= field_info.entries_nums[i];
+        }
+    }
+    return {data_path, offset_in_binlog};
+}
+
+std::tuple<
+    std::string,
+    std::shared_ptr<
+        ChunkedColumnBase>> static ReadFromChunkCache(const storage::
+                                                          ChunkCachePtr& cc,
+                                                      const std::string&
+                                                          data_path,
+                                                      const storage::
+                                                          MmapChunkDescriptorPtr&
+                                                              descriptor,
+                                                      const FieldMeta&
+                                                          field_meta) {
+    auto column = cc->Read(data_path, descriptor, field_meta);
+    cc->Prefetch(data_path);
+    return {data_path, std::dynamic_pointer_cast<ChunkedColumnBase>(column)};
+}
+
+std::unique_ptr<DataArray>
+ChunkedSegmentSealedImpl::get_vector(FieldId field_id,
+                                     const int64_t* ids,
+                                     int64_t count) const {
+    auto& field_meta = schema_->operator[](field_id);
+    AssertInfo(field_meta.is_vector(), "vector field is not vector type");
+
+    if (!get_bit(index_ready_bitset_, field_id) &&
+        !get_bit(binlog_index_bitset_, field_id)) {
+        return fill_with_empty(field_id, count);
+    }
+
+    AssertInfo(vector_indexings_.is_ready(field_id),
+               "vector index is not ready");
+    auto field_indexing = vector_indexings_.get_field_indexing(field_id);
+    auto vec_index =
+        dynamic_cast<index::VectorIndex*>(field_indexing->indexing_.get());
+    AssertInfo(vec_index, "invalid vector indexing");
+
+    auto index_type = vec_index->GetIndexType();
+    auto metric_type = vec_index->GetMetricType();
+    auto has_raw_data = vec_index->HasRawData();
+
+    if (has_raw_data && !TEST_skip_index_for_retrieve_) {
+        // If index has raw data, get vector from memory.
+        auto ids_ds = GenIdsDataset(count, ids);
+        if (field_meta.get_data_type() == DataType::VECTOR_SPARSE_FLOAT) {
+            auto res = vec_index->GetSparseVector(ids_ds);
+            return segcore::CreateVectorDataArrayFrom(
+                res.get(), count, field_meta);
+        } else {
+            // dense vector:
+            auto vector = vec_index->GetVector(ids_ds);
+            return segcore::CreateVectorDataArrayFrom(
+                vector.data(), count, field_meta);
+        }
+    }
+
+    // If index doesn't have raw data, get vector from chunk cache.
+    auto cc = storage::MmapManager::GetInstance().GetChunkCache();
+
+    // group by data_path
+    auto id_to_data_path =
+        std::unordered_map<std::int64_t, std::tuple<std::string, int64_t>>{};
+    auto path_to_column =
+        std::unordered_map<std::string, std::shared_ptr<ChunkedColumnBase>>{};
+    for (auto i = 0; i < count; i++) {
+        const auto& tuple = GetFieldDataPath(field_id, ids[i]);
+        id_to_data_path.emplace(ids[i], tuple);
+        path_to_column.emplace(std::get<0>(tuple), nullptr);
+    }
+
+    // read and prefetch
+    auto& pool = ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::HIGH);
+    std::vector<std::future<
+        std::tuple<std::string, std::shared_ptr<ChunkedColumnBase>>>>
+        futures;
+    futures.reserve(path_to_column.size());
+    for (const auto& iter : path_to_column) {
+        const auto& data_path = iter.first;
+        futures.emplace_back(pool.Submit(
+            ReadFromChunkCache, cc, data_path, mmap_descriptor_, field_meta));
+    }
+
+    for (int i = 0; i < futures.size(); ++i) {
+        const auto& [data_path, column] = futures[i].get();
+        path_to_column[data_path] = column;
+    }
+
+    if (field_meta.get_data_type() == DataType::VECTOR_SPARSE_FLOAT) {
+        auto buf = std::vector<knowhere::sparse::SparseRow<float>>(count);
+        for (auto i = 0; i < count; ++i) {
+            const auto& [data_path, offset_in_binlog] =
+                id_to_data_path.at(ids[i]);
+            const auto& column = path_to_column.at(data_path);
+            AssertInfo(
+                offset_in_binlog < column->NumRows(),
+                "column idx out of range, idx: {}, size: {}, data_path: {}",
+                offset_in_binlog,
+                column->NumRows(),
+                data_path);
+            auto sparse_column =
+                std::dynamic_pointer_cast<ChunkedSparseFloatColumn>(column);
+            AssertInfo(sparse_column, "incorrect column created");
+            buf[i] = *static_cast<const knowhere::sparse::SparseRow<float>*>(
+                static_cast<const void*>(
+                    sparse_column->ValueAt(offset_in_binlog)));
+        }
+        return segcore::CreateVectorDataArrayFrom(
+            buf.data(), count, field_meta);
+    } else {
+        // assign to data array
+        auto row_bytes = field_meta.get_sizeof();
+        auto buf = std::vector<char>(count * row_bytes);
+        for (auto i = 0; i < count; ++i) {
+            AssertInfo(id_to_data_path.count(ids[i]) != 0, "id not found");
+            const auto& [data_path, offset_in_binlog] =
+                id_to_data_path.at(ids[i]);
+            AssertInfo(path_to_column.count(data_path) != 0,
+                       "column not found");
+            const auto& column = path_to_column.at(data_path);
+            AssertInfo(
+                offset_in_binlog * row_bytes < column->DataByteSize(),
+                "column idx out of range, idx: {}, size: {}, data_path: {}",
+                offset_in_binlog * row_bytes,
+                column->DataByteSize(),
+                data_path);
+            auto vector = column->ValueAt(offset_in_binlog);
+            std::memcpy(buf.data() + i * row_bytes, vector, row_bytes);
+        }
+        return segcore::CreateVectorDataArrayFrom(
+            buf.data(), count, field_meta);
+    }
+}
+
+void
+ChunkedSegmentSealedImpl::DropFieldData(const FieldId field_id) {
+    if (SystemProperty::Instance().IsSystem(field_id)) {
+        auto system_field_type =
+            SystemProperty::Instance().GetSystemFieldType(field_id);
+
+        std::unique_lock lck(mutex_);
+        --system_ready_count_;
+        if (system_field_type == SystemFieldType::Timestamp) {
+            insert_record_.timestamps_.clear();
+        }
+        lck.unlock();
+    } else {
+        auto& field_meta = schema_->operator[](field_id);
+        std::unique_lock lck(mutex_);
+        if (get_bit(field_data_ready_bitset_, field_id)) {
+            fields_.erase(field_id);
+            set_bit(field_data_ready_bitset_, field_id, false);
+        }
+        if (get_bit(binlog_index_bitset_, field_id)) {
+            set_bit(binlog_index_bitset_, field_id, false);
+            vector_indexings_.drop_field_indexing(field_id);
+        }
+        lck.unlock();
+    }
+}
+
+void
+ChunkedSegmentSealedImpl::DropIndex(const FieldId field_id) {
+    AssertInfo(!SystemProperty::Instance().IsSystem(field_id),
+               "Field id:" + std::to_string(field_id.get()) +
+                   " isn't one of system type when drop index");
+    auto& field_meta = schema_->operator[](field_id);
+    AssertInfo(field_meta.is_vector(),
+               "Field meta of offset:" + std::to_string(field_id.get()) +
+                   " is not vector type");
+
+    std::unique_lock lck(mutex_);
+    vector_indexings_.drop_field_indexing(field_id);
+    set_bit(index_ready_bitset_, field_id, false);
+}
+
+void
+ChunkedSegmentSealedImpl::check_search(const query::Plan* plan) const {
+    AssertInfo(plan, "Search plan is null");
+    AssertInfo(plan->extra_info_opt_.has_value(),
+               "Extra info of search plan doesn't have value");
+
+    if (!is_system_field_ready()) {
+        PanicInfo(
+            FieldNotLoaded,
+            "failed to load row ID or timestamp, potential missing bin logs or "
+            "empty segments. Segment ID = " +
+                std::to_string(this->id_));
+    }
+
+    auto& request_fields = plan->extra_info_opt_.value().involved_fields_;
+    auto field_ready_bitset =
+        field_data_ready_bitset_ | index_ready_bitset_ | binlog_index_bitset_;
+    AssertInfo(request_fields.size() == field_ready_bitset.size(),
+               "Request fields size not equal to field ready bitset size when "
+               "check search");
+    auto absent_fields = request_fields - field_ready_bitset;
+
+    if (absent_fields.any()) {
+        // absent_fields.find_first() returns std::optional<>
+        auto field_id =
+            FieldId(absent_fields.find_first().value() + START_USER_FIELDID);
+        auto& field_meta = schema_->operator[](field_id);
+        PanicInfo(
+            FieldNotLoaded,
+            "User Field(" + field_meta.get_name().get() + ") is not loaded");
+    }
+}
+
 std::vector<SegOffset>
-SegmentSealedImpl::search_pk(const PkType& pk, Timestamp timestamp) const {
+ChunkedSegmentSealedImpl::search_pk(const PkType& pk,
+                                    Timestamp timestamp) const {
     auto pk_field_id = schema_->get_primary_field_id().value_or(FieldId(-1));
     AssertInfo(pk_field_id.get() != -1, "Primary key is -1");
     auto pk_column = fields_.at(pk_field_id);
@@ -775,18 +1168,22 @@ SegmentSealedImpl::search_pk(const PkType& pk, Timestamp timestamp) const {
         case DataType::INT64: {
             auto target = std::get<int64_t>(pk);
             // get int64 pks
-            auto src = reinterpret_cast<const int64_t*>(pk_column->Data());
-            auto it =
-                std::lower_bound(src,
-                                 src + pk_column->NumRows(),
-                                 target,
-                                 [](const int64_t& elem, const int64_t& value) {
-                                     return elem < value;
-                                 });
-            for (; it != src + pk_column->NumRows() && *it == target; it++) {
-                auto offset = it - src;
-                if (insert_record_.timestamps_[offset] <= timestamp) {
-                    pk_offsets.emplace_back(it - src);
+            auto num_chunk = pk_column->num_chunks();
+            for (int i = 0; i < num_chunk; ++i) {
+                auto src = reinterpret_cast<const int64_t*>(pk_column->Data(i));
+                auto chunk_row_num = pk_column->chunk_row_nums(i);
+                auto it = std::lower_bound(
+                    src,
+                    src + chunk_row_num,
+                    target,
+                    [](const int64_t& elem, const int64_t& value) {
+                        return elem < value;
+                    });
+                for (; it != src + chunk_row_num && *it == target; it++) {
+                    auto offset = it - src;
+                    if (insert_record_.timestamps_[offset] <= timestamp) {
+                        pk_offsets.emplace_back(offset);
+                    }
                 }
             }
             break;
@@ -794,14 +1191,18 @@ SegmentSealedImpl::search_pk(const PkType& pk, Timestamp timestamp) const {
         case DataType::VARCHAR: {
             auto target = std::get<std::string>(pk);
             // get varchar pks
-            auto var_column = std::dynamic_pointer_cast<
-                SingleChunkVariableColumn<std::string>>(pk_column);
-            auto views = var_column->Views();
-            auto it = std::lower_bound(views.begin(), views.end(), target);
-            for (; it != views.end() && *it == target; it++) {
-                auto offset = std::distance(views.begin(), it);
-                if (insert_record_.timestamps_[offset] <= timestamp) {
-                    pk_offsets.emplace_back(offset);
+            auto var_column =
+                std::dynamic_pointer_cast<ChunkedVariableColumn<std::string>>(
+                    pk_column);
+            auto num_chunk = var_column->num_chunks();
+            for (int i = 0; i < num_chunk; ++i) {
+                auto views = var_column->StringViews(i).first;
+                auto it = std::lower_bound(views.begin(), views.end(), target);
+                for (; it != views.end() && *it == target; it++) {
+                    auto offset = std::distance(views.begin(), it);
+                    if (insert_record_.timestamps_[offset] <= timestamp) {
+                        pk_offsets.emplace_back(offset);
+                    }
                 }
             }
             break;
@@ -819,7 +1220,8 @@ SegmentSealedImpl::search_pk(const PkType& pk, Timestamp timestamp) const {
 }
 
 std::vector<SegOffset>
-SegmentSealedImpl::search_pk(const PkType& pk, int64_t insert_barrier) const {
+ChunkedSegmentSealedImpl::search_pk(const PkType& pk,
+                                    int64_t insert_barrier) const {
     auto pk_field_id = schema_->get_primary_field_id().value_or(FieldId(-1));
     AssertInfo(pk_field_id.get() != -1, "Primary key is -1");
     auto pk_column = fields_.at(pk_field_id);
@@ -828,34 +1230,45 @@ SegmentSealedImpl::search_pk(const PkType& pk, int64_t insert_barrier) const {
         case DataType::INT64: {
             auto target = std::get<int64_t>(pk);
             // get int64 pks
-            auto src = reinterpret_cast<const int64_t*>(pk_column->Data());
-            auto it =
-                std::lower_bound(src,
-                                 src + pk_column->NumRows(),
-                                 target,
-                                 [](const int64_t& elem, const int64_t& value) {
-                                     return elem < value;
-                                 });
-            for (; it != src + pk_column->NumRows() && *it == target; it++) {
-                if (it - src < insert_barrier) {
-                    pk_offsets.emplace_back(it - src);
+
+            auto num_chunk = pk_column->num_chunks();
+            for (int i = 0; i < num_chunk; ++i) {
+                auto src = reinterpret_cast<const int64_t*>(pk_column->Data(i));
+                auto chunk_row_num = pk_column->chunk_row_nums(i);
+                auto it = std::lower_bound(
+                    src,
+                    src + chunk_row_num,
+                    target,
+                    [](const int64_t& elem, const int64_t& value) {
+                        return elem < value;
+                    });
+                for (; it != src + chunk_row_num && *it == target; it++) {
+                    auto offset = it - src;
+                    if (offset < insert_barrier) {
+                        pk_offsets.emplace_back(offset);
+                    }
                 }
             }
+
             break;
         }
         case DataType::VARCHAR: {
             auto target = std::get<std::string>(pk);
             // get varchar pks
-            auto var_column = std::dynamic_pointer_cast<
-                SingleChunkVariableColumn<std::string>>(pk_column);
-            auto views = var_column->Views();
-            auto it = std::lower_bound(views.begin(), views.end(), target);
-            while (it != views.end() && *it == target) {
-                auto offset = std::distance(views.begin(), it);
-                if (offset < insert_barrier) {
-                    pk_offsets.emplace_back(offset);
+            auto var_column =
+                std::dynamic_pointer_cast<ChunkedVariableColumn<std::string>>(
+                    pk_column);
+
+            auto num_chunk = var_column->num_chunks();
+            for (int i = 0; i < num_chunk; ++i) {
+                auto views = var_column->StringViews(i).first;
+                auto it = std::lower_bound(views.begin(), views.end(), target);
+                for (; it != views.end() && *it == target; it++) {
+                    auto offset = std::distance(views.begin(), it);
+                    if (offset < insert_barrier) {
+                        pk_offsets.emplace_back(offset);
+                    }
                 }
-                ++it;
             }
             break;
         }
@@ -872,10 +1285,11 @@ SegmentSealedImpl::search_pk(const PkType& pk, int64_t insert_barrier) const {
 }
 
 std::shared_ptr<DeletedRecord::TmpBitmap>
-SegmentSealedImpl::get_deleted_bitmap_s(int64_t del_barrier,
-                                        int64_t insert_barrier,
-                                        DeletedRecord& delete_record,
-                                        Timestamp query_timestamp) const {
+ChunkedSegmentSealedImpl::get_deleted_bitmap_s(
+    int64_t del_barrier,
+    int64_t insert_barrier,
+    DeletedRecord& delete_record,
+    Timestamp query_timestamp) const {
     // if insert_barrier and del_barrier have not changed, use cache data directly
     bool hit_cache = false;
     int64_t old_del_barrier = 0;
@@ -939,343 +1353,47 @@ SegmentSealedImpl::get_deleted_bitmap_s(int64_t del_barrier,
     return current;
 }
 
-void
-SegmentSealedImpl::mask_with_delete(BitsetTypeView& bitset,
-                                    int64_t ins_barrier,
-                                    Timestamp timestamp) const {
-    auto del_barrier = get_barrier(get_deleted_record(), timestamp);
-    if (del_barrier == 0) {
-        return;
-    }
-
-    auto bitmap_holder = std::shared_ptr<DeletedRecord::TmpBitmap>();
-
+std::pair<std::vector<OffsetMap::OffsetType>, bool>
+ChunkedSegmentSealedImpl::find_first(int64_t limit,
+                                     const BitsetType& bitset) const {
     if (!is_sorted_by_pk_) {
-        bitmap_holder = get_deleted_bitmap(del_barrier,
-                                           ins_barrier,
-                                           deleted_record_,
-                                           insert_record_,
-                                           timestamp);
-    } else {
-        bitmap_holder = get_deleted_bitmap_s(
-            del_barrier, ins_barrier, deleted_record_, timestamp);
+        return insert_record_.pk2offset_->find_first(limit, bitset);
+    }
+    if (limit == Unlimited || limit == NoLimit) {
+        limit = num_rows_.value();
     }
 
-    if (!bitmap_holder || !bitmap_holder->bitmap_ptr) {
-        return;
-    }
-    auto& delete_bitset = *bitmap_holder->bitmap_ptr;
-    AssertInfo(
-        delete_bitset.size() == bitset.size(),
-        fmt::format(
-            "Deleted bitmap size:{} not equal to filtered bitmap size:{}",
-            delete_bitset.size(),
-            bitset.size()));
-    bitset |= delete_bitset;
-}
+    int64_t hit_num = 0;  // avoid counting the number everytime.
+    auto size = bitset.size();
+    int64_t cnt = size - bitset.count();
+    auto more_hit_than_limit = cnt > limit;
+    limit = std::min(limit, cnt);
+    std::vector<int64_t> seg_offsets;
+    seg_offsets.reserve(limit);
 
-void
-SegmentSealedImpl::vector_search(SearchInfo& search_info,
-                                 const void* query_data,
-                                 int64_t query_count,
-                                 Timestamp timestamp,
-                                 const BitsetView& bitset,
-                                 SearchResult& output) const {
-    AssertInfo(is_system_field_ready(), "System field is not ready");
-    auto field_id = search_info.field_id_;
-    auto& field_meta = schema_->operator[](field_id);
-
-    AssertInfo(field_meta.is_vector(),
-               "The meta type of vector field is not vector type");
-    if (get_bit(binlog_index_bitset_, field_id)) {
-        AssertInfo(
-            vec_binlog_config_.find(field_id) != vec_binlog_config_.end(),
-            "The binlog params is not generate.");
-        auto binlog_search_info =
-            vec_binlog_config_.at(field_id)->GetSearchConf(search_info);
-
-        AssertInfo(vector_indexings_.is_ready(field_id),
-                   "vector indexes isn't ready for field " +
-                       std::to_string(field_id.get()));
-        query::SearchOnSealedIndex(*schema_,
-                                   vector_indexings_,
-                                   binlog_search_info,
-                                   query_data,
-                                   query_count,
-                                   bitset,
-                                   output);
-        milvus::tracer::AddEvent(
-            "finish_searching_vector_temperate_binlog_index");
-    } else if (get_bit(index_ready_bitset_, field_id)) {
-        AssertInfo(vector_indexings_.is_ready(field_id),
-                   "vector indexes isn't ready for field " +
-                       std::to_string(field_id.get()));
-        query::SearchOnSealedIndex(*schema_,
-                                   vector_indexings_,
-                                   search_info,
-                                   query_data,
-                                   query_count,
-                                   bitset,
-                                   output);
-        milvus::tracer::AddEvent("finish_searching_vector_index");
-    } else {
-        AssertInfo(
-            get_bit(field_data_ready_bitset_, field_id),
-            "Field Data is not loaded: " + std::to_string(field_id.get()));
-        AssertInfo(num_rows_.has_value(), "Can't get row count value");
-        auto row_count = num_rows_.value();
-        auto vec_data = fields_.at(field_id);
-        query::SearchOnSealed(*schema_,
-                              vec_data->Data(),
-                              search_info,
-                              query_data,
-                              query_count,
-                              row_count,
-                              bitset,
-                              output);
-        milvus::tracer::AddEvent("finish_searching_vector_data");
-    }
-}
-
-std::tuple<std::string, int64_t>
-SegmentSealedImpl::GetFieldDataPath(FieldId field_id, int64_t offset) const {
-    auto offset_in_binlog = offset;
-    auto data_path = std::string();
-    auto it = field_data_info_.field_infos.find(field_id.get());
-    AssertInfo(it != field_data_info_.field_infos.end(),
-               fmt::format("cannot find binlog file for field: {}, seg: {}",
-                           field_id.get(),
-                           id_));
-    auto field_info = it->second;
-
-    for (auto i = 0; i < field_info.insert_files.size(); i++) {
-        if (offset_in_binlog < field_info.entries_nums[i]) {
-            data_path = field_info.insert_files[i];
-            break;
-        } else {
-            offset_in_binlog -= field_info.entries_nums[i];
+    int64_t offset = 0;
+    for (; hit_num < limit && offset < num_rows_.value(); offset++) {
+        if (offset >= size) {
+            // In fact, this case won't happen on sealed segments.
+            continue;
         }
-    }
-    return {data_path, offset_in_binlog};
-}
 
-std::tuple<
-    std::string,
-    std::shared_ptr<
-        SingleChunkColumnBase>> static ReadFromChunkCache(const storage::
-                                                              ChunkCachePtr& cc,
-                                                          const std::string&
-                                                              data_path,
-                                                          const storage::
-                                                              MmapChunkDescriptorPtr&
-                                                                  descriptor) {
-    // For mmap mode, field_meta is unused, so just construct a fake field meta.
-    auto fm =
-        FieldMeta(FieldName(""), FieldId(0), milvus::DataType::NONE, false);
-    // TODO: add Load() interface for chunk cache when support retrieve_enable, make Read() raise error if cache miss
-    auto column = cc->Read(data_path, descriptor, fm, true);
-    cc->Prefetch(data_path);
-    return {data_path,
-            std::dynamic_pointer_cast<SingleChunkColumnBase>(column)};
-}
-
-std::unique_ptr<DataArray>
-SegmentSealedImpl::get_vector(FieldId field_id,
-                              const int64_t* ids,
-                              int64_t count) const {
-    auto& field_meta = schema_->operator[](field_id);
-    AssertInfo(field_meta.is_vector(), "vector field is not vector type");
-
-    if (!get_bit(index_ready_bitset_, field_id) &&
-        !get_bit(binlog_index_bitset_, field_id)) {
-        return fill_with_empty(field_id, count);
-    }
-
-    AssertInfo(vector_indexings_.is_ready(field_id),
-               "vector index is not ready");
-    auto field_indexing = vector_indexings_.get_field_indexing(field_id);
-    auto vec_index =
-        dynamic_cast<index::VectorIndex*>(field_indexing->indexing_.get());
-    AssertInfo(vec_index, "invalid vector indexing");
-
-    auto index_type = vec_index->GetIndexType();
-    auto metric_type = vec_index->GetMetricType();
-    auto has_raw_data = vec_index->HasRawData();
-
-    if (has_raw_data && !TEST_skip_index_for_retrieve_) {
-        // If index has raw data, get vector from memory.
-        auto ids_ds = GenIdsDataset(count, ids);
-        if (field_meta.get_data_type() == DataType::VECTOR_SPARSE_FLOAT) {
-            auto res = vec_index->GetSparseVector(ids_ds);
-            return segcore::CreateVectorDataArrayFrom(
-                res.get(), count, field_meta);
-        } else {
-            // dense vector:
-            auto vector = vec_index->GetVector(ids_ds);
-            return segcore::CreateVectorDataArrayFrom(
-                vector.data(), count, field_meta);
+        if (!bitset[offset]) {
+            seg_offsets.push_back(offset);
+            hit_num++;
         }
     }
 
-    // If index doesn't have raw data, get vector from chunk cache.
-    auto cc = storage::MmapManager::GetInstance().GetChunkCache();
-
-    // group by data_path
-    auto id_to_data_path =
-        std::unordered_map<std::int64_t, std::tuple<std::string, int64_t>>{};
-    auto path_to_column =
-        std::unordered_map<std::string,
-                           std::shared_ptr<SingleChunkColumnBase>>{};
-    for (auto i = 0; i < count; i++) {
-        const auto& tuple = GetFieldDataPath(field_id, ids[i]);
-        id_to_data_path.emplace(ids[i], tuple);
-        path_to_column.emplace(std::get<0>(tuple), nullptr);
-    }
-
-    // read and prefetch
-    auto& pool = ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::HIGH);
-    std::vector<std::future<
-        std::tuple<std::string, std::shared_ptr<SingleChunkColumnBase>>>>
-        futures;
-    futures.reserve(path_to_column.size());
-    for (const auto& iter : path_to_column) {
-        const auto& data_path = iter.first;
-        futures.emplace_back(
-            pool.Submit(ReadFromChunkCache, cc, data_path, mmap_descriptor_));
-    }
-
-    for (int i = 0; i < futures.size(); ++i) {
-        const auto& [data_path, column] = futures[i].get();
-        path_to_column[data_path] = column;
-    }
-
-    if (field_meta.get_data_type() == DataType::VECTOR_SPARSE_FLOAT) {
-        auto buf = std::vector<knowhere::sparse::SparseRow<float>>(count);
-        for (auto i = 0; i < count; ++i) {
-            const auto& [data_path, offset_in_binlog] =
-                id_to_data_path.at(ids[i]);
-            const auto& column = path_to_column.at(data_path);
-            AssertInfo(
-                offset_in_binlog < column->NumRows(),
-                "column idx out of range, idx: {}, size: {}, data_path: {}",
-                offset_in_binlog,
-                column->NumRows(),
-                data_path);
-            auto sparse_column =
-                std::dynamic_pointer_cast<SingleChunkSparseFloatColumn>(column);
-            AssertInfo(sparse_column, "incorrect column created");
-            buf[i] = static_cast<const knowhere::sparse::SparseRow<float>*>(
-                static_cast<const void*>(
-                    sparse_column->Data()))[offset_in_binlog];
-        }
-        return segcore::CreateVectorDataArrayFrom(
-            buf.data(), count, field_meta);
-    } else {
-        // assign to data array
-        auto row_bytes = field_meta.get_sizeof();
-        auto buf = std::vector<char>(count * row_bytes);
-        for (auto i = 0; i < count; ++i) {
-            AssertInfo(id_to_data_path.count(ids[i]) != 0, "id not found");
-            const auto& [data_path, offset_in_binlog] =
-                id_to_data_path.at(ids[i]);
-            AssertInfo(path_to_column.count(data_path) != 0,
-                       "column not found");
-            const auto& column = path_to_column.at(data_path);
-            AssertInfo(
-                offset_in_binlog < column->NumRows(),
-                "column idx out of range, idx: {}, size: {}, data_path: {}",
-                offset_in_binlog,
-                column->NumRows(),
-                data_path);
-            auto vector = &column->Data()[offset_in_binlog * row_bytes];
-            std::memcpy(buf.data() + i * row_bytes, vector, row_bytes);
-        }
-        return segcore::CreateVectorDataArrayFrom(
-            buf.data(), count, field_meta);
-    }
+    return {seg_offsets, more_hit_than_limit && offset != num_rows_.value()};
 }
 
-void
-SegmentSealedImpl::DropFieldData(const FieldId field_id) {
-    if (SystemProperty::Instance().IsSystem(field_id)) {
-        auto system_field_type =
-            SystemProperty::Instance().GetSystemFieldType(field_id);
-
-        std::unique_lock lck(mutex_);
-        --system_ready_count_;
-        if (system_field_type == SystemFieldType::Timestamp) {
-            insert_record_.timestamps_.clear();
-        }
-        lck.unlock();
-    } else {
-        auto& field_meta = schema_->operator[](field_id);
-        std::unique_lock lck(mutex_);
-        if (get_bit(field_data_ready_bitset_, field_id)) {
-            fields_.erase(field_id);
-            set_bit(field_data_ready_bitset_, field_id, false);
-        }
-        if (get_bit(binlog_index_bitset_, field_id)) {
-            set_bit(binlog_index_bitset_, field_id, false);
-            vector_indexings_.drop_field_indexing(field_id);
-        }
-        lck.unlock();
-    }
-}
-
-void
-SegmentSealedImpl::DropIndex(const FieldId field_id) {
-    AssertInfo(!SystemProperty::Instance().IsSystem(field_id),
-               "Field id:" + std::to_string(field_id.get()) +
-                   " isn't one of system type when drop index");
-    auto& field_meta = schema_->operator[](field_id);
-    AssertInfo(field_meta.is_vector(),
-               "Field meta of offset:" + std::to_string(field_id.get()) +
-                   " is not vector type");
-
-    std::unique_lock lck(mutex_);
-    vector_indexings_.drop_field_indexing(field_id);
-    set_bit(index_ready_bitset_, field_id, false);
-}
-
-void
-SegmentSealedImpl::check_search(const query::Plan* plan) const {
-    AssertInfo(plan, "Search plan is null");
-    AssertInfo(plan->extra_info_opt_.has_value(),
-               "Extra info of search plan doesn't have value");
-
-    if (!is_system_field_ready()) {
-        PanicInfo(
-            FieldNotLoaded,
-            "failed to load row ID or timestamp, potential missing bin logs or "
-            "empty segments. Segment ID = " +
-                std::to_string(this->id_));
-    }
-
-    auto& request_fields = plan->extra_info_opt_.value().involved_fields_;
-    auto field_ready_bitset =
-        field_data_ready_bitset_ | index_ready_bitset_ | binlog_index_bitset_;
-    AssertInfo(request_fields.size() == field_ready_bitset.size(),
-               "Request fields size not equal to field ready bitset size when "
-               "check search");
-    auto absent_fields = request_fields - field_ready_bitset;
-
-    if (absent_fields.any()) {
-        // absent_fields.find_first() returns std::optional<>
-        auto field_id =
-            FieldId(absent_fields.find_first().value() + START_USER_FIELDID);
-        auto& field_meta = schema_->operator[](field_id);
-        PanicInfo(
-            FieldNotLoaded,
-            "User Field(" + field_meta.get_name().get() + ") is not loaded");
-    }
-}
-
-SegmentSealedImpl::SegmentSealedImpl(SchemaPtr schema,
-                                     IndexMetaPtr index_meta,
-                                     const SegcoreConfig& segcore_config,
-                                     int64_t segment_id,
-                                     bool TEST_skip_index_for_retrieve,
-                                     bool is_sorted_by_pk)
+ChunkedSegmentSealedImpl::ChunkedSegmentSealedImpl(
+    SchemaPtr schema,
+    IndexMetaPtr index_meta,
+    const SegcoreConfig& segcore_config,
+    int64_t segment_id,
+    bool TEST_skip_index_for_retrieve,
+    bool is_sorted_by_pk)
     : segcore_config_(segcore_config),
       field_data_ready_bitset_(schema->size()),
       index_ready_bitset_(schema->size()),
@@ -1293,7 +1411,7 @@ SegmentSealedImpl::SegmentSealedImpl(SchemaPtr schema,
     mcm->Register(mmap_descriptor_);
 }
 
-SegmentSealedImpl::~SegmentSealedImpl() {
+ChunkedSegmentSealedImpl::~ChunkedSegmentSealedImpl() {
     auto cc = storage::MmapManager::GetInstance().GetChunkCache();
     if (cc == nullptr) {
         return;
@@ -1311,10 +1429,10 @@ SegmentSealedImpl::~SegmentSealedImpl() {
 }
 
 void
-SegmentSealedImpl::bulk_subscript(SystemFieldType system_type,
-                                  const int64_t* seg_offsets,
-                                  int64_t count,
-                                  void* output) const {
+ChunkedSegmentSealedImpl::bulk_subscript(SystemFieldType system_type,
+                                         const int64_t* seg_offsets,
+                                         int64_t count,
+                                         void* output) const {
     AssertInfo(is_system_field_ready(),
                "System field isn't ready when do bulk_insert, segID:{}",
                id_);
@@ -1340,10 +1458,10 @@ SegmentSealedImpl::bulk_subscript(SystemFieldType system_type,
 
 template <typename S, typename T>
 void
-SegmentSealedImpl::bulk_subscript_impl(const void* src_raw,
-                                       const int64_t* seg_offsets,
-                                       int64_t count,
-                                       T* dst) {
+ChunkedSegmentSealedImpl::bulk_subscript_impl(const void* src_raw,
+                                              const int64_t* seg_offsets,
+                                              int64_t count,
+                                              T* dst) {
     static_assert(IsScalar<T>);
     auto src = static_cast<const S*>(src_raw);
     for (int64_t i = 0; i < count; ++i) {
@@ -1351,14 +1469,27 @@ SegmentSealedImpl::bulk_subscript_impl(const void* src_raw,
         dst[i] = src[offset];
     }
 }
+template <typename S, typename T>
+void
+ChunkedSegmentSealedImpl::bulk_subscript_impl(const ChunkedColumnBase* field,
+                                              const int64_t* seg_offsets,
+                                              int64_t count,
+                                              T* dst) {
+    static_assert(IsScalar<T>);
+    for (int64_t i = 0; i < count; ++i) {
+        auto offset = seg_offsets[i];
+        dst[i] = *static_cast<const S*>(
+            static_cast<const void*>(field->ValueAt(offset)));
+    }
+}
 
 template <typename S, typename T>
 void
-SegmentSealedImpl::bulk_subscript_impl(const SingleChunkColumnBase* column,
-                                       const int64_t* seg_offsets,
-                                       int64_t count,
-                                       void* dst_raw) {
-    auto field = reinterpret_cast<const SingleChunkVariableColumn<S>*>(column);
+ChunkedSegmentSealedImpl::bulk_subscript_impl(const ChunkedColumnBase* column,
+                                              const int64_t* seg_offsets,
+                                              int64_t count,
+                                              void* dst_raw) {
+    auto field = reinterpret_cast<const ChunkedVariableColumn<S>*>(column);
     auto dst = reinterpret_cast<T*>(dst_raw);
     for (int64_t i = 0; i < count; ++i) {
         auto offset = seg_offsets[i];
@@ -1368,12 +1499,12 @@ SegmentSealedImpl::bulk_subscript_impl(const SingleChunkColumnBase* column,
 
 template <typename S, typename T>
 void
-SegmentSealedImpl::bulk_subscript_ptr_impl(
-    const SingleChunkColumnBase* column,
+ChunkedSegmentSealedImpl::bulk_subscript_ptr_impl(
+    const ChunkedColumnBase* column,
     const int64_t* seg_offsets,
     int64_t count,
     google::protobuf::RepeatedPtrField<T>* dst) {
-    auto field = reinterpret_cast<const SingleChunkVariableColumn<S>*>(column);
+    auto field = reinterpret_cast<const ChunkedVariableColumn<S>*>(column);
     for (int64_t i = 0; i < count; ++i) {
         auto offset = seg_offsets[i];
         dst->at(i) = std::move(T(field->RawAt(offset)));
@@ -1382,12 +1513,12 @@ SegmentSealedImpl::bulk_subscript_ptr_impl(
 
 template <typename T>
 void
-SegmentSealedImpl::bulk_subscript_array_impl(
-    const SingleChunkColumnBase* column,
+ChunkedSegmentSealedImpl::bulk_subscript_array_impl(
+    const ChunkedColumnBase* column,
     const int64_t* seg_offsets,
     int64_t count,
     google::protobuf::RepeatedPtrField<T>* dst) {
-    auto field = reinterpret_cast<const SingleChunkArrayColumn*>(column);
+    auto field = reinterpret_cast<const ChunkedArrayColumn*>(column);
     for (int64_t i = 0; i < count; ++i) {
         auto offset = seg_offsets[i];
         dst->at(i) = std::move(field->RawAt(offset));
@@ -1396,23 +1527,22 @@ SegmentSealedImpl::bulk_subscript_array_impl(
 
 // for dense vector
 void
-SegmentSealedImpl::bulk_subscript_impl(int64_t element_sizeof,
-                                       const void* src_raw,
-                                       const int64_t* seg_offsets,
-                                       int64_t count,
-                                       void* dst_raw) {
-    auto column = reinterpret_cast<const char*>(src_raw);
+ChunkedSegmentSealedImpl::bulk_subscript_impl(int64_t element_sizeof,
+                                              const ChunkedColumnBase* field,
+                                              const int64_t* seg_offsets,
+                                              int64_t count,
+                                              void* dst_raw) {
     auto dst_vec = reinterpret_cast<char*>(dst_raw);
     for (int64_t i = 0; i < count; ++i) {
         auto offset = seg_offsets[i];
-        auto src = column + element_sizeof * offset;
+        auto src = field->ValueAt(offset);
         auto dst = dst_vec + i * element_sizeof;
         memcpy(dst, src, element_sizeof);
     }
 }
 
 void
-SegmentSealedImpl::ClearData() {
+ChunkedSegmentSealedImpl::ClearData() {
     {
         std::unique_lock lck(mutex_);
         field_data_ready_bitset_.reset();
@@ -1440,7 +1570,8 @@ SegmentSealedImpl::ClearData() {
 }
 
 std::unique_ptr<DataArray>
-SegmentSealedImpl::fill_with_empty(FieldId field_id, int64_t count) const {
+ChunkedSegmentSealedImpl::fill_with_empty(FieldId field_id,
+                                          int64_t count) const {
     auto& field_meta = schema_->operator[](field_id);
     if (IsVectorDataType(field_meta.get_data_type())) {
         return CreateVectorDataArray(count, field_meta);
@@ -1448,11 +1579,90 @@ SegmentSealedImpl::fill_with_empty(FieldId field_id, int64_t count) const {
     return CreateScalarDataArray(count, field_meta);
 }
 
+void
+ChunkedSegmentSealedImpl::CreateTextIndex(FieldId field_id) {
+    std::unique_lock lck(mutex_);
+
+    const auto& field_meta = schema_->operator[](field_id);
+    auto& cfg = storage::MmapManager::GetInstance().GetMmapConfig();
+    std::unique_ptr<index::TextMatchIndex> index;
+    if (!cfg.GetScalarIndexEnableMmap()) {
+        // build text index in ram.
+        index = std::make_unique<index::TextMatchIndex>(
+            std::numeric_limits<int64_t>::max(),
+            "milvus_tokenizer",
+            field_meta.get_tokenizer_params());
+    } else {
+        // build text index using mmap.
+        index = std::make_unique<index::TextMatchIndex>(
+            cfg.GetMmapPath(),
+            "milvus_tokenizer",
+            field_meta.get_tokenizer_params());
+    }
+
+    {
+        // build
+        auto iter = fields_.find(field_id);
+        if (iter != fields_.end()) {
+            auto column =
+                std::dynamic_pointer_cast<ChunkedVariableColumn<std::string>>(
+                    iter->second);
+            AssertInfo(
+                column != nullptr,
+                "failed to create text index, field is not of text type: {}",
+                field_id.get());
+            auto n = column->NumRows();
+            for (size_t i = 0; i < n; i++) {
+                index->AddText(std::string(column->RawAt(i)), i);
+            }
+        } else {  // fetch raw data from index.
+            auto field_index_iter = scalar_indexings_.find(field_id);
+            AssertInfo(field_index_iter != scalar_indexings_.end(),
+                       "failed to create text index, neither raw data nor "
+                       "index are found");
+            auto ptr = field_index_iter->second.get();
+            AssertInfo(ptr->HasRawData(),
+                       "text raw data not found, trying to create text index "
+                       "from index, but this index don't contain raw data");
+            auto impl = dynamic_cast<index::ScalarIndex<std::string>*>(ptr);
+            AssertInfo(impl != nullptr,
+                       "failed to create text index, field index cannot be "
+                       "converted to string index");
+            auto n = impl->Size();
+            for (size_t i = 0; i < n; i++) {
+                index->AddText(impl->Reverse_Lookup(i), i);
+            }
+        }
+    }
+
+    // create index reader.
+    index->CreateReader();
+    // release index writer.
+    index->Finish();
+
+    index->Reload();
+
+    index->RegisterTokenizer("milvus_tokenizer",
+                             field_meta.get_tokenizer_params());
+
+    text_indexes_[field_id] = std::move(index);
+}
+
+void
+ChunkedSegmentSealedImpl::LoadTextIndex(
+    FieldId field_id, std::unique_ptr<index::TextMatchIndex> index) {
+    std::unique_lock lck(mutex_);
+    const auto& field_meta = schema_->operator[](field_id);
+    index->RegisterTokenizer("milvus_tokenizer",
+                             field_meta.get_tokenizer_params());
+    text_indexes_[field_id] = std::move(index);
+}
+
 std::unique_ptr<DataArray>
-SegmentSealedImpl::get_raw_data(FieldId field_id,
-                                const FieldMeta& field_meta,
-                                const int64_t* seg_offsets,
-                                int64_t count) const {
+ChunkedSegmentSealedImpl::get_raw_data(FieldId field_id,
+                                       const FieldMeta& field_meta,
+                                       const int64_t* seg_offsets,
+                                       int64_t count) const {
     // DO NOT directly access the column by map like: `fields_.at(field_id)->Data()`,
     // we have to clone the shared pointer,
     // to make sure it won't get released if segment released
@@ -1495,7 +1705,7 @@ SegmentSealedImpl::get_raw_data(FieldId field_id,
         }
 
         case DataType::BOOL: {
-            bulk_subscript_impl<bool>(column->Data(),
+            bulk_subscript_impl<bool>(column.get(),
                                       seg_offsets,
                                       count,
                                       ret->mutable_scalars()
@@ -1505,7 +1715,7 @@ SegmentSealedImpl::get_raw_data(FieldId field_id,
             break;
         }
         case DataType::INT8: {
-            bulk_subscript_impl<int8_t>(column->Data(),
+            bulk_subscript_impl<int8_t>(column.get(),
                                         seg_offsets,
                                         count,
                                         ret->mutable_scalars()
@@ -1515,7 +1725,7 @@ SegmentSealedImpl::get_raw_data(FieldId field_id,
             break;
         }
         case DataType::INT16: {
-            bulk_subscript_impl<int16_t>(column->Data(),
+            bulk_subscript_impl<int16_t>(column.get(),
                                          seg_offsets,
                                          count,
                                          ret->mutable_scalars()
@@ -1525,7 +1735,7 @@ SegmentSealedImpl::get_raw_data(FieldId field_id,
             break;
         }
         case DataType::INT32: {
-            bulk_subscript_impl<int32_t>(column->Data(),
+            bulk_subscript_impl<int32_t>(column.get(),
                                          seg_offsets,
                                          count,
                                          ret->mutable_scalars()
@@ -1535,7 +1745,7 @@ SegmentSealedImpl::get_raw_data(FieldId field_id,
             break;
         }
         case DataType::INT64: {
-            bulk_subscript_impl<int64_t>(column->Data(),
+            bulk_subscript_impl<int64_t>(column.get(),
                                          seg_offsets,
                                          count,
                                          ret->mutable_scalars()
@@ -1545,7 +1755,7 @@ SegmentSealedImpl::get_raw_data(FieldId field_id,
             break;
         }
         case DataType::FLOAT: {
-            bulk_subscript_impl<float>(column->Data(),
+            bulk_subscript_impl<float>(column.get(),
                                        seg_offsets,
                                        count,
                                        ret->mutable_scalars()
@@ -1555,7 +1765,7 @@ SegmentSealedImpl::get_raw_data(FieldId field_id,
             break;
         }
         case DataType::DOUBLE: {
-            bulk_subscript_impl<double>(column->Data(),
+            bulk_subscript_impl<double>(column.get(),
                                         seg_offsets,
                                         count,
                                         ret->mutable_scalars()
@@ -1566,7 +1776,7 @@ SegmentSealedImpl::get_raw_data(FieldId field_id,
         }
         case DataType::VECTOR_FLOAT: {
             bulk_subscript_impl(field_meta.get_sizeof(),
-                                column->Data(),
+                                column.get(),
                                 seg_offsets,
                                 count,
                                 ret->mutable_vectors()
@@ -1578,7 +1788,7 @@ SegmentSealedImpl::get_raw_data(FieldId field_id,
         case DataType::VECTOR_FLOAT16: {
             bulk_subscript_impl(
                 field_meta.get_sizeof(),
-                column->Data(),
+                column.get(),
                 seg_offsets,
                 count,
                 ret->mutable_vectors()->mutable_float16_vector()->data());
@@ -1587,7 +1797,7 @@ SegmentSealedImpl::get_raw_data(FieldId field_id,
         case DataType::VECTOR_BFLOAT16: {
             bulk_subscript_impl(
                 field_meta.get_sizeof(),
-                column->Data(),
+                column.get(),
                 seg_offsets,
                 count,
                 ret->mutable_vectors()->mutable_bfloat16_vector()->data());
@@ -1596,21 +1806,21 @@ SegmentSealedImpl::get_raw_data(FieldId field_id,
         case DataType::VECTOR_BINARY: {
             bulk_subscript_impl(
                 field_meta.get_sizeof(),
-                column->Data(),
+                column.get(),
                 seg_offsets,
                 count,
                 ret->mutable_vectors()->mutable_binary_vector()->data());
             break;
         }
         case DataType::VECTOR_SPARSE_FLOAT: {
-            auto rows = static_cast<const knowhere::sparse::SparseRow<float>*>(
-                static_cast<const void*>(column->Data()));
             auto dst = ret->mutable_vectors()->mutable_sparse_float_vector();
             SparseRowsToProto(
                 [&](size_t i) {
                     auto offset = seg_offsets[i];
-                    return offset != INVALID_SEG_OFFSET ? (rows + offset)
-                                                        : nullptr;
+                    auto row =
+                        static_cast<const knowhere::sparse::SparseRow<float>*>(
+                            static_cast<const void*>(column->ValueAt(offset)));
+                    return offset != INVALID_SEG_OFFSET ? row : nullptr;
                 },
                 count,
                 dst);
@@ -1628,9 +1838,9 @@ SegmentSealedImpl::get_raw_data(FieldId field_id,
 }
 
 std::unique_ptr<DataArray>
-SegmentSealedImpl::bulk_subscript(FieldId field_id,
-                                  const int64_t* seg_offsets,
-                                  int64_t count) const {
+ChunkedSegmentSealedImpl::bulk_subscript(FieldId field_id,
+                                         const int64_t* seg_offsets,
+                                         int64_t count) const {
     auto& field_meta = schema_->operator[](field_id);
     // if count == 0, return empty data array
     if (count == 0) {
@@ -1640,8 +1850,8 @@ SegmentSealedImpl::bulk_subscript(FieldId field_id,
     if (HasIndex(field_id)) {
         // if field has load scalar index, reverse raw data from index
         if (!IsVectorDataType(field_meta.get_data_type())) {
-            AssertInfo(num_chunk(field_id) == 1,
-                       "num chunk not equal to 1 for sealed segment");
+            // AssertInfo(num_chunk() == 1,
+            //            "num chunk not equal to 1 for sealed segment");
             auto index = chunk_index_impl(field_id, 0);
             if (index->HasRawData()) {
                 return ReverseDataFromIndex(
@@ -1658,7 +1868,7 @@ SegmentSealedImpl::bulk_subscript(FieldId field_id,
 }
 
 std::unique_ptr<DataArray>
-SegmentSealedImpl::bulk_subscript(
+ChunkedSegmentSealedImpl::bulk_subscript(
     FieldId field_id,
     const int64_t* seg_offsets,
     int64_t count,
@@ -1680,7 +1890,7 @@ SegmentSealedImpl::bulk_subscript(
     }
     auto dst = ret->mutable_scalars()->mutable_json_data()->mutable_data();
     auto field =
-        reinterpret_cast<const SingleChunkVariableColumn<Json>*>(column.get());
+        reinterpret_cast<const ChunkedVariableColumn<Json>*>(column.get());
     for (int64_t i = 0; i < count; ++i) {
         auto offset = seg_offsets[i];
         dst->at(i) = ExtractSubJson(std::string(field->RawAt(offset)),
@@ -1690,14 +1900,14 @@ SegmentSealedImpl::bulk_subscript(
 }
 
 bool
-SegmentSealedImpl::HasIndex(FieldId field_id) const {
+ChunkedSegmentSealedImpl::HasIndex(FieldId field_id) const {
     std::shared_lock lck(mutex_);
     return get_bit(index_ready_bitset_, field_id) |
            get_bit(binlog_index_bitset_, field_id);
 }
 
 bool
-SegmentSealedImpl::HasFieldData(FieldId field_id) const {
+ChunkedSegmentSealedImpl::HasFieldData(FieldId field_id) const {
     std::shared_lock lck(mutex_);
     if (SystemProperty::Instance().IsSystem(field_id)) {
         return is_system_field_ready();
@@ -1707,7 +1917,7 @@ SegmentSealedImpl::HasFieldData(FieldId field_id) const {
 }
 
 bool
-SegmentSealedImpl::HasRawData(int64_t field_id) const {
+ChunkedSegmentSealedImpl::HasRawData(int64_t field_id) const {
     std::shared_lock lck(mutex_);
     auto fieldID = FieldId(field_id);
     const auto& field_meta = schema_->operator[](fieldID);
@@ -1731,14 +1941,14 @@ SegmentSealedImpl::HasRawData(int64_t field_id) const {
 }
 
 DataType
-SegmentSealedImpl::GetFieldDataType(milvus::FieldId field_id) const {
+ChunkedSegmentSealedImpl::GetFieldDataType(milvus::FieldId field_id) const {
     auto& field_meta = schema_->operator[](field_id);
     return field_meta.get_data_type();
 }
 
 std::pair<std::unique_ptr<IdArray>, std::vector<SegOffset>>
-SegmentSealedImpl::search_ids(const IdArray& id_array,
-                              Timestamp timestamp) const {
+ChunkedSegmentSealedImpl::search_ids(const IdArray& id_array,
+                                     Timestamp timestamp) const {
     auto field_id = schema_->get_primary_field_id().value_or(FieldId(-1));
     AssertInfo(field_id.get() != -1, "Primary key is -1");
     auto& field_meta = schema_->operator[](field_id);
@@ -1746,10 +1956,10 @@ SegmentSealedImpl::search_ids(const IdArray& id_array,
     auto ids_size = GetSizeOfIdArray(id_array);
     std::vector<PkType> pks(ids_size);
     ParsePksFromIDs(pks, data_type, id_array);
+
     auto res_id_arr = std::make_unique<IdArray>();
     std::vector<SegOffset> res_offsets;
     res_offsets.reserve(pks.size());
-
     for (auto& pk : pks) {
         std::vector<SegOffset> pk_offsets;
         if (!is_sorted_by_pk_) {
@@ -1780,44 +1990,11 @@ SegmentSealedImpl::search_ids(const IdArray& id_array,
     return {std::move(res_id_arr), std::move(res_offsets)};
 }
 
-std::pair<std::vector<OffsetMap::OffsetType>, bool>
-SegmentSealedImpl::find_first(int64_t limit, const BitsetType& bitset) const {
-    if (!is_sorted_by_pk_) {
-        return insert_record_.pk2offset_->find_first(limit, bitset);
-    }
-    if (limit == Unlimited || limit == NoLimit) {
-        limit = num_rows_.value();
-    }
-
-    int64_t hit_num = 0;  // avoid counting the number everytime.
-    auto size = bitset.size();
-    int64_t cnt = size - bitset.count();
-    auto more_hit_than_limit = cnt > limit;
-    limit = std::min(limit, cnt);
-    std::vector<int64_t> seg_offsets;
-    seg_offsets.reserve(limit);
-
-    int64_t offset = 0;
-    for (; hit_num < limit && offset < num_rows_.value(); offset++) {
-        if (offset >= size) {
-            // In fact, this case won't happen on sealed segments.
-            continue;
-        }
-
-        if (!bitset[offset]) {
-            seg_offsets.push_back(offset);
-            hit_num++;
-        }
-    }
-
-    return {seg_offsets, more_hit_than_limit && offset != num_rows_.value()};
-}
-
 SegcoreError
-SegmentSealedImpl::Delete(int64_t reserved_offset,  // deprecated
-                          int64_t size,
-                          const IdArray* ids,
-                          const Timestamp* timestamps_raw) {
+ChunkedSegmentSealedImpl::Delete(int64_t reserved_offset,  // deprecated
+                                 int64_t size,
+                                 const IdArray* ids,
+                                 const Timestamp* timestamps_raw) {
     auto field_id = schema_->get_primary_field_id().value_or(FieldId(-1));
     AssertInfo(field_id.get() != -1, "Primary key is -1");
     auto& field_meta = schema_->operator[](field_id);
@@ -1861,7 +2038,7 @@ SegmentSealedImpl::Delete(int64_t reserved_offset,  // deprecated
 }
 
 std::string
-SegmentSealedImpl::debug() const {
+ChunkedSegmentSealedImpl::debug() const {
     std::string log_str;
     log_str += "Sealed\n";
     log_str += "\n";
@@ -1869,7 +2046,7 @@ SegmentSealedImpl::debug() const {
 }
 
 void
-SegmentSealedImpl::LoadSegmentMeta(
+ChunkedSegmentSealedImpl::LoadSegmentMeta(
     const proto::segcore::LoadSegmentMeta& segment_meta) {
     std::unique_lock lck(mutex_);
     std::vector<int64_t> slice_lengths;
@@ -1881,14 +2058,14 @@ SegmentSealedImpl::LoadSegmentMeta(
 }
 
 int64_t
-SegmentSealedImpl::get_active_count(Timestamp ts) const {
+ChunkedSegmentSealedImpl::get_active_count(Timestamp ts) const {
     // TODO optimize here to reduce expr search range
     return this->get_row_count();
 }
 
 void
-SegmentSealedImpl::mask_with_timestamps(BitsetTypeView& bitset_chunk,
-                                        Timestamp timestamp) const {
+ChunkedSegmentSealedImpl::mask_with_timestamps(BitsetTypeView& bitset_chunk,
+                                               Timestamp timestamp) const {
     // TODO change the
     AssertInfo(insert_record_.timestamps_.num_chunk() == 1,
                "num chunk not equal to 1 for sealed segment");
@@ -1921,7 +2098,7 @@ SegmentSealedImpl::mask_with_timestamps(BitsetTypeView& bitset_chunk,
 }
 
 bool
-SegmentSealedImpl::generate_interim_index(const FieldId field_id) {
+ChunkedSegmentSealedImpl::generate_interim_index(const FieldId field_id) {
     if (col_index_meta_ == nullptr || !col_index_meta_->HasFiled(field_id)) {
         return false;
     }
@@ -1975,15 +2152,14 @@ SegmentSealedImpl::generate_interim_index(const FieldId field_id) {
         if (row_count < field_binlog_config->GetBuildThreshold()) {
             return false;
         }
-        std::shared_ptr<SingleChunkColumnBase> vec_data{};
+        std::shared_ptr<ChunkedColumnBase> vec_data{};
         {
             std::shared_lock lck(mutex_);
             vec_data = fields_.at(field_id);
         }
         auto dim =
             is_sparse
-                ? dynamic_cast<SingleChunkSparseFloatColumn*>(vec_data.get())
-                      ->Dim()
+                ? dynamic_cast<ChunkedSparseFloatColumn*>(vec_data.get())->Dim()
                 : field_meta.get_dim();
 
         auto build_config = field_binlog_config->GetBuildBaseParams();
@@ -1991,17 +2167,24 @@ SegmentSealedImpl::generate_interim_index(const FieldId field_id) {
         build_config[knowhere::meta::NUM_BUILD_THREAD] = std::to_string(1);
         auto index_metric = field_binlog_config->GetMetricType();
 
-        auto dataset =
-            knowhere::GenDataSet(row_count, dim, (void*)vec_data->Data());
-        dataset->SetIsOwner(false);
-        dataset->SetIsSparse(is_sparse);
+        auto vec_index = std::make_unique<index::VectorMemIndex<float>>(
+            field_binlog_config->GetIndexType(),
+            index_metric,
+            knowhere::Version::GetCurrentVersion().VersionNumber());
+        auto num_chunk = fields_.at(field_id)->num_chunks();
+        for (int i = 0; i < num_chunk; ++i) {
+            auto dataset = knowhere::GenDataSet(
+                vec_data->chunk_row_nums(i), dim, vec_data->Data(i));
+            dataset->SetIsOwner(false);
+            dataset->SetIsSparse(is_sparse);
 
-        index::IndexBasePtr vec_index =
-            std::make_unique<index::VectorMemIndex<float>>(
-                field_binlog_config->GetIndexType(),
-                index_metric,
-                knowhere::Version::GetCurrentVersion().VersionNumber());
-        vec_index->BuildWithDataset(dataset, build_config);
+            if (i == 0) {
+                vec_index->BuildWithDataset(dataset, build_config);
+            } else {
+                vec_index->AddWithDataset(dataset, build_config);
+            }
+        }
+
         if (enable_binlog_index()) {
             std::unique_lock lck(mutex_);
             vector_indexings_.append_field_indexing(
@@ -2021,7 +2204,7 @@ SegmentSealedImpl::generate_interim_index(const FieldId field_id) {
     }
 }
 void
-SegmentSealedImpl::RemoveFieldFile(const FieldId field_id) {
+ChunkedSegmentSealedImpl::RemoveFieldFile(const FieldId field_id) {
     auto cc = storage::MmapManager::GetInstance().GetChunkCache();
     if (cc == nullptr) {
         return;
@@ -2034,84 +2217,6 @@ SegmentSealedImpl::RemoveFieldFile(const FieldId field_id) {
             return;
         }
     }
-}
-
-void
-SegmentSealedImpl::CreateTextIndex(FieldId field_id) {
-    std::unique_lock lck(mutex_);
-
-    const auto& field_meta = schema_->operator[](field_id);
-    auto& cfg = storage::MmapManager::GetInstance().GetMmapConfig();
-    std::unique_ptr<index::TextMatchIndex> index;
-    if (!cfg.GetScalarIndexEnableMmap()) {
-        // build text index in ram.
-        index = std::make_unique<index::TextMatchIndex>(
-            std::numeric_limits<int64_t>::max(),
-            "milvus_tokenizer",
-            field_meta.get_tokenizer_params());
-    } else {
-        // build text index using mmap.
-        index = std::make_unique<index::TextMatchIndex>(
-            cfg.GetMmapPath(),
-            "milvus_tokenizer",
-            field_meta.get_tokenizer_params());
-    }
-
-    {
-        // build
-        auto iter = fields_.find(field_id);
-        if (iter != fields_.end()) {
-            auto column = std::dynamic_pointer_cast<
-                SingleChunkVariableColumn<std::string>>(iter->second);
-            AssertInfo(
-                column != nullptr,
-                "failed to create text index, field is not of text type: {}",
-                field_id.get());
-            auto n = column->NumRows();
-            for (size_t i = 0; i < n; i++) {
-                index->AddText(std::string(column->RawAt(i)), i);
-            }
-        } else {  // fetch raw data from index.
-            auto field_index_iter = scalar_indexings_.find(field_id);
-            AssertInfo(field_index_iter != scalar_indexings_.end(),
-                       "failed to create text index, neither raw data nor "
-                       "index are found");
-            auto ptr = field_index_iter->second.get();
-            AssertInfo(ptr->HasRawData(),
-                       "text raw data not found, trying to create text index "
-                       "from index, but this index don't contain raw data");
-            auto impl = dynamic_cast<index::ScalarIndex<std::string>*>(ptr);
-            AssertInfo(impl != nullptr,
-                       "failed to create text index, field index cannot be "
-                       "converted to string index");
-            auto n = impl->Size();
-            for (size_t i = 0; i < n; i++) {
-                index->AddText(impl->Reverse_Lookup(i), i);
-            }
-        }
-    }
-
-    // create index reader.
-    index->CreateReader();
-    // release index writer.
-    index->Finish();
-
-    index->Reload();
-
-    index->RegisterTokenizer("milvus_tokenizer",
-                             field_meta.get_tokenizer_params());
-
-    text_indexes_[field_id] = std::move(index);
-}
-
-void
-SegmentSealedImpl::LoadTextIndex(FieldId field_id,
-                                 std::unique_ptr<index::TextMatchIndex> index) {
-    std::unique_lock lck(mutex_);
-    const auto& field_meta = schema_->operator[](field_id);
-    index->RegisterTokenizer("milvus_tokenizer",
-                             field_meta.get_tokenizer_params());
-    text_indexes_[field_id] = std::move(index);
 }
 
 }  // namespace milvus::segcore

--- a/internal/core/src/segcore/ConcurrentVector.h
+++ b/internal/core/src/segcore/ConcurrentVector.h
@@ -234,9 +234,11 @@ class ConcurrentVectorImpl : public VectorBase {
         if (element_count == 0) {
             return;
         }
+        auto size =
+            size_per_chunk_ == MAX_ROW_COUNT ? element_count : size_per_chunk_;
         chunks_ptr_->emplace_to_at_least(
-            upper_div(element_offset + element_count, size_per_chunk_),
-            elements_per_row_ * size_per_chunk_);
+            upper_div(element_offset + element_count, size),
+            elements_per_row_ * size);
         set_data(
             element_offset, static_cast<const Type*>(source), element_count);
     }

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -399,7 +399,7 @@ SegmentGrowingImpl::chunk_view_impl(FieldId field_id, int64_t chunk_id) const {
 }
 
 int64_t
-SegmentGrowingImpl::num_chunk() const {
+SegmentGrowingImpl::num_chunk(FieldId field_id) const {
     auto size = get_insert_record().ack_responder_.GetAck();
     return upper_div(size, segcore_config_.get_chunk_rows());
 }

--- a/internal/core/src/segcore/SegmentGrowingImpl.h
+++ b/internal/core/src/segcore/SegmentGrowingImpl.h
@@ -135,6 +135,22 @@ class SegmentGrowingImpl : public SegmentGrowing {
         return segcore_config_.get_chunk_rows();
     }
 
+    virtual int64_t
+    chunk_size(FieldId field_id, int64_t chunk_id) const final {
+        return segcore_config_.get_chunk_rows();
+    }
+
+    std::pair<int64_t, int64_t>
+    get_chunk_by_offset(FieldId field_id, int64_t offset) const override {
+        auto size_per_chunk = segcore_config_.get_chunk_rows();
+        return {offset / size_per_chunk, offset % size_per_chunk};
+    }
+
+    int64_t
+    num_rows_until_chunk(FieldId field_id, int64_t chunk_id) const override {
+        return chunk_id * segcore_config_.get_chunk_rows();
+    }
+
     void
     try_remove_chunks(FieldId fieldId);
 
@@ -320,7 +336,7 @@ class SegmentGrowingImpl : public SegmentGrowing {
 
  protected:
     int64_t
-    num_chunk() const override;
+    num_chunk(FieldId field_id) const override;
 
     SpanBase
     chunk_data_impl(FieldId field_id, int64_t chunk_id) const override;

--- a/internal/core/src/segcore/SegmentInterface.cpp
+++ b/internal/core/src/segcore/SegmentInterface.cpp
@@ -392,14 +392,6 @@ SegmentInternalInterface::LoadPrimitiveSkipIndex(milvus::FieldId field_id,
         field_id, chunk_id, data_type, chunk_data, valid_data, count);
 }
 
-void
-SegmentInternalInterface::LoadStringSkipIndex(
-    milvus::FieldId field_id,
-    int64_t chunk_id,
-    const milvus::VariableColumn<std::string>& var_column) {
-    skip_index_.LoadString(field_id, chunk_id, var_column);
-}
-
 index::TextMatchIndex*
 SegmentInternalInterface::GetTextIndex(FieldId field_id) const {
     std::shared_lock lock(mutex_);

--- a/internal/core/src/segcore/SegmentInterface.h
+++ b/internal/core/src/segcore/SegmentInterface.h
@@ -21,6 +21,7 @@
 
 #include "DeletedRecord.h"
 #include "FieldIndexing.h"
+#include "common/Common.h"
 #include "common/Schema.h"
 #include "common/Span.h"
 #include "common/SystemProperty.h"
@@ -179,13 +180,24 @@ class SegmentInternalInterface : public SegmentInterface {
         BufferView buffer = chunk_info.first;
         std::vector<ViewType> res;
         res.reserve(length);
-        char* pos = buffer.data_;
-        for (size_t j = 0; j < length; j++) {
-            uint32_t size;
-            size = *reinterpret_cast<uint32_t*>(pos);
-            pos += sizeof(uint32_t);
-            res.emplace_back(ViewType(pos, size));
-            pos += size;
+        if (buffer.data_.index() == 1) {
+            char* pos = std::get<1>(buffer.data_).first;
+            for (size_t j = 0; j < length; j++) {
+                uint32_t size;
+                size = *reinterpret_cast<uint32_t*>(pos);
+                pos += sizeof(uint32_t);
+                res.emplace_back(ViewType(pos, size));
+                pos += size;
+            }
+        } else {
+            auto elements = std::get<0>(buffer.data_);
+            for (auto& element : elements) {
+                for (int i = element.start_; i < element.end_; i++) {
+                    res.emplace_back(ViewType(
+                        element.data_ + element.offsets_[i],
+                        element.offsets_[i + 1] - element.offsets_[i]));
+                }
+            }
         }
         return std::make_pair(res, chunk_info.second);
     }
@@ -246,6 +258,10 @@ class SegmentInternalInterface : public SegmentInterface {
     set_field_avg_size(FieldId field_id,
                        int64_t num_rows,
                        int64_t field_size) override;
+    virtual bool
+    is_chunked() const {
+        return false;
+    }
 
     const SkipIndex&
     GetSkipIndex() const;
@@ -258,10 +274,13 @@ class SegmentInternalInterface : public SegmentInterface {
                            const bool* valid_data,
                            int64_t count);
 
+    template <typename T>
     void
     LoadStringSkipIndex(FieldId field_id,
                         int64_t chunk_id,
-                        const milvus::VariableColumn<std::string>& var_column);
+                        const T& var_column) {
+        skip_index_.LoadString(field_id, chunk_id, var_column);
+    }
 
     virtual DataType
     GetFieldDataType(FieldId fieldId) const = 0;
@@ -291,6 +310,9 @@ class SegmentInternalInterface : public SegmentInterface {
     virtual int64_t
     num_chunk_data(FieldId field_id) const = 0;
 
+    virtual int64_t
+    num_rows_until_chunk(FieldId field_id, int64_t chunk_id) const = 0;
+
     // bitset 1 means not hit. 0 means hit.
     virtual void
     mask_with_timestamps(BitsetTypeView& bitset_chunk,
@@ -298,7 +320,13 @@ class SegmentInternalInterface : public SegmentInterface {
 
     // count of chunks
     virtual int64_t
-    num_chunk() const = 0;
+    num_chunk(FieldId field_id) const = 0;
+
+    virtual int64_t
+    chunk_size(FieldId field_id, int64_t chunk_id) const = 0;
+
+    virtual std::pair<int64_t, int64_t>
+    get_chunk_by_offset(FieldId field_id, int64_t offset) const = 0;
 
     // element size in each chunk
     virtual int64_t
@@ -384,7 +412,13 @@ class SegmentInternalInterface : public SegmentInterface {
     // internal API: return chunk_index in span, support scalar index only
     virtual const index::IndexBase*
     chunk_index_impl(FieldId field_id, int64_t chunk_id) const = 0;
+    virtual void
+    check_search(const query::Plan* plan) const = 0;
 
+    virtual const ConcurrentVector<Timestamp>&
+    get_timestamps() const = 0;
+
+ public:
     // calculate output[i] = Vec[seg_offsets[i]}, where Vec binds to system_type
     virtual void
     bulk_subscript(SystemFieldType system_type,
@@ -404,12 +438,6 @@ class SegmentInternalInterface : public SegmentInterface {
         const int64_t* seg_offsets,
         int64_t count,
         const std::vector<std::string>& dynamic_field_names) const = 0;
-
-    virtual void
-    check_search(const query::Plan* plan) const = 0;
-
-    virtual const ConcurrentVector<Timestamp>&
-    get_timestamps() const = 0;
 
  protected:
     mutable std::shared_mutex mutex_;

--- a/internal/core/src/segcore/SegmentSealed.h
+++ b/internal/core/src/segcore/SegmentSealed.h
@@ -19,7 +19,6 @@
 #include "pb/segcore.pb.h"
 #include "segcore/SegmentInterface.h"
 #include "segcore/Types.h"
-#include "mmap/Column.h"
 
 namespace milvus::segcore {
 
@@ -42,6 +41,12 @@ class SegmentSealed : public SegmentInternalInterface {
     AddFieldDataInfoForSealed(const LoadFieldDataInfo& field_data_info) = 0;
     virtual void
     WarmupChunkCache(const FieldId field_id, bool mmap_enabled) = 0;
+    virtual void
+    RemoveFieldFile(const FieldId field_id) = 0;
+    virtual void
+    ClearData() = 0;
+    virtual std::unique_ptr<DataArray>
+    get_vector(FieldId field_id, const int64_t* ids, int64_t count) const = 0;
 
     virtual void
     LoadTextIndex(FieldId field_id,

--- a/internal/core/src/segcore/Utils.cpp
+++ b/internal/core/src/segcore/Utils.cpp
@@ -10,6 +10,7 @@
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
 #include "segcore/Utils.h"
+#include <arrow/record_batch.h>
 
 #include <future>
 #include <memory>
@@ -22,6 +23,7 @@
 #include "index/ScalarIndex.h"
 #include "mmap/Utils.h"
 #include "log/Log.h"
+#include "storage/DataCodec.h"
 #include "storage/RemoteChunkManagerSingleton.h"
 #include "storage/ThreadPools.h"
 #include "storage/Util.h"
@@ -784,6 +786,42 @@ ReverseDataFromIndex(const index::IndexBase* index,
 // init segcore storage config first, and create default remote chunk manager
 // segcore use default remote chunk manager to load data from minio/s3
 void
+LoadArrowReaderFromRemote(const std::vector<std::string>& remote_files,
+                          std::shared_ptr<ArrowReaderChannel> channel) {
+    try {
+        auto rcm = storage::RemoteChunkManagerSingleton::GetInstance()
+                       .GetRemoteChunkManager();
+        auto& pool = ThreadPools::GetThreadPool(ThreadPoolPriority::HIGH);
+
+        std::vector<std::future<std::shared_ptr<milvus::ArrowDataWrapper>>>
+            futures;
+        futures.reserve(remote_files.size());
+        for (const auto& file : remote_files) {
+            auto future = pool.Submit([&]() {
+                auto fileSize = rcm->Size(file);
+                auto buf = std::shared_ptr<uint8_t[]>(new uint8_t[fileSize]);
+                rcm->Read(file, buf.get(), fileSize);
+                auto result =
+                    storage::DeserializeFileData(buf, fileSize, false);
+                result->SetData(buf);
+                return result->GetReader();
+            });
+            futures.emplace_back(std::move(future));
+        }
+
+        for (auto& future : futures) {
+            auto field_data = future.get();
+            channel->push(field_data);
+        }
+
+        channel->close();
+    } catch (std::exception& e) {
+        LOG_INFO("failed to load data from remote: {}", e.what());
+        channel->close(std::current_exception());
+    }
+}
+
+void
 LoadFieldDatasFromRemote(const std::vector<std::string>& remote_files,
                          FieldDataChannelPtr channel) {
     try {
@@ -815,7 +853,6 @@ LoadFieldDatasFromRemote(const std::vector<std::string>& remote_files,
         channel->close(std::current_exception());
     }
 }
-
 int64_t
 upper_bound(const ConcurrentVector<Timestamp>& timestamps,
             int64_t first,

--- a/internal/core/src/segcore/Utils.h
+++ b/internal/core/src/segcore/Utils.h
@@ -185,9 +185,12 @@ ReverseDataFromIndex(const index::IndexBase* index,
                      const FieldMeta& field_meta);
 
 void
+LoadArrowReaderFromRemote(const std::vector<std::string>& remote_files,
+                          std::shared_ptr<ArrowReaderChannel> channel);
+
+void
 LoadFieldDatasFromRemote(const std::vector<std::string>& remote_files,
                          FieldDataChannelPtr channel);
-
 /**
  * Returns an index pointing to the first element in the range [first, last) such that `value < element` is true
  * (i.e. that is strictly greater than value), or last if no such element is found.

--- a/internal/core/src/storage/ChunkCache.h
+++ b/internal/core/src/storage/ChunkCache.h
@@ -17,8 +17,9 @@
 #pragma once
 #include <future>
 #include <unordered_map>
+#include "common/FieldMeta.h"
 #include "storage/MmapChunkManager.h"
-#include "mmap/Column.h"
+#include "mmap/ChunkedColumn.h"
 
 namespace milvus::storage {
 
@@ -47,6 +48,11 @@ class ChunkCache {
     std::shared_ptr<ColumnBase>
     Read(const std::string& filepath,
          const MmapChunkDescriptorPtr& descriptor,
+         const FieldMeta& field_meta);
+
+    std::shared_ptr<ColumnBase>
+    Read(const std::string& filepath,
+         const MmapChunkDescriptorPtr& descriptor,
          const FieldMeta& field_meta,
          bool mmap_enabled,
          bool mmap_rss_not_need = false);
@@ -58,6 +64,9 @@ class ChunkCache {
     Prefetch(const std::string& filepath);
 
  private:
+    std::string
+    CachePath(const std::string& filepath);
+
     std::shared_ptr<ColumnBase>
     ConvertToColumn(const FieldDataPtr& field_data,
                     const MmapChunkDescriptorPtr& descriptor,

--- a/internal/core/src/storage/Event.cpp
+++ b/internal/core/src/storage/Event.cpp
@@ -210,7 +210,8 @@ DescriptorEventData::Serialize() {
 BaseEventData::BaseEventData(BinlogReaderPtr reader,
                              int event_length,
                              DataType data_type,
-                             bool nullable) {
+                             bool nullable,
+                             bool is_field_data) {
     auto ast = reader->Read(sizeof(start_timestamp), &start_timestamp);
     AssertInfo(ast.ok(), "read start timestamp failed");
     ast = reader->Read(sizeof(end_timestamp), &end_timestamp);
@@ -220,9 +221,11 @@ BaseEventData::BaseEventData(BinlogReaderPtr reader,
         event_length - sizeof(start_timestamp) - sizeof(end_timestamp);
     auto res = reader->Read(payload_length);
     AssertInfo(res.first.ok(), "read payload failed");
-    auto payload_reader = std::make_shared<PayloadReader>(
-        res.second.get(), payload_length, data_type, nullable);
-    field_data = payload_reader->get_field_data();
+    payload_reader = std::make_shared<PayloadReader>(
+        res.second.get(), payload_length, data_type, nullable, is_field_data);
+    if (is_field_data) {
+        field_data = payload_reader->get_field_data();
+    }
 }
 
 std::vector<uint8_t>

--- a/internal/core/src/storage/Event.h
+++ b/internal/core/src/storage/Event.h
@@ -24,6 +24,7 @@
 
 #include "common/FieldData.h"
 #include "common/Types.h"
+#include "storage/PayloadReader.h"
 #include "storage/Types.h"
 #include "storage/BinlogReader.h"
 
@@ -76,12 +77,14 @@ struct BaseEventData {
     Timestamp start_timestamp;
     Timestamp end_timestamp;
     FieldDataPtr field_data;
+    std::shared_ptr<PayloadReader> payload_reader;
 
     BaseEventData() = default;
     explicit BaseEventData(BinlogReaderPtr reader,
                            int event_length,
                            DataType data_type,
-                           bool nullable);
+                           bool nullable,
+                           bool is_field_data = true);
 
     std::vector<uint8_t>
     Serialize();

--- a/internal/core/src/storage/InsertData.h
+++ b/internal/core/src/storage/InsertData.h
@@ -20,6 +20,7 @@
 #include <memory>
 
 #include "storage/DataCodec.h"
+#include "storage/PayloadReader.h"
 
 namespace milvus::storage {
 
@@ -27,6 +28,10 @@ class InsertData : public DataCodec {
  public:
     explicit InsertData(FieldDataPtr data)
         : DataCodec(data, CodecType::InsertDataType) {
+    }
+
+    explicit InsertData(std::shared_ptr<PayloadReader> payload_reader)
+        : DataCodec(payload_reader, CodecType::InsertDataType) {
     }
 
     std::vector<uint8_t>

--- a/internal/core/src/storage/PayloadReader.h
+++ b/internal/core/src/storage/PayloadReader.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <memory>
+#include <arrow/record_batch.h>
 #include <parquet/arrow/reader.h>
 
 #include "common/FieldData.h"
@@ -29,16 +30,27 @@ class PayloadReader {
     explicit PayloadReader(const uint8_t* data,
                            int length,
                            DataType data_type,
-                           bool nullable_);
+                           bool nullable,
+                           bool is_field_data = true);
 
     ~PayloadReader() = default;
 
     void
-    init(std::shared_ptr<arrow::io::BufferReader> buffer);
+    init(std::shared_ptr<arrow::io::BufferReader> buffer, bool is_field_data);
 
     const FieldDataPtr
     get_field_data() const {
         return field_data_;
+    }
+
+    std::shared_ptr<arrow::RecordBatchReader>
+    get_reader() {
+        return record_batch_reader_;
+    }
+
+    std::shared_ptr<parquet::arrow::FileReader>
+    get_file_reader() {
+        return arrow_reader_;
     }
 
  private:
@@ -46,6 +58,9 @@ class PayloadReader {
     int dim_;
     bool nullable_;
     FieldDataPtr field_data_;
+
+    std::shared_ptr<parquet::arrow::FileReader> arrow_reader_;
+    std::shared_ptr<arrow::RecordBatchReader> record_batch_reader_;
 };
 
 }  // namespace milvus::storage

--- a/internal/core/src/storage/Util.h
+++ b/internal/core/src/storage/Util.h
@@ -102,7 +102,8 @@ GetSegmentRawDataPathPrefix(ChunkManagerPtr cm, int64_t segment_id);
 
 std::unique_ptr<DataCodec>
 DownloadAndDecodeRemoteFile(ChunkManager* chunk_manager,
-                            const std::string& file);
+                            const std::string& file,
+                            bool is_field_data = true);
 
 std::pair<std::string, size_t>
 EncodeAndUploadIndexSlice(ChunkManager* chunk_manager,

--- a/internal/core/unittest/test_chunk.cpp
+++ b/internal/core/unittest/test_chunk.cpp
@@ -9,17 +9,23 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
+#include <fcntl.h>
 #include <gtest/gtest.h>
 #include <arrow/buffer.h>
 #include <arrow/io/memory.h>
 #include <parquet/arrow/reader.h>
+#include <unistd.h>
 #include <memory>
+#include <string>
 
+#include "boost/filesystem/operations.hpp"
+#include "boost/filesystem/path.hpp"
 #include "common/Chunk.h"
 #include "common/ChunkWriter.h"
 #include "common/EasyAssert.h"
 #include "common/FieldDataInterface.h"
 #include "common/FieldMeta.h"
+#include "common/File.h"
 #include "common/Types.h"
 #include "storage/Event.h"
 #include "storage/Util.h"
@@ -53,8 +59,7 @@ TEST(chunk, test_int64_field) {
     FieldMeta field_meta(
         FieldName("a"), milvus::FieldId(1), DataType::INT64, false);
     auto chunk = create_chunk(field_meta, 1, rb_reader);
-    auto span =
-        std::dynamic_pointer_cast<FixedWidthChunk<int64_t>>(chunk)->Span();
+    auto span = std::dynamic_pointer_cast<FixedWidthChunk>(chunk)->Span();
     EXPECT_EQ(span.row_count(), data.size());
     for (size_t i = 0; i < data.size(); ++i) {
         auto n = *(int64_t*)((char*)span.data() + i * span.element_sizeof());
@@ -92,7 +97,7 @@ TEST(chunk, test_variable_field) {
     auto chunk = create_chunk(field_meta, 1, rb_reader);
     auto views = std::dynamic_pointer_cast<StringChunk>(chunk)->StringViews();
     for (size_t i = 0; i < data.size(); ++i) {
-        EXPECT_EQ(views[i], data[i]);
+        EXPECT_EQ(views.first[i], data[i]);
     }
 }
 
@@ -183,4 +188,68 @@ TEST(chunk, test_sparse_float) {
             EXPECT_EQ(v1[j].val, v2[j].val);
         }
     }
+}
+
+class TempDir {
+ public:
+    TempDir() {
+        auto path = boost::filesystem::unique_path("%%%%_%%%%");
+        auto abs_path = boost::filesystem::temp_directory_path() / path;
+        boost::filesystem::create_directory(abs_path);
+        dir_ = abs_path;
+    }
+
+    ~TempDir() {
+        boost::filesystem::remove_all(dir_);
+    }
+
+    std::string
+    dir() {
+        return dir_.string();
+    }
+
+ private:
+    boost::filesystem::path dir_;
+};
+
+TEST(chunk, multiple_chunk_mmap) {
+    TempDir temp;
+    std::string temp_dir = temp.dir();
+    auto file = File::Open(temp_dir + "/multi_chunk_mmap", O_CREAT | O_RDWR);
+
+    FixedVector<int64_t> data = {1, 2, 3, 4, 5};
+    auto field_data =
+        milvus::storage::CreateFieldData(storage::DataType::INT64);
+    field_data->FillFieldData(data.data(), data.size());
+    storage::InsertEventData event_data;
+    event_data.field_data = field_data;
+    auto ser_data = event_data.Serialize();
+    auto buffer = std::make_shared<arrow::io::BufferReader>(
+        ser_data.data() + 2 * sizeof(milvus::Timestamp),
+        ser_data.size() - 2 * sizeof(milvus::Timestamp));
+
+    parquet::arrow::FileReaderBuilder reader_builder;
+    auto s = reader_builder.Open(buffer);
+    EXPECT_TRUE(s.ok());
+    std::unique_ptr<parquet::arrow::FileReader> arrow_reader;
+    s = reader_builder.Build(&arrow_reader);
+    EXPECT_TRUE(s.ok());
+
+    std::shared_ptr<::arrow::RecordBatchReader> rb_reader;
+    s = arrow_reader->GetRecordBatchReader(&rb_reader);
+    EXPECT_TRUE(s.ok());
+
+    FieldMeta field_meta(
+        FieldName("a"), milvus::FieldId(1), DataType::INT64, false);
+    int file_offset = 0;
+    auto page_size = sysconf(_SC_PAGESIZE);
+    auto chunk = create_chunk(field_meta, 1, file, file_offset, rb_reader);
+    EXPECT_TRUE(chunk->Size() % page_size == 0);
+    file_offset += chunk->Size();
+
+    std::shared_ptr<::arrow::RecordBatchReader> rb_reader2;
+    s = arrow_reader->GetRecordBatchReader(&rb_reader2);
+    EXPECT_TRUE(s.ok());
+    auto chunk2 = create_chunk(field_meta, 1, file, file_offset, rb_reader2);
+    EXPECT_TRUE(chunk->Size() % page_size == 0);
 }

--- a/internal/core/unittest/test_sealed.cpp
+++ b/internal/core/unittest/test_sealed.cpp
@@ -508,7 +508,7 @@ TEST(Sealed, LoadFieldData) {
     vec_info.index_params["metric_type"] = knowhere::metric::L2;
     segment->LoadIndex(vec_info);
 
-    ASSERT_EQ(segment->num_chunk(), 1);
+    ASSERT_EQ(segment->num_chunk(FieldId(0)), 1);
     ASSERT_EQ(segment->num_chunk_index(double_id), 0);
     ASSERT_EQ(segment->num_chunk_index(str_id), 0);
     auto chunk_span1 = segment->chunk_data<int64_t>(counter_id, 0);
@@ -671,7 +671,7 @@ TEST(Sealed, ClearData) {
     vec_info.index_params["metric_type"] = knowhere::metric::L2;
     segment->LoadIndex(vec_info);
 
-    ASSERT_EQ(segment->num_chunk(), 1);
+    ASSERT_EQ(segment->num_chunk(FieldId(0)), 1);
     ASSERT_EQ(segment->num_chunk_index(double_id), 0);
     ASSERT_EQ(segment->num_chunk_index(str_id), 0);
     auto chunk_span1 = segment->chunk_data<int64_t>(counter_id, 0);
@@ -775,7 +775,7 @@ TEST(Sealed, LoadFieldDataMmap) {
     vec_info.index_params["metric_type"] = knowhere::metric::L2;
     segment->LoadIndex(vec_info);
 
-    ASSERT_EQ(segment->num_chunk(), 1);
+    ASSERT_EQ(segment->num_chunk(FieldId(0)), 1);
     ASSERT_EQ(segment->num_chunk_index(double_id), 0);
     ASSERT_EQ(segment->num_chunk_index(str_id), 0);
     auto chunk_span1 = segment->chunk_data<int64_t>(counter_id, 0);

--- a/internal/core/unittest/test_span.cpp
+++ b/internal/core/unittest/test_span.cpp
@@ -46,7 +46,7 @@ TEST(Span, Naive) {
     auto float_ptr = dataset.get_col<float>(float_vec_fid);
     auto nullable_data_ptr = dataset.get_col<int64_t>(nullable_fid);
     auto nullable_valid_data_ptr = dataset.get_col_valid(nullable_fid);
-    auto num_chunk = segment->num_chunk();
+    auto num_chunk = segment->num_chunk(FieldId(0));
     ASSERT_EQ(num_chunk, upper_div(N, size_per_chunk));
     auto row_count = segment->get_row_count();
     ASSERT_EQ(N, row_count);

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -281,11 +281,16 @@ func NewSegment(ctx context.Context,
 		return nil, err
 	}
 
+	multipleChunkEnable := paramtable.Get().QueryNodeCfg.MultipleChunkedEnable.GetAsBool()
 	var cSegType C.SegmentType
 	var locker *state.LoadStateLock
 	switch segmentType {
 	case SegmentTypeSealed:
-		cSegType = C.Sealed
+		if multipleChunkEnable {
+			cSegType = C.ChunkedSealed
+		} else {
+			cSegType = C.Sealed
+		}
 		locker = state.NewLoadStateLock(state.LoadStateOnlyMeta)
 	case SegmentTypeGrowing:
 		locker = state.NewLoadStateLock(state.LoadStateDataLoaded)

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -2330,6 +2330,7 @@ type queryNodeConfig struct {
 	InterimIndexNProbe            ParamItem `refreshable:"false"`
 	InterimIndexMemExpandRate     ParamItem `refreshable:"false"`
 	InterimIndexBuildParallelRate ParamItem `refreshable:"false"`
+	MultipleChunkedEnable         ParamItem `refreshable:"false"`
 
 	KnowhereScoreConsistency ParamItem `refreshable:"false"`
 
@@ -2544,6 +2545,15 @@ This defaults to true, indicating that Milvus creates temporary index for growin
 		Export:       true,
 	}
 	p.InterimIndexBuildParallelRate.Init(base.mgr)
+
+	p.MultipleChunkedEnable = ParamItem{
+		Key:          "queryNode.segcore.multipleChunkedEnable",
+		Version:      "2.0.0",
+		DefaultValue: "false",
+		Doc:          "Enable multiple chunked search",
+		Export:       true,
+	}
+	p.MultipleChunkedEnable.Init(base.mgr)
 
 	p.InterimIndexNProbe = ParamItem{
 		Key:     "queryNode.segcore.interimIndex.nprobe",


### PR DESCRIPTION
This PR splits sealed segment to chunked data to avoid unnecessary memory copy and save memory usage when loading segments so that loading can be accelerated.

To support rollback to previous version, we add an option `multipleChunkedEnable` which is false by default.