### PR TITLE
fix: [hotfix] Initialize timestamp range in composite binlog writer (#45283)

### DIFF
--- a/internal/storage/serde_events.go
+++ b/internal/storage/serde_events.go
@@ -981,6 +981,9 @@ func newCompositeBinlogRecordWriter(collectionID, partitionID, segmentID UniqueI
 		pkstats:      stats,
 		bm25Stats:    bm25Stats,
 		options:      options,
+		// initial time range
+		tsFrom: math.MaxInt64,
+		tsTo:   0,
 	}, nil
 }
 


### PR DESCRIPTION
Cherry pick from 2.6
pr: 45283
Related to #45282

Initialize `tsFrom` and `tsTo` fields in the composite binlog record writer constructor to prevent timestamp range information loss in stats tasks.

The composite binlog writer now properly initializes the timestamp range fields, ensuring that:
1. The first timestamp update will correctly set the minimum (`tsFrom`)
2. The first timestamp update will correctly set the maximum (`tsTo`)
3. All subsequent data writes will maintain accurate timestamp range tracking