### PR TITLE
fix: [2.4] load collection stucks if compaction/gc happens

### DIFF
--- a/internal/querycoordv2/observers/target_observer.go
+++ b/internal/querycoordv2/observers/target_observer.go
@@ -176,13 +176,19 @@ func (ob *TargetObserver) schedule(ctx context.Context) {
 
 		case <-ticker.C:
 			ob.clean()
-			loaded := lo.FilterMap(ob.meta.GetAllCollections(), func(collection *meta.Collection, _ int) (int64, bool) {
-				if collection.GetStatus() == querypb.LoadStatus_Loaded {
-					return collection.GetCollectionID(), true
+
+			collections := ob.meta.GetAllCollections()
+			var loadedIDs, loadingIDs []int64
+			for _, c := range collections {
+				if c.GetStatus() == querypb.LoadStatus_Loaded {
+					loadedIDs = append(loadedIDs, c.GetCollectionID())
+				} else {
+					loadingIDs = append(loadingIDs, c.GetCollectionID())
 				}
-				return 0, false
-			})
-			ob.loadedDispatcher.AddTask(loaded...)
+			}
+
+			ob.loadedDispatcher.AddTask(loadedIDs...)
+			ob.loadingDispatcher.AddTask(loadingIDs...)
 
 		case req := <-ob.updateChan:
 			log.Info("manually trigger update target",


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/39680
pr: https://github.com/milvus-io/milvus/pull/39701
if compaction/gc happens, load collection may stuck due to SegmentNotFound, we should trigger UpdateNextTarget to get a new data view to execute loading operation.