### PR TITLE
fix: [2.5] Fix standby mixcoord start failed

### DIFF
--- a/internal/querycoordv2/server.go
+++ b/internal/querycoordv2/server.go
@@ -275,6 +275,7 @@ func (s *Server) Init() error {
 		return nil
 	}
 
+	s.UpdateStateCode(commonpb.StateCode_Initializing)
 	return s.initQueryCoord()
 }
 
@@ -296,7 +297,6 @@ func (s *Server) initQueryCoord() error {
 	}
 	log.Info("QueryCoord report DataCoord ready")
 
-	s.UpdateStateCode(commonpb.StateCode_Initializing)
 	log.Info("start init querycoord", zap.Any("State", commonpb.StateCode_Initializing))
 	// Init KV and ID allocator
 	metaType := Params.MetaStoreCfg.MetaStoreType.GetValue()
@@ -668,6 +668,7 @@ func (s *Server) Stop() error {
 // UpdateStateCode updates the status of the coord, including healthy, unhealthy
 func (s *Server) UpdateStateCode(code commonpb.StateCode) {
 	s.status.Store(int32(code))
+	log.Info("update querycoord state", zap.String("state", code.String()))
 }
 
 func (s *Server) State() commonpb.StateCode {

--- a/internal/rootcoord/root_coord.go
+++ b/internal/rootcoord/root_coord.go
@@ -442,7 +442,6 @@ func (c *Core) initInternal() error {
 	defer initSpan.End()
 	log := log.Ctx(initCtx)
 
-	c.UpdateStateCode(commonpb.StateCode_Initializing)
 	c.initKVCreator()
 
 	if err := c.initIDAllocator(initCtx); err != nil {
@@ -550,6 +549,7 @@ func (c *Core) Init() error {
 		log.Info("RootCoord enter standby mode successfully")
 	} else {
 		c.initOnce.Do(func() {
+			c.UpdateStateCode(commonpb.StateCode_Initializing)
 			initError = c.initInternal()
 		})
 	}


### PR DESCRIPTION
When standby transitions to active, the component state changes to Initialize. If the initialization takes too long (exceeding the liveness probe's maximum retries), the standby pod is stopped and fails to start.
This PR removes the Initialize state during standby transitions in rolling upgrades. The state now switches directly from standby to healthy, preventing health check failures.

issue: https://github.com/milvus-io/milvus/issues/37630

pr: https://github.com/milvus-io/milvus/pull/38308