### PR TITLE
fix: drop collection failed if enable streaming service

### DIFF
--- a/internal/datacoord/channel_manager.go
+++ b/internal/datacoord/channel_manager.go
@@ -88,8 +88,8 @@ type ChannelBGChecker func(ctx context.Context)
 // ChannelmanagerOpt is to set optional parameters in channel manager.
 type ChannelmanagerOpt func(c *ChannelManagerImpl)
 
-func withFactoryV2(f ChannelPolicyFactory) ChannelmanagerOpt {
-	return func(c *ChannelManagerImpl) { c.factory = f }
+func withEmptyPolicyFactory() ChannelmanagerOpt {
+	return func(c *ChannelManagerImpl) { c.factory = NewEmptyChannelPolicyFactory() }
 }
 
 func withCheckerV2() ChannelmanagerOpt {
@@ -161,7 +161,7 @@ func (m *ChannelManagerImpl) Startup(ctx context.Context, legacyNodes, allNodes 
 		m.finishRemoveChannel(info.NodeID, lo.Values(info.Channels)...)
 	}
 
-	if m.balanceCheckLoop != nil && !streamingutil.IsStreamingServiceEnabled() {
+	if m.balanceCheckLoop != nil {
 		log.Info("starting channel balance loop")
 		m.wg.Add(1)
 		go func() {
@@ -330,20 +330,19 @@ func (m *ChannelManagerImpl) Balance() {
 }
 
 func (m *ChannelManagerImpl) Match(nodeID UniqueID, channel string) bool {
-	if streamingutil.IsStreamingServiceEnabled() {
-		// Skip the channel matching check since the
-		// channel manager no longer manages channels in streaming mode.
-		return true
-	}
-
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
+	if streamingutil.IsStreamingServiceEnabled() {
+		// Skip the channel matching check since the
+		// channel manager no longer manages channels in streaming mode.
+		// Only check if the channel exists.
+		return m.store.HasChannel(channel)
+	}
 	info := m.store.GetNode(nodeID)
 	if info == nil {
 		return false
 	}
-
 	_, ok := info.Channels[channel]
 	return ok
 }
@@ -413,6 +412,7 @@ func (m *ChannelManagerImpl) FindWatcher(channel string) (UniqueID, error) {
 func (m *ChannelManagerImpl) removeChannel(nodeID int64, ch RWChannel) error {
 	op := NewChannelOpSet(NewChannelOp(nodeID, Delete, ch))
 	log.Info("remove channel assignment",
+		zap.Int64("nodeID", nodeID),
 		zap.String("channel", ch.GetName()),
 		zap.Int64("assignment", nodeID),
 		zap.Int64("collectionID", ch.GetCollectionID()))
@@ -448,7 +448,8 @@ func (m *ChannelManagerImpl) AdvanceChannelState(ctx context.Context) {
 	m.mu.RUnlock()
 
 	// Processing standby channels
-	updatedStandbys := m.advanceStandbys(ctx, standbys)
+	updatedStandbys := false
+	updatedStandbys = m.advanceStandbys(ctx, standbys)
 	updatedToCheckes := m.advanceToChecks(ctx, toChecks)
 	updatedToNotifies := m.advanceToNotifies(ctx, toNotifies)
 
@@ -485,8 +486,15 @@ func (m *ChannelManagerImpl) advanceStandbys(_ context.Context, standbys []*Node
 			}
 			validChannels[chName] = ch
 		}
-		nodeAssign.Channels = validChannels
+		// If streaming service is enabled, the channel manager no longer manages channels.
+		// So the standby channels shouldn't be processed by channel manager,
+		// but the remove channel operation should be executed.
+		// TODO: ChannelManager can be removed in future at 3.0.0.
+		if streamingutil.IsStreamingServiceEnabled() {
+			continue
+		}
 
+		nodeAssign.Channels = validChannels
 		if len(nodeAssign.Channels) == 0 {
 			continue
 		}
@@ -496,6 +504,7 @@ func (m *ChannelManagerImpl) advanceStandbys(_ context.Context, standbys []*Node
 			log.Warn("Reassign channels fail",
 				zap.Int64("nodeID", nodeAssign.NodeID),
 				zap.Strings("channels", chNames),
+				zap.Error(err),
 			)
 			continue
 		}

--- a/internal/datacoord/channel_manager_factory.go
+++ b/internal/datacoord/channel_manager_factory.go
@@ -39,3 +39,17 @@ func (f *ChannelPolicyFactoryV1) NewBalancePolicy() BalanceChannelPolicy {
 func (f *ChannelPolicyFactoryV1) NewAssignPolicy() AssignPolicy {
 	return AvgAssignByCountPolicy
 }
+
+func NewEmptyChannelPolicyFactory() *EmptyChannelPolicyFactory {
+	return &EmptyChannelPolicyFactory{}
+}
+
+type EmptyChannelPolicyFactory struct{}
+
+func (f *EmptyChannelPolicyFactory) NewBalancePolicy() BalanceChannelPolicy {
+	return EmptyBalancePolicy
+}
+
+func (f *EmptyChannelPolicyFactory) NewAssignPolicy() AssignPolicy {
+	return EmptyAssignPolicy
+}

--- a/internal/datacoord/channel_store.go
+++ b/internal/datacoord/channel_store.go
@@ -74,6 +74,8 @@ type RWChannelStore interface {
 	UpdateState(isSuccessful bool, channels ...RWChannel)
 	// SegLegacyChannelByNode is used by StateChannelStore only
 	SetLegacyChannelByNode(nodeIDs ...int64)
+
+	HasChannel(channel string) bool
 }
 
 // ChannelOpTypeNames implements zap log marshaller for ChannelOpSet.
@@ -545,10 +547,7 @@ func (c *StateChannelStore) updateMetaMemoryForSingleOp(op *ChannelOp) error {
 				storedChannel.setState(ToWatch)
 			}
 		case Delete: // Remove Channel
-			// if not Delete from bufferID, remove from channel
-			if op.NodeID != bufferID {
-				c.removeAssignment(op.NodeID, ch.GetName())
-			}
+			c.removeAssignment(op.NodeID, ch.GetName())
 		default:
 			log.Error("unknown opType in updateMetaMemoryForSingleOp", zap.Any("type", op.Type))
 		}

--- a/internal/datacoord/channel_store_test.go
+++ b/internal/datacoord/channel_store_test.go
@@ -37,7 +37,8 @@ func (s *StateChannelStoreSuite) SetupTest() {
 func generateWatchInfo(name string, state datapb.ChannelWatchState) *datapb.ChannelWatchInfo {
 	return &datapb.ChannelWatchInfo{
 		Vchan: &datapb.VchannelInfo{
-			ChannelName: name,
+			CollectionID: 1,
+			ChannelName:  name,
 		},
 		Schema: &schemapb.CollectionSchema{},
 		State:  state,

--- a/internal/datacoord/compaction_test.go
+++ b/internal/datacoord/compaction_test.go
@@ -57,7 +57,7 @@ func (s *CompactionPlanHandlerSuite) SetupTest() {
 	s.mockCm = NewMockChannelManager(s.T())
 	s.mockSessMgr = session.NewMockDataNodeManager(s.T())
 	s.cluster = NewMockCluster(s.T())
-	s.handler = newCompactionPlanHandler(s.cluster, s.mockSessMgr, s.mockCm, s.mockMeta, s.mockAlloc, nil, nil)
+	s.handler = newCompactionPlanHandler(s.cluster, s.mockSessMgr, s.mockMeta, s.mockAlloc, nil, nil)
 }
 
 func (s *CompactionPlanHandlerSuite) TestScheduleEmpty() {
@@ -449,54 +449,6 @@ func (s *CompactionPlanHandlerSuite) TestPickAnyNodeForClusteringTask() {
 	s.Equal(int64(NullNodeID), node)
 }
 
-func (s *CompactionPlanHandlerSuite) TestPickShardNode() {
-	s.SetupTest()
-	nodeSlots := map[int64]int64{
-		100: 2,
-		101: 6,
-	}
-
-	t1 := newMixCompactionTask(&datapb.CompactionTask{
-		PlanID:  19530,
-		Type:    datapb.CompactionType_MixCompaction,
-		Channel: "ch-01",
-		NodeID:  1,
-	}, nil, s.mockMeta, s.mockSessMgr)
-	t1.plan = &datapb.CompactionPlan{
-		PlanID:  19530,
-		Channel: "ch-01",
-		Type:    datapb.CompactionType_MixCompaction,
-	}
-
-	t2 := newMixCompactionTask(&datapb.CompactionTask{
-		PlanID:  19531,
-		Type:    datapb.CompactionType_MixCompaction,
-		Channel: "ch-02",
-		NodeID:  1,
-	}, nil, s.mockMeta, s.mockSessMgr)
-	t2.plan = &datapb.CompactionPlan{
-		PlanID:  19531,
-		Channel: "ch-02",
-		Type:    datapb.CompactionType_Level0DeleteCompaction,
-	}
-
-	s.mockCm.EXPECT().FindWatcher(mock.Anything).RunAndReturn(func(channel string) (int64, error) {
-		if channel == "ch-01" {
-			return 100, nil
-		}
-		if channel == "ch-02" {
-			return 101, nil
-		}
-		return 1, nil
-	}).Twice()
-
-	node := s.handler.pickShardNode(nodeSlots, t1)
-	s.Equal(int64(100), node)
-
-	node = s.handler.pickShardNode(nodeSlots, t2)
-	s.Equal(int64(101), node)
-}
-
 func (s *CompactionPlanHandlerSuite) TestRemoveTasksByChannel() {
 	s.SetupTest()
 	ch := "ch1"
@@ -604,7 +556,7 @@ func (s *CompactionPlanHandlerSuite) TestExecCompactionPlan() {
 	s.SetupTest()
 	s.mockMeta.EXPECT().CheckAndSetSegmentsCompacting(mock.Anything).Return(true, true).Maybe()
 	s.mockMeta.EXPECT().SaveCompactionTask(mock.Anything).Return(nil)
-	handler := newCompactionPlanHandler(nil, s.mockSessMgr, s.mockCm, s.mockMeta, s.mockAlloc, nil, nil)
+	handler := newCompactionPlanHandler(nil, s.mockSessMgr, s.mockMeta, s.mockAlloc, nil, nil)
 
 	task := &datapb.CompactionTask{
 		TriggerID: 1,

--- a/internal/datacoord/policy.go
+++ b/internal/datacoord/policy.go
@@ -145,6 +145,10 @@ func AvgBalanceChannelPolicy(cluster Assignments) *ChannelOpSet {
 // ExclusiveNodes means donot assign channels to these nodes.
 type AssignPolicy func(currentCluster Assignments, toAssign *NodeChannelInfo, exclusiveNodes []int64) *ChannelOpSet
 
+func EmptyAssignPolicy(currentCluster Assignments, toAssign *NodeChannelInfo, execlusiveNodes []int64) *ChannelOpSet {
+	return nil
+}
+
 func AvgAssignByCountPolicy(currentCluster Assignments, toAssign *NodeChannelInfo, execlusiveNodes []int64) *ChannelOpSet {
 	var (
 		toCluster   Assignments

--- a/internal/datacoord/server_test.go
+++ b/internal/datacoord/server_test.go
@@ -1680,7 +1680,7 @@ func TestGetCompactionState(t *testing.T) {
 				{State: datapb.CompactionTaskState_timeout},
 				{State: datapb.CompactionTaskState_timeout},
 			})
-		mockHandler := newCompactionPlanHandler(nil, nil, nil, mockMeta, nil, nil, nil)
+		mockHandler := newCompactionPlanHandler(nil, nil, mockMeta, nil, nil, nil)
 		svr.compactionHandler = mockHandler
 		resp, err := svr.GetCompactionState(context.Background(), &milvuspb.GetCompactionStateRequest{CompactionID: 1})
 		assert.NoError(t, err)

--- a/internal/datacoord/services_test.go
+++ b/internal/datacoord/services_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
+	"github.com/milvus-io/milvus/internal/datacoord/broker"
 	"github.com/milvus-io/milvus/internal/datacoord/session"
 	"github.com/milvus-io/milvus/internal/metastore/mocks"
 	"github.com/milvus-io/milvus/internal/metastore/model"
@@ -1525,11 +1526,9 @@ func TestGetChannelRecoveryInfo(t *testing.T) {
 	s.stateCode.Store(commonpb.StateCode_Healthy)
 
 	// get collection failed
-	handler := NewNMockHandler(t)
-	handler.EXPECT().GetCollection(mock.Anything, mock.Anything).
-		Return(nil, errors.New("mock err"))
-	s.handler = handler
-	assert.NoError(t, err)
+	broker := broker.NewMockBroker(t)
+	broker.EXPECT().DescribeCollectionInternal(mock.Anything, mock.Anything).Return(nil, errors.New("mock err"))
+	s.broker = broker
 	resp, err = s.GetChannelRecoveryInfo(ctx, &datapb.GetChannelRecoveryInfoRequest{
 		Vchannel: "ch-1",
 	})
@@ -1547,9 +1546,13 @@ func TestGetChannelRecoveryInfo(t *testing.T) {
 		IndexedSegmentIds:   []int64{4},
 	}
 
-	handler = NewNMockHandler(t)
-	handler.EXPECT().GetCollection(mock.Anything, mock.Anything).
-		Return(&collectionInfo{Schema: &schemapb.CollectionSchema{}}, nil)
+	broker.EXPECT().DescribeCollectionInternal(mock.Anything, mock.Anything).Unset()
+	broker.EXPECT().DescribeCollectionInternal(mock.Anything, mock.Anything).
+		Return(&milvuspb.DescribeCollectionResponse{
+			Status: &commonpb.Status{ErrorCode: commonpb.ErrorCode_Success},
+			Schema: &schemapb.CollectionSchema{},
+		}, nil)
+	handler := NewNMockHandler(t)
 	handler.EXPECT().GetDataVChanPositions(mock.Anything, mock.Anything).Return(channelInfo)
 	s.handler = handler
 

--- a/internal/flushcommon/pipeline/data_sync_service.go
+++ b/internal/flushcommon/pipeline/data_sync_service.go
@@ -77,6 +77,7 @@ type nodeConfig struct {
 	vChannelName string
 	metacache    metacache.MetaCache
 	serverID     typeutil.UniqueID
+	dropCallback func()
 }
 
 // Start the flow graph in dataSyncService
@@ -222,6 +223,7 @@ func getServiceWithChannel(initCtx context.Context, params *util.PipelineParams,
 	info *datapb.ChannelWatchInfo, metacache metacache.MetaCache,
 	unflushed, flushed []*datapb.SegmentInfo, input <-chan *msgstream.MsgPack,
 	wbTaskObserverCallback writebuffer.TaskObserverCallback,
+	dropCallback func(),
 ) (*DataSyncService, error) {
 	var (
 		channelName  = info.GetVchan().GetChannelName()
@@ -238,6 +240,7 @@ func getServiceWithChannel(initCtx context.Context, params *util.PipelineParams,
 		vChannelName: channelName,
 		metacache:    metacache,
 		serverID:     serverID,
+		dropCallback: dropCallback,
 	}
 
 	ctx, cancel := context.WithCancel(params.Ctx)
@@ -355,7 +358,7 @@ func NewDataSyncService(initCtx context.Context, pipelineParams *util.PipelinePa
 	if metaCache, err = getMetaCacheWithTickler(initCtx, pipelineParams, info, tickler, unflushedSegmentInfos, flushedSegmentInfos); err != nil {
 		return nil, err
 	}
-	return getServiceWithChannel(initCtx, pipelineParams, info, metaCache, unflushedSegmentInfos, flushedSegmentInfos, nil, nil)
+	return getServiceWithChannel(initCtx, pipelineParams, info, metaCache, unflushedSegmentInfos, flushedSegmentInfos, nil, nil, nil)
 }
 
 func NewStreamingNodeDataSyncService(
@@ -364,6 +367,7 @@ func NewStreamingNodeDataSyncService(
 	info *datapb.ChannelWatchInfo,
 	input <-chan *msgstream.MsgPack,
 	wbTaskObserverCallback writebuffer.TaskObserverCallback,
+	dropCallback func(),
 ) (*DataSyncService, error) {
 	// recover segment checkpoints
 	var (
@@ -389,7 +393,7 @@ func NewStreamingNodeDataSyncService(
 	if metaCache, err = getMetaCacheForStreaming(initCtx, pipelineParams, info, unflushedSegmentInfos, flushedSegmentInfos); err != nil {
 		return nil, err
 	}
-	return getServiceWithChannel(initCtx, pipelineParams, info, metaCache, unflushedSegmentInfos, flushedSegmentInfos, input, wbTaskObserverCallback)
+	return getServiceWithChannel(initCtx, pipelineParams, info, metaCache, unflushedSegmentInfos, flushedSegmentInfos, input, wbTaskObserverCallback, dropCallback)
 }
 
 func NewDataSyncServiceWithMetaCache(metaCache metacache.MetaCache) *DataSyncService {

--- a/internal/rootcoord/create_collection_task.go
+++ b/internal/rootcoord/create_collection_task.go
@@ -550,13 +550,6 @@ func (t *createCollectionTask) Execute(ctx context.Context) error {
 	vchanNames := t.channels.virtualChannels
 	chanNames := t.channels.physicalChannels
 
-	startPositions, err := t.addChannelsAndGetStartPositions(ctx, ts)
-	if err != nil {
-		// ugly here, since we must get start positions first.
-		t.core.chanTimeTick.removeDmlChannels(t.channels.physicalChannels...)
-		return err
-	}
-
 	partitions := make([]*model.Partition, len(partIDs))
 	for i, partID := range partIDs {
 		partitions[i] = &model.Partition{
@@ -580,7 +573,6 @@ func (t *createCollectionTask) Execute(ctx context.Context) error {
 		PhysicalChannelNames: chanNames,
 		ShardsNum:            t.Req.ShardsNum,
 		ConsistencyLevel:     t.Req.ConsistencyLevel,
-		StartPositions:       toKeyDataPairs(startPositions),
 		CreateTime:           ts,
 		State:                pb.CollectionState_CollectionCreating,
 		Partitions:           partitions,
@@ -603,6 +595,16 @@ func (t *createCollectionTask) Execute(ctx context.Context) error {
 		log.Warn("add duplicate collection", zap.String("collection", t.Req.GetCollectionName()), zap.Uint64("ts", ts))
 		return nil
 	}
+
+	// TODO: The create collection is not idempotent for other component, such as wal.
+	// we need to make the create collection operation must success after some persistent operation, refactor it in future.
+	startPositions, err := t.addChannelsAndGetStartPositions(ctx, ts)
+	if err != nil {
+		// ugly here, since we must get start positions first.
+		t.core.chanTimeTick.removeDmlChannels(t.channels.physicalChannels...)
+		return err
+	}
+	collInfo.StartPositions = toKeyDataPairs(startPositions)
 
 	undoTask := newBaseUndoTask(t.core.stepExecutor)
 	undoTask.AddStep(&expireCacheStep{

--- a/internal/rootcoord/root_coord.go
+++ b/internal/rootcoord/root_coord.go
@@ -462,13 +462,22 @@ func (c *Core) initInternal() error {
 	c.garbageCollector = newBgGarbageCollector(c)
 	c.stepExecutor = newBgStepExecutor(c.ctx)
 
-	c.proxyWatcher = proxyutil.NewProxyWatcher(
-		c.etcdCli,
-		c.chanTimeTick.initSessions,
-		c.proxyClientManager.AddProxyClients,
-	)
-	c.proxyWatcher.AddSessionFunc(c.chanTimeTick.addSession, c.proxyClientManager.AddProxyClient)
-	c.proxyWatcher.DelSessionFunc(c.chanTimeTick.delSession, c.proxyClientManager.DelProxyClient)
+	if !streamingutil.IsStreamingServiceEnabled() {
+		c.proxyWatcher = proxyutil.NewProxyWatcher(
+			c.etcdCli,
+			c.chanTimeTick.initSessions,
+			c.proxyClientManager.AddProxyClients,
+		)
+		c.proxyWatcher.AddSessionFunc(c.chanTimeTick.addSession, c.proxyClientManager.AddProxyClient)
+		c.proxyWatcher.DelSessionFunc(c.chanTimeTick.delSession, c.proxyClientManager.DelProxyClient)
+	} else {
+		c.proxyWatcher = proxyutil.NewProxyWatcher(
+			c.etcdCli,
+			c.proxyClientManager.AddProxyClients,
+		)
+		c.proxyWatcher.AddSessionFunc(c.proxyClientManager.AddProxyClient)
+		c.proxyWatcher.DelSessionFunc(c.proxyClientManager.DelProxyClient)
+	}
 	log.Info("init proxy manager done")
 
 	c.metricsCacheManager = metricsinfo.NewMetricsCacheManager()
@@ -730,11 +739,11 @@ func (c *Core) startInternal() error {
 }
 
 func (c *Core) startServerLoop() {
-	c.wg.Add(2)
-	go c.startTimeTickLoop()
+	c.wg.Add(1)
 	go c.tsLoop()
 	if !streamingutil.IsStreamingServiceEnabled() {
-		c.wg.Add(1)
+		c.wg.Add(2)
+		go c.startTimeTickLoop()
 		go c.chanTimeTick.startWatch(&c.wg)
 	}
 }

--- a/internal/rootcoord/timeticksync.go
+++ b/internal/rootcoord/timeticksync.go
@@ -163,7 +163,7 @@ func (t *timetickSync) sendToChannel() bool {
 		}
 	}
 
-	if len(idleSessionList) > 0 && !streamingutil.IsStreamingServiceEnabled() {
+	if len(idleSessionList) > 0 {
 		// give warning every 2 second if not get ttMsg from source sessions
 		if maxCnt%10 == 0 {
 			log.Warn("session idle for long time", zap.Any("idle list", idleSessionList),

--- a/internal/streamingnode/server/flusher/flusherimpl/channel_lifetime.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/channel_lifetime.go
@@ -129,7 +129,9 @@ func (c *channelLifetime) Run() error {
 					BinLogFileCounterIncr: uint64(len(insertLogs)),
 				})
 			}
-		})
+		},
+		func() { go func() { c.Cancel() }() },
+	)
 	if err != nil {
 		return err
 	}

--- a/internal/streamingnode/server/wal/adaptor/wal_test.go
+++ b/internal/streamingnode/server/wal/adaptor/wal_test.go
@@ -60,8 +60,8 @@ func initResourceForTest(t *testing.T) {
 	flusher := mock_flusher.NewMockFlusher(t)
 	flusher.EXPECT().RegisterPChannel(mock.Anything, mock.Anything).Return(nil).Maybe()
 	flusher.EXPECT().UnregisterPChannel(mock.Anything).Return().Maybe()
-	flusher.EXPECT().RegisterVChannel(mock.Anything, mock.Anything).Return()
-	flusher.EXPECT().UnregisterVChannel(mock.Anything).Return()
+	flusher.EXPECT().RegisterVChannel(mock.Anything, mock.Anything).Return().Maybe()
+	flusher.EXPECT().UnregisterVChannel(mock.Anything).Return().Maybe()
 
 	resource.InitForTest(
 		t,
@@ -194,6 +194,9 @@ func (f *testOneWALFramework) testSendCreateCollection(ctx context.Context, w wa
 }
 
 func (f *testOneWALFramework) testSendDropCollection(ctx context.Context, w wal.WAL) {
+	// Here, the drop colllection is conflict with the txn message, so we need to wait for a while.
+	// TODO: fix it in the redo interceptor.
+	time.Sleep(2 * time.Second)
 	// drop collection after test
 	dropMsg, err := message.NewDropCollectionMessageBuilderV1().
 		WithHeader(&message.DropCollectionMessageHeader{


### PR DESCRIPTION
issue: #36858

- Start channel manager on datacoord, but with empty assign policy in streaming service.
- Make collection at dropping state can be recovered by flusher to make sure that
 milvus consume the dropCollection message.
- Add backoff for flusher lifetime.
- remove the proxy watcher from timetick at rootcoord in streaming service.

Also see the better fixup: #37176