### PR TITLE
fix: Make legacy non-lexicographic branch break swtich

### DIFF
--- a/internal/core/src/index/StringIndexMarisa.cpp
+++ b/internal/core/src/index/StringIndexMarisa.cpp
@@ -374,7 +374,6 @@ StringIndexMarisa::Range(std::string value, OpType op) {
                     }
                     ids.push_back(agent.key().id());
                 }
-                break;
             } else {
                 // lexicographic order is not guaranteed, check all values
                 while (trie_.predictive_search(agent)) {
@@ -385,6 +384,7 @@ StringIndexMarisa::Range(std::string value, OpType op) {
                     }
                 };
             }
+            break;
         }
         case OpType::LessEqual: {
             if (in_lexico_order) {
@@ -396,7 +396,6 @@ StringIndexMarisa::Range(std::string value, OpType op) {
                     }
                     ids.push_back(agent.key().id());
                 }
-                break;
             } else {
                 // lexicographic order is not guaranteed, check all values
                 while (trie_.predictive_search(agent)) {
@@ -407,6 +406,7 @@ StringIndexMarisa::Range(std::string value, OpType op) {
                     }
                 };
             }
+            break;
         }
         default:
             PanicInfo(


### PR DESCRIPTION
Related to #35941
Previous PR: #36034

This patch makes the switch branching logic correct and make the unit test work for cases which does not select the whole dataset.