### PR TITLE
enhance: alterindex & altercollection supports altering properties

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/klauspost/compress v1.17.9
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
-	github.com/milvus-io/milvus-proto/go-api/v2 v2.5.0-beta.0.20241202112430-822be0295910
+	github.com/milvus-io/milvus-proto/go-api/v2 v2.5.0-beta.0.20241204065646-180ce3a8d277
 	github.com/minio/minio-go/v7 v7.0.73
 	github.com/pingcap/log v1.1.1-0.20221015072633-39906604fb81
 	github.com/prometheus/client_golang v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -632,6 +632,8 @@ github.com/milvus-io/gorocksdb v0.0.0-20220624081344-8c5f4212846b h1:TfeY0NxYxZz
 github.com/milvus-io/gorocksdb v0.0.0-20220624081344-8c5f4212846b/go.mod h1:iwW+9cWfIzzDseEBCCeDSN5SD16Tidvy8cwQ7ZY8Qj4=
 github.com/milvus-io/milvus-proto/go-api/v2 v2.5.0-beta.0.20241202112430-822be0295910 h1:cFRrdFZwhFHv33pue1z8beYSvrXDYFSFsCuvXGX3DHE=
 github.com/milvus-io/milvus-proto/go-api/v2 v2.5.0-beta.0.20241202112430-822be0295910/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.5.0-beta.0.20241204065646-180ce3a8d277 h1:5/35+F32fs6ifVzI1e+VkUNpK0gWyXQSdZVnmNUFrrg=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.5.0-beta.0.20241204065646-180ce3a8d277/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
 github.com/milvus-io/pulsar-client-go v0.12.1 h1:O2JZp1tsYiO7C0MQ4hrUY/aJXnn2Gry6hpm7UodghmE=
 github.com/milvus-io/pulsar-client-go v0.12.1/go.mod h1:dkutuH4oS2pXiGm+Ti7fQZ4MRjrMPZ8IJeEGAWMeckk=
 github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8 h1:AMFGa4R4MiIpspGNG7Z948v4n35fFGB3RR3G/ry4FWs=

--- a/internal/datacoord/index_service_test.go
+++ b/internal/datacoord/index_service_test.go
@@ -637,6 +637,41 @@ func TestServer_AlterIndex(t *testing.T) {
 		req.Params[0].Value = "true"
 	})
 
+	t.Run("delete_params", func(t *testing.T) {
+		deleteReq := &indexpb.AlterIndexRequest{
+			CollectionID: collID,
+			IndexName:    indexName,
+			DeleteKeys:   []string{common.MmapEnabledKey},
+		}
+		resp, err := s.AlterIndex(ctx, deleteReq)
+		assert.NoError(t, merr.CheckRPCCall(resp, err))
+
+		describeResp, err := s.DescribeIndex(ctx, &indexpb.DescribeIndexRequest{
+			CollectionID: collID,
+			IndexName:    indexName,
+			Timestamp:    createTS,
+		})
+		assert.NoError(t, merr.CheckRPCCall(describeResp, err))
+		for _, param := range describeResp.IndexInfos[0].GetUserIndexParams() {
+			assert.NotEqual(t, common.MmapEnabledKey, param.GetKey())
+		}
+	})
+	t.Run("update_and_delete_params", func(t *testing.T) {
+		updateAndDeleteReq := &indexpb.AlterIndexRequest{
+			CollectionID: collID,
+			IndexName:    indexName,
+			Params: []*commonpb.KeyValuePair{
+				{
+					Key:   common.MmapEnabledKey,
+					Value: "true",
+				},
+			},
+			DeleteKeys: []string{common.MmapEnabledKey},
+		}
+		resp, err := s.AlterIndex(ctx, updateAndDeleteReq)
+		assert.ErrorIs(t, merr.CheckRPCCall(resp, err), merr.ErrParameterInvalid)
+	})
+
 	t.Run("success", func(t *testing.T) {
 		resp, err := s.AlterIndex(ctx, req)
 		assert.NoError(t, merr.CheckRPCCall(resp, err))

--- a/internal/datacoord/mock_test.go
+++ b/internal/datacoord/mock_test.go
@@ -450,6 +450,10 @@ func (m *mockRootCoordClient) AlterCollection(ctx context.Context, request *milv
 	panic("not implemented") // TODO: Implement
 }
 
+func (m *mockRootCoordClient) AlterCollectionField(ctx context.Context, request *milvuspb.AlterCollectionFieldRequest, opts ...grpc.CallOption) (*commonpb.Status, error) {
+	panic("not implemented") // TODO: Implement
+}
+
 func (m *mockRootCoordClient) CreatePartition(ctx context.Context, req *milvuspb.CreatePartitionRequest, opts ...grpc.CallOption) (*commonpb.Status, error) {
 	panic("not implemented") // TODO: Implement
 }

--- a/internal/distributed/proxy/service.go
+++ b/internal/distributed/proxy/service.go
@@ -696,6 +696,10 @@ func (s *Server) AlterCollection(ctx context.Context, request *milvuspb.AlterCol
 	return s.proxy.AlterCollection(ctx, request)
 }
 
+func (s *Server) AlterCollectionField(ctx context.Context, request *milvuspb.AlterCollectionFieldRequest) (*commonpb.Status, error) {
+	return s.proxy.AlterCollectionField(ctx, request)
+}
+
 // CreatePartition notifies Proxy to create a partition
 func (s *Server) CreatePartition(ctx context.Context, request *milvuspb.CreatePartitionRequest) (*commonpb.Status, error) {
 	return s.proxy.CreatePartition(ctx, request)

--- a/internal/distributed/rootcoord/client/client.go
+++ b/internal/distributed/rootcoord/client/client.go
@@ -240,6 +240,17 @@ func (c *Client) AlterCollection(ctx context.Context, request *milvuspb.AlterCol
 	})
 }
 
+func (c *Client) AlterCollectionField(ctx context.Context, request *milvuspb.AlterCollectionFieldRequest, opts ...grpc.CallOption) (*commonpb.Status, error) {
+	request = typeutil.Clone(request)
+	commonpbutil.UpdateMsgBase(
+		request.GetBase(),
+		commonpbutil.FillMsgBaseFromClient(paramtable.GetNodeID(), commonpbutil.WithTargetID(c.grpcClient.GetNodeID())),
+	)
+	return wrapGrpcCall(ctx, c, func(client rootcoordpb.RootCoordClient) (*commonpb.Status, error) {
+		return client.AlterCollectionField(ctx, request)
+	})
+}
+
 // CreatePartition create partition
 func (c *Client) CreatePartition(ctx context.Context, in *milvuspb.CreatePartitionRequest, opts ...grpc.CallOption) (*commonpb.Status, error) {
 	in = typeutil.Clone(in)

--- a/internal/distributed/rootcoord/service.go
+++ b/internal/distributed/rootcoord/service.go
@@ -530,6 +530,10 @@ func (s *Server) AlterCollection(ctx context.Context, request *milvuspb.AlterCol
 	return s.rootCoord.AlterCollection(ctx, request)
 }
 
+func (s *Server) AlterCollectionField(ctx context.Context, request *milvuspb.AlterCollectionFieldRequest) (*commonpb.Status, error) {
+	return s.rootCoord.AlterCollectionField(ctx, request)
+}
+
 func (s *Server) RenameCollection(ctx context.Context, request *milvuspb.RenameCollectionRequest) (*commonpb.Status, error) {
 	return s.rootCoord.RenameCollection(ctx, request)
 }

--- a/internal/mocks/mock_rootcoord.go
+++ b/internal/mocks/mock_rootcoord.go
@@ -272,6 +272,65 @@ func (_c *RootCoord_AlterCollection_Call) RunAndReturn(run func(context.Context,
 	return _c
 }
 
+// AlterCollectionField provides a mock function with given fields: _a0, _a1
+func (_m *RootCoord) AlterCollectionField(_a0 context.Context, _a1 *milvuspb.AlterCollectionFieldRequest) (*commonpb.Status, error) {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AlterCollectionField")
+	}
+
+	var r0 *commonpb.Status
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *milvuspb.AlterCollectionFieldRequest) (*commonpb.Status, error)); ok {
+		return rf(_a0, _a1)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *milvuspb.AlterCollectionFieldRequest) *commonpb.Status); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*commonpb.Status)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *milvuspb.AlterCollectionFieldRequest) error); ok {
+		r1 = rf(_a0, _a1)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// RootCoord_AlterCollectionField_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AlterCollectionField'
+type RootCoord_AlterCollectionField_Call struct {
+	*mock.Call
+}
+
+// AlterCollectionField is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *milvuspb.AlterCollectionFieldRequest
+func (_e *RootCoord_Expecter) AlterCollectionField(_a0 interface{}, _a1 interface{}) *RootCoord_AlterCollectionField_Call {
+	return &RootCoord_AlterCollectionField_Call{Call: _e.mock.On("AlterCollectionField", _a0, _a1)}
+}
+
+func (_c *RootCoord_AlterCollectionField_Call) Run(run func(_a0 context.Context, _a1 *milvuspb.AlterCollectionFieldRequest)) *RootCoord_AlterCollectionField_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*milvuspb.AlterCollectionFieldRequest))
+	})
+	return _c
+}
+
+func (_c *RootCoord_AlterCollectionField_Call) Return(_a0 *commonpb.Status, _a1 error) *RootCoord_AlterCollectionField_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *RootCoord_AlterCollectionField_Call) RunAndReturn(run func(context.Context, *milvuspb.AlterCollectionFieldRequest) (*commonpb.Status, error)) *RootCoord_AlterCollectionField_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // AlterDatabase provides a mock function with given fields: _a0, _a1
 func (_m *RootCoord) AlterDatabase(_a0 context.Context, _a1 *rootcoordpb.AlterDatabaseRequest) (*commonpb.Status, error) {
 	ret := _m.Called(_a0, _a1)

--- a/internal/mocks/mock_rootcoord_client.go
+++ b/internal/mocks/mock_rootcoord_client.go
@@ -329,6 +329,80 @@ func (_c *MockRootCoordClient_AlterCollection_Call) RunAndReturn(run func(contex
 	return _c
 }
 
+// AlterCollectionField provides a mock function with given fields: ctx, in, opts
+func (_m *MockRootCoordClient) AlterCollectionField(ctx context.Context, in *milvuspb.AlterCollectionFieldRequest, opts ...grpc.CallOption) (*commonpb.Status, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, in)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AlterCollectionField")
+	}
+
+	var r0 *commonpb.Status
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *milvuspb.AlterCollectionFieldRequest, ...grpc.CallOption) (*commonpb.Status, error)); ok {
+		return rf(ctx, in, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *milvuspb.AlterCollectionFieldRequest, ...grpc.CallOption) *commonpb.Status); ok {
+		r0 = rf(ctx, in, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*commonpb.Status)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *milvuspb.AlterCollectionFieldRequest, ...grpc.CallOption) error); ok {
+		r1 = rf(ctx, in, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockRootCoordClient_AlterCollectionField_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AlterCollectionField'
+type MockRootCoordClient_AlterCollectionField_Call struct {
+	*mock.Call
+}
+
+// AlterCollectionField is a helper method to define mock.On call
+//   - ctx context.Context
+//   - in *milvuspb.AlterCollectionFieldRequest
+//   - opts ...grpc.CallOption
+func (_e *MockRootCoordClient_Expecter) AlterCollectionField(ctx interface{}, in interface{}, opts ...interface{}) *MockRootCoordClient_AlterCollectionField_Call {
+	return &MockRootCoordClient_AlterCollectionField_Call{Call: _e.mock.On("AlterCollectionField",
+		append([]interface{}{ctx, in}, opts...)...)}
+}
+
+func (_c *MockRootCoordClient_AlterCollectionField_Call) Run(run func(ctx context.Context, in *milvuspb.AlterCollectionFieldRequest, opts ...grpc.CallOption)) *MockRootCoordClient_AlterCollectionField_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]grpc.CallOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(grpc.CallOption)
+			}
+		}
+		run(args[0].(context.Context), args[1].(*milvuspb.AlterCollectionFieldRequest), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockRootCoordClient_AlterCollectionField_Call) Return(_a0 *commonpb.Status, _a1 error) *MockRootCoordClient_AlterCollectionField_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockRootCoordClient_AlterCollectionField_Call) RunAndReturn(run func(context.Context, *milvuspb.AlterCollectionFieldRequest, ...grpc.CallOption) (*commonpb.Status, error)) *MockRootCoordClient_AlterCollectionField_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // AlterDatabase provides a mock function with given fields: ctx, in, opts
 func (_m *MockRootCoordClient) AlterDatabase(ctx context.Context, in *rootcoordpb.AlterDatabaseRequest, opts ...grpc.CallOption) (*commonpb.Status, error) {
 	_va := make([]interface{}, len(opts))

--- a/internal/proto/index_coord.proto
+++ b/internal/proto/index_coord.proto
@@ -138,6 +138,7 @@ message AlterIndexRequest {
     int64 collectionID = 1;
     string index_name = 2;
     repeated common.KeyValuePair params = 3;
+    repeated string delete_keys = 4;
 }
 
 message GetIndexInfoRequest {

--- a/internal/proto/root_coord.proto
+++ b/internal/proto/root_coord.proto
@@ -64,7 +64,8 @@ service RootCoord {
     rpc ShowCollections(milvus.ShowCollectionsRequest) returns (milvus.ShowCollectionsResponse) {}
 
     rpc AlterCollection(milvus.AlterCollectionRequest) returns (common.Status) {}
-
+    
+    rpc AlterCollectionField(milvus.AlterCollectionFieldRequest) returns (common.Status) {}
   /**
    * @brief This method is used to create partition
    *
@@ -245,4 +246,3 @@ message CollectionInfoOnPChannel {
 message PartitionInfoOnPChannel {
   int64 partition_id = 1;
 }
-

--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -142,7 +142,6 @@ func (node *Proxy) InvalidateCollectionMetaCache(ctx context.Context, request *p
 			log.Info("complete to invalidate collection meta cache with collection name", zap.String("type", request.GetBase().GetMsgType().String()))
 		case commonpb.MsgType_LoadCollection, commonpb.MsgType_ReleaseCollection:
 			// All the request from query use collectionID
-			// All the request from query use collectionID
 			if request.CollectionID != UniqueID(0) {
 				aliasName = globalMetaCache.RemoveCollectionsByID(ctx, collectionID, 0, false)
 				for _, name := range aliasName {
@@ -164,6 +163,12 @@ func (node *Proxy) InvalidateCollectionMetaCache(ctx context.Context, request *p
 		case commonpb.MsgType_DropDatabase:
 			globalMetaCache.RemoveDatabase(ctx, request.GetDbName())
 		case commonpb.MsgType_AlterCollection, commonpb.MsgType_AlterCollectionField:
+			if request.CollectionID != UniqueID(0) {
+				aliasName = globalMetaCache.RemoveCollectionsByID(ctx, collectionID, 0, false)
+				for _, name := range aliasName {
+					globalMetaCache.DeprecateShardCache(request.GetDbName(), name)
+				}
+			}
 			if collectionName != "" {
 				globalMetaCache.RemoveCollection(ctx, request.GetDbName(), collectionName)
 			}

--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -142,6 +142,7 @@ func (node *Proxy) InvalidateCollectionMetaCache(ctx context.Context, request *p
 			log.Info("complete to invalidate collection meta cache with collection name", zap.String("type", request.GetBase().GetMsgType().String()))
 		case commonpb.MsgType_LoadCollection, commonpb.MsgType_ReleaseCollection:
 			// All the request from query use collectionID
+			// All the request from query use collectionID
 			if request.CollectionID != UniqueID(0) {
 				aliasName = globalMetaCache.RemoveCollectionsByID(ctx, collectionID, 0, false)
 				for _, name := range aliasName {
@@ -162,6 +163,11 @@ func (node *Proxy) InvalidateCollectionMetaCache(ctx context.Context, request *p
 			log.Info("complete to invalidate collection meta cache", zap.String("type", request.GetBase().GetMsgType().String()))
 		case commonpb.MsgType_DropDatabase:
 			globalMetaCache.RemoveDatabase(ctx, request.GetDbName())
+		case commonpb.MsgType_AlterCollection:
+			if collectionName != "" {
+				globalMetaCache.RemoveCollection(ctx, request.GetDbName(), collectionName)
+			}
+			log.Info("complete to invalidate collection meta cache", zap.String("type", request.GetBase().GetMsgType().String()))
 		default:
 			log.Warn("receive unexpected msgType of invalidate collection meta cache", zap.String("msgType", request.GetBase().GetMsgType().String()))
 			if request.CollectionID != UniqueID(0) {

--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -1307,6 +1307,72 @@ func (node *Proxy) AlterCollection(ctx context.Context, request *milvuspb.AlterC
 	return act.result, nil
 }
 
+func (node *Proxy) AlterCollectionField(ctx context.Context, request *milvuspb.AlterCollectionFieldRequest) (*commonpb.Status, error) {
+	if err := merr.CheckHealthy(node.GetStateCode()); err != nil {
+		return merr.Status(err), nil
+	}
+
+	ctx, sp := otel.Tracer(typeutil.ProxyRole).Start(ctx, "Proxy-AlterCollectionField")
+	defer sp.End()
+	method := "AlterCollectionField"
+	tr := timerecord.NewTimeRecorder(method)
+
+	metrics.ProxyFunctionCall.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), method, metrics.TotalLabel, request.GetDbName(), request.GetCollectionName()).Inc()
+
+	act := &alterCollectionFieldTask{
+		ctx:                         ctx,
+		Condition:                   NewTaskCondition(ctx),
+		AlterCollectionFieldRequest: request,
+		rootCoord:                   node.rootCoord,
+		queryCoord:                  node.queryCoord,
+		dataCoord:                   node.dataCoord,
+	}
+
+	log := log.Ctx(ctx).With(
+		zap.String("role", typeutil.ProxyRole),
+		zap.String("db", request.DbName),
+		zap.String("collection", request.CollectionName),
+		zap.String("fieldName", request.FieldName),
+		zap.Any("props", request.Properties))
+
+	log.Info(rpcReceived(method))
+
+	if err := node.sched.ddQueue.Enqueue(act); err != nil {
+		log.Warn(
+			rpcFailedToEnqueue(method),
+			zap.Error(err))
+
+		metrics.ProxyFunctionCall.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), method, metrics.AbandonLabel, request.GetDbName(), request.GetCollectionName()).Inc()
+		return merr.Status(err), nil
+	}
+
+	log.Debug(
+		rpcEnqueued(method),
+		zap.Uint64("BeginTs", act.BeginTs()),
+		zap.Uint64("EndTs", act.EndTs()),
+		zap.Uint64("timestamp", request.Base.Timestamp))
+
+	if err := act.WaitToFinish(); err != nil {
+		log.Warn(
+			rpcFailedToWaitToFinish(method),
+			zap.Error(err),
+			zap.Uint64("BeginTs", act.BeginTs()),
+			zap.Uint64("EndTs", act.EndTs()))
+
+		metrics.ProxyFunctionCall.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), method, metrics.FailLabel, request.GetDbName(), request.GetCollectionName()).Inc()
+		return merr.Status(err), nil
+	}
+
+	log.Info(
+		rpcDone(method),
+		zap.Uint64("BeginTs", act.BeginTs()),
+		zap.Uint64("EndTs", act.EndTs()))
+
+	metrics.ProxyFunctionCall.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), method, metrics.SuccessLabel, request.GetDbName(), request.GetCollectionName()).Inc()
+	metrics.ProxyReqLatency.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), method).Observe(float64(tr.ElapseSpan().Milliseconds()))
+	return act.result, nil
+}
+
 // CreatePartition create a partition in specific collection.
 func (node *Proxy) CreatePartition(ctx context.Context, request *milvuspb.CreatePartitionRequest) (*commonpb.Status, error) {
 	if err := merr.CheckHealthy(node.GetStateCode()); err != nil {

--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -163,7 +163,7 @@ func (node *Proxy) InvalidateCollectionMetaCache(ctx context.Context, request *p
 			log.Info("complete to invalidate collection meta cache", zap.String("type", request.GetBase().GetMsgType().String()))
 		case commonpb.MsgType_DropDatabase:
 			globalMetaCache.RemoveDatabase(ctx, request.GetDbName())
-		case commonpb.MsgType_AlterCollection:
+		case commonpb.MsgType_AlterCollection, commonpb.MsgType_AlterCollectionField:
 			if collectionName != "" {
 				globalMetaCache.RemoveCollection(ctx, request.GetDbName(), collectionName)
 			}

--- a/internal/proxy/rootcoord_mock_test.go
+++ b/internal/proxy/rootcoord_mock_test.go
@@ -1095,6 +1095,10 @@ func (coord *RootCoordMock) AlterCollection(ctx context.Context, request *milvus
 	return &commonpb.Status{}, nil
 }
 
+func (coord *RootCoordMock) AlterCollectionField(ctx context.Context, request *milvuspb.AlterCollectionFieldRequest, opts ...grpc.CallOption) (*commonpb.Status, error) {
+	return &commonpb.Status{}, nil
+}
+
 func (coord *RootCoordMock) CreateDatabase(ctx context.Context, in *milvuspb.CreateDatabaseRequest, opts ...grpc.CallOption) (*commonpb.Status, error) {
 	return &commonpb.Status{}, nil
 }

--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -1140,7 +1140,7 @@ func (t *alterCollectionFieldTask) OnEnqueue() error {
 	if t.Base == nil {
 		t.Base = commonpbutil.NewMsgBase()
 	}
-	t.Base.MsgType = commonpb.MsgType_AlterCollection
+	t.Base.MsgType = commonpb.MsgType_AlterCollectionField
 	t.Base.SourceID = paramtable.GetNodeID()
 	return nil
 }
@@ -1152,17 +1152,17 @@ func (t *alterCollectionFieldTask) PreExecute(ctx context.Context) error {
 	}
 
 	IsStringType := false
-	indexName := ""
+	fieldName := ""
 	var dataType int32
 	for _, field := range collSchema.Fields {
-		if field.GetName() == t.FieldName && typeutil.IsStringType(field.DataType) {
+		if field.GetName() == t.FieldName && (typeutil.IsStringType(field.DataType) || typeutil.IsArrayContainStringElementType(field.DataType, field.ElementType)) {
 			IsStringType = true
-			indexName = field.GetName()
+			fieldName = field.GetName()
 			dataType = int32(field.DataType)
 		}
 	}
 	if !IsStringType {
-		return merr.WrapErrParameterInvalid(indexName, "%s can not modify the maxlength for non-string types", schemapb.DataType_name[dataType])
+		return merr.WrapErrParameterInvalid(fieldName, "%s can not modify the maxlength for non-string types", schemapb.DataType_name[dataType])
 	}
 
 	return nil

--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -1153,14 +1153,16 @@ func (t *alterCollectionFieldTask) PreExecute(ctx context.Context) error {
 
 	IsStringType := false
 	indexName := ""
+	var dataType int32
 	for _, field := range collSchema.Fields {
 		if field.GetName() == t.FieldName && typeutil.IsStringType(field.DataType) {
 			IsStringType = true
 			indexName = field.GetName()
+			dataType = int32(field.DataType)
 		}
 	}
 	if !IsStringType {
-		return merr.WrapErrParameterInvalid(indexName, "it can not modify the maxlength for non-string types")
+		return merr.WrapErrParameterInvalid(indexName, "%s can not modify the maxlength for non-string types", schemapb.DataType_name[dataType])
 	}
 
 	return nil

--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -89,7 +89,7 @@ const (
 	DescribeAliasTaskName         = "DescribeAliasTask"
 	ListAliasesTaskName           = "ListAliasesTask"
 	AlterCollectionTaskName       = "AlterCollectionTask"
-	AlterCollectionFieldTaskName  = "AlterColeectionFiledTask"
+	AlterCollectionFieldTaskName  = "AlterColeectionFieldTask"
 	UpsertTaskName                = "UpsertTask"
 	CreateResourceGroupTaskName   = "CreateResourceGroupTask"
 	UpdateResourceGroupsTaskName  = "UpdateResourceGroupsTask"

--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -89,7 +89,7 @@ const (
 	DescribeAliasTaskName         = "DescribeAliasTask"
 	ListAliasesTaskName           = "ListAliasesTask"
 	AlterCollectionTaskName       = "AlterCollectionTask"
-	AlterCollectionFieldTaskName  = "AlterColeectionFieldTask"
+	AlterCollectionFieldTaskName  = "AlterCollectionFieldTask"
 	UpsertTaskName                = "UpsertTask"
 	CreateResourceGroupTaskName   = "CreateResourceGroupTask"
 	UpdateResourceGroupsTaskName  = "UpdateResourceGroupsTask"

--- a/internal/proxy/task_index.go
+++ b/internal/proxy/task_index.go
@@ -612,9 +612,21 @@ func (t *alterIndexTask) OnEnqueue() error {
 }
 
 func (t *alterIndexTask) PreExecute(ctx context.Context) error {
-	for _, param := range t.req.GetExtraParams() {
-		if !indexparams.IsConfigableIndexParam(param.GetKey()) {
-			return merr.WrapErrParameterInvalidMsg("%s is not configable index param", param.GetKey())
+	if len(t.req.GetDeleteKeys()) > 0 && len(t.req.GetExtraParams()) > 0 {
+		return merr.WrapErrParameterInvalidMsg("cannot provide both DeleteKeys and ExtraParams")
+	}
+
+	if len(t.req.GetExtraParams()) > 0 {
+		for _, param := range t.req.GetExtraParams() {
+			if !indexparams.IsConfigableIndexParam(param.GetKey()) {
+				return merr.WrapErrParameterInvalidMsg("%s is not configable index param in extraParams", param.GetKey())
+			}
+		}
+	} else if len(t.req.GetDeleteKeys()) > 0 {
+		for _, param := range t.req.GetDeleteKeys() {
+			if !indexparams.IsConfigableIndexParam(param) {
+				return merr.WrapErrParameterInvalidMsg("%s is not configable index param in deleteKeys", param)
+			}
 		}
 	}
 
@@ -656,6 +668,7 @@ func (t *alterIndexTask) Execute(ctx context.Context) error {
 		zap.String("collection", t.req.GetCollectionName()),
 		zap.String("indexName", t.req.GetIndexName()),
 		zap.Any("params", t.req.GetExtraParams()),
+		zap.Any("deletekeys", t.req.GetDeleteKeys()),
 	)
 
 	log.Info("alter index")
@@ -665,6 +678,7 @@ func (t *alterIndexTask) Execute(ctx context.Context) error {
 		CollectionID: t.collectionID,
 		IndexName:    t.req.GetIndexName(),
 		Params:       t.req.GetExtraParams(),
+		DeleteKeys:   t.req.GetDeleteKeys(),
 	}
 	t.result, err = t.datacoord.AlterIndex(ctx, req)
 	if err = merr.CheckRPCCall(t.result, err); err != nil {

--- a/internal/rootcoord/alter_collection_task.go
+++ b/internal/rootcoord/alter_collection_task.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
+	"github.com/milvus-io/milvus/internal/metastore/model"
 	"github.com/milvus-io/milvus/internal/proto/querypb"
 	"github.com/milvus-io/milvus/internal/util/proxyutil"
 	"github.com/milvus-io/milvus/pkg/common"
@@ -48,8 +49,12 @@ func (a *alterCollectionTask) Prepare(ctx context.Context) error {
 
 func (a *alterCollectionTask) Execute(ctx context.Context) error {
 	// Now we only support alter properties of collection
-	if a.Req.GetProperties() == nil {
-		return errors.New("only support alter collection properties, but collection properties is empty")
+	if a.Req.GetProperties() == nil && a.Req.GetDeleteKeys() == nil {
+		return errors.New("only support alter collection properties, but collection properties or deletekeys is empty")
+	}
+
+	if len(a.Req.GetProperties()) > 0 && len(a.Req.GetDeleteKeys()) > 0 {
+		return errors.New("can not provide properties and deletekeys at the same time")
 	}
 
 	oldColl, err := a.core.meta.GetCollectionByName(ctx, a.Req.GetDbName(), a.Req.GetCollectionName(), a.ts)
@@ -59,13 +64,16 @@ func (a *alterCollectionTask) Execute(ctx context.Context) error {
 		return err
 	}
 
-	if ContainsKeyPairArray(a.Req.GetProperties(), oldColl.Properties) {
-		log.Info("skip to alter collection due to no changes were detected in the properties", zap.Int64("collectionID", oldColl.CollectionID))
-		return nil
-	}
-
 	newColl := oldColl.Clone()
-	newColl.Properties = MergeProperties(oldColl.Properties, a.Req.GetProperties())
+	if len(a.Req.Properties) > 0 {
+		if ContainsKeyPairArray(a.Req.GetProperties(), oldColl.Properties) {
+			log.Info("skip to alter collection due to no changes were detected in the properties", zap.Int64("collectionID", oldColl.CollectionID))
+			return nil
+		}
+		newColl.Properties = MergeProperties(oldColl.Properties, a.Req.GetProperties())
+	} else if len(a.Req.DeleteKeys) > 0 {
+		newColl.Properties = DeleteProperties(oldColl.Properties, a.Req.GetDeleteKeys())
+	}
 
 	ts := a.GetTs()
 	redoTask := newBaseRedoTask(a.core.stepExecutor)
@@ -132,4 +140,176 @@ func (a *alterCollectionTask) GetLockerKey() LockerKey {
 		NewDatabaseLockerKey(a.Req.GetDbName(), false),
 		NewCollectionLockerKey(collection, true),
 	)
+}
+
+func DeleteProperties(oldProps []*commonpb.KeyValuePair, deleteKeys []string) []*commonpb.KeyValuePair {
+	propsMap := make(map[string]string)
+	for _, prop := range oldProps {
+		propsMap[prop.Key] = prop.Value
+	}
+	for _, key := range deleteKeys {
+		delete(propsMap, key)
+	}
+	propKV := make([]*commonpb.KeyValuePair, 0, len(propsMap))
+	for key, value := range propsMap {
+		propKV = append(propKV, &commonpb.KeyValuePair{Key: key, Value: value})
+	}
+	log.Info("Alter Collection Drop Properties", zap.Any("newProperties", propKV))
+	return propKV
+}
+
+type alterCollectionFieldTask struct {
+	baseTask
+	Req *milvuspb.AlterCollectionFieldRequest
+}
+
+func (a *alterCollectionFieldTask) Prepare(ctx context.Context) error {
+	if a.Req.GetCollectionName() == "" {
+		return fmt.Errorf("alter collection field failed, collection name does not exists")
+	}
+
+	if a.Req.GetFieldName() == "" {
+		return fmt.Errorf("alter collection field failed, filed name does not exists")
+	}
+
+	err := IsValidateUpdatedFieldProps(a.Req.GetProperties())
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (a *alterCollectionFieldTask) Execute(ctx context.Context) error {
+	if a.Req.GetProperties() == nil {
+		return errors.New("only support alter collection properties, but collection field properties is empty")
+	}
+
+	oldColl, err := a.core.meta.GetCollectionByName(ctx, a.Req.GetDbName(), a.Req.GetCollectionName(), a.ts)
+	if err != nil {
+		log.Warn("get collection failed during changing collection state",
+			zap.String("collectionName", a.Req.GetCollectionName()),
+			zap.String("fieldName", a.Req.GetFieldName()),
+			zap.Uint64("ts", a.ts))
+		return err
+	}
+
+	newColl := oldColl.Clone()
+	err = UpdateFieldProperties(newColl, a.Req.GetFieldName(), a.Req.GetProperties())
+	if err != nil {
+		return err
+	}
+	ts := a.GetTs()
+	redoTask := newBaseRedoTask(a.core.stepExecutor)
+	redoTask.AddSyncStep(&AlterCollectionStep{
+		baseStep: baseStep{core: a.core},
+		oldColl:  oldColl,
+		newColl:  newColl,
+		ts:       ts,
+	})
+
+	redoTask.AddSyncStep(&BroadcastAlteredCollectionStep{
+		baseStep: baseStep{core: a.core},
+		req: &milvuspb.AlterCollectionRequest{
+			Base:           a.Req.Base,
+			DbName:         a.Req.DbName,
+			CollectionName: a.Req.CollectionName,
+			CollectionID:   oldColl.CollectionID,
+		},
+		core: a.core,
+	})
+
+	// properties needs to be refreshed in the cache
+	aliases := a.core.meta.ListAliasesByID(oldColl.CollectionID)
+	redoTask.AddSyncStep(&expireCacheStep{
+		baseStep:        baseStep{core: a.core},
+		dbName:          a.Req.GetDbName(),
+		collectionNames: append(aliases, a.Req.GetCollectionName()),
+		collectionID:    oldColl.CollectionID,
+		opts:            []proxyutil.ExpireCacheOpt{proxyutil.SetMsgType(commonpb.MsgType_AlterCollection)},
+	})
+
+	oldReplicaNumber, _ := common.DatabaseLevelReplicaNumber(oldColl.Properties)
+	oldResourceGroups, _ := common.DatabaseLevelResourceGroups(oldColl.Properties)
+	newReplicaNumber, _ := common.DatabaseLevelReplicaNumber(newColl.Properties)
+	newResourceGroups, _ := common.DatabaseLevelResourceGroups(newColl.Properties)
+	left, right := lo.Difference(oldResourceGroups, newResourceGroups)
+	rgChanged := len(left) > 0 || len(right) > 0
+	replicaChanged := oldReplicaNumber != newReplicaNumber
+	if rgChanged || replicaChanged {
+		log.Ctx(ctx).Warn("alter collection trigger update load config",
+			zap.Int64("collectionID", oldColl.CollectionID),
+			zap.Int64("oldReplicaNumber", oldReplicaNumber),
+			zap.Int64("newReplicaNumber", newReplicaNumber),
+			zap.Strings("oldResourceGroups", oldResourceGroups),
+			zap.Strings("newResourceGroups", newResourceGroups),
+		)
+		redoTask.AddAsyncStep(NewSimpleStep("", func(ctx context.Context) ([]nestedStep, error) {
+			resp, err := a.core.queryCoord.UpdateLoadConfig(ctx, &querypb.UpdateLoadConfigRequest{
+				CollectionIDs:  []int64{oldColl.CollectionID},
+				ReplicaNumber:  int32(newReplicaNumber),
+				ResourceGroups: newResourceGroups,
+			})
+			if err := merr.CheckRPCCall(resp, err); err != nil {
+				log.Warn("failed to trigger update load config for collection", zap.Int64("collectionID", newColl.CollectionID), zap.Error(err))
+				return nil, err
+			}
+			return nil, nil
+		}))
+	}
+
+	return redoTask.Execute(ctx)
+}
+
+var allowedProps = []string{
+	common.MaxLengthKey,
+}
+
+func IsKeyAllowed(key string) bool {
+	for _, allowedKey := range allowedProps {
+		if key == allowedKey {
+			return true
+		}
+	}
+	return false
+}
+
+func IsValidateUpdatedFieldProps(updatedProps []*commonpb.KeyValuePair) error {
+	for _, prop := range updatedProps {
+		if !IsKeyAllowed(prop.Key) {
+			return merr.WrapErrParameterInvalidMsg("%s does not allow update in collection field param", prop.Key)
+		}
+	}
+	return nil
+}
+
+func UpdateFieldProperties(coll *model.Collection, fieldName string, updatedProps []*commonpb.KeyValuePair) error {
+	for i, field := range coll.Fields {
+		if field.Name == fieldName {
+			coll.Fields[i].TypeParams = UpdateFieldPropertyParams(field.TypeParams, updatedProps)
+			return nil
+		}
+	}
+	return merr.WrapErrParameterInvalidMsg("%s does not exist in collection", fieldName)
+}
+
+func UpdateFieldPropertyParams(oldProps, updatedProps []*commonpb.KeyValuePair) []*commonpb.KeyValuePair {
+	props := make(map[string]string)
+	for _, prop := range oldProps {
+		props[prop.Key] = prop.Value
+	}
+	log.Info("UpdateFieldPropertyParams", zap.Any("oldprops", props), zap.Any("newprops", updatedProps))
+	for _, prop := range updatedProps {
+		props[prop.Key] = prop.Value
+	}
+	log.Info("UpdateFieldPropertyParams", zap.Any("newprops", props))
+	propKV := make([]*commonpb.KeyValuePair, 0)
+	for key, value := range props {
+		propKV = append(propKV, &commonpb.KeyValuePair{
+			Key:   key,
+			Value: value,
+		})
+	}
+
+	return propKV
 }

--- a/internal/rootcoord/alter_collection_task.go
+++ b/internal/rootcoord/alter_collection_task.go
@@ -218,6 +218,14 @@ func (a *alterCollectionFieldTask) Execute(ctx context.Context) error {
 		},
 		core: a.core,
 	})
+	collectionNames := []string{}
+	redoTask.AddSyncStep(&expireCacheStep{
+		baseStep:        baseStep{core: a.core},
+		dbName:          a.Req.GetDbName(),
+		collectionNames: append(collectionNames, a.Req.GetCollectionName()),
+		collectionID:    oldColl.CollectionID,
+		opts:            []proxyutil.ExpireCacheOpt{proxyutil.SetMsgType(commonpb.MsgType_AlterCollection)},
+	})
 
 	return redoTask.Execute(ctx)
 }

--- a/internal/rootcoord/alter_collection_task.go
+++ b/internal/rootcoord/alter_collection_task.go
@@ -224,7 +224,7 @@ func (a *alterCollectionFieldTask) Execute(ctx context.Context) error {
 		dbName:          a.Req.GetDbName(),
 		collectionNames: append(collectionNames, a.Req.GetCollectionName()),
 		collectionID:    oldColl.CollectionID,
-		opts:            []proxyutil.ExpireCacheOpt{proxyutil.SetMsgType(commonpb.MsgType_AlterCollection)},
+		opts:            []proxyutil.ExpireCacheOpt{proxyutil.SetMsgType(commonpb.MsgType_AlterCollectionField)},
 	})
 
 	return redoTask.Execute(ctx)
@@ -232,6 +232,7 @@ func (a *alterCollectionFieldTask) Execute(ctx context.Context) error {
 
 var allowedProps = []string{
 	common.MaxLengthKey,
+	common.MmapEnabledKey,
 }
 
 func IsKeyAllowed(key string) bool {

--- a/internal/rootcoord/alter_collection_task.go
+++ b/internal/rootcoord/alter_collection_task.go
@@ -50,7 +50,7 @@ func (a *alterCollectionTask) Prepare(ctx context.Context) error {
 func (a *alterCollectionTask) Execute(ctx context.Context) error {
 	// Now we only support alter properties of collection
 	if a.Req.GetProperties() == nil && a.Req.GetDeleteKeys() == nil {
-		return errors.New("only support alter collection properties, but collection properties or deletekeys is empty")
+		return errors.New("The collection properties to alter and keys to delete must not be empty at the same time")
 	}
 
 	if len(a.Req.GetProperties()) > 0 && len(a.Req.GetDeleteKeys()) > 0 {
@@ -259,7 +259,7 @@ func UpdateFieldProperties(coll *model.Collection, fieldName string, updatedProp
 			return nil
 		}
 	}
-	return merr.WrapErrParameterInvalidMsg("%s does not exist in collection", fieldName)
+	return merr.WrapErrParameterInvalidMsg("field %s does not exist in collection", fieldName)
 }
 
 func UpdateFieldPropertyParams(oldProps, updatedProps []*commonpb.KeyValuePair) []*commonpb.KeyValuePair {

--- a/internal/rootcoord/alter_collection_task_test.go
+++ b/internal/rootcoord/alter_collection_task_test.go
@@ -310,4 +310,42 @@ func Test_alterCollectionTask_Execute(t *testing.T) {
 			Value: "true",
 		})
 	})
+
+	t.Run("test delete collection props", func(t *testing.T) {
+		coll := &model.Collection{
+			Properties: []*commonpb.KeyValuePair{
+				{
+					Key:   common.CollectionTTLConfigKey,
+					Value: "1",
+				},
+				{
+					Key:   common.CollectionAutoCompactionKey,
+					Value: "true",
+				},
+			},
+		}
+
+		deleteKeys := []string{common.CollectionTTLConfigKey}
+		coll.Properties = DeleteProperties(coll.Properties, deleteKeys)
+		assert.NotContains(t, coll.Properties, &commonpb.KeyValuePair{
+			Key:   common.CollectionTTLConfigKey,
+			Value: "1",
+		})
+
+		assert.Contains(t, coll.Properties, &commonpb.KeyValuePair{
+			Key:   common.CollectionAutoCompactionKey,
+			Value: "true",
+		})
+
+		deleteKeys = []string{"nonexistent.key"}
+		coll.Properties = DeleteProperties(coll.Properties, deleteKeys)
+		assert.Contains(t, coll.Properties, &commonpb.KeyValuePair{
+			Key:   common.CollectionAutoCompactionKey,
+			Value: "true",
+		})
+
+		deleteKeys = []string{common.CollectionAutoCompactionKey}
+		coll.Properties = DeleteProperties(coll.Properties, deleteKeys)
+		assert.Empty(t, coll.Properties)
+	})
 }

--- a/internal/rootcoord/broker.go
+++ b/internal/rootcoord/broker.go
@@ -225,7 +225,11 @@ func (b *ServerBroker) GetSegmentIndexState(ctx context.Context, collID UniqueID
 }
 
 func (b *ServerBroker) BroadcastAlteredCollection(ctx context.Context, req *milvuspb.AlterCollectionRequest) error {
-	log.Info("broadcasting request to alter collection", zap.String("collectionName", req.GetCollectionName()), zap.Int64("collectionID", req.GetCollectionID()), zap.Any("props", req.GetProperties()))
+	log.Info("broadcasting request to alter collection",
+		zap.String("collectionName", req.GetCollectionName()),
+		zap.Int64("collectionID", req.GetCollectionID()),
+		zap.Any("props", req.GetProperties()),
+		zap.Any("deleteKeys", req.GetDeleteKeys()))
 
 	colMeta, err := b.s.meta.GetCollectionByID(ctx, req.GetDbName(), req.GetCollectionID(), typeutil.MaxTimestamp, false)
 	if err != nil {

--- a/internal/util/mock/grpc_rootcoord_client.go
+++ b/internal/util/mock/grpc_rootcoord_client.go
@@ -262,6 +262,10 @@ func (m *GrpcRootCoordClient) AlterCollection(ctx context.Context, in *milvuspb.
 	return &commonpb.Status{}, m.Err
 }
 
+func (m *GrpcRootCoordClient) AlterCollectionField(ctx context.Context, in *milvuspb.AlterCollectionFieldRequest, opts ...grpc.CallOption) (*commonpb.Status, error) {
+	return &commonpb.Status{}, m.Err
+}
+
 func (m *GrpcRootCoordClient) AlterDatabase(ctx context.Context, in *rootcoordpb.AlterDatabaseRequest, opts ...grpc.CallOption) (*commonpb.Status, error) {
 	return &commonpb.Status{}, m.Err
 }

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/json-iterator/go v1.1.12
 	github.com/klauspost/compress v1.17.7
-	github.com/milvus-io/milvus-proto/go-api/v2 v2.5.0-beta.0.20241202112430-822be0295910
+	github.com/milvus-io/milvus-proto/go-api/v2 v2.5.0-beta.0.20241204065646-180ce3a8d277
 	github.com/nats-io/nats-server/v2 v2.10.12
 	github.com/nats-io/nats.go v1.34.1
 	github.com/panjf2000/ants/v2 v2.7.2

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -488,8 +488,8 @@ github.com/milvus-io/cgosymbolizer v0.0.0-20240722103217-b7dee0e50119 h1:9VXijWu
 github.com/milvus-io/cgosymbolizer v0.0.0-20240722103217-b7dee0e50119/go.mod h1:DvXTE/K/RtHehxU8/GtDs4vFtfw64jJ3PaCnFri8CRg=
 github.com/milvus-io/gorocksdb v0.0.0-20220624081344-8c5f4212846b h1:TfeY0NxYxZzUfIfYe5qYDBzt4ZYRqzUjTR6CvUzjat8=
 github.com/milvus-io/gorocksdb v0.0.0-20220624081344-8c5f4212846b/go.mod h1:iwW+9cWfIzzDseEBCCeDSN5SD16Tidvy8cwQ7ZY8Qj4=
-github.com/milvus-io/milvus-proto/go-api/v2 v2.5.0-beta.0.20241202112430-822be0295910 h1:cFRrdFZwhFHv33pue1z8beYSvrXDYFSFsCuvXGX3DHE=
-github.com/milvus-io/milvus-proto/go-api/v2 v2.5.0-beta.0.20241202112430-822be0295910/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.5.0-beta.0.20241204065646-180ce3a8d277 h1:5/35+F32fs6ifVzI1e+VkUNpK0gWyXQSdZVnmNUFrrg=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.5.0-beta.0.20241204065646-180ce3a8d277/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
 github.com/milvus-io/pulsar-client-go v0.12.1 h1:O2JZp1tsYiO7C0MQ4hrUY/aJXnn2Gry6hpm7UodghmE=
 github.com/milvus-io/pulsar-client-go v0.12.1/go.mod h1:dkutuH4oS2pXiGm+Ti7fQZ4MRjrMPZ8IJeEGAWMeckk=
 github.com/minio/highwayhash v1.0.2 h1:Aak5U0nElisjDCfPSG79Tgzkn2gl66NxOMspRrKnA/g=

--- a/pkg/util/typeutil/schema.go
+++ b/pkg/util/typeutil/schema.go
@@ -560,6 +560,15 @@ func IsStringType(dataType schemapb.DataType) bool {
 	}
 }
 
+func IsArrayContainStringElementType(dataType schemapb.DataType, elementType schemapb.DataType) bool {
+	if IsArrayType(dataType) {
+		if elementType == schemapb.DataType_String || elementType == schemapb.DataType_VarChar {
+			return true
+		}
+	}
+	return false
+}
+
 func IsVariableDataType(dataType schemapb.DataType) bool {
 	return IsStringType(dataType) || IsArrayType(dataType) || IsJSONType(dataType)
 }


### PR DESCRIPTION
enhance : 

1. alterindex delete properties
We have introduced a new parameter deleteKeys to the alterindex functionality, which allows for the deletion of properties within an index. This enhancement provides users with the flexibility to manage index properties more effectively by removing specific keys as needed.
2. altercollection delete properties
We have introduced a new parameter deleteKeys to the altercollection functionality, which allows for the deletion of properties within an collection. This enhancement provides users with the flexibility to manage collection properties more effectively by removing specific keys as needed.

3.support altercollectionfield
We currently support modifying the fieldparams of a field in a collection using altercollectionfield, which only allows changes to the max-length attribute.
Key Points:
-  New Parameter - deleteKeys: This new parameter enables the deletion of specified properties from an index. By passing a list of keys to deleteKeys, users can remove the corresponding properties from the index.

- Mutual Exclusivity: The deleteKeys parameter cannot be used in conjunction with the extraParams parameter. Users must choose one parameter to pass based on their requirement. If deleteKeys is provided, it indicates an intent to delete properties; if extraParams is provided, it signifies the addition or update of properties.

issue: https://github.com/milvus-io/milvus/issues/37436