### PR TITLE
enhance: set mmap.scalarField default value as true

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -410,7 +410,7 @@ queryNode:
   mmap:
     vectorField: false # Enable mmap for loading vector data
     vectorIndex: false # Enable mmap for loading vector index
-    scalarField: false # Enable mmap for loading scalar data
+    scalarField: true # Enable mmap for loading scalar data
     scalarIndex: false # Enable mmap for loading scalar index
     growingMmapEnabled: false # Enable mmap for using in growing raw data
     fixedFileSizeForMmapAlloc: 1 # tmp file size for mmap chunk manager

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -2640,7 +2640,7 @@ This defaults to true, indicating that Milvus creates temporary index for growin
 	p.MmapScalarField = ParamItem{
 		Key:          "queryNode.mmap.scalarField",
 		Version:      "2.4.7",
-		DefaultValue: "false",
+		DefaultValue: "true",
 		Formatter: func(originValue string) string {
 			if p.MmapEnabled.GetAsBool() {
 				return "true"


### PR DESCRIPTION
issue: #35896 
If a scalar index does not have raw data, milvus will load raw data to memory by default and it will consume much memory. So we set this config item's default value as true to use mmap to load raw data.