### PR TITLE
enhance: [AddField] Use schema update ts as guarantee ts

### DIFF
--- a/internal/proxy/rootcoord_mock_test.go
+++ b/internal/proxy/rootcoord_mock_test.go
@@ -599,6 +599,7 @@ func (coord *MixCoordMock) DescribeCollection(ctx context.Context, req *milvuspb
 		CreatedTimestamp:     meta.createdUtcTimestamp,
 		CreatedUtcTimestamp:  meta.createdUtcTimestamp,
 		Properties:           meta.properties,
+		UpdateTimestamp:      meta.createdTimestamp,
 	}, nil
 }
 

--- a/internal/proxy/task_query.go
+++ b/internal/proxy/task_query.go
@@ -476,6 +476,14 @@ func (t *queryTask) PreExecute(ctx context.Context) error {
 			guaranteeTs = parseGuaranteeTsFromConsistency(guaranteeTs, t.BeginTs(), consistencyLevel)
 		}
 	}
+
+	// use collection schema updated timestamp if it's greater than calculate guarantee timestamp
+	// this make query view updated happens before new read request happens
+	// see also schema change design
+	if collectionInfo.updateTimestamp > guaranteeTs {
+		guaranteeTs = collectionInfo.updateTimestamp
+	}
+
 	t.GuaranteeTimestamp = guaranteeTs
 	// need modify mvccTs and guaranteeTs for iterator specially
 	if t.queryParams.isIterator && t.request.GetGuaranteeTimestamp() > 0 {

--- a/internal/proxy/task_search.go
+++ b/internal/proxy/task_search.go
@@ -249,6 +249,14 @@ func (t *searchTask) PreExecute(ctx context.Context) error {
 			guaranteeTs = parseGuaranteeTsFromConsistency(guaranteeTs, t.BeginTs(), consistencyLevel)
 		}
 	}
+
+	// use collection schema updated timestamp if it's greater than calculate guarantee timestamp
+	// this make query view updated happens before new read request happens
+	// see also schema change design
+	if collectionInfo.updateTimestamp > guaranteeTs {
+		guaranteeTs = collectionInfo.updateTimestamp
+	}
+
 	t.SearchRequest.GuaranteeTimestamp = guaranteeTs
 	t.SearchRequest.ConsistencyLevel = consistencyLevel
 	if t.isIterator && t.request.GetGuaranteeTimestamp() > 0 {


### PR DESCRIPTION
Related to #39718

Use schema update ts when it's greater than calculated guarantee timestamp to make sure that all read request using updated schema shall wait all schema change event processed.