### PR TITLE
fix: segv if the LoadArrowReaderFromRemote run at the exception path

### DIFF
--- a/internal/core/src/segcore/Utils.cpp
+++ b/internal/core/src/segcore/Utils.cpp
@@ -901,7 +901,7 @@ LoadArrowReaderFromRemote(const std::vector<std::string>& remote_files,
             futures;
         futures.reserve(remote_files.size());
         for (const auto& file : remote_files) {
-            auto future = pool.Submit([&]() {
+            auto future = pool.Submit([rcm, file]() {
                 auto fileSize = rcm->Size(file);
                 auto buf = std::shared_ptr<uint8_t[]>(new uint8_t[fileSize]);
                 rcm->Read(file, buf.get(), fileSize);


### PR DESCRIPTION
issue: #41067