### PR TITLE
enhance: [2.5] Use middleware to observe restful v2 in/out rpc stats (#37223)

### DIFF
--- a/pkg/metrics/grpc_stats_handler.go
+++ b/pkg/metrics/grpc_stats_handler.go
@@ -25,12 +25,12 @@ import (
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
 
-// milvusGrpcKey is context key type.
-type milvusGrpcKey struct{}
+// milvusStatsKey is context key type.
+type milvusStatsKey struct{}
 
-// GrpcStats stores the meta and payload size info
+// RPCStats stores the meta and payload size info
 // it should be attached to context so that request sizing could be avoided
-type GrpcStats struct {
+type RPCStats struct {
 	fullMethodName     string
 	collectionName     string
 	inboundPayloadSize int
@@ -38,7 +38,7 @@ type GrpcStats struct {
 	nodeID             int64
 }
 
-func (s *GrpcStats) SetCollectionName(collName string) *GrpcStats {
+func (s *RPCStats) SetCollectionName(collName string) *RPCStats {
 	if s == nil {
 		return s
 	}
@@ -46,7 +46,7 @@ func (s *GrpcStats) SetCollectionName(collName string) *GrpcStats {
 	return s
 }
 
-func (s *GrpcStats) SetInboundLabel(label string) *GrpcStats {
+func (s *RPCStats) SetInboundLabel(label string) *RPCStats {
 	if s == nil {
 		return s
 	}
@@ -54,7 +54,7 @@ func (s *GrpcStats) SetInboundLabel(label string) *GrpcStats {
 	return s
 }
 
-func (s *GrpcStats) SetNodeID(nodeID int64) *GrpcStats {
+func (s *RPCStats) SetNodeID(nodeID int64) *RPCStats {
 	if s == nil {
 		return s
 	}
@@ -62,12 +62,12 @@ func (s *GrpcStats) SetNodeID(nodeID int64) *GrpcStats {
 	return s
 }
 
-func attachStats(ctx context.Context, stats *GrpcStats) context.Context {
-	return context.WithValue(ctx, milvusGrpcKey{}, stats)
+func attachStats(ctx context.Context, stats *RPCStats) context.Context {
+	return context.WithValue(ctx, milvusStatsKey{}, stats)
 }
 
-func GetStats(ctx context.Context) *GrpcStats {
-	stats, ok := ctx.Value(milvusGrpcKey{}).(*GrpcStats)
+func GetStats(ctx context.Context) *RPCStats {
+	stats, ok := ctx.Value(milvusStatsKey{}).(*RPCStats)
 	if !ok {
 		return nil
 	}
@@ -122,7 +122,7 @@ func (h *grpcSizeStatsHandler) TagRPC(ctx context.Context, info *stats.RPCTagInf
 		return ctx
 	}
 	// attach stats
-	return attachStats(ctx, &GrpcStats{fullMethodName: info.FullMethodName})
+	return attachStats(ctx, &RPCStats{fullMethodName: info.FullMethodName})
 }
 
 // HandleRPC implements per-RPC stats instrumentation.

--- a/pkg/metrics/restful_middleware.go
+++ b/pkg/metrics/restful_middleware.go
@@ -1,0 +1,45 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"context"
+	"strconv"
+)
+
+func WrapRestfulContext(ctx context.Context, inputLength int64) context.Context {
+	return context.WithValue(ctx, milvusStatsKey{}, &RPCStats{
+		inboundPayloadSize: int(inputLength),
+	})
+}
+
+func RecordRestfulMetrics(ctx context.Context, outputLength int64, observeOutbound bool) {
+	if mstats := GetStats(ctx); mstats != nil {
+		// all info set
+		// set metrics with inbound size and related meta
+		nodeIDValue := strconv.FormatInt(mstats.nodeID, 10)
+		if mstats.inboundPayloadSize > 0 {
+			ProxyReceiveBytes.WithLabelValues(
+				nodeIDValue,
+				mstats.inboundLabel, mstats.collectionName).Add(float64(mstats.inboundPayloadSize))
+		}
+		// set outbound payload size metrics
+		if outputLength > 0 && observeOutbound {
+			ProxyReadReqSendBytes.WithLabelValues(nodeIDValue).Add(float64(outputLength))
+		}
+	}
+}


### PR DESCRIPTION
Cherry pick from master
pr: #37223
Related to #36102

Previous PR #36107 add grpc inteceptor to observe rpc stats. Using same strategy, this pr add gin middleware to observer restful v2 rpc stats.