### PR TITLE
enhance: [2.5] Add mutex preventing concurrent plugin.Open (#41761)

### DIFF
--- a/internal/querynodev2/server.go
+++ b/internal/querynodev2/server.go
@@ -57,6 +57,7 @@ import (
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/dependency"
+	"github.com/milvus-io/milvus/internal/util/hookutil"
 	"github.com/milvus-io/milvus/internal/util/initcore"
 	"github.com/milvus-io/milvus/internal/util/searchutil/optimizers"
 	"github.com/milvus-io/milvus/internal/util/searchutil/scheduler"
@@ -568,6 +569,8 @@ func (node *QueryNode) initHook() error {
 	}
 	log.Info("start to load plugin", zap.String("path", path))
 
+	hookutil.LockHookInit()
+	defer hookutil.UnlockHookInit()
 	p, err := plugin.Open(path)
 	if err != nil {
 		return fmt.Errorf("fail to open the plugin, error: %s", err.Error())

--- a/internal/util/hookutil/hook.go
+++ b/internal/util/hookutil/hook.go
@@ -73,6 +73,8 @@ func initHook() error {
 	}
 
 	log.Info("start to load plugin", zap.String("path", path))
+	LockHookInit()
+	defer UnlockHookInit()
 	p, err := plugin.Open(path)
 	if err != nil {
 		return fmt.Errorf("fail to open the plugin, error: %s", err.Error())

--- a/internal/util/hookutil/mutex.go
+++ b/internal/util/hookutil/mutex.go
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the LF AI & Data foundation under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package hookutil
+
+import "sync"
+
+// initMutex shall protect the call of plugin.Open(...)
+// there might be concurrent issue for opening go plugin
+// causing empty pluginpath panicking
+var initMutex sync.Mutex
+
+func LockHookInit() {
+	initMutex.Lock()
+}
+
+func UnlockHookInit() {
+	initMutex.Unlock()
+}


### PR DESCRIPTION
Cherry pick from master
pr: #41761 
Concurrent calling plugin.Open might cause empty pluginpath issue