### PR TITLE
fix: Fix tracing config update logic

### DIFF
--- a/cmd/roles/roles.go
+++ b/cmd/roles/roles.go
@@ -528,8 +528,10 @@ func (mr *MilvusRoles) Run() {
 		tracer.SetTracerProvider(exp, params.TraceCfg.SampleFraction.GetAsFloat())
 		log.Info("Reset tracer finished", zap.String("Exporter", params.TraceCfg.Exporter.GetValue()), zap.Float64("SampleFraction", params.TraceCfg.SampleFraction.GetAsFloat()))
 
+		tracer.NotifyTracerProviderUpdated()
+
 		if paramtable.GetRole() == typeutil.QueryNodeRole || paramtable.GetRole() == typeutil.StandaloneRole {
-			initcore.InitTraceConfig(params)
+			initcore.ResetTraceConfig(params)
 			log.Info("Reset segcore tracer finished", zap.String("Exporter", params.TraceCfg.Exporter.GetValue()))
 		}
 	}))

--- a/internal/core/src/common/Tracer.cpp
+++ b/internal/core/src/common/Tracer.cpp
@@ -14,6 +14,8 @@
 #include <opentelemetry/exporters/otlp/otlp_http_exporter_options.h>
 #include "log/Log.h"
 
+#include <atomic>
+#include <cstddef>
 #include <iomanip>
 #include <iostream>
 #include <utility>
@@ -42,12 +44,13 @@ namespace jaeger = opentelemetry::exporter::jaeger;
 namespace ostream = opentelemetry::exporter::trace;
 namespace otlp = opentelemetry::exporter::otlp;
 
-static bool enable_trace = true;
+static std::atomic<bool> enable_trace = true;
 static std::shared_ptr<trace::TracerProvider> noop_trace_provider =
     std::make_shared<opentelemetry::trace::NoopTracerProvider>();
 
 void
 initTelemetry(const TraceConfig& cfg) {
+    bool export_created = true;
     std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> exporter;
     if (cfg.exporter == "stdout") {
         exporter = ostream::OStreamSpanExporterFactory::Create();
@@ -72,13 +75,13 @@ initTelemetry(const TraceConfig& cfg) {
             LOG_INFO("init otlp grpc exporter, endpoint: {}", opts.endpoint);
         } else {
             LOG_INFO("unknown otlp exporter method: {}", cfg.otlpMethod);
-            enable_trace = false;
+            export_created = false;
         }
     } else {
         LOG_INFO("Empty Trace");
-        enable_trace = false;
+        export_created = false;
     }
-    if (enable_trace) {
+    if (export_created) {
         auto processor = trace_sdk::BatchSpanProcessorFactory::Create(
             std::move(exporter), {});
         resource::ResourceAttributes attributes = {
@@ -90,8 +93,10 @@ initTelemetry(const TraceConfig& cfg) {
             trace_sdk::TracerProviderFactory::Create(
                 std::move(processor), resource, std::move(sampler));
         trace::Provider::SetTracerProvider(provider);
+        enable_trace.store(true);
     } else {
         trace::Provider::SetTracerProvider(noop_trace_provider);
+        enable_trace.store(false);
     }
 }
 
@@ -105,7 +110,7 @@ GetTracer() {
 std::shared_ptr<trace::Span>
 StartSpan(const std::string& name, TraceContext* parentCtx) {
     trace::StartSpanOptions opts;
-    if (enable_trace && parentCtx != nullptr && parentCtx->traceID != nullptr &&
+    if (enable_trace.load() && parentCtx != nullptr && parentCtx->traceID != nullptr &&
         parentCtx->spanID != nullptr) {
         if (EmptyTraceID(parentCtx) || EmptySpanID(parentCtx)) {
             return noop_trace_provider->GetTracer("noop")->StartSpan("noop");
@@ -122,21 +127,21 @@ StartSpan(const std::string& name, TraceContext* parentCtx) {
 thread_local std::shared_ptr<trace::Span> local_span;
 void
 SetRootSpan(std::shared_ptr<trace::Span> span) {
-    if (enable_trace) {
+    if (enable_trace.load()) {
         local_span = std::move(span);
     }
 }
 
 void
 CloseRootSpan() {
-    if (enable_trace) {
+    if (enable_trace.load()) {
         local_span = nullptr;
     }
 }
 
 void
 AddEvent(const std::string& event_label) {
-    if (enable_trace && local_span != nullptr) {
+    if (enable_trace.load() && local_span != nullptr) {
         local_span->AddEvent(event_label);
     }
 }

--- a/internal/distributed/datanode/service.go
+++ b/internal/distributed/datanode/service.go
@@ -26,7 +26,6 @@ import (
 
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	clientv3 "go.etcd.io/etcd/client/v3"
-	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -131,14 +130,12 @@ func (s *Server) startGrpcLoop(grpcPort int) {
 		return
 	}
 
-	opts := tracer.GetInterceptorOpts()
 	s.grpcServer = grpc.NewServer(
 		grpc.KeepaliveEnforcementPolicy(kaep),
 		grpc.KeepaliveParams(kasp),
 		grpc.MaxRecvMsgSize(Params.ServerMaxRecvSize.GetAsInt()),
 		grpc.MaxSendMsgSize(Params.ServerMaxSendSize.GetAsInt()),
 		grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(
-			otelgrpc.UnaryServerInterceptor(opts...),
 			logutil.UnaryTraceLoggerInterceptor,
 			interceptor.ClusterValidationUnaryServerInterceptor(),
 			interceptor.ServerIDValidationUnaryServerInterceptor(func() int64 {
@@ -149,7 +146,6 @@ func (s *Server) startGrpcLoop(grpcPort int) {
 			}),
 		)),
 		grpc.StreamInterceptor(grpc_middleware.ChainStreamServer(
-			otelgrpc.StreamServerInterceptor(opts...),
 			logutil.StreamTraceLoggerInterceptor,
 			interceptor.ClusterValidationStreamServerInterceptor(),
 			interceptor.ServerIDValidationStreamServerInterceptor(func() int64 {
@@ -158,7 +154,8 @@ func (s *Server) startGrpcLoop(grpcPort int) {
 				}
 				return s.serverID.Load()
 			}),
-		)))
+		)),
+		grpc.StatsHandler(tracer.GetDynamicOtelGrpcServerStatsHandler()))
 	datapb.RegisterDataNodeServer(s.grpcServer, s)
 
 	ctx, cancel := context.WithCancel(s.ctx)

--- a/pkg/tracer/stats_handler.go
+++ b/pkg/tracer/stats_handler.go
@@ -1,0 +1,153 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tracer
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"go.opentelemetry.io/otel"
+	"google.golang.org/grpc/stats"
+)
+
+var (
+	dynamicServerHandler *dynamicOtelGrpcStatsHandler
+	initServerOnce       sync.Once
+	dynamicClientHandler *dynamicOtelGrpcStatsHandler
+	initClientOnce       sync.Once
+)
+
+// dynamicOtelGrpcStatsHandler wraps otelgprc.StatsHandler
+// to implement runtime configuration update.
+type dynamicOtelGrpcStatsHandler struct {
+	handler atomic.Pointer[stats.Handler]
+}
+
+func getDynamicServerHandler() *dynamicOtelGrpcStatsHandler {
+	initServerOnce.Do(func() {
+		statsHandler := otelgrpc.NewServerHandler(
+			otelgrpc.WithInterceptorFilter(filterFunc),
+			otelgrpc.WithTracerProvider(otel.GetTracerProvider()),
+		)
+
+		dynamicServerHandler = &dynamicOtelGrpcStatsHandler{}
+		dynamicServerHandler.handler.Store(&statsHandler)
+	})
+
+	return dynamicServerHandler
+}
+
+func getDynamicClientHandler() *dynamicOtelGrpcStatsHandler {
+	initClientOnce.Do(func() {
+		statsHandler := otelgrpc.NewClientHandler(
+			otelgrpc.WithInterceptorFilter(filterFunc),
+			otelgrpc.WithTracerProvider(otel.GetTracerProvider()),
+		)
+
+		dynamicClientHandler = &dynamicOtelGrpcStatsHandler{}
+		dynamicClientHandler.handler.Store(&statsHandler)
+	})
+
+	return dynamicClientHandler
+}
+
+// GetDynamicOtelGrpcServerStatsHandler returns the singleton instance of grpc server stats.Handler
+func GetDynamicOtelGrpcServerStatsHandler() stats.Handler {
+	return getDynamicServerHandler()
+}
+
+// GetDynamicOtelGrpcClientStatsHandler returns the singleton instance of grpc client stats.Handler
+func GetDynamicOtelGrpcClientStatsHandler() stats.Handler {
+	return getDynamicClientHandler()
+}
+
+func NotifyTracerProviderUpdated() {
+	serverhandler := getDynamicServerHandler()
+	statsHandler := otelgrpc.NewServerHandler(
+		otelgrpc.WithInterceptorFilter(filterFunc),
+		otelgrpc.WithTracerProvider(otel.GetTracerProvider()),
+	)
+
+	serverhandler.setHandler(statsHandler)
+
+	clientHandler := getDynamicClientHandler()
+	statsHandler = otelgrpc.NewClientHandler(
+		otelgrpc.WithInterceptorFilter(filterFunc),
+		otelgrpc.WithTracerProvider(otel.GetTracerProvider()),
+	)
+	clientHandler.setHandler(statsHandler)
+}
+
+func (h *dynamicOtelGrpcStatsHandler) getHandler() stats.Handler {
+	return *h.handler.Load()
+}
+
+func (h *dynamicOtelGrpcStatsHandler) setHandler(handler stats.Handler) {
+	h.handler.Store(&handler)
+}
+
+// TagRPC can attach some information to the given context.
+// The context used for the rest lifetime of the RPC will be derived from
+// the returned context.
+func (h *dynamicOtelGrpcStatsHandler) TagRPC(ctx context.Context, info *stats.RPCTagInfo) context.Context {
+	handler := h.getHandler()
+	if handler == nil {
+		return ctx
+	}
+
+	return handler.TagRPC(ctx, info)
+}
+
+// HandleRPC processes the RPC stats.
+func (h *dynamicOtelGrpcStatsHandler) HandleRPC(ctx context.Context, stats stats.RPCStats) {
+	handler := h.getHandler()
+	if handler == nil {
+		return
+	}
+
+	handler.HandleRPC(ctx, stats)
+}
+
+// TagConn can attach some information to the given context.
+// The returned context will be used for stats handling.
+// For conn stats handling, the context used in HandleConn for this
+// connection will be derived from the context returned.
+// For RPC stats handling,
+//   - On server side, the context used in HandleRPC for all RPCs on this
+//
+// connection will be derived from the context returned.
+//   - On client side, the context is not derived from the context returned.
+func (h *dynamicOtelGrpcStatsHandler) TagConn(ctx context.Context, tagInfo *stats.ConnTagInfo) context.Context {
+	handler := h.getHandler()
+	if handler == nil {
+		return ctx
+	}
+
+	return handler.TagConn(ctx, tagInfo)
+}
+
+// HandleConn processes the Conn stats.
+func (h *dynamicOtelGrpcStatsHandler) HandleConn(ctx context.Context, stats stats.ConnStats) {
+	handler := h.getHandler()
+	if handler == nil {
+		return
+	}
+
+	handler.HandleConn(ctx, stats)
+}


### PR DESCRIPTION
Related to #35927

There are serveral issue this PR addresses:
- Use `ResetTraceConfig` method instead init one in update event handler
- Implement dynamic stats.Handler to receive tracing config update event
- Update `enable_trace` flag when `ResetTraceConfig` is invoked
- Change `enable_trace` to `std::atomic<bool>` in case of data race