### PR TITLE
enhance: Return deltadata for `DeleteCodec.Deserialize`

### DIFF
--- a/internal/datanode/importv2/pool_test.go
+++ b/internal/datanode/importv2/pool_test.go
@@ -20,9 +20,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/milvus-io/milvus/pkg/config"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestResizePools(t *testing.T) {

--- a/internal/datanode/iterators/deltalog_iterator.go
+++ b/internal/datanode/iterators/deltalog_iterator.go
@@ -17,7 +17,7 @@ type DeltalogIterator struct {
 	disposedOnce sync.Once
 	disposed     atomic.Bool
 
-	data  *storage.DeleteData
+	data  *storage.DeltaData
 	blobs []*storage.Blob
 	label *Label
 	pos   int
@@ -50,8 +50,8 @@ func (d *DeltalogIterator) Next() (*LabeledRowData, error) {
 	}
 
 	row := &DeltalogRow{
-		Pk:        d.data.Pks[d.pos],
-		Timestamp: d.data.Tss[d.pos],
+		Pk:        d.data.DeletePks().Get(d.pos),
+		Timestamp: d.data.DeleteTimestamps()[d.pos],
 	}
 	d.pos++
 
@@ -76,7 +76,7 @@ func (d *DeltalogIterator) hasNext() bool {
 		d.data = dData
 		d.blobs = nil
 	}
-	return int64(d.pos) < d.data.RowCount
+	return int64(d.pos) < d.data.DeleteRowCount()
 }
 
 func (d *DeltalogIterator) isDisposed() bool {

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -1019,8 +1019,8 @@ func (s *LocalSegment) AddFieldDataInfo(ctx context.Context, rowCount int64, fie
 }
 
 func (s *LocalSegment) LoadDeltaData(ctx context.Context, deltaData *storage.DeltaData) error {
-	pks, tss := deltaData.DeletePks, deltaData.DeleteTimestamps
-	rowNum := deltaData.DelRowCount
+	pks, tss := deltaData.DeletePks(), deltaData.DeleteTimestamps()
+	rowNum := deltaData.DeleteRowCount()
 
 	if !s.ptrLock.RLockIf(state.IsNotReleased) {
 		return merr.WrapErrSegmentNotLoaded(s.ID(), "segment released")

--- a/internal/querynodev2/segments/segment_l0.go
+++ b/internal/querynodev2/segments/segment_l0.go
@@ -155,10 +155,10 @@ func (s *L0Segment) LoadDeltaData(ctx context.Context, deltaData *storage.DeltaD
 	s.dataGuard.Lock()
 	defer s.dataGuard.Unlock()
 
-	for i := 0; i < deltaData.DeletePks.Len(); i++ {
-		s.pks = append(s.pks, deltaData.DeletePks.Get(i))
+	for i := 0; i < int(deltaData.DeleteRowCount()); i++ {
+		s.pks = append(s.pks, deltaData.DeletePks().Get(i))
 	}
-	s.tss = append(s.tss, deltaData.DeleteTimestamps...)
+	s.tss = append(s.tss, deltaData.DeleteTimestamps()...)
 	return nil
 }
 

--- a/internal/storage/data_codec_test.go
+++ b/internal/storage/data_codec_test.go
@@ -574,9 +574,11 @@ func TestDeleteCodec(t *testing.T) {
 
 		pid, sid, data, err := deleteCodec.Deserialize([]*Blob{blob})
 		assert.NoError(t, err)
+		intPks, ok := data.DeletePks().(*Int64PrimaryKeys)
+		require.True(t, ok)
 		assert.Equal(t, pid, int64(1))
 		assert.Equal(t, sid, int64(1))
-		assert.Equal(t, data, deleteData)
+		assert.Equal(t, []int64{1, 2}, intPks.values)
 	})
 
 	t.Run("string pk", func(t *testing.T) {
@@ -591,9 +593,11 @@ func TestDeleteCodec(t *testing.T) {
 
 		pid, sid, data, err := deleteCodec.Deserialize([]*Blob{blob})
 		assert.NoError(t, err)
+		strPks, ok := data.DeletePks().(*VarcharPrimaryKeys)
+		require.True(t, ok)
 		assert.Equal(t, pid, int64(1))
 		assert.Equal(t, sid, int64(1))
-		assert.Equal(t, data, deleteData)
+		assert.Equal(t, []string{"test1", "test2"}, strPks.values)
 	})
 }
 
@@ -633,8 +637,10 @@ func TestUpgradeDeleteLog(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, int64(1), parID)
 		assert.Equal(t, int64(1), segID)
-		assert.ElementsMatch(t, dData.Pks, deleteData.Pks)
-		assert.ElementsMatch(t, dData.Tss, deleteData.Tss)
+		intPks, ok := deleteData.DeletePks().(*Int64PrimaryKeys)
+		require.True(t, ok)
+		assert.ElementsMatch(t, []int64{1, 2}, intPks.values)
+		assert.ElementsMatch(t, dData.Tss, deleteData.DeleteTimestamps())
 	})
 
 	t.Run("with split lenth error", func(t *testing.T) {

--- a/internal/storage/primary_keys.go
+++ b/internal/storage/primary_keys.go
@@ -38,7 +38,7 @@ type Int64PrimaryKeys struct {
 	values []int64
 }
 
-func NewInt64PrimaryKeys(cap int) *Int64PrimaryKeys {
+func NewInt64PrimaryKeys(cap int64) *Int64PrimaryKeys {
 	return &Int64PrimaryKeys{values: make([]int64, 0, cap)}
 }
 
@@ -97,7 +97,7 @@ type VarcharPrimaryKeys struct {
 	size   int64
 }
 
-func NewVarcharPrimaryKeys(cap int) *VarcharPrimaryKeys {
+func NewVarcharPrimaryKeys(cap int64) *VarcharPrimaryKeys {
 	return &VarcharPrimaryKeys{
 		values: make([]string, 0, cap),
 	}


### PR DESCRIPTION
Related to #35303 #30404

This PR change return type of `DeleteCodec.Deserialize` from `storage.DeleteData` to `DeltaData`, which
reduces the memory usage of interface header.

Also refine `storage.DeltaData` methods to make it easier to usage.