### PR TITLE
feat: Add an interface for aggregation functions

### DIFF
--- a/internal/core/src/query/PlanImpl.h
+++ b/internal/core/src/query/PlanImpl.h
@@ -103,6 +103,7 @@ struct RetrievePlan {
     std::unique_ptr<RetrievePlanNode> plan_node_;
     std::vector<FieldId> field_ids_;
     std::vector<std::string> target_dynamic_fields_;
+    std::unique_ptr<proto::plan::Aggr> aggr;
 };
 
 using PlanPtr = std::unique_ptr<Plan>;

--- a/internal/core/src/query/PlanProto.cpp
+++ b/internal/core/src/query/PlanProto.cpp
@@ -223,6 +223,10 @@ ProtoParser::CreateRetrievePlan(const proto::plan::PlanNode& plan_node_proto) {
         retrieve_plan->target_dynamic_fields_.push_back(dynamic_field);
     }
 
+    if (plan_node_proto.query().has_aggregation()) {
+        retrieve_plan->aggr = std::make_unique<proto::plan::Aggr>(plan_node_proto.query().aggregation());
+    }
+
     return retrieve_plan;
 }
 

--- a/internal/core/src/segcore/CMakeLists.txt
+++ b/internal/core/src/segcore/CMakeLists.txt
@@ -9,6 +9,9 @@
 # is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 # or implied. See the License for the specific language governing permissions and limitations under the License
 
+add_subdirectory(aggregation)
 
 add_source_at_current_directory_recursively()
 add_library(milvus_segcore OBJECT ${SOURCE_FILES})
+
+target_link_libraries(milvus_segcore milvus_segcore_aggregation)

--- a/internal/core/src/segcore/SegmentInterface.h
+++ b/internal/core/src/segcore/SegmentInterface.h
@@ -360,6 +360,11 @@ class SegmentInternalInterface : public SegmentInterface {
         bool ignore_non_pk,
         bool fill_ids) const;
 
+    void
+    DoAggregation(
+        const proto::plan::Aggr& aggr,
+        std::unique_ptr<proto::segcore::RetrieveResults>& results) const;
+
     // return whether field mmap or not
     virtual bool
     is_mmap_field(FieldId field_id) const = 0;

--- a/internal/core/src/segcore/aggregation/Aggregation.cpp
+++ b/internal/core/src/segcore/aggregation/Aggregation.cpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <segcore/aggregation/Aggregation.h>
+
+namespace milvus::segcore::aggregation {
+
+template <>
+google::protobuf::RepeatedField<int32_t>
+AggregationHelpers<int32_t>::GetDataFromScalars(const proto::schema::ScalarField& scalars) {
+    return scalars.int_data().data();
+}
+
+template <>
+google::protobuf::RepeatedField<int64_t>
+AggregationHelpers<int64_t>::GetDataFromScalars(const proto::schema::ScalarField& scalars) {
+    return scalars.long_data().data();
+}
+
+template <>
+google::protobuf::RepeatedField<float>
+AggregationHelpers<float>::GetDataFromScalars(const proto::schema::ScalarField& scalars) {
+    return scalars.float_data().data();
+}
+
+template <>
+google::protobuf::RepeatedField<double>
+AggregationHelpers<double>::GetDataFromScalars(const proto::schema::ScalarField& scalars) {
+    return scalars.double_data().data();
+}
+
+template <>
+google::protobuf::RepeatedPtrField<std::string>
+AggregationHelpers<std::string>::GetDataFromScalars(const proto::schema::ScalarField& scalars) {
+    return scalars.string_data().data();
+}
+
+} // namespace milvus::segcore::aggregation

--- a/internal/core/src/segcore/aggregation/Aggregation.h
+++ b/internal/core/src/segcore/aggregation/Aggregation.h
@@ -1,0 +1,61 @@
+
+#pragma once
+
+#include <google/protobuf/text_format.h>
+#include "pb/schema.pb.h"
+#include "pb/internal.pb.h"
+#include "log/Log.h"
+
+namespace milvus::segcore::aggregation {
+
+class Aggregator {
+  public:
+    virtual void
+    Aggregate(
+        google::protobuf::RepeatedPtrField<proto::schema::FieldData> fields,
+        proto::internal::AggrData* aggr_output) = 0;
+};
+
+
+class Aggregation {
+  public:
+    virtual std::shared_ptr<Aggregator>
+    GetAggregator(
+        std::vector<proto::schema::DataType>& input_types) = 0;
+
+    static std::shared_ptr<Aggregation>
+    GetAggregation(
+        const std::string& name);
+
+    // static RegisterAggregation
+
+    static int count_aggr() {
+        return _aggregations.size();
+    }
+    
+  private:
+    static std::map<std::string, std::shared_ptr<Aggregation>> _aggregations;
+    // static Aggregations _aggregations;
+};
+
+
+template <typename T>
+struct DataReturn {
+    typedef google::protobuf::RepeatedField<T> type;
+};
+
+template<>
+struct DataReturn<std::string> {
+    typedef google::protobuf::RepeatedPtrField<std::string> type;
+};
+
+template <typename T>
+class AggregationHelpers {
+  public:
+
+    // DataReturn<T>::type should have operator[] that returns T
+    static typename DataReturn<T>::type
+    GetDataFromScalars(const proto::schema::ScalarField& scalars);
+};
+
+} // namespace milvus::segcore::aggregation

--- a/internal/core/src/segcore/aggregation/CMakeLists.txt
+++ b/internal/core/src/segcore/aggregation/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_library(milvus_segcore_aggregation OBJECT
+    Aggregation.cpp
+    RegisterAggregations.cpp
+    MaxAggregation.cpp
+)

--- a/internal/core/src/segcore/aggregation/MaxAggregation.cpp
+++ b/internal/core/src/segcore/aggregation/MaxAggregation.cpp
@@ -1,0 +1,58 @@
+#include <segcore/aggregation/MaxAggregation.h>
+
+namespace milvus::segcore::aggregation {
+
+template <>
+void MaxAggregator<int32_t>::SetMaxIr(proto::internal::MaxIR* max_ir, const int32_t& max) {
+    max_ir->set_int_(static_cast<int64_t>(max));
+}
+
+template <>
+void MaxAggregator<int64_t>::SetMaxIr(proto::internal::MaxIR* max_ir, const int64_t& max) {
+    max_ir->set_int_(max);
+}
+
+template <>
+void MaxAggregator<float>::SetMaxIr(proto::internal::MaxIR* max_ir, const float& max) {
+    max_ir->set_float_(static_cast<double>(max));
+}
+
+template <>
+void MaxAggregator<double>::SetMaxIr(proto::internal::MaxIR* max_ir, const double& max) {
+    max_ir->set_float_(max);
+}
+
+template <>
+void MaxAggregator<std::string>::SetMaxIr(proto::internal::MaxIR* max_ir, const std::string& max) {
+    max_ir->set_str(max);
+}
+
+
+std::shared_ptr<Aggregator>
+MaxAggregation::GetAggregator(
+    std::vector<proto::schema::DataType>& input_types) {
+    
+    if (input_types.size() != 1) {
+        throw std::runtime_error("Max aggregation expects single argument");
+    }
+    switch (input_types[0]) {
+    case proto::schema::DataType::Int8:
+    case proto::schema::DataType::Int16:
+    case proto::schema::DataType::Int32:
+        return std::make_shared<MaxAggregator<int32_t>>();
+    case proto::schema::DataType::Int64:
+        return std::make_shared<MaxAggregator<int64_t>>();
+    case proto::schema::DataType::Float:
+        return std::make_shared<MaxAggregator<float>>();
+    case proto::schema::DataType::Double:
+        return std::make_shared<MaxAggregator<double>>();
+    case proto::schema::DataType::String:
+    case proto::schema::DataType::VarChar:
+        return std::make_shared<MaxAggregator<std::string>>();
+    }
+
+    // unsupported type
+    return nullptr;
+}
+
+} // namespace milvus::segcore::aggregation

--- a/internal/core/src/segcore/aggregation/MaxAggregation.h
+++ b/internal/core/src/segcore/aggregation/MaxAggregation.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <google/protobuf/text_format.h>
+#include <pb/schema.pb.h>
+#include <pb/internal.pb.h>
+#include <segcore/aggregation/Aggregation.h>
+
+namespace milvus::segcore::aggregation {
+
+template <typename T>
+class MaxAggregator : public Aggregator {
+  public:
+    void
+    Aggregate(
+        google::protobuf::RepeatedPtrField<proto::schema::FieldData> fields,
+        proto::internal::AggrData* aggr_output);
+
+  private:
+    void SetMaxIr(proto::internal::MaxIR* max_ir, const T& max);
+};
+
+template <typename T>
+void MaxAggregator<T>::Aggregate(
+    google::protobuf::RepeatedPtrField<proto::schema::FieldData> fields,
+    proto::internal::AggrData* aggr_output) {
+
+    const auto& scalars = fields[0].scalars();
+    // const auto& data = scalars.long_data().data();
+    const auto& data = AggregationHelpers<T>::GetDataFromScalars(scalars);
+
+    if (data.size() < 1) {
+        LOG_WARN("no data to aggregate");
+        return;
+    }
+    T max = data[0];
+    for (int i = 1; i < data.size(); i++) {
+        max = std::max(max, data[i]);
+    }
+
+    // const auto& max_ir = aggr_output->mutable_max_ir();
+    // max_ir->set_int_(max);
+    SetMaxIr(aggr_output->mutable_max_ir(), max);
+}
+
+class MaxAggregation : public Aggregation {
+  public:
+    std::shared_ptr<Aggregator>
+    GetAggregator(
+        std::vector<proto::schema::DataType>& input_types);
+};
+
+} // namespace milvus::segcore::aggregation

--- a/internal/core/src/segcore/aggregation/RegisterAggregations.cpp
+++ b/internal/core/src/segcore/aggregation/RegisterAggregations.cpp
@@ -1,0 +1,23 @@
+#include <segcore/aggregation/Aggregation.h>
+#include <segcore/aggregation/MaxAggregation.h>
+
+namespace milvus::segcore::aggregation {
+
+std::shared_ptr<Aggregation> Aggregation::GetAggregation(const std::string& name) {
+    auto iter = _aggregations.find(name);
+    if (iter == _aggregations.end()) {
+        return nullptr;
+    }
+    return iter->second;
+}
+
+static std::map<std::string, std::shared_ptr<Aggregation>> init_aggregations() {
+    return {
+        {"max", std::make_shared<MaxAggregation>()},
+    };
+}
+
+std::map<std::string, std::shared_ptr<Aggregation>>
+Aggregation::_aggregations = init_aggregations();
+
+} // namespace milvus::segcore::aggregation

--- a/internal/proto/internal.proto
+++ b/internal/proto/internal.proto
@@ -189,6 +189,35 @@ message RetrieveRequest {
 
 
 
+message MaxIR {
+  oneof max {
+    int64 int = 1;
+    double float = 2;
+    string str = 3;
+  }
+}
+
+message MinIR {
+  oneof max {
+    int64 int = 1;
+    double float = 2;
+    string str = 3;
+  }
+}
+
+message AvgIR {
+  double val = 1;
+  int64 weight = 2;
+}
+
+message AggrData {
+  oneof data {
+    MaxIR max_ir = 1;
+    MinIR min_ir = 2;
+    AvgIR avg_ir = 3;
+  }
+}
+
 message RetrieveResults {
   common.MsgBase base = 1;
   common.Status status = 2;
@@ -203,6 +232,9 @@ message RetrieveResults {
   CostAggregation costAggregation = 13;
   int64 all_retrieve_count = 14;
   bool has_more_result = 15;
+
+  // aggregations
+  AggrData aggr = 16;
 }
 
 message LoadIndex {

--- a/internal/proto/plan.proto
+++ b/internal/proto/plan.proto
@@ -200,10 +200,16 @@ message VectorANNS {
   string placeholder_tag = 5;  // always be "$0"
 }
 
+message Aggr {
+  string fn_name = 1;
+  repeated ColumnInfo arguments = 2;
+}
+
 message QueryPlanNode {
   Expr predicates = 1;
   bool is_count = 2;
   int64 limit = 3;
+  Aggr aggregation = 4;
 };
 
 message PlanNode {

--- a/internal/proto/segcore.proto
+++ b/internal/proto/segcore.proto
@@ -4,6 +4,7 @@ package milvus.proto.segcore;
 option go_package = "github.com/milvus-io/milvus/internal/proto/segcorepb";
 import "schema.proto";
 import "common.proto";
+import "internal.proto";
 
 message RetrieveResults {
   schema.IDs ids = 1;
@@ -11,6 +12,7 @@ message RetrieveResults {
   repeated schema.FieldData fields_data = 3;
   int64 all_retrieve_count = 4;
   bool has_more_result = 5;
+  internal.AggrData aggr = 6;
 }
 
 message LoadFieldMeta {

--- a/internal/proxy/aggr_reducer.go
+++ b/internal/proxy/aggr_reducer.go
@@ -1,0 +1,54 @@
+package proxy
+
+import (
+	"fmt"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/proto/internalpb"
+	"github.com/milvus-io/milvus/internal/proto/planpb"
+	"github.com/milvus-io/milvus/internal/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/util/merr"
+	"github.com/samber/lo"
+)
+
+type aggrReducer struct {
+	reducer funcutil.AggrReducer
+	collectionName string
+	outputFieldName string
+}
+
+func newAggrReducer(collectionName string, outputFieldName string, aggr *planpb.Aggr) (*aggrReducer, error) {
+	types := lo.Map(aggr.Arguments, func(col *planpb.ColumnInfo, _ int) schemapb.DataType {
+		return col.DataType
+	})
+	reducer, err := funcutil.NewAggrReducer(aggr.FnName, types)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't create aggregation reducer: %w", err)
+	}
+
+	return &aggrReducer{
+		reducer: reducer,
+		collectionName: collectionName,
+		outputFieldName: outputFieldName,
+	}, nil
+}
+
+func (r *aggrReducer) Reduce(results []*internalpb.RetrieveResults) (*milvuspb.QueryResults, error) {
+	// panic("not implemented")
+	inputs := lo.Map(results, func(result *internalpb.RetrieveResults, _ int) *internalpb.AggrData {
+		return result.GetAggr()
+	})
+
+	output, err := r.reducer.ReduceFinal(inputs)
+	if err != nil {
+		return nil, err
+	}
+	output.FieldName = r.outputFieldName
+
+	return &milvuspb.QueryResults{
+		Status: merr.Success(),
+		FieldsData: []*schemapb.FieldData{output},
+		CollectionName: r.collectionName,
+	}, nil
+}

--- a/internal/proxy/reducer.go
+++ b/internal/proxy/reducer.go
@@ -7,6 +7,9 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/proto/internalpb"
 	"github.com/milvus-io/milvus/internal/proto/planpb"
+	"github.com/milvus-io/milvus/pkg/util/typeutil"
+	"github.com/milvus-io/milvus/pkg/log"
+	"go.uber.org/zap"
 )
 
 type milvusReducer interface {
@@ -18,6 +21,43 @@ func createMilvusReducer(ctx context.Context, params *queryParams, req *internal
 		return &cntReducer{
 			collectionName: collectionName,
 		}
+	} else if plan.GetQuery().GetAggregation() != nil {
+		outputFieldName := GenOutputFieldNameForAggr(schema, plan.GetQuery().GetAggregation())
+		reducer, err := newAggrReducer(collectionName, outputFieldName, plan.GetQuery().GetAggregation())
+		if err != nil {
+			// TODO:ashkrisk surely there's a better way
+			log.Fatal("could not create aggr reducer", zap.Error(err))
+		}
+		return reducer
 	}
 	return newDefaultLimitReducer(ctx, params, req, schema, collectionName)
+}
+
+func GenOutputFieldNameForAggr(schema *schemapb.CollectionSchema, aggr *planpb.Aggr) string {
+	fallback := aggr.FnName + "(...)"
+	name := aggr.FnName + "("
+
+	if len(aggr.Arguments) > 0 {
+		helper, err := typeutil.CreateSchemaHelper(schema)
+		if err != nil {
+			log.Error("Couldn't create schemaHelper from schema")
+			return fallback
+		}
+
+		for i, arg := range aggr.Arguments {
+			field, err := helper.GetFieldFromID(arg.GetFieldId())
+			if err != nil {
+				log.Error("Unable to generate field name from ID")
+				return fallback
+			}
+
+			if i != 0 {
+				name += ","
+			}
+			name += field.GetName()
+		}
+	}
+
+	name += ")"
+	return name
 }

--- a/internal/querynodev2/segments/aggr_reducer.go
+++ b/internal/querynodev2/segments/aggr_reducer.go
@@ -1,0 +1,81 @@
+package segments
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/proto/internalpb"
+	"github.com/milvus-io/milvus/internal/proto/planpb"
+	"github.com/milvus-io/milvus/internal/proto/segcorepb"
+	"github.com/milvus-io/milvus/internal/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/util/merr"
+	"github.com/samber/lo"
+)
+
+type aggrReducerInternal struct {
+	reducer funcutil.AggrReducer
+}
+
+func newAggrReducerInternal(aggr *planpb.Aggr) (*aggrReducerInternal, error) {
+	types := lo.Map(aggr.Arguments, func(col *planpb.ColumnInfo, _ int) schemapb.DataType {
+		return col.DataType
+	})
+	reducer, err := funcutil.NewAggrReducer(aggr.FnName, types)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't create aggregation reducer: %w", err)
+	}
+
+	return &aggrReducerInternal {
+		reducer: reducer,
+	}, nil
+}
+
+func (r *aggrReducerInternal) Reduce(ctx context.Context, results []*internalpb.RetrieveResults) (*internalpb.RetrieveResults, error) {
+	inputs := lo.Map(results, func(result *internalpb.RetrieveResults, _ int) *internalpb.AggrData {
+		return result.Aggr
+	})
+	output, err := r.reducer.Reduce(inputs)
+	if err != nil {
+		return nil, err
+	}
+
+	return &internalpb.RetrieveResults{
+		Status: merr.Success(),
+		Aggr: output,
+	}, nil
+}
+
+type aggrReducerSegcore struct {
+	reducer funcutil.AggrReducer
+}
+
+func newAggrReducerSegcore(aggr *planpb.Aggr) (*aggrReducerSegcore, error) {
+	types := lo.Map(aggr.Arguments, func(col *planpb.ColumnInfo, _ int) schemapb.DataType {
+		return col.DataType
+	})
+	reducer, err := funcutil.NewAggrReducer(aggr.FnName, types)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't create aggregation reducer: %w", err)
+	}
+
+	return &aggrReducerSegcore{
+		reducer: reducer,
+	}, nil
+}
+
+func (r *aggrReducerSegcore) Reduce(ctx context.Context, results []*segcorepb.RetrieveResults, segments []Segment, plan *RetrievePlan) (*segcorepb.RetrieveResults, error) {
+	inputs := lo.Map(results, func(result *segcorepb.RetrieveResults, _ int) *internalpb.AggrData {
+		// TODO
+		return result.GetAggr()
+	})
+
+	output, err := r.reducer.Reduce(inputs)
+	if err != nil {
+		return nil, err
+	}
+
+	return &segcorepb.RetrieveResults{
+		Aggr: output,
+	}, nil
+}

--- a/internal/querynodev2/tasks/query_task.go
+++ b/internal/querynodev2/tasks/query_task.go
@@ -157,6 +157,7 @@ func (t *QueryTask) Execute() error {
 		},
 		AllRetrieveCount: reducedResult.GetAllRetrieveCount(),
 		HasMoreResult:    reducedResult.HasMoreResult,
+		Aggr: 			  reducedResult.Aggr,
 	}
 	return nil
 }

--- a/internal/util/funcutil/aggr_utils.go
+++ b/internal/util/funcutil/aggr_utils.go
@@ -1,0 +1,180 @@
+package funcutil
+
+import (
+	"fmt"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/proto/internalpb"
+	"github.com/samber/lo"
+)
+
+type AggrReducer interface {
+	Reduce(data []*internalpb.AggrData) (*internalpb.AggrData, error)
+	ReduceFinal(data []*internalpb.AggrData) (*schemapb.FieldData, error)
+}
+
+func NewAggrReducer(fnName string, inputTypes []schemapb.DataType) (AggrReducer, error) {
+	// TODO:ashkrisk can probably use a map here instead
+	switch fnName {
+	case "max":
+		return newMaxReducer(inputTypes)
+		// case "min":
+		// 	return newMinReducer(inputTypes)
+		// case "avg":
+		// 	return newAvgReducer(inputTypes)
+	}
+
+	return nil, fmt.Errorf("Unknown aggregation function '%s'", fnName)
+}
+
+func newMaxReducer(inputTypes []schemapb.DataType) (AggrReducer, error) {
+	if len(inputTypes) != 1 {
+		return nil, fmt.Errorf("max reducer expects single input, got %d", len(inputTypes))
+	}
+	switch inputTypes[0] {
+	case schemapb.DataType_Int8:
+		fallthrough
+	case schemapb.DataType_Int16:
+		fallthrough
+	case schemapb.DataType_Int32:
+		fallthrough
+	case schemapb.DataType_Int64:
+		return newMaxReducerInt(), nil
+	case schemapb.DataType_Float:
+		fallthrough
+	case schemapb.DataType_Double:
+		return newMaxReducerFloat(), nil
+	case schemapb.DataType_String:
+		fallthrough
+	case schemapb.DataType_VarChar:
+		return newMaxReducerString(), nil
+	}
+
+	return nil, fmt.Errorf("Unsupported type for maxReducer: %s", inputTypes[0].String())
+}
+
+type maxReducerInt struct{}
+
+type maxReducerFloat struct{}
+
+type maxReducerString struct{}
+
+func newMaxReducerInt() AggrReducer {
+	return maxReducerInt{}
+}
+
+func newMaxReducerFloat() AggrReducer {
+	return maxReducerFloat{}
+}
+
+func newMaxReducerString() AggrReducer {
+	return maxReducerString{}
+}
+
+func (r maxReducerInt) Reduce(data []*internalpb.AggrData) (*internalpb.AggrData, error) {
+	vals := lo.Map(data, func(d *internalpb.AggrData, _ int) int64 {
+		return d.GetMaxIr().GetInt()
+	})
+	max := lo.Max(vals)
+	return &internalpb.AggrData{
+		Data: &internalpb.AggrData_MaxIr{
+			MaxIr: &internalpb.MaxIR{
+				Max: &internalpb.MaxIR_Int{
+					Int: max,
+				},
+			},
+		},
+	}, nil
+}
+
+func (r maxReducerFloat) Reduce(data []*internalpb.AggrData) (*internalpb.AggrData, error) {
+	vals := lo.Map(data, func(d *internalpb.AggrData, _ int) float64 {
+		return d.GetMaxIr().GetFloat()
+	})
+	max := lo.Max(vals)
+	return &internalpb.AggrData{
+		Data: &internalpb.AggrData_MaxIr{
+			MaxIr: &internalpb.MaxIR{
+				Max: &internalpb.MaxIR_Float{
+					Float: max,
+				},
+			},
+		},
+	}, nil
+}
+
+func (r maxReducerString) Reduce(data []*internalpb.AggrData) (*internalpb.AggrData, error) {
+	vals := lo.Map(data, func(d *internalpb.AggrData, _ int) string {
+		return d.GetMaxIr().GetStr()
+	})
+	max := lo.Max(vals)
+	return &internalpb.AggrData{
+		Data: &internalpb.AggrData_MaxIr{
+			MaxIr: &internalpb.MaxIR{
+				Max: &internalpb.MaxIR_Str{
+					Str: max,
+				},
+			},
+		},
+	}, nil
+}
+
+func (r maxReducerInt) ReduceFinal(data []*internalpb.AggrData) (*schemapb.FieldData, error) {
+	ir, err := r.Reduce(data)
+	if err != nil {
+		return nil, err
+	}
+	max := ir.GetMaxIr().GetInt()
+	return &schemapb.FieldData{
+		Type: schemapb.DataType_Int64,
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_LongData{
+					LongData: &schemapb.LongArray{
+						Data: []int64{max},
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+func (r maxReducerFloat) ReduceFinal(data []*internalpb.AggrData) (*schemapb.FieldData, error) {
+	ir, err := r.Reduce(data)
+	if err != nil {
+		return nil, err
+	}
+	max := ir.GetMaxIr().GetFloat()
+	return &schemapb.FieldData{
+		Type: schemapb.DataType_Double,
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_DoubleData{
+					DoubleData: &schemapb.DoubleArray{
+						Data: []float64{max},
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+func (r maxReducerString) ReduceFinal(data []*internalpb.AggrData) (*schemapb.FieldData, error) {
+	ir, err := r.Reduce(data)
+	if err != nil {
+		return nil, err
+	}
+	max := ir.GetMaxIr().GetStr()
+	return &schemapb.FieldData{
+		Type: schemapb.DataType_VarChar,
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_StringData{
+					StringData: &schemapb.StringArray{
+						Data: []string{max},
+					},
+				},
+			},
+		},
+	}, nil
+}

--- a/scripts/generate_proto.sh
+++ b/scripts/generate_proto.sh
@@ -97,6 +97,7 @@ ${protoc_opt} --cpp_out=$CPP_SRC_DIR/src/pb clustering.proto|| { echo 'generate 
 ${protoc_opt} --cpp_out=$CPP_SRC_DIR/src/pb index_cgo_msg.proto|| { echo 'generate index_cgo_msg.proto failed'; exit 1; }
 ${protoc_opt} --cpp_out=$CPP_SRC_DIR/src/pb cgo_msg.proto|| { echo 'generate cgo_msg.proto failed'; exit 1; }
 ${protoc_opt} --cpp_out=$CPP_SRC_DIR/src/pb plan.proto|| { echo 'generate plan.proto failed'; exit 1; }
+${protoc_opt} --cpp_out=$CPP_SRC_DIR/src/pb internal.proto|| { echo 'generate internal.proto failed'; exit 1; }
 
 popd
 


### PR DESCRIPTION
Issue: #37441

Right now this is a rough draft and not ready to be merged, but I would appreciate any and all feedback. In particular I would love to feedback on:
- The overall approach
- The organisation of the code - are there better places for me to intercept the query execution flow and introduce aggregation logic?


In the current approach, there are three components to each aggregation function:
- Proto file changes, for storing intermediate representations of the aggregates
- Implement the C++ interface for aggregation function
- Implement the Golang interface for the aggregation function

As an example, the `max` function is implemented through the aggregation interface.

Test cases still need to be added.