### PR TITLE
enhance: validate external collection request

### DIFF
--- a/internal/metastore/model/collection.go
+++ b/internal/metastore/model/collection.go
@@ -55,6 +55,8 @@ type Collection struct {
 	SchemaVersion        int32
 	ShardInfos           map[string]*ShardInfo
 	FileResourceIds      []int64
+	ExternalSource       string
+	ExternalSpec         string
 }
 
 type ShardInfo struct {
@@ -94,6 +96,8 @@ func (c *Collection) ShallowClone() *Collection {
 		SchemaVersion:        c.SchemaVersion,
 		ShardInfos:           c.ShardInfos,
 		FileResourceIds:      c.FileResourceIds,
+		ExternalSource:       c.ExternalSource,
+		ExternalSpec:         c.ExternalSpec,
 	}
 }
 
@@ -132,6 +136,8 @@ func (c *Collection) Clone() *Collection {
 		SchemaVersion:        c.SchemaVersion,
 		ShardInfos:           shardInfos,
 		FileResourceIds:      slices.Clone(c.FileResourceIds),
+		ExternalSource:       c.ExternalSource,
+		ExternalSpec:         c.ExternalSpec,
 	}
 }
 
@@ -180,6 +186,8 @@ func (c *Collection) ApplyUpdates(header *message.AlterCollectionMessageHeader, 
 			c.Functions = UnmarshalFunctionModels(updates.Schema.Functions)
 			c.StructArrayFields = UnmarshalStructArrayFieldModels(updates.Schema.StructArrayFields)
 			c.SchemaVersion = updates.Schema.Version
+			c.ExternalSource = updates.Schema.ExternalSource
+			c.ExternalSpec = updates.Schema.ExternalSpec
 		}
 	}
 }
@@ -238,6 +246,8 @@ func UnmarshalCollectionModel(coll *pb.CollectionInfo) *Collection {
 		SchemaVersion:        coll.Schema.Version,
 		ShardInfos:           shardInfos,
 		FileResourceIds:      coll.Schema.GetFileResourceIds(),
+		ExternalSource:       coll.Schema.ExternalSource,
+		ExternalSpec:         coll.Schema.ExternalSpec,
 	}
 }
 
@@ -290,6 +300,8 @@ func marshalCollectionModelWithConfig(coll *Collection, c *config) *pb.Collectio
 		DbName:             coll.DBName,
 		Version:            coll.SchemaVersion,
 		FileResourceIds:    coll.FileResourceIds,
+		ExternalSource:     coll.ExternalSource,
+		ExternalSpec:       coll.ExternalSpec,
 	}
 
 	if c.withFields {

--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -408,6 +408,11 @@ func (t *createCollectionTask) PreExecute(ctx context.Context) error {
 		return err
 	}
 
+	// validate external collection
+	if err := validateExternalCollection(t.schema); err != nil {
+		return err
+	}
+
 	// validate auto id definition
 	if err := ValidateFieldAutoID(t.schema); err != nil {
 		return err

--- a/internal/rootcoord/ddl_callbacks_create_collection.go
+++ b/internal/rootcoord/ddl_callbacks_create_collection.go
@@ -205,6 +205,8 @@ func newCollectionModel(header *message.CreateCollectionMessageHeader, body *mes
 		SchemaVersion:        0,
 		ShardInfos:           shardInfos,
 		FileResourceIds:      body.CollectionSchema.GetFileResourceIds(),
+		ExternalSource:       body.CollectionSchema.ExternalSource,
+		ExternalSpec:         body.CollectionSchema.ExternalSpec,
 	}
 }
 


### PR DESCRIPTION
issue: #45881 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Pull Request Summary: Validate External Collection Request

**Core Invariant:** External collections must have an explicit ExternalSource identifier, and all non-system fields must declare an external_field mapping. These collections cannot enable dynamic fields and may omit a primary key.

**What is Added (Enhancement):**
- Validation gate `validateExternalCollection()` enforces three constraints during collection creation: (1) dynamic fields must be disabled, (2) every non-system field must have an external_field mapping defined, and (3) struct array sub-fields must also declare external_field mappings. The validation is invoked in `createCollectionTask.PreExecute` after dynamic field validation, failing fast on misconfiguration.

**Why This Does NOT Introduce Regression:**
- Regular (non-external) collections have empty ExternalSource and bypass all new validation entirely—only explicit external collections (ExternalSource != "") trigger the constraint checks. The primary key validation explicitly exempts external collections via `if coll.ExternalSource == ""`, preserving existing behavior for standard collections.
- ExternalSource and ExternalSpec are persisted through marshal/unmarshal and clone operations, ensuring metadata consistency and enabling proper downstream handling already implemented in `internal/datacoord/external_collection_inspector.go`.

**Operational Effect:**
- Users attempting to create external collections without proper external_field mappings or with dynamic fields enabled now receive immediate validation errors during request pre-execution, preventing invalid configurations from reaching the coordinator layer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->