### PR TITLE
enhance: [GoSDK] Return SchemaMismatch error to retry

### DIFF
--- a/client/milvusclient/write.go
+++ b/client/milvusclient/write.go
@@ -41,7 +41,8 @@ func (c *Client) Insert(ctx context.Context, option InsertOption, callOptions ..
 		}
 		req, err := option.InsertRequest(collection)
 		if err != nil {
-			return collection.UpdateTimestamp, err
+			// return schema mismatch err to retry with newer schema
+			return collection.UpdateTimestamp, merr.WrapErrCollectionSchemaMisMatch(err)
 		}
 
 		return collection.UpdateTimestamp, c.callService(func(milvusService milvuspb.MilvusServiceClient) error {
@@ -99,7 +100,8 @@ func (c *Client) Upsert(ctx context.Context, option UpsertOption, callOptions ..
 		}
 		req, err := option.UpsertRequest(collection)
 		if err != nil {
-			return collection.UpdateTimestamp, err
+			// return schema mismatch err to retry with newer schema
+			return collection.UpdateTimestamp, merr.WrapErrCollectionSchemaMisMatch(err)
 		}
 		return collection.UpdateTimestamp, c.callService(func(milvusService milvuspb.MilvusServiceClient) error {
 			resp, err := milvusService.Upsert(ctx, req, callOptions...)

--- a/client/milvusclient/write_test.go
+++ b/client/milvusclient/write_test.go
@@ -147,6 +147,12 @@ func (s *WriteSuite) TestInsert() {
 	s.Run("bad_input", func() {
 		collName := fmt.Sprintf("coll_%s", s.randString(6))
 		s.setupCache(collName, s.schema)
+		// bs, err := proto.Marshal(s.schema.ProtoMessage())
+		// s.Require().NoError(err)
+		s.mock.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(&milvuspb.DescribeCollectionResponse{
+			CollectionName: collName,
+			Schema:         s.schema.ProtoMessage(),
+		}, nil)
 
 		type badCase struct {
 			tag   string


### PR DESCRIPTION
Related to #39718

After adding field, composing write request may failure and shall trigger retry with new schema. This PR make composing error returns SchemaMismatch error to trigger retry policy