### PR TITLE
fix: use query node label check if streamingnode

### DIFF
--- a/internal/querycoordv2/balance/channel_level_score_balancer_test.go
+++ b/internal/querycoordv2/balance/channel_level_score_balancer_test.go
@@ -72,7 +72,7 @@ func (suite *ChannelLevelScoreBalancerTestSuite) SetupTest() {
 	testMeta := meta.NewMeta(idAllocator, store, nodeManager)
 	testTarget := meta.NewTargetManager(suite.broker, testMeta)
 
-	distManager := meta.NewDistributionManager()
+	distManager := meta.NewDistributionManager(nodeManager)
 	suite.mockScheduler = task.NewMockScheduler(suite.T())
 	suite.balancer = NewChannelLevelScoreBalancer(suite.mockScheduler, nodeManager, distManager, testMeta, testTarget)
 

--- a/internal/querycoordv2/balance/rowcount_based_balancer_test.go
+++ b/internal/querycoordv2/balance/rowcount_based_balancer_test.go
@@ -74,7 +74,7 @@ func (suite *RowCountBasedBalancerTestSuite) SetupTest() {
 	testMeta := meta.NewMeta(idAllocator, store, nodeManager)
 	testTarget := meta.NewTargetManager(suite.broker, testMeta)
 
-	distManager := meta.NewDistributionManager()
+	distManager := meta.NewDistributionManager(nodeManager)
 	suite.mockScheduler = task.NewMockScheduler(suite.T())
 	suite.balancer = NewRowCountBasedBalancer(suite.mockScheduler, nodeManager, distManager, testMeta, testTarget)
 

--- a/internal/querycoordv2/balance/score_based_balancer_test.go
+++ b/internal/querycoordv2/balance/score_based_balancer_test.go
@@ -74,7 +74,7 @@ func (suite *ScoreBasedBalancerTestSuite) SetupTest() {
 	testMeta := meta.NewMeta(idAllocator, store, nodeManager)
 	testTarget := meta.NewTargetManager(suite.broker, testMeta)
 
-	distManager := meta.NewDistributionManager()
+	distManager := meta.NewDistributionManager(nodeManager)
 	suite.mockScheduler = task.NewMockScheduler(suite.T())
 	suite.balancer = NewScoreBasedBalancer(suite.mockScheduler, nodeManager, distManager, testMeta, testTarget)
 

--- a/internal/querycoordv2/checkers/channel_checker_test.go
+++ b/internal/querycoordv2/checkers/channel_checker_test.go
@@ -78,7 +78,7 @@ func (suite *ChannelCheckerTestSuite) SetupTest() {
 	suite.broker = meta.NewMockBroker(suite.T())
 	targetManager := meta.NewTargetManager(suite.broker, suite.meta)
 
-	distManager := meta.NewDistributionManager()
+	distManager := meta.NewDistributionManager(suite.nodeMgr)
 
 	balancer := suite.createMockBalancer()
 	suite.checker = NewChannelChecker(suite.meta, distManager, targetManager, suite.nodeMgr, func() balance.Balance { return balancer })

--- a/internal/querycoordv2/checkers/controller_base_test.go
+++ b/internal/querycoordv2/checkers/controller_base_test.go
@@ -71,7 +71,7 @@ func (suite *ControllerBaseTestSuite) SetupTest() {
 	idAllocator := RandomIncrementIDAllocator()
 	suite.nodeMgr = session.NewNodeManager()
 	suite.meta = meta.NewMeta(idAllocator, store, suite.nodeMgr)
-	suite.dist = meta.NewDistributionManager()
+	suite.dist = meta.NewDistributionManager(suite.nodeMgr)
 	suite.broker = meta.NewMockBroker(suite.T())
 	suite.targetManager = meta.NewTargetManager(suite.broker, suite.meta)
 

--- a/internal/querycoordv2/checkers/controller_test.go
+++ b/internal/querycoordv2/checkers/controller_test.go
@@ -77,7 +77,7 @@ func (suite *CheckerControllerSuite) SetupTest() {
 	idAllocator := RandomIncrementIDAllocator()
 	suite.nodeMgr = session.NewNodeManager()
 	suite.meta = meta.NewMeta(idAllocator, store, suite.nodeMgr)
-	suite.dist = meta.NewDistributionManager()
+	suite.dist = meta.NewDistributionManager(suite.nodeMgr)
 	suite.broker = meta.NewMockBroker(suite.T())
 	suite.targetManager = meta.NewTargetManager(suite.broker, suite.meta)
 

--- a/internal/querycoordv2/checkers/index_checker_test.go
+++ b/internal/querycoordv2/checkers/index_checker_test.go
@@ -73,7 +73,7 @@ func (suite *IndexCheckerSuite) SetupTest() {
 	idAllocator := params.RandomIncrementIDAllocator()
 	suite.nodeMgr = session.NewNodeManager()
 	suite.meta = meta.NewMeta(idAllocator, store, suite.nodeMgr)
-	distManager := meta.NewDistributionManager()
+	distManager := meta.NewDistributionManager(suite.nodeMgr)
 	suite.broker = meta.NewMockBroker(suite.T())
 
 	suite.targetMgr = meta.NewMockTargetManager(suite.T())

--- a/internal/querycoordv2/checkers/leader_checker_test.go
+++ b/internal/querycoordv2/checkers/leader_checker_test.go
@@ -73,7 +73,7 @@ func (suite *LeaderCheckerTestSuite) SetupTest() {
 	suite.meta = meta.NewMeta(idAllocator, store, suite.nodeMgr)
 	suite.broker = meta.NewMockBroker(suite.T())
 
-	distManager := meta.NewDistributionManager()
+	distManager := meta.NewDistributionManager(suite.nodeMgr)
 	targetManager := meta.NewTargetManager(suite.broker, suite.meta)
 	suite.checker = NewLeaderChecker(suite.meta, distManager, targetManager, suite.nodeMgr)
 }

--- a/internal/querycoordv2/checkers/segment_checker_test.go
+++ b/internal/querycoordv2/checkers/segment_checker_test.go
@@ -73,7 +73,7 @@ func (suite *SegmentCheckerTestSuite) SetupTest() {
 	idAllocator := RandomIncrementIDAllocator()
 	suite.nodeMgr = session.NewNodeManager()
 	suite.meta = meta.NewMeta(idAllocator, store, suite.nodeMgr)
-	distManager := meta.NewDistributionManager()
+	distManager := meta.NewDistributionManager(suite.nodeMgr)
 	suite.broker = meta.NewMockBroker(suite.T())
 	targetManager := meta.NewTargetManager(suite.broker, suite.meta)
 

--- a/internal/querycoordv2/dist/dist_controller_test.go
+++ b/internal/querycoordv2/dist/dist_controller_test.go
@@ -76,7 +76,7 @@ func (suite *DistControllerTestSuite) SetupTest() {
 	suite.meta = meta.NewMeta(idAllocator, store, suite.nodeMgr)
 
 	suite.mockCluster = session.NewMockCluster(suite.T())
-	distManager := meta.NewDistributionManager()
+	distManager := meta.NewDistributionManager(suite.nodeMgr)
 	suite.broker = meta.NewMockBroker(suite.T())
 	targetManager := meta.NewTargetManager(suite.broker, suite.meta)
 	suite.mockScheduler = task.NewMockScheduler(suite.T())

--- a/internal/querycoordv2/dist/dist_handler_test.go
+++ b/internal/querycoordv2/dist/dist_handler_test.go
@@ -64,7 +64,7 @@ func (suite *DistHandlerSuite) SetupSuite() {
 	suite.client = session.NewMockCluster(suite.T())
 	suite.nodeManager = session.NewNodeManager()
 	suite.scheduler = task.NewMockScheduler(suite.T())
-	suite.dist = meta.NewDistributionManager()
+	suite.dist = meta.NewDistributionManager(suite.nodeManager)
 
 	suite.target = meta.NewMockTargetManager(suite.T())
 	suite.ctx = context.Background()
@@ -298,7 +298,7 @@ func TestHeartbeatMetricsRecording(t *testing.T) {
 	handler := &distHandler{
 		nodeID:      nodeID,
 		nodeManager: nodeManager,
-		dist:        meta.NewDistributionManager(),
+		dist:        meta.NewDistributionManager(nodeManager),
 		target:      meta.NewTargetManager(nil, nil),
 		scheduler:   task.NewScheduler(ctx, nil, nil, nil, nil, nil, nil),
 	}

--- a/internal/querycoordv2/handlers_test.go
+++ b/internal/querycoordv2/handlers_test.go
@@ -142,7 +142,7 @@ func TestServer_getSegmentsJSON(t *testing.T) {
 	req := &milvuspb.GetMetricsRequest{}
 	mockCluster.EXPECT().GetMetrics(mock.Anything, mock.Anything, req).Return(resp, nil)
 
-	server.dist = meta.NewDistributionManager()
+	server.dist = meta.NewDistributionManager(nodeManager)
 	server.dist.SegmentDistManager.Update(1, meta.SegmentFromInfo(&datapb.SegmentInfo{
 		ID:            1,
 		CollectionID:  1,

--- a/internal/querycoordv2/job/job_test.go
+++ b/internal/querycoordv2/job/job_test.go
@@ -172,7 +172,7 @@ func (suite *JobSuite) SetupTest() {
 	suite.ctx = context.Background()
 
 	suite.store = querycoord.NewCatalog(suite.kv)
-	suite.dist = meta.NewDistributionManager()
+	suite.dist = meta.NewDistributionManager(session.NewNodeManager())
 	suite.nodeMgr = session.NewNodeManager()
 	suite.meta = meta.NewMeta(RandomIncrementIDAllocator(), suite.store, suite.nodeMgr)
 	suite.targetMgr = meta.NewTargetManager(suite.broker, suite.meta)

--- a/internal/querycoordv2/meta/dist_manager.go
+++ b/internal/querycoordv2/meta/dist_manager.go
@@ -20,6 +20,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/internal/json"
+	"github.com/milvus-io/milvus/internal/querycoordv2/session"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/util/metricsinfo"
 )
@@ -29,10 +30,10 @@ type DistributionManager struct {
 	ChannelDistManager ChannelDistManagerInterface
 }
 
-func NewDistributionManager() *DistributionManager {
+func NewDistributionManager(nodeManager *session.NodeManager) *DistributionManager {
 	return &DistributionManager{
 		SegmentDistManager: NewSegmentDistManager(),
-		ChannelDistManager: NewChannelDistManager(),
+		ChannelDistManager: NewChannelDistManager(nodeManager),
 	}
 }
 

--- a/internal/querycoordv2/meta/dist_manager_test.go
+++ b/internal/querycoordv2/meta/dist_manager_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus/internal/json"
+	"github.com/milvus-io/milvus/internal/querycoordv2/session"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v2/util/metricsinfo"
@@ -14,7 +15,7 @@ import (
 
 func TestGetDistributionJSON(t *testing.T) {
 	// Initialize DistributionManager
-	manager := NewDistributionManager()
+	manager := NewDistributionManager(session.NewNodeManager())
 
 	// Add some segments to the SegmentDistManager
 	segment1 := SegmentFromInfo(&datapb.SegmentInfo{

--- a/internal/querycoordv2/observers/collection_observer_test.go
+++ b/internal/querycoordv2/observers/collection_observer_test.go
@@ -196,7 +196,7 @@ func (suite *CollectionObserverSuite) SetupTest() {
 	suite.store = querycoord.NewCatalog(suite.kv)
 
 	// Dependencies
-	suite.dist = meta.NewDistributionManager()
+	suite.dist = meta.NewDistributionManager(session.NewNodeManager())
 	suite.nodeMgr = session.NewNodeManager()
 	suite.meta = meta.NewMeta(suite.idAllocator, suite.store, suite.nodeMgr)
 	suite.broker = meta.NewMockBroker(suite.T())

--- a/internal/querycoordv2/observers/replica_observer_test.go
+++ b/internal/querycoordv2/observers/replica_observer_test.go
@@ -88,7 +88,7 @@ func (suite *ReplicaObserverSuite) SetupTest() {
 	suite.nodeMgr = session.NewNodeManager()
 	suite.meta = meta.NewMeta(idAllocator, store, suite.nodeMgr)
 
-	suite.distMgr = meta.NewDistributionManager()
+	suite.distMgr = meta.NewDistributionManager(suite.nodeMgr)
 	suite.observer = NewReplicaObserver(suite.meta, suite.distMgr)
 	suite.observer.Start()
 	suite.collectionID = int64(1000)

--- a/internal/querycoordv2/observers/target_observer_test.go
+++ b/internal/querycoordv2/observers/target_observer_test.go
@@ -96,7 +96,7 @@ func (suite *TargetObserverSuite) SetupTest() {
 
 	suite.broker = meta.NewMockBroker(suite.T())
 	suite.targetMgr = meta.NewTargetManager(suite.broker, suite.meta)
-	suite.distMgr = meta.NewDistributionManager()
+	suite.distMgr = meta.NewDistributionManager(nodeMgr)
 	suite.cluster = session.NewMockCluster(suite.T())
 	suite.observer = NewTargetObserver(suite.meta, suite.targetMgr, suite.distMgr, suite.broker, suite.cluster, nodeMgr)
 	suite.collectionID = int64(1000)
@@ -333,7 +333,7 @@ func (suite *TargetObserverCheckSuite) SetupTest() {
 
 	suite.broker = meta.NewMockBroker(suite.T())
 	suite.targetMgr = meta.NewTargetManager(suite.broker, suite.meta)
-	suite.distMgr = meta.NewDistributionManager()
+	suite.distMgr = meta.NewDistributionManager(nodeMgr)
 	suite.cluster = session.NewMockCluster(suite.T())
 	suite.observer = NewTargetObserver(
 		suite.meta,

--- a/internal/querycoordv2/ops_service_test.go
+++ b/internal/querycoordv2/ops_service_test.go
@@ -98,7 +98,7 @@ func (suite *OpsServiceSuite) SetupTest() {
 	suite.kv = etcdkv.NewEtcdKV(cli, config.MetaRootPath.GetValue())
 
 	suite.store = querycoord.NewCatalog(suite.kv)
-	suite.dist = meta.NewDistributionManager()
+	suite.dist = meta.NewDistributionManager(suite.nodeMgr)
 	suite.nodeMgr = session.NewNodeManager()
 	suite.meta = meta.NewMeta(params.RandomIncrementIDAllocator(), suite.store, suite.nodeMgr)
 	suite.broker = meta.NewMockBroker(suite.T())
@@ -126,7 +126,7 @@ func (suite *OpsServiceSuite) SetupTest() {
 		suite.targetMgr,
 	)
 	meta.GlobalFailedLoadCache = meta.NewFailedLoadCache()
-	suite.distMgr = meta.NewDistributionManager()
+	suite.distMgr = meta.NewDistributionManager(suite.nodeMgr)
 	suite.distController = dist.NewMockController(suite.T())
 
 	suite.checkerController = checkers.NewCheckerController(suite.meta, suite.distMgr,

--- a/internal/querycoordv2/server.go
+++ b/internal/querycoordv2/server.go
@@ -419,10 +419,7 @@ func (s *Server) initMeta() error {
 		return err
 	}
 
-	s.dist = &meta.DistributionManager{
-		SegmentDistManager: meta.NewSegmentDistManager(),
-		ChannelDistManager: meta.NewChannelDistManager(),
-	}
+	s.dist = meta.NewDistributionManager(s.nodeMgr)
 	s.targetMgr = meta.NewTargetManager(s.broker, s.meta)
 	err = s.targetMgr.Recover(s.ctx, s.store)
 	if err != nil {

--- a/internal/querycoordv2/server_test.go
+++ b/internal/querycoordv2/server_test.go
@@ -831,7 +831,7 @@ func TestHandleNodeDownMetricsCleanup(t *testing.T) {
 	server := &Server{
 		ctx:                 ctx,
 		taskScheduler:       task.NewScheduler(ctx, nil, nil, nil, nil, nil, nil),
-		dist:                meta.NewDistributionManager(),
+		dist:                meta.NewDistributionManager(session.NewNodeManager()),
 		distController:      dist.NewDistController(nil, nil, nil, nil, nil, nil),
 		metricsCacheManager: metricsinfo.NewMetricsCacheManager(),
 		meta: &meta.Meta{

--- a/internal/querycoordv2/services_test.go
+++ b/internal/querycoordv2/services_test.go
@@ -149,8 +149,8 @@ func (suite *ServiceSuite) SetupTest() {
 	suite.kv = etcdkv.NewEtcdKV(cli, config.MetaRootPath.GetValue())
 
 	suite.store = querycoord.NewCatalog(suite.kv)
-	suite.dist = meta.NewDistributionManager()
 	suite.nodeMgr = session.NewNodeManager()
+	suite.dist = meta.NewDistributionManager(suite.nodeMgr)
 	suite.meta = meta.NewMeta(params.RandomIncrementIDAllocator(), suite.store, suite.nodeMgr)
 	suite.broker = meta.NewMockBroker(suite.T())
 	suite.targetMgr = meta.NewTargetManager(suite.broker, suite.meta)
@@ -186,7 +186,7 @@ func (suite *ServiceSuite) SetupTest() {
 		suite.targetMgr,
 	)
 	meta.GlobalFailedLoadCache = meta.NewFailedLoadCache()
-	suite.distMgr = meta.NewDistributionManager()
+	suite.distMgr = meta.NewDistributionManager(suite.nodeMgr)
 	suite.distController = dist.NewMockController(suite.T())
 
 	suite.collectionObserver = observers.NewCollectionObserver(

--- a/internal/querycoordv2/task/task_test.go
+++ b/internal/querycoordv2/task/task_test.go
@@ -160,10 +160,10 @@ func (suite *TaskSuite) SetupTest() {
 	suite.kv = etcdkv.NewEtcdKV(cli, config.MetaRootPath.GetValue())
 	suite.store = querycoord.NewCatalog(suite.kv)
 	suite.meta = meta.NewMeta(RandomIncrementIDAllocator(), suite.store, session.NewNodeManager())
-	suite.dist = meta.NewDistributionManager()
+	suite.nodeMgr = session.NewNodeManager()
+	suite.dist = meta.NewDistributionManager(suite.nodeMgr)
 	suite.broker = meta.NewMockBroker(suite.T())
 	suite.target = meta.NewTargetManager(suite.broker, suite.meta)
-	suite.nodeMgr = session.NewNodeManager()
 	suite.cluster = session.NewMockCluster(suite.T())
 
 	suite.scheduler = suite.newScheduler()


### PR DESCRIPTION
issue: #44014

- Because the session of querynode and streamingnode is different.
- So when streamingnode session down first, a streaming query node will be treated as querynode.
- Use label but not streaming node session to fix it.