### PR TITLE
fix: [2.4] Fix bug for Search fails with filter expression contains underscore

### DIFF
--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -315,6 +315,11 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplArray() {
                 func(data, size, val, index, res);
                 break;
             }
+            case proto::plan::Match: {
+                UnaryElementFuncForArray<ValueType, proto::plan::Match> func;
+                func(data, valid_data, size, val, index, res, valid_res);
+                break;
+            }
             default:
                 PanicInfo(
                     OpTypeInvalid,

--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -317,7 +317,7 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplArray() {
             }
             case proto::plan::Match: {
                 UnaryElementFuncForArray<ValueType, proto::plan::Match> func;
-                func(data, valid_data, size, val, index, res, valid_res);
+                func(data, size, val, index, res);
                 break;
             }
             default:

--- a/internal/core/src/exec/expression/UnaryExpr.h
+++ b/internal/core/src/exec/expression/UnaryExpr.h
@@ -198,7 +198,7 @@ struct UnaryElementFuncForArray {
                     auto array_data = src[i].template get_data<GetType>(index);
                     res[i] = matcher(array_data);
                 }
-            }else {
+            } else {
                 PanicInfo(OpTypeInvalid,
                           "unsupported op_type:{} for "
                           "UnaryElementFuncForArray",

--- a/internal/core/src/exec/expression/UnaryExpr.h
+++ b/internal/core/src/exec/expression/UnaryExpr.h
@@ -184,7 +184,21 @@ struct UnaryElementFuncForArray {
                 UnaryArrayCompare(array_data <= val);
             } else if constexpr (op == proto::plan::OpType::PrefixMatch) {
                 UnaryArrayCompare(milvus::query::Match(array_data, val, op));
-            } else {
+            } else if constexpr (op == proto::plan::OpType::Match) {
+                if constexpr (std::is_same_v<GetType, proto::plan::Array>) {
+                    res[i] = false;
+                } else {
+                    if (index >= src[i].length()) {
+                        res[i] = false;
+                        continue;
+                    }
+                    PatternMatchTranslator translator;
+                    auto regex_pattern = translator(val);
+                    RegexMatcher matcher(regex_pattern);
+                    auto array_data = src[i].template get_data<GetType>(index);
+                    res[i] = matcher(array_data);
+                }
+            }else {
                 PanicInfo(OpTypeInvalid,
                           "unsupported op_type:{} for "
                           "UnaryElementFuncForArray",


### PR DESCRIPTION
Enhance the matching for elements within the UnaryRangeArray
https://github.com/milvus-io/milvus/issues/38068