### PR TITLE
fix: [2.6] add null check for packed_writer_ in JsonStatsParquetWrite…

### DIFF
--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -1421,8 +1421,10 @@ class SegmentExpr : public Expr {
             return false;
         };
 
+        // if path is empty, json stats can not know key name,
+        // so we can't use json shredding data
         return PlanUseJsonStats(context) && HasJsonStats(field_id) &&
-               !path_contains_integer(nested_path);
+               !nested_path.empty() && !path_contains_integer(nested_path);
     }
 
     virtual bool

--- a/internal/core/src/index/json_stats/JsonKeyStats.h
+++ b/internal/core/src/index/json_stats/JsonKeyStats.h
@@ -18,6 +18,7 @@
 
 // Forward declaration of test accessor in global namespace for friend declaration
 class TraverseJsonForBuildStatsAccessor;
+class CollectSingleJsonStatsInfoAccessor;
 
 #include <string>
 #include <boost/filesystem.hpp>
@@ -707,6 +708,7 @@ class JsonKeyStats : public ScalarIndex<std::string> {
 
     // Friend accessor for unit tests to call private methods safely.
     friend class ::TraverseJsonForBuildStatsAccessor;
+    friend class ::CollectSingleJsonStatsInfoAccessor;
 };
 
 using CacheJsonKeyStatsPtr =

--- a/internal/core/src/index/json_stats/parquet_writer.cpp
+++ b/internal/core/src/index/json_stats/parquet_writer.cpp
@@ -46,8 +46,12 @@ JsonStatsParquetWriter::~JsonStatsParquetWriter() {
 
 void
 JsonStatsParquetWriter::Close() {
-    Flush();
-    packed_writer_->Close();
+    // check packed_writer_ initialized
+    if (packed_writer_) {
+        Flush();
+        // ignore close status here
+        auto _ = packed_writer_->Close();
+    }
 }
 
 void


### PR DESCRIPTION
fix: [2.6] add null check for packed_writer_ in JsonStatsParquetWriter::Close() (#45158) (#45176)
Cherry-pick from master
Related to #45157
Fix a bug where DataNode panics when building json stats index throws an exception before the writer is initialized. The destructor would call Close() on an uninitialized packed_writer_ pointer, causing a null pointer dereference.

fix: fix bug for shredding json when empty but not null json (#45214)

pr: #45221

fix: not use json_shredding for json path is null (#45311)

pr: #45310