### PR TITLE
enhance: [2.5]Add scalarStats mmap to the Milvus configuration items

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -436,8 +436,8 @@ queryNode:
     vectorIndex: false # Enable mmap for loading vector index
     scalarField: false # Enable mmap for loading scalar data
     scalarIndex: false # Enable mmap for loading scalar index
-    scalarStats: true # Enable mmap for scalarStats json or text index
     chunkCache: true # Enable mmap for chunk cache (raw vector retrieving).
+    scalarStats: true # Enable mmap for loading scalar stats
     # Enable memory mapping (mmap) to optimize the handling of growing raw data. 
     # By activating this feature, the memory overhead associated with newly added or modified data will be significantly minimized. 
     # However, this optimization may come at the cost of a slight decrease in query latency for the affected data segments.

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -436,6 +436,7 @@ queryNode:
     vectorIndex: false # Enable mmap for loading vector index
     scalarField: false # Enable mmap for loading scalar data
     scalarIndex: false # Enable mmap for loading scalar index
+    scalarStats: true # Enable mmap for scalarStats json or text index
     chunkCache: true # Enable mmap for chunk cache (raw vector retrieving).
     # Enable memory mapping (mmap) to optimize the handling of growing raw data. 
     # By activating this feature, the memory overhead associated with newly added or modified data will be significantly minimized. 

--- a/internal/core/src/common/type_c.h
+++ b/internal/core/src/common/type_c.h
@@ -106,6 +106,7 @@ typedef struct CMmapConfig {
     bool scalar_field_enable_mmap;
     bool vector_index_enable_mmap;
     bool vector_field_enable_mmap;
+    bool scalar_stats_enable_mmap;
 } CMmapConfig;
 
 typedef struct CTraceConfig {

--- a/internal/core/src/exec/expression/Expr.cpp
+++ b/internal/core/src/exec/expression/Expr.cpp
@@ -152,8 +152,6 @@ CompileExpression(const expr::TypedExprPtr& expr,
                   const std::unordered_set<std::string>& flatten_candidates,
                   bool enable_constant_folding) {
     ExprPtr result;
-    std::cout << "CompileExpression context" << context->get_consistency_level()
-              << std::endl;
     auto compiled_inputs = CompileInputs(expr, context, flatten_candidates);
 
     auto GetTypes = [](const std::vector<ExprPtr>& exprs) {

--- a/internal/core/src/index/JsonKeyInvertedIndex.cpp
+++ b/internal/core/src/index/JsonKeyInvertedIndex.cpp
@@ -155,9 +155,9 @@ JsonKeyInvertedIndex::JsonKeyInvertedIndex(
         wrapper_ =
             std::make_shared<TantivyIndexWrapper>(field_name.c_str(),
                                                   d_type_,
-                                                  is_mmap ? path_.c_str() : "",
+                                                  !is_mmap ? "" : path_.c_str(),
                                                   false,
-                                                  is_mmap,
+                                                  !is_mmap,
                                                   1,
                                                   JSON_INDEX_MEMORY_BUDGET);
     }

--- a/internal/core/src/index/JsonKeyInvertedIndex.cpp
+++ b/internal/core/src/index/JsonKeyInvertedIndex.cpp
@@ -132,7 +132,7 @@ JsonKeyInvertedIndex::AddJson(const char* json, int64_t offset) {
 }
 
 JsonKeyInvertedIndex::JsonKeyInvertedIndex(
-    const storage::FileManagerContext& ctx, bool is_load)
+    const storage::FileManagerContext& ctx, bool is_load, bool is_mmap)
     : commit_interval_in_ms_(std::numeric_limits<int64_t>::max()),
       last_commit_time_(stdclock::now()) {
     schema_ = ctx.fieldDataMeta.field_schema;
@@ -144,6 +144,7 @@ JsonKeyInvertedIndex::JsonKeyInvertedIndex(
         auto prefix = disk_file_manager_->GetLocalJsonKeyIndexPrefix();
         path_ = prefix;
     } else {
+        LOG_INFO("Create JsonKeyInvertedIndex is mmap: {}", is_mmap);
         auto prefix = disk_file_manager_->GetJsonKeyIndexIdentifier();
         path_ = std::string(TMP_JSON_INVERTED_LOG_PREFIX) + prefix;
 
@@ -154,9 +155,9 @@ JsonKeyInvertedIndex::JsonKeyInvertedIndex(
         wrapper_ =
             std::make_shared<TantivyIndexWrapper>(field_name.c_str(),
                                                   d_type_,
-                                                  path_.c_str(),
+                                                  is_mmap ? path_.c_str() : "",
                                                   false,
-                                                  false,
+                                                  is_mmap,
                                                   1,
                                                   JSON_INDEX_MEMORY_BUDGET);
     }

--- a/internal/core/src/index/JsonKeyInvertedIndex.h
+++ b/internal/core/src/index/JsonKeyInvertedIndex.h
@@ -22,7 +22,8 @@ using stdclock = std::chrono::high_resolution_clock;
 class JsonKeyInvertedIndex : public InvertedIndexTantivy<std::string> {
  public:
     explicit JsonKeyInvertedIndex(const storage::FileManagerContext& ctx,
-                                  bool is_load);
+                                  bool is_load,
+                                  bool is_mmap = true);
 
     explicit JsonKeyInvertedIndex(int64_t commit_interval_in_ms,
                                   const char* unique_id);

--- a/internal/core/src/index/TextMatchIndex.cpp
+++ b/internal/core/src/index/TextMatchIndex.cpp
@@ -65,8 +65,8 @@ TextMatchIndex::TextMatchIndex(const storage::FileManagerContext& ctx,
         std::to_string(disk_file_manager_->GetFieldDataMeta().field_id);
     wrapper_ =
         std::make_shared<TantivyIndexWrapper>(field_name.c_str(),
-                                              is_mmap,
-                                              is_mmap ? path_.c_str() : "",
+                                              !is_mmap,
+                                              !is_mmap ? "" : path_.c_str(),
                                               tokenizer_name,
                                               analyzer_params);
 }

--- a/internal/core/src/index/TextMatchIndex.cpp
+++ b/internal/core/src/index/TextMatchIndex.cpp
@@ -48,7 +48,8 @@ TextMatchIndex::TextMatchIndex(const std::string& path,
 
 TextMatchIndex::TextMatchIndex(const storage::FileManagerContext& ctx,
                                const char* tokenizer_name,
-                               const char* analyzer_params)
+                               const char* analyzer_params,
+                               bool is_mmap)
     : commit_interval_in_ms_(std::numeric_limits<int64_t>::max()),
       last_commit_time_(stdclock::now()) {
     schema_ = ctx.fieldDataMeta.field_schema;
@@ -62,11 +63,12 @@ TextMatchIndex::TextMatchIndex(const storage::FileManagerContext& ctx,
     d_type_ = TantivyDataType::Text;
     std::string field_name =
         std::to_string(disk_file_manager_->GetFieldDataMeta().field_id);
-    wrapper_ = std::make_shared<TantivyIndexWrapper>(field_name.c_str(),
-                                                     false,
-                                                     path_.c_str(),
-                                                     tokenizer_name,
-                                                     analyzer_params);
+    wrapper_ =
+        std::make_shared<TantivyIndexWrapper>(field_name.c_str(),
+                                              is_mmap,
+                                              is_mmap ? path_.c_str() : "",
+                                              tokenizer_name,
+                                              analyzer_params);
 }
 
 TextMatchIndex::TextMatchIndex(const storage::FileManagerContext& ctx)

--- a/internal/core/src/index/TextMatchIndex.h
+++ b/internal/core/src/index/TextMatchIndex.h
@@ -35,7 +35,8 @@ class TextMatchIndex : public InvertedIndexTantivy<std::string> {
     // for building index.
     explicit TextMatchIndex(const storage::FileManagerContext& ctx,
                             const char* tokenizer_name,
-                            const char* analyzer_params);
+                            const char* analyzer_params,
+                            bool is_mmap = true);
     // for loading index
     explicit TextMatchIndex(const storage::FileManagerContext& ctx);
 

--- a/internal/core/src/indexbuilder/index_c.cpp
+++ b/internal/core/src/indexbuilder/index_c.cpp
@@ -35,7 +35,7 @@
 #include "storage/Util.h"
 #include "index/Meta.h"
 #include "index/JsonKeyInvertedIndex.h"
-
+#include "storage/MmapManager.h"
 using namespace milvus;
 CStatus
 CreateIndexV0(enum CDataType dtype,
@@ -269,8 +269,9 @@ BuildJsonKeyIndex(ProtoLayoutInterface result,
 
         auto field_schema =
             FieldMeta::ParseFrom(build_index_info->field_schema());
+        auto& cfg = storage::MmapManager::GetInstance().GetMmapConfig();
         auto index = std::make_unique<index::JsonKeyInvertedIndex>(
-            fileManagerContext, false);
+            fileManagerContext, false, cfg.GetScalarStatsEnableMmap());
         index->Build(config);
         auto create_index_result = index->Upload(config);
         create_index_result->SerializeAt(
@@ -336,10 +337,12 @@ BuildTextIndex(ProtoLayoutInterface result,
 
         auto field_schema =
             FieldMeta::ParseFrom(build_index_info->field_schema());
+        auto& cfg = storage::MmapManager::GetInstance().GetMmapConfig();
         auto index = std::make_unique<index::TextMatchIndex>(
             fileManagerContext,
             "milvus_tokenizer",
-            field_schema.get_analyzer_params().c_str());
+            field_schema.get_analyzer_params().c_str(),
+            cfg.GetScalarStatsEnableMmap());
         index->Build(config);
         auto create_index_result = index->Upload(config);
         create_index_result->SerializeAt(

--- a/internal/core/src/query/ExecPlanNodeVisitor.cpp
+++ b/internal/core/src/query/ExecPlanNodeVisitor.cpp
@@ -83,8 +83,6 @@ ExecPlanNodeVisitor::ExecuteTask(
               plan.plan_node_->ToString(),
               query_context->get_active_count(),
               query_context->get_query_timestamp());
-    std::cout << "ExecuteTask query_context"
-              << query_context->get_consistency_level() << std::endl;
     auto task =
         milvus::exec::Task::Create(DEFAULT_TASK_ID, plan, 0, query_context);
     int64_t processed_num = 0;

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -1472,8 +1472,9 @@ ChunkedSegmentSealedImpl::CreateTextIndex(FieldId field_id) {
     auto& cfg = storage::MmapManager::GetInstance().GetMmapConfig();
     std::unique_ptr<index::TextMatchIndex> index;
     std::string unique_id = GetUniqueFieldId(field_meta.get_id().get());
-    if (!cfg.GetScalarIndexEnableMmap()) {
+    if (!cfg.GetScalarStatsEnableMmap()) {
         // build text index in ram.
+        LOG_INFO("ChunkedSegmentSealedImpl CreateTextIndex in ram");
         index = std::make_unique<index::TextMatchIndex>(
             std::numeric_limits<int64_t>::max(),
             unique_id.c_str(),
@@ -1481,6 +1482,7 @@ ChunkedSegmentSealedImpl::CreateTextIndex(FieldId field_id) {
             field_meta.get_analyzer_params().c_str());
     } else {
         // build text index using mmap.
+        LOG_INFO("ChunkedSegmentSealedImpl CreateTextIndex in mmap");
         index = std::make_unique<index::TextMatchIndex>(
             cfg.GetMmapPath(),
             unique_id.c_str(),

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -875,7 +875,7 @@ SegmentGrowingImpl::CreateTextIndex(FieldId field_id) {
     std::string unique_id = GetUniqueFieldId(field_meta.get_id().get());
     // todo: make this(200) configurable.
     auto index = std::make_unique<index::TextMatchIndex>(
-        200,
+        JSON_INDEX_COMMIT_INTERVAL,
         unique_id.c_str(),
         "milvus_tokenizer",
         field_meta.get_analyzer_params().c_str());

--- a/internal/core/src/segcore/SegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/SegmentSealedImpl.cpp
@@ -2033,8 +2033,9 @@ SegmentSealedImpl::CreateTextIndex(FieldId field_id) {
     auto& cfg = storage::MmapManager::GetInstance().GetMmapConfig();
     std::unique_ptr<index::TextMatchIndex> index;
     std::string unique_id = GetUniqueFieldId(field_meta.get_id().get());
-    if (!cfg.GetScalarIndexEnableMmap()) {
+    if (!cfg.GetScalarStatsEnableMmap()) {
         // build text index in ram.
+        LOG_INFO("SegmentSealedImpl CreateTextIndex in ram");
         index = std::make_unique<index::TextMatchIndex>(
             std::numeric_limits<int64_t>::max(),
             unique_id.c_str(),
@@ -2042,6 +2043,7 @@ SegmentSealedImpl::CreateTextIndex(FieldId field_id) {
             field_meta.get_analyzer_params().c_str());
     } else {
         // build text index using mmap.
+        LOG_INFO("SegmentSealedImpl CreateTextIndex in mmap");
         index = std::make_unique<index::TextMatchIndex>(
             cfg.GetMmapPath(),
             unique_id.c_str(),

--- a/internal/core/src/storage/Types.h
+++ b/internal/core/src/storage/Types.h
@@ -133,6 +133,7 @@ struct MmapConfig {
     bool scalar_field_enable_mmap;
     bool vector_index_enable_mmap;
     bool vector_field_enable_mmap;
+    bool scalar_stats_enable_mmap;
     bool
     GetEnableGrowingMmap() const {
         return growing_enable_mmap;
@@ -174,6 +175,11 @@ struct MmapConfig {
         this->vector_field_enable_mmap = flag;
     }
 
+    bool
+    GetScalarStatsEnableMmap() const {
+        return scalar_stats_enable_mmap;
+    }
+
     std::string
     GetMmapPath() {
         return mmap_path;
@@ -188,6 +194,8 @@ struct MmapConfig {
            << ", growing_enable_mmap=" << std::boolalpha << growing_enable_mmap
            << ", scalar_index_enable_mmap=" << std::boolalpha
            << scalar_index_enable_mmap
+           << ", scalar_stats_enable_mmap=" << std::boolalpha
+           << scalar_stats_enable_mmap
            << ", scalar_field_enable_mmap=" << std::boolalpha
            << scalar_field_enable_mmap
            << ", vector_index_enable_mmap=" << std::boolalpha

--- a/internal/core/src/storage/storage_c.cpp
+++ b/internal/core/src/storage/storage_c.cpp
@@ -105,6 +105,8 @@ InitMmapManager(CMmapConfig c_mmap_config) {
             c_mmap_config.vector_index_enable_mmap;
         mmap_config.vector_field_enable_mmap =
             c_mmap_config.vector_field_enable_mmap;
+        mmap_config.scalar_stats_enable_mmap =
+            c_mmap_config.scalar_stats_enable_mmap;
         milvus::storage::MmapManager::GetInstance().Init(mmap_config);
         return milvus::SuccessCStatus();
     } catch (std::exception& e) {

--- a/internal/indexnode/indexnode.go
+++ b/internal/indexnode/indexnode.go
@@ -207,6 +207,8 @@ func (i *IndexNode) initSegcore() {
 
 	cJSONIndexEnabled := C.bool(Params.DataCoordCfg.EnabledJSONKeyStats.GetAsBool())
 	C.InitDefaultJSONKeyIndexEnable(cJSONIndexEnabled)
+
+	initcore.InitMmapManager(paramtable.Get())
 }
 
 func (i *IndexNode) CloseSegcore() {

--- a/internal/indexnode/indexnode.go
+++ b/internal/indexnode/indexnode.go
@@ -208,6 +208,8 @@ func (i *IndexNode) initSegcore() {
 	cJSONIndexEnabled := C.bool(Params.DataCoordCfg.EnabledJSONKeyStats.GetAsBool())
 	C.InitDefaultJSONKeyIndexEnable(cJSONIndexEnabled)
 
+	initcore.InitRemoteChunkManager(paramtable.Get())
+
 	initcore.InitMmapManager(paramtable.Get())
 }
 

--- a/internal/util/initcore/init_core.go
+++ b/internal/util/initcore/init_core.go
@@ -193,6 +193,7 @@ func InitMmapManager(params *paramtable.ComponentParam) error {
 		scalar_field_enable_mmap: C.bool(params.QueryNodeCfg.MmapScalarField.GetAsBool()),
 		vector_index_enable_mmap: C.bool(params.QueryNodeCfg.MmapVectorIndex.GetAsBool()),
 		vector_field_enable_mmap: C.bool(params.QueryNodeCfg.MmapVectorField.GetAsBool()),
+		scalar_stats_enable_mmap: C.bool(params.QueryNodeCfg.MmapScalarStats.GetAsBool()),
 	}
 	status := C.InitMmapManager(mmapConfig)
 	return HandleCStatus(&status, "InitMmapManager failed")

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -2514,6 +2514,7 @@ type queryNodeConfig struct {
 	MmapScalarField                     ParamItem `refreshable:"false"`
 	MmapScalarIndex                     ParamItem `refreshable:"false"`
 	MmapChunkCache                      ParamItem `refreshable:"false"`
+	MmapScalarStats                     ParamItem `refreshable:"false"`
 	GrowingMmapEnabled                  ParamItem `refreshable:"false"`
 	FixedFileSizeForMmapManager         ParamItem `refreshable:"false"`
 	MaxMmapDiskPercentageForMmapManager ParamItem `refreshable:"false"`
@@ -2885,6 +2886,21 @@ This defaults to true, indicating that Milvus creates temporary index for growin
 		Export: true,
 	}
 	p.MmapScalarIndex.Init(base.mgr)
+
+	p.MmapScalarStats = ParamItem{
+		Key:          "queryNode.mmap.scalarStats",
+		Version:      "2.5.4",
+		DefaultValue: "true",
+		Formatter: func(originValue string) string {
+			if p.MmapEnabled.GetAsBool() {
+				return "true"
+			}
+			return originValue
+		},
+		Doc:    "Enable mmap for loading scalar stats",
+		Export: true,
+	}
+	p.MmapScalarStats.Init(base.mgr)
 
 	p.MmapChunkCache = ParamItem{
 		Key:          "queryNode.mmap.chunkCache",


### PR DESCRIPTION
Modify the code for text match and json key index in version 2.5.5 to use mmap.scalarStats. This parameter determines whether to use the RAM mode or the mmap mode.These configuration items only serve the sealedsegment.
issue: https://github.com/milvus-io/milvus/issues/39944
pr: https://github.com/milvus-io/milvus/pull/38039