### PR TITLE
enhance: Optimize memory usage during garbage collection

### DIFF
--- a/internal/datacoord/garbage_collector.go
+++ b/internal/datacoord/garbage_collector.go
@@ -425,16 +425,14 @@ func (gc *garbageCollector) recycleDroppedSegments(ctx context.Context) {
 	compactTo := make(map[int64]*SegmentInfo)
 	channels := typeutil.NewSet[string]()
 	for _, segment := range all {
-		cloned := segment.Clone()
-		binlog.DecompressBinLogs(cloned.SegmentInfo)
-		if cloned.GetState() == commonpb.SegmentState_Dropped {
-			drops[cloned.GetID()] = cloned
-			channels.Insert(cloned.GetInsertChannel())
+		if segment.GetState() == commonpb.SegmentState_Dropped {
+			drops[segment.GetID()] = segment
+			channels.Insert(segment.GetInsertChannel())
 			// continue
 			// A(indexed), B(indexed) -> C(no indexed), D(no indexed) -> E(no indexed), A, B can not be GC
 		}
-		for _, from := range cloned.GetCompactionFrom() {
-			compactTo[from] = cloned
+		for _, from := range segment.GetCompactionFrom() {
+			compactTo[from] = segment
 		}
 	}
 
@@ -469,31 +467,37 @@ func (gc *garbageCollector) recycleDroppedSegments(ctx context.Context) {
 			continue
 		}
 
-		logs := getLogs(segment)
-		for key := range getTextLogs(segment) {
+		cloned := segment.Clone()
+		binlog.DecompressBinLogs(cloned.SegmentInfo)
+
+		logs := getLogs(cloned)
+		for key := range getTextLogs(cloned) {
 			logs[key] = struct{}{}
 		}
 
-		for key := range getJSONKeyLogs(segment, gc) {
+		for key := range getJSONKeyLogs(cloned, gc) {
 			logs[key] = struct{}{}
 		}
 
-		log.Info("GC segment start...", zap.Int("insert_logs", len(segment.GetBinlogs())),
-			zap.Int("delta_logs", len(segment.GetDeltalogs())),
-			zap.Int("stats_logs", len(segment.GetStatslogs())),
-			zap.Int("bm25_logs", len(segment.GetBm25Statslogs())),
-			zap.Int("text_logs", len(segment.GetTextStatsLogs())),
-			zap.Int("json_key_logs", len(segment.GetJsonKeyStats())))
+		log.Info("GC segment start...", zap.Int("insert_logs", len(cloned.GetBinlogs())),
+			zap.Int("delta_logs", len(cloned.GetDeltalogs())),
+			zap.Int("stats_logs", len(cloned.GetStatslogs())),
+			zap.Int("bm25_logs", len(cloned.GetBm25Statslogs())),
+			zap.Int("text_logs", len(cloned.GetTextStatsLogs())),
+			zap.Int("json_key_logs", len(cloned.GetJsonKeyStats())))
 		if err := gc.removeObjectFiles(ctx, logs); err != nil {
 			log.Warn("GC segment remove logs failed", zap.Error(err))
+			cloned = nil
 			continue
 		}
 
-		if err := gc.meta.DropSegment(ctx, segment.GetID()); err != nil {
+		if err := gc.meta.DropSegment(ctx, cloned.GetID()); err != nil {
 			log.Warn("GC segment meta failed to drop segment", zap.Error(err))
+			cloned = nil
 			continue
 		}
 		log.Info("GC segment meta drop segment done")
+		cloned = nil // release memory
 	}
 }
 


### PR DESCRIPTION
Defer clone and decompress operations until just before removing from meta, instead of eagerly applying them to all segments in advance.

issue: https://github.com/milvus-io/milvus/issues/42592