### PR TITLE
fix: Fix intermittent deadlock in grouped allocator

### DIFF
--- a/pkg/util/vralloc/sharedalloc.go
+++ b/pkg/util/vralloc/sharedalloc.go
@@ -110,6 +110,14 @@ func (ga *GroupedAllocator) GetAllocator(name string) Allocator[string] {
 	return ga.children[name]
 }
 
+// Note: GroupedAllocator should notify its all children.
+func (ga *GroupedAllocator) notify() {
+	ga.SharedAllocator.notify()
+	for _, child := range ga.children {
+		child.notify()
+	}
+}
+
 type GroupedAllocatorBuilder struct {
 	ga GroupedAllocator
 }


### PR DESCRIPTION
issue: #42523
Resolve deadlock issue in GroupedAllocator where resource release notifications fail to propagate across hierarchy levels, causing child allocators to wait indefinitely.

Changes include:
- Add recursive notify() method to GroupedAllocator
- Ensure all child allocators receive resource release notifications
- Fix TOCTOU race condition in hierarchical resource management

This resolves the intermittent test timeout in TestGroupedAllocator test that exhibited deadlock due to missed condition notifications.