### PR TITLE
fix: expr filter return wrong result when skipped

### DIFF
--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -555,8 +555,11 @@ class SegmentExpr : public Expr {
                                 valid_res + processed_size,
                                 values...);
                         } else {
-                            res[processed_size] = valid_res[processed_size] =
-                                (valid_data[0]);
+                            if (valid_data.size() > processed_size &&
+                                !valid_data[processed_size]) {
+                                res[processed_size] =
+                                    valid_res[processed_size] = false;
+                            }
                         }
                         processed_size++;
                     }


### PR DESCRIPTION
relate: https://github.com/milvus-io/milvus/issues/44777
Should return res with false if skipped. But now return vaild[0], it almost be true.