### PR TITLE
fix: wal state may be unconsistent after recovering from crash

### DIFF
--- a/internal/streamingnode/server/wal/adaptor/initializing.go
+++ b/internal/streamingnode/server/wal/adaptor/initializing.go
@@ -25,6 +25,12 @@ import (
 func buildInterceptorParams(ctx context.Context, underlyingWALImpls walimpls.WALImpls, cp *utility.WALCheckpoint) (*interceptors.InterceptorBuildParam, error) {
 	var lastConfirmedMessageID message.MessageID
 	if cp != nil {
+		// lastConfirmedMessageID is used to promise we can use it to read all messages which timetick is greater than timetick of current message.
+		// When we send the first time tick message, its timetick is always greater than the timetick of the previous message.
+		// But for the uncommitted message, its timetick is undetermined, and wal support to recover the uncommitted-txn.
+		// For protecting the `LastConfirmedMessageID` promise,
+		// we use the checkpoint (checkpoint is always see the committed message) to promise we can see the uncommitted message
+		// when using the FirstTimeTickMessage as the poisition to read.
 		lastConfirmedMessageID = cp.MessageID
 	}
 	msg, err := sendFirstTimeTick(ctx, underlyingWALImpls, lastConfirmedMessageID)
@@ -52,7 +58,10 @@ func buildInterceptorParams(ctx context.Context, underlyingWALImpls walimpls.WAL
 }
 
 // sendFirstTimeTick sends the first timetick message to walimpls.
-// It is used to make a fence operation with the underlying walimpls and get the timetick and last message id to recover the wal state.
+// It is used to
+// 1. make a fence operation with the underlying walimpls
+// 2. get position of wal to determine the end of current wal.
+// 3. make all un-synced messages synced by the timetick message, so the un-synced messages can be seen by the recovery storage.
 func sendFirstTimeTick(ctx context.Context, underlyingWALImpls walimpls.WALImpls, lastConfirmedMessageID message.MessageID) (msg message.ImmutableMessage, err error) {
 	logger := resource.Resource().Logger().With(zap.String("channel", underlyingWALImpls.Channel().String()))
 	if lastConfirmedMessageID != nil {

--- a/internal/streamingnode/server/wal/adaptor/opener.go
+++ b/internal/streamingnode/server/wal/adaptor/opener.go
@@ -14,6 +14,7 @@ import (
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/shard/shards"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/txn"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/recovery"
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/utility"
 	"github.com/milvus-io/milvus/internal/util/streamingutil/status"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/types"
@@ -88,18 +89,31 @@ func (o *openerAdaptorImpl) openRWWAL(ctx context.Context, l walimpls.WALImpls, 
 	roWAL := adaptImplsToROWAL(l, func() {
 		o.walInstances.Remove(id)
 	})
+	cpProto, err := resource.Resource().StreamingNodeCatalog().GetConsumeCheckpoint(ctx, opt.Channel.Name)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get checkpoint from catalog")
+	}
+	cp := utility.NewWALCheckpointFromProto(cpProto)
 
 	// recover the wal state.
-	param, err := buildInterceptorParams(ctx, l)
+	param, err := buildInterceptorParams(ctx, l, cp)
 	if err != nil {
 		roWAL.Close()
 		return nil, errors.Wrap(err, "when building interceptor params")
 	}
-	rs, snapshot, err := recovery.RecoverRecoveryStorage(ctx, newRecoveryStreamBuilder(roWAL), param.LastTimeTickMessage)
+	rs, snapshot, err := recovery.RecoverRecoveryStorage(ctx, newRecoveryStreamBuilder(roWAL), cp, param.LastTimeTickMessage)
 	if err != nil {
 		param.Clear()
 		roWAL.Close()
 		return nil, errors.Wrap(err, "when recovering recovery storage")
+	}
+	param.LastConfirmedMessageID = param.LastTimeTickMessage.MessageID()
+	if cp.MessageID != nil {
+		for _, builder := range snapshot.TxnBuffer.GetUncommittedMessageBuilder() {
+			if builder.LastConfirmedMessageID().LT(param.LastConfirmedMessageID) {
+				param.LastConfirmedMessageID = builder.LastConfirmedMessageID()
+			}
+		}
 	}
 	param.InitialRecoverSnapshot = snapshot
 	param.TxnManager = txn.NewTxnManager(param.ChannelInfo, snapshot.TxnBuffer.GetUncommittedMessageBuilder())

--- a/internal/streamingnode/server/wal/adaptor/opener_test.go
+++ b/internal/streamingnode/server/wal/adaptor/opener_test.go
@@ -3,14 +3,21 @@ package adaptor
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal"
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/metricsutil"
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/utility"
+	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/mocks/streaming/mock_walimpls"
+	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v2/streaming/util/types"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/walimpls"
+	"github.com/milvus-io/milvus/pkg/v2/streaming/walimpls/impls/rmq"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
 
@@ -30,4 +37,47 @@ func TestOpenerAdaptorFailure(t *testing.T) {
 	l, err := opener.Open(context.Background(), &wal.OpenOption{})
 	assert.ErrorIs(t, err, errExpected)
 	assert.Nil(t, l)
+}
+
+func TestDetermineLastConfirmedMessageID(t *testing.T) {
+	txnBuffer := utility.NewTxnBuffer(log.With(), metricsutil.NewScanMetrics(types.PChannelInfo{}).NewScannerMetrics())
+	lastConfirmedMessageID := determineLastConfirmedMessageID(rmq.NewRmqID(5), txnBuffer)
+	assert.Equal(t, rmq.NewRmqID(5), lastConfirmedMessageID)
+	beginMsg := message.NewBeginTxnMessageBuilderV2().
+		WithVChannel("v1").
+		WithHeader(&message.BeginTxnMessageHeader{}).
+		WithBody(&message.BeginTxnMessageBody{}).
+		MustBuildMutable().
+		WithTimeTick(1).
+		WithTxnContext(message.TxnContext{
+			TxnID:     1,
+			Keepalive: time.Hour,
+		}).
+		WithLastConfirmed(rmq.NewRmqID(1)).
+		IntoImmutableMessage(rmq.NewRmqID(1))
+	beginMsg2 := message.NewBeginTxnMessageBuilderV2().
+		WithVChannel("v1").
+		WithHeader(&message.BeginTxnMessageHeader{}).
+		WithBody(&message.BeginTxnMessageBody{}).
+		MustBuildMutable().
+		WithTxnContext(message.TxnContext{
+			TxnID:     2,
+			Keepalive: time.Hour,
+		}).
+		WithTimeTick(1).
+		WithLastConfirmed(rmq.NewRmqID(2)).
+		IntoImmutableMessage(rmq.NewRmqID(2))
+
+	txnBuffer.HandleImmutableMessages([]message.ImmutableMessage{
+		message.MustAsImmutableBeginTxnMessageV2(beginMsg2),
+	}, 4)
+
+	lastConfirmedMessageID = determineLastConfirmedMessageID(rmq.NewRmqID(5), txnBuffer)
+	assert.Equal(t, rmq.NewRmqID(2), lastConfirmedMessageID)
+
+	txnBuffer.HandleImmutableMessages([]message.ImmutableMessage{
+		message.MustAsImmutableBeginTxnMessageV2(beginMsg),
+	}, 4)
+	lastConfirmedMessageID = determineLastConfirmedMessageID(rmq.NewRmqID(5), txnBuffer)
+	assert.Equal(t, rmq.NewRmqID(1), lastConfirmedMessageID)
 }

--- a/internal/streamingnode/server/wal/adaptor/scanner_adaptor.go
+++ b/internal/streamingnode/server/wal/adaptor/scanner_adaptor.go
@@ -249,6 +249,11 @@ func (s *scannerAdaptorImpl) handleUpstream(msg message.ImmutableMessage) {
 
 		if len(msgs) > 0 {
 			// Push the confirmed messages into pending queue for consuming.
+			if s.logger.Level().Enabled(zap.DebugLevel) {
+				for _, m := range msgs {
+					s.logger.Debug("push committed message into pending queue", zap.Uint64("committedTimeTick", msg.TimeTick()), log.FieldMessage(m))
+				}
+			}
 			s.pendingQueue.Add(msgs)
 		}
 		if msg.IsPersisted() || s.pendingQueue.Len() == 0 {

--- a/internal/streamingnode/server/wal/interceptors/interceptor.go
+++ b/internal/streamingnode/server/wal/interceptors/interceptor.go
@@ -25,6 +25,7 @@ type InterceptorBuildParam struct {
 	ChannelInfo            types.PChannelInfo
 	WAL                    *syncutil.Future[wal.WAL]   // The wal final object, can be used after interceptor is ready.
 	LastTimeTickMessage    message.ImmutableMessage    // The last time tick message in wal.
+	LastConfirmedMessageID message.MessageID           // The last confirmed message id in wal.
 	WriteAheadBuffer       *wab.WriteAheadBuffer       // The write ahead buffer for the wal, used to erase the subscription of underlying wal.
 	MVCCManager            *mvcc.MVCCManager           // The MVCC manager for the wal, can be used to get the latest mvcc timetick.
 	InitialRecoverSnapshot *recovery.RecoverySnapshot  // The initial recover snapshot for the wal, used to recover the wal state.

--- a/internal/streamingnode/server/wal/interceptors/timetick/timetick_sync_operator.go
+++ b/internal/streamingnode/server/wal/interceptors/timetick/timetick_sync_operator.go
@@ -32,7 +32,7 @@ func newTimeTickSyncOperator(param *interceptors.InterceptorBuildParam) *timeTic
 			zap.Any("pchannel", param.ChannelInfo),
 		),
 		interceptorBuildParam: param,
-		ackManager:            ack.NewAckManager(param.LastTimeTickMessage.TimeTick(), param.LastTimeTickMessage.LastConfirmedMessageID(), metrics),
+		ackManager:            ack.NewAckManager(param.LastTimeTickMessage.TimeTick(), param.LastConfirmedMessageID, metrics),
 		ackDetails:            ack.NewAckDetails(),
 		sourceID:              paramtable.GetNodeID(),
 		metrics:               metrics,

--- a/internal/streamingnode/server/wal/recovery/recovery_storage_impl.go
+++ b/internal/streamingnode/server/wal/recovery/recovery_storage_impl.go
@@ -34,9 +34,10 @@ const (
 func RecoverRecoveryStorage(
 	ctx context.Context,
 	recoveryStreamBuilder RecoveryStreamBuilder,
+	cp *utility.WALCheckpoint,
 	lastTimeTickMessage message.ImmutableMessage,
 ) (RecoveryStorage, *RecoverySnapshot, error) {
-	rs := newRecoveryStorage(recoveryStreamBuilder.Channel())
+	rs := newRecoveryStorage(recoveryStreamBuilder.Channel(), cp)
 	if err := rs.recoverRecoveryInfoFromMeta(ctx, recoveryStreamBuilder.Channel(), lastTimeTickMessage); err != nil {
 		rs.Logger().Warn("recovery storage failed", zap.Error(err))
 		return nil, nil, err
@@ -65,7 +66,7 @@ func RecoverRecoveryStorage(
 }
 
 // newRecoveryStorage creates a new recovery storage.
-func newRecoveryStorage(channel types.PChannelInfo) *recoveryStorageImpl {
+func newRecoveryStorage(channel types.PChannelInfo, cp *utility.WALCheckpoint) *recoveryStorageImpl {
 	cfg := newConfig()
 	return &recoveryStorageImpl{
 		backgroundTaskNotifier: syncutil.NewAsyncTaskNotifier[struct{}](),
@@ -73,6 +74,7 @@ func newRecoveryStorage(channel types.PChannelInfo) *recoveryStorageImpl {
 		mu:                     sync.Mutex{},
 		currentClusterID:       paramtable.Get().CommonCfg.ClusterPrefix.GetValue(),
 		channel:                channel,
+		checkpoint:             cp,
 		dirtyCounter:           0,
 		persistNotifier:        make(chan struct{}, 1),
 		gracefulClosed:         false,
@@ -149,11 +151,6 @@ func (r *recoveryStorageImpl) ObserveMessage(ctx context.Context, msg message.Im
 			r.Logger().Warn("failed to ack broadcast message", zap.Error(err))
 			return err
 		}
-	}
-	if funcutil.IsControlChannel(msg.VChannel()) && msg.MessageType() != message.MessageTypeAlterReplicateConfig {
-		// message on control channel except AlterReplicateConfig message is just used to determine the DDL/DCL order,
-		// will not affect the recovery storage, so skip it.
-		return nil
 	}
 
 	r.mu.Lock()
@@ -292,6 +289,12 @@ func (r *recoveryStorageImpl) updateCheckpoint(msg message.ImmutableMessage) {
 
 // The incoming message id is always sorted with timetick.
 func (r *recoveryStorageImpl) handleMessage(msg message.ImmutableMessage) {
+	if funcutil.IsControlChannel(msg.VChannel()) && msg.MessageType() != message.MessageTypeAlterReplicateConfig {
+		// message on control channel except AlterReplicateConfig message is just used to determine the DDL/DCL order,
+		// will not affect the recovery storage, so skip it.
+		return
+	}
+
 	if msg.VChannel() != "" && msg.MessageType() != message.MessageTypeCreateCollection &&
 		msg.MessageType() != message.MessageTypeDropCollection && r.vchannels[msg.VChannel()] == nil && !funcutil.IsControlChannel(msg.VChannel()) {
 		r.detectInconsistency(msg, "vchannel not found")

--- a/pkg/streaming/util/message/builder.go
+++ b/pkg/streaming/util/message/builder.go
@@ -355,6 +355,11 @@ func (b *ImmutableTxnMessageBuilder) EstimateSize() int {
 	return size
 }
 
+// LastConfirmedMessageID returns the last confirmed message id of the txn.
+func (b *ImmutableTxnMessageBuilder) LastConfirmedMessageID() MessageID {
+	return b.begin.LastConfirmedMessageID()
+}
+
 // Messages returns the begin message and body messages.
 func (b *ImmutableTxnMessageBuilder) Messages() (ImmutableBeginTxnMessageV2, []ImmutableMessage) {
 	return b.begin, b.messages

--- a/pkg/streaming/util/message/marshal_log_object.go
+++ b/pkg/streaming/util/message/marshal_log_object.go
@@ -58,9 +58,6 @@ func (m *immutableMessageImpl) MarshalLogObject(enc zapcore.ObjectEncoder) error
 	}
 	if broadcast := m.BroadcastHeader(); broadcast != nil {
 		enc.AddInt64("broadcastID", int64(broadcast.BroadcastID))
-	}
-	if broadcast := m.BroadcastHeader(); broadcast != nil {
-		enc.AddInt64("broadcastID", int64(broadcast.BroadcastID))
 		enc.AddString("broadcastVChannels", strings.Join(broadcast.VChannels, ","))
 	}
 	if replicate := m.ReplicateHeader(); replicate != nil {

--- a/pkg/streaming/util/message/marshal_log_object.go
+++ b/pkg/streaming/util/message/marshal_log_object.go
@@ -59,6 +59,17 @@ func (m *immutableMessageImpl) MarshalLogObject(enc zapcore.ObjectEncoder) error
 	if broadcast := m.BroadcastHeader(); broadcast != nil {
 		enc.AddInt64("broadcastID", int64(broadcast.BroadcastID))
 	}
+	if broadcast := m.BroadcastHeader(); broadcast != nil {
+		enc.AddInt64("broadcastID", int64(broadcast.BroadcastID))
+		enc.AddString("broadcastVChannels", strings.Join(broadcast.VChannels, ","))
+	}
+	if replicate := m.ReplicateHeader(); replicate != nil {
+		enc.AddString("rClusterID", replicate.ClusterID)
+		enc.AddString("rMessageID", replicate.MessageID.String())
+		enc.AddString("rLastConfirmedMessageID", replicate.LastConfirmedMessageID.String())
+		enc.AddUint64("rTimeTick", replicate.TimeTick)
+		enc.AddString("rVchannel", replicate.VChannel)
+	}
 	enc.AddInt("size", len(m.payload))
 	marshalSpecializedHeader(m.MessageType(), m.Version(), m.properties[messageHeader], enc)
 	return nil


### PR DESCRIPTION
issue: #45088, #45086

- Message on control channel should trigger the checkpoint update.
- LastConfrimedMessageID should be recovered from the minimum of checkpoint or the LastConfirmedMessageID of uncommitted txn.
- Add more log info for wal debugging.