### PR TITLE
fix: Compaction L0 segments in strict order

### DIFF
--- a/internal/datacoord/compaction.go
+++ b/internal/datacoord/compaction.go
@@ -261,7 +261,8 @@ func (c *compactionPlanHandler) schedule() []CompactionTask {
 
 		switch t.GetType() {
 		case datapb.CompactionType_Level0DeleteCompaction:
-			if mixChannelExcludes.Contain(t.GetChannel()) ||
+			if l0ChannelExcludes.Contain(t.GetChannel()) ||
+				mixChannelExcludes.Contain(t.GetChannel()) ||
 				clusterChannelExcludes.Contain(t.GetChannel()) {
 				excluded = append(excluded, t)
 				continue

--- a/internal/datacoord/compaction_l0_view.go
+++ b/internal/datacoord/compaction_l0_view.go
@@ -2,6 +2,7 @@ package datacoord
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/samber/lo"
 
@@ -80,6 +81,11 @@ func (v *LevelZeroSegmentsView) ForceTrigger() (CompactionView, string) {
 		return view.dmlPos.GetTimestamp() < v.earliestGrowingSegmentPos.GetTimestamp()
 	})
 
+	// Sort segments by dmlPosition
+	sort.Slice(validSegments, func(i, j int) bool {
+		return validSegments[i].dmlPos.GetTimestamp() < validSegments[j].dmlPos.GetTimestamp()
+	})
+
 	targetViews, reason := v.forceTrigger(validSegments)
 	if len(targetViews) > 0 {
 		return &LevelZeroSegmentsView{
@@ -97,6 +103,10 @@ func (v *LevelZeroSegmentsView) Trigger() (CompactionView, string) {
 	// Only choose segments with position less than the earliest growing segment position
 	validSegments := lo.Filter(v.segments, func(view *SegmentView, _ int) bool {
 		return view.dmlPos.GetTimestamp() < v.earliestGrowingSegmentPos.GetTimestamp()
+	})
+	// Sort segments by dmlPosition
+	sort.Slice(validSegments, func(i, j int) bool {
+		return validSegments[i].dmlPos.GetTimestamp() < validSegments[j].dmlPos.GetTimestamp()
 	})
 
 	targetViews, reason := v.minCountSizeTrigger(validSegments)

--- a/internal/datacoord/compaction_l0_view_test.go
+++ b/internal/datacoord/compaction_l0_view_test.go
@@ -118,28 +118,28 @@ func (s *LevelZeroSegmentsViewSuite) TestTrigger() {
 			8 * 1024 * 1024,
 			1,
 			30000,
-			[]UniqueID{100, 101},
+			[]UniqueID{101, 100},
 		},
 		{
 			"Trigger by > TriggerDeltaCount",
 			1,
 			10,
 			30000,
-			[]UniqueID{100, 101},
+			[]UniqueID{101, 100},
 		},
 		{
 			"Trigger by > maxDeltaSize",
 			128 * 1024 * 1024,
 			1,
 			30000,
-			[]UniqueID{100},
+			[]UniqueID{101},
 		},
 		{
 			"Trigger by > maxDeltaCount",
 			1,
 			24,
 			30000,
-			[]UniqueID{100},
+			[]UniqueID{101},
 		},
 	}
 
@@ -166,7 +166,7 @@ func (s *LevelZeroSegmentsViewSuite) TestTrigger() {
 				gotSegIDs := lo.Map(levelZeroView.GetSegmentsView(), func(v *SegmentView, _ int) int64 {
 					return v.ID
 				})
-				s.ElementsMatch(gotSegIDs, test.expectedSegs)
+				s.Equal(gotSegIDs, test.expectedSegs)
 				log.Info("output view", zap.String("view", levelZeroView.String()), zap.String("trigger reason", reason))
 			}
 		})

--- a/internal/datacoord/compaction_test.go
+++ b/internal/datacoord/compaction_test.go
@@ -396,44 +396,6 @@ func (s *CompactionPlanHandlerSuite) TestScheduleNodeWithL0Executing() {
 				meta:     s.mockMeta,
 			},
 		}, []UniqueID{10, 13}},
-		{"with multiple L0 tasks same channel", []CompactionTask{
-			&l0CompactionTask{
-				CompactionTask: &datapb.CompactionTask{
-					PlanID:  10,
-					Type:    datapb.CompactionType_Level0DeleteCompaction,
-					State:   datapb.CompactionTaskState_pipelining,
-					Channel: "ch-11",
-					NodeID:  102,
-				},
-				plan:     &datapb.CompactionPlan{PlanID: 10, Channel: "ch-3", Type: datapb.CompactionType_Level0DeleteCompaction},
-				sessions: s.mockSessMgr,
-				meta:     s.mockMeta,
-			},
-			&l0CompactionTask{
-				CompactionTask: &datapb.CompactionTask{
-					PlanID:  11,
-					Type:    datapb.CompactionType_Level0DeleteCompaction,
-					State:   datapb.CompactionTaskState_pipelining,
-					Channel: "ch-11",
-					NodeID:  102,
-				},
-				plan:     &datapb.CompactionPlan{PlanID: 11, Channel: "ch-3", Type: datapb.CompactionType_Level0DeleteCompaction},
-				sessions: s.mockSessMgr,
-				meta:     s.mockMeta,
-			},
-			&l0CompactionTask{
-				CompactionTask: &datapb.CompactionTask{
-					PlanID:  12,
-					Type:    datapb.CompactionType_Level0DeleteCompaction,
-					State:   datapb.CompactionTaskState_pipelining,
-					Channel: "ch-11",
-					NodeID:  102,
-				},
-				plan:     &datapb.CompactionPlan{PlanID: 12, Channel: "ch-3", Type: datapb.CompactionType_Level0DeleteCompaction},
-				sessions: s.mockSessMgr,
-				meta:     s.mockMeta,
-			},
-		}, []UniqueID{10, 11, 12}},
 		{"without L0 tasks", []CompactionTask{
 			&mixCompactionTask{
 				CompactionTask: &datapb.CompactionTask{


### PR DESCRIPTION
Deletes in QueryNode relies on strict time order of delete entities. Any misorder of deltalogs will result in missing deletes on loaded segments

Previously, L0 compaction triggers, chooses, schedules L0 segments and L0 compactions randomly. This PR makes sure L0 segments are compacted according to their position time.

1. Revert concurrent L0 compaction on one channel Revert "enhance: enable parallel execution of L0 compactions (#36816) (#36985)"

2. Add secondury prioritizer that smaller planID has higher priority

3. Sort segments by dmlPosition when triggering L0 compaction

See also: #39231