### PR TITLE
enhance: log unhealthy task type for easier resource troubleshooting

### DIFF
--- a/internal/datacoord/task/global_scheduler.go
+++ b/internal/datacoord/task/global_scheduler.go
@@ -251,7 +251,8 @@ func (s *globalTaskScheduler) updateTaskTimeMetrics() {
 
 		queueingTime := time.Since(task.GetTaskTime(taskcommon.TimeQueue))
 		if queueingTime > paramtable.Get().DataCoordCfg.TaskSlowThreshold.GetAsDuration(time.Second) {
-			log.Ctx(s.ctx).Warn("task queueing time is too long", zap.Int64("taskID", taskID),
+			log.Ctx(s.ctx).Warn("task queueing time is too long",
+				zap.Int64("taskID", taskID), zap.String("taskType", taskType),
 				zap.Int64("queueing time(ms)", queueingTime.Milliseconds()))
 		}
 
@@ -272,7 +273,8 @@ func (s *globalTaskScheduler) updateTaskTimeMetrics() {
 
 		runningTime := time.Since(task.GetTaskTime(taskcommon.TimeStart))
 		if runningTime > paramtable.Get().DataCoordCfg.TaskSlowThreshold.GetAsDuration(time.Second) {
-			log.Ctx(s.ctx).Warn("task running time is too long", zap.Int64("taskID", task.GetTaskID()),
+			log.Ctx(s.ctx).Warn("task running time is too long",
+				zap.Int64("taskID", task.GetTaskID()), zap.String("taskType", taskType),
 				zap.Int64("running time(ms)", runningTime.Milliseconds()))
 		}
 


### PR DESCRIPTION
Tasks queuing or running for a long time indicate resource insufficiency. Displaying the unhealthy tasks' types helps diagnosing what kind of resource needs scaling, i.e. datanodes or indexnodes.

> Resubmission of #44274