### PR TITLE
fix: [2.5] always call handleNodeUp in rewatchNodes for proper stopping balance

### DIFF
--- a/internal/querycoordv2/server.go
+++ b/internal/querycoordv2/server.go
@@ -818,11 +818,13 @@ func (s *Server) rewatchNodes(sessions map[string]*sessionutil.Session) error {
 				Labels:   nodeSession.GetServerLabel(),
 			}))
 
+			// call handleNodeUp no matter what state new querynode is in
+			// all component need this op so that stopping balance could work correctly
+			s.handleNodeUp(nodeSession.GetServerID())
+
 			if nodeSession.Stopping {
 				s.nodeMgr.Stopping(nodeSession.ServerID)
 				s.handleNodeStopping(nodeSession.ServerID)
-			} else {
-				s.handleNodeUp(nodeSession.GetServerID())
 			}
 		}
 	}


### PR DESCRIPTION
Cherry-pick from master
pr: #45961
Related to #45960

When QueryCoord restarts or reconnects to etcd, the rewatchNodes function previously skipped handleNodeUp for QueryNodes in stopping state. This caused stopping balance to fail because necessary components were not initialized:
- Task scheduler executor was not added
- Dist handler was not started
- Node was not registered in resource manager

This fix ensures handleNodeUp is always called for new nodes regardless of their stopping state, followed by handleNodeStopping if the node is stopping. This allows the graceful shutdown process to correctly migrate segments and channels away from stopping nodes.