### PR TITLE
fix: core dump in cpp unittest(built with clang++)

### DIFF
--- a/internal/core/unittest/test_c_api.cpp
+++ b/internal/core/unittest/test_c_api.cpp
@@ -3972,7 +3972,7 @@ TEST(CApiTest, SealedSegment_search_without_predicates) {
     CSearchResult search_result;
     auto res = CSearch(
         segment, plan, placeholderGroup, ROW_COUNT + ts_offset, &search_result);
-    std::cout << res.error_msg << std::endl;
+    std::cout << (res.error_msg ? res.error_msg : "(none)") << std::endl;
     ASSERT_EQ(res.error_code, Success);
 
     CSearchResult search_result2;


### PR DESCRIPTION
The case is:
```
std::cout << (const char*)0 << std::endl;
std::cout << NULL << std::endl;
```

GCC may allow nullptr in `std::cout`, But clang++
will generate a core in this case.

core stack:
```
frame #0: 0x00007ff80dc85e92 libsystem_platform.dylib`_platform_strlen + 18
frame #1: 0x0000000100021225 all_tests`std::__1::__constexpr_strlen[abi:ue170006](__str=0x0000000000000000) at constexpr_c_functions.h:49:10
frame #2: 0x0000000100021165 all_tests`std::__1::char_traits<char>::length[abi:ue170006](__s=0x0000000000000000) at char_traits.h:222:14
frame #3: 0x0000000100054b29 all_tests`std::__1::basic_ostream<char, std::__1::char_traits<char>>& std::__1::operator<<[abi:ue170006]<std::__1::char_traits<char>>(__os=0x00007ff84f653f70, __str=0x0000000000000000) at ostream:909:57
frame #4: 0x000000010045e21c all_tests`CApiTest_SealedSegment_search_without_predicates_Test::TestBody(this=0x0000600002da8000) at test_c_api.cpp:3975:15
...

(lldb) p res.error_msg
(const char *) 0x0000000000000000
```