### PR TITLE
fix: Fix return EOF when geometry enable null

### DIFF
--- a/internal/proxy/validate_util.go
+++ b/internal/proxy/validate_util.go
@@ -834,10 +834,6 @@ func (v *validateUtil) checkGeometryFieldData(field *schemapb.FieldData, fieldSc
 	}
 
 	for index, wktdata := range geometryArray {
-		if field.GetValidData() != nil && !field.GetValidData()[index] {
-			wkbArray[index] = nil
-			continue
-		}
 		// ignore parsed geom, the check is during insert task pre execute,so geo data became wkb
 		// fmt.Println(strings.Trim(string(wktdata), "\""))
 		geomT, err := wkt.Unmarshal(wktdata)


### PR DESCRIPTION
issue: #44648 

If the value is `null` during insertion, it will be omitted instead of being filled with nil. Therefore, when performing checks, there’s no need to retrieve data based on the valid offset.