### PR TITLE
fix: Replace incorrect log import with milvus v2 log package

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -111,6 +111,8 @@ linters-settings:
             desc: "not allowed, gogo protobuf is deprecated"
           - pkg: "github.com/golang/protobuf/proto"
             desc: "not allowed, protobuf v1 is deprecated, use google.golang.org/protobuf/proto instead"
+          - pkg: "github.com/pingcap/log"
+            desc: "not allowed, use github.com/milvus-io/milvus/pkg/v2/log"
   forbidigo:
     forbid:
       - '^time\.Tick$'

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.3
 	github.com/minio/minio-go/v7 v7.0.73
 	github.com/panjf2000/ants/v2 v2.11.3 // indirect
-	github.com/pingcap/log v1.1.1-0.20221015072633-39906604fb81
+	github.com/pingcap/log v1.1.1-0.20221015072633-39906604fb81 // indirect
 	github.com/prometheus/client_golang v1.20.5
 	github.com/prometheus/client_model v0.6.1
 	github.com/prometheus/common v0.55.0

--- a/internal/coordinator/restful_mgr_routes.go
+++ b/internal/coordinator/restful_mgr_routes.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 
 	"github.com/cockroachdb/errors"
-	"github.com/pingcap/log"
 	"github.com/samber/lo"
 	"go.uber.org/zap"
 
@@ -18,6 +17,7 @@ import (
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
 	management "github.com/milvus-io/milvus/internal/http"
 	"github.com/milvus-io/milvus/internal/json"
+	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v2/util/commonpbutil"

--- a/internal/flushcommon/metacache/bm25_stats.go
+++ b/internal/flushcommon/metacache/bm25_stats.go
@@ -19,10 +19,10 @@ package metacache
 import (
 	"sync"
 
-	"github.com/pingcap/log"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/pkg/v2/log"
 )
 
 type SegmentBM25Stats struct {

--- a/internal/querycoordv2/meta/channel_dist_manager.go
+++ b/internal/querycoordv2/meta/channel_dist_manager.go
@@ -19,13 +19,13 @@ package meta
 import (
 	"sync"
 
-	"github.com/pingcap/log"
 	"github.com/samber/lo"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus/internal/querycoordv2/session"
 	"github.com/milvus-io/milvus/internal/util/metrics"
+	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v2/util/metricsinfo"

--- a/internal/querynodev2/delegator/delegator_data_test.go
+++ b/internal/querynodev2/delegator/delegator_data_test.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
-	"github.com/pingcap/log"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
@@ -45,6 +44,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/function"
 	"github.com/milvus-io/milvus/internal/util/initcore"
 	"github.com/milvus-io/milvus/pkg/v2/common"
+	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/mq/msgstream"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/internalpb"

--- a/internal/util/bloomfilter/bloom_filter.go
+++ b/internal/util/bloomfilter/bloom_filter.go
@@ -19,11 +19,11 @@ import (
 	"github.com/bits-and-blooms/bloom/v3"
 	"github.com/cockroachdb/errors"
 	"github.com/greatroar/blobloom"
-	"github.com/pingcap/log"
 	"github.com/zeebo/xxh3"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/internal/json"
+	"github.com/milvus-io/milvus/pkg/v2/log"
 )
 
 type BFType int


### PR DESCRIPTION
issue: #44730
Fix the issue where logs were not outputting as expected due to incorrect log package imports across multiple components.

Changes include:
- Add golangci-lint rule to forbid github.com/pingcap/log usage
- Replace github.com/pingcap/log with github.com/milvus-io/milvus/pkg/v2/log