### PR TITLE
fix: Prevent duplicate segment results in count queries

### DIFF
--- a/internal/querycoordv2/task/task_test.go
+++ b/internal/querycoordv2/task/task_test.go
@@ -19,7 +19,6 @@ package task
 import (
 	"context"
 	"math/rand"
-	"strings"
 	"testing"
 	"time"
 
@@ -92,11 +91,6 @@ type TaskSuite struct {
 
 func (suite *TaskSuite) SetupSuite() {
 	paramtable.Init()
-	addressList, err := suite.SetupEtcd()
-	suite.Require().NoError(err)
-	params := paramtable.Get()
-	params.Save(params.EtcdCfg.Endpoints.Key, strings.Join(addressList, ","))
-
 	suite.collection = 1000
 	suite.replica = meta.NewReplica(&querypb.Replica{
 		CollectionID:  suite.collection,
@@ -144,7 +138,6 @@ func (suite *TaskSuite) SetupSuite() {
 }
 
 func (suite *TaskSuite) TearDownSuite() {
-	suite.TearDownEmbedEtcd()
 	paramtable.Get().Reset(paramtable.Get().EtcdCfg.Endpoints.Key)
 }
 

--- a/internal/querynodev2/delegator/delegator.go
+++ b/internal/querynodev2/delegator/delegator.go
@@ -684,7 +684,6 @@ func (sd *shardDelegator) Query(ctx context.Context, req *querypb.QueryRequest) 
 		log.Debug("execute count on segments...",
 			zap.Int64s("sealedIDs", sealedIDs),
 			zap.Int64s("growingIDs", growingIDs),
-			zap.Int64("targetVersion", sd.distribution.queryView.version),
 		)
 	}
 

--- a/internal/querynodev2/delegator/distribution.go
+++ b/internal/querynodev2/delegator/distribution.go
@@ -178,6 +178,7 @@ func (d *distribution) PinReadableSegments(requiredLoadRatio float64, partitions
 		}
 	}
 	sealed, growing = current.Get(partitions...)
+	version = current.version
 	if requiredLoadRatio == 1.0 {
 		// if require full result, current target is fully loaded, so we can use current target version to filter segments
 		// Note: we can also use query view's segment list to filter segments, but it's not efficient enough

--- a/internal/querynodev2/delegator/distribution.go
+++ b/internal/querynodev2/delegator/distribution.go
@@ -179,14 +179,13 @@ func (d *distribution) PinReadableSegments(requiredLoadRatio float64, partitions
 	}
 	sealed, growing = current.Get(partitions...)
 	version = current.version
-	if requiredLoadRatio == 1.0 {
-		// if require full result, current target is fully loaded, so we can use current target version to filter segments
-		// Note: we can also use query view's segment list to filter segments, but it's not efficient enough
+	if d.queryView.GetLoadedRatio() == 1.0 {
+		// if query view is fully loaded, we can use current target version to filter segments
 		targetVersion := current.GetTargetVersion()
 		filterReadable := d.readableFilter(targetVersion)
 		sealed, growing = d.filterSegments(sealed, growing, filterReadable)
 	} else {
-		// if require partial result, we need to filter segments by query view's segment list
+		// if query view is not fully loaded, we need to filter segments by query view's segment list to offer partial result
 		sealed = lo.Map(sealed, func(item SnapshotItem, _ int) SnapshotItem {
 			return SnapshotItem{
 				NodeID: item.NodeID,

--- a/tests/integration/balance/balance_test.go
+++ b/tests/integration/balance/balance_test.go
@@ -337,6 +337,8 @@ func (s *BalanceTestSuit) TestConcurrentBalanceChannelAndSegment() {
 	name := "test_balance_" + funcutil.GenRandomStr()
 	s.initCollection(name, 1, 4, 10, 2000, 500)
 
+	paramtable.Get().Save(paramtable.Get().QueryCoordCfg.AutoBalanceChannel.Key, "false")
+
 	stopSearchCh := make(chan struct{})
 	failCounter := atomic.NewInt64(0)
 
@@ -366,12 +368,26 @@ func (s *BalanceTestSuit) TestConcurrentBalanceChannelAndSegment() {
 		}
 	}()
 
+	for _, qn := range s.Cluster.GetAllQueryNodes() {
+		resp, err := qn.MustGetClient(ctx).GetDataDistribution(ctx, &querypb.GetDataDistributionRequest{})
+		s.NoError(err)
+		s.True(merr.Ok(resp.GetStatus()))
+		log.Info("segments on query node", zap.Int64("nodeID", qn.GetNodeID()), zap.Int("channel", len(resp.Channels)), zap.Int("segments", len(resp.Segments)))
+	}
+
 	// then we add 1 query node, expected segment and channel will be move to new query node concurrently
 	qn1 := s.Cluster.AddQueryNode()
 	sn1 := s.Cluster.AddStreamingNode()
 
 	// wait until balance channel finished
 	s.Eventually(func() bool {
+		for _, qn := range s.Cluster.GetAllQueryNodes() {
+			resp, err := qn.MustGetClient(ctx).GetDataDistribution(ctx, &querypb.GetDataDistributionRequest{})
+			s.NoError(err)
+			s.True(merr.Ok(resp.GetStatus()))
+			log.Info("segments on query node", zap.Int64("nodeID", qn.GetNodeID()), zap.Int("channel", len(resp.Channels)), zap.Int("segments", len(resp.Segments)))
+		}
+
 		resp, err := qn1.MustGetClient(ctx).GetDataDistribution(ctx, &querypb.GetDataDistributionRequest{})
 		s.NoError(err)
 		resp2, err := sn1.MustGetClient(ctx).GetDataDistribution(ctx, &querypb.GetDataDistributionRequest{})


### PR DESCRIPTION
issue: #41570
Fix issue where growing and sealed segments could be searched simultaneously, causing inflated count(*) results. This was caused by logic introduced in PR #42009 that made sealed segments readable before target version advancement.

Changes include:
- Fix conditional filtering logic in PinReadableSegments to prevent sealed segments from becoming readable prematurely
- Use target version filter for full results (ratio=1.0) to ensure sealed segments only become readable after target advancement
- Use query view segment list filter for partial results (ratio<1.0) to maintain backward compatibility
- Simplify target version setting in AddDistributions to prevent premature segment readability
- Add logging for redundant growing segments during sync
- Add comprehensive unit tests covering the duplicate segment scenario

This fix ensures count(*) queries return accurate results by preventing the same segment from being counted in both growing and sealed states.