### PR TITLE
enhance: [StorageV2] fix issues integrating basic RW operations

### DIFF
--- a/internal/core/src/mmap/ChunkedColumnGroup.h
+++ b/internal/core/src/mmap/ChunkedColumnGroup.h
@@ -378,7 +378,7 @@ class ProxyChunkColumn : public ChunkedColumnInterface {
  private:
     std::shared_ptr<ChunkedColumnGroup> group_;
     FieldId field_id_;
-    const FieldMeta& field_meta_;
+    const FieldMeta field_meta_;
     DataType data_type_;
 };
 

--- a/internal/core/src/segcore/load_field_data_c.cpp
+++ b/internal/core/src/segcore/load_field_data_c.cpp
@@ -19,9 +19,11 @@
 #include "segcore/load_field_data_c.h"
 
 CStatus
-NewLoadFieldDataInfo(CLoadFieldDataInfo* c_load_field_data_info) {
+NewLoadFieldDataInfo(CLoadFieldDataInfo* c_load_field_data_info,
+                     int64_t storage_version) {
     try {
         auto load_field_data_info = std::make_unique<LoadFieldDataInfo>();
+        load_field_data_info->storage_version = storage_version;
         *c_load_field_data_info = load_field_data_info.release();
         return milvus::SuccessCStatus();
     } catch (std::exception& e) {

--- a/internal/core/src/segcore/load_field_data_c.h
+++ b/internal/core/src/segcore/load_field_data_c.h
@@ -26,7 +26,8 @@ extern "C" {
 typedef void* CLoadFieldDataInfo;
 
 CStatus
-NewLoadFieldDataInfo(CLoadFieldDataInfo* c_load_field_data_info);
+NewLoadFieldDataInfo(CLoadFieldDataInfo* c_load_field_data_info,
+                     int64_t storage_version);
 
 void
 DeleteLoadFieldDataInfo(CLoadFieldDataInfo c_load_field_data_info);

--- a/internal/core/src/segcore/packed_writer_c.cpp
+++ b/internal/core/src/segcore/packed_writer_c.cpp
@@ -52,6 +52,7 @@ NewPackedWriter(struct ArrowSchema* schema,
 
         auto writer = std::make_unique<milvus_storage::PackedRecordBatchWriter>(
             trueFs, truePaths, trueSchema, conf, columnGroups, buffer_size);
+        AssertInfo(writer, "write must not be null");
 
         *c_packed_writer = writer.release();
         return milvus::SuccessCStatus();

--- a/internal/core/thirdparty/milvus-storage/CMakeLists.txt
+++ b/internal/core/thirdparty/milvus-storage/CMakeLists.txt
@@ -14,7 +14,7 @@
 # Update milvus-storage_VERSION for the first occurrence
 milvus_add_pkg_config("milvus-storage")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( milvus-storage_VERSION d143229 )
+set( milvus-storage_VERSION 7adf4bd )
 set( GIT_REPOSITORY  "https://github.com/milvus-io/milvus-storage.git")
 message(STATUS "milvus-storage repo: ${GIT_REPOSITORY}")
 message(STATUS "milvus-storage version: ${milvus-storage_VERSION}")

--- a/internal/datanode/compactor/segment_writer.go
+++ b/internal/datanode/compactor/segment_writer.go
@@ -170,8 +170,10 @@ func (w *MultiSegmentWriter) rotateWriter() error {
 		}),
 		storage.WithVersion(w.storageVersion),
 	)
+	// TODO bucketName shall be passed via StorageConfig like index/stats task
+	bucketName := paramtable.Get().ServiceParam.MinioCfg.BucketName.GetValue()
 	rw, err := storage.NewBinlogRecordWriter(w.ctx, w.collectionID, w.partitionID, newSegmentID,
-		w.schema, w.allocator.logIDAlloc, chunkSize, rootPath, w.maxRows, w.rwOption...,
+		w.schema, w.allocator.logIDAlloc, chunkSize, bucketName, rootPath, w.maxRows, w.rwOption...,
 	)
 	if err != nil {
 		return err

--- a/internal/datanode/index/task_stats.go
+++ b/internal/datanode/index/task_stats.go
@@ -180,7 +180,8 @@ func (st *statsTask) sort(ctx context.Context) ([]*datapb.FieldBinlog, error) {
 		st.req.GetSchema(),
 		alloc,
 		st.req.GetBinlogMaxSize(),
-		st.req.GetStorageConfig().RootPath,
+		st.req.GetStorageConfig().GetBucketName(),
+		st.req.GetStorageConfig().GetRootPath(),
 		numRows,
 		storage.WithUploader(func(ctx context.Context, kvs map[string][]byte) error {
 			return st.binlogIO.Upload(ctx, kvs)
@@ -229,7 +230,9 @@ func (st *statsTask) sort(ctx context.Context) ([]*datapb.FieldBinlog, error) {
 
 	rr, err := storage.NewBinlogRecordReader(ctx, st.req.InsertLogs, st.req.Schema,
 		storage.WithVersion(st.req.StorageVersion),
-		storage.WithDownloader(st.binlogIO.Download))
+		storage.WithDownloader(st.binlogIO.Download),
+		storage.WithBucketName(st.req.StorageConfig.BucketName),
+	)
 	if err != nil {
 		log.Warn("error creating insert binlog reader", zap.Error(err))
 		return nil, err

--- a/internal/datanode/index_services.go
+++ b/internal/datanode/index_services.go
@@ -258,6 +258,7 @@ func (node *DataNode) CreateJobV2(ctx context.Context, req *workerpb.CreateJobV2
 			zap.String("fieldType", indexRequest.GetFieldType().String()),
 			zap.Any("field", indexRequest.GetField()),
 			zap.Int64("taskSlot", indexRequest.GetTaskSlot()),
+			zap.Int64("lackBinlogRows", indexRequest.GetLackBinlogRows()),
 		)
 		taskCtx, taskCancel := context.WithCancel(node.ctx)
 		if oldInfo := node.taskManager.LoadOrStoreIndexTask(indexRequest.GetClusterID(), indexRequest.GetBuildID(), &index.IndexTaskInfo{

--- a/internal/flushcommon/syncmgr/pack_writer_v2.go
+++ b/internal/flushcommon/syncmgr/pack_writer_v2.go
@@ -37,6 +37,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/util/metautil"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/retry"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
@@ -135,7 +136,9 @@ func (bw *BulkPackWriterV2) writeInserts(ctx context.Context, pack *SyncPack) (m
 		}
 	}
 
-	w, err := storage.NewPackedRecordWriter(paths, bw.schema, bw.bufferSize, bw.multiPartUploadSize, columnGroups)
+	bucketName := paramtable.Get().ServiceParam.MinioCfg.BucketName.GetValue()
+
+	w, err := storage.NewPackedRecordWriter(bucketName, paths, bw.schema, bw.bufferSize, bw.multiPartUploadSize, columnGroups)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/flushcommon/writebuffer/write_buffer.go
+++ b/internal/flushcommon/writebuffer/write_buffer.go
@@ -18,6 +18,7 @@ import (
 	"github.com/milvus-io/milvus/internal/flushcommon/metacache/pkoracle"
 	"github.com/milvus-io/milvus/internal/flushcommon/syncmgr"
 	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/internal/util/streamingutil"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/metrics"
@@ -599,7 +600,8 @@ func (wb *writeBufferBase) getSyncTask(ctx context.Context, segmentID int64) (sy
 		WithAllocator(wb.allocator).
 		WithMetaWriter(wb.metaWriter).
 		WithMetaCache(wb.metaCache).
-		WithSyncPack(pack)
+		WithSyncPack(pack).
+		WithMultiPartUploadSize(packed.DefaultMultiPartUploadSize)
 	return task, nil
 }
 

--- a/internal/querynodev2/handlers.go
+++ b/internal/querynodev2/handlers.go
@@ -84,17 +84,18 @@ func loadGrowingSegments(ctx context.Context, delegator delegator.ShardDelegator
 			}
 			if len(segmentInfo.GetBinlogs()) > 0 {
 				growingSegments = append(growingSegments, &querypb.SegmentLoadInfo{
-					SegmentID:     segmentInfo.ID,
-					Level:         segmentInfo.GetLevel(),
-					PartitionID:   segmentInfo.PartitionID,
-					CollectionID:  segmentInfo.CollectionID,
-					BinlogPaths:   segmentInfo.Binlogs,
-					NumOfRows:     segmentInfo.NumOfRows,
-					Statslogs:     segmentInfo.Statslogs,
-					Deltalogs:     segmentInfo.Deltalogs,
-					Bm25Logs:      segmentInfo.Bm25Statslogs,
-					InsertChannel: segmentInfo.InsertChannel,
-					StartPosition: segmentInfo.GetStartPosition(),
+					SegmentID:      segmentInfo.ID,
+					Level:          segmentInfo.GetLevel(),
+					PartitionID:    segmentInfo.PartitionID,
+					CollectionID:   segmentInfo.CollectionID,
+					BinlogPaths:    segmentInfo.Binlogs,
+					NumOfRows:      segmentInfo.NumOfRows,
+					Statslogs:      segmentInfo.Statslogs,
+					Deltalogs:      segmentInfo.Deltalogs,
+					Bm25Logs:       segmentInfo.Bm25Statslogs,
+					InsertChannel:  segmentInfo.InsertChannel,
+					StartPosition:  segmentInfo.GetStartPosition(),
+					StorageVersion: segmentInfo.GetStorageVersion(),
 				})
 			} else {
 				log.Info("skip segment which binlog is empty", zap.Int64("segmentID", segmentInfo.ID))

--- a/internal/querynodev2/segments/load_field_data_info.go
+++ b/internal/querynodev2/segments/load_field_data_info.go
@@ -37,7 +37,7 @@ func newLoadFieldDataInfo(ctx context.Context) (*LoadFieldDataInfo, error) {
 	var status C.CStatus
 	var cLoadFieldDataInfo C.CLoadFieldDataInfo
 	GetDynamicPool().Submit(func() (any, error) {
-		status = C.NewLoadFieldDataInfo(&cLoadFieldDataInfo)
+		status = C.NewLoadFieldDataInfo(&cLoadFieldDataInfo, C.int64_t(0))
 		return nil, nil
 	}).Await()
 	if err := HandleCStatus(ctx, &status, "newLoadFieldDataInfo failed"); err != nil {

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -741,8 +741,9 @@ func (s *LocalSegment) LoadMultiFieldData(ctx context.Context) error {
 	)
 
 	req := &segcore.LoadFieldDataRequest{
-		MMapDir:  paramtable.Get().QueryNodeCfg.MmapDirPath.GetValue(),
-		RowCount: rowCount,
+		MMapDir:        paramtable.Get().QueryNodeCfg.MmapDirPath.GetValue(),
+		RowCount:       rowCount,
+		StorageVersion: loadInfo.StorageVersion,
 	}
 	for _, field := range fields {
 		req.Fields = append(req.Fields, segcore.LoadFieldDataInfo{
@@ -803,7 +804,8 @@ func (s *LocalSegment) LoadFieldData(ctx context.Context, fieldID int64, rowCoun
 			Field:      field,
 			EnableMMap: mmapEnabled,
 		}},
-		RowCount: rowCount,
+		RowCount:       rowCount,
+		StorageVersion: s.LoadInfo().GetStorageVersion(),
 	}
 
 	GetLoadPool().Submit(func() (any, error) {

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -229,6 +229,17 @@ type segmentLoader struct {
 
 var _ Loader = (*segmentLoader)(nil)
 
+func addBucketNameStorageV2(segmentInfo *querypb.SegmentLoadInfo) {
+	if segmentInfo.GetStorageVersion() == 2 {
+		bucketName := paramtable.Get().ServiceParam.MinioCfg.BucketName.GetValue()
+		for _, fieldBinlog := range segmentInfo.GetBinlogPaths() {
+			for _, binlog := range fieldBinlog.GetBinlogs() {
+				binlog.LogPath = path.Join(bucketName, binlog.LogPath)
+			}
+		}
+	}
+}
+
 func (loader *segmentLoader) Load(ctx context.Context,
 	collectionID int64,
 	segmentType SegmentType,
@@ -244,6 +255,10 @@ func (loader *segmentLoader) Load(ctx context.Context,
 		log.Info("no segment to load")
 		return nil, nil
 	}
+	for _, segmentInfo := range segments {
+		addBucketNameStorageV2(segmentInfo)
+	}
+
 	coll := loader.manager.Collection.Get(collectionID)
 	// filter field schema which need to be loaded
 	for _, info := range segments {

--- a/internal/querynodev2/server.go
+++ b/internal/querynodev2/server.go
@@ -270,6 +270,11 @@ func (node *QueryNode) InitSegcore() error {
 		return err
 	}
 
+	err = initcore.InitStorageV2FileSystem(paramtable.Get())
+	if err != nil {
+		return err
+	}
+
 	err = initcore.InitMmapManager(paramtable.Get())
 	if err != nil {
 		return err

--- a/internal/storage/rw.go
+++ b/internal/storage/rw.go
@@ -31,6 +31,7 @@ import (
 	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
 
 const (
@@ -197,7 +198,11 @@ func NewBinlogRecordReader(ctx context.Context, binlogs []*datapb.FieldBinlog, s
 		paths := make([][]string, len(binlogLists[0]))
 		for _, binlogs := range binlogLists {
 			for j, binlog := range binlogs {
-				paths[j] = append(paths[j], path.Join(rwOptions.bucketName, binlog.GetLogPath()))
+				logPath := binlog.GetLogPath()
+				if paramtable.Get().CommonCfg.StorageType.GetValue() != "local" {
+					path.Join(rwOptions.bucketName, logPath)
+				}
+				paths[j] = append(paths[j], logPath)
 			}
 		}
 		return newPackedRecordReader(paths, schema, rwOptions.bufferSize)

--- a/internal/storage/rw_test.go
+++ b/internal/storage/rw_test.go
@@ -75,6 +75,7 @@ type PackedBinlogRecordSuite struct {
 	partitionID  UniqueID
 	segmentID    UniqueID
 	schema       *schemapb.CollectionSchema
+	bucketName   string
 	rootPath     string
 	maxRowNum    int64
 	chunkSize    uint64
@@ -93,6 +94,7 @@ func (s *PackedBinlogRecordSuite) SetupTest() {
 	s.segmentID = UniqueID(0)
 	s.schema = generateTestSchema()
 	s.rootPath = "/tmp"
+	s.bucketName = "a-bucket"
 	s.maxRowNum = int64(1000)
 	s.chunkSize = uint64(1024)
 }
@@ -128,7 +130,7 @@ func (s *PackedBinlogRecordSuite) TestPackedBinlogRecordIntegration() {
 		WithColumnGroups(columnGroups),
 	}
 
-	w, err := NewBinlogRecordWriter(s.ctx, s.collectionID, s.partitionID, s.segmentID, s.schema, s.logIDAlloc, s.chunkSize, s.rootPath, s.maxRowNum, wOption...)
+	w, err := NewBinlogRecordWriter(s.ctx, s.collectionID, s.partitionID, s.segmentID, s.schema, s.logIDAlloc, s.chunkSize, s.bucketName, s.rootPath, s.maxRowNum, wOption...)
 	s.NoError(err)
 
 	blobs, err := generateTestData(rows)
@@ -212,7 +214,7 @@ func (s *PackedBinlogRecordSuite) TestGenerateBM25Stats() {
 	rec, err := ValueSerializer([]*Value{v}, s.schema.Fields)
 	s.NoError(err)
 
-	w, err := NewBinlogRecordWriter(s.ctx, s.collectionID, s.partitionID, s.segmentID, s.schema, s.logIDAlloc, s.chunkSize, s.rootPath, s.maxRowNum, wOption...)
+	w, err := NewBinlogRecordWriter(s.ctx, s.collectionID, s.partitionID, s.segmentID, s.schema, s.logIDAlloc, s.chunkSize, s.bucketName, s.rootPath, s.maxRowNum, wOption...)
 	s.NoError(err)
 	err = w.Write(rec)
 	s.NoError(err)
@@ -233,7 +235,7 @@ func (s *PackedBinlogRecordSuite) TestUnsuportedStorageVersion() {
 	wOption := []RwOption{
 		WithVersion(-1),
 	}
-	_, err := NewBinlogRecordWriter(s.ctx, s.collectionID, s.partitionID, s.segmentID, s.schema, s.logIDAlloc, s.chunkSize, s.rootPath, s.maxRowNum, wOption...)
+	_, err := NewBinlogRecordWriter(s.ctx, s.collectionID, s.partitionID, s.segmentID, s.schema, s.logIDAlloc, s.chunkSize, s.bucketName, s.rootPath, s.maxRowNum, wOption...)
 	s.Error(err)
 
 	rOption := []RwOption{
@@ -252,7 +254,7 @@ func (s *PackedBinlogRecordSuite) TestNoPrimaryKeyError() {
 		WithVersion(StorageV2),
 		WithColumnGroups(columnGroups),
 	}
-	_, err := NewBinlogRecordWriter(s.ctx, s.collectionID, s.partitionID, s.segmentID, s.schema, s.logIDAlloc, s.chunkSize, s.rootPath, s.maxRowNum, wOption...)
+	_, err := NewBinlogRecordWriter(s.ctx, s.collectionID, s.partitionID, s.segmentID, s.schema, s.logIDAlloc, s.chunkSize, s.bucketName, s.rootPath, s.maxRowNum, wOption...)
 	s.Error(err)
 }
 
@@ -265,7 +267,7 @@ func (s *PackedBinlogRecordSuite) TestConvertArrowSchemaError() {
 		WithVersion(StorageV2),
 		WithColumnGroups(columnGroups),
 	}
-	_, err := NewBinlogRecordWriter(s.ctx, s.collectionID, s.partitionID, s.segmentID, s.schema, s.logIDAlloc, s.chunkSize, s.rootPath, s.maxRowNum, wOption...)
+	_, err := NewBinlogRecordWriter(s.ctx, s.collectionID, s.partitionID, s.segmentID, s.schema, s.logIDAlloc, s.chunkSize, s.bucketName, s.rootPath, s.maxRowNum, wOption...)
 	s.Error(err)
 }
 
@@ -284,7 +286,7 @@ func (s *PackedBinlogRecordSuite) TestAllocIDExhausedError() {
 		WithColumnGroups(columnGroups),
 	}
 	logIDAlloc := allocator.NewLocalAllocator(1, 1)
-	w, err := NewBinlogRecordWriter(s.ctx, s.collectionID, s.partitionID, s.segmentID, s.schema, logIDAlloc, s.chunkSize, s.rootPath, s.maxRowNum, wOption...)
+	w, err := NewBinlogRecordWriter(s.ctx, s.collectionID, s.partitionID, s.segmentID, s.schema, logIDAlloc, s.chunkSize, s.bucketName, s.rootPath, s.maxRowNum, wOption...)
 	s.NoError(err)
 
 	size := 10

--- a/internal/storage/rw_test.go
+++ b/internal/storage/rw_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/rootcoordpb"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/tsoutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
@@ -116,6 +117,7 @@ func genTestColumnGroups(schema *schemapb.CollectionSchema) []storagecommon.Colu
 }
 
 func (s *PackedBinlogRecordSuite) TestPackedBinlogRecordIntegration() {
+	paramtable.Get().Save(paramtable.Get().CommonCfg.StorageType.Key, "local")
 	s.mockBinlogIO.EXPECT().Upload(mock.Anything, mock.Anything).Return(nil)
 	rows := 10000
 	readBatchSize := 1024

--- a/internal/storage/serde_events_v2.go
+++ b/internal/storage/serde_events_v2.go
@@ -36,6 +36,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/proto/etcdpb"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/metautil"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
 
@@ -204,6 +205,9 @@ func NewPackedRecordWriter(bucketName string, paths []string, schema *schemapb.C
 	// compose true path before create packed writer here
 	// and returned writtenPaths shall remain untouched
 	truePaths := lo.Map(paths, func(p string, _ int) string {
+		if paramtable.Get().CommonCfg.StorageType.GetValue() == "local" {
+			return p
+		}
 		return path.Join(bucketName, p)
 	})
 	writer, err := packed.NewPackedWriter(truePaths, arrowSchema, bufferSize, multiPartUploadSize, columnGroups)

--- a/internal/storage/serde_events_v2_test.go
+++ b/internal/storage/serde_events_v2_test.go
@@ -31,7 +31,7 @@ func TestPackedSerde(t *testing.T) {
 		t.Skip("storage v2 cgo not ready yet")
 		initcore.InitLocalArrowFileSystem("/tmp")
 		size := 10
-
+		bucketName := "a-bucket"
 		paths := [][]string{{"/tmp/0"}, {"/tmp/1"}}
 		bufferSize := int64(10 * 1024 * 1024) // 10MB
 		schema := generateTestSchema()
@@ -49,7 +49,7 @@ func TestPackedSerde(t *testing.T) {
 			}
 			multiPartUploadSize := int64(0)
 			batchSize := 7
-			writer, err := NewPackedSerializeWriter(chunkPaths, generateTestSchema(), bufferSize, multiPartUploadSize, []storagecommon.ColumnGroup{group}, batchSize)
+			writer, err := NewPackedSerializeWriter(bucketName, chunkPaths, generateTestSchema(), bufferSize, multiPartUploadSize, []storagecommon.ColumnGroup{group}, batchSize)
 			assert.NoError(t, err)
 
 			for i := 1; i <= size; i++ {

--- a/internal/util/segcore/requests.go
+++ b/internal/util/segcore/requests.go
@@ -34,9 +34,10 @@ type DeleteRequest struct {
 }
 
 type LoadFieldDataRequest struct {
-	Fields   []LoadFieldDataInfo
-	MMapDir  string
-	RowCount int64
+	Fields         []LoadFieldDataInfo
+	MMapDir        string
+	RowCount       int64
+	StorageVersion int64
 }
 
 type LoadFieldDataInfo struct {
@@ -46,7 +47,7 @@ type LoadFieldDataInfo struct {
 
 func (req *LoadFieldDataRequest) getCLoadFieldDataRequest() (result *cLoadFieldDataRequest, err error) {
 	var cLoadFieldDataInfo C.CLoadFieldDataInfo
-	status := C.NewLoadFieldDataInfo(&cLoadFieldDataInfo)
+	status := C.NewLoadFieldDataInfo(&cLoadFieldDataInfo, C.int64_t(req.StorageVersion))
 	if err := ConsumeCStatusIntoError(&status); err != nil {
 		return nil, errors.Wrap(err, "NewLoadFieldDataInfo failed")
 	}


### PR DESCRIPTION
Related to #39173

This PR:
- Upgrade milvus-storage commit to fix filesystem finalized issue
- Add bucket-name as prefix for all fs style access io
- Initial arrow fs on querynodes startup
- Fix timestamp access when loading sealed segment