### PR TITLE
enhance: unindexed collection can be compacted

### DIFF
--- a/internal/datacoord/compaction_policy_single.go
+++ b/internal/datacoord/compaction_policy_single.go
@@ -98,7 +98,7 @@ func (policy *singleCompactionPolicy) triggerOneCollection(ctx context.Context, 
 	views := make([]CompactionView, 0)
 	for _, group := range partSegments {
 		if Params.DataCoordCfg.IndexBasedCompaction.GetAsBool() {
-			group.segments = FilterInIndexedSegments(policy.handler, policy.meta, false, group.segments...)
+			group.segments = FilterInIndexedSegments(policy.handler, policy.meta, true, group.segments...)
 		}
 
 		collectionTTL, err := getCollectionTTL(collection.Properties)

--- a/internal/datacoord/compaction_trigger.go
+++ b/internal/datacoord/compaction_trigger.go
@@ -327,7 +327,7 @@ func (t *compactionTrigger) handleGlobalSignal(signal *compactionSignal) error {
 		}
 
 		if Params.DataCoordCfg.IndexBasedCompaction.GetAsBool() {
-			group.segments = FilterInIndexedSegments(t.handler, t.meta, signal.isForce, group.segments...)
+			group.segments = FilterInIndexedSegments(t.handler, t.meta, true, group.segments...)
 		}
 
 		coll, err := t.getCollection(group.collectionID)
@@ -629,7 +629,7 @@ func (t *compactionTrigger) generatePlans(segments []*SegmentInfo, signal *compa
 func (t *compactionTrigger) getCandidateSegments(channel string, partitionID UniqueID) []*SegmentInfo {
 	segments := t.meta.GetSegmentsByChannel(channel)
 	if Params.DataCoordCfg.IndexBasedCompaction.GetAsBool() {
-		segments = FilterInIndexedSegments(t.handler, t.meta, false, segments...)
+		segments = FilterInIndexedSegments(t.handler, t.meta, true, segments...)
 	}
 
 	var res []*SegmentInfo

--- a/internal/datacoord/garbage_collector.go
+++ b/internal/datacoord/garbage_collector.go
@@ -440,7 +440,7 @@ func (gc *garbageCollector) recycleDroppedSegments(ctx context.Context) {
 			droppedCompactTo[to] = struct{}{}
 		}
 	}
-	indexedSegments := FilterInIndexedSegments(gc.handler, gc.meta, false, lo.Keys(droppedCompactTo)...)
+	indexedSegments := FilterInIndexedSegments(gc.handler, gc.meta, true, lo.Keys(droppedCompactTo)...)
 	indexedSet := make(typeutil.UniqueSet)
 	for _, segment := range indexedSegments {
 		indexedSet.Insert(segment.GetID())

--- a/internal/datacoord/util.go
+++ b/internal/datacoord/util.go
@@ -72,7 +72,7 @@ func VerifyResponse(response interface{}, err error) error {
 	}
 }
 
-func FilterInIndexedSegments(handler Handler, mt *meta, skipNoIndexCollection bool, segments ...*SegmentInfo) []*SegmentInfo {
+func FilterInIndexedSegments(handler Handler, mt *meta, includeUnIndexedCollection bool, segments ...*SegmentInfo) []*SegmentInfo {
 	if len(segments) == 0 {
 		return nil
 	}
@@ -84,7 +84,7 @@ func FilterInIndexedSegments(handler Handler, mt *meta, skipNoIndexCollection bo
 	ret := make([]*SegmentInfo, 0)
 	for collection, segmentList := range collectionSegments {
 		// No segments will be filtered if there are no indices in the collection.
-		if skipNoIndexCollection && !mt.indexMeta.HasIndex(collection) {
+		if includeUnIndexedCollection && !mt.indexMeta.HasIndex(collection) {
 			ret = append(ret, segmentList...)
 			continue
 		}


### PR DESCRIPTION
fix #39633 
For unindexed collection, we don't need to wait for index build done before compaction