### PR TITLE
fix: [2.4] Check all values for `trie.predictive_search` (#35943)

### DIFF
--- a/internal/core/src/index/StringIndexMarisa.cpp
+++ b/internal/core/src/index/StringIndexMarisa.cpp
@@ -399,12 +399,8 @@ StringIndexMarisa::Range(std::string value, OpType op) {
                 auto key = std::string(agent.key().ptr(), agent.key().length());
                 if (key > value) {
                     ids.push_back(agent.key().id());
-                    break;
                 }
             };
-            while (trie_.predictive_search(agent)) {
-                ids.push_back(agent.key().id());
-            }
             break;
         }
         case OpType::GreaterEqual: {
@@ -412,11 +408,7 @@ StringIndexMarisa::Range(std::string value, OpType op) {
                 auto key = std::string(agent.key().ptr(), agent.key().length());
                 if (key >= value) {
                     ids.push_back(agent.key().id());
-                    break;
                 }
-            }
-            while (trie_.predictive_search(agent)) {
-                ids.push_back(agent.key().id());
             }
             break;
         }


### PR DESCRIPTION
Cherry-pick from master
pr: #35943 
Related to #35941

For marisa trie `predictive_search` default behavior, it value iterated is not in lexicographic order.

This PR is a brute force fix to make range operator returns correct values.