### PR TITLE
enhance: Graceful stop flowgraph manager when stopping datanode

### DIFF
--- a/internal/datanode/data_node.go
+++ b/internal/datanode/data_node.go
@@ -362,6 +362,11 @@ func (node *DataNode) Stop() error {
 			node.channelManager.Close()
 		}
 
+		if node.flowgraphManager != nil {
+			node.flowgraphManager.ClearFlowgraphs()
+			node.flowgraphManager.Close()
+		}
+
 		if node.writeBufferManager != nil {
 			node.writeBufferManager.Stop()
 		}

--- a/internal/datanode/services_test.go
+++ b/internal/datanode/services_test.go
@@ -685,6 +685,8 @@ func (s *DataNodeServicesSuite) TestSyncSegments() {
 		mockFlowgraphManager := pipeline.NewMockFlowgraphManager(s.T())
 		mockFlowgraphManager.EXPECT().GetFlowgraphService(mock.Anything).
 			Return(pipeline.NewDataSyncServiceWithMetaCache(cache), true)
+		mockFlowgraphManager.EXPECT().ClearFlowgraphs().Return().Maybe()
+		mockFlowgraphManager.EXPECT().Close().Return().Maybe()
 		s.node.flowgraphManager = mockFlowgraphManager
 		ctx := context.Background()
 		req := &datapb.SyncSegmentsRequest{
@@ -783,6 +785,8 @@ func (s *DataNodeServicesSuite) TestSyncSegments() {
 		mockFlowgraphManager := pipeline.NewMockFlowgraphManager(s.T())
 		mockFlowgraphManager.EXPECT().GetFlowgraphService(mock.Anything).
 			Return(pipeline.NewDataSyncServiceWithMetaCache(cache), true)
+		mockFlowgraphManager.EXPECT().ClearFlowgraphs().Return().Maybe()
+		mockFlowgraphManager.EXPECT().Close().Return().Maybe()
 		s.node.flowgraphManager = mockFlowgraphManager
 		ctx := context.Background()
 		req := &datapb.SyncSegmentsRequest{
@@ -869,6 +873,8 @@ func (s *DataNodeServicesSuite) TestSyncSegments() {
 		mockFlowgraphManager := pipeline.NewMockFlowgraphManager(s.T())
 		mockFlowgraphManager.EXPECT().GetFlowgraphService(mock.Anything).
 			Return(pipeline.NewDataSyncServiceWithMetaCache(cache), true)
+		mockFlowgraphManager.EXPECT().ClearFlowgraphs().Return().Maybe()
+		mockFlowgraphManager.EXPECT().Close().Return().Maybe()
 		s.node.flowgraphManager = mockFlowgraphManager
 		ctx := context.Background()
 		req := &datapb.SyncSegmentsRequest{
@@ -966,6 +972,8 @@ func (s *DataNodeServicesSuite) TestSyncSegments() {
 		mockFlowgraphManager := pipeline.NewMockFlowgraphManager(s.T())
 		mockFlowgraphManager.EXPECT().GetFlowgraphService(mock.Anything).
 			Return(pipeline.NewDataSyncServiceWithMetaCache(cache), true)
+		mockFlowgraphManager.EXPECT().ClearFlowgraphs().Return().Maybe()
+		mockFlowgraphManager.EXPECT().Close().Return().Maybe()
 		s.node.flowgraphManager = mockFlowgraphManager
 		ctx := context.Background()
 		req := &datapb.SyncSegmentsRequest{
@@ -1046,6 +1054,8 @@ func (s *DataNodeServicesSuite) TestSyncSegments() {
 		mockFlowgraphManager := pipeline.NewMockFlowgraphManager(s.T())
 		mockFlowgraphManager.EXPECT().GetFlowgraphService(mock.Anything).
 			Return(pipeline.NewDataSyncServiceWithMetaCache(cache), true)
+		mockFlowgraphManager.EXPECT().ClearFlowgraphs().Return().Maybe()
+		mockFlowgraphManager.EXPECT().Close().Return().Maybe()
 		s.node.flowgraphManager = mockFlowgraphManager
 		ctx := context.Background()
 		req := &datapb.SyncSegmentsRequest{
@@ -1104,6 +1114,8 @@ func (s *DataNodeServicesSuite) TestSyncSegments() {
 		mockFlowgraphManager := pipeline.NewMockFlowgraphManager(s.T())
 		mockFlowgraphManager.EXPECT().GetFlowgraphService(mock.Anything).
 			Return(pipeline.NewDataSyncServiceWithMetaCache(cache), true)
+		mockFlowgraphManager.EXPECT().ClearFlowgraphs().Return().Maybe()
+		mockFlowgraphManager.EXPECT().Close().Return().Maybe()
 		s.node.flowgraphManager = mockFlowgraphManager
 		ctx := context.Background()
 		req := &datapb.SyncSegmentsRequest{


### PR DESCRIPTION
Flowgraph manager is not stopped durong datanode stopping procedure which may lead to unexpect flowgraph behavior during/after datanode stop progress.