### PR TITLE
fix: [2.6] reject duplicate primary keys in upsert batch request

### DIFF
--- a/internal/proxy/task_insert.go
+++ b/internal/proxy/task_insert.go
@@ -235,11 +235,15 @@ func (it *insertTask) PreExecute(ctx context.Context) error {
 		return err
 	}
 
-	// set field ID to insert field data
-	err = fillFieldPropertiesBySchema(it.insertMsg.GetFieldsData(), schema.CollectionSchema)
+	// Validate and set field ID to insert field data
+	err = validateFieldDataColumns(it.insertMsg.GetFieldsData(), schema)
 	if err != nil {
-		log.Info("set fieldID to fieldData failed",
-			zap.Error(err))
+		log.Info("validate field data columns failed", zap.Error(err))
+		return err
+	}
+	err = fillFieldPropertiesOnly(it.insertMsg.GetFieldsData(), schema)
+	if err != nil {
+		log.Info("fill field properties failed", zap.Error(err))
 		return err
 	}
 

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -1153,6 +1153,59 @@ func parsePrimaryFieldData2IDs(fieldData *schemapb.FieldData) (*schemapb.IDs, er
 	return primaryData, nil
 }
 
+// hasDuplicates checks if there are any duplicate values in the slice.
+// Returns true immediately when the first duplicate is found (early exit).
+func hasDuplicates[T comparable](ids []T) bool {
+	seen := make(map[T]struct{}, len(ids))
+	for _, id := range ids {
+		if _, exists := seen[id]; exists {
+			return true
+		}
+		seen[id] = struct{}{}
+	}
+	return false
+}
+
+// CheckDuplicatePkExist checks if there are duplicate primary keys in the field data.
+// Returns (true, nil) if duplicates exist, (false, nil) if no duplicates.
+// Returns (false, error) if there's an error during checking.
+func CheckDuplicatePkExist(primaryFieldSchema *schemapb.FieldSchema, fieldsData []*schemapb.FieldData) (bool, error) {
+	if len(fieldsData) == 0 {
+		return false, nil
+	}
+
+	// find primary field data
+	var primaryFieldData *schemapb.FieldData
+	for _, field := range fieldsData {
+		if field.GetFieldName() == primaryFieldSchema.GetName() {
+			primaryFieldData = field
+			break
+		}
+	}
+
+	if primaryFieldData == nil {
+		return false, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("must assign pk when checking duplicates, primary field: %v", primaryFieldSchema.GetName()))
+	}
+
+	// check for duplicates based on primary key type
+	switch primaryFieldData.Field.(type) {
+	case *schemapb.FieldData_Scalars:
+		scalarField := primaryFieldData.GetScalars()
+		switch scalarField.Data.(type) {
+		case *schemapb.ScalarField_LongData:
+			intIDs := scalarField.GetLongData().GetData()
+			return hasDuplicates(intIDs), nil
+		case *schemapb.ScalarField_StringData:
+			strIDs := scalarField.GetStringData().GetData()
+			return hasDuplicates(strIDs), nil
+		default:
+			return false, merr.WrapErrParameterInvalidMsg("unsupported primary key type")
+		}
+	default:
+		return false, merr.WrapErrParameterInvalidMsg("primary field must be scalar type")
+	}
+}
+
 // autoGenPrimaryFieldData generate primary data when autoID == true
 func autoGenPrimaryFieldData(fieldSchema *schemapb.FieldSchema, data interface{}) (*schemapb.FieldData, error) {
 	var fieldData schemapb.FieldData
@@ -1212,53 +1265,70 @@ func autoGenDynamicFieldData(data [][]byte) *schemapb.FieldData {
 	}
 }
 
-// fillFieldPropertiesBySchema set fieldID to fieldData according FieldSchemas
-func fillFieldPropertiesBySchema(columns []*schemapb.FieldData, schema *schemapb.CollectionSchema) error {
-	fieldName2Schema := make(map[string]*schemapb.FieldSchema)
-
+// validateFieldDataColumns validates that all required fields are present and no unknown fields exist.
+// It checks:
+// 1. The number of columns matches the expected count (excluding BM25 output fields)
+// 2. All field names exist in the schema
+// Returns detailed error message listing expected and provided fields if validation fails.
+func validateFieldDataColumns(columns []*schemapb.FieldData, schema *schemaInfo) error {
 	expectColumnNum := 0
-	for _, field := range schema.GetFields() {
-		fieldName2Schema[field.Name] = field
-		if !IsBM25FunctionOutputField(field, schema) {
+
+	// Count expected columns
+	for _, field := range schema.CollectionSchema.GetFields() {
+		if !IsBM25FunctionOutputField(field, schema.CollectionSchema) {
 			expectColumnNum++
 		}
 	}
-
-	for _, structField := range schema.GetStructArrayFields() {
-		for _, field := range structField.GetFields() {
-			fieldName2Schema[field.Name] = field
-			expectColumnNum++
-		}
+	for _, structField := range schema.CollectionSchema.GetStructArrayFields() {
+		expectColumnNum += len(structField.GetFields())
 	}
 
+	// Validate column count
 	if len(columns) != expectColumnNum {
 		return fmt.Errorf("len(columns) mismatch the expectColumnNum, expectColumnNum: %d, len(columns): %d",
 			expectColumnNum, len(columns))
 	}
 
+	// Validate field existence using schemaHelper
 	for _, fieldData := range columns {
-		if fieldSchema, ok := fieldName2Schema[fieldData.FieldName]; ok {
-			fieldData.FieldId = fieldSchema.FieldID
-			fieldData.Type = fieldSchema.DataType
-
-			// Set the ElementType because it may not be set in the insert request.
-			if fieldData.Type == schemapb.DataType_Array {
-				fd, ok := fieldData.Field.(*schemapb.FieldData_Scalars)
-				if !ok || fd.Scalars.GetArrayData() == nil {
-					return fmt.Errorf("field convert FieldData_Scalars fail in fieldData, fieldName: %s,"+
-						" collectionName:%s", fieldData.FieldName, schema.Name)
-				}
-				fd.Scalars.GetArrayData().ElementType = fieldSchema.ElementType
-			} else if fieldData.Type == schemapb.DataType_ArrayOfVector {
-				fd, ok := fieldData.Field.(*schemapb.FieldData_Vectors)
-				if !ok || fd.Vectors.GetVectorArray() == nil {
-					return fmt.Errorf("field convert FieldData_Vectors fail in fieldData, fieldName: %s,"+
-						" collectionName:%s", fieldData.FieldName, schema.Name)
-				}
-				fd.Vectors.GetVectorArray().ElementType = fieldSchema.ElementType
-			}
-		} else {
+		_, err := schema.schemaHelper.GetFieldFromNameDefaultJSON(fieldData.FieldName)
+		if err != nil {
 			return fmt.Errorf("fieldName %v not exist in collection schema", fieldData.FieldName)
+		}
+	}
+
+	return nil
+}
+
+// fillFieldPropertiesOnly fills field properties (FieldId, Type, ElementType) from schema.
+// It assumes that columns have been validated and does not perform validation.
+// Use validateFieldDataColumns before calling this function if validation is needed.
+func fillFieldPropertiesOnly(columns []*schemapb.FieldData, schema *schemaInfo) error {
+	for _, fieldData := range columns {
+		// Use schemaHelper to get field schema, automatically handles dynamic fields
+		fieldSchema, err := schema.schemaHelper.GetFieldFromNameDefaultJSON(fieldData.FieldName)
+		if err != nil {
+			return fmt.Errorf("fieldName %v not exist in collection schema", fieldData.FieldName)
+		}
+
+		fieldData.FieldId = fieldSchema.FieldID
+		fieldData.Type = fieldSchema.DataType
+
+		// Set the ElementType because it may not be set in the insert request.
+		if fieldData.Type == schemapb.DataType_Array {
+			fd, ok := fieldData.Field.(*schemapb.FieldData_Scalars)
+			if !ok || fd.Scalars.GetArrayData() == nil {
+				return fmt.Errorf("field convert FieldData_Scalars fail in fieldData, fieldName: %s, collectionName: %s",
+					fieldData.FieldName, schema.Name)
+			}
+			fd.Scalars.GetArrayData().ElementType = fieldSchema.ElementType
+		} else if fieldData.Type == schemapb.DataType_ArrayOfVector {
+			fd, ok := fieldData.Field.(*schemapb.FieldData_Vectors)
+			if !ok || fd.Vectors.GetVectorArray() == nil {
+				return fmt.Errorf("field convert FieldData_Vectors fail in fieldData, fieldName: %s, collectionName: %s",
+					fieldData.FieldName, schema.Name)
+			}
+			fd.Vectors.GetVectorArray().ElementType = fieldSchema.ElementType
 		}
 	}
 

--- a/tests/go_client/testcases/upsert_test.go
+++ b/tests/go_client/testcases/upsert_test.go
@@ -436,7 +436,7 @@ func TestUpsertAutoID(t *testing.T) {
 	// upsert without pks -> error
 	vecColumn = hp.GenColumnData(nb, entity.FieldTypeFloatVector, *hp.TNewDataOption())
 	_, err = mc.Upsert(ctx, client.NewColumnBasedInsertOption(schema.CollectionName).WithColumns(vecColumn))
-	common.CheckErr(t, err, false, "has no corresponding fieldData pass in: invalid parameter")
+	common.CheckErr(t, err, false, "must assign pk when checking duplicates, primary field: int64: invalid parameter")
 }
 
 // test upsert autoId collection

--- a/tests/python_client/milvus_client/test_milvus_client_partial_update.py
+++ b/tests/python_client/milvus_client/test_milvus_client_partial_update.py
@@ -1221,14 +1221,12 @@ class TestMilvusClientPartialUpdateValid(TestMilvusClientV2Base):
     @pytest.mark.tags(CaseLabel.L1)
     def test_milvus_client_partial_update_same_pk_same_field(self):
         """
-        target:  Test PU will success and query will success
+        target: Test upsert with duplicate primary keys in the same batch will fail
         method:
             1. Create a collection
             2. Insert rows
-            3. Upsert the rows with same pk and same field
-            4. Query the rows
-            5. Upsert the rows with same pk and different field
-        expected: Step 2 -> 4 should success 5 should fail
+            3. Upsert a batch with duplicate primary keys (all rows have pk=0)
+        expected: Step 3 should fail with duplicate primary keys error
         """
         # step 1: create collection
         client = self._client()
@@ -1236,30 +1234,25 @@ class TestMilvusClientPartialUpdateValid(TestMilvusClientV2Base):
         schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
         schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
         schema.add_field(default_int32_field_name, DataType.INT32, nullable=True)
-        index_params = self.prepare_index_params(client)[0] 
+        index_params = self.prepare_index_params(client)[0]
         index_params.add_index(default_primary_key_field_name, index_type="AUTOINDEX")
         index_params.add_index(default_vector_field_name, index_type="AUTOINDEX")
         index_params.add_index(default_int32_field_name, index_type="AUTOINDEX")
         collection_name = cf.gen_collection_name_by_testcase_name(module_index=1)
-        self.create_collection(client, collection_name, default_dim, schema=schema, 
+        self.create_collection(client, collection_name, default_dim, schema=schema,
                                consistency_level="Strong", index_params=index_params)
-        
+
         # step 2: Insert rows
         rows = cf.gen_row_data_by_schema(nb=default_nb, schema=schema)
         self.upsert(client, collection_name, rows, partial_update=True)
 
-        # step 3: Upsert the rows with same pk and same field
-        new_rows = [{default_primary_key_field_name: 0, 
+        # step 3: Upsert a batch with duplicate primary keys - should fail
+        new_rows = [{default_primary_key_field_name: 0,
                     default_int32_field_name: i} for i in range(default_nb)]
-        self.upsert(client, collection_name, new_rows, partial_update=True)
-
-        # step 4: Query the rows
-        result = self.query(client, collection_name, filter=f"{default_primary_key_field_name} == 0",
-                   check_task=CheckTasks.check_query_results,
-                   output_fields=[default_int32_field_name],
-                   check_items={exp_res: [new_rows[-1]],
-                                "pk_name": default_primary_key_field_name})[0]
-        assert len(result) == 1
+        error = {ct.err_code: 1100,
+                 ct.err_msg: "duplicate primary keys are not allowed in the same batch"}
+        self.upsert(client, collection_name, new_rows, partial_update=True,
+                    check_task=CheckTasks.err_res, check_items=error)
 
         self.drop_collection(client, collection_name)
 

--- a/tests/python_client/testcases/test_insert.py
+++ b/tests/python_client/testcases/test_insert.py
@@ -2077,7 +2077,7 @@ class TestUpsertInvalid(TestcaseBase):
             log.debug(f"dirty_i: {dirty_i}")
             for i in range(len(data)):
                 if data[i][dirty_i].__class__ is int:
-                    tmp = data[i][0]
+                    tmp = data[i][dirty_i]
                     data[i][dirty_i] = "iamstring"
                     error = {ct.err_code: 999, ct.err_msg: "The Input data type is inconsistent with defined schema"}
                     collection_w.upsert(data=data, check_task=CheckTasks.err_res, check_items=error)


### PR DESCRIPTION
issue: #44320
pr: #45997

Add validation to detect and reject duplicate primary keys within the same upsert batch. This prevents inconsistent behavior where the last duplicate entry would silently overwrite previous entries.

Changes:
- Add CheckDuplicatePkExist function to detect duplicate primary keys (supports Int64 and VarChar types)
- Add generic hasDuplicates helper function for efficient duplicate detection using hashmap
- Split fillFieldPropertiesBySchema into validateFieldDataColumns and fillFieldPropertiesOnly for better separation of concerns
- Add duplicate PK check in upsertTask.PreExecute before creating UpsertMsg
- Add unit tests for duplicate PK detection in task_upsert_test.go and util_test.go
- Add Python client tests for duplicate PK scenarios with Int64 and VarChar primary keys