### PR TITLE
enhance: Enable balance on querynode with different mem capacity

### DIFF
--- a/internal/proto/query_coord.proto
+++ b/internal/proto/query_coord.proto
@@ -606,6 +606,7 @@ message GetDataDistributionResponse {
     repeated ChannelVersionInfo channels = 4;
     repeated LeaderView leader_views = 5;
     int64 lastModifyTs = 6;
+    double memCapacityInMB = 7;
 }
 
 message LeaderView {

--- a/internal/querycoordv2/balance/score_based_balancer_test.go
+++ b/internal/querycoordv2/balance/score_based_balancer_test.go
@@ -1001,6 +1001,107 @@ func (suite *ScoreBasedBalancerTestSuite) TestMultiReplicaBalance() {
 	}
 }
 
+func (suite *ScoreBasedBalancerTestSuite) TestQNMemoryCapacity() {
+	cases := []struct {
+		name                 string
+		nodes                []int64
+		collectionID         int64
+		replicaID            int64
+		collectionsSegments  []*datapb.SegmentInfo
+		states               []session.State
+		shouldMock           bool
+		distributions        map[int64][]*meta.Segment
+		distributionChannels map[int64][]*meta.DmChannel
+		expectPlans          []SegmentAssignPlan
+		expectChannelPlans   []ChannelAssignPlan
+	}{
+		{
+			name:         "test qn memory capacity",
+			nodes:        []int64{1, 2},
+			collectionID: 1,
+			replicaID:    1,
+			collectionsSegments: []*datapb.SegmentInfo{
+				{ID: 1, PartitionID: 1}, {ID: 2, PartitionID: 1}, {ID: 3, PartitionID: 1}, {ID: 4, PartitionID: 1},
+			},
+			states: []session.State{session.NodeStateNormal, session.NodeStateNormal},
+			distributions: map[int64][]*meta.Segment{
+				1: {{SegmentInfo: &datapb.SegmentInfo{ID: 1, CollectionID: 1, NumOfRows: 10}, Node: 1}},
+				2: {
+					{SegmentInfo: &datapb.SegmentInfo{ID: 2, CollectionID: 1, NumOfRows: 10}, Node: 2},
+					{SegmentInfo: &datapb.SegmentInfo{ID: 3, CollectionID: 1, NumOfRows: 20}, Node: 2},
+					{SegmentInfo: &datapb.SegmentInfo{ID: 4, CollectionID: 1, NumOfRows: 20}, Node: 2},
+				},
+			},
+			expectPlans:        []SegmentAssignPlan{},
+			expectChannelPlans: []ChannelAssignPlan{},
+		},
+	}
+
+	for _, c := range cases {
+		suite.Run(c.name, func() {
+			suite.SetupSuite()
+			defer suite.TearDownTest()
+			balancer := suite.balancer
+
+			// 1. set up target for multi collections
+			collection := utils.CreateTestCollection(c.collectionID, int32(c.replicaID))
+			suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, c.collectionID).Return(
+				nil, c.collectionsSegments, nil)
+			suite.broker.EXPECT().GetPartitions(mock.Anything, c.collectionID).Return([]int64{c.collectionID}, nil).Maybe()
+			collection.LoadPercentage = 100
+			collection.Status = querypb.LoadStatus_Loaded
+			balancer.meta.CollectionManager.PutCollection(collection)
+			balancer.meta.CollectionManager.PutPartition(utils.CreateTestPartition(c.collectionID, c.collectionID))
+			balancer.meta.ReplicaManager.Put(utils.CreateTestReplica(c.replicaID, c.collectionID, c.nodes))
+			balancer.targetMgr.UpdateCollectionNextTarget(c.collectionID)
+			balancer.targetMgr.UpdateCollectionCurrentTarget(c.collectionID)
+			balancer.targetMgr.UpdateCollectionNextTarget(c.collectionID)
+
+			// 2. set up target for distribution for multi collections
+			for node, s := range c.distributions {
+				balancer.dist.SegmentDistManager.Update(node, s...)
+			}
+			for node, v := range c.distributionChannels {
+				balancer.dist.ChannelDistManager.Update(node, v...)
+			}
+
+			// 3. set up nodes info and resourceManager for balancer
+			nodeInfoMap := make(map[int64]*session.NodeInfo)
+			for i := range c.nodes {
+				nodeInfo := session.NewNodeInfo(session.ImmutableNodeInfo{
+					NodeID:   c.nodes[i],
+					Address:  "127.0.0.1:0",
+					Hostname: "localhost",
+				})
+				nodeInfo.UpdateStats(session.WithChannelCnt(len(c.distributionChannels[c.nodes[i]])))
+				nodeInfo.SetState(c.states[i])
+				nodeInfoMap[c.nodes[i]] = nodeInfo
+				suite.balancer.nodeManager.Add(nodeInfo)
+				suite.balancer.meta.ResourceManager.HandleNodeUp(c.nodes[i])
+			}
+			utils.RecoverAllCollection(balancer.meta)
+
+			// test qn has same memory capacity
+			nodeInfoMap[1].UpdateStats(session.WithMemCapacity(1024))
+			nodeInfoMap[2].UpdateStats(session.WithMemCapacity(1024))
+			segmentPlans, channelPlans := suite.getCollectionBalancePlans(balancer, c.collectionID)
+			suite.Len(channelPlans, 0)
+			suite.Len(segmentPlans, 1)
+			suite.Equal(segmentPlans[0].To, int64(1))
+			suite.Equal(segmentPlans[0].Segment.NumOfRows, int64(20))
+
+			// test qn has different memory capacity
+			nodeInfoMap[1].UpdateStats(session.WithMemCapacity(1024))
+			nodeInfoMap[2].UpdateStats(session.WithMemCapacity(2048))
+			segmentPlans, channelPlans = suite.getCollectionBalancePlans(balancer, c.collectionID)
+			suite.Len(channelPlans, 0)
+			suite.Len(segmentPlans, 1)
+			suite.Equal(segmentPlans[0].To, int64(1))
+			suite.Equal(segmentPlans[0].Segment.NumOfRows, int64(10))
+		})
+	}
+}
+
 func TestScoreBasedBalancerSuite(t *testing.T) {
 	suite.Run(t, new(ScoreBasedBalancerTestSuite))
 }

--- a/internal/querycoordv2/dist/dist_handler.go
+++ b/internal/querycoordv2/dist/dist_handler.go
@@ -123,8 +123,8 @@ func (dh *distHandler) handleDistResp(resp *querypb.GetDataDistributionResponse,
 		node.UpdateStats(
 			session.WithSegmentCnt(len(resp.GetSegments())),
 			session.WithChannelCnt(len(resp.GetChannels())),
+			session.WithMemCapacity(resp.GetMemCapacityInMB()),
 		)
-
 		dh.updateSegmentsDistribution(resp)
 		dh.updateChannelsDistribution(resp)
 		dh.updateLeaderView(resp)

--- a/internal/querycoordv2/session/node_manager.go
+++ b/internal/querycoordv2/session/node_manager.go
@@ -159,6 +159,13 @@ func (n *NodeInfo) ChannelCnt() int {
 	return n.stats.getChannelCnt()
 }
 
+// return node's memory capacity in mb
+func (n *NodeInfo) MemCapacity() float64 {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+	return n.stats.getMemCapacity()
+}
+
 func (n *NodeInfo) SetLastHeartbeat(time time.Time) {
 	n.lastHeartbeat.Store(time.UnixNano())
 }
@@ -216,5 +223,11 @@ func WithSegmentCnt(cnt int) StatsOption {
 func WithChannelCnt(cnt int) StatsOption {
 	return func(n *NodeInfo) {
 		n.setChannelCnt(cnt)
+	}
+}
+
+func WithMemCapacity(capacity float64) StatsOption {
+	return func(n *NodeInfo) {
+		n.setMemCapacity(capacity)
 	}
 }

--- a/internal/querycoordv2/session/stats.go
+++ b/internal/querycoordv2/session/stats.go
@@ -17,8 +17,9 @@
 package session
 
 type stats struct {
-	segmentCnt int
-	channelCnt int
+	segmentCnt      int
+	channelCnt      int
+	memCapacityInMB float64
 }
 
 func (s *stats) setSegmentCnt(cnt int) {
@@ -35,6 +36,14 @@ func (s *stats) setChannelCnt(cnt int) {
 
 func (s *stats) getChannelCnt() int {
 	return s.channelCnt
+}
+
+func (s *stats) setMemCapacity(capacity float64) {
+	s.memCapacityInMB = capacity
+}
+
+func (s *stats) getMemCapacity() float64 {
+	return s.memCapacityInMB
 }
 
 func newStats() stats {

--- a/internal/querynodev2/services.go
+++ b/internal/querynodev2/services.go
@@ -48,6 +48,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/metrics"
 	"github.com/milvus-io/milvus/pkg/util/commonpbutil"
 	"github.com/milvus-io/milvus/pkg/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/util/hardware"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/metricsinfo"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
@@ -1238,12 +1239,13 @@ func (node *QueryNode) GetDataDistribution(ctx context.Context, req *querypb.Get
 	})
 
 	return &querypb.GetDataDistributionResponse{
-		Status:       merr.Success(),
-		NodeID:       node.GetNodeID(),
-		Segments:     segmentVersionInfos,
-		Channels:     channelVersionInfos,
-		LeaderViews:  leaderViews,
-		LastModifyTs: lastModifyTs,
+		Status:          merr.Success(),
+		NodeID:          node.GetNodeID(),
+		Segments:        segmentVersionInfos,
+		Channels:        channelVersionInfos,
+		LeaderViews:     leaderViews,
+		LastModifyTs:    lastModifyTs,
+		MemCapacityInMB: float64(hardware.GetMemoryCount() / 1024 / 1024),
 	}, nil
 }
 


### PR DESCRIPTION
issue: #36464
This PR enable balance on querynode with different mem capacity, for query node which has more mem capactity will be assigned more records, and query node with the largest difference between assignedScore and currentScore will have a higher priority to carry the new segment.