### PR TITLE
fix: [skip e2e] move gRPC server start after service registration in zilliz client tests

### DIFF
--- a/internal/util/function/models/zilliz/zilliz_client_test.go
+++ b/internal/util/function/models/zilliz/zilliz_client_test.go
@@ -205,12 +205,6 @@ func setupMockServer(t *testing.T) (*grpc.Server, *bufconn.Listener, func(contex
 		return lis.Dial()
 	}
 
-	go func() {
-		if err := s.Serve(lis); err != nil {
-			t.Logf("Server exited with error: %v", err)
-		}
-	}()
-
 	return s, lis, dialer
 }
 
@@ -269,6 +263,12 @@ func TestZillizClient_Embedding(t *testing.T) {
 
 	modelservicepb.RegisterTextEmbeddingServiceServer(s, mockServer)
 
+	go func() {
+		if err := s.Serve(lis); err != nil {
+			t.Logf("Server exited with error: %v", err)
+		}
+	}()
+
 	// Create connection
 	conn, err := grpc.DialContext(
 		context.Background(),
@@ -309,6 +309,12 @@ func TestZillizClient_Embedding_Error(t *testing.T) {
 	}
 
 	modelservicepb.RegisterTextEmbeddingServiceServer(s, mockServer)
+
+	go func() {
+		if err := s.Serve(lis); err != nil {
+			t.Logf("Server exited with error: %v", err)
+		}
+	}()
 
 	// Create connection
 	conn, err := grpc.DialContext(
@@ -352,6 +358,12 @@ func TestZillizClient_Rerank(t *testing.T) {
 
 	modelservicepb.RegisterRerankServiceServer(s, mockServer)
 
+	go func() {
+		if err := s.Serve(lis); err != nil {
+			t.Logf("Server exited with error: %v", err)
+		}
+	}()
+
 	// Create connection
 	conn, err := grpc.DialContext(
 		context.Background(),
@@ -391,6 +403,12 @@ func TestZillizClient_Rerank_Error(t *testing.T) {
 	}
 
 	modelservicepb.RegisterRerankServiceServer(s, mockServer)
+
+	go func() {
+		if err := s.Serve(lis); err != nil {
+			t.Logf("Server exited with error: %v", err)
+		}
+	}()
 
 	// Create connection
 	conn, err := grpc.DialContext(
@@ -463,6 +481,12 @@ func TestNewZilliClient_WithMockServer(t *testing.T) {
 	defer s.Stop()
 	defer lis.Close()
 
+	go func() {
+		if err := s.Serve(lis); err != nil {
+			t.Logf("Server exited with error: %v", err)
+		}
+	}()
+
 	// We need to test the client creation with a working connection
 	// Since NewZilliClient uses the global client manager, we need to test it differently
 	t.Run("valid config with mock server", func(t *testing.T) {
@@ -501,6 +525,12 @@ func TestZillizClient_Embedding_EmptyResponse(t *testing.T) {
 	}
 
 	modelservicepb.RegisterTextEmbeddingServiceServer(s, mockServer)
+
+	go func() {
+		if err := s.Serve(lis); err != nil {
+			t.Logf("Server exited with error: %v", err)
+		}
+	}()
 
 	// Create connection
 	conn, err := grpc.DialContext(


### PR DESCRIPTION
The tests were failing with "grpc: Server.RegisterService after Server.Serve" because setupMockServer() was starting the gRPC server before tests could register their services. gRPC requires all services to be registered before Server.Serve() is called.

Changes:
- Remove s.Serve() from setupMockServer() helper function
- Add s.Serve() to each test after service registration
- Apply fix consistently to all 6 affected tests:
  * TestZillizClient_Embedding
  * TestZillizClient_Embedding_Error
  * TestZillizClient_Rerank
  * TestZillizClient_Rerank_Error
  * TestNewZilliClient_WithMockServer
  * TestZillizClient_Embedding_EmptyResponse

This follows the correct gRPC server lifecycle:
1. Create server
2. Register services
3. Start serving

Related to #44620
Case: "internal/util/function/models/zilliz TestZillizClient_Rerank"