### PR TITLE
fix: [2.5] Reduce task slot for standalone to 1/4 of normal datanode

### DIFF
--- a/internal/indexnode/util.go
+++ b/internal/indexnode/util.go
@@ -63,7 +63,7 @@ func calculateNodeSlots() int64 {
 	}
 	totalSlot := max(slot, 1) * Params.IndexNodeCfg.WorkerSlotUnit.GetAsInt64() * Params.IndexNodeCfg.BuildParallel.GetAsInt64()
 	if paramtable.GetRole() == typeutil.StandaloneRole {
-		totalSlot = max(totalSlot/2, 1)
+		totalSlot = max(totalSlot/4, 1)
 	}
 	return totalSlot
 }

--- a/internal/indexnode/util.go
+++ b/internal/indexnode/util.go
@@ -63,7 +63,7 @@ func calculateNodeSlots() int64 {
 	}
 	totalSlot := max(slot, 1) * Params.IndexNodeCfg.WorkerSlotUnit.GetAsInt64() * Params.IndexNodeCfg.BuildParallel.GetAsInt64()
 	if paramtable.GetRole() == typeutil.StandaloneRole {
-		totalSlot = max(totalSlot/4, 1)
+		totalSlot = max(int64(float64(totalSlot)*paramtable.Get().IndexNodeCfg.StandaloneSlotRatio.GetAsFloat()), 1)
 	}
 	return totalSlot
 }

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -5207,7 +5207,8 @@ type indexNodeConfig struct {
 	BuildParallel       ParamItem `refreshable:"false"`
 	GracefulStopTimeout ParamItem `refreshable:"true"`
 
-	WorkerSlotUnit ParamItem `refreshable:"true"`
+	WorkerSlotUnit      ParamItem `refreshable:"true"`
+	StandaloneSlotRatio ParamItem `refreshable:"false"`
 }
 
 func (p *indexNodeConfig) init(base *BaseTable) {
@@ -5234,6 +5235,14 @@ func (p *indexNodeConfig) init(base *BaseTable) {
 		Doc:          "Indicates how many slots each worker occupies per 2c8g",
 	}
 	p.WorkerSlotUnit.Init(base.mgr)
+
+	p.StandaloneSlotRatio = ParamItem{
+		Key:          "indexNode.standaloneSlotFactor",
+		Version:      "2.5.14",
+		DefaultValue: "0.25",
+		Doc:          "Offline task slot ratio in standalone mode",
+	}
+	p.StandaloneSlotRatio.Init(base.mgr)
 }
 
 type streamingConfig struct {

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -624,6 +624,8 @@ func TestComponentParam(t *testing.T) {
 
 		params.Save("indexnode.gracefulStopTimeout", "100")
 		assert.Equal(t, 100*time.Second, Params.GracefulStopTimeout.GetAsDuration(time.Second))
+		assert.Equal(t, 16, Params.WorkerSlotUnit.GetAsInt())
+		assert.Equal(t, 0.25, Params.StandaloneSlotRatio.GetAsFloat())
 	})
 
 	t.Run("test streamingConfig", func(t *testing.T) {


### PR DESCRIPTION
issue: #42129 

master pr: #42808 