### PR TITLE
fix: [2.4] remove the mmap.enable param in the type param when creating index

### DIFF
--- a/internal/datacoord/index_meta.go
+++ b/internal/datacoord/index_meta.go
@@ -178,13 +178,15 @@ func (m *indexMeta) updateIndexTasksMetrics() {
 }
 
 func checkParams(fieldIndex *model.Index, req *indexpb.CreateIndexRequest) bool {
-	if len(fieldIndex.TypeParams) != len(req.TypeParams) {
+	metaTypeParams := DeleteParams(fieldIndex.TypeParams, []string{common.MmapEnabledKey})
+	reqTypeParams := DeleteParams(req.TypeParams, []string{common.MmapEnabledKey})
+	if len(metaTypeParams) != len(reqTypeParams) {
 		return false
 	}
 	notEq := false
-	for _, param1 := range fieldIndex.TypeParams {
+	for _, param1 := range metaTypeParams {
 		exist := false
-		for _, param2 := range req.TypeParams {
+		for _, param2 := range reqTypeParams {
 			if param2.Key == param1.Key && param2.Value == param1.Value {
 				exist = true
 			}

--- a/internal/datacoord/index_meta_test.go
+++ b/internal/datacoord/index_meta_test.go
@@ -242,6 +242,10 @@ func TestMeta_HasSameReq(t *testing.T) {
 				Key:   common.DimKey,
 				Value: "128",
 			},
+			{
+				Key:   common.MmapEnabledKey,
+				Value: "true",
+			},
 		}
 		indexParams = []*commonpb.KeyValuePair{
 			{

--- a/internal/datacoord/index_service.go
+++ b/internal/datacoord/index_service.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus/internal/metastore/model"
+	"github.com/milvus-io/milvus/pkg/common"
 	pkgcommon "github.com/milvus-io/milvus/pkg/common"
 	"github.com/milvus-io/milvus/pkg/log"
 	"github.com/milvus-io/milvus/pkg/metrics"
@@ -236,13 +237,15 @@ func (s *Server) CreateIndex(ctx context.Context, req *indexpb.CreateIndexReques
 			return merr.Status(err), nil
 		}
 	}
+	// exclude the mmap.enable param, because it will be conflict with the index's mmap.enable param
+	typeParams := DeleteParams(req.GetTypeParams(), []string{common.MmapEnabledKey})
 
 	index := &model.Index{
 		CollectionID:    req.GetCollectionID(),
 		FieldID:         req.GetFieldID(),
 		IndexID:         indexID,
 		IndexName:       req.GetIndexName(),
-		TypeParams:      req.GetTypeParams(),
+		TypeParams:      typeParams,
 		IndexParams:     req.GetIndexParams(),
 		CreateTime:      req.GetTimestamp(),
 		IsAutoIndex:     req.GetIsAutoIndex(),
@@ -327,7 +330,7 @@ func UpdateParams(index *model.Index, from []*commonpb.KeyValuePair, updates []*
 	})
 }
 
-func DeleteParams(index *model.Index, from []*commonpb.KeyValuePair, deletes []string) []*commonpb.KeyValuePair {
+func DeleteParams(from []*commonpb.KeyValuePair, deletes []string) []*commonpb.KeyValuePair {
 	params := make(map[string]string)
 	for _, param := range from {
 		params[param.GetKey()] = param.GetValue()
@@ -418,7 +421,7 @@ func (s *Server) AlterIndex(ctx context.Context, req *indexpb.AlterIndexRequest)
 			index.IndexParams = newIndexParams
 		} else if len(req.GetDeleteKeys()) > 0 {
 			// delete user index params
-			newUserIndexParams := DeleteParams(index, index.UserIndexParams, req.GetDeleteKeys())
+			newUserIndexParams := DeleteParams(index.UserIndexParams, req.GetDeleteKeys())
 			log.Info("alter index user deletekeys",
 				zap.String("indexName", index.IndexName),
 				zap.Any("params", newUserIndexParams),
@@ -426,7 +429,7 @@ func (s *Server) AlterIndex(ctx context.Context, req *indexpb.AlterIndexRequest)
 			index.UserIndexParams = newUserIndexParams
 
 			// delete index params
-			newIndexParams := DeleteParams(index, index.IndexParams, req.GetDeleteKeys())
+			newIndexParams := DeleteParams(index.IndexParams, req.GetDeleteKeys())
 			log.Info("alter index index deletekeys",
 				zap.String("indexName", index.IndexName),
 				zap.Any("params", newIndexParams),


### PR DESCRIPTION
Because when GetIndexParams is used, index params and type params are concatenated, so when loading index, the mmap.enable parameter in type params is also referenced.

- issue: #39801 
- pr: #39803