### PR TITLE
enhance: [2.4] Remove hardcoded partition num in restful handler (#40112)

### DIFF
--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -1230,7 +1230,6 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 				fieldSchema.AutoID = httpReq.Schema.AutoId
 			}
 			if field.IsPartitionKey {
-				partitionsNum = int64(64)
 				if partitionsNumStr, ok := httpReq.Params["partitionsNum"]; ok {
 					if partitions, err := strconv.ParseInt(fmt.Sprintf("%v", partitionsNumStr), 10, 64); err == nil {
 						partitionsNum = partitions


### PR DESCRIPTION
Cherry-pick from master
pr: #40112 
The partition num shall be determined by core logic if user did not specifiy the partition num in request.