### PR TITLE
enhance: [2.5] Limit the maximum number of segments restored and fail the job if saving the binlog fails

### DIFF
--- a/internal/datacoord/import_checker.go
+++ b/internal/datacoord/import_checker.go
@@ -242,6 +242,10 @@ func (c *importChecker) checkPreImportingJob(job ImportJob) {
 		err = c.imeta.AddTask(context.TODO(), t)
 		if err != nil {
 			log.Warn("add new import task failed", WrapTaskLog(t, zap.Error(err))...)
+			updateErr := c.imeta.UpdateJob(context.TODO(), job.GetJobID(), UpdateJobState(internalpb.ImportJobState_Failed), UpdateJobReason(err.Error()))
+			if updateErr != nil {
+				log.Warn("failed to update job state to Failed", zap.Error(updateErr))
+			}
 			return
 		}
 		log.Info("add new import task", WrapTaskLog(t)...)

--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -1706,6 +1706,11 @@ func (s *Server) ImportV2(ctx context.Context, in *internalpb.ImportRequestInter
 			resp.Status = merr.Status(merr.WrapErrImportFailed(fmt.Sprintf("no binlog to import, input=%s", in.GetFiles())))
 			return resp, nil
 		}
+		if len(files) > paramtable.Get().DataCoordCfg.MaxFilesPerImportReq.GetAsInt() {
+			resp.Status = merr.Status(merr.WrapErrImportFailed(fmt.Sprintf("The max number of import files should not exceed %d, but got %d",
+				paramtable.Get().DataCoordCfg.MaxFilesPerImportReq.GetAsInt(), len(files))))
+			return resp, nil
+		}
 		log.Info("list binlogs prefixes for import", zap.Any("binlog_prefixes", files))
 	}
 


### PR DESCRIPTION
1. Limit the maximum number of restored segments to 1024.
2. Fail the import job if saving binlog fails.
3. Fail the import job if saving the import task fails to prevent repeatedly generating dirty importing segments.

issue: https://github.com/milvus-io/milvus/issues/39331

pr: https://github.com/milvus-io/milvus/pull/39344