### PR TITLE
enhance: Set mmap.vectorField default value to true (#36115)

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -408,7 +408,7 @@ queryNode:
     # 2. If set to "disable" original vector data will only be loaded into the chunk cache during search/query.
     warmup: disable
   mmap:
-    vectorField: false # Enable mmap for loading vector data
+    vectorField: true # Enable mmap for loading vector data
     vectorIndex: false # Enable mmap for loading vector index
     scalarField: false # Enable mmap for loading scalar data
     scalarIndex: false # Enable mmap for loading scalar index

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -2592,7 +2592,7 @@ This defaults to true, indicating that Milvus creates temporary index for growin
 	p.MmapVectorField = ParamItem{
 		Key:          "queryNode.mmap.vectorField",
 		Version:      "2.4.7",
-		DefaultValue: "false",
+		DefaultValue: "true",
 		Formatter: func(originValue string) string {
 			if p.MmapEnabled.GetAsBool() {
 				return "true"


### PR DESCRIPTION
We should maintain compatibility with the previous behavior, so let's set the default value of `mmap.vectorField` to `true`.

issue: https://github.com/milvus-io/milvus/issues/35273

pr: https://github.com/milvus-io/milvus/pull/36115