### PR TITLE
fix: impose a hard limit on physical memory limit when loading cells

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -464,15 +464,13 @@ queryNode:
         vectorIndex: sync
       # If evictionEnabled is true, a background thread will run every evictionIntervalMs to determine if an
       # eviction is necessary and the amount of data to evict from memory/disk.
-      # - The max ratio is the max amount of memory/disk that can be used for cache.
       # - If the current memory/disk usage exceeds the high watermark, an eviction will be triggered to evict data from memory/disk
       #   until the memory/disk usage is below the low watermark.
+      # - The max amount of memory/disk that can be used for cache is controlled by overloadedMemoryThresholdPercentage and diskMaxUsagePercentage.
       memoryLowWatermarkRatio: 0.6
       memoryHighWatermarkRatio: 0.8
-      memoryMaxRatio: 0.9
       diskLowWatermarkRatio: 0.6
       diskHighWatermarkRatio: 0.8
-      diskMaxRatio: 0.9
       # Enable eviction for Tiered Storage. Defaults to false.
       # Note that if eviction is enabled, cache data loaded during sync warmup is also subject to eviction.
       evictionEnabled: false

--- a/internal/core/src/cachinglayer/CacheSlot.h
+++ b/internal/core/src/cachinglayer/CacheSlot.h
@@ -249,6 +249,9 @@ class CacheSlot final : public std::enable_shared_from_this<CacheSlot<CellT>> {
                 try {
                     auto start = std::chrono::high_resolution_clock::now();
                     std::vector<cid_t> cids_vec(cids.begin(), cids.end());
+                    LOG_TRACE("[MCL] CacheSlot loading cells: key={}, cell_ids=[{}]",
+                             translator_->key(),
+                             fmt::join(cids_vec.begin(), cids_vec.end(), ","));
                     auto results = translator_->get_cells(cids_vec);
                     auto latency =
                         std::chrono::duration_cast<std::chrono::microseconds>(
@@ -290,7 +293,7 @@ class CacheSlot final : public std::enable_shared_from_this<CacheSlot<CellT>> {
         }
         ~CacheCell() {
             if (state_ == State::LOADING) {
-                LOG_ERROR("CacheSlot Cell {} destroyed while loading", key());
+                LOG_ERROR("[MCL] CacheSlot Cell {} destroyed while loading", key());
             }
         }
 

--- a/internal/core/src/cachinglayer/Manager.cpp
+++ b/internal/core/src/cachinglayer/Manager.cpp
@@ -37,7 +37,8 @@ Manager::ConfigureTieredStorage(CacheWarmupPolicies warmup_policies,
 
         if (!evictionEnabled) {
             LOG_INFO(
-                "Tiered Storage manager is configured with disabled eviction");
+                "[MCL] Tiered Storage manager is configured "
+                "with disabled eviction");
             return;
         }
 
@@ -48,21 +49,12 @@ Manager::ConfigureTieredStorage(CacheWarmupPolicies warmup_policies,
         ResourceUsage high_watermark{cache_limit.memory_high_watermark_bytes,
                                      cache_limit.disk_high_watermark_bytes};
 
-        AssertInfo(
-            low_watermark.GEZero(),
-            "Milvus Caching Layer: low watermark must be greater than 0");
-        AssertInfo((high_watermark - low_watermark).GEZero(),
-                   "Milvus Caching Layer: high watermark must be greater than "
-                   "low watermark");
-        AssertInfo(
-            (max - high_watermark).GEZero(),
-            "Milvus Caching Layer: max must be greater than high watermark");
-
         manager.dlist_ = std::make_unique<internal::DList>(
             max, low_watermark, high_watermark, eviction_config);
 
         LOG_INFO(
-            "Configured Tiered Storage manager with memory watermark: low {} "
+            "[MCL] Configured Tiered Storage manager with "
+            "memory watermark: low {} "
             "bytes ({:.2} GB), high {} bytes ({:.2} GB), max {} bytes "
             "({:.2} GB), disk watermark: low "
             "{} bytes ({:.2} GB), high {} bytes ({:.2} GB), max {} bytes "

--- a/internal/core/src/cachinglayer/Utils.cpp
+++ b/internal/core/src/cachinglayer/Utils.cpp
@@ -1,0 +1,276 @@
+// Copyright (C) 2019-2025 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+
+#include "cachinglayer/Utils.h"
+
+#include <algorithm>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "log/Log.h"
+
+namespace milvus::cachinglayer::internal {
+
+int64_t
+getHostTotalMemory() {
+#ifdef __linux__
+    std::ifstream meminfo("/proc/meminfo");
+    if (!meminfo.is_open()) {
+        LOG_WARN("[MCL] Failed to open /proc/meminfo");
+        return 0;
+    }
+
+    std::string line;
+    while (std::getline(meminfo, line)) {
+        if (line.find("MemTotal:") == 0) {
+            std::istringstream iss(line);
+            std::string key;
+            int64_t value;
+            std::string unit;
+
+            if (iss >> key >> value >> unit) {
+                // Convert kB to bytes
+                if (unit == "kB") {
+                    value *= 1024;
+                }
+                return value;
+            }
+        }
+    }
+#else
+    LOG_WARN("[MCL] Host memory detection not implemented for this platform");
+#endif
+    return 0;
+}
+
+// Impl based on pkg/util/hardware/container_linux.go::getContainerMemLimit()
+int64_t
+getContainerMemLimit() {
+#ifdef __linux__
+    std::vector<int64_t> limits;
+
+    // 1. Check MEM_LIMIT environment variable (Docker/container override)
+    const char* mem_limit_env = std::getenv("MEM_LIMIT");
+    if (mem_limit_env) {
+        try {
+            int64_t env_limit = std::stoll(mem_limit_env);
+            limits.push_back(env_limit);
+            LOG_DEBUG("[MCL] Found MEM_LIMIT environment variable: {} bytes",
+                      env_limit);
+        } catch (...) {
+            LOG_WARN("[MCL] Invalid MEM_LIMIT environment variable: {}",
+                     mem_limit_env);
+        }
+    }
+
+    // 2. Check cgroups v2 memory limit
+    std::ifstream cgroup_v2("/sys/fs/cgroup/memory.max");
+    if (cgroup_v2.is_open()) {
+        std::string line;
+        if (std::getline(cgroup_v2, line) && line != "max") {
+            try {
+                int64_t v2_limit = std::stoll(line);
+                limits.push_back(v2_limit);
+                LOG_DEBUG("[MCL] Found cgroups v2 memory limit: {} bytes",
+                          v2_limit);
+            } catch (...) {
+                LOG_WARN("[MCL] Failed to parse cgroups v2 memory limit: {}",
+                         line);
+            }
+        }
+    }
+
+    // 3. Check cgroups v1 memory limit
+    std::ifstream cgroup_v1("/sys/fs/cgroup/memory/memory.limit_in_bytes");
+    if (cgroup_v1.is_open()) {
+        std::string line;
+        if (std::getline(cgroup_v1, line)) {
+            try {
+                int64_t v1_limit = std::stoll(line);
+                // Filter out unrealistic values (cgroups v1 sometimes returns very large numbers)
+                if (v1_limit < (1LL << 62)) {  // Reasonable upper bound
+                    limits.push_back(v1_limit);
+                    LOG_DEBUG("[MCL] Found cgroups v1 memory limit: {} bytes",
+                              v1_limit);
+                }
+            } catch (...) {
+                LOG_WARN("[MCL] Failed to parse cgroups v1 memory limit: {}",
+                         line);
+            }
+        }
+    }
+
+    // 4. Check process-specific cgroup limits from /proc/self/cgroup
+    std::ifstream proc_cgroup("/proc/self/cgroup");
+    if (proc_cgroup.is_open()) {
+        std::string line;
+        while (std::getline(proc_cgroup, line)) {
+            // Look for memory controller lines
+            if (line.find(":memory:") != std::string::npos ||
+                line.find(":0:") != std::string::npos) {
+                size_t last_colon = line.find_last_of(':');
+                if (last_colon != std::string::npos) {
+                    std::string cgroup_path = line.substr(last_colon + 1);
+
+                    // Try v2 path
+                    std::string v2_path =
+                        "/sys/fs/cgroup" + cgroup_path + "/memory.max";
+                    std::ifstream proc_v2(v2_path);
+                    if (proc_v2.is_open()) {
+                        std::string proc_line;
+                        if (std::getline(proc_v2, proc_line) &&
+                            proc_line != "max") {
+                            try {
+                                int64_t proc_limit = std::stoll(proc_line);
+                                limits.push_back(proc_limit);
+                                LOG_DEBUG(
+                                    "[MCL] Found process-specific cgroups v2 "
+                                    "limit: {} bytes",
+                                    proc_limit);
+                            } catch (...) {
+                                // Ignore parse errors
+                            }
+                        }
+                    }
+
+                    // Try v1 path
+                    std::string v1_path = "/sys/fs/cgroup/memory" +
+                                          cgroup_path +
+                                          "/memory.limit_in_bytes";
+                    std::ifstream proc_v1(v1_path);
+                    if (proc_v1.is_open()) {
+                        std::string proc_line;
+                        if (std::getline(proc_v1, proc_line)) {
+                            try {
+                                int64_t proc_limit = std::stoll(proc_line);
+                                // Filters out unrealistic cgroups v1 values (sometimes returns very large numbers
+                                // when unlimited)
+                                if (proc_limit < (1LL << 62)) {
+                                    limits.push_back(proc_limit);
+                                    LOG_DEBUG(
+                                        "[MCL] Found process-specific cgroups "
+                                        "v1 limit: {} bytes",
+                                        proc_limit);
+                                }
+                            } catch (...) {
+                                // Ignore parse errors
+                            }
+                        }
+                    }
+                }
+                break;  // Found memory controller, no need to continue
+            }
+        }
+    }
+
+    // Return the minimum of all found limits
+    if (!limits.empty()) {
+        int64_t min_limit = *std::min_element(limits.begin(), limits.end());
+        LOG_DEBUG("[MCL] Using minimum memory limit: {} bytes from {} sources",
+                  min_limit,
+                  limits.size());
+        return min_limit;
+    }
+
+#else
+    LOG_WARN(
+        "[MCL] Container/cgroup memory limit detection not implemented for "
+        "this platform");
+#endif
+    return 0;
+}
+
+SystemMemoryInfo
+getSystemMemoryInfo() {
+    SystemMemoryInfo info;
+
+    // Get total memory (host vs container)
+    int64_t host_memory = getHostTotalMemory();
+    int64_t container_limit = getContainerMemLimit();
+
+    if (container_limit > 0 && container_limit < host_memory) {
+        info.total_memory_bytes = container_limit;
+        LOG_DEBUG("[MCL] Using container memory limit: {} bytes",
+                  container_limit);
+    } else {
+        info.total_memory_bytes = host_memory;
+        if (container_limit > host_memory) {
+            LOG_WARN(
+                "[MCL] Container limit ({} bytes) exceeds host memory ({} "
+                "bytes), using host memory",
+                container_limit,
+                host_memory);
+        }
+    }
+
+    // Get current process memory usage (RSS - Shared)
+    info.used_memory_bytes = getCurrentProcessMemoryUsage();
+    info.available_memory_bytes =
+        info.total_memory_bytes - info.used_memory_bytes;
+
+    return info;
+}
+
+int64_t
+getCurrentProcessMemoryUsage() {
+#ifdef __linux__
+    std::ifstream status("/proc/self/status");
+    if (!status.is_open()) {
+        LOG_WARN("[MCL] Failed to open /proc/self/status, returning 0");
+        return 0;
+    }
+
+    int64_t rss = 0;
+    int64_t shared = 0;
+    std::string line;
+
+    while (std::getline(status, line)) {
+        if (line.find("VmRSS:") == 0) {
+            std::istringstream iss(line);
+            std::string key;
+            int64_t value;
+            std::string unit;
+
+            if (iss >> key >> value >> unit) {
+                // Convert kB to bytes
+                if (unit == "kB") {
+                    value *= 1024;
+                }
+                rss = value;
+            }
+        } else if (line.find("RssFile:") == 0) {
+            std::istringstream iss(line);
+            std::string key;
+            int64_t value;
+            std::string unit;
+
+            if (iss >> key >> value >> unit) {
+                // Convert kB to bytes
+                if (unit == "kB") {
+                    value *= 1024;
+                }
+                shared = value;
+            }
+        }
+    }
+
+    // Return RSS - Shared (file-backed memory) to match Go implementation
+    return rss - shared;
+#else
+    LOG_WARN(
+        "[MCL] Process memory monitoring not implemented for this platform");
+    return 0;
+#endif
+}
+
+}  // namespace milvus::cachinglayer::internal

--- a/internal/core/src/cachinglayer/lrucache/DList.cpp
+++ b/internal/core/src/cachinglayer/lrucache/DList.cpp
@@ -27,18 +27,73 @@ bool
 DList::reserveMemory(const ResourceUsage& size) {
     std::unique_lock<std::mutex> list_lock(list_mtx_);
     auto used = used_memory_.load();
-    if (max_memory_.CanHold(used + size)) {
-        used_memory_ += size;
-        return true;
+
+    // Combined logical and physical memory limit check
+    bool logical_limit_exceeded = !max_memory_.CanHold(used + size);
+    int64_t physical_eviction_needed =
+        eviction_config_.enable_physical_memory_protection &&
+                size.memory_bytes > 0
+            ? checkPhysicalMemoryLimit(size)
+            : 0;
+
+    // If either limit is exceeded, attempt unified eviction
+    // we attempt eviction based on logical limit once, but multiple times on physical limit
+    // because physical eviction may not be accurate.
+    while (logical_limit_exceeded || physical_eviction_needed > 0) {
+        ResourceUsage eviction_target;
+        ResourceUsage min_eviction;
+
+        if (logical_limit_exceeded) {
+            // Calculate logical eviction requirements
+            eviction_target = used + size - low_watermark_;
+            min_eviction = used + size - max_memory_;
+        }
+
+        if (physical_eviction_needed > 0) {
+            // Combine with logical eviction target (take the maximum)
+            eviction_target.memory_bytes = std::max(
+                eviction_target.memory_bytes, physical_eviction_needed);
+            min_eviction.memory_bytes =
+                std::max(min_eviction.memory_bytes, physical_eviction_needed);
+        }
+
+        // Attempt unified eviction
+        ResourceUsage evicted_size = tryEvict(eviction_target, min_eviction);
+        if (!evicted_size.AnyGTZero()) {
+            LOG_WARN(
+                "[MCL] Failed to reserve size={} due to "
+                "eviction failure, target={}, min_eviction={}",
+                size.ToString(),
+                eviction_target.ToString(),
+                min_eviction.ToString());
+            return false;
+        }
+        // logical limit is accurate, thus we can guarantee after one successful eviction, logical limit is satisfied.
+        logical_limit_exceeded = false;
+
+        if (physical_eviction_needed == 0) {
+            // we only need to evict for logical limit and we have succeeded.
+            return true;
+        }
+
+        if (physical_eviction_needed = checkPhysicalMemoryLimit(size);
+            physical_eviction_needed == 0) {
+            // if after eviction we no longer need to evict, we can return.
+            return true;
+        }
+        // else perform another round of eviction.
+        LOG_TRACE(
+            "[MCL] reserving size={} failed, evicted_size={}, "
+            "still need to evict {}",
+            size.ToString(),
+            evicted_size.ToString(),
+            FormatBytes(physical_eviction_needed));
     }
 
-    // try to evict so that used + size <= low watermark, but if that is not possible,
-    // evict enough for the current reservation.
-    if (tryEvict(used + size - low_watermark_, used + size - max_memory_)) {
-        used_memory_ += size;
-        return true;
-    }
-    return false;
+    // Reserve resources (both checks passed)
+    used_memory_ += size;
+    loading_memory_ += size;  // Track as loading
+    return true;
 }
 
 void
@@ -101,7 +156,25 @@ DList::usageInfo(const ResourceUsage& actively_pinned) const {
             precision);
 }
 
-bool
+// not thread safe, use for debug only
+std::string
+DList::chainString() const {
+    std::stringstream ss;
+    ss << "[MCL] DList chain: ";
+    size_t num_nodes = 0;
+    for (auto it = tail_; it != nullptr; it = it->next_) {
+        ss << "(" << it->key() << ", " << it->size().ToString()
+           << ", pins=" << it->pin_count_ << ")";
+        num_nodes++;
+        if (it->next_ != nullptr) {
+            ss << " -> ";
+        }
+    }
+    ss << "Total nodes: " << num_nodes << std::endl;
+    return ss.str();
+}
+
+ResourceUsage
 DList::tryEvict(const ResourceUsage& expected_eviction,
                 const ResourceUsage& min_eviction) {
     std::vector<ListNode*> to_evict;
@@ -145,15 +218,18 @@ DList::tryEvict(const ResourceUsage& expected_eviction,
     }
     if (!size_to_evict.CanHold(expected_eviction)) {
         if (!size_to_evict.CanHold(min_eviction)) {
-            LOG_WARN(
-                "Milvus Caching Layer: cannot evict even min_eviction {}, "
-                "giving up eviction. Current usage: {}",
+            LOG_INFO(
+                "[MCL] Cannot evict even min_eviction {}, max possible "
+                "eviction {}, giving up eviction. Current usage: {}. This may "
+                "indicate a lack of resources.",
                 min_eviction.ToString(),
+                size_to_evict.ToString(),
                 usageInfo(actively_pinned));
-            return false;
+            LOG_TRACE("[MCL] DList chain: {}", chainString());
+            return ResourceUsage{0, 0};
         }
-        LOG_INFO(
-            "Milvus Caching Layer: cannot evict expected_eviction {}, "
+        LOG_DEBUG(
+            "[MCL] cannot evict expected_eviction {}, "
             "evicting as much({}) as possible. Current usage: {}",
             expected_eviction.ToString(),
             size_to_evict.ToString(),
@@ -168,6 +244,8 @@ DList::tryEvict(const ResourceUsage& expected_eviction,
         list_node->clear_data();
         used_memory_ -= size;
     }
+
+    LOG_TRACE("[MCL] Logically evicted size: {}", size_to_evict.ToString());
 
     switch (size_to_evict.storage_type()) {
         case StorageType::MEMORY:
@@ -187,14 +265,13 @@ DList::tryEvict(const ResourceUsage& expected_eviction,
         default:
             PanicInfo(ErrorCode::UnexpectedError, "Unknown StorageType");
     }
-    return true;
+    return size_to_evict;
 }
 
 bool
 DList::UpdateLimit(const ResourceUsage& new_limit) {
-    AssertInfo(new_limit.GEZero(),
-               "Milvus Caching Layer: memory and disk usage limit must be "
-               "greater than 0");
+    AssertInfo((new_limit - high_watermark_).AllGEZero(),
+               "[MCL] limit must be greater than high watermark");
     std::unique_lock<std::mutex> list_lock(list_mtx_);
     auto used = used_memory_.load();
     if (!new_limit.CanHold(used)) {
@@ -202,7 +279,7 @@ DList::UpdateLimit(const ResourceUsage& new_limit) {
         auto deficit = used - new_limit;
         // deficit is the hard limit of eviction, if we cannot evict deficit, we give
         // up the limit change.
-        if (!tryEvict(deficit, deficit)) {
+        if (!tryEvict(deficit, deficit).AnyGTZero()) {
             return false;
         }
     }
@@ -217,16 +294,18 @@ DList::UpdateLimit(const ResourceUsage& new_limit) {
 void
 DList::UpdateLowWatermark(const ResourceUsage& new_low_watermark) {
     std::unique_lock<std::mutex> list_lock(list_mtx_);
-    AssertInfo(new_low_watermark.GEZero(),
-               "Milvus Caching Layer: low watermark must be greater than 0");
+    AssertInfo(new_low_watermark.AllGEZero(),
+               "[MCL] low watermark must be greater than or "
+               "equal to 0");
     low_watermark_ = new_low_watermark;
 }
 
 void
 DList::UpdateHighWatermark(const ResourceUsage& new_high_watermark) {
     std::unique_lock<std::mutex> list_lock(list_mtx_);
-    AssertInfo(new_high_watermark.GEZero(),
-               "Milvus Caching Layer: high watermark must be greater than 0");
+    AssertInfo((new_high_watermark - low_watermark_).AllGEZero(),
+               "[MCL] high watermark must be greater than or "
+               "equal to low watermark");
     high_watermark_ = new_high_watermark;
 }
 
@@ -234,6 +313,7 @@ void
 DList::releaseMemory(const ResourceUsage& size) {
     // safe to substract on atomic without lock
     used_memory_ -= size;
+    loading_memory_ -= size;
 }
 
 void
@@ -296,6 +376,45 @@ bool
 DList::IsEmpty() const {
     std::lock_guard<std::mutex> list_lock(list_mtx_);
     return head_ == nullptr;
+}
+
+void
+DList::addLoadingResource(const ResourceUsage& size) {
+    loading_memory_ += size;
+}
+
+void
+DList::removeLoadingResource(const ResourceUsage& size) {
+    loading_memory_ -= size;
+}
+
+int64_t
+DList::checkPhysicalMemoryLimit(const ResourceUsage& size) const {
+    auto sys_mem = getSystemMemoryInfo();
+    auto current_loading = loading_memory_.load();
+    int64_t projected_usage = sys_mem.used_memory_bytes +
+                              current_loading.memory_bytes + size.memory_bytes;
+    int64_t limit =
+        static_cast<int64_t>(sys_mem.total_memory_bytes *
+                             eviction_config_.physical_memory_protection_ratio);
+
+    int64_t eviction_needed = std::max(0L, projected_usage - limit);
+
+    LOG_TRACE(
+        "[MCL] Physical memory check: "
+        "projected_usage={}(used={}, loading={}, requesting={}), limit={} ({}% "
+        "of {} "
+        "total), eviction_needed={}",
+        FormatBytes(projected_usage),
+        FormatBytes(sys_mem.used_memory_bytes),
+        FormatBytes(current_loading.memory_bytes),
+        FormatBytes(size.memory_bytes),
+        FormatBytes(limit),
+        eviction_config_.physical_memory_protection_ratio * 100,
+        FormatBytes(sys_mem.total_memory_bytes),
+        FormatBytes(eviction_needed));
+
+    return eviction_needed;
 }
 
 }  // namespace milvus::cachinglayer::internal

--- a/internal/core/src/cachinglayer/lrucache/ListNode.cpp
+++ b/internal/core/src/cachinglayer/lrucache/ListNode.cpp
@@ -69,7 +69,7 @@ bool
 ListNode::manual_evict() {
     std::unique_lock<std::shared_mutex> lock(mtx_);
     if (state_ == State::ERROR || state_ == State::LOADING) {
-        LOG_ERROR("manual_evict() called on a {} cell",
+        LOG_ERROR("[MCL] manual_evict() called on a {} cell",
                   state_to_string(state_));
         return true;
     }
@@ -78,7 +78,7 @@ ListNode::manual_evict() {
     }
     if (pin_count_.load() > 0) {
         LOG_ERROR(
-            "manual_evict() called on a LOADED and pinned cell, aborting "
+            "[MCL] manual_evict() called on a LOADED and pinned cell, aborting "
             "eviction.");
         return false;
     }
@@ -227,12 +227,21 @@ ListNode::clear_data() {
                       2 * dlist_->eviction_config().cache_touch_window;
     }
     unload();
+    LOG_TRACE(
+        "[MCL] ListNode evicted: key={}, size={}", key(), size_.ToString());
     state_ = State::NOT_LOADED;
 }
 
 void
 ListNode::unload() {
     // Default implementation does nothing
+}
+
+void
+ListNode::remove_self_from_loading_resource() {
+    if (dlist_) {
+        dlist_->removeLoadingResource(size_);
+    }
 }
 
 }  // namespace milvus::cachinglayer::internal

--- a/internal/core/src/cachinglayer/lrucache/ListNode.h
+++ b/internal/core/src/cachinglayer/lrucache/ListNode.h
@@ -113,6 +113,7 @@ class ListNode {
                 state_ = State::LOADED;
                 load_promise_->setValue(folly::Unit());
                 load_promise_ = nullptr;
+                remove_self_from_loading_resource();
             } else {
                 // LOADED: cell has been loaded by another thread, do nothing.
                 return;
@@ -134,6 +135,7 @@ class ListNode {
                 load_promise_ = nullptr;
                 // the node that marked LOADING has already reserved memory, do not double count.
                 touch(false);
+                remove_self_from_loading_resource();
             } else {
                 // LOADED: cell has been loaded by another thread, do nothing.
                 return;
@@ -143,6 +145,9 @@ class ListNode {
 
     void
     set_error(folly::exception_wrapper error);
+
+    void
+    remove_self_from_loading_resource();
 
     State state_{State::NOT_LOADED};
 

--- a/internal/core/src/common/Chunk.h
+++ b/internal/core/src/common/Chunk.h
@@ -168,7 +168,10 @@ class StringChunk : public Chunk {
     std::string_view
     operator[](const int i) const {
         if (i < 0 || i >= row_nums_) {
-            PanicInfo(ErrorCode::OutOfRange, "index out of range");
+            PanicInfo(ErrorCode::OutOfRange,
+                      "index out of range {} at {}",
+                      i,
+                      row_nums_);
         }
 
         return {data_ + offsets_[i], offsets_[i + 1] - offsets_[i]};

--- a/internal/core/src/log/Log.h
+++ b/internal/core/src/log/Log.h
@@ -75,6 +75,12 @@
                 GetThreadName(),    \
                 milvus::tracer::GetTraceID())
 
+// avoid evaluating args if trace log is not enabled
+#define LOG_TRACE(args...)                                               \
+    if (VLOG_IS_ON(GLOG_TRACE)) {                                        \
+        VLOG(GLOG_TRACE) << SERVER_MODULE_FUNCTION << fmt::format(args); \
+    }
+
 #define LOG_DEBUG(args...) \
     VLOG(GLOG_DEBUG) << SERVER_MODULE_FUNCTION << fmt::format(args)
 #define LOG_INFO(args...) \

--- a/internal/core/unittest/test_cachinglayer/test_cache_slot.cpp
+++ b/internal/core/unittest/test_cachinglayer/test_cache_slot.cpp
@@ -515,9 +515,9 @@ TEST_F(CacheSlotTest, EvictionTest) {
     ResourceUsage new_limit = ResourceUsage(300, 0);
     ResourceUsage new_high_watermark = ResourceUsage(250, 0);
     ResourceUsage new_low_watermark = ResourceUsage(200, 0);
-    EXPECT_TRUE(dlist_->UpdateLimit(new_limit));
-    dlist_->UpdateHighWatermark(new_high_watermark);
     dlist_->UpdateLowWatermark(new_low_watermark);
+    dlist_->UpdateHighWatermark(new_high_watermark);
+    EXPECT_TRUE(dlist_->UpdateLimit(new_limit));
     EXPECT_EQ(DListTestFriend::get_max_memory(*dlist_), new_limit);
 
     std::vector<cl_uid_t> uids_012 = {10, 20, 30};
@@ -579,9 +579,9 @@ TEST_P(CacheSlotConcurrentTest, ConcurrentAccessMultipleSlots) {
     ResourceUsage new_limit = ResourceUsage(700, 0);
     ResourceUsage new_high_watermark = ResourceUsage(650, 0);
     ResourceUsage new_low_watermark = ResourceUsage(600, 0);
-    ASSERT_TRUE(dlist_->UpdateLimit(new_limit));
-    dlist_->UpdateHighWatermark(new_high_watermark);
     dlist_->UpdateLowWatermark(new_low_watermark);
+    dlist_->UpdateHighWatermark(new_high_watermark);
+    ASSERT_TRUE(dlist_->UpdateLimit(new_limit));
     EXPECT_EQ(DListTestFriend::get_max_memory(*dlist_).memory_bytes,
               new_limit.memory_bytes);
 

--- a/internal/core/unittest/test_cachinglayer/test_dlist.cpp
+++ b/internal/core/unittest/test_cachinglayer/test_dlist.cpp
@@ -104,6 +104,8 @@ TEST_F(DListTest, UpdateLimitDecreaseNoEviction) {
     ASSERT_EQ(get_used_memory(), current_usage);
 
     ResourceUsage new_limit{50, 25};
+    dlist->UpdateLowWatermark({40, 20});
+    dlist->UpdateHighWatermark({50, 25});
     EXPECT_TRUE(dlist->UpdateLimit(new_limit));
 
     EXPECT_EQ(get_used_memory(), current_usage);
@@ -124,6 +126,8 @@ TEST_F(DListTest, UpdateLimitDecreaseWithEvictionLRU) {
     EXPECT_CALL(*node2, clear_data()).Times(0);
 
     ResourceUsage new_limit{70, 40};
+    dlist->UpdateLowWatermark({56, 32});
+    dlist->UpdateHighWatermark({70, 40});
     EXPECT_TRUE(dlist->UpdateLimit(new_limit));
 
     EXPECT_EQ(get_used_memory(), usage_node2);
@@ -146,6 +150,8 @@ TEST_F(DListTest, UpdateLimitDecreaseWithEvictionMultiple) {
     EXPECT_CALL(*node3, clear_data()).Times(0);
 
     ResourceUsage new_limit{40, 15};
+    dlist->UpdateLowWatermark({32, 12});
+    dlist->UpdateHighWatermark({40, 15});
     EXPECT_TRUE(dlist->UpdateLimit(new_limit));
 
     EXPECT_EQ(get_used_memory(), usage_node3);
@@ -164,6 +170,8 @@ TEST_F(DListTest, UpdateLimitSkipsPinned) {
     EXPECT_CALL(*node2, clear_data()).Times(1);
 
     ResourceUsage new_limit{70, 40};
+    dlist->UpdateLowWatermark({56, 32});
+    dlist->UpdateHighWatermark({70, 40});
     EXPECT_TRUE(dlist->UpdateLimit(new_limit));
 
     EXPECT_EQ(get_used_memory(), usage_node1);
@@ -176,6 +184,8 @@ TEST_F(DListTest, UpdateLimitToZero) {
     EXPECT_CALL(*node1, clear_data()).Times(1);
     EXPECT_CALL(*node2, clear_data()).Times(1);
 
+    dlist->UpdateLowWatermark({0, 0});
+    dlist->UpdateHighWatermark({1, 1});
     EXPECT_TRUE(dlist->UpdateLimit({1, 1}));
 
     EXPECT_EQ(get_used_memory(), ResourceUsage{});
@@ -585,6 +595,8 @@ TEST_F(DListTest, UpdateLimitIncreaseMemDecreaseDisk) {
     EXPECT_CALL(*node2, clear_data()).Times(0);
 
     ResourceUsage new_limit{200, 35};
+    dlist->UpdateLowWatermark({80, 34});
+    dlist->UpdateHighWatermark({90, 34});
     EXPECT_TRUE(dlist->UpdateLimit(new_limit));
 
     EXPECT_EQ(get_used_memory(), usage2);
@@ -604,6 +616,8 @@ TEST_F(DListTest, EvictedNodeDestroyed) {
     EXPECT_CALL(*node1, clear_data()).Times(1);
     EXPECT_CALL(*node2, clear_data()).Times(0);
     ResourceUsage new_limit{70, 40};
+    dlist->UpdateLowWatermark({56, 32});
+    dlist->UpdateHighWatermark({70, 40});
     EXPECT_TRUE(dlist->UpdateLimit(new_limit));
     DLF::verify_list(dlist.get(), {node2});
     ResourceUsage memory_after_eviction = get_used_memory();
@@ -677,8 +691,8 @@ TEST_F(DListTest, ReserveMemoryUsesLowWatermark) {
     low_watermark = {80, 80};
     high_watermark = {90, 90};
     EXPECT_TRUE(dlist->UpdateLimit(initial_limit));
-    dlist->UpdateLowWatermark(low_watermark);
     dlist->UpdateHighWatermark(high_watermark);
+    dlist->UpdateLowWatermark(low_watermark);
 
     // Add nodes totaling 95/95 usage (above high watermark)
     MockListNode* node1 = add_and_load_node({45, 45}, "node1");  // Tail

--- a/internal/querynodev2/server.go
+++ b/internal/querynodev2/server.go
@@ -321,10 +321,10 @@ func (node *QueryNode) InitSegcore() error {
 
 	memoryLowWatermarkRatio := paramtable.Get().QueryNodeCfg.TieredMemoryLowWatermarkRatio.GetAsFloat()
 	memoryHighWatermarkRatio := paramtable.Get().QueryNodeCfg.TieredMemoryHighWatermarkRatio.GetAsFloat()
-	memoryMaxRatio := paramtable.Get().QueryNodeCfg.TieredMemoryMaxRatio.GetAsFloat()
+	memoryMaxRatio := paramtable.Get().QueryNodeCfg.OverloadedMemoryThresholdPercentage.GetAsFloat()
 	diskLowWatermarkRatio := paramtable.Get().QueryNodeCfg.TieredDiskLowWatermarkRatio.GetAsFloat()
 	diskHighWatermarkRatio := paramtable.Get().QueryNodeCfg.TieredDiskHighWatermarkRatio.GetAsFloat()
-	diskMaxRatio := paramtable.Get().QueryNodeCfg.TieredDiskMaxRatio.GetAsFloat()
+	diskMaxRatio := paramtable.Get().QueryNodeCfg.MaxDiskUsagePercentage.GetAsFloat()
 
 	if memoryLowWatermarkRatio > memoryHighWatermarkRatio {
 		return errors.New("memoryLowWatermarkRatio should not be greater than memoryHighWatermarkRatio")

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -2788,10 +2788,8 @@ type queryNodeConfig struct {
 	TieredWarmupVectorIndex        ParamItem `refreshable:"false"`
 	TieredMemoryLowWatermarkRatio  ParamItem `refreshable:"false"`
 	TieredMemoryHighWatermarkRatio ParamItem `refreshable:"false"`
-	TieredMemoryMaxRatio           ParamItem `refreshable:"false"`
 	TieredDiskLowWatermarkRatio    ParamItem `refreshable:"false"`
 	TieredDiskHighWatermarkRatio   ParamItem `refreshable:"false"`
-	TieredDiskMaxRatio             ParamItem `refreshable:"false"`
 	TieredEvictionEnabled          ParamItem `refreshable:"false"`
 	TieredCacheTouchWindowMs       ParamItem `refreshable:"false"`
 	TieredEvictionIntervalMs       ParamItem `refreshable:"false"`
@@ -3013,9 +3011,9 @@ Note that if eviction is enabled, cache data loaded during sync warmup is also s
 		},
 		Doc: `If evictionEnabled is true, a background thread will run every evictionIntervalMs to determine if an
 eviction is necessary and the amount of data to evict from memory/disk.
-- The max ratio is the max amount of memory/disk that can be used for cache.
 - If the current memory/disk usage exceeds the high watermark, an eviction will be triggered to evict data from memory/disk
-  until the memory/disk usage is below the low watermark.`,
+  until the memory/disk usage is below the low watermark.
+- The max amount of memory/disk that can be used for cache is controlled by overloadedMemoryThresholdPercentage and diskMaxUsagePercentage.`,
 		Export: true,
 	}
 	p.TieredMemoryLowWatermarkRatio.Init(base.mgr)
@@ -3034,21 +3032,6 @@ eviction is necessary and the amount of data to evict from memory/disk.
 		Export: true,
 	}
 	p.TieredMemoryHighWatermarkRatio.Init(base.mgr)
-
-	p.TieredMemoryMaxRatio = ParamItem{
-		Key:          "queryNode.segcore.tieredStorage.memoryMaxRatio",
-		Version:      "2.6.0",
-		DefaultValue: "0.9",
-		Formatter: func(v string) string {
-			ratio := getAsFloat(v)
-			if ratio < 0 || ratio > 1 {
-				return "0.9"
-			}
-			return fmt.Sprintf("%f", ratio)
-		},
-		Export: true,
-	}
-	p.TieredMemoryMaxRatio.Init(base.mgr)
 
 	p.TieredDiskLowWatermarkRatio = ParamItem{
 		Key:          "queryNode.segcore.tieredStorage.diskLowWatermarkRatio",
@@ -3079,21 +3062,6 @@ eviction is necessary and the amount of data to evict from memory/disk.
 		Export: true,
 	}
 	p.TieredDiskHighWatermarkRatio.Init(base.mgr)
-
-	p.TieredDiskMaxRatio = ParamItem{
-		Key:          "queryNode.segcore.tieredStorage.diskMaxRatio",
-		Version:      "2.6.0",
-		DefaultValue: "0.9",
-		Formatter: func(v string) string {
-			ratio := getAsFloat(v)
-			if ratio < 0 || ratio > 1 {
-				return "0.9"
-			}
-			return fmt.Sprintf("%f", ratio)
-		},
-		Export: true,
-	}
-	p.TieredDiskMaxRatio.Init(base.mgr)
 
 	p.TieredCacheTouchWindowMs = ParamItem{
 		Key:          "queryNode.segcore.tieredStorage.cacheTouchWindowMs",


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/43038

If some data are set to load lazily and eviction is not enabled, QN may permit more segment to be loaded than its capacity. In that case later when searching, more data are loaded into the QN and may cause an OOM. this PR poses a hard limit on physical memory when loading data within any segment. If more segments than capacity are loaded in QN, searches will fail when the QN is full.