### PR TITLE
fix: [StorageV2] end to end minor issues for sync, stats, and load

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -405,9 +405,6 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         bool enable_mmap,
         bool is_proxy_column);
 
-    void
-    init_narrow_column_field_ids(const LoadFieldDataInfo& field_data_info);
-
  private:
     // InsertRecord needs to pin pk column.
     friend class storagev1translator::InsertRecordTranslator;
@@ -439,9 +436,6 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     mutable DeletedRecord<true> deleted_record_;
 
     LoadFieldDataInfo field_data_info_;
-
-    // for storage v2
-    std::vector<FieldId> narrow_column_field_ids_;
 
     SchemaPtr schema_;
     int64_t id_;

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -450,6 +450,11 @@ SegmentGrowingImpl::load_column_group_data_internal(
             std::vector<int64_t> all_row_groups(row_group_num);
             std::iota(all_row_groups.begin(), all_row_groups.end(), 0);
             row_group_lists.push_back(all_row_groups);
+            auto status = reader->Close();
+            AssertInfo(status.ok(),
+                       "failed to close file reader when get row group "
+                       "metadata from file: " +
+                           file + " with error: " + status.ToString());
         }
 
         // create parallel degree split strategy

--- a/internal/core/src/segcore/Utils.cpp
+++ b/internal/core/src/segcore/Utils.cpp
@@ -950,7 +950,8 @@ LoadArrowReaderFromRemote(const std::vector<std::string>& remote_files,
         auto rcm = storage::RemoteChunkManagerSingleton::GetInstance()
                        .GetRemoteChunkManager();
 
-        auto codec_futures = storage::GetObjectData(rcm.get(), remote_files, milvus::PriorityForLoad(priority), false);
+        auto codec_futures = storage::GetObjectData(
+            rcm.get(), remote_files, milvus::PriorityForLoad(priority), false);
         for (auto& codec_future : codec_futures) {
             auto reader = codec_future.get()->GetReader();
             channel->push(reader);
@@ -969,7 +970,8 @@ LoadFieldDatasFromRemote(const std::vector<std::string>& remote_files,
     try {
         auto rcm = storage::RemoteChunkManagerSingleton::GetInstance()
                        .GetRemoteChunkManager();
-        auto codec_futures = storage::GetObjectData(rcm.get(), remote_files, milvus::PriorityForLoad(priority));
+        auto codec_futures = storage::GetObjectData(
+            rcm.get(), remote_files, milvus::PriorityForLoad(priority));
         for (auto& codec_future : codec_futures) {
             auto field_data = codec_future.get()->GetFieldData();
             channel->push(field_data);

--- a/internal/core/src/storage/Util.h
+++ b/internal/core/src/storage/Util.h
@@ -35,6 +35,7 @@
 #include "storage/Types.h"
 #include "milvus-storage/filesystem/fs.h"
 #include "storage/ThreadPools.h"
+#include "milvus-storage/common/metadata.h"
 
 namespace milvus::storage {
 
@@ -268,5 +269,11 @@ ConvertFieldDataToArrowDataWrapper(const FieldDataPtr& field_data) {
         event_data.payload_reader->get_file_reader(),
         file_data);
 }
+
+milvus_storage::FieldIDList
+GetFieldIDList(FieldId column_group_id,
+               const std::string& filepath,
+               const std::shared_ptr<arrow::Schema>& arrow_schema,
+               milvus_storage::ArrowFileSystemPtr fs);
 
 }  // namespace milvus::storage

--- a/internal/core/unittest/test_group_chunk_translator.cpp
+++ b/internal/core/unittest/test_group_chunk_translator.cpp
@@ -106,6 +106,11 @@ TEST_P(GroupChunkTranslatorTest, TestWithMmap) {
 
     row_group_meta_list.push_back(
         fr->file_metadata()->GetRowGroupMetadataVector());
+    auto status = fr->Close();
+    AssertInfo(
+        status.ok(),
+        "failed to close file reader when get row group metadata from file: " +
+            paths_[0] + " with error: " + status.ToString());
 
     GroupChunkTranslator translator(segment_id_,
                                     field_metas,

--- a/internal/core/unittest/test_growing_storage_v2.cpp
+++ b/internal/core/unittest/test_growing_storage_v2.cpp
@@ -200,6 +200,11 @@ TEST_F(TestGrowingStorageV2, LoadWithStrategy) {
     auto fr = std::make_shared<milvus_storage::FileRowGroupReader>(
         fs_, paths[0], schema_);
     auto row_group_metadata = fr->file_metadata()->GetRowGroupMetadataVector();
+    auto status = fr->Close();
+    AssertInfo(
+        status.ok(),
+        "failed to close file reader when get row group metadata from file: " +
+            paths[0] + " with error: " + status.ToString());
     std::vector<int64_t> row_groups(row_group_metadata.size());
     std::iota(row_groups.begin(), row_groups.end(), 0);
     std::vector<std::vector<int64_t>> row_group_lists = {row_groups};

--- a/internal/datanode/index/task_stats.go
+++ b/internal/datanode/index/task_stats.go
@@ -430,6 +430,9 @@ func (st *statsTask) createTextIndex(ctx context.Context,
 	})
 
 	getInsertFiles := func(fieldID int64) ([]string, error) {
+		if st.req.GetStorageVersion() == storage.StorageV2 {
+			return []string{}, nil
+		}
 		binlogs, ok := fieldBinlogs[fieldID]
 		if !ok {
 			return nil, fmt.Errorf("field binlog not found for field %d", fieldID)
@@ -461,7 +464,9 @@ func (st *statsTask) createTextIndex(ctx context.Context,
 			return err
 		}
 
-		buildIndexParams := buildIndexParams(st.req, files, field, newStorageConfig, 0)
+		req := proto.Clone(st.req).(*workerpb.CreateStatsRequest)
+		req.InsertLogs = insertBinlogs
+		buildIndexParams := buildIndexParams(req, files, field, newStorageConfig, 0)
 
 		uploaded, err := indexcgowrapper.CreateTextIndex(ctx, buildIndexParams)
 		if err != nil {
@@ -521,6 +526,9 @@ func (st *statsTask) createJSONKeyStats(ctx context.Context,
 	})
 
 	getInsertFiles := func(fieldID int64) ([]string, error) {
+		if st.req.GetStorageVersion() == storage.StorageV2 {
+			return []string{}, nil
+		}
 		binlogs, ok := fieldBinlogs[fieldID]
 		if !ok {
 			return nil, fmt.Errorf("field binlog not found for field %d", fieldID)
@@ -551,7 +559,9 @@ func (st *statsTask) createJSONKeyStats(ctx context.Context,
 			return err
 		}
 
-		buildIndexParams := buildIndexParams(st.req, files, field, newStorageConfig, tantivyMemory)
+		req := proto.Clone(st.req).(*workerpb.CreateStatsRequest)
+		req.InsertLogs = insertBinlogs
+		buildIndexParams := buildIndexParams(req, files, field, newStorageConfig, tantivyMemory)
 
 		uploaded, err := indexcgowrapper.CreateJSONKeyStats(ctx, buildIndexParams)
 		if err != nil {
@@ -614,7 +624,9 @@ func buildIndexParams(
 			req.GetStorageConfig(),
 			req.GetCollectionID(),
 			req.GetPartitionID(),
-			req.GetTargetSegmentID())
+			req.GetTargetSegmentID(),
+		)
+		log.Info("build index params", zap.Any("segment insert files", params.SegmentInsertFiles))
 	}
 
 	return params

--- a/internal/storage/serde.go
+++ b/internal/storage/serde.go
@@ -514,19 +514,6 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 	return m
 }()
 
-func IsVectorDataType(dataType schemapb.DataType) bool {
-	switch dataType {
-	case schemapb.DataType_BinaryVector,
-		schemapb.DataType_Float16Vector,
-		schemapb.DataType_BFloat16Vector,
-		schemapb.DataType_Int8Vector,
-		schemapb.DataType_FloatVector,
-		schemapb.DataType_SparseFloatVector:
-		return true
-	}
-	return false
-}
-
 // Since parquet does not support custom fallback encoding for now,
 // we disable dict encoding for primary key.
 // It can be scale to all fields once parquet fallback encoding is available.

--- a/internal/storage/serde.go
+++ b/internal/storage/serde.go
@@ -892,6 +892,9 @@ func BuildRecord(b *array.RecordBuilder, data *InsertData, fields []*schemapb.Fi
 		if !ok {
 			panic("unknown type")
 		}
+		if data.Data[field.FieldID].RowNum() == 0 {
+			return merr.WrapErrServiceInternal(fmt.Sprintf("row num is 0 for field %s", field.Name))
+		}
 		for j := 0; j < data.Data[field.FieldID].RowNum(); j++ {
 			ok = typeEntry.serialize(fBuilder, data.Data[field.FieldID].GetRow(j))
 			if !ok {

--- a/internal/storage/serde_test.go
+++ b/internal/storage/serde_test.go
@@ -215,25 +215,3 @@ func TestCalculateArraySize(t *testing.T) {
 		})
 	}
 }
-
-func TestIsVectorDataType(t *testing.T) {
-	tests := []struct {
-		name string
-		dt   schemapb.DataType
-		want bool
-	}{
-		{"test float vector", schemapb.DataType_FloatVector, true},
-		{"test binary vector", schemapb.DataType_BinaryVector, true},
-		{"test float16 vector", schemapb.DataType_Float16Vector, true},
-		{"test bfloat16 vector", schemapb.DataType_BFloat16Vector, true},
-		{"test int8 vector", schemapb.DataType_Int8Vector, true},
-		{"test sparse float vector", schemapb.DataType_SparseFloatVector, true},
-		{"test sparse binary vector", schemapb.DataType_String, false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := IsVectorDataType(tt.dt)
-			assert.Equal(t, tt.want, got)
-		})
-	}
-}


### PR DESCRIPTION
Fix issues in end-to-end tests: 
1. **Split column groups based on schema**, rather than estimating by average chunk row size. **Ensure column group consistency within a segment**, to avoid errors caused by loading multiple column group chunks simultaneously.
2. **Use sorted segmentId** when generating the stats binlog path, to ensure consistent and correct file path resolution.
3. **Determine field IDs as follows**:
    For multi-column column groups, retrieve the field ID list from metadata.
    For single-column column groups, use the column group ID directly as the field ID.

related: #39173 
fix: #42862 