### PR TITLE
fix: [2.5] fix chunk cache madvise when sparse raw data is mmaped

### DIFF
--- a/internal/core/src/mmap/ChunkedColumn.h
+++ b/internal/core/src/mmap/ChunkedColumn.h
@@ -282,14 +282,6 @@ class ChunkedSparseFloatColumn : public ChunkedColumnBase {
             std::dynamic_pointer_cast<SparseFloatVectorChunk>(chunk)->Dim());
     }
 
-    // This is used to advice mmap prefetch, we don't currently support mmap for
-    // sparse float vector thus not implemented for now.
-    size_t
-    DataByteSize() const override {
-        PanicInfo(ErrorCode::Unsupported,
-                  "ByteSize not supported for sparse float column");
-    }
-
     SpanBase
     Span(int64_t chunk_id) const override {
         PanicInfo(ErrorCode::Unsupported,
@@ -303,7 +295,6 @@ class ChunkedSparseFloatColumn : public ChunkedColumnBase {
 
  private:
     int64_t dim_ = 0;
-    std::vector<knowhere::sparse::SparseRow<float>> vec_;
 };
 
 template <typename T>


### PR DESCRIPTION
instead of marking as not supported, ChunkedSparseFloatColumn::DataByteSize can simply use the impl of super class.
pr: https://github.com/milvus-io/milvus/pull/39145
issue: #39158