### PR TITLE
enhance: [2.5] Remove collection name validation from DescribeCollection

### DIFF
--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -618,8 +618,9 @@ func (t *describeCollectionTask) PreExecute(ctx context.Context) error {
 	if t.CollectionID != 0 && len(t.CollectionName) == 0 {
 		return nil
 	}
-
-	return validateCollectionName(t.CollectionName)
+	// collection name shall not validate here
+	// only validate shall be done in `CreateCollection`
+	return nil
 }
 
 func (t *describeCollectionTask) Execute(ctx context.Context) error {

--- a/internal/proxy/task_test.go
+++ b/internal/proxy/task_test.go
@@ -1196,7 +1196,7 @@ func TestDescribeCollectionTask(t *testing.T) {
 	// illegal name
 	task.CollectionName = "#0xc0de"
 	err = task.PreExecute(ctx)
-	assert.Error(t, err)
+	assert.NoError(t, err)
 
 	// describe collection with id
 	task.CollectionID = 1

--- a/tests/go_client/testcases/search_test.go
+++ b/tests/go_client/testcases/search_test.go
@@ -57,6 +57,7 @@ func TestSearchDefaultGrowing(t *testing.T) {
 
 // test search collection and partition name not exist
 func TestSearchInvalidCollectionPartitionName(t *testing.T) {
+	t.Skipf("https://github.com/milvus-io/milvus/issues/43031, pr#43299, remove name check for describe collection")
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 

--- a/tests/python_client/milvus_client/test_milvus_client_collection.py
+++ b/tests/python_client/milvus_client/test_milvus_client_collection.py
@@ -952,6 +952,7 @@ class TestMilvusClientHasCollectionInvalid(TestMilvusClientV2Base):
 
     @pytest.mark.tags(CaseLabel.L1)
     @pytest.mark.parametrize("name", ["12-s", "12 s", "(mn)", "中文", "%$#"])
+    @pytest.mark.skip(reason="https://github.com/milvus-io/milvus/issues/43031, pr#43299, remove name check for has collection")
     def test_milvus_client_has_collection_invalid_collection_name(self, name):
         """
         target: test fast create collection normal case

--- a/tests/python_client/milvus_client/test_milvus_client_collection.py
+++ b/tests/python_client/milvus_client/test_milvus_client_collection.py
@@ -898,6 +898,7 @@ class TestMilvusClientDescribeCollectionInvalid(TestMilvusClientV2Base):
 
     @pytest.mark.tags(CaseLabel.L1)
     @pytest.mark.parametrize("name", ["12-s", "12 s", "(mn)", "中文", "%$#"])
+    @pytest.mark.skip(reason="https://github.com/milvus-io/milvus/issues/43031, pr#43299, remove name check for describe collection")
     def test_milvus_client_describe_collection_invalid_collection_name(self, name):
         """
         target: test fast create collection normal case

--- a/tests/python_client/milvus_client/test_milvus_client_insert.py
+++ b/tests/python_client/milvus_client/test_milvus_client_insert.py
@@ -104,6 +104,7 @@ class TestMilvusClientInsertInvalid(TestMilvusClientV2Base):
                     check_task=CheckTasks.err_res, check_items=error)
 
     @pytest.mark.tags(CaseLabel.L1)
+    @pytest.mark.skip(reason="https://github.com/milvus-io/milvus/issues/43031, pr#43299, remove name check for describe collection")
     def test_milvus_client_insert_collection_name_over_max_length(self):
         """
         target: test high level api: client.create_collection
@@ -564,6 +565,7 @@ class TestMilvusClientUpsertInvalid(TestMilvusClientV2Base):
                     check_task=CheckTasks.err_res, check_items=error)
 
     @pytest.mark.tags(CaseLabel.L1)
+    @pytest.mark.skip(reason="https://github.com/milvus-io/milvus/issues/43031, pr#43299, remove name check for describe collection")
     def test_milvus_client_upsert_collection_name_over_max_length(self):
         """
         target: test high level api: client.create_collection

--- a/tests/python_client/milvus_client/test_milvus_client_insert.py
+++ b/tests/python_client/milvus_client/test_milvus_client_insert.py
@@ -87,6 +87,7 @@ class TestMilvusClientInsertInvalid(TestMilvusClientV2Base):
 
     @pytest.mark.tags(CaseLabel.L1)
     @pytest.mark.parametrize("collection_name", ["12-s", "12 s", "(mn)", "中文", "%$#"])
+    @pytest.mark.skip(reason="https://github.com/milvus-io/milvus/issues/43031, pr#43299, remove name check for describe collection")
     def test_milvus_client_insert_invalid_collection_name(self, collection_name):
         """
         target: test high level api: client.create_collection
@@ -546,6 +547,7 @@ class TestMilvusClientUpsertInvalid(TestMilvusClientV2Base):
 
     @pytest.mark.tags(CaseLabel.L1)
     @pytest.mark.parametrize("collection_name", ["12-s", "12 s", "(mn)", "中文", "%$#"])
+    @pytest.mark.skip(reason="https://github.com/milvus-io/milvus/issues/43031, pr#43299, remove name check for describe collection")
     def test_milvus_client_upsert_invalid_collection_name(self, collection_name):
         """
         target: test high level api: client.create_collection


### PR DESCRIPTION
Cherry-pick from master
pr: #43299
Related to #43031

Previous pr: #43064

Since old version may create collection with invalidate collection name, milvus shall allow some API to let user notice such collection still exists.

This patch removes collection name validation from `DescribeCollection` call, letting user know that such collection still exists.