### PR TITLE
enhance: Print out-of-date schema ts when returning ErrSchemaMismatch

### DIFF
--- a/internal/proxy/task_insert.go
+++ b/internal/proxy/task_insert.go
@@ -149,7 +149,11 @@ func (it *insertTask) PreExecute(ctx context.Context) error {
 	if it.schemaTimestamp != 0 {
 		if it.schemaTimestamp != colInfo.updateTimestamp {
 			err := merr.WrapErrCollectionSchemaMisMatch(collectionName)
-			log.Ctx(ctx).Info("collection schema mismatch", zap.String("collectionName", collectionName), zap.Error(err))
+			log.Ctx(ctx).Info("collection schema mismatch",
+				zap.String("collectionName", collectionName),
+				zap.Uint64("requestSchemaTs", it.schemaTimestamp),
+				zap.Uint64("collectionSchemaTs", colInfo.updateTimestamp),
+				zap.Error(err))
 			return err
 		}
 	}

--- a/internal/proxy/task_upsert.go
+++ b/internal/proxy/task_upsert.go
@@ -340,7 +340,10 @@ func (it *upsertTask) PreExecute(ctx context.Context) error {
 	if it.schemaTimestamp != 0 {
 		if it.schemaTimestamp != colInfo.updateTimestamp {
 			err := merr.WrapErrCollectionSchemaMisMatch(collectionName)
-			log.Info("collection schema mismatch", zap.String("collectionName", collectionName), zap.Error(err))
+			log.Info("collection schema mismatch", zap.String("collectionName", collectionName),
+				zap.Uint64("requestSchemaTs", it.schemaTimestamp),
+				zap.Uint64("collectionSchemaTs", colInfo.updateTimestamp),
+				zap.Error(err))
 			return err
 		}
 	}


### PR DESCRIPTION
Related to #41858

This PR add log while debugging schema mismatch between pymilvus cache and proxy schema.