### PR TITLE
enhance: [GoSDK] Pass `UseDefaultConsistency` flag for query option

### DIFF
--- a/client/milvusclient/read_options.go
+++ b/client/milvusclient/read_options.go
@@ -523,9 +523,10 @@ func (opt *queryOption) Request() (*milvuspb.QueryRequest, error) {
 		PartitionNames: opt.partitionNames,
 		OutputFields:   opt.outputFields,
 
-		Expr:             opt.expr,
-		QueryParams:      entity.MapKvPairs(opt.queryParams),
-		ConsistencyLevel: opt.consistencyLevel.CommonConsistencyLevel(),
+		Expr:                  opt.expr,
+		QueryParams:           entity.MapKvPairs(opt.queryParams),
+		ConsistencyLevel:      opt.consistencyLevel.CommonConsistencyLevel(),
+		UseDefaultConsistency: opt.useDefaultConsistencyLevel,
 	}
 
 	req.ExprTemplateValues = make(map[string]*schemapb.TemplateValue)


### PR DESCRIPTION
If the flag is not passed, the behaviors will not be expected when user not passing consistency level.