### PR TITLE
enhance: move streaming coord from datacoord to rootcoord

### DIFF
--- a/internal/coordinator/coordclient/registry.go
+++ b/internal/coordinator/coordclient/registry.go
@@ -58,6 +58,9 @@ func EnableLocalClientRole(cfg *LocalClientRoleConfig) {
 
 // RegisterQueryCoordServer register query coord server
 func RegisterQueryCoordServer(server querypb.QueryCoordServer) {
+	if !enableLocal.EnableQueryCoord {
+		return
+	}
 	newLocalClient := grpcclient.NewLocalGRPCClient(&querypb.QueryCoord_ServiceDesc, server, querypb.NewQueryCoordClient)
 	glocalClient.queryCoordClient.Set(&nopCloseQueryCoordClient{newLocalClient})
 	log.Ctx(context.TODO()).Info("register query coord server", zap.Any("enableLocalClient", enableLocal))
@@ -65,6 +68,9 @@ func RegisterQueryCoordServer(server querypb.QueryCoordServer) {
 
 // RegsterDataCoordServer register data coord server
 func RegisterDataCoordServer(server datapb.DataCoordServer) {
+	if !enableLocal.EnableDataCoord {
+		return
+	}
 	newLocalClient := grpcclient.NewLocalGRPCClient(&datapb.DataCoord_ServiceDesc, server, datapb.NewDataCoordClient)
 	glocalClient.dataCoordClient.Set(&nopCloseDataCoordClient{newLocalClient})
 	log.Ctx(context.TODO()).Info("register data coord server", zap.Any("enableLocalClient", enableLocal))
@@ -72,6 +78,9 @@ func RegisterDataCoordServer(server datapb.DataCoordServer) {
 
 // RegisterRootCoordServer register root coord server
 func RegisterRootCoordServer(server rootcoordpb.RootCoordServer) {
+	if !enableLocal.EnableRootCoord {
+		return
+	}
 	newLocalClient := grpcclient.NewLocalGRPCClient(&rootcoordpb.RootCoord_ServiceDesc, server, rootcoordpb.NewRootCoordClient)
 	glocalClient.rootCoordClient.Set(&nopCloseRootCoordClient{newLocalClient})
 	log.Ctx(context.TODO()).Info("register root coord server", zap.Any("enableLocalClient", enableLocal))
@@ -128,9 +137,6 @@ func GetRootCoordClient(ctx context.Context) types.RootCoordClient {
 // MustGetLocalRootCoordClientFuture return root coord client future,
 // panic if root coord client is not enabled
 func MustGetLocalRootCoordClientFuture() *syncutil.Future[types.RootCoordClient] {
-	if !enableLocal.EnableRootCoord {
-		panic("root coord client is not enabled")
-	}
 	return glocalClient.rootCoordClient
 }
 

--- a/internal/coordinator/coordclient/registry_test.go
+++ b/internal/coordinator/coordclient/registry_test.go
@@ -31,6 +31,13 @@ func TestRegistry(t *testing.T) {
 	assert.False(t, enableLocal.EnableDataCoord)
 	assert.False(t, enableLocal.EnableRootCoord)
 
+	RegisterRootCoordServer(&rootcoordpb.UnimplementedRootCoordServer{})
+	RegisterDataCoordServer(&datapb.UnimplementedDataCoordServer{})
+	RegisterQueryCoordServer(&querypb.UnimplementedQueryCoordServer{})
+	assert.False(t, glocalClient.dataCoordClient.Ready())
+	assert.False(t, glocalClient.queryCoordClient.Ready())
+	assert.False(t, glocalClient.rootCoordClient.Ready())
+
 	enableLocal = &LocalClientRoleConfig{}
 
 	EnableLocalClientRole(&LocalClientRoleConfig{

--- a/internal/coordinator/coordclient/registry_test.go
+++ b/internal/coordinator/coordclient/registry_test.go
@@ -31,13 +31,6 @@ func TestRegistry(t *testing.T) {
 	assert.False(t, enableLocal.EnableDataCoord)
 	assert.False(t, enableLocal.EnableRootCoord)
 
-	RegisterRootCoordServer(&rootcoordpb.UnimplementedRootCoordServer{})
-	RegisterDataCoordServer(&datapb.UnimplementedDataCoordServer{})
-	RegisterQueryCoordServer(&querypb.UnimplementedQueryCoordServer{})
-	assert.False(t, glocalClient.dataCoordClient.Ready())
-	assert.False(t, glocalClient.queryCoordClient.Ready())
-	assert.False(t, glocalClient.rootCoordClient.Ready())
-
 	enableLocal = &LocalClientRoleConfig{}
 
 	EnableLocalClientRole(&LocalClientRoleConfig{

--- a/internal/datacoord/server.go
+++ b/internal/datacoord/server.go
@@ -33,7 +33,6 @@ import (
 	"github.com/tikv/client-go/v2/txnkv"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
-	"google.golang.org/grpc"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
@@ -49,7 +48,6 @@ import (
 	"github.com/milvus-io/milvus/internal/metastore/kv/datacoord"
 	"github.com/milvus-io/milvus/internal/proto/datapb"
 	"github.com/milvus-io/milvus/internal/storage"
-	streamingcoord "github.com/milvus-io/milvus/internal/streamingcoord/server"
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/dependency"
 	"github.com/milvus-io/milvus/internal/util/sessionutil"
@@ -162,9 +160,6 @@ type Server struct {
 
 	// manage ways that data coord access other coord
 	broker broker.Broker
-
-	// streamingcoord server is embedding in datacoord now.
-	streamingCoord *streamingcoord.Server
 
 	metricsRequest *metricsinfo.MetricsRequest
 }
@@ -312,12 +307,6 @@ func (s *Server) Init() error {
 	if err := s.initKV(); err != nil {
 		return err
 	}
-	if streamingutil.IsStreamingServiceEnabled() {
-		s.streamingCoord = streamingcoord.NewServerBuilder().
-			WithETCD(s.etcdCli).
-			WithMetaKV(s.kv).
-			WithSession(s.session).Build()
-	}
 	if s.enableActiveStandBy {
 		s.activateFunc = func() error {
 			log.Info("DataCoord switch from standby to active, activating")
@@ -327,11 +316,6 @@ func (s *Server) Init() error {
 			}
 			s.startDataCoord()
 			log.Info("DataCoord startup success")
-
-			if s.streamingCoord != nil {
-				s.streamingCoord.Start()
-				log.Info("StreamingCoord stratup successfully at standby mode")
-			}
 			return nil
 		}
 		s.stateCode.Store(commonpb.StateCode_StandBy)
@@ -340,10 +324,6 @@ func (s *Server) Init() error {
 	}
 
 	return s.initDataCoord()
-}
-
-func (s *Server) RegisterStreamingCoordGRPCService(server *grpc.Server) {
-	s.streamingCoord.RegisterGRPCService(server)
 }
 
 func (s *Server) initDataCoord() error {
@@ -374,15 +354,6 @@ func (s *Server) initDataCoord() error {
 	if err != nil {
 		log.Error("data coordinator id allocator initialize failed", zap.Error(err))
 		return err
-	}
-
-	// Initialize streaming coordinator.
-	if streamingutil.IsStreamingServiceEnabled() {
-
-		if err = s.streamingCoord.Init(context.TODO()); err != nil {
-			return err
-		}
-		log.Info("init streaming coordinator done")
 	}
 
 	s.handler = newServerHandler(s)
@@ -445,10 +416,6 @@ func (s *Server) Start() error {
 	if !s.enableActiveStandBy {
 		s.startDataCoord()
 		log.Info("DataCoord startup successfully")
-		if s.streamingCoord != nil {
-			s.streamingCoord.Start()
-			log.Info("StreamingCoord stratup successfully")
-		}
 	}
 
 	return nil
@@ -1101,12 +1068,6 @@ func (s *Server) Stop() error {
 	log.Info("datacoord server shutdown")
 	s.garbageCollector.close()
 	log.Info("datacoord garbage collector stopped")
-
-	if s.streamingCoord != nil {
-		log.Info("StreamingCoord stoping...")
-		s.streamingCoord.Stop()
-		log.Info("StreamingCoord stopped")
-	}
 
 	s.stopServerLoop()
 

--- a/internal/distributed/datacoord/service.go
+++ b/internal/distributed/datacoord/service.go
@@ -41,8 +41,6 @@ import (
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/dependency"
 	_ "github.com/milvus-io/milvus/internal/util/grpcclient"
-	"github.com/milvus-io/milvus/internal/util/streamingutil"
-	streamingserviceinterceptor "github.com/milvus-io/milvus/internal/util/streamingutil/service/interceptor"
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/tracer"
 	"github.com/milvus-io/milvus/pkg/util"
@@ -190,7 +188,6 @@ func (s *Server) startGrpcLoop() {
 				}
 				return s.serverID.Load()
 			}),
-			streamingserviceinterceptor.NewStreamingServiceUnaryServerInterceptor(),
 		)),
 		grpc.StreamInterceptor(grpc_middleware.ChainStreamServer(
 			logutil.StreamTraceLoggerInterceptor,
@@ -201,7 +198,6 @@ func (s *Server) startGrpcLoop() {
 				}
 				return s.serverID.Load()
 			}),
-			streamingserviceinterceptor.NewStreamingServiceStreamServerInterceptor(),
 		)),
 		grpc.StatsHandler(tracer.GetDynamicOtelGrpcServerStatsHandler()),
 	}
@@ -210,10 +206,6 @@ func (s *Server) startGrpcLoop() {
 	s.grpcServer = grpc.NewServer(grpcOpts...)
 	indexpb.RegisterIndexCoordServer(s.grpcServer, s)
 	datapb.RegisterDataCoordServer(s.grpcServer, s)
-	// register the streaming coord grpc service.
-	if streamingutil.IsStreamingServiceEnabled() {
-		s.dataCoord.RegisterStreamingCoordGRPCService(s.grpcServer)
-	}
 	coordclient.RegisterDataCoordServer(s)
 	go funcutil.CheckGrpcReady(ctx, s.grpcErrChan)
 	if err := s.grpcServer.Serve(s.listener); err != nil {

--- a/internal/distributed/rootcoord/service_test.go
+++ b/internal/distributed/rootcoord/service_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/tikv/client-go/v2/txnkv"
 	clientv3 "go.etcd.io/etcd/client/v3"
+	"google.golang.org/grpc"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
@@ -95,6 +96,9 @@ func (m *mockCore) SetQueryCoordClient(client types.QueryCoordClient) error {
 }
 
 func (m *mockCore) SetProxyCreator(func(ctx context.Context, addr string, nodeID int64) (types.ProxyClient, error)) {
+}
+
+func (m *mockCore) RegisterStreamingCoordGRPCService(server *grpc.Server) {
 }
 
 func (m *mockCore) Register() error {

--- a/internal/mocks/mock_datacoord.go
+++ b/internal/mocks/mock_datacoord.go
@@ -10,8 +10,6 @@ import (
 
 	datapb "github.com/milvus-io/milvus/internal/proto/datapb"
 
-	grpc "google.golang.org/grpc"
-
 	indexpb "github.com/milvus-io/milvus/internal/proto/indexpb"
 
 	internalpb "github.com/milvus-io/milvus/internal/proto/internalpb"
@@ -2602,39 +2600,6 @@ func (_c *MockDataCoord_Register_Call) Return(_a0 error) *MockDataCoord_Register
 }
 
 func (_c *MockDataCoord_Register_Call) RunAndReturn(run func() error) *MockDataCoord_Register_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// RegisterStreamingCoordGRPCService provides a mock function with given fields: s
-func (_m *MockDataCoord) RegisterStreamingCoordGRPCService(s *grpc.Server) {
-	_m.Called(s)
-}
-
-// MockDataCoord_RegisterStreamingCoordGRPCService_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RegisterStreamingCoordGRPCService'
-type MockDataCoord_RegisterStreamingCoordGRPCService_Call struct {
-	*mock.Call
-}
-
-// RegisterStreamingCoordGRPCService is a helper method to define mock.On call
-//   - s *grpc.Server
-func (_e *MockDataCoord_Expecter) RegisterStreamingCoordGRPCService(s interface{}) *MockDataCoord_RegisterStreamingCoordGRPCService_Call {
-	return &MockDataCoord_RegisterStreamingCoordGRPCService_Call{Call: _e.mock.On("RegisterStreamingCoordGRPCService", s)}
-}
-
-func (_c *MockDataCoord_RegisterStreamingCoordGRPCService_Call) Run(run func(s *grpc.Server)) *MockDataCoord_RegisterStreamingCoordGRPCService_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*grpc.Server))
-	})
-	return _c
-}
-
-func (_c *MockDataCoord_RegisterStreamingCoordGRPCService_Call) Return() *MockDataCoord_RegisterStreamingCoordGRPCService_Call {
-	_c.Call.Return()
-	return _c
-}
-
-func (_c *MockDataCoord_RegisterStreamingCoordGRPCService_Call) RunAndReturn(run func(*grpc.Server)) *MockDataCoord_RegisterStreamingCoordGRPCService_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/mocks/mock_rootcoord.go
+++ b/internal/mocks/mock_rootcoord.go
@@ -8,6 +8,8 @@ import (
 	commonpb "github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
 
+	grpc "google.golang.org/grpc"
+
 	internalpb "github.com/milvus-io/milvus/internal/proto/internalpb"
 
 	milvuspb "github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
@@ -2659,6 +2661,39 @@ func (_c *RootCoord_Register_Call) Return(_a0 error) *RootCoord_Register_Call {
 }
 
 func (_c *RootCoord_Register_Call) RunAndReturn(run func() error) *RootCoord_Register_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// RegisterStreamingCoordGRPCService provides a mock function with given fields: server
+func (_m *RootCoord) RegisterStreamingCoordGRPCService(server *grpc.Server) {
+	_m.Called(server)
+}
+
+// RootCoord_RegisterStreamingCoordGRPCService_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RegisterStreamingCoordGRPCService'
+type RootCoord_RegisterStreamingCoordGRPCService_Call struct {
+	*mock.Call
+}
+
+// RegisterStreamingCoordGRPCService is a helper method to define mock.On call
+//   - server *grpc.Server
+func (_e *RootCoord_Expecter) RegisterStreamingCoordGRPCService(server interface{}) *RootCoord_RegisterStreamingCoordGRPCService_Call {
+	return &RootCoord_RegisterStreamingCoordGRPCService_Call{Call: _e.mock.On("RegisterStreamingCoordGRPCService", server)}
+}
+
+func (_c *RootCoord_RegisterStreamingCoordGRPCService_Call) Run(run func(server *grpc.Server)) *RootCoord_RegisterStreamingCoordGRPCService_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(*grpc.Server))
+	})
+	return _c
+}
+
+func (_c *RootCoord_RegisterStreamingCoordGRPCService_Call) Return() *RootCoord_RegisterStreamingCoordGRPCService_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *RootCoord_RegisterStreamingCoordGRPCService_Call) RunAndReturn(run func(*grpc.Server)) *RootCoord_RegisterStreamingCoordGRPCService_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/rootcoord/root_coord.go
+++ b/internal/rootcoord/root_coord.go
@@ -826,7 +826,9 @@ func (c *Core) Stop() error {
 	c.stopExecutor()
 	c.stopScheduler()
 
-	c.streamingCoord.Stop()
+	if c.streamingCoord != nil {
+		c.streamingCoord.Stop()
+	}
 	if c.proxyWatcher != nil {
 		c.proxyWatcher.Stop()
 	}

--- a/internal/streamingcoord/client/client.go
+++ b/internal/streamingcoord/client/client.go
@@ -44,8 +44,8 @@ type Client interface {
 // NewClient creates a new client.
 func NewClient(etcdCli *clientv3.Client) Client {
 	// StreamingCoord is deployed on DataCoord node.
-	role := sessionutil.GetSessionPrefixByRole(typeutil.DataCoordRole)
-	rb := resolver.NewSessionBuilder(etcdCli, role)
+	role := sessionutil.GetSessionPrefixByRole(typeutil.RootCoordRole)
+	rb := resolver.NewSessionExclusiveBuilder(etcdCli, role)
 	dialTimeout := paramtable.Get().StreamingCoordGrpcClientCfg.DialTimeout.GetAsDuration(time.Millisecond)
 	dialOptions := getDialOptions(rb)
 	conn := lazygrpc.NewConn(func(ctx context.Context) (*grpc.ClientConn, error) {
@@ -53,7 +53,7 @@ func NewClient(etcdCli *clientv3.Client) Client {
 		defer cancel()
 		return grpc.DialContext(
 			ctx,
-			resolver.SessionResolverScheme+":///"+typeutil.DataCoordRole,
+			resolver.SessionResolverScheme+":///"+typeutil.RootCoordRole,
 			dialOptions...,
 		)
 	})

--- a/internal/streamingcoord/server/balancer/balancer_impl.go
+++ b/internal/streamingcoord/server/balancer/balancer_impl.go
@@ -32,7 +32,7 @@ func RecoverBalancer(
 	}
 	b := &balancerImpl{
 		lifetime:               typeutil.NewLifetime(),
-		logger:                 log.With(zap.String("policy", policy)),
+		logger:                 resource.Resource().Logger().With(log.FieldComponent("balancer"), zap.String("policy", policy)),
 		channelMetaManager:     manager,
 		policy:                 mustGetPolicy(policy),
 		reqCh:                  make(chan *request, 5),

--- a/internal/streamingcoord/server/resource/test_utility.go
+++ b/internal/streamingcoord/server/resource/test_utility.go
@@ -5,6 +5,7 @@ package resource
 
 import (
 	"github.com/milvus-io/milvus/internal/streamingnode/client/manager"
+	"github.com/milvus-io/milvus/pkg/log"
 )
 
 // OptStreamingManagerClient provides streaming manager client to the resource.
@@ -16,7 +17,9 @@ func OptStreamingManagerClient(c manager.ManagerClient) optResourceInit {
 
 // InitForTest initializes the singleton of resources for test.
 func InitForTest(opts ...optResourceInit) {
-	r = &resourceImpl{}
+	r = &resourceImpl{
+		logger: log.With(),
+	}
 	for _, opt := range opts {
 		opt(r)
 	}

--- a/internal/streamingcoord/server/server.go
+++ b/internal/streamingcoord/server/server.go
@@ -9,72 +9,76 @@ import (
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/balancer"
 	_ "github.com/milvus-io/milvus/internal/streamingcoord/server/balancer/policy" // register the balancer policy
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/service"
-	"github.com/milvus-io/milvus/internal/util/componentutil"
 	"github.com/milvus-io/milvus/internal/util/sessionutil"
+	"github.com/milvus-io/milvus/internal/util/streamingutil"
 	"github.com/milvus-io/milvus/internal/util/streamingutil/util"
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/streaming/proto/streamingpb"
+	"github.com/milvus-io/milvus/pkg/util/conc"
 	"github.com/milvus-io/milvus/pkg/util/syncutil"
 )
 
 // Server is the streamingcoord server.
 type Server struct {
+	logger *log.MLogger
+
 	// session of current server.
 	session sessionutil.SessionInterface
 
 	// service level variables.
-	assignmentService     service.AssignmentService
-	componentStateService *componentutil.ComponentStateService // state.
+	assignmentService service.AssignmentService
 
 	// basic component variables can be used at service level.
 	balancer *syncutil.Future[balancer.Balancer]
 }
 
 // Init initializes the streamingcoord server.
-func (s *Server) Init(ctx context.Context) (err error) {
-	log.Info("init streamingcoord server...")
-
-	// Init all underlying component of streamingcoord server.
+func (s *Server) Start(ctx context.Context) (err error) {
+	s.logger.Info("init streamingcoord...")
 	if err := s.initBasicComponent(ctx); err != nil {
-		log.Error("init basic component of streamingcoord server failed", zap.Error(err))
+		s.logger.Warn("init basic component of streamingcoord failed", zap.Error(err))
 		return err
 	}
 	// Init all grpc service of streamingcoord server.
-	s.componentStateService.OnInitialized(s.session.GetServerID())
-	log.Info("streamingcoord server initialized")
+	s.logger.Info("streamingcoord initialized")
 	return nil
 }
 
 // initBasicComponent initialize all underlying dependency for streamingcoord.
-func (s *Server) initBasicComponent(ctx context.Context) error {
-	// Init balancer
-	var err error
-	// Read new incoming topics from configuration, and register it into balancer.
-	newIncomingTopics := util.GetAllTopicsFromConfiguration()
-	balancer, err := balancer.RecoverBalancer(ctx, "pchannel_count_fair", newIncomingTopics.Collect()...)
-	if err != nil {
-		return err
+func (s *Server) initBasicComponent(ctx context.Context) (err error) {
+	if streamingutil.IsStreamingServiceEnabled() {
+		fBalancer := conc.Go(func() (struct{}, error) {
+			s.logger.Info("start recovery balancer...")
+			// Read new incoming topics from configuration, and register it into balancer.
+			newIncomingTopics := util.GetAllTopicsFromConfiguration()
+			balancer, err := balancer.RecoverBalancer(ctx, "pchannel_count_fair", newIncomingTopics.Collect()...)
+			if err != nil {
+				s.logger.Warn("recover balancer failed", zap.Error(err))
+				return struct{}{}, err
+			}
+			s.balancer.Set(balancer)
+			s.logger.Info("recover balancer done")
+			return struct{}{}, nil
+		})
+		return conc.AwaitAll(fBalancer)
 	}
-	s.balancer.Set(balancer)
-	return err
+	return nil
 }
 
-// registerGRPCService register all grpc service to grpc server.
+// RegisterGRPCService register all grpc service to grpc server.
 func (s *Server) RegisterGRPCService(grpcServer *grpc.Server) {
-	streamingpb.RegisterStreamingCoordAssignmentServiceServer(grpcServer, s.assignmentService)
-	streamingpb.RegisterStreamingCoordStateServiceServer(grpcServer, s.componentStateService)
+	if streamingutil.IsStreamingServiceEnabled() {
+		streamingpb.RegisterStreamingCoordAssignmentServiceServer(grpcServer, s.assignmentService)
+	}
 }
 
-// Start starts the streamingcoord server.
-func (s *Server) Start() {
-	// Just do nothing now.
-	log.Info("start streamingcoord server")
-}
-
-// Stop stops the streamingcoord server.
+// Close closes the streamingcoord server.
 func (s *Server) Stop() {
-	s.componentStateService.OnStopping()
-	log.Info("close balancer...")
-	s.balancer.Get().Close()
-	log.Info("streamingcoord server stopped")
+	if s.balancer.Ready() {
+		s.logger.Info("start close balancer...")
+		s.balancer.Get().Close()
+	} else {
+		s.logger.Info("balancer not ready, skip close")
+	}
+	s.logger.Info("streamingcoord server stopped")
 }

--- a/internal/streamingcoord/server/service/discover/discover_server.go
+++ b/internal/streamingcoord/server/service/discover/discover_server.go
@@ -8,6 +8,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/balancer"
+	"github.com/milvus-io/milvus/internal/streamingcoord/server/resource"
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/streaming/proto/streamingpb"
 	"github.com/milvus-io/milvus/pkg/streaming/util/types"
@@ -27,7 +28,7 @@ func NewAssignmentDiscoverServer(
 		streamServer: discoverGrpcServerHelper{
 			streamServer,
 		},
-		logger: log.With(),
+		logger: resource.Resource().Logger().With(log.FieldComponent("assignment-discover-server")),
 	}
 }
 

--- a/internal/streamingcoord/server/service/discover/discover_server_test.go
+++ b/internal/streamingcoord/server/service/discover/discover_server_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/milvus-io/milvus/internal/mocks/streamingcoord/server/mock_balancer"
+	"github.com/milvus-io/milvus/internal/streamingcoord/server/resource"
 	"github.com/milvus-io/milvus/pkg/mocks/streaming/proto/mock_streamingpb"
 	"github.com/milvus-io/milvus/pkg/streaming/proto/streamingpb"
 	"github.com/milvus-io/milvus/pkg/streaming/util/types"
@@ -15,6 +16,7 @@ import (
 )
 
 func TestAssignmentDiscover(t *testing.T) {
+	resource.InitForTest()
 	b := mock_balancer.NewMockBalancer(t)
 	b.EXPECT().WatchChannelAssignments(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, cb func(typeutil.VersionInt64Pair, []types.PChannelInfoAssigned) error) error {
 		versions := []typeutil.VersionInt64Pair{

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -121,8 +121,6 @@ type DataCoord interface {
 type DataCoordComponent interface {
 	DataCoord
 
-	RegisterStreamingCoordGRPCService(s *grpc.Server)
-
 	SetAddress(address string)
 	// SetEtcdClient set EtcdClient for DataCoord
 	// `etcdClient` is a client of etcd
@@ -213,6 +211,8 @@ type RootCoordComponent interface {
 
 	// GetMetrics notifies RootCoordComponent to collect metrics for specified component
 	GetMetrics(ctx context.Context, req *milvuspb.GetMetricsRequest) (*milvuspb.GetMetricsResponse, error)
+
+	RegisterStreamingCoordGRPCService(server *grpc.Server)
 }
 
 // ProxyClient is the client interface for proxy server

--- a/internal/util/streamingutil/service/discoverer/session_discoverer_test.go
+++ b/internal/util/streamingutil/service/discoverer/session_discoverer_test.go
@@ -25,7 +25,7 @@ func TestSessionDiscoverer(t *testing.T) {
 	etcdClient, err := etcd.GetEmbedEtcdClient()
 	assert.NoError(t, err)
 	targetVersion := "0.1.0"
-	d := NewSessionDiscoverer(etcdClient, "session/", targetVersion)
+	d := NewSessionDiscoverer(etcdClient, "session/", false, targetVersion)
 
 	s := d.NewVersionedState()
 	assert.True(t, s.Version.EQ(typeutil.VersionInt64(-1)))
@@ -95,7 +95,7 @@ func TestSessionDiscoverer(t *testing.T) {
 	assert.ErrorIs(t, err, io.EOF)
 
 	// Do a init discover here.
-	d = NewSessionDiscoverer(etcdClient, "session/", targetVersion)
+	d = NewSessionDiscoverer(etcdClient, "session/", false, targetVersion)
 	err = d.Discover(ctx, func(state VersionedState) error {
 		// balance attributes
 		sessions := state.Sessions()

--- a/internal/util/streamingutil/service/resolver/builder.go
+++ b/internal/util/streamingutil/service/resolver/builder.go
@@ -28,9 +28,15 @@ func NewChannelAssignmentBuilder(w types.AssignmentDiscoverWatcher) Builder {
 }
 
 // NewSessionBuilder creates a new resolver builder.
+// Multiple sessions are allowed, use the role as prefix.
 func NewSessionBuilder(c *clientv3.Client, role string) Builder {
-	// TODO: use 2.5.0 after 2.5.0 released.
-	return newBuilder(SessionResolverScheme, discoverer.NewSessionDiscoverer(c, role, "2.4.0"))
+	return newBuilder(SessionResolverScheme, discoverer.NewSessionDiscoverer(c, role, false, "2.4.0"))
+}
+
+// NewSessionExclusiveBuilder creates a new resolver builder with exclusive.
+// Only one session is allowed, not use the prefix, only use the role directly.
+func NewSessionExclusiveBuilder(c *clientv3.Client, role string) Builder {
+	return newBuilder(SessionResolverScheme, discoverer.NewSessionDiscoverer(c, role, true, "2.4.0"))
 }
 
 // newBuilder creates a new resolver builder.

--- a/pkg/log/fields.go
+++ b/pkg/log/fields.go
@@ -1,0 +1,18 @@
+package log
+
+import "go.uber.org/zap"
+
+const (
+	FieldNameModule    = "module"
+	FieldNameComponent = "component"
+)
+
+// FieldModule returns a zap field with the module name.
+func FieldModule(module string) zap.Field {
+	return zap.String(FieldNameModule, module)
+}
+
+// FieldComponent returns a zap field with the component name.
+func FieldComponent(component string) zap.Field {
+	return zap.String(FieldNameComponent, component)
+}

--- a/pkg/log/global.go
+++ b/pkg/log/global.go
@@ -143,7 +143,7 @@ func WithReqID(ctx context.Context, reqID int64) context.Context {
 
 // WithModule adds given module field to the logger in ctx
 func WithModule(ctx context.Context, module string) context.Context {
-	fields := []zap.Field{zap.String("module", module)}
+	fields := []zap.Field{zap.String(FieldNameModule, module)}
 	return WithFields(ctx, fields...)
 }
 


### PR DESCRIPTION
issue: #38399

We want to support broadcast operation for both streaming and msgstream.
But msgstream can be only sent message from rootcoord and proxy.
So this pr move the streamingcoord to rootcoord to make easier implementation.