### PR TITLE
enhance: [2.4] Remove levelZeroMut totally (#38473)

### DIFF
--- a/internal/querynodev2/delegator/delegator.go
+++ b/internal/querynodev2/delegator/delegator.go
@@ -113,7 +113,6 @@ type shardDelegator struct {
 	segmentManager segments.SegmentManager
 	tsafeManager   tsafe.Manager
 	pkOracle       pkoracle.PkOracle
-	level0Mut      sync.RWMutex
 	// stream delete buffer
 	deleteMut    sync.RWMutex
 	deleteBuffer deletebuffer.DeleteBuffer[*deletebuffer.Item]

--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -494,9 +494,6 @@ func (sd *shardDelegator) LoadSegments(ctx context.Context, req *querypb.LoadSeg
 }
 
 func (sd *shardDelegator) GetLevel0Deletions(partitionID int64, candidate pkoracle.Candidate) ([]storage.PrimaryKey, []storage.Timestamp) {
-	sd.level0Mut.Lock()
-	defer sd.level0Mut.Unlock()
-
 	// TODO: this could be large, host all L0 delete on delegator might be a dangerous, consider mmap it on local segment and stream processing it
 	level0Segments := sd.segmentManager.GetBy(segments.WithLevel(datapb.SegmentLevel_L0), segments.WithChannel(sd.vchannelName))
 	pks := make([]storage.PrimaryKey, 0)
@@ -529,8 +526,6 @@ func (sd *shardDelegator) GetLevel0Deletions(partitionID int64, candidate pkorac
 }
 
 func (sd *shardDelegator) RefreshLevel0DeletionStats() {
-	sd.level0Mut.Lock()
-	defer sd.level0Mut.Unlock()
 	level0Segments := sd.segmentManager.GetBy(segments.WithLevel(datapb.SegmentLevel_L0), segments.WithChannel(sd.vchannelName))
 	totalSize := int64(0)
 	for _, segment := range level0Segments {

--- a/internal/querynodev2/delegator/delta_forward.go
+++ b/internal/querynodev2/delegator/delta_forward.go
@@ -181,9 +181,6 @@ func (sd *shardDelegator) forwardL0RemoteLoad(ctx context.Context,
 }
 
 func (sd *shardDelegator) getLevel0Deltalogs(partitionID int64) []*datapb.FieldBinlog {
-	sd.level0Mut.Lock()
-	defer sd.level0Mut.Unlock()
-
 	level0Segments := sd.segmentManager.GetBy(
 		segments.WithLevel(datapb.SegmentLevel_L0),
 		segments.WithChannel(sd.vchannelName))


### PR DESCRIPTION
Cherry pick from master
pr: #38473
The level zero mutex could be remove since all operations are guarded by segment manager mutex

---------