### PR TITLE
fix: update bitnami repo

### DIFF
--- a/build/ci/jenkins/DeployTest.groovy
+++ b/build/ci/jenkins/DeployTest.groovy
@@ -186,10 +186,10 @@ pipeline {
                             sh "helm repo update"
                             if ("${params.deploy_task}" == "upgrade"){
                                 if ("${params.milvus_mode}" == "standalone") {
-                                    sh "helm install --wait --timeout 720s ${env.RELEASE_NAME} milvus/milvus  --set image.all.repository=${old_image_repository_modified} --set image.all.tag=${old_image_tag_modified} --set etcd.image.repository=bitnami/etcd --set etcd.image.tag=3.5.0-debian-10-r24 -f standalone-values.yaml;"    
+                                    sh "helm install --wait --timeout 720s ${env.RELEASE_NAME} milvus/milvus  --set image.all.repository=${old_image_repository_modified} --set image.all.tag=${old_image_tag_modified} --set etcd.image.repository=milvusdb/etcd --set etcd.image.tag=3.5.5-r2 -f standalone-values.yaml;"    
                                 }
                                 if ("${params.milvus_mode}" == "cluster") {
-                                    sh "helm install --wait --timeout 720s ${env.RELEASE_NAME} milvus/milvus  --set image.all.repository=${old_image_repository_modified} --set image.all.tag=${old_image_tag_modified} --set etcd.image.repository=bitnami/etcd --set etcd.image.tag=3.5.0-debian-10-r24 -f cluster-values.yaml;"    
+                                    sh "helm install --wait --timeout 720s ${env.RELEASE_NAME} milvus/milvus  --set image.all.repository=${old_image_repository_modified} --set image.all.tag=${old_image_tag_modified} --set etcd.image.repository=milvusdb/etcd --set etcd.image.tag=3.5.5-r2 -f cluster-values.yaml;"    
                                 }
                             }
 

--- a/deployments/docker/dev/docker-compose.yml
+++ b/deployments/docker/dev/docker-compose.yml
@@ -83,7 +83,7 @@ services:
       - "2181:2181"
 
   kafka:
-    image: 'bitnami/kafka:3.1.0'
+    image: 'bitnamilegacy/kafka:3.1.0'
     ports:
       - '9092:9092'
     environment:


### PR DESCRIPTION
This pull request updates dependencies for Milvus deployments, focusing on the images used for etcd and Kafka in both Helm and Docker Compose configurations. The main goal is to align the deployment with newer or organization-specific images for improved compatibility and maintenance.

**Helm deployment image updates:**

* Switched the etcd image repository from `bitnami/etcd` to `milvusdb/etcd` and updated the etcd image tag from `3.5.0-debian-10-r24` to `3.5.5-r2` in both standalone and cluster Helm installation commands in `DeployTest.groovy`.

**Docker Compose image updates:**

* Changed the Kafka image from `bitnami/kafka:3.1.0` to `bitnamilegacy/kafka:3.1.0` in `docker-compose.yml`.

issue: #44978