### PR TITLE
enhance: [10kcp] Optimize segmentManager segments

### DIFF
--- a/internal/datacoord/mock_segment_manager.go
+++ b/internal/datacoord/mock_segment_manager.go
@@ -79,9 +79,9 @@ func (_c *MockManager_AllocSegment_Call) RunAndReturn(run func(context.Context, 
 	return _c
 }
 
-// DropSegment provides a mock function with given fields: ctx, segmentID
-func (_m *MockManager) DropSegment(ctx context.Context, segmentID int64) {
-	_m.Called(ctx, segmentID)
+// DropSegment provides a mock function with given fields: ctx, channel, partitionID, segmentID
+func (_m *MockManager) DropSegment(ctx context.Context, channel string, partitionID int64, segmentID int64) {
+	_m.Called(ctx, channel, partitionID, segmentID)
 }
 
 // MockManager_DropSegment_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DropSegment'
@@ -90,15 +90,17 @@ type MockManager_DropSegment_Call struct {
 }
 
 // DropSegment is a helper method to define mock.On call
-//  - ctx context.Context
-//  - segmentID int64
-func (_e *MockManager_Expecter) DropSegment(ctx interface{}, segmentID interface{}) *MockManager_DropSegment_Call {
-	return &MockManager_DropSegment_Call{Call: _e.mock.On("DropSegment", ctx, segmentID)}
+//   - ctx context.Context
+//   - channel string
+//   - partitionID int64
+//   - segmentID int64
+func (_e *MockManager_Expecter) DropSegment(ctx interface{}, channel interface{}, partitionID interface{}, segmentID interface{}) *MockManager_DropSegment_Call {
+	return &MockManager_DropSegment_Call{Call: _e.mock.On("DropSegment", ctx, channel, partitionID, segmentID)}
 }
 
-func (_c *MockManager_DropSegment_Call) Run(run func(ctx context.Context, segmentID int64)) *MockManager_DropSegment_Call {
+func (_c *MockManager_DropSegment_Call) Run(run func(ctx context.Context, channel string, partitionID int64, segmentID int64)) *MockManager_DropSegment_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(int64))
+		run(args[0].(context.Context), args[1].(string), args[2].(int64), args[3].(int64))
 	})
 	return _c
 }
@@ -108,7 +110,7 @@ func (_c *MockManager_DropSegment_Call) Return() *MockManager_DropSegment_Call {
 	return _c
 }
 
-func (_c *MockManager_DropSegment_Call) RunAndReturn(run func(context.Context, int64)) *MockManager_DropSegment_Call {
+func (_c *MockManager_DropSegment_Call) RunAndReturn(run func(context.Context, string, int64, int64)) *MockManager_DropSegment_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -148,17 +150,8 @@ func (_c *MockManager_DropSegmentsOfChannel_Call) RunAndReturn(run func(context.
 }
 
 // ExpireAllocations provides a mock function with given fields: channel, ts
-func (_m *MockManager) ExpireAllocations(channel string, ts uint64) error {
-	ret := _m.Called(channel, ts)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(string, uint64) error); ok {
-		r0 = rf(channel, ts)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
+func (_m *MockManager) ExpireAllocations(channel string, ts uint64) {
+	_m.Called(channel, ts)
 }
 
 // MockManager_ExpireAllocations_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ExpireAllocations'
@@ -180,12 +173,12 @@ func (_c *MockManager_ExpireAllocations_Call) Run(run func(channel string, ts ui
 	return _c
 }
 
-func (_c *MockManager_ExpireAllocations_Call) Return(_a0 error) *MockManager_ExpireAllocations_Call {
-	_c.Call.Return(_a0)
+func (_c *MockManager_ExpireAllocations_Call) Return() *MockManager_ExpireAllocations_Call {
+	_c.Call.Return()
 	return _c
 }
 
-func (_c *MockManager_ExpireAllocations_Call) RunAndReturn(run func(string, uint64) error) *MockManager_ExpireAllocations_Call {
+func (_c *MockManager_ExpireAllocations_Call) RunAndReturn(run func(string, uint64)) *MockManager_ExpireAllocations_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -246,25 +239,25 @@ func (_c *MockManager_GetFlushableSegments_Call) RunAndReturn(run func(context.C
 	return _c
 }
 
-// SealAllSegments provides a mock function with given fields: ctx, collectionID, segIDs
-func (_m *MockManager) SealAllSegments(ctx context.Context, collectionID int64, segIDs []int64) ([]int64, error) {
-	ret := _m.Called(ctx, collectionID, segIDs)
+// SealAllSegments provides a mock function with given fields: ctx, channels, segIDs
+func (_m *MockManager) SealAllSegments(ctx context.Context, channels []string, segIDs []int64) ([]int64, error) {
+	ret := _m.Called(ctx, channels, segIDs)
 
 	var r0 []int64
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, int64, []int64) ([]int64, error)); ok {
-		return rf(ctx, collectionID, segIDs)
+	if rf, ok := ret.Get(0).(func(context.Context, []string, []int64) ([]int64, error)); ok {
+		return rf(ctx, channels, segIDs)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, int64, []int64) []int64); ok {
-		r0 = rf(ctx, collectionID, segIDs)
+	if rf, ok := ret.Get(0).(func(context.Context, []string, []int64) []int64); ok {
+		r0 = rf(ctx, channels, segIDs)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]int64)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, int64, []int64) error); ok {
-		r1 = rf(ctx, collectionID, segIDs)
+	if rf, ok := ret.Get(1).(func(context.Context, []string, []int64) error); ok {
+		r1 = rf(ctx, channels, segIDs)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -278,16 +271,16 @@ type MockManager_SealAllSegments_Call struct {
 }
 
 // SealAllSegments is a helper method to define mock.On call
-//  - ctx context.Context
-//  - collectionID int64
-//  - segIDs []int64
-func (_e *MockManager_Expecter) SealAllSegments(ctx interface{}, collectionID interface{}, segIDs interface{}) *MockManager_SealAllSegments_Call {
-	return &MockManager_SealAllSegments_Call{Call: _e.mock.On("SealAllSegments", ctx, collectionID, segIDs)}
+//   - ctx context.Context
+//   - channels []string
+//   - segIDs []int64
+func (_e *MockManager_Expecter) SealAllSegments(ctx interface{}, channels interface{}, segIDs interface{}) *MockManager_SealAllSegments_Call {
+	return &MockManager_SealAllSegments_Call{Call: _e.mock.On("SealAllSegments", ctx, channels, segIDs)}
 }
 
-func (_c *MockManager_SealAllSegments_Call) Run(run func(ctx context.Context, collectionID int64, segIDs []int64)) *MockManager_SealAllSegments_Call {
+func (_c *MockManager_SealAllSegments_Call) Run(run func(ctx context.Context, channels []string, segIDs []int64)) *MockManager_SealAllSegments_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(int64), args[2].([]int64))
+		run(args[0].(context.Context), args[1].([]string), args[2].([]int64))
 	})
 	return _c
 }
@@ -297,7 +290,7 @@ func (_c *MockManager_SealAllSegments_Call) Return(_a0 []int64, _a1 error) *Mock
 	return _c
 }
 
-func (_c *MockManager_SealAllSegments_Call) RunAndReturn(run func(context.Context, int64, []int64) ([]int64, error)) *MockManager_SealAllSegments_Call {
+func (_c *MockManager_SealAllSegments_Call) RunAndReturn(run func(context.Context, []string, []int64) ([]int64, error)) *MockManager_SealAllSegments_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/datacoord/segment_manager_test.go
+++ b/internal/datacoord/segment_manager_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/milvus-io/milvus/internal/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/util/etcd"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
 
 func TestManagerOptions(t *testing.T) {
@@ -97,6 +98,14 @@ func TestManagerOptions(t *testing.T) {
 	})
 }
 
+func GetSegmentsByChannelAndPartition(t *testing.T, segmentManager *SegmentManager, channel string, partitionID int64) *typeutil.ConcurrentMap[int64, struct{}] {
+	partition2Segments, ok := segmentManager.channel2Segments.Get(channel)
+	assert.True(t, ok)
+	segments, ok := partition2Segments.Get(partitionID)
+	assert.True(t, ok)
+	return segments
+}
+
 func TestAllocSegment(t *testing.T) {
 	ctx := context.Background()
 	paramtable.Init()
@@ -142,19 +151,23 @@ func TestAllocSegment(t *testing.T) {
 	})
 
 	t.Run("alloc clear unhealthy segment", func(t *testing.T) {
-		allocations1, err := segmentManager.AllocSegment(ctx, collID, 100, "c1", 100)
+		vchannel := "c1"
+		partitionID := int64(100)
+		allocations1, err := segmentManager.AllocSegment(ctx, collID, partitionID, vchannel, 100)
 		assert.NoError(t, err)
 		assert.EqualValues(t, 1, len(allocations1))
-		assert.EqualValues(t, 1, len(segmentManager.segments))
+		segments := GetSegmentsByChannelAndPartition(t, segmentManager, vchannel, partitionID)
+		assert.EqualValues(t, 1, segments.Len())
 
 		err = meta.SetState(allocations1[0].SegmentID, commonpb.SegmentState_Dropped)
 		assert.NoError(t, err)
 
-		allocations2, err := segmentManager.AllocSegment(ctx, collID, 100, "c1", 100)
+		allocations2, err := segmentManager.AllocSegment(ctx, collID, partitionID, vchannel, 100)
 		assert.NoError(t, err)
 		assert.EqualValues(t, 1, len(allocations2))
 		// clear old healthy and alloc new
-		assert.EqualValues(t, 1, len(segmentManager.segments))
+		segments = GetSegmentsByChannelAndPartition(t, segmentManager, vchannel, partitionID)
+		assert.EqualValues(t, 1, segments.Len())
 		assert.NotEqual(t, allocations1[0].SegmentID, allocations2[0].SegmentID)
 	})
 }
@@ -217,7 +230,8 @@ func TestLastExpireReset(t *testing.T) {
 	meta.SetCurrentRows(segmentID1, bigRows)
 	meta.SetCurrentRows(segmentID2, bigRows)
 	meta.SetCurrentRows(segmentID3, smallRows)
-	segmentManager.tryToSealSegment(expire1, channelName)
+	err = segmentManager.tryToSealSegment(expire1, channelName)
+	assert.NoError(t, err)
 	assert.Equal(t, commonpb.SegmentState_Sealed, meta.GetSegment(segmentID1).GetState())
 	assert.Equal(t, commonpb.SegmentState_Sealed, meta.GetSegment(segmentID2).GetState())
 	assert.Equal(t, commonpb.SegmentState_Growing, meta.GetSegment(segmentID3).GetState())
@@ -270,11 +284,14 @@ func TestLoadSegmentsFromMeta(t *testing.T) {
 	assert.NoError(t, err)
 	meta.AddCollection(&collectionInfo{ID: collID, Schema: schema})
 
+	vchannel := "ch0"
+	partitionID := int64(100)
+
 	sealedSegment := &datapb.SegmentInfo{
 		ID:             1,
 		CollectionID:   collID,
-		PartitionID:    0,
-		InsertChannel:  "",
+		PartitionID:    partitionID,
+		InsertChannel:  vchannel,
 		State:          commonpb.SegmentState_Sealed,
 		MaxRowNum:      100,
 		LastExpireTime: 1000,
@@ -282,8 +299,8 @@ func TestLoadSegmentsFromMeta(t *testing.T) {
 	growingSegment := &datapb.SegmentInfo{
 		ID:             2,
 		CollectionID:   collID,
-		PartitionID:    0,
-		InsertChannel:  "",
+		PartitionID:    partitionID,
+		InsertChannel:  vchannel,
 		State:          commonpb.SegmentState_Growing,
 		MaxRowNum:      100,
 		LastExpireTime: 1000,
@@ -291,8 +308,8 @@ func TestLoadSegmentsFromMeta(t *testing.T) {
 	flushedSegment := &datapb.SegmentInfo{
 		ID:             3,
 		CollectionID:   collID,
-		PartitionID:    0,
-		InsertChannel:  "",
+		PartitionID:    partitionID,
+		InsertChannel:  vchannel,
 		State:          commonpb.SegmentState_Flushed,
 		MaxRowNum:      100,
 		LastExpireTime: 1000,
@@ -304,9 +321,10 @@ func TestLoadSegmentsFromMeta(t *testing.T) {
 	err = meta.AddSegment(context.TODO(), NewSegmentInfo(flushedSegment))
 	assert.NoError(t, err)
 
-	segmentManager, _ := newSegmentManager(meta, mockAllocator)
-	segments := segmentManager.segments
-	assert.EqualValues(t, 2, len(segments))
+	segmentManager, err := newSegmentManager(meta, mockAllocator)
+	assert.NoError(t, err)
+	segments := GetSegmentsByChannelAndPartition(t, segmentManager, vchannel, partitionID)
+	assert.EqualValues(t, 2, segments.Len())
 }
 
 func TestSaveSegmentsToMeta(t *testing.T) {
@@ -323,7 +341,7 @@ func TestSaveSegmentsToMeta(t *testing.T) {
 	allocations, err := segmentManager.AllocSegment(context.Background(), collID, 0, "c1", 1000)
 	assert.NoError(t, err)
 	assert.EqualValues(t, 1, len(allocations))
-	_, err = segmentManager.SealAllSegments(context.Background(), collID, nil)
+	_, err = segmentManager.SealAllSegments(context.Background(), []string{"c1"}, nil)
 	assert.NoError(t, err)
 	segment := meta.GetHealthySegment(allocations[0].SegmentID)
 	assert.NotNil(t, segment)
@@ -345,7 +363,7 @@ func TestSaveSegmentsToMetaWithSpecificSegments(t *testing.T) {
 	allocations, err := segmentManager.AllocSegment(context.Background(), collID, 0, "c1", 1000)
 	assert.NoError(t, err)
 	assert.EqualValues(t, 1, len(allocations))
-	_, err = segmentManager.SealAllSegments(context.Background(), collID, []int64{allocations[0].SegmentID})
+	_, err = segmentManager.SealAllSegments(context.Background(), []string{"c1"}, []int64{allocations[0].SegmentID})
 	assert.NoError(t, err)
 	segment := meta.GetHealthySegment(allocations[0].SegmentID)
 	assert.NotNil(t, segment)
@@ -364,14 +382,14 @@ func TestDropSegment(t *testing.T) {
 	assert.NoError(t, err)
 	meta.AddCollection(&collectionInfo{ID: collID, Schema: schema})
 	segmentManager, _ := newSegmentManager(meta, mockAllocator)
-	allocations, err := segmentManager.AllocSegment(context.Background(), collID, 0, "c1", 1000)
+	allocations, err := segmentManager.AllocSegment(context.Background(), collID, 100, "c1", 1000)
 	assert.NoError(t, err)
 	assert.EqualValues(t, 1, len(allocations))
 	segID := allocations[0].SegmentID
 	segment := meta.GetHealthySegment(segID)
 	assert.NotNil(t, segment)
 
-	segmentManager.DropSegment(context.Background(), segID)
+	segmentManager.DropSegment(context.Background(), "c1", 100, segID)
 	segment = meta.GetHealthySegment(segID)
 	assert.NotNil(t, segment)
 }
@@ -433,8 +451,7 @@ func TestExpireAllocation(t *testing.T) {
 	segment := meta.GetHealthySegment(id)
 	assert.NotNil(t, segment)
 	assert.EqualValues(t, 100, len(segment.allocations))
-	err = segmentManager.ExpireAllocations("ch1", maxts)
-	assert.NoError(t, err)
+	segmentManager.ExpireAllocations("ch1", maxts)
 	segment = meta.GetHealthySegment(id)
 	assert.NotNil(t, segment)
 	assert.EqualValues(t, 0, len(segment.allocations))
@@ -456,7 +473,7 @@ func TestGetFlushableSegments(t *testing.T) {
 		assert.NoError(t, err)
 		assert.EqualValues(t, 1, len(allocations))
 
-		ids, err := segmentManager.SealAllSegments(context.TODO(), collID, nil)
+		ids, err := segmentManager.SealAllSegments(context.TODO(), []string{"c1"}, nil)
 		assert.NoError(t, err)
 		assert.EqualValues(t, 1, len(ids))
 		assert.EqualValues(t, allocations[0].SegmentID, ids[0])
@@ -750,6 +767,7 @@ func TestAllocationPool(t *testing.T) {
 }
 
 func TestSegmentManager_DropSegmentsOfChannel(t *testing.T) {
+	partitionID := int64(100)
 	type fields struct {
 		meta     *meta
 		segments []UniqueID
@@ -772,6 +790,7 @@ func TestSegmentManager_DropSegmentsOfChannel(t *testing.T) {
 							1: {
 								SegmentInfo: &datapb.SegmentInfo{
 									ID:            1,
+									PartitionID:   partitionID,
 									InsertChannel: "ch1",
 									State:         commonpb.SegmentState_Flushed,
 								},
@@ -779,6 +798,7 @@ func TestSegmentManager_DropSegmentsOfChannel(t *testing.T) {
 							2: {
 								SegmentInfo: &datapb.SegmentInfo{
 									ID:            2,
+									PartitionID:   partitionID,
 									InsertChannel: "ch2",
 									State:         commonpb.SegmentState_Flushed,
 								},
@@ -802,6 +822,7 @@ func TestSegmentManager_DropSegmentsOfChannel(t *testing.T) {
 							1: {
 								SegmentInfo: &datapb.SegmentInfo{
 									ID:            1,
+									PartitionID:   partitionID,
 									InsertChannel: "ch1",
 									State:         commonpb.SegmentState_Dropped,
 								},
@@ -809,6 +830,7 @@ func TestSegmentManager_DropSegmentsOfChannel(t *testing.T) {
 							2: {
 								SegmentInfo: &datapb.SegmentInfo{
 									ID:            2,
+									PartitionID:   partitionID,
 									InsertChannel: "ch2",
 									State:         commonpb.SegmentState_Growing,
 								},
@@ -827,11 +849,34 @@ func TestSegmentManager_DropSegmentsOfChannel(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &SegmentManager{
-				meta:     tt.fields.meta,
-				segments: tt.fields.segments,
+				meta:             tt.fields.meta,
+				channel2Segments: typeutil.NewConcurrentMap[string, Partition2Segments](),
+			}
+			for _, segmentID := range tt.fields.segments {
+				segmentInfo := tt.fields.meta.GetSegment(segmentID)
+				partID := partitionID
+				channel := tt.args.channel
+				if segmentInfo != nil {
+					partID = segmentInfo.GetPartitionID()
+					channel = segmentInfo.GetInsertChannel()
+				}
+				partition2Segments, _ := s.channel2Segments.GetOrInsert(channel, typeutil.NewConcurrentMap[int64, Segments]())
+				segments, _ := partition2Segments.GetOrInsert(partID, typeutil.NewConcurrentMap[int64, struct{}]())
+				segments.Insert(segmentID, struct{}{})
 			}
 			s.DropSegmentsOfChannel(context.TODO(), tt.args.channel)
-			assert.ElementsMatch(t, tt.want, s.segments)
+			all := make([]int64, 0)
+			s.channel2Segments.Range(func(_ string, partition2Segments Partition2Segments) bool {
+				partition2Segments.Range(func(_ int64, segments Segments) bool {
+					segments.Range(func(segmentID int64, _ struct{}) bool {
+						all = append(all, segmentID)
+						return true
+					})
+					return true
+				})
+				return true
+			})
+			assert.ElementsMatch(t, tt.want, all)
 		})
 	}
 }

--- a/internal/datacoord/server_test.go
+++ b/internal/datacoord/server_test.go
@@ -821,52 +821,10 @@ func TestServer_getSystemInfoMetrics(t *testing.T) {
 	}
 }
 
-type spySegmentManager struct {
-	spyCh chan struct{}
-}
-
-// AllocSegment allocates rows and record the allocation.
-func (s *spySegmentManager) AllocSegment(ctx context.Context, collectionID UniqueID, partitionID UniqueID, channelName string, requestRows int64) ([]*Allocation, error) {
-	panic("not implemented") // TODO: Implement
-}
-
-func (s *spySegmentManager) allocSegmentForImport(ctx context.Context, collectionID UniqueID, partitionID UniqueID, channelName string, requestRows int64, taskID int64) (*Allocation, error) {
-	panic("not implemented") // TODO: Implement
-}
-
-// DropSegment drops the segment from manager.
-func (s *spySegmentManager) DropSegment(ctx context.Context, segmentID UniqueID) {
-}
-
-// FlushImportSegments set importing segment state to Flushed.
-func (s *spySegmentManager) FlushImportSegments(ctx context.Context, collectionID UniqueID, segmentIDs []UniqueID) error {
-	panic("not implemented")
-}
-
-// SealAllSegments seals all segments of collection with collectionID and return sealed segments
-func (s *spySegmentManager) SealAllSegments(ctx context.Context, collectionID UniqueID, segIDs []UniqueID) ([]UniqueID, error) {
-	panic("not implemented") // TODO: Implement
-}
-
-// GetFlushableSegments returns flushable segment ids
-func (s *spySegmentManager) GetFlushableSegments(ctx context.Context, channel string, ts Timestamp) ([]UniqueID, error) {
-	panic("not implemented") // TODO: Implement
-}
-
-// ExpireAllocations notifies segment status to expire old allocations
-func (s *spySegmentManager) ExpireAllocations(channel string, ts Timestamp) error {
-	panic("not implemented") // TODO: Implement
-}
-
-// DropSegmentsOfChannel drops all segments in a channel
-func (s *spySegmentManager) DropSegmentsOfChannel(ctx context.Context, channel string) {
-	s.spyCh <- struct{}{}
-}
-
 func TestDropVirtualChannel(t *testing.T) {
 	t.Run("normal DropVirtualChannel", func(t *testing.T) {
-		spyCh := make(chan struct{}, 1)
-		svr := newTestServer(t, WithSegmentManager(&spySegmentManager{spyCh: spyCh}))
+		segmentManager := NewMockManager(t)
+		svr := newTestServer(t, WithSegmentManager(segmentManager))
 
 		defer closeTestServer(t, svr)
 
@@ -993,11 +951,10 @@ func TestDropVirtualChannel(t *testing.T) {
 			}
 			req.Segments = append(req.Segments, seg2Drop)
 		}
+		segmentManager.EXPECT().DropSegmentsOfChannel(mock.Anything, mock.Anything).Return()
 		resp, err := svr.DropVirtualChannel(ctx, req)
 		assert.NoError(t, err)
 		assert.Equal(t, commonpb.ErrorCode_Success, resp.GetStatus().GetErrorCode())
-
-		<-spyCh
 
 		// resend
 		resp, err = svr.DropVirtualChannel(ctx, req)

--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -112,7 +112,7 @@ func (s *Server) Flush(ctx context.Context, req *datapb.FlushRequest) (*datapb.F
 	}
 	timeOfSeal, _ := tsoutil.ParseTS(ts)
 
-	sealedSegmentIDs, err := s.segmentManager.SealAllSegments(ctx, req.GetCollectionID(), req.GetSegmentIDs())
+	sealedSegmentIDs, err := s.segmentManager.SealAllSegments(ctx, coll.VChannelNames, req.GetSegmentIDs())
 	if err != nil {
 		return &datapb.FlushResponse{
 			Status: merr.Status(errors.Wrapf(err, "failed to flush collection %d",
@@ -507,10 +507,10 @@ func (s *Server) SaveBinlogPaths(ctx context.Context, req *datapb.SaveBinlogPath
 		// Set segment state
 		if req.GetDropped() {
 			// segmentManager manages growing segments
-			s.segmentManager.DropSegment(ctx, req.GetSegmentID())
+			s.segmentManager.DropSegment(ctx, req.GetChannel(), req.GetPartitionID(), req.GetSegmentID())
 			operators = append(operators, UpdateStatusOperator(req.GetSegmentID(), commonpb.SegmentState_Dropped))
 		} else if req.GetFlushed() {
-			s.segmentManager.DropSegment(ctx, req.GetSegmentID())
+			s.segmentManager.DropSegment(ctx, req.GetChannel(), req.GetPartitionID(), req.GetSegmentID())
 			// set segment to SegmentState_Flushing
 			operators = append(operators, UpdateStatusOperator(req.GetSegmentID(), commonpb.SegmentState_Flushing))
 		}
@@ -1446,10 +1446,7 @@ func (s *Server) handleDataNodeTtMsg(ctx context.Context, ttMsg *msgpb.DataNodeT
 
 	s.updateSegmentStatistics(segmentStats)
 
-	if err := s.segmentManager.ExpireAllocations(channel, ts); err != nil {
-		log.Warn("failed to expire allocations", zap.Error(err))
-		return err
-	}
+	s.segmentManager.ExpireAllocations(channel, ts)
 
 	flushableIDs, err := s.segmentManager.GetFlushableSegments(ctx, channel, ts)
 	if err != nil {

--- a/internal/datacoord/services_test.go
+++ b/internal/datacoord/services_test.go
@@ -773,7 +773,7 @@ func (s *ServerSuite) TestFlush_NormalCase() {
 	s.testServer.cluster = mockCluster
 
 	schema := newTestSchema()
-	s.testServer.meta.AddCollection(&collectionInfo{ID: 0, Schema: schema, Partitions: []int64{}})
+	s.testServer.meta.AddCollection(&collectionInfo{ID: 0, Schema: schema, Partitions: []int64{}, VChannelNames: []string{"channel-1"}})
 	allocations, err := s.testServer.segmentManager.AllocSegment(context.TODO(), 0, 1, "channel-1", 1)
 	s.NoError(err)
 	s.EqualValues(1, len(allocations))


### PR DESCRIPTION
1. Use vchannel and partition indices for segments.
2. Replace coarse-grained mutex with concurrent map.

issue: https://github.com/milvus-io/milvus/issues/37633, https://github.com/milvus-io/milvus/issues/37630

pr: https://github.com/milvus-io/milvus/pull/37836