### PR TITLE
fix: Pass fs via `FileManagerContext` when loading index

### DIFF
--- a/internal/core/src/clustering/KmeansClusteringTest.cpp
+++ b/internal/core/src/clustering/KmeansClusteringTest.cpp
@@ -189,6 +189,7 @@ test_run() {
     std::string root_path = "/tmp/test-kmeans-clustering/";
     auto storage_config = gen_local_storage_config(root_path);
     auto cm = storage::CreateChunkManager(storage_config);
+    auto fs = storage::InitArrowFileSystem(storage_config);
 
     std::vector<T> data_gen(nb * dim);
     for (int64_t i = 0; i < nb * dim; ++i) {
@@ -216,7 +217,7 @@ test_run() {
     auto log_path = get_binlog_path(0);
     auto cm_w = ChunkManagerWrapper(cm);
     cm_w.Write(log_path, serialized_bytes.data(), serialized_bytes.size());
-    storage::FileManagerContext ctx(field_meta, index_meta, cm);
+    storage::FileManagerContext ctx(field_meta, index_meta, cm, fs);
 
     std::map<int64_t, std::vector<std::string>> remote_files;
     std::map<int64_t, int64_t> num_rows;

--- a/internal/core/src/clustering/analyze_c.cpp
+++ b/internal/core/src/clustering/analyze_c.cpp
@@ -21,6 +21,7 @@
 #include "types.h"
 #include "index/Utils.h"
 #include "index/Meta.h"
+#include "storage/StorageV2FSCache.h"
 #include "storage/Util.h"
 #include "pb/clustering.pb.h"
 #include "monitor/scope_metric.h"
@@ -78,9 +79,29 @@ Analyze(CAnalyze* res_analyze,
             get_storage_config(analyze_info->storage_config());
         auto chunk_manager =
             milvus::storage::CreateChunkManager(storage_config);
+        auto fs = milvus::storage::StorageV2FSCache::Instance().Get({
+            storage_config.address,
+            storage_config.bucket_name,
+            storage_config.access_key_id,
+            storage_config.access_key_value,
+            storage_config.root_path,
+            storage_config.storage_type,
+            storage_config.cloud_provider,
+            storage_config.iam_endpoint,
+            storage_config.log_level,
+            storage_config.region,
+            storage_config.useSSL,
+            storage_config.sslCACert,
+            storage_config.useIAM,
+            storage_config.useVirtualHost,
+            storage_config.requestTimeoutMs,
+            false,
+            storage_config.gcp_credential_json,
+            false,
+        });
 
         milvus::storage::FileManagerContext fileManagerContext(
-            field_meta, index_meta, chunk_manager);
+            field_meta, index_meta, chunk_manager, fs);
 
         if (field_type != DataType::VECTOR_FLOAT) {
             throw SegcoreError(

--- a/internal/core/src/exec/expression/JsonContainsByStatsTest.cpp
+++ b/internal/core/src/exec/expression/JsonContainsByStatsTest.cpp
@@ -77,6 +77,7 @@ BuildAndLoadJsonKeyStats(const std::vector<std::string>& json_strings,
     storage_config.storage_type = "local";
     storage_config.root_path = root_path;
     auto chunk_manager = storage::CreateChunkManager(storage_config);
+    auto fs = storage::InitArrowFileSystem(storage_config);
 
     milvus_storage::ArrowFileSystemSingleton::GetInstance().Init(
         milvus_storage::ArrowFileSystemConfig{
@@ -94,7 +95,7 @@ BuildAndLoadJsonKeyStats(const std::vector<std::string>& json_strings,
     chunk_manager->Write(
         log_path, serialized_bytes.data(), serialized_bytes.size());
 
-    storage::FileManagerContext ctx(field_meta, index_meta, chunk_manager);
+    storage::FileManagerContext ctx(field_meta, index_meta, chunk_manager, fs);
 
     Config build_config;
     build_config[INSERT_FILES_KEY] = std::vector<std::string>{log_path};

--- a/internal/core/src/index/BitmapIndexArrayTest.cpp
+++ b/internal/core/src/index/BitmapIndexArrayTest.cpp
@@ -17,6 +17,7 @@
 
 #include "common/Tracer.h"
 #include "index/BitmapIndex.h"
+#include "milvus-storage/filesystem/fs.h"
 #include "storage/Util.h"
 #include "storage/InsertData.h"
 #include "indexbuilder/IndexFactory.h"
@@ -225,7 +226,8 @@ class ArrayBitmapIndexTest : public testing::Test {
         chunk_manager_->Write(
             log_path, serialized_bytes.data(), serialized_bytes.size());
 
-        storage::FileManagerContext ctx(field_meta, index_meta, chunk_manager_);
+        storage::FileManagerContext ctx(
+            field_meta, index_meta, chunk_manager_, fs_);
         std::vector<std::string> index_files;
 
         Config config;
@@ -297,6 +299,7 @@ class ArrayBitmapIndexTest : public testing::Test {
         storage_config.storage_type = "local";
         storage_config.root_path = root_path;
         chunk_manager_ = storage::CreateChunkManager(storage_config);
+        fs_ = storage::InitArrowFileSystem(storage_config);
 
         Init(collection_id,
              partition_id,
@@ -350,6 +353,7 @@ class ArrayBitmapIndexTest : public testing::Test {
 
  private:
     std::shared_ptr<storage::ChunkManager> chunk_manager_;
+    milvus_storage::ArrowFileSystemPtr fs_;
 
  public:
     DataType type_;

--- a/internal/core/src/index/BitmapIndexTest.cpp
+++ b/internal/core/src/index/BitmapIndexTest.cpp
@@ -21,6 +21,7 @@
 #include "common/Tracer.h"
 #include "common/Types.h"
 #include "index/BitmapIndex.h"
+#include "milvus-storage/filesystem/fs.h"
 #include "storage/Util.h"
 #include "storage/InsertData.h"
 #include "indexbuilder/IndexFactory.h"
@@ -156,7 +157,8 @@ class BitmapIndexTest : public testing::Test {
         chunk_manager_->Write(
             log_path, serialized_bytes.data(), serialized_bytes.size());
 
-        storage::FileManagerContext ctx(field_meta, index_meta, chunk_manager_);
+        storage::FileManagerContext ctx(
+            field_meta, index_meta, chunk_manager_, fs_);
 
         Config config;
         config["index_type"] = milvus::index::BITMAP_INDEX_TYPE;
@@ -234,6 +236,7 @@ class BitmapIndexTest : public testing::Test {
         storage_config.storage_type = "local";
         storage_config.root_path = root_path;
         chunk_manager_ = storage::CreateChunkManager(storage_config);
+        fs_ = storage::InitArrowFileSystem(storage_config);
 
         Init(collection_id,
              partition_id,
@@ -518,6 +521,7 @@ class BitmapIndexTest : public testing::Test {
     bool nullable_;
     FixedVector<bool> valid_data_;
     std::shared_ptr<storage::ChunkManager> chunk_manager_;
+    milvus_storage::ArrowFileSystemPtr fs_;
     int index_version_;
     int index_build_id_;
     bool has_default_value_{false};

--- a/internal/core/src/index/HybridScalarIndexTest.cpp
+++ b/internal/core/src/index/HybridScalarIndexTest.cpp
@@ -154,7 +154,8 @@ class HybridIndexTestV1 : public testing::Test {
         chunk_manager_->Write(
             log_path, serialized_bytes.data(), serialized_bytes.size());
 
-        storage::FileManagerContext ctx(field_meta, index_meta, chunk_manager_);
+        storage::FileManagerContext ctx(
+            field_meta, index_meta, chunk_manager_, fs_);
         std::vector<std::string> index_files;
 
         Config config;
@@ -226,6 +227,7 @@ class HybridIndexTestV1 : public testing::Test {
         storage_config.storage_type = "local";
         storage_config.root_path = root_path;
         chunk_manager_ = storage::CreateChunkManager(storage_config);
+        fs_ = storage::InitArrowFileSystem(storage_config);
 
         Init(collection_id,
              partition_id,
@@ -507,6 +509,7 @@ class HybridIndexTestV1 : public testing::Test {
     size_t cardinality_;
     boost::container::vector<T> data_;
     std::shared_ptr<storage::ChunkManager> chunk_manager_;
+    milvus_storage::ArrowFileSystemPtr fs_;
     bool nullable_;
     FixedVector<bool> valid_data_;
     int index_build_id_;

--- a/internal/core/src/index/InvertedIndexTest.cpp
+++ b/internal/core/src/index/InvertedIndexTest.cpp
@@ -96,6 +96,7 @@ test_run() {
     std::string root_path = "/tmp/test-inverted-index/";
     auto storage_config = gen_local_storage_config(root_path);
     auto cm = storage::CreateChunkManager(storage_config);
+    auto fs = storage::InitArrowFileSystem(storage_config);
 
     size_t nb = 10000;
     std::vector<T> data_gen;
@@ -160,7 +161,7 @@ test_run() {
     auto cm_w = test::ChunkManagerWrapper(cm);
     cm_w.Write(log_path, serialized_bytes.data(), serialized_bytes.size());
 
-    storage::FileManagerContext ctx(field_meta, index_meta, cm);
+    storage::FileManagerContext ctx(field_meta, index_meta, cm, fs);
     std::vector<std::string> index_files;
 
     {
@@ -498,6 +499,7 @@ test_string() {
     std::string root_path = "/tmp/test-inverted-index/";
     auto storage_config = gen_local_storage_config(root_path);
     auto cm = storage::CreateChunkManager(storage_config);
+    auto fs = storage::InitArrowFileSystem(storage_config);
 
     size_t nb = 10000;
     boost::container::vector<T> data;
@@ -553,7 +555,7 @@ test_string() {
     auto cm_w = test::ChunkManagerWrapper(cm);
     cm_w.Write(log_path, serialized_bytes.data(), serialized_bytes.size());
 
-    storage::FileManagerContext ctx(field_meta, index_meta, cm);
+    storage::FileManagerContext ctx(field_meta, index_meta, cm, fs);
     std::vector<std::string> index_files;
 
     {

--- a/internal/core/src/index/JsonFlatIndexTest.cpp
+++ b/internal/core/src/index/JsonFlatIndexTest.cpp
@@ -19,6 +19,7 @@
 #include "common/Tracer.h"
 #include "expr/ITypeExpr.h"
 #include "index/JsonFlatIndex.h"
+#include "milvus-storage/filesystem/fs.h"
 #include "pb/plan.pb.h"
 #include "plan/PlanNode.h"
 #include "query/ExecPlanNodeVisitor.h"
@@ -82,6 +83,7 @@ class JsonFlatIndexTest : public ::testing::Test {
         std::string root_path = "/tmp/test-json-flat-index/";
         auto storage_config = gen_local_storage_config(root_path);
         cm_ = storage::CreateChunkManager(storage_config);
+        fs_ = storage::InitArrowFileSystem(storage_config);
 
         json_data_ = {
             R"({"profile": {"name": {"first": "Alice", "last": "Smith", "preferred_name": "Al"}, "team": {"name": "Engineering", "supervisor": {"name": "Bob"}}, "is_active": true, "employee_id": 1001, "skills": ["cpp", "rust", "python"], "scores": [95, 88, 92]}})",
@@ -121,7 +123,7 @@ class JsonFlatIndexTest : public ::testing::Test {
             log_path_, serialized_bytes.data(), serialized_bytes.size());
 
         ctx_ = std::make_unique<storage::FileManagerContext>(
-            field_meta_, index_meta_, cm_);
+            field_meta_, index_meta_, cm_, fs_);
 
         // Build index
         Config config;
@@ -166,6 +168,7 @@ class JsonFlatIndexTest : public ::testing::Test {
     storage::FieldDataMeta field_meta_;
     storage::IndexMeta index_meta_;
     storage::ChunkManagerPtr cm_;
+    milvus_storage::ArrowFileSystemPtr fs_;
     std::unique_ptr<test::ChunkManagerWrapper> cm_w_;
     std::unique_ptr<storage::FileManagerContext> ctx_;
     std::string log_path_;

--- a/internal/core/src/index/NgramInvertedIndexTest.cpp
+++ b/internal/core/src/index/NgramInvertedIndexTest.cpp
@@ -58,6 +58,7 @@ test_ngram_with_data(const boost::container::vector<std::string>& data,
     std::string root_path = "/tmp/test-inverted-index/";
     auto storage_config = gen_local_storage_config(root_path);
     auto cm = CreateChunkManager(storage_config);
+    auto fs = storage::InitArrowFileSystem(storage_config);
 
     size_t nb = data.size();
 
@@ -96,7 +97,7 @@ test_ngram_with_data(const boost::container::vector<std::string>& data,
     auto cm_w = ChunkManagerWrapper(cm);
     cm_w.Write(log_path, serialized_bytes.data(), serialized_bytes.size());
 
-    storage::FileManagerContext ctx(field_meta, index_meta, cm);
+    storage::FileManagerContext ctx(field_meta, index_meta, cm, fs);
     std::vector<std::string> index_files;
 
     auto index_size = 0;

--- a/internal/core/src/index/NgramInvertedIndexTest.cpp
+++ b/internal/core/src/index/NgramInvertedIndexTest.cpp
@@ -385,6 +385,7 @@ TEST(NgramIndex, TestNonLikeExpressionsWithNgram) {
     std::string root_path = "/tmp/test-inverted-index/";
     auto storage_config = gen_local_storage_config(root_path);
     auto cm = CreateChunkManager(storage_config);
+    auto fs = storage::InitArrowFileSystem(storage_config);
 
     size_t nb = data.size();
 
@@ -423,7 +424,7 @@ TEST(NgramIndex, TestNonLikeExpressionsWithNgram) {
     auto cm_w = ChunkManagerWrapper(cm);
     cm_w.Write(log_path, serialized_bytes.data(), serialized_bytes.size());
 
-    storage::FileManagerContext ctx(field_meta, index_meta, cm);
+    storage::FileManagerContext ctx(field_meta, index_meta, cm, fs);
     std::vector<std::string> index_files;
 
     // Build ngram index

--- a/internal/core/src/segcore/FieldIndexing.cpp
+++ b/internal/core/src/segcore/FieldIndexing.cpp
@@ -354,6 +354,8 @@ ScalarFieldIndexing<T>::recreate_index(const FieldMeta& field_meta,
             auto chunk_manager =
                 milvus::storage::LocalChunkManagerSingleton::GetInstance()
                     .GetChunkManager();
+            auto fs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
+                          .GetArrowFileSystem();
 
             // Create FieldDataMeta for RTree index
             storage::FieldDataMeta field_data_meta;
@@ -380,7 +382,7 @@ ScalarFieldIndexing<T>::recreate_index(const FieldMeta& field_meta,
 
             // Create FileManagerContext with all required components
             storage::FileManagerContext ctx(
-                field_data_meta, index_meta, chunk_manager);
+                field_data_meta, index_meta, chunk_manager, fs);
 
             index_ = std::make_unique<index::RTreeIndex<std::string>>(ctx);
             built_ = false;

--- a/internal/core/src/segcore/load_index_c.cpp
+++ b/internal/core/src/segcore/load_index_c.cpp
@@ -400,8 +400,11 @@ AppendIndexV2(CTraceContext c_trace, CLoadIndexInfo c_load_index_info) {
         auto remote_chunk_manager =
             milvus::storage::RemoteChunkManagerSingleton::GetInstance()
                 .GetRemoteChunkManager();
+        auto fs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
+                      .GetArrowFileSystem();
+        AssertInfo(fs != nullptr, "arrow file system is nullptr");
         milvus::storage::FileManagerContext fileManagerContext(
-            field_meta, index_meta, remote_chunk_manager);
+            field_meta, index_meta, remote_chunk_manager, fs);
         fileManagerContext.set_for_loading_index(true);
 
         // use cache layer to load vector/scalar index

--- a/internal/core/src/segcore/segment_c.cpp
+++ b/internal/core/src/segcore/segment_c.cpp
@@ -477,6 +477,9 @@ LoadTextIndex(CSegmentInterface c_segment,
         auto remote_chunk_manager =
             milvus::storage::RemoteChunkManagerSingleton::GetInstance()
                 .GetRemoteChunkManager();
+        auto fs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
+                      .GetArrowFileSystem();
+        AssertInfo(fs != nullptr, "arrow file system is null");
 
         milvus::Config config;
         std::vector<std::string> files;
@@ -487,7 +490,7 @@ LoadTextIndex(CSegmentInterface c_segment,
         config[milvus::LOAD_PRIORITY] = info_proto->load_priority();
         config[milvus::index::ENABLE_MMAP] = info_proto->enable_mmap();
         milvus::storage::FileManagerContext ctx(
-            field_meta, index_meta, remote_chunk_manager);
+            field_meta, index_meta, remote_chunk_manager, fs);
 
         auto index = std::make_unique<milvus::index::TextMatchIndex>(ctx);
         index->Load(config);
@@ -536,6 +539,9 @@ LoadJsonKeyIndex(CTraceContext c_trace,
         auto remote_chunk_manager =
             milvus::storage::RemoteChunkManagerSingleton::GetInstance()
                 .GetRemoteChunkManager();
+        auto fs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
+                      .GetArrowFileSystem();
+        AssertInfo(fs != nullptr, "arrow file system is null");
 
         milvus::Config config;
         std::vector<std::string> files;
@@ -556,7 +562,7 @@ LoadJsonKeyIndex(CTraceContext c_trace,
             info_proto->fieldid(),
             info_proto->stats_size()};
         milvus::storage::FileManagerContext file_ctx(
-            field_meta, index_meta, remote_chunk_manager);
+            field_meta, index_meta, remote_chunk_manager, fs);
 
         std::unique_ptr<
             milvus::cachinglayer::Translator<milvus::index::JsonKeyStats>>

--- a/internal/core/src/segcore/storagev1translator/V1SealedIndexTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/V1SealedIndexTranslator.cpp
@@ -116,13 +116,15 @@ V1SealedIndexTranslator::LoadVecIndex() {
         auto remote_chunk_manager =
             milvus::storage::RemoteChunkManagerSingleton::GetInstance()
                 .GetRemoteChunkManager();
+        auto fs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
+                      .GetArrowFileSystem();
 
         auto config = milvus::index::ParseConfigFromIndexParams(
             index_load_info_.index_params);
         config["index_files"] = index_load_info_.index_files;
 
         milvus::storage::FileManagerContext fileManagerContext(
-            field_meta, index_meta, remote_chunk_manager);
+            field_meta, index_meta, remote_chunk_manager, fs);
         fileManagerContext.set_for_loading_index(true);
 
         auto index = milvus::index::IndexFactory::GetInstance().CreateIndex(

--- a/internal/core/src/storage/DiskFileManagerTest.cpp
+++ b/internal/core/src/storage/DiskFileManagerTest.cpp
@@ -31,6 +31,7 @@
 #include "common/Slice.h"
 #include "common/Common.h"
 #include "common/Types.h"
+#include "milvus-storage/filesystem/fs.h"
 #include "storage/ChunkManager.h"
 #include "storage/DataCodec.h"
 #include "storage/InsertData.h"
@@ -56,11 +57,14 @@ class DiskAnnFileManagerTest : public testing::Test {
 
     virtual void
     SetUp() {
-        cm_ = storage::CreateChunkManager(get_default_local_storage_config());
+        auto storage_config = get_default_local_storage_config();
+        cm_ = storage::CreateChunkManager(storage_config);
+        fs_ = storage::InitArrowFileSystem(storage_config);
     }
 
  protected:
     ChunkManagerPtr cm_;
+    milvus_storage::ArrowFileSystemPtr fs_;
 };
 
 TEST_F(DiskAnnFileManagerTest, AddFilePositiveParallel) {
@@ -80,7 +84,7 @@ TEST_F(DiskAnnFileManagerTest, AddFilePositiveParallel) {
 
     int64_t slice_size = milvus::FILE_SLICE_SIZE;
     auto diskAnnFileManager = std::make_shared<DiskFileManagerImpl>(
-        storage::FileManagerContext(filed_data_meta, index_meta, cm_));
+        storage::FileManagerContext(filed_data_meta, index_meta, cm_, fs_));
     auto ok = diskAnnFileManager->AddFile(indexFilePath);
     EXPECT_EQ(ok, true);
 
@@ -161,7 +165,7 @@ TEST_F(DiskAnnFileManagerTest, ReadAndWriteWithStream) {
     IndexMeta index_meta = {3, 100, 1000, 1, "index"};
 
     auto diskAnnFileManager = std::make_shared<DiskFileManagerImpl>(
-        storage::FileManagerContext(filed_data_meta, index_meta, cm_, fs));
+        storage::FileManagerContext(filed_data_meta, index_meta, cm_, fs_));
 
     auto os = diskAnnFileManager->OpenOutputStream(index_file_path);
     size_t write_offset = 0;
@@ -319,15 +323,16 @@ const FieldDataMeta kOptVecFieldDataMeta = {1, 2, 3, 100};
 using OffsetT = uint32_t;
 
 auto
-CreateFileManager(const ChunkManagerPtr& cm)
+CreateFileManager(const ChunkManagerPtr& cm,
+                  milvus_storage::ArrowFileSystemPtr fs)
     -> std::shared_ptr<DiskFileManagerImpl> {
     // collection_id: 1, partition_id: 2, segment_id: 3
     // field_id: 100, index_build_id: 1000, index_version: 1
     IndexMeta index_meta = {
         3, 100, 1000, 1, "opt_fields", "field_name", DataType::VECTOR_FLOAT, 1};
     int64_t slice_size = milvus::FILE_SLICE_SIZE;
-    return std::make_shared<DiskFileManagerImpl>(
-        storage::FileManagerContext(kOptVecFieldDataMeta, index_meta, cm));
+    return std::make_shared<DiskFileManagerImpl>(storage::FileManagerContext(
+        kOptVecFieldDataMeta, index_meta, cm, std::move(fs)));
 }
 
 template <typename T>
@@ -453,7 +458,7 @@ CheckOptFieldCorrectness(
 }  // namespace
 
 TEST_F(DiskAnnFileManagerTest, CacheOptFieldToDiskOptFieldMoreThanOne) {
-    auto file_manager = CreateFileManager(cm_);
+    auto file_manager = CreateFileManager(cm_, fs_);
     const auto insert_file_path =
         PrepareInsertData<DataType::INT64, int64_t>(kOptFieldDataRange);
     OptFieldT opt_fields =
@@ -468,7 +473,7 @@ TEST_F(DiskAnnFileManagerTest, CacheOptFieldToDiskOptFieldMoreThanOne) {
 }
 
 TEST_F(DiskAnnFileManagerTest, CacheOptFieldToDiskSpaceCorrect) {
-    auto file_manager = CreateFileManager(cm_);
+    auto file_manager = CreateFileManager(cm_, fs_);
     const auto insert_file_path =
         PrepareInsertData<DataType::INT64, int64_t>(kOptFieldDataRange);
     auto opt_fields =
@@ -482,7 +487,7 @@ TEST_F(DiskAnnFileManagerTest, CacheOptFieldToDiskSpaceCorrect) {
 
 #define TEST_TYPE(NAME, TYPE, NATIVE_TYPE, RANGE)                            \
     TEST_F(DiskAnnFileManagerTest, CacheOptFieldToDiskCorrect##NAME) {       \
-        auto file_manager = CreateFileManager(cm_);                          \
+        auto file_manager = CreateFileManager(cm_, fs_);                     \
         auto insert_file_path = PrepareInsertData<TYPE, NATIVE_TYPE>(RANGE); \
         auto opt_fields =                                                    \
             PrepareOptionalField<TYPE>(file_manager, insert_file_path);      \
@@ -505,7 +510,7 @@ TEST_TYPE(VARCHAR, DataType::VARCHAR, std::string, 100);
 #undef TEST_TYPE
 
 TEST_F(DiskAnnFileManagerTest, CacheOptFieldToDiskOnlyOneCategory) {
-    auto file_manager = CreateFileManager(cm_);
+    auto file_manager = CreateFileManager(cm_, fs_);
     {
         const auto insert_file_path =
             PrepareInsertData<DataType::INT64, int64_t>(1);
@@ -527,7 +532,7 @@ TEST_F(DiskAnnFileManagerTest, FileCleanup) {
         LocalChunkManagerSingleton::GetInstance().GetChunkManager();
 
     {
-        auto file_manager = CreateFileManager(cm_);
+        auto file_manager = CreateFileManager(cm_, fs_);
 
         auto random_file_suffix = std::to_string(rand());
         local_text_index_file_path =

--- a/internal/core/src/storage/FileManager.h
+++ b/internal/core/src/storage/FileManager.h
@@ -33,17 +33,17 @@ namespace milvus::storage {
 struct FileManagerContext {
     FileManagerContext() : chunkManagerPtr(nullptr) {
     }
-    FileManagerContext(const ChunkManagerPtr& chunkManagerPtr)
+    explicit FileManagerContext(const ChunkManagerPtr& chunkManagerPtr)
         : chunkManagerPtr(chunkManagerPtr) {
     }
     FileManagerContext(const FieldDataMeta& fieldDataMeta,
                        const IndexMeta& indexMeta,
                        const ChunkManagerPtr& chunkManagerPtr,
-                       milvus_storage::ArrowFileSystemPtr fs = nullptr)
+                       milvus_storage::ArrowFileSystemPtr fs)
         : fieldDataMeta(fieldDataMeta),
           indexMeta(indexMeta),
           chunkManagerPtr(chunkManagerPtr),
-          fs(fs) {
+          fs(std::move(fs)) {
     }
 
     bool

--- a/internal/core/unittest/test_index_wrapper.cpp
+++ b/internal/core/unittest/test_index_wrapper.cpp
@@ -18,6 +18,7 @@
 #include "indexbuilder/IndexFactory.h"
 #include "indexbuilder/VecIndexCreator.h"
 #include "common/QueryResult.h"
+#include "milvus-storage/filesystem/fs.h"
 #include "test_utils/indexbuilder_test_utils.h"
 #include "test_utils/storage_test_utils.h"
 
@@ -32,6 +33,7 @@ class IndexWrapperTest : public ::testing::TestWithParam<Param> {
     void
     SetUp() override {
         storage_config_ = get_default_local_storage_config();
+        fs_ = storage::InitArrowFileSystem(storage_config_);
 
         auto param = GetParam();
         index_type = param.first;
@@ -98,6 +100,7 @@ class IndexWrapperTest : public ::testing::TestWithParam<Param> {
     int64_t query_offset = 1;
     int64_t NB = 10;
     StorageConfig storage_config_;
+    milvus_storage::ArrowFileSystemPtr fs_;
 };
 
 INSTANTIATE_TEST_SUITE_P(
@@ -126,7 +129,7 @@ TEST_P(IndexWrapperTest, BuildAndQuery) {
     auto chunk_manager = milvus::storage::CreateChunkManager(storage_config_);
 
     storage::FileManagerContext file_manager_context(
-        field_data_meta, index_meta, chunk_manager);
+        field_data_meta, index_meta, chunk_manager, fs_);
     config[milvus::index::INDEX_ENGINE_VERSION] =
         std::to_string(knowhere::Version::GetCurrentVersion().VersionNumber());
     auto index = milvus::indexbuilder::IndexFactory::GetInstance().CreateIndex(

--- a/internal/core/unittest/test_indexing.cpp
+++ b/internal/core/unittest/test_indexing.cpp
@@ -311,6 +311,7 @@ class IndexTest : public ::testing::TestWithParam<Param> {
     void
     SetUp() override {
         storage_config_ = get_default_local_storage_config();
+        fs_ = milvus::storage::InitArrowFileSystem(storage_config_);
 
         auto param = GetParam();
         index_type = param.first;
@@ -393,6 +394,7 @@ class IndexTest : public ::testing::TestWithParam<Param> {
     int64_t query_offset = 100;
     int64_t NB = 3000;  // will be updated to 27000 for mmap+hnsw
     StorageConfig storage_config_;
+    milvus_storage::ArrowFileSystemPtr fs_;
 };
 
 INSTANTIATE_TEST_SUITE_P(
@@ -485,7 +487,7 @@ TEST_P(IndexTest, BuildAndQuery) {
     milvus::storage::IndexMeta index_meta{3, 100, 1000, 1};
     auto chunk_manager = milvus::storage::CreateChunkManager(storage_config_);
     milvus::storage::FileManagerContext file_manager_context(
-        field_data_meta, index_meta, chunk_manager);
+        field_data_meta, index_meta, chunk_manager, fs_);
     index = milvus::index::IndexFactory::GetInstance().CreateIndex(
         create_index_info, file_manager_context);
 
@@ -554,7 +556,7 @@ TEST_P(IndexTest, Mmap) {
     milvus::storage::IndexMeta index_meta{3, 100, 1000, 1};
     auto chunk_manager = milvus::storage::CreateChunkManager(storage_config_);
     milvus::storage::FileManagerContext file_manager_context(
-        field_data_meta, index_meta, chunk_manager);
+        field_data_meta, index_meta, chunk_manager, fs_);
     index = milvus::index::IndexFactory::GetInstance().CreateIndex(
         create_index_info, file_manager_context);
 
@@ -617,7 +619,7 @@ TEST_P(IndexTest, GetVector) {
     milvus::storage::IndexMeta index_meta{3, 100, 1000, 1};
     auto chunk_manager = milvus::storage::CreateChunkManager(storage_config_);
     milvus::storage::FileManagerContext file_manager_context(
-        field_data_meta, index_meta, chunk_manager);
+        field_data_meta, index_meta, chunk_manager, fs_);
     index = milvus::index::IndexFactory::GetInstance().CreateIndex(
         create_index_info, file_manager_context);
 
@@ -720,7 +722,7 @@ TEST_P(IndexTest, GetVector_EmptySparseVector) {
     milvus::storage::IndexMeta index_meta{3, 100, 1000, 1};
     auto chunk_manager = milvus::storage::CreateChunkManager(storage_config_);
     milvus::storage::FileManagerContext file_manager_context(
-        field_data_meta, index_meta, chunk_manager);
+        field_data_meta, index_meta, chunk_manager, fs_);
     index = milvus::index::IndexFactory::GetInstance().CreateIndex(
         create_index_info, file_manager_context);
 
@@ -788,8 +790,9 @@ TEST(Indexing, SearchDiskAnnWithInvalidParam) {
     milvus::storage::IndexMeta index_meta{
         segment_id, field_id, build_id, index_version};
     auto chunk_manager = storage::CreateChunkManager(storage_config);
+    auto fs = storage::InitArrowFileSystem(storage_config);
     milvus::storage::FileManagerContext file_manager_context(
-        field_data_meta, index_meta, chunk_manager);
+        field_data_meta, index_meta, chunk_manager, fs);
     auto index = milvus::index::IndexFactory::GetInstance().CreateIndex(
         create_index_info, file_manager_context);
 
@@ -874,8 +877,9 @@ TEST(Indexing, SearchDiskAnnWithFloat16) {
     milvus::storage::IndexMeta index_meta{
         segment_id, field_id, build_id, index_version};
     auto chunk_manager = storage::CreateChunkManager(storage_config);
+    auto fs = storage::InitArrowFileSystem(storage_config);
     milvus::storage::FileManagerContext file_manager_context(
-        field_data_meta, index_meta, chunk_manager);
+        field_data_meta, index_meta, chunk_manager, fs);
     auto index = milvus::index::IndexFactory::GetInstance().CreateIndex(
         create_index_info, file_manager_context);
 
@@ -960,8 +964,9 @@ TEST(Indexing, SearchDiskAnnWithBFloat16) {
     milvus::storage::IndexMeta index_meta{
         segment_id, field_id, build_id, index_version};
     auto chunk_manager = storage::CreateChunkManager(storage_config);
+    auto fs = milvus::storage::InitArrowFileSystem(storage_config);
     milvus::storage::FileManagerContext file_manager_context(
-        field_data_meta, index_meta, chunk_manager);
+        field_data_meta, index_meta, chunk_manager, fs);
     auto index = milvus::index::IndexFactory::GetInstance().CreateIndex(
         create_index_info, file_manager_context);
 

--- a/internal/core/unittest/test_json_stats/test_traverse_json_for_build_stats.cpp
+++ b/internal/core/unittest/test_json_stats/test_traverse_json_for_build_stats.cpp
@@ -89,7 +89,8 @@ TEST(TraverseJsonForBuildStatsTest,
     storage_config.storage_type = "local";
     storage_config.root_path = "/tmp/test-traverse-json-build-stats";
     auto cm = milvus::storage::CreateChunkManager(storage_config);
-    milvus::storage::FileManagerContext ctx(field_meta, index_meta, cm);
+    auto fs = milvus::storage::InitArrowFileSystem(storage_config);
+    milvus::storage::FileManagerContext ctx(field_meta, index_meta, cm, fs);
     JsonKeyStats stats(ctx, true);
 
     int index = 0;

--- a/internal/core/unittest/test_sealed.cpp
+++ b/internal/core/unittest/test_sealed.cpp
@@ -2396,6 +2396,7 @@ TEST(Sealed, SearchVectorArray) {
     std::string root_path = "/tmp/test-vector-array/";
     auto storage_config = gen_local_storage_config(root_path);
     auto cm = CreateChunkManager(storage_config);
+    auto fs = milvus::storage::InitArrowFileSystem(storage_config);
     auto vec_array_col = dataset.get_col<VectorFieldProto>(array_vec);
     std::vector<milvus::VectorArray> vector_arrays;
     for (auto& v : vec_array_col) {
@@ -2438,7 +2439,7 @@ TEST(Sealed, SearchVectorArray) {
     auto cm_w = ChunkManagerWrapper(cm);
     cm_w.Write(log_path, serialized_bytes.data(), serialized_bytes.size());
 
-    storage::FileManagerContext ctx(field_meta, index_meta, cm);
+    storage::FileManagerContext ctx(field_meta, index_meta, cm, fs);
     std::vector<std::string> index_files;
 
     // create index
@@ -2452,7 +2453,7 @@ TEST(Sealed, SearchVectorArray) {
     auto emb_list_hnsw_index =
         milvus::index::IndexFactory::GetInstance().CreateIndex(
             create_index_info,
-            storage::FileManagerContext(field_meta, index_meta, cm));
+            storage::FileManagerContext(field_meta, index_meta, cm, fs));
 
     // build index
     Config config;

--- a/internal/core/unittest/test_storage_v2_index_raw_data.cpp
+++ b/internal/core/unittest/test_storage_v2_index_raw_data.cpp
@@ -109,7 +109,7 @@ TEST_F(StorageV2IndexRawDataTest, TestGetRawData) {
                                          false);
         auto index_meta = gen_index_meta(
             segment_id, int64_field.get(), index_build_id, index_version);
-        storage::FileManagerContext ctx(field_meta, index_meta, cm_);
+        storage::FileManagerContext ctx(field_meta, index_meta, cm_, fs_);
 
         auto index = indexbuilder::IndexFactory::GetInstance().CreateIndex(
             milvus::DataType::INT64, config, ctx);
@@ -148,7 +148,8 @@ TEST_F(StorageV2IndexRawDataTest, TestGetRawData) {
             collection_id, partition_id, segment_id, float_field.get()};
         auto file_manager =
             std::make_shared<milvus::storage::DiskFileManagerImpl>(
-                storage::FileManagerContext(field_data_meta, index_meta, cm_));
+                storage::FileManagerContext(
+                    field_data_meta, index_meta, cm_, fs_));
         auto res = file_manager->CacheRawDataToDisk<float>(config);
         ASSERT_EQ(res, "/tmp/milvus/local_data/raw_datas/3/105/raw_data");
     }
@@ -175,7 +176,7 @@ TEST_F(StorageV2IndexRawDataTest, TestGetRawData) {
         FieldDataMeta field_data_meta = {
             collection_id, partition_id, segment_id, int32_field.get()};
         auto ctx =
-            storage::FileManagerContext(field_data_meta, index_meta, cm_);
+            storage::FileManagerContext(field_data_meta, index_meta, cm_, fs_);
 
         auto int32_index = milvus::index::CreateScalarIndexSort<int32_t>(ctx);
         int32_index->Build(config);
@@ -204,7 +205,7 @@ TEST_F(StorageV2IndexRawDataTest, TestGetRawData) {
         FieldDataMeta field_data_meta = {
             collection_id, partition_id, segment_id, varchar_field.get()};
         auto ctx =
-            storage::FileManagerContext(field_data_meta, index_meta, cm_);
+            storage::FileManagerContext(field_data_meta, index_meta, cm_, fs_);
 
         auto string_index =
             std::make_unique<milvus::index::StringIndexMarisa>(ctx);
@@ -237,7 +238,7 @@ TEST_F(StorageV2IndexRawDataTest, TestGetRawData) {
         FieldDataMeta field_data_meta = {
             collection_id, partition_id, segment_id, vec_field.get()};
         auto ctx =
-            storage::FileManagerContext(field_data_meta, index_meta, cm_);
+            storage::FileManagerContext(field_data_meta, index_meta, cm_, fs_);
 
         try {
             auto vec_index =

--- a/internal/core/unittest/test_utils/DataGen.h
+++ b/internal/core/unittest/test_utils/DataGen.h
@@ -1587,8 +1587,9 @@ GenVecIndexing(int64_t N,
     storage_config.storage_type = "local";
     storage_config.root_path = TestRemotePath;
     auto chunk_manager = milvus::storage::CreateChunkManager(storage_config);
+    auto fs = milvus::storage::InitArrowFileSystem(storage_config);
     milvus::storage::FileManagerContext file_manager_context(
-        field_data_meta, index_meta, chunk_manager);
+        field_data_meta, index_meta, chunk_manager, fs);
     auto indexing = std::make_unique<index::VectorMemIndex<float>>(
         DataType::NONE,
         index_type,

--- a/internal/querynodev2/segments/segment_loader_test.go
+++ b/internal/querynodev2/segments/segment_loader_test.go
@@ -86,6 +86,8 @@ func (suite *SegmentLoaderSuite) SetupTest() {
 	initcore.InitLocalChunkManager(suite.rootPath)
 	initcore.InitMmapManager(paramtable.Get(), 1)
 	initcore.InitTieredStorage(paramtable.Get())
+	initcore.InitLocalArrowFileSystem(suite.rootPath)
+	initcore.InitRemoteArrowFileSystem(paramtable.Get())
 
 	// Data
 	suite.schema = mock_segcore.GenTestCollectionSchema("test", schemapb.DataType_Int64, false)


### PR DESCRIPTION
Related to #44615