### PR TITLE
enhance: [2.4] Optimize the result format of GetQueryNodeDistribution (#39664)

### DIFF
--- a/internal/proxy/management.go
+++ b/internal/proxy/management.go
@@ -23,6 +23,8 @@ import (
 	"strconv"
 	"sync"
 
+	"github.com/samber/lo"
+
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	management "github.com/milvus-io/milvus/internal/http"
 	"github.com/milvus-io/milvus/pkg/proto/datapb"
@@ -185,9 +187,22 @@ func (node *Proxy) GetQueryNodeDistribution(w http.ResponseWriter, req *http.Req
 		return
 	}
 	w.WriteHeader(http.StatusOK)
-	// skip marshal status to output
-	resp.Status = nil
-	bytes, err := json.Marshal(resp)
+
+	// Use string array for SealedSegmentIDs to prevent precision loss in JSON parsers.
+	// Large integers (int64) may be incorrectly rounded when parsed as double.
+	type distribution struct {
+		Channels         []string `json:"channel_names"`
+		SealedSegmentIDs []string `json:"sealed_segmentIDs"`
+	}
+
+	dist := distribution{
+		Channels: resp.ChannelNames,
+		SealedSegmentIDs: lo.Map(resp.SealedSegmentIDs, func(id int64, _ int) string {
+			return strconv.FormatInt(id, 10)
+		}),
+	}
+
+	bytes, err := json.Marshal(dist)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(fmt.Sprintf(`{"msg": "failed to get query node distribution, %s"}`, err.Error())))

--- a/internal/proxy/management_test.go
+++ b/internal/proxy/management_test.go
@@ -228,7 +228,6 @@ func (s *ProxyManagementSuite) TestGetQueryNodeDistribution() {
 
 		s.querycoord.EXPECT().GetQueryNodeDistribution(mock.Anything, mock.Anything).Return(&querypb.GetQueryNodeDistributionResponse{
 			Status:           merr.Success(),
-			ID:               1,
 			ChannelNames:     []string{"channel-1"},
 			SealedSegmentIDs: []int64{1, 2, 3},
 		}, nil)
@@ -240,7 +239,7 @@ func (s *ProxyManagementSuite) TestGetQueryNodeDistribution() {
 		recorder := httptest.NewRecorder()
 		s.proxy.GetQueryNodeDistribution(recorder, req)
 		s.Equal(http.StatusOK, recorder.Code)
-		s.Equal(`{"ID":1,"channel_names":["channel-1"],"sealed_segmentIDs":[1,2,3]}`, recorder.Body.String())
+		s.Equal(`{"channel_names":["channel-1"],"sealed_segmentIDs":["1","2","3"]}`, recorder.Body.String())
 	})
 
 	s.Run("return_error", func() {


### PR DESCRIPTION
pr: #39664
Use string array for SealedSegmentIDs to prevent precision loss in JSON parsers. Large integers (int64) may be incorrectly rounded when parsed as double.