### PR TITLE
fix: [AddField] Forbid delete `dynamicfield.enable` property

### DIFF
--- a/internal/rootcoord/alter_collection_task.go
+++ b/internal/rootcoord/alter_collection_task.go
@@ -34,6 +34,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/mq/msgstream"
 	"github.com/milvus-io/milvus/pkg/v2/proto/querypb"
+	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 )
 
@@ -45,6 +46,10 @@ type alterCollectionTask struct {
 func (a *alterCollectionTask) Prepare(ctx context.Context) error {
 	if a.Req.GetCollectionName() == "" {
 		return errors.New("alter collection failed, collection name does not exists")
+	}
+
+	if funcutil.SliceContain(a.Req.GetDeleteKeys(), common.EnableDynamicSchemaKey) {
+		return merr.WrapErrParameterInvalidMsg("cannot delete key %s, dynamic field schema could support set to true/false", common.EnableDynamicSchemaKey)
 	}
 
 	return nil

--- a/internal/rootcoord/alter_collection_task_test.go
+++ b/internal/rootcoord/alter_collection_task_test.go
@@ -33,6 +33,7 @@ import (
 	mockrootcoord "github.com/milvus-io/milvus/internal/rootcoord/mocks"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/mq/msgstream"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 )
 
 func Test_alterCollectionTask_Prepare(t *testing.T) {
@@ -40,6 +41,17 @@ func Test_alterCollectionTask_Prepare(t *testing.T) {
 		task := &alterCollectionTask{Req: &milvuspb.AlterCollectionRequest{Base: &commonpb.MsgBase{MsgType: commonpb.MsgType_AlterCollection}}}
 		err := task.Prepare(context.Background())
 		assert.Error(t, err)
+	})
+
+	t.Run("banned_delete_keys", func(t *testing.T) {
+		task := &alterCollectionTask{Req: &milvuspb.AlterCollectionRequest{
+			Base:           &commonpb.MsgBase{MsgType: commonpb.MsgType_AlterCollection},
+			CollectionName: "test_collection",
+			DeleteKeys:     []string{common.EnableDynamicSchemaKey},
+		}}
+		err := task.Prepare(context.Background())
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
 	})
 
 	t.Run("normal case", func(t *testing.T) {


### PR DESCRIPTION
Related to #44311

This PR forbids delete `dynamicfield.enable` property and returns user understandable error message to user.