### PR TITLE
enhance: support batch set bitset

### DIFF
--- a/internal/core/src/bitset/detail/platform/arm/neon-decl.h
+++ b/internal/core/src/bitset/detail/platform/arm/neon-decl.h
@@ -311,6 +311,13 @@ ALL_FORWARD_TYPES_1(DECLARE_PARTIAL_FORWARD_OPS)
 
 ///////////////////////////////////////////////////////////////////////////
 
+// bitset_batch_set neon implementation
+template <typename ElementType>
+void
+bitset_batch_set_neon(ElementType* data, const uint32_t* idxs, const size_t n);
+
+///////////////////////////////////////////////////////////////////////////
+
 #undef ALL_DATATYPES_1
 #undef ALL_FORWARD_TYPES_1
 

--- a/internal/core/src/bitset/detail/platform/arm/neon-inst.cpp
+++ b/internal/core/src/bitset/detail/platform/arm/neon-inst.cpp
@@ -84,6 +84,9 @@ namespace neon {
 
 ///////////////////////////////////////////////////////////////////////////
 
+template void
+bitset_batch_set_neon<uint64_t>(uint64_t*, const uint32_t*, const size_t);
+
 //
 #define INSTANTIATE_COMPARE_VAL_NEON(TTYPE, OP)                               \
     template bool OpCompareValImpl<TTYPE, CompareOpType::OP>::op_compare_val( \

--- a/internal/core/src/bitset/detail/platform/arm/sve-decl.h
+++ b/internal/core/src/bitset/detail/platform/arm/sve-decl.h
@@ -30,6 +30,14 @@ namespace arm {
 namespace sve {
 
 ///////////////////////////////////////////////////////////////////////////
+
+// bitset_batch_set sve implementation
+template <typename ElementType>
+void
+bitset_batch_set_sve(ElementType* data, const uint32_t* idxs, const size_t n);
+
+///////////////////////////////////////////////////////////////////////////
+
 // a facility to run through all acceptable data types
 #define ALL_DATATYPES_1(FUNC) \
     FUNC(int8_t);             \

--- a/internal/core/src/bitset/detail/platform/arm/sve-inst.cpp
+++ b/internal/core/src/bitset/detail/platform/arm/sve-inst.cpp
@@ -186,6 +186,11 @@ ALL_ARITH_CMP_OPS(INSTANTIATE_ARITH_COMPARE_SVE, double)
 
 ///////////////////////////////////////////////////////////////////////////
 
+template void
+bitset_batch_set_sve<uint64_t>(uint64_t*, const uint32_t*, const size_t);
+
+///////////////////////////////////////////////////////////////////////////
+
 //
 #undef ALL_COMPARE_OPS
 #undef ALL_RANGE_OPS

--- a/internal/core/src/bitset/detail/platform/dynamic.h
+++ b/internal/core/src/bitset/detail/platform/dynamic.h
@@ -28,6 +28,11 @@ namespace detail {
 namespace dynamic {
 
 ///////////////////////////////////////////////////////////////////////////
+
+template <typename ElementType>
+void
+bitset_batch_set(ElementType* data, const uint32_t* idxs, const size_t n);
+
 // a facility to run through all acceptable data types
 #define ALL_DATATYPES_1(FUNC) \
     FUNC(int8_t);             \

--- a/internal/core/src/bitset/detail/platform/x86/avx2-decl.h
+++ b/internal/core/src/bitset/detail/platform/x86/avx2-decl.h
@@ -196,6 +196,12 @@ ALL_DATATYPES_1(DECLARE_PARTIAL_OP_ARITH_COMPARE)
 #undef DECLARE_PARTIAL_OP_ARITH_COMPARE
 
 ///////////////////////////////////////////////////////////////////////////
+// bitset_batch_set avx implementation
+template <typename ElementType>
+void
+bitset_batch_set_avx2(ElementType* data, const uint32_t* idxs, const size_t n);
+
+///////////////////////////////////////////////////////////////////////////
 
 // forward ops
 template <typename ElementT>

--- a/internal/core/src/bitset/detail/platform/x86/avx2-inst.cpp
+++ b/internal/core/src/bitset/detail/platform/x86/avx2-inst.cpp
@@ -186,6 +186,12 @@ ALL_ARITH_CMP_OPS(INSTANTIATE_ARITH_COMPARE_AVX2, double)
 ///////////////////////////////////////////////////////////////////////////
 
 //
+template void
+bitset_batch_set_avx2<uint64_t>(uint64_t*, const uint32_t*, const size_t);
+
+///////////////////////////////////////////////////////////////////////////
+
+//
 #undef ALL_COMPARE_OPS
 #undef ALL_RANGE_OPS
 #undef ALL_ARITH_CMP_OPS

--- a/internal/core/src/bitset/detail/platform/x86/avx512-decl.h
+++ b/internal/core/src/bitset/detail/platform/x86/avx512-decl.h
@@ -197,6 +197,15 @@ ALL_DATATYPES_1(DECLARE_PARTIAL_OP_ARITH_COMPARE)
 
 ///////////////////////////////////////////////////////////////////////////
 
+// bitset_batch_set avx512 implementation
+template <typename ElementType>
+void
+bitset_batch_set_avx512(ElementType* data,
+                        const uint32_t* idxs,
+                        const size_t n);
+
+///////////////////////////////////////////////////////////////////////////
+
 // forward ops
 template <typename ElementT>
 struct ForwardOpsImpl {

--- a/internal/core/src/bitset/detail/platform/x86/avx512-inst.cpp
+++ b/internal/core/src/bitset/detail/platform/x86/avx512-inst.cpp
@@ -83,6 +83,9 @@ namespace avx512 {
 
 ///////////////////////////////////////////////////////////////////////////
 
+template void
+bitset_batch_set_avx512<uint64_t>(uint64_t*, const uint32_t*, const size_t);
+
 //
 #define INSTANTIATE_COMPARE_VAL_AVX512(TTYPE, OP)                             \
     template bool OpCompareValImpl<TTYPE, CompareOpType::OP>::op_compare_val( \


### PR DESCRIPTION
#44617

Optimization points:

For positioning operations, use SIMD to execute the hotspots of i / data_type and i % data_type
For the set operation, reduce memory read-write operations in the subsequent data_type writing process
Tests
Bitset length: 100w
Set 10% of data evenly, 100,000 set operations
AVX2

Set 1% of data evenly, 10,000 set operations
Before optimization: 21us
After optimization: 25us
Improvement ratio: -19%
(Note: Data points are too scattered to reduce memory read-write operations)

Set 10% of data evenly, 100,000 set operations
Before optimization: 120us
After optimization: 83us
Improvement ratio: 40%

Set 25% of data evenly, 250,000 set operations
Before optimization: 278us
After optimization: 200us
Improvement ratio: 28%

Set 50% of data, 500,000 set operations
Before optimization: 601us
After optimization: 398us
Improvement ratio: 34%

Set 100% of data, 1,000,000 set operations
Before optimization: 1170us
After optimization: 793us
Improvement ratio: 32%