### PR TITLE
fix: ddl framework bug patch

### DIFF
--- a/internal/datacoord/index_meta_test.go
+++ b/internal/datacoord/index_meta_test.go
@@ -134,8 +134,8 @@ func TestMeta_ScalarAutoIndex(t *testing.T) {
 			},
 		}
 		tmpIndexID, err := m.CanCreateIndex(req, false)
-		assert.NoError(t, err)
-		assert.Equal(t, int64(indexID), tmpIndexID)
+		assert.ErrorIs(t, err, errIndexOperationIgnored)
+		assert.Zero(t, tmpIndexID)
 	})
 
 	t.Run("user index params not consistent", func(t *testing.T) {
@@ -203,8 +203,8 @@ func TestMeta_ScalarAutoIndex(t *testing.T) {
 			},
 		}
 		tmpIndexID, err := m.CanCreateIndex(req, false)
-		assert.NoError(t, err)
-		assert.Equal(t, int64(indexID), tmpIndexID)
+		assert.ErrorIs(t, err, errIndexOperationIgnored)
+		assert.Zero(t, tmpIndexID)
 		newIndexParams := req.GetIndexParams()
 		assert.Equal(t, len(newIndexParams), 1)
 		assert.Equal(t, newIndexParams[0].Key, common.IndexTypeKey)
@@ -287,8 +287,8 @@ func TestMeta_CanCreateIndex(t *testing.T) {
 		assert.NoError(t, err)
 
 		tmpIndexID, err = m.CanCreateIndex(req, false)
-		assert.NoError(t, err)
-		assert.Equal(t, indexID, tmpIndexID)
+		assert.ErrorIs(t, err, errIndexOperationIgnored)
+		assert.Zero(t, tmpIndexID)
 	})
 
 	t.Run("params not consistent", func(t *testing.T) {
@@ -326,8 +326,8 @@ func TestMeta_CanCreateIndex(t *testing.T) {
 		req.UserIndexParams = []*commonpb.KeyValuePair{{Key: common.IndexTypeKey, Value: "AUTOINDEX"}, {Key: common.MetricTypeKey, Value: "COSINE"}}
 		req.UserAutoindexMetricTypeSpecified = false
 		tmpIndexID, err = m.CanCreateIndex(req, false)
-		assert.NoError(t, err)
-		assert.Equal(t, indexID, tmpIndexID)
+		assert.ErrorIs(t, err, errIndexOperationIgnored)
+		assert.Zero(t, tmpIndexID)
 		// req should follow the meta
 		assert.Equal(t, "L2", req.GetUserIndexParams()[1].Value)
 		assert.Equal(t, "L2", req.GetIndexParams()[1].Value)

--- a/internal/querycoordv2/job/job_load.go
+++ b/internal/querycoordv2/job/job_load.go
@@ -101,7 +101,7 @@ func (job *LoadCollectionJob) Execute() error {
 
 	// 2. put load info meta
 	fieldIndexIDs := make(map[int64]int64, len(req.GetLoadFields()))
-	fieldIDs := make([]int64, len(req.GetLoadFields()))
+	fieldIDs := make([]int64, 0, len(req.GetLoadFields()))
 	for _, loadField := range req.GetLoadFields() {
 		if loadField.GetIndexId() != 0 {
 			fieldIndexIDs[loadField.GetFieldId()] = loadField.GetIndexId()

--- a/internal/rootcoord/ddl_callbacks_alter_collection_name.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_name.go
@@ -104,8 +104,12 @@ func (c *Core) broadcastAlterCollectionForRenameCollection(ctx context.Context, 
 }
 
 func (c *Core) validateEncryption(ctx context.Context, oldDBName string, newDBName string) error {
-	// old and new DB names are filled in Prepare, shouldn't be empty here
+	if oldDBName == newDBName {
+		return nil
+	}
+	// Check if renaming across databases with encryption enabled
 
+	// old and new DB names are filled in Prepare, shouldn't be empty here
 	originalDB, err := c.meta.GetDatabaseByName(ctx, oldDBName, typeutil.MaxTimestamp)
 	if err != nil {
 		return fmt.Errorf("failed to get original database: %w", err)

--- a/internal/rootcoord/ddl_callbacks_alter_database.go
+++ b/internal/rootcoord/ddl_callbacks_alter_database.go
@@ -18,7 +18,6 @@ package rootcoord
 
 import (
 	"context"
-	"strings"
 
 	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
@@ -39,7 +38,9 @@ import (
 )
 
 func (c *Core) broadcastAlterDatabase(ctx context.Context, req *rootcoordpb.AlterDatabaseRequest) error {
-	req.DbName = strings.TrimSpace(req.DbName)
+	if req.GetDbName() == "" {
+		return merr.WrapErrParameterInvalidMsg("alter database failed, database name does not exists")
+	}
 	if req.GetProperties() == nil && req.GetDeleteKeys() == nil {
 		return merr.WrapErrParameterInvalidMsg("alter database with empty properties and delete keys, expected to set either properties or delete keys")
 	}

--- a/internal/streamingcoord/server/broadcaster/tombstone_scheduler.go
+++ b/internal/streamingcoord/server/broadcaster/tombstone_scheduler.go
@@ -121,4 +121,6 @@ func (s *tombstoneScheduler) triggerGCTombstone() {
 			return
 		}
 	}
+	// all the tombstones are dropped, reset the tombstones.
+	s.tombstones = make([]tombstoneItem, 0)
 }


### PR DESCRIPTION
issue: #45080, #45274, #45285

- LoadCollection doesn't ignore the ignorable request, for false field array.
- CreatIndex doesn't ignore the ignorable request, for wrong index.
- index meta is not thread safe.
- lost parameter check of DDL.
- DDL Ack scheduler may get stuck and DDL is block until next incoming DDL.
- lost parameter checker of ddl