### PR TITLE
enhance: [2.5] Add mutex and range check preventing concurrent del (#44128)

### DIFF
--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -293,6 +293,7 @@ type LocalSegment struct {
 	rowNum      *atomic.Int64
 	insertCount *atomic.Int64
 
+	deltaMut           sync.Mutex
 	lastDeltaTimestamp *atomic.Uint64
 	fields             *typeutil.ConcurrentMap[int64, *FieldInfo]
 	fieldIndexes       *typeutil.ConcurrentMap[int64, *IndexedFieldInfo] // indexID -> IndexedFieldInfo
@@ -716,6 +717,16 @@ func (s *LocalSegment) Delete(ctx context.Context, primaryKeys storage.PrimaryKe
 	}
 	defer s.ptrLock.Unpin()
 
+	s.deltaMut.Lock()
+	defer s.deltaMut.Unlock()
+
+	if s.lastDeltaTimestamp.Load() >= timestamps[len(timestamps)-1] {
+		log.Info("skip delete due to delete record before lastDeltaTimestamp",
+			zap.Int64("segmentID", s.ID()),
+			zap.Uint64("lastDeltaTimestamp", s.lastDeltaTimestamp.Load()))
+		return nil
+	}
+
 	var err error
 	GetDynamicPool().Submit(func() (any, error) {
 		start := time.Now()
@@ -898,6 +909,15 @@ func (s *LocalSegment) LoadDeltaData(ctx context.Context, deltaData *storage.Del
 		zap.Int64("partitionID", s.Partition()),
 		zap.Int64("segmentID", s.ID()),
 	)
+
+	s.deltaMut.Lock()
+	defer s.deltaMut.Unlock()
+
+	if s.lastDeltaTimestamp.Load() >= tss[len(tss)-1] {
+		log.Info("skip load delta data due to delete record before lastDeltaTimestamp",
+			zap.Uint64("lastDeltaTimestamp", s.lastDeltaTimestamp.Load()))
+		return nil
+	}
 
 	ids, err := storage.ParsePrimaryKeysBatch2IDs(pks)
 	if err != nil {


### PR DESCRIPTION
Cherry-pick from master
pr: #44128
This PR adds a mutex prevent concurrent applying delete on same segment and check latestDeltaTimestamp to skip overlapping delete range