### PR TITLE
enhance: [2.5] Remove balance constraints between channel and segment tasks

### DIFF
--- a/internal/querycoordv2/balance/balance.go
+++ b/internal/querycoordv2/balance/balance.go
@@ -145,14 +145,6 @@ func (b *RoundRobinBalancer) BalanceReplica(ctx context.Context, replica *meta.R
 	return nil, nil
 }
 
-func (b *RoundRobinBalancer) permitBalanceChannel(collectionID int64) bool {
-	return b.scheduler.GetSegmentTaskNum(task.WithCollectionID2TaskFilter(collectionID), task.WithTaskTypeFilter(task.TaskTypeMove)) == 0
-}
-
-func (b *RoundRobinBalancer) permitBalanceSegment(collectionID int64) bool {
-	return b.scheduler.GetChannelTaskNum(task.WithCollectionID2TaskFilter(collectionID), task.WithTaskTypeFilter(task.TaskTypeMove)) == 0
-}
-
 func (b *RoundRobinBalancer) getNodes(nodes []int64) []*session.NodeInfo {
 	ret := make([]*session.NodeInfo, 0, len(nodes))
 	for _, n := range nodes {

--- a/internal/querycoordv2/balance/channel_level_score_balancer.go
+++ b/internal/querycoordv2/balance/channel_level_score_balancer.go
@@ -122,19 +122,17 @@ func (b *ChannelLevelScoreBalancer) BalanceReplica(ctx context.Context, replica 
 				zap.Any("available nodes", rwNodes),
 			)
 			// handle stopped nodes here, have to assign segments on stopping nodes to nodes with the smallest score
-			if b.permitBalanceChannel(replica.GetCollectionID()) {
-				channelPlans = append(channelPlans, b.genStoppingChannelPlan(ctx, replica, channelName, rwNodes, roNodes)...)
-			}
+			channelPlans = append(channelPlans, b.genStoppingChannelPlan(ctx, replica, channelName, rwNodes, roNodes)...)
 
-			if len(channelPlans) == 0 && b.permitBalanceSegment(replica.GetCollectionID()) {
+			if len(channelPlans) == 0 {
 				segmentPlans = append(segmentPlans, b.genStoppingSegmentPlan(ctx, replica, channelName, rwNodes, roNodes)...)
 			}
 		} else {
-			if paramtable.Get().QueryCoordCfg.AutoBalanceChannel.GetAsBool() && b.permitBalanceChannel(replica.GetCollectionID()) {
+			if paramtable.Get().QueryCoordCfg.AutoBalanceChannel.GetAsBool() {
 				channelPlans = append(channelPlans, b.genChannelPlan(ctx, replica, channelName, rwNodes)...)
 			}
 
-			if len(channelPlans) == 0 && b.permitBalanceSegment(replica.GetCollectionID()) {
+			if len(channelPlans) == 0 {
 				segmentPlans = append(segmentPlans, b.genSegmentPlan(ctx, br, replica, channelName, rwNodes)...)
 			}
 		}

--- a/internal/querycoordv2/balance/multi_target_balance.go
+++ b/internal/querycoordv2/balance/multi_target_balance.go
@@ -510,18 +510,16 @@ func (b *MultiTargetBalancer) BalanceReplica(ctx context.Context, replica *meta.
 			zap.Any("available nodes", rwNodes),
 		)
 		// handle stopped nodes here, have to assign segments on stopping nodes to nodes with the smallest score
-		if b.permitBalanceChannel(replica.GetCollectionID()) {
-			channelPlans = append(channelPlans, b.genStoppingChannelPlan(ctx, replica, rwNodes, roNodes)...)
-		}
-		if len(channelPlans) == 0 && b.permitBalanceSegment(replica.GetCollectionID()) {
+		channelPlans = append(channelPlans, b.genStoppingChannelPlan(ctx, replica, rwNodes, roNodes)...)
+		if len(channelPlans) == 0 {
 			segmentPlans = append(segmentPlans, b.genStoppingSegmentPlan(ctx, replica, rwNodes, roNodes)...)
 		}
 	} else {
-		if paramtable.Get().QueryCoordCfg.AutoBalanceChannel.GetAsBool() && b.permitBalanceChannel(replica.GetCollectionID()) {
+		if paramtable.Get().QueryCoordCfg.AutoBalanceChannel.GetAsBool() {
 			channelPlans = append(channelPlans, b.genChannelPlan(ctx, br, replica, rwNodes)...)
 		}
 
-		if len(channelPlans) == 0 && b.permitBalanceSegment(replica.GetCollectionID()) {
+		if len(channelPlans) == 0 {
 			segmentPlans = b.genSegmentPlan(ctx, replica, rwNodes)
 		}
 	}

--- a/internal/querycoordv2/balance/rowcount_based_balancer.go
+++ b/internal/querycoordv2/balance/rowcount_based_balancer.go
@@ -204,19 +204,17 @@ func (b *RowCountBasedBalancer) BalanceReplica(ctx context.Context, replica *met
 			zap.Any("available nodes", rwNodes),
 		)
 		// handle stopped nodes here, have to assign segments on stopping nodes to nodes with the smallest score
-		if b.permitBalanceChannel(replica.GetCollectionID()) {
-			channelPlans = append(channelPlans, b.genStoppingChannelPlan(ctx, replica, rwNodes, roNodes)...)
-		}
+		channelPlans = append(channelPlans, b.genStoppingChannelPlan(ctx, replica, rwNodes, roNodes)...)
 
-		if len(channelPlans) == 0 && b.permitBalanceSegment(replica.GetCollectionID()) {
+		if len(channelPlans) == 0 {
 			segmentPlans = append(segmentPlans, b.genStoppingSegmentPlan(ctx, replica, rwNodes, roNodes)...)
 		}
 	} else {
-		if paramtable.Get().QueryCoordCfg.AutoBalanceChannel.GetAsBool() && b.permitBalanceChannel(replica.GetCollectionID()) {
+		if paramtable.Get().QueryCoordCfg.AutoBalanceChannel.GetAsBool() {
 			channelPlans = append(channelPlans, b.genChannelPlan(ctx, br, replica, rwNodes)...)
 		}
 
-		if len(channelPlans) == 0 && b.permitBalanceSegment(replica.GetCollectionID()) {
+		if len(channelPlans) == 0 {
 			segmentPlans = append(segmentPlans, b.genSegmentPlan(ctx, replica, rwNodes)...)
 		}
 	}

--- a/internal/querycoordv2/balance/score_based_balancer.go
+++ b/internal/querycoordv2/balance/score_based_balancer.go
@@ -468,18 +468,16 @@ func (b *ScoreBasedBalancer) BalanceReplica(ctx context.Context, replica *meta.R
 		)
 		br.AddRecord(StrRecordf("executing stopping balance: %v", roNodes))
 		// handle stopped nodes here, have to assign segments on stopping nodes to nodes with the smallest score
-		if b.permitBalanceChannel(replica.GetCollectionID()) {
-			channelPlans = append(channelPlans, b.genStoppingChannelPlan(ctx, replica, rwNodes, roNodes)...)
-		}
-		if len(channelPlans) == 0 && b.permitBalanceSegment(replica.GetCollectionID()) {
+		channelPlans = append(channelPlans, b.genStoppingChannelPlan(ctx, replica, rwNodes, roNodes)...)
+		if len(channelPlans) == 0 {
 			segmentPlans = append(segmentPlans, b.genStoppingSegmentPlan(ctx, replica, rwNodes, roNodes)...)
 		}
 	} else {
-		if paramtable.Get().QueryCoordCfg.AutoBalanceChannel.GetAsBool() && b.permitBalanceChannel(replica.GetCollectionID()) {
+		if paramtable.Get().QueryCoordCfg.AutoBalanceChannel.GetAsBool() {
 			channelPlans = append(channelPlans, b.genChannelPlan(ctx, br, replica, rwNodes)...)
 		}
 
-		if len(channelPlans) == 0 && b.permitBalanceSegment(replica.GetCollectionID()) {
+		if len(channelPlans) == 0 {
 			segmentPlans = append(segmentPlans, b.genSegmentPlan(ctx, br, replica, rwNodes)...)
 		}
 	}

--- a/internal/querycoordv2/balance/score_based_balancer_test.go
+++ b/internal/querycoordv2/balance/score_based_balancer_test.go
@@ -1189,14 +1189,14 @@ func (suite *ScoreBasedBalancerTestSuite) TestBalanceSegmentAndChannel() {
 	segmentPlans, _ := suite.getCollectionBalancePlans(balancer, collectionID)
 	suite.Equal(len(segmentPlans), 2)
 
-	// mock balance channel is executing, expect to generate 0 balance segment task
+	// mock balance channel is executing, expect to generate 2 balance segment task, balance segment won't be blocked by balance channel
 	suite.mockScheduler.ExpectedCalls = nil
 	suite.mockScheduler.EXPECT().GetChannelTaskNum(mock.Anything, mock.Anything).Return(1).Maybe()
 	suite.mockScheduler.EXPECT().GetSegmentTaskNum(mock.Anything, mock.Anything).Return(0).Maybe()
 	suite.mockScheduler.EXPECT().GetSegmentTaskDelta(mock.Anything, mock.Anything).Return(0).Maybe()
 	suite.mockScheduler.EXPECT().GetChannelTaskDelta(mock.Anything, mock.Anything).Return(0).Maybe()
 	segmentPlans, _ = suite.getCollectionBalancePlans(balancer, collectionID)
-	suite.Equal(len(segmentPlans), 0)
+	suite.Equal(len(segmentPlans), 2)
 
 	// set unbalance channel distribution
 	balancer.dist.ChannelDistManager.Update(1, []*meta.DmChannel{
@@ -1214,14 +1214,14 @@ func (suite *ScoreBasedBalancerTestSuite) TestBalanceSegmentAndChannel() {
 	_, channelPlans := suite.getCollectionBalancePlans(balancer, collectionID)
 	suite.Equal(len(channelPlans), 2)
 
-	// mock balance channel is executing, expect to generate 0 balance segment task
+	// mock balance channel is executing, expect to generate 2 balance segment task, balance segment won't be blocked by balance channel
 	suite.mockScheduler.ExpectedCalls = nil
 	suite.mockScheduler.EXPECT().GetChannelTaskNum(mock.Anything, mock.Anything).Return(0).Maybe()
 	suite.mockScheduler.EXPECT().GetSegmentTaskNum(mock.Anything, mock.Anything).Return(1).Maybe()
 	suite.mockScheduler.EXPECT().GetSegmentTaskDelta(mock.Anything, mock.Anything).Return(0).Maybe()
 	suite.mockScheduler.EXPECT().GetChannelTaskDelta(mock.Anything, mock.Anything).Return(0).Maybe()
 	_, channelPlans = suite.getCollectionBalancePlans(balancer, collectionID)
-	suite.Equal(len(channelPlans), 0)
+	suite.Equal(len(channelPlans), 2)
 }
 
 func (suite *ScoreBasedBalancerTestSuite) TestBalanceChannelOnMultiCollections() {


### PR DESCRIPTION
issue: #42176
pr: #42177

Remove the mutual exclusion constraints between channel and segment balance tasks to allow them to run concurrently.

Changes include:
- Remove permitBalanceChannel() and permitBalanceSegment() methods from RoundRobinBalancer
- Update ChannelLevelScoreBalancer, MultiTargetBalancer, RowCountBasedBalancer, and ScoreBasedBalancer to remove constraint checks
- Allow segment balance tasks to proceed even when channel balance tasks are running
- Update test cases to reflect new behavior where balance tasks no longer block each other
- Improve error handling in task executor by preferring serviceable shard leaders for segment release operations
- Add fallback logic to find latest shard leader when serviceable leader is not available

This change improves the efficiency of load balancing by removing unnecessary coordination overhead between different types of balance operations.

Signed-off-by: Wei Liu <wei.liu@zilliz.com>