### PR TITLE
enhance: [StorageV2] Release record and close reader

### DIFF
--- a/internal/core/src/segcore/packed_reader_c.cpp
+++ b/internal/core/src/segcore/packed_reader_c.cpp
@@ -138,6 +138,7 @@ CloseReader(CPackedReader c_packed_reader) {
         auto packed_reader =
             static_cast<milvus_storage::PackedRecordBatchReader*>(
                 c_packed_reader);
+        packed_reader->Close();
         delete packed_reader;
         return milvus::SuccessCStatus();
     } catch (std::exception& e) {

--- a/internal/datanode/compactor/mix_compactor.go
+++ b/internal/datanode/compactor/mix_compactor.go
@@ -291,6 +291,7 @@ func (t *mixCompactionTask) writeSegment(ctx context.Context,
 		} else {
 			mWriter.Write(r)
 		}
+		r.Release()
 	}
 
 	deltalogDeleteEntriesCount := len(delta)

--- a/internal/datanode/compactor/mix_compactor.go
+++ b/internal/datanode/compactor/mix_compactor.go
@@ -291,7 +291,6 @@ func (t *mixCompactionTask) writeSegment(ctx context.Context,
 		} else {
 			mWriter.Write(r)
 		}
-		r.Release()
 	}
 
 	deltalogDeleteEntriesCount := len(delta)

--- a/internal/datanode/index/task_stats.go
+++ b/internal/datanode/index/task_stats.go
@@ -242,6 +242,7 @@ func (st *statsTask) sort(ctx context.Context) ([]*datapb.FieldBinlog, error) {
 		log.Warn("error creating insert binlog reader", zap.Error(err))
 		return nil, err
 	}
+	defer rr.Close()
 
 	rrs := []storage.RecordReader{rr}
 	numValidRows, err := storage.Sort(st.req.GetBinlogMaxSize(), st.req.GetSchema(), rrs, srw, predicate)

--- a/internal/storage/sort.go
+++ b/internal/storage/sort.go
@@ -186,9 +186,6 @@ func MergeSort(batchSize uint64, schema *schemapb.CollectionSchema, rr []RecordR
 	recs := make([]Record, len(rr))
 	advanceRecord := func(i int) error {
 		rec, err := rr[i].Next()
-		if recs[i] != nil {
-			recs[i].Release()
-		}
 		recs[i] = rec // assign nil if err
 		if err != nil {
 			return err


### PR DESCRIPTION
Related to #39173

This PR
- Close packed reader after sort
- Release arrow.Record preventing memory leakage
- Invoke `pack_reader->Close()` for CloseReader