### PR TITLE
fix: avoid panic when field not exists in schema in query node

### DIFF
--- a/internal/core/src/query/PlanImpl.h
+++ b/internal/core/src/query/PlanImpl.h
@@ -37,8 +37,8 @@ struct ExtractedPlanInfo {
     add_involved_field(FieldId field_id) {
         auto pos = field_id.get() - START_USER_FIELDID;
         AssertInfo(0 <= pos && pos < involved_fields_.size(),
-                   "invalid field id, field_id {}, schema size {}",
-                   field_id,
+                   "invalid field id, field_id:{}, schema size:{}",
+                   field_id.get(),
                    involved_fields_.size());
         involved_fields_.set(pos);
     }

--- a/internal/core/src/query/PlanImpl.h
+++ b/internal/core/src/query/PlanImpl.h
@@ -36,7 +36,10 @@ struct ExtractedPlanInfo {
     void
     add_involved_field(FieldId field_id) {
         auto pos = field_id.get() - START_USER_FIELDID;
-        AssertInfo(pos >= 0, "invalid field id");
+        AssertInfo(0 <= pos && pos < involved_fields_.size(),
+                   "invalid field id, field_id {}, schema size {}",
+                   field_id,
+                   involved_fields_.size());
         involved_fields_.set(pos);
     }
 


### PR DESCRIPTION
ref #40473

This PR is a workaround to avoid the panic described in the issue.