### PR TITLE
fix: [2.5] Ref collection meta when load l0 segment meta only

### DIFF
--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -435,6 +435,7 @@ func (sd *shardDelegator) LoadSegments(ctx context.Context, req *querypb.LoadSeg
 			if err != nil {
 				return err
 			}
+			sd.collection.Ref(1)
 			sd.segmentManager.Put(ctx, segments.SegmentTypeSealed, l0Seg)
 			return nil
 		}


### PR DESCRIPTION
Cherry-pick from master
pr: #37178
Related to #37177

Previous PR #37160

Collection meta is not ref-ed when loading l0 segment in `RemoteLoad` policy, which cause collection meta release when lots of l0 segment released.