### PR TITLE
fix: [2.4] rbac star privilege return empty when listing policy

### DIFF
--- a/internal/metastore/kv/rootcoord/kv_catalog.go
+++ b/internal/metastore/kv/rootcoord/kv_catalog.go
@@ -1325,13 +1325,20 @@ func (kc *Catalog) ListPolicy(ctx context.Context, tenant string) ([]*milvuspb.G
 				continue
 			}
 			dbName, objectName := funcutil.SplitObjectName(grantInfos[2])
+
+			var privilegeName string
+			if granteeIDInfos[0] == util.AnyWord {
+				privilegeName = util.AnyWord
+			} else {
+				privilegeName = util.PrivilegeNameForAPI(granteeIDInfos[0])
+			}
 			grants = append(grants, &milvuspb.GrantEntity{
 				Role:       &milvuspb.RoleEntity{Name: grantInfos[0]},
 				Object:     &milvuspb.ObjectEntity{Name: grantInfos[1]},
 				ObjectName: objectName,
 				DbName:     dbName,
 				Grantor: &milvuspb.GrantorEntity{
-					Privilege: &milvuspb.PrivilegeEntity{Name: util.PrivilegeNameForAPI(granteeIDInfos[0])},
+					Privilege: &milvuspb.PrivilegeEntity{Name: privilegeName},
 				},
 			})
 		}

--- a/internal/metastore/kv/rootcoord/kv_catalog_test.go
+++ b/internal/metastore/kv/rootcoord/kv_catalog_test.go
@@ -2472,13 +2472,17 @@ func TestRBAC_Grant(t *testing.T) {
 		)
 
 		grant := func(role, obj, objName, privilege, dbName string) *milvuspb.GrantEntity {
+			privilegeName := util.PrivilegeNameForAPI(privilege)
+			if privilege == util.AnyWord {
+				privilegeName = util.AnyWord
+			}
 			return &milvuspb.GrantEntity{
 				Role:       &milvuspb.RoleEntity{Name: role},
 				Object:     &milvuspb.ObjectEntity{Name: obj},
 				ObjectName: objName,
 				DbName:     dbName,
 				Grantor: &milvuspb.GrantorEntity{
-					Privilege: &milvuspb.PrivilegeEntity{Name: util.PrivilegeNameForAPI(privilege)},
+					Privilege: &milvuspb.PrivilegeEntity{Name: privilegeName},
 				},
 			}
 		}
@@ -2492,6 +2496,7 @@ func TestRBAC_Grant(t *testing.T) {
 							fmt.Sprintf("%s/%s", key, "PrivilegeLoad"),
 							fmt.Sprintf("%s/%s", key, "PrivilegeRelease"),
 							fmt.Sprintf("%s/%s", key, "random/a/b/c"),
+							fmt.Sprintf("%s/%s", key, util.AnyWord),
 						}
 					}
 					return nil
@@ -2554,12 +2559,14 @@ func TestRBAC_Grant(t *testing.T) {
 				policy, err := c.ListPolicy(ctx, tenant)
 				if test.isValid {
 					assert.NoError(t, err)
-					assert.Equal(t, 4, len(policy))
+					assert.Equal(t, 6, len(policy))
 					ps := []*milvuspb.GrantEntity{
 						grant("role1", "obj1", "obj_name1", "PrivilegeLoad", "default"),
 						grant("role1", "obj1", "obj_name1", "PrivilegeRelease", "default"),
+						grant("role1", "obj1", "obj_name1", util.AnyWord, "default"),
 						grant("role2", "obj2", "obj_name2", "PrivilegeLoad", "default"),
 						grant("role2", "obj2", "obj_name2", "PrivilegeRelease", "default"),
+						grant("role2", "obj2", "obj_name2", util.AnyWord, "default"),
 					}
 					assert.ElementsMatch(t, ps, policy)
 				} else {


### PR DESCRIPTION
cherry-pick from master: https://github.com/milvus-io/milvus/pull/40553
related: https://github.com/milvus-io/milvus/issues/40547