### PR TITLE
enhance: make TransferChannel/TransferSegment idempotent (#36489)

### DIFF
--- a/internal/querycoordv2/handlers.go
+++ b/internal/querycoordv2/handlers.go
@@ -146,7 +146,8 @@ func (s *Server) balanceSegments(ctx context.Context,
 		err = s.taskScheduler.Add(t)
 		if err != nil {
 			t.Cancel(err)
-			return err
+			log.Info("skip balance segment task", zap.Int64("segmentID", plan.Segment.GetID()), zap.Error(err))
+			continue
 		}
 		tasks = append(tasks, t)
 	}
@@ -223,7 +224,8 @@ func (s *Server) balanceChannels(ctx context.Context,
 		err = s.taskScheduler.Add(t)
 		if err != nil {
 			t.Cancel(err)
-			return err
+			log.Info("skip balance channel task", zap.String("channel", plan.Channel.GetChannelName()), zap.Error(err))
+			continue
 		}
 		tasks = append(tasks, t)
 	}


### PR DESCRIPTION
issue: #36488
pr: #36489
when call TransferChannel/TransferSegment, querycoord will generate and submit balance task to scheduler, if segment/channel's task already exist in scheduler, submit task will failed.

to make TransferChannel/TransferSegment idempotent, we should skip to submit if task already exist in scheduler.