### PR TITLE
fix: Provide an option to specify a timeout to resolve Go unit test failures due to timeouts.

### DIFF
--- a/scripts/run_go_codecov.sh
+++ b/scripts/run_go_codecov.sh
@@ -28,6 +28,8 @@ echo "mode: atomic" > ${FILE_COVERAGE_INFO}
 # run unittest
 echo "Running unittest under ./internal & ./pkg"
 
+TEST_TIMEOUT=${TEST_TIMEOUT:-10m}
+
 TEST_CMD=$@
 if [ -z "$TEST_CMD" ]; then
    TEST_CMD="go test" 
@@ -36,14 +38,14 @@ fi
 # starting the timer
 beginTime=`date +%s`
 pushd cmd/tools
-$TEST_CMD -race -tags dynamic,test -v -coverpkg=./... -coverprofile=profile.out -covermode=atomic ./...
+$TEST_CMD -race -tags dynamic,test -v -coverpkg=./... -coverprofile=profile.out -covermode=atomic ./... -timeout $TEST_TIMEOUT
 if [ -f profile.out ]; then
     grep -v kafka profile.out | grep -v planparserv2/generated | grep -v mocks | sed '1d' >> ../${FILE_COVERAGE_INFO}
     rm profile.out
 fi
 popd
 for d in $(go list ./internal/... | grep -v -e vendor -e kafka -e planparserv2/generated -e mocks); do
-    $TEST_CMD -race -tags dynamic,test -v -coverpkg=./... -coverprofile=profile.out -covermode=atomic "$d"
+    $TEST_CMD -race -tags dynamic,test -v -coverpkg=./... -coverprofile=profile.out -covermode=atomic -timeout $TEST_TIMEOUT "$d"
     if [ -f profile.out ]; then
         grep -v kafka profile.out | grep -v planparserv2/generated | grep -v mocks | sed '1d' >> ${FILE_COVERAGE_INFO}
         rm profile.out
@@ -51,7 +53,7 @@ for d in $(go list ./internal/... | grep -v -e vendor -e kafka -e planparserv2/g
 done
 pushd pkg
 for d in $(go list ./... | grep -v -e vendor -e kafka -e planparserv2/generated -e mocks); do
-    $TEST_CMD -race -tags dynamic,test -v -coverpkg=./... -coverprofile=profile.out -covermode=atomic "$d"
+    $TEST_CMD -race -tags dynamic,test -v -coverpkg=./... -coverprofile=profile.out -covermode=atomic -timeout $TEST_TIMEOUT "$d"
     if [ -f profile.out ]; then
         grep -v kafka profile.out | grep -v planparserv2/generated | grep -v mocks | sed '1d' >> ../${FILE_COVERAGE_INFO}
         rm profile.out
@@ -61,7 +63,7 @@ popd
 # milvusclient
 pushd client
 for d in $(go list ./... | grep -v -e vendor -e kafka -e planparserv2/generated -e mocks); do
-    $TEST_CMD -race -tags dynamic -v -coverpkg=./... -coverprofile=profile.out -covermode=atomic "$d"
+    $TEST_CMD -race -tags dynamic -v -coverpkg=./... -coverprofile=profile.out -covermode=atomic -timeout $TEST_TIMEOUT "$d"
     if [ -f profile.out ]; then
         grep -v kafka profile.out | grep -v planparserv2/generated | grep -v mocks | sed '1d' >> ../${FILE_COVERAGE_INFO}
         rm profile.out


### PR DESCRIPTION
When executing unit tests locally for OSS Milvus using the following steps:
```
$ cd deployments/docker/dev
$ docker compose up -d
$ cd ../../../
$ make codecov
```
some tests fail due to timeout errors. For example:
```
panic: test timed out after 10m0s
running tests:
    TestQueryNodeService (9m40s)
```
Increasing the timeout value allows the test to run successfully.

Currently, Milvus does not provide an option to configure the test timeout value. This PR introduces a new environment variable, `TEST_TIMEOUT`, allowing users to set a custom timeout value for tests.  

Related Issue: #39669 
  