### PR TITLE
enhance: better auto-detect of SVE options for the bitset library

### DIFF
--- a/internal/core/src/bitset/CMakeLists.txt
+++ b/internal/core/src/bitset/CMakeLists.txt
@@ -13,7 +13,7 @@ set(BITSET_SRCS
     detail/platform/dynamic.cpp
 )
 
-
+add_library(milvus_bitset)
 
 if (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64")
     list(APPEND BITSET_SRCS
@@ -34,10 +34,35 @@ elseif (${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm*")
         detail/platform/arm/instruction_set.cpp
     )
 
+    # Perform a test for the ARM SVE command set.
+    # Sometimes, a compiler may support it, but there are no headers available.
+    include(CheckCXXCompilerFlag)
+    include(CheckIncludeFileCXX)
+
+    check_cxx_compiler_flag("-march=armv8-a+sve" COMPILER_SUPPORTS_SVE)
+    check_include_file_cxx("arm_sve.h" COMPILER_HAS_ARM_SVE_HEADER)
+
+    if(COMPILER_SUPPORTS_SVE)
+        message(STATUS "Compiler supports SVE")
+    else()
+        message(STATUS "Compiler does NOT support SVE")
+    endif()
+
+    if(COMPILER_HAS_ARM_SVE_HEADER)
+        message(STATUS "Compiler has arm_sve.h")
+    else()
+        message(STATUS "Compiler has no arm_sve.h")
+    endif()
+
     # targeting AWS graviton, 
     #  https://github.com/aws/aws-graviton-getting-started/blob/main/c-c%2B%2B.md
 
-    #set_source_files_properties(detail/platform/arm/sve-inst.cpp PROPERTIES COMPILE_FLAGS "-mcpu=neoverse-v1")
+    if (COMPILER_SUPPORTS_SVE AND COMPILER_HAS_ARM_SVE_HEADER)
+        message(STATUS "SVE support for the bitset library is enabled")
+        target_compile_definitions(milvus_bitset PRIVATE BITSET_ENABLE_SVE_SUPPORT=1)
+
+        set_source_files_properties(detail/platform/arm/sve-inst.cpp PROPERTIES COMPILE_FLAGS "-march=armv8-a+sve")
+    endif()
 endif()
 
-add_library(milvus_bitset OBJECT ${BITSET_SRCS})
+target_sources(milvus_bitset PRIVATE ${BITSET_SRCS})

--- a/internal/core/src/bitset/detail/platform/arm/sve-inst.cpp
+++ b/internal/core/src/bitset/detail/platform/arm/sve-inst.cpp
@@ -19,7 +19,7 @@
 #include "bitset/common.h"
 
 #ifndef BITSET_HEADER_ONLY
-#ifdef __ARM_FEATURE_SVE
+#if defined(__ARM_FEATURE_SVE) && defined(BITSET_ENABLE_SVE_SUPPORT)
 
 #include "sve-decl.h"
 #include "sve-impl.h"

--- a/internal/core/src/bitset/detail/platform/dynamic.cpp
+++ b/internal/core/src/bitset/detail/platform/dynamic.cpp
@@ -622,7 +622,7 @@ init_dynamic_hook() {
 #endif
 
 #if defined(__aarch64__)
-#if defined(__ARM_FEATURE_SVE)
+#if defined(BITSET_ENABLE_SVE_SUPPORT)
     // sve
     if (arm::InstructionSet::GetInstance().supports_sve()) {
 #define SET_OP_COMPARE_COLUMN_SVE(TTYPE, UTYPE, OP)              \

--- a/internal/core/unittest/CMakeLists.txt
+++ b/internal/core/unittest/CMakeLists.txt
@@ -213,9 +213,26 @@ add_subdirectory(bench)
 # install(TARGETS dynamic_simd_test DESTINATION unittest)
 # endif()
 
+# bitset unit test
+include(CheckCXXCompilerFlag)
+include(CheckIncludeFileCXX)
+
+check_cxx_compiler_flag("-march=armv8-a+sve" COMPILER_SUPPORTS_SVE)
+check_include_file_cxx("arm_sve.h" COMPILER_HAS_ARM_SVE_HEADER)
+
 add_executable(bitset_test
         test_bitset.cpp
 )
+
+if (COMPILER_SUPPORTS_SVE AND COMPILER_HAS_ARM_SVE_HEADER)
+        message(STATUS "SVE support for the bitset library UT is enabled")
+        target_compile_definitions(bitset_test PRIVATE BITSET_ENABLE_SVE_SUPPORT=1)
+
+        set_source_files_properties(test_bitset.cpp PROPERTIES COMPILE_FLAGS "-march=armv8-a+sve")
+else()
+        message(STATUS "SVE support for the bitset library UT is disabled")
+endif()
+
 target_link_libraries(bitset_test
         milvus_bitset
         gtest

--- a/internal/core/unittest/test_bitset.cpp
+++ b/internal/core/unittest/test_bitset.cpp
@@ -39,7 +39,7 @@
 #if defined(__aarch64__)
 #include "bitset/detail/platform/arm/neon.h"
 
-#ifdef __ARM_FEATURE_SVE
+#if defined(__ARM_FEATURE_SVE) && defined(BITSET_ENABLE_SVE_SUPPORT)
 #include "bitset/detail/platform/arm/sve.h"
 #endif
 
@@ -503,7 +503,7 @@ TYPED_TEST_P(FindSuite, Neon) {
 }
 
 TYPED_TEST_P(FindSuite, Sve) {
-#if defined(__aarch64__) && defined(__ARM_FEATURE_SVE)
+#if defined(__aarch64__) && defined(__ARM_FEATURE_SVE) && defined(BITSET_ENABLE_SVE_SUPPORT)
     using namespace milvus::bitset::detail::arm;
 
     using impl_traits =
@@ -688,7 +688,7 @@ TYPED_TEST_P(InplaceCompareColumnSuite, Neon) {
 
 //
 TYPED_TEST_P(InplaceCompareColumnSuite, Sve) {
-#if defined(__aarch64__) && defined(__ARM_FEATURE_SVE)
+#if defined(__aarch64__) && defined(__ARM_FEATURE_SVE) && defined(BITSET_ENABLE_SVE_SUPPORT)
     using namespace milvus::bitset::detail::arm;
 
     using impl_traits =
@@ -878,7 +878,7 @@ TYPED_TEST_P(InplaceCompareValSuite, Neon) {
 }
 
 TYPED_TEST_P(InplaceCompareValSuite, Sve) {
-#if defined(__aarch64__) && defined(__ARM_FEATURE_SVE)
+#if defined(__aarch64__) && defined(__ARM_FEATURE_SVE) && defined(BITSET_ENABLE_SVE_SUPPORT)
     using namespace milvus::bitset::detail::arm;
 
     using impl_traits =
@@ -1073,7 +1073,7 @@ TYPED_TEST_P(InplaceWithinRangeColumnSuite, Neon) {
 }
 
 TYPED_TEST_P(InplaceWithinRangeColumnSuite, Sve) {
-#if defined(__aarch64__) && defined(__ARM_FEATURE_SVE)
+#if defined(__aarch64__) && defined(__ARM_FEATURE_SVE) && defined(BITSET_ENABLE_SVE_SUPPORT)
     using namespace milvus::bitset::detail::arm;
 
     using impl_traits =
@@ -1259,7 +1259,7 @@ TYPED_TEST_P(InplaceWithinRangeValSuite, Neon) {
 }
 
 TYPED_TEST_P(InplaceWithinRangeValSuite, Sve) {
-#if defined(__aarch64__) && defined(__ARM_FEATURE_SVE)
+#if defined(__aarch64__) && defined(__ARM_FEATURE_SVE) && defined(BITSET_ENABLE_SVE_SUPPORT)
     using namespace milvus::bitset::detail::arm;
 
     using impl_traits =
@@ -1712,7 +1712,7 @@ TYPED_TEST_P(InplaceArithCompareSuite, Neon) {
 }
 
 TYPED_TEST_P(InplaceArithCompareSuite, Sve) {
-#if defined(__aarch64__) && defined(__ARM_FEATURE_SVE)
+#if defined(__aarch64__) && defined(__ARM_FEATURE_SVE) && defined(BITSET_ENABLE_SVE_SUPPORT)
     using namespace milvus::bitset::detail::arm;
 
     using impl_traits =
@@ -1897,7 +1897,7 @@ TYPED_TEST_P(AppendSuite, Neon) {
 }
 
 TYPED_TEST_P(AppendSuite, Sve) {
-#if defined(__aarch64__) && defined(__ARM_FEATURE_SVE)
+#if defined(__aarch64__) && defined(__ARM_FEATURE_SVE) && defined(BITSET_ENABLE_SVE_SUPPORT)
     using namespace milvus::bitset::detail::arm;
 
     using impl_traits =
@@ -2062,7 +2062,7 @@ TYPED_TEST_P(CountSuite, Neon) {
 }
 
 TYPED_TEST_P(CountSuite, Sve) {
-#if defined(__aarch64__) && defined(__ARM_FEATURE_SVE)
+#if defined(__aarch64__) && defined(__ARM_FEATURE_SVE) && defined(BITSET_ENABLE_SVE_SUPPORT)
     using namespace milvus::bitset::detail::arm;
 
     using impl_traits =
@@ -2408,7 +2408,7 @@ TYPED_TEST_P(InplaceOpSuite, Neon) {
 }
 
 TYPED_TEST_P(InplaceOpSuite, Sve) {
-#if defined(__aarch64__) && defined(__ARM_FEATURE_SVE)
+#if defined(__aarch64__) && defined(__ARM_FEATURE_SVE) && defined(BITSET_ENABLE_SVE_SUPPORT)
     using namespace milvus::bitset::detail::arm;
 
     using impl_traits =
@@ -2636,7 +2636,7 @@ TYPED_TEST_P(InplaceOpMultipleSuite, Neon) {
 }
 
 TYPED_TEST_P(InplaceOpMultipleSuite, Sve) {
-#if defined(__aarch64__) && defined(__ARM_FEATURE_SVE)
+#if defined(__aarch64__) && defined(__ARM_FEATURE_SVE) && defined(BITSET_ENABLE_SVE_SUPPORT)
     using namespace milvus::bitset::detail::arm;
 
     using impl_traits =
@@ -2851,7 +2851,7 @@ TYPED_TEST_P(FillSuite, Neon) {
 }
 
 TYPED_TEST_P(FillSuite, Sve) {
-#if defined(__aarch64__) && defined(__ARM_FEATURE_SVE)
+#if defined(__aarch64__) && defined(__ARM_FEATURE_SVE) && defined(BITSET_ENABLE_SVE_SUPPORT)
     using namespace milvus::bitset::detail::arm;
 
     using impl_traits =


### PR DESCRIPTION
Enables the compilation of SVE code for the bitset library if a C++ compiler supports it.

There are two conditions for enabling the SVE code
* a C++ compiler needs to have a `-march=armv8-a+sve`
* `arm_sve.h` header must be available

AFAIK, `gcc 7 does not support SVE`, `gcc 8` and `gcc 9` support SVE, but have no `arm_sve.h` file, and only `gcc 10` has both.
    