### PR TITLE
fix: [2.5] Add timeout mechanism for balance channel task waiting

### DIFF
--- a/internal/querycoordv2/task/task_test.go
+++ b/internal/querycoordv2/task/task_test.go
@@ -2003,3 +2003,208 @@ func newReplicaDefaultRG(replicaID int64) *meta.Replica {
 		typeutil.NewUniqueSet(),
 	)
 }
+
+func (suite *TaskSuite) TestBalanceChannelTaskWaitingTimeout() {
+	ctx := context.Background()
+	collectionID := suite.collection
+	partitionID := int64(1)
+	channel := "channel-timeout-test"
+	vchannel := &datapb.VchannelInfo{
+		CollectionID: collectionID,
+		ChannelName:  channel,
+	}
+
+	segments := []*datapb.SegmentInfo{
+		{
+			ID:            1,
+			CollectionID:  collectionID,
+			PartitionID:   partitionID,
+			InsertChannel: channel,
+		},
+	}
+
+	suite.meta.PutCollection(ctx, utils.CreateTestCollection(collectionID, 1), utils.CreateTestPartition(collectionID, 1))
+	suite.broker.ExpectedCalls = nil
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, mock.Anything).Return([]*datapb.VchannelInfo{vchannel}, segments, nil)
+	suite.target.UpdateCollectionNextTarget(ctx, collectionID)
+	suite.target.UpdateCollectionCurrentTarget(ctx, collectionID)
+	suite.target.UpdateCollectionNextTarget(ctx, collectionID)
+
+	// Set up old delegator distribution
+	suite.dist.ChannelDistManager.Update(2, &meta.DmChannel{
+		VchannelInfo: &datapb.VchannelInfo{
+			CollectionID: collectionID,
+			ChannelName:  channel,
+		},
+		Node:    2,
+		Version: 1,
+	})
+	suite.dist.LeaderViewManager.Update(2, &meta.LeaderView{
+		ID:           2,
+		CollectionID: collectionID,
+		Channel:      channel,
+	})
+
+	suite.dist.ChannelDistManager.Update(1, &meta.DmChannel{
+		VchannelInfo: &datapb.VchannelInfo{
+			CollectionID: collectionID,
+			ChannelName:  channel,
+		},
+		Node:    1,
+		Version: 1,
+	})
+	suite.dist.LeaderViewManager.Update(1, &meta.LeaderView{
+		ID:                 1,
+		CollectionID:       collectionID,
+		Channel:            channel,
+		Version:            1,
+		UnServiceableError: merr.ErrSegmentLack,
+	})
+
+	// Create balance channel task (move from node 2 to node 1)
+	task, err := NewChannelTask(context.Background(),
+		10*time.Second,
+		WrapIDSource(2),
+		collectionID,
+		suite.replica,
+		NewChannelAction(1, ActionTypeGrow, channel),
+		NewChannelAction(2, ActionTypeReduce, channel),
+	)
+	suite.NoError(err)
+	task.SetID(1001)
+
+	// Initialize balanceChannelTaskWaitingTs if not already initialized
+	if suite.scheduler.balanceChannelTaskWaitingTs == nil {
+		suite.scheduler.balanceChannelTaskWaitingTs = typeutil.NewConcurrentMap[typeutil.UniqueID, time.Time]()
+	}
+
+	// Set a very short timeout for testing (1 millisecond)
+	originalTimeout := paramtable.Get().QueryCoordCfg.BalanceChannelTaskWaitingTimeout.GetValue()
+	paramtable.Get().Save(paramtable.Get().QueryCoordCfg.BalanceChannelTaskWaitingTimeout.Key, "1")
+	defer paramtable.Get().Save(paramtable.Get().QueryCoordCfg.BalanceChannelTaskWaitingTimeout.Key, originalTimeout)
+
+	// First preProcess call should record the waiting start time
+	result := suite.scheduler.preProcess(task)
+	suite.True(result)                            // Should return true because new delegator is not ready
+	suite.Equal(0, task.step)                     // Task should not step up
+	suite.Equal(TaskStatusStarted, task.Status()) // Task should still be started
+
+	// Verify that waiting timestamp is recorded
+	_, exists := suite.scheduler.balanceChannelTaskWaitingTs.Get(task.ID())
+	suite.True(exists)
+
+	// Wait for timeout to exceed
+	time.Sleep(2 * time.Millisecond)
+
+	// Second preProcess call should timeout and cancel the task
+	result = suite.scheduler.preProcess(task)
+	suite.False(result)                            // Should return false because task is canceled
+	suite.Equal(TaskStatusCanceled, task.Status()) // Task should be canceled
+
+	// Verify that waiting timestamp is removed after timeout
+	_, exists = suite.scheduler.balanceChannelTaskWaitingTs.Get(task.ID())
+	suite.False(exists)
+}
+
+func (suite *TaskSuite) TestBalanceChannelTaskWaitingTimeoutWithNewDelegatorReady() {
+	ctx := context.Background()
+	collectionID := suite.collection
+	partitionID := int64(1)
+	channel := "channel-ready-test"
+	vchannel := &datapb.VchannelInfo{
+		CollectionID: collectionID,
+		ChannelName:  channel,
+	}
+
+	segments := []*datapb.SegmentInfo{
+		{
+			ID:            1,
+			CollectionID:  collectionID,
+			PartitionID:   partitionID,
+			InsertChannel: channel,
+		},
+	}
+
+	suite.meta.PutCollection(ctx, utils.CreateTestCollection(collectionID, 1), utils.CreateTestPartition(collectionID, 1))
+	suite.broker.ExpectedCalls = nil
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, mock.Anything).Return([]*datapb.VchannelInfo{vchannel}, segments, nil)
+	suite.target.UpdateCollectionNextTarget(ctx, collectionID)
+	suite.target.UpdateCollectionCurrentTarget(ctx, collectionID)
+	suite.target.UpdateCollectionNextTarget(ctx, collectionID)
+
+	// Set up old delegator distribution
+	suite.dist.ChannelDistManager.Update(2, &meta.DmChannel{
+		VchannelInfo: &datapb.VchannelInfo{
+			CollectionID: collectionID,
+			ChannelName:  channel,
+		},
+		Node:    2,
+		Version: 1,
+	})
+	suite.dist.LeaderViewManager.Update(2, &meta.LeaderView{
+		ID:           2,
+		CollectionID: collectionID,
+		Channel:      channel,
+	})
+
+	suite.dist.ChannelDistManager.Update(1, &meta.DmChannel{
+		VchannelInfo: &datapb.VchannelInfo{
+			CollectionID: collectionID,
+			ChannelName:  channel,
+		},
+		Node:    1,
+		Version: 2,
+	})
+
+	suite.dist.LeaderViewManager.Update(1, &meta.LeaderView{
+		ID:                 1,
+		CollectionID:       collectionID,
+		Channel:            channel,
+		Version:            2,
+		UnServiceableError: merr.ErrSegmentLack,
+	})
+
+	// Create balance channel task (move from node 2 to node 1)
+	task, err := NewChannelTask(context.Background(),
+		10*time.Second,
+		WrapIDSource(2),
+		collectionID,
+		suite.replica,
+		NewChannelAction(1, ActionTypeGrow, channel),
+		NewChannelAction(2, ActionTypeReduce, channel),
+	)
+	suite.NoError(err)
+	task.SetID(1002)
+
+	// Initialize balanceChannelTaskWaitingTs if not already initialized
+	if suite.scheduler.balanceChannelTaskWaitingTs == nil {
+		suite.scheduler.balanceChannelTaskWaitingTs = typeutil.NewConcurrentMap[typeutil.UniqueID, time.Time]()
+	}
+
+	// First preProcess call should record the waiting start time
+	result := suite.scheduler.preProcess(task)
+	suite.True(result)        // Should return true because new delegator is not ready
+	suite.Equal(0, task.step) // Task should not step up
+
+	// Verify that waiting timestamp is recorded
+	_, exists := suite.scheduler.balanceChannelTaskWaitingTs.Get(task.ID())
+	suite.True(exists)
+
+	// Now set up new delegator distribution (new delegator becomes ready)
+	suite.dist.LeaderViewManager.Update(1, &meta.LeaderView{
+		ID:           1,
+		CollectionID: collectionID,
+		Channel:      channel,
+		Version:      2,
+	})
+
+	// Second preProcess call should succeed because new delegator is ready
+	result = suite.scheduler.preProcess(task)
+	suite.True(result)                            // Should return true because task can proceed
+	suite.Equal(1, task.step)                     // Task should step up
+	suite.Equal(TaskStatusStarted, task.Status()) // Task should still be started
+
+	// Verify that waiting timestamp is removed when delegator becomes ready
+	_, exists = suite.scheduler.balanceChannelTaskWaitingTs.Get(task.ID())
+	suite.False(exists)
+}

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -1954,6 +1954,8 @@ type queryCoordConfig struct {
 	BalanceSegmentBatchSize            ParamItem `refreshable:"true"`
 	BalanceChannelBatchSize            ParamItem `refreshable:"true"`
 	EnableBalanceOnMultipleCollections ParamItem `refreshable:"true"`
+
+	BalanceChannelTaskWaitingTimeout ParamItem `refreshable:"true"`
 }
 
 func (p *queryCoordConfig) init(base *BaseTable) {
@@ -2577,6 +2579,15 @@ If this parameter is set false, Milvus simply searches the growing segments with
 		Export:       false,
 	}
 	p.EnableBalanceOnMultipleCollections.Init(base.mgr)
+
+	p.BalanceChannelTaskWaitingTimeout = ParamItem{
+		Key:          "queryCoord.balanceChannelTaskWaitingTimeout",
+		Version:      "2.5.13",
+		DefaultValue: "60000",
+		Doc:          "the timeout for waiting new delegator ready in balance channel task",
+		Export:       false,
+	}
+	p.BalanceChannelTaskWaitingTimeout.Init(base.mgr)
 }
 
 // /////////////////////////////////////////////////////////////////////////////

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -385,6 +385,7 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, 5, Params.BalanceSegmentBatchSize.GetAsInt())
 		assert.Equal(t, 1, Params.BalanceChannelBatchSize.GetAsInt())
 		assert.Equal(t, true, Params.EnableBalanceOnMultipleCollections.GetAsBool())
+		assert.Equal(t, 60000, Params.BalanceChannelTaskWaitingTimeout.GetAsInt())
 	})
 
 	t.Run("test queryNodeConfig", func(t *testing.T) {


### PR DESCRIPTION
issue: #42216
pr: #42217

Fix the issue where balance channel tasks could wait indefinitely for new delegator to become ready, potentially blocking balance segment operations.

Changes include:
- Add balanceChannelTaskWaitingTs field to track waiting start time
- Implement timeout mechanism with configurable duration parameter
- Add BalanceChannelTaskWaitingTimeout config parameter (default 60s)
- Cancel balance channel task when timeout is exceeded
- Add comprehensive unit tests for timeout scenarios

The timeout prevents balance channel tasks from waiting forever while ensuring proper cleanup of resources and maintaining system responsiveness.