### PR TITLE
enhance: DataCodec to release ownership of input_data after initialization

### DIFF
--- a/internal/core/src/storage/DataCodec.cpp
+++ b/internal/core/src/storage/DataCodec.cpp
@@ -103,9 +103,6 @@ DeserializeFileData(const std::shared_ptr<uint8_t[]> input_data,
             index_data->set_index_meta(index_meta);
             index_data->SetTimestamps(index_event_data.start_timestamp,
                                       index_event_data.end_timestamp);
-            // DataCodec must keep the input_data alive for zero-copy usage,
-            // otherwise segmentation violation will occur
-            index_data->SetData(input_data);
             return index_data;
         }
         default:


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/43088
issue: https://github.com/milvus-io/milvus/issues/43038

see also https://github.com/milvus-io/milvus/pull/43533. 