### PR TITLE
fix: loss small bm25 binlogs

### DIFF
--- a/internal/flushcommon/syncmgr/task.go
+++ b/internal/flushcommon/syncmgr/task.go
@@ -152,7 +152,7 @@ func (t *SyncTask) Run(ctx context.Context) (err error) {
 	t.processStatsBlob()
 	t.processDeltaBlob()
 
-	if len(t.bm25Binlogs) > 0 || len(t.mergedBm25Blob) > 0 {
+	if len(t.bm25Blobs) > 0 || len(t.mergedBm25Blob) > 0 {
 		t.processBM25StastBlob()
 	}
 


### PR DESCRIPTION
Sync task don't flush small bm25 logs, cause growing segment bm25 stats loss.
relate: https://github.com/milvus-io/milvus/issues/36805