### PR TITLE
fix: create collection task check failed after restart

### DIFF
--- a/internal/metastore/model/field.go
+++ b/internal/metastore/model/field.go
@@ -85,9 +85,13 @@ func CheckFieldsEqual(fieldsA, fieldsB []*Field) bool {
 	if len(fieldsA) != len(fieldsB) {
 		return false
 	}
-	l := len(fieldsA)
-	for i := 0; i < l; i++ {
-		if !fieldsA[i].Equal(*fieldsB[i]) {
+	mapA := make(map[int64]*Field)
+	for _, f := range fieldsA {
+		mapA[f.FieldID] = f
+	}
+
+	for _, f := range fieldsB {
+		if other, exists := mapA[f.FieldID]; !exists || !f.Equal(*other) {
 			return false
 		}
 	}

--- a/internal/metastore/model/field_test.go
+++ b/internal/metastore/model/field_test.go
@@ -70,31 +70,31 @@ func TestCheckFieldsEqual(t *testing.T) {
 		{
 			// length not match.
 			args: args{
-				fieldsA: []*Field{{Name: "f1"}},
+				fieldsA: []*Field{{FieldID: 1, Name: "f1"}},
 				fieldsB: []*Field{},
 			},
 			want: false,
 		},
 		{
 			args: args{
-				fieldsA: []*Field{{Name: "f1"}},
-				fieldsB: []*Field{{Name: "f2"}},
+				fieldsA: []*Field{{FieldID: 1, Name: "f1"}},
+				fieldsB: []*Field{{FieldID: 2, Name: "f2"}},
 			},
 			want: false,
 		},
 		{
 			args: args{
-				fieldsA: []*Field{{Name: "f1"}, {Name: "f2"}},
-				fieldsB: []*Field{{Name: "f1"}, {Name: "f2"}},
+				fieldsA: []*Field{{FieldID: 1, Name: "f1"}, {FieldID: 2, Name: "f2"}},
+				fieldsB: []*Field{{FieldID: 1, Name: "f1"}, {FieldID: 2, Name: "f2"}},
 			},
 			want: true,
 		},
 		{
 			args: args{
-				fieldsA: []*Field{{Name: "f1", TypeParams: []*commonpb.KeyValuePair{
+				fieldsA: []*Field{{FieldID: 1, Name: "f1", TypeParams: []*commonpb.KeyValuePair{
 					{Key: "dim", Value: "128"},
 				}}},
-				fieldsB: []*Field{{Name: "f1", TypeParams: []*commonpb.KeyValuePair{
+				fieldsB: []*Field{{FieldID: 1, Name: "f1", TypeParams: []*commonpb.KeyValuePair{
 					{Key: "dim", Value: "256"},
 				}}},
 			},
@@ -102,14 +102,21 @@ func TestCheckFieldsEqual(t *testing.T) {
 		},
 		{
 			args: args{
-				fieldsA: []*Field{{Name: "f1", TypeParams: []*commonpb.KeyValuePair{
+				fieldsA: []*Field{{FieldID: 1, Name: "f1", TypeParams: []*commonpb.KeyValuePair{
 					{Key: "max_length", Value: "65536"},
 				}}},
-				fieldsB: []*Field{{Name: "f1", TypeParams: []*commonpb.KeyValuePair{
+				fieldsB: []*Field{{FieldID: 1, Name: "f1", TypeParams: []*commonpb.KeyValuePair{
 					{Key: "max_length", Value: "32768"},
 				}}},
 			},
 			want: false,
+		},
+		{
+			args: args{
+				fieldsA: []*Field{{FieldID: 1, Name: "f1"}, {FieldID: 2, Name: "f2"}},
+				fieldsB: []*Field{{FieldID: 2, Name: "f2"}, {FieldID: 1, Name: "f1"}},
+			},
+			want: true,
 		},
 	}
 	for _, tt := range tests {

--- a/internal/metastore/model/partition.go
+++ b/internal/metastore/model/partition.go
@@ -45,9 +45,13 @@ func CheckPartitionsEqual(partitionsA, partitionsB []*Partition) bool {
 	if len(partitionsA) != len(partitionsB) {
 		return false
 	}
-	l := len(partitionsA)
-	for i := 0; i < l; i++ {
-		if !partitionsA[i].Equal(*partitionsB[i]) {
+	mapA := make(map[string]*Partition)
+	for _, p := range partitionsA {
+		mapA[p.PartitionName] = p
+	}
+
+	for _, p := range partitionsB {
+		if other, exists := mapA[p.PartitionName]; !exists || !p.Equal(*other) {
 			return false
 		}
 	}

--- a/internal/metastore/model/partition_test.go
+++ b/internal/metastore/model/partition_test.go
@@ -36,6 +36,13 @@ func TestCheckPartitionsEqual(t *testing.T) {
 			},
 			want: true,
 		},
+		{
+			args: args{
+				partitionsA: []*Partition{{PartitionName: "not_default"}, {PartitionName: "_default"}},
+				partitionsB: []*Partition{{PartitionName: "_default"}, {PartitionName: "not_default"}},
+			},
+			want: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -520,7 +520,7 @@ func TestProxy(t *testing.T) {
 	// an int64 field (pk) & a float vector field
 	constructCollectionSchema := func() *schemapb.CollectionSchema {
 		pk := &schemapb.FieldSchema{
-			FieldID:      0,
+			FieldID:      100,
 			Name:         int64Field,
 			IsPrimaryKey: true,
 			Description:  "",
@@ -530,7 +530,7 @@ func TestProxy(t *testing.T) {
 			AutoID:       true,
 		}
 		fVec := &schemapb.FieldSchema{
-			FieldID:      0,
+			FieldID:      101,
 			Name:         floatVecField,
 			IsPrimaryKey: false,
 			Description:  "",
@@ -545,7 +545,7 @@ func TestProxy(t *testing.T) {
 			AutoID:      false,
 		}
 		bVec := &schemapb.FieldSchema{
-			FieldID:      0,
+			FieldID:      102,
 			Name:         binaryVecField,
 			IsPrimaryKey: false,
 			Description:  "",
@@ -3669,7 +3669,7 @@ func TestProxy(t *testing.T) {
 
 	constructCollectionSchema = func() *schemapb.CollectionSchema {
 		pk := &schemapb.FieldSchema{
-			FieldID:      0,
+			FieldID:      100,
 			Name:         int64Field,
 			IsPrimaryKey: true,
 			Description:  "",
@@ -3679,7 +3679,7 @@ func TestProxy(t *testing.T) {
 			AutoID:       false,
 		}
 		fVec := &schemapb.FieldSchema{
-			FieldID:      0,
+			FieldID:      101,
 			Name:         floatVecField,
 			IsPrimaryKey: false,
 			Description:  "",
@@ -3694,7 +3694,7 @@ func TestProxy(t *testing.T) {
 			AutoID:      false,
 		}
 		bVec := &schemapb.FieldSchema{
-			FieldID:      0,
+			FieldID:      102,
 			Name:         binaryVecField,
 			IsPrimaryKey: false,
 			Description:  "",

--- a/internal/proxy/task_test.go
+++ b/internal/proxy/task_test.go
@@ -1236,8 +1236,9 @@ func TestCreateCollectionTask(t *testing.T) {
 		assert.Error(t, err)
 
 		schema = proto.Clone(schemaBackup).(*schemapb.CollectionSchema)
+		lastFieldID := schema.Fields[len(schema.Fields)-1].FieldID
 		schema.Fields = append(schema.Fields, &schemapb.FieldSchema{
-			FieldID:      0,
+			FieldID:      lastFieldID + 1,
 			Name:         "second_vector",
 			IsPrimaryKey: false,
 			Description:  "",

--- a/tests/integration/jsonexpr/json_expr_test.go
+++ b/tests/integration/jsonexpr/json_expr_test.go
@@ -55,7 +55,7 @@ func (s *JSONExprSuite) TestJsonEnableDynamicSchema() {
 
 	constructCollectionSchema := func() *schemapb.CollectionSchema {
 		pk := &schemapb.FieldSchema{
-			FieldID:      0,
+			FieldID:      100,
 			Name:         integration.Int64Field,
 			IsPrimaryKey: true,
 			Description:  "",
@@ -65,7 +65,7 @@ func (s *JSONExprSuite) TestJsonEnableDynamicSchema() {
 			AutoID:       true,
 		}
 		fVec := &schemapb.FieldSchema{
-			FieldID:      0,
+			FieldID:      101,
 			Name:         integration.FloatVecField,
 			IsPrimaryKey: false,
 			Description:  "",
@@ -138,7 +138,7 @@ func (s *JSONExprSuite) TestJSON_InsertWithoutDynamicData() {
 
 	constructCollectionSchema := func() *schemapb.CollectionSchema {
 		pk := &schemapb.FieldSchema{
-			FieldID:      0,
+			FieldID:      100,
 			Name:         integration.Int64Field,
 			IsPrimaryKey: true,
 			Description:  "",
@@ -148,7 +148,7 @@ func (s *JSONExprSuite) TestJSON_InsertWithoutDynamicData() {
 			AutoID:       true,
 		}
 		fVec := &schemapb.FieldSchema{
-			FieldID:      0,
+			FieldID:      101,
 			Name:         integration.FloatVecField,
 			IsPrimaryKey: false,
 			Description:  "",
@@ -228,7 +228,7 @@ func (s *JSONExprSuite) TestJSON_DynamicSchemaWithJSON() {
 
 	constructCollectionSchema := func() *schemapb.CollectionSchema {
 		pk := &schemapb.FieldSchema{
-			FieldID:      0,
+			FieldID:      100,
 			Name:         integration.Int64Field,
 			IsPrimaryKey: true,
 			Description:  "",
@@ -238,7 +238,7 @@ func (s *JSONExprSuite) TestJSON_DynamicSchemaWithJSON() {
 			AutoID:       true,
 		}
 		fVec := &schemapb.FieldSchema{
-			FieldID:      0,
+			FieldID:      101,
 			Name:         integration.FloatVecField,
 			IsPrimaryKey: false,
 			Description:  "",
@@ -920,7 +920,7 @@ func (s *JSONExprSuite) TestJsonWithEscapeString() {
 
 	constructCollectionSchema := func() *schemapb.CollectionSchema {
 		pk := &schemapb.FieldSchema{
-			FieldID:      0,
+			FieldID:      100,
 			Name:         integration.Int64Field,
 			IsPrimaryKey: true,
 			Description:  "",
@@ -930,7 +930,7 @@ func (s *JSONExprSuite) TestJsonWithEscapeString() {
 			AutoID:       true,
 		}
 		fVec := &schemapb.FieldSchema{
-			FieldID:      0,
+			FieldID:      101,
 			Name:         integration.FloatVecField,
 			IsPrimaryKey: false,
 			Description:  "",
@@ -1039,7 +1039,7 @@ func (s *JSONExprSuite) TestJsonContains() {
 
 	constructCollectionSchema := func() *schemapb.CollectionSchema {
 		pk := &schemapb.FieldSchema{
-			FieldID:      0,
+			FieldID:      100,
 			Name:         integration.Int64Field,
 			IsPrimaryKey: true,
 			Description:  "",
@@ -1049,7 +1049,7 @@ func (s *JSONExprSuite) TestJsonContains() {
 			AutoID:       true,
 		}
 		fVec := &schemapb.FieldSchema{
-			FieldID:      0,
+			FieldID:      101,
 			Name:         integration.FloatVecField,
 			IsPrimaryKey: false,
 			Description:  "",

--- a/tests/integration/meta_watcher_test.go
+++ b/tests/integration/meta_watcher_test.go
@@ -63,7 +63,7 @@ func (s *MetaWatcherSuite) TestShowSegments() {
 
 	constructCollectionSchema := func() *schemapb.CollectionSchema {
 		pk := &schemapb.FieldSchema{
-			FieldID:      0,
+			FieldID:      100,
 			Name:         int64Field,
 			IsPrimaryKey: true,
 			Description:  "",
@@ -73,7 +73,7 @@ func (s *MetaWatcherSuite) TestShowSegments() {
 			AutoID:       true,
 		}
 		fVec := &schemapb.FieldSchema{
-			FieldID:      0,
+			FieldID:      101,
 			Name:         floatVecField,
 			IsPrimaryKey: false,
 			Description:  "",
@@ -166,7 +166,7 @@ func (s *MetaWatcherSuite) TestShowReplicas() {
 
 	constructCollectionSchema := func() *schemapb.CollectionSchema {
 		pk := &schemapb.FieldSchema{
-			FieldID:      0,
+			FieldID:      100,
 			Name:         int64Field,
 			IsPrimaryKey: true,
 			Description:  "",
@@ -176,7 +176,7 @@ func (s *MetaWatcherSuite) TestShowReplicas() {
 			AutoID:       true,
 		}
 		fVec := &schemapb.FieldSchema{
-			FieldID:      0,
+			FieldID:      101,
 			Name:         floatVecField,
 			IsPrimaryKey: false,
 			Description:  "",


### PR DESCRIPTION
The fields and partitions information are stored and fetched with different prefixes in the metadata. In the CreateCollectionTask, the RootCoord checks the existing collection information against the metadata. This check fails if the order of the fields or partitions info differs, leading to an error after restarting Milvus. To resolve this, we should use a map in the check logic to ensure consistency.

related: https://github.com/milvus-io/milvus/issues/40955