### PR TITLE
enhance: Remove hardcoded partition num in restful handler

### DIFF
--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -1497,7 +1497,6 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 				fieldSchema.AutoID = httpReq.Schema.AutoId
 			}
 			if field.IsPartitionKey {
-				partitionsNum = int64(64)
 				if partitionsNumStr, ok := httpReq.Params["partitionsNum"]; ok {
 					if partitions, err := strconv.ParseInt(fmt.Sprintf("%v", partitionsNumStr), 10, 64); err == nil {
 						partitionsNum = partitions


### PR DESCRIPTION
The partition num shall be determined by core logic if user did not specifiy the partition num in request.