### PR TITLE
fix: [2.5]json stats add map null check before insert into tantivity

### DIFF
--- a/internal/core/src/index/JsonKeyStatsInvertedIndex.cpp
+++ b/internal/core/src/index/JsonKeyStatsInvertedIndex.cpp
@@ -58,7 +58,7 @@ JsonKeyStatsInvertedIndex::AddInvertedRecord(
     std::vector<uintptr_t> json_offsets_lens;
     std::vector<const char*> keys;
     std::vector<const int64_t*> json_offsets;
-    if(mp.empty()) {
+    if (mp.empty()) {
         return;
     }
     for (auto& iter : mp) {

--- a/internal/core/src/index/JsonKeyStatsInvertedIndex.cpp
+++ b/internal/core/src/index/JsonKeyStatsInvertedIndex.cpp
@@ -58,6 +58,9 @@ JsonKeyStatsInvertedIndex::AddInvertedRecord(
     std::vector<uintptr_t> json_offsets_lens;
     std::vector<const char*> keys;
     std::vector<const int64_t*> json_offsets;
+    if(mp.empty()) {
+        return;
+    }
     for (auto& iter : mp) {
         keys.push_back(iter.first.c_str());
         json_offsets.push_back(iter.second.data());


### PR DESCRIPTION
json stats add map null check before insert into tantivity
issue:https://github.com/milvus-io/milvus/issues/41494
pr:https://github.com/milvus-io/milvus/pull/41505