### PR TITLE
enhance: [2.4] Use `MARISA_LABEL_ORDER` when building trie index

### DIFF
--- a/internal/core/src/index/StringIndexMarisa.h
+++ b/internal/core/src/index/StringIndexMarisa.h
@@ -120,6 +120,9 @@ class StringIndexMarisa : public StringIndex {
     std::vector<size_t>
     prefix_match(const std::string_view prefix);
 
+    bool
+    in_lexicographic_order();
+
     void
     LoadWithoutAssemble(const BinarySet& binary_set,
                         const Config& config) override;


### PR DESCRIPTION
Cherry pick from master
pr: #36034

Related to #35941
Previous PR: #35943

This PR make `Trie` index using `MARISA_LABEL_ORDER`, which make predictive search iterating in lexicographic order.

When trie index is build in label order, lexicographc could be utilized accelerating `Range` operations.

However according to the official document, using `MARISA_LABEL_ORDER` will make "exact match lookup, common prefix search, and predictive search" slower.