### PR TITLE
enhance: Enable to add router from proxy to replica

### DIFF
--- a/internal/querycoordv2/server.go
+++ b/internal/querycoordv2/server.go
@@ -130,6 +130,11 @@ type Server struct {
 	proxyCreator       proxyutil.ProxyCreator
 	proxyWatcher       proxyutil.ProxyWatcherInterface
 	proxyClientManager proxyutil.ProxyClientManagerInterface
+
+	// assign replica to proxy
+	proxyAssignLock sync.RWMutex
+	// proxy ID -> replica IDs
+	proxyAssignedReplicas map[int64][]int64
 }
 
 func NewQueryCoord(ctx context.Context) (*Server, error) {

--- a/internal/querycoordv2/services.go
+++ b/internal/querycoordv2/services.go
@@ -957,7 +957,7 @@ func (s *Server) GetShardLeaders(ctx context.Context, req *querypb.GetShardLeade
 				return true
 			})
 			replicas := lo.Keys(replicaShards)
-			average := len(proxyIDs) / len(replicas)
+			average := len(replicas) / len(proxyIDs)
 			if average == 0 {
 				average = 1
 			}
@@ -981,12 +981,11 @@ func (s *Server) GetShardLeaders(ctx context.Context, req *querypb.GetShardLeade
 		permitAssignReplica := func() bool {
 			return proxyCount > 1 && len(replicaShards) > 1 && (len(replicaShards)%proxyCount == 0 || proxyCount%len(replicaShards) == 0)
 		}
-		log.Info("xxx", zap.Bool("allReplicaReady", allReplicaReady()), zap.Bool("permitAssignReplica", permitAssignReplica()), zap.Any("replicaShards", replicaShards), zap.Int("proxyCount", proxyCount))
 		if allReplicaReady() && permitAssignReplica() {
 			s.proxyAssignLock.Lock()
 			defer s.proxyAssignLock.Unlock()
 			proxyID := req.GetBase().GetSourceID()
-			if _, ok := s.proxyAssignedReplicas[proxyID]; !ok {
+			if _, ok := s.proxyAssignedReplicas[proxyID]; !ok || len(s.proxyAssignedReplicas[proxyID]) != proxyCount {
 				// assign replicas to proxyIDs
 				assignReplicas()
 

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -1540,7 +1540,7 @@ please adjust in embedded Milvus: false`,
 	p.ReplicaSelectionPolicy = ParamItem{
 		Key:          "proxy.replicaSelectionPolicy",
 		Version:      "2.3.0",
-		DefaultValue: "look_aside",
+		DefaultValue: "round_robin",
 		Doc:          "replica selection policy in multiple replicas load balancing, support round_robin and look_aside",
 	}
 	p.ReplicaSelectionPolicy.Init(base.mgr)
@@ -1752,6 +1752,7 @@ type queryCoordConfig struct {
 	UpdateCollectionLoadStatusInterval ParamItem `refreshable:"false"`
 	ClusterLevelLoadReplicaNumber      ParamItem `refreshable:"true"`
 	ClusterLevelLoadResourceGroups     ParamItem `refreshable:"true"`
+	EnableAssignReplicaToProxy         ParamItem `refreshable:"true"`
 }
 
 func (p *queryCoordConfig) init(base *BaseTable) {
@@ -2306,6 +2307,15 @@ If this parameter is set false, Milvus simply searches the growing segments with
 		Export:       false,
 	}
 	p.ClusterLevelLoadResourceGroups.Init(base.mgr)
+
+	p.EnableAssignReplicaToProxy = ParamItem{
+		Key:          "queryCoord.enableAssignReplicaToProxy",
+		Version:      "2.4.10",
+		DefaultValue: "false",
+		Doc:          "whether assign replicas to proxy",
+		Export:       false,
+	}
+	p.EnableAssignReplicaToProxy.Init(base.mgr)
 }
 
 // /////////////////////////////////////////////////////////////////////////////

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -1540,7 +1540,7 @@ please adjust in embedded Milvus: false`,
 	p.ReplicaSelectionPolicy = ParamItem{
 		Key:          "proxy.replicaSelectionPolicy",
 		Version:      "2.3.0",
-		DefaultValue: "round_robin",
+		DefaultValue: "look_aside",
 		Doc:          "replica selection policy in multiple replicas load balancing, support round_robin and look_aside",
 	}
 	p.ReplicaSelectionPolicy.Init(base.mgr)

--- a/tests/integration/suite.go
+++ b/tests/integration/suite.go
@@ -84,7 +84,7 @@ func (s *MiniClusterSuite) TearDownSuite() {
 }
 
 func (s *MiniClusterSuite) SetupTest() {
-	log.SetLevel(zapcore.InfoLevel)
+	log.SetLevel(zapcore.DebugLevel)
 	s.T().Log("Setup test...")
 	// setup mini cluster to use embed etcd
 	endpoints := etcd.GetEmbedEtcdEndpoints(s.EtcdServer)


### PR DESCRIPTION
issue: #35859
if milvus has multi replica and multi proxy, in case of each proxy access all replicas, we can add router from proxy to replica, which means assign replicas to all proxy, each proxy got same number of replicas, then only access those replicas.

Notice when the goal of evenly assign all replicas to proxies can't be achieved, fallback to share all replicas between proxies.