### PR TITLE
fix: segment stats may be inconsistent after wal closing

### DIFF
--- a/internal/streamingcoord/client/assignment/assignment_test.go
+++ b/internal/streamingcoord/client/assignment/assignment_test.go
@@ -95,6 +95,10 @@ func TestAssignmentService(t *testing.T) {
 
 	assignmentService.ReportAssignmentError(ctx, types.PChannelInfo{Name: "c1", Term: 1}, errors.New("test"))
 
+	// Repeated report error at the same term should be ignored.
+	assignmentService.ReportAssignmentError(ctx, types.PChannelInfo{Name: "c1", Term: 1}, errors.New("test"))
+	assignmentService.ReportAssignmentError(ctx, types.PChannelInfo{Name: "c1", Term: 1}, errors.New("test"))
+
 	// test close
 	go close(closeCh)
 	time.Sleep(10 * time.Millisecond)

--- a/internal/streamingcoord/server/balancer/balancer_impl.go
+++ b/internal/streamingcoord/server/balancer/balancer_impl.go
@@ -226,7 +226,7 @@ func (b *balancerImpl) applyBalanceResultToStreamingNode(ctx context.Context, mo
 
 			// assign the channel to the target node.
 			if err := resource.Resource().StreamingNodeManagerClient().Assign(ctx, channel.CurrentAssignment()); err != nil {
-				b.logger.Warn("fail to assign channel", zap.Any("assignment", channel.CurrentAssignment()))
+				b.logger.Warn("fail to assign channel", zap.Any("assignment", channel.CurrentAssignment()), zap.Error(err))
 				return err
 			}
 			b.logger.Info("assign channel success", zap.Any("assignment", channel.CurrentAssignment()))

--- a/internal/streamingnode/server/wal/interceptors/segment/inspector/impls.go
+++ b/internal/streamingnode/server/wal/interceptors/segment/inspector/impls.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/milvus-io/milvus/internal/streamingnode/server/resource"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/segment/stats"
 	"github.com/milvus-io/milvus/pkg/log"
+	"github.com/milvus-io/milvus/pkg/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/util/syncutil"
 	"github.com/milvus-io/milvus/pkg/util/typeutil"
 )
@@ -121,9 +124,16 @@ func (s *sealOperationInspectorImpl) background() {
 				return true
 			})
 		case <-mustSealTicker.C:
-			segmentBelongs := resource.Resource().SegmentAssignStatsManager().SealByTotalGrowingSegmentsSize()
+			threshold := paramtable.Get().DataCoordCfg.GrowingSegmentsMemSizeInMB.GetAsUint64() * 1024 * 1024
+			segmentBelongs := resource.Resource().SegmentAssignStatsManager().SealByTotalGrowingSegmentsSize(threshold)
+			if segmentBelongs == nil {
+				continue
+			}
+			log.Info("seal by total growing segments size", zap.String("vchannel", segmentBelongs.VChannel),
+				zap.Uint64("sealThreshold", threshold),
+				zap.Int64("sealSegment", segmentBelongs.SegmentID))
 			if pm, ok := s.managers.Get(segmentBelongs.PChannel); ok {
-				pm.MustSealSegments(s.taskNotifier.Context(), segmentBelongs)
+				pm.MustSealSegments(s.taskNotifier.Context(), *segmentBelongs)
 			}
 		}
 	}

--- a/internal/streamingnode/server/wal/interceptors/segment/manager/partition_manager.go
+++ b/internal/streamingnode/server/wal/interceptors/segment/manager/partition_manager.go
@@ -164,19 +164,14 @@ func (m *partitionSegmentManager) collectShouldBeSealedWithPolicy(predicates fun
 	return shouldBeSealedSegments
 }
 
-// CollectDirtySegmentsAndClear collects all segments in the manager and clear the maanger.
-func (m *partitionSegmentManager) CollectDirtySegmentsAndClear() []*segmentAllocManager {
+// CollectAllSegmentsAndClear collects all segments in the manager and clear the manager.
+func (m *partitionSegmentManager) CollectAllSegmentsAndClear() []*segmentAllocManager {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	dirtySegments := make([]*segmentAllocManager, 0, len(m.segments))
-	for _, segment := range m.segments {
-		if segment.IsDirtyEnough() {
-			dirtySegments = append(dirtySegments, segment)
-		}
-	}
-	m.segments = make([]*segmentAllocManager, 0)
-	return dirtySegments
+	segments := m.segments
+	m.segments = nil
+	return segments
 }
 
 // CollectAllCanBeSealedAndClear collects all segments that can be sealed and clear the manager.

--- a/internal/streamingnode/server/wal/interceptors/segment/manager/pchannel_manager.go
+++ b/internal/streamingnode/server/wal/interceptors/segment/manager/pchannel_manager.go
@@ -265,31 +265,35 @@ func (m *PChannelSegmentAllocManager) Close(ctx context.Context) {
 
 	// Try to seal all wait
 	m.helper.SealAllWait(ctx)
-	m.logger.Info("seal all waited segments done", zap.Int("waitCounter", m.helper.WaitCounter()))
+	m.logger.Info("seal all waited segments done, may be some not done here", zap.Int("waitCounter", m.helper.WaitCounter()))
 
 	segments := make([]*segmentAllocManager, 0)
 	m.managers.Range(func(pm *partitionSegmentManager) {
-		segments = append(segments, pm.CollectDirtySegmentsAndClear()...)
+		segments = append(segments, pm.CollectAllSegmentsAndClear()...)
 	})
 
-	// commitAllSegmentsOnSamePChannel commits all segments on the same pchannel.
+	// Try to seal the dirty segment to avoid generate too large segment.
 	protoSegments := make([]*streamingpb.SegmentAssignmentMeta, 0, len(segments))
+	growingCnt := 0
 	for _, segment := range segments {
-		protoSegments = append(protoSegments, segment.Snapshot())
+		if segment.GetState() == streamingpb.SegmentAssignmentState_SEGMENT_ASSIGNMENT_STATE_GROWING {
+			growingCnt++
+		}
+		if segment.IsDirtyEnough() {
+			// Only persist the dirty segment.
+			protoSegments = append(protoSegments, segment.Snapshot())
+		}
 	}
-
-	m.logger.Info("segment assignment manager save all dirty segment assignments info", zap.Int("segmentCount", len(protoSegments)))
+	m.logger.Info("segment assignment manager save all dirty segment assignments info",
+		zap.Int("dirtySegmentCount", len(protoSegments)),
+		zap.Int("growingSegmentCount", growingCnt),
+		zap.Int("segmentCount", len(segments)))
 	if err := resource.Resource().StreamingNodeCatalog().SaveSegmentAssignments(ctx, m.pchannel.Name, protoSegments); err != nil {
 		m.logger.Warn("commit segment assignment at pchannel failed", zap.Error(err))
 	}
 
 	// remove the stats from stats manager.
-	m.logger.Info("segment assignment manager remove all segment stats from stats manager")
-	for _, segment := range segments {
-		if segment.GetState() == streamingpb.SegmentAssignmentState_SEGMENT_ASSIGNMENT_STATE_GROWING {
-			resource.Resource().SegmentAssignStatsManager().UnregisterSealedSegment(segment.GetSegmentID())
-		}
-	}
-
+	removedStatsSegmentCnt := resource.Resource().SegmentAssignStatsManager().UnregisterAllStatsOnPChannel(m.pchannel.Name)
+	m.logger.Info("segment assignment manager remove all segment stats from stats manager", zap.Int("removedStatsSegmentCount", removedStatsSegmentCnt))
 	m.metrics.Close()
 }


### PR DESCRIPTION
issue: #38399

- The stats may be kept after wal closing if the growing segment is not dirty.
- Change the error handling of wal open to avoid redundant manager api call.