### PR TITLE
fix: skip dim check for non-vector fields in PreCheck (#41287)

### DIFF
--- a/internal/datacoord/task_index.go
+++ b/internal/datacoord/task_index.go
@@ -209,7 +209,7 @@ func (it *indexBuildTask) PreCheck(ctx context.Context, dependency *taskSchedule
 
 	// Extract dim only for vector types to avoid unnecessary warnings
 	dim := -1
-	if typeutil.IsVectorType(field.GetDataType()) {
+	if typeutil.IsFixDimVectorType(field.GetDataType()) {
 		if dimVal, err := storage.GetDimFromParams(field.GetTypeParams()); err != nil {
 			log.Ctx(ctx).Warn("failed to get dim from field type params",
 				zap.String("field type", field.GetDataType().String()), zap.Error(err))

--- a/internal/datacoord/task_index.go
+++ b/internal/datacoord/task_index.go
@@ -213,7 +213,6 @@ func (it *indexBuildTask) PreCheck(ctx context.Context, dependency *taskSchedule
 		if dimVal, err := storage.GetDimFromParams(field.GetTypeParams()); err != nil {
 			log.Ctx(ctx).Warn("failed to get dim from field type params",
 				zap.String("field type", field.GetDataType().String()), zap.Error(err))
-			// don't return, maybe field is scalar field or sparseFloatVector
 		} else {
 			dim = dimVal
 		}

--- a/internal/datacoord/task_index.go
+++ b/internal/datacoord/task_index.go
@@ -208,7 +208,7 @@ func (it *indexBuildTask) PreCheck(ctx context.Context, dependency *taskSchedule
 	}
 
 	// Extract dim only for vector types to avoid unnecessary warnings
-	var dim int
+	dim := -1
 	if typeutil.IsVectorType(field.GetDataType()) {
 		if dimVal, err := storage.GetDimFromParams(field.GetTypeParams()); err != nil {
 			log.Ctx(ctx).Warn("failed to get dim from field type params",


### PR DESCRIPTION
## What this PR does

This PR fixes an issue where the `PreCheck` function in DataCoord logs unnecessary warnings 
when attempting to retrieve 'dim' from non-vector fields.

The change adds a check to only call `GetDimFromParams` when the field type is a vector type.

## Related issue

Fixes #41287