### PR TITLE
enhance: [2.5] increate tantivy index worker and memory budget for json key stats for buliding index

### DIFF
--- a/internal/core/src/index/JsonKeyStatsInvertedIndex.cpp
+++ b/internal/core/src/index/JsonKeyStatsInvertedIndex.cpp
@@ -273,8 +273,9 @@ JsonKeyStatsInvertedIndex::JsonKeyStatsInvertedIndex(
             path_.c_str(),
             false,
             false,
-            1,
-            json_stats_tantivy_memory_budget);
+            // To speed up index building process.
+            4,
+            4 * 64 * 1024 * 1024);
     }
 }
 


### PR DESCRIPTION
issue: #40897

This PR, combined with https://github.com/milvus-io/milvus/pull/40898, makes tantivy total duration decrease roughly
from 6.3s to 1.68s for the case in the issue.