### PR TITLE
enhance: [2.5] Rectify client_request_id logic (#41089)

### DIFF
--- a/pkg/util/logutil/grpc_interceptor_test.go
+++ b/pkg/util/logutil/grpc_interceptor_test.go
@@ -46,13 +46,13 @@ func TestCtxWithLevelAndTrace(t *testing.T) {
 	t.Run(("pass through variables"), func(t *testing.T) {
 		md := metadata.New(map[string]string{
 			logLevelRPCMetaKey: zapcore.ErrorLevel.String(),
-			clientRequestIDKey: "client-req-id",
+			clientRequestIDKey: "cb1ef460136611f0b3352a4f4aa7d7fd",
 		})
 		ctx := metadata.NewIncomingContext(context.TODO(), md)
 		newctx := withLevelAndTrace(ctx)
 		md, ok := metadata.FromOutgoingContext(newctx)
 		assert.True(t, ok)
-		assert.Equal(t, "client-req-id", md.Get(clientRequestIDKey)[0])
+		assert.Equal(t, "cb1ef460136611f0b3352a4f4aa7d7fd", md.Get(clientRequestIDKey)[0])
 		assert.Equal(t, zapcore.ErrorLevel.String(), md.Get(logLevelRPCMetaKey)[0])
 		expectedctx := context.TODO()
 		expectedctx = log.WithErrorLevel(expectedctx)


### PR DESCRIPTION
Cherry-pick from master
pr: #41089 
The traceID is not initialized by client_request_id in context. If the client sent valid traceID, milvus log will print two different traceID which is wierd.

This PR add the logic to tray parsing incoming `client_request_id` into traceID. If it works just use it the request traceID, otherwise set it to a different field named `client_request_id`.

---------