### PR TITLE
 fix: make json path index non exists offsets compatible with 2.5

### DIFF
--- a/internal/core/src/exec/expression/ExistsExpr.h
+++ b/internal/core/src/exec/expression/ExistsExpr.h
@@ -52,8 +52,8 @@ class PhyExistsFilterExpr : public SegmentExpr {
                       DataType::NONE,
                       active_count,
                       batch_size,
-                      true,
-                      consistency_level),
+                      consistency_level,
+                      true),
           expr_(expr) {
     }
 

--- a/internal/core/src/index/JsonInvertedIndex.cpp
+++ b/internal/core/src/index/JsonInvertedIndex.cpp
@@ -142,9 +142,6 @@ JsonInvertedIndex<T>::LoadIndexMetas(
         return;
     }
 
-    LOG_INFO(
-        "No non_exist_offset_file found, use null_offset_ to fill "
-        "non_exist_offsets_");
     // Fallback: no non_exist_offset_file found. This occurs in two scenarios:
     // 1. Legacy v2.5.x data where non_exist_offset_file doesn't exist
     // 2. All records are valid (no invalid offsets to track)

--- a/internal/core/src/index/JsonInvertedIndex.cpp
+++ b/internal/core/src/index/JsonInvertedIndex.cpp
@@ -148,9 +148,7 @@ JsonInvertedIndex<T>::LoadIndexMetas(
     //
     // Use null_offset_ as the source for non_exist_offsets_ to maintain
     // backward compatibility. This ensures Exists() behaves like v2.5.x IsNotNull().
-    for (auto& n : this->null_offset_) {
-        non_exist_offsets_.push_back(n);
-    }
+    non_exist_offsets_ = this->null_offset_;
 }
 
 template <typename T>


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/43666