### PR TITLE
enhance: Skip load delta data in delegater when using RemoteLoad

### DIFF
--- a/internal/querynodev2/delegator/delegator.go
+++ b/internal/querynodev2/delegator/delegator.go
@@ -144,6 +144,9 @@ type shardDelegator struct {
 	// fieldId -> functionRunner map for search function field
 	functionRunners map[UniqueID]function.FunctionRunner
 	isBM25Field     map[UniqueID]bool
+
+	// current forward policy
+	l0ForwardPolicy string
 }
 
 // getLogger returns the zap logger with pre-defined shard attributes.
@@ -913,6 +916,9 @@ func NewShardDelegator(ctx context.Context, collectionID UniqueID, replicaID Uni
 
 	excludedSegments := NewExcludedSegments(paramtable.Get().QueryNodeCfg.CleanExcludeSegInterval.GetAsDuration(time.Second))
 
+	policy := paramtable.Get().QueryNodeCfg.LevelZeroForwardPolicy.GetValue()
+	log.Info("shard delegator setup l0 forward policy", zap.String("policy", policy))
+
 	sd := &shardDelegator{
 		collectionID:     collectionID,
 		replicaID:        replicaID,
@@ -935,6 +941,7 @@ func NewShardDelegator(ctx context.Context, collectionID UniqueID, replicaID Uni
 		excludedSegments: excludedSegments,
 		functionRunners:  make(map[int64]function.FunctionRunner),
 		isBM25Field:      make(map[int64]bool),
+		l0ForwardPolicy:  policy,
 	}
 
 	for _, tf := range collection.Schema().GetFunctions() {

--- a/internal/querynodev2/delegator/delta_forward.go
+++ b/internal/querynodev2/delegator/delta_forward.go
@@ -56,13 +56,13 @@ func (sd *shardDelegator) forwardL0Deletion(ctx context.Context,
 	targetNodeID int64,
 	worker cluster.Worker,
 ) error {
-	switch policy := paramtable.Get().QueryNodeCfg.LevelZeroForwardPolicy.GetValue(); policy {
+	switch sd.l0ForwardPolicy {
 	case ForwardPolicyDefault, L0ForwardPolicyBF:
 		return sd.forwardL0ByBF(ctx, info, candidate, targetNodeID, worker)
 	case L0ForwardPolicyRemoteLoad:
 		return sd.forwardL0RemoteLoad(ctx, info, req, targetNodeID, worker)
 	default:
-		return merr.WrapErrServiceInternal("Unknown l0 forward policy: %s", policy)
+		return merr.WrapErrServiceInternal("Unknown l0 forward policy: %s", sd.l0ForwardPolicy)
 	}
 }
 


### PR DESCRIPTION
Related to #35303

Delta data is not needed when using `RemoteLoad` l0 forward policy. By skipping load delta data, memory pressure could be eased if l0 segment size/number is large.