### PR TITLE
enhance: Add context trace for querycoord queryable check

### DIFF
--- a/internal/querycoordv2/services.go
+++ b/internal/querycoordv2/services.go
@@ -902,7 +902,7 @@ func (s *Server) GetShardLeaders(ctx context.Context, req *querypb.GetShardLeade
 		}, nil
 	}
 
-	leaders, err := utils.GetShardLeaders(s.meta, s.targetMgr, s.dist, s.nodeMgr, req.GetCollectionID())
+	leaders, err := utils.GetShardLeaders(ctx, s.meta, s.targetMgr, s.dist, s.nodeMgr, req.GetCollectionID())
 	return &querypb.GetShardLeadersResponse{
 		Status: merr.Status(err),
 		Shards: leaders,
@@ -919,7 +919,7 @@ func (s *Server) CheckHealth(ctx context.Context, req *milvuspb.CheckHealthReque
 		return componentutil.CheckHealthRespWithErrMsg(errReasons...), nil
 	}
 
-	if err := utils.CheckCollectionsQueryable(s.meta, s.targetMgr, s.dist, s.nodeMgr); err != nil {
+	if err := utils.CheckCollectionsQueryable(ctx, s.meta, s.targetMgr, s.dist, s.nodeMgr); err != nil {
 		return componentutil.CheckHealthRespWithErr(err), nil
 	}
 

--- a/internal/querycoordv2/utils/meta_test.go
+++ b/internal/querycoordv2/utils/meta_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/rgpb"
 	etcdKV "github.com/milvus-io/milvus/internal/kv/etcd"
@@ -39,7 +40,7 @@ import (
 func TestSpawnReplicasWithRG(t *testing.T) {
 	paramtable.Init()
 	config := GenerateEtcdConfig()
-	cli, _ := etcd.GetEtcdClient(
+	cli, err := etcd.GetEtcdClient(
 		config.UseEmbedEtcd.GetAsBool(),
 		config.EtcdUseSSL.GetAsBool(),
 		config.Endpoints.GetAsStrings(),
@@ -47,6 +48,7 @@ func TestSpawnReplicasWithRG(t *testing.T) {
 		config.EtcdTLSKey.GetValue(),
 		config.EtcdTLSCACert.GetValue(),
 		config.EtcdTLSMinVersion.GetValue())
+	require.NoError(t, err)
 	kv := etcdKV.NewEtcdKV(cli, config.MetaRootPath.GetValue())
 
 	store := querycoord.NewCatalog(kv)


### PR DESCRIPTION
When check health logic failed to collection not-queryable, the related reason is hard to find in log.

This PR add context for log with trace id and print unqueryable collection info log.