### PR TITLE
enhance: [10kcp] Trim data distribiton resp index info

### DIFF
--- a/internal/querynodev2/services.go
+++ b/internal/querynodev2/services.go
@@ -1203,7 +1203,11 @@ func (node *QueryNode) GetDataDistribution(ctx context.Context, req *querypb.Get
 			Level:              s.Level(),
 			LastDeltaTimestamp: s.LastDeltaTimestamp(),
 			IndexInfo: lo.SliceToMap(s.Indexes(), func(info *segments.IndexedFieldInfo) (int64, *querypb.FieldIndexInfo) {
-				return info.IndexInfo.FieldID, info.IndexInfo
+				return info.IndexInfo.FieldID, &querypb.FieldIndexInfo{
+					BuildID:     info.IndexInfo.BuildID,
+					IndexID:     info.IndexInfo.IndexID,
+					EnableIndex: info.IndexInfo.EnableIndex,
+				}
 			}),
 		})
 	}


### PR DESCRIPTION
Related to #37630

Data distribution became too large when segment number was huge. This PR trims the index info struct and return needed info only.