### PR TITLE
fix: Make sure segment in ut is destroyed before static MmapManager singleton

### DIFF
--- a/internal/core/unittest/test_expr_materialized_view.cpp
+++ b/internal/core/unittest/test_expr_materialized_view.cpp
@@ -143,6 +143,9 @@ class ExprMaterializedViewTest : public testing::Test {
 
     static void
     TearDownTestSuite() {
+        exec_plan_node_visitor = nullptr;
+        segment = nullptr;
+        gen_data = nullptr;
     }
 
  protected:


### PR DESCRIPTION
issue: #41507 