### PR TITLE
fix: [2.5] Fix GetCompactionTo return empty results when segment was GCed

### DIFF
--- a/internal/datacoord/segment_info.go
+++ b/internal/datacoord/segment_info.go
@@ -172,22 +172,20 @@ func (s *SegmentsInfo) GetRealSegmentsForChannel(channel string) []*SegmentInfo 
 // Return (nil, true) if given segmentID can be found with no compaction to.
 // Return (notnil, true) if given segmentID can be found and has compaction to.
 func (s *SegmentsInfo) GetCompactionTo(fromSegmentID int64) ([]*SegmentInfo, bool) {
-	if _, ok := s.segments[fromSegmentID]; !ok {
-		return nil, false
-	}
+	_, exist := s.segments[fromSegmentID]
 	if compactTos, ok := s.compactionTo[fromSegmentID]; ok {
 		result := []*SegmentInfo{}
 		for _, compactTo := range compactTos {
 			to, ok := s.segments[compactTo]
 			if !ok {
 				log.Warn("compactionTo relation is broken", zap.Int64("from", fromSegmentID), zap.Int64("to", compactTo))
-				return nil, true
+				return nil, exist
 			}
 			result = append(result, to)
 		}
-		return result, true
+		return result, exist
 	}
-	return nil, true
+	return nil, exist
 }
 
 // DropSegment deletes provided segmentID

--- a/internal/datacoord/segment_info.go
+++ b/internal/datacoord/segment_info.go
@@ -168,7 +168,7 @@ func (s *SegmentsInfo) GetRealSegmentsForChannel(channel string) []*SegmentInfo 
 }
 
 // GetCompactionTo returns the segment that the provided segment is compacted to.
-// Return (nil, false) if given segmentID can not found in the meta.
+// Return (nil, false) if given segmentID can not found in the meta and compact to is nil.
 // Return (nil, true) if given segmentID can be found with no compaction to.
 // Return (notnil, true) if given segmentID can be found and has compaction to.
 func (s *SegmentsInfo) GetCompactionTo(fromSegmentID int64) ([]*SegmentInfo, bool) {

--- a/internal/datacoord/segment_info_test.go
+++ b/internal/datacoord/segment_info_test.go
@@ -51,7 +51,7 @@ func TestCompactionTo(t *testing.T) {
 		segments.DropSegment(1)
 		compactTos, ok = segments.GetCompactionTo(1)
 		assert.False(t, ok)
-		assert.Nil(t, compactTos)
+		assert.NotNil(t, compactTos)
 		compactTos, ok = segments.GetCompactionTo(2)
 		assert.True(t, ok)
 		assert.NotNil(t, compactTos)


### PR DESCRIPTION
issue: #44269 
master pr: #44270 