### PR TITLE
enhance: Enable mergeSort by default starting from version 2.6.0

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -758,7 +758,7 @@ dataNode:
   compaction:
     levelZeroBatchMemoryRatio: 0.5 # The minimal memory ratio of free memory for level zero compaction executing in batch mode
     levelZeroMaxBatchSize: -1 # Max batch size refers to the max number of L1/L2 segments in a batch when executing L0 compaction. Default to -1, any value that is less than 1 means no limit. Valid range: >= 1.
-    useMergeSort: false # Whether to enable mergeSort mode when performing mixCompaction.
+    useMergeSort: true # Whether to enable mergeSort mode when performing mixCompaction.
     maxSegmentMergeSort: 30 # The maximum number of segments to be merged in mergeSort mode.
   gracefulStopTimeout: 1800 # seconds. force stop node without graceful stop
   slot:

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -5524,8 +5524,9 @@ if this parameter <= 0, will set it as 10`,
 		Key:          "dataNode.compaction.useMergeSort",
 		Version:      "2.5.0",
 		Doc:          "Whether to enable mergeSort mode when performing mixCompaction.",
-		DefaultValue: "false",
-		Export:       true,
+		DefaultValue: "true",
+		// Enable by default start from 2.6.0
+		Export: true,
 	}
 	p.UseMergeSort.Init(base.mgr)
 

--- a/tests/python_client/testcases/test_compaction.py
+++ b/tests/python_client/testcases/test_compaction.py
@@ -599,8 +599,7 @@ class TestCompactionOperation(TestcaseBase):
         collection_w.wait_for_compaction_completed()
         c_plans = collection_w.get_compaction_plans(check_task=CheckTasks.check_merge_compact)[0]
 
-        old_segmentIDs = [c_plans.plans[0].target]
-        old_segmentIDs.extend(c_plans.plans[0].sources)
+        old_segmentIDs = c_plans.plans[0].sources
         # waiting for handoff completed and search
         cost = 180
         start = time()


### PR DESCRIPTION
issue: #42980 

Enable mergeSort for mix compaction to reduce sort stats tasks.