### PR TITLE
enhance: allow '.' and '-' characters in usernames (#42417)

### DIFF
--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -1172,8 +1172,8 @@ func ValidateUsername(username string) error {
 	usernameSize := len(username)
 	for i := 1; i < usernameSize; i++ {
 		c := username[i]
-		if c != '_' && !isAlpha(c) && !isNumber(c) {
-			return merr.WrapErrParameterInvalidMsg("invalid user name %s, username must contain only numbers, letters and underscores, but got %s", username, c)
+		if c != '_' && c != '-' && c != '.' && !isAlpha(c) && !isNumber(c) {
+			return merr.WrapErrParameterInvalidMsg("invalid user name %s, username must contain only numbers, letters, underscores, dots, and hyphens, but got %s", username, c)
 		}
 	}
 	return nil

--- a/internal/proxy/util_test.go
+++ b/internal/proxy/util_test.go
@@ -765,11 +765,11 @@ func TestValidateUsername(t *testing.T) {
 	// length gt 32
 	res = ValidateUsername("aaaaaaaaaabbbbbbbbbbccccccccccddddd")
 	assert.Error(t, res)
-	// illegal character which not alphabet, _, or number
-	res = ValidateUsername("a1^7*).,")
+	// illegal character which not alphabet, _, ., ., or number
+	res = ValidateUsername("a1^7*),")
 	assert.Error(t, res)
-	// normal username that only contains alphabet, _, and number
-	res = ValidateUsername("a17_good")
+	// normal username that only contains alphabet, _, ., -, and number
+	res = ValidateUsername("a.17_good-")
 	assert.Nil(t, res)
 }
 


### PR DESCRIPTION
related: #42417

 - update the isValidUsername function to accept dots and hyphens in addition to letters, digits, and underscores
 - this change improves compatibility with common username formats and addresses feedback in issue #42417