### PR TITLE
fix: populate index info after segment loading to prevent redundant load tasks

### DIFF
--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -931,6 +931,16 @@ func (loader *segmentLoader) loadSealedSegment(ctx context.Context, loadInfo *qu
 		return errors.Wrap(err, "At FinishLoad")
 	}
 
+	for _, indexInfo := range loadInfo.IndexInfos {
+		segment.fieldIndexes.Insert(indexInfo.GetIndexID(), &IndexedFieldInfo{
+			FieldBinlog: &datapb.FieldBinlog{
+				FieldID: indexInfo.GetFieldID(),
+			},
+			IndexInfo: indexInfo,
+			IsLoaded:  true,
+		})
+	}
+
 	// load text indexes.
 	for _, info := range textIndexes {
 		if err := segment.LoadTextIndex(ctx, info, schemaHelper); err != nil {


### PR DESCRIPTION
After segments gained self-management capabilities for loading, the index information from the initial load was not being preserved in the Go-side segment metadata. This caused QueryCoord to repeatedly dispatch load index tasks, which would fail in segcore since the indexes were already loaded.

**Root Cause:**
The segment's `fieldIndexes` map was not being populated with index metadata after calling `FinishLoad`, leading to a mismatch between the Go-side metadata and segcore's internal state.

**Solution:**
After successfully loading a sealed segment, iterate through `loadInfo.IndexInfos` and insert each index entry into the segment's `fieldIndexes` map. This ensures the Go-side metadata stays in sync with segcore and prevents redundant load index operations.

Fixes #45802
Related to #45060