### PR TITLE
fix: Make GetShardLeaders only retries on retriable error

### DIFF
--- a/internal/proxy/lb_policy.go
+++ b/internal/proxy/lb_policy.go
@@ -106,9 +106,8 @@ func (lb *LBPolicyImpl) GetShardLeaders(ctx context.Context, dbName string, coll
 		var err error
 		shardLeaders, err = globalMetaCache.GetShards(ctx, withCache, dbName, collName, collectionID)
 		if err != nil {
-			return !errors.Is(err, merr.ErrCollectionLoaded), err
+			return !errors.Is(err, merr.ErrCollectionNotLoaded), err
 		}
-
 		return false, nil
 	})
 


### PR DESCRIPTION
issue: #37532
pr: #37684