### PR TITLE
enhance: tiered storage: estimate segment loading resource usage while considering eviction

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -485,6 +485,14 @@ queryNode:
       # If a cached data hasn't been accessed again after this time since its last access, it will be evicted.
       # If set to 0, time based eviction is disabled.
       cacheTtl: 0
+      # The factor of memory eviction. Defaults to 0.0, and available range is [0.0, 1.0].
+      # This factor determines the amount of evictable memory can be evicted in one segment.
+      # The reason why not make the factor as 1.0 is to avoid frequent eviction.
+      memoryEvictionFactor: 0
+      # The factor of disk eviction. Defaults to 0.0, and available range is [0.0, 1.0].
+      # This factor determines the amount of evictable disk space can be evicted in one segment.
+      # The reason why not make the factor as 1.0 is to avoid frequent eviction.
+      diskEvictionFactor: 0
     knowhereScoreConsistency: false # Enable knowhere strong consistency score computation logic
     jsonKeyStatsCommitInterval: 200 # the commit interval for the JSON key Stats to commit
   loadMemoryUsageFactor: 1 # The multiply factor of calculating the memory usage while loading segments

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -487,14 +487,14 @@ queryNode:
       # Conversely, a lower ratio results in more evictions but allows more segments to be loaded.
       # This parameter is only valid when eviction is enabled.
       # It defaults to 1.0 (meaning all evictable memory is cached), with a valid range of [0.0, 1.0].
-      evictableMemoryCacheRatio: 0
+      evictableMemoryCacheRatio: 1.0
       # This ratio estimates how much evictable disk space can be cached.
       # The higher the ratio, the more physical disk space is reserved for evictable disk usage,
       # resulting in fewer evictions but fewer segments can be loaded.
       # Conversely, a lower ratio results in more evictions but allows more segments to be loaded.
       # This parameter is only valid when eviction is enabled.
       # It defaults to 1.0 (meaning all evictable disk is cached), with a valid range of [0.0, 1.0].
-      evictableDiskCacheRatio: 0
+      evictableDiskCacheRatio: 1.0
       # Time in seconds after which an unaccessed cache cell will be evicted. 
       # If a cached data hasn't been accessed again after this time since its last access, it will be evicted.
       # If set to 0, time based eviction is disabled.

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -487,14 +487,14 @@ queryNode:
       # Conversely, a lower ratio results in more evictions but allows more segments to be loaded.
       # This parameter is only valid when eviction is enabled.
       # It defaults to 1.0 (meaning all evictable memory is cached), with a valid range of [0.0, 1.0].
-      evictableMemoryCacheRatio: 1.0
+      evictableMemoryCacheRatio: 1
       # This ratio estimates how much evictable disk space can be cached.
       # The higher the ratio, the more physical disk space is reserved for evictable disk usage,
       # resulting in fewer evictions but fewer segments can be loaded.
       # Conversely, a lower ratio results in more evictions but allows more segments to be loaded.
       # This parameter is only valid when eviction is enabled.
       # It defaults to 1.0 (meaning all evictable disk is cached), with a valid range of [0.0, 1.0].
-      evictableDiskCacheRatio: 1.0
+      evictableDiskCacheRatio: 1
       # Time in seconds after which an unaccessed cache cell will be evicted. 
       # If a cached data hasn't been accessed again after this time since its last access, it will be evicted.
       # If set to 0, time based eviction is disabled.

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -481,18 +481,24 @@ queryNode:
       # Enable eviction for Tiered Storage. Defaults to false.
       # Note that if eviction is enabled, cache data loaded during sync warmup is also subject to eviction.
       evictionEnabled: false
+      # This ratio estimates how much evictable memory can be cached.
+      # The higher the ratio, the more physical memory is reserved for evictable memory,
+      # resulting in fewer evictions but fewer segments can be loaded.
+      # Conversely, a lower ratio results in more evictions but allows more segments to be loaded.
+      # This parameter is only valid when eviction is enabled.
+      # It defaults to 1.0 (meaning all evictable memory is cached), with a valid range of [0.0, 1.0].
+      evictableMemoryCacheRatio: 0
+      # This ratio estimates how much evictable disk space can be cached.
+      # The higher the ratio, the more physical disk space is reserved for evictable disk usage,
+      # resulting in fewer evictions but fewer segments can be loaded.
+      # Conversely, a lower ratio results in more evictions but allows more segments to be loaded.
+      # This parameter is only valid when eviction is enabled.
+      # It defaults to 1.0 (meaning all evictable disk is cached), with a valid range of [0.0, 1.0].
+      evictableDiskCacheRatio: 0
       # Time in seconds after which an unaccessed cache cell will be evicted. 
       # If a cached data hasn't been accessed again after this time since its last access, it will be evicted.
       # If set to 0, time based eviction is disabled.
       cacheTtl: 0
-      # The factor of memory eviction. Defaults to 0.0, and available range is [0.0, 1.0].
-      # This factor determines the amount of evictable memory can be evicted in one segment.
-      # The reason why not make the factor as 1.0 is to avoid frequent eviction.
-      memoryEvictionFactor: 0
-      # The factor of disk eviction. Defaults to 0.0, and available range is [0.0, 1.0].
-      # This factor determines the amount of evictable disk space can be evicted in one segment.
-      # The reason why not make the factor as 1.0 is to avoid frequent eviction.
-      diskEvictionFactor: 0
     knowhereScoreConsistency: false # Enable knowhere strong consistency score computation logic
     jsonKeyStatsCommitInterval: 200 # the commit interval for the JSON key Stats to commit
   loadMemoryUsageFactor: 1 # The multiply factor of calculating the memory usage while loading segments

--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -100,6 +100,7 @@ func (sd *shardDelegator) ProcessInsert(insertRecords map[int64]*InsertData) {
 			growing, err = segments.NewSegment(
 				context.Background(),
 				sd.collection,
+				sd.segmentManager,
 				segments.SegmentTypeGrowing,
 				0,
 				&querypb.SegmentLoadInfo{

--- a/internal/querynodev2/segments/manager_test.go
+++ b/internal/querynodev2/segments/manager_test.go
@@ -59,6 +59,7 @@ func (s *ManagerSuite) SetupTest() {
 		segment, err := NewSegment(
 			context.Background(),
 			collection,
+			s.mgr,
 			s.types[i],
 			0,
 			&querypb.SegmentLoadInfo{

--- a/internal/querynodev2/segments/mock_segment_manager.go
+++ b/internal/querynodev2/segments/mock_segment_manager.go
@@ -25,6 +25,39 @@ func (_m *MockSegmentManager) EXPECT() *MockSegmentManager_Expecter {
 	return &MockSegmentManager_Expecter{mock: &_m.Mock}
 }
 
+// AddReservedResource provides a mock function with given fields: usage
+func (_m *MockSegmentManager) AddReservedResource(usage ResourceUsage) {
+	_m.Called(usage)
+}
+
+// MockSegmentManager_AddReservedResource_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddReservedResource'
+type MockSegmentManager_AddReservedResource_Call struct {
+	*mock.Call
+}
+
+// AddReservedResource is a helper method to define mock.On call
+//   - usage ResourceUsage
+func (_e *MockSegmentManager_Expecter) AddReservedResource(usage interface{}) *MockSegmentManager_AddReservedResource_Call {
+	return &MockSegmentManager_AddReservedResource_Call{Call: _e.mock.On("AddReservedResource", usage)}
+}
+
+func (_c *MockSegmentManager_AddReservedResource_Call) Run(run func(usage ResourceUsage)) *MockSegmentManager_AddReservedResource_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(ResourceUsage))
+	})
+	return _c
+}
+
+func (_c *MockSegmentManager_AddReservedResource_Call) Return() *MockSegmentManager_AddReservedResource_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockSegmentManager_AddReservedResource_Call) RunAndReturn(run func(ResourceUsage)) *MockSegmentManager_AddReservedResource_Call {
+	_c.Run(run)
+	return _c
+}
+
 // Clear provides a mock function with given fields: ctx
 func (_m *MockSegmentManager) Clear(ctx context.Context) {
 	_m.Called(ctx)
@@ -451,6 +484,51 @@ func (_c *MockSegmentManager_GetGrowing_Call) RunAndReturn(run func(int64) Segme
 	return _c
 }
 
+// GetReservedResource provides a mock function with no fields
+func (_m *MockSegmentManager) GetReservedResource() ResourceUsage {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetReservedResource")
+	}
+
+	var r0 ResourceUsage
+	if rf, ok := ret.Get(0).(func() ResourceUsage); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(ResourceUsage)
+	}
+
+	return r0
+}
+
+// MockSegmentManager_GetReservedResource_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetReservedResource'
+type MockSegmentManager_GetReservedResource_Call struct {
+	*mock.Call
+}
+
+// GetReservedResource is a helper method to define mock.On call
+func (_e *MockSegmentManager_Expecter) GetReservedResource() *MockSegmentManager_GetReservedResource_Call {
+	return &MockSegmentManager_GetReservedResource_Call{Call: _e.mock.On("GetReservedResource")}
+}
+
+func (_c *MockSegmentManager_GetReservedResource_Call) Run(run func()) *MockSegmentManager_GetReservedResource_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockSegmentManager_GetReservedResource_Call) Return(_a0 ResourceUsage) *MockSegmentManager_GetReservedResource_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockSegmentManager_GetReservedResource_Call) RunAndReturn(run func() ResourceUsage) *MockSegmentManager_GetReservedResource_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetSealed provides a mock function with given fields: segmentID
 func (_m *MockSegmentManager) GetSealed(segmentID int64) Segment {
 	ret := _m.Called(segmentID)
@@ -723,6 +801,39 @@ func (_c *MockSegmentManager_RemoveBy_Call) Return(_a0 int, _a1 int) *MockSegmen
 
 func (_c *MockSegmentManager_RemoveBy_Call) RunAndReturn(run func(context.Context, ...SegmentFilter) (int, int)) *MockSegmentManager_RemoveBy_Call {
 	_c.Call.Return(run)
+	return _c
+}
+
+// SubReservedResource provides a mock function with given fields: usage
+func (_m *MockSegmentManager) SubReservedResource(usage ResourceUsage) {
+	_m.Called(usage)
+}
+
+// MockSegmentManager_SubReservedResource_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SubReservedResource'
+type MockSegmentManager_SubReservedResource_Call struct {
+	*mock.Call
+}
+
+// SubReservedResource is a helper method to define mock.On call
+//   - usage ResourceUsage
+func (_e *MockSegmentManager_Expecter) SubReservedResource(usage interface{}) *MockSegmentManager_SubReservedResource_Call {
+	return &MockSegmentManager_SubReservedResource_Call{Call: _e.mock.On("SubReservedResource", usage)}
+}
+
+func (_c *MockSegmentManager_SubReservedResource_Call) Run(run func(usage ResourceUsage)) *MockSegmentManager_SubReservedResource_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(ResourceUsage))
+	})
+	return _c
+}
+
+func (_c *MockSegmentManager_SubReservedResource_Call) Return() *MockSegmentManager_SubReservedResource_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockSegmentManager_SubReservedResource_Call) RunAndReturn(run func(ResourceUsage)) *MockSegmentManager_SubReservedResource_Call {
+	_c.Run(run)
 	return _c
 }
 

--- a/internal/querynodev2/segments/mock_segment_manager.go
+++ b/internal/querynodev2/segments/mock_segment_manager.go
@@ -25,35 +25,35 @@ func (_m *MockSegmentManager) EXPECT() *MockSegmentManager_Expecter {
 	return &MockSegmentManager_Expecter{mock: &_m.Mock}
 }
 
-// AddReservedResource provides a mock function with given fields: usage
-func (_m *MockSegmentManager) AddReservedResource(usage ResourceUsage) {
+// AddLogicalResource provides a mock function with given fields: usage
+func (_m *MockSegmentManager) AddLogicalResource(usage ResourceUsage) {
 	_m.Called(usage)
 }
 
-// MockSegmentManager_AddReservedResource_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddReservedResource'
-type MockSegmentManager_AddReservedResource_Call struct {
+// MockSegmentManager_AddLogicalResource_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddLogicalResource'
+type MockSegmentManager_AddLogicalResource_Call struct {
 	*mock.Call
 }
 
-// AddReservedResource is a helper method to define mock.On call
+// AddLogicalResource is a helper method to define mock.On call
 //   - usage ResourceUsage
-func (_e *MockSegmentManager_Expecter) AddReservedResource(usage interface{}) *MockSegmentManager_AddReservedResource_Call {
-	return &MockSegmentManager_AddReservedResource_Call{Call: _e.mock.On("AddReservedResource", usage)}
+func (_e *MockSegmentManager_Expecter) AddLogicalResource(usage interface{}) *MockSegmentManager_AddLogicalResource_Call {
+	return &MockSegmentManager_AddLogicalResource_Call{Call: _e.mock.On("AddLogicalResource", usage)}
 }
 
-func (_c *MockSegmentManager_AddReservedResource_Call) Run(run func(usage ResourceUsage)) *MockSegmentManager_AddReservedResource_Call {
+func (_c *MockSegmentManager_AddLogicalResource_Call) Run(run func(usage ResourceUsage)) *MockSegmentManager_AddLogicalResource_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run(args[0].(ResourceUsage))
 	})
 	return _c
 }
 
-func (_c *MockSegmentManager_AddReservedResource_Call) Return() *MockSegmentManager_AddReservedResource_Call {
+func (_c *MockSegmentManager_AddLogicalResource_Call) Return() *MockSegmentManager_AddLogicalResource_Call {
 	_c.Call.Return()
 	return _c
 }
 
-func (_c *MockSegmentManager_AddReservedResource_Call) RunAndReturn(run func(ResourceUsage)) *MockSegmentManager_AddReservedResource_Call {
+func (_c *MockSegmentManager_AddLogicalResource_Call) RunAndReturn(run func(ResourceUsage)) *MockSegmentManager_AddLogicalResource_Call {
 	_c.Run(run)
 	return _c
 }
@@ -484,12 +484,12 @@ func (_c *MockSegmentManager_GetGrowing_Call) RunAndReturn(run func(int64) Segme
 	return _c
 }
 
-// GetReservedResource provides a mock function with no fields
-func (_m *MockSegmentManager) GetReservedResource() ResourceUsage {
+// GetLogicalResource provides a mock function with no fields
+func (_m *MockSegmentManager) GetLogicalResource() ResourceUsage {
 	ret := _m.Called()
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetReservedResource")
+		panic("no return value specified for GetLogicalResource")
 	}
 
 	var r0 ResourceUsage
@@ -502,29 +502,29 @@ func (_m *MockSegmentManager) GetReservedResource() ResourceUsage {
 	return r0
 }
 
-// MockSegmentManager_GetReservedResource_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetReservedResource'
-type MockSegmentManager_GetReservedResource_Call struct {
+// MockSegmentManager_GetLogicalResource_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetLogicalResource'
+type MockSegmentManager_GetLogicalResource_Call struct {
 	*mock.Call
 }
 
-// GetReservedResource is a helper method to define mock.On call
-func (_e *MockSegmentManager_Expecter) GetReservedResource() *MockSegmentManager_GetReservedResource_Call {
-	return &MockSegmentManager_GetReservedResource_Call{Call: _e.mock.On("GetReservedResource")}
+// GetLogicalResource is a helper method to define mock.On call
+func (_e *MockSegmentManager_Expecter) GetLogicalResource() *MockSegmentManager_GetLogicalResource_Call {
+	return &MockSegmentManager_GetLogicalResource_Call{Call: _e.mock.On("GetLogicalResource")}
 }
 
-func (_c *MockSegmentManager_GetReservedResource_Call) Run(run func()) *MockSegmentManager_GetReservedResource_Call {
+func (_c *MockSegmentManager_GetLogicalResource_Call) Run(run func()) *MockSegmentManager_GetLogicalResource_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run()
 	})
 	return _c
 }
 
-func (_c *MockSegmentManager_GetReservedResource_Call) Return(_a0 ResourceUsage) *MockSegmentManager_GetReservedResource_Call {
+func (_c *MockSegmentManager_GetLogicalResource_Call) Return(_a0 ResourceUsage) *MockSegmentManager_GetLogicalResource_Call {
 	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *MockSegmentManager_GetReservedResource_Call) RunAndReturn(run func() ResourceUsage) *MockSegmentManager_GetReservedResource_Call {
+func (_c *MockSegmentManager_GetLogicalResource_Call) RunAndReturn(run func() ResourceUsage) *MockSegmentManager_GetLogicalResource_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -804,35 +804,35 @@ func (_c *MockSegmentManager_RemoveBy_Call) RunAndReturn(run func(context.Contex
 	return _c
 }
 
-// SubReservedResource provides a mock function with given fields: usage
-func (_m *MockSegmentManager) SubReservedResource(usage ResourceUsage) {
+// SubLogicalResource provides a mock function with given fields: usage
+func (_m *MockSegmentManager) SubLogicalResource(usage ResourceUsage) {
 	_m.Called(usage)
 }
 
-// MockSegmentManager_SubReservedResource_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SubReservedResource'
-type MockSegmentManager_SubReservedResource_Call struct {
+// MockSegmentManager_SubLogicalResource_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SubLogicalResource'
+type MockSegmentManager_SubLogicalResource_Call struct {
 	*mock.Call
 }
 
-// SubReservedResource is a helper method to define mock.On call
+// SubLogicalResource is a helper method to define mock.On call
 //   - usage ResourceUsage
-func (_e *MockSegmentManager_Expecter) SubReservedResource(usage interface{}) *MockSegmentManager_SubReservedResource_Call {
-	return &MockSegmentManager_SubReservedResource_Call{Call: _e.mock.On("SubReservedResource", usage)}
+func (_e *MockSegmentManager_Expecter) SubLogicalResource(usage interface{}) *MockSegmentManager_SubLogicalResource_Call {
+	return &MockSegmentManager_SubLogicalResource_Call{Call: _e.mock.On("SubLogicalResource", usage)}
 }
 
-func (_c *MockSegmentManager_SubReservedResource_Call) Run(run func(usage ResourceUsage)) *MockSegmentManager_SubReservedResource_Call {
+func (_c *MockSegmentManager_SubLogicalResource_Call) Run(run func(usage ResourceUsage)) *MockSegmentManager_SubLogicalResource_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run(args[0].(ResourceUsage))
 	})
 	return _c
 }
 
-func (_c *MockSegmentManager_SubReservedResource_Call) Return() *MockSegmentManager_SubReservedResource_Call {
+func (_c *MockSegmentManager_SubLogicalResource_Call) Return() *MockSegmentManager_SubLogicalResource_Call {
 	_c.Call.Return()
 	return _c
 }
 
-func (_c *MockSegmentManager_SubReservedResource_Call) RunAndReturn(run func(ResourceUsage)) *MockSegmentManager_SubReservedResource_Call {
+func (_c *MockSegmentManager_SubLogicalResource_Call) RunAndReturn(run func(ResourceUsage)) *MockSegmentManager_SubLogicalResource_Call {
 	_c.Run(run)
 	return _c
 }

--- a/internal/querynodev2/segments/retrieve_test.go
+++ b/internal/querynodev2/segments/retrieve_test.go
@@ -88,6 +88,7 @@ func (suite *RetrieveSuite) SetupTest() {
 
 	suite.sealed, err = NewSegment(ctx,
 		suite.collection,
+		suite.manager.Segment,
 		SegmentTypeSealed,
 		0,
 		&querypb.SegmentLoadInfo{
@@ -117,6 +118,7 @@ func (suite *RetrieveSuite) SetupTest() {
 
 	suite.growing, err = NewSegment(ctx,
 		suite.collection,
+		suite.manager.Segment,
 		SegmentTypeGrowing,
 		0,
 		&querypb.SegmentLoadInfo{

--- a/internal/querynodev2/segments/search_test.go
+++ b/internal/querynodev2/segments/search_test.go
@@ -80,6 +80,7 @@ func (suite *SearchSuite) SetupTest() {
 
 	suite.sealed, err = NewSegment(ctx,
 		suite.collection,
+		suite.manager.Segment,
 		SegmentTypeSealed,
 		0,
 		&querypb.SegmentLoadInfo{
@@ -109,6 +110,7 @@ func (suite *SearchSuite) SetupTest() {
 
 	suite.growing, err = NewSegment(ctx,
 		suite.collection,
+		suite.manager.Segment,
 		SegmentTypeGrowing,
 		0,
 		&querypb.SegmentLoadInfo{

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -240,14 +240,14 @@ func (s *baseSegment) ResourceUsageEstimate() ResourceUsage {
 	}
 
 	usage, err := getResourceUsageEstimateOfSegment(s.collection.Schema(), s.LoadInfo(), resourceEstimateFactor{
-		memoryUsageFactor:          1.0,
-		memoryIndexUsageFactor:     1.0,
-		EnableInterminSegmentIndex: false,
-		tempSegmentIndexFactor:     0.0,
-		deltaDataExpansionFactor:   paramtable.Get().QueryNodeCfg.DeltaDataExpansionRate.GetAsFloat(),
-		TieredEvictionEnabled:      paramtable.Get().QueryNodeCfg.TieredEvictionEnabled.GetAsBool(),
-		TieredMemoryEvictionFactor: paramtable.Get().QueryNodeCfg.TieredMemoryEvictionFactor.GetAsFloat(),
-		TieredDiskEvictionFactor:   paramtable.Get().QueryNodeCfg.TieredDiskEvictionFactor.GetAsFloat(),
+		memoryUsageFactor:               1.0,
+		memoryIndexUsageFactor:          1.0,
+		EnableInterminSegmentIndex:      false,
+		tempSegmentIndexFactor:          0.0,
+		deltaDataExpansionFactor:        paramtable.Get().QueryNodeCfg.DeltaDataExpansionRate.GetAsFloat(),
+		TieredEvictionEnabled:           paramtable.Get().QueryNodeCfg.TieredEvictionEnabled.GetAsBool(),
+		TieredEvictableMemoryCacheRatio: paramtable.Get().QueryNodeCfg.TieredEvictableMemoryCacheRatio.GetAsFloat(),
+		TieredEvictableDiskCacheRatio:   paramtable.Get().QueryNodeCfg.TieredEvictableDiskCacheRatio.GetAsFloat(),
 	})
 	if err != nil {
 		// Should never failure, if failed, segment should never be loaded.

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -1257,7 +1257,7 @@ func (s *LocalSegment) CreateTextIndex(ctx context.Context, fieldID int64) error
 
 func (s *LocalSegment) FinishLoad() error {
 	usage := s.ResourceUsageEstimate()
-	s.manager.AddReservedResource(usage)
+	s.manager.AddLogicalResource(usage)
 	return s.csegment.FinishLoad()
 }
 
@@ -1321,7 +1321,7 @@ func (s *LocalSegment) Release(ctx context.Context, opts ...releaseOption) {
 	}).Await()
 
 	// release reserved resource after the segment resource is really released.
-	s.manager.SubReservedResource(usage)
+	s.manager.SubLogicalResource(usage)
 
 	log.Info("delete segment from memory")
 }

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -1803,12 +1803,12 @@ func getResourceUsageEstimateOfSegment(schema *schemapb.CollectionSchema, loadIn
 		// deltalog is not evictable, skip evictable size calculation
 	}
 
-	evictableMemoryCacheSize := uint64(float64(segmentEvictableMemorySize) * (1.0 - multiplyFactor.TieredEvictableMemoryCacheRatio))
-	evictableDiskCacheSize := uint64(float64(segmentEvictableDiskSize) * (1.0 - multiplyFactor.TieredEvictableDiskCacheRatio))
+	evictableMemoryUncacheSize := uint64(float64(segmentEvictableMemorySize) * (1.0 - multiplyFactor.TieredEvictableMemoryCacheRatio))
+	evictableDiskUncacheSize := uint64(float64(segmentEvictableDiskSize) * (1.0 - multiplyFactor.TieredEvictableDiskCacheRatio))
 
 	return &ResourceUsage{
-		MemorySize:         segmentMemorySize + indexMemorySize - evictableMemoryCacheSize,
-		DiskSize:           segmentDiskSize - evictableDiskCacheSize,
+		MemorySize:         segmentMemorySize + indexMemorySize - evictableMemoryUncacheSize,
+		DiskSize:           segmentDiskSize - evictableDiskUncacheSize,
 		MmapFieldCount:     mmapFieldCount,
 		FieldGpuMemorySize: fieldGpuMemorySize,
 	}, nil

--- a/internal/querynodev2/segments/segment_test.go
+++ b/internal/querynodev2/segments/segment_test.go
@@ -70,6 +70,7 @@ func (suite *SegmentSuite) SetupTest() {
 
 	suite.sealed, err = NewSegment(ctx,
 		suite.collection,
+		suite.manager.Segment,
 		SegmentTypeSealed,
 		0,
 		&querypb.SegmentLoadInfo{
@@ -113,6 +114,7 @@ func (suite *SegmentSuite) SetupTest() {
 
 	suite.growing, err = NewSegment(ctx,
 		suite.collection,
+		suite.manager.Segment,
 		SegmentTypeGrowing,
 		0,
 		&querypb.SegmentLoadInfo{

--- a/internal/querynodev2/server_test.go
+++ b/internal/querynodev2/server_test.go
@@ -229,6 +229,7 @@ func (suite *QueryNodeSuite) TestStop() {
 	segment, err := segments.NewSegment(
 		context.Background(),
 		collection,
+		suite.node.manager.Segment,
 		segments.SegmentTypeSealed,
 		1,
 		&querypb.SegmentLoadInfo{

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -2839,6 +2839,8 @@ type queryNodeConfig struct {
 	TieredDiskLowWatermarkRatio     ParamItem `refreshable:"false"`
 	TieredDiskHighWatermarkRatio    ParamItem `refreshable:"false"`
 	TieredEvictionEnabled           ParamItem `refreshable:"false"`
+	TieredMemoryEvictionFactor      ParamItem `refreshable:"false"`
+	TieredDiskEvictionFactor        ParamItem `refreshable:"false"`
 	TieredCacheTouchWindowMs        ParamItem `refreshable:"false"`
 	TieredEvictionIntervalMs        ParamItem `refreshable:"false"`
 	TieredLoadingMemoryFactor       ParamItem `refreshable:"false"`
@@ -3047,6 +3049,30 @@ Note that if eviction is enabled, cache data loaded during sync warmup is also s
 		Export: true,
 	}
 	p.TieredEvictionEnabled.Init(base.mgr)
+
+	p.TieredMemoryEvictionFactor = ParamItem{
+		Key:          "queryNode.segcore.tieredStorage.memoryEvictionFactor",
+		Version:      "2.6.0",
+		DefaultValue: "0.0",
+		Doc: `The factor of memory eviction. Defaults to 0.0, and available range is [0.0, 1.0].
+This factor determines the amount of evictable memory can be evicted in one segment.
+The reason why not make the factor as 1.0 is to avoid frequent eviction.
+`,
+		Export: true,
+	}
+	p.TieredMemoryEvictionFactor.Init(base.mgr)
+
+	p.TieredDiskEvictionFactor = ParamItem{
+		Key:          "queryNode.segcore.tieredStorage.diskEvictionFactor",
+		Version:      "2.6.0",
+		DefaultValue: "0.0",
+		Doc: `The factor of disk eviction. Defaults to 0.0, and available range is [0.0, 1.0].
+This factor determines the amount of evictable disk space can be evicted in one segment.
+The reason why not make the factor as 1.0 is to avoid frequent eviction.
+`,
+		Export: true,
+	}
+	p.TieredDiskEvictionFactor.Init(base.mgr)
 
 	p.TieredMemoryLowWatermarkRatio = ParamItem{
 		Key:          "queryNode.segcore.tieredStorage.memoryLowWatermarkRatio",

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -2839,8 +2839,8 @@ type queryNodeConfig struct {
 	TieredDiskLowWatermarkRatio     ParamItem `refreshable:"false"`
 	TieredDiskHighWatermarkRatio    ParamItem `refreshable:"false"`
 	TieredEvictionEnabled           ParamItem `refreshable:"false"`
-	TieredMemoryEvictionFactor      ParamItem `refreshable:"false"`
-	TieredDiskEvictionFactor        ParamItem `refreshable:"false"`
+	TieredEvictableMemoryCacheRatio ParamItem `refreshable:"false"`
+	TieredEvictableDiskCacheRatio   ParamItem `refreshable:"false"`
 	TieredCacheTouchWindowMs        ParamItem `refreshable:"false"`
 	TieredEvictionIntervalMs        ParamItem `refreshable:"false"`
 	TieredLoadingMemoryFactor       ParamItem `refreshable:"false"`
@@ -3050,27 +3050,47 @@ Note that if eviction is enabled, cache data loaded during sync warmup is also s
 	}
 	p.TieredEvictionEnabled.Init(base.mgr)
 
-	p.TieredMemoryEvictionFactor = ParamItem{
-		Key:          "queryNode.segcore.tieredStorage.memoryEvictionFactor",
+	p.TieredEvictableMemoryCacheRatio = ParamItem{
+		Key:          "queryNode.segcore.tieredStorage.evictableMemoryCacheRatio",
 		Version:      "2.6.0",
-		DefaultValue: "0.0",
-		Doc: `The factor of memory eviction. Defaults to 0.0, and available range is [0.0, 1.0].
-This factor determines the amount of evictable memory can be evicted in one segment.
-The reason why not make the factor as 1.0 is to avoid frequent eviction.`,
+		DefaultValue: "1.0",
+		Formatter: func(v string) string {
+			ratio := getAsFloat(v)
+			if ratio < 0 || ratio > 1 {
+				return "1.0"
+			}
+			return fmt.Sprintf("%f", ratio)
+		},
+		Doc: `This ratio estimates how much evictable memory can be cached.
+The higher the ratio, the more physical memory is reserved for evictable memory,
+resulting in fewer evictions but fewer segments can be loaded.
+Conversely, a lower ratio results in more evictions but allows more segments to be loaded.
+This parameter is only valid when eviction is enabled.
+It defaults to 1.0 (meaning all evictable memory is cached), with a valid range of [0.0, 1.0].`,
 		Export: true,
 	}
-	p.TieredMemoryEvictionFactor.Init(base.mgr)
+	p.TieredEvictableMemoryCacheRatio.Init(base.mgr)
 
-	p.TieredDiskEvictionFactor = ParamItem{
-		Key:          "queryNode.segcore.tieredStorage.diskEvictionFactor",
+	p.TieredEvictableDiskCacheRatio = ParamItem{
+		Key:          "queryNode.segcore.tieredStorage.evictableDiskCacheRatio",
 		Version:      "2.6.0",
-		DefaultValue: "0.0",
-		Doc: `The factor of disk eviction. Defaults to 0.0, and available range is [0.0, 1.0].
-This factor determines the amount of evictable disk space can be evicted in one segment.
-The reason why not make the factor as 1.0 is to avoid frequent eviction.`,
+		DefaultValue: "1.0",
+		Formatter: func(v string) string {
+			ratio := getAsFloat(v)
+			if ratio < 0 || ratio > 1 {
+				return "1.0"
+			}
+			return fmt.Sprintf("%f", ratio)
+		},
+		Doc: `This ratio estimates how much evictable disk space can be cached.
+The higher the ratio, the more physical disk space is reserved for evictable disk usage,
+resulting in fewer evictions but fewer segments can be loaded.
+Conversely, a lower ratio results in more evictions but allows more segments to be loaded.
+This parameter is only valid when eviction is enabled.
+It defaults to 1.0 (meaning all evictable disk is cached), with a valid range of [0.0, 1.0].`,
 		Export: true,
 	}
-	p.TieredDiskEvictionFactor.Init(base.mgr)
+	p.TieredEvictableDiskCacheRatio.Init(base.mgr)
 
 	p.TieredMemoryLowWatermarkRatio = ParamItem{
 		Key:          "queryNode.segcore.tieredStorage.memoryLowWatermarkRatio",

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -3056,8 +3056,7 @@ Note that if eviction is enabled, cache data loaded during sync warmup is also s
 		DefaultValue: "0.0",
 		Doc: `The factor of memory eviction. Defaults to 0.0, and available range is [0.0, 1.0].
 This factor determines the amount of evictable memory can be evicted in one segment.
-The reason why not make the factor as 1.0 is to avoid frequent eviction.
-`,
+The reason why not make the factor as 1.0 is to avoid frequent eviction.`,
 		Export: true,
 	}
 	p.TieredMemoryEvictionFactor.Init(base.mgr)
@@ -3068,8 +3067,7 @@ The reason why not make the factor as 1.0 is to avoid frequent eviction.
 		DefaultValue: "0.0",
 		Doc: `The factor of disk eviction. Defaults to 0.0, and available range is [0.0, 1.0].
 This factor determines the amount of evictable disk space can be evicted in one segment.
-The reason why not make the factor as 1.0 is to avoid frequent eviction.
-`,
+The reason why not make the factor as 1.0 is to avoid frequent eviction.`,
 		Export: true,
 	}
 	p.TieredDiskEvictionFactor.Init(base.mgr)


### PR DESCRIPTION
issue: #41435 

After introducing the caching layer's lazy loading and eviction mechanisms, most parts of a segment won't be loaded into memory or disk immediately, even if the segment is marked as LOADED. This means physical resource usage may be very low. However, we still need to reserve enough resources for the segments marked as LOADED. Thus, the logic of resource usage estimation during segment loading, which based on physcial resource usage only for now, should be changed.

To address this issue, we introduced the concept of logical resource usage in this patch. This can be thought of as the base reserved resource for each LOADED segment.

A segment’s logical resource usage is derived from its final evictable and inevictable resource usage and calculated as follows:

```
SLR = SFPIER + evitable_cache_ratio * SFPER
```

it also equals to

```
SLR = (SFPIER + SFPER) - (1.0 - evitable_cache_ratio) * SFPER
```

`SLR`: The logical resource usage of a segment.
`SFPIER`: The final physical inevictable resource usage of a segment.
`SFPER`: The final physical evictable resource usage of a segment.
`evitable_cache_ratio`: The ratio of a segment's evictable resources that can be cached locally. The higher the ratio, the more physical memory is reserved for evictable memory.

When loading a segment, two types of resource usage are taken into account.

First is the estimated maximum physical resource usage:

```
PPR = HPR + CPR + SMPR - SFPER
```

`PPR`: The predicted physical resource usage after the current segment is allowed to load.  
`HPR`: The physical resource usage obtained from hardware information.  
`CPR`: The total physical resource usage of segments that have been committed but not yet loaded. When one new segment is allow to load, `CPR' = CPR + (SMR - SER)`. When one of the committed segments is loaded, `CPR' = CPR - (SMR - SER)`.
`SMPR`: The maximum physical resource usage of the current segment.
`SFPER`: The final physical evictable resource usage of the current segment.

Second is the estimated logical resource usage, this check is only valid when eviction is enabled:

```
PLR = LLR + CLR + SLR
```

`PLR`: The predicted logical resource usage after the current segment is allowed to load.  
`LLR`: The total logical resource usage of all loaded segments. When a new segment is loaded, `LLR` should be updated to `LLR' = LLR + SLR`.
`CLR`: The total logical resource usage of segments that have been committed but not yet loaded. When one new segment is allow to load, `CLR' = CLR + SLR`. When one of the committed segments is loaded, `CLR' = CLR - SLR`.
`SLR`: The logical resource usage of the current segment.

Only when `PPR < PRL && PLR < PRL` (`PRL`: Physical resource limit of the querynode), the segment is allowed to be loaded.