### PR TITLE
enhance: [StorageV2] Fill ts range default values for `PackedBinlogRecordWriter`

### DIFF
--- a/internal/storage/serde_events_v2.go
+++ b/internal/storage/serde_events_v2.go
@@ -572,5 +572,8 @@ func newPackedBinlogRecordWriter(collectionID, partitionID, segmentID UniqueID, 
 		pkstats:             stats,
 		bm25Stats:           bm25Stats,
 		storageConfig:       storageConfig,
+
+		tsFrom: typeutil.MaxTimestamp,
+		tsTo:   0,
 	}, nil
 }


### PR DESCRIPTION
This PR fill default value for `PackedBinlogRecordWriter` timestamp range so target segment meta will contains correct timestamp range