### PR TITLE
fix: main dispatcher not terminate cause messsage stream leak. (#40061)

### DIFF
--- a/pkg/mq/msgdispatcher/client_test.go
+++ b/pkg/mq/msgdispatcher/client_test.go
@@ -82,3 +82,40 @@ func TestClient_Concurrency(t *testing.T) {
 	n := c.managers.Len()
 	assert.Equal(t, expected, n)
 }
+
+func TestClientMainDispatcherLeak(t *testing.T) {
+	client := NewClient(newMockFactory(), typeutil.ProxyRole, 1)
+	assert.NotNil(t, client)
+	pchannel := "mock_vchannel_0"
+
+	vchannel1 := fmt.Sprintf("%s_abc_v0", pchannel) //"mock_vchannel_0_abc_v0"
+	vchannel2 := fmt.Sprintf("%s_abc_v1", pchannel) //"mock_vchannel_0_abc_v0"
+	_, err := client.Register(context.Background(), NewStreamConfig(vchannel1, nil, common.SubscriptionPositionUnknown))
+	assert.NoError(t, err)
+
+	_, err = client.Register(context.Background(), NewStreamConfig(vchannel2, nil, common.SubscriptionPositionUnknown))
+	assert.NoError(t, err)
+
+	client.Deregister(vchannel2)
+	client.Deregister(vchannel1)
+
+	assert.NotPanics(
+		t, func() {
+			_, err = client.Register(context.Background(), NewStreamConfig(vchannel1, nil, common.SubscriptionPositionUnknown))
+			assert.NoError(t, err)
+			_, err = client.Register(context.Background(), NewStreamConfig(vchannel2, nil, common.SubscriptionPositionUnknown))
+			assert.NoError(t, err)
+		},
+	)
+
+	client.Deregister(vchannel1)
+	client.Deregister(vchannel2)
+	assert.NotPanics(
+		t, func() {
+			_, err = client.Register(context.Background(), NewStreamConfig(vchannel1, nil, common.SubscriptionPositionUnknown))
+			assert.NoError(t, err)
+			_, err = client.Register(context.Background(), NewStreamConfig(vchannel2, nil, common.SubscriptionPositionUnknown))
+			assert.NoError(t, err)
+		},
+	)
+}


### PR DESCRIPTION
Main dispatcher will leak when we remove solo dispatcher in the end.
relate: https://github.com/milvus-io/milvus/issues/40046
pr: https://github.com/milvus-io/milvus/pull/40061