### PR TITLE
fix: Use param item instead of global var for seal worker

### DIFF
--- a/internal/streamingnode/server/wal/interceptors/shard/stats/stats_manager_test.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/stats/stats_manager_test.go
@@ -145,7 +145,7 @@ func TestStatsManager(t *testing.T) {
 	assert.Empty(t, m.sealOperators)
 }
 
-func TestConcurrentStasManager(t *testing.T) {
+func TestConcurrentStatsManager(t *testing.T) {
 	paramtable.Init()
 	params := paramtable.Get()
 	params.Save(params.DataCoordCfg.SegmentMaxBinlogFileNumber.Key, "5")
@@ -155,7 +155,7 @@ func TestConcurrentStasManager(t *testing.T) {
 	params.Save(params.DataCoordCfg.SegmentMaxLifetime.Key, "0.3")
 	params.Save(params.DataCoordCfg.SegmentMaxIdleTime.Key, "0.1")
 	params.Save(params.DataCoordCfg.SegmentMinSizeFromIdleToSealed.Key, "1024")
-	defaultSealWorkerTimerInterval = 10 * time.Millisecond
+	params.Save(params.StreamingCfg.SealWorkerInterval.Key, "10ms")
 
 	m := NewStatsManager()
 

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -5415,6 +5415,10 @@ type streamingConfig struct {
 	WALRecoveryGracefulCloseTimeout ParamItem `refreshable:"true"`
 	WALTruncateSampleInterval       ParamItem `refreshable:"true"`
 	WALTruncateRetentionInterval    ParamItem `refreshable:"true"`
+
+	// inteceptors
+	SealWorkerInterval         ParamItem `refreshable:"false"`
+	GrowingBytesNotifyCoolDown ParamItem `refreshable:"false"`
 }
 
 func (p *streamingConfig) init(base *BaseTable) {
@@ -5640,6 +5644,22 @@ Greater the interval, more wal storage usage, more redundant data in wal`,
 		Export:       true,
 	}
 	p.WALTruncateRetentionInterval.Init(base.mgr)
+
+	p.SealWorkerInterval = ParamItem{
+		Key:          "streaming.inteceptors.sealWorkerInterval",
+		Version:      "2.6.0",
+		DefaultValue: "1m",
+		Export:       false,
+	}
+	p.SealWorkerInterval.Init(base.mgr)
+
+	p.GrowingBytesNotifyCoolDown = ParamItem{
+		Key:          "streaming.inteceptors.growingBytesNotifyCooldown",
+		Version:      "2.6.0",
+		DefaultValue: "5s",
+		Export:       false,
+	}
+	p.GrowingBytesNotifyCoolDown.Init(base.mgr)
 }
 
 // runtimeConfig is just a private environment value table.


### PR DESCRIPTION
Related to #41899