### PR TITLE
fix: merge datanode bm25 error after reload growing segment with no data

### DIFF
--- a/internal/flushcommon/metacache/actions.go
+++ b/internal/flushcommon/metacache/actions.go
@@ -161,6 +161,9 @@ func RollStats(newStats ...*storage.PrimaryKeyStats) SegmentAction {
 
 func MergeBm25Stats(newStats map[int64]*storage.BM25Stats) SegmentAction {
 	return func(info *SegmentInfo) {
+		if info.bm25stats == nil {
+			info.bm25stats = NewEmptySegmentBM25Stats()
+		}
 		info.bm25stats.Merge(newStats)
 	}
 }

--- a/internal/flushcommon/syncmgr/storage_serializer.go
+++ b/internal/flushcommon/syncmgr/storage_serializer.go
@@ -131,7 +131,7 @@ func (s *storageV1Serializer) EncodeBuffer(ctx context.Context, pack *SyncPack) 
 			}
 			task.mergedStatsBlob = mergedStatsBlob
 
-			if len(pack.bm25Stats) > 0 {
+			if hasBM25Function(s.schema) {
 				mergedBM25Blob, err := s.serializeMergedBM25Stats(pack)
 				if err != nil {
 					log.Warn("failed to serialize merged bm25 stats log", zap.Error(err))
@@ -310,4 +310,13 @@ func (s *storageV1Serializer) serializeDeltalog(pack *SyncPack) (*storage.Blob, 
 	}
 	writer.Close()
 	return finalizer()
+}
+
+func hasBM25Function(schema *schemapb.CollectionSchema) bool {
+	for _, function := range schema.GetFunctions() {
+		if function.GetType() == schemapb.FunctionType_BM25 {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Segment with numrow 0 don't init bm25 stats, cause flush with bm25 stats failed.
relate: https://github.com/milvus-io/milvus/issues/37150