### PR TITLE
fix: used wrong label for query received_nq metrics

### DIFF
--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -3648,7 +3648,7 @@ func (node *Proxy) Query(ctx context.Context, request *milvuspb.QueryRequest) (*
 		SetCollectionName(request.GetCollectionName())
 	metrics.ProxyReceivedNQ.WithLabelValues(
 		strconv.FormatInt(paramtable.GetNodeID(), 10),
-		metrics.SearchLabel,
+		metrics.QueryLabel,
 		request.GetCollectionName(),
 	).Add(float64(1))
 


### PR DESCRIPTION
issue: #37982