### PR TITLE
fix: Balance channel may stuck at increasing replica number case

### DIFF
--- a/internal/querycoordv2/observers/target_observer.go
+++ b/internal/querycoordv2/observers/target_observer.go
@@ -376,9 +376,8 @@ func (ob *TargetObserver) shouldUpdateCurrentTarget(ctx context.Context, collect
 		})
 		collectionReadyLeaders = append(collectionReadyLeaders, channelReadyLeaders...)
 
-		nodes := lo.Map(channelReadyLeaders, func(view *meta.LeaderView, _ int) int64 { return view.ID })
-		group := utils.GroupNodesByReplica(ob.meta.ReplicaManager, collectionID, nodes)
-		if int32(len(group)) < replicaNum {
+		// to avoid stuck here in dynamic increase replica case, we just check available delegator number
+		if int32(len(collectionReadyLeaders)) < replicaNum {
 			log.RatedInfo(10, "channel not ready",
 				zap.Int("readyReplicaNum", len(channelReadyLeaders)),
 				zap.String("channelName", channel),


### PR DESCRIPTION
issue: #37640
pr: #37641
fix the pr #36549
cause balance channel will wait until new delegator becomes serviceable, but new delegator need to sync target version then becomes serviceable, and sync target version need to be wait all replica load done. so if increasing replica number and balance channel happens at same time, logic dead lock occurs.