### PR TITLE
fix: Get shard client failed by client is closed

### DIFF
--- a/internal/proxy/lb_policy.go
+++ b/internal/proxy/lb_policy.go
@@ -203,7 +203,6 @@ func (lb *LBPolicyImpl) ExecuteWithRetry(ctx context.Context, workload ChannelWo
 			lastErr = errors.Wrapf(err, "failed to get delegator %d for channel %s", targetNode.nodeID, workload.channel)
 			return lastErr
 		}
-		defer lb.clientMgr.ReleaseClientRef(targetNode.nodeID)
 
 		err = workload.exec(ctx, targetNode.nodeID, client, workload.channel)
 		if err != nil {

--- a/internal/proxy/lb_policy_test.go
+++ b/internal/proxy/lb_policy_test.go
@@ -250,7 +250,6 @@ func (s *LBPolicySuite) TestExecuteWithRetry() {
 
 	// test execute success
 	s.lbBalancer.ExpectedCalls = nil
-	s.mgr.EXPECT().ReleaseClientRef(mock.Anything)
 	s.mgr.EXPECT().GetClient(mock.Anything, mock.Anything).Return(s.qn, nil)
 	s.lbBalancer.EXPECT().RegisterNodeInfo(mock.Anything)
 	s.lbBalancer.EXPECT().SelectNode(mock.Anything, mock.Anything, mock.Anything).Return(1, nil)
@@ -289,7 +288,6 @@ func (s *LBPolicySuite) TestExecuteWithRetry() {
 
 	// test get client failed, and retry failed, expected success
 	s.mgr.ExpectedCalls = nil
-	s.mgr.EXPECT().ReleaseClientRef(mock.Anything)
 	s.mgr.EXPECT().GetClient(mock.Anything, mock.Anything).Return(nil, errors.New("fake error")).Times(1)
 	s.lbBalancer.ExpectedCalls = nil
 	s.lbBalancer.EXPECT().RegisterNodeInfo(mock.Anything)
@@ -310,7 +308,6 @@ func (s *LBPolicySuite) TestExecuteWithRetry() {
 	s.Error(err)
 
 	s.mgr.ExpectedCalls = nil
-	s.mgr.EXPECT().ReleaseClientRef(mock.Anything)
 	s.mgr.EXPECT().GetClient(mock.Anything, mock.Anything).Return(nil, errors.New("fake error")).Times(1)
 	s.mgr.EXPECT().GetClient(mock.Anything, mock.Anything).Return(s.qn, nil)
 	s.lbBalancer.EXPECT().RegisterNodeInfo(mock.Anything)
@@ -331,7 +328,6 @@ func (s *LBPolicySuite) TestExecuteWithRetry() {
 
 	// test exec failed, then retry success
 	s.mgr.ExpectedCalls = nil
-	s.mgr.EXPECT().ReleaseClientRef(mock.Anything)
 	s.mgr.EXPECT().GetClient(mock.Anything, mock.Anything).Return(s.qn, nil)
 	s.lbBalancer.ExpectedCalls = nil
 	s.lbBalancer.EXPECT().RegisterNodeInfo(mock.Anything)
@@ -359,7 +355,6 @@ func (s *LBPolicySuite) TestExecuteWithRetry() {
 	// test exec timeout
 	s.mgr.ExpectedCalls = nil
 	s.mgr.EXPECT().GetClient(mock.Anything, mock.Anything).Return(s.qn, nil)
-	s.mgr.EXPECT().ReleaseClientRef(mock.Anything)
 	s.lbBalancer.EXPECT().CancelWorkload(mock.Anything, mock.Anything)
 	s.qn.EXPECT().GetComponentStates(mock.Anything, mock.Anything).Return(nil, nil).Maybe()
 	s.qn.EXPECT().Search(mock.Anything, mock.Anything).Return(nil, context.Canceled).Times(1)
@@ -384,7 +379,6 @@ func (s *LBPolicySuite) TestExecute() {
 	ctx := context.Background()
 	mockErr := errors.New("mock error")
 	// test  all channel success
-	s.mgr.EXPECT().ReleaseClientRef(mock.Anything)
 	s.mgr.EXPECT().GetClient(mock.Anything, mock.Anything).Return(s.qn, nil)
 	s.lbBalancer.EXPECT().RegisterNodeInfo(mock.Anything)
 	s.lbBalancer.EXPECT().SelectNode(mock.Anything, mock.Anything, mock.Anything).Return(1, nil)

--- a/internal/proxy/look_aside_balancer.go
+++ b/internal/proxy/look_aside_balancer.go
@@ -260,7 +260,6 @@ func (b *LookAsideBalancer) checkQueryNodeHealthLoop(ctx context.Context) {
 							log.RatedInfo(10, "get client failed", zap.Int64("node", node), zap.Error(err))
 							return struct{}{}, nil
 						}
-						defer b.clientMgr.ReleaseClientRef(node)
 
 						resp, err := qn.GetComponentStates(ctx, &milvuspb.GetComponentStatesRequest{})
 						if err != nil {

--- a/internal/proxy/look_aside_balancer_test.go
+++ b/internal/proxy/look_aside_balancer_test.go
@@ -43,7 +43,6 @@ type LookAsideBalancerSuite struct {
 
 func (suite *LookAsideBalancerSuite) SetupTest() {
 	suite.clientMgr = NewMockShardClientManager(suite.T())
-	suite.clientMgr.EXPECT().ReleaseClientRef(mock.Anything).Maybe()
 	suite.balancer = NewLookAsideBalancer(suite.clientMgr)
 	suite.balancer.Start(context.Background())
 
@@ -309,7 +308,6 @@ func (suite *LookAsideBalancerSuite) TestCheckHealthLoop() {
 		},
 	}, nil).Maybe()
 	suite.clientMgr.ExpectedCalls = nil
-	suite.clientMgr.EXPECT().ReleaseClientRef(mock.Anything).Maybe()
 	suite.clientMgr.EXPECT().GetClient(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, ni nodeInfo) (types.QueryNodeClient, error) {
 		if ni.nodeID == 1 {
 			return qn, nil
@@ -373,7 +371,6 @@ func (suite *LookAsideBalancerSuite) TestGetClientFailed() {
 
 	// test get shard client from client mgr return nil
 	suite.clientMgr.ExpectedCalls = nil
-	suite.clientMgr.EXPECT().ReleaseClientRef(mock.Anything).Maybe()
 	suite.clientMgr.EXPECT().GetClient(mock.Anything, mock.Anything).Return(nil, errors.New("shard client not found"))
 	// expected stopping the health check after failure times reaching the limit
 	suite.Eventually(func() bool {
@@ -385,7 +382,6 @@ func (suite *LookAsideBalancerSuite) TestNodeRecover() {
 	// mock qn down for a while and then recover
 	qn3 := mocks.NewMockQueryNodeClient(suite.T())
 	suite.clientMgr.ExpectedCalls = nil
-	suite.clientMgr.EXPECT().ReleaseClientRef(mock.Anything)
 	suite.clientMgr.EXPECT().GetClient(mock.Anything, mock.Anything).Return(qn3, nil)
 	qn3.EXPECT().GetComponentStates(mock.Anything, mock.Anything).Return(&milvuspb.ComponentStates{
 		State: &milvuspb.ComponentInfo{
@@ -424,7 +420,6 @@ func (suite *LookAsideBalancerSuite) TestNodeOffline() {
 	// mock qn down for a while and then recover
 	qn3 := mocks.NewMockQueryNodeClient(suite.T())
 	suite.clientMgr.ExpectedCalls = nil
-	suite.clientMgr.EXPECT().ReleaseClientRef(mock.Anything)
 	suite.clientMgr.EXPECT().GetClient(mock.Anything, mock.Anything).Return(qn3, nil)
 	qn3.EXPECT().GetComponentStates(mock.Anything, mock.Anything).Return(&milvuspb.ComponentStates{
 		State: &milvuspb.ComponentInfo{

--- a/internal/proxy/mock_shardclient_manager.go
+++ b/internal/proxy/mock_shardclient_manager.go
@@ -113,39 +113,6 @@ func (_c *MockShardClientManager_GetClient_Call) RunAndReturn(run func(context.C
 	return _c
 }
 
-// ReleaseClientRef provides a mock function with given fields: nodeID
-func (_m *MockShardClientManager) ReleaseClientRef(nodeID int64) {
-	_m.Called(nodeID)
-}
-
-// MockShardClientManager_ReleaseClientRef_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ReleaseClientRef'
-type MockShardClientManager_ReleaseClientRef_Call struct {
-	*mock.Call
-}
-
-// ReleaseClientRef is a helper method to define mock.On call
-//   - nodeID int64
-func (_e *MockShardClientManager_Expecter) ReleaseClientRef(nodeID interface{}) *MockShardClientManager_ReleaseClientRef_Call {
-	return &MockShardClientManager_ReleaseClientRef_Call{Call: _e.mock.On("ReleaseClientRef", nodeID)}
-}
-
-func (_c *MockShardClientManager_ReleaseClientRef_Call) Run(run func(nodeID int64)) *MockShardClientManager_ReleaseClientRef_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(int64))
-	})
-	return _c
-}
-
-func (_c *MockShardClientManager_ReleaseClientRef_Call) Return() *MockShardClientManager_ReleaseClientRef_Call {
-	_c.Call.Return()
-	return _c
-}
-
-func (_c *MockShardClientManager_ReleaseClientRef_Call) RunAndReturn(run func(int64)) *MockShardClientManager_ReleaseClientRef_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // SetClientCreatorFunc provides a mock function with given fields: creator
 func (_m *MockShardClientManager) SetClientCreatorFunc(creator queryNodeCreatorFunc) {
 	_m.Called(creator)

--- a/internal/proxy/shard_client_test.go
+++ b/internal/proxy/shard_client_test.go
@@ -2,11 +2,15 @@ package proxy
 
 import (
 	"context"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/milvus-io/milvus/internal/mocks"
+	"github.com/milvus-io/milvus/internal/proto/internalpb"
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
 )
@@ -40,7 +44,7 @@ func TestShardClient(t *testing.T) {
 	}
 
 	qn := mocks.NewMockQueryNodeClient(t)
-	qn.EXPECT().Close().Return(nil)
+	qn.EXPECT().Close().Return(nil).Maybe()
 	creator := func(ctx context.Context, addr string, nodeID int64) (types.QueryNodeClient, error) {
 		return qn, nil
 	}
@@ -60,7 +64,51 @@ func TestShardClient(t *testing.T) {
 	shardClient.DecRef()
 	assert.Equal(t, int64(1), shardClient.refCnt.Load())
 
+	// only shard client manager can close shard client
 	shardClient.DecRef()
-	assert.Equal(t, int64(0), shardClient.refCnt.Load())
-	assert.Equal(t, true, shardClient.isClosed)
+	shardClient.DecRef()
+	shardClient.DecRef()
+	shardClient.DecRef()
+	assert.Equal(t, false, shardClient.isClosed)
+}
+
+func TestPurgeClient(t *testing.T) {
+	nodeInfo := nodeInfo{
+		nodeID: 1,
+	}
+
+	qn := mocks.NewMockQueryNodeClient(t)
+	qn.EXPECT().Close().Return(nil).Maybe()
+	creator := func(ctx context.Context, addr string, nodeID int64) (types.QueryNodeClient, error) {
+		return qn, nil
+	}
+
+	s := &shardClientMgrImpl{
+		clients: struct {
+			sync.RWMutex
+			data map[UniqueID]*shardClient
+		}{data: make(map[UniqueID]*shardClient)},
+		clientCreator:   creator,
+		closeCh:         make(chan struct{}),
+		purgeInterval:   1 * time.Second,
+		purgeExpiredAge: 3,
+	}
+	mockQC := mocks.NewMockQueryCoordClient(t)
+	mockRC := mocks.NewMockRootCoordClient(t)
+	mockRC.EXPECT().ListPolicy(mock.Anything, mock.Anything).Return(&internalpb.ListPolicyResponse{}, nil)
+	InitMetaCache(context.TODO(), mockRC, mockQC, s)
+
+	go s.PurgeClient()
+	defer s.Close()
+	// test client has been used
+	_, err := s.GetClient(context.Background(), nodeInfo)
+	assert.Nil(t, err)
+	time.Sleep(5 * time.Second)
+	// expected client has not been purged
+	assert.Equal(t, len(s.clients.data), 1)
+
+	s.ReleaseClientRef(1)
+	time.Sleep(5 * time.Second)
+	// expected client has been purged
+	assert.Equal(t, len(s.clients.data), 0)
 }

--- a/internal/proxy/task_policies.go
+++ b/internal/proxy/task_policies.go
@@ -39,7 +39,6 @@ func RoundRobinPolicy(
 				combineErr = merr.Combine(combineErr, err)
 				continue
 			}
-			defer mgr.ReleaseClientRef(target.nodeID)
 			err = query(ctx, target.nodeID, qn, channel)
 			if err != nil {
 				log.Warn("query channel failed", zap.String("channel", channel), zap.Int64("nodeID", target.nodeID), zap.Error(err))

--- a/internal/proxy/task_query_test.go
+++ b/internal/proxy/task_query_test.go
@@ -79,7 +79,6 @@ func TestQueryTask_all(t *testing.T) {
 	}, nil).Maybe()
 
 	mgr := NewMockShardClientManager(t)
-	mgr.EXPECT().ReleaseClientRef(mock.Anything)
 	mgr.EXPECT().GetClient(mock.Anything, mock.Anything).Return(qn, nil).Maybe()
 	lb := NewLBPolicyImpl(mgr)
 

--- a/internal/proxy/task_search_test.go
+++ b/internal/proxy/task_search_test.go
@@ -2111,7 +2111,6 @@ func TestSearchTask_ErrExecute(t *testing.T) {
 	qc.EXPECT().ShowCollections(mock.Anything, mock.Anything).Return(&querypb.ShowCollectionsResponse{}, nil).Maybe()
 
 	mgr := NewMockShardClientManager(t)
-	mgr.EXPECT().ReleaseClientRef(mock.Anything)
 	mgr.EXPECT().GetClient(mock.Anything, mock.Anything).Return(qn, nil).Maybe()
 	lb := NewLBPolicyImpl(mgr)
 

--- a/internal/proxy/task_statistic_test.go
+++ b/internal/proxy/task_statistic_test.go
@@ -80,7 +80,6 @@ func (s *StatisticTaskSuite) SetupTest() {
 
 	s.qn.EXPECT().GetComponentStates(mock.Anything, mock.Anything).Return(nil, nil).Maybe()
 	mgr := NewMockShardClientManager(s.T())
-	mgr.EXPECT().ReleaseClientRef(mock.Anything).Maybe()
 	mgr.EXPECT().GetClient(mock.Anything, mock.Anything).Return(s.qn, nil).Maybe()
 	s.lb = NewLBPolicyImpl(mgr)
 


### PR DESCRIPTION
issue: #37718
This PR refine the shard client ref counter, dec ref counter won't release client anymore, and only permit shard client manager to remove client.