### PR TITLE
enhance: [AddField][Nullable] Fill absent nullable field server-side

### DIFF
--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -1691,10 +1691,11 @@ func checkFieldsDataBySchema(schema *schemapb.CollectionSchema, insertMsg *msgst
 			}
 			// when use default_value or has set Nullable
 			// it's ok that no corresponding fieldData found
-			dataToAppend := &schemapb.FieldData{
-				Type:      fieldSchema.GetDataType(),
-				FieldName: fieldSchema.GetName(),
+			dataToAppend, err := typeutil.GenEmptyFieldData(fieldSchema)
+			if err != nil {
+				return err
 			}
+			dataToAppend.ValidData = make([]bool, insertMsg.GetNumRows())
 			insertMsg.FieldsData = append(insertMsg.FieldsData, dataToAppend)
 		}
 	}


### PR DESCRIPTION
Related to #39718

The absent nullable field shall be filled at server-side in nullable design. While the implementation here was buggy causing the feature was not able to serve.

This PR make proxy fill the field data in correct format so that field data with absent column(s) will be accepted.