### PR TITLE
enhance: Make segcore thread name set correctly

### DIFF
--- a/internal/core/src/storage/ThreadPools.cpp
+++ b/internal/core/src/storage/ThreadPools.cpp
@@ -20,9 +20,7 @@ namespace milvus {
 
 std::map<ThreadPoolPriority, std::unique_ptr<ThreadPool>>
     ThreadPools::thread_pool_map;
-std::map<ThreadPoolPriority, std::string> ThreadPools::name_map;
 std::shared_mutex ThreadPools::mutex_;
-std::once_flag ThreadPools::init_flag;
 
 void
 ThreadPools::ShutDown() {
@@ -35,7 +33,6 @@ ThreadPools::ShutDown() {
 
 ThreadPool&
 ThreadPools::GetThreadPool(milvus::ThreadPoolPriority priority) {
-    std::call_once(ThreadPools::init_flag, &ThreadPools::initNameMap);
     std::unique_lock<std::shared_mutex> lock(mutex_);
     auto iter = thread_pool_map.find(priority);
     if (iter != thread_pool_map.end()) {
@@ -53,7 +50,7 @@ ThreadPools::GetThreadPool(milvus::ThreadPoolPriority priority) {
                 coefficient = LOW_PRIORITY_THREAD_CORE_COEFFICIENT;
                 break;
         }
-        std::string name = name_map[priority];
+        std::string name = name_map()[priority];
         auto result = thread_pool_map.emplace(
             priority, std::make_unique<ThreadPool>(coefficient, name));
         return *(result.first->second);

--- a/internal/core/src/storage/ThreadPools.cpp
+++ b/internal/core/src/storage/ThreadPools.cpp
@@ -14,6 +14,7 @@
 //
 
 #include "ThreadPools.h"
+#include <mutex>
 
 namespace milvus {
 
@@ -21,6 +22,7 @@ std::map<ThreadPoolPriority, std::unique_ptr<ThreadPool>>
     ThreadPools::thread_pool_map;
 std::map<ThreadPoolPriority, std::string> ThreadPools::name_map;
 std::shared_mutex ThreadPools::mutex_;
+std::once_flag ThreadPools::init_flag;
 
 void
 ThreadPools::ShutDown() {
@@ -33,6 +35,7 @@ ThreadPools::ShutDown() {
 
 ThreadPool&
 ThreadPools::GetThreadPool(milvus::ThreadPoolPriority priority) {
+    std::call_once(ThreadPools::init_flag, &ThreadPools::initNameMap);
     std::unique_lock<std::shared_mutex> lock(mutex_);
     auto iter = thread_pool_map.find(priority);
     if (iter != thread_pool_map.end()) {

--- a/internal/core/src/storage/ThreadPools.h
+++ b/internal/core/src/storage/ThreadPools.h
@@ -46,17 +46,17 @@ class ThreadPools {
     void
     ShutDown();
 
-    static void
-    initNameMap() {
-        name_map[HIGH] = "HIGH_SEGC_POOL";
-        name_map[MIDDLE] = "MIDD_SEGC_POOL";
-        name_map[LOW] = "LOW_SEGC_POOL";
+    static std::map<ThreadPoolPriority, std::string>
+    name_map() {
+        static std::map<ThreadPoolPriority, std::string> name_map = {
+            {HIGH, "HIGH_SEGC_POOL"},
+            {MIDDLE, "MIDD_SEGC_POOL"},
+            {LOW, "LOW_SEGC_POOL"}};
+        return name_map;
     }
 
     static std::map<ThreadPoolPriority, std::unique_ptr<ThreadPool>>
         thread_pool_map;
-    static std::once_flag init_flag;
-    static std::map<ThreadPoolPriority, std::string> name_map;
     static std::shared_mutex mutex_;
 };
 

--- a/internal/core/src/storage/ThreadPools.h
+++ b/internal/core/src/storage/ThreadPools.h
@@ -42,14 +42,20 @@ class ThreadPools {
 
  private:
     ThreadPools() {
-        name_map[HIGH] = "high_priority_thread_pool";
-        name_map[MIDDLE] = "middle_priority_thread_pool";
-        name_map[LOW] = "low_priority_thread_pool";
     }
     void
     ShutDown();
+
+    static void
+    initNameMap() {
+        name_map[HIGH] = "HIGH_SEGC_POOL";
+        name_map[MIDDLE] = "MIDD_SEGC_POOL";
+        name_map[LOW] = "LOW_SEGC_POOL";
+    }
+
     static std::map<ThreadPoolPriority, std::unique_ptr<ThreadPool>>
         thread_pool_map;
+    static std::once_flag init_flag;
     static std::map<ThreadPoolPriority, std::string> name_map;
     static std::shared_mutex mutex_;
 };


### PR DESCRIPTION
Previous PR: #42017 did not work due to following updated points by this PR:

- Initialize the `name_map`, which not touched at all before
- Trim the thread name under 15 characters to fit syscall limit