### PR TITLE
fix: remove num_build_thread param

### DIFF
--- a/pkg/util/paramtable/knowhere_param.go
+++ b/pkg/util/paramtable/knowhere_param.go
@@ -2,7 +2,6 @@ package paramtable
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
@@ -22,7 +21,6 @@ const (
 
 const (
 	BuildDramBudgetKey = "build_dram_budget_gb"
-	NumBuildThreadKey  = "num_build_thread"
 	VecFieldSizeKey    = "vec_field_size_gb"
 )
 
@@ -89,7 +87,6 @@ func (p *knowhereConfig) GetRuntimeParameter(stage string) (map[string]string, e
 
 	if stage == BuildStage {
 		params[BuildDramBudgetKey] = fmt.Sprintf("%f", float32(hardware.GetFreeMemoryCount())/(1<<30))
-		params[NumBuildThreadKey] = strconv.Itoa(int(float32(hardware.GetCPUNum())))
 	}
 
 	return params, nil

--- a/pkg/util/paramtable/knowhere_param_test.go
+++ b/pkg/util/paramtable/knowhere_param_test.go
@@ -82,7 +82,6 @@ func TestKnowhereConfig_GetRuntimeParameter(t *testing.T) {
 	params, err := cfg.GetRuntimeParameter(BuildStage)
 	assert.NoError(t, err)
 	assert.Contains(t, params, BuildDramBudgetKey)
-	assert.Contains(t, params, NumBuildThreadKey)
 
 	params, err = cfg.GetRuntimeParameter(SearchStage)
 	assert.NoError(t, err)
@@ -208,7 +207,6 @@ func TestKnowhereConfig_MergeWithResource(t *testing.T) {
 			expectedParams: map[string]string{
 				"existing_key":     "existing_value",
 				BuildDramBudgetKey: "", // We can't predict the exact value, but it should exist
-				NumBuildThreadKey:  "", // We can't predict the exact value, but it should exist
 				VecFieldSizeKey:    "1.000000",
 			},
 		},


### PR DESCRIPTION
issue: #39090 
The num_build_thread parameter will limit the number of build omps. This parameter will override the effect of buildIndexThreadPoolRatio. Removing this parameter will have no actual effect. This parameter is actually only used in the growing index, where it will be explicitly set. 