### PR TITLE
enhance: refine rootcoord/metatable interfaces to ensure that each method includes a ctx parameter

### DIFF
--- a/internal/rootcoord/alter_collection_task.go
+++ b/internal/rootcoord/alter_collection_task.go
@@ -84,7 +84,7 @@ func (a *alterCollectionTask) Execute(ctx context.Context) error {
 	})
 
 	// properties needs to be refreshed in the cache
-	aliases := a.core.meta.ListAliasesByID(oldColl.CollectionID)
+	aliases := a.core.meta.ListAliasesByID(ctx, oldColl.CollectionID)
 	redoTask.AddSyncStep(&expireCacheStep{
 		baseStep:        baseStep{core: a.core},
 		dbName:          a.Req.GetDbName(),

--- a/internal/rootcoord/alter_collection_task_test.go
+++ b/internal/rootcoord/alter_collection_task_test.go
@@ -92,7 +92,7 @@ func Test_alterCollectionTask_Execute(t *testing.T) {
 			mock.Anything,
 			mock.Anything,
 		).Return(errors.New("err"))
-		meta.On("ListAliasesByID", mock.Anything).Return([]string{})
+		meta.On("ListAliasesByID", mock.Anything, mock.Anything).Return([]string{})
 
 		core := newTestCore(withValidProxyManager(), withMeta(meta))
 		task := &alterCollectionTask{
@@ -122,7 +122,7 @@ func Test_alterCollectionTask_Execute(t *testing.T) {
 			mock.Anything,
 			mock.Anything,
 		).Return(nil)
-		meta.On("ListAliasesByID", mock.Anything).Return([]string{})
+		meta.On("ListAliasesByID", mock.Anything, mock.Anything).Return([]string{})
 
 		broker := newMockBroker()
 		broker.BroadcastAlteredCollectionFunc = func(ctx context.Context, req *milvuspb.AlterCollectionRequest) error {
@@ -157,7 +157,7 @@ func Test_alterCollectionTask_Execute(t *testing.T) {
 			mock.Anything,
 			mock.Anything,
 		).Return(nil)
-		meta.On("ListAliasesByID", mock.Anything).Return([]string{})
+		meta.On("ListAliasesByID", mock.Anything, mock.Anything).Return([]string{})
 
 		broker := newMockBroker()
 		broker.BroadcastAlteredCollectionFunc = func(ctx context.Context, req *milvuspb.AlterCollectionRequest) error {
@@ -231,7 +231,7 @@ func Test_alterCollectionTask_Execute(t *testing.T) {
 			mock.Anything,
 			mock.Anything,
 		).Return(nil)
-		meta.On("ListAliasesByID", mock.Anything).Return([]string{})
+		meta.On("ListAliasesByID", mock.Anything, mock.Anything).Return([]string{})
 
 		broker := newMockBroker()
 		broker.BroadcastAlteredCollectionFunc = func(ctx context.Context, req *milvuspb.AlterCollectionRequest) error {

--- a/internal/rootcoord/describe_collection_task.go
+++ b/internal/rootcoord/describe_collection_task.go
@@ -45,7 +45,7 @@ func (t *describeCollectionTask) Execute(ctx context.Context) (err error) {
 		return err
 	}
 
-	aliases := t.core.meta.ListAliasesByID(coll.CollectionID)
+	aliases := t.core.meta.ListAliasesByID(ctx, coll.CollectionID)
 	db, err := t.core.meta.GetDatabaseByID(ctx, coll.DBID, t.GetTs())
 	if err != nil {
 		return err

--- a/internal/rootcoord/describe_collection_task_test.go
+++ b/internal/rootcoord/describe_collection_task_test.go
@@ -105,6 +105,7 @@ func Test_describeCollectionTask_Execute(t *testing.T) {
 		}, nil)
 		meta.On("ListAliasesByID",
 			mock.Anything,
+			mock.Anything,
 		).Return([]string{alias1, alias2})
 		meta.EXPECT().GetDatabaseByID(mock.Anything, mock.Anything, mock.Anything).Return(&model.Database{
 			ID:   1,

--- a/internal/rootcoord/drop_collection_task.go
+++ b/internal/rootcoord/drop_collection_task.go
@@ -37,18 +37,18 @@ type dropCollectionTask struct {
 	Req *milvuspb.DropCollectionRequest
 }
 
-func (t *dropCollectionTask) validate() error {
+func (t *dropCollectionTask) validate(ctx context.Context) error {
 	if err := CheckMsgType(t.Req.GetBase().GetMsgType(), commonpb.MsgType_DropCollection); err != nil {
 		return err
 	}
-	if t.core.meta.IsAlias(t.Req.GetDbName(), t.Req.GetCollectionName()) {
+	if t.core.meta.IsAlias(ctx, t.Req.GetDbName(), t.Req.GetCollectionName()) {
 		return fmt.Errorf("cannot drop the collection via alias = %s", t.Req.CollectionName)
 	}
 	return nil
 }
 
 func (t *dropCollectionTask) Prepare(ctx context.Context) error {
-	return t.validate()
+	return t.validate(ctx)
 }
 
 func (t *dropCollectionTask) Execute(ctx context.Context) error {
@@ -68,7 +68,7 @@ func (t *dropCollectionTask) Execute(ctx context.Context) error {
 	}
 
 	// meta cache of all aliases should also be cleaned.
-	aliases := t.core.meta.ListAliasesByID(collMeta.CollectionID)
+	aliases := t.core.meta.ListAliasesByID(ctx, collMeta.CollectionID)
 
 	ts := t.GetTs()
 

--- a/internal/rootcoord/drop_collection_task_test.go
+++ b/internal/rootcoord/drop_collection_task_test.go
@@ -51,6 +51,7 @@ func Test_dropCollectionTask_Prepare(t *testing.T) {
 		meta.On("IsAlias",
 			mock.Anything,
 			mock.Anything,
+			mock.Anything,
 		).Return(true)
 
 		core := newTestCore(withMeta(meta))
@@ -70,6 +71,7 @@ func Test_dropCollectionTask_Prepare(t *testing.T) {
 
 		meta := mockrootcoord.NewIMetaTable(t)
 		meta.On("IsAlias",
+			mock.Anything,
 			mock.Anything,
 			mock.Anything,
 		).Return(false)
@@ -129,6 +131,7 @@ func Test_dropCollectionTask_Execute(t *testing.T) {
 			mock.Anything,
 		).Return(coll.Clone(), nil)
 		meta.On("ListAliasesByID",
+			mock.Anything,
 			mock.AnythingOfType("int64"),
 		).Return([]string{})
 
@@ -162,6 +165,7 @@ func Test_dropCollectionTask_Execute(t *testing.T) {
 			mock.Anything,
 		).Return(errors.New("error mock ChangeCollectionState"))
 		meta.On("ListAliasesByID",
+			mock.Anything,
 			mock.Anything,
 		).Return([]string{})
 
@@ -206,6 +210,7 @@ func Test_dropCollectionTask_Execute(t *testing.T) {
 			mock.Anything,
 		).Return(nil)
 		meta.On("ListAliasesByID",
+			mock.Anything,
 			mock.Anything,
 		).Return([]string{})
 		removeCollectionMetaCalled := false

--- a/internal/rootcoord/list_db_task.go
+++ b/internal/rootcoord/list_db_task.go
@@ -58,7 +58,7 @@ func (t *listDatabaseTask) Execute(ctx context.Context) error {
 			privilegeDBs.Insert(util.AnyWord)
 			return privilegeDBs, nil
 		}
-		userRoles, err := t.core.meta.SelectUser("", &milvuspb.UserEntity{
+		userRoles, err := t.core.meta.SelectUser(ctx, "", &milvuspb.UserEntity{
 			Name: curUser,
 		}, true)
 		if err != nil {
@@ -72,7 +72,7 @@ func (t *listDatabaseTask) Execute(ctx context.Context) error {
 				privilegeDBs.Insert(util.AnyWord)
 				return privilegeDBs, nil
 			}
-			entities, err := t.core.meta.SelectGrant("", &milvuspb.GrantEntity{
+			entities, err := t.core.meta.SelectGrant(ctx, "", &milvuspb.GrantEntity{
 				Role:   role,
 				DbName: util.AnyWord,
 			})

--- a/internal/rootcoord/list_db_task_test.go
+++ b/internal/rootcoord/list_db_task_test.go
@@ -132,7 +132,7 @@ func Test_ListDBTask(t *testing.T) {
 
 		{
 			// select role fail
-			meta.EXPECT().SelectUser(mock.Anything, mock.Anything, mock.Anything).
+			meta.EXPECT().SelectUser(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 				Return(nil, errors.New("mock select user error")).Once()
 			ctx := GetContext(context.Background(), "foo:root")
 			task := getTask()
@@ -142,7 +142,7 @@ func Test_ListDBTask(t *testing.T) {
 
 		{
 			// select role, empty result
-			meta.EXPECT().SelectUser(mock.Anything, mock.Anything, mock.Anything).
+			meta.EXPECT().SelectUser(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 				Return([]*milvuspb.UserResult{}, nil).Once()
 			ctx := GetContext(context.Background(), "foo:root")
 			task := getTask()
@@ -153,7 +153,7 @@ func Test_ListDBTask(t *testing.T) {
 
 		{
 			// select role, the user is added to admin role
-			meta.EXPECT().SelectUser(mock.Anything, mock.Anything, mock.Anything).
+			meta.EXPECT().SelectUser(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 				Return([]*milvuspb.UserResult{
 					{
 						User: &milvuspb.UserEntity{
@@ -176,7 +176,7 @@ func Test_ListDBTask(t *testing.T) {
 
 		{
 			// select grant fail
-			meta.EXPECT().SelectUser(mock.Anything, mock.Anything, mock.Anything).
+			meta.EXPECT().SelectUser(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 				Return([]*milvuspb.UserResult{
 					{
 						User: &milvuspb.UserEntity{
@@ -189,7 +189,7 @@ func Test_ListDBTask(t *testing.T) {
 						},
 					},
 				}, nil).Once()
-			meta.EXPECT().SelectGrant(mock.Anything, mock.Anything).
+			meta.EXPECT().SelectGrant(mock.Anything, mock.Anything, mock.Anything).
 				Return(nil, errors.New("mock select grant error")).Once()
 			ctx := GetContext(context.Background(), "foo:root")
 			task := getTask()
@@ -199,7 +199,7 @@ func Test_ListDBTask(t *testing.T) {
 
 		{
 			// normal user
-			meta.EXPECT().SelectUser(mock.Anything, mock.Anything, mock.Anything).
+			meta.EXPECT().SelectUser(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 				Return([]*milvuspb.UserResult{
 					{
 						User: &milvuspb.UserEntity{
@@ -220,7 +220,7 @@ func Test_ListDBTask(t *testing.T) {
 					Name: "default",
 				},
 			}, nil).Once()
-			meta.EXPECT().SelectGrant(mock.Anything, mock.Anything).
+			meta.EXPECT().SelectGrant(mock.Anything, mock.Anything, mock.Anything).
 				Return([]*milvuspb.GrantEntity{
 					{
 						DbName: "fooDB",
@@ -236,7 +236,7 @@ func Test_ListDBTask(t *testing.T) {
 
 		{
 			// normal user with any db privilege
-			meta.EXPECT().SelectUser(mock.Anything, mock.Anything, mock.Anything).
+			meta.EXPECT().SelectUser(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 				Return([]*milvuspb.UserResult{
 					{
 						User: &milvuspb.UserEntity{
@@ -257,7 +257,7 @@ func Test_ListDBTask(t *testing.T) {
 					Name: "default",
 				},
 			}, nil).Once()
-			meta.EXPECT().SelectGrant(mock.Anything, mock.Anything).
+			meta.EXPECT().SelectGrant(mock.Anything, mock.Anything, mock.Anything).
 				Return([]*milvuspb.GrantEntity{
 					{
 						DbName: "*",

--- a/internal/rootcoord/meta_table.go
+++ b/internal/rootcoord/meta_table.go
@@ -61,9 +61,9 @@ type IMetaTable interface {
 	GetCollectionByIDWithMaxTs(ctx context.Context, collectionID UniqueID) (*model.Collection, error)
 	ListCollections(ctx context.Context, dbName string, ts Timestamp, onlyAvail bool) ([]*model.Collection, error)
 	ListAllAvailCollections(ctx context.Context) map[int64][]int64
-	ListCollectionPhysicalChannels() map[typeutil.UniqueID][]string
-	GetCollectionVirtualChannels(colID int64) []string
-	GetPChannelInfo(pchannel string) *rootcoordpb.GetPChannelInfoResponse
+	ListCollectionPhysicalChannels(ctx context.Context) map[typeutil.UniqueID][]string
+	GetCollectionVirtualChannels(ctx context.Context, colID int64) []string
+	GetPChannelInfo(ctx context.Context, pchannel string) *rootcoordpb.GetPChannelInfoResponse
 	AddPartition(ctx context.Context, partition *model.Partition) error
 	ChangePartitionState(ctx context.Context, collectionID UniqueID, partitionID UniqueID, state pb.PartitionState, ts Timestamp) error
 	RemovePartition(ctx context.Context, dbID int64, collectionID UniqueID, partitionID UniqueID, ts Timestamp) error
@@ -76,35 +76,33 @@ type IMetaTable interface {
 	RenameCollection(ctx context.Context, dbName string, oldName string, newDBName string, newName string, ts Timestamp) error
 
 	// TODO: it'll be a big cost if we handle the time travel logic, since we should always list all aliases in catalog.
-	IsAlias(db, name string) bool
-	ListAliasesByID(collID UniqueID) []string
+	IsAlias(ctx context.Context, db, name string) bool
+	ListAliasesByID(ctx context.Context, collID UniqueID) []string
 
-	// TODO: better to accept ctx.
-	AddCredential(credInfo *internalpb.CredentialInfo) error
-	GetCredential(username string) (*internalpb.CredentialInfo, error)
-	DeleteCredential(username string) error
-	AlterCredential(credInfo *internalpb.CredentialInfo) error
-	ListCredentialUsernames() (*milvuspb.ListCredUsersResponse, error)
+	AddCredential(ctx context.Context, credInfo *internalpb.CredentialInfo) error
+	GetCredential(ctx context.Context, username string) (*internalpb.CredentialInfo, error)
+	DeleteCredential(ctx context.Context, username string) error
+	AlterCredential(ctx context.Context, credInfo *internalpb.CredentialInfo) error
+	ListCredentialUsernames(ctx context.Context) (*milvuspb.ListCredUsersResponse, error)
 
-	// TODO: better to accept ctx.
-	CreateRole(tenant string, entity *milvuspb.RoleEntity) error
-	DropRole(tenant string, roleName string) error
-	OperateUserRole(tenant string, userEntity *milvuspb.UserEntity, roleEntity *milvuspb.RoleEntity, operateType milvuspb.OperateUserRoleType) error
-	SelectRole(tenant string, entity *milvuspb.RoleEntity, includeUserInfo bool) ([]*milvuspb.RoleResult, error)
-	SelectUser(tenant string, entity *milvuspb.UserEntity, includeRoleInfo bool) ([]*milvuspb.UserResult, error)
-	OperatePrivilege(tenant string, entity *milvuspb.GrantEntity, operateType milvuspb.OperatePrivilegeType) error
-	SelectGrant(tenant string, entity *milvuspb.GrantEntity) ([]*milvuspb.GrantEntity, error)
-	DropGrant(tenant string, role *milvuspb.RoleEntity) error
-	ListPolicy(tenant string) ([]string, error)
-	ListUserRole(tenant string) ([]string, error)
+	CreateRole(ctx context.Context, tenant string, entity *milvuspb.RoleEntity) error
+	DropRole(ctx context.Context, tenant string, roleName string) error
+	OperateUserRole(ctx context.Context, tenant string, userEntity *milvuspb.UserEntity, roleEntity *milvuspb.RoleEntity, operateType milvuspb.OperateUserRoleType) error
+	SelectRole(ctx context.Context, tenant string, entity *milvuspb.RoleEntity, includeUserInfo bool) ([]*milvuspb.RoleResult, error)
+	SelectUser(ctx context.Context, tenant string, entity *milvuspb.UserEntity, includeRoleInfo bool) ([]*milvuspb.UserResult, error)
+	OperatePrivilege(ctx context.Context, tenant string, entity *milvuspb.GrantEntity, operateType milvuspb.OperatePrivilegeType) error
+	SelectGrant(ctx context.Context, tenant string, entity *milvuspb.GrantEntity) ([]*milvuspb.GrantEntity, error)
+	DropGrant(ctx context.Context, tenant string, role *milvuspb.RoleEntity) error
+	ListPolicy(ctx context.Context, tenant string) ([]string, error)
+	ListUserRole(ctx context.Context, tenant string) ([]string, error)
 	BackupRBAC(ctx context.Context, tenant string) (*milvuspb.RBACMeta, error)
 	RestoreRBAC(ctx context.Context, tenant string, meta *milvuspb.RBACMeta) error
-	IsCustomPrivilegeGroup(groupName string) (bool, error)
-	CreatePrivilegeGroup(groupName string) error
-	DropPrivilegeGroup(groupName string) error
-	ListPrivilegeGroups() ([]*milvuspb.PrivilegeGroupInfo, error)
-	OperatePrivilegeGroup(groupName string, privileges []*milvuspb.PrivilegeEntity, operateType milvuspb.OperatePrivilegeGroupType) error
-	GetPrivilegeGroupRoles(groupName string) ([]*milvuspb.RoleEntity, error)
+	IsCustomPrivilegeGroup(ctx context.Context, groupName string) (bool, error)
+	CreatePrivilegeGroup(ctx context.Context, groupName string) error
+	DropPrivilegeGroup(ctx context.Context, groupName string) error
+	ListPrivilegeGroups(ctx context.Context) ([]*milvuspb.PrivilegeGroupInfo, error)
+	OperatePrivilegeGroup(ctx context.Context, groupName string, privileges []*milvuspb.PrivilegeEntity, operateType milvuspb.OperatePrivilegeGroupType) error
+	GetPrivilegeGroupRoles(ctx context.Context, groupName string) ([]*milvuspb.RoleEntity, error)
 }
 
 // MetaTable is a persistent meta set of all databases, collections and partitions.
@@ -729,7 +727,7 @@ func (mt *MetaTable) listCollectionFromCache(dbName string, onlyAvail bool) ([]*
 }
 
 // ListCollectionPhysicalChannels list physical channels of all collections.
-func (mt *MetaTable) ListCollectionPhysicalChannels() map[typeutil.UniqueID][]string {
+func (mt *MetaTable) ListCollectionPhysicalChannels(ctx context.Context) map[typeutil.UniqueID][]string {
 	mt.ddLock.RLock()
 	defer mt.ddLock.RUnlock()
 
@@ -838,7 +836,7 @@ func (mt *MetaTable) RenameCollection(ctx context.Context, dbName string, oldNam
 }
 
 // GetCollectionVirtualChannels returns virtual channels of a given collection.
-func (mt *MetaTable) GetCollectionVirtualChannels(colID int64) []string {
+func (mt *MetaTable) GetCollectionVirtualChannels(ctx context.Context, colID int64) []string {
 	mt.ddLock.RLock()
 	defer mt.ddLock.RUnlock()
 	for id, collInfo := range mt.collID2Meta {
@@ -850,7 +848,7 @@ func (mt *MetaTable) GetCollectionVirtualChannels(colID int64) []string {
 }
 
 // GetPChannelInfo returns infos on pchannel.
-func (mt *MetaTable) GetPChannelInfo(pchannel string) *rootcoordpb.GetPChannelInfoResponse {
+func (mt *MetaTable) GetPChannelInfo(ctx context.Context, pchannel string) *rootcoordpb.GetPChannelInfoResponse {
 	mt.ddLock.RLock()
 	defer mt.ddLock.RUnlock()
 	resp := &rootcoordpb.GetPChannelInfoResponse{
@@ -1199,7 +1197,7 @@ func (mt *MetaTable) ListAliases(ctx context.Context, dbName string, collectionN
 	return aliases, nil
 }
 
-func (mt *MetaTable) IsAlias(db, name string) bool {
+func (mt *MetaTable) IsAlias(ctx context.Context, db, name string) bool {
 	mt.ddLock.RLock()
 	defer mt.ddLock.RUnlock()
 
@@ -1218,7 +1216,7 @@ func (mt *MetaTable) listAliasesByID(collID UniqueID) []string {
 	return ret
 }
 
-func (mt *MetaTable) ListAliasesByID(collID UniqueID) []string {
+func (mt *MetaTable) ListAliasesByID(ctx context.Context, collID UniqueID) []string {
 	mt.ddLock.RLock()
 	defer mt.ddLock.RUnlock()
 
@@ -1226,14 +1224,14 @@ func (mt *MetaTable) ListAliasesByID(collID UniqueID) []string {
 }
 
 // AddCredential add credential
-func (mt *MetaTable) AddCredential(credInfo *internalpb.CredentialInfo) error {
+func (mt *MetaTable) AddCredential(ctx context.Context, credInfo *internalpb.CredentialInfo) error {
 	if credInfo.Username == "" {
 		return fmt.Errorf("username is empty")
 	}
 	mt.permissionLock.Lock()
 	defer mt.permissionLock.Unlock()
 
-	usernames, err := mt.catalog.ListCredentials(mt.ctx)
+	usernames, err := mt.catalog.ListCredentials(ctx)
 	if err != nil {
 		return err
 	}
@@ -1243,7 +1241,7 @@ func (mt *MetaTable) AddCredential(credInfo *internalpb.CredentialInfo) error {
 		return errors.New(errMsg)
 	}
 
-	if origin, _ := mt.catalog.GetCredential(mt.ctx, credInfo.Username); origin != nil {
+	if origin, _ := mt.catalog.GetCredential(ctx, credInfo.Username); origin != nil {
 		return fmt.Errorf("user already exists: %s", credInfo.Username)
 	}
 
@@ -1251,11 +1249,11 @@ func (mt *MetaTable) AddCredential(credInfo *internalpb.CredentialInfo) error {
 		Username:          credInfo.Username,
 		EncryptedPassword: credInfo.EncryptedPassword,
 	}
-	return mt.catalog.CreateCredential(mt.ctx, credential)
+	return mt.catalog.CreateCredential(ctx, credential)
 }
 
 // AlterCredential update credential
-func (mt *MetaTable) AlterCredential(credInfo *internalpb.CredentialInfo) error {
+func (mt *MetaTable) AlterCredential(ctx context.Context, credInfo *internalpb.CredentialInfo) error {
 	if credInfo.Username == "" {
 		return fmt.Errorf("username is empty")
 	}
@@ -1267,32 +1265,32 @@ func (mt *MetaTable) AlterCredential(credInfo *internalpb.CredentialInfo) error 
 		Username:          credInfo.Username,
 		EncryptedPassword: credInfo.EncryptedPassword,
 	}
-	return mt.catalog.AlterCredential(mt.ctx, credential)
+	return mt.catalog.AlterCredential(ctx, credential)
 }
 
 // GetCredential get credential by username
-func (mt *MetaTable) GetCredential(username string) (*internalpb.CredentialInfo, error) {
+func (mt *MetaTable) GetCredential(ctx context.Context, username string) (*internalpb.CredentialInfo, error) {
 	mt.permissionLock.RLock()
 	defer mt.permissionLock.RUnlock()
 
-	credential, err := mt.catalog.GetCredential(mt.ctx, username)
+	credential, err := mt.catalog.GetCredential(ctx, username)
 	return model.MarshalCredentialModel(credential), err
 }
 
 // DeleteCredential delete credential
-func (mt *MetaTable) DeleteCredential(username string) error {
+func (mt *MetaTable) DeleteCredential(ctx context.Context, username string) error {
 	mt.permissionLock.Lock()
 	defer mt.permissionLock.Unlock()
 
-	return mt.catalog.DropCredential(mt.ctx, username)
+	return mt.catalog.DropCredential(ctx, username)
 }
 
 // ListCredentialUsernames list credential usernames
-func (mt *MetaTable) ListCredentialUsernames() (*milvuspb.ListCredUsersResponse, error) {
+func (mt *MetaTable) ListCredentialUsernames(ctx context.Context) (*milvuspb.ListCredUsersResponse, error) {
 	mt.permissionLock.RLock()
 	defer mt.permissionLock.RUnlock()
 
-	usernames, err := mt.catalog.ListCredentials(mt.ctx)
+	usernames, err := mt.catalog.ListCredentials(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("list credential usernames err:%w", err)
 	}
@@ -1300,14 +1298,14 @@ func (mt *MetaTable) ListCredentialUsernames() (*milvuspb.ListCredUsersResponse,
 }
 
 // CreateRole create role
-func (mt *MetaTable) CreateRole(tenant string, entity *milvuspb.RoleEntity) error {
+func (mt *MetaTable) CreateRole(ctx context.Context, tenant string, entity *milvuspb.RoleEntity) error {
 	if funcutil.IsEmptyString(entity.Name) {
 		return fmt.Errorf("the role name in the role info is empty")
 	}
 	mt.permissionLock.Lock()
 	defer mt.permissionLock.Unlock()
 
-	results, err := mt.catalog.ListRole(mt.ctx, tenant, nil, false)
+	results, err := mt.catalog.ListRole(ctx, tenant, nil, false)
 	if err != nil {
 		log.Warn("fail to list roles", zap.Error(err))
 		return err
@@ -1324,19 +1322,19 @@ func (mt *MetaTable) CreateRole(tenant string, entity *milvuspb.RoleEntity) erro
 		return errors.New(errMsg)
 	}
 
-	return mt.catalog.CreateRole(mt.ctx, tenant, entity)
+	return mt.catalog.CreateRole(ctx, tenant, entity)
 }
 
 // DropRole drop role info
-func (mt *MetaTable) DropRole(tenant string, roleName string) error {
+func (mt *MetaTable) DropRole(ctx context.Context, tenant string, roleName string) error {
 	mt.permissionLock.Lock()
 	defer mt.permissionLock.Unlock()
 
-	return mt.catalog.DropRole(mt.ctx, tenant, roleName)
+	return mt.catalog.DropRole(ctx, tenant, roleName)
 }
 
 // OperateUserRole operate the relationship between a user and a role, including adding a user to a role and removing a user from a role
-func (mt *MetaTable) OperateUserRole(tenant string, userEntity *milvuspb.UserEntity, roleEntity *milvuspb.RoleEntity, operateType milvuspb.OperateUserRoleType) error {
+func (mt *MetaTable) OperateUserRole(ctx context.Context, tenant string, userEntity *milvuspb.UserEntity, roleEntity *milvuspb.RoleEntity, operateType milvuspb.OperateUserRoleType) error {
 	if funcutil.IsEmptyString(userEntity.Name) {
 		return fmt.Errorf("username in the user entity is empty")
 	}
@@ -1347,31 +1345,31 @@ func (mt *MetaTable) OperateUserRole(tenant string, userEntity *milvuspb.UserEnt
 	mt.permissionLock.Lock()
 	defer mt.permissionLock.Unlock()
 
-	return mt.catalog.AlterUserRole(mt.ctx, tenant, userEntity, roleEntity, operateType)
+	return mt.catalog.AlterUserRole(ctx, tenant, userEntity, roleEntity, operateType)
 }
 
 // SelectRole select role.
 // Enter the role condition by the entity param. And this param is nil, which means selecting all roles.
 // Get all users that are added to the role by setting the includeUserInfo param to true.
-func (mt *MetaTable) SelectRole(tenant string, entity *milvuspb.RoleEntity, includeUserInfo bool) ([]*milvuspb.RoleResult, error) {
+func (mt *MetaTable) SelectRole(ctx context.Context, tenant string, entity *milvuspb.RoleEntity, includeUserInfo bool) ([]*milvuspb.RoleResult, error) {
 	mt.permissionLock.RLock()
 	defer mt.permissionLock.RUnlock()
 
-	return mt.catalog.ListRole(mt.ctx, tenant, entity, includeUserInfo)
+	return mt.catalog.ListRole(ctx, tenant, entity, includeUserInfo)
 }
 
 // SelectUser select user.
 // Enter the user condition by the entity param. And this param is nil, which means selecting all users.
 // Get all roles that are added the user to by setting the includeRoleInfo param to true.
-func (mt *MetaTable) SelectUser(tenant string, entity *milvuspb.UserEntity, includeRoleInfo bool) ([]*milvuspb.UserResult, error) {
+func (mt *MetaTable) SelectUser(ctx context.Context, tenant string, entity *milvuspb.UserEntity, includeRoleInfo bool) ([]*milvuspb.UserResult, error) {
 	mt.permissionLock.RLock()
 	defer mt.permissionLock.RUnlock()
 
-	return mt.catalog.ListUser(mt.ctx, tenant, entity, includeRoleInfo)
+	return mt.catalog.ListUser(ctx, tenant, entity, includeRoleInfo)
 }
 
 // OperatePrivilege grant or revoke privilege by setting the operateType param
-func (mt *MetaTable) OperatePrivilege(tenant string, entity *milvuspb.GrantEntity, operateType milvuspb.OperatePrivilegeType) error {
+func (mt *MetaTable) OperatePrivilege(ctx context.Context, tenant string, entity *milvuspb.GrantEntity, operateType milvuspb.OperatePrivilegeType) error {
 	if funcutil.IsEmptyString(entity.ObjectName) {
 		return fmt.Errorf("the object name in the grant entity is empty")
 	}
@@ -1400,13 +1398,13 @@ func (mt *MetaTable) OperatePrivilege(tenant string, entity *milvuspb.GrantEntit
 	mt.permissionLock.Lock()
 	defer mt.permissionLock.Unlock()
 
-	return mt.catalog.AlterGrant(mt.ctx, tenant, entity, operateType)
+	return mt.catalog.AlterGrant(ctx, tenant, entity, operateType)
 }
 
 // SelectGrant select grant
 // The principal entity MUST be not empty in the grant entity
 // The resource entity and the resource name are optional, and the two params should be not empty together when you select some grants about the resource kind.
-func (mt *MetaTable) SelectGrant(tenant string, entity *milvuspb.GrantEntity) ([]*milvuspb.GrantEntity, error) {
+func (mt *MetaTable) SelectGrant(ctx context.Context, tenant string, entity *milvuspb.GrantEntity) ([]*milvuspb.GrantEntity, error) {
 	var entities []*milvuspb.GrantEntity
 	if entity == nil {
 		return entities, fmt.Errorf("the grant entity is nil")
@@ -1422,50 +1420,50 @@ func (mt *MetaTable) SelectGrant(tenant string, entity *milvuspb.GrantEntity) ([
 	mt.permissionLock.RLock()
 	defer mt.permissionLock.RUnlock()
 
-	return mt.catalog.ListGrant(mt.ctx, tenant, entity)
+	return mt.catalog.ListGrant(ctx, tenant, entity)
 }
 
-func (mt *MetaTable) DropGrant(tenant string, role *milvuspb.RoleEntity) error {
+func (mt *MetaTable) DropGrant(ctx context.Context, tenant string, role *milvuspb.RoleEntity) error {
 	if role == nil || funcutil.IsEmptyString(role.Name) {
 		return fmt.Errorf("the role entity is invalid when dropping the grant")
 	}
 	mt.permissionLock.Lock()
 	defer mt.permissionLock.Unlock()
 
-	return mt.catalog.DeleteGrant(mt.ctx, tenant, role)
+	return mt.catalog.DeleteGrant(ctx, tenant, role)
 }
 
-func (mt *MetaTable) ListPolicy(tenant string) ([]string, error) {
+func (mt *MetaTable) ListPolicy(ctx context.Context, tenant string) ([]string, error) {
 	mt.permissionLock.RLock()
 	defer mt.permissionLock.RUnlock()
 
-	return mt.catalog.ListPolicy(mt.ctx, tenant)
+	return mt.catalog.ListPolicy(ctx, tenant)
 }
 
-func (mt *MetaTable) ListUserRole(tenant string) ([]string, error) {
+func (mt *MetaTable) ListUserRole(ctx context.Context, tenant string) ([]string, error) {
 	mt.permissionLock.RLock()
 	defer mt.permissionLock.RUnlock()
 
-	return mt.catalog.ListUserRole(mt.ctx, tenant)
+	return mt.catalog.ListUserRole(ctx, tenant)
 }
 
 func (mt *MetaTable) BackupRBAC(ctx context.Context, tenant string) (*milvuspb.RBACMeta, error) {
 	mt.permissionLock.RLock()
 	defer mt.permissionLock.RUnlock()
 
-	return mt.catalog.BackupRBAC(mt.ctx, tenant)
+	return mt.catalog.BackupRBAC(ctx, tenant)
 }
 
 func (mt *MetaTable) RestoreRBAC(ctx context.Context, tenant string, meta *milvuspb.RBACMeta) error {
 	mt.permissionLock.Lock()
 	defer mt.permissionLock.Unlock()
 
-	return mt.catalog.RestoreRBAC(mt.ctx, tenant, meta)
+	return mt.catalog.RestoreRBAC(ctx, tenant, meta)
 }
 
 // check if the privielge group name is defined by users
-func (mt *MetaTable) IsCustomPrivilegeGroup(groupName string) (bool, error) {
-	privGroups, err := mt.catalog.ListPrivilegeGroups(mt.ctx)
+func (mt *MetaTable) IsCustomPrivilegeGroup(ctx context.Context, groupName string) (bool, error) {
+	privGroups, err := mt.catalog.ListPrivilegeGroups(ctx)
 	if err != nil {
 		return false, err
 	}
@@ -1477,14 +1475,14 @@ func (mt *MetaTable) IsCustomPrivilegeGroup(groupName string) (bool, error) {
 	return false, nil
 }
 
-func (mt *MetaTable) CreatePrivilegeGroup(groupName string) error {
+func (mt *MetaTable) CreatePrivilegeGroup(ctx context.Context, groupName string) error {
 	if funcutil.IsEmptyString(groupName) {
 		return fmt.Errorf("the privilege group name is empty")
 	}
 	mt.permissionLock.Lock()
 	defer mt.permissionLock.Unlock()
 
-	definedByUsers, err := mt.IsCustomPrivilegeGroup(groupName)
+	definedByUsers, err := mt.IsCustomPrivilegeGroup(ctx, groupName)
 	if err != nil {
 		return err
 	}
@@ -1498,17 +1496,17 @@ func (mt *MetaTable) CreatePrivilegeGroup(groupName string) error {
 		GroupName:  groupName,
 		Privileges: make([]*milvuspb.PrivilegeEntity, 0),
 	}
-	return mt.catalog.SavePrivilegeGroup(mt.ctx, data)
+	return mt.catalog.SavePrivilegeGroup(ctx, data)
 }
 
-func (mt *MetaTable) DropPrivilegeGroup(groupName string) error {
+func (mt *MetaTable) DropPrivilegeGroup(ctx context.Context, groupName string) error {
 	if funcutil.IsEmptyString(groupName) {
 		return fmt.Errorf("the privilege group name is empty")
 	}
 	mt.permissionLock.Lock()
 	defer mt.permissionLock.Unlock()
 
-	definedByUsers, err := mt.IsCustomPrivilegeGroup(groupName)
+	definedByUsers, err := mt.IsCustomPrivilegeGroup(ctx, groupName)
 	if err != nil {
 		return err
 	}
@@ -1516,7 +1514,7 @@ func (mt *MetaTable) DropPrivilegeGroup(groupName string) error {
 		return nil
 	}
 	// check if the group is used by any role
-	roles, err := mt.catalog.ListRole(mt.ctx, util.DefaultTenant, nil, false)
+	roles, err := mt.catalog.ListRole(ctx, util.DefaultTenant, nil, false)
 	if err != nil {
 		return err
 	}
@@ -1524,7 +1522,7 @@ func (mt *MetaTable) DropPrivilegeGroup(groupName string) error {
 		return entity.GetRole()
 	})
 	for _, role := range roleEntity {
-		grants, err := mt.catalog.ListGrant(mt.ctx, util.DefaultTenant, &milvuspb.GrantEntity{
+		grants, err := mt.catalog.ListGrant(ctx, util.DefaultTenant, &milvuspb.GrantEntity{
 			Role:   role,
 			DbName: util.AnyWord,
 		})
@@ -1537,17 +1535,17 @@ func (mt *MetaTable) DropPrivilegeGroup(groupName string) error {
 			}
 		}
 	}
-	return mt.catalog.DropPrivilegeGroup(mt.ctx, groupName)
+	return mt.catalog.DropPrivilegeGroup(ctx, groupName)
 }
 
-func (mt *MetaTable) ListPrivilegeGroups() ([]*milvuspb.PrivilegeGroupInfo, error) {
+func (mt *MetaTable) ListPrivilegeGroups(ctx context.Context) ([]*milvuspb.PrivilegeGroupInfo, error) {
 	mt.permissionLock.Lock()
 	defer mt.permissionLock.Unlock()
 
-	return mt.catalog.ListPrivilegeGroups(mt.ctx)
+	return mt.catalog.ListPrivilegeGroups(ctx)
 }
 
-func (mt *MetaTable) OperatePrivilegeGroup(groupName string, privileges []*milvuspb.PrivilegeEntity, operateType milvuspb.OperatePrivilegeGroupType) error {
+func (mt *MetaTable) OperatePrivilegeGroup(ctx context.Context, groupName string, privileges []*milvuspb.PrivilegeEntity, operateType milvuspb.OperatePrivilegeGroupType) error {
 	if funcutil.IsEmptyString(groupName) {
 		return fmt.Errorf("the privilege group name is empty")
 	}
@@ -1555,14 +1553,14 @@ func (mt *MetaTable) OperatePrivilegeGroup(groupName string, privileges []*milvu
 	defer mt.permissionLock.Unlock()
 
 	// validate input params
-	definedByUsers, err := mt.IsCustomPrivilegeGroup(groupName)
+	definedByUsers, err := mt.IsCustomPrivilegeGroup(ctx, groupName)
 	if err != nil {
 		return err
 	}
 	if !definedByUsers {
 		return merr.WrapErrParameterInvalidMsg("there is no privilege group name [%s] to operate", groupName)
 	}
-	groups, err := mt.catalog.ListPrivilegeGroups(mt.ctx)
+	groups, err := mt.catalog.ListPrivilegeGroups(ctx)
 	if err != nil {
 		return err
 	}
@@ -1581,7 +1579,7 @@ func (mt *MetaTable) OperatePrivilegeGroup(groupName string, privileges []*milvu
 	}
 
 	// merge with current privileges
-	group, err := mt.catalog.GetPrivilegeGroup(mt.ctx, groupName)
+	group, err := mt.catalog.GetPrivilegeGroup(ctx, groupName)
 	if err != nil {
 		log.Warn("fail to get privilege group", zap.String("privilege_group", groupName), zap.Error(err))
 		return err
@@ -1610,10 +1608,10 @@ func (mt *MetaTable) OperatePrivilegeGroup(groupName string, privileges []*milvu
 		GroupName:  groupName,
 		Privileges: mergedPrivs,
 	}
-	return mt.catalog.SavePrivilegeGroup(mt.ctx, data)
+	return mt.catalog.SavePrivilegeGroup(ctx, data)
 }
 
-func (mt *MetaTable) GetPrivilegeGroupRoles(groupName string) ([]*milvuspb.RoleEntity, error) {
+func (mt *MetaTable) GetPrivilegeGroupRoles(ctx context.Context, groupName string) ([]*milvuspb.RoleEntity, error) {
 	if funcutil.IsEmptyString(groupName) {
 		return nil, fmt.Errorf("the privilege group name is empty")
 	}
@@ -1621,7 +1619,7 @@ func (mt *MetaTable) GetPrivilegeGroupRoles(groupName string) ([]*milvuspb.RoleE
 	defer mt.permissionLock.RUnlock()
 
 	// get all roles
-	roles, err := mt.catalog.ListRole(mt.ctx, util.DefaultTenant, nil, false)
+	roles, err := mt.catalog.ListRole(ctx, util.DefaultTenant, nil, false)
 	if err != nil {
 		return nil, err
 	}
@@ -1631,7 +1629,7 @@ func (mt *MetaTable) GetPrivilegeGroupRoles(groupName string) ([]*milvuspb.RoleE
 
 	rolesMap := make(map[*milvuspb.RoleEntity]struct{})
 	for _, role := range roleEntity {
-		grants, err := mt.catalog.ListGrant(mt.ctx, util.DefaultTenant, &milvuspb.GrantEntity{
+		grants, err := mt.catalog.ListGrant(ctx, util.DefaultTenant, &milvuspb.GrantEntity{
 			Role:   role,
 			DbName: util.AnyWord,
 		})

--- a/internal/rootcoord/meta_table_test.go
+++ b/internal/rootcoord/meta_table_test.go
@@ -48,7 +48,7 @@ func generateMetaTable(t *testing.T) *MetaTable {
 
 func TestRbacAddCredential(t *testing.T) {
 	mt := generateMetaTable(t)
-	err := mt.AddCredential(&internalpb.CredentialInfo{
+	err := mt.AddCredential(context.TODO(), &internalpb.CredentialInfo{
 		Username: "user1",
 		Tenant:   util.DefaultTenant,
 	})
@@ -73,7 +73,7 @@ func TestRbacAddCredential(t *testing.T) {
 				paramtable.Get().Save(Params.ProxyCfg.MaxUserNum.Key, "3")
 			}
 			defer paramtable.Get().Reset(Params.ProxyCfg.MaxUserNum.Key)
-			err := mt.AddCredential(test.info)
+			err := mt.AddCredential(context.TODO(), test.info)
 			assert.Error(t, err)
 		})
 	}
@@ -84,9 +84,9 @@ func TestRbacCreateRole(t *testing.T) {
 
 	paramtable.Get().Save(Params.ProxyCfg.MaxRoleNum.Key, "2")
 	defer paramtable.Get().Reset(Params.ProxyCfg.MaxRoleNum.Key)
-	err := mt.CreateRole(util.DefaultTenant, &milvuspb.RoleEntity{Name: "role1"})
+	err := mt.CreateRole(context.TODO(), util.DefaultTenant, &milvuspb.RoleEntity{Name: "role1"})
 	require.NoError(t, err)
-	err = mt.CreateRole(util.DefaultTenant, &milvuspb.RoleEntity{Name: "role2"})
+	err = mt.CreateRole(context.TODO(), util.DefaultTenant, &milvuspb.RoleEntity{Name: "role2"})
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -100,12 +100,12 @@ func TestRbacCreateRole(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			err := mt.CreateRole(util.DefaultTenant, test.inEntity)
+			err := mt.CreateRole(context.TODO(), util.DefaultTenant, test.inEntity)
 			assert.Error(t, err)
 		})
 	}
 	t.Run("role has existed", func(t *testing.T) {
-		err := mt.CreateRole(util.DefaultTenant, &milvuspb.RoleEntity{Name: "role1"})
+		err := mt.CreateRole(context.TODO(), util.DefaultTenant, &milvuspb.RoleEntity{Name: "role1"})
 		assert.Error(t, err)
 		assert.True(t, common.IsIgnorableError(err))
 	})
@@ -119,7 +119,7 @@ func TestRbacCreateRole(t *testing.T) {
 			mock.Anything,
 		).Return(nil, errors.New("error mock list role"))
 		mockMt := &MetaTable{catalog: mockCata}
-		err := mockMt.CreateRole(util.DefaultTenant, &milvuspb.RoleEntity{Name: "role1"})
+		err := mockMt.CreateRole(context.TODO(), util.DefaultTenant, &milvuspb.RoleEntity{Name: "role1"})
 		assert.Error(t, err)
 	}
 }
@@ -127,7 +127,7 @@ func TestRbacCreateRole(t *testing.T) {
 func TestRbacDropRole(t *testing.T) {
 	mt := generateMetaTable(t)
 
-	err := mt.CreateRole(util.DefaultTenant, &milvuspb.RoleEntity{Name: "role1"})
+	err := mt.CreateRole(context.TODO(), util.DefaultTenant, &milvuspb.RoleEntity{Name: "role1"})
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -141,7 +141,7 @@ func TestRbacDropRole(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			err := mt.DropRole(util.DefaultTenant, test.roleName)
+			err := mt.DropRole(context.TODO(), util.DefaultTenant, test.roleName)
 			assert.NoError(t, err)
 		})
 	}
@@ -149,7 +149,7 @@ func TestRbacDropRole(t *testing.T) {
 
 func TestRbacOperateRole(t *testing.T) {
 	mt := generateMetaTable(t)
-	err := mt.CreateRole(util.DefaultTenant, &milvuspb.RoleEntity{Name: "role1"})
+	err := mt.CreateRole(context.TODO(), util.DefaultTenant, &milvuspb.RoleEntity{Name: "role1"})
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -168,7 +168,7 @@ func TestRbacOperateRole(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			err := mt.OperateUserRole(util.DefaultTenant, &milvuspb.UserEntity{Name: test.user}, &milvuspb.RoleEntity{Name: test.role}, test.oType)
+			err := mt.OperateUserRole(context.TODO(), util.DefaultTenant, &milvuspb.UserEntity{Name: test.user}, &milvuspb.RoleEntity{Name: test.role}, test.oType)
 			assert.Error(t, err)
 		})
 	}
@@ -185,7 +185,7 @@ func TestRbacSelect(t *testing.T) {
 	}
 
 	for _, role := range roles {
-		err := mt.CreateRole(util.DefaultTenant, &milvuspb.RoleEntity{Name: role})
+		err := mt.CreateRole(context.TODO(), util.DefaultTenant, &milvuspb.RoleEntity{Name: role})
 		require.NoError(t, err)
 	}
 
@@ -198,6 +198,7 @@ func TestRbacSelect(t *testing.T) {
 		require.NoError(t, err)
 		for _, r := range rs {
 			err := mt.OperateUserRole(
+				context.TODO(),
 				util.DefaultTenant,
 				&milvuspb.UserEntity{Name: user},
 				&milvuspb.RoleEntity{Name: r},
@@ -226,7 +227,7 @@ func TestRbacSelect(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			res, err := mt.SelectUser(util.DefaultTenant, test.inEntity, test.includeRoleInfo)
+			res, err := mt.SelectUser(context.TODO(), util.DefaultTenant, test.inEntity, test.includeRoleInfo)
 
 			if test.isValid {
 				assert.NoError(t, err)
@@ -264,7 +265,7 @@ func TestRbacSelect(t *testing.T) {
 
 	for _, test := range testRoles {
 		t.Run(test.description, func(t *testing.T) {
-			res, err := mt.SelectRole(util.DefaultTenant, test.inEntity, test.includeUserInfo)
+			res, err := mt.SelectRole(context.TODO(), util.DefaultTenant, test.inEntity, test.includeUserInfo)
 
 			if test.isValid {
 				assert.NoError(t, err)
@@ -357,7 +358,7 @@ func TestRbacOperatePrivilege(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			err := mt.OperatePrivilege(util.DefaultTenant, test.entity, test.oType)
+			err := mt.OperatePrivilege(context.TODO(), util.DefaultTenant, test.entity, test.oType)
 			assert.Error(t, err)
 		})
 	}
@@ -372,7 +373,7 @@ func TestRbacOperatePrivilege(t *testing.T) {
 		ObjectName: "obj_name",
 	}
 
-	err := mt.OperatePrivilege(util.DefaultTenant, &validEntity, milvuspb.OperatePrivilegeType_Grant)
+	err := mt.OperatePrivilege(context.TODO(), util.DefaultTenant, &validEntity, milvuspb.OperatePrivilegeType_Grant)
 	assert.NoError(t, err)
 }
 
@@ -399,7 +400,7 @@ func TestRbacSelectGrant(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			entities, err := mt.SelectGrant(util.DefaultTenant, test.entity)
+			entities, err := mt.SelectGrant(context.TODO(), util.DefaultTenant, test.entity)
 			if test.isValid {
 				assert.NoError(t, err)
 				assert.Equal(t, 0, len(entities))
@@ -426,7 +427,7 @@ func TestRbacDropGrant(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			err := mt.DropGrant(util.DefaultTenant, test.role)
+			err := mt.DropGrant(context.TODO(), util.DefaultTenant, test.role)
 			if test.isValid {
 				assert.NoError(t, err)
 			} else {
@@ -439,11 +440,11 @@ func TestRbacDropGrant(t *testing.T) {
 func TestRbacListPolicy(t *testing.T) {
 	mt := generateMetaTable(t)
 
-	policies, err := mt.ListPolicy(util.DefaultTenant)
+	policies, err := mt.ListPolicy(context.TODO(), util.DefaultTenant)
 	assert.NoError(t, err)
 	assert.Empty(t, policies)
 
-	userRoles, err := mt.ListUserRole(util.DefaultTenant)
+	userRoles, err := mt.ListUserRole(context.TODO(), util.DefaultTenant)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(userRoles))
 }
@@ -2091,24 +2092,24 @@ func TestMetaTable_PrivilegeGroup(t *testing.T) {
 		aliases: newNameDb(),
 		catalog: catalog,
 	}
-	err := mt.CreatePrivilegeGroup("pg1")
+	err := mt.CreatePrivilegeGroup(context.TODO(), "pg1")
 	assert.Error(t, err)
-	err = mt.CreatePrivilegeGroup("")
+	err = mt.CreatePrivilegeGroup(context.TODO(), "")
 	assert.Error(t, err)
-	err = mt.CreatePrivilegeGroup("Insert")
+	err = mt.CreatePrivilegeGroup(context.TODO(), "Insert")
 	assert.Error(t, err)
-	err = mt.CreatePrivilegeGroup("pg2")
+	err = mt.CreatePrivilegeGroup(context.TODO(), "pg2")
 	assert.NoError(t, err)
-	err = mt.DropPrivilegeGroup("")
+	err = mt.DropPrivilegeGroup(context.TODO(), "")
 	assert.Error(t, err)
-	err = mt.DropPrivilegeGroup("pg1")
+	err = mt.DropPrivilegeGroup(context.TODO(), "pg1")
 	assert.NoError(t, err)
-	err = mt.OperatePrivilegeGroup("", []*milvuspb.PrivilegeEntity{}, milvuspb.OperatePrivilegeGroupType_AddPrivilegesToGroup)
+	err = mt.OperatePrivilegeGroup(context.TODO(), "", []*milvuspb.PrivilegeEntity{}, milvuspb.OperatePrivilegeGroupType_AddPrivilegesToGroup)
 	assert.Error(t, err)
-	err = mt.OperatePrivilegeGroup("pg3", []*milvuspb.PrivilegeEntity{}, milvuspb.OperatePrivilegeGroupType_AddPrivilegesToGroup)
+	err = mt.OperatePrivilegeGroup(context.TODO(), "pg3", []*milvuspb.PrivilegeEntity{}, milvuspb.OperatePrivilegeGroupType_AddPrivilegesToGroup)
 	assert.Error(t, err)
-	_, err = mt.GetPrivilegeGroupRoles("")
+	_, err = mt.GetPrivilegeGroupRoles(context.TODO(), "")
 	assert.Error(t, err)
-	_, err = mt.ListPrivilegeGroups()
+	_, err = mt.ListPrivilegeGroups(context.TODO())
 	assert.NoError(t, err)
 }

--- a/internal/rootcoord/mock_test.go
+++ b/internal/rootcoord/mock_test.go
@@ -72,36 +72,36 @@ type mockMetaTable struct {
 	CreateAliasFunc                  func(ctx context.Context, dbName string, alias string, collectionName string, ts Timestamp) error
 	AlterAliasFunc                   func(ctx context.Context, dbName string, alias string, collectionName string, ts Timestamp) error
 	DropAliasFunc                    func(ctx context.Context, dbName string, alias string, ts Timestamp) error
-	IsAliasFunc                      func(dbName, name string) bool
+	IsAliasFunc                      func(ctx context.Context, dbName, name string) bool
 	DescribeAliasFunc                func(ctx context.Context, dbName, alias string, ts Timestamp) (string, error)
 	ListAliasesFunc                  func(ctx context.Context, dbName, collectionName string, ts Timestamp) ([]string, error)
-	ListAliasesByIDFunc              func(collID UniqueID) []string
+	ListAliasesByIDFunc              func(ctx context.Context, collID UniqueID) []string
 	GetCollectionIDByNameFunc        func(name string) (UniqueID, error)
 	GetPartitionByNameFunc           func(collID UniqueID, partitionName string, ts Timestamp) (UniqueID, error)
-	GetCollectionVirtualChannelsFunc func(colID int64) []string
+	GetCollectionVirtualChannelsFunc func(ctx context.Context, colID int64) []string
 	AlterCollectionFunc              func(ctx context.Context, oldColl *model.Collection, newColl *model.Collection, ts Timestamp) error
 	RenameCollectionFunc             func(ctx context.Context, oldName string, newName string, ts Timestamp) error
-	AddCredentialFunc                func(credInfo *internalpb.CredentialInfo) error
-	GetCredentialFunc                func(username string) (*internalpb.CredentialInfo, error)
-	DeleteCredentialFunc             func(username string) error
-	AlterCredentialFunc              func(credInfo *internalpb.CredentialInfo) error
-	ListCredentialUsernamesFunc      func() (*milvuspb.ListCredUsersResponse, error)
-	CreateRoleFunc                   func(tenant string, entity *milvuspb.RoleEntity) error
-	DropRoleFunc                     func(tenant string, roleName string) error
-	OperateUserRoleFunc              func(tenant string, userEntity *milvuspb.UserEntity, roleEntity *milvuspb.RoleEntity, operateType milvuspb.OperateUserRoleType) error
-	SelectRoleFunc                   func(tenant string, entity *milvuspb.RoleEntity, includeUserInfo bool) ([]*milvuspb.RoleResult, error)
-	SelectUserFunc                   func(tenant string, entity *milvuspb.UserEntity, includeRoleInfo bool) ([]*milvuspb.UserResult, error)
-	OperatePrivilegeFunc             func(tenant string, entity *milvuspb.GrantEntity, operateType milvuspb.OperatePrivilegeType) error
-	SelectGrantFunc                  func(tenant string, entity *milvuspb.GrantEntity) ([]*milvuspb.GrantEntity, error)
-	DropGrantFunc                    func(tenant string, role *milvuspb.RoleEntity) error
-	ListPolicyFunc                   func(tenant string) ([]string, error)
-	ListUserRoleFunc                 func(tenant string) ([]string, error)
+	AddCredentialFunc                func(ctx context.Context, credInfo *internalpb.CredentialInfo) error
+	GetCredentialFunc                func(ctx context.Context, username string) (*internalpb.CredentialInfo, error)
+	DeleteCredentialFunc             func(ctx context.Context, username string) error
+	AlterCredentialFunc              func(ctx context.Context, credInfo *internalpb.CredentialInfo) error
+	ListCredentialUsernamesFunc      func(ctx context.Context) (*milvuspb.ListCredUsersResponse, error)
+	CreateRoleFunc                   func(ctx context.Context, tenant string, entity *milvuspb.RoleEntity) error
+	DropRoleFunc                     func(ctx context.Context, tenant string, roleName string) error
+	OperateUserRoleFunc              func(ctx context.Context, tenant string, userEntity *milvuspb.UserEntity, roleEntity *milvuspb.RoleEntity, operateType milvuspb.OperateUserRoleType) error
+	SelectRoleFunc                   func(ctx context.Context, tenant string, entity *milvuspb.RoleEntity, includeUserInfo bool) ([]*milvuspb.RoleResult, error)
+	SelectUserFunc                   func(ctx context.Context, tenant string, entity *milvuspb.UserEntity, includeRoleInfo bool) ([]*milvuspb.UserResult, error)
+	OperatePrivilegeFunc             func(ctx context.Context, tenant string, entity *milvuspb.GrantEntity, operateType milvuspb.OperatePrivilegeType) error
+	SelectGrantFunc                  func(ctx context.Context, tenant string, entity *milvuspb.GrantEntity) ([]*milvuspb.GrantEntity, error)
+	DropGrantFunc                    func(ctx context.Context, tenant string, role *milvuspb.RoleEntity) error
+	ListPolicyFunc                   func(ctx context.Context, tenant string) ([]string, error)
+	ListUserRoleFunc                 func(ctx context.Context, tenant string) ([]string, error)
 	DescribeDatabaseFunc             func(ctx context.Context, dbName string) (*model.Database, error)
-	CreatePrivilegeGroupFunc         func(groupName string) error
-	DropPrivilegeGroupFunc           func(groupName string) error
-	ListPrivilegeGroupsFunc          func() ([]*milvuspb.PrivilegeGroupInfo, error)
-	OperatePrivilegeGroupFunc        func(groupName string, privileges []*milvuspb.PrivilegeEntity, operateType milvuspb.OperatePrivilegeGroupType) error
-	GetPrivilegeGroupRolesFunc       func(groupName string) ([]*milvuspb.RoleEntity, error)
+	CreatePrivilegeGroupFunc         func(ctx context.Context, groupName string) error
+	DropPrivilegeGroupFunc           func(ctx context.Context, groupName string) error
+	ListPrivilegeGroupsFunc          func(ctx context.Context) ([]*milvuspb.PrivilegeGroupInfo, error)
+	OperatePrivilegeGroupFunc        func(ctx context.Context, groupName string, privileges []*milvuspb.PrivilegeEntity, operateType milvuspb.OperatePrivilegeGroupType) error
+	GetPrivilegeGroupRolesFunc       func(ctx context.Context, groupName string) ([]*milvuspb.RoleEntity, error)
 }
 
 func (m mockMetaTable) GetDatabaseByName(ctx context.Context, dbName string, ts Timestamp) (*model.Database, error) {
@@ -160,8 +160,8 @@ func (m mockMetaTable) DropAlias(ctx context.Context, dbName, alias string, ts T
 	return m.DropAliasFunc(ctx, dbName, alias, ts)
 }
 
-func (m mockMetaTable) IsAlias(dbName, name string) bool {
-	return m.IsAliasFunc(dbName, name)
+func (m mockMetaTable) IsAlias(ctx context.Context, dbName, name string) bool {
+	return m.IsAliasFunc(ctx, dbName, name)
 }
 
 func (m mockMetaTable) DescribeAlias(ctx context.Context, dbName, alias string, ts Timestamp) (string, error) {
@@ -172,8 +172,8 @@ func (m mockMetaTable) ListAliases(ctx context.Context, dbName, collectionName s
 	return m.ListAliasesFunc(ctx, dbName, collectionName, ts)
 }
 
-func (m mockMetaTable) ListAliasesByID(collID UniqueID) []string {
-	return m.ListAliasesByIDFunc(collID)
+func (m mockMetaTable) ListAliasesByID(ctx context.Context, collID UniqueID) []string {
+	return m.ListAliasesByIDFunc(ctx, collID)
 }
 
 func (m mockMetaTable) AlterCollection(ctx context.Context, oldColl *model.Collection, newColl *model.Collection, ts Timestamp) error {
@@ -192,88 +192,88 @@ func (m mockMetaTable) GetPartitionByName(collID UniqueID, partitionName string,
 	return m.GetPartitionByNameFunc(collID, partitionName, ts)
 }
 
-func (m mockMetaTable) GetCollectionVirtualChannels(colID int64) []string {
-	return m.GetCollectionVirtualChannelsFunc(colID)
+func (m mockMetaTable) GetCollectionVirtualChannels(ctx context.Context, colID int64) []string {
+	return m.GetCollectionVirtualChannelsFunc(ctx, colID)
 }
 
-func (m mockMetaTable) AddCredential(credInfo *internalpb.CredentialInfo) error {
-	return m.AddCredentialFunc(credInfo)
+func (m mockMetaTable) AddCredential(ctx context.Context, credInfo *internalpb.CredentialInfo) error {
+	return m.AddCredentialFunc(ctx, credInfo)
 }
 
-func (m mockMetaTable) GetCredential(username string) (*internalpb.CredentialInfo, error) {
-	return m.GetCredentialFunc(username)
+func (m mockMetaTable) GetCredential(ctx context.Context, username string) (*internalpb.CredentialInfo, error) {
+	return m.GetCredentialFunc(ctx, username)
 }
 
-func (m mockMetaTable) DeleteCredential(username string) error {
-	return m.DeleteCredentialFunc(username)
+func (m mockMetaTable) DeleteCredential(ctx context.Context, username string) error {
+	return m.DeleteCredentialFunc(ctx, username)
 }
 
-func (m mockMetaTable) AlterCredential(credInfo *internalpb.CredentialInfo) error {
-	return m.AlterCredentialFunc(credInfo)
+func (m mockMetaTable) AlterCredential(ctx context.Context, credInfo *internalpb.CredentialInfo) error {
+	return m.AlterCredentialFunc(ctx, credInfo)
 }
 
-func (m mockMetaTable) ListCredentialUsernames() (*milvuspb.ListCredUsersResponse, error) {
-	return m.ListCredentialUsernamesFunc()
+func (m mockMetaTable) ListCredentialUsernames(ctx context.Context) (*milvuspb.ListCredUsersResponse, error) {
+	return m.ListCredentialUsernamesFunc(ctx)
 }
 
-func (m mockMetaTable) CreateRole(tenant string, entity *milvuspb.RoleEntity) error {
-	return m.CreateRoleFunc(tenant, entity)
+func (m mockMetaTable) CreateRole(ctx context.Context, tenant string, entity *milvuspb.RoleEntity) error {
+	return m.CreateRoleFunc(ctx, tenant, entity)
 }
 
-func (m mockMetaTable) DropRole(tenant string, roleName string) error {
-	return m.DropRoleFunc(tenant, roleName)
+func (m mockMetaTable) DropRole(ctx context.Context, tenant string, roleName string) error {
+	return m.DropRoleFunc(ctx, tenant, roleName)
 }
 
-func (m mockMetaTable) OperateUserRole(tenant string, userEntity *milvuspb.UserEntity, roleEntity *milvuspb.RoleEntity, operateType milvuspb.OperateUserRoleType) error {
-	return m.OperateUserRoleFunc(tenant, userEntity, roleEntity, operateType)
+func (m mockMetaTable) OperateUserRole(ctx context.Context, tenant string, userEntity *milvuspb.UserEntity, roleEntity *milvuspb.RoleEntity, operateType milvuspb.OperateUserRoleType) error {
+	return m.OperateUserRoleFunc(ctx, tenant, userEntity, roleEntity, operateType)
 }
 
-func (m mockMetaTable) SelectRole(tenant string, entity *milvuspb.RoleEntity, includeUserInfo bool) ([]*milvuspb.RoleResult, error) {
-	return m.SelectRoleFunc(tenant, entity, includeUserInfo)
+func (m mockMetaTable) SelectRole(ctx context.Context, tenant string, entity *milvuspb.RoleEntity, includeUserInfo bool) ([]*milvuspb.RoleResult, error) {
+	return m.SelectRoleFunc(ctx, tenant, entity, includeUserInfo)
 }
 
-func (m mockMetaTable) SelectUser(tenant string, entity *milvuspb.UserEntity, includeRoleInfo bool) ([]*milvuspb.UserResult, error) {
-	return m.SelectUserFunc(tenant, entity, includeRoleInfo)
+func (m mockMetaTable) SelectUser(ctx context.Context, tenant string, entity *milvuspb.UserEntity, includeRoleInfo bool) ([]*milvuspb.UserResult, error) {
+	return m.SelectUserFunc(ctx, tenant, entity, includeRoleInfo)
 }
 
-func (m mockMetaTable) OperatePrivilege(tenant string, entity *milvuspb.GrantEntity, operateType milvuspb.OperatePrivilegeType) error {
-	return m.OperatePrivilegeFunc(tenant, entity, operateType)
+func (m mockMetaTable) OperatePrivilege(ctx context.Context, tenant string, entity *milvuspb.GrantEntity, operateType milvuspb.OperatePrivilegeType) error {
+	return m.OperatePrivilegeFunc(ctx, tenant, entity, operateType)
 }
 
-func (m mockMetaTable) SelectGrant(tenant string, entity *milvuspb.GrantEntity) ([]*milvuspb.GrantEntity, error) {
-	return m.SelectGrantFunc(tenant, entity)
+func (m mockMetaTable) SelectGrant(ctx context.Context, tenant string, entity *milvuspb.GrantEntity) ([]*milvuspb.GrantEntity, error) {
+	return m.SelectGrantFunc(ctx, tenant, entity)
 }
 
-func (m mockMetaTable) DropGrant(tenant string, role *milvuspb.RoleEntity) error {
-	return m.DropGrantFunc(tenant, role)
+func (m mockMetaTable) DropGrant(ctx context.Context, tenant string, role *milvuspb.RoleEntity) error {
+	return m.DropGrantFunc(ctx, tenant, role)
 }
 
-func (m mockMetaTable) ListPolicy(tenant string) ([]string, error) {
-	return m.ListPolicyFunc(tenant)
+func (m mockMetaTable) ListPolicy(ctx context.Context, tenant string) ([]string, error) {
+	return m.ListPolicyFunc(ctx, tenant)
 }
 
-func (m mockMetaTable) ListUserRole(tenant string) ([]string, error) {
-	return m.ListUserRoleFunc(tenant)
+func (m mockMetaTable) ListUserRole(ctx context.Context, tenant string) ([]string, error) {
+	return m.ListUserRoleFunc(ctx, tenant)
 }
 
-func (m mockMetaTable) CreatePrivilegeGroup(groupName string) error {
-	return m.CreatePrivilegeGroupFunc(groupName)
+func (m mockMetaTable) CreatePrivilegeGroup(ctx context.Context, groupName string) error {
+	return m.CreatePrivilegeGroupFunc(ctx, groupName)
 }
 
-func (m mockMetaTable) DropPrivilegeGroup(groupName string) error {
-	return m.DropPrivilegeGroupFunc(groupName)
+func (m mockMetaTable) DropPrivilegeGroup(ctx context.Context, groupName string) error {
+	return m.DropPrivilegeGroupFunc(ctx, groupName)
 }
 
-func (m mockMetaTable) ListPrivilegeGroups() ([]*milvuspb.PrivilegeGroupInfo, error) {
-	return m.ListPrivilegeGroupsFunc()
+func (m mockMetaTable) ListPrivilegeGroups(ctx context.Context) ([]*milvuspb.PrivilegeGroupInfo, error) {
+	return m.ListPrivilegeGroupsFunc(ctx)
 }
 
-func (m mockMetaTable) OperatePrivilegeGroup(groupName string, privileges []*milvuspb.PrivilegeEntity, operateType milvuspb.OperatePrivilegeGroupType) error {
-	return m.OperatePrivilegeGroupFunc(groupName, privileges, operateType)
+func (m mockMetaTable) OperatePrivilegeGroup(ctx context.Context, groupName string, privileges []*milvuspb.PrivilegeEntity, operateType milvuspb.OperatePrivilegeGroupType) error {
+	return m.OperatePrivilegeGroupFunc(ctx, groupName, privileges, operateType)
 }
 
-func (m mockMetaTable) GetPrivilegeGroupRoles(groupName string) ([]*milvuspb.RoleEntity, error) {
-	return m.GetPrivilegeGroupRolesFunc(groupName)
+func (m mockMetaTable) GetPrivilegeGroupRoles(ctx context.Context, groupName string) ([]*milvuspb.RoleEntity, error) {
+	return m.GetPrivilegeGroupRolesFunc(ctx, groupName)
 }
 
 func newMockMetaTable() *mockMetaTable {
@@ -498,49 +498,49 @@ func withInvalidMeta() Opt {
 	meta.DropAliasFunc = func(ctx context.Context, dbName string, alias string, ts Timestamp) error {
 		return errors.New("error mock DropAlias")
 	}
-	meta.AddCredentialFunc = func(credInfo *internalpb.CredentialInfo) error {
+	meta.AddCredentialFunc = func(ctx context.Context, credInfo *internalpb.CredentialInfo) error {
 		return errors.New("error mock AddCredential")
 	}
-	meta.GetCredentialFunc = func(username string) (*internalpb.CredentialInfo, error) {
+	meta.GetCredentialFunc = func(ctx context.Context, username string) (*internalpb.CredentialInfo, error) {
 		return nil, errors.New("error mock GetCredential")
 	}
-	meta.DeleteCredentialFunc = func(username string) error {
+	meta.DeleteCredentialFunc = func(ctx context.Context, username string) error {
 		return errors.New("error mock DeleteCredential")
 	}
-	meta.AlterCredentialFunc = func(credInfo *internalpb.CredentialInfo) error {
+	meta.AlterCredentialFunc = func(ctx context.Context, credInfo *internalpb.CredentialInfo) error {
 		return errors.New("error mock AlterCredential")
 	}
-	meta.ListCredentialUsernamesFunc = func() (*milvuspb.ListCredUsersResponse, error) {
+	meta.ListCredentialUsernamesFunc = func(ctx context.Context) (*milvuspb.ListCredUsersResponse, error) {
 		return nil, errors.New("error mock ListCredentialUsernames")
 	}
-	meta.CreateRoleFunc = func(tenant string, entity *milvuspb.RoleEntity) error {
+	meta.CreateRoleFunc = func(ctx context.Context, tenant string, entity *milvuspb.RoleEntity) error {
 		return errors.New("error mock CreateRole")
 	}
-	meta.DropRoleFunc = func(tenant string, roleName string) error {
+	meta.DropRoleFunc = func(ctx context.Context, tenant string, roleName string) error {
 		return errors.New("error mock DropRole")
 	}
-	meta.OperateUserRoleFunc = func(tenant string, userEntity *milvuspb.UserEntity, roleEntity *milvuspb.RoleEntity, operateType milvuspb.OperateUserRoleType) error {
+	meta.OperateUserRoleFunc = func(ctx context.Context, tenant string, userEntity *milvuspb.UserEntity, roleEntity *milvuspb.RoleEntity, operateType milvuspb.OperateUserRoleType) error {
 		return errors.New("error mock OperateUserRole")
 	}
-	meta.SelectUserFunc = func(tenant string, entity *milvuspb.UserEntity, includeRoleInfo bool) ([]*milvuspb.UserResult, error) {
+	meta.SelectUserFunc = func(ctx context.Context, tenant string, entity *milvuspb.UserEntity, includeRoleInfo bool) ([]*milvuspb.UserResult, error) {
 		return nil, errors.New("error mock SelectUser")
 	}
-	meta.SelectRoleFunc = func(tenant string, entity *milvuspb.RoleEntity, includeUserInfo bool) ([]*milvuspb.RoleResult, error) {
+	meta.SelectRoleFunc = func(ctx context.Context, tenant string, entity *milvuspb.RoleEntity, includeUserInfo bool) ([]*milvuspb.RoleResult, error) {
 		return nil, errors.New("error mock SelectRole")
 	}
-	meta.OperatePrivilegeFunc = func(tenant string, entity *milvuspb.GrantEntity, operateType milvuspb.OperatePrivilegeType) error {
+	meta.OperatePrivilegeFunc = func(ctx context.Context, tenant string, entity *milvuspb.GrantEntity, operateType milvuspb.OperatePrivilegeType) error {
 		return errors.New("error mock OperatePrivilege")
 	}
-	meta.SelectGrantFunc = func(tenant string, entity *milvuspb.GrantEntity) ([]*milvuspb.GrantEntity, error) {
+	meta.SelectGrantFunc = func(ctx context.Context, tenant string, entity *milvuspb.GrantEntity) ([]*milvuspb.GrantEntity, error) {
 		return nil, errors.New("error mock SelectGrant")
 	}
-	meta.DropGrantFunc = func(tenant string, role *milvuspb.RoleEntity) error {
+	meta.DropGrantFunc = func(ctx context.Context, tenant string, role *milvuspb.RoleEntity) error {
 		return errors.New("error mock DropGrant")
 	}
-	meta.ListPolicyFunc = func(tenant string) ([]string, error) {
+	meta.ListPolicyFunc = func(ctx context.Context, tenant string) ([]string, error) {
 		return nil, errors.New("error mock ListPolicy")
 	}
-	meta.ListUserRoleFunc = func(tenant string) ([]string, error) {
+	meta.ListUserRoleFunc = func(ctx context.Context, tenant string) ([]string, error) {
 		return nil, errors.New("error mock ListUserRole")
 	}
 	meta.DescribeAliasFunc = func(ctx context.Context, dbName, alias string, ts Timestamp) (string, error) {
@@ -552,19 +552,19 @@ func withInvalidMeta() Opt {
 	meta.DescribeDatabaseFunc = func(ctx context.Context, dbName string) (*model.Database, error) {
 		return nil, errors.New("error mock DescribeDatabase")
 	}
-	meta.CreatePrivilegeGroupFunc = func(groupName string) error {
+	meta.CreatePrivilegeGroupFunc = func(ctx context.Context, groupName string) error {
 		return errors.New("error mock CreatePrivilegeGroup")
 	}
-	meta.DropPrivilegeGroupFunc = func(groupName string) error {
+	meta.DropPrivilegeGroupFunc = func(ctx context.Context, groupName string) error {
 		return errors.New("error mock DropPrivilegeGroup")
 	}
-	meta.ListPrivilegeGroupsFunc = func() ([]*milvuspb.PrivilegeGroupInfo, error) {
+	meta.ListPrivilegeGroupsFunc = func(ctx context.Context) ([]*milvuspb.PrivilegeGroupInfo, error) {
 		return nil, errors.New("error mock ListPrivilegeGroups")
 	}
-	meta.OperatePrivilegeGroupFunc = func(groupName string, privileges []*milvuspb.PrivilegeEntity, operateType milvuspb.OperatePrivilegeGroupType) error {
+	meta.OperatePrivilegeGroupFunc = func(ctx context.Context, groupName string, privileges []*milvuspb.PrivilegeEntity, operateType milvuspb.OperatePrivilegeGroupType) error {
 		return errors.New("error mock OperatePrivilegeGroup")
 	}
-	meta.GetPrivilegeGroupRolesFunc = func(groupName string) ([]*milvuspb.RoleEntity, error) {
+	meta.GetPrivilegeGroupRolesFunc = func(ctx context.Context, groupName string) ([]*milvuspb.RoleEntity, error) {
 		return nil, errors.New("error mock GetPrivilegeGroupRoles")
 	}
 	return withMeta(meta)

--- a/internal/rootcoord/mocks/meta_table.go
+++ b/internal/rootcoord/mocks/meta_table.go
@@ -77,17 +77,17 @@ func (_c *IMetaTable_AddCollection_Call) RunAndReturn(run func(context.Context, 
 	return _c
 }
 
-// AddCredential provides a mock function with given fields: credInfo
-func (_m *IMetaTable) AddCredential(credInfo *internalpb.CredentialInfo) error {
-	ret := _m.Called(credInfo)
+// AddCredential provides a mock function with given fields: ctx, credInfo
+func (_m *IMetaTable) AddCredential(ctx context.Context, credInfo *internalpb.CredentialInfo) error {
+	ret := _m.Called(ctx, credInfo)
 
 	if len(ret) == 0 {
 		panic("no return value specified for AddCredential")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(*internalpb.CredentialInfo) error); ok {
-		r0 = rf(credInfo)
+	if rf, ok := ret.Get(0).(func(context.Context, *internalpb.CredentialInfo) error); ok {
+		r0 = rf(ctx, credInfo)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -101,14 +101,15 @@ type IMetaTable_AddCredential_Call struct {
 }
 
 // AddCredential is a helper method to define mock.On call
+//   - ctx context.Context
 //   - credInfo *internalpb.CredentialInfo
-func (_e *IMetaTable_Expecter) AddCredential(credInfo interface{}) *IMetaTable_AddCredential_Call {
-	return &IMetaTable_AddCredential_Call{Call: _e.mock.On("AddCredential", credInfo)}
+func (_e *IMetaTable_Expecter) AddCredential(ctx interface{}, credInfo interface{}) *IMetaTable_AddCredential_Call {
+	return &IMetaTable_AddCredential_Call{Call: _e.mock.On("AddCredential", ctx, credInfo)}
 }
 
-func (_c *IMetaTable_AddCredential_Call) Run(run func(credInfo *internalpb.CredentialInfo)) *IMetaTable_AddCredential_Call {
+func (_c *IMetaTable_AddCredential_Call) Run(run func(ctx context.Context, credInfo *internalpb.CredentialInfo)) *IMetaTable_AddCredential_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*internalpb.CredentialInfo))
+		run(args[0].(context.Context), args[1].(*internalpb.CredentialInfo))
 	})
 	return _c
 }
@@ -118,7 +119,7 @@ func (_c *IMetaTable_AddCredential_Call) Return(_a0 error) *IMetaTable_AddCreden
 	return _c
 }
 
-func (_c *IMetaTable_AddCredential_Call) RunAndReturn(run func(*internalpb.CredentialInfo) error) *IMetaTable_AddCredential_Call {
+func (_c *IMetaTable_AddCredential_Call) RunAndReturn(run func(context.Context, *internalpb.CredentialInfo) error) *IMetaTable_AddCredential_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -269,17 +270,17 @@ func (_c *IMetaTable_AlterCollection_Call) RunAndReturn(run func(context.Context
 	return _c
 }
 
-// AlterCredential provides a mock function with given fields: credInfo
-func (_m *IMetaTable) AlterCredential(credInfo *internalpb.CredentialInfo) error {
-	ret := _m.Called(credInfo)
+// AlterCredential provides a mock function with given fields: ctx, credInfo
+func (_m *IMetaTable) AlterCredential(ctx context.Context, credInfo *internalpb.CredentialInfo) error {
+	ret := _m.Called(ctx, credInfo)
 
 	if len(ret) == 0 {
 		panic("no return value specified for AlterCredential")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(*internalpb.CredentialInfo) error); ok {
-		r0 = rf(credInfo)
+	if rf, ok := ret.Get(0).(func(context.Context, *internalpb.CredentialInfo) error); ok {
+		r0 = rf(ctx, credInfo)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -293,14 +294,15 @@ type IMetaTable_AlterCredential_Call struct {
 }
 
 // AlterCredential is a helper method to define mock.On call
+//   - ctx context.Context
 //   - credInfo *internalpb.CredentialInfo
-func (_e *IMetaTable_Expecter) AlterCredential(credInfo interface{}) *IMetaTable_AlterCredential_Call {
-	return &IMetaTable_AlterCredential_Call{Call: _e.mock.On("AlterCredential", credInfo)}
+func (_e *IMetaTable_Expecter) AlterCredential(ctx interface{}, credInfo interface{}) *IMetaTable_AlterCredential_Call {
+	return &IMetaTable_AlterCredential_Call{Call: _e.mock.On("AlterCredential", ctx, credInfo)}
 }
 
-func (_c *IMetaTable_AlterCredential_Call) Run(run func(credInfo *internalpb.CredentialInfo)) *IMetaTable_AlterCredential_Call {
+func (_c *IMetaTable_AlterCredential_Call) Run(run func(ctx context.Context, credInfo *internalpb.CredentialInfo)) *IMetaTable_AlterCredential_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*internalpb.CredentialInfo))
+		run(args[0].(context.Context), args[1].(*internalpb.CredentialInfo))
 	})
 	return _c
 }
@@ -310,7 +312,7 @@ func (_c *IMetaTable_AlterCredential_Call) Return(_a0 error) *IMetaTable_AlterCr
 	return _c
 }
 
-func (_c *IMetaTable_AlterCredential_Call) RunAndReturn(run func(*internalpb.CredentialInfo) error) *IMetaTable_AlterCredential_Call {
+func (_c *IMetaTable_AlterCredential_Call) RunAndReturn(run func(context.Context, *internalpb.CredentialInfo) error) *IMetaTable_AlterCredential_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -620,17 +622,17 @@ func (_c *IMetaTable_CreateDatabase_Call) RunAndReturn(run func(context.Context,
 	return _c
 }
 
-// CreatePrivilegeGroup provides a mock function with given fields: groupName
-func (_m *IMetaTable) CreatePrivilegeGroup(groupName string) error {
-	ret := _m.Called(groupName)
+// CreatePrivilegeGroup provides a mock function with given fields: ctx, groupName
+func (_m *IMetaTable) CreatePrivilegeGroup(ctx context.Context, groupName string) error {
+	ret := _m.Called(ctx, groupName)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreatePrivilegeGroup")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string) error); ok {
-		r0 = rf(groupName)
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, groupName)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -644,14 +646,15 @@ type IMetaTable_CreatePrivilegeGroup_Call struct {
 }
 
 // CreatePrivilegeGroup is a helper method to define mock.On call
+//   - ctx context.Context
 //   - groupName string
-func (_e *IMetaTable_Expecter) CreatePrivilegeGroup(groupName interface{}) *IMetaTable_CreatePrivilegeGroup_Call {
-	return &IMetaTable_CreatePrivilegeGroup_Call{Call: _e.mock.On("CreatePrivilegeGroup", groupName)}
+func (_e *IMetaTable_Expecter) CreatePrivilegeGroup(ctx interface{}, groupName interface{}) *IMetaTable_CreatePrivilegeGroup_Call {
+	return &IMetaTable_CreatePrivilegeGroup_Call{Call: _e.mock.On("CreatePrivilegeGroup", ctx, groupName)}
 }
 
-func (_c *IMetaTable_CreatePrivilegeGroup_Call) Run(run func(groupName string)) *IMetaTable_CreatePrivilegeGroup_Call {
+func (_c *IMetaTable_CreatePrivilegeGroup_Call) Run(run func(ctx context.Context, groupName string)) *IMetaTable_CreatePrivilegeGroup_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -661,22 +664,22 @@ func (_c *IMetaTable_CreatePrivilegeGroup_Call) Return(_a0 error) *IMetaTable_Cr
 	return _c
 }
 
-func (_c *IMetaTable_CreatePrivilegeGroup_Call) RunAndReturn(run func(string) error) *IMetaTable_CreatePrivilegeGroup_Call {
+func (_c *IMetaTable_CreatePrivilegeGroup_Call) RunAndReturn(run func(context.Context, string) error) *IMetaTable_CreatePrivilegeGroup_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// CreateRole provides a mock function with given fields: tenant, entity
-func (_m *IMetaTable) CreateRole(tenant string, entity *milvuspb.RoleEntity) error {
-	ret := _m.Called(tenant, entity)
+// CreateRole provides a mock function with given fields: ctx, tenant, entity
+func (_m *IMetaTable) CreateRole(ctx context.Context, tenant string, entity *milvuspb.RoleEntity) error {
+	ret := _m.Called(ctx, tenant, entity)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateRole")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, *milvuspb.RoleEntity) error); ok {
-		r0 = rf(tenant, entity)
+	if rf, ok := ret.Get(0).(func(context.Context, string, *milvuspb.RoleEntity) error); ok {
+		r0 = rf(ctx, tenant, entity)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -690,15 +693,16 @@ type IMetaTable_CreateRole_Call struct {
 }
 
 // CreateRole is a helper method to define mock.On call
+//   - ctx context.Context
 //   - tenant string
 //   - entity *milvuspb.RoleEntity
-func (_e *IMetaTable_Expecter) CreateRole(tenant interface{}, entity interface{}) *IMetaTable_CreateRole_Call {
-	return &IMetaTable_CreateRole_Call{Call: _e.mock.On("CreateRole", tenant, entity)}
+func (_e *IMetaTable_Expecter) CreateRole(ctx interface{}, tenant interface{}, entity interface{}) *IMetaTable_CreateRole_Call {
+	return &IMetaTable_CreateRole_Call{Call: _e.mock.On("CreateRole", ctx, tenant, entity)}
 }
 
-func (_c *IMetaTable_CreateRole_Call) Run(run func(tenant string, entity *milvuspb.RoleEntity)) *IMetaTable_CreateRole_Call {
+func (_c *IMetaTable_CreateRole_Call) Run(run func(ctx context.Context, tenant string, entity *milvuspb.RoleEntity)) *IMetaTable_CreateRole_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(*milvuspb.RoleEntity))
+		run(args[0].(context.Context), args[1].(string), args[2].(*milvuspb.RoleEntity))
 	})
 	return _c
 }
@@ -708,22 +712,22 @@ func (_c *IMetaTable_CreateRole_Call) Return(_a0 error) *IMetaTable_CreateRole_C
 	return _c
 }
 
-func (_c *IMetaTable_CreateRole_Call) RunAndReturn(run func(string, *milvuspb.RoleEntity) error) *IMetaTable_CreateRole_Call {
+func (_c *IMetaTable_CreateRole_Call) RunAndReturn(run func(context.Context, string, *milvuspb.RoleEntity) error) *IMetaTable_CreateRole_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// DeleteCredential provides a mock function with given fields: username
-func (_m *IMetaTable) DeleteCredential(username string) error {
-	ret := _m.Called(username)
+// DeleteCredential provides a mock function with given fields: ctx, username
+func (_m *IMetaTable) DeleteCredential(ctx context.Context, username string) error {
+	ret := _m.Called(ctx, username)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteCredential")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string) error); ok {
-		r0 = rf(username)
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, username)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -737,14 +741,15 @@ type IMetaTable_DeleteCredential_Call struct {
 }
 
 // DeleteCredential is a helper method to define mock.On call
+//   - ctx context.Context
 //   - username string
-func (_e *IMetaTable_Expecter) DeleteCredential(username interface{}) *IMetaTable_DeleteCredential_Call {
-	return &IMetaTable_DeleteCredential_Call{Call: _e.mock.On("DeleteCredential", username)}
+func (_e *IMetaTable_Expecter) DeleteCredential(ctx interface{}, username interface{}) *IMetaTable_DeleteCredential_Call {
+	return &IMetaTable_DeleteCredential_Call{Call: _e.mock.On("DeleteCredential", ctx, username)}
 }
 
-func (_c *IMetaTable_DeleteCredential_Call) Run(run func(username string)) *IMetaTable_DeleteCredential_Call {
+func (_c *IMetaTable_DeleteCredential_Call) Run(run func(ctx context.Context, username string)) *IMetaTable_DeleteCredential_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -754,7 +759,7 @@ func (_c *IMetaTable_DeleteCredential_Call) Return(_a0 error) *IMetaTable_Delete
 	return _c
 }
 
-func (_c *IMetaTable_DeleteCredential_Call) RunAndReturn(run func(string) error) *IMetaTable_DeleteCredential_Call {
+func (_c *IMetaTable_DeleteCredential_Call) RunAndReturn(run func(context.Context, string) error) *IMetaTable_DeleteCredential_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -915,17 +920,17 @@ func (_c *IMetaTable_DropDatabase_Call) RunAndReturn(run func(context.Context, s
 	return _c
 }
 
-// DropGrant provides a mock function with given fields: tenant, role
-func (_m *IMetaTable) DropGrant(tenant string, role *milvuspb.RoleEntity) error {
-	ret := _m.Called(tenant, role)
+// DropGrant provides a mock function with given fields: ctx, tenant, role
+func (_m *IMetaTable) DropGrant(ctx context.Context, tenant string, role *milvuspb.RoleEntity) error {
+	ret := _m.Called(ctx, tenant, role)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DropGrant")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, *milvuspb.RoleEntity) error); ok {
-		r0 = rf(tenant, role)
+	if rf, ok := ret.Get(0).(func(context.Context, string, *milvuspb.RoleEntity) error); ok {
+		r0 = rf(ctx, tenant, role)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -939,15 +944,16 @@ type IMetaTable_DropGrant_Call struct {
 }
 
 // DropGrant is a helper method to define mock.On call
+//   - ctx context.Context
 //   - tenant string
 //   - role *milvuspb.RoleEntity
-func (_e *IMetaTable_Expecter) DropGrant(tenant interface{}, role interface{}) *IMetaTable_DropGrant_Call {
-	return &IMetaTable_DropGrant_Call{Call: _e.mock.On("DropGrant", tenant, role)}
+func (_e *IMetaTable_Expecter) DropGrant(ctx interface{}, tenant interface{}, role interface{}) *IMetaTable_DropGrant_Call {
+	return &IMetaTable_DropGrant_Call{Call: _e.mock.On("DropGrant", ctx, tenant, role)}
 }
 
-func (_c *IMetaTable_DropGrant_Call) Run(run func(tenant string, role *milvuspb.RoleEntity)) *IMetaTable_DropGrant_Call {
+func (_c *IMetaTable_DropGrant_Call) Run(run func(ctx context.Context, tenant string, role *milvuspb.RoleEntity)) *IMetaTable_DropGrant_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(*milvuspb.RoleEntity))
+		run(args[0].(context.Context), args[1].(string), args[2].(*milvuspb.RoleEntity))
 	})
 	return _c
 }
@@ -957,22 +963,22 @@ func (_c *IMetaTable_DropGrant_Call) Return(_a0 error) *IMetaTable_DropGrant_Cal
 	return _c
 }
 
-func (_c *IMetaTable_DropGrant_Call) RunAndReturn(run func(string, *milvuspb.RoleEntity) error) *IMetaTable_DropGrant_Call {
+func (_c *IMetaTable_DropGrant_Call) RunAndReturn(run func(context.Context, string, *milvuspb.RoleEntity) error) *IMetaTable_DropGrant_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// DropPrivilegeGroup provides a mock function with given fields: groupName
-func (_m *IMetaTable) DropPrivilegeGroup(groupName string) error {
-	ret := _m.Called(groupName)
+// DropPrivilegeGroup provides a mock function with given fields: ctx, groupName
+func (_m *IMetaTable) DropPrivilegeGroup(ctx context.Context, groupName string) error {
+	ret := _m.Called(ctx, groupName)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DropPrivilegeGroup")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string) error); ok {
-		r0 = rf(groupName)
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, groupName)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -986,14 +992,15 @@ type IMetaTable_DropPrivilegeGroup_Call struct {
 }
 
 // DropPrivilegeGroup is a helper method to define mock.On call
+//   - ctx context.Context
 //   - groupName string
-func (_e *IMetaTable_Expecter) DropPrivilegeGroup(groupName interface{}) *IMetaTable_DropPrivilegeGroup_Call {
-	return &IMetaTable_DropPrivilegeGroup_Call{Call: _e.mock.On("DropPrivilegeGroup", groupName)}
+func (_e *IMetaTable_Expecter) DropPrivilegeGroup(ctx interface{}, groupName interface{}) *IMetaTable_DropPrivilegeGroup_Call {
+	return &IMetaTable_DropPrivilegeGroup_Call{Call: _e.mock.On("DropPrivilegeGroup", ctx, groupName)}
 }
 
-func (_c *IMetaTable_DropPrivilegeGroup_Call) Run(run func(groupName string)) *IMetaTable_DropPrivilegeGroup_Call {
+func (_c *IMetaTable_DropPrivilegeGroup_Call) Run(run func(ctx context.Context, groupName string)) *IMetaTable_DropPrivilegeGroup_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -1003,22 +1010,22 @@ func (_c *IMetaTable_DropPrivilegeGroup_Call) Return(_a0 error) *IMetaTable_Drop
 	return _c
 }
 
-func (_c *IMetaTable_DropPrivilegeGroup_Call) RunAndReturn(run func(string) error) *IMetaTable_DropPrivilegeGroup_Call {
+func (_c *IMetaTable_DropPrivilegeGroup_Call) RunAndReturn(run func(context.Context, string) error) *IMetaTable_DropPrivilegeGroup_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// DropRole provides a mock function with given fields: tenant, roleName
-func (_m *IMetaTable) DropRole(tenant string, roleName string) error {
-	ret := _m.Called(tenant, roleName)
+// DropRole provides a mock function with given fields: ctx, tenant, roleName
+func (_m *IMetaTable) DropRole(ctx context.Context, tenant string, roleName string) error {
+	ret := _m.Called(ctx, tenant, roleName)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DropRole")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string) error); ok {
-		r0 = rf(tenant, roleName)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = rf(ctx, tenant, roleName)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -1032,15 +1039,16 @@ type IMetaTable_DropRole_Call struct {
 }
 
 // DropRole is a helper method to define mock.On call
+//   - ctx context.Context
 //   - tenant string
 //   - roleName string
-func (_e *IMetaTable_Expecter) DropRole(tenant interface{}, roleName interface{}) *IMetaTable_DropRole_Call {
-	return &IMetaTable_DropRole_Call{Call: _e.mock.On("DropRole", tenant, roleName)}
+func (_e *IMetaTable_Expecter) DropRole(ctx interface{}, tenant interface{}, roleName interface{}) *IMetaTable_DropRole_Call {
+	return &IMetaTable_DropRole_Call{Call: _e.mock.On("DropRole", ctx, tenant, roleName)}
 }
 
-func (_c *IMetaTable_DropRole_Call) Run(run func(tenant string, roleName string)) *IMetaTable_DropRole_Call {
+func (_c *IMetaTable_DropRole_Call) Run(run func(ctx context.Context, tenant string, roleName string)) *IMetaTable_DropRole_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(string))
+		run(args[0].(context.Context), args[1].(string), args[2].(string))
 	})
 	return _c
 }
@@ -1050,7 +1058,7 @@ func (_c *IMetaTable_DropRole_Call) Return(_a0 error) *IMetaTable_DropRole_Call 
 	return _c
 }
 
-func (_c *IMetaTable_DropRole_Call) RunAndReturn(run func(string, string) error) *IMetaTable_DropRole_Call {
+func (_c *IMetaTable_DropRole_Call) RunAndReturn(run func(context.Context, string, string) error) *IMetaTable_DropRole_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1237,17 +1245,17 @@ func (_c *IMetaTable_GetCollectionByName_Call) RunAndReturn(run func(context.Con
 	return _c
 }
 
-// GetCollectionVirtualChannels provides a mock function with given fields: colID
-func (_m *IMetaTable) GetCollectionVirtualChannels(colID int64) []string {
-	ret := _m.Called(colID)
+// GetCollectionVirtualChannels provides a mock function with given fields: ctx, colID
+func (_m *IMetaTable) GetCollectionVirtualChannels(ctx context.Context, colID int64) []string {
+	ret := _m.Called(ctx, colID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetCollectionVirtualChannels")
 	}
 
 	var r0 []string
-	if rf, ok := ret.Get(0).(func(int64) []string); ok {
-		r0 = rf(colID)
+	if rf, ok := ret.Get(0).(func(context.Context, int64) []string); ok {
+		r0 = rf(ctx, colID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]string)
@@ -1263,14 +1271,15 @@ type IMetaTable_GetCollectionVirtualChannels_Call struct {
 }
 
 // GetCollectionVirtualChannels is a helper method to define mock.On call
+//   - ctx context.Context
 //   - colID int64
-func (_e *IMetaTable_Expecter) GetCollectionVirtualChannels(colID interface{}) *IMetaTable_GetCollectionVirtualChannels_Call {
-	return &IMetaTable_GetCollectionVirtualChannels_Call{Call: _e.mock.On("GetCollectionVirtualChannels", colID)}
+func (_e *IMetaTable_Expecter) GetCollectionVirtualChannels(ctx interface{}, colID interface{}) *IMetaTable_GetCollectionVirtualChannels_Call {
+	return &IMetaTable_GetCollectionVirtualChannels_Call{Call: _e.mock.On("GetCollectionVirtualChannels", ctx, colID)}
 }
 
-func (_c *IMetaTable_GetCollectionVirtualChannels_Call) Run(run func(colID int64)) *IMetaTable_GetCollectionVirtualChannels_Call {
+func (_c *IMetaTable_GetCollectionVirtualChannels_Call) Run(run func(ctx context.Context, colID int64)) *IMetaTable_GetCollectionVirtualChannels_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(int64))
+		run(args[0].(context.Context), args[1].(int64))
 	})
 	return _c
 }
@@ -1280,14 +1289,14 @@ func (_c *IMetaTable_GetCollectionVirtualChannels_Call) Return(_a0 []string) *IM
 	return _c
 }
 
-func (_c *IMetaTable_GetCollectionVirtualChannels_Call) RunAndReturn(run func(int64) []string) *IMetaTable_GetCollectionVirtualChannels_Call {
+func (_c *IMetaTable_GetCollectionVirtualChannels_Call) RunAndReturn(run func(context.Context, int64) []string) *IMetaTable_GetCollectionVirtualChannels_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetCredential provides a mock function with given fields: username
-func (_m *IMetaTable) GetCredential(username string) (*internalpb.CredentialInfo, error) {
-	ret := _m.Called(username)
+// GetCredential provides a mock function with given fields: ctx, username
+func (_m *IMetaTable) GetCredential(ctx context.Context, username string) (*internalpb.CredentialInfo, error) {
+	ret := _m.Called(ctx, username)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetCredential")
@@ -1295,19 +1304,19 @@ func (_m *IMetaTable) GetCredential(username string) (*internalpb.CredentialInfo
 
 	var r0 *internalpb.CredentialInfo
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string) (*internalpb.CredentialInfo, error)); ok {
-		return rf(username)
+	if rf, ok := ret.Get(0).(func(context.Context, string) (*internalpb.CredentialInfo, error)); ok {
+		return rf(ctx, username)
 	}
-	if rf, ok := ret.Get(0).(func(string) *internalpb.CredentialInfo); ok {
-		r0 = rf(username)
+	if rf, ok := ret.Get(0).(func(context.Context, string) *internalpb.CredentialInfo); ok {
+		r0 = rf(ctx, username)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*internalpb.CredentialInfo)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(username)
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, username)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1321,14 +1330,15 @@ type IMetaTable_GetCredential_Call struct {
 }
 
 // GetCredential is a helper method to define mock.On call
+//   - ctx context.Context
 //   - username string
-func (_e *IMetaTable_Expecter) GetCredential(username interface{}) *IMetaTable_GetCredential_Call {
-	return &IMetaTable_GetCredential_Call{Call: _e.mock.On("GetCredential", username)}
+func (_e *IMetaTable_Expecter) GetCredential(ctx interface{}, username interface{}) *IMetaTable_GetCredential_Call {
+	return &IMetaTable_GetCredential_Call{Call: _e.mock.On("GetCredential", ctx, username)}
 }
 
-func (_c *IMetaTable_GetCredential_Call) Run(run func(username string)) *IMetaTable_GetCredential_Call {
+func (_c *IMetaTable_GetCredential_Call) Run(run func(ctx context.Context, username string)) *IMetaTable_GetCredential_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -1338,7 +1348,7 @@ func (_c *IMetaTable_GetCredential_Call) Return(_a0 *internalpb.CredentialInfo, 
 	return _c
 }
 
-func (_c *IMetaTable_GetCredential_Call) RunAndReturn(run func(string) (*internalpb.CredentialInfo, error)) *IMetaTable_GetCredential_Call {
+func (_c *IMetaTable_GetCredential_Call) RunAndReturn(run func(context.Context, string) (*internalpb.CredentialInfo, error)) *IMetaTable_GetCredential_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1463,17 +1473,17 @@ func (_c *IMetaTable_GetDatabaseByName_Call) RunAndReturn(run func(context.Conte
 	return _c
 }
 
-// GetPChannelInfo provides a mock function with given fields: pchannel
-func (_m *IMetaTable) GetPChannelInfo(pchannel string) *rootcoordpb.GetPChannelInfoResponse {
-	ret := _m.Called(pchannel)
+// GetPChannelInfo provides a mock function with given fields: ctx, pchannel
+func (_m *IMetaTable) GetPChannelInfo(ctx context.Context, pchannel string) *rootcoordpb.GetPChannelInfoResponse {
+	ret := _m.Called(ctx, pchannel)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetPChannelInfo")
 	}
 
 	var r0 *rootcoordpb.GetPChannelInfoResponse
-	if rf, ok := ret.Get(0).(func(string) *rootcoordpb.GetPChannelInfoResponse); ok {
-		r0 = rf(pchannel)
+	if rf, ok := ret.Get(0).(func(context.Context, string) *rootcoordpb.GetPChannelInfoResponse); ok {
+		r0 = rf(ctx, pchannel)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*rootcoordpb.GetPChannelInfoResponse)
@@ -1489,14 +1499,15 @@ type IMetaTable_GetPChannelInfo_Call struct {
 }
 
 // GetPChannelInfo is a helper method to define mock.On call
+//   - ctx context.Context
 //   - pchannel string
-func (_e *IMetaTable_Expecter) GetPChannelInfo(pchannel interface{}) *IMetaTable_GetPChannelInfo_Call {
-	return &IMetaTable_GetPChannelInfo_Call{Call: _e.mock.On("GetPChannelInfo", pchannel)}
+func (_e *IMetaTable_Expecter) GetPChannelInfo(ctx interface{}, pchannel interface{}) *IMetaTable_GetPChannelInfo_Call {
+	return &IMetaTable_GetPChannelInfo_Call{Call: _e.mock.On("GetPChannelInfo", ctx, pchannel)}
 }
 
-func (_c *IMetaTable_GetPChannelInfo_Call) Run(run func(pchannel string)) *IMetaTable_GetPChannelInfo_Call {
+func (_c *IMetaTable_GetPChannelInfo_Call) Run(run func(ctx context.Context, pchannel string)) *IMetaTable_GetPChannelInfo_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -1506,14 +1517,14 @@ func (_c *IMetaTable_GetPChannelInfo_Call) Return(_a0 *rootcoordpb.GetPChannelIn
 	return _c
 }
 
-func (_c *IMetaTable_GetPChannelInfo_Call) RunAndReturn(run func(string) *rootcoordpb.GetPChannelInfoResponse) *IMetaTable_GetPChannelInfo_Call {
+func (_c *IMetaTable_GetPChannelInfo_Call) RunAndReturn(run func(context.Context, string) *rootcoordpb.GetPChannelInfoResponse) *IMetaTable_GetPChannelInfo_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetPrivilegeGroupRoles provides a mock function with given fields: groupName
-func (_m *IMetaTable) GetPrivilegeGroupRoles(groupName string) ([]*milvuspb.RoleEntity, error) {
-	ret := _m.Called(groupName)
+// GetPrivilegeGroupRoles provides a mock function with given fields: ctx, groupName
+func (_m *IMetaTable) GetPrivilegeGroupRoles(ctx context.Context, groupName string) ([]*milvuspb.RoleEntity, error) {
+	ret := _m.Called(ctx, groupName)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetPrivilegeGroupRoles")
@@ -1521,19 +1532,19 @@ func (_m *IMetaTable) GetPrivilegeGroupRoles(groupName string) ([]*milvuspb.Role
 
 	var r0 []*milvuspb.RoleEntity
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string) ([]*milvuspb.RoleEntity, error)); ok {
-		return rf(groupName)
+	if rf, ok := ret.Get(0).(func(context.Context, string) ([]*milvuspb.RoleEntity, error)); ok {
+		return rf(ctx, groupName)
 	}
-	if rf, ok := ret.Get(0).(func(string) []*milvuspb.RoleEntity); ok {
-		r0 = rf(groupName)
+	if rf, ok := ret.Get(0).(func(context.Context, string) []*milvuspb.RoleEntity); ok {
+		r0 = rf(ctx, groupName)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*milvuspb.RoleEntity)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(groupName)
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, groupName)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1547,14 +1558,15 @@ type IMetaTable_GetPrivilegeGroupRoles_Call struct {
 }
 
 // GetPrivilegeGroupRoles is a helper method to define mock.On call
+//   - ctx context.Context
 //   - groupName string
-func (_e *IMetaTable_Expecter) GetPrivilegeGroupRoles(groupName interface{}) *IMetaTable_GetPrivilegeGroupRoles_Call {
-	return &IMetaTable_GetPrivilegeGroupRoles_Call{Call: _e.mock.On("GetPrivilegeGroupRoles", groupName)}
+func (_e *IMetaTable_Expecter) GetPrivilegeGroupRoles(ctx interface{}, groupName interface{}) *IMetaTable_GetPrivilegeGroupRoles_Call {
+	return &IMetaTable_GetPrivilegeGroupRoles_Call{Call: _e.mock.On("GetPrivilegeGroupRoles", ctx, groupName)}
 }
 
-func (_c *IMetaTable_GetPrivilegeGroupRoles_Call) Run(run func(groupName string)) *IMetaTable_GetPrivilegeGroupRoles_Call {
+func (_c *IMetaTable_GetPrivilegeGroupRoles_Call) Run(run func(ctx context.Context, groupName string)) *IMetaTable_GetPrivilegeGroupRoles_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -1564,22 +1576,22 @@ func (_c *IMetaTable_GetPrivilegeGroupRoles_Call) Return(_a0 []*milvuspb.RoleEnt
 	return _c
 }
 
-func (_c *IMetaTable_GetPrivilegeGroupRoles_Call) RunAndReturn(run func(string) ([]*milvuspb.RoleEntity, error)) *IMetaTable_GetPrivilegeGroupRoles_Call {
+func (_c *IMetaTable_GetPrivilegeGroupRoles_Call) RunAndReturn(run func(context.Context, string) ([]*milvuspb.RoleEntity, error)) *IMetaTable_GetPrivilegeGroupRoles_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// IsAlias provides a mock function with given fields: db, name
-func (_m *IMetaTable) IsAlias(db string, name string) bool {
-	ret := _m.Called(db, name)
+// IsAlias provides a mock function with given fields: ctx, db, name
+func (_m *IMetaTable) IsAlias(ctx context.Context, db string, name string) bool {
+	ret := _m.Called(ctx, db, name)
 
 	if len(ret) == 0 {
 		panic("no return value specified for IsAlias")
 	}
 
 	var r0 bool
-	if rf, ok := ret.Get(0).(func(string, string) bool); ok {
-		r0 = rf(db, name)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) bool); ok {
+		r0 = rf(ctx, db, name)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
@@ -1593,15 +1605,16 @@ type IMetaTable_IsAlias_Call struct {
 }
 
 // IsAlias is a helper method to define mock.On call
+//   - ctx context.Context
 //   - db string
 //   - name string
-func (_e *IMetaTable_Expecter) IsAlias(db interface{}, name interface{}) *IMetaTable_IsAlias_Call {
-	return &IMetaTable_IsAlias_Call{Call: _e.mock.On("IsAlias", db, name)}
+func (_e *IMetaTable_Expecter) IsAlias(ctx interface{}, db interface{}, name interface{}) *IMetaTable_IsAlias_Call {
+	return &IMetaTable_IsAlias_Call{Call: _e.mock.On("IsAlias", ctx, db, name)}
 }
 
-func (_c *IMetaTable_IsAlias_Call) Run(run func(db string, name string)) *IMetaTable_IsAlias_Call {
+func (_c *IMetaTable_IsAlias_Call) Run(run func(ctx context.Context, db string, name string)) *IMetaTable_IsAlias_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(string))
+		run(args[0].(context.Context), args[1].(string), args[2].(string))
 	})
 	return _c
 }
@@ -1611,14 +1624,14 @@ func (_c *IMetaTable_IsAlias_Call) Return(_a0 bool) *IMetaTable_IsAlias_Call {
 	return _c
 }
 
-func (_c *IMetaTable_IsAlias_Call) RunAndReturn(run func(string, string) bool) *IMetaTable_IsAlias_Call {
+func (_c *IMetaTable_IsAlias_Call) RunAndReturn(run func(context.Context, string, string) bool) *IMetaTable_IsAlias_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// IsCustomPrivilegeGroup provides a mock function with given fields: groupName
-func (_m *IMetaTable) IsCustomPrivilegeGroup(groupName string) (bool, error) {
-	ret := _m.Called(groupName)
+// IsCustomPrivilegeGroup provides a mock function with given fields: ctx, groupName
+func (_m *IMetaTable) IsCustomPrivilegeGroup(ctx context.Context, groupName string) (bool, error) {
+	ret := _m.Called(ctx, groupName)
 
 	if len(ret) == 0 {
 		panic("no return value specified for IsCustomPrivilegeGroup")
@@ -1626,17 +1639,17 @@ func (_m *IMetaTable) IsCustomPrivilegeGroup(groupName string) (bool, error) {
 
 	var r0 bool
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string) (bool, error)); ok {
-		return rf(groupName)
+	if rf, ok := ret.Get(0).(func(context.Context, string) (bool, error)); ok {
+		return rf(ctx, groupName)
 	}
-	if rf, ok := ret.Get(0).(func(string) bool); ok {
-		r0 = rf(groupName)
+	if rf, ok := ret.Get(0).(func(context.Context, string) bool); ok {
+		r0 = rf(ctx, groupName)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
 
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(groupName)
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, groupName)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1650,14 +1663,15 @@ type IMetaTable_IsCustomPrivilegeGroup_Call struct {
 }
 
 // IsCustomPrivilegeGroup is a helper method to define mock.On call
+//   - ctx context.Context
 //   - groupName string
-func (_e *IMetaTable_Expecter) IsCustomPrivilegeGroup(groupName interface{}) *IMetaTable_IsCustomPrivilegeGroup_Call {
-	return &IMetaTable_IsCustomPrivilegeGroup_Call{Call: _e.mock.On("IsCustomPrivilegeGroup", groupName)}
+func (_e *IMetaTable_Expecter) IsCustomPrivilegeGroup(ctx interface{}, groupName interface{}) *IMetaTable_IsCustomPrivilegeGroup_Call {
+	return &IMetaTable_IsCustomPrivilegeGroup_Call{Call: _e.mock.On("IsCustomPrivilegeGroup", ctx, groupName)}
 }
 
-func (_c *IMetaTable_IsCustomPrivilegeGroup_Call) Run(run func(groupName string)) *IMetaTable_IsCustomPrivilegeGroup_Call {
+func (_c *IMetaTable_IsCustomPrivilegeGroup_Call) Run(run func(ctx context.Context, groupName string)) *IMetaTable_IsCustomPrivilegeGroup_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -1667,7 +1681,7 @@ func (_c *IMetaTable_IsCustomPrivilegeGroup_Call) Return(_a0 bool, _a1 error) *I
 	return _c
 }
 
-func (_c *IMetaTable_IsCustomPrivilegeGroup_Call) RunAndReturn(run func(string) (bool, error)) *IMetaTable_IsCustomPrivilegeGroup_Call {
+func (_c *IMetaTable_IsCustomPrivilegeGroup_Call) RunAndReturn(run func(context.Context, string) (bool, error)) *IMetaTable_IsCustomPrivilegeGroup_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1733,17 +1747,17 @@ func (_c *IMetaTable_ListAliases_Call) RunAndReturn(run func(context.Context, st
 	return _c
 }
 
-// ListAliasesByID provides a mock function with given fields: collID
-func (_m *IMetaTable) ListAliasesByID(collID int64) []string {
-	ret := _m.Called(collID)
+// ListAliasesByID provides a mock function with given fields: ctx, collID
+func (_m *IMetaTable) ListAliasesByID(ctx context.Context, collID int64) []string {
+	ret := _m.Called(ctx, collID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ListAliasesByID")
 	}
 
 	var r0 []string
-	if rf, ok := ret.Get(0).(func(int64) []string); ok {
-		r0 = rf(collID)
+	if rf, ok := ret.Get(0).(func(context.Context, int64) []string); ok {
+		r0 = rf(ctx, collID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]string)
@@ -1759,14 +1773,15 @@ type IMetaTable_ListAliasesByID_Call struct {
 }
 
 // ListAliasesByID is a helper method to define mock.On call
+//   - ctx context.Context
 //   - collID int64
-func (_e *IMetaTable_Expecter) ListAliasesByID(collID interface{}) *IMetaTable_ListAliasesByID_Call {
-	return &IMetaTable_ListAliasesByID_Call{Call: _e.mock.On("ListAliasesByID", collID)}
+func (_e *IMetaTable_Expecter) ListAliasesByID(ctx interface{}, collID interface{}) *IMetaTable_ListAliasesByID_Call {
+	return &IMetaTable_ListAliasesByID_Call{Call: _e.mock.On("ListAliasesByID", ctx, collID)}
 }
 
-func (_c *IMetaTable_ListAliasesByID_Call) Run(run func(collID int64)) *IMetaTable_ListAliasesByID_Call {
+func (_c *IMetaTable_ListAliasesByID_Call) Run(run func(ctx context.Context, collID int64)) *IMetaTable_ListAliasesByID_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(int64))
+		run(args[0].(context.Context), args[1].(int64))
 	})
 	return _c
 }
@@ -1776,7 +1791,7 @@ func (_c *IMetaTable_ListAliasesByID_Call) Return(_a0 []string) *IMetaTable_List
 	return _c
 }
 
-func (_c *IMetaTable_ListAliasesByID_Call) RunAndReturn(run func(int64) []string) *IMetaTable_ListAliasesByID_Call {
+func (_c *IMetaTable_ListAliasesByID_Call) RunAndReturn(run func(context.Context, int64) []string) *IMetaTable_ListAliasesByID_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1829,17 +1844,17 @@ func (_c *IMetaTable_ListAllAvailCollections_Call) RunAndReturn(run func(context
 	return _c
 }
 
-// ListCollectionPhysicalChannels provides a mock function with given fields:
-func (_m *IMetaTable) ListCollectionPhysicalChannels() map[int64][]string {
-	ret := _m.Called()
+// ListCollectionPhysicalChannels provides a mock function with given fields: ctx
+func (_m *IMetaTable) ListCollectionPhysicalChannels(ctx context.Context) map[int64][]string {
+	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ListCollectionPhysicalChannels")
 	}
 
 	var r0 map[int64][]string
-	if rf, ok := ret.Get(0).(func() map[int64][]string); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(context.Context) map[int64][]string); ok {
+		r0 = rf(ctx)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[int64][]string)
@@ -1855,13 +1870,14 @@ type IMetaTable_ListCollectionPhysicalChannels_Call struct {
 }
 
 // ListCollectionPhysicalChannels is a helper method to define mock.On call
-func (_e *IMetaTable_Expecter) ListCollectionPhysicalChannels() *IMetaTable_ListCollectionPhysicalChannels_Call {
-	return &IMetaTable_ListCollectionPhysicalChannels_Call{Call: _e.mock.On("ListCollectionPhysicalChannels")}
+//   - ctx context.Context
+func (_e *IMetaTable_Expecter) ListCollectionPhysicalChannels(ctx interface{}) *IMetaTable_ListCollectionPhysicalChannels_Call {
+	return &IMetaTable_ListCollectionPhysicalChannels_Call{Call: _e.mock.On("ListCollectionPhysicalChannels", ctx)}
 }
 
-func (_c *IMetaTable_ListCollectionPhysicalChannels_Call) Run(run func()) *IMetaTable_ListCollectionPhysicalChannels_Call {
+func (_c *IMetaTable_ListCollectionPhysicalChannels_Call) Run(run func(ctx context.Context)) *IMetaTable_ListCollectionPhysicalChannels_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -1871,7 +1887,7 @@ func (_c *IMetaTable_ListCollectionPhysicalChannels_Call) Return(_a0 map[int64][
 	return _c
 }
 
-func (_c *IMetaTable_ListCollectionPhysicalChannels_Call) RunAndReturn(run func() map[int64][]string) *IMetaTable_ListCollectionPhysicalChannels_Call {
+func (_c *IMetaTable_ListCollectionPhysicalChannels_Call) RunAndReturn(run func(context.Context) map[int64][]string) *IMetaTable_ListCollectionPhysicalChannels_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1937,9 +1953,9 @@ func (_c *IMetaTable_ListCollections_Call) RunAndReturn(run func(context.Context
 	return _c
 }
 
-// ListCredentialUsernames provides a mock function with given fields:
-func (_m *IMetaTable) ListCredentialUsernames() (*milvuspb.ListCredUsersResponse, error) {
-	ret := _m.Called()
+// ListCredentialUsernames provides a mock function with given fields: ctx
+func (_m *IMetaTable) ListCredentialUsernames(ctx context.Context) (*milvuspb.ListCredUsersResponse, error) {
+	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ListCredentialUsernames")
@@ -1947,19 +1963,19 @@ func (_m *IMetaTable) ListCredentialUsernames() (*milvuspb.ListCredUsersResponse
 
 	var r0 *milvuspb.ListCredUsersResponse
 	var r1 error
-	if rf, ok := ret.Get(0).(func() (*milvuspb.ListCredUsersResponse, error)); ok {
-		return rf()
+	if rf, ok := ret.Get(0).(func(context.Context) (*milvuspb.ListCredUsersResponse, error)); ok {
+		return rf(ctx)
 	}
-	if rf, ok := ret.Get(0).(func() *milvuspb.ListCredUsersResponse); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(context.Context) *milvuspb.ListCredUsersResponse); ok {
+		r0 = rf(ctx)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*milvuspb.ListCredUsersResponse)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1973,13 +1989,14 @@ type IMetaTable_ListCredentialUsernames_Call struct {
 }
 
 // ListCredentialUsernames is a helper method to define mock.On call
-func (_e *IMetaTable_Expecter) ListCredentialUsernames() *IMetaTable_ListCredentialUsernames_Call {
-	return &IMetaTable_ListCredentialUsernames_Call{Call: _e.mock.On("ListCredentialUsernames")}
+//   - ctx context.Context
+func (_e *IMetaTable_Expecter) ListCredentialUsernames(ctx interface{}) *IMetaTable_ListCredentialUsernames_Call {
+	return &IMetaTable_ListCredentialUsernames_Call{Call: _e.mock.On("ListCredentialUsernames", ctx)}
 }
 
-func (_c *IMetaTable_ListCredentialUsernames_Call) Run(run func()) *IMetaTable_ListCredentialUsernames_Call {
+func (_c *IMetaTable_ListCredentialUsernames_Call) Run(run func(ctx context.Context)) *IMetaTable_ListCredentialUsernames_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -1989,7 +2006,7 @@ func (_c *IMetaTable_ListCredentialUsernames_Call) Return(_a0 *milvuspb.ListCred
 	return _c
 }
 
-func (_c *IMetaTable_ListCredentialUsernames_Call) RunAndReturn(run func() (*milvuspb.ListCredUsersResponse, error)) *IMetaTable_ListCredentialUsernames_Call {
+func (_c *IMetaTable_ListCredentialUsernames_Call) RunAndReturn(run func(context.Context) (*milvuspb.ListCredUsersResponse, error)) *IMetaTable_ListCredentialUsernames_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -2053,9 +2070,9 @@ func (_c *IMetaTable_ListDatabases_Call) RunAndReturn(run func(context.Context, 
 	return _c
 }
 
-// ListPolicy provides a mock function with given fields: tenant
-func (_m *IMetaTable) ListPolicy(tenant string) ([]string, error) {
-	ret := _m.Called(tenant)
+// ListPolicy provides a mock function with given fields: ctx, tenant
+func (_m *IMetaTable) ListPolicy(ctx context.Context, tenant string) ([]string, error) {
+	ret := _m.Called(ctx, tenant)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ListPolicy")
@@ -2063,19 +2080,19 @@ func (_m *IMetaTable) ListPolicy(tenant string) ([]string, error) {
 
 	var r0 []string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string) ([]string, error)); ok {
-		return rf(tenant)
+	if rf, ok := ret.Get(0).(func(context.Context, string) ([]string, error)); ok {
+		return rf(ctx, tenant)
 	}
-	if rf, ok := ret.Get(0).(func(string) []string); ok {
-		r0 = rf(tenant)
+	if rf, ok := ret.Get(0).(func(context.Context, string) []string); ok {
+		r0 = rf(ctx, tenant)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]string)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(tenant)
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, tenant)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -2089,14 +2106,15 @@ type IMetaTable_ListPolicy_Call struct {
 }
 
 // ListPolicy is a helper method to define mock.On call
+//   - ctx context.Context
 //   - tenant string
-func (_e *IMetaTable_Expecter) ListPolicy(tenant interface{}) *IMetaTable_ListPolicy_Call {
-	return &IMetaTable_ListPolicy_Call{Call: _e.mock.On("ListPolicy", tenant)}
+func (_e *IMetaTable_Expecter) ListPolicy(ctx interface{}, tenant interface{}) *IMetaTable_ListPolicy_Call {
+	return &IMetaTable_ListPolicy_Call{Call: _e.mock.On("ListPolicy", ctx, tenant)}
 }
 
-func (_c *IMetaTable_ListPolicy_Call) Run(run func(tenant string)) *IMetaTable_ListPolicy_Call {
+func (_c *IMetaTable_ListPolicy_Call) Run(run func(ctx context.Context, tenant string)) *IMetaTable_ListPolicy_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -2106,14 +2124,14 @@ func (_c *IMetaTable_ListPolicy_Call) Return(_a0 []string, _a1 error) *IMetaTabl
 	return _c
 }
 
-func (_c *IMetaTable_ListPolicy_Call) RunAndReturn(run func(string) ([]string, error)) *IMetaTable_ListPolicy_Call {
+func (_c *IMetaTable_ListPolicy_Call) RunAndReturn(run func(context.Context, string) ([]string, error)) *IMetaTable_ListPolicy_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// ListPrivilegeGroups provides a mock function with given fields:
-func (_m *IMetaTable) ListPrivilegeGroups() ([]*milvuspb.PrivilegeGroupInfo, error) {
-	ret := _m.Called()
+// ListPrivilegeGroups provides a mock function with given fields: ctx
+func (_m *IMetaTable) ListPrivilegeGroups(ctx context.Context) ([]*milvuspb.PrivilegeGroupInfo, error) {
+	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ListPrivilegeGroups")
@@ -2121,19 +2139,19 @@ func (_m *IMetaTable) ListPrivilegeGroups() ([]*milvuspb.PrivilegeGroupInfo, err
 
 	var r0 []*milvuspb.PrivilegeGroupInfo
 	var r1 error
-	if rf, ok := ret.Get(0).(func() ([]*milvuspb.PrivilegeGroupInfo, error)); ok {
-		return rf()
+	if rf, ok := ret.Get(0).(func(context.Context) ([]*milvuspb.PrivilegeGroupInfo, error)); ok {
+		return rf(ctx)
 	}
-	if rf, ok := ret.Get(0).(func() []*milvuspb.PrivilegeGroupInfo); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(context.Context) []*milvuspb.PrivilegeGroupInfo); ok {
+		r0 = rf(ctx)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*milvuspb.PrivilegeGroupInfo)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -2147,13 +2165,14 @@ type IMetaTable_ListPrivilegeGroups_Call struct {
 }
 
 // ListPrivilegeGroups is a helper method to define mock.On call
-func (_e *IMetaTable_Expecter) ListPrivilegeGroups() *IMetaTable_ListPrivilegeGroups_Call {
-	return &IMetaTable_ListPrivilegeGroups_Call{Call: _e.mock.On("ListPrivilegeGroups")}
+//   - ctx context.Context
+func (_e *IMetaTable_Expecter) ListPrivilegeGroups(ctx interface{}) *IMetaTable_ListPrivilegeGroups_Call {
+	return &IMetaTable_ListPrivilegeGroups_Call{Call: _e.mock.On("ListPrivilegeGroups", ctx)}
 }
 
-func (_c *IMetaTable_ListPrivilegeGroups_Call) Run(run func()) *IMetaTable_ListPrivilegeGroups_Call {
+func (_c *IMetaTable_ListPrivilegeGroups_Call) Run(run func(ctx context.Context)) *IMetaTable_ListPrivilegeGroups_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -2163,14 +2182,14 @@ func (_c *IMetaTable_ListPrivilegeGroups_Call) Return(_a0 []*milvuspb.PrivilegeG
 	return _c
 }
 
-func (_c *IMetaTable_ListPrivilegeGroups_Call) RunAndReturn(run func() ([]*milvuspb.PrivilegeGroupInfo, error)) *IMetaTable_ListPrivilegeGroups_Call {
+func (_c *IMetaTable_ListPrivilegeGroups_Call) RunAndReturn(run func(context.Context) ([]*milvuspb.PrivilegeGroupInfo, error)) *IMetaTable_ListPrivilegeGroups_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// ListUserRole provides a mock function with given fields: tenant
-func (_m *IMetaTable) ListUserRole(tenant string) ([]string, error) {
-	ret := _m.Called(tenant)
+// ListUserRole provides a mock function with given fields: ctx, tenant
+func (_m *IMetaTable) ListUserRole(ctx context.Context, tenant string) ([]string, error) {
+	ret := _m.Called(ctx, tenant)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ListUserRole")
@@ -2178,19 +2197,19 @@ func (_m *IMetaTable) ListUserRole(tenant string) ([]string, error) {
 
 	var r0 []string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string) ([]string, error)); ok {
-		return rf(tenant)
+	if rf, ok := ret.Get(0).(func(context.Context, string) ([]string, error)); ok {
+		return rf(ctx, tenant)
 	}
-	if rf, ok := ret.Get(0).(func(string) []string); ok {
-		r0 = rf(tenant)
+	if rf, ok := ret.Get(0).(func(context.Context, string) []string); ok {
+		r0 = rf(ctx, tenant)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]string)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(tenant)
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, tenant)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -2204,14 +2223,15 @@ type IMetaTable_ListUserRole_Call struct {
 }
 
 // ListUserRole is a helper method to define mock.On call
+//   - ctx context.Context
 //   - tenant string
-func (_e *IMetaTable_Expecter) ListUserRole(tenant interface{}) *IMetaTable_ListUserRole_Call {
-	return &IMetaTable_ListUserRole_Call{Call: _e.mock.On("ListUserRole", tenant)}
+func (_e *IMetaTable_Expecter) ListUserRole(ctx interface{}, tenant interface{}) *IMetaTable_ListUserRole_Call {
+	return &IMetaTable_ListUserRole_Call{Call: _e.mock.On("ListUserRole", ctx, tenant)}
 }
 
-func (_c *IMetaTable_ListUserRole_Call) Run(run func(tenant string)) *IMetaTable_ListUserRole_Call {
+func (_c *IMetaTable_ListUserRole_Call) Run(run func(ctx context.Context, tenant string)) *IMetaTable_ListUserRole_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -2221,22 +2241,22 @@ func (_c *IMetaTable_ListUserRole_Call) Return(_a0 []string, _a1 error) *IMetaTa
 	return _c
 }
 
-func (_c *IMetaTable_ListUserRole_Call) RunAndReturn(run func(string) ([]string, error)) *IMetaTable_ListUserRole_Call {
+func (_c *IMetaTable_ListUserRole_Call) RunAndReturn(run func(context.Context, string) ([]string, error)) *IMetaTable_ListUserRole_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// OperatePrivilege provides a mock function with given fields: tenant, entity, operateType
-func (_m *IMetaTable) OperatePrivilege(tenant string, entity *milvuspb.GrantEntity, operateType milvuspb.OperatePrivilegeType) error {
-	ret := _m.Called(tenant, entity, operateType)
+// OperatePrivilege provides a mock function with given fields: ctx, tenant, entity, operateType
+func (_m *IMetaTable) OperatePrivilege(ctx context.Context, tenant string, entity *milvuspb.GrantEntity, operateType milvuspb.OperatePrivilegeType) error {
+	ret := _m.Called(ctx, tenant, entity, operateType)
 
 	if len(ret) == 0 {
 		panic("no return value specified for OperatePrivilege")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, *milvuspb.GrantEntity, milvuspb.OperatePrivilegeType) error); ok {
-		r0 = rf(tenant, entity, operateType)
+	if rf, ok := ret.Get(0).(func(context.Context, string, *milvuspb.GrantEntity, milvuspb.OperatePrivilegeType) error); ok {
+		r0 = rf(ctx, tenant, entity, operateType)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -2250,16 +2270,17 @@ type IMetaTable_OperatePrivilege_Call struct {
 }
 
 // OperatePrivilege is a helper method to define mock.On call
+//   - ctx context.Context
 //   - tenant string
 //   - entity *milvuspb.GrantEntity
 //   - operateType milvuspb.OperatePrivilegeType
-func (_e *IMetaTable_Expecter) OperatePrivilege(tenant interface{}, entity interface{}, operateType interface{}) *IMetaTable_OperatePrivilege_Call {
-	return &IMetaTable_OperatePrivilege_Call{Call: _e.mock.On("OperatePrivilege", tenant, entity, operateType)}
+func (_e *IMetaTable_Expecter) OperatePrivilege(ctx interface{}, tenant interface{}, entity interface{}, operateType interface{}) *IMetaTable_OperatePrivilege_Call {
+	return &IMetaTable_OperatePrivilege_Call{Call: _e.mock.On("OperatePrivilege", ctx, tenant, entity, operateType)}
 }
 
-func (_c *IMetaTable_OperatePrivilege_Call) Run(run func(tenant string, entity *milvuspb.GrantEntity, operateType milvuspb.OperatePrivilegeType)) *IMetaTable_OperatePrivilege_Call {
+func (_c *IMetaTable_OperatePrivilege_Call) Run(run func(ctx context.Context, tenant string, entity *milvuspb.GrantEntity, operateType milvuspb.OperatePrivilegeType)) *IMetaTable_OperatePrivilege_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(*milvuspb.GrantEntity), args[2].(milvuspb.OperatePrivilegeType))
+		run(args[0].(context.Context), args[1].(string), args[2].(*milvuspb.GrantEntity), args[3].(milvuspb.OperatePrivilegeType))
 	})
 	return _c
 }
@@ -2269,22 +2290,22 @@ func (_c *IMetaTable_OperatePrivilege_Call) Return(_a0 error) *IMetaTable_Operat
 	return _c
 }
 
-func (_c *IMetaTable_OperatePrivilege_Call) RunAndReturn(run func(string, *milvuspb.GrantEntity, milvuspb.OperatePrivilegeType) error) *IMetaTable_OperatePrivilege_Call {
+func (_c *IMetaTable_OperatePrivilege_Call) RunAndReturn(run func(context.Context, string, *milvuspb.GrantEntity, milvuspb.OperatePrivilegeType) error) *IMetaTable_OperatePrivilege_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// OperatePrivilegeGroup provides a mock function with given fields: groupName, privileges, operateType
-func (_m *IMetaTable) OperatePrivilegeGroup(groupName string, privileges []*milvuspb.PrivilegeEntity, operateType milvuspb.OperatePrivilegeGroupType) error {
-	ret := _m.Called(groupName, privileges, operateType)
+// OperatePrivilegeGroup provides a mock function with given fields: ctx, groupName, privileges, operateType
+func (_m *IMetaTable) OperatePrivilegeGroup(ctx context.Context, groupName string, privileges []*milvuspb.PrivilegeEntity, operateType milvuspb.OperatePrivilegeGroupType) error {
+	ret := _m.Called(ctx, groupName, privileges, operateType)
 
 	if len(ret) == 0 {
 		panic("no return value specified for OperatePrivilegeGroup")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, []*milvuspb.PrivilegeEntity, milvuspb.OperatePrivilegeGroupType) error); ok {
-		r0 = rf(groupName, privileges, operateType)
+	if rf, ok := ret.Get(0).(func(context.Context, string, []*milvuspb.PrivilegeEntity, milvuspb.OperatePrivilegeGroupType) error); ok {
+		r0 = rf(ctx, groupName, privileges, operateType)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -2298,16 +2319,17 @@ type IMetaTable_OperatePrivilegeGroup_Call struct {
 }
 
 // OperatePrivilegeGroup is a helper method to define mock.On call
+//   - ctx context.Context
 //   - groupName string
 //   - privileges []*milvuspb.PrivilegeEntity
 //   - operateType milvuspb.OperatePrivilegeGroupType
-func (_e *IMetaTable_Expecter) OperatePrivilegeGroup(groupName interface{}, privileges interface{}, operateType interface{}) *IMetaTable_OperatePrivilegeGroup_Call {
-	return &IMetaTable_OperatePrivilegeGroup_Call{Call: _e.mock.On("OperatePrivilegeGroup", groupName, privileges, operateType)}
+func (_e *IMetaTable_Expecter) OperatePrivilegeGroup(ctx interface{}, groupName interface{}, privileges interface{}, operateType interface{}) *IMetaTable_OperatePrivilegeGroup_Call {
+	return &IMetaTable_OperatePrivilegeGroup_Call{Call: _e.mock.On("OperatePrivilegeGroup", ctx, groupName, privileges, operateType)}
 }
 
-func (_c *IMetaTable_OperatePrivilegeGroup_Call) Run(run func(groupName string, privileges []*milvuspb.PrivilegeEntity, operateType milvuspb.OperatePrivilegeGroupType)) *IMetaTable_OperatePrivilegeGroup_Call {
+func (_c *IMetaTable_OperatePrivilegeGroup_Call) Run(run func(ctx context.Context, groupName string, privileges []*milvuspb.PrivilegeEntity, operateType milvuspb.OperatePrivilegeGroupType)) *IMetaTable_OperatePrivilegeGroup_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].([]*milvuspb.PrivilegeEntity), args[2].(milvuspb.OperatePrivilegeGroupType))
+		run(args[0].(context.Context), args[1].(string), args[2].([]*milvuspb.PrivilegeEntity), args[3].(milvuspb.OperatePrivilegeGroupType))
 	})
 	return _c
 }
@@ -2317,22 +2339,22 @@ func (_c *IMetaTable_OperatePrivilegeGroup_Call) Return(_a0 error) *IMetaTable_O
 	return _c
 }
 
-func (_c *IMetaTable_OperatePrivilegeGroup_Call) RunAndReturn(run func(string, []*milvuspb.PrivilegeEntity, milvuspb.OperatePrivilegeGroupType) error) *IMetaTable_OperatePrivilegeGroup_Call {
+func (_c *IMetaTable_OperatePrivilegeGroup_Call) RunAndReturn(run func(context.Context, string, []*milvuspb.PrivilegeEntity, milvuspb.OperatePrivilegeGroupType) error) *IMetaTable_OperatePrivilegeGroup_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// OperateUserRole provides a mock function with given fields: tenant, userEntity, roleEntity, operateType
-func (_m *IMetaTable) OperateUserRole(tenant string, userEntity *milvuspb.UserEntity, roleEntity *milvuspb.RoleEntity, operateType milvuspb.OperateUserRoleType) error {
-	ret := _m.Called(tenant, userEntity, roleEntity, operateType)
+// OperateUserRole provides a mock function with given fields: ctx, tenant, userEntity, roleEntity, operateType
+func (_m *IMetaTable) OperateUserRole(ctx context.Context, tenant string, userEntity *milvuspb.UserEntity, roleEntity *milvuspb.RoleEntity, operateType milvuspb.OperateUserRoleType) error {
+	ret := _m.Called(ctx, tenant, userEntity, roleEntity, operateType)
 
 	if len(ret) == 0 {
 		panic("no return value specified for OperateUserRole")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, *milvuspb.UserEntity, *milvuspb.RoleEntity, milvuspb.OperateUserRoleType) error); ok {
-		r0 = rf(tenant, userEntity, roleEntity, operateType)
+	if rf, ok := ret.Get(0).(func(context.Context, string, *milvuspb.UserEntity, *milvuspb.RoleEntity, milvuspb.OperateUserRoleType) error); ok {
+		r0 = rf(ctx, tenant, userEntity, roleEntity, operateType)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -2346,17 +2368,18 @@ type IMetaTable_OperateUserRole_Call struct {
 }
 
 // OperateUserRole is a helper method to define mock.On call
+//   - ctx context.Context
 //   - tenant string
 //   - userEntity *milvuspb.UserEntity
 //   - roleEntity *milvuspb.RoleEntity
 //   - operateType milvuspb.OperateUserRoleType
-func (_e *IMetaTable_Expecter) OperateUserRole(tenant interface{}, userEntity interface{}, roleEntity interface{}, operateType interface{}) *IMetaTable_OperateUserRole_Call {
-	return &IMetaTable_OperateUserRole_Call{Call: _e.mock.On("OperateUserRole", tenant, userEntity, roleEntity, operateType)}
+func (_e *IMetaTable_Expecter) OperateUserRole(ctx interface{}, tenant interface{}, userEntity interface{}, roleEntity interface{}, operateType interface{}) *IMetaTable_OperateUserRole_Call {
+	return &IMetaTable_OperateUserRole_Call{Call: _e.mock.On("OperateUserRole", ctx, tenant, userEntity, roleEntity, operateType)}
 }
 
-func (_c *IMetaTable_OperateUserRole_Call) Run(run func(tenant string, userEntity *milvuspb.UserEntity, roleEntity *milvuspb.RoleEntity, operateType milvuspb.OperateUserRoleType)) *IMetaTable_OperateUserRole_Call {
+func (_c *IMetaTable_OperateUserRole_Call) Run(run func(ctx context.Context, tenant string, userEntity *milvuspb.UserEntity, roleEntity *milvuspb.RoleEntity, operateType milvuspb.OperateUserRoleType)) *IMetaTable_OperateUserRole_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(*milvuspb.UserEntity), args[2].(*milvuspb.RoleEntity), args[3].(milvuspb.OperateUserRoleType))
+		run(args[0].(context.Context), args[1].(string), args[2].(*milvuspb.UserEntity), args[3].(*milvuspb.RoleEntity), args[4].(milvuspb.OperateUserRoleType))
 	})
 	return _c
 }
@@ -2366,7 +2389,7 @@ func (_c *IMetaTable_OperateUserRole_Call) Return(_a0 error) *IMetaTable_Operate
 	return _c
 }
 
-func (_c *IMetaTable_OperateUserRole_Call) RunAndReturn(run func(string, *milvuspb.UserEntity, *milvuspb.RoleEntity, milvuspb.OperateUserRoleType) error) *IMetaTable_OperateUserRole_Call {
+func (_c *IMetaTable_OperateUserRole_Call) RunAndReturn(run func(context.Context, string, *milvuspb.UserEntity, *milvuspb.RoleEntity, milvuspb.OperateUserRoleType) error) *IMetaTable_OperateUserRole_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -2568,9 +2591,9 @@ func (_c *IMetaTable_RestoreRBAC_Call) RunAndReturn(run func(context.Context, st
 	return _c
 }
 
-// SelectGrant provides a mock function with given fields: tenant, entity
-func (_m *IMetaTable) SelectGrant(tenant string, entity *milvuspb.GrantEntity) ([]*milvuspb.GrantEntity, error) {
-	ret := _m.Called(tenant, entity)
+// SelectGrant provides a mock function with given fields: ctx, tenant, entity
+func (_m *IMetaTable) SelectGrant(ctx context.Context, tenant string, entity *milvuspb.GrantEntity) ([]*milvuspb.GrantEntity, error) {
+	ret := _m.Called(ctx, tenant, entity)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SelectGrant")
@@ -2578,19 +2601,19 @@ func (_m *IMetaTable) SelectGrant(tenant string, entity *milvuspb.GrantEntity) (
 
 	var r0 []*milvuspb.GrantEntity
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string, *milvuspb.GrantEntity) ([]*milvuspb.GrantEntity, error)); ok {
-		return rf(tenant, entity)
+	if rf, ok := ret.Get(0).(func(context.Context, string, *milvuspb.GrantEntity) ([]*milvuspb.GrantEntity, error)); ok {
+		return rf(ctx, tenant, entity)
 	}
-	if rf, ok := ret.Get(0).(func(string, *milvuspb.GrantEntity) []*milvuspb.GrantEntity); ok {
-		r0 = rf(tenant, entity)
+	if rf, ok := ret.Get(0).(func(context.Context, string, *milvuspb.GrantEntity) []*milvuspb.GrantEntity); ok {
+		r0 = rf(ctx, tenant, entity)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*milvuspb.GrantEntity)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(string, *milvuspb.GrantEntity) error); ok {
-		r1 = rf(tenant, entity)
+	if rf, ok := ret.Get(1).(func(context.Context, string, *milvuspb.GrantEntity) error); ok {
+		r1 = rf(ctx, tenant, entity)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -2604,15 +2627,16 @@ type IMetaTable_SelectGrant_Call struct {
 }
 
 // SelectGrant is a helper method to define mock.On call
+//   - ctx context.Context
 //   - tenant string
 //   - entity *milvuspb.GrantEntity
-func (_e *IMetaTable_Expecter) SelectGrant(tenant interface{}, entity interface{}) *IMetaTable_SelectGrant_Call {
-	return &IMetaTable_SelectGrant_Call{Call: _e.mock.On("SelectGrant", tenant, entity)}
+func (_e *IMetaTable_Expecter) SelectGrant(ctx interface{}, tenant interface{}, entity interface{}) *IMetaTable_SelectGrant_Call {
+	return &IMetaTable_SelectGrant_Call{Call: _e.mock.On("SelectGrant", ctx, tenant, entity)}
 }
 
-func (_c *IMetaTable_SelectGrant_Call) Run(run func(tenant string, entity *milvuspb.GrantEntity)) *IMetaTable_SelectGrant_Call {
+func (_c *IMetaTable_SelectGrant_Call) Run(run func(ctx context.Context, tenant string, entity *milvuspb.GrantEntity)) *IMetaTable_SelectGrant_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(*milvuspb.GrantEntity))
+		run(args[0].(context.Context), args[1].(string), args[2].(*milvuspb.GrantEntity))
 	})
 	return _c
 }
@@ -2622,14 +2646,14 @@ func (_c *IMetaTable_SelectGrant_Call) Return(_a0 []*milvuspb.GrantEntity, _a1 e
 	return _c
 }
 
-func (_c *IMetaTable_SelectGrant_Call) RunAndReturn(run func(string, *milvuspb.GrantEntity) ([]*milvuspb.GrantEntity, error)) *IMetaTable_SelectGrant_Call {
+func (_c *IMetaTable_SelectGrant_Call) RunAndReturn(run func(context.Context, string, *milvuspb.GrantEntity) ([]*milvuspb.GrantEntity, error)) *IMetaTable_SelectGrant_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// SelectRole provides a mock function with given fields: tenant, entity, includeUserInfo
-func (_m *IMetaTable) SelectRole(tenant string, entity *milvuspb.RoleEntity, includeUserInfo bool) ([]*milvuspb.RoleResult, error) {
-	ret := _m.Called(tenant, entity, includeUserInfo)
+// SelectRole provides a mock function with given fields: ctx, tenant, entity, includeUserInfo
+func (_m *IMetaTable) SelectRole(ctx context.Context, tenant string, entity *milvuspb.RoleEntity, includeUserInfo bool) ([]*milvuspb.RoleResult, error) {
+	ret := _m.Called(ctx, tenant, entity, includeUserInfo)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SelectRole")
@@ -2637,19 +2661,19 @@ func (_m *IMetaTable) SelectRole(tenant string, entity *milvuspb.RoleEntity, inc
 
 	var r0 []*milvuspb.RoleResult
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string, *milvuspb.RoleEntity, bool) ([]*milvuspb.RoleResult, error)); ok {
-		return rf(tenant, entity, includeUserInfo)
+	if rf, ok := ret.Get(0).(func(context.Context, string, *milvuspb.RoleEntity, bool) ([]*milvuspb.RoleResult, error)); ok {
+		return rf(ctx, tenant, entity, includeUserInfo)
 	}
-	if rf, ok := ret.Get(0).(func(string, *milvuspb.RoleEntity, bool) []*milvuspb.RoleResult); ok {
-		r0 = rf(tenant, entity, includeUserInfo)
+	if rf, ok := ret.Get(0).(func(context.Context, string, *milvuspb.RoleEntity, bool) []*milvuspb.RoleResult); ok {
+		r0 = rf(ctx, tenant, entity, includeUserInfo)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*milvuspb.RoleResult)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(string, *milvuspb.RoleEntity, bool) error); ok {
-		r1 = rf(tenant, entity, includeUserInfo)
+	if rf, ok := ret.Get(1).(func(context.Context, string, *milvuspb.RoleEntity, bool) error); ok {
+		r1 = rf(ctx, tenant, entity, includeUserInfo)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -2663,16 +2687,17 @@ type IMetaTable_SelectRole_Call struct {
 }
 
 // SelectRole is a helper method to define mock.On call
+//   - ctx context.Context
 //   - tenant string
 //   - entity *milvuspb.RoleEntity
 //   - includeUserInfo bool
-func (_e *IMetaTable_Expecter) SelectRole(tenant interface{}, entity interface{}, includeUserInfo interface{}) *IMetaTable_SelectRole_Call {
-	return &IMetaTable_SelectRole_Call{Call: _e.mock.On("SelectRole", tenant, entity, includeUserInfo)}
+func (_e *IMetaTable_Expecter) SelectRole(ctx interface{}, tenant interface{}, entity interface{}, includeUserInfo interface{}) *IMetaTable_SelectRole_Call {
+	return &IMetaTable_SelectRole_Call{Call: _e.mock.On("SelectRole", ctx, tenant, entity, includeUserInfo)}
 }
 
-func (_c *IMetaTable_SelectRole_Call) Run(run func(tenant string, entity *milvuspb.RoleEntity, includeUserInfo bool)) *IMetaTable_SelectRole_Call {
+func (_c *IMetaTable_SelectRole_Call) Run(run func(ctx context.Context, tenant string, entity *milvuspb.RoleEntity, includeUserInfo bool)) *IMetaTable_SelectRole_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(*milvuspb.RoleEntity), args[2].(bool))
+		run(args[0].(context.Context), args[1].(string), args[2].(*milvuspb.RoleEntity), args[3].(bool))
 	})
 	return _c
 }
@@ -2682,14 +2707,14 @@ func (_c *IMetaTable_SelectRole_Call) Return(_a0 []*milvuspb.RoleResult, _a1 err
 	return _c
 }
 
-func (_c *IMetaTable_SelectRole_Call) RunAndReturn(run func(string, *milvuspb.RoleEntity, bool) ([]*milvuspb.RoleResult, error)) *IMetaTable_SelectRole_Call {
+func (_c *IMetaTable_SelectRole_Call) RunAndReturn(run func(context.Context, string, *milvuspb.RoleEntity, bool) ([]*milvuspb.RoleResult, error)) *IMetaTable_SelectRole_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// SelectUser provides a mock function with given fields: tenant, entity, includeRoleInfo
-func (_m *IMetaTable) SelectUser(tenant string, entity *milvuspb.UserEntity, includeRoleInfo bool) ([]*milvuspb.UserResult, error) {
-	ret := _m.Called(tenant, entity, includeRoleInfo)
+// SelectUser provides a mock function with given fields: ctx, tenant, entity, includeRoleInfo
+func (_m *IMetaTable) SelectUser(ctx context.Context, tenant string, entity *milvuspb.UserEntity, includeRoleInfo bool) ([]*milvuspb.UserResult, error) {
+	ret := _m.Called(ctx, tenant, entity, includeRoleInfo)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SelectUser")
@@ -2697,19 +2722,19 @@ func (_m *IMetaTable) SelectUser(tenant string, entity *milvuspb.UserEntity, inc
 
 	var r0 []*milvuspb.UserResult
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string, *milvuspb.UserEntity, bool) ([]*milvuspb.UserResult, error)); ok {
-		return rf(tenant, entity, includeRoleInfo)
+	if rf, ok := ret.Get(0).(func(context.Context, string, *milvuspb.UserEntity, bool) ([]*milvuspb.UserResult, error)); ok {
+		return rf(ctx, tenant, entity, includeRoleInfo)
 	}
-	if rf, ok := ret.Get(0).(func(string, *milvuspb.UserEntity, bool) []*milvuspb.UserResult); ok {
-		r0 = rf(tenant, entity, includeRoleInfo)
+	if rf, ok := ret.Get(0).(func(context.Context, string, *milvuspb.UserEntity, bool) []*milvuspb.UserResult); ok {
+		r0 = rf(ctx, tenant, entity, includeRoleInfo)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*milvuspb.UserResult)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(string, *milvuspb.UserEntity, bool) error); ok {
-		r1 = rf(tenant, entity, includeRoleInfo)
+	if rf, ok := ret.Get(1).(func(context.Context, string, *milvuspb.UserEntity, bool) error); ok {
+		r1 = rf(ctx, tenant, entity, includeRoleInfo)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -2723,16 +2748,17 @@ type IMetaTable_SelectUser_Call struct {
 }
 
 // SelectUser is a helper method to define mock.On call
+//   - ctx context.Context
 //   - tenant string
 //   - entity *milvuspb.UserEntity
 //   - includeRoleInfo bool
-func (_e *IMetaTable_Expecter) SelectUser(tenant interface{}, entity interface{}, includeRoleInfo interface{}) *IMetaTable_SelectUser_Call {
-	return &IMetaTable_SelectUser_Call{Call: _e.mock.On("SelectUser", tenant, entity, includeRoleInfo)}
+func (_e *IMetaTable_Expecter) SelectUser(ctx interface{}, tenant interface{}, entity interface{}, includeRoleInfo interface{}) *IMetaTable_SelectUser_Call {
+	return &IMetaTable_SelectUser_Call{Call: _e.mock.On("SelectUser", ctx, tenant, entity, includeRoleInfo)}
 }
 
-func (_c *IMetaTable_SelectUser_Call) Run(run func(tenant string, entity *milvuspb.UserEntity, includeRoleInfo bool)) *IMetaTable_SelectUser_Call {
+func (_c *IMetaTable_SelectUser_Call) Run(run func(ctx context.Context, tenant string, entity *milvuspb.UserEntity, includeRoleInfo bool)) *IMetaTable_SelectUser_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(*milvuspb.UserEntity), args[2].(bool))
+		run(args[0].(context.Context), args[1].(string), args[2].(*milvuspb.UserEntity), args[3].(bool))
 	})
 	return _c
 }
@@ -2742,7 +2768,7 @@ func (_c *IMetaTable_SelectUser_Call) Return(_a0 []*milvuspb.UserResult, _a1 err
 	return _c
 }
 
-func (_c *IMetaTable_SelectUser_Call) RunAndReturn(run func(string, *milvuspb.UserEntity, bool) ([]*milvuspb.UserResult, error)) *IMetaTable_SelectUser_Call {
+func (_c *IMetaTable_SelectUser_Call) RunAndReturn(run func(context.Context, string, *milvuspb.UserEntity, bool) ([]*milvuspb.UserResult, error)) *IMetaTable_SelectUser_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/rootcoord/root_coord_test.go
+++ b/internal/rootcoord/root_coord_test.go
@@ -1682,19 +1682,19 @@ func TestRootCoord_RBACError(t *testing.T) {
 	})
 	t.Run("operate user role failed", func(t *testing.T) {
 		mockMeta := c.meta.(*mockMetaTable)
-		mockMeta.SelectRoleFunc = func(tenant string, entity *milvuspb.RoleEntity, includeUserInfo bool) ([]*milvuspb.RoleResult, error) {
+		mockMeta.SelectRoleFunc = func(ctx context.Context, tenant string, entity *milvuspb.RoleEntity, includeUserInfo bool) ([]*milvuspb.RoleResult, error) {
 			return nil, nil
 		}
-		mockMeta.SelectUserFunc = func(tenant string, entity *milvuspb.UserEntity, includeRoleInfo bool) ([]*milvuspb.UserResult, error) {
+		mockMeta.SelectUserFunc = func(ctx context.Context, tenant string, entity *milvuspb.UserEntity, includeRoleInfo bool) ([]*milvuspb.UserResult, error) {
 			return nil, nil
 		}
 		resp, err := c.OperateUserRole(ctx, &milvuspb.OperateUserRoleRequest{RoleName: "foo", Username: "bar", Type: milvuspb.OperateUserRoleType_AddUserToRole})
 		assert.NoError(t, err)
 		assert.NotEqual(t, commonpb.ErrorCode_Success, resp.ErrorCode)
-		mockMeta.SelectRoleFunc = func(tenant string, entity *milvuspb.RoleEntity, includeUserInfo bool) ([]*milvuspb.RoleResult, error) {
+		mockMeta.SelectRoleFunc = func(ctx context.Context, tenant string, entity *milvuspb.RoleEntity, includeUserInfo bool) ([]*milvuspb.RoleResult, error) {
 			return nil, errors.New("mock error")
 		}
-		mockMeta.SelectUserFunc = func(tenant string, entity *milvuspb.UserEntity, includeRoleInfo bool) ([]*milvuspb.UserResult, error) {
+		mockMeta.SelectUserFunc = func(ctx context.Context, tenant string, entity *milvuspb.UserEntity, includeRoleInfo bool) ([]*milvuspb.UserResult, error) {
 			return nil, errors.New("mock error")
 		}
 	})
@@ -1745,10 +1745,10 @@ func TestRootCoord_RBACError(t *testing.T) {
 		}
 
 		mockMeta := c.meta.(*mockMetaTable)
-		mockMeta.SelectRoleFunc = func(tenant string, entity *milvuspb.RoleEntity, includeUserInfo bool) ([]*milvuspb.RoleResult, error) {
+		mockMeta.SelectRoleFunc = func(ctx context.Context, tenant string, entity *milvuspb.RoleEntity, includeUserInfo bool) ([]*milvuspb.RoleResult, error) {
 			return nil, nil
 		}
-		mockMeta.ListPrivilegeGroupsFunc = func() ([]*milvuspb.PrivilegeGroupInfo, error) {
+		mockMeta.ListPrivilegeGroupsFunc = func(ctx context.Context) ([]*milvuspb.PrivilegeGroupInfo, error) {
 			return nil, nil
 		}
 		{
@@ -1765,7 +1765,7 @@ func TestRootCoord_RBACError(t *testing.T) {
 			assert.NotEqual(t, commonpb.ErrorCode_Success, resp.ErrorCode)
 		}
 
-		mockMeta.SelectUserFunc = func(tenant string, entity *milvuspb.UserEntity, includeRoleInfo bool) ([]*milvuspb.UserResult, error) {
+		mockMeta.SelectUserFunc = func(ctx context.Context, tenant string, entity *milvuspb.UserEntity, includeRoleInfo bool) ([]*milvuspb.UserResult, error) {
 			return nil, nil
 		}
 		resp, err := c.OperatePrivilege(ctx, &milvuspb.OperatePrivilegeRequest{Entity: &milvuspb.GrantEntity{
@@ -1779,23 +1779,23 @@ func TestRootCoord_RBACError(t *testing.T) {
 		}, Type: milvuspb.OperatePrivilegeType_Grant})
 		assert.NoError(t, err)
 		assert.NotEqual(t, commonpb.ErrorCode_Success, resp.ErrorCode)
-		mockMeta.SelectRoleFunc = func(tenant string, entity *milvuspb.RoleEntity, includeUserInfo bool) ([]*milvuspb.RoleResult, error) {
+		mockMeta.SelectRoleFunc = func(ctx context.Context, tenant string, entity *milvuspb.RoleEntity, includeUserInfo bool) ([]*milvuspb.RoleResult, error) {
 			return nil, errors.New("mock error")
 		}
-		mockMeta.SelectUserFunc = func(tenant string, entity *milvuspb.UserEntity, includeRoleInfo bool) ([]*milvuspb.UserResult, error) {
+		mockMeta.SelectUserFunc = func(ctx context.Context, tenant string, entity *milvuspb.UserEntity, includeRoleInfo bool) ([]*milvuspb.UserResult, error) {
 			return nil, errors.New("mock error")
 		}
 	})
 
 	t.Run("operate privilege group failed", func(t *testing.T) {
 		mockMeta := c.meta.(*mockMetaTable)
-		mockMeta.ListPrivilegeGroupsFunc = func() ([]*milvuspb.PrivilegeGroupInfo, error) {
+		mockMeta.ListPrivilegeGroupsFunc = func(ctx context.Context) ([]*milvuspb.PrivilegeGroupInfo, error) {
 			return nil, errors.New("mock error")
 		}
-		mockMeta.CreatePrivilegeGroupFunc = func(groupName string) error {
+		mockMeta.CreatePrivilegeGroupFunc = func(ctx context.Context, groupName string) error {
 			return errors.New("mock error")
 		}
-		mockMeta.GetPrivilegeGroupRolesFunc = func(groupName string) ([]*milvuspb.RoleEntity, error) {
+		mockMeta.GetPrivilegeGroupRolesFunc = func(ctx context.Context, groupName string) ([]*milvuspb.RoleEntity, error) {
 			return nil, errors.New("mock error")
 		}
 		{
@@ -1832,7 +1832,7 @@ func TestRootCoord_RBACError(t *testing.T) {
 			assert.NotEqual(t, commonpb.ErrorCode_Success, resp.GetStatus().GetErrorCode())
 		}
 		mockMeta := c.meta.(*mockMetaTable)
-		mockMeta.SelectRoleFunc = func(tenant string, entity *milvuspb.RoleEntity, includeUserInfo bool) ([]*milvuspb.RoleResult, error) {
+		mockMeta.SelectRoleFunc = func(ctx context.Context, tenant string, entity *milvuspb.RoleEntity, includeUserInfo bool) ([]*milvuspb.RoleResult, error) {
 			return nil, nil
 		}
 		{
@@ -1845,21 +1845,21 @@ func TestRootCoord_RBACError(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NotEqual(t, commonpb.ErrorCode_Success, resp.GetStatus().GetErrorCode())
 		}
-		mockMeta.SelectRoleFunc = func(tenant string, entity *milvuspb.RoleEntity, includeUserInfo bool) ([]*milvuspb.RoleResult, error) {
+		mockMeta.SelectRoleFunc = func(ctx context.Context, tenant string, entity *milvuspb.RoleEntity, includeUserInfo bool) ([]*milvuspb.RoleResult, error) {
 			return nil, errors.New("mock error")
 		}
 	})
 
 	t.Run("select grant success", func(t *testing.T) {
 		mockMeta := c.meta.(*mockMetaTable)
-		mockMeta.SelectRoleFunc = func(tenant string, entity *milvuspb.RoleEntity, includeUserInfo bool) ([]*milvuspb.RoleResult, error) {
+		mockMeta.SelectRoleFunc = func(ctx context.Context, tenant string, entity *milvuspb.RoleEntity, includeUserInfo bool) ([]*milvuspb.RoleResult, error) {
 			return []*milvuspb.RoleResult{
 				{
 					Role: &milvuspb.RoleEntity{Name: "foo"},
 				},
 			}, nil
 		}
-		mockMeta.SelectGrantFunc = func(tenant string, entity *milvuspb.GrantEntity) ([]*milvuspb.GrantEntity, error) {
+		mockMeta.SelectGrantFunc = func(ctx context.Context, tenant string, entity *milvuspb.GrantEntity) ([]*milvuspb.GrantEntity, error) {
 			return []*milvuspb.GrantEntity{
 				{
 					Role: &milvuspb.RoleEntity{Name: "foo"},
@@ -1874,11 +1874,11 @@ func TestRootCoord_RBACError(t *testing.T) {
 			assert.Equal(t, commonpb.ErrorCode_Success, resp.GetStatus().GetErrorCode())
 		}
 
-		mockMeta.SelectRoleFunc = func(tenant string, entity *milvuspb.RoleEntity, includeUserInfo bool) ([]*milvuspb.RoleResult, error) {
+		mockMeta.SelectRoleFunc = func(ctx context.Context, tenant string, entity *milvuspb.RoleEntity, includeUserInfo bool) ([]*milvuspb.RoleResult, error) {
 			return nil, errors.New("mock error")
 		}
 
-		mockMeta.SelectGrantFunc = func(tenant string, entity *milvuspb.GrantEntity) ([]*milvuspb.GrantEntity, error) {
+		mockMeta.SelectGrantFunc = func(ctx context.Context, tenant string, entity *milvuspb.GrantEntity) ([]*milvuspb.GrantEntity, error) {
 			return nil, errors.New("mock error")
 		}
 	})
@@ -1889,13 +1889,13 @@ func TestRootCoord_RBACError(t *testing.T) {
 		assert.NotEqual(t, commonpb.ErrorCode_Success, resp.GetStatus().GetErrorCode())
 
 		mockMeta := c.meta.(*mockMetaTable)
-		mockMeta.ListPolicyFunc = func(tenant string) ([]string, error) {
+		mockMeta.ListPolicyFunc = func(ctx context.Context, tenant string) ([]string, error) {
 			return []string{}, nil
 		}
 		resp, err = c.ListPolicy(ctx, &internalpb.ListPolicyRequest{})
 		assert.NoError(t, err)
 		assert.NotEqual(t, commonpb.ErrorCode_Success, resp.GetStatus().GetErrorCode())
-		mockMeta.ListPolicyFunc = func(tenant string) ([]string, error) {
+		mockMeta.ListPolicyFunc = func(ctx context.Context, tenant string) ([]string, error) {
 			return []string{}, errors.New("mock error")
 		}
 	})
@@ -1909,13 +1909,13 @@ func TestRootCoord_BuiltinRoles(t *testing.T) {
 	t.Run("init builtin roles success", func(t *testing.T) {
 		c := newTestCore(withHealthyCode(), withInvalidMeta())
 		mockMeta := c.meta.(*mockMetaTable)
-		mockMeta.CreateRoleFunc = func(tenant string, entity *milvuspb.RoleEntity) error {
+		mockMeta.CreateRoleFunc = func(ctx context.Context, tenant string, entity *milvuspb.RoleEntity) error {
 			return nil
 		}
-		mockMeta.OperatePrivilegeFunc = func(tenant string, entity *milvuspb.GrantEntity, operateType milvuspb.OperatePrivilegeType) error {
+		mockMeta.OperatePrivilegeFunc = func(ctx context.Context, tenant string, entity *milvuspb.GrantEntity, operateType milvuspb.OperatePrivilegeType) error {
 			return nil
 		}
-		mockMeta.ListPrivilegeGroupsFunc = func() ([]*milvuspb.PrivilegeGroupInfo, error) {
+		mockMeta.ListPrivilegeGroupsFunc = func(ctx context.Context) ([]*milvuspb.PrivilegeGroupInfo, error) {
 			return nil, nil
 		}
 		err := c.initBuiltinRoles()
@@ -1929,7 +1929,7 @@ func TestRootCoord_BuiltinRoles(t *testing.T) {
 	t.Run("init builtin roles fail to create role", func(t *testing.T) {
 		c := newTestCore(withHealthyCode(), withInvalidMeta())
 		mockMeta := c.meta.(*mockMetaTable)
-		mockMeta.CreateRoleFunc = func(tenant string, entity *milvuspb.RoleEntity) error {
+		mockMeta.CreateRoleFunc = func(ctx context.Context, tenant string, entity *milvuspb.RoleEntity) error {
 			return merr.ErrPrivilegeNotPermitted
 		}
 		err := c.initBuiltinRoles()
@@ -1938,10 +1938,10 @@ func TestRootCoord_BuiltinRoles(t *testing.T) {
 	t.Run("init builtin roles fail to operate privileg", func(t *testing.T) {
 		c := newTestCore(withHealthyCode(), withInvalidMeta())
 		mockMeta := c.meta.(*mockMetaTable)
-		mockMeta.CreateRoleFunc = func(tenant string, entity *milvuspb.RoleEntity) error {
+		mockMeta.CreateRoleFunc = func(ctx context.Context, tenant string, entity *milvuspb.RoleEntity) error {
 			return nil
 		}
-		mockMeta.OperatePrivilegeFunc = func(tenant string, entity *milvuspb.GrantEntity, operateType milvuspb.OperatePrivilegeType) error {
+		mockMeta.OperatePrivilegeFunc = func(ctx context.Context, tenant string, entity *milvuspb.GrantEntity, operateType milvuspb.OperatePrivilegeType) error {
 			return merr.ErrPrivilegeNotPermitted
 		}
 		err := c.initBuiltinRoles()
@@ -1974,8 +1974,8 @@ func TestCore_InitRBAC(t *testing.T) {
 	t.Run("init default role and public role privilege", func(t *testing.T) {
 		meta := mockrootcoord.NewIMetaTable(t)
 		c := newTestCore(withHealthyCode(), withMeta(meta))
-		meta.EXPECT().CreateRole(mock.Anything, mock.Anything).Return(nil).Twice()
-		meta.EXPECT().OperatePrivilege(mock.Anything, mock.Anything, mock.Anything).Return(nil).Twice()
+		meta.EXPECT().CreateRole(mock.Anything, mock.Anything, mock.Anything).Return(nil).Twice()
+		meta.EXPECT().OperatePrivilege(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Twice()
 
 		Params.Save(Params.RoleCfg.Enabled.Key, "false")
 		Params.Save(Params.ProxyCfg.EnablePublicPrivilege.Key, "true")
@@ -1993,8 +1993,8 @@ func TestCore_InitRBAC(t *testing.T) {
 		builtinRoles := `{"db_admin": {"privileges": [{"object_type": "Global", "object_name": "*", "privilege": "CreateCollection", "db_name": "*"}]}}`
 		meta := mockrootcoord.NewIMetaTable(t)
 		c := newTestCore(withHealthyCode(), withMeta(meta))
-		meta.EXPECT().CreateRole(mock.Anything, mock.Anything).Return(nil).Times(3)
-		meta.EXPECT().OperatePrivilege(mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+		meta.EXPECT().CreateRole(mock.Anything, mock.Anything, mock.Anything).Return(nil).Times(3)
+		meta.EXPECT().OperatePrivilege(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 
 		Params.Save(Params.RoleCfg.Enabled.Key, "true")
 		Params.Save(Params.RoleCfg.Roles.Key, builtinRoles)

--- a/internal/rootcoord/show_collection_task.go
+++ b/internal/rootcoord/show_collection_task.go
@@ -65,7 +65,7 @@ func (t *showCollectionTask) Execute(ctx context.Context) error {
 			privilegeColls.Insert(util.AnyWord)
 			return privilegeColls, nil
 		}
-		userRoles, err := t.core.meta.SelectUser("", &milvuspb.UserEntity{
+		userRoles, err := t.core.meta.SelectUser(ctx, "", &milvuspb.UserEntity{
 			Name: curUser,
 		}, true)
 		if err != nil {
@@ -79,7 +79,7 @@ func (t *showCollectionTask) Execute(ctx context.Context) error {
 				privilegeColls.Insert(util.AnyWord)
 				return privilegeColls, nil
 			}
-			entities, err := t.core.meta.SelectGrant("", &milvuspb.GrantEntity{
+			entities, err := t.core.meta.SelectGrant(ctx, "", &milvuspb.GrantEntity{
 				Role:   role,
 				DbName: t.Req.GetDbName(),
 			})

--- a/internal/rootcoord/show_collection_task_test.go
+++ b/internal/rootcoord/show_collection_task_test.go
@@ -169,7 +169,7 @@ func TestShowCollectionsAuth(t *testing.T) {
 		meta := mockrootcoord.NewIMetaTable(t)
 		core := newTestCore(withMeta(meta))
 
-		meta.EXPECT().SelectUser(mock.Anything, mock.Anything, mock.Anything).
+		meta.EXPECT().SelectUser(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 			Return(nil, errors.New("mock error: select user")).Once()
 
 		task := &showCollectionTask{
@@ -189,7 +189,7 @@ func TestShowCollectionsAuth(t *testing.T) {
 		meta := mockrootcoord.NewIMetaTable(t)
 		core := newTestCore(withMeta(meta))
 
-		meta.EXPECT().SelectUser(mock.Anything, mock.Anything, mock.Anything).
+		meta.EXPECT().SelectUser(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 			Return([]*milvuspb.UserResult{}, nil).Once()
 
 		task := &showCollectionTask{
@@ -210,7 +210,7 @@ func TestShowCollectionsAuth(t *testing.T) {
 		meta := mockrootcoord.NewIMetaTable(t)
 		core := newTestCore(withMeta(meta))
 
-		meta.EXPECT().SelectUser(mock.Anything, mock.Anything, mock.Anything).
+		meta.EXPECT().SelectUser(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 			Return([]*milvuspb.UserResult{
 				{
 					User: &milvuspb.UserEntity{
@@ -250,7 +250,7 @@ func TestShowCollectionsAuth(t *testing.T) {
 		meta := mockrootcoord.NewIMetaTable(t)
 		core := newTestCore(withMeta(meta))
 
-		meta.EXPECT().SelectUser(mock.Anything, mock.Anything, mock.Anything).
+		meta.EXPECT().SelectUser(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 			Return([]*milvuspb.UserResult{
 				{
 					User: &milvuspb.UserEntity{
@@ -263,7 +263,7 @@ func TestShowCollectionsAuth(t *testing.T) {
 					},
 				},
 			}, nil).Once()
-		meta.EXPECT().SelectGrant(mock.Anything, mock.Anything).Return(nil, errors.New("mock error: select grant")).Once()
+		meta.EXPECT().SelectGrant(mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("mock error: select grant")).Once()
 
 		task := &showCollectionTask{
 			baseTask: newBaseTask(context.Background(), core),
@@ -281,7 +281,7 @@ func TestShowCollectionsAuth(t *testing.T) {
 		meta := mockrootcoord.NewIMetaTable(t)
 		core := newTestCore(withMeta(meta))
 
-		meta.EXPECT().SelectUser(mock.Anything, mock.Anything, mock.Anything).
+		meta.EXPECT().SelectUser(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 			Return([]*milvuspb.UserResult{
 				{
 					User: &milvuspb.UserEntity{
@@ -294,7 +294,7 @@ func TestShowCollectionsAuth(t *testing.T) {
 					},
 				},
 			}, nil).Once()
-		meta.EXPECT().SelectGrant(mock.Anything, mock.Anything).Return([]*milvuspb.GrantEntity{
+		meta.EXPECT().SelectGrant(mock.Anything, mock.Anything, mock.Anything).Return([]*milvuspb.GrantEntity{
 			{
 				Object: &milvuspb.ObjectEntity{Name: commonpb.ObjectType_Global.String()},
 				Grantor: &milvuspb.GrantorEntity{
@@ -331,7 +331,7 @@ func TestShowCollectionsAuth(t *testing.T) {
 		meta := mockrootcoord.NewIMetaTable(t)
 		core := newTestCore(withMeta(meta))
 
-		meta.EXPECT().SelectUser(mock.Anything, mock.Anything, mock.Anything).
+		meta.EXPECT().SelectUser(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 			Return([]*milvuspb.UserResult{
 				{
 					User: &milvuspb.UserEntity{
@@ -344,7 +344,7 @@ func TestShowCollectionsAuth(t *testing.T) {
 					},
 				},
 			}, nil).Once()
-		meta.EXPECT().SelectGrant(mock.Anything, mock.Anything).Return([]*milvuspb.GrantEntity{
+		meta.EXPECT().SelectGrant(mock.Anything, mock.Anything, mock.Anything).Return([]*milvuspb.GrantEntity{
 			{
 				Object:     &milvuspb.ObjectEntity{Name: commonpb.ObjectType_Collection.String()},
 				ObjectName: util.AnyWord,
@@ -376,7 +376,7 @@ func TestShowCollectionsAuth(t *testing.T) {
 		meta := mockrootcoord.NewIMetaTable(t)
 		core := newTestCore(withMeta(meta))
 
-		meta.EXPECT().SelectUser(mock.Anything, mock.Anything, mock.Anything).
+		meta.EXPECT().SelectUser(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 			Return([]*milvuspb.UserResult{
 				{
 					User: &milvuspb.UserEntity{
@@ -389,7 +389,7 @@ func TestShowCollectionsAuth(t *testing.T) {
 					},
 				},
 			}, nil).Once()
-		meta.EXPECT().SelectGrant(mock.Anything, mock.Anything).Return([]*milvuspb.GrantEntity{
+		meta.EXPECT().SelectGrant(mock.Anything, mock.Anything, mock.Anything).Return([]*milvuspb.GrantEntity{
 			{
 				Object:     &milvuspb.ObjectEntity{Name: commonpb.ObjectType_Collection.String()},
 				ObjectName: "a",


### PR DESCRIPTION
issue: #35917
Before enhancing log trace information, it's necessary to pass the context to the method entry point.
This PR first refine the rootcoord/metatable interfaces to ensure that each method includes a ctx parameter.


