### PR TITLE
fix: Use the correct RootPath when decompressing binlog in stats task

### DIFF
--- a/internal/datacoord/import_checker_test.go
+++ b/internal/datacoord/import_checker_test.go
@@ -216,16 +216,22 @@ func (s *ImportCheckerSuite) TestCheckJob() {
 	alloc.EXPECT().AllocID(mock.Anything).Return(rand.Int63(), nil).Maybe()
 	sjm := s.checker.sjm.(*MockStatsJobManager)
 	sjm.EXPECT().SubmitStatsTask(mock.Anything, mock.Anything, mock.Anything, false).Return(nil)
-	sjm.EXPECT().GetStatsTaskState(mock.Anything, mock.Anything).Return(indexpb.JobState_JobStateNone)
+	sjm.EXPECT().GetStatsTask(mock.Anything, mock.Anything).Return(&indexpb.StatsTask{
+		State: indexpb.JobState_JobStateNone,
+	})
 	s.checker.checkStatsJob(job)
 	s.Equal(internalpb.ImportJobState_Stats, s.imeta.GetJob(context.TODO(), job.GetJobID()).GetState())
 	sjm = NewMockStatsJobManager(s.T())
-	sjm.EXPECT().GetStatsTaskState(mock.Anything, mock.Anything).Return(indexpb.JobState_JobStateInProgress)
+	sjm.EXPECT().GetStatsTask(mock.Anything, mock.Anything).Return(&indexpb.StatsTask{
+		State: indexpb.JobState_JobStateInProgress,
+	})
 	s.checker.sjm = sjm
 	s.checker.checkStatsJob(job)
 	s.Equal(internalpb.ImportJobState_Stats, s.imeta.GetJob(context.TODO(), job.GetJobID()).GetState())
 	sjm = NewMockStatsJobManager(s.T())
-	sjm.EXPECT().GetStatsTaskState(mock.Anything, mock.Anything).Return(indexpb.JobState_JobStateFinished)
+	sjm.EXPECT().GetStatsTask(mock.Anything, mock.Anything).Return(&indexpb.StatsTask{
+		State: indexpb.JobState_JobStateFinished,
+	})
 	s.checker.sjm = sjm
 	s.checker.checkStatsJob(job)
 	s.Equal(internalpb.ImportJobState_IndexBuilding, s.imeta.GetJob(context.TODO(), job.GetJobID()).GetState())

--- a/internal/datacoord/import_util.go
+++ b/internal/datacoord/import_util.go
@@ -459,8 +459,8 @@ func getStatsProgress(jobID int64, imeta ImportMeta, sjm StatsJobManager) float3
 	}
 	doneCnt := 0
 	for _, originSegmentID := range originSegmentIDs {
-		state := sjm.GetStatsTaskState(originSegmentID, indexpb.StatsSubJob_Sort)
-		if state == indexpb.JobState_JobStateFinished {
+		t := sjm.GetStatsTask(originSegmentID, indexpb.StatsSubJob_Sort)
+		if t.GetState() == indexpb.JobState_JobStateFinished {
 			doneCnt++
 		}
 	}

--- a/internal/datacoord/job_manager.go
+++ b/internal/datacoord/job_manager.go
@@ -20,7 +20,7 @@ type StatsJobManager interface {
 	Start()
 	Stop()
 	SubmitStatsTask(originSegmentID, targetSegmentID int64, subJobType indexpb.StatsSubJob, canRecycle bool) error
-	GetStatsTaskState(originSegmentID int64, subJobType indexpb.StatsSubJob) indexpb.JobState
+	GetStatsTask(originSegmentID int64, subJobType indexpb.StatsSubJob) *indexpb.StatsTask
 	DropStatsTask(originSegmentID int64, subJobType indexpb.StatsSubJob) error
 }
 
@@ -264,11 +264,12 @@ func (jm *statsJobManager) SubmitStatsTask(originSegmentID, targetSegmentID int6
 	return nil
 }
 
-func (jm *statsJobManager) GetStatsTaskState(originSegmentID int64, subJobType indexpb.StatsSubJob) indexpb.JobState {
-	state := jm.mt.statsTaskMeta.GetStatsTaskStateBySegmentID(originSegmentID, subJobType)
+func (jm *statsJobManager) GetStatsTask(originSegmentID int64, subJobType indexpb.StatsSubJob) *indexpb.StatsTask {
+	task := jm.mt.statsTaskMeta.GetStatsTaskBySegmentID(originSegmentID, subJobType)
 	log.Info("statsJobManager get stats task state", zap.Int64("segmentID", originSegmentID),
-		zap.String("subJobType", subJobType.String()), zap.String("state", state.String()))
-	return state
+		zap.String("subJobType", subJobType.String()), zap.String("state", task.GetState().String()),
+		zap.String("failReason", task.GetFailReason()))
+	return task
 }
 
 func (jm *statsJobManager) DropStatsTask(originSegmentID int64, subJobType indexpb.StatsSubJob) error {

--- a/internal/datacoord/mock_job_manager.go
+++ b/internal/datacoord/mock_job_manager.go
@@ -67,49 +67,51 @@ func (_c *MockStatsJobManager_DropStatsTask_Call) RunAndReturn(run func(int64, i
 	return _c
 }
 
-// GetStatsTaskState provides a mock function with given fields: originSegmentID, subJobType
-func (_m *MockStatsJobManager) GetStatsTaskState(originSegmentID int64, subJobType indexpb.StatsSubJob) indexpb.JobState {
+// GetStatsTask provides a mock function with given fields: originSegmentID, subJobType
+func (_m *MockStatsJobManager) GetStatsTask(originSegmentID int64, subJobType indexpb.StatsSubJob) *indexpb.StatsTask {
 	ret := _m.Called(originSegmentID, subJobType)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetStatsTaskState")
+		panic("no return value specified for GetStatsTask")
 	}
 
-	var r0 indexpb.JobState
-	if rf, ok := ret.Get(0).(func(int64, indexpb.StatsSubJob) indexpb.JobState); ok {
+	var r0 *indexpb.StatsTask
+	if rf, ok := ret.Get(0).(func(int64, indexpb.StatsSubJob) *indexpb.StatsTask); ok {
 		r0 = rf(originSegmentID, subJobType)
 	} else {
-		r0 = ret.Get(0).(indexpb.JobState)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*indexpb.StatsTask)
+		}
 	}
 
 	return r0
 }
 
-// MockStatsJobManager_GetStatsTaskState_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetStatsTaskState'
-type MockStatsJobManager_GetStatsTaskState_Call struct {
+// MockStatsJobManager_GetStatsTask_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetStatsTask'
+type MockStatsJobManager_GetStatsTask_Call struct {
 	*mock.Call
 }
 
-// GetStatsTaskState is a helper method to define mock.On call
+// GetStatsTask is a helper method to define mock.On call
 //   - originSegmentID int64
 //   - subJobType indexpb.StatsSubJob
-func (_e *MockStatsJobManager_Expecter) GetStatsTaskState(originSegmentID interface{}, subJobType interface{}) *MockStatsJobManager_GetStatsTaskState_Call {
-	return &MockStatsJobManager_GetStatsTaskState_Call{Call: _e.mock.On("GetStatsTaskState", originSegmentID, subJobType)}
+func (_e *MockStatsJobManager_Expecter) GetStatsTask(originSegmentID interface{}, subJobType interface{}) *MockStatsJobManager_GetStatsTask_Call {
+	return &MockStatsJobManager_GetStatsTask_Call{Call: _e.mock.On("GetStatsTask", originSegmentID, subJobType)}
 }
 
-func (_c *MockStatsJobManager_GetStatsTaskState_Call) Run(run func(originSegmentID int64, subJobType indexpb.StatsSubJob)) *MockStatsJobManager_GetStatsTaskState_Call {
+func (_c *MockStatsJobManager_GetStatsTask_Call) Run(run func(originSegmentID int64, subJobType indexpb.StatsSubJob)) *MockStatsJobManager_GetStatsTask_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run(args[0].(int64), args[1].(indexpb.StatsSubJob))
 	})
 	return _c
 }
 
-func (_c *MockStatsJobManager_GetStatsTaskState_Call) Return(_a0 indexpb.JobState) *MockStatsJobManager_GetStatsTaskState_Call {
+func (_c *MockStatsJobManager_GetStatsTask_Call) Return(_a0 *indexpb.StatsTask) *MockStatsJobManager_GetStatsTask_Call {
 	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *MockStatsJobManager_GetStatsTaskState_Call) RunAndReturn(run func(int64, indexpb.StatsSubJob) indexpb.JobState) *MockStatsJobManager_GetStatsTaskState_Call {
+func (_c *MockStatsJobManager_GetStatsTask_Call) RunAndReturn(run func(int64, indexpb.StatsSubJob) *indexpb.StatsTask) *MockStatsJobManager_GetStatsTask_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/datacoord/mock_segment_manager.go
+++ b/internal/datacoord/mock_segment_manager.go
@@ -213,17 +213,17 @@ func (_c *MockManager_DropSegmentsOfChannel_Call) RunAndReturn(run func(context.
 	return _c
 }
 
-// ExpireAllocations provides a mock function with given fields: channel, ts
-func (_m *MockManager) ExpireAllocations(channel string, ts uint64) error {
-	ret := _m.Called(channel, ts)
+// ExpireAllocations provides a mock function with given fields: ctx, channel, ts
+func (_m *MockManager) ExpireAllocations(ctx context.Context, channel string, ts uint64) error {
+	ret := _m.Called(ctx, channel, ts)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ExpireAllocations")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, uint64) error); ok {
-		r0 = rf(channel, ts)
+	if rf, ok := ret.Get(0).(func(context.Context, string, uint64) error); ok {
+		r0 = rf(ctx, channel, ts)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -237,15 +237,16 @@ type MockManager_ExpireAllocations_Call struct {
 }
 
 // ExpireAllocations is a helper method to define mock.On call
+//   - ctx context.Context
 //   - channel string
 //   - ts uint64
-func (_e *MockManager_Expecter) ExpireAllocations(channel interface{}, ts interface{}) *MockManager_ExpireAllocations_Call {
-	return &MockManager_ExpireAllocations_Call{Call: _e.mock.On("ExpireAllocations", channel, ts)}
+func (_e *MockManager_Expecter) ExpireAllocations(ctx interface{}, channel interface{}, ts interface{}) *MockManager_ExpireAllocations_Call {
+	return &MockManager_ExpireAllocations_Call{Call: _e.mock.On("ExpireAllocations", ctx, channel, ts)}
 }
 
-func (_c *MockManager_ExpireAllocations_Call) Run(run func(channel string, ts uint64)) *MockManager_ExpireAllocations_Call {
+func (_c *MockManager_ExpireAllocations_Call) Run(run func(ctx context.Context, channel string, ts uint64)) *MockManager_ExpireAllocations_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(uint64))
+		run(args[0].(context.Context), args[1].(string), args[2].(uint64))
 	})
 	return _c
 }
@@ -255,7 +256,7 @@ func (_c *MockManager_ExpireAllocations_Call) Return(_a0 error) *MockManager_Exp
 	return _c
 }
 
-func (_c *MockManager_ExpireAllocations_Call) RunAndReturn(run func(string, uint64) error) *MockManager_ExpireAllocations_Call {
+func (_c *MockManager_ExpireAllocations_Call) RunAndReturn(run func(context.Context, string, uint64) error) *MockManager_ExpireAllocations_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/indexnode/task_stats.go
+++ b/internal/indexnode/task_stats.go
@@ -125,13 +125,13 @@ func (st *statsTask) PreExecute(ctx context.Context) error {
 		zap.Int64("segmentID", st.req.GetSegmentID()),
 	)
 
-	if err := binlog.DecompressBinLog(storage.InsertBinlog, st.req.GetCollectionID(), st.req.GetPartitionID(),
+	if err := binlog.DecompressBinLogWithRootPath(st.req.GetStorageConfig().GetRootPath(), storage.InsertBinlog, st.req.GetCollectionID(), st.req.GetPartitionID(),
 		st.req.GetSegmentID(), st.req.GetInsertLogs()); err != nil {
 		log.Warn("Decompress insert binlog error", zap.Error(err))
 		return err
 	}
 
-	if err := binlog.DecompressBinLog(storage.DeleteBinlog, st.req.GetCollectionID(), st.req.GetPartitionID(),
+	if err := binlog.DecompressBinLogWithRootPath(st.req.GetStorageConfig().GetRootPath(), storage.DeleteBinlog, st.req.GetCollectionID(), st.req.GetPartitionID(),
 		st.req.GetSegmentID(), st.req.GetDeltaLogs()); err != nil {
 		log.Warn("Decompress delta binlog error", zap.Error(err))
 		return err


### PR DESCRIPTION
issue: #38336 