### PR TITLE
fix: log is_sorted_by_pk_ when loading sealed segment

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -322,10 +322,11 @@ ChunkedSegmentSealedImpl::load_field_data_internal(
 
         auto field_data_info =
             FieldDataInfo(field_id.get(), num_rows, load_info.mmap_dir_path);
-        LOG_INFO("segment {} loads field {} with num_rows {}",
+        LOG_INFO("segment {} loads field {} with num_rows {}, sorted by pk {}",
                  this->get_segment_id(),
                  field_id.get(),
-                 num_rows);
+                 num_rows,
+                 is_sorted_by_pk_);
 
         if (SystemProperty::Instance().IsSystem(field_id)) {
             auto insert_files = info.insert_files;


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/41993