### PR TITLE
fix: [hotfix] Move FinishLoad before text index creation to ensure raw data availability

### DIFF
--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -376,10 +376,6 @@ func (loader *segmentLoader) Load(ctx context.Context,
 			segment.SetBloomFilter(bfs)
 		}
 
-		if err = segment.FinishLoad(); err != nil {
-			return errors.Wrap(err, "At FinishLoad")
-		}
-
 		if segment.Level() != datapb.SegmentLevel_L0 {
 			loader.manager.Segment.Put(ctx, segmentType, segment)
 		}
@@ -962,6 +958,10 @@ func (loader *segmentLoader) loadSealedSegment(ctx context.Context, loadInfo *qu
 	}
 	loadRawDataSpan := tr.RecordSpan()
 
+	if err = segment.FinishLoad(); err != nil {
+		return errors.Wrap(err, "At FinishLoad")
+	}
+
 	// load text indexes.
 	for _, info := range textIndexes {
 		if err := segment.LoadTextIndex(ctx, info, schemaHelper); err != nil {
@@ -1041,6 +1041,9 @@ func (loader *segmentLoader) LoadSegment(ctx context.Context,
 	} else {
 		if err := segment.LoadMultiFieldData(ctx); err != nil {
 			return err
+		}
+		if err := segment.FinishLoad(); err != nil {
+			return errors.Wrap(err, "At FinishLoad")
 		}
 	}
 


### PR DESCRIPTION
Cherry-pick from master
pr: #45334
Related to #45333

Fix segment loading failure when adding fields with text match enabled. The issue occurred because text indexes were being loaded before FinishLoad() was called, meaning raw data was not properly available when text index creation attempted to access it, resulting in "failed to create text index, neither raw data nor index are found" errors.

Solution is to move the FinishLoad() call to execute after raw data loading but before text index loading. This ensures that:
1. Raw data is properly loaded and available in memory
2. Text indexes can access the raw data they need during creation
3. The segment is in the correct state before any index operations