### PR TITLE
fix: Check all values for `trie.predictive_search`

### DIFF
--- a/internal/core/src/index/StringIndexMarisa.cpp
+++ b/internal/core/src/index/StringIndexMarisa.cpp
@@ -315,12 +315,8 @@ StringIndexMarisa::Range(std::string value, OpType op) {
                 auto key = std::string(agent.key().ptr(), agent.key().length());
                 if (key > value) {
                     ids.push_back(agent.key().id());
-                    break;
                 }
             };
-            while (trie_.predictive_search(agent)) {
-                ids.push_back(agent.key().id());
-            }
             break;
         }
         case OpType::GreaterEqual: {
@@ -328,11 +324,7 @@ StringIndexMarisa::Range(std::string value, OpType op) {
                 auto key = std::string(agent.key().ptr(), agent.key().length());
                 if (key >= value) {
                     ids.push_back(agent.key().id());
-                    break;
                 }
-            }
-            while (trie_.predictive_search(agent)) {
-                ids.push_back(agent.key().id());
             }
             break;
         }


### PR DESCRIPTION
Related to #35941

For marisa trie `predictive_search` default behavior, it value iterated is not in lexicographic order.

This PR is a brute force fix to make range operator returns correct values.