### PR TITLE
enhance: [StorageV2] Pass bucket name for compaction readers

### DIFF
--- a/internal/datanode/compactor/clustering_compactor.go
+++ b/internal/datanode/compactor/clustering_compactor.go
@@ -587,9 +587,18 @@ func (t *clusteringCompactionTask) mappingSegment(
 		return merr.WrapErrIllegalCompactionPlan()
 	}
 
-	rr, err := storage.NewBinlogRecordReader(ctx, segment.GetFieldBinlogs(), t.plan.Schema, storage.WithDownloader(func(ctx context.Context, paths []string) ([][]byte, error) {
-		return t.binlogIO.Download(ctx, paths)
-	}), storage.WithVersion(segment.StorageVersion), storage.WithBufferSize(t.memoryBufferSize))
+	// TODO bucketName shall be passed via StorageConfig like index/stats task
+	bucketName := paramtable.Get().ServiceParam.MinioCfg.BucketName.GetValue()
+
+	rr, err := storage.NewBinlogRecordReader(ctx,
+		segment.GetFieldBinlogs(),
+		t.plan.Schema,
+		storage.WithDownloader(func(ctx context.Context, paths []string) ([][]byte, error) {
+			return t.binlogIO.Download(ctx, paths)
+		}),
+		storage.WithVersion(segment.StorageVersion), storage.WithBufferSize(t.memoryBufferSize),
+		storage.WithBucketName(bucketName),
+	)
 	if err != nil {
 		log.Warn("new binlog record reader wrong", zap.Error(err))
 		return err
@@ -856,9 +865,19 @@ func (t *clusteringCompactionTask) scalarAnalyzeSegment(
 
 	expiredFilter := compaction.NewEntityFilter(nil, t.plan.GetCollectionTtl(), t.currentTime)
 
-	rr, err := storage.NewBinlogRecordReader(ctx, segment.GetFieldBinlogs(), t.plan.Schema, storage.WithDownloader(func(ctx context.Context, paths []string) ([][]byte, error) {
-		return t.binlogIO.Download(ctx, paths)
-	}), storage.WithVersion(segment.StorageVersion), storage.WithBufferSize(t.memoryBufferSize))
+	// TODO bucketName shall be passed via StorageConfig like index/stats task
+	bucketName := paramtable.Get().ServiceParam.MinioCfg.BucketName.GetValue()
+
+	rr, err := storage.NewBinlogRecordReader(ctx,
+		segment.GetFieldBinlogs(),
+		t.plan.Schema,
+		storage.WithDownloader(func(ctx context.Context, paths []string) ([][]byte, error) {
+			return t.binlogIO.Download(ctx, paths)
+		}),
+		storage.WithVersion(segment.StorageVersion),
+		storage.WithBufferSize(t.memoryBufferSize),
+		storage.WithBucketName(bucketName),
+	)
 	if err != nil {
 		log.Warn("new binlog record reader wrong", zap.Error(err))
 		return make(map[interface{}]int64), err

--- a/internal/datanode/compactor/mix_compactor.go
+++ b/internal/datanode/compactor/mix_compactor.go
@@ -217,7 +217,16 @@ func (t *mixCompactionTask) writeSegment(ctx context.Context,
 	}
 	entityFilter := compaction.NewEntityFilter(delta, t.plan.GetCollectionTtl(), t.currentTime)
 
-	reader, err := storage.NewBinlogRecordReader(ctx, seg.GetFieldBinlogs(), t.plan.GetSchema(), storage.WithDownloader(t.binlogIO.Download), storage.WithVersion(seg.GetStorageVersion()))
+	// TODO bucketName shall be passed via StorageConfig like index/stats task
+	bucketName := paramtable.Get().ServiceParam.MinioCfg.BucketName.GetValue()
+
+	reader, err := storage.NewBinlogRecordReader(ctx,
+		seg.GetFieldBinlogs(),
+		t.plan.GetSchema(),
+		storage.WithDownloader(t.binlogIO.Download),
+		storage.WithVersion(seg.GetStorageVersion()),
+		storage.WithBucketName(bucketName),
+	)
 	if err != nil {
 		log.Warn("compact wrong, failed to new insert binlogs reader", zap.Error(err))
 		return


### PR DESCRIPTION
Related to #39173

Like logic in #41919, storage v2 fs shall use complete paths with bucketName prefix to be compatible with its definition. This PR fills bucket name from config when creating reader for compaction tasks.

NOTE: the bucket name shall be read from task params config for compaction task pooling.