### PR TITLE
fix: [10kcp] Fix incorrect memory estimation for small segments

### DIFF
--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -1652,7 +1652,7 @@ func getResourceUsageEstimateOfSegment(schema *schemapb.CollectionSchema, loadIn
 		binlogSize := uint64(getBinlogDataMemorySize(fieldBinlog))
 		shouldCalculateDataSize := false
 
-		if fieldIndexInfo, ok := fieldID2IndexInfo[fieldID]; ok {
+		if fieldIndexInfo, ok := fieldID2IndexInfo[fieldID]; ok && len(fieldIndexInfo.GetIndexFilePaths()) > 0 {
 			var estimateResult ResourceEstimate
 			err := GetCLoadInfoWithFunc(ctx, fieldSchema, loadInfo, fieldIndexInfo, func(c *LoadIndexInfo) error {
 				loadResourceRequest := C.EstimateLoadIndexResource(c.cLoadIndexInfo)


### PR DESCRIPTION
Skip estimation index memory logic for segments without index file.

issue: https://github.com/milvus-io/milvus/issues/37630

pr: https://github.com/milvus-io/milvus/pull/38813