### PR TITLE
fix: Prevent panic in upsert due to missing nullable fields [Proxy]

### DIFF
--- a/internal/proxy/task_upsert.go
+++ b/internal/proxy/task_upsert.go
@@ -401,9 +401,6 @@ func (it *upsertTask) queryPreExecute(ctx context.Context) error {
 						return err
 					}
 					insertWithNullField = append(insertWithNullField, fieldData)
-				} else {
-					// unreachable code
-					return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("field %s is not nullable and has no default value", fieldSchema.Name))
 				}
 			} else {
 				insertWithNullField = append(insertWithNullField, fieldData)

--- a/internal/proxy/task_upsert_test.go
+++ b/internal/proxy/task_upsert_test.go
@@ -1082,3 +1082,273 @@ func TestUpdateTask_PreExecute_QueryPreExecuteError(t *testing.T) {
 		assert.Contains(t, err.Error(), "query pre-execute failed")
 	})
 }
+
+func TestUpsertTask_queryPreExecute_MixLogic(t *testing.T) {
+	// Schema for the test collection
+	schema := newSchemaInfo(&schemapb.CollectionSchema{
+		Name: "test_merge_collection",
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "id", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
+			{FieldID: 101, Name: "value", DataType: schemapb.DataType_Int32},
+			{FieldID: 102, Name: "extra", DataType: schemapb.DataType_VarChar, Nullable: true},
+		},
+	})
+
+	// Upsert IDs: 1 (update), 2 (update), 3 (insert)
+	upsertData := []*schemapb.FieldData{
+		{
+			FieldName: "id", FieldId: 100, Type: schemapb.DataType_Int64,
+			Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{1, 2, 3}}}}},
+		},
+		{
+			FieldName: "value", FieldId: 101, Type: schemapb.DataType_Int32,
+			Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: []int32{100, 200, 300}}}}},
+		},
+	}
+	numRows := uint64(len(upsertData[0].GetScalars().GetLongData().GetData()))
+
+	// Query result for existing PKs: 1, 2
+	mockQueryResult := &milvuspb.QueryResults{
+		Status: merr.Success(),
+		FieldsData: []*schemapb.FieldData{
+			{
+				FieldName: "id", FieldId: 100, Type: schemapb.DataType_Int64,
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{1, 2}}}}},
+			},
+			{
+				FieldName: "value", FieldId: 101, Type: schemapb.DataType_Int32,
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: []int32{10, 20}}}}},
+			},
+			{
+				FieldName: "extra", FieldId: 102, Type: schemapb.DataType_VarChar,
+				Field:     &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: []string{"old1", "old2"}}}}},
+				ValidData: []bool{true, true},
+			},
+		},
+	}
+
+	task := &upsertTask{
+		ctx:    context.Background(),
+		schema: schema,
+		req: &milvuspb.UpsertRequest{
+			FieldsData: upsertData,
+			NumRows:    uint32(numRows),
+		},
+		upsertMsg: &msgstream.UpsertMsg{
+			InsertMsg: &msgstream.InsertMsg{
+				InsertRequest: &msgpb.InsertRequest{
+					FieldsData: upsertData,
+					NumRows:    numRows,
+				},
+			},
+		},
+		node: &Proxy{},
+	}
+
+	mockRetrieve := mockey.Mock(retrieveByPKs).Return(mockQueryResult, nil).Build()
+	defer mockRetrieve.UnPatch()
+
+	err := task.queryPreExecute(context.Background())
+	assert.NoError(t, err)
+
+	// Verify delete PKs
+	deletePks := task.deletePKs.GetIntId().GetData()
+	assert.ElementsMatch(t, []int64{1, 2}, deletePks)
+
+	// Verify merged insert data
+	primaryFieldSchema, err := typeutil.GetPrimaryFieldSchema(schema.CollectionSchema)
+	assert.NoError(t, err)
+	idField, err := typeutil.GetPrimaryFieldData(task.insertFieldData, primaryFieldSchema)
+	assert.NoError(t, err)
+	ids, err := parsePrimaryFieldData2IDs(idField)
+	assert.NoError(t, err)
+	insertPKs := ids.GetIntId().GetData()
+	assert.Equal(t, []int64{1, 2, 3}, insertPKs)
+
+	var valueField *schemapb.FieldData
+	for _, f := range task.insertFieldData {
+		if f.GetFieldName() == "value" {
+			valueField = f
+			break
+		}
+	}
+	assert.NotNil(t, valueField)
+	assert.Equal(t, []int32{100, 200, 300}, valueField.GetScalars().GetIntData().GetData())
+}
+
+func TestUpsertTask_queryPreExecute_PureInsert(t *testing.T) {
+	// Schema for the test collection
+	schema := newSchemaInfo(&schemapb.CollectionSchema{
+		Name: "test_merge_collection",
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "id", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
+			{FieldID: 101, Name: "value", DataType: schemapb.DataType_Int32},
+			{FieldID: 102, Name: "extra", DataType: schemapb.DataType_VarChar, Nullable: true},
+		},
+	})
+
+	// Upsert IDs: 4, 5
+	upsertData := []*schemapb.FieldData{
+		{
+			FieldName: "id", FieldId: 100, Type: schemapb.DataType_Int64,
+			Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{4, 5}}}}},
+		},
+		{
+			FieldName: "value", FieldId: 101, Type: schemapb.DataType_Int32,
+			Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: []int32{400, 500}}}}},
+		},
+	}
+	numRows := uint64(len(upsertData[0].GetScalars().GetLongData().GetData()))
+
+	// Query result is empty, but schema is preserved
+	mockQueryResult := &milvuspb.QueryResults{Status: merr.Success(), FieldsData: []*schemapb.FieldData{
+		{
+			FieldName: "id", FieldId: 100, Type: schemapb.DataType_Int64,
+			Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{}}}}},
+		},
+		{
+			FieldName: "value", FieldId: 101, Type: schemapb.DataType_Int32,
+			Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: []int32{}}}}},
+		},
+		{
+			FieldName: "extra", FieldId: 102, Type: schemapb.DataType_VarChar,
+			Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: []string{}}}}},
+		},
+	}}
+
+	task := &upsertTask{
+		ctx:    context.Background(),
+		schema: schema,
+		req: &milvuspb.UpsertRequest{
+			FieldsData: upsertData,
+			NumRows:    uint32(numRows),
+		},
+		upsertMsg: &msgstream.UpsertMsg{
+			InsertMsg: &msgstream.InsertMsg{
+				InsertRequest: &msgpb.InsertRequest{
+					FieldsData: upsertData,
+					NumRows:    numRows,
+				},
+			},
+		},
+		node: &Proxy{},
+	}
+
+	mockRetrieve := mockey.Mock(retrieveByPKs).Return(mockQueryResult, nil).Build()
+	defer mockRetrieve.UnPatch()
+
+	err := task.queryPreExecute(context.Background())
+	assert.NoError(t, err)
+
+	// Verify delete PKs
+	deletePks := task.deletePKs.GetIntId().GetData()
+	assert.Empty(t, deletePks)
+
+	// Verify merged insert data
+	primaryFieldSchema, err := typeutil.GetPrimaryFieldSchema(schema.CollectionSchema)
+	assert.NoError(t, err)
+	idField, err := typeutil.GetPrimaryFieldData(task.insertFieldData, primaryFieldSchema)
+	assert.NoError(t, err)
+	ids, err := parsePrimaryFieldData2IDs(idField)
+	assert.NoError(t, err)
+	insertPKs := ids.GetIntId().GetData()
+	assert.Equal(t, []int64{4, 5}, insertPKs)
+
+	var valueField *schemapb.FieldData
+	for _, f := range task.insertFieldData {
+		if f.GetFieldName() == "value" {
+			valueField = f
+			break
+		}
+	}
+	assert.NotNil(t, valueField)
+	assert.Equal(t, []int32{400, 500}, valueField.GetScalars().GetIntData().GetData())
+}
+
+func TestUpsertTask_queryPreExecute_PureUpdate(t *testing.T) {
+	// Schema for the test collection
+	schema := newSchemaInfo(&schemapb.CollectionSchema{
+		Name: "test_merge_collection",
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "id", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
+			{FieldID: 101, Name: "value", DataType: schemapb.DataType_Int32},
+			{FieldID: 102, Name: "extra", DataType: schemapb.DataType_VarChar, Nullable: true},
+		},
+	})
+
+	// Upsert IDs: 6, 7
+	upsertData := []*schemapb.FieldData{
+		{
+			FieldName: "id", FieldId: 100, Type: schemapb.DataType_Int64,
+			Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{6, 7}}}}},
+		},
+		{
+			FieldName: "value", FieldId: 101, Type: schemapb.DataType_Int32,
+			Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: []int32{600, 700}}}}},
+		},
+	}
+	numRows := uint64(len(upsertData[0].GetScalars().GetLongData().GetData()))
+
+	// Query result for existing PKs: 6, 7
+	mockQueryResult := &milvuspb.QueryResults{
+		Status: merr.Success(),
+		FieldsData: []*schemapb.FieldData{
+			{
+				FieldName: "id", FieldId: 100, Type: schemapb.DataType_Int64,
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{6, 7}}}}},
+			},
+			{
+				FieldName: "value", FieldId: 101, Type: schemapb.DataType_Int32,
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: []int32{60, 70}}}}},
+			},
+		},
+	}
+
+	task := &upsertTask{
+		ctx:    context.Background(),
+		schema: schema,
+		req: &milvuspb.UpsertRequest{
+			FieldsData: upsertData,
+			NumRows:    uint32(numRows),
+		},
+		upsertMsg: &msgstream.UpsertMsg{
+			InsertMsg: &msgstream.InsertMsg{
+				InsertRequest: &msgpb.InsertRequest{
+					FieldsData: upsertData,
+					NumRows:    numRows,
+				},
+			},
+		},
+		node: &Proxy{},
+	}
+
+	mockRetrieve := mockey.Mock(retrieveByPKs).Return(mockQueryResult, nil).Build()
+	defer mockRetrieve.UnPatch()
+
+	err := task.queryPreExecute(context.Background())
+	assert.NoError(t, err)
+
+	// Verify delete PKs
+	deletePks := task.deletePKs.GetIntId().GetData()
+	assert.ElementsMatch(t, []int64{6, 7}, deletePks)
+
+	// Verify merged insert data
+	primaryFieldSchema, err := typeutil.GetPrimaryFieldSchema(schema.CollectionSchema)
+	assert.NoError(t, err)
+	idField, err := typeutil.GetPrimaryFieldData(task.insertFieldData, primaryFieldSchema)
+	assert.NoError(t, err)
+	ids, err := parsePrimaryFieldData2IDs(idField)
+	assert.NoError(t, err)
+	insertPKs := ids.GetIntId().GetData()
+	assert.Equal(t, []int64{6, 7}, insertPKs)
+
+	var valueField *schemapb.FieldData
+	for _, f := range task.insertFieldData {
+		if f.GetFieldName() == "value" {
+			valueField = f
+			break
+		}
+	}
+	assert.NotNil(t, valueField)
+	assert.Equal(t, []int32{600, 700}, valueField.GetScalars().GetIntData().GetData())
+}

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -1952,6 +1952,10 @@ func LackOfFieldsDataBySchema(schema *schemapb.CollectionSchema, fieldsData []*s
 			continue
 		}
 
+		if fieldSchema.GetNullable() || fieldSchema.GetDefaultValue() != nil {
+			continue
+		}
+
 		if _, ok := dataNameMap[fieldSchema.GetName()]; !ok {
 			if (fieldSchema.IsPrimaryKey && fieldSchema.AutoID && !Params.ProxyCfg.SkipAutoIDCheck.GetAsBool() && skipPkFieldCheck) ||
 				IsBM25FunctionOutputField(fieldSchema, schema) ||

--- a/pkg/util/typeutil/schema.go
+++ b/pkg/util/typeutil/schema.go
@@ -1085,15 +1085,25 @@ func UpdateFieldData(base, update []*schemapb.FieldData, baseIdx, updateIdx int6
 			continue
 		}
 
+		updateFieldIdx := updateIdx
 		// Update ValidData if present
 		if len(updateFieldData.GetValidData()) != 0 {
 			if len(baseFieldData.GetValidData()) != 0 {
-				baseFieldData.ValidData[baseIdx] = updateFieldData.ValidData[updateIdx]
+				baseFieldData.ValidData[baseIdx] = updateFieldData.ValidData[updateFieldIdx]
 			}
 
 			// update field data to null,only modify valid data
-			if !updateFieldData.ValidData[updateIdx] {
+			if !updateFieldData.ValidData[updateFieldIdx] {
 				continue
+			}
+
+			// for nullable field data, such as data=[1,1], valid_data=[true, false, true]
+			// should update the updateFieldIdx to the expected valid index
+			updateFieldIdx = 0
+			for _, validData := range updateFieldData.GetValidData()[:updateIdx] {
+				if validData {
+					updateFieldIdx += 1
+				}
 			}
 		}
 
@@ -1107,43 +1117,43 @@ func UpdateFieldData(base, update []*schemapb.FieldData, baseIdx, updateIdx int6
 			switch baseScalar.Data.(type) {
 			case *schemapb.ScalarField_BoolData:
 				updateData := updateScalar.GetBoolData()
-				if updateData != nil && int(updateIdx) < len(updateData.Data) {
-					baseScalar.GetBoolData().Data[baseIdx] = updateData.Data[updateIdx]
+				if updateData != nil && int(updateFieldIdx) < len(updateData.Data) {
+					baseScalar.GetBoolData().Data[baseIdx] = updateData.Data[updateFieldIdx]
 				}
 			case *schemapb.ScalarField_IntData:
 				updateData := updateScalar.GetIntData()
-				if updateData != nil && int(updateIdx) < len(updateData.Data) {
-					baseScalar.GetIntData().Data[baseIdx] = updateData.Data[updateIdx]
+				if updateData != nil && int(updateFieldIdx) < len(updateData.Data) {
+					baseScalar.GetIntData().Data[baseIdx] = updateData.Data[updateFieldIdx]
 				}
 			case *schemapb.ScalarField_LongData:
 				updateData := updateScalar.GetLongData()
-				if updateData != nil && int(updateIdx) < len(updateData.Data) {
-					baseScalar.GetLongData().Data[baseIdx] = updateData.Data[updateIdx]
+				if updateData != nil && int(updateFieldIdx) < len(updateData.Data) {
+					baseScalar.GetLongData().Data[baseIdx] = updateData.Data[updateFieldIdx]
 				}
 			case *schemapb.ScalarField_FloatData:
 				updateData := updateScalar.GetFloatData()
-				if updateData != nil && int(updateIdx) < len(updateData.Data) {
-					baseScalar.GetFloatData().Data[baseIdx] = updateData.Data[updateIdx]
+				if updateData != nil && int(updateFieldIdx) < len(updateData.Data) {
+					baseScalar.GetFloatData().Data[baseIdx] = updateData.Data[updateFieldIdx]
 				}
 			case *schemapb.ScalarField_DoubleData:
 				updateData := updateScalar.GetDoubleData()
-				if updateData != nil && int(updateIdx) < len(updateData.Data) {
-					baseScalar.GetDoubleData().Data[baseIdx] = updateData.Data[updateIdx]
+				if updateData != nil && int(updateFieldIdx) < len(updateData.Data) {
+					baseScalar.GetDoubleData().Data[baseIdx] = updateData.Data[updateFieldIdx]
 				}
 			case *schemapb.ScalarField_StringData:
 				updateData := updateScalar.GetStringData()
-				if updateData != nil && int(updateIdx) < len(updateData.Data) {
-					baseScalar.GetStringData().Data[baseIdx] = updateData.Data[updateIdx]
+				if updateData != nil && int(updateFieldIdx) < len(updateData.Data) {
+					baseScalar.GetStringData().Data[baseIdx] = updateData.Data[updateFieldIdx]
 				}
 			case *schemapb.ScalarField_ArrayData:
 				updateData := updateScalar.GetArrayData()
-				if updateData != nil && int(updateIdx) < len(updateData.Data) {
-					baseScalar.GetArrayData().Data[baseIdx] = updateData.Data[updateIdx]
+				if updateData != nil && int(updateFieldIdx) < len(updateData.Data) {
+					baseScalar.GetArrayData().Data[baseIdx] = updateData.Data[updateFieldIdx]
 				}
 			case *schemapb.ScalarField_JsonData:
 				updateData := updateScalar.GetJsonData()
 				baseData := baseScalar.GetJsonData()
-				if updateData != nil && int(updateIdx) < len(updateData.Data) {
+				if updateData != nil && int(updateFieldIdx) < len(updateData.Data) {
 					if baseFieldData.GetIsDynamic() {
 						// dynamic field is a json with only 1 level nested struct,
 						// so we need to unmarshal and iterate updateData's key value, and update the baseData's key value
@@ -1153,7 +1163,7 @@ func UpdateFieldData(base, update []*schemapb.FieldData, baseIdx, updateIdx int6
 						if err := json.Unmarshal(baseData.Data[baseIdx], &baseMap); err != nil {
 							return fmt.Errorf("failed to unmarshal base json: %v", err)
 						}
-						if err := json.Unmarshal(updateData.Data[updateIdx], &updateMap); err != nil {
+						if err := json.Unmarshal(updateData.Data[updateFieldIdx], &updateMap); err != nil {
 							return fmt.Errorf("failed to unmarshal update json: %v", err)
 						}
 						// merge
@@ -1167,7 +1177,7 @@ func UpdateFieldData(base, update []*schemapb.FieldData, baseIdx, updateIdx int6
 						}
 						baseScalar.GetJsonData().Data[baseIdx] = newJSON
 					} else {
-						baseScalar.GetJsonData().Data[baseIdx] = updateData.Data[updateIdx]
+						baseScalar.GetJsonData().Data[baseIdx] = updateData.Data[updateFieldIdx]
 					}
 				}
 			default:
@@ -1186,10 +1196,10 @@ func UpdateFieldData(base, update []*schemapb.FieldData, baseIdx, updateIdx int6
 				updateData := updateVector.GetBinaryVector()
 				if updateData != nil {
 					baseData := baseVector.GetBinaryVector()
-					baseStartIdx := updateIdx * (dim / 8)
-					baseEndIdx := (updateIdx + 1) * (dim / 8)
-					updateStartIdx := updateIdx * (dim / 8)
-					updateEndIdx := (updateIdx + 1) * (dim / 8)
+					baseStartIdx := updateFieldIdx * (dim / 8)
+					baseEndIdx := (updateFieldIdx + 1) * (dim / 8)
+					updateStartIdx := updateFieldIdx * (dim / 8)
+					updateEndIdx := (updateFieldIdx + 1) * (dim / 8)
 					if int(updateEndIdx) <= len(updateData) && int(baseEndIdx) <= len(baseData) {
 						copy(baseData[baseStartIdx:baseEndIdx], updateData[updateStartIdx:updateEndIdx])
 					}
@@ -1198,10 +1208,10 @@ func UpdateFieldData(base, update []*schemapb.FieldData, baseIdx, updateIdx int6
 				updateData := updateVector.GetFloatVector()
 				if updateData != nil {
 					baseData := baseVector.GetFloatVector()
-					baseStartIdx := updateIdx * dim
-					baseEndIdx := (updateIdx + 1) * dim
-					updateStartIdx := updateIdx * dim
-					updateEndIdx := (updateIdx + 1) * dim
+					baseStartIdx := updateFieldIdx * dim
+					baseEndIdx := (updateFieldIdx + 1) * dim
+					updateStartIdx := updateFieldIdx * dim
+					updateEndIdx := (updateFieldIdx + 1) * dim
 					if int(updateEndIdx) <= len(updateData.Data) && int(baseEndIdx) <= len(baseData.Data) {
 						copy(baseData.Data[baseStartIdx:baseEndIdx], updateData.Data[updateStartIdx:updateEndIdx])
 					}
@@ -1210,10 +1220,10 @@ func UpdateFieldData(base, update []*schemapb.FieldData, baseIdx, updateIdx int6
 				updateData := updateVector.GetFloat16Vector()
 				if updateData != nil {
 					baseData := baseVector.GetFloat16Vector()
-					baseStartIdx := updateIdx * (dim * 2)
-					baseEndIdx := (updateIdx + 1) * (dim * 2)
-					updateStartIdx := updateIdx * (dim * 2)
-					updateEndIdx := (updateIdx + 1) * (dim * 2)
+					baseStartIdx := updateFieldIdx * (dim * 2)
+					baseEndIdx := (updateFieldIdx + 1) * (dim * 2)
+					updateStartIdx := updateFieldIdx * (dim * 2)
+					updateEndIdx := (updateFieldIdx + 1) * (dim * 2)
 					if int(updateEndIdx) <= len(updateData) && int(baseEndIdx) <= len(baseData) {
 						copy(baseData[baseStartIdx:baseEndIdx], updateData[updateStartIdx:updateEndIdx])
 					}
@@ -1222,20 +1232,20 @@ func UpdateFieldData(base, update []*schemapb.FieldData, baseIdx, updateIdx int6
 				updateData := updateVector.GetBfloat16Vector()
 				if updateData != nil {
 					baseData := baseVector.GetBfloat16Vector()
-					baseStartIdx := updateIdx * (dim * 2)
-					baseEndIdx := (updateIdx + 1) * (dim * 2)
-					updateStartIdx := updateIdx * (dim * 2)
-					updateEndIdx := (updateIdx + 1) * (dim * 2)
+					baseStartIdx := updateFieldIdx * (dim * 2)
+					baseEndIdx := (updateFieldIdx + 1) * (dim * 2)
+					updateStartIdx := updateFieldIdx * (dim * 2)
+					updateEndIdx := (updateFieldIdx + 1) * (dim * 2)
 					if int(updateEndIdx) <= len(updateData) && int(baseEndIdx) <= len(baseData) {
 						copy(baseData[baseStartIdx:baseEndIdx], updateData[updateStartIdx:updateEndIdx])
 					}
 				}
 			case *schemapb.VectorField_SparseFloatVector:
 				updateData := updateVector.GetSparseFloatVector()
-				if updateData != nil && int(updateIdx) < len(updateData.Contents) {
+				if updateData != nil && int(updateFieldIdx) < len(updateData.Contents) {
 					baseData := baseVector.GetSparseFloatVector()
-					if int(updateIdx) < len(baseData.Contents) {
-						baseData.Contents[updateIdx] = updateData.Contents[updateIdx]
+					if int(updateFieldIdx) < len(baseData.Contents) {
+						baseData.Contents[updateFieldIdx] = updateData.Contents[updateFieldIdx]
 						// Update dimension if necessary
 						if updateData.Dim > baseData.Dim {
 							baseData.Dim = updateData.Dim
@@ -1246,10 +1256,10 @@ func UpdateFieldData(base, update []*schemapb.FieldData, baseIdx, updateIdx int6
 				updateData := updateVector.GetInt8Vector()
 				if updateData != nil {
 					baseData := baseVector.GetInt8Vector()
-					baseStartIdx := updateIdx * dim
-					baseEndIdx := (updateIdx + 1) * dim
-					updateStartIdx := updateIdx * dim
-					updateEndIdx := (updateIdx + 1) * dim
+					baseStartIdx := updateFieldIdx * dim
+					baseEndIdx := (updateFieldIdx + 1) * dim
+					updateStartIdx := updateFieldIdx * dim
+					updateEndIdx := (updateFieldIdx + 1) * dim
 					if int(updateEndIdx) <= len(updateData) && int(baseEndIdx) <= len(baseData) {
 						copy(baseData[baseStartIdx:baseEndIdx], updateData[updateStartIdx:updateEndIdx])
 					}

--- a/pkg/util/typeutil/schema_test.go
+++ b/pkg/util/typeutil/schema_test.go
@@ -3078,7 +3078,7 @@ func TestUpdateFieldData(t *testing.T) {
 		}
 
 		// Update index 1
-		err := UpdateFieldData(baseData, updateData, 1)
+		err := UpdateFieldData(baseData, updateData, 1, 1)
 		require.NoError(t, err)
 
 		// Check results
@@ -3141,7 +3141,7 @@ func TestUpdateFieldData(t *testing.T) {
 		}
 
 		// Update index 1 (second vector)
-		err := UpdateFieldData(baseData, updateData, 1)
+		err := UpdateFieldData(baseData, updateData, 1, 1)
 		require.NoError(t, err)
 
 		// Check results
@@ -3180,7 +3180,7 @@ func TestUpdateFieldData(t *testing.T) {
 		updateData := []*schemapb.FieldData{}
 
 		// Update should succeed but change nothing
-		err := UpdateFieldData(baseData, updateData, 1)
+		err := UpdateFieldData(baseData, updateData, 1, 1)
 		require.NoError(t, err)
 
 		// Data should remain unchanged
@@ -3225,9 +3225,9 @@ func TestUpdateFieldData(t *testing.T) {
 		}
 
 		// Update index 1
-		err := UpdateFieldData(baseData, updateData, 1)
+		err := UpdateFieldData(baseData, updateData, 1, 1)
 		require.NoError(t, err)
-		err = UpdateFieldData(baseData, updateData, 2)
+		err = UpdateFieldData(baseData, updateData, 2, 2)
 		require.NoError(t, err)
 
 		// Check that ValidData was updated
@@ -3283,7 +3283,7 @@ func TestUpdateFieldData(t *testing.T) {
 		}
 
 		// Test updating first row
-		err := UpdateFieldData(baseData, updateData, 0)
+		err := UpdateFieldData(baseData, updateData, 0, 0)
 		require.NoError(t, err)
 
 		// Verify first row was correctly merged
@@ -3298,7 +3298,7 @@ func TestUpdateFieldData(t *testing.T) {
 		assert.Equal(t, "new_value", result["key5"])  // New value
 
 		// Test updating second row
-		err = UpdateFieldData(baseData, updateData, 1)
+		err = UpdateFieldData(baseData, updateData, 1, 1)
 		require.NoError(t, err)
 
 		// Verify second row was correctly merged
@@ -3356,7 +3356,7 @@ func TestUpdateFieldData(t *testing.T) {
 		}
 
 		// Test updating
-		err := UpdateFieldData(baseData, updateData, 0)
+		err := UpdateFieldData(baseData, updateData, 0, 0)
 		require.NoError(t, err)
 
 		// For non-dynamic fields, the update should completely replace the old value
@@ -3407,7 +3407,7 @@ func TestUpdateFieldData(t *testing.T) {
 		}
 
 		// Test updating with invalid base JSON
-		err := UpdateFieldData(baseData, updateData, 0)
+		err := UpdateFieldData(baseData, updateData, 0, 0)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to unmarshal base json")
 
@@ -3416,7 +3416,7 @@ func TestUpdateFieldData(t *testing.T) {
 		updateData[0].GetScalars().GetJsonData().Data[0] = []byte(`invalid json`)
 
 		// Test updating with invalid update JSON
-		err = UpdateFieldData(baseData, updateData, 0)
+		err = UpdateFieldData(baseData, updateData, 0, 0)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to unmarshal update json")
 	})


### PR DESCRIPTION
issue: #43980
Fixes a panic that occurred when a partial update was converted to an insert due to a non-existent primary key. The panic was caused by missing nullable fields that were not provided in the original partial update request.

The upsert pre-execution logic is refactored to handle this correctly:
- Explicitly splits upsert data into 'insert' and 'update' batches.
- Automatically generates data for missing nullable or default-value fields during inserts, preventing the panic.
- Enhances `typeutil.UpdateFieldData` to support different source and destination indexes for flexible data merging.
- Adds comprehensive unit tests for mixed upsert, pure insert, and pure update scenarios.