### PR TITLE
fix: Fix l0 segment leak by refactoring segment checker logic

### DIFF
--- a/internal/querycoordv2/meta/segment_dist_manager.go
+++ b/internal/querycoordv2/meta/segment_dist_manager.go
@@ -91,6 +91,18 @@ func WithSegmentID(segmentID int64) SegmentDistFilter {
 	})
 }
 
+func WithLevel(level datapb.SegmentLevel) SegmentDistFilter {
+	return SegmentDistFilterFunc(func(s *Segment) bool {
+		return s.GetLevel() == level
+	})
+}
+
+func WithoutLevel(level datapb.SegmentLevel) SegmentDistFilter {
+	return SegmentDistFilterFunc(func(s *Segment) bool {
+		return s.GetLevel() != level
+	})
+}
+
 type CollectionSegDistFilter int64
 
 func (f CollectionSegDistFilter) Match(s *Segment) bool {


### PR DESCRIPTION
#39551
Fix the issue where l0 segments could leak due to improper handling in the segment checker. This commit introduces a more robust approach to manage l0 segments separately from other segment types.

Changes include:
- Add dedicated getL0SegmentDiff() method for l0-specific logic
- Separate l0 segment handling from regular segment processing logic
- Improve l0 segment load and release task generation conditions
- Add comprehensive unit tests for the new methods

The new approach ensures l0 segments are handled with higher priority and prevents segment leakage by implementing proper delegator-based validation for l0 segment placement and cleanup.