### PR TITLE
enhance: Remove implicit dependencies between tasks in querycoord

### DIFF
--- a/internal/querycoordv2/checkers/channel_checker.go
+++ b/internal/querycoordv2/checkers/channel_checker.go
@@ -201,12 +201,6 @@ func (c *ChannelChecker) findRepeatedChannels(ctx context.Context, replicaID int
 		}
 
 		if leaderView.UnServiceableError != nil {
-			log.RatedInfo(10, "replica has unavailable shard leader",
-				zap.Int64("collectionID", replica.GetCollectionID()),
-				zap.Int64("replicaID", replicaID),
-				zap.Int64("leaderID", ch.Node),
-				zap.String("channel", ch.GetChannelName()),
-				zap.Error(leaderView.UnServiceableError))
 			continue
 		}
 
@@ -221,6 +215,16 @@ func (c *ChannelChecker) findRepeatedChannels(ctx context.Context, replicaID int
 		} else {
 			ret = append(ret, ch)
 		}
+	}
+
+	for _, ch := range ret {
+		log.Info("find duplicate shard leaders",
+			zap.Int64("collectionID", replica.GetCollectionID()),
+			zap.Int64("replicaID", replicaID),
+			zap.String("channel", ch.GetChannelName()),
+			zap.Int64("leaderID", versionsMap[ch.GetChannelName()].Node),
+			zap.Any("duplicateLeaderID", ch.Node),
+		)
 	}
 	return ret
 }

--- a/internal/querycoordv2/task/executor.go
+++ b/internal/querycoordv2/task/executor.go
@@ -321,6 +321,7 @@ func (ex *Executor) subscribeChannel(task *ChannelTask, step int) error {
 	defer ex.removeTask(task, step)
 	startTs := time.Now()
 	action := task.Actions()[step].(*ChannelAction)
+	defer action.rpcReturned.Store(true)
 	log := log.With(
 		zap.Int64("taskID", task.ID()),
 		zap.Int64("collectionID", task.CollectionID()),
@@ -417,6 +418,7 @@ func (ex *Executor) unsubscribeChannel(task *ChannelTask, step int) error {
 	defer ex.removeTask(task, step)
 	startTs := time.Now()
 	action := task.Actions()[step].(*ChannelAction)
+	defer action.rpcReturned.Store(true)
 	log := log.With(
 		zap.Int64("taskID", task.ID()),
 		zap.Int64("collectionID", task.CollectionID()),

--- a/internal/querycoordv2/task/scheduler.go
+++ b/internal/querycoordv2/task/scheduler.go
@@ -736,36 +736,12 @@ func (scheduler *taskScheduler) isRelated(task Task, node int64) bool {
 // return true if the task should be executed,
 // false otherwise
 func (scheduler *taskScheduler) preProcess(task Task) bool {
-	log := log.Ctx(scheduler.ctx).WithRateGroup("qcv2.taskScheduler", 1, 60).With(
-		zap.Int64("collectionID", task.CollectionID()),
-		zap.Int64("taskID", task.ID()),
-	)
 	if task.Status() != TaskStatusStarted {
 		return false
 	}
 
 	actions, step := task.Actions(), task.Step()
 	for step < len(actions) && actions[step].IsFinished(scheduler.distMgr) {
-		if GetTaskType(task) == TaskTypeMove && actions[step].Type() == ActionTypeGrow {
-			var ready bool
-			switch actions[step].(type) {
-			case *ChannelAction:
-				// if balance channel task has finished grow action, block reduce action until
-				// segment distribution has been sync to new delegator, cause new delegator may
-				// causes a few time to load delta log, if reduce the old delegator in advance,
-				// new delegator can't service search and query, will got no available channel error
-				channelAction := actions[step].(*ChannelAction)
-				leader := scheduler.distMgr.LeaderViewManager.GetLeaderShardView(channelAction.Node(), channelAction.Shard)
-				ready = leader.UnServiceableError == nil
-			default:
-				ready = true
-			}
-
-			if !ready {
-				log.RatedInfo(30, "Blocking reduce action in balance channel task")
-				break
-			}
-		}
 		task.StepUp()
 		step++
 	}


### PR DESCRIPTION
issue: #38430
When the RPC corresponding to a task returns successfully, the data distribution should have reached the expected state. If the expected state is not achieved, it indicates an unexpected issue, such as a node going offline. In such cases, if the task still waits for the data distribution to meet the expectation before completing, it relies on other tasks to correct the distribution, leading to implicit dependencies between tasks.

This PR removes the requirement for tasks to wait for the expected data distribution as a completion condition, thereby eliminating the implicit dependencies between tasks.