### PR TITLE
test: fix unstable balance integration test

### DIFF
--- a/internal/querycoordv2/meta/replica.go
+++ b/internal/querycoordv2/meta/replica.go
@@ -1,9 +1,11 @@
 package meta
 
 import (
+	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
@@ -418,6 +420,7 @@ func (replica *mutableReplica) tryBalanceNodeForChannel() {
 					}
 				}
 				replica.replicaPB.ChannelNodeInfos[channelName].RwNodes = currentNodes
+				log.Info("assign exclusive node to channel", zap.String("channelName", channelName), zap.Int64s("nodes", currentNodes))
 			}
 		}
 	}

--- a/tests/integration/balance/balance_test.go
+++ b/tests/integration/balance/balance_test.go
@@ -56,6 +56,9 @@ func (s *BalanceTestSuit) SetupSuite() {
 	// disable compaction
 	paramtable.Get().Save(paramtable.Get().DataCoordCfg.EnableCompaction.Key, "false")
 
+	// speed up assign node to replica
+	paramtable.Get().Save(paramtable.Get().QueryCoordCfg.CheckNodeInReplicaInterval.Key, "5")
+
 	s.Require().NoError(s.SetupEmbedEtcd())
 }
 


### PR DESCRIPTION
cause the test case wait for 60 seconds until all segment has been balanced, but the replica_manager will assign node to delegator for every 60s, which could fail the balance test, because querynode hasn't been assign to replica.