### PR TITLE
fix: [2.5] Protect getSegmentIndexes with rlock

### DIFF
--- a/internal/datacoord/index_meta.go
+++ b/internal/datacoord/index_meta.go
@@ -714,6 +714,8 @@ func (m *indexMeta) IsUnIndexedSegment(collectionID UniqueID, segID UniqueID) bo
 }
 
 func (m *indexMeta) GetSegmentsIndexes(collectionID UniqueID, segIDs []UniqueID) map[int64]map[UniqueID]*model.SegmentIndex {
+	m.fieldIndexLock.RLock()
+	defer m.fieldIndexLock.RUnlock()
 	segmentsIndexes := make(map[int64]map[UniqueID]*model.SegmentIndex)
 	for _, segmentID := range segIDs {
 		segmentsIndexes[segmentID] = m.getSegmentIndexes(collectionID, segmentID)
@@ -722,6 +724,8 @@ func (m *indexMeta) GetSegmentsIndexes(collectionID UniqueID, segIDs []UniqueID)
 }
 
 func (m *indexMeta) GetSegmentIndexes(collectionID UniqueID, segID UniqueID) map[UniqueID]*model.SegmentIndex {
+	m.fieldIndexLock.RLock()
+	defer m.fieldIndexLock.RUnlock()
 	return m.getSegmentIndexes(collectionID, segID)
 }
 


### PR DESCRIPTION
Cherry-pick from master
pr: #40719
Related to #40718