### PR TITLE
fix: bitmap index large size cause panic error

### DIFF
--- a/internal/core/src/index/BitmapIndex.cpp
+++ b/internal/core/src/index/BitmapIndex.cpp
@@ -198,7 +198,7 @@ BitmapIndex<T>::BuildArrayField(const std::vector<FieldDataPtr>& field_datas) {
 template <typename T>
 size_t
 BitmapIndex<T>::GetIndexDataSize() {
-    auto index_data_size = 0;
+    size_t index_data_size = 0;
     for (auto& pair : data_) {
         index_data_size += pair.second.getSizeInBytes() + sizeof(T);
     }
@@ -208,7 +208,7 @@ BitmapIndex<T>::GetIndexDataSize() {
 template <>
 size_t
 BitmapIndex<std::string>::GetIndexDataSize() {
-    auto index_data_size = 0;
+    size_t index_data_size = 0;
     for (auto& pair : data_) {
         index_data_size +=
             pair.second.getSizeInBytes() + pair.first.size() + sizeof(size_t);


### PR DESCRIPTION
```
template <>
size_t
BitmapIndex<std::string>::GetIndexDataSize() {
    auto index_data_size = 0;
    for (auto& pair : data_) {
        index_data_size +=
            pair.second.getSizeInBytes(false) + pair.first.size() + sizeof(size_t);
    }
    return index_data_size;
}
```
like this code , index_data_size type will atomic infer as int type that not as excepted  size_t, when size is large, it will overflow, so i change it to size_t.

in my case Cardinality is about 90000000, the index_data_size will outrange of int max 2,147,483,647, casue return size is very verry big like 18446744073709551615, next alloc memory will throw exception.