### PR TITLE
fix: Fix load config parsing using wrong parameters for dynamic replica

### DIFF
--- a/internal/rootcoord/alter_collection_task.go
+++ b/internal/rootcoord/alter_collection_task.go
@@ -186,10 +186,10 @@ func executeAlterCollectionTaskSteps(ctx context.Context,
 		opts:            []proxyutil.ExpireCacheOpt{proxyutil.SetMsgType(commonpb.MsgType_AlterCollection)},
 	})
 
-	oldReplicaNumber, _ := common.DatabaseLevelReplicaNumber(oldColl.Properties)
-	oldResourceGroups, _ := common.DatabaseLevelResourceGroups(oldColl.Properties)
-	newReplicaNumber, _ := common.DatabaseLevelReplicaNumber(newColl.Properties)
-	newResourceGroups, _ := common.DatabaseLevelResourceGroups(newColl.Properties)
+	oldReplicaNumber, _ := common.CollectionLevelReplicaNumber(oldColl.Properties)
+	oldResourceGroups, _ := common.CollectionLevelResourceGroups(oldColl.Properties)
+	newReplicaNumber, _ := common.CollectionLevelReplicaNumber(newColl.Properties)
+	newResourceGroups, _ := common.CollectionLevelResourceGroups(newColl.Properties)
 	left, right := lo.Difference(oldResourceGroups, newResourceGroups)
 	rgChanged := len(left) > 0 || len(right) > 0
 	replicaChanged := oldReplicaNumber != newReplicaNumber

--- a/tests/integration/replicas/load/load_test.go
+++ b/tests/integration/replicas/load/load_test.go
@@ -191,11 +191,11 @@ func (s *LoadTestSuite) TestLoadWithPredefineCollectionLevelConfig() {
 		CollectionName: collectionName,
 		Properties: []*commonpb.KeyValuePair{
 			{
-				Key:   common.DatabaseReplicaNumber,
+				Key:   common.CollectionReplicaNumber,
 				Value: "5",
 			},
 			{
-				Key:   common.DatabaseResourceGroups,
+				Key:   common.CollectionResourceGroups,
 				Value: strings.Join(rgs, ","),
 			},
 		},
@@ -216,11 +216,11 @@ func (s *LoadTestSuite) TestLoadWithPredefineCollectionLevelConfig() {
 		CollectionName: collectionName,
 		Properties: []*commonpb.KeyValuePair{
 			{
-				Key:   common.DatabaseReplicaNumber,
+				Key:   common.CollectionReplicaNumber,
 				Value: "2",
 			},
 			{
-				Key:   common.DatabaseResourceGroups,
+				Key:   common.CollectionResourceGroups,
 				Value: strings.Join(rgs[:2], ","),
 			},
 		},


### PR DESCRIPTION
issue: #44429
Fix the issue where dynamic modification of collection replica count doesn't take effect due to incorrect parameter usage in load config parsing.

Changes include:
- Replace DatabaseLevelReplicaNumber with CollectionLevelReplicaNumber
- Replace DatabaseLevelResourceGroups with CollectionLevelResourceGroups
- Update test cases to use correct collection-level constants
- Ensure dynamic replica changes are properly applied to collections