### PR TITLE
fix: Revert "enhance: DataCodec to release ownership of input_data after initialization (#43542)"

### DIFF
--- a/internal/core/src/storage/DataCodec.cpp
+++ b/internal/core/src/storage/DataCodec.cpp
@@ -103,6 +103,9 @@ DeserializeFileData(const std::shared_ptr<uint8_t[]> input_data,
             index_data->set_index_meta(index_meta);
             index_data->SetTimestamps(index_event_data.start_timestamp,
                                       index_event_data.end_timestamp);
+            // DataCodec must keep the input_data alive for zero-copy usage,
+            // otherwise segmentation violation will occur
+            index_data->SetData(input_data);
             return index_data;
         }
         default:


### PR DESCRIPTION
Reverts pr #43542

This reverts commit d23205b718d0b3dbdde4f26a88a69babf60045ff.

Since underlining payload reader does not read data in `DeserializeFileData` but using zero-copy holding raw ptr to data, removing holding ptr logic may cause segv or unwanted behavior