### PR TITLE
fix: Use `proto.Equal` to compare default value of field

### DIFF
--- a/internal/metastore/model/field.go
+++ b/internal/metastore/model/field.go
@@ -4,6 +4,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/pkg/v2/common"
+	"google.golang.org/protobuf/proto"
 )
 
 type Field struct {
@@ -75,7 +76,7 @@ func (f *Field) Equal(other Field) bool {
 		f.IsPartitionKey == other.IsPartitionKey &&
 		f.IsDynamic == other.IsDynamic &&
 		f.IsClusteringKey == other.IsClusteringKey &&
-		f.DefaultValue == other.DefaultValue &&
+		proto.Equal(f.DefaultValue, other.DefaultValue) &&
 		f.ElementType == other.ElementType &&
 		f.IsFunctionOutput == other.IsFunctionOutput &&
 		f.Nullable == other.Nullable

--- a/internal/metastore/model/field.go
+++ b/internal/metastore/model/field.go
@@ -1,10 +1,11 @@
 package model
 
 import (
+	"google.golang.org/protobuf/proto"
+
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/pkg/v2/common"
-	"google.golang.org/protobuf/proto"
 )
 
 type Field struct {


### PR DESCRIPTION
Related to #43796