### PR TITLE
enhance: Utilize "find0" in segment.find_first

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -1255,12 +1255,8 @@ ChunkedSegmentSealedImpl::find_first(int64_t limit,
     std::vector<int64_t> seg_offsets;
     seg_offsets.reserve(limit);
 
-    // flip bitset since `find_next` is used to find true.
-    auto flipped = bitset.clone();
-    flipped.flip();
-
     int64_t offset = 0;
-    std::optional<size_t> result = flipped.find_first();
+    std::optional<size_t> result = bitset.find_first(false);
     while (result.has_value() && hit_num < limit) {
         hit_num++;
         seg_offsets.push_back(result.value());
@@ -1269,7 +1265,7 @@ ChunkedSegmentSealedImpl::find_first(int64_t limit,
             // In fact, this case won't happen on sealed segments.
             continue;
         }
-        result = flipped.find_next(offset);
+        result = bitset.find_next(offset, false);
     }
 
     return {seg_offsets, more_hit_than_limit && result.has_value()};

--- a/internal/core/src/segcore/SegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/SegmentSealedImpl.cpp
@@ -1719,13 +1719,8 @@ SegmentSealedImpl::find_first(int64_t limit, const BitsetType& bitset) const {
     std::vector<int64_t> seg_offsets;
     seg_offsets.reserve(limit);
 
-    // flip bitset since `find_first` & `find_next` is used to find true.
-    // could be optimized by support find false in bitset.
-    auto flipped = bitset.clone();
-    flipped.flip();
-
     int64_t offset = 0;
-    std::optional<size_t> result = flipped.find_first();
+    std::optional<size_t> result = bitset.find_first(false);
     while (result.has_value() && hit_num < limit) {
         hit_num++;
         seg_offsets.push_back(result.value());
@@ -1734,7 +1729,7 @@ SegmentSealedImpl::find_first(int64_t limit, const BitsetType& bitset) const {
             // In fact, this case won't happen on sealed segments.
             continue;
         }
-        result = flipped.find_next(offset);
+        result = bitset.find_next(offset, false);
     }
 
     return {seg_offsets, more_hit_than_limit && result.has_value()};


### PR DESCRIPTION
Related to #39003

Previous PR #39004 has to clone & flip bitset due to bitset does not support find0 operator. #39176 added this feature so clone & flip could be removed now.