### PR TITLE
enhance: increase session TTL from 10s to 30s

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -987,7 +987,7 @@ common:
     internaltlsEnabled: false
     tlsMode: 0
   session:
-    ttl: 10 # ttl value when session granting a lease to register service
+    ttl: 30 # ttl value when session granting a lease to register service
     retryTimes: 30 # retry times when session sending etcd requests
   locks:
     metrics:

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -47,7 +47,7 @@ const (
 	DefaultMiddlePriorityThreadCoreCoefficient = 5
 	DefaultLowPriorityThreadCoreCoefficient    = 1
 
-	DefaultSessionTTL        = 10 // s
+	DefaultSessionTTL        = 30 // s
 	DefaultSessionRetryTimes = 30
 
 	DefaultMaxDegree                = 56
@@ -846,7 +846,7 @@ Large numeric passwords require double quotes to avoid yaml parsing precision is
 	p.SessionTTL = ParamItem{
 		Key:          "common.session.ttl",
 		Version:      "2.0.0",
-		DefaultValue: "10",
+		DefaultValue: "30",
 		Doc:          "ttl value when session granting a lease to register service",
 		Export:       true,
 	}


### PR DESCRIPTION
issue: #45227
Increase the default session TTL to 30 seconds to tolerate etcd failover time. This prevents session expiration during etcd cluster failover, improving system stability.

When etcd undergoes failover (leader election or node restart), the previous 10s TTL was too short to survive the failover window, causing unnecessary session expiration and component restarts. The new 30s TTL provides sufficient buffer for etcd to complete failover while maintaining session liveness.

Changes:
- Update DefaultSessionTTL constant from 10 to 30
- Update SessionTTL ParamItem DefaultValue from "10" to "30"