### PR TITLE
enhance: Remove pre-marking segments as L2 during clustering compaction

### DIFF
--- a/internal/datacoord/compaction_policy_clustering.go
+++ b/internal/datacoord/compaction_policy_clustering.go
@@ -126,7 +126,8 @@ func (policy *clusteringCompactionPolicy) triggerOneCollection(ctx context.Conte
 			isFlush(segment) &&
 			!segment.isCompacting && // not compacting now
 			!segment.GetIsImporting() && // not importing now
-			segment.GetLevel() != datapb.SegmentLevel_L0 // ignore level zero segments
+			segment.GetLevel() != datapb.SegmentLevel_L0 && // ignore level zero segments
+			!segment.GetIsInvisible()
 	})
 
 	views := make([]CompactionView, 0)

--- a/internal/datacoord/compaction_policy_single.go
+++ b/internal/datacoord/compaction_policy_single.go
@@ -94,7 +94,8 @@ func (policy *singleCompactionPolicy) triggerOneCollection(ctx context.Context, 
 			isFlush(segment) &&
 			!segment.isCompacting && // not compacting now
 			!segment.GetIsImporting() && // not importing now
-			segment.GetLevel() == datapb.SegmentLevel_L2 // only support L2 for now
+			segment.GetLevel() == datapb.SegmentLevel_L2 && // only support L2 for now
+			!segment.GetIsInvisible()
 	})
 
 	views := make([]CompactionView, 0)

--- a/internal/datacoord/compaction_trigger.go
+++ b/internal/datacoord/compaction_trigger.go
@@ -317,7 +317,8 @@ func (t *compactionTrigger) handleGlobalSignal(signal *compactionSignal) error {
 			!segment.isCompacting && // not compacting now
 			!segment.GetIsImporting() && // not importing now
 			segment.GetLevel() != datapb.SegmentLevel_L0 && // ignore level zero segments
-			segment.GetLevel() != datapb.SegmentLevel_L2 // ignore l2 segment
+			segment.GetLevel() != datapb.SegmentLevel_L2 && // ignore l2 segment
+			!segment.GetIsInvisible()
 	}) // partSegments is list of chanPartSegments, which is channel-partition organized segments
 
 	if len(partSegments) == 0 {

--- a/internal/datacoord/handler_test.go
+++ b/internal/datacoord/handler_test.go
@@ -560,6 +560,312 @@ func TestGetQueryVChanPositions_Retrieve_unIndexed(t *testing.T) {
 		// assert.EqualValues(t, 0, len(vchan.UnflushedSegmentIds))
 		// assert.ElementsMatch(t, []int64{e.GetID()}, vchan.FlushedSegmentIds) // expected e
 	})
+
+	t.Run("complex derivation", func(t *testing.T) {
+		// numbers indicate segmentID, letters indicate segment information
+		// i: indexed,  u: unindexed,  g: gced
+		//        1i,  2i,  3g     4i,  5i,  6i
+		//        |    |    |      |    |    |
+		//        \    |    /      \    |    /
+		//         \   |   /        \   |   /
+		//    7u,  [8i,9i,10i]      [11u, 12i]
+		//    |     |  |  |          |     |
+		//    \     |  /  \          /     |
+		//     \    | /    \        /      |
+		//       [13u]      [14i, 15u]    12i
+		//        |         |     |        |
+		//        \         /     \        /
+		//         \       /       \      /
+		//           [16u]          [17u]
+		// all leaf nodes are [1,2,3,4,5,6,7], but because segment3 has been gced, the leaf node becomes [7,8,9,10,4,5,6]
+		// should be returned: flushed: [7, 8, 9, 10, 4, 5, 6]
+		svr := newTestServer(t)
+		defer closeTestServer(t, svr)
+		schema := newTestSchema()
+		svr.meta.AddCollection(&collectionInfo{
+			ID:     0,
+			Schema: schema,
+		})
+		err := svr.meta.indexMeta.CreateIndex(&model.Index{
+			TenantID:     "",
+			CollectionID: 0,
+			FieldID:      2,
+			IndexID:      1,
+		})
+		assert.NoError(t, err)
+		seg1 := &datapb.SegmentInfo{
+			ID:            1,
+			CollectionID:  0,
+			PartitionID:   0,
+			InsertChannel: "ch1",
+			State:         commonpb.SegmentState_Dropped,
+			DmlPosition: &msgpb.MsgPosition{
+				ChannelName: "ch1",
+				MsgID:       []byte{1, 2, 3},
+				MsgGroup:    "",
+				Timestamp:   1,
+			},
+			NumOfRows: 100,
+		}
+		err = svr.meta.AddSegment(context.TODO(), NewSegmentInfo(seg1))
+		assert.NoError(t, err)
+		seg2 := &datapb.SegmentInfo{
+			ID:            2,
+			CollectionID:  0,
+			PartitionID:   0,
+			InsertChannel: "ch1",
+			State:         commonpb.SegmentState_Dropped,
+			DmlPosition: &msgpb.MsgPosition{
+				ChannelName: "ch1",
+				MsgID:       []byte{1, 2, 3},
+				MsgGroup:    "",
+				Timestamp:   1,
+			},
+			NumOfRows: 100,
+		}
+		err = svr.meta.AddSegment(context.TODO(), NewSegmentInfo(seg2))
+		assert.NoError(t, err)
+		// seg3 was GCed
+		seg4 := &datapb.SegmentInfo{
+			ID:            4,
+			CollectionID:  0,
+			PartitionID:   0,
+			InsertChannel: "ch1",
+			State:         commonpb.SegmentState_Dropped,
+			DmlPosition: &msgpb.MsgPosition{
+				ChannelName: "ch1",
+				MsgID:       []byte{1, 2, 3},
+				MsgGroup:    "",
+				Timestamp:   1,
+			},
+			NumOfRows: 100,
+		}
+		err = svr.meta.AddSegment(context.TODO(), NewSegmentInfo(seg4))
+		assert.NoError(t, err)
+		seg5 := &datapb.SegmentInfo{
+			ID:            5,
+			CollectionID:  0,
+			PartitionID:   0,
+			InsertChannel: "ch1",
+			State:         commonpb.SegmentState_Dropped,
+			DmlPosition: &msgpb.MsgPosition{
+				ChannelName: "ch1",
+				MsgID:       []byte{1, 2, 3},
+				MsgGroup:    "",
+				Timestamp:   1,
+			},
+			NumOfRows: 100,
+		}
+		err = svr.meta.AddSegment(context.TODO(), NewSegmentInfo(seg5))
+		assert.NoError(t, err)
+		seg6 := &datapb.SegmentInfo{
+			ID:            6,
+			CollectionID:  0,
+			PartitionID:   0,
+			InsertChannel: "ch1",
+			State:         commonpb.SegmentState_Dropped,
+			DmlPosition: &msgpb.MsgPosition{
+				ChannelName: "ch1",
+				MsgID:       []byte{1, 2, 3},
+				MsgGroup:    "",
+				Timestamp:   1,
+			},
+			NumOfRows: 100,
+		}
+		err = svr.meta.AddSegment(context.TODO(), NewSegmentInfo(seg6))
+		assert.NoError(t, err)
+		seg7 := &datapb.SegmentInfo{
+			ID:            7,
+			CollectionID:  0,
+			PartitionID:   0,
+			InsertChannel: "ch1",
+			State:         commonpb.SegmentState_Dropped,
+			DmlPosition: &msgpb.MsgPosition{
+				ChannelName: "ch1",
+				MsgID:       []byte{1, 2, 3},
+				MsgGroup:    "",
+				Timestamp:   1,
+			},
+			NumOfRows: 2048,
+		}
+		err = svr.meta.AddSegment(context.TODO(), NewSegmentInfo(seg7))
+		assert.NoError(t, err)
+		seg8 := &datapb.SegmentInfo{
+			ID:            8,
+			CollectionID:  0,
+			PartitionID:   0,
+			InsertChannel: "ch1",
+			State:         commonpb.SegmentState_Dropped,
+			DmlPosition: &msgpb.MsgPosition{
+				ChannelName: "ch1",
+				MsgID:       []byte{1, 2, 3},
+				MsgGroup:    "",
+				Timestamp:   1,
+			},
+			NumOfRows:      100,
+			CompactionFrom: []int64{1, 2, 3},
+		}
+		err = svr.meta.AddSegment(context.TODO(), NewSegmentInfo(seg8))
+		assert.NoError(t, err)
+		seg9 := &datapb.SegmentInfo{
+			ID:            9,
+			CollectionID:  0,
+			PartitionID:   0,
+			InsertChannel: "ch1",
+			State:         commonpb.SegmentState_Dropped,
+			DmlPosition: &msgpb.MsgPosition{
+				ChannelName: "ch1",
+				MsgID:       []byte{1, 2, 3},
+				MsgGroup:    "",
+				Timestamp:   1,
+			},
+			NumOfRows:      100,
+			CompactionFrom: []int64{1, 2, 3},
+		}
+		err = svr.meta.AddSegment(context.TODO(), NewSegmentInfo(seg9))
+		assert.NoError(t, err)
+		seg10 := &datapb.SegmentInfo{
+			ID:            10,
+			CollectionID:  0,
+			PartitionID:   0,
+			InsertChannel: "ch1",
+			State:         commonpb.SegmentState_Dropped,
+			DmlPosition: &msgpb.MsgPosition{
+				ChannelName: "ch1",
+				MsgID:       []byte{1, 2, 3},
+				MsgGroup:    "",
+				Timestamp:   1,
+			},
+			NumOfRows:      100,
+			CompactionFrom: []int64{1, 2, 3},
+		}
+		err = svr.meta.AddSegment(context.TODO(), NewSegmentInfo(seg10))
+		assert.NoError(t, err)
+		seg11 := &datapb.SegmentInfo{
+			ID:            11,
+			CollectionID:  0,
+			PartitionID:   0,
+			InsertChannel: "ch1",
+			State:         commonpb.SegmentState_Dropped,
+			DmlPosition: &msgpb.MsgPosition{
+				ChannelName: "ch1",
+				MsgID:       []byte{1, 2, 3},
+				MsgGroup:    "",
+				Timestamp:   1,
+			},
+			NumOfRows:      2048,
+			CompactionFrom: []int64{4, 5, 6},
+		}
+		err = svr.meta.AddSegment(context.TODO(), NewSegmentInfo(seg11))
+		assert.NoError(t, err)
+		seg12 := &datapb.SegmentInfo{
+			ID:            12,
+			CollectionID:  0,
+			PartitionID:   0,
+			InsertChannel: "ch1",
+			State:         commonpb.SegmentState_Dropped,
+			DmlPosition: &msgpb.MsgPosition{
+				ChannelName: "ch1",
+				MsgID:       []byte{1, 2, 3},
+				MsgGroup:    "",
+				Timestamp:   1,
+			},
+			NumOfRows:      100,
+			CompactionFrom: []int64{4, 5, 6},
+		}
+		err = svr.meta.AddSegment(context.TODO(), NewSegmentInfo(seg12))
+		assert.NoError(t, err)
+		seg13 := &datapb.SegmentInfo{
+			ID:            13,
+			CollectionID:  0,
+			PartitionID:   0,
+			InsertChannel: "ch1",
+			State:         commonpb.SegmentState_Dropped,
+			DmlPosition: &msgpb.MsgPosition{
+				ChannelName: "ch1",
+				MsgID:       []byte{1, 2, 3},
+				MsgGroup:    "",
+				Timestamp:   1,
+			},
+			NumOfRows:      2047,
+			CompactionFrom: []int64{7, 8, 9},
+		}
+		err = svr.meta.AddSegment(context.TODO(), NewSegmentInfo(seg13))
+		assert.NoError(t, err)
+		seg14 := &datapb.SegmentInfo{
+			ID:            14,
+			CollectionID:  0,
+			PartitionID:   0,
+			InsertChannel: "ch1",
+			State:         commonpb.SegmentState_Dropped,
+			DmlPosition: &msgpb.MsgPosition{
+				ChannelName: "ch1",
+				MsgID:       []byte{1, 2, 3},
+				MsgGroup:    "",
+				Timestamp:   1,
+			},
+			NumOfRows:      100,
+			CompactionFrom: []int64{10, 11},
+		}
+		err = svr.meta.AddSegment(context.TODO(), NewSegmentInfo(seg14))
+		assert.NoError(t, err)
+		seg15 := &datapb.SegmentInfo{
+			ID:            15,
+			CollectionID:  0,
+			PartitionID:   0,
+			InsertChannel: "ch1",
+			State:         commonpb.SegmentState_Dropped,
+			DmlPosition: &msgpb.MsgPosition{
+				ChannelName: "ch1",
+				MsgID:       []byte{1, 2, 3},
+				MsgGroup:    "",
+				Timestamp:   1,
+			},
+			NumOfRows:      2048,
+			CompactionFrom: []int64{10, 11},
+		}
+		err = svr.meta.AddSegment(context.TODO(), NewSegmentInfo(seg15))
+		assert.NoError(t, err)
+		seg16 := &datapb.SegmentInfo{
+			ID:            16,
+			CollectionID:  0,
+			PartitionID:   0,
+			InsertChannel: "ch1",
+			State:         commonpb.SegmentState_Flushed,
+			DmlPosition: &msgpb.MsgPosition{
+				ChannelName: "ch1",
+				MsgID:       []byte{1, 2, 3},
+				MsgGroup:    "",
+				Timestamp:   1,
+			},
+			NumOfRows:      2048,
+			CompactionFrom: []int64{13, 14},
+		}
+		err = svr.meta.AddSegment(context.TODO(), NewSegmentInfo(seg16))
+		assert.NoError(t, err)
+		seg17 := &datapb.SegmentInfo{
+			ID:            17,
+			CollectionID:  0,
+			PartitionID:   0,
+			InsertChannel: "ch1",
+			State:         commonpb.SegmentState_Flushed,
+			DmlPosition: &msgpb.MsgPosition{
+				ChannelName: "ch1",
+				MsgID:       []byte{1, 2, 3},
+				MsgGroup:    "",
+				Timestamp:   1,
+			},
+			NumOfRows:      2048,
+			CompactionFrom: []int64{12, 15},
+		}
+		err = svr.meta.AddSegment(context.TODO(), NewSegmentInfo(seg17))
+		assert.NoError(t, err)
+
+		vchan := svr.handler.GetQueryVChanPositions(&channelMeta{Name: "ch1", CollectionID: 0})
+		assert.ElementsMatch(t, []int64{7, 8, 9, 10, 4, 5, 6}, vchan.FlushedSegmentIds)
+		assert.ElementsMatch(t, []int64{1, 2}, vchan.DroppedSegmentIds)
+	})
+
 }
 
 func TestShouldDropChannel(t *testing.T) {

--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -1631,7 +1631,8 @@ func isSegmentHealthy(segment *SegmentInfo) bool {
 	return segment != nil &&
 		segment.GetState() != commonpb.SegmentState_SegmentStateNone &&
 		segment.GetState() != commonpb.SegmentState_NotExist &&
-		segment.GetState() != commonpb.SegmentState_Dropped
+		segment.GetState() != commonpb.SegmentState_Dropped &&
+		!segment.GetIsInvisible()
 }
 
 func (m *meta) HasSegments(segIDs []UniqueID) (bool, error) {

--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -1631,8 +1631,7 @@ func isSegmentHealthy(segment *SegmentInfo) bool {
 	return segment != nil &&
 		segment.GetState() != commonpb.SegmentState_SegmentStateNone &&
 		segment.GetState() != commonpb.SegmentState_NotExist &&
-		segment.GetState() != commonpb.SegmentState_Dropped &&
-		!segment.GetIsInvisible()
+		segment.GetState() != commonpb.SegmentState_Dropped
 }
 
 func (m *meta) HasSegments(segIDs []UniqueID) (bool, error) {

--- a/internal/datacoord/partition_stats_meta.go
+++ b/internal/datacoord/partition_stats_meta.go
@@ -121,6 +121,8 @@ func (psm *partitionStatsMeta) SavePartitionStatsInfo(info *datapb.PartitionStat
 	}
 
 	psm.partitionStatsInfos[info.GetVChannel()][info.GetPartitionID()].infos[info.GetVersion()] = info
+	// after v2.5.0,  the current version will be updated when updating the partition stats info, so there’s no need to split it into two steps
+	psm.partitionStatsInfos[info.GetVChannel()][info.GetPartitionID()].currentVersion = info.Version
 	return nil
 }
 

--- a/internal/datacoord/partition_stats_meta_test.go
+++ b/internal/datacoord/partition_stats_meta_test.go
@@ -75,7 +75,7 @@ func (s *PartitionStatsMetaSuite) TestGetPartitionStats() {
 	s.NotNil(ps)
 
 	currentVersion := partitionStatsMeta.GetCurrentPartitionStatsVersion(1, 2, "ch-1")
-	s.Equal(emptyPartitionStatsVersion, currentVersion)
+	s.Equal(int64(100), currentVersion)
 
 	currentVersion2 := partitionStatsMeta.GetCurrentPartitionStatsVersion(1, 2, "ch-2")
 	s.Equal(emptyPartitionStatsVersion, currentVersion2)

--- a/internal/datacoord/task_stats_test.go
+++ b/internal/datacoord/task_stats_test.go
@@ -67,6 +67,7 @@ func (s *statsTaskSuite) SetupSuite() {
 						NumOfRows:     65535,
 						State:         commonpb.SegmentState_Flushed,
 						MaxRowNum:     65535,
+						Level:         datapb.SegmentLevel_L2,
 					},
 				},
 			},
@@ -82,6 +83,7 @@ func (s *statsTaskSuite) SetupSuite() {
 								NumOfRows:     65535,
 								State:         commonpb.SegmentState_Flushed,
 								MaxRowNum:     65535,
+								Level:         datapb.SegmentLevel_L2,
 							},
 						},
 					},
@@ -97,6 +99,7 @@ func (s *statsTaskSuite) SetupSuite() {
 								NumOfRows:     65535,
 								State:         commonpb.SegmentState_Flushed,
 								MaxRowNum:     65535,
+								Level:         datapb.SegmentLevel_L2,
 							},
 						},
 					},
@@ -545,12 +548,14 @@ func (s *statsTaskSuite) TestTaskStats_PreCheck() {
 			catalog := catalogmocks.NewDataCoordCatalog(s.T())
 			s.mt.catalog = catalog
 			s.mt.statsTaskMeta.catalog = catalog
+			s.mt.segments.SetState(s.segID, commonpb.SegmentState_Flushed)
 			catalog.EXPECT().AlterSegments(mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			catalog.EXPECT().SaveStatsTask(mock.Anything, mock.Anything).Return(nil)
 
 			s.NoError(st.SetJobInfo(s.mt))
-			s.NotNil(s.mt.GetHealthySegment(s.segID + 1))
+			s.NotNil(s.mt.GetHealthySegment(s.targetID))
 			s.Equal(indexpb.JobState_JobStateFinished, s.mt.statsTaskMeta.tasks[s.taskID].GetState())
+			s.Equal(datapb.SegmentLevel_L2, s.mt.GetHealthySegment(s.targetID).GetLevel())
 		})
 	})
 }

--- a/internal/proto/data_coord.proto
+++ b/internal/proto/data_coord.proto
@@ -357,6 +357,10 @@ message SegmentInfo {
   // textStatsLogs is used to record tokenization index for fields.
   map<int64, TextIndexStats> textStatsLogs = 26;
   repeated FieldBinlog bm25statslogs = 27;
+
+  // This field is used to indicate that some intermediate state segments should not be loaded.
+  // For example, segments that have been clustered but haven't undergone stats yet.
+  bool is_invisible = 28;
 }
 
 message SegmentStartPosition {


### PR DESCRIPTION
issue: #36686 

This pr will remove pre-marking segments as L2 during clustering compaction in version 2.5,  and ensure compatibility with version 2.4.

The core of this change is to **ensure that the many-to-many lineage derivation logic is correct, making sure that both the parent and child cannot simultaneously exist in the target segment view.**

feature:
  - Clustering compaction no longer marks the input segments as L2.
  - Add a new field `is_invisible` to `segmentInfo`, and mark segments that have completed clustering but have not yet built indexes as `is_invisible` to prevent them from being loaded prematurely."
  - Do not mark the input segment as `Dropped` before the clustering compaction is completed.
  - After compaction fails, only the result segment needs to be marked as Dropped.

compatibility:
  - If the upgraded task has not failed, there are no compatibility issues.
    - If the status after the upgrade is `MetaSaved`, then skip the stats task based on whether TmpSegments is empty.
  - If the failure occurs before `MetaSaved`:
    - there are no ResultSegments, and InputSegments have not been marked as dropped yet.
    - the level of input segments need to revert to LastLevel
  - If the failure occurs after `MetaSaved`:
    - ResultSegments have already been generated, and InputSegments have been marked as Dropped. At this point, simply make the ResultSegments visible.
    - the level of ResultSegments needs to be set to L1（in order to participate in mixCompaction）