### PR TITLE
enhance: Remove bf from datanode (#36367)

### DIFF
--- a/internal/datanode/data_sync_service.go
+++ b/internal/datanode/data_sync_service.go
@@ -350,7 +350,6 @@ func newDataSyncService(initCtx context.Context, node *DataNode, info *datapb.Ch
 	// recover segment checkpoints
 	var (
 		err                   error
-		metaCache             metacache.MetaCache
 		unflushedSegmentInfos []*datapb.SegmentInfo
 		flushedSegmentInfos   []*datapb.SegmentInfo
 	)
@@ -375,8 +374,10 @@ func newDataSyncService(initCtx context.Context, node *DataNode, info *datapb.Ch
 		}
 	}
 	// init metaCache meta
-	if metaCache, err = getMetaCacheWithTickler(initCtx, node, info, tickler, unflushedSegmentInfos, flushedSegmentInfos, nil); err != nil {
+	metaCache, err := getMetaCacheWithTickler(initCtx, node, info, tickler, unflushedSegmentInfos, flushedSegmentInfos, storageCache)
+	if err != nil {
 		return nil, err
 	}
+
 	return getServiceWithChannel(initCtx, node, info, metaCache, storageCache, unflushedSegmentInfos, flushedSegmentInfos)
 }

--- a/internal/datanode/writebuffer/l0_write_buffer.go
+++ b/internal/datanode/writebuffer/l0_write_buffer.go
@@ -163,9 +163,9 @@ func (wb *l0WriteBuffer) BufferData(insertMsgs []*msgstream.InsertMsg, deleteMsg
 		}
 	}
 
-	if streamingutil.IsStreamingServiceEnabled() {
-		// In streaming service mode, flushed segments no longer maintain a bloom filter.
-		// So, here we skip filtering delete entries by bf.
+	if paramtable.Get().DataNodeCfg.SkipBFStatsLoad.GetAsBool() {
+		// In Skip BF mode, datanode no longer maintains bloom filters.
+		// So, here we skip filtering delete entries.
 		wb.dispatchDeleteMsgsWithoutFilter(deleteMsgs, startPos, endPos)
 	} else {
 		// distribute delete msg

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -4317,7 +4317,8 @@ Setting this parameter too small causes the system to store a small amount of da
 		Key:          "dataNode.skip.BFStats.Load",
 		Version:      "2.2.5",
 		PanicIfEmpty: false,
-		DefaultValue: "false",
+		DefaultValue: "true",
+		Forbidden:    true, // The SkipBFStatsLoad is a static config that not allow dynamic refresh.
 	}
 	p.SkipBFStatsLoad.Init(base.mgr)
 


### PR DESCRIPTION
Remove bf from datanode:
1. When watching vchannels, skip loading **flushed** segments's bf. For generating merged bf, we need to keep loading **growing** segments's bf.
2. Bypass bloom filter checks for delete messages, directly writing to L0 segments.
3. In version 2.4, when dropping a partition, marking segments as dropped depends on having the full segment list in the DataNode. So, we need to keep syncing the segments every 10 minutes.

issue: https://github.com/milvus-io/milvus/issues/34585

pr: https://github.com/milvus-io/milvus/pull/35902, https://github.com/milvus-io/milvus/pull/36367, https://github.com/milvus-io/milvus/pull/36592