### PR TITLE
enhance:[StorageV2] Adapt local storage & other minor issue

### DIFF
--- a/internal/datacoord/channel.go
+++ b/internal/datacoord/channel.go
@@ -19,10 +19,10 @@ package datacoord
 import (
 	"fmt"
 
+	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 
-	"github.com/cockroachdb/errors"
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/pkg/v2/log"

--- a/internal/datacoord/task_index.go
+++ b/internal/datacoord/task_index.go
@@ -22,9 +22,9 @@ import (
 	"path"
 	"time"
 
+	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 
-	"github.com/cockroachdb/errors"
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/datacoord/session"

--- a/internal/datacoord/task_stats.go
+++ b/internal/datacoord/task_stats.go
@@ -21,9 +21,9 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 
-	"github.com/cockroachdb/errors"
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
 	"github.com/milvus-io/milvus/internal/datacoord/session"
 	globalTask "github.com/milvus-io/milvus/internal/datacoord/task"

--- a/internal/datanode/importv2/util.go
+++ b/internal/datanode/importv2/util.go
@@ -193,8 +193,7 @@ func AppendSystemFieldsData(task *ImportTask, data *storage.InsertData, rowNum i
 	return nil
 }
 
-type nullDefaultAppender[T any] struct {
-}
+type nullDefaultAppender[T any] struct{}
 
 func (h *nullDefaultAppender[T]) AppendDefault(fieldData storage.FieldData, defaultVal T, rowNum int) error {
 	values := make([]T, rowNum)


### PR DESCRIPTION
Related to #39173

This PR
- Handle storage v2 log path in local storage mode on querynode
- Ignore field info check when append index for loaded sealed segment when using storage v2