### PR TITLE
fix: fix search/query/count may access same growing and sealed segment (#36258)

### DIFF
--- a/internal/querynodev2/services.go
+++ b/internal/querynodev2/services.go
@@ -1335,6 +1335,13 @@ func (node *QueryNode) SyncDistribution(ctx context.Context, req *querypb.SyncDi
 				return id, action.GetCheckpoint().Timestamp
 			})
 			shardDelegator.AddExcludedSegments(droppedInfos)
+			flushedInfo := lo.SliceToMap(action.GetSealedInTarget(), func(id int64) (int64, uint64) {
+				if action.GetCheckpoint() == nil {
+					return id, typeutil.MaxTimestamp
+				}
+				return id, action.GetCheckpoint().Timestamp
+			})
+			shardDelegator.AddExcludedSegments(flushedInfo)
 			shardDelegator.SyncTargetVersion(action.GetTargetVersion(), action.GetGrowingInTarget(),
 				action.GetSealedInTarget(), action.GetDroppedInTarget(), action.GetCheckpoint())
 		case querypb.SyncType_UpdatePartitionStats:


### PR DESCRIPTION
issue: #36257
pr: #36258
during syncTargetVersion, sealed segment should be excluded, to avoid it's growing segment be conusmed from stream again.