### PR TITLE
fix: GetValueFromConfig return nullopt instead of exception for null value

### DIFF
--- a/internal/core/src/index/Utils.h
+++ b/internal/core/src/index/Utils.h
@@ -84,6 +84,9 @@ template <typename T>
 inline std::optional<T>
 GetValueFromConfig(const Config& cfg, const std::string& key) {
     if (cfg.contains(key)) {
+        if (cfg.at(key).is_null()) {
+            return std::nullopt;
+        }
         try {
             // compatibility for boolean string
             if constexpr (std::is_same_v<T, bool>) {

--- a/internal/core/unittest/test_c_api.cpp
+++ b/internal/core/unittest/test_c_api.cpp
@@ -4600,7 +4600,7 @@ TEST(CApiTest, IsLoadWithDisk) {
 
 TEST(CApiTest, TestGetValueFromConfig) {
     nlohmann::json cfg = nlohmann::json::parse(
-        R"({"a" : 100, "b" : true, "c" : "true", "d" : 1.234})");
+        R"({"a" : 100, "b" : true, "c" : "true", "d" : 1.234, "e" : null})");
     auto a_value = GetValueFromConfig<int64_t>(cfg, "a");
     ASSERT_EQ(a_value.value(), 100);
 
@@ -4621,4 +4621,7 @@ TEST(CApiTest, TestGetValueFromConfig) {
                       std::string::npos,
                   true);
     }
+
+    auto e_value = GetValueFromConfig<std::string>(cfg, "e");
+    ASSERT_FALSE(e_value.has_value());
 }


### PR DESCRIPTION
#41707