### PR TITLE
fix: revert remote jsonstats path

### DIFF
--- a/internal/core/src/storage/DiskFileManagerImpl.cpp
+++ b/internal/core/src/storage/DiskFileManagerImpl.cpp
@@ -794,12 +794,13 @@ DiskFileManagerImpl::GetLocalTempJsonKeyIndexPrefix() {
 
 std::string
 DiskFileManagerImpl::GetRemoteJsonKeyLogPrefix() {
-    return GenJsonKeyIndexPathPrefix(rcm_,
-                                     index_meta_.build_id,
-                                     index_meta_.index_version,
-                                     field_meta_.segment_id,
-                                     field_meta_.field_id,
-                                     false);
+    return GenRemoteJsonKeyIndexPathPrefix(rcm_,
+                                           index_meta_.build_id,
+                                           index_meta_.index_version,
+                                           field_meta_.collection_id,
+                                           field_meta_.partition_id,
+                                           field_meta_.segment_id,
+                                           field_meta_.field_id);
 }
 
 std::string

--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -628,6 +628,36 @@ GenJsonKeyIndexPathPrefix(ChunkManagerPtr cm,
 }
 
 std::string
+GenJsonKeyIndexPathIdentifier(int64_t build_id,
+                              int64_t index_version,
+                              int64_t collection_id,
+                              int64_t partition_id,
+                              int64_t segment_id,
+                              int64_t field_id) {
+    return std::to_string(build_id) + "/" + std::to_string(index_version) +
+           "/" + std::to_string(collection_id) + "/" +
+           std::to_string(partition_id) + "/" + std::to_string(segment_id) +
+           "/" + std::to_string(field_id) + "/";
+}
+
+std::string
+GenRemoteJsonKeyIndexPathPrefix(ChunkManagerPtr cm,
+                                int64_t build_id,
+                                int64_t index_version,
+                                int64_t collection_id,
+                                int64_t partition_id,
+                                int64_t segment_id,
+                                int64_t field_id) {
+    return cm->GetRootPath() + "/" + std::string(JSON_KEY_INDEX_LOG_ROOT_PATH) +
+           "/" +
+           GenJsonKeyIndexPathIdentifier(build_id,
+                                         index_version,
+                                         collection_id,
+                                         partition_id,
+                                         segment_id,
+                                         field_id);
+}
+std::string
 GenFieldRawDataPathPrefix(ChunkManagerPtr cm,
                           int64_t segment_id,
                           int64_t field_id) {

--- a/internal/core/src/storage/Util.h
+++ b/internal/core/src/storage/Util.h
@@ -124,6 +124,14 @@ GenJsonKeyIndexPathPrefix(ChunkManagerPtr cm,
                           bool is_temp);
 
 std::string
+GenRemoteJsonKeyIndexPathPrefix(ChunkManagerPtr cm,
+                                int64_t build_id,
+                                int64_t index_version,
+                                int64_t collection_id,
+                                int64_t partition_id,
+                                int64_t segment_id,
+                                int64_t field_id);
+std::string
 GenFieldRawDataPathPrefix(ChunkManagerPtr cm,
                           int64_t segment_id,
                           int64_t field_id);


### PR DESCRIPTION
fix: revert remote jsonstats path
relate-pr:https://github.com/milvus-io/milvus/pull/42676
issue:https://github.com/milvus-io/milvus/issues/42872