### PR TITLE
fix: Fall back to a brute-force search if json index type unmatched

### DIFF
--- a/internal/core/src/common/Types.h
+++ b/internal/core/src/common/Types.h
@@ -594,6 +594,23 @@ struct TypeTraits<DataType::VECTOR_FLOAT> {
     static constexpr const char* Name = "VECTOR_FLOAT";
 };
 
+inline DataType
+FromValCase(milvus::proto::plan::GenericValue::ValCase val_case) {
+    switch (val_case) {
+        case milvus::proto::plan::GenericValue::ValCase::kBoolVal:
+            return milvus::DataType::BOOL;
+        case milvus::proto::plan::GenericValue::ValCase::kInt64Val:
+            return DataType::INT64;
+        case milvus::proto::plan::GenericValue::ValCase::kFloatVal:
+            return DataType::DOUBLE;
+        case milvus::proto::plan::GenericValue::ValCase::kStringVal:
+            return DataType::STRING;
+        case milvus::proto::plan::GenericValue::ValCase::kArrayVal:
+            return DataType::ARRAY;
+        default:
+            return DataType::NONE;
+    }
+}
 }  // namespace milvus
 template <>
 struct fmt::formatter<milvus::DataType> : formatter<string_view> {

--- a/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.h
+++ b/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.h
@@ -455,6 +455,7 @@ class PhyBinaryArithOpEvalRangeExpr : public SegmentExpr {
                       segment,
                       expr->column_.field_id_,
                       expr->column_.nested_path_,
+                      DataType::NONE,
                       active_count,
                       batch_size),
           expr_(expr) {

--- a/internal/core/src/exec/expression/BinaryRangeExpr.h
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.h
@@ -231,6 +231,7 @@ class PhyBinaryRangeFilterExpr : public SegmentExpr {
                       segment,
                       expr->column_.field_id_,
                       expr->column_.nested_path_,
+                      DataType::NONE,
                       active_count,
                       batch_size),
           expr_(expr) {

--- a/internal/core/src/exec/expression/ExistsExpr.h
+++ b/internal/core/src/exec/expression/ExistsExpr.h
@@ -48,6 +48,7 @@ class PhyExistsFilterExpr : public SegmentExpr {
                       segment,
                       expr->column_.field_id_,
                       expr->column_.nested_path_,
+                      DataType::NONE,
                       active_count,
                       batch_size),
           expr_(expr) {

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -114,13 +114,14 @@ class SegmentExpr : public Expr {
                 const segcore::SegmentInternalInterface* segment,
                 const FieldId field_id,
                 const std::vector<std::string> nested_path,
+                const DataType value_type,
                 int64_t active_count,
                 int64_t batch_size)
         : Expr(DataType::BOOL, std::move(input), name),
           segment_(segment),
           field_id_(field_id),
           nested_path_(nested_path),
-
+          value_type_(value_type),
           active_count_(active_count),
           batch_size_(batch_size) {
         size_per_chunk_ = segment_->size_per_chunk();
@@ -146,7 +147,8 @@ class SegmentExpr : public Expr {
 
         if (field_meta.get_data_type() == DataType::JSON) {
             auto pointer = milvus::Json::pointer(nested_path_);
-            if (is_index_mode_ = segment_->HasIndex(field_id_, pointer)) {
+            if (is_index_mode_ =
+                    segment_->HasIndex(field_id_, pointer, value_type_)) {
                 num_index_chunk_ = 1;
             }
         } else {
@@ -1095,7 +1097,7 @@ class SegmentExpr : public Expr {
 
     std::vector<std::string> nested_path_;
     DataType field_type_;
-
+    DataType value_type_;
     bool is_index_mode_{false};
     bool is_data_mode_{false};
     // sometimes need to skip index and using raw data

--- a/internal/core/src/exec/expression/JsonContainsExpr.h
+++ b/internal/core/src/exec/expression/JsonContainsExpr.h
@@ -42,6 +42,7 @@ class PhyJsonContainsFilterExpr : public SegmentExpr {
                       segment,
                       expr->column_.field_id_,
                       expr->column_.nested_path_,
+                      DataType::NONE,
                       active_count,
                       batch_size),
           expr_(expr) {

--- a/internal/core/src/exec/expression/NullExpr.h
+++ b/internal/core/src/exec/expression/NullExpr.h
@@ -41,6 +41,7 @@ class PhyNullExpr : public SegmentExpr {
                       segment,
                       expr->column_.field_id_,
                       expr->column_.nested_path_,
+                      DataType::NONE,
                       active_count,
                       batch_size),
           expr_(expr) {

--- a/internal/core/src/exec/expression/TermExpr.h
+++ b/internal/core/src/exec/expression/TermExpr.h
@@ -63,6 +63,7 @@ class PhyTermFilterExpr : public SegmentExpr {
                       segment,
                       expr->column_.field_id_,
                       expr->column_.nested_path_,
+                      DataType::NONE,
                       active_count,
                       batch_size),
           expr_(expr),

--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -308,145 +308,144 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplArray(OffsetVector* input) {
     if (expr_->column_.nested_path_.size() > 0) {
         index = std::stoi(expr_->column_.nested_path_[0]);
     }
-    auto execute_sub_batch =
-        [op_type]<FilterType filter_type = FilterType::sequential>(
-            const milvus::ArrayView* data,
-            const bool* valid_data,
-            const int32_t* offsets,
-            const int size,
-            TargetBitmapView res,
-            TargetBitmapView valid_res,
-            ValueType val,
-            int index) {
-            switch (op_type) {
-                case proto::plan::GreaterThan: {
-                    UnaryElementFuncForArray<ValueType,
-                                             proto::plan::GreaterThan,
-                                             filter_type>
-                        func;
-                    func(data,
-                         valid_data,
-                         size,
-                         val,
-                         index,
-                         res,
-                         valid_res,
-                         offsets);
-                    break;
-                }
-                case proto::plan::GreaterEqual: {
-                    UnaryElementFuncForArray<ValueType,
-                                             proto::plan::GreaterEqual,
-                                             filter_type>
-                        func;
-                    func(data,
-                         valid_data,
-                         size,
-                         val,
-                         index,
-                         res,
-                         valid_res,
-                         offsets);
-                    break;
-                }
-                case proto::plan::LessThan: {
-                    UnaryElementFuncForArray<ValueType,
-                                             proto::plan::LessThan,
-                                             filter_type>
-                        func;
-                    func(data,
-                         valid_data,
-                         size,
-                         val,
-                         index,
-                         res,
-                         valid_res,
-                         offsets);
-                    break;
-                }
-                case proto::plan::LessEqual: {
-                    UnaryElementFuncForArray<ValueType,
-                                             proto::plan::LessEqual,
-                                             filter_type>
-                        func;
-                    func(data,
-                         valid_data,
-                         size,
-                         val,
-                         index,
-                         res,
-                         valid_res,
-                         offsets);
-                    break;
-                }
-                case proto::plan::Equal: {
-                    UnaryElementFuncForArray<ValueType,
-                                             proto::plan::Equal,
-                                             filter_type>
-                        func;
-                    func(data,
-                         valid_data,
-                         size,
-                         val,
-                         index,
-                         res,
-                         valid_res,
-                         offsets);
-                    break;
-                }
-                case proto::plan::NotEqual: {
-                    UnaryElementFuncForArray<ValueType,
-                                             proto::plan::NotEqual,
-                                             filter_type>
-                        func;
-                    func(data,
-                         valid_data,
-                         size,
-                         val,
-                         index,
-                         res,
-                         valid_res,
-                         offsets);
-                    break;
-                }
-                case proto::plan::PrefixMatch: {
-                    UnaryElementFuncForArray<ValueType,
-                                             proto::plan::PrefixMatch,
-                                             filter_type>
-                        func;
-                    func(data,
-                         valid_data,
-                         size,
-                         val,
-                         index,
-                         res,
-                         valid_res,
-                         offsets);
-                    break;
-                }
-                case proto::plan::Match: {
-                    UnaryElementFuncForArray<ValueType,
-                                             proto::plan::Match,
-                                             filter_type>
-                        func;
-                    func(data,
-                         valid_data,
-                         size,
-                         val,
-                         index,
-                         res,
-                         valid_res,
-                         offsets);
-                    break;
-                }
-                default:
-                    PanicInfo(
-                        OpTypeInvalid,
-                        fmt::format(
-                            "unsupported operator type for unary expr: {}",
-                            op_type));
+    auto execute_sub_batch = [op_type]<FilterType filter_type =
+                                           FilterType::sequential>(
+        const milvus::ArrayView* data,
+        const bool* valid_data,
+        const int32_t* offsets,
+        const int size,
+        TargetBitmapView res,
+        TargetBitmapView valid_res,
+        ValueType val,
+        int index) {
+        switch (op_type) {
+            case proto::plan::GreaterThan: {
+                UnaryElementFuncForArray<ValueType,
+                                         proto::plan::GreaterThan,
+                                         filter_type>
+                    func;
+                func(data,
+                     valid_data,
+                     size,
+                     val,
+                     index,
+                     res,
+                     valid_res,
+                     offsets);
+                break;
             }
-        };
+            case proto::plan::GreaterEqual: {
+                UnaryElementFuncForArray<ValueType,
+                                         proto::plan::GreaterEqual,
+                                         filter_type>
+                    func;
+                func(data,
+                     valid_data,
+                     size,
+                     val,
+                     index,
+                     res,
+                     valid_res,
+                     offsets);
+                break;
+            }
+            case proto::plan::LessThan: {
+                UnaryElementFuncForArray<ValueType,
+                                         proto::plan::LessThan,
+                                         filter_type>
+                    func;
+                func(data,
+                     valid_data,
+                     size,
+                     val,
+                     index,
+                     res,
+                     valid_res,
+                     offsets);
+                break;
+            }
+            case proto::plan::LessEqual: {
+                UnaryElementFuncForArray<ValueType,
+                                         proto::plan::LessEqual,
+                                         filter_type>
+                    func;
+                func(data,
+                     valid_data,
+                     size,
+                     val,
+                     index,
+                     res,
+                     valid_res,
+                     offsets);
+                break;
+            }
+            case proto::plan::Equal: {
+                UnaryElementFuncForArray<ValueType,
+                                         proto::plan::Equal,
+                                         filter_type>
+                    func;
+                func(data,
+                     valid_data,
+                     size,
+                     val,
+                     index,
+                     res,
+                     valid_res,
+                     offsets);
+                break;
+            }
+            case proto::plan::NotEqual: {
+                UnaryElementFuncForArray<ValueType,
+                                         proto::plan::NotEqual,
+                                         filter_type>
+                    func;
+                func(data,
+                     valid_data,
+                     size,
+                     val,
+                     index,
+                     res,
+                     valid_res,
+                     offsets);
+                break;
+            }
+            case proto::plan::PrefixMatch: {
+                UnaryElementFuncForArray<ValueType,
+                                         proto::plan::PrefixMatch,
+                                         filter_type>
+                    func;
+                func(data,
+                     valid_data,
+                     size,
+                     val,
+                     index,
+                     res,
+                     valid_res,
+                     offsets);
+                break;
+            }
+            case proto::plan::Match: {
+                UnaryElementFuncForArray<ValueType,
+                                         proto::plan::Match,
+                                         filter_type>
+                    func;
+                func(data,
+                     valid_data,
+                     size,
+                     val,
+                     index,
+                     res,
+                     valid_res,
+                     offsets);
+                break;
+            }
+            default:
+                PanicInfo(
+                    OpTypeInvalid,
+                    fmt::format("unsupported operator type for unary expr: {}",
+                                op_type));
+        }
+    };
     int64_t processed_size;
     if (has_offset_input_) {
         processed_size =
@@ -512,7 +511,7 @@ PhyUnaryRangeFilterExpr::ExecArrayEqualForIndex(bool reverse) {
                 };
             } else {
                 auto size_per_chunk = segment_->size_per_chunk();
-                retrieve = [size_per_chunk, this](int64_t offset) -> auto {
+                retrieve = [ size_per_chunk, this ](int64_t offset) -> auto {
                     auto chunk_idx = offset / size_per_chunk;
                     auto chunk_offset = offset % size_per_chunk;
                     const auto& chunk =
@@ -636,15 +635,15 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJson(OffsetVector* input) {
         res[i] = (cmp);                                             \
     } while (false)
 
-    auto execute_sub_batch = [op_type, pointer]<FilterType filter_type =
-                                                    FilterType::sequential>(
-                                 const milvus::Json* data,
-                                 const bool* valid_data,
-                                 const int32_t* offsets,
-                                 const int size,
-                                 TargetBitmapView res,
-                                 TargetBitmapView valid_res,
-                                 ExprValueType val) {
+    auto execute_sub_batch =
+        [ op_type, pointer ]<FilterType filter_type = FilterType::sequential>(
+            const milvus::Json* data,
+            const bool* valid_data,
+            const int32_t* offsets,
+            const int size,
+            TargetBitmapView res,
+            TargetBitmapView valid_res,
+            ExprValueType val) {
         switch (op_type) {
             case proto::plan::GreaterThan: {
                 for (size_t i = 0; i < size; ++i) {
@@ -1025,13 +1024,13 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplForData(OffsetVector* input) {
 
     auto execute_sub_batch = [expr_type]<FilterType filter_type =
                                              FilterType::sequential>(
-                                 const T* data,
-                                 const bool* valid_data,
-                                 const int32_t* offsets,
-                                 const int size,
-                                 TargetBitmapView res,
-                                 TargetBitmapView valid_res,
-                                 IndexInnerType val) {
+        const T* data,
+        const bool* valid_data,
+        const int32_t* offsets,
+        const int size,
+        TargetBitmapView res,
+        TargetBitmapView valid_res,
+        IndexInnerType val) {
         switch (expr_type) {
             case proto::plan::GreaterThan: {
                 UnaryElementFunc<T, proto::plan::GreaterThan, filter_type> func;

--- a/internal/core/src/exec/expression/UnaryExpr.h
+++ b/internal/core/src/exec/expression/UnaryExpr.h
@@ -322,6 +322,7 @@ class PhyUnaryRangeFilterExpr : public SegmentExpr {
                       segment,
                       expr->column_.field_id_,
                       expr->column_.nested_path_,
+                      FromValCase(expr->val_.val_case()),
                       active_count,
                       batch_size),
           expr_(expr) {
@@ -382,7 +383,7 @@ class PhyUnaryRangeFilterExpr : public SegmentExpr {
     CanUseIndexForArray();
 
     bool
-    CanUseIndexForJson();
+    CanUseIndexForJson(DataType val_type);
 
     VectorPtr
     ExecTextMatch();

--- a/internal/core/src/index/Index.h
+++ b/internal/core/src/index/Index.h
@@ -72,6 +72,11 @@ class IndexBase {
         return index_type_;
     }
 
+    virtual enum DataType
+    JsonCastType() const {
+        return DataType::NONE;
+    }
+
  protected:
     explicit IndexBase(IndexType index_type)
         : index_type_(std::move(index_type)) {

--- a/internal/core/src/index/JsonInvertedIndex.h
+++ b/internal/core/src/index/JsonInvertedIndex.h
@@ -12,6 +12,7 @@
 #pragma once
 #include "common/FieldDataInterface.h"
 #include "index/InvertedIndexTantivy.h"
+#include "index/ScalarIndex.h"
 #include "storage/FileManager.h"
 #include "boost/filesystem.hpp"
 #include "tantivy-binding.h"
@@ -24,7 +25,7 @@ class JsonInvertedIndex : public index::InvertedIndexTantivy<T> {
     JsonInvertedIndex(const proto::schema::DataType cast_type,
                       const std::string& nested_path,
                       const storage::FileManagerContext& ctx)
-        : nested_path_(nested_path) {
+        : nested_path_(nested_path), cast_type_(cast_type) {
         this->schema_ = ctx.fieldDataMeta.field_schema;
         this->mem_file_manager_ =
             std::make_shared<storage::MemFileManagerImpl>(ctx);
@@ -61,7 +62,14 @@ class JsonInvertedIndex : public index::InvertedIndexTantivy<T> {
         this->wrapper_->create_reader();
     }
 
+    enum DataType
+    JsonCastType() const override {
+        return static_cast<enum DataType>(cast_type_);
+    }
+
  private:
     std::string nested_path_;
+    proto::schema::DataType cast_type_;
 };
+
 }  // namespace milvus::index

--- a/internal/core/src/segcore/SegmentGrowingImpl.h
+++ b/internal/core/src/segcore/SegmentGrowingImpl.h
@@ -310,7 +310,9 @@ class SegmentGrowingImpl : public SegmentGrowing {
     }
 
     bool
-    HasIndex(FieldId field_id, const std::string& nested_path) const override {
+    HasIndex(FieldId field_id,
+             const std::string& nested_path,
+             DataType data_type) const override {
         return false;
     };
 

--- a/internal/core/src/segcore/SegmentInterface.h
+++ b/internal/core/src/segcore/SegmentInterface.h
@@ -282,7 +282,9 @@ class SegmentInternalInterface : public SegmentInterface {
     HasIndex(FieldId field_id) const = 0;
 
     virtual bool
-    HasIndex(FieldId field_id, const std::string& nested_path) const {
+    HasIndex(FieldId field_id,
+             const std::string& nested_path,
+             DataType data_type) const {
         PanicInfo(ErrorCode::NotImplemented, "not implemented");
     };
     virtual bool

--- a/internal/core/src/segcore/SegmentSealed.h
+++ b/internal/core/src/segcore/SegmentSealed.h
@@ -16,6 +16,7 @@
 #include <tuple>
 
 #include "common/LoadInfo.h"
+#include "index/JsonInvertedIndex.h"
 #include "pb/segcore.pb.h"
 #include "segcore/SegmentInterface.h"
 #include "segcore/Types.h"
@@ -75,11 +76,18 @@ class SegmentSealed : public SegmentInternalInterface {
     virtual bool
     HasIndex(FieldId field_id) const override = 0;
     bool
-    HasIndex(FieldId field_id, const std::string& path) const override {
+    HasIndex(FieldId field_id,
+             const std::string& path,
+             DataType data_type) const override {
         JSONIndexKey key;
         key.field_id = field_id;
         key.nested_path = path;
-        return json_indexings_.find(key) != json_indexings_.end();
+        auto index = json_indexings_.find(key);
+        if (index == json_indexings_.end()) {
+            return false;
+        }
+
+        return data_type == index->second->JsonCastType();
     }
 
  protected:

--- a/internal/core/src/segcore/SegmentSealed.h
+++ b/internal/core/src/segcore/SegmentSealed.h
@@ -83,11 +83,8 @@ class SegmentSealed : public SegmentInternalInterface {
         key.field_id = field_id;
         key.nested_path = path;
         auto index = json_indexings_.find(key);
-        if (index == json_indexings_.end()) {
-            return false;
-        }
-
-        return data_type == index->second->JsonCastType();
+        return index != json_indexings_.end() &&
+               data_type == index->second->JsonCastType();
     }
 
  protected:


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/35528
If the query data type does not match the index type, fall back to a brute-force search