### PR TITLE
fix: prevent crash when contains_all/any is used with empty array

### DIFF
--- a/internal/core/unittest/test_array_inverted_index.cpp
+++ b/internal/core/unittest/test_array_inverted_index.cpp
@@ -164,6 +164,10 @@ TYPED_TEST_P(ArrayInvertedIndexTest, ArrayContainsAny) {
     auto ref = [this, &elems](size_t offset) -> bool {
         std::unordered_set<TypeParam> row(this->vec_of_array_[offset].begin(),
                                           this->vec_of_array_[offset].end());
+        if (elems.empty()) {
+            return true;
+        }
+
         for (const auto& elem : elems) {
             if (row.find(elem) != row.end()) {
                 return true;
@@ -212,6 +216,10 @@ TYPED_TEST_P(ArrayInvertedIndexTest, ArrayContainsAll) {
     auto ref = [this, &elems](size_t offset) -> bool {
         std::unordered_set<TypeParam> row(this->vec_of_array_[offset].begin(),
                                           this->vec_of_array_[offset].end());
+        if (elems.empty()) {
+            return true;
+        }
+
         for (const auto& elem : elems) {
             if (row.find(elem) == row.end()) {
                 return false;


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/41348

related and optimized by https://github.com/milvus-io/milvus/pull/41347

master pr: https://github.com/milvus-io/milvus/pull/41739
2.5 pr: #41756 