### PR TITLE
fix: [StorageV2] Access future result to get exception if any

### DIFF
--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
@@ -231,6 +231,10 @@ GroupChunkTranslator::get_cells(const std::vector<cachinglayer::cid_t>& cids) {
             filled_cids.insert(cid);
         }
     }
+
+    // access underlying feature to get exception if any
+    load_future.get();
+
     // Verify all requested cids have been filled
     for (auto cid : cids) {
         AssertInfo(filled_cids.find(cid) != filled_cids.end(),


### PR DESCRIPTION
Related to #43584

When `LoadWithStrategy` throw exception, the ex was wrapped in the returned future. If the future is not handled, this exception would be ignored.

This patch add `future.get()` to get exception if any.