### PR TITLE
enhance: print as storage size unit MB with 2 digits only, so the log is easier to read

### DIFF
--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -56,6 +56,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/util/contextutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/hardware"
+	"github.com/milvus-io/milvus/pkg/v2/util/logutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/metric"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
@@ -497,15 +498,12 @@ func (loader *segmentLoader) requestResource(ctx context.Context, infos ...*quer
 	result.Resource.MemorySize += mu
 	result.Resource.DiskSize += du
 
-	toMB := func(mem uint64) float64 {
-		return float64(mem) / 1024 / 1024
-	}
 	loader.committedResource.Add(result.Resource)
 	log.Info("request resource for loading segments (unit in MiB)",
-		zap.Float64("memory", toMB(result.Resource.MemorySize)),
-		zap.Float64("committedMemory", toMB(loader.committedResource.MemorySize)),
-		zap.Float64("disk", toMB(result.Resource.DiskSize)),
-		zap.Float64("committedDisk", toMB(loader.committedResource.DiskSize)),
+		zap.Float64("memory", logutil.ToMB(float64(result.Resource.MemorySize))),
+		zap.Float64("committedMemory", logutil.ToMB(float64(loader.committedResource.MemorySize))),
+		zap.Float64("disk", logutil.ToMB(float64(result.Resource.DiskSize))),
+		zap.Float64("committedDisk", logutil.ToMB(float64(loader.committedResource.DiskSize))),
 	)
 
 	return result, nil
@@ -1405,10 +1403,6 @@ func (loader *segmentLoader) checkSegmentSize(ctx context.Context, segmentLoadIn
 		zap.Int64("collectionID", segmentLoadInfos[0].GetCollectionID()),
 	)
 
-	toMB := func(mem uint64) float64 {
-		return float64(mem) / 1024 / 1024
-	}
-
 	memUsage = memUsage + loader.committedResource.MemorySize
 	if memUsage == 0 || totalMem == 0 {
 		return 0, 0, errors.New("get memory failed when checkSegmentSize")
@@ -1442,8 +1436,8 @@ func (loader *segmentLoader) checkSegmentSize(ctx context.Context, segmentLoadIn
 
 		log.Debug("segment resource for loading",
 			zap.Int64("segmentID", loadInfo.GetSegmentID()),
-			zap.Float64("memoryUsage(MB)", toMB(usage.MemorySize)),
-			zap.Float64("diskUsage(MB)", toMB(usage.DiskSize)),
+			zap.Float64("memoryUsage(MB)", logutil.ToMB(float64(usage.MemorySize))),
+			zap.Float64("diskUsage(MB)", logutil.ToMB(float64(usage.DiskSize))),
 			zap.Float64("memoryLoadFactor", factor.memoryUsageFactor),
 		)
 		mmapFieldCount += usage.MmapFieldCount
@@ -1456,31 +1450,31 @@ func (loader *segmentLoader) checkSegmentSize(ctx context.Context, segmentLoadIn
 	}
 
 	log.Info("predict memory and disk usage while loading (in MiB)",
-		zap.Float64("maxSegmentSize(MB)", toMB(maxSegmentSize)),
-		zap.Float64("committedMemSize(MB)", toMB(loader.committedResource.MemorySize)),
-		zap.Float64("memLimit(MB)", toMB(totalMem)),
-		zap.Float64("memUsage(MB)", toMB(memUsage)),
-		zap.Float64("committedDiskSize(MB)", toMB(loader.committedResource.DiskSize)),
-		zap.Float64("diskUsage(MB)", toMB(diskUsage)),
-		zap.Float64("predictMemUsage(MB)", toMB(predictMemUsage)),
-		zap.Float64("predictDiskUsage(MB)", toMB(predictDiskUsage)),
+		zap.Float64("maxSegmentSize(MB)", logutil.ToMB(float64(maxSegmentSize))),
+		zap.Float64("committedMemSize(MB)", logutil.ToMB(float64(loader.committedResource.MemorySize))),
+		zap.Float64("memLimit(MB)", logutil.ToMB(float64(totalMem))),
+		zap.Float64("memUsage(MB)", logutil.ToMB(float64(memUsage))),
+		zap.Float64("committedDiskSize(MB)", logutil.ToMB(float64(loader.committedResource.DiskSize))),
+		zap.Float64("diskUsage(MB)", logutil.ToMB(float64(diskUsage))),
+		zap.Float64("predictMemUsage(MB)", logutil.ToMB(float64(predictMemUsage))),
+		zap.Float64("predictDiskUsage(MB)", logutil.ToMB(float64(predictDiskUsage))),
 		zap.Int("mmapFieldCount", mmapFieldCount),
 	)
 
 	if predictMemUsage > uint64(float64(totalMem)*paramtable.Get().QueryNodeCfg.OverloadedMemoryThresholdPercentage.GetAsFloat()) {
 		return 0, 0, fmt.Errorf("load segment failed, OOM if load, maxSegmentSize = %v MB,  memUsage = %v MB, predictMemUsage = %v MB, totalMem = %v MB thresholdFactor = %f",
-			toMB(maxSegmentSize),
-			toMB(memUsage),
-			toMB(predictMemUsage),
-			toMB(totalMem),
+			logutil.ToMB(float64(maxSegmentSize)),
+			logutil.ToMB(float64(memUsage)),
+			logutil.ToMB(float64(predictMemUsage)),
+			logutil.ToMB(float64(totalMem)),
 			paramtable.Get().QueryNodeCfg.OverloadedMemoryThresholdPercentage.GetAsFloat())
 	}
 
 	if predictDiskUsage > uint64(float64(paramtable.Get().QueryNodeCfg.DiskCapacityLimit.GetAsInt64())*paramtable.Get().QueryNodeCfg.MaxDiskUsagePercentage.GetAsFloat()) {
 		return 0, 0, merr.WrapErrServiceDiskLimitExceeded(float32(predictDiskUsage), float32(paramtable.Get().QueryNodeCfg.DiskCapacityLimit.GetAsInt64()), fmt.Sprintf("load segment failed, disk space is not enough, diskUsage = %v MB, predictDiskUsage = %v MB, totalDisk = %v MB, thresholdFactor = %f",
-			toMB(diskUsage),
-			toMB(predictDiskUsage),
-			toMB(uint64(paramtable.Get().QueryNodeCfg.DiskCapacityLimit.GetAsInt64())),
+			logutil.ToMB(float64(diskUsage)),
+			logutil.ToMB(float64(predictDiskUsage)),
+			logutil.ToMB(float64(uint64(paramtable.Get().QueryNodeCfg.DiskCapacityLimit.GetAsInt64()))),
 			paramtable.Get().QueryNodeCfg.MaxDiskUsagePercentage.GetAsFloat()))
 	}
 

--- a/pkg/util/gc/gc_tuner.go
+++ b/pkg/util/gc/gc_tuner.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/util/hardware"
+	"github.com/milvus-io/milvus/pkg/v2/util/logutil"
 )
 
 var (
@@ -82,25 +83,21 @@ func optimizeGOGC() {
 
 	action(newGoGC)
 
-	toMB := func(mem uint64) uint64 {
-		return mem / 1024 / 1024
-	}
-
 	// currently we assume 20 ms as long gc pause
 	if (m.PauseNs[(m.NumGC+255)%256] / uint64(time.Millisecond)) < 20 {
 		log.Ctx(context.TODO()).Debug("GC Tune done", zap.Uint32("previous GOGC", previousGOGC),
-			zap.Uint64("heapuse ", toMB(heapuse)),
-			zap.Uint64("total memory", toMB(totaluse)),
-			zap.Uint64("next GC", toMB(m.NextGC)),
+			zap.Uint64("heapuse ", logutil.ToMB(heapuse)),
+			zap.Uint64("total memory", logutil.ToMB(totaluse)),
+			zap.Uint64("next GC", logutil.ToMB(m.NextGC)),
 			zap.Uint32("new GOGC", newGoGC),
 			zap.Duration("gc-pause", time.Duration(m.PauseNs[(m.NumGC+255)%256])),
 			zap.Uint64("gc-pause-end", m.PauseEnd[(m.NumGC+255)%256]),
 		)
 	} else {
 		log.Ctx(context.TODO()).Warn("GC Tune done, and the gc is slow", zap.Uint32("previous GOGC", previousGOGC),
-			zap.Uint64("heapuse ", toMB(heapuse)),
-			zap.Uint64("total memory", toMB(totaluse)),
-			zap.Uint64("next GC", toMB(m.NextGC)),
+			zap.Uint64("heapuse ", logutil.ToMB(heapuse)),
+			zap.Uint64("total memory", logutil.ToMB(totaluse)),
+			zap.Uint64("next GC", logutil.ToMB(m.NextGC)),
 			zap.Uint32("new GOGC", newGoGC),
 			zap.Duration("gc-pause", time.Duration(m.PauseNs[(m.NumGC+255)%256])),
 			zap.Uint64("gc-pause-end", m.PauseEnd[(m.NumGC+255)%256]),

--- a/pkg/util/logutil/logutil.go
+++ b/pkg/util/logutil/logutil.go
@@ -18,10 +18,12 @@ package logutil
 
 import (
 	"context"
+	"math"
 	"sync"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"golang.org/x/exp/constraints"
 	"google.golang.org/grpc/grpclog"
 
 	"github.com/milvus-io/milvus/pkg/v2/log"
@@ -171,4 +173,9 @@ func Logger(ctx context.Context) *zap.Logger {
 
 func WithModule(ctx context.Context, module string) context.Context {
 	return log.WithModule(ctx, module)
+}
+
+// keeps only 2 decimal places
+func ToMB[T constraints.Integer | constraints.Float](mem T) T {
+	return T(math.Round(float64(mem)/1024/1024*100) / 100)
 }

--- a/pkg/util/merr/utils.go
+++ b/pkg/util/merr/utils.go
@@ -27,6 +27,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/milvus-io/milvus/pkg/v2/log"
+	"github.com/milvus-io/milvus/pkg/v2/util/logutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
 
@@ -354,12 +355,9 @@ func WrapErrServiceUnavailable(reason string, msg ...string) error {
 }
 
 func WrapErrServiceMemoryLimitExceeded(predict, limit float32, msg ...string) error {
-	toMB := func(mem float32) float32 {
-		return mem / 1024 / 1024
-	}
 	err := wrapFields(ErrServiceMemoryLimitExceeded,
-		value("predict(MB)", toMB(predict)),
-		value("limit(MB)", toMB(limit)),
+		value("predict(MB)", logutil.ToMB(float64(predict))),
+		value("limit(MB)", logutil.ToMB(float64(limit))),
 	)
 	if len(msg) > 0 {
 		err = errors.Wrap(err, strings.Join(msg, "->"))
@@ -397,12 +395,9 @@ func WrapErrServiceCrossClusterRouting(expectedCluster, actualCluster string, ms
 }
 
 func WrapErrServiceDiskLimitExceeded(predict, limit float32, msg ...string) error {
-	toMB := func(mem float32) float32 {
-		return mem / 1024 / 1024
-	}
 	err := wrapFields(ErrServiceDiskLimitExceeded,
-		value("predict(MB)", toMB(predict)),
-		value("limit(MB)", toMB(limit)),
+		value("predict(MB)", logutil.ToMB(float64(predict))),
+		value("limit(MB)", logutil.ToMB(float64(limit))),
 	)
 	if len(msg) > 0 {
 		err = errors.Wrap(err, strings.Join(msg, "->"))


### PR DESCRIPTION
issue: #41435