### PR TITLE
fix: remove metrics reset calls to ensure accurate reporting

### DIFF
--- a/internal/querynodev2/metrics_info.go
+++ b/internal/querynodev2/metrics_info.go
@@ -75,9 +75,6 @@ func getQuotaMetrics(node *QueryNode) (*metricsinfo.QueryNodeQuotaMetrics, error
 	collections := node.manager.Collection.ListWithName()
 	nodeID := fmt.Sprint(node.GetNodeID())
 
-	metrics.QueryNodeNumEntities.Reset()
-	metrics.QueryNodeEntitiesSize.Reset()
-
 	var totalGrowingSize int64
 	growingSegments := node.manager.Segment.GetBy(segments.WithType(segments.SegmentTypeGrowing))
 	growingGroupByCollection := lo.GroupBy(growingSegments, func(seg segments.Segment) int64 {


### PR DESCRIPTION
issue: #41048
Fixes issue introduced in PR #33522 where metric resets caused incomplete data collection by monitoring systems.