### PR TITLE
fix: ScoreBasedBalancer may balance more segments to new online querynode

### DIFF
--- a/internal/querycoordv2/balance/channel_level_score_balancer_test.go
+++ b/internal/querycoordv2/balance/channel_level_score_balancer_test.go
@@ -569,7 +569,7 @@ func (suite *ChannelLevelScoreBalancerTestSuite) TestStoppedBalance() {
 					{SegmentInfo: &datapb.SegmentInfo{ID: 2, CollectionID: 1, NumOfRows: 20}, Node: 1},
 				},
 				2: {
-					{SegmentInfo: &datapb.SegmentInfo{ID: 3, CollectionID: 1, NumOfRows: 30}, Node: 2},
+					{SegmentInfo: &datapb.SegmentInfo{ID: 3, CollectionID: 1, NumOfRows: 100}, Node: 2},
 				},
 			},
 			expectPlans: []SegmentAssignPlan{

--- a/internal/querycoordv2/checkers/balance_checker_test.go
+++ b/internal/querycoordv2/checkers/balance_checker_test.go
@@ -48,6 +48,7 @@ type BalanceCheckerTestSuite struct {
 	nodeMgr   *session.NodeManager
 	scheduler *task.MockScheduler
 	targetMgr *meta.TargetManager
+	dist      *meta.DistributionManager
 }
 
 func (suite *BalanceCheckerTestSuite) SetupSuite() {
@@ -78,7 +79,8 @@ func (suite *BalanceCheckerTestSuite) SetupTest() {
 	suite.targetMgr = meta.NewTargetManager(suite.broker, suite.meta)
 
 	suite.balancer = balance.NewMockBalancer(suite.T())
-	suite.checker = NewBalanceChecker(suite.meta, suite.targetMgr, suite.nodeMgr, suite.scheduler, func() balance.Balance { return suite.balancer })
+	suite.dist = meta.NewDistributionManager()
+	suite.checker = NewBalanceChecker(suite.meta, suite.dist, suite.targetMgr, suite.nodeMgr, suite.scheduler, func() balance.Balance { return suite.balancer })
 }
 
 func (suite *BalanceCheckerTestSuite) TearDownTest() {
@@ -157,9 +159,6 @@ func (suite *BalanceCheckerTestSuite) TestAutoBalanceConf() {
 	idsToBalance = []int64{int64(replicaID2)}
 	replicasToBalance = suite.checker.replicasToBalance()
 	suite.ElementsMatch(idsToBalance, replicasToBalance)
-	// final round
-	replicasToBalance = suite.checker.replicasToBalance()
-	suite.Empty(replicasToBalance)
 }
 
 func (suite *BalanceCheckerTestSuite) TestBusyScheduler() {
@@ -366,6 +365,153 @@ func (suite *BalanceCheckerTestSuite) TestTargetNotReady() {
 	idsToBalance := []int64{int64(replicaID1)}
 	replicasToBalance := suite.checker.replicasToBalance()
 	suite.ElementsMatch(idsToBalance, replicasToBalance)
+}
+
+func (suite *BalanceCheckerTestSuite) TestMultiCollections() {
+	nodeID1, nodeID2 := int64(1), int64(2)
+	suite.nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{
+		NodeID:   nodeID1,
+		Address:  "localhost",
+		Hostname: "localhost",
+	}))
+	suite.nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{
+		NodeID:   nodeID2,
+		Address:  "localhost",
+		Hostname: "localhost",
+	}))
+	suite.nodeMgr.Stopping(nodeID1)
+	suite.checker.meta.ResourceManager.HandleNodeUp(nodeID1)
+	suite.checker.meta.ResourceManager.HandleNodeUp(nodeID2)
+
+	c1Segments := []*datapb.SegmentInfo{
+		{
+			ID:            1,
+			PartitionID:   1,
+			InsertChannel: "test-insert-channel",
+			NumOfRows:     100,
+		},
+		{
+			ID:            2,
+			PartitionID:   1,
+			InsertChannel: "test-insert-channel",
+			NumOfRows:     100,
+		},
+	}
+	c1Channels := []*datapb.VchannelInfo{
+		{
+			CollectionID: 1,
+			ChannelName:  "test-insert-channel",
+		},
+	}
+
+	c2Segments := []*datapb.SegmentInfo{
+		{
+			ID:            3,
+			PartitionID:   2,
+			InsertChannel: "test-insert-channel",
+			NumOfRows:     10000,
+		},
+		{
+			ID:            4,
+			PartitionID:   2,
+			InsertChannel: "test-insert-channel",
+			NumOfRows:     10000,
+		},
+	}
+	c2Channels := []*datapb.VchannelInfo{
+		{
+			CollectionID: 2,
+			ChannelName:  "test-insert-channel",
+		},
+	}
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, collectionID int64, i2 ...int64) ([]*datapb.VchannelInfo, []*datapb.SegmentInfo, error) {
+			if collectionID == 1 {
+				return c1Channels, c1Segments, nil
+			}
+			return c2Channels, c2Segments, nil
+		})
+
+	segmentsOnDist := []*meta.Segment{
+		{
+			SegmentInfo: c1Segments[0],
+			Node:        1,
+		},
+		{
+			SegmentInfo: c1Segments[1],
+			Node:        1,
+		},
+		{
+			SegmentInfo: c2Segments[0],
+			Node:        1,
+		},
+		{
+			SegmentInfo: c2Segments[1],
+			Node:        1,
+		},
+	}
+	suite.dist.SegmentDistManager.Update(1, segmentsOnDist...)
+
+	// set collections meta
+	cid1, replicaID1, partitionID1 := 1, 1, 1
+	collection1 := utils.CreateTestCollection(int64(cid1), int32(replicaID1))
+	collection1.Status = querypb.LoadStatus_Loaded
+	replica1 := utils.CreateTestReplica(int64(replicaID1), int64(cid1), []int64{nodeID1, nodeID2})
+	partition1 := utils.CreateTestPartition(int64(cid1), int64(partitionID1))
+	suite.checker.meta.CollectionManager.PutCollection(collection1, partition1)
+	suite.checker.meta.ReplicaManager.Put(replica1)
+	suite.targetMgr.UpdateCollectionNextTarget(int64(cid1))
+	suite.targetMgr.UpdateCollectionCurrentTarget(int64(cid1))
+
+	cid2, replicaID2, partitionID2 := 2, 2, 2
+	collection2 := utils.CreateTestCollection(int64(cid2), int32(replicaID2))
+	collection2.Status = querypb.LoadStatus_Loaded
+	replica2 := utils.CreateTestReplica(int64(replicaID2), int64(cid2), []int64{nodeID1, nodeID2})
+	partition2 := utils.CreateTestPartition(int64(cid2), int64(partitionID2))
+	suite.checker.meta.CollectionManager.PutCollection(collection2, partition2)
+	suite.checker.meta.ReplicaManager.Put(replica2)
+	suite.targetMgr.UpdateCollectionNextTarget(int64(cid2))
+	suite.targetMgr.UpdateCollectionCurrentTarget(int64(cid2))
+
+	// test balance, expect balance collection 2
+	replicas := suite.checker.replicasToBalance()
+	suite.Len(replicas, 1)
+	suite.Equal(replicas[0], replica1.GetID())
+
+	// mock distribution
+	segmentsOnDist1 := []*meta.Segment{
+		{
+			SegmentInfo: c1Segments[0],
+			Node:        1,
+		},
+		{
+			SegmentInfo: c1Segments[1],
+			Node:        1,
+		},
+		{
+			SegmentInfo: c2Segments[0],
+			Node:        1,
+		},
+	}
+
+	segmentsOnDist2 := []*meta.Segment{
+		{
+			SegmentInfo: c2Segments[1],
+			Node:        1,
+		},
+	}
+	suite.dist.SegmentDistManager.Update(1, segmentsOnDist1...)
+	suite.dist.SegmentDistManager.Update(2, segmentsOnDist2...)
+
+	// test balance, expect balance collection 2
+	replicas = suite.checker.replicasToBalance()
+	suite.Len(replicas, 1)
+	suite.Equal(replicas[0], replica2.GetID())
+
+	// test balance, expect balance collection 2
+	replicas = suite.checker.replicasToBalance()
+	suite.Len(replicas, 1)
+	suite.Equal(replicas[0], replica1.GetID())
 }
 
 func TestBalanceCheckerSuite(t *testing.T) {

--- a/internal/querycoordv2/checkers/controller.go
+++ b/internal/querycoordv2/checkers/controller.go
@@ -67,7 +67,7 @@ func NewCheckerController(
 	checkers := map[utils.CheckerType]Checker{
 		utils.ChannelChecker: NewChannelChecker(meta, dist, targetMgr, nodeMgr, getBalancerFunc),
 		utils.SegmentChecker: NewSegmentChecker(meta, dist, targetMgr, nodeMgr, getBalancerFunc),
-		utils.BalanceChecker: NewBalanceChecker(meta, targetMgr, nodeMgr, scheduler, getBalancerFunc),
+		utils.BalanceChecker: NewBalanceChecker(meta, dist, targetMgr, nodeMgr, scheduler, getBalancerFunc),
 		utils.IndexChecker:   NewIndexChecker(meta, dist, broker, nodeMgr, targetMgr),
 		// todo temporary work around must fix
 		// utils.LeaderChecker:  NewLeaderChecker(meta, dist, targetMgr, nodeMgr, true),

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -1775,6 +1775,8 @@ type queryCoordConfig struct {
 	UpdateCollectionLoadStatusInterval ParamItem `refreshable:"false"`
 	ClusterLevelLoadReplicaNumber      ParamItem `refreshable:"true"`
 	ClusterLevelLoadResourceGroups     ParamItem `refreshable:"true"`
+
+	DataPercentLimitInBalance ParamItem `refreshable:"true"`
 }
 
 func (p *queryCoordConfig) init(base *BaseTable) {
@@ -2329,6 +2331,15 @@ If this parameter is set false, Milvus simply searches the growing segments with
 		Export:       false,
 	}
 	p.ClusterLevelLoadResourceGroups.Init(base.mgr)
+
+	p.DataPercentLimitInBalance = ParamItem{
+		Key:          "queryCoord.dataPercentLimitInBalance",
+		Version:      "2.4.15",
+		DefaultValue: "0.25",
+		Doc:          "collection's data percentage limit on the balance plan to single querynode for each balance",
+		Export:       false,
+	}
+	p.DataPercentLimitInBalance.Init(base.mgr)
 }
 
 // /////////////////////////////////////////////////////////////////////////////

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -355,6 +355,7 @@ func TestComponentParam(t *testing.T) {
 
 		assert.Equal(t, 0, Params.ClusterLevelLoadReplicaNumber.GetAsInt())
 		assert.Len(t, Params.ClusterLevelLoadResourceGroups.GetAsStrings(), 0)
+		assert.Equal(t, Params.DataPercentLimitInBalance.GetAsFloat(), 0.25)
 	})
 
 	t.Run("test queryNodeConfig", func(t *testing.T) {


### PR DESCRIPTION
issue: #37651
this PR introduce two constriant to avoid balance too aggresive on new online querynode:

1. sort the collections with total row count, balance the largest collection first
2. add a data percent limit on the balance plan to single querynode, in case of move too much data to new node in one round.