### PR TITLE
fix: [10kcp] Query coord stop progress is too slow

### DIFF
--- a/internal/querycoordv2/balance/channel_level_score_balancer_test.go
+++ b/internal/querycoordv2/balance/channel_level_score_balancer_test.go
@@ -68,7 +68,7 @@ func (suite *ChannelLevelScoreBalancerTestSuite) SetupTest() {
 	idAllocator := RandomIncrementIDAllocator()
 	nodeManager := session.NewNodeManager()
 	testMeta := meta.NewMeta(idAllocator, store, nodeManager)
-	testTarget := meta.NewTargetManager(suite.broker, testMeta)
+	testTarget := meta.NewTargetManager(suite.broker, testMeta, querycoord.NewCatalog(suite.kv))
 
 	distManager := meta.NewDistributionManager()
 	suite.mockScheduler = task.NewMockScheduler(suite.T())

--- a/internal/querycoordv2/balance/rowcount_based_balancer_test.go
+++ b/internal/querycoordv2/balance/rowcount_based_balancer_test.go
@@ -71,7 +71,7 @@ func (suite *RowCountBasedBalancerTestSuite) SetupTest() {
 	idAllocator := RandomIncrementIDAllocator()
 	nodeManager := session.NewNodeManager()
 	testMeta := meta.NewMeta(idAllocator, store, nodeManager)
-	testTarget := meta.NewTargetManager(suite.broker, testMeta)
+	testTarget := meta.NewTargetManager(suite.broker, testMeta, querycoord.NewCatalog(suite.kv))
 
 	distManager := meta.NewDistributionManager()
 	suite.mockScheduler = task.NewMockScheduler(suite.T())

--- a/internal/querycoordv2/balance/score_based_balancer_test.go
+++ b/internal/querycoordv2/balance/score_based_balancer_test.go
@@ -68,7 +68,7 @@ func (suite *ScoreBasedBalancerTestSuite) SetupTest() {
 	idAllocator := RandomIncrementIDAllocator()
 	nodeManager := session.NewNodeManager()
 	testMeta := meta.NewMeta(idAllocator, store, nodeManager)
-	testTarget := meta.NewTargetManager(suite.broker, testMeta)
+	testTarget := meta.NewTargetManager(suite.broker, testMeta, querycoord.NewCatalog(suite.kv))
 
 	distManager := meta.NewDistributionManager()
 	suite.mockScheduler = task.NewMockScheduler(suite.T())

--- a/internal/querycoordv2/checkers/balance_checker_test.go
+++ b/internal/querycoordv2/checkers/balance_checker_test.go
@@ -75,7 +75,7 @@ func (suite *BalanceCheckerTestSuite) SetupTest() {
 	suite.meta = meta.NewMeta(idAllocator, store, suite.nodeMgr)
 	suite.broker = meta.NewMockBroker(suite.T())
 	suite.scheduler = task.NewMockScheduler(suite.T())
-	suite.targetMgr = meta.NewTargetManager(suite.broker, suite.meta)
+	suite.targetMgr = meta.NewTargetManager(suite.broker, suite.meta, querycoord.NewCatalog(suite.kv))
 
 	suite.balancer = balance.NewMockBalancer(suite.T())
 	suite.checker = NewBalanceChecker(suite.meta, suite.targetMgr, suite.nodeMgr, suite.scheduler, func() balance.Balance { return suite.balancer })

--- a/internal/querycoordv2/checkers/channel_checker_test.go
+++ b/internal/querycoordv2/checkers/channel_checker_test.go
@@ -72,7 +72,7 @@ func (suite *ChannelCheckerTestSuite) SetupTest() {
 	suite.nodeMgr = session.NewNodeManager()
 	suite.meta = meta.NewMeta(idAllocator, store, suite.nodeMgr)
 	suite.broker = meta.NewMockBroker(suite.T())
-	targetManager := meta.NewTargetManager(suite.broker, suite.meta)
+	targetManager := meta.NewTargetManager(suite.broker, suite.meta, querycoord.NewCatalog(suite.kv))
 
 	distManager := meta.NewDistributionManager()
 

--- a/internal/querycoordv2/checkers/controller_base_test.go
+++ b/internal/querycoordv2/checkers/controller_base_test.go
@@ -73,7 +73,7 @@ func (suite *ControllerBaseTestSuite) SetupTest() {
 	suite.meta = meta.NewMeta(idAllocator, store, suite.nodeMgr)
 	suite.dist = meta.NewDistributionManager()
 	suite.broker = meta.NewMockBroker(suite.T())
-	suite.targetManager = meta.NewTargetManager(suite.broker, suite.meta)
+	suite.targetManager = meta.NewTargetManager(suite.broker, suite.meta, querycoord.NewCatalog(suite.kv))
 
 	suite.balancer = balance.NewMockBalancer(suite.T())
 	suite.scheduler = task.NewMockScheduler(suite.T())

--- a/internal/querycoordv2/checkers/controller_test.go
+++ b/internal/querycoordv2/checkers/controller_test.go
@@ -77,7 +77,7 @@ func (suite *CheckerControllerSuite) SetupTest() {
 	suite.meta = meta.NewMeta(idAllocator, store, suite.nodeMgr)
 	suite.dist = meta.NewDistributionManager()
 	suite.broker = meta.NewMockBroker(suite.T())
-	suite.targetManager = meta.NewTargetManager(suite.broker, suite.meta)
+	suite.targetManager = meta.NewTargetManager(suite.broker, suite.meta, querycoord.NewCatalog(suite.kv))
 
 	suite.balancer = balance.NewMockBalancer(suite.T())
 	suite.scheduler = task.NewMockScheduler(suite.T())

--- a/internal/querycoordv2/checkers/leader_checker_test.go
+++ b/internal/querycoordv2/checkers/leader_checker_test.go
@@ -74,7 +74,7 @@ func (suite *LeaderCheckerTestSuite) SetupTest() {
 	suite.broker = meta.NewMockBroker(suite.T())
 
 	distManager := meta.NewDistributionManager()
-	targetManager := meta.NewTargetManager(suite.broker, suite.meta)
+	targetManager := meta.NewTargetManager(suite.broker, suite.meta, querycoord.NewCatalog(suite.kv))
 	suite.checker = NewLeaderChecker(suite.meta, distManager, targetManager, suite.nodeMgr)
 }
 

--- a/internal/querycoordv2/checkers/segment_checker_test.go
+++ b/internal/querycoordv2/checkers/segment_checker_test.go
@@ -74,7 +74,7 @@ func (suite *SegmentCheckerTestSuite) SetupTest() {
 	suite.meta = meta.NewMeta(idAllocator, store, suite.nodeMgr)
 	distManager := meta.NewDistributionManager()
 	suite.broker = meta.NewMockBroker(suite.T())
-	targetManager := meta.NewTargetManager(suite.broker, suite.meta)
+	targetManager := meta.NewTargetManager(suite.broker, suite.meta, querycoord.NewCatalog(suite.kv))
 
 	balancer := suite.createMockBalancer()
 	suite.checker = NewSegmentChecker(suite.meta, distManager, targetManager, suite.nodeMgr, func() balance.Balance { return balancer })

--- a/internal/querycoordv2/dist/dist_controller_test.go
+++ b/internal/querycoordv2/dist/dist_controller_test.go
@@ -78,7 +78,7 @@ func (suite *DistControllerTestSuite) SetupTest() {
 	suite.mockCluster = session.NewMockCluster(suite.T())
 	distManager := meta.NewDistributionManager()
 	suite.broker = meta.NewMockBroker(suite.T())
-	targetManager := meta.NewTargetManager(suite.broker, suite.meta)
+	targetManager := meta.NewTargetManager(suite.broker, suite.meta, querycoord.NewCatalog(suite.kv))
 	suite.mockScheduler = task.NewMockScheduler(suite.T())
 	suite.mockScheduler.EXPECT().GetExecutedFlag(mock.Anything).Return(nil).Maybe()
 	syncTargetVersionFn := func(collectionID int64) {}

--- a/internal/querycoordv2/job/job_test.go
+++ b/internal/querycoordv2/job/job_test.go
@@ -163,7 +163,7 @@ func (suite *JobSuite) SetupTest() {
 	suite.dist = meta.NewDistributionManager()
 	suite.nodeMgr = session.NewNodeManager()
 	suite.meta = meta.NewMeta(RandomIncrementIDAllocator(), suite.store, suite.nodeMgr)
-	suite.targetMgr = meta.NewTargetManager(suite.broker, suite.meta)
+	suite.targetMgr = meta.NewTargetManager(suite.broker, suite.meta, querycoord.NewCatalog(suite.kv))
 	suite.targetObserver = observers.NewTargetObserver(suite.meta,
 		suite.targetMgr,
 		suite.dist,

--- a/internal/querycoordv2/meta/collection_manager_test.go
+++ b/internal/querycoordv2/meta/collection_manager_test.go
@@ -375,7 +375,7 @@ func (suite *CollectionManagerSuite) TestRecoverLoadingCollection() {
 			err = mgr.UpdatePartitionLoadPercent(partitionID, 10)
 			suite.NoError(err)
 		}
-		_, err = mgr.UpdateCollectionLoadPercent(ctx, collectionID)
+		_, err = mgr.UpdateCollectionLoadPercent(collectionID)
 		suite.NoError(err)
 	}
 	suite.clearMemory()

--- a/internal/querycoordv2/meta/mock_broker.go
+++ b/internal/querycoordv2/meta/mock_broker.go
@@ -206,10 +206,6 @@ func (_c *MockBroker_GetCollectionLoadInfo_Call) RunAndReturn(run func(context.C
 func (_m *MockBroker) GetDataViewVersions(ctx context.Context, collectionIDs []int64) (map[int64]int64, error) {
 	ret := _m.Called(ctx, collectionIDs)
 
-	if len(ret) == 0 {
-		panic("no return value specified for GetDataViewVersions")
-	}
-
 	var r0 map[int64]int64
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, []int64) (map[int64]int64, error)); ok {
@@ -271,10 +267,6 @@ func (_m *MockBroker) GetIndexInfo(ctx context.Context, collectionID int64, segm
 	_ca = append(_ca, ctx, collectionID)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetIndexInfo")
-	}
 
 	var r0 map[int64][]*querypb.FieldIndexInfo
 	var r1 error

--- a/internal/querycoordv2/meta/mock_target_manager.go
+++ b/internal/querycoordv2/meta/mock_target_manager.go
@@ -3,9 +3,9 @@
 package meta
 
 import (
-	metastore "github.com/milvus-io/milvus/internal/metastore"
-	datapb "github.com/milvus-io/milvus/internal/proto/datapb"
+	context "context"
 
+	datapb "github.com/milvus-io/milvus/internal/proto/datapb"
 	mock "github.com/stretchr/testify/mock"
 
 	typeutil "github.com/milvus-io/milvus/pkg/util/typeutil"
@@ -606,13 +606,17 @@ func (_c *MockTargetManager_IsNextTargetExist_Call) RunAndReturn(run func(int64)
 	return _c
 }
 
-// Recover provides a mock function with given fields: catalog
-func (_m *MockTargetManager) Recover(catalog metastore.QueryCoordCatalog) error {
-	ret := _m.Called(catalog)
+// Recover provides a mock function with given fields: ctx
+func (_m *MockTargetManager) Recover() error {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Recover")
+	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(metastore.QueryCoordCatalog) error); ok {
-		r0 = rf(catalog)
+	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
+		r0 = rf()
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -626,14 +630,14 @@ type MockTargetManager_Recover_Call struct {
 }
 
 // Recover is a helper method to define mock.On call
-//   - catalog metastore.QueryCoordCatalog
-func (_e *MockTargetManager_Expecter) Recover(catalog interface{}) *MockTargetManager_Recover_Call {
-	return &MockTargetManager_Recover_Call{Call: _e.mock.On("Recover", catalog)}
+//   - ctx context.Context
+func (_e *MockTargetManager_Expecter) Recover() *MockTargetManager_Recover_Call {
+	return &MockTargetManager_Recover_Call{Call: _e.mock.On("Recover")}
 }
 
-func (_c *MockTargetManager_Recover_Call) Run(run func(catalog metastore.QueryCoordCatalog)) *MockTargetManager_Recover_Call {
+func (_c *MockTargetManager_Recover_Call) Run(run func()) *MockTargetManager_Recover_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(metastore.QueryCoordCatalog))
+		run()
 	})
 	return _c
 }
@@ -643,7 +647,7 @@ func (_c *MockTargetManager_Recover_Call) Return(_a0 error) *MockTargetManager_R
 	return _c
 }
 
-func (_c *MockTargetManager_Recover_Call) RunAndReturn(run func(metastore.QueryCoordCatalog) error) *MockTargetManager_Recover_Call {
+func (_c *MockTargetManager_Recover_Call) RunAndReturn(run func(context.Context) error) *MockTargetManager_Recover_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -729,42 +733,13 @@ func (_c *MockTargetManager_RemovePartition_Call) RunAndReturn(run func(int64, .
 	return _c
 }
 
-// SaveCurrentTarget provides a mock function with given fields: catalog
-func (_m *MockTargetManager) SaveCurrentTarget(catalog metastore.QueryCoordCatalog) {
-	_m.Called(catalog)
-}
+// UpdateCollectionCurrentTarget provides a mock function with given fields: ctx, collectionID
+func (_m *MockTargetManager) UpdateCollectionCurrentTarget(ctx context.Context, collectionID int64) bool {
+	ret := _m.Called(ctx, collectionID)
 
-// MockTargetManager_SaveCurrentTarget_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SaveCurrentTarget'
-type MockTargetManager_SaveCurrentTarget_Call struct {
-	*mock.Call
-}
-
-// SaveCurrentTarget is a helper method to define mock.On call
-//   - catalog metastore.QueryCoordCatalog
-func (_e *MockTargetManager_Expecter) SaveCurrentTarget(catalog interface{}) *MockTargetManager_SaveCurrentTarget_Call {
-	return &MockTargetManager_SaveCurrentTarget_Call{Call: _e.mock.On("SaveCurrentTarget", catalog)}
-}
-
-func (_c *MockTargetManager_SaveCurrentTarget_Call) Run(run func(catalog metastore.QueryCoordCatalog)) *MockTargetManager_SaveCurrentTarget_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(metastore.QueryCoordCatalog))
-	})
-	return _c
-}
-
-func (_c *MockTargetManager_SaveCurrentTarget_Call) Return() *MockTargetManager_SaveCurrentTarget_Call {
-	_c.Call.Return()
-	return _c
-}
-
-func (_c *MockTargetManager_SaveCurrentTarget_Call) RunAndReturn(run func(metastore.QueryCoordCatalog)) *MockTargetManager_SaveCurrentTarget_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// UpdateCollectionCurrentTarget provides a mock function with given fields: collectionID
-func (_m *MockTargetManager) UpdateCollectionCurrentTarget(collectionID int64) bool {
-	ret := _m.Called(collectionID)
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateCollectionCurrentTarget")
+	}
 
 	var r0 bool
 	if rf, ok := ret.Get(0).(func(int64) bool); ok {

--- a/internal/querycoordv2/meta/mock_target_manager.go
+++ b/internal/querycoordv2/meta/mock_target_manager.go
@@ -3,8 +3,6 @@
 package meta
 
 import (
-	context "context"
-
 	datapb "github.com/milvus-io/milvus/internal/proto/datapb"
 	mock "github.com/stretchr/testify/mock"
 
@@ -606,16 +604,12 @@ func (_c *MockTargetManager_IsNextTargetExist_Call) RunAndReturn(run func(int64)
 	return _c
 }
 
-// Recover provides a mock function with given fields: ctx
+// Recover provides a mock function with given fields:
 func (_m *MockTargetManager) Recover() error {
 	ret := _m.Called()
 
-	if len(ret) == 0 {
-		panic("no return value specified for Recover")
-	}
-
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
+	if rf, ok := ret.Get(0).(func() error); ok {
 		r0 = rf()
 	} else {
 		r0 = ret.Error(0)
@@ -630,7 +624,6 @@ type MockTargetManager_Recover_Call struct {
 }
 
 // Recover is a helper method to define mock.On call
-//   - ctx context.Context
 func (_e *MockTargetManager_Expecter) Recover() *MockTargetManager_Recover_Call {
 	return &MockTargetManager_Recover_Call{Call: _e.mock.On("Recover")}
 }
@@ -647,7 +640,7 @@ func (_c *MockTargetManager_Recover_Call) Return(_a0 error) *MockTargetManager_R
 	return _c
 }
 
-func (_c *MockTargetManager_Recover_Call) RunAndReturn(run func(context.Context) error) *MockTargetManager_Recover_Call {
+func (_c *MockTargetManager_Recover_Call) RunAndReturn(run func() error) *MockTargetManager_Recover_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -733,13 +726,9 @@ func (_c *MockTargetManager_RemovePartition_Call) RunAndReturn(run func(int64, .
 	return _c
 }
 
-// UpdateCollectionCurrentTarget provides a mock function with given fields: ctx, collectionID
-func (_m *MockTargetManager) UpdateCollectionCurrentTarget(ctx context.Context, collectionID int64) bool {
-	ret := _m.Called(ctx, collectionID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for UpdateCollectionCurrentTarget")
-	}
+// UpdateCollectionCurrentTarget provides a mock function with given fields: collectionID
+func (_m *MockTargetManager) UpdateCollectionCurrentTarget(collectionID int64) bool {
+	ret := _m.Called(collectionID)
 
 	var r0 bool
 	if rf, ok := ret.Get(0).(func(int64) bool); ok {

--- a/internal/querycoordv2/meta/target_manager_test.go
+++ b/internal/querycoordv2/meta/target_manager_test.go
@@ -113,7 +113,7 @@ func (suite *TargetManagerSuite) SetupTest() {
 	idAllocator := RandomIncrementIDAllocator()
 	suite.meta = NewMeta(idAllocator, suite.catalog, session.NewNodeManager())
 	suite.broker = NewMockBroker(suite.T())
-	suite.mgr = NewTargetManager(suite.broker, suite.meta)
+	suite.mgr = NewTargetManager(suite.broker, suite.meta, querycoord.NewCatalog(suite.kv))
 
 	for _, collection := range suite.collections {
 		dmChannels := make([]*datapb.VchannelInfo, 0)
@@ -582,13 +582,16 @@ func (suite *TargetManagerSuite) TestRecover() {
 	suite.mgr.UpdateCollectionNextTarget(collectionID)
 	suite.mgr.UpdateCollectionCurrentTarget(collectionID)
 
-	suite.mgr.SaveCurrentTarget(suite.catalog)
+	// target should be save to meta store after update current target
+	targets, err := suite.catalog.GetCollectionTargets(ctx)
+	suite.NoError(err)
+	suite.Len(targets, 1)
 
 	// clear target in memory
 	version := suite.mgr.current.getCollectionTarget(collectionID).GetTargetVersion()
 	suite.mgr.current.removeCollectionTarget(collectionID)
 	// try to recover
-	suite.mgr.Recover(suite.catalog)
+	suite.mgr.Recover(ctx)
 
 	target := suite.mgr.current.getCollectionTarget(collectionID)
 	suite.NotNil(target)
@@ -596,8 +599,9 @@ func (suite *TargetManagerSuite) TestRecover() {
 	suite.Len(target.GetAllSegmentIDs(), 2)
 	suite.Equal(target.GetTargetVersion(), version)
 
-	// after recover, target info should be cleaned up
-	targets, err := suite.catalog.GetCollectionTargets()
+	// target should be removed from meta store after collection released
+	suite.mgr.RemoveCollection(ctx, collectionID)
+	targets, err = suite.catalog.GetCollectionTargets(ctx)
 	suite.NoError(err)
 	suite.Len(targets, 0)
 }

--- a/internal/querycoordv2/meta/target_manager_test.go
+++ b/internal/querycoordv2/meta/target_manager_test.go
@@ -583,7 +583,7 @@ func (suite *TargetManagerSuite) TestRecover() {
 	suite.mgr.UpdateCollectionCurrentTarget(collectionID)
 
 	// target should be save to meta store after update current target
-	targets, err := suite.catalog.GetCollectionTargets(ctx)
+	targets, err := suite.catalog.GetCollectionTargets()
 	suite.NoError(err)
 	suite.Len(targets, 1)
 
@@ -591,7 +591,7 @@ func (suite *TargetManagerSuite) TestRecover() {
 	version := suite.mgr.current.getCollectionTarget(collectionID).GetTargetVersion()
 	suite.mgr.current.removeCollectionTarget(collectionID)
 	// try to recover
-	suite.mgr.Recover(ctx)
+	suite.mgr.Recover()
 
 	target := suite.mgr.current.getCollectionTarget(collectionID)
 	suite.NotNil(target)
@@ -600,8 +600,8 @@ func (suite *TargetManagerSuite) TestRecover() {
 	suite.Equal(target.GetTargetVersion(), version)
 
 	// target should be removed from meta store after collection released
-	suite.mgr.RemoveCollection(ctx, collectionID)
-	targets, err = suite.catalog.GetCollectionTargets(ctx)
+	suite.mgr.RemoveCollection(collectionID)
+	targets, err = suite.catalog.GetCollectionTargets()
 	suite.NoError(err)
 	suite.Len(targets, 0)
 }

--- a/internal/querycoordv2/mocks/mock_querynode.go
+++ b/internal/querycoordv2/mocks/mock_querynode.go
@@ -88,10 +88,6 @@ func (_c *MockQueryNodeServer_Delete_Call) RunAndReturn(run func(context.Context
 func (_m *MockQueryNodeServer) DeleteBatch(_a0 context.Context, _a1 *querypb.DeleteBatchRequest) (*querypb.DeleteBatchResponse, error) {
 	ret := _m.Called(_a0, _a1)
 
-	if len(ret) == 0 {
-		panic("no return value specified for DeleteBatch")
-	}
-
 	var r0 *querypb.DeleteBatchResponse
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, *querypb.DeleteBatchRequest) (*querypb.DeleteBatchResponse, error)); ok {

--- a/internal/querycoordv2/observers/collection_observer_test.go
+++ b/internal/querycoordv2/observers/collection_observer_test.go
@@ -196,7 +196,7 @@ func (suite *CollectionObserverSuite) SetupTest() {
 	suite.nodeMgr = session.NewNodeManager()
 	suite.meta = meta.NewMeta(suite.idAllocator, suite.store, suite.nodeMgr)
 	suite.broker = meta.NewMockBroker(suite.T())
-	suite.targetMgr = meta.NewTargetManager(suite.broker, suite.meta)
+	suite.targetMgr = meta.NewTargetManager(suite.broker, suite.meta, querycoord.NewCatalog(suite.kv))
 	suite.cluster = session.NewMockCluster(suite.T())
 	suite.targetObserver = NewTargetObserver(suite.meta,
 		suite.targetMgr,

--- a/internal/querycoordv2/observers/target_observer_test.go
+++ b/internal/querycoordv2/observers/target_observer_test.go
@@ -91,7 +91,7 @@ func (suite *TargetObserverSuite) SetupTest() {
 	suite.meta = meta.NewMeta(idAllocator, store, nodeMgr)
 
 	suite.broker = meta.NewMockBroker(suite.T())
-	suite.targetMgr = meta.NewTargetManager(suite.broker, suite.meta)
+	suite.targetMgr = meta.NewTargetManager(suite.broker, suite.meta, querycoord.NewCatalog(suite.kv))
 	suite.distMgr = meta.NewDistributionManager()
 	suite.cluster = session.NewMockCluster(suite.T())
 	suite.observer = NewTargetObserver(suite.meta, suite.targetMgr, suite.distMgr, suite.broker, suite.cluster, nodeMgr)
@@ -300,7 +300,7 @@ func (suite *TargetObserverCheckSuite) SetupTest() {
 	suite.meta = meta.NewMeta(idAllocator, store, nodeMgr)
 
 	suite.broker = meta.NewMockBroker(suite.T())
-	suite.targetMgr = meta.NewTargetManager(suite.broker, suite.meta)
+	suite.targetMgr = meta.NewTargetManager(suite.broker, suite.meta, querycoord.NewCatalog(suite.kv))
 	suite.distMgr = meta.NewDistributionManager()
 	suite.cluster = session.NewMockCluster(suite.T())
 	suite.observer = NewTargetObserver(

--- a/internal/querycoordv2/ops_service_test.go
+++ b/internal/querycoordv2/ops_service_test.go
@@ -102,7 +102,7 @@ func (suite *OpsServiceSuite) SetupTest() {
 	suite.nodeMgr = session.NewNodeManager()
 	suite.meta = meta.NewMeta(params.RandomIncrementIDAllocator(), suite.store, suite.nodeMgr)
 	suite.broker = meta.NewMockBroker(suite.T())
-	suite.targetMgr = meta.NewTargetManager(suite.broker, suite.meta)
+	suite.targetMgr = meta.NewTargetManager(suite.broker, suite.meta, querycoord.NewCatalog(suite.kv))
 	suite.targetObserver = observers.NewTargetObserver(
 		suite.meta,
 		suite.targetMgr,

--- a/internal/querycoordv2/server.go
+++ b/internal/querycoordv2/server.go
@@ -410,8 +410,8 @@ func (s *Server) initMeta() error {
 		ChannelDistManager: meta.NewChannelDistManager(),
 		LeaderViewManager:  meta.NewLeaderViewManager(),
 	}
-	s.targetMgr = meta.NewTargetManager(s.broker, s.meta)
-	err = s.targetMgr.Recover(s.store)
+	s.targetMgr = meta.NewTargetManager(s.broker, s.meta, s.store)
+	err = s.targetMgr.Recover()
 	if err != nil {
 		log.Warn("failed to recover collection targets", zap.Error(err))
 	}
@@ -564,12 +564,6 @@ func (s *Server) Stop() error {
 	}
 	if s.targetObserver != nil {
 		s.targetObserver.Stop()
-	}
-
-	// save target to meta store, after querycoord restart, make it fast to recover current target
-	// should save target after target observer stop, incase of target changed
-	if s.targetMgr != nil {
-		s.targetMgr.SaveCurrentTarget(s.store)
 	}
 
 	if s.replicaObserver != nil {

--- a/internal/querycoordv2/server_test.go
+++ b/internal/querycoordv2/server_test.go
@@ -551,7 +551,7 @@ func (suite *ServerSuite) updateCollectionStatus(collectionID int64, status quer
 func (suite *ServerSuite) hackServer() {
 	suite.broker = meta.NewMockBroker(suite.T())
 	suite.server.broker = suite.broker
-	suite.server.targetMgr = meta.NewTargetManager(suite.broker, suite.server.meta)
+	suite.server.targetMgr = meta.NewTargetManager(suite.broker, suite.server.meta, suite.server.store)
 	suite.server.taskScheduler = task.NewScheduler(
 		suite.server.ctx,
 		suite.server.meta,

--- a/internal/querycoordv2/services_test.go
+++ b/internal/querycoordv2/services_test.go
@@ -151,7 +151,9 @@ func (suite *ServiceSuite) SetupTest() {
 	suite.nodeMgr = session.NewNodeManager()
 	suite.meta = meta.NewMeta(params.RandomIncrementIDAllocator(), suite.store, suite.nodeMgr)
 	suite.broker = meta.NewMockBroker(suite.T())
-	suite.targetMgr = meta.NewTargetManager(suite.broker, suite.meta)
+	suite.targetMgr = meta.NewTargetManager(suite.broker, suite.meta, suite.store)
+	suite.cluster = session.NewMockCluster(suite.T())
+	suite.cluster.EXPECT().SyncDistribution(mock.Anything, mock.Anything, mock.Anything).Return(merr.Success(), nil).Maybe()
 	suite.targetObserver = observers.NewTargetObserver(
 		suite.meta,
 		suite.targetMgr,

--- a/internal/querycoordv2/task/task_test.go
+++ b/internal/querycoordv2/task/task_test.go
@@ -155,7 +155,7 @@ func (suite *TaskSuite) SetupTest() {
 	suite.meta = meta.NewMeta(RandomIncrementIDAllocator(), suite.store, session.NewNodeManager())
 	suite.dist = meta.NewDistributionManager()
 	suite.broker = meta.NewMockBroker(suite.T())
-	suite.target = meta.NewTargetManager(suite.broker, suite.meta)
+	suite.target = meta.NewTargetManager(suite.broker, suite.meta, querycoord.NewCatalog(suite.kv))
 	suite.nodeMgr = session.NewNodeManager()
 	suite.cluster = session.NewMockCluster(suite.T())
 


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/38237

query coord will save collection's target during stop progress, which will be used for new querycoord's fast recover. but if milvus cluster has thounsands of collections, which make query coord's stop progress much more slower than expected.

this PR refine the impl to save collection's target to etcd when target update, and clean it when collection released.

pr: https://github.com/milvus-io/milvus/pull/38238