### PR TITLE
enhance: add proxy and datanode checker when wal balance startup

### DIFF
--- a/internal/mocks/util/streamingutil/service/mock_discoverer/mock_Discoverer.go
+++ b/internal/mocks/util/streamingutil/service/mock_discoverer/mock_Discoverer.go
@@ -69,51 +69,6 @@ func (_c *MockDiscoverer_Discover_Call) RunAndReturn(run func(context.Context, f
 	return _c
 }
 
-// NewVersionedState provides a mock function with given fields:
-func (_m *MockDiscoverer) NewVersionedState() discoverer.VersionedState {
-	ret := _m.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for NewVersionedState")
-	}
-
-	var r0 discoverer.VersionedState
-	if rf, ok := ret.Get(0).(func() discoverer.VersionedState); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(discoverer.VersionedState)
-	}
-
-	return r0
-}
-
-// MockDiscoverer_NewVersionedState_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'NewVersionedState'
-type MockDiscoverer_NewVersionedState_Call struct {
-	*mock.Call
-}
-
-// NewVersionedState is a helper method to define mock.On call
-func (_e *MockDiscoverer_Expecter) NewVersionedState() *MockDiscoverer_NewVersionedState_Call {
-	return &MockDiscoverer_NewVersionedState_Call{Call: _e.mock.On("NewVersionedState")}
-}
-
-func (_c *MockDiscoverer_NewVersionedState_Call) Run(run func()) *MockDiscoverer_NewVersionedState_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *MockDiscoverer_NewVersionedState_Call) Return(_a0 discoverer.VersionedState) *MockDiscoverer_NewVersionedState_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockDiscoverer_NewVersionedState_Call) RunAndReturn(run func() discoverer.VersionedState) *MockDiscoverer_NewVersionedState_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // NewMockDiscoverer creates a new instance of MockDiscoverer. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewMockDiscoverer(t interface {

--- a/internal/mocks/util/streamingutil/service/mock_resolver/mock_Resolver.go
+++ b/internal/mocks/util/streamingutil/service/mock_resolver/mock_Resolver.go
@@ -22,22 +22,32 @@ func (_m *MockResolver) EXPECT() *MockResolver_Expecter {
 	return &MockResolver_Expecter{mock: &_m.Mock}
 }
 
-// GetLatestState provides a mock function with given fields:
-func (_m *MockResolver) GetLatestState() discoverer.VersionedState {
-	ret := _m.Called()
+// GetLatestState provides a mock function with given fields: ctx
+func (_m *MockResolver) GetLatestState(ctx context.Context) (discoverer.VersionedState, error) {
+	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetLatestState")
 	}
 
 	var r0 discoverer.VersionedState
-	if rf, ok := ret.Get(0).(func() discoverer.VersionedState); ok {
-		r0 = rf()
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context) (discoverer.VersionedState, error)); ok {
+		return rf(ctx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context) discoverer.VersionedState); ok {
+		r0 = rf(ctx)
 	} else {
 		r0 = ret.Get(0).(discoverer.VersionedState)
 	}
 
-	return r0
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // MockResolver_GetLatestState_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetLatestState'
@@ -46,23 +56,24 @@ type MockResolver_GetLatestState_Call struct {
 }
 
 // GetLatestState is a helper method to define mock.On call
-func (_e *MockResolver_Expecter) GetLatestState() *MockResolver_GetLatestState_Call {
-	return &MockResolver_GetLatestState_Call{Call: _e.mock.On("GetLatestState")}
+//   - ctx context.Context
+func (_e *MockResolver_Expecter) GetLatestState(ctx interface{}) *MockResolver_GetLatestState_Call {
+	return &MockResolver_GetLatestState_Call{Call: _e.mock.On("GetLatestState", ctx)}
 }
 
-func (_c *MockResolver_GetLatestState_Call) Run(run func()) *MockResolver_GetLatestState_Call {
+func (_c *MockResolver_GetLatestState_Call) Run(run func(ctx context.Context)) *MockResolver_GetLatestState_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(context.Context))
 	})
 	return _c
 }
 
-func (_c *MockResolver_GetLatestState_Call) Return(_a0 discoverer.VersionedState) *MockResolver_GetLatestState_Call {
-	_c.Call.Return(_a0)
+func (_c *MockResolver_GetLatestState_Call) Return(_a0 discoverer.VersionedState, _a1 error) *MockResolver_GetLatestState_Call {
+	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockResolver_GetLatestState_Call) RunAndReturn(run func() discoverer.VersionedState) *MockResolver_GetLatestState_Call {
+func (_c *MockResolver_GetLatestState_Call) RunAndReturn(run func(context.Context) (discoverer.VersionedState, error)) *MockResolver_GetLatestState_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/streamingcoord/client/client.go
+++ b/internal/streamingcoord/client/client.go
@@ -68,7 +68,7 @@ type Client interface {
 func NewClient(etcdCli *clientv3.Client) Client {
 	// StreamingCoord is deployed on DataCoord node.
 	role := sessionutil.GetSessionPrefixByRole(typeutil.RootCoordRole)
-	rb := resolver.NewSessionExclusiveBuilder(etcdCli, role)
+	rb := resolver.NewSessionExclusiveBuilder(etcdCli, role, ">=2.6.0-dev")
 	dialTimeout := paramtable.Get().StreamingCoordGrpcClientCfg.DialTimeout.GetAsDuration(time.Millisecond)
 	dialOptions := getDialOptions(rb)
 	conn := lazygrpc.NewConn(func(ctx context.Context) (*grpc.ClientConn, error) {

--- a/internal/streamingcoord/server/balancer/balancer_impl.go
+++ b/internal/streamingcoord/server/balancer/balancer_impl.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/balancer/channel"
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/resource"
+	"github.com/milvus-io/milvus/internal/util/sessionutil"
 	"github.com/milvus-io/milvus/internal/util/streamingutil/service/resolver"
 	"github.com/milvus-io/milvus/internal/util/streamingutil/status"
 	"github.com/milvus-io/milvus/pkg/v2/log"
@@ -180,7 +181,7 @@ func (b *balancerImpl) blockUntilAllNodeIsGreaterThan260(ctx context.Context) er
 		logger := b.logger.With(zap.String("role", role))
 		logger.Info("start to wait that the nodes is greater than 2.6.0")
 		// Check if there's any proxy or data node with version < 2.6.0.
-		proxyResolver := resolver.NewSessionBuilder(resource.Resource().ETCD(), role, "<2.6.0")
+		proxyResolver := resolver.NewSessionBuilder(resource.Resource().ETCD(), sessionutil.GetSessionPrefixByRole(role), "<2.6.0")
 		r := proxyResolver.Resolver()
 		err := r.Watch(ctx, func(vs resolver.VersionedState) error {
 			if len(vs.Sessions()) == 0 {

--- a/internal/streamingcoord/server/balancer/balancer_test.go
+++ b/internal/streamingcoord/server/balancer/balancer_test.go
@@ -2,6 +2,8 @@ package balancer_test
 
 import (
 	"context"
+	"encoding/json"
+	"path"
 	"testing"
 	"time"
 
@@ -14,8 +16,10 @@ import (
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/balancer"
 	_ "github.com/milvus-io/milvus/internal/streamingcoord/server/balancer/policy"
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/resource"
+	"github.com/milvus-io/milvus/internal/util/sessionutil"
 	"github.com/milvus-io/milvus/pkg/v2/proto/streamingpb"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/types"
+	"github.com/milvus-io/milvus/pkg/v2/util/etcd"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/syncutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
@@ -23,6 +27,12 @@ import (
 
 func TestBalancer(t *testing.T) {
 	paramtable.Init()
+	err := etcd.InitEtcdServer(true, "", t.TempDir(), "stdout", "info")
+	assert.NoError(t, err)
+	defer etcd.StopEtcdServer()
+
+	etcdClient, err := etcd.GetEmbedEtcdClient()
+	assert.NoError(t, err)
 
 	streamingNodeManager := mock_manager.NewMockManagerClient(t)
 	streamingNodeManager.EXPECT().WatchNodeChanged(mock.Anything).Return(make(chan struct{}), nil)
@@ -57,7 +67,7 @@ func TestBalancer(t *testing.T) {
 	}, nil)
 
 	catalog := mock_metastore.NewMockStreamingCoordCataLog(t)
-	resource.InitForTest(resource.OptStreamingCatalog(catalog), resource.OptStreamingManagerClient(streamingNodeManager))
+	resource.InitForTest(resource.OptETCD(etcdClient), resource.OptStreamingCatalog(catalog), resource.OptStreamingManagerClient(streamingNodeManager))
 	catalog.EXPECT().ListPChannel(mock.Anything).Unset()
 	catalog.EXPECT().ListPChannel(mock.Anything).RunAndReturn(func(ctx context.Context) ([]*streamingpb.PChannelMeta, error) {
 		return []*streamingpb.PChannelMeta{
@@ -89,10 +99,35 @@ func TestBalancer(t *testing.T) {
 	})
 	catalog.EXPECT().SavePChannels(mock.Anything, mock.Anything).Return(nil).Maybe()
 
+	// Test for lower datanode and proxy version protection.
+	metaRoot := paramtable.Get().EtcdCfg.MetaRootPath.GetValue()
+	proxyPath1 := path.Join(metaRoot, sessionutil.DefaultServiceRoot, typeutil.ProxyRole+"-1")
+	r := sessionutil.SessionRaw{Version: "2.5.11", ServerID: 1}
+	data, _ := json.Marshal(r)
+	resource.Resource().ETCD().Put(context.Background(), proxyPath1, string(data))
+	proxyPath2 := path.Join(metaRoot, sessionutil.DefaultServiceRoot, typeutil.ProxyRole+"-2")
+	r = sessionutil.SessionRaw{Version: "2.5.11", ServerID: 2}
+	data, _ = json.Marshal(r)
+	resource.Resource().ETCD().Put(context.Background(), proxyPath2, string(data))
+	metaRoot = paramtable.Get().EtcdCfg.MetaRootPath.GetValue()
+	dataNodePath := path.Join(metaRoot, sessionutil.DefaultServiceRoot, typeutil.DataNodeRole)
+	resource.Resource().ETCD().Put(context.Background(), dataNodePath, string(data))
+
 	ctx := context.Background()
 	b, err := balancer.RecoverBalancer(ctx, "pchannel_count_fair")
 	assert.NoError(t, err)
 	assert.NotNil(t, b)
+
+	ctx1, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	err = b.WatchChannelAssignments(ctx1, func(version typeutil.VersionInt64Pair, relations []types.PChannelInfoAssigned) error {
+		assert.Len(t, relations, 2)
+		return nil
+	})
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	resource.Resource().ETCD().Delete(context.Background(), proxyPath1)
+	resource.Resource().ETCD().Delete(context.Background(), proxyPath2)
+	resource.Resource().ETCD().Delete(context.Background(), dataNodePath)
 
 	b.MarkAsUnavailable(ctx, []types.PChannelInfo{{
 		Name: "test-channel-1",

--- a/internal/streamingnode/client/manager/manager_client.go
+++ b/internal/streamingnode/client/manager/manager_client.go
@@ -47,7 +47,7 @@ type ManagerClient interface {
 // NewManagerClient creates a new manager client.
 func NewManagerClient(etcdCli *clientv3.Client) ManagerClient {
 	role := sessionutil.GetSessionPrefixByRole(typeutil.StreamingNodeRole)
-	rb := resolver.NewSessionBuilder(etcdCli, role)
+	rb := resolver.NewSessionBuilder(etcdCli, role, ">=2.6.0-dev")
 	dialTimeout := paramtable.Get().StreamingNodeGrpcClientCfg.DialTimeout.GetAsDuration(time.Millisecond)
 	dialOptions := getDialOptions(rb)
 	conn := lazygrpc.NewConn(func(ctx context.Context) (*grpc.ClientConn, error) {

--- a/internal/streamingnode/client/manager/manager_client_impl.go
+++ b/internal/streamingnode/client/manager/manager_client_impl.go
@@ -61,7 +61,10 @@ func (c *managerClientImpl) CollectAllStatus(ctx context.Context) (map[int64]*ty
 	defer c.lifetime.Done()
 
 	// Get all discovered streamingnode.
-	state := c.rb.Resolver().GetLatestState()
+	state, err := c.rb.Resolver().GetLatestState(ctx)
+	if err != nil {
+		return nil, err
+	}
 	if len(state.State.Addresses) == 0 {
 		return make(map[int64]*types.StreamingNodeStatus), nil
 	}
@@ -73,7 +76,10 @@ func (c *managerClientImpl) CollectAllStatus(ctx context.Context) (map[int64]*ty
 	}
 
 	// Collect status may cost some time, so we need to check the lifetime again.
-	newState := c.rb.Resolver().GetLatestState()
+	newState, err := c.rb.Resolver().GetLatestState(ctx)
+	if err != nil {
+		return nil, err
+	}
 	if newState.Version.GT(state.Version) {
 		newSession := newState.Sessions()
 		for serverID := range result {

--- a/internal/streamingnode/client/manager/manager_test.go
+++ b/internal/streamingnode/client/manager/manager_test.go
@@ -50,11 +50,11 @@ func TestManager(t *testing.T) {
 	assert.False(t, ok)
 
 	// Test CollectAllStatus
-	r.EXPECT().GetLatestState().RunAndReturn(func() discoverer.VersionedState {
+	r.EXPECT().GetLatestState(mock.Anything).RunAndReturn(func(ctx context.Context) (discoverer.VersionedState, error) {
 		return discoverer.VersionedState{
 			Version: typeutil.VersionInt64(1),
 			State:   resolver.State{},
-		}
+		}, nil
 	})
 	// Not address here.
 	nodes, err := m.CollectAllStatus(context.Background())
@@ -75,11 +75,11 @@ func TestManager(t *testing.T) {
 		{1: false, 2: false, 3: true},
 		{1: true, 2: false},
 	}
-	r.EXPECT().GetLatestState().Unset()
-	r.EXPECT().GetLatestState().RunAndReturn(func() discoverer.VersionedState {
+	r.EXPECT().GetLatestState(mock.Anything).Unset()
+	r.EXPECT().GetLatestState(mock.Anything).RunAndReturn(func(ctx context.Context) (discoverer.VersionedState, error) {
 		s := newVersionedState(int64(i), states[i])
 		i++
-		return s
+		return s, nil
 	})
 
 	nodes, err = m.CollectAllStatus(context.Background())

--- a/internal/util/streamingutil/service/discoverer/channel_assignment_discoverer_test.go
+++ b/internal/util/streamingutil/service/discoverer/channel_assignment_discoverer_test.go
@@ -36,14 +36,8 @@ func TestChannelAssignmentDiscoverer(t *testing.T) {
 		})
 
 	d := NewChannelAssignmentDiscoverer(w)
-	s := d.NewVersionedState()
-	assert.True(t, s.Version.EQ(typeutil.VersionInt64Pair{Global: -1, Local: -1}))
 
 	expected := []*types.VersionedStreamingNodeAssignments{
-		{
-			Version:     typeutil.VersionInt64Pair{Global: -1, Local: -1},
-			Assignments: map[int64]types.StreamingNodeAssignment{},
-		},
 		{
 			Version: typeutil.VersionInt64Pair{
 				Global: 1,
@@ -81,6 +75,7 @@ func TestChannelAssignmentDiscoverer(t *testing.T) {
 		},
 	}
 
+	ch <- expected[0]
 	idx := 0
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/util/streamingutil/service/discoverer/discoverer.go
+++ b/internal/util/streamingutil/service/discoverer/discoverer.go
@@ -13,9 +13,6 @@ import (
 // 1. concurrent safe.
 // 2. the version of discovery may be repeated or decreasing. So user should check the version in callback.
 type Discoverer interface {
-	// NewVersionedState returns a lowest versioned state.
-	NewVersionedState() VersionedState
-
 	// Discover watches the service discovery on these goroutine.
 	// 1. Call the callback when the discovery is changed, and block until the discovery is canceled or break down.
 	// 2. Discover should always send the current state first and then block.

--- a/internal/util/streamingutil/service/discoverer/session_discoverer.go
+++ b/internal/util/streamingutil/service/discoverer/session_discoverer.go
@@ -40,14 +40,6 @@ type sessionDiscoverer struct {
 	peerSessions map[string]*sessionutil.SessionRaw // map[Key]SessionRaw, map the key path of session to session.
 }
 
-// NewVersionedState return the empty version state.
-func (sw *sessionDiscoverer) NewVersionedState() VersionedState {
-	return VersionedState{
-		Version: typeutil.VersionInt64(-1),
-		State:   resolver.State{},
-	}
-}
-
 // Discover watches the service discovery on these goroutine.
 // It may be broken down if compaction happens on etcd server.
 func (sw *sessionDiscoverer) Discover(ctx context.Context, cb func(VersionedState) error) error {

--- a/internal/util/streamingutil/service/discoverer/session_discoverer.go
+++ b/internal/util/streamingutil/service/discoverer/session_discoverer.go
@@ -17,13 +17,13 @@ import (
 )
 
 // NewSessionDiscoverer returns a new Discoverer for the milvus session registration.
-func NewSessionDiscoverer(etcdCli *clientv3.Client, prefix string, exclusive bool, minimumVersion string) Discoverer {
+func NewSessionDiscoverer(etcdCli *clientv3.Client, prefix string, exclusive bool, semverRange string) Discoverer {
 	return &sessionDiscoverer{
 		etcdCli:      etcdCli,
 		prefix:       prefix,
 		exclusive:    exclusive,
-		versionRange: semver.MustParseRange(">=" + minimumVersion),
-		logger:       log.With(zap.String("prefix", prefix), zap.Bool("exclusive", exclusive), zap.String("expectedVersion", minimumVersion)),
+		versionRange: semver.MustParseRange(semverRange),
+		logger:       log.With(zap.String("prefix", prefix), zap.Bool("exclusive", exclusive), zap.String("semver", semverRange)),
 		revision:     0,
 		peerSessions: make(map[string]*sessionutil.SessionRaw),
 	}

--- a/internal/util/streamingutil/service/discoverer/session_discoverer_test.go
+++ b/internal/util/streamingutil/service/discoverer/session_discoverer_test.go
@@ -24,7 +24,7 @@ func TestSessionDiscoverer(t *testing.T) {
 
 	etcdClient, err := etcd.GetEmbedEtcdClient()
 	assert.NoError(t, err)
-	targetVersion := "0.1.0"
+	targetVersion := ">=0.1.0"
 	d := NewSessionDiscoverer(etcdClient, "session/", false, targetVersion)
 
 	s := d.NewVersionedState()

--- a/internal/util/streamingutil/service/discoverer/session_discoverer_test.go
+++ b/internal/util/streamingutil/service/discoverer/session_discoverer_test.go
@@ -24,11 +24,8 @@ func TestSessionDiscoverer(t *testing.T) {
 
 	etcdClient, err := etcd.GetEmbedEtcdClient()
 	assert.NoError(t, err)
-	targetVersion := ">=0.1.0"
-	d := NewSessionDiscoverer(etcdClient, "session/", false, targetVersion)
-
-	s := d.NewVersionedState()
-	assert.True(t, s.Version.EQ(typeutil.VersionInt64(-1)))
+	targetVersion := "0.1.0"
+	d := NewSessionDiscoverer(etcdClient, "session/", false, ">="+targetVersion)
 
 	expected := []map[int64]*sessionutil.SessionRaw{
 		{},
@@ -95,7 +92,7 @@ func TestSessionDiscoverer(t *testing.T) {
 	assert.ErrorIs(t, err, io.EOF)
 
 	// Do a init discover here.
-	d = NewSessionDiscoverer(etcdClient, "session/", false, targetVersion)
+	d = NewSessionDiscoverer(etcdClient, "session/", false, ">="+targetVersion)
 	err = d.Discover(ctx, func(state VersionedState) error {
 		// balance attributes
 		sessions := state.Sessions()

--- a/internal/util/streamingutil/service/resolver/builder.go
+++ b/internal/util/streamingutil/service/resolver/builder.go
@@ -33,19 +33,19 @@ func NewChannelAssignmentBuilder(w types.AssignmentDiscoverWatcher) Builder {
 
 // NewSessionBuilder creates a new resolver builder.
 // Multiple sessions are allowed, use the role as prefix.
-func NewSessionBuilder(c *clientv3.Client, role string) Builder {
+func NewSessionBuilder(c *clientv3.Client, role string, version string) Builder {
 	b := newBuilder(SessionResolverScheme,
-		discoverer.NewSessionDiscoverer(c, role, false, "2.4.0"),
+		discoverer.NewSessionDiscoverer(c, role, false, version),
 		log.With(log.FieldComponent("grpc-resolver"), zap.String("scheme", SessionResolverScheme), zap.String("role", role), zap.Bool("exclusive", false)))
 	return b
 }
 
 // NewSessionExclusiveBuilder creates a new resolver builder with exclusive.
 // Only one session is allowed, not use the prefix, only use the role directly.
-func NewSessionExclusiveBuilder(c *clientv3.Client, role string) Builder {
+func NewSessionExclusiveBuilder(c *clientv3.Client, role string, version string) Builder {
 	b := newBuilder(
 		SessionResolverScheme,
-		discoverer.NewSessionDiscoverer(c, role, true, "2.4.0"),
+		discoverer.NewSessionDiscoverer(c, role, true, version),
 		log.With(log.FieldComponent("grpc-resolver"), zap.String("scheme", SessionResolverScheme), zap.String("role", role), zap.Bool("exclusive", true)))
 	return b
 }

--- a/internal/util/streamingutil/service/resolver/builder_test.go
+++ b/internal/util/streamingutil/service/resolver/builder_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/milvus-io/milvus/internal/mocks/util/streamingutil/service/mock_discoverer"
 	"github.com/milvus-io/milvus/internal/util/streamingutil/service/discoverer"
 	"github.com/milvus-io/milvus/pkg/v2/log"
-	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
 
 func TestNewBuilder(t *testing.T) {
@@ -30,18 +29,12 @@ func TestNewBuilder(t *testing.T) {
 			}
 		}
 	})
-	d.EXPECT().NewVersionedState().Return(discoverer.VersionedState{
-		Version: typeutil.VersionInt64(-1),
-	})
 
 	b := newBuilder("test", d, log.With())
 	r := b.Resolver()
 	assert.NotNil(t, r)
 	assert.Equal(t, "test", b.Scheme())
 	mockClientConn := mock_resolver.NewMockClientConn(t)
-	mockClientConn.EXPECT().UpdateState(mock.Anything).RunAndReturn(func(args resolver.State) error {
-		return nil
-	})
 	grpcResolver, err := b.Build(resolver.Target{}, mockClientConn, resolver.BuildOptions{})
 	assert.NoError(t, err)
 	assert.NotNil(t, grpcResolver)

--- a/internal/util/streamingutil/service/resolver/resolver.go
+++ b/internal/util/streamingutil/service/resolver/resolver.go
@@ -34,7 +34,7 @@ type Builder interface {
 type Resolver interface {
 	// GetLatestState returns the latest state of the resolver.
 	// The returned state should be read only, applied any change to it will cause data race.
-	GetLatestState() VersionedState
+	GetLatestState(ctx context.Context) (VersionedState, error)
 
 	// Watch watch the state change of the resolver.
 	// cb will be called with latest state after call, and will be called with new state when state changed.

--- a/internal/util/streamingutil/service/resolver/resolver_with_discoverer_test.go
+++ b/internal/util/streamingutil/service/resolver/resolver_with_discoverer_test.go
@@ -33,10 +33,6 @@ func TestResolverWithDiscoverer(t *testing.T) {
 			}
 		}
 	})
-	d.EXPECT().NewVersionedState().Return(discoverer.VersionedState{
-		Version: typeutil.VersionInt64(-1),
-	})
-
 	r := newResolverWithDiscoverer(d, time.Second, log.With())
 
 	var resultOfGRPCResolver resolver.State
@@ -55,32 +51,23 @@ func TestResolverWithDiscoverer(t *testing.T) {
 	err = r.RegisterNewWatcher(w2) // A closed resolver should be removed automatically by resolver.
 	assert.NoError(t, err)
 
-	state := r.GetLatestState()
-	assert.Equal(t, typeutil.VersionInt64(-1), state.Version)
-	time.Sleep(500 * time.Millisecond)
-
-	state = r.GetLatestState()
-	assert.Equal(t, typeutil.VersionInt64(-1), state.Version)
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	state, err := r.GetLatestState(ctx)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
 
 	// should be non block after context canceled
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Millisecond)
 	defer cancel()
 	err = r.Watch(ctx, func(s VersionedState) error {
 		state = s
+		t.Errorf("should not be called")
 		return nil
 	})
-	assert.Equal(t, typeutil.VersionInt64(-1), state.Version)
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 	assert.True(t, errors.Is(err, ErrCanceled))
 
-	// should be non block after state operation failure.
 	testErr := errors.New("test error")
-	err = r.Watch(context.Background(), func(s VersionedState) error {
-		return testErr
-	})
-	assert.ErrorIs(t, err, testErr)
-	assert.True(t, errors.Is(err, ErrInterrupted))
-
 	outCh := make(chan VersionedState, 1)
 	go func() {
 		var state VersionedState
@@ -153,6 +140,13 @@ func TestResolverWithDiscoverer(t *testing.T) {
 	// after close, new register is not allowed.
 	err = r.RegisterNewWatcher(nil)
 	assert.True(t, errors.Is(err, ErrCanceled))
+
+	// should be non block after state operation failure.
+	err = r.Watch(context.Background(), func(s VersionedState) error {
+		return testErr
+	})
+	assert.ErrorIs(t, err, testErr)
+	assert.True(t, errors.Is(err, ErrInterrupted))
 }
 
 func shouldbeBlock(t *testing.T, ch <-chan VersionedState) {

--- a/pkg/mq/msgstream/mq_msgstream.go
+++ b/pkg/mq/msgstream/mq_msgstream.go
@@ -39,6 +39,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/mq/common"
 	"github.com/milvus-io/milvus/pkg/v2/mq/msgstream/mqwrapper"
+	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/retry"
@@ -459,6 +460,10 @@ func (ms *mqMsgStream) receiveMsg(consumer mqwrapper.Consumer) {
 				log.Ctx(ms.ctx).Warn("MqMsgStream get msg whose payload is nil")
 				continue
 			}
+			if message.CheckIfMessageFromStreaming(msg.Properties()) {
+				log.Ctx(ms.ctx).Warn("MqMsgStream can not consume the message from streaming service")
+				continue
+			}
 
 			var err error
 			var packMsg ConsumeMsg
@@ -841,6 +846,10 @@ func (ms *MqTtMsgStream) consumeToTtMsg(consumer mqwrapper.Consumer) {
 
 			if msg.Payload() == nil {
 				log.Warn("MqTtMsgStream get msg whose payload is nil")
+				continue
+			}
+			if message.CheckIfMessageFromStreaming(msg.Properties()) {
+				log.Warn("MqTtMsgStream can not consume the message from streaming service")
 				continue
 			}
 

--- a/pkg/streaming/util/message/message_test.go
+++ b/pkg/streaming/util/message/message_test.go
@@ -34,3 +34,12 @@ func TestVersion(t *testing.T) {
 	assert.True(t, VersionV1.GT(VersionOld))
 	assert.True(t, VersionV2.GT(VersionV1))
 }
+
+// TestCheckIfMessageFromStreaming tests CheckIfMessageFromStreaming function.
+func TestCheckIfMessageFromStreaming(t *testing.T) {
+	assert.False(t, CheckIfMessageFromStreaming(nil))
+	assert.False(t, CheckIfMessageFromStreaming(map[string]string{}))
+	assert.True(t, CheckIfMessageFromStreaming(map[string]string{
+		messageVersion: "1",
+	}))
+}

--- a/pkg/streaming/util/message/properties.go
+++ b/pkg/streaming/util/message/properties.go
@@ -81,3 +81,14 @@ func (prop propertiesImpl) EstimateSize() int {
 	}
 	return size
 }
+
+// CheckIfMessageFromStreaming checks if the message is from streaming.
+func CheckIfMessageFromStreaming(props map[string]string) bool {
+	if props == nil {
+		return false
+	}
+	if props[messageVersion] != "" {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
issue: #40532

- balance should enable only when there's no proxy and datanode which version is lower than 2.6.0