### PR TITLE
fix: [2.5.7 hotfix] Json Stats filter the data is double but the filter expr is int

### DIFF
--- a/internal/core/src/exec/expression/BinaryRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.cpp
@@ -532,25 +532,33 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForJsonForIndex() {
     } while (false)
 #define BinaryRangeJSONTypeCompare(cmp)                                    \
     do {                                                                   \
-        if (type == uint8_t(milvus::index::JSONType::STRING)) {            \
-            if constexpr (std::is_same_v<GetType, std::string_view>) {     \
+        if constexpr (std::is_same_v<GetType, std::string_view>) {         \
+            if (type == uint8_t(milvus::index::JSONType::STRING)) {        \
                 auto val = json.at_string(offset, size);                   \
                 return (cmp);                                              \
             } else {                                                       \
                 return false;                                              \
             }                                                              \
-        } else if (type == uint8_t(milvus::index::JSONType::DOUBLE)) {     \
-            if constexpr (std::is_same_v<GetType, double>) {               \
+        } else if constexpr (std::is_same_v<GetType, double>) {            \
+            if (type == uint8_t(milvus::index::JSONType::INT64)) {         \
+                auto val =                                                 \
+                    std::stoll(std::string(json.at_string(offset, size))); \
+                return (cmp);                                              \
+            } else if (type == uint8_t(milvus::index::JSONType::DOUBLE)) { \
                 auto val =                                                 \
                     std::stod(std::string(json.at_string(offset, size)));  \
                 return (cmp);                                              \
             } else {                                                       \
                 return false;                                              \
             }                                                              \
-        } else if (type == uint8_t(milvus::index::JSONType::INT64)) {      \
-            if constexpr (std::is_same_v<GetType, int64_t>) {              \
+        } else if constexpr (std::is_same_v<GetType, int64_t>) {           \
+            if (type == uint8_t(milvus::index::JSONType::INT64)) {         \
                 auto val =                                                 \
                     std::stoll(std::string(json.at_string(offset, size))); \
+                return (cmp);                                              \
+            } else if (type == uint8_t(milvus::index::JSONType::DOUBLE)) { \
+                auto val =                                                 \
+                    std::stod(std::string(json.at_string(offset, size)));  \
                 return (cmp);                                              \
             } else {                                                       \
                 return false;                                              \

--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -946,24 +946,31 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJsonForIndex() {
 
 #define UnaryJSONTypeCompare(cmp)                                              \
     do {                                                                       \
-        if (type == uint8_t(milvus::index::JSONType::STRING)) {                \
-            if constexpr (std::is_same_v<GetType, std::string_view>) {         \
+        if constexpr (std::is_same_v<GetType, std::string_view>) {             \
+            if (type == uint8_t(milvus::index::JSONType::STRING)) {            \
                 auto x = json.at_string(offset, size);                         \
                 return (cmp);                                                  \
             } else {                                                           \
                 return false;                                                  \
             }                                                                  \
-        } else if (type == uint8_t(milvus::index::JSONType::DOUBLE)) {         \
-            if constexpr (std::is_same_v<GetType, double>) {                   \
+        } else if constexpr (std::is_same_v<GetType, double>) {                \
+            if (type == uint8_t(milvus::index::JSONType::INT64)) {             \
+                auto x =                                                       \
+                    std::stoll(std::string(json.at_string(offset, size)));     \
+                return (cmp);                                                  \
+            } else if (type == uint8_t(milvus::index::JSONType::DOUBLE)) {     \
                 auto x = std::stod(std::string(json.at_string(offset, size))); \
                 return (cmp);                                                  \
             } else {                                                           \
                 return false;                                                  \
             }                                                                  \
-        } else if (type == uint8_t(milvus::index::JSONType::INT64)) {          \
-            if constexpr (std::is_same_v<GetType, int64_t>) {                  \
+        } else if constexpr (std::is_same_v<GetType, int64_t>) {               \
+            if (type == uint8_t(milvus::index::JSONType::INT64)) {             \
                 auto x =                                                       \
                     std::stoll(std::string(json.at_string(offset, size)));     \
+                return (cmp);                                                  \
+            } else if (type == uint8_t(milvus::index::JSONType::DOUBLE)) {     \
+                auto x = std::stod(std::string(json.at_string(offset, size))); \
                 return (cmp);                                                  \
             } else {                                                           \
                 return false;                                                  \


### PR DESCRIPTION
Json Stats filter the data is double but the filter is int
issue: https://github.com/milvus-io/milvus/issues/40707
master-pr:https://github.com/milvus-io/milvus/pull/38039
relater-pr: https://github.com/milvus-io/milvus/pull/40771