### PR TITLE
fix: [skip e2e] Make test case assigner result deterministic

### DIFF
--- a/internal/datacoord/compaction_test.go
+++ b/internal/datacoord/compaction_test.go
@@ -450,7 +450,7 @@ func (s *CompactionPlanHandlerSuite) TestPickAnyNode() {
 
 	assigner := newSlotBasedNodeAssigner(s.cluster)
 	assigner.slots = map[int64]int64{
-		100: 8,
+		100: 9,
 		101: 16,
 	}
 


### PR DESCRIPTION
Related to #39296

The case initialized with {100:8 ,101: 16}. After first assignment, the slots become {100:8, 101:8} and the following result is not stable.