### PR TITLE
fix: Query coord stop progress is too slow

### DIFF
--- a/internal/querycoordv2/balance/channel_level_score_balancer_test.go
+++ b/internal/querycoordv2/balance/channel_level_score_balancer_test.go
@@ -69,7 +69,7 @@ func (suite *ChannelLevelScoreBalancerTestSuite) SetupTest() {
 	idAllocator := RandomIncrementIDAllocator()
 	nodeManager := session.NewNodeManager()
 	testMeta := meta.NewMeta(idAllocator, store, nodeManager)
-	testTarget := meta.NewTargetManager(suite.broker, testMeta)
+	testTarget := meta.NewTargetManager(suite.broker, testMeta, querycoord.NewCatalog(suite.kv))
 
 	distManager := meta.NewDistributionManager()
 	suite.mockScheduler = task.NewMockScheduler(suite.T())

--- a/internal/querycoordv2/balance/rowcount_based_balancer_test.go
+++ b/internal/querycoordv2/balance/rowcount_based_balancer_test.go
@@ -72,7 +72,7 @@ func (suite *RowCountBasedBalancerTestSuite) SetupTest() {
 	idAllocator := RandomIncrementIDAllocator()
 	nodeManager := session.NewNodeManager()
 	testMeta := meta.NewMeta(idAllocator, store, nodeManager)
-	testTarget := meta.NewTargetManager(suite.broker, testMeta)
+	testTarget := meta.NewTargetManager(suite.broker, testMeta, querycoord.NewCatalog(suite.kv))
 
 	distManager := meta.NewDistributionManager()
 	suite.mockScheduler = task.NewMockScheduler(suite.T())

--- a/internal/querycoordv2/balance/score_based_balancer_test.go
+++ b/internal/querycoordv2/balance/score_based_balancer_test.go
@@ -69,7 +69,7 @@ func (suite *ScoreBasedBalancerTestSuite) SetupTest() {
 	idAllocator := RandomIncrementIDAllocator()
 	nodeManager := session.NewNodeManager()
 	testMeta := meta.NewMeta(idAllocator, store, nodeManager)
-	testTarget := meta.NewTargetManager(suite.broker, testMeta)
+	testTarget := meta.NewTargetManager(suite.broker, testMeta, querycoord.NewCatalog(suite.kv))
 
 	distManager := meta.NewDistributionManager()
 	suite.mockScheduler = task.NewMockScheduler(suite.T())

--- a/internal/querycoordv2/checkers/balance_checker_test.go
+++ b/internal/querycoordv2/checkers/balance_checker_test.go
@@ -75,7 +75,7 @@ func (suite *BalanceCheckerTestSuite) SetupTest() {
 	suite.meta = meta.NewMeta(idAllocator, store, suite.nodeMgr)
 	suite.broker = meta.NewMockBroker(suite.T())
 	suite.scheduler = task.NewMockScheduler(suite.T())
-	suite.targetMgr = meta.NewTargetManager(suite.broker, suite.meta)
+	suite.targetMgr = meta.NewTargetManager(suite.broker, suite.meta, querycoord.NewCatalog(suite.kv))
 
 	suite.balancer = balance.NewMockBalancer(suite.T())
 	suite.checker = NewBalanceChecker(suite.meta, suite.targetMgr, suite.nodeMgr, suite.scheduler, func() balance.Balance { return suite.balancer })

--- a/internal/querycoordv2/checkers/channel_checker_test.go
+++ b/internal/querycoordv2/checkers/channel_checker_test.go
@@ -72,7 +72,7 @@ func (suite *ChannelCheckerTestSuite) SetupTest() {
 	suite.nodeMgr = session.NewNodeManager()
 	suite.meta = meta.NewMeta(idAllocator, store, suite.nodeMgr)
 	suite.broker = meta.NewMockBroker(suite.T())
-	targetManager := meta.NewTargetManager(suite.broker, suite.meta)
+	targetManager := meta.NewTargetManager(suite.broker, suite.meta, querycoord.NewCatalog(suite.kv))
 
 	distManager := meta.NewDistributionManager()
 

--- a/internal/querycoordv2/checkers/controller_base_test.go
+++ b/internal/querycoordv2/checkers/controller_base_test.go
@@ -73,7 +73,7 @@ func (suite *ControllerBaseTestSuite) SetupTest() {
 	suite.meta = meta.NewMeta(idAllocator, store, suite.nodeMgr)
 	suite.dist = meta.NewDistributionManager()
 	suite.broker = meta.NewMockBroker(suite.T())
-	suite.targetManager = meta.NewTargetManager(suite.broker, suite.meta)
+	suite.targetManager = meta.NewTargetManager(suite.broker, suite.meta, querycoord.NewCatalog(suite.kv))
 
 	suite.balancer = balance.NewMockBalancer(suite.T())
 	suite.scheduler = task.NewMockScheduler(suite.T())

--- a/internal/querycoordv2/checkers/controller_test.go
+++ b/internal/querycoordv2/checkers/controller_test.go
@@ -78,7 +78,7 @@ func (suite *CheckerControllerSuite) SetupTest() {
 	suite.meta = meta.NewMeta(idAllocator, store, suite.nodeMgr)
 	suite.dist = meta.NewDistributionManager()
 	suite.broker = meta.NewMockBroker(suite.T())
-	suite.targetManager = meta.NewTargetManager(suite.broker, suite.meta)
+	suite.targetManager = meta.NewTargetManager(suite.broker, suite.meta, querycoord.NewCatalog(suite.kv))
 
 	suite.balancer = balance.NewMockBalancer(suite.T())
 	suite.scheduler = task.NewMockScheduler(suite.T())

--- a/internal/querycoordv2/checkers/leader_checker_test.go
+++ b/internal/querycoordv2/checkers/leader_checker_test.go
@@ -74,7 +74,7 @@ func (suite *LeaderCheckerTestSuite) SetupTest() {
 	suite.broker = meta.NewMockBroker(suite.T())
 
 	distManager := meta.NewDistributionManager()
-	targetManager := meta.NewTargetManager(suite.broker, suite.meta)
+	targetManager := meta.NewTargetManager(suite.broker, suite.meta, querycoord.NewCatalog(suite.kv))
 	suite.checker = NewLeaderChecker(suite.meta, distManager, targetManager, suite.nodeMgr)
 }
 

--- a/internal/querycoordv2/checkers/segment_checker_test.go
+++ b/internal/querycoordv2/checkers/segment_checker_test.go
@@ -74,7 +74,7 @@ func (suite *SegmentCheckerTestSuite) SetupTest() {
 	suite.meta = meta.NewMeta(idAllocator, store, suite.nodeMgr)
 	distManager := meta.NewDistributionManager()
 	suite.broker = meta.NewMockBroker(suite.T())
-	targetManager := meta.NewTargetManager(suite.broker, suite.meta)
+	targetManager := meta.NewTargetManager(suite.broker, suite.meta, querycoord.NewCatalog(suite.kv))
 
 	balancer := suite.createMockBalancer()
 	suite.checker = NewSegmentChecker(suite.meta, distManager, targetManager, suite.nodeMgr, func() balance.Balance { return balancer })

--- a/internal/querycoordv2/dist/dist_controller_test.go
+++ b/internal/querycoordv2/dist/dist_controller_test.go
@@ -78,7 +78,7 @@ func (suite *DistControllerTestSuite) SetupTest() {
 	suite.mockCluster = session.NewMockCluster(suite.T())
 	distManager := meta.NewDistributionManager()
 	suite.broker = meta.NewMockBroker(suite.T())
-	targetManager := meta.NewTargetManager(suite.broker, suite.meta)
+	targetManager := meta.NewTargetManager(suite.broker, suite.meta, querycoord.NewCatalog(suite.kv))
 	suite.mockScheduler = task.NewMockScheduler(suite.T())
 	suite.mockScheduler.EXPECT().GetExecutedFlag(mock.Anything).Return(nil).Maybe()
 	syncTargetVersionFn := func(collectionID int64) {}

--- a/internal/querycoordv2/job/job_test.go
+++ b/internal/querycoordv2/job/job_test.go
@@ -165,7 +165,7 @@ func (suite *JobSuite) SetupTest() {
 	suite.dist = meta.NewDistributionManager()
 	suite.nodeMgr = session.NewNodeManager()
 	suite.meta = meta.NewMeta(RandomIncrementIDAllocator(), suite.store, suite.nodeMgr)
-	suite.targetMgr = meta.NewTargetManager(suite.broker, suite.meta)
+	suite.targetMgr = meta.NewTargetManager(suite.broker, suite.meta, querycoord.NewCatalog(suite.kv))
 	suite.targetObserver = observers.NewTargetObserver(suite.meta,
 		suite.targetMgr,
 		suite.dist,

--- a/internal/querycoordv2/meta/mock_target_manager.go
+++ b/internal/querycoordv2/meta/mock_target_manager.go
@@ -5,9 +5,7 @@ package meta
 import (
 	context "context"
 
-	metastore "github.com/milvus-io/milvus/internal/metastore"
 	datapb "github.com/milvus-io/milvus/internal/proto/datapb"
-
 	mock "github.com/stretchr/testify/mock"
 
 	typeutil "github.com/milvus-io/milvus/pkg/util/typeutil"
@@ -780,17 +778,17 @@ func (_c *MockTargetManager_IsNextTargetExist_Call) RunAndReturn(run func(contex
 	return _c
 }
 
-// Recover provides a mock function with given fields: ctx, catalog
-func (_m *MockTargetManager) Recover(ctx context.Context, catalog metastore.QueryCoordCatalog) error {
-	ret := _m.Called(ctx, catalog)
+// Recover provides a mock function with given fields: ctx
+func (_m *MockTargetManager) Recover(ctx context.Context) error {
+	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Recover")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, metastore.QueryCoordCatalog) error); ok {
-		r0 = rf(ctx, catalog)
+	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
+		r0 = rf(ctx)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -805,14 +803,13 @@ type MockTargetManager_Recover_Call struct {
 
 // Recover is a helper method to define mock.On call
 //   - ctx context.Context
-//   - catalog metastore.QueryCoordCatalog
-func (_e *MockTargetManager_Expecter) Recover(ctx interface{}, catalog interface{}) *MockTargetManager_Recover_Call {
-	return &MockTargetManager_Recover_Call{Call: _e.mock.On("Recover", ctx, catalog)}
+func (_e *MockTargetManager_Expecter) Recover(ctx interface{}) *MockTargetManager_Recover_Call {
+	return &MockTargetManager_Recover_Call{Call: _e.mock.On("Recover", ctx)}
 }
 
-func (_c *MockTargetManager_Recover_Call) Run(run func(ctx context.Context, catalog metastore.QueryCoordCatalog)) *MockTargetManager_Recover_Call {
+func (_c *MockTargetManager_Recover_Call) Run(run func(ctx context.Context)) *MockTargetManager_Recover_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(metastore.QueryCoordCatalog))
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -822,7 +819,7 @@ func (_c *MockTargetManager_Recover_Call) Return(_a0 error) *MockTargetManager_R
 	return _c
 }
 
-func (_c *MockTargetManager_Recover_Call) RunAndReturn(run func(context.Context, metastore.QueryCoordCatalog) error) *MockTargetManager_Recover_Call {
+func (_c *MockTargetManager_Recover_Call) RunAndReturn(run func(context.Context) error) *MockTargetManager_Recover_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -906,40 +903,6 @@ func (_c *MockTargetManager_RemovePartition_Call) Return() *MockTargetManager_Re
 }
 
 func (_c *MockTargetManager_RemovePartition_Call) RunAndReturn(run func(context.Context, int64, ...int64)) *MockTargetManager_RemovePartition_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// SaveCurrentTarget provides a mock function with given fields: ctx, catalog
-func (_m *MockTargetManager) SaveCurrentTarget(ctx context.Context, catalog metastore.QueryCoordCatalog) {
-	_m.Called(ctx, catalog)
-}
-
-// MockTargetManager_SaveCurrentTarget_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SaveCurrentTarget'
-type MockTargetManager_SaveCurrentTarget_Call struct {
-	*mock.Call
-}
-
-// SaveCurrentTarget is a helper method to define mock.On call
-//   - ctx context.Context
-//   - catalog metastore.QueryCoordCatalog
-func (_e *MockTargetManager_Expecter) SaveCurrentTarget(ctx interface{}, catalog interface{}) *MockTargetManager_SaveCurrentTarget_Call {
-	return &MockTargetManager_SaveCurrentTarget_Call{Call: _e.mock.On("SaveCurrentTarget", ctx, catalog)}
-}
-
-func (_c *MockTargetManager_SaveCurrentTarget_Call) Run(run func(ctx context.Context, catalog metastore.QueryCoordCatalog)) *MockTargetManager_SaveCurrentTarget_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(metastore.QueryCoordCatalog))
-	})
-	return _c
-}
-
-func (_c *MockTargetManager_SaveCurrentTarget_Call) Return() *MockTargetManager_SaveCurrentTarget_Call {
-	_c.Call.Return()
-	return _c
-}
-
-func (_c *MockTargetManager_SaveCurrentTarget_Call) RunAndReturn(run func(context.Context, metastore.QueryCoordCatalog)) *MockTargetManager_SaveCurrentTarget_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/querycoordv2/observers/collection_observer_test.go
+++ b/internal/querycoordv2/observers/collection_observer_test.go
@@ -199,7 +199,7 @@ func (suite *CollectionObserverSuite) SetupTest() {
 	suite.nodeMgr = session.NewNodeManager()
 	suite.meta = meta.NewMeta(suite.idAllocator, suite.store, suite.nodeMgr)
 	suite.broker = meta.NewMockBroker(suite.T())
-	suite.targetMgr = meta.NewTargetManager(suite.broker, suite.meta)
+	suite.targetMgr = meta.NewTargetManager(suite.broker, suite.meta, querycoord.NewCatalog(suite.kv))
 	suite.cluster = session.NewMockCluster(suite.T())
 	suite.targetObserver = NewTargetObserver(suite.meta,
 		suite.targetMgr,

--- a/internal/querycoordv2/observers/target_observer_test.go
+++ b/internal/querycoordv2/observers/target_observer_test.go
@@ -93,7 +93,7 @@ func (suite *TargetObserverSuite) SetupTest() {
 	suite.meta = meta.NewMeta(idAllocator, store, nodeMgr)
 
 	suite.broker = meta.NewMockBroker(suite.T())
-	suite.targetMgr = meta.NewTargetManager(suite.broker, suite.meta)
+	suite.targetMgr = meta.NewTargetManager(suite.broker, suite.meta, querycoord.NewCatalog(suite.kv))
 	suite.distMgr = meta.NewDistributionManager()
 	suite.cluster = session.NewMockCluster(suite.T())
 	suite.observer = NewTargetObserver(suite.meta, suite.targetMgr, suite.distMgr, suite.broker, suite.cluster, nodeMgr)
@@ -299,7 +299,7 @@ func (suite *TargetObserverCheckSuite) SetupTest() {
 	suite.meta = meta.NewMeta(idAllocator, store, nodeMgr)
 
 	suite.broker = meta.NewMockBroker(suite.T())
-	suite.targetMgr = meta.NewTargetManager(suite.broker, suite.meta)
+	suite.targetMgr = meta.NewTargetManager(suite.broker, suite.meta, querycoord.NewCatalog(suite.kv))
 	suite.distMgr = meta.NewDistributionManager()
 	suite.cluster = session.NewMockCluster(suite.T())
 	suite.observer = NewTargetObserver(

--- a/internal/querycoordv2/ops_service_test.go
+++ b/internal/querycoordv2/ops_service_test.go
@@ -102,7 +102,7 @@ func (suite *OpsServiceSuite) SetupTest() {
 	suite.nodeMgr = session.NewNodeManager()
 	suite.meta = meta.NewMeta(params.RandomIncrementIDAllocator(), suite.store, suite.nodeMgr)
 	suite.broker = meta.NewMockBroker(suite.T())
-	suite.targetMgr = meta.NewTargetManager(suite.broker, suite.meta)
+	suite.targetMgr = meta.NewTargetManager(suite.broker, suite.meta, querycoord.NewCatalog(suite.kv))
 	suite.targetObserver = observers.NewTargetObserver(
 		suite.meta,
 		suite.targetMgr,

--- a/internal/querycoordv2/server.go
+++ b/internal/querycoordv2/server.go
@@ -451,8 +451,8 @@ func (s *Server) initMeta() error {
 		ChannelDistManager: meta.NewChannelDistManager(),
 		LeaderViewManager:  meta.NewLeaderViewManager(),
 	}
-	s.targetMgr = meta.NewTargetManager(s.broker, s.meta)
-	err = s.targetMgr.Recover(s.ctx, s.store)
+	s.targetMgr = meta.NewTargetManager(s.broker, s.meta, s.store)
+	err = s.targetMgr.Recover(s.ctx)
 	if err != nil {
 		log.Warn("failed to recover collection targets", zap.Error(err))
 	}
@@ -604,12 +604,6 @@ func (s *Server) Stop() error {
 	}
 	if s.targetObserver != nil {
 		s.targetObserver.Stop()
-	}
-
-	// save target to meta store, after querycoord restart, make it fast to recover current target
-	// should save target after target observer stop, incase of target changed
-	if s.targetMgr != nil {
-		s.targetMgr.SaveCurrentTarget(s.ctx, s.store)
 	}
 
 	if s.replicaObserver != nil {

--- a/internal/querycoordv2/server_test.go
+++ b/internal/querycoordv2/server_test.go
@@ -553,7 +553,7 @@ func (suite *ServerSuite) updateCollectionStatus(collectionID int64, status quer
 func (suite *ServerSuite) hackServer() {
 	suite.broker = meta.NewMockBroker(suite.T())
 	suite.server.broker = suite.broker
-	suite.server.targetMgr = meta.NewTargetManager(suite.broker, suite.server.meta)
+	suite.server.targetMgr = meta.NewTargetManager(suite.broker, suite.server.meta, suite.server.store)
 	suite.server.taskScheduler = task.NewScheduler(
 		suite.server.ctx,
 		suite.server.meta,

--- a/internal/querycoordv2/services_test.go
+++ b/internal/querycoordv2/services_test.go
@@ -150,7 +150,7 @@ func (suite *ServiceSuite) SetupTest() {
 	suite.nodeMgr = session.NewNodeManager()
 	suite.meta = meta.NewMeta(params.RandomIncrementIDAllocator(), suite.store, suite.nodeMgr)
 	suite.broker = meta.NewMockBroker(suite.T())
-	suite.targetMgr = meta.NewTargetManager(suite.broker, suite.meta)
+	suite.targetMgr = meta.NewTargetManager(suite.broker, suite.meta, suite.store)
 	suite.cluster = session.NewMockCluster(suite.T())
 	suite.cluster.EXPECT().SyncDistribution(mock.Anything, mock.Anything, mock.Anything).Return(merr.Success(), nil).Maybe()
 	suite.targetObserver = observers.NewTargetObserver(

--- a/internal/querycoordv2/task/task_test.go
+++ b/internal/querycoordv2/task/task_test.go
@@ -159,7 +159,7 @@ func (suite *TaskSuite) SetupTest() {
 	suite.meta = meta.NewMeta(RandomIncrementIDAllocator(), suite.store, session.NewNodeManager())
 	suite.dist = meta.NewDistributionManager()
 	suite.broker = meta.NewMockBroker(suite.T())
-	suite.target = meta.NewTargetManager(suite.broker, suite.meta)
+	suite.target = meta.NewTargetManager(suite.broker, suite.meta, querycoord.NewCatalog(suite.kv))
 	suite.nodeMgr = session.NewNodeManager()
 	suite.cluster = session.NewMockCluster(suite.T())
 


### PR DESCRIPTION
issue: #38237
query coord will save collection's target during stop progress, which will be used for new querycoord's fast recover. but if milvus cluster has thounsands of collections, which make query coord's stop progress much more slower than expected.

this PR refine the impl to save collection's target to etcd when target update, and clean it when collection released.