### PR TITLE
enhance: Move `SyncCreatedPartition` step to proxy

### DIFF
--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -1324,6 +1324,7 @@ func (node *Proxy) CreatePartition(ctx context.Context, request *milvuspb.Create
 		Condition:              NewTaskCondition(ctx),
 		CreatePartitionRequest: request,
 		rootCoord:              node.rootCoord,
+		queryCoord:             node.queryCoord,
 		result:                 nil,
 	}
 

--- a/internal/rootcoord/create_partition_task.go
+++ b/internal/rootcoord/create_partition_task.go
@@ -114,12 +114,6 @@ func (t *createPartitionTask) Execute(ctx context.Context) error {
 		partitionIDs: []int64{partID},
 	})
 
-	undoTask.AddStep(&syncNewCreatedPartitionStep{
-		baseStep:     baseStep{core: t.core},
-		collectionID: t.collMeta.CollectionID,
-		partitionID:  partID,
-	}, &nullStep{})
-
 	undoTask.AddStep(&changePartitionStateStep{
 		baseStep:     baseStep{core: t.core},
 		collectionID: t.collMeta.CollectionID,

--- a/internal/rootcoord/step.go
+++ b/internal/rootcoord/step.go
@@ -327,25 +327,6 @@ func (s *releasePartitionsStep) Weight() stepPriority {
 	return stepPriorityUrgent
 }
 
-type syncNewCreatedPartitionStep struct {
-	baseStep
-	collectionID UniqueID
-	partitionID  UniqueID
-}
-
-func (s *syncNewCreatedPartitionStep) Execute(ctx context.Context) ([]nestedStep, error) {
-	err := s.core.broker.SyncNewCreatedPartition(ctx, s.collectionID, s.partitionID)
-	return nil, err
-}
-
-func (s *syncNewCreatedPartitionStep) Desc() string {
-	return fmt.Sprintf("sync new partition, collectionID=%d, partitionID=%d", s.partitionID, s.partitionID)
-}
-
-func (s *syncNewCreatedPartitionStep) Weight() stepPriority {
-	return stepPriorityUrgent
-}
-
 type dropIndexStep struct {
 	baseStep
 	collID  UniqueID


### PR DESCRIPTION
Related to #38275

This PR move sync created partition step to proxy to avoid potential logic deadlock when create partition happens with target segment change.