### PR TITLE
enhance: optimize expr performace for some points

### DIFF
--- a/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.h
+++ b/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.h
@@ -24,6 +24,7 @@
 #include "common/Vector.h"
 #include "exec/expression/Expr.h"
 #include "segcore/SegmentInterface.h"
+#include "exec/expression/Element.h"
 
 namespace milvus {
 namespace exec {
@@ -478,6 +479,10 @@ class PhyBinaryArithOpEvalRangeExpr : public SegmentExpr {
 
  private:
     std::shared_ptr<const milvus::expr::BinaryArithOpEvalRangeExpr> expr_;
+    SingleElement right_operand_arg_;
+    SingleElement value_arg_;
+    bool arg_inited_{false};
 };
+
 }  //namespace exec
 }  // namespace milvus

--- a/internal/core/src/exec/expression/BinaryRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.cpp
@@ -143,9 +143,14 @@ PhyBinaryRangeFilterExpr::PreCheckOverflow(HighPrecisionType& val1,
                                            OffsetVector* input) {
     lower_inclusive = expr_->lower_inclusive_;
     upper_inclusive = expr_->upper_inclusive_;
-    val1 = GetValueFromProto<HighPrecisionType>(expr_->lower_val_);
-    val2 = GetValueFromProto<HighPrecisionType>(expr_->upper_val_);
 
+    if (!arg_inited_) {
+        lower_arg_.SetValue<HighPrecisionType>(expr_->lower_val_);
+        upper_arg_.SetValue<HighPrecisionType>(expr_->upper_val_);
+        arg_inited_ = true;
+    }
+    val1 = lower_arg_.GetValue<HighPrecisionType>();
+    val2 = upper_arg_.GetValue<HighPrecisionType>();
     auto get_next_overflow_batch =
         [this](OffsetVector* input) -> ColumnVectorPtr {
         int64_t batch_size;
@@ -358,8 +363,13 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForJson(OffsetVector* input) {
 
     bool lower_inclusive = expr_->lower_inclusive_;
     bool upper_inclusive = expr_->upper_inclusive_;
-    ValueType val1 = GetValueFromProto<ValueType>(expr_->lower_val_);
-    ValueType val2 = GetValueFromProto<ValueType>(expr_->upper_val_);
+    if (!arg_inited_) {
+        lower_arg_.SetValue<ValueType>(expr_->lower_val_);
+        upper_arg_.SetValue<ValueType>(expr_->upper_val_);
+        arg_inited_ = true;
+    }
+    ValueType val1 = lower_arg_.GetValue<ValueType>();
+    ValueType val2 = upper_arg_.GetValue<ValueType>();
     auto pointer = milvus::Json::pointer(expr_->column_.nested_path_);
 
     auto execute_sub_batch =
@@ -464,8 +474,15 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForArray(OffsetVector* input) {
 
     bool lower_inclusive = expr_->lower_inclusive_;
     bool upper_inclusive = expr_->upper_inclusive_;
-    ValueType val1 = GetValueFromProto<ValueType>(expr_->lower_val_);
-    ValueType val2 = GetValueFromProto<ValueType>(expr_->upper_val_);
+
+    if (!arg_inited_) {
+        lower_arg_.SetValue<ValueType>(expr_->lower_val_);
+        upper_arg_.SetValue<ValueType>(expr_->upper_val_);
+        arg_inited_ = true;
+    }
+    ValueType val1 = lower_arg_.GetValue<ValueType>();
+    ValueType val2 = upper_arg_.GetValue<ValueType>();
+
     int index = -1;
     if (expr_->column_.nested_path_.size() > 0) {
         index = std::stoi(expr_->column_.nested_path_[0]);

--- a/internal/core/src/exec/expression/BinaryRangeExpr.h
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.h
@@ -22,6 +22,7 @@
 #include "common/Types.h"
 #include "common/Vector.h"
 #include "exec/expression/Expr.h"
+#include "exec/expression/Element.h"
 #include "segcore/SegmentInterface.h"
 
 namespace milvus {
@@ -277,6 +278,9 @@ class PhyBinaryRangeFilterExpr : public SegmentExpr {
  private:
     std::shared_ptr<const milvus::expr::BinaryRangeFilterExpr> expr_;
     int64_t overflow_check_pos_{0};
+    SingleElement lower_arg_;
+    SingleElement upper_arg_;
+    bool arg_inited_{false};
 };
 }  //namespace exec
 }  // namespace milvus

--- a/internal/core/src/exec/expression/Element.h
+++ b/internal/core/src/exec/expression/Element.h
@@ -1,0 +1,263 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <algorithm>
+#include <memory>
+#include <string>
+
+#include "common/Types.h"
+#include "exec/expression/EvalCtx.h"
+#include "exec/expression/VectorFunction.h"
+#include "exec/expression/Utils.h"
+#include "exec/QueryContext.h"
+#include "expr/ITypeExpr.h"
+#include "query/PlanProto.h"
+
+namespace milvus {
+namespace exec {
+
+class BaseElement {
+ public:
+    virtual ~BaseElement() = default;
+};
+
+class SingleElement : public BaseElement {
+ public:
+    using ValueType = std::variant<std::monostate,
+                                   bool,
+                                   int8_t,
+                                   int16_t,
+                                   int32_t,
+                                   int64_t,
+                                   float,
+                                   double,
+                                   std::string,
+                                   proto::plan::Array>;
+
+    SingleElement() = default;
+    virtual ~SingleElement() = default;
+
+    template <typename T>
+    void
+    SetValue(const proto::plan::GenericValue& value) {
+        value_ = GetValueFromProto<T>(value);
+    }
+
+    template <typename T>
+    void
+    SetValue(const T& value) {
+        if constexpr (std::is_same_v<T, bool> || std::is_same_v<T, int8_t> ||
+                      std::is_same_v<T, int16_t> ||
+                      std::is_same_v<T, int32_t> ||
+                      std::is_same_v<T, int64_t> || std::is_same_v<T, float> ||
+                      std::is_same_v<T, double> ||
+                      std::is_same_v<T, std::string>) {
+            value_ = value;
+        } else {
+            static_assert(sizeof(T) == 0,
+                          "Type not supported in SingleElement");
+        }
+    }
+
+    template <typename T>
+    T
+    GetValue() const {
+        try {
+            return std::get<T>(value_);
+        } catch (const std::bad_variant_access& e) {
+            PanicInfo(ErrorCode::UnexpectedError,
+                      "SingleElement GetValue() failed: {}",
+                      e.what());
+        }
+    }
+
+ public:
+    ValueType value_;
+};
+
+class MultiElement : public BaseElement {
+ public:
+    using ValueType = std::variant<std::monostate,
+                                   bool,
+                                   int8_t,
+                                   int16_t,
+                                   int32_t,
+                                   int64_t,
+                                   float,
+                                   double,
+                                   std::string,
+                                   std::string_view>;
+
+    MultiElement() = default;
+    virtual ~MultiElement() = default;
+
+    virtual bool
+    In(const ValueType& value) const = 0;
+
+    virtual bool
+    Empty() const = 0;
+
+    virtual size_t
+    Size() const = 0;
+};
+
+template <typename T>
+class SortVectorElement : public MultiElement {
+ public:
+    explicit SortVectorElement(
+        const std::vector<proto::plan::GenericValue>& values) {
+        for (auto& value : values) {
+            values_.push_back(GetValueFromProto<T>(value));
+        }
+        std::sort(values_.begin(), values_.end());
+        sorted_ = true;
+    }
+
+    explicit SortVectorElement(const std::vector<T>& values) {
+        for (const auto& value : values) {
+            values_.push_back(value);
+        }
+        std::sort(values_.begin(), values_.end());
+        sorted_ = true;
+    }
+
+    bool
+    Empty() const override {
+        return values_.empty();
+    }
+
+    size_t
+    Size() const override {
+        return values_.size();
+    }
+
+    bool
+    In(const ValueType& value) const override {
+        AssertInfo(sorted_, "In() should be sorted before");
+        if (std::holds_alternative<T>(value)) {
+            return std::binary_search(
+                values_.begin(), values_.end(), std::get<T>(value));
+        }
+        return false;
+    }
+
+    void
+    Sort() {
+        std::sort(values_.begin(), values_.end());
+        sorted_ = true;
+    }
+
+    void
+    AddElement(const T& value) {
+        values_.push_back(value);
+    }
+
+ public:
+    std::vector<T> values_;
+    bool sorted_{false};
+};
+
+template <typename T>
+class FlatVectorElement : public MultiElement {
+ public:
+    explicit FlatVectorElement(
+        const std::vector<proto::plan::GenericValue>& values) {
+        for (auto& value : values) {
+            values_.push_back(GetValueFromProto<T>(value));
+        }
+    }
+
+    explicit FlatVectorElement(const std::vector<T>& values) {
+        for (const auto& value : values) {
+            values_.push_back(value);
+        }
+    }
+
+    bool
+    Empty() const override {
+        return values_.empty();
+    }
+
+    bool
+    In(const ValueType& value) const override {
+        if (std::holds_alternative<T>(value)) {
+            for (const auto& v : values_) {
+                if (v == value)
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    size_t
+    Size() const override {
+        return values_.size();
+    }
+
+    void
+    AddElement(const T& value) {
+        values_.push_back(value);
+    }
+
+ public:
+    std::vector<T> values_;
+};
+
+template <typename T>
+class SetElement : public MultiElement {
+ public:
+    explicit SetElement(const std::vector<proto::plan::GenericValue>& values) {
+        for (auto& value : values) {
+            values_.insert(GetValueFromProto<T>(value));
+        }
+    }
+
+    explicit SetElement(const std::vector<T>& values) {
+        for (const auto& value : values) {
+            values_.insert(value);
+        }
+    }
+
+    bool
+    Empty() const override {
+        return values_.empty();
+    }
+
+    bool
+    In(const ValueType& value) const override {
+        if (std::holds_alternative<T>(value)) {
+            return values_.count(std::get<T>(value)) > 0;
+        }
+    }
+
+    void
+    AddElement(const T& value) {
+        values_.insert(value);
+    }
+
+    size_t
+    Size() const override {
+        return values_.size();
+    }
+
+ public:
+    std::set<T> values_;
+};
+
+}  //namespace exec
+}  // namespace milvus

--- a/internal/core/src/exec/expression/JsonContainsExpr.h
+++ b/internal/core/src/exec/expression/JsonContainsExpr.h
@@ -22,6 +22,7 @@
 #include "common/Types.h"
 #include "common/Vector.h"
 #include "exec/expression/Expr.h"
+#include "exec/expression/Element.h"
 #include "segcore/SegmentInterface.h"
 
 namespace milvus {
@@ -89,6 +90,8 @@ class PhyJsonContainsFilterExpr : public SegmentExpr {
 
  private:
     std::shared_ptr<const milvus::expr::JsonContainsExpr> expr_;
+    bool arg_inited_{false};
+    std::shared_ptr<MultiElement> arg_set_;
 };
 }  //namespace exec
 }  // namespace milvus

--- a/internal/core/src/exec/expression/TermExpr.h
+++ b/internal/core/src/exec/expression/TermExpr.h
@@ -22,6 +22,7 @@
 #include "common/Types.h"
 #include "common/Vector.h"
 #include "exec/expression/Expr.h"
+#include "exec/expression/Element.h"
 #include "segcore/SegmentInterface.h"
 
 namespace milvus {
@@ -122,6 +123,9 @@ class PhyTermFilterExpr : public SegmentExpr {
     milvus::Timestamp query_timestamp_;
     bool cached_bits_inited_{false};
     TargetBitmap cached_bits_;
+    bool arg_inited_{false};
+    std::shared_ptr<MultiElement> arg_set_;
+    SingleElement arg_val_;
 };
 }  //namespace exec
 }  // namespace milvus

--- a/internal/core/src/exec/expression/UnaryExpr.h
+++ b/internal/core/src/exec/expression/UnaryExpr.h
@@ -24,6 +24,7 @@
 #include "common/Types.h"
 #include "common/Vector.h"
 #include "exec/expression/Expr.h"
+#include "exec/expression/Element.h"
 #include "index/Meta.h"
 #include "index/ScalarIndex.h"
 #include "segcore/SegmentInterface.h"
@@ -385,6 +386,8 @@ class PhyUnaryRangeFilterExpr : public SegmentExpr {
  private:
     std::shared_ptr<const milvus::expr::UnaryRangeFilterExpr> expr_;
     int64_t overflow_check_pos_{0};
+    bool arg_inited_{false};
+    SingleElement value_arg_;
 };
 }  // namespace exec
 }  // namespace milvus


### PR DESCRIPTION
1. skip get expr arguments which deserialize proto for every batch execute.
2. replace unordered_set with sort array that has better performace for small set.

#39688