### PR TITLE
fix: [2.5] Use start pos ts instead for sealSegmentByLifetime policy

### DIFF
--- a/internal/datacoord/segment_allocation_policy.go
+++ b/internal/datacoord/segment_allocation_policy.go
@@ -157,10 +157,15 @@ func sealL1SegmentByCapacity(sizeFactor float64) segmentSealPolicyFunc {
 }
 
 // sealL1SegmentByLifetimePolicy get segmentSealPolicy with lifetime limit compares ts - segment.lastExpireTime
-func sealL1SegmentByLifetime(lifetime time.Duration) segmentSealPolicyFunc {
+func sealL1SegmentByLifetime() segmentSealPolicyFunc {
 	return func(segment *SegmentInfo, ts Timestamp) (bool, string) {
+		if segment.GetStartPosition() == nil {
+			return false, ""
+		}
+		lifetime := Params.DataCoordCfg.SegmentMaxLifetime.GetAsDuration(time.Second)
 		pts, _ := tsoutil.ParseTS(ts)
-		epts, _ := tsoutil.ParseTS(segment.GetLastExpireTime())
+		epts, _ := tsoutil.ParseTS(segment.GetStartPosition().GetTimestamp())
+		// epts, _ := tsoutil.ParseTS(segment.GetLastExpireTime())
 		d := pts.Sub(epts)
 		return d >= lifetime,
 			fmt.Sprintf("Segment Lifetime expired, segment last expire: %v, now:%v, max lifetime %v",

--- a/internal/datacoord/segment_manager.go
+++ b/internal/datacoord/segment_manager.go
@@ -198,7 +198,7 @@ func defaultAllocatePolicy() AllocatePolicy {
 func defaultSegmentSealPolicy() []SegmentSealPolicy {
 	return []SegmentSealPolicy{
 		sealL1SegmentByBinlogFileNumber(Params.DataCoordCfg.SegmentMaxBinlogFileNumber.GetAsInt()),
-		sealL1SegmentByLifetime(Params.DataCoordCfg.SegmentMaxLifetime.GetAsDuration(time.Second)),
+		sealL1SegmentByLifetime(),
 		sealL1SegmentByCapacity(Params.DataCoordCfg.SegmentSealProportion.GetAsFloat()),
 		sealL1SegmentByIdleTime(Params.DataCoordCfg.SegmentMaxIdleTime.GetAsDuration(time.Second), Params.DataCoordCfg.SegmentMinSizeFromIdleToSealed.GetAsFloat(), Params.DataCoordCfg.SegmentMaxSize.GetAsFloat()),
 	}


### PR DESCRIPTION
Cherry-pick from master
pr: #39982
Related to #39981