### PR TITLE
fix: [2.4] Return all compactTo segments after support split (#36361)

### DIFF
--- a/internal/datacoord/index_service_test.go
+++ b/internal/datacoord/index_service_test.go
@@ -548,7 +548,7 @@ func TestServer_AlterIndex(t *testing.T) {
 			catalog:   catalog,
 			indexMeta: indexMeta,
 			segments: &SegmentsInfo{
-				compactionTo: make(map[int64]int64),
+				compactionTo: make(map[int64][]int64),
 				segments: map[UniqueID]*SegmentInfo{
 					invalidSegID: {
 						SegmentInfo: &datapb.SegmentInfo{

--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -1644,7 +1644,7 @@ func (m *meta) HasSegments(segIDs []UniqueID) (bool, error) {
 }
 
 // GetCompactionTo returns the segment info of the segment to be compacted to.
-func (m *meta) GetCompactionTo(segmentID int64) (*SegmentInfo, bool) {
+func (m *meta) GetCompactionTo(segmentID int64) ([]*SegmentInfo, bool) {
 	m.RLock()
 	defer m.RUnlock()
 

--- a/internal/datacoord/meta_test.go
+++ b/internal/datacoord/meta_test.go
@@ -925,7 +925,7 @@ func Test_meta_SetSegmentsCompacting(t *testing.T) {
 							isCompacting: false,
 						},
 					},
-					compactionTo: make(map[int64]UniqueID),
+					compactionTo: make(map[int64][]UniqueID),
 				},
 			},
 			args{

--- a/internal/datacoord/segment_info_test.go
+++ b/internal/datacoord/segment_info_test.go
@@ -3,98 +3,106 @@ package datacoord
 import (
 	"testing"
 
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/milvus-io/milvus/internal/proto/datapb"
 )
 
 func TestCompactionTo(t *testing.T) {
-	segments := NewSegmentsInfo()
-	segment := NewSegmentInfo(&datapb.SegmentInfo{
-		ID: 1,
+	t.Run("mix_2_to_1", func(t *testing.T) {
+		segments := NewSegmentsInfo()
+		segment := NewSegmentInfo(&datapb.SegmentInfo{
+			ID: 1,
+		})
+		segments.SetSegment(segment.GetID(), segment)
+
+		compactTos, ok := segments.GetCompactionTo(1)
+		assert.True(t, ok)
+		assert.Nil(t, compactTos)
+
+		segment = NewSegmentInfo(&datapb.SegmentInfo{
+			ID: 2,
+		})
+		segments.SetSegment(segment.GetID(), segment)
+		segment = NewSegmentInfo(&datapb.SegmentInfo{
+			ID:             3,
+			CompactionFrom: []int64{1, 2},
+		})
+		segments.SetSegment(segment.GetID(), segment)
+
+		getCompactToIDs := func(segments []*SegmentInfo) []int64 {
+			return lo.Map(segments, func(segment *SegmentInfo, _ int) int64 { return segment.GetID() })
+		}
+
+		compactTos, ok = segments.GetCompactionTo(3)
+		assert.Nil(t, compactTos)
+		assert.True(t, ok)
+		compactTos, ok = segments.GetCompactionTo(1)
+		assert.True(t, ok)
+		assert.NotNil(t, compactTos)
+		assert.ElementsMatch(t, []int64{3}, getCompactToIDs(compactTos))
+		compactTos, ok = segments.GetCompactionTo(2)
+		assert.True(t, ok)
+		assert.NotNil(t, compactTos)
+		assert.ElementsMatch(t, []int64{3}, getCompactToIDs(compactTos))
+
+		// should be droped.
+		segments.DropSegment(1)
+		compactTos, ok = segments.GetCompactionTo(1)
+		assert.False(t, ok)
+		assert.Nil(t, compactTos)
+		compactTos, ok = segments.GetCompactionTo(2)
+		assert.True(t, ok)
+		assert.NotNil(t, compactTos)
+		assert.ElementsMatch(t, []int64{3}, getCompactToIDs(compactTos))
+		compactTos, ok = segments.GetCompactionTo(3)
+		assert.Nil(t, compactTos)
+		assert.True(t, ok)
+
+		segments.DropSegment(3)
+		compactTos, ok = segments.GetCompactionTo(2)
+		assert.True(t, ok)
+		assert.Nil(t, compactTos)
 	})
-	segments.SetSegment(segment.GetID(), segment)
 
-	s, ok := segments.GetCompactionTo(1)
-	assert.True(t, ok)
-	assert.Nil(t, s)
+	t.Run("split_1_to_2", func(t *testing.T) {
+		segments := NewSegmentsInfo()
+		segment := NewSegmentInfo(&datapb.SegmentInfo{
+			ID: 1,
+		})
+		segments.SetSegment(segment.GetID(), segment)
 
-	segment = NewSegmentInfo(&datapb.SegmentInfo{
-		ID: 2,
+		compactTos, ok := segments.GetCompactionTo(1)
+		assert.True(t, ok)
+		assert.Nil(t, compactTos)
+
+		segment = NewSegmentInfo(&datapb.SegmentInfo{
+			ID:             2,
+			CompactionFrom: []int64{1},
+		})
+		segments.SetSegment(segment.GetID(), segment)
+		segment = NewSegmentInfo(&datapb.SegmentInfo{
+			ID:             3,
+			CompactionFrom: []int64{1},
+		})
+		segments.SetSegment(segment.GetID(), segment)
+
+		getCompactToIDs := func(segments []*SegmentInfo) []int64 {
+			return lo.Map(segments, func(segment *SegmentInfo, _ int) int64 { return segment.GetID() })
+		}
+
+		compactTos, ok = segments.GetCompactionTo(2)
+		assert.Nil(t, compactTos)
+		assert.True(t, ok)
+		compactTos, ok = segments.GetCompactionTo(3)
+		assert.Nil(t, compactTos)
+		assert.True(t, ok)
+		compactTos, ok = segments.GetCompactionTo(1)
+		assert.True(t, ok)
+		assert.NotNil(t, compactTos)
+		assert.ElementsMatch(t, []int64{2, 3}, getCompactToIDs(compactTos))
 	})
-	segments.SetSegment(segment.GetID(), segment)
-	segment = NewSegmentInfo(&datapb.SegmentInfo{
-		ID:             3,
-		CompactionFrom: []int64{1, 2},
-	})
-	segments.SetSegment(segment.GetID(), segment)
-
-	s, ok = segments.GetCompactionTo(3)
-	assert.Nil(t, s)
-	assert.True(t, ok)
-	s, ok = segments.GetCompactionTo(1)
-	assert.True(t, ok)
-	assert.NotNil(t, s)
-	assert.Equal(t, int64(3), s.GetID())
-	s, ok = segments.GetCompactionTo(2)
-	assert.True(t, ok)
-	assert.NotNil(t, s)
-	assert.Equal(t, int64(3), s.GetID())
-
-	// should be overwrite.
-	segment = NewSegmentInfo(&datapb.SegmentInfo{
-		ID:             3,
-		CompactionFrom: []int64{2},
-	})
-	segments.SetSegment(segment.GetID(), segment)
-
-	s, ok = segments.GetCompactionTo(3)
-	assert.True(t, ok)
-	assert.Nil(t, s)
-	s, ok = segments.GetCompactionTo(1)
-	assert.True(t, ok)
-	assert.Nil(t, s)
-	s, ok = segments.GetCompactionTo(2)
-	assert.True(t, ok)
-	assert.NotNil(t, s)
-	assert.Equal(t, int64(3), s.GetID())
-
-	// should be overwrite back.
-	segment = NewSegmentInfo(&datapb.SegmentInfo{
-		ID:             3,
-		CompactionFrom: []int64{1, 2},
-	})
-	segments.SetSegment(segment.GetID(), segment)
-
-	s, ok = segments.GetCompactionTo(3)
-	assert.Nil(t, s)
-	assert.True(t, ok)
-	s, ok = segments.GetCompactionTo(1)
-	assert.True(t, ok)
-	assert.NotNil(t, s)
-	assert.Equal(t, int64(3), s.GetID())
-	s, ok = segments.GetCompactionTo(2)
-	assert.True(t, ok)
-	assert.NotNil(t, s)
-	assert.Equal(t, int64(3), s.GetID())
-
-	// should be droped.
-	segments.DropSegment(1)
-	s, ok = segments.GetCompactionTo(1)
-	assert.False(t, ok)
-	assert.Nil(t, s)
-	s, ok = segments.GetCompactionTo(2)
-	assert.True(t, ok)
-	assert.NotNil(t, s)
-	assert.Equal(t, int64(3), s.GetID())
-	s, ok = segments.GetCompactionTo(3)
-	assert.Nil(t, s)
-	assert.True(t, ok)
-
-	segments.DropSegment(3)
-	s, ok = segments.GetCompactionTo(2)
-	assert.True(t, ok)
-	assert.Nil(t, s)
 }
 
 func TestGetSegmentSize(t *testing.T) {

--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -395,7 +395,7 @@ func (s *Server) GetSegmentInfo(ctx context.Context, req *datapb.GetSegmentInfoR
 			info = s.meta.GetSegment(id)
 			// TODO: GetCompactionTo should be removed and add into GetSegment method and protected by lock.
 			// Too much modification need to be applied to SegmentInfo, a refactor is needed.
-			child, ok := s.meta.GetCompactionTo(id)
+			children, ok := s.meta.GetCompactionTo(id)
 
 			// info may be not-nil, but ok is false when the segment is being dropped concurrently.
 			if info == nil || !ok {
@@ -406,7 +406,7 @@ func (s *Server) GetSegmentInfo(ctx context.Context, req *datapb.GetSegmentInfoR
 			}
 
 			clonedInfo := info.Clone()
-			if child != nil {
+			for _, child := range children {
 				clonedChild := child.Clone()
 				// child segment should decompress binlog path
 				binlog.DecompressBinLog(storage.DeleteBinlog, clonedChild.GetCollectionID(), clonedChild.GetPartitionID(), clonedChild.GetID(), clonedChild.GetDeltalogs())


### PR DESCRIPTION
Cherry-pick from master
pr: #36361
Related to #36360