### PR TITLE
fix: wrong execution order of DDL/DCL on secondary

### DIFF
--- a/internal/distributed/streaming/replicate_service_test.go
+++ b/internal/distributed/streaming/replicate_service_test.go
@@ -118,7 +118,7 @@ func createReplicateCreateCollectionMessages() []message.ReplicateMutableMessage
 		immutableMsg := msg.WithLastConfirmedUseMessageID().WithTimeTick(1).IntoImmutableMessage(pulsar2.NewPulsarID(
 			pulsar.NewMessageID(1, 2, 3, 4),
 		))
-		replicateMsgs = append(replicateMsgs, message.NewReplicateMessage("primary", immutableMsg.IntoImmutableMessageProto()))
+		replicateMsgs = append(replicateMsgs, message.MustNewReplicateMessage("primary", immutableMsg.IntoImmutableMessageProto()))
 	}
 	return replicateMsgs
 }

--- a/internal/distributed/streaming/streaming_test.go
+++ b/internal/distributed/streaming/streaming_test.go
@@ -121,7 +121,7 @@ func TestReplicateCreateCollection(t *testing.T) {
 		immutableMsg := msg.WithLastConfirmedUseMessageID().WithTimeTick(1).IntoImmutableMessage(pulsar2.NewPulsarID(
 			pulsar.NewMessageID(1, 2, 3, 4),
 		))
-		_, err := streaming.WAL().Replicate().Append(context.Background(), message.NewReplicateMessage("primary", immutableMsg.IntoImmutableMessageProto()))
+		_, err := streaming.WAL().Replicate().Append(context.Background(), message.MustNewReplicateMessage("primary", immutableMsg.IntoImmutableMessageProto()))
 		if err != nil {
 			panic(err)
 		}

--- a/internal/streamingcoord/server/broadcaster/broadcast_manager.go
+++ b/internal/streamingcoord/server/broadcaster/broadcast_manager.go
@@ -67,7 +67,7 @@ func newBroadcastTaskManager(protos []*streamingpb.BroadcastTask) *broadcastTask
 		case streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_REPLICATED:
 			// The task is recovered from the remote cluster, so it doesn't hold the resource lock.
 			// but the task execution order should be protected by the order of broadcastID (by ackCallbackScheduler)
-			if isAllDone(task.task) {
+			if task.isControlChannelAcked() || isAllDone(task.task) {
 				pendingAckCallbackTasks = append(pendingAckCallbackTasks, task)
 			}
 		case streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_TOMBSTONE:

--- a/internal/streamingcoord/server/broadcaster/broadcast_scheduler.go
+++ b/internal/streamingcoord/server/broadcaster/broadcast_scheduler.go
@@ -56,7 +56,7 @@ func (b *broadcasterScheduler) AddTask(ctx context.Context, task *pendingBroadca
 	// Wait both request context and the background task context.
 	ctx, _ = contextutil.MergeContext(ctx, b.backgroundTaskNotifier.Context())
 	// wait for all the vchannels acked.
-	result, err := task.BlockUntilAllAck(ctx)
+	result, err := task.BlockUntilDone(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/streamingcoord/server/broadcaster/broadcast_task.go
+++ b/internal/streamingcoord/server/broadcaster/broadcast_task.go
@@ -13,6 +13,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/proto/streamingpb"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/types"
+	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
 )
 
 // newBroadcastTaskFromProto creates a new broadcast task from the proto.
@@ -26,10 +27,14 @@ func newBroadcastTaskFromProto(proto *streamingpb.BroadcastTask, metrics *broadc
 		dirty:                true, // the task is recovered from the recovery info, so it's persisted.
 		metrics:              m,
 		ackCallbackScheduler: ackCallbackScheduler,
+		done:                 make(chan struct{}),
 		allAcked:             make(chan struct{}),
 	}
-	if proto.State == streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_TOMBSTONE {
+	if isAllDone(bt.task) {
 		close(bt.allAcked)
+	}
+	if proto.State == streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_TOMBSTONE {
+		close(bt.done)
 	}
 	return bt
 }
@@ -51,10 +56,8 @@ func newBroadcastTaskFromBroadcastMessage(msg message.BroadcastMutableMessage, m
 		dirty:                false,
 		metrics:              m,
 		ackCallbackScheduler: ackCallbackScheduler,
+		done:                 make(chan struct{}),
 		allAcked:             make(chan struct{}),
-	}
-	if bt.task.State == streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_TOMBSTONE {
-		close(bt.allAcked)
 	}
 	return bt
 }
@@ -72,14 +75,16 @@ func newBroadcastTaskFromImmutableMessage(msg message.ImmutableMessage, metrics 
 // broadcastTask is the state of the broadcast task.
 type broadcastTask struct {
 	log.Binder
-	mu                   sync.Mutex
-	msg                  message.BroadcastMutableMessage
-	task                 *streamingpb.BroadcastTask
-	dirty                bool // a flag to indicate that the task has been modified and needs to be saved into the recovery info.
-	metrics              *taskMetricsGuard
-	allAcked             chan struct{}
-	guards               *lockGuards
-	ackCallbackScheduler *ackCallbackScheduler
+	mu                       sync.Mutex
+	msg                      message.BroadcastMutableMessage
+	task                     *streamingpb.BroadcastTask
+	dirty                    bool // a flag to indicate that the task has been modified and needs to be saved into the recovery info.
+	metrics                  *taskMetricsGuard
+	done                     chan struct{}
+	allAcked                 chan struct{}
+	guards                   *lockGuards
+	ackCallbackScheduler     *ackCallbackScheduler
+	joinAckCallbackScheduled bool // a flag to indicate that the join ack callback is scheduled.
 }
 
 // SetLogger sets the logger of the broadcast task.
@@ -131,6 +136,16 @@ func (b *broadcastTask) BroadcastResult() (message.BroadcastMutableMessage, map[
 func (b *broadcastTask) Header() *message.BroadcastHeader {
 	// header is a immutable field, no need to lock.
 	return b.msg.BroadcastHeader()
+}
+
+// ControlChannelTimeTick returns the time tick of the control channel.
+func (b *broadcastTask) ControlChannelTimeTick() uint64 {
+	for idx, vc := range b.Header().VChannels {
+		if funcutil.IsControlChannel(vc) {
+			return b.task.AckedCheckpoints[idx].TimeTick
+		}
+	}
+	return 0
 }
 
 // State returns the State of the broadcast task.
@@ -214,26 +229,48 @@ func (b *broadcastTask) Ack(ctx context.Context, msgs ...message.ImmutableMessag
 
 // ack acknowledges the message at the specified vchannel.
 func (b *broadcastTask) ack(ctx context.Context, msgs ...message.ImmutableMessage) (err error) {
-	b.copyAndSetAckedCheckpoints(msgs...)
+	isControlChannelAcked := b.copyAndSetAckedCheckpoints(msgs...)
 	if !b.dirty {
 		return nil
 	}
 	if err := b.saveTaskIfDirty(ctx, b.Logger()); err != nil {
 		return err
 	}
-	if isAllDone(b.task) {
+
+	allDone := isAllDone(b.task)
+	if (isControlChannelAcked || allDone) && !b.joinAckCallbackScheduled {
+		// after 2.6.5, the control channel is always broadcasted, it's used to determine the order of the ack callback operations.
+		// so if the control channel is acked, it should be added to the ack callback scheduler.
+		//
+		// allDone is for the compatibility only for the operation before 2.6.5, the control channel is not broadcasted,
 		b.ackCallbackScheduler.AddTask(b)
+		b.joinAckCallbackScheduled = true
+	}
+	if allDone {
+		close(b.allAcked)
 		b.metrics.ObserveAckAll()
 	}
 	return nil
 }
 
-// BlockUntilAllAck blocks until all the vchannels are acked.
-func (b *broadcastTask) BlockUntilAllAck(ctx context.Context) (*types.BroadcastAppendResult, error) {
+// hasControlChannel checks if the control channel is broadcasted.
+// for the operation since 2.6.5, the control channel is always broadcasted.
+// so it's just a dummy function for compatibility.
+func (b *broadcastTask) isControlChannelAcked() bool {
+	for idx, vc := range b.Header().VChannels {
+		if funcutil.IsControlChannel(vc) && b.task.AckedCheckpoints[idx] != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// BlockUntilDone blocks until the broadcast task is done.
+func (b *broadcastTask) BlockUntilDone(ctx context.Context) (*types.BroadcastAppendResult, error) {
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
-	case <-b.allAcked:
+	case <-b.done:
 		_, result := b.BroadcastResult()
 		return &types.BroadcastAppendResult{
 			BroadcastID:   b.Header().BroadcastID,
@@ -242,8 +279,18 @@ func (b *broadcastTask) BlockUntilAllAck(ctx context.Context) (*types.BroadcastA
 	}
 }
 
+// BlockUntilAllAck blocks until all the vchannels are acked.
+func (b *broadcastTask) BlockUntilAllAck(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-b.allAcked:
+		return nil
+	}
+}
+
 // copyAndSetAckedCheckpoints copies the task and set the acked checkpoints.
-func (b *broadcastTask) copyAndSetAckedCheckpoints(msgs ...message.ImmutableMessage) {
+func (b *broadcastTask) copyAndSetAckedCheckpoints(msgs ...message.ImmutableMessage) (isControlChannelAcked bool) {
 	task := proto.Clone(b.task).(*streamingpb.BroadcastTask)
 	for _, msg := range msgs {
 		vchannel := msg.VChannel()
@@ -269,9 +316,13 @@ func (b *broadcastTask) copyAndSetAckedCheckpoints(msgs ...message.ImmutableMess
 			LastConfirmedMessageId: msg.LastConfirmedMessageID().IntoProto(),
 			TimeTick:               msg.TimeTick(),
 		}
+		if funcutil.IsControlChannel(vchannel) {
+			isControlChannelAcked = true
+		}
 	}
 	// update current task state.
 	b.task = task
+	return
 }
 
 // findIdxOfVChannel finds the index of the vchannel in the broadcast task.
@@ -339,7 +390,7 @@ func (b *broadcastTask) MarkAckCallbackDone(ctx context.Context) error {
 	defer b.mu.Unlock()
 	if b.task.State != streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_TOMBSTONE {
 		b.task.State = streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_TOMBSTONE
-		close(b.allAcked)
+		close(b.done)
 		b.dirty = true
 	}
 

--- a/internal/streamingcoord/server/service/assignment.go
+++ b/internal/streamingcoord/server/service/assignment.go
@@ -91,6 +91,8 @@ func (s *assignmentServiceImpl) UpdateReplicateConfiguration(ctx context.Context
 		}
 		return nil, err
 	}
+	defer broadcaster.Close()
+
 	msg, err := s.validateReplicateConfiguration(ctx, config)
 	if err != nil {
 		if errors.Is(err, errReplicateConfigurationSame) {

--- a/internal/streamingnode/server/wal/interceptors/replicate/replicates/manager_test.go
+++ b/internal/streamingnode/server/wal/interceptors/replicate/replicates/manager_test.go
@@ -420,7 +420,7 @@ func newReplicateMessage(clusterID string, sourceClusterID string, timetick ...u
 		WithLastConfirmed(walimplstest.NewTestMessageID(1)).
 		IntoImmutableMessage(walimplstest.NewTestMessageID(1))
 
-	replicateMsg := message.NewReplicateMessage(
+	replicateMsg := message.MustNewReplicateMessage(
 		sourceClusterID,
 		msg.IntoImmutableMessageProto(),
 	)
@@ -480,7 +480,7 @@ func newReplicateTxnMessage(clusterID string, sourceClusterID string, timetick .
 	immutables := newImmutableTxnMessage(sourceClusterID, timetick...)
 	replicateMsgs := []message.MutableMessage{}
 	for _, immutable := range immutables {
-		replicateMsg := message.NewReplicateMessage(
+		replicateMsg := message.MustNewReplicateMessage(
 			sourceClusterID,
 			immutable.IntoImmutableMessageProto(),
 		)

--- a/internal/streamingnode/server/wal/interceptors/replicate/replicates/txn.go
+++ b/internal/streamingnode/server/wal/interceptors/replicate/replicates/txn.go
@@ -43,7 +43,7 @@ func (s *replicateTxnHelper) BeginDone(txn *message.TxnContext) {
 
 func (s *replicateTxnHelper) AddNewMessage(txn *message.TxnContext, replicateHeader *message.ReplicateHeader) error {
 	if s.currentTxn == nil {
-		return status.NewReplicateViolation("add new txn message without new txn, incoming: %d", s.currentTxn.TxnID, txn.TxnID)
+		return status.NewReplicateViolation("add new txn message without new txn, incoming: %d", txn.TxnID)
 	}
 	if s.currentTxn.TxnID != txn.TxnID {
 		return status.NewReplicateViolation("add new txn message with different txn, current: %d, incoming: %d", s.currentTxn.TxnID, txn.TxnID)

--- a/internal/streamingnode/server/wal/interceptors/shard/shard_interceptor.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/shard_interceptor.go
@@ -16,6 +16,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/proto/messagespb"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
 )
 
 const interceptorName = "shard"
@@ -52,8 +53,10 @@ func (impl *shardInterceptor) Name() string {
 // DoAppend assigns segment for every partition in the message.
 func (impl *shardInterceptor) DoAppend(ctx context.Context, msg message.MutableMessage, appendOp interceptors.Append) (msgID message.MessageID, err error) {
 	op, ok := impl.ops[msg.MessageType()]
-	if ok {
+	if ok && !funcutil.IsControlChannel(msg.VChannel()) {
 		// If the message type is registered in the interceptor, use the registered operation.
+		// control channel message is only used to determine the DDL/DCL order,
+		// perform no effect on the shard manager, so skip it.
 		return op(ctx, msg, appendOp)
 	}
 	return appendOp(ctx, msg)

--- a/internal/streamingnode/server/wal/interceptors/txn/session_test.go
+++ b/internal/streamingnode/server/wal/interceptors/txn/session_test.go
@@ -229,7 +229,7 @@ func TestManagerFromReplcateMessage(t *testing.T) {
 			Keepalive: 10 * time.Millisecond,
 		}).
 		IntoImmutableMessage(walimplstest.NewTestMessageID(1))
-	replicateMsg := message.NewReplicateMessage("test2", immutableMsg.IntoImmutableMessageProto()).WithTimeTick(2)
+	replicateMsg := message.MustNewReplicateMessage("test2", immutableMsg.IntoImmutableMessageProto()).WithTimeTick(2)
 
 	session, err := manager.BeginNewTxn(context.Background(), message.MustAsMutableBeginTxnMessageV2(replicateMsg))
 	assert.NoError(t, err)

--- a/internal/streamingnode/server/wal/recovery/recovery_storage_impl.go
+++ b/internal/streamingnode/server/wal/recovery/recovery_storage_impl.go
@@ -150,7 +150,9 @@ func (r *recoveryStorageImpl) ObserveMessage(ctx context.Context, msg message.Im
 			return err
 		}
 	}
-	if funcutil.IsControlChannel(msg.VChannel()) {
+	if funcutil.IsControlChannel(msg.VChannel()) && msg.MessageType() != message.MessageTypeAlterReplicateConfig {
+		// message on control channel except AlterReplicateConfig message is just used to determine the DDL/DCL order,
+		// will not affect the recovery storage, so skip it.
 		return nil
 	}
 

--- a/internal/streamingnode/server/wal/recovery/replicate_checkpoint_test.go
+++ b/internal/streamingnode/server/wal/recovery/replicate_checkpoint_test.go
@@ -30,7 +30,7 @@ func TestUpdateCheckpoint(t *testing.T) {
 	assert.Nil(t, rs.checkpoint.ReplicateCheckpoint.MessageID)
 	assert.Zero(t, rs.checkpoint.ReplicateCheckpoint.TimeTick)
 
-	replicateMsg := message.NewReplicateMessage("test3", message.NewCreateDatabaseMessageBuilderV2().
+	replicateMsg := message.MustNewReplicateMessage("test3", message.NewCreateDatabaseMessageBuilderV2().
 		WithHeader(&message.CreateDatabaseMessageHeader{}).
 		WithBody(&message.CreateDatabaseMessageBody{}).
 		WithVChannel("test3-rootcoord-dml_0").

--- a/internal/streamingnode/server/wal/utility/txn_buffer.go
+++ b/internal/streamingnode/server/wal/utility/txn_buffer.go
@@ -75,11 +75,14 @@ func (b *TxnBuffer) handleBeginTxn(msg message.ImmutableMessage) {
 		return
 	}
 	if _, ok := b.builders[beginMsg.TxnContext().TxnID]; ok {
+		// Because the wal on secondary node may replicate the same txn message, so we need to reset the txn from buffer to avoid
+		// the txn body repeated.
 		b.logger.Warn(
-			"txn id already exist, so ignore the repeated begin txn message",
+			"txn id already exist, rollback the txn from buffer",
 			zap.Int64("txnID", int64(beginMsg.TxnContext().TxnID)),
 			zap.Any("messageID", beginMsg.MessageID()),
 		)
+		b.rollbackTxn(beginMsg.TxnContext().TxnID)
 		return
 	}
 	b.builders[beginMsg.TxnContext().TxnID] = message.NewImmutableTxnMessageBuilder(beginMsg)
@@ -145,9 +148,13 @@ func (b *TxnBuffer) handleRollbackTxn(msg message.ImmutableMessage) {
 		zap.Int64("txnID", int64(rollbackMsg.TxnContext().TxnID)),
 		zap.Any("messageID", rollbackMsg.MessageID()),
 	)
-	if builder, ok := b.builders[rollbackMsg.TxnContext().TxnID]; ok {
+	b.rollbackTxn(rollbackMsg.TxnContext().TxnID)
+}
+
+func (b *TxnBuffer) rollbackTxn(txnID message.TxnID) {
+	if builder, ok := b.builders[txnID]; ok {
 		// just drop the txn from buffer.
-		delete(b.builders, rollbackMsg.TxnContext().TxnID)
+		delete(b.builders, txnID)
 		b.bytes -= builder.EstimateSize()
 		b.metrics.ObserveTxn(message.TxnStateRollbacked)
 	}

--- a/internal/streamingnode/server/wal/utility/txn_buffer.go
+++ b/internal/streamingnode/server/wal/utility/txn_buffer.go
@@ -83,7 +83,6 @@ func (b *TxnBuffer) handleBeginTxn(msg message.ImmutableMessage) {
 			zap.Any("messageID", beginMsg.MessageID()),
 		)
 		b.rollbackTxn(beginMsg.TxnContext().TxnID)
-		return
 	}
 	b.builders[beginMsg.TxnContext().TxnID] = message.NewImmutableTxnMessageBuilder(beginMsg)
 	b.bytes += beginMsg.EstimateSize()

--- a/pkg/mocks/streaming/util/mock_message/mock_MutableMessage.go
+++ b/pkg/mocks/streaming/util/mock_message/mock_MutableMessage.go
@@ -950,6 +950,54 @@ func (_c *MockMutableMessage_WithOldVersion_Call) RunAndReturn(run func() messag
 	return _c
 }
 
+// WithReplicateHeader provides a mock function with given fields: rh
+func (_m *MockMutableMessage) WithReplicateHeader(rh *message.ReplicateHeader) message.MutableMessage {
+	ret := _m.Called(rh)
+
+	if len(ret) == 0 {
+		panic("no return value specified for WithReplicateHeader")
+	}
+
+	var r0 message.MutableMessage
+	if rf, ok := ret.Get(0).(func(*message.ReplicateHeader) message.MutableMessage); ok {
+		r0 = rf(rh)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(message.MutableMessage)
+		}
+	}
+
+	return r0
+}
+
+// MockMutableMessage_WithReplicateHeader_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'WithReplicateHeader'
+type MockMutableMessage_WithReplicateHeader_Call struct {
+	*mock.Call
+}
+
+// WithReplicateHeader is a helper method to define mock.On call
+//   - rh *message.ReplicateHeader
+func (_e *MockMutableMessage_Expecter) WithReplicateHeader(rh interface{}) *MockMutableMessage_WithReplicateHeader_Call {
+	return &MockMutableMessage_WithReplicateHeader_Call{Call: _e.mock.On("WithReplicateHeader", rh)}
+}
+
+func (_c *MockMutableMessage_WithReplicateHeader_Call) Run(run func(rh *message.ReplicateHeader)) *MockMutableMessage_WithReplicateHeader_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(*message.ReplicateHeader))
+	})
+	return _c
+}
+
+func (_c *MockMutableMessage_WithReplicateHeader_Call) Return(_a0 message.MutableMessage) *MockMutableMessage_WithReplicateHeader_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockMutableMessage_WithReplicateHeader_Call) RunAndReturn(run func(*message.ReplicateHeader) message.MutableMessage) *MockMutableMessage_WithReplicateHeader_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // WithTimeTick provides a mock function with given fields: tt
 func (_m *MockMutableMessage) WithTimeTick(tt uint64) message.MutableMessage {
 	ret := _m.Called(tt)

--- a/pkg/streaming/util/message/message.go
+++ b/pkg/streaming/util/message/message.go
@@ -112,6 +112,10 @@ type MutableMessage interface {
 	// !!! preserved for streaming system internal usage, don't call it outside of streaming system.
 	WithTxnContext(txnCtx TxnContext) MutableMessage
 
+	// WithReplicateHeader sets the replicate header of current message.
+	// !!! preserved for streaming system internal usage, don't call it outside of streaming system.
+	WithReplicateHeader(rh *ReplicateHeader) MutableMessage
+
 	// IntoImmutableMessage converts the mutable message to immutable message.
 	IntoImmutableMessage(msgID MessageID) ImmutableMessage
 }

--- a/pkg/streaming/util/message/message_impl.go
+++ b/pkg/streaming/util/message/message_impl.go
@@ -101,6 +101,28 @@ func (m *messageImpl) WithWALTerm(term int64) MutableMessage {
 	return m
 }
 
+// WithReplicateHeader sets the replicate header of current message.
+func (m *messageImpl) WithReplicateHeader(rh *ReplicateHeader) MutableMessage {
+	if rh == nil {
+		return m
+	}
+	if m.properties.Exist(messageReplicateMesssageHeader) {
+		panic("replicate header already set in properties of message")
+	}
+	rhProto, err := EncodeProto(&messagespb.ReplicateHeader{
+		ClusterId:              rh.ClusterID,
+		MessageId:              rh.MessageID.IntoProto(),
+		LastConfirmedMessageId: rh.LastConfirmedMessageID.IntoProto(),
+		TimeTick:               rh.TimeTick,
+		Vchannel:               rh.VChannel,
+	})
+	if err != nil {
+		panic("should not happen on replicate header proto")
+	}
+	m.properties.Set(messageReplicateMesssageHeader, rhProto)
+	return m
+}
+
 // WithTimeTick sets the time tick of current message.
 func (m *messageImpl) WithTimeTick(tt uint64) MutableMessage {
 	m.properties.Set(messageTimeTick, EncodeUint64(tt))

--- a/pkg/util/funcutil/func.go
+++ b/pkg/util/funcutil/func.go
@@ -300,6 +300,11 @@ func IsControlChannel(channel string) bool {
 	return strings.HasSuffix(channel, ControlChannelSuffix)
 }
 
+// IsOnPhysicalChannel checks if the channel is on the physical channel
+func IsOnPhysicalChannel(channel string, physicalChannel string) bool {
+	return strings.HasPrefix(channel, physicalChannel)
+}
+
 // ToPhysicalChannel get physical channel name from virtual channel name
 func ToPhysicalChannel(vchannel string) string {
 	if IsPhysicalChannel(vchannel) {


### PR DESCRIPTION
issue: #44697, #44696

- The DDL executing order of secondary keep same with order of control channel timetick now.
- filtering the control channel operation on shard manager of streamingnode to avoid wrong vchannel of create segment.
- fix that the immutable txn message lost replicate header.