### PR TITLE
fix: Return early when skip load pk index

### DIFF
--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -1033,6 +1033,7 @@ func (s *LocalSegment) LoadIndex(ctx context.Context, indexInfo *querypb.FieldIn
 			IndexInfo: indexInfo,
 			IsLoaded:  true,
 		})
+		return nil
 	}
 
 	return s.innerLoadIndex(ctx, fieldSchema, indexInfo, tr, fieldType)


### PR DESCRIPTION
Previous PR #39437 only print log and add index while load operation is still executed. This PR return early when segment decides not to load PK index.