### PR TITLE
enhance: Optimize partial update merge logic by unifying nullable format

### DIFF
--- a/internal/proxy/task_upsert.go
+++ b/internal/proxy/task_upsert.go
@@ -296,17 +296,39 @@ func (it *upsertTask) queryPreExecute(ctx context.Context) error {
 		if fieldData.GetIsDynamic() {
 			fieldName = "$meta"
 		}
-		fieldID, ok := it.schema.MapFieldID(fieldName)
-		if !ok {
-			log.Info("field not found in schema", zap.Any("field", fieldData))
-			return merr.WrapErrParameterInvalidMsg("field not found in schema")
+		fieldSchema, err := it.schema.schemaHelper.GetFieldFromName(fieldName)
+		if err != nil {
+			log.Info("get field schema failed", zap.Error(err))
+			return err
 		}
-		fieldData.FieldId = fieldID
+		fieldData.FieldId = fieldSchema.GetFieldID()
 		fieldData.FieldName = fieldName
+
+		// compatible with different nullable data format from sdk
+		if len(fieldData.GetValidData()) != 0 {
+			err := FillWithNullValue(fieldData, fieldSchema, int(it.upsertMsg.InsertMsg.NRows()))
+			if err != nil {
+				log.Info("unify null field data format failed", zap.Error(err))
+				return err
+			}
+		}
 	}
 
-	// Note: the most difficult part is to handle the merge progress of upsert and query result
-	// we need to enable merge logic on different length between upsertFieldData and it.insertFieldData
+	// Two nullable data formats are supported:
+	//
+	//	COMPRESSED FORMAT (SDK format, before validateUtil.fillWithValue processing):
+	//		Logical data: [1, null, 2]
+	//		Storage: Data=[1, 2] + ValidData=[true, false, true]
+	//		- Data array contains only non-null values (compressed)
+	//		- ValidData array tracks null positions for all rows
+	//
+	//	FULL FORMAT (Milvus internal format, after validateUtil.fillWithValue processing):
+	//		Logical data: [1, null, 2]
+	//		Storage: Data=[1, 0, 2] + ValidData=[true, false, true]
+	//		- Data array contains values for all rows (nulls filled with zero/default)
+	//		- ValidData array still tracks null positions
+	//
+	// Note: we will unify the nullable format to FULL FORMAT before executing the merge logic
 	insertIdxInUpsert := make([]int, 0)
 	updateIdxInUpsert := make([]int, 0)
 	// 1. split upsert data into insert and update by query result
@@ -367,7 +389,7 @@ func (it *upsertTask) queryPreExecute(ctx context.Context) error {
 			if !ok {
 				return merr.WrapErrParameterInvalidMsg("primary key not found in exist data mapping")
 			}
-			typeutil.AppendFieldDataWithNullData(it.insertFieldData, existFieldData, int64(existIndex), false)
+			typeutil.AppendFieldData(it.insertFieldData, existFieldData, int64(existIndex))
 			err := typeutil.UpdateFieldData(it.insertFieldData, upsertFieldData, int64(baseIdx), int64(idx))
 			baseIdx += 1
 			if err != nil {
@@ -386,7 +408,7 @@ func (it *upsertTask) queryPreExecute(ctx context.Context) error {
 			return lackOfFieldErr
 		}
 
-		// if the nullable or default value field is not set in upsert request, which means the len(upsertFieldData) < len(it.insertFieldData)
+		// if the nullable field has not passed in upsert request, which means the len(upsertFieldData) < len(it.insertFieldData)
 		// we need to generate the nullable field data before append as insert
 		insertWithNullField := make([]*schemapb.FieldData, 0)
 		upsertFieldMap := lo.SliceToMap(it.upsertMsg.InsertMsg.GetFieldsData(), func(field *schemapb.FieldData) (string, *schemapb.FieldData) {
@@ -407,27 +429,27 @@ func (it *upsertTask) queryPreExecute(ctx context.Context) error {
 			}
 		}
 		for _, idx := range insertIdxInUpsert {
-			typeutil.AppendFieldDataWithNullData(it.insertFieldData, insertWithNullField, int64(idx), true)
+			typeutil.AppendFieldData(it.insertFieldData, insertWithNullField, int64(idx))
 		}
 	}
 
-	// 4. clean field data with valid data after merge upsert and query result
 	for _, fieldData := range it.insertFieldData {
-		// Note: Since protobuf cannot correctly identify null values, zero values + valid data are used to identify null values,
-		// therefore for field data obtained from query results, if the field is nullable, it needs to clean zero values
-		if len(fieldData.GetValidData()) != 0 && getValidNumber(fieldData.GetValidData()) != len(fieldData.GetValidData()) {
-			err := ResetNullFieldData(fieldData)
+		if len(fieldData.GetValidData()) > 0 {
+			err := ToCompressedFormatNullable(fieldData)
 			if err != nil {
-				log.Info("reset null field data failed", zap.Error(err))
+				log.Info("convert to compressed format nullable failed", zap.Error(err))
 				return err
 			}
 		}
 	}
-
 	return nil
 }
 
-func ResetNullFieldData(field *schemapb.FieldData) error {
+// ToCompressedFormatNullable converts the field data from full format nullable to compressed format nullable
+func ToCompressedFormatNullable(field *schemapb.FieldData) error {
+	if getValidNumber(field.GetValidData()) == len(field.GetValidData()) {
+		return nil
+	}
 	switch field.Field.(type) {
 	case *schemapb.FieldData_Scalars:
 		switch sd := field.GetScalars().GetData().(type) {
@@ -529,6 +551,20 @@ func ResetNullFieldData(field *schemapb.FieldData) error {
 				sd.JsonData.Data = ret
 			}
 
+		case *schemapb.ScalarField_ArrayData:
+			validRowNum := getValidNumber(field.GetValidData())
+			if validRowNum == 0 {
+				sd.ArrayData.Data = make([]*schemapb.ScalarField, 0)
+			} else {
+				ret := make([]*schemapb.ScalarField, 0, validRowNum)
+				for i, valid := range field.GetValidData() {
+					if valid {
+						ret = append(ret, sd.ArrayData.Data[i])
+					}
+				}
+				sd.ArrayData.Data = ret
+			}
+
 		default:
 			return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("undefined data type:%s", field.Type.String()))
 		}
@@ -540,6 +576,7 @@ func ResetNullFieldData(field *schemapb.FieldData) error {
 	return nil
 }
 
+// GenNullableFieldData generates nullable field data in FULL FORMAT
 func GenNullableFieldData(field *schemapb.FieldSchema, upsertIDSize int) (*schemapb.FieldData, error) {
 	switch field.DataType {
 	case schemapb.DataType_Bool:
@@ -662,6 +699,24 @@ func GenNullableFieldData(field *schemapb.FieldSchema, upsertIDSize int) (*schem
 					Data: &schemapb.ScalarField_JsonData{
 						JsonData: &schemapb.JSONArray{
 							Data: make([][]byte, upsertIDSize),
+						},
+					},
+				},
+			},
+		}, nil
+
+	case schemapb.DataType_Array:
+		return &schemapb.FieldData{
+			FieldId:   field.FieldID,
+			FieldName: field.Name,
+			Type:      field.DataType,
+			IsDynamic: field.IsDynamic,
+			ValidData: make([]bool, upsertIDSize),
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_ArrayData{
+						ArrayData: &schemapb.ArrayArray{
+							Data: make([]*schemapb.ScalarField, upsertIDSize),
 						},
 					},
 				},

--- a/internal/proxy/validate_util.go
+++ b/internal/proxy/validate_util.go
@@ -340,12 +340,12 @@ func (v *validateUtil) fillWithValue(data []*schemapb.FieldData, schema *typeuti
 		}
 
 		if fieldSchema.GetDefaultValue() == nil {
-			err = v.fillWithNullValue(field, fieldSchema, numRows)
+			err = FillWithNullValue(field, fieldSchema, numRows)
 			if err != nil {
 				return err
 			}
 		} else {
-			err = v.fillWithDefaultValue(field, fieldSchema, numRows)
+			err = FillWithDefaultValue(field, fieldSchema, numRows)
 			if err != nil {
 				return err
 			}
@@ -355,7 +355,7 @@ func (v *validateUtil) fillWithValue(data []*schemapb.FieldData, schema *typeuti
 	return nil
 }
 
-func (v *validateUtil) fillWithNullValue(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema, numRows int) error {
+func FillWithNullValue(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema, numRows int) error {
 	err := nullutil.CheckValidData(field.GetValidData(), fieldSchema, numRows)
 	if err != nil {
 		return err
@@ -434,7 +434,7 @@ func (v *validateUtil) fillWithNullValue(field *schemapb.FieldData, fieldSchema 
 	return nil
 }
 
-func (v *validateUtil) fillWithDefaultValue(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema, numRows int) error {
+func FillWithDefaultValue(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema, numRows int) error {
 	var err error
 	switch field.Field.(type) {
 	case *schemapb.FieldData_Scalars:

--- a/pkg/util/typeutil/schema.go
+++ b/pkg/util/typeutil/schema.go
@@ -755,26 +755,6 @@ func PrepareResultFieldData(sample []*schemapb.FieldData, topK int64) []*schemap
 }
 
 func AppendFieldData(dst, src []*schemapb.FieldData, idx int64) (appendSize int64) {
-	return AppendFieldDataWithNullData(dst, src, idx, false)
-}
-
-// AppendFieldData appends field data of specified index from src to dst
-//
-// Note: The field data in src may have two different nullable formats, so the caller
-// must specify how to handle null values using the skipAppendNullData parameter.
-//
-// Two nullable data formats are supported:
-//
-//	Case 1: Before validateUtil.fillWithValue processing
-//		Data: [1, null, 2] = [1, 2] + [true, false, true]
-//		Set skipAppendNullData = true to skip appending values to data array of dst
-//
-//	Case 2: After validateUtil.fillWithValue processing
-//		Data: [1, null, 2] = [1, 0, 2] + [true, false, true]
-//		Set skipAppendNullData = false to append zero values to data array of dst
-//
-// TODO: Unify nullable format - SDK uses Case 1, Milvus uses Case 2
-func AppendFieldDataWithNullData(dst, src []*schemapb.FieldData, idx int64, skipAppendNullData bool) (appendSize int64) {
 	dstMap := make(map[int64]*schemapb.FieldData)
 	for _, fieldData := range dst {
 		if fieldData != nil {
@@ -799,10 +779,6 @@ func AppendFieldDataWithNullData(dst, src []*schemapb.FieldData, idx int64, skip
 			}
 			valid := fieldData.ValidData[idx]
 			dstFieldData.ValidData = append(dstFieldData.ValidData, valid)
-
-			if !valid && skipAppendNullData {
-				continue
-			}
 		}
 		switch fieldType := fieldData.Field.(type) {
 		case *schemapb.FieldData_Scalars:
@@ -1108,25 +1084,10 @@ func UpdateFieldData(base, update []*schemapb.FieldData, baseIdx, updateIdx int6
 			continue
 		}
 
-		updateFieldIdx := updateIdx
 		// Update ValidData if present
 		if len(updateFieldData.GetValidData()) != 0 {
 			if len(baseFieldData.GetValidData()) != 0 {
-				baseFieldData.ValidData[baseIdx] = updateFieldData.ValidData[updateFieldIdx]
-			}
-
-			// update field data to null, only modify valid data
-			if !updateFieldData.ValidData[updateFieldIdx] {
-				continue
-			}
-
-			// for nullable field data, such as data=[1,1], valid_data=[true, false, true]
-			// should update the updateFieldIdx to the expected valid index
-			updateFieldIdx = 0
-			for _, validData := range updateFieldData.GetValidData()[:updateIdx] {
-				if validData {
-					updateFieldIdx += 1
-				}
+				baseFieldData.ValidData[baseIdx] = updateFieldData.ValidData[updateIdx]
 			}
 		}
 
@@ -1140,43 +1101,58 @@ func UpdateFieldData(base, update []*schemapb.FieldData, baseIdx, updateIdx int6
 			switch baseScalar.Data.(type) {
 			case *schemapb.ScalarField_BoolData:
 				updateData := updateScalar.GetBoolData()
-				if updateData != nil && int(updateFieldIdx) < len(updateData.Data) {
-					baseScalar.GetBoolData().Data[baseIdx] = updateData.Data[updateFieldIdx]
+				baseData := baseScalar.GetBoolData()
+				if updateData != nil && baseData != nil &&
+					int(updateIdx) < len(updateData.Data) && int(baseIdx) < len(baseData.Data) {
+					baseData.Data[baseIdx] = updateData.Data[updateIdx]
 				}
 			case *schemapb.ScalarField_IntData:
 				updateData := updateScalar.GetIntData()
-				if updateData != nil && int(updateFieldIdx) < len(updateData.Data) {
-					baseScalar.GetIntData().Data[baseIdx] = updateData.Data[updateFieldIdx]
+				baseData := baseScalar.GetIntData()
+				if updateData != nil && baseData != nil &&
+					int(updateIdx) < len(updateData.Data) && int(baseIdx) < len(baseData.Data) {
+					baseData.Data[baseIdx] = updateData.Data[updateIdx]
 				}
 			case *schemapb.ScalarField_LongData:
 				updateData := updateScalar.GetLongData()
-				if updateData != nil && int(updateFieldIdx) < len(updateData.Data) {
-					baseScalar.GetLongData().Data[baseIdx] = updateData.Data[updateFieldIdx]
+				baseData := baseScalar.GetLongData()
+				if updateData != nil && baseData != nil &&
+					int(updateIdx) < len(updateData.Data) && int(baseIdx) < len(baseData.Data) {
+					baseData.Data[baseIdx] = updateData.Data[updateIdx]
 				}
 			case *schemapb.ScalarField_FloatData:
 				updateData := updateScalar.GetFloatData()
-				if updateData != nil && int(updateFieldIdx) < len(updateData.Data) {
-					baseScalar.GetFloatData().Data[baseIdx] = updateData.Data[updateFieldIdx]
+				baseData := baseScalar.GetFloatData()
+				if updateData != nil && baseData != nil &&
+					int(updateIdx) < len(updateData.Data) && int(baseIdx) < len(baseData.Data) {
+					baseData.Data[baseIdx] = updateData.Data[updateIdx]
 				}
 			case *schemapb.ScalarField_DoubleData:
 				updateData := updateScalar.GetDoubleData()
-				if updateData != nil && int(updateFieldIdx) < len(updateData.Data) {
-					baseScalar.GetDoubleData().Data[baseIdx] = updateData.Data[updateFieldIdx]
+				baseData := baseScalar.GetDoubleData()
+				if updateData != nil && baseData != nil &&
+					int(updateIdx) < len(updateData.Data) && int(baseIdx) < len(baseData.Data) {
+					baseData.Data[baseIdx] = updateData.Data[updateIdx]
 				}
 			case *schemapb.ScalarField_StringData:
 				updateData := updateScalar.GetStringData()
-				if updateData != nil && int(updateFieldIdx) < len(updateData.Data) {
-					baseScalar.GetStringData().Data[baseIdx] = updateData.Data[updateFieldIdx]
+				baseData := baseScalar.GetStringData()
+				if updateData != nil && baseData != nil &&
+					int(updateIdx) < len(updateData.Data) && int(baseIdx) < len(baseData.Data) {
+					baseData.Data[baseIdx] = updateData.Data[updateIdx]
 				}
 			case *schemapb.ScalarField_ArrayData:
 				updateData := updateScalar.GetArrayData()
-				if updateData != nil && int(updateFieldIdx) < len(updateData.Data) {
-					baseScalar.GetArrayData().Data[baseIdx] = updateData.Data[updateFieldIdx]
+				baseData := baseScalar.GetArrayData()
+				if updateData != nil && baseData != nil &&
+					int(updateIdx) < len(updateData.Data) && int(baseIdx) < len(baseData.Data) {
+					baseData.Data[baseIdx] = updateData.Data[updateIdx]
 				}
 			case *schemapb.ScalarField_JsonData:
 				updateData := updateScalar.GetJsonData()
 				baseData := baseScalar.GetJsonData()
-				if updateData != nil && int(updateFieldIdx) < len(updateData.Data) {
+				if updateData != nil && baseData != nil &&
+					int(updateIdx) < len(updateData.Data) && int(baseIdx) < len(baseData.Data) {
 					if baseFieldData.GetIsDynamic() {
 						// dynamic field is a json with only 1 level nested struct,
 						// so we need to unmarshal and iterate updateData's key value, and update the baseData's key value
@@ -1186,7 +1162,7 @@ func UpdateFieldData(base, update []*schemapb.FieldData, baseIdx, updateIdx int6
 						if err := json.Unmarshal(baseData.Data[baseIdx], &baseMap); err != nil {
 							return fmt.Errorf("failed to unmarshal base json: %v", err)
 						}
-						if err := json.Unmarshal(updateData.Data[updateFieldIdx], &updateMap); err != nil {
+						if err := json.Unmarshal(updateData.Data[updateIdx], &updateMap); err != nil {
 							return fmt.Errorf("failed to unmarshal update json: %v", err)
 						}
 						// merge
@@ -1200,7 +1176,7 @@ func UpdateFieldData(base, update []*schemapb.FieldData, baseIdx, updateIdx int6
 						}
 						baseScalar.GetJsonData().Data[baseIdx] = newJSON
 					} else {
-						baseScalar.GetJsonData().Data[baseIdx] = updateData.Data[updateFieldIdx]
+						baseScalar.GetJsonData().Data[baseIdx] = updateData.Data[updateIdx]
 					}
 				}
 			default:
@@ -1216,73 +1192,71 @@ func UpdateFieldData(base, update []*schemapb.FieldData, baseIdx, updateIdx int6
 
 			switch baseVector.Data.(type) {
 			case *schemapb.VectorField_BinaryVector:
+				baseData := baseVector.GetBinaryVector()
 				updateData := updateVector.GetBinaryVector()
-				if updateData != nil {
-					baseData := baseVector.GetBinaryVector()
-					baseStartIdx := updateFieldIdx * (dim / 8)
-					baseEndIdx := (updateFieldIdx + 1) * (dim / 8)
-					updateStartIdx := updateFieldIdx * (dim / 8)
-					updateEndIdx := (updateFieldIdx + 1) * (dim / 8)
+				if baseData != nil && updateData != nil {
+					baseStartIdx := baseIdx * (dim / 8)
+					baseEndIdx := (baseIdx + 1) * (dim / 8)
+					updateStartIdx := updateIdx * (dim / 8)
+					updateEndIdx := (updateIdx + 1) * (dim / 8)
 					if int(updateEndIdx) <= len(updateData) && int(baseEndIdx) <= len(baseData) {
 						copy(baseData[baseStartIdx:baseEndIdx], updateData[updateStartIdx:updateEndIdx])
 					}
 				}
 			case *schemapb.VectorField_FloatVector:
+				baseData := baseVector.GetFloatVector()
 				updateData := updateVector.GetFloatVector()
-				if updateData != nil {
-					baseData := baseVector.GetFloatVector()
-					baseStartIdx := updateFieldIdx * dim
-					baseEndIdx := (updateFieldIdx + 1) * dim
-					updateStartIdx := updateFieldIdx * dim
-					updateEndIdx := (updateFieldIdx + 1) * dim
+				if baseData != nil && updateData != nil {
+					baseStartIdx := baseIdx * dim
+					baseEndIdx := (baseIdx + 1) * dim
+					updateStartIdx := updateIdx * dim
+					updateEndIdx := (updateIdx + 1) * dim
 					if int(updateEndIdx) <= len(updateData.Data) && int(baseEndIdx) <= len(baseData.Data) {
 						copy(baseData.Data[baseStartIdx:baseEndIdx], updateData.Data[updateStartIdx:updateEndIdx])
 					}
 				}
 			case *schemapb.VectorField_Float16Vector:
+				baseData := baseVector.GetFloat16Vector()
 				updateData := updateVector.GetFloat16Vector()
-				if updateData != nil {
-					baseData := baseVector.GetFloat16Vector()
-					baseStartIdx := updateFieldIdx * (dim * 2)
-					baseEndIdx := (updateFieldIdx + 1) * (dim * 2)
-					updateStartIdx := updateFieldIdx * (dim * 2)
-					updateEndIdx := (updateFieldIdx + 1) * (dim * 2)
+				if baseData != nil && updateData != nil {
+					baseStartIdx := baseIdx * (dim * 2)
+					baseEndIdx := (baseIdx + 1) * (dim * 2)
+					updateStartIdx := updateIdx * (dim * 2)
+					updateEndIdx := (updateIdx + 1) * (dim * 2)
 					if int(updateEndIdx) <= len(updateData) && int(baseEndIdx) <= len(baseData) {
 						copy(baseData[baseStartIdx:baseEndIdx], updateData[updateStartIdx:updateEndIdx])
 					}
 				}
 			case *schemapb.VectorField_Bfloat16Vector:
+				baseData := baseVector.GetBfloat16Vector()
 				updateData := updateVector.GetBfloat16Vector()
-				if updateData != nil {
-					baseData := baseVector.GetBfloat16Vector()
-					baseStartIdx := updateFieldIdx * (dim * 2)
-					baseEndIdx := (updateFieldIdx + 1) * (dim * 2)
-					updateStartIdx := updateFieldIdx * (dim * 2)
-					updateEndIdx := (updateFieldIdx + 1) * (dim * 2)
+				if baseData != nil && updateData != nil {
+					baseStartIdx := baseIdx * (dim * 2)
+					baseEndIdx := (baseIdx + 1) * (dim * 2)
+					updateStartIdx := updateIdx * (dim * 2)
+					updateEndIdx := (updateIdx + 1) * (dim * 2)
 					if int(updateEndIdx) <= len(updateData) && int(baseEndIdx) <= len(baseData) {
 						copy(baseData[baseStartIdx:baseEndIdx], updateData[updateStartIdx:updateEndIdx])
 					}
 				}
 			case *schemapb.VectorField_SparseFloatVector:
+				baseData := baseVector.GetSparseFloatVector()
 				updateData := updateVector.GetSparseFloatVector()
-				if updateData != nil && int(updateFieldIdx) < len(updateData.Contents) {
-					baseData := baseVector.GetSparseFloatVector()
-					if int(updateFieldIdx) < len(baseData.Contents) {
-						baseData.Contents[updateFieldIdx] = updateData.Contents[updateFieldIdx]
-						// Update dimension if necessary
-						if updateData.Dim > baseData.Dim {
-							baseData.Dim = updateData.Dim
-						}
+				if baseData != nil && updateData != nil && int(baseIdx) < len(baseData.Contents) && int(updateIdx) < len(updateData.Contents) {
+					baseData.Contents[baseIdx] = updateData.Contents[updateIdx]
+					// Update dimension if necessary
+					if updateData.Dim > baseData.Dim {
+						baseData.Dim = updateData.Dim
 					}
 				}
 			case *schemapb.VectorField_Int8Vector:
+				baseData := baseVector.GetInt8Vector()
 				updateData := updateVector.GetInt8Vector()
-				if updateData != nil {
-					baseData := baseVector.GetInt8Vector()
-					baseStartIdx := updateFieldIdx * dim
-					baseEndIdx := (updateFieldIdx + 1) * dim
-					updateStartIdx := updateFieldIdx * dim
-					updateEndIdx := (updateFieldIdx + 1) * dim
+				if baseData != nil && updateData != nil {
+					baseStartIdx := baseIdx * dim
+					baseEndIdx := (baseIdx + 1) * dim
+					updateStartIdx := updateIdx * dim
+					updateEndIdx := (updateIdx + 1) * dim
 					if int(updateEndIdx) <= len(updateData) && int(baseEndIdx) <= len(baseData) {
 						copy(baseData[baseStartIdx:baseEndIdx], updateData[updateStartIdx:updateEndIdx])
 					}

--- a/pkg/util/typeutil/schema_test.go
+++ b/pkg/util/typeutil/schema_test.go
@@ -3216,7 +3216,7 @@ func TestUpdateFieldData(t *testing.T) {
 					Scalars: &schemapb.ScalarField{
 						Data: &schemapb.ScalarField_LongData{
 							LongData: &schemapb.LongArray{
-								Data: []int64{30},
+								Data: []int64{0, 0, 30, 0},
 							},
 						},
 					},
@@ -3233,7 +3233,7 @@ func TestUpdateFieldData(t *testing.T) {
 		// Check that ValidData was updated
 		assert.Equal(t, false, baseData[0].ValidData[1])
 		// Check that data was updated
-		assert.Equal(t, int64(2), baseData[0].GetScalars().GetLongData().Data[1])
+		assert.Equal(t, int64(0), baseData[0].GetScalars().GetLongData().Data[1])
 		assert.Equal(t, int64(30), baseData[0].GetScalars().GetLongData().Data[2])
 	})
 
@@ -3424,7 +3424,6 @@ func TestUpdateFieldData(t *testing.T) {
 	t.Run("nullable field with valid data index mapping", func(t *testing.T) {
 		// Test the new logic for nullable fields where updateIdx needs to be mapped to actual data index
 		// Scenario: data=[1,2,3], valid_data=[true, false, true]
-		// updateIdx=1 should map to data index 0 (first valid data), updateIdx=2 should map to data index 1 (second valid data)
 
 		baseData := []*schemapb.FieldData{
 			{
@@ -3454,7 +3453,7 @@ func TestUpdateFieldData(t *testing.T) {
 					Scalars: &schemapb.ScalarField{
 						Data: &schemapb.ScalarField_LongData{
 							LongData: &schemapb.LongArray{
-								Data: []int64{999, 888, 777}, // Only indices 0 and 2 will be used
+								Data: []int64{999, 0, 777},
 							},
 						},
 					},
@@ -3462,21 +3461,19 @@ func TestUpdateFieldData(t *testing.T) {
 			},
 		}
 
-		// Test updating at index 1 (which maps to data index 0 due to valid_data[1] = false)
+		// Test updating at index 1
 		err := UpdateFieldData(baseData, updateData, 0, 1)
 		require.NoError(t, err)
 
 		// Since valid_data[1] = false, no data should be updated
-		assert.Equal(t, int64(100), baseData[0].GetScalars().GetLongData().Data[0])
+		assert.Equal(t, int64(0), baseData[0].GetScalars().GetLongData().Data[0])
 		assert.Equal(t, false, baseData[0].ValidData[0])
 
-		// Test updating at index 2 (which maps to data index 1 due to valid_data[2] = true)
+		// Test updating at index 2
 		err = UpdateFieldData(baseData, updateData, 1, 2)
 		require.NoError(t, err)
 
-		// Index 2 maps to data index 1 because valid_data[0] = true, valid_data[1] = false
-		// So updateFieldIdx = 0 + 1 = 1, which means we use data[1] = 888
-		assert.Equal(t, int64(888), baseData[0].GetScalars().GetLongData().Data[1])
+		assert.Equal(t, int64(777), baseData[0].GetScalars().GetLongData().Data[1])
 		assert.Equal(t, true, baseData[0].ValidData[1])
 	})
 
@@ -3512,7 +3509,7 @@ func TestUpdateFieldData(t *testing.T) {
 					Scalars: &schemapb.ScalarField{
 						Data: &schemapb.ScalarField_FloatData{
 							FloatData: &schemapb.FloatArray{
-								Data: []float32{999.9, 888.8},
+								Data: []float32{0, 999.9, 0, 888.8, 0},
 							},
 						},
 					},
@@ -3520,44 +3517,62 @@ func TestUpdateFieldData(t *testing.T) {
 			},
 		}
 
-		// Test updating at index 1 (valid_data[1] = true, so data[1] = 999.9)
+		// Test updating at index 1
 		err := UpdateFieldData(baseData, updateData, 1, 1)
 		require.NoError(t, err)
 		assert.Equal(t, float32(999.9), baseData[0].GetScalars().GetFloatData().Data[1])
 		assert.Equal(t, true, baseData[0].ValidData[0])
 
-		// Test updating at index 3 (valid_data[3] = true, so data[3] = 888.8)
+		// Test updating at index 3
 		err = UpdateFieldData(baseData, updateData, 3, 3)
 		require.NoError(t, err)
 		assert.Equal(t, float32(888.8), baseData[0].GetScalars().GetFloatData().Data[3])
 		assert.Equal(t, true, baseData[0].ValidData[1])
 
-		// Test updating at index 0 (valid_data[0] = false, so no data update, only ValidData update)
+		// Test updating at index 0
 		err = UpdateFieldData(baseData, updateData, 2, 2)
 		require.NoError(t, err)
-		assert.Equal(t, float32(3.3), baseData[0].GetScalars().GetFloatData().Data[2]) // Should remain unchanged
+		assert.Equal(t, float32(0), baseData[0].GetScalars().GetFloatData().Data[2])
 		assert.Equal(t, false, baseData[0].ValidData[2])
 	})
 }
 
-func TestAppendFieldDataWithNullData(t *testing.T) {
-	// Test data with nullable fields
-	createTestFieldData := func(fieldName string, fieldID int64, dataType schemapb.DataType, data interface{}, validData []bool) *schemapb.FieldData {
+// TestUpdateFieldData_BoundsChecking tests the enhanced bounds checking for UpdateFieldData function
+func TestUpdateFieldData_BoundsChecking(t *testing.T) {
+	const (
+		Dim = 8
+	)
+
+	// Helper function to create test scalar field data
+	createScalarFieldData := func(fieldName string, fieldID int64, dataType schemapb.DataType, data interface{}) *schemapb.FieldData {
 		fieldData := &schemapb.FieldData{
 			Type:      dataType,
 			FieldName: fieldName,
 			FieldId:   fieldID,
-			ValidData: validData,
 		}
 
 		switch dataType {
+		case schemapb.DataType_Bool:
+			fieldData.Field = &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_BoolData{
+						BoolData: &schemapb.BoolArray{Data: data.([]bool)},
+					},
+				},
+			}
 		case schemapb.DataType_Int32:
 			fieldData.Field = &schemapb.FieldData_Scalars{
 				Scalars: &schemapb.ScalarField{
 					Data: &schemapb.ScalarField_IntData{
-						IntData: &schemapb.IntArray{
-							Data: data.([]int32),
-						},
+						IntData: &schemapb.IntArray{Data: data.([]int32)},
+					},
+				},
+			}
+		case schemapb.DataType_Int64:
+			fieldData.Field = &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_LongData{
+						LongData: &schemapb.LongArray{Data: data.([]int64)},
 					},
 				},
 			}
@@ -3565,19 +3580,42 @@ func TestAppendFieldDataWithNullData(t *testing.T) {
 			fieldData.Field = &schemapb.FieldData_Scalars{
 				Scalars: &schemapb.ScalarField{
 					Data: &schemapb.ScalarField_FloatData{
-						FloatData: &schemapb.FloatArray{
-							Data: data.([]float32),
+						FloatData: &schemapb.FloatArray{Data: data.([]float32)},
+					},
+				},
+			}
+		case schemapb.DataType_Double:
+			fieldData.Field = &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_DoubleData{
+						DoubleData: &schemapb.DoubleArray{Data: data.([]float64)},
+					},
+				},
+			}
+		case schemapb.DataType_VarChar:
+			fieldData.Field = &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_StringData{
+						StringData: &schemapb.StringArray{Data: data.([]string)},
+					},
+				},
+			}
+		case schemapb.DataType_Array:
+			fieldData.Field = &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_ArrayData{
+						ArrayData: &schemapb.ArrayArray{
+							Data:        data.([]*schemapb.ScalarField),
+							ElementType: schemapb.DataType_Int32,
 						},
 					},
 				},
 			}
-		case schemapb.DataType_Bool:
+		case schemapb.DataType_JSON:
 			fieldData.Field = &schemapb.FieldData_Scalars{
 				Scalars: &schemapb.ScalarField{
-					Data: &schemapb.ScalarField_BoolData{
-						BoolData: &schemapb.BoolArray{
-							Data: data.([]bool),
-						},
+					Data: &schemapb.ScalarField_JsonData{
+						JsonData: &schemapb.JSONArray{Data: data.([][]byte)},
 					},
 				},
 			}
@@ -3585,37 +3623,848 @@ func TestAppendFieldDataWithNullData(t *testing.T) {
 		return fieldData
 	}
 
-	t.Run("TestAppendFieldDataWithNullData_SkipNullValues", func(t *testing.T) {
-		// Case 1: Before validateUtil.fillWithValue - skip null values
-		// Data: [1, null, 2] = [1, 2] + [true, false, true]
-		src := []*schemapb.FieldData{
-			createTestFieldData("int_field", 1, schemapb.DataType_Int32, []int32{1, 2, 3}, []bool{true, false, true}),
+	// Helper function to create test vector field data (unused in this test, but kept for consistency)
+	_ = func(fieldName string, fieldID int64, dataType schemapb.DataType, data interface{}, dim int64) *schemapb.FieldData {
+		fieldData := &schemapb.FieldData{
+			Type:      dataType,
+			FieldName: fieldName,
+			FieldId:   fieldID,
 		}
 
-		dst := make([]*schemapb.FieldData, 1)
-		appendSize := AppendFieldDataWithNullData(dst, src, 0, true) // skipAppendNullData = true, idx = 0
+		switch dataType {
+		case schemapb.DataType_BinaryVector:
+			fieldData.Field = &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Dim: dim,
+					Data: &schemapb.VectorField_BinaryVector{
+						BinaryVector: data.([]byte),
+					},
+				},
+			}
+		case schemapb.DataType_FloatVector:
+			fieldData.Field = &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Dim: dim,
+					Data: &schemapb.VectorField_FloatVector{
+						FloatVector: &schemapb.FloatArray{Data: data.([]float32)},
+					},
+				},
+			}
+		case schemapb.DataType_Float16Vector:
+			fieldData.Field = &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Dim: dim,
+					Data: &schemapb.VectorField_Float16Vector{
+						Float16Vector: data.([]byte),
+					},
+				},
+			}
+		case schemapb.DataType_BFloat16Vector:
+			fieldData.Field = &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Dim: dim,
+					Data: &schemapb.VectorField_Bfloat16Vector{
+						Bfloat16Vector: data.([]byte),
+					},
+				},
+			}
+		case schemapb.DataType_SparseFloatVector:
+			fieldData.Field = &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Dim: dim,
+					Data: &schemapb.VectorField_SparseFloatVector{
+						SparseFloatVector: data.(*schemapb.SparseFloatArray),
+					},
+				},
+			}
+		case schemapb.DataType_Int8Vector:
+			fieldData.Field = &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Dim: dim,
+					Data: &schemapb.VectorField_Int8Vector{
+						Int8Vector: data.([]byte),
+					},
+				},
+			}
+		}
+		return fieldData
+	}
 
-		// Should append value at index 0 (valid)
-		assert.Equal(t, int64(4), appendSize) // 1 int32 value * 4 bytes
-		assert.NotNil(t, dst[0])
-		assert.Equal(t, []int32{1}, dst[0].GetScalars().GetIntData().Data)
-		assert.Equal(t, []bool{true}, dst[0].ValidData)
+	t.Run("scalar field bounds checking - baseIdx out of bounds", func(t *testing.T) {
+		// Test case: baseIdx is out of bounds for base data
+		baseData := []*schemapb.FieldData{
+			createScalarFieldData("bool_field", 1, schemapb.DataType_Bool, []bool{true, false}),
+		}
+		updateData := []*schemapb.FieldData{
+			createScalarFieldData("bool_field", 1, schemapb.DataType_Bool, []bool{false, true}),
+		}
+
+		// baseIdx = 2 is out of bounds (base data only has 2 elements: indices 0,1)
+		err := UpdateFieldData(baseData, updateData, 2, 0)
+		require.NoError(t, err) // Should not panic, just skip update
+
+		// Original data should remain unchanged
+		assert.Equal(t, []bool{true, false}, baseData[0].GetScalars().GetBoolData().Data)
 	})
 
-	t.Run("TestAppendFieldDataWithNullData_IncludeNullValues", func(t *testing.T) {
-		// Case 2: After validateUtil.fillWithValue - include null values with zero values
-		// Data: [1, null, 2] = [1, 0, 2] + [true, false, true]
-		src := []*schemapb.FieldData{
-			createTestFieldData("int_field", 1, schemapb.DataType_Int32, []int32{1, 0, 2}, []bool{true, false, true}),
+	t.Run("scalar field bounds checking - updateIdx out of bounds", func(t *testing.T) {
+		// Test case: updateIdx is out of bounds for update data
+		baseData := []*schemapb.FieldData{
+			createScalarFieldData("int_field", 1, schemapb.DataType_Int32, []int32{1, 2, 3}),
+		}
+		updateData := []*schemapb.FieldData{
+			createScalarFieldData("int_field", 1, schemapb.DataType_Int32, []int32{10, 20}), // Only 2 elements
 		}
 
-		dst := make([]*schemapb.FieldData, 1)
-		appendSize := AppendFieldDataWithNullData(dst, src, 0, false) // skipAppendNullData = false, idx = 0
+		// updateIdx = 2 is out of bounds (update data only has 2 elements: indices 0,1)
+		err := UpdateFieldData(baseData, updateData, 1, 2)
+		require.NoError(t, err) // Should not panic, just skip update
 
-		// Should append value at index 0 (including null values)
-		assert.Equal(t, int64(4), appendSize) // 1 int32 value * 4 bytes
-		assert.NotNil(t, dst[0])
-		assert.Equal(t, []int32{1}, dst[0].GetScalars().GetIntData().Data)
-		assert.Equal(t, []bool{true}, dst[0].ValidData)
+		// Original data should remain unchanged
+		assert.Equal(t, []int32{1, 2, 3}, baseData[0].GetScalars().GetIntData().Data)
+	})
+
+	t.Run("scalar field bounds checking - both indices in bounds", func(t *testing.T) {
+		// Test case: both indices are in bounds, update should succeed
+		baseData := []*schemapb.FieldData{
+			createScalarFieldData("long_field", 1, schemapb.DataType_Int64, []int64{1, 2, 3, 4}),
+		}
+		updateData := []*schemapb.FieldData{
+			createScalarFieldData("long_field", 1, schemapb.DataType_Int64, []int64{10, 20, 30, 40}),
+		}
+
+		// Both indices are in bounds
+		err := UpdateFieldData(baseData, updateData, 2, 1)
+		require.NoError(t, err)
+
+		// Data at baseIdx=2 should be updated with data from updateIdx=1
+		assert.Equal(t, int64(20), baseData[0].GetScalars().GetLongData().Data[2])
+		// Other data should remain unchanged
+		assert.Equal(t, int64(1), baseData[0].GetScalars().GetLongData().Data[0])
+		assert.Equal(t, int64(2), baseData[0].GetScalars().GetLongData().Data[1])
+		assert.Equal(t, int64(4), baseData[0].GetScalars().GetLongData().Data[3])
+	})
+
+	t.Run("scalar field nil data checking - baseData is nil", func(t *testing.T) {
+		// Test case: baseData is nil
+		baseData := []*schemapb.FieldData{
+			{
+				Type:      schemapb.DataType_Float,
+				FieldName: "float_field",
+				FieldId:   1,
+				Field: &schemapb.FieldData_Scalars{
+					Scalars: &schemapb.ScalarField{
+						Data: &schemapb.ScalarField_FloatData{
+							FloatData: nil, // baseData is nil
+						},
+					},
+				},
+			},
+		}
+		updateData := []*schemapb.FieldData{
+			createScalarFieldData("float_field", 1, schemapb.DataType_Float, []float32{1.1, 2.2}),
+		}
+
+		err := UpdateFieldData(baseData, updateData, 0, 0)
+		require.NoError(t, err) // Should not panic, just skip update
+	})
+
+	t.Run("scalar field nil data checking - updateData is nil", func(t *testing.T) {
+		// Test case: updateData is nil
+		baseData := []*schemapb.FieldData{
+			createScalarFieldData("double_field", 1, schemapb.DataType_Double, []float64{1.1, 2.2}),
+		}
+		updateData := []*schemapb.FieldData{
+			{
+				Type:      schemapb.DataType_Double,
+				FieldName: "double_field",
+				FieldId:   1,
+				Field: &schemapb.FieldData_Scalars{
+					Scalars: &schemapb.ScalarField{
+						Data: &schemapb.ScalarField_DoubleData{
+							DoubleData: nil, // updateData is nil
+						},
+					},
+				},
+			},
+		}
+
+		err := UpdateFieldData(baseData, updateData, 0, 0)
+		require.NoError(t, err) // Should not panic, just skip update
+
+		// Original data should remain unchanged
+		assert.Equal(t, []float64{1.1, 2.2}, baseData[0].GetScalars().GetDoubleData().Data)
+	})
+
+	t.Run("test all scalar field types bounds checking", func(t *testing.T) {
+		// Test all scalar field types with bounds checking
+		scalarTypes := []struct {
+			name       string
+			dataType   schemapb.DataType
+			baseData   interface{}
+			updateData interface{}
+		}{
+			{
+				name:       "BoolData",
+				dataType:   schemapb.DataType_Bool,
+				baseData:   []bool{true, false, true},
+				updateData: []bool{false, true, false},
+			},
+			{
+				name:       "IntData",
+				dataType:   schemapb.DataType_Int32,
+				baseData:   []int32{1, 2, 3},
+				updateData: []int32{10, 20, 30},
+			},
+			{
+				name:       "LongData",
+				dataType:   schemapb.DataType_Int64,
+				baseData:   []int64{1, 2, 3},
+				updateData: []int64{10, 20, 30},
+			},
+			{
+				name:       "FloatData",
+				dataType:   schemapb.DataType_Float,
+				baseData:   []float32{1.1, 2.2, 3.3},
+				updateData: []float32{10.1, 20.2, 30.3},
+			},
+			{
+				name:       "DoubleData",
+				dataType:   schemapb.DataType_Double,
+				baseData:   []float64{1.1, 2.2, 3.3},
+				updateData: []float64{10.1, 20.2, 30.3},
+			},
+			{
+				name:       "StringData",
+				dataType:   schemapb.DataType_VarChar,
+				baseData:   []string{"a", "b", "c"},
+				updateData: []string{"x", "y", "z"},
+			},
+		}
+
+		for _, testCase := range scalarTypes {
+			t.Run(testCase.name, func(t *testing.T) {
+				baseData := []*schemapb.FieldData{
+					createScalarFieldData("test_field", 1, testCase.dataType, testCase.baseData),
+				}
+				updateData := []*schemapb.FieldData{
+					createScalarFieldData("test_field", 1, testCase.dataType, testCase.updateData),
+				}
+
+				// Test bounds checking - baseIdx out of bounds
+				err := UpdateFieldData(baseData, updateData, 3, 0) // baseIdx=3 is out of bounds
+				require.NoError(t, err)
+
+				// Test bounds checking - updateIdx out of bounds
+				err = UpdateFieldData(baseData, updateData, 0, 3) // updateIdx=3 is out of bounds
+				require.NoError(t, err)
+
+				// Test successful update
+				err = UpdateFieldData(baseData, updateData, 1, 1)
+				require.NoError(t, err)
+
+				// Verify the update worked correctly
+				switch testCase.dataType {
+				case schemapb.DataType_Bool:
+					assert.Equal(t, true, baseData[0].GetScalars().GetBoolData().Data[1])
+				case schemapb.DataType_Int32:
+					assert.Equal(t, int32(20), baseData[0].GetScalars().GetIntData().Data[1])
+				case schemapb.DataType_Int64:
+					assert.Equal(t, int64(20), baseData[0].GetScalars().GetLongData().Data[1])
+				case schemapb.DataType_Float:
+					assert.Equal(t, float32(20.2), baseData[0].GetScalars().GetFloatData().Data[1])
+				case schemapb.DataType_Double:
+					assert.Equal(t, float64(20.2), baseData[0].GetScalars().GetDoubleData().Data[1])
+				case schemapb.DataType_VarChar:
+					assert.Equal(t, "y", baseData[0].GetScalars().GetStringData().Data[1])
+				}
+			})
+		}
+	})
+}
+
+// TestUpdateFieldData_VectorBoundsChecking tests the enhanced bounds checking for vector fields in UpdateFieldData function
+func TestUpdateFieldData_VectorBoundsChecking(t *testing.T) {
+	const (
+		Dim = 8
+	)
+
+	// Helper function to create test vector field data
+	createVectorFieldData := func(fieldName string, fieldID int64, dataType schemapb.DataType, data interface{}, dim int64) *schemapb.FieldData {
+		fieldData := &schemapb.FieldData{
+			Type:      dataType,
+			FieldName: fieldName,
+			FieldId:   fieldID,
+		}
+
+		switch dataType {
+		case schemapb.DataType_BinaryVector:
+			fieldData.Field = &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Dim: dim,
+					Data: &schemapb.VectorField_BinaryVector{
+						BinaryVector: data.([]byte),
+					},
+				},
+			}
+		case schemapb.DataType_FloatVector:
+			fieldData.Field = &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Dim: dim,
+					Data: &schemapb.VectorField_FloatVector{
+						FloatVector: &schemapb.FloatArray{Data: data.([]float32)},
+					},
+				},
+			}
+		case schemapb.DataType_Float16Vector:
+			fieldData.Field = &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Dim: dim,
+					Data: &schemapb.VectorField_Float16Vector{
+						Float16Vector: data.([]byte),
+					},
+				},
+			}
+		case schemapb.DataType_BFloat16Vector:
+			fieldData.Field = &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Dim: dim,
+					Data: &schemapb.VectorField_Bfloat16Vector{
+						Bfloat16Vector: data.([]byte),
+					},
+				},
+			}
+		case schemapb.DataType_SparseFloatVector:
+			fieldData.Field = &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Dim: dim,
+					Data: &schemapb.VectorField_SparseFloatVector{
+						SparseFloatVector: data.(*schemapb.SparseFloatArray),
+					},
+				},
+			}
+		case schemapb.DataType_Int8Vector:
+			fieldData.Field = &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Dim: dim,
+					Data: &schemapb.VectorField_Int8Vector{
+						Int8Vector: data.([]byte),
+					},
+				},
+			}
+		}
+		return fieldData
+	}
+
+	t.Run("vector field bounds checking - baseIdx out of bounds", func(t *testing.T) {
+		// Test case: baseIdx is out of bounds for base vector data
+		baseData := []*schemapb.FieldData{
+			createVectorFieldData("float_vector_field", 1, schemapb.DataType_FloatVector,
+				[]float32{1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0}, Dim), // Only 1 vector
+		}
+		updateData := []*schemapb.FieldData{
+			createVectorFieldData("float_vector_field", 1, schemapb.DataType_FloatVector,
+				[]float32{10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0}, Dim),
+		}
+
+		// baseIdx = 1 is out of bounds (base data only has 1 vector: index 0)
+		err := UpdateFieldData(baseData, updateData, 1, 0)
+		require.NoError(t, err) // Should not panic, just skip update
+
+		// Original data should remain unchanged
+		originalVector := baseData[0].GetVectors().GetFloatVector().Data
+		for i := 0; i < Dim; i++ {
+			assert.Equal(t, float32(i+1), originalVector[i])
+		}
+	})
+
+	t.Run("vector field bounds checking - updateIdx out of bounds", func(t *testing.T) {
+		// Test case: updateIdx is out of bounds for update vector data
+		baseData := []*schemapb.FieldData{
+			createVectorFieldData("binary_vector_field", 1, schemapb.DataType_BinaryVector,
+				make([]byte, 2*Dim/8), Dim), // 2 vectors
+		}
+		updateData := []*schemapb.FieldData{
+			createVectorFieldData("binary_vector_field", 1, schemapb.DataType_BinaryVector,
+				make([]byte, 1*Dim/8), Dim), // Only 1 vector
+		}
+
+		// updateIdx = 1 is out of bounds (update data only has 1 vector: index 0)
+		err := UpdateFieldData(baseData, updateData, 0, 1)
+		require.NoError(t, err) // Should not panic, just skip update
+	})
+
+	t.Run("vector field bounds checking - both indices in bounds", func(t *testing.T) {
+		// Test case: both indices are in bounds, update should succeed
+		baseData := []*schemapb.FieldData{
+			createVectorFieldData("float_vector_field", 1, schemapb.DataType_FloatVector,
+				[]float32{
+					1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, // vector 0
+					9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, // vector 1
+				}, Dim),
+		}
+		updateData := []*schemapb.FieldData{
+			createVectorFieldData("float_vector_field", 1, schemapb.DataType_FloatVector,
+				[]float32{
+					100.0, 200.0, 300.0, 400.0, 500.0, 600.0, 700.0, 800.0, // vector 0
+					900.0, 1000.0, 1100.0, 1200.0, 1300.0, 1400.0, 1500.0, 1600.0, // vector 1
+				}, Dim),
+		}
+
+		// Both indices are in bounds
+		err := UpdateFieldData(baseData, updateData, 1, 1)
+		require.NoError(t, err)
+
+		// Vector at baseIdx=1 should be updated with vector from updateIdx=1
+		updatedVector := baseData[0].GetVectors().GetFloatVector().Data
+		for i := 0; i < Dim; i++ {
+			assert.Equal(t, float32(900+i*100), updatedVector[Dim+i])
+		}
+		// Vector at baseIdx=0 should remain unchanged
+		for i := 0; i < Dim; i++ {
+			assert.Equal(t, float32(i+1), updatedVector[i])
+		}
+	})
+
+	t.Run("vector field nil data checking - baseData is nil", func(t *testing.T) {
+		// Test case: baseData is nil
+		baseData := []*schemapb.FieldData{
+			{
+				Type:      schemapb.DataType_FloatVector,
+				FieldName: "float_vector_field",
+				FieldId:   1,
+				Field: &schemapb.FieldData_Vectors{
+					Vectors: &schemapb.VectorField{
+						Dim: Dim,
+						Data: &schemapb.VectorField_FloatVector{
+							FloatVector: nil, // baseData is nil
+						},
+					},
+				},
+			},
+		}
+		updateData := []*schemapb.FieldData{
+			createVectorFieldData("float_vector_field", 1, schemapb.DataType_FloatVector,
+				[]float32{1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0}, Dim),
+		}
+
+		err := UpdateFieldData(baseData, updateData, 0, 0)
+		require.NoError(t, err) // Should not panic, just skip update
+	})
+
+	t.Run("vector field nil data checking - updateData is nil", func(t *testing.T) {
+		// Test case: updateData is nil
+		baseData := []*schemapb.FieldData{
+			createVectorFieldData("binary_vector_field", 1, schemapb.DataType_BinaryVector,
+				make([]byte, Dim/8), Dim),
+		}
+		updateData := []*schemapb.FieldData{
+			{
+				Type:      schemapb.DataType_BinaryVector,
+				FieldName: "binary_vector_field",
+				FieldId:   1,
+				Field: &schemapb.FieldData_Vectors{
+					Vectors: &schemapb.VectorField{
+						Dim: Dim,
+						Data: &schemapb.VectorField_BinaryVector{
+							BinaryVector: nil, // updateData is nil
+						},
+					},
+				},
+			},
+		}
+
+		err := UpdateFieldData(baseData, updateData, 0, 0)
+		require.NoError(t, err) // Should not panic, just skip update
+	})
+
+	t.Run("test all vector field types bounds checking", func(t *testing.T) {
+		// Test all vector field types with bounds checking
+		vectorTypes := []struct {
+			name       string
+			dataType   schemapb.DataType
+			baseData   interface{}
+			updateData interface{}
+		}{
+			{
+				name:       "BinaryVector",
+				dataType:   schemapb.DataType_BinaryVector,
+				baseData:   make([]byte, 2*Dim/8), // 2 vectors
+				updateData: make([]byte, 2*Dim/8), // 2 vectors
+			},
+			{
+				name:       "FloatVector",
+				dataType:   schemapb.DataType_FloatVector,
+				baseData:   []float32{1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0},                 // 2 vectors
+				updateData: []float32{10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0, 100.0, 110.0, 120.0, 130.0, 140.0, 150.0, 160.0}, // 2 vectors
+			},
+			{
+				name:       "Float16Vector",
+				dataType:   schemapb.DataType_Float16Vector,
+				baseData:   make([]byte, 2*Dim*2), // 2 vectors
+				updateData: make([]byte, 2*Dim*2), // 2 vectors
+			},
+			{
+				name:       "BFloat16Vector",
+				dataType:   schemapb.DataType_BFloat16Vector,
+				baseData:   make([]byte, 2*Dim*2), // 2 vectors
+				updateData: make([]byte, 2*Dim*2), // 2 vectors
+			},
+			{
+				name:       "Int8Vector",
+				dataType:   schemapb.DataType_Int8Vector,
+				baseData:   make([]byte, 2*Dim), // 2 vectors
+				updateData: make([]byte, 2*Dim), // 2 vectors
+			},
+		}
+
+		for _, testCase := range vectorTypes {
+			t.Run(testCase.name, func(t *testing.T) {
+				baseData := []*schemapb.FieldData{
+					createVectorFieldData("test_vector_field", 1, testCase.dataType, testCase.baseData, Dim),
+				}
+				updateData := []*schemapb.FieldData{
+					createVectorFieldData("test_vector_field", 1, testCase.dataType, testCase.updateData, Dim),
+				}
+
+				// Test bounds checking - baseIdx out of bounds
+				err := UpdateFieldData(baseData, updateData, 2, 0) // baseIdx=2 is out of bounds
+				require.NoError(t, err)
+
+				// Test bounds checking - updateIdx out of bounds
+				err = UpdateFieldData(baseData, updateData, 0, 2) // updateIdx=2 is out of bounds
+				require.NoError(t, err)
+
+				// Test successful update
+				err = UpdateFieldData(baseData, updateData, 1, 1)
+				require.NoError(t, err)
+			})
+		}
+	})
+
+	t.Run("sparse float vector bounds checking", func(t *testing.T) {
+		// Create sparse float vector data
+		baseSparseData := &schemapb.SparseFloatArray{
+			Dim: 10,
+			Contents: [][]byte{
+				CreateSparseFloatRow([]uint32{1, 3, 5}, []float32{1.1, 3.3, 5.5}), // vector 0
+				CreateSparseFloatRow([]uint32{2, 4, 6}, []float32{2.2, 4.4, 6.6}), // vector 1
+			},
+		}
+		updateSparseData := &schemapb.SparseFloatArray{
+			Dim: 10,
+			Contents: [][]byte{
+				CreateSparseFloatRow([]uint32{7, 9}, []float32{7.7, 9.9}),   // vector 0
+				CreateSparseFloatRow([]uint32{8, 10}, []float32{8.8, 10.0}), // vector 1
+			},
+		}
+
+		baseData := []*schemapb.FieldData{
+			createVectorFieldData("sparse_vector_field", 1, schemapb.DataType_SparseFloatVector, baseSparseData, 10),
+		}
+		updateData := []*schemapb.FieldData{
+			createVectorFieldData("sparse_vector_field", 1, schemapb.DataType_SparseFloatVector, updateSparseData, 10),
+		}
+
+		// Test bounds checking - baseIdx out of bounds
+		err := UpdateFieldData(baseData, updateData, 2, 0) // baseIdx=2 is out of bounds
+		require.NoError(t, err)
+
+		// Test bounds checking - updateIdx out of bounds
+		err = UpdateFieldData(baseData, updateData, 0, 2) // updateIdx=2 is out of bounds
+		require.NoError(t, err)
+
+		// Test successful update
+		err = UpdateFieldData(baseData, updateData, 1, 1)
+		require.NoError(t, err)
+
+		// Verify the update worked correctly
+		updatedContents := baseData[0].GetVectors().GetSparseFloatVector().Contents
+		assert.Equal(t, updateSparseData.Contents[1], updatedContents[1])
+	})
+}
+
+// TestUpdateFieldData_IndexFix tests the index fix for vector fields in UpdateFieldData function
+// This test verifies that baseIdx is used correctly for base data indexing instead of updateIdx
+func TestUpdateFieldData_IndexFix(t *testing.T) {
+	const (
+		Dim = 8
+	)
+
+	// Helper function to create test vector field data
+	createVectorFieldData := func(fieldName string, fieldID int64, dataType schemapb.DataType, data interface{}, dim int64) *schemapb.FieldData {
+		fieldData := &schemapb.FieldData{
+			Type:      dataType,
+			FieldName: fieldName,
+			FieldId:   fieldID,
+		}
+
+		switch dataType {
+		case schemapb.DataType_BinaryVector:
+			fieldData.Field = &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Dim: dim,
+					Data: &schemapb.VectorField_BinaryVector{
+						BinaryVector: data.([]byte),
+					},
+				},
+			}
+		case schemapb.DataType_FloatVector:
+			fieldData.Field = &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Dim: dim,
+					Data: &schemapb.VectorField_FloatVector{
+						FloatVector: &schemapb.FloatArray{Data: data.([]float32)},
+					},
+				},
+			}
+		case schemapb.DataType_Float16Vector:
+			fieldData.Field = &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Dim: dim,
+					Data: &schemapb.VectorField_Float16Vector{
+						Float16Vector: data.([]byte),
+					},
+				},
+			}
+		case schemapb.DataType_BFloat16Vector:
+			fieldData.Field = &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Dim: dim,
+					Data: &schemapb.VectorField_Bfloat16Vector{
+						Bfloat16Vector: data.([]byte),
+					},
+				},
+			}
+		case schemapb.DataType_SparseFloatVector:
+			fieldData.Field = &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Dim: dim,
+					Data: &schemapb.VectorField_SparseFloatVector{
+						SparseFloatVector: data.(*schemapb.SparseFloatArray),
+					},
+				},
+			}
+		case schemapb.DataType_Int8Vector:
+			fieldData.Field = &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Dim: dim,
+					Data: &schemapb.VectorField_Int8Vector{
+						Int8Vector: data.([]byte),
+					},
+				},
+			}
+		}
+		return fieldData
+	}
+
+	t.Run("vector field index fix - binary vector", func(t *testing.T) {
+		// Test case: Verify that baseIdx is used for base data indexing, not updateIdx
+		// Create base data with 3 vectors
+		baseData := []*schemapb.FieldData{
+			createVectorFieldData("binary_vector_field", 1, schemapb.DataType_BinaryVector,
+				make([]byte, 3*Dim/8), Dim), // 3 vectors
+		}
+		// Create update data with 2 vectors
+		updateData := []*schemapb.FieldData{
+			createVectorFieldData("binary_vector_field", 1, schemapb.DataType_BinaryVector,
+				make([]byte, 2*Dim/8), Dim), // 2 vectors
+		}
+
+		// Fill update data with specific pattern
+		updateBytes := updateData[0].GetVectors().GetBinaryVector()
+		for i := range updateBytes {
+			updateBytes[i] = 0xFF // Fill with 0xFF pattern
+		}
+
+		// Update baseIdx=2 with updateIdx=1
+		// This should update the 3rd vector in base data with the 2nd vector from update data
+		err := UpdateFieldData(baseData, updateData, 2, 1)
+		require.NoError(t, err)
+
+		// Verify that the correct vector was updated
+		baseBytes := baseData[0].GetVectors().GetBinaryVector()
+		baseStartIdx := 2 * (Dim / 8)
+		updateStartIdx := 1 * (Dim / 8)
+
+		// Check that the 3rd vector in base data matches the 2nd vector from update data
+		for i := 0; i < Dim/8; i++ {
+			assert.Equal(t, updateBytes[updateStartIdx+i], baseBytes[baseStartIdx+i])
+		}
+	})
+
+	t.Run("vector field index fix - float vector", func(t *testing.T) {
+		// Test case: Verify that baseIdx is used for base data indexing, not updateIdx
+		baseData := []*schemapb.FieldData{
+			createVectorFieldData("float_vector_field", 1, schemapb.DataType_FloatVector,
+				[]float32{
+					1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, // vector 0
+					9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, // vector 1
+					17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, // vector 2
+				}, Dim),
+		}
+		updateData := []*schemapb.FieldData{
+			createVectorFieldData("float_vector_field", 1, schemapb.DataType_FloatVector,
+				[]float32{
+					100.0, 200.0, 300.0, 400.0, 500.0, 600.0, 700.0, 800.0, // vector 0
+					900.0, 1000.0, 1100.0, 1200.0, 1300.0, 1400.0, 1500.0, 1600.0, // vector 1
+				}, Dim),
+		}
+
+		// Update baseIdx=2 with updateIdx=1
+		// This should update the 3rd vector in base data with the 2nd vector from update data
+		err := UpdateFieldData(baseData, updateData, 2, 1)
+		require.NoError(t, err)
+
+		// Verify that the correct vector was updated
+		baseVectorData := baseData[0].GetVectors().GetFloatVector().Data
+		// Vector 0 should remain unchanged
+		for i := 0; i < Dim; i++ {
+			assert.Equal(t, float32(i+1), baseVectorData[i])
+		}
+		// Vector 1 should remain unchanged
+		for i := 0; i < Dim; i++ {
+			assert.Equal(t, float32(9+i), baseVectorData[Dim+i])
+		}
+		// Vector 2 should be updated with update vector 1
+		for i := 0; i < Dim; i++ {
+			assert.Equal(t, float32(900+i*100), baseVectorData[2*Dim+i])
+		}
+	})
+
+	t.Run("vector field index fix - float16 vector", func(t *testing.T) {
+		// Test case: Verify that baseIdx is used for base data indexing, not updateIdx
+		baseData := []*schemapb.FieldData{
+			createVectorFieldData("float16_vector_field", 1, schemapb.DataType_Float16Vector,
+				make([]byte, 3*Dim*2), Dim), // 3 vectors
+		}
+		updateData := []*schemapb.FieldData{
+			createVectorFieldData("float16_vector_field", 1, schemapb.DataType_Float16Vector,
+				make([]byte, 2*Dim*2), Dim), // 2 vectors
+		}
+
+		// Fill update data with specific pattern
+		updateBytes := updateData[0].GetVectors().GetFloat16Vector()
+		for i := range updateBytes {
+			updateBytes[i] = 0xAA // Fill with 0xAA pattern
+		}
+
+		// Update baseIdx=2 with updateIdx=1
+		err := UpdateFieldData(baseData, updateData, 2, 1)
+		require.NoError(t, err)
+
+		// Verify that the correct vector was updated
+		baseBytes := baseData[0].GetVectors().GetFloat16Vector()
+		baseStartIdx := 2 * (Dim * 2)
+		updateStartIdx := 1 * (Dim * 2)
+
+		// Check that the 3rd vector in base data matches the 2nd vector from update data
+		for i := 0; i < Dim*2; i++ {
+			assert.Equal(t, updateBytes[updateStartIdx+i], baseBytes[baseStartIdx+i])
+		}
+	})
+
+	t.Run("vector field index fix - bfloat16 vector", func(t *testing.T) {
+		// Test case: Verify that baseIdx is used for base data indexing, not updateIdx
+		baseData := []*schemapb.FieldData{
+			createVectorFieldData("bfloat16_vector_field", 1, schemapb.DataType_BFloat16Vector,
+				make([]byte, 3*Dim*2), Dim), // 3 vectors
+		}
+		updateData := []*schemapb.FieldData{
+			createVectorFieldData("bfloat16_vector_field", 1, schemapb.DataType_BFloat16Vector,
+				make([]byte, 2*Dim*2), Dim), // 2 vectors
+		}
+
+		// Fill update data with specific pattern
+		updateBytes := updateData[0].GetVectors().GetBfloat16Vector()
+		for i := range updateBytes {
+			updateBytes[i] = 0xBB // Fill with 0xBB pattern
+		}
+
+		// Update baseIdx=2 with updateIdx=1
+		err := UpdateFieldData(baseData, updateData, 2, 1)
+		require.NoError(t, err)
+
+		// Verify that the correct vector was updated
+		baseBytes := baseData[0].GetVectors().GetBfloat16Vector()
+		baseStartIdx := 2 * (Dim * 2)
+		updateStartIdx := 1 * (Dim * 2)
+
+		// Check that the 3rd vector in base data matches the 2nd vector from update data
+		for i := 0; i < Dim*2; i++ {
+			assert.Equal(t, updateBytes[updateStartIdx+i], baseBytes[baseStartIdx+i])
+		}
+	})
+
+	t.Run("vector field index fix - int8 vector", func(t *testing.T) {
+		// Test case: Verify that baseIdx is used for base data indexing, not updateIdx
+		baseData := []*schemapb.FieldData{
+			createVectorFieldData("int8_vector_field", 1, schemapb.DataType_Int8Vector,
+				make([]byte, 3*Dim), Dim), // 3 vectors
+		}
+		updateData := []*schemapb.FieldData{
+			createVectorFieldData("int8_vector_field", 1, schemapb.DataType_Int8Vector,
+				make([]byte, 2*Dim), Dim), // 2 vectors
+		}
+
+		// Fill update data with specific pattern
+		updateBytes := updateData[0].GetVectors().GetInt8Vector()
+		for i := range updateBytes {
+			updateBytes[i] = 0xCC // Fill with 0xCC pattern
+		}
+
+		// Update baseIdx=2 with updateIdx=1
+		err := UpdateFieldData(baseData, updateData, 2, 1)
+		require.NoError(t, err)
+
+		// Verify that the correct vector was updated
+		baseBytes := baseData[0].GetVectors().GetInt8Vector()
+		baseStartIdx := 2 * Dim
+		updateStartIdx := 1 * Dim
+
+		// Check that the 3rd vector in base data matches the 2nd vector from update data
+		for i := 0; i < Dim; i++ {
+			assert.Equal(t, updateBytes[updateStartIdx+i], baseBytes[baseStartIdx+i])
+		}
+	})
+
+	t.Run("vector field index fix - sparse float vector", func(t *testing.T) {
+		// Test case: Verify that baseIdx is used for base data indexing, not updateIdx
+		baseSparseData := &schemapb.SparseFloatArray{
+			Dim: 10,
+			Contents: [][]byte{
+				CreateSparseFloatRow([]uint32{1, 3, 5}, []float32{1.1, 3.3, 5.5}), // vector 0
+				CreateSparseFloatRow([]uint32{2, 4, 6}, []float32{2.2, 4.4, 6.6}), // vector 1
+				CreateSparseFloatRow([]uint32{7, 9}, []float32{7.7, 9.9}),         // vector 2
+			},
+		}
+		updateSparseData := &schemapb.SparseFloatArray{
+			Dim: 10,
+			Contents: [][]byte{
+				CreateSparseFloatRow([]uint32{10, 12}, []float32{10.0, 12.0}), // vector 0
+				CreateSparseFloatRow([]uint32{11, 13}, []float32{11.0, 13.0}), // vector 1
+			},
+		}
+
+		baseData := []*schemapb.FieldData{
+			createVectorFieldData("sparse_vector_field", 1, schemapb.DataType_SparseFloatVector, baseSparseData, 10),
+		}
+		updateData := []*schemapb.FieldData{
+			createVectorFieldData("sparse_vector_field", 1, schemapb.DataType_SparseFloatVector, updateSparseData, 10),
+		}
+
+		// Update baseIdx=2 with updateIdx=1
+		// This should update the 3rd vector in base data with the 2nd vector from update data
+		err := UpdateFieldData(baseData, updateData, 2, 1)
+		require.NoError(t, err)
+
+		// Verify that the correct vector was updated
+		updatedContents := baseData[0].GetVectors().GetSparseFloatVector().Contents
+		// Vector 0 should remain unchanged
+		assert.Equal(t, baseSparseData.Contents[0], updatedContents[0])
+		// Vector 1 should remain unchanged
+		assert.Equal(t, baseSparseData.Contents[1], updatedContents[1])
+		// Vector 2 should be updated with update vector 1
+		assert.Equal(t, updateSparseData.Contents[1], updatedContents[2])
 	})
 }

--- a/tests/python_client/common/common_func.py
+++ b/tests/python_client/common/common_func.py
@@ -3931,3 +3931,103 @@ def parse_fmod(x: int, y: int) -> int:
     v = abs(x) % abs(y)
 
     return v if x >= 0 else -v
+
+def gen_partial_row_data_by_schema(nb=ct.default_nb, schema=None, desired_field_names=None, num_fields=1,
+                                   start=0, random_pk=False, skip_field_names=[]):
+    """
+    Generate row data that contains a subset of fields from the given schema.
+    Args:
+        schema: Collection schema or collection info dict. If None, uses default schema.
+        desired_field_names (list[str] | None): Explicit field names to include (intersected with eligible fields).
+        num_fields (int): Number of fields to include if desired_field_names is not provided. Defaults to 1.
+        start (int): Starting value for primary key fields when sequential values are needed.
+        random_pk (bool): Whether to generate random primary key values.
+        skip_field_names (list[str]): Field names to skip.
+        nb (int): Number of rows to generate. Defaults to 1.
+    Returns:
+        list[dict]: a list of rows.
+    Notes:
+        - Skips auto_id fields and function output fields.
+        - Primary INT64/VARCHAR fields get sequential values from `start` unless `random_pk=True`.
+        - Works with both schema dicts (from v2 client describe_collection) and ORM schema objects.
+    """
+    if schema is None:
+        schema = gen_default_collection_schema()
+    func_output_fields = []
+    # Build list of eligible fields
+    if isinstance(schema, dict):
+        fields = schema.get('fields', [])
+        functions = schema.get('functions', [])
+        for func in functions:
+            output_field_names = func.get('output_field_names', [])
+            func_output_fields.extend(output_field_names)
+        func_output_fields = list(set(func_output_fields))
+        eligible_fields = []
+        for field in fields:
+            field_name = field.get('name', None)
+            if field.get('auto_id', False):
+                continue
+            if field_name in func_output_fields or field_name in skip_field_names:
+                continue
+            eligible_fields.append(field)
+        # Choose subset
+        if desired_field_names:
+            desired_set = set(desired_field_names)
+            chosen_fields = [f for f in eligible_fields if f.get('name') in desired_set]
+        else:
+            n = max(0, min(len(eligible_fields), num_fields if num_fields is not None else 1))
+            chosen_fields = eligible_fields[:n]
+        rows = []
+        curr_start = start
+        for _ in range(nb):
+            row = {}
+            for field in chosen_fields:
+                fname = field.get('name', None)
+                value = gen_data_by_collection_field(field, random_pk=random_pk)
+                # Override for PKs when not random
+                if not random_pk and field.get('is_primary', False) is True:
+                    if field.get('type', None) == DataType.INT64:
+                        value = curr_start
+                        curr_start += 1
+                    elif field.get('type', None) == DataType.VARCHAR:
+                        value = str(curr_start)
+                        curr_start += 1
+                row[fname] = value
+            rows.append(row)
+        return rows
+    # ORM schema path
+    fields = schema.fields
+    if hasattr(schema, "functions"):
+        functions = schema.functions
+        for func in functions:
+            func_output_fields.extend(func.output_field_names)
+    func_output_fields = list(set(func_output_fields))
+    eligible_fields = []
+    for field in fields:
+        if field.auto_id:
+            continue
+        if field.name in func_output_fields or field.name in skip_field_names:
+            continue
+        eligible_fields.append(field)
+    if desired_field_names:
+        desired_set = set(desired_field_names)
+        chosen_fields = [f for f in eligible_fields if f.name in desired_set]
+    else:
+        n = max(0, min(len(eligible_fields), num_fields if num_fields is not None else 1))
+        chosen_fields = eligible_fields[:n]
+    rows = []
+    curr_start = start
+    for _ in range(nb):
+        row = {}
+        for field in chosen_fields:
+            value = gen_data_by_collection_field(field, random_pk=random_pk)
+            if not random_pk and field.is_primary is True:
+                if field.dtype == DataType.INT64:
+                    value = curr_start
+                    curr_start += 1
+                elif field.dtype == DataType.VARCHAR:
+                    value = str(curr_start)
+                    curr_start += 1
+            row[field.name] = value
+        rows.append(row)
+    return rows

--- a/tests/python_client/milvus_client_v2/test_milvus_client_partial_update.py
+++ b/tests/python_client/milvus_client_v2/test_milvus_client_partial_update.py
@@ -1,0 +1,314 @@
+import pytest
+import time
+import random
+import numpy as np
+from common.common_type import CaseLabel, CheckTasks
+from common import common_func as cf
+from common import common_type as ct
+from utils.util_log import test_log as log
+from utils.util_pymilvus import *
+from base.client_v2_base import TestMilvusClientV2Base
+from pymilvus import DataType, FieldSchema, CollectionSchema
+from sklearn import preprocessing
+
+# Test parameters
+default_nb = ct.default_nb
+default_nq = ct.default_nq
+default_limit = ct.default_limit
+default_search_exp = "id >= 0"
+exp_res = "exp_res"
+default_primary_key_field_name = "id"
+default_vector_field_name = "vector"
+default_int32_field_name = ct.default_int32_field_name
+
+
+class TestMilvusClientPartialUpdate(TestMilvusClientV2Base):
+    """ Test case of partial update functionality """
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_partial_update_all_field_types(self):
+        """
+        Test partial update functionality with all field types
+        1. Create collection with all data types
+        2. Insert initial data
+        3. Perform partial update for each field type
+        4. Verify all updates work correctly
+        """
+        client = self._client()
+        dim = 64
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        
+        # Create schema with all data types
+        schema = cf.gen_all_datatype_collection_schema(dim=dim)
+
+        # Create index parameters
+        index_params = client.prepare_index_params()
+        for i in range(len(schema.fields)):
+            field_name = schema.fields[i].name
+            print(f"field_name: {field_name}")
+            if field_name == "json_field":
+                index_params.add_index(field_name, index_type="AUTOINDEX",
+                                    params={"json_cast_type": "json"})
+            elif field_name == "text_sparse_emb":
+                index_params.add_index(field_name, index_type="AUTOINDEX", metric_type="BM25")
+            else:
+                index_params.add_index(field_name, index_type="AUTOINDEX")
+
+        # Create collection
+        client.create_collection(collection_name, default_dim, consistency_level="Strong", schema=schema, index_params=index_params)
+
+        # Load collection
+        self.load_collection(client, collection_name)
+
+        # Insert initial data
+        nb = 1000
+        rows = cf.gen_row_data_by_schema(nb=nb, schema=schema)
+        self.upsert(client, collection_name, rows, partial_update=True)
+        log.info(f"Inserted {nb} initial records")
+
+        primary_key_field_name = schema.fields[0].name
+        for i in range(len(schema.fields)):
+            update_field_name = schema.fields[i if i != 0 else 1].name
+            new_row = cf.gen_partial_row_data_by_schema(nb=nb, schema=schema, 
+                                                        desired_field_names=[primary_key_field_name, update_field_name])
+            client.upsert(collection_name, new_row, partial_update=True)
+
+        log.info("Partial update test for all field types passed successfully")
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_partial_update_simple_demo(self):
+        """
+        Test simple partial update demo with nullable fields
+        1. Create collection with explicit schema including nullable fields
+        2. Insert initial data with some null values
+        3. Perform partial updates with different field combinations
+        4. Verify partial update behavior preserves unchanged fields
+        """
+        client = self._client()
+        dim = 3
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        
+        # Create schema with nullable fields
+        schema = self.create_schema(client, enable_dynamic_field=False)[0]
+        schema.add_field("id", DataType.INT64, is_primary=True, auto_id=False)
+        schema.add_field("vector", DataType.FLOAT_VECTOR, dim=dim)
+        schema.add_field("name", DataType.VARCHAR, max_length=100, nullable=True)
+        schema.add_field("price", DataType.FLOAT, nullable=True)
+        schema.add_field("category", DataType.VARCHAR, max_length=50, nullable=True)
+
+        # Create collection
+        self.create_collection(client, collection_name, schema=schema)
+
+        # Create index
+        index_params = self.prepare_index_params(client)[0]
+        index_params.add_index("vector", index_type="AUTOINDEX", metric_type="L2")
+        self.create_index(client, collection_name, index_params=index_params)
+
+        # Load collection
+        self.load_collection(client, collection_name)
+
+        # Insert initial data with some null values
+        initial_data = [
+            {
+                "id": 1,
+                "vector": preprocessing.normalize([np.array([random.random() for j in range(dim)])])[0].tolist(),
+                "name": "Product A",
+                "price": 100.0,
+                "category": "Electronics"
+            },
+            {
+                "id": 2,
+                "vector": preprocessing.normalize([np.array([random.random() for j in range(dim)])])[0].tolist(),
+                "name": "Product B",
+                "price": None,  # Null price
+                "category": "Home"
+            },
+            {
+                "id": 3,
+                "vector": preprocessing.normalize([np.array([random.random() for j in range(dim)])])[0].tolist(),
+                "name": "Product C",
+                "price": None,  # Null price
+                "category": "Books"
+            }
+        ]
+
+        self.upsert(client, collection_name, initial_data, partial_update=False)
+        log.info("Inserted initial data with null values")
+
+        # Verify initial state
+        results = self.query(client, collection_name, filter="id > 0", output_fields=["*"])[0]
+        assert len(results) == 3
+
+        initial_data_map = {data['id']: data for data in results}
+        assert initial_data_map[1]['name'] == "Product A"
+        assert initial_data_map[1]['price'] == 100.0
+        assert initial_data_map[1]['category'] == "Electronics"
+        assert initial_data_map[2]['name'] == "Product B"
+        assert initial_data_map[2]['price'] is None
+        assert initial_data_map[2]['category'] == "Home"
+        assert initial_data_map[3]['name'] == "Product C"
+        assert initial_data_map[3]['price'] is None
+        assert initial_data_map[3]['category'] == "Books"
+
+        log.info("Initial data verification passed")
+
+        # First partial update - update all fields
+        log.info("First partial update - updating all fields...")
+        first_update_data = [
+            {
+                "id": 1,
+                "vector": preprocessing.normalize([np.array([random.random() for j in range(dim)])])[0].tolist(),
+                "name": "Product A-Update",
+                "price": 111.1,
+                "category": "Electronics-Update"
+            },
+            {
+                "id": 2,
+                "vector": preprocessing.normalize([np.array([random.random() for j in range(dim)])])[0].tolist(),
+                "name": "Product B-Update",
+                "price": 222.2,
+                "category": "Home-Update"
+            },
+            {
+                "id": 3,
+                "vector": preprocessing.normalize([np.array([random.random() for j in range(dim)])])[0].tolist(),
+                "name": "Product C-Update",
+                "price": None,  # Still null
+                "category": "Books-Update"
+            }
+        ]
+
+        self.upsert(client, collection_name, first_update_data, partial_update=True)
+
+        # Verify first update
+        results = self.query(client, collection_name, filter="id > 0", output_fields=["*"])[0]
+        assert len(results) == 3
+
+        first_update_map = {data['id']: data for data in results}
+        assert first_update_map[1]['name'] == "Product A-Update"
+        assert abs(first_update_map[1]['price'] - 111.1) < 0.001
+        assert first_update_map[1]['category'] == "Electronics-Update"
+        assert first_update_map[2]['name'] == "Product B-Update"
+        assert abs(first_update_map[2]['price'] - 222.2) < 0.001
+        assert first_update_map[2]['category'] == "Home-Update"
+        assert first_update_map[3]['name'] == "Product C-Update"
+        assert first_update_map[3]['price'] is None
+        assert first_update_map[3]['category'] == "Books-Update"
+
+        log.info("First partial update verification passed")
+
+        # Second partial update - update only specific fields
+        log.info("Second partial update - updating specific fields...")
+        second_update_data = [
+            {
+                "id": 1,
+                "name": "Product A-Update-Again",
+                "price": 1111.1,
+                "category": "Electronics-Update-Again"
+            },
+            {
+                "id": 2,
+                "name": "Product B-Update-Again",
+                "price": None,  # Set back to null
+                "category": "Home-Update-Again"
+            },
+            {
+                "id": 3,
+                "name": "Product C-Update-Again",
+                "price": 3333.3,  # Set price from null to value
+                "category": "Books-Update-Again"
+            }
+        ]
+
+        self.upsert(client, collection_name, second_update_data, partial_update=True)
+
+        # Verify second update
+        results = self.query(client, collection_name, filter="id > 0", output_fields=["*"])[0]
+        assert len(results) == 3
+
+        second_update_map = {data['id']: data for data in results}
+        
+        # Verify ID 1: all fields updated
+        assert second_update_map[1]['name'] == "Product A-Update-Again"
+        assert abs(second_update_map[1]['price'] - 1111.1) < 0.001
+        assert second_update_map[1]['category'] == "Electronics-Update-Again"
+        
+        # Verify ID 2: all fields updated, price set to null
+        assert second_update_map[2]['name'] == "Product B-Update-Again"
+        assert second_update_map[2]['price'] is None
+        assert second_update_map[2]['category'] == "Home-Update-Again"
+        
+        # Verify ID 3: all fields updated, price set from null to value
+        assert second_update_map[3]['name'] == "Product C-Update-Again"
+        assert abs(second_update_map[3]['price'] - 3333.3) < 0.001
+        assert second_update_map[3]['category'] == "Books-Update-Again"
+
+        # Verify vector fields were preserved from first update (not updated in second update)
+        # Note: Vector comparison might be complex, so we just verify they exist
+        assert 'vector' in second_update_map[1]
+        assert 'vector' in second_update_map[2]
+        assert 'vector' in second_update_map[3]
+
+        log.info("Second partial update verification passed")
+        log.info("Simple partial update demo test completed successfully")
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_milvus_client_partial_update_null_to_null(self):
+        """
+        Target: test PU can successfully update a null to null
+        Method:
+            1. Create a collection, enable nullable fields
+            2. Insert default_nb rows to the collection
+            3. Partial Update the nullable field with null
+            4. Query the collection to check the value of nullable field
+        Expected: query should have correct value and number of entities
+        """
+        # step 1: create collection with nullable fields
+        client = self._client()
+        schema = self.create_schema(client, enable_dynamic_field=False)[0]
+        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
+        schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
+        schema.add_field(default_int32_field_name, DataType.INT32, nullable=True)
+        
+        index_params = self.prepare_index_params(client)[0]
+        index_params.add_index(default_primary_key_field_name, index_type="AUTOINDEX")
+        index_params.add_index(default_vector_field_name, index_type="AUTOINDEX")
+        index_params.add_index(default_int32_field_name, index_type="AUTOINDEX")
+        
+        collection_name = cf.gen_collection_name_by_testcase_name(module_index=1)
+        self.create_collection(client, collection_name, default_dim, schema=schema, 
+                               consistency_level="Strong", index_params=index_params)
+        
+        # step 2: insert default_nb rows to the collection
+        rows = cf.gen_row_data_by_schema(nb=default_nb, schema=schema, skip_field_names=[default_int32_field_name])
+        self.upsert(client, collection_name, rows, partial_update=True)
+        
+        # step 3: Partial Update the nullable field with null
+        new_row = cf.gen_partial_row_data_by_schema(
+            nb=default_nb, 
+            schema=schema, 
+            desired_field_names=[default_primary_key_field_name, default_int32_field_name], 
+            start=0
+        )
+        
+        # Set the nullable field to None
+        for data in new_row:
+            data[default_int32_field_name] = None
+            
+        self.upsert(client, collection_name, new_row, partial_update=True)
+        
+        # step 4: Query the collection to check the value of nullable field
+        result = self.query(client, collection_name, filter=default_search_exp,
+                   check_task=CheckTasks.check_query_results,
+                   output_fields=[default_int32_field_name],
+                   check_items={exp_res: new_row,
+                                "with_vec": True,
+                                "pk_name": default_primary_key_field_name})[0]
+        assert len(result) == default_nb
+        
+        # Verify that all nullable fields are indeed null
+        for data in result:
+            assert data[default_int32_field_name] is None, f"Expected null value for {default_int32_field_name}, got {data[default_int32_field_name]}"
+        
+        log.info("Partial update null to null test completed successfully")
+        self.drop_collection(client, collection_name)


### PR DESCRIPTION
issue: #43980
This commit optimizes the partial update merge logic by standardizing nullable field representation before merge operations to avoid corner cases during the merge process.

Key changes:
- Unify nullable field data format to FULL FORMAT before merge execution
- Add extensive unit tests for bounds checking and edge cases

The optimization ensures:
- Consistent nullable field representation across SDK and internal
- Proper handling of null values during merge operations
- Prevention of index out-of-bounds errors in vector field updates
- Better error handling and validation for partial update scenarios

This resolves issues where different nullable field formats could cause merge failures or data corruption during partial update operations.