### PR TITLE
fix: keep inner topK to avoid exceeding efSearch

### DIFF
--- a/internal/proxy/search_util.go
+++ b/internal/proxy/search_util.go
@@ -70,11 +70,7 @@ func parseSearchInfo(searchParamsPair []*commonpb.KeyValuePair, schema *schemapb
 			}
 			topK = externalLimit
 		} else {
-			if topKInParam < externalLimit {
-				topK = externalLimit
-			} else {
-				topK = topKInParam
-			}
+			topK = topKInParam
 		}
 	}
 

--- a/internal/proxy/task_search_test.go
+++ b/internal/proxy/task_search_test.go
@@ -1995,7 +1995,7 @@ func TestTaskSearch_parseSearchInfo(t *testing.T) {
 		info, offset, err := parseSearchInfo(offsetParam, nil, rank)
 		assert.NoError(t, err)
 		assert.NotNil(t, info)
-		assert.Equal(t, externalLimit, info.GetTopk())
+		assert.Equal(t, int64(10), info.GetTopk())
 		assert.Equal(t, int64(0), offset)
 	})
 


### PR DESCRIPTION
issue :https://github.com/milvus-io/milvus/issues/36243
pr : https://github.com/milvus-io/milvus/pull/36284