### PR TITLE
fix: [2.5] Try recreate producer when produce failed

### DIFF
--- a/pkg/mq/msgstream/mqwrapper/kafka/kafka_producer.go
+++ b/pkg/mq/msgstream/mqwrapper/kafka/kafka_producer.go
@@ -97,3 +97,7 @@ func (kp *kafkaProducer) Close() {
 		}
 	})
 }
+
+func (kp *kafkaProducer) Healthy() bool {
+	return !kp.isClosed
+}

--- a/pkg/mq/msgstream/mqwrapper/nmq/nmq_producer.go
+++ b/pkg/mq/msgstream/mqwrapper/nmq/nmq_producer.go
@@ -76,3 +76,7 @@ func (np *nmqProducer) Close() {
 	// No specific producer to be closed.
 	// stream doesn't close here.
 }
+
+func (np *nmqProducer) Healthy() bool {
+	return true
+}

--- a/pkg/mq/msgstream/mqwrapper/producer.go
+++ b/pkg/mq/msgstream/mqwrapper/producer.go
@@ -31,4 +31,6 @@ type Producer interface {
 	Send(ctx context.Context, message *common.ProducerMessage) (common.MessageID, error)
 
 	Close()
+
+	Healthy() bool
 }

--- a/pkg/mq/msgstream/mqwrapper/pulsar/pulsar_client.go
+++ b/pkg/mq/msgstream/mqwrapper/pulsar/pulsar_client.go
@@ -98,7 +98,7 @@ func (pc *pulsarClient) CreateProducer(ctx context.Context, options mqcommon.Pro
 	elapsed := start.ElapseSpan()
 	metrics.MsgStreamRequestLatency.WithLabelValues(metrics.CreateProducerLabel).Observe(float64(elapsed.Milliseconds()))
 	metrics.MsgStreamOpCounter.WithLabelValues(metrics.CreateProducerLabel, metrics.SuccessLabel).Inc()
-	producer := &pulsarProducer{p: pp}
+	producer := &pulsarProducer{p: pp, state: Healthy}
 	return producer, nil
 }
 

--- a/pkg/mq/msgstream/mqwrapper/rmq/rmq_producer.go
+++ b/pkg/mq/msgstream/mqwrapper/rmq/rmq_producer.go
@@ -56,3 +56,7 @@ func (rp *rmqProducer) Close() {
 	// TODO: close producer. Now it has bug
 	// rp.p.Close()
 }
+
+func (rp *rmqProducer) Healthy() bool {
+	return true
+}


### PR DESCRIPTION
issue: #41179 
master pr: #41532 

Under the `producer_exception` policy, when exceed the backlog limit, the producer becomes unavailable, so we need to try recreating the producer.