### PR TITLE
test: use pytest-tagging dependency

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -9,7 +9,7 @@
 # is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 # or implied. See the License for the specific language governing permissions and limitations under the License.
 
-FROM python:3.8-buster
+FROM python:3.10-buster
 
 RUN apt-get update && apt-get install -y jq
 

--- a/tests/python_client/Dockerfile
+++ b/tests/python_client/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-buster
+FROM python:3.10-buster
 
 RUN apt-get update && apt-get install -y jq
 

--- a/tests/python_client/requirements.txt
+++ b/tests/python_client/requirements.txt
@@ -15,7 +15,7 @@ pytest-xdist==2.5.0
 pymilvus==2.5.0rc70
 pymilvus[bulk_writer]==2.5.0rc70
 pytest-rerunfailures==9.1.1
-pytest_tagging==1.5.2
+pytest_tagging==1.5.3
 ndg-httpsclient
 pyopenssl
 pyasn1

--- a/tests/python_client/requirements.txt
+++ b/tests/python_client/requirements.txt
@@ -15,7 +15,7 @@ pytest-xdist==2.5.0
 pymilvus==2.5.0rc70
 pymilvus[bulk_writer]==2.5.0rc70
 pytest-rerunfailures==9.1.1
-git+https://github.com/Projectplace/pytest-tags
+pytest_tagging==1.5.2
 ndg-httpsclient
 pyopenssl
 pyasn1

--- a/tests/scripts/ci-util-4am.sh
+++ b/tests/scripts/ci-util-4am.sh
@@ -44,7 +44,8 @@ export PIP_TRUSTED_HOST="nexus-ci.zilliz.cc"
 export PIP_INDEX_URL="https://nexus-ci.zilliz.cc/repository/pypi-all/simple"
 export PIP_INDEX="https://nexus-ci.zilliz.cc/repository/pypi-all/pypi"
 export PIP_FIND_LINKS="https://nexus-ci.zilliz.cc/repository/pypi-all/pypi"
- python3 -m pip install --no-cache-dir -r requirements.txt --timeout 30 --retries 6 
+ python3 -m pip install --no-cache-dir -r requirements.txt --timeout 30 --retries 6
+ pip uninstall pytest-tags -y || true
 }
 
 # Login in ci docker registry


### PR DESCRIPTION
Pytest-tagging is a compatible alternative to pytest-tags.

/kind improvement