### PR TITLE
enhance: print as storage size unit MB with 2 digits only, so the log is easier to read

### DIFF
--- a/pkg/util/gc/gc_tuner.go
+++ b/pkg/util/gc/gc_tuner.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/util/hardware"
+	"github.com/milvus-io/milvus/pkg/v2/util/logutil"
 )
 
 var (
@@ -82,25 +83,21 @@ func optimizeGOGC() {
 
 	action(newGoGC)
 
-	toMB := func(mem uint64) uint64 {
-		return mem / 1024 / 1024
-	}
-
 	// currently we assume 20 ms as long gc pause
 	if (m.PauseNs[(m.NumGC+255)%256] / uint64(time.Millisecond)) < 20 {
 		log.Ctx(context.TODO()).Debug("GC Tune done", zap.Uint32("previous GOGC", previousGOGC),
-			zap.Uint64("heapuse ", toMB(heapuse)),
-			zap.Uint64("total memory", toMB(totaluse)),
-			zap.Uint64("next GC", toMB(m.NextGC)),
+			zap.Uint64("heapuse ", logutil.ToMB(heapuse)),
+			zap.Uint64("total memory", logutil.ToMB(totaluse)),
+			zap.Uint64("next GC", logutil.ToMB(m.NextGC)),
 			zap.Uint32("new GOGC", newGoGC),
 			zap.Duration("gc-pause", time.Duration(m.PauseNs[(m.NumGC+255)%256])),
 			zap.Uint64("gc-pause-end", m.PauseEnd[(m.NumGC+255)%256]),
 		)
 	} else {
 		log.Ctx(context.TODO()).Warn("GC Tune done, and the gc is slow", zap.Uint32("previous GOGC", previousGOGC),
-			zap.Uint64("heapuse ", toMB(heapuse)),
-			zap.Uint64("total memory", toMB(totaluse)),
-			zap.Uint64("next GC", toMB(m.NextGC)),
+			zap.Uint64("heapuse ", logutil.ToMB(heapuse)),
+			zap.Uint64("total memory", logutil.ToMB(totaluse)),
+			zap.Uint64("next GC", logutil.ToMB(m.NextGC)),
 			zap.Uint32("new GOGC", newGoGC),
 			zap.Duration("gc-pause", time.Duration(m.PauseNs[(m.NumGC+255)%256])),
 			zap.Uint64("gc-pause-end", m.PauseEnd[(m.NumGC+255)%256]),

--- a/pkg/util/logutil/logutil.go
+++ b/pkg/util/logutil/logutil.go
@@ -18,10 +18,12 @@ package logutil
 
 import (
 	"context"
+	"math"
 	"sync"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"golang.org/x/exp/constraints"
 	"google.golang.org/grpc/grpclog"
 
 	"github.com/milvus-io/milvus/pkg/v2/log"
@@ -171,4 +173,9 @@ func Logger(ctx context.Context) *zap.Logger {
 
 func WithModule(ctx context.Context, module string) context.Context {
 	return log.WithModule(ctx, module)
+}
+
+// keeps only 2 decimal places
+func ToMB[T constraints.Integer | constraints.Float](mem T) T {
+	return T(math.Round(float64(mem)/1024/1024*100) / 100)
 }

--- a/pkg/util/merr/utils.go
+++ b/pkg/util/merr/utils.go
@@ -27,6 +27,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/milvus-io/milvus/pkg/v2/log"
+	"github.com/milvus-io/milvus/pkg/v2/util/logutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
 
@@ -354,12 +355,9 @@ func WrapErrServiceUnavailable(reason string, msg ...string) error {
 }
 
 func WrapErrServiceMemoryLimitExceeded(predict, limit float32, msg ...string) error {
-	toMB := func(mem float32) float32 {
-		return mem / 1024 / 1024
-	}
 	err := wrapFields(ErrServiceMemoryLimitExceeded,
-		value("predict(MB)", toMB(predict)),
-		value("limit(MB)", toMB(limit)),
+		value("predict(MB)", logutil.ToMB(float64(predict))),
+		value("limit(MB)", logutil.ToMB(float64(limit))),
 	)
 	if len(msg) > 0 {
 		err = errors.Wrap(err, strings.Join(msg, "->"))
@@ -397,12 +395,9 @@ func WrapErrServiceCrossClusterRouting(expectedCluster, actualCluster string, ms
 }
 
 func WrapErrServiceDiskLimitExceeded(predict, limit float32, msg ...string) error {
-	toMB := func(mem float32) float32 {
-		return mem / 1024 / 1024
-	}
 	err := wrapFields(ErrServiceDiskLimitExceeded,
-		value("predict(MB)", toMB(predict)),
-		value("limit(MB)", toMB(limit)),
+		value("predict(MB)", logutil.ToMB(float64(predict))),
+		value("limit(MB)", logutil.ToMB(float64(limit))),
 	)
 	if len(msg) > 0 {
 		err = errors.Wrap(err, strings.Join(msg, "->"))


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/41435