### PR TITLE
fix: [hotfix] Support JSON default value in compaction

### DIFF
--- a/internal/storage/arrow_util.go
+++ b/internal/storage/arrow_util.go
@@ -339,6 +339,11 @@ func GenerateEmptyArrayFromSchema(schema *schemapb.FieldSchema, numRows int) (ar
 			bd.AppendValues(
 				lo.RepeatBy(numRows, func(_ int) string { return schema.GetDefaultValue().GetStringData() }),
 				nil)
+		case schemapb.DataType_JSON:
+			bd := builder.(*array.BinaryBuilder)
+			bd.AppendValues(
+				lo.RepeatBy(numRows, func(_ int) []byte { return schema.GetDefaultValue().GetBytesData() }),
+				nil)
 		default:
 			return nil, merr.WrapErrServiceInternal(fmt.Sprintf("Unexpected default value type: %s", schema.GetDataType().String()))
 		}

--- a/internal/storage/arrow_util_test.go
+++ b/internal/storage/arrow_util_test.go
@@ -190,6 +190,19 @@ func TestGenerateEmptyArray(t *testing.T) {
 			},
 			expectErr: true,
 		},
+		{
+			tag: "internal_default_json",
+			field: &schemapb.FieldSchema{
+				DataType: schemapb.DataType_JSON,
+				Nullable: true,
+				DefaultValue: &schemapb.ValueField{
+					Data: &schemapb.ValueField_BytesData{
+						BytesData: []byte(`{}`),
+					},
+				},
+			},
+			expectValue: []byte(`{}`),
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Cherry-pick from master
pr: #45330
Related to #45329

Fix compaction failure when handling newly added dynamic fields with storage v1 binlogs. The issue occurred because the `GenerateEmptyArrayFromSchema` function did not support JSON data type default values, causing "Unexpected default value" errors during compaction.