### PR TITLE
fix: dirty cp metrics after drop

### DIFF
--- a/internal/datacoord/handler.go
+++ b/internal/datacoord/handler.go
@@ -593,11 +593,6 @@ func (h *ServerHandler) FinishDropChannel(channel string, collectionID int64) er
 		log.Warn("DropChannel failed", zap.String("vChannel", channel), zap.Error(err))
 		return err
 	}
-	err = h.s.meta.DropChannelCheckpoint(channel)
-	if err != nil {
-		log.Warn("DropChannel failed to drop channel checkpoint", zap.String("channel", channel), zap.Error(err))
-		return err
-	}
 	log.Info("DropChannel succeeded", zap.String("channel", channel))
 	// Channel checkpoints are cleaned up during garbage collection.
 


### PR DESCRIPTION
issue: #42688

- The channel cp is dropped by garbage collector
- The channel is dropped and the cp is marked as math.Uint64
- If we drop it here, the update channel checkpoints will write the dirty cp back.