### PR TITLE
enhance: Mark cgo thread with tag name

### DIFF
--- a/internal/core/src/segcore/segcore_init_c.cpp
+++ b/internal/core/src/segcore/segcore_init_c.cpp
@@ -108,11 +108,11 @@ GetMinimalIndexVersion() {
 
 extern "C" void
 SetThreadName(const char* name) {
-    #ifdef __linux__
+#ifdef __linux__
     pthread_setname_np(pthread_self(), name);
-    #elif __APPLE__
+#elif __APPLE__
     pthread_setname_np(name);
-    #endif
+#endif
 }
 
 }  // namespace milvus::segcore

--- a/internal/core/src/segcore/segcore_init_c.cpp
+++ b/internal/core/src/segcore/segcore_init_c.cpp
@@ -9,6 +9,7 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
+#include "pthread.h"
 #include "config/ConfigKnowhere.h"
 #include "fmt/core.h"
 #include "log/Log.h"
@@ -103,6 +104,15 @@ GetCurrentIndexVersion() {
 extern "C" int32_t
 GetMinimalIndexVersion() {
     return milvus::config::GetMinimalIndexVersion();
+}
+
+extern "C" void
+SetThreadName(const char* name) {
+    #ifdef __linux__
+    pthread_setname_np(pthread_self(), name);
+    #elif __APPLE__
+    pthread_setname_np(name);
+    #endif
 }
 
 }  // namespace milvus::segcore

--- a/internal/core/src/segcore/segcore_init_c.h
+++ b/internal/core/src/segcore/segcore_init_c.h
@@ -56,6 +56,9 @@ GetCurrentIndexVersion();
 int32_t
 GetMinimalIndexVersion();
 
+void
+SetThreadName(const char*);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Related to #37999

This PR add `SetThreadName` API for marking cgo thread and utilize it when initializing cgo worker.