### PR TITLE
enhance: support cluster deployed in mixed environments consisting of IPv4/IPv6 dual-stack and IPv6-only nodes

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -1031,6 +1031,7 @@ common:
   enablePosixMode: false # Specifies whether to run in POSIX mode for enhanced file system compatibility
   usingJSONShreddingForQuery: true # Indicates whether to use json stats when query
   clusterID: 0 # cluster id
+  preferIPv6Address: false # Prefer publish ipv6 addresses to support deploy cluster in mixed environments consisting of IPv4/IPv6 dual-stack and IPv6-only nodes
 
 # QuotaConfig, configurations of Milvus quota and limits.
 # By default, we enable:

--- a/internal/distributed/datanode/service.go
+++ b/internal/distributed/datanode/service.go
@@ -81,6 +81,7 @@ func NewServer(ctx context.Context, factory dependency.Factory) (*Server, error)
 
 func (s *Server) Prepare() error {
 	listener, err := netutil.NewListener(
+		netutil.OptPreferIPv6Address(paramtable.Get().CommonCfg.PreferIPv6Address.GetAsBool()),
 		netutil.OptIP(paramtable.Get().DataNodeGrpcServerCfg.IP),
 		netutil.OptHighPriorityToUsePort(paramtable.Get().DataNodeGrpcServerCfg.Port.GetAsInt()),
 	)

--- a/internal/distributed/mixcoord/service.go
+++ b/internal/distributed/mixcoord/service.go
@@ -97,6 +97,7 @@ func NewServer(ctx context.Context, factory dependency.Factory) (*Server, error)
 func (s *Server) Prepare() error {
 	log := log.Ctx(s.ctx)
 	listener, err := netutil.NewListener(
+		netutil.OptPreferIPv6Address(paramtable.Get().CommonCfg.PreferIPv6Address.GetAsBool()),
 		netutil.OptIP(paramtable.Get().RootCoordGrpcServerCfg.IP),
 		netutil.OptPort(paramtable.Get().RootCoordGrpcServerCfg.Port.GetAsInt()),
 	)

--- a/internal/distributed/proxy/listener_manager.go
+++ b/internal/distributed/proxy/listener_manager.go
@@ -42,6 +42,7 @@ func newListenerManager(ctx context.Context) (l *listenerManager, err error) {
 
 	log := log.Ctx(ctx)
 	externalGrpcListener, err := netutil.NewListener(
+		netutil.OptPreferIPv6Address(paramtable.Get().CommonCfg.PreferIPv6Address.GetAsBool()),
 		netutil.OptIP(paramtable.Get().ProxyGrpcServerCfg.IP),
 		netutil.OptPort(paramtable.Get().ProxyGrpcServerCfg.Port.GetAsInt()),
 	)
@@ -52,6 +53,7 @@ func newListenerManager(ctx context.Context) (l *listenerManager, err error) {
 	log.Info("Proxy listen on external grpc listener", zap.String("address", externalGrpcListener.Address()), zap.Int("port", externalGrpcListener.Port()))
 
 	internalGrpcListener, err := netutil.NewListener(
+		netutil.OptPreferIPv6Address(paramtable.Get().CommonCfg.PreferIPv6Address.GetAsBool()),
 		netutil.OptIP(paramtable.Get().ProxyGrpcServerCfg.IP),
 		netutil.OptPort(paramtable.Get().ProxyGrpcServerCfg.InternalPort.GetAsInt()),
 	)
@@ -147,7 +149,9 @@ func newHTTPListner(ctx context.Context, l *listenerManager) error {
 
 	var err error
 	l.portShareMode = false
-	l.httpListener, err = netutil.NewListener(netutil.OptIP(Params.IP), netutil.OptPort(httpPort), netutil.OptTLS(tlsConf))
+	l.httpListener, err = netutil.NewListener(
+		netutil.OptPreferIPv6Address(paramtable.Get().CommonCfg.PreferIPv6Address.GetAsBool()),
+		netutil.OptIP(Params.IP), netutil.OptPort(httpPort), netutil.OptTLS(tlsConf))
 	if err != nil {
 		log.Warn("Proxy server(http) failed to listen on", zap.Error(err))
 		return err

--- a/internal/distributed/querynode/service.go
+++ b/internal/distributed/querynode/service.go
@@ -91,6 +91,7 @@ func NewServer(ctx context.Context, factory dependency.Factory) (*Server, error)
 
 func (s *Server) Prepare() error {
 	listener, err := netutil.NewListener(
+		netutil.OptPreferIPv6Address(paramtable.Get().CommonCfg.PreferIPv6Address.GetAsBool()),
 		netutil.OptIP(paramtable.Get().QueryNodeGrpcServerCfg.IP),
 		netutil.OptHighPriorityToUsePort(paramtable.Get().QueryNodeGrpcServerCfg.Port.GetAsInt()),
 	)

--- a/internal/distributed/streamingnode/service.go
+++ b/internal/distributed/streamingnode/service.go
@@ -106,6 +106,7 @@ func NewServer(ctx context.Context, f dependency.Factory) (*Server, error) {
 
 func (s *Server) Prepare() error {
 	listener, err := netutil.NewListener(
+		netutil.OptPreferIPv6Address(paramtable.Get().CommonCfg.PreferIPv6Address.GetAsBool()),
 		netutil.OptIP(paramtable.Get().StreamingNodeGrpcServerCfg.IP),
 		netutil.OptHighPriorityToUsePort(paramtable.Get().StreamingNodeGrpcServerCfg.Port.GetAsInt()),
 	)

--- a/pkg/util/netutil/listener.go
+++ b/pkg/util/netutil/listener.go
@@ -85,6 +85,7 @@ type netListenerConfig struct {
 	ip                    string
 	highPriorityToUsePort int
 	port                  int
+	preferIPv6Address     bool
 	tlsConfig             *tls.Config
 }
 
@@ -92,12 +93,14 @@ type netListenerConfig struct {
 func getNetListenerConfig(opts ...Opt) *netListenerConfig {
 	defaultConfig := &netListenerConfig{
 		net:                   "tcp",
-		ip:                    funcutil.GetLocalIP(),
 		highPriorityToUsePort: 0,
 		port:                  0,
 	}
 	for _, opt := range opts {
 		opt(defaultConfig)
+	}
+	if len(defaultConfig.ip) == 0 {
+		defaultConfig.ip = funcutil.GetLocalIP(defaultConfig.preferIPv6Address)
 	}
 	return defaultConfig
 }
@@ -116,6 +119,13 @@ func OptNet(net string) Opt {
 func OptIP(ip string) Opt {
 	return func(nlc *netListenerConfig) {
 		nlc.ip = ip
+	}
+}
+
+// OptPreferIPv6Address sets whether prefer to get ipv6 address for the listener.
+func OptPreferIPv6Address(preferIPv6Address bool) Opt {
+	return func(nlc *netListenerConfig) {
+		nlc.preferIPv6Address = preferIPv6Address
 	}
 }
 

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -332,6 +332,8 @@ type commonConfig struct {
 	ClusterID              ParamItem `refreshable:"false"`
 
 	HybridSearchRequeryPolicy ParamItem `refreshable:"true"`
+
+	PreferIPv6Address ParamItem `refreshable:"false"`
 }
 
 func (p *commonConfig) init(base *BaseTable) {
@@ -1284,6 +1286,15 @@ This helps Milvus-CDC synchronize incremental data`,
 		Export:       false,
 	}
 	p.HybridSearchRequeryPolicy.Init(base.mgr)
+
+	p.PreferIPv6Address = ParamItem{
+		Key:          "common.preferIPv6Address",
+		Version:      "2.6.3",
+		Doc:          "Prefer publish ipv6 addresses",
+		DefaultValue: "false",
+		Export:       true,
+	}
+	p.PreferIPv6Address.Init(base.mgr)
 }
 
 type gpuConfig struct {

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -153,6 +153,10 @@ func TestComponentParam(t *testing.T) {
 			params.CommonCfg.ClusterID.GetAsInt()
 		})
 		params.Save("common.clusterID", "0")
+
+		assert.Equal(t, false, params.CommonCfg.PreferIPv6Address.GetAsBool())
+		params.Save("common.preferIPv6Address", "true")
+		assert.Equal(t, true, params.CommonCfg.PreferIPv6Address.GetAsBool())
 	})
 
 	t.Run("test rootCoordConfig", func(t *testing.T) {

--- a/pkg/util/paramtable/grpc_param.go
+++ b/pkg/util/paramtable/grpc_param.go
@@ -87,7 +87,8 @@ func (p *grpcConfig) init(domain string, base *BaseTable) {
 		Export:  true,
 	}
 	p.IPItem.Init(base.mgr)
-	p.IP = funcutil.GetIP(p.IPItem.GetValue())
+
+	p.IP = funcutil.GetIP(p.IPItem.GetValue(), Get().CommonCfg.PreferIPv6Address.GetAsBool())
 
 	p.Port = ParamItem{
 		Key:          p.Domain + ".port",


### PR DESCRIPTION
 related issue: https://github.com/milvus-io/milvus/issues/45065

This PR introduces the `common.preferIPv6Address` configuration to support clusters deployed in mixed environments consisting of IPv4/IPv6 dual-stack and IPv6-only nodes.

when `common.preferIPv6Address` is true, milvus can be deployed in the following environments:
1. IPv4 only nodes (https://github.com/milvus-io/milvus/pull/32960 support)
2. IPv6 only nodes  (https://github.com/milvus-io/milvus/pull/32960 support)
3. IPv4 & IPv6 dual-stack nodes  (https://github.com/milvus-io/milvus/pull/32960 support)
4. **mixed environments consisting of IPv4/IPv6 dual-stack and IPv6-only nodes  (this PR support)**

Thank you for review!
