### PR TITLE
fix: add null check for packed_writer_ in JsonStatsParquetWriter::Close()

### DIFF
--- a/internal/core/src/index/json_stats/parquet_writer.cpp
+++ b/internal/core/src/index/json_stats/parquet_writer.cpp
@@ -46,8 +46,12 @@ JsonStatsParquetWriter::~JsonStatsParquetWriter() {
 
 void
 JsonStatsParquetWriter::Close() {
-    Flush();
-    packed_writer_->Close();
+    // check packed_writer_ initialized
+    if (packed_writer_) {
+        Flush();
+        // ignore close status here
+        auto _ = packed_writer_->Close();
+    }
 }
 
 void


### PR DESCRIPTION
Related to #45157

Fix a bug where DataNode panics when building json stats index throws an exception before the writer is initialized. The destructor would call Close() on an uninitialized packed_writer_ pointer, causing a null pointer dereference.

Changes:
- Add null check for packed_writer_ before calling Flush() and Close()
- Prevents null pointer dereference in edge cases
- Ignore close status as this is a cleanup operation

This ensures safe cleanup even when initialization fails due to exceptions.