### PR TITLE
enhance: Fill start pos & level for growing segment

### DIFF
--- a/internal/querynodev2/handlers.go
+++ b/internal/querynodev2/handlers.go
@@ -96,6 +96,7 @@ func loadGrowingSegments(ctx context.Context, delegator delegator.ShardDelegator
 			if len(segmentInfo.GetBinlogs()) > 0 {
 				growingSegments = append(growingSegments, &querypb.SegmentLoadInfo{
 					SegmentID:     segmentInfo.ID,
+					Level:         segmentInfo.GetLevel(),
 					PartitionID:   segmentInfo.PartitionID,
 					CollectionID:  segmentInfo.CollectionID,
 					BinlogPaths:   segmentInfo.Binlogs,
@@ -104,6 +105,7 @@ func loadGrowingSegments(ctx context.Context, delegator delegator.ShardDelegator
 					Deltalogs:     segmentInfo.Deltalogs,
 					Bm25Logs:      segmentInfo.Bm25Statslogs,
 					InsertChannel: segmentInfo.InsertChannel,
+					StartPosition: segmentInfo.GetStartPosition(),
 				})
 			} else {
 				log.Info("skip segment which binlog is empty", zap.Int64("segmentID", segmentInfo.ID))


### PR DESCRIPTION
Start position & level info is missing for growing segment loaded in watch dml channel operation.

Level is important for metrics and start position is crucial for growing exclude logic.