### PR TITLE
feat: Add support for modifying max capacity of array fields

### DIFF
--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -1332,16 +1332,15 @@ func (t *alterCollectionFieldTask) PreExecute(ctx context.Context) error {
 		case common.MaxLengthKey:
 			IsStringType := false
 			fieldName := ""
-			var dataType int32
 			for _, field := range collSchema.Fields {
 				if field.GetName() == t.FieldName && (typeutil.IsStringType(field.DataType) || typeutil.IsArrayContainStringElementType(field.DataType, field.ElementType)) {
 					IsStringType = true
 					fieldName = field.GetName()
-					dataType = int32(field.DataType)
+					break
 				}
 			}
 			if !IsStringType {
-				return merr.WrapErrParameterInvalidMsg(fieldName, "%s can not modify the maxlength for non-string types", schemapb.DataType_name[dataType])
+				return merr.WrapErrParameterInvalidMsg("%s can not modify the maxlength for non-string types", fieldName)
 			}
 			value, err := strconv.Atoi(prop.Value)
 			if err != nil {
@@ -1359,6 +1358,7 @@ func (t *alterCollectionFieldTask) PreExecute(ctx context.Context) error {
 				if field.GetName() == t.FieldName && typeutil.IsArrayType(field.DataType) {
 					IsArrayType = true
 					fieldName = field.GetName()
+					break
 				}
 			}
 			if !IsArrayType {

--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -1341,11 +1341,11 @@ func (t *alterCollectionFieldTask) PreExecute(ctx context.Context) error {
 				}
 			}
 			if !IsStringType {
-				return merr.WrapErrParameterInvalid(fieldName, "%s can not modify the maxlength for non-string types", schemapb.DataType_name[dataType])
+				return merr.WrapErrParameterInvalidMsg(fieldName, "%s can not modify the maxlength for non-string types", schemapb.DataType_name[dataType])
 			}
 			value, err := strconv.Atoi(prop.Value)
 			if err != nil {
-				return merr.WrapErrParameterInvalid("%s should be an integer, but got %T", prop.Key, prop.Value)
+				return merr.WrapErrParameterInvalidMsg("%s should be an integer, but got %T", prop.Key, prop.Value)
 			}
 
 			defaultMaxVarCharLength := Params.ProxyCfg.MaxVarCharLength.GetAsInt64()
@@ -1362,12 +1362,12 @@ func (t *alterCollectionFieldTask) PreExecute(ctx context.Context) error {
 				}
 			}
 			if !IsArrayType {
-				return merr.WrapErrParameterInvalid("%s can not modify the maxcapacity for non-array types", fieldName)
+				return merr.WrapErrParameterInvalidMsg("%s can not modify the maxcapacity for non-array types", fieldName)
 			}
 
 			maxCapacityPerRow, err := strconv.ParseInt(prop.Value, 10, 64)
 			if err != nil {
-				return merr.WrapErrParameterInvalid("the value for %s of field %s must be an integer", common.MaxCapacityKey, fieldName)
+				return merr.WrapErrParameterInvalidMsg("the value for %s of field %s must be an integer", common.MaxCapacityKey, fieldName)
 			}
 			if maxCapacityPerRow > defaultMaxArrayCapacity || maxCapacityPerRow <= 0 {
 				return merr.WrapErrParameterInvalidMsg("the maximum capacity specified for a Array should be in (0, %d]", defaultMaxArrayCapacity)

--- a/internal/proxy/task_test.go
+++ b/internal/proxy/task_test.go
@@ -4663,7 +4663,7 @@ func TestAlterCollectionFieldCheckLoaded(t *testing.T) {
 	assert.Equal(t, merr.Code(merr.ErrCollectionLoaded), merr.Code(err))
 }
 
-func TestAlterCollectionField1(t *testing.T) {
+func TestAlterCollectionField(t *testing.T) {
 	qc := NewMixCoordMock()
 	InitMetaCache(context.Background(), qc, nil)
 	collectionName := "test_alter_collection_field"
@@ -4785,6 +4785,15 @@ func TestAlterCollectionField1(t *testing.T) {
 			fieldName: "array_field",
 			properties: []*commonpb.KeyValuePair{
 				{Key: common.MaxCapacityKey, Value: "0"},
+			},
+			expectError: true,
+			errCode:     merr.Code(merr.ErrParameterInvalid),
+		},
+		{
+			name:      "max_capacity invalid type",
+			fieldName: "string_field",
+			properties: []*commonpb.KeyValuePair{
+				{Key: common.MaxCapacityKey, Value: "3"},
 			},
 			expectError: true,
 			errCode:     merr.Code(merr.ErrParameterInvalid),

--- a/tests/python_client/milvus_client/test_milvus_client_alter.py
+++ b/tests/python_client/milvus_client/test_milvus_client_alter.py
@@ -232,10 +232,9 @@ class TestMilvusClientAlterCollectionField(TestMilvusClientV2Base):
         self.alter_collection_field(client, collection_name, field_name=vector_field_name,
                                     field_params={"max_length": new_max_length},
                                     check_task=CheckTasks.err_res, check_items=error)
-        error = {ct.err_code: 999, ct.err_msg: "max_capacity does not allow update in collection field param"}
-        self.alter_collection_field(client, collection_name, field_name=array_field_name,
-                                    field_params={"max_capacity": 20},
-                                    check_task=CheckTasks.err_res, check_items=error)
+        # self.alter_collection_field(client, collection_name, field_name=array_field_name,
+        #                             field_params={"max_capacity": 20},
+        #                             check_task=CheckTasks.err_res, check_items=error)
         error = {ct.err_code: 999, ct.err_msg: "element_type does not allow update in collection field param"}
         self.alter_collection_field(client, collection_name, field_name=array_field_name,
                                     field_params={"element_type": DataType.INT64},

--- a/tests/python_client/milvus_client/test_milvus_client_alter.py
+++ b/tests/python_client/milvus_client/test_milvus_client_alter.py
@@ -242,7 +242,7 @@ class TestMilvusClientAlterCollectionField(TestMilvusClientV2Base):
                                  check_items={str_field_name: {"max_length": new_max_length, "mmap_enabled": False},
                                               vector_field_name: {"mmap_enabled": False},
                                               json_field_name: {"mmap_enabled": True},
-                                              array_field_name: {"max_length": new_max_length, "max_capacity": 10}})
+                                              array_field_name: {"max_length": new_max_length, "max_capacity": 20}})
 
         # verify that cannot insert data with the old max_length
         for alter_field in [pk_field_name, str_field_name, array_field_name]:

--- a/tests/python_client/milvus_client/test_milvus_client_alter.py
+++ b/tests/python_client/milvus_client/test_milvus_client_alter.py
@@ -228,13 +228,12 @@ class TestMilvusClientAlterCollectionField(TestMilvusClientV2Base):
                                     field_params={"mmap.enabled": False})
         self.alter_collection_field(client, collection_name, field_name=array_field_name,
                                     field_params={"max_length": new_max_length})
+        self.alter_collection_field(client, collection_name, field_name=array_field_name,
+                                    field_params={"max_capacity": 20})
         error = {ct.err_code: 999, ct.err_msg: f"can not modify the maxlength for non-string types"}
         self.alter_collection_field(client, collection_name, field_name=vector_field_name,
                                     field_params={"max_length": new_max_length},
                                     check_task=CheckTasks.err_res, check_items=error)
-        # self.alter_collection_field(client, collection_name, field_name=array_field_name,
-        #                             field_params={"max_capacity": 20},
-        #                             check_task=CheckTasks.err_res, check_items=error)
         error = {ct.err_code: 999, ct.err_msg: "element_type does not allow update in collection field param"}
         self.alter_collection_field(client, collection_name, field_name=array_field_name,
                                     field_params={"element_type": DataType.INT64},


### PR DESCRIPTION
feat: Add support for modifying max capacity of array fields

This commit adds support for modifying the max capacity of array fields in the `alterCollectionFieldTask` function. It checks if the field is an array type and then validates and updates the max capacity value. This change improves the flexibility of array fields in the collection.

Issue: https://github.com/milvus-io/milvus/issues/41363