### PR TITLE
enhance: [AddField] Use default value if exist when reopen sealed

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -2162,7 +2162,9 @@ ChunkedSegmentSealedImpl::reopen(SchemaPtr sch) {
 
     auto absent_fields = sch->absent_fields(*schema_);
     for (const auto& field_meta : *absent_fields) {
-        fill_empty_field(field_meta);
+        if (!IsVectorDataType(field_meta.data_type)) {
+            fill_empty_field(field_meta);
+        }
     }
 
     schema_ = sch;
@@ -2178,7 +2180,9 @@ ChunkedSegmentSealedImpl::finish_load() {
         // this shall check the ready bitset here
         if (!get_bit(field_data_ready_bitset_, field_id) &&
             !get_bit(index_ready_bitset_, field_id)) {
-            fill_empty_field(field_meta);
+            if (!IsVectorDataType(field_meta.data_type)) {
+                fill_empty_field(field_meta);
+            }
         }
     }
 }

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -2162,7 +2162,7 @@ ChunkedSegmentSealedImpl::reopen(SchemaPtr sch) {
 
     auto absent_fields = sch->absent_fields(*schema_);
     for (const auto& field_meta : *absent_fields) {
-        if (!IsVectorDataType(field_meta.data_type)) {
+        if (!IsVectorDataType(field_meta.get_data_type())) {
             fill_empty_field(field_meta);
         }
     }
@@ -2180,7 +2180,7 @@ ChunkedSegmentSealedImpl::finish_load() {
         // this shall check the ready bitset here
         if (!get_bit(field_data_ready_bitset_, field_id) &&
             !get_bit(index_ready_bitset_, field_id)) {
-            if (!IsVectorDataType(field_meta.data_type)) {
+            if (!IsVectorDataType(field_meta.get_data_type())) {
                 fill_empty_field(field_meta);
             }
         }

--- a/internal/core/src/storage/Util.h
+++ b/internal/core/src/storage/Util.h
@@ -57,6 +57,19 @@ CreateArrowBuilder(DataType data_type);
 std::shared_ptr<arrow::ArrayBuilder>
 CreateArrowBuilder(DataType data_type, int dim);
 
+/// \brief Utility function to create arrow:Scalar from FieldMeta.default_value
+///
+/// Construct a arrow::Scalar based on input field meta
+/// The data_type_ is checked to determine which `one_of` member of default value shall be used
+/// Note that:
+/// 1. default_value shall have value
+/// 2. the type check shall be guaranteed(current by go side)
+///
+/// \param[in] field_meta the field meta object to construct arrow::Scalar from.
+/// \return an std::shared_ptr of arrow::Scalar
+std::shared_ptr<arrow::Scalar>
+CreateArrowScalarFromDefaultValue(const FieldMeta& field_meta);
+
 std::shared_ptr<arrow::Schema>
 CreateArrowSchema(DataType data_type, bool nullable);
 

--- a/internal/core/unittest/test_storage.cpp
+++ b/internal/core/unittest/test_storage.cpp
@@ -12,12 +12,14 @@
 #include <gtest/gtest.h>
 
 #include <iostream>
+#include <optional>
 #include <random>
 #include <string>
 #include <vector>
 #include "common/EasyAssert.h"
 #include "storage/LocalChunkManagerSingleton.h"
 #include "storage/RemoteChunkManagerSingleton.h"
+#include "storage/Util.h"
 #include "storage/storage_c.h"
 
 #define private public
@@ -109,4 +111,91 @@ TEST_F(StorageTest, InitChunkCacheSingleton) {
 
 TEST_F(StorageTest, CleanRemoteChunkManagerSingleton) {
     CleanRemoteChunkManagerSingleton();
+}
+
+class StorageUtilTest : public testing::Test {
+ public:
+    StorageUtilTest() = default;
+    ~StorageUtilTest() {
+    }
+    void
+    SetUp() override {
+    }
+};
+
+TEST_F(StorageUtilTest, CreateArrowScalarFromDefaultValue) {
+    {
+        FieldMeta field_without_defval(
+            FieldName("f"), FieldId(100), DataType::INT64, false, std::nullopt);
+        ASSERT_ANY_THROW(
+            CreateArrowScalarFromDefaultValue(field_without_defval));
+    }
+    {
+        DefaultValueType default_value;
+        default_value.set_int_data(10);
+        FieldMeta int_field(FieldName("f"),
+                            FieldId(100),
+                            DataType::INT32,
+                            false,
+                            default_value);
+        auto scalar = CreateArrowScalarFromDefaultValue(int_field);
+        ASSERT_TRUE(scalar->Equals(*arrow::MakeScalar(int32_t(10))));
+    }
+    {
+        DefaultValueType default_value;
+        default_value.set_long_data(10);
+        FieldMeta long_field(FieldName("f"),
+                             FieldId(100),
+                             DataType::INT64,
+                             false,
+                             default_value);
+        auto scalar = CreateArrowScalarFromDefaultValue(long_field);
+        ASSERT_TRUE(scalar->Equals(*arrow::MakeScalar(int64_t(10))));
+    }
+    {
+        DefaultValueType default_value;
+        default_value.set_float_data(1.0f);
+        FieldMeta float_field(FieldName("f"),
+                              FieldId(100),
+                              DataType::FLOAT,
+                              false,
+                              default_value);
+        auto scalar = CreateArrowScalarFromDefaultValue(float_field);
+        ASSERT_TRUE(scalar->ApproxEquals(*arrow::MakeScalar(1.0f)));
+    }
+    {
+        DefaultValueType default_value;
+        default_value.set_double_data(1.0f);
+        FieldMeta double_field(FieldName("f"),
+                               FieldId(100),
+                               DataType::DOUBLE,
+                               false,
+                               default_value);
+        auto scalar = CreateArrowScalarFromDefaultValue(double_field);
+        ASSERT_TRUE(scalar->ApproxEquals(arrow::DoubleScalar(1.0f)));
+    }
+    {
+        DefaultValueType default_value;
+        default_value.set_bool_data(true);
+        FieldMeta bool_field(
+            FieldName("f"), FieldId(100), DataType::BOOL, false, default_value);
+        auto scalar = CreateArrowScalarFromDefaultValue(bool_field);
+        ASSERT_TRUE(scalar->Equals(*arrow::MakeScalar(true)));
+    }
+    {
+        DefaultValueType default_value;
+        default_value.set_string_data("bar");
+        FieldMeta varchar_field(FieldName("f"),
+                                FieldId(100),
+                                DataType::VARCHAR,
+                                false,
+                                default_value);
+        auto scalar = CreateArrowScalarFromDefaultValue(varchar_field);
+        ASSERT_TRUE(scalar->Equals(*arrow::MakeScalar("bar")));
+    }
+    {
+        FieldMeta unsupport_field(
+            FieldName("f"), FieldId(100), DataType::JSON, false, std::nullopt);
+        ASSERT_ANY_THROW(CreateArrowScalarFromDefaultValue(unsupport_field));
+    }
 }


### PR DESCRIPTION
Related to #39718

This patch make reopen sealed segment use default value if set when reopening it instead of always null.