### PR TITLE
fix: Correct varchar primarykey size calculation

### DIFF
--- a/internal/flushcommon/writebuffer/delta_buffer_test.go
+++ b/internal/flushcommon/writebuffer/delta_buffer_test.go
@@ -39,8 +39,8 @@ func (s *DeltaBufferSuite) TestBuffer() {
 		})
 
 		memSize := deltaBuffer.Buffer(pks, tss, &msgpb.MsgPosition{Timestamp: 100}, &msgpb.MsgPosition{Timestamp: 200})
-		// 40 = (3*8+8)(string pk) + 8(ts)
-		s.EqualValues(100*40, memSize)
+		// 19 = (3+8)(string pk) + 8(ts)
+		s.EqualValues(100*19, memSize)
 	})
 }
 

--- a/internal/querynodev2/delegator/deletebuffer/delete_buffer_test.go
+++ b/internal/querynodev2/delegator/deletebuffer/delete_buffer_test.go
@@ -112,7 +112,7 @@ func (s *DoubleCacheBufferSuite) TestPut() {
 	s.Equal(1, len(buffer.ListAfter(12)))
 	entryNum, memorySize := buffer.Size()
 	s.EqualValues(2, entryNum)
-	s.EqualValues(304, memorySize)
+	s.EqualValues(234, memorySize)
 
 	buffer.Put(&Item{
 		Ts: 13,
@@ -133,7 +133,7 @@ func (s *DoubleCacheBufferSuite) TestPut() {
 	s.Equal(1, len(buffer.ListAfter(13)))
 	entryNum, memorySize = buffer.Size()
 	s.EqualValues(2, entryNum)
-	s.EqualValues(304, memorySize)
+	s.EqualValues(234, memorySize)
 }
 
 func TestDoubleCacheDeleteBuffer(t *testing.T) {

--- a/internal/storage/primary_key.go
+++ b/internal/storage/primary_key.go
@@ -155,7 +155,6 @@ func (ip *Int64PrimaryKey) GetValue() interface{} {
 }
 
 func (ip *Int64PrimaryKey) Size() int64 {
-	// 8 + reflect.ValueOf(Int64PrimaryKey).Type().Size()
 	return 16
 }
 
@@ -256,7 +255,7 @@ func (vcp *VarCharPrimaryKey) Type() schemapb.DataType {
 }
 
 func (vcp *VarCharPrimaryKey) Size() int64 {
-	return int64(8*len(vcp.Value) + 8)
+	return int64(len(vcp.Value) + 8)
 }
 
 func GenPrimaryKeyByRawData(data interface{}, pkType schemapb.DataType) (PrimaryKey, error) {

--- a/internal/storage/primary_key_test.go
+++ b/internal/storage/primary_key_test.go
@@ -10,8 +10,16 @@ import (
 )
 
 func TestVarCharPrimaryKey(t *testing.T) {
-	pk := NewVarCharPrimaryKey("milvus")
+	t.Run("size", func(t *testing.T) {
+		longString := "The High-Performance Vector Database Built for Scale"
+		pk := NewVarCharPrimaryKey(longString)
+		gotSize := pk.Size()
+		expectSize := len(longString) + 8
 
+		assert.EqualValues(t, expectSize, gotSize)
+	})
+
+	pk := NewVarCharPrimaryKey("milvus")
 	testPk := NewVarCharPrimaryKey("milvus")
 
 	// test GE


### PR DESCRIPTION
See also: #37582