### PR TITLE
feat: support dropping index without releasing collection

### DIFF
--- a/internal/core/src/common/LoadInfo.h
+++ b/internal/core/src/common/LoadInfo.h
@@ -39,6 +39,8 @@ struct LoadFieldDataInfo {
     int64_t storage_version = 0;
     milvus::proto::common::LoadPriority load_priority =
         milvus::proto::common::LoadPriority::HIGH;
+    CacheWarmupPolicy warmup_policy =
+        CacheWarmupPolicy::CacheWarmupPolicy_Disable;
 };
 
 struct LoadDeletedRecordInfo {

--- a/internal/core/src/exec/expression/ColumnExpr.cpp
+++ b/internal/core/src/exec/expression/ColumnExpr.cpp
@@ -106,7 +106,8 @@ PhyColumnExpr::DoEval(OffsetVector* input) {
                 expr_->GetColumn().data_type_,
                 expr_->GetColumn().field_id_,
                 chunk_id,
-                data_barrier);
+                data_barrier,
+                pinned_index_);
             auto chunk_data_by_offset = chunk_data(chunk_offset);
             if (!chunk_data_by_offset.has_value()) {
                 valid_res[processed_rows] = false;
@@ -131,12 +132,12 @@ PhyColumnExpr::DoEval(OffsetVector* input) {
         T* res_value = res_vec->RawAsValues<T>();
         TargetBitmapView valid_res(res_vec->GetValidRawData(), real_batch_size);
         valid_res.set();
-        auto chunk_data = segment_chunk_reader_.GetChunkDataAccessor(
+        auto chunk_data = segment_chunk_reader_.GetMultipleChunkDataAccessor(
             expr_->GetColumn().data_type_,
             expr_->GetColumn().field_id_,
-            is_indexed_,
             current_chunk_id_,
-            current_chunk_pos_);
+            current_chunk_pos_,
+            pinned_index_);
         for (int i = 0; i < real_batch_size; ++i) {
             auto data = chunk_data();
             if (!data.has_value()) {
@@ -173,7 +174,8 @@ PhyColumnExpr::DoEval(OffsetVector* input) {
                 expr_->GetColumn().data_type_,
                 expr_->GetColumn().field_id_,
                 chunk_id,
-                data_barrier);
+                data_barrier,
+                pinned_index_);
 
             for (int i = chunk_id == current_chunk_id_ ? current_chunk_pos_ : 0;
                  i < chunk_size;

--- a/internal/core/src/exec/expression/ExistsExpr.cpp
+++ b/internal/core/src/exec/expression/ExistsExpr.cpp
@@ -56,38 +56,41 @@ PhyExistsFilterExpr::EvalJsonExistsForIndex() {
     if (cached_index_chunk_id_ != 0) {
         cached_index_chunk_id_ = 0;
         auto pointer = milvus::Json::pointer(expr_->column_.nested_path_);
-        auto pw = segment_->GetJsonIndex(expr_->column_.field_id_, pointer);
-        auto* index = pw.get();
+        auto* index = pinned_index_[cached_index_chunk_id_].get();
         AssertInfo(index != nullptr,
                    "Cannot find json index with path: " + pointer);
         switch (index->GetCastType().data_type()) {
             case JsonCastType::DataType::DOUBLE: {
                 auto* json_index =
-                    dynamic_cast<index::JsonInvertedIndex<double>*>(index);
+                    const_cast<index::JsonInvertedIndex<double>*>(
+                        dynamic_cast<const index::JsonInvertedIndex<double>*>(
+                            index));
                 cached_index_chunk_res_ = std::make_shared<TargetBitmap>(
                     std::move(json_index->Exists()));
                 break;
             }
 
             case JsonCastType::DataType::VARCHAR: {
-                auto* json_index =
-                    dynamic_cast<index::JsonInvertedIndex<std::string>*>(index);
+                auto* json_index = const_cast<
+                    index::JsonInvertedIndex<std::string>*>(
+                    dynamic_cast<const index::JsonInvertedIndex<std::string>*>(
+                        index));
                 cached_index_chunk_res_ = std::make_shared<TargetBitmap>(
                     std::move(json_index->Exists()));
                 break;
             }
 
             case JsonCastType::DataType::BOOL: {
-                auto* json_index =
-                    dynamic_cast<index::JsonInvertedIndex<bool>*>(index);
+                auto* json_index = const_cast<index::JsonInvertedIndex<bool>*>(
+                    dynamic_cast<const index::JsonInvertedIndex<bool>*>(index));
                 cached_index_chunk_res_ = std::make_shared<TargetBitmap>(
                     std::move(json_index->Exists()));
                 break;
             }
 
             case JsonCastType::DataType::JSON: {
-                auto* json_flat_index =
-                    dynamic_cast<index::JsonFlatIndex*>(index);
+                auto* json_flat_index = const_cast<index::JsonFlatIndex*>(
+                    dynamic_cast<const index::JsonFlatIndex*>(index));
                 auto executor =
                     json_flat_index->create_executor<double>(pointer);
                 cached_index_chunk_res_ = std::make_shared<TargetBitmap>(

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -41,6 +41,22 @@ namespace exec {
 
 enum class FilterType { sequential = 0, random = 1 };
 
+inline std::vector<PinWrapper<const index::IndexBase*>>
+PinIndex(const segcore::SegmentInternalInterface* segment,
+         const FieldMeta& field_meta,
+         const std::vector<std::string>& path = {},
+         DataType data_type = DataType::NONE,
+         bool any_type = false,
+         bool is_array = false) {
+    if (field_meta.get_data_type() == DataType::JSON) {
+        auto pointer = milvus::Json::pointer(path);
+        return segment->PinJsonIndex(
+            field_meta.get_id(), pointer, data_type, any_type, is_array);
+    } else {
+        return segment->PinIndex(field_meta.get_id());
+    }
+}
+
 class Expr {
  public:
     Expr(DataType type,
@@ -174,20 +190,15 @@ class SegmentExpr : public Expr {
             pk_type_ = field_meta.get_data_type();
         }
 
-        if (field_meta.get_data_type() == DataType::JSON) {
-            auto pointer = milvus::Json::pointer(nested_path_);
-            if (is_index_mode_ = segment_->HasIndex(field_id_,
-                                                    pointer,
-                                                    value_type_,
-                                                    allow_any_json_cast_type_,
-                                                    is_json_contains_)) {
-                num_index_chunk_ = 1;
-            }
-        } else {
-            is_index_mode_ = segment_->HasIndex(field_id_);
-            if (is_index_mode_) {
-                num_index_chunk_ = segment_->num_chunk_index(field_id_);
-            }
+        pinned_index_ = PinIndex(segment_,
+                                 field_meta,
+                                 nested_path_,
+                                 value_type_,
+                                 allow_any_json_cast_type_,
+                                 is_json_contains_);
+        if (pinned_index_.size() > 0) {
+            is_index_mode_ = true;
+            num_index_chunk_ = pinned_index_.size();
         }
         // if index not include raw data, also need load data
         if (segment_->HasFieldData(field_id_)) {
@@ -410,8 +421,8 @@ class SegmentExpr : public Expr {
         using Index = index::ScalarIndex<IndexInnerType>;
         TargetBitmap valid_res(input->size());
 
-        auto pw = segment_->chunk_scalar_index<IndexInnerType>(field_id_, 0);
-        auto* index_ptr = const_cast<Index*>(pw.get());
+        auto scalar_index = dynamic_cast<const Index*>(pinned_index_[0].get());
+        auto* index_ptr = const_cast<Index*>(scalar_index);
 
         auto valid_result = index_ptr->IsNotNull();
         for (auto i = 0; i < input->size(); ++i) {
@@ -439,8 +450,8 @@ class SegmentExpr : public Expr {
         using IndexInnerType = std::
             conditional_t<std::is_same_v<T, std::string_view>, std::string, T>;
         using Index = index::ScalarIndex<IndexInnerType>;
-        auto pw = segment_->chunk_scalar_index<IndexInnerType>(field_id_, 0);
-        auto* index_ptr = const_cast<Index*>(pw.get());
+        auto scalar_index = dynamic_cast<const Index*>(pinned_index_[0].get());
+        auto* index_ptr = const_cast<Index*>(scalar_index);
         auto valid_result = index_ptr->IsNotNull();
         auto batch_size = input->size();
 
@@ -889,8 +900,8 @@ class SegmentExpr : public Expr {
 
                 if (field_type_ == DataType::JSON) {
                     auto pointer = milvus::Json::pointer(nested_path_);
-                    json_pw = segment_->chunk_json_index(field_id_, pointer, i);
 
+                    json_pw = pinned_index_[i];
                     // check if it is a json flat index, if so, create a json flat index query executor
                     auto json_flat_index =
                         dynamic_cast<const index::JsonFlatIndex*>(
@@ -909,9 +920,9 @@ class SegmentExpr : public Expr {
                         index_ptr = dynamic_cast<Index*>(json_index);
                     }
                 } else {
-                    pw = segment_->chunk_scalar_index<IndexInnerType>(field_id_,
-                                                                      i);
-                    index_ptr = const_cast<Index*>(pw.get());
+                    auto scalar_index =
+                        dynamic_cast<const Index*>(pinned_index_[i].get());
+                    index_ptr = const_cast<Index*>(scalar_index);
                 }
                 cached_index_chunk_res_ = std::make_shared<TargetBitmap>(
                     std::move(func(index_ptr, values...)));
@@ -1046,9 +1057,9 @@ class SegmentExpr : public Expr {
                                   element_type);
                 }
             }
-            auto pw =
-                segment_->chunk_scalar_index<IndexInnerType>(field_id_, 0);
-            auto* index_ptr = const_cast<Index*>(pw.get());
+            auto scalar_index =
+                dynamic_cast<const Index*>(pinned_index_[0].get());
+            auto* index_ptr = const_cast<Index*>(scalar_index);
             const auto& res = index_ptr->IsNotNull();
             for (auto i = 0; i < batch_size; ++i) {
                 valid_result[i] = res[input[i]];
@@ -1176,9 +1187,9 @@ class SegmentExpr : public Expr {
             // It avoids indexing execute for every batch because indexing
             // executing costs quite much time.
             if (cached_index_chunk_id_ != i) {
-                auto pw =
-                    segment_->chunk_scalar_index<IndexInnerType>(field_id_, i);
-                auto* index_ptr = const_cast<Index*>(pw.get());
+                auto scalar_index =
+                    dynamic_cast<const Index*>(pinned_index_[i].get());
+                auto* index_ptr = const_cast<Index*>(scalar_index);
                 auto execute_sub_batch = [](Index* index_ptr) {
                     TargetBitmap res = index_ptr->IsNotNull();
                     return res;
@@ -1215,9 +1226,9 @@ class SegmentExpr : public Expr {
         using Index = index::ScalarIndex<IndexInnerType>;
 
         for (size_t i = current_index_chunk_; i < num_index_chunk_; i++) {
-            auto pw =
-                segment_->chunk_scalar_index<IndexInnerType>(field_id_, i);
-            auto* index_ptr = const_cast<Index*>(pw.get());
+            auto scalar_index =
+                dynamic_cast<const Index*>(pinned_index_[i].get());
+            auto* index_ptr = const_cast<Index*>(scalar_index);
             func(index_ptr, values...);
         }
     }
@@ -1235,9 +1246,9 @@ class SegmentExpr : public Expr {
         using Index = index::ScalarIndex<IndexInnerType>;
         if (op == OpType::Match || op == OpType::InnerMatch ||
             op == OpType::PostfixMatch) {
-            auto pw = segment_->chunk_scalar_index<IndexInnerType>(
-                field_id_, current_index_chunk_);
-            auto* index_ptr = const_cast<Index*>(pw.get());
+            auto scalar_index = dynamic_cast<const Index*>(
+                pinned_index_[current_index_chunk_].get());
+            auto* index_ptr = const_cast<Index*>(scalar_index);
             // 1, index support regex query and try use it, then index handles the query;
             // 2, index has raw data, then call index.Reverse_Lookup to handle the query;
             return (index_ptr->TryUseRegexQuery() &&
@@ -1256,9 +1267,9 @@ class SegmentExpr : public Expr {
 
         using Index = index::ScalarIndex<IndexInnerType>;
         for (size_t i = current_index_chunk_; i < num_index_chunk_; i++) {
-            auto pw =
-                segment_->chunk_scalar_index<IndexInnerType>(field_id_, i);
-            auto* index_ptr = const_cast<Index*>(pw.get());
+            auto scalar_index =
+                dynamic_cast<const Index*>(pinned_index_[i].get());
+            auto* index_ptr = const_cast<Index*>(scalar_index);
             if (!index_ptr->HasRawData()) {
                 return false;
             }
@@ -1270,17 +1281,6 @@ class SegmentExpr : public Expr {
     void
     SetNotUseIndex() {
         use_index_ = false;
-    }
-
-    bool
-    CanUseNgramIndex(FieldId field_id) const {
-        return segment_->HasNgramIndex(field_id);
-    }
-
-    bool
-    CanUseNgramIndexForJson(FieldId field_id,
-                            const std::string& nested_path) const {
-        return segment_->HasNgramIndexForJson(field_id, nested_path);
     }
 
     bool
@@ -1320,6 +1320,7 @@ class SegmentExpr : public Expr {
     // sometimes need to skip index and using raw data
     // default true means use index as much as possible
     bool use_index_{true};
+    std::vector<PinWrapper<const index::IndexBase*>> pinned_index_{};
 
     int64_t active_count_{0};
     int64_t num_data_chunk_{0};

--- a/internal/core/src/exec/operator/groupby/SearchGroupByOperator.h
+++ b/internal/core/src/exec/operator/groupby/SearchGroupByOperator.h
@@ -21,6 +21,7 @@
 #include "cachinglayer/CacheSlot.h"
 #include "common/QueryInfo.h"
 #include "common/Types.h"
+#include "index/ScalarIndex.h"
 #include "knowhere/index/index_node.h"
 #include "segcore/SegmentInterface.h"
 #include "segcore/SegmentGrowingImpl.h"
@@ -84,18 +85,24 @@ class SealedDataGetter : public DataGetter<T> {
         int64_t,
         PinWrapper<std::pair<std::vector<std::string_view>, FixedVector<bool>>>>
         pw_map_;
+
+    PinWrapper<const index::IndexBase*> index_ptr_;
     // Getting str_view from segment is cpu-costly, this map is to cache this view for performance
  public:
     SealedDataGetter(const segcore::SegmentSealed& segment, FieldId& field_id)
         : segment_(segment), field_id_(field_id) {
         from_data_ = segment_.HasFieldData(field_id_);
-        if (!from_data_ && !segment_.HasIndex(field_id_)) {
-            ThrowInfo(
-                UnexpectedError,
-                "The segment:{} used to init data getter has no effective "
-                "data source, neither"
-                "index or data",
-                segment_.get_segment_id());
+        if (!from_data_) {
+            auto index = segment_.PinIndex(field_id_);
+            if (index.empty()) {
+                ThrowInfo(
+                    UnexpectedError,
+                    "The segment:{} used to init data getter has no effective "
+                    "data source, neither"
+                    "index or data",
+                    segment_.get_segment_id());
+            }
+            index_ptr_ = std::move(index[0]);
         }
     }
 
@@ -130,8 +137,10 @@ class SealedDataGetter : public DataGetter<T> {
             }
         } else {
             // null is not supported for indexed fields
-            auto pw = segment_.chunk_scalar_index<T>(field_id_, 0);
-            auto* chunk_index = pw.get();
+            AssertInfo(index_ptr_.get() != nullptr,
+                       "indexed field should have only one index");
+            auto chunk_index =
+                dynamic_cast<const index::ScalarIndex<T>*>(index_ptr_.get());
             auto raw = chunk_index->Reverse_Lookup(idx);
             AssertInfo(raw.has_value(), "field data not found");
             return raw.value();
@@ -195,7 +204,7 @@ struct GroupByMap {
                bool strict_group_size = false)
         : group_capacity_(group_capacity),
           group_size_(group_size),
-          strict_group_size_(strict_group_size){};
+          strict_group_size_(strict_group_size) {};
     bool
     IsGroupResEnough() {
         bool enough = false;

--- a/internal/core/src/exec/operator/groupby/SearchGroupByOperator.h
+++ b/internal/core/src/exec/operator/groupby/SearchGroupByOperator.h
@@ -204,7 +204,7 @@ struct GroupByMap {
                bool strict_group_size = false)
         : group_capacity_(group_capacity),
           group_size_(group_size),
-          strict_group_size_(strict_group_size) {};
+          strict_group_size_(strict_group_size){};
     bool
     IsGroupResEnough() {
         bool enough = false;

--- a/internal/core/src/segcore/SegmentChunkReader.cpp
+++ b/internal/core/src/segcore/SegmentChunkReader.cpp
@@ -93,7 +93,7 @@ SegmentChunkReader::GetMultipleChunkDataAccessor<std::string>(
             dynamic_cast<const index::ScalarIndex<std::string>*>(index);
         if (index_ptr->HasRawData()) {
             return [&, index_ptr = std::move(index_ptr)]() mutable
-                       -> const data_access_type {
+                   -> const data_access_type {
                 if (current_chunk_pos >= active_count_) {
                     return std::nullopt;
                 }

--- a/internal/core/src/segcore/SegmentChunkReader.cpp
+++ b/internal/core/src/segcore/SegmentChunkReader.cpp
@@ -18,24 +18,32 @@
 namespace milvus::segcore {
 template <typename T>
 MultipleChunkDataAccessor
-SegmentChunkReader::GetChunkDataAccessor(FieldId field_id,
-                                         bool index,
-                                         int64_t& current_chunk_id,
-                                         int64_t& current_chunk_pos) const {
+SegmentChunkReader::GetMultipleChunkDataAccessor(
+    FieldId field_id,
+    int64_t& current_chunk_id,
+    int64_t& current_chunk_pos,
+    const std::vector<PinWrapper<const index::IndexBase*>>& pinned_index)
+    const {
+    const index::IndexBase* index = nullptr;
+    if (current_chunk_id < pinned_index.size()) {
+        index = pinned_index[current_chunk_id].get();
+    }
+
     if (index) {
-        auto pw = segment_->chunk_scalar_index<T>(field_id, current_chunk_id);
-        if (pw.get()->HasRawData()) {
-            return [&, pw = std::move(pw)]() -> const data_access_type {
-                auto index = pw.get();
-                if (current_chunk_pos >= active_count_) {
-                    return std::nullopt;
-                }
-                auto raw = index->Reverse_Lookup(current_chunk_pos++);
-                if (!raw.has_value()) {
-                    return std::nullopt;
-                }
-                return raw.value();
-            };
+        auto index_ptr = dynamic_cast<const index::ScalarIndex<T>*>(index);
+        if (index_ptr->HasRawData()) {
+            return
+                [&,
+                 index_ptr = std::move(index_ptr)]() -> const data_access_type {
+                    if (current_chunk_pos >= active_count_) {
+                        return std::nullopt;
+                    }
+                    auto raw = index_ptr->Reverse_Lookup(current_chunk_pos++);
+                    if (!raw.has_value()) {
+                        return std::nullopt;
+                    }
+                    return raw.value();
+                };
         }
     }
     // pw is captured by value, each time we need to access a new chunk, we need to
@@ -69,21 +77,27 @@ SegmentChunkReader::GetChunkDataAccessor(FieldId field_id,
 
 template <>
 MultipleChunkDataAccessor
-SegmentChunkReader::GetChunkDataAccessor<std::string>(
+SegmentChunkReader::GetMultipleChunkDataAccessor<std::string>(
     FieldId field_id,
-    bool index,
     int64_t& current_chunk_id,
-    int64_t& current_chunk_pos) const {
+    int64_t& current_chunk_pos,
+    const std::vector<PinWrapper<const index::IndexBase*>>& pinned_index)
+    const {
+    const index::IndexBase* index = nullptr;
+    if (current_chunk_id < pinned_index.size()) {
+        index = pinned_index[current_chunk_id].get();
+    }
+
     if (index) {
-        auto pw = segment_->chunk_scalar_index<std::string>(field_id,
-                                                            current_chunk_id);
-        if (pw.get()->HasRawData()) {
-            return [&, pw = std::move(pw)]() mutable -> const data_access_type {
-                auto index = pw.get();
+        auto index_ptr =
+            dynamic_cast<const index::ScalarIndex<std::string>*>(index);
+        if (index_ptr->HasRawData()) {
+            return [&, index_ptr = std::move(index_ptr)]() mutable
+                       -> const data_access_type {
                 if (current_chunk_pos >= active_count_) {
                     return std::nullopt;
                 }
-                auto raw = index->Reverse_Lookup(current_chunk_pos++);
+                auto raw = index_ptr->Reverse_Lookup(current_chunk_pos++);
                 if (!raw.has_value()) {
                     return std::nullopt;
                 }
@@ -156,37 +170,41 @@ SegmentChunkReader::GetChunkDataAccessor<std::string>(
 }
 
 MultipleChunkDataAccessor
-SegmentChunkReader::GetChunkDataAccessor(DataType data_type,
-                                         FieldId field_id,
-                                         bool index,
-                                         int64_t& current_chunk_id,
-                                         int64_t& current_chunk_pos) const {
+SegmentChunkReader::GetMultipleChunkDataAccessor(
+    DataType data_type,
+    FieldId field_id,
+    int64_t& current_chunk_id,
+    int64_t& current_chunk_pos,
+    const std::vector<PinWrapper<const index::IndexBase*>>& pinned_index)
+    const {
     switch (data_type) {
         case DataType::BOOL:
-            return GetChunkDataAccessor<bool>(
-                field_id, index, current_chunk_id, current_chunk_pos);
+            return GetMultipleChunkDataAccessor<bool>(
+                field_id, current_chunk_id, current_chunk_pos, pinned_index);
         case DataType::INT8:
-            return GetChunkDataAccessor<int8_t>(
-                field_id, index, current_chunk_id, current_chunk_pos);
+            return GetMultipleChunkDataAccessor<int8_t>(
+                field_id, current_chunk_id, current_chunk_pos, pinned_index);
         case DataType::INT16:
-            return GetChunkDataAccessor<int16_t>(
-                field_id, index, current_chunk_id, current_chunk_pos);
+            return GetMultipleChunkDataAccessor<int16_t>(
+                field_id, current_chunk_id, current_chunk_pos, pinned_index);
         case DataType::INT32:
-            return GetChunkDataAccessor<int32_t>(
-                field_id, index, current_chunk_id, current_chunk_pos);
+            return GetMultipleChunkDataAccessor<int32_t>(
+                field_id, current_chunk_id, current_chunk_pos, pinned_index);
         case DataType::INT64:
+            return GetMultipleChunkDataAccessor<int64_t>(
+                field_id, current_chunk_id, current_chunk_pos, pinned_index);
         case DataType::TIMESTAMPTZ:
-            return GetChunkDataAccessor<int64_t>(
-                field_id, index, current_chunk_id, current_chunk_pos);
+            return GetMultipleChunkDataAccessor<int64_t>(
+                field_id, current_chunk_id, current_chunk_pos, pinned_index);
         case DataType::FLOAT:
-            return GetChunkDataAccessor<float>(
-                field_id, index, current_chunk_id, current_chunk_pos);
+            return GetMultipleChunkDataAccessor<float>(
+                field_id, current_chunk_id, current_chunk_pos, pinned_index);
         case DataType::DOUBLE:
-            return GetChunkDataAccessor<double>(
-                field_id, index, current_chunk_id, current_chunk_pos);
+            return GetMultipleChunkDataAccessor<double>(
+                field_id, current_chunk_id, current_chunk_pos, pinned_index);
         case DataType::VARCHAR: {
-            return GetChunkDataAccessor<std::string>(
-                field_id, index, current_chunk_id, current_chunk_pos);
+            return GetMultipleChunkDataAccessor<std::string>(
+                field_id, current_chunk_id, current_chunk_pos, pinned_index);
         }
         default:
             ThrowInfo(DataTypeInvalid, "unsupported data type: {}", data_type);
@@ -195,21 +213,23 @@ SegmentChunkReader::GetChunkDataAccessor(DataType data_type,
 
 template <typename T>
 ChunkDataAccessor
-SegmentChunkReader::GetChunkDataAccessor(FieldId field_id,
-                                         int chunk_id,
-                                         int data_barrier) const {
+SegmentChunkReader::GetChunkDataAccessor(
+    FieldId field_id,
+    int chunk_id,
+    int data_barrier,
+    const std::vector<PinWrapper<const index::IndexBase*>>& pinned_index)
+    const {
     if (chunk_id >= data_barrier) {
-        auto pw = segment_->chunk_scalar_index<T>(field_id, chunk_id);
-        if (pw.get()->HasRawData()) {
-            return
-                [pw = std::move(pw)](int i) mutable -> const data_access_type {
-                    auto index = pw.get();
-                    auto raw = index->Reverse_Lookup(i);
-                    if (!raw.has_value()) {
-                        return std::nullopt;
-                    }
-                    return raw.value();
-                };
+        auto index = pinned_index[chunk_id].get();
+        auto index_ptr = dynamic_cast<const index::ScalarIndex<T>*>(index);
+        if (index->HasRawData()) {
+            return [index_ptr](int i) mutable -> const data_access_type {
+                auto raw = index_ptr->Reverse_Lookup(i);
+                if (!raw.has_value()) {
+                    return std::nullopt;
+                }
+                return raw.value();
+            };
         }
     }
     auto pw = segment_->chunk_data<T>(field_id, chunk_id);
@@ -226,22 +246,24 @@ SegmentChunkReader::GetChunkDataAccessor(FieldId field_id,
 
 template <>
 ChunkDataAccessor
-SegmentChunkReader::GetChunkDataAccessor<std::string>(FieldId field_id,
-                                                      int chunk_id,
-                                                      int data_barrier) const {
+SegmentChunkReader::GetChunkDataAccessor<std::string>(
+    FieldId field_id,
+    int chunk_id,
+    int data_barrier,
+    const std::vector<PinWrapper<const index::IndexBase*>>& pinned_index)
+    const {
     if (chunk_id >= data_barrier) {
-        auto pw = segment_->chunk_scalar_index<std::string>(field_id, chunk_id);
-        auto indexing = pw.get();
-        if (indexing->HasRawData()) {
-            return
-                [pw = std::move(pw)](int i) mutable -> const data_access_type {
-                    auto index = pw.get();
-                    auto raw = index->Reverse_Lookup(i);
-                    if (!raw.has_value()) {
-                        return std::nullopt;
-                    }
-                    return raw.value();
-                };
+        auto index = pinned_index[chunk_id].get();
+        auto index_ptr =
+            dynamic_cast<const index::ScalarIndex<std::string>*>(index);
+        if (index_ptr->HasRawData()) {
+            return [index_ptr](int i) mutable -> const data_access_type {
+                auto raw = index_ptr->Reverse_Lookup(i);
+                if (!raw.has_value()) {
+                    return std::nullopt;
+                }
+                return raw.value();
+            };
         }
     }
     if (segment_->type() == SegmentType::Growing &&
@@ -271,36 +293,40 @@ SegmentChunkReader::GetChunkDataAccessor<std::string>(FieldId field_id,
 }
 
 ChunkDataAccessor
-SegmentChunkReader::GetChunkDataAccessor(DataType data_type,
-                                         FieldId field_id,
-                                         int chunk_id,
-                                         int data_barrier) const {
+SegmentChunkReader::GetChunkDataAccessor(
+    DataType data_type,
+    FieldId field_id,
+    int chunk_id,
+    int data_barrier,
+    const std::vector<PinWrapper<const index::IndexBase*>>& pinned_index)
+    const {
     switch (data_type) {
         case DataType::BOOL:
-            return GetChunkDataAccessor<bool>(field_id, chunk_id, data_barrier);
+            return GetChunkDataAccessor<bool>(
+                field_id, chunk_id, data_barrier, pinned_index);
         case DataType::INT8:
             return GetChunkDataAccessor<int8_t>(
-                field_id, chunk_id, data_barrier);
+                field_id, chunk_id, data_barrier, pinned_index);
         case DataType::INT16:
             return GetChunkDataAccessor<int16_t>(
-                field_id, chunk_id, data_barrier);
+                field_id, chunk_id, data_barrier, pinned_index);
         case DataType::INT32:
             return GetChunkDataAccessor<int32_t>(
-                field_id, chunk_id, data_barrier);
+                field_id, chunk_id, data_barrier, pinned_index);
         case DataType::TIMESTAMPTZ:
         case DataType::INT64:
             return GetChunkDataAccessor<int64_t>(
-                field_id, chunk_id, data_barrier);
+                field_id, chunk_id, data_barrier, pinned_index);
         case DataType::FLOAT:
             return GetChunkDataAccessor<float>(
-                field_id, chunk_id, data_barrier);
+                field_id, chunk_id, data_barrier, pinned_index);
         case DataType::DOUBLE:
             return GetChunkDataAccessor<double>(
-                field_id, chunk_id, data_barrier);
+                field_id, chunk_id, data_barrier, pinned_index);
         case DataType::VARCHAR:
         case DataType::TEXT: {
             return GetChunkDataAccessor<std::string>(
-                field_id, chunk_id, data_barrier);
+                field_id, chunk_id, data_barrier, pinned_index);
         }
         default:
             ThrowInfo(DataTypeInvalid, "unsupported data type: {}", data_type);

--- a/internal/core/src/segcore/SegmentChunkReader.h
+++ b/internal/core/src/segcore/SegmentChunkReader.h
@@ -46,17 +46,21 @@ class SegmentChunkReader {
     }
 
     MultipleChunkDataAccessor
-    GetChunkDataAccessor(DataType data_type,
-                         FieldId field_id,
-                         bool index,
-                         int64_t& current_chunk_id,
-                         int64_t& current_chunk_pos) const;
+    GetMultipleChunkDataAccessor(
+        DataType data_type,
+        FieldId field_id,
+        int64_t& current_chunk_id,
+        int64_t& current_chunk_pos,
+        const std::vector<PinWrapper<const index::IndexBase*>>& pinned_index)
+        const;
 
     ChunkDataAccessor
     GetChunkDataAccessor(DataType data_type,
                          FieldId field_id,
                          int chunk_id,
-                         int data_barrier) const;
+                         int data_barrier,
+                         const std::vector<PinWrapper<const index::IndexBase*>>&
+                             pinned_index) const;
 
     void
     MoveCursorForMultipleChunk(int64_t& current_chunk_id,
@@ -118,16 +122,20 @@ class SegmentChunkReader {
  private:
     template <typename T>
     MultipleChunkDataAccessor
-    GetChunkDataAccessor(FieldId field_id,
-                         bool index,
-                         int64_t& current_chunk_id,
-                         int64_t& current_chunk_pos) const;
+    GetMultipleChunkDataAccessor(
+        FieldId field_id,
+        int64_t& current_chunk_id,
+        int64_t& current_chunk_pos,
+        const std::vector<PinWrapper<const index::IndexBase*>>& pinned_index)
+        const;
 
     template <typename T>
     ChunkDataAccessor
     GetChunkDataAccessor(FieldId field_id,
                          int chunk_id,
-                         int data_barrier) const;
+                         int data_barrier,
+                         const std::vector<PinWrapper<const index::IndexBase*>>&
+                             pinned_index) const;
 
     const int64_t size_per_chunk_;
 };

--- a/internal/core/src/segcore/SegmentInterface.cpp
+++ b/internal/core/src/segcore/SegmentInterface.cpp
@@ -550,17 +550,6 @@ SegmentInternalInterface::GetNgramIndexForJson(
     return PinWrapper<index::NgramInvertedIndex*>(nullptr);
 }
 
-bool
-SegmentInternalInterface::HasNgramIndex(FieldId field_id) const {
-    return false;
-}
-
-bool
-SegmentInternalInterface::HasNgramIndexForJson(
-    FieldId field_id, const std::string& nested_path) const {
-    return false;
-}
-
 index::JsonKeyStats*
 SegmentInternalInterface::GetJsonStats(FieldId field_id) const {
     std::shared_lock lock(mutex_);

--- a/internal/core/src/segcore/load_field_data_c.cpp
+++ b/internal/core/src/segcore/load_field_data_c.cpp
@@ -96,6 +96,14 @@ AppendLoadFieldDataPath(CLoadFieldDataInfo c_load_field_data_info,
 }
 
 void
+AppendWarmupPolicy(CLoadFieldDataInfo c_load_field_data_info,
+                   CacheWarmupPolicy warmup_policy) {
+    auto load_field_data_info =
+        static_cast<LoadFieldDataInfo*>(c_load_field_data_info);
+    load_field_data_info->warmup_policy = warmup_policy;
+}
+
+void
 SetStorageVersion(CLoadFieldDataInfo c_load_field_data_info,
                   int64_t storage_version) {
     SCOPE_CGO_CALL_METRIC();

--- a/internal/core/src/segcore/load_field_data_c.h
+++ b/internal/core/src/segcore/load_field_data_c.h
@@ -45,6 +45,10 @@ AppendLoadFieldDataPath(CLoadFieldDataInfo c_load_field_data_info,
                         const char* file_path);
 
 void
+AppendWarmupPolicy(CLoadFieldDataInfo c_load_field_data_info,
+                   CacheWarmupPolicy warmup_policy);
+
+void
 SetStorageVersion(CLoadFieldDataInfo c_load_field_data_info,
                   int64_t storage_version);
 

--- a/internal/core/src/segcore/segment_c.cpp
+++ b/internal/core/src/segcore/segment_c.cpp
@@ -310,6 +310,15 @@ HasRawData(CSegmentInterface c_segment, int64_t field_id) {
     return segment->HasRawData(field_id);
 }
 
+bool
+HasFieldData(CSegmentInterface c_segment, int64_t field_id) {
+    SCOPE_CGO_CALL_METRIC();
+
+    auto segment =
+        reinterpret_cast<milvus::segcore::SegmentInterface*>(c_segment);
+    return segment->HasFieldData(milvus::FieldId(field_id));
+}
+
 //////////////////////////////    interfaces for growing segment    //////////////////////////////
 CStatus
 Insert(CSegmentInterface c_segment,
@@ -611,6 +620,25 @@ DropSealedSegmentIndex(CSegmentInterface c_segment, int64_t field_id) {
             dynamic_cast<milvus::segcore::SegmentSealed*>(segment_interface);
         AssertInfo(segment != nullptr, "segment conversion failed");
         segment->DropIndex(milvus::FieldId(field_id));
+        return milvus::SuccessCStatus();
+    } catch (std::exception& e) {
+        return milvus::FailureCStatus(&e);
+    }
+}
+
+CStatus
+DropSealedSegmentJSONIndex(CSegmentInterface c_segment,
+                           int64_t field_id,
+                           const char* nested_path) {
+    SCOPE_CGO_CALL_METRIC();
+
+    try {
+        auto segment_interface =
+            reinterpret_cast<milvus::segcore::SegmentInterface*>(c_segment);
+        auto segment =
+            dynamic_cast<milvus::segcore::SegmentSealed*>(segment_interface);
+        AssertInfo(segment != nullptr, "segment conversion failed");
+        segment->DropJSONIndex(milvus::FieldId(field_id), nested_path);
         return milvus::SuccessCStatus();
     } catch (std::exception& e) {
         return milvus::FailureCStatus(&e);

--- a/internal/core/src/segcore/segment_c.h
+++ b/internal/core/src/segcore/segment_c.h
@@ -89,6 +89,9 @@ GetRealCount(CSegmentInterface c_segment);
 bool
 HasRawData(CSegmentInterface c_segment, int64_t field_id);
 
+bool
+HasFieldData(CSegmentInterface c_segment, int64_t field_id);
+
 //////////////////////////////    interfaces for growing segment    //////////////////////////////
 CStatus
 Insert(CSegmentInterface c_segment,
@@ -139,6 +142,11 @@ DropFieldData(CSegmentInterface c_segment, int64_t field_id);
 
 CStatus
 DropSealedSegmentIndex(CSegmentInterface c_segment, int64_t field_id);
+
+CStatus
+DropSealedSegmentJSONIndex(CSegmentInterface c_segment,
+                           int64_t field_id,
+                           const char* nested_path);
 
 CStatus
 AddFieldDataInfoForSealed(CSegmentInterface c_segment,

--- a/internal/core/src/segcore/storagev1translator/V1SealedIndexTranslator.h
+++ b/internal/core/src/segcore/storagev1translator/V1SealedIndexTranslator.h
@@ -58,10 +58,11 @@ class V1SealedIndexTranslator : public Translator<milvus::index::IndexBase> {
         int64_t index_build_id;
         int64_t index_version;
     };
-    std::unique_ptr<milvus::index::IndexBase>
+
+    index::IndexBasePtr
     LoadVecIndex();
 
-    std::unique_ptr<milvus::index::IndexBase>
+    index::IndexBasePtr
     LoadScalarIndex();
 
     std::string key_;

--- a/internal/core/unittest/test_binlog_index.cpp
+++ b/internal/core/unittest/test_binlog_index.cpp
@@ -287,9 +287,6 @@ TEST_P(BinlogIndexTest, AccuracyWithLoadFieldData) {
         ASSERT_NO_THROW(segment->LoadIndex(load_info));
         EXPECT_TRUE(segment->HasIndex(vec_field_id));
         EXPECT_EQ(segment->get_row_count(), data_n);
-        // only INDEX_FAISS_IVFFLAT has raw data, thus it should release the raw field data.
-        EXPECT_EQ(segment->HasFieldData(vec_field_id),
-                  index_type != knowhere::IndexEnum::INDEX_FAISS_IVFFLAT);
         auto ivf_sr = segment->Search(plan.get(), ph_group.get(), 1L << 63, 0);
         auto similary = GetKnnSearchRecall(num_queries,
                                            binlog_index_sr->seg_offsets_.data(),
@@ -386,8 +383,6 @@ TEST_P(BinlogIndexTest, AccuracyWithMapFieldData) {
         ASSERT_NO_THROW(segment->LoadIndex(load_info));
         EXPECT_TRUE(segment->HasIndex(vec_field_id));
         EXPECT_EQ(segment->get_row_count(), data_n);
-        EXPECT_EQ(segment->HasFieldData(vec_field_id),
-                  index_type != knowhere::IndexEnum::INDEX_FAISS_IVFFLAT);
         auto ivf_sr = segment->Search(plan.get(), ph_group.get(), 1L << 63);
         auto similary = GetKnnSearchRecall(num_queries,
                                            binlog_index_sr->seg_offsets_.data(),
@@ -436,8 +431,6 @@ TEST_P(BinlogIndexTest, DisableInterimIndex) {
     ASSERT_NO_THROW(segment->LoadIndex(load_info));
     EXPECT_TRUE(segment->HasIndex(vec_field_id));
     EXPECT_EQ(segment->get_row_count(), data_n);
-    EXPECT_EQ(segment->HasFieldData(vec_field_id),
-              index_type != knowhere::IndexEnum::INDEX_FAISS_IVFFLAT);
 }
 
 TEST_P(BinlogIndexTest, LoadBingLogWihIDMAP) {

--- a/internal/core/unittest/test_ngram_query.cpp
+++ b/internal/core/unittest/test_ngram_query.cpp
@@ -211,6 +211,11 @@ test_ngram_with_data(const boost::container::vector<std::string>& data,
         BitsetType final;
         final = ExecuteQueryExpr(parsed, segment.get(), nb, MAX_TIMESTAMP);
         for (size_t i = 0; i < nb; i++) {
+            if (final[i] != expected_result[i]) {
+                std::cout << "final[" << i << "] = " << final[i]
+                          << ", expected_result[" << i
+                          << "] = " << expected_result[i] << std::endl;
+            }
             ASSERT_EQ(final[i], expected_result[i]);
         }
     }

--- a/internal/core/unittest/test_sealed.cpp
+++ b/internal/core/unittest/test_sealed.cpp
@@ -573,8 +573,8 @@ TEST(Sealed, LoadFieldData) {
     segment->LoadIndex(vec_info);
 
     ASSERT_EQ(segment->num_chunk(fakevec_id), 1);
-    ASSERT_EQ(segment->num_chunk_index(double_id), 0);
-    ASSERT_EQ(segment->num_chunk_index(str_id), 0);
+    ASSERT_EQ(segment->PinIndex(double_id).size(), 0);
+    ASSERT_EQ(segment->PinIndex(str_id).size(), 0);
     auto chunk_span1 = segment->chunk_data<int64_t>(counter_id, 0);
     auto chunk_span2 = segment->chunk_data<double>(double_id, 0);
     auto chunk_span3 =
@@ -654,9 +654,6 @@ TEST(Sealed, LoadFieldData) {
     auto sr = segment->Search(plan.get(), ph_group.get(), timestamp);
     auto json = SearchResultToJson(*sr);
     std::cout << json.dump(1);
-
-    segment->DropIndex(fakevec_id);
-    ASSERT_ANY_THROW(segment->Search(plan.get(), ph_group.get(), timestamp));
 }
 
 TEST(Sealed, ClearData) {
@@ -737,8 +734,8 @@ TEST(Sealed, ClearData) {
     segment->LoadIndex(vec_info);
 
     ASSERT_EQ(segment->num_chunk(fakevec_id), 1);
-    ASSERT_EQ(segment->num_chunk_index(double_id), 0);
-    ASSERT_EQ(segment->num_chunk_index(str_id), 0);
+    ASSERT_EQ(segment->PinIndex(double_id).size(), 0);
+    ASSERT_EQ(segment->PinIndex(str_id).size(), 0);
     auto chunk_span1 = segment->chunk_data<int64_t>(counter_id, 0);
     auto chunk_span2 = segment->chunk_data<double>(double_id, 0);
     auto chunk_span3 =
@@ -842,8 +839,8 @@ TEST(Sealed, LoadFieldDataMmap) {
     segment->LoadIndex(vec_info);
 
     ASSERT_EQ(segment->num_chunk(fakevec_id), 1);
-    ASSERT_EQ(segment->num_chunk_index(double_id), 0);
-    ASSERT_EQ(segment->num_chunk_index(str_id), 0);
+    ASSERT_EQ(segment->PinIndex(double_id).size(), 0);
+    ASSERT_EQ(segment->PinIndex(str_id).size(), 0);
     auto chunk_span1 = segment->chunk_data<int64_t>(counter_id, 0);
     auto chunk_span2 = segment->chunk_data<double>(double_id, 0);
     auto chunk_span3 =
@@ -861,9 +858,6 @@ TEST(Sealed, LoadFieldDataMmap) {
     auto sr = segment->Search(plan.get(), ph_group.get(), timestamp);
     auto json = SearchResultToJson(*sr);
     std::cout << json.dump(1);
-
-    segment->DropIndex(fakevec_id);
-    ASSERT_ANY_THROW(segment->Search(plan.get(), ph_group.get(), timestamp));
 }
 
 TEST(Sealed, LoadPkScalarIndex) {

--- a/internal/distributed/querynode/client/client.go
+++ b/internal/distributed/querynode/client/client.go
@@ -383,3 +383,14 @@ func (c *Client) RunAnalyzer(ctx context.Context, req *querypb.RunAnalyzerReques
 		return client.RunAnalyzer(ctx, req)
 	})
 }
+
+func (c *Client) DropIndex(ctx context.Context, req *querypb.DropIndexRequest, _ ...grpc.CallOption) (*commonpb.Status, error) {
+	req = typeutil.Clone(req)
+	commonpbutil.UpdateMsgBase(
+		req.GetBase(),
+		commonpbutil.FillMsgBaseFromClient(c.nodeID),
+	)
+	return wrapGrpcCall(ctx, c, func(client querypb.QueryNodeClient) (*commonpb.Status, error) {
+		return client.DropIndex(ctx, req)
+	})
+}

--- a/internal/distributed/querynode/service.go
+++ b/internal/distributed/querynode/service.go
@@ -402,3 +402,7 @@ func (s *Server) UpdateSchema(ctx context.Context, req *querypb.UpdateSchemaRequ
 func (s *Server) RunAnalyzer(ctx context.Context, req *querypb.RunAnalyzerRequest) (*milvuspb.RunAnalyzerResponse, error) {
 	return s.querynode.RunAnalyzer(ctx, req)
 }
+
+func (s *Server) DropIndex(ctx context.Context, req *querypb.DropIndexRequest) (*commonpb.Status, error) {
+	return s.querynode.DropIndex(ctx, req)
+}

--- a/internal/mocks/mock_querynode.go
+++ b/internal/mocks/mock_querynode.go
@@ -148,6 +148,65 @@ func (_c *MockQueryNode_DeleteBatch_Call) RunAndReturn(run func(context.Context,
 	return _c
 }
 
+// DropIndex provides a mock function with given fields: _a0, _a1
+func (_m *MockQueryNode) DropIndex(_a0 context.Context, _a1 *querypb.DropIndexRequest) (*commonpb.Status, error) {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DropIndex")
+	}
+
+	var r0 *commonpb.Status
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *querypb.DropIndexRequest) (*commonpb.Status, error)); ok {
+		return rf(_a0, _a1)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *querypb.DropIndexRequest) *commonpb.Status); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*commonpb.Status)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *querypb.DropIndexRequest) error); ok {
+		r1 = rf(_a0, _a1)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockQueryNode_DropIndex_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DropIndex'
+type MockQueryNode_DropIndex_Call struct {
+	*mock.Call
+}
+
+// DropIndex is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *querypb.DropIndexRequest
+func (_e *MockQueryNode_Expecter) DropIndex(_a0 interface{}, _a1 interface{}) *MockQueryNode_DropIndex_Call {
+	return &MockQueryNode_DropIndex_Call{Call: _e.mock.On("DropIndex", _a0, _a1)}
+}
+
+func (_c *MockQueryNode_DropIndex_Call) Run(run func(_a0 context.Context, _a1 *querypb.DropIndexRequest)) *MockQueryNode_DropIndex_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*querypb.DropIndexRequest))
+	})
+	return _c
+}
+
+func (_c *MockQueryNode_DropIndex_Call) Return(_a0 *commonpb.Status, _a1 error) *MockQueryNode_DropIndex_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockQueryNode_DropIndex_Call) RunAndReturn(run func(context.Context, *querypb.DropIndexRequest) (*commonpb.Status, error)) *MockQueryNode_DropIndex_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetAddress provides a mock function with no fields
 func (_m *MockQueryNode) GetAddress() string {
 	ret := _m.Called()

--- a/internal/mocks/mock_querynode_client.go
+++ b/internal/mocks/mock_querynode_client.go
@@ -224,6 +224,80 @@ func (_c *MockQueryNodeClient_DeleteBatch_Call) RunAndReturn(run func(context.Co
 	return _c
 }
 
+// DropIndex provides a mock function with given fields: ctx, in, opts
+func (_m *MockQueryNodeClient) DropIndex(ctx context.Context, in *querypb.DropIndexRequest, opts ...grpc.CallOption) (*commonpb.Status, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, in)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DropIndex")
+	}
+
+	var r0 *commonpb.Status
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *querypb.DropIndexRequest, ...grpc.CallOption) (*commonpb.Status, error)); ok {
+		return rf(ctx, in, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *querypb.DropIndexRequest, ...grpc.CallOption) *commonpb.Status); ok {
+		r0 = rf(ctx, in, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*commonpb.Status)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *querypb.DropIndexRequest, ...grpc.CallOption) error); ok {
+		r1 = rf(ctx, in, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockQueryNodeClient_DropIndex_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DropIndex'
+type MockQueryNodeClient_DropIndex_Call struct {
+	*mock.Call
+}
+
+// DropIndex is a helper method to define mock.On call
+//   - ctx context.Context
+//   - in *querypb.DropIndexRequest
+//   - opts ...grpc.CallOption
+func (_e *MockQueryNodeClient_Expecter) DropIndex(ctx interface{}, in interface{}, opts ...interface{}) *MockQueryNodeClient_DropIndex_Call {
+	return &MockQueryNodeClient_DropIndex_Call{Call: _e.mock.On("DropIndex",
+		append([]interface{}{ctx, in}, opts...)...)}
+}
+
+func (_c *MockQueryNodeClient_DropIndex_Call) Run(run func(ctx context.Context, in *querypb.DropIndexRequest, opts ...grpc.CallOption)) *MockQueryNodeClient_DropIndex_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]grpc.CallOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(grpc.CallOption)
+			}
+		}
+		run(args[0].(context.Context), args[1].(*querypb.DropIndexRequest), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockQueryNodeClient_DropIndex_Call) Return(_a0 *commonpb.Status, _a1 error) *MockQueryNodeClient_DropIndex_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockQueryNodeClient_DropIndex_Call) RunAndReturn(run func(context.Context, *querypb.DropIndexRequest, ...grpc.CallOption) (*commonpb.Status, error)) *MockQueryNodeClient_DropIndex_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetComponentStates provides a mock function with given fields: ctx, in, opts
 func (_m *MockQueryNodeClient) GetComponentStates(ctx context.Context, in *milvuspb.GetComponentStatesRequest, opts ...grpc.CallOption) (*milvuspb.ComponentStates, error) {
 	_va := make([]interface{}, len(opts))

--- a/internal/mocks/util/mock_segcore/mock_CSegment.go
+++ b/internal/mocks/util/mock_segcore/mock_CSegment.go
@@ -140,6 +140,101 @@ func (_c *MockCSegment_Delete_Call) RunAndReturn(run func(context.Context, *segc
 	return _c
 }
 
+// DropIndex provides a mock function with given fields: ctx, fieldID
+func (_m *MockCSegment) DropIndex(ctx context.Context, fieldID int64) error {
+	ret := _m.Called(ctx, fieldID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DropIndex")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, int64) error); ok {
+		r0 = rf(ctx, fieldID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockCSegment_DropIndex_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DropIndex'
+type MockCSegment_DropIndex_Call struct {
+	*mock.Call
+}
+
+// DropIndex is a helper method to define mock.On call
+//   - ctx context.Context
+//   - fieldID int64
+func (_e *MockCSegment_Expecter) DropIndex(ctx interface{}, fieldID interface{}) *MockCSegment_DropIndex_Call {
+	return &MockCSegment_DropIndex_Call{Call: _e.mock.On("DropIndex", ctx, fieldID)}
+}
+
+func (_c *MockCSegment_DropIndex_Call) Run(run func(ctx context.Context, fieldID int64)) *MockCSegment_DropIndex_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(int64))
+	})
+	return _c
+}
+
+func (_c *MockCSegment_DropIndex_Call) Return(_a0 error) *MockCSegment_DropIndex_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockCSegment_DropIndex_Call) RunAndReturn(run func(context.Context, int64) error) *MockCSegment_DropIndex_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// DropJSONIndex provides a mock function with given fields: ctx, fieldID, nestedPath
+func (_m *MockCSegment) DropJSONIndex(ctx context.Context, fieldID int64, nestedPath string) error {
+	ret := _m.Called(ctx, fieldID, nestedPath)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DropJSONIndex")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, int64, string) error); ok {
+		r0 = rf(ctx, fieldID, nestedPath)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockCSegment_DropJSONIndex_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DropJSONIndex'
+type MockCSegment_DropJSONIndex_Call struct {
+	*mock.Call
+}
+
+// DropJSONIndex is a helper method to define mock.On call
+//   - ctx context.Context
+//   - fieldID int64
+//   - nestedPath string
+func (_e *MockCSegment_Expecter) DropJSONIndex(ctx interface{}, fieldID interface{}, nestedPath interface{}) *MockCSegment_DropJSONIndex_Call {
+	return &MockCSegment_DropJSONIndex_Call{Call: _e.mock.On("DropJSONIndex", ctx, fieldID, nestedPath)}
+}
+
+func (_c *MockCSegment_DropJSONIndex_Call) Run(run func(ctx context.Context, fieldID int64, nestedPath string)) *MockCSegment_DropJSONIndex_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(int64), args[2].(string))
+	})
+	return _c
+}
+
+func (_c *MockCSegment_DropJSONIndex_Call) Return(_a0 error) *MockCSegment_DropJSONIndex_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockCSegment_DropJSONIndex_Call) RunAndReturn(run func(context.Context, int64, string) error) *MockCSegment_DropJSONIndex_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // FinishLoad provides a mock function with no fields
 func (_m *MockCSegment) FinishLoad() error {
 	ret := _m.Called()
@@ -181,6 +276,52 @@ func (_c *MockCSegment_FinishLoad_Call) Return(_a0 error) *MockCSegment_FinishLo
 }
 
 func (_c *MockCSegment_FinishLoad_Call) RunAndReturn(run func() error) *MockCSegment_FinishLoad_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// HasFieldData provides a mock function with given fields: fieldID
+func (_m *MockCSegment) HasFieldData(fieldID int64) bool {
+	ret := _m.Called(fieldID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for HasFieldData")
+	}
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(int64) bool); ok {
+		r0 = rf(fieldID)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
+// MockCSegment_HasFieldData_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'HasFieldData'
+type MockCSegment_HasFieldData_Call struct {
+	*mock.Call
+}
+
+// HasFieldData is a helper method to define mock.On call
+//   - fieldID int64
+func (_e *MockCSegment_Expecter) HasFieldData(fieldID interface{}) *MockCSegment_HasFieldData_Call {
+	return &MockCSegment_HasFieldData_Call{Call: _e.mock.On("HasFieldData", fieldID)}
+}
+
+func (_c *MockCSegment_HasFieldData_Call) Run(run func(fieldID int64)) *MockCSegment_HasFieldData_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(int64))
+	})
+	return _c
+}
+
+func (_c *MockCSegment_HasFieldData_Call) Return(_a0 bool) *MockCSegment_HasFieldData_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockCSegment_HasFieldData_Call) RunAndReturn(run func(int64) bool) *MockCSegment_HasFieldData_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/proxy/task_index.go
+++ b/internal/proxy/task_index.go
@@ -1045,15 +1045,6 @@ func (dit *dropIndexTask) PreExecute(ctx context.Context) error {
 	}
 	dit.collectionID = collID
 
-	loaded, err := isCollectionLoaded(ctx, dit.mixCoord, collID)
-	if err != nil {
-		return err
-	}
-
-	if loaded {
-		return errors.New("index cannot be dropped, collection is loaded, please release it first")
-	}
-
 	return nil
 }
 

--- a/internal/proxy/task_index_test.go
+++ b/internal/proxy/task_index_test.go
@@ -175,64 +175,7 @@ func TestDropIndexTask_PreExecute(t *testing.T) {
 		dit.mixCoord = qc
 
 		err := dit.PreExecute(ctx)
-		assert.Error(t, err)
-	})
-
-	t.Run("show collection error", func(t *testing.T) {
-		qc := getMockQueryCoord()
-		qc.ExpectedCalls = nil
-		qc.EXPECT().LoadCollection(mock.Anything, mock.Anything).Return(merr.Success(), nil)
-		qc.EXPECT().GetShardLeaders(mock.Anything, mock.Anything).Return(&querypb.GetShardLeadersResponse{
-			Status: merr.Success(),
-			Shards: []*querypb.ShardLeadersList{
-				{
-					ChannelName: "channel-1",
-					NodeIds:     []int64{1, 2, 3},
-					NodeAddrs:   []string{"localhost:9000", "localhost:9001", "localhost:9002"},
-					Serviceable: []bool{true, true, true},
-				},
-			},
-		}, nil)
-		qc.EXPECT().ShowLoadCollections(mock.Anything, mock.Anything).Return(&querypb.ShowCollectionsResponse{
-			Status:        merr.Success(),
-			CollectionIDs: []int64{collectionID},
-		}, nil)
-		qc.EXPECT().ShowCollections(mock.Anything, mock.Anything).Return(nil, errors.New("error"))
-		dit.mixCoord = qc
-
-		err := dit.PreExecute(ctx)
-		assert.Error(t, err)
-	})
-
-	t.Run("show collection fail", func(t *testing.T) {
-		qc := getMockQueryCoord()
-		qc.ExpectedCalls = nil
-		qc.EXPECT().LoadCollection(mock.Anything, mock.Anything).Return(merr.Success(), nil)
-		qc.EXPECT().GetShardLeaders(mock.Anything, mock.Anything).Return(&querypb.GetShardLeadersResponse{
-			Status: merr.Success(),
-			Shards: []*querypb.ShardLeadersList{
-				{
-					ChannelName: "channel-1",
-					NodeIds:     []int64{1, 2, 3},
-					NodeAddrs:   []string{"localhost:9000", "localhost:9001", "localhost:9002"},
-					Serviceable: []bool{true, true, true},
-				},
-			},
-		}, nil)
-		qc.EXPECT().ShowLoadCollections(mock.Anything, mock.Anything).Return(&querypb.ShowCollectionsResponse{
-			Status:        merr.Success(),
-			CollectionIDs: []int64{collectionID},
-		}, nil)
-		qc.EXPECT().ShowLoadCollections(mock.Anything, mock.Anything).Return(&querypb.ShowCollectionsResponse{
-			Status: &commonpb.Status{
-				ErrorCode: commonpb.ErrorCode_UnexpectedError,
-				Reason:    "fail reason",
-			},
-		}, nil)
-		dit.mixCoord = qc
-
-		err := dit.PreExecute(ctx)
-		assert.Error(t, err)
+		assert.NoError(t, err)
 	})
 }
 

--- a/internal/querycoordv2/checkers/index_checker.go
+++ b/internal/querycoordv2/checkers/index_checker.go
@@ -127,12 +127,13 @@ func (c *IndexChecker) checkReplica(ctx context.Context, collection *meta.Collec
 
 	idSegmentsStats := make(map[int64]*meta.Segment)
 	targetsStats := make(map[int64][]int64) // segmentID => FieldID
+	redundant := make(map[int64][]int64)    // segmentID => indexIDs
+	redundantSegments := make(map[int64]*meta.Segment)
 	for _, segment := range segments {
 		// skip update index in read only node
 		if roNodeSet.Contain(segment.Node) {
 			continue
 		}
-
 		missing := c.checkSegment(segment, indexInfos)
 		missingStats := c.checkSegmentStats(segment, schema, collection.LoadFields)
 		if len(missing) > 0 {
@@ -141,6 +142,12 @@ func (c *IndexChecker) checkReplica(ctx context.Context, collection *meta.Collec
 		} else if len(missingStats) > 0 {
 			targetsStats[segment.GetID()] = missingStats
 			idSegmentsStats[segment.GetID()] = segment
+		}
+
+		redundantIndices := c.checkRedundantIndices(segment, indexInfos)
+		if len(redundantIndices) > 0 {
+			redundant[segment.GetID()] = redundantIndices
+			redundantSegments[segment.GetID()] = segment
 		}
 	}
 
@@ -191,6 +198,11 @@ func (c *IndexChecker) checkReplica(ctx context.Context, collection *meta.Collec
 	})
 	tasks = append(tasks, tasksStats...)
 
+	dropTasks := lo.FilterMap(lo.Values(redundantSegments), func(segment *meta.Segment, _ int) (task.Task, bool) {
+		return c.createSegmentIndexDropTasks(ctx, replica, segment, redundant[segment.GetID()]), true
+	})
+	tasks = append(tasks, dropTasks...)
+
 	return tasks
 }
 
@@ -208,6 +220,24 @@ func (c *IndexChecker) checkSegment(segment *meta.Segment, indexInfos []*indexpb
 		}
 	}
 	return result
+}
+
+// checkRedundantIndices returns redundant indexIDs for each segment
+func (c *IndexChecker) checkRedundantIndices(segment *meta.Segment, indexInfos []*indexpb.IndexInfo) []int64 {
+	var redundant []int64
+	indexInfoMap := typeutil.NewSet[int64]()
+
+	for _, indexInfo := range indexInfos {
+		indexInfoMap.Insert(indexInfo.IndexID)
+	}
+
+	for indexID := range segment.IndexInfo {
+		if !indexInfoMap.Contain(indexID) {
+			redundant = append(redundant, indexID)
+		}
+	}
+
+	return redundant
 }
 
 func (c *IndexChecker) createSegmentUpdateTask(ctx context.Context, segment *meta.Segment, replica *meta.Replica) (task.Task, bool) {
@@ -288,4 +318,15 @@ func (c *IndexChecker) createSegmentStatsUpdateTask(ctx context.Context, segment
 	t.SetPriority(task.TaskPriorityLow)
 	t.SetReason("missing json stats")
 	return t, true
+}
+
+func (c *IndexChecker) createSegmentIndexDropTasks(ctx context.Context, replica *meta.Replica, segment *meta.Segment, indexIDs []int64) task.Task {
+	if len(indexIDs) == 0 {
+		return nil
+	}
+	action := task.NewDropIndexAction(segment.Node, task.ActionTypeDropIndex, segment.GetInsertChannel(), indexIDs)
+	t := task.NewDropIndexTask(ctx, c.ID(), replica.GetCollectionID(), replica, segment.GetID(), action)
+	t.SetPriority(task.TaskPriorityLow)
+	t.SetReason("drop index")
+	return t
 }

--- a/internal/querycoordv2/checkers/index_checker_test.go
+++ b/internal/querycoordv2/checkers/index_checker_test.go
@@ -309,7 +309,7 @@ func (suite *IndexCheckerSuite) TestCreateNewIndex() {
 
 	// dist
 	segment := utils.CreateTestSegment(1, 1, 2, 1, 1, "test-insert-channel")
-	segment.IndexInfo = map[int64]*querypb.FieldIndexInfo{101: {
+	segment.IndexInfo = map[int64]*querypb.FieldIndexInfo{1000: {
 		FieldID:     101,
 		IndexID:     1000,
 		EnableIndex: true,

--- a/internal/querycoordv2/mocks/mock_querynode.go
+++ b/internal/querycoordv2/mocks/mock_querynode.go
@@ -147,6 +147,65 @@ func (_c *MockQueryNodeServer_DeleteBatch_Call) RunAndReturn(run func(context.Co
 	return _c
 }
 
+// DropIndex provides a mock function with given fields: _a0, _a1
+func (_m *MockQueryNodeServer) DropIndex(_a0 context.Context, _a1 *querypb.DropIndexRequest) (*commonpb.Status, error) {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DropIndex")
+	}
+
+	var r0 *commonpb.Status
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *querypb.DropIndexRequest) (*commonpb.Status, error)); ok {
+		return rf(_a0, _a1)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *querypb.DropIndexRequest) *commonpb.Status); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*commonpb.Status)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *querypb.DropIndexRequest) error); ok {
+		r1 = rf(_a0, _a1)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockQueryNodeServer_DropIndex_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DropIndex'
+type MockQueryNodeServer_DropIndex_Call struct {
+	*mock.Call
+}
+
+// DropIndex is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *querypb.DropIndexRequest
+func (_e *MockQueryNodeServer_Expecter) DropIndex(_a0 interface{}, _a1 interface{}) *MockQueryNodeServer_DropIndex_Call {
+	return &MockQueryNodeServer_DropIndex_Call{Call: _e.mock.On("DropIndex", _a0, _a1)}
+}
+
+func (_c *MockQueryNodeServer_DropIndex_Call) Run(run func(_a0 context.Context, _a1 *querypb.DropIndexRequest)) *MockQueryNodeServer_DropIndex_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*querypb.DropIndexRequest))
+	})
+	return _c
+}
+
+func (_c *MockQueryNodeServer_DropIndex_Call) Return(_a0 *commonpb.Status, _a1 error) *MockQueryNodeServer_DropIndex_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockQueryNodeServer_DropIndex_Call) RunAndReturn(run func(context.Context, *querypb.DropIndexRequest) (*commonpb.Status, error)) *MockQueryNodeServer_DropIndex_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetComponentStates provides a mock function with given fields: _a0, _a1
 func (_m *MockQueryNodeServer) GetComponentStates(_a0 context.Context, _a1 *milvuspb.GetComponentStatesRequest) (*milvuspb.ComponentStates, error) {
 	ret := _m.Called(_a0, _a1)

--- a/internal/querycoordv2/mocks/querynode.go
+++ b/internal/querycoordv2/mocks/querynode.go
@@ -28,6 +28,7 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
+	commonpb "github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	. "github.com/milvus-io/milvus/internal/querycoordv2/params"
 	"github.com/milvus-io/milvus/internal/util/sessionutil"
@@ -186,4 +187,11 @@ func (node *MockQueryNode) getAllSegments() []*querypb.SegmentVersionInfo {
 		}
 	}
 	return ret
+}
+
+func (node *MockQueryNode) DropIndex(ctx context.Context, req *querypb.DropIndexRequest) (*commonpb.Status, error) {
+	return &commonpb.Status{
+		ErrorCode: commonpb.ErrorCode_Success,
+		Reason:    "success",
+	}, nil
 }

--- a/internal/querycoordv2/session/cluster.go
+++ b/internal/querycoordv2/session/cluster.go
@@ -52,6 +52,7 @@ type Cluster interface {
 	GetMetrics(ctx context.Context, nodeID int64, req *milvuspb.GetMetricsRequest) (*milvuspb.GetMetricsResponse, error)
 	SyncDistribution(ctx context.Context, nodeID int64, req *querypb.SyncDistributionRequest) (*commonpb.Status, error)
 	GetComponentStates(ctx context.Context, nodeID int64) (*milvuspb.ComponentStates, error)
+	DropIndex(ctx context.Context, nodeID int64, req *querypb.DropIndexRequest) (*commonpb.Status, error)
 	Start()
 	Stop()
 }
@@ -261,6 +262,20 @@ func (c *QueryCluster) GetComponentStates(ctx context.Context, nodeID int64) (*m
 	)
 	err1 := c.send(ctx, nodeID, func(cli types.QueryNodeClient) {
 		resp, err = cli.GetComponentStates(ctx, &milvuspb.GetComponentStatesRequest{})
+	})
+	if err1 != nil {
+		return nil, err1
+	}
+	return resp, err
+}
+
+func (c *QueryCluster) DropIndex(ctx context.Context, nodeID int64, req *querypb.DropIndexRequest) (*commonpb.Status, error) {
+	var (
+		resp *commonpb.Status
+		err  error
+	)
+	err1 := c.send(ctx, nodeID, func(cli types.QueryNodeClient) {
+		resp, err = cli.DropIndex(ctx, req)
 	})
 	if err1 != nil {
 		return nil, err1

--- a/internal/querycoordv2/session/mock_cluster.go
+++ b/internal/querycoordv2/session/mock_cluster.go
@@ -27,6 +27,66 @@ func (_m *MockCluster) EXPECT() *MockCluster_Expecter {
 	return &MockCluster_Expecter{mock: &_m.Mock}
 }
 
+// DropIndex provides a mock function with given fields: ctx, nodeID, req
+func (_m *MockCluster) DropIndex(ctx context.Context, nodeID int64, req *querypb.DropIndexRequest) (*commonpb.Status, error) {
+	ret := _m.Called(ctx, nodeID, req)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DropIndex")
+	}
+
+	var r0 *commonpb.Status
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, int64, *querypb.DropIndexRequest) (*commonpb.Status, error)); ok {
+		return rf(ctx, nodeID, req)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, int64, *querypb.DropIndexRequest) *commonpb.Status); ok {
+		r0 = rf(ctx, nodeID, req)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*commonpb.Status)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, int64, *querypb.DropIndexRequest) error); ok {
+		r1 = rf(ctx, nodeID, req)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockCluster_DropIndex_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DropIndex'
+type MockCluster_DropIndex_Call struct {
+	*mock.Call
+}
+
+// DropIndex is a helper method to define mock.On call
+//   - ctx context.Context
+//   - nodeID int64
+//   - req *querypb.DropIndexRequest
+func (_e *MockCluster_Expecter) DropIndex(ctx interface{}, nodeID interface{}, req interface{}) *MockCluster_DropIndex_Call {
+	return &MockCluster_DropIndex_Call{Call: _e.mock.On("DropIndex", ctx, nodeID, req)}
+}
+
+func (_c *MockCluster_DropIndex_Call) Run(run func(ctx context.Context, nodeID int64, req *querypb.DropIndexRequest)) *MockCluster_DropIndex_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(int64), args[2].(*querypb.DropIndexRequest))
+	})
+	return _c
+}
+
+func (_c *MockCluster_DropIndex_Call) Return(_a0 *commonpb.Status, _a1 error) *MockCluster_DropIndex_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockCluster_DropIndex_Call) RunAndReturn(run func(context.Context, int64, *querypb.DropIndexRequest) (*commonpb.Status, error)) *MockCluster_DropIndex_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetComponentStates provides a mock function with given fields: ctx, nodeID
 func (_m *MockCluster) GetComponentStates(ctx context.Context, nodeID int64) (*milvuspb.ComponentStates, error) {
 	ret := _m.Called(ctx, nodeID)

--- a/internal/querycoordv2/task/task.go
+++ b/internal/querycoordv2/task/task.go
@@ -523,6 +523,26 @@ func (task *LeaderTask) MarshalJSON() ([]byte, error) {
 	return marshalJSON(task)
 }
 
+type DropIndexTask struct {
+	*baseTask
+	segmentID typeutil.UniqueID
+}
+
+func NewDropIndexTask(ctx context.Context,
+	source Source,
+	collectionID typeutil.UniqueID,
+	replica *meta.Replica,
+	segmentID typeutil.UniqueID,
+	action *DropIndexAction,
+) *DropIndexTask {
+	base := newBaseTask(ctx, source, collectionID, replica, action.Shard, fmt.Sprintf("DropIndexTask-%s", action.Type().String()))
+	base.actions = []Action{action}
+	return &DropIndexTask{
+		baseTask:  base,
+		segmentID: segmentID,
+	}
+}
+
 func marshalJSON(task Task) ([]byte, error) {
 	return json.Marshal(&metricsinfo.QueryCoordTask{
 		TaskName:     task.Name(),
@@ -537,4 +557,8 @@ func marshalJSON(task Task) ([]byte, error) {
 		Step:   task.Step(),
 		Reason: task.GetReason(),
 	})
+}
+
+func (task *DropIndexTask) SegmentID() typeutil.UniqueID {
+	return task.segmentID
 }

--- a/internal/querycoordv2/task/utils.go
+++ b/internal/querycoordv2/task/utils.go
@@ -98,6 +98,8 @@ func GetTaskType(task Task) Type {
 		return TaskTypeUpdate
 	case task.Actions()[0].Type() == ActionTypeStatsUpdate:
 		return TaskTypeStatsUpdate
+	case task.Actions()[0].Type() == ActionTypeDropIndex:
+		return TaskTypeDropIndex
 	}
 	return 0
 }

--- a/internal/querynodev2/cluster/manager.go
+++ b/internal/querynodev2/cluster/manager.go
@@ -31,6 +31,7 @@ import (
 // Manager is the interface for worker manager.
 type Manager interface {
 	GetWorker(ctx context.Context, nodeID int64) (Worker, error)
+	GetAllWorkers() []Worker
 }
 
 // WorkerBuilder is function alias to build a worker from NodeID
@@ -72,6 +73,10 @@ func (m *grpcWorkerManager) GetWorker(ctx context.Context, nodeID int64) (Worker
 		return nil, fmt.Errorf("node is not healthy: %d", nodeID)
 	}
 	return worker, nil
+}
+
+func (m *grpcWorkerManager) GetAllWorkers() []Worker {
+	return m.workers.Values()
 }
 
 func NewWorkerManager(builder WorkerBuilder) Manager {

--- a/internal/querynodev2/cluster/mock_manager.go
+++ b/internal/querynodev2/cluster/mock_manager.go
@@ -21,6 +21,53 @@ func (_m *MockManager) EXPECT() *MockManager_Expecter {
 	return &MockManager_Expecter{mock: &_m.Mock}
 }
 
+// GetAllWorkers provides a mock function with no fields
+func (_m *MockManager) GetAllWorkers() []Worker {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAllWorkers")
+	}
+
+	var r0 []Worker
+	if rf, ok := ret.Get(0).(func() []Worker); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]Worker)
+		}
+	}
+
+	return r0
+}
+
+// MockManager_GetAllWorkers_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllWorkers'
+type MockManager_GetAllWorkers_Call struct {
+	*mock.Call
+}
+
+// GetAllWorkers is a helper method to define mock.On call
+func (_e *MockManager_Expecter) GetAllWorkers() *MockManager_GetAllWorkers_Call {
+	return &MockManager_GetAllWorkers_Call{Call: _e.mock.On("GetAllWorkers")}
+}
+
+func (_c *MockManager_GetAllWorkers_Call) Run(run func()) *MockManager_GetAllWorkers_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockManager_GetAllWorkers_Call) Return(_a0 []Worker) *MockManager_GetAllWorkers_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockManager_GetAllWorkers_Call) RunAndReturn(run func() []Worker) *MockManager_GetAllWorkers_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetWorker provides a mock function with given fields: ctx, nodeID
 func (_m *MockManager) GetWorker(ctx context.Context, nodeID int64) (Worker, error) {
 	ret := _m.Called(ctx, nodeID)

--- a/internal/querynodev2/cluster/mock_worker.go
+++ b/internal/querynodev2/cluster/mock_worker.go
@@ -135,6 +135,53 @@ func (_c *MockWorker_DeleteBatch_Call) RunAndReturn(run func(context.Context, *q
 	return _c
 }
 
+// DropIndex provides a mock function with given fields: ctx, req
+func (_m *MockWorker) DropIndex(ctx context.Context, req *querypb.DropIndexRequest) error {
+	ret := _m.Called(ctx, req)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DropIndex")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *querypb.DropIndexRequest) error); ok {
+		r0 = rf(ctx, req)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockWorker_DropIndex_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DropIndex'
+type MockWorker_DropIndex_Call struct {
+	*mock.Call
+}
+
+// DropIndex is a helper method to define mock.On call
+//   - ctx context.Context
+//   - req *querypb.DropIndexRequest
+func (_e *MockWorker_Expecter) DropIndex(ctx interface{}, req interface{}) *MockWorker_DropIndex_Call {
+	return &MockWorker_DropIndex_Call{Call: _e.mock.On("DropIndex", ctx, req)}
+}
+
+func (_c *MockWorker_DropIndex_Call) Run(run func(ctx context.Context, req *querypb.DropIndexRequest)) *MockWorker_DropIndex_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*querypb.DropIndexRequest))
+	})
+	return _c
+}
+
+func (_c *MockWorker_DropIndex_Call) Return(_a0 error) *MockWorker_DropIndex_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockWorker_DropIndex_Call) RunAndReturn(run func(context.Context, *querypb.DropIndexRequest) error) *MockWorker_DropIndex_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetStatistics provides a mock function with given fields: ctx, req
 func (_m *MockWorker) GetStatistics(ctx context.Context, req *querypb.GetStatisticsRequest) (*internalpb.GetStatisticsResponse, error) {
 	ret := _m.Called(ctx, req)

--- a/internal/querynodev2/cluster/worker.go
+++ b/internal/querynodev2/cluster/worker.go
@@ -46,6 +46,7 @@ type Worker interface {
 	QueryStreamSegments(ctx context.Context, req *querypb.QueryRequest, srv streamrpc.QueryStreamServer) error
 	GetStatistics(ctx context.Context, req *querypb.GetStatisticsRequest) (*internalpb.GetStatisticsResponse, error)
 	UpdateSchema(ctx context.Context, req *querypb.UpdateSchemaRequest) (*commonpb.Status, error)
+	DropIndex(ctx context.Context, req *querypb.DropIndexRequest) error
 
 	IsHealthy() bool
 	Stop()
@@ -252,6 +253,15 @@ func (w *remoteWorker) GetStatistics(ctx context.Context, req *querypb.GetStatis
 func (w *remoteWorker) UpdateSchema(ctx context.Context, req *querypb.UpdateSchemaRequest) (*commonpb.Status, error) {
 	client := w.getClient()
 	return client.UpdateSchema(ctx, req)
+}
+
+func (w *remoteWorker) DropIndex(ctx context.Context, req *querypb.DropIndexRequest) error {
+	client := w.getClient()
+	status, err := client.DropIndex(ctx, req)
+	if err = merr.CheckRPCCall(status, err); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (w *remoteWorker) IsHealthy() bool {

--- a/internal/querynodev2/delegator/delegator.go
+++ b/internal/querynodev2/delegator/delegator.go
@@ -91,6 +91,7 @@ type ShardDelegator interface {
 	SyncTargetVersion(action *querypb.SyncAction, partitions []int64)
 	GetChannelQueryView() *channelQueryView
 	GetDeleteBufferSize() (entryNum int64, memorySize int64)
+	DropIndex(ctx context.Context, req *querypb.DropIndexRequest) error
 
 	// manage exclude segments
 	AddExcludedSegments(excludeInfo map[int64]uint64)

--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -991,3 +991,13 @@ func (sd *shardDelegator) buildBM25IDF(req *internalpb.SearchRequest) (float64, 
 	req.PlaceholderGroup = funcutil.SparseVectorDataToPlaceholderGroupBytes(idfSparseVector)
 	return avgdl, nil
 }
+
+func (sd *shardDelegator) DropIndex(ctx context.Context, req *querypb.DropIndexRequest) error {
+	workers := sd.workerManager.GetAllWorkers()
+	for _, worker := range workers {
+		if err := worker.DropIndex(ctx, req); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/querynodev2/delegator/mock_delegator.go
+++ b/internal/querynodev2/delegator/mock_delegator.go
@@ -140,6 +140,53 @@ func (_c *MockShardDelegator_Collection_Call) RunAndReturn(run func() int64) *Mo
 	return _c
 }
 
+// DropIndex provides a mock function with given fields: ctx, req
+func (_m *MockShardDelegator) DropIndex(ctx context.Context, req *querypb.DropIndexRequest) error {
+	ret := _m.Called(ctx, req)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DropIndex")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *querypb.DropIndexRequest) error); ok {
+		r0 = rf(ctx, req)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockShardDelegator_DropIndex_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DropIndex'
+type MockShardDelegator_DropIndex_Call struct {
+	*mock.Call
+}
+
+// DropIndex is a helper method to define mock.On call
+//   - ctx context.Context
+//   - req *querypb.DropIndexRequest
+func (_e *MockShardDelegator_Expecter) DropIndex(ctx interface{}, req interface{}) *MockShardDelegator_DropIndex_Call {
+	return &MockShardDelegator_DropIndex_Call{Call: _e.mock.On("DropIndex", ctx, req)}
+}
+
+func (_c *MockShardDelegator_DropIndex_Call) Run(run func(ctx context.Context, req *querypb.DropIndexRequest)) *MockShardDelegator_DropIndex_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*querypb.DropIndexRequest))
+	})
+	return _c
+}
+
+func (_c *MockShardDelegator_DropIndex_Call) Return(_a0 error) *MockShardDelegator_DropIndex_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockShardDelegator_DropIndex_Call) RunAndReturn(run func(context.Context, *querypb.DropIndexRequest) error) *MockShardDelegator_DropIndex_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetChannelQueryView provides a mock function with no fields
 func (_m *MockShardDelegator) GetChannelQueryView() *channelQueryView {
 	ret := _m.Called()

--- a/internal/querynodev2/local_worker.go
+++ b/internal/querynodev2/local_worker.go
@@ -82,5 +82,10 @@ func (w *LocalWorker) IsHealthy() bool {
 	return true
 }
 
+func (w *LocalWorker) DropIndex(ctx context.Context, req *querypb.DropIndexRequest) error {
+	status, err := w.node.DropIndex(ctx, req)
+	return merr.CheckRPCCall(status, err)
+}
+
 func (w *LocalWorker) Stop() {
 }

--- a/internal/querynodev2/segments/mock_segment.go
+++ b/internal/querynodev2/segments/mock_segment.go
@@ -270,6 +270,53 @@ func (_c *MockSegment_Delete_Call) RunAndReturn(run func(context.Context, storag
 	return _c
 }
 
+// DropIndex provides a mock function with given fields: ctx, indexID
+func (_m *MockSegment) DropIndex(ctx context.Context, indexID int64) error {
+	ret := _m.Called(ctx, indexID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DropIndex")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, int64) error); ok {
+		r0 = rf(ctx, indexID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockSegment_DropIndex_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DropIndex'
+type MockSegment_DropIndex_Call struct {
+	*mock.Call
+}
+
+// DropIndex is a helper method to define mock.On call
+//   - ctx context.Context
+//   - indexID int64
+func (_e *MockSegment_Expecter) DropIndex(ctx interface{}, indexID interface{}) *MockSegment_DropIndex_Call {
+	return &MockSegment_DropIndex_Call{Call: _e.mock.On("DropIndex", ctx, indexID)}
+}
+
+func (_c *MockSegment_DropIndex_Call) Run(run func(ctx context.Context, indexID int64)) *MockSegment_DropIndex_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(int64))
+	})
+	return _c
+}
+
+func (_c *MockSegment_DropIndex_Call) Return(_a0 error) *MockSegment_DropIndex_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockSegment_DropIndex_Call) RunAndReturn(run func(context.Context, int64) error) *MockSegment_DropIndex_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ExistIndex provides a mock function with given fields: fieldID
 func (_m *MockSegment) ExistIndex(fieldID int64) bool {
 	ret := _m.Called(fieldID)

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -509,6 +509,43 @@ func (s *LocalSegment) HasRawData(fieldID int64) bool {
 	return s.csegment.HasRawData(fieldID)
 }
 
+func (s *LocalSegment) HasFieldData(fieldID int64) bool {
+	if !s.ptrLock.PinIf(state.IsNotReleased) {
+		return false
+	}
+	defer s.ptrLock.Unpin()
+	return s.csegment.HasFieldData(fieldID)
+}
+
+func (s *LocalSegment) DropIndex(ctx context.Context, indexID int64) error {
+	if !s.ptrLock.PinIf(state.IsNotReleased) {
+		return merr.WrapErrSegmentNotLoaded(s.ID(), "segment released")
+	}
+	defer s.ptrLock.Unpin()
+
+	if indexInfo, ok := s.fieldIndexes.Get(indexID); ok {
+		field := typeutil.GetField(s.collection.schema.Load(), indexInfo.IndexInfo.FieldID)
+		if typeutil.IsJSONType(field.GetDataType()) {
+			nestedPath, err := funcutil.GetAttrByKeyFromRepeatedKV(common.JSONPathKey, indexInfo.IndexInfo.GetIndexParams())
+			if err != nil {
+				return err
+			}
+			err = s.csegment.DropJSONIndex(ctx, indexInfo.IndexInfo.FieldID, nestedPath)
+			if err != nil {
+				return err
+			}
+		} else {
+			err := s.csegment.DropIndex(ctx, indexInfo.IndexInfo.FieldID)
+			if err != nil {
+				return err
+			}
+		}
+
+		s.fieldIndexes.Remove(indexID)
+	}
+	return nil
+}
+
 func (s *LocalSegment) Indexes() []*IndexedFieldInfo {
 	var result []*IndexedFieldInfo
 	s.fieldIndexes.Range(func(key int64, value *IndexedFieldInfo) bool {
@@ -777,7 +814,7 @@ func (s *LocalSegment) LoadMultiFieldData(ctx context.Context) error {
 	return nil
 }
 
-func (s *LocalSegment) LoadFieldData(ctx context.Context, fieldID int64, rowCount int64, field *datapb.FieldBinlog) error {
+func (s *LocalSegment) LoadFieldData(ctx context.Context, fieldID int64, rowCount int64, field *datapb.FieldBinlog, warmupPolicy ...string) error {
 	if !s.ptrLock.PinIf(state.IsNotReleased) {
 		return merr.WrapErrSegmentNotLoaded(s.ID(), "segment released")
 	}
@@ -809,6 +846,10 @@ func (s *LocalSegment) LoadFieldData(ctx context.Context, fieldID int64, rowCoun
 		}},
 		RowCount:       rowCount,
 		StorageVersion: s.LoadInfo().GetStorageVersion(),
+	}
+
+	if len(warmupPolicy) > 0 {
+		req.WarmupPolicy = warmupPolicy[0]
 	}
 
 	GetLoadPool().Submit(func() (any, error) {

--- a/internal/querynodev2/segments/segment_interface.go
+++ b/internal/querynodev2/segments/segment_interface.go
@@ -77,6 +77,7 @@ type Segment interface {
 	ExistIndex(fieldID int64) bool
 	Indexes() []*IndexedFieldInfo
 	HasRawData(fieldID int64) bool
+	DropIndex(ctx context.Context, indexID int64) error
 
 	// Modification related
 	Insert(ctx context.Context, rowIDs []int64, timestamps []typeutil.Timestamp, record *segcorepb.InsertRecord) error

--- a/internal/querynodev2/segments/segment_l0.go
+++ b/internal/querynodev2/segments/segment_l0.go
@@ -121,6 +121,10 @@ func (s *L0Segment) HasRawData(fieldID int64) bool {
 	return false
 }
 
+func (s *L0Segment) DropIndex(ctx context.Context, indexID int64) error {
+	return nil
+}
+
 func (s *L0Segment) Indexes() []*IndexedFieldInfo {
 	return nil
 }

--- a/internal/util/mock/grpc_querynode_client.go
+++ b/internal/util/mock/grpc_querynode_client.go
@@ -145,3 +145,7 @@ func (m *GrpcQueryNodeClient) RunAnalyzer(ctx context.Context, in *querypb.RunAn
 func (m *GrpcQueryNodeClient) Close() error {
 	return m.Err
 }
+
+func (m *GrpcQueryNodeClient) DropIndex(ctx context.Context, in *querypb.DropIndexRequest, opts ...grpc.CallOption) (*commonpb.Status, error) {
+	return &commonpb.Status{}, m.Err
+}

--- a/internal/util/segcore/segment.go
+++ b/internal/util/segcore/segment.go
@@ -101,6 +101,12 @@ func (s *cSegmentImpl) HasRawData(fieldID int64) bool {
 	return bool(ret)
 }
 
+// HasFieldData checks if the segment has field data.
+func (s *cSegmentImpl) HasFieldData(fieldID int64) bool {
+	ret := C.HasFieldData(s.ptr, C.int64_t(fieldID))
+	return bool(ret)
+}
+
 // Search requests a search on the segment.
 func (s *cSegmentImpl) Search(ctx context.Context, searchReq *SearchRequest) (*SearchResult, error) {
 	traceCtx := ParseCTraceContext(ctx)
@@ -287,6 +293,22 @@ func (s *cSegmentImpl) FinishLoad() error {
 	status := C.FinishLoad(s.ptr)
 	if err := ConsumeCStatusIntoError(&status); err != nil {
 		return errors.Wrap(err, "failed to finish load segment")
+	}
+	return nil
+}
+
+func (s *cSegmentImpl) DropIndex(ctx context.Context, fieldID int64) error {
+	status := C.DropSealedSegmentIndex(s.ptr, C.int64_t(fieldID))
+	if err := ConsumeCStatusIntoError(&status); err != nil {
+		return errors.Wrap(err, "failed to drop index")
+	}
+	return nil
+}
+
+func (s *cSegmentImpl) DropJSONIndex(ctx context.Context, fieldID int64, nestedPath string) error {
+	status := C.DropSealedSegmentJSONIndex(s.ptr, C.int64_t(fieldID), C.CString(nestedPath))
+	if err := ConsumeCStatusIntoError(&status); err != nil {
+		return errors.Wrap(err, "failed to drop json index")
 	}
 	return nil
 }

--- a/internal/util/segcore/segment_interface.go
+++ b/internal/util/segcore/segment_interface.go
@@ -37,6 +37,11 @@ type SealedSegment interface {
 
 	// AddFieldDataInfo adds field data info into the segment.
 	AddFieldDataInfo(ctx context.Context, request *AddFieldDataInfoRequest) (*AddFieldDataInfoResult, error)
+
+	// DropIndex drops the index of the segment.
+	DropIndex(ctx context.Context, fieldID int64) error
+
+	DropJSONIndex(ctx context.Context, fieldID int64, nestedPath string) error
 }
 
 // basicSegmentMethodSet is the basic method set of a segment.
@@ -56,6 +61,9 @@ type basicSegmentMethodSet interface {
 
 	// HasRawData checks if the segment has raw data.
 	HasRawData(fieldID int64) bool
+
+	// HasFieldData checks if the segment has field data.
+	HasFieldData(fieldID int64) bool
 
 	// Search requests a search on the segment.
 	Search(ctx context.Context, searchReq *SearchRequest) (*SearchResult, error)

--- a/internal/util/wrappers/qn_wrapper.go
+++ b/internal/util/wrappers/qn_wrapper.go
@@ -160,6 +160,10 @@ func (qn *qnServerWrapper) RunAnalyzer(ctx context.Context, in *querypb.RunAnaly
 	return qn.QueryNode.RunAnalyzer(ctx, in)
 }
 
+func (qn *qnServerWrapper) DropIndex(ctx context.Context, in *querypb.DropIndexRequest, opts ...grpc.CallOption) (*commonpb.Status, error) {
+	return qn.QueryNode.DropIndex(ctx, in)
+}
+
 func WrapQueryNodeServerAsClient(qn types.QueryNode) types.QueryNodeClient {
 	return &qnServerWrapper{
 		QueryNode: qn,

--- a/pkg/proto/query_coord.proto
+++ b/pkg/proto/query_coord.proto
@@ -171,6 +171,7 @@ service QueryNode {
     rpc UpdateSchema(UpdateSchemaRequest) returns (common.Status) {}
 
     rpc RunAnalyzer(RunAnalyzerRequest) returns(milvus.RunAnalyzerResponse){}
+    rpc DropIndex(DropIndexRequest) returns (common.Status) {}
 }
 
 // --------------------QueryCoord grpc request and response proto------------------
@@ -1000,4 +1001,11 @@ message ListLoadedSegmentsRequest {
 message ListLoadedSegmentsResponse {
     common.Status status = 1;
     repeated int64 segmentIDs = 2;
+}
+message DropIndexRequest {
+    common.MsgBase base = 1;
+    int64 segmentID = 2;
+    repeated int64 indexIDs = 3;
+    string channel = 4;
+    bool need_transfer = 5;
 }

--- a/pkg/proto/querypb/query_coord.pb.go
+++ b/pkg/proto/querypb/query_coord.pb.go
@@ -7731,6 +7731,85 @@ func (x *ListLoadedSegmentsResponse) GetSegmentIDs() []int64 {
 	return nil
 }
 
+type DropIndexRequest struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Base         *commonpb.MsgBase `protobuf:"bytes,1,opt,name=base,proto3" json:"base,omitempty"`
+	SegmentID    int64             `protobuf:"varint,2,opt,name=segmentID,proto3" json:"segmentID,omitempty"`
+	IndexIDs     []int64           `protobuf:"varint,3,rep,packed,name=indexIDs,proto3" json:"indexIDs,omitempty"`
+	Channel      string            `protobuf:"bytes,4,opt,name=channel,proto3" json:"channel,omitempty"`
+	NeedTransfer bool              `protobuf:"varint,5,opt,name=need_transfer,json=needTransfer,proto3" json:"need_transfer,omitempty"`
+}
+
+func (x *DropIndexRequest) Reset() {
+	*x = DropIndexRequest{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_query_coord_proto_msgTypes[92]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *DropIndexRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DropIndexRequest) ProtoMessage() {}
+
+func (x *DropIndexRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_query_coord_proto_msgTypes[92]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DropIndexRequest.ProtoReflect.Descriptor instead.
+func (*DropIndexRequest) Descriptor() ([]byte, []int) {
+	return file_query_coord_proto_rawDescGZIP(), []int{92}
+}
+
+func (x *DropIndexRequest) GetBase() *commonpb.MsgBase {
+	if x != nil {
+		return x.Base
+	}
+	return nil
+}
+
+func (x *DropIndexRequest) GetSegmentID() int64 {
+	if x != nil {
+		return x.SegmentID
+	}
+	return 0
+}
+
+func (x *DropIndexRequest) GetIndexIDs() []int64 {
+	if x != nil {
+		return x.IndexIDs
+	}
+	return nil
+}
+
+func (x *DropIndexRequest) GetChannel() string {
+	if x != nil {
+		return x.Channel
+	}
+	return ""
+}
+
+func (x *DropIndexRequest) GetNeedTransfer() bool {
+	if x != nil {
+		return x.NeedTransfer
+	}
+	return false
+}
+
 var File_query_coord_proto protoreflect.FileDescriptor
 
 var file_query_coord_proto_rawDesc = []byte{
@@ -9293,7 +9372,19 @@ var file_query_coord_proto_rawDesc = []byte{
 	0x75, 0x73, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x63, 0x6f, 0x6d, 0x6d, 0x6f, 0x6e, 0x2e,
 	0x53, 0x74, 0x61, 0x74, 0x75, 0x73, 0x52, 0x06, 0x73, 0x74, 0x61, 0x74, 0x75, 0x73, 0x12, 0x1e,
 	0x0a, 0x0a, 0x73, 0x65, 0x67, 0x6d, 0x65, 0x6e, 0x74, 0x49, 0x44, 0x73, 0x18, 0x02, 0x20, 0x03,
-	0x28, 0x03, 0x52, 0x0a, 0x73, 0x65, 0x67, 0x6d, 0x65, 0x6e, 0x74, 0x49, 0x44, 0x73, 0x2a, 0x36,
+	0x28, 0x03, 0x52, 0x0a, 0x73, 0x65, 0x67, 0x6d, 0x65, 0x6e, 0x74, 0x49, 0x44, 0x73, 0x22, 0xbd,
+	0x01, 0x0a, 0x10, 0x44, 0x72, 0x6f, 0x70, 0x49, 0x6e, 0x64, 0x65, 0x78, 0x52, 0x65, 0x71, 0x75,
+	0x65, 0x73, 0x74, 0x12, 0x30, 0x0a, 0x04, 0x62, 0x61, 0x73, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28,
+	0x0b, 0x32, 0x1c, 0x2e, 0x6d, 0x69, 0x6c, 0x76, 0x75, 0x73, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f,
+	0x2e, 0x63, 0x6f, 0x6d, 0x6d, 0x6f, 0x6e, 0x2e, 0x4d, 0x73, 0x67, 0x42, 0x61, 0x73, 0x65, 0x52,
+	0x04, 0x62, 0x61, 0x73, 0x65, 0x12, 0x1c, 0x0a, 0x09, 0x73, 0x65, 0x67, 0x6d, 0x65, 0x6e, 0x74,
+	0x49, 0x44, 0x18, 0x02, 0x20, 0x01, 0x28, 0x03, 0x52, 0x09, 0x73, 0x65, 0x67, 0x6d, 0x65, 0x6e,
+	0x74, 0x49, 0x44, 0x12, 0x1a, 0x0a, 0x08, 0x69, 0x6e, 0x64, 0x65, 0x78, 0x49, 0x44, 0x73, 0x18,
+	0x03, 0x20, 0x03, 0x28, 0x03, 0x52, 0x08, 0x69, 0x6e, 0x64, 0x65, 0x78, 0x49, 0x44, 0x73, 0x12,
+	0x18, 0x0a, 0x07, 0x63, 0x68, 0x61, 0x6e, 0x6e, 0x65, 0x6c, 0x18, 0x04, 0x20, 0x01, 0x28, 0x09,
+	0x52, 0x07, 0x63, 0x68, 0x61, 0x6e, 0x6e, 0x65, 0x6c, 0x12, 0x23, 0x0a, 0x0d, 0x6e, 0x65, 0x65,
+	0x64, 0x5f, 0x74, 0x72, 0x61, 0x6e, 0x73, 0x66, 0x65, 0x72, 0x18, 0x05, 0x20, 0x01, 0x28, 0x08,
+	0x52, 0x0c, 0x6e, 0x65, 0x65, 0x64, 0x54, 0x72, 0x61, 0x6e, 0x73, 0x66, 0x65, 0x72, 0x2a, 0x36,
 	0x0a, 0x09, 0x4c, 0x6f, 0x61, 0x64, 0x53, 0x63, 0x6f, 0x70, 0x65, 0x12, 0x08, 0x0a, 0x04, 0x46,
 	0x75, 0x6c, 0x6c, 0x10, 0x00, 0x12, 0x09, 0x0a, 0x05, 0x44, 0x65, 0x6c, 0x74, 0x61, 0x10, 0x01,
 	0x12, 0x09, 0x0a, 0x05, 0x49, 0x6e, 0x64, 0x65, 0x78, 0x10, 0x02, 0x12, 0x09, 0x0a, 0x05, 0x53,
@@ -9568,7 +9659,7 @@ var file_query_coord_proto_rawDesc = []byte{
 	0x71, 0x75, 0x65, 0x72, 0x79, 0x2e, 0x55, 0x70, 0x64, 0x61, 0x74, 0x65, 0x4c, 0x6f, 0x61, 0x64,
 	0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x1b, 0x2e,
 	0x6d, 0x69, 0x6c, 0x76, 0x75, 0x73, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x63, 0x6f, 0x6d,
-	0x6d, 0x6f, 0x6e, 0x2e, 0x53, 0x74, 0x61, 0x74, 0x75, 0x73, 0x22, 0x00, 0x32, 0xee, 0x14, 0x0a,
+	0x6d, 0x6f, 0x6e, 0x2e, 0x53, 0x74, 0x61, 0x74, 0x75, 0x73, 0x22, 0x00, 0x32, 0xc0, 0x15, 0x0a,
 	0x09, 0x51, 0x75, 0x65, 0x72, 0x79, 0x4e, 0x6f, 0x64, 0x65, 0x12, 0x6c, 0x0a, 0x12, 0x47, 0x65,
 	0x74, 0x43, 0x6f, 0x6d, 0x70, 0x6f, 0x6e, 0x65, 0x6e, 0x74, 0x53, 0x74, 0x61, 0x74, 0x65, 0x73,
 	0x12, 0x2e, 0x2e, 0x6d, 0x69, 0x6c, 0x76, 0x75, 0x73, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2e,
@@ -9735,11 +9826,16 @@ var file_query_coord_proto_rawDesc = []byte{
 	0x75, 0x6e, 0x41, 0x6e, 0x61, 0x6c, 0x79, 0x7a, 0x65, 0x72, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73,
 	0x74, 0x1a, 0x28, 0x2e, 0x6d, 0x69, 0x6c, 0x76, 0x75, 0x73, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f,
 	0x2e, 0x6d, 0x69, 0x6c, 0x76, 0x75, 0x73, 0x2e, 0x52, 0x75, 0x6e, 0x41, 0x6e, 0x61, 0x6c, 0x79,
-	0x7a, 0x65, 0x72, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x00, 0x42, 0x32, 0x5a,
-	0x30, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x6d, 0x69, 0x6c, 0x76,
-	0x75, 0x73, 0x2d, 0x69, 0x6f, 0x2f, 0x6d, 0x69, 0x6c, 0x76, 0x75, 0x73, 0x2f, 0x70, 0x6b, 0x67,
-	0x2f, 0x76, 0x32, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x71, 0x75, 0x65, 0x72, 0x79, 0x70,
-	0x62, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x7a, 0x65, 0x72, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x00, 0x12, 0x50, 0x0a,
+	0x09, 0x44, 0x72, 0x6f, 0x70, 0x49, 0x6e, 0x64, 0x65, 0x78, 0x12, 0x24, 0x2e, 0x6d, 0x69, 0x6c,
+	0x76, 0x75, 0x73, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x71, 0x75, 0x65, 0x72, 0x79, 0x2e,
+	0x44, 0x72, 0x6f, 0x70, 0x49, 0x6e, 0x64, 0x65, 0x78, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74,
+	0x1a, 0x1b, 0x2e, 0x6d, 0x69, 0x6c, 0x76, 0x75, 0x73, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2e,
+	0x63, 0x6f, 0x6d, 0x6d, 0x6f, 0x6e, 0x2e, 0x53, 0x74, 0x61, 0x74, 0x75, 0x73, 0x22, 0x00, 0x42,
+	0x32, 0x5a, 0x30, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x6d, 0x69,
+	0x6c, 0x76, 0x75, 0x73, 0x2d, 0x69, 0x6f, 0x2f, 0x6d, 0x69, 0x6c, 0x76, 0x75, 0x73, 0x2f, 0x70,
+	0x6b, 0x67, 0x2f, 0x76, 0x32, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x71, 0x75, 0x65, 0x72,
+	0x79, 0x70, 0x62, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (
@@ -9755,7 +9851,7 @@ func file_query_coord_proto_rawDescGZIP() []byte {
 }
 
 var file_query_coord_proto_enumTypes = make([]protoimpl.EnumInfo, 7)
-var file_query_coord_proto_msgTypes = make([]protoimpl.MessageInfo, 113)
+var file_query_coord_proto_msgTypes = make([]protoimpl.MessageInfo, 114)
 var file_query_coord_proto_goTypes = []interface{}{
 	(LoadScope)(0),                                 // 0: milvus.proto.query.LoadScope
 	(DataScope)(0),                                 // 1: milvus.proto.query.DataScope
@@ -9856,384 +9952,388 @@ var file_query_coord_proto_goTypes = []interface{}{
 	(*RunAnalyzerRequest)(nil),                     // 96: milvus.proto.query.RunAnalyzerRequest
 	(*ListLoadedSegmentsRequest)(nil),              // 97: milvus.proto.query.ListLoadedSegmentsRequest
 	(*ListLoadedSegmentsResponse)(nil),             // 98: milvus.proto.query.ListLoadedSegmentsResponse
-	nil,                                            // 99: milvus.proto.query.LoadCollectionRequest.FieldIndexIDEntry
-	nil,                                            // 100: milvus.proto.query.LoadPartitionsRequest.FieldIndexIDEntry
-	nil,                                            // 101: milvus.proto.query.UpdateResourceGroupsRequest.ResourceGroupsEntry
-	nil,                                            // 102: milvus.proto.query.WatchDmChannelsRequest.SegmentInfosEntry
-	nil,                                            // 103: milvus.proto.query.WatchDmChannelsRequest.SealedSegmentRowCountEntry
-	nil,                                            // 104: milvus.proto.query.SegmentLoadInfo.TextStatsLogsEntry
-	nil,                                            // 105: milvus.proto.query.SegmentLoadInfo.JsonKeyStatsLogsEntry
-	nil,                                            // 106: milvus.proto.query.GetDataDistributionRequest.CheckpointsEntry
-	nil,                                            // 107: milvus.proto.query.LeaderView.SegmentDistEntry
-	nil,                                            // 108: milvus.proto.query.LeaderView.GrowingSegmentsEntry
-	nil,                                            // 109: milvus.proto.query.LeaderView.PartitionStatsVersionsEntry
-	nil,                                            // 110: milvus.proto.query.SegmentVersionInfo.IndexInfoEntry
-	nil,                                            // 111: milvus.proto.query.SegmentVersionInfo.JsonStatsInfoEntry
-	nil,                                            // 112: milvus.proto.query.CollectionLoadInfo.FieldIndexIDEntry
-	nil,                                            // 113: milvus.proto.query.PartitionLoadInfo.FieldIndexIDEntry
-	nil,                                            // 114: milvus.proto.query.Replica.ChannelNodeInfosEntry
-	nil,                                            // 115: milvus.proto.query.SyncAction.PartitionStatsVersionsEntry
-	nil,                                            // 116: milvus.proto.query.SyncAction.SealedSegmentRowCountEntry
-	nil,                                            // 117: milvus.proto.query.ResourceGroupInfo.NumLoadedReplicaEntry
-	nil,                                            // 118: milvus.proto.query.ResourceGroupInfo.NumOutgoingNodeEntry
-	nil,                                            // 119: milvus.proto.query.ResourceGroupInfo.NumIncomingNodeEntry
-	(*commonpb.MsgBase)(nil),                       // 120: milvus.proto.common.MsgBase
-	(*commonpb.Status)(nil),                        // 121: milvus.proto.common.Status
-	(*schemapb.LongArray)(nil),                     // 122: milvus.proto.schema.LongArray
-	(*schemapb.CollectionSchema)(nil),              // 123: milvus.proto.schema.CollectionSchema
-	(commonpb.LoadPriority)(0),                     // 124: milvus.proto.common.LoadPriority
-	(*internalpb.GetStatisticsRequest)(nil),        // 125: milvus.proto.internal.GetStatisticsRequest
-	(*indexpb.IndexInfo)(nil),                      // 126: milvus.proto.index.IndexInfo
-	(*commonpb.KeyValuePair)(nil),                  // 127: milvus.proto.common.KeyValuePair
-	(*datapb.VchannelInfo)(nil),                    // 128: milvus.proto.data.VchannelInfo
-	(*datapb.SegmentInfo)(nil),                     // 129: milvus.proto.data.SegmentInfo
-	(*datapb.FieldBinlog)(nil),                     // 130: milvus.proto.data.FieldBinlog
-	(*msgpb.MsgPosition)(nil),                      // 131: milvus.proto.msg.MsgPosition
-	(datapb.SegmentLevel)(0),                       // 132: milvus.proto.data.SegmentLevel
-	(*internalpb.SearchRequest)(nil),               // 133: milvus.proto.internal.SearchRequest
-	(*internalpb.RetrieveRequest)(nil),             // 134: milvus.proto.internal.RetrieveRequest
-	(commonpb.SegmentState)(0),                     // 135: milvus.proto.common.SegmentState
-	(*rgpb.ResourceGroupConfig)(nil),               // 136: milvus.proto.rg.ResourceGroupConfig
-	(*commonpb.NodeInfo)(nil),                      // 137: milvus.proto.common.NodeInfo
-	(*schemapb.IDs)(nil),                           // 138: milvus.proto.schema.IDs
-	(*datapb.TextIndexStats)(nil),                  // 139: milvus.proto.data.TextIndexStats
-	(*datapb.JsonKeyStats)(nil),                    // 140: milvus.proto.data.JsonKeyStats
-	(*internalpb.ShowConfigurationsRequest)(nil),   // 141: milvus.proto.internal.ShowConfigurationsRequest
-	(*milvuspb.GetMetricsRequest)(nil),             // 142: milvus.proto.milvus.GetMetricsRequest
-	(*milvuspb.GetReplicasRequest)(nil),            // 143: milvus.proto.milvus.GetReplicasRequest
-	(*milvuspb.CheckHealthRequest)(nil),            // 144: milvus.proto.milvus.CheckHealthRequest
-	(*milvuspb.CreateResourceGroupRequest)(nil),    // 145: milvus.proto.milvus.CreateResourceGroupRequest
-	(*milvuspb.DropResourceGroupRequest)(nil),      // 146: milvus.proto.milvus.DropResourceGroupRequest
-	(*milvuspb.TransferNodeRequest)(nil),           // 147: milvus.proto.milvus.TransferNodeRequest
-	(*milvuspb.ListResourceGroupsRequest)(nil),     // 148: milvus.proto.milvus.ListResourceGroupsRequest
-	(*milvuspb.GetComponentStatesRequest)(nil),     // 149: milvus.proto.milvus.GetComponentStatesRequest
-	(*internalpb.GetTimeTickChannelRequest)(nil),   // 150: milvus.proto.internal.GetTimeTickChannelRequest
-	(*internalpb.GetStatisticsChannelRequest)(nil), // 151: milvus.proto.internal.GetStatisticsChannelRequest
-	(*internalpb.ShowConfigurationsResponse)(nil),  // 152: milvus.proto.internal.ShowConfigurationsResponse
-	(*milvuspb.GetMetricsResponse)(nil),            // 153: milvus.proto.milvus.GetMetricsResponse
-	(*milvuspb.GetReplicasResponse)(nil),           // 154: milvus.proto.milvus.GetReplicasResponse
-	(*milvuspb.CheckHealthResponse)(nil),           // 155: milvus.proto.milvus.CheckHealthResponse
-	(*milvuspb.ListResourceGroupsResponse)(nil),    // 156: milvus.proto.milvus.ListResourceGroupsResponse
-	(*milvuspb.ComponentStates)(nil),               // 157: milvus.proto.milvus.ComponentStates
-	(*milvuspb.StringResponse)(nil),                // 158: milvus.proto.milvus.StringResponse
-	(*internalpb.GetStatisticsResponse)(nil),       // 159: milvus.proto.internal.GetStatisticsResponse
-	(*internalpb.SearchResults)(nil),               // 160: milvus.proto.internal.SearchResults
-	(*internalpb.RetrieveResults)(nil),             // 161: milvus.proto.internal.RetrieveResults
-	(*milvuspb.RunAnalyzerResponse)(nil),           // 162: milvus.proto.milvus.RunAnalyzerResponse
+	(*DropIndexRequest)(nil),                       // 99: milvus.proto.query.DropIndexRequest
+	nil,                                            // 100: milvus.proto.query.LoadCollectionRequest.FieldIndexIDEntry
+	nil,                                            // 101: milvus.proto.query.LoadPartitionsRequest.FieldIndexIDEntry
+	nil,                                            // 102: milvus.proto.query.UpdateResourceGroupsRequest.ResourceGroupsEntry
+	nil,                                            // 103: milvus.proto.query.WatchDmChannelsRequest.SegmentInfosEntry
+	nil,                                            // 104: milvus.proto.query.WatchDmChannelsRequest.SealedSegmentRowCountEntry
+	nil,                                            // 105: milvus.proto.query.SegmentLoadInfo.TextStatsLogsEntry
+	nil,                                            // 106: milvus.proto.query.SegmentLoadInfo.JsonKeyStatsLogsEntry
+	nil,                                            // 107: milvus.proto.query.GetDataDistributionRequest.CheckpointsEntry
+	nil,                                            // 108: milvus.proto.query.LeaderView.SegmentDistEntry
+	nil,                                            // 109: milvus.proto.query.LeaderView.GrowingSegmentsEntry
+	nil,                                            // 110: milvus.proto.query.LeaderView.PartitionStatsVersionsEntry
+	nil,                                            // 111: milvus.proto.query.SegmentVersionInfo.IndexInfoEntry
+	nil,                                            // 112: milvus.proto.query.SegmentVersionInfo.JsonStatsInfoEntry
+	nil,                                            // 113: milvus.proto.query.CollectionLoadInfo.FieldIndexIDEntry
+	nil,                                            // 114: milvus.proto.query.PartitionLoadInfo.FieldIndexIDEntry
+	nil,                                            // 115: milvus.proto.query.Replica.ChannelNodeInfosEntry
+	nil,                                            // 116: milvus.proto.query.SyncAction.PartitionStatsVersionsEntry
+	nil,                                            // 117: milvus.proto.query.SyncAction.SealedSegmentRowCountEntry
+	nil,                                            // 118: milvus.proto.query.ResourceGroupInfo.NumLoadedReplicaEntry
+	nil,                                            // 119: milvus.proto.query.ResourceGroupInfo.NumOutgoingNodeEntry
+	nil,                                            // 120: milvus.proto.query.ResourceGroupInfo.NumIncomingNodeEntry
+	(*commonpb.MsgBase)(nil),                       // 121: milvus.proto.common.MsgBase
+	(*commonpb.Status)(nil),                        // 122: milvus.proto.common.Status
+	(*schemapb.LongArray)(nil),                     // 123: milvus.proto.schema.LongArray
+	(*schemapb.CollectionSchema)(nil),              // 124: milvus.proto.schema.CollectionSchema
+	(commonpb.LoadPriority)(0),                     // 125: milvus.proto.common.LoadPriority
+	(*internalpb.GetStatisticsRequest)(nil),        // 126: milvus.proto.internal.GetStatisticsRequest
+	(*indexpb.IndexInfo)(nil),                      // 127: milvus.proto.index.IndexInfo
+	(*commonpb.KeyValuePair)(nil),                  // 128: milvus.proto.common.KeyValuePair
+	(*datapb.VchannelInfo)(nil),                    // 129: milvus.proto.data.VchannelInfo
+	(*datapb.SegmentInfo)(nil),                     // 130: milvus.proto.data.SegmentInfo
+	(*datapb.FieldBinlog)(nil),                     // 131: milvus.proto.data.FieldBinlog
+	(*msgpb.MsgPosition)(nil),                      // 132: milvus.proto.msg.MsgPosition
+	(datapb.SegmentLevel)(0),                       // 133: milvus.proto.data.SegmentLevel
+	(*internalpb.SearchRequest)(nil),               // 134: milvus.proto.internal.SearchRequest
+	(*internalpb.RetrieveRequest)(nil),             // 135: milvus.proto.internal.RetrieveRequest
+	(commonpb.SegmentState)(0),                     // 136: milvus.proto.common.SegmentState
+	(*rgpb.ResourceGroupConfig)(nil),               // 137: milvus.proto.rg.ResourceGroupConfig
+	(*commonpb.NodeInfo)(nil),                      // 138: milvus.proto.common.NodeInfo
+	(*schemapb.IDs)(nil),                           // 139: milvus.proto.schema.IDs
+	(*datapb.TextIndexStats)(nil),                  // 140: milvus.proto.data.TextIndexStats
+	(*datapb.JsonKeyStats)(nil),                    // 141: milvus.proto.data.JsonKeyStats
+	(*internalpb.ShowConfigurationsRequest)(nil),   // 142: milvus.proto.internal.ShowConfigurationsRequest
+	(*milvuspb.GetMetricsRequest)(nil),             // 143: milvus.proto.milvus.GetMetricsRequest
+	(*milvuspb.GetReplicasRequest)(nil),            // 144: milvus.proto.milvus.GetReplicasRequest
+	(*milvuspb.CheckHealthRequest)(nil),            // 145: milvus.proto.milvus.CheckHealthRequest
+	(*milvuspb.CreateResourceGroupRequest)(nil),    // 146: milvus.proto.milvus.CreateResourceGroupRequest
+	(*milvuspb.DropResourceGroupRequest)(nil),      // 147: milvus.proto.milvus.DropResourceGroupRequest
+	(*milvuspb.TransferNodeRequest)(nil),           // 148: milvus.proto.milvus.TransferNodeRequest
+	(*milvuspb.ListResourceGroupsRequest)(nil),     // 149: milvus.proto.milvus.ListResourceGroupsRequest
+	(*milvuspb.GetComponentStatesRequest)(nil),     // 150: milvus.proto.milvus.GetComponentStatesRequest
+	(*internalpb.GetTimeTickChannelRequest)(nil),   // 151: milvus.proto.internal.GetTimeTickChannelRequest
+	(*internalpb.GetStatisticsChannelRequest)(nil), // 152: milvus.proto.internal.GetStatisticsChannelRequest
+	(*internalpb.ShowConfigurationsResponse)(nil),  // 153: milvus.proto.internal.ShowConfigurationsResponse
+	(*milvuspb.GetMetricsResponse)(nil),            // 154: milvus.proto.milvus.GetMetricsResponse
+	(*milvuspb.GetReplicasResponse)(nil),           // 155: milvus.proto.milvus.GetReplicasResponse
+	(*milvuspb.CheckHealthResponse)(nil),           // 156: milvus.proto.milvus.CheckHealthResponse
+	(*milvuspb.ListResourceGroupsResponse)(nil),    // 157: milvus.proto.milvus.ListResourceGroupsResponse
+	(*milvuspb.ComponentStates)(nil),               // 158: milvus.proto.milvus.ComponentStates
+	(*milvuspb.StringResponse)(nil),                // 159: milvus.proto.milvus.StringResponse
+	(*internalpb.GetStatisticsResponse)(nil),       // 160: milvus.proto.internal.GetStatisticsResponse
+	(*internalpb.SearchResults)(nil),               // 161: milvus.proto.internal.SearchResults
+	(*internalpb.RetrieveResults)(nil),             // 162: milvus.proto.internal.RetrieveResults
+	(*milvuspb.RunAnalyzerResponse)(nil),           // 163: milvus.proto.milvus.RunAnalyzerResponse
 }
 var file_query_coord_proto_depIdxs = []int32{
-	120, // 0: milvus.proto.query.ShowCollectionsRequest.base:type_name -> milvus.proto.common.MsgBase
-	121, // 1: milvus.proto.query.ShowCollectionsResponse.status:type_name -> milvus.proto.common.Status
-	122, // 2: milvus.proto.query.ShowCollectionsResponse.load_fields:type_name -> milvus.proto.schema.LongArray
-	120, // 3: milvus.proto.query.ShowPartitionsRequest.base:type_name -> milvus.proto.common.MsgBase
-	121, // 4: milvus.proto.query.ShowPartitionsResponse.status:type_name -> milvus.proto.common.Status
-	120, // 5: milvus.proto.query.LoadCollectionRequest.base:type_name -> milvus.proto.common.MsgBase
-	123, // 6: milvus.proto.query.LoadCollectionRequest.schema:type_name -> milvus.proto.schema.CollectionSchema
-	99,  // 7: milvus.proto.query.LoadCollectionRequest.field_indexID:type_name -> milvus.proto.query.LoadCollectionRequest.FieldIndexIDEntry
-	124, // 8: milvus.proto.query.LoadCollectionRequest.priority:type_name -> milvus.proto.common.LoadPriority
-	120, // 9: milvus.proto.query.ReleaseCollectionRequest.base:type_name -> milvus.proto.common.MsgBase
-	125, // 10: milvus.proto.query.GetStatisticsRequest.req:type_name -> milvus.proto.internal.GetStatisticsRequest
+	121, // 0: milvus.proto.query.ShowCollectionsRequest.base:type_name -> milvus.proto.common.MsgBase
+	122, // 1: milvus.proto.query.ShowCollectionsResponse.status:type_name -> milvus.proto.common.Status
+	123, // 2: milvus.proto.query.ShowCollectionsResponse.load_fields:type_name -> milvus.proto.schema.LongArray
+	121, // 3: milvus.proto.query.ShowPartitionsRequest.base:type_name -> milvus.proto.common.MsgBase
+	122, // 4: milvus.proto.query.ShowPartitionsResponse.status:type_name -> milvus.proto.common.Status
+	121, // 5: milvus.proto.query.LoadCollectionRequest.base:type_name -> milvus.proto.common.MsgBase
+	124, // 6: milvus.proto.query.LoadCollectionRequest.schema:type_name -> milvus.proto.schema.CollectionSchema
+	100, // 7: milvus.proto.query.LoadCollectionRequest.field_indexID:type_name -> milvus.proto.query.LoadCollectionRequest.FieldIndexIDEntry
+	125, // 8: milvus.proto.query.LoadCollectionRequest.priority:type_name -> milvus.proto.common.LoadPriority
+	121, // 9: milvus.proto.query.ReleaseCollectionRequest.base:type_name -> milvus.proto.common.MsgBase
+	126, // 10: milvus.proto.query.GetStatisticsRequest.req:type_name -> milvus.proto.internal.GetStatisticsRequest
 	1,   // 11: milvus.proto.query.GetStatisticsRequest.scope:type_name -> milvus.proto.query.DataScope
-	120, // 12: milvus.proto.query.LoadPartitionsRequest.base:type_name -> milvus.proto.common.MsgBase
-	123, // 13: milvus.proto.query.LoadPartitionsRequest.schema:type_name -> milvus.proto.schema.CollectionSchema
-	100, // 14: milvus.proto.query.LoadPartitionsRequest.field_indexID:type_name -> milvus.proto.query.LoadPartitionsRequest.FieldIndexIDEntry
-	126, // 15: milvus.proto.query.LoadPartitionsRequest.index_info_list:type_name -> milvus.proto.index.IndexInfo
-	124, // 16: milvus.proto.query.LoadPartitionsRequest.priority:type_name -> milvus.proto.common.LoadPriority
-	120, // 17: milvus.proto.query.ReleasePartitionsRequest.base:type_name -> milvus.proto.common.MsgBase
-	120, // 18: milvus.proto.query.GetPartitionStatesRequest.base:type_name -> milvus.proto.common.MsgBase
-	121, // 19: milvus.proto.query.GetPartitionStatesResponse.status:type_name -> milvus.proto.common.Status
+	121, // 12: milvus.proto.query.LoadPartitionsRequest.base:type_name -> milvus.proto.common.MsgBase
+	124, // 13: milvus.proto.query.LoadPartitionsRequest.schema:type_name -> milvus.proto.schema.CollectionSchema
+	101, // 14: milvus.proto.query.LoadPartitionsRequest.field_indexID:type_name -> milvus.proto.query.LoadPartitionsRequest.FieldIndexIDEntry
+	127, // 15: milvus.proto.query.LoadPartitionsRequest.index_info_list:type_name -> milvus.proto.index.IndexInfo
+	125, // 16: milvus.proto.query.LoadPartitionsRequest.priority:type_name -> milvus.proto.common.LoadPriority
+	121, // 17: milvus.proto.query.ReleasePartitionsRequest.base:type_name -> milvus.proto.common.MsgBase
+	121, // 18: milvus.proto.query.GetPartitionStatesRequest.base:type_name -> milvus.proto.common.MsgBase
+	122, // 19: milvus.proto.query.GetPartitionStatesResponse.status:type_name -> milvus.proto.common.Status
 	43,  // 20: milvus.proto.query.GetPartitionStatesResponse.partition_descriptions:type_name -> milvus.proto.query.PartitionStates
-	120, // 21: milvus.proto.query.GetSegmentInfoRequest.base:type_name -> milvus.proto.common.MsgBase
-	121, // 22: milvus.proto.query.GetSegmentInfoResponse.status:type_name -> milvus.proto.common.Status
+	121, // 21: milvus.proto.query.GetSegmentInfoRequest.base:type_name -> milvus.proto.common.MsgBase
+	122, // 22: milvus.proto.query.GetSegmentInfoResponse.status:type_name -> milvus.proto.common.Status
 	44,  // 23: milvus.proto.query.GetSegmentInfoResponse.infos:type_name -> milvus.proto.query.SegmentInfo
-	120, // 24: milvus.proto.query.GetShardLeadersRequest.base:type_name -> milvus.proto.common.MsgBase
-	121, // 25: milvus.proto.query.GetShardLeadersResponse.status:type_name -> milvus.proto.common.Status
+	121, // 24: milvus.proto.query.GetShardLeadersRequest.base:type_name -> milvus.proto.common.MsgBase
+	122, // 25: milvus.proto.query.GetShardLeadersResponse.status:type_name -> milvus.proto.common.Status
 	23,  // 26: milvus.proto.query.GetShardLeadersResponse.shards:type_name -> milvus.proto.query.ShardLeadersList
-	120, // 27: milvus.proto.query.UpdateResourceGroupsRequest.base:type_name -> milvus.proto.common.MsgBase
-	101, // 28: milvus.proto.query.UpdateResourceGroupsRequest.resource_groups:type_name -> milvus.proto.query.UpdateResourceGroupsRequest.ResourceGroupsEntry
-	120, // 29: milvus.proto.query.SyncNewCreatedPartitionRequest.base:type_name -> milvus.proto.common.MsgBase
+	121, // 27: milvus.proto.query.UpdateResourceGroupsRequest.base:type_name -> milvus.proto.common.MsgBase
+	102, // 28: milvus.proto.query.UpdateResourceGroupsRequest.resource_groups:type_name -> milvus.proto.query.UpdateResourceGroupsRequest.ResourceGroupsEntry
+	121, // 29: milvus.proto.query.SyncNewCreatedPartitionRequest.base:type_name -> milvus.proto.common.MsgBase
 	4,   // 30: milvus.proto.query.LoadMetaInfo.load_type:type_name -> milvus.proto.query.LoadType
-	127, // 31: milvus.proto.query.LoadMetaInfo.db_properties:type_name -> milvus.proto.common.KeyValuePair
-	120, // 32: milvus.proto.query.WatchDmChannelsRequest.base:type_name -> milvus.proto.common.MsgBase
-	128, // 33: milvus.proto.query.WatchDmChannelsRequest.infos:type_name -> milvus.proto.data.VchannelInfo
-	123, // 34: milvus.proto.query.WatchDmChannelsRequest.schema:type_name -> milvus.proto.schema.CollectionSchema
-	129, // 35: milvus.proto.query.WatchDmChannelsRequest.exclude_infos:type_name -> milvus.proto.data.SegmentInfo
+	128, // 31: milvus.proto.query.LoadMetaInfo.db_properties:type_name -> milvus.proto.common.KeyValuePair
+	121, // 32: milvus.proto.query.WatchDmChannelsRequest.base:type_name -> milvus.proto.common.MsgBase
+	129, // 33: milvus.proto.query.WatchDmChannelsRequest.infos:type_name -> milvus.proto.data.VchannelInfo
+	124, // 34: milvus.proto.query.WatchDmChannelsRequest.schema:type_name -> milvus.proto.schema.CollectionSchema
+	130, // 35: milvus.proto.query.WatchDmChannelsRequest.exclude_infos:type_name -> milvus.proto.data.SegmentInfo
 	25,  // 36: milvus.proto.query.WatchDmChannelsRequest.load_meta:type_name -> milvus.proto.query.LoadMetaInfo
-	102, // 37: milvus.proto.query.WatchDmChannelsRequest.segment_infos:type_name -> milvus.proto.query.WatchDmChannelsRequest.SegmentInfosEntry
-	126, // 38: milvus.proto.query.WatchDmChannelsRequest.index_info_list:type_name -> milvus.proto.index.IndexInfo
-	103, // 39: milvus.proto.query.WatchDmChannelsRequest.sealed_segment_row_count:type_name -> milvus.proto.query.WatchDmChannelsRequest.SealedSegmentRowCountEntry
-	120, // 40: milvus.proto.query.UnsubDmChannelRequest.base:type_name -> milvus.proto.common.MsgBase
-	130, // 41: milvus.proto.query.SegmentLoadInfo.binlog_paths:type_name -> milvus.proto.data.FieldBinlog
-	130, // 42: milvus.proto.query.SegmentLoadInfo.statslogs:type_name -> milvus.proto.data.FieldBinlog
-	130, // 43: milvus.proto.query.SegmentLoadInfo.deltalogs:type_name -> milvus.proto.data.FieldBinlog
+	103, // 37: milvus.proto.query.WatchDmChannelsRequest.segment_infos:type_name -> milvus.proto.query.WatchDmChannelsRequest.SegmentInfosEntry
+	127, // 38: milvus.proto.query.WatchDmChannelsRequest.index_info_list:type_name -> milvus.proto.index.IndexInfo
+	104, // 39: milvus.proto.query.WatchDmChannelsRequest.sealed_segment_row_count:type_name -> milvus.proto.query.WatchDmChannelsRequest.SealedSegmentRowCountEntry
+	121, // 40: milvus.proto.query.UnsubDmChannelRequest.base:type_name -> milvus.proto.common.MsgBase
+	131, // 41: milvus.proto.query.SegmentLoadInfo.binlog_paths:type_name -> milvus.proto.data.FieldBinlog
+	131, // 42: milvus.proto.query.SegmentLoadInfo.statslogs:type_name -> milvus.proto.data.FieldBinlog
+	131, // 43: milvus.proto.query.SegmentLoadInfo.deltalogs:type_name -> milvus.proto.data.FieldBinlog
 	29,  // 44: milvus.proto.query.SegmentLoadInfo.index_infos:type_name -> milvus.proto.query.FieldIndexInfo
-	131, // 45: milvus.proto.query.SegmentLoadInfo.start_position:type_name -> milvus.proto.msg.MsgPosition
-	131, // 46: milvus.proto.query.SegmentLoadInfo.delta_position:type_name -> milvus.proto.msg.MsgPosition
-	132, // 47: milvus.proto.query.SegmentLoadInfo.level:type_name -> milvus.proto.data.SegmentLevel
-	104, // 48: milvus.proto.query.SegmentLoadInfo.textStatsLogs:type_name -> milvus.proto.query.SegmentLoadInfo.TextStatsLogsEntry
-	130, // 49: milvus.proto.query.SegmentLoadInfo.bm25logs:type_name -> milvus.proto.data.FieldBinlog
-	105, // 50: milvus.proto.query.SegmentLoadInfo.jsonKeyStatsLogs:type_name -> milvus.proto.query.SegmentLoadInfo.JsonKeyStatsLogsEntry
-	124, // 51: milvus.proto.query.SegmentLoadInfo.priority:type_name -> milvus.proto.common.LoadPriority
-	127, // 52: milvus.proto.query.FieldIndexInfo.index_params:type_name -> milvus.proto.common.KeyValuePair
-	120, // 53: milvus.proto.query.LoadSegmentsRequest.base:type_name -> milvus.proto.common.MsgBase
+	132, // 45: milvus.proto.query.SegmentLoadInfo.start_position:type_name -> milvus.proto.msg.MsgPosition
+	132, // 46: milvus.proto.query.SegmentLoadInfo.delta_position:type_name -> milvus.proto.msg.MsgPosition
+	133, // 47: milvus.proto.query.SegmentLoadInfo.level:type_name -> milvus.proto.data.SegmentLevel
+	105, // 48: milvus.proto.query.SegmentLoadInfo.textStatsLogs:type_name -> milvus.proto.query.SegmentLoadInfo.TextStatsLogsEntry
+	131, // 49: milvus.proto.query.SegmentLoadInfo.bm25logs:type_name -> milvus.proto.data.FieldBinlog
+	106, // 50: milvus.proto.query.SegmentLoadInfo.jsonKeyStatsLogs:type_name -> milvus.proto.query.SegmentLoadInfo.JsonKeyStatsLogsEntry
+	125, // 51: milvus.proto.query.SegmentLoadInfo.priority:type_name -> milvus.proto.common.LoadPriority
+	128, // 52: milvus.proto.query.FieldIndexInfo.index_params:type_name -> milvus.proto.common.KeyValuePair
+	121, // 53: milvus.proto.query.LoadSegmentsRequest.base:type_name -> milvus.proto.common.MsgBase
 	28,  // 54: milvus.proto.query.LoadSegmentsRequest.infos:type_name -> milvus.proto.query.SegmentLoadInfo
-	123, // 55: milvus.proto.query.LoadSegmentsRequest.schema:type_name -> milvus.proto.schema.CollectionSchema
+	124, // 55: milvus.proto.query.LoadSegmentsRequest.schema:type_name -> milvus.proto.schema.CollectionSchema
 	25,  // 56: milvus.proto.query.LoadSegmentsRequest.load_meta:type_name -> milvus.proto.query.LoadMetaInfo
-	131, // 57: milvus.proto.query.LoadSegmentsRequest.delta_positions:type_name -> milvus.proto.msg.MsgPosition
+	132, // 57: milvus.proto.query.LoadSegmentsRequest.delta_positions:type_name -> milvus.proto.msg.MsgPosition
 	0,   // 58: milvus.proto.query.LoadSegmentsRequest.load_scope:type_name -> milvus.proto.query.LoadScope
-	126, // 59: milvus.proto.query.LoadSegmentsRequest.index_info_list:type_name -> milvus.proto.index.IndexInfo
-	120, // 60: milvus.proto.query.ReleaseSegmentsRequest.base:type_name -> milvus.proto.common.MsgBase
+	127, // 59: milvus.proto.query.LoadSegmentsRequest.index_info_list:type_name -> milvus.proto.index.IndexInfo
+	121, // 60: milvus.proto.query.ReleaseSegmentsRequest.base:type_name -> milvus.proto.common.MsgBase
 	1,   // 61: milvus.proto.query.ReleaseSegmentsRequest.scope:type_name -> milvus.proto.query.DataScope
-	131, // 62: milvus.proto.query.ReleaseSegmentsRequest.checkpoint:type_name -> milvus.proto.msg.MsgPosition
-	133, // 63: milvus.proto.query.SearchRequest.req:type_name -> milvus.proto.internal.SearchRequest
+	132, // 62: milvus.proto.query.ReleaseSegmentsRequest.checkpoint:type_name -> milvus.proto.msg.MsgPosition
+	134, // 63: milvus.proto.query.SearchRequest.req:type_name -> milvus.proto.internal.SearchRequest
 	1,   // 64: milvus.proto.query.SearchRequest.scope:type_name -> milvus.proto.query.DataScope
-	134, // 65: milvus.proto.query.QueryRequest.req:type_name -> milvus.proto.internal.RetrieveRequest
+	135, // 65: milvus.proto.query.QueryRequest.req:type_name -> milvus.proto.internal.RetrieveRequest
 	1,   // 66: milvus.proto.query.QueryRequest.scope:type_name -> milvus.proto.query.DataScope
-	120, // 67: milvus.proto.query.SyncReplicaSegmentsRequest.base:type_name -> milvus.proto.common.MsgBase
+	121, // 67: milvus.proto.query.SyncReplicaSegmentsRequest.base:type_name -> milvus.proto.common.MsgBase
 	36,  // 68: milvus.proto.query.SyncReplicaSegmentsRequest.replica_segments:type_name -> milvus.proto.query.ReplicaSegmentsInfo
-	120, // 69: milvus.proto.query.GetLoadInfoRequest.base:type_name -> milvus.proto.common.MsgBase
-	121, // 70: milvus.proto.query.GetLoadInfoResponse.status:type_name -> milvus.proto.common.Status
-	123, // 71: milvus.proto.query.GetLoadInfoResponse.schema:type_name -> milvus.proto.schema.CollectionSchema
+	121, // 69: milvus.proto.query.GetLoadInfoRequest.base:type_name -> milvus.proto.common.MsgBase
+	122, // 70: milvus.proto.query.GetLoadInfoResponse.status:type_name -> milvus.proto.common.Status
+	124, // 71: milvus.proto.query.GetLoadInfoResponse.schema:type_name -> milvus.proto.schema.CollectionSchema
 	4,   // 72: milvus.proto.query.GetLoadInfoResponse.load_type:type_name -> milvus.proto.query.LoadType
-	120, // 73: milvus.proto.query.HandoffSegmentsRequest.base:type_name -> milvus.proto.common.MsgBase
+	121, // 73: milvus.proto.query.HandoffSegmentsRequest.base:type_name -> milvus.proto.common.MsgBase
 	44,  // 74: milvus.proto.query.HandoffSegmentsRequest.segmentInfos:type_name -> milvus.proto.query.SegmentInfo
-	120, // 75: milvus.proto.query.LoadBalanceRequest.base:type_name -> milvus.proto.common.MsgBase
+	121, // 75: milvus.proto.query.LoadBalanceRequest.base:type_name -> milvus.proto.common.MsgBase
 	3,   // 76: milvus.proto.query.LoadBalanceRequest.balance_reason:type_name -> milvus.proto.query.TriggerCondition
 	44,  // 77: milvus.proto.query.QueryChannelInfo.global_sealed_segments:type_name -> milvus.proto.query.SegmentInfo
-	131, // 78: milvus.proto.query.QueryChannelInfo.seek_position:type_name -> milvus.proto.msg.MsgPosition
+	132, // 78: milvus.proto.query.QueryChannelInfo.seek_position:type_name -> milvus.proto.msg.MsgPosition
 	2,   // 79: milvus.proto.query.PartitionStates.state:type_name -> milvus.proto.query.PartitionState
-	135, // 80: milvus.proto.query.SegmentInfo.segment_state:type_name -> milvus.proto.common.SegmentState
+	136, // 80: milvus.proto.query.SegmentInfo.segment_state:type_name -> milvus.proto.common.SegmentState
 	29,  // 81: milvus.proto.query.SegmentInfo.index_infos:type_name -> milvus.proto.query.FieldIndexInfo
-	132, // 82: milvus.proto.query.SegmentInfo.level:type_name -> milvus.proto.data.SegmentLevel
+	133, // 82: milvus.proto.query.SegmentInfo.level:type_name -> milvus.proto.data.SegmentLevel
 	43,  // 83: milvus.proto.query.CollectionInfo.partition_states:type_name -> milvus.proto.query.PartitionStates
 	4,   // 84: milvus.proto.query.CollectionInfo.load_type:type_name -> milvus.proto.query.LoadType
-	123, // 85: milvus.proto.query.CollectionInfo.schema:type_name -> milvus.proto.schema.CollectionSchema
+	124, // 85: milvus.proto.query.CollectionInfo.schema:type_name -> milvus.proto.schema.CollectionSchema
 	46,  // 86: milvus.proto.query.UnsubscribeChannelInfo.collection_channels:type_name -> milvus.proto.query.UnsubscribeChannels
 	44,  // 87: milvus.proto.query.SegmentChangeInfo.online_segments:type_name -> milvus.proto.query.SegmentInfo
 	44,  // 88: milvus.proto.query.SegmentChangeInfo.offline_segments:type_name -> milvus.proto.query.SegmentInfo
-	120, // 89: milvus.proto.query.SealedSegmentsChangeInfo.base:type_name -> milvus.proto.common.MsgBase
+	121, // 89: milvus.proto.query.SealedSegmentsChangeInfo.base:type_name -> milvus.proto.common.MsgBase
 	48,  // 90: milvus.proto.query.SealedSegmentsChangeInfo.infos:type_name -> milvus.proto.query.SegmentChangeInfo
-	120, // 91: milvus.proto.query.GetDataDistributionRequest.base:type_name -> milvus.proto.common.MsgBase
-	106, // 92: milvus.proto.query.GetDataDistributionRequest.checkpoints:type_name -> milvus.proto.query.GetDataDistributionRequest.CheckpointsEntry
-	121, // 93: milvus.proto.query.GetDataDistributionResponse.status:type_name -> milvus.proto.common.Status
+	121, // 91: milvus.proto.query.GetDataDistributionRequest.base:type_name -> milvus.proto.common.MsgBase
+	107, // 92: milvus.proto.query.GetDataDistributionRequest.checkpoints:type_name -> milvus.proto.query.GetDataDistributionRequest.CheckpointsEntry
+	122, // 93: milvus.proto.query.GetDataDistributionResponse.status:type_name -> milvus.proto.common.Status
 	55,  // 94: milvus.proto.query.GetDataDistributionResponse.segments:type_name -> milvus.proto.query.SegmentVersionInfo
 	56,  // 95: milvus.proto.query.GetDataDistributionResponse.channels:type_name -> milvus.proto.query.ChannelVersionInfo
 	52,  // 96: milvus.proto.query.GetDataDistributionResponse.leader_views:type_name -> milvus.proto.query.LeaderView
-	107, // 97: milvus.proto.query.LeaderView.segment_dist:type_name -> milvus.proto.query.LeaderView.SegmentDistEntry
-	108, // 98: milvus.proto.query.LeaderView.growing_segments:type_name -> milvus.proto.query.LeaderView.GrowingSegmentsEntry
-	109, // 99: milvus.proto.query.LeaderView.partition_stats_versions:type_name -> milvus.proto.query.LeaderView.PartitionStatsVersionsEntry
+	108, // 97: milvus.proto.query.LeaderView.segment_dist:type_name -> milvus.proto.query.LeaderView.SegmentDistEntry
+	109, // 98: milvus.proto.query.LeaderView.growing_segments:type_name -> milvus.proto.query.LeaderView.GrowingSegmentsEntry
+	110, // 99: milvus.proto.query.LeaderView.partition_stats_versions:type_name -> milvus.proto.query.LeaderView.PartitionStatsVersionsEntry
 	53,  // 100: milvus.proto.query.LeaderView.status:type_name -> milvus.proto.query.LeaderViewStatus
-	110, // 101: milvus.proto.query.SegmentVersionInfo.index_info:type_name -> milvus.proto.query.SegmentVersionInfo.IndexInfoEntry
-	132, // 102: milvus.proto.query.SegmentVersionInfo.level:type_name -> milvus.proto.data.SegmentLevel
-	111, // 103: milvus.proto.query.SegmentVersionInfo.json_stats_info:type_name -> milvus.proto.query.SegmentVersionInfo.JsonStatsInfoEntry
+	111, // 101: milvus.proto.query.SegmentVersionInfo.index_info:type_name -> milvus.proto.query.SegmentVersionInfo.IndexInfoEntry
+	133, // 102: milvus.proto.query.SegmentVersionInfo.level:type_name -> milvus.proto.data.SegmentLevel
+	112, // 103: milvus.proto.query.SegmentVersionInfo.json_stats_info:type_name -> milvus.proto.query.SegmentVersionInfo.JsonStatsInfoEntry
 	5,   // 104: milvus.proto.query.CollectionLoadInfo.status:type_name -> milvus.proto.query.LoadStatus
-	112, // 105: milvus.proto.query.CollectionLoadInfo.field_indexID:type_name -> milvus.proto.query.CollectionLoadInfo.FieldIndexIDEntry
+	113, // 105: milvus.proto.query.CollectionLoadInfo.field_indexID:type_name -> milvus.proto.query.CollectionLoadInfo.FieldIndexIDEntry
 	4,   // 106: milvus.proto.query.CollectionLoadInfo.load_type:type_name -> milvus.proto.query.LoadType
 	5,   // 107: milvus.proto.query.PartitionLoadInfo.status:type_name -> milvus.proto.query.LoadStatus
-	113, // 108: milvus.proto.query.PartitionLoadInfo.field_indexID:type_name -> milvus.proto.query.PartitionLoadInfo.FieldIndexIDEntry
-	114, // 109: milvus.proto.query.Replica.channel_node_infos:type_name -> milvus.proto.query.Replica.ChannelNodeInfosEntry
+	114, // 108: milvus.proto.query.PartitionLoadInfo.field_indexID:type_name -> milvus.proto.query.PartitionLoadInfo.FieldIndexIDEntry
+	115, // 109: milvus.proto.query.Replica.channel_node_infos:type_name -> milvus.proto.query.Replica.ChannelNodeInfosEntry
 	6,   // 110: milvus.proto.query.SyncAction.type:type_name -> milvus.proto.query.SyncType
 	28,  // 111: milvus.proto.query.SyncAction.info:type_name -> milvus.proto.query.SegmentLoadInfo
-	131, // 112: milvus.proto.query.SyncAction.checkpoint:type_name -> milvus.proto.msg.MsgPosition
-	115, // 113: milvus.proto.query.SyncAction.partition_stats_versions:type_name -> milvus.proto.query.SyncAction.PartitionStatsVersionsEntry
-	131, // 114: milvus.proto.query.SyncAction.deleteCP:type_name -> milvus.proto.msg.MsgPosition
-	116, // 115: milvus.proto.query.SyncAction.sealed_segment_row_count:type_name -> milvus.proto.query.SyncAction.SealedSegmentRowCountEntry
-	120, // 116: milvus.proto.query.SyncDistributionRequest.base:type_name -> milvus.proto.common.MsgBase
+	132, // 112: milvus.proto.query.SyncAction.checkpoint:type_name -> milvus.proto.msg.MsgPosition
+	116, // 113: milvus.proto.query.SyncAction.partition_stats_versions:type_name -> milvus.proto.query.SyncAction.PartitionStatsVersionsEntry
+	132, // 114: milvus.proto.query.SyncAction.deleteCP:type_name -> milvus.proto.msg.MsgPosition
+	117, // 115: milvus.proto.query.SyncAction.sealed_segment_row_count:type_name -> milvus.proto.query.SyncAction.SealedSegmentRowCountEntry
+	121, // 116: milvus.proto.query.SyncDistributionRequest.base:type_name -> milvus.proto.common.MsgBase
 	61,  // 117: milvus.proto.query.SyncDistributionRequest.actions:type_name -> milvus.proto.query.SyncAction
-	123, // 118: milvus.proto.query.SyncDistributionRequest.schema:type_name -> milvus.proto.schema.CollectionSchema
+	124, // 118: milvus.proto.query.SyncDistributionRequest.schema:type_name -> milvus.proto.schema.CollectionSchema
 	25,  // 119: milvus.proto.query.SyncDistributionRequest.load_meta:type_name -> milvus.proto.query.LoadMetaInfo
-	126, // 120: milvus.proto.query.SyncDistributionRequest.index_info_list:type_name -> milvus.proto.index.IndexInfo
-	136, // 121: milvus.proto.query.ResourceGroup.config:type_name -> milvus.proto.rg.ResourceGroupConfig
-	120, // 122: milvus.proto.query.TransferReplicaRequest.base:type_name -> milvus.proto.common.MsgBase
-	120, // 123: milvus.proto.query.DescribeResourceGroupRequest.base:type_name -> milvus.proto.common.MsgBase
-	121, // 124: milvus.proto.query.DescribeResourceGroupResponse.status:type_name -> milvus.proto.common.Status
+	127, // 120: milvus.proto.query.SyncDistributionRequest.index_info_list:type_name -> milvus.proto.index.IndexInfo
+	137, // 121: milvus.proto.query.ResourceGroup.config:type_name -> milvus.proto.rg.ResourceGroupConfig
+	121, // 122: milvus.proto.query.TransferReplicaRequest.base:type_name -> milvus.proto.common.MsgBase
+	121, // 123: milvus.proto.query.DescribeResourceGroupRequest.base:type_name -> milvus.proto.common.MsgBase
+	122, // 124: milvus.proto.query.DescribeResourceGroupResponse.status:type_name -> milvus.proto.common.Status
 	67,  // 125: milvus.proto.query.DescribeResourceGroupResponse.resource_group:type_name -> milvus.proto.query.ResourceGroupInfo
-	117, // 126: milvus.proto.query.ResourceGroupInfo.num_loaded_replica:type_name -> milvus.proto.query.ResourceGroupInfo.NumLoadedReplicaEntry
-	118, // 127: milvus.proto.query.ResourceGroupInfo.num_outgoing_node:type_name -> milvus.proto.query.ResourceGroupInfo.NumOutgoingNodeEntry
-	119, // 128: milvus.proto.query.ResourceGroupInfo.num_incoming_node:type_name -> milvus.proto.query.ResourceGroupInfo.NumIncomingNodeEntry
-	136, // 129: milvus.proto.query.ResourceGroupInfo.config:type_name -> milvus.proto.rg.ResourceGroupConfig
-	137, // 130: milvus.proto.query.ResourceGroupInfo.nodes:type_name -> milvus.proto.common.NodeInfo
-	120, // 131: milvus.proto.query.DeleteRequest.base:type_name -> milvus.proto.common.MsgBase
-	138, // 132: milvus.proto.query.DeleteRequest.primary_keys:type_name -> milvus.proto.schema.IDs
+	118, // 126: milvus.proto.query.ResourceGroupInfo.num_loaded_replica:type_name -> milvus.proto.query.ResourceGroupInfo.NumLoadedReplicaEntry
+	119, // 127: milvus.proto.query.ResourceGroupInfo.num_outgoing_node:type_name -> milvus.proto.query.ResourceGroupInfo.NumOutgoingNodeEntry
+	120, // 128: milvus.proto.query.ResourceGroupInfo.num_incoming_node:type_name -> milvus.proto.query.ResourceGroupInfo.NumIncomingNodeEntry
+	137, // 129: milvus.proto.query.ResourceGroupInfo.config:type_name -> milvus.proto.rg.ResourceGroupConfig
+	138, // 130: milvus.proto.query.ResourceGroupInfo.nodes:type_name -> milvus.proto.common.NodeInfo
+	121, // 131: milvus.proto.query.DeleteRequest.base:type_name -> milvus.proto.common.MsgBase
+	139, // 132: milvus.proto.query.DeleteRequest.primary_keys:type_name -> milvus.proto.schema.IDs
 	1,   // 133: milvus.proto.query.DeleteRequest.scope:type_name -> milvus.proto.query.DataScope
-	120, // 134: milvus.proto.query.DeleteBatchRequest.base:type_name -> milvus.proto.common.MsgBase
-	138, // 135: milvus.proto.query.DeleteBatchRequest.primary_keys:type_name -> milvus.proto.schema.IDs
+	121, // 134: milvus.proto.query.DeleteBatchRequest.base:type_name -> milvus.proto.common.MsgBase
+	139, // 135: milvus.proto.query.DeleteBatchRequest.primary_keys:type_name -> milvus.proto.schema.IDs
 	1,   // 136: milvus.proto.query.DeleteBatchRequest.scope:type_name -> milvus.proto.query.DataScope
-	121, // 137: milvus.proto.query.DeleteBatchResponse.status:type_name -> milvus.proto.common.Status
-	120, // 138: milvus.proto.query.ActivateCheckerRequest.base:type_name -> milvus.proto.common.MsgBase
-	120, // 139: milvus.proto.query.DeactivateCheckerRequest.base:type_name -> milvus.proto.common.MsgBase
-	120, // 140: milvus.proto.query.ListCheckersRequest.base:type_name -> milvus.proto.common.MsgBase
-	121, // 141: milvus.proto.query.ListCheckersResponse.status:type_name -> milvus.proto.common.Status
+	122, // 137: milvus.proto.query.DeleteBatchResponse.status:type_name -> milvus.proto.common.Status
+	121, // 138: milvus.proto.query.ActivateCheckerRequest.base:type_name -> milvus.proto.common.MsgBase
+	121, // 139: milvus.proto.query.DeactivateCheckerRequest.base:type_name -> milvus.proto.common.MsgBase
+	121, // 140: milvus.proto.query.ListCheckersRequest.base:type_name -> milvus.proto.common.MsgBase
+	122, // 141: milvus.proto.query.ListCheckersResponse.status:type_name -> milvus.proto.common.Status
 	75,  // 142: milvus.proto.query.ListCheckersResponse.checkerInfos:type_name -> milvus.proto.query.CheckerInfo
-	132, // 143: milvus.proto.query.SegmentTarget.level:type_name -> milvus.proto.data.SegmentLevel
+	133, // 143: milvus.proto.query.SegmentTarget.level:type_name -> milvus.proto.data.SegmentLevel
 	76,  // 144: milvus.proto.query.PartitionTarget.segments:type_name -> milvus.proto.query.SegmentTarget
 	77,  // 145: milvus.proto.query.ChannelTarget.partition_targets:type_name -> milvus.proto.query.PartitionTarget
-	131, // 146: milvus.proto.query.ChannelTarget.seek_position:type_name -> milvus.proto.msg.MsgPosition
-	131, // 147: milvus.proto.query.ChannelTarget.delete_checkpoint:type_name -> milvus.proto.msg.MsgPosition
+	132, // 146: milvus.proto.query.ChannelTarget.seek_position:type_name -> milvus.proto.msg.MsgPosition
+	132, // 147: milvus.proto.query.ChannelTarget.delete_checkpoint:type_name -> milvus.proto.msg.MsgPosition
 	78,  // 148: milvus.proto.query.CollectionTarget.Channel_targets:type_name -> milvus.proto.query.ChannelTarget
-	120, // 149: milvus.proto.query.ListQueryNodeRequest.base:type_name -> milvus.proto.common.MsgBase
-	121, // 150: milvus.proto.query.ListQueryNodeResponse.status:type_name -> milvus.proto.common.Status
+	121, // 149: milvus.proto.query.ListQueryNodeRequest.base:type_name -> milvus.proto.common.MsgBase
+	122, // 150: milvus.proto.query.ListQueryNodeResponse.status:type_name -> milvus.proto.common.Status
 	80,  // 151: milvus.proto.query.ListQueryNodeResponse.nodeInfos:type_name -> milvus.proto.query.NodeInfo
-	120, // 152: milvus.proto.query.GetQueryNodeDistributionRequest.base:type_name -> milvus.proto.common.MsgBase
-	121, // 153: milvus.proto.query.GetQueryNodeDistributionResponse.status:type_name -> milvus.proto.common.Status
-	120, // 154: milvus.proto.query.SuspendBalanceRequest.base:type_name -> milvus.proto.common.MsgBase
-	120, // 155: milvus.proto.query.ResumeBalanceRequest.base:type_name -> milvus.proto.common.MsgBase
-	120, // 156: milvus.proto.query.CheckBalanceStatusRequest.base:type_name -> milvus.proto.common.MsgBase
-	121, // 157: milvus.proto.query.CheckBalanceStatusResponse.status:type_name -> milvus.proto.common.Status
-	120, // 158: milvus.proto.query.SuspendNodeRequest.base:type_name -> milvus.proto.common.MsgBase
-	120, // 159: milvus.proto.query.ResumeNodeRequest.base:type_name -> milvus.proto.common.MsgBase
-	120, // 160: milvus.proto.query.TransferSegmentRequest.base:type_name -> milvus.proto.common.MsgBase
-	120, // 161: milvus.proto.query.TransferChannelRequest.base:type_name -> milvus.proto.common.MsgBase
-	120, // 162: milvus.proto.query.CheckQueryNodeDistributionRequest.base:type_name -> milvus.proto.common.MsgBase
-	120, // 163: milvus.proto.query.UpdateLoadConfigRequest.base:type_name -> milvus.proto.common.MsgBase
-	120, // 164: milvus.proto.query.UpdateSchemaRequest.base:type_name -> milvus.proto.common.MsgBase
-	123, // 165: milvus.proto.query.UpdateSchemaRequest.schema:type_name -> milvus.proto.schema.CollectionSchema
-	120, // 166: milvus.proto.query.RunAnalyzerRequest.base:type_name -> milvus.proto.common.MsgBase
-	120, // 167: milvus.proto.query.ListLoadedSegmentsRequest.base:type_name -> milvus.proto.common.MsgBase
-	121, // 168: milvus.proto.query.ListLoadedSegmentsResponse.status:type_name -> milvus.proto.common.Status
-	136, // 169: milvus.proto.query.UpdateResourceGroupsRequest.ResourceGroupsEntry.value:type_name -> milvus.proto.rg.ResourceGroupConfig
-	129, // 170: milvus.proto.query.WatchDmChannelsRequest.SegmentInfosEntry.value:type_name -> milvus.proto.data.SegmentInfo
-	139, // 171: milvus.proto.query.SegmentLoadInfo.TextStatsLogsEntry.value:type_name -> milvus.proto.data.TextIndexStats
-	140, // 172: milvus.proto.query.SegmentLoadInfo.JsonKeyStatsLogsEntry.value:type_name -> milvus.proto.data.JsonKeyStats
-	131, // 173: milvus.proto.query.GetDataDistributionRequest.CheckpointsEntry.value:type_name -> milvus.proto.msg.MsgPosition
-	54,  // 174: milvus.proto.query.LeaderView.SegmentDistEntry.value:type_name -> milvus.proto.query.SegmentDist
-	131, // 175: milvus.proto.query.LeaderView.GrowingSegmentsEntry.value:type_name -> milvus.proto.msg.MsgPosition
-	29,  // 176: milvus.proto.query.SegmentVersionInfo.IndexInfoEntry.value:type_name -> milvus.proto.query.FieldIndexInfo
-	30,  // 177: milvus.proto.query.SegmentVersionInfo.JsonStatsInfoEntry.value:type_name -> milvus.proto.query.JsonStatsInfo
-	59,  // 178: milvus.proto.query.Replica.ChannelNodeInfosEntry.value:type_name -> milvus.proto.query.ChannelNodeInfo
-	7,   // 179: milvus.proto.query.QueryCoord.ShowLoadCollections:input_type -> milvus.proto.query.ShowCollectionsRequest
-	9,   // 180: milvus.proto.query.QueryCoord.ShowLoadPartitions:input_type -> milvus.proto.query.ShowPartitionsRequest
-	14,  // 181: milvus.proto.query.QueryCoord.LoadPartitions:input_type -> milvus.proto.query.LoadPartitionsRequest
-	15,  // 182: milvus.proto.query.QueryCoord.ReleasePartitions:input_type -> milvus.proto.query.ReleasePartitionsRequest
-	11,  // 183: milvus.proto.query.QueryCoord.LoadCollection:input_type -> milvus.proto.query.LoadCollectionRequest
-	12,  // 184: milvus.proto.query.QueryCoord.ReleaseCollection:input_type -> milvus.proto.query.ReleaseCollectionRequest
-	24,  // 185: milvus.proto.query.QueryCoord.SyncNewCreatedPartition:input_type -> milvus.proto.query.SyncNewCreatedPartitionRequest
-	16,  // 186: milvus.proto.query.QueryCoord.GetPartitionStates:input_type -> milvus.proto.query.GetPartitionStatesRequest
-	18,  // 187: milvus.proto.query.QueryCoord.GetLoadSegmentInfo:input_type -> milvus.proto.query.GetSegmentInfoRequest
-	40,  // 188: milvus.proto.query.QueryCoord.LoadBalance:input_type -> milvus.proto.query.LoadBalanceRequest
-	141, // 189: milvus.proto.query.QueryCoord.ShowConfigurations:input_type -> milvus.proto.internal.ShowConfigurationsRequest
-	142, // 190: milvus.proto.query.QueryCoord.GetMetrics:input_type -> milvus.proto.milvus.GetMetricsRequest
-	143, // 191: milvus.proto.query.QueryCoord.GetReplicas:input_type -> milvus.proto.milvus.GetReplicasRequest
-	20,  // 192: milvus.proto.query.QueryCoord.GetShardLeaders:input_type -> milvus.proto.query.GetShardLeadersRequest
-	144, // 193: milvus.proto.query.QueryCoord.CheckHealth:input_type -> milvus.proto.milvus.CheckHealthRequest
-	145, // 194: milvus.proto.query.QueryCoord.CreateResourceGroup:input_type -> milvus.proto.milvus.CreateResourceGroupRequest
-	22,  // 195: milvus.proto.query.QueryCoord.UpdateResourceGroups:input_type -> milvus.proto.query.UpdateResourceGroupsRequest
-	146, // 196: milvus.proto.query.QueryCoord.DropResourceGroup:input_type -> milvus.proto.milvus.DropResourceGroupRequest
-	147, // 197: milvus.proto.query.QueryCoord.TransferNode:input_type -> milvus.proto.milvus.TransferNodeRequest
-	64,  // 198: milvus.proto.query.QueryCoord.TransferReplica:input_type -> milvus.proto.query.TransferReplicaRequest
-	148, // 199: milvus.proto.query.QueryCoord.ListResourceGroups:input_type -> milvus.proto.milvus.ListResourceGroupsRequest
-	65,  // 200: milvus.proto.query.QueryCoord.DescribeResourceGroup:input_type -> milvus.proto.query.DescribeResourceGroupRequest
-	97,  // 201: milvus.proto.query.QueryCoord.ListLoadedSegments:input_type -> milvus.proto.query.ListLoadedSegmentsRequest
-	73,  // 202: milvus.proto.query.QueryCoord.ListCheckers:input_type -> milvus.proto.query.ListCheckersRequest
-	71,  // 203: milvus.proto.query.QueryCoord.ActivateChecker:input_type -> milvus.proto.query.ActivateCheckerRequest
-	72,  // 204: milvus.proto.query.QueryCoord.DeactivateChecker:input_type -> milvus.proto.query.DeactivateCheckerRequest
-	81,  // 205: milvus.proto.query.QueryCoord.ListQueryNode:input_type -> milvus.proto.query.ListQueryNodeRequest
-	83,  // 206: milvus.proto.query.QueryCoord.GetQueryNodeDistribution:input_type -> milvus.proto.query.GetQueryNodeDistributionRequest
-	85,  // 207: milvus.proto.query.QueryCoord.SuspendBalance:input_type -> milvus.proto.query.SuspendBalanceRequest
-	86,  // 208: milvus.proto.query.QueryCoord.ResumeBalance:input_type -> milvus.proto.query.ResumeBalanceRequest
-	87,  // 209: milvus.proto.query.QueryCoord.CheckBalanceStatus:input_type -> milvus.proto.query.CheckBalanceStatusRequest
-	89,  // 210: milvus.proto.query.QueryCoord.SuspendNode:input_type -> milvus.proto.query.SuspendNodeRequest
-	90,  // 211: milvus.proto.query.QueryCoord.ResumeNode:input_type -> milvus.proto.query.ResumeNodeRequest
-	91,  // 212: milvus.proto.query.QueryCoord.TransferSegment:input_type -> milvus.proto.query.TransferSegmentRequest
-	92,  // 213: milvus.proto.query.QueryCoord.TransferChannel:input_type -> milvus.proto.query.TransferChannelRequest
-	93,  // 214: milvus.proto.query.QueryCoord.CheckQueryNodeDistribution:input_type -> milvus.proto.query.CheckQueryNodeDistributionRequest
-	94,  // 215: milvus.proto.query.QueryCoord.UpdateLoadConfig:input_type -> milvus.proto.query.UpdateLoadConfigRequest
-	149, // 216: milvus.proto.query.QueryNode.GetComponentStates:input_type -> milvus.proto.milvus.GetComponentStatesRequest
-	150, // 217: milvus.proto.query.QueryNode.GetTimeTickChannel:input_type -> milvus.proto.internal.GetTimeTickChannelRequest
-	151, // 218: milvus.proto.query.QueryNode.GetStatisticsChannel:input_type -> milvus.proto.internal.GetStatisticsChannelRequest
-	26,  // 219: milvus.proto.query.QueryNode.WatchDmChannels:input_type -> milvus.proto.query.WatchDmChannelsRequest
-	27,  // 220: milvus.proto.query.QueryNode.UnsubDmChannel:input_type -> milvus.proto.query.UnsubDmChannelRequest
-	31,  // 221: milvus.proto.query.QueryNode.LoadSegments:input_type -> milvus.proto.query.LoadSegmentsRequest
-	12,  // 222: milvus.proto.query.QueryNode.ReleaseCollection:input_type -> milvus.proto.query.ReleaseCollectionRequest
-	14,  // 223: milvus.proto.query.QueryNode.LoadPartitions:input_type -> milvus.proto.query.LoadPartitionsRequest
-	15,  // 224: milvus.proto.query.QueryNode.ReleasePartitions:input_type -> milvus.proto.query.ReleasePartitionsRequest
-	32,  // 225: milvus.proto.query.QueryNode.ReleaseSegments:input_type -> milvus.proto.query.ReleaseSegmentsRequest
-	18,  // 226: milvus.proto.query.QueryNode.GetSegmentInfo:input_type -> milvus.proto.query.GetSegmentInfoRequest
-	35,  // 227: milvus.proto.query.QueryNode.SyncReplicaSegments:input_type -> milvus.proto.query.SyncReplicaSegmentsRequest
-	13,  // 228: milvus.proto.query.QueryNode.GetStatistics:input_type -> milvus.proto.query.GetStatisticsRequest
-	33,  // 229: milvus.proto.query.QueryNode.Search:input_type -> milvus.proto.query.SearchRequest
-	33,  // 230: milvus.proto.query.QueryNode.SearchSegments:input_type -> milvus.proto.query.SearchRequest
-	34,  // 231: milvus.proto.query.QueryNode.Query:input_type -> milvus.proto.query.QueryRequest
-	34,  // 232: milvus.proto.query.QueryNode.QueryStream:input_type -> milvus.proto.query.QueryRequest
-	34,  // 233: milvus.proto.query.QueryNode.QuerySegments:input_type -> milvus.proto.query.QueryRequest
-	34,  // 234: milvus.proto.query.QueryNode.QueryStreamSegments:input_type -> milvus.proto.query.QueryRequest
-	141, // 235: milvus.proto.query.QueryNode.ShowConfigurations:input_type -> milvus.proto.internal.ShowConfigurationsRequest
-	142, // 236: milvus.proto.query.QueryNode.GetMetrics:input_type -> milvus.proto.milvus.GetMetricsRequest
-	50,  // 237: milvus.proto.query.QueryNode.GetDataDistribution:input_type -> milvus.proto.query.GetDataDistributionRequest
-	62,  // 238: milvus.proto.query.QueryNode.SyncDistribution:input_type -> milvus.proto.query.SyncDistributionRequest
-	68,  // 239: milvus.proto.query.QueryNode.Delete:input_type -> milvus.proto.query.DeleteRequest
-	69,  // 240: milvus.proto.query.QueryNode.DeleteBatch:input_type -> milvus.proto.query.DeleteBatchRequest
-	95,  // 241: milvus.proto.query.QueryNode.UpdateSchema:input_type -> milvus.proto.query.UpdateSchemaRequest
-	96,  // 242: milvus.proto.query.QueryNode.RunAnalyzer:input_type -> milvus.proto.query.RunAnalyzerRequest
-	8,   // 243: milvus.proto.query.QueryCoord.ShowLoadCollections:output_type -> milvus.proto.query.ShowCollectionsResponse
-	10,  // 244: milvus.proto.query.QueryCoord.ShowLoadPartitions:output_type -> milvus.proto.query.ShowPartitionsResponse
-	121, // 245: milvus.proto.query.QueryCoord.LoadPartitions:output_type -> milvus.proto.common.Status
-	121, // 246: milvus.proto.query.QueryCoord.ReleasePartitions:output_type -> milvus.proto.common.Status
-	121, // 247: milvus.proto.query.QueryCoord.LoadCollection:output_type -> milvus.proto.common.Status
-	121, // 248: milvus.proto.query.QueryCoord.ReleaseCollection:output_type -> milvus.proto.common.Status
-	121, // 249: milvus.proto.query.QueryCoord.SyncNewCreatedPartition:output_type -> milvus.proto.common.Status
-	17,  // 250: milvus.proto.query.QueryCoord.GetPartitionStates:output_type -> milvus.proto.query.GetPartitionStatesResponse
-	19,  // 251: milvus.proto.query.QueryCoord.GetLoadSegmentInfo:output_type -> milvus.proto.query.GetSegmentInfoResponse
-	121, // 252: milvus.proto.query.QueryCoord.LoadBalance:output_type -> milvus.proto.common.Status
-	152, // 253: milvus.proto.query.QueryCoord.ShowConfigurations:output_type -> milvus.proto.internal.ShowConfigurationsResponse
-	153, // 254: milvus.proto.query.QueryCoord.GetMetrics:output_type -> milvus.proto.milvus.GetMetricsResponse
-	154, // 255: milvus.proto.query.QueryCoord.GetReplicas:output_type -> milvus.proto.milvus.GetReplicasResponse
-	21,  // 256: milvus.proto.query.QueryCoord.GetShardLeaders:output_type -> milvus.proto.query.GetShardLeadersResponse
-	155, // 257: milvus.proto.query.QueryCoord.CheckHealth:output_type -> milvus.proto.milvus.CheckHealthResponse
-	121, // 258: milvus.proto.query.QueryCoord.CreateResourceGroup:output_type -> milvus.proto.common.Status
-	121, // 259: milvus.proto.query.QueryCoord.UpdateResourceGroups:output_type -> milvus.proto.common.Status
-	121, // 260: milvus.proto.query.QueryCoord.DropResourceGroup:output_type -> milvus.proto.common.Status
-	121, // 261: milvus.proto.query.QueryCoord.TransferNode:output_type -> milvus.proto.common.Status
-	121, // 262: milvus.proto.query.QueryCoord.TransferReplica:output_type -> milvus.proto.common.Status
-	156, // 263: milvus.proto.query.QueryCoord.ListResourceGroups:output_type -> milvus.proto.milvus.ListResourceGroupsResponse
-	66,  // 264: milvus.proto.query.QueryCoord.DescribeResourceGroup:output_type -> milvus.proto.query.DescribeResourceGroupResponse
-	98,  // 265: milvus.proto.query.QueryCoord.ListLoadedSegments:output_type -> milvus.proto.query.ListLoadedSegmentsResponse
-	74,  // 266: milvus.proto.query.QueryCoord.ListCheckers:output_type -> milvus.proto.query.ListCheckersResponse
-	121, // 267: milvus.proto.query.QueryCoord.ActivateChecker:output_type -> milvus.proto.common.Status
-	121, // 268: milvus.proto.query.QueryCoord.DeactivateChecker:output_type -> milvus.proto.common.Status
-	82,  // 269: milvus.proto.query.QueryCoord.ListQueryNode:output_type -> milvus.proto.query.ListQueryNodeResponse
-	84,  // 270: milvus.proto.query.QueryCoord.GetQueryNodeDistribution:output_type -> milvus.proto.query.GetQueryNodeDistributionResponse
-	121, // 271: milvus.proto.query.QueryCoord.SuspendBalance:output_type -> milvus.proto.common.Status
-	121, // 272: milvus.proto.query.QueryCoord.ResumeBalance:output_type -> milvus.proto.common.Status
-	88,  // 273: milvus.proto.query.QueryCoord.CheckBalanceStatus:output_type -> milvus.proto.query.CheckBalanceStatusResponse
-	121, // 274: milvus.proto.query.QueryCoord.SuspendNode:output_type -> milvus.proto.common.Status
-	121, // 275: milvus.proto.query.QueryCoord.ResumeNode:output_type -> milvus.proto.common.Status
-	121, // 276: milvus.proto.query.QueryCoord.TransferSegment:output_type -> milvus.proto.common.Status
-	121, // 277: milvus.proto.query.QueryCoord.TransferChannel:output_type -> milvus.proto.common.Status
-	121, // 278: milvus.proto.query.QueryCoord.CheckQueryNodeDistribution:output_type -> milvus.proto.common.Status
-	121, // 279: milvus.proto.query.QueryCoord.UpdateLoadConfig:output_type -> milvus.proto.common.Status
-	157, // 280: milvus.proto.query.QueryNode.GetComponentStates:output_type -> milvus.proto.milvus.ComponentStates
-	158, // 281: milvus.proto.query.QueryNode.GetTimeTickChannel:output_type -> milvus.proto.milvus.StringResponse
-	158, // 282: milvus.proto.query.QueryNode.GetStatisticsChannel:output_type -> milvus.proto.milvus.StringResponse
-	121, // 283: milvus.proto.query.QueryNode.WatchDmChannels:output_type -> milvus.proto.common.Status
-	121, // 284: milvus.proto.query.QueryNode.UnsubDmChannel:output_type -> milvus.proto.common.Status
-	121, // 285: milvus.proto.query.QueryNode.LoadSegments:output_type -> milvus.proto.common.Status
-	121, // 286: milvus.proto.query.QueryNode.ReleaseCollection:output_type -> milvus.proto.common.Status
-	121, // 287: milvus.proto.query.QueryNode.LoadPartitions:output_type -> milvus.proto.common.Status
-	121, // 288: milvus.proto.query.QueryNode.ReleasePartitions:output_type -> milvus.proto.common.Status
-	121, // 289: milvus.proto.query.QueryNode.ReleaseSegments:output_type -> milvus.proto.common.Status
-	19,  // 290: milvus.proto.query.QueryNode.GetSegmentInfo:output_type -> milvus.proto.query.GetSegmentInfoResponse
-	121, // 291: milvus.proto.query.QueryNode.SyncReplicaSegments:output_type -> milvus.proto.common.Status
-	159, // 292: milvus.proto.query.QueryNode.GetStatistics:output_type -> milvus.proto.internal.GetStatisticsResponse
-	160, // 293: milvus.proto.query.QueryNode.Search:output_type -> milvus.proto.internal.SearchResults
-	160, // 294: milvus.proto.query.QueryNode.SearchSegments:output_type -> milvus.proto.internal.SearchResults
-	161, // 295: milvus.proto.query.QueryNode.Query:output_type -> milvus.proto.internal.RetrieveResults
-	161, // 296: milvus.proto.query.QueryNode.QueryStream:output_type -> milvus.proto.internal.RetrieveResults
-	161, // 297: milvus.proto.query.QueryNode.QuerySegments:output_type -> milvus.proto.internal.RetrieveResults
-	161, // 298: milvus.proto.query.QueryNode.QueryStreamSegments:output_type -> milvus.proto.internal.RetrieveResults
-	152, // 299: milvus.proto.query.QueryNode.ShowConfigurations:output_type -> milvus.proto.internal.ShowConfigurationsResponse
-	153, // 300: milvus.proto.query.QueryNode.GetMetrics:output_type -> milvus.proto.milvus.GetMetricsResponse
-	51,  // 301: milvus.proto.query.QueryNode.GetDataDistribution:output_type -> milvus.proto.query.GetDataDistributionResponse
-	121, // 302: milvus.proto.query.QueryNode.SyncDistribution:output_type -> milvus.proto.common.Status
-	121, // 303: milvus.proto.query.QueryNode.Delete:output_type -> milvus.proto.common.Status
-	70,  // 304: milvus.proto.query.QueryNode.DeleteBatch:output_type -> milvus.proto.query.DeleteBatchResponse
-	121, // 305: milvus.proto.query.QueryNode.UpdateSchema:output_type -> milvus.proto.common.Status
-	162, // 306: milvus.proto.query.QueryNode.RunAnalyzer:output_type -> milvus.proto.milvus.RunAnalyzerResponse
-	243, // [243:307] is the sub-list for method output_type
-	179, // [179:243] is the sub-list for method input_type
-	179, // [179:179] is the sub-list for extension type_name
-	179, // [179:179] is the sub-list for extension extendee
-	0,   // [0:179] is the sub-list for field type_name
+	121, // 152: milvus.proto.query.GetQueryNodeDistributionRequest.base:type_name -> milvus.proto.common.MsgBase
+	122, // 153: milvus.proto.query.GetQueryNodeDistributionResponse.status:type_name -> milvus.proto.common.Status
+	121, // 154: milvus.proto.query.SuspendBalanceRequest.base:type_name -> milvus.proto.common.MsgBase
+	121, // 155: milvus.proto.query.ResumeBalanceRequest.base:type_name -> milvus.proto.common.MsgBase
+	121, // 156: milvus.proto.query.CheckBalanceStatusRequest.base:type_name -> milvus.proto.common.MsgBase
+	122, // 157: milvus.proto.query.CheckBalanceStatusResponse.status:type_name -> milvus.proto.common.Status
+	121, // 158: milvus.proto.query.SuspendNodeRequest.base:type_name -> milvus.proto.common.MsgBase
+	121, // 159: milvus.proto.query.ResumeNodeRequest.base:type_name -> milvus.proto.common.MsgBase
+	121, // 160: milvus.proto.query.TransferSegmentRequest.base:type_name -> milvus.proto.common.MsgBase
+	121, // 161: milvus.proto.query.TransferChannelRequest.base:type_name -> milvus.proto.common.MsgBase
+	121, // 162: milvus.proto.query.CheckQueryNodeDistributionRequest.base:type_name -> milvus.proto.common.MsgBase
+	121, // 163: milvus.proto.query.UpdateLoadConfigRequest.base:type_name -> milvus.proto.common.MsgBase
+	121, // 164: milvus.proto.query.UpdateSchemaRequest.base:type_name -> milvus.proto.common.MsgBase
+	124, // 165: milvus.proto.query.UpdateSchemaRequest.schema:type_name -> milvus.proto.schema.CollectionSchema
+	121, // 166: milvus.proto.query.RunAnalyzerRequest.base:type_name -> milvus.proto.common.MsgBase
+	121, // 167: milvus.proto.query.ListLoadedSegmentsRequest.base:type_name -> milvus.proto.common.MsgBase
+	122, // 168: milvus.proto.query.ListLoadedSegmentsResponse.status:type_name -> milvus.proto.common.Status
+	121, // 169: milvus.proto.query.DropIndexRequest.base:type_name -> milvus.proto.common.MsgBase
+	137, // 170: milvus.proto.query.UpdateResourceGroupsRequest.ResourceGroupsEntry.value:type_name -> milvus.proto.rg.ResourceGroupConfig
+	130, // 171: milvus.proto.query.WatchDmChannelsRequest.SegmentInfosEntry.value:type_name -> milvus.proto.data.SegmentInfo
+	140, // 172: milvus.proto.query.SegmentLoadInfo.TextStatsLogsEntry.value:type_name -> milvus.proto.data.TextIndexStats
+	141, // 173: milvus.proto.query.SegmentLoadInfo.JsonKeyStatsLogsEntry.value:type_name -> milvus.proto.data.JsonKeyStats
+	132, // 174: milvus.proto.query.GetDataDistributionRequest.CheckpointsEntry.value:type_name -> milvus.proto.msg.MsgPosition
+	54,  // 175: milvus.proto.query.LeaderView.SegmentDistEntry.value:type_name -> milvus.proto.query.SegmentDist
+	132, // 176: milvus.proto.query.LeaderView.GrowingSegmentsEntry.value:type_name -> milvus.proto.msg.MsgPosition
+	29,  // 177: milvus.proto.query.SegmentVersionInfo.IndexInfoEntry.value:type_name -> milvus.proto.query.FieldIndexInfo
+	30,  // 178: milvus.proto.query.SegmentVersionInfo.JsonStatsInfoEntry.value:type_name -> milvus.proto.query.JsonStatsInfo
+	59,  // 179: milvus.proto.query.Replica.ChannelNodeInfosEntry.value:type_name -> milvus.proto.query.ChannelNodeInfo
+	7,   // 180: milvus.proto.query.QueryCoord.ShowLoadCollections:input_type -> milvus.proto.query.ShowCollectionsRequest
+	9,   // 181: milvus.proto.query.QueryCoord.ShowLoadPartitions:input_type -> milvus.proto.query.ShowPartitionsRequest
+	14,  // 182: milvus.proto.query.QueryCoord.LoadPartitions:input_type -> milvus.proto.query.LoadPartitionsRequest
+	15,  // 183: milvus.proto.query.QueryCoord.ReleasePartitions:input_type -> milvus.proto.query.ReleasePartitionsRequest
+	11,  // 184: milvus.proto.query.QueryCoord.LoadCollection:input_type -> milvus.proto.query.LoadCollectionRequest
+	12,  // 185: milvus.proto.query.QueryCoord.ReleaseCollection:input_type -> milvus.proto.query.ReleaseCollectionRequest
+	24,  // 186: milvus.proto.query.QueryCoord.SyncNewCreatedPartition:input_type -> milvus.proto.query.SyncNewCreatedPartitionRequest
+	16,  // 187: milvus.proto.query.QueryCoord.GetPartitionStates:input_type -> milvus.proto.query.GetPartitionStatesRequest
+	18,  // 188: milvus.proto.query.QueryCoord.GetLoadSegmentInfo:input_type -> milvus.proto.query.GetSegmentInfoRequest
+	40,  // 189: milvus.proto.query.QueryCoord.LoadBalance:input_type -> milvus.proto.query.LoadBalanceRequest
+	142, // 190: milvus.proto.query.QueryCoord.ShowConfigurations:input_type -> milvus.proto.internal.ShowConfigurationsRequest
+	143, // 191: milvus.proto.query.QueryCoord.GetMetrics:input_type -> milvus.proto.milvus.GetMetricsRequest
+	144, // 192: milvus.proto.query.QueryCoord.GetReplicas:input_type -> milvus.proto.milvus.GetReplicasRequest
+	20,  // 193: milvus.proto.query.QueryCoord.GetShardLeaders:input_type -> milvus.proto.query.GetShardLeadersRequest
+	145, // 194: milvus.proto.query.QueryCoord.CheckHealth:input_type -> milvus.proto.milvus.CheckHealthRequest
+	146, // 195: milvus.proto.query.QueryCoord.CreateResourceGroup:input_type -> milvus.proto.milvus.CreateResourceGroupRequest
+	22,  // 196: milvus.proto.query.QueryCoord.UpdateResourceGroups:input_type -> milvus.proto.query.UpdateResourceGroupsRequest
+	147, // 197: milvus.proto.query.QueryCoord.DropResourceGroup:input_type -> milvus.proto.milvus.DropResourceGroupRequest
+	148, // 198: milvus.proto.query.QueryCoord.TransferNode:input_type -> milvus.proto.milvus.TransferNodeRequest
+	64,  // 199: milvus.proto.query.QueryCoord.TransferReplica:input_type -> milvus.proto.query.TransferReplicaRequest
+	149, // 200: milvus.proto.query.QueryCoord.ListResourceGroups:input_type -> milvus.proto.milvus.ListResourceGroupsRequest
+	65,  // 201: milvus.proto.query.QueryCoord.DescribeResourceGroup:input_type -> milvus.proto.query.DescribeResourceGroupRequest
+	97,  // 202: milvus.proto.query.QueryCoord.ListLoadedSegments:input_type -> milvus.proto.query.ListLoadedSegmentsRequest
+	73,  // 203: milvus.proto.query.QueryCoord.ListCheckers:input_type -> milvus.proto.query.ListCheckersRequest
+	71,  // 204: milvus.proto.query.QueryCoord.ActivateChecker:input_type -> milvus.proto.query.ActivateCheckerRequest
+	72,  // 205: milvus.proto.query.QueryCoord.DeactivateChecker:input_type -> milvus.proto.query.DeactivateCheckerRequest
+	81,  // 206: milvus.proto.query.QueryCoord.ListQueryNode:input_type -> milvus.proto.query.ListQueryNodeRequest
+	83,  // 207: milvus.proto.query.QueryCoord.GetQueryNodeDistribution:input_type -> milvus.proto.query.GetQueryNodeDistributionRequest
+	85,  // 208: milvus.proto.query.QueryCoord.SuspendBalance:input_type -> milvus.proto.query.SuspendBalanceRequest
+	86,  // 209: milvus.proto.query.QueryCoord.ResumeBalance:input_type -> milvus.proto.query.ResumeBalanceRequest
+	87,  // 210: milvus.proto.query.QueryCoord.CheckBalanceStatus:input_type -> milvus.proto.query.CheckBalanceStatusRequest
+	89,  // 211: milvus.proto.query.QueryCoord.SuspendNode:input_type -> milvus.proto.query.SuspendNodeRequest
+	90,  // 212: milvus.proto.query.QueryCoord.ResumeNode:input_type -> milvus.proto.query.ResumeNodeRequest
+	91,  // 213: milvus.proto.query.QueryCoord.TransferSegment:input_type -> milvus.proto.query.TransferSegmentRequest
+	92,  // 214: milvus.proto.query.QueryCoord.TransferChannel:input_type -> milvus.proto.query.TransferChannelRequest
+	93,  // 215: milvus.proto.query.QueryCoord.CheckQueryNodeDistribution:input_type -> milvus.proto.query.CheckQueryNodeDistributionRequest
+	94,  // 216: milvus.proto.query.QueryCoord.UpdateLoadConfig:input_type -> milvus.proto.query.UpdateLoadConfigRequest
+	150, // 217: milvus.proto.query.QueryNode.GetComponentStates:input_type -> milvus.proto.milvus.GetComponentStatesRequest
+	151, // 218: milvus.proto.query.QueryNode.GetTimeTickChannel:input_type -> milvus.proto.internal.GetTimeTickChannelRequest
+	152, // 219: milvus.proto.query.QueryNode.GetStatisticsChannel:input_type -> milvus.proto.internal.GetStatisticsChannelRequest
+	26,  // 220: milvus.proto.query.QueryNode.WatchDmChannels:input_type -> milvus.proto.query.WatchDmChannelsRequest
+	27,  // 221: milvus.proto.query.QueryNode.UnsubDmChannel:input_type -> milvus.proto.query.UnsubDmChannelRequest
+	31,  // 222: milvus.proto.query.QueryNode.LoadSegments:input_type -> milvus.proto.query.LoadSegmentsRequest
+	12,  // 223: milvus.proto.query.QueryNode.ReleaseCollection:input_type -> milvus.proto.query.ReleaseCollectionRequest
+	14,  // 224: milvus.proto.query.QueryNode.LoadPartitions:input_type -> milvus.proto.query.LoadPartitionsRequest
+	15,  // 225: milvus.proto.query.QueryNode.ReleasePartitions:input_type -> milvus.proto.query.ReleasePartitionsRequest
+	32,  // 226: milvus.proto.query.QueryNode.ReleaseSegments:input_type -> milvus.proto.query.ReleaseSegmentsRequest
+	18,  // 227: milvus.proto.query.QueryNode.GetSegmentInfo:input_type -> milvus.proto.query.GetSegmentInfoRequest
+	35,  // 228: milvus.proto.query.QueryNode.SyncReplicaSegments:input_type -> milvus.proto.query.SyncReplicaSegmentsRequest
+	13,  // 229: milvus.proto.query.QueryNode.GetStatistics:input_type -> milvus.proto.query.GetStatisticsRequest
+	33,  // 230: milvus.proto.query.QueryNode.Search:input_type -> milvus.proto.query.SearchRequest
+	33,  // 231: milvus.proto.query.QueryNode.SearchSegments:input_type -> milvus.proto.query.SearchRequest
+	34,  // 232: milvus.proto.query.QueryNode.Query:input_type -> milvus.proto.query.QueryRequest
+	34,  // 233: milvus.proto.query.QueryNode.QueryStream:input_type -> milvus.proto.query.QueryRequest
+	34,  // 234: milvus.proto.query.QueryNode.QuerySegments:input_type -> milvus.proto.query.QueryRequest
+	34,  // 235: milvus.proto.query.QueryNode.QueryStreamSegments:input_type -> milvus.proto.query.QueryRequest
+	142, // 236: milvus.proto.query.QueryNode.ShowConfigurations:input_type -> milvus.proto.internal.ShowConfigurationsRequest
+	143, // 237: milvus.proto.query.QueryNode.GetMetrics:input_type -> milvus.proto.milvus.GetMetricsRequest
+	50,  // 238: milvus.proto.query.QueryNode.GetDataDistribution:input_type -> milvus.proto.query.GetDataDistributionRequest
+	62,  // 239: milvus.proto.query.QueryNode.SyncDistribution:input_type -> milvus.proto.query.SyncDistributionRequest
+	68,  // 240: milvus.proto.query.QueryNode.Delete:input_type -> milvus.proto.query.DeleteRequest
+	69,  // 241: milvus.proto.query.QueryNode.DeleteBatch:input_type -> milvus.proto.query.DeleteBatchRequest
+	95,  // 242: milvus.proto.query.QueryNode.UpdateSchema:input_type -> milvus.proto.query.UpdateSchemaRequest
+	96,  // 243: milvus.proto.query.QueryNode.RunAnalyzer:input_type -> milvus.proto.query.RunAnalyzerRequest
+	99,  // 244: milvus.proto.query.QueryNode.DropIndex:input_type -> milvus.proto.query.DropIndexRequest
+	8,   // 245: milvus.proto.query.QueryCoord.ShowLoadCollections:output_type -> milvus.proto.query.ShowCollectionsResponse
+	10,  // 246: milvus.proto.query.QueryCoord.ShowLoadPartitions:output_type -> milvus.proto.query.ShowPartitionsResponse
+	122, // 247: milvus.proto.query.QueryCoord.LoadPartitions:output_type -> milvus.proto.common.Status
+	122, // 248: milvus.proto.query.QueryCoord.ReleasePartitions:output_type -> milvus.proto.common.Status
+	122, // 249: milvus.proto.query.QueryCoord.LoadCollection:output_type -> milvus.proto.common.Status
+	122, // 250: milvus.proto.query.QueryCoord.ReleaseCollection:output_type -> milvus.proto.common.Status
+	122, // 251: milvus.proto.query.QueryCoord.SyncNewCreatedPartition:output_type -> milvus.proto.common.Status
+	17,  // 252: milvus.proto.query.QueryCoord.GetPartitionStates:output_type -> milvus.proto.query.GetPartitionStatesResponse
+	19,  // 253: milvus.proto.query.QueryCoord.GetLoadSegmentInfo:output_type -> milvus.proto.query.GetSegmentInfoResponse
+	122, // 254: milvus.proto.query.QueryCoord.LoadBalance:output_type -> milvus.proto.common.Status
+	153, // 255: milvus.proto.query.QueryCoord.ShowConfigurations:output_type -> milvus.proto.internal.ShowConfigurationsResponse
+	154, // 256: milvus.proto.query.QueryCoord.GetMetrics:output_type -> milvus.proto.milvus.GetMetricsResponse
+	155, // 257: milvus.proto.query.QueryCoord.GetReplicas:output_type -> milvus.proto.milvus.GetReplicasResponse
+	21,  // 258: milvus.proto.query.QueryCoord.GetShardLeaders:output_type -> milvus.proto.query.GetShardLeadersResponse
+	156, // 259: milvus.proto.query.QueryCoord.CheckHealth:output_type -> milvus.proto.milvus.CheckHealthResponse
+	122, // 260: milvus.proto.query.QueryCoord.CreateResourceGroup:output_type -> milvus.proto.common.Status
+	122, // 261: milvus.proto.query.QueryCoord.UpdateResourceGroups:output_type -> milvus.proto.common.Status
+	122, // 262: milvus.proto.query.QueryCoord.DropResourceGroup:output_type -> milvus.proto.common.Status
+	122, // 263: milvus.proto.query.QueryCoord.TransferNode:output_type -> milvus.proto.common.Status
+	122, // 264: milvus.proto.query.QueryCoord.TransferReplica:output_type -> milvus.proto.common.Status
+	157, // 265: milvus.proto.query.QueryCoord.ListResourceGroups:output_type -> milvus.proto.milvus.ListResourceGroupsResponse
+	66,  // 266: milvus.proto.query.QueryCoord.DescribeResourceGroup:output_type -> milvus.proto.query.DescribeResourceGroupResponse
+	98,  // 267: milvus.proto.query.QueryCoord.ListLoadedSegments:output_type -> milvus.proto.query.ListLoadedSegmentsResponse
+	74,  // 268: milvus.proto.query.QueryCoord.ListCheckers:output_type -> milvus.proto.query.ListCheckersResponse
+	122, // 269: milvus.proto.query.QueryCoord.ActivateChecker:output_type -> milvus.proto.common.Status
+	122, // 270: milvus.proto.query.QueryCoord.DeactivateChecker:output_type -> milvus.proto.common.Status
+	82,  // 271: milvus.proto.query.QueryCoord.ListQueryNode:output_type -> milvus.proto.query.ListQueryNodeResponse
+	84,  // 272: milvus.proto.query.QueryCoord.GetQueryNodeDistribution:output_type -> milvus.proto.query.GetQueryNodeDistributionResponse
+	122, // 273: milvus.proto.query.QueryCoord.SuspendBalance:output_type -> milvus.proto.common.Status
+	122, // 274: milvus.proto.query.QueryCoord.ResumeBalance:output_type -> milvus.proto.common.Status
+	88,  // 275: milvus.proto.query.QueryCoord.CheckBalanceStatus:output_type -> milvus.proto.query.CheckBalanceStatusResponse
+	122, // 276: milvus.proto.query.QueryCoord.SuspendNode:output_type -> milvus.proto.common.Status
+	122, // 277: milvus.proto.query.QueryCoord.ResumeNode:output_type -> milvus.proto.common.Status
+	122, // 278: milvus.proto.query.QueryCoord.TransferSegment:output_type -> milvus.proto.common.Status
+	122, // 279: milvus.proto.query.QueryCoord.TransferChannel:output_type -> milvus.proto.common.Status
+	122, // 280: milvus.proto.query.QueryCoord.CheckQueryNodeDistribution:output_type -> milvus.proto.common.Status
+	122, // 281: milvus.proto.query.QueryCoord.UpdateLoadConfig:output_type -> milvus.proto.common.Status
+	158, // 282: milvus.proto.query.QueryNode.GetComponentStates:output_type -> milvus.proto.milvus.ComponentStates
+	159, // 283: milvus.proto.query.QueryNode.GetTimeTickChannel:output_type -> milvus.proto.milvus.StringResponse
+	159, // 284: milvus.proto.query.QueryNode.GetStatisticsChannel:output_type -> milvus.proto.milvus.StringResponse
+	122, // 285: milvus.proto.query.QueryNode.WatchDmChannels:output_type -> milvus.proto.common.Status
+	122, // 286: milvus.proto.query.QueryNode.UnsubDmChannel:output_type -> milvus.proto.common.Status
+	122, // 287: milvus.proto.query.QueryNode.LoadSegments:output_type -> milvus.proto.common.Status
+	122, // 288: milvus.proto.query.QueryNode.ReleaseCollection:output_type -> milvus.proto.common.Status
+	122, // 289: milvus.proto.query.QueryNode.LoadPartitions:output_type -> milvus.proto.common.Status
+	122, // 290: milvus.proto.query.QueryNode.ReleasePartitions:output_type -> milvus.proto.common.Status
+	122, // 291: milvus.proto.query.QueryNode.ReleaseSegments:output_type -> milvus.proto.common.Status
+	19,  // 292: milvus.proto.query.QueryNode.GetSegmentInfo:output_type -> milvus.proto.query.GetSegmentInfoResponse
+	122, // 293: milvus.proto.query.QueryNode.SyncReplicaSegments:output_type -> milvus.proto.common.Status
+	160, // 294: milvus.proto.query.QueryNode.GetStatistics:output_type -> milvus.proto.internal.GetStatisticsResponse
+	161, // 295: milvus.proto.query.QueryNode.Search:output_type -> milvus.proto.internal.SearchResults
+	161, // 296: milvus.proto.query.QueryNode.SearchSegments:output_type -> milvus.proto.internal.SearchResults
+	162, // 297: milvus.proto.query.QueryNode.Query:output_type -> milvus.proto.internal.RetrieveResults
+	162, // 298: milvus.proto.query.QueryNode.QueryStream:output_type -> milvus.proto.internal.RetrieveResults
+	162, // 299: milvus.proto.query.QueryNode.QuerySegments:output_type -> milvus.proto.internal.RetrieveResults
+	162, // 300: milvus.proto.query.QueryNode.QueryStreamSegments:output_type -> milvus.proto.internal.RetrieveResults
+	153, // 301: milvus.proto.query.QueryNode.ShowConfigurations:output_type -> milvus.proto.internal.ShowConfigurationsResponse
+	154, // 302: milvus.proto.query.QueryNode.GetMetrics:output_type -> milvus.proto.milvus.GetMetricsResponse
+	51,  // 303: milvus.proto.query.QueryNode.GetDataDistribution:output_type -> milvus.proto.query.GetDataDistributionResponse
+	122, // 304: milvus.proto.query.QueryNode.SyncDistribution:output_type -> milvus.proto.common.Status
+	122, // 305: milvus.proto.query.QueryNode.Delete:output_type -> milvus.proto.common.Status
+	70,  // 306: milvus.proto.query.QueryNode.DeleteBatch:output_type -> milvus.proto.query.DeleteBatchResponse
+	122, // 307: milvus.proto.query.QueryNode.UpdateSchema:output_type -> milvus.proto.common.Status
+	163, // 308: milvus.proto.query.QueryNode.RunAnalyzer:output_type -> milvus.proto.milvus.RunAnalyzerResponse
+	122, // 309: milvus.proto.query.QueryNode.DropIndex:output_type -> milvus.proto.common.Status
+	245, // [245:310] is the sub-list for method output_type
+	180, // [180:245] is the sub-list for method input_type
+	180, // [180:180] is the sub-list for extension type_name
+	180, // [180:180] is the sub-list for extension extendee
+	0,   // [0:180] is the sub-list for field type_name
 }
 
 func init() { file_query_coord_proto_init() }
@@ -11346,6 +11446,18 @@ func file_query_coord_proto_init() {
 				return nil
 			}
 		}
+		file_query_coord_proto_msgTypes[92].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*DropIndexRequest); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -11353,7 +11465,7 @@ func file_query_coord_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_query_coord_proto_rawDesc,
 			NumEnums:      7,
-			NumMessages:   113,
+			NumMessages:   114,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/pkg/proto/querypb/query_coord_grpc.pb.go
+++ b/pkg/proto/querypb/query_coord_grpc.pb.go
@@ -1475,6 +1475,7 @@ const (
 	QueryNode_DeleteBatch_FullMethodName          = "/milvus.proto.query.QueryNode/DeleteBatch"
 	QueryNode_UpdateSchema_FullMethodName         = "/milvus.proto.query.QueryNode/UpdateSchema"
 	QueryNode_RunAnalyzer_FullMethodName          = "/milvus.proto.query.QueryNode/RunAnalyzer"
+	QueryNode_DropIndex_FullMethodName            = "/milvus.proto.query.QueryNode/DropIndex"
 )
 
 // QueryNodeClient is the client API for QueryNode service.
@@ -1511,6 +1512,7 @@ type QueryNodeClient interface {
 	DeleteBatch(ctx context.Context, in *DeleteBatchRequest, opts ...grpc.CallOption) (*DeleteBatchResponse, error)
 	UpdateSchema(ctx context.Context, in *UpdateSchemaRequest, opts ...grpc.CallOption) (*commonpb.Status, error)
 	RunAnalyzer(ctx context.Context, in *RunAnalyzerRequest, opts ...grpc.CallOption) (*milvuspb.RunAnalyzerResponse, error)
+	DropIndex(ctx context.Context, in *DropIndexRequest, opts ...grpc.CallOption) (*commonpb.Status, error)
 }
 
 type queryNodeClient struct {
@@ -1810,6 +1812,15 @@ func (c *queryNodeClient) RunAnalyzer(ctx context.Context, in *RunAnalyzerReques
 	return out, nil
 }
 
+func (c *queryNodeClient) DropIndex(ctx context.Context, in *DropIndexRequest, opts ...grpc.CallOption) (*commonpb.Status, error) {
+	out := new(commonpb.Status)
+	err := c.cc.Invoke(ctx, QueryNode_DropIndex_FullMethodName, in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // QueryNodeServer is the server API for QueryNode service.
 // All implementations should embed UnimplementedQueryNodeServer
 // for forward compatibility
@@ -1844,6 +1855,7 @@ type QueryNodeServer interface {
 	DeleteBatch(context.Context, *DeleteBatchRequest) (*DeleteBatchResponse, error)
 	UpdateSchema(context.Context, *UpdateSchemaRequest) (*commonpb.Status, error)
 	RunAnalyzer(context.Context, *RunAnalyzerRequest) (*milvuspb.RunAnalyzerResponse, error)
+	DropIndex(context.Context, *DropIndexRequest) (*commonpb.Status, error)
 }
 
 // UnimplementedQueryNodeServer should be embedded to have forward compatible implementations.
@@ -1930,6 +1942,9 @@ func (UnimplementedQueryNodeServer) UpdateSchema(context.Context, *UpdateSchemaR
 }
 func (UnimplementedQueryNodeServer) RunAnalyzer(context.Context, *RunAnalyzerRequest) (*milvuspb.RunAnalyzerResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method RunAnalyzer not implemented")
+}
+func (UnimplementedQueryNodeServer) DropIndex(context.Context, *DropIndexRequest) (*commonpb.Status, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DropIndex not implemented")
 }
 
 // UnsafeQueryNodeServer may be embedded to opt out of forward compatibility for this service.
@@ -2435,6 +2450,24 @@ func _QueryNode_RunAnalyzer_Handler(srv interface{}, ctx context.Context, dec fu
 	return interceptor(ctx, in, info, handler)
 }
 
+func _QueryNode_DropIndex_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DropIndexRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(QueryNodeServer).DropIndex(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: QueryNode_DropIndex_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(QueryNodeServer).DropIndex(ctx, req.(*DropIndexRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // QueryNode_ServiceDesc is the grpc.ServiceDesc for QueryNode service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -2541,6 +2574,10 @@ var QueryNode_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "RunAnalyzer",
 			Handler:    _QueryNode_RunAnalyzer_Handler,
+		},
+		{
+			MethodName: "DropIndex",
+			Handler:    _QueryNode_DropIndex_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{

--- a/tests/python_client/milvus_client/test_milvus_client_index.py
+++ b/tests/python_client/milvus_client/test_milvus_client_index.py
@@ -182,8 +182,7 @@ class TestMilvusClientIndexInvalid(TestMilvusClientV2Base):
         collection_name = cf.gen_unique_str(prefix)
         # 1. create collection
         self.create_collection(client, collection_name, default_dim, consistency_level="Strong")
-        error = {ct.err_code: 65535, ct.err_msg: f"index cannot be dropped, collection is loaded, "
-                                                 f"please release it first"}
+        error = {ct.err_code: 1100, ct.err_msg: f"vector index cannot be dropped on loaded collection"}
         self.drop_index(client, collection_name, "vector",
                         check_task=CheckTasks.err_res, check_items=error)
         self.drop_collection(client, collection_name)

--- a/tests/python_client/testcases/async_milvus_client/test_index_async.py
+++ b/tests/python_client/testcases/async_milvus_client/test_index_async.py
@@ -201,9 +201,9 @@ class TestAsyncMilvusClientIndexInvalid(TestMilvusClientV2Base):
         collection_name = cf.gen_unique_str(prefix)
         # 1. create collection
         await async_client.create_collection(collection_name, default_dim, consistency_level="Strong")
+
         # 2. drop index
-        error = {ct.err_code: 65535, ct.err_msg: f"index cannot be dropped, collection is loaded, "
-                                                 f"please release it first"}
+        error = {ct.err_code: 1100, ct.err_msg: f"vector index cannot be dropped on loaded collection"}
         await async_client.drop_index(collection_name, "vector", check_task=CheckTasks.err_res, check_items=error)
         # 3. drop action
         await async_client.drop_collection(collection_name)

--- a/tests/python_client/testcases/test_index.py
+++ b/tests/python_client/testcases/test_index.py
@@ -1164,9 +1164,8 @@ class TestIndexInvalid(TestcaseBase):
         collection_w.create_index(ct.default_float_vec_field_name, ct.default_index)
         collection_w.load()
         collection_w.drop_index(check_task=CheckTasks.err_res,
-                                check_items={"err_code": 999,
-                                             "err_msg": "index cannot be dropped, collection is "
-                                                        "loaded, please release it first"})
+                                check_items={ct.err_code: 1100,
+                                             ct.err_msg: "vector index cannot be dropped on loaded collection"})
 
     @pytest.mark.tags(CaseLabel.L1)
     @pytest.mark.parametrize("n_trees", [-1, 1025, 'a'])
@@ -2359,12 +2358,12 @@ class TestBitmapIndex(TestcaseBase):
         method:
             1. build and drop `BITMAP` index on an empty collection
             2. rebuild `BITMAP` index on loaded collection
-            3. drop index on loaded collection and raises expected error
+            3. drop index on loaded collection
             4. re-build the same index on loaded collection
         expected:
             1. build and drop index successful on a not loaded collection
             2. build index successful on non-indexed and loaded fields
-            3. can not drop index on loaded collection
+            3. can drop index on loaded collection
         """
         # init params
         collection_name, nb = f"{request.function.__name__}_{primary_field}_{auto_id}", 3000
@@ -2401,9 +2400,7 @@ class TestBitmapIndex(TestcaseBase):
         self.collection_wrap.load()
 
         # re-drop scalars' index
-        self.drop_multi_index(index_names=list(set(index_params.keys()) - {DataType.FLOAT_VECTOR.name}),
-                              check_task=CheckTasks.err_res,
-                              check_items={ct.err_code: 65535, ct.err_msg: iem.DropLoadedIndex})
+        self.drop_multi_index(index_names=list(set(index_params.keys()) - {DataType.FLOAT_VECTOR.name}))
 
         # re-build loaded index
         self.build_multi_index(index_params=index_params)


### PR DESCRIPTION
issue: #42942

This pr includes the following changes:
1. Added checks for index checker in querycoord to generate drop index tasks
2. Added drop index interface to querynode
3. To avoid search failure after dropping the index, the querynode allows the use of lazy mode (warmup=disable) to load raw data even when indexes contain raw data.
4. In segcore, loading the index no longer deletes raw data; instead, it evicts it.
5. In expr, the index is pinned to prevent concurrent errors.