### PR TITLE
fix: [2.4] Store default value if `ErrKeyNotFound` is returned (#37691)

### DIFF
--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -119,7 +119,11 @@ func (m *Manager) CASCachedValue(key string, origin string, value interface{}) b
 	m.cacheMutex.Lock()
 	defer m.cacheMutex.Unlock()
 	current, err := m.GetConfig(key)
-	if err != nil && !errors.Is(err, ErrKeyNotFound) {
+	if errors.Is(err, ErrKeyNotFound) {
+		m.configCache[key] = value
+		return true
+	}
+	if err != nil {
 		return false
 	}
 	if current != origin {


### PR DESCRIPTION
Cherry-pick from master
pr: #37691
Related to #37690