### PR TITLE
enhance: use milvus-storage internal C++ Reader API for Loon FFI

### DIFF
--- a/internal/core/src/storage/loon_ffi/ffi_reader_c.h
+++ b/internal/core/src/storage/loon_ffi/ffi_reader_c.h
@@ -30,7 +30,7 @@ extern "C" {
  * from storage in Milvus. The reader supports Arrow-based data access
  * through the FFI (Foreign Function Interface) layer.
  */
-typedef ReaderHandle CFFIPackedReader;
+typedef void* CFFIPackedReader;
 
 /**
  * @brief Creates a new packed FFI reader from a manifest file path.
@@ -109,7 +109,7 @@ NewPackedFFIReaderWithManifest(const char* manifest_content,
                                struct ArrowSchema* schema,
                                char** needed_columns,
                                int64_t needed_columns_size,
-                               CFFIPackedReader* c_packed_reader,
+                               CFFIPackedReader* c_loon_reader,
                                CStorageConfig c_storage_config,
                                CPluginContext* c_plugin_context);
 

--- a/internal/core/thirdparty/milvus-storage/CMakeLists.txt
+++ b/internal/core/thirdparty/milvus-storage/CMakeLists.txt
@@ -14,7 +14,7 @@
 # Update milvus-storage_VERSION for the first occurrence
 milvus_add_pkg_config("milvus-storage")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( milvus-storage_VERSION 302143c)
+set( milvus-storage_VERSION ba7df7b)
 set( GIT_REPOSITORY  "https://github.com/milvus-io/milvus-storage.git")
 message(STATUS "milvus-storage repo: ${GIT_REPOSITORY}")
 message(STATUS "milvus-storage version: ${milvus-storage_VERSION}")

--- a/internal/storagev2/packed/packed_reader_ffi.go
+++ b/internal/storagev2/packed/packed_reader_ffi.go
@@ -163,13 +163,8 @@ func (r *FFIPackedReader) Close() error {
 		r.recordReader = nil
 	}
 
-	if r.cPackedReader != 0 {
-		status := C.CloseFFIReader(r.cPackedReader)
-		r.cPackedReader = 0
-		return ConsumeCStatusIntoError(&status)
-	}
-
-	return nil
+	status := C.CloseFFIReader(r.cPackedReader)
+	return ConsumeCStatusIntoError(&status)
 }
 
 // Schema returns the schema of the reader


### PR DESCRIPTION
This PR refactors the Loon FFI reader implementation to use milvus-storage's internal C++ Reader API directly instead of the external FFI interface.

Key changes:
- Replace external FFI calls (get_record_batch_reader, reader_destroy) with direct C++ Reader API calls
- Add GetLoonReader() helper function to create Reader instances using milvus-storage::api::Reader::create()
- Use MakeInternalPropertiesFromStorageConfig() instead of MakePropertiesFromStorageConfig() to get internal properties
- Update NewPackedFFIReaderWithManifest() to deserialize column groups from JSON manifest content directly
- Simplify GetFFIReaderStream() to use Reader::get_record_batch_reader() and arrow::ExportRecordBatchReader() for Arrow stream export
- Change CFFIPackedReader typedef from ReaderHandle to void* for flexibility
- Update milvus-storage dependency version to ba7df7b

This change improves code maintainability by using the native C++ API directly and eliminates the overhead of going through the external FFI layer.

issue: #44956