### PR TITLE
fix: apply mmap settings correctly during segment load

### DIFF
--- a/internal/core/src/common/Consts.h
+++ b/internal/core/src/common/Consts.h
@@ -133,3 +133,4 @@ const std::string ELEMENT_TYPE_KEY_FOR_ARROW = "elementType";
 // EPSILON value for comparing float numbers
 const float EPSILON = 0.0000000119;
 const std::string NAMESPACE_FIELD_NAME = "$namespace_id";
+const std::string MMAP_ENABLED_KEY = "mmap.enabled";

--- a/internal/core/src/common/Schema.cpp
+++ b/internal/core/src/common/Schema.cpp
@@ -26,7 +26,9 @@
 #include "Schema.h"
 #include "SystemProperty.h"
 #include "arrow/util/key_value_metadata.h"
+#include "common/Consts.h"
 #include "milvus-storage/common/constants.h"
+#include "pb/common.pb.h"
 #include "protobuf_utils.h"
 
 namespace milvus {
@@ -61,6 +63,12 @@ Schema::ParseFrom(const milvus::proto::schema::CollectionSchema& schema_proto) {
         if (child.name() == namespace_field_name) {
             schema->set_namespace_field_id(field_id);
         }
+
+        auto [has_setting, enabled] =
+            GetBoolFromRepeatedKVs(child.type_params(), MMAP_ENABLED_KEY);
+        if (has_setting) {
+            schema->mmap_fields_[field_id] = enabled;
+        }
     };
 
     for (const milvus::proto::schema::FieldSchema& child :
@@ -74,6 +82,9 @@ Schema::ParseFrom(const milvus::proto::schema::CollectionSchema& schema_proto) {
             process_field(sub_field);
         }
     }
+
+    std::tie(schema->has_mmap_setting_, schema->mmap_enabled_) =
+        GetBoolFromRepeatedKVs(schema_proto.properties(), MMAP_ENABLED_KEY);
 
     AssertInfo(schema->get_primary_field_id().has_value(),
                "primary key should be specified");
@@ -148,6 +159,16 @@ Schema::AbsentFields(Schema& old_schema) const {
     }
 
     return std::make_unique<std::vector<FieldMeta>>(result);
+}
+
+std::pair<bool, bool>
+Schema::MmapEnabled(const FieldId& field_id) const {
+    auto it = mmap_fields_.find(field_id);
+    // fallback to  collection-level config
+    if (it == mmap_fields_.end()) {
+        return {has_mmap_setting_, mmap_enabled_};
+    }
+    return {true, it->second};
 }
 
 }  // namespace milvus

--- a/internal/core/src/common/Schema.h
+++ b/internal/core/src/common/Schema.h
@@ -374,6 +374,24 @@ class Schema {
     std::unique_ptr<std::vector<FieldMeta>>
     AbsentFields(Schema& old_schema) const;
 
+    /**
+     * @brief Determines whether the specified field should use mmap for data loading.
+     *
+     * This function checks mmap settings at the field level first. If no field-level
+     * setting is found, it falls back to the collection-level mmap configuration.
+     *
+     * @param field The field ID to check mmap settings for.
+     *
+     * @return A pair of booleans:
+     *         - first:  Whether an mmap setting exists (at field or collection level).
+     *         - second: Whether mmap is enabled (only meaningful when first is true).
+     *
+     * @note If no mmap setting exists at any level, first will be false and second
+     *       should be ignored.
+     */
+    std::pair<bool, bool>
+    MmapEnabled(const FieldId& field) const;
+
  private:
     int64_t debug_id = START_USER_FIELDID;
     std::vector<FieldId> field_ids_;
@@ -395,6 +413,11 @@ class Schema {
 
     // schema_version_, currently marked with update timestamp
     uint64_t schema_version_;
+
+    // mmap settings
+    bool has_mmap_setting_ = false;
+    bool mmap_enabled_ = false;
+    std::unordered_map<FieldId, bool> mmap_fields_;
 };
 
 using SchemaPtr = std::shared_ptr<Schema>;

--- a/internal/core/src/common/SchemaTest.cpp
+++ b/internal/core/src/common/SchemaTest.cpp
@@ -1,0 +1,212 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+
+#include <gtest/gtest.h>
+
+#include "common/Schema.h"
+
+using namespace milvus;
+
+class SchemaTest : public ::testing::Test {
+ protected:
+    void
+    SetUp() override {
+        schema_ = std::make_shared<Schema>();
+    }
+
+    std::shared_ptr<Schema> schema_;
+};
+
+TEST_F(SchemaTest, MmapEnabledNoSetting) {
+    // Add a field without any mmap setting
+    auto field_id = schema_->AddDebugField("test_field", DataType::INT64);
+    schema_->set_primary_field_id(field_id);
+
+    // When no mmap setting exists at any level, first should be false
+    auto [has_setting, enabled] = schema_->MmapEnabled(field_id);
+    EXPECT_FALSE(has_setting);
+    // The enabled value is undefined when has_setting is false, so we don't check it
+}
+
+TEST_F(SchemaTest, MmapEnabledCollectionLevelEnabled) {
+    // Create schema with collection-level mmap enabled via protobuf
+    milvus::proto::schema::CollectionSchema schema_proto;
+
+    auto* field = schema_proto.add_fields();
+    field->set_fieldid(100);
+    field->set_name("pk_field");
+    field->set_data_type(milvus::proto::schema::DataType::Int64);
+    field->set_is_primary_key(true);
+
+    // Set collection-level mmap enabled
+    auto* prop = schema_proto.add_properties();
+    prop->set_key("mmap.enabled");
+    prop->set_value("true");
+
+    auto parsed_schema = Schema::ParseFrom(schema_proto);
+    FieldId pk_field_id(100);
+
+    auto [has_setting, enabled] = parsed_schema->MmapEnabled(pk_field_id);
+    EXPECT_TRUE(has_setting);
+    EXPECT_TRUE(enabled);
+}
+
+TEST_F(SchemaTest, MmapEnabledCollectionLevelDisabled) {
+    // Create schema with collection-level mmap disabled via protobuf
+    milvus::proto::schema::CollectionSchema schema_proto;
+
+    auto* field = schema_proto.add_fields();
+    field->set_fieldid(100);
+    field->set_name("pk_field");
+    field->set_data_type(milvus::proto::schema::DataType::Int64);
+    field->set_is_primary_key(true);
+
+    // Set collection-level mmap disabled
+    auto* prop = schema_proto.add_properties();
+    prop->set_key("mmap.enabled");
+    prop->set_value("false");
+
+    auto parsed_schema = Schema::ParseFrom(schema_proto);
+    FieldId pk_field_id(100);
+
+    auto [has_setting, enabled] = parsed_schema->MmapEnabled(pk_field_id);
+    EXPECT_TRUE(has_setting);
+    EXPECT_FALSE(enabled);
+}
+
+TEST_F(SchemaTest, MmapEnabledCollectionLevelCaseInsensitive) {
+    // Test that mmap value parsing is case-insensitive
+    milvus::proto::schema::CollectionSchema schema_proto;
+
+    auto* field = schema_proto.add_fields();
+    field->set_fieldid(100);
+    field->set_name("pk_field");
+    field->set_data_type(milvus::proto::schema::DataType::Int64);
+    field->set_is_primary_key(true);
+
+    // Set collection-level mmap with uppercase TRUE
+    auto* prop = schema_proto.add_properties();
+    prop->set_key("mmap.enabled");
+    prop->set_value("TRUE");
+
+    auto parsed_schema = Schema::ParseFrom(schema_proto);
+    FieldId pk_field_id(100);
+
+    auto [has_setting, enabled] = parsed_schema->MmapEnabled(pk_field_id);
+    EXPECT_TRUE(has_setting);
+    EXPECT_TRUE(enabled);
+}
+
+TEST_F(SchemaTest, MmapEnabledFieldLevelOverridesCollectionLevel) {
+    // Test that field-level mmap setting overrides collection-level setting
+    milvus::proto::schema::CollectionSchema schema_proto;
+
+    auto* field = schema_proto.add_fields();
+    field->set_fieldid(100);
+    field->set_name("pk_field");
+    field->set_data_type(milvus::proto::schema::DataType::Int64);
+    field->set_is_primary_key(true);
+
+    // Set collection-level mmap enabled
+    auto* prop = schema_proto.add_properties();
+    prop->set_key("mmap.enabled");
+    prop->set_value("true");
+
+    // Note: Field-level mmap settings are set via schema_proto.properties()
+    // in the current implementation, which applies to all fields.
+    // This test verifies the fallback behavior when no field-level override exists.
+
+    auto parsed_schema = Schema::ParseFrom(schema_proto);
+    FieldId pk_field_id(100);
+
+    // Without field-level override, should use collection-level setting
+    auto [has_setting, enabled] = parsed_schema->MmapEnabled(pk_field_id);
+    EXPECT_TRUE(has_setting);
+    EXPECT_TRUE(enabled);
+}
+
+TEST_F(SchemaTest, MmapEnabledNonExistentField) {
+    // Test MmapEnabled with a field that doesn't exist in mmap_fields_
+    // but collection-level setting exists
+    milvus::proto::schema::CollectionSchema schema_proto;
+
+    auto* field1 = schema_proto.add_fields();
+    field1->set_fieldid(100);
+    field1->set_name("pk_field");
+    field1->set_data_type(milvus::proto::schema::DataType::Int64);
+    field1->set_is_primary_key(true);
+
+    auto* field2 = schema_proto.add_fields();
+    field2->set_fieldid(101);
+    field2->set_name("data_field");
+    field2->set_data_type(milvus::proto::schema::DataType::Float);
+
+    // Set collection-level mmap enabled
+    auto* prop = schema_proto.add_properties();
+    prop->set_key("mmap.enabled");
+    prop->set_value("true");
+
+    auto parsed_schema = Schema::ParseFrom(schema_proto);
+
+    // Both fields should fallback to collection-level setting
+    FieldId pk_field_id(100);
+    auto [has_setting1, enabled1] = parsed_schema->MmapEnabled(pk_field_id);
+    EXPECT_TRUE(has_setting1);
+    EXPECT_TRUE(enabled1);
+
+    FieldId data_field_id(101);
+    auto [has_setting2, enabled2] = parsed_schema->MmapEnabled(data_field_id);
+    EXPECT_TRUE(has_setting2);
+    EXPECT_TRUE(enabled2);
+
+    // Test with a field ID that was never added to the schema
+    FieldId non_existent_field_id(999);
+    auto [has_setting3, enabled3] =
+        parsed_schema->MmapEnabled(non_existent_field_id);
+    EXPECT_TRUE(has_setting3);  // Falls back to collection-level
+    EXPECT_TRUE(enabled3);
+}
+
+TEST_F(SchemaTest, MmapEnabledMultipleFields) {
+    // Test MmapEnabled with multiple fields, all using collection-level setting
+    milvus::proto::schema::CollectionSchema schema_proto;
+
+    auto* pk_field = schema_proto.add_fields();
+    pk_field->set_fieldid(100);
+    pk_field->set_name("pk_field");
+    pk_field->set_data_type(milvus::proto::schema::DataType::Int64);
+    pk_field->set_is_primary_key(true);
+
+    auto* int_field = schema_proto.add_fields();
+    int_field->set_fieldid(101);
+    int_field->set_name("int_field");
+    int_field->set_data_type(milvus::proto::schema::DataType::Int32);
+
+    auto* float_field = schema_proto.add_fields();
+    float_field->set_fieldid(102);
+    float_field->set_name("float_field");
+    float_field->set_data_type(milvus::proto::schema::DataType::Float);
+
+    // Set collection-level mmap disabled
+    auto* prop = schema_proto.add_properties();
+    prop->set_key("mmap.enabled");
+    prop->set_value("false");
+
+    auto parsed_schema = Schema::ParseFrom(schema_proto);
+
+    // All fields should have the same collection-level setting
+    for (int64_t id = 100; id <= 102; ++id) {
+        FieldId field_id(id);
+        auto [has_setting, enabled] = parsed_schema->MmapEnabled(field_id);
+        EXPECT_TRUE(has_setting);
+        EXPECT_FALSE(enabled);
+    }
+}

--- a/internal/core/src/common/protobuf_utils.h
+++ b/internal/core/src/common/protobuf_utils.h
@@ -45,6 +45,32 @@ RepeatedKeyValToMap(
     return mapping;
 }
 
+/**
+ * @brief Get a boolean value from repeated KeyValuePair by key.
+ *
+ * @param kvs The repeated KeyValuePair field to search.
+ * @param key The key to look for.
+ * @return std::pair<bool, bool> where:
+ *         - first: whether the key was found.
+ *         - second: the parsed boolean value (true if value is "true", case-insensitive).
+ */
+static std::pair<bool, bool>
+GetBoolFromRepeatedKVs(
+    const google::protobuf::RepeatedPtrField<proto::common::KeyValuePair>& kvs,
+    const std::string& key) {
+    for (auto& kv : kvs) {
+        if (kv.key() == key) {
+            std::string lower;
+            std::transform(kv.value().begin(),
+                           kv.value().end(),
+                           std::back_inserter(lower),
+                           ::tolower);
+            return {true, lower == "true"};
+        }
+    }
+    return {false, false};
+}
+
 class ProtoLayout;
 using ProtoLayoutPtr = std::unique_ptr<ProtoLayout>;
 


### PR DESCRIPTION
Previously, mmap settings configured at the collection or field level were not being applied during segment loading in segcore. This was caused by:

1. A typo in the key name: "mmap.enable" instead of "mmap.enabled"
2. Missing logic to parse and apply mmap settings from schema

This commit fixes the issue by:
- Correcting the key name to "mmap.enabled" to match the standard
- Adding Schema::MmapEnabled() method to retrieve field/collection level mmap settings with proper fallback logic
- Parsing mmap settings from field type_params and collection properties during schema parsing
- Applying computed mmap settings in LoadColumnGroup() and Load() methods instead of hardcoded false values
- Using global MmapConfig as fallback when no explicit setting exists

The mmap setting priority is now:
1. Field-level mmap setting (from type_params)
2. Collection-level mmap setting (from properties)
3. Global mmap config (from MmapManager)

For column groups, if any field has mmap enabled, the entire group uses mmap (since they are loaded together).

Related issue: #45060