### PR TITLE
fix: Fix timeout when listing meta

### DIFF
--- a/internal/metastore/kv/datacoord/kv_catalog.go
+++ b/internal/metastore/kv/datacoord/kv_catalog.go
@@ -489,23 +489,23 @@ func (kc *Catalog) DropChannel(ctx context.Context, channel string) error {
 }
 
 func (kc *Catalog) ListChannelCheckpoint(ctx context.Context) (map[string]*msgpb.MsgPosition, error) {
-	keys, values, err := kc.MetaKv.LoadWithPrefix(ChannelCheckpointPrefix)
-	if err != nil {
-		return nil, err
-	}
-
 	channelCPs := make(map[string]*msgpb.MsgPosition)
-	for i, key := range keys {
-		value := values[i]
+	applyFn := func(key []byte, value []byte) error {
 		channelCP := &msgpb.MsgPosition{}
-		err = proto.Unmarshal([]byte(value), channelCP)
+		err := proto.Unmarshal(value, channelCP)
 		if err != nil {
 			log.Error("unmarshal channelCP failed when ListChannelCheckpoint", zap.Error(err))
-			return nil, err
+			return err
 		}
-		ss := strings.Split(key, "/")
+		ss := strings.Split(string(key), "/")
 		vChannel := ss[len(ss)-1]
 		channelCPs[vChannel] = channelCP
+		return nil
+	}
+
+	err := kc.MetaKv.WalkWithPrefix(ChannelCheckpointPrefix, paginationSize, applyFn)
+	if err != nil {
+		return nil, err
 	}
 
 	return channelCPs, nil
@@ -575,24 +575,23 @@ func (kc *Catalog) CreateIndex(ctx context.Context, index *model.Index) error {
 }
 
 func (kc *Catalog) ListIndexes(ctx context.Context) ([]*model.Index, error) {
-	_, values, err := kc.MetaKv.LoadWithPrefix(util.FieldIndexPrefix)
-	if err != nil {
-		log.Error("list index meta fail", zap.String("prefix", util.FieldIndexPrefix), zap.Error(err))
-		return nil, err
-	}
-
 	indexes := make([]*model.Index, 0)
-	for _, value := range values {
+	applyFn := func(key []byte, value []byte) error {
 		meta := &indexpb.FieldIndex{}
-		err = proto.Unmarshal([]byte(value), meta)
+		err := proto.Unmarshal(value, meta)
 		if err != nil {
 			log.Warn("unmarshal index info failed", zap.Error(err))
-			return nil, err
+			return err
 		}
 
 		indexes = append(indexes, model.UnmarshalIndexModel(meta))
+		return nil
 	}
 
+	err := kc.MetaKv.WalkWithPrefix(util.FieldIndexPrefix, paginationSize, applyFn)
+	if err != nil {
+		return nil, err
+	}
 	return indexes, nil
 }
 
@@ -652,22 +651,22 @@ func (kc *Catalog) CreateSegmentIndex(ctx context.Context, segIdx *model.Segment
 }
 
 func (kc *Catalog) ListSegmentIndexes(ctx context.Context) ([]*model.SegmentIndex, error) {
-	_, values, err := kc.MetaKv.LoadWithPrefix(util.SegmentIndexPrefix)
-	if err != nil {
-		log.Error("list segment index meta fail", zap.String("prefix", util.SegmentIndexPrefix), zap.Error(err))
-		return nil, err
-	}
-
 	segIndexes := make([]*model.SegmentIndex, 0)
-	for _, value := range values {
+	applyFn := func(key []byte, value []byte) error {
 		segmentIndexInfo := &indexpb.SegmentIndex{}
-		err = proto.Unmarshal([]byte(value), segmentIndexInfo)
+		err := proto.Unmarshal(value, segmentIndexInfo)
 		if err != nil {
 			log.Warn("unmarshal segment index info failed", zap.Error(err))
-			return segIndexes, err
+			return err
 		}
 
 		segIndexes = append(segIndexes, model.UnmarshalSegmentIndexModel(segmentIndexInfo))
+		return nil
+	}
+
+	err := kc.MetaKv.WalkWithPrefix(util.SegmentIndexPrefix, paginationSize, applyFn)
+	if err != nil {
+		return nil, err
 	}
 
 	return segIndexes, nil
@@ -709,17 +708,19 @@ func (kc *Catalog) SaveImportJob(ctx context.Context, job *datapb.ImportJob) err
 
 func (kc *Catalog) ListImportJobs(ctx context.Context) ([]*datapb.ImportJob, error) {
 	jobs := make([]*datapb.ImportJob, 0)
-	_, values, err := kc.MetaKv.LoadWithPrefix(ImportJobPrefix)
-	if err != nil {
-		return nil, err
-	}
-	for _, value := range values {
+	applyFn := func(key []byte, value []byte) error {
 		job := &datapb.ImportJob{}
-		err = proto.Unmarshal([]byte(value), job)
+		err := proto.Unmarshal(value, job)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		jobs = append(jobs, job)
+		return nil
+	}
+
+	err := kc.MetaKv.WalkWithPrefix(ImportJobPrefix, paginationSize, applyFn)
+	if err != nil {
+		return nil, err
 	}
 	return jobs, nil
 }
@@ -741,19 +742,20 @@ func (kc *Catalog) SavePreImportTask(ctx context.Context, task *datapb.PreImport
 func (kc *Catalog) ListPreImportTasks(ctx context.Context) ([]*datapb.PreImportTask, error) {
 	tasks := make([]*datapb.PreImportTask, 0)
 
-	_, values, err := kc.MetaKv.LoadWithPrefix(PreImportTaskPrefix)
+	applyFn := func(key []byte, value []byte) error {
+		task := &datapb.PreImportTask{}
+		err := proto.Unmarshal(value, task)
+		if err != nil {
+			return err
+		}
+		tasks = append(tasks, task)
+		return nil
+	}
+
+	err := kc.MetaKv.WalkWithPrefix(PreImportTaskPrefix, paginationSize, applyFn)
 	if err != nil {
 		return nil, err
 	}
-	for _, value := range values {
-		task := &datapb.PreImportTask{}
-		err = proto.Unmarshal([]byte(value), task)
-		if err != nil {
-			return nil, err
-		}
-		tasks = append(tasks, task)
-	}
-
 	return tasks, nil
 }
 
@@ -774,17 +776,19 @@ func (kc *Catalog) SaveImportTask(ctx context.Context, task *datapb.ImportTaskV2
 func (kc *Catalog) ListImportTasks(ctx context.Context) ([]*datapb.ImportTaskV2, error) {
 	tasks := make([]*datapb.ImportTaskV2, 0)
 
-	_, values, err := kc.MetaKv.LoadWithPrefix(ImportTaskPrefix)
-	if err != nil {
-		return nil, err
-	}
-	for _, value := range values {
+	applyFn := func(key []byte, value []byte) error {
 		task := &datapb.ImportTaskV2{}
-		err = proto.Unmarshal([]byte(value), task)
+		err := proto.Unmarshal(value, task)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		tasks = append(tasks, task)
+		return nil
+	}
+
+	err := kc.MetaKv.WalkWithPrefix(ImportTaskPrefix, paginationSize, applyFn)
+	if err != nil {
+		return nil, err
 	}
 	return tasks, nil
 }
@@ -812,17 +816,19 @@ func (kc *Catalog) GcConfirm(ctx context.Context, collectionID, partitionID type
 func (kc *Catalog) ListCompactionTask(ctx context.Context) ([]*datapb.CompactionTask, error) {
 	tasks := make([]*datapb.CompactionTask, 0)
 
-	_, values, err := kc.MetaKv.LoadWithPrefix(CompactionTaskPrefix)
-	if err != nil {
-		return nil, err
-	}
-	for _, value := range values {
+	applyFn := func(key []byte, value []byte) error {
 		info := &datapb.CompactionTask{}
-		err = proto.Unmarshal([]byte(value), info)
+		err := proto.Unmarshal(value, info)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		tasks = append(tasks, info)
+		return nil
+	}
+
+	err := kc.MetaKv.WalkWithPrefix(CompactionTaskPrefix, paginationSize, applyFn)
+	if err != nil {
+		return nil, err
 	}
 	return tasks, nil
 }
@@ -849,17 +855,19 @@ func (kc *Catalog) DropCompactionTask(ctx context.Context, task *datapb.Compacti
 func (kc *Catalog) ListAnalyzeTasks(ctx context.Context) ([]*indexpb.AnalyzeTask, error) {
 	tasks := make([]*indexpb.AnalyzeTask, 0)
 
-	_, values, err := kc.MetaKv.LoadWithPrefix(AnalyzeTaskPrefix)
-	if err != nil {
-		return nil, err
-	}
-	for _, value := range values {
+	applyFn := func(key []byte, value []byte) error {
 		task := &indexpb.AnalyzeTask{}
-		err = proto.Unmarshal([]byte(value), task)
+		err := proto.Unmarshal(value, task)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		tasks = append(tasks, task)
+		return nil
+	}
+
+	err := kc.MetaKv.WalkWithPrefix(AnalyzeTaskPrefix, paginationSize, applyFn)
+	if err != nil {
+		return nil, err
 	}
 	return tasks, nil
 }
@@ -887,17 +895,19 @@ func (kc *Catalog) DropAnalyzeTask(ctx context.Context, taskID typeutil.UniqueID
 func (kc *Catalog) ListPartitionStatsInfos(ctx context.Context) ([]*datapb.PartitionStatsInfo, error) {
 	infos := make([]*datapb.PartitionStatsInfo, 0)
 
-	_, values, err := kc.MetaKv.LoadWithPrefix(PartitionStatsInfoPrefix)
-	if err != nil {
-		return nil, err
-	}
-	for _, value := range values {
+	applyFn := func(key []byte, value []byte) error {
 		info := &datapb.PartitionStatsInfo{}
-		err = proto.Unmarshal([]byte(value), info)
+		err := proto.Unmarshal(value, info)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		infos = append(infos, info)
+		return nil
+	}
+
+	err := kc.MetaKv.WalkWithPrefix(PartitionStatsInfoPrefix, paginationSize, applyFn)
+	if err != nil {
+		return nil, err
 	}
 	return infos, nil
 }
@@ -947,18 +957,20 @@ func (kc *Catalog) DropCurrentPartitionStatsVersion(ctx context.Context, collID,
 
 func (kc *Catalog) ListStatsTasks(ctx context.Context) ([]*indexpb.StatsTask, error) {
 	tasks := make([]*indexpb.StatsTask, 0)
-	_, values, err := kc.MetaKv.LoadWithPrefix(StatsTaskPrefix)
-	if err != nil {
-		return nil, err
-	}
 
-	for _, value := range values {
+	applyFn := func(key []byte, value []byte) error {
 		task := &indexpb.StatsTask{}
-		err = proto.Unmarshal([]byte(value), task)
+		err := proto.Unmarshal(value, task)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		tasks = append(tasks, task)
+		return nil
+	}
+
+	err := kc.MetaKv.WalkWithPrefix(StatsTaskPrefix, paginationSize, applyFn)
+	if err != nil {
+		return nil, err
 	}
 	return tasks, nil
 }

--- a/internal/metastore/kv/querycoord/kv_catalog.go
+++ b/internal/metastore/kv/querycoord/kv_catalog.go
@@ -19,6 +19,8 @@ import (
 	"github.com/milvus-io/milvus/pkg/util/compressor"
 )
 
+var paginationSize = 2000
+
 var ErrInvalidKey = errors.New("invalid load info key")
 
 const (
@@ -105,51 +107,57 @@ func (s Catalog) RemoveResourceGroup(ctx context.Context, rgName string) error {
 }
 
 func (s Catalog) GetCollections(ctx context.Context) ([]*querypb.CollectionLoadInfo, error) {
-	_, values, err := s.cli.LoadWithPrefix(CollectionLoadInfoPrefix)
-	if err != nil {
-		return nil, err
-	}
-	ret := make([]*querypb.CollectionLoadInfo, 0, len(values))
-	for _, v := range values {
+	ret := make([]*querypb.CollectionLoadInfo, 0)
+	applyFn := func(key []byte, value []byte) error {
 		info := querypb.CollectionLoadInfo{}
-		if err := proto.Unmarshal([]byte(v), &info); err != nil {
-			return nil, err
+		if err := proto.Unmarshal(value, &info); err != nil {
+			return err
 		}
 		ret = append(ret, &info)
+		return nil
+	}
+
+	err := s.cli.WalkWithPrefix(CollectionLoadInfoPrefix, paginationSize, applyFn)
+	if err != nil {
+		return nil, err
 	}
 
 	return ret, nil
 }
 
 func (s Catalog) GetPartitions(ctx context.Context) (map[int64][]*querypb.PartitionLoadInfo, error) {
-	_, values, err := s.cli.LoadWithPrefix(PartitionLoadInfoPrefix)
-	if err != nil {
-		return nil, err
-	}
 	ret := make(map[int64][]*querypb.PartitionLoadInfo)
-	for _, v := range values {
+	applyFn := func(key []byte, value []byte) error {
 		info := querypb.PartitionLoadInfo{}
-		if err := proto.Unmarshal([]byte(v), &info); err != nil {
-			return nil, err
+		if err := proto.Unmarshal(value, &info); err != nil {
+			return err
 		}
 		ret[info.GetCollectionID()] = append(ret[info.GetCollectionID()], &info)
+		return nil
+	}
+
+	err := s.cli.WalkWithPrefix(PartitionLoadInfoPrefix, paginationSize, applyFn)
+	if err != nil {
+		return nil, err
 	}
 
 	return ret, nil
 }
 
 func (s Catalog) GetReplicas(ctx context.Context) ([]*querypb.Replica, error) {
-	_, values, err := s.cli.LoadWithPrefix(ReplicaPrefix)
-	if err != nil {
-		return nil, err
-	}
-	ret := make([]*querypb.Replica, 0, len(values))
-	for _, v := range values {
+	ret := make([]*querypb.Replica, 0)
+	applyFn := func(key []byte, value []byte) error {
 		info := querypb.Replica{}
-		if err := proto.Unmarshal([]byte(v), &info); err != nil {
-			return nil, err
+		if err := proto.Unmarshal(value, &info); err != nil {
+			return err
 		}
 		ret = append(ret, &info)
+		return nil
+	}
+
+	err := s.cli.WalkWithPrefix(ReplicaPrefix, paginationSize, applyFn)
+	if err != nil {
+		return nil, err
 	}
 
 	replicasV1, err := s.getReplicasFromV1(ctx)
@@ -290,21 +298,23 @@ func (s Catalog) RemoveCollectionTarget(ctx context.Context, collectionID int64)
 }
 
 func (s Catalog) GetCollectionTargets(ctx context.Context) (map[int64]*querypb.CollectionTarget, error) {
-	keys, values, err := s.cli.LoadWithPrefix(CollectionTargetPrefix)
-	if err != nil {
-		return nil, err
-	}
 	ret := make(map[int64]*querypb.CollectionTarget)
-	for i, v := range values {
+	applyFn := func(key []byte, value []byte) error {
 		var decompressed bytes.Buffer
-		compressor.ZstdDecompress(bytes.NewReader([]byte(v)), io.Writer(&decompressed))
+		compressor.ZstdDecompress(bytes.NewReader(value), io.Writer(&decompressed))
 		target := &querypb.CollectionTarget{}
 		if err := proto.Unmarshal(decompressed.Bytes(), target); err != nil {
 			// recover target from meta is a optimize policy, skip when failure happens
-			log.Warn("failed to unmarshal collection target", zap.String("key", keys[i]), zap.Error(err))
-			continue
+			log.Warn("failed to unmarshal collection target", zap.String("key", string(key)), zap.Error(err))
+			return nil
 		}
 		ret[target.GetCollectionID()] = target
+		return nil
+	}
+
+	err := s.cli.WalkWithPrefix(CollectionTargetPrefix, paginationSize, applyFn)
+	if err != nil {
+		return nil, err
 	}
 
 	return ret, nil

--- a/internal/metastore/kv/querycoord/kv_catalog_test.go
+++ b/internal/metastore/kv/querycoord/kv_catalog_test.go
@@ -239,7 +239,7 @@ func (suite *CatalogTestSuite) TestCollectionTarget() {
 	mockStore := mocks.NewMetaKv(suite.T())
 	mockErr := errors.New("failed to access etcd")
 	mockStore.EXPECT().MultiSave(mock.Anything).Return(mockErr)
-	mockStore.EXPECT().LoadWithPrefix(mock.Anything).Return(nil, nil, mockErr)
+	mockStore.EXPECT().WalkWithPrefix(mock.Anything, mock.Anything, mock.Anything).Return(mockErr)
 
 	suite.catalog.cli = mockStore
 	err = suite.catalog.SaveCollectionTargets(ctx, &querypb.CollectionTarget{})


### PR DESCRIPTION
When there are too many key-value pairs, the etcd list operation may times out. This PR replaces `LoadWithPrefix` in list operations, which could involve many keys, with `WalkWithPrefix`.

issue: https://github.com/milvus-io/milvus/issues/37917