### PR TITLE
fix: remove the mmap.enable param in the type param when creating index

### DIFF
--- a/internal/datacoord/index_meta.go
+++ b/internal/datacoord/index_meta.go
@@ -245,13 +245,15 @@ func (m *indexMeta) updateIndexTasksMetrics() {
 }
 
 func checkParams(fieldIndex *model.Index, req *indexpb.CreateIndexRequest) bool {
-	if len(fieldIndex.TypeParams) != len(req.TypeParams) {
+	metaTypeParams := DeleteParams(fieldIndex.TypeParams, []string{common.MmapEnabledKey})
+	reqTypeParams := DeleteParams(req.TypeParams, []string{common.MmapEnabledKey})
+	if len(metaTypeParams) != len(reqTypeParams) {
 		return false
 	}
 	notEq := false
-	for _, param1 := range fieldIndex.TypeParams {
+	for _, param1 := range metaTypeParams {
 		exist := false
-		for _, param2 := range req.TypeParams {
+		for _, param2 := range reqTypeParams {
 			if param2.Key == param1.Key && param2.Value == param1.Value {
 				exist = true
 			}

--- a/internal/datacoord/index_meta_test.go
+++ b/internal/datacoord/index_meta_test.go
@@ -376,6 +376,10 @@ func TestMeta_HasSameReq(t *testing.T) {
 				Key:   common.DimKey,
 				Value: "128",
 			},
+			{
+				Key:   common.MmapEnabledKey,
+				Value: "true",
+			},
 		}
 		indexParams = []*commonpb.KeyValuePair{
 			{


### PR DESCRIPTION
Because when GetIndexParams is used, index params and type params are concatenated, so when loading index, the mmap.enable parameter in type params is also referenced.

- issue: #39801 