### PR TITLE
enhance: [2.6][backlog] Fix unittest and remove fs fallback logic (#44615)

### DIFF
--- a/internal/core/src/storage/DiskFileManagerImpl.cpp
+++ b/internal/core/src/storage/DiskFileManagerImpl.cpp
@@ -166,16 +166,16 @@ DiskFileManagerImpl::AddFileInternal(
     return true;
 }  // namespace knowhere
 
+// Opens an input stream with fs_
+// note that `fs_` must not be nullptr.
 std::shared_ptr<InputStream>
 DiskFileManagerImpl::OpenInputStream(const std::string& filename) {
     auto local_file_name = GetFileName(filename);
     auto remote_file_path = GetRemoteIndexPathV2(local_file_name);
 
     auto fs = fs_;
-    if (!fs) {
-        fs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
-                 .GetArrowFileSystem();
-    }
+    AssertInfo(fs, "fs is nullptr");
+
     auto remote_file = fs->OpenInputFile(remote_file_path);
     AssertInfo(remote_file.ok(), "failed to open remote file");
     return std::static_pointer_cast<milvus::InputStream>(
@@ -183,16 +183,16 @@ DiskFileManagerImpl::OpenInputStream(const std::string& filename) {
             std::move(remote_file.ValueOrDie())));
 }
 
+// Opens an output stream with fs_
+// note that `fs_` must not be nullptr.
 std::shared_ptr<OutputStream>
 DiskFileManagerImpl::OpenOutputStream(const std::string& filename) {
     auto local_file_name = GetFileName(filename);
     auto remote_file_path = GetRemoteIndexPathV2(local_file_name);
 
     auto fs = fs_;
-    if (!fs) {
-        fs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
-                 .GetArrowFileSystem();
-    }
+    AssertInfo(fs, "fs is nullptr");
+
     auto remote_stream = fs->OpenOutputStream(remote_file_path);
     AssertInfo(remote_stream.ok(),
                "failed to open remote stream, reason: {}",

--- a/internal/core/src/storage/DiskFileManagerImpl.h
+++ b/internal/core/src/storage/DiskFileManagerImpl.h
@@ -52,9 +52,31 @@ class DiskFileManagerImpl : public FileManagerImpl {
     bool
     RemoveFile(const std::string& filename) noexcept override;
 
+    /**
+    * @brief Opens an output stream for provided filename
+    * 
+    *  This function utilizes the arrow file system to open an output stream for the provided filename.
+    * 
+    * @param filename the filename to open
+    * @return std::shared_ptr<OutputStream> a shared pointer to the output stream
+    * @throws milvus::SegcoreError
+    * 
+    * @note the internal `fs_` must be initialized to use this API.
+    */
     std::shared_ptr<InputStream>
     OpenInputStream(const std::string& filename) override;
 
+    /**
+    * @brief Opens an output stream for provided filename
+    * 
+    *  This function utilizes the arrow file system to open an output stream for the provided filename.
+    * 
+    * @param filename the filename to open
+    * @return std::shared_ptr<OutputStream> a shared pointer to the output stream
+    * @throws milvus::SegcoreError if fs_ is nullptr
+    * 
+    * @note the internal `fs_` must be initialized to use this API.
+    */
     std::shared_ptr<OutputStream>
     OpenOutputStream(const std::string& filename) override;
 


### PR DESCRIPTION
Cherry-pick from master
pr: #44615
Related to #44535

This PR:
- Fix the unittest creating `DiskFileManagerImpl` without `filesystem`
- Add comments for methods need `fs_`
- Remove fallback creation and add assertion for nullptr fs