### PR TITLE
fix: Fix compaction failed due to ID exhausted

### DIFF
--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -4319,7 +4319,7 @@ mix is prioritized by level: mix compactions first, then L0 compactions, then cl
 	p.CompactionPreAllocateIDExpansionFactor = ParamItem{
 		Key:          "dataCoord.compaction.preAllocateIDExpansionFactor",
 		Version:      "2.5.8",
-		DefaultValue: "100",
+		DefaultValue: "10000",
 		Doc:          `The expansion factor for pre-allocating IDs during compaction.`,
 	}
 	p.CompactionPreAllocateIDExpansionFactor.Init(base.mgr)

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -539,7 +539,7 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, float64(100), Params.CompactionGCIntervalInSeconds.GetAsDuration(time.Second).Seconds())
 		params.Save("dataCoord.compaction.dropTolerance", "100")
 		assert.Equal(t, float64(100), Params.CompactionDropToleranceInSeconds.GetAsDuration(time.Second).Seconds())
-		assert.Equal(t, int64(100), Params.CompactionPreAllocateIDExpansionFactor.GetAsInt64())
+		assert.Equal(t, int64(10000), Params.CompactionPreAllocateIDExpansionFactor.GetAsInt64())
 
 		params.Save("dataCoord.compaction.clustering.enable", "true")
 		assert.Equal(t, true, Params.ClusteringCompactionEnable.GetAsBool())


### PR DESCRIPTION
Change default `compaction.preAllocateIDExpansionFactor` to 10000.

issue: https://github.com/milvus-io/milvus/issues/43673