### PR TITLE
enhance: [StorageV2] Make packed reader use correct path

### DIFF
--- a/internal/core/thirdparty/milvus-storage/CMakeLists.txt
+++ b/internal/core/thirdparty/milvus-storage/CMakeLists.txt
@@ -14,7 +14,7 @@
 # Update milvus-storage_VERSION for the first occurrence
 milvus_add_pkg_config("milvus-storage")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( milvus-storage_VERSION d04ae52 )
+set( milvus-storage_VERSION 1238e21 )
 set( GIT_REPOSITORY  "https://github.com/milvus-io/milvus-storage.git")
 message(STATUS "milvus-storage repo: ${GIT_REPOSITORY}")
 message(STATUS "milvus-storage version: ${milvus-storage_VERSION}")

--- a/internal/datanode/index/task_index.go
+++ b/internal/datanode/index/task_index.go
@@ -299,7 +299,7 @@ func (it *indexBuildTask) Execute(ctx context.Context) error {
 	if buildIndexParams.StorageVersion == storage.StorageV2 {
 		buildIndexParams.SegmentInsertFiles = GetSegmentInsertFiles(
 			it.req.GetInsertLogs(),
-			it.req.GetStorageConfig().RootPath,
+			it.req.GetStorageConfig(),
 			it.req.GetCollectionID(),
 			it.req.GetPartitionID(),
 			it.req.GetSegmentID())

--- a/internal/datanode/index/task_stats.go
+++ b/internal/datanode/index/task_stats.go
@@ -605,7 +605,7 @@ func buildIndexParams(
 	if req.GetStorageVersion() == storage.StorageV2 {
 		params.SegmentInsertFiles = GetSegmentInsertFiles(
 			req.GetInsertLogs(),
-			req.GetStorageConfig().RootPath,
+			req.GetStorageConfig(),
 			req.GetCollectionID(),
 			req.GetPartitionID(),
 			req.GetTargetSegmentID())

--- a/internal/storage/rw.go
+++ b/internal/storage/rw.go
@@ -207,7 +207,7 @@ func NewBinlogRecordReader(ctx context.Context, binlogs []*datapb.FieldBinlog, s
 			for j, binlog := range binlogs {
 				logPath := binlog.GetLogPath()
 				if paramtable.Get().CommonCfg.StorageType.GetValue() != "local" {
-					path.Join(rwOptions.bucketName, logPath)
+					logPath = path.Join(rwOptions.bucketName, logPath)
 				}
 				paths[j] = append(paths[j], logPath)
 			}


### PR DESCRIPTION
Related to #39173

This PR
- Use updated path with bucketName for packedReader
- Update milvus-storage commit to report reader/writer initialization failure, see also milvus-io/milvus-storage#192