### PR TITLE
fix: Modify the documentation of the Demos and Tutorials chapter (#38054)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,31 @@ Milvus is trusted by AI developers to build applications such as text and image 
 
 Here is a selection of demos and tutorials to show how to build various types of AI applications made with Milvus:
 
+You can explore a comprehensive [Tutorials Overview](https://milvus.io/docs/tutorials-overview.md) covering topics such as Retrieval-Augmented Generation (RAG), Semantic Search, Hybrid Search, Question Answering, Recommendation Systems, and various quick-start guides. These resources are designed to help you get started quickly and efficiently.
+
+| Tutorial | Use Case | Related Milvus Features |
+| -------- | -------- | --------- |
+| [Build RAG with Milvus](https://milvus.io/docs/build-rag-with-milvus.md) |  RAG | vector search |
+| [Multimodal RAG with Milvus](https://milvus.io/docs/multimodal_rag_with_milvus.md) | RAG | vector search, dynamic field |
+| [Image Search with Milvus](https://milvus.io/docs/image_similarity_search.md) | Semantic Search | vector search, dynamic field |
+| [Hybrid Search with Milvus](https://milvus.io/docs/hybrid_search_with_milvus.md) | Hybrid Search | hybrid search, multi vector, dense embedding, sparse embedding |
+| [Multimodal Search using Multi Vectors](https://milvus.io/docs/multimodal_rag_with_milvus.md) | Semantic Search | multi vector, hybrid search |
+| [Question Answering System](https://milvus.io/docs/question_answering_system.md) | Question Answering | vector search |
+| [Recommender System](https://milvus.io/docs/recommendation_system.md) | Recommendation System | vector search |
+| [Video Similarity Search](https://milvus.io/docs/video_similarity_search.md) | Semantic Search | vector search |
+| [Audio Similarity Search](https://milvus.io/docs/audio_similarity_search.md) | Semantic Search | vector search |
+| [DNA Classification](https://milvus.io/docs/dna_sequence_classification.md) | Classification | vector search |
+| [Text Search Engine](https://milvus.io/docs/text_search_engine.md) | Semantic Search | vector search |
+| [Search Image by Text](https://milvus.io/docs/text_image_search.md) | Semantic Search | vector search |
+| [Image Deduplication](https://milvus.io/docs/image_deduplication_system.md) | Deduplication | vector search |
+| [Graph RAG with Milvus](https://milvus.io/docs/graph_rag_with_milvus.md) | RAG | graph search |
+| [Contextual Retrieval with Milvus](https://milvus.io/docs/contextual_retrieval_with_milvus.md) | Quickstart | vector search |
+| [HDBSCAN Clustering with Milvus](https://milvus.io/docs/hdbscan_clustering_with_milvus.md) | Quickstart | vector search |
+| [Use ColPali for Multi-Modal Retrieval with Milvus](https://milvus.io/docs/use_ColPali_with_milvus.md) | Quickstart | vector search |
+| [Vector Visualization](https://milvus.io/docs/vector_visualization.md) | Quickstart | vector search |
+| [Movie Recommendation with Milvus](https://milvus.io/docs/movie_recommendation_with_milvus.md) | Recommendation System | vector search |
+| [Funnel Search with Matryoshka Embeddings](https://milvus.io/docs/funnel_search_with_matryoshka.md) | Quickstart | vector search |
+
 <table>
   <tr>
     <td width="30%">
@@ -123,8 +148,6 @@ Here is a selection of demos and tutorials to show how to build various types of
     </th>
   </tr>
 </table>
-
-You can explore a comprehensive [Tutorials Overview](https://milvus.io/docs/tutorials-overview.md) covering topics such as Retrieval-Augmented Generation (RAG), Semantic Search, Hybrid Search, Question Answering, Recommendation Systems, and various quick-start guides. These resources are designed to help you get started quickly and efficiently.
 
 ## Ecosystem and Integration
    Milvus integrates with a comprehensive suite of [AI development tools](https://milvus.io/docs/integrations_overview.md), such as LangChain, LlamaIndex, OpenAI and HuggingFace, making it an ideal vector store for GenAI applications such as Retrieval-Augmented Generation (RAG). Milvus works with both open-source embedding models and embedding service, in text, image and video modalities. Milvus also provides a convenient util [`pymilvus[model]`](https://milvus.io/docs/embeddings.md), users can use the simple wrapper code to transform unstructured data into vector embeddings and leverage reranking models for optimized search results. The Milvus ecosystem also includes [Attu](https://github.com/zilliztech/attu?tab=readme-ov-file#attu) for GUI-based administration, [Birdwatcher](https://milvus.io/docs/birdwatcher_overview.md) for system debugging, [Prometheus/Grafana](https://milvus.io/docs/monitor_overview.md) for monitoring, [Milvus CDC](https://milvus.io/docs/milvus-cdc-overview.md) for data synchronization, [VTS](https://github.com/zilliztech/vts?tab=readme-ov-file#vts) for data migration and data connectors for [Spark](https://milvus.io/docs/integrate_with_spark.md#Spark-Milvus-Connector-User-Guide), [Kafka](https://github.com/zilliztech/kafka-connect-milvus?tab=readme-ov-file#kafka-connect-milvus-connector), [Fivetran](https://fivetran.com/docs/destinations/milvus), and [Airbyte](https://milvus.io/docs/integrate_with_airbyte.md) to build search pipelines.

--- a/README.md
+++ b/README.md
@@ -89,25 +89,9 @@ Milvus is designed to handle vector search at scale. Users can store vectors, wh
 
 Milvus is trusted by AI developers to build applications such as text and image search, Retrieval-Augmented Generation (RAG), and recommendation systems. Milvus powers [many mission-critical business]((https://milvus.io/use-cases)) for startups and enterprises.
 
-## Demos and Tutorials 
-Here is a selection of demos and tutorials to show how to build various types of AI applications made with Milvus:
+## Demos and Tutorials
 
-| Tutorial | Use Case | Related Milvus Features | 
-| -------- | -------- | --------- |
-| [Build RAG with Milvus](build-rag-with-milvus.md) |  RAG | vector search |
-| [Multimodal RAG with Milvus](multimodal_rag_with_milvus.md) | RAG | vector search, dynamic field |
-| [Image Search with Milvus](image_similarity_search.md) | Semantic Search | vector search, dynamic field |
-| [Hybrid Search with Milvus](hybrid_search_with_milvus.md) | Hybrid Search | hybrid search, multi vector, dense embedding, sparse embedding |
-| [Multimodal Search using Multi Vectors](multimodal_rag_with_milvus.md) | Semantic Search | multi vector, hybrid search |
-| [Recommender System](recommendation_system.md) | Recommendation System | vector search |
-| [Video Similarity Search](video_similarity_search.md) | Semantic Search | vector search |
-| [Audio Similarity Search](audio_similarity_search.md) | Semantic Search | vector search |
-| [DNA Classification](dna_sequence_classification.md) | Classification | vector search |
-| [Graph RAG with Milvus](graph_rag_with_milvus.md) | RAG | vector search |
-| [Contextual Retrieval with Milvus](contextual_retrieval_with_milvus.md) | RAG, Semantic Search | vector search |
-| [HDBSCAN Clustering with Milvus](hdbscan_clustering_with_milvus.md) | Clustering | vector search |
-| [Use ColPali for Multi-Modal Retrieval with Milvus](use_ColPali_with_milvus.md) | RAG, Semantic Search | vector search |
-| [Vector Visualization](vector_visualization.md) | Data Visualization | vector search |
+Here is a selection of demos and tutorials to show how to build various types of AI applications made with Milvus:
 
 <table>
   <tr>
@@ -139,6 +123,8 @@ Here is a selection of demos and tutorials to show how to build various types of
     </th>
   </tr>
 </table>
+
+You can explore a comprehensive [Tutorials Overview](https://milvus.io/docs/tutorials-overview.md) covering topics such as Retrieval-Augmented Generation (RAG), Semantic Search, Hybrid Search, Question Answering, Recommendation Systems, and various quick-start guides. These resources are designed to help you get started quickly and efficiently.
 
 ## Ecosystem and Integration
    Milvus integrates with a comprehensive suite of [AI development tools](https://milvus.io/docs/integrations_overview.md), such as LangChain, LlamaIndex, OpenAI and HuggingFace, making it an ideal vector store for GenAI applications such as Retrieval-Augmented Generation (RAG). Milvus works with both open-source embedding models and embedding service, in text, image and video modalities. Milvus also provides a convenient util [`pymilvus[model]`](https://milvus.io/docs/embeddings.md), users can use the simple wrapper code to transform unstructured data into vector embeddings and leverage reranking models for optimized search results. The Milvus ecosystem also includes [Attu](https://github.com/zilliztech/attu?tab=readme-ov-file#attu) for GUI-based administration, [Birdwatcher](https://milvus.io/docs/birdwatcher_overview.md) for system debugging, [Prometheus/Grafana](https://milvus.io/docs/monitor_overview.md) for monitoring, [Milvus CDC](https://milvus.io/docs/milvus-cdc-overview.md) for data synchronization, [VTS](https://github.com/zilliztech/vts?tab=readme-ov-file#vts) for data migration and data connectors for [Spark](https://milvus.io/docs/integrate_with_spark.md#Spark-Milvus-Connector-User-Guide), [Kafka](https://github.com/zilliztech/kafka-connect-milvus?tab=readme-ov-file#kafka-connect-milvus-connector), [Fivetran](https://fivetran.com/docs/destinations/milvus), and [Airbyte](https://milvus.io/docs/integrate_with_airbyte.md) to build search pipelines.

--- a/README_CN.md
+++ b/README_CN.md
@@ -145,6 +145,10 @@ $ make milvus
 
 迅速检索相似化学分子式。
 
+### 教程
+
+你可以从[教程概述](https://milvus.io/docs/tutorials-overview.md)中，找到涵盖 RAG（检索增强生成）、语义搜索、混合搜索、问答、推荐系统等主题以及各种快速入门指南。这些资源旨在帮助你快速高效地入门。
+
 ## 训练营
 
 Milvus [训练营](https://github.com/milvus-io/bootcamp)能够帮助你了解向量数据库的操作及各种应用场景。通过 Milvus 训练营探索如何进行 Milvus 性能测评，搭建智能问答机器人、推荐系统、以图搜图系统、分子式检索系统等。

--- a/README_CN.md
+++ b/README_CN.md
@@ -100,6 +100,33 @@ $ make milvus
 
 ## 入门指南
 
+### 教程
+
+你可以从[教程概述](https://milvus.io/docs/tutorials-overview.md)中，找到涵盖 RAG（检索增强生成）、语义搜索、混合搜索、问答、推荐系统等主题以及各种快速入门指南。这些资源旨在帮助你快速高效地入门。
+
+| 教程 | 使用场景 | 相关 Milvus 功能 |
+| -------- | -------- | --------- |
+| [使用 Milvus 构建 RAG](https://milvus.io/docs/build-rag-with-milvus.md) |  RAG | 向量搜索 |
+| [使用 Milvus 构建多模态 RAG](https://milvus.io/docs/multimodal_rag_with_milvus.md) | RAG | 向量搜索, 动态字段 |
+| [使用 Milvus 进行图像搜索](https://milvus.io/docs/image_similarity_search.md) | 语义搜索 | 向量搜索, 动态字段 |
+| [使用 Milvus 进行混合搜索](https://milvus.io/docs/hybrid_search_with_milvus.md) | 混合搜索 | 混合搜索, 多向量, 密集嵌入, 稀疏嵌入 |
+| [使用多向量实现多模态搜索](https://milvus.io/docs/multimodal_rag_with_milvus.md) | 语义搜索 | 多向量, 混合搜索 |
+| [问答系统](https://milvus.io/docs/question_answering_system.md) | 问答系统 | 向量搜索 |
+| [推荐系统](https://milvus.io/docs/recommendation_system.md) | 推荐系统 | 向量搜索 |
+| [视频相似性搜索](https://milvus.io/docs/video_similarity_search.md) | 语义搜索 | 向量搜索 |
+| [音频相似性搜索](https://milvus.io/docs/audio_similarity_search.md) | 语义搜索 | 向量搜索 |
+| [DNA 分类](https://milvus.io/docs/dna_sequence_classification.md) | 分类 | 向量搜索 |
+| [文本搜索引擎](https://milvus.io/docs/text_search_engine.md) | 语义搜索 | 向量搜索 |
+| [通过文本搜索图像](https://milvus.io/docs/text_image_search.md) | 语义搜索 | 向量搜索 |
+| [图像去重](https://milvus.io/docs/image_deduplication_system.md) | 重复数据删除 | 向量搜索 |
+| [使用 Milvus 构建图形 RAG](https://milvus.io/docs/graph_rag_with_milvus.md) | RAG | 图搜索 |
+| [使用 Milvus 进行上下文检索](https://milvus.io/docs/contextual_retrieval_with_milvus.md) | 快速入门 | 向量搜索 |
+| [使用 Milvus 进行 HDBSCAN 聚类](https://milvus.io/docs/hdbscan_clustering_with_milvus.md) | 快速入门 | 向量搜索 |
+| [使用 ColPali 实现多模态检索](https://milvus.io/docs/use_ColPali_with_milvus.md) | 快速入门 | 向量搜索 |
+| [向量可视化](https://milvus.io/docs/vector_visualization.md) | 快速入门 | 向量搜索 |
+| [基于 Milvus 的电影推荐](https://milvus.io/docs/movie_recommendation_with_milvus.md) | 推荐系统 | 向量搜索 |
+| [使用 Matryoshka 嵌入进行漏斗搜索](https://milvus.io/docs/funnel_search_with_matryoshka.md) | 快速入门 | 向量搜索 |
+
 ### 应用场景
 
 <table>
@@ -144,10 +171,6 @@ $ make milvus
 #### 分子式检索系统
 
 迅速检索相似化学分子式。
-
-### 教程
-
-你可以从[教程概述](https://milvus.io/docs/tutorials-overview.md)中，找到涵盖 RAG（检索增强生成）、语义搜索、混合搜索、问答、推荐系统等主题以及各种快速入门指南。这些资源旨在帮助你快速高效地入门。
 
 ## 训练营
 


### PR DESCRIPTION
issue: #38054 
- Delete the table about tutorials in the English document, use link to replace the existing table, and add corresponding descriptions (the table content is outdated, and using link can reduce maintenance costs).
- Add link and corresponding descriptions of tutorials in Chinese documentation.