### PR TITLE
fix: [2.5] Unsorted small segments should not be considered as indexed

### DIFF
--- a/internal/datacoord/handler.go
+++ b/internal/datacoord/handler.go
@@ -193,7 +193,7 @@ func (h *ServerHandler) GetQueryVChanPositions(channel RWChannel, partitionIDs .
 	// ================================================
 
 	segmentIndexed := func(segID UniqueID) bool {
-		return indexed.Contain(segID) || validSegmentInfos[segID].GetNumOfRows() < Params.DataCoordCfg.MinSegmentNumRowsToEnableIndex.GetAsInt64()
+		return indexed.Contain(segID) || (validSegmentInfos[segID].GetIsSorted() && validSegmentInfos[segID].GetNumOfRows() < Params.DataCoordCfg.MinSegmentNumRowsToEnableIndex.GetAsInt64())
 	}
 
 	flushedIDs, droppedIDs = retrieveSegment(validSegmentInfos, flushedIDs, droppedIDs, segmentIndexed)

--- a/tests/python_client/testcases/test_compaction.py
+++ b/tests/python_client/testcases/test_compaction.py
@@ -818,7 +818,8 @@ class TestCompactionOperation(TestcaseBase):
             end = time()
             if end - start > cost:
                 raise MilvusException(1, "Compact merge two segments more than 180s")
-        assert c_plans.plans[0].target == segments_info[0].segmentID
+        # target --sort--> querySegment
+        # assert c_plans.plans[0].target == segments_info[0].segmentID
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_compact_no_merge(self):
@@ -849,7 +850,8 @@ class TestCompactionOperation(TestcaseBase):
         collection_w.release()
         collection_w.load()
         seg_after, _ = self.utility_wrap.get_query_segment_info(collection_w.name)
-        assert seg_after[0].segmentID == c_plans.plans[0].target
+        # target --sort--> querySegment
+        # assert seg_after[0].segmentID == c_plans.plans[0].target
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_compact_manual_and_auto(self):
@@ -933,7 +935,8 @@ class TestCompactionOperation(TestcaseBase):
         replicas = collection_w.get_replicas()[0]
         replica_num = len(replicas.groups)
         assert len(segments_info) == 1*replica_num
-        assert segments_info[0].segmentID == target
+        # target --sort--> querySegment
+        # assert segments_info[0].segmentID == target
 
 
     @pytest.mark.tags(CaseLabel.L2)

--- a/tests/python_client/testcases/test_query.py
+++ b/tests/python_client/testcases/test_query.py
@@ -3567,6 +3567,8 @@ class TestQueryCount(TestcaseBase):
         collection_w.create_index(ct.default_float_vec_field_name, ct.default_index)
         collection_w.compact()
         collection_w.wait_for_compaction_completed()
+        # recreate index wait for compactTo indexed
+        collection_w.create_index(ct.default_float_vec_field_name, ct.default_index)
 
         collection_w.load()
         segment_info, _ = self.utility_wrap.get_query_segment_info(collection_w.name)


### PR DESCRIPTION
issue: #42143 
master pr: #42614 