### PR TITLE
fix: change upsert duplicate PK behavior from dedup to error

### DIFF
--- a/internal/proxy/task_upsert_test.go
+++ b/internal/proxy/task_upsert_test.go
@@ -35,7 +35,6 @@ import (
 	"github.com/milvus-io/milvus/internal/proxy/shardclient"
 	"github.com/milvus-io/milvus/internal/util/function/embedding"
 	"github.com/milvus-io/milvus/internal/util/segcore"
-	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/mq/msgstream"
 	"github.com/milvus-io/milvus/pkg/v2/proto/planpb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/rootcoordpb"
@@ -1467,402 +1466,137 @@ func TestGenNullableFieldData_GeometryAndTimestamptz(t *testing.T) {
 	})
 }
 
-func TestUpsertTask_PlanNamespace_AfterPreExecute(t *testing.T) {
-	mockey.PatchConvey("TestUpsertTask_PlanNamespace_AfterPreExecute", t, func() {
-		// Setup global meta cache and common mocks
-		globalMetaCache = &MetaCache{}
-		mockey.Mock(GetReplicateID).Return("", nil).Build()
-		mockey.Mock((*MetaCache).GetCollectionID).Return(int64(1001), nil).Build()
-		mockey.Mock((*MetaCache).GetCollectionInfo).Return(&collectionInfo{updateTimestamp: 12345}, nil).Build()
-		mockey.Mock((*MetaCache).GetPartitionInfo).Return(&partitionInfo{name: "_default"}, nil).Build()
-		mockey.Mock((*MetaCache).GetPartitionID).Return(int64(1002), nil).Build()
-		mockey.Mock(isPartitionKeyMode).Return(false, nil).Build()
-		mockey.Mock(validatePartitionTag).Return(nil).Build()
-
-		// Schema with namespace enabled
-		mockey.Mock((*MetaCache).GetCollectionSchema).To(func(_ *MetaCache, _ context.Context, _ string, _ string) (*schemaInfo, error) {
-			info := createTestSchema()
-			info.CollectionSchema.Properties = append(info.CollectionSchema.Properties, &commonpb.KeyValuePair{Key: common.NamespaceEnabledKey, Value: "true"})
-			return info, nil
-		}).Build()
-
-		// Capture plan to verify namespace
-		var capturedPlan *planpb.PlanNode
-		mockey.Mock(planparserv2.CreateRequeryPlan).To(func(_ *schemapb.FieldSchema, _ *schemapb.IDs) *planpb.PlanNode {
-			capturedPlan = &planpb.PlanNode{}
-			return capturedPlan
-		}).Build()
-
-		// Mock query to return a valid result for queryPreExecute merge path
-		mockey.Mock((*Proxy).query).Return(&milvuspb.QueryResults{
-			Status: merr.Success(),
-			FieldsData: []*schemapb.FieldData{
-				{
-					FieldName: "id",
-					FieldId:   100,
-					Type:      schemapb.DataType_Int64,
-					Field:     &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{1, 2}}}}},
-				},
-				{
-					FieldName: "name",
-					FieldId:   102,
-					Type:      schemapb.DataType_VarChar,
-					Field:     &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: []string{"old1", "old2"}}}}},
-				},
-				{
-					FieldName: "vector",
-					FieldId:   101,
-					Type:      schemapb.DataType_FloatVector,
-					Field:     &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{Dim: 128, Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: make([]float32, 256)}}}},
-				},
-			},
-		}, segcore.StorageCost{}, nil).Build()
-
-		// Build task
-		task := createTestUpdateTask()
-		ns := "ns-1"
-		task.req.PartialUpdate = true
-		task.req.Namespace = &ns
-
-		// Skip insert/delete heavy logic
-		mockey.Mock((*upsertTask).insertPreExecute).Return(nil).Build()
-		mockey.Mock((*upsertTask).deletePreExecute).Return(nil).Build()
-
-		err := task.PreExecute(context.Background())
-		assert.NoError(t, err)
-		assert.NotNil(t, capturedPlan)
-		assert.NotNil(t, capturedPlan.Namespace)
-		assert.Equal(t, *task.req.Namespace, *capturedPlan.Namespace)
-	})
-}
-
-func TestUpsertTask_Deduplicate_Int64PK(t *testing.T) {
-	// Test deduplication with Int64 primary key
-	primaryFieldSchema := &schemapb.FieldSchema{
-		Name:         "id",
-		FieldID:      100,
-		DataType:     schemapb.DataType_Int64,
-		IsPrimaryKey: true,
-	}
-
-	collSchema := &schemapb.CollectionSchema{
+func TestUpsertTask_DuplicatePK_Int64(t *testing.T) {
+	schema := &schemapb.CollectionSchema{
+		Name: "test_duplicate_pk",
 		Fields: []*schemapb.FieldSchema{
-			primaryFieldSchema,
-			{
-				Name:     "float_field",
-				FieldID:  101,
-				DataType: schemapb.DataType_Float,
-			},
+			{FieldID: 100, Name: "id", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
+			{FieldID: 101, Name: "value", DataType: schemapb.DataType_Int32},
 		},
 	}
-	schema := newSchemaInfo(collSchema)
 
-	// Create field data with duplicate IDs: [1, 2, 3, 2, 1]
-	// Expected to keep last occurrence of each: [3, 2, 1] (indices 2, 3, 4)
+	// Data with duplicate primary keys: 1, 2, 1 (duplicate)
 	fieldsData := []*schemapb.FieldData{
 		{
 			FieldName: "id",
+			FieldId:   100,
 			Type:      schemapb.DataType_Int64,
 			Field: &schemapb.FieldData_Scalars{
 				Scalars: &schemapb.ScalarField{
 					Data: &schemapb.ScalarField_LongData{
-						LongData: &schemapb.LongArray{
-							Data: []int64{1, 2, 3, 2, 1},
-						},
+						LongData: &schemapb.LongArray{Data: []int64{1, 2, 1}},
 					},
 				},
 			},
 		},
 		{
-			FieldName: "float_field",
-			Type:      schemapb.DataType_Float,
+			FieldName: "value",
+			FieldId:   101,
+			Type:      schemapb.DataType_Int32,
 			Field: &schemapb.FieldData_Scalars{
 				Scalars: &schemapb.ScalarField{
-					Data: &schemapb.ScalarField_FloatData{
-						FloatData: &schemapb.FloatArray{
-							Data: []float32{1.1, 2.2, 3.3, 2.4, 1.5},
-						},
+					Data: &schemapb.ScalarField_IntData{
+						IntData: &schemapb.IntArray{Data: []int32{100, 200, 300}},
 					},
 				},
 			},
 		},
 	}
 
-	deduplicatedFields, newNumRows, err := DeduplicateFieldData(primaryFieldSchema, fieldsData, schema)
+	// Test CheckDuplicatePkExist directly
+	primaryFieldSchema, err := typeutil.GetPrimaryFieldSchema(schema)
 	assert.NoError(t, err)
-	assert.Equal(t, uint32(3), newNumRows)
-	assert.Equal(t, 2, len(deduplicatedFields))
-
-	// Check deduplicated primary keys
-	pkField := deduplicatedFields[0]
-	pkData := pkField.GetScalars().GetLongData().GetData()
-	assert.Equal(t, 3, len(pkData))
-	assert.Equal(t, []int64{3, 2, 1}, pkData)
-
-	// Check corresponding float values (should be 3.3, 2.4, 1.5)
-	floatField := deduplicatedFields[1]
-	floatData := floatField.GetScalars().GetFloatData().GetData()
-	assert.Equal(t, 3, len(floatData))
-	assert.Equal(t, []float32{3.3, 2.4, 1.5}, floatData)
+	hasDuplicate, err := CheckDuplicatePkExist(primaryFieldSchema, fieldsData)
+	assert.NoError(t, err)
+	assert.True(t, hasDuplicate, "should detect duplicate primary keys")
 }
 
-func TestUpsertTask_Deduplicate_VarCharPK(t *testing.T) {
-	// Test deduplication with VarChar primary key
-	primaryFieldSchema := &schemapb.FieldSchema{
-		Name:         "id",
-		FieldID:      100,
-		DataType:     schemapb.DataType_VarChar,
-		IsPrimaryKey: true,
-	}
-
-	collSchema := &schemapb.CollectionSchema{
+func TestUpsertTask_DuplicatePK_VarChar(t *testing.T) {
+	schema := &schemapb.CollectionSchema{
+		Name: "test_duplicate_pk_varchar",
 		Fields: []*schemapb.FieldSchema{
-			primaryFieldSchema,
-			{
-				Name:     "int_field",
-				FieldID:  101,
-				DataType: schemapb.DataType_Int64,
-			},
+			{FieldID: 100, Name: "id", IsPrimaryKey: true, DataType: schemapb.DataType_VarChar, TypeParams: []*commonpb.KeyValuePair{{Key: "max_length", Value: "100"}}},
+			{FieldID: 101, Name: "value", DataType: schemapb.DataType_Int32},
 		},
 	}
-	schema := newSchemaInfo(collSchema)
 
-	// Create field data with duplicate IDs: ["a", "b", "c", "b", "a"]
-	// Expected to keep last occurrence of each: ["c", "b", "a"] (indices 2, 3, 4)
+	// Data with duplicate primary keys: "a", "b", "a" (duplicate)
 	fieldsData := []*schemapb.FieldData{
 		{
 			FieldName: "id",
+			FieldId:   100,
 			Type:      schemapb.DataType_VarChar,
 			Field: &schemapb.FieldData_Scalars{
 				Scalars: &schemapb.ScalarField{
 					Data: &schemapb.ScalarField_StringData{
-						StringData: &schemapb.StringArray{
-							Data: []string{"a", "b", "c", "b", "a"},
-						},
+						StringData: &schemapb.StringArray{Data: []string{"a", "b", "a"}},
 					},
 				},
 			},
 		},
 		{
-			FieldName: "int_field",
-			Type:      schemapb.DataType_Int64,
+			FieldName: "value",
+			FieldId:   101,
+			Type:      schemapb.DataType_Int32,
 			Field: &schemapb.FieldData_Scalars{
 				Scalars: &schemapb.ScalarField{
-					Data: &schemapb.ScalarField_LongData{
-						LongData: &schemapb.LongArray{
-							Data: []int64{100, 200, 300, 201, 101},
-						},
+					Data: &schemapb.ScalarField_IntData{
+						IntData: &schemapb.IntArray{Data: []int32{100, 200, 300}},
 					},
 				},
 			},
 		},
 	}
 
-	deduplicatedFields, newNumRows, err := DeduplicateFieldData(primaryFieldSchema, fieldsData, schema)
+	// Test CheckDuplicatePkExist directly
+	primaryFieldSchema, err := typeutil.GetPrimaryFieldSchema(schema)
 	assert.NoError(t, err)
-	assert.Equal(t, uint32(3), newNumRows)
-	assert.Equal(t, 2, len(deduplicatedFields))
-
-	// Check deduplicated primary keys
-	pkField := deduplicatedFields[0]
-	pkData := pkField.GetScalars().GetStringData().GetData()
-	assert.Equal(t, 3, len(pkData))
-	assert.Equal(t, []string{"c", "b", "a"}, pkData)
-
-	// Check corresponding int64 values (should be 300, 201, 101)
-	int64Field := deduplicatedFields[1]
-	int64Data := int64Field.GetScalars().GetLongData().GetData()
-	assert.Equal(t, 3, len(int64Data))
-	assert.Equal(t, []int64{300, 201, 101}, int64Data)
+	hasDuplicate, err := CheckDuplicatePkExist(primaryFieldSchema, fieldsData)
+	assert.NoError(t, err)
+	assert.True(t, hasDuplicate, "should detect duplicate primary keys")
 }
 
-func TestUpsertTask_Deduplicate_NoDuplicates(t *testing.T) {
-	// Test with no duplicates - should return original data
-	primaryFieldSchema := &schemapb.FieldSchema{
-		Name:         "id",
-		FieldID:      100,
-		DataType:     schemapb.DataType_Int64,
-		IsPrimaryKey: true,
-	}
-
-	collSchema := &schemapb.CollectionSchema{
+func TestUpsertTask_NoDuplicatePK(t *testing.T) {
+	schema := &schemapb.CollectionSchema{
+		Name: "test_no_duplicate_pk",
 		Fields: []*schemapb.FieldSchema{
-			primaryFieldSchema,
+			{FieldID: 100, Name: "id", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
+			{FieldID: 101, Name: "value", DataType: schemapb.DataType_Int32},
 		},
 	}
-	schema := newSchemaInfo(collSchema)
 
+	// Data with unique primary keys: 1, 2, 3
 	fieldsData := []*schemapb.FieldData{
 		{
 			FieldName: "id",
+			FieldId:   100,
 			Type:      schemapb.DataType_Int64,
 			Field: &schemapb.FieldData_Scalars{
 				Scalars: &schemapb.ScalarField{
 					Data: &schemapb.ScalarField_LongData{
-						LongData: &schemapb.LongArray{
-							Data: []int64{1, 2, 3, 4, 5},
-						},
+						LongData: &schemapb.LongArray{Data: []int64{1, 2, 3}},
 					},
 				},
 			},
 		},
-	}
-
-	deduplicatedFields, newNumRows, err := DeduplicateFieldData(primaryFieldSchema, fieldsData, schema)
-	assert.NoError(t, err)
-	assert.Equal(t, uint32(5), newNumRows)
-	assert.Equal(t, 1, len(deduplicatedFields))
-
-	// Should be unchanged
-	pkField := deduplicatedFields[0]
-	pkData := pkField.GetScalars().GetLongData().GetData()
-	assert.Equal(t, []int64{1, 2, 3, 4, 5}, pkData)
-}
-
-func TestUpsertTask_Deduplicate_WithVector(t *testing.T) {
-	// Test deduplication with vector field
-	primaryFieldSchema := &schemapb.FieldSchema{
-		Name:         "id",
-		FieldID:      100,
-		DataType:     schemapb.DataType_Int64,
-		IsPrimaryKey: true,
-	}
-
-	collSchema := &schemapb.CollectionSchema{
-		Fields: []*schemapb.FieldSchema{
-			primaryFieldSchema,
-			{
-				Name:     "vector",
-				FieldID:  101,
-				DataType: schemapb.DataType_FloatVector,
-			},
-		},
-	}
-	schema := newSchemaInfo(collSchema)
-
-	dim := 4
-	// Create field data with duplicate IDs: [1, 2, 1]
-	// Expected to keep indices [1, 2] (last occurrence of 2, last occurrence of 1)
-	fieldsData := []*schemapb.FieldData{
 		{
-			FieldName: "id",
-			Type:      schemapb.DataType_Int64,
+			FieldName: "value",
+			FieldId:   101,
+			Type:      schemapb.DataType_Int32,
 			Field: &schemapb.FieldData_Scalars{
 				Scalars: &schemapb.ScalarField{
-					Data: &schemapb.ScalarField_LongData{
-						LongData: &schemapb.LongArray{
-							Data: []int64{1, 2, 1},
-						},
-					},
-				},
-			},
-		},
-		{
-			FieldName: "vector",
-			Type:      schemapb.DataType_FloatVector,
-			Field: &schemapb.FieldData_Vectors{
-				Vectors: &schemapb.VectorField{
-					Dim: int64(dim),
-					Data: &schemapb.VectorField_FloatVector{
-						FloatVector: &schemapb.FloatArray{
-							Data: []float32{
-								1.0, 1.1, 1.2, 1.3, // vector for ID 1 (first occurrence)
-								2.0, 2.1, 2.2, 2.3, // vector for ID 2
-								1.4, 1.5, 1.6, 1.7, // vector for ID 1 (second occurrence - keep this)
-							},
-						},
+					Data: &schemapb.ScalarField_IntData{
+						IntData: &schemapb.IntArray{Data: []int32{100, 200, 300}},
 					},
 				},
 			},
 		},
 	}
 
-	deduplicatedFields, newNumRows, err := DeduplicateFieldData(primaryFieldSchema, fieldsData, schema)
+	// Call CheckDuplicatePkExist directly to verify no duplicate error
+	primaryFieldSchema, err := typeutil.GetPrimaryFieldSchema(schema)
 	assert.NoError(t, err)
-	assert.Equal(t, uint32(2), newNumRows)
-	assert.Equal(t, 2, len(deduplicatedFields))
-
-	// Check deduplicated primary keys
-	pkField := deduplicatedFields[0]
-	pkData := pkField.GetScalars().GetLongData().GetData()
-	assert.Equal(t, 2, len(pkData))
-	assert.Equal(t, []int64{2, 1}, pkData)
-
-	// Check corresponding vector (should keep vectors for ID 2 and ID 1's last occurrence)
-	vectorField := deduplicatedFields[1]
-	vectorData := vectorField.GetVectors().GetFloatVector().GetData()
-	assert.Equal(t, 8, len(vectorData)) // 2 vectors * 4 dimensions
-	expectedVector := []float32{
-		2.0, 2.1, 2.2, 2.3, // vector for ID 2
-		1.4, 1.5, 1.6, 1.7, // vector for ID 1 (last occurrence)
-	}
-	assert.Equal(t, expectedVector, vectorData)
-}
-
-func TestUpsertTask_Deduplicate_EmptyData(t *testing.T) {
-	// Test with empty data
-	primaryFieldSchema := &schemapb.FieldSchema{
-		Name:         "id",
-		FieldID:      100,
-		DataType:     schemapb.DataType_Int64,
-		IsPrimaryKey: true,
-	}
-
-	collSchema := &schemapb.CollectionSchema{
-		Fields: []*schemapb.FieldSchema{
-			primaryFieldSchema,
-		},
-	}
-	schema := newSchemaInfo(collSchema)
-
-	fieldsData := []*schemapb.FieldData{}
-
-	deduplicatedFields, newNumRows, err := DeduplicateFieldData(primaryFieldSchema, fieldsData, schema)
+	hasDuplicate, err := CheckDuplicatePkExist(primaryFieldSchema, fieldsData)
 	assert.NoError(t, err)
-	assert.Equal(t, uint32(0), newNumRows)
-	assert.Equal(t, 0, len(deduplicatedFields))
-}
-
-func TestUpsertTask_Deduplicate_MissingPrimaryKey(t *testing.T) {
-	// Test with missing primary key field
-	primaryFieldSchema := &schemapb.FieldSchema{
-		Name:         "id",
-		FieldID:      100,
-		DataType:     schemapb.DataType_Int64,
-		IsPrimaryKey: true,
-	}
-
-	collSchema := &schemapb.CollectionSchema{
-		Fields: []*schemapb.FieldSchema{
-			primaryFieldSchema,
-			{
-				Name:     "other_field",
-				FieldID:  101,
-				DataType: schemapb.DataType_Float,
-			},
-		},
-	}
-	schema := newSchemaInfo(collSchema)
-
-	fieldsData := []*schemapb.FieldData{
-		{
-			FieldName: "other_field",
-			Type:      schemapb.DataType_Float,
-			Field: &schemapb.FieldData_Scalars{
-				Scalars: &schemapb.ScalarField{
-					Data: &schemapb.ScalarField_FloatData{
-						FloatData: &schemapb.FloatArray{
-							Data: []float32{1.1, 2.2},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	_, _, err := DeduplicateFieldData(primaryFieldSchema, fieldsData, schema)
-	assert.Error(t, err)
-	// validateFieldDataColumns will fail first due to column count mismatch
-	// or the function will fail when trying to find primary key
-	assert.True(t, err != nil)
+	assert.False(t, hasDuplicate, "should not have duplicate primary keys")
 }

--- a/tests/go_client/testcases/upsert_test.go
+++ b/tests/go_client/testcases/upsert_test.go
@@ -436,7 +436,7 @@ func TestUpsertAutoID(t *testing.T) {
 	// upsert without pks -> error
 	vecColumn = hp.GenColumnData(nb, entity.FieldTypeFloatVector, *hp.TNewDataOption())
 	_, err = mc.Upsert(ctx, client.NewColumnBasedInsertOption(schema.CollectionName).WithColumns(vecColumn))
-	common.CheckErr(t, err, false, "has no corresponding fieldData pass in: invalid parameter")
+	common.CheckErr(t, err, false, "must assign pk when upsert")
 }
 
 // test upsert autoId collection


### PR DESCRIPTION
issue: #44320

Replace the DeduplicateFieldData function with CheckDuplicatePkExist that returns an error when duplicate primary keys are detected in the same batch, instead of silently deduplicating.

Changes:
- Replace DeduplicateFieldData with CheckDuplicatePkExist in util.go
- Update upsertTask.PreExecute to return error on duplicate PKs
- Simplify helper function from findLastOccurrenceIndices to hasDuplicates
- Update unit tests to verify the new error behavior
- Add Python integration tests for duplicate PK error cases