### PR TITLE
enhance: [2.5]intermin index support different index type and more data type(fp16/bf16)

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -407,8 +407,11 @@ queryNode:
       # Milvus will eventually seals and indexes all segments, but enabling this optimizes search performance for immediate queries following data insertion.
       # This defaults to true, indicating that Milvus creates temporary index for growing segments and the sealed segments that are not indexed upon searches.
       enableIndex: true
-      nlist: 128 # temp index nlist, recommend to set sqrt(chunkRows), must smaller than chunkRows/8
+      nlist: 128 # interim index nlist, recommend to set sqrt(chunkRows), must smaller than chunkRows/8
       nprobe: 16 # nprobe to search small index, based on your accuracy requirement, must smaller than nlist
+      subDim: 4 # interim index sub dim, recommend to (subDim % vector dim == 0)
+      refineRatio: 4.5 # interim index parameters, should set to be >= 1.0
+      denseVectorIndexType: IVF_FLAT_CC # Dense vector intermin index type
       memExpansionRate: 1.15 # extra memory needed by building interim index
       buildParallelRate: 0.5 # the ratio of building interim index parallel matched with cpu num
     multipleChunkedEnable: true # Enable multiple chunked search

--- a/internal/core/src/common/type_c.h
+++ b/internal/core/src/common/type_c.h
@@ -103,6 +103,9 @@ typedef struct CMmapConfig {
     uint64_t fix_file_size;
     bool growing_enable_mmap;
     bool scalar_index_enable_mmap;
+    bool scalar_field_enable_mmap;
+    bool vector_index_enable_mmap;
+    bool vector_field_enable_mmap;
 } CMmapConfig;
 
 typedef struct CTraceConfig {

--- a/internal/core/src/index/VectorMemIndex.h
+++ b/internal/core/src/index/VectorMemIndex.h
@@ -39,6 +39,12 @@ class VectorMemIndex : public VectorIndex {
         const storage::FileManagerContext& file_manager_context =
             storage::FileManagerContext());
 
+    // knowhere data view index special constucter for intermin index, no need to hold file_manager_ to upload or download files
+    VectorMemIndex(const IndexType& index_type,
+                   const MetricType& metric_type,
+                   const IndexVersion& version,
+                   const knowhere::ViewDataOp view_data);
+
     BinarySet
     Serialize(const Config& config) override;
 

--- a/internal/core/src/mmap/ChunkVector.h
+++ b/internal/core/src/mmap/ChunkVector.h
@@ -16,6 +16,7 @@
 #pragma once
 #include "mmap/ChunkData.h"
 #include "storage/MmapManager.h"
+#include "segcore/SegcoreConfig.h"
 namespace milvus {
 template <typename Type>
 class ChunkVectorBase {

--- a/internal/core/src/query/SearchOnGrowing.cpp
+++ b/internal/core/src/query/SearchOnGrowing.cpp
@@ -42,10 +42,9 @@ FloatSegmentIndexSearch(const segcore::SegmentGrowingImpl& segment,
     // TODO(SPARSE): see todo in PlanImpl.h::PlaceHolder.
     auto dim = is_sparse ? 0 : field.get_dim();
 
-    AssertInfo(field.get_data_type() == DataType::VECTOR_FLOAT ||
-                   field.get_data_type() == DataType::VECTOR_SPARSE_FLOAT,
-               "[FloatSearch]Field data type isn't VECTOR_FLOAT or "
-               "VECTOR_SPARSE_FLOAT");
+    AssertInfo(IsVectorDataType(field.get_data_type()),
+               "[FloatSearch]Field data type isn't VECTOR_FLOAT, "
+               "VECTOR_FLOAT16, VECTOR_BFLOAT16 or VECTOR_SPARSE_FLOAT");
     dataset::SearchDataset search_dataset{info.metric_type_,
                                           num_queries,
                                           info.topk_,

--- a/internal/core/src/segcore/ConcurrentVector.h
+++ b/internal/core/src/segcore/ConcurrentVector.h
@@ -541,4 +541,17 @@ class ConcurrentVector<BFloat16Vector>
     }
 };
 
+static bool
+ConcurrentDenseVectorCheck(const VectorBase* vec_base, DataType data_type) {
+    if (data_type == DataType::VECTOR_FLOAT) {
+        return dynamic_cast<const ConcurrentVector<FloatVector>*>(vec_base);
+    } else if (data_type == DataType::VECTOR_FLOAT16) {
+        return dynamic_cast<const ConcurrentVector<Float16Vector>*>(vec_base);
+    } else if (data_type == DataType::VECTOR_BFLOAT16) {
+        return dynamic_cast<const ConcurrentVector<BFloat16Vector>*>(vec_base);
+    } else {
+        return false;
+    }
+}
+
 }  // namespace milvus::segcore

--- a/internal/core/src/segcore/FieldIndexing.cpp
+++ b/internal/core/src/segcore/FieldIndexing.cpp
@@ -28,7 +28,8 @@ using std::unique_ptr;
 VectorFieldIndexing::VectorFieldIndexing(const FieldMeta& field_meta,
                                          const FieldIndexMeta& field_index_meta,
                                          int64_t segment_max_row_count,
-                                         const SegcoreConfig& segcore_config)
+                                         const SegcoreConfig& segcore_config,
+                                         const VectorBase* field_raw_data)
     : FieldIndexing(field_meta, segcore_config),
       built_(false),
       sync_with_index_(false),
@@ -38,15 +39,66 @@ VectorFieldIndexing::VectorFieldIndexing(const FieldMeta& field_meta,
           segcore_config,
           SegmentType::Growing,
           IsSparseFloatVectorDataType(field_meta.get_data_type()))) {
-    recreate_index();
+    recreate_index(field_meta.get_data_type(), field_raw_data);
 }
 
 void
-VectorFieldIndexing::recreate_index() {
-    index_ = std::make_unique<index::VectorMemIndex<float>>(
-        config_->GetIndexType(),
-        config_->GetMetricType(),
-        knowhere::Version::GetCurrentVersion().VersionNumber());
+VectorFieldIndexing::recreate_index(DataType data_type,
+                                    const VectorBase* field_raw_data) {
+    if (IsSparseFloatVectorDataType(data_type)) {
+        index_ = std::make_unique<index::VectorMemIndex<float>>(
+            config_->GetIndexType(),
+            config_->GetMetricType(),
+            knowhere::Version::GetCurrentVersion().VersionNumber());
+    } else if (data_type == DataType::VECTOR_FLOAT) {
+        auto concurrent_fp32_vec =
+            reinterpret_cast<const ConcurrentVector<FloatVector>*>(
+                field_raw_data);
+        AssertInfo(concurrent_fp32_vec != nullptr,
+                   "Fail to generate a cocurrent vector when recreate_index in "
+                   "growing segment.");
+        knowhere::ViewDataOp view_data = [field_raw_data_ptr =
+                                              concurrent_fp32_vec](size_t id) {
+            return (const void*)field_raw_data_ptr->get_element(id);
+        };
+        index_ = std::make_unique<index::VectorMemIndex<float>>(
+            config_->GetIndexType(),
+            config_->GetMetricType(),
+            knowhere::Version::GetCurrentVersion().VersionNumber(),
+            view_data);
+    } else if (data_type == DataType::VECTOR_FLOAT16) {
+        auto concurrent_fp16_vec =
+            reinterpret_cast<const ConcurrentVector<Float16Vector>*>(
+                field_raw_data);
+        AssertInfo(concurrent_fp16_vec != nullptr,
+                   "Fail to generate a cocurrent vector when    recreate_index "
+                   "in growing segment.");
+        knowhere::ViewDataOp view_data = [field_raw_data_ptr =
+                                              concurrent_fp16_vec](size_t id) {
+            return (const void*)field_raw_data_ptr->get_element(id);
+        };
+        index_ = std::make_unique<index::VectorMemIndex<float16>>(
+            config_->GetIndexType(),
+            config_->GetMetricType(),
+            knowhere::Version::GetCurrentVersion().VersionNumber(),
+            view_data);
+    } else if (data_type == DataType::VECTOR_BFLOAT16) {
+        auto concurrent_bf16_vec =
+            reinterpret_cast<const ConcurrentVector<BFloat16Vector>*>(
+                field_raw_data);
+        AssertInfo(concurrent_bf16_vec != nullptr,
+                   "Fail to generate a cocurrent vector when    recreate_index "
+                   "in growing segment.");
+        knowhere::ViewDataOp view_data = [field_raw_data_ptr =
+                                              concurrent_bf16_vec](size_t id) {
+            return (const void*)field_raw_data_ptr->get_element(id);
+        };
+        index_ = std::make_unique<index::VectorMemIndex<bfloat16>>(
+            config_->GetIndexType(),
+            config_->GetMetricType(),
+            knowhere::Version::GetCurrentVersion().VersionNumber(),
+            view_data);
+    }
 }
 
 void
@@ -54,24 +106,40 @@ VectorFieldIndexing::BuildIndexRange(int64_t ack_beg,
                                      int64_t ack_end,
                                      const VectorBase* vec_base) {
     // No BuildIndexRange support for sparse vector.
-    AssertInfo(field_meta_.get_data_type() == DataType::VECTOR_FLOAT,
-               "Data type of vector field is not VECTOR_FLOAT");
+    AssertInfo(field_meta_.get_data_type() == DataType::VECTOR_FLOAT ||
+                   field_meta_.get_data_type() == DataType::VECTOR_FLOAT16 ||
+                   field_meta_.get_data_type() == DataType::VECTOR_BFLOAT16,
+               "Data type of vector field is not in (VECTOR_FLOAT, "
+               "VECTOR_FLOAT16,VECTOR_BFLOAT16)");
     auto dim = field_meta_.get_dim();
-
-    auto source = dynamic_cast<const ConcurrentVector<FloatVector>*>(vec_base);
-    AssertInfo(source, "vec_base can't cast to ConcurrentVector type");
-    auto num_chunk = source->num_chunk();
+    AssertInfo(
+        ConcurrentDenseVectorCheck(vec_base, field_meta_.get_data_type()),
+        "vec_base can't cast to ConcurrentVector type");
+    auto num_chunk = vec_base->num_chunk();
     AssertInfo(ack_end <= num_chunk, "ack_end is bigger than num_chunk");
     auto conf = get_build_params();
     data_.grow_to_at_least(ack_end);
     for (int chunk_id = ack_beg; chunk_id < ack_end; chunk_id++) {
-        const auto& chunk_data = source->get_chunk_data(chunk_id);
-        auto indexing = std::make_unique<index::VectorMemIndex<float>>(
-            knowhere::IndexEnum::INDEX_FAISS_IVFFLAT,
-            knowhere::metric::L2,
-            knowhere::Version::GetCurrentVersion().VersionNumber());
-        auto dataset =
-            knowhere::GenDataSet(source->get_size_per_chunk(), dim, chunk_data);
+        const auto& chunk_data = vec_base->get_chunk_data(chunk_id);
+        std::unique_ptr<index::VectorIndex> indexing = nullptr;
+        if (field_meta_.get_data_type() == DataType::VECTOR_FLOAT) {
+            indexing = std::make_unique<index::VectorMemIndex<float>>(
+                knowhere::IndexEnum::INDEX_FAISS_IVFFLAT,
+                knowhere::metric::L2,
+                knowhere::Version::GetCurrentVersion().VersionNumber());
+        } else if (field_meta_.get_data_type() == DataType::VECTOR_FLOAT16) {
+            indexing = std::make_unique<index::VectorMemIndex<float16>>(
+                knowhere::IndexEnum::INDEX_FAISS_IVFFLAT,
+                knowhere::metric::L2,
+                knowhere::Version::GetCurrentVersion().VersionNumber());
+        } else {
+            indexing = std::make_unique<index::VectorMemIndex<bfloat16>>(
+                knowhere::IndexEnum::INDEX_FAISS_IVFFLAT,
+                knowhere::metric::L2,
+                knowhere::Version::GetCurrentVersion().VersionNumber());
+        }
+        auto dataset = knowhere::GenDataSet(
+            vec_base->get_size_per_chunk(), dim, chunk_data);
         indexing->BuildWithDataset(dataset, conf);
         data_[chunk_id] = std::move(indexing);
     }
@@ -135,7 +203,7 @@ VectorFieldIndexing::AppendSegmentIndexSparse(int64_t reserved_offset,
                 }
             } catch (SegcoreError& error) {
                 LOG_ERROR("growing sparse index build error: {}", error.what());
-                recreate_index();
+                recreate_index(field_meta_.get_data_type(), nullptr);
                 index_cur_ = 0;
                 return;
             }
@@ -162,16 +230,27 @@ VectorFieldIndexing::AppendSegmentIndexDense(int64_t reserved_offset,
                                              int64_t size,
                                              const VectorBase* field_raw_data,
                                              const void* data_source) {
-    AssertInfo(field_meta_.get_data_type() == DataType::VECTOR_FLOAT,
-               "Data type of vector field is not VECTOR_FLOAT");
+    AssertInfo(field_meta_.get_data_type() == DataType::VECTOR_FLOAT ||
+                   field_meta_.get_data_type() == DataType::VECTOR_FLOAT16 ||
+                   field_meta_.get_data_type() == DataType::VECTOR_BFLOAT16,
+               "Data type of vector field is not in (VECTOR_FLOAT, "
+               "VECTOR_FLOAT16,VECTOR_BFLOAT16)");
     auto dim = field_meta_.get_dim();
     auto conf = get_build_params();
-    auto source =
-        dynamic_cast<const ConcurrentVector<FloatVector>*>(field_raw_data);
-
-    auto size_per_chunk = source->get_size_per_chunk();
+    auto size_per_chunk = field_raw_data->get_size_per_chunk();
     //append vector [vector_id_beg, vector_id_end] into index
     //build index [vector_id_beg, build_threshold) when index not exist
+    AssertInfo(
+        ConcurrentDenseVectorCheck(field_raw_data, field_meta_.get_data_type()),
+        "vec_base can't cast to ConcurrentVector type");
+    size_t vec_length;
+    if (field_meta_.get_data_type() == DataType::VECTOR_FLOAT) {
+        vec_length = dim * sizeof(float);
+    } else if (field_meta_.get_data_type() == DataType::VECTOR_FLOAT16) {
+        vec_length = dim * sizeof(float16);
+    } else {
+        vec_length = dim * sizeof(bfloat16);
+    }
     if (!built_) {
         idx_t vector_id_beg = index_cur_.load();
         Assert(vector_id_beg == 0);
@@ -182,13 +261,13 @@ VectorFieldIndexing::AppendSegmentIndexDense(int64_t reserved_offset,
         int64_t vec_num = vector_id_end - vector_id_beg + 1;
         // for train index
         const void* data_addr;
-        unique_ptr<float[]> vec_data;
+        unique_ptr<char[]> vec_data;
         //all train data in one chunk
         if (chunk_id_beg == chunk_id_end) {
             data_addr = field_raw_data->get_chunk_data(chunk_id_beg);
         } else {
             //merge data from multiple chunks together
-            vec_data = std::make_unique<float[]>(vec_num * dim);
+            vec_data = std::make_unique<char[]>(vec_num * vec_length);
             int64_t offset = 0;
             //copy vector data [vector_id_beg, vector_id_end]
             for (int chunk_id = chunk_id_beg; chunk_id <= chunk_id_end;
@@ -199,10 +278,11 @@ VectorFieldIndexing::AppendSegmentIndexDense(int64_t reserved_offset,
                         ? vector_id_end - chunk_id * size_per_chunk + 1
                         : size_per_chunk;
                 std::memcpy(
-                    vec_data.get() + offset * dim,
-                    (const float*)field_raw_data->get_chunk_data(chunk_id) +
-                        chunk_offset * dim,
-                    chunk_copysz * dim * sizeof(float));
+                    (void*)((const char*)vec_data.get() + offset * vec_length),
+                    (void*)((const char*)field_raw_data->get_chunk_data(
+                                chunk_id) +
+                            chunk_offset * vec_length),
+                    chunk_copysz * vec_length);
                 offset += chunk_copysz;
             }
             data_addr = vec_data.get();
@@ -213,7 +293,7 @@ VectorFieldIndexing::AppendSegmentIndexDense(int64_t reserved_offset,
             index_->BuildWithDataset(dataset, conf);
         } catch (SegcoreError& error) {
             LOG_ERROR("growing index build error: {}", error.what());
-            recreate_index();
+            recreate_index(field_meta_.get_data_type(), field_raw_data);
             return;
         }
         index_cur_.fetch_add(vec_num);
@@ -249,8 +329,8 @@ VectorFieldIndexing::AppendSegmentIndexDense(int64_t reserved_offset,
             auto dataset = knowhere::GenDataSet(
                 chunk_sz,
                 dim,
-                (const float*)source->get_chunk_data(chunk_id) +
-                    chunk_offset * dim);
+                (const char*)field_raw_data->get_chunk_data(chunk_id) +
+                    chunk_offset * vec_length);
             index_->AddWithDataset(dataset, conf);
             index_cur_.fetch_add(chunk_sz);
         }
@@ -319,7 +399,8 @@ std::unique_ptr<FieldIndexing>
 CreateIndex(const FieldMeta& field_meta,
             const FieldIndexMeta& field_index_meta,
             int64_t segment_max_row_count,
-            const SegcoreConfig& segcore_config) {
+            const SegcoreConfig& segcore_config,
+            const VectorBase* field_raw_data) {
     if (field_meta.is_vector()) {
         if (field_meta.get_data_type() == DataType::VECTOR_FLOAT ||
             field_meta.get_data_type() == DataType::VECTOR_FLOAT16 ||
@@ -328,7 +409,8 @@ CreateIndex(const FieldMeta& field_meta,
             return std::make_unique<VectorFieldIndexing>(field_meta,
                                                          field_index_meta,
                                                          segment_max_row_count,
-                                                         segcore_config);
+                                                         segcore_config,
+                                                         field_raw_data);
         } else {
             PanicInfo(DataTypeInvalid,
                       fmt::format("unsupported vector type in index: {}",

--- a/internal/core/src/segcore/FieldIndexing.h
+++ b/internal/core/src/segcore/FieldIndexing.h
@@ -176,7 +176,8 @@ class VectorFieldIndexing : public FieldIndexing {
     explicit VectorFieldIndexing(const FieldMeta& field_meta,
                                  const FieldIndexMeta& field_index_meta,
                                  int64_t segment_max_row_count,
-                                 const SegcoreConfig& segcore_config);
+                                 const SegcoreConfig& segcore_config,
+                                 const VectorBase* field_raw_data);
 
     void
     BuildIndexRange(int64_t ack_beg,
@@ -235,7 +236,7 @@ class VectorFieldIndexing : public FieldIndexing {
 
  private:
     void
-    recreate_index();
+    recreate_index(DataType data_type, const VectorBase* field_raw_data);
     // current number of rows in index.
     std::atomic<idx_t> index_cur_ = 0;
     // whether the growing index has been built.
@@ -252,21 +253,23 @@ std::unique_ptr<FieldIndexing>
 CreateIndex(const FieldMeta& field_meta,
             const FieldIndexMeta& field_index_meta,
             int64_t segment_max_row_count,
-            const SegcoreConfig& segcore_config);
+            const SegcoreConfig& segcore_config,
+            const VectorBase* field_raw_data = nullptr);
 
 class IndexingRecord {
  public:
     explicit IndexingRecord(const Schema& schema,
                             const IndexMetaPtr& indexMetaPtr,
-                            const SegcoreConfig& segcore_config)
+                            const SegcoreConfig& segcore_config,
+                            const InsertRecord<false>* insert_record)
         : schema_(schema),
           index_meta_(indexMetaPtr),
           segcore_config_(segcore_config) {
-        Initialize();
+        Initialize(insert_record);
     }
 
     void
-    Initialize() {
+    Initialize(const InsertRecord<false>* insert_record) {
         int offset_id = 0;
         auto enable_growing_mmap = storage::MmapManager::GetInstance()
                                        .GetMmapConfig()
@@ -292,12 +295,15 @@ class IndexingRecord {
                         index_meta_->GetFieldIndexMeta(field_id);
                     //Disable growing index for flat
                     if (!vec_field_meta.IsFlatIndex()) {
+                        auto field_raw_data =
+                            insert_record->get_data_base(field_id);
                         field_indexings_.try_emplace(
                             field_id,
                             CreateIndex(field_meta,
                                         vec_field_meta,
                                         index_meta_->GetIndexMaxRowCount(),
-                                        segcore_config_));
+                                        segcore_config_,
+                                        field_raw_data));
                     }
                 }
             }
@@ -326,6 +332,20 @@ class IndexingRecord {
                 size,
                 field_raw_data,
                 stream_data->vectors().float_vector().data().data());
+        } else if (type == DataType::VECTOR_FLOAT16 &&
+                   reserved_offset + size >= indexing->get_build_threshold()) {
+            indexing->AppendSegmentIndexDense(
+                reserved_offset,
+                size,
+                field_raw_data,
+                stream_data->vectors().float16_vector().data());
+        } else if (type == DataType::VECTOR_BFLOAT16 &&
+                   reserved_offset + size >= indexing->get_build_threshold()) {
+            indexing->AppendSegmentIndexDense(
+                reserved_offset,
+                size,
+                field_raw_data,
+                stream_data->vectors().bfloat16_vector().data());
         } else if (type == DataType::VECTOR_SPARSE_FLOAT) {
             auto data = SparseBytesToRows(
                 stream_data->vectors().sparse_float_vector().contents());
@@ -353,7 +373,9 @@ class IndexingRecord {
         auto type = indexing->get_field_meta().get_data_type();
         const void* p = data->Data();
 
-        if (type == DataType::VECTOR_FLOAT &&
+        if ((type == DataType::VECTOR_FLOAT ||
+             type == DataType::VECTOR_FLOAT16 ||
+             type == DataType::VECTOR_BFLOAT16) &&
             reserved_offset + size >= indexing->get_build_threshold()) {
             auto vec_base = record.get_data_base(fieldId);
             indexing->AppendSegmentIndexDense(
@@ -385,6 +407,10 @@ class IndexingRecord {
             if (indexing->get_field_meta().get_data_type() ==
                     DataType::VECTOR_FLOAT ||
                 indexing->get_field_meta().get_data_type() ==
+                    DataType::VECTOR_FLOAT16 ||
+                indexing->get_field_meta().get_data_type() ==
+                    DataType::VECTOR_BFLOAT16 ||
+                indexing->get_field_meta().get_data_type() ==
                     DataType::VECTOR_SPARSE_FLOAT) {
                 indexing->GetDataFromIndex(
                     seg_offsets, count, element_size, output_raw);
@@ -408,7 +434,8 @@ class IndexingRecord {
             const FieldIndexing& indexing = get_field_indexing(fieldId);
             return indexing.has_raw_data();
         }
-        return true;
+        // if this field id not in IndexingRecord or not build index, we should find raw data in InsertRecord instead of IndexingRecord.
+        return false;
     }
 
     // concurrent

--- a/internal/core/src/segcore/IndexConfigGenerator.h
+++ b/internal/core/src/segcore/IndexConfigGenerator.h
@@ -31,7 +31,8 @@ enum class IndexConfigLevel {
 // when the segment is sealed before the index is built.
 class VecIndexConfig {
     inline static const std::map<std::string, double> index_build_ratio = {
-        {knowhere::IndexEnum::INDEX_FAISS_IVFFLAT_CC, 0.1}};
+        {knowhere::IndexEnum::INDEX_FAISS_IVFFLAT_CC, 0.1},
+        {knowhere::IndexEnum::INDEX_FAISS_SCANN_DVR, 0.1}};
 
     inline static const std::unordered_set<std::string> maintain_params = {
         "radius", "range_filter", "drop_ratio_search", "dim_max_score_ratio"};

--- a/internal/core/src/segcore/SegcoreConfig.h
+++ b/internal/core/src/segcore/SegcoreConfig.h
@@ -73,11 +73,53 @@ class SegcoreConfig {
         return enable_interim_segment_index_;
     }
 
+    void
+    set_sub_dim(int64_t sub_dim) {
+        sub_dim_ = sub_dim;
+    }
+
+    int64_t
+    get_sub_dim() const {
+        return sub_dim_;
+    }
+
+    void
+    set_refine_ratio(float refine_ratio) {
+        refine_ratio_ = refine_ratio;
+    }
+
+    int64_t
+    get_refine_ratio() const {
+        return refine_ratio_;
+    }
+
+    void
+    set_dense_vector_intermin_index_type(const std::string index_type) {
+        AssertInfo(valid_dense_vector_index_type.find(index_type) !=
+                       valid_dense_vector_index_type.end(),
+                   "fail to set dense vector index type.");
+        dense_index_type_ = index_type;
+    }
+
+    std::string
+    get_dense_vector_intermin_index_type() const {
+        return dense_index_type_;
+    }
+
  private:
+    inline static const std::unordered_set<std::string>
+        valid_dense_vector_index_type = {
+            knowhere::IndexEnum::INDEX_FAISS_IVFFLAT_CC,
+            knowhere::IndexEnum::INDEX_FAISS_SCANN_DVR,
+    };
     inline static bool enable_interim_segment_index_ = false;
     inline static int64_t chunk_rows_ = 32 * 1024;
     inline static int64_t nlist_ = 100;
     inline static int64_t nprobe_ = 4;
+    inline static int64_t sub_dim_ = 2;
+    inline static float refine_ratio_ = 3.0;
+    inline static std::string dense_index_type_ =
+        knowhere::IndexEnum::INDEX_FAISS_IVFFLAT_CC;
 };
 
 }  // namespace milvus::segcore

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -52,19 +52,16 @@ SegmentGrowingImpl::mask_with_delete(BitsetTypeView& bitset,
 void
 SegmentGrowingImpl::try_remove_chunks(FieldId fieldId) {
     //remove the chunk data to reduce memory consumption
-    if (indexing_record_.SyncDataWithIndex(fieldId)) {
-        VectorBase* vec_data_base =
-            dynamic_cast<segcore::ConcurrentVector<FloatVector>*>(
-                insert_record_.get_data_base(fieldId));
-        if (!vec_data_base) {
-            vec_data_base =
-                dynamic_cast<segcore::ConcurrentVector<SparseFloatVector>*>(
-                    insert_record_.get_data_base(fieldId));
-        }
-        if (vec_data_base && vec_data_base->num_chunk() > 0 &&
-            chunk_mutex_.try_lock()) {
-            vec_data_base->clear();
-            chunk_mutex_.unlock();
+    auto& field_meta = schema_->operator[](fieldId);
+    auto data_type = field_meta.get_data_type();
+    if (IsVectorDataType(data_type)) {
+        if (indexing_record_.HasRawData(fieldId)) {
+            auto vec_data_base = insert_record_.get_data_base(fieldId);
+            if (vec_data_base && vec_data_base->num_chunk() > 0 &&
+                chunk_mutex_.try_lock()) {
+                vec_data_base->clear();
+                chunk_mutex_.unlock();
+            }
         }
     }
 }
@@ -102,7 +99,7 @@ SegmentGrowingImpl::Insert(int64_t reserved_offset,
         AssertInfo(field_id_to_offset.count(field_id),
                    fmt::format("can't find field {}", field_id.get()));
         auto data_offset = field_id_to_offset[field_id];
-        if (!indexing_record_.SyncDataWithIndex(field_id)) {
+        if (!indexing_record_.HasRawData(field_id)) {
             insert_record_.get_data_base(field_id)->set_data_raw(
                 reserved_offset,
                 num_rows,
@@ -242,7 +239,7 @@ SegmentGrowingImpl::LoadFieldData(const LoadFieldDataInfo& infos) {
             continue;
         }
 
-        if (!indexing_record_.SyncDataWithIndex(field_id)) {
+        if (!indexing_record_.HasRawData(field_id)) {
             insert_record_.get_data_base(field_id)->set_data_raw(
                 reserved_offset, field_data);
             if (insert_record_.is_valid_data_exist(field_id)) {
@@ -661,7 +658,7 @@ SegmentGrowingImpl::bulk_subscript_ptr_impl(
     auto& src = *vec;
     for (int64_t i = 0; i < count; ++i) {
         auto offset = seg_offsets[i];
-        if (IsVariableTypeSupportInChunk<S> && mmap_descriptor_ != nullptr) {
+        if (IsVariableTypeSupportInChunk<S> && src.is_mmap()) {
             dst->at(i) = std::move(T(src.view_element(offset)));
         } else {
             dst->at(i) = std::move(T(src[offset]));
@@ -687,7 +684,7 @@ SegmentGrowingImpl::bulk_subscript_impl(FieldId field_id,
 
     // if index has finished building, grab from index without any
     // synchronization operations.
-    if (indexing_record_.SyncDataWithIndex(field_id)) {
+    if (indexing_record_.HasRawData(field_id)) {
         indexing_record_.GetDataFromIndex(
             field_id, seg_offsets, count, element_sizeof, output_raw);
         return;
@@ -698,7 +695,7 @@ SegmentGrowingImpl::bulk_subscript_impl(FieldId field_id,
         // after the above check but before we grabbed the lock, we should grab
         // from index as the data in chunk may have been removed in
         // try_remove_chunks.
-        if (!indexing_record_.SyncDataWithIndex(field_id)) {
+        if (!indexing_record_.HasRawData(field_id)) {
             auto output_base = reinterpret_cast<char*>(output_raw);
             for (int i = 0; i < count; ++i) {
                 auto dst = output_base + i * element_sizeof;

--- a/internal/core/src/segcore/SegmentGrowingImpl.h
+++ b/internal/core/src/segcore/SegmentGrowingImpl.h
@@ -236,28 +236,21 @@ class SegmentGrowingImpl : public SegmentGrowing {
                                 IndexMetaPtr indexMeta,
                                 const SegcoreConfig& segcore_config,
                                 int64_t segment_id)
-        : mmap_descriptor_(storage::MmapManager::GetInstance()
-                                   .GetMmapConfig()
-                                   .GetEnableGrowingMmap()
-                               ? storage::MmapChunkDescriptorPtr(
-                                     new storage::MmapChunkDescriptor(
-                                         {segment_id, SegmentType::Growing}))
-                               : nullptr),
+        : mmap_descriptor_(
+              storage::MmapChunkDescriptorPtr(new storage::MmapChunkDescriptor(
+                  {segment_id, SegmentType::Growing}))),
           segcore_config_(segcore_config),
           schema_(std::move(schema)),
           index_meta_(indexMeta),
           insert_record_(
               *schema_, segcore_config.get_chunk_rows(), mmap_descriptor_),
-          indexing_record_(*schema_, index_meta_, segcore_config_),
+          indexing_record_(
+              *schema_, index_meta_, segcore_config_, &insert_record_),
           id_(segment_id),
           deleted_record_(&insert_record_, this) {
-        if (mmap_descriptor_ != nullptr) {
-            LOG_INFO("growing segment {} use mmap to hold raw data",
-                     this->get_segment_id());
-            auto mcm =
-                storage::MmapManager::GetInstance().GetMmapChunkManager();
-            mcm->Register(mmap_descriptor_);
-        }
+        auto mcm = storage::MmapManager::GetInstance().GetMmapChunkManager();
+        mcm->Register(mmap_descriptor_);
+
         this->CreateTextIndexes();
     }
 
@@ -314,9 +307,18 @@ class SegmentGrowingImpl : public SegmentGrowing {
         //growing index hold raw data when
         // 1. growing index enabled and it holds raw data
         // 2. growing index disabled then raw data held by chunk
+        // 3. growing index enabled and it not holds raw data, then raw data held by chunk
         if (indexing_record_.is_in(FieldId(field_id))) {
-            return indexing_record_.HasRawData(FieldId(field_id));
+            if (indexing_record_.HasRawData(FieldId(field_id))) {
+                // 1. growing index enabled and it holds raw data
+                return true;
+            } else {
+                // 3. growing index enabled and it not holds raw data, then raw data held by chunk
+                return insert_record_.get_data_base(FieldId(field_id))
+                           ->num_chunk() > 0;
+            }
         }
+        // 2. growing index disabled then raw data held by chunk
         return true;
     }
 
@@ -392,13 +394,13 @@ class SegmentGrowingImpl : public SegmentGrowing {
     SchemaPtr schema_;
     IndexMetaPtr index_meta_;
 
-    // small indexes for every chunk
-    IndexingRecord indexing_record_;
-
     // inserted fields data and row_ids, timestamps
     InsertRecord<false> insert_record_;
 
     mutable std::shared_mutex chunk_mutex_;
+
+    // small indexes for every chunk
+    IndexingRecord indexing_record_;
 
     // deleted pks
     mutable DeletedRecord<false> deleted_record_;

--- a/internal/core/src/segcore/SegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/SegmentSealedImpl.cpp
@@ -149,7 +149,8 @@ SegmentSealedImpl::LoadVecIndex(const LoadIndexInfo& info) {
     if (get_bit(field_data_ready_bitset_, field_id)) {
         fields_.erase(field_id);
         set_bit(field_data_ready_bitset_, field_id, false);
-    } else if (get_bit(binlog_index_bitset_, field_id)) {
+    }
+    if (get_bit(binlog_index_bitset_, field_id)) {
         set_bit(binlog_index_bitset_, field_id, false);
         vector_indexings_.drop_field_indexing(field_id);
     }
@@ -169,8 +170,7 @@ SegmentSealedImpl::WarmupChunkCache(const FieldId field_id, bool mmap_enabled) {
     auto& field_meta = schema_->operator[](field_id);
     AssertInfo(field_meta.is_vector(), "vector field is not vector type");
 
-    if (!get_bit(index_ready_bitset_, field_id) &&
-        !get_bit(binlog_index_bitset_, field_id)) {
+    if (!get_bit(index_ready_bitset_, field_id)) {
         return;
     }
 
@@ -511,21 +511,13 @@ SegmentSealedImpl::LoadFieldData(FieldId field_id, FieldDataInfo& data) {
             }
         }
 
-        bool use_temp_index = false;
         {
-            // update num_rows to build temperate binlog index
+            // update num_rows to build temperate intermin index
             std::unique_lock lck(mutex_);
             update_row_count(num_rows);
         }
 
-        if (generate_interim_index(field_id)) {
-            std::unique_lock lck(mutex_);
-            fields_.erase(field_id);
-            set_bit(field_data_ready_bitset_, field_id, false);
-            use_temp_index = true;
-        }
-
-        if (!use_temp_index) {
+        if (!generate_interim_index(field_id)) {
             std::unique_lock lck(mutex_);
             set_bit(field_data_ready_bitset_, field_id, true);
         }
@@ -645,16 +637,7 @@ SegmentSealedImpl::MapFieldData(const FieldId field_id, FieldDataInfo& data) {
         insert_record_.seal_pks();
     }
 
-    bool use_interim_index = false;
-    if (generate_interim_index(field_id)) {
-        std::unique_lock lck(mutex_);
-        // mmap_fields is useless, no change
-        fields_.erase(field_id);
-        set_bit(field_data_ready_bitset_, field_id, false);
-        use_interim_index = true;
-    }
-
-    if (!use_interim_index) {
+    if (!generate_interim_index(field_id)) {
         std::unique_lock lck(mutex_);
         set_bit(field_data_ready_bitset_, field_id, true);
     }
@@ -1569,8 +1552,12 @@ SegmentSealedImpl::bulk_subscript(FieldId field_id,
     if (count == 0) {
         return fill_with_empty(field_id, count);
     }
-
-    if (HasIndex(field_id)) {
+    AssertInfo(HasFieldData(field_id) || HasIndex(field_id),
+               "Not found raw data in index or field data struct.");
+    if (HasFieldData(field_id)) {
+        Assert(get_bit(field_data_ready_bitset_, field_id));
+        return get_raw_data(field_id, field_meta, seg_offsets, count);
+    } else {
         // if field has load scalar index, reverse raw data from index
         if (!IsVectorDataType(field_meta.get_data_type())) {
             AssertInfo(num_chunk(field_id) == 1,
@@ -1584,10 +1571,6 @@ SegmentSealedImpl::bulk_subscript(FieldId field_id,
         }
         return get_vector(field_id, seg_offsets, count);
     }
-
-    Assert(get_bit(field_data_ready_bitset_, field_id));
-
-    return get_raw_data(field_id, field_meta, seg_offsets, count);
 }
 
 std::unique_ptr<DataArray>
@@ -1649,14 +1632,21 @@ SegmentSealedImpl::HasRawData(int64_t field_id) const {
     auto fieldID = FieldId(field_id);
     const auto& field_meta = schema_->operator[](fieldID);
     if (IsVectorDataType(field_meta.get_data_type())) {
-        if (get_bit(index_ready_bitset_, fieldID) |
-            get_bit(binlog_index_bitset_, fieldID)) {
+        if (get_bit(index_ready_bitset_, fieldID)) {
             AssertInfo(vector_indexings_.is_ready(fieldID),
                        "vector index is not ready");
             auto field_indexing = vector_indexings_.get_field_indexing(fieldID);
             auto vec_index = dynamic_cast<index::VectorIndex*>(
                 field_indexing->indexing_.get());
             return vec_index->HasRawData();
+        } else if (get_bit(binlog_index_bitset_, fieldID)) {
+            AssertInfo(vector_indexings_.is_ready(fieldID),
+                       "vector index is not ready");
+            auto field_indexing = vector_indexings_.get_field_indexing(fieldID);
+            auto vec_index = dynamic_cast<index::VectorIndex*>(
+                field_indexing->indexing_.get());
+            return vec_index->HasRawData() ||
+                   get_bit(field_data_ready_bitset_, fieldID);
         }
     } else {
         auto scalar_index = scalar_indexings_.find(fieldID);
@@ -1876,8 +1866,9 @@ SegmentSealedImpl::generate_interim_index(const FieldId field_id) {
             return false;
         }
         // check data type
-        // TODO: QianYa when add other data type, please check the SupportInterimIndexDataType method in the go code
         if (field_meta.get_data_type() != DataType::VECTOR_FLOAT &&
+            field_meta.get_data_type() != DataType::VECTOR_FLOAT16 &&
+            field_meta.get_data_type() != DataType::VECTOR_BFLOAT16 &&
             !is_sparse) {
             return false;
         }
@@ -1935,27 +1926,86 @@ SegmentSealedImpl::generate_interim_index(const FieldId field_id) {
         dataset->SetIsOwner(false);
         dataset->SetIsSparse(is_sparse);
 
-        index::IndexBasePtr vec_index =
-            std::make_unique<index::VectorMemIndex<float>>(
+        index::IndexBasePtr vec_index = nullptr;
+        if (!is_sparse) {
+            size_t data_size;
+            if (field_meta.get_data_type() == DataType::VECTOR_FLOAT) {
+                data_size = dim * sizeof(knowhere::fp32);
+                knowhere::ViewDataOp view_data = [field_raw_data_ptr = vec_data,
+                                                  data_size =
+                                                      data_size](size_t id) {
+                    return ((const char*)field_raw_data_ptr->Data() +
+                            data_size * id);
+                };
+                vec_index = std::make_unique<index::VectorMemIndex<float>>(
+                    field_binlog_config->GetIndexType(),
+                    index_metric,
+                    knowhere::Version::GetCurrentVersion().VersionNumber(),
+                    view_data);
+            } else if (field_meta.get_data_type() == DataType::VECTOR_FLOAT16) {
+                data_size = dim * sizeof(knowhere::fp16);
+                knowhere::ViewDataOp view_data = [field_raw_data_ptr = vec_data,
+                                                  data_size =
+                                                      data_size](size_t id) {
+                    return ((const char*)field_raw_data_ptr->Data() +
+                            data_size * id);
+                };
+                vec_index =
+                    std::make_unique<index::VectorMemIndex<knowhere::fp16>>(
+                        field_binlog_config->GetIndexType(),
+                        index_metric,
+                        knowhere::Version::GetCurrentVersion().VersionNumber(),
+                        view_data);
+            } else if (field_meta.get_data_type() ==
+                       DataType::VECTOR_BFLOAT16) {
+                data_size = dim * sizeof(knowhere::bf16);
+                knowhere::ViewDataOp view_data = [field_raw_data_ptr = vec_data,
+                                                  data_size =
+                                                      data_size](size_t id) {
+                    return ((const char*)field_raw_data_ptr->Data() +
+                            data_size * id);
+                };
+                vec_index =
+                    std::make_unique<index::VectorMemIndex<knowhere::bf16>>(
+                        field_binlog_config->GetIndexType(),
+                        index_metric,
+                        knowhere::Version::GetCurrentVersion().VersionNumber(),
+                        view_data);
+            }
+        } else {
+            vec_index = std::make_unique<index::VectorMemIndex<float>>(
                 field_binlog_config->GetIndexType(),
                 index_metric,
                 knowhere::Version::GetCurrentVersion().VersionNumber());
+        }
+        if (vec_index == nullptr) {
+            LOG_INFO("fail to generate intermin index, invalid data type.");
+            return false;
+        }
         vec_index->BuildWithDataset(dataset, build_config);
         if (enable_binlog_index()) {
             std::unique_lock lck(mutex_);
+            if (vec_index->HasRawData()) {
+                // some knowhere view data index not has raw data, still keep it
+                fields_.erase(field_id);
+                set_bit(field_data_ready_bitset_, field_id, false);
+            } else {
+                set_bit(field_data_ready_bitset_, field_id, true);
+            }
+
             vector_indexings_.append_field_indexing(
                 field_id, index_metric, std::move(vec_index));
 
             vec_binlog_config_[field_id] = std::move(field_binlog_config);
             set_bit(binlog_index_bitset_, field_id, true);
             LOG_INFO(
-                "replace binlog with binlog index in segment {}, field {}.",
+                "replace binlog with intermin index in segment {}, field {}.",
                 this->get_segment_id(),
                 field_id.get());
         }
         return true;
     } catch (std::exception& e) {
-        LOG_WARN("fail to generate binlog index, because {}", e.what());
+        LOG_WARN("fail to generate intermin index, because {}", e.what());
         return false;
     }
 }

--- a/internal/core/src/segcore/segcore_init_c.cpp
+++ b/internal/core/src/segcore/segcore_init_c.cpp
@@ -34,7 +34,7 @@ SegcoreSetChunkRows(const int64_t value) {
 }
 
 extern "C" void
-SegcoreSetEnableTempSegmentIndex(const bool value) {
+SegcoreSetEnableInterminSegmentIndex(const bool value) {
     milvus::segcore::SegcoreConfig& config =
         milvus::segcore::SegcoreConfig::default_config();
     config.set_enable_interim_segment_index(value);
@@ -52,6 +52,35 @@ SegcoreSetNprobe(const int64_t value) {
     milvus::segcore::SegcoreConfig& config =
         milvus::segcore::SegcoreConfig::default_config();
     config.set_nprobe(value);
+}
+
+extern "C" CStatus
+SegcoreSetDenseVectorInterminIndexType(const char* value) {
+    milvus::segcore::SegcoreConfig& config =
+        milvus::segcore::SegcoreConfig::default_config();
+    try {
+        config.set_dense_vector_intermin_index_type(std::string(value));
+        auto status = CStatus();
+        status.error_code = Success;
+        status.error_msg = "";
+        return status;
+    } catch (std::exception& e) {
+        return milvus::FailureCStatus(&e);
+    }
+}
+
+extern "C" void
+SegcoreSetSubDim(const int64_t value) {
+    milvus::segcore::SegcoreConfig& config =
+        milvus::segcore::SegcoreConfig::default_config();
+    config.set_sub_dim(value);
+}
+
+extern "C" void
+SegcoreSetRefineRatio(const float value) {
+    milvus::segcore::SegcoreConfig& config =
+        milvus::segcore::SegcoreConfig::default_config();
+    config.set_refine_ratio(value);
 }
 
 extern "C" void

--- a/internal/core/src/segcore/segcore_init_c.h
+++ b/internal/core/src/segcore/segcore_init_c.h
@@ -13,6 +13,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "common/type_c.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -25,13 +26,25 @@ void
 SegcoreSetChunkRows(const int64_t);
 
 void
-SegcoreSetEnableTempSegmentIndex(const bool);
+SegcoreSetEnableInterminSegmentIndex(const bool);
 
 void
 SegcoreSetNlist(const int64_t);
 
 void
 SegcoreSetNprobe(const int64_t);
+
+CStatus
+SegcoreSetDenseVectorInterminIndexType(const char*);
+
+void
+SegcoreSetSubDim(const int64_t);
+
+void
+SegcoreSetRefineRatio(const float);
+
+void
+SegcoreInterminDenseIndexType(const char*);
 
 // return value must be freed by the caller
 char*

--- a/internal/core/src/segcore/vector_index_c.cpp
+++ b/internal/core/src/segcore/vector_index_c.cpp
@@ -19,6 +19,7 @@
 #include "index/Meta.h"
 #include "index/IndexFactory.h"
 #include "pb/index_cgo_msg.pb.h"
+#include "segcore/SegcoreConfig.h"
 
 CStatus
 ValidateIndexParams(const char* index_type,

--- a/internal/core/src/storage/Types.h
+++ b/internal/core/src/storage/Types.h
@@ -130,6 +130,9 @@ struct MmapConfig {
     uint64_t fix_file_size;
     bool growing_enable_mmap;
     bool scalar_index_enable_mmap;
+    bool scalar_field_enable_mmap;
+    bool vector_index_enable_mmap;
+    bool vector_field_enable_mmap;
     bool
     GetEnableGrowingMmap() const {
         return growing_enable_mmap;
@@ -146,6 +149,31 @@ struct MmapConfig {
     SetScalarIndexEnableMmap(bool flag) {
         this->scalar_index_enable_mmap = flag;
     }
+    bool
+    GetScalarFieldEnableMmap() const {
+        return scalar_field_enable_mmap;
+    }
+    void
+    SetScalarFieldEnableMmap(bool flag) {
+        this->scalar_field_enable_mmap = flag;
+    }
+    bool
+    GetVectorIndexEnableMmap() const {
+        return vector_index_enable_mmap;
+    }
+    void
+    SetVectorIndexEnableMmap(bool flag) {
+        this->vector_index_enable_mmap = flag;
+    }
+    bool
+    GetVectorFieldEnableMmap() const {
+        return vector_field_enable_mmap;
+    }
+    void
+    SetVectorFieldEnableMmap(bool flag) {
+        this->vector_field_enable_mmap = flag;
+    }
+
     std::string
     GetMmapPath() {
         return mmap_path;
@@ -159,7 +187,13 @@ struct MmapConfig {
            << ", fix_file_size=" << fix_file_size / (1024 * 1024) << "MB"
            << ", growing_enable_mmap=" << std::boolalpha << growing_enable_mmap
            << ", scalar_index_enable_mmap=" << std::boolalpha
-           << scalar_index_enable_mmap << "]";
+           << scalar_index_enable_mmap
+           << ", scalar_field_enable_mmap=" << std::boolalpha
+           << scalar_field_enable_mmap
+           << ", vector_index_enable_mmap=" << std::boolalpha
+           << vector_index_enable_mmap
+           << ", vector_field_enable_mmap=" << std::boolalpha
+           << vector_field_enable_mmap << "]";
         return ss.str();
     }
 };

--- a/internal/core/src/storage/storage_c.cpp
+++ b/internal/core/src/storage/storage_c.cpp
@@ -99,6 +99,12 @@ InitMmapManager(CMmapConfig c_mmap_config) {
         mmap_config.growing_enable_mmap = c_mmap_config.growing_enable_mmap;
         mmap_config.scalar_index_enable_mmap =
             c_mmap_config.scalar_index_enable_mmap;
+        mmap_config.scalar_field_enable_mmap =
+            c_mmap_config.scalar_field_enable_mmap;
+        mmap_config.vector_index_enable_mmap =
+            c_mmap_config.vector_index_enable_mmap;
+        mmap_config.vector_field_enable_mmap =
+            c_mmap_config.vector_field_enable_mmap;
         milvus::storage::MmapManager::GetInstance().Init(mmap_config);
         return milvus::SuccessCStatus();
     } catch (std::exception& e) {

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -243,10 +243,10 @@ func (s *baseSegment) ResourceUsageEstimate() ResourceUsage {
 	}
 
 	usage, err := getResourceUsageEstimateOfSegment(s.collection.Schema(), s.LoadInfo(), resourceEstimateFactor{
-		memoryUsageFactor:        1.0,
-		memoryIndexUsageFactor:   1.0,
-		enableTempSegmentIndex:   false,
-		deltaDataExpansionFactor: paramtable.Get().QueryNodeCfg.DeltaDataExpansionRate.GetAsFloat(),
+		memoryUsageFactor:          1.0,
+		memoryIndexUsageFactor:     1.0,
+		EnableInterminSegmentIndex: false,
+		deltaDataExpansionFactor:   paramtable.Get().QueryNodeCfg.DeltaDataExpansionRate.GetAsFloat(),
 	})
 	if err != nil {
 		// Should never failure, if failed, segment should never be loaded.

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -139,11 +139,11 @@ func (r *LoadResource) IsZero() bool {
 }
 
 type resourceEstimateFactor struct {
-	memoryUsageFactor        float64
-	memoryIndexUsageFactor   float64
-	enableTempSegmentIndex   bool
-	tempSegmentIndexFactor   float64
-	deltaDataExpansionFactor float64
+	memoryUsageFactor          float64
+	memoryIndexUsageFactor     float64
+	EnableInterminSegmentIndex bool
+	tempSegmentIndexFactor     float64
+	deltaDataExpansionFactor   float64
 }
 
 func NewLoader(
@@ -1376,11 +1376,11 @@ func (loader *segmentLoader) checkSegmentSize(ctx context.Context, segmentLoadIn
 	diskUsage := uint64(localDiskUsage) + loader.committedResource.DiskSize
 
 	factor := resourceEstimateFactor{
-		memoryUsageFactor:        paramtable.Get().QueryNodeCfg.LoadMemoryUsageFactor.GetAsFloat(),
-		memoryIndexUsageFactor:   paramtable.Get().QueryNodeCfg.MemoryIndexLoadPredictMemoryUsageFactor.GetAsFloat(),
-		enableTempSegmentIndex:   paramtable.Get().QueryNodeCfg.EnableTempSegmentIndex.GetAsBool(),
-		tempSegmentIndexFactor:   paramtable.Get().QueryNodeCfg.InterimIndexMemExpandRate.GetAsFloat(),
-		deltaDataExpansionFactor: paramtable.Get().QueryNodeCfg.DeltaDataExpansionRate.GetAsFloat(),
+		memoryUsageFactor:          paramtable.Get().QueryNodeCfg.LoadMemoryUsageFactor.GetAsFloat(),
+		memoryIndexUsageFactor:     paramtable.Get().QueryNodeCfg.MemoryIndexLoadPredictMemoryUsageFactor.GetAsFloat(),
+		EnableInterminSegmentIndex: paramtable.Get().QueryNodeCfg.EnableInterminSegmentIndex.GetAsBool(),
+		tempSegmentIndexFactor:     paramtable.Get().QueryNodeCfg.InterimIndexMemExpandRate.GetAsFloat(),
+		deltaDataExpansionFactor:   paramtable.Get().QueryNodeCfg.DeltaDataExpansionRate.GetAsFloat(),
 	}
 	maxSegmentSize := uint64(0)
 	predictMemUsage := memUsage
@@ -1520,7 +1520,7 @@ func getResourceUsageEstimateOfSegment(schema *schemapb.CollectionSchema, loadIn
 		} else {
 			shouldCalculateDataSize = true
 			// querynode will generate a (memory type) intermin index for vector type
-			interimIndexEnable := multiplyFactor.enableTempSegmentIndex && !isGrowingMmapEnable() && SupportInterimIndexDataType(fieldSchema.GetDataType())
+			interimIndexEnable := multiplyFactor.EnableInterminSegmentIndex && !isGrowingMmapEnable() && SupportInterimIndexDataType(fieldSchema.GetDataType())
 			if interimIndexEnable {
 				segmentMemorySize += uint64(float64(binlogSize) * multiplyFactor.tempSegmentIndexFactor)
 			}
@@ -1584,7 +1584,9 @@ func DoubleMemorySystemField(fieldID int64) bool {
 
 func SupportInterimIndexDataType(dataType schemapb.DataType) bool {
 	return dataType == schemapb.DataType_FloatVector ||
-		dataType == schemapb.DataType_SparseFloatVector
+		dataType == schemapb.DataType_SparseFloatVector ||
+		dataType == schemapb.DataType_Float16Vector ||
+		dataType == schemapb.DataType_BFloat16Vector
 }
 
 func (loader *segmentLoader) getFieldType(collectionID, fieldID int64) (schemapb.DataType, error) {

--- a/internal/querynodev2/server.go
+++ b/internal/querynodev2/server.go
@@ -197,15 +197,6 @@ func (node *QueryNode) InitSegcore() error {
 	cKnowhereThreadPoolSize := C.uint32_t(paramtable.Get().QueryNodeCfg.KnowhereThreadPoolSize.GetAsUint32())
 	C.SegcoreSetKnowhereSearchThreadPoolNum(cKnowhereThreadPoolSize)
 
-	enableGrowingIndex := C.bool(paramtable.Get().QueryNodeCfg.EnableTempSegmentIndex.GetAsBool())
-	C.SegcoreSetEnableTempSegmentIndex(enableGrowingIndex)
-
-	nlist := C.int64_t(paramtable.Get().QueryNodeCfg.InterimIndexNlist.GetAsInt64())
-	C.SegcoreSetNlist(nlist)
-
-	nprobe := C.int64_t(paramtable.Get().QueryNodeCfg.InterimIndexNProbe.GetAsInt64())
-	C.SegcoreSetNprobe(nprobe)
-
 	// override segcore SIMD type
 	cSimdType := C.CString(paramtable.Get().CommonCfg.SimdType.GetValue())
 	C.SegcoreSetSimdType(cSimdType)
@@ -255,6 +246,11 @@ func (node *QueryNode) InitSegcore() error {
 	}
 
 	err = initcore.InitMmapManager(paramtable.Get())
+	if err != nil {
+		return err
+	}
+
+	err = initcore.InitInterminIndexConfig(paramtable.Get())
 	if err != nil {
 		return err
 	}

--- a/internal/util/initcore/init_core.go
+++ b/internal/util/initcore/init_core.go
@@ -190,9 +190,34 @@ func InitMmapManager(params *paramtable.ComponentParam) error {
 		fix_file_size:            C.uint64_t(mmapFileSize),
 		growing_enable_mmap:      C.bool(params.QueryNodeCfg.GrowingMmapEnabled.GetAsBool()),
 		scalar_index_enable_mmap: C.bool(params.QueryNodeCfg.MmapScalarIndex.GetAsBool()),
+		scalar_field_enable_mmap: C.bool(params.QueryNodeCfg.MmapScalarField.GetAsBool()),
+		vector_index_enable_mmap: C.bool(params.QueryNodeCfg.MmapVectorIndex.GetAsBool()),
+		vector_field_enable_mmap: C.bool(params.QueryNodeCfg.MmapVectorField.GetAsBool()),
 	}
 	status := C.InitMmapManager(mmapConfig)
 	return HandleCStatus(&status, "InitMmapManager failed")
+}
+
+func InitInterminIndexConfig(params *paramtable.ComponentParam) error {
+	enableInterminIndex := C.bool(params.QueryNodeCfg.EnableInterminSegmentIndex.GetAsBool())
+	C.SegcoreSetEnableInterminSegmentIndex(enableInterminIndex)
+
+	nlist := C.int64_t(params.QueryNodeCfg.InterimIndexNlist.GetAsInt64())
+	C.SegcoreSetNlist(nlist)
+
+	nprobe := C.int64_t(params.QueryNodeCfg.InterimIndexNProbe.GetAsInt64())
+	C.SegcoreSetNprobe(nprobe)
+
+	subDim := C.int64_t(params.QueryNodeCfg.InterimIndexSubDim.GetAsInt64())
+	C.SegcoreSetSubDim(subDim)
+
+	refineRatio := C.float(params.QueryNodeCfg.InterimIndexRefineRatio.GetAsFloat())
+	C.SegcoreSetRefineRatio(refineRatio)
+
+	denseVecIndexType := C.CString(params.QueryNodeCfg.DenseVectorInterminIndexType.GetValue())
+	defer C.free(unsafe.Pointer(denseVecIndexType))
+	status := C.SegcoreSetDenseVectorInterminIndexType(denseVecIndexType)
+	return HandleCStatus(&status, "InitInterminIndexConfig failed")
 }
 
 func CleanRemoteChunkManager() {

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -420,11 +420,11 @@ func TestComponentParam(t *testing.T) {
 		chunkRows = Params.ChunkRows.GetAsInt64()
 		assert.Equal(t, int64(8192), chunkRows)
 
-		enableInterimIndex := Params.EnableTempSegmentIndex.GetAsBool()
+		enableInterimIndex := Params.EnableInterminSegmentIndex.GetAsBool()
 		assert.Equal(t, true, enableInterimIndex)
 
 		params.Save("queryNode.segcore.interimIndex.enableIndex", "true")
-		enableInterimIndex = Params.EnableTempSegmentIndex.GetAsBool()
+		enableInterimIndex = Params.EnableInterminSegmentIndex.GetAsBool()
 		assert.Equal(t, true, enableInterimIndex)
 
 		assert.Equal(t, false, Params.KnowhereScoreConsistency.GetAsBool())


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/27678
related: https://github.com/milvus-io/milvus/pull/39753
some raw data status will change:
Intermin index has raw data: 
<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:////Users/cqy/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip.htm">
<link rel=File-List
href="file:////Users/cqy/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip_filelist.xml">
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
.font5
	{color:windowtext;
	font-size:9.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:等线;
	mso-generic-font-family:auto;
	mso-font-charset:134;}
tr
	{mso-height-source:auto;
	mso-ruby-visibility:none;}
col
	{mso-width-source:auto;
	mso-ruby-visibility:none;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:12.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:等线;
	mso-generic-font-family:auto;
	mso-font-charset:134;
	mso-number-format:General;
	text-align:general;
	vertical-align:middle;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
ruby
	{ruby-align:left;}
rt
	{color:windowtext;
	font-size:9.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:等线;
	mso-generic-font-family:auto;
	mso-font-charset:134;
	mso-char-type:none;
	display:none;}
-->
</head>

<body link="#0563C1" vlink="#954F72">


sparse vector | growing segment | sealed segment
-- | -- | --
BM25 | no | no
IP | yes | no
  |   |  
dense vector | growing segment | sealed segment
ivf flat cc | yes | yes
scann_dvr | no | no



</body>

</html>
