### PR TITLE
fix: update MixCoord registration in MilvusRoles

### DIFF
--- a/cmd/roles/roles.go
+++ b/cmd/roles/roles.go
@@ -183,7 +183,7 @@ func (mr *MilvusRoles) runProxy(ctx context.Context, localMsg bool, wg *sync.Wai
 
 func (mr *MilvusRoles) runMixCoord(ctx context.Context, localMsg bool, wg *sync.WaitGroup) component {
 	wg.Add(1)
-	return runComponent(ctx, localMsg, wg, components.NewMixCoord, metrics.RegisterRootCoord)
+	return runComponent(ctx, localMsg, wg, components.NewMixCoord, metrics.RegisterMixCoord)
 }
 
 func (mr *MilvusRoles) runQueryNode(ctx context.Context, localMsg bool, wg *sync.WaitGroup) component {

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -113,7 +113,7 @@ func runMixCoord(ctx context.Context, localMsg bool) *grpcmixcoord.Server {
 	}()
 	wg.Wait()
 
-	metrics.RegisterRootCoord(Registry)
+	metrics.RegisterMixCoord(Registry)
 	return rc
 }
 

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -28,12 +28,10 @@ func TestRegisterMetrics(t *testing.T) {
 	assert.NotPanics(t, func() {
 		r := prometheus.NewRegistry()
 		// Make sure it doesn't panic.
-		RegisterRootCoord(r)
+		RegisterMixCoord(r)
 		RegisterDataNode(r)
-		RegisterDataCoord(r)
 		RegisterProxy(r)
 		RegisterQueryNode(r)
-		RegisterQueryCoord(r)
 		RegisterMetaMetrics(r)
 		RegisterStorageMetrics(r)
 		RegisterMsgStreamMetrics(r)

--- a/pkg/metrics/rootcoord_metrics.go
+++ b/pkg/metrics/rootcoord_metrics.go
@@ -246,7 +246,7 @@ var (
 )
 
 // RegisterRootCoord registers RootCoord metrics
-func RegisterRootCoord(registry *prometheus.Registry) {
+func RegisterMixCoord(registry *prometheus.Registry) {
 	registry.Register(RootCoordProxyCounter)
 
 	// for time tick
@@ -286,6 +286,8 @@ func RegisterRootCoord(registry *prometheus.Registry) {
 	registry.MustRegister(DiskQuota)
 
 	RegisterStreamingServiceClient(registry)
+	RegisterQueryCoord(registry)
+	RegisterDataCoord(registry)
 }
 
 func CleanupRootCoordDBMetrics(dbName string) {


### PR DESCRIPTION
enhance: update MixCoord registration in MilvusRoles

The `runMixCoord` function in `MilvusRoles` was updated to use the `RegisterMixCoord` function from the `rootcoord_metrics` package instead of `RegisterRootCoord`. This change aligns with the recent modifications made to the `rootcoord_metrics` package.
issue:https://github.com/milvus-io/milvus/issues/41338
