### PR TITLE
doc: fix comment typo for log format

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -867,7 +867,7 @@ log:
     maxSize: 300 # The maximum size of a log file, unit: MB.
     maxAge: 10 # The maximum retention time before a log file is automatically cleared, unit: day. The minimum value is 1.
     maxBackups: 20 # The maximum number of log files to back up, unit: day. The minimum value is 1.
-  format: text # Milvus log format. Option: text and JSON
+  format: text # Milvus log format. Option: text and json
   stdout: true # Stdout enable or not
 
 grpc:


### PR DESCRIPTION
The original comment stated that the log format options were [text] and [JSON] (with uppercase 'JSON'). However, setting the value to [JSON] (uppercase) causes the program to panic at runtime. The actual valid option is [json]

panic stack:

2025-10-28T17:27:10.227358474+08:00 panic: unsupport log format: JSON

2025-10-28T17:27:10.227398624+08:00 goroutine 1 gp=0xc000002380 m=16 mp=0xc002300008 [running]:
panic({0x68e9bc0?, 0xc001fea210?})
2025-10-28T17:27:10.227460554+08:00 /usr/local/go/src/runtime/panic.go:811 +0x168 fp=0xc00210f180 sp=0xc00210f0d0 pc=0x2693908
[github.com/milvus-io/milvus/pkg/v2/log.NewTextEncoderByConfig(0xc00047b980)](https://github.com/milvus-io/milvus/pkg/v2/log.NewTextEncoderByConfig(0xc00047b980))
2025-10-28T17:27:10.227478324+08:00 /workspace/source/pkg/log/zap_text_encoder.go:148 +0x2db fp=0xc00210f350 sp=0xc00210f180 pc=0x2d2783b
2025-10-28T17:27:10.227503864+08:00 [github.com/milvus-io/milvus/pkg/v2/log.newZapTextEncoder(...)](https://github.com/milvus-io/milvus/pkg/v2/log.newZapTextEncoder(...))
2025-10-28T17:27:10.227524864+08:00 /workspace/source/pkg/log/config.go:84
2025-10-28T17:27:10.227537434+08:00 [github.com/milvus-io/milvus/pkg/v2/log.InitLoggerWithWriteSyncer](https://github.com/milvus-io/milvus/pkg/v2/log.InitLoggerWithWriteSyncer)(0xc00047b980, {0x7da0bd0, 0xc002208198}, {0xc00210f5c0, 0x1, 0x68e9bc0?})
2025-10-28T17:27:10.227542574+08:00 /workspace/source/pkg/log/log.go:125 +0xd6 fp=0xc00210f3e0 sp=0xc00210f350 pc=0x2d25456
2025-10-28T17:27:10.227546764+08:00 [github.com/milvus-io/milvus/pkg/v2/log.InitLogger](https://github.com/milvus-io/milvus/pkg/v2/log.InitLogger)(0xc00210f700, {0xc00210f5c0, 0x1, 0x1})
2025-10-28T17:27:10.227565374+08:00 /workspace/source/pkg/log/log.go:89 +0x42d fp=0xc00210f4f0 sp=0xc00210f3e0 pc=0x2d2512d
2025-10-28T17:27:10.227573624+08:00 [github.com/milvus-io/milvus/pkg/v2/util/logutil.SetupLogger.func1()](https://github.com/milvus-io/milvus/pkg/v2/util/logutil.SetupLogger.func1())
/workspace/source/pkg/util/logutil/logutil.go:144 +0x86 fp=0xc00210f5e0 sp=0xc00210f4f0 pc=0x33ebca6
2025-10-28T17:27:10.227594805+08:00 sync.(*Once).doSlow(0x7eab920?, 0x14?)
2025-10-28T17:27:10.227615825+08:00 /usr/local/go/src/sync/once.go:78 +0xab fp=0xc00210f638 sp=0xc00210f5e0 pc=0x26b9b4b
sync.(*Once).Do(...)
2025-10-28T17:27:10.227626915+08:00 /usr/local/go/src/sync/once.go:69
2025-10-28T17:27:10.227642465+08:00 [github.com/milvus-io/milvus/pkg/v2/util/logutil.SetupLogger(0xb1b6c68?)](https://github.com/milvus-io/milvus/pkg/v2/util/logutil.SetupLogger(0xb1b6c68?))
2025-10-28T17:27:10.227668425+08:00 /workspace/source/pkg/util/logutil/logutil.go:142 +0x3a fp=0xc00210f668 sp=0xc00210f638 pc=0x33ebbfa
2025-10-28T17:27:10.227687915+08:00 [github.com/milvus-io/milvus/cmd/roles.(*MilvusRoles).setupLogger(0x6cadf40?)](https://github.com/milvus-io/milvus/cmd/roles.(*MilvusRoles).setupLogger(0x6cadf40?))
2025-10-28T17:27:10.227694655+08:00 /workspace/source/cmd/roles/roles.go:240 +0x2ca fp=0xc00210f830 sp=0xc00210f668 pc=0x646bbca
[github.com/milvus-io/milvus/cmd/roles.(*MilvusRoles).Run(0xc001cfc780)](https://github.com/milvus-io/milvus/cmd/roles.(*MilvusRoles).Run(0xc001cfc780))
2025-10-28T17:27:10.227717725+08:00 /workspace/source/cmd/roles/roles.go:390 +0x7ea fp=0xc00210fba8 sp=0xc00210f830 pc=0x646cb2a
[github.com/milvus-io/milvus/cmd/milvus.(*run).execute](https://github.com/milvus-io/milvus/cmd/milvus.(*run).execute)(0xb1c1300, {0xc0003a2960, 0x3, 0x3}, 0xc0013d4fc0)
2025-10-28T17:27:10.227737445+08:00 /workspace/source/cmd/milvus/run.go:48 +0x2ae fp=0xc00210fc68 sp=0xc00210fba8 pc=0x6479e0e
2025-10-28T17:27:10.227756535+08:00 [github.com/milvus-io/milvus/cmd/milvus.RunMilvus](https://github.com/milvus-io/milvus/cmd/milvus.RunMilvus)({0xc0003a2960, 0x3, 0x3})
2025-10-28T17:27:10.227775215+08:00 /workspace/source/cmd/milvus/milvus.go:60 +0x1e2 fp=0xc00210fcd8 sp=0xc00210fc68 pc=0x6479ac2
2025-10-28T17:27:10.227791605+08:00 main.main()