### PR TITLE
test: fix: resolve Python Logger warnings

### DIFF
--- a/tests/python_client/chaos/checker.py
+++ b/tests/python_client/chaos/checker.py
@@ -38,7 +38,7 @@ def get_chaos_info():
         with open(constants.CHAOS_INFO_SAVE_PATH, 'r') as f:
             chaos_info = json.load(f)
     except Exception as e:
-        log.warn(f"get_chaos_info error: {e}")
+        log.warning(f"get_chaos_info error: {e}")
         return None
     return chaos_info
 

--- a/tests/python_client/chaos/testcases/test_concurrent_operation_for_multi_tenancy.py
+++ b/tests/python_client/chaos/testcases/test_concurrent_operation_for_multi_tenancy.py
@@ -24,7 +24,7 @@ def get_all_collections():
             data = json.load(f)
             all_collections = data["all"]
     except Exception as e:
-        log.warn(f"get_all_collections error: {e}")
+        log.warning(f"get_all_collections error: {e}")
         return [None]
     return all_collections
 

--- a/tests/python_client/testcases/test_concurrent.py
+++ b/tests/python_client/testcases/test_concurrent.py
@@ -27,7 +27,7 @@ def get_all_collections():
             data = json.load(f)
             all_collections = data["all"]
     except Exception as e:
-        log.warn(f"get_all_collections error: {e}")
+        log.warning(f"get_all_collections error: {e}")
         return [None]
     return all_collections
 


### PR DESCRIPTION
# PR Summary
This PR resolves the deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```