### PR TITLE
fix: [2.5] Add and use lifetime context for compaction trigger (#39857)

### DIFF
--- a/internal/datacoord/compaction_policy_clustering.go
+++ b/internal/datacoord/compaction_policy_clustering.go
@@ -49,9 +49,8 @@ func (policy *clusteringCompactionPolicy) Enable() bool {
 		Params.DataCoordCfg.ClusteringCompactionAutoEnable.GetAsBool()
 }
 
-func (policy *clusteringCompactionPolicy) Trigger() (map[CompactionTriggerType][]CompactionView, error) {
+func (policy *clusteringCompactionPolicy) Trigger(ctx context.Context) (map[CompactionTriggerType][]CompactionView, error) {
 	log.Info("start trigger clusteringCompactionPolicy...")
-	ctx := context.Background()
 	collections := policy.meta.GetCollections()
 
 	events := make(map[CompactionTriggerType][]CompactionView, 0)

--- a/internal/datacoord/compaction_policy_clustering_test.go
+++ b/internal/datacoord/compaction_policy_clustering_test.go
@@ -99,7 +99,7 @@ func (s *ClusteringCompactionPolicySuite) TestEnable() {
 
 func (s *ClusteringCompactionPolicySuite) TestTriggerWithNoCollecitons() {
 	// trigger with no collections
-	events, err := s.clusteringCompactionPolicy.Trigger()
+	events, err := s.clusteringCompactionPolicy.Trigger(context.Background())
 	s.NoError(err)
 	gotViews, ok := events[TriggerTypeClustering]
 	s.True(ok)
@@ -132,7 +132,7 @@ func (s *ClusteringCompactionPolicySuite) TestTriggerWithCollections() {
 	})
 
 	// trigger
-	events, err := s.clusteringCompactionPolicy.Trigger()
+	events, err := s.clusteringCompactionPolicy.Trigger(context.Background())
 	s.NoError(err)
 	gotViews, ok := events[TriggerTypeClustering]
 	s.True(ok)

--- a/internal/datacoord/compaction_policy_single.go
+++ b/internal/datacoord/compaction_policy_single.go
@@ -46,8 +46,7 @@ func (policy *singleCompactionPolicy) Enable() bool {
 	return Params.DataCoordCfg.EnableAutoCompaction.GetAsBool()
 }
 
-func (policy *singleCompactionPolicy) Trigger() (map[CompactionTriggerType][]CompactionView, error) {
-	ctx := context.Background()
+func (policy *singleCompactionPolicy) Trigger(ctx context.Context) (map[CompactionTriggerType][]CompactionView, error) {
 	collections := policy.meta.GetCollections()
 
 	events := make(map[CompactionTriggerType][]CompactionView, 0)

--- a/internal/datacoord/compaction_policy_single_test.go
+++ b/internal/datacoord/compaction_policy_single_test.go
@@ -65,7 +65,7 @@ func (s *SingleCompactionPolicySuite) SetupTest() {
 }
 
 func (s *SingleCompactionPolicySuite) TestTrigger() {
-	events, err := s.singlePolicy.Trigger()
+	events, err := s.singlePolicy.Trigger(context.Background())
 	s.NoError(err)
 	gotViews, ok := events[TriggerTypeSingle]
 	s.True(ok)


### PR DESCRIPTION
Cherry-pick from master
pr: #39857 
Related to #39856

This PR add lifetime bound context for compaction trigger and use it instead of context.Background in case of rootcoord down and some grpc call retry forever

---------