### PR TITLE
fix: use tantivy version to make json index compatible with milvus 2.5

### DIFF
--- a/internal/core/src/index/IndexFactory.cpp
+++ b/internal/core/src/index/IndexFactory.cpp
@@ -391,18 +391,21 @@ IndexFactory::CreateJsonIndex(
                 cast_dtype,
                 nested_path,
                 file_manager_context,
+                create_index_info.tantivy_index_version,
                 JsonCastFunction::FromString(json_cast_function));
         case JsonCastType::DataType::DOUBLE:
             return std::make_unique<index::JsonInvertedIndex<double>>(
                 cast_dtype,
                 nested_path,
                 file_manager_context,
+                create_index_info.tantivy_index_version,
                 JsonCastFunction::FromString(json_cast_function));
         case JsonCastType::DataType::VARCHAR:
             return std::make_unique<index::JsonInvertedIndex<std::string>>(
                 cast_dtype,
                 nested_path,
                 file_manager_context,
+                create_index_info.tantivy_index_version,
                 JsonCastFunction::FromString(json_cast_function));
         default:
             PanicInfo(DataTypeInvalid, "Invalid data type:{}", cast_dtype);

--- a/internal/core/src/index/JsonInvertedIndex.h
+++ b/internal/core/src/index/JsonInvertedIndex.h
@@ -71,6 +71,7 @@ class JsonInvertedIndex : public index::InvertedIndexTantivy<T> {
     JsonInvertedIndex(const JsonCastType& cast_type,
                       const std::string& nested_path,
                       const storage::FileManagerContext& ctx,
+                      const int64_t tantivy_index_version,
                       const JsonCastFunction& cast_function =
                           JsonCastFunction::FromString("unknown"))
         : nested_path_(nested_path),
@@ -94,8 +95,11 @@ class JsonInvertedIndex : public index::InvertedIndexTantivy<T> {
         boost::filesystem::create_directories(this->path_);
         std::string field_name = std::to_string(
             this->disk_file_manager_->GetFieldDataMeta().field_id);
-        this->wrapper_ = std::make_shared<index::TantivyIndexWrapper>(
-            field_name.c_str(), this->d_type_, this->path_.c_str());
+        this->wrapper_ =
+            std::make_shared<index::TantivyIndexWrapper>(field_name.c_str(),
+                                                         this->d_type_,
+                                                         this->path_.c_str(),
+                                                         tantivy_index_version);
     }
 
     void


### PR DESCRIPTION
pr: #43563 
issue: https://github.com/milvus-io/milvus/issues/43562