### PR TITLE
fix: [2.4] Make sure querycoord observers started once (#35811)

### DIFF
--- a/internal/querycoordv2/observers/leader_cache_observer.go
+++ b/internal/querycoordv2/observers/leader_cache_observer.go
@@ -36,6 +36,7 @@ type CollectionShardLeaderCache = map[string]*querypb.ShardLeadersList
 type LeaderCacheObserver struct {
 	wg           sync.WaitGroup
 	proxyManager proxyutil.ProxyClientManagerInterface
+	startOnce    sync.Once
 	stopOnce     sync.Once
 	closeCh      chan struct{}
 
@@ -44,8 +45,10 @@ type LeaderCacheObserver struct {
 }
 
 func (o *LeaderCacheObserver) Start(ctx context.Context) {
-	o.wg.Add(1)
-	go o.schedule(ctx)
+	o.startOnce.Do(func() {
+		o.wg.Add(1)
+		go o.schedule(ctx)
+	})
 }
 
 func (o *LeaderCacheObserver) Stop() {

--- a/internal/querycoordv2/observers/replica_observer.go
+++ b/internal/querycoordv2/observers/replica_observer.go
@@ -37,7 +37,8 @@ type ReplicaObserver struct {
 	meta    *meta.Meta
 	distMgr *meta.DistributionManager
 
-	stopOnce sync.Once
+	startOnce sync.Once
+	stopOnce  sync.Once
 }
 
 func NewReplicaObserver(meta *meta.Meta, distMgr *meta.DistributionManager) *ReplicaObserver {
@@ -48,11 +49,13 @@ func NewReplicaObserver(meta *meta.Meta, distMgr *meta.DistributionManager) *Rep
 }
 
 func (ob *ReplicaObserver) Start() {
-	ctx, cancel := context.WithCancel(context.Background())
-	ob.cancel = cancel
+	ob.startOnce.Do(func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		ob.cancel = cancel
 
-	ob.wg.Add(1)
-	go ob.schedule(ctx)
+		ob.wg.Add(1)
+		go ob.schedule(ctx)
+	})
 }
 
 func (ob *ReplicaObserver) Stop() {

--- a/internal/querycoordv2/observers/resource_observer.go
+++ b/internal/querycoordv2/observers/resource_observer.go
@@ -36,7 +36,8 @@ type ResourceObserver struct {
 	wg     sync.WaitGroup
 	meta   *meta.Meta
 
-	stopOnce sync.Once
+	startOnce sync.Once
+	stopOnce  sync.Once
 }
 
 func NewResourceObserver(meta *meta.Meta) *ResourceObserver {
@@ -46,11 +47,13 @@ func NewResourceObserver(meta *meta.Meta) *ResourceObserver {
 }
 
 func (ob *ResourceObserver) Start() {
-	ctx, cancel := context.WithCancel(context.Background())
-	ob.cancel = cancel
+	ob.startOnce.Do(func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		ob.cancel = cancel
 
-	ob.wg.Add(1)
-	go ob.schedule(ctx)
+		ob.wg.Add(1)
+		go ob.schedule(ctx)
+	})
 }
 
 func (ob *ResourceObserver) Stop() {

--- a/internal/querycoordv2/services_test.go
+++ b/internal/querycoordv2/services_test.go
@@ -1084,8 +1084,6 @@ func (suite *ServiceSuite) TestReleasePartition() {
 func (suite *ServiceSuite) TestRefreshCollection() {
 	server := suite.server
 
-	server.collectionObserver.Start()
-
 	// Test refresh all collections.
 	for _, collection := range suite.collections {
 		err := server.refreshCollection(collection)


### PR DESCRIPTION
Cherry-pick from master
pr: #35811
Related to #35809