### PR TITLE
docs: fix typos and clarify terminology across guides and configs

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -28,11 +28,11 @@ comment:
   require_changes: false
   branches: # branch names that can post comment
     - master
- 
+
 component_management:
   default_rules:  # default rules that will be inherited by all components
     statuses:
-      - type: project # in this case every component that doens't have a status defined will have a project type one
+      - type: project # in this case every component that doesn't have a status defined will have a project type one
         target: auto
         branches:
           - "!main"
@@ -66,8 +66,3 @@ ignore:
   - "**/*.proto"
   - "internal/metastore/db/dbmodel/mocks/.*"
   - "**/mock_*.go"
-
-
-
-
-

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -149,16 +149,16 @@ minio:
   cloudProvider: aws
   # The JSON content contains the gcs service account credentials.
   # Used only for the "gcpnative" cloud provider.
-  gcpCredentialJSON: 
+  gcpCredentialJSON:
   # Custom endpoint for fetch IAM role credentials. when useIAM is true & cloudProvider is "aws".
   # Leave it empty if you want to use AWS default endpoint
-  iamEndpoint: 
+  iamEndpoint:
   logLevel: fatal # Log level for aws sdk log. Supported level:  off, fatal, error, warn, info, debug, trace
   region:  # Specify minio storage system location region
   useVirtualHost: false # Whether use virtual host mode for bucket. WARNING: For Aliyun OSS and Tencent COS, this parameter is useless and is set to true by default
   requestTimeoutMs: 10000 # minio timeout for request time in milliseconds
-  # The maximum number of objects requested per batch in minio ListObjects rpc, 
-  # 0 means using oss client by default, decrease these configration if ListObjects timeout
+  # The maximum number of objects requested per batch in minio ListObjects RPC,
+  # 0 means using oss client by default; decrease this configuration if ListObjects time out
   listObjectsMaxKeys: 0
 
 # Milvus supports four message queues (MQ): rocksmq (based on RocksDB), Pulsar, Kafka, and Woodpecker.
@@ -178,7 +178,7 @@ mq:
   mqBufSize: 16 # MQ client consumer buffer length
   dispatcher:
     mergeCheckInterval: 0.1 # the interval time(in seconds) for dispatcher to check whether to merge
-    targetBufSize: 16 # the lenth of channel buffer for targe
+    targetBufSize: 16 # the length of channel buffer for targe
     maxTolerantLag: 3 # Default value: "3", the timeout(in seconds) that target sends msgPack
 
 # Related configuration of woodpecker, used to manage Milvus logs of recent mutation operations, output streaming log, and provide embedded log sequential read and write.
@@ -228,7 +228,7 @@ pulsar:
   # Default value applies when Pulsar is running on the same network with Milvus.
   address: localhost
   port: 6650 # Port of Pulsar service.
-  webport: 80 # Web port of of Pulsar service. If you connect direcly without proxy, should use 8080.
+  webport: 80 # Web port of of Pulsar service. If you connect directly without proxy, should use 8080.
   # The maximum size of each message in Pulsar. Unit: Byte.
   # By default, Pulsar can transmit at most 2MB of data in a single message. When the size of inserted data is greater than this value, proxy fragments the data into multiple messages to ensure that they can be transmitted correctly.
   # If the corresponding parameter in Pulsar remains unchanged, increasing this configuration will cause Milvus to fail, and reducing it produces no advantage.
@@ -242,8 +242,8 @@ pulsar:
   # Perform a backlog cleanup every time the data of given bytes is written.
   # Because milvus use puslar reader to read the message, so if there's no pulsar subscriber when milvus running.
   # If the pulsar cluster open the backlog protection (backlogQuotaDefaultLimitBytes), the backlog exceed will reported to fail the write operation
-  # set this option to non-zero will create a subscription seek to latest position to clear the pulsar backlog. 
-  # If these options is non-zero, the wal data in pulsar is fully protected by retention policy, 
+  # set this option to non-zero will create a subscription seek to latest position to clear the pulsar backlog.
+  # If these options is non-zero, the wal data in pulsar is fully protected by retention policy,
   # so admin of pulsar should give enough retention time to avoid the wal message lost.
   # If these options is zero, no subscription will be created, so pulsar cluster must close the backlog protection, otherwise the milvus can not recovered if backlog exceed.
   # If this option is zero or negative, it will be ignored and the default value (100m) will be used.
@@ -252,10 +252,10 @@ pulsar:
 # If you want to enable kafka, needs to comment the pulsar configs
 # kafka:
 #   brokerList: localhost:9092
-#   saslUsername: 
-#   saslPassword: 
-#   saslMechanisms: 
-#   securityProtocol: 
+#   saslUsername:
+#   saslPassword:
+#   saslMechanisms:
+#   securityProtocol:
 #   ssl:
 #     enabled: false # whether to enable ssl mode
 #     tlsCert:  # path to client's public key (PEM) used for authentication
@@ -328,8 +328,8 @@ proxy:
   ddlConcurrency: 16 # The concurrent execution number of DDL at proxy.
   dclConcurrency: 16 # The concurrent execution number of DCL at proxy.
   mustUsePartitionKey: false # switch for whether proxy must use partition key for the collection
-  # maximum number of result entries, typically Nq * TopK * GroupSize. 
-  # It costs additional memory and time to process a large number of result entries. 
+  # maximum number of result entries, typically Nq * TopK * GroupSize.
+  # It costs additional memory and time to process a large number of result entries.
   # If the number of result entries exceeds this limit, the search will be rejected.
   # Disabled if the value is less or equal to 0.
   maxResultEntries: -1
@@ -419,7 +419,7 @@ queryCoord:
   heartbeatAvailableInterval: 10000 # 10s, Only QueryNodes which fetched heartbeats within the duration are available
   loadTimeoutSeconds: 600
   distRequestTimeout: 5000 # the request timeout for querycoord fetching data distribution from querynodes, in milliseconds
-  heatbeatWarningLag: 5000 # the lag value for querycoord report warning when last heatbeat is too old, in milliseconds
+  heartbeatWarningLag: 5000 # the lag value for querycoord report warning when last heartbeat is too old, in milliseconds
   checkHandoffInterval: 5000
   enableActiveStandby: false
   checkInterval: 1000
@@ -607,7 +607,7 @@ dataCoord:
     maxSize: 1024 # The maximum size of a segment, unit: MB. datacoord.segment.maxSize and datacoord.segment.sealProportion together determine if a segment can be sealed.
     diskSegmentMaxSize: 2048 # Maximum size of a segment in MB for collection which has Disk index
     sealProportion: 0.12 # The minimum proportion to datacoord.segment.maxSize to seal a segment. datacoord.segment.maxSize and datacoord.segment.sealProportion together determine if a segment can be sealed.
-    sealProportionJitter: 0.1 # segment seal proportion jitter ratio, default value 0.1(10%), if seal proportion is 12%, with jitter=0.1, the actuall applied ratio will be 10.8~12%
+    sealProportionJitter: 0.1 # segment seal proportion jitter ratio, default value 0.1 (10%); if seal proportion is 12%, with jitter=0.1, the actual applied ratio will be 10.8~12%
     assignmentExpiration: 2000 # Expiration time of the segment assignment, unit: ms
     allocLatestExpireAttempt: 200 # The time attempting to alloc latest lastExpire from rootCoord after restart
     maxLife: 86400 # The max lifetime of segment in seconds, 24*60*60
@@ -625,7 +625,7 @@ dataCoord:
     compactableProportion: 0.85
     # over (compactableProportion * segment max # of rows) rows.
     # MUST BE GREATER THAN OR EQUAL TO <smallProportion>!!!
-    # During compaction, the size of segment # of rows is able to exceed segment max # of rows by (expansionRate-1) * 100%. 
+    # During compaction, the size of segment # of rows is able to exceed segment max # of rows by (expansionRate-1) * 100%.
     expansionRate: 1.25
   sealPolicy:
     channel:
@@ -642,11 +642,11 @@ dataCoord:
   forceRebuildSegmentIndex: false # force rebuild segment index to specify index engine's version
   # if param forceRebuildSegmentIndex is enabled, the vector index will be rebuilt to aligned with targetVecIndexVersion.
   # if param forceRebuildSegmentIndex is not enabled, the newly created vector index will be aligned with the newer one of index engine's version and targetVecIndexVersion.
-  # if param targetVecIndexVersion is not set, the default value is -1, which means no target vec index version, then the vector index will be aligned with index engine's version 
+  # if param targetVecIndexVersion is not set, the default value is -1, which means no target vec index version, then the vector index will be aligned with index engine's version
   targetVecIndexVersion: -1
   segmentFlushInterval: 2 # the minimal interval duration(unit: Seconds) between flushing operation on same segment
   # Switch value to control if to enable segment compaction.
-  # Compaction merges small-size segments into a large segment, and clears the entities deleted beyond the rentention duration of Time Travel.
+  # Compaction merges small-size segments into a large segment, and clears the entities deleted beyond the retention duration of Time Travel.
   enableCompaction: true
   compaction:
     # Switch value to control if to enable automatic segment compaction during which data coord locates and merges compactable segments in the background.
@@ -867,7 +867,7 @@ log:
     # The default value is set empty, indicating to output log files to standard output (stdout) and standard error (stderr).
     # If this parameter is set to a valid local path, Milvus writes and stores log files in this path.
     # Set this parameter as the path that you have permission to write.
-    rootPath: 
+    rootPath:
     maxSize: 300 # The maximum size of a log file, unit: MB.
     maxAge: 10 # The maximum retention time before a log file is automatically cleared, unit: day. The minimum value is 1.
     maxBackups: 20 # The maximum number of log files to back up, unit: day. The minimum value is 1.
@@ -958,8 +958,8 @@ common:
     authorizationEnabled: false
     # The superusers will ignore some system check processes,
     # like the old password verification when updating the credential
-    superUsers: 
-    # default password for root user. The maximum length is 72 characters. 
+    superUsers:
+    # default password for root user. The maximum length is 72 characters.
     # Large numeric passwords require double quotes to avoid yaml parsing precision issues.
     defaultRootPassword: Milvus
     rootShouldBindRole: false # Whether the root user should bind a role when the authorization is enabled.
@@ -1105,7 +1105,7 @@ quotaAndLimits:
     # Maximum number of db-related requests per second.
     # Setting this item to 10 indicates that Milvus processes no more than 10 db-related requests per second, including db creation/drop/alter requests.
     # To use this setting, set quotaAndLimits.dbRate.enabled to true at the same time.
-    # 		
+    #
     max: -1
   dml:
     enabled: false # Whether DML request throttling is enabled.
@@ -1329,7 +1329,7 @@ streaming:
     # Use the underlying wal default value if 0 is given.
     length: 128
   logging:
-    # The threshold of slow log, 1s by default. 
+    # The threshold of slow log, 1s by default.
     # If the wal implementation is woodpecker, the minimum threshold is 3s
     appendSlowThreshold: 1s
   flush:
@@ -1342,7 +1342,7 @@ streaming:
     # a flush process will be triggered to decrease total bytes of growing segment until growingSegmentBytesLwmThreshold, 0.2 by default
     growingSegmentBytesHwmThreshold: 0.2
     # The lower watermark of total growing segment bytes for one streaming node,
-    # growing segment flush process will try to flush some growing segment into sealed 
+    # growing segment flush process will try to flush some growing segment into sealed
     # until the total bytes of growing segment is less than this threshold, 0.1 by default.
     growingSegmentBytesLwmThreshold: 0.1
     l0:
@@ -1356,12 +1356,12 @@ streaming:
       # If the binary size of l0 segment is greater than this size, it will be flushed.
       maxSize: 32m
   walRecovery:
-    # The interval of persist recovery info, 10s by default. 
+    # The interval of persist recovery info, 10s by default.
     # Every the interval, the recovery info of wal will try to persist, and the checkpoint of wal can be advanced.
     # Currently it only affect the recovery of wal, but not affect the recovery of data flush into object storage
     persistInterval: 10s
     # The max dirty message count of wal recovery, 100 by default.
-    # If there are more than this count of dirty message in wal recovery info, it will be persisted immediately, 
+    # If there are more than this count of dirty message in wal recovery info, it will be persisted immediately,
     # but not wait for the persist interval.
     maxDirtyMessage: 100
     # The graceful close timeout for wal recovery, 3s by default.

--- a/docs/design_docs/20211223-knowhere_design.md
+++ b/docs/design_docs/20211223-knowhere_design.md
@@ -35,7 +35,7 @@ Load(const BinarySet&);
 /*
  * Create index
  * @param [in] dataset_ptr: index data (key of the Dataset is "tensor", "rows" and "dim")
- * @parma [in] config: index param
+ * @param [in] config: index param
  */
 void
 BuildAll(const DatasetPtr& dataset_ptr, const Config& config);
@@ -43,8 +43,8 @@ BuildAll(const DatasetPtr& dataset_ptr, const Config& config);
 /*
  * KNN (K-Nearest Neighbors) Query
  * @param [in] dataset_ptr: query data (key of the Dataset is "tensor" and "rows")
- * @parma [in] config: query param
- * @parma [out] blacklist: mark for deletion
+ * @param [in] config: query param
+ * @param [out] blacklist: mark for deletion
  * @return: query result (key of the Dataset is "ids" and "distance")
  */
 DatasetPtr
@@ -61,7 +61,7 @@ CopyGpuToCpu();
 /*
  * If the user IDs has been set, they will be returned in the Query interface;
  * else the range of the returned IDs is [0, row_num-1].
- * @parma [in] uids: user ids
+ * @param [in] uids: user ids
  */
 void
 SetUids(std::shared_ptr<std::vector<IDType>> uids);

--- a/docs/developer_guides/chap09_data_coord.md
+++ b/docs/developer_guides/chap09_data_coord.md
@@ -11,9 +11,9 @@ type DataCoord interface {
 	Component
 	TimeTickProvider
 
-  // Flush notifies DataCoord to flush all current growing segments of specified Collection
+  // Flush notifies DataCoord to flush all current growing segments of a specified Collection
 	Flush(ctx context.Context, req *datapb.FlushRequest) (*datapb.FlushResponse, error)
-	// AssignSegmentID applies allocations for specified Coolection/Partition and related Channel Name(Virtial Channel)
+  // AssignSegmentID applies allocations for a specified Collection/Partition and related channel name (virtual channel)
 	AssignSegmentID(ctx context.Context, req *datapb.AssignSegmentIDRequest) (*datapb.AssignSegmentIDResponse, error)
   // GetSegmentStates requests segment state information
 	GetSegmentStates(ctx context.Context, req *datapb.GetSegmentStatesRequest) (*datapb.GetSegmentStatesResponse, error)
@@ -23,7 +23,7 @@ type DataCoord interface {
 	GetSegmentInfoChannel(ctx context.Context) (*milvuspb.StringResponse, error)
   // GetCollectionStatistics requests collection statistics
 	GetCollectionStatistics(ctx context.Context, req *datapb.GetCollectionStatisticsRequest) (*datapb.GetCollectionStatisticsResponse, error)
-  // GetParititonStatistics requests partition statistics
+  // GetPartitionStatistics requests partition statistics
 	GetPartitionStatistics(ctx context.Context, req *datapb.GetPartitionStatisticsRequest) (*datapb.GetPartitionStatisticsResponse, error)
   // GetSegmentInfo requests segment info
 	GetSegmentInfo(ctx context.Context, req *datapb.GetSegmentInfoRequest) (*datapb.GetSegmentInfoResponse, error)
@@ -31,7 +31,7 @@ type DataCoord interface {
 	GetRecoveryInfo(ctx context.Context, req *datapb.GetRecoveryInfoRequest) (*datapb.GetRecoveryInfoResponse, error)
 	// SaveBinlogPaths updates segments binlogs(including insert binlogs, stats logs and delta logs)
 	SaveBinlogPaths(ctx context.Context, req *datapb.SaveBinlogPathsRequest) (*commonpb.Status, error)
-	// GetFlushedSegments returns flushed segment list of requested collection/parition
+  // GetFlushedSegments returns the flushed segment list of the requested collection/partition
 	GetFlushedSegments(ctx context.Context, req *datapb.GetFlushedSegmentsRequest) (*datapb.GetFlushedSegmentsResponse, error)
   // GetMetrics gets the metrics about DataCoord
 	GetMetrics(ctx context.Context, req *milvuspb.GetMetricsRequest) (*milvuspb.GetMetricsResponse, error)

--- a/docs/developer_guides/how_to_develop_with_local_milvus_proto.md
+++ b/docs/developer_guides/how_to_develop_with_local_milvus_proto.md
@@ -5,7 +5,7 @@
 Milvus protobuf service definition is in [repo](https://github.com/milvus-io/milvus-proto)
 When developers try to develop a new  public API or add parameters to existing ones, it's painful to wait for PR merged in milvus-proto repo, especially when the API definition is still in a draft status.
 
-This document demonstrates how to develop a new API without miluvs-proto repo update.
+This document demonstrates how to develop a new API without a milvus-proto repo update.
 
 ## Add or modify messages only
 
@@ -37,23 +37,23 @@ libprotoc 3.21.4
 ~/workspace/milvus-proto
 ```
 
-Back to milvus repo. Golang has provided a "convienient" way to use local repo instead of the remote one
+Back to the Milvus repo. Golang has provided a "convenient" way to use a local repo instead of the remote one
 
 ```
-# go mod edit -replace github.com/milvus-io/milvus-proto/go-api/v2=/home/silverxia/workspace/milvus-proto/go-api 
+# go mod edit -replace github.com/milvus-io/milvus-proto/go-api/v2=/home/silverxia/workspace/milvus-proto/go-api
 # cd pkg
 // set pkg module as well
 # go mod edit -replace github.com/milvus-io/milvus-proto/go-api/v2=/home/silverxia/workspace/milvus-proto/go-api
-# cd .. 
+# cd ..
 ```
 
-Whoola, your IDE shall now recognize the new TestObject definition now
+Voilà! Your IDE should now recognize the new TestObject definition.
 
 <img src="./figs/ide_with_newdef.png" width=550>
 
 ## Update Milvus API
 
-The tricky point is to update Milvus service API as well. If the modification is small and limited, the previous part is enough. The more common case is we need to use the new/updated message in an API(either exising or new).
+The tricky point is to update Milvus service API as well. If the modification is small and limited, the previous part is enough. The more common case is needing to use the new or updated message in an API (either existing or new).
 
 For example, the `TestObject` needs to appear in datanode `SyncSegments` API request struct. Golang module replacement does not fit since we need to generated a new service definition with the modified milvus-proto.
 
@@ -78,9 +78,9 @@ message SyncSegmentsRequest {
 }
 ```
 
-`make generated-proto` will fail since the current public online repo (actully the submodule here)does not contain the definition for TestObject.
+`make generated-proto` will fail since the current public online repo (actually the submodule here) does not contain the definition for TestObject.
 
-To work around that, we could modify the script slighly:
+To work around that, we could modify the script slightly:
 
 ```sh
 # scripts/generate_proto.sh
@@ -110,4 +110,3 @@ type SyncSegmentsRequest struct {
 ```
 
 Feel free to debug and POC your new API locally!
-

--- a/docs/user_guides/clustering_compaction.md
+++ b/docs/user_guides/clustering_compaction.md
@@ -6,7 +6,7 @@ This guide will help you understand what is clustering compaction and how to use
 
 ##  Feature Overview
 
-Clustering compaction is designed to accelerate searches/querys and reduce costs in large collections. Key functionalities include:
+Clustering compaction is designed to accelerate searches/queries and reduce costs in large collections. Key functionalities include:
 
 **1. Clustering Key**
 
@@ -14,7 +14,7 @@ Supports specifying a scalar field as the clustering key in the collection schem
 
 **2. Clustering Compaction**
 
-Clustering compaction redistributes the data according to value of the clustering key field, split by range. 
+Clustering compaction redistributes the data according to value of the clustering key field, split by range.
 
 Metadata of the data distribution (referred to as `partitionStats`) is generated and stored.
 
@@ -39,7 +39,7 @@ Enable config:
 ```yaml
 dataCoord.compaction.clustering.enable=true
 dataCoord.compaction.clustering.autoEnable=true
-```   
+```
 For more detail, see Configuration.
 
 **Create clustering key collection**
@@ -71,16 +71,16 @@ coll.wait_for_compaction_completed(is_clustering=True)
 **You will automatically get query/search optimization**
 
 ## Best Practice
-   
+
 To use the clustering compaction feature efficiently, here are some tips:
 
 - Use for Large Collections: Clustering compaction provides better benefits for larger collections. It is not very necessary for small datasets. We recommend using it for collections with at least 1 million rows.
 - Choose an Appropriate Clustering Key: Set the most frequently used scalar field as the clustering key. For instance, if you provide a multi-tenant service and have a userID field in your data model, and the most common query pattern is userID = ???, then set userID as the clustering key.
 - Use PartitionKey As ClusteringKey: If you want all collections in the Milvus cluster to enable this feature by default, or if you have a large collection with a partition key and are still facing performance issues with scalar filtering queries, you can enable this feature. By setting the configuration `common.usePartitionKeyAsClusteringKey=true`, Milvus can treat all partition key as clustering key. Furthermore, you can still specify a clustering key different from the partition key, which will take precedence.
-  
+
 ## Performance
-  
-The benefit of clustering compaction is closely related to data size and query patterns. 
+
+The benefit of clustering compaction is closely related to data size and query patterns.
 
 A test demonstrates that clustering compaction can yield up to a 25x improvement in QPS (queries per second).
 We conducted this test on a 20-million-record, 768-dimensional LAION dataset, designating the key field (of type Int64) as the clusteringKey. After performing clustering compaction, we ran concurrent searches until CPU usage reached a high water mark. To test the data pruning effect, we adjusted the search expression. By narrowing the search range, the prune_ratio increased, indicating a higher percentage of data being skipped during execution.
@@ -107,7 +107,7 @@ dataCoord:
       maxInterval: 259200 # If a collection haven't been clustering compacted for longer than maxInterval, force compact
       newDataSizeThreshold: 512m # If new data size is large than newDataSizeThreshold, execute clustering compaction
       timeout: 7200
-     
+
 queryNode:
   enableSegmentPrune: true # use partition stats to prune data in search/query on shard delegator
 

--- a/docs/user_guides/tls_proxy.md
+++ b/docs/user_guides/tls_proxy.md
@@ -49,7 +49,7 @@ oid_section		= new_oids
 # To use this configuration file with the "-extfile" option of the
 # "openssl x509" utility, name here the section containing the
 # X.509v3 extensions to use:
-# extensions		= 
+# extensions		=
 # (Alternatively, use a configuration file that has only
 # X.509v3 extensions in its main [= default] section.)
 
@@ -147,7 +147,7 @@ x509_extensions	= v3_ca	# The extensions to add to the self signed cert
 # input_password = secret
 # output_password = secret
 
-# This sets a mask for permitted string types. There are several options. 
+# This sets a mask for permitted string types. There are several options.
 # default: PrintableString, T61String, BMPString.
 # pkix	 : PrintableString, BMPString (PKIX recommendation before 2004)
 # utf8only: only UTF8Strings (PKIX recommendation after 2004).
@@ -170,7 +170,7 @@ stateOrProvinceName_default	= Some-State
 localityName			= Locality Name (eg, city)
 
 0.organizationName		= Organization Name (eg, company)
-0.organizationName_default	= Internet Widgits Pty Ltd
+0.organizationName_default	= Internet Widgets Pty Ltd
 
 # we can do this but it is not needed normally :-)
 #1.organizationName		= Second Organization Name (eg, company)
@@ -483,7 +483,7 @@ common:
     # tlsMode 0 indicates no authentication
     # tlsMode 1 indicates one-way authentication
     # tlsMode 2 indicates two-way authentication
-    tlsMode: 2 
+    tlsMode: 2
 ```
 ### One-way authentication
 Server-side needs server.pem and server.key files, client-side needs server.pem file.

--- a/internal/datacoord/import_util.go
+++ b/internal/datacoord/import_util.go
@@ -754,7 +754,7 @@ func ValidateBinlogImportRequest(ctx context.Context, cm storage.ChunkManager,
 }
 
 // ListBinlogImportRequestFiles lists the binlog files from the request.
-// TODO: dyh, remove listing binlog after backup-restore derectly passed the segments paths.
+// TODO: dyh, remove listing binlog after backup-restore directly passes the segment paths.
 func ListBinlogImportRequestFiles(ctx context.Context, cm storage.ChunkManager,
 	reqFiles []*internalpb.ImportFile, options []*commonpb.KeyValuePair,
 ) ([]*internalpb.ImportFile, error) {

--- a/internal/querycoordv2/server.go
+++ b/internal/querycoordv2/server.go
@@ -570,7 +570,7 @@ func (s *Server) Stop() error {
 	}
 
 	// save target to meta store, after querycoord restart, make it fast to recover current target
-	// should save target after target observer stop, incase of target changed
+	// should save target after target observer stop, in case the target changed
 	if s.targetMgr != nil {
 		s.targetMgr.SaveCurrentTarget(s.ctx, s.store)
 	}

--- a/internal/util/importutilv2/parquet/util.go
+++ b/internal/util/importutilv2/parquet/util.go
@@ -523,7 +523,7 @@ func isSchemaEqual(schema *schemapb.CollectionSchema, arrSchema *arrow.Schema) e
 			return err
 		}
 		if !isArrowDataTypeConvertible(arrField.Type, toArrDataType, field) {
-			return merr.WrapErrImportFailed(fmt.Sprintf("field '%s' type mis-match, expect arrow type '%s', get arrow data type '%s'",
+			return merr.WrapErrImportFailed(fmt.Sprintf("field '%s' type mismatch, expect arrow type '%s', get arrow data type '%s'",
 				field.Name, toArrDataType.String(), arrField.Type.String()))
 		}
 	}
@@ -588,13 +588,13 @@ func isSchemaEqual(schema *schemapb.CollectionSchema, arrSchema *arrow.Schema) e
 
 			// Check if the arrow type is convertible to the expected type
 			if !isArrowDataTypeConvertible(arrowSubField.Type, expectedArrowType, subField) {
-				return merr.WrapErrImportFailed(fmt.Sprintf("sub-field '%s' in struct '%s' type mis-match, expect arrow type '%s', got '%s'",
+				return merr.WrapErrImportFailed(fmt.Sprintf("sub-field '%s' in struct '%s' type mismatch, expect arrow type '%s', got '%s'",
 					fieldName, structField.Name, expectedArrowType.String(), arrowSubField.Type.String()))
 			}
 		}
 
 		if len(structFieldMap) != len(structField.Fields) {
-			return merr.WrapErrImportFailed(fmt.Sprintf("struct field number dismatch: %s, expect %d, got %d", structField.Name, len(structField.Fields), len(structFieldMap)))
+			return merr.WrapErrImportFailed(fmt.Sprintf("struct field number mismatch: %s, expect %d, got %d", structField.Name, len(structField.Fields), len(structFieldMap)))
 		}
 	}
 

--- a/pkg/util/typeutil/hash.go
+++ b/pkg/util/typeutil/hash.go
@@ -42,7 +42,7 @@ func Hash32Bytes(b []byte) (uint32, error) {
 	return h.Sum32() & 0x7fffffff, nil
 }
 
-// Hash32Uint64 hashing an uint64 nubmer to uint32
+// Hash32Uint64 hashing an uint64 number to uint32
 func Hash32Uint64(v uint64) (uint32, error) {
 	// need unsafe package to get element byte size
 	/* #nosec G103 */
@@ -140,15 +140,15 @@ func HashKey2Partitions(keys *schemapb.FieldData, partitionNames []string) ([]ui
 	return hashValues, nil
 }
 
-// this method returns a static sequence for partitions for partiton key mode
+// this method returns a static sequence for partitions for partition key mode
 func RearrangePartitionsForPartitionKey(partitions map[string]int64) ([]string, []int64, error) {
-	// Make sure the order of the partition names got every time is the same
+	// Make sure the order of the partition names is the same every time
 	partitionNames := make([]string, len(partitions))
 	partitionIDs := make([]int64, len(partitions))
 	for partitionName, partitionID := range partitions {
 		splits := strings.Split(partitionName, "_")
 		if len(splits) < 2 {
-			return nil, nil, fmt.Errorf("bad default partion name in partition key mode: %s", partitionName)
+			return nil, nil, fmt.Errorf("bad default partition name in partition key mode: %s", partitionName)
 		}
 		index, err := strconv.ParseInt(splits[len(splits)-1], 10, 64)
 		if err != nil {

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -13,7 +13,7 @@ The framework allows developers to:
 - Execute end-to-end test scenarios
 - Execute the method of any component from its client
 - Simulate component failures and recovery
-- Modify the milvus configration at runtime or startup
+- Modify the milvus configuration at runtime or startup
 
 The test framework is built on top of Go's testing package and the testify/suite framework, making it easy to write structured and maintainable integration tests.
 
@@ -29,12 +29,12 @@ Because integration test is a multi-process framework, it requires some componen
 Build the milvus binary first.
 
 ```base
-make milvus 
+make milvus
 
 # test framework will use the env `MILVUS_WORK_DIR` to find the milvus binary.
 # already done in the scripts/setenv.sh
 # or you can set it manually
-export MILVUS_WORK_DIR=$(pwd) 
+export MILVUS_WORK_DIR=$(pwd)
 ```
 
 Run the docker compose to start the etcd, minio and pulsar.
@@ -68,16 +68,16 @@ It's a good choice to add a new test case into integration test if:
 - The test case need to control the lifecycle of Milvus components, such as starting/stopping components or modifying configuration then executing some end-to-end scenarios.
 - If the test case is hard to apply in the unit-test and E2E test, such as testing in a non-default configured Milvus cluster, and need to be tested between multiple components.
 
-Should not add a new test case into integration test if: 
+Should not add a new test case into integration test if:
 
 - Function-verification that can be covered by unit test or already be covered by E2E test.
 - Performance test.
 
 ### Using `suite`
 
-MiniCluster` and `MiniClusterSuite` provides lots of comment preset tool function to execute intergration test.
+`MiniCluster` and `MiniClusterSuite` provide lots of common preset tool functions to execute integration tests.
 
-It is recommend to add a new test with `testify/suite`
+It is recommended to add a new test with `testify/suite`
 
 ```go
 
@@ -115,21 +115,21 @@ Some utility methods are provided in `MiniClusterSuite` to interact with the clu
 - Use `s.WithMilvusConfig` to modify the milvus configuration at startup in `SetupSuite` method.
 - Use `s.WithOptions` to modify the test options at startup in `SetupSuite` method.
 - Use `s.Cluster` to get the `MiniClusterV3` instance, which provides methods to interact with the Milvus cluster.
-- Some useful milvus method is provided in `util_` files, such as `CreateCollection`, `Insert`, `Flush`..., 
+- Some useful milvus method is provided in `util_` files, such as `CreateCollection`, `Insert`, `Flush`...,
 
 #### method of `MiniClusterV3`
 
-- Use `s.Cluster.MustModifyMilvusConfig` to modify the milvus configuration at runtime, it will return a guard function to restore the modified configuration. It doesn't promise that the configuration will be applied immediately, milvus may not support the dynamic configuration change for some configurations or some configration may be applied slowly.
+- Use `s.Cluster.MustModifyMilvusConfig` to modify the milvus configuration at runtime, it will return a guard function to restore the modified configuration. It doesn't promise that the configuration will be applied immediately, Milvus may not support the dynamic configuration change for some configurations or some configuration may be applied slowly.
 - Use `s.Cluster.Add*` to add components to the cluster, such as `AddMixCoord`, `AddProxy`, `AddDataNode`, `AddQueryNode`, `AddStreamingNode`. it will return the `MilvusProcess` object to manage the lifetime of new incoming component. It will block until the component is healthy by default, use `WithoutWaitForReady` option to avoid it.
 - Use `s.Cluster.Default*` to get the default component, such as `DefaultMixCoord`, `DefaultProxy`, `DefaultDataNode`, `DefaultQueryNode`, `DefaultStreamingNode`.
 - Use `s.*Client` to get the grpc client of the default component that can be got from `s.Cluster.Default*`, such as `s.MixCoordClient`, `s.ProxyClient`, `s.DataNodeClient`, `s.QueryNodeClient`, `s.StreamingNodeClient`.
-- Use `s.MilvusClient` to get the grpc client of the Milvus server, which is connnected to the proxy that is returned from `DefaultProxy()`.
+- Use `s.MilvusClient` to get the grpc client of the Milvus server, which is connected to the proxy that is returned from `DefaultProxy()`.
 
 #### method of `MilvusProcess`
 
 - Use `p.MustGetClient` to get the grpc client of the component, which provides methods to interact with the component.
 - Use `p.MustWaitForReady` to wait for the component to be ready, it will block until the component is healthy.
-- Use `p.Stop` to stop the component, it will block until the component is stopped. It will perform a graceful shutdown by default. When the given deadline is excceed, `ForceStop` is performed.
+- Use `p.Stop` to stop the component, it will block until the component is stopped. It will perform a graceful shutdown by default. When the given deadline is exceeded, `ForceStop` is performed.
 - Use `p.ForceStop` to force stop the component, it will not wait for the component to be stopped.
 - Use `p.IsWorking` to check if the component is working, it will return false if the component is stopped.
 
@@ -137,10 +137,10 @@ Some utility methods are provided in `MiniClusterSuite` to interact with the clu
 
 It's a known issue that integration test cases run in same process might affect due to some singleton component not fully cleaned.
 
-As a temp solution, test cases are separated into different packages to run independently. 
+As a temp solution, test cases are separated into different packages to run independently.
 
 ### Some tips
 
-1. Sometimes, if the test case is killed by some SIGKILL, it will leave some orphan milvus process running in the background. You could use `killall milvus` to kill all milvus process, or `killall -9 milvus` to kill all milvus process forcefully. 
+1. Sometimes, if the test case is killed by some SIGKILL, it will leave some orphan milvus process running in the background. You could use `killall milvus` to kill all milvus process, or `killall -9 milvus` to kill all milvus process forcefully.
 2. Because the test framework use some determined port (such as 53100 for coord, 19530 for proxy), it will be failed to start a new milvus process if the port is already in use. You could use `lsof -i :53100` to check if the port is already in use.
 3. The test coverage of milvus can not be generated by the integration test, because that the integration test use multi-process. the test coverage only cover the code that is executed by the integration test itself.


### PR DESCRIPTION
- correct spelling and terminology in configuration comments and docstrings (codecov.yml, configs/milvus.yaml, internal/querycoordv2/server.go, internal/datacoord/import_util.go)
- clean up developer documentation typos and grammar in design docs and guides (geometry, knowhere, data_coord, local proto workflow)
- improve clarity of filter/output_field descriptions in geometry design doc

Author: rezky_nightky <with.rezky@gmail.com>
Timestamp: 2025-11-30T13:56:03Z
Repository: milvus
Branch: master
Signing: GPG (989AF9F0)
Performance: 13 files, +144/-150 lines