### PR TITLE
enhance: [StorageV2] add close state validation for storage readers and writers

### DIFF
--- a/internal/core/thirdparty/milvus-storage/CMakeLists.txt
+++ b/internal/core/thirdparty/milvus-storage/CMakeLists.txt
@@ -14,7 +14,7 @@
 # Update milvus-storage_VERSION for the first occurrence
 milvus_add_pkg_config("milvus-storage")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( milvus-storage_VERSION d757696 )
+set( milvus-storage_VERSION 2b6d934 )
 set( GIT_REPOSITORY  "https://github.com/milvus-io/milvus-storage.git")
 message(STATUS "milvus-storage repo: ${GIT_REPOSITORY}")
 message(STATUS "milvus-storage version: ${milvus-storage_VERSION}")


### PR DESCRIPTION
related: #39173  

bump milvus-storage version, include:
* https://github.com/milvus-io/milvus-storage/pull/213

key changes:
- Add closed_ flag to ParquetFileWriter to prevent operations on closed writers
- Add closed_ flag to PackedRecordBatchWriter to prevent operations on closed writers  
- Add file reader tracking fields to PackedRecordBatchReader (file_reader_to_path_index_, original_paths_, read_count_)
- Implement proper close state checking in writer implementations
- Prevent duplicate close operations and ensure proper cleanup


