### PR TITLE
enhance: Reduce compaction task cleanup tolerance time

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -664,7 +664,7 @@ dataCoord:
     taskQueueCapacity: 100000 # compaction task queue size
     rpcTimeout: 10
     maxParallelTaskNum: -1 # Deprecated, see datanode.slot.slotCap
-    dropTolerance: 86400 # Compaction task will be cleaned after finish longer than this time(in seconds)
+    dropTolerance: 3600 # Compaction task will be cleaned after finish longer than this time(in seconds)
     gcInterval: 1800 # The time interval in seconds for compaction gc
     scheduleInterval: 500 # The time interval in milliseconds for scheduling compaction tasks. If the configuration setting is below 100ms, it will be adjusted upwards to 100ms
     mix:

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -4622,7 +4622,7 @@ During compaction, the size of segment # of rows is able to exceed segment max #
 		Key:          "dataCoord.compaction.dropTolerance",
 		Version:      "2.4.2",
 		Doc:          "Compaction task will be cleaned after finish longer than this time(in seconds)",
-		DefaultValue: "86400",
+		DefaultValue: "3600",
 		Export:       true,
 	}
 	p.CompactionDropToleranceInSeconds.Init(base.mgr)


### PR DESCRIPTION
issue: #43858
Reduce CompactionDropToleranceInSeconds from 24 hours to 1 hour to improve memory efficiency and faster task metadata cleanup. Changes include:
- Update default value from 86400s (24h) to 3600s (1h) in component_param.go
- Update corresponding configuration in milvus.yaml
- Faster cleanup of completed compaction task metadata
- Reduce memory footprint by shorter retention period