### PR TITLE
fix: [AddField] Use corresponding datatype for int8/int16 def val

### DIFF
--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -343,7 +343,11 @@ CreateArrowScalarFromDefaultValue(const FieldMeta& field_meta) {
             return std::make_shared<arrow::BooleanScalar>(
                 default_value.bool_data());
         case DataType::INT8:
+            return std::make_shared<arrow::Int8Scalar>(
+                default_value.int_data());
         case DataType::INT16:
+            return std::make_shared<arrow::Int16Scalar>(
+                default_value.int_data());
         case DataType::INT32:
             return std::make_shared<arrow::Int32Scalar>(
                 default_value.int_data());


### PR DESCRIPTION
Related to #42629

This PR handles converting default value to int8/int18 scalar with int32 default value definition