### PR TITLE
fix: Add timeout mechanism for balance channel task waiting

### DIFF
--- a/internal/querycoordv2/task/scheduler.go
+++ b/internal/querycoordv2/task/scheduler.go
@@ -40,6 +40,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/util/hardware"
 	"github.com/milvus-io/milvus/pkg/v2/util/lock"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/timerecord"
 	. "github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
@@ -297,6 +298,9 @@ type taskScheduler struct {
 	// nodeID -> collectionID -> taskDelta
 	segmentTaskDelta *ExecutingTaskDelta
 	channelTaskDelta *ExecutingTaskDelta
+
+	// balance channel task waiting ts
+	balanceChannelTaskWaitingTs *ConcurrentMap[UniqueID, time.Time]
 }
 
 func NewScheduler(ctx context.Context,
@@ -322,15 +326,16 @@ func NewScheduler(ctx context.Context,
 		cluster:   cluster,
 		nodeMgr:   nodeMgr,
 
-		collKeyLock:      lock.NewKeyLock[int64](),
-		tasks:            NewConcurrentMap[UniqueID, struct{}](),
-		segmentTasks:     NewConcurrentMap[replicaSegmentIndex, Task](),
-		channelTasks:     NewConcurrentMap[replicaChannelIndex, Task](),
-		processQueue:     newTaskQueue(),
-		waitQueue:        newTaskQueue(),
-		taskStats:        expirable.NewLRU[UniqueID, Task](256, nil, time.Minute*15),
-		segmentTaskDelta: NewExecutingTaskDelta(),
-		channelTaskDelta: NewExecutingTaskDelta(),
+		collKeyLock:                 lock.NewKeyLock[int64](),
+		tasks:                       NewConcurrentMap[UniqueID, struct{}](),
+		segmentTasks:                NewConcurrentMap[replicaSegmentIndex, Task](),
+		channelTasks:                NewConcurrentMap[replicaChannelIndex, Task](),
+		processQueue:                newTaskQueue(),
+		waitQueue:                   newTaskQueue(),
+		taskStats:                   expirable.NewLRU[UniqueID, Task](256, nil, time.Minute*15),
+		segmentTaskDelta:            NewExecutingTaskDelta(),
+		channelTaskDelta:            NewExecutingTaskDelta(),
+		balanceChannelTaskWaitingTs: NewConcurrentMap[UniqueID, time.Time](),
 	}
 }
 
@@ -862,14 +867,30 @@ func (scheduler *taskScheduler) preProcess(task Task) bool {
 			default:
 				newDelegatorReady = true
 			}
+
+			// for balance channel task, if the new delegator is not ready, wait for it to prevent release the old delegator too early
+			// cause balance channel will block balance segment, so we need to prevent balance channel waiting forever
+			// so we add param to control the waiting timeout, and cancel the task if timeout
 			if !newDelegatorReady {
-				log.Ctx(scheduler.ctx).
-					WithRateGroup("qcv2.preProcess", 1, 60).
-					RatedInfo(30, "Blocking reduce action in balance channel task",
+				startWaitingTs, ok := scheduler.balanceChannelTaskWaitingTs.Get(task.ID())
+				if !ok {
+					startWaitingTs = time.Now()
+					scheduler.balanceChannelTaskWaitingTs.Insert(task.ID(), startWaitingTs)
+				}
+
+				if time.Since(startWaitingTs) > paramtable.Get().QueryCoordCfg.BalanceChannelTaskWaitingTimeout.GetAsDuration(time.Millisecond) {
+					scheduler.balanceChannelTaskWaitingTs.Remove(task.ID())
+					log.Info("balance channel task waiting timeout for new delegator ready, cancel task",
+						zap.Int64("taskID", task.ID()),
 						zap.Int64("collectionID", task.CollectionID()),
 						zap.String("channelName", task.Shard()),
-						zap.Int64("taskID", task.ID()))
+						zap.Duration("waitingTime", time.Since(startWaitingTs)))
+					task.SetStatus(TaskStatusCanceled)
+				}
 				break
+			} else {
+				// new delegator ready, clean waiting ts
+				scheduler.balanceChannelTaskWaitingTs.Remove(task.ID())
 			}
 		}
 		task.StepUp()

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -2096,6 +2096,8 @@ type queryCoordConfig struct {
 	BalanceSegmentBatchSize            ParamItem `refreshable:"true"`
 	BalanceChannelBatchSize            ParamItem `refreshable:"true"`
 	EnableBalanceOnMultipleCollections ParamItem `refreshable:"true"`
+
+	BalanceChannelTaskWaitingTimeout ParamItem `refreshable:"true"`
 }
 
 func (p *queryCoordConfig) init(base *BaseTable) {
@@ -2719,6 +2721,15 @@ If this parameter is set false, Milvus simply searches the growing segments with
 		Export:       false,
 	}
 	p.EnableBalanceOnMultipleCollections.Init(base.mgr)
+
+	p.BalanceChannelTaskWaitingTimeout = ParamItem{
+		Key:          "queryCoord.balanceChannelTaskWaitingTimeout",
+		Version:      "2.5.13",
+		DefaultValue: "60000",
+		Doc:          "the timeout for waiting new delegator ready in balance channel task",
+		Export:       false,
+	}
+	p.BalanceChannelTaskWaitingTimeout.Init(base.mgr)
 }
 
 // /////////////////////////////////////////////////////////////////////////////

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -385,6 +385,8 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, 5, Params.BalanceSegmentBatchSize.GetAsInt())
 		assert.Equal(t, 1, Params.BalanceChannelBatchSize.GetAsInt())
 		assert.Equal(t, true, Params.EnableBalanceOnMultipleCollections.GetAsBool())
+
+		assert.Equal(t, 60000, Params.BalanceChannelTaskWaitingTimeout.GetAsInt())
 	})
 
 	t.Run("test queryNodeConfig", func(t *testing.T) {


### PR DESCRIPTION
issue: #42116 
Fix the issue where balance channel tasks could wait indefinitely for new delegator to become ready, potentially blocking balance segment operations.

Changes include:
- Add balanceChannelTaskWaitingTs field to track waiting start time
- Implement timeout mechanism with configurable duration parameter
- Add BalanceChannelTaskWaitingTimeout config parameter (default 60s)
- Cancel balance channel task when timeout is exceeded
- Add comprehensive unit tests for timeout scenarios

The timeout prevents balance channel tasks from waiting forever while ensuring proper cleanup of resources and maintaining system responsiveness.