### PR TITLE
fix: Improve import memory management to prevent OOM

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -754,7 +754,7 @@ dataNode:
     maxImportFileSizeInGB: 16 # The maximum file size (in GB) for an import file, where an import file refers to either a Row-Based file or a set of Column-Based files.
     readBufferSizeInMB: 16 # The base insert buffer size (in MB) during import. The actual buffer size will be dynamically calculated based on the number of shards.
     readDeleteBufferSizeInMB: 16 # The delete buffer size (in MB) during import.
-    memoryLimitPercentage: 20 # The percentage of memory limit for import/pre-import tasks.
+    memoryLimitPercentage: 10 # The percentage of memory limit for import/pre-import tasks.
   compaction:
     levelZeroBatchMemoryRatio: 0.5 # The minimal memory ratio of free memory for level zero compaction executing in batch mode
     levelZeroMaxBatchSize: -1 # Max batch size refers to the max number of L1/L2 segments in a batch when executing L0 compaction. Default to -1, any value that is less than 1 means no limit. Valid range: >= 1.

--- a/internal/datanode/importv2/memory_allocator.go
+++ b/internal/datanode/importv2/memory_allocator.go
@@ -75,26 +75,9 @@ func (ma *memoryAllocator) BlockingAllocate(taskID int64, size int64) {
 	percentage := paramtable.Get().DataNodeCfg.ImportMemoryLimitPercentage.GetAsFloat()
 	memoryLimit := int64(float64(ma.systemTotalMemory) * percentage / 100.0)
 
-	// Check if we can allocate immediately
-	if ma.usedMemory+size <= memoryLimit {
-		ma.usedMemory += size
-		log.Info("memory allocated successfully",
-			zap.Int64("taskID", taskID),
-			zap.Int64("allocatedSize", size),
-			zap.Int64("usedMemory", ma.usedMemory),
-			zap.Int64("availableMemory", memoryLimit-ma.usedMemory))
-		return
-	}
-
-	log.Info("task waiting for memory allocation",
-		zap.Int64("taskID", taskID),
-		zap.Int64("requestedSize", size),
-		zap.Int64("usedMemory", ma.usedMemory),
-		zap.Int64("availableMemory", memoryLimit-ma.usedMemory))
-
 	// Wait until enough memory is available
 	for ma.usedMemory+size > memoryLimit {
-		log.Warn("task still waiting for memory allocation...",
+		log.Warn("task waiting for memory allocation...",
 			zap.Int64("taskID", taskID),
 			zap.Int64("requestedSize", size),
 			zap.Int64("usedMemory", ma.usedMemory),

--- a/internal/datanode/importv2/memory_allocator_test.go
+++ b/internal/datanode/importv2/memory_allocator_test.go
@@ -121,7 +121,7 @@ func TestMemoryAllocatorNegativeRelease(t *testing.T) {
 // TestMemoryAllocatorMultipleTasks tests memory management for multiple tasks
 func TestMemoryAllocatorMultipleTasks(t *testing.T) {
 	// Create memory allocator with 1GB system memory
-	ma := NewMemoryAllocator(1024 * 1024 * 1024)
+	ma := NewMemoryAllocator(1024 * 1024 * 1024 * 2)
 
 	// Allocate memory for multiple tasks with smaller sizes
 	taskIDs := []int64{1, 2, 3, 4, 5}

--- a/internal/datanode/importv2/scheduler_test.go
+++ b/internal/datanode/importv2/scheduler_test.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
-	"github.com/samber/lo"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
@@ -551,88 +550,6 @@ func (s *SchedulerSuite) TestScheduler_ImportFileWithFunction() {
 	s.manager.Add(importTask)
 	err = importTask.(*ImportTask).importFile(s.reader)
 	s.NoError(err)
-}
-
-// TestScheduler_ScheduleTasks tests the scheduleTasks method with various scenarios
-func (s *SchedulerSuite) TestScheduler_ScheduleTasks() {
-	// Memory limit exceeded - some tasks should be skipped
-	s.Run("MemoryLimitExceeded", func() {
-		manager := NewMockTaskManager(s.T())
-		s.scheduler.manager = manager
-
-		// Add tasks that exceed memory limit
-		tasks := make(map[int64]Task, 0)
-		for i := 0; i < 5; i++ {
-			t := NewMockTask(s.T())
-			t.EXPECT().GetTaskID().Return(int64(i))
-			t.EXPECT().GetBufferSize().Return(int64(300))
-			if i < 3 { // Only first 3 tasks should be allocated (900 total)
-				t.EXPECT().Execute().Return([]*conc.Future[any]{})
-			}
-			tasks[t.GetTaskID()] = t
-		}
-
-		manager.EXPECT().GetBy(mock.Anything).Return(lo.Values(tasks))
-		manager.EXPECT().Update(mock.Anything, mock.Anything).Return()
-
-		memAllocator := NewMemoryAllocator(1000 / 0.2)
-		s.scheduler.memoryAllocator = memAllocator
-
-		s.scheduler.scheduleTasks()
-		s.Equal(int64(0), memAllocator.(*memoryAllocator).usedMemory)
-	})
-
-	// Task execution failure - memory should be released
-	s.Run("TaskExecutionFailure", func() {
-		manager := NewMockTaskManager(s.T())
-		s.scheduler.manager = manager
-
-		tasks := make(map[int64]Task, 0)
-		// Create a task that will fail execution
-		failedTask := NewMockTask(s.T())
-		failedTask.EXPECT().GetTaskID().Return(int64(1))
-		failedTask.EXPECT().GetBufferSize().Return(int64(256))
-
-		// Create a future that will fail
-		failedFuture := conc.Go(func() (any, error) {
-			return nil, errors.New("mock execution error")
-		})
-		failedTask.EXPECT().Execute().Return([]*conc.Future[any]{failedFuture})
-		tasks[failedTask.GetTaskID()] = failedTask
-
-		// Create a successful task
-		successTask := NewMockTask(s.T())
-		successTask.EXPECT().GetTaskID().Return(int64(2))
-		successTask.EXPECT().GetBufferSize().Return(int64(128))
-		successTask.EXPECT().Execute().Return([]*conc.Future[any]{})
-		tasks[successTask.GetTaskID()] = successTask
-
-		manager.EXPECT().GetBy(mock.Anything).Return(lo.Values(tasks))
-		manager.EXPECT().Update(mock.Anything, mock.Anything).Return()
-
-		memAllocator := NewMemoryAllocator(512 * 5)
-		s.scheduler.memoryAllocator = memAllocator
-
-		s.scheduler.scheduleTasks()
-		s.Equal(int64(0), memAllocator.(*memoryAllocator).usedMemory)
-	})
-
-	// Empty task list
-	s.Run("EmptyTaskList", func() {
-		manager := NewMockTaskManager(s.T())
-		s.scheduler.manager = manager
-
-		memAllocator := NewMemoryAllocator(1024)
-		s.scheduler.memoryAllocator = memAllocator
-
-		manager.EXPECT().GetBy(mock.Anything).Return(nil)
-
-		// Should not panic or error
-		s.NotPanics(func() {
-			s.scheduler.scheduleTasks()
-		})
-		s.Equal(int64(0), memAllocator.(*memoryAllocator).usedMemory)
-	})
 }
 
 func TestScheduler(t *testing.T) {

--- a/internal/datanode/importv2/task_import.go
+++ b/internal/datanode/importv2/task_import.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"runtime/debug"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -36,6 +37,8 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/v2/util/conc"
+	"github.com/milvus-io/milvus/pkg/v2/util/hardware"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
 
@@ -107,7 +110,27 @@ func (t *ImportTask) GetSlots() int64 {
 }
 
 func (t *ImportTask) GetBufferSize() int64 {
-	return GetTaskBufferSize(t)
+	// Calculate the task buffer size based on the number of vchannels and partitions
+	baseBufferSize := paramtable.Get().DataNodeCfg.ImportBaseBufferSize.GetAsInt()
+	vchannelNum := len(t.GetVchannels())
+	partitionNum := len(t.GetPartitionIDs())
+	taskBufferSize := int64(baseBufferSize * vchannelNum * partitionNum)
+
+	// If the file size is smaller than the task buffer size, use the file size
+	fileSize := lo.MaxBy(t.GetFileStats(), func(a, b *datapb.ImportFileStats) bool {
+		return a.GetTotalMemorySize() > b.GetTotalMemorySize()
+	}).GetTotalMemorySize()
+	if fileSize != 0 && fileSize < taskBufferSize {
+		taskBufferSize = fileSize
+	}
+
+	// Task buffer size should not exceed the memory limit
+	percentage := paramtable.Get().DataNodeCfg.ImportMemoryLimitPercentage.GetAsFloat()
+	memoryLimit := int64(float64(hardware.GetMemoryCount()) * percentage / 100.0)
+	if taskBufferSize > memoryLimit {
+		return memoryLimit
+	}
+	return taskBufferSize
 }
 
 func (t *ImportTask) Cancel() {
@@ -139,11 +162,11 @@ func (t *ImportTask) Clone() Task {
 }
 
 func (t *ImportTask) Execute() []*conc.Future[any] {
-	bufferSize := int(t.GetBufferSize())
+	bufferSize := t.GetBufferSize()
 	log.Info("start to import", WrapLogFields(t,
-		zap.Int("bufferSize", bufferSize),
+		zap.Int64("bufferSize", bufferSize),
 		zap.Int64("taskSlot", t.GetSlots()),
-		zap.Any("files", t.GetFileStats()),
+		zap.Any("files", t.req.GetFiles()),
 		zap.Any("schema", t.GetSchema()),
 	)...)
 	t.manager.Update(t.GetTaskID(), UpdateState(datapb.ImportTaskStateV2_InProgress))
@@ -151,7 +174,7 @@ func (t *ImportTask) Execute() []*conc.Future[any] {
 	req := t.req
 
 	fn := func(file *internalpb.ImportFile) error {
-		reader, err := importutilv2.NewReader(t.ctx, t.cm, t.GetSchema(), file, req.GetOptions(), bufferSize, t.req.GetStorageConfig())
+		reader, err := importutilv2.NewReader(t.ctx, t.cm, t.GetSchema(), file, req.GetOptions(), int(bufferSize), t.req.GetStorageConfig())
 		if err != nil {
 			log.Warn("new reader failed", WrapLogFields(t, zap.String("file", file.String()), zap.Error(err))...)
 			reason := fmt.Sprintf("error: %v, file: %s", err, file.String())
@@ -176,6 +199,12 @@ func (t *ImportTask) Execute() []*conc.Future[any] {
 	for _, file := range req.GetFiles() {
 		file := file
 		f := GetExecPool().Submit(func() (any, error) {
+			// Use blocking allocation - this will wait until memory is available
+			GetMemoryAllocator().BlockingAllocate(t.GetTaskID(), bufferSize)
+			defer func() {
+				GetMemoryAllocator().Release(t.GetTaskID(), bufferSize)
+				debug.FreeOSMemory()
+			}()
 			err := fn(file)
 			return err, err
 		})

--- a/internal/datanode/importv2/task_l0_import.go
+++ b/internal/datanode/importv2/task_l0_import.go
@@ -140,7 +140,7 @@ func (t *L0ImportTask) Execute() []*conc.Future[any] {
 	log.Info("start to import l0", WrapLogFields(t,
 		zap.Int("bufferSize", bufferSize),
 		zap.Int64("taskSlot", t.GetSlots()),
-		zap.Any("files", t.GetFileStats()),
+		zap.Any("files", t.req.GetFiles()),
 		zap.Any("schema", t.GetSchema()),
 	)...)
 	t.manager.Update(t.GetTaskID(), UpdateState(datapb.ImportTaskStateV2_InProgress))

--- a/internal/datanode/importv2/task_l0_preimport.go
+++ b/internal/datanode/importv2/task_l0_preimport.go
@@ -128,7 +128,7 @@ func (t *L0PreImportTask) Execute() []*conc.Future[any] {
 	log.Info("start to preimport l0", WrapLogFields(t,
 		zap.Int("bufferSize", bufferSize),
 		zap.Int64("taskSlot", t.GetSlots()),
-		zap.Any("files", t.GetFileStats()),
+		zap.Any("files", t.req.GetImportFiles()),
 		zap.Any("schema", t.GetSchema()),
 	)...)
 	t.manager.Update(t.GetTaskID(), UpdateState(datapb.ImportTaskStateV2_InProgress))

--- a/internal/datanode/importv2/util.go
+++ b/internal/datanode/importv2/util.go
@@ -39,9 +39,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/metrics"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
-	"github.com/milvus-io/milvus/pkg/v2/util/hardware"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
-	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
 
@@ -551,20 +549,4 @@ func NewMetaCache(req *datapb.ImportRequest) map[string]metacache.MetaCache {
 		metaCaches[channel] = metaCache
 	}
 	return metaCaches
-}
-
-// GetBufferSize returns the memory buffer size required by this task
-func GetTaskBufferSize(task Task) int64 {
-	baseBufferSize := paramtable.Get().DataNodeCfg.ImportBaseBufferSize.GetAsInt()
-	vchannelNum := len(task.GetVchannels())
-	partitionNum := len(task.GetPartitionIDs())
-	totalBufferSize := int64(baseBufferSize * vchannelNum * partitionNum)
-
-	percentage := paramtable.Get().DataNodeCfg.ImportMemoryLimitPercentage.GetAsFloat()
-	memoryLimit := int64(float64(hardware.GetMemoryCount()) * percentage / 100.0)
-
-	if totalBufferSize > memoryLimit {
-		return memoryLimit
-	}
-	return totalBufferSize
 }

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -5555,14 +5555,14 @@ if this parameter <= 0, will set it as 10`,
 		Key:          "dataNode.import.memoryLimitPercentage",
 		Version:      "2.5.15",
 		Doc:          "The percentage of memory limit for import/pre-import tasks.",
-		DefaultValue: "20",
+		DefaultValue: "10",
 		PanicIfEmpty: false,
 		Export:       true,
 		Formatter: func(v string) string {
 			percentage := getAsFloat(v)
 			if percentage <= 0 || percentage > 100 {
-				log.Warn("invalid import memory limit percentage, using default 20%")
-				return "20"
+				log.Warn("invalid import memory limit percentage, using default 10%")
+				return "10"
 			}
 			return fmt.Sprintf("%f", percentage)
 		},

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -623,7 +623,7 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, int64(16), Params.MaxImportFileSizeInGB.GetAsInt64())
 		assert.Equal(t, 16*1024*1024, Params.ImportBaseBufferSize.GetAsInt())
 		assert.Equal(t, 16*1024*1024, Params.ImportDeleteBufferSize.GetAsInt())
-		assert.Equal(t, 20.0, Params.ImportMemoryLimitPercentage.GetAsFloat())
+		assert.Equal(t, 10.0, Params.ImportMemoryLimitPercentage.GetAsFloat())
 		params.Save("datanode.gracefulStopTimeout", "100")
 		assert.Equal(t, 100*time.Second, Params.GracefulStopTimeout.GetAsDuration(time.Second))
 		assert.Equal(t, 16, Params.SlotCap.GetAsInt())


### PR DESCRIPTION
1. Use blocking memory allocation to wait until memory becomes available
2. Perform memory allocation at the file level instead of per task
3. Limit Parquet file reader batch size to prevent excessive memory consumption
4. Limit import buffer size from 20% to 10% of total memory

issue: https://github.com/milvus-io/milvus/issues/43387, https://github.com/milvus-io/milvus/issues/43131