### PR TITLE
fix: Inserting null and non-null array at the same time will cause milvus crash when growing mmap open

### DIFF
--- a/internal/core/src/mmap/ChunkData.h
+++ b/internal/core/src/mmap/ChunkData.h
@@ -214,9 +214,7 @@ VariableLengthChunk<Array>::set(
     size_t total_size = 0;
     for (auto i = 0; i < length; i++) {
         total_size += src[i].byte_size();
-    }
-    if (length > 0 && IsVariableDataType(src[0].get_element_type())) {
-        for (auto i = 0; i < length; i++) {
+        if (IsVariableDataType(src[i].get_element_type())) {
             total_size += (src[i].length() * sizeof(uint32_t));
         }
     }


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/40981
2.5 pr: https://github.com/milvus-io/milvus/pull/41052