### PR TITLE
fix: compact the assignment history of channel to decrease the size of assignment recovery info

### DIFF
--- a/internal/streamingcoord/server/balancer/channel/pchannel_test.go
+++ b/internal/streamingcoord/server/balancer/channel/pchannel_test.go
@@ -112,4 +112,17 @@ func TestPChannel(t *testing.T) {
 	mutablePChannel = updatedChannelInfo.CopyForWrite()
 	assert.True(t, mutablePChannel.TryAssignToServerID(types.AccessModeRW, types.StreamingNodeInfo{ServerID: 789}))
 	assert.Len(t, mutablePChannel.AssignHistories(), 1)
+
+	assert.True(t, mutablePChannel.TryAssignToServerID(types.AccessModeRW, types.StreamingNodeInfo{ServerID: 790}))
+	assert.Len(t, mutablePChannel.AssignHistories(), 1)
+
+	assert.True(t, mutablePChannel.TryAssignToServerID(types.AccessModeRW, types.StreamingNodeInfo{ServerID: 790}))
+	assert.Len(t, mutablePChannel.AssignHistories(), 2)
+	assert.True(t, mutablePChannel.TryAssignToServerID(types.AccessModeRW, types.StreamingNodeInfo{ServerID: 790}))
+	assert.Len(t, mutablePChannel.AssignHistories(), 2)
+	for _, h := range mutablePChannel.AssignHistories() {
+		if h.Node.ServerID == 790 {
+			assert.Equal(t, h.Channel.Term, mutablePChannel.CurrentTerm()-1)
+		}
+	}
 }


### PR DESCRIPTION
issue: #45210

If the underlying WAL is failed to open, the recovery info size of streaming coord `streamingcoord-meta/pchannel` will increase fast until reaching the etcd limitation.
So make a compaction by serverID at assignment history to decrease the `streamingcoord-meta/pchannel` size.