### PR TITLE
enhance: use english name as language name for all type language identifier

### DIFF
--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/tokenizers/lang_ident_tokenizer.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/tokenizers/lang_ident_tokenizer.rs
@@ -36,7 +36,7 @@ impl Identifier for WhatlangIdentifier {
         detect(text)
             .map_or("default", |info| {
                 if info.confidence() > self.confidence {
-                    info.lang().code()
+                    info.lang().eng_name()
                 } else {
                     "default"
                 }


### PR DESCRIPTION
Set whatlang detect return language name as english name.
Make sure same with lingua. 