### PR TITLE
fix: Modify the batchsize of writer to timely flushing binlogs

### DIFF
--- a/internal/indexnode/task_stats.go
+++ b/internal/indexnode/task_stats.go
@@ -51,7 +51,7 @@ import (
 
 var _ task = (*statsTask)(nil)
 
-const statsBatchSize = 10000
+const statsBatchSize = 100
 
 type statsTask struct {
 	ident  string


### PR DESCRIPTION
issue: #37579 

If the schema includes large varchar fields, a few thousand rows can reach hundreds of MB in size. Therefore, if the batch size of the segment writer is large, it will produce relatively large `binlogs`, which can cause datanode to run out of memory (OOM) during compaction.