### PR TITLE
fix: [2.4] Check collection released before target checks

### DIFF
--- a/internal/querycoordv2/observers/target_observer.go
+++ b/internal/querycoordv2/observers/target_observer.go
@@ -220,11 +220,9 @@ func (ob *TargetObserver) schedule(ctx context.Context) {
 				delete(ob.readyNotifiers, req.CollectionID)
 				ob.mut.Unlock()
 
-				ob.loadedDispatcher.RemoveTask(req.CollectionID)
-				ob.loadingDispatcher.RemoveTask(req.CollectionID)
-
+				ob.keylocks.Lock(req.CollectionID)
 				ob.targetMgr.RemoveCollection(req.CollectionID)
-
+				ob.keylocks.Unlock(req.CollectionID)
 				req.Notifier <- nil
 			case ReleasePartition:
 				ob.targetMgr.RemovePartition(req.CollectionID, req.PartitionIDs...)
@@ -254,6 +252,11 @@ func (ob *TargetObserver) TriggerUpdateCurrentTarget(collectionID int64) {
 func (ob *TargetObserver) check(ctx context.Context, collectionID int64) {
 	ob.keylocks.Lock(collectionID)
 	defer ob.keylocks.Unlock(collectionID)
+
+	// if collection release, skip check
+	if ob.meta.CollectionManager.GetCollection(ctx, collectionID) == nil {
+		return
+	}
 
 	if ob.shouldUpdateCurrentTarget(ctx, collectionID) {
 		ob.updateCurrentTarget(collectionID)

--- a/internal/querycoordv2/observers/target_observer.go
+++ b/internal/querycoordv2/observers/target_observer.go
@@ -254,7 +254,7 @@ func (ob *TargetObserver) check(ctx context.Context, collectionID int64) {
 	defer ob.keylocks.Unlock(collectionID)
 
 	// if collection release, skip check
-	if ob.meta.CollectionManager.GetCollection(ctx, collectionID) == nil {
+	if ob.meta.CollectionManager.GetCollection(collectionID) == nil {
 		return
 	}
 

--- a/internal/querycoordv2/observers/target_observer.go
+++ b/internal/querycoordv2/observers/target_observer.go
@@ -220,7 +220,11 @@ func (ob *TargetObserver) schedule(ctx context.Context) {
 				delete(ob.readyNotifiers, req.CollectionID)
 				ob.mut.Unlock()
 
+				ob.loadedDispatcher.RemoveTask(req.CollectionID)
+				ob.loadingDispatcher.RemoveTask(req.CollectionID)
+
 				ob.targetMgr.RemoveCollection(req.CollectionID)
+
 				req.Notifier <- nil
 			case ReleasePartition:
 				ob.targetMgr.RemovePartition(req.CollectionID, req.PartitionIDs...)

--- a/internal/querycoordv2/observers/task_dispatcher.go
+++ b/internal/querycoordv2/observers/task_dispatcher.go
@@ -33,6 +33,7 @@ type taskDispatcher[K comparable] struct {
 	tasks      *typeutil.ConcurrentMap[K, bool]
 	pool       *conc.Pool[any]
 	notifyCh   chan struct{}
+	removeCh   chan K
 	taskRunner task[K]
 	wg         sync.WaitGroup
 	cancel     context.CancelFunc
@@ -46,6 +47,7 @@ func newTaskDispatcher[K comparable](runner task[K]) *taskDispatcher[K] {
 		tasks:      typeutil.NewConcurrentMap[K, bool](),
 		pool:       conc.NewPool[any](paramtable.Get().QueryCoordCfg.ObserverTaskParallel.GetAsInt()),
 		notifyCh:   make(chan struct{}, 1),
+		removeCh:   make(chan K),
 		taskRunner: runner,
 	}
 }
@@ -81,6 +83,10 @@ func (d *taskDispatcher[K]) AddTask(keys ...K) {
 	}
 }
 
+func (d *taskDispatcher[K]) RemoveTask(key K) {
+	d.removeCh <- key
+}
+
 func (d *taskDispatcher[K]) notify() {
 	select {
 	case d.notifyCh <- struct{}{}:
@@ -105,6 +111,8 @@ func (d *taskDispatcher[K]) schedule(ctx context.Context) {
 				}
 				return true
 			})
+		case key := <-d.removeCh:
+			d.tasks.Remove(key)
 		}
 	}
 }


### PR DESCRIPTION
Cherry-pick from master
pr: #39841
Related to #39840

The target could be updated async in previous code. This PR make remove collection from target observer block until all tasks related in dispatchers are removed preventing the metrics being updated after collection released.