### PR TITLE
fix bitmap index large size cause panic error

### DIFF
--- a/internal/core/src/index/BitmapIndex.cpp
+++ b/internal/core/src/index/BitmapIndex.cpp
@@ -198,7 +198,7 @@ BitmapIndex<T>::BuildArrayField(const std::vector<FieldDataPtr>& field_datas) {
 template <typename T>
 size_t
 BitmapIndex<T>::GetIndexDataSize() {
-    auto index_data_size = 0;
+    size_t index_data_size = 0;
     for (auto& pair : data_) {
         index_data_size += pair.second.getSizeInBytes(false) + sizeof(T);
     }
@@ -208,7 +208,7 @@ BitmapIndex<T>::GetIndexDataSize() {
 template <>
 size_t
 BitmapIndex<std::string>::GetIndexDataSize() {
-    auto index_data_size = 0;
+    size_t index_data_size = 0;
     for (auto& pair : data_) {
         index_data_size +=
             pair.second.getSizeInBytes(false) + pair.first.size() + sizeof(size_t);

--- a/internal/core/src/index/BitmapIndex.cpp
+++ b/internal/core/src/index/BitmapIndex.cpp
@@ -200,7 +200,7 @@ size_t
 BitmapIndex<T>::GetIndexDataSize() {
     auto index_data_size = 0;
     for (auto& pair : data_) {
-        index_data_size += pair.second.getSizeInBytes() + sizeof(T);
+        index_data_size += pair.second.getSizeInBytes(false) + sizeof(T);
     }
     return index_data_size;
 }
@@ -211,7 +211,7 @@ BitmapIndex<std::string>::GetIndexDataSize() {
     auto index_data_size = 0;
     for (auto& pair : data_) {
         index_data_size +=
-            pair.second.getSizeInBytes() + pair.first.size() + sizeof(size_t);
+            pair.second.getSizeInBytes(false) + pair.first.size() + sizeof(size_t);
     }
     return index_data_size;
 }
@@ -224,7 +224,7 @@ BitmapIndex<T>::SerializeIndexData(uint8_t* data_ptr) {
         data_ptr += sizeof(T);
 
         pair.second.write(reinterpret_cast<char*>(data_ptr));
-        data_ptr += pair.second.getSizeInBytes();
+        data_ptr += pair.second.getSizeInBytes(false);
     }
 }
 
@@ -256,7 +256,7 @@ BitmapIndex<std::string>::SerializeIndexData(uint8_t* data_ptr) {
         data_ptr += key_size;
 
         pair.second.write(reinterpret_cast<char*>(data_ptr));
-        data_ptr += pair.second.getSizeInBytes();
+        data_ptr += pair.second.getSizeInBytes(false);
     }
 }
 
@@ -355,7 +355,7 @@ BitmapIndex<T>::DeserializeIndexData(const uint8_t* data_ptr,
 
         roaring::Roaring value;
         value = roaring::Roaring::read(reinterpret_cast<const char*>(data_ptr));
-        data_ptr += value.getSizeInBytes();
+        data_ptr += value.getSizeInBytes(false);
 
         if (build_mode_ == BitmapIndexBuildMode::BITSET) {
             bitsets_[key] = ConvertRoaringToBitset(value);
@@ -418,7 +418,7 @@ BitmapIndex<std::string>::DeserializeIndexData(const uint8_t* data_ptr,
 
         roaring::Roaring value;
         value = roaring::Roaring::read(reinterpret_cast<const char*>(data_ptr));
-        data_ptr += value.getSizeInBytes();
+        data_ptr += value.getSizeInBytes(false);
 
         if (build_mode_ == BitmapIndexBuildMode::BITSET) {
             bitsets_[key] = ConvertRoaringToBitset(value);
@@ -494,7 +494,7 @@ BitmapIndex<T>::MMapIndexData(const std::string& file_name,
         bitmaps[key] = {file_offset, frozen_size};
 
         file_offset += aligned_size;
-        data_ptr += value.getSizeInBytes();
+        data_ptr += value.getSizeInBytes(false);
     }
 
     file.Seek(0, SEEK_SET);

--- a/internal/core/src/index/BitmapIndex.cpp
+++ b/internal/core/src/index/BitmapIndex.cpp
@@ -223,7 +223,7 @@ BitmapIndex<T>::SerializeIndexData(uint8_t* data_ptr) {
         memcpy(data_ptr, &pair.first, sizeof(T));
         data_ptr += sizeof(T);
 
-        pair.second.write(reinterpret_cast<char*>(data_ptr));
+        pair.second.write(reinterpret_cast<char*>(data_ptr), false);
         data_ptr += pair.second.getSizeInBytes(false);
     }
 }
@@ -255,7 +255,7 @@ BitmapIndex<std::string>::SerializeIndexData(uint8_t* data_ptr) {
         memcpy(data_ptr, pair.first.data(), key_size);
         data_ptr += key_size;
 
-        pair.second.write(reinterpret_cast<char*>(data_ptr));
+        pair.second.write(reinterpret_cast<char*>(data_ptr), false);
         data_ptr += pair.second.getSizeInBytes(false);
     }
 }

--- a/internal/core/src/index/BitmapIndex.cpp
+++ b/internal/core/src/index/BitmapIndex.cpp
@@ -354,7 +354,7 @@ BitmapIndex<T>::DeserializeIndexData(const uint8_t* data_ptr,
         data_ptr += sizeof(T);
 
         roaring::Roaring value;
-        value = roaring::Roaring::read(reinterpret_cast<const char*>(data_ptr));
+        value = roaring::Roaring::read(reinterpret_cast<const char*>(data_ptr), false);
         data_ptr += value.getSizeInBytes(false);
 
         if (build_mode_ == BitmapIndexBuildMode::BITSET) {
@@ -417,7 +417,7 @@ BitmapIndex<std::string>::DeserializeIndexData(const uint8_t* data_ptr,
         data_ptr += key_size;
 
         roaring::Roaring value;
-        value = roaring::Roaring::read(reinterpret_cast<const char*>(data_ptr));
+        value = roaring::Roaring::read(reinterpret_cast<const char*>(data_ptr), false);
         data_ptr += value.getSizeInBytes(false);
 
         if (build_mode_ == BitmapIndexBuildMode::BITSET) {
@@ -471,7 +471,7 @@ BitmapIndex<T>::MMapIndexData(const std::string& file_name,
         T key = ParseKey(&data_ptr);
 
         roaring::Roaring value;
-        value = roaring::Roaring::read(reinterpret_cast<const char*>(data_ptr));
+        value = roaring::Roaring::read(reinterpret_cast<const char*>(data_ptr), false);
         for (const auto& v : value) {
             valid_bitset_.set(v);
         }


### PR DESCRIPTION
about croaring getSizeInBytes describe

![image](https://github.com/user-attachments/assets/3c6cb657-6cb4-43fe-bc23-a8676fa4a84c)

default sue compact serialize version.
 bitmap index when Cardinality is large  GetIndexDataSize will get  very large size cause alloc failed exception.
in our case ,the bitmap index cardinality is 53583500, GetIndexDataSize will return 18446744071658782694.  when use getSizeInBytes(false) that  GetIndexDataSize will return 1794992794. 
so i suggest use getSizeInBytes(false) !