### PR TITLE
fix: [2.6]Fix the geometry return POINT(0 0) when growing mmap is enabled

### DIFF
--- a/internal/core/src/mmap/ChunkData.h
+++ b/internal/core/src/mmap/ChunkData.h
@@ -124,7 +124,7 @@ VariableLengthChunk<std::string>::set(
             data_[i + begin] = std::string_view("");
         } else {
             char* data_ptr = buf + offset;
-            std::strcpy(data_ptr, src[i].c_str());
+            std::memcpy(data_ptr, src[i].data(), src[i].size());
             data_[i + begin] = std::string_view(data_ptr, src[i].size());
         }
         offset += data_size;


### PR DESCRIPTION
issue: #44802 
master pr: #44889 

After a Geometry object is serialized into WKB, the resulting binary may contain '\0' bytes.
When growing mmap is enabled, the append data logic uses strcpy, which stops copying at the first '\0' bytes.
This causes only part of the WKB---typically the portion up to the geometry type field to be copied, leading to corrupted data.
As a result, during parsing, all POINT geometries are incorrectly interperted as POINT(0 0).

To fix this issue, memcpy will be used instead of strcpy.