### PR TITLE
fix: [hotfix-2.4] fill the metric type field in the LoadMetaInfo object

### DIFF
--- a/internal/core/src/query/SearchOnSealed.cpp
+++ b/internal/core/src/query/SearchOnSealed.cpp
@@ -42,7 +42,10 @@ SearchOnSealedIndex(const Schema& schema,
     // Keep the field_indexing smart pointer, until all reference by raw dropped.
     auto field_indexing = record.get_field_indexing(field_id);
     AssertInfo(field_indexing->metric_type_ == search_info.metric_type_,
-               "Metric type of field index isn't the same with search info");
+               "Metric type of field index isn't the same with search info,"
+               "field index: {}, search info: {}",
+               field_indexing->metric_type_,
+               search_info.metric_type_);
 
     auto dataset = knowhere::GenDataSet(num_queries, dim, query_data);
     dataset->SetIsSparse(is_sparse);

--- a/internal/core/src/segcore/ConcurrentVector.h
+++ b/internal/core/src/segcore/ConcurrentVector.h
@@ -71,7 +71,7 @@ class ThreadSafeVector {
 
     int64_t
     size() const {
-        std::lock_guard lck(mutex_);
+        std::shared_lock lck(mutex_);
         return size_;
     }
 


### PR DESCRIPTION
- issue: #35960
- pr: #35962