### PR TITLE
fix: [StorageV2] Use separate channel for `get_cells`

### DIFF
--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
@@ -203,10 +203,11 @@ GroupChunkTranslator::get_cells(const std::vector<cachinglayer::cid_t>& cids) {
         std::make_unique<ParallelDegreeSplitStrategy>(parallel_degree);
 
     auto& pool = ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::MIDDLE);
+    auto channel = std::make_shared<ArrowReaderChannel>();
 
     auto load_future = pool.Submit([&]() {
         return LoadWithStrategy(insert_files_,
-                                column_group_info_.arrow_reader_channel,
+                                channel,
                                 DEFAULT_FIELD_MAX_MEMORY_LIMIT,
                                 std::move(strategy),
                                 row_group_lists,

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
@@ -223,7 +223,7 @@ GroupChunkTranslator::get_cells(const std::vector<cachinglayer::cid_t>& cids) {
     std::shared_ptr<milvus::ArrowDataWrapper> r;
     std::unordered_set<cachinglayer::cid_t> filled_cids;
     filled_cids.reserve(cids.size());
-    while (column_group_info_.arrow_reader_channel->pop(r)) {
+    while (channel->pop(r)) {
         for (const auto& table_info : r->arrow_tables) {
             // Convert file_index and row_group_index to global cid
             auto cid = get_cid_from_file_and_row_group_index(


### PR DESCRIPTION
Related to #43584

There might be concurrent calls on `translator.get_cells`. The channel cannot be shared among these calls, otherwise the logic will break.

This patch create new channel for each `get_cells` invocation in case of data race.