### PR TITLE
fix: Release data memory after sync task completes

### DIFF
--- a/internal/flushcommon/syncmgr/serializer.go
+++ b/internal/flushcommon/syncmgr/serializer.go
@@ -143,3 +143,9 @@ func (p *SyncPack) WithDataSource(source string) *SyncPack {
 	p.dataSource = source
 	return p
 }
+
+func (p *SyncPack) ReleaseData() {
+	p.insertData = nil
+	p.deltaData = nil
+	p.bm25Stats = nil
+}

--- a/internal/flushcommon/syncmgr/task.go
+++ b/internal/flushcommon/syncmgr/task.go
@@ -168,6 +168,8 @@ func (t *SyncTask) Run(ctx context.Context) (err error) {
 		}
 	}
 
+	t.pack.ReleaseData()
+
 	actions := []metacache.SegmentAction{metacache.FinishSyncing(t.batchRows)}
 	if t.pack.isFlush {
 		actions = append(actions, metacache.UpdateState(commonpb.SegmentState_Flushed))

--- a/internal/flushcommon/syncmgr/task_test.go
+++ b/internal/flushcommon/syncmgr/task_test.go
@@ -210,6 +210,12 @@ func (s *SyncTaskSuite) runTestRunNormal(storageVersion int64) {
 		action(seg)
 	}).Return()
 
+	isDataReleased := func(task *SyncTask) bool {
+		return task.pack.insertData == nil &&
+			task.pack.deltaData == nil &&
+			task.pack.bm25Stats == nil
+	}
+
 	s.Run("without_data", func() {
 		task := s.getSuiteSyncTask(new(SyncPack).WithCheckpoint(
 			&msgpb.MsgPosition{
@@ -225,6 +231,7 @@ func (s *SyncTaskSuite) runTestRunNormal(storageVersion int64) {
 
 		err := task.Run(ctx)
 		s.NoError(err)
+		s.True(isDataReleased(task)) // data should be released after task finished
 	})
 
 	s.Run("with_insert_delete_cp", func() {
@@ -244,6 +251,7 @@ func (s *SyncTaskSuite) runTestRunNormal(storageVersion int64) {
 
 		err := task.Run(ctx)
 		s.NoError(err)
+		s.True(isDataReleased(task)) // data should be released after task finished
 	})
 
 	s.Run("with_flush", func() {
@@ -263,6 +271,7 @@ func (s *SyncTaskSuite) runTestRunNormal(storageVersion int64) {
 		}
 		err := task.Run(ctx)
 		s.NoError(err)
+		s.True(isDataReleased(task)) // data should be released after task finished
 	})
 
 	s.Run("with_drop", func() {
@@ -282,6 +291,7 @@ func (s *SyncTaskSuite) runTestRunNormal(storageVersion int64) {
 		}
 		err := task.Run(ctx)
 		s.NoError(err)
+		s.True(isDataReleased(task)) // data should be released after task finished
 	})
 }
 


### PR DESCRIPTION
Release data memory after sync task completes to prevent datanode oom during import.

issue: https://github.com/milvus-io/milvus/issues/42608