### PR TITLE
fix: datacoord stuck at stopping progress (#36852)

### DIFF
--- a/internal/datacoord/mock_session_manager.go
+++ b/internal/datacoord/mock_session_manager.go
@@ -971,13 +971,13 @@ func (_c *MockSessionManager_QuerySlot_Call) RunAndReturn(run func(int64) (*data
 	return _c
 }
 
-// SyncSegments provides a mock function with given fields: nodeID, req
-func (_m *MockSessionManager) SyncSegments(nodeID int64, req *datapb.SyncSegmentsRequest) error {
-	ret := _m.Called(nodeID, req)
+// SyncSegments provides a mock function with given fields: ctx, nodeID, req
+func (_m *MockSessionManager) SyncSegments(ctx context.Context, nodeID int64, req *datapb.SyncSegmentsRequest) error {
+	ret := _m.Called(ctx, nodeID, req)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(int64, *datapb.SyncSegmentsRequest) error); ok {
-		r0 = rf(nodeID, req)
+	if rf, ok := ret.Get(0).(func(context.Context, int64, *datapb.SyncSegmentsRequest) error); ok {
+		r0 = rf(ctx, nodeID, req)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -991,15 +991,16 @@ type MockSessionManager_SyncSegments_Call struct {
 }
 
 // SyncSegments is a helper method to define mock.On call
+//   - ctx context.Context
 //   - nodeID int64
 //   - req *datapb.SyncSegmentsRequest
-func (_e *MockSessionManager_Expecter) SyncSegments(nodeID interface{}, req interface{}) *MockSessionManager_SyncSegments_Call {
-	return &MockSessionManager_SyncSegments_Call{Call: _e.mock.On("SyncSegments", nodeID, req)}
+func (_e *MockSessionManager_Expecter) SyncSegments(ctx interface{}, nodeID interface{}, req interface{}) *MockSessionManager_SyncSegments_Call {
+	return &MockSessionManager_SyncSegments_Call{Call: _e.mock.On("SyncSegments", ctx, nodeID, req)}
 }
 
-func (_c *MockSessionManager_SyncSegments_Call) Run(run func(nodeID int64, req *datapb.SyncSegmentsRequest)) *MockSessionManager_SyncSegments_Call {
+func (_c *MockSessionManager_SyncSegments_Call) Run(run func(ctx context.Context, nodeID int64, req *datapb.SyncSegmentsRequest)) *MockSessionManager_SyncSegments_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(int64), args[1].(*datapb.SyncSegmentsRequest))
+		run(args[0].(context.Context), args[1].(int64), args[2].(*datapb.SyncSegmentsRequest))
 	})
 	return _c
 }
@@ -1009,7 +1010,7 @@ func (_c *MockSessionManager_SyncSegments_Call) Return(_a0 error) *MockSessionMa
 	return _c
 }
 
-func (_c *MockSessionManager_SyncSegments_Call) RunAndReturn(run func(int64, *datapb.SyncSegmentsRequest) error) *MockSessionManager_SyncSegments_Call {
+func (_c *MockSessionManager_SyncSegments_Call) RunAndReturn(run func(context.Context, int64, *datapb.SyncSegmentsRequest) error) *MockSessionManager_SyncSegments_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/datacoord/sync_segments_scheduler_test.go
+++ b/internal/datacoord/sync_segments_scheduler_test.go
@@ -17,6 +17,7 @@
 package datacoord
 
 import (
+	"context"
 	"sync/atomic"
 	"testing"
 
@@ -304,7 +305,7 @@ func (s *SyncSegmentsSchedulerSuite) Test_newSyncSegmentsScheduler() {
 	cm.EXPECT().FindWatcher(mock.Anything).Return(100, nil)
 
 	sm := NewMockSessionManager(s.T())
-	sm.EXPECT().SyncSegments(mock.Anything, mock.Anything).RunAndReturn(func(i int64, request *datapb.SyncSegmentsRequest) error {
+	sm.EXPECT().SyncSegments(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, i int64, request *datapb.SyncSegmentsRequest) error {
 		for _, seg := range request.GetSegmentInfos() {
 			if seg.GetState() == commonpb.SegmentState_Flushed {
 				s.new.Add(1)
@@ -333,21 +334,22 @@ func (s *SyncSegmentsSchedulerSuite) Test_SyncSegmentsFail() {
 	sm := NewMockSessionManager(s.T())
 
 	sss := newSyncSegmentsScheduler(s.m, cm, sm)
+	ctx := context.Background()
 
 	s.Run("pk not found", func() {
 		sss.meta.collections[1].Schema.Fields[0].IsPrimaryKey = false
-		sss.SyncSegmentsForCollections()
+		sss.SyncSegmentsForCollections(ctx)
 		sss.meta.collections[1].Schema.Fields[0].IsPrimaryKey = true
 	})
 
 	s.Run("find watcher failed", func() {
 		cm.EXPECT().FindWatcher(mock.Anything).Return(0, errors.New("mock error")).Twice()
-		sss.SyncSegmentsForCollections()
+		sss.SyncSegmentsForCollections(ctx)
 	})
 
 	s.Run("sync segment failed", func() {
 		cm.EXPECT().FindWatcher(mock.Anything).Return(100, nil)
-		sm.EXPECT().SyncSegments(mock.Anything, mock.Anything).Return(errors.New("mock error"))
-		sss.SyncSegmentsForCollections()
+		sm.EXPECT().SyncSegments(mock.Anything, mock.Anything, mock.Anything).Return(errors.New("mock error"))
+		sss.SyncSegmentsForCollections(ctx)
 	})
 }


### PR DESCRIPTION
issue: #36868
pr: #36852
if datacoord is syncing segments to datanode, and stop datacoord happens, datacoord's stop progress will stuck until syncing segment finished.

This PR add ctx to syncing segment, which will failed if stopping datacoord happens.