### PR TITLE
enhance: Improve partial result evaluation with row count based strategy

### DIFF
--- a/internal/querynodev2/delegator/delegator.go
+++ b/internal/querynodev2/delegator/delegator.go
@@ -305,7 +305,7 @@ func (sd *shardDelegator) modifyQueryRequest(req *querypb.QueryRequest, scope qu
 }
 
 // Search preforms search operation on shard.
-func (sd *shardDelegator) search(ctx context.Context, req *querypb.SearchRequest, sealed []SnapshotItem, growing []SegmentEntry) ([]*internalpb.SearchResults, error) {
+func (sd *shardDelegator) search(ctx context.Context, req *querypb.SearchRequest, sealed []SnapshotItem, growing []SegmentEntry, sealedRowCount map[int64]int64) ([]*internalpb.SearchResults, error) {
 	log := sd.getLogger(ctx)
 	if req.Req.IgnoreGrowing {
 		growing = []SegmentEntry{}
@@ -355,7 +355,7 @@ func (sd *shardDelegator) search(ctx context.Context, req *querypb.SearchRequest
 		log.Warn("Search organizeSubTask failed", zap.Error(err))
 		return nil, err
 	}
-	results, err := executeSubTasks(ctx, tasks, func(ctx context.Context, req *querypb.SearchRequest, worker cluster.Worker) (*internalpb.SearchResults, error) {
+	results, err := executeSubTasks(ctx, tasks, NewRowCountBasedEvaluator(sealedRowCount), func(ctx context.Context, req *querypb.SearchRequest, worker cluster.Worker) (*internalpb.SearchResults, error) {
 		resp, err := worker.SearchSegments(ctx, req)
 		status, ok := status.FromError(err)
 		if ok && status.Code() == codes.Unavailable {
@@ -421,7 +421,7 @@ func (sd *shardDelegator) Search(ctx context.Context, req *querypb.SearchRequest
 		fmt.Sprint(paramtable.GetNodeID()), metrics.SearchLabel).
 		Observe(float64(waitTr.ElapseSpan().Milliseconds()))
 
-	sealed, growing, version, err := sd.distribution.PinReadableSegments(partialResultRequiredDataRatio, req.GetReq().GetPartitionIDs()...)
+	sealed, growing, sealedRowCount, version, err := sd.distribution.PinReadableSegments(partialResultRequiredDataRatio, req.GetReq().GetPartitionIDs()...)
 	if err != nil {
 		log.Warn("delegator failed to search, current distribution is not serviceable", zap.Error(err))
 		return nil, err
@@ -471,7 +471,7 @@ func (sd *shardDelegator) Search(ctx context.Context, req *querypb.SearchRequest
 					searchReq.GetReq().MvccTimestamp = tSafe
 				}
 				searchReq.Req.CollectionTtlTimestamps = req.GetReq().GetCollectionTtlTimestamps()
-				results, err := sd.search(ctx, searchReq, sealed, growing)
+				results, err := sd.search(ctx, searchReq, sealed, growing, sealedRowCount)
 				if err != nil {
 					return nil, err
 				}
@@ -502,7 +502,7 @@ func (sd *shardDelegator) Search(ctx context.Context, req *querypb.SearchRequest
 		}
 		return results, nil
 	}
-	return sd.search(ctx, req, sealed, growing)
+	return sd.search(ctx, req, sealed, growing, sealedRowCount)
 }
 
 func (sd *shardDelegator) QueryStream(ctx context.Context, req *querypb.QueryRequest, srv streamrpc.QueryStreamServer) error {
@@ -540,7 +540,7 @@ func (sd *shardDelegator) QueryStream(ctx context.Context, req *querypb.QueryReq
 		fmt.Sprint(paramtable.GetNodeID()), metrics.QueryLabel).
 		Observe(float64(waitTr.ElapseSpan().Milliseconds()))
 
-	sealed, growing, version, err := sd.distribution.PinReadableSegments(float64(1.0), req.GetReq().GetPartitionIDs()...)
+	sealed, growing, sealedRowCount, version, err := sd.distribution.PinReadableSegments(float64(1.0), req.GetReq().GetPartitionIDs()...)
 	if err != nil {
 		log.Warn("delegator failed to query, current distribution is not serviceable", zap.Error(err))
 		return err
@@ -561,7 +561,7 @@ func (sd *shardDelegator) QueryStream(ctx context.Context, req *querypb.QueryReq
 		return err
 	}
 
-	_, err = executeSubTasks(ctx, tasks, func(ctx context.Context, req *querypb.QueryRequest, worker cluster.Worker) (*internalpb.RetrieveResults, error) {
+	_, err = executeSubTasks(ctx, tasks, NewRowCountBasedEvaluator(sealedRowCount), func(ctx context.Context, req *querypb.QueryRequest, worker cluster.Worker) (*internalpb.RetrieveResults, error) {
 		err := worker.QueryStreamSegments(ctx, req, srv)
 		status, ok := status.FromError(err)
 		if ok && status.Code() == codes.Unavailable {
@@ -626,7 +626,7 @@ func (sd *shardDelegator) Query(ctx context.Context, req *querypb.QueryRequest) 
 		fmt.Sprint(paramtable.GetNodeID()), metrics.QueryLabel).
 		Observe(float64(waitTr.ElapseSpan().Milliseconds()))
 
-	sealed, growing, version, err := sd.distribution.PinReadableSegments(partialResultRequiredDataRatio, req.GetReq().GetPartitionIDs()...)
+	sealed, growing, sealedRowCount, version, err := sd.distribution.PinReadableSegments(partialResultRequiredDataRatio, req.GetReq().GetPartitionIDs()...)
 	if err != nil {
 		log.Warn("delegator failed to query, current distribution is not serviceable", zap.Error(err))
 		return nil, err
@@ -656,7 +656,7 @@ func (sd *shardDelegator) Query(ctx context.Context, req *querypb.QueryRequest) 
 		return nil, err
 	}
 
-	results, err := executeSubTasks(ctx, tasks, func(ctx context.Context, req *querypb.QueryRequest, worker cluster.Worker) (*internalpb.RetrieveResults, error) {
+	results, err := executeSubTasks(ctx, tasks, NewRowCountBasedEvaluator(sealedRowCount), func(ctx context.Context, req *querypb.QueryRequest, worker cluster.Worker) (*internalpb.RetrieveResults, error) {
 		resp, err := worker.QuerySegments(ctx, req)
 		status, ok := status.FromError(err)
 		if ok && status.Code() == codes.Unavailable {
@@ -712,7 +712,7 @@ func (sd *shardDelegator) GetStatistics(ctx context.Context, req *querypb.GetSta
 		return nil, err
 	}
 
-	sealed, growing, version, err := sd.distribution.PinReadableSegments(1.0, req.Req.GetPartitionIDs()...)
+	sealed, growing, sealedRowCount, version, err := sd.distribution.PinReadableSegments(1.0, req.Req.GetPartitionIDs()...)
 	if err != nil {
 		log.Warn("delegator failed to GetStatistics, current distribution is not servicable")
 		return nil, merr.WrapErrChannelNotAvailable(sd.vchannelName, "distribution is not serviceable")
@@ -732,7 +732,7 @@ func (sd *shardDelegator) GetStatistics(ctx context.Context, req *querypb.GetSta
 		return nil, err
 	}
 
-	results, err := executeSubTasks(ctx, tasks, func(ctx context.Context, req *querypb.GetStatisticsRequest, worker cluster.Worker) (*internalpb.GetStatisticsResponse, error) {
+	results, err := executeSubTasks(ctx, tasks, NewRowCountBasedEvaluator(sealedRowCount), func(ctx context.Context, req *querypb.GetStatisticsRequest, worker cluster.Worker) (*internalpb.GetStatisticsResponse, error) {
 		return worker.GetStatistics(ctx, req)
 	}, "GetStatistics", log)
 	if err != nil {
@@ -806,7 +806,7 @@ func organizeSubTask[T any](ctx context.Context,
 
 func executeSubTasks[T any, R interface {
 	GetStatus() *commonpb.Status
-}](ctx context.Context, tasks []subTask[T], execute func(context.Context, T, cluster.Worker) (R, error), taskType string, log *log.MLogger,
+}](ctx context.Context, tasks []subTask[T], evaluator PartialResultEvaluator, execute func(context.Context, T, cluster.Worker) (R, error), taskType string, log *log.MLogger,
 ) ([]R, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -882,15 +882,15 @@ func executeSubTasks[T any, R interface {
 	}
 	close(resultCh)
 
-	successSegmentList := []int64{}
-	failureSegmentList := []int64{}
+	successSegmentList := typeutil.NewSet[int64]()
+	failureSegmentList := make([]int64, 0)
 	var errors []error
 
 	// Collect results
 	results := make([]R, 0, len(tasks))
 	for item := range resultCh {
 		if item.err == nil {
-			successSegmentList = append(successSegmentList, item.segments...)
+			successSegmentList.Insert(item.segments...)
 			results = append(results, item.result)
 		} else {
 			failureSegmentList = append(failureSegmentList, item.segments...)
@@ -898,25 +898,24 @@ func executeSubTasks[T any, R interface {
 		}
 	}
 
-	accessDataRatio := 1.0
-	totalSegments := len(successSegmentList) + len(failureSegmentList)
-	if totalSegments > 0 {
-		accessDataRatio = float64(len(successSegmentList)) / float64(totalSegments)
-		if accessDataRatio < 1.0 {
+	if len(errors) == 0 {
+		return results, nil
+	}
+
+	// Use evaluator to determine if partial results should be returned
+	if evaluator != nil {
+		shouldReturnPartial, accessedDataRatio := evaluator(taskType, successSegmentList, failureSegmentList, errors)
+		if shouldReturnPartial {
 			log.Info("partial result executed successfully",
 				zap.String("taskType", taskType),
-				zap.Float64("successRatio", accessDataRatio),
-				zap.Float64("partialResultRequiredDataRatio", partialResultRequiredDataRatio),
-				zap.Int("totalSegments", totalSegments),
+				zap.Float64("accessedDataRatio", accessedDataRatio),
 				zap.Int64s("failureSegmentList", failureSegmentList),
 			)
+			return results, nil
 		}
 	}
 
-	if accessDataRatio < partialResultRequiredDataRatio {
-		return nil, merr.Combine(errors...)
-	}
-	return results, nil
+	return nil, merr.Combine(errors...)
 }
 
 // speedupGuranteeTS returns the guarantee timestamp for strong consistency search.
@@ -1054,7 +1053,7 @@ func (sd *shardDelegator) UpdateSchema(ctx context.Context, schema *schemapb.Col
 		return err
 	}
 
-	_, err = executeSubTasks(ctx, tasks, func(ctx context.Context, req *querypb.UpdateSchemaRequest, worker cluster.Worker) (*StatusWrapper, error) {
+	_, err = executeSubTasks(ctx, tasks, nil, func(ctx context.Context, req *querypb.UpdateSchemaRequest, worker cluster.Worker) (*StatusWrapper, error) {
 		status, err := worker.UpdateSchema(ctx, req)
 		return (*StatusWrapper)(status), err
 	}, "UpdateSchema", log)
@@ -1260,4 +1259,49 @@ func (sd *shardDelegator) RunAnalyzer(ctx context.Context, req *querypb.RunAnaly
 			Tokens: tokens,
 		}
 	}), nil
+}
+
+// PartialResultEvaluator evaluates whether partial results should be returned
+// Parameters:
+//   - taskType: the type of task being executed (Search, Query, etc.)
+//   - successSegments: list of segments that were successfully processed
+//   - failureSegments: list of segments that failed to process
+//   - errors: list of errors that occurred
+//
+// Returns:
+//   - bool: whether to return partial results
+//   - float64: actual accessed data ratio (for logging)
+type PartialResultEvaluator func(taskType string, successSegments typeutil.Set[int64], failureSegments []int64, errors []error) (bool, float64)
+
+// NewRowCountBasedEvaluator creates a PartialResultEvaluator based on row count
+func NewRowCountBasedEvaluator(sealedRowCount map[int64]int64) PartialResultEvaluator {
+	return func(taskType string, successSegments typeutil.Set[int64], failureSegments []int64, errors []error) (bool, float64) {
+		var partialResultRequiredDataRatio float64
+		if taskType == "Query" || taskType == "Search" {
+			partialResultRequiredDataRatio = paramtable.Get().QueryNodeCfg.PartialResultRequiredDataRatio.GetAsFloat()
+		} else {
+			partialResultRequiredDataRatio = 1.0
+		}
+
+		if partialResultRequiredDataRatio >= 1.0 || len(sealedRowCount) == 0 {
+			return false, 0.0
+		}
+
+		// Calculate accessed data ratio for partial result
+		successRowCount := int64(0)
+		totalRowCount := int64(0)
+		for sid, rowCount := range sealedRowCount {
+			if successSegments.Contain(sid) {
+				successRowCount += rowCount
+			}
+			totalRowCount += rowCount
+		}
+
+		if totalRowCount == 0 {
+			return false, 1.0
+		}
+
+		accessedDataRatio := float64(successRowCount) / float64(totalRowCount)
+		return accessedDataRatio > partialResultRequiredDataRatio, accessedDataRatio
+	}
 }

--- a/internal/querynodev2/delegator/distribution_test.go
+++ b/internal/querynodev2/delegator/distribution_test.go
@@ -187,7 +187,7 @@ func (s *DistributionSuite) TestAddDistribution() {
 			s.dist.SyncTargetVersion(&querypb.SyncAction{
 				TargetVersion: 1000,
 			}, []int64{1})
-			_, _, version, err := s.dist.PinReadableSegments(1.0, 1)
+			_, _, _, version, err := s.dist.PinReadableSegments(1.0, 1)
 			s.Require().NoError(err)
 			s.dist.AddDistributions(tc.input...)
 			sealed, _ := s.dist.PeekSegments(false)
@@ -269,7 +269,7 @@ func (s *DistributionSuite) TestAddGrowing() {
 				TargetVersion:   1000,
 				GrowingInTarget: []int64{1, 2},
 			}, tc.workingParts)
-			_, growing, version, err := s.dist.PinReadableSegments(1.0, tc.workingParts...)
+			_, growing, _, version, err := s.dist.PinReadableSegments(1.0, tc.workingParts...)
 			s.Require().NoError(err)
 			defer s.dist.Unpin(version)
 
@@ -471,7 +471,7 @@ func (s *DistributionSuite) TestRemoveDistribution() {
 			var version int64
 			if tc.withMockRead {
 				var err error
-				_, _, version, err = s.dist.PinReadableSegments(1.0, 1)
+				_, _, _, version, err = s.dist.PinReadableSegments(1.0, 1)
 				s.Require().NoError(err)
 			}
 
@@ -762,7 +762,7 @@ func (s *DistributionSuite) Test_SyncTargetVersion() {
 		DroppedInTarget:       []int64{6},
 	}, []int64{1})
 
-	s1, s2, _, err := s.dist.PinReadableSegments(1.0, 1)
+	s1, s2, _, _, err := s.dist.PinReadableSegments(1.0, 1)
 	s.Require().NoError(err)
 	s.Len(s1[0].Segments, 2)
 	s.Len(s2, 1)
@@ -778,7 +778,7 @@ func (s *DistributionSuite) Test_SyncTargetVersion() {
 		DroppedInTarget:       []int64{},
 	}, []int64{1})
 	s.False(s.dist.Serviceable())
-	_, _, _, err = s.dist.PinReadableSegments(1.0, 1)
+	_, _, _, _, err = s.dist.PinReadableSegments(1.0, 1)
 	s.Error(err)
 }
 
@@ -1214,7 +1214,7 @@ func (s *DistributionSuite) TestPinReadableSegments_RequiredLoadRatio() {
 			}, []int64{1})
 
 			// Test PinReadableSegments with different requiredLoadRatio
-			sealed, growing, _, err := s.dist.PinReadableSegments(tc.requiredLoadRatio, 1)
+			sealed, growing, _, _, err := s.dist.PinReadableSegments(tc.requiredLoadRatio, 1)
 
 			if tc.shouldError {
 				s.Error(err)


### PR DESCRIPTION
issue: #43360
Enhance the partial result evaluation mechanism in delegator to use row count based data ratio instead of simple segment count ratio for better accuracy.

Key improvements:
- Introduce PartialResultEvaluator interface for flexible evaluation strategy
- Implement NewRowCountBasedEvaluator using sealed segment row count data
- Replace segment count based ratio with row count based data ratio calculation
- Update PinReadableSegments to return sealedRowCount information
- Modify executeSubTasks to use configurable evaluator for partial result decisions
- Add comprehensive unit tests for the new row count based evaluation logic

This change provides more accurate partial result evaluation by considering the actual data volume rather than just segment quantity, leading to better query performance and consistency when some segments are unavailable.