### PR TITLE
enhance: [StorageV2] Refactor binlog reader with FFI packed reader integration

### DIFF
--- a/internal/core/thirdparty/milvus-storage/CMakeLists.txt
+++ b/internal/core/thirdparty/milvus-storage/CMakeLists.txt
@@ -14,7 +14,7 @@
 # Update milvus-storage_VERSION for the first occurrence
 milvus_add_pkg_config("milvus-storage")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( milvus-storage_VERSION e5f5b4c )
+set( milvus-storage_VERSION cbcc922 )
 set( GIT_REPOSITORY  "https://github.com/milvus-io/milvus-storage.git")
 message(STATUS "milvus-storage repo: ${GIT_REPOSITORY}")
 message(STATUS "milvus-storage version: ${milvus-storage_VERSION}")

--- a/internal/datanode/compactor/mix_compactor_test.go
+++ b/internal/datanode/compactor/mix_compactor_test.go
@@ -1110,10 +1110,9 @@ func genTestCollectionMeta() *etcdpb.CollectionMeta {
 					},
 				},
 				{
-					FieldID:      Int64FieldWithDefaultValue,
-					Name:         "field_int64_with_default_value",
-					IsPrimaryKey: true,
-					DataType:     schemapb.DataType_Int64,
+					FieldID:  Int64FieldWithDefaultValue,
+					Name:     "field_int64_with_default_value",
+					DataType: schemapb.DataType_Int64,
 					DefaultValue: &schemapb.ValueField{
 						Data: &schemapb.ValueField_LongData{
 							LongData: 10,

--- a/internal/storage/rw.go
+++ b/internal/storage/rw.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	sio "io"
-	"path"
 	"sort"
 
 	"github.com/samber/lo"
@@ -274,22 +273,12 @@ func NewBinlogRecordReader(ctx context.Context, binlogs []*datapb.FieldBinlog, s
 		sort.Slice(binlogs, func(i, j int) bool {
 			return binlogs[i].GetFieldID() < binlogs[j].GetFieldID()
 		})
-		binlogLists := lo.Map(binlogs, func(fieldBinlog *datapb.FieldBinlog, _ int) []*datapb.Binlog {
-			return fieldBinlog.GetBinlogs()
-		})
-		bucketName := rwOptions.storageConfig.BucketName
-		paths := make([][]string, len(binlogLists[0]))
-		for _, binlogs := range binlogLists {
-			for j, binlog := range binlogs {
-				logPath := binlog.GetLogPath()
-				if rwOptions.storageConfig.StorageType != "local" {
-					logPath = path.Join(bucketName, logPath)
-				}
-				paths[j] = append(paths[j], logPath)
-			}
+
+		var err error
+		rr, err = NewRecordReaderFromBinlogs(binlogs, schema, rwOptions.bufferSize, rwOptions.storageConfig, pluginContext)
+		if err != nil {
+			return nil, err
 		}
-		// FIXME: add needed fields support
-		rr = newIterativePackedRecordReader(paths, schema, rwOptions.bufferSize, rwOptions.storageConfig, pluginContext)
 	default:
 		return nil, merr.WrapErrServiceInternal(fmt.Sprintf("unsupported storage version %d", rwOptions.version))
 	}

--- a/internal/storage/rw_test.go
+++ b/internal/storage/rw_test.go
@@ -96,26 +96,32 @@ func (s *PackedBinlogRecordSuite) TestPackedBinlogRecordIntegration() {
 		{
 			GroupID: 0,
 			Columns: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12},
+			Fields:  []int64{0, 1, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 101},
 		},
 		{
 			GroupID: 102,
 			Columns: []int{13},
+			Fields:  []int64{102},
 		},
 		{
 			GroupID: 103,
 			Columns: []int{14},
+			Fields:  []int64{103},
 		},
 		{
 			GroupID: 104,
 			Columns: []int{15},
+			Fields:  []int64{104},
 		},
 		{
 			GroupID: 105,
 			Columns: []int{16},
+			Fields:  []int64{105},
 		},
 		{
 			GroupID: 106,
 			Columns: []int{17},
+			Fields:  []int64{106},
 		},
 	}
 	wOption := []RwOption{

--- a/internal/storagev2/packed/packed_reader_ffi.go
+++ b/internal/storagev2/packed/packed_reader_ffi.go
@@ -1,0 +1,322 @@
+// Copyright 2023 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packed
+
+/*
+#cgo pkg-config: milvus_core milvus-storage
+
+#include <stdlib.h>
+#include "milvus-storage/ffi_c.h"
+#include "arrow/c/abi.h"
+#include "arrow/c/helpers.h"
+*/
+import "C"
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+	"unsafe"
+
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/cdata"
+
+	"github.com/milvus-io/milvus/pkg/v2/proto/indexcgopb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
+)
+
+// Property keys - matching milvus-storage/properties.h
+const (
+	PROPERTY_FS_ADDRESS                = "fs.address"
+	PROPERTY_FS_BUCKET_NAME            = "fs.bucket_name"
+	PROPERTY_FS_ACCESS_KEY_ID          = "fs.access_key_id"
+	PROPERTY_FS_ACCESS_KEY_VALUE       = "fs.access_key_value"
+	PROPERTY_FS_ROOT_PATH              = "fs.root_path"
+	PROPERTY_FS_STORAGE_TYPE           = "fs.storage_type"
+	PROPERTY_FS_CLOUD_PROVIDER         = "fs.cloud_provider"
+	PROPERTY_FS_IAM_ENDPOINT           = "fs.iam_endpoint"
+	PROPERTY_FS_LOG_LEVEL              = "fs.log_level"
+	PROPERTY_FS_REGION                 = "fs.region"
+	PROPERTY_FS_USE_SSL                = "fs.use_ssl"
+	PROPERTY_FS_SSL_CA_CERT            = "fs.ssl_ca_cert"
+	PROPERTY_FS_USE_IAM                = "fs.use_iam"
+	PROPERTY_FS_USE_VIRTUAL_HOST       = "fs.use_virtual_host"
+	PROPERTY_FS_REQUEST_TIMEOUT_MS     = "fs.request_timeout_ms"
+	PROPERTY_FS_GCP_CREDENTIAL_JSON    = "fs.gcp_credential_json"
+	PROPERTY_FS_USE_CUSTOM_PART_UPLOAD = "fs.use_custom_part_upload"
+)
+
+// MakePropertiesFromStorageConfig creates a Properties object from StorageConfig
+// This function converts a StorageConfig structure into a Properties object by
+// calling the FFI properties_create function. All configuration fields from
+// StorageConfig are mapped to corresponding key-value pairs in Properties.
+func MakePropertiesFromStorageConfig(storageConfig *indexpb.StorageConfig) (*C.Properties, error) {
+	if storageConfig == nil {
+		return nil, fmt.Errorf("storageConfig is required")
+	}
+
+	// Prepare key-value pairs from StorageConfig
+	var keys []string
+	var values []string
+
+	// Add non-empty string fields
+	if storageConfig.GetAddress() != "" {
+		keys = append(keys, PROPERTY_FS_ADDRESS)
+		values = append(values, storageConfig.GetAddress())
+	}
+	if storageConfig.GetBucketName() != "" {
+		keys = append(keys, PROPERTY_FS_BUCKET_NAME)
+		values = append(values, storageConfig.GetBucketName())
+	}
+	if storageConfig.GetAccessKeyID() != "" {
+		keys = append(keys, PROPERTY_FS_ACCESS_KEY_ID)
+		values = append(values, storageConfig.GetAccessKeyID())
+	}
+	if storageConfig.GetSecretAccessKey() != "" {
+		keys = append(keys, PROPERTY_FS_ACCESS_KEY_VALUE)
+		values = append(values, storageConfig.GetSecretAccessKey())
+	}
+	if storageConfig.GetRootPath() != "" {
+		keys = append(keys, PROPERTY_FS_ROOT_PATH)
+		values = append(values, storageConfig.GetRootPath())
+	}
+	if storageConfig.GetStorageType() != "" {
+		keys = append(keys, PROPERTY_FS_STORAGE_TYPE)
+		values = append(values, storageConfig.GetStorageType())
+	}
+	if storageConfig.GetCloudProvider() != "" {
+		keys = append(keys, PROPERTY_FS_CLOUD_PROVIDER)
+		values = append(values, storageConfig.GetCloudProvider())
+	}
+	if storageConfig.GetIAMEndpoint() != "" {
+		keys = append(keys, PROPERTY_FS_IAM_ENDPOINT)
+		values = append(values, storageConfig.GetIAMEndpoint())
+	}
+	// Always add log level if any string field is set (matching C++ behavior)
+	keys = append(keys, PROPERTY_FS_LOG_LEVEL)
+	values = append(values, "Warn")
+
+	if storageConfig.GetRegion() != "" {
+		keys = append(keys, PROPERTY_FS_REGION)
+		values = append(values, storageConfig.GetRegion())
+	}
+	if storageConfig.GetSslCACert() != "" {
+		keys = append(keys, PROPERTY_FS_SSL_CA_CERT)
+		values = append(values, storageConfig.GetSslCACert())
+	}
+	if storageConfig.GetGcpCredentialJSON() != "" {
+		keys = append(keys, PROPERTY_FS_GCP_CREDENTIAL_JSON)
+		values = append(values, storageConfig.GetGcpCredentialJSON())
+	}
+
+	// Add boolean fields
+	keys = append(keys, PROPERTY_FS_USE_SSL)
+	if storageConfig.GetUseSSL() {
+		values = append(values, "true")
+	} else {
+		values = append(values, "false")
+	}
+
+	keys = append(keys, PROPERTY_FS_USE_IAM)
+	if storageConfig.GetUseIAM() {
+		values = append(values, "true")
+	} else {
+		values = append(values, "false")
+	}
+
+	keys = append(keys, PROPERTY_FS_USE_VIRTUAL_HOST)
+	if storageConfig.GetUseVirtualHost() {
+		values = append(values, "true")
+	} else {
+		values = append(values, "false")
+	}
+
+	keys = append(keys, PROPERTY_FS_USE_CUSTOM_PART_UPLOAD)
+	values = append(values, "true") // hardcoded to true as in the original code
+
+	// Add integer field
+	keys = append(keys, PROPERTY_FS_REQUEST_TIMEOUT_MS)
+	values = append(values, strconv.FormatInt(storageConfig.GetRequestTimeoutMs(), 10))
+
+	// Convert to C arrays
+	cKeys := make([]*C.char, len(keys))
+	cValues := make([]*C.char, len(values))
+	for i := range keys {
+		cKeys[i] = C.CString(keys[i])
+		cValues[i] = C.CString(values[i])
+	}
+	// Defer cleanup of all C strings
+	defer func() {
+		for i := range cKeys {
+			C.free(unsafe.Pointer(cKeys[i]))
+			C.free(unsafe.Pointer(cValues[i]))
+		}
+	}()
+
+	// Create Properties using FFI
+	properties := &C.Properties{}
+	var cKeysPtr **C.char
+	var cValuesPtr **C.char
+	if len(cKeys) > 0 {
+		cKeysPtr = &cKeys[0]
+		cValuesPtr = &cValues[0]
+	}
+
+	result := C.properties_create(
+		(**C.char)(unsafe.Pointer(cKeysPtr)),
+		(**C.char)(unsafe.Pointer(cValuesPtr)),
+		C.size_t(len(keys)),
+		properties,
+	)
+
+	err := HandleFFIResult(result)
+	if err != nil {
+		return nil, err
+	}
+	return properties, nil
+}
+
+func HandleFFIResult(ffiResult C.FFIResult) error {
+	defer C.FreeFFIResult(&ffiResult)
+	if C.IsSuccess(&ffiResult) == 0 {
+		errMsg := C.GetErrorMessage(&ffiResult)
+		errStr := "Unknown error"
+		if errMsg != nil {
+			errStr = C.GoString(errMsg)
+		}
+
+		return fmt.Errorf("failed to create properties: %s", errStr)
+	}
+	return nil
+}
+
+func NewFFIPackedReader(manifest string, schema *arrow.Schema, neededColumns []string, bufferSize int64, storageConfig *indexpb.StorageConfig, storagePluginContext *indexcgopb.StoragePluginContext) (reader *FFIPackedReader, err error) {
+	if storageConfig == nil {
+		return nil, fmt.Errorf("storageConfig is required")
+	}
+
+	cManifest := C.CString(manifest)
+	defer C.free(unsafe.Pointer(cManifest))
+
+	var cas cdata.CArrowSchema
+	cdata.ExportArrowSchema(schema, &cas)
+	cSchema := (*C.struct_ArrowSchema)(unsafe.Pointer(&cas))
+	defer cdata.ReleaseCArrowSchema(&cas)
+
+	cProperties, err := MakePropertiesFromStorageConfig(storageConfig)
+	if err != nil {
+		return nil, err
+	}
+	defer C.properties_free(cProperties)
+
+	cNeededColumn := make([]*C.char, len(neededColumns))
+	for i, columnName := range neededColumns {
+		cNeededColumn[i] = C.CString(columnName)
+		defer C.free(unsafe.Pointer(cNeededColumn[i]))
+	}
+	cNeededColumnArray := (**C.char)(unsafe.Pointer(&cNeededColumn[0]))
+	cNumColumns := C.size_t(len(neededColumns))
+
+	var readerHandler C.ReaderHandle
+
+	result := C.reader_new(cManifest, cSchema, cNeededColumnArray, cNumColumns, cProperties, &readerHandler)
+
+	err = HandleFFIResult(result)
+	if err != nil {
+		return nil, err
+	}
+
+	// handle initialization cleanup
+	defer func() {
+		if err != nil {
+			C.reader_destroy(readerHandler)
+		}
+	}()
+
+	// Get the ArrowArrayStream
+	var cStream cdata.CArrowArrayStream
+
+	result = C.get_record_batch_reader(readerHandler, nil, (*C.struct_ArrowArrayStream)(unsafe.Pointer(&cStream)))
+	err = HandleFFIResult(result)
+	if err != nil {
+		return nil, err
+	}
+
+	// Import the stream as a RecordReader
+	recordReader, err := cdata.ImportCRecordReader(&cStream, schema)
+	if err != nil {
+		return nil, fmt.Errorf("failed to import record reader: %w", err)
+	}
+
+	return &FFIPackedReader{
+		ffiReaderHandle: readerHandler,
+		recordReader:    recordReader,
+		schema:          schema,
+	}, nil
+}
+
+// ReadNext reads the next record batch from the reader
+func (r *FFIPackedReader) ReadNext() (arrow.Record, error) {
+	if r.recordReader == nil {
+		return nil, io.EOF
+	}
+
+	// no need to manual release
+	// stream reader will release previous one
+
+	// Read next record from the stream
+	rec, err := r.recordReader.Read()
+	if err != nil {
+		if err == io.EOF {
+			return nil, io.EOF
+		}
+		return nil, fmt.Errorf("failed to read next record: %w", err)
+	}
+
+	return rec, nil
+}
+
+// Close closes the FFI reader
+func (r *FFIPackedReader) Close() error {
+	// no need to manual release current batch
+	// stream reader handles it
+
+	if r.recordReader != nil {
+		r.recordReader = nil
+	}
+
+	if r.ffiReaderHandle != 0 {
+		C.reader_destroy(r.ffiReaderHandle)
+	}
+
+	return nil
+}
+
+// Schema returns the schema of the reader
+func (r *FFIPackedReader) Schema() *arrow.Schema {
+	return r.schema
+}
+
+// Retain increases the reference count
+func (r *FFIPackedReader) Retain() {
+}
+
+// Release decreases the reference count
+func (r *FFIPackedReader) Release() {
+	r.Close()
+}
+
+// Ensure FFIPackedReader implements array.RecordReader interface
+// var _ array.RecordReader = (*FFIPackedReader)(nil)

--- a/internal/storagev2/packed/packed_reader_ffi.go
+++ b/internal/storagev2/packed/packed_reader_ffi.go
@@ -39,23 +39,23 @@ import (
 
 // Property keys - matching milvus-storage/properties.h
 const (
-	PROPERTY_FS_ADDRESS                = "fs.address"
-	PROPERTY_FS_BUCKET_NAME            = "fs.bucket_name"
-	PROPERTY_FS_ACCESS_KEY_ID          = "fs.access_key_id"
-	PROPERTY_FS_ACCESS_KEY_VALUE       = "fs.access_key_value"
-	PROPERTY_FS_ROOT_PATH              = "fs.root_path"
-	PROPERTY_FS_STORAGE_TYPE           = "fs.storage_type"
-	PROPERTY_FS_CLOUD_PROVIDER         = "fs.cloud_provider"
-	PROPERTY_FS_IAM_ENDPOINT           = "fs.iam_endpoint"
-	PROPERTY_FS_LOG_LEVEL              = "fs.log_level"
-	PROPERTY_FS_REGION                 = "fs.region"
-	PROPERTY_FS_USE_SSL                = "fs.use_ssl"
-	PROPERTY_FS_SSL_CA_CERT            = "fs.ssl_ca_cert"
-	PROPERTY_FS_USE_IAM                = "fs.use_iam"
-	PROPERTY_FS_USE_VIRTUAL_HOST       = "fs.use_virtual_host"
-	PROPERTY_FS_REQUEST_TIMEOUT_MS     = "fs.request_timeout_ms"
-	PROPERTY_FS_GCP_CREDENTIAL_JSON    = "fs.gcp_credential_json"
-	PROPERTY_FS_USE_CUSTOM_PART_UPLOAD = "fs.use_custom_part_upload"
+	PropertyFSAddress             = "fs.address"
+	PropertyFSBucketName          = "fs.bucket_name"
+	PropertyFSAccessKeyID         = "fs.access_key_id"
+	PropertyFSAccessKeyValue      = "fs.access_key_value"
+	PropertyFSRootPath            = "fs.root_path"
+	PropertyFSStorageType         = "fs.storage_type"
+	PropertyFSCloudProvider       = "fs.cloud_provider"
+	PropertyFSIAMEndpoint         = "fs.iam_endpoint"
+	PropertyFSLogLevel            = "fs.log_level"
+	PropertyFSRegion              = "fs.region"
+	PropertyFSUseSSL              = "fs.use_ssl"
+	PropertyFSSSLCACert           = "fs.ssl_ca_cert"
+	PropertyFSUseIAM              = "fs.use_iam"
+	PropertyFSUseVirtualHost      = "fs.use_virtual_host"
+	PropertyFSRequestTimeoutMS    = "fs.request_timeout_ms"
+	PropertyFSGCPCredentialJSON   = "fs.gcp_credential_json"
+	PropertyFSUseCustomPartUpload = "fs.use_custom_part_upload"
 )
 
 // MakePropertiesFromStorageConfig creates a Properties object from StorageConfig
@@ -73,81 +73,81 @@ func MakePropertiesFromStorageConfig(storageConfig *indexpb.StorageConfig) (*C.P
 
 	// Add non-empty string fields
 	if storageConfig.GetAddress() != "" {
-		keys = append(keys, PROPERTY_FS_ADDRESS)
+		keys = append(keys, PropertyFSAddress)
 		values = append(values, storageConfig.GetAddress())
 	}
 	if storageConfig.GetBucketName() != "" {
-		keys = append(keys, PROPERTY_FS_BUCKET_NAME)
+		keys = append(keys, PropertyFSBucketName)
 		values = append(values, storageConfig.GetBucketName())
 	}
 	if storageConfig.GetAccessKeyID() != "" {
-		keys = append(keys, PROPERTY_FS_ACCESS_KEY_ID)
+		keys = append(keys, PropertyFSAccessKeyID)
 		values = append(values, storageConfig.GetAccessKeyID())
 	}
 	if storageConfig.GetSecretAccessKey() != "" {
-		keys = append(keys, PROPERTY_FS_ACCESS_KEY_VALUE)
+		keys = append(keys, PropertyFSAccessKeyValue)
 		values = append(values, storageConfig.GetSecretAccessKey())
 	}
 	if storageConfig.GetRootPath() != "" {
-		keys = append(keys, PROPERTY_FS_ROOT_PATH)
+		keys = append(keys, PropertyFSRootPath)
 		values = append(values, storageConfig.GetRootPath())
 	}
 	if storageConfig.GetStorageType() != "" {
-		keys = append(keys, PROPERTY_FS_STORAGE_TYPE)
+		keys = append(keys, PropertyFSStorageType)
 		values = append(values, storageConfig.GetStorageType())
 	}
 	if storageConfig.GetCloudProvider() != "" {
-		keys = append(keys, PROPERTY_FS_CLOUD_PROVIDER)
+		keys = append(keys, PropertyFSCloudProvider)
 		values = append(values, storageConfig.GetCloudProvider())
 	}
 	if storageConfig.GetIAMEndpoint() != "" {
-		keys = append(keys, PROPERTY_FS_IAM_ENDPOINT)
+		keys = append(keys, PropertyFSIAMEndpoint)
 		values = append(values, storageConfig.GetIAMEndpoint())
 	}
 	// Always add log level if any string field is set (matching C++ behavior)
-	keys = append(keys, PROPERTY_FS_LOG_LEVEL)
+	keys = append(keys, PropertyFSLogLevel)
 	values = append(values, "Warn")
 
 	if storageConfig.GetRegion() != "" {
-		keys = append(keys, PROPERTY_FS_REGION)
+		keys = append(keys, PropertyFSRegion)
 		values = append(values, storageConfig.GetRegion())
 	}
 	if storageConfig.GetSslCACert() != "" {
-		keys = append(keys, PROPERTY_FS_SSL_CA_CERT)
+		keys = append(keys, PropertyFSSSLCACert)
 		values = append(values, storageConfig.GetSslCACert())
 	}
 	if storageConfig.GetGcpCredentialJSON() != "" {
-		keys = append(keys, PROPERTY_FS_GCP_CREDENTIAL_JSON)
+		keys = append(keys, PropertyFSGCPCredentialJSON)
 		values = append(values, storageConfig.GetGcpCredentialJSON())
 	}
 
 	// Add boolean fields
-	keys = append(keys, PROPERTY_FS_USE_SSL)
+	keys = append(keys, PropertyFSUseSSL)
 	if storageConfig.GetUseSSL() {
 		values = append(values, "true")
 	} else {
 		values = append(values, "false")
 	}
 
-	keys = append(keys, PROPERTY_FS_USE_IAM)
+	keys = append(keys, PropertyFSUseIAM)
 	if storageConfig.GetUseIAM() {
 		values = append(values, "true")
 	} else {
 		values = append(values, "false")
 	}
 
-	keys = append(keys, PROPERTY_FS_USE_VIRTUAL_HOST)
+	keys = append(keys, PropertyFSUseVirtualHost)
 	if storageConfig.GetUseVirtualHost() {
 		values = append(values, "true")
 	} else {
 		values = append(values, "false")
 	}
 
-	keys = append(keys, PROPERTY_FS_USE_CUSTOM_PART_UPLOAD)
+	keys = append(keys, PropertyFSUseCustomPartUpload)
 	values = append(values, "true") // hardcoded to true as in the original code
 
 	// Add integer field
-	keys = append(keys, PROPERTY_FS_REQUEST_TIMEOUT_MS)
+	keys = append(keys, PropertyFSRequestTimeoutMS)
 	values = append(values, strconv.FormatInt(storageConfig.GetRequestTimeoutMs(), 10))
 
 	// Convert to C arrays

--- a/internal/storagev2/packed/type.go
+++ b/internal/storagev2/packed/type.go
@@ -18,6 +18,7 @@ package packed
 #include <stdlib.h>
 #include "arrow/c/abi.h"
 #include "arrow/c/helpers.h"
+#include "milvus-storage/ffi_c.h"
 #include "segcore/packed_reader_c.h"
 #include "segcore/packed_writer_c.h"
 */
@@ -25,6 +26,7 @@ import "C"
 
 import (
 	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/arrio"
 	"github.com/apache/arrow/go/v17/arrow/cdata"
 )
 
@@ -37,6 +39,13 @@ type PackedReader struct {
 	arr           *cdata.CArrowArray
 	schema        *arrow.Schema
 	currentBatch  arrow.Record
+}
+
+type FFIPackedReader struct {
+	ffiReaderHandle C.ReaderHandle
+	// cPackedReader C.CFFIPackedReader
+	recordReader arrio.Reader
+	schema       *arrow.Schema
 }
 
 type (


### PR DESCRIPTION
Related to #45132

Refactor the binlog record reader to properly integrate with the FFI-based packed reader, enabling automatic detection of binlog formats and seamless fallback handling between legacy and manifest-based reading paths.

- **Binlog reader refactoring**: Extract `NewRecordReaderFromBinlogs` to handle both legacy and manifest-based binlogs
  - Automatically detect binlog format by checking `ChildFields` presence
  - Route to appropriate reader implementation (iterative vs manifest-based)
- **ManifestReader implementation**: Add full manifest generation and reading support
  - Convert `FieldBinlog` structures to manifest JSON format
  - Support column projection with `neededColumns` configuration
  - Integrate with FFIPackedReader for efficient data streaming
- **FFI bindings**: Implement complete CGO wrapper for milvus-storage FFI interface
  - Add `MakePropertiesFromStorageConfig` to convert storage config to C Properties
  - Implement `FFIPackedReader` with Arrow C Data Interface integration
  - Handle memory management and cleanup for C resources
- **Test improvements**: Add `Fields` parameter to test cases for better coverage
- **Dependency update**: Bump milvus-storage version to cbcc922 for latest FFI support