### PR TITLE
fix: Replace json.doc() calls with json.dom_doc() in JsonContainsExpr

### DIFF
--- a/internal/core/src/exec/expression/JsonContainsExpr.cpp
+++ b/internal/core/src/exec/expression/JsonContainsExpr.cpp
@@ -1105,7 +1105,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllWithDiffType(EvalCtx& context) {
             const std::unordered_set<int> elements_index) {
         auto executor = [&](size_t i) -> bool {
             const auto& json = data[i];
-            auto doc = json.doc();
+            auto doc = json.dom_doc();
             auto array = doc.at_pointer(pointer).get_array();
             if (array.error()) {
                 return false;
@@ -1643,7 +1643,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsWithDiffType(EvalCtx& context) {
             const std::vector<proto::plan::GenericValue>& elements) {
         auto executor = [&](const size_t i) {
             auto& json = data[i];
-            auto doc = json.doc();
+            auto doc = json.dom_doc();
             auto array = doc.at_pointer(pointer).get_array();
             if (array.error()) {
                 return false;


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/45783
for simdjson ondemand api, a iterator can only be used once. use dom api to prevent crashes when processing JSON contains operations with different types.