### PR TITLE
enhance: Implement dynamic interval updates for ticker components

### DIFF
--- a/internal/querycoordv2/dist/dist_handler.go
+++ b/internal/querycoordv2/dist/dist_handler.go
@@ -68,9 +68,11 @@ func (dh *distHandler) start(ctx context.Context) {
 	defer dh.wg.Done()
 	log := log.Ctx(ctx).With(zap.Int64("nodeID", dh.nodeID)).WithRateGroup("qcv2.distHandler", 1, 60)
 	log.Info("start dist handler")
-	ticker := time.NewTicker(Params.QueryCoordCfg.DistPullInterval.GetAsDuration(time.Millisecond))
+	distInterval := Params.QueryCoordCfg.DistPullInterval.GetAsDuration(time.Millisecond)
+	ticker := time.NewTicker(distInterval)
 	defer ticker.Stop()
-	checkExecutedFlagTicker := time.NewTicker(Params.QueryCoordCfg.CheckExecutedFlagInterval.GetAsDuration(time.Millisecond))
+	flagInterval := Params.QueryCoordCfg.CheckExecutedFlagInterval.GetAsDuration(time.Millisecond)
+	checkExecutedFlagTicker := time.NewTicker(flagInterval)
 	defer checkExecutedFlagTicker.Stop()
 	failures := 0
 	for {
@@ -90,8 +92,28 @@ func (dh *distHandler) start(ctx context.Context) {
 				default:
 				}
 			}
+			// only reset when interval updated
+			newFlagInterval := Params.QueryCoordCfg.CheckExecutedFlagInterval.GetAsDuration(time.Millisecond)
+			if newFlagInterval != flagInterval {
+				flagInterval = newFlagInterval
+				select {
+				case <-checkExecutedFlagTicker.C:
+				default:
+				}
+				checkExecutedFlagTicker.Reset(flagInterval)
+			}
 		case <-ticker.C:
 			dh.pullDist(ctx, &failures, true)
+			// only reset when interval updated
+			newDistInterval := Params.QueryCoordCfg.DistPullInterval.GetAsDuration(time.Millisecond)
+			if newDistInterval != distInterval {
+				distInterval = newDistInterval
+				select {
+				case <-ticker.C:
+				default:
+				}
+				ticker.Reset(distInterval)
+			}
 		}
 	}
 }

--- a/internal/querynodev2/segments/disk_usage_fetcher.go
+++ b/internal/querynodev2/segments/disk_usage_fetcher.go
@@ -76,6 +76,16 @@ func (d *diskUsageFetcher) Start() {
 			return
 		case <-ticker.C:
 			d.fetch()
+			// apply dynamic update only when changed
+			newInterval := paramtable.Get().QueryNodeCfg.DiskSizeFetchInterval.GetAsDuration(time.Second)
+			if newInterval != interval {
+				interval = newInterval
+				select {
+				case <-ticker.C:
+				default:
+				}
+				ticker.Reset(interval)
+			}
 		}
 	}
 }


### PR DESCRIPTION
issue: #43858

Enable dynamic configuration updates for ticker intervals without restart. This enhancement allows runtime configuration changes to take effect immediately for better operational flexibility.

Changes include:
- Apply "drain+Reset only when interval changed" pattern across all ticker components to preserve existing timing phases
- Fix goroutine variable capture issue in CheckerController.Start()
- Remove unnecessary ticker.Stop() in manual trigger paths
- Add dynamic interval checking in QueryCoordV2 components:
  * checkers/controller.go: Various checker intervals
  * dist/dist_handler.go: DistPullInterval, CheckExecutedFlagInterval
  * session/cluster.go: CheckNodeSessionInterval
  * server.go: CheckAutoBalanceConfigInterval
  * observers/target_observer.go: UpdateNextTargetInterval
  * observers/collection_observer.go: CollectionObserverInterval
- Add dynamic interval checking in QueryNodeV2 components:
  * segments/disk_usage_fetcher.go: DiskSizeFetchInterval
- Ensure thread safety by performing all ticker operations in same goroutine with proper drain before Reset to avoid spurious triggers