### PR TITLE
enhance: add checkers for Faiss-based HNSW

### DIFF
--- a/pkg/util/indexparamcheck/conf_adapter_mgr.go
+++ b/pkg/util/indexparamcheck/conf_adapter_mgr.go
@@ -57,6 +57,10 @@ func (mgr *indexCheckerMgrImpl) registerIndexChecker() {
 	mgr.checkers[IndexHNSW] = newHnswChecker()
 	mgr.checkers[IndexDISKANN] = newDiskannChecker()
 	mgr.checkers[IndexSparseInverted] = newSparseInvertedIndexChecker()
+	mgr.checkers[IndexFaissHNSW] = newFloatVectorBaseChecker()
+	mgr.checkers[IndexFaissHNSWPQ] = newFloatVectorBaseChecker()
+	mgr.checkers[IndexFaissHNSWSQ] = newFloatVectorBaseChecker()
+	mgr.checkers[IndexFaissHNSWPRQ] = newFloatVectorBaseChecker()
 	// WAND doesn't have more index params than sparse inverted index, thus
 	// using the same checker.
 	mgr.checkers[IndexSparseWand] = newSparseInvertedIndexChecker()

--- a/pkg/util/indexparamcheck/index_type.go
+++ b/pkg/util/indexparamcheck/index_type.go
@@ -40,6 +40,14 @@ const (
 	IndexDISKANN         IndexType = "DISKANN"
 	IndexSparseInverted  IndexType = "SPARSE_INVERTED_INDEX"
 	IndexSparseWand      IndexType = "SPARSE_WAND"
+	// For temporary use, will be removed in the future.
+	// 1. All Index related param check will be moved to Knowhere recently.
+	// 2. FAISS_HNSW_xxx will be rename to HNSW_xxx after QA test. We keep the original name for comparison purpose.
+	// TODO: @liliu-z @foxspy
+	IndexFaissHNSW    IndexType = "FAISS_HNSW_FLAT"
+	IndexFaissHNSWPQ  IndexType = "FAISS_HNSW_PQ"
+	IndexFaissHNSWSQ  IndexType = "FAISS_HNSW_SQ"
+	IndexFaissHNSWPRQ IndexType = "FAISS_HNSW_PRQ"
 
 	// scalar index
 	IndexSTLSORT  IndexType = "STL_SORT"


### PR DESCRIPTION
Knowhere introduced FAISS-based HNSQ Flat/SQ/PQ/PRQ. This PR adds param check in Milvus side. 

This PR actually do nothing but let the check pass, since:
1. All indexes param check will be moved to Knowhere recently. @foxspy 
2. The index name will be changed from `FAISS_HNSW_xx` to `HNSW_xx` after QA test.  @alexanderguzhva 

