### PR TITLE
fix: [2.4] Fix collections with duplicate names can be created

### DIFF
--- a/internal/rootcoord/create_collection_task_test.go
+++ b/internal/rootcoord/create_collection_task_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"math"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -747,6 +748,8 @@ func Test_createCollectionTask_Execute(t *testing.T) {
 			mock.Anything,
 			mock.Anything,
 		).Return(coll, nil)
+		meta.EXPECT().DescribeAlias(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return("", merr.WrapErrAliasNotFound("", ""))
 
 		core := newTestCore(withMeta(meta), withTtSynchronizer(ticker))
 
@@ -794,6 +797,8 @@ func Test_createCollectionTask_Execute(t *testing.T) {
 			mock.Anything,
 			mock.Anything,
 		).Return(coll, nil)
+		meta.EXPECT().DescribeAlias(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return("", merr.WrapErrAliasNotFound("", ""))
 
 		core := newTestCore(withMeta(meta), withTtSynchronizer(ticker))
 
@@ -828,6 +833,40 @@ func Test_createCollectionTask_Execute(t *testing.T) {
 		assert.Error(t, err)
 	})
 
+	t.Run("collection name duplicates an alias", func(t *testing.T) {
+		defer cleanTestEnv()
+
+		collectionName := funcutil.GenRandomStr()
+		ticker := newRocksMqTtSynchronizer()
+		field1 := funcutil.GenRandomStr()
+		schema := &schemapb.CollectionSchema{Name: collectionName, Fields: []*schemapb.FieldSchema{{Name: field1}}}
+
+		meta := mockrootcoord.NewIMetaTable(t)
+		// mock collection name duplicates an alias
+		meta.EXPECT().DescribeAlias(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return(collectionName, nil)
+
+		core := newTestCore(withMeta(meta), withTtSynchronizer(ticker))
+		task := &createCollectionTask{
+			baseTask: newBaseTask(context.Background(), core),
+			Req: &milvuspb.CreateCollectionRequest{
+				Base:           &commonpb.MsgBase{MsgType: commonpb.MsgType_CreateCollection},
+				DbName:         "mock-db",
+				CollectionName: collectionName,
+				Properties: []*commonpb.KeyValuePair{
+					{
+						Key:   common.ConsistencyLevel,
+						Value: "1",
+					},
+				},
+			},
+			schema: schema,
+		}
+		err := task.Execute(context.Background())
+		assert.Error(t, err)
+		assert.True(t, strings.Contains(err.Error(), "conflicts with an existing alias"))
+	})
+
 	t.Run("normal case", func(t *testing.T) {
 		defer cleanTestEnv()
 
@@ -855,6 +894,8 @@ func Test_createCollectionTask_Execute(t *testing.T) {
 			mock.Anything,
 			mock.Anything,
 		).Return(nil)
+		meta.EXPECT().DescribeAlias(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return("", merr.WrapErrAliasNotFound("", ""))
 
 		dc := newMockDataCoord()
 		dc.GetComponentStatesFunc = func(ctx context.Context) (*milvuspb.ComponentStates, error) {
@@ -939,6 +980,8 @@ func Test_createCollectionTask_Execute(t *testing.T) {
 			mock.Anything,
 			mock.Anything,
 		).Return(errors.New("error mock ChangeCollectionState"))
+		meta.EXPECT().DescribeAlias(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return("", merr.WrapErrAliasNotFound("", ""))
 
 		removeCollectionCalled := false
 		removeCollectionChan := make(chan struct{}, 1)

--- a/internal/rootcoord/drop_collection_task_test.go
+++ b/internal/rootcoord/drop_collection_task_test.go
@@ -191,15 +191,10 @@ func Test_dropCollectionTask_Execute(t *testing.T) {
 		coll := &model.Collection{Name: collectionName, ShardsNum: int32(shardNum), PhysicalChannelNames: pchans}
 
 		meta := mockrootcoord.NewIMetaTable(t)
-		meta.On("GetCollectionByName",
-			mock.Anything,
-			mock.Anything,
-			mock.Anything,
-			mock.Anything,
-		).Return(coll.Clone(), nil)
-		meta.On("ListAliasesByID",
-			mock.Anything,
-		).Return([]string{"mock-alias-0", "mock-alias-1"})
+		meta.EXPECT().GetCollectionByName(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return(coll.Clone(), nil)
+		meta.EXPECT().ListAliasesByID(mock.Anything, mock.Anything).
+			Return([]string{"mock-alias-0", "mock-alias-1"})
 
 		core := newTestCore(
 			withMeta(meta),

--- a/internal/rootcoord/drop_collection_task_test.go
+++ b/internal/rootcoord/drop_collection_task_test.go
@@ -193,7 +193,7 @@ func Test_dropCollectionTask_Execute(t *testing.T) {
 		meta := mockrootcoord.NewIMetaTable(t)
 		meta.EXPECT().GetCollectionByName(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 			Return(coll.Clone(), nil)
-		meta.EXPECT().ListAliasesByID(mock.Anything, mock.Anything).
+		meta.EXPECT().ListAliasesByID(mock.Anything).
 			Return([]string{"mock-alias-0", "mock-alias-1"})
 
 		core := newTestCore(

--- a/internal/rootcoord/drop_collection_task_test.go
+++ b/internal/rootcoord/drop_collection_task_test.go
@@ -18,6 +18,7 @@ package rootcoord
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -175,6 +176,45 @@ func Test_dropCollectionTask_Execute(t *testing.T) {
 		}
 		err := task.Execute(context.Background())
 		assert.Error(t, err)
+	})
+
+	t.Run("aliases have not been dropped", func(t *testing.T) {
+		defer cleanTestEnv()
+
+		collectionName := funcutil.GenRandomStr()
+		shardNum := 2
+
+		ticker := newRocksMqTtSynchronizer()
+		pchans := ticker.getDmlChannelNames(shardNum)
+		ticker.addDmlChannels(pchans...)
+
+		coll := &model.Collection{Name: collectionName, ShardsNum: int32(shardNum), PhysicalChannelNames: pchans}
+
+		meta := mockrootcoord.NewIMetaTable(t)
+		meta.On("GetCollectionByName",
+			mock.Anything,
+			mock.Anything,
+			mock.Anything,
+			mock.Anything,
+		).Return(coll.Clone(), nil)
+		meta.On("ListAliasesByID",
+			mock.Anything,
+		).Return([]string{"mock-alias-0", "mock-alias-1"})
+
+		core := newTestCore(
+			withMeta(meta),
+			withTtSynchronizer(ticker))
+
+		task := &dropCollectionTask{
+			baseTask: newBaseTask(context.Background(), core),
+			Req: &milvuspb.DropCollectionRequest{
+				Base:           &commonpb.MsgBase{MsgType: commonpb.MsgType_DropCollection},
+				CollectionName: collectionName,
+			},
+		}
+		err := task.Execute(context.Background())
+		assert.Error(t, err)
+		assert.True(t, strings.Contains(err.Error(), "please remove all aliases"))
 	})
 
 	t.Run("normal case, redo", func(t *testing.T) {

--- a/tests/python_client/milvus_client/test_milvus_client_alias.py
+++ b/tests/python_client/milvus_client/test_milvus_client_alias.py
@@ -196,6 +196,7 @@ class TestMilvusClientAliasInvalid(TestcaseBase):
                                                 f"[alias={alias}]"}
         client_w.create_alias(client, collection_name_1, alias,
                               check_task=CheckTasks.err_res, check_items=error)
+        client_w.drop_alias(client, alias)
         client_w.drop_collection(client, collection_name)
 
     @pytest.mark.tags(CaseLabel.L1)
@@ -373,6 +374,7 @@ class TestMilvusClientAliasInvalid(TestcaseBase):
         error = {ct.err_code: 1600, ct.err_msg: f"alias not found[database=default][alias={collection_name}]"}
         client_w.alter_alias(client, collection_name, another_alias,
                              check_task=CheckTasks.err_res, check_items=error)
+        client_w.drop_alias(client, alias)
         client_w.drop_collection(client, collection_name)
 
 
@@ -501,4 +503,6 @@ class TestMilvusClientAliasValid(TestcaseBase):
         # 4. assert collection is equal to alias according to partitions
         partition_name_list_alias = client_w.list_partitions(client, another_alias)[0]
         assert partition_name_list == partition_name_list_alias
+        client_w.drop_alias(client, alias)
+        client_w.drop_alias(client, another_alias)
         client_w.drop_collection(client, collection_name)

--- a/tests/python_client/testcases/test_alias.py
+++ b/tests/python_client/testcases/test_alias.py
@@ -194,6 +194,7 @@ class TestAliasOperation(TestcaseBase):
 
         assert res is True
 
+    @pytest.mark.skip(reason="https://github.com/milvus-io/milvus/issues/40030, TODO: need to fix")
     @pytest.mark.tags(CaseLabel.L2)
     def test_alias_called_by_utility_drop_collection(self):
         """
@@ -426,6 +427,7 @@ class TestAliasOperationInvalid(TestcaseBase):
                  ct.err_msg: f"cannot drop the collection via alias = {alias_name}"}
         collection_alias.drop(check_task=CheckTasks.err_res, check_items=error)
 
+    @pytest.mark.skip(reason="https://github.com/milvus-io/milvus/issues/40030, TODO: need to fix")
     @pytest.mark.tags(CaseLabel.L0)
     @pytest.mark.xfail(reason="issue #36963")
     def test_alias_reuse_alias_name_from_dropped_collection(self):
@@ -461,6 +463,7 @@ class TestAliasOperationInvalid(TestcaseBase):
         res2 = self.utility_wrap.list_aliases(c_name)[0]
         assert len(res2) == 1
 
+    @pytest.mark.skip(reason="https://github.com/milvus-io/milvus/issues/40030, TODO: need to fix")
     @pytest.mark.tags(CaseLabel.L0)
     @pytest.mark.xfail(reason="issue #36963")
     def test_alias_rename_collection_to_alias_name(self):

--- a/tests/python_client/testcases/test_alias.py
+++ b/tests/python_client/testcases/test_alias.py
@@ -194,7 +194,6 @@ class TestAliasOperation(TestcaseBase):
 
         assert res is True
 
-    @pytest.mark.skip(reason="https://github.com/milvus-io/milvus/issues/40030, TODO: need to fix")
     @pytest.mark.tags(CaseLabel.L2)
     def test_alias_called_by_utility_drop_collection(self):
         """
@@ -223,6 +222,7 @@ class TestAliasOperation(TestcaseBase):
         self.utility_wrap.drop_collection(alias_name,
                                           check_task=CheckTasks.err_res,
                                           check_items=error)
+        self.utility_wrap.drop_alias(alias_name)
         self.utility_wrap.drop_collection(c_name)
         assert not self.utility_wrap.has_collection(c_name)[0]
 
@@ -427,7 +427,6 @@ class TestAliasOperationInvalid(TestcaseBase):
                  ct.err_msg: f"cannot drop the collection via alias = {alias_name}"}
         collection_alias.drop(check_task=CheckTasks.err_res, check_items=error)
 
-    @pytest.mark.skip(reason="https://github.com/milvus-io/milvus/issues/40030, TODO: need to fix")
     @pytest.mark.tags(CaseLabel.L0)
     @pytest.mark.xfail(reason="issue #36963")
     def test_alias_reuse_alias_name_from_dropped_collection(self):
@@ -452,6 +451,7 @@ class TestAliasOperationInvalid(TestcaseBase):
         assert len(res) == 1
 
         # dropping collection that has an alias shall drop the alias as well
+        self.utility_wrap.drop_alias(alias_name)
         collection_w.drop()
         collection_w = self.init_collection_wrap(name=c_name, schema=default_schema,
                                                  check_task=CheckTasks.check_collection_property,
@@ -463,7 +463,6 @@ class TestAliasOperationInvalid(TestcaseBase):
         res2 = self.utility_wrap.list_aliases(c_name)[0]
         assert len(res2) == 1
 
-    @pytest.mark.skip(reason="https://github.com/milvus-io/milvus/issues/40030, TODO: need to fix")
     @pytest.mark.tags(CaseLabel.L0)
     @pytest.mark.xfail(reason="issue #36963")
     def test_alias_rename_collection_to_alias_name(self):
@@ -473,6 +472,7 @@ class TestAliasOperationInvalid(TestcaseBase):
                 1.create a collection
                 2.create an alias for the collection
                 3.rename the collection to the alias name
+        expected: in step 3, rename collection to alias name failed
         """
         self._connect()
         c_name = cf.gen_unique_str("collection")
@@ -485,13 +485,3 @@ class TestAliasOperationInvalid(TestcaseBase):
                  ct.err_msg: f"duplicated new collection name default:{alias_name} with other collection name or alias"}
         self.utility_wrap.rename_collection(collection_w.name, alias_name,
                                             check_task=CheckTasks.err_res, check_items=error)
-
-        collection_w.drop()
-        collection_w = self.init_collection_wrap(name=c_name, schema=default_schema,
-                                                 check_task=CheckTasks.check_collection_property,
-                                                 check_items={exp_name: c_name, exp_schema: default_schema})
-        error = {ct.err_code: 999,
-                 ct.err_msg: f"this is not expected, any collection name or alias name shall be unique"}
-        self.utility_wrap.rename_collection(collection_w.name, alias_name,
-                                            check_task=CheckTasks.err_res, check_items=error)
-

--- a/tests/python_client/testcases/test_query.py
+++ b/tests/python_client/testcases/test_query.py
@@ -3576,6 +3576,7 @@ class TestQueryCount(TestcaseBase):
         collection_w_alias.drop(check_task=CheckTasks.err_res,
                                 check_items={ct.err_code: 1,
                                              ct.err_msg: "cannot drop the collection via alias"})
+        self.utility_wrap.drop_alias(alias)
         collection_w.drop()
 
     @pytest.mark.tags(CaseLabel.L2)


### PR DESCRIPTION
This PR introduces two restrictions:

1. Before dropping a collection, all aliases associated with that collection must be dropped.
2. When creating a collection, if the collection name duplicates any alias, the collection creation will fail.

issue: https://github.com/milvus-io/milvus/issues/40142

pr: https://github.com/milvus-io/milvus/pull/40143