### PR TITLE
fix: Set schema properties before broadcast alter collection

### DIFF
--- a/internal/rootcoord/broker.go
+++ b/internal/rootcoord/broker.go
@@ -261,6 +261,7 @@ func (b *ServerBroker) BroadcastAlteredCollection(ctx context.Context, collectio
 			Fields:            model.MarshalFieldModels(colMeta.Fields),
 			StructArrayFields: model.MarshalStructArrayFieldModels(colMeta.StructArrayFields),
 			Functions:         model.MarshalFunctionModels(colMeta.Functions),
+			Properties:        colMeta.Properties,
 		},
 		PartitionIDs:   partitionIDs,
 		StartPositions: colMeta.StartPositions,


### PR DESCRIPTION
This causes collection schema properties is empty in datacoord caches, thus making compaction, indexing, unable to get properties from schema.

See also: #45053, #45159