### PR TITLE
fix: Check resource when loading deltalogs

### DIFF
--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -1262,8 +1262,9 @@ func (loader *segmentLoader) loadDeltalogs(ctx context.Context, segment Segment,
 // it also executes resource protection logic in case of OOM.
 func (loader *segmentLoader) LoadDeltaLogs(ctx context.Context, segment Segment, deltaLogs []*datapb.FieldBinlog) error {
 	loadInfo := &querypb.SegmentLoadInfo{
-		SegmentID: segment.ID(),
-		Deltalogs: deltaLogs,
+		SegmentID:    segment.ID(),
+		CollectionID: segment.Collection(),
+		Deltalogs:    deltaLogs,
 	}
 	// Check memory & storage limit
 	requestResourceResult, err := loader.requestResource(ctx, loadInfo)


### PR DESCRIPTION
Related to #36887

`LoadDeltaLogs` API did not check memory usage. When system is under high delete load pressure, this could result into OOM quit.

This PR add resource check for `LoadDeltaLogs` actions and separate internal deltalog loading function with public one.