### PR TITLE
fix: prevent crash when ARRAY_CONTAINS_ALL is used with empty array

### DIFF
--- a/internal/core/src/exec/expression/JsonContainsExpr.cpp
+++ b/internal/core/src/exec/expression/JsonContainsExpr.cpp
@@ -52,6 +52,10 @@ PhyJsonContainsFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
 
 VectorPtr
 PhyJsonContainsFilterExpr::EvalJsonContainsForDataSegment(EvalCtx& context) {
+    if (expr_->vals_.empty() || expr_->vals_[0].val_case() == proto::plan::GenericValue::VAL_NOT_SET) {
+        PanicInfo(DataTypeInvalid, "JsonContains expression has no valid value set");
+    }
+
     auto data_type = expr_->column_.data_type_;
     switch (expr_->op_) {
         case proto::plan::JSONContainsExpr_JSONOp_Contains:

--- a/internal/core/src/exec/expression/JsonContainsExpr.cpp
+++ b/internal/core/src/exec/expression/JsonContainsExpr.cpp
@@ -53,7 +53,7 @@ PhyJsonContainsFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
 VectorPtr
 PhyJsonContainsFilterExpr::EvalJsonContainsForDataSegment(EvalCtx& context) {
     if (expr_->vals_.empty() || expr_->vals_[0].val_case() == proto::plan::GenericValue::VAL_NOT_SET) {
-        PanicInfo(DataTypeInvalid, "JsonContains expression has no valid value set");
+        throw milvus::SegcoreError(DataTypeInvalid, "Empty values are not allowed in JsonContains expression.");
     }
 
     auto data_type = expr_->column_.data_type_;

--- a/internal/core/unittest/test_array_expr.cpp
+++ b/internal/core/unittest/test_array_expr.cpp
@@ -1458,17 +1458,17 @@ TEST(Expr, TestArrayContainsEmptyValuesPanic) {
     std::vector<proto::plan::GenericValue> empty_values;
 
     for (auto field_id : fields) {
+        auto expr = std::make_shared<milvus::expr::JsonContainsExpr>(
+            expr::ColumnInfo(field_id, DataType::ARRAY),
+            proto::plan::JSONContainsExpr_JSONOp_Contains,
+            true,
+            empty_values);
+
+        auto dummy_seg = CreateGrowingSegment(schema, empty_index_meta);
+        auto seg_promote = dynamic_cast<SegmentGrowingImpl*>(dummy_seg.get());
+        auto plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, expr);
         EXPECT_THROW(
             {
-                auto expr = std::make_shared<milvus::expr::JsonContainsExpr>(
-                    expr::ColumnInfo(field_id, DataType::ARRAY),
-                    proto::plan::JSONContainsExpr_JSONOp_Contains,
-                    true,
-                    empty_values);
-
-                auto dummy_seg = CreateGrowingSegment(schema, empty_index_meta);
-                auto seg_promote = dynamic_cast<SegmentGrowingImpl*>(dummy_seg.get());
-                auto plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, expr);
                 ExecuteQueryExpr(plan, seg_promote, 0, MAX_TIMESTAMP);
             },
             milvus::SegcoreError


### PR DESCRIPTION
### What this PR does
- Fixes a crash that occurs when using like ARRAY_CONTAINS_ALL... with an empty array in a filter expression.

### How it works
This PR adds a guard clause in PhyJsonContainsFilterExpr::EvalJsonContainsForDataSegment() that:
- Checks whether expr_->vals_ is empty
- Checks whether val_case() is set on the first value

If not, it raises a PanicInfo(DataTypeInvalid) with a clear error message.

related issue : #41348