### PR TITLE
fix: jieba tokenizer cause panic when dict word was empty string (#43337)

### DIFF
--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/tokenizers/jieba_tokenizer.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/tokenizers/jieba_tokenizer.rs
@@ -70,6 +70,13 @@ fn get_jieba_dict(params: &json::Map<String, json::Value>) -> Result<(Vec<String
                     )));
                 }
                 let text = word.as_str().unwrap().to_string();
+
+                // remove word if word is ""
+                // add empty string to tokenizer will case panic
+                if text.len() == 0 {
+                    continue;
+                }
+
                 if text == "_default_" || text == "_extend_default_" {
                     if system_dict.is_some() {
                         return Err(TantivyBindingError::InvalidArgument(format!(


### PR DESCRIPTION
pr: https://github.com/milvus-io/milvus/pull/43337
relate: https://github.com/milvus-io/milvus/issues/42779