### PR TITLE
enhance: [2.5] Use mvcc timestamp as guarantee ts if set (#38980)

### DIFF
--- a/internal/proxy/task_query.go
+++ b/internal/proxy/task_query.go
@@ -570,6 +570,7 @@ func (t *queryTask) queryShard(ctx context.Context, nodeID int64, qn types.Query
 	retrieveReq.GetBase().TargetID = nodeID
 	if needOverrideMvcc && mvccTs > 0 {
 		retrieveReq.MvccTimestamp = mvccTs
+		retrieveReq.GuaranteeTimestamp = mvccTs
 	}
 
 	req := &querypb.QueryRequest{


### PR DESCRIPTION
Cherry pick from master
pr: #38980
When MvccTimestamp is set, it could be used as guarantee timestamp directly instead of new ts allocated by scheduler reducing the waiting time when delegator has tsafe lag