### PR TITLE
enhance: Use mvcc timestamp as guarantee ts if set

### DIFF
--- a/internal/proxy/task_query.go
+++ b/internal/proxy/task_query.go
@@ -570,6 +570,7 @@ func (t *queryTask) queryShard(ctx context.Context, nodeID int64, qn types.Query
 	retrieveReq.GetBase().TargetID = nodeID
 	if needOverrideMvcc && mvccTs > 0 {
 		retrieveReq.MvccTimestamp = mvccTs
+		retrieveReq.GuaranteeTimestamp = mvccTs
 	}
 
 	req := &querypb.QueryRequest{


### PR DESCRIPTION
When MvccTimestamp is set, it could be used as guarantee timestamp directly instead of new ts allocated by scheduler reducing the waiting time when delegator has tsafe lag