### PR TITLE
fix: Skip text index creation when segment is zero after sorting

### DIFF
--- a/internal/indexnode/index_test.go
+++ b/internal/indexnode/index_test.go
@@ -166,3 +166,20 @@ func generateTestData(collID, partID, segID int64, num int) ([]*Blob, error) {
 	blobs, err := insertCodec.Serialize(partID, segID, data)
 	return blobs, err
 }
+
+func generateDeleteData(collID, partID, segID int64, num int) ([]*Blob, error) {
+	pks := make([]storage.PrimaryKey, 0, num)
+	tss := make([]storage.Timestamp, 0, num)
+	for i := 1; i <= num; i++ {
+		pks = append(pks, storage.NewInt64PrimaryKey(int64(i)))
+		tss = append(tss, storage.Timestamp(i+1))
+	}
+
+	deleteCodec := storage.NewDeleteCodec()
+	blob, err := deleteCodec.Serialize(collID, partID, segID, &storage.DeleteData{
+		Pks:      pks,
+		Tss:      tss,
+		RowCount: int64(num),
+	})
+	return []*Blob{blob}, err
+}

--- a/internal/indexnode/task_stats.go
+++ b/internal/indexnode/task_stats.go
@@ -276,6 +276,11 @@ func (st *statsTask) Execute(ctx context.Context) error {
 		}
 	}
 
+	if len(insertLogs) == 0 {
+		log.Ctx(ctx).Info("there is no insertBinlogs, skip creating text index")
+		return nil
+	}
+
 	if st.req.GetSubJobType() == indexpb.StatsSubJob_Sort || st.req.GetSubJobType() == indexpb.StatsSubJob_TextIndexJob {
 		err = st.createTextIndex(ctx,
 			st.req.GetStorageConfig(),


### PR DESCRIPTION
issue: #39961 