### PR TITLE
enhance: [2.4] Use fdopen, fwrite to reduce direct syscall (#38157)

### DIFF
--- a/internal/core/src/mmap/Utils.h
+++ b/internal/core/src/mmap/Utils.h
@@ -101,12 +101,12 @@ WriteFieldData(File& file,
                     auto str =
                         static_cast<const std::string*>(data->RawValue(i));
                     ssize_t written_data_size =
-                        file.WriteInt<uint32_t>(uint32_t(str->size()));
+                        file.FWriteInt<uint32_t>(uint32_t(str->size()));
                     if (written_data_size != sizeof(uint32_t)) {
                         THROW_FILE_WRITE_ERROR
                     }
                     total_written += written_data_size;
-                    auto written_data = file.Write(str->data(), str->size());
+                    auto written_data = file.FWrite(str->data(), str->size());
                     if (written_data < str->size()) {
                         THROW_FILE_WRITE_ERROR
                     }
@@ -120,14 +120,14 @@ WriteFieldData(File& file,
                     indices.push_back(total_written);
                     auto padded_string =
                         static_cast<const Json*>(data->RawValue(i))->data();
-                    ssize_t written_data_size =
-                        file.WriteInt<uint32_t>(uint32_t(padded_string.size()));
+                    ssize_t written_data_size = file.FWriteInt<uint32_t>(
+                        uint32_t(padded_string.size()));
                     if (written_data_size != sizeof(uint32_t)) {
                         THROW_FILE_WRITE_ERROR
                     }
                     total_written += written_data_size;
                     ssize_t written_data =
-                        file.Write(padded_string.data(), padded_string.size());
+                        file.FWrite(padded_string.data(), padded_string.size());
                     if (written_data < padded_string.size()) {
                         THROW_FILE_WRITE_ERROR
                     }
@@ -141,7 +141,7 @@ WriteFieldData(File& file,
                     indices.push_back(total_written);
                     auto array = static_cast<const Array*>(data->RawValue(i));
                     ssize_t written =
-                        file.Write(array->data(), array->byte_size());
+                        file.FWrite(array->data(), array->byte_size());
                     if (written < array->byte_size()) {
                         THROW_FILE_WRITE_ERROR
                     }
@@ -157,7 +157,7 @@ WriteFieldData(File& file,
                         static_cast<const knowhere::sparse::SparseRow<float>*>(
                             data->RawValue(i));
                     ssize_t written =
-                        file.Write(vec->data(), vec->data_byte_size());
+                        file.FWrite(vec->data(), vec->data_byte_size());
                     if (written < vec->data_byte_size()) {
                         break;
                     }
@@ -172,7 +172,7 @@ WriteFieldData(File& file,
         }
     } else {
         // write as: data|data|data|data|data|data......
-        size_t written = file.Write(data->Data(), data->Size());
+        size_t written = file.FWrite(data->Data(), data->Size());
         if (written < data->Size()) {
             THROW_FILE_WRITE_ERROR
         }
@@ -181,5 +181,6 @@ WriteFieldData(File& file,
             total_written += data->Size(i);
         }
     }
+    file.FFlush();
 }
 }  // namespace milvus


### PR DESCRIPTION
Cherry-pick from master
pr: #38157
`File.Write` and `File.WriteInt` use `write`, which may be just direct syscall in some systems. When mappding field data and write line by line, this could cost lost of CPU time when the row number is large.

---------