### PR TITLE
fix: expression with capital AND and OR are not recognized

### DIFF
--- a/internal/parser/planparserv2/Plan.g4
+++ b/internal/parser/planparserv2/Plan.g4
@@ -71,11 +71,11 @@ BAND: '&';
 BOR: '|';
 BXOR: '^';
 
-AND: '&&' | 'and';
-OR: '||' | 'or';
+AND: '&&' | 'and' | 'AND';
+OR: '||' | 'or'  | 'OR';
 
 BNOT: '~';
-NOT: '!' | 'not';
+NOT: '!' | 'not' | 'NOT';
 
 IN: 'in' | 'IN';
 EmptyArray: '[' (Whitespace | Newline)* ']';


### PR DESCRIPTION
fix #38864
AND, OR and NOT is not recognized in milvus parser