### PR TITLE
fix: [GoSDK] Fix array row base convertion logic

### DIFF
--- a/client/row/data.go
+++ b/client/row/data.go
@@ -119,7 +119,7 @@ func AnyToColumns(rows []interface{}, schemas ...*entity.Schema) ([]column.Colum
 			data := make([][]byte, 0, rowsLen)
 			col = column.NewColumnJSONBytes(field.Name, data)
 		case entity.FieldTypeArray:
-			col := NewArrayColumn(field)
+			col = NewArrayColumn(field)
 			if col == nil {
 				return nil, errors.Newf("unsupported element type %s for Array", field.ElementType.String())
 			}


### PR DESCRIPTION
Related to #40928

Array column is nil due to var lifespan issue