### PR TITLE
fix: Prevent Close from hanging on etcd reconnection

### DIFF
--- a/internal/datacoord/server.go
+++ b/internal/datacoord/server.go
@@ -649,11 +649,6 @@ func (s *Server) rewatchDataNodes(sessions map[string]*sessionutil.Session) erro
 		datanodes = append(datanodes, info)
 	}
 
-	// if err := s.nodeManager.Startup(s.ctx, datanodes); err != nil {
-	// 	log.Warn("DataCoord failed to add datanode", zap.Error(err))
-	// 	return err
-	// }
-
 	log.Info("DataCoord Cluster Manager start up")
 	if err := s.cluster.Startup(s.ctx, datanodes); err != nil {
 		log.Warn("DataCoord Cluster Manager failed to start up", zap.Error(err))


### PR DESCRIPTION
issue: #45623
When etcd reconnects, the DataCoord rewatches DataNodes and calls ChannelManager.Startup again without closing the previous instance. This causes multiple contexts and goroutines to accumulate, leading to Close hanging indefinitely waiting for untracked goroutines.

Root cause:
- Etcd reconnection triggers rewatch flow and calls Startup again
- Startup was not idempotent, allowing repeated calls
- Multiple context cancellations and goroutines accumulated
- Close would wait indefinitely for untracked goroutines

Changes:
- Add started field to ChannelManagerImpl
- Refactor Startup to check and handle restart scenario
- Add state check in Close to prevent hanging