### PR TITLE
enhance: [2.4] Unify LoadStateLock RLock & PinIf (#39206)

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -836,6 +836,7 @@ common:
     threshold:
       info: 500 # minimum milliseconds for printing durations in info level
       warn: 1000 # minimum milliseconds for printing durations in warn level
+    maxWLockConditionalWaitTime: 600 # maximum seconds for waiting wlock conditional
   storage:
     scheme: s3
     enablev2: false

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -1507,19 +1507,12 @@ func (s *LocalSegment) WarmupChunkCache(ctx context.Context, fieldID int64, mmap
 			return nil, nil
 		}).Await()
 	case "async":
-<<<<<<< HEAD
 		GetWarmupPool().Submit(func() (any, error) {
-			// bad implemtation, warmup is async at another goroutine and hold the rlock.
-			// the state transition of segment in segment loader will blocked.
-			// add a waiter to avoid it.
-			s.ptrLock.BlockUntilDataLoadedOrReleased()
-=======
-		task := func() (any, error) {
 			// failed to wait for state update, return directly
 			if !s.ptrLock.BlockUntilDataLoadedOrReleased() {
 				return nil, nil
 			}
->>>>>>> 3408d2f261 (enhance: Log error instead of panicking if load lock wait timeout)
+
 			if s.PinIfNotReleased() != nil {
 				return nil, nil
 			}

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -608,6 +608,7 @@ func (s *LocalSegment) Retrieve(ctx context.Context, plan *RetrievePlan) (*segco
 	if !s.ptrLock.PinIf(state.IsNotReleased) {
 		return nil, merr.WrapErrSegmentNotLoaded(s.ID(), "segment released")
 	}
+	defer s.ptrLock.Unpin()
 
 	log := log.Ctx(ctx).With(
 		zap.Int64("collectionID", s.Collection()),

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -1507,11 +1507,19 @@ func (s *LocalSegment) WarmupChunkCache(ctx context.Context, fieldID int64, mmap
 			return nil, nil
 		}).Await()
 	case "async":
+<<<<<<< HEAD
 		GetWarmupPool().Submit(func() (any, error) {
 			// bad implemtation, warmup is async at another goroutine and hold the rlock.
 			// the state transition of segment in segment loader will blocked.
 			// add a waiter to avoid it.
 			s.ptrLock.BlockUntilDataLoadedOrReleased()
+=======
+		task := func() (any, error) {
+			// failed to wait for state update, return directly
+			if !s.ptrLock.BlockUntilDataLoadedOrReleased() {
+				return nil, nil
+			}
+>>>>>>> 3408d2f261 (enhance: Log error instead of panicking if load lock wait timeout)
 			if s.PinIfNotReleased() != nil {
 				return nil, nil
 			}

--- a/internal/querynodev2/segments/state/load_state_lock_test.go
+++ b/internal/querynodev2/segments/state/load_state_lock_test.go
@@ -197,12 +197,15 @@ func TestWaitOrPanic(t *testing.T) {
 		defer paramtable.Get().Reset(paramtable.Get().CommonCfg.MaxWLockConditionalWaitTime.Key)
 
 		l := NewLoadStateLock(LoadStateDataLoaded)
+		executed := false
 
 		assert.NotPanics(t, func() {
 			l.waitOrPanic(func(state loadStateEnum) bool {
 				return state == LoadStateDataLoaded
-			}, noop)
+			}, func() { executed = true })
 		})
+
+		assert.True(t, executed)
 	})
 
 	t.Run("timeout_panic", func(t *testing.T) {
@@ -210,12 +213,14 @@ func TestWaitOrPanic(t *testing.T) {
 		defer paramtable.Get().Reset(paramtable.Get().CommonCfg.MaxWLockConditionalWaitTime.Key)
 
 		l := NewLoadStateLock(LoadStateOnlyMeta)
+		executed := false
 
-		assert.Panics(t, func() {
+		assert.NotPanics(t, func() {
 			l.waitOrPanic(func(state loadStateEnum) bool {
 				return state == LoadStateDataLoaded
 			}, noop)
 		})
+		assert.False(t, executed)
 	})
 }
 

--- a/internal/querynodev2/segments/state/load_state_lock_test.go
+++ b/internal/querynodev2/segments/state/load_state_lock_test.go
@@ -6,9 +6,12 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/pkg/util/paramtable"
 )
 
 func TestLoadStateLoadData(t *testing.T) {
+	paramtable.Init()
 	l := NewLoadStateLock(LoadStateOnlyMeta)
 	// Test Load Data, roll back
 	g, err := l.StartLoadData()
@@ -44,6 +47,7 @@ func TestLoadStateLoadData(t *testing.T) {
 }
 
 func TestStartReleaseData(t *testing.T) {
+	paramtable.Init()
 	l := NewLoadStateLock(LoadStateOnlyMeta)
 	// Test Release Data, nothing to do on only meta.
 	g := l.StartReleaseData()
@@ -104,6 +108,7 @@ func TestStartReleaseData(t *testing.T) {
 }
 
 func TestBlockUntilDataLoadedOrReleased(t *testing.T) {
+	paramtable.Init()
 	l := NewLoadStateLock(LoadStateOnlyMeta)
 	ch := make(chan struct{})
 	go func() {
@@ -122,6 +127,7 @@ func TestBlockUntilDataLoadedOrReleased(t *testing.T) {
 }
 
 func TestStartReleaseAll(t *testing.T) {
+	paramtable.Init()
 	l := NewLoadStateLock(LoadStateOnlyMeta)
 	// Test Release All, nothing to do on only meta.
 	g := l.StartReleaseAll()
@@ -183,22 +189,52 @@ func TestStartReleaseAll(t *testing.T) {
 	assert.Equal(t, LoadStateReleased, l.state)
 }
 
-func TestRLock(t *testing.T) {
+func TestWaitOrPanic(t *testing.T) {
+	paramtable.Init()
+
+	t.Run("normal", func(t *testing.T) {
+		paramtable.Get().Save(paramtable.Get().CommonCfg.MaxWLockConditionalWaitTime.Key, "600")
+		defer paramtable.Get().Reset(paramtable.Get().CommonCfg.MaxWLockConditionalWaitTime.Key)
+
+		l := NewLoadStateLock(LoadStateDataLoaded)
+
+		assert.NotPanics(t, func() {
+			l.waitOrPanic(func(state loadStateEnum) bool {
+				return state == LoadStateDataLoaded
+			}, noop)
+		})
+	})
+
+	t.Run("timeout_panic", func(t *testing.T) {
+		paramtable.Get().Save(paramtable.Get().CommonCfg.MaxWLockConditionalWaitTime.Key, "1")
+		defer paramtable.Get().Reset(paramtable.Get().CommonCfg.MaxWLockConditionalWaitTime.Key)
+
+		l := NewLoadStateLock(LoadStateOnlyMeta)
+
+		assert.Panics(t, func() {
+			l.waitOrPanic(func(state loadStateEnum) bool {
+				return state == LoadStateDataLoaded
+			}, noop)
+		})
+	})
+}
+
+func TestPinIf(t *testing.T) {
 	l := NewLoadStateLock(LoadStateOnlyMeta)
-	assert.True(t, l.RLockIf(IsNotReleased))
-	l.RUnlock()
-	assert.False(t, l.RLockIf(IsDataLoaded))
+	assert.True(t, l.PinIf(IsNotReleased))
+	l.Unpin()
+	assert.False(t, l.PinIf(IsDataLoaded))
 
 	l = NewLoadStateLock(LoadStateDataLoaded)
-	assert.True(t, l.RLockIf(IsNotReleased))
-	l.RUnlock()
-	assert.True(t, l.RLockIf(IsDataLoaded))
-	l.RUnlock()
+	assert.True(t, l.PinIf(IsNotReleased))
+	l.Unpin()
+	assert.True(t, l.PinIf(IsDataLoaded))
+	l.Unpin()
 
 	l = NewLoadStateLock(LoadStateOnlyMeta)
 	l.StartReleaseAll().Done(nil)
-	assert.False(t, l.RLockIf(IsNotReleased))
-	assert.False(t, l.RLockIf(IsDataLoaded))
+	assert.False(t, l.PinIf(IsNotReleased))
+	assert.False(t, l.PinIf(IsDataLoaded))
 }
 
 func TestPin(t *testing.T) {

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -237,9 +237,10 @@ type commonConfig struct {
 	MetricsPort ParamItem `refreshable:"false"`
 
 	// lock related params
-	EnableLockMetrics        ParamItem `refreshable:"false"`
-	LockSlowLogInfoThreshold ParamItem `refreshable:"true"`
-	LockSlowLogWarnThreshold ParamItem `refreshable:"true"`
+	EnableLockMetrics           ParamItem `refreshable:"false"`
+	LockSlowLogInfoThreshold    ParamItem `refreshable:"true"`
+	LockSlowLogWarnThreshold    ParamItem `refreshable:"true"`
+	MaxWLockConditionalWaitTime ParamItem `refreshable:"true"`
 
 	StorageScheme             ParamItem `refreshable:"false"`
 	EnableStorageV2           ParamItem `refreshable:"false"`
@@ -745,6 +746,15 @@ like the old password verification when updating the credential`,
 		Export:       true,
 	}
 	p.LockSlowLogWarnThreshold.Init(base.mgr)
+
+	p.MaxWLockConditionalWaitTime = ParamItem{
+		Key:          "common.locks.maxWLockConditionalWaitTime",
+		Version:      "2.4.21",
+		DefaultValue: "600",
+		Doc:          "maximum seconds for waiting wlock conditional",
+		Export:       true,
+	}
+	p.MaxWLockConditionalWaitTime.Init(base.mgr)
 
 	p.EnableStorageV2 = ParamItem{
 		Key:          "common.storage.enablev2",


### PR DESCRIPTION
Cherry-pick from master
pr: #39206 #39308
Related to #39205

This PR merge `RLock` & `PinIfNotReleased` into `PinIf` function preventing segment being released before any Read operation finished.

---------