### PR TITLE
fix: [2.5] Fix channel not balance on datanodes

### DIFF
--- a/internal/datacoord/channel_manager.go
+++ b/internal/datacoord/channel_manager.go
@@ -197,18 +197,7 @@ func (m *ChannelManagerImpl) AddNode(nodeID UniqueID) error {
 	log.Info("register node", zap.Int64("registered node", nodeID))
 
 	m.store.AddNode(nodeID)
-	updates := m.assignPolicy(m.store.GetNodesChannels(), m.store.GetBufferChannelInfo(), m.legacyNodes.Collect())
-
-	if updates == nil {
-		log.Info("register node with no reassignment", zap.Int64("registered node", nodeID))
-		return nil
-	}
-
-	err := m.execute(updates)
-	if err != nil {
-		log.Warn("fail to update channel operation updates into meta", zap.Error(err))
-	}
-	return err
+	return nil
 }
 
 // Release writes ToRelease channel watch states for a channel

--- a/internal/datacoord/policy_test.go
+++ b/internal/datacoord/policy_test.go
@@ -139,7 +139,10 @@ func (s *AssignByCountPolicySuite) TestWithoutUnassignedChannels() {
 		opSet := AvgAssignByCountPolicy(s.curCluster, nil, execlusiveNodes)
 		s.NotNil(opSet)
 
-		s.Equal(2, opSet.GetChannelNumber())
+		for _, op := range opSet.Collect() {
+			s.T().Logf("opType=%s, opNodeID=%d, numOpChannel=%d", ChannelOpTypeNames[op.Type], op.NodeID, len(op.Channels))
+		}
+		s.Equal(6, opSet.GetChannelNumber())
 		for _, op := range opSet.Collect() {
 			if op.NodeID == bufferID {
 				s.Equal(Watch, op.Type)
@@ -253,16 +256,17 @@ func (s *AssignByCountPolicySuite) TestWithUnassignedChannels() {
 
 		s.Equal(67, opSet.GetChannelNumber())
 		for _, op := range opSet.Collect() {
+			s.T().Logf("opType=%s, opNodeID=%d, numOpChannel=%d", ChannelOpTypeNames[op.Type], op.NodeID, len(op.Channels))
 			if op.NodeID == bufferID {
 				s.Equal(Delete, op.Type)
 			}
 		}
-		s.Equal(4, opSet.Len())
+		s.Equal(6, opSet.Len())
 
 		nodeIDs := lo.FilterMap(opSet.Collect(), func(op *ChannelOp, _ int) (int64, bool) {
 			return op.NodeID, op.NodeID != bufferID
 		})
-		s.ElementsMatch([]int64{3, 2}, nodeIDs)
+		s.ElementsMatch([]int64{3, 2, 1}, nodeIDs)
 	})
 
 	s.Run("toAssign from nodeID = 1", func() {

--- a/pkg/mq/msgdispatcher/client.go
+++ b/pkg/mq/msgdispatcher/client.go
@@ -115,10 +115,6 @@ func (c *client) Deregister(vchannel string) {
 
 	if manager, ok := c.managers.Get(pchannel); ok {
 		manager.Remove(vchannel)
-		if manager.NumTarget() == 0 && manager.NumConsumer() == 0 {
-			manager.Close()
-			c.managers.Remove(pchannel)
-		}
 		log.Info("deregister done", zap.String("role", c.role), zap.Int64("nodeID", c.nodeID),
 			zap.String("vchannel", vchannel), zap.Duration("dur", time.Since(start)))
 	}


### PR DESCRIPTION
1. Prevent channels from being assigned to only one datanode during datacoord startup.
2. Optimize the channel assignment policy by considering newly assigned channels.

issue: https://github.com/milvus-io/milvus/issues/40421, https://github.com/milvus-io/milvus/issues/37630

pr: https://github.com/milvus-io/milvus/pull/40422