### PR TITLE
fix: [2.5] avoid panic when field not exists in schema in query node 

### DIFF
--- a/internal/core/src/query/PlanImpl.h
+++ b/internal/core/src/query/PlanImpl.h
@@ -38,7 +38,7 @@ struct ExtractedPlanInfo {
         auto pos = field_id.get() - START_USER_FIELDID;
         AssertInfo(0 <= pos && pos < involved_fields_.size(),
                    "invalid field id, field_id {}, schema size {}",
-                   field_id,
+                   field_id.get(),
                    involved_fields_.size());
         involved_fields_.set(pos);
     }

--- a/internal/core/src/query/PlanImpl.h
+++ b/internal/core/src/query/PlanImpl.h
@@ -36,7 +36,10 @@ struct ExtractedPlanInfo {
     void
     add_involved_field(FieldId field_id) {
         auto pos = field_id.get() - START_USER_FIELDID;
-        AssertInfo(pos >= 0, "invalid field id");
+        AssertInfo(0 <= pos && pos < involved_fields_.size(),
+                   "invalid field id, field_id {}, schema size {}",
+                   field_id,
+                   involved_fields_.size());
         involved_fields_.set(pos);
     }
 


### PR DESCRIPTION
ref https://github.com/milvus-io/milvus/issues/40473
cherry-pick: https://github.com/milvus-io/milvus/pull/40541
