### PR TITLE
fix: [2.5] Fix index blocked by failed sort stats

### DIFF
--- a/internal/datacoord/job_manager.go
+++ b/internal/datacoord/job_manager.go
@@ -321,7 +321,7 @@ func (jm *statsJobManager) SubmitStatsTask(originSegmentID, targetSegmentID int6
 	}
 	if err = jm.mt.statsTaskMeta.AddStatsTask(t); err != nil {
 		if errors.Is(err, merr.ErrTaskDuplicate) {
-			log.RatedInfo(10, "stats task already exists", zap.Int64("taskID", taskID),
+			log.Ctx(jm.ctx).WithRateGroup("job_manager", 1, 60).RatedInfo(10, "stats task already exists", zap.Int64("taskID", taskID),
 				zap.Int64("collectionID", originSegment.GetCollectionID()),
 				zap.Int64("segmentID", originSegment.GetID()))
 			return nil

--- a/internal/datacoord/task_stats.go
+++ b/internal/datacoord/task_stats.go
@@ -152,11 +152,10 @@ func (st *statsTask) UpdateVersion(ctx context.Context, nodeID int64, meta *meta
 		if !compactionHandler.checkAndSetSegmentStating(st.req.GetInsertChannel(), st.segmentID) {
 			log.Warn("segment is contains by l0 compaction, skip stats", zap.Int64("taskID", st.taskID),
 				zap.Int64("segmentID", st.segmentID))
-			// Retry stats task if segment is contains by l0 compaction.
-			st.SetState(indexpb.JobState_JobStateRetry, "segment is contains by l0 compaction")
 			// reset compacting
 			meta.SetSegmentsCompacting(ctx, []UniqueID{st.segmentID}, false)
 			st.SetStartTime(time.Now())
+			// Return err and keep task state as init to trigger retry.
 			return errors.New("segment is contains by l0 compaction")
 		}
 	}


### PR DESCRIPTION
When l0 compaction is executing, do not mark the stats task as failed; keep it in the init state to allow retry.

issue: https://github.com/milvus-io/milvus/issues/43039