### PR TITLE
enhance: Make terminate warning as error

### DIFF
--- a/internal/core/CMakeLists.txt
+++ b/internal/core/CMakeLists.txt
@@ -151,8 +151,6 @@ if ( APPLE )
             "-fopenmp"
             "-pedantic"
             "-Wall"
-            "-Werror=terminate"
-            "-Werror=exceptions"
             "-D_DARWIN_C_SOURCE"
             "-Wno-gnu-zero-variadic-macro-arguments"
             "-Wno-variadic-macros"

--- a/internal/core/CMakeLists.txt
+++ b/internal/core/CMakeLists.txt
@@ -151,6 +151,8 @@ if ( APPLE )
             "-fopenmp"
             "-pedantic"
             "-Wall"
+            "-Werror=terminate"
+            "-Werror=exceptions"
             "-D_DARWIN_C_SOURCE"
             "-Wno-gnu-zero-variadic-macro-arguments"
             "-Wno-variadic-macros"

--- a/internal/core/CMakeLists.txt
+++ b/internal/core/CMakeLists.txt
@@ -128,6 +128,8 @@ if (LINUX OR MSYS)
                   "-fopenmp"
                   "-Wno-error"
                   "-Wno-all"
+                  "-Werror=terminate"
+                  "-Werror=exceptions"
                   )
     if (USE_ASAN STREQUAL "ON") 
         message( STATUS "Building Milvus Core Using AddressSanitizer")


### PR DESCRIPTION
Related to #41219

Make terminate warning as error in compile configuration in case of future `noexcept` issue