### PR TITLE
enhance: [GoSDK] support `AddCollectionField` API

### DIFF
--- a/client/milvusclient/collection.go
+++ b/client/milvusclient/collection.go
@@ -167,10 +167,6 @@ func (c *Client) AlterCollectionFieldProperty(ctx context.Context, option AlterC
 	})
 }
 
-type GetCollectionOption interface {
-	Request() *milvuspb.GetCollectionStatisticsRequest
-}
-
 func (c *Client) GetCollectionStats(ctx context.Context, opt GetCollectionOption) (map[string]string, error) {
 	var stats map[string]string
 	err := c.callService(func(milvusService milvuspb.MilvusServiceClient) error {
@@ -185,4 +181,15 @@ func (c *Client) GetCollectionStats(ctx context.Context, opt GetCollectionOption
 		return nil, err
 	}
 	return stats, nil
+}
+
+// AddCollectionField adds a field to a collection.
+func (c *Client) AddCollectionField(ctx context.Context, opt AddCollectionFieldOption, callOpts ...grpc.CallOption) error {
+	req := opt.Request()
+
+	err := c.callService(func(milvusService milvuspb.MilvusServiceClient) error {
+		resp, err := milvusService.AddCollectionField(ctx, req, callOpts...)
+		return merr.CheckRPCCall(resp, err)
+	})
+	return err
 }

--- a/client/milvusclient/collection_example_test.go
+++ b/client/milvusclient/collection_example_test.go
@@ -524,3 +524,28 @@ func ExampleClient_DropCollection() {
 		// handle err
 	}
 }
+
+func ExampleClient_AddCollectionField() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	milvusAddr := "127.0.0.1:19530"
+
+	cli, err := milvusclient.New(ctx, &milvusclient.ClientConfig{
+		Address: milvusAddr,
+	})
+	if err != nil {
+		log.Fatal("failed to connect to milvus server: ", err.Error())
+	}
+
+	defer cli.Close(ctx)
+
+	// the field to add
+	// must be nullable for now
+	newField := entity.NewField().WithName("new_field").WithDataType(entity.FieldTypeInt64).WithNullable(true)
+
+	err = cli.AddCollectionField(ctx, milvusclient.NewAddCollectionFieldOption("customized_setup_2", newField))
+	if err != nil {
+		// handle error
+	}
+}

--- a/client/milvusclient/collection_options.go
+++ b/client/milvusclient/collection_options.go
@@ -385,6 +385,10 @@ func NewAlterCollectionFieldPropertiesOption(collectionName string, fieldName st
 	}
 }
 
+type GetCollectionOption interface {
+	Request() *milvuspb.GetCollectionStatisticsRequest
+}
+
 type getCollectionStatsOption struct {
 	collectionName string
 }
@@ -397,4 +401,28 @@ func (opt *getCollectionStatsOption) Request() *milvuspb.GetCollectionStatistics
 
 func NewGetCollectionStatsOption(collectionName string) *getCollectionStatsOption {
 	return &getCollectionStatsOption{collectionName: collectionName}
+}
+
+type AddCollectionFieldOption interface {
+	Request() *milvuspb.AddCollectionFieldRequest
+}
+
+type addCollectionFieldOption struct {
+	collectionName string
+	fieldSch       *entity.Field
+}
+
+func (c *addCollectionFieldOption) Request() *milvuspb.AddCollectionFieldRequest {
+	bs, _ := proto.Marshal(c.fieldSch.ProtoMessage())
+	return &milvuspb.AddCollectionFieldRequest{
+		CollectionName: c.collectionName,
+		Schema:         bs,
+	}
+}
+
+func NewAddCollectionFieldOption(collectionName string, field *entity.Field) *addCollectionFieldOption {
+	return &addCollectionFieldOption{
+		collectionName: collectionName,
+		fieldSch:       field,
+	}
 }


### PR DESCRIPTION
Related to #39718

This PR makes go milvusclient support `AddCollectionField` API and adds example code for it.