### PR TITLE
enhance: add storage usage for delete/upsert/restful

### DIFF
--- a/internal/distributed/proxy/httpserver/constant.go
+++ b/internal/distributed/proxy/httpserver/constant.go
@@ -133,7 +133,7 @@ const (
 	HTTPReturnHas = "has"
 
 	HTTPReturnScannedRemoteBytes = "scanned_remote_bytes"
-	HTTPReturnScannedTotalBytes  = "scanned_local_bytes"
+	HTTPReturnScannedTotalBytes  = "scanned_total_bytes"
 	HTTPReturnCacheHitRatio      = "cache_hit_ratio"
 
 	HTTPReturnFieldName             = "name"

--- a/internal/distributed/proxy/httpserver/constant.go
+++ b/internal/distributed/proxy/httpserver/constant.go
@@ -132,6 +132,10 @@ const (
 
 	HTTPReturnHas = "has"
 
+	HTTPReturnScannedRemoteBytes = "scanned_remote_bytes"
+	HTTPReturnScannedTotalBytes  = "scanned_local_bytes"
+	HTTPReturnCacheHitRatio      = "cache_hit_ratio"
+
 	HTTPReturnFieldName             = "name"
 	HTTPReturnFieldID               = "id"
 	HTTPReturnFieldType             = "type"

--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -860,11 +860,23 @@ func (h *HandlersV2) query(ctx context.Context, c *gin.Context, anyReq any, dbNa
 				HTTPReturnMessage: merr.ErrInvalidSearchResult.Error() + ", error: " + err.Error(),
 			})
 		} else {
-			HTTPReturnStream(c, http.StatusOK, gin.H{
-				HTTPReturnCode: merr.Code(nil),
-				HTTPReturnData: outputData,
-				HTTPReturnCost: proxy.GetCostValue(queryResp.GetStatus()),
-			})
+			if proxy.Params.QueryNodeCfg.StorageUsageTrackingEnabled.GetAsBool() {
+				scannedRemoteBytes, scannedTotalBytes, cacheHitRatio := proxy.GetStorageCost(queryResp.GetStatus())
+				HTTPReturnStream(c, http.StatusOK, gin.H{
+					HTTPReturnCode:               merr.Code(nil),
+					HTTPReturnData:               outputData,
+					HTTPReturnCost:               proxy.GetCostValue(queryResp.GetStatus()),
+					HTTPReturnScannedRemoteBytes: scannedRemoteBytes,
+					HTTPReturnScannedTotalBytes:  scannedTotalBytes,
+					HTTPReturnCacheHitRatio:      cacheHitRatio,
+				})
+			} else {
+				HTTPReturnStream(c, http.StatusOK, gin.H{
+					HTTPReturnCode: merr.Code(nil),
+					HTTPReturnData: outputData,
+					HTTPReturnCost: proxy.GetCostValue(queryResp.GetStatus()),
+				})
+			}
 		}
 	}
 	return resp, err
@@ -916,11 +928,23 @@ func (h *HandlersV2) get(ctx context.Context, c *gin.Context, anyReq any, dbName
 				HTTPReturnMessage: merr.ErrInvalidSearchResult.Error() + ", error: " + err.Error(),
 			})
 		} else {
-			HTTPReturnStream(c, http.StatusOK, gin.H{
-				HTTPReturnCode: merr.Code(nil),
-				HTTPReturnData: outputData,
-				HTTPReturnCost: proxy.GetCostValue(queryResp.GetStatus()),
-			})
+			if proxy.Params.QueryNodeCfg.StorageUsageTrackingEnabled.GetAsBool() {
+				scannedRemoteBytes, scannedTotalBytes, cacheHitRatio := proxy.GetStorageCost(queryResp.GetStatus())
+				HTTPReturnStream(c, http.StatusOK, gin.H{
+					HTTPReturnCode:               merr.Code(nil),
+					HTTPReturnData:               outputData,
+					HTTPReturnCost:               proxy.GetCostValue(queryResp.GetStatus()),
+					HTTPReturnScannedRemoteBytes: scannedRemoteBytes,
+					HTTPReturnScannedTotalBytes:  scannedTotalBytes,
+					HTTPReturnCacheHitRatio:      cacheHitRatio,
+				})
+			} else {
+				HTTPReturnStream(c, http.StatusOK, gin.H{
+					HTTPReturnCode: merr.Code(nil),
+					HTTPReturnData: outputData,
+					HTTPReturnCost: proxy.GetCostValue(queryResp.GetStatus()),
+				})
+			}
 		}
 	}
 	return resp, err
@@ -1082,28 +1106,62 @@ func (h *HandlersV2) upsert(ctx context.Context, c *gin.Context, anyReq any, dbN
 	if err == nil {
 		upsertResp := resp.(*milvuspb.MutationResult)
 		cost := proxy.GetCostValue(upsertResp.GetStatus())
+		scannedRemoteBytes, scannedTotalBytes, cacheHitRatio := proxy.GetStorageCost(upsertResp.GetStatus())
 		switch upsertResp.IDs.GetIdField().(type) {
 		case *schemapb.IDs_IntId:
 			allowJS, _ := strconv.ParseBool(c.Request.Header.Get(HTTPHeaderAllowInt64))
 			if allowJS {
+				if proxy.Params.QueryNodeCfg.StorageUsageTrackingEnabled.GetAsBool() {
+					HTTPReturn(c, http.StatusOK, gin.H{
+						HTTPReturnCode:               merr.Code(nil),
+						HTTPReturnData:               gin.H{"upsertCount": upsertResp.UpsertCnt, "upsertIds": upsertResp.IDs.IdField.(*schemapb.IDs_IntId).IntId.Data},
+						HTTPReturnCost:               cost,
+						HTTPReturnScannedRemoteBytes: scannedRemoteBytes,
+						HTTPReturnScannedTotalBytes:  scannedTotalBytes,
+						HTTPReturnCacheHitRatio:      cacheHitRatio,
+					})
+				} else {
+					HTTPReturn(c, http.StatusOK, gin.H{
+						HTTPReturnCode: merr.Code(nil),
+						HTTPReturnData: gin.H{"upsertCount": upsertResp.UpsertCnt, "upsertIds": upsertResp.IDs.IdField.(*schemapb.IDs_IntId).IntId.Data},
+						HTTPReturnCost: cost,
+					})
+				}
+			} else {
+				if proxy.Params.QueryNodeCfg.StorageUsageTrackingEnabled.GetAsBool() {
+					HTTPReturn(c, http.StatusOK, gin.H{
+						HTTPReturnCode:               merr.Code(nil),
+						HTTPReturnData:               gin.H{"upsertCount": upsertResp.UpsertCnt, "upsertIds": formatInt64(upsertResp.IDs.IdField.(*schemapb.IDs_IntId).IntId.Data)},
+						HTTPReturnCost:               cost,
+						HTTPReturnScannedRemoteBytes: scannedRemoteBytes,
+						HTTPReturnScannedTotalBytes:  scannedTotalBytes,
+						HTTPReturnCacheHitRatio:      cacheHitRatio,
+					})
+				} else {
+					HTTPReturn(c, http.StatusOK, gin.H{
+						HTTPReturnCode: merr.Code(nil),
+						HTTPReturnData: gin.H{"upsertCount": upsertResp.UpsertCnt, "upsertIds": formatInt64(upsertResp.IDs.IdField.(*schemapb.IDs_IntId).IntId.Data)},
+						HTTPReturnCost: cost,
+					})
+				}
+			}
+		case *schemapb.IDs_StrId:
+			if proxy.Params.QueryNodeCfg.StorageUsageTrackingEnabled.GetAsBool() {
 				HTTPReturn(c, http.StatusOK, gin.H{
-					HTTPReturnCode: merr.Code(nil),
-					HTTPReturnData: gin.H{"upsertCount": upsertResp.UpsertCnt, "upsertIds": upsertResp.IDs.IdField.(*schemapb.IDs_IntId).IntId.Data},
-					HTTPReturnCost: cost,
+					HTTPReturnCode:               merr.Code(nil),
+					HTTPReturnData:               gin.H{"upsertCount": upsertResp.UpsertCnt, "upsertIds": upsertResp.IDs.IdField.(*schemapb.IDs_StrId).StrId.Data},
+					HTTPReturnCost:               cost,
+					HTTPReturnScannedRemoteBytes: scannedRemoteBytes,
+					HTTPReturnScannedTotalBytes:  scannedTotalBytes,
+					HTTPReturnCacheHitRatio:      cacheHitRatio,
 				})
 			} else {
 				HTTPReturn(c, http.StatusOK, gin.H{
 					HTTPReturnCode: merr.Code(nil),
-					HTTPReturnData: gin.H{"upsertCount": upsertResp.UpsertCnt, "upsertIds": formatInt64(upsertResp.IDs.IdField.(*schemapb.IDs_IntId).IntId.Data)},
+					HTTPReturnData: gin.H{"upsertCount": upsertResp.UpsertCnt, "upsertIds": upsertResp.IDs.IdField.(*schemapb.IDs_StrId).StrId.Data},
 					HTTPReturnCost: cost,
 				})
 			}
-		case *schemapb.IDs_StrId:
-			HTTPReturn(c, http.StatusOK, gin.H{
-				HTTPReturnCode: merr.Code(nil),
-				HTTPReturnData: gin.H{"upsertCount": upsertResp.UpsertCnt, "upsertIds": upsertResp.IDs.IdField.(*schemapb.IDs_StrId).StrId.Data},
-				HTTPReturnCost: cost,
-			})
 		default:
 			HTTPReturn(c, http.StatusOK, gin.H{
 				HTTPReturnCode:    merr.Code(merr.ErrCheckPrimaryKey),
@@ -1241,6 +1299,7 @@ func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbN
 	if err == nil {
 		searchResp := resp.(*milvuspb.SearchResults)
 		cost := proxy.GetCostValue(searchResp.GetStatus())
+		scannedRemoteBytes, scannedTotalBytes, cacheHitRatio := proxy.GetStorageCost(searchResp.GetStatus())
 		if searchResp.Results.TopK == int64(0) {
 			HTTPReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(nil), HTTPReturnData: []interface{}{}, HTTPReturnCost: cost})
 		} else {
@@ -1254,9 +1313,45 @@ func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbN
 				})
 			} else {
 				if len(searchResp.Results.Recalls) > 0 {
-					HTTPReturnStream(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(nil), HTTPReturnData: outputData, HTTPReturnCost: cost, HTTPReturnRecalls: searchResp.Results.Recalls, HTTPReturnTopks: searchResp.Results.Topks})
+					if proxy.Params.QueryNodeCfg.StorageUsageTrackingEnabled.GetAsBool() {
+						HTTPReturnStream(c, http.StatusOK, gin.H{
+							HTTPReturnCode:               merr.Code(nil),
+							HTTPReturnData:               outputData,
+							HTTPReturnCost:               cost,
+							HTTPReturnRecalls:            searchResp.Results.Recalls,
+							HTTPReturnTopks:              searchResp.Results.Topks,
+							HTTPReturnScannedRemoteBytes: scannedRemoteBytes,
+							HTTPReturnScannedTotalBytes:  scannedTotalBytes,
+							HTTPReturnCacheHitRatio:      cacheHitRatio,
+						})
+					} else {
+						HTTPReturnStream(c, http.StatusOK, gin.H{
+							HTTPReturnCode:    merr.Code(nil),
+							HTTPReturnData:    outputData,
+							HTTPReturnCost:    cost,
+							HTTPReturnRecalls: searchResp.Results.Recalls,
+							HTTPReturnTopks:   searchResp.Results.Topks,
+						})
+					}
 				} else {
-					HTTPReturnStream(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(nil), HTTPReturnData: outputData, HTTPReturnCost: cost, HTTPReturnTopks: searchResp.Results.Topks})
+					if proxy.Params.QueryNodeCfg.StorageUsageTrackingEnabled.GetAsBool() {
+						HTTPReturnStream(c, http.StatusOK, gin.H{
+							HTTPReturnCode:               merr.Code(nil),
+							HTTPReturnData:               outputData,
+							HTTPReturnCost:               cost,
+							HTTPReturnTopks:              searchResp.Results.Topks,
+							HTTPReturnScannedRemoteBytes: scannedRemoteBytes,
+							HTTPReturnScannedTotalBytes:  scannedTotalBytes,
+							HTTPReturnCacheHitRatio:      cacheHitRatio,
+						})
+					} else {
+						HTTPReturnStream(c, http.StatusOK, gin.H{
+							HTTPReturnCode:  merr.Code(nil),
+							HTTPReturnData:  outputData,
+							HTTPReturnCost:  cost,
+							HTTPReturnTopks: searchResp.Results.Topks,
+						})
+					}
 				}
 			}
 		}
@@ -1355,6 +1450,7 @@ func (h *HandlersV2) advancedSearch(ctx context.Context, c *gin.Context, anyReq 
 	if err == nil {
 		searchResp := resp.(*milvuspb.SearchResults)
 		cost := proxy.GetCostValue(searchResp.GetStatus())
+		scannedRemoteBytes, scannedTotalBytes, cacheHitRatio := proxy.GetStorageCost(searchResp.GetStatus())
 		if searchResp.Results.TopK == int64(0) {
 			HTTPReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(nil), HTTPReturnData: []interface{}{}, HTTPReturnCost: cost})
 		} else {
@@ -1367,7 +1463,11 @@ func (h *HandlersV2) advancedSearch(ctx context.Context, c *gin.Context, anyReq 
 					HTTPReturnMessage: merr.ErrInvalidSearchResult.Error() + ", error: " + err.Error(),
 				})
 			} else {
-				HTTPReturnStream(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(nil), HTTPReturnData: outputData, HTTPReturnCost: cost, HTTPReturnTopks: searchResp.Results.Topks})
+				if proxy.Params.QueryNodeCfg.StorageUsageTrackingEnabled.GetAsBool() {
+					HTTPReturnStream(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(nil), HTTPReturnData: outputData, HTTPReturnCost: cost, HTTPReturnTopks: searchResp.Results.Topks, HTTPReturnScannedRemoteBytes: scannedRemoteBytes, HTTPReturnScannedTotalBytes: scannedTotalBytes, HTTPReturnCacheHitRatio: cacheHitRatio})
+				} else {
+					HTTPReturnStream(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(nil), HTTPReturnData: outputData, HTTPReturnCost: cost, HTTPReturnTopks: searchResp.Results.Topks})
+				}
 			}
 		}
 	}

--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -2491,6 +2491,13 @@ func (node *Proxy) Delete(ctx context.Context, request *milvuspb.DeleteRequest) 
 	})
 	SetReportValue(dr.result.GetStatus(), v)
 
+	metrics.ProxyScannedRemoteBytes.WithLabelValues(nodeID, metrics.DeleteLabel, dbName, collectionName).Add(float64(dr.scannedRemoteBytes.Load()))
+	metrics.ProxyScannedTotalBytes.WithLabelValues(nodeID, metrics.DeleteLabel, dbName, collectionName).Add(float64(dr.scannedTotalBytes.Load()))
+	SetStorageCost(dr.result.GetStatus(), segcore.StorageCost{
+		ScannedRemoteBytes: dr.scannedRemoteBytes.Load(),
+		ScannedTotalBytes:  dr.scannedTotalBytes.Load(),
+	})
+
 	if merr.Ok(dr.result.GetStatus()) {
 		metrics.ProxyReportValue.WithLabelValues(nodeID, hookutil.OpTypeDelete, dbName, username).Add(float64(v))
 	}
@@ -2621,6 +2628,9 @@ func (node *Proxy) Upsert(ctx context.Context, request *milvuspb.UpsertRequest) 
 		hookutil.FailCntKey:         len(it.result.ErrIndex),
 	})
 	SetReportValue(it.result.GetStatus(), v)
+	SetStorageCost(it.result.GetStatus(), it.storageCost)
+	metrics.ProxyScannedRemoteBytes.WithLabelValues(nodeID, metrics.UpsertLabel, dbName, collectionName).Add(float64(it.storageCost.ScannedRemoteBytes))
+	metrics.ProxyScannedTotalBytes.WithLabelValues(nodeID, metrics.UpsertLabel, dbName, collectionName).Add(float64(it.storageCost.ScannedTotalBytes))
 	if merr.Ok(it.result.GetStatus()) {
 		metrics.ProxyReportValue.WithLabelValues(nodeID, hookutil.OpTypeUpsert, dbName, username).Add(float64(v))
 	}

--- a/internal/proxy/task_upsert_test.go
+++ b/internal/proxy/task_upsert_test.go
@@ -695,7 +695,7 @@ func TestRetrieveByPKs_Success(t *testing.T) {
 			},
 		}
 
-		result, err := retrieveByPKs(context.Background(), task, ids, []string{"*"})
+		result, _, err := retrieveByPKs(context.Background(), task, ids, []string{"*"})
 
 		// Verify results
 		assert.NoError(t, err)
@@ -717,7 +717,7 @@ func TestRetrieveByPKs_GetPrimaryFieldSchemaError(t *testing.T) {
 			},
 		}
 
-		result, err := retrieveByPKs(context.Background(), task, ids, []string{"*"})
+		result, _, err := retrieveByPKs(context.Background(), task, ids, []string{"*"})
 
 		assert.Error(t, err)
 		assert.Nil(t, result)
@@ -750,7 +750,7 @@ func TestRetrieveByPKs_PartitionKeyMode(t *testing.T) {
 			},
 		}
 
-		result, err := retrieveByPKs(context.Background(), task, ids, []string{"*"})
+		result, _, err := retrieveByPKs(context.Background(), task, ids, []string{"*"})
 
 		assert.NoError(t, err)
 		assert.NotNil(t, result)
@@ -829,7 +829,7 @@ func TestUpdateTask_queryPreExecute_Success(t *testing.T) {
 					},
 				},
 			},
-		}, nil).Build()
+		}, segcore.StorageCost{}, nil).Build()
 
 		mockey.Mock(typeutil.NewIDsChecker).Return(&typeutil.IDsChecker{}, nil).Build()
 
@@ -1148,7 +1148,7 @@ func TestUpsertTask_queryPreExecute_MixLogic(t *testing.T) {
 		node: &Proxy{},
 	}
 
-	mockRetrieve := mockey.Mock(retrieveByPKs).Return(mockQueryResult, nil).Build()
+	mockRetrieve := mockey.Mock(retrieveByPKs).Return(mockQueryResult, segcore.StorageCost{}, nil).Build()
 	defer mockRetrieve.UnPatch()
 
 	err := task.queryPreExecute(context.Background())
@@ -1237,7 +1237,7 @@ func TestUpsertTask_queryPreExecute_PureInsert(t *testing.T) {
 		node: &Proxy{},
 	}
 
-	mockRetrieve := mockey.Mock(retrieveByPKs).Return(mockQueryResult, nil).Build()
+	mockRetrieve := mockey.Mock(retrieveByPKs).Return(mockQueryResult, segcore.StorageCost{}, nil).Build()
 	defer mockRetrieve.UnPatch()
 
 	err := task.queryPreExecute(context.Background())
@@ -1325,7 +1325,7 @@ func TestUpsertTask_queryPreExecute_PureUpdate(t *testing.T) {
 		node: &Proxy{},
 	}
 
-	mockRetrieve := mockey.Mock(retrieveByPKs).Return(mockQueryResult, nil).Build()
+	mockRetrieve := mockey.Mock(retrieveByPKs).Return(mockQueryResult, segcore.StorageCost{}, nil).Build()
 	defer mockRetrieve.UnPatch()
 
 	err := task.queryPreExecute(context.Background())

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -2421,6 +2421,9 @@ func SetReportValue(status *commonpb.Status, value int) {
 }
 
 func SetStorageCost(status *commonpb.Status, storageCost segcore.StorageCost) {
+	if !Params.QueryNodeCfg.StorageUsageTrackingEnabled.GetAsBool() {
+		return
+	}
 	if storageCost.ScannedTotalBytes <= 0 {
 		return
 	}

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -2451,6 +2451,25 @@ func GetCostValue(status *commonpb.Status) int {
 	return value
 }
 
+func GetStorageCost(status *commonpb.Status) (int64, int64, float64) {
+	if status == nil || status.ExtraInfo == nil {
+		return 0, 0, 0
+	}
+	scannedRemoteBytes, err := strconv.ParseInt(status.ExtraInfo["scanned_remote_bytes"], 10, 64)
+	if err != nil {
+		return 0, 0, 0
+	}
+	scannedTotalBytes, err := strconv.ParseInt(status.ExtraInfo["scanned_total_bytes"], 10, 64)
+	if err != nil {
+		return 0, 0, 0
+	}
+	cacheHitRatio, err := strconv.ParseFloat(status.ExtraInfo["cache_hit_ratio"], 64)
+	if err != nil {
+		return 0, 0, 0
+	}
+	return scannedRemoteBytes, scannedTotalBytes, cacheHitRatio
+}
+
 // GetRequestInfo returns collection name and rateType of request and return tokens needed.
 func GetRequestInfo(ctx context.Context, req proto.Message) (int64, map[int64][]int64, internalpb.RateType, int, error) {
 	switch r := req.(type) {

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -2454,23 +2454,43 @@ func GetCostValue(status *commonpb.Status) int {
 	return value
 }
 
-func GetStorageCost(status *commonpb.Status) (int64, int64, float64) {
+// final return value means value is valid or not
+func GetStorageCost(status *commonpb.Status) (int64, int64, float64, bool) {
 	if status == nil || status.ExtraInfo == nil {
-		return 0, 0, 0
+		return 0, 0, 0, false
 	}
-	scannedRemoteBytes, err := strconv.ParseInt(status.ExtraInfo["scanned_remote_bytes"], 10, 64)
-	if err != nil {
-		return 0, 0, 0
+	var scannedRemoteBytes int64
+	var scannedTotalBytes int64
+	var cacheHitRatio float64
+	var err error
+	if value, ok := status.ExtraInfo["scanned_remote_bytes"]; ok {
+		scannedRemoteBytes, err = strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			log.Warn("scanned_remote_bytes is not a valid int64", zap.String("value", value), zap.Error(err))
+			return 0, 0, 0, false
+		}
+	} else {
+		return 0, 0, 0, false
 	}
-	scannedTotalBytes, err := strconv.ParseInt(status.ExtraInfo["scanned_total_bytes"], 10, 64)
-	if err != nil {
-		return 0, 0, 0
+	if value, ok := status.ExtraInfo["scanned_total_bytes"]; ok {
+		scannedTotalBytes, err = strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			log.Warn("scanned_total_bytes is not a valid int64", zap.String("value", value), zap.Error(err))
+			return 0, 0, 0, false
+		}
+	} else {
+		return 0, 0, 0, false
 	}
-	cacheHitRatio, err := strconv.ParseFloat(status.ExtraInfo["cache_hit_ratio"], 64)
-	if err != nil {
-		return 0, 0, 0
+	if value, ok := status.ExtraInfo["cache_hit_ratio"]; ok {
+		cacheHitRatio, err = strconv.ParseFloat(value, 64)
+		if err != nil {
+			log.Warn("cache_hit_ratio is not a valid float64", zap.String("value", value), zap.Error(err))
+			return 0, 0, 0, false
+		}
+	} else {
+		return 0, 0, 0, false
 	}
-	return scannedRemoteBytes, scannedTotalBytes, cacheHitRatio
+	return scannedRemoteBytes, scannedTotalBytes, cacheHitRatio, true
 }
 
 // GetRequestInfo returns collection name and rateType of request and return tokens needed.

--- a/internal/proxy/util_test.go
+++ b/internal/proxy/util_test.go
@@ -4599,16 +4599,18 @@ func TestGetStorageCost(t *testing.T) {
 	// nil and empty cases
 	t.Run("nil or empty status", func(t *testing.T) {
 		{
-			remote, total, ratio := GetStorageCost(nil)
+			remote, total, ratio, ok := GetStorageCost(nil)
 			assert.Equal(t, int64(0), remote)
 			assert.Equal(t, int64(0), total)
 			assert.Equal(t, 0.0, ratio)
+			assert.False(t, ok)
 		}
 		{
-			remote, total, ratio := GetStorageCost(&commonpb.Status{})
+			remote, total, ratio, ok := GetStorageCost(&commonpb.Status{})
 			assert.Equal(t, int64(0), remote)
 			assert.Equal(t, int64(0), total)
 			assert.Equal(t, 0.0, ratio)
+			assert.False(t, ok)
 		}
 	})
 
@@ -4617,10 +4619,11 @@ func TestGetStorageCost(t *testing.T) {
 		st := &commonpb.Status{ExtraInfo: map[string]string{
 			"scanned_remote_bytes": "100",
 		}}
-		remote, total, ratio := GetStorageCost(st)
+		remote, total, ratio, ok := GetStorageCost(st)
 		assert.Equal(t, int64(0), remote)
 		assert.Equal(t, int64(0), total)
 		assert.Equal(t, 0.0, ratio)
+		assert.False(t, ok)
 	})
 
 	// invalid number formats should result in zeros
@@ -4630,30 +4633,33 @@ func TestGetStorageCost(t *testing.T) {
 			"scanned_total_bytes":  "200",
 			"cache_hit_ratio":      "0.5",
 		}}
-		remote, total, ratio := GetStorageCost(st)
+		remote, total, ratio, ok := GetStorageCost(st)
 		assert.Equal(t, int64(0), remote)
 		assert.Equal(t, int64(0), total)
 		assert.Equal(t, 0.0, ratio)
+		assert.False(t, ok)
 
 		st = &commonpb.Status{ExtraInfo: map[string]string{
 			"scanned_remote_bytes": "100",
 			"scanned_total_bytes":  "y",
 			"cache_hit_ratio":      "0.5",
 		}}
-		remote, total, ratio = GetStorageCost(st)
+		remote, total, ratio, ok = GetStorageCost(st)
 		assert.Equal(t, int64(0), remote)
 		assert.Equal(t, int64(0), total)
 		assert.Equal(t, 0.0, ratio)
+		assert.False(t, ok)
 
 		st = &commonpb.Status{ExtraInfo: map[string]string{
 			"scanned_remote_bytes": "100",
 			"scanned_total_bytes":  "200",
 			"cache_hit_ratio":      "abc",
 		}}
-		remote, total, ratio = GetStorageCost(st)
+		remote, total, ratio, ok = GetStorageCost(st)
 		assert.Equal(t, int64(0), remote)
 		assert.Equal(t, int64(0), total)
 		assert.Equal(t, 0.0, ratio)
+		assert.False(t, ok)
 	})
 
 	// success case
@@ -4663,9 +4669,10 @@ func TestGetStorageCost(t *testing.T) {
 			"scanned_total_bytes":  "456",
 			"cache_hit_ratio":      "0.27",
 		}}
-		remote, total, ratio := GetStorageCost(st)
+		remote, total, ratio, ok := GetStorageCost(st)
 		assert.Equal(t, int64(123), remote)
 		assert.Equal(t, int64(456), total)
 		assert.InDelta(t, 0.27, ratio, 1e-9)
+		assert.True(t, ok)
 	})
 }

--- a/pkg/metrics/proxy_metrics.go
+++ b/pkg/metrics/proxy_metrics.go
@@ -471,7 +471,7 @@ var (
 			Subsystem: typeutil.ProxyRole,
 			Name:      "scanned_remote_bytes",
 			Help:      "the scanned remote bytes",
-		}, []string{nodeIDLabelName, queryTypeLabelName, databaseLabelName, collectionName})
+		}, []string{nodeIDLabelName, msgTypeLabelName, databaseLabelName, collectionName})
 
 	ProxyScannedTotalBytes = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -479,7 +479,7 @@ var (
 			Subsystem: typeutil.ProxyRole,
 			Name:      "scanned_total_bytes",
 			Help:      "the scanned total bytes",
-		}, []string{nodeIDLabelName, queryTypeLabelName, databaseLabelName, collectionName})
+		}, []string{nodeIDLabelName, msgTypeLabelName, databaseLabelName, collectionName})
 )
 
 // RegisterProxy registers Proxy metrics
@@ -715,27 +715,51 @@ func CleanupProxyCollectionMetrics(nodeID int64, dbName string, collection strin
 		collectionName:     collection,
 	})
 	ProxyScannedRemoteBytes.Delete(prometheus.Labels{
-		nodeIDLabelName:    strconv.FormatInt(nodeID, 10),
-		queryTypeLabelName: SearchLabel,
-		databaseLabelName:  dbName,
-		collectionName:     collection,
+		nodeIDLabelName:   strconv.FormatInt(nodeID, 10),
+		msgTypeLabelName:  SearchLabel,
+		databaseLabelName: dbName,
+		collectionName:    collection,
 	})
 	ProxyScannedRemoteBytes.Delete(prometheus.Labels{
-		nodeIDLabelName:    strconv.FormatInt(nodeID, 10),
-		queryTypeLabelName: QueryLabel,
-		databaseLabelName:  dbName,
-		collectionName:     collection,
+		nodeIDLabelName:   strconv.FormatInt(nodeID, 10),
+		msgTypeLabelName:  QueryLabel,
+		databaseLabelName: dbName,
+		collectionName:    collection,
+	})
+	ProxyScannedRemoteBytes.Delete(prometheus.Labels{
+		nodeIDLabelName:   strconv.FormatInt(nodeID, 10),
+		msgTypeLabelName:  UpsertLabel,
+		databaseLabelName: dbName,
+		collectionName:    collection,
+	})
+	ProxyScannedRemoteBytes.Delete(prometheus.Labels{
+		nodeIDLabelName:   strconv.FormatInt(nodeID, 10),
+		msgTypeLabelName:  DeleteLabel,
+		databaseLabelName: dbName,
+		collectionName:    collection,
 	})
 	ProxyScannedTotalBytes.Delete(prometheus.Labels{
-		nodeIDLabelName:    strconv.FormatInt(nodeID, 10),
-		queryTypeLabelName: SearchLabel,
-		databaseLabelName:  dbName,
-		collectionName:     collection,
+		nodeIDLabelName:   strconv.FormatInt(nodeID, 10),
+		msgTypeLabelName:  SearchLabel,
+		databaseLabelName: dbName,
+		collectionName:    collection,
 	})
 	ProxyScannedTotalBytes.Delete(prometheus.Labels{
-		nodeIDLabelName:    strconv.FormatInt(nodeID, 10),
-		queryTypeLabelName: QueryLabel,
-		databaseLabelName:  dbName,
-		collectionName:     collection,
+		nodeIDLabelName:   strconv.FormatInt(nodeID, 10),
+		msgTypeLabelName:  QueryLabel,
+		databaseLabelName: dbName,
+		collectionName:    collection,
+	})
+	ProxyScannedTotalBytes.Delete(prometheus.Labels{
+		nodeIDLabelName:   strconv.FormatInt(nodeID, 10),
+		msgTypeLabelName:  UpsertLabel,
+		databaseLabelName: dbName,
+		collectionName:    collection,
+	})
+	ProxyScannedTotalBytes.Delete(prometheus.Labels{
+		nodeIDLabelName:   strconv.FormatInt(nodeID, 10),
+		msgTypeLabelName:  DeleteLabel,
+		databaseLabelName: dbName,
+		collectionName:    collection,
 	})
 }

--- a/pkg/metrics/proxy_metrics.go
+++ b/pkg/metrics/proxy_metrics.go
@@ -465,20 +465,20 @@ var (
 			Buckets:   buckets,
 		}, []string{nodeIDLabelName, collectionName, functionTypeName, functionProvider, functionName})
 
-	ProxyScannedRemoteBytes = prometheus.NewCounterVec(
+	ProxyScannedRemoteMB = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: milvusNamespace,
 			Subsystem: typeutil.ProxyRole,
-			Name:      "scanned_remote_bytes",
-			Help:      "the scanned remote bytes",
+			Name:      "scanned_remote_mb",
+			Help:      "the scanned remote megabytes",
 		}, []string{nodeIDLabelName, msgTypeLabelName, databaseLabelName, collectionName})
 
-	ProxyScannedTotalBytes = prometheus.NewCounterVec(
+	ProxyScannedTotalMB = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: milvusNamespace,
 			Subsystem: typeutil.ProxyRole,
-			Name:      "scanned_total_bytes",
-			Help:      "the scanned total bytes",
+			Name:      "scanned_total_mb",
+			Help:      "the scanned total megabytes",
 		}, []string{nodeIDLabelName, msgTypeLabelName, databaseLabelName, collectionName})
 )
 
@@ -550,8 +550,8 @@ func RegisterProxy(registry *prometheus.Registry) {
 
 	registry.MustRegister(ProxyFunctionlatency)
 
-	registry.MustRegister(ProxyScannedRemoteBytes)
-	registry.MustRegister(ProxyScannedTotalBytes)
+	registry.MustRegister(ProxyScannedRemoteMB)
+	registry.MustRegister(ProxyScannedTotalMB)
 	RegisterStreamingServiceClient(registry)
 }
 
@@ -714,49 +714,49 @@ func CleanupProxyCollectionMetrics(nodeID int64, dbName string, collection strin
 		databaseLabelName:  dbName,
 		collectionName:     collection,
 	})
-	ProxyScannedRemoteBytes.Delete(prometheus.Labels{
+	ProxyScannedRemoteMB.Delete(prometheus.Labels{
 		nodeIDLabelName:   strconv.FormatInt(nodeID, 10),
 		msgTypeLabelName:  SearchLabel,
 		databaseLabelName: dbName,
 		collectionName:    collection,
 	})
-	ProxyScannedRemoteBytes.Delete(prometheus.Labels{
+	ProxyScannedRemoteMB.Delete(prometheus.Labels{
 		nodeIDLabelName:   strconv.FormatInt(nodeID, 10),
 		msgTypeLabelName:  QueryLabel,
 		databaseLabelName: dbName,
 		collectionName:    collection,
 	})
-	ProxyScannedRemoteBytes.Delete(prometheus.Labels{
+	ProxyScannedRemoteMB.Delete(prometheus.Labels{
 		nodeIDLabelName:   strconv.FormatInt(nodeID, 10),
 		msgTypeLabelName:  UpsertLabel,
 		databaseLabelName: dbName,
 		collectionName:    collection,
 	})
-	ProxyScannedRemoteBytes.Delete(prometheus.Labels{
+	ProxyScannedRemoteMB.Delete(prometheus.Labels{
 		nodeIDLabelName:   strconv.FormatInt(nodeID, 10),
 		msgTypeLabelName:  DeleteLabel,
 		databaseLabelName: dbName,
 		collectionName:    collection,
 	})
-	ProxyScannedTotalBytes.Delete(prometheus.Labels{
+	ProxyScannedTotalMB.Delete(prometheus.Labels{
 		nodeIDLabelName:   strconv.FormatInt(nodeID, 10),
 		msgTypeLabelName:  SearchLabel,
 		databaseLabelName: dbName,
 		collectionName:    collection,
 	})
-	ProxyScannedTotalBytes.Delete(prometheus.Labels{
+	ProxyScannedTotalMB.Delete(prometheus.Labels{
 		nodeIDLabelName:   strconv.FormatInt(nodeID, 10),
 		msgTypeLabelName:  QueryLabel,
 		databaseLabelName: dbName,
 		collectionName:    collection,
 	})
-	ProxyScannedTotalBytes.Delete(prometheus.Labels{
+	ProxyScannedTotalMB.Delete(prometheus.Labels{
 		nodeIDLabelName:   strconv.FormatInt(nodeID, 10),
 		msgTypeLabelName:  UpsertLabel,
 		databaseLabelName: dbName,
 		collectionName:    collection,
 	})
-	ProxyScannedTotalBytes.Delete(prometheus.Labels{
+	ProxyScannedTotalMB.Delete(prometheus.Labels{
 		nodeIDLabelName:   strconv.FormatInt(nodeID, 10),
 		msgTypeLabelName:  DeleteLabel,
 		databaseLabelName: dbName,


### PR DESCRIPTION
#44212 

Also, record metrics only when storageUsageTracking is enabled.
Use MB for scanned_remote counter and scanned_total counter metrics to avoid overflow.