### PR TITLE
fix: Check query_timestamp in case of concurrent delete

### DIFF
--- a/internal/core/src/segcore/DeletedRecord.h
+++ b/internal/core/src/segcore/DeletedRecord.h
@@ -205,7 +205,12 @@ class DeletedRecord {
             }
             it++;
         }
-        // no need to continue if it.first == query_timestamp, since only timestamps before mvcc_ts are needed
+        while (it != accessor.end() && it->first == query_timestamp) {
+            if (it->second < insert_barrier) {
+                bitset.set(it->second);
+            }
+            it++;
+        }
     }
 
     size_t

--- a/internal/core/src/segcore/DeletedRecord.h
+++ b/internal/core/src/segcore/DeletedRecord.h
@@ -190,7 +190,7 @@ class DeletedRecord {
         }
 
         auto start_iter = hit_snapshot ? next_iter : accessor.begin();
-        
+
         // accessor.lower_bound(std::make_pair(query_timestamp, 0)) is not reliable here:
         // concurrent delete may append new value while end_iter is the end causing mvcc broken
         auto it = start_iter;

--- a/internal/core/unittest/test_delete_record.cpp
+++ b/internal/core/unittest/test_delete_record.cpp
@@ -65,12 +65,14 @@ TEST(DeleteMVCC, common_case) {
         for (int i = 0; i < c; i++) {
             ASSERT_EQ(bitsets_view[i], expected[i]);
         }
+        BitsetType bitsets2(c);
+        BitsetTypeView bitsets_view2(bitsets);
         // query at ts (10)
         query_timestamp = 10;
-        delete_record.Query(bitsets_view, insert_barrier, query_timestamp);
+        delete_record.Query(bitsets_view2, insert_barrier, query_timestamp);
         expected = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
         for (int i = 0; i < c; i++) {
-            ASSERT_EQ(bitsets_view[i], expected[i]);
+            ASSERT_EQ(bitsets_view2[i], expected[i]);
         }
     }
     {

--- a/internal/core/unittest/test_delete_record.cpp
+++ b/internal/core/unittest/test_delete_record.cpp
@@ -92,8 +92,8 @@ TEST(DeleteMVCC, common_case) {
         BitsetType bitsets(c);
         BitsetTypeView bitsets_view(bitsets);
         auto insert_barrier = c;
-        // query at ts (12)
-        Timestamp query_timestamp = 12;
+        // query at ts (13)
+        Timestamp query_timestamp = 13;
         delete_record.Query(bitsets_view, insert_barrier, query_timestamp);
         std::vector<bool> expected = {0, 1, 0, 0, 0, 1, 0, 0, 0, 0};
         for (int i = 0; i < c; i++) {

--- a/internal/core/unittest/test_delete_record.cpp
+++ b/internal/core/unittest/test_delete_record.cpp
@@ -59,10 +59,9 @@ TEST(DeleteMVCC, common_case) {
         BitsetTypeView bitsets_view(bitsets);
         auto insert_barrier = c;
         // query at ts (10)
-        // same as delete ts, shall not set bitset
         Timestamp query_timestamp = 10;
         delete_record.Query(bitsets_view, insert_barrier, query_timestamp);
-        std::vector<bool> expected = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+        std::vector<bool> expected = {0, 1, 0, 0, 0, 0, 0, 0, 0, 0};
         for (int i = 0; i < c; i++) {
             ASSERT_EQ(bitsets_view[i], expected[i]);
         }
@@ -92,8 +91,8 @@ TEST(DeleteMVCC, common_case) {
         BitsetType bitsets(c);
         BitsetTypeView bitsets_view(bitsets);
         auto insert_barrier = c;
-        // query at ts (13)
-        Timestamp query_timestamp = 13;
+        // query at ts (12)
+        Timestamp query_timestamp = 12;
         delete_record.Query(bitsets_view, insert_barrier, query_timestamp);
         std::vector<bool> expected = {0, 1, 0, 0, 0, 1, 0, 0, 0, 0};
         for (int i = 0; i < c; i++) {

--- a/internal/core/unittest/test_delete_record.cpp
+++ b/internal/core/unittest/test_delete_record.cpp
@@ -58,8 +58,8 @@ TEST(DeleteMVCC, common_case) {
         BitsetType bitsets(c);
         BitsetTypeView bitsets_view(bitsets);
         auto insert_barrier = c;
-        // query at ts (9)
-        Timestamp query_timestamp = 9;
+        // query at ts (11)
+        Timestamp query_timestamp = 11;
         delete_record.Query(bitsets_view, insert_barrier, query_timestamp);
         std::vector<bool> expected = {0, 1, 0, 0, 0, 0, 0, 0, 0, 0};
         for (int i = 0; i < c; i++) {

--- a/internal/core/unittest/test_delete_record.cpp
+++ b/internal/core/unittest/test_delete_record.cpp
@@ -58,10 +58,17 @@ TEST(DeleteMVCC, common_case) {
         BitsetType bitsets(c);
         BitsetTypeView bitsets_view(bitsets);
         auto insert_barrier = c;
-        // query at ts (10)
-        Timestamp query_timestamp = 10;
+        // query at ts (9)
+        Timestamp query_timestamp = 9;
         delete_record.Query(bitsets_view, insert_barrier, query_timestamp);
         std::vector<bool> expected = {0, 1, 0, 0, 0, 0, 0, 0, 0, 0};
+        for (int i = 0; i < c; i++) {
+            ASSERT_EQ(bitsets_view[i], expected[i]);
+        }
+        // query at ts (10)
+        query_timestamp = 10;
+        delete_record.Query(bitsets_view, insert_barrier, query_timestamp);
+        expected = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
         for (int i = 0; i < c; i++) {
             ASSERT_EQ(bitsets_view[i], expected[i]);
         }

--- a/internal/core/unittest/test_delete_record.cpp
+++ b/internal/core/unittest/test_delete_record.cpp
@@ -58,21 +58,13 @@ TEST(DeleteMVCC, common_case) {
         BitsetType bitsets(c);
         BitsetTypeView bitsets_view(bitsets);
         auto insert_barrier = c;
-        // query at ts (11)
-        Timestamp query_timestamp = 11;
+        // query at ts (10)
+        // same as delete ts, shall not set bitset
+        Timestamp query_timestamp = 10;
         delete_record.Query(bitsets_view, insert_barrier, query_timestamp);
-        std::vector<bool> expected = {0, 1, 0, 0, 0, 0, 0, 0, 0, 0};
+        std::vector<bool> expected = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
         for (int i = 0; i < c; i++) {
             ASSERT_EQ(bitsets_view[i], expected[i]);
-        }
-        BitsetType bitsets2(c);
-        BitsetTypeView bitsets_view2(bitsets);
-        // query at ts (10)
-        query_timestamp = 10;
-        delete_record.Query(bitsets_view2, insert_barrier, query_timestamp);
-        expected = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-        for (int i = 0; i < c; i++) {
-            ASSERT_EQ(bitsets_view2[i], expected[i]);
         }
     }
     {


### PR DESCRIPTION
Related to #38961