### PR TITLE
enhance: Balance the collection with the largest row count first

### DIFF
--- a/internal/querycoordv2/meta/mock_target_manager.go
+++ b/internal/querycoordv2/meta/mock_target_manager.go
@@ -74,6 +74,54 @@ func (_c *MockTargetManager_CanSegmentBeMoved_Call) RunAndReturn(run func(contex
 	return _c
 }
 
+// GetCollectionRowCount provides a mock function with given fields: ctx, collectionID, scope
+func (_m *MockTargetManager) GetCollectionRowCount(ctx context.Context, collectionID int64, scope int32) int64 {
+	ret := _m.Called(ctx, collectionID, scope)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetCollectionRowCount")
+	}
+
+	var r0 int64
+	if rf, ok := ret.Get(0).(func(context.Context, int64, int32) int64); ok {
+		r0 = rf(ctx, collectionID, scope)
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+
+	return r0
+}
+
+// MockTargetManager_GetCollectionRowCount_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetCollectionRowCount'
+type MockTargetManager_GetCollectionRowCount_Call struct {
+	*mock.Call
+}
+
+// GetCollectionRowCount is a helper method to define mock.On call
+//   - ctx context.Context
+//   - collectionID int64
+//   - scope int32
+func (_e *MockTargetManager_Expecter) GetCollectionRowCount(ctx interface{}, collectionID interface{}, scope interface{}) *MockTargetManager_GetCollectionRowCount_Call {
+	return &MockTargetManager_GetCollectionRowCount_Call{Call: _e.mock.On("GetCollectionRowCount", ctx, collectionID, scope)}
+}
+
+func (_c *MockTargetManager_GetCollectionRowCount_Call) Run(run func(ctx context.Context, collectionID int64, scope int32)) *MockTargetManager_GetCollectionRowCount_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(int64), args[2].(int32))
+	})
+	return _c
+}
+
+func (_c *MockTargetManager_GetCollectionRowCount_Call) Return(_a0 int64) *MockTargetManager_GetCollectionRowCount_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockTargetManager_GetCollectionRowCount_Call) RunAndReturn(run func(context.Context, int64, int32) int64) *MockTargetManager_GetCollectionRowCount_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetCollectionTargetVersion provides a mock function with given fields: ctx, collectionID, scope
 func (_m *MockTargetManager) GetCollectionTargetVersion(ctx context.Context, collectionID int64, scope int32) int64 {
 	ret := _m.Called(ctx, collectionID, scope)

--- a/internal/querycoordv2/meta/target.go
+++ b/internal/querycoordv2/meta/target.go
@@ -42,11 +42,15 @@ type CollectionTarget struct {
 
 	// record target status, if target has been save before milvus v2.4.19, then the target will lack of segment info.
 	lackSegmentInfo bool
+
+	// cache collection total row count
+	totalRowCount int64
 }
 
 func NewCollectionTarget(segments map[int64]*datapb.SegmentInfo, dmChannels map[string]*DmChannel, partitionIDs []int64) *CollectionTarget {
 	channel2Segments := make(map[string][]*datapb.SegmentInfo, len(dmChannels))
 	partition2Segments := make(map[int64][]*datapb.SegmentInfo, len(partitionIDs))
+	totalRowCount := int64(0)
 	for _, segment := range segments {
 		channel := segment.GetInsertChannel()
 		if _, ok := channel2Segments[channel]; !ok {
@@ -58,6 +62,7 @@ func NewCollectionTarget(segments map[int64]*datapb.SegmentInfo, dmChannels map[
 			partition2Segments[partitionID] = make([]*datapb.SegmentInfo, 0)
 		}
 		partition2Segments[partitionID] = append(partition2Segments[partitionID], segment)
+		totalRowCount += segment.GetNumOfRows()
 	}
 	return &CollectionTarget{
 		segments:           segments,
@@ -66,6 +71,7 @@ func NewCollectionTarget(segments map[int64]*datapb.SegmentInfo, dmChannels map[
 		dmChannels:         dmChannels,
 		partitions:         typeutil.NewSet(partitionIDs...),
 		version:            time.Now().UnixNano(),
+		totalRowCount:      totalRowCount,
 	}
 }
 
@@ -77,6 +83,7 @@ func FromPbCollectionTarget(target *querypb.CollectionTarget) *CollectionTarget 
 	var partitions []int64
 
 	lackSegmentInfo := false
+	totalRowCount := int64(0)
 	for _, t := range target.GetChannelTargets() {
 		if _, ok := channel2Segments[t.GetChannelName()]; !ok {
 			channel2Segments[t.GetChannelName()] = make([]*datapb.SegmentInfo, 0)
@@ -100,6 +107,7 @@ func FromPbCollectionTarget(target *querypb.CollectionTarget) *CollectionTarget 
 				segments[segment.GetID()] = info
 				channel2Segments[t.GetChannelName()] = append(channel2Segments[t.GetChannelName()], info)
 				partition2Segments[partition.GetPartitionID()] = append(partition2Segments[partition.GetPartitionID()], info)
+				totalRowCount += segment.GetNumOfRows()
 			}
 			partitions = append(partitions, partition.GetPartitionID())
 		}
@@ -128,6 +136,7 @@ func FromPbCollectionTarget(target *querypb.CollectionTarget) *CollectionTarget 
 		partitions:         typeutil.NewSet(partitions...),
 		version:            target.GetVersion(),
 		lackSegmentInfo:    lackSegmentInfo,
+		totalRowCount:      totalRowCount,
 	}
 }
 
@@ -220,6 +229,10 @@ func (p *CollectionTarget) IsEmpty() bool {
 // if target is ready, it should have all segment info
 func (p *CollectionTarget) Ready() bool {
 	return !p.lackSegmentInfo
+}
+
+func (p *CollectionTarget) GetRowCount() int64 {
+	return p.totalRowCount
 }
 
 type target struct {

--- a/internal/querycoordv2/meta/target_manager.go
+++ b/internal/querycoordv2/meta/target_manager.go
@@ -72,6 +72,7 @@ type TargetManagerInterface interface {
 	GetTargetJSON(ctx context.Context, scope TargetScope, collectionID int64) string
 	GetPartitions(ctx context.Context, collectionID int64, scope TargetScope) ([]int64, error)
 	IsCurrentTargetReady(ctx context.Context, collectionID int64) bool
+	GetCollectionRowCount(ctx context.Context, collectionID int64, scope TargetScope) int64
 }
 
 type TargetManager struct {
@@ -608,4 +609,12 @@ func (mgr *TargetManager) IsCurrentTargetReady(ctx context.Context, collectionID
 	}
 
 	return target.Ready()
+}
+
+func (mgr *TargetManager) GetCollectionRowCount(ctx context.Context, collectionID int64, scope TargetScope) int64 {
+	target := mgr.getCollectionTarget(scope, collectionID)
+	if len(target) == 0 {
+		return 0
+	}
+	return target[0].GetRowCount()
 }

--- a/internal/querycoordv2/meta/target_manager_test.go
+++ b/internal/querycoordv2/meta/target_manager_test.go
@@ -620,6 +620,7 @@ func (suite *TargetManagerSuite) TestRecover() {
 		suite.Equal(int64(100), segment.GetNumOfRows())
 	}
 	suite.True(target.Ready())
+	suite.Equal(int64(200), target.GetRowCount())
 
 	// after recover, target info should be cleaned up
 	targets, err := suite.catalog.GetCollectionTargets(ctx)

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -1969,6 +1969,7 @@ type queryCoordConfig struct {
 	AutoBalance                         ParamItem `refreshable:"true"`
 	AutoBalanceChannel                  ParamItem `refreshable:"true"`
 	Balancer                            ParamItem `refreshable:"true"`
+	BalanceTriggerOrder                 ParamItem `refreshable:"true"`
 	GlobalRowCountFactor                ParamItem `refreshable:"true"`
 	ScoreUnbalanceTolerationFactor      ParamItem `refreshable:"true"`
 	ReverseUnbalanceTolerationFactor    ParamItem `refreshable:"true"`
@@ -2105,6 +2106,16 @@ If this parameter is set false, Milvus simply searches the growing segments with
 		Export:       true,
 	}
 	p.Balancer.Init(base.mgr)
+
+	p.BalanceTriggerOrder = ParamItem{
+		Key:          "queryCoord.balanceTriggerOrder",
+		Version:      "2.5.8",
+		DefaultValue: "ByRowCount",
+		PanicIfEmpty: false,
+		Doc:          "sorting order for collection balancing, options: ByRowCount, ByCollectionID",
+		Export:       false,
+	}
+	p.BalanceTriggerOrder.Init(base.mgr)
 
 	p.GlobalRowCountFactor = ParamItem{
 		Key:          "queryCoord.globalRowCountFactor",


### PR DESCRIPTION
issue: #37651
this PR enable to balance the collection with largest row count first, to avoid temporary migration of small table data to new nodes during their onboarding, only to be moved out again after the large table balance, which would cause unnecessary load.