### PR TITLE
fix: [2.5] update QueryNode NumEntities metrics when collection has no segments (#45147)

### DIFF
--- a/internal/querynodev2/metrics_info.go
+++ b/internal/querynodev2/metrics_info.go
@@ -80,7 +80,11 @@ func getQuotaMetrics(node *QueryNode) (*metricsinfo.QueryNodeQuotaMetrics, error
 	growingGroupByCollection := lo.GroupBy(growingSegments, func(seg segments.Segment) int64 {
 		return seg.Collection()
 	})
-	for collection := range collections {
+	for collection, name := range collections {
+		coll := node.manager.Collection.Get(collection)
+		if coll == nil {
+			continue
+		}
 		segs := growingGroupByCollection[collection]
 		size := lo.SumBy(segs, func(seg segments.Segment) int64 {
 			return seg.MemSize()
@@ -88,18 +92,16 @@ func getQuotaMetrics(node *QueryNode) (*metricsinfo.QueryNodeQuotaMetrics, error
 		totalGrowingSize += size
 		metrics.QueryNodeEntitiesSize.WithLabelValues(nodeID, fmt.Sprint(collection),
 			segments.SegmentTypeGrowing.String()).Set(float64(size))
-	}
 
-	for _, segs := range growingGroupByCollection {
 		numEntities := lo.SumBy(segs, func(seg segments.Segment) int64 {
 			return seg.RowNum()
 		})
-		segment := segs[0]
+
 		metrics.QueryNodeNumEntities.WithLabelValues(
-			segment.DatabaseName(),
-			collections[segment.Collection()],
+			coll.GetDBName(),
+			name,
 			nodeID,
-			fmt.Sprint(segment.Collection()),
+			fmt.Sprint(collection),
 			segments.SegmentTypeGrowing.String(),
 		).Set(float64(numEntities))
 	}
@@ -108,25 +110,26 @@ func getQuotaMetrics(node *QueryNode) (*metricsinfo.QueryNodeQuotaMetrics, error
 	sealedGroupByCollection := lo.GroupBy(sealedSegments, func(seg segments.Segment) int64 {
 		return seg.Collection()
 	})
-	for collection := range collections {
+	for collection, name := range collections {
+		coll := node.manager.Collection.Get(collection)
+		if coll == nil {
+			continue
+		}
 		segs := sealedGroupByCollection[collection]
 		size := lo.SumBy(segs, func(seg segments.Segment) int64 {
 			return seg.MemSize()
 		})
 		metrics.QueryNodeEntitiesSize.WithLabelValues(fmt.Sprint(node.GetNodeID()),
 			fmt.Sprint(collection), segments.SegmentTypeSealed.String()).Set(float64(size))
-	}
-
-	for _, segs := range sealedGroupByCollection {
 		numEntities := lo.SumBy(segs, func(seg segments.Segment) int64 {
 			return seg.RowNum()
 		})
-		segment := segs[0]
+
 		metrics.QueryNodeNumEntities.WithLabelValues(
-			segment.DatabaseName(),
-			collections[segment.Collection()],
+			coll.GetDBName(),
+			name,
 			nodeID,
-			fmt.Sprint(segment.Collection()),
+			fmt.Sprint(collection),
 			segments.SegmentTypeSealed.String(),
 		).Set(float64(numEntities))
 	}


### PR DESCRIPTION
Cherry-pick from master
pr: #45147
Related to #44509

Fix a bug where QueryNodeNumEntities metrics were not updated for collections with zero segments, causing stale metrics when all segments are flushed or compacted.

The previous implementation used separate loops: one to update size metrics for all collections, and another to update num entities metrics only for collections present in the grouped segments map. Collections with no segments were skipped in the second loop, leaving their NumEntities metrics stale.

Changes:
- Consolidate size and num entities metric updates into single loop
- Iterate over all collections instead of grouped segments
- Get collection metadata from manager instead of segment instances
- Correctly set NumEntities to 0 for collections with no segments
- Apply the same fix to both growing and sealed segment processing
- Add nil check for collection metadata before processing

This ensures all collection metrics are updated consistently, even when segment count drops to zero.