### PR TITLE
enhance: Enable node assign policy on resource group

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/gin-gonic/gin v1.9.1
 	github.com/go-playground/validator/v10 v10.14.0
 	github.com/gofrs/flock v0.8.1
-	github.com/golang/protobuf v1.5.4
+	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/btree v1.1.2
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/klauspost/compress v1.17.9

--- a/internal/querycoordv2/meta/resource_manager_test.go
+++ b/internal/querycoordv2/meta/resource_manager_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/rgpb"
 	etcdkv "github.com/milvus-io/milvus/internal/kv/etcd"
 	"github.com/milvus-io/milvus/internal/kv/mocks"
@@ -30,6 +31,7 @@ import (
 	"github.com/milvus-io/milvus/internal/querycoordv2/params"
 	"github.com/milvus-io/milvus/internal/querycoordv2/session"
 	"github.com/milvus-io/milvus/pkg/kv"
+	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/util/etcd"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/metricsinfo"
@@ -209,6 +211,7 @@ func (suite *ResourceManagerSuite) TestManipulateResourceGroup() {
 	suite.manager.UpdateResourceGroups(map[string]*rgpb.ResourceGroupConfig{
 		"rg2": newResourceGroupConfig(0, 0),
 	})
+	log.Info("xxxxx")
 	// RemoveResourceGroup will remove all nodes from the resource group.
 	err = suite.manager.RemoveResourceGroup("rg2")
 	suite.NoError(err)
@@ -625,10 +628,11 @@ func (suite *ResourceManagerSuite) TestUnassignFail() {
 }
 
 func TestGetResourceGroupsJSON(t *testing.T) {
+	nodeManager := session.NewNodeManager()
 	manager := &ResourceManager{groups: make(map[string]*ResourceGroup)}
-	rg1 := NewResourceGroup("rg1", newResourceGroupConfig(0, 10))
+	rg1 := NewResourceGroup("rg1", newResourceGroupConfig(0, 10), nodeManager)
 	rg1.nodes = typeutil.NewUniqueSet(1, 2)
-	rg2 := NewResourceGroup("rg2", newResourceGroupConfig(0, 20))
+	rg2 := NewResourceGroup("rg2", newResourceGroupConfig(0, 20), nodeManager)
 	rg2.nodes = typeutil.NewUniqueSet(3, 4)
 	manager.groups["rg1"] = rg1
 	manager.groups["rg2"] = rg2
@@ -651,5 +655,339 @@ func TestGetResourceGroupsJSON(t *testing.T) {
 
 	for _, rg := range resourceGroups {
 		checkResult(rg)
+	}
+}
+
+func (suite *ResourceManagerSuite) TestNodeLabels_NodeAssign() {
+	suite.manager.AddResourceGroup("rg1", &rgpb.ResourceGroupConfig{
+		Requests: &rgpb.ResourceGroupLimit{
+			NodeNum: 10,
+		},
+		Limits: &rgpb.ResourceGroupLimit{
+			NodeNum: 10,
+		},
+		NodeFilter: &rgpb.ResourceGroupNodeFilter{
+			NodeLabels: []*commonpb.KeyValuePair{
+				{
+					Key:   "dc_name",
+					Value: "label1",
+				},
+			},
+		},
+	})
+
+	suite.manager.AddResourceGroup("rg2", &rgpb.ResourceGroupConfig{
+		Requests: &rgpb.ResourceGroupLimit{
+			NodeNum: 10,
+		},
+		Limits: &rgpb.ResourceGroupLimit{
+			NodeNum: 10,
+		},
+		NodeFilter: &rgpb.ResourceGroupNodeFilter{
+			NodeLabels: []*commonpb.KeyValuePair{
+				{
+					Key:   "dc_name",
+					Value: "label2",
+				},
+			},
+		},
+	})
+
+	suite.manager.AddResourceGroup("rg3", &rgpb.ResourceGroupConfig{
+		Requests: &rgpb.ResourceGroupLimit{
+			NodeNum: 10,
+		},
+		Limits: &rgpb.ResourceGroupLimit{
+			NodeNum: 10,
+		},
+		NodeFilter: &rgpb.ResourceGroupNodeFilter{
+			NodeLabels: []*commonpb.KeyValuePair{
+				{
+					Key:   "dc_name",
+					Value: "label3",
+				},
+			},
+		},
+	})
+
+	// test that all query nodes has been marked label1
+	for i := 1; i <= 30; i++ {
+		suite.manager.nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{
+			NodeID:   int64(i),
+			Address:  "localhost",
+			Hostname: "localhost",
+			Labels: map[string]string{
+				"dc_name": "label1",
+			},
+		}))
+		suite.manager.HandleNodeUp(int64(i))
+	}
+	suite.Equal(10, suite.manager.GetResourceGroup("rg1").NodeNum())
+	suite.Equal(0, suite.manager.GetResourceGroup("rg2").NodeNum())
+	suite.Equal(0, suite.manager.GetResourceGroup("rg3").NodeNum())
+	suite.Equal(20, suite.manager.GetResourceGroup(DefaultResourceGroupName).NodeNum())
+
+	// test new querynode with label2
+	for i := 31; i <= 40; i++ {
+		suite.manager.nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{
+			NodeID:   int64(i),
+			Address:  "localhost",
+			Hostname: "localhost",
+			Labels: map[string]string{
+				"dc_name": "label2",
+			},
+		}))
+		suite.manager.HandleNodeUp(int64(i))
+	}
+	suite.Equal(10, suite.manager.GetResourceGroup("rg1").NodeNum())
+	suite.Equal(10, suite.manager.GetResourceGroup("rg2").NodeNum())
+	suite.Equal(0, suite.manager.GetResourceGroup("rg3").NodeNum())
+	suite.Equal(20, suite.manager.GetResourceGroup(DefaultResourceGroupName).NodeNum())
+	nodesInRG, _ := suite.manager.GetNodes("rg2")
+	for _, node := range nodesInRG {
+		suite.Equal("label2", suite.manager.nodeMgr.Get(node).Labels()["dc_name"])
+	}
+
+	// test new querynode with label3
+	for i := 41; i <= 50; i++ {
+		suite.manager.nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{
+			NodeID:   int64(i),
+			Address:  "localhost",
+			Hostname: "localhost",
+			Labels: map[string]string{
+				"dc_name": "label3",
+			},
+		}))
+		suite.manager.HandleNodeUp(int64(i))
+	}
+	suite.Equal(10, suite.manager.GetResourceGroup("rg1").NodeNum())
+	suite.Equal(10, suite.manager.GetResourceGroup("rg2").NodeNum())
+	suite.Equal(10, suite.manager.GetResourceGroup("rg3").NodeNum())
+	suite.Equal(20, suite.manager.GetResourceGroup(DefaultResourceGroupName).NodeNum())
+	nodesInRG, _ = suite.manager.GetNodes("rg3")
+	for _, node := range nodesInRG {
+		suite.Equal("label3", suite.manager.nodeMgr.Get(node).Labels()["dc_name"])
+	}
+
+	// test swap rg's label
+	suite.manager.UpdateResourceGroups(map[string]*rgpb.ResourceGroupConfig{
+		"rg1": {
+			Requests: &rgpb.ResourceGroupLimit{
+				NodeNum: 10,
+			},
+			Limits: &rgpb.ResourceGroupLimit{
+				NodeNum: 10,
+			},
+			NodeFilter: &rgpb.ResourceGroupNodeFilter{
+				NodeLabels: []*commonpb.KeyValuePair{
+					{
+						Key:   "dc_name",
+						Value: "label2",
+					},
+				},
+			},
+		},
+		"rg2": {
+			Requests: &rgpb.ResourceGroupLimit{
+				NodeNum: 10,
+			},
+			Limits: &rgpb.ResourceGroupLimit{
+				NodeNum: 10,
+			},
+			NodeFilter: &rgpb.ResourceGroupNodeFilter{
+				NodeLabels: []*commonpb.KeyValuePair{
+					{
+						Key:   "dc_name",
+						Value: "label3",
+					},
+				},
+			},
+		},
+		"rg3": {
+			Requests: &rgpb.ResourceGroupLimit{
+				NodeNum: 10,
+			},
+			Limits: &rgpb.ResourceGroupLimit{
+				NodeNum: 10,
+			},
+			NodeFilter: &rgpb.ResourceGroupNodeFilter{
+				NodeLabels: []*commonpb.KeyValuePair{
+					{
+						Key:   "dc_name",
+						Value: "label1",
+					},
+				},
+			},
+		},
+	})
+
+	log.Info("test swap rg's label")
+	for i := 0; i < 4; i++ {
+		suite.manager.AutoRecoverResourceGroup("rg1")
+		suite.manager.AutoRecoverResourceGroup("rg2")
+		suite.manager.AutoRecoverResourceGroup("rg3")
+		suite.manager.AutoRecoverResourceGroup(DefaultResourceGroupName)
+	}
+	suite.Equal(10, suite.manager.GetResourceGroup("rg1").NodeNum())
+	suite.Equal(10, suite.manager.GetResourceGroup("rg2").NodeNum())
+	suite.Equal(10, suite.manager.GetResourceGroup("rg3").NodeNum())
+	suite.Equal(20, suite.manager.GetResourceGroup(DefaultResourceGroupName).NodeNum())
+	nodesInRG, _ = suite.manager.GetNodes("rg1")
+	for _, node := range nodesInRG {
+		suite.Equal("label2", suite.manager.nodeMgr.Get(node).Labels()["dc_name"])
+	}
+
+	nodesInRG, _ = suite.manager.GetNodes("rg2")
+	for _, node := range nodesInRG {
+		suite.Equal("label3", suite.manager.nodeMgr.Get(node).Labels()["dc_name"])
+	}
+
+	nodesInRG, _ = suite.manager.GetNodes("rg3")
+	for _, node := range nodesInRG {
+		suite.Equal("label1", suite.manager.nodeMgr.Get(node).Labels()["dc_name"])
+	}
+}
+
+func (suite *ResourceManagerSuite) TestNodeLabels_NodeDown() {
+	suite.manager.AddResourceGroup("rg1", &rgpb.ResourceGroupConfig{
+		Requests: &rgpb.ResourceGroupLimit{
+			NodeNum: 10,
+		},
+		Limits: &rgpb.ResourceGroupLimit{
+			NodeNum: 10,
+		},
+		NodeFilter: &rgpb.ResourceGroupNodeFilter{
+			NodeLabels: []*commonpb.KeyValuePair{
+				{
+					Key:   "dc_name",
+					Value: "label1",
+				},
+			},
+		},
+	})
+
+	suite.manager.AddResourceGroup("rg2", &rgpb.ResourceGroupConfig{
+		Requests: &rgpb.ResourceGroupLimit{
+			NodeNum: 10,
+		},
+		Limits: &rgpb.ResourceGroupLimit{
+			NodeNum: 10,
+		},
+		NodeFilter: &rgpb.ResourceGroupNodeFilter{
+			NodeLabels: []*commonpb.KeyValuePair{
+				{
+					Key:   "dc_name",
+					Value: "label2",
+				},
+			},
+		},
+	})
+
+	suite.manager.AddResourceGroup("rg3", &rgpb.ResourceGroupConfig{
+		Requests: &rgpb.ResourceGroupLimit{
+			NodeNum: 10,
+		},
+		Limits: &rgpb.ResourceGroupLimit{
+			NodeNum: 10,
+		},
+		NodeFilter: &rgpb.ResourceGroupNodeFilter{
+			NodeLabels: []*commonpb.KeyValuePair{
+				{
+					Key:   "dc_name",
+					Value: "label3",
+				},
+			},
+		},
+	})
+
+	// test that all query nodes has been marked label1
+	for i := 1; i <= 10; i++ {
+		suite.manager.nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{
+			NodeID:   int64(i),
+			Address:  "localhost",
+			Hostname: "localhost",
+			Labels: map[string]string{
+				"dc_name": "label1",
+			},
+		}))
+		suite.manager.HandleNodeUp(int64(i))
+	}
+
+	// test new querynode with label2
+	for i := 31; i <= 40; i++ {
+		suite.manager.nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{
+			NodeID:   int64(i),
+			Address:  "localhost",
+			Hostname: "localhost",
+			Labels: map[string]string{
+				"dc_name": "label2",
+			},
+		}))
+		suite.manager.HandleNodeUp(int64(i))
+	}
+	// test new querynode with label3
+	for i := 41; i <= 50; i++ {
+		suite.manager.nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{
+			NodeID:   int64(i),
+			Address:  "localhost",
+			Hostname: "localhost",
+			Labels: map[string]string{
+				"dc_name": "label3",
+			},
+		}))
+		suite.manager.HandleNodeUp(int64(i))
+	}
+	suite.Equal(10, suite.manager.GetResourceGroup("rg1").NodeNum())
+	suite.Equal(10, suite.manager.GetResourceGroup("rg2").NodeNum())
+	suite.Equal(10, suite.manager.GetResourceGroup("rg3").NodeNum())
+
+	// test node down with label1
+	suite.manager.HandleNodeDown(int64(1))
+	suite.manager.nodeMgr.Remove(int64(1))
+	suite.Equal(9, suite.manager.GetResourceGroup("rg1").NodeNum())
+	suite.Equal(10, suite.manager.GetResourceGroup("rg2").NodeNum())
+	suite.Equal(10, suite.manager.GetResourceGroup("rg3").NodeNum())
+
+	// test node up with label2
+	suite.manager.nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{
+		NodeID:   int64(101),
+		Address:  "localhost",
+		Hostname: "localhost",
+		Labels: map[string]string{
+			"dc_name": "label2",
+		},
+	}))
+	suite.manager.HandleNodeUp(int64(101))
+	suite.Equal(9, suite.manager.GetResourceGroup("rg1").NodeNum())
+	suite.Equal(10, suite.manager.GetResourceGroup("rg2").NodeNum())
+	suite.Equal(10, suite.manager.GetResourceGroup("rg3").NodeNum())
+	suite.Equal(1, suite.manager.GetResourceGroup(DefaultResourceGroupName).NodeNum())
+
+	// test node up with label1
+	suite.manager.nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{
+		NodeID:   int64(102),
+		Address:  "localhost",
+		Hostname: "localhost",
+		Labels: map[string]string{
+			"dc_name": "label1",
+		},
+	}))
+	suite.manager.HandleNodeUp(int64(102))
+	suite.Equal(10, suite.manager.GetResourceGroup("rg1").NodeNum())
+	suite.Equal(10, suite.manager.GetResourceGroup("rg2").NodeNum())
+	suite.Equal(10, suite.manager.GetResourceGroup("rg3").NodeNum())
+	suite.Equal(1, suite.manager.GetResourceGroup(DefaultResourceGroupName).NodeNum())
+	nodesInRG, _ := suite.manager.GetNodes("rg1")
+	for _, node := range nodesInRG {
+		suite.Equal("label1", suite.manager.nodeMgr.Get(node).Labels()["dc_name"])
+	}
+
+	suite.manager.AutoRecoverResourceGroup("rg1")
+	suite.manager.AutoRecoverResourceGroup("rg2")
+	suite.manager.AutoRecoverResourceGroup("rg3")
+	suite.manager.AutoRecoverResourceGroup(DefaultResourceGroupName)
+	nodesInRG, _ = suite.manager.GetNodes(DefaultResourceGroupName)
+	for _, node := range nodesInRG {
+		suite.Equal("label2", suite.manager.nodeMgr.Get(node).Labels()["dc_name"])
 	}
 }

--- a/internal/querycoordv2/observers/resource_observer_test.go
+++ b/internal/querycoordv2/observers/resource_observer_test.go
@@ -130,12 +130,8 @@ func (suite *ResourceObserverSuite) TestObserverRecoverOperation() {
 	suite.NoError(suite.meta.ResourceManager.MeetRequirement("rg1"))
 	suite.NoError(suite.meta.ResourceManager.MeetRequirement("rg2"))
 	suite.NoError(suite.meta.ResourceManager.MeetRequirement("rg3"))
-	// but new node with id 10 is not in
-	suite.nodeMgr.Remove(10)
-	suite.NoError(suite.meta.ResourceManager.MeetRequirement("rg1"))
-	suite.NoError(suite.meta.ResourceManager.MeetRequirement("rg2"))
-	suite.NoError(suite.meta.ResourceManager.MeetRequirement("rg3"))
 	// new node is down, rg3 cannot use that node anymore.
+	suite.nodeMgr.Remove(10)
 	suite.meta.ResourceManager.HandleNodeDown(10)
 	suite.observer.checkAndRecoverResourceGroup()
 	suite.NoError(suite.meta.ResourceManager.MeetRequirement("rg1"))

--- a/internal/querycoordv2/server.go
+++ b/internal/querycoordv2/server.go
@@ -507,6 +507,7 @@ func (s *Server) startQueryCoord() error {
 			Address:  node.Address,
 			Hostname: node.HostName,
 			Version:  node.Version,
+			Labels:   node.GetServerLabel(),
 		}))
 		s.taskScheduler.AddExecutor(node.ServerID)
 
@@ -745,6 +746,7 @@ func (s *Server) watchNodes(revision int64) {
 					Address:  addr,
 					Hostname: event.Session.HostName,
 					Version:  event.Session.Version,
+					Labels:   event.Session.GetServerLabel(),
 				}))
 				s.nodeUpEventChan <- nodeID
 				select {

--- a/internal/querycoordv2/session/node_manager.go
+++ b/internal/querycoordv2/session/node_manager.go
@@ -111,6 +111,7 @@ type ImmutableNodeInfo struct {
 	Address  string
 	Hostname string
 	Version  semver.Version
+	Labels   map[string]string
 }
 
 const (
@@ -145,6 +146,10 @@ func (n *NodeInfo) Addr() string {
 
 func (n *NodeInfo) Hostname() string {
 	return n.immutableInfo.Hostname
+}
+
+func (n *NodeInfo) Labels() map[string]string {
+	return n.immutableInfo.Labels
 }
 
 func (n *NodeInfo) SegmentCnt() int {

--- a/internal/util/sessionutil/session_util_test.go
+++ b/internal/util/sessionutil/session_util_test.go
@@ -1064,6 +1064,21 @@ func (s *SessionSuite) TestSafeCloseLiveCh() {
 	})
 }
 
+func (s *SessionSuite) TestGetSessions() {
+	os.Setenv("MILVUS_SERVER_LABEL_key1", "value1")
+	os.Setenv("MILVUS_SERVER_LABEL_key2", "value2")
+	os.Setenv("key3", "value3")
+
+	defer os.Unsetenv("MILVUS_SERVER_LABEL_key1")
+	defer os.Unsetenv("MILVUS_SERVER_LABEL_key2")
+	defer os.Unsetenv("key3")
+
+	ret := GetServerLabelsFromEnv("querynode")
+	assert.Equal(s.T(), 2, len(ret))
+	assert.Equal(s.T(), "value1", ret["key1"])
+	assert.Equal(s.T(), "value2", ret["key2"])
+}
+
 func TestSessionSuite(t *testing.T) {
 	suite.Run(t, new(SessionSuite))
 }


### PR DESCRIPTION
issue: #36977
with node_label_filter on resource group, user can add label on querynode with env `MILVUS_COMPONENT_LABEL`, then resource group will prefer to accept node which match it's node_label_filter.

then querynode's can't be group by labels, and put querynodes with same label to same resource groups.