### PR TITLE
enhance: add pulsar truncate api to protect pulsar unconsumed message

### DIFF
--- a/pkg/streaming/walimpls/impls/kafka/wal.go
+++ b/pkg/streaming/walimpls/impls/kafka/wal.go
@@ -104,6 +104,9 @@ func (w *walImpl) Read(ctx context.Context, opt walimpls.ReadOption) (s walimpls
 }
 
 func (w *walImpl) Truncate(ctx context.Context, id message.MessageID) error {
+	if w.Channel().AccessMode != types.AccessModeRW {
+		panic("truncate on a wal that is not in read-write mode")
+	}
 	return nil
 }
 

--- a/pkg/streaming/walimpls/impls/pulsar/wal.go
+++ b/pkg/streaming/walimpls/impls/pulsar/wal.go
@@ -77,7 +77,20 @@ func (w *walImpl) Read(ctx context.Context, opt walimpls.ReadOption) (s walimpls
 }
 
 func (w *walImpl) Truncate(ctx context.Context, id message.MessageID) error {
-	return nil
+	if w.Channel().AccessMode != types.AccessModeRW {
+		panic("truncate on a wal that is not in read-write mode")
+	}
+	cursor, err := w.c.Subscribe(pulsar.ConsumerOptions{
+		Topic:                    w.Channel().Name,
+		SubscriptionName:         truncateCursorSubscriptionName,
+		Type:                     pulsar.Exclusive,
+		MaxPendingChunkedMessage: 1,
+	})
+	if err != nil {
+		return err
+	}
+	defer cursor.Close()
+	return cursor.Seek(id.(pulsarID).PulsarID())
 }
 
 func (w *walImpl) Close() {

--- a/pkg/streaming/walimpls/impls/rmq/wal.go
+++ b/pkg/streaming/walimpls/impls/rmq/wal.go
@@ -105,6 +105,9 @@ func (w *walImpl) Read(ctx context.Context, opt walimpls.ReadOption) (s walimpls
 }
 
 func (w *walImpl) Truncate(ctx context.Context, id message.MessageID) error {
+	if w.Channel().AccessMode != types.AccessModeRW {
+		panic("truncate on a wal that is not in read-write mode")
+	}
 	return nil
 }
 

--- a/pkg/streaming/walimpls/impls/walimplstest/wal.go
+++ b/pkg/streaming/walimpls/impls/walimplstest/wal.go
@@ -57,6 +57,9 @@ func (w *walImpls) Read(ctx context.Context, opts walimpls.ReadOption) (walimpls
 }
 
 func (w *walImpls) Truncate(ctx context.Context, id message.MessageID) error {
+	if w.Channel().AccessMode != types.AccessModeRW {
+		panic("truncate on a wal that is not in read-write mode")
+	}
 	return nil
 }
 

--- a/pkg/streaming/walimpls/impls/wp/wal.go
+++ b/pkg/streaming/walimpls/impls/wp/wal.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/milvus-io/milvus/pkg/v2/proto/streamingpb"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v2/streaming/util/types"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/walimpls"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/walimpls/helper"
 )
@@ -25,6 +26,10 @@ func (w *walImpl) WALName() string {
 }
 
 func (w *walImpl) Append(ctx context.Context, msg message.MutableMessage) (message.MessageID, error) {
+	if w.Channel().AccessMode != types.AccessModeRW {
+		panic("write on a wal that is not in read-write mode")
+	}
+
 	r := w.p.Write(ctx,
 		&wp.WriterMessage{
 			Payload:    msg.Payload(),
@@ -70,7 +75,10 @@ func (w *walImpl) Read(ctx context.Context, opt walimpls.ReadOption) (walimpls.S
 }
 
 func (w *walImpl) Truncate(ctx context.Context, id message.MessageID) error {
-	return w.l.Truncate(ctx, id.(*wpID).logMsgId)
+	if w.Channel().AccessMode != types.AccessModeRW {
+		panic("truncate on a wal that is not in read-write mode")
+	}
+	return w.l.Truncate(ctx, id.(wpID).logMsgId)
 }
 
 func (w *walImpl) Close() {


### PR DESCRIPTION
issue: #41465

- implement truncate api for pulsar based on durable subscription.
- truncate api can only be called if wal is read-write.