### PR TITLE
fix: access log remove new log not the old and skip rotate empty log

### DIFF
--- a/internal/proxy/accesslog/global_test.go
+++ b/internal/proxy/accesslog/global_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
@@ -94,7 +95,7 @@ func TestAccessLogger_DynamicEnable(t *testing.T) {
 	ok := _globalL.Write(accessInfo)
 	assert.False(t, ok)
 
-	etcdCli, _ := etcd.GetEtcdClient(
+	etcdCli, err := etcd.GetEtcdClient(
 		Params.EtcdCfg.UseEmbedEtcd.GetAsBool(),
 		Params.EtcdCfg.EtcdUseSSL.GetAsBool(),
 		Params.EtcdCfg.Endpoints.GetAsStrings(),
@@ -102,6 +103,7 @@ func TestAccessLogger_DynamicEnable(t *testing.T) {
 		Params.EtcdCfg.EtcdTLSKey.GetValue(),
 		Params.EtcdCfg.EtcdTLSCACert.GetValue(),
 		Params.EtcdCfg.EtcdTLSMinVersion.GetValue())
+	require.NoError(t, err)
 
 	// enable access log
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/proxy/accesslog/writer.go
+++ b/internal/proxy/accesslog/writer.go
@@ -247,6 +247,10 @@ func (l *RotateWriter) Rotate() error {
 }
 
 func (l *RotateWriter) rotate() error {
+	if l.size == 0 {
+		return nil
+	}
+
 	if err := l.closeFile(); err != nil {
 		return err
 	}
@@ -330,7 +334,7 @@ func (l *RotateWriter) millRunOnce() error {
 	}
 
 	if l.maxBackups >= 0 && l.maxBackups < len(files) {
-		for _, f := range files[l.maxBackups:] {
+		for _, f := range files[:len(files)-l.maxBackups] {
 			errRemove := os.Remove(path.Join(l.dir(), f.fileName))
 			if err == nil && errRemove != nil {
 				err = errRemove
@@ -436,7 +440,6 @@ func (l *RotateWriter) oldLogFiles() ([]logInfo, error) {
 		}
 		if t, err := timeFromName(f.Name(), prefix, ext); err == nil {
 			logFiles = append(logFiles, logInfo{t, f.Name()})
-			continue
 		}
 	}
 


### PR DESCRIPTION
relate: https://github.com/milvus-io/milvus/issues/38293