### PR TITLE
fix: Add EmptySessionWatcher to prevent panic in IndexNodeBinding mode

### DIFF
--- a/internal/datacoord/server.go
+++ b/internal/datacoord/server.go
@@ -523,6 +523,7 @@ func (s *Server) initServiceDiscovery() error {
 			log.Warn("DataCoord failed to add datanode", zap.Error(err))
 			return err
 		}
+		s.dnSessionWatcher = sessionutil.EmptySessionWatcher()
 	} else {
 		err := s.rewatchDataNodes(sessions)
 		if err != nil {

--- a/internal/util/sessionutil/session_util.go
+++ b/internal/util/sessionutil/session_util.go
@@ -806,6 +806,20 @@ func (w *sessionWatcher) Stop() {
 	w.wg.Wait()
 }
 
+// EmptySessionWatcher returns a place holder for IndexNodeBinding mode datacoord
+func EmptySessionWatcher() SessionWatcher {
+	return emptySessionWatcher{}
+}
+
+// emptySessionWatcher is a place holder for IndexNodeBinding mode datacoord
+type emptySessionWatcher struct{}
+
+func (emptySessionWatcher) EventChannel() <-chan *SessionEvent {
+	return nil
+}
+
+func (emptySessionWatcher) Stop() {}
+
 // WatchServices watches the service's up and down in etcd, and sends event to
 // eventChannel.
 // prefix is a parameter to know which service to watch and can be obtained in


### PR DESCRIPTION
Related to #45910

When IndexNodeBinding mode is enabled, DataCoord skips session watching for datanodes but the dnSessionWatcher field remains nil. This causes a panic when other code attempts to access the watcher.

This fix introduces an EmptySessionWatcher as a placeholder for the IndexNodeBinding mode scenario. The empty watcher implements the SessionWatcher interface with no-op methods, preventing nil pointer dereferences while maintaining the expected interface contract.