### PR TITLE
enhance: fix skip msg log with empty position info

### DIFF
--- a/pkg/mq/msgstream/mq_msgstream.go
+++ b/pkg/mq/msgstream/mq_msgstream.go
@@ -966,7 +966,8 @@ func (ms *MqTtMsgStream) Seek(ctx context.Context, msgPositions []*MsgPosition, 
 						zap.Int64("source", tsMsg.SourceID()),
 						zap.String("type", tsMsg.Type().String()),
 						zap.Int("size", tsMsg.Size()),
-						zap.Any("position", tsMsg.Position()),
+						zap.Uint64("msgTs", tsMsg.BeginTs()),
+						zap.Uint64("posTs", mp.GetTimestamp()),
 					)
 				}
 			}


### PR DESCRIPTION
All skiped message position info was nil, should print BeginTs or MessageID instead.
relate: https://github.com/milvus-io/milvus/issues/36569