### PR TITLE
enhance: migrate test case from test_alias.py to test_milvus_client_alias.py 

### DIFF
--- a/tests/python_client/testcases/test_alias.py
+++ b/tests/python_client/testcases/test_alias.py
@@ -100,6 +100,9 @@ class TestAliasOperation(TestcaseBase):
         res1 = collection_alias.query(expr="", output_fields=["count(*)"])[0]
         assert res1[0].get("count(*)") == nb2
 
+    #########################################################
+    # test_alias_create_operation_default() migrated to milvus_client
+    #########################################################
     @pytest.mark.tags(CaseLabel.L1)
     def test_alias_create_operation_default(self):
         """


### PR DESCRIPTION
issue: [#43793](https://github.com/milvus-io/milvus/issues/43793)

- migrate test_alias_create_operation_default() to test_milvus_client_alias_create_operation_default()