### PR TITLE
enhance: Reduce session TTL from 30s to 10s for faster failure detection

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -907,7 +907,7 @@ common:
     internaltlsEnabled: false
     tlsMode: 0
   session:
-    ttl: 30 # ttl value when session granting a lease to register service
+    ttl: 10 # ttl value when session granting a lease to register service
     retryTimes: 30 # retry times when session sending etcd requests
   locks:
     metrics:

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -47,7 +47,7 @@ const (
 	DefaultMiddlePriorityThreadCoreCoefficient = 5
 	DefaultLowPriorityThreadCoreCoefficient    = 1
 
-	DefaultSessionTTL        = 30 // s
+	DefaultSessionTTL        = 10 // s
 	DefaultSessionRetryTimes = 30
 
 	DefaultMaxDegree                = 56
@@ -719,7 +719,7 @@ Large numeric passwords require double quotes to avoid yaml parsing precision is
 	p.SessionTTL = ParamItem{
 		Key:          "common.session.ttl",
 		Version:      "2.0.0",
-		DefaultValue: "60",
+		DefaultValue: "10",
 		Doc:          "ttl value when session granting a lease to register service",
 		Export:       true,
 	}


### PR DESCRIPTION
Optimize session management by reducing the TTL (Time To Live) value for service registration from 30 seconds to 10 seconds. This change improves the system's ability to detect service failures more quickly and enhances overall cluster responsiveness.

Changes include:
- Update default session TTL from 30s to 10s in milvus.yaml
- Adjust DefaultSessionTTL constant from 30 to 10 seconds
- Update SessionTTL default value from 60 to 10 seconds
- Maintain consistent TTL values across configuration files

This optimization reduces the time required for the system to detect when services become unavailable, leading to faster failover and improved cluster stability during node failures or network issues.