### PR TITLE
enhance: add avx build tag to use sonic in gin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ PWD 	  := $(shell pwd)
 GOPATH	:= $(shell $(GO) env GOPATH)
 SHELL 	:= /bin/bash
 OBJPREFIX := "github.com/milvus-io/milvus/cmd/milvus"
-MILVUS_GO_BUILD_TAGS := "dynamic,sonic,with_jemalloc"
+MILVUS_GO_BUILD_TAGS := "dynamic,sonic,with_jemalloc,avx"
 
 INSTALL_PATH := $(PWD)/bin
 LIBRARY_PATH := $(PWD)/lib


### PR DESCRIPTION
This will make gin use sonic.ConfigStd to decode json data. There is about a 30% performance boost on my machine.