### PR TITLE
fix: reuse consumer for backlog clear and use shared consumer

### DIFF
--- a/pkg/streaming/walimpls/impls/pulsar/opener.go
+++ b/pkg/streaming/walimpls/impls/pulsar/opener.go
@@ -56,11 +56,9 @@ func (o *openerImpl) Open(ctx context.Context, opt *walimpls.OpenOption) (walimp
 		notifier:           syncutil.NewAsyncTaskNotifier[struct{}](),
 		backlogClearHelper: backlogClearHelper,
 	}
-	if opt.Channel.AccessMode == types.AccessModeRW {
-		// because the producer of pulsar cannot be created if the topic is backlog exceeded,
-		// so we need to set the producer at background with backoff retry.
-		w.initProducerAtBackground()
-	}
+	// because the producer of pulsar cannot be created if the topic is backlog exceeded,
+	// so we need to set the producer at background with backoff retry.
+	w.initProducerAtBackground()
 	return w, nil
 }
 

--- a/pkg/streaming/walimpls/impls/pulsar/wal.go
+++ b/pkg/streaming/walimpls/impls/pulsar/wal.go
@@ -30,7 +30,8 @@ type walImpl struct {
 // initProducerAtBackground initializes the producer at background.
 func (w *walImpl) initProducerAtBackground() {
 	if w.Channel().AccessMode != types.AccessModeRW {
-		panic("producer should not be initialized on a wal that is not in read-write mode")
+		w.notifier.Finish(struct{}{})
+		return
 	}
 
 	defer w.notifier.Finish(struct{}{})


### PR DESCRIPTION
issue: #42820

- fix that ro pulsar cannot be closed when upgrading milvus.