### PR TITLE
fix: Allow to compile on windows

### DIFF
--- a/pkg/util/hardware/mem_info_windows.go
+++ b/pkg/util/hardware/mem_info_windows.go
@@ -12,42 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !darwin && !openbsd && !freebsd && !windows
-// +build !darwin,!openbsd,!freebsd,!windows
+//go:build windows
+// +build windows
 
 package hardware
 
 import (
-	"os"
-
-	"github.com/shirou/gopsutil/v3/process"
-	"github.com/sirupsen/logrus"
+	"github.com/shirou/gopsutil/v3/mem"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/pkg/v2/log"
 )
 
-var proc *process.Process
-
-func init() {
-	var err error
-	proc, err = process.NewProcess(int32(os.Getpid()))
-	if err != nil {
-		panic(err)
-	}
-
-	// avoid to output a lot of error logs from cgroups package
-	logrus.SetLevel(logrus.PanicLevel)
-}
-
 // GetUsedMemoryCount returns the memory usage in bytes.
 func GetUsedMemoryCount() uint64 {
-	memInfo, err := proc.MemoryInfoEx()
+	// not in container, calculate by `gopsutil`
+	stats, err := mem.VirtualMemory()
 	if err != nil {
-		log.Warn("failed to get memory info", zap.Error(err))
+		log.Warn("failed to get memory usage count",
+			zap.Error(err))
 		return 0
 	}
 
-	// sub the shared memory to filter out the file-backed map memory usage
-	return memInfo.RSS - memInfo.Shared
+	return stats.Used
 }


### PR DESCRIPTION
This PR fixes #41384 .

When using milvus client and compile on windows, the compilation failed with the undefined RSS error.

On windows, the way to get memory used is the same as on darwin.
