### PR TITLE
enhance: [2.4] Remove segment-level tag from monitoring metrics

### DIFF
--- a/internal/datacoord/index_meta.go
+++ b/internal/datacoord/index_meta.go
@@ -801,7 +801,7 @@ func (m *indexMeta) SetStoredIndexFileSizeMetric(collections map[UniqueID]*colle
 		coll, ok := collections[segmentIdx.CollectionID]
 		if ok {
 			metrics.DataCoordStoredIndexFilesSize.WithLabelValues(coll.DatabaseName, coll.Schema.GetName(),
-				fmt.Sprint(segmentIdx.CollectionID), fmt.Sprint(segmentIdx.SegmentID)).Set(float64(segmentIdx.IndexSize))
+				fmt.Sprint(segmentIdx.CollectionID)).Set(float64(segmentIdx.IndexSize))
 			total += segmentIdx.IndexSize
 		}
 	}

--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -416,7 +416,7 @@ func (m *meta) GetQuotaInfo() *metricsinfo.DataCoordQuotaMetrics {
 			coll, ok := m.collections[segment.GetCollectionID()]
 			if ok {
 				metrics.DataCoordStoredBinlogSize.WithLabelValues(coll.DatabaseName,
-					fmt.Sprint(segment.GetCollectionID()), fmt.Sprint(segment.GetID()), segment.GetState().String()).Set(float64(segmentSize))
+					fmt.Sprint(segment.GetCollectionID()), segment.GetState().String()).Set(float64(segmentSize))
 			} else {
 				log.Warn("not found database name", zap.Int64("collectionID", segment.GetCollectionID()))
 			}
@@ -515,10 +515,6 @@ func (m *meta) DropSegment(segmentID UniqueID) error {
 		return err
 	}
 	metrics.DataCoordNumSegments.WithLabelValues(segment.GetState().String(), segment.GetLevel().String()).Dec()
-	coll, ok := m.collections[segment.CollectionID]
-	if ok {
-		metrics.CleanupDataCoordSegmentMetrics(coll.DatabaseName, segment.CollectionID, segment.ID)
-	}
 
 	m.segments.DropSegment(segmentID)
 	log.Info("meta update: dropping segment - complete",

--- a/internal/metastore/kv/datacoord/kv_catalog.go
+++ b/internal/metastore/kv/datacoord/kv_catalog.go
@@ -356,9 +356,7 @@ func (kc *Catalog) collectMetrics(s *datapb.SegmentInfo) {
 	cnt += statsFieldFn(s.GetStatslogs())
 	cnt += statsFieldFn(s.GetDeltalogs())
 
-	metrics.DataCoordSegmentBinLogFileCount.
-		WithLabelValues(fmt.Sprint(s.CollectionID), fmt.Sprint(s.GetID())).
-		Set(float64(cnt))
+	metrics.DataCoordSegmentBinLogFileCount.WithLabelValues(fmt.Sprint(s.CollectionID)).Set(float64(cnt))
 }
 
 func (kc *Catalog) hasBinlogPrefix(segment *datapb.SegmentInfo) (bool, error) {

--- a/pkg/metrics/datacoord_metrics.go
+++ b/pkg/metrics/datacoord_metrics.go
@@ -141,7 +141,6 @@ var (
 		}, []string{
 			databaseLabelName,
 			collectionIDLabelName,
-			segmentIDLabelName,
 			segmentStateLabelName,
 		})
 	DataCoordSegmentBinLogFileCount = prometheus.NewGaugeVec(
@@ -152,7 +151,6 @@ var (
 			Help:      "number of binlog files for each segment",
 		}, []string{
 			collectionIDLabelName,
-			segmentIDLabelName,
 		})
 
 	DataCoordStoredIndexFilesSize = prometheus.NewGaugeVec(
@@ -165,7 +163,6 @@ var (
 			databaseLabelName,
 			collectionName,
 			collectionIDLabelName,
-			segmentIDLabelName,
 		})
 
 	DataCoordDmlChannelNum = prometheus.NewGaugeVec(
@@ -378,25 +375,6 @@ func RegisterDataCoord(registry *prometheus.Registry) {
 	registry.MustRegister(GarbageCollectorFileScanDuration)
 	registry.MustRegister(GarbageCollectorRunCount)
 	registry.MustRegister(DataCoordTaskExecuteLatency)
-}
-
-func CleanupDataCoordSegmentMetrics(dbName string, collectionID int64, segmentID int64) {
-	DataCoordSegmentBinLogFileCount.
-		Delete(
-			prometheus.Labels{
-				collectionIDLabelName: fmt.Sprint(collectionID),
-				segmentIDLabelName:    fmt.Sprint(segmentID),
-			})
-	DataCoordStoredBinlogSize.Delete(prometheus.Labels{
-		databaseLabelName:     dbName,
-		collectionIDLabelName: fmt.Sprint(collectionID),
-		segmentIDLabelName:    fmt.Sprint(segmentID),
-	})
-	DataCoordStoredIndexFilesSize.DeletePartialMatch(prometheus.Labels{
-		databaseLabelName:     dbName,
-		collectionIDLabelName: fmt.Sprint(collectionID),
-		segmentIDLabelName:    fmt.Sprint(segmentID),
-	})
 }
 
 func CleanupDataCoordWithCollectionID(collectionID int64) {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -101,7 +101,6 @@ const (
 	indexName                = "index_name"
 	isVectorIndex            = "is_vector_index"
 	segmentStateLabelName    = "segment_state"
-	segmentIDLabelName       = "segment_id"
 	segmentLevelLabelName    = "segment_level"
 	usernameLabelName        = "username"
 	roleNameLabelName        = "role_name"


### PR DESCRIPTION
When there are a large number of segments, the metrics consume a lot of memory. This PR Remove segment-level tag from monitoring metrics.

issue: https://github.com/milvus-io/milvus/issues/37636

pr: https://github.com/milvus-io/milvus/pull/37696