### PR TITLE
fix: [AddField] Use correct error code for `SchemaMismatch`

### DIFF
--- a/pkg/util/merr/errors.go
+++ b/pkg/util/merr/errors.go
@@ -18,8 +18,9 @@ package merr
 
 import (
 	"github.com/cockroachdb/errors"
-	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/samber/lo"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 )
 
 const (

--- a/pkg/util/merr/errors.go
+++ b/pkg/util/merr/errors.go
@@ -18,6 +18,7 @@ package merr
 
 import (
 	"github.com/cockroachdb/errors"
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/samber/lo"
 )
 
@@ -71,7 +72,7 @@ var (
 	ErrCollectionOnRecovering                  = newMilvusError("collection on recovering", 106, true)
 	ErrCollectionVectorClusteringKeyNotAllowed = newMilvusError("vector clustering key not allowed", 107, false)
 	ErrCollectionReplicateMode                 = newMilvusError("can't operate on the collection under standby mode", 108, false)
-	ErrCollectionSchemaMismatch                = newMilvusError("collection schema mismatch", 109, false)
+	ErrCollectionSchemaMismatch                = newMilvusError("collection schema mismatch", int32(commonpb.ErrorCode_SchemaMismatch), false)
 	// Partition related
 	ErrPartitionNotFound       = newMilvusError("partition not found", 200, false)
 	ErrPartitionNotLoaded      = newMilvusError("partition not loaded", 201, false)


### PR DESCRIPTION
Related to #41858

The error code returned for `SchemaMismatch` was 109, which was not matched with definition in common.proto. The correct value shall be 62 instead.