### PR TITLE
fix: HierarchyPager used instead of FlatPager to adhere bulk insert failure on using Azure buckets

### DIFF
--- a/internal/storage/azure_object_storage.go
+++ b/internal/storage/azure_object_storage.go
@@ -192,7 +192,7 @@ func (AzureObjectStorage *AzureObjectStorage) StatObject(ctx context.Context, bu
 
 func (AzureObjectStorage *AzureObjectStorage) WalkWithObjects(ctx context.Context, bucketName string, prefix string, recursive bool, walkFunc ChunkObjectWalkFunc) error {
 	if recursive {
-		pager := AzureObjectStorage.Client.NewContainerClient(bucketName).NewListBlobsFlatPager(&azblob.ListBlobsFlatOptions{
+		pager := AzureObjectStorage.Client.NewContainerClient(bucketName).NewListBlobsHierarchyPager("", &container.ListBlobsHierarchyOptions{
 			Prefix: &prefix,
 		})
 		if pager.More() {


### PR DESCRIPTION
Related task: [#39135 ](https://github.com/milvus-io/milvus/issues/39135)