### PR TITLE
fix: Search/Query may failed during updating delegator cache.

### DIFF
--- a/internal/proxy/lb_policy.go
+++ b/internal/proxy/lb_policy.go
@@ -98,6 +98,7 @@ func (lb *LBPolicyImpl) Start(ctx context.Context) {
 	}
 }
 
+// GetShardLeaders should always retry until ctx done, except the collection is not loaded.
 func (lb *LBPolicyImpl) GetShardLeaders(ctx context.Context, dbName string, collName string, collectionID int64, withCache bool) (map[string][]nodeInfo, error) {
 	var shardLeaders map[string][]nodeInfo
 	// use retry to handle query coord service not ready
@@ -105,7 +106,7 @@ func (lb *LBPolicyImpl) GetShardLeaders(ctx context.Context, dbName string, coll
 		var err error
 		shardLeaders, err = globalMetaCache.GetShards(ctx, withCache, dbName, collName, collectionID)
 		if err != nil {
-			return true, err
+			return !errors.Is(err, merr.ErrCollectionLoaded), err
 		}
 
 		return false, nil

--- a/internal/proxy/shard_client.go
+++ b/internal/proxy/shard_client.go
@@ -47,6 +47,7 @@ func (n *shardClient) getClient(ctx context.Context) (types.QueryNodeClient, err
 		n.Lock()
 		if !n.initialized.Load() {
 			if err := n.initClients(); err != nil {
+				n.Unlock()
 				return nil, err
 			}
 			n.initialized.Store(true)

--- a/internal/proxy/shard_client.go
+++ b/internal/proxy/shard_client.go
@@ -127,6 +127,10 @@ func (n *shardClient) initClients() error {
 	for i := 0; i < num; i++ {
 		client, err := n.creator(context.Background(), n.info.address, n.info.nodeID)
 		if err != nil {
+			// roll back already created clients
+			for _, c := range clients[:i] {
+				c.Close()
+			}
 			return errors.Wrap(err, fmt.Sprintf("create client for node=%d failed", n.info.nodeID))
 		}
 		clients = append(clients, client)

--- a/internal/proxy/shard_client.go
+++ b/internal/proxy/shard_client.go
@@ -38,16 +38,18 @@ type shardClient struct {
 	poolSize int
 	pooling  bool
 
-	creator queryNodeCreatorFunc
+	initialized atomic.Bool
+	creator     queryNodeCreatorFunc
 }
 
 func (n *shardClient) getClient(ctx context.Context) (types.QueryNodeClient, error) {
-	if len(n.clients) == 0 {
+	if !n.initialized.Load() {
 		n.Lock()
-		if len(n.clients) == 0 {
+		if !n.initialized.Load() {
 			if err := n.initClients(); err != nil {
 				return nil, err
 			}
+			n.initialized.Store(true)
 		}
 		n.Unlock()
 	}

--- a/internal/proxy/shard_client.go
+++ b/internal/proxy/shard_client.go
@@ -31,26 +31,35 @@ var errClosed = errors.New("client is closed")
 type shardClient struct {
 	sync.RWMutex
 	info     nodeInfo
-	client   types.QueryNodeClient
 	isClosed bool
 	refCnt   int
 	clients  []types.QueryNodeClient
 	idx      atomic.Int64
 	poolSize int
 	pooling  bool
+
+	creator queryNodeCreatorFunc
 }
 
 func (n *shardClient) getClient(ctx context.Context) (types.QueryNodeClient, error) {
+	if len(n.clients) == 0 {
+		n.Lock()
+		if len(n.clients) == 0 {
+			if err := n.initClients(); err != nil {
+				return nil, err
+			}
+		}
+		n.Unlock()
+	}
+
 	n.RLock()
 	defer n.RUnlock()
 	if n.isClosed {
 		return nil, errClosed
 	}
-	if n.pooling {
-		idx := n.idx.Inc()
-		return n.clients[int(idx)%n.poolSize], nil
-	}
-	return n.client, nil
+
+	idx := n.idx.Inc()
+	return n.clients[int(idx)%n.poolSize], nil
 }
 
 func (n *shardClient) inc() {
@@ -65,12 +74,13 @@ func (n *shardClient) inc() {
 func (n *shardClient) close() {
 	n.isClosed = true
 	n.refCnt = 0
-	if n.client != nil {
-		if err := n.client.Close(); err != nil {
+
+	for _, client := range n.clients {
+		if err := client.Close(); err != nil {
 			log.Warn("close grpc client failed", zap.Error(err))
 		}
-		n.client = nil
 	}
+	n.clients = nil
 }
 
 func (n *shardClient) dec() bool {
@@ -94,41 +104,35 @@ func (n *shardClient) Close() {
 	n.close()
 }
 
-func newShardClient(info *nodeInfo, client types.QueryNodeClient) *shardClient {
-	ret := &shardClient{
+func newPoolingShardClient(info *nodeInfo, creator queryNodeCreatorFunc) (*shardClient, error) {
+	return &shardClient{
 		info: nodeInfo{
 			nodeID:  info.nodeID,
 			address: info.address,
 		},
-		client: client,
-		refCnt: 1,
-	}
-	return ret
+		refCnt:  1,
+		pooling: true,
+		creator: creator,
+	}, nil
 }
 
-func newPoolingShardClient(info *nodeInfo, creator queryNodeCreatorFunc) (*shardClient, error) {
+func (n *shardClient) initClients() error {
 	num := paramtable.Get().ProxyCfg.QueryNodePoolingSize.GetAsInt()
 	if num <= 0 {
 		num = 1
 	}
 	clients := make([]types.QueryNodeClient, 0, num)
 	for i := 0; i < num; i++ {
-		client, err := creator(context.Background(), info.address, info.nodeID)
+		client, err := n.creator(context.Background(), n.info.address, n.info.nodeID)
 		if err != nil {
-			return nil, err
+			return errors.Wrap(err, fmt.Sprintf("create client for node=%d failed", n.info.nodeID))
 		}
 		clients = append(clients, client)
 	}
-	return &shardClient{
-		info: nodeInfo{
-			nodeID:  info.nodeID,
-			address: info.address,
-		},
-		refCnt:   1,
-		pooling:  true,
-		clients:  clients,
-		poolSize: num,
-	}, nil
+
+	n.clients = clients
+	n.poolSize = num
+	return nil
 }
 
 type shardClientMgr interface {


### PR DESCRIPTION
issue: #37115

casue init query node client is too heavy, so we remove updateShardClient from leader mutex, which cause much more concurrent cornor cases.

This PR delay query node client's init operation until `getClient` is called, then use leader mutex to protect updating shard client progress to avoid concurrent issues.