### PR TITLE
fix: [AddField] Use metacache schema in embedding node

### DIFF
--- a/internal/flushcommon/pipeline/data_sync_service.go
+++ b/internal/flushcommon/pipeline/data_sync_service.go
@@ -288,7 +288,7 @@ func getServiceWithChannel(initCtx context.Context, params *util.PipelineParams,
 	nodeList = append(nodeList, ddNode)
 
 	if len(info.GetSchema().GetFunctions()) > 0 {
-		emNode, err := newEmbeddingNode(channelName, info.GetSchema())
+		emNode, err := newEmbeddingNode(channelName, config.metacache)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/flushcommon/pipeline/flow_graph_embedding_node.go
+++ b/internal/flushcommon/pipeline/flow_graph_embedding_node.go
@@ -38,7 +38,6 @@ import (
 type embeddingNode struct {
 	BaseNode
 
-	// schema      *schemapb.CollectionSchema
 	metaCache   metacache.MetaCache
 	pkField     *schemapb.FieldSchema
 	channelName string

--- a/internal/flushcommon/pipeline/flow_graph_embedding_node.go
+++ b/internal/flushcommon/pipeline/flow_graph_embedding_node.go
@@ -24,6 +24,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/flushcommon/metacache"
 	"github.com/milvus-io/milvus/internal/flushcommon/writebuffer"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/util/function"
@@ -37,7 +38,8 @@ import (
 type embeddingNode struct {
 	BaseNode
 
-	schema      *schemapb.CollectionSchema
+	// schema      *schemapb.CollectionSchema
+	metaCache   metacache.MetaCache
 	pkField     *schemapb.FieldSchema
 	channelName string
 
@@ -45,7 +47,7 @@ type embeddingNode struct {
 	functionRunners map[int64]function.FunctionRunner
 }
 
-func newEmbeddingNode(channelName string, schema *schemapb.CollectionSchema) (*embeddingNode, error) {
+func newEmbeddingNode(channelName string, metaCache metacache.MetaCache) (*embeddingNode, error) {
 	baseNode := BaseNode{}
 	baseNode.SetMaxQueueLength(paramtable.Get().DataNodeCfg.FlowGraphMaxQueueLength.GetAsInt32())
 	baseNode.SetMaxParallelism(paramtable.Get().DataNodeCfg.FlowGraphMaxParallelism.GetAsInt32())
@@ -53,9 +55,11 @@ func newEmbeddingNode(channelName string, schema *schemapb.CollectionSchema) (*e
 	node := &embeddingNode{
 		BaseNode:        baseNode,
 		channelName:     channelName,
-		schema:          schema,
+		metaCache:       metaCache,
 		functionRunners: make(map[int64]function.FunctionRunner),
 	}
+
+	schema := metaCache.Schema()
 
 	for _, field := range schema.GetFields() {
 		if field.GetIsPrimaryKey() {
@@ -152,7 +156,7 @@ func (eNode *embeddingNode) Operate(in []Msg) []Msg {
 		return []Msg{fgMsg}
 	}
 
-	insertData, err := writebuffer.PrepareInsert(eNode.schema, eNode.pkField, fgMsg.InsertMessages)
+	insertData, err := writebuffer.PrepareInsert(eNode.metaCache.Schema(), eNode.pkField, fgMsg.InsertMessages)
 	if err != nil {
 		log.Error("failed to prepare insert data", zap.Error(err))
 		panic(err)

--- a/internal/flushcommon/pipeline/flow_graph_embedding_node_test.go
+++ b/internal/flushcommon/pipeline/flow_graph_embedding_node_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/flushcommon/metacache"
 	"github.com/milvus-io/milvus/internal/util/flowgraph"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/mq/msgstream"
@@ -66,8 +67,11 @@ func TestEmbeddingNode_BM25_Operator(t *testing.T) {
 		}},
 	}
 
+	metaCache := metacache.NewMockMetaCache(t)
+	metaCache.EXPECT().Schema().Return(collSchema)
+
 	t.Run("normal case", func(t *testing.T) {
-		node, err := newEmbeddingNode("test-channel", collSchema)
+		node, err := newEmbeddingNode("test-channel", metaCache)
 		assert.NoError(t, err)
 
 		var output []Msg
@@ -108,7 +112,7 @@ func TestEmbeddingNode_BM25_Operator(t *testing.T) {
 	})
 
 	t.Run("with close msg", func(t *testing.T) {
-		node, err := newEmbeddingNode("test-channel", collSchema)
+		node, err := newEmbeddingNode("test-channel", metaCache)
 		assert.NoError(t, err)
 
 		var output []Msg
@@ -125,7 +129,7 @@ func TestEmbeddingNode_BM25_Operator(t *testing.T) {
 	})
 
 	t.Run("prepare insert failed", func(t *testing.T) {
-		node, err := newEmbeddingNode("test-channel", collSchema)
+		node, err := newEmbeddingNode("test-channel", metaCache)
 		assert.NoError(t, err)
 
 		assert.Panics(t, func() {
@@ -146,7 +150,7 @@ func TestEmbeddingNode_BM25_Operator(t *testing.T) {
 	})
 
 	t.Run("embedding failed", func(t *testing.T) {
-		node, err := newEmbeddingNode("test-channel", collSchema)
+		node, err := newEmbeddingNode("test-channel", metaCache)
 		assert.NoError(t, err)
 
 		node.functionRunners[0].GetSchema().Type = 0


### PR DESCRIPTION
Related to #42084

Embedding node cached schema when created, causing schema mismatch after schema change. This PR make embeddingNode use schema from metacache, which will be updated.