### PR TITLE
enhance: Take nq into slow query consideration

### DIFF
--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -1991,7 +1991,7 @@ please adjust in embedded Milvus: false`,
 	p.SlowLogSpanInSeconds = ParamItem{
 		Key:          "proxy.slowLogSpanInSeconds",
 		Version:      "2.5.8",
-		Doc:          "query whose executed time exceeds the `slowLogSpanInSeconds` will have slow log, in seconds.",
+		Doc:          "query whose executed time exceeds the `slowLogSpanInSeconds` will have slow log, in seconds. If request type is search, the query time will be divided by nq number.",
 		DefaultValue: "1",
 		FallbackKeys: []string{"proxy.slowQuerySpanInSeconds"},
 		Export:       false,


### PR DESCRIPTION
Related to #40756

Large nq will naturally increase query time, which causing lots of slow log when user NQ numbers are very large.

This PR make slow search counts span per nq (using avg val) to decide whether one request is slow or not.