### PR TITLE
fix: including shouldCopy parameter in file readers

### DIFF
--- a/internal/datanode/compactor/clustering_compactor.go
+++ b/internal/datanode/compactor/clustering_compactor.go
@@ -633,7 +633,7 @@ func (t *clusteringCompactionTask) mappingSegment(
 		}
 
 		vs := make([]*storage.Value, r.Len())
-		if err = storage.ValueDeserializer(r, vs, t.plan.Schema.Fields); err != nil {
+		if err = storage.ValueDeserializer(r, vs, t.plan.Schema.Fields, false); err != nil {
 			log.Warn("compact wrong, failed to deserialize data", zap.Error(err))
 			return err
 		}
@@ -918,7 +918,7 @@ func (t *clusteringCompactionTask) scalarAnalyzeSegment(
 	}
 
 	pkIter := storage.NewDeserializeReader(rr, func(r storage.Record, v []*storage.Value) error {
-		return storage.ValueDeserializer(r, v, selectedFields)
+		return storage.ValueDeserializer(r, v, selectedFields, true)
 	})
 	defer pkIter.Close()
 	analyzeResult, remained, err := t.iterAndGetScalarAnalyzeResult(pkIter, expiredFilter)

--- a/internal/storage/arrow_util_test.go
+++ b/internal/storage/arrow_util_test.go
@@ -209,7 +209,7 @@ func TestGenerateEmptyArray(t *testing.T) {
 				assert.NoError(t, err)
 				assert.EqualValues(t, rowNum, a.Len())
 				for i := range rowNum {
-					value, ok := serdeMap[tc.field.DataType].deserialize(a, i)
+					value, ok := serdeMap[tc.field.DataType].deserialize(a, i, false)
 					assert.True(t, a.IsValid(i))
 					assert.True(t, ok)
 					assert.Equal(t, tc.expectValue, value)

--- a/internal/storage/rw_test.go
+++ b/internal/storage/rw_test.go
@@ -135,7 +135,7 @@ func (s *PackedBinlogRecordSuite) TestPackedBinlogRecordIntegration() {
 	blobs, err := generateTestData(rows)
 	s.NoError(err)
 
-	reader, err := NewBinlogDeserializeReader(generateTestSchema(), MakeBlobsReader(blobs))
+	reader, err := NewBinlogDeserializeReader(generateTestSchema(), MakeBlobsReader(blobs), false)
 	s.NoError(err)
 	defer reader.Close()
 
@@ -330,7 +330,7 @@ func (s *PackedBinlogRecordSuite) TestAllocIDExhausedError() {
 	blobs, err := generateTestData(size)
 	s.NoError(err)
 
-	reader, err := NewBinlogDeserializeReader(generateTestSchema(), MakeBlobsReader(blobs))
+	reader, err := NewBinlogDeserializeReader(generateTestSchema(), MakeBlobsReader(blobs), false)
 	s.NoError(err)
 	defer reader.Close()
 

--- a/internal/storage/serde.go
+++ b/internal/storage/serde.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"math"
 	"strconv"
+	"strings"
 
 	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/apache/arrow/go/v17/arrow/array"
@@ -105,10 +106,10 @@ type serdeEntry struct {
 var serdeMap = func() map[schemapb.DataType]serdeEntry {
 	m := make(map[schemapb.DataType]serdeEntry)
 	m[schemapb.DataType_Bool] = serdeEntry{
-		func(i int) arrow.DataType {
+		arrowType: func(i int) arrow.DataType {
 			return arrow.FixedWidthTypes.Boolean
 		},
-		func(a arrow.Array, i int, shouldCopy bool) (any, bool) {
+		deserialize: func(a arrow.Array, i int, shouldCopy bool) (any, bool) {
 			if a.IsNull(i) {
 				return nil, true
 			}
@@ -117,7 +118,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			}
 			return nil, false
 		},
-		func(b array.Builder, v any) bool {
+		serialize: func(b array.Builder, v any) bool {
 			if v == nil {
 				b.AppendNull()
 				return true
@@ -132,10 +133,10 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 		},
 	}
 	m[schemapb.DataType_Int8] = serdeEntry{
-		func(i int) arrow.DataType {
+		arrowType: func(i int) arrow.DataType {
 			return arrow.PrimitiveTypes.Int8
 		},
-		func(a arrow.Array, i int, shouldCopy bool) (any, bool) {
+		deserialize: func(a arrow.Array, i int, shouldCopy bool) (any, bool) {
 			if a.IsNull(i) {
 				return nil, true
 			}
@@ -144,7 +145,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			}
 			return nil, false
 		},
-		func(b array.Builder, v any) bool {
+		serialize: func(b array.Builder, v any) bool {
 			if v == nil {
 				b.AppendNull()
 				return true
@@ -159,10 +160,10 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 		},
 	}
 	m[schemapb.DataType_Int16] = serdeEntry{
-		func(i int) arrow.DataType {
+		arrowType: func(i int) arrow.DataType {
 			return arrow.PrimitiveTypes.Int16
 		},
-		func(a arrow.Array, i int, shouldCopy bool) (any, bool) {
+		deserialize: func(a arrow.Array, i int, shouldCopy bool) (any, bool) {
 			if a.IsNull(i) {
 				return nil, true
 			}
@@ -171,7 +172,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			}
 			return nil, false
 		},
-		func(b array.Builder, v any) bool {
+		serialize: func(b array.Builder, v any) bool {
 			if v == nil {
 				b.AppendNull()
 				return true
@@ -186,10 +187,10 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 		},
 	}
 	m[schemapb.DataType_Int32] = serdeEntry{
-		func(i int) arrow.DataType {
+		arrowType: func(i int) arrow.DataType {
 			return arrow.PrimitiveTypes.Int32
 		},
-		func(a arrow.Array, i int, shouldCopy bool) (any, bool) {
+		deserialize: func(a arrow.Array, i int, shouldCopy bool) (any, bool) {
 			if a.IsNull(i) {
 				return nil, true
 			}
@@ -198,7 +199,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			}
 			return nil, false
 		},
-		func(b array.Builder, v any) bool {
+		serialize: func(b array.Builder, v any) bool {
 			if v == nil {
 				b.AppendNull()
 				return true
@@ -213,10 +214,10 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 		},
 	}
 	m[schemapb.DataType_Int64] = serdeEntry{
-		func(i int) arrow.DataType {
+		arrowType: func(i int) arrow.DataType {
 			return arrow.PrimitiveTypes.Int64
 		},
-		func(a arrow.Array, i int, shouldCopy bool) (any, bool) {
+		deserialize: func(a arrow.Array, i int, shouldCopy bool) (any, bool) {
 			if a.IsNull(i) {
 				return nil, true
 			}
@@ -225,7 +226,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			}
 			return nil, false
 		},
-		func(b array.Builder, v any) bool {
+		serialize: func(b array.Builder, v any) bool {
 			if v == nil {
 				b.AppendNull()
 				return true
@@ -240,10 +241,10 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 		},
 	}
 	m[schemapb.DataType_Float] = serdeEntry{
-		func(i int) arrow.DataType {
+		arrowType: func(i int) arrow.DataType {
 			return arrow.PrimitiveTypes.Float32
 		},
-		func(a arrow.Array, i int, shouldCopy bool) (any, bool) {
+		deserialize: func(a arrow.Array, i int, shouldCopy bool) (any, bool) {
 			if a.IsNull(i) {
 				return nil, true
 			}
@@ -252,7 +253,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			}
 			return nil, false
 		},
-		func(b array.Builder, v any) bool {
+		serialize: func(b array.Builder, v any) bool {
 			if v == nil {
 				b.AppendNull()
 				return true
@@ -267,10 +268,10 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 		},
 	}
 	m[schemapb.DataType_Double] = serdeEntry{
-		func(i int) arrow.DataType {
+		arrowType: func(i int) arrow.DataType {
 			return arrow.PrimitiveTypes.Float64
 		},
-		func(a arrow.Array, i int, shouldCopy bool) (any, bool) {
+		deserialize: func(a arrow.Array, i int, shouldCopy bool) (any, bool) {
 			if a.IsNull(i) {
 				return nil, true
 			}
@@ -279,7 +280,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			}
 			return nil, false
 		},
-		func(b array.Builder, v any) bool {
+		serialize: func(b array.Builder, v any) bool {
 			if v == nil {
 				b.AppendNull()
 				return true
@@ -294,23 +295,23 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 		},
 	}
 	stringEntry := serdeEntry{
-		func(i int) arrow.DataType {
+		arrowType: func(i int) arrow.DataType {
 			return arrow.BinaryTypes.String
 		},
-		func(a arrow.Array, i int, shouldCopy bool) (any, bool) {
+		deserialize: func(a arrow.Array, i int, shouldCopy bool) (any, bool) {
 			if a.IsNull(i) {
 				return nil, true
 			}
 			if arr, ok := a.(*array.String); ok && i < arr.Len() {
 				value := arr.Value(i)
 				if shouldCopy {
-					return string([]byte(value)), true
+					return strings.Clone(value), true
 				}
 				return value, true
 			}
 			return nil, false
 		},
-		func(b array.Builder, v any) bool {
+		serialize: func(b array.Builder, v any) bool {
 			if v == nil {
 				b.AppendNull()
 				return true
@@ -332,25 +333,22 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 	// We're not using the deserialized data in go, so we can skip the heavy pb serde.
 	// If there is need in the future, just assign it to m[schemapb.DataType_Array]
 	eagerArrayEntry := serdeEntry{
-		func(i int) arrow.DataType {
+		arrowType: func(i int) arrow.DataType {
 			return arrow.BinaryTypes.Binary
 		},
-		func(a arrow.Array, i int, shouldCopy bool) (any, bool) {
+		deserialize: func(a arrow.Array, i int, shouldCopy bool) (any, bool) {
 			if a.IsNull(i) {
 				return nil, true
 			}
 			if arr, ok := a.(*array.Binary); ok && i < arr.Len() {
 				v := &schemapb.ScalarField{}
 				if err := proto.Unmarshal(arr.Value(i), v); err == nil {
-					if shouldCopy {
-						return proto.Clone(v), true
-					}
 					return v, true
 				}
 			}
 			return nil, false
 		},
-		func(b array.Builder, v any) bool {
+		serialize: func(b array.Builder, v any) bool {
 			if v == nil {
 				b.AppendNull()
 				return true
@@ -369,10 +367,10 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 	_ = eagerArrayEntry
 
 	byteEntry := serdeEntry{
-		func(i int) arrow.DataType {
+		arrowType: func(i int) arrow.DataType {
 			return arrow.BinaryTypes.Binary
 		},
-		func(a arrow.Array, i int, shouldCopy bool) (any, bool) {
+		deserialize: func(a arrow.Array, i int, shouldCopy bool) (any, bool) {
 			if a.IsNull(i) {
 				return nil, true
 			}
@@ -387,7 +385,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			}
 			return nil, false
 		},
-		func(b array.Builder, v any) bool {
+		serialize: func(b array.Builder, v any) bool {
 			if v == nil {
 				b.AppendNull()
 				return true
@@ -441,31 +439,31 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 	}
 
 	m[schemapb.DataType_BinaryVector] = serdeEntry{
-		func(i int) arrow.DataType {
+		arrowType: func(i int) arrow.DataType {
 			return &arrow.FixedSizeBinaryType{ByteWidth: (i + 7) / 8}
 		},
-		fixedSizeDeserializer,
-		fixedSizeSerializer,
+		deserialize: fixedSizeDeserializer,
+		serialize:   fixedSizeSerializer,
 	}
 	m[schemapb.DataType_Float16Vector] = serdeEntry{
-		func(i int) arrow.DataType {
+		arrowType: func(i int) arrow.DataType {
 			return &arrow.FixedSizeBinaryType{ByteWidth: i * 2}
 		},
-		fixedSizeDeserializer,
-		fixedSizeSerializer,
+		deserialize: fixedSizeDeserializer,
+		serialize:   fixedSizeSerializer,
 	}
 	m[schemapb.DataType_BFloat16Vector] = serdeEntry{
-		func(i int) arrow.DataType {
+		arrowType: func(i int) arrow.DataType {
 			return &arrow.FixedSizeBinaryType{ByteWidth: i * 2}
 		},
-		fixedSizeDeserializer,
-		fixedSizeSerializer,
+		deserialize: fixedSizeDeserializer,
+		serialize:   fixedSizeSerializer,
 	}
 	m[schemapb.DataType_Int8Vector] = serdeEntry{
-		func(i int) arrow.DataType {
+		arrowType: func(i int) arrow.DataType {
 			return &arrow.FixedSizeBinaryType{ByteWidth: i}
 		},
-		func(a arrow.Array, i int, shouldCopy bool) (any, bool) {
+		deserialize: func(a arrow.Array, i int, shouldCopy bool) (any, bool) {
 			if a.IsNull(i) {
 				return nil, true
 			}
@@ -480,7 +478,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			}
 			return nil, false
 		},
-		func(b array.Builder, v any) bool {
+		serialize: func(b array.Builder, v any) bool {
 			if v == nil {
 				b.AppendNull()
 				return true
@@ -498,19 +496,25 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 		},
 	}
 	m[schemapb.DataType_FloatVector] = serdeEntry{
-		func(i int) arrow.DataType {
+		arrowType: func(i int) arrow.DataType {
 			return &arrow.FixedSizeBinaryType{ByteWidth: i * 4}
 		},
-		func(a arrow.Array, i int, shouldCopy bool) (any, bool) {
+		deserialize: func(a arrow.Array, i int, shouldCopy bool) (any, bool) {
 			if a.IsNull(i) {
 				return nil, true
 			}
 			if arr, ok := a.(*array.FixedSizeBinary); ok && i < arr.Len() {
-				return arrow.Float32Traits.CastFromBytes(arr.Value(i)), true
+				vector := arrow.Float32Traits.CastFromBytes(arr.Value(i))
+				if shouldCopy {
+					vectorCopy := make([]float32, len(vector))
+					copy(vectorCopy, vector)
+					return vectorCopy, true
+				}
+				return vector, true
 			}
 			return nil, false
 		},
-		func(b array.Builder, v any) bool {
+		serialize: func(b array.Builder, v any) bool {
 			if v == nil {
 				b.AppendNull()
 				return true

--- a/internal/storage/serde_events_test.go
+++ b/internal/storage/serde_events_test.go
@@ -47,7 +47,7 @@ func TestBinlogDeserializeReader(t *testing.T) {
 	t.Run("test empty data", func(t *testing.T) {
 		reader, err := NewBinlogDeserializeReader(generateTestSchema(), func() ([]*Blob, error) {
 			return nil, io.EOF
-		})
+		}, false)
 		assert.NoError(t, err)
 		defer reader.Close()
 		_, err = reader.NextValue()
@@ -58,7 +58,7 @@ func TestBinlogDeserializeReader(t *testing.T) {
 		size := 3
 		blobs, err := generateTestData(size)
 		assert.NoError(t, err)
-		reader, err := NewBinlogDeserializeReader(generateTestSchema(), MakeBlobsReader(blobs))
+		reader, err := NewBinlogDeserializeReader(generateTestSchema(), MakeBlobsReader(blobs), false)
 		assert.NoError(t, err)
 		defer reader.Close()
 
@@ -77,7 +77,7 @@ func TestBinlogDeserializeReader(t *testing.T) {
 		size := 3
 		blobs, err := generateTestData(size)
 		assert.NoError(t, err)
-		reader, err := NewBinlogDeserializeReader(generateTestAddedFieldSchema(), MakeBlobsReader(blobs))
+		reader, err := NewBinlogDeserializeReader(generateTestAddedFieldSchema(), MakeBlobsReader(blobs), false)
 		assert.NoError(t, err)
 		defer reader.Close()
 
@@ -146,7 +146,7 @@ func TestBinlogSerializeWriter(t *testing.T) {
 		size := 100
 		blobs, err := generateTestData(size)
 		assert.NoError(t, err)
-		reader, err := NewBinlogDeserializeReader(generateTestSchema(), MakeBlobsReader(blobs))
+		reader, err := NewBinlogDeserializeReader(generateTestSchema(), MakeBlobsReader(blobs), false)
 		assert.NoError(t, err)
 		defer reader.Close()
 
@@ -187,7 +187,7 @@ func TestBinlogValueWriter(t *testing.T) {
 	t.Run("test empty data", func(t *testing.T) {
 		reader, err := NewBinlogDeserializeReader(generateTestSchema(), func() ([]*Blob, error) {
 			return nil, io.EOF
-		})
+		}, false)
 		assert.NoError(t, err)
 		defer reader.Close()
 		_, err = reader.NextValue()
@@ -198,7 +198,7 @@ func TestBinlogValueWriter(t *testing.T) {
 		size := 16
 		blobs, err := generateTestData(size)
 		assert.NoError(t, err)
-		reader, err := NewBinlogDeserializeReader(generateTestSchema(), MakeBlobsReader(blobs))
+		reader, err := NewBinlogDeserializeReader(generateTestSchema(), MakeBlobsReader(blobs), false)
 		assert.NoError(t, err)
 		defer reader.Close()
 
@@ -245,7 +245,7 @@ func TestBinlogValueWriter(t *testing.T) {
 		assert.Less(t, writers[0].buf.Len(), writers[13].buf.Len())
 
 		// assert.Equal(t, blobs[0].Value, newblobs[0].Value)
-		reader, err = NewBinlogDeserializeReader(generateTestSchema(), MakeBlobsReader(newblobs))
+		reader, err = NewBinlogDeserializeReader(generateTestSchema(), MakeBlobsReader(newblobs), false)
 		assert.NoError(t, err)
 		defer reader.Close()
 		for i := 1; i <= size; i++ {
@@ -445,7 +445,7 @@ func TestNull(t *testing.T) {
 			blobs[i] = blob
 			i++
 		}
-		reader, err := NewBinlogDeserializeReader(generateTestSchema(), MakeBlobsReader(blobs))
+		reader, err := NewBinlogDeserializeReader(generateTestSchema(), MakeBlobsReader(blobs), false)
 		assert.NoError(t, err)
 		defer reader.Close()
 		v, err := reader.NextValue()

--- a/internal/storage/serde_events_v2.go
+++ b/internal/storage/serde_events_v2.go
@@ -127,7 +127,7 @@ func newPackedRecordReader(paths [][]string, schema *schemapb.CollectionSchema, 
 }
 
 func NewPackedDeserializeReader(paths [][]string, schema *schemapb.CollectionSchema,
-	bufferSize int64,
+	bufferSize int64, shouldCopy bool,
 ) (*DeserializeReaderImpl[*Value], error) {
 	reader, err := newPackedRecordReader(paths, schema, bufferSize, nil)
 	if err != nil {
@@ -135,7 +135,7 @@ func NewPackedDeserializeReader(paths [][]string, schema *schemapb.CollectionSch
 	}
 
 	return NewDeserializeReader(reader, func(r Record, v []*Value) error {
-		return ValueDeserializer(r, v, schema.Fields)
+		return ValueDeserializer(r, v, schema.Fields, shouldCopy)
 	}), nil
 }
 

--- a/internal/storage/serde_events_v2_test.go
+++ b/internal/storage/serde_events_v2_test.go
@@ -40,7 +40,7 @@ func TestPackedSerde(t *testing.T) {
 			blobs, err := generateTestData(size)
 			assert.NoError(t, err)
 
-			reader, err := NewBinlogDeserializeReader(generateTestSchema(), MakeBlobsReader(blobs))
+			reader, err := NewBinlogDeserializeReader(generateTestSchema(), MakeBlobsReader(blobs), false)
 			assert.NoError(t, err)
 
 			group := storagecommon.ColumnGroup{GroupID: storagecommon.DefaultShortColumnGroupID}
@@ -70,7 +70,7 @@ func TestPackedSerde(t *testing.T) {
 			prepareChunkData(chunkPaths, size)
 		}
 
-		reader, err := NewPackedDeserializeReader(paths, schema, bufferSize)
+		reader, err := NewPackedDeserializeReader(paths, schema, bufferSize, false)
 		assert.NoError(t, err)
 		defer reader.Close()
 

--- a/internal/storage/serde_test.go
+++ b/internal/storage/serde_test.go
@@ -152,7 +152,7 @@ func TestSerDeCopy(t *testing.T) {
 			if !reflect.DeepEqual(copy, tt.v) {
 				t.Errorf("deserialize() got = %v, want %v", copy, tt.v)
 			}
-			ref, got1 := serdeMap[dt].deserialize(a, 0, false)
+			ref, _ := serdeMap[dt].deserialize(a, 0, false)
 			// check the unsafe pointers of copy and ref are different
 			switch v := copy.(type) {
 			case []byte:

--- a/internal/storage/serde_test.go
+++ b/internal/storage/serde_test.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"reflect"
 	"testing"
+	"unsafe"
 
 	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/apache/arrow/go/v17/arrow/array"
@@ -109,13 +110,62 @@ func TestSerDe(t *testing.T) {
 			serdeMap[dt].serialize(builder, v)
 			// assert.True(t, ok)
 			a := builder.NewArray()
-			got, got1 := serdeMap[dt].deserialize(a, 0)
+			got, got1 := serdeMap[dt].deserialize(a, 0, false)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("deserialize() got = %v, want %v", got, tt.want)
 			}
 			if got1 != tt.want1 {
 				t.Errorf("deserialize() got1 = %v, want %v", got1, tt.want1)
 			}
+		})
+	}
+}
+
+func TestSerDeCopy(t *testing.T) {
+	tests := []struct {
+		name string
+		dt   schemapb.DataType
+		v    any
+	}{
+		{"test string copy", schemapb.DataType_String, "test"},
+		{"test string no copy", schemapb.DataType_String, "test"},
+		{"test binary copy", schemapb.DataType_JSON, []byte{1, 2, 3}},
+		{"test binary no copy", schemapb.DataType_JSON, []byte{1, 2, 3}},
+		{"test bool copy", schemapb.DataType_Bool, true},
+		{"test bool no copy", schemapb.DataType_Bool, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dt := tt.dt
+			v := tt.v
+			builder := array.NewBuilder(memory.DefaultAllocator, serdeMap[dt].arrowType(1))
+			defer builder.Release()
+			serdeMap[dt].serialize(builder, v)
+			a := builder.NewArray()
+
+			// Test deserialize with shouldCopy parameter
+			copy, got1 := serdeMap[dt].deserialize(a, 0, true)
+			if !got1 {
+				t.Errorf("deserialize() failed for %s", tt.name)
+			}
+			if !reflect.DeepEqual(copy, tt.v) {
+				t.Errorf("deserialize() got = %v, want %v", copy, tt.v)
+			}
+			ref, got1 := serdeMap[dt].deserialize(a, 0, false)
+			// check the unsafe pointers of copy and ref are different
+			switch v := copy.(type) {
+			case []byte:
+				if unsafe.Pointer(&v[0]) == unsafe.Pointer(&ref.([]byte)[0]) {
+					t.Errorf("deserialize() got same pointer for %v", tt.v)
+				}
+			case string:
+				if unsafe.StringData(v) == unsafe.StringData(ref.(string)) {
+					t.Errorf("deserialize() got same pointer for %v", tt.v)
+				}
+			}
+
+			a.Release()
 		})
 	}
 }
@@ -127,7 +177,7 @@ func BenchmarkDeserializeReader(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		reader, err := NewBinlogDeserializeReader(generateTestSchema(), MakeBlobsReader(blobs))
+		reader, err := NewBinlogDeserializeReader(generateTestSchema(), MakeBlobsReader(blobs), false)
 		assert.NoError(b, err)
 		defer reader.Close()
 		for i := 0; i < len; i++ {

--- a/internal/util/importutilv2/binlog/reader.go
+++ b/internal/util/importutilv2/binlog/reader.go
@@ -126,7 +126,7 @@ func (r *reader) init(paths []string, tsStart, tsEnd uint64, storageConfig *inde
 	}
 
 	r.dr = storage.NewDeserializeReader(rr, func(record storage.Record, v []*storage.Value) error {
-		return storage.ValueDeserializer(record, v, r.schema.Fields)
+		return storage.ValueDeserializer(record, v, r.schema.Fields, true)
 	})
 
 	if len(paths) < 2 {


### PR DESCRIPTION
This parameter determines whether the returned value should be a copy or a reference from the arrow array. The updates enhance memory management and provide more control over data handling during deserialization.

See #43186