### PR TITLE
fix: Revert error code change

### DIFF
--- a/pkg/util/merr/errors.go
+++ b/pkg/util/merr/errors.go
@@ -19,8 +19,6 @@ package merr
 import (
 	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
-
-	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 )
 
 const (
@@ -73,7 +71,7 @@ var (
 	ErrCollectionOnRecovering                  = newMilvusError("collection on recovering", 106, true)
 	ErrCollectionVectorClusteringKeyNotAllowed = newMilvusError("vector clustering key not allowed", 107, false)
 	ErrCollectionReplicateMode                 = newMilvusError("can't operate on the collection under standby mode", 108, false)
-	ErrCollectionSchemaMismatch                = newMilvusError("collection schema mismatch", int32(commonpb.ErrorCode_SchemaMismatch), false)
+	ErrCollectionSchemaMismatch                = newMilvusError("collection schema mismatch", 109, false)
 	// Partition related
 	ErrPartitionNotFound       = newMilvusError("partition not found", 200, false)
 	ErrPartitionNotLoaded      = newMilvusError("partition not loaded", 201, false)


### PR DESCRIPTION
Previous pr: #42839 changed the `SchemaMismatch` code, but commonpb Errorcode is translated by `oldCode`