### PR TITLE
fix: [2.6] avoid concurrent Reset/Add operations on DataCoord metrics (#44789)

### DIFF
--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -477,7 +477,7 @@ func (m *meta) GetQuotaInfo() *metricsinfo.DataCoordQuotaMetrics {
 	segments := m.segments.GetSegments()
 	var total int64
 	storedBinlogSize := make(map[string]map[string]int64) // map[collectionID]map[segment_state]size
-	binlogFileSize := make(map[string]int64)              // map[collectionID]size
+	binlogFileCount := make(map[string]int64)             // map[collectionID]count
 	coll2DbName := make(map[string]string)
 
 	for _, segment := range segments {
@@ -502,7 +502,7 @@ func (m *meta) GetQuotaInfo() *metricsinfo.DataCoordQuotaMetrics {
 				}
 
 				storedBinlogSize[collIDStr][segment.GetState().String()] += segmentSize
-				binlogFileSize[collIDStr] += int64(getBinlogFileCount(segment.SegmentInfo))
+				binlogFileCount[collIDStr] += int64(getBinlogFileCount(segment.SegmentInfo))
 			} else {
 				log.Ctx(context.TODO()).Warn("not found database name", zap.Int64("collectionID", segment.GetCollectionID()))
 			}
@@ -527,7 +527,7 @@ func (m *meta) GetQuotaInfo() *metricsinfo.DataCoordQuotaMetrics {
 	}
 	// Reset to remove dropped collection
 	metrics.DataCoordSegmentBinLogFileCount.Reset()
-	for collectionID, size := range binlogFileSize {
+	for collectionID, size := range binlogFileCount {
 		metrics.DataCoordSegmentBinLogFileCount.WithLabelValues(collectionID).Set(float64(size))
 	}
 

--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -502,7 +502,7 @@ func (m *meta) GetQuotaInfo() *metricsinfo.DataCoordQuotaMetrics {
 				}
 
 				storedBinlogSize[collIDStr][segment.GetState().String()] += segmentSize
-				binlogFileSize[collIDStr] += segmentSize
+				binlogFileSize[collIDStr] += int64(getBinlogFileCount(segment.SegmentInfo))
 			} else {
 				log.Ctx(context.TODO()).Warn("not found database name", zap.Int64("collectionID", segment.GetCollectionID()))
 			}


### PR DESCRIPTION
Cherry-pick from master
pr: #44789

This commit addresses issue #44788 where the
`datacoord_stored_binlog_size` metric could become inaccurate when multiple concurrent `GetMetrics` calls arrived at DataCoord.

### Problem

The original implementation called `Reset()` followed by `Add()` operations on Prometheus metrics within the `GetQuotaInfo()` method. When multiple goroutines invoked this method concurrently, race conditions occurred:
- Thread 1: Reset() → Add(value1)
- Thread 2: Reset() → Add(value2)
- Result: Metrics could be reset multiple times and values added in an interleaved fashion, leading to inaccurate and inflated metric values

### Solution

Changed the approach from `Reset() + Add()` to aggregating metric values in local maps first, then using `Set()` to update metrics atomically:

1. Collect segment size data into local maps:
   - `storedBinlogSize`: tracks size per collection per segment state
   - `binlogFileSize`: tracks total file count per collection
   - `coll2DbName`: maps collection IDs to database names

2. After aggregation is complete, use `Set()` (instead of `Add()`) to update metrics in a single operation per label combination

This ensures that concurrent `GetMetrics` calls don't interfere with each other, as each invocation works with its own local state and only updates the final metric value atomically.

---------