### PR TITLE
enhance: [QueryCoord] Refactor load config watch to periodic check

### DIFF
--- a/internal/datacoord/task_queue.go
+++ b/internal/datacoord/task_queue.go
@@ -33,9 +33,7 @@ type schedulePolicy interface {
 	Remove(taskID UniqueID)
 }
 
-var (
-	_ schedulePolicy = &priorityQueuePolicy{}
-)
+var _ schedulePolicy = &priorityQueuePolicy{}
 
 // priorityQueuePolicy implements a priority queue that sorts tasks by taskID (smaller taskID has higher priority)
 type priorityQueuePolicy struct {

--- a/internal/querycoordv2/server.go
+++ b/internal/querycoordv2/server.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strconv"
-	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -57,7 +55,6 @@ import (
 	"github.com/milvus-io/milvus/internal/util/sessionutil"
 	"github.com/milvus-io/milvus/internal/util/tsoutil"
 	"github.com/milvus-io/milvus/pkg/v2/common"
-	"github.com/milvus-io/milvus/pkg/v2/config"
 	"github.com/milvus-io/milvus/pkg/v2/kv"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/metrics"
@@ -558,8 +555,6 @@ func (s *Server) startQueryCoord() error {
 	go s.handleNodeUpLoop()
 	go s.watchNodes(revision)
 
-	// check replica changes after restart
-	s.checkLoadConfigChanges(s.ctx)
 	// watch load config changes
 	s.watchLoadConfigChanges()
 
@@ -953,102 +948,58 @@ func (s *Server) updateBalanceConfig() bool {
 	return false
 }
 
-func (s *Server) checkLoadConfigChanges(ctx context.Context) {
-	// try to check load config changes after restart, and try to update replicas
-	collectionIDs := s.meta.GetAll(ctx)
+func (s *Server) watchLoadConfigChanges() {
+	log := log.Ctx(s.ctx)
+	ticker := time.NewTicker(Params.QueryCoordCfg.CheckLoadConfigInterval.GetAsDuration(time.Millisecond))
+
+	go func() {
+		defer ticker.Stop()
+		for {
+			select {
+			case <-s.ctx.Done():
+				log.Info("watch load config changes loop exit due to context done")
+				return
+			case <-ticker.C:
+				s.checkLoadConfigChanges()
+			}
+		}
+	}()
+}
+
+func (s *Server) checkLoadConfigChanges() {
+	log := log.Ctx(s.ctx)
+
+	collectionIDs := s.meta.GetAll(s.ctx)
+	if len(collectionIDs) == 0 {
+		log.Warn("no collection loaded, skip to trigger update load config")
+		return
+	}
 	collectionIDs = lo.Filter(collectionIDs, func(collectionID int64, _ int) bool {
-		collection := s.meta.GetCollection(ctx, collectionID)
+		collection := s.meta.GetCollection(s.ctx, collectionID)
 		if collection.UserSpecifiedReplicaMode {
 			log.Info("collection is user specified replica mode, skip update load config", zap.Int64("collectionID", collectionID))
 			return false
 		}
 		return true
 	})
-	replicaNum := paramtable.Get().QueryCoordCfg.ClusterLevelLoadReplicaNumber.GetAsUint32()
+
 	rgs := paramtable.Get().QueryCoordCfg.ClusterLevelLoadResourceGroups.GetAsStrings()
-	log.Info("apply load config changes",
-		zap.Int64s("collectionIDs", collectionIDs),
-		zap.Int32("replicaNum", int32(replicaNum)),
-		zap.Strings("resourceGroups", rgs))
-	s.UpdateLoadConfig(ctx, &querypb.UpdateLoadConfigRequest{
+	if len(rgs) == 0 {
+		log.Info("invalid cluster level load config, skip it", zap.Strings("resource_groups", rgs))
+		return
+	}
+	replicaNum := paramtable.Get().QueryCoordCfg.ClusterLevelLoadReplicaNumber.GetAsInt64()
+	if replicaNum <= 0 {
+		log.Info("invalid cluster level load config, skip it", zap.Int64("replica_num", replicaNum))
+		return
+	}
+
+	err := s.updateLoadConfig(s.ctx, &querypb.UpdateLoadConfigRequest{
 		CollectionIDs:  collectionIDs,
 		ReplicaNumber:  int32(replicaNum),
 		ResourceGroups: rgs,
 	})
-}
-
-func (s *Server) watchLoadConfigChanges() {
-	log := log.Ctx(s.ctx)
-	replicaNumHandler := config.NewHandler("watchReplicaNumberChanges", func(e *config.Event) {
-		log.Info("watch load config changes", zap.String("key", e.Key), zap.String("value", e.Value), zap.String("type", e.EventType))
-
-		collectionIDs := s.meta.GetAll(s.ctx)
-		if len(collectionIDs) == 0 {
-			log.Warn("no collection loaded, skip to trigger update load config")
-			return
-		}
-		collectionIDs = lo.Filter(collectionIDs, func(collectionID int64, _ int) bool {
-			collection := s.meta.GetCollection(s.ctx, collectionID)
-			if collection.UserSpecifiedReplicaMode {
-				log.Info("collection is user specified replica mode, skip update load config", zap.Int64("collectionID", collectionID))
-				return false
-			}
-			return true
-		})
-
-		replicaNum, err := strconv.ParseInt(e.Value, 10, 64)
-		if err != nil {
-			log.Warn("invalid cluster level load config, skip it", zap.String("key", e.Key), zap.String("value", e.Value))
-			return
-		}
-		if replicaNum <= 0 {
-			log.Info("invalid cluster level load config, skip it", zap.Int64("replica_num", replicaNum))
-			return
-		}
-		rgs := paramtable.Get().QueryCoordCfg.ClusterLevelLoadResourceGroups.GetAsStrings()
-
-		s.UpdateLoadConfig(s.ctx, &querypb.UpdateLoadConfigRequest{
-			CollectionIDs:  collectionIDs,
-			ReplicaNumber:  int32(replicaNum),
-			ResourceGroups: rgs,
-		})
-	})
-	paramtable.Get().Watch(paramtable.Get().QueryCoordCfg.ClusterLevelLoadReplicaNumber.Key, replicaNumHandler)
-
-	rgHandler := config.NewHandler("watchResourceGroupChanges", func(e *config.Event) {
-		log.Info("watch load config changes", zap.String("key", e.Key), zap.String("value", e.Value), zap.String("type", e.EventType))
-		collectionIDs := s.meta.GetAll(s.ctx)
-		if len(collectionIDs) == 0 {
-			log.Warn("no collection loaded, skip to trigger update load config")
-			return
-		}
-		collectionIDs = lo.Filter(collectionIDs, func(collectionID int64, _ int) bool {
-			collection := s.meta.GetCollection(s.ctx, collectionID)
-			if collection.UserSpecifiedReplicaMode {
-				log.Info("collection is user specified replica mode, skip update load config", zap.Int64("collectionID", collectionID))
-				return false
-			}
-			return true
-		})
-
-		if len(e.Value) == 0 {
-			log.Warn("invalid cluster level load config, skip it", zap.String("key", e.Key), zap.String("value", e.Value))
-			return
-		}
-
-		rgs := strings.Split(e.Value, ",")
-		rgs = lo.Map(rgs, func(rg string, _ int) string { return strings.TrimSpace(rg) })
-		if len(rgs) == 0 {
-			log.Info("invalid cluster level load config, skip it", zap.Strings("resource_groups", rgs))
-			return
-		}
-
-		replicaNum := paramtable.Get().QueryCoordCfg.ClusterLevelLoadReplicaNumber.GetAsInt64()
-		s.UpdateLoadConfig(s.ctx, &querypb.UpdateLoadConfigRequest{
-			CollectionIDs:  collectionIDs,
-			ReplicaNumber:  int32(replicaNum),
-			ResourceGroups: rgs,
-		})
-	})
-	paramtable.Get().Watch(paramtable.Get().QueryCoordCfg.ClusterLevelLoadResourceGroups.Key, rgHandler)
+	if err != nil {
+		log.Warn("failed to update load config", zap.Error(err))
+	}
 }

--- a/internal/querycoordv2/server_test.go
+++ b/internal/querycoordv2/server_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"github.com/tikv/client-go/v2/txnkv"
+	"go.uber.org/atomic"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
@@ -425,72 +426,6 @@ func (suite *ServerSuite) TestUpdateAutoBalanceConfigLoop() {
 	})
 }
 
-func TestCheckLoadConfigChanges(t *testing.T) {
-	mockey.PatchConvey("TestCheckLoadConfigChanges", t, func() {
-		ctx := context.Background()
-
-		// Create mock server
-		testServer := &Server{}
-		testServer.meta = &meta.Meta{}
-		testServer.ctx = ctx
-
-		// Create mock collection with IsUserSpecifiedReplicaMode = false
-		mockCollection1 := &meta.Collection{
-			CollectionLoadInfo: &querypb.CollectionLoadInfo{
-				CollectionID:             1001,
-				UserSpecifiedReplicaMode: false,
-			},
-		}
-
-		// Create mock collection with IsUserSpecifiedReplicaMode = true
-		mockCollection2 := &meta.Collection{
-			CollectionLoadInfo: &querypb.CollectionLoadInfo{
-				CollectionID:             1002,
-				UserSpecifiedReplicaMode: true,
-			},
-		}
-
-		// Mock meta.CollectionManager.GetAll to return collection IDs
-		mockey.Mock((*meta.CollectionManager).GetAll).Return([]int64{1001, 1002}).Build()
-
-		// Mock meta.CollectionManager.GetCollection to return different collections
-		mockey.Mock((*meta.CollectionManager).GetCollection).To(func(m *meta.CollectionManager, ctx context.Context, collectionID int64) *meta.Collection {
-			if collectionID == 1001 {
-				return mockCollection1
-			} else if collectionID == 1002 {
-				return mockCollection2
-			}
-			return nil
-		}).Build()
-
-		// Mock paramtable.ParamItem.GetAsUint32() for ClusterLevelLoadReplicaNumber
-		mockey.Mock((*paramtable.ParamItem).GetAsUint32).Return(uint32(2)).Build()
-
-		// Mock paramtable.ParamItem.GetAsStrings() for ClusterLevelLoadResourceGroups
-		mockey.Mock((*paramtable.ParamItem).GetAsStrings).Return([]string{"default"}).Build()
-
-		// Mock UpdateLoadConfig to capture the call
-		var updateLoadConfigCalled bool
-		var capturedRequest *querypb.UpdateLoadConfigRequest
-		mockey.Mock((*Server).UpdateLoadConfig).To(func(s *Server, ctx context.Context, req *querypb.UpdateLoadConfigRequest) (*commonpb.Status, error) {
-			updateLoadConfigCalled = true
-			capturedRequest = req
-			return merr.Success(), nil
-		}).Build()
-
-		// Call checkLoadConfigChanges
-		testServer.checkLoadConfigChanges(ctx)
-
-		// Verify UpdateLoadConfig was called
-		assert.True(t, updateLoadConfigCalled, "UpdateLoadConfig should be called")
-
-		// Verify that only collections with IsUserSpecifiedReplicaMode = false are included
-		assert.Equal(t, []int64{1001}, capturedRequest.CollectionIDs, "Only collections with IsUserSpecifiedReplicaMode = false should be included")
-		assert.Equal(t, int32(2), capturedRequest.ReplicaNumber, "ReplicaNumber should match cluster level config")
-		assert.Equal(t, []string{"default"}, capturedRequest.ResourceGroups, "ResourceGroups should match cluster level config")
-	})
-}
-
 func (suite *ServerSuite) waitNodeUp(node *mocks.MockQueryNode, timeout time.Duration) bool {
 	start := time.Now()
 	for time.Since(start) < timeout {
@@ -749,4 +684,95 @@ func TestServer(t *testing.T) {
 		testMeta = v
 		suite.Run(t, new(ServerSuite))
 	}
+}
+
+func TestCheckLoadConfig(t *testing.T) {
+	mockey.PatchConvey("checkLoadConfigChanges", t, func() {
+		paramtable.Init()
+		paramtable.Get().Save(paramtable.Get().QueryCoordCfg.ClusterLevelLoadReplicaNumber.Key, "2")
+		paramtable.Get().Save(paramtable.Get().QueryCoordCfg.ClusterLevelLoadResourceGroups.Key, "rg1,rg2")
+
+		s := &Server{
+			meta: &meta.Meta{},
+		}
+		var replicaNumberInRequest int32
+		var resourceGroupsInRequest []string
+		var collectionIDsInRequest []int64
+		mockey.Mock((*Server).updateLoadConfig).To(func(ctx context.Context, req *querypb.UpdateLoadConfigRequest) error {
+			replicaNumberInRequest = req.ReplicaNumber
+			resourceGroupsInRequest = req.ResourceGroups
+			collectionIDsInRequest = req.CollectionIDs
+			return nil
+		}).Build()
+		mockey.Mock((*meta.CollectionManager).GetAll).To(func(ctx context.Context) []int64 {
+			return []int64{1, 2, 3}
+		}).Build()
+		mockey.Mock((*meta.CollectionManager).GetCollection).To(func(ctx context.Context, collectionID int64) *meta.Collection {
+			if collectionID == 1 {
+				return &meta.Collection{
+					CollectionLoadInfo: &querypb.CollectionLoadInfo{
+						CollectionID: 1,
+					},
+				}
+			} else {
+				return &meta.Collection{
+					CollectionLoadInfo: &querypb.CollectionLoadInfo{
+						CollectionID:             2,
+						UserSpecifiedReplicaMode: true,
+					},
+				}
+			}
+		}).Build()
+		s.checkLoadConfigChanges()
+
+		assert.Equal(t, replicaNumberInRequest, int32(2))
+		assert.Equal(t, resourceGroupsInRequest, []string{"rg1", "rg2"})
+		assert.Equal(t, collectionIDsInRequest, []int64{1})
+	})
+}
+
+func TestWatchLoadConfigChanges(t *testing.T) {
+	mockey.PatchConvey("watchLoadConfigChanges", t, func() {
+		paramtable.Init()
+		paramtable.Get().Save(paramtable.Get().QueryCoordCfg.CheckLoadConfigInterval.Key, "100")
+		paramtable.Get().Save(paramtable.Get().QueryCoordCfg.ClusterLevelLoadReplicaNumber.Key, "1")
+		paramtable.Get().Save(paramtable.Get().QueryCoordCfg.ClusterLevelLoadResourceGroups.Key, "default")
+
+		triggerCounter := atomic.NewInt32(0)
+		mockey.Mock((*Server).checkLoadConfigChanges).To(func() {
+			triggerCounter.Add(1)
+		}).Build()
+
+		mockey.Mock((*meta.CollectionManager).GetAll).To(func(ctx context.Context) []int64 {
+			return []int64{1, 2, 3}
+		}).Build()
+		mockey.Mock((*meta.CollectionManager).GetCollection).To(func(ctx context.Context, collectionID int64) *meta.Collection {
+			if collectionID == 1 {
+				return &meta.Collection{
+					CollectionLoadInfo: &querypb.CollectionLoadInfo{
+						CollectionID: 1,
+					},
+				}
+			} else {
+				return &meta.Collection{
+					CollectionLoadInfo: &querypb.CollectionLoadInfo{
+						CollectionID:             2,
+						UserSpecifiedReplicaMode: true,
+					},
+				}
+			}
+		}).Build()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		s := &Server{
+			meta: &meta.Meta{},
+			ctx:  ctx,
+		}
+
+		s.watchLoadConfigChanges()
+
+		time.Sleep(500 * time.Millisecond)
+		assert.True(t, triggerCounter.Load() > 0)
+	})
 }

--- a/internal/querycoordv2/services.go
+++ b/internal/querycoordv2/services.go
@@ -1193,7 +1193,18 @@ func (s *Server) UpdateLoadConfig(ctx context.Context, req *querypb.UpdateLoadCo
 		log.Warn(msg, zap.Error(err))
 		return merr.Status(errors.Wrap(err, msg)), nil
 	}
+	err := s.updateLoadConfig(ctx, req)
+	if err != nil {
+		log.Warn("failed to update load config", zap.Error(err))
+		return merr.Status(err), nil
+	}
 
+	log.Info("update load config request finished")
+
+	return merr.Success(), nil
+}
+
+func (s *Server) updateLoadConfig(ctx context.Context, req *querypb.UpdateLoadConfigRequest) error {
 	jobs := make([]job.Job, 0, len(req.GetCollectionIDs()))
 	for _, collectionID := range req.GetCollectionIDs() {
 		collection := s.meta.GetCollection(ctx, collectionID)
@@ -1221,7 +1232,6 @@ func (s *Server) UpdateLoadConfig(ctx context.Context, req *querypb.UpdateLoadCo
 		}
 
 		if !replicaChanged && !rgChanged {
-			log.Info("no need to update load config", zap.Int64("collectionID", collectionID))
 			continue
 		}
 
@@ -1247,12 +1257,5 @@ func (s *Server) UpdateLoadConfig(ctx context.Context, req *querypb.UpdateLoadCo
 		}
 	}
 
-	if err != nil {
-		msg := "failed to update load config"
-		log.Warn(msg, zap.Error(err))
-		return merr.Status(errors.Wrap(err, msg)), nil
-	}
-	log.Info("update load config request finished")
-
-	return merr.Success(), nil
+	return err
 }

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -1966,6 +1966,8 @@ type queryCoordConfig struct {
 	BalanceSegmentBatchSize            ParamItem `refreshable:"true"`
 	BalanceChannelBatchSize            ParamItem `refreshable:"true"`
 	EnableBalanceOnMultipleCollections ParamItem `refreshable:"true"`
+
+	CheckLoadConfigInterval ParamItem `refreshable:"false"`
 }
 
 func (p *queryCoordConfig) init(base *BaseTable) {
@@ -2589,6 +2591,15 @@ If this parameter is set false, Milvus simply searches the growing segments with
 		Export:       false,
 	}
 	p.EnableBalanceOnMultipleCollections.Init(base.mgr)
+
+	p.CheckLoadConfigInterval = ParamItem{
+		Key:          "queryCoord.checkLoadConfigInterval",
+		Version:      "2.5.16",
+		DefaultValue: "60000",
+		Doc:          "the interval of check load config, in milliseconds",
+		Export:       false,
+	}
+	p.CheckLoadConfigInterval.Init(base.mgr)
 }
 
 // /////////////////////////////////////////////////////////////////////////////

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -385,6 +385,8 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, 5, Params.BalanceSegmentBatchSize.GetAsInt())
 		assert.Equal(t, 1, Params.BalanceChannelBatchSize.GetAsInt())
 		assert.Equal(t, true, Params.EnableBalanceOnMultipleCollections.GetAsBool())
+
+		assert.Equal(t, 60000, Params.CheckLoadConfigInterval.GetAsInt())
 	})
 
 	t.Run("test queryNodeConfig", func(t *testing.T) {

--- a/scripts/run_go_codecov.sh
+++ b/scripts/run_go_codecov.sh
@@ -36,14 +36,14 @@ fi
 # starting the timer
 beginTime=`date +%s`
 pushd cmd/tools
-$TEST_CMD -race -tags dynamic,test -v -coverpkg=./... -coverprofile=profile.out -covermode=atomic ./...
+$TEST_CMD -gcflags="all=-N -l" -race -tags dynamic,test -v -coverpkg=./... -coverprofile=profile.out -covermode=atomic ./...
 if [ -f profile.out ]; then
     grep -v kafka profile.out | grep -v planparserv2/generated | grep -v mocks | sed '1d' >> ../${FILE_COVERAGE_INFO}
     rm profile.out
 fi
 popd
 for d in $(go list ./internal/... | grep -v -e vendor -e kafka -e planparserv2/generated -e mocks); do
-    $TEST_CMD -race -tags dynamic,test -v -coverpkg=./... -coverprofile=profile.out -covermode=atomic "$d"
+    $TEST_CMD -gcflags="all=-N -l" -race -tags dynamic,test -v -coverpkg=./... -coverprofile=profile.out -covermode=atomic "$d"
     if [ -f profile.out ]; then
         grep -v kafka profile.out | grep -v planparserv2/generated | grep -v mocks | sed '1d' >> ${FILE_COVERAGE_INFO}
         rm profile.out
@@ -51,7 +51,7 @@ for d in $(go list ./internal/... | grep -v -e vendor -e kafka -e planparserv2/g
 done
 pushd pkg
 for d in $(go list ./... | grep -v -e vendor -e kafka -e planparserv2/generated -e mocks); do
-    $TEST_CMD -race -tags dynamic,test -v -coverpkg=./... -coverprofile=profile.out -covermode=atomic "$d"
+    $TEST_CMD -gcflags="all=-N -l" -race -tags dynamic,test -v -coverpkg=./... -coverprofile=profile.out -covermode=atomic "$d"
     if [ -f profile.out ]; then
         grep -v kafka profile.out | grep -v planparserv2/generated | grep -v mocks | sed '1d' >> ../${FILE_COVERAGE_INFO}
         rm profile.out
@@ -61,7 +61,7 @@ popd
 # milvusclient
 pushd client
 for d in $(go list ./... | grep -v -e vendor -e kafka -e planparserv2/generated -e mocks); do
-    $TEST_CMD -race -tags dynamic -v -coverpkg=./... -coverprofile=profile.out -covermode=atomic "$d"
+    $TEST_CMD -gcflags="all=-N -l" -race -tags dynamic -v -coverpkg=./... -coverprofile=profile.out -covermode=atomic "$d"
     if [ -f profile.out ]; then
         grep -v kafka profile.out | grep -v planparserv2/generated | grep -v mocks | sed '1d' >> ../${FILE_COVERAGE_INFO}
         rm profile.out

--- a/scripts/run_go_unittest.sh
+++ b/scripts/run_go_unittest.sh
@@ -60,119 +60,119 @@ done
 
 function test_proxy()
 {
-go test -race -cover -tags dynamic,test "${MILVUS_DIR}/proxy/..." -failfast -count=1 -ldflags="-r ${RPATH}"
-go test -race -cover -tags dynamic,test "${MILVUS_DIR}/distributed/proxy/..." -failfast -count=1 -ldflags="-r ${RPATH}"
+go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${MILVUS_DIR}/proxy/..." -failfast -count=1 -ldflags="-r ${RPATH}"
+go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${MILVUS_DIR}/distributed/proxy/..." -failfast -count=1 -ldflags="-r ${RPATH}"
 }
 
 function test_querynode()
 {
-go test -race -cover -tags dynamic,test "${MILVUS_DIR}/querynodev2/..." -failfast -count=1 -ldflags="-r ${RPATH}"
-go test -race -cover -tags dynamic,test "${MILVUS_DIR}/distributed/querynode/..." -failfast -count=1 -ldflags="-r ${RPATH}"
+go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${MILVUS_DIR}/querynodev2/..." -failfast -count=1 -ldflags="-r ${RPATH}"
+go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${MILVUS_DIR}/distributed/querynode/..." -failfast -count=1 -ldflags="-r ${RPATH}"
 }
 
 
 function test_kv()
 {
-go test -race -cover -tags dynamic,test "${MILVUS_DIR}/kv/..." -failfast -count=1 -ldflags="-r ${RPATH}"
+go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${MILVUS_DIR}/kv/..." -failfast -count=1 -ldflags="-r ${RPATH}"
 }
 
 function test_mq()
 {
-go test -race -cover -tags dynamic,test $(go list "${MILVUS_DIR}/mq/..." | grep -v kafka)  -failfast -count=1 -ldflags="-r ${RPATH}"
+go test -gcflags="all=-N -l" -race -cover -tags dynamic,test $(go list "${MILVUS_DIR}/mq/..." | grep -v kafka)  -failfast -count=1 -ldflags="-r ${RPATH}"
 }
 
 function test_storage()
 {
-go test -race -cover -tags dynamic,test "${MILVUS_DIR}/storage" -failfast -count=1 -ldflags="-r ${RPATH}"
+go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${MILVUS_DIR}/storage" -failfast -count=1 -ldflags="-r ${RPATH}"
 }
 
 function test_allocator()
 {
-go test -race -cover -tags dynamic,test "${MILVUS_DIR}/allocator/..." -failfast -count=1 -ldflags="-r ${RPATH}"
+go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${MILVUS_DIR}/allocator/..." -failfast -count=1 -ldflags="-r ${RPATH}"
 }
 
 function test_tso()
 {
-go test -race -cover -tags dynamic,test "${MILVUS_DIR}/tso/..." -failfast -count=1 -ldflags="-r ${RPATH}"
+go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${MILVUS_DIR}/tso/..." -failfast -count=1 -ldflags="-r ${RPATH}"
 }
 
 function test_util()
 {
-go test -race -cover -tags dynamic,test "${MILVUS_DIR}/util/funcutil/..." -failfast -count=1  -ldflags="-r ${RPATH}"
+go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${MILVUS_DIR}/util/funcutil/..." -failfast -count=1  -ldflags="-r ${RPATH}"
 pushd pkg
-go test -race -cover -tags dynamic,test "${PKG_DIR}/util/retry/..." -failfast -count=1  -ldflags="-r ${RPATH}"
+go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${PKG_DIR}/util/retry/..." -failfast -count=1  -ldflags="-r ${RPATH}"
 popd
-go test -race -cover -tags dynamic,test "${MILVUS_DIR}/util/sessionutil/..." -failfast -count=1  -ldflags="-r ${RPATH}"
-go test -race -cover -tags dynamic,test "${MILVUS_DIR}/util/typeutil/..." -failfast -count=1  -ldflags="-r ${RPATH}"
-go test -race -cover -tags dynamic,test "${MILVUS_DIR}/util/importutilv2/..." -failfast -count=1  -ldflags="-r ${RPATH}"
-go test -race -cover -tags dynamic,test "${MILVUS_DIR}/util/proxyutil/..." -failfast -count=1  -ldflags="-r ${RPATH}"
-go test -race -cover -tags dynamic,test "${MILVUS_DIR}/util/initcore/..." -failfast -count=1  -ldflags="-r ${RPATH}"
-go test -race -cover -tags dynamic,test "${MILVUS_DIR}/util/cgo/..." -failfast -count=1  -ldflags="-r ${RPATH}"
-go test -race -cover -tags dynamic,test "${MILVUS_DIR}/util/streamingutil/..." -failfast -count=1  -ldflags="-r ${RPATH}"
+go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${MILVUS_DIR}/util/sessionutil/..." -failfast -count=1  -ldflags="-r ${RPATH}"
+go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${MILVUS_DIR}/util/typeutil/..." -failfast -count=1  -ldflags="-r ${RPATH}"
+go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${MILVUS_DIR}/util/importutilv2/..." -failfast -count=1  -ldflags="-r ${RPATH}"
+go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${MILVUS_DIR}/util/proxyutil/..." -failfast -count=1  -ldflags="-r ${RPATH}"
+go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${MILVUS_DIR}/util/initcore/..." -failfast -count=1  -ldflags="-r ${RPATH}"
+go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${MILVUS_DIR}/util/cgo/..." -failfast -count=1  -ldflags="-r ${RPATH}"
+go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${MILVUS_DIR}/util/streamingutil/..." -failfast -count=1  -ldflags="-r ${RPATH}"
 }
 
 function test_pkg()
 {
 pushd pkg
-go test -race -cover -tags dynamic,test "${PKG_DIR}/common/..." -failfast -count=1   -ldflags="-r ${RPATH}"
-go test -race -cover -tags dynamic,test "${PKG_DIR}/config/..." -failfast -count=1  -ldflags="-r ${RPATH}"
-go test -race -cover -tags dynamic,test "${PKG_DIR}/log/..." -failfast -count=1  -ldflags="-r ${RPATH}"
-go test -race -cover -tags dynamic,test "${PKG_DIR}/mq/..." -failfast -count=1  -ldflags="-r ${RPATH}"
-go test -race -cover -tags dynamic,test "${PKG_DIR}/tracer/..." -failfast -count=1  -ldflags="-r ${RPATH}"
-go test -race -cover -tags dynamic,test "${PKG_DIR}/util/..." -failfast -count=1  -ldflags="-r ${RPATH}"
-go test -race -cover -tags dynamic,test "${PKG_DIR}/streaming/..." -failfast -count=1  -ldflags="-r ${RPATH}"
+go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${PKG_DIR}/common/..." -failfast -count=1   -ldflags="-r ${RPATH}"
+go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${PKG_DIR}/config/..." -failfast -count=1  -ldflags="-r ${RPATH}"
+go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${PKG_DIR}/log/..." -failfast -count=1  -ldflags="-r ${RPATH}"
+go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${PKG_DIR}/mq/..." -failfast -count=1  -ldflags="-r ${RPATH}"
+go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${PKG_DIR}/tracer/..." -failfast -count=1  -ldflags="-r ${RPATH}"
+go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${PKG_DIR}/util/..." -failfast -count=1  -ldflags="-r ${RPATH}"
+go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${PKG_DIR}/streaming/..." -failfast -count=1  -ldflags="-r ${RPATH}"
 popd
 }
 
 function test_datanode
 {
 
-go test -race -cover -tags dynamic,test "${MILVUS_DIR}/datanode/..." -failfast -count=1  -ldflags="-r ${RPATH}"
-go test -race -cover -tags dynamic,test "${MILVUS_DIR}/distributed/datanode/..." -failfast -count=1  -ldflags="-r ${RPATH}"
+go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${MILVUS_DIR}/datanode/..." -failfast -count=1  -ldflags="-r ${RPATH}"
+go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${MILVUS_DIR}/distributed/datanode/..." -failfast -count=1  -ldflags="-r ${RPATH}"
 
 }
 
 function test_indexnode()
 {
-go test -race -cover -tags dynamic,test "${MILVUS_DIR}/indexnode/..." -failfast -count=1 -ldflags="-r ${RPATH}"
+go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${MILVUS_DIR}/indexnode/..." -failfast -count=1 -ldflags="-r ${RPATH}"
 }
 
 function test_rootcoord()
 {
-go test -race -cover -tags dynamic,test "${MILVUS_DIR}/distributed/rootcoord/..." -failfast -count=1 -ldflags="-r ${RPATH}"
-go test -race -cover -tags dynamic,test "${MILVUS_DIR}/rootcoord" -failfast  -ldflags="-r ${RPATH}"
+go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${MILVUS_DIR}/distributed/rootcoord/..." -failfast -count=1 -ldflags="-r ${RPATH}"
+go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${MILVUS_DIR}/rootcoord" -failfast  -ldflags="-r ${RPATH}"
 }
 
 function test_datacoord()
 {
-go test -race -cover -tags dynamic,test "${MILVUS_DIR}/distributed/datacoord/..." -failfast -count=1 -ldflags="-r ${RPATH}"
-go test -race -cover -tags dynamic,test "${MILVUS_DIR}/datacoord/..." -failfast -count=1 -ldflags="-r ${RPATH}"
+go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${MILVUS_DIR}/distributed/datacoord/..." -failfast -count=1 -ldflags="-r ${RPATH}"
+go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${MILVUS_DIR}/datacoord/..." -failfast -count=1 -ldflags="-r ${RPATH}"
 }
 
 function test_querycoord()
 {
-go test -race -cover -tags dynamic,test "${MILVUS_DIR}/distributed/querycoord/..." -failfast -count=1  -ldflags="-r ${RPATH}"
-go test -race -cover -tags dynamic,test "${MILVUS_DIR}/querycoordv2/..." -failfast -count=1  -ldflags="-r ${RPATH}"
+go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${MILVUS_DIR}/distributed/querycoord/..." -failfast -count=1  -ldflags="-r ${RPATH}"
+go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${MILVUS_DIR}/querycoordv2/..." -failfast -count=1  -ldflags="-r ${RPATH}"
 }
 
 function test_metastore()
 {
-go test -race -cover -tags dynamic,test "${MILVUS_DIR}/metastore/..." -failfast -count=1 -ldflags="-r ${RPATH}"
+go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${MILVUS_DIR}/metastore/..." -failfast -count=1 -ldflags="-r ${RPATH}"
 }
 
 function test_cmd()
 {
-go test -race -cover -tags dynamic,test "${ROOT_DIR}/cmd/tools/..." -failfast -count=1 -ldflags="-r ${RPATH}"
+go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${ROOT_DIR}/cmd/tools/..." -failfast -count=1 -ldflags="-r ${RPATH}"
 }
 
 function test_streaming()
 {
-go test -race -cover -tags dynamic,test "${MILVUS_DIR}/streamingcoord/..." -failfast -count=1 -ldflags="-r ${RPATH}"
-go test -race -cover -tags dynamic,test "${MILVUS_DIR}/streamingnode/..." -failfast -count=1 -ldflags="-r ${RPATH}"
-go test -race -cover -tags dynamic,test "${MILVUS_DIR}/util/streamingutil/..." -failfast -count=1 -ldflags="-r ${RPATH}"
-go test -race -cover -tags dynamic,test "${MILVUS_DIR}/distributed/streaming/..." -failfast -count=1 -ldflags="-r ${RPATH}"
+go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${MILVUS_DIR}/streamingcoord/..." -failfast -count=1 -ldflags="-r ${RPATH}"
+go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${MILVUS_DIR}/streamingnode/..." -failfast -count=1 -ldflags="-r ${RPATH}"
+go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${MILVUS_DIR}/util/streamingutil/..." -failfast -count=1 -ldflags="-r ${RPATH}"
+go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${MILVUS_DIR}/distributed/streaming/..." -failfast -count=1 -ldflags="-r ${RPATH}"
 pushd pkg
-go test -race -cover -tags dynamic,test "${PKG_DIR}/streaming/..." -failfast -count=1  -ldflags="-r ${RPATH}"
+go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${PKG_DIR}/streaming/..." -failfast -count=1  -ldflags="-r ${RPATH}"
 popd
 }
 


### PR DESCRIPTION
issue: #43107
pr: #43525
This PR replaces the event-driven load config watch mechanism in QueryCoord with a periodic polling approach. This change aims to simplify the configuration update logic and enhance its robustness.

Key changes include:
- Deprecated the use of `config.NewHandler` and `paramtable.Watch` for monitoring `ClusterLevelLoadReplicaNumber` and `ClusterLevelLoadResourceGroups`.
- Introduced `queryCoord.checkLoadConfigInterval` to define the frequency of periodic config checks.
- Implemented a background goroutine using `time.NewTicker` that periodically invokes `checkLoadConfigChanges`.
- The `checkLoadConfigChanges` function now directly retrieves and applies the latest configuration values for collections not in user-specified replica mode.
- Updated relevant unit tests (`TestCheckLoadConfig` and `TestWatchLoadConfigChanges`) to align with the new periodic check mechanism.