### PR TITLE
fix: Pass cluster id tranforming drop task to drop job request

### DIFF
--- a/internal/datanode/services.go
+++ b/internal/datanode/services.go
@@ -812,9 +812,14 @@ func (node *DataNode) DropTask(ctx context.Context, request *workerpb.DropTaskRe
 		if err != nil {
 			return merr.Status(err), nil
 		}
+		clusterID, err := properties.GetClusterID()
+		if err != nil {
+			return merr.Status(err), nil
+		}
 		return node.DropJobsV2(ctx, &workerpb.DropJobsV2Request{
-			TaskIDs: []int64{taskID},
-			JobType: jobType,
+			ClusterID: clusterID,
+			TaskIDs:   []int64{taskID},
+			JobType:   jobType,
 		})
 	default:
 		err := fmt.Errorf("unrecognized task type '%s', properties=%v", taskType, request.GetProperties())


### PR DESCRIPTION
Related to #42530

The cluster id is missing when drop worker drop causing redoing task on report duplicated task error.