### PR TITLE
fix: [2.5]support infix and suffix match types in JsonStats

### DIFF
--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -1402,6 +1402,8 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJsonForIndex() {
                                 }
                             }
                         }
+                    case proto::plan::InnerMatch:
+                    case proto::plan::PostfixMatch:
                     case proto::plan::PrefixMatch:
                         if constexpr (std::is_same_v<GetType,
                                                      proto::plan::Array>) {


### PR DESCRIPTION
fix: [2.5]support infix and suffix match types in JsonStats
issue:https://github.com/milvus-io/milvus/issues/41386
pr:https://github.com/milvus-io/milvus/pull/38039