### PR TITLE
fix: [2.5]exists expr on nested dictionaries fail in JSONkeyIndex

### DIFF
--- a/internal/core/src/index/JsonKeyInvertedIndex.cpp
+++ b/internal/core/src/index/JsonKeyInvertedIndex.cpp
@@ -49,6 +49,10 @@ JsonKeyInvertedIndex::TravelJson(const char* json,
     jsmntok current = tokens[0];
     Assert(current.type != JSMN_UNDEFINED);
     if (current.type == JSMN_OBJECT) {
+        if (!path.empty()) {
+            AddInvertedRecord(
+                path, offset, current.start, current.end - current.start);
+        }
         int j = 1;
         for (int i = 0; i < current.size; i++) {
             Assert(tokens[j].type == JSMN_STRING && tokens[j].size != 0);


### PR DESCRIPTION
fix: exists expr on nested dictionaries fail in JSONkeyIndex
issue: https://github.com/milvus-io/milvus/issues/39963
pr: https://github.com/milvus-io/milvus/pull/38039