### PR TITLE
enhance: Return segment id hint in QueryStream response

### DIFF
--- a/internal/querynodev2/segments/retrieve.go
+++ b/internal/querynodev2/segments/retrieve.go
@@ -124,7 +124,8 @@ func retrieveOnSegmentsWithStream(ctx context.Context, mgr *Manager, segments []
 					CostAggregation: &internalpb.CostAggregation{
 						TotalRelatedDataSize: GetSegmentRelatedDataSize(segment),
 					},
-					AllRetrieveCount: result.GetAllRetrieveCount(),
+					SealedSegmentIDsRetrieved: []int64{segment.ID()},
+					AllRetrieveCount:          result.GetAllRetrieveCount(),
 				}); err != nil {
 					errs[i] = err
 				}


### PR DESCRIPTION
Related to #36482

This PR reuses `SealedSegmentIDsRetrieved` field in `RetrieveResults` struct to store segment id hint.