### PR TITLE
fix: [2.5] avoid concurrent Reset/Add operations on DataCoord metrics (#44789)

### DIFF
--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -465,7 +465,7 @@ func (m *meta) GetQuotaInfo() *metricsinfo.DataCoordQuotaMetrics {
 	segments := m.segments.GetSegments()
 	var total int64
 	storedBinlogSize := make(map[string]map[string]int64) // map[collectionID]map[segment_state]size
-	binlogFileSize := make(map[string]int64)              // map[collectionID]size
+	binlogFileCount := make(map[string]int64)             // map[collectionID]count
 	coll2DbName := make(map[string]string)
 
 	for _, segment := range segments {
@@ -490,7 +490,7 @@ func (m *meta) GetQuotaInfo() *metricsinfo.DataCoordQuotaMetrics {
 				}
 
 				storedBinlogSize[collIDStr][segment.GetState().String()] += segmentSize
-				binlogFileSize[collIDStr] += int64(getBinlogFileCount(segment.SegmentInfo))
+				binlogFileCount[collIDStr] += int64(getBinlogFileCount(segment.SegmentInfo))
 			} else {
 				log.Ctx(context.TODO()).Warn("not found database name", zap.Int64("collectionID", segment.GetCollectionID()))
 			}
@@ -515,7 +515,7 @@ func (m *meta) GetQuotaInfo() *metricsinfo.DataCoordQuotaMetrics {
 	}
 	// Reset to remove dropped collection
 	metrics.DataCoordSegmentBinLogFileCount.Reset()
-	for collectionID, size := range binlogFileSize {
+	for collectionID, size := range binlogFileCount {
 		metrics.DataCoordSegmentBinLogFileCount.WithLabelValues(collectionID).Set(float64(size))
 	}
 

--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -490,7 +490,7 @@ func (m *meta) GetQuotaInfo() *metricsinfo.DataCoordQuotaMetrics {
 				}
 
 				storedBinlogSize[collIDStr][segment.GetState().String()] += segmentSize
-				binlogFileSize[collIDStr] += segmentSize
+				binlogFileSize[collIDStr] += int64(getBinlogFileCount(segment.SegmentInfo))
 			} else {
 				log.Ctx(context.TODO()).Warn("not found database name", zap.Int64("collectionID", segment.GetCollectionID()))
 			}

--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -464,8 +464,10 @@ func (m *meta) GetQuotaInfo() *metricsinfo.DataCoordQuotaMetrics {
 
 	segments := m.segments.GetSegments()
 	var total int64
-	metrics.DataCoordStoredBinlogSize.Reset()
-	metrics.DataCoordSegmentBinLogFileCount.Reset()
+	storedBinlogSize := make(map[string]map[string]int64) // map[collectionID]map[segment_state]size
+	binlogFileSize := make(map[string]int64)              // map[collectionID]size
+	coll2DbName := make(map[string]string)
+
 	for _, segment := range segments {
 		segmentSize := segment.getSegmentSize()
 		if isSegmentHealthy(segment) && !segment.GetIsImporting() {
@@ -481,10 +483,14 @@ func (m *meta) GetQuotaInfo() *metricsinfo.DataCoordQuotaMetrics {
 
 			coll, ok := m.collections.Get(segment.GetCollectionID())
 			if ok {
-				metrics.DataCoordStoredBinlogSize.WithLabelValues(coll.DatabaseName,
-					fmt.Sprint(segment.GetCollectionID()), segment.GetState().String()).Add(float64(segmentSize))
-				metrics.DataCoordSegmentBinLogFileCount.WithLabelValues(
-					fmt.Sprint(segment.GetCollectionID())).Add(float64(getBinlogFileCount(segment.SegmentInfo)))
+				collIDStr := fmt.Sprint(segment.GetCollectionID())
+				coll2DbName[collIDStr] = coll.DatabaseName
+				if _, ok := storedBinlogSize[collIDStr]; !ok {
+					storedBinlogSize[collIDStr] = make(map[string]int64)
+				}
+
+				storedBinlogSize[collIDStr][segment.GetState().String()] += segmentSize
+				binlogFileSize[collIDStr] += segmentSize
 			} else {
 				log.Ctx(context.TODO()).Warn("not found database name", zap.Int64("collectionID", segment.GetCollectionID()))
 			}
@@ -498,6 +504,19 @@ func (m *meta) GetQuotaInfo() *metricsinfo.DataCoordQuotaMetrics {
 				collectionL0RowCounts[segment.GetCollectionID()] += segment.getDeltaCount()
 			}
 		}
+	}
+
+	// Reset to remove dropped collection
+	metrics.DataCoordStoredBinlogSize.Reset()
+	for collectionID, state2Size := range storedBinlogSize {
+		for state, size := range state2Size {
+			metrics.DataCoordStoredBinlogSize.WithLabelValues(coll2DbName[collectionID], collectionID, state).Set(float64(size))
+		}
+	}
+	// Reset to remove dropped collection
+	metrics.DataCoordSegmentBinLogFileCount.Reset()
+	for collectionID, size := range binlogFileSize {
+		metrics.DataCoordSegmentBinLogFileCount.WithLabelValues(collectionID).Set(float64(size))
 	}
 
 	metrics.DataCoordNumStoredRows.Reset()


### PR DESCRIPTION
Cherry-pick from master
pr: #44789

This commit addresses issue #44788 where the
`datacoord_stored_binlog_size` metric could become inaccurate when multiple concurrent `GetMetrics` calls arrived at DataCoord.

### Problem

The original implementation called `Reset()` followed by `Add()` operations on Prometheus metrics within the `GetQuotaInfo()` method. When multiple goroutines invoked this method concurrently, race conditions occurred:
- Thread 1: Reset() → Add(value1)
- Thread 2: Reset() → Add(value2)
- Result: Metrics could be reset multiple times and values added in an interleaved fashion, leading to inaccurate and inflated metric values

### Solution

Changed the approach from `Reset() + Add()` to aggregating metric values in local maps first, then using `Set()` to update metrics atomically:

1. Collect segment size data into local maps:
   - `storedBinlogSize`: tracks size per collection per segment state
   - `binlogFileSize`: tracks total file count per collection
   - `coll2DbName`: maps collection IDs to database names

2. After aggregation is complete, use `Set()` (instead of `Add()`) to update metrics in a single operation per label combination

This ensures that concurrent `GetMetrics` calls don't interfere with each other, as each invocation works with its own local state and only updates the final metric value atomically.

---------