### PR TITLE
fix: pipeline/delegator leak

### DIFF
--- a/internal/util/pipeline/pipeline.go
+++ b/internal/util/pipeline/pipeline.go
@@ -48,8 +48,9 @@ func (p *pipeline) Add(nodes ...Node) {
 func (p *pipeline) addNode(node Node) {
 	nodeCtx := NewNodeCtx(node)
 	if p.enableTtChecker {
-		manager := timerecord.GetCheckerManger("fgNode", p.nodeTtInterval, func(list []string) {
-			log.Warn("some node(s) haven't received input", zap.Strings("list", list), zap.Duration("duration ", p.nodeTtInterval))
+		nodeTtInterval := p.nodeTtInterval
+		manager := timerecord.GetCheckerManger("fgNode", nodeTtInterval, func(list []string) {
+			log.Warn("some node(s) haven't received input", zap.Strings("list", list), zap.Duration("duration ", nodeTtInterval))
 		})
 		name := fmt.Sprintf("nodeCtxTtChecker-%s", node.Name())
 		nodeCtx.Checker = timerecord.NewChecker(name, manager)


### PR DESCRIPTION
 the manager's logging lambda should not capture the pipeline object

this creates a circular reference between the manager and the pipeline object, making it impossible for both to be GC-ed.

issue: https://github.com/milvus-io/milvus/issues/42581
pr: https://github.com/milvus-io/milvus/pull/42582