### PR TITLE
fix: fix disk path sent to cachinglayer

### DIFF
--- a/internal/querynodev2/server.go
+++ b/internal/querynodev2/server.go
@@ -386,7 +386,7 @@ func (node *QueryNode) InitSegcore() error {
 	loadingMemoryFactor := C.float(paramtable.Get().QueryNodeCfg.TieredLoadingMemoryFactor.GetAsFloat())
 	overloadedMemoryThresholdPercentage := C.float(memoryMaxRatio)
 	maxDiskUsagePercentage := C.float(diskMaxRatio)
-	diskPath := C.CString(localDataRootPath)
+	diskPath := C.CString(paramtable.Get().LocalStorageCfg.Path.GetValue())
 	defer C.free(unsafe.Pointer(diskPath))
 
 	C.ConfigureTieredStorage(C.CacheWarmupPolicy(scalarFieldCacheWarmupPolicy),


### PR DESCRIPTION
`localDataRootPath` is used to init local chunk manager and has `querynode` appended to it, thus is incorrect

#41435

