### PR TITLE
fix: limit the concurency of zstd compression and decrease the memory usage of binlog generation

### DIFF
--- a/internal/storage/compress/zstd.go
+++ b/internal/storage/compress/zstd.go
@@ -1,0 +1,130 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// From github.com/apache/arrow/go/v17/parquet/compress/ztsd.go
+// to implement a new codec to limit the concurrency of zstd compression.
+
+package compress
+
+import (
+	"io"
+	"sync"
+
+	"github.com/apache/arrow/go/v17/parquet/compress"
+	"github.com/klauspost/compress/zstd"
+
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+)
+
+type zstdCodec struct{}
+
+type zstdcloser struct {
+	*zstd.Decoder
+}
+
+var (
+	enc         *zstd.Encoder
+	dec         *zstd.Decoder
+	initEncoder sync.Once
+	initDecoder sync.Once
+)
+
+func getencoder() *zstd.Encoder {
+	initEncoder.Do(func() {
+		enc, _ = zstd.NewWriter(nil, zstd.WithZeroFrames(true))
+	})
+	return enc
+}
+
+func getdecoder() *zstd.Decoder {
+	initDecoder.Do(func() {
+		dec, _ = zstd.NewReader(nil)
+	})
+	return dec
+}
+
+func (zstdCodec) Decode(dst, src []byte) []byte {
+	dst, err := getdecoder().DecodeAll(src, dst[:0])
+	if err != nil {
+		panic(err)
+	}
+	return dst
+}
+
+func (z *zstdcloser) Close() error {
+	z.Decoder.Close()
+	return nil
+}
+
+func (zstdCodec) NewReader(r io.Reader) io.ReadCloser {
+	ret, _ := zstd.NewReader(r)
+	return &zstdcloser{ret}
+}
+
+func (zstdCodec) NewWriter(w io.Writer) io.WriteCloser {
+	ret, _ := zstd.NewWriter(w)
+	return ret
+}
+
+func (z zstdCodec) NewWriterLevel(w io.Writer, level int) (io.WriteCloser, error) {
+	var compressLevel zstd.EncoderLevel
+	if level == compress.DefaultCompressionLevel {
+		compressLevel = zstd.SpeedDefault
+	} else {
+		compressLevel = zstd.EncoderLevelFromZstd(level)
+	}
+	return zstd.NewWriter(w, zstd.WithEncoderLevel(compressLevel), zstd.WithEncoderConcurrency(z.getConcurrency()))
+}
+
+func (z zstdCodec) Encode(dst, src []byte) []byte {
+	return getencoder().EncodeAll(src, dst[:0])
+}
+
+func (z zstdCodec) EncodeLevel(dst, src []byte, level int) []byte {
+	compressLevel := zstd.EncoderLevelFromZstd(level)
+	if level == compress.DefaultCompressionLevel {
+		compressLevel = zstd.SpeedDefault
+	}
+	enc, _ := zstd.NewWriter(nil, zstd.WithZeroFrames(true), zstd.WithEncoderLevel(compressLevel), zstd.WithEncoderConcurrency(z.getConcurrency()))
+	return enc.EncodeAll(src, dst[:0])
+}
+
+// from zstd.h, ZSTD_COMPRESSBOUND
+func (zstdCodec) CompressBound(len int64) int64 {
+	extra := ((128 << 10) - len) >> 11
+	if len >= (128 << 10) {
+		extra = 0
+	}
+	return len + (len >> 8) + extra
+}
+
+// getConcurrency returns the concurrency for zstd compression.
+func (zstdCodec) getConcurrency() int {
+	// Every concurrent zstd compress thread will use additional memory, for double fast, 8MB is required.
+	// So on a 8-core machine, we will use 64MB memory for zstd compression.
+	// And binlog generation can be done in high concurrency, milvus may be OOM if the cpu is throttled.
+	// But most of the time, we only serialize 16MB data for one binlog generation.
+	// So 1 is enough for most cases to avoid to use too much memory.
+	concurrent := paramtable.Get().CommonCfg.StorageZstdConcurrency.GetAsInt()
+	if concurrent < 0 {
+		return 0
+	}
+	return concurrent
+}
+
+func init() {
+	compress.RegisterCodec(compress.Codecs.Zstd, zstdCodec{})
+}

--- a/internal/storage/payload_writer.go
+++ b/internal/storage/payload_writer.go
@@ -32,6 +32,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	_ "github.com/milvus-io/milvus/internal/storage/compress" // register a custom zstd codec here, to avoid to much memory usage when serializing.
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"

--- a/internal/util/importutilv2/binlog/l0_reader_test.go
+++ b/internal/util/importutilv2/binlog/l0_reader_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"testing"
 
 	"github.com/cockroachdb/errors"
@@ -29,6 +30,7 @@ import (
 	"github.com/milvus-io/milvus/internal/mocks"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/pkg/v2/proto/internalpb"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
 
 func TestL0Reader_NewL0Reader(t *testing.T) {
@@ -92,4 +94,9 @@ func TestL0Reader_Read(t *testing.T) {
 	_, err = r.Read()
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, io.EOF)
+}
+
+func TestMain(m *testing.M) {
+	paramtable.Init()
+	os.Exit(m.Run())
 }

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -270,6 +270,7 @@ type commonConfig struct {
 	StorageScheme             ParamItem `refreshable:"false"`
 	EnableStorageV2           ParamItem `refreshable:"false"`
 	StoragePathPrefix         ParamItem `refreshable:"false"`
+	StorageZstdConcurrency    ParamItem `refreshable:"false"`
 	TTMsgEnabled              ParamItem `refreshable:"true"`
 	TraceLogMode              ParamItem `refreshable:"true"`
 	BloomFilterSize           ParamItem `refreshable:"true"`
@@ -825,6 +826,17 @@ Large numeric passwords require double quotes to avoid yaml parsing precision is
 		DefaultValue: "",
 	}
 	p.StoragePathPrefix.Init(base.mgr)
+
+	p.StorageZstdConcurrency = ParamItem{
+		Key:          "common.storage.zstd.concurrency",
+		Version:      "2.6.0",
+		DefaultValue: "1",
+		Doc: `The number of concurrent zstd compress threads for one binlog generation, 0 means use all cores.
+Every concurrent zstd compress thread will use additional memory.
+The default value is 1, which is enough for most cases.`,
+		Export: false,
+	}
+	p.StorageZstdConcurrency.Init(base.mgr)
 
 	p.TTMsgEnabled = ParamItem{
 		Key:          "common.ttMsgEnabled",

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -142,6 +142,10 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, 60*time.Second, params.CommonCfg.SyncTaskPoolReleaseTimeoutSeconds.GetAsDuration(time.Second))
 		params.Save("common.sync.taskPoolReleaseTimeoutSeconds", "100")
 		assert.Equal(t, 100*time.Second, params.CommonCfg.SyncTaskPoolReleaseTimeoutSeconds.GetAsDuration(time.Second))
+
+		assert.Equal(t, 1, params.CommonCfg.StorageZstdConcurrency.GetAsInt())
+		params.Save("common.storage.zstd.concurrency", "2")
+		assert.Equal(t, 2, params.CommonCfg.StorageZstdConcurrency.GetAsInt())
 	})
 
 	t.Run("test rootCoordConfig", func(t *testing.T) {


### PR DESCRIPTION
issue: #42028

- limit the concurrency of zstd compression.
- zstd.go modified from `github.com/apache/arrow/go/v17/parquet/compress/ztsd.go`
- may be related to #42129