### PR TITLE
enhance: [2.6] Remove large segment ID arrays from QueryNode logs

### DIFF
--- a/internal/querynodev2/delegator/delegator.go
+++ b/internal/querynodev2/delegator/delegator.go
@@ -220,10 +220,6 @@ func (sd *shardDelegator) GetSegmentInfo(readable bool) ([]SnapshotItem, []Segme
 
 // SyncDistribution revises distribution.
 func (sd *shardDelegator) SyncDistribution(ctx context.Context, entries ...SegmentEntry) {
-	log := sd.getLogger(ctx)
-
-	log.Info("sync distribution", zap.Any("entries", entries))
-
 	sd.distribution.AddDistributions(entries...)
 }
 


### PR DESCRIPTION
issue: #45718
pr: #45719
Logging complete segment ID arrays caused excessive log volume (3-6 TB for 200k segments). Remove arrays from logger fields and keep only segment counts for observability.

Changes:
- Remove requestSegments/preparedSegments arrays from Load logger
- Remove segmentIDs from BM25 stats logs
- Remove entries structure from sync distribution log

This reduces log volume by 99.99% for large-scale operations.