### PR TITLE
test:[skip e2e] update pulsar labelSelectors to v3 in chaos test

### DIFF
--- a/tests/python_client/chaos/chaos_objects/pod_failure/chaos_pulsar_pod_failure.yaml
+++ b/tests/python_client/chaos/chaos_objects/pod_failure/chaos_pulsar_pod_failure.yaml
@@ -9,7 +9,7 @@ spec:
       - chaos-testing
     labelSelectors:
       release: milvus-chaos
-      app: pulsar
+      app: pulsarv3
   mode: fixed
   value: "1"
   action: pod-failure

--- a/tests/python_client/chaos/chaos_objects/pod_kill/chaos_pulsar_pod_kill.yaml
+++ b/tests/python_client/chaos/chaos_objects/pod_kill/chaos_pulsar_pod_kill.yaml
@@ -15,7 +15,7 @@ spec:
         - chaos-testing
       labelSelectors:
         release: milvus-chaos
-        app: pulsar
+        app: pulsarv3
     mode: fixed
     value: "1"
     action: pod-kill


### PR DESCRIPTION

After upgrading pulsar from v2 to v3, the labels of the helm deployed pulsar were changed from app=pulsarv to app=pulsarv3.
Therefore, it is necessary to modify this part of the labelSelector so that chaos mesh can correctly inject faults