### PR TITLE
enhance: [StorageV2] Return EOF when packedReader closed

### DIFF
--- a/internal/storagev2/packed/packed_reader.go
+++ b/internal/storagev2/packed/packed_reader.go
@@ -98,6 +98,11 @@ func NewPackedReader(filePaths []string, schema *arrow.Schema, bufferSize int64,
 }
 
 func (pr *PackedReader) ReadNext() (arrow.Record, error) {
+	// return EOF if reader is closed
+	if pr.cPackedReader == nil {
+		return nil, io.EOF
+	}
+
 	if pr.currentBatch != nil {
 		pr.currentBatch.Release()
 		pr.currentBatch = nil


### PR DESCRIPTION
This patch makes `PackedReader` return EOF when try to calling `ReadNext` after closing it.

This behavior make importv2.binlog reader could retry after EOF reached and act normally.