### PR TITLE
fix: [2.4] Return thread watcher goroutine after closed (#38091)

### DIFF
--- a/internal/util/metrics/thread.go
+++ b/internal/util/metrics/thread.go
@@ -75,6 +75,7 @@ func (thw *threadWatcher) watchThreadNum() {
 			metrics.ThreadNum.Set(float64(threadNum))
 		case <-thw.ch:
 			log.Info("thread watcher exit")
+			return
 		}
 	}
 }

--- a/internal/util/metrics/thread_test.go
+++ b/internal/util/metrics/thread_test.go
@@ -1,0 +1,41 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestThreadWatcher(t *testing.T) {
+	watcher := NewThreadWatcher()
+
+	watcher.Start()
+
+	ch := make(chan struct{})
+	go func() {
+		defer close(ch)
+		watcher.Stop()
+	}()
+	select {
+	case <-ch:
+	case <-time.After(time.Second * 5):
+		assert.FailNow(t, "watcher failed to close after 5 seconds")
+	}
+}


### PR DESCRIPTION
Cherry-pick from master
pr: #38091 
Resolves #38090