### PR TITLE
enhance: [2.5] Sync multipleChunkEnabled default value & milvus yaml

### DIFF
--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -2693,7 +2693,7 @@ This defaults to true, indicating that Milvus creates temporary index for growin
 	p.MultipleChunkedEnable = ParamItem{
 		Key:          "queryNode.segcore.multipleChunkedEnable",
 		Version:      "2.0.0",
-		DefaultValue: "false",
+		DefaultValue: "true",
 		Doc:          "Enable multiple chunked search",
 		Export:       true,
 	}


### PR DESCRIPTION
Cherry-pick from master
pr: #39372 
The default value and yaml have different values which may cause confusion when upgrading from older version.