### PR TITLE
enhance: [2.4] Add cgo call metrics for load/write API (#37405)

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -120,6 +120,8 @@ const (
 	lockOp                   = "lock_op"
 	loadTypeName             = "load_type"
 	pathLabelName            = "path"
+	cgoNameLabelName         = `cgo_name`
+	cgoTypeLabelName         = `cgo_type`
 
 	// entities label
 	LoadedLabel         = "loaded"

--- a/pkg/metrics/querynode_metrics.go
+++ b/pkg/metrics/querynode_metrics.go
@@ -790,6 +790,19 @@ var (
 			channelNameLabelName,
 		},
 	)
+
+	QueryNodeCGOCallLatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.QueryNodeRole,
+			Name:      "cgo_latency",
+			Help:      "latency of each cgo call",
+			Buckets:   buckets,
+		}, []string{
+			nodeIDLabelName,
+			cgoNameLabelName,
+			cgoTypeLabelName,
+		})
 )
 
 // RegisterQueryNode registers QueryNode metrics
@@ -859,6 +872,7 @@ func RegisterQueryNode(registry *prometheus.Registry) {
 	registry.MustRegister(QueryNodeSearchHitSegmentNum)
 	registry.MustRegister(QueryNodeDeleteBufferSize)
 	registry.MustRegister(QueryNodeDeleteBufferRowNum)
+	registry.MustRegister(QueryNodeCGOCallLatency)
 	// Add cgo metrics
 	RegisterCGOMetrics(registry)
 }


### PR DESCRIPTION
Cherry-pick from master
pr: #37405

Cgo API cost is not observerable since not metrics is related to them. This PR add metrics for some sync cgo call related to load & write

---------