### PR TITLE
fix: [2.5] Fixed bug for the % was treadted as wildcard with an escape character

### DIFF
--- a/internal/parser/planparserv2/pattern_match.go
+++ b/internal/parser/planparserv2/pattern_match.go
@@ -57,7 +57,7 @@ func optimizeLikePattern(pattern string) (planpb.OpType, string, bool) {
 	trailing := isUnescapedTrailingPercent(pattern)
 
 	trimRight := func(s string) string {
-		if s[len(s)-1] != '%' {
+		if s == "" || s[len(s)-1] != '%' {
 			return s
 		}
 		for i := len(s) - 2; i >= 0; i-- {

--- a/internal/parser/planparserv2/pattern_match_test.go
+++ b/internal/parser/planparserv2/pattern_match_test.go
@@ -80,6 +80,8 @@ func TestOptimizeLikePattern(t *testing.T) {
 		{"%a\t%", planpb.OpType_InnerMatch, "a\t", true},
 		{"%", planpb.OpType_PrefixMatch, "", true},
 		{"%%", planpb.OpType_PrefixMatch, "", true},
+		{"a\\%%", planpb.OpType_PrefixMatch, "a%", true},
+		{"a\\\\%%", planpb.OpType_PrefixMatch, "a\\\\", true},
 		{"%a%b%", planpb.OpType_Invalid, "", false},
 		{"%a_b%", planpb.OpType_Invalid, "", false},
 		{"%abc\\", planpb.OpType_PostfixMatch, "abc\\", true},


### PR DESCRIPTION
issue: #43864 
master pr: #43887

1. `expr = 'text like "abc\\\\%%"'` should only match strings that start with the prefix `abc%`.
For example, it can match strings like `abc%def` and `abc%bca`, but it should not match `abcdef` or `abc\def`.