### PR TITLE
fix: dirty querynode doesn't clean up after restart

### DIFF
--- a/internal/querycoordv2/server.go
+++ b/internal/querycoordv2/server.go
@@ -469,12 +469,10 @@ func (s *Server) startQueryCoord() error {
 		return err
 	}
 
-	if len(sessions) > 0 {
-		log.Info("rewatch nodes", zap.Any("sessions", sessions))
-		err = s.rewatchNodes(sessions)
-		if err != nil {
-			return err
-		}
+	log.Info("rewatch nodes", zap.Any("sessions", sessions))
+	err = s.rewatchNodes(sessions)
+	if err != nil {
+		return err
 	}
 
 	s.wg.Add(1)

--- a/internal/querycoordv2/server_test.go
+++ b/internal/querycoordv2/server_test.go
@@ -761,7 +761,7 @@ func TestRewatchNodesWithEmptySessions(t *testing.T) {
 	defer mockHandleNodeDown.UnPatch()
 
 	// Act: Call rewatchNodes with empty sessions
-	err := server.rewatchNodes(map[string]*sessionutil.Session{})
+	err := server.rewatchNodes(nil)
 
 	// Assert: All nodes should be removed
 	assert.NoError(t, err)


### PR DESCRIPTION
issue: #43905