### PR TITLE
fix: [2.4] Fix flowgraph leak

### DIFF
--- a/pkg/mq/msgdispatcher/client.go
+++ b/pkg/mq/msgdispatcher/client.go
@@ -75,7 +75,7 @@ func (c *client) Register(ctx context.Context, vchannel string, pos *Pos, subPos
 	}
 	ch, err := manager.Add(ctx, vchannel, pos, subPos)
 	if err != nil {
-		if manager.Num() == 0 {
+		if manager.NumTarget() == 0 {
 			manager.Close()
 			delete(c.managers, pchannel)
 		}
@@ -92,7 +92,7 @@ func (c *client) Deregister(vchannel string) {
 	defer c.managerMut.Unlock()
 	if manager, ok := c.managers[pchannel]; ok {
 		manager.Remove(vchannel)
-		if manager.Num() == 0 {
+		if manager.NumTarget() == 0 {
 			manager.Close()
 			delete(c.managers, pchannel)
 		}


### PR DESCRIPTION
Consider lag targets when determining whether to remove the dispatcher manager.

issue: https://github.com/milvus-io/milvus/issues/39642

pr: https://github.com/milvus-io/milvus/pull/39656