### PR TITLE
fix: Update milvus-storage to fix duplicate AWS SDK initialization

### DIFF
--- a/internal/core/src/storage/StorageV2FSCache.cpp
+++ b/internal/core/src/storage/StorageV2FSCache.cpp
@@ -80,7 +80,7 @@ StorageV2FSCache::Get(const Key& key) {
             return nullptr;
         }
 
-        auto fs = result.value();
+        auto fs = result.ValueOrDie();
         iter->second.first.set_value(fs);
         return fs;
     } catch (...) {

--- a/internal/core/thirdparty/milvus-storage/CMakeLists.txt
+++ b/internal/core/thirdparty/milvus-storage/CMakeLists.txt
@@ -14,7 +14,7 @@
 # Update milvus-storage_VERSION for the first occurrence
 milvus_add_pkg_config("milvus-storage")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( milvus-storage_VERSION aa189ad )
+set( milvus-storage_VERSION e5f5b4c )
 set( GIT_REPOSITORY  "https://github.com/milvus-io/milvus-storage.git")
 message(STATUS "milvus-storage repo: ${GIT_REPOSITORY}")
 message(STATUS "milvus-storage version: ${milvus-storage_VERSION}")


### PR DESCRIPTION
Update milvus-storage version from aa189ad to e5f5b4c to include the fix for duplicate AWS SDK initialization that was causing init conflicts.

This update removes the redundant arrow::fs::InitializeS3() call that was resulting in duplicate Aws::InitAPI() initialization. The duplicate initialization was causing AWS SDK to ignore custom configurations, particularly affecting GCP Workload Identity authentication.

Changes in milvus-storage e5f5b4c:
- Remove redundant arrow::fs::InitializeS3() call
- Keep only the extended S3 initialization with custom AWS SDK options
- Ensure GCP IAM authentication via custom HTTP client factory works correctly

Relates to #44745
Reference: milvus-io/milvus-storage#285