### PR TITLE
enhance: better logging for grpc resolver

### DIFF
--- a/internal/streamingcoord/server/resource/resource.go
+++ b/internal/streamingcoord/server/resource/resource.go
@@ -9,6 +9,7 @@ import (
 	"github.com/milvus-io/milvus/internal/streamingnode/client/manager"
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/idalloc"
+	"github.com/milvus-io/milvus/internal/util/streamingutil"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/util/syncutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
@@ -54,8 +55,10 @@ func Init(opts ...optResourceInit) {
 	assertNotNil(newR.RootCoordClient())
 	assertNotNil(newR.ETCD())
 	assertNotNil(newR.StreamingCatalog())
-	newR.streamingNodeManagerClient = manager.NewManagerClient(newR.etcdClient)
-	assertNotNil(newR.StreamingNodeManagerClient())
+	if streamingutil.IsStreamingServiceEnabled() {
+		newR.streamingNodeManagerClient = manager.NewManagerClient(newR.etcdClient)
+		assertNotNil(newR.StreamingNodeManagerClient())
+	}
 	r = newR
 }
 

--- a/internal/util/streamingutil/service/resolver/builder.go
+++ b/internal/util/streamingutil/service/resolver/builder.go
@@ -9,6 +9,7 @@ import (
 	"google.golang.org/grpc/resolver"
 
 	"github.com/milvus-io/milvus/internal/util/streamingutil/service/discoverer"
+	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/types"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
@@ -24,33 +25,46 @@ var idAllocator = typeutil.NewIDAllocator()
 
 // NewChannelAssignmentBuilder creates a new resolver builder.
 func NewChannelAssignmentBuilder(w types.AssignmentDiscoverWatcher) Builder {
-	return newBuilder(ChannelAssignmentResolverScheme, discoverer.NewChannelAssignmentDiscoverer(w))
+	b := newBuilder(ChannelAssignmentResolverScheme,
+		discoverer.NewChannelAssignmentDiscoverer(w),
+		log.With(log.FieldComponent("grpc-resolver"), zap.String("scheme", ChannelAssignmentResolverScheme)))
+	return b
 }
 
 // NewSessionBuilder creates a new resolver builder.
 // Multiple sessions are allowed, use the role as prefix.
 func NewSessionBuilder(c *clientv3.Client, role string) Builder {
-	return newBuilder(SessionResolverScheme, discoverer.NewSessionDiscoverer(c, role, false, "2.4.0"))
+	b := newBuilder(SessionResolverScheme,
+		discoverer.NewSessionDiscoverer(c, role, false, "2.4.0"),
+		log.With(log.FieldComponent("grpc-resolver"), zap.String("scheme", SessionResolverScheme), zap.String("role", role), zap.Bool("exclusive", false)))
+	return b
 }
 
 // NewSessionExclusiveBuilder creates a new resolver builder with exclusive.
 // Only one session is allowed, not use the prefix, only use the role directly.
 func NewSessionExclusiveBuilder(c *clientv3.Client, role string) Builder {
-	return newBuilder(SessionResolverScheme, discoverer.NewSessionDiscoverer(c, role, true, "2.4.0"))
+	b := newBuilder(
+		SessionResolverScheme,
+		discoverer.NewSessionDiscoverer(c, role, true, "2.4.0"),
+		log.With(log.FieldComponent("grpc-resolver"), zap.String("scheme", SessionResolverScheme), zap.String("role", role), zap.Bool("exclusive", true)))
+	return b
 }
 
 // newBuilder creates a new resolver builder.
-func newBuilder(scheme string, d discoverer.Discoverer) Builder {
-	resolver := newResolverWithDiscoverer(scheme, d, 1*time.Second) // configurable.
-	return &builderImpl{
+func newBuilder(scheme string, d discoverer.Discoverer, logger *log.MLogger) Builder {
+	resolver := newResolverWithDiscoverer(d, 1*time.Second, logger) // configurable.
+	b := &builderImpl{
 		lifetime: typeutil.NewLifetime(),
 		scheme:   scheme,
 		resolver: resolver,
 	}
+	b.SetLogger(logger)
+	return b
 }
 
 // builderImpl implements resolver.Builder.
 type builderImpl struct {
+	log.Binder
 	lifetime *typeutil.Lifetime
 	scheme   string
 	resolver *resolverWithDiscoverer
@@ -70,7 +84,8 @@ func (b *builderImpl) Build(_ resolver.Target, cc resolver.ClientConn, _ resolve
 	}
 	defer b.lifetime.Done()
 
-	r := newWatchBasedGRPCResolver(cc, b.resolver.logger.With(zap.Int64("id", idAllocator.Allocate())))
+	r := newWatchBasedGRPCResolver(cc)
+	r.SetLogger(b.resolver.Logger().With(zap.Int64("id", idAllocator.Allocate())))
 	b.resolver.RegisterNewWatcher(r)
 	return r, nil
 }

--- a/internal/util/streamingutil/service/resolver/builder_test.go
+++ b/internal/util/streamingutil/service/resolver/builder_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/milvus-io/milvus/internal/mocks/google.golang.org/grpc/mock_resolver"
 	"github.com/milvus-io/milvus/internal/mocks/util/streamingutil/service/mock_discoverer"
 	"github.com/milvus-io/milvus/internal/util/streamingutil/service/discoverer"
+	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
 
@@ -33,7 +34,7 @@ func TestNewBuilder(t *testing.T) {
 		Version: typeutil.VersionInt64(-1),
 	})
 
-	b := newBuilder("test", d)
+	b := newBuilder("test", d, log.With())
 	r := b.Resolver()
 	assert.NotNil(t, r)
 	assert.Equal(t, "test", b.Scheme())

--- a/internal/util/streamingutil/service/resolver/resolver_with_discoverer.go
+++ b/internal/util/streamingutil/service/resolver/resolver_with_discoverer.go
@@ -17,16 +17,16 @@ import (
 var _ Resolver = (*resolverWithDiscoverer)(nil)
 
 // newResolverWithDiscoverer creates a new resolver with discoverer.
-func newResolverWithDiscoverer(scheme string, d discoverer.Discoverer, retryInterval time.Duration) *resolverWithDiscoverer {
+func newResolverWithDiscoverer(d discoverer.Discoverer, retryInterval time.Duration, logger *log.MLogger) *resolverWithDiscoverer {
 	r := &resolverWithDiscoverer{
 		taskNotifier:    syncutil.NewAsyncTaskNotifier[struct{}](),
-		logger:          log.With(zap.String("scheme", scheme)),
 		registerCh:      make(chan *watchBasedGRPCResolver),
 		discoverer:      d,
 		retryInterval:   retryInterval,
 		latestStateCond: syncutil.NewContextCond(&sync.Mutex{}),
 		latestState:     d.NewVersionedState(),
 	}
+	r.SetLogger(logger)
 	go r.doDiscover()
 	return r
 }
@@ -40,7 +40,7 @@ type versionStateWithError struct {
 // resolverWithDiscoverer is the resolver for bkproxy service.
 type resolverWithDiscoverer struct {
 	taskNotifier *syncutil.AsyncTaskNotifier[struct{}]
-	logger       *log.MLogger
+	log.Binder
 
 	registerCh chan *watchBasedGRPCResolver
 
@@ -115,25 +115,26 @@ func (r *resolverWithDiscoverer) doDiscover() {
 		// Check if all grpc resolver is stopped.
 		for r := range grpcResolvers {
 			if r.State() == typeutil.LifetimeStateWorking {
-				r.logger.Warn("resolver is stopped before grpc watcher exist, maybe bug here")
+				r.Logger().Warn("resolver is stopped before grpc watcher exist, maybe bug here")
 				break
 			}
 		}
-		r.logger.Info("resolver stopped")
+		r.Logger().Info("resolver stopped")
 		r.taskNotifier.Finish(struct{}{})
 	}()
 
 	for {
 		ch := r.asyncDiscover(r.taskNotifier.Context())
-		r.logger.Info("service discover task started, listening...")
+		r.Logger().Info("service discover task started, listening...")
 	L:
 		for {
 			select {
 			case watcher := <-r.registerCh:
+				watcher.Logger().Info("new grpc resolver registered")
 				// New grpc resolver registered.
 				// Trigger the latest state to the new grpc resolver.
 				if err := watcher.Update(r.GetLatestState()); err != nil {
-					r.logger.Info("resolver is closed, ignore the new grpc resolver", zap.Error(err))
+					r.Logger().Info("resolver is closed, ignore the new grpc resolver", zap.Error(err))
 				} else {
 					grpcResolvers[watcher] = struct{}{}
 				}
@@ -143,7 +144,7 @@ func (r *resolverWithDiscoverer) doDiscover() {
 						// resolver stopped.
 						return
 					}
-					r.logger.Warn("service discover break down", zap.Error(stateWithError.err), zap.Duration("retryInterval", r.retryInterval))
+					r.Logger().Warn("service discover break down", zap.Error(stateWithError.err), zap.Duration("retryInterval", r.retryInterval))
 					time.Sleep(r.retryInterval)
 					break L
 				}
@@ -153,21 +154,21 @@ func (r *resolverWithDiscoverer) doDiscover() {
 				latestState := r.GetLatestState()
 				if !state.Version.GT(latestState.Version) {
 					// Ignore the old version.
-					r.logger.Info("service discover update, ignore old version", zap.Any("state", state))
+					r.Logger().Info("service discover update, ignore old version", zap.Any("state", state))
 					continue
 				}
 				// Update all grpc resolver.
-				r.logger.Info("service discover update, update resolver", zap.Any("state", state), zap.Int("resolver_count", len(grpcResolvers)))
+				r.Logger().Info("service discover update, update resolver", zap.Any("state", state), zap.Int("resolver_count", len(grpcResolvers)))
 				for watcher := range grpcResolvers {
 					// Update operation do not block.
 					// Only return error if the resolver is closed, so just print a info log and delete the resolver.
 					if err := watcher.Update(state); err != nil {
 						// updateError is always context.Canceled.
-						r.logger.Info("resolver is closed, unregister the resolver", zap.NamedError("updateError", err))
+						r.Logger().Info("resolver is closed, unregister the resolver", zap.NamedError("updateError", err))
 						delete(grpcResolvers, watcher)
 					}
 				}
-				r.logger.Info("update resolver done")
+				r.Logger().Info("update resolver done")
 				// Update the latest state and notify all resolver watcher should be executed after the all grpc watcher updated.
 				r.latestStateCond.LockAndBroadcast()
 				r.latestState = state

--- a/internal/util/streamingutil/service/resolver/resolver_with_discoverer_test.go
+++ b/internal/util/streamingutil/service/resolver/resolver_with_discoverer_test.go
@@ -37,7 +37,7 @@ func TestResolverWithDiscoverer(t *testing.T) {
 		Version: typeutil.VersionInt64(-1),
 	})
 
-	r := newResolverWithDiscoverer("test", d, time.Second)
+	r := newResolverWithDiscoverer(d, time.Second, log.With())
 
 	var resultOfGRPCResolver resolver.State
 	mockClientConn := mock_resolver.NewMockClientConn(t)
@@ -45,8 +45,8 @@ func TestResolverWithDiscoverer(t *testing.T) {
 		resultOfGRPCResolver = args
 		return nil
 	})
-	w := newWatchBasedGRPCResolver(mockClientConn, log.With())
-	w2 := newWatchBasedGRPCResolver(nil, log.With())
+	w := newWatchBasedGRPCResolver(mockClientConn)
+	w2 := newWatchBasedGRPCResolver(nil)
 	w2.Close()
 
 	// Test Register a grpc resolver watcher.

--- a/internal/util/streamingutil/service/resolver/watch_based_grpc_resolver.go
+++ b/internal/util/streamingutil/service/resolver/watch_based_grpc_resolver.go
@@ -12,11 +12,10 @@ import (
 var _ resolver.Resolver = (*watchBasedGRPCResolver)(nil)
 
 // newWatchBasedGRPCResolver creates a new watch based grpc resolver.
-func newWatchBasedGRPCResolver(cc resolver.ClientConn, logger *log.MLogger) *watchBasedGRPCResolver {
+func newWatchBasedGRPCResolver(cc resolver.ClientConn) *watchBasedGRPCResolver {
 	return &watchBasedGRPCResolver{
 		lifetime: typeutil.NewLifetime(),
 		cc:       cc,
-		logger:   logger,
 	}
 }
 
@@ -24,8 +23,8 @@ func newWatchBasedGRPCResolver(cc resolver.ClientConn, logger *log.MLogger) *wat
 type watchBasedGRPCResolver struct {
 	lifetime *typeutil.Lifetime
 
-	cc     resolver.ClientConn
-	logger *log.MLogger
+	cc resolver.ClientConn
+	log.Binder
 }
 
 // ResolveNow will be called by gRPC to try to resolve the target name
@@ -52,10 +51,10 @@ func (r *watchBasedGRPCResolver) Update(state VersionedState) error {
 
 	if err := r.cc.UpdateState(state.State); err != nil {
 		// watch based resolver could ignore the error, just log and return nil
-		r.logger.Warn("fail to update resolver state", zap.Error(err))
+		r.Logger().Warn("fail to update resolver state", zap.Any("state", state.State), zap.Error(err))
 		return nil
 	}
-	r.logger.Info("update resolver state success", zap.Any("state", state.State))
+	r.Logger().Info("update resolver state success", zap.Any("state", state.State))
 	return nil
 }
 

--- a/internal/util/streamingutil/service/resolver/watch_based_grpc_resolver_test.go
+++ b/internal/util/streamingutil/service/resolver/watch_based_grpc_resolver_test.go
@@ -9,7 +9,6 @@ import (
 	"google.golang.org/grpc/resolver"
 
 	"github.com/milvus-io/milvus/internal/mocks/google.golang.org/grpc/mock_resolver"
-	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
 
@@ -22,7 +21,7 @@ func TestWatchBasedGRPCResolver(t *testing.T) {
 	cc := mock_resolver.NewMockClientConn(t)
 	cc.EXPECT().UpdateState(mock.Anything).Return(nil)
 
-	r := newWatchBasedGRPCResolver(cc, log.With())
+	r := newWatchBasedGRPCResolver(cc)
 	assert.NoError(t, r.Update(VersionedState{State: resolver.State{Addresses: []resolver.Address{{Addr: "addr"}}}}))
 
 	cc.EXPECT().UpdateState(mock.Anything).Unset()


### PR DESCRIPTION
issue: #40311

- better logging for grpc resolver
- remove the redundant streaming node manage client when streaming service is disable