### PR TITLE
fix: search/query failed due to segment not loaded

### DIFF
--- a/internal/querycoordv2/meta/leader_view_manager.go
+++ b/internal/querycoordv2/meta/leader_view_manager.go
@@ -109,6 +109,12 @@ func WithSegment2LeaderView(segmentID int64, isGrowing bool) LeaderViewFilter {
 	})
 }
 
+func WithServiceable() LeaderViewFilter {
+	return lvFilterFunc(func(view *LeaderView) bool {
+		return view.UnServiceableError == nil
+	})
+}
+
 type LeaderView struct {
 	ID                     int64
 	CollectionID           int64

--- a/internal/querycoordv2/task/executor.go
+++ b/internal/querycoordv2/task/executor.go
@@ -282,7 +282,7 @@ func (ex *Executor) releaseSegment(task *SegmentTask, step int) {
 				dstNode = action.Node()
 				req.NeedTransfer = false
 			} else {
-				view := ex.dist.LeaderViewManager.GetLatestShardLeaderByFilter(meta.WithReplica2LeaderView(replica), meta.WithChannelName2LeaderView(action.Shard))
+				view := ex.dist.LeaderViewManager.GetLatestShardLeaderByFilter(meta.WithReplica2LeaderView(replica), meta.WithChannelName2LeaderView(action.Shard), meta.WithServiceable())
 				if view == nil {
 					msg := "no shard leader for the segment to execute releasing"
 					err := merr.WrapErrChannelNotFound(task.Shard(), "shard delegator not found")


### PR DESCRIPTION
issue: #36970
cause release segment and balance channel may happen at same time, and before new delegator become serviceable, if release segment exeuctes on new delegator, and search/query comes on old delegator, then release segment and query segment happens in parallel, if release segment execute first in worker, then search/query will got a SegmentNodeLoaded error.

This PR add serviceable filter on delegator, then all load/release segment operation will happens on serviceable delegator.