### PR TITLE
fix: [AddField] Use shared_ptr of schema in plan fixing dangling ref

### DIFF
--- a/internal/core/src/query/Plan.cpp
+++ b/internal/core/src/query/Plan.cpp
@@ -43,7 +43,7 @@ ParsePlaceholderGroup(const Plan* plan,
         element.tag_ = info.tag();
         Assert(plan->tag2field_.count(element.tag_));
         auto field_id = plan->tag2field_.at(element.tag_);
-        auto& field_meta = plan->schema_[field_id];
+        auto& field_meta = plan->schema_->operator[](field_id);
         AssertInfo(static_cast<int>(field_meta.get_data_type()) ==
                        static_cast<int>(info.type()),
                    "vector type must be the same, field {} - type {}, search "
@@ -95,28 +95,28 @@ ParsePlanNodeProto(proto::plan::PlanNode& plan_node,
 }
 
 std::unique_ptr<Plan>
-CreateSearchPlanByExpr(const Schema& schema,
+CreateSearchPlanByExpr(SchemaPtr schema,
                        const void* serialized_expr_plan,
                        const int64_t size) {
     // Note: serialized_expr_plan is of binary format
     proto::plan::PlanNode plan_node;
     ParsePlanNodeProto(plan_node, serialized_expr_plan, size);
-    return ProtoParser(schema).CreatePlan(plan_node);
+    return ProtoParser(std::move(schema)).CreatePlan(plan_node);
 }
 
 std::unique_ptr<Plan>
-CreateSearchPlanFromPlanNode(const Schema& schema,
+CreateSearchPlanFromPlanNode(SchemaPtr schema,
                              const proto::plan::PlanNode& plan_node) {
-    return ProtoParser(schema).CreatePlan(plan_node);
+    return ProtoParser(std::move(schema)).CreatePlan(plan_node);
 }
 
 std::unique_ptr<RetrievePlan>
-CreateRetrievePlanByExpr(const Schema& schema,
+CreateRetrievePlanByExpr(SchemaPtr schema,
                          const void* serialized_expr_plan,
                          const int64_t size) {
     proto::plan::PlanNode plan_node;
     ParsePlanNodeProto(plan_node, serialized_expr_plan, size);
-    return ProtoParser(schema).CreateRetrievePlan(plan_node);
+    return ProtoParser(std::move(schema)).CreateRetrievePlan(plan_node);
 }
 
 int64_t

--- a/internal/core/src/query/Plan.h
+++ b/internal/core/src/query/Plan.h
@@ -33,12 +33,12 @@ ParsePlanNodeProto(proto::plan::PlanNode& plan_node,
 
 // Note: serialized_expr_plan is of binary format
 std::unique_ptr<Plan>
-CreateSearchPlanByExpr(const Schema& schema,
+CreateSearchPlanByExpr(SchemaPtr schema,
                        const void* serialized_expr_plan,
                        const int64_t size);
 
 std::unique_ptr<Plan>
-CreateSearchPlanFromPlanNode(const Schema& schema,
+CreateSearchPlanFromPlanNode(SchemaPtr schema,
                              const proto::plan::PlanNode& plan_node);
 
 std::unique_ptr<PlaceholderGroup>
@@ -55,7 +55,7 @@ int64_t
 GetNumOfQueries(const PlaceholderGroup*);
 
 std::unique_ptr<RetrievePlan>
-CreateRetrievePlanByExpr(const Schema& schema,
+CreateRetrievePlanByExpr(SchemaPtr schema,
                          const void* serialized_expr_plan,
                          const int64_t size);
 

--- a/internal/core/src/query/PlanImpl.h
+++ b/internal/core/src/query/PlanImpl.h
@@ -49,11 +49,11 @@ struct ExtractedPlanInfo {
 
 struct Plan {
  public:
-    explicit Plan(const Schema& schema) : schema_(schema) {
+    explicit Plan(SchemaPtr schema) : schema_(std::move(schema)) {
     }
 
  public:
-    const Schema& schema_;
+    SchemaPtr schema_;
     std::unique_ptr<VectorPlanNode> plan_node_;
     std::map<std::string, FieldId> tag2field_;  // PlaceholderName -> FieldId
     std::vector<FieldId> target_entries_;
@@ -98,11 +98,11 @@ struct Placeholder {
 
 struct RetrievePlan {
  public:
-    explicit RetrievePlan(const Schema& schema) : schema_(schema) {
+    explicit RetrievePlan(SchemaPtr schema) : schema_(std::move(schema)) {
     }
 
  public:
-    const Schema& schema_;
+    SchemaPtr schema_;
     std::unique_ptr<RetrievePlanNode> plan_node_;
     std::vector<FieldId> field_ids_;
     std::vector<std::string> target_dynamic_fields_;

--- a/internal/core/src/query/PlanProto.cpp
+++ b/internal/core/src/query/PlanProto.cpp
@@ -302,7 +302,7 @@ ProtoParser::CreatePlan(const proto::plan::PlanNode& plan_node_proto) {
     auto plan_node = PlanNodeFromProto(plan_node_proto);
     plan->tag2field_["$0"] = plan_node->search_info_.field_id_;
     plan->plan_node_ = std::move(plan_node);
-    ExtractedPlanInfo extra_info(schema.size());
+    ExtractedPlanInfo extra_info(schema->size());
     extra_info.add_involved_field(plan->plan_node_->search_info_.field_id_);
     plan->extra_info_opt_ = std::move(extra_info);
 
@@ -341,7 +341,7 @@ expr::TypedExprPtr
 ProtoParser::ParseUnaryRangeExprs(const proto::plan::UnaryRangeExpr& expr_pb) {
     auto& column_info = expr_pb.column_info();
     auto field_id = FieldId(column_info.field_id());
-    auto data_type = schema[field_id].get_data_type();
+    auto data_type = schema->operator[](field_id).get_data_type();
     Assert(data_type == static_cast<DataType>(column_info.data_type()));
     std::vector<::milvus::proto::plan::GenericValue> extra_values;
     for (auto val : expr_pb.extra_values()) {
@@ -358,7 +358,7 @@ expr::TypedExprPtr
 ProtoParser::ParseNullExprs(const proto::plan::NullExpr& expr_pb) {
     auto& column_info = expr_pb.column_info();
     auto field_id = FieldId(column_info.field_id());
-    auto data_type = schema[field_id].get_data_type();
+    auto data_type = schema->operator[](field_id).get_data_type();
     Assert(data_type == static_cast<DataType>(column_info.data_type()));
     return std::make_shared<milvus::expr::NullExpr>(
         expr::ColumnInfo(column_info), expr_pb.op());
@@ -369,7 +369,7 @@ ProtoParser::ParseBinaryRangeExprs(
     const proto::plan::BinaryRangeExpr& expr_pb) {
     auto& columnInfo = expr_pb.column_info();
     auto field_id = FieldId(columnInfo.field_id());
-    auto data_type = schema[field_id].get_data_type();
+    auto data_type = schema->operator[](field_id).get_data_type();
     Assert(data_type == (DataType)columnInfo.data_type());
     return std::make_shared<expr::BinaryRangeFilterExpr>(
         columnInfo,
@@ -406,13 +406,13 @@ expr::TypedExprPtr
 ProtoParser::ParseCompareExprs(const proto::plan::CompareExpr& expr_pb) {
     auto& left_column_info = expr_pb.left_column_info();
     auto left_field_id = FieldId(left_column_info.field_id());
-    auto left_data_type = schema[left_field_id].get_data_type();
+    auto left_data_type = schema->operator[](left_field_id).get_data_type();
     Assert(left_data_type ==
            static_cast<DataType>(left_column_info.data_type()));
 
     auto& right_column_info = expr_pb.right_column_info();
     auto right_field_id = FieldId(right_column_info.field_id());
-    auto right_data_type = schema[right_field_id].get_data_type();
+    auto right_data_type = schema->operator[](right_field_id).get_data_type();
     Assert(right_data_type ==
            static_cast<DataType>(right_column_info.data_type()));
 
@@ -427,7 +427,7 @@ expr::TypedExprPtr
 ProtoParser::ParseTermExprs(const proto::plan::TermExpr& expr_pb) {
     auto& columnInfo = expr_pb.column_info();
     auto field_id = FieldId(columnInfo.field_id());
-    auto data_type = schema[field_id].get_data_type();
+    auto data_type = schema->operator[](field_id).get_data_type();
     Assert(data_type == (DataType)columnInfo.data_type());
     std::vector<::milvus::proto::plan::GenericValue> values;
     for (size_t i = 0; i < expr_pb.values_size(); i++) {
@@ -458,7 +458,7 @@ ProtoParser::ParseBinaryArithOpEvalRangeExprs(
     const proto::plan::BinaryArithOpEvalRangeExpr& expr_pb) {
     auto& column_info = expr_pb.column_info();
     auto field_id = FieldId(column_info.field_id());
-    auto data_type = schema[field_id].get_data_type();
+    auto data_type = schema->operator[](field_id).get_data_type();
     Assert(data_type == static_cast<DataType>(column_info.data_type()));
     return std::make_shared<expr::BinaryArithOpEvalRangeExpr>(
         column_info,
@@ -472,7 +472,7 @@ expr::TypedExprPtr
 ProtoParser::ParseExistExprs(const proto::plan::ExistsExpr& expr_pb) {
     auto& column_info = expr_pb.info();
     auto field_id = FieldId(column_info.field_id());
-    auto data_type = schema[field_id].get_data_type();
+    auto data_type = schema->operator[](field_id).get_data_type();
     Assert(data_type == static_cast<DataType>(column_info.data_type()));
     return std::make_shared<expr::ExistsExpr>(column_info);
 }
@@ -482,7 +482,7 @@ ProtoParser::ParseJsonContainsExprs(
     const proto::plan::JSONContainsExpr& expr_pb) {
     auto& columnInfo = expr_pb.column_info();
     auto field_id = FieldId(columnInfo.field_id());
-    auto data_type = schema[field_id].get_data_type();
+    auto data_type = schema->operator[](field_id).get_data_type();
     Assert(data_type == (DataType)columnInfo.data_type());
     std::vector<::milvus::proto::plan::GenericValue> values;
     for (size_t i = 0; i < expr_pb.elements_size(); i++) {

--- a/internal/core/src/query/PlanProto.h
+++ b/internal/core/src/query/PlanProto.h
@@ -35,7 +35,7 @@ class ProtoParser {
     }
 
  public:
-    explicit ProtoParser(const Schema& schema) : schema(schema) {
+    explicit ProtoParser(SchemaPtr schema) : schema(std::move(schema)) {
     }
 
     std::unique_ptr<VectorPlanNode>
@@ -99,7 +99,7 @@ class ProtoParser {
     ParseValueExprs(const proto::plan::ValueExpr& expr_pb);
 
  private:
-    const Schema& schema;
+    const SchemaPtr schema;
 };
 
 }  // namespace milvus::query

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -803,7 +803,7 @@ ChunkedSegmentSealedImpl::check_search(const query::Plan* plan) const {
         // absent_fields.find_first() returns std::optional<>
         auto field_id =
             FieldId(absent_fields.find_first().value() + START_USER_FIELDID);
-        auto& field_meta = plan->schema_.operator[](field_id);
+        auto& field_meta = plan->schema_->operator[](field_id);
         // request field may has added field
         if (!field_meta.is_nullable()) {
             PanicInfo(FieldNotLoaded,
@@ -1845,9 +1845,9 @@ ChunkedSegmentSealedImpl::RemoveFieldFile(const FieldId field_id) {
 }
 
 void
-ChunkedSegmentSealedImpl::LazyCheckSchema(const Schema& sch) {
-    if (sch.get_schema_version() > schema_->get_schema_version()) {
-        Reopen(std::make_shared<Schema>(sch));
+ChunkedSegmentSealedImpl::LazyCheckSchema(SchemaPtr sch) {
+    if (sch->get_schema_version() > schema_->get_schema_version()) {
+        Reopen(sch);
     }
 }
 

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -132,7 +132,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     Reopen(SchemaPtr sch) override;
 
     void
-    LazyCheckSchema(const Schema& sch) override;
+    LazyCheckSchema(SchemaPtr sch) override;
 
     void
     FinishLoad() override;

--- a/internal/core/src/segcore/Collection.h
+++ b/internal/core/src/segcore/Collection.h
@@ -34,7 +34,7 @@ class Collection {
                  const uint64_t version);
 
  public:
-    SchemaPtr&
+    SchemaPtr
     get_schema() {
         return schema_;
     }

--- a/internal/core/src/segcore/ReduceUtils.cpp
+++ b/internal/core/src/segcore/ReduceUtils.cpp
@@ -32,7 +32,7 @@ AssembleGroupByValues(
             std::make_unique<google::protobuf::RepeatedField<bool>>();
         valid_data->Resize(group_by_vals.size(), true);
         auto group_by_field =
-            plan->schema_.operator[](group_by_field_id.value());
+            plan->schema_->operator[](group_by_field_id.value());
         auto group_by_data_type = group_by_field.get_data_type();
 
         int group_by_val_size = group_by_vals.size();

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -1224,9 +1224,9 @@ SegmentGrowingImpl::BulkGetJsonData(
 }
 
 void
-SegmentGrowingImpl::LazyCheckSchema(const Schema& sch) {
-    if (sch.get_schema_version() > schema_->get_schema_version()) {
-        Reopen(std::make_shared<Schema>(sch));
+SegmentGrowingImpl::LazyCheckSchema(SchemaPtr sch) {
+    if (sch->get_schema_version() > schema_->get_schema_version()) {
+        Reopen(sch);
     }
 }
 

--- a/internal/core/src/segcore/SegmentGrowingImpl.h
+++ b/internal/core/src/segcore/SegmentGrowingImpl.h
@@ -103,7 +103,7 @@ class SegmentGrowingImpl : public SegmentGrowing {
     Reopen(SchemaPtr sch) override;
 
     void
-    LazyCheckSchema(const Schema& sch) override;
+    LazyCheckSchema(SchemaPtr sch) override;
 
     void
     FinishLoad() override;

--- a/internal/core/src/segcore/SegmentInterface.h
+++ b/internal/core/src/segcore/SegmentInterface.h
@@ -151,7 +151,7 @@ class SegmentInterface {
                     int64_t count) const = 0;
 
     virtual void
-    LazyCheckSchema(const Schema& sch) = 0;
+    LazyCheckSchema(SchemaPtr sch) = 0;
 
     // reopen segment with new schema
     virtual void

--- a/internal/core/src/segcore/plan_c.cpp
+++ b/internal/core/src/segcore/plan_c.cpp
@@ -20,11 +20,11 @@ CreateSearchPlanByExpr(CCollection c_col,
                        const void* serialized_expr_plan,
                        const int64_t size,
                        CSearchPlan* res_plan) {
-    auto col = (milvus::segcore::Collection*)c_col;
+    auto col = static_cast<milvus::segcore::Collection*>(c_col);
 
     try {
         auto res = milvus::query::CreateSearchPlanByExpr(
-            *col->get_schema(), serialized_expr_plan, size);
+            col->get_schema(), serialized_expr_plan, size);
         auto col_index_meta = col->get_index_meta();
         auto field_id = milvus::query::GetFieldID(res.get());
         AssertInfo(col_index_meta != nullptr, "index meta not exist");
@@ -142,7 +142,7 @@ CreateRetrievePlanByExpr(CCollection c_col,
 
     try {
         auto res = milvus::query::CreateRetrievePlanByExpr(
-            *col->get_schema(), serialized_expr_plan, size);
+            col->get_schema(), serialized_expr_plan, size);
 
         auto status = CStatus();
         status.error_code = milvus::Success;
@@ -174,7 +174,7 @@ DeleteRetrievePlan(CRetrievePlan c_plan) {
 bool
 ShouldIgnoreNonPk(CRetrievePlan c_plan) {
     auto plan = static_cast<milvus::query::RetrievePlan*>(c_plan);
-    auto pk_field = plan->schema_.get_primary_field_id();
+    auto pk_field = plan->schema_->get_primary_field_id();
     auto only_contain_pk = pk_field.has_value() &&
                            plan->field_ids_.size() == 1 &&
                            pk_field.value() == plan->field_ids_[0];

--- a/internal/core/src/segcore/reduce/Reduce.cpp
+++ b/internal/core/src/segcore/reduce/Reduce.cpp
@@ -336,9 +336,9 @@ ReduceHelper::GetSearchResultDataSlice(int slice_index) {
 
     // reserve space for pks
     auto primary_field_id =
-        plan_->schema_.get_primary_field_id().value_or(milvus::FieldId(-1));
+        plan_->schema_->get_primary_field_id().value_or(milvus::FieldId(-1));
     AssertInfo(primary_field_id.get() != INVALID_FIELD_ID, "Primary key is -1");
-    auto pk_type = plan_->schema_[primary_field_id].get_data_type();
+    auto pk_type = plan_->schema_->operator[](primary_field_id).get_data_type();
     switch (pk_type) {
         case milvus::DataType::INT64: {
             auto ids = std::make_unique<milvus::proto::schema::LongArray>();
@@ -431,7 +431,7 @@ ReduceHelper::GetSearchResultDataSlice(int slice_index) {
 
     // set output fields
     for (auto field_id : plan_->target_entries_) {
-        auto& field_meta = plan_->schema_[field_id];
+        auto& field_meta = plan_->schema_->operator[](field_id);
         auto field_data =
             milvus::segcore::MergeDataArray(result_pairs, field_meta);
         if (field_meta.get_data_type() == DataType::ARRAY) {

--- a/internal/core/src/segcore/reduce/StreamReduce.cpp
+++ b/internal/core/src/segcore/reduce/StreamReduce.cpp
@@ -146,7 +146,7 @@ StreamReducerHelper::AssembleMergedResult() {
             new_merged_result->topk_per_nq_prefix_sum_.begin() + 1);
         new_merged_result->result_offsets_ = std::move(new_result_offsets);
         for (auto field_id : plan_->target_entries_) {
-            auto& field_meta = plan_->schema_[field_id];
+            auto& field_meta = plan_->schema_->operator[](field_id);
             auto field_data =
                 MergeDataArray(merge_output_data_bases, field_meta);
             if (field_meta.get_data_type() == DataType::ARRAY) {
@@ -558,9 +558,9 @@ StreamReducerHelper::GetSearchResultDataSlice(int slice_index) {
 
     // reserve space for pks
     auto primary_field_id =
-        plan_->schema_.get_primary_field_id().value_or(milvus::FieldId(-1));
+        plan_->schema_->get_primary_field_id().value_or(milvus::FieldId(-1));
     AssertInfo(primary_field_id.get() != INVALID_FIELD_ID, "Primary key is -1");
-    auto pk_type = plan_->schema_[primary_field_id].get_data_type();
+    auto pk_type = plan_->schema_->operator[](primary_field_id).get_data_type();
     switch (pk_type) {
         case milvus::DataType::INT64: {
             auto ids = std::make_unique<milvus::proto::schema::LongArray>();
@@ -665,7 +665,7 @@ StreamReducerHelper::GetSearchResultDataSlice(int slice_index) {
 
     // set output fields
     for (auto field_id : plan_->target_entries_) {
-        auto& field_meta = plan_->schema_[field_id];
+        auto& field_meta = plan_->schema_->operator[](field_id);
         auto field_data =
             milvus::segcore::MergeDataArray(result_pairs, field_meta);
         if (field_meta.get_data_type() == DataType::ARRAY) {

--- a/internal/core/src/segcore/storagev1translator/ChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/ChunkTranslator.cpp
@@ -112,7 +112,7 @@ ChunkTranslator::get_cells(
 
     if (use_mmap_) {
         folder = std::filesystem::path(mmap_dir_path_) /
-                      std::to_string(segment_id_) / std::to_string(field_id_);
+                 std::to_string(segment_id_) / std::to_string(field_id_);
         std::filesystem::create_directories(folder);
     }
 

--- a/internal/core/src/segcore/storagev1translator/ChunkTranslator.h
+++ b/internal/core/src/segcore/storagev1translator/ChunkTranslator.h
@@ -60,7 +60,6 @@ class ChunkTranslator : public milvus::cachinglayer::Translator<milvus::Chunk> {
     }
 
  private:
-
     std::vector<std::pair<std::string, int64_t>> files_and_rows_;
     int64_t segment_id_;
     int64_t field_id_;

--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -1156,7 +1156,7 @@ CacheRawDataAndFillMissing(const MemFileManagerImplPtr& file_manager,
     }
 
     if (lack_binlog_rows > 0) {
-        LOG_INFO("create index lack binlog detected, lock row num: {}",
+        LOG_INFO("create index lack binlog detected, lack row num: {}",
                  lack_binlog_rows);
         auto field_schema = file_manager->GetFieldDataMeta().field_schema;
         auto default_value = [&]() -> std::optional<DefaultValueType> {

--- a/internal/core/unittest/bench/bench_search.cpp
+++ b/internal/core/unittest/bench/bench_search.cpp
@@ -48,7 +48,7 @@ const auto search_plan = [] {
         >)";
     auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
     auto plan =
-        CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+        CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     return plan;
 }();
 auto ph_group = [] {

--- a/internal/core/unittest/test_array_expr.cpp
+++ b/internal/core/unittest/test_array_expr.cpp
@@ -605,7 +605,7 @@ TEST(Expr, TestArrayRange) {
         raw_plan.replace(loc, 4, clause);
         auto plan_str = translate_text_plan_to_binary_plan(raw_plan.c_str());
         auto plan =
-            CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+            CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
         BitsetType final;
         final = ExecuteQueryExpr(
             plan->plan_node_->plannodes_->sources()[0]->sources()[0],
@@ -743,7 +743,7 @@ TEST(Expr, TestArrayEqual) {
         raw_plan.replace(loc, 4, clause);
         auto plan_str = translate_text_plan_to_binary_plan(raw_plan.c_str());
         auto plan =
-            CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+            CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
         BitsetType final;
         final = ExecuteQueryExpr(
             plan->plan_node_->plannodes_->sources()[0]->sources()[0],
@@ -852,7 +852,7 @@ TEST(Expr, TestArrayNullExpr) {
         raw_plan.replace(loc, 4, clause);
         auto plan_str = translate_text_plan_to_binary_plan(raw_plan.c_str());
         auto plan =
-            CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+            CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
         BitsetType final;
         final = ExecuteQueryExpr(
             plan->plan_node_->plannodes_->sources()[0]->sources()[0],
@@ -964,7 +964,7 @@ TEST(Expr, PraseArrayContainsExpr) {
                          DataType::INT64,
                          false);
         auto plan =
-            CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+            CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     }
 }
 
@@ -2431,7 +2431,7 @@ TEST(Expr, TestArrayBinaryArith) {
         raw_plan.replace(loc, 4, clause);
         auto plan_str = translate_text_plan_to_binary_plan(raw_plan.c_str());
         auto plan =
-            CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+            CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
         BitsetType final;
         final = ExecuteQueryExpr(
             plan->plan_node_->plannodes_->sources()[0]->sources()[0],
@@ -2763,7 +2763,7 @@ TEST(Expr, TestArrayInTerm) {
         raw_plan.replace(loc, 4, clause);
         auto plan_str = translate_text_plan_to_binary_plan(raw_plan.c_str());
         auto plan =
-            CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+            CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
         BitsetType final;
         final = ExecuteQueryExpr(
             plan->plan_node_->plannodes_->sources()[0]->sources()[0],

--- a/internal/core/unittest/test_array_inverted_index.cpp
+++ b/internal/core/unittest/test_array_inverted_index.cpp
@@ -154,7 +154,7 @@ TYPED_TEST_P(ArrayInvertedIndexTest, ArrayContainsAny) {
     auto expr = test::GenExpr();
     expr->set_allocated_json_contains_expr(contains_expr.release());
 
-    auto parser = ProtoParser(*this->schema_);
+    auto parser = ProtoParser(this->schema_);
     auto typed_expr = parser.ParseExprs(*expr);
     auto parsed =
         std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, typed_expr);
@@ -206,7 +206,7 @@ TYPED_TEST_P(ArrayInvertedIndexTest, ArrayContainsAll) {
     auto expr = test::GenExpr();
     expr->set_allocated_json_contains_expr(contains_expr.release());
 
-    auto parser = ProtoParser(*this->schema_);
+    auto parser = ProtoParser(this->schema_);
     auto typed_expr = parser.ParseExprs(*expr);
     auto parsed =
         std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, typed_expr);
@@ -266,7 +266,7 @@ TYPED_TEST_P(ArrayInvertedIndexTest, ArrayEqual) {
     auto expr = test::GenExpr();
     expr->set_allocated_unary_range_expr(unary_range_expr.release());
 
-    auto parser = ProtoParser(*this->schema_);
+    auto parser = ProtoParser(this->schema_);
     auto typed_expr = parser.ParseExprs(*expr);
     auto parsed =
         std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, typed_expr);

--- a/internal/core/unittest/test_binlog_index.cpp
+++ b/internal/core/unittest/test_binlog_index.cpp
@@ -247,7 +247,7 @@ TEST_P(BinlogIndexTest, AccuracyWithLoadFieldData) {
             : CreateSparseFloatPlaceholderGroup(num_queries);
 
     auto plan = milvus::query::CreateSearchPlanByExpr(
-        *schema, plan_str.data(), plan_str.size());
+        schema, plan_str.data(), plan_str.size());
     auto ph_group =
         ParsePlaceholderGroup(plan.get(), ph_group_raw.SerializeAsString());
 
@@ -346,7 +346,7 @@ TEST_P(BinlogIndexTest, AccuracyWithMapFieldData) {
             : CreateSparseFloatPlaceholderGroup(num_queries);
 
     auto plan = milvus::query::CreateSearchPlanByExpr(
-        *schema, plan_str.data(), plan_str.size());
+        schema, plan_str.data(), plan_str.size());
     auto ph_group =
         ParsePlaceholderGroup(plan.get(), ph_group_raw.SerializeAsString());
 

--- a/internal/core/unittest/test_c_api.cpp
+++ b/internal/core/unittest/test_c_api.cpp
@@ -490,7 +490,7 @@ TEST(CApiTest, MultiDeleteGrowingSegment) {
         retrive_pks.push_back(value);
     }
     auto schema = ((milvus::segcore::Collection*)collection)->get_schema();
-    auto plan = std::make_unique<query::RetrievePlan>(*schema);
+    auto plan = std::make_unique<query::RetrievePlan>(schema);
     auto term_expr = std::make_shared<milvus::expr::TermFilterExpr>(
         milvus::expr::ColumnInfo(
             FieldId(101), DataType::INT64, std::vector<std::string>()),
@@ -617,7 +617,7 @@ TEST(CApiTest, MultiDeleteSealedSegment) {
         retrive_pks.push_back(value);
     }
     auto schema = ((milvus::segcore::Collection*)collection)->get_schema();
-    auto plan = std::make_unique<query::RetrievePlan>(*schema);
+    auto plan = std::make_unique<query::RetrievePlan>(schema);
     auto term_expr = std::make_shared<milvus::expr::TermFilterExpr>(
         milvus::expr::ColumnInfo(
             FieldId(101), DataType::INT64, std::vector<std::string>()),
@@ -734,7 +734,7 @@ TEST(CApiTest, DeleteRepeatedPksFromGrowingSegment) {
         }
     }
     auto schema = ((milvus::segcore::Collection*)collection)->get_schema();
-    auto plan = std::make_unique<query::RetrievePlan>(*schema);
+    auto plan = std::make_unique<query::RetrievePlan>(schema);
     auto term_expr = std::make_shared<milvus::expr::TermFilterExpr>(
         milvus::expr::ColumnInfo(
             FieldId(101), DataType::INT64, std::vector<std::string>()),
@@ -819,7 +819,7 @@ TEST(CApiTest, DeleteRepeatedPksFromSealedSegment) {
         }
     }
     auto schema = ((milvus::segcore::Collection*)collection)->get_schema();
-    auto plan = std::make_unique<query::RetrievePlan>(*schema);
+    auto plan = std::make_unique<query::RetrievePlan>(schema);
     auto term_expr = std::make_shared<milvus::expr::TermFilterExpr>(
         milvus::expr::ColumnInfo(
             FieldId(101), DataType::INT64, std::vector<std::string>()),
@@ -991,7 +991,7 @@ TEST(CApiTest, InsertSamePkAfterDeleteOnGrowingSegment) {
         }
     }
     auto schema = ((milvus::segcore::Collection*)collection)->get_schema();
-    auto plan = std::make_unique<query::RetrievePlan>(*schema);
+    auto plan = std::make_unique<query::RetrievePlan>(schema);
     auto term_expr = std::make_shared<milvus::expr::TermFilterExpr>(
         milvus::expr::ColumnInfo(
             FieldId(101), DataType::INT64, std::vector<std::string>()),
@@ -1089,7 +1089,7 @@ TEST(CApiTest, InsertSamePkAfterDeleteOnSealedSegment) {
         }
     }
     auto schema = ((milvus::segcore::Collection*)collection)->get_schema();
-    auto plan = std::make_unique<query::RetrievePlan>(*schema);
+    auto plan = std::make_unique<query::RetrievePlan>(schema);
     auto term_expr = std::make_shared<milvus::expr::TermFilterExpr>(
         milvus::expr::ColumnInfo(
             FieldId(101), DataType::INT64, std::vector<std::string>()),
@@ -1260,7 +1260,7 @@ TEST(CApiTest, RetrieveTestWithExpr) {
     auto status = NewSegment(collection, Growing, -1, &segment, false);
     ASSERT_EQ(status.error_code, Success);
     auto schema = ((milvus::segcore::Collection*)collection)->get_schema();
-    auto plan = std::make_unique<query::RetrievePlan>(*schema);
+    auto plan = std::make_unique<query::RetrievePlan>(schema);
 
     int N = 10000;
     auto dataset = DataGen(schema, N);
@@ -4371,7 +4371,7 @@ TEST(CApiTest, RetrieveScalarFieldFromSealedSegmentWithIndex) {
     segment->LoadIndex(load_index_info);
 
     // create retrieve plan
-    auto plan = std::make_unique<query::RetrievePlan>(*schema);
+    auto plan = std::make_unique<query::RetrievePlan>(schema);
     plan->plan_node_ = std::make_unique<query::RetrievePlanNode>();
     std::vector<proto::plan::GenericValue> retrive_row_ids;
     proto::plan::GenericValue val;

--- a/internal/core/unittest/test_chunk_vector.cpp
+++ b/internal/core/unittest/test_chunk_vector.cpp
@@ -290,7 +290,7 @@ TEST_P(ChunkVectorTest, SearchWithMmap) {
                       : CreatePlaceholderGroup(num_queries, 128, 1024);
 
         auto plan = milvus::query::CreateSearchPlanByExpr(
-            *schema, plan_str.data(), plan_str.size());
+            schema, plan_str.data(), plan_str.size());
         auto ph_group =
             ParsePlaceholderGroup(plan.get(), ph_group_raw.SerializeAsString());
         Timestamp timestamp = 1000000;
@@ -350,7 +350,7 @@ TEST_F(ChunkVectorTest, QueryWithMmap) {
 
     auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
     auto plan = milvus::query::CreateSearchPlanByExpr(
-        *schema, plan_str.data(), plan_str.size());
+        schema, plan_str.data(), plan_str.size());
     auto num_queries = 3;
     auto ph_group_raw =
         milvus::segcore::CreatePlaceholderGroup(num_queries, 16, 1024);

--- a/internal/core/unittest/test_expr.cpp
+++ b/internal/core/unittest/test_expr.cpp
@@ -161,7 +161,7 @@ TEST_P(ExprTest, Range) {
     schema->AddDebugField("fakevec", data_type, 16, metric_type);
     schema->AddDebugField("age", DataType::INT32);
     auto plan =
-        CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+        CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     Assert(plan->tag2field_.at("$0") ==
            schema->get_field_id(FieldName("fakevec")));
 }
@@ -212,7 +212,7 @@ TEST_P(ExprTest, InvalidRange) {
     schema->AddDebugField("fakevec", data_type, 16, metric_type);
     schema->AddDebugField("age", DataType::INT32);
     ASSERT_ANY_THROW(
-        CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size()));
+        CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size()));
 }
 
 TEST_P(ExprTest, ShowExecutor) {
@@ -400,7 +400,7 @@ TEST_P(ExprTest, TestRange) {
         raw_plan.replace(loc, 4, clause);
         auto plan_str = translate_text_plan_with_metric_type(raw_plan);
         auto plan =
-            CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+            CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
         BitsetType final;
         final = ExecuteQueryExpr(
             plan->plan_node_->plannodes_->sources()[0]->sources()[0],
@@ -780,7 +780,7 @@ TEST_P(ExprTest, TestRangeNullable) {
         raw_plan.replace(loc, 4, clause);
         auto plan_str = translate_text_plan_with_metric_type(raw_plan);
         auto plan =
-            CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+            CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
         query::ExecPlanNodeVisitor visitor(*seg_promote, MAX_TIMESTAMP);
         BitsetType final;
         final = ExecuteQueryExpr(
@@ -2229,7 +2229,7 @@ TEST_P(ExprTest, TestTerm) {
         raw_plan.replace(loc, 4, clause);
         auto plan_str = translate_text_plan_with_metric_type(raw_plan);
         auto plan =
-            CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+            CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
         BitsetType final;
         final = ExecuteQueryExpr(
             plan->plan_node_->plannodes_->sources()[0]->sources()[0],
@@ -2379,7 +2379,7 @@ TEST_P(ExprTest, TestTermNullable) {
         raw_plan.replace(loc, 4, clause);
         auto plan_str = translate_text_plan_with_metric_type(raw_plan);
         auto plan =
-            CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+            CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
         BitsetType final;
         final = ExecuteQueryExpr(
             plan->plan_node_->plannodes_->sources()[0]->sources()[0],
@@ -2505,7 +2505,7 @@ TEST_P(ExprTest, TestCall) {
     for (auto& [raw_plan, ref_func] : test_cases) {
         auto plan_str = translate_text_plan_with_metric_type(raw_plan);
         auto plan =
-            CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+            CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
         BitsetType final;
         final = ExecuteQueryExpr(
             plan->plan_node_->plannodes_->sources()[0]->sources()[0],
@@ -2601,7 +2601,7 @@ TEST_P(ExprTest, TestCall) {
     for (auto& raw_plan : incorrect_test_cases) {
         auto plan_str = translate_text_plan_with_metric_type(raw_plan);
         EXPECT_ANY_THROW(
-            CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size()));
+            CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size()));
     }
 }
 
@@ -2674,7 +2674,7 @@ TEST_P(ExprTest, TestCompare) {
         raw_plan.replace(loc, 4, clause);
         auto plan_str = translate_text_plan_with_metric_type(raw_plan);
         auto plan =
-            CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+            CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
         BitsetType final;
         final = ExecuteQueryExpr(
             plan->plan_node_->plannodes_->sources()[0]->sources()[0],
@@ -2828,7 +2828,7 @@ TEST_P(ExprTest, TestCompareNullable) {
         raw_plan.replace(loc, 4, clause);
         auto plan_str = translate_text_plan_with_metric_type(raw_plan);
         auto plan =
-            CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+            CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
         BitsetType final;
         final = ExecuteQueryExpr(
             plan->plan_node_->plannodes_->sources()[0]->sources()[0],
@@ -2982,7 +2982,7 @@ TEST_P(ExprTest, TestCompareNullable2) {
         raw_plan.replace(loc, 4, clause);
         auto plan_str = translate_text_plan_with_metric_type(raw_plan);
         auto plan =
-            CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+            CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
         BitsetType final;
         final = ExecuteQueryExpr(
             plan->plan_node_->plannodes_->sources()[0]->sources()[0],
@@ -3104,7 +3104,7 @@ TEST_P(ExprTest, TestCompareWithScalarIndex) {
         auto binary_plan =
             translate_text_plan_with_metric_type(dsl_string.str());
         auto plan = CreateSearchPlanByExpr(
-            *schema, binary_plan.data(), binary_plan.size());
+            schema, binary_plan.data(), binary_plan.size());
         // std::cout << ShowPlanNodeVisitor().call_child(*plan->plan_node_) << std::endl;
         BitsetType final;
         final = ExecuteQueryExpr(
@@ -3266,7 +3266,7 @@ TEST_P(ExprTest, TestCompareWithScalarIndexNullable) {
         auto binary_plan =
             translate_text_plan_with_metric_type(dsl_string.str());
         auto plan = CreateSearchPlanByExpr(
-            *schema, binary_plan.data(), binary_plan.size());
+            schema, binary_plan.data(), binary_plan.size());
         // std::cout << ShowPlanNodeVisitor().call_child(*plan->plan_node_) << std::endl;
         BitsetType final;
         final = ExecuteQueryExpr(
@@ -3428,7 +3428,7 @@ TEST_P(ExprTest, TestCompareWithScalarIndexNullable2) {
         auto binary_plan =
             translate_text_plan_with_metric_type(dsl_string.str());
         auto plan = CreateSearchPlanByExpr(
-            *schema, binary_plan.data(), binary_plan.size());
+            schema, binary_plan.data(), binary_plan.size());
         // std::cout << ShowPlanNodeVisitor().call_child(*plan->plan_node_) << std::endl;
         BitsetType final;
         final = ExecuteQueryExpr(
@@ -6081,7 +6081,7 @@ TEST_P(ExprTest, TestCompareWithScalarIndexMaris) {
         auto binary_plan =
             translate_text_plan_with_metric_type(dsl_string.str());
         auto plan = CreateSearchPlanByExpr(
-            *schema, binary_plan.data(), binary_plan.size());
+            schema, binary_plan.data(), binary_plan.size());
         //         std::cout << ShowPlanNodeVisitor().call_child(*plan->plan_node_) << std::endl;
         BitsetType final;
         final = ExecuteQueryExpr(
@@ -6238,7 +6238,7 @@ TEST_P(ExprTest, TestCompareWithScalarIndexMarisNullable) {
         auto binary_plan =
             translate_text_plan_with_metric_type(dsl_string.str());
         auto plan = CreateSearchPlanByExpr(
-            *schema, binary_plan.data(), binary_plan.size());
+            schema, binary_plan.data(), binary_plan.size());
         //         std::cout << ShowPlanNodeVisitor().call_child(*plan->plan_node_) << std::endl;
         BitsetType final;
         final = ExecuteQueryExpr(
@@ -6395,7 +6395,7 @@ TEST_P(ExprTest, TestCompareWithScalarIndexMarisNullable2) {
         auto binary_plan =
             translate_text_plan_with_metric_type(dsl_string.str());
         auto plan = CreateSearchPlanByExpr(
-            *schema, binary_plan.data(), binary_plan.size());
+            schema, binary_plan.data(), binary_plan.size());
         //         std::cout << ShowPlanNodeVisitor().call_child(*plan->plan_node_) << std::endl;
         BitsetType final;
         final = ExecuteQueryExpr(
@@ -7130,7 +7130,7 @@ TEST_P(ExprTest, TestBinaryArithOpEvalRange) {
         // dsl_string.replace(loc, 4, clause);
         auto plan_str = translate_text_plan_with_metric_type(raw_plan);
         auto plan =
-            CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+            CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
         BitsetType final;
         final = ExecuteQueryExpr(
             plan->plan_node_->plannodes_->sources()[0]->sources()[0],
@@ -8110,7 +8110,7 @@ TEST_P(ExprTest, TestBinaryArithOpEvalRangeNullable) {
         // dsl_string.replace(loc, 4, clause);
         auto plan_str = translate_text_plan_with_metric_type(raw_plan);
         auto plan =
-            CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+            CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
         BitsetType final;
         final = ExecuteQueryExpr(
             plan->plan_node_->plannodes_->sources()[0]->sources()[0],
@@ -8989,7 +8989,7 @@ TEST_P(ExprTest, TestBinaryArithOpEvalRangeJSON) {
         raw_plan.replace(loc, 5, clause);
         auto plan_str = translate_text_plan_to_binary_plan(raw_plan.c_str());
         auto plan =
-            CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+            CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
         BitsetType final;
         final = ExecuteQueryExpr(
             plan->plan_node_->plannodes_->sources()[0]->sources()[0],
@@ -9934,7 +9934,7 @@ TEST_P(ExprTest, TestBinaryArithOpEvalRangeJSONNullable) {
         raw_plan.replace(loc, 5, clause);
         auto plan_str = translate_text_plan_to_binary_plan(raw_plan.c_str());
         auto plan =
-            CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+            CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
         BitsetType final;
         final = ExecuteQueryExpr(
             plan->plan_node_->plannodes_->sources()[0]->sources()[0],
@@ -10783,7 +10783,7 @@ TEST_P(ExprTest, TestBinaryArithOpEvalRangeWithScalarSortIndex) {
 
         auto binary_plan = translate_text_plan_with_metric_type(expr.str());
         auto plan = CreateSearchPlanByExpr(
-            *schema, binary_plan.data(), binary_plan.size());
+            schema, binary_plan.data(), binary_plan.size());
 
         BitsetType final;
         final = ExecuteQueryExpr(
@@ -11541,7 +11541,7 @@ TEST_P(ExprTest, TestBinaryArithOpEvalRangeWithScalarSortIndexNullable) {
 
         auto binary_plan = translate_text_plan_with_metric_type(expr.str());
         auto plan = CreateSearchPlanByExpr(
-            *schema, binary_plan.data(), binary_plan.size());
+            schema, binary_plan.data(), binary_plan.size());
 
         BitsetType final;
         final = ExecuteQueryExpr(
@@ -11779,7 +11779,7 @@ TEST_P(ExprTest, TestUnaryRangeWithJSON) {
 
         auto unary_plan = translate_text_plan_with_metric_type(expr.str());
         auto plan = CreateSearchPlanByExpr(
-            *schema, unary_plan.data(), unary_plan.size());
+            schema, unary_plan.data(), unary_plan.size());
 
         BitsetType final;
         final = ExecuteQueryExpr(
@@ -12039,7 +12039,7 @@ TEST_P(ExprTest, TestUnaryRangeWithJSONNullable) {
 
         auto unary_plan = translate_text_plan_with_metric_type(expr.str());
         auto plan = CreateSearchPlanByExpr(
-            *schema, unary_plan.data(), unary_plan.size());
+            schema, unary_plan.data(), unary_plan.size());
 
         BitsetType final;
         final = ExecuteQueryExpr(
@@ -12176,7 +12176,7 @@ TEST_P(ExprTest, TestNullExprWithJSON) {
         raw_plan.replace(loc, 4, clause);
         auto plan_str = translate_text_plan_to_binary_plan(raw_plan.c_str());
         auto plan =
-            CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+            CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
         BitsetType final;
         final = ExecuteQueryExpr(
             plan->plan_node_->plannodes_->sources()[0]->sources()[0],
@@ -12345,7 +12345,7 @@ TEST_P(ExprTest, TestTermWithJSON) {
 
         auto unary_plan = translate_text_plan_with_metric_type(expr.str());
         auto plan = CreateSearchPlanByExpr(
-            *schema, unary_plan.data(), unary_plan.size());
+            schema, unary_plan.data(), unary_plan.size());
 
         BitsetType final;
         final = ExecuteQueryExpr(
@@ -12578,7 +12578,7 @@ TEST_P(ExprTest, TestTermWithJSONNullable) {
 
         auto unary_plan = translate_text_plan_with_metric_type(expr.str());
         auto plan = CreateSearchPlanByExpr(
-            *schema, unary_plan.data(), unary_plan.size());
+            schema, unary_plan.data(), unary_plan.size());
 
         BitsetType final;
         final = ExecuteQueryExpr(
@@ -12763,7 +12763,7 @@ TEST_P(ExprTest, TestExistsWithJSON) {
 
         auto unary_plan = translate_text_plan_with_metric_type(expr.str());
         auto plan = CreateSearchPlanByExpr(
-            *schema, unary_plan.data(), unary_plan.size());
+            schema, unary_plan.data(), unary_plan.size());
 
         BitsetType final;
         final = ExecuteQueryExpr(
@@ -12991,7 +12991,7 @@ TEST_P(ExprTest, TestExistsWithJSONNullable) {
 
         auto unary_plan = translate_text_plan_with_metric_type(expr.str());
         auto plan = CreateSearchPlanByExpr(
-            *schema, unary_plan.data(), unary_plan.size());
+            schema, unary_plan.data(), unary_plan.size());
 
         BitsetType final;
         final = ExecuteQueryExpr(
@@ -13795,7 +13795,7 @@ TEST_P(ExprTest, PraseJsonContainsExpr) {
         schema->AddDebugField("fakevec", data_type, 16, metric_type);
         schema->AddDebugField("json", DataType::JSON);
         auto plan =
-            CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+            CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     }
 }
 

--- a/internal/core/unittest/test_expr_materialized_view.cpp
+++ b/internal/core/unittest/test_expr_materialized_view.cpp
@@ -156,7 +156,7 @@ class ExprMaterializedViewTest : public testing::Test {
         auto binary_plan = milvus::segcore::translate_text_plan_to_binary_plan(
             plan_str.c_str());
         return milvus::query::CreateSearchPlanByExpr(
-            *schema, binary_plan.data(), binary_plan.size());
+            schema, binary_plan.data(), binary_plan.size());
     }
 
     knowhere::MaterializedViewSearchInfo
@@ -335,7 +335,7 @@ TEST_F(ExprMaterializedViewTest, TestMvNoExpr) {
                 milvus::segcore::translate_text_plan_to_binary_plan(
                     plan_str.c_str());
             auto plan = milvus::query::CreateSearchPlanByExpr(
-                *schema, binary_plan.data(), binary_plan.size());
+                schema, binary_plan.data(), binary_plan.size());
             auto mv = ExecutePlan(plan);
             TestMvExpectDefault(mv);
         }

--- a/internal/core/unittest/test_float16.cpp
+++ b/internal/core/unittest/test_float16.cpp
@@ -105,7 +105,7 @@ TEST(Float16, ExecWithoutPredicateFlat) {
         >)";
     auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
     auto plan =
-        CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+        CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     int64_t N = ROW_COUNT;
     auto dataset = DataGen(schema, N);
     auto segment = CreateGrowingSegment(schema, empty_index_meta);
@@ -197,7 +197,7 @@ TEST(Float16, RetrieveEmpty) {
 
     auto segment = CreateSealedSegment(schema);
 
-    auto plan = std::make_unique<query::RetrievePlan>(*schema);
+    auto plan = std::make_unique<query::RetrievePlan>(schema);
     std::vector<proto::plan::GenericValue> values;
     {
         for (int i = 0; i < req_size; ++i) {
@@ -273,7 +273,7 @@ TEST(Float16, ExecWithPredicate) {
 
     auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
     auto plan =
-        CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+        CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     auto num_queries = 5;
     auto ph_group_raw =
         CreatePlaceholderGroup<milvus::Float16Vector>(num_queries, 16, 1024);
@@ -343,7 +343,7 @@ TEST(BFloat16, ExecWithoutPredicateFlat) {
         >)";
     auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
     auto plan =
-        CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+        CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     int64_t N = ROW_COUNT;
     auto dataset = DataGen(schema, N);
     auto segment = CreateGrowingSegment(schema, empty_index_meta);
@@ -436,7 +436,7 @@ TEST(BFloat16, RetrieveEmpty) {
 
     auto segment = CreateSealedSegment(schema);
 
-    auto plan = std::make_unique<query::RetrievePlan>(*schema);
+    auto plan = std::make_unique<query::RetrievePlan>(schema);
     std::vector<int64_t> values;
     std::vector<proto::plan::GenericValue> retrieve_ints;
     for (int i = 0; i < req_size; ++i) {
@@ -511,7 +511,7 @@ TEST(BFloat16, ExecWithPredicate) {
 
     auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
     auto plan =
-        CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+        CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     auto num_queries = 5;
     auto ph_group_raw =
         CreatePlaceholderGroup<milvus::BFloat16Vector>(num_queries, 16, 1024);

--- a/internal/core/unittest/test_group_by.cpp
+++ b/internal/core/unittest/test_group_by.cpp
@@ -107,7 +107,7 @@ TEST(GroupBY, SealedIndex) {
         proto::plan::PlanNode plan_node;
         auto ok =
             google::protobuf::TextFormat::ParseFromString(raw_plan, &plan_node);
-        auto plan = CreateSearchPlanFromPlanNode(*schema, plan_node);
+        auto plan = CreateSearchPlanFromPlanNode(schema, plan_node);
         auto num_queries = 1;
         auto seed = 1024;
         auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, seed);
@@ -160,7 +160,7 @@ TEST(GroupBY, SealedIndex) {
         proto::plan::PlanNode plan_node;
         auto ok =
             google::protobuf::TextFormat::ParseFromString(raw_plan, &plan_node);
-        auto plan = CreateSearchPlanFromPlanNode(*schema, plan_node);
+        auto plan = CreateSearchPlanFromPlanNode(schema, plan_node);
         auto num_queries = 1;
         auto seed = 1024;
         auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, seed);
@@ -210,7 +210,7 @@ TEST(GroupBY, SealedIndex) {
         proto::plan::PlanNode plan_node;
         auto ok =
             google::protobuf::TextFormat::ParseFromString(raw_plan, &plan_node);
-        auto plan = CreateSearchPlanFromPlanNode(*schema, plan_node);
+        auto plan = CreateSearchPlanFromPlanNode(schema, plan_node);
         auto num_queries = 1;
         auto seed = 1024;
         auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, seed);
@@ -261,7 +261,7 @@ TEST(GroupBY, SealedIndex) {
         proto::plan::PlanNode plan_node;
         auto ok =
             google::protobuf::TextFormat::ParseFromString(raw_plan, &plan_node);
-        auto plan = CreateSearchPlanFromPlanNode(*schema, plan_node);
+        auto plan = CreateSearchPlanFromPlanNode(schema, plan_node);
         auto num_queries = 1;
         auto seed = 1024;
         auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, seed);
@@ -311,7 +311,7 @@ TEST(GroupBY, SealedIndex) {
         proto::plan::PlanNode plan_node;
         auto ok =
             google::protobuf::TextFormat::ParseFromString(raw_plan, &plan_node);
-        auto plan = CreateSearchPlanFromPlanNode(*schema, plan_node);
+        auto plan = CreateSearchPlanFromPlanNode(schema, plan_node);
         auto num_queries = 1;
         auto seed = 1024;
         auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, seed);
@@ -361,7 +361,7 @@ TEST(GroupBY, SealedIndex) {
         proto::plan::PlanNode plan_node;
         auto ok =
             google::protobuf::TextFormat::ParseFromString(raw_plan, &plan_node);
-        auto plan = CreateSearchPlanFromPlanNode(*schema, plan_node);
+        auto plan = CreateSearchPlanFromPlanNode(schema, plan_node);
         auto num_queries = 1;
         auto seed = 1024;
         auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, seed);
@@ -437,7 +437,7 @@ TEST(GroupBY, SealedData) {
          >)";
         auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
         auto plan =
-            CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+            CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
         auto num_queries = 1;
         auto seed = 1024;
         auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, seed);
@@ -548,7 +548,7 @@ TEST(GroupBY, Reduce) {
          >)";
     auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
     auto plan =
-        CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+        CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, seed);
     auto ph_group =
         ParsePlaceholderGroup(plan.get(), ph_group_raw.SerializeAsString());
@@ -643,7 +643,7 @@ TEST(GroupBY, GrowingRawData) {
          >)";
     auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
     auto plan =
-        CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+        CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, seed);
     auto ph_group =
         ParsePlaceholderGroup(plan.get(), ph_group_raw.SerializeAsString());
@@ -743,7 +743,7 @@ TEST(GroupBY, GrowingIndex) {
          >)";
     auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
     auto plan =
-        CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+        CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, seed);
     auto ph_group =
         ParsePlaceholderGroup(plan.get(), ph_group_raw.SerializeAsString());

--- a/internal/core/unittest/test_growing_index.cpp
+++ b/internal/core/unittest/test_growing_index.cpp
@@ -304,7 +304,7 @@ TEST_P(GrowingIndexTest, Correctness) {
         }
 
         auto plan = milvus::query::CreateSearchPlanByExpr(
-            *schema, plan_str.data(), plan_str.size());
+            schema, plan_str.data(), plan_str.size());
         auto ph_group =
             ParsePlaceholderGroup(plan.get(), ph_group_raw.SerializeAsString());
 
@@ -320,7 +320,7 @@ TEST_P(GrowingIndexTest, Correctness) {
             continue;
         }
         auto range_plan = milvus::query::CreateSearchPlanByExpr(
-            *schema, range_plan_str.data(), range_plan_str.size());
+            schema, range_plan_str.data(), range_plan_str.size());
         auto range_ph_group = ParsePlaceholderGroup(
             range_plan.get(), ph_group_raw.SerializeAsString());
         auto range_sr =

--- a/internal/core/unittest/test_integer_overflow.cpp
+++ b/internal/core/unittest/test_integer_overflow.cpp
@@ -618,7 +618,7 @@ binary_arith_op_eval_range_expr: <
         raw_plan.replace(loc, 4, clause);
         auto plan_str = translate_text_plan_to_binary_plan(raw_plan.c_str());
         auto plan =
-            CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+            CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
         BitsetType final;
         // vectorsearch node => mvcc node => filter node
         // just test filter node

--- a/internal/core/unittest/test_iterative_filter.cpp
+++ b/internal/core/unittest/test_iterative_filter.cpp
@@ -117,7 +117,7 @@ TEST(IterativeFilter, SealedIndex) {
         proto::plan::PlanNode plan_node;
         auto ok =
             google::protobuf::TextFormat::ParseFromString(raw_plan, &plan_node);
-        auto plan = CreateSearchPlanFromPlanNode(*schema, plan_node);
+        auto plan = CreateSearchPlanFromPlanNode(schema, plan_node);
         auto num_queries = 1;
         auto seed = 1024;
         auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, seed);
@@ -153,7 +153,7 @@ TEST(IterativeFilter, SealedIndex) {
         proto::plan::PlanNode plan_node2;
         auto ok2 = google::protobuf::TextFormat::ParseFromString(raw_plan2,
                                                                  &plan_node2);
-        auto plan2 = CreateSearchPlanFromPlanNode(*schema, plan_node2);
+        auto plan2 = CreateSearchPlanFromPlanNode(schema, plan_node2);
         auto search_result2 =
             segment->Search(plan2.get(), ph_group.get(), 1L << 63);
         CheckFilterSearchResult(
@@ -183,7 +183,7 @@ TEST(IterativeFilter, SealedIndex) {
         proto::plan::PlanNode plan_node;
         auto ok =
             google::protobuf::TextFormat::ParseFromString(raw_plan, &plan_node);
-        auto plan = CreateSearchPlanFromPlanNode(*schema, plan_node);
+        auto plan = CreateSearchPlanFromPlanNode(schema, plan_node);
         auto num_queries = 1;
         auto seed = 1024;
         auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, seed);
@@ -212,7 +212,7 @@ TEST(IterativeFilter, SealedIndex) {
         proto::plan::PlanNode plan_node2;
         auto ok2 = google::protobuf::TextFormat::ParseFromString(raw_plan2,
                                                                  &plan_node2);
-        auto plan2 = CreateSearchPlanFromPlanNode(*schema, plan_node2);
+        auto plan2 = CreateSearchPlanFromPlanNode(schema, plan_node2);
         auto search_result2 =
             segment->Search(plan2.get(), ph_group.get(), 1L << 63);
         CheckFilterSearchResult(
@@ -233,7 +233,7 @@ TEST(IterativeFilter, SealedIndex) {
         proto::plan::PlanNode plan_node;
         auto ok =
             google::protobuf::TextFormat::ParseFromString(raw_plan, &plan_node);
-        auto plan = CreateSearchPlanFromPlanNode(*schema, plan_node);
+        auto plan = CreateSearchPlanFromPlanNode(schema, plan_node);
         auto num_queries = 1;
         auto seed = 1024;
         auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, seed);
@@ -253,7 +253,7 @@ TEST(IterativeFilter, SealedIndex) {
         proto::plan::PlanNode plan_node2;
         auto ok2 = google::protobuf::TextFormat::ParseFromString(raw_plan2,
                                                                  &plan_node2);
-        auto plan2 = CreateSearchPlanFromPlanNode(*schema, plan_node2);
+        auto plan2 = CreateSearchPlanFromPlanNode(schema, plan_node2);
         auto search_result2 =
             segment->Search(plan2.get(), ph_group.get(), 1L << 63);
         CheckFilterSearchResult(
@@ -315,7 +315,7 @@ TEST(IterativeFilter, SealedData) {
         proto::plan::PlanNode plan_node;
         auto ok =
             google::protobuf::TextFormat::ParseFromString(raw_plan, &plan_node);
-        auto plan = CreateSearchPlanFromPlanNode(*schema, plan_node);
+        auto plan = CreateSearchPlanFromPlanNode(schema, plan_node);
         auto num_queries = 1;
         auto seed = 1024;
         auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, seed);
@@ -351,7 +351,7 @@ TEST(IterativeFilter, SealedData) {
         proto::plan::PlanNode plan_node2;
         auto ok2 = google::protobuf::TextFormat::ParseFromString(raw_plan2,
                                                                  &plan_node2);
-        auto plan2 = CreateSearchPlanFromPlanNode(*schema, plan_node2);
+        auto plan2 = CreateSearchPlanFromPlanNode(schema, plan_node2);
         auto search_result2 =
             segment->Search(plan2.get(), ph_group.get(), 1L << 63);
         CheckFilterSearchResult(
@@ -422,7 +422,7 @@ TEST(IterativeFilter, GrowingRawData) {
         proto::plan::PlanNode plan_node;
         auto ok =
             google::protobuf::TextFormat::ParseFromString(raw_plan, &plan_node);
-        auto plan = CreateSearchPlanFromPlanNode(*schema, plan_node);
+        auto plan = CreateSearchPlanFromPlanNode(schema, plan_node);
         auto num_queries = 1;
         auto seed = 1024;
         auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, seed);
@@ -458,7 +458,7 @@ TEST(IterativeFilter, GrowingRawData) {
         proto::plan::PlanNode plan_node2;
         auto ok2 = google::protobuf::TextFormat::ParseFromString(raw_plan2,
                                                                  &plan_node2);
-        auto plan2 = CreateSearchPlanFromPlanNode(*schema, plan_node2);
+        auto plan2 = CreateSearchPlanFromPlanNode(schema, plan_node2);
         auto search_result2 =
             segment_growing_impl->Search(plan2.get(), ph_group.get(), 1L << 63);
         CheckFilterSearchResult(
@@ -542,7 +542,7 @@ TEST(IterativeFilter, GrowingIndex) {
         proto::plan::PlanNode plan_node;
         auto ok =
             google::protobuf::TextFormat::ParseFromString(raw_plan, &plan_node);
-        auto plan = CreateSearchPlanFromPlanNode(*schema, plan_node);
+        auto plan = CreateSearchPlanFromPlanNode(schema, plan_node);
         auto num_queries = 1;
         auto seed = 1024;
         auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, seed);
@@ -578,7 +578,7 @@ TEST(IterativeFilter, GrowingIndex) {
         proto::plan::PlanNode plan_node2;
         auto ok2 = google::protobuf::TextFormat::ParseFromString(raw_plan2,
                                                                  &plan_node2);
-        auto plan2 = CreateSearchPlanFromPlanNode(*schema, plan_node2);
+        auto plan2 = CreateSearchPlanFromPlanNode(schema, plan_node2);
         auto search_result2 =
             segment_growing_impl->Search(plan2.get(), ph_group.get(), 1L << 63);
         CheckFilterSearchResult(

--- a/internal/core/unittest/test_plan_proto.cpp
+++ b/internal/core/unittest/test_plan_proto.cpp
@@ -27,6 +27,6 @@ TEST(PlanProto, NotSetUnsupported) {
     schema->set_primary_field_id(i64_fid);
 
     proto::plan::Expr expr_pb;
-    ProtoParser parser(*schema);
+    ProtoParser parser(schema);
     ASSERT_ANY_THROW(parser.ParseExprs(expr_pb));
 }

--- a/internal/core/unittest/test_query.cpp
+++ b/internal/core/unittest/test_query.cpp
@@ -43,7 +43,7 @@ TEST(Query, ParsePlaceholderGroup) {
     schema->AddDebugField(
         "fakevec", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
     auto plan =
-        CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+        CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     int64_t num_queries = 100000;
     int dim = 16;
     auto raw_group = CreatePlaceholderGroup(num_queries, dim);
@@ -96,7 +96,7 @@ TEST(Query, ExecWithPredicateLoader) {
 
     auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
     auto plan =
-        CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+        CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     auto num_queries = 5;
     auto ph_group_raw = CreatePlaceholderGroup(num_queries, 16, 1024);
     auto ph_group =
@@ -178,7 +178,7 @@ TEST(Query, ExecWithPredicateSmallN) {
 
     auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
     auto plan =
-        CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+        CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     auto num_queries = 5;
     auto ph_group_raw = CreatePlaceholderGroup(num_queries, 7, 1024);
     auto ph_group =
@@ -237,7 +237,7 @@ TEST(Query, ExecWithPredicate) {
 
     auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
     auto plan =
-        CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+        CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     auto num_queries = 5;
     auto ph_group_raw = CreatePlaceholderGroup(num_queries, 16, 1024);
     auto ph_group =
@@ -317,7 +317,7 @@ TEST(Query, ExecTerm) {
 
     auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
     auto plan =
-        CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+        CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     auto num_queries = 3;
     auto ph_group_raw = CreatePlaceholderGroup(num_queries, 16, 1024);
     auto ph_group =
@@ -350,7 +350,7 @@ TEST(Query, ExecEmpty) {
     auto segment = CreateGrowingSegment(schema, empty_index_meta);
     auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
     auto plan =
-        CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+        CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     auto num_queries = 5;
     auto ph_group_raw = CreatePlaceholderGroup(num_queries, 16, 1024);
     auto ph_group =
@@ -388,7 +388,7 @@ TEST(Query, ExecWithoutPredicateFlat) {
         >)";
     auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
     auto plan =
-        CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+        CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     int64_t N = ROW_COUNT;
     auto dataset = DataGen(schema, N);
     auto segment = CreateGrowingSegment(schema, empty_index_meta);
@@ -429,7 +429,7 @@ TEST(Query, ExecWithoutPredicate) {
         >)";
     auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
     auto plan =
-        CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+        CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     int64_t N = ROW_COUNT;
     auto dataset = DataGen(schema, N);
     auto segment = CreateGrowingSegment(schema, empty_index_meta);
@@ -501,7 +501,7 @@ TEST(Query, InnerProduct) {
     auto segment = CreateGrowingSegment(schema, empty_index_meta);
     auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
     auto plan =
-        CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+        CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     segment->PreInsert(N);
     segment->Insert(0,
                     N,
@@ -688,7 +688,7 @@ TEST(Query, DISABLED_FillSegment) {
         >)";
     auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
     auto plan =
-        CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+        CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     auto ph_proto = CreatePlaceholderGroup(10, 16, 443);
     auto ph = ParsePlaceholderGroup(plan.get(), ph_proto.SerializeAsString());
     Timestamp ts = N * 2UL;
@@ -902,7 +902,7 @@ TEST(Query, ExecWithPredicateBinary) {
 
     auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
     auto plan =
-        CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+        CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     auto num_queries = 5;
     auto ph_group_raw = CreatePlaceholderGroupFromBlob<milvus::BinaryVector>(
         num_queries, 512, vec_ptr.data() + 1024 * 512 / 8);

--- a/internal/core/unittest/test_random_sample.cpp
+++ b/internal/core/unittest/test_random_sample.cpp
@@ -53,7 +53,7 @@ TEST_P(RandomSampleTest, SampleOnly) {
     auto dataset = DataGen(schema, N);
     auto segment = CreateSealedWithFieldDataLoaded(schema, dataset);
 
-    auto plan = std::make_unique<query::RetrievePlan>(*schema);
+    auto plan = std::make_unique<query::RetrievePlan>(schema);
     plan->plan_node_ = std::make_unique<query::RetrievePlanNode>();
     plan->plan_node_->plannodes_ =
         milvus::test::CreateRetrievePlanForRandomSample(sample_factor);
@@ -108,7 +108,7 @@ TEST_P(RandomSampleTest, SampleWithUnaryFiler) {
         OpType::Equal,
         val,
         std::vector<proto::plan::GenericValue>{});
-    auto plan = std::make_unique<query::RetrievePlan>(*schema);
+    auto plan = std::make_unique<query::RetrievePlan>(schema);
     plan->plan_node_ = std::make_unique<query::RetrievePlanNode>();
     plan->plan_node_->plannodes_ =
         milvus::test::CreateRetrievePlanForRandomSample(sample_factor, expr);
@@ -152,7 +152,7 @@ TEST(RandomSampleTest, SampleWithEmptyInput) {
         OpType::LessThan,
         val,
         std::vector<proto::plan::GenericValue>{});
-    auto plan = std::make_unique<query::RetrievePlan>(*schema);
+    auto plan = std::make_unique<query::RetrievePlan>(schema);
     plan->plan_node_ = std::make_unique<query::RetrievePlanNode>();
     plan->plan_node_->plannodes_ =
         milvus::test::CreateRetrievePlanForRandomSample(sample_factor, expr);

--- a/internal/core/unittest/test_regex_query.cpp
+++ b/internal/core/unittest/test_regex_query.cpp
@@ -115,7 +115,7 @@ TEST_F(GrowingSegmentRegexQueryTest, RegexQueryOnNonStringField) {
     auto expr = test::GenExpr();
     expr->set_allocated_unary_range_expr(unary_range_expr);
 
-    auto parser = ProtoParser(*schema);
+    auto parser = ProtoParser(schema);
     auto typed_expr = parser.ParseExprs(*expr);
     auto parsed =
         std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, typed_expr);
@@ -137,7 +137,7 @@ TEST_F(GrowingSegmentRegexQueryTest, RegexQueryOnStringField) {
     auto expr = test::GenExpr();
     expr->set_allocated_unary_range_expr(unary_range_expr);
 
-    auto parser = ProtoParser(*schema);
+    auto parser = ProtoParser(schema);
     auto typed_expr = parser.ParseExprs(*expr);
     auto parsed =
         std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, typed_expr);
@@ -163,7 +163,7 @@ TEST_F(GrowingSegmentRegexQueryTest, RegexQueryOnJsonField) {
     auto expr = test::GenExpr();
     expr->set_allocated_unary_range_expr(unary_range_expr);
 
-    auto parser = ProtoParser(*schema);
+    auto parser = ProtoParser(schema);
     auto typed_expr = parser.ParseExprs(*expr);
     auto parsed =
         std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, typed_expr);
@@ -322,7 +322,7 @@ TEST_F(SealedSegmentRegexQueryTest, BFRegexQueryOnNonStringField) {
     auto expr = test::GenExpr();
     expr->set_allocated_unary_range_expr(unary_range_expr);
 
-    auto parser = ProtoParser(*schema);
+    auto parser = ProtoParser(schema);
     auto typed_expr = parser.ParseExprs(*expr);
     auto parsed =
         std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, typed_expr);
@@ -343,7 +343,7 @@ TEST_F(SealedSegmentRegexQueryTest, BFRegexQueryOnStringField) {
     auto expr = test::GenExpr();
     expr->set_allocated_unary_range_expr(unary_range_expr);
 
-    auto parser = ProtoParser(*schema);
+    auto parser = ProtoParser(schema);
     auto typed_expr = parser.ParseExprs(*expr);
     auto parsed =
         std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, typed_expr);
@@ -369,7 +369,7 @@ TEST_F(SealedSegmentRegexQueryTest, BFRegexQueryOnJsonField) {
     auto expr = test::GenExpr();
     expr->set_allocated_unary_range_expr(unary_range_expr);
 
-    auto parser = ProtoParser(*schema);
+    auto parser = ProtoParser(schema);
     auto typed_expr = parser.ParseExprs(*expr);
     auto parsed =
         std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, typed_expr);
@@ -394,7 +394,7 @@ TEST_F(SealedSegmentRegexQueryTest, RegexQueryOnIndexedNonStringField) {
     auto expr = test::GenExpr();
     expr->set_allocated_unary_range_expr(unary_range_expr);
 
-    auto parser = ProtoParser(*schema);
+    auto parser = ProtoParser(schema);
     auto typed_expr = parser.ParseExprs(*expr);
     auto parsed =
         std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, typed_expr);
@@ -419,7 +419,7 @@ TEST_F(SealedSegmentRegexQueryTest, RegexQueryOnStlSortStringField) {
     auto expr = test::GenExpr();
     expr->set_allocated_unary_range_expr(unary_range_expr);
 
-    auto parser = ProtoParser(*schema);
+    auto parser = ProtoParser(schema);
     auto typed_expr = parser.ParseExprs(*expr);
     auto parsed =
         std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, typed_expr);
@@ -449,7 +449,7 @@ TEST_F(SealedSegmentRegexQueryTest, PrefixMatchOnInvertedIndexStringField) {
     auto expr = test::GenExpr();
     expr->set_allocated_unary_range_expr(unary_range_expr);
 
-    auto parser = ProtoParser(*schema);
+    auto parser = ProtoParser(schema);
     auto typed_expr = parser.ParseExprs(*expr);
     auto parsed =
         std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, typed_expr);
@@ -479,7 +479,7 @@ TEST_F(SealedSegmentRegexQueryTest, InnerMatchOnInvertedIndexStringField) {
     auto expr = test::GenExpr();
     expr->set_allocated_unary_range_expr(unary_range_expr);
 
-    auto parser = ProtoParser(*schema);
+    auto parser = ProtoParser(schema);
     auto typed_expr = parser.ParseExprs(*expr);
     auto parsed =
         std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, typed_expr);
@@ -508,7 +508,7 @@ TEST_F(SealedSegmentRegexQueryTest, RegexQueryOnInvertedIndexStringField) {
     auto expr = test::GenExpr();
     expr->set_allocated_unary_range_expr(unary_range_expr);
 
-    auto parser = ProtoParser(*schema);
+    auto parser = ProtoParser(schema);
     auto typed_expr = parser.ParseExprs(*expr);
     auto parsed =
         std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, typed_expr);
@@ -538,7 +538,7 @@ TEST_F(SealedSegmentRegexQueryTest, PostfixMatchOnInvertedIndexStringField) {
     auto expr = test::GenExpr();
     expr->set_allocated_unary_range_expr(unary_range_expr);
 
-    auto parser = ProtoParser(*schema);
+    auto parser = ProtoParser(schema);
     auto typed_expr = parser.ParseExprs(*expr);
     auto parsed =
         std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, typed_expr);
@@ -567,7 +567,7 @@ TEST_F(SealedSegmentRegexQueryTest, RegexQueryOnUnsupportedIndex) {
     auto expr = test::GenExpr();
     expr->set_allocated_unary_range_expr(unary_range_expr);
 
-    auto parser = ProtoParser(*schema);
+    auto parser = ProtoParser(schema);
     auto typed_expr = parser.ParseExprs(*expr);
     auto parsed =
         std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, typed_expr);

--- a/internal/core/unittest/test_retrieve.cpp
+++ b/internal/core/unittest/test_retrieve.cpp
@@ -64,7 +64,7 @@ TEST_P(RetrieveTest, AutoID) {
     auto segment = CreateSealedWithFieldDataLoaded(schema, dataset);
     auto i64_col = dataset.get_col<int64_t>(fid_64);
 
-    auto plan = std::make_unique<query::RetrievePlan>(*schema);
+    auto plan = std::make_unique<query::RetrievePlan>(schema);
     std::vector<proto::plan::GenericValue> values;
     for (int i = 0; i < req_size; ++i) {
         proto::plan::GenericValue val;
@@ -121,7 +121,7 @@ TEST_P(RetrieveTest, AutoID2) {
     auto segment = CreateSealedWithFieldDataLoaded(schema, dataset);
     auto i64_col = dataset.get_col<int64_t>(fid_64);
 
-    auto plan = std::make_unique<query::RetrievePlan>(*schema);
+    auto plan = std::make_unique<query::RetrievePlan>(schema);
     std::vector<proto::plan::GenericValue> values;
     {
         for (int i = 0; i < req_size; ++i) {
@@ -181,7 +181,7 @@ TEST_P(RetrieveTest, NotExist) {
     auto segment = CreateSealedWithFieldDataLoaded(schema, dataset);
     auto i64_col = dataset.get_col<int64_t>(fid_64);
 
-    auto plan = std::make_unique<query::RetrievePlan>(*schema);
+    auto plan = std::make_unique<query::RetrievePlan>(schema);
     std::vector<proto::plan::GenericValue> values;
     {
         for (int i = 0; i < req_size; ++i) {
@@ -242,7 +242,7 @@ TEST_P(RetrieveTest, Empty) {
 
     auto segment = CreateSealedSegment(schema);
 
-    auto plan = std::make_unique<query::RetrievePlan>(*schema);
+    auto plan = std::make_unique<query::RetrievePlan>(schema);
     std::vector<proto::plan::GenericValue> values;
     {
         for (int i = 0; i < req_size; ++i) {
@@ -289,7 +289,7 @@ TEST_P(RetrieveTest, Limit) {
     auto dataset = DataGen(schema, N, 42);
     auto segment = CreateSealedWithFieldDataLoaded(schema, dataset);
 
-    auto plan = std::make_unique<query::RetrievePlan>(*schema);
+    auto plan = std::make_unique<query::RetrievePlan>(schema);
     proto::plan::GenericValue unary_val;
     unary_val.set_int64_val(0);
     auto expr = std::make_shared<expr::UnaryRangeFilterExpr>(
@@ -336,7 +336,7 @@ TEST_P(RetrieveTest, FillEntry) {
     int64_t N = 101;
     auto dataset = DataGen(schema, N, 42);
     auto segment = CreateSealedWithFieldDataLoaded(schema, dataset);
-    auto plan = std::make_unique<query::RetrievePlan>(*schema);
+    auto plan = std::make_unique<query::RetrievePlan>(schema);
     proto::plan::GenericValue unary_val;
     unary_val.set_int64_val(0);
     auto expr = std::make_shared<expr::UnaryRangeFilterExpr>(
@@ -381,7 +381,7 @@ TEST_P(RetrieveTest, LargeTimestamp) {
     auto segment = CreateSealedWithFieldDataLoaded(schema, dataset);
     auto i64_col = dataset.get_col<int64_t>(fid_64);
 
-    auto plan = std::make_unique<query::RetrievePlan>(*schema);
+    auto plan = std::make_unique<query::RetrievePlan>(schema);
     std::vector<proto::plan::GenericValue> values;
     {
         for (int i = 0; i < req_size; ++i) {
@@ -450,7 +450,7 @@ TEST_P(RetrieveTest, Delete) {
     auto i64_col = dataset.get_col<int64_t>(fid_64);
     auto ts_col = dataset.get_col<int64_t>(fid_ts);
 
-    auto plan = std::make_unique<query::RetrievePlan>(*schema);
+    auto plan = std::make_unique<query::RetrievePlan>(schema);
     std::vector<int64_t> timestamps;
     for (int i = 0; i < req_size; ++i) {
         timestamps.emplace_back(ts_col[choose(i)]);

--- a/internal/core/unittest/test_sealed.cpp
+++ b/internal/core/unittest/test_sealed.cpp
@@ -81,7 +81,7 @@ TEST(Sealed, without_predicate) {
 
     auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
     auto plan =
-        CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+        CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     auto num_queries = 5;
     auto ph_group_raw =
         CreatePlaceholderGroupFromBlob(num_queries, 16, query_ptr);
@@ -182,7 +182,7 @@ TEST(Sealed, without_search_ef_less_than_limit) {
 
     auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
     auto plan =
-        CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+        CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     auto num_queries = 5;
     auto ph_group_raw =
         CreatePlaceholderGroupFromBlob(num_queries, 16, query_ptr);
@@ -286,7 +286,7 @@ TEST(Sealed, with_predicate) {
 
     auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
     auto plan =
-        CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+        CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     auto num_queries = 5;
     auto ph_group_raw =
         CreatePlaceholderGroupFromBlob(num_queries, 16, query_ptr);
@@ -394,7 +394,7 @@ TEST(Sealed, with_predicate_filter_all) {
     auto query_ptr = vec_col.data() + BIAS * dim;
     auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
     auto plan =
-        CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+        CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     auto num_queries = 5;
     auto ph_group_raw =
         CreatePlaceholderGroupFromBlob(num_queries, 16, query_ptr);
@@ -550,7 +550,7 @@ TEST(Sealed, LoadFieldData) {
     Timestamp timestamp = 1000000;
     auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
     auto plan =
-        CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+        CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     auto num_queries = 5;
     auto ph_group_raw = CreatePlaceholderGroup(num_queries, 16, 1024);
     auto ph_group =
@@ -714,7 +714,7 @@ TEST(Sealed, ClearData) {
     Timestamp timestamp = 1000000;
     auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
     auto plan =
-        CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+        CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     auto num_queries = 5;
     auto ph_group_raw = CreatePlaceholderGroup(num_queries, 16, 1024);
     auto ph_group =
@@ -819,7 +819,7 @@ TEST(Sealed, LoadFieldDataMmap) {
     Timestamp timestamp = 1000000;
     auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
     auto plan =
-        CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+        CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     auto num_queries = 5;
     auto ph_group_raw = CreatePlaceholderGroup(num_queries, 16, 1024);
     auto ph_group =
@@ -934,7 +934,7 @@ TEST(Sealed, LoadScalarIndex) {
     Timestamp timestamp = 1000000;
     auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
     auto plan =
-        CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+        CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     auto num_queries = 5;
     auto ph_group_raw = CreatePlaceholderGroup(num_queries, 16, 1024);
     auto ph_group =
@@ -1036,7 +1036,7 @@ TEST(Sealed, Delete) {
     Timestamp timestamp = 1000000;
     auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
     auto plan =
-        CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+        CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     auto num_queries = 5;
     auto ph_group_raw = CreatePlaceholderGroup(num_queries, 16, 1024);
     auto ph_group =
@@ -1118,7 +1118,7 @@ TEST(Sealed, OverlapDelete) {
     Timestamp timestamp = 1000000;
     auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
     auto plan =
-        CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+        CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     auto num_queries = 5;
     auto ph_group_raw = CreatePlaceholderGroup(num_queries, 16, 1024);
     auto ph_group =
@@ -1242,7 +1242,7 @@ TEST(Sealed, BF) {
     auto binary_plan =
         translate_text_plan_to_binary_plan(serialized_expr_plan.data());
     auto plan =
-        CreateSearchPlanByExpr(*schema, binary_plan.data(), binary_plan.size());
+        CreateSearchPlanByExpr(schema, binary_plan.data(), binary_plan.size());
 
     auto num_queries = 10;
     auto query = GenQueryVecs(num_queries, dim);
@@ -1305,7 +1305,7 @@ TEST(Sealed, BF_Overflow) {
     auto binary_plan =
         translate_text_plan_to_binary_plan(serialized_expr_plan.data());
     auto plan =
-        CreateSearchPlanByExpr(*schema, binary_plan.data(), binary_plan.size());
+        CreateSearchPlanByExpr(schema, binary_plan.data(), binary_plan.size());
 
     auto num_queries = 10;
     auto query = GenQueryVecs(num_queries, dim);
@@ -1493,7 +1493,7 @@ TEST(Sealed, LoadArrayFieldData) {
 
     auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
     auto plan =
-        CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+        CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     auto num_queries = 5;
     auto ph_group_raw = CreatePlaceholderGroup(num_queries, 16, 1024);
     auto ph_group =
@@ -1550,7 +1550,7 @@ TEST(Sealed, LoadArrayFieldDataWithMMap) {
 
     auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
     auto plan =
-        CreateSearchPlanByExpr(*schema, plan_str.data(), plan_str.size());
+        CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     auto num_queries = 5;
     auto ph_group_raw = CreatePlaceholderGroup(num_queries, 16, 1024);
     auto ph_group =

--- a/internal/core/unittest/test_string_expr.cpp
+++ b/internal/core/unittest/test_string_expr.cpp
@@ -281,7 +281,7 @@ TEST(StringExpr, Term) {
     auto seg_promote = dynamic_cast<SegmentGrowingImpl*>(seg.get());
     for (const auto& [_, term] : terms) {
         auto plan_proto = GenTermPlan(fvec_meta, str_meta, term);
-        auto plan = ProtoParser(*schema).CreatePlan(*plan_proto);
+        auto plan = ProtoParser(schema).CreatePlan(*plan_proto);
         BitsetType final;
         final = ExecuteQueryExpr(
             plan->plan_node_->plannodes_->sources()[0]->sources()[0],
@@ -373,7 +373,7 @@ TEST(StringExpr, TermNullable) {
     auto seg_promote = dynamic_cast<SegmentGrowingImpl*>(seg.get());
     for (const auto& [_, term] : terms) {
         auto plan_proto = GenTermPlan(fvec_meta, str_meta, term);
-        auto plan = ProtoParser(*schema).CreatePlan(*plan_proto);
+        auto plan = ProtoParser(schema).CreatePlan(*plan_proto);
         query::ExecPlanNodeVisitor visitor(*seg_promote, MAX_TIMESTAMP);
         BitsetType final;
         final = ExecuteQueryExpr(
@@ -511,7 +511,7 @@ TEST(StringExpr, Compare) {
     auto seg_promote = dynamic_cast<SegmentGrowingImpl*>(seg.get());
     for (const auto& [op, ref_func] : testcases) {
         auto plan_proto = gen_compare_plan(op);
-        auto plan = ProtoParser(*schema).CreatePlan(*plan_proto);
+        auto plan = ProtoParser(schema).CreatePlan(*plan_proto);
         query::ExecPlanNodeVisitor visitor(*seg_promote, MAX_TIMESTAMP);
         BitsetType final;
         final = ExecuteQueryExpr(
@@ -660,7 +660,7 @@ TEST(StringExpr, CompareNullable) {
     auto seg_promote = dynamic_cast<SegmentGrowingImpl*>(seg.get());
     for (const auto& [op, ref_func] : testcases) {
         auto plan_proto = gen_compare_plan(op);
-        auto plan = ProtoParser(*schema).CreatePlan(*plan_proto);
+        auto plan = ProtoParser(schema).CreatePlan(*plan_proto);
         query::ExecPlanNodeVisitor visitor(*seg_promote, MAX_TIMESTAMP);
         BitsetType final;
         final = ExecuteQueryExpr(
@@ -813,7 +813,7 @@ TEST(StringExpr, CompareNullable2) {
     auto seg_promote = dynamic_cast<SegmentGrowingImpl*>(seg.get());
     for (const auto& [op, ref_func] : testcases) {
         auto plan_proto = gen_compare_plan(op);
-        auto plan = ProtoParser(*schema).CreatePlan(*plan_proto);
+        auto plan = ProtoParser(schema).CreatePlan(*plan_proto);
         query::ExecPlanNodeVisitor visitor(*seg_promote, MAX_TIMESTAMP);
         BitsetType final;
         final = ExecuteQueryExpr(
@@ -937,7 +937,7 @@ TEST(StringExpr, UnaryRange) {
     auto seg_promote = dynamic_cast<SegmentGrowingImpl*>(seg.get());
     for (const auto& [op, value, ref_func] : testcases) {
         auto plan_proto = gen_unary_range_plan(op, value);
-        auto plan = ProtoParser(*schema).CreatePlan(*plan_proto);
+        auto plan = ProtoParser(schema).CreatePlan(*plan_proto);
         BitsetType final;
         final = ExecuteQueryExpr(
             plan->plan_node_->plannodes_->sources()[0]->sources()[0],
@@ -1065,7 +1065,7 @@ TEST(StringExpr, UnaryRangeNullable) {
     auto seg_promote = dynamic_cast<SegmentGrowingImpl*>(seg.get());
     for (const auto& [op, value, ref_func] : testcases) {
         auto plan_proto = gen_unary_range_plan(op, value);
-        auto plan = ProtoParser(*schema).CreatePlan(*plan_proto);
+        auto plan = ProtoParser(schema).CreatePlan(*plan_proto);
         BitsetType final;
         final = ExecuteQueryExpr(
             plan->plan_node_->plannodes_->sources()[0]->sources()[0],
@@ -1179,7 +1179,7 @@ TEST(StringExpr, NullExpr) {
     // is_null
     for (const auto op : ops) {
         auto plan_proto = gen_plan(op);
-        auto plan = ProtoParser(*schema).CreatePlan(*plan_proto);
+        auto plan = ProtoParser(schema).CreatePlan(*plan_proto);
         BitsetType final;
         final = ExecuteQueryExpr(
             plan->plan_node_->plannodes_->sources()[0]->sources()[0],
@@ -1310,7 +1310,7 @@ TEST(StringExpr, BinaryRange) {
          testcases) {
         auto plan_proto =
             gen_binary_range_plan(lb_inclusive, ub_inclusive, lb, ub);
-        auto plan = ProtoParser(*schema).CreatePlan(*plan_proto);
+        auto plan = ProtoParser(schema).CreatePlan(*plan_proto);
         BitsetType final;
         final = ExecuteQueryExpr(
             plan->plan_node_->plannodes_->sources()[0]->sources()[0],
@@ -1458,7 +1458,7 @@ TEST(StringExpr, BinaryRangeNullable) {
          testcases) {
         auto plan_proto =
             gen_binary_range_plan(lb_inclusive, ub_inclusive, lb, ub);
-        auto plan = ProtoParser(*schema).CreatePlan(*plan_proto);
+        auto plan = ProtoParser(schema).CreatePlan(*plan_proto);
         query::ExecPlanNodeVisitor visitor(*seg_promote, MAX_TIMESTAMP);
         BitsetType final;
         final = ExecuteQueryExpr(
@@ -1531,7 +1531,7 @@ TEST(AlwaysTrueStringPlan, SearchWithOutputFields) {
 
     auto plan_proto = GenAlwaysTruePlan(fvec_meta, str_meta);
     SetTargetEntry(plan_proto, {str_meta.get_id().get()});
-    auto plan = ProtoParser(*schema).CreatePlan(*plan_proto);
+    auto plan = ProtoParser(schema).CreatePlan(*plan_proto);
     auto num_queries = 5;
     auto topk = 10;
     auto ph_group_raw =
@@ -1607,7 +1607,7 @@ TEST(AlwaysTrueStringPlan, QueryWithOutputFields) {
     auto plan_proto = GenPlanNode();
     plan_proto->mutable_query()->set_allocated_predicates(expr_proto);
     SetTargetEntry(plan_proto, {str_meta.get_id().get()});
-    auto plan = ProtoParser(*schema).CreateRetrievePlan(*plan_proto);
+    auto plan = ProtoParser(schema).CreateRetrievePlan(*plan_proto);
 
     Timestamp time = MAX_TIMESTAMP;
 
@@ -1650,7 +1650,7 @@ TEST(AlwaysTrueStringPlan, QueryWithOutputFieldsNullable) {
     auto plan_proto = GenPlanNode();
     plan_proto->mutable_query()->set_allocated_predicates(expr_proto);
     SetTargetEntry(plan_proto, {str_meta.get_id().get()});
-    auto plan = ProtoParser(*schema).CreateRetrievePlan(*plan_proto);
+    auto plan = ProtoParser(schema).CreateRetrievePlan(*plan_proto);
 
     Timestamp time = MAX_TIMESTAMP;
 

--- a/internal/core/unittest/test_text_match.cpp
+++ b/internal/core/unittest/test_text_match.cpp
@@ -85,7 +85,7 @@ GetMatchExpr(SchemaPtr schema,
     auto expr = test::GenExpr();
     expr->set_allocated_unary_range_expr(unary_range_expr);
 
-    auto parser = ProtoParser(*schema);
+    auto parser = ProtoParser(schema);
     auto typed_expr = parser.ParseExprs(*expr);
     auto parsed =
         std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, typed_expr);


### PR DESCRIPTION
Related to #42640

The search/query plan holded a reference to schema, which could be destructed after schema change. This PR make plan hold a shared ptr to it fixing dangling reference problem under concurrent read & schema change.

This PR also remove field binlog check for loading index for old segment with old schema may have binlog lack.