### PR TITLE
enhance: [StorageV2] Refine storage rw option usage & validation

### DIFF
--- a/internal/datacoord/compaction_task_mix.go
+++ b/internal/datacoord/compaction_task_mix.go
@@ -185,7 +185,8 @@ func (t *mixCompactionTask) GetTaskProto() *datapb.CompactionTask {
 func newMixCompactionTask(t *datapb.CompactionTask,
 	allocator allocator.Allocator,
 	meta CompactionMeta,
-	ievm IndexEngineVersionManager) *mixCompactionTask {
+	ievm IndexEngineVersionManager,
+) *mixCompactionTask {
 	task := &mixCompactionTask{
 		allocator: allocator,
 		meta:      meta,

--- a/internal/datacoord/import_util.go
+++ b/internal/datacoord/import_util.go
@@ -851,7 +851,8 @@ func createSortCompactionTask(ctx context.Context,
 	targetSegmentID int64,
 	meta *meta,
 	handler Handler,
-	alloc allocator.Allocator) (*datapb.CompactionTask, error) {
+	alloc allocator.Allocator,
+) (*datapb.CompactionTask, error) {
 	if originSegment.GetNumOfRows() == 0 {
 		operator := UpdateStatusOperator(originSegment.GetID(), commonpb.SegmentState_Dropped)
 		err := meta.UpdateSegmentsInfo(ctx, operator)

--- a/internal/datanode/compactor/clustering_compactor_storage_v2_test.go
+++ b/internal/datanode/compactor/clustering_compactor_storage_v2_test.go
@@ -52,12 +52,7 @@ type ClusteringCompactionTaskStorageV2Suite struct {
 func (s *ClusteringCompactionTaskStorageV2Suite) SetupTest() {
 	s.setupTest()
 	paramtable.Get().Save("common.storage.enableV2", "true")
-<<<<<<< HEAD
-	initcore.InitStorageV2FileSystem(paramtable.Get())
 	s.task.compactionParams = compaction.GenParams()
-=======
-	refreshPlanParams(s.plan)
->>>>>>> 3d3a711376 (fix unittest and add storage config in sync task)
 }
 
 func (s *ClusteringCompactionTaskStorageV2Suite) TearDownTest() {

--- a/internal/datanode/compactor/clustering_compactor_storage_v2_test.go
+++ b/internal/datanode/compactor/clustering_compactor_storage_v2_test.go
@@ -34,9 +34,9 @@ import (
 	"github.com/milvus-io/milvus/internal/flushcommon/syncmgr"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/storagev2/packed"
-	"github.com/milvus-io/milvus/internal/util/initcore"
 	"github.com/milvus-io/milvus/pkg/v2/objectstorage"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/tsoutil"
 )
@@ -51,15 +51,17 @@ type ClusteringCompactionTaskStorageV2Suite struct {
 
 func (s *ClusteringCompactionTaskStorageV2Suite) SetupTest() {
 	s.setupTest()
-	paramtable.Get().Save("common.storageType", "local")
 	paramtable.Get().Save("common.storage.enableV2", "true")
+<<<<<<< HEAD
 	initcore.InitStorageV2FileSystem(paramtable.Get())
 	s.task.compactionParams = compaction.GenParams()
+=======
+	refreshPlanParams(s.plan)
+>>>>>>> 3d3a711376 (fix unittest and add storage config in sync task)
 }
 
 func (s *ClusteringCompactionTaskStorageV2Suite) TearDownTest() {
 	paramtable.Get().Reset(paramtable.Get().CommonCfg.EntityExpirationTTL.Key)
-	paramtable.Get().Reset("common.storageType")
 	paramtable.Get().Reset("common.storage.enableV2")
 	os.RemoveAll(paramtable.Get().LocalStorageCfg.Path.GetValue() + "insert_log")
 	os.RemoveAll(paramtable.Get().LocalStorageCfg.Path.GetValue() + "delta_log")
@@ -282,7 +284,10 @@ func (s *ClusteringCompactionTaskStorageV2Suite) initStorageV2Segments(rows int,
 	channelName := fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", CollectionID)
 	deleteData := storage.NewDeleteData([]storage.PrimaryKey{storage.NewInt64PrimaryKey(100)}, []uint64{tsoutil.ComposeTSByTime(getMilvusBirthday().Add(time.Second), 0)})
 	pack := new(syncmgr.SyncPack).WithCollectionID(CollectionID).WithPartitionID(PartitionID).WithSegmentID(segmentID).WithChannelName(channelName).WithInsertData(genInsertData(rows, segmentID, genCollectionSchema())).WithDeleteData(deleteData)
-	bw := syncmgr.NewBulkPackWriterV2(mc, genCollectionSchema(), cm, s.mockAlloc, packed.DefaultWriteBufferSize, 0, nil)
+	bw := syncmgr.NewBulkPackWriterV2(mc, genCollectionSchema(), cm, s.mockAlloc, packed.DefaultWriteBufferSize, 0, &indexpb.StorageConfig{
+		StorageType: "local",
+		RootPath:    rootPath,
+	})
 	return bw.Write(context.Background(), pack)
 }
 

--- a/internal/datanode/compactor/clustering_compactor_test.go
+++ b/internal/datanode/compactor/clustering_compactor_test.go
@@ -63,6 +63,8 @@ func (s *ClusteringCompactionTaskSuite) SetupSuite() {
 }
 
 func (s *ClusteringCompactionTaskSuite) setupTest() {
+	paramtable.Get().Save(paramtable.Get().CommonCfg.StorageType.Key, "local")
+
 	s.mockBinlogIO = mock_util.NewMockBinlogIO(s.T())
 
 	s.mockBinlogIO.EXPECT().Upload(mock.Anything, mock.Anything).Return(nil).Maybe()
@@ -116,6 +118,7 @@ func (s *ClusteringCompactionTaskSuite) SetupSubTest() {
 
 func (s *ClusteringCompactionTaskSuite) TearDownTest() {
 	paramtable.Get().Reset(paramtable.Get().CommonCfg.EntityExpirationTTL.Key)
+	paramtable.Get().Reset(paramtable.Get().CommonCfg.StorageType.Key)
 }
 
 func (s *ClusteringCompactionTaskSuite) TestWrongCompactionType() {
@@ -421,6 +424,9 @@ func (s *ClusteringCompactionTaskSuite) TestCompactionWithBM25Function() {
 	defer paramtable.Get().Reset(paramtable.Get().DataNodeCfg.BinLogMaxSize.Key)
 	s.task.compactionParams = compaction.GenParams()
 	s.prepareCompactionWithBM25FunctionTask()
+
+	err := s.task.init()
+	s.Require().NoError(err)
 
 	compactionResult, err := s.task.Compact()
 	s.Require().NoError(err)

--- a/internal/datanode/compactor/merge_sort.go
+++ b/internal/datanode/compactor/merge_sort.go
@@ -54,8 +54,6 @@ func mergeSortMultipleSegments(ctx context.Context,
 		return nil, err
 	}
 
-	bucketName := compactionParams.StorageConfig.GetBucketName()
-
 	segmentReaders := make([]storage.RecordReader, len(binlogs))
 	segmentFilters := make([]compaction.EntityFilter, len(binlogs))
 	for i, s := range binlogs {
@@ -64,7 +62,6 @@ func mergeSortMultipleSegments(ctx context.Context,
 			plan.GetSchema(),
 			storage.WithDownloader(binlogIO.Download),
 			storage.WithVersion(s.StorageVersion),
-			storage.WithBucketName(bucketName),
 			storage.WithStorageConfig(compactionParams.StorageConfig),
 		)
 		if err != nil {

--- a/internal/datanode/compactor/mix_compactor.go
+++ b/internal/datanode/compactor/mix_compactor.go
@@ -213,14 +213,11 @@ func (t *mixCompactionTask) writeSegment(ctx context.Context,
 	}
 	entityFilter := compaction.NewEntityFilter(delta, t.plan.GetCollectionTtl(), t.currentTime)
 
-	bucketName := t.compactionParams.StorageConfig.GetBucketName()
-
 	reader, err := storage.NewBinlogRecordReader(ctx,
 		seg.GetFieldBinlogs(),
 		t.plan.GetSchema(),
 		storage.WithDownloader(t.binlogIO.Download),
 		storage.WithVersion(seg.GetStorageVersion()),
-		storage.WithBucketName(bucketName),
 		storage.WithStorageConfig(t.compactionParams.StorageConfig),
 	)
 	if err != nil {

--- a/internal/datanode/compactor/mix_compactor_storage_v2_test.go
+++ b/internal/datanode/compactor/mix_compactor_storage_v2_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/objectstorage"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/tsoutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
@@ -320,7 +321,10 @@ func (s *MixCompactionTaskStorageV2Suite) initStorageV2Segments(rows int, seed i
 
 	channelName := fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", CollectionID)
 	pack := new(syncmgr.SyncPack).WithCollectionID(CollectionID).WithPartitionID(PartitionID).WithSegmentID(seed).WithChannelName(channelName).WithInsertData(getInsertData(rows, seed, s.meta.GetSchema()))
-	bw := syncmgr.NewBulkPackWriterV2(mc, s.meta.Schema, cm, alloc, packed.DefaultWriteBufferSize, 0, nil)
+	bw := syncmgr.NewBulkPackWriterV2(mc, s.meta.Schema, cm, alloc, packed.DefaultWriteBufferSize, 0, &indexpb.StorageConfig{
+		StorageType: "local",
+		RootPath:    rootPath,
+	})
 	return bw.Write(context.Background(), pack)
 }
 

--- a/internal/datanode/compactor/mix_compactor_test.go
+++ b/internal/datanode/compactor/mix_compactor_test.go
@@ -327,7 +327,6 @@ func (s *MixCompactionTaskSuite) prepareCompactSortedSegment() {
 				{Binlogs: []*datapb.Binlog{{LogPath: deltaPath}}},
 			},
 		})
-
 	}
 }
 
@@ -468,6 +467,10 @@ func (s *MixCompactionTaskSuite) prepareSplitMergeEntityExpired() {
 
 func (s *MixCompactionTaskSuite) TestSplitMergeEntityExpired() {
 	s.prepareSplitMergeEntityExpired()
+
+	err := s.task.preCompact()
+	s.Require().NoError(err)
+
 	compactionSegments, err := s.task.mergeSplit(s.task.ctx)
 	s.NoError(err)
 	s.Equal(1, len(compactionSegments))
@@ -566,6 +569,9 @@ func (s *MixCompactionTaskSuite) TestMergeNoExpirationLackBinlog() {
 			s.task.partitionID = PartitionID
 			s.task.maxRows = 1000
 
+			err := s.task.preCompact()
+			s.Require().NoError(err)
+
 			res, err := s.task.mergeSplit(s.task.ctx)
 			s.NoError(err)
 			s.EqualValues(test.expectedRes, len(res))
@@ -644,6 +650,9 @@ func (s *MixCompactionTaskSuite) TestMergeNoExpiration() {
 			s.task.collectionID = CollectionID
 			s.task.partitionID = PartitionID
 			s.task.maxRows = 1000
+
+			err := s.task.preCompact()
+			s.NoError(err)
 
 			res, err := s.task.mergeSplit(s.task.ctx)
 			s.NoError(err)

--- a/internal/datanode/compactor/segment_writer.go
+++ b/internal/datanode/compactor/segment_writer.go
@@ -157,7 +157,6 @@ func (w *MultiSegmentWriter) rotateWriter() error {
 	w.currentSegmentID = newSegmentID
 
 	chunkSize := w.binLogMaxSize
-	rootPath := w.params.StorageConfig.GetRootPath()
 
 	w.rwOption = append(w.rwOption,
 		storage.WithUploader(func(ctx context.Context, kvs map[string][]byte) error {
@@ -165,10 +164,8 @@ func (w *MultiSegmentWriter) rotateWriter() error {
 		}),
 		storage.WithVersion(w.storageVersion),
 	)
-	// TODO bucketName shall be passed via StorageConfig like index/stats task
-	bucketName := w.params.StorageConfig.GetBucketName()
 	rw, err := storage.NewBinlogRecordWriter(w.ctx, w.collectionID, w.partitionID, newSegmentID,
-		w.schema, w.allocator.logIDAlloc, chunkSize, bucketName, rootPath, w.maxRows, w.rwOption...,
+		w.schema, w.allocator.logIDAlloc, chunkSize, w.maxRows, w.rwOption...,
 	)
 	if err != nil {
 		return err

--- a/internal/datanode/compactor/sort_compaction.go
+++ b/internal/datanode/compactor/sort_compaction.go
@@ -166,8 +166,6 @@ func (t *sortCompactionTask) sortSegment(ctx context.Context) (*datapb.Compactio
 		t.plan.GetSchema(),
 		alloc,
 		t.compactionParams.BinLogMaxSize,
-		t.compactionParams.StorageConfig.GetBucketName(),
-		t.compactionParams.StorageConfig.GetRootPath(),
 		numRows,
 		storage.WithUploader(func(ctx context.Context, kvs map[string][]byte) error {
 			return t.binlogIO.Upload(ctx, kvs)
@@ -209,7 +207,6 @@ func (t *sortCompactionTask) sortSegment(ctx context.Context) (*datapb.Compactio
 	rr, err := storage.NewBinlogRecordReader(ctx, t.insertLogs, t.plan.Schema,
 		storage.WithVersion(t.segmentStorageVersion),
 		storage.WithDownloader(t.binlogIO.Download),
-		storage.WithBucketName(t.compactionParams.StorageConfig.BucketName),
 		storage.WithStorageConfig(t.compactionParams.StorageConfig),
 	)
 	if err != nil {

--- a/internal/datanode/importv2/task_import.go
+++ b/internal/datanode/importv2/task_import.go
@@ -145,7 +145,7 @@ func (t *ImportTask) Execute() []*conc.Future[any] {
 	req := t.req
 
 	fn := func(file *internalpb.ImportFile) error {
-		reader, err := importutilv2.NewReader(t.ctx, t.cm, t.GetSchema(), file, req.GetOptions(), bufferSize)
+		reader, err := importutilv2.NewReader(t.ctx, t.cm, t.GetSchema(), file, req.GetOptions(), bufferSize, t.req.GetStorageConfig())
 		if err != nil {
 			log.Warn("new reader failed", WrapLogFields(t, zap.String("file", file.String()), zap.Error(err))...)
 			reason := fmt.Sprintf("error: %v, file: %s", err, file.String())

--- a/internal/datanode/importv2/task_preimport.go
+++ b/internal/datanode/importv2/task_preimport.go
@@ -141,7 +141,7 @@ func (t *PreImportTask) Execute() []*conc.Future[any] {
 		})
 
 	fn := func(i int, file *internalpb.ImportFile) error {
-		reader, err := importutilv2.NewReader(t.ctx, t.cm, t.GetSchema(), file, t.options, bufferSize)
+		reader, err := importutilv2.NewReader(t.ctx, t.cm, t.GetSchema(), file, t.options, bufferSize, t.req.GetStorageConfig())
 		if err != nil {
 			log.Warn("new reader failed", WrapLogFields(t, zap.String("file", file.String()), zap.Error(err))...)
 			reason := fmt.Sprintf("error: %v, file: %s", err, file.String())

--- a/internal/datanode/index/task_stats.go
+++ b/internal/datanode/index/task_stats.go
@@ -185,8 +185,6 @@ func (st *statsTask) sort(ctx context.Context) ([]*datapb.FieldBinlog, error) {
 		st.req.GetSchema(),
 		alloc,
 		st.req.GetBinlogMaxSize(),
-		st.req.GetStorageConfig().GetBucketName(),
-		st.req.GetStorageConfig().GetRootPath(),
 		numRows,
 		storage.WithUploader(func(ctx context.Context, kvs map[string][]byte) error {
 			return st.binlogIO.Upload(ctx, kvs)
@@ -237,7 +235,6 @@ func (st *statsTask) sort(ctx context.Context) ([]*datapb.FieldBinlog, error) {
 	rr, err := storage.NewBinlogRecordReader(ctx, st.req.InsertLogs, st.req.Schema,
 		storage.WithVersion(st.req.StorageVersion),
 		storage.WithDownloader(st.binlogIO.Download),
-		storage.WithBucketName(st.req.StorageConfig.BucketName),
 		storage.WithStorageConfig(st.req.GetStorageConfig()),
 	)
 	if err != nil {

--- a/internal/storage/rw.go
+++ b/internal/storage/rw.go
@@ -32,7 +32,6 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
-	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
 
 const (
@@ -45,15 +44,42 @@ type (
 	uploaderFn   func(ctx context.Context, kvs map[string][]byte) error
 )
 
+// rwOp is enum alias for rwOption op field.
+type rwOp int32
+
+const (
+	OpWrite rwOp = 0
+	OpRead  rwOp = 1
+)
+
 type rwOptions struct {
 	version             int64
+	op                  rwOp
 	bufferSize          int64
 	downloader          downloaderFn
 	uploader            uploaderFn
 	multiPartUploadSize int64
 	columnGroups        []storagecommon.ColumnGroup
-	bucketName          string
 	storageConfig       *indexpb.StorageConfig
+}
+
+func (o *rwOptions) validate() error {
+	if o.storageConfig == nil {
+		return merr.WrapErrServiceInternal("storage config is nil")
+	}
+	if o.op == OpWrite && o.uploader == nil {
+		return merr.WrapErrServiceInternal("uploader is nil for writer")
+	}
+	switch o.version {
+	case StorageV1:
+		if o.op == OpRead && o.downloader == nil {
+			return merr.WrapErrServiceInternal("downloader is nil for v1 reader")
+		}
+	case StorageV2:
+	default:
+		return merr.WrapErrServiceInternal(fmt.Sprintf("unsupported storage version %d", o.version))
+	}
+	return nil
 }
 
 type RwOption func(*rwOptions)
@@ -62,24 +88,20 @@ func DefaultWriterOptions() *rwOptions {
 	return &rwOptions{
 		bufferSize:          packed.DefaultWriteBufferSize,
 		multiPartUploadSize: packed.DefaultMultiPartUploadSize,
+		op:                  OpWrite,
 	}
 }
 
 func DefaultReaderOptions() *rwOptions {
 	return &rwOptions{
 		bufferSize: packed.DefaultReadBufferSize,
+		op:         OpRead,
 	}
 }
 
 func WithVersion(version int64) RwOption {
 	return func(options *rwOptions) {
 		options.version = version
-	}
-}
-
-func WithBucketName(bucketName string) RwOption {
-	return func(options *rwOptions) {
-		options.bucketName = bucketName
 	}
 }
 
@@ -202,6 +224,9 @@ func NewBinlogRecordReader(ctx context.Context, binlogs []*datapb.FieldBinlog, s
 	for _, opt := range option {
 		opt(rwOptions)
 	}
+	if err := rwOptions.validate(); err != nil {
+		return nil, err
+	}
 	switch rwOptions.version {
 	case StorageV1:
 		blobsReader, err := makeBlobsReader(ctx, binlogs, rwOptions.downloader)
@@ -216,12 +241,13 @@ func NewBinlogRecordReader(ctx context.Context, binlogs []*datapb.FieldBinlog, s
 		binlogLists := lo.Map(binlogs, func(fieldBinlog *datapb.FieldBinlog, _ int) []*datapb.Binlog {
 			return fieldBinlog.GetBinlogs()
 		})
+		bucketName := rwOptions.storageConfig.BucketName
 		paths := make([][]string, len(binlogLists[0]))
 		for _, binlogs := range binlogLists {
 			for j, binlog := range binlogs {
 				logPath := binlog.GetLogPath()
-				if paramtable.Get().CommonCfg.StorageType.GetValue() != "local" {
-					logPath = path.Join(rwOptions.bucketName, logPath)
+				if rwOptions.storageConfig.StorageType != "local" {
+					logPath = path.Join(bucketName, logPath)
 				}
 				paths[j] = append(paths[j], logPath)
 			}
@@ -232,16 +258,17 @@ func NewBinlogRecordReader(ctx context.Context, binlogs []*datapb.FieldBinlog, s
 }
 
 func NewBinlogRecordWriter(ctx context.Context, collectionID, partitionID, segmentID UniqueID,
-	schema *schemapb.CollectionSchema, allocator allocator.Interface, chunkSize uint64, bucketName, rootPath string, maxRowNum int64,
+	schema *schemapb.CollectionSchema, allocator allocator.Interface, chunkSize uint64, maxRowNum int64,
 	option ...RwOption,
 ) (BinlogRecordWriter, error) {
 	rwOptions := DefaultWriterOptions()
 	for _, opt := range option {
 		opt(rwOptions)
 	}
-	if rwOptions.storageConfig != nil {
-		bucketName = rwOptions.storageConfig.BucketName
+	if err := rwOptions.validate(); err != nil {
+		return nil, err
 	}
+
 	blobsWriter := func(blobs []*Blob) error {
 		kvs := make(map[string][]byte, len(blobs))
 		for _, blob := range blobs {
@@ -251,12 +278,13 @@ func NewBinlogRecordWriter(ctx context.Context, collectionID, partitionID, segme
 	}
 	switch rwOptions.version {
 	case StorageV1:
+		rootPath := rwOptions.storageConfig.GetRootPath()
 		return newCompositeBinlogRecordWriter(collectionID, partitionID, segmentID, schema,
 			blobsWriter, allocator, chunkSize, rootPath, maxRowNum,
 		)
 	case StorageV2:
 		return newPackedBinlogRecordWriter(collectionID, partitionID, segmentID, schema,
-			blobsWriter, allocator, chunkSize, bucketName, rootPath, maxRowNum,
+			blobsWriter, allocator, chunkSize, maxRowNum,
 			rwOptions.bufferSize, rwOptions.multiPartUploadSize, rwOptions.columnGroups,
 			rwOptions.storageConfig,
 		)

--- a/internal/storage/rw_test.go
+++ b/internal/storage/rw_test.go
@@ -29,36 +29,19 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
-	"google.golang.org/grpc"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/allocator"
 	"github.com/milvus-io/milvus/internal/mocks/flushcommon/mock_util"
 	"github.com/milvus-io/milvus/internal/storagecommon"
-	"github.com/milvus-io/milvus/internal/util/initcore"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
-	"github.com/milvus-io/milvus/pkg/v2/proto/rootcoordpb"
-	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/tsoutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
-
-type mockIDAllocator struct{}
-
-func (tso *mockIDAllocator) AllocID(ctx context.Context, req *rootcoordpb.AllocIDRequest, opts ...grpc.CallOption) (*rootcoordpb.AllocIDResponse, error) {
-	return &rootcoordpb.AllocIDResponse{
-		Status: merr.Success(),
-		ID:     int64(1),
-		Count:  req.Count,
-	}, nil
-}
-
-func newMockIDAllocator() *mockIDAllocator {
-	return &mockIDAllocator{}
-}
 
 func TestPackedBinlogRecordSuite(t *testing.T) {
 	suite.Run(t, new(PackedBinlogRecordSuite))
@@ -72,14 +55,13 @@ type PackedBinlogRecordSuite struct {
 	logIDAlloc   allocator.Interface
 	mockBinlogIO *mock_util.MockBinlogIO
 
-	collectionID UniqueID
-	partitionID  UniqueID
-	segmentID    UniqueID
-	schema       *schemapb.CollectionSchema
-	bucketName   string
-	rootPath     string
-	maxRowNum    int64
-	chunkSize    uint64
+	collectionID  UniqueID
+	partitionID   UniqueID
+	segmentID     UniqueID
+	schema        *schemapb.CollectionSchema
+	maxRowNum     int64
+	chunkSize     uint64
+	storageConfig *indexpb.StorageConfig
 }
 
 func (s *PackedBinlogRecordSuite) SetupTest() {
@@ -87,17 +69,22 @@ func (s *PackedBinlogRecordSuite) SetupTest() {
 	s.ctx = ctx
 	logIDAlloc := allocator.NewLocalAllocator(1, math.MaxInt64)
 	s.logIDAlloc = logIDAlloc
-	initcore.InitLocalArrowFileSystem("/tmp")
+	// initcore.InitLocalArrowFileSystem("/tmp")
 	s.mockID.Store(time.Now().UnixMilli())
 	s.mockBinlogIO = mock_util.NewMockBinlogIO(s.T())
 	s.collectionID = UniqueID(0)
 	s.partitionID = UniqueID(0)
 	s.segmentID = UniqueID(0)
 	s.schema = generateTestSchema()
-	s.rootPath = "/tmp"
-	s.bucketName = "a-bucket"
+	// s.rootPath = "/tmp"
+	// s.bucketName = "a-bucket"
 	s.maxRowNum = int64(1000)
 	s.chunkSize = uint64(1024)
+	s.storageConfig = &indexpb.StorageConfig{
+		StorageType: "local",
+		RootPath:    "/tmp",
+		BucketName:  "a-bucket",
+	}
 }
 
 func (s *PackedBinlogRecordSuite) TestPackedBinlogRecordIntegration() {
@@ -139,9 +126,10 @@ func (s *PackedBinlogRecordSuite) TestPackedBinlogRecordIntegration() {
 		WithMultiPartUploadSize(0),
 		WithBufferSize(1 * 1024 * 1024), // 1MB
 		WithColumnGroups(columnGroups),
+		WithStorageConfig(s.storageConfig),
 	}
 
-	w, err := NewBinlogRecordWriter(s.ctx, s.collectionID, s.partitionID, s.segmentID, s.schema, s.logIDAlloc, s.chunkSize, s.bucketName, s.rootPath, s.maxRowNum, wOption...)
+	w, err := NewBinlogRecordWriter(s.ctx, s.collectionID, s.partitionID, s.segmentID, s.schema, s.logIDAlloc, s.chunkSize, s.maxRowNum, wOption...)
 	s.NoError(err)
 
 	blobs, err := generateTestData(rows)
@@ -183,6 +171,7 @@ func (s *PackedBinlogRecordSuite) TestPackedBinlogRecordIntegration() {
 	binlogs := lo.Values(fieldBinlogs)
 	rOption := []RwOption{
 		WithVersion(StorageV2),
+		WithStorageConfig(s.storageConfig),
 	}
 	r, err := NewBinlogRecordReader(s.ctx, binlogs, s.schema, rOption...)
 	s.NoError(err)
@@ -228,6 +217,7 @@ func (s *PackedBinlogRecordSuite) TestGenerateBM25Stats() {
 		WithMultiPartUploadSize(0),
 		WithBufferSize(10 * 1024 * 1024), // 10MB
 		WithColumnGroups(columnGroups),
+		WithStorageConfig(s.storageConfig),
 	}
 
 	v := &Value{
@@ -238,7 +228,7 @@ func (s *PackedBinlogRecordSuite) TestGenerateBM25Stats() {
 	rec, err := ValueSerializer([]*Value{v}, s.schema.Fields)
 	s.NoError(err)
 
-	w, err := NewBinlogRecordWriter(s.ctx, s.collectionID, s.partitionID, s.segmentID, s.schema, s.logIDAlloc, s.chunkSize, s.bucketName, s.rootPath, s.maxRowNum, wOption...)
+	w, err := NewBinlogRecordWriter(s.ctx, s.collectionID, s.partitionID, s.segmentID, s.schema, s.logIDAlloc, s.chunkSize, s.maxRowNum, wOption...)
 	s.NoError(err)
 	err = w.Write(rec)
 	s.NoError(err)
@@ -258,8 +248,9 @@ func (s *PackedBinlogRecordSuite) TestGenerateBM25Stats() {
 func (s *PackedBinlogRecordSuite) TestUnsuportedStorageVersion() {
 	wOption := []RwOption{
 		WithVersion(-1),
+		WithStorageConfig(s.storageConfig),
 	}
-	_, err := NewBinlogRecordWriter(s.ctx, s.collectionID, s.partitionID, s.segmentID, s.schema, s.logIDAlloc, s.chunkSize, s.bucketName, s.rootPath, s.maxRowNum, wOption...)
+	_, err := NewBinlogRecordWriter(s.ctx, s.collectionID, s.partitionID, s.segmentID, s.schema, s.logIDAlloc, s.chunkSize, s.maxRowNum, wOption...)
 	s.Error(err)
 
 	rOption := []RwOption{
@@ -282,8 +273,9 @@ func (s *PackedBinlogRecordSuite) TestNoPrimaryKeyError() {
 	wOption := []RwOption{
 		WithVersion(StorageV2),
 		WithColumnGroups(columnGroups),
+		WithStorageConfig(s.storageConfig),
 	}
-	_, err := NewBinlogRecordWriter(s.ctx, s.collectionID, s.partitionID, s.segmentID, s.schema, s.logIDAlloc, s.chunkSize, s.bucketName, s.rootPath, s.maxRowNum, wOption...)
+	_, err := NewBinlogRecordWriter(s.ctx, s.collectionID, s.partitionID, s.segmentID, s.schema, s.logIDAlloc, s.chunkSize, s.maxRowNum, wOption...)
 	s.Error(err)
 }
 
@@ -300,14 +292,16 @@ func (s *PackedBinlogRecordSuite) TestConvertArrowSchemaError() {
 	wOption := []RwOption{
 		WithVersion(StorageV2),
 		WithColumnGroups(columnGroups),
+		WithStorageConfig(s.storageConfig),
 	}
-	_, err := NewBinlogRecordWriter(s.ctx, s.collectionID, s.partitionID, s.segmentID, s.schema, s.logIDAlloc, s.chunkSize, s.bucketName, s.rootPath, s.maxRowNum, wOption...)
+	_, err := NewBinlogRecordWriter(s.ctx, s.collectionID, s.partitionID, s.segmentID, s.schema, s.logIDAlloc, s.chunkSize, s.maxRowNum, wOption...)
 	s.Error(err)
 }
 
 func (s *PackedBinlogRecordSuite) TestEmptyBinlog() {
 	rOption := []RwOption{
 		WithVersion(StorageV2),
+		WithStorageConfig(s.storageConfig),
 	}
 	_, err := NewBinlogRecordReader(s.ctx, []*datapb.FieldBinlog{}, s.schema, rOption...)
 	s.Error(err)
@@ -323,9 +317,13 @@ func (s *PackedBinlogRecordSuite) TestAllocIDExhausedError() {
 	wOption := []RwOption{
 		WithVersion(StorageV2),
 		WithColumnGroups(columnGroups),
+		WithStorageConfig(s.storageConfig),
+		WithUploader(func(ctx context.Context, kvs map[string][]byte) error {
+			return nil
+		}),
 	}
 	logIDAlloc := allocator.NewLocalAllocator(1, 1)
-	w, err := NewBinlogRecordWriter(s.ctx, s.collectionID, s.partitionID, s.segmentID, s.schema, logIDAlloc, s.chunkSize, s.bucketName, s.rootPath, s.maxRowNum, wOption...)
+	w, err := NewBinlogRecordWriter(s.ctx, s.collectionID, s.partitionID, s.segmentID, s.schema, logIDAlloc, s.chunkSize, s.maxRowNum, wOption...)
 	s.NoError(err)
 
 	size := 10
@@ -570,6 +568,82 @@ func Test_makeBlobsReader(t *testing.T) {
 				got = append(got, bs)
 			}
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestRwOptionValidate(t *testing.T) {
+	testCases := []struct {
+		tag         string
+		input       *rwOptions
+		expectError bool
+	}{
+		{
+			tag: "normal_case",
+			input: &rwOptions{
+				version:       StorageV1,
+				storageConfig: &indexpb.StorageConfig{},
+				op:            OpRead,
+				downloader:    func(ctx context.Context, paths []string) ([][]byte, error) { return nil, nil },
+			},
+			expectError: false,
+		},
+		{
+			tag: "normal_case_v2",
+			input: &rwOptions{
+				version:       StorageV2,
+				storageConfig: &indexpb.StorageConfig{},
+				op:            OpRead,
+			},
+			expectError: false,
+		},
+		{
+			tag: "bad_version",
+			input: &rwOptions{
+				version:       -1,
+				storageConfig: &indexpb.StorageConfig{},
+				downloader:    func(ctx context.Context, paths []string) ([][]byte, error) { return nil, nil },
+				op:            OpRead,
+			},
+			expectError: true,
+		},
+		{
+			tag: "missing_config",
+			input: &rwOptions{
+				version:       StorageV2,
+				storageConfig: nil,
+				op:            OpRead,
+			},
+			expectError: true,
+		},
+		{
+			tag: "v1eader_missing_downloader",
+			input: &rwOptions{
+				version:       StorageV1,
+				storageConfig: &indexpb.StorageConfig{},
+				op:            OpRead,
+			},
+			expectError: true,
+		},
+		{
+			tag: "writer_missing_uploader",
+			input: &rwOptions{
+				version:       StorageV2,
+				storageConfig: &indexpb.StorageConfig{},
+				op:            OpWrite,
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.tag, func(t *testing.T) {
+			err := tc.input.validate()
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
 		})
 	}
 }

--- a/internal/storage/serde_events_v2.go
+++ b/internal/storage/serde_events_v2.go
@@ -37,6 +37,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/metautil"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
 
@@ -211,10 +212,15 @@ func NewPackedRecordWriter(bucketName string, paths []string, schema *schemapb.C
 		return nil, merr.WrapErrServiceInternal(
 			fmt.Sprintf("can not convert collection schema %s to arrow schema: %s", schema.Name, err.Error()))
 	}
+	// if storage config is not passed, use common config
+	storageType := paramtable.Get().CommonCfg.StorageType.GetValue()
+	if storageConfig != nil {
+		storageType = storageConfig.GetStorageType()
+	}
 	// compose true path before create packed writer here
 	// and returned writtenPaths shall remain untouched
 	truePaths := lo.Map(paths, func(p string, _ int) string {
-		if storageConfig.GetStorageType() == "local" {
+		if storageType == "local" {
 			return p
 		}
 		return path.Join(bucketName, p)

--- a/internal/util/importutilv2/binlog/reader_test.go
+++ b/internal/util/importutilv2/binlog/reader_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/util/testutil"
 	"github.com/milvus-io/milvus/pkg/v2/common"
+	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/testutils"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
@@ -333,7 +334,7 @@ func (suite *ReaderSuite) run(dataType schemapb.DataType, elemType schemapb.Data
 	cm, originalInsertData := suite.createMockChunk(schema, insertBinlogs, true)
 	cm.EXPECT().Size(mock.Anything, mock.Anything).Return(128, nil)
 
-	reader, err := NewReader(context.Background(), cm, schema, []string{insertPrefix, deltaPrefix}, suite.tsStart, suite.tsEnd)
+	reader, err := NewReader(context.Background(), cm, schema, []string{insertPrefix, deltaPrefix}, suite.tsStart, suite.tsEnd, &indexpb.StorageConfig{})
 	suite.NoError(err)
 	insertData, err := reader.Read()
 	suite.NoError(err)
@@ -530,18 +531,18 @@ func (suite *ReaderSuite) TestVerify() {
 
 	checkFunc := func() {
 		cm, _ := suite.createMockChunk(schema, insertBinlogs, false)
-		reader, err := NewReader(context.Background(), cm, schema, []string{insertPrefix, deltaPrefix}, suite.tsStart, suite.tsEnd)
+		reader, err := NewReader(context.Background(), cm, schema, []string{insertPrefix, deltaPrefix}, suite.tsStart, suite.tsEnd, &indexpb.StorageConfig{})
 		suite.Error(err)
 		suite.Nil(reader)
 	}
 
 	// no insert binlogs to import
-	reader, err := NewReader(context.Background(), nil, schema, []string{}, suite.tsStart, suite.tsEnd)
+	reader, err := NewReader(context.Background(), nil, schema, []string{}, suite.tsStart, suite.tsEnd, &indexpb.StorageConfig{})
 	suite.Error(err)
 	suite.Nil(reader)
 
 	// too many input paths
-	reader, err = NewReader(context.Background(), nil, schema, []string{insertPrefix, deltaPrefix, "dummy"}, suite.tsStart, suite.tsEnd)
+	reader, err = NewReader(context.Background(), nil, schema, []string{insertPrefix, deltaPrefix, "dummy"}, suite.tsStart, suite.tsEnd, &indexpb.StorageConfig{})
 	suite.Error(err)
 	suite.Nil(reader)
 
@@ -694,7 +695,7 @@ func (suite *ReaderSuite) TestZeroDeltaRead() {
 
 	checkFunc := func(targetSchema *schemapb.CollectionSchema, expectReadBinlogs map[int64][]string) {
 		cm := mockChunkFunc(sourceSchema, expectReadBinlogs)
-		reader, err := NewReader(context.Background(), cm, targetSchema, []string{insertPrefix, deltaPrefix}, suite.tsStart, suite.tsEnd)
+		reader, err := NewReader(context.Background(), cm, targetSchema, []string{insertPrefix, deltaPrefix}, suite.tsStart, suite.tsEnd, &indexpb.StorageConfig{})
 		suite.NoError(err)
 		suite.NotNil(reader)
 

--- a/internal/util/importutilv2/reader.go
+++ b/internal/util/importutilv2/reader.go
@@ -26,6 +26,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/importutilv2/json"
 	"github.com/milvus-io/milvus/internal/util/importutilv2/numpy"
 	"github.com/milvus-io/milvus/internal/util/importutilv2/parquet"
+	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 )
@@ -50,6 +51,7 @@ func NewReader(ctx context.Context,
 	importFile *internalpb.ImportFile,
 	options Options,
 	bufferSize int,
+	storageConfig *indexpb.StorageConfig,
 ) (Reader, error) {
 	if IsBackup(options) {
 		tsStart, tsEnd, err := ParseTimeRange(options)
@@ -57,7 +59,7 @@ func NewReader(ctx context.Context,
 			return nil, err
 		}
 		paths := importFile.GetPaths()
-		return binlog.NewReader(ctx, cm, schema, paths, tsStart, tsEnd)
+		return binlog.NewReader(ctx, cm, schema, paths, tsStart, tsEnd, storageConfig)
 	}
 
 	fileType, err := GetFileType(importFile)

--- a/internal/util/importutilv2/reader_test.go
+++ b/internal/util/importutilv2/reader_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/mocks"
+	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 )
@@ -50,7 +51,7 @@ func TestImportNewReader(t *testing.T) {
 	}
 
 	checkFunc := func(name string, req *internalpb.ImportFile, options []*commonpb.KeyValuePair) {
-		_, err := NewReader(ctx, cm, schema, req, options, 1024)
+		_, err := NewReader(ctx, cm, schema, req, options, 1024, &indexpb.StorageConfig{})
 		assert.Error(t, err)
 		assert.True(t, strings.Contains(err.Error(), name))
 	}


### PR DESCRIPTION
Related to #39173

This PR:
- Make all datanode task passes storage config via storage config option
- Remove legacy comments, rootPath & bucketName parameters
- Fix clustering compaction option behavior
- Add validation logic for `rwOptions`
- Use correct storageType from storageConfig
- Add storage config in sync task