### PR TITLE
feat: add support for external collections in createCollectionTask

### DIFF
--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -367,6 +367,11 @@ func (t *createCollectionTask) PreExecute(ctx context.Context) error {
 	t.schema.AutoID = false
 	t.schema.DbName = t.GetDbName()
 
+	isExternalCollection := typeutil.IsExternalCollection(t.schema)
+	if err := typeutil.ValidateExternalCollectionSchema(t.schema); err != nil {
+		return err
+	}
+
 	disableCheck, err := common.IsDisableFuncRuntimeCheck(t.GetProperties()...)
 	if err != nil {
 		return err
@@ -398,9 +403,11 @@ func (t *createCollectionTask) PreExecute(ctx context.Context) error {
 		return err
 	}
 
-	// validate primary key definition
-	if err := validatePrimaryKey(t.schema); err != nil {
-		return err
+	// validate primary key definition when needed
+	if !isExternalCollection {
+		if err := validatePrimaryKey(t.schema); err != nil {
+			return err
+		}
 	}
 
 	// validate dynamic field

--- a/internal/proxy/task_test.go
+++ b/internal/proxy/task_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
 
@@ -1610,6 +1611,136 @@ func TestCreateCollectionTask(t *testing.T) {
 
 		err = task2.PreExecute(ctx)
 		assert.NoError(t, err)
+	})
+}
+
+func TestCreateCollectionTaskExternalCollection(t *testing.T) {
+	mix := NewMixCoordMock()
+	ctx := context.Background()
+	collectionName := "external_collection_" + funcutil.GenRandomStr()
+
+	buildExternalSchema := func() *schemapb.CollectionSchema {
+		return &schemapb.CollectionSchema{
+			Name:           collectionName,
+			ExternalSource: "s3://bucket/prefix",
+			Fields: []*schemapb.FieldSchema{
+				{
+					FieldID:  1,
+					Name:     "text_field",
+					DataType: schemapb.DataType_VarChar,
+					TypeParams: []*commonpb.KeyValuePair{
+						{Key: common.MaxLengthKey, Value: "64"},
+					},
+				},
+				{
+					FieldID:  2,
+					Name:     "vec_field",
+					DataType: schemapb.DataType_FloatVector,
+					TypeParams: []*commonpb.KeyValuePair{
+						{Key: common.DimKey, Value: "16"},
+					},
+				},
+			},
+		}
+	}
+
+	marshal := func(schema *schemapb.CollectionSchema) []byte {
+		bytes, err := proto.Marshal(schema)
+		require.NoError(t, err)
+		return bytes
+	}
+
+	task := &createCollectionTask{
+		Condition: NewTaskCondition(ctx),
+		CreateCollectionRequest: &milvuspb.CreateCollectionRequest{
+			CollectionName: collectionName,
+			Schema:         marshal(buildExternalSchema()),
+			ShardsNum:      common.DefaultShardsNum,
+		},
+		ctx:      ctx,
+		mixCoord: mix,
+	}
+
+	t.Run("valid external schema", func(t *testing.T) {
+		err := task.OnEnqueue()
+		require.NoError(t, err)
+		err = task.PreExecute(ctx)
+		require.NoError(t, err)
+	})
+
+	t.Run("dynamic field forbidden", func(t *testing.T) {
+		schema := buildExternalSchema()
+		schema.EnableDynamicField = true
+		task.CreateCollectionRequest.Schema = marshal(schema)
+		err := task.PreExecute(ctx)
+		assert.Error(t, err)
+	})
+
+	t.Run("primary key forbidden", func(t *testing.T) {
+		schema := buildExternalSchema()
+		schema.Fields[0].IsPrimaryKey = true
+		task.CreateCollectionRequest.Schema = marshal(schema)
+		err := task.PreExecute(ctx)
+		assert.Error(t, err)
+	})
+
+	t.Run("partition key forbidden", func(t *testing.T) {
+		schema := buildExternalSchema()
+		schema.Fields[0].IsPartitionKey = true
+		task.CreateCollectionRequest.Schema = marshal(schema)
+		err := task.PreExecute(ctx)
+		assert.Error(t, err)
+	})
+
+	t.Run("clustering key forbidden", func(t *testing.T) {
+		schema := buildExternalSchema()
+		schema.Fields[0].IsClusteringKey = true
+		task.CreateCollectionRequest.Schema = marshal(schema)
+		err := task.PreExecute(ctx)
+		assert.Error(t, err)
+	})
+
+	t.Run("auto id forbidden", func(t *testing.T) {
+		schema := buildExternalSchema()
+		schema.Fields[0].AutoID = true
+		task.CreateCollectionRequest.Schema = marshal(schema)
+		err := task.PreExecute(ctx)
+		assert.Error(t, err)
+	})
+
+	t.Run("text match forbidden", func(t *testing.T) {
+		schema := buildExternalSchema()
+		schema.Fields[0].TypeParams = append(schema.Fields[0].TypeParams, &commonpb.KeyValuePair{
+			Key:   "enable_match",
+			Value: "true",
+		})
+		task.CreateCollectionRequest.Schema = marshal(schema)
+		err := task.PreExecute(ctx)
+		assert.Error(t, err)
+	})
+
+	t.Run("struct field forbidden", func(t *testing.T) {
+		schema := buildExternalSchema()
+		schema.StructArrayFields = []*schemapb.StructArrayFieldSchema{
+			{
+				FieldID: 3,
+				Name:    "struct_array_field",
+				Fields: []*schemapb.FieldSchema{
+					{
+						FieldID:     4,
+						Name:        "nested_array",
+						DataType:    schemapb.DataType_Array,
+						ElementType: schemapb.DataType_Int64,
+						TypeParams: []*commonpb.KeyValuePair{
+							{Key: common.MaxCapacityKey, Value: "10"},
+						},
+					},
+				},
+			},
+		}
+		task.CreateCollectionRequest.Schema = marshal(schema)
+		err := task.PreExecute(ctx)
+		assert.Error(t, err)
 	})
 }
 

--- a/internal/rootcoord/create_collection_task.go
+++ b/internal/rootcoord/create_collection_task.go
@@ -176,6 +176,10 @@ func (t *createCollectionTask) validateSchema(ctx context.Context, schema *schem
 		return err
 	}
 
+	if err := typeutil.ValidateExternalCollectionSchema(schema); err != nil {
+		return err
+	}
+
 	if hasSystemFields(schema, []string{RowIDFieldName, TimeStampFieldName, MetaFieldName, NamespaceFieldName}) {
 		log.Ctx(ctx).Error("schema contains system field",
 			zap.String("RowIDFieldName", RowIDFieldName),
@@ -314,6 +318,10 @@ func (t *createCollectionTask) handleNamespaceField(ctx context.Context, schema 
 	}
 	if !has || !enabled {
 		return nil
+	}
+
+	if typeutil.IsExternalCollection(schema) {
+		return merr.WrapErrParameterInvalidMsg("external collection does not support namespace field")
 	}
 
 	if hasIsolation {

--- a/pkg/util/typeutil/schema_test.go
+++ b/pkg/util/typeutil/schema_test.go
@@ -4976,3 +4976,99 @@ func TestSchemaHelper_CanRetrieveRawFieldData(t *testing.T) {
 	}
 	assert.False(t, helper.CanRetrieveRawFieldData(orphanField))
 }
+
+func TestIsExternalCollection(t *testing.T) {
+	assert.False(t, IsExternalCollection(nil))
+
+	schema := &schemapb.CollectionSchema{}
+	assert.False(t, IsExternalCollection(schema))
+
+	schema.ExternalSource = "   "
+	assert.False(t, IsExternalCollection(schema))
+
+	schema.ExternalSource = "s3://bucket/path"
+	assert.True(t, IsExternalCollection(schema))
+}
+
+func TestValidateExternalCollectionSchema(t *testing.T) {
+	buildSchema := func() *schemapb.CollectionSchema {
+		return &schemapb.CollectionSchema{
+			Name:           "external",
+			ExternalSource: "s3://bucket/path",
+			Fields: []*schemapb.FieldSchema{
+				{
+					Name:     "text",
+					DataType: schemapb.DataType_VarChar,
+					TypeParams: []*commonpb.KeyValuePair{
+						{Key: common.MaxLengthKey, Value: "32"},
+					},
+				},
+				{
+					Name:     "vec",
+					DataType: schemapb.DataType_FloatVector,
+					TypeParams: []*commonpb.KeyValuePair{
+						{Key: common.DimKey, Value: "16"},
+					},
+				},
+			},
+		}
+	}
+
+	t.Run("non external schema skipped", func(t *testing.T) {
+		schema := buildSchema()
+		schema.ExternalSource = ""
+		assert.NoError(t, ValidateExternalCollectionSchema(schema))
+	})
+
+	t.Run("dynamic field disabled", func(t *testing.T) {
+		schema := buildSchema()
+		schema.EnableDynamicField = true
+		assert.Error(t, ValidateExternalCollectionSchema(schema))
+	})
+
+	t.Run("struct fields disabled", func(t *testing.T) {
+		schema := buildSchema()
+		schema.StructArrayFields = []*schemapb.StructArrayFieldSchema{
+			{Name: "struct_field", Fields: []*schemapb.FieldSchema{{Name: "nested", DataType: schemapb.DataType_Array}}},
+		}
+		assert.Error(t, ValidateExternalCollectionSchema(schema))
+	})
+
+	t.Run("primary key disabled", func(t *testing.T) {
+		schema := buildSchema()
+		schema.Fields[0].IsPrimaryKey = true
+		assert.Error(t, ValidateExternalCollectionSchema(schema))
+	})
+
+	t.Run("partition key disabled", func(t *testing.T) {
+		schema := buildSchema()
+		schema.Fields[0].IsPartitionKey = true
+		assert.Error(t, ValidateExternalCollectionSchema(schema))
+	})
+
+	t.Run("clustering key disabled", func(t *testing.T) {
+		schema := buildSchema()
+		schema.Fields[0].IsClusteringKey = true
+		assert.Error(t, ValidateExternalCollectionSchema(schema))
+	})
+
+	t.Run("auto id disabled", func(t *testing.T) {
+		schema := buildSchema()
+		schema.Fields[0].AutoID = true
+		assert.Error(t, ValidateExternalCollectionSchema(schema))
+	})
+
+	t.Run("text match disabled", func(t *testing.T) {
+		schema := buildSchema()
+		schema.Fields[0].TypeParams = append(schema.Fields[0].TypeParams, &commonpb.KeyValuePair{
+			Key:   "enable_match",
+			Value: "true",
+		})
+		assert.Error(t, ValidateExternalCollectionSchema(schema))
+	})
+
+	t.Run("valid schema passes", func(t *testing.T) {
+		err := ValidateExternalCollectionSchema(buildSchema())
+		assert.NoError(t, err)
+	})
+}


### PR DESCRIPTION
issue: #45881 
- Implemented validation for external collection schemas to ensure unsupported features are disabled, such as primary keys, dynamic fields, and struct fields.
- Added unit tests to verify the behavior of external collection handling in task execution and schema validation.
- Enhanced existing methods to accommodate the new external collection logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Core Invariant
External collections (identified by non-empty `ExternalSource` field in schema) operate under a distinct set of constraints: they prohibit primary keys, partition keys, clustering keys, auto-ID, dynamic fields, struct fields, namespace fields, and text matching on fields. These constraints are enforced uniformly across the proxy and rootcoord layers through schema validation.

## What's Added (New Feature)
Two public validation functions in `pkg/util/typeutil/schema.go` enable external collection detection and validation:
- `IsExternalCollection(schema)` safely detects external collections by checking for non-blank ExternalSource
- `ValidateExternalCollectionSchema(schema)` enforces all field-level constraints for external collections, returning nil without inspection for regular collections (early exit at line 1752-1754)

These validators are invoked at two checkpoints: during proxy PreExecute in `CreateCollectionTask` and during rootcoord validation in `createCollectionTask.validateSchema`, ensuring consistent rejection of unsupported features.

## Why No Regression (Early-Exit Pattern)
Regular collections are unaffected because `ValidateExternalCollectionSchema` immediately returns nil for non-external schemas (`if !IsExternalCollection(schema) { return nil }`). Primary key validation in the proxy layer is gated behind `if !isExternalCollection` to skip only external collections, preserving the existing validation path for all regular collections. Existing test suite `TestCreateCollectionTask` remains unchanged; new external collection tests are isolated in `TestCreateCollectionTaskExternalCollection`.

## Additional Constraint Enforcement
Namespace field handling in `handleNamespaceField` explicitly rejects external collections with a parameter-invalid error, preventing namespace-based isolation on external sources—a natural limitation given external collections are read-only facades over external data sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->