### PR TITLE
fix: QueryNode stuck at graceful stopping progress

### DIFF
--- a/internal/querycoordv2/server.go
+++ b/internal/querycoordv2/server.go
@@ -464,7 +464,9 @@ func (s *Server) startQueryCoord() error {
 
 	s.checkNodeStateInRG()
 	for _, node := range sessions {
-		s.handleNodeUp(node.ServerID)
+		if !node.Stopping {
+			s.handleNodeUp(node.ServerID)
+		}
 	}
 
 	s.wg.Add(2)


### PR DESCRIPTION
issue: #37446
pr: #37447
call `handleNodeUp` for a stopping node in querycoord's startup progress, which make the dirty node won't be removed from resource group, and the dirty node won't be marked as read only, all segment/channel on it won't be moved out, and query node stuck at graceful stopping progress.

This PR check the node's stopping state before call `handleNodeUp`