### PR TITLE
fix: [2.5] bulk insert should use function runner's input field list instead schema's

### DIFF
--- a/internal/datanode/importv2/util.go
+++ b/internal/datanode/importv2/util.go
@@ -214,8 +214,10 @@ func RunEmbeddingFunction(task *ImportTask, data *storage.InsertData) error {
 		if err != nil {
 			return err
 		}
-		inputDatas := make([]any, 0, len(fn.InputFieldIds))
-		for _, inputFieldID := range fn.InputFieldIds {
+
+		inputFieldIDs := lo.Map(runner.GetInputFields(), func(field *schemapb.FieldSchema, _ int) int64 { return field.GetFieldID() })
+		inputDatas := make([]any, 0, len(inputFieldIDs))
+		for _, inputFieldID := range inputFieldIDs {
 			inputDatas = append(inputDatas, data.Data[inputFieldID].GetDataRows())
 		}
 		outputFieldData, err := runner.BatchRun(inputDatas...)


### PR DESCRIPTION
relate: https://github.com/milvus-io/milvus/issues/41213
pr: https://github.com/milvus-io/milvus/pull/41560