### PR TITLE
enhance: Enable balance on querynode with different mem capacity (#36466)

### DIFF
--- a/internal/proto/query_coord.proto
+++ b/internal/proto/query_coord.proto
@@ -606,6 +606,7 @@ message GetDataDistributionResponse {
     repeated ChannelVersionInfo channels = 4;
     repeated LeaderView leader_views = 5;
     int64 lastModifyTs = 6;
+    double memCapacityInMB = 7;
 }
 
 message LeaderView {

--- a/internal/querycoordv2/dist/dist_handler.go
+++ b/internal/querycoordv2/dist/dist_handler.go
@@ -123,8 +123,8 @@ func (dh *distHandler) handleDistResp(resp *querypb.GetDataDistributionResponse,
 		node.UpdateStats(
 			session.WithSegmentCnt(len(resp.GetSegments())),
 			session.WithChannelCnt(len(resp.GetChannels())),
+			session.WithMemCapacity(resp.GetMemCapacityInMB()),
 		)
-
 		dh.updateSegmentsDistribution(resp)
 		dh.updateChannelsDistribution(resp)
 		dh.updateLeaderView(resp)

--- a/internal/querycoordv2/session/node_manager.go
+++ b/internal/querycoordv2/session/node_manager.go
@@ -159,6 +159,13 @@ func (n *NodeInfo) ChannelCnt() int {
 	return n.stats.getChannelCnt()
 }
 
+// return node's memory capacity in mb
+func (n *NodeInfo) MemCapacity() float64 {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+	return n.stats.getMemCapacity()
+}
+
 func (n *NodeInfo) SetLastHeartbeat(time time.Time) {
 	n.lastHeartbeat.Store(time.UnixNano())
 }
@@ -216,5 +223,11 @@ func WithSegmentCnt(cnt int) StatsOption {
 func WithChannelCnt(cnt int) StatsOption {
 	return func(n *NodeInfo) {
 		n.setChannelCnt(cnt)
+	}
+}
+
+func WithMemCapacity(capacity float64) StatsOption {
+	return func(n *NodeInfo) {
+		n.setMemCapacity(capacity)
 	}
 }

--- a/internal/querycoordv2/session/stats.go
+++ b/internal/querycoordv2/session/stats.go
@@ -17,8 +17,9 @@
 package session
 
 type stats struct {
-	segmentCnt int
-	channelCnt int
+	segmentCnt      int
+	channelCnt      int
+	memCapacityInMB float64
 }
 
 func (s *stats) setSegmentCnt(cnt int) {
@@ -35,6 +36,14 @@ func (s *stats) setChannelCnt(cnt int) {
 
 func (s *stats) getChannelCnt() int {
 	return s.channelCnt
+}
+
+func (s *stats) setMemCapacity(capacity float64) {
+	s.memCapacityInMB = capacity
+}
+
+func (s *stats) getMemCapacity() float64 {
+	return s.memCapacityInMB
 }
 
 func newStats() stats {

--- a/internal/querynodev2/services.go
+++ b/internal/querynodev2/services.go
@@ -48,6 +48,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/metrics"
 	"github.com/milvus-io/milvus/pkg/util/commonpbutil"
 	"github.com/milvus-io/milvus/pkg/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/util/hardware"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/metricsinfo"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
@@ -1265,12 +1266,13 @@ func (node *QueryNode) GetDataDistribution(ctx context.Context, req *querypb.Get
 	})
 
 	return &querypb.GetDataDistributionResponse{
-		Status:       merr.Success(),
-		NodeID:       node.GetNodeID(),
-		Segments:     segmentVersionInfos,
-		Channels:     channelVersionInfos,
-		LeaderViews:  leaderViews,
-		LastModifyTs: lastModifyTs,
+		Status:          merr.Success(),
+		NodeID:          node.GetNodeID(),
+		Segments:        segmentVersionInfos,
+		Channels:        channelVersionInfos,
+		LeaderViews:     leaderViews,
+		LastModifyTs:    lastModifyTs,
+		MemCapacityInMB: float64(hardware.GetMemoryCount() / 1024 / 1024),
 	}, nil
 }
 


### PR DESCRIPTION
issue: #36464
pr: #36466
This PR enable balance on querynode with different mem capacity, for query node which has more mem capactity will be assigned more records, and query node with the largest difference between assignedScore and currentScore will have a higher priority to carry the new segment.