### PR TITLE
enhance: add autoindex configuration for the int8 vector type

### DIFF
--- a/internal/core/src/index/IndexFactory.cpp
+++ b/internal/core/src/index/IndexFactory.cpp
@@ -548,9 +548,8 @@ IndexFactory::CreateVectorIndex(
                           "VECTOR_ARRAY for DiskAnnIndex is not supported");
             }
             case DataType::VECTOR_INT8: {
-                // TODO caiyd, not support yet
-                ThrowInfo(Unsupported,
-                          "VECTOR_INT8 for DiskAnnIndex is not supported");
+                return std::make_unique<VectorDiskAnnIndex<int8>>(
+                    index_type, metric_type, version, file_manager_context);
             }
             default:
                 ThrowInfo(

--- a/internal/core/src/index/VectorDiskIndex.cpp
+++ b/internal/core/src/index/VectorDiskIndex.cpp
@@ -419,5 +419,6 @@ template class VectorDiskAnnIndex<float16>;
 template class VectorDiskAnnIndex<bfloat16>;
 template class VectorDiskAnnIndex<bin1>;
 template class VectorDiskAnnIndex<sparse_u32_f32>;
+template class VectorDiskAnnIndex<int8>;
 
 }  // namespace milvus::index

--- a/internal/core/src/storage/DiskFileManagerImpl.cpp
+++ b/internal/core/src/storage/DiskFileManagerImpl.cpp
@@ -1026,6 +1026,8 @@ template std::string
 DiskFileManagerImpl::CacheRawDataToDisk<bin1>(const Config& config);
 template std::string
 DiskFileManagerImpl::CacheRawDataToDisk<sparse_u32_f32>(const Config& config);
+template std::string
+DiskFileManagerImpl::CacheRawDataToDisk<int8_t>(const Config& config);
 
 std::string
 DiskFileManagerImpl::GetRemoteIndexFilePrefixV2() const {

--- a/internal/proxy/task_index.go
+++ b/internal/proxy/task_index.go
@@ -287,7 +287,7 @@ func (cit *createIndexTask) parseIndexParams(ctx context.Context) error {
 				}
 			} else if typeutil.IsIntVectorType(cit.fieldSchema.DataType) {
 				// override int vector index params by autoindex
-				for k, v := range Params.AutoIndexConfig.IndexParams.GetAsJSONMap() {
+				for k, v := range Params.AutoIndexConfig.IntVectorIndexParams.GetAsJSONMap() {
 					indexParamsMap[k] = v
 				}
 			}
@@ -361,7 +361,7 @@ func (cit *createIndexTask) parseIndexParams(ctx context.Context) error {
 			} else if typeutil.IsIntVectorType(cit.fieldSchema.DataType) ||
 				(typeutil.IsArrayOfVectorType(cit.fieldSchema.DataType) && typeutil.IsIntVectorType(cit.fieldSchema.ElementType)) {
 				// override int vector index params by autoindex
-				config = Params.AutoIndexConfig.IndexParams.GetAsJSONMap()
+				config = Params.AutoIndexConfig.IntVectorIndexParams.GetAsJSONMap()
 			}
 			if !exist {
 				if err := handle(0, config); err != nil {

--- a/pkg/util/paramtable/autoindex_param.go
+++ b/pkg/util/paramtable/autoindex_param.go
@@ -36,6 +36,7 @@ type AutoIndexConfig struct {
 	EnableResultLimitCheck ParamItem `refreshable:"true"`
 
 	IndexParams            ParamItem  `refreshable:"true"`
+	IntVectorIndexParams   ParamItem  `refreshable:"true"`
 	SparseIndexParams      ParamItem  `refreshable:"true"`
 	BinaryIndexParams      ParamItem  `refreshable:"true"`
 	DeduplicateIndexParams ParamItem  `refreshable:"true"`
@@ -100,6 +101,15 @@ func (p *AutoIndexConfig) init(base *BaseTable) {
 		Export:       true,
 	}
 	p.SparseIndexParams.Init(base.mgr)
+
+	p.IntVectorIndexParams = ParamItem{
+		Key:          "autoIndex.params.int8.build",
+		Version:      "2.6.4",
+		DefaultValue: `{"M": 18,"efConstruction": 240,"index_type": "HNSW", "metric_type": "COSINE"}`,
+		Formatter:    GetBuildParamFormatter(IntVectorDefaultMetricType, "autoIndex.params.int.build"),
+		Export:       true,
+	}
+	p.IntVectorIndexParams.Init(base.mgr)
 
 	p.BinaryIndexParams = ParamItem{
 		Key:          "autoIndex.params.binary.build",

--- a/pkg/util/paramtable/autoindex_param_test.go
+++ b/pkg/util/paramtable/autoindex_param_test.go
@@ -65,6 +65,24 @@ func TestAutoIndexParams_build(t *testing.T) {
 		assert.Equal(t, strconv.Itoa(map2["nlist"].(int)), CParams.AutoIndexConfig.IndexParams.GetAsJSONMap()["nlist"])
 	})
 
+	t.Run("test parseIntVectorBuildParams success", func(t *testing.T) {
+		var err error
+		map1 := map[string]any{
+			IndexTypeKey:     "HNSW",
+			"M":              24,
+			"efConstruction": 200,
+			"metric_type":    "COSINE",
+		}
+		var jsonStrBytes []byte
+		jsonStrBytes, err = json.Marshal(map1)
+		assert.NoError(t, err)
+		bt.Save(CParams.AutoIndexConfig.IntVectorIndexParams.Key, string(jsonStrBytes))
+		intVectorParams := CParams.AutoIndexConfig.IntVectorIndexParams.GetAsJSONMap()
+		assert.Equal(t, "HNSW", intVectorParams[IndexTypeKey])
+		assert.Equal(t, strconv.Itoa(map1["M"].(int)), intVectorParams["M"])
+		assert.Equal(t, strconv.Itoa(map1["efConstruction"].(int)), intVectorParams["efConstruction"])
+		assert.Equal(t, "COSINE", intVectorParams["metric_type"])
+	})
 	t.Run("test parseSparseBuildParams success", func(t *testing.T) {
 		// Params := CParams.AutoIndexConfig
 		// buildParams := make([string]interface)


### PR DESCRIPTION
issue: #38666 

Add int8 support for autoindex to ensure it can be independently configured. At the same time, remove the restriction on int8 type for vectorDiskIndex (note that vectorDiskIndex only determines the building and loading method of the index, not the index type).

