### PR TITLE
fix: kafka should auto reset the offset from earliest to read

### DIFF
--- a/pkg/streaming/walimpls/impls/kafka/builder.go
+++ b/pkg/streaming/walimpls/impls/kafka/builder.go
@@ -54,6 +54,7 @@ func (b *builderImpl) getConsumerConfig() kafka.ConfigMap {
 	config := &paramtable.Get().KafkaCfg
 	consumerConfig := getBasicConfig(config)
 	consumerConfig.SetKey("allow.auto.create.topics", true)
+	consumerConfig.SetKey("auto.offset.reset", "earliest")
 	for k, v := range config.ConsumerExtraConfig.GetValue() {
 		consumerConfig.SetKey(k, v)
 	}


### PR DESCRIPTION
issue: #44172, #45210, #44851

kafka will auto reset the offset to "latest" if the offset is Out-of-range. the recovery of milvus wal cannot read any message from that. So once the offset is out-of-range, kafka should read from eariest to read the latest uncleared data.

https://kafka.apache.org/documentation/#consumerconfigs_auto.offset.reset
