### PR TITLE
fix: Save update timestamp in catalog.AlterCollection API

### DIFF
--- a/internal/metastore/kv/rootcoord/kv_catalog.go
+++ b/internal/metastore/kv/rootcoord/kv_catalog.go
@@ -647,6 +647,7 @@ func (kc *Catalog) alterModifyCollection(ctx context.Context, oldColl *model.Col
 	oldCollClone.State = newColl.State
 	oldCollClone.Properties = newColl.Properties
 	oldCollClone.Fields = newColl.Fields
+	oldCollClone.UpdateTimestamp = newColl.UpdateTimestamp
 
 	oldKey := BuildCollectionKey(oldColl.DBID, oldColl.CollectionID)
 	newKey := BuildCollectionKey(newColl.DBID, oldColl.CollectionID)

--- a/internal/metastore/kv/rootcoord/kv_catalog_test.go
+++ b/internal/metastore/kv/rootcoord/kv_catalog_test.go
@@ -3,6 +3,7 @@ package rootcoord
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"strings"
 	"sync"
 	"testing"
@@ -1046,7 +1047,7 @@ func TestCatalog_AlterCollection(t *testing.T) {
 		ctx := context.Background()
 		var collectionID int64 = 1
 		oldC := &model.Collection{CollectionID: collectionID, State: pb.CollectionState_CollectionCreating}
-		newC := &model.Collection{CollectionID: collectionID, State: pb.CollectionState_CollectionCreated}
+		newC := &model.Collection{CollectionID: collectionID, State: pb.CollectionState_CollectionCreated, UpdateTimestamp: rand.Uint64()}
 		err := kc.AlterCollection(ctx, oldC, newC, metastore.MODIFY, 0)
 		assert.NoError(t, err)
 		key := BuildCollectionKey(0, collectionID)
@@ -1057,6 +1058,7 @@ func TestCatalog_AlterCollection(t *testing.T) {
 		assert.NoError(t, err)
 		got := model.UnmarshalCollectionModel(&collPb)
 		assert.Equal(t, pb.CollectionState_CollectionCreated, got.State)
+		assert.Equal(t, newC.UpdateTimestamp, got.UpdateTimestamp)
 	})
 
 	t.Run("modify, tenant id changed", func(t *testing.T) {


### PR DESCRIPTION
Related to #41467