### PR TITLE
fix: Retain collection early to prevent it from being released before query completion

### DIFF
--- a/internal/querynodev2/services_test.go
+++ b/internal/querynodev2/services_test.go
@@ -1579,6 +1579,8 @@ func (suite *ServiceSuite) TestQuery_Failed() {
 
 	// data
 	schema := mock_segcore.GenTestCollectionSchema(suite.collectionName, schemapb.DataType_Int64, false)
+	suite.node.manager.Collection.PutOrRef(suite.collectionID, schema, nil, nil)
+	defer suite.node.manager.Collection.Unref(suite.collectionID, 1)
 	creq, err := suite.genCQueryRequest(10, IndexFaissIDMap, schema)
 	suite.NoError(err)
 	req := &querypb.QueryRequest{


### PR DESCRIPTION
issue: #45314

This PR only ensures that no panic occurs. However, we still need to provide protection for the delegator handling ongoing query tasks.