### PR TITLE
enhance: [Restful] Make default timeout configurable

### DIFF
--- a/internal/distributed/proxy/httpserver/constant.go
+++ b/internal/distributed/proxy/httpserver/constant.go
@@ -17,8 +17,6 @@
 package httpserver
 
 import (
-	"time"
-
 	"github.com/milvus-io/milvus/pkg/v2/util/metric"
 )
 
@@ -120,7 +118,6 @@ const (
 	HTTPHeaderAllowInt64     = "Accept-Type-Allow-Int64"
 	HTTPHeaderDBName         = "DB-Name"
 	HTTPHeaderRequestTimeout = "Request-Timeout"
-	HTTPDefaultTimeout       = 30 * time.Second
 	HTTPReturnCode           = "code"
 	HTTPReturnMessage        = "message"
 	HTTPReturnData           = "data"

--- a/internal/distributed/proxy/httpserver/timeout_middleware.go
+++ b/internal/distributed/proxy/httpserver/timeout_middleware.go
@@ -29,6 +29,7 @@ import (
 
 	mhttp "github.com/milvus-io/milvus/internal/http"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
 
 func defaultResponse(c *gin.Context) {
@@ -153,7 +154,7 @@ func checkWriteHeaderCode(code int) {
 
 func timeoutMiddleware(handler gin.HandlerFunc) gin.HandlerFunc {
 	t := &Timeout{
-		timeout:  mhttp.HTTPDefaultTimeout,
+		timeout:  paramtable.Get().HTTPCfg.RequestTimeoutMs.GetAsDuration(time.Millisecond),
 		handler:  handler,
 		response: defaultResponse,
 	}

--- a/internal/http/constant.go
+++ b/internal/http/constant.go
@@ -1,13 +1,8 @@
 package http
 
-import (
-	"time"
-)
-
 const (
 	HTTPHeaderAllowInt64     = "Accept-Type-Allow-Int64"
 	HTTPHeaderRequestTimeout = "Request-Timeout"
-	HTTPDefaultTimeout       = 30 * time.Second
 	HTTPReturnCode           = "code"
 	HTTPReturnMessage        = "message"
 	HTTPReturnData           = "data"

--- a/pkg/util/paramtable/http_param.go
+++ b/pkg/util/paramtable/http_param.go
@@ -71,4 +71,13 @@ func (p *httpConfig) init(base *BaseTable) {
 		Export:       true,
 	}
 	p.EnablePprof.Init(base.mgr)
+
+	p.RequestTimeoutMs = ParamItem{
+		Key:          "proxy.http.requestTimeoutMs",
+		DefaultValue: "30000",
+		Version:      "2.5.10",
+		Doc:          "default restful request timeout duration in milliseconds",
+		Export:       false,
+	}
+	p.RequestTimeoutMs.Init(base.mgr)
 }

--- a/pkg/util/paramtable/http_param.go
+++ b/pkg/util/paramtable/http_param.go
@@ -22,7 +22,7 @@ type httpConfig struct {
 	Port                 ParamItem `refreshable:"false"`
 	AcceptTypeAllowInt64 ParamItem `refreshable:"true"`
 	EnablePprof          ParamItem `refreshable:"false"`
-	RequestTimeoutMs     ParamItem `refreshable:"false"`
+	RequestTimeoutMs     ParamItem `refreshable:"true"`
 }
 
 func (p *httpConfig) init(base *BaseTable) {


### PR DESCRIPTION
The restful API default timeout was hard-coded. This PR make this timeout value configurable via paramtable.