### PR TITLE
enhance: [DataCoord] Remove full-collection index work from metrics

### DIFF
--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -538,11 +538,6 @@ func (m *meta) GetQuotaInfo() *metricsinfo.DataCoordQuotaMetrics {
 	return info
 }
 
-// SetStoredIndexFileSizeMetric returns the total index files size of all segment for each collection.
-func (m *meta) SetStoredIndexFileSizeMetric() uint64 {
-	return m.indexMeta.SetStoredIndexFileSizeMetric(m.collections)
-}
-
 func (m *meta) GetAllCollectionNumRows() map[int64]int64 {
 	m.segMu.RLock()
 	defer m.segMu.RUnlock()

--- a/internal/datacoord/meta_test.go
+++ b/internal/datacoord/meta_test.go
@@ -838,20 +838,6 @@ func TestMeta_Basic(t *testing.T) {
 		assert.Equal(t, int64(size0+size1), quotaInfo.TotalBinlogSize)
 	})
 
-	t.Run("Test GetCollectionBinlogSize", func(t *testing.T) {
-		meta := createMeta(&datacoord.Catalog{}, withIndexMeta(createIndexMeta(&datacoord.Catalog{})))
-		ret := meta.SetStoredIndexFileSizeMetric()
-		assert.Equal(t, uint64(0), ret)
-
-		meta.collections = typeutil.NewConcurrentMap[UniqueID, *collectionInfo]()
-		meta.collections.Insert(100, &collectionInfo{
-			ID:           100,
-			DatabaseName: "db",
-		})
-		ret = meta.SetStoredIndexFileSizeMetric()
-		assert.Equal(t, uint64(11), ret)
-	})
-
 	t.Run("Test AddAllocation", func(t *testing.T) {
 		meta, _ := newMemoryMeta(t)
 		err := meta.AddAllocation(1, &Allocation{


### PR DESCRIPTION
issue: #43858

- Remove full-collection index handling in getCollectionMetrics
- Avoid heavy metadata scans and RPC calls during metrics
- Reduce latency and CPU/memory usage on large datasets
- No functional change to metrics semantics