### PR TITLE
fix: [StorageV2] Throw exception when read rg fails

### DIFF
--- a/internal/core/src/segcore/memory_planner.cpp
+++ b/internal/core/src/segcore/memory_planner.cpp
@@ -240,6 +240,7 @@ LoadWithStrategy(const std::vector<std::string>& remote_files,
     } catch (std::exception& e) {
         LOG_INFO("[StorageV2] failed to load data from remote: {}", e.what());
         channel->close();
+        throw e;
     }
 }
 


### PR DESCRIPTION
Related to #43261

Read error with catched in `LoadWithStrategy`. Caller could not detect read failure when some error occurred. This patch make `LoadWithStrategy` throw ex instead of swallowing it.