### PR TITLE
fix: make ack of broadcaster cannot canceled by client

### DIFF
--- a/internal/streamingcoord/server/balancer/policy/vchannelfair/expected_layout.go
+++ b/internal/streamingcoord/server/balancer/policy/vchannelfair/expected_layout.go
@@ -45,6 +45,18 @@ type assignmentSnapshot struct {
 	GlobalUnbalancedScore float64
 }
 
+// Clone will clone the assignment snapshot.
+func (s *assignmentSnapshot) Clone() assignmentSnapshot {
+	assignments := make(map[types.ChannelID]types.PChannelInfoAssigned, len(s.Assignments))
+	for channelID, assignment := range s.Assignments {
+		assignments[channelID] = assignment
+	}
+	return assignmentSnapshot{
+		Assignments:           assignments,
+		GlobalUnbalancedScore: s.GlobalUnbalancedScore,
+	}
+}
+
 // streamingNodeInfo is the streaming node info for vchannel fair policy.
 type streamingNodeInfo struct {
 	AssignedVChannelCount int

--- a/internal/streamingcoord/server/balancer/policy/vchannelfair/pchannel_count_fair_test.go
+++ b/internal/streamingcoord/server/balancer/policy/vchannelfair/pchannel_count_fair_test.go
@@ -256,3 +256,20 @@ func newLayout(channels map[string]int, vchannels map[string]map[string]int64, s
 	}
 	return layout
 }
+
+func TestAssignmentClone(t *testing.T) {
+	snapshot := assignmentSnapshot{
+		Assignments: map[types.ChannelID]types.PChannelInfoAssigned{
+			newChannelID("c1"): {
+				Channel: types.PChannelInfo{
+					Name: "c1",
+				},
+			},
+		},
+	}
+	clonedSnapshot := snapshot.Clone()
+	clonedSnapshot.Assignments[newChannelID("c2")] = types.PChannelInfoAssigned{}
+	assert.Len(t, snapshot.Assignments, 1)
+	assert.Equal(t, snapshot.Assignments[newChannelID("c1")], clonedSnapshot.Assignments[newChannelID("c1")])
+	assert.Len(t, clonedSnapshot.Assignments, 2)
+}

--- a/internal/streamingcoord/server/balancer/policy/vchannelfair/vchannel_fair_policy.go
+++ b/internal/streamingcoord/server/balancer/policy/vchannelfair/vchannel_fair_policy.go
@@ -94,7 +94,7 @@ func (p *policy) Balance(currentLayout balancer.CurrentLayout) (layout balancer.
 
 	// 4. Do a DFS to make a greatest snapshot.
 	// The DFS will find the unbalance score minimized assignment based on current layout.
-	greatestSnapshot := snapshot
+	greatestSnapshot := snapshot.Clone()
 	p.assignChannels(expectedLayout, reassignChannelIDs, &greatestSnapshot)
 	if greatestSnapshot.GlobalUnbalancedScore < snapshot.GlobalUnbalancedScore-p.cfg.RebalanceTolerance {
 		if p.Logger().Level().Enabled(zap.DebugLevel) {

--- a/internal/streamingcoord/server/broadcaster/broadcast_task.go
+++ b/internal/streamingcoord/server/broadcaster/broadcast_task.go
@@ -416,7 +416,7 @@ func (b *broadcastTask) saveTaskIfDirty(ctx context.Context, logger *log.MLogger
 	logger = logger.With(zap.String("state", b.task.State.String()), zap.Int("ackedVChannelCount", ackedCount(b.task)))
 	if err := resource.Resource().StreamingCatalog().SaveBroadcastTask(ctx, b.Header().BroadcastID, b.task); err != nil {
 		logger.Warn("save broadcast task failed", zap.Error(err))
-		if ctx.Err() != nil {
+		if ctx.Err() == nil {
 			panic("critical error: the save broadcast task is failed before the context is done")
 		}
 		return err

--- a/internal/streamingcoord/server/service/broadcast.go
+++ b/internal/streamingcoord/server/service/broadcast.go
@@ -52,6 +52,8 @@ func (s *broadcastServceImpl) Ack(ctx context.Context, req *streamingpb.Broadcas
 	if err != nil {
 		return nil, err
 	}
+	// Once the ack is reached at streamingcoord, the ack operation should not be cancelable.
+	ctx = context.WithoutCancel(ctx)
 	if req.Message == nil {
 		// before 2.6.1, the request don't have the message field, only have the broadcast id and vchannel.
 		// so we need to use the legacy ack interface.

--- a/internal/streamingnode/client/handler/handler_client_impl.go
+++ b/internal/streamingnode/client/handler/handler_client_impl.go
@@ -15,6 +15,7 @@ import (
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/utility"
 	"github.com/milvus-io/milvus/internal/util/streamingutil/service/balancer/picker"
+	"github.com/milvus-io/milvus/internal/util/streamingutil/service/contextutil"
 	"github.com/milvus-io/milvus/internal/util/streamingutil/service/lazygrpc"
 	"github.com/milvus-io/milvus/internal/util/streamingutil/service/resolver"
 	"github.com/milvus-io/milvus/internal/util/streamingutil/status"
@@ -218,6 +219,8 @@ func (hc *handlerClientImpl) createHandlerAfterStreamingNodeReady(ctx context.Co
 		assign := hc.watcher.Get(ctx, pchannel)
 		if assign != nil {
 			// Find assignment, try to create producer on this assignment.
+			// pick the target streaming node to serve.
+			ctx = contextutil.WithPickServerID(ctx, assign.Node.ServerID)
 			createResult, err := create(ctx, assign)
 			if err == nil {
 				logger.Info("create handler success", zap.Any("assignment", assign), zap.Bool("isLocal", registry.IsLocal(createResult)))

--- a/internal/streamingnode/client/handler/producer/producer_impl.go
+++ b/internal/streamingnode/client/handler/producer/producer_impl.go
@@ -32,7 +32,9 @@ func CreateProducer(
 	opts *ProducerOptions,
 	handler streamingpb.StreamingNodeHandlerServiceClient,
 ) (Producer, error) {
-	ctx = createProduceRequest(ctx, opts)
+	ctx = contextutil.WithCreateProducer(ctx, &streamingpb.CreateProducerRequest{
+		Pchannel: types.NewProtoFromPChannelInfo(opts.Assignment.Channel),
+	})
 	streamClient, err := handler.Produce(ctx)
 	if err != nil {
 		return nil, err
@@ -78,16 +80,6 @@ func CreateProducer(
 	// Start the producer client.
 	go cli.execute()
 	return cli, nil
-}
-
-// createProduceRequest creates the produce request.
-func createProduceRequest(ctx context.Context, opts *ProducerOptions) context.Context {
-	// select server to consume.
-	ctx = contextutil.WithPickServerID(ctx, opts.Assignment.Node.ServerID)
-	// select channel to consume.
-	return contextutil.WithCreateProducer(ctx, &streamingpb.CreateProducerRequest{
-		Pchannel: types.NewProtoFromPChannelInfo(opts.Assignment.Channel),
-	})
 }
 
 // Expected message sequence:


### PR DESCRIPTION
issue: #45141

- make ack of broadcaster cannot canceled by rpc.
- make clone for assignment snapshot of wal balancer.
- add server id for GetReplicateCheckpoint to avoid failure.