### PR TITLE
fix: Search may return less result after qn recover (#36549)

### DIFF
--- a/internal/querycoordv2/dist/dist_controller.go
+++ b/internal/querycoordv2/dist/dist_controller.go
@@ -36,13 +36,14 @@ type Controller interface {
 }
 
 type ControllerImpl struct {
-	mu          sync.RWMutex
-	handlers    map[int64]*distHandler
-	client      session.Cluster
-	nodeManager *session.NodeManager
-	dist        *meta.DistributionManager
-	targetMgr   *meta.TargetManager
-	scheduler   task.Scheduler
+	mu                  sync.RWMutex
+	handlers            map[int64]*distHandler
+	client              session.Cluster
+	nodeManager         *session.NodeManager
+	dist                *meta.DistributionManager
+	targetMgr           meta.TargetManagerInterface
+	scheduler           task.Scheduler
+	syncTargetVersionFn TriggerUpdateTargetVersion
 }
 
 func (dc *ControllerImpl) StartDistInstance(ctx context.Context, nodeID int64) {
@@ -52,7 +53,7 @@ func (dc *ControllerImpl) StartDistInstance(ctx context.Context, nodeID int64) {
 		log.Info("node has started", zap.Int64("nodeID", nodeID))
 		return
 	}
-	h := newDistHandler(ctx, nodeID, dc.client, dc.nodeManager, dc.scheduler, dc.dist, dc.targetMgr)
+	h := newDistHandler(ctx, nodeID, dc.client, dc.nodeManager, dc.scheduler, dc.dist, dc.targetMgr, dc.syncTargetVersionFn)
 	dc.handlers[nodeID] = h
 }
 
@@ -100,13 +101,15 @@ func NewDistController(
 	dist *meta.DistributionManager,
 	targetMgr *meta.TargetManager,
 	scheduler task.Scheduler,
+	syncTargetVersionFn TriggerUpdateTargetVersion,
 ) *ControllerImpl {
 	return &ControllerImpl{
-		handlers:    make(map[int64]*distHandler),
-		client:      client,
-		nodeManager: nodeManager,
-		dist:        dist,
-		targetMgr:   targetMgr,
-		scheduler:   scheduler,
+		handlers:            make(map[int64]*distHandler),
+		client:              client,
+		nodeManager:         nodeManager,
+		dist:                dist,
+		targetMgr:           targetMgr,
+		scheduler:           scheduler,
+		syncTargetVersionFn: syncTargetVersionFn,
 	}
 }

--- a/internal/querycoordv2/dist/dist_controller_test.go
+++ b/internal/querycoordv2/dist/dist_controller_test.go
@@ -81,7 +81,8 @@ func (suite *DistControllerTestSuite) SetupTest() {
 	targetManager := meta.NewTargetManager(suite.broker, suite.meta)
 	suite.mockScheduler = task.NewMockScheduler(suite.T())
 	suite.mockScheduler.EXPECT().GetExecutedFlag(mock.Anything).Return(nil).Maybe()
-	suite.controller = NewDistController(suite.mockCluster, suite.nodeMgr, distManager, targetManager, suite.mockScheduler)
+	syncTargetVersionFn := func(collectionID int64) {}
+	suite.controller = NewDistController(suite.mockCluster, suite.nodeMgr, distManager, targetManager, suite.mockScheduler, syncTargetVersionFn)
 }
 
 func (suite *DistControllerTestSuite) TearDownSuite() {

--- a/internal/querycoordv2/dist/dist_handler_test.go
+++ b/internal/querycoordv2/dist/dist_handler_test.go
@@ -66,6 +66,7 @@ func (suite *DistHandlerSuite) SetupSuite() {
 	suite.scheduler.EXPECT().GetExecutedFlag(mock.Anything).Return(nil).Maybe()
 	suite.target.EXPECT().GetSealedSegment(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 	suite.target.EXPECT().GetDmChannel(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	suite.target.EXPECT().GetCollectionTargetVersion(mock.Anything, mock.Anything).Return(1011).Maybe()
 }
 
 func (suite *DistHandlerSuite) TestBasic() {
@@ -97,14 +98,16 @@ func (suite *DistHandlerSuite) TestBasic() {
 
 		LeaderViews: []*querypb.LeaderView{
 			{
-				Collection: 1,
-				Channel:    "test-channel-1",
+				Collection:    1,
+				Channel:       "test-channel-1",
+				TargetVersion: 1011,
 			},
 		},
 		LastModifyTs: 1,
 	}, nil)
 
-	suite.handler = newDistHandler(suite.ctx, suite.nodeID, suite.client, suite.nodeManager, suite.scheduler, suite.dist, suite.target)
+	syncTargetVersionFn := func(collectionID int64) {}
+	suite.handler = newDistHandler(suite.ctx, suite.nodeID, suite.client, suite.nodeManager, suite.scheduler, suite.dist, suite.target, syncTargetVersionFn)
 	defer suite.handler.stop()
 
 	time.Sleep(10 * time.Second)
@@ -119,7 +122,8 @@ func (suite *DistHandlerSuite) TestGetDistributionFailed() {
 	}))
 	suite.client.EXPECT().GetDataDistribution(mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("fake error"))
 
-	suite.handler = newDistHandler(suite.ctx, suite.nodeID, suite.client, suite.nodeManager, suite.scheduler, suite.dist, suite.target)
+	syncTargetVersionFn := func(collectionID int64) {}
+	suite.handler = newDistHandler(suite.ctx, suite.nodeID, suite.client, suite.nodeManager, suite.scheduler, suite.dist, suite.target, syncTargetVersionFn)
 	defer suite.handler.stop()
 
 	time.Sleep(10 * time.Second)

--- a/internal/querycoordv2/job/job_test.go
+++ b/internal/querycoordv2/job/job_test.go
@@ -171,6 +171,7 @@ func (suite *JobSuite) SetupTest() {
 		suite.dist,
 		suite.broker,
 		suite.cluster,
+		suite.nodeMgr,
 	)
 	suite.targetObserver.Start()
 	suite.scheduler = NewScheduler()

--- a/internal/querycoordv2/meta/leader_view_manager.go
+++ b/internal/querycoordv2/meta/leader_view_manager.go
@@ -149,6 +149,7 @@ func (view *LeaderView) Clone() *LeaderView {
 		TargetVersion:          view.TargetVersion,
 		NumOfGrowingRows:       view.NumOfGrowingRows,
 		PartitionStatsVersions: view.PartitionStatsVersions,
+		UnServiceableError:     view.UnServiceableError,
 	}
 }
 

--- a/internal/querycoordv2/ops_service_test.go
+++ b/internal/querycoordv2/ops_service_test.go
@@ -109,6 +109,7 @@ func (suite *OpsServiceSuite) SetupTest() {
 		suite.dist,
 		suite.broker,
 		suite.cluster,
+		suite.nodeMgr,
 	)
 	suite.cluster = session.NewMockCluster(suite.T())
 	suite.jobScheduler = job.NewScheduler()

--- a/internal/querycoordv2/server.go
+++ b/internal/querycoordv2/server.go
@@ -284,16 +284,6 @@ func (s *Server) initQueryCoord() error {
 	s.proxyWatcher.DelSessionFunc(s.proxyClientManager.DelProxyClient)
 	log.Info("init proxy manager done")
 
-	// Init heartbeat
-	log.Info("init dist controller")
-	s.distController = dist.NewDistController(
-		s.cluster,
-		s.nodeMgr,
-		s.dist,
-		s.targetMgr,
-		s.taskScheduler,
-	)
-
 	// Init checker controller
 	log.Info("init checker controller")
 	s.getBalancerFunc = func() balance.Balance {
@@ -338,6 +328,20 @@ func (s *Server) initQueryCoord() error {
 
 	// Init observers
 	s.initObserver()
+
+	// Init heartbeat
+	syncTargetVersionFn := func(collectionID int64) {
+		s.targetObserver.TriggerUpdateCurrentTarget(collectionID)
+	}
+	log.Info("init dist controller")
+	s.distController = dist.NewDistController(
+		s.cluster,
+		s.nodeMgr,
+		s.dist,
+		s.targetMgr,
+		s.taskScheduler,
+		syncTargetVersionFn,
+	)
 
 	// Init load status cache
 	meta.GlobalFailedLoadCache = meta.NewFailedLoadCache()
@@ -407,6 +411,7 @@ func (s *Server) initObserver() {
 		s.dist,
 		s.broker,
 		s.cluster,
+		s.nodeMgr,
 	)
 	s.collectionObserver = observers.NewCollectionObserver(
 		s.dist,

--- a/internal/querycoordv2/server_test.go
+++ b/internal/querycoordv2/server_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/milvus-io/milvus/internal/querycoordv2/session"
 	"github.com/milvus-io/milvus/internal/querycoordv2/task"
 	"github.com/milvus-io/milvus/internal/util/sessionutil"
+	"github.com/milvus-io/milvus/pkg/common"
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/util/commonpbutil"
 	"github.com/milvus-io/milvus/pkg/util/etcd"
@@ -560,12 +561,17 @@ func (suite *ServerSuite) hackServer() {
 		suite.server.cluster,
 		suite.server.nodeMgr,
 	)
+
+	syncTargetVersionFn := func(collectionID int64) {
+		suite.server.targetObserver.Check(context.Background(), collectionID, common.AllPartitionsID)
+	}
 	suite.server.distController = dist.NewDistController(
 		suite.server.cluster,
 		suite.server.nodeMgr,
 		suite.server.dist,
 		suite.server.targetMgr,
 		suite.server.taskScheduler,
+		syncTargetVersionFn,
 	)
 	suite.server.checkerController = checkers.NewCheckerController(
 		suite.server.meta,
@@ -582,6 +588,7 @@ func (suite *ServerSuite) hackServer() {
 		suite.server.dist,
 		suite.broker,
 		suite.server.cluster,
+		suite.server.nodeMgr,
 	)
 	suite.server.collectionObserver = observers.NewCollectionObserver(
 		suite.server.dist,

--- a/internal/querycoordv2/services.go
+++ b/internal/querycoordv2/services.go
@@ -154,6 +154,7 @@ func (s *Server) ShowPartitions(ctx context.Context, req *querypb.ShowPartitions
 			return partition.GetPartitionID()
 		})
 	}
+
 	for _, partitionID := range partitions {
 		percentage := s.meta.GetPartitionLoadPercentage(partitionID)
 		if percentage < 0 {
@@ -172,6 +173,7 @@ func (s *Server) ShowPartitions(ctx context.Context, req *querypb.ShowPartitions
 				Status: merr.Status(err),
 			}, nil
 		}
+
 		percentages = append(percentages, int64(percentage))
 	}
 

--- a/internal/querycoordv2/services_test.go
+++ b/internal/querycoordv2/services_test.go
@@ -157,6 +157,7 @@ func (suite *ServiceSuite) SetupTest() {
 		suite.dist,
 		suite.broker,
 		suite.cluster,
+		suite.nodeMgr,
 	)
 	suite.targetObserver.Start()
 	for _, node := range suite.nodes {

--- a/internal/querycoordv2/utils/util.go
+++ b/internal/querycoordv2/utils/util.go
@@ -45,7 +45,7 @@ func CheckNodeAvailable(nodeID int64, info *session.NodeInfo) error {
 // 2. All QueryNodes in the distribution are online
 // 3. The last heartbeat response time is within HeartbeatAvailableInterval for all QueryNodes(include leader) in the distribution
 // 4. All segments of the shard in target should be in the distribution
-func CheckLeaderAvailable(nodeMgr *session.NodeManager, targetMgr meta.TargetManagerInterface, leader *meta.LeaderView) error {
+func CheckDelegatorDataReady(nodeMgr *session.NodeManager, targetMgr meta.TargetManagerInterface, leader *meta.LeaderView, scope int32) error {
 	log := log.Ctx(context.TODO()).
 		WithRateGroup("utils.CheckLeaderAvailable", 1, 60).
 		With(zap.Int64("leaderID", leader.ID))
@@ -68,7 +68,7 @@ func CheckLeaderAvailable(nodeMgr *session.NodeManager, targetMgr meta.TargetMan
 			return err
 		}
 	}
-	segmentDist := targetMgr.GetSealedSegmentsByChannel(leader.CollectionID, leader.Channel, meta.CurrentTarget)
+	segmentDist := targetMgr.GetSealedSegmentsByChannel(leader.CollectionID, leader.Channel, scope)
 	// Check whether segments are fully loaded
 	for segmentID, info := range segmentDist {
 		_, exist := leader.Segments[segmentID]

--- a/tests/integration/replicas/load/load_test.go
+++ b/tests/integration/replicas/load/load_test.go
@@ -760,7 +760,14 @@ func (s *LoadTestSuite) TestDynamicUpdateLoadConfigs_WithRGLackOfNode() {
 	s.Len(resp.GetResourceGroups(), rgNum+2)
 
 	// test load collection with dynamic update
-	s.loadCollection(collectionName, dbName, 3, rgs[:3])
+	loadStatus, err := s.Cluster.Proxy.LoadCollection(ctx, &milvuspb.LoadCollectionRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		ReplicaNumber:  int32(3),
+		ResourceGroups: rgs[:3],
+	})
+	s.NoError(err)
+	s.True(merr.Ok(loadStatus))
 	s.Eventually(func() bool {
 		resp3, err := s.Cluster.Proxy.GetReplicas(ctx, &milvuspb.GetReplicasRequest{
 			DbName:         dbName,
@@ -771,7 +778,14 @@ func (s *LoadTestSuite) TestDynamicUpdateLoadConfigs_WithRGLackOfNode() {
 		return len(resp3.GetReplicas()) == 3
 	}, 30*time.Second, 1*time.Second)
 
-	s.loadCollection(collectionName, dbName, 2, rgs[3:])
+	loadStatus, err = s.Cluster.Proxy.LoadCollection(ctx, &milvuspb.LoadCollectionRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		ReplicaNumber:  int32(2),
+		ResourceGroups: rgs[3:],
+	})
+	s.NoError(err)
+	s.True(merr.Ok(loadStatus))
 	s.Eventually(func() bool {
 		resp3, err := s.Cluster.Proxy.GetReplicas(ctx, &milvuspb.GetReplicasRequest{
 			DbName:         dbName,
@@ -783,7 +797,14 @@ func (s *LoadTestSuite) TestDynamicUpdateLoadConfigs_WithRGLackOfNode() {
 	}, 30*time.Second, 1*time.Second)
 
 	// test load collection with dynamic update
-	s.loadCollection(collectionName, dbName, 5, rgs)
+	loadStatus, err = s.Cluster.Proxy.LoadCollection(ctx, &milvuspb.LoadCollectionRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		ReplicaNumber:  int32(5),
+		ResourceGroups: rgs,
+	})
+	s.NoError(err)
+	s.True(merr.Ok(loadStatus))
 	s.Eventually(func() bool {
 		resp3, err := s.Cluster.Proxy.GetReplicas(ctx, &milvuspb.GetReplicasRequest{
 			DbName:         dbName,


### PR DESCRIPTION
issue: #36293 #36242
pr: #36549
after qn recover, delegator may be loaded in new node, after all segment has been loaded, delegator becomes serviceable. but delegator's target version hasn't been synced, and if search/query comes, delegator will use wrong target version to filter out a empty segment list, which caused empty search result.

This pr will block delegator's serviceable status until target version is synced

---------