### PR TITLE
enhance: Remove CPU profile to prevent blocking stop progress

### DIFF
--- a/cmd/components/util.go
+++ b/cmd/components/util.go
@@ -39,7 +39,6 @@ func stopWithTimeout(stop func() error, timeout time.Duration) error {
 	defer cancel()
 
 	future := conc.Go(func() (struct{}, error) {
-		time.Sleep(10 * time.Second)
 		return struct{}{}, stop()
 	})
 	select {
@@ -76,6 +75,7 @@ func dumpPprof() {
 		log.Error("failed to create pprof directory",
 			zap.String("path", pprofDir),
 			zap.Error(err))
+		return
 	}
 
 	// Generate base file path with timestamp
@@ -131,6 +131,7 @@ func dumpPprof() {
 				f.Close()
 				os.Remove(filename)
 			}
+			return
 		}
 		files[p.filename] = f
 	}


### PR DESCRIPTION
pr: #40460
- Removed CPU profile dump from util.go's pprof collection
- Avoid potential blocking in StopCPUProfile() during shutdown
- Maintain goroutine/heap/block/mutex profiles for diagnostics
- Ensure safe shutdown timeout handling without profile stalls