### PR TITLE
fix: Accurate size estimation for sliced arrow arrays in compaction

### DIFF
--- a/internal/storage/serde_events_v2.go
+++ b/internal/storage/serde_events_v2.go
@@ -140,7 +140,8 @@ func (pw *packedRecordWriter) Write(r Record) error {
 	}
 	pw.rowNum += int64(r.Len())
 	for col, arr := range rec.Columns() {
-		size := arr.Data().SizeInBytes()
+		// size := arr.Data().SizeInBytes()
+		size := calculateActualDataSize(arr)
 		pw.writtenUncompressed += size
 		for _, columnGroup := range pw.columnGroups {
 			if lo.Contains(columnGroup.Columns, col) {


### PR DESCRIPTION
Sliced arrow arrays "incorrectly" returned the original array's size via SizeInBytes(), causing inaccurate memory estimates during compaction.

This resulted in segments closing prematurely in mergeSplit mode - expected 500MB compactions produced 4x100+MB segments instead.

Fixed by calculating actual byte size of sliced arrays, ensuring proper segment sizing and more accurate memory usage tracking.

See also: #45293