### PR TITLE
fix: filter the streaming query node from resource group when upgrading

### DIFF
--- a/internal/querycoordv2/server.go
+++ b/internal/querycoordv2/server.go
@@ -859,8 +859,16 @@ func (s *Server) tryHandleNodeUp() {
 }
 
 func (s *Server) handleNodeUp(node int64) {
+	nodeInfo := s.nodeMgr.Get(node)
+	if nodeInfo == nil {
+		return
+	}
 	s.taskScheduler.AddExecutor(node)
 	s.distController.StartDistInstance(s.ctx, node)
+	if nodeInfo.IsEmbeddedQueryNodeInStreamingNode() {
+		// The querynode embedded in the streaming node can not work with streaming node.
+		return
+	}
 	// need assign to new rg and replica
 	s.meta.ResourceManager.HandleNodeUp(s.ctx, node)
 }

--- a/internal/querycoordv2/session/node_manager.go
+++ b/internal/querycoordv2/session/node_manager.go
@@ -24,6 +24,7 @@ import (
 	"github.com/blang/semver/v4"
 	"go.uber.org/atomic"
 
+	"github.com/milvus-io/milvus/internal/util/sessionutil"
 	"github.com/milvus-io/milvus/pkg/v2/metrics"
 )
 
@@ -150,6 +151,10 @@ func (n *NodeInfo) Hostname() string {
 
 func (n *NodeInfo) Labels() map[string]string {
 	return n.immutableInfo.Labels
+}
+
+func (n *NodeInfo) IsEmbeddedQueryNodeInStreamingNode() bool {
+	return n.immutableInfo.Labels[sessionutil.LabelStreamingNodeEmbeddedQueryNode] == "1"
 }
 
 func (n *NodeInfo) SegmentCnt() int {

--- a/internal/util/sessionutil/session_util.go
+++ b/internal/util/sessionutil/session_util.go
@@ -48,8 +48,9 @@ const (
 	// DefaultServiceRoot default root path used in kv by Session
 	DefaultServiceRoot = "session/"
 	// DefaultIDKey default id key for Session
-	DefaultIDKey         = "id"
-	SupportedLabelPrefix = "MILVUS_SERVER_LABEL_"
+	DefaultIDKey                        = "id"
+	SupportedLabelPrefix                = "MILVUS_SERVER_LABEL_"
+	LabelStreamingNodeEmbeddedQueryNode = "QUERYNODE_STREAMING-EMBEDDED" // Used for upgrading from 2.5.x to 2.6.0.
 )
 
 // SessionEventType session event type


### PR DESCRIPTION
issue: #42492
pr: #38677

- filter the streaming query node out from 2.6.0, avoid to load sealed segment on streaming query node.