### PR TITLE
fix: [2.5] Fix parsing import endTs

### DIFF
--- a/internal/util/importutilv2/option.go
+++ b/internal/util/importutilv2/option.go
@@ -83,11 +83,14 @@ func ParseTimeRange(options Options) (uint64, uint64, error) {
 		for _, targetKey := range targetKeys {
 			for key, value := range importOptions {
 				if strings.EqualFold(key, targetKey) {
-					pTs, err := strconv.ParseUint(value, 10, 64)
+					ts, err := strconv.ParseUint(value, 10, 64)
 					if err != nil {
 						return 0, merr.WrapErrImportFailed(fmt.Sprintf("parse %s failed, value=%s, err=%s", targetKey, value, err))
 					}
-					return pTs, nil
+					if !tsoutil.IsValidHybridTs(ts) {
+						return 0, merr.WrapErrImportFailed(fmt.Sprintf("%s is not a valid hybrid timestamp, value=%s", targetKey, value))
+					}
+					return ts, nil
 				}
 			}
 		}

--- a/internal/util/importutilv2/option.go
+++ b/internal/util/importutilv2/option.go
@@ -83,11 +83,11 @@ func ParseTimeRange(options Options) (uint64, uint64, error) {
 		for _, targetKey := range targetKeys {
 			for key, value := range importOptions {
 				if strings.EqualFold(key, targetKey) {
-					pTs, err := strconv.ParseInt(value, 10, 64)
+					pTs, err := strconv.ParseUint(value, 10, 64)
 					if err != nil {
 						return 0, merr.WrapErrImportFailed(fmt.Sprintf("parse %s failed, value=%s, err=%s", targetKey, value, err))
 					}
-					return tsoutil.ComposeTS(pTs, 0), nil
+					return pTs, nil
 				}
 			}
 		}

--- a/internal/util/importutilv2/option_test.go
+++ b/internal/util/importutilv2/option_test.go
@@ -17,6 +17,8 @@
 package importutilv2
 
 import (
+	"fmt"
+	"math"
 	"testing"
 	"time"
 
@@ -49,5 +51,30 @@ func TestOption_GetTimeout(t *testing.T) {
 
 	options = []*commonpb.KeyValuePair{{Key: Timeout, Value: "invalidTime"}}
 	_, err = GetTimeoutTs(options)
+	assert.Error(t, err)
+}
+
+func TestOption_ParseTimeRange(t *testing.T) {
+	s, e, err := ParseTimeRange(nil)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(0), s)
+	assert.Equal(t, uint64(math.MaxUint64), e)
+
+	startTs := tsoutil.GetCurrentTime()
+	options := []*commonpb.KeyValuePair{{Key: StartTs, Value: fmt.Sprintf("%d", startTs)}}
+	s, e, err = ParseTimeRange(options)
+	assert.NoError(t, err)
+	assert.Equal(t, startTs, s)
+	assert.Equal(t, uint64(math.MaxUint64), e)
+
+	endTs := tsoutil.GetCurrentTime()
+	options = []*commonpb.KeyValuePair{{Key: EndTs, Value: fmt.Sprintf("%d", endTs)}}
+	s, e, err = ParseTimeRange(options)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(0), s)
+	assert.Equal(t, endTs, e)
+
+	options = []*commonpb.KeyValuePair{{Key: EndTs, Value: "&%#$%^&%^&$%^&&"}}
+	_, _, err = ParseTimeRange(options)
 	assert.Error(t, err)
 }

--- a/internal/util/importutilv2/option_test.go
+++ b/internal/util/importutilv2/option_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/tsoutil"
 )
 
@@ -76,5 +77,14 @@ func TestOption_ParseTimeRange(t *testing.T) {
 
 	options = []*commonpb.KeyValuePair{{Key: EndTs, Value: "&%#$%^&%^&$%^&&"}}
 	_, _, err = ParseTimeRange(options)
-	assert.Error(t, err)
+	assert.ErrorIs(t, err, merr.ErrImportFailed)
+
+	physicalTs := time.Now().UnixMilli()
+	options = []*commonpb.KeyValuePair{{Key: EndTs, Value: fmt.Sprintf("%d", physicalTs)}}
+	_, _, err = ParseTimeRange(options)
+	assert.ErrorIs(t, err, merr.ErrImportFailed)
+
+	options = []*commonpb.KeyValuePair{{Key: StartTs, Value: "0"}}
+	_, _, err = ParseTimeRange(options)
+	assert.ErrorIs(t, err, merr.ErrImportFailed)
 }

--- a/pkg/util/tsoutil/tso.go
+++ b/pkg/util/tsoutil/tso.go
@@ -99,3 +99,16 @@ func SubByNow(ts uint64) int64 {
 func PhysicalTimeFormat(ts uint64) string {
 	return PhysicalTime(ts).Format(time.DateTime)
 }
+
+const (
+	minUnixMillis = 1546300800000   // 2019-01-01 00:00:00 UTC
+	maxUnixMillis = 253402300799000 // 9999-12-31 23:59:59 UTC
+)
+
+func IsValidPhysicalTs(t uint64) bool {
+	return t >= minUnixMillis && t <= maxUnixMillis
+}
+
+func IsValidHybridTs(t uint64) bool {
+	return IsValidPhysicalTs(t >> logicalBits)
+}

--- a/pkg/util/tsoutil/tso_test.go
+++ b/pkg/util/tsoutil/tso_test.go
@@ -70,3 +70,13 @@ func TestAddPhysicalDurationOnTs(t *testing.T) {
 	// diff := CalculateDuration(ts2, ts1)
 	assert.Equal(t, ts3, ts2)
 }
+
+func TestIsValidUnixMilli(t *testing.T) {
+	physicalTs := uint64(time.Now().UnixMilli())
+	assert.True(t, IsValidPhysicalTs(physicalTs))
+	assert.False(t, IsValidHybridTs(physicalTs))
+
+	hybridTs := GetCurrentTime()
+	assert.False(t, IsValidPhysicalTs(hybridTs))
+	assert.True(t, IsValidHybridTs(hybridTs))
+}


### PR DESCRIPTION
Parsing import beginTs, endTs as a hybrid timestamp.

issue: https://github.com/milvus-io/milvus/issues/40326

pr: https://github.com/milvus-io/milvus/pull/40332