### PR TITLE
enhance: Use dbName in error message

### DIFF
--- a/internal/metastore/catalog.go
+++ b/internal/metastore/catalog.go
@@ -22,7 +22,7 @@ type RootCoordCatalog interface {
 
 	CreateCollection(ctx context.Context, collectionInfo *model.Collection, ts typeutil.Timestamp) error
 	GetCollectionByID(ctx context.Context, dbID int64, ts typeutil.Timestamp, collectionID typeutil.UniqueID) (*model.Collection, error)
-	GetCollectionByName(ctx context.Context, dbID int64, collectionName string, ts typeutil.Timestamp) (*model.Collection, error)
+	GetCollectionByName(ctx context.Context, dbID int64, dbName string, collectionName string, ts typeutil.Timestamp) (*model.Collection, error)
 	ListCollections(ctx context.Context, dbID int64, ts typeutil.Timestamp) ([]*model.Collection, error)
 	CollectionExists(ctx context.Context, dbID int64, collectionID typeutil.UniqueID, ts typeutil.Timestamp) bool
 	DropCollection(ctx context.Context, collectionInfo *model.Collection, ts typeutil.Timestamp) error

--- a/internal/metastore/kv/rootcoord/kv_catalog.go
+++ b/internal/metastore/kv/rootcoord/kv_catalog.go
@@ -863,7 +863,7 @@ func (kc *Catalog) DropAlias(ctx context.Context, dbID int64, alias string, ts t
 	return kc.Snapshot.MultiSaveAndRemove(ctx, nil, []string{k, oldKeyWithoutDb, oldKBefore210}, ts)
 }
 
-func (kc *Catalog) GetCollectionByName(ctx context.Context, dbID int64, collectionName string, ts typeutil.Timestamp) (*model.Collection, error) {
+func (kc *Catalog) GetCollectionByName(ctx context.Context, dbID int64, dbName string, collectionName string, ts typeutil.Timestamp) (*model.Collection, error) {
 	prefix := getDatabasePrefix(dbID)
 	_, vals, err := kc.Snapshot.LoadWithPrefix(ctx, prefix, ts)
 	if err != nil {
@@ -884,7 +884,7 @@ func (kc *Catalog) GetCollectionByName(ctx context.Context, dbID int64, collecti
 		}
 	}
 
-	return nil, merr.WrapErrCollectionNotFoundWithDB(dbID, collectionName, fmt.Sprintf("timestamp = %d", ts))
+	return nil, merr.WrapErrCollectionNotFoundWithDB(dbName, collectionName, fmt.Sprintf("timestamp = %d", ts))
 }
 
 func (kc *Catalog) ListCollections(ctx context.Context, dbID int64, ts typeutil.Timestamp) ([]*model.Collection, error) {

--- a/internal/metastore/mocks/mock_rootcoord_catalog.go
+++ b/internal/metastore/mocks/mock_rootcoord_catalog.go
@@ -1293,9 +1293,9 @@ func (_c *RootCoordCatalog_GetCollectionByID_Call) RunAndReturn(run func(context
 	return _c
 }
 
-// GetCollectionByName provides a mock function with given fields: ctx, dbID, collectionName, ts
-func (_m *RootCoordCatalog) GetCollectionByName(ctx context.Context, dbID int64, collectionName string, ts uint64) (*model.Collection, error) {
-	ret := _m.Called(ctx, dbID, collectionName, ts)
+// GetCollectionByName provides a mock function with given fields: ctx, dbID, dbName, collectionName, ts
+func (_m *RootCoordCatalog) GetCollectionByName(ctx context.Context, dbID int64, dbName string, collectionName string, ts uint64) (*model.Collection, error) {
+	ret := _m.Called(ctx, dbID, dbName, collectionName, ts)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetCollectionByName")
@@ -1303,19 +1303,19 @@ func (_m *RootCoordCatalog) GetCollectionByName(ctx context.Context, dbID int64,
 
 	var r0 *model.Collection
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, int64, string, uint64) (*model.Collection, error)); ok {
-		return rf(ctx, dbID, collectionName, ts)
+	if rf, ok := ret.Get(0).(func(context.Context, int64, string, string, uint64) (*model.Collection, error)); ok {
+		return rf(ctx, dbID, dbName, collectionName, ts)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, int64, string, uint64) *model.Collection); ok {
-		r0 = rf(ctx, dbID, collectionName, ts)
+	if rf, ok := ret.Get(0).(func(context.Context, int64, string, string, uint64) *model.Collection); ok {
+		r0 = rf(ctx, dbID, dbName, collectionName, ts)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.Collection)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, int64, string, uint64) error); ok {
-		r1 = rf(ctx, dbID, collectionName, ts)
+	if rf, ok := ret.Get(1).(func(context.Context, int64, string, string, uint64) error); ok {
+		r1 = rf(ctx, dbID, dbName, collectionName, ts)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1331,15 +1331,16 @@ type RootCoordCatalog_GetCollectionByName_Call struct {
 // GetCollectionByName is a helper method to define mock.On call
 //   - ctx context.Context
 //   - dbID int64
+//   - dbName string
 //   - collectionName string
 //   - ts uint64
-func (_e *RootCoordCatalog_Expecter) GetCollectionByName(ctx interface{}, dbID interface{}, collectionName interface{}, ts interface{}) *RootCoordCatalog_GetCollectionByName_Call {
-	return &RootCoordCatalog_GetCollectionByName_Call{Call: _e.mock.On("GetCollectionByName", ctx, dbID, collectionName, ts)}
+func (_e *RootCoordCatalog_Expecter) GetCollectionByName(ctx interface{}, dbID interface{}, dbName interface{}, collectionName interface{}, ts interface{}) *RootCoordCatalog_GetCollectionByName_Call {
+	return &RootCoordCatalog_GetCollectionByName_Call{Call: _e.mock.On("GetCollectionByName", ctx, dbID, dbName, collectionName, ts)}
 }
 
-func (_c *RootCoordCatalog_GetCollectionByName_Call) Run(run func(ctx context.Context, dbID int64, collectionName string, ts uint64)) *RootCoordCatalog_GetCollectionByName_Call {
+func (_c *RootCoordCatalog_GetCollectionByName_Call) Run(run func(ctx context.Context, dbID int64, dbName string, collectionName string, ts uint64)) *RootCoordCatalog_GetCollectionByName_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(int64), args[2].(string), args[3].(uint64))
+		run(args[0].(context.Context), args[1].(int64), args[2].(string), args[3].(string), args[4].(uint64))
 	})
 	return _c
 }
@@ -1349,7 +1350,7 @@ func (_c *RootCoordCatalog_GetCollectionByName_Call) Return(_a0 *model.Collectio
 	return _c
 }
 
-func (_c *RootCoordCatalog_GetCollectionByName_Call) RunAndReturn(run func(context.Context, int64, string, uint64) (*model.Collection, error)) *RootCoordCatalog_GetCollectionByName_Call {
+func (_c *RootCoordCatalog_GetCollectionByName_Call) RunAndReturn(run func(context.Context, int64, string, string, uint64) (*model.Collection, error)) *RootCoordCatalog_GetCollectionByName_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/rootcoord/meta_table.go
+++ b/internal/rootcoord/meta_table.go
@@ -733,8 +733,8 @@ func (mt *MetaTable) getCollectionByNameInternal(ctx context.Context, dbName str
 	}
 
 	// travel meta information from catalog. No need to check time travel logic again, since catalog already did.
-	ctx1 := contextutil.WithTenantID(ctx, Params.CommonCfg.ClusterName.GetValue())
-	coll, err := mt.catalog.GetCollectionByName(ctx1, db.ID, collectionName, ts)
+	ctx = contextutil.WithTenantID(ctx, Params.CommonCfg.ClusterName.GetValue())
+	coll, err := mt.catalog.GetCollectionByName(ctx, db.ID, db.Name, collectionName, ts)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/rootcoord/meta_table_test.go
+++ b/internal/rootcoord/meta_table_test.go
@@ -617,6 +617,7 @@ func TestMetaTable_GetCollectionByName(t *testing.T) {
 			mock.Anything,
 			mock.Anything,
 			mock.Anything,
+			mock.Anything,
 		).Return(nil, errors.New("error mock GetCollectionByName"))
 		meta := &MetaTable{
 			dbName2Meta: map[string]*model.Database{
@@ -634,6 +635,7 @@ func TestMetaTable_GetCollectionByName(t *testing.T) {
 	t.Run("collection not available", func(t *testing.T) {
 		catalog := mocks.NewRootCoordCatalog(t)
 		catalog.On("GetCollectionByName",
+			mock.Anything,
 			mock.Anything,
 			mock.Anything,
 			mock.Anything,
@@ -656,6 +658,7 @@ func TestMetaTable_GetCollectionByName(t *testing.T) {
 	t.Run("normal case, filter unavailable partitions", func(t *testing.T) {
 		catalog := mocks.NewRootCoordCatalog(t)
 		catalog.On("GetCollectionByName",
+			mock.Anything,
 			mock.Anything,
 			mock.Anything,
 			mock.Anything,
@@ -1654,6 +1657,7 @@ func TestMetaTable_RenameCollection(t *testing.T) {
 			mock.Anything,
 			mock.Anything,
 			mock.Anything,
+			mock.Anything,
 		).Return(nil, merr.WrapErrCollectionNotFound("error"))
 		meta := &MetaTable{
 			dbName2Meta: map[string]*model.Database{
@@ -1693,6 +1697,7 @@ func TestMetaTable_RenameCollection(t *testing.T) {
 			mock.Anything,
 		).Return(nil)
 		catalog.On("GetCollectionByName",
+			mock.Anything,
 			mock.Anything,
 			mock.Anything,
 			mock.Anything,
@@ -1737,6 +1742,7 @@ func TestMetaTable_RenameCollection(t *testing.T) {
 			mock.Anything,
 		).Return(nil)
 		catalog.On("GetCollectionByName",
+			mock.Anything,
 			mock.Anything,
 			mock.Anything,
 			mock.Anything,

--- a/tests/python_client/milvus_client/test_milvus_client_alias.py
+++ b/tests/python_client/milvus_client/test_milvus_client_alias.py
@@ -96,7 +96,7 @@ class TestMilvusClientAliasInvalid(TestMilvusClientV2Base):
         client = self._client()
         alias = cf.gen_unique_str("collection_alias")
         collection_name = "not_exist_collection_alias"
-        error = {ct.err_code: 100, ct.err_msg: f"collection not found[database=1][collection={collection_name}]"}
+        error = {ct.err_code: 100, ct.err_msg: f"collection not found[database=default][collection={collection_name}]"}
         self.create_alias(client, collection_name, alias,
                           check_task=CheckTasks.err_res, check_items=error)
 


### PR DESCRIPTION
The collection not found err could contains db id in err message, which is not meaningful to users.

This patch make error message wrapping dbname instead of db id.