### PR TITLE
enhance: add disk file writer with Direct IO support

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -414,7 +414,7 @@ queryNode:
       subDim: 4 # interim index sub dim, recommend to (subDim % vector dim == 0)
       refineRatio: 4.5 # interim index parameters, should set to be >= 1.0
       refineQuantType: NONE # Data representation of SCANN_DVR index, options: 'NONE', 'FLOAT16', 'BFLOAT16' and 'UINT8'
-      refineWithQuant: true # whether to use refineQuantType to refine for fatser but loss a little precision
+      refineWithQuant: true # whether to use refineQuantType to refine for faster but loss a little precision
       denseVectorIndexType: IVF_FLAT_CC # Dense vector intermin index type
       memExpansionRate: 1.15 # extra memory needed by building interim index
       buildParallelRate: 0.5 # the ratio of building interim index parallel matched with cpu num
@@ -535,7 +535,7 @@ dataCoord:
     notifyChannelOperationTimeout: 5 # Timeout notifing channel operations (in seconds).
   segment:
     maxSize: 1024 # The maximum size of a segment, unit: MB. datacoord.segment.maxSize and datacoord.segment.sealProportion together determine if a segment can be sealed.
-    diskSegmentMaxSize: 2048 # Maximun size of a segment in MB for collection which has Disk index
+    diskSegmentMaxSize: 2048 # Maximum size of a segment in MB for collection which has Disk index
     sealProportion: 0.12 # The minimum proportion to datacoord.segment.maxSize to seal a segment. datacoord.segment.maxSize and datacoord.segment.sealProportion together determine if a segment can be sealed.
     sealProportionJitter: 0.1 # segment seal proportion jitter ratio, default value 0.1(10%), if seal proportion is 12%, with jitter=0.1, the actuall applied ratio will be 10.8~12%
     assignmentExpiration: 2000 # Expiration time of the segment assignment, unit: ms
@@ -574,7 +574,7 @@ dataCoord:
   # if param forceRebuildSegmentIndex is not enabled, the newly created vector index will be aligned with the newer one of index engine's version and targetVecIndexVersion.
   # if param targetVecIndexVersion is not set, the default value is -1, which means no target vec index version, then the vector index will be aligned with index engine's version 
   targetVecIndexVersion: -1
-  segmentFlushInterval: 2 # the minimal interval duration(unit: Seconds) between flusing operation on same segment
+  segmentFlushInterval: 2 # the minimal interval duration(unit: Seconds) between flushing operation on same segment
   # Switch value to control if to enable segment compaction. 
   # Compaction merges small-size segments into a large segment, and clears the entities deleted beyond the rentention duration of Time Travel.
   enableCompaction: true
@@ -593,13 +593,13 @@ dataCoord:
     maxParallelTaskNum: 10
     dropTolerance: 86400 # Compaction task will be cleaned after finish longer than this time(in seconds)
     gcInterval: 1800 # The time interval in seconds for compaction gc
-    scheduleInterval: 500 # The time interval in milliseconds for scheduling compaction tasks. If the configuration setting is below 100ms, it will be ajusted upwards to 100ms
+    scheduleInterval: 500 # The time interval in milliseconds for scheduling compaction tasks. If the configuration setting is below 100ms, it will be adjusted upwards to 100ms
     mix:
       triggerInterval: 60 # The time interval in seconds to trigger mix compaction
     levelzero:
       triggerInterval: 10 # The time interval in seconds for trigger L0 compaction
       forceTrigger:
-        minSize: 8388608 # The minmum size in bytes to force trigger a LevelZero Compaction, default as 8MB
+        minSize: 8388608 # The minimum size in bytes to force trigger a LevelZero Compaction, default as 8MB
         maxSize: 67108864 # The maxmum size in bytes to force trigger a LevelZero Compaction, default as 64MB
         deltalogMinNum: 10 # The minimum number of deltalog files to force trigger a LevelZero Compaction
         deltalogMaxNum: 30 # The maxmum number of deltalog files to force trigger a LevelZero Compaction, default as 30
@@ -856,6 +856,19 @@ common:
   # Valid values: [auto, avx512, avx2, avx, sse4_2]
   # This configuration is only used by querynode and indexnode, it selects CPU instruction set for Searching and Index-building.
   simdType: auto
+  # This parameter controls the write mode of the local disk, which is used to write temporary data downloaded from remote storage.
+  # Currently, only QueryNode uses 'common.diskWrite*' parameters. Support for other components will be added in the future.
+  # The options include 'direct' and 'buffered'. The default value is 'buffered'.
+  diskWriteMode: buffered
+  # Disk write buffer size in KB, only used when disk write mode is 'direct', default is 64KB.
+  # Current valid range is [4, 65536]. If the value is not aligned to 4KB, it will be rounded up to the nearest multiple of 4KB.
+  diskWriteBufferSizeKb: 64
+  # This parameter controls the number of writer threads used for disk write operations. The valid range is [0, hardware_concurrency].
+  # It is designed to limit the maximum concurrency of disk write operations to reduce the impact on disk read performance.
+  # For example, if you want to limit the maximum concurrency of disk write operations to 1, you can set this parameter to 1.
+  # The default value is 0, which means the caller will perform write operations directly without using an additional writer thread pool.
+  # In this case, the maximum concurrency of disk write operations is determined by the caller's thread pool size.
+  diskWriteNumThreads: 0
   security:
     authorizationEnabled: false
     # The superusers will ignore some system check processes,

--- a/internal/core/src/index/BitmapIndex.cpp
+++ b/internal/core/src/index/BitmapIndex.cpp
@@ -31,6 +31,8 @@
 #include "storage/Util.h"
 #include "query/Utils.h"
 
+#include "storage/FileWriter.h"
+
 namespace milvus {
 namespace index {
 
@@ -460,41 +462,37 @@ BitmapIndex<T>::MMapIndexData(const std::string& file_name,
     std::filesystem::create_directories(
         std::filesystem::path(file_name).parent_path());
 
-    auto file = File::Open(file_name, O_RDWR | O_CREAT | O_TRUNC);
     auto file_offset = 0;
     std::map<T, std::pair<int32_t, int32_t>> bitmaps;
+    {
+        auto file_writer = storage::FileWriter(file_name);
+        for (size_t i = 0; i < index_length; ++i) {
+            T key = ParseKey(&data_ptr);
 
-    for (size_t i = 0; i < index_length; ++i) {
-        T key = ParseKey(&data_ptr);
+            roaring::Roaring value;
+            value =
+                roaring::Roaring::read(reinterpret_cast<const char*>(data_ptr));
+            for (const auto& v : value) {
+                valid_bitset_.set(v);
+            }
 
-        roaring::Roaring value;
-        value = roaring::Roaring::read(reinterpret_cast<const char*>(data_ptr));
-        for (const auto& v : value) {
-            valid_bitset_.set(v);
+            // convert roaring vaule to frozen mode
+            int32_t frozen_size = value.getFrozenSizeInBytes();
+            auto aligned_size =
+                ((frozen_size + ALIGNMENT - 1) / ALIGNMENT) * ALIGNMENT;
+            std::vector<uint8_t> buf(aligned_size, 0);
+            value.writeFrozen(reinterpret_cast<char*>(buf.data()));
+
+            file_writer.Write(buf.data(), aligned_size);
+            bitmaps[key] = {file_offset, frozen_size};
+
+            file_offset += aligned_size;
+            data_ptr += value.getSizeInBytes();
         }
-
-        // convert roaring vaule to frozen mode
-        int32_t frozen_size = value.getFrozenSizeInBytes();
-        auto aligned_size =
-            ((frozen_size + ALIGNMENT - 1) / ALIGNMENT) * ALIGNMENT;
-        std::vector<uint8_t> buf(aligned_size, 0);
-        value.writeFrozen(reinterpret_cast<char*>(buf.data()));
-
-        auto written = file.Write(buf.data(), aligned_size);
-        if (written != aligned_size) {
-            file.Close();
-            remove(file_name.c_str());
-            PanicInfo(
-                ErrorCode::UnistdError,
-                fmt::format("write data to fd error: {}", strerror(errno)));
-        }
-        bitmaps[key] = {file_offset, frozen_size};
-
-        file_offset += aligned_size;
-        data_ptr += value.getSizeInBytes();
+        file_writer.Finish();
     }
 
-    file.Seek(0, SEEK_SET);
+    auto file = File::Open(file_name, O_RDONLY);
     mmap_data_ = static_cast<char*>(
         mmap(NULL, file_offset, PROT_READ, MAP_PRIVATE, file.Descriptor(), 0));
     if (mmap_data_ == MAP_FAILED) {

--- a/internal/core/src/index/BitmapIndex.h
+++ b/internal/core/src/index/BitmapIndex.h
@@ -24,7 +24,6 @@
 #include "common/RegexQuery.h"
 #include "index/ScalarIndex.h"
 #include "storage/FileManager.h"
-#include "storage/DiskFileManagerImpl.h"
 #include "storage/MemFileManagerImpl.h"
 
 namespace milvus {

--- a/internal/core/src/index/HybridScalarIndex.h
+++ b/internal/core/src/index/HybridScalarIndex.h
@@ -26,7 +26,6 @@
 #include "index/StringIndexMarisa.h"
 #include "index/InvertedIndexTantivy.h"
 #include "storage/FileManager.h"
-#include "storage/DiskFileManagerImpl.h"
 #include "storage/MemFileManagerImpl.h"
 
 namespace milvus {

--- a/internal/core/src/monitor/prometheus_client.cpp
+++ b/internal/core/src/monitor/prometheus_client.cpp
@@ -327,4 +327,22 @@ DEFINE_PROMETHEUS_GAUGE(internal_cgo_executing_task_total_all,
                         internal_cgo_executing_task_total,
                         {});
 
+// --- file writer metrics ---
+
+std::map<std::string, std::string> diskWriteModeBufferedLabel = {
+    {"mode", "buffered"}};
+std::map<std::string, std::string> diskWriteModeDirectLabel = {
+    {"mode", "direct"}};
+
+DEFINE_PROMETHEUS_COUNTER_FAMILY(disk_write_total_bytes,
+                                 "[cpp]disk write total bytes");
+DEFINE_PROMETHEUS_COUNTER(disk_write_total_bytes_buffered,
+                          disk_write_total_bytes,
+                          diskWriteModeBufferedLabel);
+DEFINE_PROMETHEUS_COUNTER(disk_write_total_bytes_direct,
+                          disk_write_total_bytes,
+                          diskWriteModeDirectLabel);
+
+// --- file writer metrics end ---
+
 }  // namespace milvus::monitor

--- a/internal/core/src/monitor/prometheus_client.h
+++ b/internal/core/src/monitor/prometheus_client.h
@@ -158,4 +158,12 @@ DECLARE_PROMETHEUS_GAUGE(internal_cgo_inflight_task_total_all);
 DECLARE_PROMETHEUS_GAUGE_FAMILY(internal_cgo_executing_task_total);
 DECLARE_PROMETHEUS_GAUGE(internal_cgo_executing_task_total_all);
 
+// --- file writer metrics ---
+
+DECLARE_PROMETHEUS_COUNTER_FAMILY(disk_write_total_bytes);
+DECLARE_PROMETHEUS_COUNTER(disk_write_total_bytes_buffered);
+DECLARE_PROMETHEUS_COUNTER(disk_write_total_bytes_direct);
+
+// --- file writer metrics end ---
+
 }  // namespace milvus::monitor

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -43,7 +43,6 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                                       IndexMetaPtr index_meta,
                                       const SegcoreConfig& segcore_config,
                                       int64_t segment_id,
-                                      bool TEST_skip_index_for_retrieve = false,
                                       bool is_sorted_by_pk = false);
     ~ChunkedSegmentSealedImpl() override;
     void
@@ -426,10 +425,6 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         vec_binlog_config_;
 
     SegmentStats stats_{};
-
-    // for sparse vector unit test only! Once a type of sparse index that
-    // doesn't has raw data is added, this should be removed.
-    bool TEST_skip_index_for_retrieve_ = false;
 
     // whether the segment is sorted by the pk
     bool is_sorted_by_pk_ = false;

--- a/internal/core/src/segcore/SegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/SegmentSealedImpl.cpp
@@ -1057,7 +1057,7 @@ SegmentSealedImpl::get_vector(FieldId field_id,
     auto metric_type = vec_index->GetMetricType();
     auto has_raw_data = vec_index->HasRawData();
 
-    if (has_raw_data && !TEST_skip_index_for_retrieve_) {
+    if (has_raw_data) {
         // If index has raw data, get vector from memory.
         auto ids_ds = GenIdsDataset(count, ids);
         if (field_meta.get_data_type() == DataType::VECTOR_SPARSE_FLOAT) {
@@ -1234,7 +1234,6 @@ SegmentSealedImpl::SegmentSealedImpl(SchemaPtr schema,
                                      IndexMetaPtr index_meta,
                                      const SegcoreConfig& segcore_config,
                                      int64_t segment_id,
-                                     bool TEST_skip_index_for_retrieve,
                                      bool is_sorted_by_pk)
     : segcore_config_(segcore_config),
       field_data_ready_bitset_(schema->size()),
@@ -1245,7 +1244,6 @@ SegmentSealedImpl::SegmentSealedImpl(SchemaPtr schema,
       schema_(schema),
       id_(segment_id),
       col_index_meta_(index_meta),
-      TEST_skip_index_for_retrieve_(TEST_skip_index_for_retrieve),
       is_sorted_by_pk_(is_sorted_by_pk),
       deleted_record_(&insert_record_, this) {
     mmap_descriptor_ = std::shared_ptr<storage::MmapChunkDescriptor>(

--- a/internal/core/src/segcore/SegmentSealedImpl.h
+++ b/internal/core/src/segcore/SegmentSealedImpl.h
@@ -46,7 +46,6 @@ class SegmentSealedImpl : public SegmentSealed {
                                IndexMetaPtr index_meta,
                                const SegcoreConfig& segcore_config,
                                int64_t segment_id,
-                               bool TEST_skip_index_for_retrieve = false,
                                bool is_sorted_by_pk = false);
     ~SegmentSealedImpl() override;
     void
@@ -420,10 +419,6 @@ class SegmentSealedImpl : public SegmentSealed {
 
     SegmentStats stats_{};
 
-    // for sparse vector unit test only! Once a type of sparse index that
-    // doesn't has raw data is added, this should be removed.
-    bool TEST_skip_index_for_retrieve_ = false;
-
     // whether the segment is sorted by the pk
     bool is_sorted_by_pk_ = false;
 
@@ -439,24 +434,14 @@ CreateSealedSegment(
     IndexMetaPtr index_meta = nullptr,
     int64_t segment_id = 0,
     const SegcoreConfig& segcore_config = SegcoreConfig::default_config(),
-    bool TEST_skip_index_for_retrieve = false,
     bool is_sorted_by_pk = false,
     bool is_multi_chunk = false) {
     if (!is_multi_chunk) {
-        return std::make_unique<SegmentSealedImpl>(schema,
-                                                   index_meta,
-                                                   segcore_config,
-                                                   segment_id,
-                                                   TEST_skip_index_for_retrieve,
-                                                   is_sorted_by_pk);
+        return std::make_unique<SegmentSealedImpl>(
+            schema, index_meta, segcore_config, segment_id, is_sorted_by_pk);
     } else {
         return std::make_unique<ChunkedSegmentSealedImpl>(
-            schema,
-            index_meta,
-            segcore_config,
-            segment_id,
-            TEST_skip_index_for_retrieve,
-            is_sorted_by_pk);
+            schema, index_meta, segcore_config, segment_id, is_sorted_by_pk);
     }
 }
 

--- a/internal/core/src/segcore/Utils.cpp
+++ b/internal/core/src/segcore/Utils.cpp
@@ -21,7 +21,6 @@
 #include "common/FieldData.h"
 #include "common/Types.h"
 #include "index/ScalarIndex.h"
-#include "mmap/Utils.h"
 #include "log/Log.h"
 #include "storage/DataCodec.h"
 #include "storage/RemoteChunkManagerSingleton.h"

--- a/internal/core/src/segcore/segment_c.cpp
+++ b/internal/core/src/segcore/segment_c.cpp
@@ -60,7 +60,6 @@ NewSegment(CCollection collection,
                     col->get_index_meta(),
                     segment_id,
                     milvus::segcore::SegcoreConfig::default_config(),
-                    false,
                     is_sorted_by_pk,
                     false);
                 break;
@@ -70,7 +69,6 @@ NewSegment(CCollection collection,
                     col->get_index_meta(),
                     segment_id,
                     milvus::segcore::SegcoreConfig::default_config(),
-                    false,
                     is_sorted_by_pk,
                     true);
                 break;

--- a/internal/core/src/storage/ChunkCache.cpp
+++ b/internal/core/src/storage/ChunkCache.cpp
@@ -80,12 +80,10 @@ ChunkCache::Read(const std::string& filepath,
             auto dir = path.parent_path();
             std::filesystem::create_directories(dir);
 
-            auto file = File::Open(path.string(), O_CREAT | O_TRUNC | O_RDWR);
             chunk = create_chunk(
-                field_meta, dim, file, 0, field_data->GetReader()->reader);
+                field_meta, field_data->GetReader()->reader, path.string());
         } else {
-            chunk =
-                create_chunk(field_meta, dim, field_data->GetReader()->reader);
+            chunk = create_chunk(field_meta, field_data->GetReader()->reader);
         }
 
         auto data_type = field_meta.get_data_type();

--- a/internal/core/src/storage/DiskFileManagerImpl.cpp
+++ b/internal/core/src/storage/DiskFileManagerImpl.cpp
@@ -43,6 +43,7 @@
 #include "storage/LocalChunkManagerSingleton.h"
 #include "storage/ThreadPools.h"
 #include "storage/Util.h"
+#include "storage/FileWriter.h"
 
 namespace milvus::storage {
 DiskFileManagerImpl::DiskFileManagerImpl(
@@ -122,7 +123,6 @@ DiskFileManagerImpl::AddFileInternal(
             AddBatchIndexFiles(file,
                                local_file_offsets,
                                batch_remote_files,
-
                                remote_file_sizes);
             batch_remote_files.clear();
             remote_file_sizes.clear();
@@ -224,7 +224,7 @@ DiskFileManagerImpl::AddBatchIndexFiles(
 void
 DiskFileManagerImpl::CacheIndexToDiskInternal(
     const std::vector<std::string>& remote_files,
-    const std::function<std::string()>& get_local_index_prefix) {
+    const std::string& local_index_prefix) {
     auto local_chunk_manager =
         LocalChunkManagerSingleton::GetInstance().GetChunkManager();
 
@@ -250,11 +250,8 @@ DiskFileManagerImpl::CacheIndexToDiskInternal(
     for (auto& slices : index_slices) {
         auto prefix = slices.first;
         auto local_index_file_name =
-            get_local_index_prefix() +
-            prefix.substr(prefix.find_last_of('/') + 1);
+            local_index_prefix + prefix.substr(prefix.find_last_of('/') + 1);
         local_chunk_manager->CreateFile(local_index_file_name);
-        auto file =
-            File::Open(local_index_file_name, O_CREAT | O_RDWR | O_TRUNC);
 
         // Get the remote files
         std::vector<std::string> batch_remote_files;
@@ -263,28 +260,31 @@ DiskFileManagerImpl::CacheIndexToDiskInternal(
         uint64_t max_parallel_degree =
             uint64_t(DEFAULT_FIELD_MAX_MEMORY_LIMIT / FILE_SLICE_SIZE);
 
-        auto appendIndexFiles = [&]() {
-            auto index_chunks_futures =
-                GetObjectData(rcm_.get(), batch_remote_files);
-            for (auto& chunk_future : index_chunks_futures) {
-                auto chunk_codec = chunk_future.get();
-                file.Write(chunk_codec->PayloadData(),
-                           chunk_codec->PayloadSize());
+        {
+            auto file_writer = storage::FileWriter(local_index_file_name);
+            auto appendIndexFiles = [&]() {
+                auto index_chunks_futures =
+                    GetObjectData(rcm_.get(), batch_remote_files);
+                for (auto& chunk_future : index_chunks_futures) {
+                    auto chunk_codec = chunk_future.get();
+                    file_writer.Write(chunk_codec->PayloadData(),
+                                      chunk_codec->PayloadSize());
+                }
+                batch_remote_files.clear();
+            };
+            for (int& iter : slices.second) {
+                auto origin_file = prefix + "_" + std::to_string(iter);
+                batch_remote_files.push_back(origin_file);
+                if (batch_remote_files.size() == max_parallel_degree) {
+                    appendIndexFiles();
+                }
             }
-            batch_remote_files.clear();
-        };
-
-        for (int& iter : slices.second) {
-            auto origin_file = prefix + "_" + std::to_string(iter);
-            batch_remote_files.push_back(origin_file);
-
-            if (batch_remote_files.size() == max_parallel_degree) {
+            if (batch_remote_files.size() > 0) {
                 appendIndexFiles();
             }
+            file_writer.Finish();
         }
-        if (batch_remote_files.size() > 0) {
-            appendIndexFiles();
-        }
+
         local_paths_.emplace_back(local_index_file_name);
     }
 }
@@ -292,22 +292,19 @@ DiskFileManagerImpl::CacheIndexToDiskInternal(
 void
 DiskFileManagerImpl::CacheIndexToDisk(
     const std::vector<std::string>& remote_files) {
-    return CacheIndexToDiskInternal(
-        remote_files, [this]() { return GetLocalIndexObjectPrefix(); });
+    return CacheIndexToDiskInternal(remote_files, GetLocalIndexObjectPrefix());
 }
 
 void
 DiskFileManagerImpl::CacheTextLogToDisk(
     const std::vector<std::string>& remote_files) {
-    return CacheIndexToDiskInternal(
-        remote_files, [this]() { return GetLocalTextIndexPrefix(); });
+    return CacheIndexToDiskInternal(remote_files, GetLocalTextIndexPrefix());
 }
 
 void
 DiskFileManagerImpl::CacheJsonKeyIndexToDisk(
     const std::vector<std::string>& remote_files) {
-    return CacheIndexToDiskInternal(
-        remote_files, [this]() { return GetLocalJsonKeyIndexPrefix(); });
+    return CacheIndexToDiskInternal(remote_files, GetLocalJsonKeyIndexPrefix());
 }
 
 template <typename DataType>

--- a/internal/core/src/storage/DiskFileManagerImpl.h
+++ b/internal/core/src/storage/DiskFileManagerImpl.h
@@ -157,9 +157,8 @@ class DiskFileManagerImpl : public FileManagerImpl {
                         get_remote_path) noexcept;
 
     void
-    CacheIndexToDiskInternal(
-        const std::vector<std::string>& remote_files,
-        const std::function<std::string()>& get_local_index_prefix);
+    CacheIndexToDiskInternal(const std::vector<std::string>& remote_files,
+                             const std::string& local_index_prefix);
 
  private:
     // local file path (abs path)

--- a/internal/core/src/storage/FileWriter.cpp
+++ b/internal/core/src/storage/FileWriter.cpp
@@ -1,0 +1,347 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <utility>
+#include "folly/futures/Future.h"
+#include "monitor/prometheus_client.h"
+#include "storage/FileWriter.h"
+
+namespace milvus::storage {
+
+FileWriter::FileWriter(std::string filename) : filename_(std::move(filename)) {
+    auto mode = GetMode();
+    use_direct_io_ = mode == WriteMode::DIRECT;
+    auto open_flags = O_CREAT | O_RDWR | O_TRUNC;
+    if (use_direct_io_) {
+        // check if the file is aligned to the alignment size
+        size_t buf_size = GetBufferSize();
+        AssertInfo(
+            buf_size != 0 && (buf_size % ALIGNMENT_BYTES) == 0,
+            "Buffer size must be greater than 0 and aligned to the alignment "
+            "size, buf_size: {}, alignment size: {}, error: {}",
+            buf_size,
+            ALIGNMENT_BYTES,
+            strerror(errno));
+        capacity_ = buf_size;
+        auto err = posix_memalign(&aligned_buf_, ALIGNMENT_BYTES, capacity_);
+        if (err != 0) {
+            aligned_buf_ = nullptr;
+            PanicInfo(
+                ErrorCode::MemAllocateFailed,
+                "Failed to allocate aligned buffer for direct io, error: {}",
+                strerror(err));
+        }
+#ifndef __APPLE__
+        open_flags |= O_DIRECT;
+#endif
+    }
+
+    fd_ = open(filename_.c_str(), open_flags, S_IRUSR | S_IWUSR);
+    if (fd_ == -1) {
+        Cleanup();
+        PanicInfo(ErrorCode::FileCreateFailed,
+                  "Failed to open file: {}, error: {}",
+                  filename_,
+                  strerror(errno));
+    }
+
+#ifdef __APPLE__
+    if (use_direct_io_) {
+        auto ret = fcntl(fd_, F_NOCACHE, 1);
+        if (ret == -1) {
+            Cleanup();
+            PanicInfo(ErrorCode::FileCreateFailed,
+                      "Failed to set F_NOCACHE on file: {}, error: {}",
+                      filename_,
+                      strerror(errno));
+        }
+    }
+#endif
+}
+
+FileWriter::~FileWriter() {
+    Cleanup();
+}
+
+void
+FileWriter::Cleanup() noexcept {
+    if (fd_ != -1) {
+        close(fd_);
+        fd_ = -1;
+    }
+    if (use_direct_io_) {
+        free(aligned_buf_);
+        aligned_buf_ = nullptr;
+    }
+}
+
+bool
+FileWriter::PositionedWrite(const void* data,
+                            size_t nbyte,
+                            size_t file_offset) {
+    const char* src = static_cast<const char*>(data);
+    size_t left = nbyte;
+
+    while (left != 0) {
+        ssize_t done = pwrite(fd_, src, left, file_offset);
+        if (done < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            return false;
+        }
+        left -= done;
+        file_offset += done;
+        src += done;
+    }
+
+    return true;
+}
+
+void
+FileWriter::PositionedWriteWithCheck(const void* data,
+                                     size_t nbyte,
+                                     size_t file_offset) {
+    if (!PositionedWrite(data, nbyte, file_offset)) {
+        Cleanup();
+        PanicInfo(ErrorCode::FileWriteFailed,
+                  "Failed to write to file: {}, error: {}",
+                  filename_,
+                  strerror(errno));
+    }
+}
+
+void
+FileWriter::WriteWithDirectIO(const void* data, size_t nbyte) {
+    const char* src = static_cast<const char*>(data);
+    // if the data can fit in the aligned buffer, we can just copy it to the aligned buffer
+    if (offset_ + nbyte <= capacity_) {
+        memcpy(static_cast<char*>(aligned_buf_) + offset_, src, nbyte);
+        offset_ += nbyte;
+        return;
+    }
+    size_t left_size = nbyte;
+
+    // we should fill and handle the cached aligned buffer first
+    if (offset_ != 0) {
+        size_t cpy_size = capacity_ - offset_;
+        memcpy(static_cast<char*>(aligned_buf_) + offset_, src, cpy_size);
+        PositionedWriteWithCheck(aligned_buf_, capacity_, file_size_);
+        file_size_ += capacity_;
+        left_size -= cpy_size;
+        src += cpy_size;
+        offset_ = 0;
+    }
+
+    // if the left data is aligned, we can just write it to the file and only save the tail to the aligned buffer
+    // it will save the time of memcpy
+    if (reinterpret_cast<uintptr_t>(src) % ALIGNMENT_BYTES == 0) {
+        size_t aligned_left_size = left_size & ~ALIGNMENT_MASK;
+        left_size -= aligned_left_size;
+        while (aligned_left_size != 0) {
+            size_t bytes_written = std::min(aligned_left_size, capacity_);
+            PositionedWriteWithCheck(src, bytes_written, file_size_);
+            file_size_ += bytes_written;
+            aligned_left_size -= bytes_written;
+            src += bytes_written;
+        }
+    }
+
+    // finally, handle the left unaligned data by the aligned buffer
+    while (left_size >= capacity_) {
+        size_t copy_size = capacity_ - offset_;
+        memcpy(static_cast<char*>(aligned_buf_) + offset_, src, copy_size);
+        PositionedWriteWithCheck(aligned_buf_, capacity_, file_size_);
+        file_size_ += capacity_;
+        offset_ = 0;
+        left_size -= copy_size;
+        src += copy_size;
+    }
+
+    // save the tail to the aligned buffer
+    if (left_size > 0) {
+        memcpy(static_cast<char*>(aligned_buf_) + offset_, src, left_size);
+        offset_ += left_size;
+        src += left_size;
+    }
+
+    assert(src == static_cast<const char*>(data) + nbyte);
+
+    monitor::disk_write_total_bytes_direct.Increment(nbyte);
+}
+
+void
+FileWriter::WriteWithBufferedIO(const void* data, size_t nbyte) {
+    PositionedWriteWithCheck(data, nbyte, file_size_);
+    file_size_ += nbyte;
+    monitor::disk_write_total_bytes_buffered.Increment(nbyte);
+}
+
+void
+FileWriter::Write(const void* data, size_t nbyte) {
+    AssertInfo(fd_ != -1, "FileWriter is not initialized or finished");
+    if (nbyte == 0) {
+        return;
+    }
+
+    auto promise = std::make_shared<folly::Promise<folly::Unit>>();
+    auto future = promise->getFuture();
+    auto task = [this, data, nbyte, promise]() {
+        try {
+            if (use_direct_io_) {
+                WriteWithDirectIO(data, nbyte);
+            } else {
+                WriteWithBufferedIO(data, nbyte);
+            }
+            promise->setValue(folly::Unit{});
+        } catch (...) {
+            promise->setException(
+                folly::exception_wrapper(std::current_exception()));
+        }
+    };
+
+    if (FileWriteWorkerPool::GetInstance().AddTask(task)) {
+        try {
+            future.wait();
+        } catch (const std::exception& e) {
+            Cleanup();
+            PanicInfo(ErrorCode::FileWriteFailed,
+                      "Failed to write to file: {}, error: {}",
+                      filename_,
+                      e.what());
+        }
+    } else {
+        if (use_direct_io_) {
+            WriteWithDirectIO(data, nbyte);
+        } else {
+            WriteWithBufferedIO(data, nbyte);
+        }
+    }
+}
+
+void
+FileWriter::FlushWithDirectIO() {
+    size_t nearest_aligned_offset =
+        (offset_ + ALIGNMENT_MASK) & ~ALIGNMENT_MASK;
+    memset(static_cast<char*>(aligned_buf_) + offset_,
+           0,
+           nearest_aligned_offset - offset_);
+    PositionedWriteWithCheck(aligned_buf_, nearest_aligned_offset, file_size_);
+    file_size_ += offset_;
+    monitor::disk_write_total_bytes_direct.Increment(offset_);
+    // truncate the file to the actual size since the file written by the aligned buffer may be larger than the actual size
+    if (ftruncate(fd_, file_size_) != 0) {
+        Cleanup();
+        PanicInfo(ErrorCode::FileWriteFailed,
+                  "Failed to truncate file: {}, error: {}",
+                  filename_,
+                  strerror(errno));
+    }
+    offset_ = 0;
+}
+
+size_t
+FileWriter::Finish() {
+    AssertInfo(fd_ != -1, "FileWriter is not initialized or finished");
+
+    // if the aligned buffer is not empty, we should flush it to the file
+    if (offset_ != 0) {
+        auto promise = std::make_shared<folly::Promise<folly::Unit>>();
+        auto future = promise->getFuture();
+        auto task = [this, promise]() {
+            try {
+                if (use_direct_io_) {
+                    FlushWithDirectIO();
+                }
+                promise->setValue(folly::Unit{});
+            } catch (...) {
+                promise->setException(
+                    folly::exception_wrapper(std::current_exception()));
+            }
+        };
+
+        if (FileWriteWorkerPool::GetInstance().AddTask(task)) {
+            try {
+                future.wait();
+            } catch (const std::exception& e) {
+                Cleanup();
+                PanicInfo(ErrorCode::FileWriteFailed,
+                          "Failed to flush file: {}, error: {}",
+                          filename_,
+                          e.what());
+            }
+        } else {
+            if (use_direct_io_) {
+                FlushWithDirectIO();
+            }
+        }
+    }
+
+    // clean up the file writer
+    Cleanup();
+
+    // return the file size
+    return file_size_;
+}
+
+FileWriter::WriteMode FileWriter::mode_ = FileWriter::WriteMode::BUFFERED;
+size_t FileWriter::buffer_size_ = DEFAULT_BUFFER_SIZE;
+
+void
+FileWriter::SetMode(WriteMode mode) {
+    if (mode != WriteMode::BUFFERED && mode != WriteMode::DIRECT) {
+        LOG_WARN(
+            "Invalid write mode: {}, expected: BUFFERED or DIRECT, "
+            "set to BUFFERED",
+            static_cast<int>(mode));
+        mode = WriteMode::BUFFERED;
+    }
+    mode_ = mode;
+    LOG_INFO("Set write mode to {}", static_cast<uint8_t>(mode));
+}
+
+void
+FileWriter::SetBufferSize(size_t buffer_size) {
+    if (buffer_size > MAX_BUFFER_SIZE) {
+        LOG_WARN("Invalid buffer size: {}, expected: <= {}, set to {}",
+                 buffer_size,
+                 MAX_BUFFER_SIZE,
+                 MAX_BUFFER_SIZE);
+        buffer_size = MAX_BUFFER_SIZE;
+    } else if (buffer_size < MIN_BUFFER_SIZE) {
+        LOG_WARN("Invalid buffer size: {}, expected: >= {}, set to {}",
+                 buffer_size,
+                 MIN_BUFFER_SIZE,
+                 MIN_BUFFER_SIZE);
+        buffer_size = MIN_BUFFER_SIZE;
+    } else {
+        buffer_size = (buffer_size + ALIGNMENT_MASK) & ~ALIGNMENT_MASK;
+    }
+    buffer_size_ = buffer_size;
+    LOG_INFO("Set buffer size to {}", buffer_size);
+}
+
+FileWriter::WriteMode
+FileWriter::GetMode() {
+    return mode_;
+}
+
+size_t
+FileWriter::GetBufferSize() {
+    return buffer_size_;
+}
+
+}  // namespace milvus::storage

--- a/internal/core/src/storage/FileWriter.h
+++ b/internal/core/src/storage/FileWriter.h
@@ -1,0 +1,198 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cassert>
+#include <stdexcept>
+#include <string>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <cstring>
+#include <thread>
+#include <folly/executors/CPUThreadPoolExecutor.h>
+
+#include "common/EasyAssert.h"
+#include "storage/PayloadWriter.h"
+#include "storage/ThreadPools.h"
+
+namespace milvus::storage {
+
+/**
+ * FileWriter is a class that sequentially writes data to new files, designed specifically for saving temporary data downloaded from remote storage.
+ * It supports both buffered and direct I/O, and can use an additional thread pool to write data to files.
+ * FileWriter is not thread-safe, so you should take care of the thread safety when using the same FileWriter object in multiple threads.
+ * For now, only QueryNode uses FileWriter to write data to files. If you want to use it in DataNode, you need to add it to the configuration.
+ *
+ * The basic usage is:
+ *
+ * auto file_writer = FileWriter("path/to/file");
+ * file_writer.Write(data, size);
+ * ...
+ * file_writer.Write(data, size);
+ * file_writer.Finish();
+ */
+class FileWriter {
+ public:
+    enum class WriteMode : uint8_t { BUFFERED = 0, DIRECT = 1 };
+
+    static constexpr size_t ALIGNMENT_BYTES = 4096;
+    static constexpr size_t ALIGNMENT_MASK = ALIGNMENT_BYTES - 1;
+    static constexpr size_t MAX_BUFFER_SIZE = 64 * 1024 * 1024;  // 64MB
+    static constexpr size_t MIN_BUFFER_SIZE = 4 * 1024;          // 4KB
+    static constexpr size_t DEFAULT_BUFFER_SIZE = 64 * 1024;     // 64KB
+
+    explicit FileWriter(std::string filename);
+
+    ~FileWriter();
+
+    void
+    Write(const void* data, size_t size);
+
+    size_t
+    Finish();
+
+    // static functions for global configuration
+    static void
+    SetMode(WriteMode mode);
+
+    static void
+    SetBufferSize(size_t buffer_size);
+
+    static WriteMode
+    GetMode();
+
+    static size_t
+    GetBufferSize();
+
+ private:
+    void
+    WriteWithDirectIO(const void* data, size_t nbyte);
+
+    void
+    WriteWithBufferedIO(const void* data, size_t nbyte);
+
+    void
+    FlushWithDirectIO();
+
+    void
+    FlushWithBufferedIO();
+
+    bool
+    PositionedWrite(const void* data, size_t nbyte, size_t file_offset);
+
+    void
+    PositionedWriteWithCheck(const void* data,
+                             size_t nbyte,
+                             size_t file_offset);
+
+    void
+    Cleanup() noexcept;
+
+    int fd_{-1};
+    std::string filename_{""};
+    size_t file_size_{0};
+
+    // for direct io
+    bool use_direct_io_{false};
+    void* aligned_buf_{nullptr};
+    size_t capacity_{0};
+    size_t offset_{0};
+
+    // for global configuration
+    static WriteMode
+        mode_;  // The write mode, which can be 'buffered' (default) or 'direct'.
+    static size_t
+        buffer_size_;  // The buffer size used for direct I/O, which is only used when the write mode is 'direct'.
+};
+
+class FileWriteWorkerPool {
+ public:
+    FileWriteWorkerPool() = default;
+
+    static FileWriteWorkerPool&
+    GetInstance() {
+        static FileWriteWorkerPool instance;
+        return instance;
+    }
+
+    static void
+    Configure(int nr_worker) {
+        auto& instance = GetInstance();
+        instance.SetWorker(nr_worker);
+    }
+
+    void
+    SetWorker(int nr_worker) {
+        if (nr_worker < 0) {
+            LOG_WARN(
+                "Invalid number of worker, expected: > 0, got: {}, "
+                "set to 0",
+                nr_worker);
+            nr_worker = 0;
+        } else if (nr_worker > std::thread::hardware_concurrency()) {
+            LOG_WARN(
+                "Invalid number of worker, expected: <= {}, got: {}, "
+                "set to {}",
+                std::thread::hardware_concurrency(),
+                nr_worker,
+                std::thread::hardware_concurrency());
+            nr_worker = std::thread::hardware_concurrency();
+        }
+        std::shared_ptr<folly::CPUThreadPoolExecutor> old_executor = nullptr;
+        {
+            std::lock_guard<std::mutex> lock(executor_mutex_);
+            old_executor = executor_;
+            if (nr_worker > 0) {
+                executor_ =
+                    std::make_shared<folly::CPUThreadPoolExecutor>(nr_worker);
+            } else {
+                executor_ = nullptr;
+            }
+        }
+        if (old_executor != nullptr) {
+            old_executor->stop();
+            old_executor->join();
+        }
+        LOG_INFO("Set the number of write worker to {}", nr_worker);
+    }
+
+    bool
+    AddTask(std::function<void()> task) {
+        if (executor_ == nullptr) {
+            return false;
+        }
+        std::lock_guard<std::mutex> lock(executor_mutex_);
+        executor_->add(std::move(task));
+        return true;
+    }
+
+    ~FileWriteWorkerPool() {
+        if (executor_ != nullptr) {
+            executor_->stop();
+            executor_->join();
+            executor_ = nullptr;
+        }
+    }
+
+ private:
+    std::shared_ptr<folly::CPUThreadPoolExecutor> executor_{nullptr};
+    std::mutex executor_mutex_{};
+};
+
+}  // namespace milvus::storage

--- a/internal/core/src/storage/storage_c.cpp
+++ b/internal/core/src/storage/storage_c.cpp
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 #include "storage/storage_c.h"
+#include "storage/FileWriter.h"
 #include "monitor/prometheus_client.h"
 #include "storage/RemoteChunkManagerSingleton.h"
 #include "storage/LocalChunkManagerSingleton.h"
@@ -107,6 +108,34 @@ InitMmapManager(CMmapConfig c_mmap_config) {
         mmap_config.vector_field_enable_mmap =
             c_mmap_config.vector_field_enable_mmap;
         milvus::storage::MmapManager::GetInstance().Init(mmap_config);
+        return milvus::SuccessCStatus();
+    } catch (std::exception& e) {
+        return milvus::FailureCStatus(&e);
+    }
+}
+
+CStatus
+InitFileWriterConfig(const char* mode,
+                     uint64_t buffer_size_kb,
+                     int nr_threads) {
+    try {
+        std::string mode_str(mode);
+        if (mode_str == "direct") {
+            milvus::storage::FileWriter::SetMode(
+                milvus::storage::FileWriter::WriteMode::DIRECT);
+            // buffer size checking is done in FileWriter::SetBufferSize,
+            // and it will try to find a proper and valid buffer size
+            milvus::storage::FileWriter::SetBufferSize(
+                buffer_size_kb * 1024);  // convert to bytes
+        } else if (mode_str == "buffered") {
+            milvus::storage::FileWriter::SetMode(
+                milvus::storage::FileWriter::WriteMode::BUFFERED);
+        } else {
+            return milvus::FailureCStatus(milvus::ConfigInvalid,
+                                          "Invalid mode");
+        }
+        milvus::storage::FileWriteWorkerPool::GetInstance().Configure(
+            nr_threads);
         return milvus::SuccessCStatus();
     } catch (std::exception& e) {
         return milvus::FailureCStatus(&e);

--- a/internal/core/src/storage/storage_c.h
+++ b/internal/core/src/storage/storage_c.h
@@ -42,6 +42,9 @@ ResizeTheadPool(int64_t priority, float ratio);
 void
 ShutDownThreadPools();
 
+CStatus
+InitFileWriterConfig(const char* mode, uint64_t buffer_size_kb, int nr_threads);
+
 #ifdef __cplusplus
 };
 #endif

--- a/internal/core/unittest/CMakeLists.txt
+++ b/internal/core/unittest/CMakeLists.txt
@@ -47,6 +47,7 @@ set(MILVUS_TEST_FILES
         test_exec.cpp
         test_expr.cpp
         test_expr_materialized_view.cpp
+        test_file_writer.cpp
         test_float16.cpp
         test_function.cpp
         test_futures.cpp

--- a/internal/core/unittest/test_chunked_segment.cpp
+++ b/internal/core/unittest/test_chunked_segment.cpp
@@ -179,7 +179,6 @@ class TestChunkSegment : public testing::Test {
             nullptr,
             -1,
             segcore::SegcoreConfig::default_config(),
-            false,
             true,
             true);
         test_data_count = 10000;

--- a/internal/core/unittest/test_expr.cpp
+++ b/internal/core/unittest/test_expr.cpp
@@ -3463,7 +3463,7 @@ TEST_P(ExprTest, test_term_pk_with_sorted) {
     schema->set_primary_field_id(int64_fid);
 
     auto seg = CreateSealedSegment(
-        schema, nullptr, 1, SegcoreConfig::default_config(), false, true);
+        schema, nullptr, 1, SegcoreConfig::default_config(), true);
     int N = 100000;
     auto raw_data = DataGen(schema, N);
 

--- a/internal/core/unittest/test_file_writer.cpp
+++ b/internal/core/unittest/test_file_writer.cpp
@@ -1,0 +1,924 @@
+// Copyright (C) 2019-2025 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <filesystem>
+#include <fstream>
+#include <random>
+#include <thread>
+
+#include "storage/FileWriter.h"
+
+using namespace milvus;
+using namespace milvus::storage;
+
+class FileWriterTest : public testing::Test {
+ protected:
+    void
+    SetUp() override {
+        test_dir_ = std::filesystem::temp_directory_path() / "file_writer_test";
+        std::filesystem::create_directories(test_dir_);
+    }
+
+    void
+    TearDown() override {
+        std::filesystem::remove_all(test_dir_);
+    }
+
+    std::filesystem::path test_dir_;
+    const size_t kBufferSize = 4096;  // 4KB buffer size
+};
+
+// Test basic file writing functionality with buffered IO
+TEST_F(FileWriterTest, BasicWriteWithBufferedIO) {
+    FileWriter::SetMode(FileWriter::WriteMode::BUFFERED);
+
+    std::string filename = (test_dir_ / "basic_write.txt").string();
+    FileWriter writer(filename);
+
+    std::string test_data = "Hello, World!";
+    writer.Write(test_data.data(), test_data.size());
+    writer.Finish();
+
+    // Verify file contents
+    std::ifstream file(filename, std::ios::binary);
+    std::string content((std::istreambuf_iterator<char>(file)),
+                        std::istreambuf_iterator<char>());
+    EXPECT_EQ(content, test_data);
+}
+
+// Test basic file writing functionality with direct IO
+TEST_F(FileWriterTest, BasicWriteWithDirectIO) {
+    FileWriter::SetMode(FileWriter::WriteMode::DIRECT);
+    FileWriter::SetBufferSize(kBufferSize);
+
+    std::string filename = (test_dir_ / "basic_write.txt").string();
+    FileWriter writer(filename);
+
+    std::string test_data = "Hello, World!";
+    writer.Write(test_data.data(), test_data.size());
+    writer.Finish();
+
+    // Verify file contents
+    std::ifstream file(filename, std::ios::binary);
+    std::string content((std::istreambuf_iterator<char>(file)),
+                        std::istreambuf_iterator<char>());
+    EXPECT_EQ(content, test_data);
+}
+
+// Test writing data with size exactly equal to buffer size
+TEST_F(FileWriterTest, ExactBufferSizeWriteWithDirectIO) {
+    FileWriter::SetMode(FileWriter::WriteMode::DIRECT);
+    FileWriter::SetBufferSize(kBufferSize);
+
+    std::string filename = (test_dir_ / "exact_buffer.txt").string();
+    FileWriter writer(filename);
+
+    std::vector<char> exact_buffer_data(kBufferSize);
+    std::generate(
+        exact_buffer_data.begin(), exact_buffer_data.end(), std::rand);
+
+    writer.Write(exact_buffer_data.data(), exact_buffer_data.size());
+    writer.Finish();
+
+    std::ifstream file(filename, std::ios::binary);
+    std::vector<char> read_data((std::istreambuf_iterator<char>(file)),
+                                std::istreambuf_iterator<char>());
+    EXPECT_EQ(read_data, exact_buffer_data);
+}
+
+// Test writing data size with multiple of buffer size
+TEST_F(FileWriterTest, MultipleOfBufferSizeWriteWithDirectIO) {
+    FileWriter::SetMode(FileWriter::WriteMode::DIRECT);
+    FileWriter::SetBufferSize(kBufferSize);
+
+    std::string filename = (test_dir_ / "multiple_of_buffer_size.txt").string();
+    FileWriter writer(filename);
+
+    std::vector<char> data(kBufferSize * 5);
+    std::generate(data.begin(), data.end(), std::rand);
+    writer.Write(data.data(), data.size());
+    writer.Finish();
+
+    // Verify file contents
+    std::ifstream file(filename, std::ios::binary);
+    std::vector<char> content((std::istreambuf_iterator<char>(file)),
+                              std::istreambuf_iterator<char>());
+    EXPECT_EQ(content, std::vector<char>(data.begin(), data.end()));
+}
+
+// Test writing data size with unaligned to buffer size
+TEST_F(FileWriterTest, UnalignedToBufferSizeWriteWithDirectIO) {
+    FileWriter::SetMode(FileWriter::WriteMode::DIRECT);
+    FileWriter::SetBufferSize(kBufferSize);
+
+    std::string filename =
+        (test_dir_ / "unaligned_to_buffer_size.txt").string();
+    FileWriter writer(filename);
+
+    std::vector<char> large_data(kBufferSize * 2 + 17);
+    std::generate(large_data.begin(), large_data.end(), std::rand);
+    writer.Write(large_data.data(), large_data.size());
+    writer.Finish();
+
+    // Verify file contents
+    std::ifstream file(filename, std::ios::binary);
+    std::vector<char> content((std::istreambuf_iterator<char>(file)),
+                              std::istreambuf_iterator<char>());
+    EXPECT_EQ(content, std::vector<char>(large_data.begin(), large_data.end()));
+}
+
+// Test writing data with direct IO without finishing
+TEST_F(FileWriterTest, WriteWithoutFinishWithDirectIO) {
+    FileWriter::SetMode(FileWriter::WriteMode::DIRECT);
+    FileWriter::SetBufferSize(kBufferSize);
+
+    std::vector<char> data(kBufferSize * 2 + 10);
+    std::generate(data.begin(), data.end(), std::rand);
+    std::string filename = (test_dir_ / "write_without_finish.txt").string();
+    {
+        FileWriter writer(filename);
+        writer.Write(data.data(), data.size());
+    }
+
+    std::ifstream file(filename, std::ios::binary);
+    std::vector<char> content((std::istreambuf_iterator<char>(file)),
+                              std::istreambuf_iterator<char>());
+
+    EXPECT_NE(content.size(), data.size());
+    EXPECT_EQ(content.size(), kBufferSize * 2);
+    EXPECT_NE(content, std::vector<char>(data.begin(), data.end()));
+    EXPECT_EQ(content,
+              std::vector<char>(data.begin(), data.begin() + kBufferSize * 2));
+}
+
+// Test writing data with size slightly less than buffer size
+TEST_F(FileWriterTest, SlightlyLessThanBufferSizeWriteWithDirectIO) {
+    FileWriter::SetMode(FileWriter::WriteMode::DIRECT);
+    FileWriter::SetBufferSize(kBufferSize);
+
+    std::string filename = (test_dir_ / "slightly_less.txt").string();
+    FileWriter writer(filename);
+
+    std::vector<char> data(kBufferSize - 1);
+    std::generate(data.begin(), data.end(), std::rand);
+
+    writer.Write(data.data(), data.size());
+    writer.Finish();
+
+    std::ifstream file(filename, std::ios::binary);
+    std::vector<char> read_data((std::istreambuf_iterator<char>(file)),
+                                std::istreambuf_iterator<char>());
+    EXPECT_EQ(read_data, data);
+}
+
+// Test writing data with multiple small chunks with direct IO
+TEST_F(FileWriterTest, MultipleSmallChunksWriteWithBufferedIO) {
+    FileWriter::SetMode(FileWriter::WriteMode::BUFFERED);
+
+    std::string filename =
+        (test_dir_ / "multiple_small_chunks_buffered.txt").string();
+    FileWriter writer(filename);
+
+    const int num_chunks = 100;
+    const size_t chunk_size = 10;  // 10 bytes per chunk
+    std::vector<std::vector<char>> chunks(num_chunks,
+                                          std::vector<char>(chunk_size));
+
+    for (auto& chunk : chunks) {
+        std::generate(chunk.begin(), chunk.end(), std::rand);
+        writer.Write(chunk.data(), chunk.size());
+    }
+    writer.Finish();
+
+    std::ifstream file(filename, std::ios::binary);
+    std::vector<char> read_data((std::istreambuf_iterator<char>(file)),
+                                std::istreambuf_iterator<char>());
+
+    std::vector<char> expected_data;
+    for (const auto& chunk : chunks) {
+        expected_data.insert(expected_data.end(), chunk.begin(), chunk.end());
+    }
+    EXPECT_EQ(read_data, expected_data);
+}
+
+// Test writing data with multiple small chunks with direct IO
+TEST_F(FileWriterTest, MultipleSmallChunksWriteWithDirectIO) {
+    FileWriter::SetMode(FileWriter::WriteMode::DIRECT);
+    FileWriter::SetBufferSize(kBufferSize);
+
+    std::string filename =
+        (test_dir_ / "multiple_small_chunks_direct.txt").string();
+    FileWriter writer(filename);
+
+    const int num_chunks = 100;
+    const size_t chunk_size = 10;  // 10 bytes per chunk
+    std::vector<std::vector<char>> chunks(num_chunks,
+                                          std::vector<char>(chunk_size));
+
+    for (auto& chunk : chunks) {
+        std::generate(chunk.begin(), chunk.end(), std::rand);
+        writer.Write(chunk.data(), chunk.size());
+    }
+    writer.Finish();
+
+    std::ifstream file(filename, std::ios::binary);
+    std::vector<char> read_data((std::istreambuf_iterator<char>(file)),
+                                std::istreambuf_iterator<char>());
+
+    std::vector<char> expected_data;
+    for (const auto& chunk : chunks) {
+        expected_data.insert(expected_data.end(), chunk.begin(), chunk.end());
+    }
+    EXPECT_EQ(read_data, expected_data);
+}
+
+// Test writing memory address aligned data
+TEST_F(FileWriterTest, MemoryAddressAlignedDataWriteWithDirectIO) {
+    FileWriter::SetMode(FileWriter::WriteMode::DIRECT);
+    FileWriter::SetBufferSize(kBufferSize);
+
+    std::string filename = (test_dir_ / "aligned_write.txt").string();
+    FileWriter writer(filename);
+
+    // Create 4KB aligned data using posix_memalign
+    void* aligned_data = nullptr;
+    if (posix_memalign(&aligned_data, 4096, kBufferSize) != 0) {
+        throw std::runtime_error("Failed to allocate aligned memory");
+    }
+    std::generate(static_cast<char*>(aligned_data),
+                  static_cast<char*>(aligned_data) + kBufferSize,
+                  std::rand);
+
+    writer.Write(aligned_data, kBufferSize);
+    writer.Finish();
+
+    // Verify file contents
+    std::ifstream file(filename, std::ios::binary);
+    std::vector<char> read_data((std::istreambuf_iterator<char>(file)),
+                                std::istreambuf_iterator<char>());
+    EXPECT_EQ(
+        read_data,
+        std::vector<char>(static_cast<char*>(aligned_data),
+                          static_cast<char*>(aligned_data) + kBufferSize));
+
+    // Clean up aligned memory
+    free(aligned_data);
+}
+
+// Test writing empty data
+TEST_F(FileWriterTest, EmptyDataWriteWithDirectIO) {
+    FileWriter::SetMode(FileWriter::WriteMode::DIRECT);
+    FileWriter::SetBufferSize(kBufferSize);
+
+    std::string filename = (test_dir_ / "empty_write.txt").string();
+    FileWriter writer(filename);
+
+    writer.Write(nullptr, 0);
+    writer.Finish();
+
+    // Verify file is empty
+    std::ifstream file(filename, std::ios::binary);
+    EXPECT_EQ(file.tellg(), 0);
+}
+
+// Test concurrent writes to different files
+TEST_F(FileWriterTest, ConcurrentWritesWithDirectIO) {
+    FileWriter::SetMode(FileWriter::WriteMode::DIRECT);
+    FileWriter::SetBufferSize(kBufferSize);
+
+    const int num_threads = 4;
+    std::vector<std::thread> threads;
+    std::vector<std::string> filenames;
+
+    filenames.reserve(num_threads);
+    for (int i = 0; i < num_threads; ++i) {
+        filenames.emplace_back(
+            (test_dir_ / ("concurrent_" + std::to_string(i) + ".txt"))
+                .string());
+    }
+
+    threads.reserve(num_threads);
+    for (int i = 0; i < num_threads; ++i) {
+        threads.emplace_back([&, i]() {
+            FileWriter writer(filenames[i]);
+            std::string test_data = "Thread " + std::to_string(i) + " data";
+            writer.Write(test_data.data(), test_data.size());
+            writer.Finish();
+        });
+    }
+
+    for (auto& thread : threads) {
+        thread.join();
+    }
+
+    // Verify all files
+    for (int i = 0; i < num_threads; ++i) {
+        std::ifstream file(filenames[i], std::ios::binary);
+        std::string content((std::istreambuf_iterator<char>(file)),
+                            std::istreambuf_iterator<char>());
+        EXPECT_EQ(content, "Thread " + std::to_string(i) + " data");
+    }
+}
+
+// Test error handling for invalid file path
+TEST_F(FileWriterTest, InvalidFilePathWithDirectIO) {
+    FileWriter::SetMode(FileWriter::WriteMode::DIRECT);
+    FileWriter::SetBufferSize(kBufferSize);
+
+    std::string invalid_path = "/invalid/path/file.txt";
+    EXPECT_THROW(FileWriter writer(invalid_path), std::runtime_error);
+}
+
+// Test writing to a file that already exists
+TEST_F(FileWriterTest, ExistingFileWithDirectIO) {
+    FileWriter::SetMode(FileWriter::WriteMode::DIRECT);
+    FileWriter::SetBufferSize(kBufferSize);
+
+    std::string filename = (test_dir_ / "existing.txt").string();
+
+    // Create initial file
+    {
+        FileWriter writer(filename);
+        std::string initial_data = "Initial data";
+        writer.Write(initial_data.data(), initial_data.size());
+        writer.Finish();
+    }
+
+    // Write to the same file again
+    FileWriter writer(filename);
+    std::string new_data = "New data";
+    writer.Write(new_data.data(), new_data.size());
+    writer.Finish();
+
+    // Verify file contains new data
+    std::ifstream file(filename, std::ios::binary);
+    std::string content((std::istreambuf_iterator<char>(file)),
+                        std::istreambuf_iterator<char>());
+    EXPECT_EQ(content, new_data);
+}
+
+// Test config FileWriterConfig with very small buffer size
+TEST_F(FileWriterTest, SmallBufferSizeWriteWithDirectIO) {
+    const size_t small_buffer_size = 64;  // 64 bytes
+    FileWriter::SetMode(FileWriter::WriteMode::DIRECT);
+    FileWriter::SetBufferSize(small_buffer_size);
+    auto real_buffer_size = FileWriter::GetBufferSize();
+    EXPECT_EQ(real_buffer_size, kBufferSize);
+}
+
+// Test config FileWriterConfig with unaligned buffer size
+TEST_F(FileWriterTest, UnalignedBufferSizeWriteWithDirectIO) {
+    const size_t unaligned_buffer_size = kBufferSize + 1;  // Not aligned to 4KB
+    FileWriter::SetMode(FileWriter::WriteMode::DIRECT);
+    FileWriter::SetBufferSize(unaligned_buffer_size);
+    auto real_buffer_size = FileWriter::GetBufferSize();
+    EXPECT_EQ(real_buffer_size, 2 * kBufferSize);
+}
+
+// Test config FileWriterConfig with zero buffer size
+TEST_F(FileWriterTest, ZeroBufferSizeWriteWithDirectIO) {
+    const size_t zero_buffer_size = 0;
+    FileWriter::SetMode(FileWriter::WriteMode::DIRECT);
+    FileWriter::SetBufferSize(zero_buffer_size);
+    auto real_buffer_size = FileWriter::GetBufferSize();
+    EXPECT_EQ(real_buffer_size, kBufferSize);
+}
+
+// Test config FileWriterConfig with very large buffer size
+TEST_F(FileWriterTest, LargeBufferSizeWriteWithDirectIO) {
+    const size_t large_buffer_size = 1024 * 1024;  // 1MB
+    FileWriter::SetMode(FileWriter::WriteMode::DIRECT);
+    FileWriter::SetBufferSize(large_buffer_size);
+
+    std::string filename = (test_dir_ / "large_buffer.txt").string();
+    FileWriter writer(filename);
+
+    std::vector<char> data(2 * large_buffer_size + 1);
+    std::generate(data.begin(), data.end(), std::rand);
+    writer.Write(data.data(), data.size());
+    writer.Finish();
+
+    std::ifstream file(filename, std::ios::binary);
+    std::vector<char> read_data((std::istreambuf_iterator<char>(file)),
+                                std::istreambuf_iterator<char>());
+    EXPECT_EQ(read_data, std::vector<char>(data.begin(), data.end()));
+}
+
+// Test config FileWriterConfig with unknown mode
+TEST_F(FileWriterTest, UnknownModeWriteWithDirectIO) {
+    uint8_t mode = 2;
+    EXPECT_NO_THROW({
+        FileWriter::SetMode(static_cast<FileWriter::WriteMode>(mode));
+        FileWriter::SetBufferSize(kBufferSize);
+    });
+}
+
+TEST_F(FileWriterTest, HalfAlignedDataWriteWithDirectIO) {
+    const size_t aligned_buffer_size = 2 * kBufferSize;
+    std::string filename = (test_dir_ / "half_aligned_buffer.txt").string();
+    FileWriter writer(filename);
+
+    char* aligned_buffer = nullptr;
+    int ret = posix_memalign(reinterpret_cast<void**>(&aligned_buffer),
+                             kBufferSize,
+                             aligned_buffer_size);
+    ASSERT_EQ(ret, 0);
+
+    const size_t first_half_size = kBufferSize / 2;
+    const size_t rest_size = aligned_buffer_size - first_half_size;
+    writer.Write(aligned_buffer, first_half_size);
+    writer.Write(aligned_buffer + first_half_size, rest_size);
+    writer.Finish();
+
+    std::ifstream file(filename, std::ios::binary);
+    std::vector<char> read_data((std::istreambuf_iterator<char>(file)),
+                                std::istreambuf_iterator<char>());
+    EXPECT_EQ(read_data,
+              std::vector<char>(aligned_buffer,
+                                aligned_buffer + aligned_buffer_size));
+
+    free(aligned_buffer);
+}
+
+// Test writing data with alternating large and small chunks
+TEST_F(FileWriterTest, AlternatingChunksWriteWithDirectIO) {
+    std::string filename = (test_dir_ / "alternating_chunks.txt").string();
+    FileWriter writer(filename);
+
+    const int num_chunks = 10;
+    std::vector<std::vector<char>> chunks;
+
+    for (int i = 0; i < num_chunks; ++i) {
+        size_t chunk_size = (i % 2 == 0) ? kBufferSize * 2 : 10;
+        std::vector<char> chunk(chunk_size);
+        std::generate(chunk.begin(), chunk.end(), std::rand);
+        chunks.push_back(chunk);
+        writer.Write(chunk.data(), chunk.size());
+    }
+    writer.Finish();
+
+    std::ifstream file(filename, std::ios::binary);
+    std::vector<char> read_data((std::istreambuf_iterator<char>(file)),
+                                std::istreambuf_iterator<char>());
+
+    std::vector<char> expected_data;
+    for (const auto& chunk : chunks) {
+        expected_data.insert(expected_data.end(), chunk.begin(), chunk.end());
+    }
+    EXPECT_EQ(read_data, expected_data);
+}
+
+// Test writing data with very large file size
+TEST_F(FileWriterTest, VeryLargeFileWriteWithDirectIO) {
+    std::string filename = (test_dir_ / "very_large_file.txt").string();
+    FileWriter writer(filename);
+
+    const size_t large_size = 100 * 1024 * 1024;  // 100MB
+    const size_t alignment = 4096;                // 4KB alignment
+    char* aligned_data = nullptr;
+    ASSERT_EQ(posix_memalign((void**)&aligned_data, alignment, large_size), 0);
+    std::generate(aligned_data, aligned_data + large_size, std::rand);
+
+    writer.Write(aligned_data, large_size);
+    writer.Finish();
+
+    std::ifstream file(filename, std::ios::binary);
+    std::vector<char> read_data((std::istreambuf_iterator<char>(file)),
+                                std::istreambuf_iterator<char>());
+    EXPECT_EQ(read_data.size(), large_size);
+    EXPECT_EQ(std::memcmp(read_data.data(), aligned_data, large_size), 0);
+
+    free(aligned_data);
+}
+
+// Test writing data with different buffer sizes in the same file
+TEST_F(FileWriterTest, MixedBufferSizesWriteWithDirectIO) {
+    std::string filename = (test_dir_ / "mixed_buffer_sizes.txt").string();
+    FileWriter writer(filename);
+
+    std::vector<size_t> chunk_sizes = {
+        10,               // Very small
+        kBufferSize - 1,  // Slightly less than buffer
+        kBufferSize,      // Exact buffer size
+        kBufferSize + 1,  // Slightly more than buffer
+        kBufferSize * 2,  // Double buffer size
+        kBufferSize * 10  // Much larger than buffer
+    };
+
+    std::vector<std::vector<char>> chunks;
+    for (size_t size : chunk_sizes) {
+        std::vector<char> chunk(size);
+        std::generate(chunk.begin(), chunk.end(), std::rand);
+        chunks.push_back(chunk);
+        writer.Write(chunk.data(), chunk.size());
+    }
+    writer.Finish();
+
+    std::ifstream file(filename, std::ios::binary);
+    std::vector<char> read_data((std::istreambuf_iterator<char>(file)),
+                                std::istreambuf_iterator<char>());
+
+    std::vector<char> expected_data;
+    for (const auto& chunk : chunks) {
+        expected_data.insert(expected_data.end(), chunk.begin(), chunk.end());
+    }
+    EXPECT_EQ(read_data, expected_data);
+}
+
+// Test multi-threaded writing to different files
+TEST_F(FileWriterTest, MultiThreadedWriteWithDirectIO) {
+    const int num_threads = 4;
+    const size_t data_size_per_thread = 50 * 1024 * 1024;  // 50MB per thread
+    std::vector<std::thread> threads;
+    std::vector<std::string> filenames;
+    std::vector<std::vector<char>> test_data;
+
+    // Prepare filenames and test data
+    for (int i = 0; i < num_threads; ++i) {
+        filenames.push_back(
+            (test_dir_ / ("multi_thread_" + std::to_string(i) + ".txt"))
+                .string());
+        test_data.emplace_back(data_size_per_thread);
+        std::generate(test_data[i].begin(), test_data[i].end(), std::rand);
+    }
+
+    // Launch threads
+    threads.reserve(num_threads);
+    for (int i = 0; i < num_threads; ++i) {
+        threads.emplace_back([&, i]() {
+            FileWriter writer(filenames[i]);
+            writer.Write(test_data[i].data(), test_data[i].size());
+            writer.Finish();
+        });
+    }
+
+    // Wait for all threads to complete
+    for (auto& thread : threads) {
+        thread.join();
+    }
+
+    // Verify all files
+    for (int i = 0; i < num_threads; ++i) {
+        std::ifstream file(filenames[i], std::ios::binary);
+        std::vector<char> read_data((std::istreambuf_iterator<char>(file)),
+                                    std::istreambuf_iterator<char>());
+        EXPECT_EQ(read_data.size(), data_size_per_thread);
+        EXPECT_EQ(read_data, test_data[i]);
+    }
+}
+
+// Test executor-based asynchronous writes
+TEST_F(FileWriterTest, ExecutorBasedAsyncWrites) {
+    // Set up executor with 2 threads
+    FileWriteWorkerPool::GetInstance().Configure(2);
+    FileWriter::SetMode(FileWriter::WriteMode::BUFFERED);
+
+    std::string filename = (test_dir_ / "executor_async.txt").string();
+    FileWriter writer(filename);
+
+    // Write multiple chunks
+    const int num_chunks = 10;
+    const size_t chunk_size = 1024;
+    std::vector<std::vector<char>> chunks(num_chunks,
+                                          std::vector<char>(chunk_size));
+
+    for (auto& chunk : chunks) {
+        std::generate(chunk.begin(), chunk.end(), std::rand);
+        writer.Write(chunk.data(), chunk.size());
+    }
+    writer.Finish();
+
+    // Verify file contents
+    std::ifstream file(filename, std::ios::binary);
+    std::vector<char> read_data((std::istreambuf_iterator<char>(file)),
+                                std::istreambuf_iterator<char>());
+
+    std::vector<char> expected_data;
+    for (const auto& chunk : chunks) {
+        expected_data.insert(expected_data.end(), chunk.begin(), chunk.end());
+    }
+    EXPECT_EQ(read_data, expected_data);
+}
+
+// Test executor-based asynchronous writes with direct IO
+TEST_F(FileWriterTest, ExecutorBasedAsyncWritesWithDirectIO) {
+    // Set up executor with 2 threads
+    FileWriteWorkerPool::GetInstance().Configure(2);
+    FileWriter::SetMode(FileWriter::WriteMode::DIRECT);
+    FileWriter::SetBufferSize(kBufferSize);
+
+    std::string filename = (test_dir_ / "executor_async_direct.txt").string();
+    FileWriter writer(filename);
+
+    // Write multiple chunks asynchronously
+    const int num_chunks = 10;
+    const size_t chunk_size = kBufferSize;
+    std::vector<std::vector<char>> chunks(num_chunks,
+                                          std::vector<char>(chunk_size));
+
+    for (auto& chunk : chunks) {
+        std::generate(chunk.begin(), chunk.end(), std::rand);
+        writer.Write(chunk.data(), chunk.size());
+    }
+    writer.Finish();
+
+    // Verify file contents
+    std::ifstream file(filename, std::ios::binary);
+    std::vector<char> read_data((std::istreambuf_iterator<char>(file)),
+                                std::istreambuf_iterator<char>());
+
+    std::vector<char> expected_data;
+    for (const auto& chunk : chunks) {
+        expected_data.insert(expected_data.end(), chunk.begin(), chunk.end());
+    }
+    EXPECT_EQ(read_data, expected_data);
+}
+
+// Test concurrent writes using executor
+TEST_F(FileWriterTest, ConcurrentWritesWithExecutor) {
+    // Set up executor with 4 threads
+    FileWriteWorkerPool::GetInstance().Configure(4);
+    FileWriter::SetMode(FileWriter::WriteMode::BUFFERED);
+
+    const int num_files = 8;
+    std::vector<std::string> filenames;
+    std::vector<std::vector<char>> test_data;
+
+    // Prepare filenames and test data
+    for (int i = 0; i < num_files; ++i) {
+        filenames.push_back(
+            (test_dir_ / ("concurrent_executor_" + std::to_string(i) + ".txt"))
+                .string());
+        test_data.emplace_back(1024 * 1024);  // 1MB per file
+        std::generate(test_data[i].begin(), test_data[i].end(), std::rand);
+    }
+
+    // Write to all files concurrently
+    std::vector<std::thread> threads;
+    threads.reserve(num_files);
+    for (int i = 0; i < num_files; ++i) {
+        threads.emplace_back([&, i]() {
+            FileWriter writer(filenames[i]);
+            writer.Write(test_data[i].data(), test_data[i].size());
+            writer.Finish();
+        });
+    }
+
+    // Wait for all threads to complete
+    for (auto& thread : threads) {
+        thread.join();
+    }
+
+    // Verify all files
+    for (int i = 0; i < num_files; ++i) {
+        std::ifstream file(filenames[i], std::ios::binary);
+        std::vector<char> read_data((std::istreambuf_iterator<char>(file)),
+                                    std::istreambuf_iterator<char>());
+        EXPECT_EQ(read_data, test_data[i]);
+    }
+}
+
+// Test executor configuration with invalid number of threads
+TEST_F(FileWriterTest, InvalidExecutorConfiguration) {
+    // Test with zero threads
+    EXPECT_NO_THROW(FileWriteWorkerPool::GetInstance().Configure(0));
+
+    // Test with negative number of threads
+    EXPECT_NO_THROW(FileWriteWorkerPool::GetInstance().Configure(-1));
+}
+
+// Test executor configuration changes
+TEST_F(FileWriterTest, ExecutorConfigurationChanges) {
+    // Set initial executor
+    FileWriteWorkerPool::GetInstance().Configure(2);
+
+    // Change executor configuration
+    FileWriteWorkerPool::GetInstance().Configure(4);
+
+    // Verify the change doesn't break functionality
+    FileWriter::SetMode(FileWriter::WriteMode::BUFFERED);
+
+    std::string filename = (test_dir_ / "executor_change.txt").string();
+    FileWriter writer(filename);
+
+    std::string test_data = "Test data for executor change";
+    writer.Write(test_data.data(), test_data.size());
+    writer.Finish();
+
+    // Verify file contents
+    std::ifstream file(filename, std::ios::binary);
+    std::string content((std::istreambuf_iterator<char>(file)),
+                        std::istreambuf_iterator<char>());
+    EXPECT_EQ(content, test_data);
+}
+
+// Test mixed buffered and direct IO with executor
+TEST_F(FileWriterTest, MixedIOWithExecutor) {
+    FileWriteWorkerPool::GetInstance().Configure(2);
+
+    // Test buffered IO with executor
+    {
+        FileWriter::SetMode(FileWriter::WriteMode::BUFFERED);
+        std::string filename = (test_dir_ / "mixed_buffered.txt").string();
+        FileWriter writer(filename);
+
+        std::string test_data = "Buffered IO test data";
+        writer.Write(test_data.data(), test_data.size());
+        writer.Finish();
+
+        std::ifstream file(filename, std::ios::binary);
+        std::string content((std::istreambuf_iterator<char>(file)),
+                            std::istreambuf_iterator<char>());
+        EXPECT_EQ(content, test_data);
+    }
+
+    // Test direct IO with executor
+    {
+        FileWriter::SetMode(FileWriter::WriteMode::DIRECT);
+        FileWriter::SetBufferSize(kBufferSize);
+        std::string filename = (test_dir_ / "mixed_direct.txt").string();
+        FileWriter writer(filename);
+
+        std::string test_data = "Direct IO test data";
+        writer.Write(test_data.data(), test_data.size());
+        writer.Finish();
+
+        std::ifstream file(filename, std::ios::binary);
+        std::string content((std::istreambuf_iterator<char>(file)),
+                            std::istreambuf_iterator<char>());
+        EXPECT_EQ(content, test_data);
+    }
+}
+
+// Test large data writes with executor
+TEST_F(FileWriterTest, LargeDataWritesWithExecutor) {
+    FileWriteWorkerPool::GetInstance().Configure(2);
+    FileWriter::SetMode(FileWriter::WriteMode::BUFFERED);
+
+    std::string filename = (test_dir_ / "large_data_executor.txt").string();
+    FileWriter writer(filename);
+
+    const size_t large_size = 10 * 1024 * 1024;  // 10MB
+    std::vector<char> large_data(large_size);
+    std::generate(large_data.begin(), large_data.end(), std::rand);
+
+    writer.Write(large_data.data(), large_data.size());
+    writer.Finish();
+
+    std::ifstream file(filename, std::ios::binary);
+    std::vector<char> read_data((std::istreambuf_iterator<char>(file)),
+                                std::istreambuf_iterator<char>());
+    EXPECT_EQ(read_data, large_data);
+}
+
+// Test executor with different buffer sizes
+TEST_F(FileWriterTest, ExecutorWithDifferentBufferSizes) {
+    FileWriteWorkerPool::GetInstance().Configure(2);
+    FileWriter::SetMode(FileWriter::WriteMode::DIRECT);
+
+    std::vector<size_t> buffer_sizes = {4096, 8192, 16384, 32768};
+
+    for (size_t buffer_size : buffer_sizes) {
+        FileWriter::SetBufferSize(buffer_size);
+
+        std::string filename =
+            (test_dir_ /
+             ("buffer_size_" + std::to_string(buffer_size) + ".txt"))
+                .string();
+        FileWriter writer(filename);
+
+        std::vector<char> test_data(buffer_size * 2);
+        std::generate(test_data.begin(), test_data.end(), std::rand);
+
+        writer.Write(test_data.data(), test_data.size());
+        writer.Finish();
+
+        std::ifstream file(filename, std::ios::binary);
+        std::vector<char> read_data((std::istreambuf_iterator<char>(file)),
+                                    std::istreambuf_iterator<char>());
+        EXPECT_EQ(read_data, test_data);
+    }
+}
+
+// Test error handling in async operations
+TEST_F(FileWriterTest, ErrorHandlingInAsyncOperations) {
+    FileWriteWorkerPool::GetInstance().Configure(2);
+    FileWriter::SetMode(FileWriter::WriteMode::BUFFERED);
+
+    // Test with invalid file path in async context
+    std::string invalid_path = "/invalid/path/async_test.txt";
+
+    // This should throw an exception even in async context
+    EXPECT_THROW(
+        {
+            FileWriter writer(invalid_path);
+            std::string test_data = "Test data";
+            writer.Write(test_data.data(), test_data.size());
+            writer.Finish();
+        },
+        std::runtime_error);
+}
+
+// Test concurrent access to FileWriterConfig
+TEST_F(FileWriterTest, ConcurrentAccessToFileWriterConfig) {
+    const int num_threads = std::thread::hardware_concurrency();
+    std::vector<std::thread> threads;
+
+    threads.reserve(num_threads);
+    for (int i = 0; i < num_threads; ++i) {
+        threads.emplace_back([i]() {
+            // Each thread sets different executor configurations
+            FileWriteWorkerPool::GetInstance().Configure(i + 1);
+            FileWriter::SetMode(i % 2 == 0 ? FileWriter::WriteMode::BUFFERED
+                                           : FileWriter::WriteMode::DIRECT);
+            FileWriter::SetBufferSize(4096 * (i + 1));
+        });
+    }
+
+    // Wait for all threads to complete
+    for (auto& thread : threads) {
+        thread.join();
+    }
+
+    // Verify that the configuration is still valid
+    FileWriter::SetMode(FileWriter::WriteMode::BUFFERED);
+    std::string filename =
+        (std::filesystem::temp_directory_path() / "concurrent_config_test.txt")
+            .string();
+
+    FileWriter writer(filename);
+    std::string test_data = "Concurrent config test";
+    writer.Write(test_data.data(), test_data.size());
+    writer.Finish();
+
+    // Clean up
+    std::filesystem::remove(filename);
+}
+// Test that changing FileWriterConfig during FileWriter operations doesn't affect existing instances
+TEST_F(FileWriterTest, ConfigChangeDuringFileWriterOperations) {
+    // Start with buffered mode
+    FileWriter::SetMode(FileWriter::WriteMode::BUFFERED);
+    FileWriteWorkerPool::GetInstance().Configure(2);
+
+    std::string filename1 =
+        (std::filesystem::temp_directory_path() / "config_change_test1.txt")
+            .string();
+    std::string filename2 =
+        (std::filesystem::temp_directory_path() / "config_change_test2.txt")
+            .string();
+
+    // Create first FileWriter
+    FileWriter writer1(filename1);
+
+    // Start writing some data with first writer
+    std::string test_data1 = "First writer data";
+    writer1.Write(test_data1.data(), test_data1.size());
+
+    // Change configuration while first writer is still active
+    FileWriter::SetMode(FileWriter::WriteMode::DIRECT);
+    FileWriter::SetBufferSize(8192);
+    FileWriteWorkerPool::GetInstance().Configure(4);
+
+    // Create second FileWriter with new configuration
+    FileWriter writer2(filename2);
+
+    // Continue writing with both writers
+    std::string test_data2 = "Second writer data";
+    writer2.Write(test_data2.data(), test_data2.size());
+
+    std::string more_data1 = "More data for first writer";
+    writer1.Write(more_data1.data(), more_data1.size());
+
+    // Finish both writers
+    size_t size1 = writer1.Finish();
+    size_t size2 = writer2.Finish();
+
+    // Verify both files were written correctly
+    EXPECT_EQ(size1, test_data1.size() + more_data1.size());
+    EXPECT_EQ(size2, test_data2.size());
+
+    // Read back and verify content
+    std::ifstream file1(filename1);
+    std::string content1((std::istreambuf_iterator<char>(file1)),
+                         std::istreambuf_iterator<char>());
+    EXPECT_EQ(content1, test_data1 + more_data1);
+
+    std::ifstream file2(filename2);
+    std::string content2((std::istreambuf_iterator<char>(file2)),
+                         std::istreambuf_iterator<char>());
+    EXPECT_EQ(content2, test_data2);
+
+    // Clean up
+    std::filesystem::remove(filename1);
+    std::filesystem::remove(filename2);
+}

--- a/internal/core/unittest/test_sealed.cpp
+++ b/internal/core/unittest/test_sealed.cpp
@@ -2563,7 +2563,7 @@ TEST(Sealed, SearchSortedPk) {
     auto varchar_pk_field = schema->AddDebugField("pk", DataType::VARCHAR);
     schema->set_primary_field_id(varchar_pk_field);
     auto segment_sealed = CreateSealedSegment(
-        schema, nullptr, 999, SegcoreConfig::default_config(), false, true);
+        schema, nullptr, 999, SegcoreConfig::default_config(), true);
     auto segment = dynamic_cast<SegmentSealedImpl*>(segment_sealed.get());
 
     int64_t dataset_size = 1000;

--- a/internal/util/initcore/init_core.go
+++ b/internal/util/initcore/init_core.go
@@ -198,6 +198,18 @@ func InitMmapManager(params *paramtable.ComponentParam) error {
 	return HandleCStatus(&status, "InitMmapManager failed")
 }
 
+func InitFileWriterConfig(params *paramtable.ComponentParam) error {
+	mode := params.CommonCfg.DiskWriteMode.GetValue()
+	bufferSize := params.CommonCfg.DiskWriteBufferSizeKb.GetAsUint64()
+	numThreads := params.CommonCfg.DiskWriteNumThreads.GetAsInt()
+	cMode := C.CString(mode)
+	cBufferSize := C.uint64_t(bufferSize)
+	cNumThreads := C.int(numThreads)
+	defer C.free(unsafe.Pointer(cMode))
+	status := C.InitFileWriterConfig(cMode, cBufferSize, cNumThreads)
+	return HandleCStatus(&status, "InitFileWriterConfig failed")
+}
+
 func InitInterminIndexConfig(params *paramtable.ComponentParam) error {
 	enableInterminIndex := C.bool(params.QueryNodeCfg.EnableInterminSegmentIndex.GetAsBool())
 	C.SegcoreSetEnableInterminSegmentIndex(enableInterminIndex)

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -242,6 +242,10 @@ type commonConfig struct {
 	StorageType ParamItem `refreshable:"false"`
 	SimdType    ParamItem `refreshable:"false"`
 
+	DiskWriteMode         ParamItem `refreshable:"true"`
+	DiskWriteBufferSizeKb ParamItem `refreshable:"true"`
+	DiskWriteNumThreads   ParamItem `refreshable:"true"`
+
 	AuthorizationEnabled  ParamItem `refreshable:"false"`
 	SuperUsers            ParamItem `refreshable:"true"`
 	DefaultRootPassword   ParamItem `refreshable:"false"`
@@ -657,6 +661,40 @@ This configuration is only used by querynode and indexnode, it selects CPU instr
 		Export: true,
 	}
 	p.ChunkCacheThreadCoreCoefficient.Init(base.mgr)
+
+	p.DiskWriteMode = ParamItem{
+		Key:          "common.diskWriteMode",
+		Version:      "2.5.16",
+		DefaultValue: "buffered",
+		Doc: `This parameter controls the write mode of the local disk, which is used to write temporary data downloaded from remote storage.
+Currently, only QueryNode uses 'common.diskWrite*' parameters. Support for other components will be added in the future.
+The options include 'direct' and 'buffered'. The default value is 'buffered'.`,
+		Export: true,
+	}
+	p.DiskWriteMode.Init(base.mgr)
+
+	p.DiskWriteBufferSizeKb = ParamItem{
+		Key:          "common.diskWriteBufferSizeKb",
+		Version:      "2.5.16",
+		DefaultValue: "64",
+		Doc: `Disk write buffer size in KB, only used when disk write mode is 'direct', default is 64KB.
+Current valid range is [4, 65536]. If the value is not aligned to 4KB, it will be rounded up to the nearest multiple of 4KB.`,
+		Export: true,
+	}
+	p.DiskWriteBufferSizeKb.Init(base.mgr)
+
+	p.DiskWriteNumThreads = ParamItem{
+		Key:          "common.diskWriteNumThreads",
+		Version:      "2.5.16",
+		DefaultValue: "0",
+		Doc: `This parameter controls the number of writer threads used for disk write operations. The valid range is [0, hardware_concurrency].
+It is designed to limit the maximum concurrency of disk write operations to reduce the impact on disk read performance.
+For example, if you want to limit the maximum concurrency of disk write operations to 1, you can set this parameter to 1.
+The default value is 0, which means the caller will perform write operations directly without using an additional writer thread pool.
+In this case, the maximum concurrency of disk write operations is determined by the caller's thread pool size.`,
+		Export: true,
+	}
+	p.DiskWriteNumThreads.Init(base.mgr)
 
 	p.BuildIndexThreadPoolRatio = ParamItem{
 		Key:          "common.buildIndexThreadPoolRatio",
@@ -2838,7 +2876,7 @@ This defaults to true, indicating that Milvus creates temporary index for growin
 		Key:          "queryNode.segcore.interimIndex.refineWithQuant",
 		Version:      "2.5.6",
 		DefaultValue: "true",
-		Doc:          `whether to use refineQuantType to refine for fatser but loss a little precision`,
+		Doc:          `whether to use refineQuantType to refine for faster but loss a little precision`,
 		Export:       true,
 	}
 	p.InterimIndexRefineWithQuant.Init(base.mgr)
@@ -3588,7 +3626,7 @@ type dataCoordConfig struct {
 
 	CompactionRPCTimeout             ParamItem `refreshable:"true"`
 	CompactionMaxParallelTasks       ParamItem `refreshable:"true"`
-	CompactionWorkerParalleTasks     ParamItem `refreshable:"true"`
+	CompactionWorkerParallelTasks    ParamItem `refreshable:"true"`
 	MinSegmentToMerge                ParamItem `refreshable:"true"`
 	SegmentSmallProportion           ParamItem `refreshable:"true"`
 	SegmentCompactableProportion     ParamItem `refreshable:"true"`
@@ -3760,7 +3798,7 @@ func (p *dataCoordConfig) init(base *BaseTable) {
 		Key:          "dataCoord.segment.diskSegmentMaxSize",
 		Version:      "2.0.0",
 		DefaultValue: "2048",
-		Doc:          "Maximun size of a segment in MB for collection which has Disk index",
+		Doc:          "Maximum size of a segment in MB for collection which has Disk index",
 		Export:       true,
 	}
 	p.DiskSegmentMaxSize.Init(base.mgr)
@@ -4024,7 +4062,7 @@ During compaction, the size of segment # of rows is able to exceed segment max #
 			}
 			return strconv.FormatInt(ms, 10)
 		},
-		Doc: "The time interval in milliseconds for scheduling compaction tasks. If the configuration setting is below 100ms, it will be ajusted upwards to 100ms",
+		Doc: "The time interval in milliseconds for scheduling compaction tasks. If the configuration setting is below 100ms, it will be adjusted upwards to 100ms",
 	}
 	p.CompactionScheduleInterval.Init(base.mgr)
 
@@ -4119,7 +4157,7 @@ During compaction, the size of segment # of rows is able to exceed segment max #
 	p.LevelZeroCompactionTriggerMinSize = ParamItem{
 		Key:          "dataCoord.compaction.levelzero.forceTrigger.minSize",
 		Version:      "2.4.0",
-		Doc:          "The minmum size in bytes to force trigger a LevelZero Compaction, default as 8MB",
+		Doc:          "The minimum size in bytes to force trigger a LevelZero Compaction, default as 8MB",
 		DefaultValue: "8388608",
 		Export:       true,
 	}
@@ -4477,7 +4515,7 @@ if param targetVecIndexVersion is not set, the default value is -1, which means 
 		Key:          "dataCoord.segmentFlushInterval",
 		Version:      "2.4.6",
 		DefaultValue: "2",
-		Doc:          "the minimal interval duration(unit: Seconds) between flusing operation on same segment",
+		Doc:          "the minimal interval duration(unit: Seconds) between flushing operation on same segment",
 		Export:       true,
 	}
 	p.SegmentFlushInterval.Init(base.mgr)


### PR DESCRIPTION
issue: #43040
pr: #42665 

This patch introduces a disk file writer that supports Direct IO.

Currently, it is exclusively utilized during the QueryNode load process.

Below is its parameters:

1. `common.diskWriteMode` This parameter controls the write mode of the local disk, which is used to write temporary data downloaded from remote storage. Currently, only QueryNode uses 'common.diskWrite*' parameters. Support for other components will be added in the future.
The options include 'direct' and 'buffered'. The default value is 'buffered'.

2. `common.diskWriteBufferSizeKb` Disk write buffer size in KB, only used when disk write mode is 'direct', default is 64KB.
Current valid range is [4, 65536]. If the value is not aligned to 4KB, it will be rounded up to the nearest multiple of 4KB.

3. `common.diskWriteNumThreads` This parameter controls the number of writer threads used for disk write operations. The valid range is [0, hardware_concurrency]. It is designed to limit the maximum concurrency of disk write operations to reduce the impact on disk read performance.
For example, if you want to limit the maximum concurrency of disk write operations to 1, you can set this parameter to 1.
The default value is 0, which means the caller will perform write operations directly without using an additional writer thread pool. In this case, the maximum concurrency of disk write operations is determined by the caller's thread pool size.

Both parameters can be updated during runtime.

---------