### PR TITLE
enhance: [2.6] prevent panic by adding null pointer check when clearing InsertRecord _pk2offset_

### DIFF
--- a/internal/core/src/segcore/InsertRecord.h
+++ b/internal/core/src/segcore/InsertRecord.h
@@ -593,7 +593,10 @@ class InsertRecordSealed {
     clear() {
         timestamps_.clear();
         timestamp_index_ = TimestampIndex();
-        pk2offset_->clear();
+        if (pk2offset_) {
+            pk2offset_->clear();
+        }
+
         reserved = 0;
         if (estimated_memory_size_ > 0) {
             cachinglayer::Manager::GetInstance().RefundLoadedResource(
@@ -753,7 +756,9 @@ class InsertRecordGrowing {
     clear() {
         timestamps_.clear();
         timestamp_index_ = TimestampIndex();
-        pk2offset_->clear();
+        if (pk2offset_) {
+            pk2offset_->clear();
+        }
         reserved = 0;
         data_.clear();
         ack_responder_.clear();


### PR DESCRIPTION
pr:https://github.com/milvus-io/milvus/pull/45281