### PR TITLE
fix: Ignore growing segment without start pos for seal policy

### DIFF
--- a/internal/datacoord/segment_allocation_policy.go
+++ b/internal/datacoord/segment_allocation_policy.go
@@ -301,7 +301,6 @@ func sealByBlockingL0(meta *meta) channelSealPolicy {
 		// util func to calculate blocking statistics
 		blockingStats := func(l0Segments []*SegmentInfo, minStartTs uint64) (blockingSize int64, blockingEntryNum int64) {
 			for _, l0Segment := range l0Segments {
-				// GetBinlogSizeAsBytes()
 				if l0Segment.GetDmlPosition().GetTimestamp() >= minStartTs {
 					blockingSize += id2Size[l0Segment.GetID()]
 					blockingEntryNum += id2EntryNum[l0Segment.GetID()]
@@ -314,6 +313,11 @@ func sealByBlockingL0(meta *meta) channelSealPolicy {
 
 		var result []*SegmentInfo
 		for len(candidates) > 0 {
+			// skip segments with nil start position
+			if candidates[0].GetStartPosition() == nil {
+				candidates = candidates[1:]
+				continue
+			}
 			// minStartPos must be [0], since growing is sorted
 			blockingSize, blockingEntryNum := blockingStats(l0segments, candidates[0].GetStartPosition().GetTimestamp())
 

--- a/internal/datacoord/segment_allocation_policy_test.go
+++ b/internal/datacoord/segment_allocation_policy_test.go
@@ -349,6 +349,12 @@ func Test_sealByBlockingL0(t *testing.T) {
 			StartPosition: &msgpb.MsgPosition{Timestamp: 35},
 		},
 	}
+	growing_3 := &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:            2003,
+			InsertChannel: "channel_1",
+		},
+	}
 
 	testCases := []*testCase{
 		{
@@ -384,6 +390,13 @@ func Test_sealByBlockingL0(t *testing.T) {
 			growingSegments: []*SegmentInfo{growing_1, growing_2},
 			sizeLimit:       -1,
 			entryNumLimit:   -1,
+			expected:        []int64{},
+		},
+		{
+			tag:             "growing_segment_with_nil_start_position",
+			channel:         "channel_1",
+			l0Segments:      []*SegmentInfo{l0_1, l0_2},
+			growingSegments: []*SegmentInfo{growing_3},
 			expected:        []int64{},
 		},
 	}


### PR DESCRIPTION
Related to #41129