### PR TITLE
fix: [2.6] Handle all-null data in StringIndexSort to prevent load timeout(#45100)

### DIFF
--- a/internal/core/src/index/StringIndexSort.h
+++ b/internal/core/src/index/StringIndexSort.h
@@ -410,6 +410,7 @@ class StringIndexSortMmapImpl : public StringIndexSortImpl {
  private:
     char* mmap_data_ = nullptr;
     size_t mmap_size_ = 0;
+    size_t data_size_ = 0;  // Actual data size without padding
     std::string mmap_filepath_;
     size_t unique_count_ = 0;
 


### PR DESCRIPTION
Cherry-pick from master
pr: #45100

Related to #45081

StringIndexSort now properly handles collections with all-null string fields by:
- Removing the error thrown when unique_count is 0 in ParseBinaryData
- Adding alignment and padding support in mmap serialization (similar to ScalarIndexSort)
- Separating data_size_ from mmap_size_ to correctly parse data without reading padding

This fixes load collection timeout failures when all string field data is null, particularly affecting STL_SORT and TRIE index types.