### PR TITLE
fix: ReleasePartition cause delegator unserviceable.

### DIFF
--- a/internal/querycoordv2/meta/mock_target_manager.go
+++ b/internal/querycoordv2/meta/mock_target_manager.go
@@ -1006,6 +1006,55 @@ func (_c *MockTargetManager_RemovePartition_Call) RunAndReturn(run func(context.
 	return _c
 }
 
+// RemovePartitionFromNextTarget provides a mock function with given fields: ctx, collectionID, partitionIDs
+func (_m *MockTargetManager) RemovePartitionFromNextTarget(ctx context.Context, collectionID int64, partitionIDs ...int64) {
+	_va := make([]interface{}, len(partitionIDs))
+	for _i := range partitionIDs {
+		_va[_i] = partitionIDs[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, collectionID)
+	_ca = append(_ca, _va...)
+	_m.Called(_ca...)
+}
+
+// MockTargetManager_RemovePartitionFromNextTarget_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RemovePartitionFromNextTarget'
+type MockTargetManager_RemovePartitionFromNextTarget_Call struct {
+	*mock.Call
+}
+
+// RemovePartitionFromNextTarget is a helper method to define mock.On call
+//   - ctx context.Context
+//   - collectionID int64
+//   - partitionIDs ...int64
+func (_e *MockTargetManager_Expecter) RemovePartitionFromNextTarget(ctx interface{}, collectionID interface{}, partitionIDs ...interface{}) *MockTargetManager_RemovePartitionFromNextTarget_Call {
+	return &MockTargetManager_RemovePartitionFromNextTarget_Call{Call: _e.mock.On("RemovePartitionFromNextTarget",
+		append([]interface{}{ctx, collectionID}, partitionIDs...)...)}
+}
+
+func (_c *MockTargetManager_RemovePartitionFromNextTarget_Call) Run(run func(ctx context.Context, collectionID int64, partitionIDs ...int64)) *MockTargetManager_RemovePartitionFromNextTarget_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]int64, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(int64)
+			}
+		}
+		run(args[0].(context.Context), args[1].(int64), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockTargetManager_RemovePartitionFromNextTarget_Call) Return() *MockTargetManager_RemovePartitionFromNextTarget_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockTargetManager_RemovePartitionFromNextTarget_Call) RunAndReturn(run func(context.Context, int64, ...int64)) *MockTargetManager_RemovePartitionFromNextTarget_Call {
+	_c.Run(run)
+	return _c
+}
+
 // SaveCurrentTarget provides a mock function with given fields: ctx, catalog
 func (_m *MockTargetManager) SaveCurrentTarget(ctx context.Context, catalog metastore.QueryCoordCatalog) {
 	_m.Called(ctx, catalog)

--- a/internal/querycoordv2/meta/target_manager.go
+++ b/internal/querycoordv2/meta/target_manager.go
@@ -54,6 +54,7 @@ type TargetManagerInterface interface {
 	UpdateCollectionNextTarget(ctx context.Context, collectionID int64) error
 	RemoveCollection(ctx context.Context, collectionID int64)
 	RemovePartition(ctx context.Context, collectionID int64, partitionIDs ...int64)
+	RemovePartitionFromNextTarget(ctx context.Context, collectionID int64, partitionIDs ...int64)
 	GetGrowingSegmentsByCollection(ctx context.Context, collectionID int64, scope TargetScope) typeutil.UniqueSet
 	GetGrowingSegmentsByChannel(ctx context.Context, collectionID int64, channelName string, scope TargetScope) typeutil.UniqueSet
 	GetSealedSegmentsByCollection(ctx context.Context, collectionID int64, scope TargetScope) map[int64]*datapb.SegmentInfo
@@ -229,6 +230,7 @@ func (mgr *TargetManager) RemoveCollection(ctx context.Context, collectionID int
 
 // RemovePartition removes all segment in the given partition,
 // NOTE: this doesn't remove any channel even the given one is the only partition
+// Deprecated: use RemovePartitionFromNextTarget instead @weiliu1031
 func (mgr *TargetManager) RemovePartition(ctx context.Context, collectionID int64, partitionIDs ...int64) {
 	log := log.With(zap.Int64("collectionID", collectionID),
 		zap.Int64s("PartitionIDs", partitionIDs))
@@ -261,6 +263,32 @@ func (mgr *TargetManager) RemovePartition(ctx context.Context, collectionID int6
 				zap.Strings("channels", newTarget.GetAllDmChannelNames()))
 		} else {
 			log.Info("all partitions have been released, release the collection current target now")
+			mgr.next.removeCollectionTarget(collectionID)
+		}
+	}
+}
+
+// remove partition from next target
+// NOTE: don't edit current target directly, it will be updated by target observer, which push the new next target as current target
+// need the full progress to update next target to current target, so the query view on delegator could be updated when current target is updated
+func (mgr *TargetManager) RemovePartitionFromNextTarget(ctx context.Context, collectionID int64, partitionIDs ...int64) {
+	log := log.With(zap.Int64("collectionID", collectionID),
+		zap.Int64s("PartitionIDs", partitionIDs))
+
+	partitionSet := typeutil.NewUniqueSet(partitionIDs...)
+
+	log.Info("remove partition from next target")
+	oleNextTarget := mgr.next.getCollectionTarget(collectionID)
+	if oleNextTarget != nil {
+		newTarget := mgr.removePartitionFromCollectionTarget(oleNextTarget, partitionSet)
+		if newTarget != nil {
+			mgr.next.updateCollectionTarget(collectionID, newTarget)
+			log.Info("finish to remove partition from next target for collection",
+				zap.Int64s("segments", newTarget.GetAllSegmentIDs()),
+				zap.Strings("channels", newTarget.GetAllDmChannelNames()))
+		} else {
+			log.Info("all partitions have been released, release the collection current target now")
+			mgr.current.removeCollectionTarget(collectionID)
 			mgr.next.removeCollectionTarget(collectionID)
 		}
 	}

--- a/internal/querycoordv2/observers/target_observer.go
+++ b/internal/querycoordv2/observers/target_observer.go
@@ -225,7 +225,7 @@ func (ob *TargetObserver) schedule(ctx context.Context) {
 				ob.keylocks.Unlock(req.CollectionID)
 				req.Notifier <- nil
 			case ReleasePartition:
-				ob.targetMgr.RemovePartition(ctx, req.CollectionID, req.PartitionIDs...)
+				ob.targetMgr.RemovePartitionFromNextTarget(ctx, req.CollectionID, req.PartitionIDs...)
 				req.Notifier <- nil
 			}
 			log.Info("manually trigger update target done",


### PR DESCRIPTION
issue: #42098 #42404
related to: ##42009 #41937

Implement new method to handle partition removal from next target without directly modifying current target.

Changes include:
- Add RemovePartitionFromNextTarget method and deprecate RemovePartition
- Update target_observer to use new method for ReleasePartition operations
- Add unit tests and mock methods for new functionality

This ensures that all changes to next target will propagates to delegator's query view.