### PR TITLE
fix: update EnableDynamicField and SchemaVersion during collection modification

### DIFF
--- a/internal/metastore/kv/rootcoord/kv_catalog.go
+++ b/internal/metastore/kv/rootcoord/kv_catalog.go
@@ -696,6 +696,8 @@ func (kc *Catalog) alterModifyCollection(ctx context.Context, oldColl *model.Col
 	oldCollClone.Fields = newColl.Fields
 	oldCollClone.StructArrayFields = newColl.StructArrayFields
 	oldCollClone.UpdateTimestamp = newColl.UpdateTimestamp
+	oldCollClone.EnableDynamicField = newColl.EnableDynamicField
+	oldCollClone.SchemaVersion = newColl.SchemaVersion
 
 	newKey := BuildCollectionKey(newColl.DBID, oldColl.CollectionID)
 	value, err := proto.Marshal(model.MarshalCollectionModel(oldCollClone))

--- a/internal/metastore/kv/rootcoord/kv_catalog_test.go
+++ b/internal/metastore/kv/rootcoord/kv_catalog_test.go
@@ -1073,6 +1073,50 @@ func TestCatalog_AlterCollection(t *testing.T) {
 		assert.Equal(t, newC.UpdateTimestamp, got.UpdateTimestamp)
 	})
 
+	t.Run("modify EnableDynamicField and SchemaVersion", func(t *testing.T) {
+		snapshot := kv.NewMockSnapshotKV()
+		kvs := map[string]string{}
+		snapshot.SaveFunc = func(ctx context.Context, key string, value string, ts typeutil.Timestamp) error {
+			kvs[key] = value
+			return nil
+		}
+		snapshot.MultiSaveFunc = func(ctx context.Context, saveKvs map[string]string, _ typeutil.Timestamp) error {
+			for k, v := range saveKvs {
+				kvs[k] = v
+			}
+			return nil
+		}
+		kc := NewCatalog(nil, snapshot).(*Catalog)
+		ctx := context.Background()
+		var collectionID int64 = 1
+		oldC := &model.Collection{
+			CollectionID:       collectionID,
+			State:              pb.CollectionState_CollectionCreated,
+			EnableDynamicField: false,
+			SchemaVersion:      1,
+		}
+		newC := &model.Collection{
+			CollectionID:       collectionID,
+			State:              pb.CollectionState_CollectionCreated,
+			EnableDynamicField: true,
+			SchemaVersion:      2,
+			UpdateTimestamp:    rand.Uint64(),
+		}
+		err := kc.AlterCollection(ctx, oldC, newC, metastore.MODIFY, 0, true)
+		assert.NoError(t, err)
+		key := BuildCollectionKey(0, collectionID)
+		value, ok := kvs[key]
+		assert.True(t, ok)
+		var collPb pb.CollectionInfo
+		err = proto.Unmarshal([]byte(value), &collPb)
+		assert.NoError(t, err)
+		got := model.UnmarshalCollectionModel(&collPb)
+		assert.Equal(t, pb.CollectionState_CollectionCreated, got.State)
+		assert.Equal(t, newC.UpdateTimestamp, got.UpdateTimestamp)
+		assert.Equal(t, newC.EnableDynamicField, got.EnableDynamicField)
+		assert.Equal(t, newC.SchemaVersion, got.SchemaVersion)
+	})
+
 	t.Run("modify, tenant id changed", func(t *testing.T) {
 		kc := NewCatalog(nil, nil)
 		ctx := context.Background()


### PR DESCRIPTION
Related to #45614

This commit fixes a bug where certain collection attributes were not properly updated during collection modification, causing metadata errors after cluster restart and collection reload failures.

When altering a collection, the `EnableDynamicField` and `SchemaVersion` attributes were not being persisted to the catalog. This caused inconsistencies between the in-memory collection metadata and the persisted state, leading to:
- Dynamic field validation failures after restart
- Collection loading errors
- Metadata state mismatches