### PR TITLE
fix: [StorageV2] Correct read and write buffer size

### DIFF
--- a/internal/datanode/compactor/clustering_compactor_test.go
+++ b/internal/datanode/compactor/clustering_compactor_test.go
@@ -179,7 +179,7 @@ func (s *ClusteringCompactionTaskSuite) TestCompactionInit() {
 	s.Require().NoError(err)
 	s.Equal(s.task.primaryKeyField, s.task.plan.Schema.Fields[2])
 	s.Equal(false, s.task.isVectorClusteringKey)
-	s.Equal(true, s.task.memoryBufferSize > 0)
+	s.Equal(true, s.task.memoryLimit > 0)
 	s.Equal(8, s.task.getWorkerPoolSize())
 	s.Equal(8, s.task.mappingPool.Cap())
 	s.Equal(8, s.task.flushPool.Cap())
@@ -305,7 +305,7 @@ func (s *ClusteringCompactionTaskSuite) prepareScalarCompactionNormalByMemoryLim
 		func(ctx context.Context, strings []string) ([][]byte, error) {
 			// 32m, only two buffers can be generated
 			one.Do(func() {
-				s.task.memoryBufferSize = 32 * 1024 * 1024
+				s.task.memoryLimit = 32 * 1024 * 1024
 			})
 			return lo.Values(kvs), nil
 		})

--- a/internal/storage/rw.go
+++ b/internal/storage/rw.go
@@ -277,7 +277,7 @@ func NewBinlogRecordWriter(ctx context.Context, collectionID, partitionID, segme
 		)
 	case StorageV2:
 		return newPackedBinlogRecordWriter(collectionID, partitionID, segmentID, schema,
-			blobsWriter, allocator, chunkSize, maxRowNum,
+			blobsWriter, allocator, maxRowNum,
 			rwOptions.bufferSize, rwOptions.multiPartUploadSize, rwOptions.columnGroups,
 			rwOptions.storageConfig,
 		)

--- a/internal/storage/serde_events_v2.go
+++ b/internal/storage/serde_events_v2.go
@@ -276,7 +276,6 @@ type PackedBinlogRecordWriter struct {
 	schema              *schemapb.CollectionSchema
 	BlobsWriter         ChunkedBlobsWriter
 	allocator           allocator.Interface
-	chunkSize           uint64
 	maxRowNum           int64
 	arrowSchema         *arrow.Schema
 	bufferSize          int64
@@ -531,7 +530,7 @@ func (pw *PackedBinlogRecordWriter) GetBufferUncompressed() uint64 {
 }
 
 func newPackedBinlogRecordWriter(collectionID, partitionID, segmentID UniqueID, schema *schemapb.CollectionSchema,
-	blobsWriter ChunkedBlobsWriter, allocator allocator.Interface, chunkSize uint64, maxRowNum int64, bufferSize, multiPartUploadSize int64, columnGroups []storagecommon.ColumnGroup,
+	blobsWriter ChunkedBlobsWriter, allocator allocator.Interface, maxRowNum int64, bufferSize, multiPartUploadSize int64, columnGroups []storagecommon.ColumnGroup,
 	storageConfig *indexpb.StorageConfig,
 ) (*PackedBinlogRecordWriter, error) {
 	arrowSchema, err := ConvertToArrowSchema(schema.Fields)
@@ -566,7 +565,6 @@ func newPackedBinlogRecordWriter(collectionID, partitionID, segmentID UniqueID, 
 		arrowSchema:         arrowSchema,
 		BlobsWriter:         blobsWriter,
 		allocator:           allocator,
-		chunkSize:           chunkSize,
 		maxRowNum:           maxRowNum,
 		bufferSize:          bufferSize,
 		multiPartUploadSize: multiPartUploadSize,


### PR DESCRIPTION
Correct read and buffer size to 64MB to prevent OOM during clustering compaction.

issue: https://github.com/milvus-io/milvus/issues/43310