### PR TITLE
feat: Enhance 3rdparty build script with build type option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -253,7 +253,7 @@ download-milvus-proto:
 
 build-3rdparty:
 	@echo "Build 3rdparty ..."
-	@(env bash $(PWD)/scripts/3rdparty_build.sh -o ${use_opendal})
+	@(env bash $(PWD)/scripts/3rdparty_build.sh -o ${use_opendal} -t ${mode})
 
 generated-proto-without-cpp: download-milvus-proto get-proto-deps
 	@echo "Generate proto ..."


### PR DESCRIPTION
See #42091

In this PR,
- Added a new `-t` option to specify the build type (Debug/Release).
- Updated the Makefile to pass the build type to the 3rdparty build script.
- Included usage instructions for the script to improve user guidance.