### PR TITLE
fix: [2.5] Use locking to ensure the atomicity of dropping segment indexes

### DIFF
--- a/internal/datacoord/garbage_collector.go
+++ b/internal/datacoord/garbage_collector.go
@@ -688,7 +688,7 @@ func (gc *garbageCollector) recycleUnusedSegIndexes(ctx context.Context) {
 			}
 
 			// Remove meta from index meta.
-			if err := gc.meta.indexMeta.RemoveSegmentIndex(ctx, segIdx.CollectionID, segIdx.PartitionID, segIdx.SegmentID, segIdx.IndexID, segIdx.BuildID); err != nil {
+			if err := gc.meta.indexMeta.RemoveSegmentIndex(ctx, segIdx.BuildID); err != nil {
 				log.Warn("delete index meta from etcd failed, wait to retry", zap.Error(err))
 				continue
 			}

--- a/internal/datacoord/garbage_collector_test.go
+++ b/internal/datacoord/garbage_collector_test.go
@@ -525,6 +525,7 @@ func createMetaForRecycleUnusedSegIndexes(catalog metastore.DataCoordCatalog) *m
 			segmentIndexes:   segIndexes,
 			indexes:          map[UniqueID]map[UniqueID]*model.Index{},
 			segmentBuildInfo: newSegmentIndexBuildInfo(),
+			keyLock:          lock.NewKeyLock[UniqueID](),
 		},
 		channelCPs:   nil,
 		chunkManager: nil,

--- a/internal/datacoord/index_meta.go
+++ b/internal/datacoord/index_meta.go
@@ -629,7 +629,10 @@ func (m *indexMeta) GetIndexesForCollection(collID UniqueID, indexName string) [
 	return indexInfos
 }
 
-func (m *indexMeta) getFieldIndexes(collID, fieldID UniqueID, indexName string) []*model.Index {
+func (m *indexMeta) GetFieldIndexes(collID, fieldID UniqueID, indexName string) []*model.Index {
+	m.fieldIndexLock.RLock()
+	defer m.fieldIndexLock.RUnlock()
+
 	indexInfos := make([]*model.Index, 0)
 	for _, index := range m.indexes[collID] {
 		if index.IsDeleted || index.FieldID != fieldID {
@@ -640,13 +643,6 @@ func (m *indexMeta) getFieldIndexes(collID, fieldID UniqueID, indexName string) 
 		}
 	}
 	return indexInfos
-}
-
-func (m *indexMeta) GetFieldIndexes(collID, fieldID UniqueID, indexName string) []*model.Index {
-	m.fieldIndexLock.RLock()
-	defer m.fieldIndexLock.RUnlock()
-
-	return m.getFieldIndexes(collID, fieldID, indexName)
 }
 
 // MarkIndexAsDeleted will mark the corresponding index as deleted, and recycleUnusedIndexFiles will recycle these tasks.
@@ -973,36 +969,32 @@ func (m *indexMeta) SetStoredIndexFileSizeMetric(collections *typeutil.Concurren
 	return total
 }
 
-func (m *indexMeta) removeSegmentIndex(ctx context.Context, collID, partID, segID, indexID, buildID UniqueID) error {
-	err := m.catalog.DropSegmentIndex(ctx, collID, partID, segID, buildID)
-	if err != nil {
-		return err
-	}
+func (m *indexMeta) RemoveSegmentIndex(ctx context.Context, buildID UniqueID) error {
+	m.keyLock.Lock(buildID)
+	defer m.keyLock.Unlock(buildID)
 
-	segIndexes, ok := m.segmentIndexes.Get(segID)
-	if ok {
-		segIndexes.Remove(indexID)
-		m.segmentIndexes.Insert(segID, segIndexes)
-	}
-	if segIndexes.Len() == 0 {
-		m.segmentIndexes.Remove(segID)
-	}
-
-	m.segmentBuildInfo.Remove(buildID)
-	return nil
-}
-
-func (m *indexMeta) RemoveSegmentIndex(ctx context.Context, collID, partID, segID, indexID, buildID UniqueID) error {
-	return m.removeSegmentIndex(ctx, collID, partID, segID, indexID, buildID)
-}
-
-func (m *indexMeta) RemoveSegmentIndexByID(ctx context.Context, buildID UniqueID) error {
 	segIdx, ok := m.segmentBuildInfo.Get(buildID)
 	if !ok {
 		return nil
 	}
 
-	return m.removeSegmentIndex(ctx, segIdx.CollectionID, segIdx.PartitionID, segIdx.SegmentID, segIdx.IndexID, buildID)
+	err := m.catalog.DropSegmentIndex(ctx, segIdx.CollectionID, segIdx.PartitionID, segIdx.SegmentID, buildID)
+	if err != nil {
+		return err
+	}
+
+	segIndexes, ok := m.segmentIndexes.Get(segIdx.SegmentID)
+	if ok {
+		segIndexes.Remove(segIdx.IndexID)
+		if segIndexes.Len() == 0 {
+			m.segmentIndexes.Remove(segIdx.SegmentID)
+		} else {
+			m.segmentIndexes.Insert(segIdx.SegmentID, segIndexes)
+		}
+	}
+
+	m.segmentBuildInfo.Remove(buildID)
+	return nil
 }
 
 func (m *indexMeta) GetDeletedIndexes() []*model.Index {

--- a/internal/datacoord/index_meta_test.go
+++ b/internal/datacoord/index_meta_test.go
@@ -1452,88 +1452,59 @@ func TestRemoveIndex(t *testing.T) {
 }
 
 func TestRemoveSegmentIndex(t *testing.T) {
+	t.Run("drop no exist segment index", func(t *testing.T) {
+		catalog := catalogmocks.NewDataCoordCatalog(t)
+		m := newSegmentIndexMeta(catalog)
+		err := m.RemoveSegmentIndex(context.TODO(), 0)
+
+		assert.NoError(t, err)
+	})
+
 	t.Run("drop segment index fail", func(t *testing.T) {
 		expectedErr := errors.New("error")
 		catalog := catalogmocks.NewDataCoordCatalog(t)
+		catalog.EXPECT().CreateSegmentIndex(mock.Anything, mock.Anything).Return(nil)
 		catalog.EXPECT().
 			DropSegmentIndex(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 			Return(expectedErr)
-
 		m := newSegmentIndexMeta(catalog)
-		err := m.RemoveSegmentIndex(context.TODO(), 0, 0, 0, 0, 0)
+		err := m.AddSegmentIndex(context.TODO(), &model.SegmentIndex{
+			SegmentID:    3,
+			CollectionID: 1,
+			PartitionID:  2,
+			NumRows:      1024,
+			IndexID:      1,
+			BuildID:      4,
+		})
+		assert.NoError(t, err)
 
+		err = m.RemoveSegmentIndex(context.TODO(), 4)
 		assert.Error(t, err)
 		assert.EqualError(t, err, "error")
 	})
 
 	t.Run("remove segment index ok", func(t *testing.T) {
 		catalog := catalogmocks.NewDataCoordCatalog(t)
+		catalog.EXPECT().CreateSegmentIndex(mock.Anything, mock.Anything).Return(nil)
 		catalog.EXPECT().
 			DropSegmentIndex(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 			Return(nil)
 
-		m := &indexMeta{
-			catalog:          catalog,
-			segmentIndexes:   typeutil.NewConcurrentMap[UniqueID, *typeutil.ConcurrentMap[UniqueID, *model.SegmentIndex]](),
-			segmentBuildInfo: newSegmentIndexBuildInfo(),
-		}
-		m.segmentIndexes.Insert(segID, typeutil.NewConcurrentMap[UniqueID, *model.SegmentIndex]())
+		m := newSegmentIndexMeta(catalog)
+		err := m.AddSegmentIndex(context.TODO(), &model.SegmentIndex{
+			SegmentID:    3,
+			CollectionID: 1,
+			PartitionID:  2,
+			NumRows:      1024,
+			IndexID:      1,
+			BuildID:      4,
+		})
+		assert.NoError(t, err)
 
-		err := m.RemoveSegmentIndex(context.TODO(), collID, partID, segID, indexID, buildID)
+		err = m.RemoveSegmentIndex(context.TODO(), 4)
 		assert.NoError(t, err)
 
 		assert.Equal(t, 0, m.segmentIndexes.Len())
-		assert.Equal(t, len(m.segmentBuildInfo.List()), 0)
-	})
-}
-
-func TestRemoveSegmentIndexByID(t *testing.T) {
-	t.Run("drop segment index fail", func(t *testing.T) {
-		expectedErr := errors.New("error")
-		catalog := catalogmocks.NewDataCoordCatalog(t)
-		catalog.EXPECT().
-			DropSegmentIndex(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-			Return(expectedErr)
-
-		catalog.EXPECT().CreateSegmentIndex(mock.Anything, mock.Anything).Return(nil)
-
-		m := newSegmentIndexMeta(catalog)
-		err := m.AddSegmentIndex(context.TODO(), &model.SegmentIndex{
-			SegmentID:    3,
-			CollectionID: 1,
-			PartitionID:  2,
-			NumRows:      1024,
-			IndexID:      1,
-			BuildID:      4,
-		})
-		assert.NoError(t, err)
-		err = m.RemoveSegmentIndexByID(context.TODO(), 4)
-		assert.Error(t, err)
-		assert.EqualError(t, err, "error")
-	})
-
-	t.Run("remove segment index ok", func(t *testing.T) {
-		catalog := catalogmocks.NewDataCoordCatalog(t)
-		catalog.EXPECT().
-			DropSegmentIndex(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-			Return(nil)
-
-		catalog.EXPECT().CreateSegmentIndex(mock.Anything, mock.Anything).Return(nil)
-
-		m := newSegmentIndexMeta(catalog)
-		err := m.AddSegmentIndex(context.TODO(), &model.SegmentIndex{
-			SegmentID:    3,
-			CollectionID: 1,
-			PartitionID:  2,
-			NumRows:      1024,
-			IndexID:      1,
-			BuildID:      4,
-		})
-		assert.NoError(t, err)
-
-		err = m.RemoveSegmentIndexByID(context.TODO(), 4)
-		assert.NoError(t, err)
-		assert.Equal(t, m.segmentIndexes.Len(), 0)
 		assert.Equal(t, len(m.segmentBuildInfo.List()), 0)
 	})
 }

--- a/internal/datacoord/task_index.go
+++ b/internal/datacoord/task_index.go
@@ -394,5 +394,5 @@ func (it *indexBuildTask) SetJobInfo(meta *meta) error {
 }
 
 func (it *indexBuildTask) DropTaskMeta(ctx context.Context, meta *meta) error {
-	return meta.indexMeta.RemoveSegmentIndexByID(ctx, it.taskID)
+	return meta.indexMeta.RemoveSegmentIndex(ctx, it.taskID)
 }


### PR DESCRIPTION
issue:  #41288 

master pr: #42075 