### PR TITLE
feat: Export milvusclient.annRequest (issue: #41261)

### DIFF
--- a/client/milvusclient/read_options.go
+++ b/client/milvusclient/read_options.go
@@ -55,7 +55,7 @@ type SearchOption interface {
 var _ SearchOption = (*searchOption)(nil)
 
 type searchOption struct {
-	annRequest                 *annRequest
+	annRequest                 *AnnRequest
 	collectionName             string
 	partitionNames             []string
 	outputFields               []string
@@ -63,7 +63,7 @@ type searchOption struct {
 	useDefaultConsistencyLevel bool
 }
 
-type annRequest struct {
+type AnnRequest struct {
 	vectors []entity.Vector
 
 	annField        string
@@ -80,8 +80,8 @@ type annRequest struct {
 	templateParams  map[string]any
 }
 
-func NewAnnRequest(annField string, limit int, vectors ...entity.Vector) *annRequest {
-	return &annRequest{
+func NewAnnRequest(annField string, limit int, vectors ...entity.Vector) *AnnRequest {
+	return &AnnRequest{
 		annField:       annField,
 		vectors:        vectors,
 		topK:           limit,
@@ -90,7 +90,7 @@ func NewAnnRequest(annField string, limit int, vectors ...entity.Vector) *annReq
 	}
 }
 
-func (r *annRequest) searchRequest() (*milvuspb.SearchRequest, error) {
+func (r *AnnRequest) searchRequest() (*milvuspb.SearchRequest, error) {
 	request := &milvuspb.SearchRequest{
 		Nq:      int64(len(r.vectors)),
 		Dsl:     r.expr,
@@ -226,52 +226,52 @@ func slice2TmplValue(val any) (*schemapb.TemplateValue, error) {
 	}, nil
 }
 
-func (r *annRequest) WithANNSField(annsField string) *annRequest {
+func (r *AnnRequest) WithANNSField(annsField string) *AnnRequest {
 	r.annField = annsField
 	return r
 }
 
-func (r *annRequest) WithGroupByField(groupByField string) *annRequest {
+func (r *AnnRequest) WithGroupByField(groupByField string) *AnnRequest {
 	r.groupByField = groupByField
 	return r
 }
 
-func (r *annRequest) WithGroupSize(groupSize int) *annRequest {
+func (r *AnnRequest) WithGroupSize(groupSize int) *AnnRequest {
 	r.groupSize = groupSize
 	return r
 }
 
-func (r *annRequest) WithStrictGroupSize(strictGroupSize bool) *annRequest {
+func (r *AnnRequest) WithStrictGroupSize(strictGroupSize bool) *AnnRequest {
 	r.strictGroupSize = strictGroupSize
 	return r
 }
 
-func (r *annRequest) WithSearchParam(key, value string) *annRequest {
+func (r *AnnRequest) WithSearchParam(key, value string) *AnnRequest {
 	r.searchParam[key] = value
 	return r
 }
 
-func (r *annRequest) WithAnnParam(ap index.AnnParam) *annRequest {
+func (r *AnnRequest) WithAnnParam(ap index.AnnParam) *AnnRequest {
 	r.annParam = ap
 	return r
 }
 
-func (r *annRequest) WithFilter(expr string) *annRequest {
+func (r *AnnRequest) WithFilter(expr string) *AnnRequest {
 	r.expr = expr
 	return r
 }
 
-func (r *annRequest) WithTemplateParam(key string, val any) *annRequest {
+func (r *AnnRequest) WithTemplateParam(key string, val any) *AnnRequest {
 	r.templateParams[key] = val
 	return r
 }
 
-func (r *annRequest) WithOffset(offset int) *annRequest {
+func (r *AnnRequest) WithOffset(offset int) *AnnRequest {
 	r.offset = offset
 	return r
 }
 
-func (r *annRequest) WithIgnoreGrowing(ignoreGrowing bool) *annRequest {
+func (r *AnnRequest) WithIgnoreGrowing(ignoreGrowing bool) *AnnRequest {
 	r.ignoreGrowing = ignoreGrowing
 	return r
 }
@@ -423,7 +423,7 @@ type hybridSearchOption struct {
 	collectionName string
 	partitionNames []string
 
-	reqs []*annRequest
+	reqs []*AnnRequest
 
 	outputFields          []string
 	useDefaultConsistency bool
@@ -490,7 +490,7 @@ func (opt *hybridSearchOption) HybridRequest() (*milvuspb.HybridSearchRequest, e
 	}, nil
 }
 
-func NewHybridSearchOption(collectionName string, limit int, annRequests ...*annRequest) *hybridSearchOption {
+func NewHybridSearchOption(collectionName string, limit int, annRequests ...*AnnRequest) *hybridSearchOption {
 	return &hybridSearchOption{
 		collectionName: collectionName,
 


### PR DESCRIPTION
Issue: #41261

`milvusclient.NewHybridSearchOption` receives a variadic `annRequests` parameter. However, since `milvusclient.annRequest` is private, there is no way to declare a slice, therefore there is no way to make it fully generic (as in, create a slice of `milvusclient.annRequest`s and pass them to `NewHybridSearchOption`. This PR renames `milvusclient.annRequest` to `milvusclient.AnnRequest` to export it.

This is an API change since it's renaming a struct. However, since the struct was previously private no external code depends on it, unless it's doing nasty things with reflection (in which case it should not depend on the name).

Signed-off-by: Mario Camou <mcamou@users.noreply.github.com>