### PR TITLE
fix: querynode upgrade from 2.5 get stucked

### DIFF
--- a/internal/querycoordv2/balance/multi_target_balance.go
+++ b/internal/querycoordv2/balance/multi_target_balance.go
@@ -499,6 +499,7 @@ func (b *MultiTargetBalancer) balanceChannels(ctx context.Context, br *balanceRe
 	var rwNodes, roNodes []int64
 	if streamingutil.IsStreamingServiceEnabled() {
 		rwNodes, roNodes = replica.GetRWSQNodes(), replica.GetROSQNodes()
+		roNodes = append(roNodes, replica.GetRONodes()...)
 	} else {
 		rwNodes, roNodes = replica.GetRWNodes(), replica.GetRONodes()
 	}

--- a/internal/querycoordv2/balance/rowcount_based_balancer.go
+++ b/internal/querycoordv2/balance/rowcount_based_balancer.go
@@ -209,6 +209,7 @@ func (b *RowCountBasedBalancer) balanceChannels(ctx context.Context, br *balance
 	var rwNodes, roNodes []int64
 	if streamingutil.IsStreamingServiceEnabled() {
 		rwNodes, roNodes = replica.GetRWSQNodes(), replica.GetROSQNodes()
+		roNodes = append(roNodes, replica.GetRONodes()...)
 	} else {
 		rwNodes, roNodes = replica.GetRWNodes(), replica.GetRONodes()
 	}

--- a/internal/querycoordv2/balance/score_based_balancer.go
+++ b/internal/querycoordv2/balance/score_based_balancer.go
@@ -481,6 +481,7 @@ func (b *ScoreBasedBalancer) balanceChannels(ctx context.Context, br *balanceRep
 	var roNodes []int64
 	if streamingutil.IsStreamingServiceEnabled() {
 		rwNodes, roNodes = replica.GetRWSQNodes(), replica.GetROSQNodes()
+		roNodes = append(roNodes, replica.GetRONodes()...)
 	} else {
 		rwNodes, roNodes = replica.GetRWNodes(), replica.GetRONodes()
 	}

--- a/internal/querynodev2/segments/segment_filter.go
+++ b/internal/querynodev2/segments/segment_filter.go
@@ -140,3 +140,10 @@ func WithLevel(level datapb.SegmentLevel) SegmentFilter {
 		return segment.Level() == level
 	})
 }
+
+// WithoutLevel is the segment filter for without segment level.
+func WithoutLevel(level datapb.SegmentLevel) SegmentFilter {
+	return SegmentFilterFunc(func(segment Segment) bool {
+		return segment.Level() != level
+	})
+}

--- a/internal/querynodev2/server.go
+++ b/internal/querynodev2/server.go
@@ -70,6 +70,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/metrics"
 	"github.com/milvus-io/milvus/pkg/v2/mq/msgdispatcher"
+	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/util/expr"
 	"github.com/milvus-io/milvus/pkg/v2/util/hardware"
 	"github.com/milvus-io/milvus/pkg/v2/util/lifetime"
@@ -555,8 +556,8 @@ func (node *QueryNode) Stop() error {
 					channelNum      = 0
 				)
 				if node.manager != nil {
-					sealedSegments = node.manager.Segment.GetBy(segments.WithType(segments.SegmentTypeSealed))
-					growingSegments = node.manager.Segment.GetBy(segments.WithType(segments.SegmentTypeGrowing))
+					sealedSegments = node.manager.Segment.GetBy(segments.WithType(segments.SegmentTypeSealed), segments.WithoutLevel(datapb.SegmentLevel_L0))
+					growingSegments = node.manager.Segment.GetBy(segments.WithType(segments.SegmentTypeGrowing), segments.WithoutLevel(datapb.SegmentLevel_L0))
 				}
 				if node.pipelineManager != nil {
 					channelNum = node.pipelineManager.Num()


### PR DESCRIPTION
issue: #42492

- consider the old RO query node (not streaming node) when balancing channel.
- querynode graceful stop can be done if there's only L0 segment exists.