### PR TITLE
fix: the underlying record got released in clustering compaction

### DIFF
--- a/internal/datanode/compactor/clustering_compactor.go
+++ b/internal/datanode/compactor/clustering_compactor.go
@@ -122,6 +122,12 @@ func (b *ClusterBuffer) Write(v *storage.Value) error {
 func (b *ClusterBuffer) Flush() error {
 	b.lock.Lock()
 	defer b.lock.Unlock()
+	return b.writer.Flush()
+}
+
+func (b *ClusterBuffer) FlushChunk() error {
+	b.lock.Lock()
+	defer b.lock.Unlock()
 	return b.writer.FlushChunk()
 }
 
@@ -613,59 +619,67 @@ func (t *clusteringCompactionTask) mappingSegment(
 		log.Warn("new binlog record reader wrong", zap.Error(err))
 		return err
 	}
-
-	reader := storage.NewDeserializeReader(rr, func(r storage.Record, v []*storage.Value) error {
-		return storage.ValueDeserializer(r, v, t.plan.Schema.Fields)
-	})
-	defer reader.Close()
+	defer rr.Close()
 
 	offset := int64(-1)
 	for {
-		v, err := reader.NextValue()
+		r, err := rr.Next()
 		if err != nil {
 			if err == sio.EOF {
-				reader.Close()
 				break
-			} else {
-				log.Warn("compact wrong, failed to iter through data", zap.Error(err))
-				return err
 			}
-		}
-		offset++
-
-		if entityFilter.Filtered((*v).PK.GetValue(), uint64((*v).Timestamp)) {
-			continue
-		}
-
-		row, ok := (*v).Value.(map[typeutil.UniqueID]interface{})
-		if !ok {
-			log.Warn("convert interface to map wrong")
-			return errors.New("unexpected error")
-		}
-
-		clusteringKey := row[t.clusteringKeyField.FieldID]
-		var clusterBuffer *ClusterBuffer
-		if t.isVectorClusteringKey {
-			clusterBuffer = t.offsetToBufferFunc(offset, mappingStats.GetCentroidIdMapping())
-		} else {
-			clusterBuffer = t.keyToBufferFunc(clusteringKey)
-		}
-		if err := clusterBuffer.Write(*v); err != nil {
+			log.Warn("compact wrong, failed to iter through data", zap.Error(err))
 			return err
 		}
-		t.writtenRowNum.Inc()
-		remained++
 
-		if (remained+1)%100 == 0 {
-			currentBufferTotalMemorySize := t.getBufferTotalUsedMemorySize()
-			if currentBufferTotalMemorySize > t.getMemoryBufferHighWatermark() {
-				// reach flushBinlog trigger threshold
-				log.Debug("largest buffer need to flush",
-					zap.Int64("currentBufferTotalMemorySize", currentBufferTotalMemorySize))
-				if err := t.flushLargestBuffers(ctx); err != nil {
-					return err
+		vs := make([]*storage.Value, r.Len())
+		if err = storage.ValueDeserializer(r, vs, t.plan.Schema.Fields); err != nil {
+			log.Warn("compact wrong, failed to deserialize data", zap.Error(err))
+			return err
+		}
+
+		for _, v := range vs {
+			offset++
+
+			if entityFilter.Filtered((*v).PK.GetValue(), uint64((*v).Timestamp)) {
+				continue
+			}
+
+			row, ok := (*v).Value.(map[typeutil.UniqueID]interface{})
+			if !ok {
+				log.Warn("convert interface to map wrong")
+				return errors.New("unexpected error")
+			}
+
+			clusteringKey := row[t.clusteringKeyField.FieldID]
+			var clusterBuffer *ClusterBuffer
+			if t.isVectorClusteringKey {
+				clusterBuffer = t.offsetToBufferFunc(offset, mappingStats.GetCentroidIdMapping())
+			} else {
+				clusterBuffer = t.keyToBufferFunc(clusteringKey)
+			}
+			if err := clusterBuffer.Write(v); err != nil {
+				return err
+			}
+			t.writtenRowNum.Inc()
+			remained++
+
+			if (remained+1)%100 == 0 {
+				currentBufferTotalMemorySize := t.getBufferTotalUsedMemorySize()
+				if currentBufferTotalMemorySize > t.getMemoryBufferHighWatermark() {
+					// reach flushBinlog trigger threshold
+					log.Debug("largest buffer need to flush",
+						zap.Int64("currentBufferTotalMemorySize", currentBufferTotalMemorySize))
+					if err := t.flushLargestBuffers(ctx); err != nil {
+						return err
+					}
 				}
 			}
+		}
+
+		// all cluster buffers are flushed for a certain record, since the values read from the same record are references instead of copies
+		for _, buffer := range t.clusterBuffers {
+			buffer.Flush()
 		}
 	}
 
@@ -733,7 +747,7 @@ func (t *clusteringCompactionTask) flushLargestBuffers(ctx context.Context) erro
 			zap.Uint64("WrittenUncompressed", size))
 
 		future := t.flushPool.Submit(func() (any, error) {
-			err := buffer.Flush()
+			err := buffer.FlushChunk()
 			if err != nil {
 				return nil, err
 			}

--- a/internal/datanode/compactor/segment_writer.go
+++ b/internal/datanode/compactor/segment_writer.go
@@ -212,6 +212,16 @@ func (w *MultiSegmentWriter) WriteValue(v *storage.Value) error {
 	return w.writer.WriteValue(v)
 }
 
+// Flush calls storage.SerializeWriter.Flush(), it is used for serialize the value buffer to record and write to binlog.
+// Note: the record is not written to binlog immediately, it will be written when the buffer is full or the writer is closed.
+// Call this function before record iteration to avoid the underlying record be released.
+func (w *MultiSegmentWriter) Flush() error {
+	if w.writer == nil {
+		return nil
+	}
+	return w.writer.Flush()
+}
+
 func (w *MultiSegmentWriter) FlushChunk() error {
 	if w.writer == nil {
 		return nil


### PR DESCRIPTION
See: #43186

In this PR:

1. Flush renamed to FlushChunk, while a new Flush primitive is introduced to serialize values to records.
2. Segment mapping in clustering compaction now process data by records instead of values, it calls flush to all buffers after each record is processed.