### PR TITLE
enhance: QueryNodeEntitiesSize metric is inaccurate fix it

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -351,7 +351,6 @@ ChunkedSegmentSealedImpl::LoadFieldData(FieldId field_id, FieldDataInfo& data) {
                     }
                     // var_column->Seal();
                     field_data_size = var_column->DataByteSize();
-                    stats_.mem_size += var_column->DataByteSize();
                     LoadStringSkipIndex(field_id, 0, *var_column);
                     column = std::move(var_column);
                     break;
@@ -366,7 +365,6 @@ ChunkedSegmentSealedImpl::LoadFieldData(FieldId field_id, FieldDataInfo& data) {
                         var_column->AddChunk(chunk);
                     }
                     // var_column->Seal();
-                    stats_.mem_size += var_column->DataByteSize();
                     field_data_size = var_column->DataByteSize();
                     column = std::move(var_column);
                     break;
@@ -381,7 +379,6 @@ ChunkedSegmentSealedImpl::LoadFieldData(FieldId field_id, FieldDataInfo& data) {
                         var_column->AddChunk(chunk);
                     }
                     // var_column->Seal();
-                    stats_.mem_size += var_column->DataByteSize();
                     field_data_size = var_column->DataByteSize();
 
                     // Construct GeometryCache for the entire field
@@ -449,6 +446,7 @@ ChunkedSegmentSealedImpl::LoadFieldData(FieldId field_id, FieldDataInfo& data) {
                                column->NumRows(),
                                num_rows));
 
+        stats_.mem_size += column->DataByteSize();
         {
             std::unique_lock lck(mutex_);
             fields_.emplace(field_id, column);


### PR DESCRIPTION
For the querynode_entity_size metric, I’m starting to feel that maybe we should abandon it. When loading a segment, the original intention was for it to measure only the memory usage of a column. However, now that some columns have indexes as well as raw data, the column itself is not actually loaded, which makes the metric meaningless. Therefore, in the future, should we consider removing this metric? After all, the memory usage of the query node can be obtained directly from the system.