### PR TITLE
fix: set guarantee ts for seach/query iterator

### DIFF
--- a/internal/proxy/task_query.go
+++ b/internal/proxy/task_query.go
@@ -551,7 +551,7 @@ func (t *queryTask) PostExecute(ctx context.Context) error {
 
 	if t.queryParams.isIterator && t.request.GetGuaranteeTimestamp() == 0 {
 		// first page for iteration, need to set up sessionTs for iterator
-		t.result.SessionTs = t.BeginTs()
+		t.result.SessionTs = t.GetGuaranteeTimestamp()
 	}
 	log.Debug("Query PostExecute done")
 	return nil

--- a/internal/proxy/task_search.go
+++ b/internal/proxy/task_search.go
@@ -745,7 +745,7 @@ func (t *searchTask) PostExecute(ctx context.Context) error {
 	t.result.CollectionName = t.request.GetCollectionName()
 	if t.isIterator && t.request.GetGuaranteeTimestamp() == 0 {
 		// first page for iteration, need to set up sessionTs for iterator
-		t.result.SessionTs = t.BeginTs()
+		t.result.SessionTs = t.SearchRequest.GetGuaranteeTimestamp()
 	}
 
 	metrics.ProxyReduceResultLatency.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), metrics.SearchLabel).Observe(float64(tr.RecordSpan().Milliseconds()))


### PR DESCRIPTION
issue: #37158

Return the GuaranteeTS so that the subsequent requests following the correct TS.

BeginTS is the current timestamp when the task is created.
The GuaranteeTS is the one parsed based on both consistency level and beginTS, in PreExecute of the task on Proxy.
The delegator will wait until GuaranteeTS is met.
In PostExecute of the task on Proxy, the TS of the first iterator request will be returned to the SDK and add it to the subsequent requests.

![image](https://github.com/user-attachments/assets/c6582e46-cd83-4d7a-afa1-f1330165b92c)

Hence, if the default consistency level is Eventually or Bounded, the order of TS will be
> Guarantee TS < BeginTS

If it returns the BeginTS, the second request will need to catch up and result in extra 200ms max of latency, which results in something like

| Call | Latency |
| --- | --- |
| first call on `Next()` | 30ms |
| second call on `Next()` | 210ms |
| third call on `Next()` | 10ms |
| fourth call on `Next()` | 11 ms |
| ... | ... |

where we expect

| Call | Latency |
| --- | --- |
| first call on `Next()` | 30ms |
| second call on `Next()` | 10ms |
| third call on `Next()` | 10ms |
| fourth call on `Next()` | 11 ms |
| ... | ... |