### PR TITLE
fix: Fix concurrent l0Compaction and Stats

### DIFF
--- a/internal/datacoord/compaction_task_l0.go
+++ b/internal/datacoord/compaction_task_l0.go
@@ -188,8 +188,13 @@ func (t *l0CompactionTask) Process() bool {
 		return t.processMetaSaved()
 	case datapb.CompactionTaskState_completed:
 		return t.processCompleted()
+	case datapb.CompactionTaskState_failed:
+		return true
+	case datapb.CompactionTaskState_timeout:
+		return true
+	default:
+		return false
 	}
-	return true
 }
 
 func (t *l0CompactionTask) processMetaSaved() bool {

--- a/internal/datacoord/compaction_task_l0_test.go
+++ b/internal/datacoord/compaction_task_l0_test.go
@@ -507,10 +507,22 @@ func (s *L0CompactionTaskSuite) TestPorcessStateTrans() {
 		s.Equal(datapb.CompactionTaskState_failed, t.GetTaskProto().GetState())
 	})
 
-	s.Run("test unknown task", func() {
-		t := s.generateTestL0Task(datapb.CompactionTaskState_unknown)
+	s.Run("test process states", func() {
+		testCases := []struct {
+			state         datapb.CompactionTaskState
+			processResult bool
+		}{
+			{state: datapb.CompactionTaskState_unknown, processResult: false},
+			{state: datapb.CompactionTaskState_pipelining, processResult: false},
+			{state: datapb.CompactionTaskState_executing, processResult: false},
+			{state: datapb.CompactionTaskState_failed, processResult: true},
+			{state: datapb.CompactionTaskState_timeout, processResult: true},
+		}
 
-		got := t.Process()
-		s.True(got)
+		for _, tc := range testCases {
+			t := s.generateTestL0Task(tc.state)
+			res := t.Process()
+			s.Equal(tc.processResult, res)
+		}
 	})
 }

--- a/internal/datacoord/compaction_task_mix_test.go
+++ b/internal/datacoord/compaction_task_mix_test.go
@@ -90,3 +90,27 @@ func (s *MixCompactionTaskSuite) TestProcessRefreshPlan_MixSegmentNotFound() {
 		s.ErrorIs(err, merr.ErrSegmentNotFound)
 	})
 }
+
+func (s *MixCompactionTaskSuite) TestProcess() {
+	s.Run("test process states", func() {
+		testCases := []struct {
+			state         datapb.CompactionTaskState
+			processResult bool
+		}{
+			{state: datapb.CompactionTaskState_unknown, processResult: false},
+			{state: datapb.CompactionTaskState_pipelining, processResult: false},
+			{state: datapb.CompactionTaskState_executing, processResult: false},
+			{state: datapb.CompactionTaskState_failed, processResult: true},
+			{state: datapb.CompactionTaskState_timeout, processResult: true},
+		}
+
+		for _, tc := range testCases {
+			task := newMixCompactionTask(&datapb.CompactionTask{
+				PlanID: 1,
+				State:  tc.state,
+			}, nil, s.mockMeta)
+			res := task.Process()
+			s.Equal(tc.processResult, res)
+		}
+	})
+}


### PR DESCRIPTION
Return `false` in the `Process()` function for `executing` or `pipelining` state `l0Compaction`. This prevents the `l0Compaction` task from being removed from the `CompactionInspector`'s executing queue, thereby avoiding concurrent execution of `l0Compaction` and `Stats`.

issue: https://github.com/milvus-io/milvus/issues/42008