### PR TITLE
fix: Fix load segment failed due to get disk usage error

### DIFF
--- a/internal/core/src/storage/LocalChunkManager.cpp
+++ b/internal/core/src/storage/LocalChunkManager.cpp
@@ -264,7 +264,7 @@ LocalChunkManager::GetSizeOfDir(const std::string& dir) {
             }
             ThrowInfo(FileReadFailed,
                       fmt::format("get status of {} failed, error: {}",
-                                  it->path(),
+                                  it->path().string(),
                                   status_ec.message()));
         }
 
@@ -280,7 +280,7 @@ LocalChunkManager::GetSizeOfDir(const std::string& dir) {
                 }
                 ThrowInfo(FileReadFailed,
                           fmt::format("get size of file {} failed, error: {}",
-                                      it->path(),
+                                      it->path().string(),
                                       file_size_ec.message()));
             }
             total_file_size += file_size;


### PR DESCRIPTION
When getting disk usage, files or directories may be removed concurrently due to segment release. This PR ignores “file or directory does not exist” errors in such cases.

issue: https://github.com/milvus-io/milvus/issues/45239