### PR TITLE
fix: Channel may be released after balance (#37862)

### DIFF
--- a/internal/querycoordv2/dist/dist_handler.go
+++ b/internal/querycoordv2/dist/dist_handler.go
@@ -180,7 +180,11 @@ func (dh *distHandler) updateChannelsDistribution(resp *querypb.GetDataDistribut
 				Version: ch.GetVersion(),
 			}
 		} else {
-			channel = channelInfo.Clone()
+			channel = &meta.DmChannel{
+				VchannelInfo: channelInfo.VchannelInfo,
+				Node:         resp.GetNodeID(),
+				Version:      ch.GetVersion(),
+			}
 		}
 		updates = append(updates, channel)
 	}


### PR DESCRIPTION
issue: #37830
pr: #37862
casue dist handler doesn't set channel's version, so if channel checker try to dedup channel, it may release the new delegator after balance finished.

this PR fix the way to set proper version for channel.