### PR TITLE
fix: unexpected password for root user

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -875,7 +875,9 @@ common:
     # The superusers will ignore some system check processes,
     # like the old password verification when updating the credential
     superUsers: 
-    defaultRootPassword: "Milvus" # default password for root user. The maximum length is 72 characters, and double quotes are required.
+    # default password for root user. The maximum length is 72 characters. 
+    # Large numeric passwords require double quotes to avoid yaml parsing precision issues.
+    defaultRootPassword: Milvus
     rootShouldBindRole: false # Whether the root user should bind a role when the authorization is enabled.
     enablePublicPrivilege: true # Whether to enable public privilege
     rbac:

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -675,10 +675,11 @@ like the old password verification when updating the credential`,
 	p.SuperUsers.Init(base.mgr)
 
 	p.DefaultRootPassword = ParamItem{
-		Key:          "common.security.defaultRootPassword",
-		Version:      "2.4.7",
-		Doc:          "default password for root user. The maximum length is 72 characters, and double quotes are required.",
-		DefaultValue: "\"Milvus\"",
+		Key:     "common.security.defaultRootPassword",
+		Version: "2.4.7",
+		Doc: `default password for root user. The maximum length is 72 characters. 
+Large numeric passwords require double quotes to avoid yaml parsing precision issues.`,
+		DefaultValue: "Milvus",
 		Export:       true,
 	}
 	p.DefaultRootPassword.Init(base.mgr)


### PR DESCRIPTION
issue: #41816 
pr #37983 introduced an issue, if doesn't specified `defaultRootPassword` in milvus.yaml, then `"Milvus"` will be used as default password for root user, instead of `Milvus`.

This PR fix the unexpected password for root, and add comment for case which use large numeric password requires double quotes.