### PR TITLE
fix: Close segment writer when reader returns error

### DIFF
--- a/internal/datanode/compactor/merge_sort.go
+++ b/internal/datanode/compactor/merge_sort.go
@@ -106,6 +106,7 @@ func mergeSortMultipleSegments(ctx context.Context,
 	}
 
 	if _, err = storage.MergeSort(compactionParams.BinLogMaxSize, plan.GetSchema(), segmentReaders, writer, predicate); err != nil {
+		writer.Close()
 		return nil, err
 	}
 

--- a/internal/datanode/compactor/mix_compactor.go
+++ b/internal/datanode/compactor/mix_compactor.go
@@ -164,6 +164,7 @@ func (t *mixCompactionTask) mergeSplit(
 	for _, seg := range t.plan.GetSegmentBinlogs() {
 		del, exp, err := t.writeSegment(ctx, seg, mWriter, pkField)
 		if err != nil {
+			mWriter.Close()
 			return nil, err
 		}
 		deletedRowCount += del


### PR DESCRIPTION
Realted #43520

Datanode may have memory leakage when reader returns error. In previously mention issue, datanodes got  OOM killed due to continueous error in read path.