### PR TITLE
fix: typo in autoindex param panic message

### DIFF
--- a/pkg/util/paramtable/autoindex_param.go
+++ b/pkg/util/paramtable/autoindex_param.go
@@ -103,7 +103,7 @@ func (p *AutoIndexConfig) init(base *BaseTable) {
 		Key:          "autoIndex.params.binary.build",
 		Version:      "2.4.5",
 		DefaultValue: `{"nlist": 1024, "index_type": "BIN_IVF_FLAT", "metric_type": "HAMMING"}`,
-		Formatter:    GetBuildParamFormatter(BinaryVectorDefaultMetricType, "autoIndex.params.sparse.build"),
+		Formatter:    GetBuildParamFormatter(BinaryVectorDefaultMetricType, "autoIndex.params.binary.build"),
 		Export:       true,
 	}
 	p.BinaryIndexParams.Init(base.mgr)


### PR DESCRIPTION
Fix a minor typo in autoindex panic message which may cause confusion troubleshooting.