### PR TITLE
enhance: [2.6] add vector reserve to improve memory allocation in segcore

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -285,6 +285,7 @@ ChunkedSegmentSealedImpl::load_column_group_data_internal(
         // warmup will be disabled only when all columns are not in load list
         bool merged_in_load_list = false;
         std::vector<FieldId> milvus_field_ids;
+        milvus_field_ids.reserve(field_id_list.size());
         for (int i = 0; i < field_id_list.size(); ++i) {
             milvus_field_ids.push_back(FieldId(field_id_list.Get(i)));
             merged_in_load_list = merged_in_load_list ||

--- a/internal/core/src/segcore/TimestampIndex.cpp
+++ b/internal/core/src/segcore/TimestampIndex.cpp
@@ -23,9 +23,11 @@ TimestampIndex::build_with(const Timestamp* timestamps, int64_t size) {
     auto num_slice = lengths_.size();
     Assert(num_slice > 0);
     std::vector<int64_t> prefix_sums;
+    prefix_sums.reserve(num_slice + 1);
     int offset = 0;
     prefix_sums.push_back(offset);
     std::vector<Timestamp> timestamp_barriers;
+    timestamp_barriers.reserve(num_slice + 1);
     Timestamp last_max_v = 0;
     for (int slice_id = 0; slice_id < num_slice; ++slice_id) {
         auto length = lengths_[slice_id];

--- a/internal/core/thirdparty/tantivy/tantivy-wrapper.h
+++ b/internal/core/thirdparty/tantivy/tantivy-wrapper.h
@@ -355,6 +355,7 @@ struct TantivyIndexWrapper {
                         int64_t offset_begin) {
         assert(!finished_);
         std::vector<const char*> views;
+        views.reserve(len);
         for (uintptr_t i = 0; i < len; i++) {
             views.push_back(array[i].c_str());
         }
@@ -435,6 +436,7 @@ struct TantivyIndexWrapper {
 
         if constexpr (std::is_same_v<T, std::string>) {
             std::vector<const char*> views;
+            views.reserve(len);
             for (uintptr_t i = 0; i < len; i++) {
                 views.push_back(array[i].c_str());
             }
@@ -621,6 +623,7 @@ struct TantivyIndexWrapper {
 
         if constexpr (std::is_same_v<T, std::string>) {
             std::vector<const char*> views;
+            views.reserve(len);
             for (uintptr_t i = 0; i < len; i++) {
                 views.push_back(array[i].c_str());
             }
@@ -709,6 +712,7 @@ struct TantivyIndexWrapper {
                 } else {
                     // smaller integer should be converted first
                     std::vector<int64_t> buf(len);
+                    buf.reserve(len);
                     for (uintptr_t i = 0; i < len; ++i) {
                         buf[i] = static_cast<int64_t>(terms[i]);
                     }
@@ -726,6 +730,7 @@ struct TantivyIndexWrapper {
                         bitset);
                 } else {
                     std::vector<double> buf(len);
+                    buf.reserve(len);
                     for (uintptr_t i = 0; i < len; ++i) {
                         buf[i] = static_cast<double>(terms[i]);
                     }
@@ -736,6 +741,7 @@ struct TantivyIndexWrapper {
 
             if constexpr (std::is_same_v<T, std::string>) {
                 std::vector<const char*> views;
+                views.reserve(len);
                 for (uintptr_t i = 0; i < len; i++) {
                     views.push_back(terms[i].c_str());
                 }


### PR DESCRIPTION
This commit optimizes std::vector usage across segcore by adding reserve() calls where the size is known in advance, reducing memory reallocations during push_back operations.

Changes:

TimestampIndex.cpp: Reserve space for prefix_sums and timestamp_barriers
SegmentGrowingImpl.cpp: Reserve space for binlog info vectors
ChunkedSegmentSealedImpl.cpp: Reserve space for futures and field data vectors
storagev2translator/GroupChunkTranslator.cpp: Reserve space for metadata vectors
This improves performance by avoiding multiple memory reallocations when the vector size is predictable.

issue: https://github.com/milvus-io/milvus/issues/45679
pr: https://github.com/milvus-io/milvus/pull/45757