### PR TITLE
fix: create nil start position segment if sync start position before insert

### DIFF
--- a/internal/flushcommon/metacache/actions.go
+++ b/internal/flushcommon/metacache/actions.go
@@ -111,7 +111,7 @@ func WithPartitionIDs(partitionIDs []int64) SegmentFilter {
 
 func WithStartPosNotRecorded() SegmentFilter {
 	return SegmentFilterFunc(func(info *SegmentInfo) bool {
-		return !info.startPosRecorded
+		return !info.startPosRecorded && info.startPosition != nil
 	})
 }
 

--- a/internal/flushcommon/metacache/actions_test.go
+++ b/internal/flushcommon/metacache/actions_test.go
@@ -57,7 +57,11 @@ func (s *SegmentFilterSuite) TestFilters() {
 	info.startPosRecorded = true
 	s.False(filter.Filter(info))
 	info.startPosRecorded = false
+	s.False(filter.Filter(info))
+	info.startPosition = &msgpb.MsgPosition{}
 	s.True(filter.Filter(info))
+	info.startPosRecorded = true
+	s.False(filter.Filter(info))
 }
 
 func TestFilters(t *testing.T) {


### PR DESCRIPTION
issue: #43434

- the segment start position can be carried by other segment sync operation. so the sync start position operation can happens before insert.
- TODO: It's a wired design should be removed.