### PR TITLE
fix: [GoSDK] Slice valid data parsing nullable data

### DIFF
--- a/client/column/columns.go
+++ b/client/column/columns.go
@@ -98,6 +98,7 @@ func parseScalarData[T any, COL Column, NCOL Column](
 	}
 	data = data[start:end]
 	if len(validData) > 0 {
+		validData = validData[start:end]
 		ncol, err := nullableCreator(name, data, validData, WithSparseNullableMode[T](true))
 		return ncol, err
 	}


### PR DESCRIPTION
Related to #43003

When nq > 1, returning nullable data in search result will lead to parsing error. This patch add slicing valid data logic to make nullable parsing validation logic could work.