### PR TITLE
test: Increase PyMilvus version to 2.6.3rc8 for 2.6 branch

### DIFF
--- a/tests/python_client/requirements.txt
+++ b/tests/python_client/requirements.txt
@@ -28,8 +28,8 @@ pytest-parallel
 pytest-random-order
 
 # pymilvus
-pymilvus==2.7.0rc38
-pymilvus[bulk_writer]==2.7.0rc38
+pymilvus==2.6.3rc8
+pymilvus[bulk_writer]==2.6.3rc8
 
 # for protobuf
 protobuf>=5.29.5


### PR DESCRIPTION
Automated daily bump from pymilvus 2.6 branch. Updates tests/python_client/requirements.txt.