### PR TITLE
enhance: Move segment loading logic from Go layer to segcore for self-managed loading

### DIFF
--- a/internal/core/src/common/Types.h
+++ b/internal/core/src/common/Types.h
@@ -205,6 +205,8 @@ ToProtoDataType(DataType data_type) {
             return proto::schema::DataType::Int8Vector;
         case DataType::VECTOR_ARRAY:
             return proto::schema::DataType::ArrayOfVector;
+        case DataType::GEOMETRY:
+            return proto::schema::DataType::Geometry;
 
         // Internal-only or unsupported mappings
         case DataType::ROW:

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -2839,7 +2839,7 @@ ChunkedSegmentSealedImpl::Load(milvus::tracer::TraceContext& trace_ctx) {
     }
 
     // Step 2: Load indexes in parallel using thread pool
-    auto& pool = ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::MIDDLE);
+    auto& pool = ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::LOW);
     std::vector<std::future<void>> load_index_futures;
 
     for (const auto& pair : field_id_to_index_info) {

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -2814,33 +2814,8 @@ ChunkedSegmentSealedImpl::Load(milvus::tracer::TraceContext& trace_ctx) {
                                    index_info_ptr,
                                    num_rows]() mutable -> void {
             // Convert proto FieldIndexInfo to LoadIndexInfo
-            LoadIndexInfo load_index_info;
-            load_index_info.field_id = field_id.get();
-
-            // Get field type from schema
-            const auto& field_meta = get_schema()[field_id];
-            load_index_info.field_type = field_meta.get_data_type();
-
-            // Set index metadata
-            load_index_info.index_id = index_info_ptr->indexid();
-            load_index_info.index_build_id = index_info_ptr->buildid();
-            load_index_info.index_version = index_info_ptr->index_version();
-            load_index_info.index_store_version =
-                index_info_ptr->index_store_version();
-            load_index_info.index_engine_version = static_cast<IndexVersion>(
-                index_info_ptr->current_index_version());
-            load_index_info.index_size = index_info_ptr->index_size();
-            load_index_info.num_rows = index_info_ptr->num_rows();
-
-            // Copy index file paths
-            for (const auto& file_path : index_info_ptr->index_file_paths()) {
-                load_index_info.index_files.push_back(file_path);
-            }
-
-            // Set index params
-            for (const auto& kv_pair : index_info_ptr->index_params()) {
-                load_index_info.index_params[kv_pair.key()] = kv_pair.value();
-            }
+            auto load_index_info = ConvertFieldIndexInfoToLoadIndexInfo(
+                index_info_ptr);
 
             LOG_INFO("Loading index for segment {} field {} with {} files",
                      id_,

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -186,6 +186,13 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     void
     FinishLoad() override;
 
+    void
+    SetLoadInfo(
+        const milvus::proto::segcore::SegmentLoadInfo& load_info) override;
+
+    void
+    Load(milvus::tracer::TraceContext& trace_ctx) override;
+
  public:
     size_t
     GetMemoryUsageInBytes() const override {
@@ -505,6 +512,11 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         bool is_proxy_column,
         std::optional<ParquetStatistics> statistics = {});
 
+    // Convert proto::segcore::FieldIndexInfo to LoadIndexInfo
+    LoadIndexInfo
+    ConvertFieldIndexInfoToLoadIndexInfo(
+        const milvus::proto::segcore::FieldIndexInfo* field_index_info) const;
+
     std::shared_ptr<ChunkedColumnInterface>
     get_column(FieldId field_id) const {
         std::shared_ptr<ChunkedColumnInterface> res;
@@ -558,6 +570,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     mutable DeletedRecord<true> deleted_record_;
 
     LoadFieldDataInfo field_data_info_;
+    milvus::proto::segcore::SegmentLoadInfo segment_load_info_;
 
     SchemaPtr schema_;
     int64_t id_;

--- a/internal/core/src/segcore/SegmentGrowingImpl.h
+++ b/internal/core/src/segcore/SegmentGrowingImpl.h
@@ -106,6 +106,9 @@ class SegmentGrowingImpl : public SegmentGrowing {
     void
     FinishLoad() override;
 
+    void
+    Load(milvus::tracer::TraceContext& trace_ctx) override;
+
  private:
     // Build geometry cache for inserted data
     void

--- a/internal/core/src/segcore/SegmentInterface.h
+++ b/internal/core/src/segcore/SegmentInterface.h
@@ -200,6 +200,9 @@ class SegmentInterface {
 
     virtual void
     SetLoadInfo(const milvus::proto::segcore::SegmentLoadInfo& load_info) = 0;
+
+    virtual void
+    Load(milvus::tracer::TraceContext& trace_ctx) = 0;
 };
 
 // internal API for DSL calculation

--- a/internal/core/src/segcore/Utils.cpp
+++ b/internal/core/src/segcore/Utils.cpp
@@ -26,6 +26,9 @@
 #include "common/Utils.h"
 #include "index/ScalarIndex.h"
 #include "log/Log.h"
+#include "segcore/storagev1translator/SealedIndexTranslator.h"
+#include "segcore/storagev1translator/V1SealedIndexTranslator.h"
+#include "segcore/Types.h"
 #include "storage/DataCodec.h"
 #include "storage/RemoteChunkManagerSingleton.h"
 #include "storage/ThreadPools.h"
@@ -1198,6 +1201,118 @@ getCellDataType(bool is_vector, bool is_index) {
         return is_vector ? milvus::cachinglayer::CellDataType::VECTOR_FIELD
                          : milvus::cachinglayer::CellDataType::SCALAR_FIELD;
     }
+}
+
+void
+LoadIndexData(milvus::tracer::TraceContext& ctx,
+              milvus::segcore::LoadIndexInfo* load_index_info) {
+    auto& index_params = load_index_info->index_params;
+    auto field_type = load_index_info->field_type;
+    auto engine_version = load_index_info->index_engine_version;
+
+    milvus::index::CreateIndexInfo index_info;
+    index_info.field_type = load_index_info->field_type;
+    index_info.index_engine_version = engine_version;
+
+    auto config = milvus::index::ParseConfigFromIndexParams(
+        load_index_info->index_params);
+    auto load_priority_str = config[milvus::LOAD_PRIORITY].get<std::string>();
+    auto priority_for_load = milvus::PriorityForLoad(load_priority_str);
+    config[milvus::LOAD_PRIORITY] = priority_for_load;
+
+    // Config should have value for milvus::index::SCALAR_INDEX_ENGINE_VERSION for production calling chain.
+    // Use value_or(1) for unit test without setting this value
+    index_info.scalar_index_engine_version =
+        milvus::index::GetValueFromConfig<int32_t>(
+            config, milvus::index::SCALAR_INDEX_ENGINE_VERSION)
+            .value_or(1);
+
+    index_info.tantivy_index_version =
+        milvus::index::GetValueFromConfig<int32_t>(
+            config, milvus::index::TANTIVY_INDEX_VERSION)
+            .value_or(milvus::index::TANTIVY_INDEX_LATEST_VERSION);
+
+    LOG_INFO(
+        "[collection={}][segment={}][field={}][enable_mmap={}][load_"
+        "priority={}] load index {}, "
+        "mmap_dir_path={}",
+        load_index_info->collection_id,
+        load_index_info->segment_id,
+        load_index_info->field_id,
+        load_index_info->enable_mmap,
+        load_priority_str,
+        load_index_info->index_id,
+        load_index_info->mmap_dir_path);
+    // get index type
+    AssertInfo(index_params.find("index_type") != index_params.end(),
+               "index type is empty");
+    index_info.index_type = index_params.at("index_type");
+
+    // get metric type
+    if (milvus::IsVectorDataType(field_type)) {
+        AssertInfo(index_params.find("metric_type") != index_params.end(),
+                   "metric type is empty for vector index");
+        index_info.metric_type = index_params.at("metric_type");
+    }
+
+    if (index_info.index_type == milvus::index::NGRAM_INDEX_TYPE) {
+        AssertInfo(
+            index_params.find(milvus::index::MIN_GRAM) != index_params.end(),
+            "min_gram is empty for ngram index");
+        AssertInfo(
+            index_params.find(milvus::index::MAX_GRAM) != index_params.end(),
+            "max_gram is empty for ngram index");
+
+        // get min_gram and max_gram and convert to uintptr_t
+        milvus::index::NgramParams ngram_params{};
+        ngram_params.loading_index = true;
+        ngram_params.min_gram =
+            std::stoul(milvus::index::GetValueFromConfig<std::string>(
+                           config, milvus::index::MIN_GRAM)
+                           .value());
+        ngram_params.max_gram =
+            std::stoul(milvus::index::GetValueFromConfig<std::string>(
+                           config, milvus::index::MAX_GRAM)
+                           .value());
+        index_info.ngram_params = std::make_optional(ngram_params);
+    }
+
+    // init file manager
+    milvus::storage::FieldDataMeta field_meta{load_index_info->collection_id,
+                                              load_index_info->partition_id,
+                                              load_index_info->segment_id,
+                                              load_index_info->field_id,
+                                              load_index_info->schema};
+    milvus::storage::IndexMeta index_meta{load_index_info->segment_id,
+                                          load_index_info->field_id,
+                                          load_index_info->index_build_id,
+                                          load_index_info->index_version};
+    config[milvus::index::INDEX_FILES] = load_index_info->index_files;
+
+    if (load_index_info->field_type == milvus::DataType::JSON) {
+        index_info.json_cast_type = milvus::JsonCastType::FromString(
+            config.at(JSON_CAST_TYPE).get<std::string>());
+        index_info.json_path = config.at(JSON_PATH).get<std::string>();
+    }
+    auto remote_chunk_manager =
+        milvus::storage::RemoteChunkManagerSingleton::GetInstance()
+            .GetRemoteChunkManager();
+    auto fs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
+                  .GetArrowFileSystem();
+    AssertInfo(fs != nullptr, "arrow file system is nullptr");
+    milvus::storage::FileManagerContext file_manager_context(
+        field_meta, index_meta, remote_chunk_manager, fs);
+    file_manager_context.set_for_loading_index(true);
+
+    // use cache layer to load vector/scalar index
+    std::unique_ptr<milvus::cachinglayer::Translator<milvus::index::IndexBase>>
+        translator = std::make_unique<
+            milvus::segcore::storagev1translator::SealedIndexTranslator>(
+            index_info, load_index_info, ctx, file_manager_context, config);
+
+    load_index_info->cache_index =
+        milvus::cachinglayer::Manager::GetInstance().CreateCacheSlot(
+            std::move(translator));
 }
 
 }  // namespace milvus::segcore

--- a/internal/core/src/segcore/Utils.h
+++ b/internal/core/src/segcore/Utils.h
@@ -22,6 +22,7 @@
 #include "index/Index.h"
 #include "cachinglayer/Utils.h"
 #include "segcore/ConcurrentVector.h"
+#include "segcore/Types.h"
 
 namespace milvus::segcore {
 
@@ -142,5 +143,9 @@ getCacheWarmupPolicy(bool is_vector, bool is_index, bool in_load_list = true);
 
 milvus::cachinglayer::CellDataType
 getCellDataType(bool is_vector, bool is_index);
+
+void
+LoadIndexData(milvus::tracer::TraceContext& ctx,
+              milvus::segcore::LoadIndexInfo* load_index_info);
 
 }  // namespace milvus::segcore

--- a/internal/core/src/segcore/load_index_c.cpp
+++ b/internal/core/src/segcore/load_index_c.cpp
@@ -34,6 +34,7 @@
 #include "cachinglayer/Manager.h"
 #include "segcore/storagev1translator/SealedIndexTranslator.h"
 #include "segcore/storagev1translator/V1SealedIndexTranslator.h"
+#include "segcore/Utils.h"
 #include "monitor/scope_metric.h"
 
 bool
@@ -239,121 +240,14 @@ AppendIndexV2(CTraceContext c_trace, CLoadIndexInfo c_load_index_info) {
     try {
         auto load_index_info =
             static_cast<milvus::segcore::LoadIndexInfo*>(c_load_index_info);
-        auto& index_params = load_index_info->index_params;
-        auto field_type = load_index_info->field_type;
-        auto engine_version = load_index_info->index_engine_version;
-
-        milvus::index::CreateIndexInfo index_info;
-        index_info.field_type = load_index_info->field_type;
-        index_info.index_engine_version = engine_version;
-
-        auto config = milvus::index::ParseConfigFromIndexParams(
-            load_index_info->index_params);
-        auto load_priority_str =
-            config[milvus::LOAD_PRIORITY].get<std::string>();
-        auto priority_for_load = milvus::PriorityForLoad(load_priority_str);
-        config[milvus::LOAD_PRIORITY] = priority_for_load;
-
-        // Config should have value for milvus::index::SCALAR_INDEX_ENGINE_VERSION for production calling chain.
-        // Use value_or(1) for unit test without setting this value
-        index_info.scalar_index_engine_version =
-            milvus::index::GetValueFromConfig<int32_t>(
-                config, milvus::index::SCALAR_INDEX_ENGINE_VERSION)
-                .value_or(1);
-
-        index_info.tantivy_index_version =
-            milvus::index::GetValueFromConfig<int32_t>(
-                config, milvus::index::TANTIVY_INDEX_VERSION)
-                .value_or(milvus::index::TANTIVY_INDEX_LATEST_VERSION);
 
         auto ctx = milvus::tracer::TraceContext{
             c_trace.traceID, c_trace.spanID, c_trace.traceFlags};
         auto span = milvus::tracer::StartSpan("SegCoreLoadIndex", &ctx);
         milvus::tracer::SetRootSpan(span);
 
-        LOG_INFO(
-            "[collection={}][segment={}][field={}][enable_mmap={}][load_"
-            "priority={}] load index {}, "
-            "mmap_dir_path={}",
-            load_index_info->collection_id,
-            load_index_info->segment_id,
-            load_index_info->field_id,
-            load_index_info->enable_mmap,
-            load_priority_str,
-            load_index_info->index_id,
-            load_index_info->mmap_dir_path);
+        LoadIndexData(ctx, load_index_info);
 
-        // get index type
-        AssertInfo(index_params.find("index_type") != index_params.end(),
-                   "index type is empty");
-        index_info.index_type = index_params.at("index_type");
-
-        // get metric type
-        if (milvus::IsVectorDataType(field_type)) {
-            AssertInfo(index_params.find("metric_type") != index_params.end(),
-                       "metric type is empty for vector index");
-            index_info.metric_type = index_params.at("metric_type");
-        }
-
-        if (index_info.index_type == milvus::index::NGRAM_INDEX_TYPE) {
-            AssertInfo(index_params.find(milvus::index::MIN_GRAM) !=
-                           index_params.end(),
-                       "min_gram is empty for ngram index");
-            AssertInfo(index_params.find(milvus::index::MAX_GRAM) !=
-                           index_params.end(),
-                       "max_gram is empty for ngram index");
-
-            // get min_gram and max_gram and convert to uintptr_t
-            milvus::index::NgramParams ngram_params{};
-            ngram_params.loading_index = true;
-            ngram_params.min_gram =
-                std::stoul(milvus::index::GetValueFromConfig<std::string>(
-                               config, milvus::index::MIN_GRAM)
-                               .value());
-            ngram_params.max_gram =
-                std::stoul(milvus::index::GetValueFromConfig<std::string>(
-                               config, milvus::index::MAX_GRAM)
-                               .value());
-            index_info.ngram_params = std::make_optional(ngram_params);
-        }
-
-        // init file manager
-        milvus::storage::FieldDataMeta field_meta{
-            load_index_info->collection_id,
-            load_index_info->partition_id,
-            load_index_info->segment_id,
-            load_index_info->field_id,
-            load_index_info->schema};
-        milvus::storage::IndexMeta index_meta{load_index_info->segment_id,
-                                              load_index_info->field_id,
-                                              load_index_info->index_build_id,
-                                              load_index_info->index_version};
-        config[milvus::index::INDEX_FILES] = load_index_info->index_files;
-
-        if (load_index_info->field_type == milvus::DataType::JSON) {
-            index_info.json_cast_type = milvus::JsonCastType::FromString(
-                config.at(JSON_CAST_TYPE).get<std::string>());
-            index_info.json_path = config.at(JSON_PATH).get<std::string>();
-        }
-        auto remote_chunk_manager =
-            milvus::storage::RemoteChunkManagerSingleton::GetInstance()
-                .GetRemoteChunkManager();
-        auto fs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
-                      .GetArrowFileSystem();
-        AssertInfo(fs != nullptr, "arrow file system is nullptr");
-        milvus::storage::FileManagerContext fileManagerContext(
-            field_meta, index_meta, remote_chunk_manager, fs);
-        fileManagerContext.set_for_loading_index(true);
-
-        // use cache layer to load vector/scalar index
-        std::unique_ptr<
-            milvus::cachinglayer::Translator<milvus::index::IndexBase>>
-            translator = std::make_unique<
-                milvus::segcore::storagev1translator::SealedIndexTranslator>(
-                index_info, load_index_info, ctx, fileManagerContext, config);
-        load_index_info->cache_index =
-            milvus::cachinglayer::Manager::GetInstance().CreateCacheSlot(
-                std::move(translator));
         span->End();
         milvus::tracer::CloseRootSpan();
 

--- a/internal/core/src/segcore/segment_c.cpp
+++ b/internal/core/src/segcore/segment_c.cpp
@@ -139,6 +139,23 @@ NewSegmentWithLoadInfo(CCollection collection,
     }
 }
 
+CStatus
+SegmentLoad(CTraceContext c_trace, CSegmentInterface c_segment) {
+    SCOPE_CGO_CALL_METRIC();
+
+    try {
+        auto segment =
+            static_cast<milvus::segcore::SegmentInterface*>(c_segment);
+        // TODO unify trace context to op context after supported
+        auto trace_ctx = milvus::tracer::TraceContext{
+            c_trace.traceID, c_trace.spanID, c_trace.traceFlags};
+        segment->Load(trace_ctx);
+        return milvus::SuccessCStatus();
+    } catch (std::exception& e) {
+        return milvus::FailureCStatus(&e);
+    }
+}
+
 void
 DeleteSegment(CSegmentInterface c_segment) {
     SCOPE_CGO_CALL_METRIC();

--- a/internal/core/src/segcore/segment_c.h
+++ b/internal/core/src/segcore/segment_c.h
@@ -36,18 +36,20 @@ NewSegment(CCollection collection,
            CSegmentInterface* newSegment,
            bool is_sorted_by_pk);
 
-// Create a new segment with pre-loaded segment information.
-// This function creates a segment and initializes it with serialized load info,
-// which can include precomputed metadata, statistics, or configuration data.
-//
-// @param collection: The collection that this segment belongs to
-// @param seg_type: Type of the segment (growing, sealed, etc.)
-// @param segment_id: Unique identifier for this segment
-// @param newSegment: Output parameter for the created segment interface
-// @param is_sorted_by_pk: Whether the segment data is sorted by primary key
-// @param load_info_blob: Serialized load information blob
-// @param load_info_length: Length of the load_info_blob in bytes
-// @return CStatus indicating success or failure
+/**
+ * @brief Create a new segment with pre-loaded segment information
+ * This function creates a segment and initializes it with serialized load info,
+ * which can include precomputed metadata, statistics, or configuration data
+ *
+ * @param collection: The collection that this segment belongs to
+ * @param seg_type: Type of the segment (growing, sealed, etc.)
+ * @param segment_id: Unique identifier for this segment
+ * @param newSegment: Output parameter for the created segment interface
+ * @param is_sorted_by_pk: Whether the segment data is sorted by primary key
+ * @param load_info_blob: Serialized load information blob
+ * @param load_info_length: Length of the load_info_blob in bytes
+ * @return CStatus indicating success or failure
+ */
 CStatus
 NewSegmentWithLoadInfo(CCollection collection,
                        SegmentType seg_type,
@@ -56,6 +58,16 @@ NewSegmentWithLoadInfo(CCollection collection,
                        bool is_sorted_by_pk,
                        const uint8_t* load_info_blob,
                        const int64_t load_info_length);
+/**
+ * @brief Dispatch a segment manage load task.
+ * This function make segment itself load index & field data according to load info previously set.
+ *
+ * @param c_trace: tracing context param
+ * @param c_segment: segment handle indicate which segment to load
+ * @return CStatus indicating success or failure
+ */
+CStatus
+SegmentLoad(CTraceContext c_trace, CSegmentInterface c_segment);
 
 void
 DeleteSegment(CSegmentInterface c_segment);

--- a/internal/querynodev2/segments/mock_segment.go
+++ b/internal/querynodev2/segments/mock_segment.go
@@ -1151,6 +1151,52 @@ func (_c *MockSegment_Level_Call) RunAndReturn(run func() datapb.SegmentLevel) *
 	return _c
 }
 
+// Load provides a mock function with given fields: ctx
+func (_m *MockSegment) Load(ctx context.Context) error {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Load")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
+		r0 = rf(ctx)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockSegment_Load_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Load'
+type MockSegment_Load_Call struct {
+	*mock.Call
+}
+
+// Load is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *MockSegment_Expecter) Load(ctx interface{}) *MockSegment_Load_Call {
+	return &MockSegment_Load_Call{Call: _e.mock.On("Load", ctx)}
+}
+
+func (_c *MockSegment_Load_Call) Run(run func(ctx context.Context)) *MockSegment_Load_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context))
+	})
+	return _c
+}
+
+func (_c *MockSegment_Load_Call) Return(_a0 error) *MockSegment_Load_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockSegment_Load_Call) RunAndReturn(run func(context.Context) error) *MockSegment_Load_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // LoadDeltaData provides a mock function with given fields: ctx, deltaData
 func (_m *MockSegment) LoadDeltaData(ctx context.Context, deltaData *storage.DeltaData) error {
 	ret := _m.Called(ctx, deltaData)

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -1368,6 +1368,10 @@ func (s *LocalSegment) FinishLoad() error {
 	return nil
 }
 
+func (s *LocalSegment) Load(ctx context.Context) error {
+	return s.csegment.Load(ctx)
+}
+
 type ReleaseScope int
 
 const (

--- a/internal/querynodev2/segments/segment_interface.go
+++ b/internal/querynodev2/segments/segment_interface.go
@@ -85,6 +85,7 @@ type Segment interface {
 	Delete(ctx context.Context, primaryKeys storage.PrimaryKeys, timestamps []typeutil.Timestamp) error
 	LoadDeltaData(ctx context.Context, deltaData *storage.DeltaData) error
 	LastDeltaTimestamp() uint64
+	Load(ctx context.Context) error
 	FinishLoad() error
 	Release(ctx context.Context, opts ...releaseOption)
 

--- a/internal/querynodev2/segments/segment_l0.go
+++ b/internal/querynodev2/segments/segment_l0.go
@@ -182,6 +182,10 @@ func (s *L0Segment) FinishLoad() error {
 	return nil
 }
 
+func (s *L0Segment) Load(ctx context.Context) error {
+	return nil
+}
+
 func (s *L0Segment) Release(ctx context.Context, opts ...releaseOption) {
 	s.dataGuard.Lock()
 	defer s.dataGuard.Unlock()

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -906,58 +906,6 @@ func (loader *segmentLoader) loadSealedSegment(ctx context.Context, loadInfo *qu
 		zap.Int64s("unindexed text fields", lo.Keys(unindexedTextFields)),
 		zap.Int64s("indexed json key fields", lo.Keys(jsonKeyStats)),
 	)
-	// if err := loader.loadFieldsIndex(ctx, schemaHelper, segment, loadInfo.GetNumOfRows(), indexedFieldInfos); err != nil {
-	// 	return err
-	// }
-	// loadFieldsIndexSpan := tr.RecordSpan()
-	// metrics.QueryNodeLoadIndexLatency.WithLabelValues(fmt.Sprint(paramtable.GetNodeID())).Observe(float64(loadFieldsIndexSpan.Milliseconds()))
-
-	// // 2. complement raw data for the scalar fields without raw data
-	// for _, info := range indexedFieldInfos {
-	// 	fieldID := info.IndexInfo.FieldID
-	// 	field, err := schemaHelper.GetFieldFromID(fieldID)
-	// 	if err != nil {
-	// 		return err
-	// 	}
-	// 	if !segment.HasRawData(fieldID) || field.GetIsPrimaryKey() {
-	// 		// Skip loading raw data for fields in column group when using storage v2
-	// 		if loadInfo.GetStorageVersion() == storage.StorageV2 &&
-	// 			!storagecommon.IsVectorDataType(field.GetDataType()) &&
-	// 			field.GetDataType() != schemapb.DataType_Text {
-	// 			log.Info("skip loading raw data for field in short column group",
-	// 				zap.Int64("fieldID", fieldID),
-	// 				zap.String("index", info.IndexInfo.GetIndexName()),
-	// 			)
-	// 			continue
-	// 		}
-
-	// 		log.Info("field index doesn't include raw data, load binlog...",
-	// 			zap.Int64("fieldID", fieldID),
-	// 			zap.String("index", info.IndexInfo.GetIndexName()),
-	// 		)
-	// 		// for scalar index's raw data, only load to mmap not memory
-	// 		if err = segment.LoadFieldData(ctx, fieldID, loadInfo.GetNumOfRows(), info.FieldBinlog); err != nil {
-	// 			log.Warn("load raw data failed", zap.Int64("fieldID", fieldID), zap.Error(err))
-	// 			return err
-	// 		}
-	// 	}
-
-	// 	if !storagecommon.IsVectorDataType(field.GetDataType()) &&
-	// 		!segment.HasFieldData(fieldID) &&
-	// 		loadInfo.GetStorageVersion() != storage.StorageV2 {
-	// 		// Lazy load raw data to avoid search failure after dropping index.
-	// 		// storage v2 will load all scalar fields so we don't need to load raw data for them.
-	// 		if err = segment.LoadFieldData(ctx, fieldID, loadInfo.GetNumOfRows(), info.FieldBinlog, "disable"); err != nil {
-	// 			log.Warn("load raw data failed", zap.Int64("fieldID", fieldID), zap.Error(err))
-	// 			return err
-	// 		}
-	// 	}
-	// }
-	// complementScalarDataSpan := tr.RecordSpan()
-	// if err := loadSealedSegmentFields(ctx, collection, segment, fieldBinlogs, loadInfo.GetNumOfRows()); err != nil {
-	// 	return err
-	// }
-	// loadRawDataSpan := tr.RecordSpan()
 
 	if err = segment.Load(ctx); err != nil {
 		return errors.Wrap(err, "At Load")

--- a/internal/util/segcore/segment_interface.go
+++ b/internal/util/segcore/segment_interface.go
@@ -80,6 +80,9 @@ type basicSegmentMethodSet interface {
 	// FinishLoad wraps up the load process and let segcore do the leftover jobs.
 	FinishLoad() error
 
+	// Load invokes segment managed loading.
+	Load(ctx context.Context) error
+
 	// Release releases the segment.
 	Release()
 }


### PR DESCRIPTION
Related to #45060

Refactor segment loading architecture to make segments autonomously manage their own loading process, moving the orchestration logic from Go (segment_loader.go) to C++ (segcore).

**C++ Layer (segcore):**
- Added `SetLoadInfo()` and `Load()` methods to `SegmentInterface` and implementations
- Implemented `ChunkedSegmentSealedImpl::Load()` with parallel loading strategy:
  - Separates indexed fields from non-indexed fields
  - Loads indexes concurrently using thread pools
  - Loads field data for non-indexed fields in parallel
- Implemented `SegmentGrowingImpl::Load()` to convert and load field data
- Extracted `LoadIndexData()` as a reusable utility function in `Utils.cpp`
- Added `SegmentLoad()` C binding in `segment_c.cpp`

**Go Layer:**
- Added `Load()` method to segment interfaces
- Updated mock implementations and test interfaces
- Integrated new C++ `SegmentLoad()` binding in Go segment wrapper