### PR TITLE
fix: [StorageV2] Make DiskFileManager use fs from context

### DIFF
--- a/internal/core/src/index/json_stats/JsonKeyStats.cpp
+++ b/internal/core/src/index/json_stats/JsonKeyStats.cpp
@@ -81,7 +81,7 @@ JsonKeyStats::JsonKeyStats(const storage::FileManagerContext& ctx,
         // try singleton if possible
         if (!trueFs) {
             trueFs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
-                          .GetArrowFileSystem();
+                         .GetArrowFileSystem();
         }
         if (!trueFs) {
             ThrowInfo(ErrorCode::UnexpectedError, "Failed to get filesystem");

--- a/internal/core/src/index/json_stats/JsonKeyStats.cpp
+++ b/internal/core/src/index/json_stats/JsonKeyStats.cpp
@@ -22,6 +22,7 @@
 #include "index/json_stats/bson_builder.h"
 #include "index/InvertedIndexUtil.h"
 #include "index/Utils.h"
+#include "milvus-storage/filesystem/fs.h"
 #include "storage/MmapManager.h"
 #include "storage/Util.h"
 #include "common/bson_view.h"
@@ -76,8 +77,12 @@ JsonKeyStats::JsonKeyStats(const storage::FileManagerContext& ctx,
         // TODO: add params to modify batch size and max file size
         auto conf = milvus_storage::StorageConfig();
         conf.part_size = DEFAULT_PART_UPLOAD_SIZE;
-        auto trueFs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
+        auto trueFs = ctx.fs;
+        // try singleton if possible
+        if (!trueFs) {
+            trueFs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
                           .GetArrowFileSystem();
+        }
         if (!trueFs) {
             ThrowInfo(ErrorCode::UnexpectedError, "Failed to get filesystem");
         }

--- a/internal/core/src/storage/DiskFileManagerImpl.cpp
+++ b/internal/core/src/storage/DiskFileManagerImpl.cpp
@@ -171,7 +171,12 @@ DiskFileManagerImpl::OpenInputStream(const std::string& filename) {
     auto local_file_name = GetFileName(filename);
     auto remote_file_path = GetRemoteIndexPathV2(local_file_name);
 
-    auto remote_file = fs_->OpenInputFile(remote_file_path);
+    auto fs = fs_;
+    if (!fs) {
+        fs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
+                 .GetArrowFileSystem();
+    }
+    auto remote_file = fs->OpenInputFile(remote_file_path);
     AssertInfo(remote_file.ok(), "failed to open remote file");
     return std::static_pointer_cast<milvus::InputStream>(
         std::make_shared<milvus::storage::RemoteInputStream>(
@@ -183,7 +188,12 @@ DiskFileManagerImpl::OpenOutputStream(const std::string& filename) {
     auto local_file_name = GetFileName(filename);
     auto remote_file_path = GetRemoteIndexPathV2(local_file_name);
 
-    auto remote_stream = fs_->OpenOutputStream(remote_file_path);
+    auto fs = fs_;
+    if (!fs) {
+        fs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
+                 .GetArrowFileSystem();
+    }
+    auto remote_stream = fs->OpenOutputStream(remote_file_path);
     AssertInfo(remote_stream.ok(),
                "failed to open remote stream, reason: {}",
                remote_stream.status().ToString());

--- a/internal/core/src/storage/DiskFileManagerImpl.cpp
+++ b/internal/core/src/storage/DiskFileManagerImpl.cpp
@@ -171,10 +171,7 @@ DiskFileManagerImpl::OpenInputStream(const std::string& filename) {
     auto local_file_name = GetFileName(filename);
     auto remote_file_path = GetRemoteIndexPathV2(local_file_name);
 
-    auto fs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
-                  .GetArrowFileSystem();
-
-    auto remote_file = fs->OpenInputFile(remote_file_path);
+    auto remote_file = fs_->OpenInputFile(remote_file_path);
     AssertInfo(remote_file.ok(), "failed to open remote file");
     return std::static_pointer_cast<milvus::InputStream>(
         std::make_shared<milvus::storage::RemoteInputStream>(
@@ -186,10 +183,7 @@ DiskFileManagerImpl::OpenOutputStream(const std::string& filename) {
     auto local_file_name = GetFileName(filename);
     auto remote_file_path = GetRemoteIndexPathV2(local_file_name);
 
-    auto fs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
-                  .GetArrowFileSystem();
-
-    auto remote_stream = fs->OpenOutputStream(remote_file_path);
+    auto remote_stream = fs_->OpenOutputStream(remote_file_path);
     AssertInfo(remote_stream.ok(),
                "failed to open remote stream, reason: {}",
                remote_stream.status().ToString());


### PR DESCRIPTION
Related to #44534

Datanode shall not use singleton fs after 2.6+. This patch make disk file manager use filesystem passed by fileManagerContext instead of errorous singleton one.