### PR TITLE
fix: Add sub task pool for multi-stage tasks

### DIFF
--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -140,6 +140,7 @@ type task interface {
 	CanSkipAllocTimestamp() bool
 	SetOnEnqueueTime()
 	GetDurationInQueue() time.Duration
+	IsSubTask() bool
 }
 
 type baseTask struct {
@@ -156,6 +157,10 @@ func (bt *baseTask) SetOnEnqueueTime() {
 
 func (bt *baseTask) GetDurationInQueue() time.Duration {
 	return time.Since(bt.onEnqueueTime)
+}
+
+func (bt *baseTask) IsSubTask() bool {
+	return false
 }
 
 type dmlTask interface {

--- a/internal/proxy/task_query.go
+++ b/internal/proxy/task_query.go
@@ -564,6 +564,10 @@ func (t *queryTask) PostExecute(ctx context.Context) error {
 	return nil
 }
 
+func (t *queryTask) IsSubTask() bool {
+	return t.reQuery
+}
+
 func (t *queryTask) queryShard(ctx context.Context, nodeID int64, qn types.QueryNodeClient, channel string) error {
 	needOverrideMvcc := false
 	mvccTs := t.MvccTimestamp

--- a/internal/proxy/task_scheduler.go
+++ b/internal/proxy/task_scheduler.go
@@ -554,7 +554,10 @@ func (sched *taskScheduler) manipulationLoop() {
 func (sched *taskScheduler) queryLoop() {
 	defer sched.wg.Done()
 
-	pool := conc.NewPool[struct{}](paramtable.Get().ProxyCfg.MaxTaskNum.GetAsInt(), conc.WithExpiryDuration(time.Minute))
+	poolSize := paramtable.Get().ProxyCfg.MaxTaskNum.GetAsInt()
+	pool := conc.NewPool[struct{}](poolSize, conc.WithExpiryDuration(time.Minute))
+	subTaskPool := conc.NewPool[struct{}](poolSize, conc.WithExpiryDuration(time.Minute))
+
 	for {
 		select {
 		case <-sched.ctx.Done():
@@ -562,7 +565,12 @@ func (sched *taskScheduler) queryLoop() {
 		case <-sched.dqQueue.utChan():
 			if !sched.dqQueue.utEmpty() {
 				t := sched.scheduleDqTask()
-				pool.Submit(func() (struct{}, error) {
+				p := pool
+				// if task is sub task spawned by another, use sub task pool in case of deadlock
+				if t.IsSubTask() {
+					p = subTaskPool
+				}
+				p.Submit(func() (struct{}, error) {
 					sched.processTask(t, sched.dqQueue)
 					return struct{}{}, nil
 				})


### PR DESCRIPTION
Related to #40078

Add a subTaskPool to execute sub task in case of logic deadlock described in issue.