### PR TITLE
fix: [GoSDK] Use client config db name when connect

### DIFF
--- a/client/milvusclient/client.go
+++ b/client/milvusclient/client.go
@@ -59,7 +59,8 @@ func New(ctx context.Context, config *ClientConfig) (*Client, error) {
 	}
 
 	c := &Client{
-		config: config,
+		config:    config,
+		currentDB: config.DBName,
 	}
 
 	// Parse remote address.


### PR DESCRIPTION
Related to #34137