### PR TITLE
enhance: [StorageV2] Include partition & clustering key to sys group

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -1014,6 +1014,8 @@ common:
       splitSystemColumn:
         enabled: true # enable split system column policy in storage v2
         includePK: true # whether split system column policy include pk field
+        includePartitionKey: true # whether split system column policy include partition key field
+        includeClusteringKey: true # whether split system column policy include clustering key field
       splitByAvgSize:
         enabled: false # enable split by average size policy in storage v2
         threshold: 1024 # split by average size policy threshold(in bytes) in storage v2

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -1014,8 +1014,6 @@ common:
       splitSystemColumn:
         enabled: true # enable split system column policy in storage v2
         includePK: true # whether split system column policy include pk field
-        includePartitionKey: true # whether split system column policy include partition key field
-        includeClusteringKey: true # whether split system column policy include clustering key field
       splitByAvgSize:
         enabled: false # enable split by average size policy in storage v2
         threshold: 1024 # split by average size policy threshold(in bytes) in storage v2

--- a/internal/storagecommon/column_group_splitter.go
+++ b/internal/storagecommon/column_group_splitter.go
@@ -50,7 +50,9 @@ func DefaultPolicies() []ColumnGroupSplitPolicy {
 	paramtable.Init()
 	result := make([]ColumnGroupSplitPolicy, 0, 4)
 	if paramtable.Get().CommonCfg.Stv2SplitSystemColumn.GetAsBool() {
-		result = append(result, NewSystemColumnPolicy(paramtable.Get().CommonCfg.Stv2SystemColumnIncludePK.GetAsBool()))
+		result = append(result, NewSystemColumnPolicy(paramtable.Get().CommonCfg.Stv2SystemColumnIncludePK.GetAsBool(),
+			paramtable.Get().CommonCfg.Stv2SystemColumnIncludePartitionKey.GetAsBool(),
+			paramtable.Get().CommonCfg.Stv2SystemColumnIncludeClusteringKey.GetAsBool()))
 	}
 	if paramtable.Get().CommonCfg.Stv2SplitByAvgSize.GetAsBool() {
 		result = append(result, NewAvgSizePolicy(paramtable.Get().CommonCfg.Stv2SplitAvgSizeThreshold.GetAsInt64()))

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -280,11 +280,13 @@ type commonConfig struct {
 	MaxWLockConditionalWaitTime ParamItem `refreshable:"true"`
 
 	// storage v2
-	EnableStorageV2           ParamItem `refreshable:"false"`
-	Stv2SplitSystemColumn     ParamItem `refreshable:"true"`
-	Stv2SystemColumnIncludePK ParamItem `refreshable:"true"`
-	Stv2SplitByAvgSize        ParamItem `refreshable:"true"`
-	Stv2SplitAvgSizeThreshold ParamItem `refreshable:"true"`
+	EnableStorageV2                      ParamItem `refreshable:"false"`
+	Stv2SplitSystemColumn                ParamItem `refreshable:"true"`
+	Stv2SystemColumnIncludePK            ParamItem `refreshable:"true"`
+	Stv2SystemColumnIncludePartitionKey  ParamItem `refreshable:"true"`
+	Stv2SystemColumnIncludeClusteringKey ParamItem `refreshable:"true"`
+	Stv2SplitByAvgSize                   ParamItem `refreshable:"true"`
+	Stv2SplitAvgSizeThreshold            ParamItem `refreshable:"true"`
 
 	StoragePathPrefix         ParamItem `refreshable:"false"`
 	StorageZstdConcurrency    ParamItem `refreshable:"false"`
@@ -949,6 +951,24 @@ Large numeric passwords require double quotes to avoid yaml parsing precision is
 		Export:       true,
 	}
 	p.Stv2SystemColumnIncludePK.Init(base.mgr)
+
+	p.Stv2SystemColumnIncludePartitionKey = ParamItem{
+		Key:          "common.storage.stv2.splitSystemColumn.includePartitionKey",
+		Version:      "2.6.2",
+		DefaultValue: "true",
+		Doc:          "whether split system column policy include partition key field",
+		Export:       true,
+	}
+	p.Stv2SystemColumnIncludePartitionKey.Init(base.mgr)
+
+	p.Stv2SystemColumnIncludeClusteringKey = ParamItem{
+		Key:          "common.storage.stv2.splitSystemColumn.includeClusteringKey",
+		Version:      "2.6.2",
+		DefaultValue: "true",
+		Doc:          "whether split system column policy include clustering key field",
+		Export:       true,
+	}
+	p.Stv2SystemColumnIncludeClusteringKey.Init(base.mgr)
 
 	p.Stv2SplitByAvgSize = ParamItem{
 		Key:          "common.storage.stv2.splitByAvgSize.enabled",

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -957,7 +957,7 @@ Large numeric passwords require double quotes to avoid yaml parsing precision is
 		Version:      "2.6.2",
 		DefaultValue: "true",
 		Doc:          "whether split system column policy include partition key field",
-		Export:       true,
+		Export:       false,
 	}
 	p.Stv2SystemColumnIncludePartitionKey.Init(base.mgr)
 
@@ -966,7 +966,7 @@ Large numeric passwords require double quotes to avoid yaml parsing precision is
 		Version:      "2.6.2",
 		DefaultValue: "true",
 		Doc:          "whether split system column policy include clustering key field",
-		Export:       true,
+		Export:       false,
 	}
 	p.Stv2SystemColumnIncludeClusteringKey.Init(base.mgr)
 


### PR DESCRIPTION
Related to #44257

This PR makes partition key & clustering candidates of system field group and adds param item controlling the policy