### PR TITLE
fix: [2.5] Merge bitmap in loop

### DIFF
--- a/internal/core/src/common/ChunkWriter.h
+++ b/internal/core/src/common/ChunkWriter.h
@@ -43,41 +43,38 @@ class ChunkWriterBase {
         return target_->get();
     }
 
+    /**
+     * Merge null bitmap from `data` to `null_bitmap` at `offset_bits`
+     * position. The `size_bits` is the size of `data` in bits.
+     * If `data` is nullptr, append always-true bitmap.
+     * The `size_total_bit` is the size of `null_bitmap` in bits.
+     * The `size_total_bit` will be updated after the merge.
+     */
     void
-    write_null_bit_maps(
-        const std::vector<std::tuple<const uint8_t*, int64_t, int64_t>>&
-            null_bitmaps) {
-        if (nullable_) {
-            // merge all null bitmaps in case of multiple chunk null bitmap dislocation
-            // say [0xFF, 0x00] with size [7, 8] cannot be treated as [0xFF, 0x00] after merged but
-            // [0x7F, 0x00], othersize the null index will be dislocated
-            std::vector<uint8_t> merged_null_bitmap;
-            int64_t size_total_bit = 0;
-            for (auto [data, size_bits, offset_bits] : null_bitmaps) {
-                // resize in byte
-                merged_null_bitmap.resize((size_total_bit + size_bits + 7) / 8,
-                                          0xFF);
-                if (data != nullptr) {
-                    bitset::detail::ElementWiseBitsetPolicy<uint8_t>::op_copy(
-                        data,
-                        offset_bits,
-                        merged_null_bitmap.data(),
-                        size_total_bit,
-                        size_bits);
-                } else {
-                    // have to append always-true bitmap due to arrow optimize this
-                    std::vector<uint8_t> null_bitmap(size_bits, 0xff);
-                    bitset::detail::ElementWiseBitsetPolicy<uint8_t>::op_copy(
-                        null_bitmap.data(),
-                        0,
-                        merged_null_bitmap.data(),
-                        size_total_bit,
-                        size_bits);
-                }
-                size_total_bit += size_bits;
-            }
-            target_->write(merged_null_bitmap.data(), (size_total_bit + 7) / 8);
+    merged_null_bitmap(std::vector<uint8_t>& null_bitmap,
+                       int64_t& size_total_bit,
+                       const uint8_t* data,
+                       int64_t size_bits,
+                       int64_t offset_bits) {
+        null_bitmap.resize((size_total_bit + size_bits + 7) / 8, 0xFF);
+        if (data != nullptr) {
+            bitset::detail::ElementWiseBitsetPolicy<uint8_t>::op_copy(
+                data,
+                offset_bits,
+                null_bitmap.data(),
+                size_total_bit,
+                size_bits);
+        } else {
+            // have to append always-true bitmap due to arrow optimize this
+            std::vector<uint8_t> null_bitmap(size_bits, 0xff);
+            bitset::detail::ElementWiseBitsetPolicy<uint8_t>::op_copy(
+                null_bitmap.data(),
+                0,
+                null_bitmap.data(),
+                size_total_bit,
+                size_bits);
         }
+        size_total_bit += size_bits;
     }
 
  protected:


### PR DESCRIPTION
Related to #43389

This patch make bitmap merged when looping `RecordBatchReader` in case of record batch got destroyed after iteration.