### PR TITLE
fix: [2.6] Support JSON default values in FillFieldData (#45455)

### DIFF
--- a/internal/core/src/common/FieldDataInterface.h
+++ b/internal/core/src/common/FieldDataInterface.h
@@ -727,21 +727,32 @@ class FieldDataJsonImpl : public FieldDataImpl<Json, true> {
     void
     FillFieldData(const std::optional<DefaultValueType> default_value,
                   ssize_t element_count) override {
-        // todo: add json default_value
-        AssertInfo(!default_value.has_value(),
-                   "json type not support default_value");
         if (element_count == 0) {
             return;
         }
-        null_count_ = element_count;
 
         std::lock_guard lck(tell_mutex_);
         if (length_ + element_count > get_num_rows()) {
             resize_field_data(length_ + element_count);
         }
 
-        bitset::detail::ElementWiseBitsetPolicy<uint8_t>::op_fill(
-            valid_data_.data(), length_, element_count, false);
+        if (default_value.has_value()) {
+            AssertInfo(default_value->has_bytes_data(),
+                       "json type default_value shall be bytes data");
+
+            auto data = default_value->bytes_data();
+            Json default_json = Json(data.data(), data.size());
+            std::fill(data_.data() + length_,
+                      data_.data() + length_ + element_count,
+                      default_json);
+            bitset::detail::ElementWiseBitsetPolicy<uint8_t>::op_fill(
+                valid_data_.data(), length_, element_count, true);
+        } else {
+            null_count_ = element_count;
+            bitset::detail::ElementWiseBitsetPolicy<uint8_t>::op_fill(
+                valid_data_.data(), length_, element_count, false);
+        }
+
         length_ += element_count;
     }
 


### PR DESCRIPTION
Cherry-pick from master
pr: #45455
Related to #45445

Previously, FillFieldData for JSON fields would assert and fail when a default_value was provided, blocking index creation for JSON fields with default values (including dynamic fields like $meta).

This change enables JSON default value support by:
- Removing the assertion that blocked default values
- Parsing bytes_data into Json objects when default_value is present
- Properly filling data_ array and setting valid_data_ bitset to true
- Maintaining null behavior when no default_value is provided

Impact:
- Fixes index creation failure for JSON fields with default values
- Resolves upgrade issues from 2.5 to 2.6.5 where dynamic fields with default values couldn't be indexed
- Index builds that were stuck in InProgress state can now complete