### PR TITLE
enhance: add a missing header for gcc 13+ compilation

### DIFF
--- a/internal/core/src/index/Meta.h
+++ b/internal/core/src/index/Meta.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "knowhere/comp/index_param.h"
 
 namespace milvus::index {


### PR DESCRIPTION
issue: #43616 
