### PR TITLE
fix: [2.5] Only generate the index_null_offset file when the field support null value

### DIFF
--- a/internal/core/src/index/InvertedIndexTantivy.cpp
+++ b/internal/core/src/index/InvertedIndexTantivy.cpp
@@ -124,8 +124,10 @@ InvertedIndexTantivy<T>::Serialize(const Config& config) {
         new uint8_t[index_valid_data_length]);
     memcpy(index_valid_data.get(), null_offset.data(), index_valid_data_length);
     BinarySet res_set;
-    res_set.Append(
-        "index_null_offset", index_valid_data, index_valid_data_length);
+    if (index_valid_data_length > 0) {
+        res_set.Append(
+            "index_null_offset", index_valid_data, index_valid_data_length);
+    }
     milvus::Disassemble(res_set);
     return res_set;
 }


### PR DESCRIPTION
issue: #38832 

master pr: #38833 