### PR TITLE
test: [GoSDK] Use strong consistency level for hybrid search cases

### DIFF
--- a/tests/go_client/testcases/helper/collection_helper.go
+++ b/tests/go_client/testcases/helper/collection_helper.go
@@ -20,7 +20,7 @@ type createCollectionOpt struct {
 	shardNum             int32
 	enabledDynamicSchema bool
 
-	consistencyLevel entity.ConsistencyLevel
+	consistencyLevel *entity.ConsistencyLevel
 	properties       map[string]any
 }
 
@@ -33,5 +33,11 @@ func TWithShardNum(shardNum int32) CreateCollectionOpt {
 func TWithProperties(properties map[string]any) CreateCollectionOpt {
 	return func(opt *createCollectionOpt) {
 		opt.properties = properties
+	}
+}
+
+func TWithConsistencyLevel(consistencyLevel entity.ConsistencyLevel) CreateCollectionOpt {
+	return func(opt *createCollectionOpt) {
+		opt.consistencyLevel = &consistencyLevel
 	}
 }

--- a/tests/go_client/testcases/helper/helper.go
+++ b/tests/go_client/testcases/helper/helper.go
@@ -166,7 +166,7 @@ func mergeOptions(schema *entity.Schema, opts ...CreateCollectionOpt) client.Cre
 	}
 
 	if !common.IsZeroValue(tmpOption.consistencyLevel) {
-		collectionOption.WithConsistencyLevel(tmpOption.consistencyLevel)
+		collectionOption.WithConsistencyLevel(*tmpOption.consistencyLevel)
 	}
 
 	return collectionOption

--- a/tests/go_client/testcases/hybrid_search_test.go
+++ b/tests/go_client/testcases/hybrid_search_test.go
@@ -22,7 +22,7 @@ func TestHybridSearchDefault(t *testing.T) {
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
 	// create -> insert [0, 3000) -> flush -> index -> load
-	prepare, schema := hp.CollPrepare.CreateCollection(ctx, t, mc, hp.NewCreateCollectionParams(hp.Int64Vec), hp.TNewFieldsOption(), hp.TNewSchemaOption())
+	prepare, schema := hp.CollPrepare.CreateCollection(ctx, t, mc, hp.NewCreateCollectionParams(hp.Int64Vec), hp.TNewFieldsOption(), hp.TNewSchemaOption(), hp.TWithConsistencyLevel(entity.ClStrong))
 	prepare.InsertData(ctx, t, mc, hp.NewInsertParams(schema), hp.TNewDataOption())
 	prepare.FlushData(ctx, t, mc, schema.CollectionName)
 	prepare.CreateIndex(ctx, t, mc, hp.TNewIndexParams(schema))
@@ -77,7 +77,7 @@ func TestHybridSearchTemplateParam(t *testing.T) {
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
 	// create -> insert [0, 3000) -> flush -> index -> load
-	prepare, schema := hp.CollPrepare.CreateCollection(ctx, t, mc, hp.NewCreateCollectionParams(hp.Int64MultiVec), hp.TNewFieldsOption(), hp.TNewSchemaOption())
+	prepare, schema := hp.CollPrepare.CreateCollection(ctx, t, mc, hp.NewCreateCollectionParams(hp.Int64MultiVec), hp.TNewFieldsOption(), hp.TNewSchemaOption(), hp.TWithConsistencyLevel(entity.ClStrong))
 	prepare.InsertData(ctx, t, mc, hp.NewInsertParams(schema), hp.TNewDataOption())
 	prepare.FlushData(ctx, t, mc, schema.CollectionName)
 	prepare.CreateIndex(ctx, t, mc, hp.TNewIndexParams(schema))
@@ -110,7 +110,7 @@ func TestHybridSearchMultiVectorsDefault(t *testing.T) {
 	for _, enableDynamic := range []bool{false, true} {
 		// create -> insert [0, 3000) -> flush -> index -> load
 		prepare, schema := hp.CollPrepare.CreateCollection(ctx, t, mc, hp.NewCreateCollectionParams(hp.AllFields),
-			hp.TNewFieldsOption(), hp.TNewSchemaOption().TWithEnableDynamicField(enableDynamic))
+			hp.TNewFieldsOption(), hp.TNewSchemaOption().TWithEnableDynamicField(enableDynamic), hp.TWithConsistencyLevel(entity.ClStrong))
 		prepare.InsertData(ctx, t, mc, hp.NewInsertParams(schema), hp.TNewDataOption().TWithNb(common.DefaultNb*3))
 		prepare.FlushData(ctx, t, mc, schema.CollectionName)
 		prepare.CreateIndex(ctx, t, mc, hp.TNewIndexParams(schema))
@@ -195,7 +195,7 @@ func TestHybridSearchInvalidParams(t *testing.T) {
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
 	// create -> insert -> flush -> index -> load
-	prepare, schema := hp.CollPrepare.CreateCollection(ctx, t, mc, hp.NewCreateCollectionParams(hp.Int64MultiVec), hp.TNewFieldsOption(), hp.TNewSchemaOption())
+	prepare, schema := hp.CollPrepare.CreateCollection(ctx, t, mc, hp.NewCreateCollectionParams(hp.Int64MultiVec), hp.TNewFieldsOption(), hp.TNewSchemaOption(), hp.TWithConsistencyLevel(entity.ClStrong))
 	prepare.InsertData(ctx, t, mc, hp.NewInsertParams(schema), hp.TNewDataOption())
 	prepare.FlushData(ctx, t, mc, schema.CollectionName)
 	prepare.CreateIndex(ctx, t, mc, hp.TNewIndexParams(schema))
@@ -249,7 +249,7 @@ func TestHybridSearchInvalidVectors(t *testing.T) {
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
-	prepare, schema := hp.CollPrepare.CreateCollection(ctx, t, mc, hp.NewCreateCollectionParams(hp.Int64Vec), hp.TNewFieldsOption(), hp.TNewSchemaOption())
+	prepare, schema := hp.CollPrepare.CreateCollection(ctx, t, mc, hp.NewCreateCollectionParams(hp.Int64Vec), hp.TNewFieldsOption(), hp.TNewSchemaOption(), hp.TWithConsistencyLevel(entity.ClStrong))
 	prepare.InsertData(ctx, t, mc, hp.NewInsertParams(schema), hp.TNewDataOption().TWithNb(500))
 	prepare.FlushData(ctx, t, mc, schema.CollectionName)
 	prepare.CreateIndex(ctx, t, mc, hp.TNewIndexParams(schema))
@@ -271,7 +271,7 @@ func TestHybridSearchMultiVectorsPagination(t *testing.T) {
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
-	prepare, schema := hp.CollPrepare.CreateCollection(ctx, t, mc, hp.NewCreateCollectionParams(hp.Int64MultiVec), hp.TNewFieldsOption(), hp.TNewSchemaOption())
+	prepare, schema := hp.CollPrepare.CreateCollection(ctx, t, mc, hp.NewCreateCollectionParams(hp.Int64MultiVec), hp.TNewFieldsOption(), hp.TNewSchemaOption(), hp.TWithConsistencyLevel(entity.ClStrong))
 	prepare.CreateIndex(ctx, t, mc, hp.TNewIndexParams(schema))
 	prepare.Load(ctx, t, mc, hp.NewLoadParams(schema.CollectionName))
 	prepare.InsertData(ctx, t, mc, hp.NewInsertParams(schema), hp.TNewDataOption().TWithNb(common.DefaultNb*5))
@@ -329,7 +329,7 @@ func TestHybridSearchMultiVectorsRangeSearch(t *testing.T) {
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
 	// create -> insert [0, 3000) -> flush -> index -> load
-	prepare, schema := hp.CollPrepare.CreateCollection(ctx, t, mc, hp.NewCreateCollectionParams(hp.Int64MultiVec), hp.TNewFieldsOption(), hp.TNewSchemaOption())
+	prepare, schema := hp.CollPrepare.CreateCollection(ctx, t, mc, hp.NewCreateCollectionParams(hp.Int64MultiVec), hp.TNewFieldsOption(), hp.TNewSchemaOption(), hp.TWithConsistencyLevel(entity.ClStrong))
 	prepare.InsertData(ctx, t, mc, hp.NewInsertParams(schema), hp.TNewDataOption().TWithNb(common.DefaultNb*3))
 	prepare.FlushData(ctx, t, mc, schema.CollectionName)
 	prepare.CreateIndex(ctx, t, mc, hp.TNewIndexParams(schema))
@@ -372,7 +372,7 @@ func TestHybridSearchSparseVector(t *testing.T) {
 
 		// create -> insert [0, 3000) -> flush -> index -> load
 		prepare, schema := hp.CollPrepare.CreateCollection(ctx, t, mc, hp.NewCreateCollectionParams(hp.Int64VarcharSparseVec), hp.TNewFieldsOption(),
-			hp.TNewSchemaOption().TWithEnableDynamicField(true))
+			hp.TNewSchemaOption().TWithEnableDynamicField(true), hp.TWithConsistencyLevel(entity.ClStrong))
 		prepare.CreateIndex(ctx, t, mc, hp.TNewIndexParams(schema).TWithFieldIndex(map[string]index.Index{common.DefaultSparseVecFieldName: idx}))
 		prepare.Load(ctx, t, mc, hp.NewLoadParams(schema.CollectionName))
 		prepare.InsertData(ctx, t, mc, hp.NewInsertParams(schema), hp.TNewDataOption().TWithNb(common.DefaultNb*3))
@@ -407,7 +407,7 @@ func TestHybridSearchGroupBy(t *testing.T) {
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
 	// create collection
-	prepare, schema := hp.CollPrepare.CreateCollection(ctx, t, mc, hp.NewCreateCollectionParams(hp.AllFields), hp.TNewFieldsOption(), hp.TNewSchemaOption())
+	prepare, schema := hp.CollPrepare.CreateCollection(ctx, t, mc, hp.NewCreateCollectionParams(hp.AllFields), hp.TNewFieldsOption(), hp.TNewSchemaOption(), hp.TWithConsistencyLevel(entity.ClStrong))
 	prepare.CreateIndex(ctx, t, mc, hp.TNewIndexParams(schema))
 	prepare.Load(ctx, t, mc, hp.NewLoadParams(schema.CollectionName))
 


### PR DESCRIPTION
There are some unstable cases in go sdk e2e cases, which used default bounded consistency level. This patch make these cases use strong level to avoid unstable test results