### PR TITLE
feat: [2.5]reorder RootCoord shutdown to the last in stopCoordinators

### DIFF
--- a/cmd/roles/roles.go
+++ b/cmd/roles/roles.go
@@ -549,7 +549,7 @@ func (mr *MilvusRoles) Run() {
 	<-mr.closed
 
 	// stop coordinators first
-	coordinators := []component{rootCoord, dataCoord, indexCoord, queryCoord}
+	coordinators := []component{dataCoord, indexCoord, queryCoord, rootCoord}
 	for idx, coord := range coordinators {
 		log.Warn("stop processing")
 		if coord != nil {


### PR DESCRIPTION
reorder RootCoord shutdown to the last in stopCoordinators
issue:https://github.com/milvus-io/milvus/issues/43018