### PR TITLE
fix: [2.4] Rectify `OffsetOrderedArray` contain logic

### DIFF
--- a/internal/core/src/segcore/InsertRecord.h
+++ b/internal/core/src/segcore/InsertRecord.h
@@ -186,7 +186,7 @@ class OffsetOrderedArray : public OffsetMap {
                              [](const std::pair<T, int64_t>& elem,
                                 const T& value) { return elem.first < value; });
 
-        return it != array_.end();
+        return it != array_.end() && it->first == target;
     }
 
     std::vector<int64_t>


### PR DESCRIPTION
Cherry pick from master
pr: #37305 
Related to #36887

Remove non-hit pk delete record logic does not work since `insert_record_.contain` does not work due to logic problem.