### PR TITLE
enhance: Optimize ScalarIndexSort bitmap initialization for range queries

### DIFF
--- a/internal/core/src/index/ScalarIndexSort.cpp
+++ b/internal/core/src/index/ScalarIndexSort.cpp
@@ -384,10 +384,10 @@ template <typename T>
 const TargetBitmap
 ScalarIndexSort<T>::Range(const T value, const OpType op) {
     AssertInfo(is_built_, "index has not been built");
-    TargetBitmap bitset(Count());
     auto lb = begin();
     auto ub = end();
     if (ShouldSkip(value, value, op)) {
+        TargetBitmap bitset(Count());
         return bitset;
     }
     switch (op) {
@@ -407,10 +407,30 @@ ScalarIndexSort<T>::Range(const T value, const OpType op) {
             ThrowInfo(OpTypeInvalid,
                       fmt::format("Invalid OperatorType: {}", op));
     }
-    for (; lb < ub; ++lb) {
-        bitset[lb->idx_] = true;
+
+    size_t hit_count = ub - lb;
+    size_t total_count = Count();
+
+    if (hit_count > total_count / 2) {
+        // Most elements are in range, initialize with true and set non-matching to false
+        TargetBitmap bitset(total_count, true);
+        // Set elements before lb to false
+        for (auto it = begin(); it < lb; ++it) {
+            bitset[it->idx_] = false;
+        }
+        // Set elements after ub to false
+        for (auto it = ub; it < end(); ++it) {
+            bitset[it->idx_] = false;
+        }
+        return bitset;
+    } else {
+        // Fewer elements are in range, initialize with false and set matching to true
+        TargetBitmap bitset(total_count);
+        for (; lb < ub; ++lb) {
+            bitset[lb->idx_] = true;
+        }
+        return bitset;
     }
-    return bitset;
 }
 
 template <typename T>
@@ -420,13 +440,14 @@ ScalarIndexSort<T>::Range(T lower_bound_value,
                           T upper_bound_value,
                           bool ub_inclusive) {
     AssertInfo(is_built_, "index has not been built");
-    TargetBitmap bitset(Count());
     if (lower_bound_value > upper_bound_value ||
         (lower_bound_value == upper_bound_value &&
          !(lb_inclusive && ub_inclusive))) {
+        TargetBitmap bitset(Count());
         return bitset;
     }
     if (ShouldSkip(lower_bound_value, upper_bound_value, OpType::Range)) {
+        TargetBitmap bitset(Count());
         return bitset;
     }
     auto lb = begin();
@@ -445,10 +466,30 @@ ScalarIndexSort<T>::Range(T lower_bound_value,
         ub = std::lower_bound(
             begin(), end(), IndexStructure<T>(upper_bound_value));
     }
-    for (; lb < ub; ++lb) {
-        bitset[lb->idx_] = true;
+
+    size_t hit_count = ub - lb;
+    size_t total_count = Count();
+
+    if (hit_count > total_count / 2) {
+        // Most elements are in range, initialize with true and set non-matching to false
+        TargetBitmap bitset(total_count, true);
+        // Set elements before lb to false
+        for (auto it = begin(); it < lb; ++it) {
+            bitset[it->idx_] = false;
+        }
+        // Set elements after ub to false
+        for (auto it = ub; it < end(); ++it) {
+            bitset[it->idx_] = false;
+        }
+        return bitset;
+    } else {
+        // Fewer elements are in range, initialize with false and set matching to true
+        TargetBitmap bitset(total_count);
+        for (; lb < ub; ++lb) {
+            bitset[lb->idx_] = true;
+        }
+        return bitset;
     }
-    return bitset;
 }
 
 template <typename T>

--- a/internal/core/src/index/ScalarIndexSort.cpp
+++ b/internal/core/src/index/ScalarIndexSort.cpp
@@ -412,8 +412,8 @@ ScalarIndexSort<T>::Range(const T value, const OpType op) {
     size_t total_count = Count();
 
     if (hit_count > total_count / 2) {
-        // Most elements are in range, initialize with true and set non-matching to false
-        TargetBitmap bitset(total_count, true);
+        // Most elements are in range, initialize with `valid_bitset` and set non-matching to false
+        TargetBitmap bitset = valid_bitset_.clone();
         // Set elements before lb to false
         for (auto it = begin(); it < lb; ++it) {
             bitset[it->idx_] = false;
@@ -471,8 +471,8 @@ ScalarIndexSort<T>::Range(T lower_bound_value,
     size_t total_count = Count();
 
     if (hit_count > total_count / 2) {
-        // Most elements are in range, initialize with true and set non-matching to false
-        TargetBitmap bitset(total_count, true);
+        // Most elements are in range, initialize with `valid_bitset_` and set non-matching to false
+        TargetBitmap bitset = valid_bitset_.clone();
         // Set elements before lb to false
         for (auto it = begin(); it < lb; ++it) {
             bitset[it->idx_] = false;


### PR DESCRIPTION
Optimize bitmap initialization in ScalarIndexSort range queries by using adaptive strategy based on result density. When more than 50% of elements match the range condition, initialize bitmap with all true values and clear non-matching elements. Otherwise, use the original approach of initializing with false and setting matching elements. Also defer bitmap allocation until after early return checks to avoid unnecessary memory allocation.

This optimization reduces bit operations for high-selectivity queries while maintaining the same performance for low-selectivity queries.