### PR TITLE
fix: Fix channel not balance on datanodes

### DIFF
--- a/internal/datacoord/channel_manager.go
+++ b/internal/datacoord/channel_manager.go
@@ -197,18 +197,7 @@ func (m *ChannelManagerImpl) AddNode(nodeID UniqueID) error {
 	log.Info("register node", zap.Int64("registered node", nodeID))
 
 	m.store.AddNode(nodeID)
-	updates := m.assignPolicy(m.store.GetNodesChannels(), m.store.GetBufferChannelInfo(), m.legacyNodes.Collect())
-
-	if updates == nil {
-		log.Info("register node with no reassignment", zap.Int64("registered node", nodeID))
-		return nil
-	}
-
-	err := m.execute(updates)
-	if err != nil {
-		log.Warn("fail to update channel operation updates into meta", zap.Error(err))
-	}
-	return err
+	return nil
 }
 
 // Release writes ToRelease channel watch states for a channel

--- a/internal/datacoord/policy_test.go
+++ b/internal/datacoord/policy_test.go
@@ -139,7 +139,10 @@ func (s *AssignByCountPolicySuite) TestWithoutUnassignedChannels() {
 		opSet := AvgAssignByCountPolicy(s.curCluster, nil, execlusiveNodes)
 		s.NotNil(opSet)
 
-		s.Equal(2, opSet.GetChannelNumber())
+		for _, op := range opSet.Collect() {
+			s.T().Logf("opType=%s, opNodeID=%d, numOpChannel=%d", ChannelOpTypeNames[op.Type], op.NodeID, len(op.Channels))
+		}
+		s.Equal(6, opSet.GetChannelNumber())
 		for _, op := range opSet.Collect() {
 			if op.NodeID == bufferID {
 				s.Equal(Watch, op.Type)
@@ -253,16 +256,17 @@ func (s *AssignByCountPolicySuite) TestWithUnassignedChannels() {
 
 		s.Equal(67, opSet.GetChannelNumber())
 		for _, op := range opSet.Collect() {
+			s.T().Logf("opType=%s, opNodeID=%d, numOpChannel=%d", ChannelOpTypeNames[op.Type], op.NodeID, len(op.Channels))
 			if op.NodeID == bufferID {
 				s.Equal(Delete, op.Type)
 			}
 		}
-		s.Equal(4, opSet.Len())
+		s.Equal(6, opSet.Len())
 
 		nodeIDs := lo.FilterMap(opSet.Collect(), func(op *ChannelOp, _ int) (int64, bool) {
 			return op.NodeID, op.NodeID != bufferID
 		})
-		s.ElementsMatch([]int64{3, 2}, nodeIDs)
+		s.ElementsMatch([]int64{3, 2, 1}, nodeIDs)
 	})
 
 	s.Run("toAssign from nodeID = 1", func() {

--- a/pkg/mq/msgdispatcher/client.go
+++ b/pkg/mq/msgdispatcher/client.go
@@ -115,10 +115,6 @@ func (c *client) Deregister(vchannel string) {
 
 	if manager, ok := c.managers.Get(pchannel); ok {
 		manager.Remove(vchannel)
-		if manager.NumTarget() == 0 && manager.NumConsumer() == 0 {
-			manager.Close()
-			c.managers.Remove(pchannel)
-		}
 		log.Info("deregister done", zap.String("role", c.role), zap.Int64("nodeID", c.nodeID),
 			zap.String("vchannel", vchannel), zap.Duration("dur", time.Since(start)))
 	}

--- a/pkg/mq/msgdispatcher/manager.go
+++ b/pkg/mq/msgdispatcher/manager.go
@@ -16,7 +16,6 @@
 
 package msgdispatcher
 
-import "C"
 import (
 	"context"
 	"fmt"

--- a/pkg/mq/msgdispatcher/manager_test.go
+++ b/pkg/mq/msgdispatcher/manager_test.go
@@ -50,8 +50,8 @@ func TestManager(t *testing.T) {
 		assert.NotNil(t, c)
 		go c.Run()
 		defer c.Close()
-		assert.Equal(t, 0, c.NumConsumer())
-		assert.Equal(t, 0, c.NumTarget())
+		assert.Equal(t, int64(0), c.(*dispatcherManager).numConsumer.Load())
+		assert.Equal(t, 0, c.(*dispatcherManager).registeredTargets.Len())
 
 		var offset int
 		for i := 0; i < 30; i++ {
@@ -64,8 +64,8 @@ func TestManager(t *testing.T) {
 				assert.NoError(t, err)
 			}
 			assert.Eventually(t, func() bool {
-				t.Logf("offset=%d, numConsumer=%d, numTarget=%d", offset, c.NumConsumer(), c.NumTarget())
-				return c.NumTarget() == offset
+				t.Logf("offset=%d, numConsumer=%d, numTarget=%d", offset, c.(*dispatcherManager).numConsumer.Load(), c.(*dispatcherManager).registeredTargets.Len())
+				return c.(*dispatcherManager).registeredTargets.Len() == offset
 			}, 3*time.Second, 10*time.Millisecond)
 			for j := 0; j < rand.Intn(r); j++ {
 				vchannel := fmt.Sprintf("%s_vchannelv%d", pchannel, offset)
@@ -74,8 +74,8 @@ func TestManager(t *testing.T) {
 				offset--
 			}
 			assert.Eventually(t, func() bool {
-				t.Logf("offset=%d, numConsumer=%d, numTarget=%d", offset, c.NumConsumer(), c.NumTarget())
-				return c.NumTarget() == offset
+				t.Logf("offset=%d, numConsumer=%d, numTarget=%d", offset, c.(*dispatcherManager).numConsumer.Load(), c.(*dispatcherManager).registeredTargets.Len())
+				return c.(*dispatcherManager).registeredTargets.Len() == offset
 			}, 3*time.Second, 10*time.Millisecond)
 		}
 	})
@@ -108,7 +108,7 @@ func TestManager(t *testing.T) {
 		assert.NoError(t, err)
 		o2, err := c.Add(ctx, NewStreamConfig(fmt.Sprintf("%s_vchannel-2", pchannel), nil, common.SubscriptionPositionUnknown))
 		assert.NoError(t, err)
-		assert.Equal(t, 3, c.NumTarget())
+		assert.Equal(t, 3, c.(*dispatcherManager).registeredTargets.Len())
 
 		consumeFn := func(output <-chan *MsgPack, done <-chan struct{}, wg *sync.WaitGroup) {
 			defer wg.Done()
@@ -130,14 +130,14 @@ func TestManager(t *testing.T) {
 		go consumeFn(o2, d2, wg)
 
 		assert.Eventually(t, func() bool {
-			return c.NumConsumer() == 1 // expected merge
+			return c.(*dispatcherManager).numConsumer.Load() == 1 // expected merge
 		}, 20*time.Second, 10*time.Millisecond)
 
 		// stop consume vchannel_2 to trigger split
 		d2 <- struct{}{}
 		assert.Eventually(t, func() bool {
-			t.Logf("c.NumConsumer=%d", c.NumConsumer())
-			return c.NumConsumer() == 2 // expected split
+			t.Logf("c.NumConsumer=%d", c.(*dispatcherManager).numConsumer.Load())
+			return c.(*dispatcherManager).numConsumer.Load() == 2 // expected split
 		}, 20*time.Second, 10*time.Millisecond)
 
 		// stop all
@@ -169,9 +169,9 @@ func TestManager(t *testing.T) {
 		assert.NoError(t, err)
 		_, err = c.Add(ctx, NewStreamConfig(fmt.Sprintf("%s_vchannel-2", pchannel), nil, common.SubscriptionPositionUnknown))
 		assert.NoError(t, err)
-		assert.Equal(t, 3, c.NumTarget())
+		assert.Equal(t, 3, c.(*dispatcherManager).registeredTargets.Len())
 		assert.Eventually(t, func() bool {
-			return c.NumConsumer() >= 1
+			return c.(*dispatcherManager).numConsumer.Load() >= 1
 		}, 3*time.Second, 10*time.Millisecond)
 		c.(*dispatcherManager).mainDispatcher.curTs.Store(1000)
 		for _, d := range c.(*dispatcherManager).deputyDispatchers {
@@ -183,9 +183,9 @@ func TestManager(t *testing.T) {
 		defer paramtable.Get().Reset(checkIntervalK)
 
 		assert.Eventually(t, func() bool {
-			return c.NumConsumer() == 1 // expected merged
+			return c.(*dispatcherManager).numConsumer.Load() == 1 // expected merged
 		}, 3*time.Second, 10*time.Millisecond)
-		assert.Equal(t, 3, c.NumTarget())
+		assert.Equal(t, 3, c.(*dispatcherManager).registeredTargets.Len())
 	})
 
 	t.Run("test_repeated_vchannel", func(t *testing.T) {
@@ -220,7 +220,7 @@ func TestManager(t *testing.T) {
 		assert.Error(t, err)
 
 		assert.Eventually(t, func() bool {
-			return c.NumConsumer() >= 1
+			return c.(*dispatcherManager).numConsumer.Load() >= 1
 		}, 3*time.Second, 10*time.Millisecond)
 	})
 }


### PR DESCRIPTION
1. Prevent channels from being assigned to only one datanode during datacoord startup.
2. Optimize the channel assignment policy by considering newly assigned channels.
3. Make msgdispatcher manager lock-free.

issue: https://github.com/milvus-io/milvus/issues/40421, https://github.com/milvus-io/milvus/issues/37630

