### PR TITLE
fix: jsonstats check if cache schema is nil lazy describecollection

### DIFF
--- a/internal/querycoordv2/checkers/index_checker.go
+++ b/internal/querycoordv2/checkers/index_checker.go
@@ -97,6 +97,13 @@ func (c *IndexChecker) Check(ctx context.Context) []task.Task {
 			log.Warn("collection released during check index", zap.Int64("collection", collectionID))
 			continue
 		}
+		if schema == nil && paramtable.Get().CommonCfg.EnabledJSONKeyStats.GetAsBool() {
+			collection, err := c.broker.DescribeCollection(ctx, collectionID)
+			if err != nil {
+				schema = collection.GetSchema()
+				c.meta.PutCollectionSchema(ctx, collectionID, collection.GetSchema())
+			}
+		}
 		replicas := c.meta.ReplicaManager.GetByCollection(ctx, collectionID)
 		for _, replica := range replicas {
 			tasks = append(tasks, c.checkReplica(ctx, collection, replica, indexInfos, schema)...)

--- a/internal/querycoordv2/checkers/index_checker.go
+++ b/internal/querycoordv2/checkers/index_checker.go
@@ -99,7 +99,7 @@ func (c *IndexChecker) Check(ctx context.Context) []task.Task {
 		}
 		if schema == nil && paramtable.Get().CommonCfg.EnabledJSONKeyStats.GetAsBool() {
 			collectionSchema, err1 := c.broker.DescribeCollection(ctx, collectionID)
-			if err1 != nil {
+			if err1 == nil {
 				schema = collectionSchema.GetSchema()
 				c.meta.PutCollectionSchema(ctx, collectionID, collectionSchema.GetSchema())
 			}

--- a/internal/querycoordv2/checkers/index_checker.go
+++ b/internal/querycoordv2/checkers/index_checker.go
@@ -98,10 +98,10 @@ func (c *IndexChecker) Check(ctx context.Context) []task.Task {
 			continue
 		}
 		if schema == nil && paramtable.Get().CommonCfg.EnabledJSONKeyStats.GetAsBool() {
-			collection, err := c.broker.DescribeCollection(ctx, collectionID)
-			if err != nil {
-				schema = collection.GetSchema()
-				c.meta.PutCollectionSchema(ctx, collectionID, collection.GetSchema())
+			collectionSchema, err1 := c.broker.DescribeCollection(ctx, collectionID)
+			if err1 != nil {
+				schema = collectionSchema.GetSchema()
+				c.meta.PutCollectionSchema(ctx, collectionID, collectionSchema.GetSchema())
 			}
 		}
 		replicas := c.meta.ReplicaManager.GetByCollection(ctx, collectionID)

--- a/internal/querycoordv2/meta/collection_manager.go
+++ b/internal/querycoordv2/meta/collection_manager.go
@@ -266,6 +266,17 @@ func (m *CollectionManager) GetCollectionSchema(ctx context.Context, collectionI
 	return collection.Schema
 }
 
+func (m *CollectionManager) PutCollectionSchema(ctx context.Context, collectionID typeutil.UniqueID, schema *schemapb.CollectionSchema) {
+	m.rwmutex.Lock()
+	defer m.rwmutex.Unlock()
+
+	collection, ok := m.collections[collectionID]
+	if !ok {
+		return
+	}
+	collection.Schema = schema
+}
+
 func (m *CollectionManager) GetPartition(ctx context.Context, partitionID typeutil.UniqueID) *Partition {
 	m.rwmutex.RLock()
 	defer m.rwmutex.RUnlock()


### PR DESCRIPTION
fix: jsonstats check if cache schema is nil lazy describecollection
pr:https://github.com/milvus-io/milvus/pull/38039
issue:https://github.com/milvus-io/milvus/issues/36995