### PR TITLE
enhance: Make DeleteRecord search pks by batch and PinAll

### DIFF
--- a/internal/core/src/mmap/ChunkedColumn.h
+++ b/internal/core/src/mmap/ChunkedColumn.h
@@ -311,6 +311,18 @@ class ChunkedColumnBase : public ChunkedColumnInterface {
         return PinWrapper<Chunk*>(ca, chunk);
     }
 
+    std::vector<PinWrapper<Chunk*>>
+    GetAllChunks() const override {
+        auto ca = SemiInlineGet(slot_->PinAllCells());
+        std::vector<PinWrapper<Chunk*>> ret;
+        ret.reserve(num_chunks_);
+        for (size_t i = 0; i < num_chunks_; i++) {
+            auto chunk = ca->get_cell_of(i);
+            ret.emplace_back(ca, chunk);
+        }
+        return ret;
+    }
+
     int64_t
     GetNumRowsUntilChunk(int64_t chunk_id) const override {
         return GetNumRowsUntilChunk()[chunk_id];

--- a/internal/core/src/mmap/ChunkedColumnInterface.h
+++ b/internal/core/src/mmap/ChunkedColumnInterface.h
@@ -100,6 +100,9 @@ class ChunkedColumnInterface {
     virtual PinWrapper<Chunk*>
     GetChunk(int64_t chunk_id) const = 0;
 
+    virtual std::vector<PinWrapper<Chunk*>>
+    GetAllChunks() const = 0;
+
     // Get number of rows before a specific chunk
     virtual int64_t
     GetNumRowsUntilChunk(int64_t chunk_id) const = 0;

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -204,6 +204,10 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         return true;
     }
 
+    std::vector<std::pair<SegOffset, Timestamp>>
+    search_batch_pks(const std::vector<PkType>& pks,
+                     const Timestamp* timestamps) const;
+
  public:
     int64_t
     num_chunk_index(FieldId field_id) const override;

--- a/internal/core/src/segcore/DeletedRecord.h
+++ b/internal/core/src/segcore/DeletedRecord.h
@@ -53,11 +53,12 @@ template <bool is_sealed = false>
 class DeletedRecord {
  public:
     DeletedRecord(InsertRecord<is_sealed>* insert_record,
-                  std::function<std::vector<SegOffset>(
-                      const PkType& pk, Timestamp timestamp)> search_pk_func,
+                  std::function<std::vector<std::pair<SegOffset, Timestamp>>(
+                      const std::vector<PkType>& pks,
+                      const Timestamp* timestamps)> search_pk_func,
                   int64_t segment_id)
         : insert_record_(insert_record),
-          search_pk_func_(search_pk_func),
+          search_pk_func_(std::move(search_pk_func)),
           segment_id_(segment_id),
           deleted_lists_(SortedDeleteList::createInstance()) {
     }
@@ -109,36 +110,34 @@ class DeletedRecord {
 
         SortedDeleteList::Accessor accessor(deleted_lists_);
         for (size_t i = 0; i < pks.size(); ++i) {
-            auto deleted_pk = pks[i];
             auto deleted_ts = timestamps[i];
             if (deleted_ts > max_timestamp) {
                 max_timestamp = deleted_ts;
             }
-            std::vector<SegOffset> offsets =
-                search_pk_func_(deleted_pk, deleted_ts);
-            for (auto& offset : offsets) {
-                auto row_id = offset.get();
-                // if alreay deleted, no need to add new record
-                if (deleted_mask_.size() > row_id && deleted_mask_[row_id]) {
-                    continue;
-                }
-                // if insert record and delete record is same timestamp,
-                // delete not take effect on this record.
-                if (deleted_ts == insert_record_->timestamps_[row_id]) {
-                    continue;
-                }
-                accessor.insert(std::make_pair(deleted_ts, row_id));
-                if constexpr (is_sealed) {
-                    Assert(deleted_mask_.size() > 0);
-                    deleted_mask_.set(row_id);
-                } else {
-                    // need to add mask size firstly for growing segment
-                    deleted_mask_.resize(insert_record_->size());
-                    deleted_mask_.set(row_id);
-                }
-                removed_num++;
-                mem_add += DELETE_PAIR_SIZE;
+        }
+        auto offsets = search_pk_func_(pks, timestamps);
+        for (auto& [offset, deleted_ts] : offsets) {
+            auto row_id = offset.get();
+            // if already deleted, no need to add new record
+            if (deleted_mask_.size() > row_id && deleted_mask_[row_id]) {
+                continue;
             }
+            // if insert record and delete record is same timestamp,
+            // delete not take effect on this record.
+            if (deleted_ts == insert_record_->timestamps_[row_id]) {
+                continue;
+            }
+            accessor.insert(std::make_pair(deleted_ts, row_id));
+            if constexpr (is_sealed) {
+                Assert(deleted_mask_.size() > 0);
+                deleted_mask_.set(row_id);
+            } else {
+                // need to add mask size firstly for growing segment
+                deleted_mask_.resize(insert_record_->size());
+                deleted_mask_.set(row_id);
+            }
+            removed_num++;
+            mem_add += DELETE_PAIR_SIZE;
         }
 
         n_.fetch_add(removed_num);
@@ -323,7 +322,8 @@ class DeletedRecord {
     std::atomic<int64_t> n_ = 0;
     std::atomic<int64_t> mem_size_ = 0;
     InsertRecord<is_sealed>* insert_record_;
-    std::function<std::vector<SegOffset>(const PkType& pk, Timestamp timestamp)>
+    std::function<std::vector<std::pair<SegOffset, Timestamp>>(
+        const std::vector<PkType>& pks, const Timestamp* timestamps)>
         search_pk_func_;
     int64_t segment_id_{0};
     std::shared_ptr<SortedDeleteList> deleted_lists_;

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -665,6 +665,20 @@ SegmentGrowingImpl::GetFieldDataType(milvus::FieldId field_id) const {
     return field_meta.get_data_type();
 }
 
+std::vector<std::pair<SegOffset, Timestamp>>
+SegmentGrowingImpl::search_batch_pks(const std::vector<PkType>& pks,
+                                     const Timestamp* timestamps) const {
+    std::vector<std::pair<SegOffset, Timestamp>> results;
+    for (size_t i = 0; i < pks.size(); ++i) {
+        auto timestamp = timestamps[i];
+        auto offsets = insert_record_.search_pk(pks[i], timestamp);
+        for (auto offset : offsets) {
+            results.emplace_back(offset, timestamp);
+        }
+    }
+    return results;
+}
+
 void
 SegmentGrowingImpl::vector_search(SearchInfo& search_info,
                                   const void* query_data,

--- a/internal/core/src/segcore/SegmentGrowingImpl.h
+++ b/internal/core/src/segcore/SegmentGrowingImpl.h
@@ -175,6 +175,10 @@ class SegmentGrowingImpl : public SegmentGrowing {
     void
     try_remove_chunks(FieldId fieldId);
 
+    std::vector<std::pair<SegOffset, Timestamp>>
+    search_batch_pks(const std::vector<PkType>& pks,
+                     const Timestamp* timestamps) const;
+
  public:
     size_t
     GetMemoryUsageInBytes() const override {
@@ -291,8 +295,9 @@ class SegmentGrowingImpl : public SegmentGrowing {
           id_(segment_id),
           deleted_record_(
               &insert_record_,
-              [this](const PkType& pk, Timestamp timestamp) {
-                  return this->search_pk(pk, timestamp);
+              [this](const std::vector<PkType>& pks,
+                     const Timestamp* timestamps) {
+                  return this->search_batch_pks(pks, timestamps);
               },
               segment_id) {
         this->CreateTextIndexes();

--- a/internal/core/unittest/test_delete_record.cpp
+++ b/internal/core/unittest/test_delete_record.cpp
@@ -42,8 +42,17 @@ TEST(DeleteMVCC, common_case) {
     auto segment_ptr = segment.get();
     DeletedRecord<true> delete_record(
         &insert_record,
-        [&insert_record](const PkType& pk, Timestamp timestamp) {
-            return insert_record.search_pk(pk, timestamp);
+        [&insert_record](const std::vector<PkType>& pks,
+                         const Timestamp* timestamps) {
+            std::vector<std::pair<SegOffset, Timestamp>> results;
+            for (size_t i = 0; i < pks.size(); ++i) {
+                auto timestamp = timestamps[i];
+                auto offsets = insert_record.search_pk(pks[i], timestamp);
+                for (auto offset : offsets) {
+                    results.emplace_back(offset, timestamp);
+                }
+            }
+            return results;
         },
         0);
     delete_record.set_sealed_row_count(c);
@@ -158,8 +167,17 @@ TEST(DeleteMVCC, delete_exist_duplicate_pks) {
     InsertRecord<false> insert_record(*schema, N);
     DeletedRecord<false> delete_record(
         &insert_record,
-        [&insert_record](const PkType& pk, Timestamp timestamp) {
-            return insert_record.search_pk(pk, timestamp);
+        [&insert_record](const std::vector<PkType>& pks,
+                         const Timestamp* timestamps) {
+            std::vector<std::pair<SegOffset, Timestamp>> results;
+            for (size_t i = 0; i < pks.size(); ++i) {
+                auto timestamp = timestamps[i];
+                auto offsets = insert_record.search_pk(pks[i], timestamp);
+                for (auto offset : offsets) {
+                    results.emplace_back(offset, timestamp);
+                }
+            }
+            return results;
         },
         0);
 
@@ -273,8 +291,17 @@ TEST(DeleteMVCC, snapshot) {
     InsertRecord<false> insert_record(*schema, N);
     DeletedRecord<false> delete_record(
         &insert_record,
-        [&insert_record](const PkType& pk, Timestamp timestamp) {
-            return insert_record.search_pk(pk, timestamp);
+        [&insert_record](const std::vector<PkType>& pks,
+                         const Timestamp* timestamps) {
+            std::vector<std::pair<SegOffset, Timestamp>> results;
+            for (size_t i = 0; i < pks.size(); ++i) {
+                auto timestamp = timestamps[i];
+                auto offsets = insert_record.search_pk(pks[i], timestamp);
+                for (auto offset : offsets) {
+                    results.emplace_back(offset, timestamp);
+                }
+            }
+            return results;
         },
         0);
 
@@ -321,8 +348,17 @@ TEST(DeleteMVCC, insert_after_snapshot) {
     InsertRecord<false> insert_record(*schema, N);
     DeletedRecord<false> delete_record(
         &insert_record,
-        [&insert_record](const PkType& pk, Timestamp timestamp) {
-            return insert_record.search_pk(pk, timestamp);
+        [&insert_record](const std::vector<PkType>& pks,
+                         const Timestamp* timestamps) {
+            std::vector<std::pair<SegOffset, Timestamp>> results;
+            for (size_t i = 0; i < pks.size(); ++i) {
+                auto timestamp = timestamps[i];
+                auto offsets = insert_record.search_pk(pks[i], timestamp);
+                for (auto offset : offsets) {
+                    results.emplace_back(offset, timestamp);
+                }
+            }
+            return results;
         },
         0);
 
@@ -416,8 +452,17 @@ TEST(DeleteMVCC, perform) {
     InsertRecord<false> insert_record(*schema, N);
     DeletedRecord<false> delete_record(
         &insert_record,
-        [&insert_record](const PkType& pk, Timestamp timestamp) {
-            return insert_record.search_pk(pk, timestamp);
+        [&insert_record](const std::vector<PkType>& pks,
+                         const Timestamp* timestamps) {
+            std::vector<std::pair<SegOffset, Timestamp>> results;
+            for (size_t i = 0; i < pks.size(); ++i) {
+                auto timestamp = timestamps[i];
+                auto offsets = insert_record.search_pk(pks[i], timestamp);
+                for (auto offset : offsets) {
+                    results.emplace_back(offset, timestamp);
+                }
+            }
+            return results;
         },
         0);
 

--- a/internal/core/unittest/test_utils.cpp
+++ b/internal/core/unittest/test_utils.cpp
@@ -90,8 +90,17 @@ TEST(Util, GetDeleteBitmap) {
     InsertRecord<false> insert_record(*schema, N);
     DeletedRecord<false> delete_record(
         &insert_record,
-        [&insert_record](const PkType& pk, Timestamp timestamp) {
-            return insert_record.search_pk(pk, timestamp);
+        [&insert_record](const std::vector<PkType>& pks,
+                         const Timestamp* timestamps) {
+            std::vector<std::pair<SegOffset, Timestamp>> results;
+            for (size_t i = 0; i < pks.size(); ++i) {
+                auto timestamp = timestamps[i];
+                auto offsets = insert_record.search_pk(pks[i], timestamp);
+                for (auto offset : offsets) {
+                    results.emplace_back(offset, timestamp);
+                }
+            }
+            return results;
         },
         0);
 


### PR DESCRIPTION
Related to #43592

When delete records are large, search pk one by one will result into many `Pincells` call which creates lots of futures.

This patch make search pk execute in batch to reduce this cost.

Also add `GetAllChunks` API to utilize `PinAllCells` to reduce pins.