### PR TITLE
enhance: Fix error messages in GC Resume

### DIFF
--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -1641,7 +1641,7 @@ func (s *Server) GcControl(ctx context.Context, request *datapb.GcControlRequest
 	case datapb.GcCommand_Resume:
 		if err := s.garbageCollector.Resume(ctx); err != nil {
 			status.ErrorCode = commonpb.ErrorCode_UnexpectedError
-			status.Reason = fmt.Sprintf("failed to pause gc, %s", err.Error())
+			status.Reason = fmt.Sprintf("failed to resume gc, %s", err.Error())
 			return status, nil
 		}
 	default:

--- a/internal/proxy/management.go
+++ b/internal/proxy/management.go
@@ -114,12 +114,12 @@ func (node *Proxy) ResumeDatacoordGC(w http.ResponseWriter, req *http.Request) {
 	})
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte(fmt.Sprintf(`{"msg": "failed to pause garbage collection, %s"}`, err.Error())))
+		w.Write([]byte(fmt.Sprintf(`{"msg": "failed to resume garbage collection, %s"}`, err.Error())))
 		return
 	}
 	if resp.GetErrorCode() != commonpb.ErrorCode_Success {
 		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte(fmt.Sprintf(`{"msg": "failed to pause garbage collection, %s"}`, resp.GetReason())))
+		w.Write([]byte(fmt.Sprintf(`{"msg": "failed to resume garbage collection, %s"}`, resp.GetReason())))
 		return
 	}
 	w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
Failure to Resume GC results in an error message complaining about failure to "pause" GC, which is not correct.