### PR TITLE
fix: [2.5] Fix deactivate balance checker also stops stopping balance

### DIFF
--- a/internal/querycoordv2/checkers/balance_checker.go
+++ b/internal/querycoordv2/checkers/balance_checker.go
@@ -468,11 +468,6 @@ func (b *BalanceChecker) submitTasks(segmentTasks, channelTasks []task.Task) {
 // The method tracks execution time and logs warnings for slow operations
 // to help identify performance bottlenecks in large clusters.
 func (b *BalanceChecker) Check(ctx context.Context) []task.Task {
-	// Skip balance operations if the checker is not active
-	if !b.IsActive() {
-		return nil
-	}
-
 	// Performance monitoring: track execution time
 	start := time.Now()
 	defer func() {
@@ -501,6 +496,11 @@ func (b *BalanceChecker) Check(ctx context.Context) []task.Task {
 
 			return nil
 		}
+	}
+
+	// Only Skip normal balance operations if the checker is not active
+	if !b.IsActive() {
+		return nil
 	}
 
 	// Phase 2: Process normal balance if no stopping balance was needed

--- a/internal/querycoordv2/checkers/balance_checker_test.go
+++ b/internal/querycoordv2/checkers/balance_checker_test.go
@@ -566,7 +566,8 @@ func TestBalanceChecker_Check_InactiveChecker(t *testing.T) {
 			func(ctx context.Context,
 				getReplicasFunc func(context.Context, int64) []int64,
 				constructQueueFunc func(context.Context) *balance.PriorityQueue,
-				getQueueFunc func() *balance.PriorityQueue, config balanceConfig) (int, int) {
+				getQueueFunc func() *balance.PriorityQueue, config balanceConfig,
+			) (int, int) {
 				stoppingBalanceCalled = true
 				return 1, 0 // Return some tasks generated
 			}).Build()
@@ -610,7 +611,8 @@ func TestBalanceChecker_Check_InactiveChecker(t *testing.T) {
 			func(ctx context.Context,
 				getReplicasFunc func(context.Context, int64) []int64,
 				constructQueueFunc func(context.Context) *balance.PriorityQueue,
-				getQueueFunc func() *balance.PriorityQueue, config balanceConfig) (int, int) {
+				getQueueFunc func() *balance.PriorityQueue, config balanceConfig,
+			) (int, int) {
 				processQueueCalled = true
 				return 0, 0
 			}).Build()
@@ -660,7 +662,8 @@ func TestBalanceChecker_Check_StoppingBalanceEnabled(t *testing.T) {
 			func(ctx context.Context,
 				getReplicasFunc func(context.Context, int64) []int64,
 				constructQueueFunc func(context.Context) *balance.PriorityQueue,
-				getQueueFunc func() *balance.PriorityQueue, config balanceConfig) (int, int) {
+				getQueueFunc func() *balance.PriorityQueue, config balanceConfig,
+			) (int, int) {
 				// Verify this is stopping balance by checking the function pointers
 				stoppingBalanceCalled = true
 				return 1, 0 // Generate stopping balance tasks
@@ -707,7 +710,8 @@ func TestBalanceChecker_Check_StoppingBalanceEnabled(t *testing.T) {
 			func(ctx context.Context,
 				getReplicasFunc func(context.Context, int64) []int64,
 				constructQueueFunc func(context.Context) *balance.PriorityQueue,
-				getQueueFunc func() *balance.PriorityQueue, config balanceConfig) (int, int) {
+				getQueueFunc func() *balance.PriorityQueue, config balanceConfig,
+			) (int, int) {
 				callCount++
 				if callCount == 1 {
 					// First call: stopping balance generates no tasks
@@ -767,7 +771,8 @@ func TestBalanceChecker_Check_NormalBalanceEnabled(t *testing.T) {
 			func(ctx context.Context,
 				getReplicasFunc func(context.Context, int64) []int64,
 				constructQueueFunc func(context.Context) *balance.PriorityQueue,
-				getQueueFunc func() *balance.PriorityQueue, config balanceConfig) (int, int) {
+				getQueueFunc func() *balance.PriorityQueue, config balanceConfig,
+			) (int, int) {
 				normalBalanceCalled = true
 				return 0, 1 // Generate normal balance tasks
 			}).Build()
@@ -816,7 +821,8 @@ func TestBalanceChecker_Check_NormalBalanceEnabled(t *testing.T) {
 			func(ctx context.Context,
 				getReplicasFunc func(context.Context, int64) []int64,
 				constructQueueFunc func(context.Context) *balance.PriorityQueue,
-				getQueueFunc func() *balance.PriorityQueue, config balanceConfig) (int, int) {
+				getQueueFunc func() *balance.PriorityQueue, config balanceConfig,
+			) (int, int) {
 				normalBalanceCalled = true
 				return 0, 1
 			}).Build()
@@ -863,7 +869,8 @@ func TestBalanceChecker_Check_NormalBalanceEnabled(t *testing.T) {
 			func(ctx context.Context,
 				getReplicasFunc func(context.Context, int64) []int64,
 				constructQueueFunc func(context.Context) *balance.PriorityQueue,
-				getQueueFunc func() *balance.PriorityQueue, config balanceConfig) (int, int) {
+				getQueueFunc func() *balance.PriorityQueue, config balanceConfig,
+			) (int, int) {
 				normalBalanceCalled = true
 				return 0, 1
 			}).Build()


### PR DESCRIPTION
issue: #43858
pr: #44834
Fix the issue introduced in PR #43992 where deactivating the balance checker incorrectly stops stopping balance operations.

Changes:
- Move IsActive() check after stopping balance logic
- Only skip normal balance when checker is inactive
- Allow stopping balance to proceed regardless of checker state

This ensures stopping balance can execute even when the balance checker is deactivated.