### PR TITLE
enhance: [GoSDK] Refine float point conversion precision loss ut

### DIFF
--- a/client/entity/vectors_test.go
+++ b/client/entity/vectors_test.go
@@ -56,7 +56,7 @@ func TestVectors(t *testing.T) {
 	t.Run("test fp32 <-> fp16/bf16 vector conversion", func(t *testing.T) {
 		raw := make([]float32, dim)
 		for i := 0; i < dim; i++ {
-			raw[i] = float32(i) * 0.1
+			raw[i] = rand.Float32() // rand result [0.1, 1.0)
 		}
 
 		fv := FloatVector(raw)
@@ -68,14 +68,17 @@ func TestVectors(t *testing.T) {
 		assert.Equal(t, dim, bf16v.Dim())
 		assert.Equal(t, dim*2, len(bf16v.Serialize()))
 
+		// TODO calculate max precision loss
+		maxDelta := float64(0.4)
+
 		fp32vFromfp16v := fp16v.ToFloat32Vector()
 		for i := 0; i < dim; i++ {
-			assert.InDelta(t, fv[i], fp32vFromfp16v[i], 0.04)
+			assert.InDelta(t, fv[i], fp32vFromfp16v[i], maxDelta)
 		}
 
 		fp32vFrombf16v := bf16v.ToFloat32Vector()
 		for i := 0; i < dim; i++ {
-			assert.InDelta(t, fp32vFromfp16v[i], fp32vFrombf16v[i], 0.04)
+			assert.InDelta(t, fp32vFromfp16v[i], fp32vFrombf16v[i], maxDelta)
 		}
 	})
 


### PR DESCRIPTION
Previous PR: #37978

This unit test is unable due to dim is a random number. When dim is large enough precision loss will be greater than 0.04