### PR TITLE
fix: Skip load extra indexes for sorted segment pk field

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -167,6 +167,12 @@ ChunkedSegmentSealedImpl::LoadScalarIndex(const LoadIndexInfo& info) {
     auto field_id = FieldId(info.field_id);
     auto& field_meta = schema_->operator[](field_id);
 
+    // if segment is pk sorted, user created indexes bring no performance gain but extra memory usage
+    if (is_sorted_by_pk_ && field_id == schema_->get_primary_field_id()) {
+        LOG_INFO("segment pk sorted, skip user index loading for primary key field");
+        return;
+    }
+
     auto row_count = info.index->Count();
     AssertInfo(row_count > 0, "Index count is 0");
 

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -169,7 +169,8 @@ ChunkedSegmentSealedImpl::LoadScalarIndex(const LoadIndexInfo& info) {
 
     // if segment is pk sorted, user created indexes bring no performance gain but extra memory usage
     if (is_sorted_by_pk_ && field_id == schema_->get_primary_field_id()) {
-        LOG_INFO("segment pk sorted, skip user index loading for primary key field");
+        LOG_INFO(
+            "segment pk sorted, skip user index loading for primary key field");
         return;
     }
 

--- a/internal/core/src/segcore/SegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/SegmentSealedImpl.cpp
@@ -206,7 +206,8 @@ SegmentSealedImpl::LoadScalarIndex(const LoadIndexInfo& info) {
 
     // if segment is pk sorted, user created indexes bring no performance gain but extra memory usage
     if (is_sorted_by_pk_ && field_id == schema_->get_primary_field_id()) {
-        LOG_INFO("segment pk sorted, skip user index loading for primary key field");
+        LOG_INFO(
+            "segment pk sorted, skip user index loading for primary key field");
         return;
     }
 

--- a/internal/core/src/segcore/SegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/SegmentSealedImpl.cpp
@@ -204,6 +204,12 @@ SegmentSealedImpl::LoadScalarIndex(const LoadIndexInfo& info) {
     auto field_id = FieldId(info.field_id);
     auto& field_meta = schema_->operator[](field_id);
 
+    // if segment is pk sorted, user created indexes bring no performance gain but extra memory usage
+    if (is_sorted_by_pk_ && field_id == schema_->get_primary_field_id()) {
+        LOG_INFO("segment pk sorted, skip user index loading for primary key field");
+        return;
+    }
+
     auto row_count = info.index->Count();
     AssertInfo(row_count > 0, "Index count is 0");
 


### PR DESCRIPTION
Related to #39339

Extra indexes can be ignored for most cases since sorted pk column already provided indexing features