### PR TITLE
Bug: removed deprecated fmt::underlying

### DIFF
--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -741,7 +741,7 @@ CreateChunkManager(const StorageConfig& storage_config) {
         default: {
             PanicInfo(ConfigInvalid,
                       "unsupported storage_config.storage_type {}",
-                      fmt::underlying(storage_type));
+                      storage_type);
         }
     }
 }


### PR DESCRIPTION
The fmt::underlying is removed in the actual fmt lib. 