### PR TITLE
fix: JsonStats filter by conjunctExpr and improve the task slot calculation logic

### DIFF
--- a/internal/core/src/exec/expression/BinaryRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.cpp
@@ -305,19 +305,17 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForData(EvalCtx& context) {
     TargetBitmapView valid_res(res_vec->GetValidRawData(), real_batch_size);
 
     size_t processed_cursor = 0;
-    auto execute_sub_batch = [lower_inclusive,
-                              upper_inclusive,
-                              &processed_cursor,
-                              &bitmap_input]<FilterType filter_type =
-                                                 FilterType::sequential>(
-                                 const T* data,
-                                 const bool* valid_data,
-                                 const int32_t* offsets,
-                                 const int size,
-                                 TargetBitmapView res,
-                                 TargetBitmapView valid_res,
-                                 HighPrecisionType val1,
-                                 HighPrecisionType val2) {
+    auto execute_sub_batch =
+        [ lower_inclusive, upper_inclusive, &processed_cursor, &
+          bitmap_input ]<FilterType filter_type = FilterType::sequential>(
+            const T* data,
+            const bool* valid_data,
+            const int32_t* offsets,
+            const int size,
+            TargetBitmapView res,
+            TargetBitmapView valid_res,
+            HighPrecisionType val1,
+            HighPrecisionType val2) {
         if (lower_inclusive && upper_inclusive) {
             BinaryRangeElementFunc<T, true, true, filter_type> func;
             func(val1,
@@ -449,20 +447,22 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForJson(EvalCtx& context) {
     auto pointer = milvus::Json::pointer(expr_->column_.nested_path_);
 
     size_t processed_cursor = 0;
-    auto execute_sub_batch = [lower_inclusive,
-                              upper_inclusive,
-                              pointer,
-                              &bitmap_input,
-                              &processed_cursor]<FilterType filter_type =
-                                                     FilterType::sequential>(
-                                 const milvus::Json* data,
-                                 const bool* valid_data,
-                                 const int32_t* offsets,
-                                 const int size,
-                                 TargetBitmapView res,
-                                 TargetBitmapView valid_res,
-                                 ValueType val1,
-                                 ValueType val2) {
+    auto execute_sub_batch =
+        [
+            lower_inclusive,
+            upper_inclusive,
+            pointer,
+            &bitmap_input,
+            &processed_cursor
+        ]<FilterType filter_type = FilterType::sequential>(
+            const milvus::Json* data,
+            const bool* valid_data,
+            const int32_t* offsets,
+            const int size,
+            TargetBitmapView res,
+            TargetBitmapView valid_res,
+            ValueType val1,
+            ValueType val2) {
         if (lower_inclusive && upper_inclusive) {
             BinaryRangeElementFuncForJson<ValueType, true, true, filter_type>
                 func;
@@ -776,10 +776,10 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForJsonForIndex() {
                                       .clone();
         cached_index_chunk_id_ = 0;
     }
-    int total_data_chunk_pos_ =  GetProcessedRows();
+    int total_data_chunk_pos = GetProcessedGlobalPos();
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, total_data_chunk_pos_, real_batch_size);
+        cached_index_chunk_res_, total_data_chunk_pos, real_batch_size);
     MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));
@@ -821,20 +821,18 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForArray(EvalCtx& context) {
     }
 
     size_t processed_cursor = 0;
-    auto execute_sub_batch = [lower_inclusive,
-                              upper_inclusive,
-                              &processed_cursor,
-                              &bitmap_input]<FilterType filter_type =
-                                                 FilterType::sequential>(
-                                 const milvus::ArrayView* data,
-                                 const bool* valid_data,
-                                 const int32_t* offsets,
-                                 const int size,
-                                 TargetBitmapView res,
-                                 TargetBitmapView valid_res,
-                                 ValueType val1,
-                                 ValueType val2,
-                                 int index) {
+    auto execute_sub_batch =
+        [ lower_inclusive, upper_inclusive, &processed_cursor, &
+          bitmap_input ]<FilterType filter_type = FilterType::sequential>(
+            const milvus::ArrayView* data,
+            const bool* valid_data,
+            const int32_t* offsets,
+            const int size,
+            TargetBitmapView res,
+            TargetBitmapView valid_res,
+            ValueType val1,
+            ValueType val2,
+            int index) {
         if (lower_inclusive && upper_inclusive) {
             BinaryRangeElementFuncForArray<ValueType, true, true, filter_type>
                 func;

--- a/internal/core/src/exec/expression/BinaryRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.cpp
@@ -776,10 +776,11 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForJsonForIndex() {
                                       .clone();
         cached_index_chunk_id_ = 0;
     }
+    int total_data_chunk_pos_ = ProcessJsonStatsChunkPos();
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, current_data_chunk_pos_, real_batch_size);
-    current_data_chunk_pos_ += real_batch_size;
+        cached_index_chunk_res_, total_data_chunk_pos_, real_batch_size);
+    MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));
 }

--- a/internal/core/src/exec/expression/BinaryRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.cpp
@@ -776,7 +776,7 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForJsonForIndex() {
                                       .clone();
         cached_index_chunk_id_ = 0;
     }
-    int total_data_chunk_pos_ = ProcessJsonStatsChunkPos();
+    int total_data_chunk_pos_ =  GetProcessedRows();
     TargetBitmap result;
     result.append(
         cached_index_chunk_res_, total_data_chunk_pos_, real_batch_size);

--- a/internal/core/src/exec/expression/BinaryRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.cpp
@@ -776,10 +776,9 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForJsonForIndex() {
                                       .clone();
         cached_index_chunk_id_ = 0;
     }
-    int total_data_chunk_pos = GetProcessedGlobalPos();
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, total_data_chunk_pos, real_batch_size);
+        cached_index_chunk_res_, current_data_global_pos_, real_batch_size);
     MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));

--- a/internal/core/src/exec/expression/ExistsExpr.cpp
+++ b/internal/core/src/exec/expression/ExistsExpr.cpp
@@ -200,7 +200,7 @@ PhyExistsFilterExpr::EvalJsonExistsForDataSegmentForIndex() {
                                                      filter_func)
                                       .clone();
     }
-    int total_data_chunk_pos_ = ProcessJsonStatsChunkPos();
+    int total_data_chunk_pos_ =  GetProcessedRows();
     TargetBitmap result;
     result.append(
         cached_index_chunk_res_, total_data_chunk_pos_, real_batch_size);

--- a/internal/core/src/exec/expression/ExistsExpr.cpp
+++ b/internal/core/src/exec/expression/ExistsExpr.cpp
@@ -200,10 +200,10 @@ PhyExistsFilterExpr::EvalJsonExistsForDataSegmentForIndex() {
                                                      filter_func)
                                       .clone();
     }
-    int total_data_chunk_pos_ =  GetProcessedRows();
+    int total_data_chunk_pos = GetProcessedGlobalPos();
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, total_data_chunk_pos_, real_batch_size);
+        cached_index_chunk_res_, total_data_chunk_pos, real_batch_size);
     MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));

--- a/internal/core/src/exec/expression/ExistsExpr.cpp
+++ b/internal/core/src/exec/expression/ExistsExpr.cpp
@@ -200,10 +200,9 @@ PhyExistsFilterExpr::EvalJsonExistsForDataSegmentForIndex() {
                                                      filter_func)
                                       .clone();
     }
-    int total_data_chunk_pos = GetProcessedGlobalPos();
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, total_data_chunk_pos, real_batch_size);
+        cached_index_chunk_res_, current_data_global_pos_, real_batch_size);
     MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));

--- a/internal/core/src/exec/expression/ExistsExpr.cpp
+++ b/internal/core/src/exec/expression/ExistsExpr.cpp
@@ -164,11 +164,14 @@ PhyExistsFilterExpr::EvalJsonExistsForDataSegment(EvalCtx& context) {
 
 VectorPtr
 PhyExistsFilterExpr::EvalJsonExistsForDataSegmentForIndex() {
-    auto real_batch_size = current_data_chunk_pos_ + batch_size_ > active_count_
-                               ? active_count_ - current_data_chunk_pos_
-                               : batch_size_;
+    auto real_batch_size = GetNextBatchSize();
+    if (real_batch_size == 0) {
+        return nullptr;
+    }
+
     auto pointer = milvus::Json::pointer(expr_->column_.nested_path_);
     if (cached_index_chunk_id_ != 0) {
+        cached_index_chunk_id_ = 0;
         const segcore::SegmentInternalInterface* segment = nullptr;
         if (segment_->type() == SegmentType::Growing) {
             segment =
@@ -196,12 +199,12 @@ PhyExistsFilterExpr::EvalJsonExistsForDataSegmentForIndex() {
                                                      is_strong_consistency,
                                                      filter_func)
                                       .clone();
-        cached_index_chunk_id_ = 0;
     }
+    int total_data_chunk_pos_ = ProcessJsonStatsChunkPos();
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, current_data_chunk_pos_, real_batch_size);
-    current_data_chunk_pos_ += real_batch_size;
+        cached_index_chunk_res_, total_data_chunk_pos_, real_batch_size);
+    MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));
 }

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -204,7 +204,7 @@ class SegmentExpr : public Expr {
     }
 
     int64_t
-     GetProcessedRows() {
+    GetProcessedGlobalPos() {
         int64_t total_pos = 0;
 
         for (size_t i = 0; i < current_data_chunk_; i++) {
@@ -214,7 +214,7 @@ class SegmentExpr : public Expr {
         total_pos += current_data_chunk_pos_;
 
         LOG_DEBUG(
-            " GetProcessedRows - total_pos: {}, current_chunk: {}, "
+            " GetProcessedGlobalPos - total_pos: {}, current_chunk: {}, "
             "current_pos: {}",
             total_pos,
             current_data_chunk_,

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -204,7 +204,7 @@ class SegmentExpr : public Expr {
     }
 
     int64_t
-    ProcessJsonStatsChunkPos() {
+     GetProcessedRows() {
         int64_t total_pos = 0;
 
         for (size_t i = 0; i < current_data_chunk_; i++) {
@@ -214,7 +214,7 @@ class SegmentExpr : public Expr {
         total_pos += current_data_chunk_pos_;
 
         LOG_DEBUG(
-            "ProcessJsonStatsChunkPos - total_pos: {}, current_chunk: {}, "
+            " GetProcessedRows - total_pos: {}, current_chunk: {}, "
             "current_pos: {}",
             total_pos,
             current_data_chunk_,

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -203,9 +203,30 @@ class SegmentExpr : public Expr {
         return true;
     }
 
+    int64_t
+    ProcessJsonStatsChunkPos() {
+        int64_t total_pos = 0;
+
+        for (size_t i = 0; i < current_data_chunk_; i++) {
+            total_pos += segment_->chunk_size(field_id_, i);
+        }
+
+        total_pos += current_data_chunk_pos_;
+
+        LOG_DEBUG(
+            "ProcessJsonStatsChunkPos - total_pos: {}, current_chunk: {}, "
+            "current_pos: {}",
+            total_pos,
+            current_data_chunk_,
+            current_data_chunk_pos_);
+
+        return total_pos;
+    }
+
     void
     MoveCursorForDataMultipleChunk() {
         int64_t processed_size = 0;
+
         for (size_t i = current_data_chunk_; i < num_data_chunk_; i++) {
             auto data_pos =
                 (i == current_data_chunk_) ? current_data_chunk_pos_ : 0;

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -203,30 +203,9 @@ class SegmentExpr : public Expr {
         return true;
     }
 
-    int64_t
-    GetProcessedGlobalPos() {
-        int64_t total_pos = 0;
-
-        for (size_t i = 0; i < current_data_chunk_; i++) {
-            total_pos += segment_->chunk_size(field_id_, i);
-        }
-
-        total_pos += current_data_chunk_pos_;
-
-        LOG_DEBUG(
-            " GetProcessedGlobalPos - total_pos: {}, current_chunk: {}, "
-            "current_pos: {}",
-            total_pos,
-            current_data_chunk_,
-            current_data_chunk_pos_);
-
-        return total_pos;
-    }
-
     void
     MoveCursorForDataMultipleChunk() {
         int64_t processed_size = 0;
-
         for (size_t i = current_data_chunk_; i < num_data_chunk_; i++) {
             auto data_pos =
                 (i == current_data_chunk_) ? current_data_chunk_pos_ : 0;
@@ -239,6 +218,8 @@ class SegmentExpr : public Expr {
             if (processed_size >= batch_size_) {
                 current_data_chunk_ = i;
                 current_data_chunk_pos_ = data_pos + size;
+                current_data_global_pos_ =
+                    current_data_global_pos_ + processed_size;
                 break;
             }
             // }
@@ -250,6 +231,7 @@ class SegmentExpr : public Expr {
             auto size =
                 std::min(active_count_ - current_data_chunk_pos_, batch_size_);
             current_data_chunk_pos_ += size;
+            current_data_global_pos_ += size;
         } else {
             int64_t processed_size = 0;
             for (size_t i = current_data_chunk_; i < num_data_chunk_; i++) {
@@ -266,6 +248,8 @@ class SegmentExpr : public Expr {
                 if (processed_size >= batch_size_) {
                     current_data_chunk_ = i;
                     current_data_chunk_pos_ = data_pos + size;
+                    current_data_global_pos_ =
+                        current_data_global_pos_ + processed_size;
                     break;
                 }
             }
@@ -1287,6 +1271,7 @@ class SegmentExpr : public Expr {
     // because expr maybe called for every batch.
     int64_t current_data_chunk_{0};
     int64_t current_data_chunk_pos_{0};
+    int64_t current_data_global_pos_{0};
     int64_t current_index_chunk_{0};
     int64_t current_index_chunk_pos_{0};
     int64_t size_per_chunk_{0};

--- a/internal/core/src/exec/expression/JsonContainsExpr.cpp
+++ b/internal/core/src/exec/expression/JsonContainsExpr.cpp
@@ -431,10 +431,9 @@ PhyJsonContainsFilterExpr::ExecJsonContainsByKeyIndex() {
                                       .clone();
         cached_index_chunk_id_ = 0;
     }
-    int total_data_chunk_pos = GetProcessedGlobalPos();
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, total_data_chunk_pos, real_batch_size);
+        cached_index_chunk_res_, current_data_global_pos_, real_batch_size);
     MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));
@@ -618,10 +617,9 @@ PhyJsonContainsFilterExpr::ExecJsonContainsArrayByKeyIndex() {
                                       .clone();
         cached_index_chunk_id_ = 0;
     }
-    int total_data_chunk_pos = GetProcessedGlobalPos();
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, total_data_chunk_pos, real_batch_size);
+        cached_index_chunk_res_, current_data_global_pos_, real_batch_size);
     MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));
@@ -898,10 +896,9 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllByKeyIndex() {
                                       .clone();
         cached_index_chunk_id_ = 0;
     }
-    int total_data_chunk_pos = GetProcessedGlobalPos();
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, total_data_chunk_pos, real_batch_size);
+        cached_index_chunk_res_, current_data_global_pos_, real_batch_size);
     MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));
@@ -1208,10 +1205,9 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllWithDiffTypeByKeyIndex() {
                                       .clone();
         cached_index_chunk_id_ = 0;
     }
-    int total_data_chunk_pos = GetProcessedGlobalPos();
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, total_data_chunk_pos, real_batch_size);
+        cached_index_chunk_res_, current_data_global_pos_, real_batch_size);
     MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));
@@ -1405,10 +1401,9 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllArrayByKeyIndex() {
                                       .clone();
         cached_index_chunk_id_ = 0;
     }
-    int total_data_chunk_pos = GetProcessedGlobalPos();
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, total_data_chunk_pos, real_batch_size);
+        cached_index_chunk_res_, current_data_global_pos_, real_batch_size);
     MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));
@@ -1690,10 +1685,9 @@ PhyJsonContainsFilterExpr::ExecJsonContainsWithDiffTypeByKeyIndex() {
                                       .clone();
         cached_index_chunk_id_ = 0;
     }
-    int total_data_chunk_pos = GetProcessedGlobalPos();
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, total_data_chunk_pos, real_batch_size);
+        cached_index_chunk_res_, current_data_global_pos_, real_batch_size);
     MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));

--- a/internal/core/src/exec/expression/JsonContainsExpr.cpp
+++ b/internal/core/src/exec/expression/JsonContainsExpr.cpp
@@ -431,10 +431,11 @@ PhyJsonContainsFilterExpr::ExecJsonContainsByKeyIndex() {
                                       .clone();
         cached_index_chunk_id_ = 0;
     }
+    int total_data_chunk_pos_ = ProcessJsonStatsChunkPos();
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, current_data_chunk_pos_, real_batch_size);
-    current_data_chunk_pos_ += real_batch_size;
+        cached_index_chunk_res_, total_data_chunk_pos_, real_batch_size);
+    MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));
 }
@@ -617,10 +618,11 @@ PhyJsonContainsFilterExpr::ExecJsonContainsArrayByKeyIndex() {
                                       .clone();
         cached_index_chunk_id_ = 0;
     }
+    int total_data_chunk_pos_ = ProcessJsonStatsChunkPos();
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, current_data_chunk_pos_, real_batch_size);
-    current_data_chunk_pos_ += real_batch_size;
+        cached_index_chunk_res_, total_data_chunk_pos_, real_batch_size);
+    MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));
 }
@@ -896,10 +898,11 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllByKeyIndex() {
                                       .clone();
         cached_index_chunk_id_ = 0;
     }
+    int total_data_chunk_pos_ = ProcessJsonStatsChunkPos();
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, current_data_chunk_pos_, real_batch_size);
-    current_data_chunk_pos_ += real_batch_size;
+        cached_index_chunk_res_, total_data_chunk_pos_, real_batch_size);
+    MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));
 }
@@ -1205,10 +1208,11 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllWithDiffTypeByKeyIndex() {
                                       .clone();
         cached_index_chunk_id_ = 0;
     }
+    int total_data_chunk_pos_ = ProcessJsonStatsChunkPos();
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, current_data_chunk_pos_, real_batch_size);
-    current_data_chunk_pos_ += real_batch_size;
+        cached_index_chunk_res_, total_data_chunk_pos_, real_batch_size);
+    MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));
 }
@@ -1401,10 +1405,11 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllArrayByKeyIndex() {
                                       .clone();
         cached_index_chunk_id_ = 0;
     }
+    int total_data_chunk_pos_ = ProcessJsonStatsChunkPos();
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, current_data_chunk_pos_, real_batch_size);
-    current_data_chunk_pos_ += real_batch_size;
+        cached_index_chunk_res_, total_data_chunk_pos_, real_batch_size);
+    MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));
 }
@@ -1685,10 +1690,11 @@ PhyJsonContainsFilterExpr::ExecJsonContainsWithDiffTypeByKeyIndex() {
                                       .clone();
         cached_index_chunk_id_ = 0;
     }
+    int total_data_chunk_pos_ = ProcessJsonStatsChunkPos();
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, current_data_chunk_pos_, real_batch_size);
-    current_data_chunk_pos_ += real_batch_size;
+        cached_index_chunk_res_, total_data_chunk_pos_, real_batch_size);
+    MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));
 }

--- a/internal/core/src/exec/expression/JsonContainsExpr.cpp
+++ b/internal/core/src/exec/expression/JsonContainsExpr.cpp
@@ -431,7 +431,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsByKeyIndex() {
                                       .clone();
         cached_index_chunk_id_ = 0;
     }
-    int total_data_chunk_pos_ = ProcessJsonStatsChunkPos();
+    int total_data_chunk_pos_ =  GetProcessedRows();
     TargetBitmap result;
     result.append(
         cached_index_chunk_res_, total_data_chunk_pos_, real_batch_size);
@@ -618,7 +618,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsArrayByKeyIndex() {
                                       .clone();
         cached_index_chunk_id_ = 0;
     }
-    int total_data_chunk_pos_ = ProcessJsonStatsChunkPos();
+    int total_data_chunk_pos_ =  GetProcessedRows();
     TargetBitmap result;
     result.append(
         cached_index_chunk_res_, total_data_chunk_pos_, real_batch_size);
@@ -898,7 +898,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllByKeyIndex() {
                                       .clone();
         cached_index_chunk_id_ = 0;
     }
-    int total_data_chunk_pos_ = ProcessJsonStatsChunkPos();
+    int total_data_chunk_pos_ =  GetProcessedRows();
     TargetBitmap result;
     result.append(
         cached_index_chunk_res_, total_data_chunk_pos_, real_batch_size);
@@ -1208,7 +1208,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllWithDiffTypeByKeyIndex() {
                                       .clone();
         cached_index_chunk_id_ = 0;
     }
-    int total_data_chunk_pos_ = ProcessJsonStatsChunkPos();
+    int total_data_chunk_pos_ =  GetProcessedRows();
     TargetBitmap result;
     result.append(
         cached_index_chunk_res_, total_data_chunk_pos_, real_batch_size);
@@ -1405,7 +1405,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllArrayByKeyIndex() {
                                       .clone();
         cached_index_chunk_id_ = 0;
     }
-    int total_data_chunk_pos_ = ProcessJsonStatsChunkPos();
+    int total_data_chunk_pos_ =  GetProcessedRows();
     TargetBitmap result;
     result.append(
         cached_index_chunk_res_, total_data_chunk_pos_, real_batch_size);
@@ -1690,7 +1690,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsWithDiffTypeByKeyIndex() {
                                       .clone();
         cached_index_chunk_id_ = 0;
     }
-    int total_data_chunk_pos_ = ProcessJsonStatsChunkPos();
+    int total_data_chunk_pos_ =  GetProcessedRows();
     TargetBitmap result;
     result.append(
         cached_index_chunk_res_, total_data_chunk_pos_, real_batch_size);

--- a/internal/core/src/exec/expression/JsonContainsExpr.cpp
+++ b/internal/core/src/exec/expression/JsonContainsExpr.cpp
@@ -431,10 +431,10 @@ PhyJsonContainsFilterExpr::ExecJsonContainsByKeyIndex() {
                                       .clone();
         cached_index_chunk_id_ = 0;
     }
-    int total_data_chunk_pos_ =  GetProcessedRows();
+    int total_data_chunk_pos = GetProcessedGlobalPos();
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, total_data_chunk_pos_, real_batch_size);
+        cached_index_chunk_res_, total_data_chunk_pos, real_batch_size);
     MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));
@@ -618,10 +618,10 @@ PhyJsonContainsFilterExpr::ExecJsonContainsArrayByKeyIndex() {
                                       .clone();
         cached_index_chunk_id_ = 0;
     }
-    int total_data_chunk_pos_ =  GetProcessedRows();
+    int total_data_chunk_pos = GetProcessedGlobalPos();
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, total_data_chunk_pos_, real_batch_size);
+        cached_index_chunk_res_, total_data_chunk_pos, real_batch_size);
     MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));
@@ -898,10 +898,10 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllByKeyIndex() {
                                       .clone();
         cached_index_chunk_id_ = 0;
     }
-    int total_data_chunk_pos_ =  GetProcessedRows();
+    int total_data_chunk_pos = GetProcessedGlobalPos();
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, total_data_chunk_pos_, real_batch_size);
+        cached_index_chunk_res_, total_data_chunk_pos, real_batch_size);
     MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));
@@ -1208,10 +1208,10 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllWithDiffTypeByKeyIndex() {
                                       .clone();
         cached_index_chunk_id_ = 0;
     }
-    int total_data_chunk_pos_ =  GetProcessedRows();
+    int total_data_chunk_pos = GetProcessedGlobalPos();
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, total_data_chunk_pos_, real_batch_size);
+        cached_index_chunk_res_, total_data_chunk_pos, real_batch_size);
     MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));
@@ -1405,10 +1405,10 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllArrayByKeyIndex() {
                                       .clone();
         cached_index_chunk_id_ = 0;
     }
-    int total_data_chunk_pos_ =  GetProcessedRows();
+    int total_data_chunk_pos = GetProcessedGlobalPos();
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, total_data_chunk_pos_, real_batch_size);
+        cached_index_chunk_res_, total_data_chunk_pos, real_batch_size);
     MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));
@@ -1690,10 +1690,10 @@ PhyJsonContainsFilterExpr::ExecJsonContainsWithDiffTypeByKeyIndex() {
                                       .clone();
         cached_index_chunk_id_ = 0;
     }
-    int total_data_chunk_pos_ =  GetProcessedRows();
+    int total_data_chunk_pos = GetProcessedGlobalPos();
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, total_data_chunk_pos_, real_batch_size);
+        cached_index_chunk_res_, total_data_chunk_pos, real_batch_size);
     MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));

--- a/internal/core/src/exec/expression/TermExpr.cpp
+++ b/internal/core/src/exec/expression/TermExpr.cpp
@@ -678,7 +678,7 @@ PhyTermFilterExpr::ExecJsonInVariableByKeyIndex() {
         cached_index_chunk_id_ = 0;
     }
 
-    int total_data_chunk_pos_ = ProcessJsonStatsChunkPos();
+    int total_data_chunk_pos_ =  GetProcessedRows();
     TargetBitmap result;
     result.append(
         cached_index_chunk_res_, total_data_chunk_pos_, real_batch_size);

--- a/internal/core/src/exec/expression/TermExpr.cpp
+++ b/internal/core/src/exec/expression/TermExpr.cpp
@@ -678,10 +678,11 @@ PhyTermFilterExpr::ExecJsonInVariableByKeyIndex() {
         cached_index_chunk_id_ = 0;
     }
 
+    int total_data_chunk_pos_ = ProcessJsonStatsChunkPos();
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, current_data_chunk_pos_, real_batch_size);
-    current_data_chunk_pos_ += real_batch_size;
+        cached_index_chunk_res_, total_data_chunk_pos_, real_batch_size);
+    MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));
 }

--- a/internal/core/src/exec/expression/TermExpr.cpp
+++ b/internal/core/src/exec/expression/TermExpr.cpp
@@ -678,10 +678,9 @@ PhyTermFilterExpr::ExecJsonInVariableByKeyIndex() {
         cached_index_chunk_id_ = 0;
     }
 
-    int total_data_chunk_pos = GetProcessedGlobalPos();
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, total_data_chunk_pos, real_batch_size);
+        cached_index_chunk_res_, current_data_global_pos_, real_batch_size);
     MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));

--- a/internal/core/src/exec/expression/TermExpr.cpp
+++ b/internal/core/src/exec/expression/TermExpr.cpp
@@ -678,10 +678,10 @@ PhyTermFilterExpr::ExecJsonInVariableByKeyIndex() {
         cached_index_chunk_id_ = 0;
     }
 
-    int total_data_chunk_pos_ =  GetProcessedRows();
+    int total_data_chunk_pos = GetProcessedGlobalPos();
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, total_data_chunk_pos_, real_batch_size);
+        cached_index_chunk_res_, total_data_chunk_pos, real_batch_size);
     MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));

--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -1401,10 +1401,9 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJsonForIndex() {
                                                      filter_func)
                                       .clone();
     }
-    int total_data_chunk_pos = GetProcessedGlobalPos();
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, total_data_chunk_pos, real_batch_size);
+        cached_index_chunk_res_, current_data_global_pos_, real_batch_size);
     MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));

--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -1405,7 +1405,7 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJsonForIndex() {
                                                      filter_func)
                                       .clone();
     }
-    int total_data_chunk_pos_ = ProcessJsonStatsChunkPos();
+    int total_data_chunk_pos_ =  GetProcessedRows();
     TargetBitmap result;
     result.append(
         cached_index_chunk_res_, total_data_chunk_pos_, real_batch_size);

--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -319,9 +319,8 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplArray(EvalCtx& context) {
     }
     int processed_cursor = 0;
     auto execute_sub_batch =
-        [op_type,
-         &processed_cursor,
-         &bitmap_input]<FilterType filter_type = FilterType::sequential>(
+        [ op_type, &processed_cursor, &
+          bitmap_input ]<FilterType filter_type = FilterType::sequential>(
             const milvus::ArrayView* data,
             const bool* valid_data,
             const int32_t* offsets,
@@ -330,152 +329,151 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplArray(EvalCtx& context) {
             TargetBitmapView valid_res,
             ValueType val,
             int index) {
-            switch (op_type) {
-                case proto::plan::GreaterThan: {
-                    UnaryElementFuncForArray<ValueType,
-                                             proto::plan::GreaterThan,
-                                             filter_type>
-                        func;
-                    func(data,
-                         valid_data,
-                         size,
-                         val,
-                         index,
-                         res,
-                         valid_res,
-                         bitmap_input,
-                         processed_cursor,
-                         offsets);
-                    break;
-                }
-                case proto::plan::GreaterEqual: {
-                    UnaryElementFuncForArray<ValueType,
-                                             proto::plan::GreaterEqual,
-                                             filter_type>
-                        func;
-                    func(data,
-                         valid_data,
-                         size,
-                         val,
-                         index,
-                         res,
-                         valid_res,
-                         bitmap_input,
-                         processed_cursor,
-                         offsets);
-                    break;
-                }
-                case proto::plan::LessThan: {
-                    UnaryElementFuncForArray<ValueType,
-                                             proto::plan::LessThan,
-                                             filter_type>
-                        func;
-                    func(data,
-                         valid_data,
-                         size,
-                         val,
-                         index,
-                         res,
-                         valid_res,
-                         bitmap_input,
-                         processed_cursor,
-                         offsets);
-                    break;
-                }
-                case proto::plan::LessEqual: {
-                    UnaryElementFuncForArray<ValueType,
-                                             proto::plan::LessEqual,
-                                             filter_type>
-                        func;
-                    func(data,
-                         valid_data,
-                         size,
-                         val,
-                         index,
-                         res,
-                         valid_res,
-                         bitmap_input,
-                         processed_cursor,
-                         offsets);
-                    break;
-                }
-                case proto::plan::Equal: {
-                    UnaryElementFuncForArray<ValueType,
-                                             proto::plan::Equal,
-                                             filter_type>
-                        func;
-                    func(data,
-                         valid_data,
-                         size,
-                         val,
-                         index,
-                         res,
-                         valid_res,
-                         bitmap_input,
-                         processed_cursor,
-                         offsets);
-                    break;
-                }
-                case proto::plan::NotEqual: {
-                    UnaryElementFuncForArray<ValueType,
-                                             proto::plan::NotEqual,
-                                             filter_type>
-                        func;
-                    func(data,
-                         valid_data,
-                         size,
-                         val,
-                         index,
-                         res,
-                         valid_res,
-                         bitmap_input,
-                         processed_cursor,
-                         offsets);
-                    break;
-                }
-                case proto::plan::PrefixMatch: {
-                    UnaryElementFuncForArray<ValueType,
-                                             proto::plan::PrefixMatch,
-                                             filter_type>
-                        func;
-                    func(data,
-                         valid_data,
-                         size,
-                         val,
-                         index,
-                         res,
-                         valid_res,
-                         bitmap_input,
-                         processed_cursor,
-                         offsets);
-                    break;
-                }
-                case proto::plan::Match: {
-                    UnaryElementFuncForArray<ValueType,
-                                             proto::plan::Match,
-                                             filter_type>
-                        func;
-                    func(data,
-                         valid_data,
-                         size,
-                         val,
-                         index,
-                         res,
-                         valid_res,
-                         bitmap_input,
-                         processed_cursor,
-                         offsets);
-                    break;
-                }
-                default:
-                    PanicInfo(
-                        OpTypeInvalid,
-                        fmt::format(
-                            "unsupported operator type for unary expr: {}",
-                            op_type));
+        switch (op_type) {
+            case proto::plan::GreaterThan: {
+                UnaryElementFuncForArray<ValueType,
+                                         proto::plan::GreaterThan,
+                                         filter_type>
+                    func;
+                func(data,
+                     valid_data,
+                     size,
+                     val,
+                     index,
+                     res,
+                     valid_res,
+                     bitmap_input,
+                     processed_cursor,
+                     offsets);
+                break;
             }
-            processed_cursor += size;
-        };
+            case proto::plan::GreaterEqual: {
+                UnaryElementFuncForArray<ValueType,
+                                         proto::plan::GreaterEqual,
+                                         filter_type>
+                    func;
+                func(data,
+                     valid_data,
+                     size,
+                     val,
+                     index,
+                     res,
+                     valid_res,
+                     bitmap_input,
+                     processed_cursor,
+                     offsets);
+                break;
+            }
+            case proto::plan::LessThan: {
+                UnaryElementFuncForArray<ValueType,
+                                         proto::plan::LessThan,
+                                         filter_type>
+                    func;
+                func(data,
+                     valid_data,
+                     size,
+                     val,
+                     index,
+                     res,
+                     valid_res,
+                     bitmap_input,
+                     processed_cursor,
+                     offsets);
+                break;
+            }
+            case proto::plan::LessEqual: {
+                UnaryElementFuncForArray<ValueType,
+                                         proto::plan::LessEqual,
+                                         filter_type>
+                    func;
+                func(data,
+                     valid_data,
+                     size,
+                     val,
+                     index,
+                     res,
+                     valid_res,
+                     bitmap_input,
+                     processed_cursor,
+                     offsets);
+                break;
+            }
+            case proto::plan::Equal: {
+                UnaryElementFuncForArray<ValueType,
+                                         proto::plan::Equal,
+                                         filter_type>
+                    func;
+                func(data,
+                     valid_data,
+                     size,
+                     val,
+                     index,
+                     res,
+                     valid_res,
+                     bitmap_input,
+                     processed_cursor,
+                     offsets);
+                break;
+            }
+            case proto::plan::NotEqual: {
+                UnaryElementFuncForArray<ValueType,
+                                         proto::plan::NotEqual,
+                                         filter_type>
+                    func;
+                func(data,
+                     valid_data,
+                     size,
+                     val,
+                     index,
+                     res,
+                     valid_res,
+                     bitmap_input,
+                     processed_cursor,
+                     offsets);
+                break;
+            }
+            case proto::plan::PrefixMatch: {
+                UnaryElementFuncForArray<ValueType,
+                                         proto::plan::PrefixMatch,
+                                         filter_type>
+                    func;
+                func(data,
+                     valid_data,
+                     size,
+                     val,
+                     index,
+                     res,
+                     valid_res,
+                     bitmap_input,
+                     processed_cursor,
+                     offsets);
+                break;
+            }
+            case proto::plan::Match: {
+                UnaryElementFuncForArray<ValueType,
+                                         proto::plan::Match,
+                                         filter_type>
+                    func;
+                func(data,
+                     valid_data,
+                     size,
+                     val,
+                     index,
+                     res,
+                     valid_res,
+                     bitmap_input,
+                     processed_cursor,
+                     offsets);
+                break;
+            }
+            default:
+                PanicInfo(
+                    OpTypeInvalid,
+                    fmt::format("unsupported operator type for unary expr: {}",
+                                op_type));
+        }
+        processed_cursor += size;
+    };
     int64_t processed_size;
     if (has_offset_input_) {
         processed_size =
@@ -547,7 +545,7 @@ PhyUnaryRangeFilterExpr::ExecArrayEqualForIndex(EvalCtx& context,
                 };
             } else {
                 auto size_per_chunk = segment_->size_per_chunk();
-                retrieve = [ size_per_chunk, this ](int64_t offset) -> auto{
+                retrieve = [ size_per_chunk, this ](int64_t offset) -> auto {
                     auto chunk_idx = offset / size_per_chunk;
                     auto chunk_offset = offset % size_per_chunk;
                     const auto& chunk =
@@ -680,18 +678,16 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJson(EvalCtx& context) {
     } while (false)
 
     int processed_cursor = 0;
-    auto execute_sub_batch = [op_type,
-                              pointer,
-                              &processed_cursor,
-                              &bitmap_input]<FilterType filter_type =
-                                                 FilterType::sequential>(
-                                 const milvus::Json* data,
-                                 const bool* valid_data,
-                                 const int32_t* offsets,
-                                 const int size,
-                                 TargetBitmapView res,
-                                 TargetBitmapView valid_res,
-                                 ExprValueType val) {
+    auto execute_sub_batch =
+        [ op_type, pointer, &processed_cursor, &
+          bitmap_input ]<FilterType filter_type = FilterType::sequential>(
+            const milvus::Json* data,
+            const bool* valid_data,
+            const int32_t* offsets,
+            const int size,
+            TargetBitmapView res,
+            TargetBitmapView valid_res,
+            ExprValueType val) {
         bool has_bitmap_input = !bitmap_input.empty();
         switch (op_type) {
             case proto::plan::GreaterThan: {
@@ -1405,10 +1401,10 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJsonForIndex() {
                                                      filter_func)
                                       .clone();
     }
-    int total_data_chunk_pos_ =  GetProcessedRows();
+    int total_data_chunk_pos = GetProcessedGlobalPos();
     TargetBitmap result;
     result.append(
-        cached_index_chunk_res_, total_data_chunk_pos_, real_batch_size);
+        cached_index_chunk_res_, total_data_chunk_pos, real_batch_size);
     MoveCursor();
     return std::make_shared<ColumnVector>(std::move(result),
                                           TargetBitmap(real_batch_size, true));
@@ -1610,17 +1606,16 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplForData(EvalCtx& context) {
     auto expr_type = expr_->op_type_;
 
     size_t processed_cursor = 0;
-    auto execute_sub_batch = [expr_type,
-                              &processed_cursor,
-                              &bitmap_input]<FilterType filter_type =
-                                                 FilterType::sequential>(
-                                 const T* data,
-                                 const bool* valid_data,
-                                 const int32_t* offsets,
-                                 const int size,
-                                 TargetBitmapView res,
-                                 TargetBitmapView valid_res,
-                                 IndexInnerType val) {
+    auto execute_sub_batch =
+        [ expr_type, &processed_cursor, &
+          bitmap_input ]<FilterType filter_type = FilterType::sequential>(
+            const T* data,
+            const bool* valid_data,
+            const int32_t* offsets,
+            const int size,
+            TargetBitmapView res,
+            TargetBitmapView valid_res,
+            IndexInnerType val) {
         switch (expr_type) {
             case proto::plan::GreaterThan: {
                 UnaryElementFunc<T, proto::plan::GreaterThan, filter_type> func;

--- a/internal/core/src/index/JsonKeyStatsInvertedIndex.cpp
+++ b/internal/core/src/index/JsonKeyStatsInvertedIndex.cpp
@@ -30,10 +30,7 @@ JsonKeyStatsInvertedIndex::AddJSONEncodeValue(
     uint16_t length,
     int32_t value,
     std::map<std::string, std::vector<int64_t>>& mp) {
-    std::string key = "";
-    if (!paths.empty()) {
-        key = std::string("/") + Join(paths, "/");
-    }
+    std::string key = milvus::Json::pointer(paths);
     LOG_DEBUG(
         "insert inverted key: {}, flag: {}, type: {}, row_id: {}, offset: "
         "{}, length:{}, value:{}",

--- a/internal/core/src/index/JsonKeyStatsInvertedIndex.cpp
+++ b/internal/core/src/index/JsonKeyStatsInvertedIndex.cpp
@@ -379,7 +379,8 @@ JsonKeyStatsInvertedIndex::Load(milvus::tracer::TraceContext ctx,
     disk_file_manager_->CacheJsonKeyIndexToDisk(index_files.value());
     AssertInfo(
         tantivy_index_exist(path_.c_str()), "index not exist: {}", path_);
-    wrapper_ = std::make_shared<TantivyIndexWrapper>(path_.c_str(), milvus::index::SetBitset);
+    wrapper_ = std::make_shared<TantivyIndexWrapper>(path_.c_str(),
+                                                     milvus::index::SetBitset);
     LOG_INFO("load json key index done for field id:{} with dir:{}",
              field_id_,
              path_);

--- a/internal/datacoord/job_manager.go
+++ b/internal/datacoord/job_manager.go
@@ -296,7 +296,12 @@ func (jm *statsJobManager) SubmitStatsTask(originSegmentID, targetSegmentID int6
 	if err != nil {
 		return err
 	}
-	taskSlot := calculateStatsTaskSlot(originSegment.getSegmentSize())
+	originSegmentSize := originSegment.getSegmentSize()
+	if subJobType == indexpb.StatsSubJob_JsonKeyIndexJob {
+		originSegmentSize = originSegment.getSegmentSize() * 2
+	}
+
+	taskSlot := calculateStatsTaskSlot(originSegmentSize)
 	t := &indexpb.StatsTask{
 		CollectionID:    originSegment.GetCollectionID(),
 		PartitionID:     originSegment.GetPartitionID(),


### PR DESCRIPTION
Optimized JSON filter execution by introducing ProcessJsonStatsChunkPos() for unified position calculation and GetNextBatchSize() for better batch processing.
Improved JSON key generation by replacing manual path joining with milvus::Json::pointer() and adjusted slot size calculation for JSON key index jobs.
Updated the task slot calculation logic in calculateStatsTaskSlot() to handle the increased resource needs of JSON key index jobs.
issue: https://github.com/milvus-io/milvus/issues/41378 https://github.com/milvus-io/milvus/issues/41218