### PR TITLE
enhance: [2.5] Add buffered writer to reduce fwrite syscall (#38570)

### DIFF
--- a/internal/core/src/common/File.h
+++ b/internal/core/src/common/File.h
@@ -21,6 +21,13 @@
 #include <unistd.h>
 
 namespace milvus {
+
+#define THROW_FILE_WRITE_ERROR                                           \
+    PanicInfo(ErrorCode::FileWriteFailed,                                \
+              fmt::format("write data to file {} failed, error code {}", \
+                          file_.Path(),                                  \
+                          strerror(errno)));
+
 class File {
  public:
     File(const File& file) = delete;
@@ -36,12 +43,26 @@ class File {
 
     static File
     Open(const std::string_view filepath, int flags) {
+        // using default buf size = 4096
+        return Open(filepath, flags, 4096);
+    }
+
+    static File
+    Open(const std::string_view filepath, int flags, size_t buf_size) {
         int fd = open(filepath.data(), flags, S_IRUSR | S_IWUSR);
         AssertInfo(fd != -1,
                    "failed to create mmap file {}: {}",
                    filepath,
                    strerror(errno));
-        return File(fd, std::string(filepath));
+        FILE* fs = fdopen(fd, "wb+");
+        AssertInfo(fs != nullptr,
+                   "failed to open file {}: {}",
+                   filepath,
+                   strerror(errno));
+        auto f = File(fd, fs, std::string(filepath));
+        // setup buffer size file stream will use
+        setvbuf(f.fs_, nullptr, _IOFBF, buf_size);
+        return f;
     }
 
     int
@@ -94,16 +115,71 @@ class File {
     }
 
  private:
-    explicit File(int fd, const std::string& filepath)
-        : fd_(fd), filepath_(filepath) {
-        fs_ = fdopen(fd_, "wb+");
-        AssertInfo(fs_ != nullptr,
-                   "failed to open file {}: {}",
-                   filepath,
-                   strerror(errno));
+    explicit File(int fd, FILE* fs, const std::string& filepath)
+        : fd_(fd), filepath_(filepath), fs_(fs) {
     }
     int fd_{-1};
     FILE* fs_;
     std::string filepath_;
+};
+
+class BufferedWriter {
+ public:
+    // Constructor: Initialize with the file pointer and the buffer size (default 4KB).
+    explicit BufferedWriter(File& file, size_t buffer_size = 4096)
+        : file_(file),
+          buffer_size_(buffer_size),
+          buffer_(new char[buffer_size]) {
+    }
+
+    ~BufferedWriter() {
+        // Ensure the buffer is flushed when the object is destroyed
+        flush();
+        delete[] buffer_;
+    }
+
+    // Write method to handle data larger than the buffer
+    void
+    Write(const void* data, size_t size) {
+        if (size > buffer_size_) {
+            flush();
+            ssize_t written_data_size = file_.FWrite(data, size);
+            if (written_data_size != size) {
+                THROW_FILE_WRITE_ERROR
+            }
+            return;
+        }
+
+        if (buffer_pos_ + size > buffer_size_) {
+            flush();
+        }
+
+        std::memcpy(buffer_ + buffer_pos_, data, size);
+        buffer_pos_ += size;
+    }
+
+    template <typename T, std::enable_if_t<std::is_integral_v<T>, int> = 0>
+    void
+    WriteInt(T value) {
+        Write(&value, sizeof(value));
+    }
+
+    // Flush method: Write the contents of the buffer to the file
+    void
+    flush() {
+        if (buffer_pos_ > 0) {
+            ssize_t written_data_size = file_.FWrite(buffer_, buffer_pos_);
+            if (written_data_size != buffer_pos_) {
+                THROW_FILE_WRITE_ERROR
+            }
+            buffer_pos_ = 0;
+        }
+    }
+
+ private:
+    File& file_;            // File pointer
+    size_t buffer_size_;    // Size of the internal buffer
+    char* buffer_;          // The buffer itself
+    size_t buffer_pos_{0};  // Current position in the buffer
 };
 }  // namespace milvus


### PR DESCRIPTION
Cherry-pick from master
pr: #38570
Related to previous PR #38157

If mmapped row is too small, frequent fwrite call still cost too much cpu time for context switching. This PR add buffered write to avoid this bad case with extra buffer per variable field.

---------