### PR TITLE
fix: [2.6] Handle JSON field default values in storage layer (#44999)

### DIFF
--- a/internal/storage/utils.go
+++ b/internal/storage/utils.go
@@ -1601,6 +1601,8 @@ func GetDefaultValue(fieldSchema *schemapb.FieldSchema) interface{} {
 		return fieldSchema.GetDefaultValue().GetStringData()
 	case schemapb.DataType_Timestamptz:
 		return fieldSchema.GetDefaultValue().GetTimestamptzData()
+	case schemapb.DataType_JSON:
+		return fieldSchema.GetDefaultValue().GetBytesData()
 	default:
 		// won't happen
 		panic(fmt.Sprintf("undefined data type:%s", fieldSchema.DataType.String()))


### PR DESCRIPTION
Cherry-pick from master
pr: #44999
Related to #44995
Added missing case for JSON data type in GetDefaultValue function to properly retrieve default values for JSON fields. This prevents crashes when enabling dynamic fields with default values during concurrent insert operations.

Changes:
- Added JSON data type case in GetDefaultValue to return BytesData
- Added comprehensive tests for fillMissingFields covering JSON and other data types with default values
- Added tests for nullable fields, required fields validation, and edge cases