### PR TITLE
enhance: Ignore entry with same ts when DeleteRecord search pks

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -206,7 +206,8 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
 
     std::vector<std::pair<SegOffset, Timestamp>>
     search_batch_pks(const std::vector<PkType>& pks,
-                     const Timestamp* timestamps) const;
+                     const Timestamp* timestamps,
+                     bool include_same_ts) const;
 
  public:
     int64_t

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -667,11 +667,13 @@ SegmentGrowingImpl::GetFieldDataType(milvus::FieldId field_id) const {
 
 std::vector<std::pair<SegOffset, Timestamp>>
 SegmentGrowingImpl::search_batch_pks(const std::vector<PkType>& pks,
-                                     const Timestamp* timestamps) const {
+                                     const Timestamp* timestamps,
+                                     bool include_same_ts) const {
     std::vector<std::pair<SegOffset, Timestamp>> results;
     for (size_t i = 0; i < pks.size(); ++i) {
         auto timestamp = timestamps[i];
-        auto offsets = insert_record_.search_pk(pks[i], timestamp);
+        auto offsets =
+            insert_record_.search_pk(pks[i], timestamp, include_same_ts);
         for (auto offset : offsets) {
             results.emplace_back(offset, timestamp);
         }

--- a/internal/core/src/segcore/SegmentGrowingImpl.h
+++ b/internal/core/src/segcore/SegmentGrowingImpl.h
@@ -177,7 +177,8 @@ class SegmentGrowingImpl : public SegmentGrowing {
 
     std::vector<std::pair<SegOffset, Timestamp>>
     search_batch_pks(const std::vector<PkType>& pks,
-                     const Timestamp* timestamps) const;
+                     const Timestamp* timestamps,
+                     bool include_same_ts) const;
 
  public:
     size_t
@@ -297,7 +298,7 @@ class SegmentGrowingImpl : public SegmentGrowing {
               &insert_record_,
               [this](const std::vector<PkType>& pks,
                      const Timestamp* timestamps) {
-                  return this->search_batch_pks(pks, timestamps);
+                  return this->search_batch_pks(pks, timestamps, false);
               },
               segment_id) {
         this->CreateTextIndexes();


### PR DESCRIPTION
Related to #43660

This patch reduces the unwanted offset&ts entries having same timestamp of delete record. Under large amount of upsert, this false hit could increase large amount of memory usage while applying delete.

The next step could be passing a callback to `search_pk_func_` to handle hit entry streamingly.