### PR TITLE
fix: QueryNode may stuck at graceful stopping progress

### DIFF
--- a/internal/querycoordv2/server.go
+++ b/internal/querycoordv2/server.go
@@ -481,9 +481,12 @@ func (s *Server) startQueryCoord() error {
 			s.nodeMgr.Stopping(node.ServerID)
 		}
 	}
+
 	s.checkNodeStateInRG()
 	for _, node := range sessions {
-		s.handleNodeUp(node.ServerID)
+		if !node.Stopping {
+			s.handleNodeUp(node.ServerID)
+		}
 	}
 
 	s.wg.Add(2)


### PR DESCRIPTION
issue: #37446
call `handleNodeUp` for a stopping node in querycoord's startup progress, which make the dirty node won't be removed from resource group, and the dirty node won't be marked as read only, all segment/channel on it won't be moved out, and query node stuck at graceful stopping progress.

This PR check the node's stopping state before call `handleNodeUp`