### PR TITLE
fix: Consider fields number when preallocating ids for import

### DIFF
--- a/internal/datacoord/import_util.go
+++ b/internal/datacoord/import_util.go
@@ -319,7 +319,10 @@ func AssembleImportRequest(task ImportTask, job ImportJob, meta *meta, alloc all
 	})
 
 	// Pre-allocate IDs for autoIDs and logIDs.
-	preAllocIDNum := (totalRows + 1) * paramtable.Get().DataCoordCfg.ImportPreAllocIDExpansionFactor.GetAsInt64()
+	fieldsNum := len(job.GetSchema().GetFields()) + 2 // userFields + tsField + rowIDField
+	binlogNum := fieldsNum + 2                        // binlogs + statslog + BM25Statslog
+	expansionFactor := paramtable.Get().DataCoordCfg.ImportPreAllocIDExpansionFactor.GetAsInt64()
+	preAllocIDNum := (totalRows + 1) * int64(binlogNum) * expansionFactor
 
 	idBegin, idEnd, err := alloc.AllocN(preAllocIDNum)
 	if err != nil {
@@ -328,6 +331,7 @@ func AssembleImportRequest(task ImportTask, job ImportJob, meta *meta, alloc all
 
 	log.Info("pre-allocate ids and ts for import task", WrapTaskLog(task,
 		zap.Int64("totalRows", totalRows),
+		zap.Int("fieldsNum", fieldsNum),
 		zap.Int64("idBegin", idBegin),
 		zap.Int64("idEnd", idEnd),
 		zap.Uint64("ts", ts))...,


### PR DESCRIPTION
In corner cases where there are many fields but only a small number of rows to import, the default preallocated IDs may be insufficient. To address this, consider the number of fields when preallocating IDs.

issue: https://github.com/milvus-io/milvus/issues/42518