### PR TITLE
fix: Remove cached null expr result

### DIFF
--- a/internal/core/src/exec/expression/NullExpr.cpp
+++ b/internal/core/src/exec/expression/NullExpr.cpp
@@ -118,10 +118,6 @@ PhyNullExpr::PreCheckNullable(OffsetVector* input) {
                          : batch_size_;
         precheck_pos_ += batch_size;
     }
-    if (cached_precheck_res_ != nullptr &&
-        cached_precheck_res_->size() == batch_size) {
-        return cached_precheck_res_;
-    }
 
     auto res_vec = std::make_shared<ColumnVector>(TargetBitmap(batch_size),
                                                   TargetBitmap(batch_size));
@@ -142,8 +138,7 @@ PhyNullExpr::PreCheckNullable(OffsetVector* input) {
                       "unsupported null expr type {}",
                       proto::plan::NullExpr_NullOp_Name(expr_->op_));
     }
-    cached_precheck_res_ = res_vec;
-    return cached_precheck_res_;
+    return res_vec;
 }
 
 }  //namespace exec

--- a/internal/core/src/exec/expression/NullExpr.h
+++ b/internal/core/src/exec/expression/NullExpr.h
@@ -77,7 +77,6 @@ class PhyNullExpr : public SegmentExpr {
 
  private:
     std::shared_ptr<const milvus::expr::NullExpr> expr_;
-    ColumnVectorPtr cached_precheck_res_{nullptr};
     int64_t precheck_pos_{0};
 };
 }  //namespace exec


### PR DESCRIPTION
pr: https://github.com/milvus-io/milvus/pull/42818
issue: #42698
cached result may be changed in caller so there is no need to cache it