### PR TITLE
fix: exclude L0 segments from num_entities metrics

### DIFF
--- a/internal/querynodev2/segments/segment_filter.go
+++ b/internal/querynodev2/segments/segment_filter.go
@@ -140,3 +140,10 @@ func WithLevel(level datapb.SegmentLevel) SegmentFilter {
 		return segment.Level() == level
 	})
 }
+
+// to filter out all segment without L0
+func WithoutL0() SegmentFilter {
+	return SegmentFilterFunc(func(segment Segment) bool {
+		return segment.Level() != datapb.SegmentLevel_L0
+	})
+}


### PR DESCRIPTION
issue: #41794
pr: #41795
- Add WithoutL0 filter to exclude L0 segments when calculating num_entities metrics
- Add comment to explain L0 segments behavior in num_entities metrics