### PR TITLE
fix: add missing OS_NAME variable in build script for Linux

### DIFF
--- a/scripts/3rdparty_build.sh
+++ b/scripts/3rdparty_build.sh
@@ -66,6 +66,11 @@ case "${unameOut}" in
     conan install ${CPP_SRC_DIR} --install-folder conan --build=missing -s compiler=clang -s compiler.version=${llvm_version} -s compiler.libcxx=libc++ -s compiler.cppstd=17 -r default-conan-local -u || { echo 'conan install failed'; exit 1; }
     ;;
   Linux*)
+    if [ -f /etc/os-release ]; then
+        OS_NAME=$(grep '^PRETTY_NAME=' /etc/os-release | cut -d '=' -f2 | tr -d '"')
+    else
+        OS_NAME="Linux"
+    fi
     echo "Running on ${OS_NAME}"
     export CPU_TARGET=avx
     GCC_VERSION=`gcc -dumpversion`


### PR DESCRIPTION
issue: #40243
This helps identify the running OS version during the build process, ensuring better logging.