### PR TITLE
fix: Make MultiSaveAndRemove execute removal first

### DIFF
--- a/internal/kv/etcd/embed_etcd_kv.go
+++ b/internal/kv/etcd/embed_etcd_kv.go
@@ -466,12 +466,13 @@ func (kv *EmbedEtcdKV) MultiSaveAndRemove(ctx context.Context, saves map[string]
 	}
 
 	ops := make([]clientv3.Op, 0, len(saves)+len(removals))
-	for key, value := range saves {
-		ops = append(ops, clientv3.OpPut(path.Join(kv.rootPath, key), value))
-	}
 
 	for _, keyDelete := range removals {
 		ops = append(ops, clientv3.OpDelete(path.Join(kv.rootPath, keyDelete)))
+	}
+
+	for key, value := range saves {
+		ops = append(ops, clientv3.OpPut(path.Join(kv.rootPath, key), value))
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, kv.requestTimeout)
@@ -491,12 +492,13 @@ func (kv *EmbedEtcdKV) MultiSaveAndRemove(ctx context.Context, saves map[string]
 // MultiSaveBytesAndRemove saves the key-value pairs and removes the keys in a transaction.
 func (kv *EmbedEtcdKV) MultiSaveBytesAndRemove(ctx context.Context, saves map[string][]byte, removals []string) error {
 	ops := make([]clientv3.Op, 0, len(saves)+len(removals))
-	for key, value := range saves {
-		ops = append(ops, clientv3.OpPut(path.Join(kv.rootPath, key), string(value)))
-	}
 
 	for _, keyDelete := range removals {
 		ops = append(ops, clientv3.OpDelete(path.Join(kv.rootPath, keyDelete)))
+	}
+
+	for key, value := range saves {
+		ops = append(ops, clientv3.OpPut(path.Join(kv.rootPath, key), string(value)))
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, kv.requestTimeout)
@@ -532,12 +534,12 @@ func (kv *EmbedEtcdKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves m
 	}
 
 	ops := make([]clientv3.Op, 0, len(saves)+len(removals))
-	for key, value := range saves {
-		ops = append(ops, clientv3.OpPut(path.Join(kv.rootPath, key), value))
-	}
-
 	for _, keyDelete := range removals {
 		ops = append(ops, clientv3.OpDelete(path.Join(kv.rootPath, keyDelete), clientv3.WithPrefix()))
+	}
+
+	for key, value := range saves {
+		ops = append(ops, clientv3.OpPut(path.Join(kv.rootPath, key), value))
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, kv.requestTimeout)

--- a/internal/kv/etcd/etcd_kv.go
+++ b/internal/kv/etcd/etcd_kv.go
@@ -467,14 +467,14 @@ func (kv *etcdKV) MultiSaveAndRemove(ctx context.Context, saves map[string]strin
 
 	start := time.Now()
 	ops := make([]clientv3.Op, 0, len(saves)+len(removals))
+	for _, keyDelete := range removals {
+		ops = append(ops, clientv3.OpDelete(path.Join(kv.rootPath, keyDelete)))
+	}
+
 	var keys []string
 	for key, value := range saves {
 		keys = append(keys, key)
 		ops = append(ops, clientv3.OpPut(path.Join(kv.rootPath, key), value))
-	}
-
-	for _, keyDelete := range removals {
-		ops = append(ops, clientv3.OpDelete(path.Join(kv.rootPath, keyDelete)))
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, kv.requestTimeout)
@@ -503,13 +503,13 @@ func (kv *etcdKV) MultiSaveBytesAndRemove(ctx context.Context, saves map[string]
 	start := time.Now()
 	ops := make([]clientv3.Op, 0, len(saves)+len(removals))
 	var keys []string
+	for _, keyDelete := range removals {
+		ops = append(ops, clientv3.OpDelete(path.Join(kv.rootPath, keyDelete)))
+	}
+
 	for key, value := range saves {
 		keys = append(keys, key)
 		ops = append(ops, clientv3.OpPut(path.Join(kv.rootPath, key), string(value)))
-	}
-
-	for _, keyDelete := range removals {
-		ops = append(ops, clientv3.OpDelete(path.Join(kv.rootPath, keyDelete)))
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, kv.requestTimeout)
@@ -564,14 +564,14 @@ func (kv *etcdKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[st
 
 	start := time.Now()
 	ops := make([]clientv3.Op, 0, len(saves))
+	for _, keyDelete := range removals {
+		ops = append(ops, clientv3.OpDelete(path.Join(kv.rootPath, keyDelete), clientv3.WithPrefix()))
+	}
+
 	var keys []string
 	for key, value := range saves {
 		keys = append(keys, key)
 		ops = append(ops, clientv3.OpPut(path.Join(kv.rootPath, key), value))
-	}
-
-	for _, keyDelete := range removals {
-		ops = append(ops, clientv3.OpDelete(path.Join(kv.rootPath, keyDelete), clientv3.WithPrefix()))
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, kv.requestTimeout)

--- a/internal/kv/mem/mem_kv.go
+++ b/internal/kv/mem/mem_kv.go
@@ -229,12 +229,14 @@ func (kv *MemoryKV) MultiSaveAndRemove(ctx context.Context, saves map[string]str
 	}
 	kv.Lock()
 	defer kv.Unlock()
-	for key, value := range saves {
-		kv.tree.ReplaceOrInsert(memoryKVItem{key, StringValue(value)})
-	}
 	for _, key := range removals {
 		kv.tree.Delete(memoryKVItem{key: key})
 	}
+
+	for key, value := range saves {
+		kv.tree.ReplaceOrInsert(memoryKVItem{key, StringValue(value)})
+	}
+
 	return nil
 }
 

--- a/internal/metastore/kv/rootcoord/suffix_snapshot.go
+++ b/internal/metastore/kv/rootcoord/suffix_snapshot.go
@@ -526,6 +526,10 @@ func (ss *SuffixSnapshot) MultiSaveAndRemove(ctx context.Context, saves map[stri
 
 	// load each removal, change execution to adding tombstones
 	for _, removal := range removals {
+		// if save batch contains removal, skip remove op
+		if _, ok := execute[removal]; ok {
+			continue
+		}
 		value, err := ss.MetaKv.Load(ctx, removal)
 		if err != nil {
 			log.Warn("SuffixSnapshot MetaKv Load failed", zap.String("key", removal), zap.Error(err))

--- a/pkg/kv/rocksdb/rocksdb_kv.go
+++ b/pkg/kv/rocksdb/rocksdb_kv.go
@@ -401,12 +401,13 @@ func (kv *RocksdbKV) MultiSaveAndRemove(ctx context.Context, saves map[string]st
 	}
 	writeBatch := gorocksdb.NewWriteBatch()
 	defer writeBatch.Destroy()
-	for k, v := range saves {
-		writeBatch.Put([]byte(k), []byte(v))
-	}
 	for _, key := range removals {
 		writeBatch.Delete([]byte(key))
 	}
+	for k, v := range saves {
+		writeBatch.Put([]byte(k), []byte(v))
+	}
+
 	err := kv.DB.Write(kv.WriteOptions, writeBatch)
 	return err
 }
@@ -436,10 +437,10 @@ func (kv *RocksdbKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map
 	}
 	writeBatch := gorocksdb.NewWriteBatch()
 	defer writeBatch.Destroy()
+	kv.prepareRemovePrefix(removals, writeBatch)
 	for k, v := range saves {
 		writeBatch.Put([]byte(k), []byte(v))
 	}
-	kv.prepareRemovePrefix(removals, writeBatch)
 	err := kv.DB.Write(kv.WriteOptions, writeBatch)
 	return err
 }


### PR DESCRIPTION
Realted to #43407

When `MultiSaveAndRemove` like ops contains same key in saves and removal keys it may cause data lost if the execution order is save first than removal.

This PR make all the kv execute removal first then save the new values. Even when same key appeared in both saves and removals, the new value shall stay.