### PR TITLE
enhance: [2.5]Use ts as msgID for request

### DIFF
--- a/internal/proxy/task_scheduler.go
+++ b/internal/proxy/task_scheduler.go
@@ -177,18 +177,14 @@ func (queue *baseTaskQueue) Enqueue(t task) error {
 	var id UniqueID
 	if t.CanSkipAllocTimestamp() {
 		ts = tsoutil.ComposeTS(time.Now().UnixMilli(), 0)
-		id, err = globalMetaCache.AllocID(t.TraceCtx())
-		if err != nil {
-			return err
-		}
 	} else {
 		ts, err = queue.tsoAllocatorIns.AllocOne(t.TraceCtx())
 		if err != nil {
 			return err
 		}
-		// we always use same msg id and ts for now.
-		id = UniqueID(ts)
 	}
+	// we always use same msg id and ts for now.
+	id = UniqueID(ts)
 	t.SetTs(ts)
 	t.SetID(id)
 

--- a/internal/proxy/task_scheduler_test.go
+++ b/internal/proxy/task_scheduler_test.go
@@ -625,7 +625,6 @@ func TestTaskScheduler_SkipAllocTimestamp(t *testing.T) {
 			collID:           collID,
 			consistencyLevel: commonpb.ConsistencyLevel_Eventually,
 		}, nil)
-	mockMetaCache.EXPECT().AllocID(mock.Anything).Return(1, nil).Twice()
 
 	t.Run("query", func(t *testing.T) {
 		qt := &queryTask{
@@ -657,22 +656,5 @@ func TestTaskScheduler_SkipAllocTimestamp(t *testing.T) {
 
 		err := queue.Enqueue(st)
 		assert.NoError(t, err)
-	})
-
-	mockMetaCache.EXPECT().AllocID(mock.Anything).Return(0, fmt.Errorf("mock error")).Once()
-	t.Run("failed", func(t *testing.T) {
-		st := &searchTask{
-			SearchRequest: &internalpb.SearchRequest{
-				Base: &commonpb.MsgBase{},
-			},
-			request: &milvuspb.SearchRequest{
-				DbName:                dbName,
-				CollectionName:        collName,
-				UseDefaultConsistency: true,
-			},
-		}
-
-		err := queue.Enqueue(st)
-		assert.Error(t, err)
 	})
 }


### PR DESCRIPTION
1. Only search/query requests with a consistency level other than strong will skip timestamp assignment.
2. MsgID holds little significance for search/query, so duplication is acceptable.

master pr: #37322 