### PR TITLE
feat: [2.5]Add support for modifying max capacity of array fields

### DIFF
--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -1249,20 +1249,19 @@ func (t *alterCollectionFieldTask) PreExecute(ctx context.Context) error {
 		case common.MaxLengthKey:
 			IsStringType := false
 			fieldName := ""
-			var dataType int32
 			for _, field := range collSchema.Fields {
 				if field.GetName() == t.FieldName && (typeutil.IsStringType(field.DataType) || typeutil.IsArrayContainStringElementType(field.DataType, field.ElementType)) {
 					IsStringType = true
 					fieldName = field.GetName()
-					dataType = int32(field.DataType)
+					break
 				}
 			}
 			if !IsStringType {
-				return merr.WrapErrParameterInvalid(fieldName, "%s can not modify the maxlength for non-string types", schemapb.DataType_name[dataType])
+				return merr.WrapErrParameterInvalidMsg("%s can not modify the maxlength for non-string types", fieldName)
 			}
 			value, err := strconv.Atoi(prop.Value)
 			if err != nil {
-				return merr.WrapErrParameterInvalid("%s should be an integer, but got %T", prop.Key, prop.Value)
+				return merr.WrapErrParameterInvalidMsg("the value for %s of field %s must be an integer", common.MaxLengthKey, fieldName)
 			}
 
 			defaultMaxVarCharLength := Params.ProxyCfg.MaxVarCharLength.GetAsInt64()
@@ -1276,15 +1275,16 @@ func (t *alterCollectionFieldTask) PreExecute(ctx context.Context) error {
 				if field.GetName() == t.FieldName && typeutil.IsArrayType(field.DataType) {
 					IsArrayType = true
 					fieldName = field.GetName()
+					break
 				}
 			}
 			if !IsArrayType {
-				return merr.WrapErrParameterInvalid("%s can not modify the maxcapacity for non-array types", fieldName)
+				return merr.WrapErrParameterInvalidMsg("%s can not modify the maxcapacity for non-array types", fieldName)
 			}
 
 			maxCapacityPerRow, err := strconv.ParseInt(prop.Value, 10, 64)
 			if err != nil {
-				return merr.WrapErrParameterInvalid("the value for %s of field %s must be an integer", common.MaxCapacityKey, fieldName)
+				return merr.WrapErrParameterInvalidMsg("the value for %s of field %s must be an integer", common.MaxCapacityKey, fieldName)
 			}
 			if maxCapacityPerRow > defaultMaxArrayCapacity || maxCapacityPerRow <= 0 {
 				return merr.WrapErrParameterInvalidMsg("the maximum capacity specified for a Array should be in (0, %d]", defaultMaxArrayCapacity)

--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -1186,6 +1186,7 @@ const (
 var allowedProps = []string{
 	common.MaxLengthKey,
 	common.MmapEnabledKey,
+	common.MaxCapacityKey,
 }
 
 func IsKeyAllowed(key string) bool {
@@ -1267,6 +1268,26 @@ func (t *alterCollectionFieldTask) PreExecute(ctx context.Context) error {
 			defaultMaxVarCharLength := Params.ProxyCfg.MaxVarCharLength.GetAsInt64()
 			if int64(value) > defaultMaxVarCharLength {
 				return merr.WrapErrParameterInvalidMsg("%s exceeds the maximum allowed value %s", prop.Value, strconv.FormatInt(defaultMaxVarCharLength, 10))
+			}
+		case common.MaxCapacityKey:
+			IsArrayType := false
+			fieldName := ""
+			for _, field := range collSchema.Fields {
+				if field.GetName() == t.FieldName && typeutil.IsArrayType(field.DataType) {
+					IsArrayType = true
+					fieldName = field.GetName()
+				}
+			}
+			if !IsArrayType {
+				return merr.WrapErrParameterInvalid("%s can not modify the maxcapacity for non-array types", fieldName)
+			}
+
+			maxCapacityPerRow, err := strconv.ParseInt(prop.Value, 10, 64)
+			if err != nil {
+				return merr.WrapErrParameterInvalid("the value for %s of field %s must be an integer", common.MaxCapacityKey, fieldName)
+			}
+			if maxCapacityPerRow > defaultMaxArrayCapacity || maxCapacityPerRow <= 0 {
+				return merr.WrapErrParameterInvalidMsg("the maximum capacity specified for a Array should be in (0, %d]", defaultMaxArrayCapacity)
 			}
 		}
 	}

--- a/internal/proxy/task_test.go
+++ b/internal/proxy/task_test.go
@@ -4418,3 +4418,197 @@ func TestInsertForReplicate(t *testing.T) {
 		assert.Error(t, err)
 	})
 }
+
+func TestAlterCollectionFieldCheckLoaded(t *testing.T) {
+	qc := NewMixCoordMock()
+	InitMetaCache(context.Background(), qc, nil)
+	collectionName := "test_alter_collection_field_check_loaded"
+	createColReq := &milvuspb.CreateCollectionRequest{
+		Base: &commonpb.MsgBase{
+			MsgType:   commonpb.MsgType_DropCollection,
+			MsgID:     100,
+			Timestamp: 100,
+		},
+		DbName:         dbName,
+		CollectionName: collectionName,
+		Schema:         nil,
+		ShardsNum:      1,
+	}
+	qc.CreateCollection(context.Background(), createColReq)
+	resp, err := qc.DescribeCollection(context.Background(), &milvuspb.DescribeCollectionRequest{CollectionName: collectionName})
+	assert.NoError(t, err)
+
+	qc.ShowLoadCollectionsFunc = func(ctx context.Context, req *querypb.ShowCollectionsRequest, opts ...grpc.CallOption) (*querypb.ShowCollectionsResponse, error) {
+		return &querypb.ShowCollectionsResponse{
+			Status: &commonpb.Status{
+				ErrorCode: commonpb.ErrorCode_Success,
+			},
+			CollectionIDs:       []int64{resp.CollectionID},
+			InMemoryPercentages: []int64{100},
+		}, nil
+	}
+
+	task := &alterCollectionFieldTask{
+		AlterCollectionFieldRequest: &milvuspb.AlterCollectionFieldRequest{
+			Base:           &commonpb.MsgBase{},
+			CollectionName: collectionName,
+			Properties:     []*commonpb.KeyValuePair{{Key: common.MmapEnabledKey, Value: "true"}},
+		},
+		mixCoord: qc,
+	}
+	err = task.PreExecute(context.Background())
+	assert.Equal(t, merr.Code(merr.ErrCollectionLoaded), merr.Code(err))
+}
+
+func TestAlterCollectionField1(t *testing.T) {
+	qc := NewMixCoordMock()
+	InitMetaCache(context.Background(), qc, nil)
+	collectionName := "test_alter_collection_field"
+
+	// Create collection with string and array fields
+	schema := &schemapb.CollectionSchema{
+		Name: collectionName,
+		Fields: []*schemapb.FieldSchema{
+			{
+				FieldID:    100,
+				Name:       "string_field",
+				DataType:   schemapb.DataType_VarChar,
+				TypeParams: []*commonpb.KeyValuePair{{Key: "max_length", Value: "100"}},
+			},
+			{
+				FieldID:     101,
+				Name:        "array_field",
+				DataType:    schemapb.DataType_Array,
+				ElementType: schemapb.DataType_Int64,
+				TypeParams:  []*commonpb.KeyValuePair{{Key: "max_capacity", Value: "100"}},
+			},
+		},
+	}
+	schemaBytes, err := proto.Marshal(schema)
+	assert.NoError(t, err)
+
+	createColReq := &milvuspb.CreateCollectionRequest{
+		Base: &commonpb.MsgBase{
+			MsgType:   commonpb.MsgType_CreateCollection,
+			MsgID:     100,
+			Timestamp: 100,
+		},
+		DbName:         dbName,
+		CollectionName: collectionName,
+		Schema:         schemaBytes,
+		ShardsNum:      1,
+	}
+	qc.CreateCollection(context.Background(), createColReq)
+
+	// Test cases
+	tests := []struct {
+		name        string
+		fieldName   string
+		properties  []*commonpb.KeyValuePair
+		expectError bool
+		errCode     int32
+	}{
+		{
+			name:      "update string field max_length",
+			fieldName: "string_field",
+			properties: []*commonpb.KeyValuePair{
+				{Key: common.MaxLengthKey, Value: "200"},
+			},
+			expectError: false,
+		},
+		{
+			name:      "update array field max_capacity",
+			fieldName: "array_field",
+			properties: []*commonpb.KeyValuePair{
+				{Key: common.MaxCapacityKey, Value: "200"},
+			},
+			expectError: false,
+		},
+		{
+			name:      "update mmap_enabled",
+			fieldName: "string_field",
+			properties: []*commonpb.KeyValuePair{
+				{Key: common.MmapEnabledKey, Value: "true"},
+			},
+			expectError: false,
+		},
+		{
+			name:      "invalid property key",
+			fieldName: "string_field",
+			properties: []*commonpb.KeyValuePair{
+				{Key: "invalid_key", Value: "value"},
+			},
+			expectError: true,
+			errCode:     merr.Code(merr.ErrParameterInvalid),
+		},
+		{
+			name:      "invalid max_length value type",
+			fieldName: "string_field",
+			properties: []*commonpb.KeyValuePair{
+				{Key: common.MaxLengthKey, Value: "not_a_number"},
+			},
+			expectError: true,
+			errCode:     merr.Code(merr.ErrParameterInvalid),
+		},
+		{
+			name:      "invalid max_capacity value type",
+			fieldName: "array_field",
+			properties: []*commonpb.KeyValuePair{
+				{Key: common.MaxCapacityKey, Value: "not_a_number"},
+			},
+			expectError: true,
+			errCode:     merr.Code(merr.ErrParameterInvalid),
+		},
+		{
+			name:      "max_length exceeds limit",
+			fieldName: "string_field",
+			properties: []*commonpb.KeyValuePair{
+				{Key: common.MaxLengthKey, Value: "65536"},
+			},
+			expectError: true,
+			errCode:     merr.Code(merr.ErrParameterInvalid),
+		},
+		{
+			name:      "max_capacity exceeds limit",
+			fieldName: "array_field",
+			properties: []*commonpb.KeyValuePair{
+				{Key: common.MaxCapacityKey, Value: "5000"},
+			},
+			expectError: true,
+			errCode:     merr.Code(merr.ErrParameterInvalid),
+		},
+		{
+			name:      "max_capacity invalid range",
+			fieldName: "array_field",
+			properties: []*commonpb.KeyValuePair{
+				{Key: common.MaxCapacityKey, Value: "0"},
+			},
+			expectError: true,
+			errCode:     merr.Code(merr.ErrParameterInvalid),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			task := &alterCollectionFieldTask{
+				AlterCollectionFieldRequest: &milvuspb.AlterCollectionFieldRequest{
+					Base:           &commonpb.MsgBase{},
+					CollectionName: collectionName,
+					FieldName:      test.fieldName,
+					Properties:     test.properties,
+				},
+				mixCoord: qc,
+			}
+
+			err := task.PreExecute(context.Background())
+			if test.expectError {
+				assert.Error(t, err)
+				if test.errCode != 0 {
+					assert.Equal(t, test.errCode, merr.Code(err))
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/proxy/task_test.go
+++ b/internal/proxy/task_test.go
@@ -4420,9 +4420,11 @@ func TestInsertForReplicate(t *testing.T) {
 }
 
 func TestAlterCollectionFieldCheckLoaded(t *testing.T) {
-	qc := NewMixCoordMock()
-	InitMetaCache(context.Background(), qc, nil)
-	collectionName := "test_alter_collection_field_check_loaded"
+	rc := NewRootCoordMock()
+	rc.state.Store(commonpb.StateCode_Healthy)
+	qc := &mocks.MockQueryCoordClient{}
+	InitMetaCache(context.Background(), rc, qc, nil)
+	collectionName := "test_alter_collection_check_loaded"
 	createColReq := &milvuspb.CreateCollectionRequest{
 		Base: &commonpb.MsgBase{
 			MsgType:   commonpb.MsgType_DropCollection,
@@ -4434,35 +4436,32 @@ func TestAlterCollectionFieldCheckLoaded(t *testing.T) {
 		Schema:         nil,
 		ShardsNum:      1,
 	}
-	qc.CreateCollection(context.Background(), createColReq)
-	resp, err := qc.DescribeCollection(context.Background(), &milvuspb.DescribeCollectionRequest{CollectionName: collectionName})
+	rc.CreateCollection(context.Background(), createColReq)
+	resp, err := rc.DescribeCollection(context.Background(), &milvuspb.DescribeCollectionRequest{CollectionName: collectionName})
 	assert.NoError(t, err)
 
-	qc.ShowLoadCollectionsFunc = func(ctx context.Context, req *querypb.ShowCollectionsRequest, opts ...grpc.CallOption) (*querypb.ShowCollectionsResponse, error) {
-		return &querypb.ShowCollectionsResponse{
-			Status: &commonpb.Status{
-				ErrorCode: commonpb.ErrorCode_Success,
-			},
-			CollectionIDs:       []int64{resp.CollectionID},
-			InMemoryPercentages: []int64{100},
-		}, nil
-	}
-
+	qc.EXPECT().ShowCollections(mock.Anything, mock.Anything).Return(&querypb.ShowCollectionsResponse{
+		Status:              &commonpb.Status{ErrorCode: commonpb.ErrorCode_Success},
+		CollectionIDs:       []int64{resp.CollectionID},
+		InMemoryPercentages: []int64{100},
+	}, nil)
 	task := &alterCollectionFieldTask{
 		AlterCollectionFieldRequest: &milvuspb.AlterCollectionFieldRequest{
 			Base:           &commonpb.MsgBase{},
 			CollectionName: collectionName,
 			Properties:     []*commonpb.KeyValuePair{{Key: common.MmapEnabledKey, Value: "true"}},
 		},
-		mixCoord: qc,
+		queryCoord: qc,
 	}
 	err = task.PreExecute(context.Background())
 	assert.Equal(t, merr.Code(merr.ErrCollectionLoaded), merr.Code(err))
 }
 
 func TestAlterCollectionField1(t *testing.T) {
-	qc := NewMixCoordMock()
-	InitMetaCache(context.Background(), qc, nil)
+	rc := NewRootCoordMock()
+	rc.state.Store(commonpb.StateCode_Healthy)
+	qc := &mocks.MockQueryCoordClient{}
+	InitMetaCache(context.Background(), rc, qc, nil)
 	collectionName := "test_alter_collection_field"
 
 	// Create collection with string and array fields
@@ -4498,8 +4497,14 @@ func TestAlterCollectionField1(t *testing.T) {
 		Schema:         schemaBytes,
 		ShardsNum:      1,
 	}
-	qc.CreateCollection(context.Background(), createColReq)
-
+	rc.CreateCollection(context.Background(), createColReq)
+	resp, err := rc.DescribeCollection(context.Background(), &milvuspb.DescribeCollectionRequest{CollectionName: collectionName})
+	assert.NoError(t, err)
+	qc.EXPECT().ShowCollections(mock.Anything, mock.Anything).Return(&querypb.ShowCollectionsResponse{
+		Status:              &commonpb.Status{ErrorCode: commonpb.ErrorCode_Success},
+		CollectionIDs:       []int64{resp.CollectionID},
+		InMemoryPercentages: []int64{100},
+	}, nil)
 	// Test cases
 	tests := []struct {
 		name        string
@@ -4521,14 +4526,6 @@ func TestAlterCollectionField1(t *testing.T) {
 			fieldName: "array_field",
 			properties: []*commonpb.KeyValuePair{
 				{Key: common.MaxCapacityKey, Value: "200"},
-			},
-			expectError: false,
-		},
-		{
-			name:      "update mmap_enabled",
-			fieldName: "string_field",
-			properties: []*commonpb.KeyValuePair{
-				{Key: common.MmapEnabledKey, Value: "true"},
 			},
 			expectError: false,
 		},
@@ -4586,6 +4583,15 @@ func TestAlterCollectionField1(t *testing.T) {
 			expectError: true,
 			errCode:     merr.Code(merr.ErrParameterInvalid),
 		},
+		{
+			name:      "max_capacity invalid type",
+			fieldName: "string_field",
+			properties: []*commonpb.KeyValuePair{
+				{Key: common.MaxCapacityKey, Value: "3"},
+			},
+			expectError: true,
+			errCode:     merr.Code(merr.ErrParameterInvalid),
+		},
 	}
 
 	for _, test := range tests {
@@ -4597,7 +4603,7 @@ func TestAlterCollectionField1(t *testing.T) {
 					FieldName:      test.fieldName,
 					Properties:     test.properties,
 				},
-				mixCoord: qc,
+				queryCoord: qc,
 			}
 
 			err := task.PreExecute(context.Background())


### PR DESCRIPTION
feat: Add support for modifying max capacity of array fields

This commit adds support for modifying the max capacity of array fields in the alterCollectionFieldTask function. It checks if the field is an array type and then validates and updates the max capacity value. This change improves the flexibility of array fields in the collection.

Issue: https://github.com/milvus-io/milvus/issues/41363
pr:https://github.com/milvus-io/milvus/pull/41404