### PR TITLE
fix: Fix search/query result is less than expected.

### DIFF
--- a/internal/querycoordv2/meta/target_manager.go
+++ b/internal/querycoordv2/meta/target_manager.go
@@ -450,7 +450,7 @@ func (mgr *TargetManager) GetGrowingSegmentsByCollection(collectionID int64,
 			segments.Insert(channel.GetUnflushedSegmentIds()...)
 		}
 
-		if len(segments) > 0 {
+		if len(segments) >= 0 {
 			return segments
 		}
 	}
@@ -474,7 +474,7 @@ func (mgr *TargetManager) GetGrowingSegmentsByChannel(collectionID int64,
 			}
 		}
 
-		if len(segments) > 0 {
+		if len(segments) >= 0 {
 			return segments
 		}
 	}
@@ -513,7 +513,7 @@ func (mgr *TargetManager) GetSealedSegmentsByChannel(collectionID int64,
 			}
 		}
 
-		if len(ret) > 0 {
+		if len(ret) >= 0 {
 			return ret
 		}
 	}
@@ -554,7 +554,7 @@ func (mgr *TargetManager) GetSealedSegmentsByPartition(collectionID int64,
 			}
 		}
 
-		if len(segments) > 0 {
+		if len(segments) >= 0 {
 			return segments
 		}
 	}

--- a/internal/querycoordv2/observers/target_observer.go
+++ b/internal/querycoordv2/observers/target_observer.go
@@ -352,7 +352,7 @@ func (ob *TargetObserver) shouldUpdateCurrentTarget(ctx context.Context, collect
 		zap.Int32("replicaNum", replicaNum),
 	)
 
-	// check channel first
+	// check shard leader ready
 	channelNames := ob.targetMgr.GetDmChannelsByCollection(collectionID, meta.NextTarget)
 	if len(channelNames) == 0 {
 		// next target is empty, no need to update
@@ -362,27 +362,12 @@ func (ob *TargetObserver) shouldUpdateCurrentTarget(ctx context.Context, collect
 
 	for _, channel := range channelNames {
 		views := ob.distMgr.LeaderViewManager.GetByFilter(meta.WithChannelName2LeaderView(channel.GetChannelName()))
-		nodes := lo.Map(views, func(v *meta.LeaderView, _ int) int64 { return v.ID })
+		nodes := lo.FilterMap(views, func(v *meta.LeaderView, _ int) (int64, bool) { return v.ID, v.UnServiceableError == nil })
 		group := utils.GroupNodesByReplica(ob.meta.ReplicaManager, collectionID, nodes)
 		if int32(len(group)) < replicaNum {
 			log.RatedInfo(10, "channel not ready",
 				zap.Int("readyReplicaNum", len(group)),
 				zap.String("channelName", channel.GetChannelName()),
-			)
-			return false
-		}
-	}
-
-	// and last check historical segment
-	SealedSegments := ob.targetMgr.GetSealedSegmentsByCollection(collectionID, meta.NextTarget)
-	for _, segment := range SealedSegments {
-		views := ob.distMgr.LeaderViewManager.GetByFilter(meta.WithSegment2LeaderView(segment.GetID(), false))
-		nodes := lo.Map(views, func(view *meta.LeaderView, _ int) int64 { return view.ID })
-		group := utils.GroupNodesByReplica(ob.meta.ReplicaManager, collectionID, nodes)
-		if int32(len(group)) < replicaNum {
-			log.RatedInfo(10, "segment not ready",
-				zap.Int("readyReplicaNum", len(group)),
-				zap.Int64("segmentID", segment.GetID()),
 			)
 			return false
 		}

--- a/internal/querycoordv2/utils/util.go
+++ b/internal/querycoordv2/utils/util.go
@@ -68,7 +68,7 @@ func CheckLeaderAvailable(nodeMgr *session.NodeManager, targetMgr meta.TargetMan
 			return err
 		}
 	}
-	segmentDist := targetMgr.GetSealedSegmentsByChannel(leader.CollectionID, leader.Channel, meta.CurrentTarget)
+	segmentDist := targetMgr.GetSealedSegmentsByChannel(leader.CollectionID, leader.Channel, meta.CurrentTargetFirst)
 	// Check whether segments are fully loaded
 	for segmentID, info := range segmentDist {
 		_, exist := leader.Segments[segmentID]
@@ -83,6 +83,7 @@ func CheckLeaderAvailable(nodeMgr *session.NodeManager, targetMgr meta.TargetMan
 			return merr.WrapErrSegmentLack(segmentID)
 		}
 	}
+
 	return nil
 }
 

--- a/tests/integration/target/target_test.go
+++ b/tests/integration/target/target_test.go
@@ -205,12 +205,10 @@ func (s *TargetTestSuit) TestQueryCoordRestart() {
 			})
 			log.Info("resp", zap.Any("status", resp.GetStatus()), zap.Any("shards", resp.Shards))
 			s.NoError(err)
-			s.True(merr.Ok(resp.GetStatus()))
-
-			return len(resp.Shards) == 2
+			return merr.Ok(resp.GetStatus()) && len(resp.Shards) == 2
 		}
 		return false
-	}, 60*time.Second, 1*time.Second)
+	}, 10*time.Second, 1*time.Second)
 
 	close(closeInsertCh)
 	wg.Wait()


### PR DESCRIPTION
issue: #36242

pr#35925 has introduce this to milvus v2.4.11, then if a loaded collection meet a querynode crash, channel has been move to another querynode, the new delegator may be discovered by proxy and start to serve requests before all segment been sync to it.

and the query/search on new delegator will execute on fewer segments than expected, which causes an unexepcted result.