### PR TITLE
enhance: mmap once for each group chunk

### DIFF
--- a/internal/core/src/common/Chunk.h
+++ b/internal/core/src/common/Chunk.h
@@ -528,7 +528,7 @@ class SparseFloatVectorChunk : public Chunk {
         std::unique_ptr<MmapFileRAII> mmap_file_raii = nullptr)
         : Chunk(row_nums, data, size, nullable, std::move(mmap_file_raii)) {
         vec_.resize(row_nums);
-        auto null_bitmap_bytes_num = (row_nums + 7) / 8;
+        auto null_bitmap_bytes_num = nullable ? (row_nums + 7) / 8 : 0;
         auto offsets_ptr =
             reinterpret_cast<uint64_t*>(data + null_bitmap_bytes_num);
         for (int i = 0; i < row_nums; i++) {

--- a/internal/core/src/common/Chunk.h
+++ b/internal/core/src/common/Chunk.h
@@ -38,6 +38,39 @@ namespace milvus {
 constexpr uint64_t MMAP_STRING_PADDING = 1;
 constexpr uint64_t MMAP_GEOMETRY_PADDING = 1;
 constexpr uint64_t MMAP_ARRAY_PADDING = 1;
+
+// Shared mmap region manager for group chunks
+class ChunkMmapGuard {
+ public:
+    ChunkMmapGuard(char* mmap_ptr, size_t mmap_size, std::string file_path)
+        : mmap_ptr_(mmap_ptr), mmap_size_(mmap_size), file_path_(file_path) {
+    }
+
+    ~ChunkMmapGuard() {
+        if (mmap_ptr_ != nullptr) {
+            munmap(mmap_ptr_, mmap_size_);
+        }
+        if (!file_path_.empty()) {
+            unlink(file_path_.c_str());
+        }
+    }
+
+    char*
+    get_ptr() const {
+        return mmap_ptr_;
+    }
+
+    bool
+    is_file_backed() const {
+        return !file_path_.empty();
+    }
+
+ private:
+    char* mmap_ptr_;
+    size_t mmap_size_;
+    const std::string file_path_;
+};
+
 class Chunk {
  public:
     Chunk() = default;
@@ -45,12 +78,12 @@ class Chunk {
           char* data,
           uint64_t size,
           bool nullable,
-          std::unique_ptr<MmapFileRAII> mmap_file_raii = nullptr)
+          std::shared_ptr<ChunkMmapGuard> chunk_mmap_guard)
         : data_(data),
           row_nums_(row_nums),
           size_(size),
           nullable_(nullable),
-          mmap_file_raii_(std::move(mmap_file_raii)) {
+          chunk_mmap_guard_(chunk_mmap_guard) {
         if (nullable) {
             valid_.reserve(row_nums);
             for (int i = 0; i < row_nums; i++) {
@@ -59,7 +92,7 @@ class Chunk {
         }
     }
     virtual ~Chunk() {
-        munmap(data_, size_);
+        // The ChunkMmapGuard will handle the unmapping and unlinking of the file if it is file backed
     }
 
     uint64_t
@@ -69,7 +102,7 @@ class Chunk {
 
     cachinglayer::ResourceUsage
     CellByteSize() const {
-        if (mmap_file_raii_) {
+        if (chunk_mmap_guard_ && chunk_mmap_guard_->is_file_backed()) {
             return cachinglayer::ResourceUsage(0, static_cast<int64_t>(size_));
         }
         return cachinglayer::ResourceUsage(static_cast<int64_t>(size_), 0);
@@ -109,7 +142,7 @@ class Chunk {
     FixedVector<bool>
         valid_;  // parse null bitmap to valid_ to be compatible with SpanBase
 
-    std::unique_ptr<MmapFileRAII> mmap_file_raii_;
+    std::shared_ptr<ChunkMmapGuard> chunk_mmap_guard_{nullptr};
 };
 
 // for fixed size data, includes fixed size array
@@ -121,8 +154,8 @@ class FixedWidthChunk : public Chunk {
                     uint64_t size,
                     uint64_t element_size,
                     bool nullable,
-                    std::unique_ptr<MmapFileRAII> mmap_file_raii = nullptr)
-        : Chunk(row_nums, data, size, nullable, std::move(mmap_file_raii)),
+                    std::shared_ptr<ChunkMmapGuard> chunk_mmap_guard)
+        : Chunk(row_nums, data, size, nullable, chunk_mmap_guard),
           dim_(dim),
           element_size_(element_size) {
         auto null_bitmap_bytes_num = nullable_ ? (row_nums_ + 7) / 8 : 0;
@@ -181,8 +214,8 @@ class StringChunk : public Chunk {
                 char* data,
                 uint64_t size,
                 bool nullable,
-                std::unique_ptr<MmapFileRAII> mmap_file_raii = nullptr)
-        : Chunk(row_nums, data, size, nullable, std::move(mmap_file_raii)) {
+                std::shared_ptr<ChunkMmapGuard> chunk_mmap_guard)
+        : Chunk(row_nums, data, size, nullable, chunk_mmap_guard) {
         auto null_bitmap_bytes_num = nullable_ ? (row_nums_ + 7) / 8 : 0;
         offsets_ = reinterpret_cast<uint32_t*>(data + null_bitmap_bytes_num);
     }
@@ -314,8 +347,8 @@ class ArrayChunk : public Chunk {
                uint64_t size,
                milvus::DataType element_type,
                bool nullable,
-               std::unique_ptr<MmapFileRAII> mmap_file_raii = nullptr)
-        : Chunk(row_nums, data, size, nullable, std::move(mmap_file_raii)),
+               std::shared_ptr<ChunkMmapGuard> chunk_mmap_guard)
+        : Chunk(row_nums, data, size, nullable, chunk_mmap_guard),
           element_type_(element_type) {
         auto null_bitmap_bytes_num = 0;
         if (nullable) {
@@ -431,8 +464,8 @@ class VectorArrayChunk : public Chunk {
                      char* data,
                      uint64_t size,
                      milvus::DataType element_type,
-                     std::unique_ptr<MmapFileRAII> mmap_file_raii = nullptr)
-        : Chunk(row_nums, data, size, false, std::move(mmap_file_raii)),
+                     std::shared_ptr<ChunkMmapGuard> chunk_mmap_guard)
+        : Chunk(row_nums, data, size, false, chunk_mmap_guard),
           dim_(dim),
           element_type_(element_type) {
         offsets_lens_ = reinterpret_cast<uint32_t*>(data);
@@ -520,13 +553,12 @@ class VectorArrayChunk : public Chunk {
 
 class SparseFloatVectorChunk : public Chunk {
  public:
-    SparseFloatVectorChunk(
-        int32_t row_nums,
-        char* data,
-        uint64_t size,
-        bool nullable,
-        std::unique_ptr<MmapFileRAII> mmap_file_raii = nullptr)
-        : Chunk(row_nums, data, size, nullable, std::move(mmap_file_raii)) {
+    SparseFloatVectorChunk(int32_t row_nums,
+                           char* data,
+                           uint64_t size,
+                           bool nullable,
+                           std::shared_ptr<ChunkMmapGuard> chunk_mmap_guard)
+        : Chunk(row_nums, data, size, nullable, chunk_mmap_guard) {
         vec_.resize(row_nums);
         auto null_bitmap_bytes_num = nullable ? (row_nums + 7) / 8 : 0;
         auto offsets_ptr =

--- a/internal/core/src/common/ChunkTarget.cpp
+++ b/internal/core/src/common/ChunkTarget.cpp
@@ -27,9 +27,9 @@ MemChunkTarget::write(const void* data, size_t size) {
     size_ += size;
 }
 
-std::tuple<char*, size_t, std::string>
+char*
 MemChunkTarget::release() {
-    return {data_, cap_, ""};
+    return data_;
 }
 
 size_t
@@ -53,7 +53,7 @@ MmapChunkTarget::write(const void* data, size_t size) {
     size_ += size;
 }
 
-std::tuple<char*, size_t, std::string>
+char*
 MmapChunkTarget::release() {
     flush();
 
@@ -64,7 +64,7 @@ MmapChunkTarget::release() {
                "failed to map: {}, map_size={}",
                strerror(errno),
                cap_);
-    return {static_cast<char*>(m), cap_, file_path_};
+    return static_cast<char*>(m);
 }
 
 size_t

--- a/internal/core/src/common/ChunkTarget.cpp
+++ b/internal/core/src/common/ChunkTarget.cpp
@@ -58,8 +58,7 @@ MmapChunkTarget::release() {
     flush();
 
     auto file = File::Open(file_path_, O_RDWR);
-    auto m = mmap(
-        nullptr, cap_, PROT_READ, MAP_SHARED, file.Descriptor(), 0);
+    auto m = mmap(nullptr, cap_, PROT_READ, MAP_SHARED, file.Descriptor(), 0);
     AssertInfo(m != MAP_FAILED,
                "failed to map: {}, map_size={}",
                strerror(errno),

--- a/internal/core/src/common/ChunkTarget.h
+++ b/internal/core/src/common/ChunkTarget.h
@@ -28,7 +28,7 @@ class ChunkTarget {
     virtual void
     write(const void* data, size_t size) = 0;
 
-    virtual std::tuple<char*, size_t, std::string>
+    virtual char*
     release() = 0;
 
     virtual ~ChunkTarget() = default;
@@ -47,7 +47,7 @@ class MmapChunkTarget : public ChunkTarget {
     void
     write(const void* data, size_t size) override;
 
-    std::tuple<char*, size_t, std::string>
+    char*
     release() override;
 
     size_t
@@ -82,7 +82,7 @@ class MemChunkTarget : public ChunkTarget {
     void
     write(const void* data, size_t size) override;
 
-    std::tuple<char*, size_t, std::string>
+    char*
     release() override;
 
     size_t

--- a/internal/core/src/common/ChunkTarget.h
+++ b/internal/core/src/common/ChunkTarget.h
@@ -25,14 +25,28 @@ class ChunkTarget {
  public:
     static constexpr size_t ALIGNED_SIZE = 4096;  // 4KB
 
+    virtual ~ChunkTarget() = default;
+
+    /**
+     * @brief write data to the target at the current position
+     * @param data the data to write
+     * @param size the size of the data to write
+     */
     virtual void
     write(const void* data, size_t size) = 0;
 
+    /**
+     * @brief release the data pointer to the caller
+     * @note no write() should be called after release()
+     * @return the data pointer
+     */
     virtual char*
     release() = 0;
 
-    virtual ~ChunkTarget() = default;
-
+    /**
+     * @brief get the current position of the target
+     * @return the current position
+     */
     virtual size_t
     tell() = 0;
 };

--- a/internal/core/src/common/ChunkWriter.cpp
+++ b/internal/core/src/common/ChunkWriter.cpp
@@ -699,8 +699,8 @@ make_chunk(const FieldMeta& field_meta,
                 row_nums, data, size, nullable, std::move(mmap_file_raii));
         case milvus::DataType::VECTOR_ARRAY:
             return std::make_unique<VectorArrayChunk>(
-                row_nums,
                 dim,
+                row_nums,
                 data,
                 size,
                 field_meta.get_element_type(),

--- a/internal/core/src/common/ChunkWriter.cpp
+++ b/internal/core/src/common/ChunkWriter.cpp
@@ -644,7 +644,7 @@ make_chunk(const FieldMeta& field_meta,
                                                      chunk_mmap_guard);
         case milvus::DataType::VECTOR_BINARY:
             return std::make_unique<FixedWidthChunk>(row_nums,
-                                                     dim,
+                                                     dim / 8,
                                                      data,
                                                      size,
                                                      sizeof(knowhere::bin1),

--- a/internal/core/src/common/ChunkWriter.cpp
+++ b/internal/core/src/common/ChunkWriter.cpp
@@ -13,7 +13,6 @@
 #include <cstdint>
 #include <memory>
 #include <tuple>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 #include "arrow/array/array_binary.h"
@@ -22,19 +21,37 @@
 #include "arrow/type_fwd.h"
 #include "common/Chunk.h"
 #include "common/EasyAssert.h"
-#include "common/FieldDataInterface.h"
-#include "common/Geometry.h"
 #include "common/Types.h"
-#include "common/VectorTrait.h"
-#include "simdjson/common_defs.h"
 #include "simdjson/padded_string.h"
-#include "storage/FileWriter.h"
 
 namespace milvus {
 
+std::pair<size_t, size_t>
+StringChunkWriter::calculate_size(const arrow::ArrayVector& array_vec) {
+    size_t size = 0;
+    // tuple <data, size, offset>
+    std::vector<std::tuple<const uint8_t*, int64_t, int64_t>> null_bitmaps;
+    for (const auto& data : array_vec) {
+        // for bson, we use binary array to store the string
+        auto array = std::dynamic_pointer_cast<arrow::BinaryArray>(data);
+        for (int i = 0; i < array->length(); i++) {
+            auto str = array->GetView(i);
+            size += str.size();
+        }
+        if (nullable_) {
+            auto null_bitmap_n = (data->length() + 7) / 8;
+            size += null_bitmap_n;
+        }
+        row_nums_ += array->length();
+    }
+
+    size += sizeof(uint32_t) * (row_nums_ + 1) + MMAP_STRING_PADDING;
+    return {size, row_nums_};
+}
+
 void
-StringChunkWriter::write(const arrow::ArrayVector& array_vec) {
-    auto size = 0;
+StringChunkWriter::write_to_target(const arrow::ArrayVector& array_vec,
+                                   const std::shared_ptr<ChunkTarget>& target) {
     std::vector<std::string_view> strs;
     // tuple <data, size, offset>
     std::vector<std::tuple<const uint8_t*, int64_t, int64_t>> null_bitmaps;
@@ -44,32 +61,20 @@ StringChunkWriter::write(const arrow::ArrayVector& array_vec) {
         for (int i = 0; i < array->length(); i++) {
             auto str = array->GetView(i);
             strs.emplace_back(str);
-            size += str.size();
         }
         if (nullable_) {
-            auto null_bitmap_n = (data->length() + 7) / 8;
-            // size, offset all in bits
             null_bitmaps.emplace_back(
                 data->null_bitmap_data(), data->length(), data->offset());
-            size += null_bitmap_n;
         }
-        row_nums_ += array->length();
-    }
-
-    size += sizeof(uint32_t) * (row_nums_ + 1) + MMAP_STRING_PADDING;
-    if (!file_path_.empty()) {
-        target_ = std::make_shared<MmapChunkTarget>(file_path_);
-    } else {
-        target_ = std::make_shared<MemChunkTarget>(size);
     }
 
     // chunk layout: null bitmap, offset1, offset2, ..., offsetn, str1, str2, ..., strn, padding
     // write null bitmaps
-    write_null_bit_maps(null_bitmaps);
+    write_null_bit_maps(null_bitmaps, target);
 
     // write data
     int offset_num = row_nums_ + 1;
-    uint32_t offset_start_pos = target_->tell() + sizeof(uint32_t) * offset_num;
+    uint32_t offset_start_pos = target->tell() + sizeof(uint32_t) * offset_num;
     std::vector<uint32_t> offsets;
     offsets.reserve(offset_num);
     for (const auto& str : strs) {
@@ -78,29 +83,42 @@ StringChunkWriter::write(const arrow::ArrayVector& array_vec) {
     }
     offsets.push_back(offset_start_pos);
 
-    target_->write(offsets.data(), offsets.size() * sizeof(uint32_t));
+    target->write(offsets.data(), offsets.size() * sizeof(uint32_t));
     for (auto str : strs) {
-        target_->write(str.data(), str.size());
+        target->write(str.data(), str.size());
     }
-}
 
-std::unique_ptr<Chunk>
-StringChunkWriter::finish() {
     // write padding, maybe not needed anymore
     // FIXME
     char padding[MMAP_STRING_PADDING];
-    target_->write(padding, MMAP_STRING_PADDING);
-    auto [data, size] = target_->get();
-    auto mmap_file_raii = file_path_.empty()
-                              ? nullptr
-                              : std::make_unique<MmapFileRAII>(file_path_);
-    return std::make_unique<StringChunk>(
-        row_nums_, data, size, nullable_, std::move(mmap_file_raii));
+    target->write(padding, MMAP_STRING_PADDING);
+}
+
+std::pair<size_t, size_t>
+JSONChunkWriter::calculate_size(const arrow::ArrayVector& array_vec) {
+    size_t size = 0;
+    for (const auto& data : array_vec) {
+        auto array = std::dynamic_pointer_cast<arrow::BinaryArray>(data);
+        for (int i = 0; i < array->length(); i++) {
+            auto str = array->GetView(i);
+            auto json = Json(simdjson::padded_string(str));
+            size += json.data().size();
+        }
+        if (nullable_) {
+            auto null_bitmap_n = (data->length() + 7) / 8;
+            size += null_bitmap_n;
+        }
+        row_nums_ += array->length();
+    }
+
+    size += sizeof(uint32_t) * (row_nums_ + 1) + simdjson::SIMDJSON_PADDING;
+
+    return {size, row_nums_};
 }
 
 void
-JSONChunkWriter::write(const arrow::ArrayVector& array_vec) {
-    auto size = 0;
+JSONChunkWriter::write_to_target(const arrow::ArrayVector& array_vec,
+                                 const std::shared_ptr<ChunkTarget>& target) {
     std::vector<Json> jsons;
     // tuple <data, size, offset>
     std::vector<std::tuple<const uint8_t*, int64_t, int64_t>> null_bitmaps;
@@ -109,31 +127,20 @@ JSONChunkWriter::write(const arrow::ArrayVector& array_vec) {
         for (int i = 0; i < array->length(); i++) {
             auto str = array->GetView(i);
             auto json = Json(simdjson::padded_string(str));
-            size += json.data().size();
             jsons.push_back(std::move(json));
         }
         if (nullable_) {
-            auto null_bitmap_n = (data->length() + 7) / 8;
-            // size, offset all in bits
             null_bitmaps.emplace_back(
                 data->null_bitmap_data(), data->length(), data->offset());
-            size += null_bitmap_n;
         }
-        row_nums_ += array->length();
-    }
-    size += sizeof(uint32_t) * (row_nums_ + 1) + simdjson::SIMDJSON_PADDING;
-    if (!file_path_.empty()) {
-        target_ = std::make_shared<MmapChunkTarget>(file_path_);
-    } else {
-        target_ = std::make_shared<MemChunkTarget>(size);
     }
 
     // chunk layout: null bitmaps, offset1, offset2, ... ,json1, json2, ..., jsonn
     // write null bitmaps
-    write_null_bit_maps(null_bitmaps);
+    write_null_bit_maps(null_bitmaps, target);
 
     int offset_num = row_nums_ + 1;
-    uint32_t offset_start_pos = target_->tell() + sizeof(uint32_t) * offset_num;
+    uint32_t offset_start_pos = target->tell() + sizeof(uint32_t) * offset_num;
     std::vector<uint32_t> offsets;
     offsets.reserve(offset_num);
     for (const auto& json : jsons) {
@@ -142,262 +149,178 @@ JSONChunkWriter::write(const arrow::ArrayVector& array_vec) {
     }
     offsets.push_back(offset_start_pos);
 
-    target_->write(offsets.data(), offset_num * sizeof(uint32_t));
+    target->write(offsets.data(), offset_num * sizeof(uint32_t));
 
     // write data
     for (const auto& json : jsons) {
-        target_->write(json.data().data(), json.data().size());
+        target->write(json.data().data(), json.data().size());
     }
-}
 
-std::unique_ptr<Chunk>
-JSONChunkWriter::finish() {
     char padding[simdjson::SIMDJSON_PADDING];
-    target_->write(padding, simdjson::SIMDJSON_PADDING);
-
-    auto [data, size] = target_->get();
-    auto mmap_file_raii = file_path_.empty()
-                              ? nullptr
-                              : std::make_unique<MmapFileRAII>(file_path_);
-    return std::make_unique<JSONChunk>(
-        row_nums_, data, size, nullable_, std::move(mmap_file_raii));
+    target->write(padding, simdjson::SIMDJSON_PADDING);
 }
 
-void
-GeometryChunkWriter::write(const arrow::ArrayVector& array_vec) {
-    auto size = 0;
-    std::vector<std::string> wkb_strs;
-    // tuple <data, size, offset>
-    std::vector<std::tuple<const uint8_t*, int64_t, int64_t>> null_bitmaps;
+std::pair<size_t, size_t>
+GeometryChunkWriter::calculate_size(const arrow::ArrayVector& array_vec) {
+    row_nums_ = 0;
+    size_t size = 0;
     for (const auto& data : array_vec) {
         auto array = std::dynamic_pointer_cast<arrow::BinaryArray>(data);
-        for (int i = 0; i < array->length(); i++) {
+        for (int64_t i = 0; i < array->length(); ++i) {
             auto str = array->GetView(i);
-            wkb_strs.emplace_back(str);
             size += str.size();
         }
         if (nullable_) {
-            auto null_bitmap_n = (data->length() + 7) / 8;
-            null_bitmaps.emplace_back(
-                data->null_bitmap_data(), data->length(), data->offset());
-            size += null_bitmap_n;
+            size += (data->length() + 7) / 8;
         }
         row_nums_ += array->length();
     }
-    // use 32-bit offsets to align with StringChunk layout
+
     size += sizeof(uint32_t) * (row_nums_ + 1) + MMAP_GEOMETRY_PADDING;
-    if (!file_path_.empty()) {
-        target_ = std::make_shared<MmapChunkTarget>(file_path_);
-    } else {
-        target_ = std::make_shared<MemChunkTarget>(size);
+    return {size, row_nums_};
+}
+
+void
+GeometryChunkWriter::write_to_target(
+    const arrow::ArrayVector& array_vec,
+    const std::shared_ptr<ChunkTarget>& target) {
+    std::vector<std::string_view> wkb_strs;
+    std::vector<std::tuple<const uint8_t*, int64_t, int64_t>> null_bitmaps;
+    wkb_strs.reserve(row_nums_);
+
+    for (const auto& data : array_vec) {
+        auto array = std::dynamic_pointer_cast<arrow::BinaryArray>(data);
+        for (int64_t i = 0; i < array->length(); ++i) {
+            auto str = array->GetView(i);
+            wkb_strs.emplace_back(str);
+        }
+        if (nullable_) {
+            null_bitmaps.emplace_back(
+                data->null_bitmap_data(), data->length(), data->offset());
+        }
     }
 
-    // chunk layout: null bitmap, offset1, offset2, ..., offsetn, wkb1, wkb2, ..., wkbn, padding
-    // write null bitmaps
-    write_null_bit_maps(null_bitmaps);
+    // chunk layout: null bitmap, offsets, wkb strings, padding
+    write_null_bit_maps(null_bitmaps, target);
 
-    int offset_num = row_nums_ + 1;
+    const int offset_num = row_nums_ + 1;
     uint32_t offset_start_pos =
-        static_cast<uint32_t>(target_->tell() + sizeof(uint32_t) * offset_num);
+        static_cast<uint32_t>(target->tell() + sizeof(uint32_t) * offset_num);
     std::vector<uint32_t> offsets;
     offsets.reserve(offset_num);
-
-    for (auto str : wkb_strs) {
+    for (const auto& str : wkb_strs) {
         offsets.push_back(offset_start_pos);
         offset_start_pos += str.size();
     }
     offsets.push_back(offset_start_pos);
 
-    target_->write(offsets.data(), offsets.size() * sizeof(uint32_t));
+    target->write(offsets.data(), offsets.size() * sizeof(uint32_t));
 
-    for (auto str : wkb_strs) {
-        target_->write(str.data(), str.size());
+    for (const auto& str : wkb_strs) {
+        target->write(str.data(), str.size());
     }
+
+    char padding[MMAP_GEOMETRY_PADDING];
+    target->write(padding, MMAP_GEOMETRY_PADDING);
 }
 
-std::unique_ptr<Chunk>
-GeometryChunkWriter::finish() {
-    // write padding, maybe not needed anymore
-    // FIXME
-    char padding[MMAP_GEOMETRY_PADDING];
-    target_->write(padding, MMAP_GEOMETRY_PADDING);
-    auto [data, size] = target_->get();
-    auto mmap_file_raii = file_path_.empty()
-                              ? nullptr
-                              : std::make_unique<MmapFileRAII>(file_path_);
-    return std::make_unique<GeometryChunk>(
-        row_nums_, data, size, nullable_, std::move(mmap_file_raii));
+std::pair<size_t, size_t>
+ArrayChunkWriter::calculate_size(const arrow::ArrayVector& array_vec) {
+    size_t size = 0;
+    const bool is_string = IsStringDataType(element_type_);
+
+    for (const auto& data : array_vec) {
+        auto array = std::dynamic_pointer_cast<arrow::BinaryArray>(data);
+        for (int64_t i = 0; i < array->length(); ++i) {
+            auto str = array->GetView(i);
+            ScalarFieldProto scalar_array;
+            scalar_array.ParseFromArray(str.data(), str.size());
+            Array arr(scalar_array);
+            size += arr.byte_size();
+            if (is_string) {
+                size += sizeof(uint32_t) * arr.length();
+            }
+        }
+
+        if (nullable_) {
+            size += (data->length() + 7) / 8;
+        }
+        row_nums_ += array->length();
+    }
+
+    size += sizeof(uint32_t) * (row_nums_ * 2 + 1) + MMAP_ARRAY_PADDING;
+    return {size, row_nums_};
 }
 
 void
-ArrayChunkWriter::write(const arrow::ArrayVector& array_vec) {
-    auto size = 0;
-    auto is_string = IsStringDataType(element_type_);
+ArrayChunkWriter::write_to_target(const arrow::ArrayVector& array_vec,
+                                  const std::shared_ptr<ChunkTarget>& target) {
+    const bool is_string = IsStringDataType(element_type_);
     std::vector<Array> arrays;
-    // tuple <data, size, offset>
+    arrays.reserve(row_nums_);
     std::vector<std::tuple<const uint8_t*, int64_t, int64_t>> null_bitmaps;
 
     for (const auto& data : array_vec) {
         auto array = std::dynamic_pointer_cast<arrow::BinaryArray>(data);
-        for (int i = 0; i < array->length(); i++) {
+        for (int64_t i = 0; i < array->length(); ++i) {
             auto str = array->GetView(i);
             ScalarFieldProto scalar_array;
             scalar_array.ParseFromArray(str.data(), str.size());
-            auto arr = Array(scalar_array);
-            size += arr.byte_size();
-            if (is_string) {
-                // element offsets size
-                size += sizeof(uint32_t) * arr.length();
-            }
-            arrays.push_back(std::move(arr));
+            arrays.emplace_back(Array(scalar_array));
         }
-        row_nums_ += array->length();
         if (nullable_) {
-            auto null_bitmap_n = (data->length() + 7) / 8;
-            // size, offset all in bits
             null_bitmaps.emplace_back(
                 data->null_bitmap_data(), data->length(), data->offset());
-            size += null_bitmap_n;
         }
     }
 
-    // offsets + lens
-    size += sizeof(uint32_t) * (row_nums_ * 2 + 1) + MMAP_ARRAY_PADDING;
-    if (!file_path_.empty()) {
-        target_ = std::make_shared<MmapChunkTarget>(file_path_);
-    } else {
-        target_ = std::make_shared<MemChunkTarget>(size);
-    }
+    write_null_bit_maps(null_bitmaps, target);
 
-    // chunk layout: nullbitmaps, offsets, elem_off1, elem_off2, .. data1, data2, ..., datan, padding
-    write_null_bit_maps(null_bitmaps);
-
-    int offsets_num = row_nums_ + 1;
-    int len_num = row_nums_;
+    const int offsets_num = row_nums_ + 1;
+    const int len_num = row_nums_;
     uint32_t offset_start_pos =
-        target_->tell() + sizeof(uint32_t) * (offsets_num + len_num);
+        target->tell() + sizeof(uint32_t) * (offsets_num + len_num);
+
     std::vector<uint32_t> offsets(offsets_num);
     std::vector<uint32_t> lens(len_num);
-    for (auto i = 0; i < arrays.size(); i++) {
+
+    for (size_t i = 0; i < arrays.size(); ++i) {
         auto& arr = arrays[i];
         offsets[i] = offset_start_pos;
         lens[i] = arr.length();
-        offset_start_pos += is_string ? sizeof(uint32_t) * lens[i] : 0;
+        if (is_string) {
+            offset_start_pos += sizeof(uint32_t) * lens[i];
+        }
         offset_start_pos += arr.byte_size();
     }
-    if (offsets_num > 0) {
-        offsets[offsets_num - 1] = offset_start_pos;
+
+    if (!offsets.empty()) {
+        offsets.back() = offset_start_pos;
     }
 
-    for (int i = 0; i < offsets.size(); i++) {
-        if (i == offsets.size() - 1) {
-            target_->write(&offsets[i], sizeof(uint32_t));
-            break;
-        }
-        target_->write(&offsets[i], sizeof(uint32_t));
-        target_->write(&lens[i], sizeof(uint32_t));
+    for (int i = 0; i < row_nums_; ++i) {
+        target->write(&offsets[i], sizeof(uint32_t));
+        target->write(&lens[i], sizeof(uint32_t));
     }
+    target->write(&offsets.back(), sizeof(uint32_t));
 
     for (auto& arr : arrays) {
         if (is_string) {
-            target_->write(arr.get_offsets_data(),
-                           arr.length() * sizeof(uint32_t));
+            target->write(arr.get_offsets_data(),
+                          arr.length() * sizeof(uint32_t));
         }
-        target_->write(arr.data(), arr.byte_size());
+        target->write(arr.data(), arr.byte_size());
     }
-}
 
-std::unique_ptr<Chunk>
-ArrayChunkWriter::finish() {
     char padding[MMAP_ARRAY_PADDING];
-    target_->write(padding, MMAP_ARRAY_PADDING);
-    auto [data, size] = target_->get();
-    auto mmap_file_raii = file_path_.empty()
-                              ? nullptr
-                              : std::make_unique<MmapFileRAII>(file_path_);
-    return std::make_unique<ArrayChunk>(row_nums_,
-                                        data,
-                                        size,
-                                        element_type_,
-                                        nullable_,
-                                        std::move(mmap_file_raii));
+    target->write(padding, MMAP_ARRAY_PADDING);
 }
 
-// Read vector array data from arrow::ArrayVector and write to target_
-void
-VectorArrayChunkWriter::write(const arrow::ArrayVector& array_vec) {
-    size_t total_size = calculateTotalSize(array_vec);
-    row_nums_ = 0;
-
-    for (const auto& array_data : array_vec) {
-        row_nums_ += array_data->length();
-    }
-
-    if (!file_path_.empty()) {
-        target_ = std::make_shared<MmapChunkTarget>(file_path_);
-    } else {
-        target_ = std::make_shared<MemChunkTarget>(total_size);
-    }
-
-    // Seirialization, the format is: [offsets_lens][all_vector_data_concatenated]
-    std::vector<uint32_t> offsets_lens;
-    std::vector<const uint8_t*> vector_data_ptrs;
-    std::vector<size_t> data_sizes;
-
-    uint32_t current_offset =
-        sizeof(uint32_t) * (row_nums_ * 2 + 1) + target_->tell();
-
-    for (const auto& array_data : array_vec) {
-        auto list_array =
-            std::static_pointer_cast<arrow::ListArray>(array_data);
-        auto binary_values =
-            std::static_pointer_cast<arrow::FixedSizeBinaryArray>(
-                list_array->values());
-        const int32_t* list_offsets = list_array->raw_value_offsets();
-        int byte_width = binary_values->byte_width();
-
-        // Generate offsets and lengths for each row
-        // Each list contains multiple vectors, each stored as a fixed-size binary chunk
-        for (int64_t i = 0; i < list_array->length(); i++) {
-            auto start_idx = list_offsets[i];
-            auto end_idx = list_offsets[i + 1];
-            auto vector_count = end_idx - start_idx;
-            auto byte_size = vector_count * byte_width;
-
-            offsets_lens.push_back(current_offset);
-            offsets_lens.push_back(static_cast<uint32_t>(vector_count));
-
-            for (int j = start_idx; j < end_idx; j++) {
-                vector_data_ptrs.push_back(binary_values->GetValue(j));
-                data_sizes.push_back(byte_width);
-            }
-
-            current_offset += byte_size;
-        }
-    }
-
-    // Add final offset
-    offsets_lens.push_back(current_offset);
-
-    // Write offset and length arrays
-    for (size_t i = 0; i < offsets_lens.size() - 1; i += 2) {
-        target_->write(&offsets_lens[i], sizeof(uint32_t));      // offset
-        target_->write(&offsets_lens[i + 1], sizeof(uint32_t));  // length
-    }
-    target_->write(&offsets_lens.back(), sizeof(uint32_t));  // final offset
-
-    for (size_t i = 0; i < vector_data_ptrs.size(); i++) {
-        target_->write(vector_data_ptrs[i], data_sizes[i]);
-    }
-}
-
-size_t
-VectorArrayChunkWriter::calculateTotalSize(
-    const arrow::ArrayVector& array_vec) {
-    size_t total_size = 0;
+std::pair<size_t, size_t>
+VectorArrayChunkWriter::calculate_size(const arrow::ArrayVector& array_vec) {
     size_t total_rows = 0;
+    size_t total_size = 0;
 
-    // Calculate total size for vector data and count rows
     for (const auto& array_data : array_vec) {
         total_rows += array_data->length();
         auto list_array =
@@ -423,66 +346,119 @@ VectorArrayChunkWriter::calculateTotalSize(
         }
     }
 
+    row_nums_ = total_rows;
+
     // Add space for offset and length arrays
-    total_size += sizeof(uint32_t) * (total_rows * 2 + 1 /* final offset */) +
-                  MMAP_ARRAY_PADDING;
-
-    return total_size;
-}
-
-std::unique_ptr<Chunk>
-VectorArrayChunkWriter::finish() {
-    char padding[MMAP_ARRAY_PADDING];
-    target_->write(padding, MMAP_ARRAY_PADDING);
-
-    auto [data, size] = target_->get();
-    auto mmap_file_raii = file_path_.empty()
-                              ? nullptr
-                              : std::make_unique<MmapFileRAII>(file_path_);
-    return std::make_unique<VectorArrayChunk>(
-        dim_, row_nums_, data, size, element_type_, std::move(mmap_file_raii));
+    total_size += sizeof(uint32_t) * (total_rows * 2 + 1) + MMAP_ARRAY_PADDING;
+    return {total_size, total_rows};
 }
 
 void
-SparseFloatVectorChunkWriter::write(const arrow::ArrayVector& array_vec) {
-    auto size = 0;
-    std::vector<std::string> strs;
-    std::vector<std::pair<const uint8_t*, int64_t>> null_bitmaps;
+VectorArrayChunkWriter::write_to_target(
+    const arrow::ArrayVector& array_vec,
+    const std::shared_ptr<ChunkTarget>& target) {
+    std::vector<uint32_t> offsets_lens;
+    offsets_lens.reserve(row_nums_ * 2 + 1);
+    std::vector<const uint8_t*> vector_data_ptrs;
+    std::vector<size_t> data_sizes;
+
+    uint32_t current_offset =
+        sizeof(uint32_t) * (row_nums_ * 2 + 1) + target->tell();
+
+    for (const auto& array_data : array_vec) {
+        auto list_array =
+            std::static_pointer_cast<arrow::ListArray>(array_data);
+        auto binary_values =
+            std::static_pointer_cast<arrow::FixedSizeBinaryArray>(
+                list_array->values());
+        const int32_t* list_offsets = list_array->raw_value_offsets();
+        int byte_width = binary_values->byte_width();
+
+        // Generate offsets and lengths for each row
+        // Each list contains multiple vectors, each stored as a fixed-size binary chunk
+        for (int64_t i = 0; i < list_array->length(); i++) {
+            auto start_idx = list_offsets[i];
+            auto end_idx = list_offsets[i + 1];
+            auto vector_count = end_idx - start_idx;
+            auto byte_size = static_cast<uint32_t>(vector_count * byte_width);
+
+            offsets_lens.push_back(current_offset);
+            offsets_lens.push_back(static_cast<uint32_t>(vector_count));
+
+            for (int32_t j = start_idx; j < end_idx; ++j) {
+                vector_data_ptrs.push_back(binary_values->GetValue(j));
+                data_sizes.push_back(byte_width);
+            }
+
+            current_offset += byte_size;
+        }
+    }
+
+    offsets_lens.push_back(current_offset);
+
+    // Write offset and length arrays
+    for (size_t i = 0; i < offsets_lens.size() - 1; i += 2) {
+        target->write(&offsets_lens[i], sizeof(uint32_t));      // offset
+        target->write(&offsets_lens[i + 1], sizeof(uint32_t));  // length
+    }
+    target->write(&offsets_lens.back(), sizeof(uint32_t));  // final offset
+
+    for (size_t i = 0; i < vector_data_ptrs.size(); i++) {
+        target->write(vector_data_ptrs[i], data_sizes[i]);
+    }
+
+    char padding[MMAP_ARRAY_PADDING];
+    target->write(padding, MMAP_ARRAY_PADDING);
+}
+
+std::pair<size_t, size_t>
+SparseFloatVectorChunkWriter::calculate_size(
+    const arrow::ArrayVector& array_vec) {
+    row_nums_ = 0;
+    size_t size = 0;
+
     for (const auto& data : array_vec) {
         auto array = std::dynamic_pointer_cast<arrow::BinaryArray>(data);
-        for (int i = 0; i < array->length(); i++) {
+        for (int64_t i = 0; i < array->length(); ++i) {
             auto str = array->GetView(i);
-            strs.emplace_back(str);
             size += str.size();
         }
-        auto null_bitmap_n = (data->length() + 7) / 8;
-        null_bitmaps.emplace_back(data->null_bitmap_data(), null_bitmap_n);
-        size += null_bitmap_n;
+        if (nullable_) {
+            size += (data->length() + 7) / 8;
+        }
         row_nums_ += array->length();
     }
-    size += sizeof(uint64_t) * (row_nums_ + 1);
-    if (!file_path_.empty()) {
-        target_ = std::make_shared<MmapChunkTarget>(file_path_);
-    } else {
-        target_ = std::make_shared<MemChunkTarget>(size);
-    }
 
-    // chunk layout: null bitmap, offset1, offset2, ..., offsetn, str1, str2, ..., strn
-    // write null bitmaps
-    for (auto [data, size] : null_bitmaps) {
-        if (data == nullptr) {
-            std::vector<uint8_t> null_bitmap(size, 0xff);
-            target_->write(null_bitmap.data(), size);
-        } else {
-            target_->write(data, size);
+    size += sizeof(uint64_t) * (row_nums_ + 1);
+    return {size, row_nums_};
+}
+
+void
+SparseFloatVectorChunkWriter::write_to_target(
+    const arrow::ArrayVector& array_vec,
+    const std::shared_ptr<ChunkTarget>& target) {
+    std::vector<std::string> strs;
+    strs.reserve(row_nums_);
+    std::vector<std::tuple<const uint8_t*, int64_t, int64_t>> null_bitmaps;
+
+    for (const auto& data : array_vec) {
+        auto array = std::dynamic_pointer_cast<arrow::BinaryArray>(data);
+        for (int64_t i = 0; i < array->length(); ++i) {
+            auto str = array->GetView(i);
+            strs.emplace_back(str);
+        }
+        if (nullable_) {
+            null_bitmaps.emplace_back(
+                data->null_bitmap_data(), data->length(), data->offset());
         }
     }
 
-    // write data
+    write_null_bit_maps(null_bitmaps, target);
 
-    int offset_num = row_nums_ + 1;
-    int offset_start_pos = target_->tell() + sizeof(uint64_t) * offset_num;
+    const int offset_num = row_nums_ + 1;
+    uint64_t offset_start_pos = target->tell() + sizeof(uint64_t) * offset_num;
     std::vector<uint64_t> offsets;
+    offsets.reserve(offset_num);
 
     for (const auto& str : strs) {
         offsets.push_back(offset_start_pos);
@@ -490,26 +466,15 @@ SparseFloatVectorChunkWriter::write(const arrow::ArrayVector& array_vec) {
     }
     offsets.push_back(offset_start_pos);
 
-    target_->write(offsets.data(), offsets.size() * sizeof(uint64_t));
+    target->write(offsets.data(), offsets.size() * sizeof(uint64_t));
 
-    for (auto str : strs) {
-        target_->write(str.data(), str.size());
+    for (const auto& str : strs) {
+        target->write(str.data(), str.size());
     }
 }
 
-std::unique_ptr<Chunk>
-SparseFloatVectorChunkWriter::finish() {
-    auto [data, size] = target_->get();
-    auto mmap_file_raii = file_path_.empty()
-                              ? nullptr
-                              : std::make_unique<MmapFileRAII>(file_path_);
-    return std::make_unique<SparseFloatVectorChunk>(
-        row_nums_, data, size, nullable_, std::move(mmap_file_raii));
-}
-
-template <typename... Args>
-std::shared_ptr<ChunkWriterBase>
-create_chunk_writer(const FieldMeta& field_meta, Args&&... args) {
+static inline std::shared_ptr<ChunkWriterBase>
+create_chunk_writer(const FieldMeta& field_meta) {
     int dim = IsVectorDataType(field_meta.get_data_type()) &&
                       !IsSparseFloatVectorDataType(field_meta.get_data_type())
                   ? field_meta.get_dim()
@@ -518,92 +483,244 @@ create_chunk_writer(const FieldMeta& field_meta, Args&&... args) {
     switch (field_meta.get_data_type()) {
         case milvus::DataType::BOOL:
             return std::make_shared<ChunkWriter<arrow::BooleanArray, bool>>(
-                dim, std::forward<Args>(args)..., nullable);
+                dim, nullable);
         case milvus::DataType::INT8:
             return std::make_shared<ChunkWriter<arrow::Int8Array, int8_t>>(
-                dim, std::forward<Args>(args)..., nullable);
+                dim, nullable);
         case milvus::DataType::INT16:
             return std::make_shared<ChunkWriter<arrow::Int16Array, int16_t>>(
-                dim, std::forward<Args>(args)..., nullable);
+                dim, nullable);
         case milvus::DataType::INT32:
             return std::make_shared<ChunkWriter<arrow::Int32Array, int32_t>>(
-                dim, std::forward<Args>(args)..., nullable);
+                dim, nullable);
         case milvus::DataType::INT64:
             return std::make_shared<ChunkWriter<arrow::Int64Array, int64_t>>(
-                dim, std::forward<Args>(args)..., nullable);
+                dim, nullable);
         case milvus::DataType::FLOAT:
             return std::make_shared<ChunkWriter<arrow::FloatArray, float>>(
-                dim, std::forward<Args>(args)..., nullable);
+                dim, nullable);
         case milvus::DataType::DOUBLE:
             return std::make_shared<ChunkWriter<arrow::DoubleArray, double>>(
-                dim, std::forward<Args>(args)..., nullable);
+                dim, nullable);
         case milvus::DataType::TIMESTAMPTZ:
             return std::make_shared<ChunkWriter<arrow::Int64Array, int64_t>>(
-                dim, std::forward<Args>(args)..., nullable);
+                dim, nullable);
         case milvus::DataType::VECTOR_FLOAT:
             return std::make_shared<
                 ChunkWriter<arrow::FixedSizeBinaryArray, knowhere::fp32>>(
-                dim, std::forward<Args>(args)..., nullable);
+                dim, nullable);
         case milvus::DataType::VECTOR_BINARY:
             return std::make_shared<
                 ChunkWriter<arrow::FixedSizeBinaryArray, knowhere::bin1>>(
-                dim / 8, std::forward<Args>(args)..., nullable);
+                dim / 8, nullable);
         case milvus::DataType::VECTOR_FLOAT16:
             return std::make_shared<
                 ChunkWriter<arrow::FixedSizeBinaryArray, knowhere::fp16>>(
-                dim, std::forward<Args>(args)..., nullable);
+                dim, nullable);
         case milvus::DataType::VECTOR_BFLOAT16:
             return std::make_shared<
                 ChunkWriter<arrow::FixedSizeBinaryArray, knowhere::bf16>>(
-                dim, std::forward<Args>(args)..., nullable);
+                dim, nullable);
         case milvus::DataType::VECTOR_INT8:
             return std::make_shared<
                 ChunkWriter<arrow::FixedSizeBinaryArray, knowhere::int8>>(
-                dim, std::forward<Args>(args)..., nullable);
+                dim, nullable);
         case milvus::DataType::VARCHAR:
         case milvus::DataType::STRING:
         case milvus::DataType::TEXT:
-            return std::make_shared<StringChunkWriter>(
-                std::forward<Args>(args)..., nullable);
+            return std::make_shared<StringChunkWriter>(nullable);
         case milvus::DataType::JSON:
-            return std::make_shared<JSONChunkWriter>(
-                std::forward<Args>(args)..., nullable);
+            return std::make_shared<JSONChunkWriter>(nullable);
         case milvus::DataType::GEOMETRY: {
-            return std::make_shared<GeometryChunkWriter>(
-                std::forward<Args>(args)..., nullable);
+            return std::make_shared<GeometryChunkWriter>(nullable);
         }
         case milvus::DataType::ARRAY:
             return std::make_shared<ArrayChunkWriter>(
-                field_meta.get_element_type(),
-                std::forward<Args>(args)...,
-                nullable);
+                field_meta.get_element_type(), nullable);
         case milvus::DataType::VECTOR_SPARSE_U32_F32:
-            return std::make_shared<SparseFloatVectorChunkWriter>(
-                std::forward<Args>(args)..., nullable);
+            return std::make_shared<SparseFloatVectorChunkWriter>(nullable);
         case milvus::DataType::VECTOR_ARRAY:
             return std::make_shared<VectorArrayChunkWriter>(
-                dim,
-                field_meta.get_element_type(),
-                std::forward<Args>(args)...);
+                dim, field_meta.get_element_type());
         default:
             ThrowInfo(Unsupported, "Unsupported data type");
+    }
+}
+
+static inline std::unique_ptr<Chunk>
+make_chunk(const FieldMeta& field_meta,
+           const std::shared_ptr<ChunkTarget>& target,
+           size_t row_nums) {
+    int dim = IsVectorDataType(field_meta.get_data_type()) &&
+                      !IsSparseFloatVectorDataType(field_meta.get_data_type())
+                  ? field_meta.get_dim()
+                  : 1;
+    bool nullable = field_meta.is_nullable();
+    auto [data, size, file_path] = target->release();
+    auto mmap_file_raii =
+        file_path.empty() ? nullptr : std::make_unique<MmapFileRAII>(file_path);
+    switch (field_meta.get_data_type()) {
+        case milvus::DataType::BOOL:
+            return std::make_unique<FixedWidthChunk>(row_nums,
+                                                     dim,
+                                                     data,
+                                                     size,
+                                                     sizeof(bool),
+                                                     nullable,
+                                                     std::move(mmap_file_raii));
+        case milvus::DataType::INT8:
+            return std::make_unique<FixedWidthChunk>(row_nums,
+                                                     dim,
+                                                     data,
+                                                     size,
+                                                     sizeof(int8_t),
+                                                     nullable,
+                                                     std::move(mmap_file_raii));
+        case milvus::DataType::INT16:
+            return std::make_unique<FixedWidthChunk>(row_nums,
+                                                     dim,
+                                                     data,
+                                                     size,
+                                                     sizeof(int16_t),
+                                                     nullable,
+                                                     std::move(mmap_file_raii));
+        case milvus::DataType::INT32:
+            return std::make_unique<FixedWidthChunk>(row_nums,
+                                                     dim,
+                                                     data,
+                                                     size,
+                                                     sizeof(int32_t),
+                                                     nullable,
+                                                     std::move(mmap_file_raii));
+        case milvus::DataType::INT64:
+            return std::make_unique<FixedWidthChunk>(row_nums,
+                                                     dim,
+                                                     data,
+                                                     size,
+                                                     sizeof(int64_t),
+                                                     nullable,
+                                                     std::move(mmap_file_raii));
+        case milvus::DataType::FLOAT:
+            return std::make_unique<FixedWidthChunk>(row_nums,
+                                                     dim,
+                                                     data,
+                                                     size,
+                                                     sizeof(float),
+                                                     nullable,
+                                                     std::move(mmap_file_raii));
+        case milvus::DataType::DOUBLE:
+            return std::make_unique<FixedWidthChunk>(row_nums,
+                                                     dim,
+                                                     data,
+                                                     size,
+                                                     sizeof(double),
+                                                     nullable,
+                                                     std::move(mmap_file_raii));
+        case milvus::DataType::TIMESTAMPTZ:
+            return std::make_unique<FixedWidthChunk>(row_nums,
+                                                     dim,
+                                                     data,
+                                                     size,
+                                                     sizeof(int64_t),
+                                                     nullable,
+                                                     std::move(mmap_file_raii));
+        case milvus::DataType::VECTOR_FLOAT:
+            return std::make_unique<FixedWidthChunk>(row_nums,
+                                                     dim,
+                                                     data,
+                                                     size,
+                                                     sizeof(knowhere::fp32),
+                                                     nullable,
+                                                     std::move(mmap_file_raii));
+        case milvus::DataType::VECTOR_BINARY:
+            return std::make_unique<FixedWidthChunk>(row_nums,
+                                                     dim,
+                                                     data,
+                                                     size,
+                                                     sizeof(knowhere::bin1),
+                                                     nullable,
+                                                     std::move(mmap_file_raii));
+        case milvus::DataType::VECTOR_FLOAT16:
+            return std::make_unique<FixedWidthChunk>(row_nums,
+                                                     dim,
+                                                     data,
+                                                     size,
+                                                     sizeof(knowhere::fp16),
+                                                     nullable,
+                                                     std::move(mmap_file_raii));
+        case milvus::DataType::VECTOR_BFLOAT16:
+            return std::make_unique<FixedWidthChunk>(row_nums,
+                                                     dim,
+                                                     data,
+                                                     size,
+                                                     sizeof(knowhere::bf16),
+                                                     nullable,
+                                                     std::move(mmap_file_raii));
+        case milvus::DataType::VECTOR_INT8:
+            return std::make_unique<FixedWidthChunk>(row_nums,
+                                                     dim,
+                                                     data,
+                                                     size,
+                                                     sizeof(knowhere::int8),
+                                                     nullable,
+                                                     std::move(mmap_file_raii));
+        case milvus::DataType::VARCHAR:
+        case milvus::DataType::STRING:
+        case milvus::DataType::TEXT:
+            return std::make_unique<StringChunk>(
+                row_nums, data, size, nullable, std::move(mmap_file_raii));
+        case milvus::DataType::JSON:
+            return std::make_unique<JSONChunk>(
+                row_nums, data, size, nullable, std::move(mmap_file_raii));
+        case milvus::DataType::GEOMETRY: {
+            return std::make_unique<GeometryChunk>(
+                row_nums, data, size, nullable, std::move(mmap_file_raii));
+        }
+        case milvus::DataType::ARRAY:
+            return std::make_unique<ArrayChunk>(row_nums,
+                                                data,
+                                                size,
+                                                field_meta.get_element_type(),
+                                                nullable,
+                                                std::move(mmap_file_raii));
+        case milvus::DataType::VECTOR_SPARSE_U32_F32:
+            return std::make_unique<SparseFloatVectorChunk>(
+                row_nums, data, size, nullable, std::move(mmap_file_raii));
+        case milvus::DataType::VECTOR_ARRAY:
+            return std::make_unique<VectorArrayChunk>(
+                row_nums,
+                dim,
+                data,
+                size,
+                field_meta.get_element_type(),
+                std::move(mmap_file_raii));
+        default:
+            ThrowInfo(DataTypeInvalid, "Unsupported data type");
     }
 }
 
 std::unique_ptr<Chunk>
 create_chunk(const FieldMeta& field_meta, const arrow::ArrayVector& array_vec) {
     auto cw = create_chunk_writer(field_meta);
-    cw->write(array_vec);
-    return cw->finish();
+    auto [size, row_nums] = cw->calculate_size(array_vec);
+    size_t aligned_size = (size + ChunkTarget::ALIGNED_SIZE - 1) &
+                          ~(ChunkTarget::ALIGNED_SIZE - 1);
+    auto target = std::make_shared<MemChunkTarget>(aligned_size);
+    cw->write_to_target(array_vec, target);
+    return make_chunk(field_meta, target, row_nums);
 }
 
 std::unique_ptr<Chunk>
 create_chunk(const FieldMeta& field_meta,
              const arrow::ArrayVector& array_vec,
              const std::string& file_path) {
-    auto cw = create_chunk_writer(field_meta, file_path);
-    cw->write(array_vec);
-    return cw->finish();
+    auto cw = create_chunk_writer(field_meta);
+    auto [size, row_nums] = cw->calculate_size(array_vec);
+    size_t aligned_size = (size + ChunkTarget::ALIGNED_SIZE - 1) &
+                          ~(ChunkTarget::ALIGNED_SIZE - 1);
+    auto target = std::make_shared<MmapChunkTarget>(file_path, aligned_size);
+    cw->write_to_target(array_vec, target);
+    return make_chunk(field_meta, target, row_nums);
 }
 
 arrow::ArrayVector

--- a/internal/core/src/common/ChunkWriter.cpp
+++ b/internal/core/src/common/ChunkWriter.cpp
@@ -72,8 +72,11 @@ StringChunkWriter::write_to_target(const arrow::ArrayVector& array_vec,
     write_null_bit_maps(null_bitmaps, target);
 
     // write data
-    int offset_num = row_nums_ + 1;
-    uint32_t offset_start_pos = sizeof(uint32_t) * offset_num;
+    const int offset_num = row_nums_ + 1;
+    const uint32_t null_bitmap_bytes =
+        nullable_ ? static_cast<uint32_t>((row_nums_ + 7) / 8) : 0;
+    uint32_t offset_start_pos =
+        null_bitmap_bytes + sizeof(uint32_t) * offset_num;
     std::vector<uint32_t> offsets;
     offsets.reserve(offset_num);
     for (const auto& str : strs) {
@@ -137,8 +140,11 @@ JSONChunkWriter::write_to_target(const arrow::ArrayVector& array_vec,
     // write null bitmaps
     write_null_bit_maps(null_bitmaps, target);
 
-    int offset_num = row_nums_ + 1;
-    uint32_t offset_start_pos = sizeof(uint32_t) * offset_num;
+    const int offset_num = row_nums_ + 1;
+    const uint32_t null_bitmap_bytes =
+        nullable_ ? static_cast<uint32_t>((row_nums_ + 7) / 8) : 0;
+    uint32_t offset_start_pos =
+        null_bitmap_bytes + sizeof(uint32_t) * offset_num;
     std::vector<uint32_t> offsets;
     offsets.reserve(offset_num);
     for (const auto& json : jsons) {
@@ -201,7 +207,10 @@ GeometryChunkWriter::write_to_target(
     write_null_bit_maps(null_bitmaps, target);
 
     const int offset_num = row_nums_ + 1;
+    const uint32_t null_bitmap_bytes =
+        nullable_ ? static_cast<uint32_t>((row_nums_ + 7) / 8) : 0;
     uint32_t offset_start_pos =
+        null_bitmap_bytes +
         static_cast<uint32_t>(sizeof(uint32_t) * offset_num);
     std::vector<uint32_t> offsets;
     offsets.reserve(offset_num);
@@ -275,7 +284,10 @@ ArrayChunkWriter::write_to_target(const arrow::ArrayVector& array_vec,
 
     const int offsets_num = row_nums_ + 1;
     const int len_num = row_nums_;
-    uint32_t offset_start_pos = sizeof(uint32_t) * (offsets_num + len_num);
+    const uint32_t null_bitmap_bytes =
+        nullable_ ? static_cast<uint32_t>((row_nums_ + 7) / 8) : 0;
+    uint32_t offset_start_pos =
+        null_bitmap_bytes + sizeof(uint32_t) * (offsets_num + len_num);
 
     std::vector<uint32_t> offsets(offsets_num);
     std::vector<uint32_t> lens(len_num);
@@ -451,7 +463,10 @@ SparseFloatVectorChunkWriter::write_to_target(
     write_null_bit_maps(null_bitmaps, target);
 
     const int offset_num = row_nums_ + 1;
-    uint64_t offset_start_pos = sizeof(uint64_t) * offset_num;
+    const uint64_t null_bitmap_bytes =
+        nullable_ ? static_cast<uint64_t>((row_nums_ + 7) / 8) : 0;
+    uint64_t offset_start_pos =
+        null_bitmap_bytes + sizeof(uint64_t) * offset_num;
     std::vector<uint64_t> offsets;
     offsets.reserve(offset_num);
 

--- a/internal/core/src/common/ChunkWriter.cpp
+++ b/internal/core/src/common/ChunkWriter.cpp
@@ -764,8 +764,11 @@ create_group_chunk(const std::vector<FieldId>& field_ids,
         auto written = static_cast<size_t>(end_off - start_off);
         if (written != chunk_sizes[i]) {
             ThrowInfo(DataTypeInvalid,
-                      "The written size {} of field {} does not match the expected size {}",
-                      written, field_ids[i].get(), chunk_sizes[i]);
+                      "The written size {} of field {} does not match the "
+                      "expected size {}",
+                      written,
+                      field_ids[i].get(),
+                      chunk_sizes[i]);
         }
         auto aligned_size = (written + ChunkTarget::ALIGNED_SIZE - 1) &
                             ~(ChunkTarget::ALIGNED_SIZE - 1);
@@ -789,7 +792,6 @@ create_group_chunk(const std::vector<FieldId>& field_ids,
             "created chunk for field {} with chunk offset: {}, chunk "
             "size: {}, file path: {}",
             field_ids[i].get(),
-            chunk_sizes[i],
             chunk_offsets[i],
             chunk_sizes[i],
             file_path);

--- a/internal/core/src/common/ChunkWriter.cpp
+++ b/internal/core/src/common/ChunkWriter.cpp
@@ -562,14 +562,13 @@ make_chunk(const FieldMeta& field_meta,
            size_t row_nums,
            char* data,
            size_t size,
-           const std::string& file_path) {
+           const std::string& file_path,
+           std::shared_ptr<ChunkMmapGuard> chunk_mmap_guard) {
     int dim = IsVectorDataType(field_meta.get_data_type()) &&
                       !IsSparseFloatVectorDataType(field_meta.get_data_type())
                   ? field_meta.get_dim()
                   : 1;
     bool nullable = field_meta.is_nullable();
-    auto mmap_file_raii =
-        file_path.empty() ? nullptr : std::make_unique<MmapFileRAII>(file_path);
     switch (field_meta.get_data_type()) {
         case milvus::DataType::BOOL:
             return std::make_unique<FixedWidthChunk>(row_nums,
@@ -578,7 +577,7 @@ make_chunk(const FieldMeta& field_meta,
                                                      size,
                                                      sizeof(bool),
                                                      nullable,
-                                                     std::move(mmap_file_raii));
+                                                     chunk_mmap_guard);
         case milvus::DataType::INT8:
             return std::make_unique<FixedWidthChunk>(row_nums,
                                                      dim,
@@ -586,7 +585,7 @@ make_chunk(const FieldMeta& field_meta,
                                                      size,
                                                      sizeof(int8_t),
                                                      nullable,
-                                                     std::move(mmap_file_raii));
+                                                     chunk_mmap_guard);
         case milvus::DataType::INT16:
             return std::make_unique<FixedWidthChunk>(row_nums,
                                                      dim,
@@ -594,7 +593,7 @@ make_chunk(const FieldMeta& field_meta,
                                                      size,
                                                      sizeof(int16_t),
                                                      nullable,
-                                                     std::move(mmap_file_raii));
+                                                     chunk_mmap_guard);
         case milvus::DataType::INT32:
             return std::make_unique<FixedWidthChunk>(row_nums,
                                                      dim,
@@ -602,7 +601,7 @@ make_chunk(const FieldMeta& field_meta,
                                                      size,
                                                      sizeof(int32_t),
                                                      nullable,
-                                                     std::move(mmap_file_raii));
+                                                     chunk_mmap_guard);
         case milvus::DataType::INT64:
             return std::make_unique<FixedWidthChunk>(row_nums,
                                                      dim,
@@ -610,7 +609,7 @@ make_chunk(const FieldMeta& field_meta,
                                                      size,
                                                      sizeof(int64_t),
                                                      nullable,
-                                                     std::move(mmap_file_raii));
+                                                     chunk_mmap_guard);
         case milvus::DataType::FLOAT:
             return std::make_unique<FixedWidthChunk>(row_nums,
                                                      dim,
@@ -618,7 +617,7 @@ make_chunk(const FieldMeta& field_meta,
                                                      size,
                                                      sizeof(float),
                                                      nullable,
-                                                     std::move(mmap_file_raii));
+                                                     chunk_mmap_guard);
         case milvus::DataType::DOUBLE:
             return std::make_unique<FixedWidthChunk>(row_nums,
                                                      dim,
@@ -626,7 +625,7 @@ make_chunk(const FieldMeta& field_meta,
                                                      size,
                                                      sizeof(double),
                                                      nullable,
-                                                     std::move(mmap_file_raii));
+                                                     chunk_mmap_guard);
         case milvus::DataType::TIMESTAMPTZ:
             return std::make_unique<FixedWidthChunk>(row_nums,
                                                      dim,
@@ -634,7 +633,7 @@ make_chunk(const FieldMeta& field_meta,
                                                      size,
                                                      sizeof(int64_t),
                                                      nullable,
-                                                     std::move(mmap_file_raii));
+                                                     chunk_mmap_guard);
         case milvus::DataType::VECTOR_FLOAT:
             return std::make_unique<FixedWidthChunk>(row_nums,
                                                      dim,
@@ -642,7 +641,7 @@ make_chunk(const FieldMeta& field_meta,
                                                      size,
                                                      sizeof(knowhere::fp32),
                                                      nullable,
-                                                     std::move(mmap_file_raii));
+                                                     chunk_mmap_guard);
         case milvus::DataType::VECTOR_BINARY:
             return std::make_unique<FixedWidthChunk>(row_nums,
                                                      dim,
@@ -650,7 +649,7 @@ make_chunk(const FieldMeta& field_meta,
                                                      size,
                                                      sizeof(knowhere::bin1),
                                                      nullable,
-                                                     std::move(mmap_file_raii));
+                                                     chunk_mmap_guard);
         case milvus::DataType::VECTOR_FLOAT16:
             return std::make_unique<FixedWidthChunk>(row_nums,
                                                      dim,
@@ -658,7 +657,7 @@ make_chunk(const FieldMeta& field_meta,
                                                      size,
                                                      sizeof(knowhere::fp16),
                                                      nullable,
-                                                     std::move(mmap_file_raii));
+                                                     chunk_mmap_guard);
         case milvus::DataType::VECTOR_BFLOAT16:
             return std::make_unique<FixedWidthChunk>(row_nums,
                                                      dim,
@@ -666,7 +665,7 @@ make_chunk(const FieldMeta& field_meta,
                                                      size,
                                                      sizeof(knowhere::bf16),
                                                      nullable,
-                                                     std::move(mmap_file_raii));
+                                                     chunk_mmap_guard);
         case milvus::DataType::VECTOR_INT8:
             return std::make_unique<FixedWidthChunk>(row_nums,
                                                      dim,
@@ -674,18 +673,18 @@ make_chunk(const FieldMeta& field_meta,
                                                      size,
                                                      sizeof(knowhere::int8),
                                                      nullable,
-                                                     std::move(mmap_file_raii));
+                                                     chunk_mmap_guard);
         case milvus::DataType::VARCHAR:
         case milvus::DataType::STRING:
         case milvus::DataType::TEXT:
             return std::make_unique<StringChunk>(
-                row_nums, data, size, nullable, std::move(mmap_file_raii));
+                row_nums, data, size, nullable, chunk_mmap_guard);
         case milvus::DataType::JSON:
             return std::make_unique<JSONChunk>(
-                row_nums, data, size, nullable, std::move(mmap_file_raii));
+                row_nums, data, size, nullable, chunk_mmap_guard);
         case milvus::DataType::GEOMETRY: {
             return std::make_unique<GeometryChunk>(
-                row_nums, data, size, nullable, std::move(mmap_file_raii));
+                row_nums, data, size, nullable, chunk_mmap_guard);
         }
         case milvus::DataType::ARRAY:
             return std::make_unique<ArrayChunk>(row_nums,
@@ -693,10 +692,10 @@ make_chunk(const FieldMeta& field_meta,
                                                 size,
                                                 field_meta.get_element_type(),
                                                 nullable,
-                                                std::move(mmap_file_raii));
+                                                chunk_mmap_guard);
         case milvus::DataType::VECTOR_SPARSE_U32_F32:
             return std::make_unique<SparseFloatVectorChunk>(
-                row_nums, data, size, nullable, std::move(mmap_file_raii));
+                row_nums, data, size, nullable, chunk_mmap_guard);
         case milvus::DataType::VECTOR_ARRAY:
             return std::make_unique<VectorArrayChunk>(
                 dim,
@@ -704,7 +703,7 @@ make_chunk(const FieldMeta& field_meta,
                 data,
                 size,
                 field_meta.get_element_type(),
-                std::move(mmap_file_raii));
+                chunk_mmap_guard);
         default:
             ThrowInfo(DataTypeInvalid, "Unsupported data type");
     }
@@ -726,7 +725,15 @@ create_chunk(const FieldMeta& field_meta,
     }
     cw->write_to_target(array_vec, target);
     auto data = target->release();
-    return make_chunk(field_meta, row_nums, data, size, file_path);
+    std::shared_ptr<ChunkMmapGuard> chunk_mmap_guard = nullptr;
+    if (!file_path.empty()) {
+        chunk_mmap_guard =
+            std::make_shared<ChunkMmapGuard>(data, size, file_path);
+    } else {
+        chunk_mmap_guard = std::make_shared<ChunkMmapGuard>(data, size, "");
+    }
+    return make_chunk(
+        field_meta, row_nums, data, size, file_path, chunk_mmap_guard);
 }
 
 std::unordered_map<FieldId, std::shared_ptr<Chunk>>
@@ -796,13 +803,24 @@ create_group_chunk(const std::vector<FieldId>& field_ids,
 
     auto data = target->release();
 
+    // For mmap mode, create a shared mmap region manager
+    std::shared_ptr<ChunkMmapGuard> chunk_mmap_guard = nullptr;
+    if (!file_path.empty()) {
+        chunk_mmap_guard = std::make_shared<ChunkMmapGuard>(
+            data, total_aligned_size, file_path);
+    } else {
+        chunk_mmap_guard =
+            std::make_shared<ChunkMmapGuard>(data, total_aligned_size, "");
+    }
+
     std::unordered_map<FieldId, std::shared_ptr<Chunk>> chunks;
     for (size_t i = 0; i < field_ids.size(); i++) {
         chunks[field_ids[i]] = std::move(make_chunk(field_metas[i],
                                                     final_row_nums,
                                                     data + chunk_offsets[i],
                                                     chunk_sizes[i],
-                                                    file_path));
+                                                    file_path,
+                                                    chunk_mmap_guard));
         LOG_INFO(
             "created chunk for field {} with chunk offset: {}, chunk "
             "size: {}, file path: {}",

--- a/internal/core/src/common/ChunkWriter.h
+++ b/internal/core/src/common/ChunkWriter.h
@@ -100,7 +100,6 @@ class ChunkWriter final : public ChunkWriterBase {
         return {size, row_nums};
     }
 
-    // you should write all data to target_ in one call
     void
     write_to_target(const arrow::ArrayVector& array_vec,
                     const std::shared_ptr<ChunkTarget>& target) override {

--- a/internal/core/src/common/ChunkWriter.h
+++ b/internal/core/src/common/ChunkWriter.h
@@ -13,7 +13,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
-#include <numeric>
 #include <utility>
 #include <vector>
 #include "arrow/array/array_primitive.h"
@@ -21,37 +20,26 @@
 #include "common/ChunkTarget.h"
 #include "arrow/record_batch.h"
 #include "common/Chunk.h"
-#include "common/EasyAssert.h"
-#include "common/FieldDataInterface.h"
 
-#include "storage/FileWriter.h"
-
-#include "common/Geometry.h"
 namespace milvus {
 class ChunkWriterBase {
  public:
     explicit ChunkWriterBase(bool nullable) : nullable_(nullable) {
     }
 
-    ChunkWriterBase(std::string file_path, bool nullable)
-        : file_path_(std::move(file_path)), nullable_(nullable) {
-    }
+    virtual std::pair<size_t, size_t>
+    calculate_size(const arrow::ArrayVector& data) = 0;
 
     virtual void
-    write(const arrow::ArrayVector& data) = 0;
+    write_to_target(const arrow::ArrayVector& array_vec,
+                    const std::shared_ptr<ChunkTarget>& target) = 0;
 
-    virtual std::unique_ptr<Chunk>
-    finish() = 0;
-
-    std::pair<char*, size_t>
-    get_data() {
-        return target_->get();
-    }
-
+ protected:
     void
     write_null_bit_maps(
         const std::vector<std::tuple<const uint8_t*, int64_t, int64_t>>&
-            null_bitmaps) {
+            null_bitmaps,
+        const std::shared_ptr<ChunkTarget>& target) {
         if (nullable_) {
             // merge all null bitmaps in case of multiple chunk null bitmap dislocation
             // say [0xFF, 0x00] with size [7, 8] cannot be treated as [0xFF, 0x00] after merged but
@@ -81,15 +69,13 @@ class ChunkWriterBase {
                 }
                 size_total_bit += size_bits;
             }
-            target_->write(merged_null_bitmap.data(), (size_total_bit + 7) / 8);
+            target->write(merged_null_bitmap.data(), (size_total_bit + 7) / 8);
         }
     }
 
  protected:
-    int row_nums_ = 0;
-    std::string file_path_{""};
+    size_t row_nums_ = 0;
     bool nullable_ = false;
-    std::shared_ptr<ChunkTarget> target_;
 };
 
 template <typename ArrowType, typename T>
@@ -98,14 +84,10 @@ class ChunkWriter final : public ChunkWriterBase {
     ChunkWriter(int dim, bool nullable) : ChunkWriterBase(nullable), dim_(dim) {
     }
 
-    ChunkWriter(int dim, std::string file_path, bool nullable)
-        : ChunkWriterBase(std::move(file_path), nullable), dim_(dim){};
-
-    void
-    write(const arrow::ArrayVector& array_vec) override {
-        auto size = 0;
-        auto row_nums = 0;
-
+    std::pair<size_t, size_t>
+    calculate_size(const arrow::ArrayVector& array_vec) override {
+        size_t size = 0;
+        size_t row_nums = 0;
         for (const auto& data : array_vec) {
             row_nums += data->length();
             auto array = std::static_pointer_cast<ArrowType>(data);
@@ -115,13 +97,14 @@ class ChunkWriter final : public ChunkWriterBase {
             }
             size += array->length() * dim_ * sizeof(T);
         }
-
         row_nums_ = row_nums;
-        if (!file_path_.empty()) {
-            target_ = std::make_shared<MmapChunkTarget>(file_path_);
-        } else {
-            target_ = std::make_shared<MemChunkTarget>(size);
-        }
+        return {size, row_nums};
+    }
+
+    // you should write all data to target_ in one call
+    void
+    write_to_target(const arrow::ArrayVector& array_vec,
+                    const std::shared_ptr<ChunkTarget>& target) override {
         // Chunk layout:
         // 1. Null bitmap (if nullable_=true): Indicates which values are null
         // 2. Data values: Contiguous storage of data elements in the order:
@@ -134,55 +117,25 @@ class ChunkWriter final : public ChunkWriterBase {
                 null_bitmaps.emplace_back(
                     data->null_bitmap_data(), data->length(), data->offset());
             }
-            write_null_bit_maps(null_bitmaps);
+            write_null_bit_maps(null_bitmaps, target);
         }
 
         for (const auto& data : array_vec) {
             auto array = std::static_pointer_cast<ArrowType>(data);
             auto data_ptr = array->raw_values();
-            target_->write(data_ptr, array->length() * dim_ * sizeof(T));
+            target->write(data_ptr, array->length() * dim_ * sizeof(T));
         }
     }
 
-    std::unique_ptr<Chunk>
-    finish() override {
-        auto [data, size] = target_->get();
-        auto mmap_file_raii = file_path_.empty()
-                                  ? nullptr
-                                  : std::make_unique<MmapFileRAII>(file_path_);
-        return std::make_unique<FixedWidthChunk>(row_nums_,
-                                                 dim_,
-                                                 data,
-                                                 size,
-                                                 sizeof(T),
-                                                 nullable_,
-                                                 std::move(mmap_file_raii));
-    }
-
  private:
-    int dim_;
+    const int64_t dim_;
 };
 
 template <>
 inline void
-ChunkWriter<arrow::BooleanArray, bool>::write(
-    const arrow::ArrayVector& array_vec) {
-    auto size = 0;
-    auto row_nums = 0;
-
-    for (const auto& data : array_vec) {
-        row_nums += data->length();
-        auto array = std::dynamic_pointer_cast<arrow::BooleanArray>(data);
-        size += array->length() * dim_;
-        size += (data->length() + 7) / 8;
-    }
-    row_nums_ = row_nums;
-    if (!file_path_.empty()) {
-        target_ = std::make_shared<MmapChunkTarget>(file_path_);
-    } else {
-        target_ = std::make_shared<MemChunkTarget>(size);
-    }
-
+ChunkWriter<arrow::BooleanArray, bool>::write_to_target(
+    const arrow::ArrayVector& array_vec,
+    const std::shared_ptr<ChunkTarget>& target) {
     if (nullable_) {
         // tuple <data, size, offset>
         std::vector<std::tuple<const uint8_t*, int64_t, int64_t>> null_bitmaps;
@@ -190,14 +143,14 @@ ChunkWriter<arrow::BooleanArray, bool>::write(
             null_bitmaps.emplace_back(
                 data->null_bitmap_data(), data->length(), data->offset());
         }
-        write_null_bit_maps(null_bitmaps);
+        write_null_bit_maps(null_bitmaps, target);
     }
 
     for (const auto& data : array_vec) {
         auto array = std::dynamic_pointer_cast<arrow::BooleanArray>(data);
         for (int i = 0; i < array->length(); i++) {
             auto value = array->Value(i);
-            target_->write(&value, sizeof(bool));
+            target->write(&value, sizeof(bool));
         }
     }
 }
@@ -206,32 +159,39 @@ class StringChunkWriter : public ChunkWriterBase {
  public:
     using ChunkWriterBase::ChunkWriterBase;
 
-    void
-    write(const arrow::ArrayVector& array_vec) override;
+    std::pair<size_t, size_t>
+    calculate_size(const arrow::ArrayVector& array_vec) override;
 
-    std::unique_ptr<Chunk>
-    finish() override;
+    void
+    write_to_target(const arrow::ArrayVector& array_vec,
+          const std::shared_ptr<ChunkTarget>& target) override;
+
+private:
+    std::vector<std::string_view> strs_;
 };
 
 class JSONChunkWriter : public ChunkWriterBase {
  public:
     using ChunkWriterBase::ChunkWriterBase;
 
-    void
-    write(const arrow::ArrayVector& array_vec) override;
+    std::pair<size_t, size_t>
+    calculate_size(const arrow::ArrayVector& array_vec) override;
 
-    std::unique_ptr<Chunk>
-    finish() override;
+    void
+    write_to_target(const arrow::ArrayVector& array_vec,
+          const std::shared_ptr<ChunkTarget>& target) override;
 };
 
 class GeometryChunkWriter : public ChunkWriterBase {
  public:
     using ChunkWriterBase::ChunkWriterBase;
-    void
-    write(const arrow::ArrayVector& array_vec) override;
 
-    std::unique_ptr<Chunk>
-    finish() override;
+    std::pair<size_t, size_t>
+    calculate_size(const arrow::ArrayVector& array_vec) override;
+
+    void
+    write_to_target(const arrow::ArrayVector& array_vec,
+          const std::shared_ptr<ChunkTarget>& target) override;
 };
 
 class ArrayChunkWriter : public ChunkWriterBase {
@@ -239,18 +199,13 @@ class ArrayChunkWriter : public ChunkWriterBase {
     ArrayChunkWriter(const milvus::DataType element_type, bool nullable)
         : ChunkWriterBase(nullable), element_type_(element_type) {
     }
-    ArrayChunkWriter(const milvus::DataType element_type,
-                     std::string file_path,
-                     bool nullable)
-        : ChunkWriterBase(std::move(file_path), nullable),
-          element_type_(element_type) {
-    }
+
+    std::pair<size_t, size_t>
+    calculate_size(const arrow::ArrayVector& array_vec) override;
 
     void
-    write(const arrow::ArrayVector& array_vec) override;
-
-    std::unique_ptr<Chunk>
-    finish() override;
+    write_to_target(const arrow::ArrayVector& array_vec,
+          const std::shared_ptr<ChunkTarget>& target) override;
 
  private:
     const milvus::DataType element_type_;
@@ -259,36 +214,34 @@ class ArrayChunkWriter : public ChunkWriterBase {
 class VectorArrayChunkWriter : public ChunkWriterBase {
  public:
     VectorArrayChunkWriter(int64_t dim,
-                           const milvus::DataType element_type,
-                           std::string file_path = "")
-        : ChunkWriterBase(std::move(file_path), false),
+                           const milvus::DataType element_type)
+        : ChunkWriterBase(false),
           element_type_(element_type),
           dim_(dim) {
     }
 
-    void
-    write(const arrow::ArrayVector& array_vec) override;
+    std::pair<size_t, size_t>
+    calculate_size(const arrow::ArrayVector& array_vec) override;
 
-    std::unique_ptr<Chunk>
-    finish() override;
+    void
+    write_to_target(const arrow::ArrayVector& array_vec,
+          const std::shared_ptr<ChunkTarget>& target) override;
 
  private:
-    size_t
-    calculateTotalSize(const arrow::ArrayVector& array_vec);
-
     const milvus::DataType element_type_;
-    int64_t dim_;
+    const int64_t dim_;
 };
 
 class SparseFloatVectorChunkWriter : public ChunkWriterBase {
  public:
     using ChunkWriterBase::ChunkWriterBase;
 
-    void
-    write(const arrow::ArrayVector& array_vec) override;
+    std::pair<size_t, size_t>
+    calculate_size(const arrow::ArrayVector& array_vec) override;
 
-    std::unique_ptr<Chunk>
-    finish() override;
+    void
+    write_to_target(const arrow::ArrayVector& array_vec,
+          const std::shared_ptr<ChunkTarget>& target) override;
 };
 
 std::unique_ptr<Chunk>

--- a/internal/core/src/common/GroupChunk.h
+++ b/internal/core/src/common/GroupChunk.h
@@ -98,4 +98,9 @@ class GroupChunk {
     std::unordered_map<FieldId, std::shared_ptr<Chunk>> chunks_;
 };
 
+enum class GroupChunkType : uint8_t {
+    DEFAULT = 0,
+    JSON_KEY_STATS = 1,
+};
+
 }  // namespace milvus

--- a/internal/core/src/common/VectorArrayChunkTest.cpp
+++ b/internal/core/src/common/VectorArrayChunkTest.cpp
@@ -21,6 +21,7 @@
 #include "common/Chunk.h"
 #include "common/VectorArray.h"
 #include "common/Types.h"
+#include "common/FieldMeta.h"
 #include "pb/schema.pb.h"
 #include "test_utils/DataGen.h"
 
@@ -243,11 +244,14 @@ TEST_F(VectorArrayChunkTest, TestWriteMultipleBatches) {
             createFloatVectorListArray(batch_data, batch_offsets, dim));
     }
 
-    // Write using VectorArrayChunkWriter
-    VectorArrayChunkWriter writer(dim, DataType::VECTOR_FLOAT);
-    writer.write(array_vec);
-
-    auto chunk = writer.finish();
+    // Write using create_chunk with FieldMeta
+    FieldMeta field_meta(FieldName("va"),
+                         FieldId(1),
+                         DataType::VECTOR_ARRAY,
+                         DataType::VECTOR_FLOAT,
+                         dim,
+                         std::nullopt);
+    auto chunk = create_chunk(field_meta, array_vec);
     auto vector_array_chunk = static_cast<VectorArrayChunk*>(chunk.get());
 
     // Verify total rows
@@ -297,11 +301,14 @@ TEST_F(VectorArrayChunkTest, TestWriteWithMmap) {
     auto list_array = createFloatVectorListArray(all_data, offsets, dim);
     arrow::ArrayVector array_vec = {list_array};
 
-    // Write with mmap
-    VectorArrayChunkWriter writer(dim, DataType::VECTOR_FLOAT, temp_file);
-    writer.write(array_vec);
-
-    auto chunk = writer.finish();
+    // Write with mmap using create_chunk
+    FieldMeta field_meta(FieldName("va"),
+                         FieldId(2),
+                         DataType::VECTOR_ARRAY,
+                         DataType::VECTOR_FLOAT,
+                         dim,
+                         std::nullopt);
+    auto chunk = create_chunk(field_meta, array_vec, temp_file);
     auto vector_array_chunk = static_cast<VectorArrayChunk*>(chunk.get());
 
     // Verify mmap write
@@ -330,10 +337,13 @@ TEST_F(VectorArrayChunkTest, TestEmptyVectorArray) {
 
     arrow::ArrayVector array_vec;
 
-    VectorArrayChunkWriter writer(dim, DataType::VECTOR_FLOAT);
-    writer.write(array_vec);
-
-    auto chunk = writer.finish();
+    FieldMeta field_meta(FieldName("va"),
+                         FieldId(3),
+                         DataType::VECTOR_ARRAY,
+                         DataType::VECTOR_FLOAT,
+                         dim,
+                         std::nullopt);
+    auto chunk = create_chunk(field_meta, array_vec);
     auto vector_array_chunk = static_cast<VectorArrayChunk*>(chunk.get());
 
     EXPECT_EQ(vector_array_chunk->RowNums(), 0);
@@ -469,11 +479,14 @@ TEST_P(VectorArrayChunkParameterizedTest, TestWriteVectorArray) {
         createVectorListArray(all_data, offsets, param.dim, param.data_type);
     arrow::ArrayVector array_vec = {list_array};
 
-    // Test VectorArrayChunkWriter
-    VectorArrayChunkWriter writer(param.dim, param.data_type);
-    writer.write(array_vec);
-
-    auto chunk = writer.finish();
+    // Test create_chunk with FieldMeta for VECTOR_ARRAY
+    FieldMeta field_meta(FieldName("va_param"),
+                         FieldId(100),
+                         DataType::VECTOR_ARRAY,
+                         param.data_type,
+                         param.dim,
+                         std::nullopt);
+    auto chunk = create_chunk(field_meta, array_vec);
     auto vector_array_chunk = static_cast<VectorArrayChunk*>(chunk.get());
 
     // Verify results

--- a/internal/core/src/index/json_stats/JsonKeyStats.cpp
+++ b/internal/core/src/index/json_stats/JsonKeyStats.cpp
@@ -898,7 +898,7 @@ JsonKeyStats::LoadColumnGroup(int64_t column_group_id,
 
     auto enable_mmap = !mmap_filepath_.empty();
     auto column_group_info =
-        FieldDataInfo(column_group_id, num_rows, mmap_filepath_);
+        FieldDataInfo(column_group_id, field_id_, num_rows, mmap_filepath_);
     LOG_INFO(
         "loads column group {} with num_rows {} for segment "
         "{}",
@@ -923,6 +923,7 @@ JsonKeyStats::LoadColumnGroup(int64_t column_group_id,
     auto translator = std::make_unique<
         milvus::segcore::storagev2translator::GroupChunkTranslator>(
         segment_id_,
+        GroupChunkType::JSON_KEY_STATS,
         field_meta_map,
         column_group_info,
         files,
@@ -968,9 +969,11 @@ JsonKeyStats::LoadShreddingData(const std::vector<std::string>& index_files) {
 
 void
 JsonKeyStats::Load(milvus::tracer::TraceContext ctx, const Config& config) {
-    if (config.contains(MMAP_FILE_PATH)) {
-        mmap_filepath_ = GetValueFromConfig<std::string>(config, MMAP_FILE_PATH)
-                             .value_or("");
+    if (config.contains(ENABLE_MMAP)) {
+        mmap_filepath_ =
+            milvus::storage::LocalChunkManagerSingleton::GetInstance()
+                .GetChunkManager()
+                ->GetRootPath();
         LOG_INFO("load json stats for segment {} with mmap local file path: {}",
                  segment_id_,
                  mmap_filepath_);

--- a/internal/core/src/index/json_stats/parquet_writer.h
+++ b/internal/core/src/index/json_stats/parquet_writer.h
@@ -105,7 +105,9 @@ class DefaultColumnGroupingStrategy : public ColumnGroupingStrategy {
     CreateGroups(const TableStatsInfo& table_info) const override {
         // put all columns into one group
         std::vector<std::vector<int>> column_groups;
+        column_groups.reserve(1);
         std::vector<int> group;
+        group.reserve(table_info.schema->num_fields());
         for (size_t i = 0; i < table_info.schema->num_fields(); ++i) {
             group.push_back(i);
         }

--- a/internal/core/src/mmap/ChunkedColumnTest.cpp
+++ b/internal/core/src/mmap/ChunkedColumnTest.cpp
@@ -23,8 +23,10 @@ TEST(test_chunked_column, test_get_chunkid) {
     std::vector<std::unique_ptr<Chunk>> chunks;
     for (auto i = 0; i < num_chunks; ++i) {
         auto row_num = num_rows_per_chunk[i];
-        auto chunk =
-            std::make_unique<FixedWidthChunk>(row_num, 1, nullptr, 0, 4, false);
+        auto chunk_mmap_guard =
+            std::make_shared<ChunkMmapGuard>(nullptr, 0, "");
+        auto chunk = std::make_unique<FixedWidthChunk>(
+            row_num, 1, nullptr, 0, 4, false, chunk_mmap_guard);
         chunks.push_back(std::move(chunk));
     }
     auto translator = std::make_unique<TestChunkTranslator>(

--- a/internal/core/src/mmap/Types.h
+++ b/internal/core/src/mmap/Types.h
@@ -40,10 +40,24 @@ struct FieldDataInfo {
         arrow_reader_channel = std::make_shared<ArrowReaderChannel>();
     }
 
+    FieldDataInfo(int64_t field_id,
+                  int64_t main_field_id,
+                  size_t row_count,
+                  std::string mmap_dir_path = "",
+                  bool in_load_list = false)
+        : field_id(field_id),
+          row_count(row_count),
+          main_field_id(main_field_id),
+          mmap_dir_path(std::move(mmap_dir_path)),
+          in_load_list(in_load_list) {
+        arrow_reader_channel = std::make_shared<ArrowReaderChannel>();
+    }
+
     int64_t field_id;
+    int64_t main_field_id{INVALID_FIELD_ID};  // used for json stats only
     size_t row_count;
-    std::string mmap_dir_path;
+    std::string mmap_dir_path{};
     std::shared_ptr<ArrowReaderChannel> arrow_reader_channel;
-    bool in_load_list = false;
+    bool in_load_list{false};
 };
 }  // namespace milvus

--- a/internal/core/src/query/CachedSearchIteratorTest.cpp
+++ b/internal/core/src/query/CachedSearchIteratorTest.cpp
@@ -250,8 +250,16 @@ class CachedSearchIteratorTest
             memcpy(chunk_data.data(),
                    base_dataset_.cbegin() + offset * dim_,
                    rows * dim_ * sizeof(float));
-            chunks.emplace_back(std::make_unique<FixedWidthChunk>(
-                rows, dim_, chunk_data.data(), buf_size, sizeof(float), false));
+            auto chunk_mmap_guard =
+                std::make_shared<ChunkMmapGuard>(nullptr, 0, "");
+            chunks.emplace_back(
+                std::make_unique<FixedWidthChunk>(rows,
+                                                  dim_,
+                                                  chunk_data.data(),
+                                                  buf_size,
+                                                  sizeof(float),
+                                                  false,
+                                                  chunk_mmap_guard));
             offset += rows;
         }
         auto translator = std::make_unique<TestChunkTranslator>(

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -422,6 +422,7 @@ ChunkedSegmentSealedImpl::load_column_group_data_internal(
         auto translator =
             std::make_unique<storagev2translator::GroupChunkTranslator>(
                 get_segment_id(),
+                GroupChunkType::DEFAULT,
                 field_metas,
                 column_group_info,
                 insert_files,

--- a/internal/core/src/segcore/ChunkedSegmentSealedTest.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedTest.cpp
@@ -95,8 +95,10 @@ TEST(test_chunk_segment, TestSearchOnSealed) {
         defer.AddDefer([buf]() { delete[] buf; });
         memcpy(buf, data.data(), 4 * data.size());
 
+        auto chunk_mmap_guard =
+            std::make_shared<ChunkMmapGuard>(nullptr, 0, "");
         chunks.emplace_back(std::make_unique<FixedWidthChunk>(
-            chunk_size, dim, buf, buf_size, 4, false));
+            chunk_size, dim, buf, buf_size, 4, false, chunk_mmap_guard));
     }
 
     auto translator = std::make_unique<TestChunkTranslator>(

--- a/internal/core/src/segcore/storagev1translator/ChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/ChunkTranslator.cpp
@@ -172,14 +172,6 @@ ChunkTranslator::get_cells(
 
     auto data_type = field_meta_.get_data_type();
 
-    std::filesystem::path folder;
-
-    if (use_mmap_) {
-        folder = std::filesystem::path(mmap_dir_path_) /
-                 std::to_string(segment_id_) / std::to_string(field_id_);
-        std::filesystem::create_directories(folder);
-    }
-
     for (auto cid : cids) {
         std::unique_ptr<milvus::Chunk> chunk = nullptr;
         if (!use_mmap_) {
@@ -192,7 +184,9 @@ ChunkTranslator::get_cells(
             chunk = create_chunk(field_meta_, array_vec);
         } else {
             // we don't know the resulting file size beforehand, thus using a separate file for each chunk.
-            auto filepath = folder / std::to_string(cid);
+            auto filepath = std::filesystem::path(mmap_dir_path_) /
+                            fmt::format("seg_{}_fid_{}_cid_{}", segment_id_, field_id_, cid);
+            std::filesystem::create_directories(std::filesystem::path(mmap_dir_path_));
 
             LOG_INFO("segment {} mmaping field {} chunk {} to path {}",
                      segment_id_,

--- a/internal/core/src/segcore/storagev1translator/ChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/ChunkTranslator.cpp
@@ -184,9 +184,12 @@ ChunkTranslator::get_cells(
             chunk = create_chunk(field_meta_, array_vec);
         } else {
             // we don't know the resulting file size beforehand, thus using a separate file for each chunk.
-            auto filepath = std::filesystem::path(mmap_dir_path_) /
-                            fmt::format("seg_{}_fid_{}_cid_{}", segment_id_, field_id_, cid);
-            std::filesystem::create_directories(std::filesystem::path(mmap_dir_path_));
+            auto filepath =
+                std::filesystem::path(mmap_dir_path_) /
+                fmt::format(
+                    "seg_{}_fid_{}_cid_{}", segment_id_, field_id_, cid);
+            std::filesystem::create_directories(
+                std::filesystem::path(mmap_dir_path_));
 
             LOG_INFO("segment {} mmaping field {} chunk {} to path {}",
                      segment_id_,

--- a/internal/core/src/segcore/storagev1translator/ChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/ChunkTranslator.cpp
@@ -186,8 +186,7 @@ ChunkTranslator::get_cells(
             // we don't know the resulting file size beforehand, thus using a separate file for each chunk.
             auto filepath =
                 std::filesystem::path(mmap_dir_path_) /
-                fmt::format(
-                    "seg_{}_fid_{}_cid_{}", segment_id_, field_id_, cid);
+                fmt::format("seg_{}_fid_{}_{}", segment_id_, field_id_, cid);
             std::filesystem::create_directories(
                 std::filesystem::path(mmap_dir_path_));
 

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
@@ -338,9 +338,13 @@ GroupChunkTranslator::load_group_chunk(
     } else {
         std::filesystem::path filepath;
         filepath = std::filesystem::path(column_group_info_.mmap_dir_path) /
-                   fmt::format("seg_{}_cg_{}_cid_{}", segment_id_, column_group_info_.field_id, cid);
+                   fmt::format("seg_{}_cg_{}_cid_{}",
+                               segment_id_,
+                               column_group_info_.field_id,
+                               cid);
         std::filesystem::create_directories(filepath.parent_path());
-        chunks = create_group_chunk(field_ids, field_metas, array_vecs, filepath.string());
+        chunks = create_group_chunk(
+            field_ids, field_metas, array_vecs, filepath.string());
     }
     return std::make_unique<milvus::GroupChunk>(chunks);
 }

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
@@ -45,6 +45,7 @@ namespace milvus::segcore::storagev2translator {
 
 GroupChunkTranslator::GroupChunkTranslator(
     int64_t segment_id,
+    GroupChunkType group_chunk_type,
     const std::unordered_map<FieldId, FieldMeta>& field_metas,
     FieldDataInfo column_group_info,
     std::vector<std::string> insert_files,
@@ -52,7 +53,23 @@ GroupChunkTranslator::GroupChunkTranslator(
     int64_t num_fields,
     milvus::proto::common::LoadPriority load_priority)
     : segment_id_(segment_id),
-      key_(fmt::format("seg_{}_cg_{}", segment_id, column_group_info.field_id)),
+      group_chunk_type_(group_chunk_type),
+      key_([&]() {
+          switch (group_chunk_type) {
+              case GroupChunkType::DEFAULT:
+                  return fmt::format(
+                      "seg_{}_cg_{}", segment_id, column_group_info.field_id);
+              case GroupChunkType::JSON_KEY_STATS:
+                  AssertInfo(
+                      column_group_info.main_field_id != INVALID_FIELD_ID,
+                      "main field id is not set for json key stats group "
+                      "chunk");
+                  return fmt::format("seg_{}_jks_{}_cg_{}",
+                                     segment_id,
+                                     column_group_info.main_field_id,
+                                     column_group_info.field_id);
+          }
+      }()),
       field_metas_(field_metas),
       column_group_info_(column_group_info),
       insert_files_(insert_files),
@@ -337,11 +354,29 @@ GroupChunkTranslator::load_group_chunk(
         chunks = create_group_chunk(field_ids, field_metas, array_vecs);
     } else {
         std::filesystem::path filepath;
-        filepath = std::filesystem::path(column_group_info_.mmap_dir_path) /
-                   fmt::format("seg_{}_cg_{}_cid_{}",
-                               segment_id_,
-                               column_group_info_.field_id,
-                               cid);
+        switch (group_chunk_type_) {
+            case GroupChunkType::DEFAULT:
+                filepath =
+                    std::filesystem::path(column_group_info_.mmap_dir_path) /
+                    fmt::format("seg_{}_cg_{}_{}",
+                                segment_id_,
+                                column_group_info_.field_id,
+                                cid);
+                break;
+            case GroupChunkType::JSON_KEY_STATS:
+                filepath =
+                    std::filesystem::path(column_group_info_.mmap_dir_path) /
+                    fmt::format("seg_{}_jks_{}_cg_{}_{}",
+                                segment_id_,
+                                column_group_info_.main_field_id,
+                                column_group_info_.field_id,
+                                cid);
+                break;
+            default:
+                ThrowInfo(ErrorCode::UnexpectedError,
+                          "unknown group chunk type: {}",
+                          static_cast<uint8_t>(group_chunk_type_));
+        }
         std::filesystem::create_directories(filepath.parent_path());
         chunks = create_group_chunk(
             field_ids, field_metas, array_vecs, filepath.string());

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.h
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.h
@@ -38,6 +38,7 @@ class GroupChunkTranslator
  public:
     GroupChunkTranslator(
         int64_t segment_id,
+        GroupChunkType group_chunk_type,
         const std::unordered_map<FieldId, FieldMeta>& field_metas,
         FieldDataInfo column_group_info,
         std::vector<std::string> insert_files,
@@ -108,6 +109,7 @@ class GroupChunkTranslator
                      const milvus::cachinglayer::cid_t cid);
 
     int64_t segment_id_;
+    GroupChunkType group_chunk_type_{GroupChunkType::DEFAULT};
     std::string key_;
     std::unordered_map<FieldId, FieldMeta> field_metas_;
     FieldDataInfo column_group_info_;

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslatorTest.cpp
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslatorTest.cpp
@@ -103,6 +103,7 @@ TEST_P(GroupChunkTranslatorTest, TestWithMmap) {
 
     auto translator = std::make_unique<GroupChunkTranslator>(
         segment_id_,
+        GroupChunkType::DEFAULT,
         field_metas,
         column_group_info,
         paths_,
@@ -232,6 +233,7 @@ TEST_P(GroupChunkTranslatorTest, TestMultipleFiles) {
 
     auto translator = std::make_unique<GroupChunkTranslator>(
         segment_id_,
+        GroupChunkType::DEFAULT,
         field_metas,
         column_group_info,
         multi_file_paths,


### PR DESCRIPTION
issue: #45486

This commit refactors the chunk writing system by introducing a two-phase
approach: size calculation followed by writing to a target. This enables
efficient group chunk creation where multiple fields share a single mmap
region, significantly reducing the number of mmap system calls and VMAs.

- Optimize `mmap` usage: single `mmap` per group chunk instead of per field
- Split ChunkWriter into two phases:
  - `calculate_size()`: Pre-compute required memory without allocation
  - `write_to_target()`: Write data to a provided ChunkTarget
- Implement `ChunkMmapGuard` for unified mmap region lifecycle management
  - Handles `munmap` and file cleanup via RAII
  - Shared via `std::shared_ptr` across multiple chunks in a group

Signed-off-by: Shawn Wang <shawn.wang@zilliz.com>