### PR TITLE
fix: ut might hang due to the live channel didn't close

### DIFF
--- a/cmd/tools/migration/migration/runner.go
+++ b/cmd/tools/migration/migration/runner.go
@@ -165,7 +165,7 @@ func (r *Runner) CheckSessions() error {
 
 func (r *Runner) RegisterSession() error {
 	r.session.Register()
-	r.session.LivenessCheck(r.ctx, func() {})
+	r.session.LivenessCheck(func() {})
 	return nil
 }
 

--- a/internal/coordinator/mix_coord.go
+++ b/internal/coordinator/mix_coord.go
@@ -114,7 +114,7 @@ func (s *mixCoordImpl) Register() error {
 	afterRegister := func() {
 		metrics.NumNodes.WithLabelValues(fmt.Sprint(paramtable.GetNodeID()), typeutil.MixCoordRole).Inc()
 		log.Info("MixCoord Register Finished")
-		s.session.LivenessCheck(s.ctx, func() {
+		s.session.LivenessCheck(func() {
 			log.Error("MixCoord disconnected from etcd, process will exit", zap.Int64("serverID", s.session.GetServerID()))
 			os.Exit(1)
 		})

--- a/internal/distributed/streamingnode/service.go
+++ b/internal/distributed/streamingnode/service.go
@@ -387,7 +387,7 @@ func (s *Server) startGPRCServer(ctx context.Context) error {
 func (s *Server) registerSessionToETCD() {
 	s.session.Register()
 	// start liveness check
-	s.session.LivenessCheck(context.Background(), func() {
+	s.session.LivenessCheck(func() {
 		log.Ctx(s.ctx).Error("StreamingNode disconnected from etcd, process will exit", zap.Int64("Server Id", paramtable.GetNodeID()))
 		os.Exit(1)
 	})

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -157,7 +157,7 @@ func (node *Proxy) Register() error {
 	node.session.Register()
 	metrics.NumNodes.WithLabelValues(fmt.Sprint(paramtable.GetNodeID()), typeutil.ProxyRole).Inc()
 	log.Info("Proxy Register Finished")
-	node.session.LivenessCheck(node.ctx, func() {
+	node.session.LivenessCheck(func() {
 		log.Error("Proxy disconnected from etcd, process will exit", zap.Int64("Server Id", node.session.ServerID))
 		os.Exit(1)
 	})

--- a/internal/querynodev2/server.go
+++ b/internal/querynodev2/server.go
@@ -182,7 +182,7 @@ func (node *QueryNode) Register() error {
 	node.session.Register()
 	// start liveness check
 	metrics.NumNodes.WithLabelValues(fmt.Sprint(node.GetNodeID()), typeutil.QueryNodeRole).Inc()
-	node.session.LivenessCheck(node.ctx, func() {
+	node.session.LivenessCheck(func() {
 		log.Ctx(node.ctx).Error("Query Node disconnected from etcd, process will exit", zap.Int64("Server Id", paramtable.GetNodeID()))
 		os.Exit(1)
 	})

--- a/internal/rootcoord/root_coord.go
+++ b/internal/rootcoord/root_coord.go
@@ -699,17 +699,6 @@ func (c *Core) cancelIfNotNil() {
 	}
 }
 
-func (c *Core) revokeSession() {
-	if c.session != nil {
-		// wait at most one second to revoke
-		c.session.Stop()
-		log.Ctx(c.ctx).Info("rootcoord session stop")
-	}
-}
-
-func (c *Core) GracefulStop() {
-}
-
 // Stop stops rootCoord.
 func (c *Core) Stop() error {
 	c.UpdateStateCode(commonpb.StateCode_Abnormal)
@@ -725,7 +714,11 @@ func (c *Core) Stop() error {
 		c.quotaCenter.stop()
 	}
 
-	c.revokeSession()
+	log.Ctx(c.ctx).Info("rootcoord stop session")
+	if c.session != nil {
+		// wait at most one second to revoke
+		c.session.Stop()
+	}
 	c.cancelIfNotNil()
 	c.wg.Wait()
 	return nil

--- a/internal/streamingcoord/server/server.go
+++ b/internal/streamingcoord/server/server.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
@@ -90,5 +89,9 @@ func (s *Server) Stop() {
 	broadcast.Release()
 	s.logger.Info("release streamingcoord resource...")
 	resource.Release()
+	s.logger.Info("stop streamingcoord session...")
+	if s.session != nil {
+		s.session.Stop()
+	}
 	s.logger.Info("streamingcoord server stopped")
 }

--- a/internal/util/sessionutil/mock_session.go
+++ b/internal/util/sessionutil/mock_session.go
@@ -3,8 +3,6 @@
 package sessionutil
 
 import (
-	context "context"
-
 	semver "github.com/blang/semver/v4"
 	mock "github.com/stretchr/testify/mock"
 
@@ -416,9 +414,9 @@ func (_c *MockSession_IsTriggerKill_Call) RunAndReturn(run func() bool) *MockSes
 	return _c
 }
 
-// LivenessCheck provides a mock function with given fields: ctx, callback
-func (_m *MockSession) LivenessCheck(ctx context.Context, callback func()) {
-	_m.Called(ctx, callback)
+// LivenessCheck provides a mock function with given fields: callback
+func (_m *MockSession) LivenessCheck(callback func()) {
+	_m.Called(callback)
 }
 
 // MockSession_LivenessCheck_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'LivenessCheck'
@@ -427,15 +425,14 @@ type MockSession_LivenessCheck_Call struct {
 }
 
 // LivenessCheck is a helper method to define mock.On call
-//   - ctx context.Context
 //   - callback func()
-func (_e *MockSession_Expecter) LivenessCheck(ctx interface{}, callback interface{}) *MockSession_LivenessCheck_Call {
-	return &MockSession_LivenessCheck_Call{Call: _e.mock.On("LivenessCheck", ctx, callback)}
+func (_e *MockSession_Expecter) LivenessCheck(callback interface{}) *MockSession_LivenessCheck_Call {
+	return &MockSession_LivenessCheck_Call{Call: _e.mock.On("LivenessCheck", callback)}
 }
 
-func (_c *MockSession_LivenessCheck_Call) Run(run func(ctx context.Context, callback func())) *MockSession_LivenessCheck_Call {
+func (_c *MockSession_LivenessCheck_Call) Run(run func(callback func())) *MockSession_LivenessCheck_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(func()))
+		run(args[0].(func()))
 	})
 	return _c
 }
@@ -445,7 +442,7 @@ func (_c *MockSession_LivenessCheck_Call) Return() *MockSession_LivenessCheck_Ca
 	return _c
 }
 
-func (_c *MockSession_LivenessCheck_Call) RunAndReturn(run func(context.Context, func())) *MockSession_LivenessCheck_Call {
+func (_c *MockSession_LivenessCheck_Call) RunAndReturn(run func(func())) *MockSession_LivenessCheck_Call {
 	_c.Run(run)
 	return _c
 }

--- a/internal/util/sessionutil/session.go
+++ b/internal/util/sessionutil/session.go
@@ -16,7 +16,6 @@
 package sessionutil
 
 import (
-	"context"
 	"time"
 
 	"github.com/blang/semver/v4"
@@ -36,7 +35,7 @@ type SessionInterface interface {
 	GoingStop() error
 	WatchServices(prefix string, revision int64, rewatch Rewatch) (watcher SessionWatcher)
 	WatchServicesWithVersionRange(prefix string, r semver.Range, revision int64, rewatch Rewatch) (watcher SessionWatcher)
-	LivenessCheck(ctx context.Context, callback func())
+	LivenessCheck(callback func())
 	Stop()
 	Revoke(timeout time.Duration)
 	UpdateRegistered(b bool)


### PR DESCRIPTION
related to #45667
if processKeepAliveResponse is context canceled,  then there might be no trigger on live channel, which may cause ut stuck forever.
Also simplified liveness check and make sure liveness only related to keep alive failure