### PR TITLE
enhance: [2.6] remove max vector field number limit

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -310,7 +310,7 @@ proxy:
       bufSize: 512 # The maximum number of messages can be buffered in the timeTick message stream of the proxy when producing messages.
   maxNameLength: 255 # The maximum length of the name or alias that can be created in Milvus, including the collection name, collection alias, partition name, and field name.
   maxFieldNum: 64 # The maximum number of field can be created when creating in a collection. It is strongly DISCOURAGED to set maxFieldNum >= 64.
-  maxVectorFieldNum: 4 # The maximum number of vector fields that can be specified in a collection. Value range: [1, 10].
+  maxVectorFieldNum: 4 # The maximum number of vector fields that can be specified in a collection
   maxShardNum: 16 # The maximum number of shards can be created when creating in a collection.
   maxDimension: 32768 # The maximum number of dimensions of a vector can have when creating in a collection.
   # Whether to produce gin logs.\n

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -1873,13 +1873,13 @@ func (p *proxyConfig) init(base *BaseTable) {
 		Version:      "2.4.0",
 		DefaultValue: "4",
 		PanicIfEmpty: true,
-		Doc:          "The maximum number of vector fields that can be specified in a collection. Value range: [1, 10].",
+		Doc:          "The maximum number of vector fields that can be specified in a collection",
 		Export:       true,
 	}
 	p.MaxVectorFieldNum.Init(base.mgr)
 
-	if p.MaxVectorFieldNum.GetAsInt() > 10 || p.MaxVectorFieldNum.GetAsInt() <= 0 {
-		panic(fmt.Sprintf("Maximum number of vector fields in a collection should be in (0, 10], not %d", p.MaxVectorFieldNum.GetAsInt()))
+	if p.MaxVectorFieldNum.GetAsInt() <= 0 {
+		panic("Maximum number of vector fields in a collection can't be negative")
 	}
 
 	p.MaxShardNum = ParamItem{


### PR DESCRIPTION
issue: #45150
pr: #45151

Removed the maximum limit constraint (value range [1, 10]) for vector fields in a collection to support more flexible schema design.