### PR TITLE
fix: [GoSDK] Return role without grants

### DIFF
--- a/client/milvusclient/database_options.go
+++ b/client/milvusclient/database_options.go
@@ -61,18 +61,26 @@ type CreateDatabaseOption interface {
 }
 
 type createDatabaseOption struct {
-	dbName string
+	dbName     string
+	Properties map[string]string
 }
 
 func (opt *createDatabaseOption) Request() *milvuspb.CreateDatabaseRequest {
 	return &milvuspb.CreateDatabaseRequest{
-		DbName: opt.dbName,
+		DbName:     opt.dbName,
+		Properties: entity.MapKvPairs(opt.Properties),
 	}
+}
+
+func (opt *createDatabaseOption) WithProperty(key string, val any) *createDatabaseOption {
+	opt.Properties[key] = fmt.Sprintf("%v", val)
+	return opt
 }
 
 func NewCreateDatabaseOption(dbName string) *createDatabaseOption {
 	return &createDatabaseOption{
-		dbName: dbName,
+		dbName:     dbName,
+		Properties: make(map[string]string),
 	}
 }
 

--- a/client/milvusclient/rbac.go
+++ b/client/milvusclient/rbac.go
@@ -128,11 +128,22 @@ func (c *Client) DropRole(ctx context.Context, opt DropRoleOption, callOpts ...g
 }
 
 func (c *Client) DescribeRole(ctx context.Context, option DescribeRoleOption, callOptions ...grpc.CallOption) (*entity.Role, error) {
-	req := option.Request()
-
 	var role *entity.Role
 	err := c.callService(func(milvusService milvuspb.MilvusServiceClient) error {
-		resp, err := milvusService.SelectGrant(ctx, req, callOptions...)
+		roleResp, err := milvusService.SelectRole(ctx, option.SelectRoleRequest(), callOptions...)
+		if err := merr.CheckRPCCall(roleResp, err); err != nil {
+			return err
+		}
+
+		if len(roleResp.GetResults()) == 0 {
+			return errors.New("role not found")
+		}
+
+		role = &entity.Role{
+			RoleName: roleResp.GetResults()[0].GetRole().GetName(),
+		}
+
+		resp, err := milvusService.SelectGrant(ctx, option.Request(), callOptions...)
 		if err := merr.CheckRPCCall(resp, err); err != nil {
 			return err
 		}
@@ -140,18 +151,16 @@ func (c *Client) DescribeRole(ctx context.Context, option DescribeRoleOption, ca
 			return errors.New("role not found")
 		}
 
-		role = &entity.Role{
-			RoleName: req.GetEntity().GetRole().GetName(),
-			Privileges: lo.Map(resp.GetEntities(), func(g *milvuspb.GrantEntity, _ int) entity.GrantItem {
-				return entity.GrantItem{
-					Object:     g.Object.GetName(),
-					ObjectName: g.GetObjectName(),
-					RoleName:   g.GetRole().GetName(),
-					Grantor:    g.GetGrantor().GetUser().GetName(),
-					Privilege:  g.GetGrantor().GetPrivilege().GetName(),
-				}
-			}),
-		}
+		role.Privileges = lo.Map(resp.GetEntities(), func(g *milvuspb.GrantEntity, _ int) entity.GrantItem {
+			return entity.GrantItem{
+				Object:     g.GetObject().GetName(),
+				ObjectName: g.GetObjectName(),
+				RoleName:   g.GetRole().GetName(),
+				Grantor:    g.GetGrantor().GetUser().GetName(),
+				Privilege:  g.GetGrantor().GetPrivilege().GetName(),
+			}
+		})
+
 		return nil
 	})
 	return role, err

--- a/client/milvusclient/rbac.go
+++ b/client/milvusclient/rbac.go
@@ -147,9 +147,6 @@ func (c *Client) DescribeRole(ctx context.Context, option DescribeRoleOption, ca
 		if err := merr.CheckRPCCall(resp, err); err != nil {
 			return err
 		}
-		if len(resp.GetEntities()) == 0 {
-			return errors.New("role not found")
-		}
 
 		role.Privileges = lo.Map(resp.GetEntities(), func(g *milvuspb.GrantEntity, _ int) entity.GrantItem {
 			return entity.GrantItem{

--- a/client/milvusclient/rbac_options.go
+++ b/client/milvusclient/rbac_options.go
@@ -234,11 +234,20 @@ func NewDropRoleOption(roleName string) *dropDropRoleOption {
 }
 
 type DescribeRoleOption interface {
+	SelectRoleRequest() *milvuspb.SelectRoleRequest
 	Request() *milvuspb.SelectGrantRequest
 }
 
 type describeRoleOption struct {
 	roleName string
+}
+
+func (opt *describeRoleOption) SelectRoleRequest() *milvuspb.SelectRoleRequest {
+	return &milvuspb.SelectRoleRequest{
+		Role: &milvuspb.RoleEntity{
+			Name: opt.roleName,
+		},
+	}
 }
 
 func (opt *describeRoleOption) Request() *milvuspb.SelectGrantRequest {

--- a/client/milvusclient/rbac_test.go
+++ b/client/milvusclient/rbac_test.go
@@ -340,7 +340,6 @@ func (s *RoleSuite) TestDescribeRole() {
 
 	s.Run("failure", func() {
 		s.mock.EXPECT().SelectRole(mock.Anything, mock.Anything).Return(nil, merr.WrapErrServiceInternal("mocked")).Once()
-		// s.mock.EXPECT().SelectGrant(mock.Anything, mock.Anything).Return(nil, merr.WrapErrServiceInternal("mocked")).Once()
 
 		_, err := s.client.DescribeRole(ctx, NewDescribeRoleOption("role"))
 		s.Error(err)


### PR DESCRIPTION
Related to #40274

Previousy DescribeRole returns only roles with grants, this PR add select role action to check role existence.

Also added database properties related option