### PR TITLE
fix: Prevent retry when importing invalid UTF-8 strings

### DIFF
--- a/internal/util/importutilv2/common/util.go
+++ b/internal/util/importutilv2/common/util.go
@@ -18,6 +18,8 @@ package common
 
 import (
 	"fmt"
+	"strings"
+	"unicode/utf8"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
@@ -55,9 +57,41 @@ func EstimateReadCountPerBatch(bufferSize int, schema *schemapb.CollectionSchema
 	return ret, nil
 }
 
+// SafeStringForError safely converts a string for use in error messages.
+// It replaces invalid UTF-8 sequences with their hex representation to avoid
+// gRPC serialization errors while still providing useful debugging information.
+func SafeStringForError(s string) string {
+	if utf8.ValidString(s) {
+		return s
+	}
+
+	var result strings.Builder
+	for i, r := range s {
+		if r == utf8.RuneError {
+			// Invalid UTF-8 sequence, encode as hex
+			result.WriteString(fmt.Sprintf("\\x%02x", s[i]))
+		} else {
+			result.WriteRune(r)
+		}
+	}
+	return result.String()
+}
+
+// SafeStringForErrorWithLimit safely converts a string for use in error messages
+// with a length limit to prevent extremely long error messages.
+func SafeStringForErrorWithLimit(s string, maxLen int) string {
+	safe := SafeStringForError(s)
+	if len(safe) <= maxLen {
+		return safe
+	}
+	return safe[:maxLen] + "..."
+}
+
 func CheckValidUTF8(s string, field *schemapb.FieldSchema) error {
 	if !typeutil.IsUTF8(s) {
-		return fmt.Errorf("field %s contains invalid UTF-8 data, value=%s", field.GetName(), s)
+		// Use safe string representation to avoid gRPC serialization errors
+		safeValue := SafeStringForErrorWithLimit(s, 100)
+		return fmt.Errorf("field '%s' contains invalid UTF-8 data, value=%s", field.GetName(), safeValue)
 	}
 	return nil
 }


### PR DESCRIPTION
Convert invalid UTF-8 string the hex in failure reason.

issue: https://github.com/milvus-io/milvus/issues/45066