### PR TITLE
fix: [2.6] support JSON default value in `CreateArrowScalarFromDefaultValue`(#44912)

### DIFF
--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -495,6 +495,9 @@ CreateArrowScalarFromDefaultValue(const FieldMeta& field_meta) {
         case DataType::TEXT:
             return std::make_shared<arrow::StringScalar>(
                 default_value.string_data());
+        case DataType::JSON:
+            return std::make_shared<arrow::BinaryScalar>(
+                default_value.bytes_data());
         default:
             ThrowInfo(DataTypeInvalid,
                       "unsupported default value data type {}",


### PR DESCRIPTION
Cherry-pick from master
pr: #44912
Related to #44897

Add missing JSON data type handling in CreateArrowScalarFromDefaultValue to fix query failures when dynamic fields are enabled. JSON default values are now properly converted to arrow::BinaryScalar using bytes_data().