### PR TITLE
enhance: [2.4] Reduce GetIndexInfos calls

### DIFF
--- a/internal/datacoord/index_meta.go
+++ b/internal/datacoord/index_meta.go
@@ -542,26 +542,24 @@ func (m *indexMeta) IsUnIndexedSegment(collectionID UniqueID, segID UniqueID) bo
 	return false
 }
 
-func (m *indexMeta) getSegmentIndexes(segID UniqueID) map[UniqueID]*model.SegmentIndex {
+func (m *indexMeta) GetSegmentsIndexes(collectionID UniqueID, segIDs []UniqueID) map[int64]map[UniqueID]*model.SegmentIndex {
 	m.RLock()
 	defer m.RUnlock()
-
-	ret := make(map[UniqueID]*model.SegmentIndex, 0)
-	segIndexInfos, ok := m.segmentIndexes[segID]
-	if !ok || len(segIndexInfos) == 0 {
-		return ret
+	segmentsIndexes := make(map[int64]map[UniqueID]*model.SegmentIndex)
+	for _, segmentID := range segIDs {
+		segmentsIndexes[segmentID] = m.getSegmentIndexes(collectionID, segmentID)
 	}
-
-	for _, segIdx := range segIndexInfos {
-		ret[segIdx.IndexID] = model.CloneSegmentIndex(segIdx)
-	}
-	return ret
+	return segmentsIndexes
 }
 
 func (m *indexMeta) GetSegmentIndexes(collectionID UniqueID, segID UniqueID) map[UniqueID]*model.SegmentIndex {
 	m.RLock()
 	defer m.RUnlock()
+	return m.getSegmentIndexes(collectionID, segID)
+}
 
+// Note: thread-unsafe, don't call it outside indexMeta
+func (m *indexMeta) getSegmentIndexes(collectionID UniqueID, segID UniqueID) map[UniqueID]*model.SegmentIndex {
 	ret := make(map[UniqueID]*model.SegmentIndex, 0)
 	segIndexInfos, ok := m.segmentIndexes[segID]
 	if !ok || len(segIndexInfos) == 0 {

--- a/internal/datacoord/index_meta_test.go
+++ b/internal/datacoord/index_meta_test.go
@@ -737,12 +737,12 @@ func TestMeta_GetSegmentIndexes(t *testing.T) {
 	m := createMeta(catalog, nil, createIndexMeta(catalog))
 
 	t.Run("success", func(t *testing.T) {
-		segIndexes := m.indexMeta.getSegmentIndexes(segID)
+		segIndexes := m.indexMeta.GetSegmentIndexes(collID, segID)
 		assert.Equal(t, 1, len(segIndexes))
 	})
 
 	t.Run("segment not exist", func(t *testing.T) {
-		segIndexes := m.indexMeta.getSegmentIndexes(segID + 100)
+		segIndexes := m.indexMeta.GetSegmentIndexes(collID, segID+100)
 		assert.Equal(t, 0, len(segIndexes))
 	})
 

--- a/internal/datacoord/index_service.go
+++ b/internal/datacoord/index_service.go
@@ -846,8 +846,9 @@ func (s *Server) GetIndexInfos(ctx context.Context, req *indexpb.GetIndexInfoReq
 		SegmentInfo: map[int64]*indexpb.SegmentInfo{},
 	}
 
+	segmentsIndexes := s.meta.indexMeta.GetSegmentsIndexes(req.GetCollectionID(), req.GetSegmentIDs())
 	for _, segID := range req.GetSegmentIDs() {
-		segIdxes := s.meta.indexMeta.GetSegmentIndexes(req.GetCollectionID(), segID)
+		segIdxes := segmentsIndexes[segID]
 		ret.SegmentInfo[segID] = &indexpb.SegmentInfo{
 			CollectionID: req.GetCollectionID(),
 			SegmentID:    segID,

--- a/internal/datacoord/task_scheduler.go
+++ b/internal/datacoord/task_scheduler.go
@@ -101,7 +101,7 @@ func (s *taskScheduler) Stop() {
 func (s *taskScheduler) reloadFromKV() {
 	segments := s.meta.GetAllSegmentsUnsafe()
 	for _, segment := range segments {
-		for _, segIndex := range s.meta.indexMeta.getSegmentIndexes(segment.ID) {
+		for _, segIndex := range s.meta.indexMeta.GetSegmentIndexes(segment.GetCollectionID(), segment.ID) {
 			if segIndex.IsDeleted {
 				continue
 			}

--- a/internal/querycoordv2/meta/coordinator_broker_test.go
+++ b/internal/querycoordv2/meta/coordinator_broker_test.go
@@ -443,7 +443,7 @@ func (s *CoordinatorBrokerDataCoordSuite) TestGetIndexInfo() {
 
 		infos, err := s.broker.GetIndexInfo(ctx, collectionID, segmentID)
 		s.NoError(err)
-		s.ElementsMatch(indexIDs, lo.Map(infos, func(info *querypb.FieldIndexInfo, _ int) int64 {
+		s.ElementsMatch(indexIDs, lo.Map(infos[segmentID], func(info *querypb.FieldIndexInfo, _ int) int64 {
 			return info.GetIndexID()
 		}))
 		s.resetMock()

--- a/internal/querycoordv2/meta/mock_broker.go
+++ b/internal/querycoordv2/meta/mock_broker.go
@@ -202,25 +202,36 @@ func (_c *MockBroker_GetCollectionLoadInfo_Call) RunAndReturn(run func(context.C
 	return _c
 }
 
-// GetIndexInfo provides a mock function with given fields: ctx, collectionID, segmentID
-func (_m *MockBroker) GetIndexInfo(ctx context.Context, collectionID int64, segmentID int64) ([]*querypb.FieldIndexInfo, error) {
-	ret := _m.Called(ctx, collectionID, segmentID)
-
-	var r0 []*querypb.FieldIndexInfo
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, int64, int64) ([]*querypb.FieldIndexInfo, error)); ok {
-		return rf(ctx, collectionID, segmentID)
+// GetIndexInfo provides a mock function with given fields: ctx, collectionID, segmentIDs
+func (_m *MockBroker) GetIndexInfo(ctx context.Context, collectionID int64, segmentIDs ...int64) (map[int64][]*querypb.FieldIndexInfo, error) {
+	_va := make([]interface{}, len(segmentIDs))
+	for _i := range segmentIDs {
+		_va[_i] = segmentIDs[_i]
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, int64, int64) []*querypb.FieldIndexInfo); ok {
-		r0 = rf(ctx, collectionID, segmentID)
+	var _ca []interface{}
+	_ca = append(_ca, ctx, collectionID)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetIndexInfo")
+	}
+
+	var r0 map[int64][]*querypb.FieldIndexInfo
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, int64, ...int64) (map[int64][]*querypb.FieldIndexInfo, error)); ok {
+		return rf(ctx, collectionID, segmentIDs...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, int64, ...int64) map[int64][]*querypb.FieldIndexInfo); ok {
+		r0 = rf(ctx, collectionID, segmentIDs...)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]*querypb.FieldIndexInfo)
+			r0 = ret.Get(0).(map[int64][]*querypb.FieldIndexInfo)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, int64, int64) error); ok {
-		r1 = rf(ctx, collectionID, segmentID)
+	if rf, ok := ret.Get(1).(func(context.Context, int64, ...int64) error); ok {
+		r1 = rf(ctx, collectionID, segmentIDs...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -236,24 +247,31 @@ type MockBroker_GetIndexInfo_Call struct {
 // GetIndexInfo is a helper method to define mock.On call
 //   - ctx context.Context
 //   - collectionID int64
-//   - segmentID int64
-func (_e *MockBroker_Expecter) GetIndexInfo(ctx interface{}, collectionID interface{}, segmentID interface{}) *MockBroker_GetIndexInfo_Call {
-	return &MockBroker_GetIndexInfo_Call{Call: _e.mock.On("GetIndexInfo", ctx, collectionID, segmentID)}
+//   - segmentIDs ...int64
+func (_e *MockBroker_Expecter) GetIndexInfo(ctx interface{}, collectionID interface{}, segmentIDs ...interface{}) *MockBroker_GetIndexInfo_Call {
+	return &MockBroker_GetIndexInfo_Call{Call: _e.mock.On("GetIndexInfo",
+		append([]interface{}{ctx, collectionID}, segmentIDs...)...)}
 }
 
-func (_c *MockBroker_GetIndexInfo_Call) Run(run func(ctx context.Context, collectionID int64, segmentID int64)) *MockBroker_GetIndexInfo_Call {
+func (_c *MockBroker_GetIndexInfo_Call) Run(run func(ctx context.Context, collectionID int64, segmentIDs ...int64)) *MockBroker_GetIndexInfo_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(int64), args[2].(int64))
+		variadicArgs := make([]int64, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(int64)
+			}
+		}
+		run(args[0].(context.Context), args[1].(int64), variadicArgs...)
 	})
 	return _c
 }
 
-func (_c *MockBroker_GetIndexInfo_Call) Return(_a0 []*querypb.FieldIndexInfo, _a1 error) *MockBroker_GetIndexInfo_Call {
+func (_c *MockBroker_GetIndexInfo_Call) Return(_a0 map[int64][]*querypb.FieldIndexInfo, _a1 error) *MockBroker_GetIndexInfo_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockBroker_GetIndexInfo_Call) RunAndReturn(run func(context.Context, int64, int64) ([]*querypb.FieldIndexInfo, error)) *MockBroker_GetIndexInfo_Call {
+func (_c *MockBroker_GetIndexInfo_Call) RunAndReturn(run func(context.Context, int64, ...int64) (map[int64][]*querypb.FieldIndexInfo, error)) *MockBroker_GetIndexInfo_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/querycoordv2/task/executor.go
+++ b/internal/querycoordv2/task/executor.go
@@ -710,7 +710,7 @@ func (ex *Executor) getLoadInfo(ctx context.Context, collectionID, segmentID int
 		return nil, nil, err
 	}
 	// update the field index params
-	for _, segmentIndex := range indexes {
+	for _, segmentIndex := range indexes[segment.GetID()] {
 		index, found := lo.Find(indexInfos, func(indexInfo *indexpb.IndexInfo) bool {
 			return indexInfo.IndexID == segmentIndex.IndexID
 		})
@@ -727,7 +727,7 @@ func (ex *Executor) getLoadInfo(ctx context.Context, collectionID, segmentID int
 		segmentIndex.IndexParams = funcutil.Map2KeyValuePair(params)
 	}
 
-	loadInfo := utils.PackSegmentLoadInfo(segment, channel.GetSeekPosition(), indexes)
+	loadInfo := utils.PackSegmentLoadInfo(segment, channel.GetSeekPosition(), indexes[segment.GetID()])
 	return loadInfo, indexInfos, nil
 }
 

--- a/internal/querycoordv2/task/task_test.go
+++ b/internal/querycoordv2/task/task_test.go
@@ -529,7 +529,7 @@ func (suite *TaskSuite) TestLoadSegmentTaskNotIndex() {
 				InsertChannel: channel.ChannelName,
 			},
 		}, nil)
-		suite.broker.EXPECT().GetIndexInfo(mock.Anything, suite.collection, segment).Return(nil, merr.WrapErrIndexNotFoundForSegment(segment))
+		suite.broker.EXPECT().GetIndexInfo(mock.Anything, suite.collection, segment).Return(nil, merr.WrapErrIndexNotFoundForSegments([]int64{segment}))
 	}
 	suite.cluster.EXPECT().LoadSegments(mock.Anything, targetNode, mock.Anything).Return(merr.Success(), nil)
 

--- a/pkg/util/merr/errors_test.go
+++ b/pkg/util/merr/errors_test.go
@@ -120,7 +120,7 @@ func (s *ErrSuite) TestWrap() {
 	// Index related
 	s.ErrorIs(WrapErrIndexNotFound("failed to get Index"), ErrIndexNotFound)
 	s.ErrorIs(WrapErrIndexNotFoundForCollection("milvus_hello", "failed to get collection index"), ErrIndexNotFound)
-	s.ErrorIs(WrapErrIndexNotFoundForSegment(100, "failed to get collection index"), ErrIndexNotFound)
+	s.ErrorIs(WrapErrIndexNotFoundForSegments([]int64{100}, "failed to get collection index"), ErrIndexNotFound)
 	s.ErrorIs(WrapErrIndexNotSupported("wsnh", "failed to create index"), ErrIndexNotSupported)
 
 	// Node related

--- a/pkg/util/merr/utils.go
+++ b/pkg/util/merr/utils.go
@@ -772,8 +772,8 @@ func WrapErrIndexNotFound(indexName string, msg ...string) error {
 	return err
 }
 
-func WrapErrIndexNotFoundForSegment(segmentID int64, msg ...string) error {
-	err := wrapFields(ErrIndexNotFound, value("segmentID", segmentID))
+func WrapErrIndexNotFoundForSegments(segmentIDs []int64, msg ...string) error {
+	err := wrapFields(ErrIndexNotFound, value("segmentIDs", segmentIDs))
 	if len(msg) > 0 {
 		err = errors.Wrap(err, strings.Join(msg, "->"))
 	}


### PR DESCRIPTION
Batch `GetIndexInfos` calls for segments to reduce RPC calls.

issue: https://github.com/milvus-io/milvus/issues/37634

pr: https://github.com/milvus-io/milvus/pull/37695