### PR TITLE
fix: Move Init and Remove EZ logic out of metatable

### DIFF
--- a/internal/rootcoord/create_collection_task.go
+++ b/internal/rootcoord/create_collection_task.go
@@ -494,8 +494,8 @@ func (t *createCollectionTask) Prepare(ctx context.Context) error {
 		t.Req.Properties = append(properties, timezoneKV)
 	}
 
-	if hookutil.GetEzPropByDBProperties(db.Properties) != nil {
-		t.Req.Properties = append(t.Req.Properties, hookutil.GetEzPropByDBProperties(db.Properties))
+	if ezProps := hookutil.GetEzPropByDBProperties(db.Properties); ezProps != nil {
+		t.Req.Properties = append(t.Req.Properties, ezProps)
 	}
 
 	t.header.DbId = db.ID

--- a/internal/rootcoord/ddl_callbacks_create_database.go
+++ b/internal/rootcoord/ddl_callbacks_create_database.go
@@ -58,10 +58,16 @@ func (c *Core) broadcastCreateDatabase(ctx context.Context, req *milvuspb.Create
 	if err != nil {
 		return errors.Wrap(err, "failed to tidy database cipher properties")
 	}
+
 	tz, exist := funcutil.TryGetAttrByKeyFromRepeatedKV(common.TimezoneKey, properties)
 	if exist && !timestamptz.IsTimezoneValid(tz) {
 		return merr.WrapErrParameterInvalidMsg("unknown or invalid IANA Time Zone ID: %s", tz)
 	}
+
+	if err := hookutil.CreateEZByDBProperties(properties); err != nil {
+		return errors.Wrap(err, "failed to create ez by db properties")
+	}
+
 	msg := message.NewCreateDatabaseMessageBuilderV2().
 		WithHeader(&message.CreateDatabaseMessageHeader{
 			DbName: req.GetDbName(),

--- a/internal/rootcoord/ddl_callbacks_drop_database.go
+++ b/internal/rootcoord/ddl_callbacks_drop_database.go
@@ -25,6 +25,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
+	"github.com/milvus-io/milvus/internal/util/hookutil"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message/ce"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"

--- a/internal/rootcoord/ddl_callbacks_drop_database.go
+++ b/internal/rootcoord/ddl_callbacks_drop_database.go
@@ -47,6 +47,11 @@ func (c *Core) broadcastDropDatabase(ctx context.Context, req *milvuspb.DropData
 		return errors.Wrap(err, "failed to get database name")
 	}
 
+	// Call back cipher plugin when dropping database succeeded
+	if err := hookutil.RemoveEZByDBProperties(db.Properties); err != nil {
+		return errors.Wrap(err, "failed to remove ez by db properties")
+	}
+
 	msg := message.NewDropDatabaseMessageBuilderV2().
 		WithHeader(&message.DropDatabaseMessageHeader{
 			DbName: req.GetDbName(),

--- a/internal/rootcoord/meta_table.go
+++ b/internal/rootcoord/meta_table.go
@@ -342,7 +342,7 @@ func (mt *MetaTable) createDefaultDb() error {
 		cipherProps := hookutil.GetDBCipherProperties(ezID, defaultRootKey)
 		defaultProperties = append(defaultProperties, cipherProps...)
 
-		if err := hookutil.CreateEZByDBProperties(DefaultRateAllocateStrategy); err != nil {
+		if err := hookutil.CreateEZByDBProperties(defaultProperties); err != nil {
 			return err
 		}
 	}

--- a/internal/rootcoord/meta_table.go
+++ b/internal/rootcoord/meta_table.go
@@ -341,6 +341,10 @@ func (mt *MetaTable) createDefaultDb() error {
 
 		cipherProps := hookutil.GetDBCipherProperties(ezID, defaultRootKey)
 		defaultProperties = append(defaultProperties, cipherProps...)
+
+		if err := hookutil.CreateEZByDBProperties(DefaultRateAllocateStrategy); err != nil {
+			return err
+		}
 	}
 
 	return mt.createDatabasePrivate(mt.ctx, model.NewDefaultDatabase(defaultProperties), ts)
@@ -377,12 +381,7 @@ func (mt *MetaTable) CreateDatabase(ctx context.Context, db *model.Database, ts 
 
 func (mt *MetaTable) createDatabasePrivate(ctx context.Context, db *model.Database, ts typeutil.Timestamp) error {
 	dbName := db.Name
-	if err := hookutil.CreateEZByDBProperties(db.Properties); err != nil {
-		return err
-	}
-
 	if err := mt.catalog.CreateDatabase(ctx, db, ts); err != nil {
-		hookutil.RemoveEZByDBProperties(db.Properties) // ignore the error since create database failed
 		return err
 	}
 
@@ -441,11 +440,6 @@ func (mt *MetaTable) DropDatabase(ctx context.Context, dbName string, ts typeuti
 		return nil
 	}
 	if err := mt.catalog.DropDatabase(ctx, db.ID, ts); err != nil {
-		return err
-	}
-
-	// Call back cipher plugin when dropping database succeeded
-	if err := hookutil.RemoveEZByDBProperties(db.Properties); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This will avoid endless retry CreateDatabase/DropDatabase when cipherPlugin fails in the new DDL framework.

See also: #45826