### PR TITLE
fix: compatibility with old sessions upgrade from 2.5 to 2.6 in standalone mode

### DIFF
--- a/internal/distributed/mixcoord/client/client.go
+++ b/internal/distributed/mixcoord/client/client.go
@@ -116,13 +116,35 @@ func (c *Client) getMixCoordAddr() (string, error) {
 	}
 	ms, ok := msess[key]
 	if !ok {
-		log.Warn("MixCoordClient mess key not exist", zap.Any("key", key))
-		return "", errors.New("find no available mixcoord, check mixcoord state")
+		if paramtable.GetRole() == typeutil.StandaloneRole {
+			return c.getCompatibleMixCoordAddr()
+		} else {
+			log.Warn("MixCoordClient mess key not exist", zap.Any("key", key))
+			return "", errors.New("find no available mixcoord, check mixcoord state")
+		}
 	}
 	log.Debug("MixCoordClient GetSessions success",
 		zap.String("address", ms.Address),
 		zap.Int64("serverID", ms.ServerID),
-	)
+		zap.String("role", key))
+	c.grpcClient.SetNodeID(ms.ServerID)
+	return ms.Address, nil
+}
+
+// compatible with standalone mode upgrade from 2.5, shoule be removed in 3.0
+func (c *Client) getCompatibleMixCoordAddr() (string, error) {
+	log := log.Ctx(c.ctx)
+	msess, _, err := c.sess.GetSessions(typeutil.RootCoordRole)
+	if err != nil {
+		log.Debug("mixCoordClient getSessions failed", zap.Any("key", typeutil.RootCoordRole), zap.Error(err))
+		return "", errors.New("find no available mixcoord, check mixcoord state")
+	}
+	ms, ok := msess[typeutil.RootCoordRole]
+	if !ok {
+		log.Warn("MixCoordClient mess key not exist", zap.Any("key", typeutil.RootCoordRole))
+		return "", errors.New("find no available mixcoord, check mixcoord state")
+	}
+	log.Debug("MixCoordClient GetSessions use rootCoord", zap.Any("key", typeutil.RootCoordRole))
 	c.grpcClient.SetNodeID(ms.ServerID)
 	return ms.Address, nil
 }


### PR DESCRIPTION
compatibility with old sessions upgrade from 2.5 to 2.6 in standalone mode
issue:https://github.com/milvus-io/milvus/issues/42602