### PR TITLE
enhance: fix typo 'asceneding' to 'ascending' in two files

### DIFF
--- a/internal/proxy/task_index_test.go
+++ b/internal/proxy/task_index_test.go
@@ -705,13 +705,13 @@ func Test_parseIndexParams(t *testing.T) {
 	})
 
 	// Compatible with the old version <= 2.3.0
-	t.Run("create Asceneding index on Arithmetic field", func(t *testing.T) {
+	t.Run("create ascending index on Arithmetic field", func(t *testing.T) {
 		cit := &createIndexTask{
 			req: &milvuspb.CreateIndexRequest{
 				ExtraParams: []*commonpb.KeyValuePair{
 					{
 						Key:   common.IndexTypeKey,
-						Value: "Asceneding",
+						Value: "ascending",
 					},
 				},
 				IndexName: "",

--- a/internal/util/indexparamcheck/conf_adapter_mgr.go
+++ b/internal/util/indexparamcheck/conf_adapter_mgr.go
@@ -51,7 +51,7 @@ func (mgr *indexCheckerMgrImpl) registerIndexChecker() {
 	mgr.checkers[IndexVector] = newVecIndexChecker()
 	mgr.checkers[IndexINVERTED] = newINVERTEDChecker()
 	mgr.checkers[IndexSTLSORT] = newSTLSORTChecker()
-	mgr.checkers["Asceneding"] = newSTLSORTChecker()
+	mgr.checkers["Ascending"] = newSTLSORTChecker()
 	mgr.checkers[IndexTRIE] = newTRIEChecker()
 	mgr.checkers[IndexTrie] = newTRIEChecker()
 	mgr.checkers[IndexBitmap] = newBITMAPChecker()


### PR DESCRIPTION
I updated two files containing same typo 'asceneding'.
* internal/util/indexparamcheck/conf_adapter_mgr.go
* internal/proxy/task_index_test.go