### PR TITLE
fix: Add back check rg nodes in rewatch logic

### DIFF
--- a/internal/querycoordv2/server.go
+++ b/internal/querycoordv2/server.go
@@ -717,6 +717,19 @@ func (s *Server) rewatchNodes(sessions map[string]*sessionutil.Session) error {
 		}
 	}
 
+	// check resource group nodes and remove legacy nodes
+	for _, rgName := range s.meta.ListResourceGroups(s.ctx) {
+		rg := s.meta.ResourceManager.GetResourceGroup(s.ctx, rgName)
+		for _, node := range rg.GetNodes() {
+			info := s.nodeMgr.Get(node)
+			if info == nil {
+				s.meta.ResourceManager.HandleNodeDown(context.Background(), node)
+			} else if info.IsStoppingState() {
+				s.meta.ResourceManager.HandleNodeStopping(context.Background(), node)
+			}
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Related to #43904

This patch adds back the check resource group node logic in `rewatchNodes` in case of legacy nodes left in rg info.