### PR TITLE
enhance: update knowhere version

### DIFF
--- a/internal/core/src/storage/DiskFileManagerTest.cpp
+++ b/internal/core/src/storage/DiskFileManagerTest.cpp
@@ -184,6 +184,7 @@ TEST_F(DiskAnnFileManagerTest, ReadAndWriteWithStream) {
     write_offset += small_index_size;
     close(fd);
     EXPECT_EQ(os->Tell(), write_offset);
+    os->Close();
 
     auto is = diskAnnFileManager->OpenInputStream(index_file_path);
     size_t read_offset = 0;

--- a/internal/core/src/storage/RemoteOutputStream.cpp
+++ b/internal/core/src/storage/RemoteOutputStream.cpp
@@ -12,11 +12,6 @@ RemoteOutputStream::RemoteOutputStream(
 }
 
 RemoteOutputStream::~RemoteOutputStream() {
-    // temp solution, will expose `Close` method in OutputStream later
-    auto status = output_stream_->Close();
-    AssertInfo(status.ok(),
-               "Failed to close output stream, error: {}",
-               status.ToString());
 }
 
 size_t
@@ -51,5 +46,11 @@ RemoteOutputStream::Write(int fd, size_t size) {
     }
 
     return size;
+}
+
+void
+RemoteOutputStream::Close() {
+    auto status = output_stream_->Close();
+    AssertInfo(status.ok(), "Failed to close output stream");
 }
 }  // namespace milvus::storage

--- a/internal/core/src/storage/RemoteOutputStream.h
+++ b/internal/core/src/storage/RemoteOutputStream.h
@@ -32,6 +32,9 @@ class RemoteOutputStream : public milvus::OutputStream {
     size_t
     Write(int fd, size_t size) override;
 
+    void
+    Close() override;
+
  private:
     std::shared_ptr<arrow::io::OutputStream> output_stream_;
 };

--- a/internal/core/thirdparty/knowhere/CMakeLists.txt
+++ b/internal/core/thirdparty/knowhere/CMakeLists.txt
@@ -14,7 +14,7 @@
 # Update KNOWHERE_VERSION for the first occurrence
 milvus_add_pkg_config("knowhere")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( KNOWHERE_VERSION 1752b41 )
+set( KNOWHERE_VERSION 9fc3b64 )
 set( GIT_REPOSITORY  "https://github.com/zilliztech/knowhere.git")
 
 message(STATUS "Knowhere repo: ${GIT_REPOSITORY}")

--- a/internal/core/thirdparty/milvus-common/CMakeLists.txt
+++ b/internal/core/thirdparty/milvus-common/CMakeLists.txt
@@ -13,7 +13,7 @@
 
 milvus_add_pkg_config("milvus-common")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( MILVUS-COMMON-VERSION 4d7781d )
+set( MILVUS-COMMON-VERSION b6629f7 )
 set( GIT_REPOSITORY "https://github.com/zilliztech/milvus-common.git")
 
 message(STATUS "milvus-common repo: ${GIT_REPOSITORY}")

--- a/tests/python_client/testcases/indexes/idx_hnsw_pq.py
+++ b/tests/python_client/testcases/indexes/idx_hnsw_pq.py
@@ -322,22 +322,22 @@ class HNSW_PQ:
         {
             "description": "Out of Range Test - unknown value",
             "params": {"refine_type": "INT8"},
-            "expected": {"err_code": 1100, "err_msg": "invalid refine type : INT8, optional types are [sq6, sq8, fp16, bf16, fp32, flat]: invalid parameter"}
+            "expected": {"err_code": 1100, "err_msg": "invalid refine type : INT8, optional types are [sq4u, sq6, sq8, fp16, bf16, fp32, flat]: invalid parameter"}
         },
         {
             "description": "Integer Type Test",
             "params": {"refine_type": 1},
-            "expected": {"err_code": 1100, "err_msg": "invalid refine type : 1, optional types are [sq6, sq8, fp16, bf16, fp32, flat]: invalid parameter"}
+            "expected": {"err_code": 1100, "err_msg": "invalid refine type : 1, optional types are [sq4u, sq6, sq8, fp16, bf16, fp32, flat]: invalid parameter"}
         },
         {
             "description": "Float Type Test",
             "params": {"refine_type": 1.0},
-            "expected": {"err_code": 1100, "err_msg": "invalid refine type : 1.0, optional types are [sq6, sq8, fp16, bf16, fp32, flat]: invalid parameter"}
+            "expected": {"err_code": 1100, "err_msg": "invalid refine type : 1.0, optional types are [sq4u, sq6, sq8, fp16, bf16, fp32, flat]: invalid parameter"}
         },
         {
             "description": "List Type Test",
             "params": {"refine_type": ["FP16"]},
-            "expected": {"err_code": 1100, "err_msg": "['FP16'], optional types are [sq6, sq8, fp16, bf16, fp32, flat]: invalid parameter"}
+            "expected": {"err_code": 1100, "err_msg": "['FP16'], optional types are [sq4u, sq6, sq8, fp16, bf16, fp32, flat]: invalid parameter"}
         },
         {
             "description": "None Type Test, use default value",

--- a/tests/python_client/testcases/indexes/idx_hnsw_sq.py
+++ b/tests/python_client/testcases/indexes/idx_hnsw_sq.py
@@ -226,22 +226,22 @@ class HNSW_SQ:
         {
             "description": "Out of Range Test - unknown value",
             "params": {"refine_type": "INT8"},
-            "expected": {"err_code": 1100, "err_msg": "invalid refine type : INT8, optional types are [sq6, sq8, fp16, bf16, fp32, flat]: invalid parameter"}
+            "expected": {"err_code": 1100, "err_msg": "invalid refine type : INT8, optional types are [sq4u, sq6, sq8, fp16, bf16, fp32, flat]: invalid parameter"}
         },
         {
             "description": "Integer Type Test",
             "params": {"refine_type": 1},
-            "expected": {"err_code": 1100, "err_msg": "invalid refine type : 1, optional types are [sq6, sq8, fp16, bf16, fp32, flat]: invalid parameter"}
+            "expected": {"err_code": 1100, "err_msg": "invalid refine type : 1, optional types are [sq4u, sq6, sq8, fp16, bf16, fp32, flat]: invalid parameter"}
         },
         {
             "description": "Float Type Test",
             "params": {"refine_type": 1.0},
-            "expected": {"err_code": 1100, "err_msg": "invalid refine type : 1.0, optional types are [sq6, sq8, fp16, bf16, fp32, flat]: invalid parameter"}
+            "expected": {"err_code": 1100, "err_msg": "invalid refine type : 1.0, optional types are [sq4u, sq6, sq8, fp16, bf16, fp32, flat]: invalid parameter"}
         },
         {
             "description": "List Type Test",
             "params": {"refine_type": ["FP16"]},
-            "expected": {"err_code": 1100, "err_msg": "['FP16'], optional types are [sq6, sq8, fp16, bf16, fp32, flat]: invalid parameter"}
+            "expected": {"err_code": 1100, "err_msg": "['FP16'], optional types are [sq4u, sq6, sq8, fp16, bf16, fp32, flat]: invalid parameter"}
         },
         {
             "description": "None Type Test, use default value",


### PR DESCRIPTION
issue: #42937 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Core invariant: callers must explicitly close output streams (call Close()) instead of relying on RemoteOutputStream's destructor to perform closure.
- Logic removed/simplified: RemoteOutputStream's destructor no longer closes or asserts on the underlying arrow::io::OutputStream; an explicit public Close() method was added and closure responsibility moved to that code path.
- Why this is safe (no data loss/regression): callers now invoke Close() before reading or destroying streams (e.g., DiskFileManagerTest::ReadAndWriteWithStream calls os->Close() before opening the input stream). Write paths remain unchanged (RemoteOutputStream::Write -> output_stream_->Write), and Close invokes output_stream_->Close() with status assertion, ensuring flush/confirmation via the same API and preserving data integrity; removing destructor-side asserts prevents unexpected failures during object destruction without changing write/close semantics.
- Chore: updated third-party pins — internal/core/thirdparty/knowhere CMakeLists.txt: KNOWHERE_VERSION -> a59816e; internal/core/thirdparty/milvus-common CMakeLists.txt: MILVUS-COMMON-VERSION -> b6629f7.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->