### PR TITLE
fix: Use locking to ensure the atomicity of dropping segment indexes 

### DIFF
--- a/internal/datacoord/garbage_collector.go
+++ b/internal/datacoord/garbage_collector.go
@@ -688,7 +688,7 @@ func (gc *garbageCollector) recycleUnusedSegIndexes(ctx context.Context) {
 			}
 
 			// Remove meta from index meta.
-			if err := gc.meta.indexMeta.RemoveSegmentIndex(ctx, segIdx.CollectionID, segIdx.PartitionID, segIdx.SegmentID, segIdx.IndexID, segIdx.BuildID); err != nil {
+			if err := gc.meta.indexMeta.RemoveSegmentIndex(ctx, segIdx.BuildID); err != nil {
 				log.Warn("delete index meta from etcd failed, wait to retry", zap.Error(err))
 				continue
 			}

--- a/internal/datacoord/garbage_collector_test.go
+++ b/internal/datacoord/garbage_collector_test.go
@@ -526,6 +526,7 @@ func createMetaForRecycleUnusedSegIndexes(catalog metastore.DataCoordCatalog) *m
 			segmentIndexes:   segIndexes,
 			indexes:          map[UniqueID]map[UniqueID]*model.Index{},
 			segmentBuildInfo: newSegmentIndexBuildInfo(),
+			keyLock:          lock.NewKeyLock[UniqueID](),
 		},
 		channelCPs:   nil,
 		chunkManager: nil,

--- a/internal/datacoord/index_meta_test.go
+++ b/internal/datacoord/index_meta_test.go
@@ -1462,88 +1462,59 @@ func TestRemoveIndex(t *testing.T) {
 }
 
 func TestRemoveSegmentIndex(t *testing.T) {
+	t.Run("drop no exist segment index", func(t *testing.T) {
+		catalog := catalogmocks.NewDataCoordCatalog(t)
+		m := newSegmentIndexMeta(catalog)
+		err := m.RemoveSegmentIndex(context.TODO(), 0)
+
+		assert.NoError(t, err)
+	})
+
 	t.Run("drop segment index fail", func(t *testing.T) {
 		expectedErr := errors.New("error")
 		catalog := catalogmocks.NewDataCoordCatalog(t)
+		catalog.EXPECT().CreateSegmentIndex(mock.Anything, mock.Anything).Return(nil)
 		catalog.EXPECT().
 			DropSegmentIndex(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 			Return(expectedErr)
-
 		m := newSegmentIndexMeta(catalog)
-		err := m.RemoveSegmentIndex(context.TODO(), 0, 0, 0, 0, 0)
+		err := m.AddSegmentIndex(context.TODO(), &model.SegmentIndex{
+			SegmentID:    3,
+			CollectionID: 1,
+			PartitionID:  2,
+			NumRows:      1024,
+			IndexID:      1,
+			BuildID:      4,
+		})
+		assert.NoError(t, err)
 
+		err = m.RemoveSegmentIndex(context.TODO(), 4)
 		assert.Error(t, err)
 		assert.EqualError(t, err, "error")
 	})
 
 	t.Run("remove segment index ok", func(t *testing.T) {
 		catalog := catalogmocks.NewDataCoordCatalog(t)
+		catalog.EXPECT().CreateSegmentIndex(mock.Anything, mock.Anything).Return(nil)
 		catalog.EXPECT().
 			DropSegmentIndex(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 			Return(nil)
 
-		m := &indexMeta{
-			catalog:          catalog,
-			segmentIndexes:   typeutil.NewConcurrentMap[UniqueID, *typeutil.ConcurrentMap[UniqueID, *model.SegmentIndex]](),
-			segmentBuildInfo: newSegmentIndexBuildInfo(),
-		}
-		m.segmentIndexes.Insert(segID, typeutil.NewConcurrentMap[UniqueID, *model.SegmentIndex]())
+		m := newSegmentIndexMeta(catalog)
+		err := m.AddSegmentIndex(context.TODO(), &model.SegmentIndex{
+			SegmentID:    3,
+			CollectionID: 1,
+			PartitionID:  2,
+			NumRows:      1024,
+			IndexID:      1,
+			BuildID:      4,
+		})
+		assert.NoError(t, err)
 
-		err := m.RemoveSegmentIndex(context.TODO(), collID, partID, segID, indexID, buildID)
+		err = m.RemoveSegmentIndex(context.TODO(), 4)
 		assert.NoError(t, err)
 
 		assert.Equal(t, 0, m.segmentIndexes.Len())
-		assert.Equal(t, len(m.segmentBuildInfo.List()), 0)
-	})
-}
-
-func TestRemoveSegmentIndexByID(t *testing.T) {
-	t.Run("drop segment index fail", func(t *testing.T) {
-		expectedErr := errors.New("error")
-		catalog := catalogmocks.NewDataCoordCatalog(t)
-		catalog.EXPECT().
-			DropSegmentIndex(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-			Return(expectedErr)
-
-		catalog.EXPECT().CreateSegmentIndex(mock.Anything, mock.Anything).Return(nil)
-
-		m := newSegmentIndexMeta(catalog)
-		err := m.AddSegmentIndex(context.TODO(), &model.SegmentIndex{
-			SegmentID:    3,
-			CollectionID: 1,
-			PartitionID:  2,
-			NumRows:      1024,
-			IndexID:      1,
-			BuildID:      4,
-		})
-		assert.NoError(t, err)
-		err = m.RemoveSegmentIndexByID(context.TODO(), 4)
-		assert.Error(t, err)
-		assert.EqualError(t, err, "error")
-	})
-
-	t.Run("remove segment index ok", func(t *testing.T) {
-		catalog := catalogmocks.NewDataCoordCatalog(t)
-		catalog.EXPECT().
-			DropSegmentIndex(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-			Return(nil)
-
-		catalog.EXPECT().CreateSegmentIndex(mock.Anything, mock.Anything).Return(nil)
-
-		m := newSegmentIndexMeta(catalog)
-		err := m.AddSegmentIndex(context.TODO(), &model.SegmentIndex{
-			SegmentID:    3,
-			CollectionID: 1,
-			PartitionID:  2,
-			NumRows:      1024,
-			IndexID:      1,
-			BuildID:      4,
-		})
-		assert.NoError(t, err)
-
-		err = m.RemoveSegmentIndexByID(context.TODO(), 4)
-		assert.NoError(t, err)
-		assert.Equal(t, m.segmentIndexes.Len(), 0)
 		assert.Equal(t, len(m.segmentBuildInfo.List()), 0)
 	})
 }

--- a/internal/proxy/task_insert.go
+++ b/internal/proxy/task_insert.go
@@ -291,8 +291,6 @@ func (it *insertTask) Execute(ctx context.Context) error {
 		return err
 	}
 	it.insertMsg.CollectionID = collID
-	it.insertMsg.BeginTimestamp = it.BeginTs()
-	it.insertMsg.EndTimestamp = it.EndTs()
 
 	getCacheDur := tr.RecordSpan()
 	stream, err := it.chMgr.getOrCreateDmlStream(ctx, collID)


### PR DESCRIPTION
issue: #41288 