### PR TITLE
fix: streaming node panic with when binary size is set as zero

### DIFF
--- a/internal/streamingnode/server/wal/interceptors/shard/shards/segment_alloc_worker.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/shards/segment_alloc_worker.go
@@ -88,10 +88,10 @@ func (w *segmentAllocWorker) doOnce() error {
 	}
 	result, err := w.wal.Append(w.ctx, w.msg)
 	if err != nil {
-		w.Logger().Warn("failed to append create segment message", log.FieldMessage(w.msg), zap.Error(err))
+		w.Logger().Warn("failed to append create segment message", zap.Error(err))
 		return err
 	}
-	w.Logger().Info("append create segment message", log.FieldMessage(w.msg), zap.String("messageID", result.MessageID.String()), zap.Uint64("timetick", result.TimeTick))
+	w.Logger().Info("append create segment message", zap.String("messageID", result.MessageID.String()), zap.Uint64("timetick", result.TimeTick))
 	return nil
 }
 

--- a/internal/streamingnode/server/wal/interceptors/shard/stats/metrics.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/stats/metrics.go
@@ -3,6 +3,7 @@ package stats
 import (
 	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/shard/utils"
 	"github.com/milvus-io/milvus/pkg/v2/metrics"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
@@ -10,26 +11,34 @@ import (
 // newMetricsHelper creates a new metrics helper for the WAL segment.
 func newMetricsHelper() *metricsHelper {
 	return &metricsHelper{
-		growingBytesHWM: metrics.WALGrowingSegmentHWMBytes.With(prometheus.Labels{metrics.NodeIDLabelName: paramtable.GetStringNodeID()}),
-		growingBytesLWM: metrics.WALGrowingSegmentLWMBytes.With(prometheus.Labels{metrics.NodeIDLabelName: paramtable.GetStringNodeID()}),
-		growingBytes:    metrics.WALGrowingSegmentBytes.MustCurryWith(prometheus.Labels{metrics.NodeIDLabelName: paramtable.GetStringNodeID()}),
+		growingBytesHWM:  metrics.WALGrowingSegmentHWMBytes.With(prometheus.Labels{metrics.NodeIDLabelName: paramtable.GetStringNodeID()}),
+		growingBytesLWM:  metrics.WALGrowingSegmentLWMBytes.With(prometheus.Labels{metrics.NodeIDLabelName: paramtable.GetStringNodeID()}),
+		growingBytes:     metrics.WALGrowingSegmentBytes.MustCurryWith(prometheus.Labels{metrics.NodeIDLabelName: paramtable.GetStringNodeID()}),
+		growingRowsTotal: metrics.WALGrowingSegmentRowsTotal.MustCurryWith(prometheus.Labels{metrics.NodeIDLabelName: paramtable.GetStringNodeID()}),
 	}
 }
 
 // metricsHelper is a helper struct for managing metrics related to WAL segments.
 type metricsHelper struct {
-	growingBytesHWM prometheus.Gauge
-	growingBytesLWM prometheus.Gauge
-	growingBytes    *prometheus.GaugeVec
+	growingBytesHWM  prometheus.Gauge
+	growingBytesLWM  prometheus.Gauge
+	growingBytes     *prometheus.GaugeVec
+	growingRowsTotal *prometheus.GaugeVec
 }
 
 // ObservePChannelBytesUpdate updates the bytes of a pchannel.
-func (m *metricsHelper) ObservePChannelBytesUpdate(pchannel string, bytes uint64) {
-	if bytes <= 0 {
+func (m *metricsHelper) ObservePChannelBytesUpdate(pchannel string, insertMetrics utils.InsertMetrics) {
+	if insertMetrics.BinarySize <= 0 {
 		metrics.WALGrowingSegmentBytes.DeletePartialMatch(prometheus.Labels{metrics.WALChannelLabelName: pchannel})
-		return
+	} else {
+		m.growingBytes.WithLabelValues(pchannel).Set(float64(insertMetrics.BinarySize))
 	}
-	m.growingBytes.WithLabelValues(pchannel).Set(float64(bytes))
+
+	if insertMetrics.Rows <= 0 {
+		metrics.WALGrowingSegmentRowsTotal.DeletePartialMatch(prometheus.Labels{metrics.WALChannelLabelName: pchannel})
+	} else {
+		m.growingRowsTotal.WithLabelValues(pchannel).Set(float64(insertMetrics.Rows))
+	}
 }
 
 // ObserveConfigUpdate is a update method for configuration changes.

--- a/internal/streamingnode/server/wal/interceptors/shard/stats/stats_manager.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/stats/stats_manager.go
@@ -166,13 +166,17 @@ func (m *StatsManager) registerNewGrowingSegment(belongs SegmentBelongs, stats *
 	}
 	m.vchannelStats[belongs.VChannel].Collect(stats.Insert)
 
-	m.metricHelper.ObservePChannelBytesUpdate(belongs.PChannel, m.pchannelStats[belongs.PChannel].BinarySize)
+	m.metricHelper.ObservePChannelBytesUpdate(belongs.PChannel, *m.pchannelStats[belongs.PChannel])
 }
 
 // AllocRows alloc number of rows on current segment.
 // AllocRows will check if the segment has enough space to insert.
 // Must be called after RegisterGrowingSegment and before UnregisterGrowingSegment.
 func (m *StatsManager) AllocRows(segmentID int64, insert InsertMetrics) error {
+	if insert.Rows == 0 || insert.BinarySize == 0 {
+		panic(fmt.Sprintf("insert rows or binary size cannot be 0, rows: %d, binary: %d", insert.Rows, insert.BinarySize))
+	}
+
 	shouldBeSealed, err := m.allocRows(segmentID, insert)
 	if shouldBeSealed {
 		m.worker.NotifySealSegment(segmentID, policy.PolicyCapacity())
@@ -209,7 +213,7 @@ func (m *StatsManager) allocRows(segmentID int64, insert InsertMetrics) (bool, e
 		}
 		m.vchannelStats[info.VChannel].Collect(insert)
 
-		m.metricHelper.ObservePChannelBytesUpdate(info.PChannel, m.pchannelStats[info.PChannel].BinarySize)
+		m.metricHelper.ObservePChannelBytesUpdate(info.PChannel, *m.pchannelStats[info.PChannel])
 		return stat.ShouldBeSealed(), nil
 	}
 	if stat.IsEmpty() {
@@ -307,15 +311,15 @@ func (m *StatsManager) unregisterSealedSegment(segmentID int64) *SegmentStats {
 
 	if _, ok := m.pchannelStats[info.PChannel]; ok {
 		m.pchannelStats[info.PChannel].Subtract(stats.Insert)
-		m.metricHelper.ObservePChannelBytesUpdate(info.PChannel, m.pchannelStats[info.PChannel].BinarySize)
-		if m.pchannelStats[info.PChannel].BinarySize == 0 {
+		m.metricHelper.ObservePChannelBytesUpdate(info.PChannel, *m.pchannelStats[info.PChannel])
+		if m.pchannelStats[info.PChannel].IsZero() {
 			// If the binary size is 0, it means the segment is empty, we can delete it.
 			delete(m.pchannelStats, info.PChannel)
 		}
 	}
 	if _, ok := m.vchannelStats[info.VChannel]; ok {
 		m.vchannelStats[info.VChannel].Subtract(stats.Insert)
-		if m.vchannelStats[info.VChannel].BinarySize == 0 {
+		if m.vchannelStats[info.VChannel].IsZero() {
 			delete(m.vchannelStats, info.VChannel)
 		}
 	}

--- a/internal/streamingnode/server/wal/interceptors/shard/stats/stats_manager_test.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/stats/stats_manager_test.go
@@ -111,6 +111,11 @@ func TestStatsManager(t *testing.T) {
 	err = m.AllocRows(7, InsertMetrics{Rows: 400, BinarySize: 400})
 	assert.ErrorIs(t, err, ErrTooLargeInsert)
 
+	assert.Panics(t, func() {
+		// alloc rows on a sealed segment should panic
+		m.AllocRows(1000, InsertMetrics{Rows: 0, BinarySize: 0})
+	})
+
 	m.UnregisterSealedSegment(3)
 	m.UnregisterSealedSegment(4)
 	m.UnregisterSealedSegment(5)

--- a/internal/streamingnode/server/wal/interceptors/shard/utils/stats.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/utils/stats.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/milvus-io/milvus/pkg/v2/proto/streamingpb"
@@ -108,6 +109,11 @@ type InsertMetrics struct {
 	BinarySize uint64
 }
 
+// IsZero return true if InsertMetrics is zero.
+func (m *InsertMetrics) IsZero() bool {
+	return m.Rows == 0 && m.BinarySize == 0
+}
+
 // Collect collects other metrics.
 func (m *InsertMetrics) Collect(other InsertMetrics) {
 	m.Rows += other.Rows
@@ -117,10 +123,10 @@ func (m *InsertMetrics) Collect(other InsertMetrics) {
 // Subtract subtract by other metrics.
 func (m *InsertMetrics) Subtract(other InsertMetrics) {
 	if m.Rows < other.Rows {
-		panic("rows cannot be less than zero")
+		panic(fmt.Sprintf("rows cannot be less than zero, current: %d, target: %d", m.Rows, other.Rows))
 	}
 	if m.BinarySize < other.BinarySize {
-		panic("binary size cannot be less than zero")
+		panic(fmt.Sprintf("binary size cannot be less than zero, current: %d, target: %d", m.Rows, other.Rows))
 	}
 	m.Rows -= other.Rows
 	m.BinarySize -= other.BinarySize

--- a/internal/streamingnode/server/wal/interceptors/shard/utils/stats_test.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/utils/stats_test.go
@@ -108,6 +108,19 @@ func TestSegmentStats(t *testing.T) {
 	assert.Equal(t, uint64(13), stat.BinLogFileCounter)
 }
 
+func TestIsZero(t *testing.T) {
+	// Test zero insert metrics
+	zeroInsert := InsertMetrics{}
+	assert.True(t, zeroInsert.IsZero())
+
+	// Test non-zero insert metrics
+	nonZeroInsert := InsertMetrics{
+		Rows:       1,
+		BinarySize: 2,
+	}
+	assert.False(t, nonZeroInsert.IsZero())
+}
+
 func TestOversizeAlloc(t *testing.T) {
 	now := time.Now()
 	stat := &SegmentStats{

--- a/pkg/metrics/streaming_service_metrics.go
+++ b/pkg/metrics/streaming_service_metrics.go
@@ -232,6 +232,11 @@ var (
 	}, WALChannelLabelName, WALTxnStateLabelName)
 
 	// Segment related metrics
+	WALGrowingSegmentRowsTotal = newWALGaugeVec(prometheus.GaugeOpts{
+		Name: "growing_segment_rows_total",
+		Help: "Rows of segment growing on wal",
+	}, WALChannelLabelName)
+
 	WALGrowingSegmentBytes = newWALGaugeVec(prometheus.GaugeOpts{
 		Name: "growing_segment_bytes",
 		Help: "Bytes of segment growing on wal",
@@ -491,6 +496,7 @@ func registerWAL(registry *prometheus.Registry) {
 	registry.MustRegister(WALInflightTxn)
 	registry.MustRegister(WALTxnDurationSeconds)
 	registry.MustRegister(WALGrowingSegmentBytes)
+	registry.MustRegister(WALGrowingSegmentRowsTotal)
 	registry.MustRegister(WALGrowingSegmentHWMBytes)
 	registry.MustRegister(WALGrowingSegmentLWMBytes)
 	registry.MustRegister(WALSegmentAllocTotal)


### PR DESCRIPTION
issue: #41853

- persist the estimated binary size for insert message into wal.
- add metric to record the total growing rows of channel.