### PR TITLE
fix: ChannelManager double assignment

### DIFF
--- a/internal/datacoord/channel.go
+++ b/internal/datacoord/channel.go
@@ -226,11 +226,9 @@ func (c *StateChannel) TransitionOnFailure(opID int64) {
 		return
 	}
 	switch c.currentState {
-	case Watching:
+	case Watching, Releasing, ToWatch:
 		c.setState(Standby)
-	case Releasing:
-		c.setState(Standby)
-	case Standby, ToWatch, Watched, ToRelease:
+	case Standby, Watched, ToRelease:
 		// Stay original state
 	}
 }

--- a/internal/datacoord/channel.go
+++ b/internal/datacoord/channel.go
@@ -22,10 +22,12 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/cockroachdb/errors"
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 )
 
 type ROChannel interface {
@@ -191,15 +193,30 @@ func NewStateChannelByWatchInfo(nodeID int64, info *datapb.ChannelWatchInfo) *St
 	return c
 }
 
-func (c *StateChannel) TransitionOnSuccess(opID int64) {
+func (c *StateChannel) TransitionState(err error, opID int64) {
 	if opID != c.Info.GetOpID() {
-		log.Warn("Try to transit on success but opID not match, stay original state ",
+		log.Warn("Try to transit state but opID not match, stay original state ",
 			zap.Any("currentState", c.currentState),
 			zap.String("channel", c.Name),
 			zap.Int64("target opID", opID),
 			zap.Int64("channel opID", c.Info.GetOpID()))
 		return
 	}
+
+	if err == nil {
+		c.transitionOnSuccess()
+		return
+	}
+
+	if errors.Is(err, merr.ErrChannelReduplicate) {
+		c.setState(ToRelease)
+		return
+	}
+
+	c.transitionOnFailure()
+}
+
+func (c *StateChannel) transitionOnSuccess() {
 	switch c.currentState {
 	case Standby:
 		c.setState(ToWatch)
@@ -216,15 +233,7 @@ func (c *StateChannel) TransitionOnSuccess(opID int64) {
 	}
 }
 
-func (c *StateChannel) TransitionOnFailure(opID int64) {
-	if opID != c.Info.GetOpID() {
-		log.Warn("Try to transit on failure but opID not match, stay original state",
-			zap.Any("currentState", c.currentState),
-			zap.String("channel", c.Name),
-			zap.Int64("target opID", opID),
-			zap.Int64("channel opID", c.Info.GetOpID()))
-		return
-	}
+func (c *StateChannel) transitionOnFailure() {
 	switch c.currentState {
 	case Watching, Releasing, ToWatch:
 		c.setState(Standby)

--- a/internal/datacoord/channel_manager.go
+++ b/internal/datacoord/channel_manager.go
@@ -156,14 +156,14 @@ func (m *ChannelManagerImpl) Startup(ctx context.Context, legacyNodes, allNodes 
 	m.mu.Lock()
 	nodeChannels := m.store.GetNodeChannelsBy(
 		WithAllNodes(),
-		func(ch *StateChannel) bool {
+		func(ch *StateChannel) bool { // Channel with drop-mark
 			return m.h.CheckShouldDropChannel(ch.GetName())
 		})
-	m.mu.Unlock()
 
 	for _, info := range nodeChannels {
 		m.finishRemoveChannel(info.NodeID, lo.Values(info.Channels)...)
 	}
+	m.mu.Unlock()
 
 	if m.balanceCheckLoop != nil {
 		log.Ctx(ctx).Info("starting channel balance loop")
@@ -238,6 +238,7 @@ func (m *ChannelManagerImpl) Watch(ctx context.Context, ch RWChannel) error {
 			zap.Array("updates", updates), zap.Error(err))
 	}
 
+	// Speed up channel assignment
 	// channel already written into meta, try to assign it to the cluster
 	// not error is returned if failed, the assignment will retry later
 	updates = m.assignPolicy(m.store.GetNodesChannels(), m.store.GetBufferChannelInfo(), m.legacyNodes.Collect())
@@ -286,11 +287,8 @@ func (m *ChannelManagerImpl) DeleteNode(nodeID UniqueID) error {
 	return nil
 }
 
-// reassign reassigns a channel to another DataNode.
+// inner method, lock before using it, reassign reassigns a channel to another DataNode.
 func (m *ChannelManagerImpl) reassign(original *NodeChannelInfo) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	updates := m.assignPolicy(m.store.GetNodesChannels(), original, m.legacyNodes.Collect())
 	if updates != nil {
 		return m.execute(updates)
@@ -436,15 +434,16 @@ func (m *ChannelManagerImpl) CheckLoop(ctx context.Context) {
 }
 
 func (m *ChannelManagerImpl) AdvanceChannelState(ctx context.Context) {
-	m.mu.RLock()
+	m.mu.Lock()
 	standbys := m.store.GetNodeChannelsBy(WithAllNodes(), WithChannelStates(Standby))
 	toNotifies := m.store.GetNodeChannelsBy(WithoutBufferNode(), WithChannelStates(ToWatch, ToRelease))
 	toChecks := m.store.GetNodeChannelsBy(WithoutBufferNode(), WithChannelStates(Watching, Releasing))
-	m.mu.RUnlock()
 
-	// Processing standby channels
-	updatedStandbys := false
-	updatedStandbys = m.advanceStandbys(ctx, standbys)
+	// Reassigning standby channels in locks to avoid concurrent assignment with Watch, Remove, AddNode, DeleteNode
+	updatedStandbys := m.advanceStandbys(ctx, standbys)
+	m.mu.Unlock()
+
+	// RPCs stays out of locks
 	updatedToCheckes := m.advanceToChecks(ctx, toChecks)
 	updatedToNotifies := m.advanceToNotifies(ctx, toNotifies)
 
@@ -453,9 +452,8 @@ func (m *ChannelManagerImpl) AdvanceChannelState(ctx context.Context) {
 	}
 }
 
+// inner method need lock
 func (m *ChannelManagerImpl) finishRemoveChannel(nodeID int64, channels ...RWChannel) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
 	for _, ch := range channels {
 		if err := m.removeChannel(nodeID, ch); err != nil {
 			log.Warn("Failed to remove channel", zap.Any("channel", ch), zap.Error(err))
@@ -469,6 +467,7 @@ func (m *ChannelManagerImpl) finishRemoveChannel(nodeID int64, channels ...RWCha
 	}
 }
 
+// inner method need locks
 func (m *ChannelManagerImpl) advanceStandbys(ctx context.Context, standbys []*NodeChannelInfo) bool {
 	var advanced bool = false
 	for _, nodeAssign := range standbys {
@@ -562,6 +561,7 @@ func (m *ChannelManagerImpl) advanceToNotifies(ctx context.Context, toNotifies [
 			got, err := f.Await()
 			res := got.(poolResult)
 
+			action := OnSuccess
 			if err != nil {
 				log.Ctx(ctx).Warn("Failed to notify channel operations to datanode",
 					zap.Int64("assignment", nodeAssign.NodeID),
@@ -569,6 +569,10 @@ func (m *ChannelManagerImpl) advanceToNotifies(ctx context.Context, toNotifies [
 					zap.String("channel name", res.ch.GetName()),
 					zap.Error(err),
 				)
+				action = OnFailure
+				if err == merr.ErrChannelReduplicate {
+					action = OnNotifyDuplicate
+				}
 				failedChannels++
 			} else {
 				succeededChannels++
@@ -576,7 +580,7 @@ func (m *ChannelManagerImpl) advanceToNotifies(ctx context.Context, toNotifies [
 			}
 
 			m.mu.Lock()
-			m.store.UpdateState(err == nil, nodeID, res.ch, res.opID)
+			m.store.UpdateState(action, nodeID, res.ch, res.opID)
 			m.mu.Unlock()
 		}
 
@@ -636,7 +640,11 @@ func (m *ChannelManagerImpl) advanceToChecks(ctx context.Context, toChecks []*No
 			if err == nil {
 				m.mu.Lock()
 				result := got.(poolResult)
-				m.store.UpdateState(result.successful, nodeID, result.ch, result.opID)
+				action := OnSuccess
+				if !result.successful {
+					action = OnFailure
+				}
+				m.store.UpdateState(action, nodeID, result.ch, result.opID)
 				m.mu.Unlock()
 
 				advanced = true
@@ -712,6 +720,7 @@ func (m *ChannelManagerImpl) Check(ctx context.Context, nodeID int64, info *data
 	return false, false
 }
 
+// inner method need lock
 func (m *ChannelManagerImpl) execute(updates *ChannelOpSet) error {
 	for _, op := range updates.ops {
 		if op.Type != Delete {

--- a/internal/datacoord/channel_manager_test.go
+++ b/internal/datacoord/channel_manager_test.go
@@ -705,8 +705,8 @@ func (s *ChannelManagerSuite) TestAdvanceChannelState() {
 		s.checkAssignment(m, 1, "ch2", ToWatch)
 
 		m.AdvanceChannelState(ctx)
-		s.checkAssignment(m, 1, "ch1", ToWatch)
-		s.checkAssignment(m, 1, "ch2", ToWatch)
+		s.checkAssignment(m, 1, "ch1", Standby)
+		s.checkAssignment(m, 1, "ch2", Standby)
 	})
 	s.Run("advance to release channels notify success", func() {
 		chNodes := map[string]int64{

--- a/internal/datacoord/channel_manager_test.go
+++ b/internal/datacoord/channel_manager_test.go
@@ -378,6 +378,31 @@ func (s *ChannelManagerSuite) TestFindWatcher() {
 func (s *ChannelManagerSuite) TestAdvanceChannelState() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	s.Run("advance towatch dn watched to torelease", func() {
+		chNodes := map[string]int64{
+			"ch1": 1,
+			"ch2": 1,
+		}
+		s.prepareMeta(chNodes, datapb.ChannelWatchState_ToWatch)
+		s.mockCluster.EXPECT().NotifyChannelOperation(mock.Anything, mock.Anything, mock.Anything).
+			RunAndReturn(func(ctx context.Context, nodeID int64, req *datapb.ChannelOperationsRequest) error {
+				s.Require().Equal(1, len(req.GetInfos()))
+				switch req.GetInfos()[0].GetVchan().GetChannelName() {
+				case "ch2":
+					return merr.WrapErrChannelReduplicate("ch2")
+				default:
+					return nil
+				}
+			}).Twice()
+		m, err := NewChannelManager(s.mockKv, s.mockHandler, s.mockCluster, s.mockAlloc)
+		s.Require().NoError(err)
+		s.checkAssignment(m, 1, "ch1", ToWatch)
+		s.checkAssignment(m, 1, "ch2", ToWatch)
+
+		m.AdvanceChannelState(ctx)
+		s.checkAssignment(m, 1, "ch1", Watching)
+		s.checkAssignment(m, 1, "ch2", ToRelease)
+	})
 	s.Run("advance statndby with no available nodes", func() {
 		chNodes := map[string]int64{
 			"ch1": bufferID,

--- a/internal/datacoord/mock_channel_store.go
+++ b/internal/datacoord/mock_channel_store.go
@@ -566,9 +566,9 @@ func (_c *MockRWChannelStore_Update_Call) RunAndReturn(run func(*ChannelOpSet) e
 	return _c
 }
 
-// UpdateState provides a mock function with given fields: isSuccessful, nodeID, channel, opID
-func (_m *MockRWChannelStore) UpdateState(isSuccessful bool, nodeID int64, channel RWChannel, opID int64) {
-	_m.Called(isSuccessful, nodeID, channel, opID)
+// UpdateState provides a mock function with given fields: action, nodeID, channel, opID
+func (_m *MockRWChannelStore) UpdateState(action Action, nodeID int64, channel RWChannel, opID int64) {
+	_m.Called(action, nodeID, channel, opID)
 }
 
 // MockRWChannelStore_UpdateState_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateState'
@@ -577,17 +577,17 @@ type MockRWChannelStore_UpdateState_Call struct {
 }
 
 // UpdateState is a helper method to define mock.On call
-//   - isSuccessful bool
+//   - action Action
 //   - nodeID int64
 //   - channel RWChannel
 //   - opID int64
-func (_e *MockRWChannelStore_Expecter) UpdateState(isSuccessful interface{}, nodeID interface{}, channel interface{}, opID interface{}) *MockRWChannelStore_UpdateState_Call {
-	return &MockRWChannelStore_UpdateState_Call{Call: _e.mock.On("UpdateState", isSuccessful, nodeID, channel, opID)}
+func (_e *MockRWChannelStore_Expecter) UpdateState(action interface{}, nodeID interface{}, channel interface{}, opID interface{}) *MockRWChannelStore_UpdateState_Call {
+	return &MockRWChannelStore_UpdateState_Call{Call: _e.mock.On("UpdateState", action, nodeID, channel, opID)}
 }
 
-func (_c *MockRWChannelStore_UpdateState_Call) Run(run func(isSuccessful bool, nodeID int64, channel RWChannel, opID int64)) *MockRWChannelStore_UpdateState_Call {
+func (_c *MockRWChannelStore_UpdateState_Call) Run(run func(action Action, nodeID int64, channel RWChannel, opID int64)) *MockRWChannelStore_UpdateState_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(bool), args[1].(int64), args[2].(RWChannel), args[3].(int64))
+		run(args[0].(Action), args[1].(int64), args[2].(RWChannel), args[3].(int64))
 	})
 	return _c
 }
@@ -597,7 +597,7 @@ func (_c *MockRWChannelStore_UpdateState_Call) Return() *MockRWChannelStore_Upda
 	return _c
 }
 
-func (_c *MockRWChannelStore_UpdateState_Call) RunAndReturn(run func(bool, int64, RWChannel, int64)) *MockRWChannelStore_UpdateState_Call {
+func (_c *MockRWChannelStore_UpdateState_Call) RunAndReturn(run func(Action, int64, RWChannel, int64)) *MockRWChannelStore_UpdateState_Call {
 	_c.Run(run)
 	return _c
 }

--- a/internal/datacoord/mock_channel_store.go
+++ b/internal/datacoord/mock_channel_store.go
@@ -566,9 +566,9 @@ func (_c *MockRWChannelStore_Update_Call) RunAndReturn(run func(*ChannelOpSet) e
 	return _c
 }
 
-// UpdateState provides a mock function with given fields: action, nodeID, channel, opID
-func (_m *MockRWChannelStore) UpdateState(action Action, nodeID int64, channel RWChannel, opID int64) {
-	_m.Called(action, nodeID, channel, opID)
+// UpdateState provides a mock function with given fields: err, nodeID, channel, opID
+func (_m *MockRWChannelStore) UpdateState(err error, nodeID int64, channel RWChannel, opID int64) {
+	_m.Called(err, nodeID, channel, opID)
 }
 
 // MockRWChannelStore_UpdateState_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateState'
@@ -577,17 +577,17 @@ type MockRWChannelStore_UpdateState_Call struct {
 }
 
 // UpdateState is a helper method to define mock.On call
-//   - action Action
+//   - err error
 //   - nodeID int64
 //   - channel RWChannel
 //   - opID int64
-func (_e *MockRWChannelStore_Expecter) UpdateState(action interface{}, nodeID interface{}, channel interface{}, opID interface{}) *MockRWChannelStore_UpdateState_Call {
-	return &MockRWChannelStore_UpdateState_Call{Call: _e.mock.On("UpdateState", action, nodeID, channel, opID)}
+func (_e *MockRWChannelStore_Expecter) UpdateState(err interface{}, nodeID interface{}, channel interface{}, opID interface{}) *MockRWChannelStore_UpdateState_Call {
+	return &MockRWChannelStore_UpdateState_Call{Call: _e.mock.On("UpdateState", err, nodeID, channel, opID)}
 }
 
-func (_c *MockRWChannelStore_UpdateState_Call) Run(run func(action Action, nodeID int64, channel RWChannel, opID int64)) *MockRWChannelStore_UpdateState_Call {
+func (_c *MockRWChannelStore_UpdateState_Call) Run(run func(err error, nodeID int64, channel RWChannel, opID int64)) *MockRWChannelStore_UpdateState_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(Action), args[1].(int64), args[2].(RWChannel), args[3].(int64))
+		run(args[0].(error), args[1].(int64), args[2].(RWChannel), args[3].(int64))
 	})
 	return _c
 }
@@ -597,7 +597,7 @@ func (_c *MockRWChannelStore_UpdateState_Call) Return() *MockRWChannelStore_Upda
 	return _c
 }
 
-func (_c *MockRWChannelStore_UpdateState_Call) RunAndReturn(run func(Action, int64, RWChannel, int64)) *MockRWChannelStore_UpdateState_Call {
+func (_c *MockRWChannelStore_UpdateState_Call) RunAndReturn(run func(error, int64, RWChannel, int64)) *MockRWChannelStore_UpdateState_Call {
 	_c.Run(run)
 	return _c
 }

--- a/internal/datanode/channel/channel_manager.go
+++ b/internal/datanode/channel/channel_manager.go
@@ -105,6 +105,12 @@ func (m *ChannelManagerImpl) Submit(info *datapb.ChannelWatchInfo) error {
 		return nil
 	}
 
+	// DataNode already watched this channel of other OpID
+	if info.GetState() == datapb.ChannelWatchState_ToWatch &&
+		m.fgManager.HasFlowgraph(channel) {
+		return merr.WrapErrChannelReduplicate(channel)
+	}
+
 	if info.GetState() == datapb.ChannelWatchState_ToRelease &&
 		!m.fgManager.HasFlowgraph(channel) {
 		log.Warn("Release op already finished, skip", zap.Int64("opID", info.GetOpID()), zap.String("channel", channel))


### PR DESCRIPTION
This pr fixs double assign in channels, recurr of dropped channel, amend extra channel meta, and refresh incorrect state with DN by the following edits:
1. Loose the lock in advanceStandbys to avoid concurrent assignment.
2. Trasfer ToWatch to ToRelease if DN returns ErrChannelRedupulicate.
3. Remove dup channel when recovering
See also: #41876 
pr: #41837 