### PR TITLE
fix: skip loading non-existent L0 segments to prevent load blocking

### DIFF
--- a/internal/datacoord/task_queue.go
+++ b/internal/datacoord/task_queue.go
@@ -33,9 +33,7 @@ type schedulePolicy interface {
 	Remove(taskID UniqueID)
 }
 
-var (
-	_ schedulePolicy = &priorityQueuePolicy{}
-)
+var _ schedulePolicy = &priorityQueuePolicy{}
 
 // priorityQueuePolicy implements a priority queue that sorts tasks by taskID (smaller taskID has higher priority)
 type priorityQueuePolicy struct {

--- a/internal/querycoordv2/checkers/controller.go
+++ b/internal/querycoordv2/checkers/controller.go
@@ -31,6 +31,7 @@ import (
 	"github.com/milvus-io/milvus/internal/querycoordv2/task"
 	"github.com/milvus-io/milvus/internal/querycoordv2/utils"
 	"github.com/milvus-io/milvus/pkg/v2/log"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 )
 
 var errTypeNotFound = errors.New("checker type not found")
@@ -63,11 +64,21 @@ func NewCheckerController(
 	broker meta.Broker,
 	getBalancerFunc GetBalancerFunc,
 ) *CheckerController {
+	checkSegmentExist := func(ctx context.Context, collectionID int64, segmentID int64) bool {
+		resp, err := broker.GetSegmentInfo(ctx, segmentID)
+		if err := merr.CheckRPCCall(resp, err); err != nil {
+			log.Info("check segment exist failed", zap.Int64("collectionID", collectionID), zap.Int64("segmentID", segmentID), zap.Error(err))
+			if errors.Is(err, merr.ErrSegmentNotFound) {
+				return false
+			}
+		}
+		return true
+	}
 	// CheckerController runs checkers with the order,
 	// the former checker has higher priority
 	checkers := map[utils.CheckerType]Checker{
 		utils.ChannelChecker: NewChannelChecker(meta, dist, targetMgr, nodeMgr, getBalancerFunc),
-		utils.SegmentChecker: NewSegmentChecker(meta, dist, targetMgr, nodeMgr, getBalancerFunc),
+		utils.SegmentChecker: NewSegmentChecker(meta, dist, targetMgr, nodeMgr, getBalancerFunc, checkSegmentExist),
 		utils.BalanceChecker: NewBalanceChecker(meta, targetMgr, nodeMgr, scheduler, getBalancerFunc),
 		utils.IndexChecker:   NewIndexChecker(meta, dist, broker, nodeMgr, targetMgr),
 		// todo temporary work around must fix


### PR DESCRIPTION
issue: #43577
In 2.5 branch, L0 segments must be loaded before other segments. If an L0 segment has been garbage collected but is still in the target list, the load operation would keep failing, preventing other segments from being loaded.

This patch adds a segment existence check for L0 segments in getSealedSegmentDiff. Only L0 segments that actually exist will be included in the load list.

Changes:
- Add checkSegmentExist function parameter to SegmentChecker constructor
- Filter L0 segments by existence check in getSealedSegmentDiff
- Add unit tests using mockey to verify the fix behavior