### PR TITLE
fix: [AddField] Check field empty instead of existence

### DIFF
--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -1249,7 +1249,9 @@ SegmentGrowingImpl::FinishLoad() {
         if (field_id.get() < START_USER_FIELDID) {
             continue;
         }
-        if (!insert_record_.is_data_exist(field_id)) {
+        // append_data is called according to schema before
+        // so we must check data empty here
+        if (insert_record_.get_data_base(field_id)->empty()) {
             fill_empty_field(field_meta);
         }
     }
@@ -1258,7 +1260,12 @@ SegmentGrowingImpl::FinishLoad() {
 void
 SegmentGrowingImpl::fill_empty_field(const FieldMeta& field_meta) {
     auto field_id = field_meta.get_id();
-    insert_record_.append_field_meta(field_id, field_meta, size_per_chunk());
+    // append meta only needed when schema is old
+    // loading old segment with new schema will have meta appended
+    if (!insert_record_.is_data_exist(field_id)) {
+        insert_record_.append_field_meta(
+            field_id, field_meta, size_per_chunk());
+    }
 
     auto total_row_num = insert_record_.size();
 
@@ -1267,6 +1274,9 @@ SegmentGrowingImpl::fill_empty_field(const FieldMeta& field_meta) {
         0, total_row_num, data.get(), field_meta);
     insert_record_.get_valid_data(field_id)->set_data_raw(
         total_row_num, data.get(), field_meta);
+    LOG_INFO("Growing segment {} fill empty field {} done",
+             this->get_segment_id(),
+             field_meta.get_id().get());
 }
 
 }  // namespace milvus::segcore

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -1251,7 +1251,7 @@ SegmentGrowingImpl::FinishLoad() {
         }
         // append_data is called according to schema before
         // so we must check data empty here
-        if (insert_record_.get_data_base(field_id)->empty()) {
+        if (!IsVectorDataType(field_meta.get_data_type()) &&insert_record_.get_data_base(field_id)->empty()) {
             fill_empty_field(field_meta);
         }
     }


### PR DESCRIPTION
Related to #42773

Growing segment fills all known meta into `InsertRecord` data, which cause even the field is missing, the field data will still exists.

This PR update the logic while finish loading growing segment to check field empty or not instead of existence.