### PR TITLE
fix: streaming consume checkpoint is always nil and limit resource of ci

### DIFF
--- a/internal/distributed/rootcoord/service.go
+++ b/internal/distributed/rootcoord/service.go
@@ -347,6 +347,12 @@ func (s *Server) Stop() (err error) {
 		defer s.tikvCli.Close()
 	}
 
+	if s.rootCoord != nil {
+		log.Info("graceful stop rootCoord")
+		s.rootCoord.GracefulStop()
+		log.Info("graceful stop rootCoord done")
+	}
+
 	if s.grpcServer != nil {
 		utils.GracefulStopGRPCServer(s.grpcServer)
 	}

--- a/internal/distributed/rootcoord/service_test.go
+++ b/internal/distributed/rootcoord/service_test.go
@@ -118,6 +118,9 @@ func (m *mockCore) Stop() error {
 	return fmt.Errorf("stop error")
 }
 
+func (m *mockCore) GracefulStop() {
+}
+
 func TestRun(t *testing.T) {
 	paramtable.Init()
 	parameters := []string{"tikv", "etcd"}

--- a/internal/metastore/kv/streamingnode/kv_catalog.go
+++ b/internal/metastore/kv/streamingnode/kv_catalog.go
@@ -110,7 +110,7 @@ func (c *catalog) GetConsumeCheckpoint(ctx context.Context, pchannelName string)
 		return nil, err
 	}
 	val := &streamingpb.WALCheckpoint{}
-	if err = proto.Unmarshal([]byte(value), &streamingpb.WALCheckpoint{}); err != nil {
+	if err = proto.Unmarshal([]byte(value), val); err != nil {
 		return nil, err
 	}
 	return val, nil

--- a/internal/metastore/kv/streamingnode/kv_catalog_test.go
+++ b/internal/metastore/kv/streamingnode/kv_catalog_test.go
@@ -37,7 +37,7 @@ func TestCatalogConsumeCheckpoint(t *testing.T) {
 	kv.EXPECT().Load(mock.Anything, mock.Anything).Return("", merr.ErrIoKeyNotFound)
 	checkpoint, err = catalog.GetConsumeCheckpoint(ctx, "p1")
 	assert.Nil(t, checkpoint)
-	assert.Nil(t, checkpoint)
+	assert.Nil(t, err)
 
 	kv.EXPECT().Save(mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	err = catalog.SaveConsumeCheckpoint(ctx, "p1", &streamingpb.WALCheckpoint{})

--- a/internal/querycoordv2/balance/streaming_query_node_channel_helper_test.go
+++ b/internal/querycoordv2/balance/streaming_query_node_channel_helper_test.go
@@ -18,8 +18,6 @@ import (
 
 func TestAssignChannelToWALLocatedFirst(t *testing.T) {
 	balancer := mock_balancer.NewMockBalancer(t)
-	snmanager.StaticStreamingNodeManager.SetBalancerReady(balancer)
-
 	balancer.EXPECT().WatchChannelAssignments(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, cb func(typeutil.VersionInt64Pair, []types.PChannelInfoAssigned) error) error {
 		versions := []typeutil.VersionInt64Pair{
 			{Global: 1, Local: 2},
@@ -46,6 +44,7 @@ func TestAssignChannelToWALLocatedFirst(t *testing.T) {
 		<-ctx.Done()
 		return context.Cause(ctx)
 	})
+	snmanager.StaticStreamingNodeManager.SetBalancerReady(balancer)
 
 	channels := []*meta.DmChannel{
 		{VchannelInfo: &datapb.VchannelInfo{ChannelName: "pchannel_v1"}},

--- a/internal/rootcoord/root_coord.go
+++ b/internal/rootcoord/root_coord.go
@@ -826,15 +826,18 @@ func (c *Core) revokeSession() {
 	}
 }
 
+func (c *Core) GracefulStop() {
+	if c.streamingCoord != nil {
+		c.streamingCoord.Stop()
+	}
+}
+
 // Stop stops rootCoord.
 func (c *Core) Stop() error {
 	c.UpdateStateCode(commonpb.StateCode_Abnormal)
 	c.stopExecutor()
 	c.stopScheduler()
 
-	if c.streamingCoord != nil {
-		c.streamingCoord.Stop()
-	}
 	if c.proxyWatcher != nil {
 		c.proxyWatcher.Stop()
 	}

--- a/internal/streamingcoord/server/balancer/balancer_impl.go
+++ b/internal/streamingcoord/server/balancer/balancer_impl.go
@@ -65,7 +65,8 @@ func (b *balancerImpl) WatchChannelAssignments(ctx context.Context, cb func(vers
 	}
 	defer b.lifetime.Done()
 
-	ctx, _ = contextutil.MergeContext(ctx, b.ctx)
+	ctx, cancel := contextutil.MergeContext(ctx, b.ctx)
+	defer cancel()
 	return b.channelMetaManager.WatchAssignmentResult(ctx, cb)
 }
 
@@ -75,6 +76,8 @@ func (b *balancerImpl) MarkAsUnavailable(ctx context.Context, pChannels []types.
 	}
 	defer b.lifetime.Done()
 
+	ctx, cancel := contextutil.MergeContext(ctx, b.ctx)
+	defer cancel()
 	return b.sendRequestAndWaitFinish(ctx, newOpMarkAsUnavailable(ctx, pChannels))
 }
 
@@ -85,6 +88,8 @@ func (b *balancerImpl) Trigger(ctx context.Context) error {
 	}
 	defer b.lifetime.Done()
 
+	ctx, cancel := contextutil.MergeContext(ctx, b.ctx)
+	defer cancel()
 	return b.sendRequestAndWaitFinish(ctx, newOpTrigger(ctx))
 }
 

--- a/internal/streamingnode/server/flusher/flusherimpl/pchannel_checkpoint_test.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/pchannel_checkpoint_test.go
@@ -43,7 +43,9 @@ func TestPChannelCheckpointManager(t *testing.T) {
 
 	p.AddVChannel("vchannel-999", rmq.NewRmqID(1000000))
 	p.DropVChannel("vchannel-1000")
-	p.Update(vchannel, rmq.NewRmqID(1000001))
+	for _, vchannel := range vchannel {
+		p.Update(vchannel, rmq.NewRmqID(1000001))
+	}
 
 	assert.Eventually(t, func() bool {
 		newMinimum := minimumOne.Load()

--- a/internal/streamingnode/server/flusher/flusherimpl/vchannel_checkpoint_test.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/vchannel_checkpoint_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestVChannelCheckpointManager(t *testing.T) {
-	exists, vchannel, minimumX := generateRandomExistsMessageID()
+	exists, vchannels, minimumX := generateRandomExistsMessageID()
 	m := newVChannelCheckpointManager(exists)
 	assert.True(t, m.MinimumCheckpoint().EQ(minimumX))
 
@@ -32,17 +32,31 @@ func TestVChannelCheckpointManager(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, m.MinimumCheckpoint().EQ(minimumX))
 
-	err = m.Update(vchannel, rmq.NewRmqID(1000001))
-	assert.NoError(t, err)
+	for _, vchannel := range vchannels {
+		err = m.Update(vchannel, rmq.NewRmqID(1000001))
+		assert.NoError(t, err)
+	}
 	assert.False(t, m.MinimumCheckpoint().EQ(minimumX))
 
-	err = m.Update(vchannel, minimumX)
+	err = m.Update(vchannels[0], minimumX)
 	assert.Error(t, err)
 
 	err = m.Drop("vchannel-501")
 	assert.NoError(t, err)
+	lastMinimum := m.MinimumCheckpoint()
+	for i := 0; i < 1001; i++ {
+		m.Update(fmt.Sprintf("vchannel-%d", i), rmq.NewRmqID(rand.Int63n(9999999)+2))
+		newMinimum := m.MinimumCheckpoint()
+		assert.True(t, lastMinimum.LTE(newMinimum))
+		lastMinimum = newMinimum
+	}
 	for i := 0; i < 1001; i++ {
 		m.Drop(fmt.Sprintf("vchannel-%d", i))
+		newMinimum := m.MinimumCheckpoint()
+		if newMinimum != nil {
+			assert.True(t, lastMinimum.LTE(newMinimum))
+			lastMinimum = newMinimum
+		}
 	}
 	assert.Len(t, m.index, 0)
 	assert.Len(t, m.checkpointHeap, 0)
@@ -50,17 +64,21 @@ func TestVChannelCheckpointManager(t *testing.T) {
 	assert.Nil(t, m.MinimumCheckpoint())
 }
 
-func generateRandomExistsMessageID() (map[string]message.MessageID, string, message.MessageID) {
+func generateRandomExistsMessageID() (map[string]message.MessageID, []string, message.MessageID) {
 	minimumX := int64(10000000)
-	var vchannel string
+	var vchannel []string
 	exists := make(map[string]message.MessageID)
 	for i := 0; i < 1000; i++ {
 		x := rand.Int63n(999999) + 2
 		exists[fmt.Sprintf("vchannel-%d", i)] = rmq.NewRmqID(x)
 		if x < minimumX {
 			minimumX = x
-			vchannel = fmt.Sprintf("vchannel-%d", i)
+			vchannel = []string{fmt.Sprintf("vchannel-%d", i)}
+		} else if x == minimumX {
+			vchannel = append(vchannel, fmt.Sprintf("vchannel-%d", i))
 		}
 	}
+	vchannel = append(vchannel, "vchannel-1")
+	exists["vchannel-1"] = rmq.NewRmqID(minimumX)
 	return exists, vchannel, rmq.NewRmqID(minimumX)
 }

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -213,6 +213,8 @@ type RootCoordComponent interface {
 	GetMetrics(ctx context.Context, req *milvuspb.GetMetricsRequest) (*milvuspb.GetMetricsResponse, error)
 
 	RegisterStreamingCoordGRPCService(server *grpc.Server)
+
+	GracefulStop()
 }
 
 // ProxyClient is the client interface for proxy server

--- a/tests/_helm/values/e2e/distributed
+++ b/tests/_helm/values/e2e/distributed
@@ -20,7 +20,7 @@ dataCoordinator:
 dataNode:
   resources:
     limits:
-      cpu: "2"
+      cpu: "1"
     requests:
       cpu: "0.5"
       memory: 500Mi
@@ -249,7 +249,21 @@ queryNode:
       cpu: "2"
     requests:
       cpu: "0.5"
-      memory: 500Mi
+      memory: 512Mi
+streamingNode:
+  resources:
+    limits:
+      cpu: "2"
+    requests:
+      cpu: "0.5"
+      memory: 512Mi
+mixCoordinator:
+  resources:
+    limits:
+      cpu: "1"
+    requests:
+      cpu: "0.2"
+      memory: 256Mi
 rootCoordinator:
   resources:
     limits:

--- a/tests/go_client/testcases/helper/helper.go
+++ b/tests/go_client/testcases/helper/helper.go
@@ -153,6 +153,12 @@ func (chainTask *CollectionPrepare) CreateCollection(ctx context.Context, t *tes
 	common.CheckErr(t, err, true)
 
 	t.Cleanup(func() {
+		// The collection will be cleanup after the test
+		// But some ctx is setted with timeout for only a part of unittest,
+		// which will cause the drop collection failed with timeout.
+		ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Second*10)
+		defer cancel()
+
 		err := mc.DropCollection(ctx, clientv2.NewDropCollectionOption(schema.CollectionName))
 		common.CheckErr(t, err, true)
 	})


### PR DESCRIPTION
issue: #38399

- fix the nil pointer bug
- limit the resource usage for streaming e2e
- enhance the go test
- fix: rootcoord block when graceful stop