### PR TITLE
enhance: Remove segment clone in `GetSegmentsChanPart`

### DIFF
--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -355,19 +355,17 @@ func (m *meta) GetSegmentsChanPart(selector SegmentInfoSelector) []*chanPartSegm
 			continue
 		}
 
-		cloned := segmentInfo.Clone()
-
-		dim := fmt.Sprintf("%d-%s", cloned.PartitionID, cloned.InsertChannel)
+		dim := fmt.Sprintf("%d-%s", segmentInfo.PartitionID, segmentInfo.InsertChannel)
 		entry, ok := mDimEntry[dim]
 		if !ok {
 			entry = &chanPartSegments{
-				collectionID: cloned.CollectionID,
-				partitionID:  cloned.PartitionID,
-				channelName:  cloned.InsertChannel,
+				collectionID: segmentInfo.CollectionID,
+				partitionID:  segmentInfo.PartitionID,
+				channelName:  segmentInfo.InsertChannel,
 			}
 			mDimEntry[dim] = entry
 		}
-		entry.segments = append(entry.segments, cloned)
+		entry.segments = append(entry.segments, segmentInfo)
 	}
 
 	result := make([]*chanPartSegments, 0, len(mDimEntry))
@@ -1818,7 +1816,6 @@ func (s *segMetricMutation) addNewSeg(state commonpb.SegmentState, level datapb.
 	}
 	if _, ok := s.stateChange[level.String()][state.String()]; !ok {
 		s.stateChange[level.String()][state.String()] = make(map[string]int)
-
 	}
 	s.stateChange[level.String()][state.String()][getSortStatus(isSorted)] += 1
 

--- a/internal/querynodev2/segments/validate.go
+++ b/internal/querynodev2/segments/validate.go
@@ -76,7 +76,7 @@ func validate(ctx context.Context, manager *Manager, collectionID int64, partiti
 		}
 		for _, segment := range segments {
 			if !funcutil.SliceContain(searchPartIDs, segment.Partition()) {
-				err := fmt.Errorf("segment %d belongs to partition %d, which is not in %v", segment.ID(), segment.Partition(), searchPartIDs)
+				err = fmt.Errorf("segment %d belongs to partition %d, which is not in %v", segment.ID(), segment.Partition(), searchPartIDs)
 				return nil, err
 			}
 		}


### PR DESCRIPTION
Datacoord meta shall be copy-on-write so cloning segment while reading is not necessary and will cost memory burst if segment number is large