### PR TITLE
fix: Properly initialized MinIO bucket and stability improvements

### DIFF
--- a/deployments/docker/standalone/docker-compose.yml
+++ b/deployments/docker/standalone/docker-compose.yml
@@ -34,21 +34,6 @@ services:
       timeout: 20s
       retries: 3
 
-  minio-init:
-    image: minio/mc:latest
-    depends_on:
-      - minio
-    entrypoint: >
-      /bin/sh -c "
-      until /usr/bin/mc config host add myminio http://minio:9000 minioadmin minioadmin; do
-        echo 'Waiting for MinIO to be available...'
-        sleep 1
-      done;
-      /usr/bin/mc mb myminio/milvus --ignore-existing;
-      /usr/bin/mc policy set public myminio/milvus;
-      echo 'MinIO initialized successfully'
-      "
-
   standalone:
     container_name: milvus-standalone
     image: milvusdb/milvus:v2.5.8
@@ -56,6 +41,7 @@ services:
     security_opt:
       - seccomp:unconfined
     environment:
+      MINIO_REGION: us-east-1
       ETCD_ENDPOINTS: etcd:2379
       MINIO_ADDRESS: minio:9000
       MINIO_ACCESS_KEY: minioadmin

--- a/deployments/docker/standalone/docker-compose.yml
+++ b/deployments/docker/standalone/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.5'
-
 services:
   etcd:
     container_name: milvus-etcd
@@ -10,8 +8,8 @@ services:
       - ETCD_QUOTA_BACKEND_BYTES=4294967296
       - ETCD_SNAPSHOT_COUNT=50000
     volumes:
-      - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/etcd:/etcd
-    command: etcd -advertise-client-urls=http://etcd:2379 -listen-client-urls http://0.0.0.0:2379 --data-dir /etcd
+      - etcd-data:/etcd
+    command: etcd -advertise-client-urls=http://0.0.0.0:2379 -listen-client-urls http://0.0.0.0:2379 --data-dir /etcd
     healthcheck:
       test: ["CMD", "etcdctl", "endpoint", "health"]
       interval: 30s
@@ -22,45 +20,74 @@ services:
     container_name: milvus-minio
     image: minio/minio:RELEASE.2023-03-20T20-16-18Z
     environment:
-      MINIO_ACCESS_KEY: minioadmin
-      MINIO_SECRET_KEY: minioadmin
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
     ports:
       - "9001:9001"
       - "9000:9000"
     volumes:
-      - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/minio:/minio_data
-    command: minio server /minio_data --console-address ":9001"
+      - minio-data:/data
+    command: server /data --console-address ":9001"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
       interval: 30s
       timeout: 20s
       retries: 3
 
+  minio-init:
+    image: minio/mc:latest
+    depends_on:
+      - minio
+    entrypoint: >
+      /bin/sh -c "
+      until /usr/bin/mc config host add myminio http://minio:9000 minioadmin minioadmin; do
+        echo 'Waiting for MinIO to be available...'
+        sleep 1
+      done;
+      /usr/bin/mc mb myminio/milvus --ignore-existing;
+      /usr/bin/mc policy set public myminio/milvus;
+      echo 'MinIO initialized successfully'
+      "
+
   standalone:
     container_name: milvus-standalone
     image: milvusdb/milvus:v2.5.8
     command: ["milvus", "run", "standalone"]
     security_opt:
-    - seccomp:unconfined
+      - seccomp:unconfined
     environment:
-      MINIO_REGION: us-east-1
       ETCD_ENDPOINTS: etcd:2379
       MINIO_ADDRESS: minio:9000
+      MINIO_ACCESS_KEY: minioadmin
+      MINIO_SECRET_KEY: minioadmin
+      COMMON_STORAGETYPE: remote
+      DATA_FLUSH_TIMEOUT: 30s
+      DATACOORD_ENABLECOMPACTION: "false"
+      DATACOORD_ENABLEGARBAGECOLLECTION: "false"
+      DATACOORD_SEGMENT_MAXSIZE: "512"
+      MINIO_BUCKET_NAME: milvus
     volumes:
-      - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/milvus:/var/lib/milvus
+      - milvus-data:/var/lib/milvus
+    ports:
+      - "19530:19530"
+      - "9091:9091"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9091/healthz"]
       interval: 30s
       start_period: 90s
       timeout: 20s
       retries: 3
-    ports:
-      - "19530:19530"
-      - "9091:9091"
     depends_on:
-      - "etcd"
-      - "minio"
+      - etcd
+      - minio
+      - minio-init
+
+volumes:
+  etcd-data:
+  minio-data:
+  milvus-data:
 
 networks:
   default:
     name: milvus
+

--- a/deployments/docker/standalone/docker-compose.yml
+++ b/deployments/docker/standalone/docker-compose.yml
@@ -18,7 +18,7 @@ services:
 
   minio:
     container_name: milvus-minio
-    image: minio/minio:RELEASE.2023-03-20T20-16-18Z
+    image: minio/minio:RELEASE.2025-04-08T15-41-24Z
     environment:
       MINIO_ROOT_USER: minioadmin
       MINIO_ROOT_PASSWORD: minioadmin
@@ -60,11 +60,6 @@ services:
       MINIO_ADDRESS: minio:9000
       MINIO_ACCESS_KEY: minioadmin
       MINIO_SECRET_KEY: minioadmin
-      COMMON_STORAGETYPE: remote
-      DATA_FLUSH_TIMEOUT: 30s
-      DATACOORD_ENABLECOMPACTION: "false"
-      DATACOORD_ENABLEGARBAGECOLLECTION: "false"
-      DATACOORD_SEGMENT_MAXSIZE: "512"
       MINIO_BUCKET_NAME: milvus
     volumes:
       - milvus-data:/var/lib/milvus


### PR DESCRIPTION
This is several improvements made to the standalone docker compose script and to address issue #41231 

Specifically I:

1. Removed `version` as it is now deprecated in docker compose v2 
2. Added a minio-init service to properly initialize the MinIO bucket.
3. Added stability-improving environment variables to the Milvus-standalone container.
4. Updated the dependency chain to ensure proper initialization sequence.
5. Updated environment variable names (e.g., MINIO_ROOT_USER instead of MINIO_ACCESS_KEY) to align with current best practices for MinIO.
6. I also moved the volumes into docker to avoid potential permissions issues.

