### PR TITLE
fix: split stream query result to avoid grpc response too large error

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -458,7 +458,7 @@ queryNode:
       maxParallelism: 1024 # Maximum number of tasks executed in parallel in the flowgraph
   enableSegmentPrune: false # use partition stats to prune data in search/query on shard delegator
   queryStreamBatchSize: 4194304 # return min batch size of stream query
-  queryStreamMaxBatchSize: 16777216 # return max batch size of stream query
+  queryStreamMaxBatchSize: 134217728 # return max batch size of stream query
   bloomFilterApplyParallelFactor: 4 # parallel factor when to apply pk to bloom filter, default to 4*CPU_CORE_NUM
   workerPooling:
     size: 10 # the size for worker querynode client pool

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -457,7 +457,8 @@ queryNode:
       maxQueueLength: 16 # The maximum size of task queue cache in flow graph in query node.
       maxParallelism: 1024 # Maximum number of tasks executed in parallel in the flowgraph
   enableSegmentPrune: false # use partition stats to prune data in search/query on shard delegator
-  queryStreamBatchSize: 4194304 # return batch size of stream query
+  queryStreamBatchSize: 4194304 # return min batch size of stream query
+  queryStreamMaxBatchSize: 16777216 # return max batch size of stream query
   bloomFilterApplyParallelFactor: 4 # parallel factor when to apply pk to bloom filter, default to 4*CPU_CORE_NUM
   workerPooling:
     size: 10 # the size for worker querynode client pool

--- a/internal/querynodev2/handlers.go
+++ b/internal/querynodev2/handlers.go
@@ -37,6 +37,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/metrics"
 	"github.com/milvus-io/milvus/pkg/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/util/merr"
+	"github.com/milvus-io/milvus/pkg/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/util/timerecord"
 )
 
@@ -317,7 +318,10 @@ func (node *QueryNode) queryStreamSegments(ctx context.Context, req *querypb.Que
 	}
 
 	// Send task to scheduler and wait until it finished.
-	task := tasks.NewQueryStreamTask(ctx, collection, node.manager, req, srv, node.streamBatchSzie)
+
+	task := tasks.NewQueryStreamTask(ctx, collection, node.manager, req, srv,
+		paramtable.Get().QueryNodeCfg.QueryStreamBatchSize.GetAsInt(),
+		paramtable.Get().QueryNodeCfg.QueryStreamMaxBatchSize.GetAsInt())
 	if err := node.scheduler.Add(task); err != nil {
 		log.Warn("failed to add query task into scheduler", zap.Error(err))
 		return err

--- a/internal/querynodev2/server.go
+++ b/internal/querynodev2/server.go
@@ -109,8 +109,7 @@ type QueryNode struct {
 	loader segments.Loader
 
 	// Search/Query
-	scheduler       tasks.Scheduler
-	streamBatchSzie int
+	scheduler tasks.Scheduler
 
 	// etcd client
 	etcdCli *clientv3.Client
@@ -316,9 +315,8 @@ func (node *QueryNode) Init() error {
 		node.scheduler = tasks.NewScheduler(
 			schedulePolicy,
 		)
-		node.streamBatchSzie = paramtable.Get().QueryNodeCfg.QueryStreamBatchSize.GetAsInt()
-		log.Info("queryNode init scheduler", zap.String("policy", schedulePolicy))
 
+		log.Info("queryNode init scheduler", zap.String("policy", schedulePolicy))
 		node.clusterManager = cluster.NewWorkerManager(func(ctx context.Context, nodeID int64) (cluster.Worker, error) {
 			if nodeID == node.GetNodeID() {
 				return NewLocalWorker(node), nil

--- a/internal/util/streamrpc/streamer.go
+++ b/internal/util/streamrpc/streamer.go
@@ -102,23 +102,64 @@ func mergeCostAggregation(a *internalpb.CostAggregation, b *internalpb.CostAggre
 	return &internalpb.CostAggregation{
 		ResponseTime:         a.GetResponseTime() + b.GetResponseTime(),
 		ServiceTime:          a.GetServiceTime() + b.GetServiceTime(),
-		TotalNQ:              a.GetTotalNQ() + b.GetTotalNQ(),
+		TotalNQ:              a.GetTotalNQ(),
 		TotalRelatedDataSize: a.GetTotalRelatedDataSize() + b.GetTotalRelatedDataSize(),
 	}
 }
 
 // Merge result by size and time.
 type ResultCacheServer struct {
-	srv   QueryStreamServer
-	cache *RetrieveResultCache
-	mu    sync.Mutex
+	mu         sync.Mutex
+	srv        QueryStreamServer
+	cache      *RetrieveResultCache
+	maxMsgSize int
 }
 
-func NewResultCacheServer(srv QueryStreamServer, cap int) *ResultCacheServer {
+func NewResultCacheServer(srv QueryStreamServer, cap int, maxMsgSize int) *ResultCacheServer {
 	return &ResultCacheServer{
-		srv:   srv,
-		cache: &RetrieveResultCache{cap: cap},
+		srv:        srv,
+		cache:      &RetrieveResultCache{cap: cap},
+		maxMsgSize: maxMsgSize,
 	}
+}
+
+func (s *ResultCacheServer) splitMsgToMaxSize(result *internalpb.RetrieveResults) []*internalpb.RetrieveResults {
+	newpks := make([]*schemapb.IDs, 0)
+	switch result.GetIds().GetIdField().(type) {
+	case *schemapb.IDs_IntId:
+		pks := result.GetIds().GetIntId().Data
+		batch := s.maxMsgSize / 8
+		print(batch)
+		for start := 0; start < len(pks); start += batch {
+			newpks = append(newpks, &schemapb.IDs{IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: pks[start:min(start+batch, len(pks))]}}})
+		}
+
+	case *schemapb.IDs_StrId:
+		pks := result.GetIds().GetStrId().Data
+		start := 0
+		size := 0
+		for i, pk := range pks {
+			if size+len(pk) > s.maxMsgSize {
+				newpks = append(newpks, &schemapb.IDs{IdField: &schemapb.IDs_StrId{StrId: &schemapb.StringArray{Data: pks[start:i]}}})
+				start = i
+				size = 0
+			}
+			size += len(pk)
+		}
+		if size > 0 {
+			newpks = append(newpks, &schemapb.IDs{IdField: &schemapb.IDs_StrId{StrId: &schemapb.StringArray{Data: pks[start:]}}})
+		}
+	}
+
+	results := make([]*internalpb.RetrieveResults, len(newpks))
+	for i, pks := range newpks {
+		results[i] = &internalpb.RetrieveResults{
+			Ids: pks,
+		}
+	}
+	results[len(results)-1].AllRetrieveCount = result.AllRetrieveCount
+	results[len(results)-1].CostAggregation = result.CostAggregation
+	return results
 }
 
 func (s *ResultCacheServer) Send(result *internalpb.RetrieveResults) error {
@@ -133,10 +174,17 @@ func (s *ResultCacheServer) Send(result *internalpb.RetrieveResults) error {
 	}
 
 	s.cache.Put(result)
-	if s.cache.IsFull() {
+	if s.cache.IsFull() && s.cache.size <= s.maxMsgSize {
 		result := s.cache.Flush()
 		if err := s.srv.Send(result); err != nil {
 			return err
+		}
+	} else if s.cache.IsFull() && s.cache.size > s.maxMsgSize {
+		results := s.splitMsgToMaxSize(s.cache.Flush())
+		for _, result := range results {
+			if err := s.srv.Send(result); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/internal/util/streamrpc/streamer_test.go
+++ b/internal/util/streamrpc/streamer_test.go
@@ -101,6 +101,10 @@ func (s *ResultCacheServerSuite) TestSplit() {
 			Ids: generateIntIds(1024),
 		})
 		s.NoError(err)
+
+		err = cacheSrv.Flush()
+		s.NoError(err)
+
 		srv.FinishSend(nil)
 
 		rev := 0
@@ -129,6 +133,10 @@ func (s *ResultCacheServerSuite) TestSplit() {
 			Ids: generateStrIds(2048),
 		})
 		s.NoError(err)
+
+		err = cacheSrv.Flush()
+		s.NoError(err)
+
 		srv.FinishSend(nil)
 
 		rev := 0

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -2409,6 +2409,7 @@ type queryNodeConfig struct {
 	DefaultSegmentFilterRatio               ParamItem `refreshable:"false"`
 	UseStreamComputing                      ParamItem `refreshable:"false"`
 	QueryStreamBatchSize                    ParamItem `refreshable:"false"`
+	QueryStreamMaxBatchSize                 ParamItem `refreshable:"false"`
 	BloomFilterApplyParallelFactor          ParamItem `refreshable:"true"`
 
 	// worker
@@ -3094,10 +3095,19 @@ user-task-polling:
 		Key:          "queryNode.queryStreamBatchSize",
 		Version:      "2.4.1",
 		DefaultValue: "4194304",
-		Doc:          "return batch size of stream query",
+		Doc:          "return min batch size of stream query",
 		Export:       true,
 	}
 	p.QueryStreamBatchSize.Init(base.mgr)
+
+	p.QueryStreamMaxBatchSize = ParamItem{
+		Key:          "queryNode.queryStreamMaxBatchSize",
+		Version:      "2.4.10",
+		DefaultValue: "16777216",
+		Doc:          "return max batch size of stream query",
+		Export:       true,
+	}
+	p.QueryStreamMaxBatchSize.Init(base.mgr)
 
 	p.BloomFilterApplyParallelFactor = ParamItem{
 		Key:          "queryNode.bloomFilterApplyParallelFactor",

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -3103,7 +3103,7 @@ user-task-polling:
 	p.QueryStreamMaxBatchSize = ParamItem{
 		Key:          "queryNode.queryStreamMaxBatchSize",
 		Version:      "2.4.10",
-		DefaultValue: "16777216",
+		DefaultValue: "134217728",
 		Doc:          "return max batch size of stream query",
 		Export:       true,
 	}


### PR DESCRIPTION
relate: https://github.com/milvus-io/milvus/issues/36089