### PR TITLE
fix: ddl framework bug patch

### DIFF
--- a/internal/datacoord/index_meta.go
+++ b/internal/datacoord/index_meta.go
@@ -53,6 +53,8 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
 
+var errIndexOperationIgnored = errors.New("index operation ignored")
+
 type indexMeta struct {
 	ctx     context.Context
 	catalog metastore.DataCoordCatalog
@@ -375,7 +377,7 @@ func (m *indexMeta) canCreateIndex(req *indexpb.CreateIndexRequest, isJson bool)
 		if req.IndexName == index.IndexName {
 			if req.FieldID == index.FieldID && checkParams(index, req) &&
 				/*only check json params when it is json index*/ (!isJson || checkIdenticalJson(index, req)) {
-				return index.IndexID, nil
+				return index.IndexID, errIndexOperationIgnored
 			}
 			errMsg := "at most one distinct index is allowed per field"
 			log.Warn(errMsg,
@@ -1058,12 +1060,17 @@ func (m *indexMeta) CheckCleanSegmentIndex(buildID UniqueID) (bool, *model.Segme
 func (m *indexMeta) getSegmentsIndexStates(collectionID UniqueID, segmentIDs []UniqueID) map[int64]map[int64]*indexpb.SegmentIndexState {
 	ret := make(map[int64]map[int64]*indexpb.SegmentIndexState, 0)
 	m.fieldIndexLock.RLock()
-	fieldIndexes, ok := m.indexes[collectionID]
+	fieldIndexesMap, ok := m.indexes[collectionID]
 	if !ok {
 		m.fieldIndexLock.RUnlock()
 		return ret
 	}
+	fieldIndexes := make(map[UniqueID]*model.Index, len(fieldIndexesMap))
+	for id, index := range fieldIndexesMap {
+		fieldIndexes[id] = index
+	}
 	m.fieldIndexLock.RUnlock()
+
 	for _, segID := range segmentIDs {
 		ret[segID] = make(map[int64]*indexpb.SegmentIndexState)
 		segIndexInfos, ok := m.segmentIndexes.Get(segID)

--- a/internal/datacoord/index_meta_test.go
+++ b/internal/datacoord/index_meta_test.go
@@ -134,8 +134,8 @@ func TestMeta_ScalarAutoIndex(t *testing.T) {
 			},
 		}
 		tmpIndexID, err := m.CanCreateIndex(req, false)
-		assert.NoError(t, err)
-		assert.Equal(t, int64(indexID), tmpIndexID)
+		assert.ErrorIs(t, err, errIndexOperationIgnored)
+		assert.Zero(t, tmpIndexID)
 	})
 
 	t.Run("user index params not consistent", func(t *testing.T) {
@@ -203,8 +203,8 @@ func TestMeta_ScalarAutoIndex(t *testing.T) {
 			},
 		}
 		tmpIndexID, err := m.CanCreateIndex(req, false)
-		assert.NoError(t, err)
-		assert.Equal(t, int64(indexID), tmpIndexID)
+		assert.ErrorIs(t, err, errIndexOperationIgnored)
+		assert.Zero(t, tmpIndexID)
 		newIndexParams := req.GetIndexParams()
 		assert.Equal(t, len(newIndexParams), 1)
 		assert.Equal(t, newIndexParams[0].Key, common.IndexTypeKey)
@@ -287,8 +287,8 @@ func TestMeta_CanCreateIndex(t *testing.T) {
 		assert.NoError(t, err)
 
 		tmpIndexID, err = m.CanCreateIndex(req, false)
-		assert.NoError(t, err)
-		assert.Equal(t, indexID, tmpIndexID)
+		assert.ErrorIs(t, err, errIndexOperationIgnored)
+		assert.Zero(t, tmpIndexID)
 	})
 
 	t.Run("params not consistent", func(t *testing.T) {
@@ -326,8 +326,8 @@ func TestMeta_CanCreateIndex(t *testing.T) {
 		req.UserIndexParams = []*commonpb.KeyValuePair{{Key: common.IndexTypeKey, Value: "AUTOINDEX"}, {Key: common.MetricTypeKey, Value: "COSINE"}}
 		req.UserAutoindexMetricTypeSpecified = false
 		tmpIndexID, err = m.CanCreateIndex(req, false)
-		assert.NoError(t, err)
-		assert.Equal(t, indexID, tmpIndexID)
+		assert.ErrorIs(t, err, errIndexOperationIgnored)
+		assert.Zero(t, tmpIndexID)
 		// req should follow the meta
 		assert.Equal(t, "L2", req.GetUserIndexParams()[1].Value)
 		assert.Equal(t, "L2", req.GetIndexParams()[1].Value)

--- a/internal/querycoordv2/job/job_load.go
+++ b/internal/querycoordv2/job/job_load.go
@@ -101,7 +101,7 @@ func (job *LoadCollectionJob) Execute() error {
 
 	// 2. put load info meta
 	fieldIndexIDs := make(map[int64]int64, len(req.GetLoadFields()))
-	fieldIDs := make([]int64, len(req.GetLoadFields()))
+	fieldIDs := make([]int64, 0, len(req.GetLoadFields()))
 	for _, loadField := range req.GetLoadFields() {
 		if loadField.GetIndexId() != 0 {
 			fieldIndexIDs[loadField.GetFieldId()] = loadField.GetIndexId()

--- a/internal/streamingcoord/server/broadcaster/tombstone_scheduler.go
+++ b/internal/streamingcoord/server/broadcaster/tombstone_scheduler.go
@@ -121,4 +121,6 @@ func (s *tombstoneScheduler) triggerGCTombstone() {
 			return
 		}
 	}
+	// all the tombstones are dropped, reset the tombstones.
+	s.tombstones = make([]tombstoneItem, 0)
 }


### PR DESCRIPTION
issue: #45080, #45274, #45285
pr: #45290

- LoadCollection doesn't ignore the ignorable request, for false field array.
- CreatIndex doesn't ignore the ignorable request, for wrong index.
- index meta is not thread safe.
- lost parameter check of DDL.
- DDL Ack scheduler may get stuck and DDL is block until next incoming DDL.