### PR TITLE
enhance: add partition gc at streaming arch

### DIFF
--- a/internal/datanode/importv2/util.go
+++ b/internal/datanode/importv2/util.go
@@ -193,8 +193,7 @@ func AppendSystemFieldsData(task *ImportTask, data *storage.InsertData, rowNum i
 	return nil
 }
 
-type nullDefaultAppender[T any] struct {
-}
+type nullDefaultAppender[T any] struct{}
 
 func (h *nullDefaultAppender[T]) AppendDefault(fieldData storage.FieldData, defaultVal T, rowNum int) error {
 	values := make([]T, rowNum)

--- a/internal/distributed/streaming/streaming.go
+++ b/internal/distributed/streaming/streaming.go
@@ -134,6 +134,7 @@ type Broadcast interface {
 
 	// Ack acknowledges a broadcast message at the specified vchannel.
 	// It must be called after the message is comsumed by the unique-consumer.
+	// It will only return error when the ctx is canceled.
 	Ack(ctx context.Context, req types.BroadcastAckRequest) error
 }
 

--- a/internal/mocks/streamingnode/server/wal/mock_recovery/mock_RecoveryStorage.go
+++ b/internal/mocks/streamingnode/server/wal/mock_recovery/mock_RecoveryStorage.go
@@ -3,6 +3,8 @@
 package mock_recovery
 
 import (
+	context "context"
+
 	message "github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
 	mock "github.com/stretchr/testify/mock"
 
@@ -54,9 +56,22 @@ func (_c *MockRecoveryStorage_Close_Call) RunAndReturn(run func()) *MockRecovery
 	return _c
 }
 
-// ObserveMessage provides a mock function with given fields: msg
-func (_m *MockRecoveryStorage) ObserveMessage(msg message.ImmutableMessage) {
-	_m.Called(msg)
+// ObserveMessage provides a mock function with given fields: ctx, msg
+func (_m *MockRecoveryStorage) ObserveMessage(ctx context.Context, msg message.ImmutableMessage) error {
+	ret := _m.Called(ctx, msg)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ObserveMessage")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, message.ImmutableMessage) error); ok {
+		r0 = rf(ctx, msg)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }
 
 // MockRecoveryStorage_ObserveMessage_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ObserveMessage'
@@ -65,25 +80,26 @@ type MockRecoveryStorage_ObserveMessage_Call struct {
 }
 
 // ObserveMessage is a helper method to define mock.On call
+//   - ctx context.Context
 //   - msg message.ImmutableMessage
-func (_e *MockRecoveryStorage_Expecter) ObserveMessage(msg interface{}) *MockRecoveryStorage_ObserveMessage_Call {
-	return &MockRecoveryStorage_ObserveMessage_Call{Call: _e.mock.On("ObserveMessage", msg)}
+func (_e *MockRecoveryStorage_Expecter) ObserveMessage(ctx interface{}, msg interface{}) *MockRecoveryStorage_ObserveMessage_Call {
+	return &MockRecoveryStorage_ObserveMessage_Call{Call: _e.mock.On("ObserveMessage", ctx, msg)}
 }
 
-func (_c *MockRecoveryStorage_ObserveMessage_Call) Run(run func(msg message.ImmutableMessage)) *MockRecoveryStorage_ObserveMessage_Call {
+func (_c *MockRecoveryStorage_ObserveMessage_Call) Run(run func(ctx context.Context, msg message.ImmutableMessage)) *MockRecoveryStorage_ObserveMessage_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(message.ImmutableMessage))
+		run(args[0].(context.Context), args[1].(message.ImmutableMessage))
 	})
 	return _c
 }
 
-func (_c *MockRecoveryStorage_ObserveMessage_Call) Return() *MockRecoveryStorage_ObserveMessage_Call {
-	_c.Call.Return()
+func (_c *MockRecoveryStorage_ObserveMessage_Call) Return(_a0 error) *MockRecoveryStorage_ObserveMessage_Call {
+	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *MockRecoveryStorage_ObserveMessage_Call) RunAndReturn(run func(message.ImmutableMessage)) *MockRecoveryStorage_ObserveMessage_Call {
-	_c.Run(run)
+func (_c *MockRecoveryStorage_ObserveMessage_Call) RunAndReturn(run func(context.Context, message.ImmutableMessage) error) *MockRecoveryStorage_ObserveMessage_Call {
+	_c.Call.Return(run)
 	return _c
 }
 

--- a/internal/rootcoord/garbage_collector_test.go
+++ b/internal/rootcoord/garbage_collector_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/streamingutil"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/proto/querypb"
+	"github.com/milvus-io/milvus/pkg/v2/streaming/util/types"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 )
 
@@ -545,7 +546,14 @@ func TestGcPartitionData(t *testing.T) {
 	defer streamingutil.UnsetStreamingServiceEnabled()
 
 	wal := mock_streaming.NewMockWALAccesser(t)
-	wal.EXPECT().AppendMessages(mock.Anything, mock.Anything, mock.Anything).Return(streaming.AppendResponses{})
+	broadcast := mock_streaming.NewMockBroadcast(t)
+	broadcast.EXPECT().Append(mock.Anything, mock.Anything).Return(&types.BroadcastAppendResult{
+		BroadcastID: 0,
+		AppendResults: map[string]*types.AppendResult{
+			"ch-0": {},
+		},
+	}, nil)
+	wal.EXPECT().Broadcast().Return(broadcast)
 	streaming.SetWALForTest(wal)
 
 	tsoAllocator := mocktso.NewAllocator(t)

--- a/internal/streamingcoord/server/broadcaster/registry/message_callback.go
+++ b/internal/streamingcoord/server/broadcaster/registry/message_callback.go
@@ -1,0 +1,56 @@
+package registry
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cockroachdb/errors"
+
+	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v2/util/syncutil"
+)
+
+// init the message ack callbacks
+func init() {
+	resetMessageAckCallbacks()
+}
+
+// resetMessageAckCallbacks resets the message ack callbacks.
+func resetMessageAckCallbacks() {
+	messageAckCallbacks = map[message.MessageType]*syncutil.Future[MessageCallback]{
+		message.MessageTypeDropPartition: syncutil.NewFuture[MessageCallback](),
+	}
+}
+
+// MessageCallback is the callback function for the message type.
+type MessageCallback = func(ctx context.Context, msg message.MutableMessage) error
+
+// messageAckCallbacks is the map of message type to the callback function.
+var messageAckCallbacks map[message.MessageType]*syncutil.Future[MessageCallback]
+
+// RegisterMessageAckCallback registers the callback function for the message type.
+func RegisterMessageAckCallback(typ message.MessageType, callback MessageCallback) {
+	future, ok := messageAckCallbacks[typ]
+	if !ok {
+		panic(fmt.Sprintf("the future of message callback for type %s is not registered", typ))
+	}
+	if future.Ready() {
+		// only for test, the register callback should be called once and only once
+		return
+	}
+	future.Set(callback)
+}
+
+// CallMessageAckCallback calls the callback function for the message type.
+func CallMessageAckCallback(ctx context.Context, msg message.MutableMessage) error {
+	callbackFuture, ok := messageAckCallbacks[msg.MessageType()]
+	if !ok {
+		// No callback need tobe called, return nil
+		return nil
+	}
+	callback, err := callbackFuture.GetWithContext(ctx)
+	if err != nil {
+		return errors.Wrap(err, "when waiting callback registered")
+	}
+	return callback(ctx, msg)
+}

--- a/internal/streamingcoord/server/broadcaster/registry/message_callback_test.go
+++ b/internal/streamingcoord/server/broadcaster/registry/message_callback_test.go
@@ -1,0 +1,50 @@
+package registry
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/pkg/v2/mocks/streaming/util/mock_message"
+	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
+)
+
+func TestMessageCallbackRegistration(t *testing.T) {
+	// Reset callbacks before test
+	resetMessageAckCallbacks()
+
+	// Test registering a callback
+	called := false
+	callback := func(ctx context.Context, msg message.MutableMessage) error {
+		called = true
+		return nil
+	}
+
+	// Register callback for DropPartition message type
+	RegisterMessageAckCallback(message.MessageTypeDropPartition, callback)
+
+	// Verify callback was registered
+	callbackFuture, ok := messageAckCallbacks[message.MessageTypeDropPartition]
+	assert.True(t, ok)
+	assert.NotNil(t, callbackFuture)
+
+	// Create a mock message
+	msg := mock_message.NewMockMutableMessage(t)
+	msg.EXPECT().MessageType().Return(message.MessageTypeDropPartition)
+
+	// Call the callback
+	err := CallMessageAckCallback(context.Background(), msg)
+	assert.NoError(t, err)
+	assert.True(t, called)
+
+	resetMessageAckCallbacks()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+	err = CallMessageAckCallback(ctx, msg)
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, context.DeadlineExceeded))
+}

--- a/internal/streamingcoord/server/broadcaster/registry/test_utility.go
+++ b/internal/streamingcoord/server/broadcaster/registry/test_utility.go
@@ -9,4 +9,5 @@ func ResetRegistration() {
 	localRegistry = make(map[AppendOperatorType]*syncutil.Future[AppendOperator])
 	localRegistry[AppendOperatorTypeMsgstream] = syncutil.NewFuture[AppendOperator]()
 	localRegistry[AppendOperatorTypeStreaming] = syncutil.NewFuture[AppendOperator]()
+	resetMessageAckCallbacks()
 }

--- a/internal/streamingnode/server/flusher/flusherimpl/msg_handler_impl.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/msg_handler_impl.go
@@ -24,7 +24,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
-	"github.com/milvus-io/milvus/internal/distributed/streaming"
 	"github.com/milvus-io/milvus/internal/flushcommon/util"
 	"github.com/milvus-io/milvus/internal/flushcommon/writebuffer"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/resource"
@@ -32,7 +31,6 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
-	"github.com/milvus-io/milvus/pkg/v2/streaming/util/types"
 	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/retry"
@@ -109,26 +107,11 @@ func (impl *msgHandlerImpl) HandleManualFlush(flushMsg message.ImmutableManualFl
 }
 
 func (impl *msgHandlerImpl) HandleSchemaChange(ctx context.Context, msg message.ImmutableSchemaChangeMessageV2) error {
-	vchannel := msg.VChannel()
-	if err := impl.wbMgr.SealSegments(context.Background(), msg.VChannel(), msg.Header().FlushedSegmentIds); err != nil {
-		return errors.Wrap(err, "failed to seal segments")
-	}
-	return streaming.WAL().Broadcast().Ack(ctx, types.BroadcastAckRequest{
-		BroadcastID: msg.BroadcastHeader().BroadcastID,
-		VChannel:    vchannel,
-	})
+	return impl.wbMgr.SealSegments(context.Background(), msg.VChannel(), msg.Header().FlushedSegmentIds)
 }
 
 func (impl *msgHandlerImpl) HandleImport(ctx context.Context, vchannel string, importMsg *msgpb.ImportMsg) error {
 	return retry.Do(ctx, func() (err error) {
-		defer func() {
-			if err == nil {
-				err = streaming.WAL().Broadcast().Ack(ctx, types.BroadcastAckRequest{
-					BroadcastID: uint64(importMsg.GetJobID()),
-					VChannel:    vchannel,
-				})
-			}
-		}()
 		client, err := resource.Resource().MixCoordClient().GetWithContext(ctx)
 		if err != nil {
 			return err

--- a/internal/streamingnode/server/flusher/flusherimpl/msg_handler_impl_test.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/msg_handler_impl_test.go
@@ -24,9 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
-	"github.com/milvus-io/milvus/internal/distributed/streaming"
 	"github.com/milvus-io/milvus/internal/flushcommon/writebuffer"
-	"github.com/milvus-io/milvus/internal/mocks/distributed/mock_streaming"
 	"github.com/milvus-io/milvus/pkg/v2/mocks/streaming/util/mock_message"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
 )
@@ -106,12 +104,6 @@ func TestFlushMsgHandler_HandleManualFlush(t *testing.T) {
 
 func TestFlushMsgHandler_HandlSchemaChange(t *testing.T) {
 	vchannel := "ch-0"
-
-	w := mock_streaming.NewMockWALAccesser(t)
-	b := mock_streaming.NewMockBroadcast(t)
-	w.EXPECT().Broadcast().Return(b)
-	b.EXPECT().Ack(mock.Anything, mock.Anything).Return(nil)
-	streaming.SetWALForTest(w)
 
 	// test failed
 	wbMgr := writebuffer.NewMockBufferManager(t)

--- a/internal/streamingnode/server/flusher/flusherimpl/wal_flusher_test.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/wal_flusher_test.go
@@ -55,7 +55,7 @@ func TestWALFlusher(t *testing.T) {
 	fMixcoord := syncutil.NewFuture[internaltypes.MixCoordClient]()
 	fMixcoord.Set(mixcoord)
 	rs := mock_recovery.NewMockRecoveryStorage(t)
-	rs.EXPECT().ObserveMessage(mock.Anything).Return()
+	rs.EXPECT().ObserveMessage(mock.Anything, mock.Anything).Return(nil)
 	rs.EXPECT().Close().Return()
 	resource.InitForTest(
 		t,

--- a/internal/streamingnode/server/wal/recovery/recovery_storage.go
+++ b/internal/streamingnode/server/wal/recovery/recovery_storage.go
@@ -1,6 +1,8 @@
 package recovery
 
 import (
+	"context"
+
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/utility"
 	"github.com/milvus-io/milvus/pkg/v2/proto/streamingpb"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
@@ -59,7 +61,7 @@ type RecoveryStream interface {
 // RecoveryStorage is an interface that is used to observe the messages from the WAL.
 type RecoveryStorage interface {
 	// ObserveMessage observes the message from the WAL.
-	ObserveMessage(msg message.ImmutableMessage)
+	ObserveMessage(ctx context.Context, msg message.ImmutableMessage) error
 
 	// UpdateFlusherCheckpoint updates the checkpoint of flusher.
 	// TODO: should be removed in future, after merge the flusher logic into recovery storage.

--- a/internal/streamingnode/server/wal/recovery/recovery_storage_test.go
+++ b/internal/streamingnode/server/wal/recovery/recovery_storage_test.go
@@ -130,7 +130,7 @@ func TestRecoveryStorage(t *testing.T) {
 
 		msgs := b.generateStreamMessage()
 		for _, msg := range msgs {
-			rs.ObserveMessage(msg)
+			rs.ObserveMessage(context.Background(), msg)
 		}
 		rs.Close()
 		var partitionNum int


### PR DESCRIPTION
issue: #41976

- make drop partition message as a broadcast message.
- add gc when drop partition message is acked.
- add a call back to handle the broadcast message when ack.
- the ack operation of broadcast message will retry until success.