### PR TITLE
fix: [StorageV2] Align null bitmap offset for fixed-length datatype

### DIFF
--- a/internal/core/src/common/ChunkWriter.h
+++ b/internal/core/src/common/ChunkWriter.h
@@ -98,7 +98,7 @@ class ChunkWriter final : public ChunkWriterBase {
     }
 
     ChunkWriter(int dim, std::string file_path, bool nullable)
-        : ChunkWriterBase(std::move(file_path), nullable), dim_(dim) {};
+        : ChunkWriterBase(std::move(file_path), nullable), dim_(dim){};
 
     void
     write(const arrow::ArrayVector& array_vec) override {
@@ -126,16 +126,14 @@ class ChunkWriter final : public ChunkWriterBase {
         // 2. Data values: Contiguous storage of data elements in the order:
         //    data1, data2, ..., dataN where each data element has size dim_*sizeof(T)
         if (nullable_) {
+            // tuple <data, size, offset>
+            std::vector<std::tuple<const uint8_t*, int64_t, int64_t>>
+                null_bitmaps;
             for (const auto& data : array_vec) {
-                auto null_bitmap = data->null_bitmap_data();
-                auto null_bitmap_n = (data->length() + 7) / 8;
-                if (null_bitmap) {
-                    target_->write(null_bitmap, null_bitmap_n);
-                } else {
-                    std::vector<uint8_t> null_bitmap(null_bitmap_n, 0xff);
-                    target_->write(null_bitmap.data(), null_bitmap_n);
-                }
+                null_bitmaps.emplace_back(
+                    data->null_bitmap_data(), data->length(), data->offset());
             }
+            write_null_bit_maps(null_bitmaps);
         }
 
         for (const auto& data : array_vec) {
@@ -183,17 +181,13 @@ ChunkWriter<arrow::BooleanArray, bool>::write(
     }
 
     if (nullable_) {
-        // chunk layout: nullbitmap, data1, data2, ..., datan
+        // tuple <data, size, offset>
+        std::vector<std::tuple<const uint8_t*, int64_t, int64_t>> null_bitmaps;
         for (const auto& data : array_vec) {
-            auto null_bitmap = data->null_bitmap_data();
-            auto null_bitmap_n = (data->length() + 7) / 8;
-            if (null_bitmap) {
-                target_->write(null_bitmap, null_bitmap_n);
-            } else {
-                std::vector<uint8_t> null_bitmap(null_bitmap_n, 0xff);
-                target_->write(null_bitmap.data(), null_bitmap_n);
-            }
+            null_bitmaps.emplace_back(
+                data->null_bitmap_data(), data->length(), data->offset());
         }
+        write_null_bit_maps(null_bitmaps);
     }
 
     for (const auto& data : array_vec) {


### PR DESCRIPTION
Related to #43626

Similar to previous pr #43321, null bitmap could be dislocated if the bitset ptr does not count the offset of array