### PR TITLE
fix: deduce metric type from non-empty search result

### DIFF
--- a/internal/proxy/search_util.go
+++ b/internal/proxy/search_util.go
@@ -602,9 +602,10 @@ func convertHybridSearchToSearch(req *milvuspb.HybridSearchRequest) *milvuspb.Se
 }
 
 func getMetricType(toReduceResults []*internalpb.SearchResults) string {
-	metricType := ""
-	if len(toReduceResults) >= 1 {
-		metricType = toReduceResults[0].GetMetricType()
+	for _, r := range toReduceResults {
+		if m := r.GetMetricType(); m != "" {
+			return m
+		}
 	}
-	return metricType
+	return ""
 }


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/32262

The old implementation always takes metric type from the first sub result, which may not always be valid. The fixed implementation returns initialized metric type from sub results.