### PR TITLE
fix: Fix replicator cannot stop and enhance replicate config validator

### DIFF
--- a/internal/cdc/replication/replicatemanager/replicate_manager.go
+++ b/internal/cdc/replication/replicatemanager/replicate_manager.go
@@ -18,12 +18,12 @@ package replicatemanager
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/samber/lo"
 	"go.uber.org/zap"
 
+	"github.com/milvus-io/milvus/internal/metastore/kv/streamingcoord"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/proto/streamingpb"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
@@ -46,10 +46,6 @@ func NewReplicateManager() *replicateManager {
 	}
 }
 
-func bindReplicatorKey(replicateInfo *streamingpb.ReplicatePChannelMeta) string {
-	return fmt.Sprintf("%s_%s", replicateInfo.GetSourceChannelName(), replicateInfo.GetTargetChannelName())
-}
-
 func (r *replicateManager) CreateReplicator(replicateInfo *streamingpb.ReplicatePChannelMeta) {
 	logger := log.With(
 		zap.String("sourceChannel", replicateInfo.GetSourceChannelName()),
@@ -60,7 +56,7 @@ func (r *replicateManager) CreateReplicator(replicateInfo *streamingpb.Replicate
 		// current cluster is not source cluster, skip create replicator
 		return
 	}
-	replicatorKey := bindReplicatorKey(replicateInfo)
+	replicatorKey := streamingcoord.BuildReplicatePChannelMetaKey(replicateInfo)
 	_, ok := r.replicators[replicatorKey]
 	if ok {
 		logger.Debug("replicator already exists, skip create replicator")
@@ -74,7 +70,7 @@ func (r *replicateManager) CreateReplicator(replicateInfo *streamingpb.Replicate
 }
 
 func (r *replicateManager) RemoveOutOfTargetReplicators(targetReplicatePChannels []*streamingpb.ReplicatePChannelMeta) {
-	targets := lo.KeyBy(targetReplicatePChannels, bindReplicatorKey)
+	targets := lo.KeyBy(targetReplicatePChannels, streamingcoord.BuildReplicatePChannelMetaKey)
 	for replicatorKey, replicator := range r.replicators {
 		if pchannelMeta, ok := targets[replicatorKey]; !ok {
 			replicator.StopReplicate()

--- a/internal/cdc/replication/replicatemanager/replicate_manager_test.go
+++ b/internal/cdc/replication/replicatemanager/replicate_manager_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus/internal/cdc/cluster"
 	"github.com/milvus-io/milvus/internal/cdc/resource"
+	"github.com/milvus-io/milvus/internal/metastore/kv/streamingcoord"
 	"github.com/milvus-io/milvus/pkg/v2/proto/streamingpb"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
@@ -60,7 +61,8 @@ func TestReplicateManager_CreateReplicator(t *testing.T) {
 
 	// Verify replicator was created
 	assert.Equal(t, 1, len(manager.replicators))
-	replicator, exists := manager.replicators["test-source-channel-1_test-target-channel-1"]
+	key := streamingcoord.BuildReplicatePChannelMetaKey(replicateInfo)
+	replicator, exists := manager.replicators[key]
 	assert.True(t, exists)
 	assert.NotNil(t, replicator)
 
@@ -77,12 +79,13 @@ func TestReplicateManager_CreateReplicator(t *testing.T) {
 
 	// Verify second replicator was created
 	assert.Equal(t, 2, len(manager.replicators))
-	replicator2, exists := manager.replicators["test-source-channel-2_test-target-channel-2"]
+	key2 := streamingcoord.BuildReplicatePChannelMetaKey(replicateInfo2)
+	replicator2, exists := manager.replicators[key2]
 	assert.True(t, exists)
 	assert.NotNil(t, replicator2)
 
 	// Verify first replicator still exists
-	replicator1, exists := manager.replicators["test-source-channel-1_test-target-channel-1"]
+	replicator1, exists := manager.replicators[key]
 	assert.True(t, exists)
 	assert.NotNil(t, replicator1)
 }

--- a/internal/cdc/replication/replicatestream/msg_queue.go
+++ b/internal/cdc/replication/replicatestream/msg_queue.go
@@ -31,11 +31,11 @@ type MsgQueue interface {
 	// (via CleanupConfirmedMessages) or ctx is canceled.
 	Enqueue(ctx context.Context, msg message.ImmutableMessage) error
 
-	// Dequeue returns the next message from the current read cursor and advances
+	// ReadNext returns the next message from the current read cursor and advances
 	// the cursor by one. It does NOT delete the message from the queue storage.
 	// Blocks when there are no readable messages (i.e., cursor is at tail) until
 	// a new message is Enqueued or ctx is canceled.
-	Dequeue(ctx context.Context) (message.ImmutableMessage, error)
+	ReadNext(ctx context.Context) (message.ImmutableMessage, error)
 
 	// SeekToHead moves the read cursor to the first not-yet-deleted message.
 	SeekToHead()
@@ -116,8 +116,8 @@ func (q *msgQueue) Enqueue(ctx context.Context, msg message.ImmutableMessage) er
 	return nil
 }
 
-// Dequeue returns the next message at the read cursor. Does not delete it.
-func (q *msgQueue) Dequeue(ctx context.Context) (message.ImmutableMessage, error) {
+// ReadNext returns the next message at the read cursor. Does not delete it.
+func (q *msgQueue) ReadNext(ctx context.Context) (message.ImmutableMessage, error) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 

--- a/internal/cdc/replication/replicatestream/msg_queue_test.go
+++ b/internal/cdc/replication/replicatestream/msg_queue_test.go
@@ -43,7 +43,7 @@ func TestMsgQueue_BasicOperations(t *testing.T) {
 	assert.Equal(t, 1, queue.Len())
 
 	// Test dequeue
-	dequeuedMsg, err := queue.Dequeue(ctx)
+	dequeuedMsg, err := queue.ReadNext(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, msg1, dequeuedMsg)
 	assert.Equal(t, 1, queue.Len()) // Length doesn't change after dequeue
@@ -89,7 +89,7 @@ func TestMsgQueue_DequeueBlocking(t *testing.T) {
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
 	defer cancel()
 
-	_, err := queue.Dequeue(ctxWithTimeout)
+	_, err := queue.ReadNext(ctxWithTimeout)
 	assert.Error(t, err)
 	// Context timeout will cause context.Canceled error, not DeadlineExceeded
 	assert.Equal(t, context.Canceled, err)
@@ -112,7 +112,7 @@ func TestMsgQueue_SeekToHead(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Dequeue first message
-	dequeuedMsg, err := queue.Dequeue(ctx)
+	dequeuedMsg, err := queue.ReadNext(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, msg1, dequeuedMsg)
 
@@ -120,7 +120,7 @@ func TestMsgQueue_SeekToHead(t *testing.T) {
 	queue.SeekToHead()
 
 	// Should be able to dequeue first message again
-	dequeuedMsg, err = queue.Dequeue(ctx)
+	dequeuedMsg, err = queue.ReadNext(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, msg1, dequeuedMsg)
 }
@@ -155,7 +155,7 @@ func TestMsgQueue_CleanupConfirmedMessages(t *testing.T) {
 	assert.Equal(t, msg2, cleanedMessages[1])
 
 	// First two messages should be removed
-	dequeuedMsg, err := queue.Dequeue(ctx)
+	dequeuedMsg, err := queue.ReadNext(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, msg3, dequeuedMsg) // Only msg3 remains
 }
@@ -181,7 +181,7 @@ func TestMsgQueue_CleanupWithReadCursor(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Dequeue first message (advance read cursor)
-	dequeuedMsg, err := queue.Dequeue(ctx)
+	dequeuedMsg, err := queue.ReadNext(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, msg1, dequeuedMsg)
 	assert.Equal(t, 1, queue.readIdx)
@@ -256,7 +256,7 @@ func TestMsgQueue_ConcurrentOperations(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		for i := 0; i < numMessages; i++ {
-			dequeuedMsg, err := queue.Dequeue(ctx)
+			dequeuedMsg, err := queue.ReadNext(ctx)
 			assert.NoError(t, err)
 			cleanedMessages := queue.CleanupConfirmedMessages(dequeuedMsg.TimeTick())
 			assert.Equal(t, 1, len(cleanedMessages))

--- a/internal/cdc/replication/replicatestream/replicate_stream_client_impl.go
+++ b/internal/cdc/replication/replicatestream/replicate_stream_client_impl.go
@@ -90,7 +90,7 @@ func (r *replicateStreamClient) startInternal() {
 	backoff.Reset()
 
 	for {
-		// Create a local context for this connection that can be cancelled
+		// Create a local context for this connection that can be canceled
 		// when we need to stop the send/recv loops
 		connCtx, connCancel := context.WithCancel(r.ctx)
 

--- a/internal/metastore/kv/streamingcoord/kv_catalog.go
+++ b/internal/metastore/kv/streamingcoord/kv_catalog.go
@@ -238,6 +238,12 @@ func (c *catalog) ListReplicatePChannels(ctx context.Context) ([]*streamingpb.Re
 	return infos, nil
 }
 
+func BuildReplicatePChannelMetaKey(meta *streamingpb.ReplicatePChannelMeta) string {
+	targetClusterID := meta.GetTargetCluster().GetClusterId()
+	sourceChannelName := meta.GetSourceChannelName()
+	return buildReplicatePChannelPath(targetClusterID, sourceChannelName)
+}
+
 func buildReplicatePChannelPath(targetClusterID, sourceChannelName string) string {
 	return fmt.Sprintf("%s%s-%s", ReplicatePChannelMetaPrefix, targetClusterID, sourceChannelName)
 }

--- a/internal/streamingcoord/server/service/assignment.go
+++ b/internal/streamingcoord/server/service/assignment.go
@@ -107,7 +107,9 @@ func (s *assignmentServiceImpl) validateReplicateConfiguration(ctx context.Conte
 
 	// validate the configuration itself
 	currentClusterID := paramtable.Get().CommonCfg.ClusterPrefix.GetValue()
-	validator := replicateutil.NewReplicateConfigValidator(config, currentClusterID, pchannels)
+	currentConfig := latestAssignment.ReplicateConfiguration
+	incomingConfig := config
+	validator := replicateutil.NewReplicateConfigValidator(incomingConfig, currentConfig, currentClusterID, pchannels)
 	if err := validator.Validate(); err != nil {
 		log.Ctx(ctx).Warn("UpdateReplicateConfiguration fail", zap.Error(err))
 		return nil, err

--- a/pkg/util/replicateutil/config_validator.go
+++ b/pkg/util/replicateutil/config_validator.go
@@ -19,6 +19,7 @@ package replicateutil
 import (
 	"fmt"
 	"net/url"
+	"slices"
 	"strings"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
@@ -29,26 +30,28 @@ type ReplicateConfigValidator struct {
 	currentClusterID string
 	currentPChannels []string
 	clusterMap       map[string]*commonpb.MilvusCluster
-	config           *commonpb.ReplicateConfiguration
+	incomingConfig   *commonpb.ReplicateConfiguration
+	currentConfig    *commonpb.ReplicateConfiguration
 }
 
 // NewReplicateConfigValidator creates a new validator instance with the given configuration
-func NewReplicateConfigValidator(config *commonpb.ReplicateConfiguration, currentClusterID string, currentPChannels []string) *ReplicateConfigValidator {
+func NewReplicateConfigValidator(incomingConfig, currentConfig *commonpb.ReplicateConfiguration, currentClusterID string, currentPChannels []string) *ReplicateConfigValidator {
 	validator := &ReplicateConfigValidator{
 		currentClusterID: currentClusterID,
 		currentPChannels: currentPChannels,
 		clusterMap:       make(map[string]*commonpb.MilvusCluster),
-		config:           config,
+		incomingConfig:   incomingConfig,
+		currentConfig:    currentConfig,
 	}
 	return validator
 }
 
 // Validate performs all validation checks on the configuration
 func (v *ReplicateConfigValidator) Validate() error {
-	if v.config == nil {
+	if v.incomingConfig == nil {
 		return fmt.Errorf("config cannot be nil")
 	}
-	clusters := v.config.GetClusters()
+	clusters := v.incomingConfig.GetClusters()
 	if len(clusters) == 0 {
 		return fmt.Errorf("clusters list cannot be empty")
 	}
@@ -59,12 +62,18 @@ func (v *ReplicateConfigValidator) Validate() error {
 	if err := v.validateRelevance(); err != nil {
 		return err
 	}
-	topologies := v.config.GetCrossClusterTopology()
+	topologies := v.incomingConfig.GetCrossClusterTopology()
 	if err := v.validateTopologyEdgeUniqueness(topologies); err != nil {
 		return err
 	}
 	if err := v.validateTopologyTypeConstraint(topologies); err != nil {
 		return err
+	}
+	// If currentConfig is provided, perform comparison validation
+	if v.currentConfig != nil {
+		if err := v.validateConfigComparison(); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -222,6 +231,59 @@ func (v *ReplicateConfigValidator) validateTopologyTypeConstraint(topologies []*
 				clusterID, inDegree[clusterID], outDegree[clusterID])
 		}
 	}
+	return nil
+}
+
+// validateConfigComparison validates that for clusters with the same ClusterID,
+// no cluster attributes can be changed
+func (v *ReplicateConfigValidator) validateConfigComparison() error {
+	currentClusters := v.currentConfig.GetClusters()
+	currentClusterMap := make(map[string]*commonpb.MilvusCluster)
+
+	// Build current cluster map
+	for _, cluster := range currentClusters {
+		if cluster != nil {
+			currentClusterMap[cluster.GetClusterId()] = cluster
+		}
+	}
+
+	// Compare each incoming cluster with current cluster
+	for _, incomingCluster := range v.incomingConfig.GetClusters() {
+		clusterID := incomingCluster.GetClusterId()
+		currentCluster, exists := currentClusterMap[clusterID]
+		if exists {
+			// Cluster exists in current config, validate that only ConnectionParam can change
+			if err := v.validateClusterConsistency(currentCluster, incomingCluster); err != nil {
+				return err
+			}
+		}
+		// If cluster doesn't exist in current config, it's a new cluster, which is allowed
+	}
+
+	return nil
+}
+
+// validateClusterConsistency validates that no cluster attributes can be changed between current and incoming cluster
+func (v *ReplicateConfigValidator) validateClusterConsistency(current, incoming *commonpb.MilvusCluster) error {
+	// Check Pchannels consistency
+	if !slices.Equal(current.GetPchannels(), incoming.GetPchannels()) {
+		return fmt.Errorf("cluster '%s' pchannels cannot be changed: current=%v, incoming=%v",
+			current.GetClusterId(), current.GetPchannels(), incoming.GetPchannels())
+	}
+
+	// Check ConnectionParam consistency
+	currentConn := current.GetConnectionParam()
+	incomingConn := incoming.GetConnectionParam()
+
+	if currentConn.GetUri() != incomingConn.GetUri() {
+		return fmt.Errorf("cluster '%s' connection_param.uri cannot be changed: current=%s, incoming=%s",
+			current.GetClusterId(), currentConn.GetUri(), incomingConn.GetUri())
+	}
+	if currentConn.GetToken() != incomingConn.GetToken() {
+		return fmt.Errorf("cluster '%s' connection_param.token cannot be changed",
+			current.GetClusterId())
+	}
+
 	return nil
 }
 

--- a/pkg/util/replicateutil/config_validator_test.go
+++ b/pkg/util/replicateutil/config_validator_test.go
@@ -34,7 +34,7 @@ func createValidValidatorConfig() *commonpb.ReplicateConfiguration {
 					Uri:   "localhost:19530",
 					Token: "test-token",
 				},
-				Pchannels: []string{"cluster-1-channel-1", "cluster-1-channel-2"},
+				Pchannels: []string{"channel-1", "channel-2"},
 			},
 			{
 				ClusterId: "cluster-2",
@@ -42,7 +42,7 @@ func createValidValidatorConfig() *commonpb.ReplicateConfiguration {
 					Uri:   "localhost:19531",
 					Token: "test-token",
 				},
-				Pchannels: []string{"cluster-2-channel-1", "cluster-2-channel-2"},
+				Pchannels: []string{"channel-1", "channel-2"},
 			},
 		},
 		CrossClusterTopology: []*commonpb.CrossClusterTopology{
@@ -64,7 +64,7 @@ func createStarTopologyConfig() *commonpb.ReplicateConfiguration {
 					Uri:   "localhost:19530",
 					Token: "test-token",
 				},
-				Pchannels: []string{"center-cluster-channel-1", "center-cluster-channel-2"},
+				Pchannels: []string{"channel-1", "channel-2"},
 			},
 			{
 				ClusterId: "leaf-cluster-1",
@@ -72,7 +72,7 @@ func createStarTopologyConfig() *commonpb.ReplicateConfiguration {
 					Uri:   "localhost:19531",
 					Token: "test-token",
 				},
-				Pchannels: []string{"leaf-cluster-1-channel-1", "leaf-cluster-1-channel-2"},
+				Pchannels: []string{"channel-1", "channel-2"},
 			},
 			{
 				ClusterId: "leaf-cluster-2",
@@ -80,7 +80,7 @@ func createStarTopologyConfig() *commonpb.ReplicateConfiguration {
 					Uri:   "localhost:19532",
 					Token: "test-token",
 				},
-				Pchannels: []string{"leaf-cluster-2-channel-1", "leaf-cluster-2-channel-2"},
+				Pchannels: []string{"channel-1", "channel-2"},
 			},
 		},
 		CrossClusterTopology: []*commonpb.CrossClusterTopology{
@@ -98,7 +98,7 @@ func createStarTopologyConfig() *commonpb.ReplicateConfiguration {
 
 func TestNewReplicateConfigValidator(t *testing.T) {
 	config := createValidValidatorConfig()
-	currentPChannels := []string{"cluster-1-channel-1", "cluster-1-channel-2"}
+	currentPChannels := []string{"channel-1", "channel-2"}
 
 	t.Run("success - create validator without current config", func(t *testing.T) {
 		validator := NewReplicateConfigValidator(config, nil, "cluster-1", currentPChannels)
@@ -125,7 +125,7 @@ func TestNewReplicateConfigValidator(t *testing.T) {
 func TestReplicateConfigValidator_Validate(t *testing.T) {
 	t.Run("success - valid configuration without current config", func(t *testing.T) {
 		config := createValidValidatorConfig()
-		currentPChannels := []string{"cluster-1-channel-1", "cluster-1-channel-2"}
+		currentPChannels := []string{"channel-1", "channel-2"}
 		validator := NewReplicateConfigValidator(config, nil, "cluster-1", currentPChannels)
 
 		err := validator.Validate()
@@ -135,7 +135,7 @@ func TestReplicateConfigValidator_Validate(t *testing.T) {
 	t.Run("success - valid configuration with current config", func(t *testing.T) {
 		config := createValidValidatorConfig()
 		currentConfig := createValidValidatorConfig()
-		currentPChannels := []string{"cluster-1-channel-1", "cluster-1-channel-2"}
+		currentPChannels := []string{"channel-1", "channel-2"}
 		validator := NewReplicateConfigValidator(config, currentConfig, "cluster-1", currentPChannels)
 
 		err := validator.Validate()
@@ -170,7 +170,7 @@ func TestReplicateConfigValidator_validateClusterBasic(t *testing.T) {
 					Uri:   "localhost:19530",
 					Token: "test-token",
 				},
-				Pchannels: []string{"cluster-1-channel-1", "cluster-1-channel-2"},
+				Pchannels: []string{"channel-1", "channel-2"},
 			},
 			{
 				ClusterId: "cluster-2",
@@ -178,7 +178,7 @@ func TestReplicateConfigValidator_validateClusterBasic(t *testing.T) {
 					Uri:   "localhost:19531",
 					Token: "test-token",
 				},
-				Pchannels: []string{"cluster-2-channel-1", "cluster-2-channel-2"},
+				Pchannels: []string{"channel-1", "channel-2"},
 			},
 		}
 
@@ -202,7 +202,7 @@ func TestReplicateConfigValidator_validateClusterBasic(t *testing.T) {
 					Uri:   "localhost:19530",
 					Token: "test-token",
 				},
-				Pchannels: []string{"cluster-1-channel-1"},
+				Pchannels: []string{"channel-1"},
 			},
 		}
 
@@ -244,7 +244,7 @@ func TestReplicateConfigValidator_validateClusterBasic(t *testing.T) {
 					Uri:   "localhost:19530",
 					Token: "test-token",
 				},
-				Pchannels: []string{"cluster-1-channel-1"},
+				Pchannels: []string{"channel-1"},
 			},
 		}
 
@@ -262,7 +262,7 @@ func TestReplicateConfigValidator_validateClusterBasic(t *testing.T) {
 			{
 				ClusterId:       "cluster-1",
 				ConnectionParam: nil,
-				Pchannels:       []string{"cluster-1-channel-1"},
+				Pchannels:       []string{"channel-1"},
 			},
 		}
 
@@ -283,7 +283,7 @@ func TestReplicateConfigValidator_validateClusterBasic(t *testing.T) {
 					Uri:   "",
 					Token: "test-token",
 				},
-				Pchannels: []string{"cluster-1-channel-1"},
+				Pchannels: []string{"channel-1"},
 			},
 		}
 
@@ -304,7 +304,7 @@ func TestReplicateConfigValidator_validateClusterBasic(t *testing.T) {
 					Uri:   "invalid-uri-format",
 					Token: "test-token",
 				},
-				Pchannels: []string{"cluster-1-channel-1"},
+				Pchannels: []string{"channel-1"},
 			},
 		}
 
@@ -346,7 +346,7 @@ func TestReplicateConfigValidator_validateClusterBasic(t *testing.T) {
 					Uri:   "localhost:19530",
 					Token: "test-token",
 				},
-				Pchannels: []string{"", "cluster-1-channel-2"},
+				Pchannels: []string{"", "channel-2"},
 			},
 		}
 
@@ -367,7 +367,7 @@ func TestReplicateConfigValidator_validateClusterBasic(t *testing.T) {
 					Uri:   "localhost:19530",
 					Token: "test-token",
 				},
-				Pchannels: []string{"cluster-1-channel-1", "cluster-1-channel-1"},
+				Pchannels: []string{"channel-1", "channel-1"},
 			},
 		}
 
@@ -380,27 +380,6 @@ func TestReplicateConfigValidator_validateClusterBasic(t *testing.T) {
 		assert.Contains(t, err.Error(), "has duplicate pchannel")
 	})
 
-	t.Run("error - pchannel doesn't start with cluster ID", func(t *testing.T) {
-		clusters := []*commonpb.MilvusCluster{
-			{
-				ClusterId: "cluster-1",
-				ConnectionParam: &commonpb.ConnectionParam{
-					Uri:   "localhost:19530",
-					Token: "test-token",
-				},
-				Pchannels: []string{"wrong-prefix-channel"},
-			},
-		}
-
-		validator := &ReplicateConfigValidator{
-			clusterMap: make(map[string]*commonpb.MilvusCluster),
-		}
-
-		err := validator.validateClusterBasic(clusters)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "does not start with clusterID as prefix")
-	})
-
 	t.Run("error - inconsistent pchannel count", func(t *testing.T) {
 		clusters := []*commonpb.MilvusCluster{
 			{
@@ -409,7 +388,7 @@ func TestReplicateConfigValidator_validateClusterBasic(t *testing.T) {
 					Uri:   "localhost:19530",
 					Token: "test-token",
 				},
-				Pchannels: []string{"cluster-1-channel-1", "cluster-1-channel-2"},
+				Pchannels: []string{"channel-1", "channel-2"},
 			},
 			{
 				ClusterId: "cluster-2",
@@ -417,7 +396,7 @@ func TestReplicateConfigValidator_validateClusterBasic(t *testing.T) {
 					Uri:   "localhost:19531",
 					Token: "test-token",
 				},
-				Pchannels: []string{"cluster-2-channel-1"}, // Only 1 channel instead of 2
+				Pchannels: []string{"channel-1"}, // Only 1 channel instead of 2
 			},
 		}
 
@@ -438,7 +417,7 @@ func TestReplicateConfigValidator_validateClusterBasic(t *testing.T) {
 					Uri:   "localhost:19530",
 					Token: "test-token",
 				},
-				Pchannels: []string{"cluster-1-channel-1"},
+				Pchannels: []string{"channel-1"},
 			},
 			{
 				ClusterId: "cluster-1", // Duplicate cluster ID
@@ -446,7 +425,7 @@ func TestReplicateConfigValidator_validateClusterBasic(t *testing.T) {
 					Uri:   "localhost:19531",
 					Token: "test-token",
 				},
-				Pchannels: []string{"cluster-1-channel-1"},
+				Pchannels: []string{"channel-1"},
 			},
 		}
 
@@ -458,17 +437,46 @@ func TestReplicateConfigValidator_validateClusterBasic(t *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "duplicate clusterID found")
 	})
+
+	t.Run("error - duplicate URI across clusters", func(t *testing.T) {
+		clusters := []*commonpb.MilvusCluster{
+			{
+				ClusterId: "cluster-1",
+				ConnectionParam: &commonpb.ConnectionParam{
+					Uri:   "localhost:19530",
+					Token: "test-token",
+				},
+				Pchannels: []string{"channel-1"},
+			},
+			{
+				ClusterId: "cluster-2",
+				ConnectionParam: &commonpb.ConnectionParam{
+					Uri:   "localhost:19530", // Same URI as cluster-1
+					Token: "test-token",
+				},
+				Pchannels: []string{"channel-1"},
+			},
+		}
+
+		validator := &ReplicateConfigValidator{
+			clusterMap: make(map[string]*commonpb.MilvusCluster),
+		}
+
+		err := validator.validateClusterBasic(clusters)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "duplicate URI found")
+	})
 }
 
 func TestReplicateConfigValidator_validateRelevance(t *testing.T) {
 	t.Run("success - current cluster included and pchannels match", func(t *testing.T) {
 		validator := &ReplicateConfigValidator{
 			currentClusterID: "cluster-1",
-			currentPChannels: []string{"cluster-1-channel-1", "cluster-1-channel-2"},
+			currentPChannels: []string{"channel-1", "channel-2"},
 			clusterMap: map[string]*commonpb.MilvusCluster{
 				"cluster-1": {
 					ClusterId: "cluster-1",
-					Pchannels: []string{"cluster-1-channel-1", "cluster-1-channel-2"},
+					Pchannels: []string{"channel-1", "channel-2"},
 				},
 			},
 		}
@@ -480,11 +488,11 @@ func TestReplicateConfigValidator_validateRelevance(t *testing.T) {
 	t.Run("error - current cluster not included", func(t *testing.T) {
 		validator := &ReplicateConfigValidator{
 			currentClusterID: "cluster-1",
-			currentPChannels: []string{"cluster-1-channel-1"},
+			currentPChannels: []string{"channel-1"},
 			clusterMap: map[string]*commonpb.MilvusCluster{
 				"cluster-2": {
 					ClusterId: "cluster-2",
-					Pchannels: []string{"cluster-2-channel-1"},
+					Pchannels: []string{"channel-1"},
 				},
 			},
 		}
@@ -497,11 +505,11 @@ func TestReplicateConfigValidator_validateRelevance(t *testing.T) {
 	t.Run("error - pchannels don't match", func(t *testing.T) {
 		validator := &ReplicateConfigValidator{
 			currentClusterID: "cluster-1",
-			currentPChannels: []string{"cluster-1-channel-1", "cluster-1-channel-2"},
+			currentPChannels: []string{"channel-1", "channel-2"},
 			clusterMap: map[string]*commonpb.MilvusCluster{
 				"cluster-1": {
 					ClusterId: "cluster-1",
-					Pchannels: []string{"cluster-1-channel-1", "cluster-1-channel-3"}, // Different channels
+					Pchannels: []string{"channel-1", "channel-3"}, // Different channels
 				},
 			},
 		}
@@ -749,7 +757,7 @@ func TestReplicateConfigValidator_validateConfigComparison(t *testing.T) {
 
 	t.Run("success - no current config", func(t *testing.T) {
 		config := createValidValidatorConfig()
-		currentPChannels := []string{"cluster-1-channel-1", "cluster-1-channel-2"}
+		currentPChannels := []string{"channel-1", "channel-2"}
 		validator := NewReplicateConfigValidator(config, nil, "cluster-1", currentPChannels)
 
 		err := validator.Validate()
@@ -764,7 +772,7 @@ func TestReplicateConfigValidator_validateConfigComparison(t *testing.T) {
 					Uri:   "localhost:19530",
 					Token: "test-token",
 				},
-				Pchannels: []string{"cluster-1-channel-1", "cluster-1-channel-2"},
+				Pchannels: []string{"channel-1", "channel-2"},
 			},
 		})
 
@@ -775,7 +783,7 @@ func TestReplicateConfigValidator_validateConfigComparison(t *testing.T) {
 					Uri:   "localhost:19530",
 					Token: "test-token",
 				},
-				Pchannels: []string{"cluster-1-channel-1", "cluster-1-channel-2"},
+				Pchannels: []string{"channel-1", "channel-2"},
 			},
 			{
 				ClusterId: "cluster-2", // New cluster
@@ -783,11 +791,11 @@ func TestReplicateConfigValidator_validateConfigComparison(t *testing.T) {
 					Uri:   "localhost:19531",
 					Token: "test-token",
 				},
-				Pchannels: []string{"cluster-2-channel-1", "cluster-2-channel-2"},
+				Pchannels: []string{"channel-1", "channel-2"},
 			},
 		})
 
-		validator := NewReplicateConfigValidator(incomingConfig, currentConfig, "cluster-1", []string{"cluster-1-channel-1", "cluster-1-channel-2"})
+		validator := NewReplicateConfigValidator(incomingConfig, currentConfig, "cluster-1", []string{"channel-1", "channel-2"})
 		err := validator.Validate()
 		assert.NoError(t, err)
 	})
@@ -800,7 +808,7 @@ func TestReplicateConfigValidator_validateConfigComparison(t *testing.T) {
 					Uri:   "localhost:19530",
 					Token: "old-token",
 				},
-				Pchannels: []string{"cluster-1-channel-1", "cluster-1-channel-2"},
+				Pchannels: []string{"channel-1", "channel-2"},
 			},
 		})
 
@@ -811,7 +819,7 @@ func TestReplicateConfigValidator_validateConfigComparison(t *testing.T) {
 					Uri:   "localhost:19530",
 					Token: "new-token", // Token changed - should fail
 				},
-				Pchannels: []string{"cluster-1-channel-1", "cluster-1-channel-2"},
+				Pchannels: []string{"channel-1", "channel-2"},
 			},
 		})
 
@@ -833,7 +841,7 @@ func TestReplicateConfigValidator_validateConfigComparison(t *testing.T) {
 					Uri:   "localhost:19530",
 					Token: "test-token",
 				},
-				Pchannels: []string{"cluster-1-channel-1", "cluster-1-channel-2"},
+				Pchannels: []string{"channel-1", "channel-2"},
 			},
 		})
 
@@ -844,7 +852,7 @@ func TestReplicateConfigValidator_validateConfigComparison(t *testing.T) {
 					Uri:   "localhost:19530",
 					Token: "test-token",
 				},
-				Pchannels: []string{"cluster-1-channel-1", "cluster-1-channel-3"}, // Different pchannels
+				Pchannels: []string{"channel-1", "channel-3"}, // Different pchannels
 			},
 		})
 
@@ -866,7 +874,7 @@ func TestReplicateConfigValidator_validateConfigComparison(t *testing.T) {
 					Uri:   "localhost:19530",
 					Token: "test-token",
 				},
-				Pchannels: []string{"cluster-1-channel-1", "cluster-1-channel-2"},
+				Pchannels: []string{"channel-1", "channel-2"},
 			},
 		})
 
@@ -877,7 +885,7 @@ func TestReplicateConfigValidator_validateConfigComparison(t *testing.T) {
 					Uri:   "localhost:19531", // URI changed - should fail
 					Token: "test-token",
 				},
-				Pchannels: []string{"cluster-1-channel-1", "cluster-1-channel-2"},
+				Pchannels: []string{"channel-1", "channel-2"},
 			},
 		})
 
@@ -899,7 +907,7 @@ func TestReplicateConfigValidator_validateConfigComparison(t *testing.T) {
 					Uri:   "localhost:19530",
 					Token: "test-token",
 				},
-				Pchannels: []string{"cluster-1-channel-1", "cluster-1-channel-2"},
+				Pchannels: []string{"channel-1", "channel-2"},
 			},
 		})
 
@@ -910,7 +918,7 @@ func TestReplicateConfigValidator_validateConfigComparison(t *testing.T) {
 					Uri:   "localhost:19530",
 					Token: "test-token",
 				},
-				Pchannels: []string{"cluster-1-channel-1", "cluster-1-channel-2"},
+				Pchannels: []string{"channel-1", "channel-2"},
 			},
 		})
 


### PR DESCRIPTION
1. Fix replicator cannot stop if error occurs on replicate stream RPC.
2. Simplify replicate stream client.
3. Enhance replicate config validator: 
  1. Compare the incoming replicate config, cluster attributes must not be changed.
  2. Cluster URI must be unique.
  3. Remove the check of pchannel prefix.
 
issue: https://github.com/milvus-io/milvus/issues/44123