### PR TITLE
enhance: reserve vector space to reduce reallocate cost in Views() and StringViews()

### DIFF
--- a/internal/core/src/mmap/Column.h
+++ b/internal/core/src/mmap/Column.h
@@ -682,6 +682,7 @@ class SingleChunkVariableColumn : public SingleChunkColumnBase {
     std::pair<std::vector<std::string_view>, FixedVector<bool>>
     StringViews() const override {
         std::vector<std::string_view> res;
+        res.reserve(num_rows_);
         char* pos = data_;
         for (size_t i = 0; i < num_rows_; ++i) {
             uint32_t size;
@@ -696,6 +697,7 @@ class SingleChunkVariableColumn : public SingleChunkColumnBase {
     [[nodiscard]] std::vector<ViewType>
     Views() const {
         std::vector<ViewType> res;
+        res.reserve(num_rows_);
         char* pos = data_;
         for (size_t i = 0; i < num_rows_; ++i) {
             uint32_t size;


### PR DESCRIPTION
issue: #37152 