### PR TITLE
fix: [2.6] Make aws credential provider singleton (#44687)

### DIFF
--- a/internal/core/src/segcore/arrow_fs_c.cpp
+++ b/internal/core/src/segcore/arrow_fs_c.cpp
@@ -53,11 +53,11 @@ InitRemoteArrowFileSystemSingleton(CStorageConfig c_storage_config) {
         conf.iam_endpoint = std::string(c_storage_config.iam_endpoint);
         conf.log_level = std::string(c_storage_config.log_level);
         conf.region = std::string(c_storage_config.region);
-        conf.useSSL = c_storage_config.useSSL;
-        conf.sslCACert = std::string(c_storage_config.sslCACert);
-        conf.useIAM = c_storage_config.useIAM;
-        conf.useVirtualHost = c_storage_config.useVirtualHost;
-        conf.requestTimeoutMs = c_storage_config.requestTimeoutMs;
+        conf.use_ssl = c_storage_config.useSSL;
+        conf.ssl_ca_cert = std::string(c_storage_config.sslCACert);
+        conf.use_iam = c_storage_config.useIAM;
+        conf.use_virtual_host = c_storage_config.useVirtualHost;
+        conf.request_timeout_ms = c_storage_config.requestTimeoutMs;
         conf.gcp_credential_json =
             std::string(c_storage_config.gcp_credential_json);
         conf.use_custom_part_upload = c_storage_config.use_custom_part_upload;

--- a/internal/core/src/storage/StorageV2FSCache.cpp
+++ b/internal/core/src/storage/StorageV2FSCache.cpp
@@ -50,11 +50,11 @@ StorageV2FSCache::Get(const Key& key) {
     conf.iam_endpoint = std::string(key.iam_endpoint);
     conf.log_level = std::string(key.log_level);
     conf.region = std::string(key.region);
-    conf.useSSL = key.useSSL;
-    conf.sslCACert = std::string(key.sslCACert);
-    conf.useIAM = key.useIAM;
-    conf.useVirtualHost = key.useVirtualHost;
-    conf.requestTimeoutMs = key.requestTimeoutMs;
+    conf.use_ssl = key.useSSL;
+    conf.ssl_ca_cert = std::string(key.sslCACert);
+    conf.use_iam = key.useIAM;
+    conf.use_virtual_host = key.useVirtualHost;
+    conf.request_timeout_ms = key.requestTimeoutMs;
     conf.gcp_credential_json = std::string(key.gcp_credential_json);
     conf.use_custom_part_upload = key.use_custom_part_upload;
     auto result = milvus_storage::CreateArrowFileSystem(conf);

--- a/internal/core/thirdparty/milvus-storage/CMakeLists.txt
+++ b/internal/core/thirdparty/milvus-storage/CMakeLists.txt
@@ -14,7 +14,7 @@
 # Update milvus-storage_VERSION for the first occurrence
 milvus_add_pkg_config("milvus-storage")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( milvus-storage_VERSION 87d9fce )
+set( milvus-storage_VERSION aa189ad )
 set( GIT_REPOSITORY  "https://github.com/milvus-io/milvus-storage.git")
 message(STATUS "milvus-storage repo: ${GIT_REPOSITORY}")
 message(STATUS "milvus-storage version: ${milvus-storage_VERSION}")


### PR DESCRIPTION
Cherry-pick from master
pr: #44687
Related to #44647

This patch make milvus-storage using singleton credential provider in case of data race when concurrent index build task recieved.

See also milvus-io/milvus-storage#267

---------