### PR TITLE
enhance: [GoSDK] Add param static check for search iterator

### DIFF
--- a/client/milvusclient/iterator.go
+++ b/client/milvusclient/iterator.go
@@ -196,6 +196,10 @@ func newSearchIteratorV1(_ *Client) (*searchIteratorV1, error) {
 //
 // If the server supports search iterator V2, it creates a search iterator V2.
 func (c *Client) SearchIterator(ctx context.Context, option SearchIteratorOption, callOptions ...grpc.CallOption) (SearchIterator, error) {
+	if err := option.ValidateParams(); err != nil {
+		return nil, err
+	}
+
 	iter, err := newSearchIteratorV2(ctx, c, option)
 	if err == nil {
 		return iter, nil

--- a/client/milvusclient/iterator_option.go
+++ b/client/milvusclient/iterator_option.go
@@ -28,6 +28,8 @@ type SearchIteratorOption interface {
 	SearchOption() *searchOption
 	// Limit returns the overall limit of entries to iterate
 	Limit() int64
+	// ValidateParams performs the static params validation
+	ValidateParams() error
 }
 
 type searchIteratorOption struct {
@@ -44,6 +46,14 @@ func (opt *searchIteratorOption) SearchOption() *searchOption {
 
 func (opt *searchIteratorOption) Limit() int64 {
 	return opt.iteratorLimit
+}
+
+// ValidateParams performs the static params validation
+func (opt *searchIteratorOption) ValidateParams() error {
+	if opt.batchSize <= 0 {
+		return fmt.Errorf("batch size must be greater than 0")
+	}
+	return nil
 }
 
 func (opt *searchIteratorOption) WithBatchSize(batchSize int) *searchIteratorOption {
@@ -117,7 +127,12 @@ func (opt *searchIteratorOption) WithSearchParam(key, value string) *searchItera
 	return opt
 }
 
+// WithIteratorLimit sets the limit of entries to iterate
+// if limit < 0, then it will be set to Unlimited
 func (opt *searchIteratorOption) WithIteratorLimit(limit int64) *searchIteratorOption {
+	if limit < 0 {
+		limit = Unlimited
+	}
 	opt.iteratorLimit = limit
 	return opt
 }

--- a/client/milvusclient/iterator_test.go
+++ b/client/milvusclient/iterator_test.go
@@ -104,6 +104,15 @@ func (s *SearchIteratorSuite) TestSearchIteratorInit() {
 	})
 
 	s.Run("failure", func() {
+		s.Run("option_error", func() {
+			collectionName := fmt.Sprintf("coll_%s", s.randString(6))
+
+			_, err := s.client.SearchIterator(ctx, NewSearchIteratorOption(collectionName, entity.FloatVector(lo.RepeatBy(128, func(_ int) float32 {
+				return rand.Float32()
+			}))).WithBatchSize(-1).WithIteratorLimit(-2))
+			s.Error(err)
+		})
+
 		s.Run("describe_fail", func() {
 			collectionName := fmt.Sprintf("coll_%s", s.randString(6))
 


### PR DESCRIPTION
Related to #37548

This patch add static search option check logic:
- batch size shall be positive
- all negative limit shall be treated as `Unlimited`