### PR TITLE
enhance: remove the rpc layer of coordinator when enabling standalone or mixcoord

### DIFF
--- a/cmd/roles/roles.go
+++ b/cmd/roles/roles.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus/cmd/components"
+	"github.com/milvus-io/milvus/internal/coordinator/coordclient"
 	"github.com/milvus-io/milvus/internal/http"
 	"github.com/milvus-io/milvus/internal/http/healthz"
 	"github.com/milvus-io/milvus/internal/util/dependency"
@@ -380,6 +381,12 @@ func (mr *MilvusRoles) Run() {
 		paramtable.Init()
 		paramtable.SetRole(mr.ServerType)
 	}
+	coordclient.EnableLocalClientRole(&coordclient.LocalClientRoleConfig{
+		ServerType:       mr.ServerType,
+		EnableQueryCoord: mr.EnableQueryCoord,
+		EnableDataCoord:  mr.EnableDataCoord,
+		EnableRootCoord:  mr.EnableRootCoord,
+	})
 
 	enableComponents := []bool{
 		mr.EnableRootCoord,

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -846,6 +846,7 @@ common:
   usePartitionKeyAsClusteringKey: false # if true, do clustering compaction and segment prune on partition key field
   useVectorAsClusteringKey: false # if true, do clustering compaction and segment prune on vector field
   enableVectorClusteringKey: false # if true, enable vector clustering key and vector clustering compaction
+  localRPCEnabled: false # enable local rpc for internal communication when mix or standalone mode.
 
 # QuotaConfig, configurations of Milvus quota and limits.
 # By default, we enable:

--- a/internal/coordinator/coordclient/registry.go
+++ b/internal/coordinator/coordclient/registry.go
@@ -1,0 +1,162 @@
+package coordclient
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+
+	dcc "github.com/milvus-io/milvus/internal/distributed/datacoord/client"
+	qcc "github.com/milvus-io/milvus/internal/distributed/querycoord/client"
+	rcc "github.com/milvus-io/milvus/internal/distributed/rootcoord/client"
+	"github.com/milvus-io/milvus/internal/proto/datapb"
+	"github.com/milvus-io/milvus/internal/proto/querypb"
+	"github.com/milvus-io/milvus/internal/proto/rootcoordpb"
+	"github.com/milvus-io/milvus/internal/types"
+	"github.com/milvus-io/milvus/internal/util/grpcclient"
+	"github.com/milvus-io/milvus/pkg/log"
+	"github.com/milvus-io/milvus/pkg/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/util/syncutil"
+	"github.com/milvus-io/milvus/pkg/util/typeutil"
+)
+
+// localClient is a client that can access local server directly
+type localClient struct {
+	queryCoordClient *syncutil.Future[types.QueryCoordClient]
+	dataCoordClient  *syncutil.Future[types.DataCoordClient]
+	rootCoordClient  *syncutil.Future[types.RootCoordClient]
+}
+
+var (
+	enableLocal  *LocalClientRoleConfig // a global map to store all can be local accessible roles.
+	glocalClient *localClient           // !!! WARNING: local client will ignore all interceptor of grpc client and server.
+)
+
+func init() {
+	enableLocal = &LocalClientRoleConfig{}
+	glocalClient = &localClient{
+		queryCoordClient: syncutil.NewFuture[types.QueryCoordClient](),
+		dataCoordClient:  syncutil.NewFuture[types.DataCoordClient](),
+		rootCoordClient:  syncutil.NewFuture[types.RootCoordClient](),
+	}
+}
+
+type LocalClientRoleConfig struct {
+	ServerType       string
+	EnableQueryCoord bool
+	EnableDataCoord  bool
+	EnableRootCoord  bool
+}
+
+// EnableLocalClientRole init localable roles
+func EnableLocalClientRole(cfg *LocalClientRoleConfig) {
+	if !paramtable.Get().CommonCfg.LocalRPCEnabled.GetAsBool() {
+		return
+	}
+	if cfg.ServerType != typeutil.StandaloneRole && cfg.ServerType != typeutil.MixtureRole {
+		return
+	}
+	enableLocal = cfg
+}
+
+// RegisterQueryCoordServer register query coord server
+func RegisterQueryCoordServer(server querypb.QueryCoordServer) {
+	if !enableLocal.EnableQueryCoord {
+		return
+	}
+	newLocalClient := grpcclient.NewLocalGRPCClient(&querypb.QueryCoord_ServiceDesc, server, querypb.NewQueryCoordClient)
+	glocalClient.queryCoordClient.Set(&nopCloseQueryCoordClient{newLocalClient})
+	log.Info("register query coord server", zap.Any("enableLocalClient", enableLocal))
+}
+
+// RegsterDataCoordServer register data coord server
+func RegisterDataCoordServer(server datapb.DataCoordServer) {
+	if !enableLocal.EnableDataCoord {
+		return
+	}
+	newLocalClient := grpcclient.NewLocalGRPCClient(&datapb.DataCoord_ServiceDesc, server, datapb.NewDataCoordClient)
+	glocalClient.dataCoordClient.Set(&nopCloseDataCoordClient{newLocalClient})
+	log.Info("register data coord server", zap.Any("enableLocalClient", enableLocal))
+}
+
+// RegisterRootCoordServer register root coord server
+func RegisterRootCoordServer(server rootcoordpb.RootCoordServer) {
+	if !enableLocal.EnableRootCoord {
+		return
+	}
+	newLocalClient := grpcclient.NewLocalGRPCClient(&rootcoordpb.RootCoord_ServiceDesc, server, rootcoordpb.NewRootCoordClient)
+	glocalClient.rootCoordClient.Set(&nopCloseRootCoordClient{newLocalClient})
+	log.Info("register root coord server", zap.Any("enableLocalClient", enableLocal))
+}
+
+// GetQueryCoordClient return query coord client
+func GetQueryCoordClient(ctx context.Context) types.QueryCoordClient {
+	var client types.QueryCoordClient
+	var err error
+	if enableLocal.EnableQueryCoord {
+		client, err = glocalClient.queryCoordClient.GetWithContext(ctx)
+	} else {
+		// TODO: we should make a singleton here. but most unittest rely on a dedicated client.
+		client, err = qcc.NewClient(ctx)
+	}
+	if err != nil {
+		panic(fmt.Sprintf("get query coord client failed: %v", err))
+	}
+	return client
+}
+
+// GetDataCoordClient return data coord client
+func GetDataCoordClient(ctx context.Context) types.DataCoordClient {
+	var client types.DataCoordClient
+	var err error
+	if enableLocal.EnableDataCoord {
+		client, err = glocalClient.dataCoordClient.GetWithContext(ctx)
+	} else {
+		// TODO: we should make a singleton here. but most unittest rely on a dedicated client.
+		client, err = dcc.NewClient(ctx)
+	}
+	if err != nil {
+		panic(fmt.Sprintf("get data coord client failed: %v", err))
+	}
+	return client
+}
+
+// GetRootCoordClient return root coord client
+func GetRootCoordClient(ctx context.Context) types.RootCoordClient {
+	var client types.RootCoordClient
+	var err error
+	if enableLocal.EnableRootCoord {
+		client, err = glocalClient.rootCoordClient.GetWithContext(ctx)
+	} else {
+		// TODO: we should make a singleton here. but most unittest rely on a dedicated client.
+		client, err = rcc.NewClient(ctx)
+	}
+	if err != nil {
+		panic(fmt.Sprintf("get root coord client failed: %v", err))
+	}
+	return client
+}
+
+type nopCloseQueryCoordClient struct {
+	querypb.QueryCoordClient
+}
+
+func (n *nopCloseQueryCoordClient) Close() error {
+	return nil
+}
+
+type nopCloseDataCoordClient struct {
+	datapb.DataCoordClient
+}
+
+func (n *nopCloseDataCoordClient) Close() error {
+	return nil
+}
+
+type nopCloseRootCoordClient struct {
+	rootcoordpb.RootCoordClient
+}
+
+func (n *nopCloseRootCoordClient) Close() error {
+	return nil
+}

--- a/internal/coordinator/coordclient/registry_test.go
+++ b/internal/coordinator/coordclient/registry_test.go
@@ -1,0 +1,78 @@
+package coordclient
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/internal/proto/datapb"
+	"github.com/milvus-io/milvus/internal/proto/querypb"
+	"github.com/milvus-io/milvus/internal/proto/rootcoordpb"
+	"github.com/milvus-io/milvus/pkg/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/util/typeutil"
+)
+
+func TestRegistry(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().CommonCfg.LocalRPCEnabled.Key, "true")
+
+	assert.False(t, enableLocal.EnableQueryCoord)
+	assert.False(t, enableLocal.EnableDataCoord)
+	assert.False(t, enableLocal.EnableRootCoord)
+
+	EnableLocalClientRole(&LocalClientRoleConfig{
+		ServerType:       typeutil.RootCoordRole,
+		EnableQueryCoord: true,
+		EnableDataCoord:  true,
+		EnableRootCoord:  true,
+	})
+	assert.False(t, enableLocal.EnableQueryCoord)
+	assert.False(t, enableLocal.EnableDataCoord)
+	assert.False(t, enableLocal.EnableRootCoord)
+
+	RegisterRootCoordServer(&rootcoordpb.UnimplementedRootCoordServer{})
+	RegisterDataCoordServer(&datapb.UnimplementedDataCoordServer{})
+	RegisterQueryCoordServer(&querypb.UnimplementedQueryCoordServer{})
+	assert.False(t, glocalClient.dataCoordClient.Ready())
+	assert.False(t, glocalClient.queryCoordClient.Ready())
+	assert.False(t, glocalClient.rootCoordClient.Ready())
+
+	enableLocal = &LocalClientRoleConfig{}
+
+	EnableLocalClientRole(&LocalClientRoleConfig{
+		ServerType:       typeutil.StandaloneRole,
+		EnableQueryCoord: true,
+		EnableDataCoord:  true,
+		EnableRootCoord:  true,
+	})
+	assert.True(t, enableLocal.EnableDataCoord)
+	assert.True(t, enableLocal.EnableQueryCoord)
+	assert.True(t, enableLocal.EnableRootCoord)
+
+	RegisterRootCoordServer(&rootcoordpb.UnimplementedRootCoordServer{})
+	RegisterDataCoordServer(&datapb.UnimplementedDataCoordServer{})
+	RegisterQueryCoordServer(&querypb.UnimplementedQueryCoordServer{})
+	assert.True(t, glocalClient.dataCoordClient.Ready())
+	assert.True(t, glocalClient.queryCoordClient.Ready())
+	assert.True(t, glocalClient.rootCoordClient.Ready())
+
+	enableLocal = &LocalClientRoleConfig{}
+
+	EnableLocalClientRole(&LocalClientRoleConfig{
+		ServerType:       typeutil.MixtureRole,
+		EnableQueryCoord: true,
+		EnableDataCoord:  true,
+		EnableRootCoord:  true,
+	})
+	assert.True(t, enableLocal.EnableDataCoord)
+	assert.True(t, enableLocal.EnableQueryCoord)
+	assert.True(t, enableLocal.EnableRootCoord)
+
+	assert.NotNil(t, GetQueryCoordClient(context.Background()))
+	assert.NotNil(t, GetDataCoordClient(context.Background()))
+	assert.NotNil(t, GetRootCoordClient(context.Background()))
+	GetQueryCoordClient(context.Background()).Close()
+	GetDataCoordClient(context.Background()).Close()
+	GetRootCoordClient(context.Background()).Close()
+}

--- a/internal/datacoord/server.go
+++ b/internal/datacoord/server.go
@@ -35,10 +35,10 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	globalIDAllocator "github.com/milvus-io/milvus/internal/allocator"
+	"github.com/milvus-io/milvus/internal/coordinator/coordclient"
 	"github.com/milvus-io/milvus/internal/datacoord/broker"
 	datanodeclient "github.com/milvus-io/milvus/internal/distributed/datanode/client"
 	indexnodeclient "github.com/milvus-io/milvus/internal/distributed/indexnode/client"
-	rootcoordclient "github.com/milvus-io/milvus/internal/distributed/rootcoord/client"
 	etcdkv "github.com/milvus-io/milvus/internal/kv/etcd"
 	"github.com/milvus-io/milvus/internal/kv/tikv"
 	"github.com/milvus-io/milvus/internal/metastore/kv/datacoord"
@@ -255,7 +255,7 @@ func defaultIndexNodeCreatorFunc(ctx context.Context, addr string, nodeID int64)
 }
 
 func defaultRootCoordCreatorFunc(ctx context.Context) (types.RootCoordClient, error) {
-	return rootcoordclient.NewClient(ctx)
+	return coordclient.GetRootCoordClient(ctx), nil
 }
 
 // QuitSignal returns signal when server quits

--- a/internal/distributed/datacoord/service.go
+++ b/internal/distributed/datacoord/service.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
+	"github.com/milvus-io/milvus/internal/coordinator/coordclient"
 	"github.com/milvus-io/milvus/internal/datacoord"
 	"github.com/milvus-io/milvus/internal/distributed/utils"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
@@ -200,6 +201,7 @@ func (s *Server) startGrpcLoop() {
 		grpc.StatsHandler(tracer.GetDynamicOtelGrpcServerStatsHandler()))
 	indexpb.RegisterIndexCoordServer(s.grpcServer, s)
 	datapb.RegisterDataCoordServer(s.grpcServer, s)
+	coordclient.RegisterDataCoordServer(s)
 	go funcutil.CheckGrpcReady(ctx, s.grpcErrChan)
 	if err := s.grpcServer.Serve(s.listener); err != nil {
 		s.grpcErrChan <- err

--- a/internal/distributed/querycoord/service.go
+++ b/internal/distributed/querycoord/service.go
@@ -31,8 +31,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
-	dcc "github.com/milvus-io/milvus/internal/distributed/datacoord/client"
-	rcc "github.com/milvus-io/milvus/internal/distributed/rootcoord/client"
+	"github.com/milvus-io/milvus/internal/coordinator/coordclient"
 	"github.com/milvus-io/milvus/internal/distributed/utils"
 	"github.com/milvus-io/milvus/internal/proto/internalpb"
 	"github.com/milvus-io/milvus/internal/proto/querypb"
@@ -169,11 +168,7 @@ func (s *Server) init() error {
 
 	// --- Master Server Client ---
 	if s.rootCoord == nil {
-		s.rootCoord, err = rcc.NewClient(s.loopCtx)
-		if err != nil {
-			log.Error("QueryCoord try to new RootCoord client failed", zap.Error(err))
-			panic(err)
-		}
+		s.rootCoord = coordclient.GetRootCoordClient(s.loopCtx)
 	}
 
 	// wait for master init or healthy
@@ -191,11 +186,7 @@ func (s *Server) init() error {
 
 	// --- Data service client ---
 	if s.dataCoord == nil {
-		s.dataCoord, err = dcc.NewClient(s.loopCtx)
-		if err != nil {
-			log.Error("QueryCoord try to new DataCoord client failed", zap.Error(err))
-			panic(err)
-		}
+		s.dataCoord = coordclient.GetDataCoordClient(s.loopCtx)
 	}
 
 	log.Info("QueryCoord try to wait for DataCoord ready")
@@ -258,6 +249,7 @@ func (s *Server) startGrpcLoop() {
 		grpc.StatsHandler(tracer.GetDynamicOtelGrpcServerStatsHandler()),
 	)
 	querypb.RegisterQueryCoordServer(s.grpcServer, s)
+	coordclient.RegisterQueryCoordServer(s)
 
 	go funcutil.CheckGrpcReady(ctx, s.grpcErrChan)
 	if err := s.grpcServer.Serve(s.listener); err != nil {

--- a/internal/distributed/querycoord/service.go
+++ b/internal/distributed/querycoord/service.go
@@ -37,7 +37,6 @@ import (
 	"github.com/milvus-io/milvus/internal/proto/querypb"
 	qc "github.com/milvus-io/milvus/internal/querycoordv2"
 	"github.com/milvus-io/milvus/internal/types"
-	"github.com/milvus-io/milvus/internal/util/componentutil"
 	"github.com/milvus-io/milvus/internal/util/dependency"
 	_ "github.com/milvus-io/milvus/internal/util/grpcclient"
 	"github.com/milvus-io/milvus/pkg/log"
@@ -172,33 +171,18 @@ func (s *Server) init() error {
 	}
 
 	// wait for master init or healthy
-	log.Info("QueryCoord try to wait for RootCoord ready")
-	err = componentutil.WaitForComponentHealthy(s.loopCtx, s.rootCoord, "RootCoord", 1000000, time.Millisecond*200)
-	if err != nil {
-		log.Error("QueryCoord wait for RootCoord ready failed", zap.Error(err))
-		panic(err)
-	}
-
 	if err := s.SetRootCoord(s.rootCoord); err != nil {
 		panic(err)
 	}
-	log.Info("QueryCoord report RootCoord ready")
 
 	// --- Data service client ---
 	if s.dataCoord == nil {
 		s.dataCoord = coordclient.GetDataCoordClient(s.loopCtx)
 	}
 
-	log.Info("QueryCoord try to wait for DataCoord ready")
-	err = componentutil.WaitForComponentHealthy(s.loopCtx, s.dataCoord, "DataCoord", 1000000, time.Millisecond*200)
-	if err != nil {
-		log.Error("QueryCoord wait for DataCoord ready failed", zap.Error(err))
-		panic(err)
-	}
 	if err := s.SetDataCoord(s.dataCoord); err != nil {
 		panic(err)
 	}
-	log.Info("QueryCoord report DataCoord ready")
 
 	if err := s.queryCoord.Init(); err != nil {
 		return err

--- a/internal/distributed/querycoord/service_test.go
+++ b/internal/distributed/querycoord/service_test.go
@@ -59,16 +59,8 @@ func Test_NewServer(t *testing.T) {
 		assert.NotNil(t, server)
 
 		mdc := mocks.NewMockDataCoordClient(t)
-		mdc.EXPECT().GetComponentStates(mock.Anything, mock.Anything).Return(&milvuspb.ComponentStates{
-			State:  &milvuspb.ComponentInfo{StateCode: commonpb.StateCode_Healthy},
-			Status: &commonpb.Status{ErrorCode: commonpb.ErrorCode_Success},
-		}, nil)
 
 		mrc := mocks.NewMockRootCoordClient(t)
-		mrc.EXPECT().GetComponentStates(mock.Anything, mock.Anything).Return(&milvuspb.ComponentStates{
-			State:  &milvuspb.ComponentInfo{StateCode: commonpb.StateCode_Healthy},
-			Status: &commonpb.Status{ErrorCode: commonpb.ErrorCode_Success},
-		}, nil)
 
 		mqc := getQueryCoord()
 		successStatus := merr.Success()

--- a/internal/distributed/rootcoord/service.go
+++ b/internal/distributed/rootcoord/service.go
@@ -31,8 +31,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
-	dcc "github.com/milvus-io/milvus/internal/distributed/datacoord/client"
-	qcc "github.com/milvus-io/milvus/internal/distributed/querycoord/client"
+	"github.com/milvus-io/milvus/internal/coordinator/coordclient"
 	"github.com/milvus-io/milvus/internal/distributed/utils"
 	"github.com/milvus-io/milvus/internal/proto/internalpb"
 	"github.com/milvus-io/milvus/internal/proto/proxypb"
@@ -72,8 +71,8 @@ type Server struct {
 	dataCoord  types.DataCoordClient
 	queryCoord types.QueryCoordClient
 
-	newDataCoordClient  func() types.DataCoordClient
-	newQueryCoordClient func() types.QueryCoordClient
+	newDataCoordClient  func(ctx context.Context) types.DataCoordClient
+	newQueryCoordClient func(ctx context.Context) types.QueryCoordClient
 }
 
 func (s *Server) DescribeDatabase(ctx context.Context, request *rootcoordpb.DescribeDatabaseRequest) (*rootcoordpb.DescribeDatabaseResponse, error) {
@@ -157,21 +156,8 @@ func (s *Server) Prepare() error {
 }
 
 func (s *Server) setClient() {
-	s.newDataCoordClient = func() types.DataCoordClient {
-		dsClient, err := dcc.NewClient(s.ctx)
-		if err != nil {
-			panic(err)
-		}
-		return dsClient
-	}
-
-	s.newQueryCoordClient = func() types.QueryCoordClient {
-		qsClient, err := qcc.NewClient(s.ctx)
-		if err != nil {
-			panic(err)
-		}
-		return qsClient
-	}
+	s.newDataCoordClient = coordclient.GetDataCoordClient
+	s.newQueryCoordClient = coordclient.GetQueryCoordClient
 }
 
 // Run initializes and starts RootCoord's grpc service.
@@ -234,7 +220,7 @@ func (s *Server) init() error {
 
 	if s.newDataCoordClient != nil {
 		log.Info("RootCoord start to create DataCoord client")
-		dataCoord := s.newDataCoordClient()
+		dataCoord := s.newDataCoordClient(s.ctx)
 		s.dataCoord = dataCoord
 		if err := s.rootCoord.SetDataCoordClient(dataCoord); err != nil {
 			panic(err)
@@ -243,7 +229,7 @@ func (s *Server) init() error {
 
 	if s.newQueryCoordClient != nil {
 		log.Info("RootCoord start to create QueryCoord client")
-		queryCoord := s.newQueryCoordClient()
+		queryCoord := s.newQueryCoordClient(s.ctx)
 		s.queryCoord = queryCoord
 		if err := s.rootCoord.SetQueryCoordClient(queryCoord); err != nil {
 			panic(err)
@@ -305,6 +291,7 @@ func (s *Server) startGrpcLoop() {
 		)),
 		grpc.StatsHandler(tracer.GetDynamicOtelGrpcServerStatsHandler()))
 	rootcoordpb.RegisterRootCoordServer(s.grpcServer, s)
+	coordclient.RegisterRootCoordServer(s)
 
 	go funcutil.CheckGrpcReady(ctx, s.grpcErrChan)
 	if err := s.grpcServer.Serve(s.listener); err != nil {

--- a/internal/distributed/rootcoord/service_test.go
+++ b/internal/distributed/rootcoord/service_test.go
@@ -142,13 +142,13 @@ func TestRun(t *testing.T) {
 
 		mockDataCoord := mocks.NewMockDataCoordClient(t)
 		mockDataCoord.EXPECT().Close().Return(nil)
-		svr.newDataCoordClient = func() types.DataCoordClient {
+		svr.newDataCoordClient = func(_ context.Context) types.DataCoordClient {
 			return mockDataCoord
 		}
 
 		mockQueryCoord := mocks.NewMockQueryCoordClient(t)
 		mockQueryCoord.EXPECT().Close().Return(nil)
-		svr.newQueryCoordClient = func() types.QueryCoordClient {
+		svr.newQueryCoordClient = func(_ context.Context) types.QueryCoordClient {
 			return mockQueryCoord
 		}
 
@@ -238,7 +238,7 @@ func TestServerRun_DataCoordClientInitErr(t *testing.T) {
 
 		mockDataCoord := mocks.NewMockDataCoordClient(t)
 		mockDataCoord.EXPECT().Close().Return(nil)
-		server.newDataCoordClient = func() types.DataCoordClient {
+		server.newDataCoordClient = func(_ context.Context) types.DataCoordClient {
 			return mockDataCoord
 		}
 		err = server.Prepare()
@@ -268,7 +268,7 @@ func TestServerRun_DataCoordClientStartErr(t *testing.T) {
 
 		mockDataCoord := mocks.NewMockDataCoordClient(t)
 		mockDataCoord.EXPECT().Close().Return(nil)
-		server.newDataCoordClient = func() types.DataCoordClient {
+		server.newDataCoordClient = func(_ context.Context) types.DataCoordClient {
 			return mockDataCoord
 		}
 		err = server.Prepare()
@@ -298,7 +298,7 @@ func TestServerRun_QueryCoordClientInitErr(t *testing.T) {
 
 		mockQueryCoord := mocks.NewMockQueryCoordClient(t)
 		mockQueryCoord.EXPECT().Close().Return(nil)
-		server.newQueryCoordClient = func() types.QueryCoordClient {
+		server.newQueryCoordClient = func(_ context.Context) types.QueryCoordClient {
 			return mockQueryCoord
 		}
 		err = server.Prepare()
@@ -328,7 +328,7 @@ func TestServer_QueryCoordClientStartErr(t *testing.T) {
 
 		mockQueryCoord := mocks.NewMockQueryCoordClient(t)
 		mockQueryCoord.EXPECT().Close().Return(nil)
-		server.newQueryCoordClient = func() types.QueryCoordClient {
+		server.newQueryCoordClient = func(_ context.Context) types.QueryCoordClient {
 			return mockQueryCoord
 		}
 		err = server.Prepare()

--- a/internal/querycoordv2/server.go
+++ b/internal/querycoordv2/server.go
@@ -226,7 +226,7 @@ func (s *Server) initQueryCoord() error {
 	log.Info("QueryCoord try to wait for RootCoord ready")
 	if err := componentutil.WaitForComponentHealthy(s.ctx, s.rootCoord, "RootCoord", 1000000, time.Millisecond*200); err != nil {
 		log.Error("QueryCoord wait for RootCoord ready failed", zap.Error(err))
-		panic(err)
+		return errors.Wrap(err, "RootCoord not ready")
 	}
 	log.Info("QueryCoord report RootCoord ready")
 
@@ -234,7 +234,7 @@ func (s *Server) initQueryCoord() error {
 	log.Info("QueryCoord try to wait for DataCoord ready")
 	if err := componentutil.WaitForComponentHealthy(s.ctx, s.dataCoord, "DataCoord", 1000000, time.Millisecond*200); err != nil {
 		log.Error("QueryCoord wait for DataCoord ready failed", zap.Error(err))
-		panic(err)
+		return errors.Wrap(err, "DataCoord not ready")
 	}
 	log.Info("QueryCoord report DataCoord ready")
 

--- a/internal/querycoordv2/server.go
+++ b/internal/querycoordv2/server.go
@@ -53,6 +53,7 @@ import (
 	"github.com/milvus-io/milvus/internal/querycoordv2/session"
 	"github.com/milvus-io/milvus/internal/querycoordv2/task"
 	"github.com/milvus-io/milvus/internal/types"
+	"github.com/milvus-io/milvus/internal/util/componentutil"
 	"github.com/milvus-io/milvus/internal/util/healthcheck"
 	"github.com/milvus-io/milvus/internal/util/proxyutil"
 	"github.com/milvus-io/milvus/internal/util/sessionutil"
@@ -221,6 +222,22 @@ func (s *Server) Init() error {
 }
 
 func (s *Server) initQueryCoord() error {
+	// wait for master init or healthy
+	log.Info("QueryCoord try to wait for RootCoord ready")
+	if err := componentutil.WaitForComponentHealthy(s.ctx, s.rootCoord, "RootCoord", 1000000, time.Millisecond*200); err != nil {
+		log.Error("QueryCoord wait for RootCoord ready failed", zap.Error(err))
+		panic(err)
+	}
+	log.Info("QueryCoord report RootCoord ready")
+
+	// wait for master init or healthy
+	log.Info("QueryCoord try to wait for DataCoord ready")
+	if err := componentutil.WaitForComponentHealthy(s.ctx, s.dataCoord, "DataCoord", 1000000, time.Millisecond*200); err != nil {
+		log.Error("QueryCoord wait for DataCoord ready failed", zap.Error(err))
+		panic(err)
+	}
+	log.Info("QueryCoord report DataCoord ready")
+
 	s.UpdateStateCode(commonpb.StateCode_Initializing)
 	log.Info("start init querycoord", zap.Any("State", commonpb.StateCode_Initializing))
 	// Init KV and ID allocator

--- a/internal/querycoordv2/server_test.go
+++ b/internal/querycoordv2/server_test.go
@@ -319,7 +319,19 @@ func (suite *ServerSuite) TestEnableActiveStandby() {
 	suite.server, err = suite.newQueryCoord()
 	suite.NoError(err)
 	mockRootCoord := coordMocks.NewMockRootCoordClient(suite.T())
+	mockRootCoord.EXPECT().GetComponentStates(mock.Anything, mock.Anything).Return(&milvuspb.ComponentStates{
+		State: &milvuspb.ComponentInfo{
+			StateCode: commonpb.StateCode_Healthy,
+		},
+		Status: merr.Success(),
+	}, nil).Maybe()
 	mockDataCoord := coordMocks.NewMockDataCoordClient(suite.T())
+	mockDataCoord.EXPECT().GetComponentStates(mock.Anything, mock.Anything).Return(&milvuspb.ComponentStates{
+		State: &milvuspb.ComponentInfo{
+			StateCode: commonpb.StateCode_Healthy,
+		},
+		Status: merr.Success(),
+	}, nil).Maybe()
 
 	mockRootCoord.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(&milvuspb.DescribeCollectionResponse{
 		Status: merr.Success(),
@@ -610,7 +622,19 @@ func (suite *ServerSuite) hackServer() {
 
 func (suite *ServerSuite) hackBroker(server *Server) {
 	mockRootCoord := coordMocks.NewMockRootCoordClient(suite.T())
+	mockRootCoord.EXPECT().GetComponentStates(mock.Anything, mock.Anything).Return(&milvuspb.ComponentStates{
+		State: &milvuspb.ComponentInfo{
+			StateCode: commonpb.StateCode_Healthy,
+		},
+		Status: merr.Success(),
+	}, nil).Maybe()
 	mockDataCoord := coordMocks.NewMockDataCoordClient(suite.T())
+	mockDataCoord.EXPECT().GetComponentStates(mock.Anything, mock.Anything).Return(&milvuspb.ComponentStates{
+		State: &milvuspb.ComponentInfo{
+			StateCode: commonpb.StateCode_Healthy,
+		},
+		Status: merr.Success(),
+	}, nil).Maybe()
 
 	for _, collection := range suite.collections {
 		mockRootCoord.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(&milvuspb.DescribeCollectionResponse{

--- a/internal/util/grpcclient/local_grpc_client.go
+++ b/internal/util/grpcclient/local_grpc_client.go
@@ -1,0 +1,68 @@
+package grpcclient
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+var _ grpc.ClientConnInterface = &localConn{}
+
+// NewLocalGRPCClient creates a grpc client that calls the server directly.
+// !!! Warning: it didn't make any network or serialization/deserialization, so it's not promise concurrent safe.
+// and there's no interceptor for client and server like the common grpc client/server.
+func NewLocalGRPCClient[C any, S any](desc *grpc.ServiceDesc, server S, clientCreator func(grpc.ClientConnInterface) C) C {
+	return clientCreator(&localConn{
+		serviceDesc: desc,
+		server:      server,
+	})
+}
+
+// localConn is a grpc.ClientConnInterface implementation that calls the server directly.
+type localConn struct {
+	serviceDesc *grpc.ServiceDesc // ServiceDesc is the descriptor for this service.
+	server      interface{}       // the server object.
+}
+
+// Invoke calls the server method directly.
+func (c *localConn) Invoke(ctx context.Context, method string, args, reply interface{}, opts ...grpc.CallOption) error {
+	methodDesc := c.findMethod(method)
+	if methodDesc == nil {
+		return status.Errorf(codes.Unimplemented, fmt.Sprintf("method %s not implemented", method))
+	}
+	resp, err := methodDesc.Handler(c.server, ctx, func(in any) error {
+		reflect.ValueOf(in).Elem().Set(reflect.ValueOf(args).Elem())
+		return nil
+	}, nil)
+	if err != nil {
+		return err
+	}
+	reflect.ValueOf(reply).Elem().Set(reflect.ValueOf(resp).Elem())
+	return nil
+}
+
+// NewStream is not supported by now, wait for implementation.
+func (c *localConn) NewStream(ctx context.Context, desc *grpc.StreamDesc, method string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	panic("we don't support local stream rpc by now")
+}
+
+// findMethod finds the method descriptor by the full method name.
+func (c *localConn) findMethod(fullMethodName string) *grpc.MethodDesc {
+	strs := strings.SplitN(fullMethodName[1:], "/", 2)
+	serviceName := strs[0]
+	methodName := strs[1]
+	if c.serviceDesc.ServiceName != serviceName {
+		return nil
+	}
+	for i := range c.serviceDesc.Methods {
+		if c.serviceDesc.Methods[i].MethodName == methodName {
+			return &c.serviceDesc.Methods[i]
+		}
+	}
+	return nil
+}

--- a/internal/util/grpcclient/local_grpc_client_test.go
+++ b/internal/util/grpcclient/local_grpc_client_test.go
@@ -1,0 +1,46 @@
+package grpcclient
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/internal/proto/rootcoordpb"
+)
+
+type mockRootCoordServer struct {
+	t *testing.T
+	*rootcoordpb.UnimplementedRootCoordServer
+}
+
+func (s *mockRootCoordServer) AllocID(ctx context.Context, req *rootcoordpb.AllocIDRequest) (*rootcoordpb.AllocIDResponse, error) {
+	assert.NotNil(s.t, req)
+	assert.Equal(s.t, uint32(100), req.Count)
+	return &rootcoordpb.AllocIDResponse{
+		ID:    1,
+		Count: 2,
+	}, nil
+}
+
+func TestLocalGRPCClient(t *testing.T) {
+	localClient := NewLocalGRPCClient(
+		&rootcoordpb.RootCoord_ServiceDesc,
+		&mockRootCoordServer{
+			t:                            t,
+			UnimplementedRootCoordServer: &rootcoordpb.UnimplementedRootCoordServer{},
+		},
+		rootcoordpb.NewRootCoordClient,
+	)
+	result, err := localClient.AllocTimestamp(context.Background(), &rootcoordpb.AllocTimestampRequest{})
+	assert.Error(t, err)
+	assert.Nil(t, result)
+
+	result2, err := localClient.AllocID(context.Background(), &rootcoordpb.AllocIDRequest{
+		Count: 100,
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, result2)
+	assert.Equal(t, int64(1), result2.ID)
+	assert.Equal(t, uint32(2), result2.Count)
+}

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -269,6 +269,9 @@ type commonConfig struct {
 
 	HealthCheckInterval   ParamItem `refreshable:"true"`
 	HealthCheckRPCTimeout ParamItem `refreshable:"true"`
+
+	// Local RPC enabled for milvus internal communication when mix or standalone mode.
+	LocalRPCEnabled ParamItem `refreshable:"false"`
 }
 
 func (p *commonConfig) init(base *BaseTable) {
@@ -934,6 +937,15 @@ This helps Milvus-CDC synchronize incremental data`,
 		Doc:          `RPC timeout for health check request`,
 	}
 	p.HealthCheckRPCTimeout.Init(base.mgr)
+
+	p.LocalRPCEnabled = ParamItem{
+		Key:          "common.localRPCEnabled",
+		Version:      "2.4.18",
+		DefaultValue: "false",
+		Doc:          `enable local rpc for internal communication when mix or standalone mode.`,
+		Export:       true,
+	}
+	p.LocalRPCEnabled.Init(base.mgr)
 }
 
 type gpuConfig struct {

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -134,6 +134,10 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, 0, len(Params.ReadOnlyPrivileges.GetAsStrings()))
 		assert.Equal(t, 0, len(Params.ReadWritePrivileges.GetAsStrings()))
 		assert.Equal(t, 0, len(Params.AdminPrivileges.GetAsStrings()))
+
+		assert.False(t, params.CommonCfg.LocalRPCEnabled.GetAsBool())
+		params.Save("common.localRPCEnabled", "true")
+		assert.True(t, params.CommonCfg.LocalRPCEnabled.GetAsBool())
 	})
 
 	t.Run("test rootCoordConfig", func(t *testing.T) {

--- a/pkg/util/syncutil/future.go
+++ b/pkg/util/syncutil/future.go
@@ -1,0 +1,56 @@
+package syncutil
+
+import (
+	"context"
+)
+
+// Future is a future value that can be set and retrieved.
+type Future[T any] struct {
+	ch    chan struct{}
+	value T
+}
+
+// NewFuture creates a new future.
+func NewFuture[T any]() *Future[T] {
+	return &Future[T]{
+		ch: make(chan struct{}),
+	}
+}
+
+// Set sets the value of the future.
+func (f *Future[T]) Set(value T) {
+	f.value = value
+	close(f.ch)
+}
+
+// GetWithContext retrieves the value of the future if set, otherwise block until set or the context is done.
+func (f *Future[T]) GetWithContext(ctx context.Context) (T, error) {
+	select {
+	case <-ctx.Done():
+		var val T
+		return val, ctx.Err()
+	case <-f.ch:
+		return f.value, nil
+	}
+}
+
+// Get retrieves the value of the future if set, otherwise block until set.
+func (f *Future[T]) Get() T {
+	<-f.ch
+	return f.value
+}
+
+// Done returns a channel that is closed when the future is set.
+func (f *Future[T]) Done() <-chan struct{} {
+	return f.ch
+}
+
+// Ready returns true if the future is set.
+func (f *Future[T]) Ready() bool {
+	select {
+	case <-f.ch:
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/util/syncutil/future_test.go
+++ b/pkg/util/syncutil/future_test.go
@@ -1,0 +1,51 @@
+package syncutil
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFuture_SetAndGet(t *testing.T) {
+	f := NewFuture[int]()
+	go func() {
+		time.Sleep(1 * time.Second) // Simulate some work
+		f.Set(42)
+	}()
+
+	val := f.Get()
+	if val != 42 {
+		t.Errorf("Expected value 42, got %d", val)
+	}
+}
+
+func TestFuture_Done(t *testing.T) {
+	f := NewFuture[string]()
+	go func() {
+		f.Set("done")
+	}()
+
+	select {
+	case <-f.Done():
+		// Success
+	case <-time.After(20 * time.Millisecond):
+		t.Error("Expected future to be done within 2 seconds")
+	}
+}
+
+func TestFuture_Ready(t *testing.T) {
+	f := NewFuture[float64]()
+	go func() {
+		time.Sleep(20 * time.Millisecond) // Simulate some work
+		f.Set(3.14)
+	}()
+
+	if f.Ready() {
+		t.Error("Expected future not to be ready immediately")
+	}
+
+	<-f.Done() // Wait for the future to be set
+
+	if !f.Ready() {
+		t.Error("Expected future to be ready after being set")
+	}
+}


### PR DESCRIPTION
issue: #37764
pr: #37815 
also see: #38259

- add a local client to call local server directly for querycoord/rootcoord/datacoord.
- enable local client if milvus is running mixcoord or standalone mode.
- after removing rpc layer from mixcoord, the querycoord at standby mode will be blocked forever of deployment rolling