### PR TITLE
fix: [2.6] BM25 with boost return result not ordered

### DIFF
--- a/internal/core/src/exec/operator/Utils.h
+++ b/internal/core/src/exec/operator/Utils.h
@@ -118,15 +118,17 @@ sort_search_result(milvus::SearchResult& result, bool large_is_better) {
 
         if (large_is_better) {
             std::sort(idx.begin(), idx.end(), [&](size_t i, size_t j) {
-                return result.distances_[i] > result.distances_[j] ||
-                       (result.seg_offsets_[j] >= 0 &&
-                        result.seg_offsets_[j] < 0);
+                if (result.seg_offsets_[j] < 0 || result.seg_offsets_[i] < 0) {
+                    return result.seg_offsets_[i] >= 0;
+                }
+                return result.distances_[i] > result.distances_[j];
             });
         } else {
             std::sort(idx.begin(), idx.end(), [&](size_t i, size_t j) {
-                return result.distances_[i] < result.distances_[j] ||
-                       (result.seg_offsets_[j] >= 0 &&
-                        result.seg_offsets_[j] < 0);
+                if (result.seg_offsets_[j] < 0 || result.seg_offsets_[i] < 0) {
+                    return result.seg_offsets_[i] >= 0;
+                }
+                return result.distances_[i] < result.distances_[j];
             });
         }
         for (auto i : idx) {


### PR DESCRIPTION
relate: https://github.com/milvus-io/milvus/issues/44758
pr: https://github.com/milvus-io/milvus/pull/44744
Wrong code which should be (result.seg_offsets_[i] >= 0 && result.seg_offsets_[j] < 0), but was (result.seg_offsets_[j] >= 0 && result.seg_offsets_[j] < 0)  now.
But because all placeholder which was offset -1, will fill with worst distance value.
For IP, L2 or COSIN, it will be +inf or -inf. So sort distance was enough.
But when use BM25, it will be NAN. Will case sort out of ordered.