### PR TITLE
fix: Fix potential panic when DeleteCheckpoint is nil

### DIFF
--- a/internal/querynodev2/services.go
+++ b/internal/querynodev2/services.go
@@ -332,9 +332,9 @@ func (node *QueryNode) WatchDmChannels(ctx context.Context, req *querypb.WatchDm
 			zap.Time("seekPosition", tsoutil.PhysicalTime(channelCheckpoint.GetTimestamp())),
 		)
 		position = &msgpb.MsgPosition{
-			ChannelName: channel.GetChannelName(),
-			MsgID:       channel.GetSeekPosition().GetMsgID(),
-			Timestamp:   channel.GetSeekPosition().GetTimestamp(),
+			ChannelName: channelCheckpoint.GetChannelName(),
+			MsgID:       channelCheckpoint.GetMsgID(),
+			Timestamp:   channelCheckpoint.GetTimestamp(),
 		}
 	} else {
 		if channelCheckpoint.GetTimestamp() > deleteCheckpoint.GetTimestamp() {


### PR DESCRIPTION
issue: #42663
Fix panic issue when processing VchannelInfo messages from older coordinator versions that don't have DeleteCheckpoint field.

Changes:
- Add null safety check for DeleteCheckpoint before accessing methods
- Maintain backward compatibility with legacy message formats
- Improve seek position selection logic for both old and new versions