### PR TITLE
enhance: [hotfix] Remove collection name validation from DescribeCollection

### DIFF
--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -618,8 +618,9 @@ func (t *describeCollectionTask) PreExecute(ctx context.Context) error {
 	if t.CollectionID != 0 && len(t.CollectionName) == 0 {
 		return nil
 	}
-
-	return validateCollectionName(t.CollectionName)
+	// collection name shall not validate here
+	// only validate shall be done in `CreateCollection`
+	return nil
 }
 
 func (t *describeCollectionTask) Execute(ctx context.Context) error {

--- a/internal/proxy/task_test.go
+++ b/internal/proxy/task_test.go
@@ -1196,7 +1196,7 @@ func TestDescribeCollectionTask(t *testing.T) {
 	// illegal name
 	task.CollectionName = "#0xc0de"
 	err = task.PreExecute(ctx)
-	assert.Error(t, err)
+	assert.NoError(t, err)
 
 	// describe collection with id
 	task.CollectionID = 1


### PR DESCRIPTION
Cherry-pick from master
pr: #43299
Related to #43031

Previous pr: #43064

Since old version may create collection with invalidate collection name, milvus shall allow some API to let user notice such collection still exists.

This patch removes collection name validateion from `DescribeCollection` call, letting user know that such collection still exists.