### PR TITLE
enhance: refine array view to optimize memory usage(#38736)

### DIFF
--- a/internal/core/src/common/Chunk.cpp
+++ b/internal/core/src/common/Chunk.cpp
@@ -51,21 +51,18 @@ ArrayChunk::ConstructViews() {
         int offset = offsets_lens_[2 * i];
         int next_offset = offsets_lens_[2 * (i + 1)];
         int len = offsets_lens_[2 * i + 1];
-
         auto data_ptr = data_ + offset;
-        auto offsets_len = 0;
-        std::vector<uint64_t> element_indices = {};
+        auto offsets_bytes_len = 0;
+        uint32_t* offsets_ptr = nullptr;
         if (IsStringDataType(element_type_)) {
-            offsets_len = len * sizeof(uint64_t);
-            std::vector<uint64_t> tmp(
-                reinterpret_cast<uint64_t*>(data_ptr),
-                reinterpret_cast<uint64_t*>(data_ptr + offsets_len));
-            element_indices = std::move(tmp);
+            offsets_bytes_len = len * sizeof(uint32_t);
+            offsets_ptr = reinterpret_cast<uint32_t*>(data_ptr);
         }
-        views_.emplace_back(data_ptr + offsets_len,
-                            next_offset - offset - offsets_len,
+        views_.emplace_back(data_ptr + offsets_bytes_len,
+                            len,
+                            next_offset - offset - offsets_bytes_len,
                             element_type_,
-                            std::move(element_indices));
+                            offsets_ptr);
     }
 }
 

--- a/internal/core/src/mmap/ChunkVector.h
+++ b/internal/core/src/mmap/ChunkVector.h
@@ -119,9 +119,10 @@ class ThreadSafeChunkVector : public ChunkVectorBase<Type> {
         } else if constexpr (std::is_same_v<Array, Type>) {
             auto& src = chunk[chunk_offset];
             return ArrayView(const_cast<char*>(src.data()),
+                             src.length(),
                              src.byte_size(),
                              src.get_element_type(),
-                             src.get_offsets_in_copy());
+                             src.get_offsets_data());
         } else {
             return chunk[chunk_offset];
         }

--- a/internal/core/src/segcore/SegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/SegmentSealedImpl.cpp
@@ -430,11 +430,11 @@ SegmentSealedImpl::LoadFieldData(FieldId field_id, FieldDataInfo& data) {
                                 var_column->Append(*array);
                             }
 
-                            // we stores the offset for each array element, so there is a additional uint64_t for each array element
+                            // we stores the offset for each array element, so there is a additional uint32_t for each array element
                             field_data_size =
-                                array->byte_size() + sizeof(uint64_t);
+                                array->byte_size() + sizeof(uint32_t);
                             stats_.mem_size +=
-                                array->byte_size() + sizeof(uint64_t);
+                                array->byte_size() + sizeof(uint32_t);
                         }
                     }
                     var_column->Seal();
@@ -544,7 +544,7 @@ SegmentSealedImpl::MapFieldData(const FieldId field_id, FieldDataInfo& data) {
     FieldDataPtr field_data;
     uint64_t total_written = 0;
     std::vector<uint64_t> indices{};
-    std::vector<std::vector<uint64_t>> element_indices{};
+    std::vector<std::vector<uint32_t>> element_indices{};
     FixedVector<bool> valid_data{};
     while (data.channel->pop(field_data)) {
         WriteFieldData(file,

--- a/internal/core/src/storage/MmapChunkManager.cpp
+++ b/internal/core/src/storage/MmapChunkManager.cpp
@@ -169,8 +169,10 @@ MmapBlocksHandler::AllocateLargeBlock(const uint64_t size) {
     if (size + Size() > max_disk_limit_) {
         PanicInfo(ErrorCode::MemAllocateSizeNotMatch,
                   "Failed to create a new mmap_block, not enough disk for "
-                  "create a new mmap block. Allocated size: {}, Max size: {} "
+                  "create a new mmap block. To Allocate:{} Allocated size: {}, "
+                  "Max size: {} "
                   "under mmap file_prefix: {}",
+                  size,
                   Size(),
                   max_disk_limit_,
                   mmap_file_prefix_);

--- a/internal/core/unittest/test_array.cpp
+++ b/internal/core/unittest/test_array.cpp
@@ -18,6 +18,7 @@ TEST(Array, TestConstructArray) {
     using namespace milvus;
 
     int N = 10;
+    // 1. test int
     milvus::proto::schema::ScalarField field_int_data;
     milvus::proto::plan::Array field_int_array;
     field_int_array.set_same_type(true);
@@ -33,28 +34,33 @@ TEST(Array, TestConstructArray) {
     }
     ASSERT_TRUE(int_array.is_same_array(field_int_array));
     auto int_array_tmp = Array(const_cast<char*>(int_array.data()),
+                               int_array.length(),
                                int_array.byte_size(),
                                int_array.get_element_type(),
-                               {});
+                               int_array.get_offsets_data());
     auto int_8_array = Array(const_cast<char*>(int_array.data()),
+                             int_array.length(),
                              int_array.byte_size(),
                              DataType::INT8,
-                             {});
+                             int_array.get_offsets_data());
     ASSERT_EQ(int_array.length(), int_8_array.length());
     auto int_16_array = Array(const_cast<char*>(int_array.data()),
+                              int_array.length(),
                               int_array.byte_size(),
                               DataType::INT16,
-                              {});
+                              int_array.get_offsets_data());
     ASSERT_EQ(int_array.length(), int_16_array.length());
     ASSERT_TRUE(int_array_tmp == int_array);
     auto int_array_view = ArrayView(const_cast<char*>(int_array.data()),
+                                    int_array.length(),
                                     int_array.byte_size(),
                                     int_array.get_element_type(),
-                                    {});
+                                    int_array.get_offsets_data());
     ASSERT_EQ(int_array.length(), int_array_view.length());
     ASSERT_EQ(int_array.byte_size(), int_array_view.byte_size());
     ASSERT_EQ(int_array.get_element_type(), int_array_view.get_element_type());
 
+    // 2. test long
     milvus::proto::schema::ScalarField field_long_data;
     milvus::proto::plan::Array field_long_array;
     field_long_array.set_same_type(true);
@@ -70,19 +76,22 @@ TEST(Array, TestConstructArray) {
     }
     ASSERT_TRUE(long_array.is_same_array(field_int_array));
     auto long_array_tmp = Array(const_cast<char*>(long_array.data()),
+                                long_array.length(),
                                 long_array.byte_size(),
                                 long_array.get_element_type(),
-                                {});
+                                long_array.get_offsets_data());
     ASSERT_TRUE(long_array_tmp == long_array);
     auto long_array_view = ArrayView(const_cast<char*>(long_array.data()),
+                                     long_array.length(),
                                      long_array.byte_size(),
                                      long_array.get_element_type(),
-                                     {});
+                                     long_array.get_offsets_data());
     ASSERT_EQ(long_array.length(), long_array_view.length());
     ASSERT_EQ(long_array.byte_size(), long_array_view.byte_size());
     ASSERT_EQ(long_array.get_element_type(),
               long_array_view.get_element_type());
 
+    // 3. test string
     milvus::proto::schema::ScalarField field_string_data;
     milvus::proto::plan::Array field_string_array;
     field_string_array.set_same_type(true);
@@ -94,32 +103,28 @@ TEST(Array, TestConstructArray) {
     }
     auto string_array = Array(field_string_data);
     ASSERT_EQ(N, string_array.length());
-    //    ASSERT_EQ(N, string_array.size());
     for (int i = 0; i < N; ++i) {
         ASSERT_EQ(string_array.get_data<std::string_view>(i),
                   std::to_string(i));
     }
     ASSERT_TRUE(string_array.is_same_array(field_string_array));
-    std::vector<uint64_t> string_element_offsets;
-    std::vector<uint64_t> string_view_element_offsets;
-    for (auto& offset : string_array.get_offsets()) {
-        string_element_offsets.emplace_back(offset);
-        string_view_element_offsets.emplace_back(offset);
-    }
     auto string_array_tmp = Array(const_cast<char*>(string_array.data()),
+                                  string_array.length(),
                                   string_array.byte_size(),
                                   string_array.get_element_type(),
-                                  std::move(string_element_offsets));
+                                  string_array.get_offsets_data());
     ASSERT_TRUE(string_array_tmp == string_array);
     auto string_array_view = ArrayView(const_cast<char*>(string_array.data()),
+                                       string_array.length(),
                                        string_array.byte_size(),
                                        string_array.get_element_type(),
-                                       std::move(string_view_element_offsets));
+                                       string_array.get_offsets_data());
     ASSERT_EQ(string_array.length(), string_array_view.length());
     ASSERT_EQ(string_array.byte_size(), string_array_view.byte_size());
     ASSERT_EQ(string_array.get_element_type(),
               string_array_view.get_element_type());
 
+    // 4. test bool
     milvus::proto::schema::ScalarField field_bool_data;
     milvus::proto::plan::Array field_bool_array;
     field_bool_array.set_same_type(true);
@@ -135,19 +140,22 @@ TEST(Array, TestConstructArray) {
     }
     ASSERT_TRUE(bool_array.is_same_array(field_bool_array));
     auto bool_array_tmp = Array(const_cast<char*>(bool_array.data()),
+                                bool_array.length(),
                                 bool_array.byte_size(),
                                 bool_array.get_element_type(),
-                                {});
+                                bool_array.get_offsets_data());
     ASSERT_TRUE(bool_array_tmp == bool_array);
     auto bool_array_view = ArrayView(const_cast<char*>(bool_array.data()),
+                                     bool_array.length(),
                                      bool_array.byte_size(),
                                      bool_array.get_element_type(),
-                                     {});
+                                     bool_array.get_offsets_data());
     ASSERT_EQ(bool_array.length(), bool_array_view.length());
     ASSERT_EQ(bool_array.byte_size(), bool_array_view.byte_size());
     ASSERT_EQ(bool_array.get_element_type(),
               bool_array_view.get_element_type());
 
+    //5. test float
     milvus::proto::schema::ScalarField field_float_data;
     milvus::proto::plan::Array field_float_array;
     field_float_array.set_same_type(true);
@@ -163,19 +171,22 @@ TEST(Array, TestConstructArray) {
     }
     ASSERT_TRUE(float_array.is_same_array(field_float_array));
     auto float_array_tmp = Array(const_cast<char*>(float_array.data()),
+                                 float_array.length(),
                                  float_array.byte_size(),
                                  float_array.get_element_type(),
-                                 {});
+                                 float_array.get_offsets_data());
     ASSERT_TRUE(float_array_tmp == float_array);
     auto float_array_view = ArrayView(const_cast<char*>(float_array.data()),
+                                      float_array.length(),
                                       float_array.byte_size(),
                                       float_array.get_element_type(),
-                                      {});
+                                      float_array.get_offsets_data());
     ASSERT_EQ(float_array.length(), float_array_view.length());
     ASSERT_EQ(float_array.byte_size(), float_array_view.byte_size());
     ASSERT_EQ(float_array.get_element_type(),
               float_array_view.get_element_type());
 
+    //6. test double
     milvus::proto::schema::ScalarField field_double_data;
     milvus::proto::plan::Array field_double_array;
     field_double_array.set_same_type(true);
@@ -192,14 +203,16 @@ TEST(Array, TestConstructArray) {
     }
     ASSERT_TRUE(double_array.is_same_array(field_double_array));
     auto double_array_tmp = Array(const_cast<char*>(double_array.data()),
+                                  double_array.length(),
                                   double_array.byte_size(),
                                   double_array.get_element_type(),
-                                  {});
+                                  double_array.get_offsets_data());
     ASSERT_TRUE(double_array_tmp == double_array);
     auto double_array_view = ArrayView(const_cast<char*>(double_array.data()),
+                                       double_array.length(),
                                        double_array.byte_size(),
                                        double_array.get_element_type(),
-                                       {});
+                                       double_array.get_offsets_data());
     ASSERT_EQ(double_array.length(), double_array_view.length());
     ASSERT_EQ(double_array.byte_size(), double_array_view.byte_size());
     ASSERT_EQ(double_array.get_element_type(),


### PR DESCRIPTION
related: #38736

700m data, array_length=10
non-mmap_offsets_uint64: 2.0G
mmap_offsets_uint64: 1.1G
mmap_offsets_uint32: 880MB