### PR TITLE
enhance: [GoSDK] Make all valid normal column compactible with nullable

### DIFF
--- a/client/milvusclient/read_options.go
+++ b/client/milvusclient/read_options.go
@@ -441,7 +441,12 @@ func (opt *hybridSearchOption) WithConsistencyLevel(cl entity.ConsistencyLevel) 
 	return opt
 }
 
+// Deprecated: typo, use WithPartitions instead
 func (opt *hybridSearchOption) WithPartitons(partitions ...string) *hybridSearchOption {
+	return opt.WithPartitions(partitions...)
+}
+
+func (opt *hybridSearchOption) WithPartitions(partitions ...string) *hybridSearchOption {
 	opt.partitionNames = partitions
 	return opt
 }

--- a/client/milvusclient/write_options.go
+++ b/client/milvusclient/write_options.go
@@ -91,6 +91,10 @@ func (opt *columnBasedDataOption) processInsertColumns(colSchema *entity.Schema,
 			dynamicColumns = append(dynamicColumns, col)
 			continue
 		}
+		// make non-nullable created column fit nullable field definition
+		if field.Nullable {
+			col.SetNullable(true)
+		}
 
 		mNameColumn[col.Name()] = col
 		if col.Type() != field.DataType {


### PR DESCRIPTION
Related to #41413

This PR
- Make normal columns treated as all valid data when insert into nullable field
- Fix the typo of `WithPartitions` of HybridSearchOption