### PR TITLE
fix: Check target partition load state only when dropping partition

### DIFF
--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -1414,6 +1414,10 @@ func isPartitionLoaded(ctx context.Context, qc types.QueryCoordClient, collID in
 		PartitionIDs: partIDs,
 	})
 	if err := merr.CheckRPCCall(resp, err); err != nil {
+		// qc returns error if partition not loaded
+		if errors.Is(err, merr.ErrPartitionNotLoaded) {
+			return false, nil
+		}
 		return false, err
 	}
 

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -49,6 +49,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/util/commonpbutil"
 	"github.com/milvus-io/milvus/pkg/util/contextutil"
 	"github.com/milvus-io/milvus/pkg/util/crypto"
+	"github.com/milvus-io/milvus/pkg/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/util/merr"
 	"github.com/milvus-io/milvus/pkg/util/metric"
 	"github.com/milvus-io/milvus/pkg/util/paramtable"
@@ -1410,23 +1411,13 @@ func isPartitionLoaded(ctx context.Context, qc types.QueryCoordClient, collID in
 	// get all loading collections
 	resp, err := qc.ShowPartitions(ctx, &querypb.ShowPartitionsRequest{
 		CollectionID: collID,
-		PartitionIDs: nil,
+		PartitionIDs: partIDs,
 	})
-	if err != nil {
+	if err := merr.CheckRPCCall(resp, err); err != nil {
 		return false, err
 	}
-	if resp.GetStatus().GetErrorCode() != commonpb.ErrorCode_Success {
-		return false, merr.Error(resp.GetStatus())
-	}
 
-	for _, loadedPartID := range resp.GetPartitionIDs() {
-		for _, partID := range partIDs {
-			if partID == loadedPartID {
-				return true, nil
-			}
-		}
-	}
-	return false, nil
+	return funcutil.SliceSetEqual(partIDs, resp.GetPartitionIDs()), nil
 }
 
 func checkFieldsDataBySchema(schema *schemapb.CollectionSchema, insertMsg *msgstream.InsertMsg, inInsert bool) error {


### PR DESCRIPTION
Related to #38372

This PR make drop partition only check target partition load states only in case of concurrent releasing other partition in same collection.