### PR TITLE
fix:[2.5]wrong p.InterimIndexRefineQuantType default value and reduce ut run time

### DIFF
--- a/internal/core/unittest/test_growing_index.cpp
+++ b/internal/core/unittest/test_growing_index.cpp
@@ -83,7 +83,7 @@ INSTANTIATE_TEST_SUITE_P(
                           knowhere::metric::L2),
         ::testing::Values(knowhere::IndexEnum::INDEX_FAISS_IVFFLAT_CC,
                           knowhere::IndexEnum::INDEX_FAISS_SCANN_DVR),
-        ::testing::Values("NONE", "BFLOAT16", "FLOAT16", "UINT8")));
+        ::testing::Values("NONE", "FLOAT16", "UINT8")));
 
 INSTANTIATE_TEST_SUITE_P(
     SparseIndexTypeParameters,
@@ -106,12 +106,11 @@ INSTANTIATE_TEST_SUITE_P(
     GrowingIndexTest,
     ::testing::Combine(
         ::testing::Values(DataType::VECTOR_FLOAT16, DataType::VECTOR_BFLOAT16),
-        ::testing::Values(knowhere::IndexEnum::INDEX_FAISS_IVFFLAT,
-                          knowhere::IndexEnum::INDEX_FAISS_IVFFLAT_CC),
+        ::testing::Values(knowhere::IndexEnum::INDEX_FAISS_IVFFLAT),
         ::testing::Values(knowhere::metric::COSINE),
         ::testing::Values(knowhere::IndexEnum::INDEX_FAISS_IVFFLAT_CC,
                           knowhere::IndexEnum::INDEX_FAISS_SCANN_DVR),
-        ::testing::Values("NONE", "BFLOAT16", "FLOAT16", "UINT8")));
+        ::testing::Values("NONE", "FLOAT16", "UINT8")));
 
 TEST_P(GrowingIndexTest, Correctness) {
     auto schema = std::make_shared<Schema>();

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -2728,7 +2728,7 @@ This defaults to true, indicating that Milvus creates temporary index for growin
 	p.InterimIndexRefineQuantType = ParamItem{
 		Key:          "queryNode.segcore.interimIndex.refineQuantType",
 		Version:      "2.5.6",
-		DefaultValue: "DATA_VIEW",
+		DefaultValue: "NONE",
 		Doc:          `Data representation of SCANN_DVR index, options: 'NONE', 'FLOAT16', 'BFLOAT16' and 'UINT8'`,
 		Export:       true,
 	}


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/27678