### PR TITLE
enhance: [2.4] Fill start pos & level for growing segment (#36888)

### DIFF
--- a/internal/querynodev2/handlers.go
+++ b/internal/querynodev2/handlers.go
@@ -93,6 +93,7 @@ func loadGrowingSegments(ctx context.Context, delegator delegator.ShardDelegator
 			if len(segmentInfo.GetBinlogs()) > 0 {
 				growingSegments = append(growingSegments, &querypb.SegmentLoadInfo{
 					SegmentID:     segmentInfo.ID,
+					Level:         segmentInfo.GetLevel(),
 					PartitionID:   segmentInfo.PartitionID,
 					CollectionID:  segmentInfo.CollectionID,
 					BinlogPaths:   segmentInfo.Binlogs,
@@ -100,6 +101,7 @@ func loadGrowingSegments(ctx context.Context, delegator delegator.ShardDelegator
 					Statslogs:     segmentInfo.Statslogs,
 					Deltalogs:     segmentInfo.Deltalogs,
 					InsertChannel: segmentInfo.InsertChannel,
+					StartPosition: segmentInfo.GetStartPosition(),
 				})
 			} else {
 				log.Info("skip segment which binlog is empty", zap.Int64("segmentID", segmentInfo.ID))


### PR DESCRIPTION
Cherry-pick from master
pr: #36888

Start position & level info is missing for growing segment loaded in watch dml channel operation.

Level is important for metrics and start position is crucial for growing exclude logic.