### PR TITLE
enhance: Make `DeleteRecord` search pks by batch

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -896,6 +896,86 @@ ChunkedSegmentSealedImpl::search_pk(const PkType& pk,
     });
 }
 
+std::vector<std::pair<SegOffset, Timestamp>>
+ChunkedSegmentSealedImpl::search_batch_pks(const std::vector<PkType>& pks,
+                                           const Timestamp* timestamps) const {
+    AssertInfo(is_sorted_by_pk_,
+               "search_batch_pks only works on pk sorted segment");
+    auto pk_field_id = schema_->get_primary_field_id().value_or(FieldId(-1));
+    AssertInfo(pk_field_id.get() != -1, "Primary key is -1");
+    auto pk_column = fields_.at(pk_field_id);
+    std::vector<std::pair<SegOffset, Timestamp>> pk_offsets;
+
+    switch (schema_->get_fields().at(pk_field_id).get_data_type()) {
+        case DataType::INT64: {
+            for (size_t i = 0; i < pks.size(); i++) {
+                // get int64 pks
+                auto target = std::get<int64_t>(pks[i]);
+                auto timestamp = timestamps[i];
+                auto num_chunk = pk_column->num_chunks();
+                for (int i = 0; i < num_chunk; ++i) {
+                    auto pw = pk_column->DataOfChunk(i);
+                    auto src = reinterpret_cast<const int64_t*>(pw.get());
+                    auto chunk_row_num = pk_column->chunk_row_nums(i);
+                    auto it = std::lower_bound(
+                        src,
+                        src + chunk_row_num,
+                        target,
+                        [](const int64_t& elem, const int64_t& value) {
+                            return elem < value;
+                        });
+                    auto num_rows_until_chunk =
+                        pk_column->GetNumRowsUntilChunk(i);
+                    for (; it != src + chunk_row_num && *it == target; ++it) {
+                        auto offset = it - src + num_rows_until_chunk;
+                        if (insert_record_.timestamps_[offset] <= timestamp) {
+                            pk_offsets.emplace_back(offset, timestamp);
+                        }
+                    }
+                }
+            }
+
+            break;
+        }
+        case DataType::VARCHAR: {
+            for (size_t i = 0; i < pks.size(); i++) {
+                // get varchar pks
+                auto target = std::get<std::string>(pks[i]);
+                auto timestamp = timestamps[i];
+
+                auto num_chunk = pk_column->num_chunks();
+                for (int i = 0; i < num_chunk; ++i) {
+                    // TODO @xiaocai2333, @sunby: chunk need to record the min/max.
+                    auto num_rows_until_chunk =
+                        pk_column->GetNumRowsUntilChunk(i);
+                    auto pw = pk_column->GetChunk(i);
+                    auto string_chunk = static_cast<StringChunk*>(pw.get());
+                    auto offset = string_chunk->binary_search_string(target);
+                    for (; offset != -1 && offset < string_chunk->RowNums() &&
+                           string_chunk->operator[](offset) == target;
+                         ++offset) {
+                        auto segment_offset = offset + num_rows_until_chunk;
+                        if (insert_record_.timestamps_[segment_offset] <=
+                            timestamp) {
+                            pk_offsets.emplace_back(segment_offset, timestamp);
+                        }
+                    }
+                }
+            }
+            break;
+        }
+        default: {
+            ThrowInfo(
+                DataTypeInvalid,
+                fmt::format(
+                    "unsupported type {}",
+                    schema_->get_fields().at(pk_field_id).get_data_type()));
+        }
+    }
+
+    return pk_offsets;
+}
+
 template <typename Condition>
 std::vector<SegOffset>
 ChunkedSegmentSealedImpl::search_sorted_pk(const PkType& pk,
@@ -1020,8 +1100,8 @@ ChunkedSegmentSealedImpl::ChunkedSegmentSealedImpl(
       is_sorted_by_pk_(is_sorted_by_pk),
       deleted_record_(
           &insert_record_,
-          [this](const PkType& pk, Timestamp timestamp) {
-              return this->search_pk(pk, timestamp);
+          [this](const std::vector<PkType>& pks, const Timestamp* timestamps) {
+              return this->search_batch_pks(pks, timestamps);
           },
           segment_id) {
     auto mcm = storage::MmapManager::GetInstance().GetMmapChunkManager();

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -201,6 +201,10 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         return true;
     }
 
+    std::vector<std::pair<SegOffset, Timestamp>>
+    search_batch_pks(const std::vector<PkType>& pks,
+                     const Timestamp* timestamps) const;
+
  public:
     int64_t
     num_chunk_index(FieldId field_id) const override;

--- a/internal/core/src/segcore/DeletedRecord.h
+++ b/internal/core/src/segcore/DeletedRecord.h
@@ -53,8 +53,9 @@ template <bool is_sealed = false>
 class DeletedRecord {
  public:
     DeletedRecord(InsertRecord<is_sealed>* insert_record,
-                  std::function<std::vector<SegOffset>(
-                      const PkType& pk, Timestamp timestamp)> search_pk_func,
+                  std::function<std::vector<std::pair<SegOffset, Timestamp>>(
+                      const std::vector<PkType>& pks,
+                      const Timestamp* timestamps)> search_pk_func,
                   int64_t segment_id)
         : insert_record_(insert_record),
           search_pk_func_(search_pk_func),
@@ -109,36 +110,60 @@ class DeletedRecord {
 
         SortedDeleteList::Accessor accessor(deleted_lists_);
         for (size_t i = 0; i < pks.size(); ++i) {
-            auto deleted_pk = pks[i];
+            // auto deleted_pk = pks[i];
             auto deleted_ts = timestamps[i];
             if (deleted_ts > max_timestamp) {
                 max_timestamp = deleted_ts;
             }
-            std::vector<SegOffset> offsets =
-                search_pk_func_(deleted_pk, deleted_ts);
-            for (auto& offset : offsets) {
-                auto row_id = offset.get();
-                // if alreay deleted, no need to add new record
-                if (deleted_mask_.size() > row_id && deleted_mask_[row_id]) {
-                    continue;
-                }
-                // if insert record and delete record is same timestamp,
-                // delete not take effect on this record.
-                if (deleted_ts == insert_record_->timestamps_[row_id]) {
-                    continue;
-                }
-                accessor.insert(std::make_pair(deleted_ts, row_id));
-                if constexpr (is_sealed) {
-                    Assert(deleted_mask_.size() > 0);
-                    deleted_mask_.set(row_id);
-                } else {
-                    // need to add mask size firstly for growing segment
-                    deleted_mask_.resize(insert_record_->size());
-                    deleted_mask_.set(row_id);
-                }
-                removed_num++;
-                mem_add += DELETE_PAIR_SIZE;
+            // std::vector<SegOffset> offsets =
+            //     search_pk_func_(deleted_pk, deleted_ts);
+            // for (auto& offset : offsets) {
+            //     auto row_id = offset.get();
+            //     // if alreay deleted, no need to add new record
+            //     if (deleted_mask_.size() > row_id && deleted_mask_[row_id]) {
+            //         continue;
+            //     }
+            //     // if insert record and delete record is same timestamp,
+            //     // delete not take effect on this record.
+            //     if (deleted_ts == insert_record_->timestamps_[row_id]) {
+            //         continue;
+            //     }
+            //     accessor.insert(std::make_pair(deleted_ts, row_id));
+            //     if constexpr (is_sealed) {
+            //         Assert(deleted_mask_.size() > 0);
+            //         deleted_mask_.set(row_id);
+            //     } else {
+            //         // need to add mask size firstly for growing segment
+            //         deleted_mask_.resize(insert_record_->size());
+            //         deleted_mask_.set(row_id);
+            //     }
+            //     removed_num++;
+            //     mem_add += DELETE_PAIR_SIZE;
+            // }
+        }
+        auto offsets = search_pk_func_(pks, timestamps);
+        for (auto& [offset, deleted_ts] : offsets) {
+            auto row_id = offset.get();
+            // if alreay deleted, no need to add new record
+            if (deleted_mask_.size() > row_id && deleted_mask_[row_id]) {
+                continue;
             }
+            // if insert record and delete record is same timestamp,
+            // delete not take effect on this record.
+            if (deleted_ts == insert_record_->timestamps_[row_id]) {
+                continue;
+            }
+            accessor.insert(std::make_pair(deleted_ts, row_id));
+            if constexpr (is_sealed) {
+                Assert(deleted_mask_.size() > 0);
+                deleted_mask_.set(row_id);
+            } else {
+                // need to add mask size firstly for growing segment
+                deleted_mask_.resize(insert_record_->size());
+                deleted_mask_.set(row_id);
+            }
+            removed_num++;
+            mem_add += DELETE_PAIR_SIZE;
         }
 
         n_.fetch_add(removed_num);
@@ -323,7 +348,8 @@ class DeletedRecord {
     std::atomic<int64_t> n_ = 0;
     std::atomic<int64_t> mem_size_ = 0;
     InsertRecord<is_sealed>* insert_record_;
-    std::function<std::vector<SegOffset>(const PkType& pk, Timestamp timestamp)>
+    std::function<std::vector<std::pair<SegOffset, Timestamp>>(
+        const std::vector<PkType>& pks, const Timestamp* timestamps)>
         search_pk_func_;
     int64_t segment_id_{0};
     std::shared_ptr<SortedDeleteList> deleted_lists_;

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -665,6 +665,20 @@ SegmentGrowingImpl::GetFieldDataType(milvus::FieldId field_id) const {
     return field_meta.get_data_type();
 }
 
+std::vector<std::pair<SegOffset, Timestamp>>
+SegmentGrowingImpl::search_batch_pks(const std::vector<PkType>& pks,
+                                     const Timestamp* timestamps) const {
+    std::vector<std::pair<SegOffset, Timestamp>> results;
+    for (size_t i = 0; i < pks.size(); ++i) {
+        auto timestamp = timestamps[i];
+        auto offsets = insert_record_.search_pk(pks[i], timestamp);
+        for (auto offset : offsets) {
+            results.emplace_back(offset, timestamp);
+        }
+    }
+    return results;
+}
+
 void
 SegmentGrowingImpl::vector_search(SearchInfo& search_info,
                                   const void* query_data,

--- a/internal/core/src/segcore/SegmentGrowingImpl.h
+++ b/internal/core/src/segcore/SegmentGrowingImpl.h
@@ -175,6 +175,10 @@ class SegmentGrowingImpl : public SegmentGrowing {
     void
     try_remove_chunks(FieldId fieldId);
 
+    std::vector<std::pair<SegOffset, Timestamp>>
+    search_batch_pks(const std::vector<PkType>& pks,
+                     const Timestamp* timestamps) const;
+
  public:
     size_t
     GetMemoryUsageInBytes() const override {
@@ -291,8 +295,9 @@ class SegmentGrowingImpl : public SegmentGrowing {
           id_(segment_id),
           deleted_record_(
               &insert_record_,
-              [this](const PkType& pk, Timestamp timestamp) {
-                  return this->search_pk(pk, timestamp);
+              [this](const std::vector<PkType>& pks,
+                     const Timestamp* timestamps) {
+                  return this->search_batch_pks(pks, timestamps);
               },
               segment_id) {
         this->CreateTextIndexes();

--- a/internal/core/unittest/test_delete_record.cpp
+++ b/internal/core/unittest/test_delete_record.cpp
@@ -42,8 +42,17 @@ TEST(DeleteMVCC, common_case) {
     auto segment_ptr = segment.get();
     DeletedRecord<true> delete_record(
         &insert_record,
-        [&insert_record](const PkType& pk, Timestamp timestamp) {
-            return insert_record.search_pk(pk, timestamp);
+        [&insert_record](const std::vector<PkType>& pks,
+                         const Timestamp* timestamps) {
+            std::vector<std::pair<SegOffset, Timestamp>> results;
+            for (size_t i = 0; i < pks.size(); ++i) {
+                auto timestamp = timestamps[i];
+                auto offsets = insert_record.search_pk(pks[i], timestamp);
+                for (auto offset : offsets) {
+                    results.emplace_back(offset, timestamp);
+                }
+            }
+            return results;
         },
         0);
     delete_record.set_sealed_row_count(c);
@@ -158,8 +167,17 @@ TEST(DeleteMVCC, delete_exist_duplicate_pks) {
     InsertRecord<false> insert_record(*schema, N);
     DeletedRecord<false> delete_record(
         &insert_record,
-        [&insert_record](const PkType& pk, Timestamp timestamp) {
-            return insert_record.search_pk(pk, timestamp);
+        [&insert_record](const std::vector<PkType>& pks,
+                         const Timestamp* timestamps) {
+            std::vector<std::pair<SegOffset, Timestamp>> results;
+            for (size_t i = 0; i < pks.size(); ++i) {
+                auto timestamp = timestamps[i];
+                auto offsets = insert_record.search_pk(pks[i], timestamp);
+                for (auto offset : offsets) {
+                    results.emplace_back(offset, timestamp);
+                }
+            }
+            return results;
         },
         0);
 
@@ -273,8 +291,17 @@ TEST(DeleteMVCC, snapshot) {
     InsertRecord<false> insert_record(*schema, N);
     DeletedRecord<false> delete_record(
         &insert_record,
-        [&insert_record](const PkType& pk, Timestamp timestamp) {
-            return insert_record.search_pk(pk, timestamp);
+        [&insert_record](const std::vector<PkType>& pks,
+                         const Timestamp* timestamps) {
+            std::vector<std::pair<SegOffset, Timestamp>> results;
+            for (size_t i = 0; i < pks.size(); ++i) {
+                auto timestamp = timestamps[i];
+                auto offsets = insert_record.search_pk(pks[i], timestamp);
+                for (auto offset : offsets) {
+                    results.emplace_back(offset, timestamp);
+                }
+            }
+            return results;
         },
         0);
 
@@ -321,8 +348,17 @@ TEST(DeleteMVCC, insert_after_snapshot) {
     InsertRecord<false> insert_record(*schema, N);
     DeletedRecord<false> delete_record(
         &insert_record,
-        [&insert_record](const PkType& pk, Timestamp timestamp) {
-            return insert_record.search_pk(pk, timestamp);
+        [&insert_record](const std::vector<PkType>& pks,
+                         const Timestamp* timestamps) {
+            std::vector<std::pair<SegOffset, Timestamp>> results;
+            for (size_t i = 0; i < pks.size(); ++i) {
+                auto timestamp = timestamps[i];
+                auto offsets = insert_record.search_pk(pks[i], timestamp);
+                for (auto offset : offsets) {
+                    results.emplace_back(offset, timestamp);
+                }
+            }
+            return results;
         },
         0);
 
@@ -416,8 +452,17 @@ TEST(DeleteMVCC, perform) {
     InsertRecord<false> insert_record(*schema, N);
     DeletedRecord<false> delete_record(
         &insert_record,
-        [&insert_record](const PkType& pk, Timestamp timestamp) {
-            return insert_record.search_pk(pk, timestamp);
+        [&insert_record](const std::vector<PkType>& pks,
+                         const Timestamp* timestamps) {
+            std::vector<std::pair<SegOffset, Timestamp>> results;
+            for (size_t i = 0; i < pks.size(); ++i) {
+                auto timestamp = timestamps[i];
+                auto offsets = insert_record.search_pk(pks[i], timestamp);
+                for (auto offset : offsets) {
+                    results.emplace_back(offset, timestamp);
+                }
+            }
+            return results;
         },
         0);
 

--- a/internal/core/unittest/test_utils.cpp
+++ b/internal/core/unittest/test_utils.cpp
@@ -90,8 +90,17 @@ TEST(Util, GetDeleteBitmap) {
     InsertRecord<false> insert_record(*schema, N);
     DeletedRecord<false> delete_record(
         &insert_record,
-        [&insert_record](const PkType& pk, Timestamp timestamp) {
-            return insert_record.search_pk(pk, timestamp);
+        [&insert_record](const std::vector<PkType>& pks,
+                         const Timestamp* timestamps) {
+            std::vector<std::pair<SegOffset, Timestamp>> results;
+            for (size_t i = 0; i < pks.size(); ++i) {
+                auto timestamp = timestamps[i];
+                auto offsets = insert_record.search_pk(pks[i], timestamp);
+                for (auto offset : offsets) {
+                    results.emplace_back(offset, timestamp);
+                }
+            }
+            return results;
         },
         0);
 


### PR DESCRIPTION
Related to #43592

When delete records are large, search pk one by one will result into many `Pincells` call which creates lots of futures.

This patch make search pk execute in batch to reduce this cost.