### PR TITLE
enhance: Use bitset or instead of bitwise set

### DIFF
--- a/internal/core/src/exec/expression/TermExpr.cpp
+++ b/internal/core/src/exec/expression/TermExpr.cpp
@@ -223,9 +223,10 @@ PhyTermFilterExpr::ExecPkTermImpl() {
     TargetBitmapView valid_res(res_vec->GetValidRawData(), real_batch_size);
     valid_res.set();
 
-    for (size_t i = 0; i < real_batch_size; ++i) {
-        res[i] = cached_bits_[current_data_chunk_pos_++];
-    }
+    auto current_chunk_view =
+        cached_bits_.view(current_data_chunk_pos_, real_batch_size);
+    res |= current_chunk_view;
+    current_data_chunk_pos_ += real_batch_size;
 
     return res_vec;
 }


### PR DESCRIPTION
Related to #39003

Copying bitset value bit by bit is slow and CPU heavy, this PR utilizes bitset operator "|=" to accelerate this procedure