### PR TITLE
fix: [2.5] Use `text_log` prefix for TextMatchIndex null offset file

### DIFF
--- a/internal/core/src/index/TextMatchIndex.cpp
+++ b/internal/core/src/index/TextMatchIndex.cpp
@@ -101,7 +101,7 @@ TextMatchIndex::Upload(const Config& config) {
     auto remote_paths_to_size = disk_file_manager_->GetRemotePathsToFileSize();
 
     auto binary_set = Serialize(config);
-    mem_file_manager_->AddFile(binary_set);
+    mem_file_manager_->AddTextLog(binary_set);
     auto remote_mem_path_to_size =
         mem_file_manager_->GetRemotePathsToFileSize();
 

--- a/internal/core/src/storage/MemFileManagerImpl.h
+++ b/internal/core/src/storage/MemFileManagerImpl.h
@@ -60,6 +60,9 @@ class MemFileManagerImpl : public FileManagerImpl {
     bool
     AddFile(const BinarySet& binary_set);
 
+    bool
+    AddTextLog(const BinarySet& binary_set);
+
     std::map<std::string, int64_t>
     GetRemotePathsToFileSize() const {
         return remote_paths_to_size_;
@@ -72,6 +75,10 @@ class MemFileManagerImpl : public FileManagerImpl {
 
     std::unordered_map<int64_t, std::vector<std::vector<uint32_t>>>
     CacheOptFieldToMemory(OptFieldT& fields_map);
+
+ private:
+    bool
+    AddBinarySet(const BinarySet& binary_set, const std::string& prefix);
 
  private:
     // remote file path


### PR DESCRIPTION
Cherry-pick from master
pr: #39935
Related to #39933