### PR TITLE
feat: manual evict cache after built interim index

### DIFF
--- a/internal/core/src/cachinglayer/CacheSlot.h
+++ b/internal/core/src/cachinglayer/CacheSlot.h
@@ -166,6 +166,25 @@ class CacheSlot final : public std::enable_shared_from_this<CacheSlot<CellT>> {
         });
     }
 
+    // Manually evicts the cell if it is not pinned.
+    // Returns true if the cell ends up in a state other than LOADED.
+    bool
+    ManualEvict(cid_t cid) {
+        return cells_[cid].manual_evict();
+    }
+
+    // Returns true if any cell is evicted.
+    bool
+    ManualEvictAll() {
+        bool evicted = false;
+        for (cid_t cid = 0; cid < cells_.size(); ++cid) {
+            if (cells_[cid].manual_evict()) {
+                evicted = true;
+            }
+        }
+        return evicted;
+    }
+
     size_t
     num_cells() const {
         return translator_->num_cells();

--- a/internal/core/src/cachinglayer/Translator.h
+++ b/internal/core/src/cachinglayer/Translator.h
@@ -25,6 +25,8 @@ struct Meta {
     // In actual resource reservation, we use the actual size of the cell to determine the type.
     StorageType storage_type;
     CacheWarmupPolicy cache_warmup_policy;
+    // Whether the translator supports strategy based eviction.
+    // Does not affect manual eviction.
     bool support_eviction;
     explicit Meta(StorageType storage_type,
                   CacheWarmupPolicy cache_warmup_policy,

--- a/internal/core/src/cachinglayer/lrucache/ListNode.h
+++ b/internal/core/src/cachinglayer/lrucache/ListNode.h
@@ -74,6 +74,11 @@ class ListNode {
     ResourceUsage&
     size();
 
+    // Manually evicts the cell if it is not pinned.
+    // Returns true if the cell ends up in a state other than LOADED.
+    bool
+    manual_evict();
+
     // TODO(tiered storage 1): pin on ERROR should re-trigger loading.
     // NOT_LOADED ---> LOADING ---> ERROR
     //      ^            |

--- a/internal/core/src/mmap/ChunkedColumn.h
+++ b/internal/core/src/mmap/ChunkedColumn.h
@@ -69,6 +69,11 @@ class ChunkedColumnBase : public ChunkedColumnInterface {
 
     virtual ~ChunkedColumnBase() = default;
 
+    void
+    ManualEvictCache() const override {
+        slot_->ManualEvictAll();
+    }
+
     PinWrapper<const char*>
     DataOfChunk(int chunk_id) const override {
         auto ca = SemiInlineGet(slot_->PinCells({chunk_id}));

--- a/internal/core/src/mmap/ChunkedColumnGroup.h
+++ b/internal/core/src/mmap/ChunkedColumnGroup.h
@@ -56,6 +56,11 @@ class ChunkedColumnGroup {
 
     virtual ~ChunkedColumnGroup() = default;
 
+    void
+    ManualEvictCache() const {
+        slot_->ManualEvictAll();
+    }
+
     // Get the number of group chunks
     size_t
     num_chunks() const {
@@ -94,6 +99,14 @@ class ChunkedColumnGroup {
         return meta->num_rows_until_chunk_;
     }
 
+    size_t
+    NumFieldsInGroup() const {
+        auto meta =
+            static_cast<milvus::segcore::storagev2translator::GroupCTMeta*>(
+                slot_->meta());
+        return meta->num_fields_;
+    }
+
  protected:
     mutable std::shared_ptr<CacheSlot<GroupChunk>> slot_;
     size_t num_chunks_{0};
@@ -109,6 +122,13 @@ class ProxyChunkColumn : public ChunkedColumnInterface {
           field_id_(field_id),
           field_meta_(field_meta),
           data_type_(field_meta.get_data_type()) {
+    }
+
+    void
+    ManualEvictCache() const override {
+        if (group_->NumFieldsInGroup() == 1) {
+            group_->ManualEvictCache();
+        }
     }
 
     PinWrapper<const char*>

--- a/internal/core/src/mmap/ChunkedColumnInterface.h
+++ b/internal/core/src/mmap/ChunkedColumnInterface.h
@@ -26,6 +26,10 @@ class ChunkedColumnInterface {
  public:
     virtual ~ChunkedColumnInterface() = default;
 
+    // Default implementation does nothing.
+    virtual void
+    ManualEvictCache() const {}
+
     // Get raw data pointer of a specific chunk
     virtual cachinglayer::PinWrapper<const char*>
     DataOfChunk(int chunk_id) const = 0;

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -1829,11 +1829,16 @@ ChunkedSegmentSealedImpl::load_field_data_common(
         insert_record_.seal_pks();
     }
 
-    generate_interim_index(field_id);
+    bool generated_interim_index = generate_interim_index(field_id);
 
     std::unique_lock lck(mutex_);
     set_bit(field_data_ready_bitset_, field_id, true);
     update_row_count(num_rows);
+    if (generated_interim_index) {
+        if (auto column = fields_.find(field_id); column != fields_.end()) {
+            column->second->ManualEvictCache();
+        }
+    }
 }
 
 void

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -409,7 +409,10 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     BitsetType index_ready_bitset_;
     BitsetType binlog_index_bitset_;
     std::atomic<int> system_ready_count_ = 0;
-    // segment data
+
+    // when index is ready (index_ready_bitset_/binlog_index_bitset_ is set to true), must also set index_has_raw_data_
+    // to indicate whether the loaded index has raw data.
+    std::unordered_map<FieldId, bool> index_has_raw_data_;
 
     // TODO: generate index for scalar
     std::optional<int64_t> num_rows_;

--- a/internal/core/src/segcore/storagev2translator/GroupCTMeta.h
+++ b/internal/core/src/segcore/storagev2translator/GroupCTMeta.h
@@ -22,11 +22,14 @@ namespace milvus::segcore::storagev2translator {
 struct GroupCTMeta : public milvus::cachinglayer::Meta {
     std::vector<int64_t> num_rows_until_chunk_;
     std::vector<int64_t> chunk_memory_size_;
-    GroupCTMeta(milvus::cachinglayer::StorageType storage_type,
+    size_t num_fields_;
+    GroupCTMeta(size_t num_fields,
+                milvus::cachinglayer::StorageType storage_type,
                 CacheWarmupPolicy cache_warmup_policy,
                 bool support_eviction)
         : milvus::cachinglayer::Meta(
-              storage_type, cache_warmup_policy, support_eviction) {
+              storage_type, cache_warmup_policy, support_eviction),
+          num_fields_(num_fields) {
     }
 };
 

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
@@ -52,6 +52,7 @@ GroupChunkTranslator::GroupChunkTranslator(
       row_group_meta_list_(row_group_meta_list),
       field_id_list_(field_id_list),
       meta_(
+          field_id_list.size(),
           use_mmap ? milvus::cachinglayer::StorageType::DISK
                    : milvus::cachinglayer::StorageType::MEMORY,
           // TODO(tiered storage 2): vector may be of small size and mixed with scalar, do we force it

--- a/internal/core/thirdparty/knowhere/CMakeLists.txt
+++ b/internal/core/thirdparty/knowhere/CMakeLists.txt
@@ -14,7 +14,7 @@
 # Update KNOWHERE_VERSION for the first occurrence
 milvus_add_pkg_config("knowhere")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( KNOWHERE_VERSION 5734ebe )
+set( KNOWHERE_VERSION 725c197 )
 set( GIT_REPOSITORY  "https://github.com/zilliztech/knowhere.git")
 message(STATUS "Knowhere repo: ${GIT_REPOSITORY}")
  message(STATUS "Knowhere version: ${KNOWHERE_VERSION}")

--- a/internal/core/unittest/test_cachinglayer/cachinglayer_test_utils.h
+++ b/internal/core/unittest/test_cachinglayer/cachinglayer_test_utils.h
@@ -100,13 +100,15 @@ class TestChunkTranslator : public Translator<milvus::Chunk> {
 
 class TestGroupChunkTranslator : public Translator<milvus::GroupChunk> {
  public:
-    TestGroupChunkTranslator(std::vector<int64_t> num_rows_per_chunk,
+    TestGroupChunkTranslator(size_t num_fields,
+                             std::vector<int64_t> num_rows_per_chunk,
                              std::string key,
                              std::vector<std::unique_ptr<GroupChunk>>&& chunks)
         : Translator<milvus::GroupChunk>(),
           num_cells_(num_rows_per_chunk.size()),
           chunks_(std::move(chunks)),
           meta_(segcore::storagev2translator::GroupCTMeta(
+              num_fields,
               StorageType::MEMORY,
               CacheWarmupPolicy::CacheWarmupPolicy_Disable,
               true)) {

--- a/internal/core/unittest/test_chunked_column_group.cpp
+++ b/internal/core/unittest/test_chunked_column_group.cpp
@@ -213,7 +213,7 @@ TEST_F(ChunkedColumnGroupTest, ChunkedColumnGroup) {
     std::vector<std::unique_ptr<GroupChunk>> group_chunks;
     group_chunks.push_back(std::move(group_chunk));
     auto translator = std::make_unique<TestGroupChunkTranslator>(
-        std::vector<int64_t>{5}, "test_key", std::move(group_chunks));
+        2, std::vector<int64_t>{5}, "test_key", std::move(group_chunks));
     auto column_group =
         std::make_shared<ChunkedColumnGroup>(std::move(translator));
 
@@ -250,7 +250,7 @@ TEST_F(ChunkedColumnGroupTest, ProxyChunkColumn) {
     std::vector<std::unique_ptr<GroupChunk>> group_chunks;
     group_chunks.push_back(std::move(group_chunk));
     auto translator = std::make_unique<TestGroupChunkTranslator>(
-        std::vector<int64_t>{5}, "test_key", std::move(group_chunks));
+        2, std::vector<int64_t>{5}, "test_key", std::move(group_chunks));
     auto column_group =
         std::make_shared<ChunkedColumnGroup>(std::move(translator));
 

--- a/internal/core/unittest/test_group_chunk_translator.cpp
+++ b/internal/core/unittest/test_group_chunk_translator.cpp
@@ -38,7 +38,7 @@ using namespace milvus;
 using namespace milvus::segcore;
 using namespace milvus::segcore::storagev2translator;
 
-class TestGroupChunkTranslator : public ::testing::TestWithParam<bool> {
+class GroupChunkTranslatorTest : public ::testing::TestWithParam<bool> {
     void
     SetUp() override {
         auto conf = milvus_storage::ArrowFileSystemConfig();
@@ -77,7 +77,7 @@ class TestGroupChunkTranslator : public ::testing::TestWithParam<bool> {
     }
 
  protected:
-    ~TestGroupChunkTranslator() {
+    ~GroupChunkTranslatorTest() {
         if (GetParam()) {  // if use_mmap is true
             std::string mmap_dir = std::to_string(segment_id_);
             if (std::filesystem::exists(mmap_dir)) {
@@ -95,7 +95,7 @@ class TestGroupChunkTranslator : public ::testing::TestWithParam<bool> {
     int64_t segment_id_ = 0;
 };
 
-TEST_P(TestGroupChunkTranslator, TestWithMmap) {
+TEST_P(GroupChunkTranslatorTest, TestWithMmap) {
     auto use_mmap = GetParam();
     std::unordered_map<FieldId, FieldMeta> field_metas = schema_->get_fields();
     auto column_group_info = FieldDataInfo(0, 3000, "");
@@ -157,6 +157,6 @@ TEST_P(TestGroupChunkTranslator, TestWithMmap) {
     }
 }
 
-INSTANTIATE_TEST_SUITE_P(TestGroupChunkTranslator,
-                         TestGroupChunkTranslator,
+INSTANTIATE_TEST_SUITE_P(GroupChunkTranslatorTest,
+                         GroupChunkTranslatorTest,
                          testing::Bool());

--- a/internal/core/unittest/test_regex_query.cpp
+++ b/internal/core/unittest/test_regex_query.cpp
@@ -248,9 +248,9 @@ class SealedSegmentRegexQueryTest : public ::testing::Test {
                 *(arr.mutable_data()->Add()) = raw_str[i];
             }
             auto index = index::CreateStringIndexSort();
-            std::vector<uint8_t> buffer(arr.ByteSize());
-            ASSERT_TRUE(arr.SerializeToArray(buffer.data(), arr.ByteSize()));
-            index->BuildWithRawDataForUT(arr.ByteSize(), buffer.data());
+            std::vector<uint8_t> buffer(arr.ByteSizeLong());
+            ASSERT_TRUE(arr.SerializeToArray(buffer.data(), arr.ByteSizeLong()));
+            index->BuildWithRawDataForUT(arr.ByteSizeLong(), buffer.data());
             LoadIndexInfo info{
                 .field_id = schema->get_field_id(FieldName("str")).get(),
                 .index_params = GenIndexParams(index.get()),
@@ -291,9 +291,9 @@ class SealedSegmentRegexQueryTest : public ::testing::Test {
             *(arr.mutable_data()->Add()) = raw_str[i];
         }
         auto index = std::make_unique<MockStringIndex>();
-        std::vector<uint8_t> buffer(arr.ByteSize());
-        ASSERT_TRUE(arr.SerializeToArray(buffer.data(), arr.ByteSize()));
-        index->BuildWithRawDataForUT(arr.ByteSize(), buffer.data());
+        std::vector<uint8_t> buffer(arr.ByteSizeLong());
+        ASSERT_TRUE(arr.SerializeToArray(buffer.data(), arr.ByteSizeLong()));
+        index->BuildWithRawDataForUT(arr.ByteSizeLong(), buffer.data());
         LoadIndexInfo info{
             .field_id = schema->get_field_id(FieldName("str")).get(),
             .index_params = GenIndexParams(index.get()),

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -60,7 +60,6 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/util/indexparams"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/metautil"
-	"github.com/milvus-io/milvus/pkg/v2/util/metric"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/timerecord"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
@@ -1067,23 +1066,6 @@ func (s *LocalSegment) innerLoadIndex(ctx context.Context,
 				return err
 			}
 			updateIndexInfoSpan := tr.RecordSpan()
-			// Skip warnup chunk cache when
-			// . scalar data
-			// . index has row data
-			// . vector was bm25 function output
-
-			if !typeutil.IsVectorType(fieldType) || s.HasRawData(indexInfo.GetFieldID()) {
-				return nil
-			}
-
-			metricType, err := funcutil.GetAttrByKeyFromRepeatedKV(common.MetricTypeKey, indexInfo.IndexParams)
-			if err != nil {
-				return errors.New("metric type not exist in index params")
-			}
-
-			if metricType == metric.BM25 {
-				return nil
-			}
 
 			log.Info("Finish loading index",
 				zap.Duration("newLoadIndexInfoSpan", newLoadIndexInfoSpan),


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/41435

this PR also makes HasRawData of ChunkedSegmentSealedImpl to return based on metadata, without needing to load the cache just to answer this simple question.