### PR TITLE
enhance: support pause GC at collection level

### DIFF
--- a/internal/datacoord/garbage_collector.go
+++ b/internal/datacoord/garbage_collector.go
@@ -120,11 +120,12 @@ func (gc *gcPauseRecords) Insert(ticket string, pauseUntil time.Time) error {
 	defer gc.mut.Unlock()
 
 	// heap small enough, short path
-	if gc.records.Len() >= gc.maxLen {
+	if gc.records.Len() < gc.maxLen {
 		gc.records.Push(gcPauseRecord{
 			ticket:     ticket,
 			pauseUntil: pauseUntil,
 		})
+		return nil
 	}
 
 	records := make([]gcPauseRecord, 0, gc.records.Len())
@@ -136,7 +137,7 @@ func (gc *gcPauseRecords) Insert(ticket string, pauseUntil time.Time) error {
 		}
 	}
 
-	if gc.records.Len() >= gc.maxLen {
+	if gc.records.Len() < gc.maxLen {
 		gc.records.Push(gcPauseRecord{
 			ticket:     ticket,
 			pauseUntil: pauseUntil,

--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -1809,8 +1809,9 @@ func (s *Server) GcControl(ctx context.Context, request *datapb.GcControlRequest
 		if err != nil {
 			return merr.Status(err), nil
 		}
+		ticket, _ := common.GetStringValue(request.GetParams(), "ticket")
 
-		if err := s.garbageCollector.Pause(ctx, collectionID, time.Duration(pauseSeconds)*time.Second); err != nil {
+		if err := s.garbageCollector.Pause(ctx, collectionID, ticket, time.Duration(pauseSeconds)*time.Second); err != nil {
 			status.ErrorCode = commonpb.ErrorCode_UnexpectedError
 			status.Reason = fmt.Sprintf("failed to pause gc, %s", err.Error())
 			return status, nil
@@ -1820,7 +1821,8 @@ func (s *Server) GcControl(ctx context.Context, request *datapb.GcControlRequest
 		if err != nil {
 			return merr.Status(err), nil
 		}
-		if err := s.garbageCollector.Resume(ctx, collectionID); err != nil {
+		ticket, _ := common.GetStringValue(request.GetParams(), "ticket")
+		if err := s.garbageCollector.Resume(ctx, collectionID, ticket); err != nil {
 			status.ErrorCode = commonpb.ErrorCode_UnexpectedError
 			status.Reason = fmt.Sprintf("failed to pause gc, %s", err.Error())
 			return status, nil

--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -1804,13 +1804,23 @@ func (s *Server) GcControl(ctx context.Context, request *datapb.GcControlRequest
 			status.Reason = fmt.Sprintf("pause duration not valid, %s", err.Error())
 			return status, nil
 		}
-		if err := s.garbageCollector.Pause(ctx, time.Duration(pauseSeconds)*time.Second); err != nil {
+
+		collectionID, err, _ := common.GetInt64Value(request.GetParams(), "collection_id")
+		if err != nil {
+			return merr.Status(err), nil
+		}
+
+		if err := s.garbageCollector.Pause(ctx, collectionID, time.Duration(pauseSeconds)*time.Second); err != nil {
 			status.ErrorCode = commonpb.ErrorCode_UnexpectedError
 			status.Reason = fmt.Sprintf("failed to pause gc, %s", err.Error())
 			return status, nil
 		}
 	case datapb.GcCommand_Resume:
-		if err := s.garbageCollector.Resume(ctx); err != nil {
+		collectionID, err, _ := common.GetInt64Value(request.GetParams(), "collection_id")
+		if err != nil {
+			return merr.Status(err), nil
+		}
+		if err := s.garbageCollector.Resume(ctx, collectionID); err != nil {
 			status.ErrorCode = commonpb.ErrorCode_UnexpectedError
 			status.Reason = fmt.Sprintf("failed to pause gc, %s", err.Error())
 			return status, nil

--- a/internal/proxy/management.go
+++ b/internal/proxy/management.go
@@ -91,13 +91,20 @@ func RegisterMgrRoute(proxy *Proxy) {
 
 func (node *Proxy) PauseDatacoordGC(w http.ResponseWriter, req *http.Request) {
 	pauseSeconds := req.URL.Query().Get("pause_seconds")
+	params := []*commonpb.KeyValuePair{
+		{Key: "duration", Value: pauseSeconds},
+	}
+	if req.URL.Query().Has("collection_id") {
+		params = append(params, &commonpb.KeyValuePair{
+			Key:   "collection_id",
+			Value: req.URL.Query().Get("collection_id"),
+		})
+	}
 
 	resp, err := node.mixCoord.GcControl(req.Context(), &datapb.GcControlRequest{
 		Base:    commonpbutil.NewMsgBase(),
 		Command: datapb.GcCommand_Pause,
-		Params: []*commonpb.KeyValuePair{
-			{Key: "duration", Value: pauseSeconds},
-		},
+		Params:  params,
 	})
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -114,9 +121,18 @@ func (node *Proxy) PauseDatacoordGC(w http.ResponseWriter, req *http.Request) {
 }
 
 func (node *Proxy) ResumeDatacoordGC(w http.ResponseWriter, req *http.Request) {
+	params := []*commonpb.KeyValuePair{}
+	if req.URL.Query().Has("collection_id") {
+		params = append(params, &commonpb.KeyValuePair{
+			Key:   "collection_id",
+			Value: req.URL.Query().Get("collection_id"),
+		})
+	}
+
 	resp, err := node.mixCoord.GcControl(req.Context(), &datapb.GcControlRequest{
 		Base:    commonpbutil.NewMsgBase(),
 		Command: datapb.GcCommand_Resume,
+		Params:  params,
 	})
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)

--- a/internal/proxy/management.go
+++ b/internal/proxy/management.go
@@ -92,7 +92,7 @@ func RegisterMgrRoute(proxy *Proxy) {
 
 func (node *Proxy) PauseDatacoordGC(w http.ResponseWriter, req *http.Request) {
 	pauseSeconds := req.URL.Query().Get("pause_seconds")
-	// generate ticke for request
+	// generate ticket for request
 	ticket := uuid.New().String()
 	params := []*commonpb.KeyValuePair{
 		{Key: "duration", Value: pauseSeconds},

--- a/internal/proxy/management.go
+++ b/internal/proxy/management.go
@@ -93,6 +93,9 @@ func RegisterMgrRoute(proxy *Proxy) {
 
 // EncodeTicket encodes the ticket with token and collectionID
 func EncodeTicket(token string, collectionID string) string {
+	if collectionID == "" {
+		collectionID = "-1"
+	}
 	m := map[string]string{
 		"token":         token,
 		"collection_id": collectionID,

--- a/internal/proxy/management_test.go
+++ b/internal/proxy/management_test.go
@@ -64,7 +64,7 @@ func (s *ProxyManagementSuite) TestPauseDataCoordGC() {
 			return &commonpb.Status{}, nil
 		})
 
-		req, err := http.NewRequest(http.MethodGet, management.RouteGcPause+"?pause_seconds=60", nil)
+		req, err := http.NewRequest(http.MethodGet, management.RouteGcPause+"?pause_seconds=60&collection_id=100", nil)
 		s.Require().NoError(err)
 
 		recorder := httptest.NewRecorder()
@@ -80,7 +80,7 @@ func (s *ProxyManagementSuite) TestPauseDataCoordGC() {
 			return &commonpb.Status{}, errors.New("mock")
 		})
 
-		req, err := http.NewRequest(http.MethodGet, management.RouteGcPause+"?pause_seconds=60", nil)
+		req, err := http.NewRequest(http.MethodGet, management.RouteGcPause+"?pause_seconds=60&collection_id=100", nil)
 		s.Require().NoError(err)
 
 		recorder := httptest.NewRecorder()
@@ -118,7 +118,7 @@ func (s *ProxyManagementSuite) TestResumeDatacoordGC() {
 			return &commonpb.Status{}, nil
 		})
 
-		req, err := http.NewRequest(http.MethodGet, management.RouteGcResume, nil)
+		req, err := http.NewRequest(http.MethodGet, management.RouteGcResume+"?collection_id=100", nil)
 		s.Require().NoError(err)
 
 		recorder := httptest.NewRecorder()

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -606,6 +606,21 @@ func IsAllowInsertAutoID(kvs ...*commonpb.KeyValuePair) (bool, bool) {
 	return false, false
 }
 
+func GetInt64Value(kvs []*commonpb.KeyValuePair, key string) (result int64, parseErr error, exist bool) {
+	kv := lo.FindOrElse(kvs, nil, func(kv *commonpb.KeyValuePair) bool {
+		return kv.GetKey() == key
+	})
+	if kv == nil {
+		return 0, nil, false
+	}
+
+	result, err := strconv.ParseInt(kv.GetValue(), 10, 64)
+	if err != nil {
+		return 0, err, true
+	}
+	return result, nil, true
+}
+
 func CheckNamespace(schema *schemapb.CollectionSchema, namespace *string) error {
 	enabled, _, err := ParseNamespaceProp(schema.Properties...)
 	if err != nil {

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -621,6 +621,16 @@ func GetInt64Value(kvs []*commonpb.KeyValuePair, key string) (result int64, pars
 	return result, nil, true
 }
 
+func GetStringValue(kvs []*commonpb.KeyValuePair, key string) (result string, exist bool) {
+	kv := lo.FindOrElse(kvs, nil, func(kv *commonpb.KeyValuePair) bool {
+		return kv.GetKey() == key
+	})
+	if kv == nil {
+		return "", false
+	}
+	return kv.GetValue(), true
+}
+
 func CheckNamespace(schema *schemapb.CollectionSchema, namespace *string) error {
 	enabled, _, err := ParseNamespaceProp(schema.Properties...)
 	if err != nil {


### PR DESCRIPTION
Add collection-level granularity to the garbage collector pause/resume mechanism. Previously, GC pause affected all collections globally. Now operators can pause GC for specific collections while allowing other collections to continue normal GC operations.

Changes:
- Add `pausedCollection` concurrent map to track per-collection pause state
- Extend `Pause()` and `Resume()` methods with `collectionID` parameter
- Add `collectionGCPaused()` helper to check collection pause status
- Skip dropped segment recycling when collection GC is paused
- Update management API to accept optional `collection_id` query parameter
- Add `GetInt64Value()` utility function for parsing int64 from KV pairs
- Maintain backward compatibility: collectionID <= 0 triggers global pause

This provides DevOps with finer control over Milvus data lifecycle.

issue: #45941