### PR TITLE
fix: Add missing keylocks in ReleasePartition operation

### DIFF
--- a/internal/querycoordv2/observers/target_observer.go
+++ b/internal/querycoordv2/observers/target_observer.go
@@ -225,7 +225,9 @@ func (ob *TargetObserver) schedule(ctx context.Context) {
 				ob.keylocks.Unlock(req.CollectionID)
 				req.Notifier <- nil
 			case ReleasePartition:
+				ob.keylocks.Lock(req.CollectionID)
 				ob.targetMgr.RemovePartitionFromNextTarget(ctx, req.CollectionID, req.PartitionIDs...)
+				ob.keylocks.Unlock(req.CollectionID)
 				req.Notifier <- nil
 			}
 			log.Info("manually trigger update target done",


### PR DESCRIPTION
issue: #42098
Fix concurrent access issue by adding proper locking around ReleasePartition operation to prevent race conditions when releasing partitions on the same collection.