### PR TITLE
enhance: add documents in batch for json key stats

### DIFF
--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -540,7 +540,7 @@ PhyUnaryRangeFilterExpr::ExecArrayEqualForIndex(EvalCtx& context,
                 };
             } else {
                 auto size_per_chunk = segment_->size_per_chunk();
-                retrieve = [ size_per_chunk, this ](int64_t offset) -> auto {
+                retrieve = [ size_per_chunk, this ](int64_t offset) -> auto{
                     auto chunk_idx = offset / size_per_chunk;
                     auto chunk_offset = offset % size_per_chunk;
                     const auto& chunk =

--- a/internal/core/src/index/InvertedIndexTantivy.cpp
+++ b/internal/core/src/index/InvertedIndexTantivy.cpp
@@ -218,7 +218,7 @@ InvertedIndexTantivy<T>::Load(milvus::tracer::TraceContext ctx,
     std::vector<std::string> null_offset_files;
     std::shared_ptr<FieldDataBase> null_offset_data;
 
-    auto find_file = [&](const std::string& target) -> auto {
+    auto find_file = [&](const std::string& target) -> auto{
         return std::find_if(inverted_index_files.begin(),
                             inverted_index_files.end(),
                             [&](const std::string& filename) {

--- a/internal/core/src/index/JsonKeyStatsInvertedIndex.h
+++ b/internal/core/src/index/JsonKeyStatsInvertedIndex.h
@@ -43,7 +43,7 @@ class JsonKeyStatsInvertedIndex : public InvertedIndexTantivy<std::string> {
                                        const char* unique_id,
                                        const std::string& path);
 
-    ~JsonKeyStatsInvertedIndex() override {};
+    ~JsonKeyStatsInvertedIndex() override{};
 
  public:
     IndexStatsPtr

--- a/internal/core/src/index/JsonKeyStatsInvertedIndex.h
+++ b/internal/core/src/index/JsonKeyStatsInvertedIndex.h
@@ -299,7 +299,7 @@ class JsonKeyStatsInvertedIndex : public InvertedIndexTantivy<std::string> {
         std::chrono::time_point<std::chrono::system_clock> index_build_begin_;
         std::chrono::time_point<std::chrono::system_clock> tantivy_build_begin_;
         // The time that we have finished push add operations to tantivy, which will be
-        // executed asynchronously.
+        // executed asynchronously
         std::chrono::time_point<std::chrono::system_clock>
             tantivy_add_schedule_end_;
         std::chrono::time_point<std::chrono::system_clock> index_build_done_;

--- a/internal/core/src/index/JsonKeyStatsInvertedIndex.h
+++ b/internal/core/src/index/JsonKeyStatsInvertedIndex.h
@@ -43,7 +43,7 @@ class JsonKeyStatsInvertedIndex : public InvertedIndexTantivy<std::string> {
                                        const char* unique_id,
                                        const std::string& path);
 
-    ~JsonKeyStatsInvertedIndex() override{};
+    ~JsonKeyStatsInvertedIndex() override {};
 
  public:
     IndexStatsPtr
@@ -294,5 +294,44 @@ class JsonKeyStatsInvertedIndex : public InvertedIndexTantivy<std::string> {
     std::atomic<stdclock::time_point> last_commit_time_;
     int64_t commit_interval_in_ms_;
     std::atomic<bool> is_data_uncommitted_ = false;
+
+    struct IndexBuildTimestamps {
+        std::chrono::time_point<std::chrono::system_clock> index_build_begin_;
+        std::chrono::time_point<std::chrono::system_clock> tantivy_build_begin_;
+        // The time that we have finished push add operations to tantivy, which will be
+        // executed asynchronously.
+        std::chrono::time_point<std::chrono::system_clock>
+            tantivy_add_schedule_end_;
+        std::chrono::time_point<std::chrono::system_clock> index_build_done_;
+
+        auto
+        getJsonParsingDuration() const {
+            return std::chrono::duration<double>(tantivy_build_begin_ -
+                                                 index_build_begin_)
+                .count();
+        }
+
+        auto
+        getTantivyAddSchedulingDuration() const {
+            return std::chrono::duration<double>(tantivy_add_schedule_end_ -
+                                                 tantivy_build_begin_)
+                .count();
+        }
+
+        auto
+        getTantivyTotalDuration() const {
+            return std::chrono::duration<double>(index_build_done_ -
+                                                 tantivy_build_begin_)
+                .count();
+        }
+
+        auto
+        getIndexBuildTotalDuration() const {
+            return std::chrono::duration<double>(index_build_done_ -
+                                                 index_build_begin_)
+                .count();
+        }
+    };
+    IndexBuildTimestamps index_build_timestamps_;
 };
 }  // namespace milvus::index

--- a/internal/core/thirdparty/tantivy/tantivy-binding/Cargo.lock
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/Cargo.lock
@@ -769,6 +769,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1819,7 +1825,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -1894,13 +1900,36 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
+dependencies = [
+ "libc",
+ "rand 0.4.6",
+]
+
+[[package]]
+name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1910,8 +1939,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -1929,7 +1973,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -1950,6 +1994,15 @@ checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -2535,6 +2588,7 @@ dependencies = [
  "libc",
  "lindera",
  "log",
+ "rand 0.3.23",
  "regex",
  "scopeguard",
  "serde_json",

--- a/internal/core/thirdparty/tantivy/tantivy-binding/Cargo.toml
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/Cargo.toml
@@ -30,6 +30,7 @@ regex = "1.11.1"
 either = "1.13.0"
 
 [dev-dependencies]
+rand = "0.3"
 tempfile = "3.0"
 
 [build-dependencies]

--- a/internal/core/thirdparty/tantivy/tantivy-binding/include/tantivy-binding.h
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/include/tantivy-binding.h
@@ -269,6 +269,12 @@ RustResult tantivy_index_add_strings_by_single_segment_writer(void *ptr,
                                                               const char *const *array,
                                                               uintptr_t len);
 
+RustResult tantivy_index_add_json_key_stats_data_by_batch(void *ptr,
+                                                          const char *const *keys,
+                                                          const int64_t *const *json_offsets,
+                                                          const uintptr_t *json_offsets_len,
+                                                          uintptr_t len);
+
 RustResult tantivy_index_add_array_int8s(void *ptr,
                                          const int8_t *array,
                                          uintptr_t len,

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/index_writer.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/index_writer.rs
@@ -131,6 +131,8 @@ impl IndexWriterWrapper {
         json_offsets: &[*const i64],
         json_offsets_len: &[usize],
     ) -> Result<()> {
+        assert!(keys.len() == json_offsets.len());
+        assert!(keys.len() == json_offsets_len.len());
         match self {
             IndexWriterWrapper::V5(writer) => {
                 writer.add_json_key_stats(keys, json_offsets, json_offsets_len)

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/index_writer_c.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/index_writer_c.rs
@@ -317,6 +317,25 @@ pub extern "C" fn tantivy_index_add_strings_by_single_segment_writer(
         .into()
 }
 
+#[no_mangle]
+pub extern "C" fn tantivy_index_add_json_key_stats_data_by_batch(
+    ptr: *mut c_void,
+    keys: *const *const c_char,
+    json_offsets: *const *const i64,
+    json_offsets_len: *const usize,
+    len: usize,
+) -> RustResult {
+    let real = ptr as *mut IndexWriterWrapper;
+    let json_offsets_len = unsafe { slice::from_raw_parts(json_offsets_len, len) };
+    let json_offsets = unsafe { slice::from_raw_parts(json_offsets, len) };
+    let keys = unsafe { slice::from_raw_parts(keys, len) };
+    unsafe {
+        (*real)
+            .add_json_key_stats(keys, json_offsets, json_offsets_len)
+            .into()
+    }
+}
+
 // --------------------------------------------- array ------------------------------------------
 
 #[no_mangle]

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/index_writer_v5/index_writer.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/index_writer_v5/index_writer.rs
@@ -302,6 +302,49 @@ impl IndexWriterWrapperImpl {
         Ok(())
     }
 
+    pub fn add_json_key_stats(
+        &mut self,
+        keys: &[*const i8],
+        json_offsets: &[*const i64],
+        json_offsets_len: &[usize],
+    ) -> Result<()> {
+        let writer = self.index_writer.as_ref().left().unwrap();
+        let id_field = self.id_field.unwrap();
+        let mut batch = Vec::with_capacity(BATCH_SIZE);
+        keys.iter()
+            .zip(json_offsets.iter())
+            .zip(json_offsets_len.iter())
+            .try_for_each(|((key, json_offsets), json_offsets_len)| -> Result<()> {
+                let key = unsafe { CStr::from_ptr(*key) }
+                    .to_str()
+                    .map_err(|e| TantivyBindingError::InternalError(e.to_string()))?;
+                let json_offsets =
+                    unsafe { std::slice::from_raw_parts(*json_offsets, *json_offsets_len) };
+
+                for offset in json_offsets {
+                    batch.push(UserOperation::Add(doc!(
+                        id_field => *offset,
+                        self.field => key,
+                    )));
+
+                    if batch.len() >= BATCH_SIZE {
+                        writer.run(std::mem::replace(
+                            &mut batch,
+                            Vec::with_capacity(BATCH_SIZE),
+                        ))?;
+                    }
+                }
+
+                Ok(())
+            })?;
+
+        if !batch.is_empty() {
+            writer.run(batch)?;
+        }
+
+        Ok(())
+    }
+
     pub fn manual_merge(&mut self) -> Result<()> {
         let index_writer = self.index_writer.as_mut().left().unwrap();
         let metas = index_writer.index().searchable_segment_metas()?;

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/index_writer_v5/index_writer.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/index_writer_v5/index_writer.rs
@@ -316,10 +316,10 @@ impl IndexWriterWrapperImpl {
                 .to_str()
                 .map_err(|e| TantivyBindingError::InternalError(e.to_string()))?;
 
-            let json_offsets =
+            let offsets =
                 unsafe { std::slice::from_raw_parts(json_offsets[i], json_offsets_len[i]) };
 
-            for offset in json_offsets {
+            for offset in offsets {
                 batch.push(UserOperation::Add(doc!(
                     id_field => *offset,
                     self.field => key,

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/index_writer_v7/index_writer.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/index_writer_v7/index_writer.rs
@@ -227,32 +227,28 @@ impl IndexWriterWrapperImpl {
         json_offsets_len: &[usize],
     ) -> Result<()> {
         let mut batch = Vec::with_capacity(BATCH_SIZE);
-        keys.iter()
-            .zip(json_offsets.iter())
-            .zip(json_offsets_len.iter())
-            .try_for_each(|((key, json_offsets), json_offsets_len)| -> Result<()> {
-                let key = unsafe { CStr::from_ptr(*key) }
-                    .to_str()
-                    .map_err(|e| TantivyBindingError::InternalError(e.to_string()))?;
-                let json_offsets =
-                    unsafe { std::slice::from_raw_parts(*json_offsets, *json_offsets_len) };
+        for i in 0..keys.len() {
+            let key = unsafe { CStr::from_ptr(keys[i]) }
+                .to_str()
+                .map_err(|e| TantivyBindingError::InternalError(e.to_string()))?;
 
-                for offset in json_offsets {
-                    batch.push(UserOperation::Add(doc!(
-                        self.id_field => *offset,
-                        self.field => key,
-                    )));
+            let json_offsets =
+                unsafe { std::slice::from_raw_parts(json_offsets[i], json_offsets_len[i]) };
 
-                    if batch.len() >= BATCH_SIZE {
-                        self.index_writer.run(std::mem::replace(
-                            &mut batch,
-                            Vec::with_capacity(BATCH_SIZE),
-                        ))?;
-                    }
+            for offset in json_offsets {
+                batch.push(UserOperation::Add(doc!(
+                    self.id_field => *offset,
+                    self.field => key,
+                )));
+
+                if batch.len() >= BATCH_SIZE {
+                    self.index_writer.run(std::mem::replace(
+                        &mut batch,
+                        Vec::with_capacity(BATCH_SIZE),
+                    ))?;
                 }
-
-                Ok(())
-            })?;
+            }
+        }
 
         if !batch.is_empty() {
             self.index_writer.run(batch)?;

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/index_writer_v7/index_writer.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/index_writer_v7/index_writer.rs
@@ -232,10 +232,10 @@ impl IndexWriterWrapperImpl {
                 .to_str()
                 .map_err(|e| TantivyBindingError::InternalError(e.to_string()))?;
 
-            let json_offsets =
+            let offsets =
                 unsafe { std::slice::from_raw_parts(json_offsets[i], json_offsets_len[i]) };
 
-            for offset in json_offsets {
+            for offset in offsets {
                 batch.push(UserOperation::Add(doc!(
                     self.id_field => *offset,
                     self.field => key,

--- a/internal/core/thirdparty/tantivy/tantivy-wrapper.h
+++ b/internal/core/thirdparty/tantivy/tantivy-wrapper.h
@@ -271,6 +271,20 @@ struct TantivyIndexWrapper {
                           typeid(T).name());
     }
 
+    void
+    add_json_key_stats_data_by_batch(const char* const* keys,
+                                     const int64_t* const* json_offsets,
+                                     const uintptr_t* json_offsets_lens,
+                                     uintptr_t len_of_lens) {
+        assert(!finished_);
+        auto res =
+            RustResultWrapper(tantivy_index_add_json_key_stats_data_by_batch(
+                writer_, keys, json_offsets, json_offsets_lens, len_of_lens));
+        AssertInfo(res.result_->success,
+                   "failed to add json key stats: {}",
+                   res.result_->error);
+    }
+
     template <typename T>
     void
     add_array_data(const T* array, uintptr_t len, int64_t offset) {


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/40897

After this, the document add operations scheduling duration is decreased roughly from 6s to 0.9s for the case in the issue.