### PR TITLE
fix: support infix and suffix match types in JsonStats

### DIFF
--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -1247,8 +1247,6 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJsonForIndex() {
                         CompareValueWithOpType(type, value, val, op_type);
                     case proto::plan::NotEqual:
                         CompareValueWithOpType(type, value, val, op_type);
-                    case proto::plan::PrefixMatch:
-                    case proto::plan::Match:
                     default:
                         return false;
                 }
@@ -1378,6 +1376,8 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJsonForIndex() {
                                 }
                             }
                         }
+                    case proto::plan::InnerMatch:
+                    case proto::plan::PostfixMatch:
                     case proto::plan::PrefixMatch:
                         if constexpr (std::is_same_v<GetType,
                                                      proto::plan::Array>) {


### PR DESCRIPTION
fix: support infix and suffix match types in JsonStats
issue:https://github.com/milvus-io/milvus/issues/41386