### PR TITLE
enhance: Add test target to Makefile and test script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -357,6 +357,10 @@ test-streaming:
 	@echo "Running go unittests..."
 	@(env bash $(PWD)/scripts/run_go_unittest.sh -t streaming)
 
+test-mixcoord:
+	@echo "Running go unittests..."
+	@(env bash $(PWD)/scripts/run_go_unittest.sh -t mixcoord)
+
 test-go: build-cpp-with-unittest
 	@echo "Running go unittests..."
 	@(env bash $(PWD)/scripts/run_go_unittest.sh)

--- a/scripts/run_go_unittest.sh
+++ b/scripts/run_go_unittest.sh
@@ -134,19 +134,16 @@ go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${MILVUS_DIR}/dist
 
 function test_rootcoord()
 {
-go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${MILVUS_DIR}/distributed/rootcoord/..." -failfast -count=1 -ldflags="-r ${RPATH}"
 go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${MILVUS_DIR}/rootcoord" -failfast  -ldflags="-r ${RPATH}"
 }
 
 function test_datacoord()
 {
-go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${MILVUS_DIR}/distributed/datacoord/..." -failfast -count=1 -ldflags="-r ${RPATH}"
 go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${MILVUS_DIR}/datacoord/..." -failfast -count=1 -ldflags="-r ${RPATH}"
 }
 
 function test_querycoord()
 {
-go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${MILVUS_DIR}/distributed/querycoord/..." -failfast -count=1  -ldflags="-r ${RPATH}"
 go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${MILVUS_DIR}/querycoordv2/..." -failfast -count=1  -ldflags="-r ${RPATH}"
 }
 
@@ -171,6 +168,10 @@ go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${PKG_DIR}/streami
 popd
 }
 
+function test_mixcoord() {
+go test -gcflags="all=-N -l" -race -cover -tags dynamic,test "${MILVUS_DIR}/distributed/mixcoord/..." -failfast -count=1 -ldflags="-r ${RPATH}"
+}
+
 function test_all()
 {
 test_proxy
@@ -189,6 +190,7 @@ test_pkg
 test_metastore
 test_cmd
 test_streaming
+test_mixcoord
 }
 
 
@@ -244,6 +246,9 @@ case "${TEST_TAG}" in
         ;;
     streaming)
 	test_streaming
+        ;;
+    mixcoord)
+	test_mixcoord
         ;;
     *)   echo "Test All";
 	test_all


### PR DESCRIPTION
Add support for running mixcoord unit tests independently by:
- Adding test-mixcoord target to Makefile for easy test execution
- Adding test_mixcoord function to run_go_unittest.sh script
- Including mixcoord in test_all function for comprehensive testing
- Adding mixcoord case to test tag handling in script

This enables developers to run mixcoord tests specifically using: make test-mixcoord