### PR TITLE
fix: [StorageV2] sync with int8 vector data type core dumped

### DIFF
--- a/internal/storage/serde.go
+++ b/internal/storage/serde.go
@@ -459,7 +459,22 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			}
 			return nil, false
 		},
-		fixedSizeSerializer,
+		func(b array.Builder, v any) bool {
+			if v == nil {
+				b.AppendNull()
+				return true
+			}
+			if builder, ok := b.(*array.FixedSizeBinaryBuilder); ok {
+				if vv, ok := v.([]byte); ok {
+					builder.Append(vv)
+					return true
+				} else if vv, ok := v.([]int8); ok {
+					builder.Append(arrow.Int8Traits.CastToBytes(vv))
+					return true
+				}
+			}
+			return false
+		},
 	}
 	m[schemapb.DataType_FloatVector] = serdeEntry{
 		func(i int) arrow.DataType {

--- a/internal/storage/serde_test.go
+++ b/internal/storage/serde_test.go
@@ -99,6 +99,7 @@ func TestSerDe(t *testing.T) {
 		{"test bfloat16 vector", args{dt: schemapb.DataType_BFloat16Vector, v: []byte{0xff, 0xff}}, []byte{0xff, 0xff}, true},
 		{"test bfloat16 vector null", args{dt: schemapb.DataType_BFloat16Vector, v: nil}, nil, true},
 		{"test bfloat16 vector negative", args{dt: schemapb.DataType_BFloat16Vector, v: -1}, nil, false},
+		{"test int8 vector", args{dt: schemapb.DataType_Int8Vector, v: []int8{10}}, []int8{10}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
related: https://github.com/milvus-io/milvus/issues/42613, #39173 