### PR TITLE
fix: [2.5] Fix import slot assignment

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -707,7 +707,6 @@ dataNode:
     maxConcurrentTaskNum: 16 # The maximum number of import/pre-import tasks allowed to run concurrently on a datanode.
     maxImportFileSizeInGB: 16 # The maximum file size (in GB) for an import file, where an import file refers to either a Row-Based file or a set of Column-Based files.
     readBufferSizeInMB: 16 # The data block size (in MB) read from chunk manager by the datanode during import.
-    maxTaskSlotNum: 16 # The maximum number of slots occupied by each import/pre-import task.
   compaction:
     levelZeroBatchMemoryRatio: 0.5 # The minimal memory ratio of free memory for level zero compaction executing in batch mode
     levelZeroMaxBatchSize: -1 # Max batch size refers to the max number of L1/L2 segments in a batch when executing L0 compaction. Default to -1, any value that is less than 1 means no limit. Valid range: >= 1.

--- a/internal/datacoord/import_task.go
+++ b/internal/datacoord/import_task.go
@@ -23,7 +23,6 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/metricsinfo"
-	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/timerecord"
 )
 
@@ -166,7 +165,7 @@ func (p *preImportTask) GetTR() *timerecord.TimeRecorder {
 }
 
 func (p *preImportTask) GetSlots() int64 {
-	return int64(funcutil.Min(len(p.GetFileStats()), paramtable.Get().DataNodeCfg.MaxTaskSlotNum.GetAsInt()))
+	return int64(len(p.GetFileStats()))
 }
 
 func (p *preImportTask) Clone() ImportTask {
@@ -212,7 +211,7 @@ func (t *importTask) GetSlots() int64 {
 	//    making segment count unsuitable as a slot number.
 	// Taking these factors into account, we've decided to use the
 	// minimum value between segment count and file count as the slot number.
-	return int64(funcutil.Min(len(t.GetFileStats()), len(t.GetSegmentIDs()), paramtable.Get().DataNodeCfg.MaxTaskSlotNum.GetAsInt()))
+	return int64(funcutil.Min(len(t.GetFileStats()), len(t.GetSegmentIDs())))
 }
 
 func (t *importTask) Clone() ImportTask {

--- a/internal/datacoord/import_task.go
+++ b/internal/datacoord/import_task.go
@@ -165,7 +165,11 @@ func (p *preImportTask) GetTR() *timerecord.TimeRecorder {
 }
 
 func (p *preImportTask) GetSlots() int64 {
-	return int64(len(p.GetFileStats()))
+	slots := int64(len(p.GetFileStats()))
+	if slots < 1 {
+		slots = 1
+	}
+	return slots
 }
 
 func (p *preImportTask) Clone() ImportTask {
@@ -211,7 +215,11 @@ func (t *importTask) GetSlots() int64 {
 	//    making segment count unsuitable as a slot number.
 	// Taking these factors into account, we've decided to use the
 	// minimum value between segment count and file count as the slot number.
-	return int64(funcutil.Min(len(t.GetFileStats()), len(t.GetSegmentIDs())))
+	slots := int64(funcutil.Min(len(t.GetFileStats()), len(t.GetSegmentIDs())))
+	if slots < 1 {
+		slots = 1
+	}
+	return slots
 }
 
 func (t *importTask) Clone() ImportTask {

--- a/internal/datanode/importv2/task_import.go
+++ b/internal/datanode/importv2/task_import.go
@@ -112,7 +112,7 @@ func (t *ImportTask) GetSlots() int64 {
 	//    making segment count unsuitable as a slot number.
 	// Taking these factors into account, we've decided to use the
 	// minimum value between segment count and file count as the slot number.
-	return int64(funcutil.Min(len(t.GetFileStats()), len(t.GetSegmentIDs()), paramtable.Get().DataNodeCfg.MaxTaskSlotNum.GetAsInt()))
+	return int64(funcutil.Min(len(t.GetFileStats()), len(t.GetSegmentIDs())))
 }
 
 func (t *ImportTask) Cancel() {

--- a/internal/datanode/importv2/task_import.go
+++ b/internal/datanode/importv2/task_import.go
@@ -112,7 +112,11 @@ func (t *ImportTask) GetSlots() int64 {
 	//    making segment count unsuitable as a slot number.
 	// Taking these factors into account, we've decided to use the
 	// minimum value between segment count and file count as the slot number.
-	return int64(funcutil.Min(len(t.GetFileStats()), len(t.GetSegmentIDs())))
+	slots := int64(funcutil.Min(len(t.GetFileStats()), len(t.GetSegmentIDs())))
+	if slots < 1 {
+		slots = 1
+	}
+	return slots
 }
 
 func (t *ImportTask) Cancel() {

--- a/internal/datanode/importv2/task_preimport.go
+++ b/internal/datanode/importv2/task_preimport.go
@@ -34,7 +34,6 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/v2/util/conc"
-	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
@@ -103,7 +102,7 @@ func (t *PreImportTask) GetSchema() *schemapb.CollectionSchema {
 }
 
 func (t *PreImportTask) GetSlots() int64 {
-	return int64(funcutil.Min(len(t.GetFileStats()), paramtable.Get().DataNodeCfg.MaxTaskSlotNum.GetAsInt()))
+	return int64(len(t.GetFileStats()))
 }
 
 func (t *PreImportTask) Cancel() {

--- a/internal/datanode/importv2/task_preimport.go
+++ b/internal/datanode/importv2/task_preimport.go
@@ -102,7 +102,11 @@ func (t *PreImportTask) GetSchema() *schemapb.CollectionSchema {
 }
 
 func (t *PreImportTask) GetSlots() int64 {
-	return int64(len(t.GetFileStats()))
+	slots := int64(len(t.GetFileStats()))
+	if slots < 1 {
+		slots = 1
+	}
+	return slots
 }
 
 func (t *PreImportTask) Cancel() {

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -4707,7 +4707,6 @@ type dataNodeConfig struct {
 	MaxConcurrentImportTaskNum ParamItem `refreshable:"true"`
 	MaxImportFileSizeInGB      ParamItem `refreshable:"true"`
 	ReadBufferSizeInMB         ParamItem `refreshable:"true"`
-	MaxTaskSlotNum             ParamItem `refreshable:"true"`
 
 	// Compaction
 	L0BatchMemoryRatio       ParamItem `refreshable:"true"`
@@ -5016,16 +5015,6 @@ if this parameter <= 0, will set it as 10`,
 		Export:       true,
 	}
 	p.ReadBufferSizeInMB.Init(base.mgr)
-
-	p.MaxTaskSlotNum = ParamItem{
-		Key:          "dataNode.import.maxTaskSlotNum",
-		Version:      "2.4.13",
-		Doc:          "The maximum number of slots occupied by each import/pre-import task.",
-		DefaultValue: "16",
-		PanicIfEmpty: false,
-		Export:       true,
-	}
-	p.MaxTaskSlotNum.Init(base.mgr)
 
 	p.L0BatchMemoryRatio = ParamItem{
 		Key:          "dataNode.compaction.levelZeroBatchMemoryRatio",

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -599,7 +599,6 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, 16, maxConcurrentImportTaskNum)
 		assert.Equal(t, int64(16), Params.MaxImportFileSizeInGB.GetAsInt64())
 		assert.Equal(t, 16, Params.ReadBufferSizeInMB.GetAsInt())
-		assert.Equal(t, 16, Params.MaxTaskSlotNum.GetAsInt())
 		params.Save("datanode.gracefulStopTimeout", "100")
 		assert.Equal(t, 100*time.Second, Params.GracefulStopTimeout.GetAsDuration(time.Second))
 		assert.Equal(t, 16, Params.SlotCap.GetAsInt())


### PR DESCRIPTION
Assign the import task to the worker with the most available slots, even if availableSlots < requiredSlots. This ensures tasks won’t be blocked indefinitely.

issue: https://github.com/milvus-io/milvus/issues/41981