### PR TITLE
enhance: Enable manual start component in standalone

### DIFF
--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -41,6 +41,7 @@ const (
 
 // for every component, register it's own api to trigger stop and check ready
 const (
+	RouteTriggerStartPath    = "/management/start"
 	RouteTriggerStopPath     = "/management/stop"
 	RouteCheckComponentReady = "/management/check/ready"
 	RouteWebUI               = "/webui/"

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -106,6 +106,26 @@ func registerDefaults() {
 	RegisterWebUIHandler()
 }
 
+func RegisterStartComponent(triggerComponentStart func(role string) error) {
+	// register restful api to trigger stop
+	Register(&Handler{
+		Path: RouteTriggerStartPath,
+		HandlerFunc: func(w http.ResponseWriter, req *http.Request) {
+			role := req.URL.Query().Get("role")
+			log.Info("start to trigger component start", zap.String("role", role))
+			if err := triggerComponentStart(role); err != nil {
+				log.Warn("failed to trigger component start", zap.Error(err))
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte(fmt.Sprintf(`{"msg": "failed to trigger component start, %s"}`, err.Error())))
+				return
+			}
+			log.Info("finish to trigger component start", zap.String("role", role))
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"msg": "OK"}`))
+		},
+	})
+}
+
 func RegisterStopComponent(triggerComponentStop func(role string) error) {
 	// register restful api to trigger stop
 	Register(&Handler{

--- a/internal/http/server_test.go
+++ b/internal/http/server_test.go
@@ -103,7 +103,6 @@ func (suite *HTTPServerTestSuite) TestHealthzHandler() {
 	url := "http://localhost:" + DefaultListenPort + "/healthz"
 	client := http.Client{}
 
-	healthz.SetComponentNum(1)
 	healthz.Register(&MockIndicator{"m1", commonpb.StateCode_Healthy})
 
 	req, _ := http.NewRequest(http.MethodGet, url, nil)
@@ -121,7 +120,6 @@ func (suite *HTTPServerTestSuite) TestHealthzHandler() {
 	body, _ = io.ReadAll(resp.Body)
 	suite.Equal("{\"state\":\"OK\",\"detail\":[{\"name\":\"m1\",\"code\":1}]}", string(body))
 
-	healthz.SetComponentNum(2)
 	healthz.Register(&MockIndicator{"m2", commonpb.StateCode_Abnormal})
 	req, _ = http.NewRequest(http.MethodGet, url, nil)
 	req.Header.Set("Content-Type", "application/json")

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -283,6 +283,8 @@ type commonConfig struct {
 	ReadOnlyPrivileges                  ParamItem `refreshable:"false"`
 	ReadWritePrivileges                 ParamItem `refreshable:"false"`
 	AdminPrivileges                     ParamItem `refreshable:"false"`
+
+	ManualStartComponents ParamItem `refreshable:"false"`
 }
 
 func (p *commonConfig) init(base *BaseTable) {
@@ -924,6 +926,13 @@ This helps Milvus-CDC synchronize incremental data`,
 		Doc:     `use to override the default value of admin privileges,  example: "PrivilegeCreateOwnership,PrivilegeDropOwnership"`,
 	}
 	p.AdminPrivileges.Init(base.mgr)
+
+	p.ManualStartComponents = ParamItem{
+		Key:     "common.manualStartComponent",
+		Doc:     `if component has been set to manualStartComponent, it will skip start progress, then can startup by management api,  example: "querynode,datanode,indexnode,proxy"`,
+		Version: "2.4.17",
+	}
+	p.ManualStartComponents.Init(base.mgr)
 }
 
 type gpuConfig struct {

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -134,6 +134,7 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, 0, len(Params.ReadOnlyPrivileges.GetAsStrings()))
 		assert.Equal(t, 0, len(Params.ReadWritePrivileges.GetAsStrings()))
 		assert.Equal(t, 0, len(Params.AdminPrivileges.GetAsStrings()))
+		assert.Equal(t, 0, len(Params.ManualStartComponents.GetAsStrings()))
 	})
 
 	t.Run("test rootCoordConfig", func(t *testing.T) {


### PR DESCRIPTION
issue: #37871
Enable param 'common.standalone.manualStartComponent' to config roles, which shoule be blocked to run during start a standalone service. then user can call management api `/management/start` to manual start a role in standalone service.