### PR TITLE
fix: increment offset for invalid data rows in JsonKeyStatsInvertedIndex

### DIFF
--- a/internal/core/src/index/JsonKeyStatsInvertedIndex.cpp
+++ b/internal/core/src/index/JsonKeyStatsInvertedIndex.cpp
@@ -414,6 +414,7 @@ JsonKeyStatsInvertedIndex::BuildWithFieldData(
             auto n = data->get_num_rows();
             for (int i = 0; i < n; i++) {
                 if (!data->is_valid(i)) {
+                    offset++;
                     continue;
                 }
                 AddJson(static_cast<const milvus::Json*>(data->RawValue(i))


### PR DESCRIPTION
fix: increment offset for null data rows in JsonKeyStatsInvertedIndex
issue: https://github.com/milvus-io/milvus/issues/43151
pr:https://github.com/milvus-io/milvus/pull/43679
