### PR TITLE
fix: mark CacheMemoryLimit as deprecated in configuration

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -453,7 +453,7 @@ queryNode:
   enableDisk: false # enable querynode load disk index, and search on disk index
   maxDiskUsagePercentage: 95
   cache:
-    memoryLimit: 2147483648 # 2 GB, 2 * 1024 *1024 *1024
+    memoryLimit: 2147483648 # Deprecated. 2 GB, 2 * 1024 *1024 *1024
     readAheadPolicy: willneed # The read ahead policy of chunk cache, options: `normal, random, sequential, willneed, dontneed`
     # options: async, sync, disable. 
     # Specifies the necessity for warming up the chunk cache. 

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -453,7 +453,7 @@ queryNode:
   enableDisk: false # enable querynode load disk index, and search on disk index
   maxDiskUsagePercentage: 95
   cache:
-    memoryLimit: 2147483648 # Deprecated. 2 GB, 2 * 1024 *1024 *1024
+    memoryLimit: 2147483648 # Deprecated: 2 GB, 2 * 1024 *1024 *1024
     readAheadPolicy: willneed # The read ahead policy of chunk cache, options: `normal, random, sequential, willneed, dontneed`
     # options: async, sync, disable. 
     # Specifies the necessity for warming up the chunk cache. 

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -2698,6 +2698,7 @@ type queryNodeConfig struct {
 	DiskCacheCapacityLimit ParamItem `refreshable:"true"`
 
 	// cache limit
+	// Deprecated: Never used
 	CacheMemoryLimit ParamItem `refreshable:"false"`
 	MmapDirPath      ParamItem `refreshable:"false"`
 	// Deprecated: Since 2.4.7, use `MmapVectorField`/`MmapVectorIndex`/`MmapScalarField`/`MmapScalarIndex` instead
@@ -2956,7 +2957,7 @@ This defaults to true, indicating that Milvus creates temporary index for growin
 		Version:      "2.0.0",
 		DefaultValue: "2147483648",
 		PanicIfEmpty: true,
-		Doc:          "2 GB, 2 * 1024 *1024 *1024",
+		Doc:          "Deprecated: 2 GB, 2 * 1024 *1024 *1024",
 		Export:       true,
 	}
 	p.CacheMemoryLimit.Init(base.mgr)


### PR DESCRIPTION
`CacheMemoryLimit` configuration is never used in current code. Thus mark it as deprecated