### PR TITLE
enhance: [2.4] Release compacted growing segment if in dropped list (#37245)

### DIFF
--- a/internal/querycoordv2/checkers/segment_checker_test.go
+++ b/internal/querycoordv2/checkers/segment_checker_test.go
@@ -690,14 +690,14 @@ func (suite *SegmentCheckerTestSuite) TestReleaseCompactedGrowingSegments() {
 	tasks := checker.Check(context.TODO())
 	suite.Len(tasks, 1)
 	sort.Slice(tasks, func(i, j int) bool {
-		return tasks[i].Actions()[0].(*task.SegmentAction).GetSegmentID() < tasks[j].Actions()[0].(*task.SegmentAction).GetSegmentID()
+		return tasks[i].Actions()[0].(*task.SegmentAction).SegmentID() < tasks[j].Actions()[0].(*task.SegmentAction).SegmentID()
 	})
 	suite.Len(tasks[0].Actions(), 1)
 	action, ok := tasks[0].Actions()[0].(*task.SegmentAction)
 	suite.True(ok)
 	suite.EqualValues(1, tasks[0].ReplicaID())
 	suite.Equal(task.ActionTypeReduce, action.Type())
-	suite.EqualValues(4, action.GetSegmentID())
+	suite.EqualValues(4, action.SegmentID())
 	suite.EqualValues(2, action.Node())
 	suite.Equal(tasks[0].Priority(), task.TaskPriorityNormal)
 }


### PR DESCRIPTION
Cherry-pick from master
pr: #37245
See also #37205

Previously releasing growing segments could be triggered by two conditions:

- Sealed Segment with same id is loaded
- Segment start position is before target checkpoint ts

Which has a worst case that the corresponding sealed segment is compacted and the checkpoint is pinned by a growing l0 segment.

This PR introduces a new rule that: a growing segment could be released if the segment id appeared in current target dropped segment id list.