### PR TITLE
enhance: [2.4] Make skip load work for all branches

### DIFF
--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -409,6 +409,16 @@ func (sd *shardDelegator) LoadSegments(ctx context.Context, req *querypb.LoadSeg
 	log.Debug("worker loads segments...")
 
 	sLoad := func(ctx context.Context, req *querypb.LoadSegmentsRequest) error {
+		info := req.GetInfos()[0]
+		// put meta l0, instead of load actual delta data
+		if info.GetLevel() == datapb.SegmentLevel_L0 && sd.l0ForwardPolicy == L0ForwardPolicyRemoteLoad {
+			l0Seg, err := segments.NewL0Segment(sd.collection, segments.SegmentTypeSealed, req.GetVersion(), info)
+			if err != nil {
+				return err
+			}
+			sd.segmentManager.Put(ctx, segments.SegmentTypeSealed, l0Seg)
+			return nil
+		}
 		segmentID := req.GetInfos()[0].GetSegmentID()
 		nodeID := req.GetDstNodeID()
 		_, err, _ := sd.sf.Do(fmt.Sprintf("%d-%d", nodeID, segmentID), func() (struct{}, error) {
@@ -422,15 +432,6 @@ func (sd *shardDelegator) LoadSegments(ctx context.Context, req *querypb.LoadSeg
 	if len(req.GetInfos()) > 1 {
 		var reqs []*querypb.LoadSegmentsRequest
 		for _, info := range req.GetInfos() {
-			// put meta l0, instead of load actual delta data
-			if info.GetLevel() == datapb.SegmentLevel_L0 && sd.l0ForwardPolicy == L0ForwardPolicyRemoteLoad {
-				l0Seg, err := segments.NewL0Segment(sd.collection, segments.SegmentTypeSealed, req.GetVersion(), info)
-				if err != nil {
-					return err
-				}
-				sd.segmentManager.Put(ctx, segments.SegmentTypeSealed, l0Seg)
-				continue
-			}
 			newReq := typeutil.Clone(req)
 			newReq.Infos = []*querypb.SegmentLoadInfo{info}
 			reqs = append(reqs, newReq)


### PR DESCRIPTION
Cherry-pick from master
pr: #37160
Related to #37112

Skip load logic used to work only when there is multiple segment load info entires in load request. In continous delete case, delegator still loads l0 segment, which occupies lot of memory.