### PR TITLE
enhance: Accelerate delete filtering during binlog import

### DIFF
--- a/internal/util/importutilv2/binlog/filter.go
+++ b/internal/util/importutilv2/binlog/filter.go
@@ -31,10 +31,8 @@ func FilterWithDelete(r *reader) (Filter, error) {
 	return func(row map[int64]interface{}) bool {
 		rowPk := row[pkField.GetFieldID()]
 		rowTs := row[common.TimeStampField]
-		for i, pk := range r.deleteData.Pks {
-			if pk.GetValue() == rowPk && int64(r.deleteData.Tss[i]) > rowTs.(int64) {
-				return false
-			}
+		if ts, ok := r.deleteData[rowPk]; ok && int64(ts) > rowTs.(int64) {
+			return false
 		}
 		return true
 	}, nil

--- a/internal/util/importutilv2/binlog/reader.go
+++ b/internal/util/importutilv2/binlog/reader.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"time"
 
 	"github.com/samber/lo"
 	"go.uber.org/atomic"
@@ -189,7 +188,6 @@ func (r *reader) filter(insertData *storage.InsertData) (*storage.InsertData, er
 	if len(r.filters) == 0 {
 		return insertData, nil
 	}
-	start := time.Now()
 	masks := make(map[int]struct{}, 0)
 OUTER:
 	for i := 0; i < insertData.GetRowNum(); i++ {
@@ -218,13 +216,6 @@ OUTER:
 			return nil, merr.WrapErrImportFailed(fmt.Sprintf("failed to append row, err=%s", err.Error()))
 		}
 	}
-	log.Ctx(context.TODO()).Info("filter data done",
-		zap.String("collection", r.schema.GetName()),
-		zap.Int("deleteRows", len(r.deleteData)),
-		zap.Int("originRows", insertData.GetRowNum()),
-		zap.Int("resultRows", result.GetRowNum()),
-		zap.Duration("dur", time.Since(start)),
-	)
 	return result, nil
 }
 


### PR DESCRIPTION
Use map for deleteData instead of slice to accelerate delete filtering during binlog import.

issue: https://github.com/milvus-io/milvus/issues/41550