### PR TITLE
fix: Make default local storage path effective

### DIFF
--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -3700,11 +3700,7 @@ This defaults to true, indicating that Milvus creates temporary index for growin
 		Doc:          "Deprecated: The folder that storing data files for mmap, setting to a path will enable Milvus to load data with mmap",
 		Formatter: func(v string) string {
 			if len(v) == 0 {
-				localStoragePath := base.Get("localStorage.path")
-				if len(localStoragePath) == 0 {
-					localStoragePath = defaultLocalStoragePath
-					log.Warn("localStorage.path is not set, using default value", zap.String("localStorage.path", localStoragePath))
-				}
+				localStoragePath := getLocalStoragePath(base)
 				return path.Join(localStoragePath, "mmap")
 			}
 			return v
@@ -3978,11 +3974,7 @@ Max read concurrency must greater than or equal to 1, and less than or equal to 
 		Formatter: func(v string) string {
 			if len(v) == 0 {
 				// use local storage path to check correct device
-				localStoragePath := base.Get("localStorage.path")
-				if len(localStoragePath) == 0 {
-					localStoragePath = defaultLocalStoragePath
-					log.Warn("localStorage.path is not set, using default value", zap.String("localStorage.path", localStoragePath))
-				}
+				localStoragePath := getLocalStoragePath(base)
 				if _, err := os.Stat(localStoragePath); os.IsNotExist(err) {
 					if err := os.MkdirAll(localStoragePath, os.ModePerm); err != nil {
 						log.Fatal("failed to mkdir", zap.String("localStoragePath", localStoragePath), zap.Error(err))
@@ -6516,4 +6508,13 @@ func (params *ComponentParam) Reset(key string) error {
 
 func (params *ComponentParam) GetWithDefault(key string, dft string) string {
 	return params.baseTable.GetWithDefault(key, dft)
+}
+
+func getLocalStoragePath(base *BaseTable) string {
+	localStoragePath := base.Get("localStorage.path")
+	if len(localStoragePath) == 0 {
+		localStoragePath = defaultLocalStoragePath
+		log.Warn("localStorage.path is not set, using default value", zap.String("localStorage.path", localStoragePath))
+	}
+	return localStoragePath
 }

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -3700,7 +3700,12 @@ This defaults to true, indicating that Milvus creates temporary index for growin
 		Doc:          "Deprecated: The folder that storing data files for mmap, setting to a path will enable Milvus to load data with mmap",
 		Formatter: func(v string) string {
 			if len(v) == 0 {
-				return path.Join(base.Get("localStorage.path"), "mmap")
+				localStoragePath := base.Get("localStorage.path")
+				if len(localStoragePath) == 0 {
+					localStoragePath = defaultLocalStoragePath
+					log.Warn("localStorage.path is not set, using default value", zap.String("localStorage.path", localStoragePath))
+				}
+				return path.Join(localStoragePath, "mmap")
 			}
 			return v
 		},
@@ -3974,6 +3979,10 @@ Max read concurrency must greater than or equal to 1, and less than or equal to 
 			if len(v) == 0 {
 				// use local storage path to check correct device
 				localStoragePath := base.Get("localStorage.path")
+				if len(localStoragePath) == 0 {
+					localStoragePath = defaultLocalStoragePath
+					log.Warn("localStorage.path is not set, using default value", zap.String("localStorage.path", localStoragePath))
+				}
 				if _, err := os.Stat(localStoragePath); os.IsNotExist(err) {
 					if err := os.MkdirAll(localStoragePath, os.ModePerm); err != nil {
 						log.Fatal("failed to mkdir", zap.String("localStoragePath", localStoragePath), zap.Error(err))

--- a/pkg/util/paramtable/service_param.go
+++ b/pkg/util/paramtable/service_param.go
@@ -1551,11 +1551,7 @@ func (p *ProfileConfig) Init(base *BaseTable) {
 		Doc:          "The folder that storing pprof files, by default will use localStoragePath/pprof",
 		Formatter: func(v string) string {
 			if len(v) == 0 {
-				localStoragePath := base.Get("localStorage.path")
-				if len(localStoragePath) == 0 {
-					localStoragePath = defaultLocalStoragePath
-					log.Warn("localStorage.path is not set, using default value", zap.String("localStorage.path", localStoragePath))
-				}
+				localStoragePath := getLocalStoragePath(base)
 				return path.Join(localStoragePath, "pprof")
 			}
 			return v

--- a/pkg/util/paramtable/service_param.go
+++ b/pkg/util/paramtable/service_param.go
@@ -37,6 +37,8 @@ const (
 	defaultEtcdLogPath        = "stdout"
 	KafkaProducerConfigPrefix = "kafka.producer."
 	KafkaConsumerConfigPrefix = "kafka.consumer."
+
+	defaultLocalStoragePath = "/var/lib/milvus/data"
 )
 
 // ServiceParam is used to quickly and easily access all basic service configurations.
@@ -462,7 +464,7 @@ func (p *LocalStorageConfig) Init(base *BaseTable) {
 	p.Path = ParamItem{
 		Key:          "localStorage.path",
 		Version:      "2.0.0",
-		DefaultValue: "/var/lib/milvus/data",
+		DefaultValue: defaultLocalStoragePath,
 		Doc: `Local path to where vector data are stored during a search or a query to avoid repetitve access to MinIO or S3 service.
 Caution: Changing this parameter after using Milvus for a period of time will affect your access to old data.
 It is recommended to change this parameter before starting Milvus for the first time.`,
@@ -1549,7 +1551,12 @@ func (p *ProfileConfig) Init(base *BaseTable) {
 		Doc:          "The folder that storing pprof files, by default will use localStoragePath/pprof",
 		Formatter: func(v string) string {
 			if len(v) == 0 {
-				return path.Join(base.Get("localStorage.path"), "pprof")
+				localStoragePath := base.Get("localStorage.path")
+				if len(localStoragePath) == 0 {
+					localStoragePath = defaultLocalStoragePath
+					log.Warn("localStorage.path is not set, using default value", zap.String("localStorage.path", localStoragePath))
+				}
+				return path.Join(localStoragePath, "pprof")
 			}
 			return v
 		},


### PR DESCRIPTION
Make default local storage path effective instead of empty when yaml config file is missing.

issue: https://github.com/milvus-io/milvus/issues/44513