### PR TITLE
fix: [AddField] Respect growing mmap setting adding empty field

### DIFF
--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -1275,10 +1275,11 @@ SegmentGrowingImpl::fill_empty_field(const FieldMeta& field_meta) {
     auto total_row_num = insert_record_.size();
 
     auto data = bulk_subscript_not_exist_field(field_meta, total_row_num);
-    insert_record_.get_data_base(field_id)->set_data_raw(
-        0, total_row_num, data.get(), field_meta);
     insert_record_.get_valid_data(field_id)->set_data_raw(
         total_row_num, data.get(), field_meta);
+    insert_record_.get_data_base(field_id)->set_data_raw(
+        0, total_row_num, data.get(), field_meta);
+
     LOG_INFO("Growing segment {} fill empty field {} done",
              this->get_segment_id(),
              field_meta.get_id().get());

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -1269,7 +1269,7 @@ SegmentGrowingImpl::fill_empty_field(const FieldMeta& field_meta) {
     // loading old segment with new schema will have meta appended
     if (!insert_record_.is_data_exist(field_id)) {
         insert_record_.append_field_meta(
-            field_id, field_meta, size_per_chunk());
+            field_id, field_meta, size_per_chunk(), mmap_descriptor_);
     }
 
     auto total_row_num = insert_record_.size();


### PR DESCRIPTION
Related to #42856

Data under mmapped growing segment shall be treated respecting growingMmap setting. Otherwise, varchar datatype could be treated with logic error.