### PR TITLE
fix: [2.5] Fix import reader goroutine leak

### DIFF
--- a/internal/datanode/importv2/scheduler_test.go
+++ b/internal/datanode/importv2/scheduler_test.go
@@ -150,7 +150,7 @@ func (s *SchedulerSuite) TestScheduler_Start_Preimport() {
 	cm := mocks.NewChunkManager(s.T())
 	ioReader := strings.NewReader(string(bytes))
 	cm.EXPECT().Size(mock.Anything, mock.Anything).Return(1024, nil)
-	cm.EXPECT().Reader(mock.Anything, mock.Anything).Return(&mockReader{Reader: ioReader}, nil)
+	cm.EXPECT().Reader(mock.Anything, mock.Anything).Return(&mockReader{Reader: ioReader, Closer: io.NopCloser(ioReader)}, nil)
 	s.cm = cm
 
 	preimportReq := &datapb.PreImportRequest{
@@ -204,7 +204,7 @@ func (s *SchedulerSuite) TestScheduler_Start_Preimport_Failed() {
 	}
 	ioReader := strings.NewReader(string(bytes))
 	cm.EXPECT().Size(mock.Anything, mock.Anything).Return(1024, nil)
-	cm.EXPECT().Reader(mock.Anything, mock.Anything).Return(&mockReader{Reader: ioReader}, nil)
+	cm.EXPECT().Reader(mock.Anything, mock.Anything).Return(&mockReader{Reader: ioReader, Closer: io.NopCloser(ioReader)}, nil)
 	s.cm = cm
 
 	preimportReq := &datapb.PreImportRequest{
@@ -243,7 +243,7 @@ func (s *SchedulerSuite) TestScheduler_Start_Import() {
 
 	cm := mocks.NewChunkManager(s.T())
 	ioReader := strings.NewReader(string(bytes))
-	cm.EXPECT().Reader(mock.Anything, mock.Anything).Return(&mockReader{Reader: ioReader}, nil)
+	cm.EXPECT().Reader(mock.Anything, mock.Anything).Return(&mockReader{Reader: ioReader, Closer: io.NopCloser(ioReader)}, nil)
 	s.cm = cm
 
 	s.syncMgr.EXPECT().SyncData(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, task syncmgr.Task, callbacks ...func(error) error) (*conc.Future[struct{}], error) {
@@ -304,7 +304,7 @@ func (s *SchedulerSuite) TestScheduler_Start_Import_Failed() {
 
 	cm := mocks.NewChunkManager(s.T())
 	ioReader := strings.NewReader(string(bytes))
-	cm.EXPECT().Reader(mock.Anything, mock.Anything).Return(&mockReader{Reader: ioReader}, nil)
+	cm.EXPECT().Reader(mock.Anything, mock.Anything).Return(&mockReader{Reader: ioReader, Closer: io.NopCloser(ioReader)}, nil)
 	s.cm = cm
 
 	s.syncMgr.EXPECT().SyncData(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, task syncmgr.Task, callbacks ...func(error) error) (*conc.Future[struct{}], error) {

--- a/internal/util/importutilv2/binlog/reader.go
+++ b/internal/util/importutilv2/binlog/reader.go
@@ -126,6 +126,7 @@ func (r *reader) readDelete(deltaLogs []string, tsStart, tsEnd uint64) (map[any]
 		// no need to read nulls in DeleteEventType
 		rowsSet, _, err := readData(reader, storage.DeleteEventType)
 		if err != nil {
+			reader.Close()
 			return nil, err
 		}
 		for _, rows := range rowsSet {
@@ -133,6 +134,7 @@ func (r *reader) readDelete(deltaLogs []string, tsStart, tsEnd uint64) (map[any]
 				dl := &storage.DeleteLog{}
 				err = dl.Parse(row)
 				if err != nil {
+					reader.Close()
 					return nil, err
 				}
 				if dl.Ts >= tsStart && dl.Ts <= tsEnd {
@@ -143,6 +145,7 @@ func (r *reader) readDelete(deltaLogs []string, tsStart, tsEnd uint64) (map[any]
 				}
 			}
 		}
+		reader.Close()
 	}
 	return deleteData, nil
 }

--- a/internal/util/importutilv2/csv/reader.go
+++ b/internal/util/importutilv2/csv/reader.go
@@ -37,6 +37,7 @@ type Row = map[storage.FieldID]any
 type reader struct {
 	ctx    context.Context
 	cm     storage.ChunkManager
+	cmr    storage.FileReader
 	schema *schemapb.CollectionSchema
 
 	cr     *csv.Reader
@@ -74,6 +75,7 @@ func NewReader(ctx context.Context, cm storage.ChunkManager, schema *schemapb.Co
 	return &reader{
 		ctx:        ctx,
 		cm:         cm,
+		cmr:        cmReader,
 		schema:     schema,
 		cr:         csvReader,
 		parser:     rowParser,
@@ -120,7 +122,11 @@ func (r *reader) Read() (*storage.InsertData, error) {
 	return insertData, nil
 }
 
-func (r *reader) Close() {}
+func (r *reader) Close() {
+	if r.cmr != nil {
+		r.cmr.Close()
+	}
+}
 
 func (r *reader) Size() (int64, error) {
 	if size := r.fileSize.Load(); size != 0 {

--- a/internal/util/importutilv2/json/reader.go
+++ b/internal/util/importutilv2/json/reader.go
@@ -40,6 +40,7 @@ type Row = map[storage.FieldID]any
 type reader struct {
 	ctx    context.Context
 	cm     storage.ChunkManager
+	cmr    storage.FileReader
 	schema *schemapb.CollectionSchema
 
 	fileSize *atomic.Int64
@@ -65,6 +66,7 @@ func NewReader(ctx context.Context, cm storage.ChunkManager, schema *schemapb.Co
 	reader := &reader{
 		ctx:        ctx,
 		cm:         cm,
+		cmr:        r,
 		schema:     schema,
 		fileSize:   atomic.NewInt64(0),
 		filePath:   path,
@@ -180,4 +182,8 @@ func (j *reader) Size() (int64, error) {
 	return size, nil
 }
 
-func (j *reader) Close() {}
+func (j *reader) Close() {
+	if j.cmr != nil {
+		j.cmr.Close()
+	}
+}

--- a/internal/util/importutilv2/numpy/field_reader.go
+++ b/internal/util/importutilv2/numpy/field_reader.go
@@ -240,8 +240,6 @@ func (c *FieldReader) Next(count int64) (any, error) {
 	return data, nil
 }
 
-func (c *FieldReader) Close() {}
-
 // setByteOrder sets BigEndian/LittleEndian, the logic of this method is copied from npyio lib
 func (c *FieldReader) setByteOrder() {
 	var nativeEndian binary.ByteOrder

--- a/internal/util/importutilv2/parquet/field_reader.go
+++ b/internal/util/importutilv2/parquet/field_reader.go
@@ -199,8 +199,6 @@ func (c *FieldReader) Next(count int64) (any, any, error) {
 	}
 }
 
-func (c *FieldReader) Close() {}
-
 func ReadBoolData(pcr *FieldReader, count int64) (any, error) {
 	chunked, err := pcr.columnReader.NextBatch(count)
 	if err != nil {

--- a/internal/util/importutilv2/parquet/reader.go
+++ b/internal/util/importutilv2/parquet/reader.go
@@ -38,6 +38,7 @@ import (
 type reader struct {
 	ctx    context.Context
 	cm     storage.ChunkManager
+	cmr    storage.FileReader
 	schema *schemapb.CollectionSchema
 
 	path string
@@ -81,6 +82,7 @@ func NewReader(ctx context.Context, cm storage.ChunkManager, schema *schemapb.Co
 	return &reader{
 		ctx:        ctx,
 		cm:         cm,
+		cmr:        cmReader,
 		schema:     schema,
 		fileSize:   atomic.NewInt64(0),
 		path:       path,
@@ -140,11 +142,11 @@ func (r *reader) Size() (int64, error) {
 }
 
 func (r *reader) Close() {
-	for _, cr := range r.frs {
-		cr.Close()
-	}
 	err := r.r.Close()
 	if err != nil {
 		log.Warn("close parquet reader failed", zap.Error(err))
+	}
+	if r.cmr != nil {
+		r.cmr.Close()
 	}
 }


### PR DESCRIPTION
Close the chunk manager's reader after the import completes to prevent goroutine leaks.

issues: https://github.com/milvus-io/milvus/issues/41868

pr: https://github.com/milvus-io/milvus/pull/41869