### PR TITLE
fix:[2.5]Add debug memory freeing in sortStats

### DIFF
--- a/internal/indexnode/task_stats.go
+++ b/internal/indexnode/task_stats.go
@@ -307,9 +307,6 @@ func (st *statsTask) sortSegment(ctx context.Context) ([]*datapb.FieldBinlog, er
 		st.req.GetTargetSegmentID(),
 		st.req.GetInsertChannel(),
 		writer.GetRowNum(), insertLogs, statsLogs, bm25StatsLogs)
-	writer = nil
-	values = nil
-	debug.FreeOSMemory()
 
 	log.Ctx(ctx).Info("sort segment end",
 		zap.String("clusterID", st.req.GetClusterID()),
@@ -326,6 +323,10 @@ func (st *statsTask) sortSegment(ctx context.Context) ([]*datapb.FieldBinlog, er
 		zap.Duration("sort elapse", sortTimeCost),
 		zap.Duration("serWrite elapse", serWriteTimeCost),
 		zap.Duration("total elapse", totalElapse))
+
+	writer = nil
+	values = nil
+	debug.FreeOSMemory()
 	return insertLogs, nil
 }
 

--- a/internal/indexnode/task_stats.go
+++ b/internal/indexnode/task_stats.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	sio "io"
+	"runtime/debug"
 	"sort"
 	"strconv"
 	"time"
@@ -306,6 +307,7 @@ func (st *statsTask) sortSegment(ctx context.Context) ([]*datapb.FieldBinlog, er
 		st.req.GetTargetSegmentID(),
 		st.req.GetInsertChannel(),
 		writer.GetRowNum(), insertLogs, statsLogs, bm25StatsLogs)
+	debug.FreeOSMemory()
 
 	log.Ctx(ctx).Info("sort segment end",
 		zap.String("clusterID", st.req.GetClusterID()),
@@ -785,6 +787,7 @@ func (st *statsTask) createJSONKeyIndex(ctx context.Context,
 		log.Info("create json key index failed dataformat invalid")
 		return nil
 	}
+
 	fieldBinlogs := lo.GroupBy(insertBinlogs, func(binlog *datapb.FieldBinlog) int64 {
 		return binlog.GetFieldID()
 	})

--- a/internal/indexnode/task_stats.go
+++ b/internal/indexnode/task_stats.go
@@ -307,6 +307,8 @@ func (st *statsTask) sortSegment(ctx context.Context) ([]*datapb.FieldBinlog, er
 		st.req.GetTargetSegmentID(),
 		st.req.GetInsertChannel(),
 		writer.GetRowNum(), insertLogs, statsLogs, bm25StatsLogs)
+	writer = nil
+	values = nil
 	debug.FreeOSMemory()
 
 	log.Ctx(ctx).Info("sort segment end",


### PR DESCRIPTION
Add debug memory freeing in createJSONKeyIndex function
issue: https://github.com/milvus-io/milvus/issues/41218
pr:https://github.com/milvus-io/milvus/pull/41284