### PR TITLE
fix: [hotfix]Use task timestamp to calculating ttl timestamp

### DIFF
--- a/internal/proxy/task_query.go
+++ b/internal/proxy/task_query.go
@@ -482,9 +482,13 @@ func (t *queryTask) PreExecute(ctx context.Context) error {
 		t.GuaranteeTimestamp = t.request.GetGuaranteeTimestamp()
 	}
 	if collectionInfo.collectionTTL != 0 {
-		physicalTime, _ := tsoutil.ParseTS(guaranteeTs)
+		physicalTime := tsoutil.PhysicalTime(t.GetBase().GetTimestamp())
 		expireTime := physicalTime.Add(-time.Duration(collectionInfo.collectionTTL))
 		t.CollectionTtlTimestamps = tsoutil.ComposeTSByTime(expireTime, 0)
+		// preventing overflow, abort ttl timestamp
+		if t.CollectionTtlTimestamps > t.GetBase().GetTimestamp() {
+			t.CollectionTtlTimestamps = 0
+		}
 	}
 	deadline, ok := t.TraceCtx().Deadline()
 	if ok {


### PR DESCRIPTION
Cherry-pick from master
pr: #42920
Related to #42918

Previously the `CollectionTtlTimestamp` could be overflowed when the guarantee_ts==1, which means using `Eventually` consistency level.

This patch use task timestamp, allocated by scheduler, to generate ttl timestamp ignore the potential very small timestamp being used.

Also add overflow check for ttl timestamp calculated.