### PR TITLE
fix: [2.4] Make legacy non-lexicographic branch break swtich

### DIFF
--- a/internal/core/src/index/StringIndexMarisa.cpp
+++ b/internal/core/src/index/StringIndexMarisa.cpp
@@ -458,7 +458,6 @@ StringIndexMarisa::Range(std::string value, OpType op) {
                     }
                     ids.push_back(agent.key().id());
                 }
-                break;
             } else {
                 // lexicographic order is not guaranteed, check all values
                 while (trie_.predictive_search(agent)) {
@@ -469,6 +468,7 @@ StringIndexMarisa::Range(std::string value, OpType op) {
                     }
                 };
             }
+            break;
         }
         case OpType::LessEqual: {
             if (in_lexico_order) {
@@ -480,7 +480,6 @@ StringIndexMarisa::Range(std::string value, OpType op) {
                     }
                     ids.push_back(agent.key().id());
                 }
-                break;
             } else {
                 // lexicographic order is not guaranteed, check all values
                 while (trie_.predictive_search(agent)) {
@@ -491,6 +490,7 @@ StringIndexMarisa::Range(std::string value, OpType op) {
                     }
                 };
             }
+            break;
         }
         default:
             PanicInfo(


### PR DESCRIPTION
Cherry-pick from master
pr: #36125
Related to #35941
Previous PR: #36034

This patch makes the switch branching logic correct and make the unit test work for cases which does not select the whole dataset.