### PR TITLE
enhance: [skip e2e] Bump actions/download-artifact to v4.1.3 fixing security issue

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -129,7 +129,7 @@ jobs:
           remove-android: 'true'
           remove-haskell: 'true'
       - name: Download code
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.1.3
         with:
           name: code
       - run: |
@@ -181,7 +181,7 @@ jobs:
           remove-android: 'true'
           remove-haskell: 'true'
       - name: Download code
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.1.3
         with:
           name: code
       - run: |
@@ -233,7 +233,7 @@ jobs:
           remove-android: 'true'
           remove-haskell: 'true'
       - name: Download code
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.1.3
         with:
           name: code
       - run: |
@@ -279,11 +279,11 @@ jobs:
         with:
           fetch-depth: 0
       - name: Download Go code coverage results
-        uses: actions/download-artifact@v4.1.0
+        uses: actions/download-artifact@v4.1.3
         with:
           name: go-result
       - name: Download Integration Test coverage results
-        uses: actions/download-artifact@v4.1.0
+        uses: actions/download-artifact@v4.1.3
         with:
           name: it-result
       - name: Display structure of code coverage results


### PR DESCRIPTION
Related to https://github.com/milvus-io/milvus/security/dependabot/110