### PR TITLE
fix: Fix tasks will panic if one of them throw an exception.

### DIFF
--- a/internal/core/src/segcore/Utils.cpp
+++ b/internal/core/src/segcore/Utils.cpp
@@ -936,7 +936,7 @@ LoadFieldDatasFromRemote(const std::vector<std::string>& remote_files,
         std::vector<std::future<FieldDataPtr>> futures;
         futures.reserve(remote_files.size());
         for (const auto& file : remote_files) {
-            auto future = pool.Submit([&]() {
+            auto future = pool.Submit([rcm, file]() {
                 auto fileSize = rcm->Size(file);
                 auto buf = std::shared_ptr<uint8_t[]>(new uint8_t[fileSize]);
                 rcm->Read(file, buf.get(), fileSize);


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/40690

the variable rcm will be dangling if a future throws an exception and return.