### PR TITLE
fix: Skip running scalar index when segment was compacted

### DIFF
--- a/internal/datacoord/index_meta.go
+++ b/internal/datacoord/index_meta.go
@@ -871,6 +871,7 @@ func (m *indexMeta) UpdateIndexState(buildID UniqueID, state commonpb.IndexState
 
 	segIdx, ok := m.segmentBuildInfo.Get(buildID)
 	if !ok {
+		log.Ctx(m.ctx).Warn("there is no index with buildID", zap.Int64("buildID", buildID))
 		return fmt.Errorf("there is no index with buildID: %d", buildID)
 	}
 
@@ -881,6 +882,7 @@ func (m *indexMeta) UpdateIndexState(buildID UniqueID, state commonpb.IndexState
 	}
 
 	if err := m.updateSegIndexMeta(segIdx, updateFunc); err != nil {
+		log.Ctx(m.ctx).Warn("failed to update index meta", zap.Int64("buildID", buildID), zap.Error(err))
 		return err
 	}
 

--- a/internal/datacoord/task/global_scheduler.go
+++ b/internal/datacoord/task/global_scheduler.go
@@ -210,6 +210,8 @@ func (s *globalTaskScheduler) check() {
 			defer s.mu.RUnlock(task.GetTaskID())
 			task.QueryTaskOnWorker(s.cluster)
 			switch task.GetTaskState() {
+			case taskcommon.None:
+				s.runningTasks.Remove(task.GetTaskID())
 			case taskcommon.Init, taskcommon.Retry:
 				s.runningTasks.Remove(task.GetTaskID())
 				s.pendingTasks.Push(task)


### PR DESCRIPTION
issue: #44689 