### PR TITLE
fix: Fix bug for gis function to filter geometry

### DIFF
--- a/internal/core/src/exec/expression/GISFunctionFilterExpr.h
+++ b/internal/core/src/exec/expression/GISFunctionFilterExpr.h
@@ -68,7 +68,6 @@ class PhyGISFunctionFilterExpr : public SegmentExpr {
         }
     }
 
-
  private:
     VectorPtr
     EvalForIndexSegment();

--- a/internal/core/src/exec/expression/GISFunctionFilterExpr.h
+++ b/internal/core/src/exec/expression/GISFunctionFilterExpr.h
@@ -56,6 +56,16 @@ class PhyGISFunctionFilterExpr : public SegmentExpr {
         return expr_->column_;
     }
 
+    std::string
+    ToString() const {
+        return fmt::format("{}", expr_->ToString());
+    }
+
+    void
+    MoveCursor() {
+    }
+
+
  private:
     VectorPtr
     EvalForIndexSegment();

--- a/internal/core/src/exec/expression/GISFunctionFilterExpr.h
+++ b/internal/core/src/exec/expression/GISFunctionFilterExpr.h
@@ -63,6 +63,9 @@ class PhyGISFunctionFilterExpr : public SegmentExpr {
 
     void
     MoveCursor() {
+        if (segment_->type() == SegmentType::Sealed) {
+            SegmentExpr::MoveCursor();
+        }
     }
 
 

--- a/internal/core/src/segcore/FieldIndexing.cpp
+++ b/internal/core/src/segcore/FieldIndexing.cpp
@@ -531,16 +531,14 @@ ScalarFieldIndexing<T>::process_geometry_data(int64_t reserved_offset,
                 // Use the accessor to get geometry data and validity
                 auto [wkb_data, is_valid] = accessor(i);
 
-                if (is_valid) {
-                    try {
-                        rtree_index->AddGeometry(wkb_data, global_offset);
-                        added_count++;
-                    } catch (std::exception& error) {
-                        ThrowInfo(UnexpectedError,
-                                  "Failed to add geometry at offset {}: {}",
-                                  global_offset,
-                                  error.what());
-                    }
+                try {
+                    rtree_index->AddGeometry(wkb_data, global_offset);
+                    added_count++;
+                } catch (std::exception& error) {
+                    ThrowInfo(UnexpectedError,
+                              "Failed to add geometry at offset {}: {}",
+                              global_offset,
+                              error.what());
                 }
             }
 


### PR DESCRIPTION
issue: #44961 

This PR fixes 3 geometry related bugs:
1. Implement `ToString` interface for GisFunctionFilter.
2. Ignore GisFunctionFilter `MoveCursor` for growing segment.
3. Don't skip null geometry for building R-Tree index, should be record in null_offsets.