### PR TITLE
fix: Lock before reading flusher cp sampling truncate cp

### DIFF
--- a/internal/streamingnode/server/wal/recovery/recovery_background_task.go
+++ b/internal/streamingnode/server/wal/recovery/recovery_background_task.go
@@ -128,6 +128,8 @@ func (rs *recoveryStorageImpl) persistDirtySnapshot(ctx context.Context, snapsho
 }
 
 func (rs *recoveryStorageImpl) sampleTruncateCheckpoint(checkpoint *WALCheckpoint) {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
 	if rs.flusherCheckpoint == nil {
 		return
 	}

--- a/internal/streamingnode/server/wal/recovery/recovery_background_task.go
+++ b/internal/streamingnode/server/wal/recovery/recovery_background_task.go
@@ -128,14 +128,13 @@ func (rs *recoveryStorageImpl) persistDirtySnapshot(ctx context.Context, snapsho
 }
 
 func (rs *recoveryStorageImpl) sampleTruncateCheckpoint(checkpoint *WALCheckpoint) {
-	rs.mu.Lock()
-	defer rs.mu.Unlock()
-	if rs.flusherCheckpoint == nil {
+	flusherCP := rs.getFlusherCheckpoint()
+	if flusherCP == nil {
 		return
 	}
 	// use the smaller one to truncate the wal.
-	if rs.flusherCheckpoint.MessageID.LTE(checkpoint.MessageID) {
-		rs.truncator.SampleCheckpoint(rs.flusherCheckpoint)
+	if flusherCP.MessageID.LTE(checkpoint.MessageID) {
+		rs.truncator.SampleCheckpoint(flusherCP)
 	} else {
 		rs.truncator.SampleCheckpoint(checkpoint)
 	}

--- a/internal/streamingnode/server/wal/recovery/recovery_storage_impl.go
+++ b/internal/streamingnode/server/wal/recovery/recovery_storage_impl.go
@@ -408,3 +408,11 @@ func (r *recoveryStorageImpl) detectInconsistency(msg message.ImmutableMessage, 
 	r.Logger().Warn("inconsistency detected", fields...)
 	r.metrics.ObserveInconsitentEvent()
 }
+
+// getFlusherCheckpoint returns flusher checkpoint concurrent-safe
+// NOTE: shall not be called with r.mu.Lock()!
+func (r *recoveryStorageImpl) getFlusherCheckpoint() *WALCheckpoint {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.flusherCheckpoint
+}


### PR DESCRIPTION
Related to #42018