### PR TITLE
fix: use recovery snapshot checkpoint if no vchannel is on-recovering

### DIFF
--- a/internal/streamingnode/server/flusher/flusherimpl/wal_flusher.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/wal_flusher.go
@@ -138,6 +138,10 @@ func (impl *WALFlusherImpl) buildFlusherComponents(ctx context.Context, l wal.WA
 		return nil, nil, err
 	}
 	impl.logger.Info("fetch recovery info done", zap.Int("recoveryInfoNum", len(recoverInfos)))
+	if len(vchannels) == 0 && checkpoint == nil {
+		impl.logger.Info("no vchannel to recover, use the snapshot checkpoint", zap.Stringer("checkpoint", snapshot.Checkpoint.MessageID))
+		checkpoint = snapshot.Checkpoint.MessageID
+	}
 
 	mixc, err := resource.Resource().MixCoordClient().GetWithContext(ctx)
 	if err != nil {


### PR DESCRIPTION
issue: #44194