### PR TITLE
fix: unstable integration test caused by paramtable.GetNodeID

### DIFF
--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -403,13 +403,6 @@ func (sd *shardDelegator) LoadSegments(ctx context.Context, req *querypb.LoadSeg
 	log := sd.getLogger(ctx)
 
 	targetNodeID := req.GetDstNodeID()
-	if len(req.GetInfos()) > 0 && req.GetInfos()[0].Level == datapb.SegmentLevel_L0 {
-		// force l0 segment to load on delegator
-		if targetNodeID != paramtable.GetNodeID() {
-			targetNodeID = paramtable.GetNodeID()
-			log.Info("unexpected L0 segment load on non-delegator node, force to load on delegator", zap.Int64("nodeIDInReq", req.GetDstNodeID()))
-		}
-	}
 	// add common log fields
 	log = log.With(
 		zap.Int64("workID", targetNodeID),

--- a/internal/querynodev2/services.go
+++ b/internal/querynodev2/services.go
@@ -457,6 +457,14 @@ func (node *QueryNode) LoadSegments(ctx context.Context, req *querypb.LoadSegmen
 			return merr.Status(err), nil
 		}
 
+		if len(req.GetInfos()) > 0 && req.GetInfos()[0].Level == datapb.SegmentLevel_L0 {
+			// force l0 segment to load on delegator
+			if req.DstNodeID != node.GetNodeID() {
+				log.Info("unexpected L0 segment load on non-delegator node, force to load on delegator")
+				req.DstNodeID = node.GetNodeID()
+			}
+		}
+
 		req.NeedTransfer = false
 		err := delegator.LoadSegments(ctx, req)
 		if err != nil {


### PR DESCRIPTION
issue: #37908
cause paramtable is global single instance, which cause paramtable.GetNodeID may return wrong server id in integration test.

This PR use node.GetNodeID to replace paramtable.GetNodeID