### PR TITLE
fix: use global logger for threadWatcher

### DIFF
--- a/internal/util/metrics/thread.go
+++ b/internal/util/metrics/thread.go
@@ -17,7 +17,6 @@
 package metrics
 
 import (
-	"context"
 	"os"
 	"sync"
 	"time"
@@ -56,7 +55,6 @@ func (thw *threadWatcher) Start() {
 }
 
 func (thw *threadWatcher) watchThreadNum() {
-	log := log.Ctx(context.TODO())
 	ticker := time.NewTicker(time.Second * 30)
 	defer ticker.Stop()
 	pid := os.Getpid()


### PR DESCRIPTION
Currently, `thread watcher observe thread num` log

https://github.com/milvus-io/milvus/blob/c43f8f79442fd7b0963ddaab19c6620a6011fc3b/internal/util/metrics/thread.go#L76

is not affected by log level config. 

I believe this is because of the initialization order.

1. Threadwatcher initialized and started to run first -> https://github.com/milvus-io/milvus/blob/c43f8f79442fd7b0963ddaab19c6620a6011fc3b/cmd/roles/roles.go#L313-L316
3. and then, logger is initialized after Threadwatcher starts to run -> https://github.com/milvus-io/milvus/blob/c43f8f79442fd7b0963ddaab19c6620a6011fc3b/cmd/roles/roles.go#L385

In my case, `thread watcher observe thread num` log (it's debug level) is written even if I set my log level to `WARN`. It's kinda annoying for who operates Milvus.

![스크린샷 2025-04-18 오후 2 07 55](https://github.com/user-attachments/assets/cd04950b-9d13-4cd4-a064-1a36ad6371c7)

Thus, I would like to suggest to use the global logger for Threadwatcher instead of a local one, to be affected by the config.
