### PR TITLE
fix: Pingpong load balancing issue when segment has only 1 row(#44840)

### DIFF
--- a/internal/querycoordv2/balance/rowcount_based_balancer.go
+++ b/internal/querycoordv2/balance/rowcount_based_balancer.go
@@ -433,7 +433,7 @@ func (b *nodeItem) setPriority(priority int) {
 }
 
 func (b *nodeItem) getPriorityWithCurrentScoreDelta(delta float64) int {
-	return int((b.currentScore + delta) - b.assignedScore)
+	return int(math.Ceil((b.currentScore + delta) - b.assignedScore))
 }
 
 func (b *nodeItem) getCurrentScore() float64 {


### PR DESCRIPTION
Use math.Ceil to calculate Priority uniformly
issue: https://github.com/milvus-io/milvus/issues/44840