### PR TITLE
enhance: Make the benchmark test available and add a JSON index benchmark test

### DIFF
--- a/internal/core/unittest/bench/CMakeLists.txt
+++ b/internal/core/unittest/bench/CMakeLists.txt
@@ -13,8 +13,10 @@ include_directories(${CMAKE_HOME_DIRECTORY}/src)
 include_directories(${CMAKE_HOME_DIRECTORY}/unittest)
 
 set(bench_srcs
+    bench_init.cpp
     bench_naive.cpp
     bench_search.cpp
+    bench_json_expr.cpp
 )
 
 set(indexbuilder_bench_srcs
@@ -29,6 +31,8 @@ target_link_libraries(all_bench
         )
 
 target_link_libraries(all_bench benchmark_main)
+
+install(TARGETS all_bench DESTINATION unittest)
 
 add_executable(indexbuilder_bench ${indexbuilder_bench_srcs})
 target_link_libraries(indexbuilder_bench

--- a/internal/core/unittest/bench/bench_init.cpp
+++ b/internal/core/unittest/bench/bench_init.cpp
@@ -1,0 +1,25 @@
+#include <folly/init/Init.h>
+
+#include "storage/LocalChunkManagerSingleton.h"
+#include "storage/RemoteChunkManagerSingleton.h"
+#include "storage/MmapManager.h"
+#include "test_utils/Constants.h"
+#include "test_utils/storage_test_utils.h"
+#include <benchmark/benchmark.h>
+
+int
+main(int argc, char** argv) {
+    folly::Init follyInit(&argc, &argv, false);
+
+    milvus::storage::LocalChunkManagerSingleton::GetInstance().Init(
+        TestLocalPath);
+    milvus::storage::RemoteChunkManagerSingleton::GetInstance().Init(
+        get_default_local_storage_config());
+    milvus::storage::MmapManager::GetInstance().Init(get_default_mmap_config());
+
+    benchmark::Initialize(&argc, argv);
+    benchmark::RunSpecifiedBenchmarks();
+    benchmark::Shutdown();
+
+    return 0;
+}

--- a/internal/core/unittest/bench/bench_json_expr.cpp
+++ b/internal/core/unittest/bench/bench_json_expr.cpp
@@ -90,7 +90,7 @@ BENCHMARK_DEFINE_F(JsonExprBenchmark, BM_JsonBruteForce)
     }
 }
 
-BENCHMARK_DEFINE_F(JsonExprBenchmark, BM_JsonValueIndex)
+BENCHMARK_DEFINE_F(JsonExprBenchmark, BM_JsonPathIndex)
 (benchmark::State& state) {
     auto schema = kTestData.schema_;
     auto segment = milvus::segcore::CreateSealedSegment(schema);
@@ -138,6 +138,6 @@ BENCHMARK_REGISTER_F(JsonExprBenchmark, BM_JsonBruteForce)
     ->Arg(1000)
     ->Arg(1000000);
 
-BENCHMARK_REGISTER_F(JsonExprBenchmark, BM_JsonValueIndex)
+BENCHMARK_REGISTER_F(JsonExprBenchmark, BM_JsonPathIndex)
     ->Arg(1000)
     ->Arg(1000000);

--- a/internal/core/unittest/bench/bench_json_expr.cpp
+++ b/internal/core/unittest/bench/bench_json_expr.cpp
@@ -1,0 +1,124 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+
+#include <benchmark/benchmark.h>
+#include <string>
+#include <nlohmann/json.hpp>
+#include "common/IndexMeta.h"
+#include "common/Schema.h"
+#include "common/Types.h"
+#include "expr/ITypeExpr.h"
+#include "index/IndexFactory.h"
+#include "index/JsonInvertedIndex.h"
+#include "mmap/Types.h"
+#include "pb/plan.pb.h"
+#include "plan/PlanNode.h"
+#include "query/ExecPlanNodeVisitor.h"
+#include "test_utils/DataGen.h"
+#include <segcore/SegmentSealedImpl.h>
+
+using json = nlohmann::json;
+
+static const auto kTestDataSize = 1000000;
+static const auto kTestData = milvus::segcore::DataGen(
+    []() {
+        auto schema = std::make_shared<milvus::Schema>();
+        schema->AddField(milvus::FieldName("json_field"),
+                         milvus::FieldId(100),
+                         milvus::DataType::JSON,
+                         false);
+        return schema;
+    }(),
+    kTestDataSize);
+
+static const auto kTestExpr = []() {
+    auto field_id = kTestData.raw_->fields_data().at(0).field_id();
+    auto value = milvus::proto::plan::GenericValue();
+    value.set_int64_val(1);
+    return std::make_shared<milvus::expr::UnaryRangeFilterExpr>(
+        milvus::expr::ColumnInfo(
+            milvus::FieldId(field_id), milvus::DataType::JSON, {"int"}, false),
+        milvus::proto::plan::OpType::Equal,
+        value,
+        std::vector<milvus::proto::plan::GenericValue>());
+}();
+
+static void
+BM_JsonBruteForce(benchmark::State& state) {
+    auto schema = kTestData.schema_;
+    auto segment = milvus::segcore::CreateSealedSegment(schema);
+
+    auto field_data = kTestData.raw_->fields_data().at(0);
+    auto field_id = field_data.field_id();
+
+    auto info = milvus::FieldDataInfo(field_id, kTestDataSize, "/tmp/a");
+    info.channel->push(milvus::segcore::CreateFieldDataFromDataArray(
+        kTestDataSize,
+        &field_data,
+        schema->get_fields().at(milvus::FieldId(field_id))));
+    info.channel->close();
+    segment->LoadFieldData(milvus::FieldId(field_id), info);
+
+    auto plan = std::make_shared<milvus::plan::FilterBitsNode>(
+        DEFAULT_PLANNODE_ID, kTestExpr);
+    for (auto _ : state) {
+        auto final = milvus::query::ExecuteQueryExpr(
+            plan, segment.get(), kTestDataSize, milvus::MAX_TIMESTAMP);
+    }
+}
+
+BENCHMARK(BM_JsonBruteForce);
+
+static void
+BM_JsonValueIndex(benchmark::State& state) {
+    auto schema = kTestData.schema_;
+    auto segment = milvus::segcore::CreateSealedSegment(schema);
+
+    auto field_data = kTestData.raw_->fields_data().at(0);
+    auto field_id = field_data.field_id();
+    auto file_manager_ctx = milvus::storage::FileManagerContext();
+    file_manager_ctx.fieldDataMeta.field_schema.set_data_type(
+        milvus::proto::schema::JSON);
+    file_manager_ctx.fieldDataMeta.field_schema.set_fieldid(100);
+    auto inv_index = milvus::index::IndexFactory::GetInstance().CreateJsonIndex(
+        milvus::index::INVERTED_INDEX_TYPE,
+        milvus::DataType::INT64,
+        "/int",
+        file_manager_ctx);
+    using json_index_type = milvus::index::JsonInvertedIndex<milvus::Json>;
+    auto json_index = std::unique_ptr<json_index_type>(
+        static_cast<json_index_type*>(inv_index.release()));
+    auto json_field = milvus::segcore::CreateFieldDataFromDataArray(
+        kTestDataSize,
+        &field_data,
+        schema->get_fields().at(milvus::FieldId(field_id)));
+    json_index->BuildWithFieldData({json_field});
+    json_index->finish();
+    json_index->create_reader();
+    milvus::segcore::LoadIndexInfo load_index_info;
+    load_index_info.field_id = field_id;
+    load_index_info.field_type = milvus::DataType::INT64;
+    load_index_info.index = std::move(json_index);
+    load_index_info.index_params = {{JSON_PATH, "/int"}};
+    segment->LoadIndex(load_index_info);
+
+    auto json_field_data_info =
+        milvus::FieldDataInfo(field_id, kTestDataSize, {json_field});
+    segment->LoadFieldData(milvus::FieldId(field_id), json_field_data_info);
+    auto plan = std::make_shared<milvus::plan::FilterBitsNode>(
+        DEFAULT_PLANNODE_ID, kTestExpr);
+    for (auto _ : state) {
+        auto final = milvus::query::ExecuteQueryExpr(
+            plan, segment.get(), kTestDataSize, milvus::MAX_TIMESTAMP);
+    }
+}
+
+BENCHMARK(BM_JsonValueIndex);


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/35528

We add tests to compare the performance of brute-force JSON filtering and JSON index filtering using a unary equal expression(eg. json["a"] == 1). The tests will be conducted on randomly generated datasets of 1,000 and 1 million records.
```
--------------------------------------------------------------------------------------
Benchmark                                            Time             CPU   Iterations
--------------------------------------------------------------------------------------
JsonExprBenchmark/BM_JsonBruteForce/1000        108163 ns       108164 ns         5617
JsonExprBenchmark/BM_JsonBruteForce/1000000  107266651 ns    107263478 ns            7


--------------------------------------------------------------------------------------
Benchmark                                            Time             CPU   Iterations
--------------------------------------------------------------------------------------
JsonExprBenchmark/BM_JsonValueIndex/1000         29513 ns        29514 ns        20895
JsonExprBenchmark/BM_JsonValueIndex/1000000     228472 ns       228450 ns         2958
```