### PR TITLE
enhance: [2.5] support balancing multiple collections in single trigger (#41875)

### DIFF
--- a/internal/querycoordv2/balance/balance.go
+++ b/internal/querycoordv2/balance/balance.go
@@ -91,7 +91,7 @@ func (b *RoundRobinBalancer) AssignSegment(ctx context.Context, collectionID int
 		return cnt1+delta1 < cnt2+delta2
 	})
 
-	balanceBatchSize := paramtable.Get().QueryCoordCfg.CollectionBalanceSegmentBatchSize.GetAsInt()
+	balanceBatchSize := paramtable.Get().QueryCoordCfg.BalanceSegmentBatchSize.GetAsInt()
 	ret := make([]SegmentAssignPlan, 0, len(segments))
 	for i, s := range segments {
 		plan := SegmentAssignPlan{

--- a/internal/querycoordv2/balance/rowcount_based_balancer.go
+++ b/internal/querycoordv2/balance/rowcount_based_balancer.go
@@ -63,7 +63,7 @@ func (b *RowCountBasedBalancer) AssignSegment(ctx context.Context, collectionID 
 		return segments[i].GetNumOfRows() > segments[j].GetNumOfRows()
 	})
 
-	balanceBatchSize := paramtable.Get().QueryCoordCfg.CollectionBalanceSegmentBatchSize.GetAsInt()
+	balanceBatchSize := paramtable.Get().QueryCoordCfg.BalanceSegmentBatchSize.GetAsInt()
 	plans := make([]SegmentAssignPlan, 0, len(segments))
 	for _, s := range segments {
 		// pick the node with the least row count and allocate to it.

--- a/internal/querycoordv2/balance/score_based_balancer.go
+++ b/internal/querycoordv2/balance/score_based_balancer.go
@@ -67,7 +67,7 @@ func (b *ScoreBasedBalancer) assignSegment(br *balanceReport, collectionID int64
 			}
 			return normalNode
 		})
-		balanceBatchSize = paramtable.Get().QueryCoordCfg.CollectionBalanceSegmentBatchSize.GetAsInt()
+		balanceBatchSize = paramtable.Get().QueryCoordCfg.BalanceSegmentBatchSize.GetAsInt()
 	}
 
 	// calculate each node's score
@@ -159,7 +159,7 @@ func (b *ScoreBasedBalancer) assignChannel(br *balanceReport, collectionID int64
 			}
 			return normalNode
 		})
-		balanceBatchSize = paramtable.Get().QueryCoordCfg.CollectionBalanceChannelBatchSize.GetAsInt()
+		balanceBatchSize = paramtable.Get().QueryCoordCfg.BalanceChannelBatchSize.GetAsInt()
 	}
 
 	// calculate each node's score
@@ -605,7 +605,7 @@ func (b *ScoreBasedBalancer) genChannelPlan(ctx context.Context, br *balanceRepo
 		channelDist[node] = b.dist.ChannelDistManager.GetByFilter(meta.WithCollectionID2Channel(replica.GetCollectionID()), meta.WithNodeID2Channel(node))
 	}
 
-	balanceBatchSize := paramtable.Get().QueryCoordCfg.CollectionBalanceSegmentBatchSize.GetAsInt()
+	balanceBatchSize := paramtable.Get().QueryCoordCfg.BalanceSegmentBatchSize.GetAsInt()
 	// find the segment from the node which has more score than the average
 	channelsToMove := make([]*meta.DmChannel, 0)
 	for node, channels := range channelDist {

--- a/internal/querycoordv2/balance/score_based_balancer_test.go
+++ b/internal/querycoordv2/balance/score_based_balancer_test.go
@@ -1371,8 +1371,8 @@ func (suite *ScoreBasedBalancerTestSuite) TestBalanceChannelOnDifferentQN() {
 	suite.balancer.meta.ResourceManager.HandleNodeUp(ctx, 2)
 	utils.RecoverAllCollection(balancer.meta)
 
-	paramtable.Get().Save(paramtable.Get().QueryCoordCfg.CollectionBalanceChannelBatchSize.Key, "10")
-	defer paramtable.Get().Reset(paramtable.Get().QueryCoordCfg.CollectionBalanceChannelBatchSize.Key)
+	paramtable.Get().Save(paramtable.Get().QueryCoordCfg.BalanceChannelBatchSize.Key, "10")
+	defer paramtable.Get().Reset(paramtable.Get().QueryCoordCfg.BalanceChannelBatchSize.Key)
 
 	// test balance channel on same query node
 	_, channelPlans = suite.getCollectionBalancePlans(balancer, collectionID)

--- a/internal/querycoordv2/checkers/balance_checker.go
+++ b/internal/querycoordv2/checkers/balance_checker.go
@@ -108,10 +108,9 @@ func (b *BalanceChecker) getReplicaForStoppingBalance(ctx context.Context) []int
 				continue
 			}
 			if b.stoppingBalanceCollectionsCurrentRound.Contain(cid) {
-				log.RatedDebug(10, "BalanceChecker is balancing this collection, skip balancing in this round",
-					zap.Int64("collectionID", cid))
 				continue
 			}
+
 			replicas := b.meta.ReplicaManager.GetByCollection(ctx, cid)
 			stoppingReplicas := make([]int64, 0)
 			for _, replica := range replicas {
@@ -208,42 +207,68 @@ func (b *BalanceChecker) balanceReplicas(ctx context.Context, replicaIDs []int64
 	return segmentPlans, channelPlans
 }
 
+// Notice: balance checker will generate tasks for multiple collections in one round,
+// so generated tasks will be submitted to scheduler directly, and return nil
 func (b *BalanceChecker) Check(ctx context.Context) []task.Task {
-	var segmentPlans []balance.SegmentAssignPlan
-	var channelPlans []balance.ChannelAssignPlan
+	segmentBatchSize := paramtable.Get().QueryCoordCfg.BalanceSegmentBatchSize.GetAsInt()
+	channelBatchSize := paramtable.Get().QueryCoordCfg.BalanceChannelBatchSize.GetAsInt()
+	balanceOnMultipleCollections := paramtable.Get().QueryCoordCfg.EnableBalanceOnMultipleCollections.GetAsBool()
+
+	segmentTasks := make([]task.Task, 0)
+	channelTasks := make([]task.Task, 0)
+
+	generateBalanceTaskForReplicas := func(replicas []int64) {
+		segmentPlans, channelPlans := b.balanceReplicas(ctx, replicas)
+		tasks := balance.CreateSegmentTasksFromPlans(ctx, b.ID(), Params.QueryCoordCfg.SegmentTaskTimeout.GetAsDuration(time.Millisecond), segmentPlans)
+		task.SetPriority(task.TaskPriorityLow, tasks...)
+		task.SetReason("segment unbalanced", tasks...)
+		segmentTasks = append(segmentTasks, tasks...)
+
+		tasks = balance.CreateChannelTasksFromPlans(ctx, b.ID(), Params.QueryCoordCfg.ChannelTaskTimeout.GetAsDuration(time.Millisecond), channelPlans)
+		task.SetReason("channel unbalanced", tasks...)
+		channelTasks = append(channelTasks, tasks...)
+	}
+
 	stoppingReplicas := b.getReplicaForStoppingBalance(ctx)
 	if len(stoppingReplicas) > 0 {
 		// check for stopping balance first
-		segmentPlans, channelPlans = b.balanceReplicas(ctx, stoppingReplicas)
+		generateBalanceTaskForReplicas(stoppingReplicas)
 		// iterate all collection to find a collection to balance
-		for len(segmentPlans) == 0 && len(channelPlans) == 0 && b.stoppingBalanceCollectionsCurrentRound.Len() > 0 {
+		for len(segmentTasks) < segmentBatchSize && len(channelTasks) < channelBatchSize && b.stoppingBalanceCollectionsCurrentRound.Len() > 0 {
+			if !balanceOnMultipleCollections && (len(segmentTasks) > 0 || len(channelTasks) > 0) {
+				// if balance on multiple collections is disabled, and there are already some tasks, break
+				break
+			}
 			replicasToBalance := b.getReplicaForStoppingBalance(ctx)
-			segmentPlans, channelPlans = b.balanceReplicas(ctx, replicasToBalance)
+			generateBalanceTaskForReplicas(replicasToBalance)
 		}
 	} else {
 		// then check for auto balance
 		if time.Since(b.autoBalanceTs) > paramtable.Get().QueryCoordCfg.AutoBalanceInterval.GetAsDuration(time.Millisecond) {
 			b.autoBalanceTs = time.Now()
 			replicasToBalance := b.getReplicaForNormalBalance(ctx)
-			segmentPlans, channelPlans = b.balanceReplicas(ctx, replicasToBalance)
+			generateBalanceTaskForReplicas(replicasToBalance)
 			// iterate all collection to find a collection to balance
-			for len(segmentPlans) == 0 && len(channelPlans) == 0 && b.normalBalanceCollectionsCurrentRound.Len() > 0 {
+			for len(segmentTasks) < segmentBatchSize && len(channelTasks) < channelBatchSize && b.normalBalanceCollectionsCurrentRound.Len() > 0 {
+				if !balanceOnMultipleCollections && (len(segmentTasks) > 0 || len(channelTasks) > 0) {
+					// if balance on multiple collections is disabled, and there are already some tasks, break
+					break
+				}
 				replicasToBalance := b.getReplicaForNormalBalance(ctx)
-				segmentPlans, channelPlans = b.balanceReplicas(ctx, replicasToBalance)
+				generateBalanceTaskForReplicas(replicasToBalance)
 			}
 		}
 	}
 
-	ret := make([]task.Task, 0)
-	tasks := balance.CreateSegmentTasksFromPlans(ctx, b.ID(), Params.QueryCoordCfg.SegmentTaskTimeout.GetAsDuration(time.Millisecond), segmentPlans)
-	task.SetPriority(task.TaskPriorityLow, tasks...)
-	task.SetReason("segment unbalanced", tasks...)
-	ret = append(ret, tasks...)
+	for _, task := range segmentTasks {
+		b.scheduler.Add(task)
+	}
 
-	tasks = balance.CreateChannelTasksFromPlans(ctx, b.ID(), Params.QueryCoordCfg.ChannelTaskTimeout.GetAsDuration(time.Millisecond), channelPlans)
-	task.SetReason("channel unbalanced", tasks...)
-	ret = append(ret, tasks...)
-	return ret
+	for _, task := range channelTasks {
+		b.scheduler.Add(task)
+	}
+
+	return nil
 }
 
 func (b *BalanceChecker) sortCollections(ctx context.Context, collections []int64) []int64 {
@@ -252,10 +277,15 @@ func (b *BalanceChecker) sortCollections(ctx context.Context, collections []int6
 		sortOrder = "byrowcount" // Default to ByRowCount
 	}
 
+	collectionRowCountMap := make(map[int64]int64)
+	for _, cid := range collections {
+		collectionRowCountMap[cid] = b.targetMgr.GetCollectionRowCount(ctx, cid, meta.CurrentTargetFirst)
+	}
+
 	// Define sorting functions
 	sortByRowCount := func(i, j int) bool {
-		rowCount1 := b.targetMgr.GetCollectionRowCount(ctx, collections[i], meta.CurrentTargetFirst)
-		rowCount2 := b.targetMgr.GetCollectionRowCount(ctx, collections[j], meta.CurrentTargetFirst)
+		rowCount1 := collectionRowCountMap[collections[i]]
+		rowCount2 := collectionRowCountMap[collections[j]]
 		return rowCount1 > rowCount2 || (rowCount1 == rowCount2 && collections[i] < collections[j])
 	}
 

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -1949,6 +1949,11 @@ type queryCoordConfig struct {
 	UpdateCollectionLoadStatusInterval ParamItem `refreshable:"false"`
 	ClusterLevelLoadReplicaNumber      ParamItem `refreshable:"true"`
 	ClusterLevelLoadResourceGroups     ParamItem `refreshable:"true"`
+
+	// balance batch size in one trigger
+	BalanceSegmentBatchSize            ParamItem `refreshable:"true"`
+	BalanceChannelBatchSize            ParamItem `refreshable:"true"`
+	EnableBalanceOnMultipleCollections ParamItem `refreshable:"true"`
 }
 
 func (p *queryCoordConfig) init(base *BaseTable) {
@@ -2543,6 +2548,35 @@ If this parameter is set false, Milvus simply searches the growing segments with
 		Export:       true,
 	}
 	p.AutoBalanceInterval.Init(base.mgr)
+
+	p.BalanceSegmentBatchSize = ParamItem{
+		Key:          "queryCoord.balanceSegmentBatchSize",
+		FallbackKeys: []string{"queryCoord.collectionBalanceSegmentBatchSize"},
+		Version:      "2.5.14",
+		DefaultValue: "5",
+		Doc:          "the max balance task number for segment at each round, which is used for queryCoord to trigger balance on multiple collections",
+		Export:       false,
+	}
+	p.BalanceSegmentBatchSize.Init(base.mgr)
+
+	p.BalanceChannelBatchSize = ParamItem{
+		Key:          "queryCoord.balanceChannelBatchSize",
+		FallbackKeys: []string{"queryCoord.collectionBalanceChannelBatchSize"},
+		Version:      "2.5.14",
+		DefaultValue: "1",
+		Doc:          "the max balance task number for channel at each round, which is used for queryCoord to trigger balance on multiple collections",
+		Export:       false,
+	}
+	p.BalanceChannelBatchSize.Init(base.mgr)
+
+	p.EnableBalanceOnMultipleCollections = ParamItem{
+		Key:          "queryCoord.enableBalanceOnMultipleCollections",
+		Version:      "2.5.14",
+		DefaultValue: "true",
+		Doc:          "whether enable trigger balance on multiple collections at one time",
+		Export:       false,
+	}
+	p.EnableBalanceOnMultipleCollections.Init(base.mgr)
 }
 
 // /////////////////////////////////////////////////////////////////////////////

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -381,6 +381,10 @@ func TestComponentParam(t *testing.T) {
 
 		assert.Equal(t, 10, Params.CollectionChannelCountFactor.GetAsInt())
 		assert.Equal(t, 3000, Params.AutoBalanceInterval.GetAsInt())
+
+		assert.Equal(t, 5, Params.BalanceSegmentBatchSize.GetAsInt())
+		assert.Equal(t, 1, Params.BalanceChannelBatchSize.GetAsInt())
+		assert.Equal(t, true, Params.EnableBalanceOnMultipleCollections.GetAsBool())
 	})
 
 	t.Run("test queryNodeConfig", func(t *testing.T) {


### PR DESCRIPTION


issue: #41874
pr: #41875
- Optimize balance_checker to support balancing multiple collections simultaneously
- Add new parameters for segment and channel balancing batch sizes
- Add enableBalanceOnMultipleCollections parameter
- Update tests for balance checker

This change improves resource utilization by allowing the system to balance multiple collections in a single trigger with configurable batch sizes.