### PR TITLE
enhance: [2.6] add a disk quota for the loaded binlog size to prevent load failures of querynode

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -1209,6 +1209,7 @@ quotaAndLimits:
     diskProtection:
       enabled: true # When the total file size of object storage is greater than `diskQuota`, all dml requests would be rejected;
       diskQuota: -1 # MB, (0, +inf), default no limit
+      loadedDiskQuota: -1 # MB, (0, +inf), default no limit
       diskQuotaPerDB: -1 # MB, (0, +inf), default no limit
       diskQuotaPerCollection: -1 # MB, (0, +inf), default no limit
       diskQuotaPerPartition: -1 # MB, (0, +inf), default no limit

--- a/internal/querynodev2/metrics_info.go
+++ b/internal/querynodev2/metrics_info.go
@@ -153,6 +153,7 @@ func getQuotaMetrics(node *QueryNode) (*metricsinfo.QueryNodeQuotaMetrics, error
 			NumFlowGraph:        node.pipelineManager.Num(),
 		},
 		GrowingSegmentsSize: totalGrowingSize,
+		LoadedBinlogSize:    node.manager.Segment.GetLoadedBinlogSize(),
 		Effect: metricsinfo.NodeEffect{
 			NodeID:        node.GetNodeID(),
 			CollectionIDs: lo.Keys(collections),

--- a/internal/querynodev2/segments/manager_test.go
+++ b/internal/querynodev2/segments/manager_test.go
@@ -190,3 +190,30 @@ func (s *ManagerSuite) TestIncreaseVersion() {
 func TestManager(t *testing.T) {
 	suite.Run(t, new(ManagerSuite))
 }
+
+func TestLoadedBinlogSizeAccounting(t *testing.T) {
+	m := NewSegmentManager()
+	if got := m.GetLoadedBinlogSize(); got != 0 {
+		t.Fatalf("expected initial 0, got %d", got)
+	}
+
+	m.AddLoadedBinlogSize(100)
+	if got := m.GetLoadedBinlogSize(); got != 100 {
+		t.Fatalf("expected 100 after add, got %d", got)
+	}
+
+	m.AddLoadedBinlogSize(50)
+	if got := m.GetLoadedBinlogSize(); got != 150 {
+		t.Fatalf("expected 150 after add, got %d", got)
+	}
+
+	m.SubLoadedBinlogSize(20)
+	if got := m.GetLoadedBinlogSize(); got != 130 {
+		t.Fatalf("expected 130 after sub, got %d", got)
+	}
+
+	m.SubLoadedBinlogSize(1000)
+	if got := m.GetLoadedBinlogSize(); got != 0 {
+		t.Fatalf("expected clamp to 0, got %d", got)
+	}
+}

--- a/internal/querynodev2/segments/mock_segment_manager.go
+++ b/internal/querynodev2/segments/mock_segment_manager.go
@@ -25,6 +25,39 @@ func (_m *MockSegmentManager) EXPECT() *MockSegmentManager_Expecter {
 	return &MockSegmentManager_Expecter{mock: &_m.Mock}
 }
 
+// AddLoadedBinlogSize provides a mock function with given fields: size
+func (_m *MockSegmentManager) AddLoadedBinlogSize(size int64) {
+	_m.Called(size)
+}
+
+// MockSegmentManager_AddLoadedBinlogSize_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddLoadedBinlogSize'
+type MockSegmentManager_AddLoadedBinlogSize_Call struct {
+	*mock.Call
+}
+
+// AddLoadedBinlogSize is a helper method to define mock.On call
+//   - size int64
+func (_e *MockSegmentManager_Expecter) AddLoadedBinlogSize(size interface{}) *MockSegmentManager_AddLoadedBinlogSize_Call {
+	return &MockSegmentManager_AddLoadedBinlogSize_Call{Call: _e.mock.On("AddLoadedBinlogSize", size)}
+}
+
+func (_c *MockSegmentManager_AddLoadedBinlogSize_Call) Run(run func(size int64)) *MockSegmentManager_AddLoadedBinlogSize_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(int64))
+	})
+	return _c
+}
+
+func (_c *MockSegmentManager_AddLoadedBinlogSize_Call) Return() *MockSegmentManager_AddLoadedBinlogSize_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockSegmentManager_AddLoadedBinlogSize_Call) RunAndReturn(run func(int64)) *MockSegmentManager_AddLoadedBinlogSize_Call {
+	_c.Run(run)
+	return _c
+}
+
 // AddLogicalResource provides a mock function with given fields: usage
 func (_m *MockSegmentManager) AddLogicalResource(usage ResourceUsage) {
 	_m.Called(usage)
@@ -484,6 +517,51 @@ func (_c *MockSegmentManager_GetGrowing_Call) RunAndReturn(run func(int64) Segme
 	return _c
 }
 
+// GetLoadedBinlogSize provides a mock function with no fields
+func (_m *MockSegmentManager) GetLoadedBinlogSize() int64 {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetLoadedBinlogSize")
+	}
+
+	var r0 int64
+	if rf, ok := ret.Get(0).(func() int64); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+
+	return r0
+}
+
+// MockSegmentManager_GetLoadedBinlogSize_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetLoadedBinlogSize'
+type MockSegmentManager_GetLoadedBinlogSize_Call struct {
+	*mock.Call
+}
+
+// GetLoadedBinlogSize is a helper method to define mock.On call
+func (_e *MockSegmentManager_Expecter) GetLoadedBinlogSize() *MockSegmentManager_GetLoadedBinlogSize_Call {
+	return &MockSegmentManager_GetLoadedBinlogSize_Call{Call: _e.mock.On("GetLoadedBinlogSize")}
+}
+
+func (_c *MockSegmentManager_GetLoadedBinlogSize_Call) Run(run func()) *MockSegmentManager_GetLoadedBinlogSize_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockSegmentManager_GetLoadedBinlogSize_Call) Return(_a0 int64) *MockSegmentManager_GetLoadedBinlogSize_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockSegmentManager_GetLoadedBinlogSize_Call) RunAndReturn(run func() int64) *MockSegmentManager_GetLoadedBinlogSize_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetLogicalResource provides a mock function with no fields
 func (_m *MockSegmentManager) GetLogicalResource() ResourceUsage {
 	ret := _m.Called()
@@ -801,6 +879,39 @@ func (_c *MockSegmentManager_RemoveBy_Call) Return(_a0 int, _a1 int) *MockSegmen
 
 func (_c *MockSegmentManager_RemoveBy_Call) RunAndReturn(run func(context.Context, ...SegmentFilter) (int, int)) *MockSegmentManager_RemoveBy_Call {
 	_c.Call.Return(run)
+	return _c
+}
+
+// SubLoadedBinlogSize provides a mock function with given fields: size
+func (_m *MockSegmentManager) SubLoadedBinlogSize(size int64) {
+	_m.Called(size)
+}
+
+// MockSegmentManager_SubLoadedBinlogSize_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SubLoadedBinlogSize'
+type MockSegmentManager_SubLoadedBinlogSize_Call struct {
+	*mock.Call
+}
+
+// SubLoadedBinlogSize is a helper method to define mock.On call
+//   - size int64
+func (_e *MockSegmentManager_Expecter) SubLoadedBinlogSize(size interface{}) *MockSegmentManager_SubLoadedBinlogSize_Call {
+	return &MockSegmentManager_SubLoadedBinlogSize_Call{Call: _e.mock.On("SubLoadedBinlogSize", size)}
+}
+
+func (_c *MockSegmentManager_SubLoadedBinlogSize_Call) Run(run func(size int64)) *MockSegmentManager_SubLoadedBinlogSize_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(int64))
+	})
+	return _c
+}
+
+func (_c *MockSegmentManager_SubLoadedBinlogSize_Call) Return() *MockSegmentManager_SubLoadedBinlogSize_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockSegmentManager_SubLoadedBinlogSize_Call) RunAndReturn(run func(int64)) *MockSegmentManager_SubLoadedBinlogSize_Call {
+	_c.Run(run)
 	return _c
 }
 

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -1361,7 +1361,7 @@ func (s *LocalSegment) FinishLoad() error {
 	// TODO: disable logical resource handling for now
 	// usage := s.ResourceUsageEstimate()
 	// s.manager.AddLogicalResource(usage)
-	binlogSize := calculateSegmentLogSize(s.LoadInfo())
+	binlogSize := calculateSegmentMemorySize(s.LoadInfo())
 	s.manager.AddLoadedBinlogSize(binlogSize)
 	s.binlogSize.Store(binlogSize)
 	return nil

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -312,6 +312,7 @@ type LocalSegment struct {
 
 	// cached results, to avoid too many CGO calls
 	memSize     *atomic.Int64
+	binlogSize  *atomic.Int64
 	rowNum      *atomic.Int64
 	insertCount *atomic.Int64
 
@@ -389,6 +390,7 @@ func NewSegment(ctx context.Context,
 		fieldJSONStats:     make(map[int64]*querypb.JsonStatsInfo),
 
 		memSize:     atomic.NewInt64(-1),
+		binlogSize:  atomic.NewInt64(0),
 		rowNum:      atomic.NewInt64(-1),
 		insertCount: atomic.NewInt64(0),
 	}
@@ -1352,10 +1354,17 @@ func (s *LocalSegment) CreateTextIndex(ctx context.Context, fieldID int64) error
 }
 
 func (s *LocalSegment) FinishLoad() error {
+	err := s.csegment.FinishLoad()
+	if err != nil {
+		return err
+	}
 	// TODO: disable logical resource handling for now
 	// usage := s.ResourceUsageEstimate()
 	// s.manager.AddLogicalResource(usage)
-	return s.csegment.FinishLoad()
+	binlogSize := calculateSegmentLogSize(s.LoadInfo())
+	s.manager.AddLoadedBinlogSize(binlogSize)
+	s.binlogSize.Store(binlogSize)
+	return nil
 }
 
 type ReleaseScope int
@@ -1423,6 +1432,13 @@ func (s *LocalSegment) Release(ctx context.Context, opts ...releaseOption) {
 	// TODO: disable logical resource handling for now
 	// usage := s.ResourceUsageEstimate()
 	// s.manager.SubLogicalResource(usage)
+
+	binlogSize := s.binlogSize.Load()
+	if binlogSize > 0 {
+		// no concurrent change to s.binlogSize, so the subtraction is safe
+		s.manager.SubLoadedBinlogSize(binlogSize)
+		s.binlogSize.Store(0)
+	}
 
 	log.Info("delete segment from memory")
 }

--- a/internal/querynodev2/segments/utils.go
+++ b/internal/querynodev2/segments/utils.go
@@ -244,6 +244,24 @@ func calculateSegmentLogSize(segmentLoadInfo *querypb.SegmentLoadInfo) int64 {
 	return segmentSize
 }
 
+func calculateSegmentMemorySize(segmentLoadInfo *querypb.SegmentLoadInfo) int64 {
+	segmentSize := int64(0)
+
+	for _, fieldBinlog := range segmentLoadInfo.BinlogPaths {
+		segmentSize += getBinlogDataMemorySize(fieldBinlog)
+	}
+
+	for _, fieldBinlog := range segmentLoadInfo.Statslogs {
+		segmentSize += getBinlogDataMemorySize(fieldBinlog)
+	}
+
+	for _, fieldBinlog := range segmentLoadInfo.Deltalogs {
+		segmentSize += getBinlogDataMemorySize(fieldBinlog)
+	}
+
+	return segmentSize
+}
+
 func getFieldSizeFromFieldBinlog(fieldBinlog *datapb.FieldBinlog) int64 {
 	fieldSize := int64(0)
 	for _, binlog := range fieldBinlog.Binlogs {

--- a/pkg/util/metricsinfo/quota_metric.go
+++ b/pkg/util/metricsinfo/quota_metric.go
@@ -62,6 +62,7 @@ type QueryNodeQuotaMetrics struct {
 	Rms                 []RateMetric
 	Fgm                 FlowGraphMetric
 	GrowingSegmentsSize int64
+	LoadedBinlogSize    int64
 	Effect              NodeEffect
 	DeleteBufferInfo    DeleteBufferInfo
 	StreamingQuota      *StreamingQuotaMetrics

--- a/pkg/util/paramtable/quota_param.go
+++ b/pkg/util/paramtable/quota_param.go
@@ -153,6 +153,7 @@ type quotaConfig struct {
 	GrowingSegmentsSizeHighWaterLevel     ParamItem `refreshable:"true"`
 	DiskProtectionEnabled                 ParamItem `refreshable:"true"`
 	DiskQuota                             ParamItem `refreshable:"true"`
+	LoadedDiskQuota                       ParamItem `refreshable:"true"`
 	DiskQuotaPerDB                        ParamItem `refreshable:"true"`
 	DiskQuotaPerCollection                ParamItem `refreshable:"true"`
 	DiskQuotaPerPartition                 ParamItem `refreshable:"true"`
@@ -1903,6 +1904,27 @@ but the rate will not be lower than minRateRatio * dmlRate.`,
 		Export: true,
 	}
 	p.DiskQuota.Init(base.mgr)
+
+	p.LoadedDiskQuota = ParamItem{
+		Key:          "quotaAndLimits.limitWriting.diskProtection.loadedDiskQuota",
+		Version:      "2.6.4",
+		DefaultValue: quota,
+		Formatter: func(v string) string {
+			if !p.DiskProtectionEnabled.GetAsBool() {
+				return max
+			}
+			level := getAsFloat(v)
+			// (0, +inf)
+			if level <= 0 {
+				return max
+			}
+			// megabytes to bytes
+			return fmt.Sprintf("%f", megaBytes2Bytes(level))
+		},
+		Doc:    "MB, (0, +inf), default no limit",
+		Export: true,
+	}
+	p.LoadedDiskQuota.Init(base.mgr)
 
 	p.DiskQuotaPerDB = ParamItem{
 		Key:          "quotaAndLimits.limitWriting.diskProtection.diskQuotaPerDB",


### PR DESCRIPTION
issue: #41435 
pr: #44893 