### PR TITLE
enhance: Add request stats interceptor collecting req metrics

### DIFF
--- a/internal/distributed/proxy/request_interceptor.go
+++ b/internal/distributed/proxy/request_interceptor.go
@@ -1,0 +1,109 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpcproxy
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"google.golang.org/grpc"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus/pkg/v2/metrics"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v2/util/requestutil"
+	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
+)
+
+var retryableCode typeutil.Set[int32]
+
+func init() {
+	retryableCode = typeutil.NewSet(
+		merr.Code(merr.ErrServiceRateLimit),
+		merr.Code(merr.ErrCollectionSchemaMismatch),
+	)
+}
+
+// UnaryRequestStatsInterceptor implements `grpc.UnaryServerInterceptor`
+// it records incoming grpc request metrics in unified interceptor
+//
+// when some retirable error occurs, it will record it as `RetryLabel` instead of failure one
+// when other interceptor rejects the request, it will record it as `RejectedLabel`
+func UnaryRequestStatsInterceptor(ctx context.Context, req any, rpcInfo *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	methodTag := ParseShortMethodName(rpcInfo.FullMethod)
+	db, _ := requestutil.GetDbNameFromRequest(req)
+	collection, _ := requestutil.GetCollectionNameFromRequest(req)
+
+	dbName := db.(string)
+	collectionName := collection.(string)
+
+	metrics.ProxyFunctionCall.WithLabelValues(
+		strconv.FormatInt(paramtable.GetNodeID(), 10),
+		methodTag,
+		metrics.TotalLabel,
+		dbName,
+		collectionName,
+	).Inc()
+
+	resp, err := handler(ctx, req)
+
+	metrics.ProxyFunctionCall.WithLabelValues(
+		strconv.FormatInt(paramtable.GetNodeID(), 10),
+		methodTag,
+		ParseMetricLabel(resp, err),
+		dbName,
+		collectionName,
+	).Inc()
+
+	return resp, err
+}
+
+// ParseShortMethodName parse short method name from full method name
+// input like: "/milvus.proto.milvus.MilvusService/Search"
+// returns "Search"
+func ParseShortMethodName(fullMethodName string) string {
+	parts := strings.Split(fullMethodName, "/")
+	return parts[len(parts)-1]
+}
+
+func ParseMetricLabel(resp any, err error) string {
+	// err only returned by interceptors
+	if err != nil {
+		return metrics.RejectedLabel
+	}
+
+	// check response status code
+	var status *commonpb.Status
+	switch resp := resp.(type) {
+	case interface{ GetStatus() *commonpb.Status }:
+		status = resp.GetStatus()
+	case *commonpb.Status:
+		status = resp
+	}
+
+	// check if retry
+	if !merr.Ok(status) {
+		// TODO use retriable if all set
+		if retryableCode.Contain(status.GetCode()) {
+			return metrics.RetryLabel
+		}
+		return metrics.FailLabel
+	}
+	return metrics.SuccessLabel
+}

--- a/internal/distributed/proxy/request_interceptor_test.go
+++ b/internal/distributed/proxy/request_interceptor_test.go
@@ -1,0 +1,141 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpcproxy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
+	"github.com/milvus-io/milvus/pkg/v2/metrics"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v2/util/testutils"
+)
+
+type StatsInterceptorSuite struct {
+	testutils.PromMetricsSuite
+}
+
+func (suite *StatsInterceptorSuite) TestUnaryRequestStatsInterceptor() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	type testCase struct {
+		tag          string
+		req          any
+		info         *grpc.UnaryServerInfo
+		handler      grpc.UnaryHandler
+		expectLabels [][]string
+	}
+
+	dbName := "default"
+	collection := "test"
+
+	cases := []testCase{
+		{
+			tag: "normal",
+			req: &milvuspb.CreateCollectionRequest{
+				DbName:         dbName,
+				CollectionName: collection,
+			},
+			info: &grpc.UnaryServerInfo{
+				FullMethod: milvuspb.MilvusService_CreateCollection_FullMethodName,
+			},
+			handler: func(ctx context.Context, req any) (interface{}, error) {
+				return merr.Success(), nil
+			},
+			expectLabels: [][]string{
+				{paramtable.GetStringNodeID(), "CreateCollection", metrics.TotalLabel, dbName, collection},
+				{paramtable.GetStringNodeID(), "CreateCollection", metrics.SuccessLabel, dbName, collection},
+			},
+		},
+		{
+			tag: "service_internal",
+			req: &milvuspb.CreateCollectionRequest{
+				DbName:         dbName,
+				CollectionName: collection,
+			},
+			info: &grpc.UnaryServerInfo{
+				FullMethod: milvuspb.MilvusService_CreateCollection_FullMethodName,
+			},
+			handler: func(ctx context.Context, req any) (interface{}, error) {
+				return merr.Status(merr.WrapErrServiceInternal("unexpcted")), nil
+			},
+			expectLabels: [][]string{
+				{paramtable.GetStringNodeID(), "CreateCollection", metrics.TotalLabel, dbName, collection},
+				{paramtable.GetStringNodeID(), "CreateCollection", metrics.FailLabel, dbName, collection},
+			},
+		},
+		{
+			tag: "rate_limited",
+			req: &milvuspb.InsertRequest{
+				DbName:         dbName,
+				CollectionName: collection,
+			},
+			info: &grpc.UnaryServerInfo{
+				FullMethod: milvuspb.MilvusService_Insert_FullMethodName,
+			},
+			handler: func(ctx context.Context, req any) (interface{}, error) {
+				return &milvuspb.MutationResult{
+					Status: merr.Status(merr.ErrServiceRateLimit),
+				}, nil
+			},
+			expectLabels: [][]string{
+				{paramtable.GetStringNodeID(), "Insert", metrics.TotalLabel, dbName, collection},
+				{paramtable.GetStringNodeID(), "Insert", metrics.RetryLabel, dbName, collection},
+			},
+		},
+		{
+			tag: "not_authorized",
+			req: &milvuspb.CreateCollectionRequest{
+				DbName:         dbName,
+				CollectionName: collection,
+			},
+			info: &grpc.UnaryServerInfo{
+				FullMethod: milvuspb.MilvusService_CreateCollection_FullMethodName,
+			},
+			handler: func(ctx context.Context, req any) (interface{}, error) {
+				return nil, status.Error(codes.Unauthenticated, "auth check failure, please check api key is correct")
+			},
+			expectLabels: [][]string{
+				{paramtable.GetStringNodeID(), "CreateCollection", metrics.TotalLabel, dbName, collection},
+				{paramtable.GetStringNodeID(), "CreateCollection", metrics.RejectedLabel, dbName, collection},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		suite.Run(tc.tag, func() {
+			UnaryRequestStatsInterceptor(ctx, tc.req, tc.info, tc.handler)
+			for _, labels := range tc.expectLabels {
+				suite.MetricsEqual(metrics.ProxyFunctionCall.WithLabelValues(labels...), 1)
+			}
+			metrics.ProxyFunctionCall.DeletePartialMatch(prometheus.Labels{})
+		})
+	}
+}
+
+func TestUnaryRequestStatsInterceptor(t *testing.T) {
+	suite.Run(t, new(StatsInterceptorSuite))
+}

--- a/internal/distributed/proxy/service.go
+++ b/internal/distributed/proxy/service.go
@@ -238,9 +238,10 @@ func (s *Server) startExternalGrpc(errChan chan error) {
 	var unaryServerOption grpc.ServerOption
 	if enableCustomInterceptor {
 		unaryServerOption = grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(
+			proxy.DatabaseInterceptor(),
+			UnaryRequestStatsInterceptor,
 			accesslog.UnaryAccessLogInterceptor,
 			proxy.GrpcAuthInterceptor(proxy.AuthenticationInterceptor),
-			proxy.DatabaseInterceptor(),
 			proxy.UnaryServerHookInterceptor(),
 			proxy.UnaryServerInterceptor(proxy.PrivilegeInterceptor),
 			logutil.UnaryTraceLoggerInterceptor,

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -26,11 +26,13 @@ import (
 const (
 	milvusNamespace = "milvus"
 
-	AbandonLabel = "abandon"
-	SuccessLabel = "success"
-	FailLabel    = "fail"
-	CancelLabel  = "cancel"
-	TotalLabel   = "total"
+	AbandonLabel  = "abandon"
+	SuccessLabel  = "success"
+	FailLabel     = "fail"
+	CancelLabel   = "cancel"
+	TotalLabel    = "total"
+	RetryLabel    = "retry"
+	RejectedLabel = "rejected"
 
 	HybridSearchLabel = "hybrid_search"
 


### PR DESCRIPTION
Related to #43966 #43809

This PR:
- Replace distributed request metrics collection into one interceptor
- Add `Retry` and `Reject` label represents auth rejection and retry-able error cases