### PR TITLE
Revert "fix:reset default auto index type for scalar (#37086)"

### DIFF
--- a/internal/proxy/task_index_test.go
+++ b/internal/proxy/task_index_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"os"
 	"sort"
+	"strconv"
 	"testing"
 
 	"github.com/cockroachdb/errors"
@@ -708,7 +709,8 @@ func Test_parseIndexParams(t *testing.T) {
 		assert.NoError(t, err)
 		sortKeyValuePairs(cit.newIndexParams)
 		assert.Equal(t, cit.newIndexParams, []*commonpb.KeyValuePair{
-			{Key: common.IndexTypeKey, Value: indexparamcheck.IndexINVERTED},
+			{Key: common.IndexTypeKey, Value: indexparamcheck.IndexHybrid},
+			{Key: common.BitmapCardinalityLimitKey, Value: strconv.Itoa(paramtable.DefaultBitmapCardinalityLimit)},
 		})
 	})
 
@@ -936,7 +938,8 @@ func Test_parseIndexParams(t *testing.T) {
 		assert.NoError(t, err)
 		sortKeyValuePairs(cit.newIndexParams)
 		assert.Equal(t, cit.newIndexParams, []*commonpb.KeyValuePair{
-			{Key: common.IndexTypeKey, Value: indexparamcheck.IndexINVERTED},
+			{Key: common.IndexTypeKey, Value: indexparamcheck.IndexHybrid},
+			{Key: common.BitmapCardinalityLimitKey, Value: strconv.Itoa(paramtable.DefaultBitmapCardinalityLimit)},
 		})
 	})
 
@@ -965,7 +968,8 @@ func Test_parseIndexParams(t *testing.T) {
 		assert.NoError(t, err)
 		sortKeyValuePairs(cit.newIndexParams)
 		assert.Equal(t, cit.newIndexParams, []*commonpb.KeyValuePair{
-			{Key: common.IndexTypeKey, Value: indexparamcheck.IndexINVERTED},
+			{Key: common.IndexTypeKey, Value: indexparamcheck.IndexHybrid},
+			{Key: common.BitmapCardinalityLimitKey, Value: strconv.Itoa(paramtable.DefaultBitmapCardinalityLimit)},
 		})
 	})
 

--- a/pkg/util/paramtable/autoindex_param.go
+++ b/pkg/util/paramtable/autoindex_param.go
@@ -172,7 +172,7 @@ func (p *AutoIndexConfig) init(base *BaseTable) {
 	p.ScalarAutoIndexParams = ParamItem{
 		Key:          "scalarAutoIndex.params.build",
 		Version:      "2.4.0",
-		DefaultValue: `{"int": "INVERTED", "float": "INVERTED", "varchar": "INVERTED", "bool": "BITMAP"}`,
+		DefaultValue: `{"int": "HYBRID","varchar": "INVERTED","bool": "BITMAP", "float": "INVERTED"}`,
 	}
 	p.ScalarAutoIndexParams.Init(base.mgr)
 


### PR DESCRIPTION
This reverts commit eeb67a38450732eb8ab3a4eb4aaac6340142662.
pr: #39819