### PR TITLE
enhance: Prevent generate "null" search params

### DIFF
--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -960,6 +960,9 @@ func generatePlaceholderGroup(ctx context.Context, body string, collSchema *sche
 
 func generateSearchParams(ctx context.Context, c *gin.Context, reqSearchParams searchParams) []*commonpb.KeyValuePair {
 	var searchParams []*commonpb.KeyValuePair
+	if reqSearchParams.Params == nil {
+		reqSearchParams.Params = make(map[string]any)
+	}
 	bs, _ := json.Marshal(reqSearchParams.Params)
 	searchParams = append(searchParams, &commonpb.KeyValuePair{Key: Params, Value: string(bs)})
 	searchParams = append(searchParams, &commonpb.KeyValuePair{Key: common.IgnoreGrowing, Value: strconv.FormatBool(reqSearchParams.IgnoreGrowing)})


### PR DESCRIPTION
Preventing generating null search params in restful search request