### PR TITLE
enhance: disable compaction for external collections

### DIFF
--- a/internal/datacoord/compaction_policy_clustering_test.go
+++ b/internal/datacoord/compaction_policy_clustering_test.go
@@ -218,6 +218,23 @@ func (s *ClusteringCompactionPolicySuite) TestTriggerOneCollectionAbnormal() {
 	s.Equal(int64(0), triggerID2)
 }
 
+func (s *ClusteringCompactionPolicySuite) TestTriggerOneCollectionSkipExternal() {
+	collID := int64(100)
+	s.handler.EXPECT().GetCollection(mock.Anything, collID).Return(&collectionInfo{
+		ID: collID,
+		Schema: func() *schemapb.CollectionSchema {
+			schema := newTestScalarClusteringKeySchema()
+			schema.ExternalSource = "s3://external"
+			return schema
+		}(),
+	}, nil)
+
+	views, triggerID, err := s.clusteringCompactionPolicy.triggerOneCollection(context.Background(), collID, false)
+	s.NoError(err)
+	s.Nil(views)
+	s.EqualValues(0, triggerID)
+}
+
 func (s *ClusteringCompactionPolicySuite) TestTriggerOneCollectionNoClusteringKeySchema() {
 	ctx := context.Background()
 	coll := &collectionInfo{

--- a/internal/datacoord/compaction_trigger.go
+++ b/internal/datacoord/compaction_trigger.go
@@ -229,6 +229,13 @@ func (t *compactionTrigger) getCollection(collectionID UniqueID) (*collectionInf
 }
 
 func isCollectionAutoCompactionEnabled(coll *collectionInfo) bool {
+	if coll == nil {
+		return false
+	}
+	if coll.IsExternal() {
+		log.Info("collection auto compaction disabled for external collection", zap.Int64("collectionID", coll.ID))
+		return false
+	}
 	enabled, err := getCollectionAutoCompactionEnabled(coll.Properties)
 	if err != nil {
 		log.Warn("collection properties auto compaction not valid, returning false", zap.Error(err))
@@ -361,6 +368,13 @@ func (t *compactionTrigger) handleSignal(signal *compactionSignal) error {
 			log.Warn("get collection info failed, skip handling compaction", zap.Error(err))
 			if signal.collectionID != 0 {
 				return err
+			}
+			continue
+		}
+		if coll.IsExternal() {
+			log.Info("skip compaction for external collection", zap.Int64("collectionID", coll.ID))
+			if signal.collectionID != 0 {
+				return merr.WrapErrServiceUnavailable("external collection compaction disabled")
 			}
 			continue
 		}

--- a/internal/datacoord/compaction_trigger_test.go
+++ b/internal/datacoord/compaction_trigger_test.go
@@ -2413,6 +2413,16 @@ func (s *CompactionTriggerSuite) TestHandleSignal() {
 	})
 }
 
+func TestIsCollectionAutoCompactionEnabledExternal(t *testing.T) {
+	coll := &collectionInfo{
+		ID: 1,
+		Schema: &schemapb.CollectionSchema{
+			ExternalSource: "s3://external",
+		},
+	}
+	assert.False(t, isCollectionAutoCompactionEnabled(coll))
+}
+
 func (s *CompactionTriggerSuite) TestHandleGlobalSignal() {
 	schema := &schemapb.CollectionSchema{
 		Fields: []*schemapb.FieldSchema{

--- a/internal/datacoord/compaction_trigger_v2_test.go
+++ b/internal/datacoord/compaction_trigger_v2_test.go
@@ -174,7 +174,7 @@ func (s *CompactionTriggerManagerSuite) TestManualTriggerSkipExternal() {
 	}, nil)
 	s.triggerManager.handler = handler
 
-	_, err := s.triggerManager.ManualTrigger(context.Background(), 1, true, false)
+	_, err := s.triggerManager.ManualTrigger(context.Background(), 1, true, false, 0)
 	s.Error(err)
 	s.ErrorIs(err, merr.ErrServiceUnavailable)
 }

--- a/internal/datacoord/compaction_trigger_v2_test.go
+++ b/internal/datacoord/compaction_trigger_v2_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
 
 func TestCompactionTriggerManagerSuite(t *testing.T) {
@@ -53,10 +54,17 @@ func (s *CompactionTriggerManagerSuite) SetupTest() {
 		Channel:      "ch-1",
 	}
 	segments := genSegmentsForMeta(s.testLabel)
-	s.meta = &meta{segments: NewSegmentsInfo()}
+	s.meta = &meta{
+		segments:    NewSegmentsInfo(),
+		collections: typeutil.NewConcurrentMap[UniqueID, *collectionInfo](),
+	}
 	for id, segment := range segments {
 		s.meta.segments.SetSegment(id, segment)
 	}
+	s.meta.collections.Insert(s.testLabel.CollectionID, &collectionInfo{
+		ID:     s.testLabel.CollectionID,
+		Schema: &schemapb.CollectionSchema{},
+	})
 	catalog := mocks.NewDataCoordCatalog(s.T())
 	catalog.EXPECT().ListPreImportTasks(mock.Anything).Return([]*datapb.PreImportTask{}, nil)
 	catalog.EXPECT().ListImportTasks(mock.Anything).Return([]*datapb.ImportTaskV2{}, nil)
@@ -355,12 +363,17 @@ func TestCompactionAndImport(t *testing.T) {
 	catelog := mocks.NewDataCoordCatalog(t)
 	catelog.EXPECT().AddSegment(mock.Anything, mock.Anything).Return(nil)
 	meta := &meta{
-		segments: NewSegmentsInfo(),
-		catalog:  catelog,
+		segments:    NewSegmentsInfo(),
+		catalog:     catelog,
+		collections: typeutil.NewConcurrentMap[UniqueID, *collectionInfo](),
 	}
 	for id, segment := range segments {
 		meta.segments.SetSegment(id, segment)
 	}
+	meta.collections.Insert(1, &collectionInfo{
+		ID:     1,
+		Schema: &schemapb.CollectionSchema{},
+	})
 	catalog := mocks.NewDataCoordCatalog(t)
 	catalog.EXPECT().ListPreImportTasks(mock.Anything).Return([]*datapb.PreImportTask{}, nil)
 	catalog.EXPECT().ListImportTasks(mock.Anything).Return([]*datapb.ImportTaskV2{}, nil)
@@ -455,6 +468,9 @@ func (s *CompactionTriggerManagerSuite) TestManualTriggerL0Compaction() {
 
 func (s *CompactionTriggerManagerSuite) TestManualTriggerInvalidParams() {
 	// Test with both clustering and L0 compaction false
+	handler := NewNMockHandler(s.T())
+	handler.EXPECT().GetCollection(mock.Anything, mock.Anything).Return(&collectionInfo{}, nil)
+	s.triggerManager.handler = handler
 	triggerID, err := s.triggerManager.ManualTrigger(context.Background(), s.testLabel.CollectionID, false, false, 0)
 	s.NoError(err)
 	s.Equal(int64(0), triggerID)

--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -158,6 +158,17 @@ type collectionInfo struct {
 	VChannelNames  []string
 }
 
+// IsExternal returns true when the collection schema references an external source or spec.
+func (c *collectionInfo) IsExternal() bool {
+	if c == nil {
+		return false
+	}
+	if c.Schema == nil {
+		return false
+	}
+	return c.Schema.GetExternalSource() != "" || c.Schema.GetExternalSpec() != ""
+}
+
 type dbInfo struct {
 	ID         int64
 	Name       string

--- a/internal/datacoord/server_test.go
+++ b/internal/datacoord/server_test.go
@@ -1680,6 +1680,11 @@ func TestManualCompaction(t *testing.T) {
 	t.Run("test manual compaction successfully", func(t *testing.T) {
 		svr := &Server{allocator: allocator.NewMockAllocator(t)}
 		svr.stateCode.Store(commonpb.StateCode_Healthy)
+		svr.meta = &meta{collections: typeutil.NewConcurrentMap[UniqueID, *collectionInfo]()}
+		svr.meta.collections.Insert(1, &collectionInfo{
+			ID:     1,
+			Schema: &schemapb.CollectionSchema{},
+		})
 		mockTrigger := NewMockTrigger(t)
 		svr.compactionTrigger = mockTrigger
 		mockTrigger.EXPECT().TriggerCompaction(mock.Anything, mock.Anything).Return(1, nil)
@@ -1698,6 +1703,11 @@ func TestManualCompaction(t *testing.T) {
 	t.Run("test manual l0 compaction successfully", func(t *testing.T) {
 		svr := &Server{allocator: allocator.NewMockAllocator(t)}
 		svr.stateCode.Store(commonpb.StateCode_Healthy)
+		svr.meta = &meta{collections: typeutil.NewConcurrentMap[UniqueID, *collectionInfo]()}
+		svr.meta.collections.Insert(1, &collectionInfo{
+			ID:     1,
+			Schema: &schemapb.CollectionSchema{},
+		})
 		mockTriggerManager := NewMockTriggerManager(t)
 		svr.compactionTriggerManager = mockTriggerManager
 		mockTriggerManager.EXPECT().ManualTrigger(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(1, nil)
@@ -1714,9 +1724,33 @@ func TestManualCompaction(t *testing.T) {
 		assert.Equal(t, commonpb.ErrorCode_Success, resp.GetStatus().GetErrorCode())
 	})
 
+	t.Run("test manual compaction external collection", func(t *testing.T) {
+		svr := &Server{}
+		svr.stateCode.Store(commonpb.StateCode_Healthy)
+		svr.meta = &meta{collections: typeutil.NewConcurrentMap[UniqueID, *collectionInfo]()}
+		svr.meta.collections.Insert(1, &collectionInfo{
+			ID: 1,
+			Schema: &schemapb.CollectionSchema{
+				ExternalSource: "s3://external",
+			},
+		})
+
+		resp, err := svr.ManualCompaction(context.TODO(), &milvuspb.ManualCompactionRequest{
+			CollectionID: 1,
+			Timetravel:   1,
+		})
+		assert.NoError(t, err)
+		assert.ErrorIs(t, merr.Error(resp.GetStatus()), merr.ErrServiceUnavailable)
+	})
+
 	t.Run("test manual compaction failure", func(t *testing.T) {
 		svr := &Server{allocator: allocator.NewMockAllocator(t)}
 		svr.stateCode.Store(commonpb.StateCode_Healthy)
+		svr.meta = &meta{collections: typeutil.NewConcurrentMap[UniqueID, *collectionInfo]()}
+		svr.meta.collections.Insert(1, &collectionInfo{
+			ID:     1,
+			Schema: &schemapb.CollectionSchema{},
+		})
 		mockTrigger := NewMockTrigger(t)
 		svr.compactionTrigger = mockTrigger
 		mockTrigger.EXPECT().TriggerCompaction(mock.Anything, mock.Anything).Return(0, errors.New("mock error"))

--- a/internal/datacoord/server_test.go
+++ b/internal/datacoord/server_test.go
@@ -1725,18 +1725,73 @@ func TestManualCompaction(t *testing.T) {
 	})
 
 	t.Run("test manual compaction external collection", func(t *testing.T) {
+		const collID = int64(1)
+		const segID = int64(10)
+
 		svr := &Server{}
 		svr.stateCode.Store(commonpb.StateCode_Healthy)
-		svr.meta = &meta{collections: typeutil.NewConcurrentMap[UniqueID, *collectionInfo]()}
-		svr.meta.collections.Insert(1, &collectionInfo{
-			ID: 1,
+		svr.meta = &meta{
+			collections: typeutil.NewConcurrentMap[UniqueID, *collectionInfo](),
+			segments:    NewSegmentsInfo(),
+			indexMeta: &indexMeta{
+				indexes:        make(map[UniqueID]map[UniqueID]*model.Index),
+				segmentIndexes: typeutil.NewConcurrentMap[UniqueID, *typeutil.ConcurrentMap[UniqueID, *model.SegmentIndex]](),
+			},
+		}
+		svr.meta.collections.Insert(collID, &collectionInfo{
+			ID: collID,
 			Schema: &schemapb.CollectionSchema{
 				ExternalSource: "s3://external",
+				Fields: []*schemapb.FieldSchema{
+					{
+						FieldID:  common.StartOfUserFieldID,
+						DataType: schemapb.DataType_FloatVector,
+						TypeParams: []*commonpb.KeyValuePair{
+							{Key: common.DimKey, Value: "128"},
+						},
+					},
+				},
+			},
+			Properties: map[string]string{
+				common.CollectionTTLConfigKey: "0",
+			},
+		})
+		svr.meta.segments.SetSegment(segID, &SegmentInfo{
+			SegmentInfo: &datapb.SegmentInfo{
+				ID:            segID,
+				CollectionID:  collID,
+				PartitionID:   1,
+				InsertChannel: "by-dev-rootcoord-0",
+				State:         commonpb.SegmentState_Flushed,
+				Level:         datapb.SegmentLevel_L1,
+				NumOfRows:     100,
+				MaxRowNum:     1000,
+				IsSorted:      true,
+				Binlogs: []*datapb.FieldBinlog{
+					{Binlogs: []*datapb.Binlog{{MemorySize: 1024, EntriesNum: 10}}},
+				},
 			},
 		})
 
+		mockInspector := NewMockCompactionInspector(t)
+		trigger := newCompactionTrigger(
+			svr.meta,
+			mockInspector,
+			newMock0Allocator(t),
+			newMockHandlerWithMeta(svr.meta),
+			newIndexEngineVersionManager(),
+		)
+		trigger.testingOnly = true
+		trigger.closeWaiter.Add(1)
+		go func() {
+			defer trigger.closeWaiter.Done()
+			trigger.work()
+		}()
+		defer trigger.stop()
+		svr.compactionTrigger = trigger
+
 		resp, err := svr.ManualCompaction(context.TODO(), &milvuspb.ManualCompactionRequest{
-			CollectionID: 1,
+			CollectionID: collID,
 			Timetravel:   1,
 		})
 		assert.NoError(t, err)

--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -1278,16 +1278,6 @@ func (s *Server) ManualCompaction(ctx context.Context, req *milvuspb.ManualCompa
 		return resp, nil
 	}
 
-	collection := s.meta.GetCollection(req.GetCollectionID())
-	if collection == nil {
-		resp.Status = merr.Status(merr.WrapErrCollectionNotFound(req.GetCollectionID()))
-		return resp, nil
-	}
-	if collection.IsExternal() {
-		resp.Status = merr.Status(merr.WrapErrServiceUnavailable("external collection compaction disabled"))
-		return resp, nil
-	}
-
 	var id int64
 	var err error
 	if req.GetMajorCompaction() || req.GetL0Compaction() || req.GetTargetSize() != 0 {

--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -1278,6 +1278,16 @@ func (s *Server) ManualCompaction(ctx context.Context, req *milvuspb.ManualCompa
 		return resp, nil
 	}
 
+	collection := s.meta.GetCollection(req.GetCollectionID())
+	if collection == nil {
+		resp.Status = merr.Status(merr.WrapErrCollectionNotFound(req.GetCollectionID()))
+		return resp, nil
+	}
+	if collection.IsExternal() {
+		resp.Status = merr.Status(merr.WrapErrServiceUnavailable("external collection compaction disabled"))
+		return resp, nil
+	}
+
 	var id int64
 	var err error
 	if req.GetMajorCompaction() || req.GetL0Compaction() || req.GetTargetSize() != 0 {

--- a/internal/datacoord/stats_inspector.go
+++ b/internal/datacoord/stats_inspector.go
@@ -102,6 +102,17 @@ func (si *statsInspector) reloadFromMeta() {
 			st.GetState() != indexpb.JobState_JobStateInProgress {
 			continue
 		}
+		if si.isExternalCollection(st.GetCollectionID()) {
+			log.Info("skip reloading stats task for external collection",
+				zap.Int64("taskID", st.GetTaskID()),
+				zap.Int64("collectionID", st.GetCollectionID()))
+			if err := si.mt.statsTaskMeta.MarkTaskCanRecycle(st.GetTaskID()); err != nil {
+				log.Warn("mark stats task can recycle failed",
+					zap.Int64("taskID", st.GetTaskID()),
+					zap.Error(err))
+			}
+			continue
+		}
 		segment := si.mt.GetHealthySegment(si.ctx, st.GetSegmentID())
 		taskSlot := int64(0)
 		if segment != nil {
@@ -191,6 +202,9 @@ func needDoBM25(segment *SegmentInfo, fieldIDs []UniqueID) bool {
 func (si *statsInspector) triggerTextStatsTask() {
 	collections := si.mt.GetCollections()
 	for _, collection := range collections {
+		if collection == nil || collection.IsExternal() {
+			continue
+		}
 		needTriggerFieldIDs := make([]UniqueID, 0)
 		for _, field := range collection.Schema.GetFields() {
 			// TODO @longjiquan: please replace it to fieldSchemaHelper.EnableMath
@@ -217,6 +231,9 @@ func (si *statsInspector) triggerTextStatsTask() {
 func (si *statsInspector) triggerJsonKeyIndexStatsTask(lastJSONStatsLastTrigger int64, maxJSONStatsTaskCount int) (int64, int) {
 	collections := si.mt.GetCollections()
 	for _, collection := range collections {
+		if collection == nil || collection.IsExternal() {
+			continue
+		}
 		needTriggerFieldIDs := make([]UniqueID, 0)
 		for _, field := range collection.Schema.GetFields() {
 			h := typeutil.CreateFieldSchemaHelper(field)
@@ -249,6 +266,9 @@ func (si *statsInspector) triggerJsonKeyIndexStatsTask(lastJSONStatsLastTrigger 
 func (si *statsInspector) triggerBM25StatsTask() {
 	collections := si.mt.GetCollections()
 	for _, collection := range collections {
+		if collection == nil || collection.IsExternal() {
+			continue
+		}
 		needTriggerFieldIDs := make([]UniqueID, 0)
 		for _, field := range collection.Schema.GetFields() {
 			// TODO: docking bm25 stats task
@@ -305,6 +325,13 @@ func (si *statsInspector) SubmitStatsTask(originSegmentID, targetSegmentID int64
 	originSegment := si.mt.GetHealthySegment(si.ctx, originSegmentID)
 	if originSegment == nil {
 		return merr.WrapErrSegmentNotFound(originSegmentID)
+	}
+	if si.isExternalCollection(originSegment.GetCollectionID()) {
+		log.Ctx(si.ctx).Info("skip submit stats task for external collection",
+			zap.Int64("collectionID", originSegment.GetCollectionID()),
+			zap.Int64("segmentID", originSegmentID),
+			zap.String("subJobType", subJobType.String()))
+		return nil
 	}
 	taskID, err := si.allocator.AllocID(context.Background())
 	if err != nil {
@@ -369,4 +396,12 @@ func (si *statsInspector) DropStatsTask(originSegmentID int64, subJobType indexp
 	log.Info("statsJobManager drop stats task success", zap.Int64("segmentID", originSegmentID),
 		zap.Int64("taskID", task.GetTaskID()), zap.String("subJobType", subJobType.String()))
 	return nil
+}
+
+func (si *statsInspector) isExternalCollection(collectionID int64) bool {
+	if si.mt == nil {
+		return false
+	}
+	coll := si.mt.GetCollection(collectionID)
+	return coll != nil && coll.IsExternal()
 }

--- a/internal/datacoord/stats_inspector_test.go
+++ b/internal/datacoord/stats_inspector_test.go
@@ -274,18 +274,19 @@ func (s *statsInspectorSuite) TestSubmitStatsTask() {
 
 func (s *statsInspectorSuite) TestSubmitStatsTaskSkipExternalCollection() {
 	segmentID := UniqueID(200)
-	s.mt.segments.SetSegment(segmentID, &SegmentInfo{
+	s.mt.segments.segments[segmentID] = &SegmentInfo{
 		SegmentInfo: &datapb.SegmentInfo{
-			ID:           segmentID,
-			CollectionID: 2,
-			PartitionID:  3,
-			IsSorted:     true,
-			State:        commonpb.SegmentState_Flushed,
-			NumOfRows:    1000,
-			MaxRowNum:    2000,
-			Level:        2,
+			ID:            segmentID,
+			CollectionID:  2,
+			PartitionID:   3,
+			InsertChannel: "by-dev-rootcoord-dml-channel",
+			IsSorted:      true,
+			State:         commonpb.SegmentState_Flushed,
+			NumOfRows:     1000,
+			MaxRowNum:     2000,
+			Level:         2,
 		},
-	})
+	}
 
 	err := s.inspector.SubmitStatsTask(segmentID, segmentID, indexpb.StatsSubJob_TextIndexJob, true)
 	s.NoError(err)


### PR DESCRIPTION
issue: #45881 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary for Senior Maintainers

**Core Invariant**: External collections (those with `ExternalSource` or `ExternalSpec` in their schema) must not undergo automatic compaction, stats collection, or manual compaction triggering, as they reference external data sources rather than being internally managed.

**Changes Overview**:
- Adds a new `IsExternal()` helper method to `collectionInfo` that safely detects external collections by checking if the schema has non-empty `ExternalSource` or `ExternalSpec` fields
- Introduces consistent guards across four compaction policy implementations (clustering, L0, single, and the trigger layer) and stats collection paths to skip processing external collections with informative logging
- In compaction trigger entry points (`ManualTrigger`, `handleSignal`), external collections are rejected with appropriate error codes (`ServiceUnavailable` for manual triggers, skip-with-log for auto-compaction signals) rather than proceeding to scheduling

**Why This Preserves Correctness**:
- Guards are purely additive—non-external collections follow the exact same code paths as before; the PR only adds early returns for external collections
- External collections are correctly identified once at the decision point and immediately skipped; internal collections proceed unmodified through all existing compaction and stats logic
- Test coverage validates the skip behavior for external collections while existing tests for normal collections continue to pass unmodified

**Enhancement Rationale**: External collections represent data managed externally (e.g., S3); compacting them in Milvus would be ineffective and unnecessary. This PR enforces the invariant that compaction and stats operations only apply to internally-managed collections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->