### PR TITLE
doc: Fix small typo in internal/datanode/README.md

### DIFF
--- a/internal/datanode/README.md
+++ b/internal/datanode/README.md
@@ -5,6 +5,6 @@ DataNode is the component to write insert and delete messages into persistent bl
 ## Dependency
 
 - KV store: a kv store that persists messages into blob storage.
-- Message stream: receive messages and publish imformation
+- Message stream: receive messages and publish information
 - Root Coordinator: get the latest unique IDs.
 - Data Coordinator: get the flush information and which message stream to subscribe.


### PR DESCRIPTION
This PR fixes a minor typo in the README file of the datanode module.
Corrected "imformation" to "information".