### PR TITLE
fix: [2.5] Align null bitmap offset when loading multi-chunk (#43321)

### DIFF
--- a/internal/core/src/common/ChunkWriter.cpp
+++ b/internal/core/src/common/ChunkWriter.cpp
@@ -12,6 +12,7 @@
 #include "common/ChunkWriter.h"
 #include <cstdint>
 #include <memory>
+#include <tuple>
 #include <utility>
 #include <vector>
 #include "arrow/array/array_binary.h"
@@ -31,7 +32,8 @@ StringChunkWriter::write(std::shared_ptr<arrow::RecordBatchReader> data) {
     auto size = 0;
     std::vector<std::string_view> strs;
     std::vector<std::shared_ptr<arrow::RecordBatch>> batches;
-    std::vector<std::pair<const uint8_t*, int64_t>> null_bitmaps;
+    // tuple <data, size, offset>
+    std::vector<std::tuple<const uint8_t*, int64_t, int64_t>> null_bitmaps;
     for (auto batch : *data) {
         auto batch_data = batch.ValueOrDie();
         batches.emplace_back(batch_data);
@@ -44,7 +46,9 @@ StringChunkWriter::write(std::shared_ptr<arrow::RecordBatchReader> data) {
         }
         if (nullable_) {
             auto null_bitmap_n = (data->length() + 7) / 8;
-            null_bitmaps.emplace_back(data->null_bitmap_data(), null_bitmap_n);
+            // size, offset all in bits
+            null_bitmaps.emplace_back(
+                data->null_bitmap_data(), data->length(), data->offset());
             size += null_bitmap_n;
         }
         row_nums_ += array->length();
@@ -92,7 +96,8 @@ void
 JSONChunkWriter::write(std::shared_ptr<arrow::RecordBatchReader> data) {
     auto size = 0;
     std::vector<Json> jsons;
-    std::vector<std::pair<const uint8_t*, int64_t>> null_bitmaps;
+    // tuple <data, size, offset>
+    std::vector<std::tuple<const uint8_t*, int64_t, int64_t>> null_bitmaps;
     for (auto batch : *data) {
         auto data = batch.ValueOrDie()->column(0);
         auto array = std::dynamic_pointer_cast<arrow::BinaryArray>(data);
@@ -104,7 +109,9 @@ JSONChunkWriter::write(std::shared_ptr<arrow::RecordBatchReader> data) {
         }
         if (nullable_) {
             auto null_bitmap_n = (data->length() + 7) / 8;
-            null_bitmaps.emplace_back(data->null_bitmap_data(), null_bitmap_n);
+            // size, offset all in bits
+            null_bitmaps.emplace_back(
+                data->null_bitmap_data(), data->length(), data->offset());
             size += null_bitmap_n;
         }
         row_nums_ += array->length();
@@ -152,7 +159,8 @@ ArrayChunkWriter::write(std::shared_ptr<arrow::RecordBatchReader> data) {
     auto size = 0;
     auto is_string = IsStringDataType(element_type_);
     std::vector<Array> arrays;
-    std::vector<std::pair<const uint8_t*, int64_t>> null_bitmaps;
+    // tuple <data, size, offset>
+    std::vector<std::tuple<const uint8_t*, int64_t, int64_t>> null_bitmaps;
 
     for (auto batch : *data) {
         auto data = batch.ValueOrDie()->column(0);
@@ -172,7 +180,9 @@ ArrayChunkWriter::write(std::shared_ptr<arrow::RecordBatchReader> data) {
         row_nums_ += array->length();
         if (nullable_) {
             auto null_bitmap_n = (data->length() + 7) / 8;
-            null_bitmaps.emplace_back(data->null_bitmap_data(), null_bitmap_n);
+            // size, offset all in bits
+            null_bitmaps.emplace_back(
+                data->null_bitmap_data(), data->length(), data->offset());
             size += null_bitmap_n;
         }
     }

--- a/internal/core/src/common/ChunkWriter.h
+++ b/internal/core/src/common/ChunkWriter.h
@@ -45,17 +45,38 @@ class ChunkWriterBase {
 
     void
     write_null_bit_maps(
-        const std::vector<std::pair<const uint8_t*, int64_t>>& null_bitmaps) {
+        const std::vector<std::tuple<const uint8_t*, int64_t, int64_t>>&
+            null_bitmaps) {
         if (nullable_) {
-            for (auto [data, size] : null_bitmaps) {
+            // merge all null bitmaps in case of multiple chunk null bitmap dislocation
+            // say [0xFF, 0x00] with size [7, 8] cannot be treated as [0xFF, 0x00] after merged but
+            // [0x7F, 0x00], othersize the null index will be dislocated
+            std::vector<uint8_t> merged_null_bitmap;
+            int64_t size_total_bit = 0;
+            for (auto [data, size_bits, offset_bits] : null_bitmaps) {
+                // resize in byte
+                merged_null_bitmap.resize((size_total_bit + size_bits + 7) / 8,
+                                          0xFF);
                 if (data != nullptr) {
-                    target_->write(data, size);
+                    bitset::detail::ElementWiseBitsetPolicy<uint8_t>::op_copy(
+                        data,
+                        offset_bits,
+                        merged_null_bitmap.data(),
+                        size_total_bit,
+                        size_bits);
                 } else {
                     // have to append always-true bitmap due to arrow optimize this
-                    std::vector<uint8_t> null_bitmap(size, 0xff);
-                    target_->write(null_bitmap.data(), size);
+                    std::vector<uint8_t> null_bitmap(size_bits, 0xff);
+                    bitset::detail::ElementWiseBitsetPolicy<uint8_t>::op_copy(
+                        null_bitmap.data(),
+                        0,
+                        merged_null_bitmap.data(),
+                        size_total_bit,
+                        size_bits);
                 }
+                size_total_bit += size_bits;
             }
+            target_->write(merged_null_bitmap.data(), (size_total_bit + 7) / 8);
         }
     }
 


### PR DESCRIPTION
Cherry-pick from master
pr: #43321
Related to #43262

This patch fixes following logic bug:
- When multiple chunks are loaded and size cannot be divided by 8, just appending uint8_t as bitmap will cause null bitmap dislocation
- `null_bitmap_data()` points to start of whole row group, which may not stand for current `arrow::Array`

The current solutions is:
- Reorganize the null_bitmap with currect size & offset
- Pass `array->offset()` in tuple to info the current offset