### PR TITLE
enhance: [2.5] Fix parquet import OOM

### DIFF
--- a/internal/util/importutilv2/parquet/reader.go
+++ b/internal/util/importutilv2/parquet/reader.go
@@ -56,8 +56,14 @@ func NewReader(ctx context.Context, cm storage.ChunkManager, schema *schemapb.Co
 	if err != nil {
 		return nil, err
 	}
+
+	// Each ColumnReader consumes ReaderProperties.BufferSize memory independently.
+	// Therefore, the bufferSize should be divided by the number of columns
+	// to ensure total memory usage stays within the intended limit.
+	columnReaderBufferSize := bufferSize / len(schema.GetFields())
+
 	r, err := file.NewParquetReader(cmReader, file.WithReadProps(&parquet.ReaderProperties{
-		BufferSize:            int64(bufferSize),
+		BufferSize:            int64(columnReaderBufferSize),
 		BufferedStreamEnabled: true,
 	}))
 	if err != nil {


### PR DESCRIPTION
Each ColumnReader consumes ReaderProperties.BufferSize memory independently. Therefore, the bufferSize should be divided by the number of columns to ensure total memory usage stays within the intended limit.

issue: https://github.com/milvus-io/milvus/issues/43755

pr: https://github.com/milvus-io/milvus/pull/43756