### PR TITLE
fix: proxy retry to get shard leader on unloaded collection

### DIFF
--- a/internal/proxy/lb_policy.go
+++ b/internal/proxy/lb_policy.go
@@ -98,6 +98,7 @@ func (lb *LBPolicyImpl) Start(ctx context.Context) {
 	}
 }
 
+// GetShardLeaders should always retry until ctx done, except the collection is not loaded.
 func (lb *LBPolicyImpl) GetShardLeaders(ctx context.Context, dbName string, collName string, collectionID int64, withCache bool) (map[string][]nodeInfo, error) {
 	var shardLeaders map[string][]nodeInfo
 	// use retry to handle query coord service not ready
@@ -105,7 +106,7 @@ func (lb *LBPolicyImpl) GetShardLeaders(ctx context.Context, dbName string, coll
 		var err error
 		shardLeaders, err = globalMetaCache.GetShards(ctx, withCache, dbName, collName, collectionID)
 		if err != nil {
-			return true, err
+			return !errors.Is(err, merr.ErrCollectionLoaded), err
 		}
 
 		return false, nil


### PR DESCRIPTION
issue: #37115

pr#37116 let proxy retry to get shard leader if error happens, which cause if search/query on a unloaded collection, which will keep retrying until ctx done.

This PR add error type check to skip retry on ErrCollectionLoaded.