### PR TITLE
feat: Ignore reporting index metrics for non-existent indexes

### DIFF
--- a/internal/datacoord/metrics_info.go
+++ b/internal/datacoord/metrics_info.go
@@ -70,6 +70,13 @@ func (s *Server) getCollectionMetrics(ctx context.Context) *metricsinfo.DataCoor
 			IndexName:    "",
 			Timestamp:    0,
 		})
+		if err == merr.ErrIndexNotFound {
+			log.Ctx(ctx).Debug("index not found, ignore to report index metrics",
+				zap.Int64("collection", collectionID),
+				zap.Error(err),
+			)
+			continue
+		}
 		if err := merr.CheckRPCCall(indexInfo, err); err != nil {
 			log.Ctx(ctx).Warn("failed to describe index, ignore to report index metrics",
 				zap.Int64("collection", collectionID),


### PR DESCRIPTION
feat: Ignore reporting index metrics for non-existent indexes

Remove the reporting of index metrics for non-existent indexes in the `getCollectionMetrics` function. This change improves the code by skipping unnecessary operations and reduces log noise.
issue: https://github.com/milvus-io/milvus/issues/41280