### PR TITLE
enhance: [skip e2e][mergify] Update unit test file list for client pkg

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -136,6 +136,7 @@ pull_request_rules:
       - or:
           - -files~=^(?!pkg\/.*_test\.go).*$
           - -files~=^(?!internal\/.*_test\.go).*$
+          - -files~=^(?!client\/.*_test\.go).*$
     actions:
       label:
         add:


### PR DESCRIPTION
This PR fix that unittest mergify rule failed to work for PR with milvusclient unit test update only.