### PR TITLE
fix: [2.5]JsonStats filter by conjunctExpr and improve the task slot calculation logic 

### DIFF
--- a/internal/core/src/exec/expression/BinaryRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.cpp
@@ -740,10 +740,9 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForJsonForIndex() {
                                       .clone();
         cached_index_chunk_id_ = 0;
     }
-    int total_data_chunk_pos= GetProcessedGlobalPos();
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, total_data_chunk_pos, real_batch_size);
+        cached_index_chunk_res_, current_data_global_pos_, real_batch_size);
     MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));

--- a/internal/core/src/exec/expression/BinaryRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.cpp
@@ -740,10 +740,11 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForJsonForIndex() {
                                       .clone();
         cached_index_chunk_id_ = 0;
     }
+    int total_data_chunk_pos= GetProcessedGlobalPos();
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, current_data_chunk_pos_, real_batch_size);
-    current_data_chunk_pos_ += real_batch_size;
+        cached_index_chunk_res_, total_data_chunk_pos, real_batch_size);
+    MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));
 }

--- a/internal/core/src/exec/expression/ExistsExpr.cpp
+++ b/internal/core/src/exec/expression/ExistsExpr.cpp
@@ -199,10 +199,9 @@ PhyExistsFilterExpr::EvalJsonExistsForDataSegmentForIndex() {
                                                      filter_func)
                                       .clone();
     }
-    int total_data_chunk_pos= GetProcessedGlobalPos();
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, total_data_chunk_pos, real_batch_size);
+        cached_index_chunk_res_, current_data_global_pos_, real_batch_size);
     MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));

--- a/internal/core/src/exec/expression/ExistsExpr.cpp
+++ b/internal/core/src/exec/expression/ExistsExpr.cpp
@@ -163,11 +163,14 @@ PhyExistsFilterExpr::EvalJsonExistsForDataSegment(EvalCtx& context) {
 
 VectorPtr
 PhyExistsFilterExpr::EvalJsonExistsForDataSegmentForIndex() {
-    auto real_batch_size = current_data_chunk_pos_ + batch_size_ > active_count_
-                               ? active_count_ - current_data_chunk_pos_
-                               : batch_size_;
+    auto real_batch_size = GetNextBatchSize();
+    if (real_batch_size == 0) {
+        return nullptr;
+    }
+
     auto pointer = milvus::Json::pointer(expr_->column_.nested_path_);
     if (cached_index_chunk_id_ != 0) {
+        cached_index_chunk_id_ = 0;
         const segcore::SegmentInternalInterface* segment = nullptr;
         if (segment_->type() == SegmentType::Growing) {
             segment =
@@ -195,12 +198,12 @@ PhyExistsFilterExpr::EvalJsonExistsForDataSegmentForIndex() {
                                                      is_strong_consistency,
                                                      filter_func)
                                       .clone();
-        cached_index_chunk_id_ = 0;
     }
+    int total_data_chunk_pos= GetProcessedGlobalPos();
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, current_data_chunk_pos_, real_batch_size);
-    current_data_chunk_pos_ += real_batch_size;
+        cached_index_chunk_res_, total_data_chunk_pos, real_batch_size);
+    MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));
 }

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -202,9 +202,30 @@ class SegmentExpr : public Expr {
         return true;
     }
 
+    int64_t
+    GetProcessedGlobalPos() {
+        int64_t total_pos = 0;
+
+        for (size_t i = 0; i < current_data_chunk_; i++) {
+            total_pos += segment_->chunk_size(field_id_, i);
+        }
+
+        total_pos += current_data_chunk_pos_;
+
+        LOG_DEBUG(
+            "GetProcessedGlobalPos - total_pos: {}, current_chunk: {}, "
+            "current_pos: {}",
+            total_pos,
+            current_data_chunk_,
+            current_data_chunk_pos_);
+
+        return total_pos;
+    }
+
     void
     MoveCursorForDataMultipleChunk() {
         int64_t processed_size = 0;
+
         for (size_t i = current_data_chunk_; i < num_data_chunk_; i++) {
             auto data_pos =
                 (i == current_data_chunk_) ? current_data_chunk_pos_ : 0;

--- a/internal/core/src/exec/expression/JsonContainsExpr.cpp
+++ b/internal/core/src/exec/expression/JsonContainsExpr.cpp
@@ -430,10 +430,9 @@ PhyJsonContainsFilterExpr::ExecJsonContainsByKeyIndex() {
                                       .clone();
         cached_index_chunk_id_ = 0;
     }
-    int total_data_chunk_pos= GetProcessedGlobalPos();
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, total_data_chunk_pos, real_batch_size);
+        cached_index_chunk_res_, current_data_global_pos_, real_batch_size);
     MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));
@@ -617,10 +616,10 @@ PhyJsonContainsFilterExpr::ExecJsonContainsArrayByKeyIndex() {
                                       .clone();
         cached_index_chunk_id_ = 0;
     }
-    int total_data_chunk_pos= GetProcessedGlobalPos();
+
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, total_data_chunk_pos, real_batch_size);
+        cached_index_chunk_res_, current_data_global_pos_, real_batch_size);
     MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));
@@ -897,10 +896,10 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllByKeyIndex() {
                                       .clone();
         cached_index_chunk_id_ = 0;
     }
-    int total_data_chunk_pos= GetProcessedGlobalPos();
+
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, total_data_chunk_pos, real_batch_size);
+        cached_index_chunk_res_, current_data_global_pos_, real_batch_size);
     MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));
@@ -1207,10 +1206,10 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllWithDiffTypeByKeyIndex() {
                                       .clone();
         cached_index_chunk_id_ = 0;
     }
-    int total_data_chunk_pos= GetProcessedGlobalPos();
+
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, total_data_chunk_pos, real_batch_size);
+        cached_index_chunk_res_, current_data_global_pos_, real_batch_size);
     MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));
@@ -1404,10 +1403,10 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllArrayByKeyIndex() {
                                       .clone();
         cached_index_chunk_id_ = 0;
     }
-    int total_data_chunk_pos= GetProcessedGlobalPos();
+
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, total_data_chunk_pos, real_batch_size);
+        cached_index_chunk_res_, current_data_global_pos_, real_batch_size);
     MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));
@@ -1689,10 +1688,10 @@ PhyJsonContainsFilterExpr::ExecJsonContainsWithDiffTypeByKeyIndex() {
                                       .clone();
         cached_index_chunk_id_ = 0;
     }
-    int total_data_chunk_pos= GetProcessedGlobalPos();
+
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, total_data_chunk_pos, real_batch_size);
+        cached_index_chunk_res_, current_data_global_pos_, real_batch_size);
     MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));

--- a/internal/core/src/exec/expression/JsonContainsExpr.cpp
+++ b/internal/core/src/exec/expression/JsonContainsExpr.cpp
@@ -430,10 +430,11 @@ PhyJsonContainsFilterExpr::ExecJsonContainsByKeyIndex() {
                                       .clone();
         cached_index_chunk_id_ = 0;
     }
+    int total_data_chunk_pos= GetProcessedGlobalPos();
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, current_data_chunk_pos_, real_batch_size);
-    current_data_chunk_pos_ += real_batch_size;
+        cached_index_chunk_res_, total_data_chunk_pos, real_batch_size);
+    MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));
 }
@@ -616,10 +617,11 @@ PhyJsonContainsFilterExpr::ExecJsonContainsArrayByKeyIndex() {
                                       .clone();
         cached_index_chunk_id_ = 0;
     }
+    int total_data_chunk_pos= GetProcessedGlobalPos();
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, current_data_chunk_pos_, real_batch_size);
-    current_data_chunk_pos_ += real_batch_size;
+        cached_index_chunk_res_, total_data_chunk_pos, real_batch_size);
+    MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));
 }
@@ -895,10 +897,11 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllByKeyIndex() {
                                       .clone();
         cached_index_chunk_id_ = 0;
     }
+    int total_data_chunk_pos= GetProcessedGlobalPos();
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, current_data_chunk_pos_, real_batch_size);
-    current_data_chunk_pos_ += real_batch_size;
+        cached_index_chunk_res_, total_data_chunk_pos, real_batch_size);
+    MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));
 }
@@ -1204,10 +1207,11 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllWithDiffTypeByKeyIndex() {
                                       .clone();
         cached_index_chunk_id_ = 0;
     }
+    int total_data_chunk_pos= GetProcessedGlobalPos();
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, current_data_chunk_pos_, real_batch_size);
-    current_data_chunk_pos_ += real_batch_size;
+        cached_index_chunk_res_, total_data_chunk_pos, real_batch_size);
+    MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));
 }
@@ -1400,10 +1404,11 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllArrayByKeyIndex() {
                                       .clone();
         cached_index_chunk_id_ = 0;
     }
+    int total_data_chunk_pos= GetProcessedGlobalPos();
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, current_data_chunk_pos_, real_batch_size);
-    current_data_chunk_pos_ += real_batch_size;
+        cached_index_chunk_res_, total_data_chunk_pos, real_batch_size);
+    MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));
 }
@@ -1684,10 +1689,11 @@ PhyJsonContainsFilterExpr::ExecJsonContainsWithDiffTypeByKeyIndex() {
                                       .clone();
         cached_index_chunk_id_ = 0;
     }
+    int total_data_chunk_pos= GetProcessedGlobalPos();
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, current_data_chunk_pos_, real_batch_size);
-    current_data_chunk_pos_ += real_batch_size;
+        cached_index_chunk_res_, total_data_chunk_pos, real_batch_size);
+    MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));
 }

--- a/internal/core/src/exec/expression/TermExpr.cpp
+++ b/internal/core/src/exec/expression/TermExpr.cpp
@@ -678,10 +678,9 @@ PhyTermFilterExpr::ExecJsonInVariableByKeyIndex() {
         cached_index_chunk_id_ = 0;
     }
 
-    int total_data_chunk_pos= GetProcessedGlobalPos();
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, total_data_chunk_pos, real_batch_size);
+        cached_index_chunk_res_, current_data_global_pos_, real_batch_size);
     MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));

--- a/internal/core/src/exec/expression/TermExpr.cpp
+++ b/internal/core/src/exec/expression/TermExpr.cpp
@@ -678,10 +678,11 @@ PhyTermFilterExpr::ExecJsonInVariableByKeyIndex() {
         cached_index_chunk_id_ = 0;
     }
 
+    int total_data_chunk_pos= GetProcessedGlobalPos();
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, current_data_chunk_pos_, real_batch_size);
-    current_data_chunk_pos_ += real_batch_size;
+        cached_index_chunk_res_, total_data_chunk_pos, real_batch_size);
+    MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));
 }

--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -1467,10 +1467,9 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJsonForIndex() {
                                                      filter_func)
                                       .clone();
     }
-    int total_data_chunk_pos= GetProcessedGlobalPos();
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, total_data_chunk_pos, real_batch_size);
+        cached_index_chunk_res_, current_data_global_pos_, real_batch_size);
     MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));

--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -959,9 +959,10 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJsonForIndex() {
         std::conditional_t<std::is_same_v<ExprValueType, std::string>,
                            std::string_view,
                            ExprValueType>;
-    auto real_batch_size = current_data_chunk_pos_ + batch_size_ > active_count_
-                               ? active_count_ - current_data_chunk_pos_
-                               : batch_size_;
+    auto real_batch_size = GetNextBatchSize();
+    if (real_batch_size == 0) {
+        return nullptr;
+    }
     auto pointerpath = milvus::Json::pointer(expr_->column_.nested_path_);
     auto pointerpair = SplitAtFirstSlashDigit(pointerpath);
     std::string pointer = pointerpair.first;
@@ -1125,6 +1126,7 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJsonForIndex() {
     auto op_type = expr_->op_type_;
 
     if (cached_index_chunk_id_ != 0) {
+        cached_index_chunk_id_ = 0;
         const segcore::SegmentInternalInterface* segment = nullptr;
         if (segment_->type() == SegmentType::Growing) {
             segment =
@@ -1222,8 +1224,6 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJsonForIndex() {
                         } else {
                             UnaryJSONTypeCompareWithValue(x != val);
                         }
-                    case proto::plan::PrefixMatch:
-                    case proto::plan::Match:
                     default:
                         return false;
                 }
@@ -1466,12 +1466,12 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJsonForIndex() {
                                                      is_strong_consistency,
                                                      filter_func)
                                       .clone();
-        cached_index_chunk_id_ = 0;
     }
+    int total_data_chunk_pos= GetProcessedGlobalPos();
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, current_data_chunk_pos_, real_batch_size);
-    current_data_chunk_pos_ += real_batch_size;
+        cached_index_chunk_res_, total_data_chunk_pos, real_batch_size);
+    MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));
 }

--- a/internal/core/src/index/JsonKeyStatsInvertedIndex.cpp
+++ b/internal/core/src/index/JsonKeyStatsInvertedIndex.cpp
@@ -30,10 +30,7 @@ JsonKeyStatsInvertedIndex::AddJSONEncodeValue(
     uint16_t length,
     int32_t value,
     std::map<std::string, std::vector<int64_t>>& mp) {
-    std::string key = "";
-    if (!paths.empty()) {
-        key = std::string("/") + Join(paths, "/");
-    }
+    std::string key = milvus::Json::pointer(paths);
     LOG_DEBUG(
         "insert inverted key: {}, flag: {}, type: {}, row_id: {}, offset: "
         "{}, length:{}, value:{}",

--- a/internal/datacoord/job_manager.go
+++ b/internal/datacoord/job_manager.go
@@ -296,7 +296,12 @@ func (jm *statsJobManager) SubmitStatsTask(originSegmentID, targetSegmentID int6
 	if err != nil {
 		return err
 	}
-	taskSlot := calculateStatsTaskSlot(originSegment.getSegmentSize())
+	originSegmentSize := originSegment.getSegmentSize()
+	if subJobType == indexpb.StatsSubJob_JsonKeyIndexJob {
+		originSegmentSize = originSegment.getSegmentSize() * 2
+	}
+
+	taskSlot := calculateStatsTaskSlot(originSegmentSize)
 	t := &indexpb.StatsTask{
 		CollectionID:    originSegment.GetCollectionID(),
 		PartitionID:     originSegment.GetPartitionID(),


### PR DESCRIPTION
Optimized JSON filter execution by introducing ProcessJsonStatsChunkPos() for unified position calculation and GetNextBatchSize() for better batch processing.
Improved JSON key generation by replacing manual path joining with milvus::Json::pointer() and adjusted slot size calculation for JSON key index jobs.
Updated the task slot calculation logic in calculateStatsTaskSlot() to handle the increased resource needs of JSON key index jobs.
issue:  https://github.com/milvus-io/milvus/issues/41378 https://github.com/milvus-io/milvus/issues/41218
pr: https://github.com/milvus-io/milvus/pull/41459