### PR TITLE
fix: [2.5] Clean privilege cache after loading policy in InitPolicyInfo

### DIFF
--- a/internal/proxy/meta_cache.go
+++ b/internal/proxy/meta_cache.go
@@ -1091,6 +1091,7 @@ func (m *MetaCache) InitPolicyInfo(info []string, userRoles []string) {
 		if err != nil {
 			log.Error("failed to load policy after RefreshPolicyInfo", zap.Error(err))
 		}
+		CleanPrivilegeCache()
 	}()
 	m.mu.Lock()
 	defer m.mu.Unlock()


### PR DESCRIPTION
- issue: #43641
- pr: #43642