### PR TITLE
enhance: [2.5] Use `%v` for missing id log (#41036)

### DIFF
--- a/internal/proxy/task_search.go
+++ b/internal/proxy/task_search.go
@@ -985,7 +985,7 @@ func (t *searchTask) Requery(span trace.Span) error {
 	for i := 0; i < typeutil.GetSizeOfIDs(ids); i++ {
 		id := typeutil.GetPK(ids, int64(i))
 		if _, ok := offsets[id]; !ok {
-			return merr.WrapErrInconsistentRequery(fmt.Sprintf("incomplete query result, missing id %s, len(searchIDs) = %d, len(queryIDs) = %d, collection=%d",
+			return merr.WrapErrInconsistentRequery(fmt.Sprintf("incomplete query result, missing id %v, len(searchIDs) = %d, len(queryIDs) = %d, collection=%d",
 				id, typeutil.GetSizeOfIDs(ids), len(offsets), t.GetCollectionID()))
 		}
 		typeutil.AppendFieldData(t.result.Results.FieldsData, queryResult.GetFieldsData(), int64(offsets[id]))


### PR DESCRIPTION
Cherry-pick from master
pr: #41036
`incomplete query result, missing id %!s(int64=348), len(searchIDs) = 10, len(queryIDs) = 9` error message format with error 
when missing id is int64