### PR TITLE
enhance: [StorageV2] Store column group info in compaction result

### DIFF
--- a/internal/storage/serde_events_v2.go
+++ b/internal/storage/serde_events_v2.go
@@ -415,7 +415,8 @@ func (pw *PackedBinlogRecordWriter) finalizeBinlogs() {
 		columnGroupID := columnGroup.GroupID
 		if _, exists := pw.fieldBinlogs[columnGroupID]; !exists {
 			pw.fieldBinlogs[columnGroupID] = &datapb.FieldBinlog{
-				FieldID: columnGroupID,
+				FieldID:     columnGroupID,
+				ChildFields: columnGroup.Fields,
 			}
 		}
 		pw.fieldBinlogs[columnGroupID].Binlogs = append(pw.fieldBinlogs[columnGroupID].Binlogs, &datapb.Binlog{


### PR DESCRIPTION
Related to #44257

This PR store split result in compaction segment binlog struct to make querynode could utilize it later.