### PR TITLE
enhance: Check if segment has too many deletions together

### DIFF
--- a/internal/datacoord/compaction_policy_single.go
+++ b/internal/datacoord/compaction_policy_single.go
@@ -108,7 +108,7 @@ func (policy *singleCompactionPolicy) triggerOneCollection(ctx context.Context, 
 		}
 
 		for _, segment := range group.segments {
-			if isDeltalogTooManySegment(segment) || isDeleteRowsTooManySegment(segment) {
+			if hasTooManyDeletions(segment) {
 				segmentViews := GetViewsByInfo(segment)
 				view := &MixSegmentView{
 					label:         segmentViews[0].label,

--- a/internal/datacoord/compaction_policy_single_test.go
+++ b/internal/datacoord/compaction_policy_single_test.go
@@ -98,17 +98,15 @@ func buildTestSegment(id int64, collId int64, level datapb.SegmentLevel, deleteR
 	}
 }
 
-func (s *SingleCompactionPolicySuite) TestIsDeltalogTooManySegment() {
-	segment := buildTestSegment(101, collID, datapb.SegmentLevel_L2, 0, 10000, 201)
-	s.Equal(true, isDeltalogTooManySegment(segment))
-}
-
 func (s *SingleCompactionPolicySuite) TestIsDeleteRowsTooManySegment() {
-	segment := buildTestSegment(101, collID, datapb.SegmentLevel_L2, 3000, 10000, 1)
-	s.Equal(true, isDeleteRowsTooManySegment(segment))
+	segment0 := buildTestSegment(101, collID, datapb.SegmentLevel_L2, 0, 10000, 201)
+	s.Equal(true, hasTooManyDeletions(segment0))
+
+	segment1 := buildTestSegment(101, collID, datapb.SegmentLevel_L2, 3000, 10000, 1)
+	s.Equal(true, hasTooManyDeletions(segment1))
 
 	segment2 := buildTestSegment(101, collID, datapb.SegmentLevel_L2, 300, 10000, 10)
-	s.Equal(true, isDeleteRowsTooManySegment(segment2))
+	s.Equal(true, hasTooManyDeletions(segment2))
 }
 
 func (s *SingleCompactionPolicySuite) TestL2SingleCompaction() {


### PR DESCRIPTION
This PR moves the deltalog file count check inside hasTooManyDeletions check. Unifies the logic on checking if a segment has too many deletions including: delta log count, deleted rows ratio and deltalog size.

This change removes several uncessary traverse through segment's binlogs and deltalogs. And add more clear trigger logs