### PR TITLE
enhance: Rectify run_clang_format grep command

### DIFF
--- a/internal/core/run_clang_format.sh
+++ b/internal/core/run_clang_format.sh
@@ -9,7 +9,7 @@ CorePath=$1
 CLANG_FORMAT=clang-format-12
 
 formatThis() {
-    find "$1" | grep "(\.cpp\|\.h\|\.cc)$" | grep -v "gen_tools/templates" | grep -v "\.pb\." | grep -v "tantivy-binding.h" | xargs $CLANG_FORMAT -i
+    find "$1" | grep -E "(\.cpp|\.h|\.cc)$" | grep -v "gen_tools/templates" | grep -v "\.pb\." | grep -v "tantivy-binding.h" | xargs $CLANG_FORMAT -i
 }
 
 formatThis "${CorePath}/src"

--- a/internal/core/src/query/SearchBruteForce.cpp
+++ b/internal/core/src/query/SearchBruteForce.cpp
@@ -37,13 +37,16 @@ CheckBruteForceSearchParam(const FieldMeta& field,
                "[BruteForceSearch] Data type isn't vector type");
     if (IsBinaryVectorDataType(data_type)) {
         AssertInfo(IsBinaryVectorMetricType(metric_type),
-                   "[BruteForceSearch] Binary vector, data type and metric type miss-match");
+                   "[BruteForceSearch] Binary vector, data type and metric "
+                   "type miss-match");
     } else if (IsFloatVectorDataType(data_type)) {
         AssertInfo(IsFloatVectorMetricType(metric_type),
-                   "[BruteForceSearch] Float vector, data type and metric type miss-match");
+                   "[BruteForceSearch] Float vector, data type and metric type "
+                   "miss-match");
     } else if (IsIntVectorDataType(data_type)) {
         AssertInfo(IsIntVectorMetricType(metric_type),
-                   "[BruteForceSearch] Int vector, data type and metric type miss-match");
+                   "[BruteForceSearch] Int vector, data type and metric type "
+                   "miss-match");
     } else {
         AssertInfo(IsVectorDataType(data_type),
                    "[BruteForceSearch] Unsupported vector data type");
@@ -165,7 +168,7 @@ BruteForceSearch(const dataset::SearchDataset& query_ds,
         } else if (data_type == DataType::VECTOR_INT8) {
             // TODO caiyd: if knowhere support real int8 bf, change it
             res = knowhere::BruteForce::RangeSearch<float>(
-                    base_dataset, query_dataset, search_cfg, bitset);
+                base_dataset, query_dataset, search_cfg, bitset);
         } else {
             PanicInfo(
                 ErrorCode::Unsupported,
@@ -279,7 +282,7 @@ DispatchBruteForceIteratorByDataType(const knowhere::DataSetPtr& base_dataset,
         case DataType::VECTOR_INT8:
             // TODO caiyd: if knowhere support real int8 bf, change it
             return knowhere::BruteForce::AnnIterator<float>(
-                    base_dataset, query_dataset, config, bitset);
+                base_dataset, query_dataset, config, bitset);
         default:
             PanicInfo(ErrorCode::Unsupported,
                       "Unsupported dataType for chunk brute force iterator:{}",

--- a/internal/core/src/segcore/ConcurrentVector.h
+++ b/internal/core/src/segcore/ConcurrentVector.h
@@ -169,11 +169,10 @@ class ConcurrentVectorImpl : public VectorBase {
                 Float16Vector,
                 std::conditional_t<
                     std::is_same_v<Type, bfloat16>,
-                        BFloat16Vector,
-                        std::conditional_t<
-                            std::is_same_v<Type, int8>,
-                            Int8Vector,
-                            BinaryVector>>>>>;
+                    BFloat16Vector,
+                    std::conditional_t<std::is_same_v<Type, int8>,
+                                       Int8Vector,
+                                       BinaryVector>>>>>;
 
  public:
     explicit ConcurrentVectorImpl(
@@ -546,8 +545,7 @@ class ConcurrentVector<BFloat16Vector>
 };
 
 template <>
-class ConcurrentVector<Int8Vector>
-    : public ConcurrentVectorImpl<int8, false> {
+class ConcurrentVector<Int8Vector> : public ConcurrentVectorImpl<int8, false> {
  public:
     ConcurrentVector(int64_t dim,
                      int64_t size_per_chunk,

--- a/internal/core/src/segcore/Utils.cpp
+++ b/internal/core/src/segcore/Utils.cpp
@@ -609,8 +609,7 @@ MergeDataArray(std::vector<MergeBase>& merge_bases,
                 }
                 vector_array->set_dim(dst->dim());
                 *dst->mutable_contents() = src.contents();
-            } else if (field_meta.get_data_type() ==
-                       DataType::VECTOR_INT8) {
+            } else if (field_meta.get_data_type() == DataType::VECTOR_INT8) {
                 auto data = VEC_FIELD_DATA(src_field_data, int8);
                 auto obj = vector_array->mutable_int8_vector();
                 obj->assign(data, dim * sizeof(int8));

--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -316,7 +316,7 @@ CreateArrowBuilder(DataType data_type, int dim) {
         case DataType::VECTOR_INT8: {
             AssertInfo(dim > 0, "invalid dim value");
             return std::make_shared<arrow::FixedSizeBinaryBuilder>(
-                    arrow::fixed_size_binary(dim * sizeof(int8)));
+                arrow::fixed_size_binary(dim * sizeof(int8)));
         }
         default: {
             PanicInfo(
@@ -837,7 +837,7 @@ CreateFieldData(const DataType& type,
                 type, total_num_rows);
         case DataType::VECTOR_INT8:
             return std::make_shared<FieldData<Int8Vector>>(
-                    dim, type, total_num_rows);
+                dim, type, total_num_rows);
         default:
             PanicInfo(DataTypeInvalid,
                       "CreateFieldData not support data type " +


### PR DESCRIPTION
Previously the grep with regex does not work and failed to match lots of .cpp files

This PR:
- use "-E" flag to use regex match
- commit the fixed result of current cpp code