### PR TITLE
fix: Skip unnecessary query node health check in proxy (#36491)

### DIFF
--- a/internal/proxy/look_aside_balancer.go
+++ b/internal/proxy/look_aside_balancer.go
@@ -247,6 +247,7 @@ func (b *LookAsideBalancer) checkQueryNodeHealthLoop(ctx context.Context) {
 						qn, err := b.clientMgr.GetClient(ctx, node)
 						if err != nil {
 							// get client from clientMgr failed, which means this qn isn't a shard leader anymore, skip it's health check
+							b.trySetQueryNodeUnReachable(node, err)
 							log.RatedInfo(10, "get client failed", zap.Int64("node", node), zap.Error(err))
 							return struct{}{}, nil
 						}


### PR DESCRIPTION
issue: #36490
pr: #36491
After the query node changes from a delegator to a worker, proxy should skip this querynode's health check.