### PR TITLE
fix: keep inner topK to avoid exceeding efSearch

### DIFF
--- a/internal/proxy/search_util.go
+++ b/internal/proxy/search_util.go
@@ -70,11 +70,7 @@ func parseSearchInfo(searchParamsPair []*commonpb.KeyValuePair, schema *schemapb
 			}
 			topK = externalLimit
 		} else {
-			if topKInParam < externalLimit {
-				topK = externalLimit
-			} else {
-				topK = topKInParam
-			}
+			topK = topKInParam
 		}
 	}
 

--- a/internal/proxy/task_search_test.go
+++ b/internal/proxy/task_search_test.go
@@ -2259,7 +2259,7 @@ func TestTaskSearch_parseSearchInfo(t *testing.T) {
 		info, offset, err := parseSearchInfo(offsetParam, nil, rank)
 		assert.NoError(t, err)
 		assert.NotNil(t, info)
-		assert.Equal(t, externalLimit, info.GetTopk())
+		assert.Equal(t, int64(10), info.GetTopk())
 		assert.Equal(t, int64(0), offset)
 	})
 
@@ -2446,13 +2446,13 @@ func TestTaskSearch_parseSearchInfo(t *testing.T) {
 		schema := &schemapb.CollectionSchema{
 			Fields: fields,
 		}
-		info, _, err := parseSearchInfo(normalParam, schema, false)
+		info, _, err := parseSearchInfo(normalParam, schema, nil)
 		assert.Nil(t, info)
 		assert.Error(t, err)
 		assert.True(t, strings.Contains(err.Error(), "exceeds configured max group size"))
 
 		resetSearchParamsValue(normalParam, GroupSizeKey, `10`)
-		info, _, err = parseSearchInfo(normalParam, schema, false)
+		info, _, err = parseSearchInfo(normalParam, schema, nil)
 		assert.NotNil(t, info)
 		assert.NoError(t, err)
 	})


### PR DESCRIPTION
issue: #https://github.com/milvus-io/milvus/issues/36243