### PR TITLE
enhance: Reserve builder space for ValueSerializer

### DIFF
--- a/internal/storage/serde_events.go
+++ b/internal/storage/serde_events.go
@@ -436,6 +436,7 @@ func ValueSerializer(v []*Value, fieldSchema []*schemapb.FieldSchema) (Record, e
 	for _, f := range fieldSchema {
 		dim, _ := typeutil.GetDim(f)
 		builders[f.FieldID] = array.NewBuilder(memory.DefaultAllocator, serdeMap[f.DataType].arrowType(int(dim)))
+		builders[f.FieldID].Reserve(len(v)) // reserve space to avoid copy
 		types[f.FieldID] = f.DataType
 	}
 


### PR DESCRIPTION
Add `arrowBuild.Reserve` call for `ValueSerializer` to reduce repeated resizing buffer when write size is large