### PR TITLE
enhance: Ignore db not found error in quota center (#36821)

### DIFF
--- a/internal/rootcoord/quota_center.go
+++ b/internal/rootcoord/quota_center.go
@@ -571,7 +571,7 @@ func (q *QuotaCenter) forceDenyWriting(errorCode commonpb.ErrorCode, cluster boo
 	for _, collectionID := range collectionIDs {
 		dbID, ok := q.collectionIDToDBID.Get(collectionID)
 		if !ok {
-			log.Warn("cannot find db id for collection", zap.Int64("collection", collectionID))
+			log.Warn("cannot find db for collection", zap.Int64("collection", collectionID))
 			continue
 		}
 		collectionLimiter := q.rateLimiter.GetCollectionLimiters(dbID, collectionID)
@@ -589,7 +589,7 @@ func (q *QuotaCenter) forceDenyWriting(errorCode commonpb.ErrorCode, cluster boo
 		for _, partitionID := range partitionIDs {
 			dbID, ok := q.collectionIDToDBID.Get(collectionID)
 			if !ok {
-				log.Warn("cannot find db id for collection", zap.Int64("collection", collectionID))
+				log.Warn("cannot find db for collection", zap.Int64("collection", collectionID))
 				continue
 			}
 			partitionLimiter := q.rateLimiter.GetPartitionLimiters(dbID, collectionID, partitionID)
@@ -780,7 +780,7 @@ func (q *QuotaCenter) calculateWriteRates() error {
 
 		dbID, ok := q.collectionIDToDBID.Get(collection)
 		if !ok {
-			log.Warn("db ID not found for collection", zap.Int64("collectionID", collection))
+			log.Warn("cannot find db for collection", zap.Int64("collection", collection))
 			continue
 		}
 		collectionLimiter := q.rateLimiter.GetCollectionLimiters(dbID, collection)
@@ -1233,7 +1233,7 @@ func (q *QuotaCenter) checkDiskQuota(denyWritingDBs map[int64]struct{}) error {
 		}
 		dbID, ok := q.collectionIDToDBID.Get(collection)
 		if !ok {
-			log.Warn("cannot find db id for collection", zap.Int64("collection", collection))
+			log.Warn("cannot find db for collection", zap.Int64("collection", collection))
 			continue
 		}
 

--- a/internal/rootcoord/quota_center.go
+++ b/internal/rootcoord/quota_center.go
@@ -571,7 +571,8 @@ func (q *QuotaCenter) forceDenyWriting(errorCode commonpb.ErrorCode, cluster boo
 	for _, collectionID := range collectionIDs {
 		dbID, ok := q.collectionIDToDBID.Get(collectionID)
 		if !ok {
-			return fmt.Errorf("db ID not found of collection ID: %d", collectionID)
+			log.Warn("cannot find db id for collection", zap.Int64("collection", collectionID))
+			continue
 		}
 		collectionLimiter := q.rateLimiter.GetCollectionLimiters(dbID, collectionID)
 		if collectionLimiter == nil {
@@ -588,7 +589,8 @@ func (q *QuotaCenter) forceDenyWriting(errorCode commonpb.ErrorCode, cluster boo
 		for _, partitionID := range partitionIDs {
 			dbID, ok := q.collectionIDToDBID.Get(collectionID)
 			if !ok {
-				return fmt.Errorf("db ID not found of collection ID: %d", collectionID)
+				log.Warn("cannot find db id for collection", zap.Int64("collection", collectionID))
+				continue
 			}
 			partitionLimiter := q.rateLimiter.GetPartitionLimiters(dbID, collectionID, partitionID)
 			if partitionLimiter == nil {
@@ -778,7 +780,8 @@ func (q *QuotaCenter) calculateWriteRates() error {
 
 		dbID, ok := q.collectionIDToDBID.Get(collection)
 		if !ok {
-			return fmt.Errorf("db ID not found of collection ID: %d", collection)
+			log.Warn("db ID not found for collection", zap.Int64("collectionID", collection))
+			continue
 		}
 		collectionLimiter := q.rateLimiter.GetCollectionLimiters(dbID, collection)
 		if collectionLimiter == nil {

--- a/internal/rootcoord/quota_center_test.go
+++ b/internal/rootcoord/quota_center_test.go
@@ -349,7 +349,7 @@ func TestQuotaCenter(t *testing.T) {
 		assert.NoError(t, err)
 
 		err = quotaCenter.forceDenyWriting(commonpb.ErrorCode_ForceDeny, false, nil, []int64{4}, nil)
-		assert.Error(t, err)
+		assert.NoError(t, err)
 
 		err = quotaCenter.forceDenyWriting(commonpb.ErrorCode_ForceDeny, false, nil, []int64{1, 2, 3}, map[int64][]int64{
 			1: {1000},


### PR DESCRIPTION
In quota center, ignore the "DB not found error" to prevent it from affecting the rate limiting of other databases.

/kind improvement

pr: https://github.com/milvus-io/milvus/pull/36821