### PR TITLE
enhance: support deep nested JSON field partial update with mergo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -106,6 +106,7 @@ require (
 	cloud.google.com/go/compute/metadata v0.6.0 // indirect
 	cloud.google.com/go/iam v1.4.1 // indirect
 	cloud.google.com/go/monitoring v1.24.0 // indirect
+	dario.cat/mergo v1.0.0 // indirect
 	github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 // indirect
 	github.com/99designs/keyring v1.2.1 // indirect
 	github.com/AthenZ/athenz v1.12.13 // indirect

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -4,6 +4,7 @@ go 1.24.6
 
 require (
 	cloud.google.com/go/storage v1.50.0
+	dario.cat/mergo v1.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.6.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.1.0


### PR DESCRIPTION
issue: #44907
Replace manual shallow merge logic with mergo library to enable deep recursive merging of nested JSON objects during partial updates.

Key changes:
- Integrate dario.cat/mergo library for deep merge capability
- Remove IsDynamic distinction for JSON field merge behavior
- Use mergo.WithOverride to ensure update values take precedence
- Support multi-level nested object partial updates

This enables true partial updates where nested objects preserve fields not mentioned in the update, while still allowing updates to deeply nested values. Empty objects {} preserve existing data, while null values can be used to explicitly clear fields.

Test coverage:
- Deep nested merge for 2-level and 3-level structures
- Mixed types (objects, arrays, primitives) in nested data
- Empty object behavior (preserves existing nested fields)
- Null value clearing for both nested objects and top-level fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)