### PR TITLE
enhance: [StorageV2] Use compressed size as log file size

### DIFF
--- a/internal/core/src/segcore/packed_writer_c.h
+++ b/internal/core/src/segcore/packed_writer_c.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "common/common_type_c.h"
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -53,6 +54,14 @@ WriteRecordBatch(CPackedWriter c_packed_writer,
 
 CStatus
 CloseWriter(CPackedWriter c_packed_writer);
+
+CStatus
+GetFileSize(const char* path, int64_t* size);
+
+CStatus
+GetFileSizeWithStorageConfig(const char* path,
+                             int64_t* size,
+                             CStorageConfig c_storage_config);
 
 #ifdef __cplusplus
 }

--- a/internal/storage/serde_events_v2.go
+++ b/internal/storage/serde_events_v2.go
@@ -156,6 +156,7 @@ type packedRecordWriter struct {
 	rowNum                  int64
 	writtenUncompressed     uint64
 	columnGroupUncompressed map[typeutil.UniqueID]uint64
+	columnGroupCompressed   map[typeutil.UniqueID]uint64
 	storageConfig           *indexpb.StorageConfig
 }
 
@@ -199,6 +200,13 @@ func (pw *packedRecordWriter) GetColumnGroupWrittenUncompressed(columnGroup type
 	return 0
 }
 
+func (pw *packedRecordWriter) GetColumnGroupWrittenCompressed(columnGroup typeutil.UniqueID) uint64 {
+	if size, ok := pw.columnGroupCompressed[columnGroup]; ok {
+		return size
+	}
+	return 0
+}
+
 func (pw *packedRecordWriter) GetWrittenPaths(columnGroup typeutil.UniqueID) string {
 	if path, ok := pw.pathsMap[columnGroup]; ok {
 		return path
@@ -212,7 +220,18 @@ func (pw *packedRecordWriter) GetWrittenRowNum() int64 {
 
 func (pw *packedRecordWriter) Close() error {
 	if pw.writer != nil {
-		return pw.writer.Close()
+		err := pw.writer.Close()
+		if err != nil {
+			return err
+		}
+		for id, fpath := range pw.pathsMap {
+			truePath := path.Join(pw.bucketName, fpath)
+			size, err := packed.GetFileSize(truePath, pw.storageConfig)
+			if err != nil {
+				return err
+			}
+			pw.columnGroupCompressed[id] = uint64(size)
+		}
 	}
 	return nil
 }
@@ -242,6 +261,7 @@ func NewPackedRecordWriter(bucketName string, paths []string, schema *schemapb.C
 			fmt.Sprintf("can not new packed record writer %s", err.Error()))
 	}
 	columnGroupUncompressed := make(map[typeutil.UniqueID]uint64)
+	columnGroupCompressed := make(map[typeutil.UniqueID]uint64)
 	pathsMap := make(map[typeutil.UniqueID]string)
 	if len(paths) != len(columnGroups) {
 		return nil, merr.WrapErrParameterInvalid(len(paths), len(columnGroups),
@@ -249,6 +269,7 @@ func NewPackedRecordWriter(bucketName string, paths []string, schema *schemapb.C
 	}
 	for i, columnGroup := range columnGroups {
 		columnGroupUncompressed[columnGroup.GroupID] = 0
+		columnGroupCompressed[columnGroup.GroupID] = 0
 		pathsMap[columnGroup.GroupID] = paths[i]
 	}
 	return &packedRecordWriter{
@@ -260,6 +281,7 @@ func NewPackedRecordWriter(bucketName string, paths []string, schema *schemapb.C
 		pathsMap:                pathsMap,
 		columnGroups:            columnGroups,
 		columnGroupUncompressed: columnGroupUncompressed,
+		columnGroupCompressed:   columnGroupCompressed,
 		storageConfig:           storageConfig,
 	}, nil
 }
@@ -402,7 +424,6 @@ func (pw *PackedBinlogRecordWriter) GetWrittenUncompressed() uint64 {
 }
 
 func (pw *PackedBinlogRecordWriter) Close() error {
-	pw.finalizeBinlogs()
 	if err := pw.writeStats(); err != nil {
 		return err
 	}
@@ -414,6 +435,7 @@ func (pw *PackedBinlogRecordWriter) Close() error {
 			return err
 		}
 	}
+	pw.finalizeBinlogs()
 	return nil
 }
 
@@ -434,7 +456,7 @@ func (pw *PackedBinlogRecordWriter) finalizeBinlogs() {
 			}
 		}
 		pw.fieldBinlogs[columnGroupID].Binlogs = append(pw.fieldBinlogs[columnGroupID].Binlogs, &datapb.Binlog{
-			LogSize:       int64(pw.writer.GetColumnGroupWrittenUncompressed(columnGroupID)),
+			LogSize:       int64(pw.writer.GetColumnGroupWrittenCompressed(columnGroupID)),
 			MemorySize:    int64(pw.writer.GetColumnGroupWrittenUncompressed(columnGroupID)),
 			LogPath:       pw.writer.GetWrittenPaths(columnGroupID),
 			EntriesNum:    pw.writer.GetWrittenRowNum(),

--- a/internal/storage/serde_events_v2.go
+++ b/internal/storage/serde_events_v2.go
@@ -424,18 +424,18 @@ func (pw *PackedBinlogRecordWriter) GetWrittenUncompressed() uint64 {
 }
 
 func (pw *PackedBinlogRecordWriter) Close() error {
-	if err := pw.writeStats(); err != nil {
-		return err
-	}
-	if err := pw.writeBm25Stats(); err != nil {
-		return err
-	}
 	if pw.writer != nil {
 		if err := pw.writer.Close(); err != nil {
 			return err
 		}
 	}
 	pw.finalizeBinlogs()
+	if err := pw.writeStats(); err != nil {
+		return err
+	}
+	if err := pw.writeBm25Stats(); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/internal/storagev2/packed/util.go
+++ b/internal/storagev2/packed/util.go
@@ -22,6 +22,7 @@ package packed
 #include "common/type_c.h"
 #include "common/protobuf_utils_c.h"
 #include "segcore/segment_c.h"
+#include "segcore/packed_writer_c.h"
 #include "storage/storage_c.h"
 */
 import "C"
@@ -29,6 +30,7 @@ import "C"
 import (
 	"unsafe"
 
+	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 )
 
@@ -40,4 +42,58 @@ func ConsumeCStatusIntoError(status *C.CStatus) error {
 	errorMsg := C.GoString(status.error_msg)
 	C.free(unsafe.Pointer(status.error_msg))
 	return merr.SegcoreError(int32(errorCode), errorMsg)
+}
+
+func GetFileSize(path string, storageConfig *indexpb.StorageConfig) (int64, error) {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	var fileSize int64
+	if storageConfig == nil {
+		status := C.GetFileSize(cPath, (*C.int64_t)(unsafe.Pointer(&fileSize)))
+		return fileSize, ConsumeCStatusIntoError(&status)
+	} else {
+		cStorageConfig := GetCStorageConfig(storageConfig)
+		defer DeleteCStorageConfig(cStorageConfig)
+		status := C.GetFileSizeWithStorageConfig(cPath, (*C.int64_t)(unsafe.Pointer(&fileSize)), cStorageConfig)
+		return fileSize, ConsumeCStatusIntoError(&status)
+	}
+}
+
+func GetCStorageConfig(storageConfig *indexpb.StorageConfig) C.CStorageConfig {
+	cStorageConfig := C.CStorageConfig{
+		address:                C.CString(storageConfig.GetAddress()),
+		bucket_name:            C.CString(storageConfig.GetBucketName()),
+		access_key_id:          C.CString(storageConfig.GetAccessKeyID()),
+		access_key_value:       C.CString(storageConfig.GetSecretAccessKey()),
+		root_path:              C.CString(storageConfig.GetRootPath()),
+		storage_type:           C.CString(storageConfig.GetStorageType()),
+		cloud_provider:         C.CString(storageConfig.GetCloudProvider()),
+		iam_endpoint:           C.CString(storageConfig.GetIAMEndpoint()),
+		log_level:              C.CString("warn"),
+		useSSL:                 C.bool(storageConfig.GetUseSSL()),
+		sslCACert:              C.CString(storageConfig.GetSslCACert()),
+		useIAM:                 C.bool(storageConfig.GetUseIAM()),
+		region:                 C.CString(storageConfig.GetRegion()),
+		useVirtualHost:         C.bool(storageConfig.GetUseVirtualHost()),
+		requestTimeoutMs:       C.int64_t(storageConfig.GetRequestTimeoutMs()),
+		gcp_credential_json:    C.CString(storageConfig.GetGcpCredentialJSON()),
+		use_custom_part_upload: true,
+	}
+	return cStorageConfig
+}
+
+func DeleteCStorageConfig(cStorageConfig C.CStorageConfig) {
+	C.free(unsafe.Pointer(cStorageConfig.address))
+	C.free(unsafe.Pointer(cStorageConfig.bucket_name))
+	C.free(unsafe.Pointer(cStorageConfig.access_key_id))
+	C.free(unsafe.Pointer(cStorageConfig.access_key_value))
+	C.free(unsafe.Pointer(cStorageConfig.root_path))
+	C.free(unsafe.Pointer(cStorageConfig.storage_type))
+	C.free(unsafe.Pointer(cStorageConfig.cloud_provider))
+	C.free(unsafe.Pointer(cStorageConfig.iam_endpoint))
+	C.free(unsafe.Pointer(cStorageConfig.log_level))
+	C.free(unsafe.Pointer(cStorageConfig.sslCACert))
+	C.free(unsafe.Pointer(cStorageConfig.region))
+	C.free(unsafe.Pointer(cStorageConfig.gcp_credential_json))
 }


### PR DESCRIPTION
Related to #39173

backlog issue that memory size and log size shared same value. This patch add `GetFileSize` api to get remote compressed binlog size as meta log file size to calculate usage more accurate.