### PR TITLE
enhance: Add build-go target (#35844)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,9 @@ ifeq (${ENABLE_AZURE}, false)
 	AZURE_OPTION := -Z
 endif
 
-milvus: build-cpp print-build-info
+milvus: build-cpp print-build-info build-go
+
+build-go:
 	@echo "Building Milvus ..."
 	@source $(PWD)/scripts/setenv.sh && \
 		mkdir -p $(INSTALL_PATH) && go env -w CGO_ENABLED="1" && \


### PR DESCRIPTION
Add a build-go target to the Makefile that only compiles Go.

issue: https://github.com/milvus-io/milvus/issues/35611

pr: https://github.com/milvus-io/milvus/pull/35844