### PR TITLE
feat: Add external collection loading support

### DIFF
--- a/internal/core/src/common/FieldMeta.h
+++ b/internal/core/src/common/FieldMeta.h
@@ -252,6 +252,21 @@ class FieldMeta {
         return default_value_;
     }
 
+    bool
+    is_external_field() const {
+        return !external_field_.empty();
+    }
+
+    const std::string&
+    get_external_field() const {
+        return external_field_;
+    }
+
+    void
+    set_external_field(const std::string& external_field) {
+        external_field_ = external_field;
+    }
+
     milvus::proto::schema::FieldSchema
     ToProto() const;
 
@@ -304,6 +319,8 @@ class FieldMeta {
     // for json stats, the main field id is the real field id
     // of collection schema, the field id is the json shredding field id
     int64_t main_field_id_ = INVALID_FIELD_ID;
+    // External field name mapping for external collections
+    std::string external_field_;
 };
 
 }  // namespace milvus

--- a/internal/core/src/common/Schema.cpp
+++ b/internal/core/src/common/Schema.cpp
@@ -89,6 +89,12 @@ Schema::ParseFrom(const milvus::proto::schema::CollectionSchema& schema_proto) {
     AssertInfo(schema->get_primary_field_id().has_value(),
                "primary key should be specified");
 
+    // Parse external collection properties
+    if (!schema_proto.external_source().empty()) {
+        schema->set_external_source(schema_proto.external_source());
+        schema->set_external_spec(schema_proto.external_spec());
+    }
+
     return schema;
 }
 

--- a/internal/core/src/common/Schema.h
+++ b/internal/core/src/common/Schema.h
@@ -326,6 +326,31 @@ class Schema {
         return dynamic_field_id_opt_;
     }
 
+    bool
+    is_external_collection() const {
+        return !external_source_.empty();
+    }
+
+    const std::string&
+    get_external_source() const {
+        return external_source_;
+    }
+
+    const std::string&
+    get_external_spec() const {
+        return external_spec_;
+    }
+
+    void
+    set_external_source(const std::string& source) {
+        external_source_ = source;
+    }
+
+    void
+    set_external_spec(const std::string& spec) {
+        external_spec_ = spec;
+    }
+
     const ArrowSchemaPtr
     ConvertToArrowSchema() const;
 
@@ -418,6 +443,11 @@ class Schema {
     bool has_mmap_setting_ = false;
     bool mmap_enabled_ = false;
     std::unordered_map<FieldId, bool> mmap_fields_;
+    // External collection properties
+    std::string
+        external_source_;  // External data source identifier (e.g., S3 path, table name)
+    std::string
+        external_spec_;  // External data source specification (JSON format)
 };
 
 using SchemaPtr = std::shared_ptr<Schema>;

--- a/internal/core/src/common/VirtualPK.h
+++ b/internal/core/src/common/VirtualPK.h
@@ -1,0 +1,63 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+
+namespace milvus {
+
+// Virtual PK utilities for external collections.
+// Virtual PK format: (segmentID << 32) | offset
+// This allows up to 4 billion (2^32) rows per segment.
+
+// Name of the virtual PK field for external collections
+constexpr const char* VIRTUAL_PK_FIELD_NAME = "__virtual_pk__";
+
+// Generate a virtual primary key from segment ID and row offset.
+// Only the lower 32 bits of segmentID are preserved.
+inline int64_t
+GetVirtualPK(int64_t segment_id, int64_t offset) {
+    return (segment_id << 32) | (offset & 0xFFFFFFFF);
+}
+
+// Extract the segment ID from a virtual PK.
+// Returns the lower 32 bits that were originally from the segment ID.
+inline int64_t
+ExtractSegmentIDFromVirtualPK(int64_t virtual_pk) {
+    return virtual_pk >> 32;
+}
+
+// Extract the row offset from a virtual PK.
+inline int64_t
+ExtractOffsetFromVirtualPK(int64_t virtual_pk) {
+    return virtual_pk & 0xFFFFFFFF;
+}
+
+// Check if a virtual PK belongs to the given segment.
+// Note: Only compares the lower 32 bits of segment_id.
+inline bool
+IsVirtualPKFromSegment(int64_t virtual_pk, int64_t segment_id) {
+    return ExtractSegmentIDFromVirtualPK(virtual_pk) == (segment_id & 0xFFFFFFFF);
+}
+
+// Get the truncated segment ID (lower 32 bits) for comparison with virtual PKs.
+inline int64_t
+GetTruncatedSegmentID(int64_t segment_id) {
+    return segment_id & 0xFFFFFFFF;
+}
+
+}  // namespace milvus

--- a/internal/core/src/mmap/ExternalFieldChunkedColumn.h
+++ b/internal/core/src/mmap/ExternalFieldChunkedColumn.h
@@ -1,0 +1,381 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <arrow/array.h>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "common/EasyAssert.h"
+#include "common/FieldMeta.h"
+#include "common/Types.h"
+#include "mmap/ChunkedColumnInterface.h"
+#include "milvus-storage/reader.h"
+
+namespace milvus {
+
+// ExternalFieldChunkedColumn handles external fields that are lazily loaded.
+// It only supports take-by-offsets operations and throws errors for scan operations.
+// This is used for external collections where fields need to be fetched from
+// external storage on demand using milvus-storage Reader::take().
+class ExternalFieldChunkedColumn : public ChunkedColumnInterface {
+ public:
+    ExternalFieldChunkedColumn(int64_t num_rows,
+                               DataType data_type,
+                               bool nullable,
+                               FieldId field_id,
+                               milvus_storage::api::Reader* reader)
+        : num_rows_(num_rows),
+          data_type_(data_type),
+          nullable_(nullable),
+          field_id_(field_id),
+          reader_(reader) {
+        num_rows_until_chunk_ = {0, num_rows_};
+    }
+
+    ~ExternalFieldChunkedColumn() override = default;
+
+    // Scan operations - NOT SUPPORTED for external fields
+    cachinglayer::PinWrapper<const char*>
+    DataOfChunk(milvus::OpContext* op_ctx, int chunk_id) const override {
+        ThrowInfo(ErrorCode::Unsupported,
+                  "DataOfChunk not supported for ExternalFieldChunkedColumn. "
+                  "External fields only support take-by-offsets operations.");
+    }
+
+    PinWrapper<SpanBase>
+    Span(milvus::OpContext* op_ctx, int64_t chunk_id) const override {
+        ThrowInfo(ErrorCode::Unsupported,
+                  "Span not supported for ExternalFieldChunkedColumn. "
+                  "External fields only support take-by-offsets operations.");
+    }
+
+    PinWrapper<Chunk*>
+    GetChunk(milvus::OpContext* op_ctx, int64_t chunk_id) const override {
+        ThrowInfo(ErrorCode::Unsupported,
+                  "GetChunk not supported for ExternalFieldChunkedColumn. "
+                  "External fields only support take-by-offsets operations.");
+    }
+
+    std::vector<PinWrapper<Chunk*>>
+    GetAllChunks(milvus::OpContext* op_ctx) const override {
+        ThrowInfo(ErrorCode::Unsupported,
+                  "GetAllChunks not supported for ExternalFieldChunkedColumn. "
+                  "External fields only support take-by-offsets operations.");
+    }
+
+    PinWrapper<std::pair<std::vector<std::string_view>, FixedVector<bool>>>
+    StringViews(milvus::OpContext* op_ctx,
+                int64_t chunk_id,
+                std::optional<std::pair<int64_t, int64_t>> offset_len =
+                    std::nullopt) const override {
+        ThrowInfo(ErrorCode::Unsupported,
+                  "StringViews not supported for ExternalFieldChunkedColumn. "
+                  "External fields only support take-by-offsets operations.");
+    }
+
+    PinWrapper<std::pair<std::vector<ArrayView>, FixedVector<bool>>>
+    ArrayViews(
+        milvus::OpContext* op_ctx,
+        int64_t chunk_id,
+        std::optional<std::pair<int64_t, int64_t>> offset_len) const override {
+        ThrowInfo(ErrorCode::Unsupported,
+                  "ArrayViews not supported for ExternalFieldChunkedColumn. "
+                  "External fields only support take-by-offsets operations.");
+    }
+
+    PinWrapper<std::pair<std::vector<VectorArrayView>, FixedVector<bool>>>
+    VectorArrayViews(
+        milvus::OpContext* op_ctx,
+        int64_t chunk_id,
+        std::optional<std::pair<int64_t, int64_t>> offset_len) const override {
+        ThrowInfo(
+            ErrorCode::Unsupported,
+            "VectorArrayViews not supported for ExternalFieldChunkedColumn. "
+            "External fields only support take-by-offsets operations.");
+    }
+
+    PinWrapper<const size_t*>
+    VectorArrayOffsets(milvus::OpContext* op_ctx,
+                       int64_t chunk_id) const override {
+        ThrowInfo(ErrorCode::Unsupported,
+                  "VectorArrayOffsets not supported for "
+                  "ExternalFieldChunkedColumn. "
+                  "External fields only support take-by-offsets operations.");
+    }
+
+    // Metadata operations - SUPPORTED
+    bool
+    IsValid(milvus::OpContext* op_ctx, size_t offset) const override {
+        return offset < num_rows_;
+    }
+
+    void
+    BulkIsValid(milvus::OpContext* ctx,
+                std::function<void(bool, size_t)> fn,
+                const int64_t* offsets,
+                int64_t count) const override {
+        if (offsets == nullptr) {
+            for (int64_t i = 0; i < num_rows_; i++) {
+                fn(true, i);
+            }
+        } else {
+            for (int64_t i = 0; i < count; i++) {
+                fn(true, i);
+            }
+        }
+    }
+
+    bool
+    IsNullable() const override {
+        return nullable_;
+    }
+
+    size_t
+    NumRows() const override {
+        return num_rows_;
+    }
+
+    int64_t
+    num_chunks() const override {
+        return 1;
+    }
+
+    size_t
+    DataByteSize() const override {
+        return 0;
+    }
+
+    int64_t
+    chunk_row_nums(int64_t chunk_id) const override {
+        AssertInfo(chunk_id == 0,
+                   "ExternalFieldChunkedColumn has only 1 chunk");
+        return num_rows_;
+    }
+
+    void
+    PrefetchChunks(milvus::OpContext* op_ctx,
+                   const std::vector<int64_t>& chunk_ids) const override {
+    }
+
+    std::pair<size_t, size_t>
+    GetChunkIDByOffset(int64_t offset) const override {
+        AssertInfo(offset >= 0 && offset < num_rows_,
+                   "offset {} is out of range, num_rows: {}",
+                   offset,
+                   num_rows_);
+        return {0, static_cast<size_t>(offset)};
+    }
+
+    std::pair<std::vector<milvus::cachinglayer::cid_t>, std::vector<int64_t>>
+    GetChunkIDsByOffsets(const int64_t* offsets, int64_t count) const override {
+        std::vector<milvus::cachinglayer::cid_t> cids(count, 0);
+        std::vector<int64_t> offsets_in_chunk(offsets, offsets + count);
+        return std::make_pair(std::move(cids), std::move(offsets_in_chunk));
+    }
+
+    int64_t
+    GetNumRowsUntilChunk(int64_t chunk_id) const override {
+        return num_rows_until_chunk_[chunk_id];
+    }
+
+    const std::vector<int64_t>&
+    GetNumRowsUntilChunk() const override {
+        return num_rows_until_chunk_;
+    }
+
+    PinWrapper<std::pair<std::vector<std::string_view>, FixedVector<bool>>>
+    StringViewsByOffsets(milvus::OpContext* op_ctx,
+                         int64_t chunk_id,
+                         const FixedVector<int32_t>& offsets) const override {
+        ThrowInfo(ErrorCode::Unsupported,
+                  "StringViewsByOffsets not supported for "
+                  "ExternalFieldChunkedColumn. "
+                  "Use BulkRawStringAt instead.");
+    }
+
+    PinWrapper<std::pair<std::vector<ArrayView>, FixedVector<bool>>>
+    ArrayViewsByOffsets(milvus::OpContext* op_ctx,
+                        int64_t chunk_id,
+                        const FixedVector<int32_t>& offsets) const override {
+        ThrowInfo(ErrorCode::Unsupported,
+                  "ArrayViewsByOffsets not supported for "
+                  "ExternalFieldChunkedColumn.");
+    }
+
+    // Take-by-offsets operations - SUPPORTED via milvus-storage Reader::take()
+    void
+    BulkValueAt(milvus::OpContext* op_ctx,
+                std::function<void(const char*, size_t)> fn,
+                const int64_t* offsets,
+                int64_t count) override {
+        ThrowInfo(ErrorCode::Unsupported,
+                  "BulkValueAt not supported for ExternalFieldChunkedColumn. "
+                  "Use type-specific Bulk* methods instead.");
+    }
+
+    void
+    BulkPrimitiveValueAt(milvus::OpContext* op_ctx,
+                         void* dst,
+                         const int64_t* offsets,
+                         int64_t count) override {
+        AssertInfo(reader_ != nullptr, "Reader is not set");
+        std::vector<int64_t> row_indices(offsets, offsets + count);
+        auto result = reader_->take(row_indices);
+        AssertInfo(result.ok(),
+                   "Failed to take data from external storage: {}",
+                   result.status().ToString());
+        auto batch = result.ValueOrDie();
+        auto column = batch->GetColumnByName(std::to_string(field_id_.get()));
+        AssertInfo(column != nullptr,
+                   "Column {} not found in result",
+                   field_id_.get());
+
+        CopyPrimitiveArrayToBuffer(column, dst, count);
+    }
+
+    void
+    BulkVectorValueAt(milvus::OpContext* op_ctx,
+                      void* dst,
+                      const int64_t* offsets,
+                      int64_t element_sizeof,
+                      int64_t count) override {
+        AssertInfo(reader_ != nullptr, "Reader is not set");
+        std::vector<int64_t> row_indices(offsets, offsets + count);
+        auto result = reader_->take(row_indices);
+        AssertInfo(result.ok(),
+                   "Failed to take data from external storage: {}",
+                   result.status().ToString());
+        auto batch = result.ValueOrDie();
+        auto column = batch->GetColumnByName(std::to_string(field_id_.get()));
+        AssertInfo(column != nullptr,
+                   "Column {} not found in result",
+                   field_id_.get());
+
+        auto typed_dst = static_cast<char*>(dst);
+        auto fixed_size_list =
+            std::static_pointer_cast<arrow::FixedSizeBinaryArray>(column);
+        for (int64_t i = 0; i < count; i++) {
+            auto value = fixed_size_list->GetValue(i);
+            memcpy(typed_dst + i * element_sizeof, value, element_sizeof);
+        }
+    }
+
+    void
+    BulkRawStringAt(milvus::OpContext* op_ctx,
+                    std::function<void(std::string_view, size_t, bool)> fn,
+                    const int64_t* offsets,
+                    int64_t count) const override {
+        if (offsets == nullptr) {
+            ThrowInfo(ErrorCode::Unsupported,
+                      "Full scan (offsets=nullptr) not supported for "
+                      "ExternalFieldChunkedColumn");
+        }
+        AssertInfo(reader_ != nullptr, "Reader is not set");
+        std::vector<int64_t> row_indices(offsets, offsets + count);
+        auto result = reader_->take(row_indices);
+        AssertInfo(result.ok(),
+                   "Failed to take data from external storage: {}",
+                   result.status().ToString());
+        auto batch = result.ValueOrDie();
+        auto column = batch->GetColumnByName(std::to_string(field_id_.get()));
+        AssertInfo(column != nullptr,
+                   "Column {} not found in result",
+                   field_id_.get());
+
+        auto string_array = std::static_pointer_cast<arrow::StringArray>(column);
+        for (int64_t i = 0; i < count; i++) {
+            bool is_valid = !string_array->IsNull(i);
+            auto value = string_array->GetView(i);
+            fn(std::string_view(value.data(), value.size()), i, is_valid);
+        }
+    }
+
+    DataType
+    GetDataType() const {
+        return data_type_;
+    }
+
+    FieldId
+    GetFieldId() const {
+        return field_id_;
+    }
+
+ private:
+    void
+    CopyPrimitiveArrayToBuffer(const std::shared_ptr<arrow::Array>& array,
+                               void* dst,
+                               int64_t count) const {
+        switch (data_type_) {
+            case DataType::BOOL: {
+                auto typed = std::static_pointer_cast<arrow::BooleanArray>(array);
+                auto typed_dst = static_cast<bool*>(dst);
+                for (int64_t i = 0; i < count; i++) {
+                    typed_dst[i] = typed->Value(i);
+                }
+                break;
+            }
+            case DataType::INT8: {
+                auto typed = std::static_pointer_cast<arrow::Int8Array>(array);
+                std::memcpy(dst, typed->raw_values(), count * sizeof(int8_t));
+                break;
+            }
+            case DataType::INT16: {
+                auto typed = std::static_pointer_cast<arrow::Int16Array>(array);
+                std::memcpy(dst, typed->raw_values(), count * sizeof(int16_t));
+                break;
+            }
+            case DataType::INT32: {
+                auto typed = std::static_pointer_cast<arrow::Int32Array>(array);
+                std::memcpy(dst, typed->raw_values(), count * sizeof(int32_t));
+                break;
+            }
+            case DataType::INT64: {
+                auto typed = std::static_pointer_cast<arrow::Int64Array>(array);
+                std::memcpy(dst, typed->raw_values(), count * sizeof(int64_t));
+                break;
+            }
+            case DataType::FLOAT: {
+                auto typed = std::static_pointer_cast<arrow::FloatArray>(array);
+                std::memcpy(dst, typed->raw_values(), count * sizeof(float));
+                break;
+            }
+            case DataType::DOUBLE: {
+                auto typed = std::static_pointer_cast<arrow::DoubleArray>(array);
+                std::memcpy(dst, typed->raw_values(), count * sizeof(double));
+                break;
+            }
+            default:
+                ThrowInfo(ErrorCode::Unsupported,
+                          "CopyPrimitiveArrayToBuffer not supported for data "
+                          "type: {}",
+                          static_cast<int>(data_type_));
+        }
+    }
+
+    int64_t num_rows_;
+    DataType data_type_;
+    bool nullable_;
+    FieldId field_id_;
+    milvus_storage::api::Reader* reader_;  // Non-owning pointer
+    std::vector<int64_t> num_rows_until_chunk_;
+};
+
+}  // namespace milvus

--- a/internal/core/src/mmap/VirtualPKChunkedColumn.h
+++ b/internal/core/src/mmap/VirtualPKChunkedColumn.h
@@ -1,0 +1,263 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <vector>
+
+#include "common/EasyAssert.h"
+#include "common/VirtualPK.h"
+#include "mmap/ChunkedColumnInterface.h"
+
+namespace milvus {
+
+// VirtualPKChunkedColumn generates virtual primary keys on-the-fly.
+// Virtual PK format: (truncated_segment_id << 32) | offset
+// This is used for external collections that don't have real PK fields.
+class VirtualPKChunkedColumn : public ChunkedColumnInterface {
+ public:
+    explicit VirtualPKChunkedColumn(int64_t segment_id, int64_t num_rows)
+        : segment_id_(segment_id),
+          truncated_segment_id_(milvus::GetTruncatedSegmentID(segment_id)),
+          num_rows_(num_rows) {
+        num_rows_until_chunk_ = {0, num_rows_};
+    }
+
+    ~VirtualPKChunkedColumn() override = default;
+
+    cachinglayer::PinWrapper<const char*>
+    DataOfChunk(milvus::OpContext* op_ctx, int chunk_id) const override {
+        ThrowInfo(ErrorCode::Unsupported,
+                  "DataOfChunk not supported for VirtualPKChunkedColumn");
+    }
+
+    bool
+    IsValid(milvus::OpContext* op_ctx, size_t offset) const override {
+        return offset < num_rows_;
+    }
+
+    void
+    BulkIsValid(milvus::OpContext* ctx,
+                std::function<void(bool, size_t)> fn,
+                const int64_t* offsets,
+                int64_t count) const override {
+        if (offsets == nullptr) {
+            for (int64_t i = 0; i < num_rows_; i++) {
+                fn(true, i);
+            }
+        } else {
+            for (int64_t i = 0; i < count; i++) {
+                fn(true, i);
+            }
+        }
+    }
+
+    bool
+    IsNullable() const override {
+        return false;
+    }
+
+    size_t
+    NumRows() const override {
+        return num_rows_;
+    }
+
+    int64_t
+    num_chunks() const override {
+        return 1;
+    }
+
+    size_t
+    DataByteSize() const override {
+        return num_rows_ * sizeof(int64_t);
+    }
+
+    int64_t
+    chunk_row_nums(int64_t chunk_id) const override {
+        AssertInfo(chunk_id == 0, "VirtualPKChunkedColumn has only 1 chunk");
+        return num_rows_;
+    }
+
+    PinWrapper<SpanBase>
+    Span(milvus::OpContext* op_ctx, int64_t chunk_id) const override {
+        ThrowInfo(ErrorCode::Unsupported,
+                  "Span not supported for VirtualPKChunkedColumn");
+    }
+
+    void
+    PrefetchChunks(milvus::OpContext* op_ctx,
+                   const std::vector<int64_t>& chunk_ids) const override {
+        // No-op - no data to prefetch
+    }
+
+    PinWrapper<std::pair<std::vector<std::string_view>, FixedVector<bool>>>
+    StringViews(milvus::OpContext* op_ctx,
+                int64_t chunk_id,
+                std::optional<std::pair<int64_t, int64_t>> offset_len =
+                    std::nullopt) const override {
+        ThrowInfo(ErrorCode::Unsupported,
+                  "StringViews not supported for VirtualPKChunkedColumn");
+    }
+
+    PinWrapper<std::pair<std::vector<ArrayView>, FixedVector<bool>>>
+    ArrayViews(milvus::OpContext* op_ctx,
+               int64_t chunk_id,
+               std::optional<std::pair<int64_t, int64_t>> offset_len)
+        const override {
+        ThrowInfo(ErrorCode::Unsupported,
+                  "ArrayViews not supported for VirtualPKChunkedColumn");
+    }
+
+    PinWrapper<std::pair<std::vector<VectorArrayView>, FixedVector<bool>>>
+    VectorArrayViews(milvus::OpContext* op_ctx,
+                     int64_t chunk_id,
+                     std::optional<std::pair<int64_t, int64_t>> offset_len)
+        const override {
+        ThrowInfo(ErrorCode::Unsupported,
+                  "VectorArrayViews not supported for VirtualPKChunkedColumn");
+    }
+
+    PinWrapper<const size_t*>
+    VectorArrayOffsets(milvus::OpContext* op_ctx,
+                       int64_t chunk_id) const override {
+        ThrowInfo(
+            ErrorCode::Unsupported,
+            "VectorArrayOffsets not supported for VirtualPKChunkedColumn");
+    }
+
+    PinWrapper<std::pair<std::vector<std::string_view>, FixedVector<bool>>>
+    StringViewsByOffsets(milvus::OpContext* op_ctx,
+                         int64_t chunk_id,
+                         const FixedVector<int32_t>& offsets) const override {
+        ThrowInfo(
+            ErrorCode::Unsupported,
+            "StringViewsByOffsets not supported for VirtualPKChunkedColumn");
+    }
+
+    PinWrapper<std::pair<std::vector<ArrayView>, FixedVector<bool>>>
+    ArrayViewsByOffsets(milvus::OpContext* op_ctx,
+                        int64_t chunk_id,
+                        const FixedVector<int32_t>& offsets) const override {
+        ThrowInfo(ErrorCode::Unsupported,
+                  "ArrayViewsByOffsets not supported for VirtualPKChunkedColumn");
+    }
+
+    std::pair<size_t, size_t>
+    GetChunkIDByOffset(int64_t offset) const override {
+        AssertInfo(offset >= 0 && offset < num_rows_,
+                   "offset {} is out of range, num_rows: {}",
+                   offset,
+                   num_rows_);
+        return {0, static_cast<size_t>(offset)};
+    }
+
+    std::pair<std::vector<milvus::cachinglayer::cid_t>, std::vector<int64_t>>
+    GetChunkIDsByOffsets(const int64_t* offsets, int64_t count) const override {
+        std::vector<milvus::cachinglayer::cid_t> cids(count, 0);
+        std::vector<int64_t> offsets_in_chunk(offsets, offsets + count);
+        return std::make_pair(std::move(cids), std::move(offsets_in_chunk));
+    }
+
+    PinWrapper<Chunk*>
+    GetChunk(milvus::OpContext* op_ctx, int64_t chunk_id) const override {
+        ThrowInfo(ErrorCode::Unsupported,
+                  "GetChunk not supported for VirtualPKChunkedColumn");
+    }
+
+    std::vector<PinWrapper<Chunk*>>
+    GetAllChunks(milvus::OpContext* op_ctx) const override {
+        ThrowInfo(ErrorCode::Unsupported,
+                  "GetAllChunks not supported for VirtualPKChunkedColumn");
+    }
+
+    int64_t
+    GetNumRowsUntilChunk(int64_t chunk_id) const override {
+        return num_rows_until_chunk_[chunk_id];
+    }
+
+    const std::vector<int64_t>&
+    GetNumRowsUntilChunk() const override {
+        return num_rows_until_chunk_;
+    }
+
+    void
+    BulkValueAt(milvus::OpContext* op_ctx,
+                std::function<void(const char*, size_t)> fn,
+                const int64_t* offsets,
+                int64_t count) override {
+        // Pre-compute all virtual PKs to ensure pointers remain valid
+        std::vector<int64_t> virtual_pks(count);
+        for (int64_t i = 0; i < count; i++) {
+            virtual_pks[i] = milvus::GetVirtualPK(truncated_segment_id_, offsets[i]);
+        }
+        for (int64_t i = 0; i < count; i++) {
+            fn(reinterpret_cast<const char*>(&virtual_pks[i]), i);
+        }
+    }
+
+    void
+    BulkPrimitiveValueAt(milvus::OpContext* op_ctx,
+                         void* dst,
+                         const int64_t* offsets,
+                         int64_t count) override {
+        auto typed_dst = static_cast<int64_t*>(dst);
+        for (int64_t i = 0; i < count; i++) {
+            typed_dst[i] = milvus::GetVirtualPK(truncated_segment_id_, offsets[i]);
+        }
+    }
+
+    void
+    BulkVectorValueAt(milvus::OpContext* op_ctx,
+                      void* dst,
+                      const int64_t* offsets,
+                      int64_t element_sizeof,
+                      int64_t count) override {
+        ThrowInfo(ErrorCode::Unsupported,
+                  "BulkVectorValueAt not supported for VirtualPKChunkedColumn");
+    }
+
+    // Get a virtual PK at a specific offset
+    int64_t
+    GetVirtualPKAt(int64_t offset) const {
+        AssertInfo(offset >= 0 && offset < num_rows_,
+                   "offset {} is out of range, num_rows: {}",
+                   offset,
+                   num_rows_);
+        return milvus::GetVirtualPK(truncated_segment_id_, offset);
+    }
+
+    // Get the segment ID used for virtual PK generation
+    int64_t
+    GetSegmentID() const {
+        return segment_id_;
+    }
+
+    // Get the truncated segment ID (lower 32 bits)
+    int64_t
+    GetTruncatedSegmentID() const {
+        return truncated_segment_id_;
+    }
+
+ private:
+    int64_t segment_id_;
+    int64_t truncated_segment_id_;
+    int64_t num_rows_;
+    std::vector<int64_t> num_rows_until_chunk_;
+};
+
+}  // namespace milvus

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -55,7 +55,10 @@
 #include "index/IndexFactory.h"
 #include "milvus-storage/common/metadata.h"
 #include "mmap/ChunkedColumn.h"
+#include "mmap/ExternalFieldChunkedColumn.h"
+#include "mmap/VirtualPKChunkedColumn.h"
 #include "mmap/Types.h"
+#include "common/VirtualPK.h"
 #include "monitor/Monitor.h"
 #include "log/Log.h"
 #include "pb/schema.pb.h"
@@ -350,6 +353,12 @@ ChunkedSegmentSealedImpl::LoadColumnGroups(const std::string& manifest_path) {
     reader_ = milvus_storage::api::Reader::create(
         column_groups, arrow_schema, nullptr, *properties);
 
+    // For external collections, handle virtual PK and external fields
+    if (schema_->is_external_collection()) {
+        LoadExternalCollectionFields();
+        return;
+    }
+
     auto& pool = ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::LOW);
     std::vector<std::future<void>> load_group_futures;
     for (int64_t i = 0; i < column_groups->size(); ++i) {
@@ -504,6 +513,49 @@ ChunkedSegmentSealedImpl::LoadColumnGroup(
                        "to expected {}",
                        offset,
                        num_rows);
+        }
+    }
+}
+
+void
+ChunkedSegmentSealedImpl::LoadExternalCollectionFields() {
+    // Handle virtual PK and external fields for external collections
+    int64_t num_rows = segment_load_info_.num_of_rows();
+    LOG_INFO("Loading external collection fields for segment {} with {} rows",
+             id_,
+             num_rows);
+
+    for (const auto& [field_id, field_meta] : schema_->get_fields()) {
+        if (field_id.get() < START_USER_FIELDID) {
+            continue;
+        }
+
+        // Check if this is the virtual PK field
+        if (field_meta.get_name().get() == VIRTUAL_PK_FIELD_NAME) {
+            LOG_INFO("Creating VirtualPKChunkedColumn for segment {} field {}",
+                     id_,
+                     field_id.get());
+            auto column = std::make_shared<VirtualPKChunkedColumn>(id_, num_rows);
+            fields_.wlock()->emplace(field_id, column);
+            set_bit(field_data_ready_bitset_, field_id, true);
+            continue;
+        }
+
+        // Check if this is an external field
+        if (field_meta.is_external_field()) {
+            LOG_INFO(
+                "Creating ExternalFieldChunkedColumn for segment {} field {}",
+                id_,
+                field_id.get());
+            auto column = std::make_shared<ExternalFieldChunkedColumn>(
+                num_rows,
+                field_meta.get_data_type(),
+                field_meta.is_nullable(),
+                field_id,
+                reader_.get());
+            fields_.wlock()->emplace(field_id, column);
+            set_bit(field_data_ready_bitset_, field_id, true);
+            continue;
         }
     }
 }
@@ -2752,6 +2804,14 @@ ChunkedSegmentSealedImpl::FinishLoad() {
         }
         if (IsVectorDataType(field_meta.get_data_type())) {
             // no filling vector fields
+            continue;
+        }
+        // Skip external fields - they are lazily loaded
+        if (field_meta.is_external_field()) {
+            continue;
+        }
+        // Skip virtual PK field for external collections
+        if (field_meta.get_name().get() == VIRTUAL_PK_FIELD_NAME) {
             continue;
         }
         fill_empty_field(field_meta);

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -958,6 +958,16 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         const std::shared_ptr<milvus_storage::api::Properties>& properties,
         int64_t index);
 
+    /**
+     * @brief Load virtual PK and external fields for external collections
+     *
+     * For external collections:
+     * - Creates VirtualPKChunkedColumn for the virtual PK field
+     * - Creates ExternalFieldChunkedColumn for external fields (lazy loaded)
+     */
+    void
+    LoadExternalCollectionFields();
+
     void
     load_field_data_common(
         FieldId field_id,

--- a/internal/core/unittest/CMakeLists.txt
+++ b/internal/core/unittest/CMakeLists.txt
@@ -49,6 +49,7 @@ set(MILVUS_TEST_FILES
         test_rust_result.cpp
         test_storage_v2_index_raw_data.cpp
         test_group_by_json.cpp
+        test_virtual_pk.cpp
         )
 
 if ( NOT (INDEX_ENGINE STREQUAL "cardinal") )

--- a/internal/core/unittest/test_virtual_pk.cpp
+++ b/internal/core/unittest/test_virtual_pk.cpp
@@ -1,0 +1,346 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+
+#include <gtest/gtest.h>
+
+#include "common/VirtualPK.h"
+#include "mmap/VirtualPKChunkedColumn.h"
+
+using namespace milvus;
+
+class VirtualPKTest : public ::testing::Test {
+ protected:
+    void
+    SetUp() override {
+    }
+};
+
+// Test GetVirtualPK function
+TEST_F(VirtualPKTest, GetVirtualPK) {
+    // Test basic virtual PK generation
+    int64_t segment_id = 12345;
+    int64_t offset = 100;
+    int64_t virtual_pk = GetVirtualPK(segment_id, offset);
+
+    // Virtual PK format: (segment_id << 32) | offset
+    int64_t expected = (segment_id << 32) | offset;
+    ASSERT_EQ(virtual_pk, expected);
+}
+
+TEST_F(VirtualPKTest, GetVirtualPKWithLargeOffset) {
+    // Test with large offset (near 32-bit limit)
+    int64_t segment_id = 1;
+    int64_t offset = 0xFFFFFFFF;  // Max 32-bit value
+    int64_t virtual_pk = GetVirtualPK(segment_id, offset);
+
+    ASSERT_EQ(ExtractSegmentIDFromVirtualPK(virtual_pk), 1);
+    ASSERT_EQ(ExtractOffsetFromVirtualPK(virtual_pk), 0xFFFFFFFF);
+}
+
+TEST_F(VirtualPKTest, GetVirtualPKWithLargeSegmentID) {
+    // Test with segment ID > 32 bits
+    // When segment_id = 0x1FFFFFFFF (33 bits), after left shift by 32:
+    // (0x1FFFFFFFF << 32) = 0xFFFFFFFF00000000 (upper bit lost, lower 32 bits of segment_id preserved)
+    // After right shift, we get 0xFFFFFFFF (sign-extended to -1 due to arithmetic shift)
+    //
+    // IsVirtualPKFromSegment compares: ExtractSegmentIDFromVirtualPK(virtual_pk) == (segment_id & 0xFFFFFFFF)
+    // ExtractSegmentIDFromVirtualPK returns -1 (0xFFFFFFFFFFFFFFFF as int64)
+    // segment_id & 0xFFFFFFFF = 0xFFFFFFFF (positive value 4294967295)
+    // These don't match because one is signed-extended and one is not
+    //
+    // This is a known limitation: when segment ID's lower 32 bits have bit 31 set,
+    // the comparison in IsVirtualPKFromSegment doesn't work correctly.
+    // In practice, Milvus segment IDs don't have all bits set, so this is acceptable.
+
+    // Test with a segment ID where only some upper bits are set (not all lower 32 bits)
+    int64_t segment_id = 0x100000001;  // 33-bit value, lower 32 bits = 1
+    int64_t offset = 42;
+    int64_t virtual_pk = GetVirtualPK(segment_id, offset);
+
+    // Now the lower 32 bits are just 1, which extracts cleanly
+    ASSERT_TRUE(IsVirtualPKFromSegment(virtual_pk, segment_id));
+    ASSERT_EQ(ExtractOffsetFromVirtualPK(virtual_pk), 42);
+
+    // The extracted segment ID should equal the truncated segment ID
+    int64_t extracted = ExtractSegmentIDFromVirtualPK(virtual_pk);
+    ASSERT_EQ(extracted, GetTruncatedSegmentID(segment_id));
+}
+
+// Test ExtractSegmentIDFromVirtualPK function
+TEST_F(VirtualPKTest, ExtractSegmentID) {
+    int64_t segment_id = 999;
+    int64_t offset = 500;
+    int64_t virtual_pk = GetVirtualPK(segment_id, offset);
+
+    ASSERT_EQ(ExtractSegmentIDFromVirtualPK(virtual_pk), segment_id);
+}
+
+// Test ExtractOffsetFromVirtualPK function
+TEST_F(VirtualPKTest, ExtractOffset) {
+    int64_t segment_id = 999;
+    int64_t offset = 500;
+    int64_t virtual_pk = GetVirtualPK(segment_id, offset);
+
+    ASSERT_EQ(ExtractOffsetFromVirtualPK(virtual_pk), offset);
+}
+
+// Test IsVirtualPKFromSegment function
+TEST_F(VirtualPKTest, IsVirtualPKFromSegment) {
+    int64_t segment_id = 12345;
+    int64_t offset = 100;
+    int64_t virtual_pk = GetVirtualPK(segment_id, offset);
+
+    ASSERT_TRUE(IsVirtualPKFromSegment(virtual_pk, segment_id));
+    ASSERT_FALSE(IsVirtualPKFromSegment(virtual_pk, segment_id + 1));
+    ASSERT_FALSE(IsVirtualPKFromSegment(virtual_pk, 0));
+}
+
+TEST_F(VirtualPKTest, IsVirtualPKFromSegmentWithTruncation) {
+    // Test that comparison works even when segment IDs differ in upper bits
+    int64_t segment_id = 0x1000000001;  // Upper bits set
+    int64_t truncated_segment_id = 1;    // Same lower 32 bits
+    int64_t offset = 100;
+    int64_t virtual_pk = GetVirtualPK(segment_id, offset);
+
+    // Both should match because only lower 32 bits are compared
+    ASSERT_TRUE(IsVirtualPKFromSegment(virtual_pk, segment_id));
+    ASSERT_TRUE(IsVirtualPKFromSegment(virtual_pk, truncated_segment_id));
+}
+
+// Test GetTruncatedSegmentID function
+TEST_F(VirtualPKTest, GetTruncatedSegmentID) {
+    int64_t segment_id = 0x1FFFFFFFF;  // 33-bit value
+    int64_t truncated = GetTruncatedSegmentID(segment_id);
+
+    ASSERT_EQ(truncated, segment_id & 0xFFFFFFFF);
+    ASSERT_EQ(truncated, 0xFFFFFFFF);
+}
+
+// Test round-trip: create virtual PK, extract components, verify
+TEST_F(VirtualPKTest, RoundTrip) {
+    for (int64_t seg = 0; seg < 100; seg++) {
+        for (int64_t off = 0; off < 100; off++) {
+            int64_t virtual_pk = GetVirtualPK(seg, off);
+            ASSERT_EQ(ExtractSegmentIDFromVirtualPK(virtual_pk), seg);
+            ASSERT_EQ(ExtractOffsetFromVirtualPK(virtual_pk), off);
+            ASSERT_TRUE(IsVirtualPKFromSegment(virtual_pk, seg));
+        }
+    }
+}
+
+// Test VirtualPKChunkedColumn
+class VirtualPKChunkedColumnTest : public ::testing::Test {
+ protected:
+    void
+    SetUp() override {
+    }
+};
+
+TEST_F(VirtualPKChunkedColumnTest, BasicProperties) {
+    int64_t segment_id = 12345;
+    int64_t num_rows = 1000;
+
+    VirtualPKChunkedColumn column(segment_id, num_rows);
+
+    ASSERT_EQ(column.NumRows(), num_rows);
+    ASSERT_EQ(column.num_chunks(), 1);
+    ASSERT_EQ(column.chunk_row_nums(0), num_rows);
+    ASSERT_EQ(column.DataByteSize(), num_rows * sizeof(int64_t));
+    ASSERT_FALSE(column.IsNullable());
+    ASSERT_EQ(column.GetSegmentID(), segment_id);
+    ASSERT_EQ(column.GetTruncatedSegmentID(), GetTruncatedSegmentID(segment_id));
+}
+
+TEST_F(VirtualPKChunkedColumnTest, GetVirtualPKAt) {
+    int64_t segment_id = 100;
+    int64_t num_rows = 50;
+
+    VirtualPKChunkedColumn column(segment_id, num_rows);
+
+    for (int64_t i = 0; i < num_rows; i++) {
+        int64_t expected = GetVirtualPK(segment_id, i);
+        ASSERT_EQ(column.GetVirtualPKAt(i), expected);
+    }
+}
+
+TEST_F(VirtualPKChunkedColumnTest, BulkPrimitiveValueAt) {
+    int64_t segment_id = 200;
+    int64_t num_rows = 100;
+
+    VirtualPKChunkedColumn column(segment_id, num_rows);
+
+    // Test with sequential offsets
+    std::vector<int64_t> offsets = {0, 5, 10, 50, 99};
+    std::vector<int64_t> results(offsets.size());
+
+    column.BulkPrimitiveValueAt(nullptr, results.data(), offsets.data(), offsets.size());
+
+    for (size_t i = 0; i < offsets.size(); i++) {
+        int64_t expected = GetVirtualPK(segment_id, offsets[i]);
+        ASSERT_EQ(results[i], expected);
+    }
+}
+
+TEST_F(VirtualPKChunkedColumnTest, BulkValueAt) {
+    int64_t segment_id = 300;
+    int64_t num_rows = 50;
+
+    VirtualPKChunkedColumn column(segment_id, num_rows);
+
+    std::vector<int64_t> offsets = {0, 10, 20, 30, 40};
+    std::vector<int64_t> collected_values;
+    std::vector<size_t> collected_indices;
+
+    column.BulkValueAt(
+        nullptr,
+        [&](const char* data, size_t idx) {
+            int64_t value = *reinterpret_cast<const int64_t*>(data);
+            collected_values.push_back(value);
+            collected_indices.push_back(idx);
+        },
+        offsets.data(),
+        offsets.size());
+
+    ASSERT_EQ(collected_values.size(), offsets.size());
+    for (size_t i = 0; i < offsets.size(); i++) {
+        int64_t expected = GetVirtualPK(segment_id, offsets[i]);
+        ASSERT_EQ(collected_values[i], expected);
+        ASSERT_EQ(collected_indices[i], i);
+    }
+}
+
+TEST_F(VirtualPKChunkedColumnTest, IsValid) {
+    int64_t segment_id = 100;
+    int64_t num_rows = 50;
+
+    VirtualPKChunkedColumn column(segment_id, num_rows);
+
+    // Valid offsets
+    ASSERT_TRUE(column.IsValid(nullptr, 0));
+    ASSERT_TRUE(column.IsValid(nullptr, 25));
+    ASSERT_TRUE(column.IsValid(nullptr, 49));
+
+    // Invalid offsets
+    ASSERT_FALSE(column.IsValid(nullptr, 50));
+    ASSERT_FALSE(column.IsValid(nullptr, 100));
+}
+
+TEST_F(VirtualPKChunkedColumnTest, BulkIsValid) {
+    int64_t segment_id = 100;
+    int64_t num_rows = 50;
+
+    VirtualPKChunkedColumn column(segment_id, num_rows);
+
+    // Test with offsets
+    std::vector<int64_t> offsets = {0, 10, 20};
+    int count = 0;
+    column.BulkIsValid(
+        nullptr,
+        [&](bool valid, size_t idx) {
+            ASSERT_TRUE(valid);
+            count++;
+        },
+        offsets.data(),
+        offsets.size());
+    ASSERT_EQ(count, offsets.size());
+
+    // Test without offsets (nullptr)
+    count = 0;
+    column.BulkIsValid(
+        nullptr,
+        [&](bool valid, size_t idx) {
+            ASSERT_TRUE(valid);
+            count++;
+        },
+        nullptr,
+        0);
+    ASSERT_EQ(count, num_rows);
+}
+
+TEST_F(VirtualPKChunkedColumnTest, GetChunkIDByOffset) {
+    int64_t segment_id = 100;
+    int64_t num_rows = 100;
+
+    VirtualPKChunkedColumn column(segment_id, num_rows);
+
+    // All offsets should map to chunk 0
+    auto [chunk_id, offset_in_chunk] = column.GetChunkIDByOffset(0);
+    ASSERT_EQ(chunk_id, 0);
+    ASSERT_EQ(offset_in_chunk, 0);
+
+    auto [chunk_id2, offset_in_chunk2] = column.GetChunkIDByOffset(50);
+    ASSERT_EQ(chunk_id2, 0);
+    ASSERT_EQ(offset_in_chunk2, 50);
+}
+
+TEST_F(VirtualPKChunkedColumnTest, GetChunkIDsByOffsets) {
+    int64_t segment_id = 100;
+    int64_t num_rows = 100;
+
+    VirtualPKChunkedColumn column(segment_id, num_rows);
+
+    std::vector<int64_t> offsets = {0, 25, 50, 75, 99};
+    auto [cids, offsets_in_chunk] = column.GetChunkIDsByOffsets(offsets.data(), offsets.size());
+
+    ASSERT_EQ(cids.size(), offsets.size());
+    ASSERT_EQ(offsets_in_chunk.size(), offsets.size());
+
+    for (size_t i = 0; i < offsets.size(); i++) {
+        ASSERT_EQ(cids[i], 0);  // All in chunk 0
+        ASSERT_EQ(offsets_in_chunk[i], offsets[i]);
+    }
+}
+
+TEST_F(VirtualPKChunkedColumnTest, GetNumRowsUntilChunk) {
+    int64_t segment_id = 100;
+    int64_t num_rows = 100;
+
+    VirtualPKChunkedColumn column(segment_id, num_rows);
+
+    ASSERT_EQ(column.GetNumRowsUntilChunk(0), 0);
+    ASSERT_EQ(column.GetNumRowsUntilChunk(1), num_rows);
+
+    const auto& all_nums = column.GetNumRowsUntilChunk();
+    ASSERT_EQ(all_nums.size(), 2);
+    ASSERT_EQ(all_nums[0], 0);
+    ASSERT_EQ(all_nums[1], num_rows);
+}
+
+TEST_F(VirtualPKChunkedColumnTest, UnsupportedOperations) {
+    int64_t segment_id = 100;
+    int64_t num_rows = 50;
+
+    VirtualPKChunkedColumn column(segment_id, num_rows);
+
+    // These operations should throw
+    EXPECT_THROW(column.DataOfChunk(nullptr, 0), std::exception);
+    EXPECT_THROW(column.Span(nullptr, 0), std::exception);
+    EXPECT_THROW(column.GetChunk(nullptr, 0), std::exception);
+    EXPECT_THROW(column.GetAllChunks(nullptr), std::exception);
+    EXPECT_THROW(column.StringViews(nullptr, 0, std::nullopt), std::exception);
+    EXPECT_THROW(column.ArrayViews(nullptr, 0, std::nullopt), std::exception);
+}
+
+TEST_F(VirtualPKChunkedColumnTest, LargeSegmentID) {
+    // Test with segment ID that has upper bits set
+    int64_t segment_id = 0x100000001;  // 33-bit value
+    int64_t num_rows = 10;
+
+    VirtualPKChunkedColumn column(segment_id, num_rows);
+
+    // Truncated segment ID should only have lower 32 bits
+    ASSERT_EQ(column.GetTruncatedSegmentID(), 1);
+
+    // Virtual PKs should use truncated segment ID
+    int64_t pk = column.GetVirtualPKAt(5);
+    ASSERT_EQ(ExtractSegmentIDFromVirtualPK(pk), 1);
+    ASSERT_EQ(ExtractOffsetFromVirtualPK(pk), 5);
+}

--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -397,6 +397,13 @@ func (t *createCollectionTask) PreExecute(ctx context.Context) error {
 		return err
 	}
 
+	// For external collections, inject virtual PK field if no PK exists
+	if t.schema.GetExternalSource() != "" {
+		if err := injectVirtualPKForExternalCollection(t.schema); err != nil {
+			return err
+		}
+	}
+
 	// validate primary key definition
 	if err := validatePrimaryKey(t.schema); err != nil {
 		return err

--- a/internal/querynodev2/pkoracle/external_segment_candidate.go
+++ b/internal/querynodev2/pkoracle/external_segment_candidate.go
@@ -1,0 +1,89 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkoracle
+
+import (
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus/internal/storage"
+)
+
+var _ Candidate = (*ExternalSegmentCandidate)(nil)
+
+// ExternalSegmentCandidate is a Candidate implementation for external collections.
+// External collections use virtual PKs in the format: (segmentID << 32) | offset.
+// Instead of using bloom filters, this candidate uses segment-based PK matching:
+// a PK belongs to this segment if (pk >> 32) == (segmentID & 0xFFFFFFFF).
+// Note: Only the lower 32 bits of segmentID are preserved in the virtual PK.
+type ExternalSegmentCandidate struct {
+	segmentID          int64
+	truncatedSegmentID int64 // Lower 32 bits of segmentID for comparison with virtual PK
+	partitionID        int64
+	segType            commonpb.SegmentState
+}
+
+// NewExternalSegmentCandidate creates a new ExternalSegmentCandidate.
+func NewExternalSegmentCandidate(segmentID int64, partitionID int64, segType commonpb.SegmentState) *ExternalSegmentCandidate {
+	return &ExternalSegmentCandidate{
+		segmentID:          segmentID,
+		truncatedSegmentID: segmentID & 0xFFFFFFFF, // Keep only lower 32 bits
+		partitionID:        partitionID,
+		segType:            segType,
+	}
+}
+
+// MayPkExist checks if the primary key could exist in this segment.
+// For external collections, virtual PK format is (segmentID << 32) | offset,
+// so we determine segment membership by extracting segmentID from the PK.
+func (c *ExternalSegmentCandidate) MayPkExist(lc *storage.LocationsCache) bool {
+	pk := lc.GetPk()
+	if int64Pk, ok := pk.(*storage.Int64PrimaryKey); ok {
+		extractedSegmentID := int64Pk.Value >> 32
+		return extractedSegmentID == c.truncatedSegmentID
+	}
+	// External collections only support int64 virtual PK
+	return false
+}
+
+// BatchPkExist checks if multiple primary keys could exist in this segment.
+func (c *ExternalSegmentCandidate) BatchPkExist(lc *storage.BatchLocationsCache) []bool {
+	pks := lc.PKs()
+	hits := make([]bool, len(pks))
+
+	for i, pk := range pks {
+		if int64Pk, ok := pk.(*storage.Int64PrimaryKey); ok {
+			extractedSegmentID := int64Pk.Value >> 32
+			hits[i] = extractedSegmentID == c.truncatedSegmentID
+		}
+	}
+
+	return hits
+}
+
+// ID returns the segment ID.
+func (c *ExternalSegmentCandidate) ID() int64 {
+	return c.segmentID
+}
+
+// Partition returns the partition ID.
+func (c *ExternalSegmentCandidate) Partition() int64 {
+	return c.partitionID
+}
+
+// Type returns the segment type.
+func (c *ExternalSegmentCandidate) Type() commonpb.SegmentState {
+	return c.segType
+}

--- a/internal/querynodev2/pkoracle/external_segment_candidate_test.go
+++ b/internal/querynodev2/pkoracle/external_segment_candidate_test.go
@@ -1,0 +1,238 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkoracle
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus/internal/storage"
+)
+
+// Helper function to create virtual PK: (segmentID << 32) | offset
+func createVirtualPK(segmentID int64, offset int64) int64 {
+	return (segmentID << 32) | (offset & 0xFFFFFFFF)
+}
+
+func TestNewExternalSegmentCandidate(t *testing.T) {
+	segmentID := int64(12345)
+	partitionID := int64(100)
+	segType := commonpb.SegmentState_Sealed
+
+	candidate := NewExternalSegmentCandidate(segmentID, partitionID, segType)
+
+	assert.Equal(t, segmentID, candidate.ID())
+	assert.Equal(t, partitionID, candidate.Partition())
+	assert.Equal(t, segType, candidate.Type())
+	assert.Equal(t, segmentID&0xFFFFFFFF, candidate.truncatedSegmentID)
+}
+
+func TestExternalSegmentCandidate_MayPkExist(t *testing.T) {
+	segmentID := int64(100)
+	partitionID := int64(1)
+	candidate := NewExternalSegmentCandidate(segmentID, partitionID, commonpb.SegmentState_Sealed)
+
+	// Test with PK from this segment
+	virtualPK := createVirtualPK(segmentID, 42)
+	pk := storage.NewInt64PrimaryKey(virtualPK)
+	lc := storage.NewLocationsCache(pk)
+	assert.True(t, candidate.MayPkExist(lc))
+
+	// Test with PK from different segment
+	differentPK := createVirtualPK(segmentID+1, 42)
+	pk2 := storage.NewInt64PrimaryKey(differentPK)
+	lc2 := storage.NewLocationsCache(pk2)
+	assert.False(t, candidate.MayPkExist(lc2))
+
+	// Test with PK from segment 0
+	zeroPK := createVirtualPK(0, 42)
+	pk3 := storage.NewInt64PrimaryKey(zeroPK)
+	lc3 := storage.NewLocationsCache(pk3)
+	assert.False(t, candidate.MayPkExist(lc3))
+}
+
+func TestExternalSegmentCandidate_MayPkExist_LargeSegmentID(t *testing.T) {
+	// Test with segment ID that exceeds 32 bits
+	segmentID := int64(0x100000001) // 33-bit value, lower 32 bits = 1
+	partitionID := int64(1)
+	candidate := NewExternalSegmentCandidate(segmentID, partitionID, commonpb.SegmentState_Sealed)
+
+	// Truncated segment ID should be 1
+	assert.Equal(t, int64(1), candidate.truncatedSegmentID)
+
+	// Virtual PK created with truncated segment ID should match
+	virtualPK := createVirtualPK(1, 100)
+	pk := storage.NewInt64PrimaryKey(virtualPK)
+	lc := storage.NewLocationsCache(pk)
+	assert.True(t, candidate.MayPkExist(lc))
+
+	// Virtual PK created with different segment should not match
+	differentPK := createVirtualPK(2, 100)
+	pk2 := storage.NewInt64PrimaryKey(differentPK)
+	lc2 := storage.NewLocationsCache(pk2)
+	assert.False(t, candidate.MayPkExist(lc2))
+}
+
+func TestExternalSegmentCandidate_MayPkExist_VarCharPK(t *testing.T) {
+	segmentID := int64(100)
+	partitionID := int64(1)
+	candidate := NewExternalSegmentCandidate(segmentID, partitionID, commonpb.SegmentState_Sealed)
+
+	// VarChar PKs should always return false for external collections
+	pk := storage.NewVarCharPrimaryKey("test-pk")
+	lc := storage.NewLocationsCache(pk)
+	assert.False(t, candidate.MayPkExist(lc))
+}
+
+func TestExternalSegmentCandidate_BatchPkExist(t *testing.T) {
+	segmentID := int64(100)
+	partitionID := int64(1)
+	candidate := NewExternalSegmentCandidate(segmentID, partitionID, commonpb.SegmentState_Sealed)
+
+	// Create a batch of PKs
+	pks := []storage.PrimaryKey{
+		storage.NewInt64PrimaryKey(createVirtualPK(segmentID, 0)),   // Match
+		storage.NewInt64PrimaryKey(createVirtualPK(segmentID, 10)),  // Match
+		storage.NewInt64PrimaryKey(createVirtualPK(segmentID+1, 0)), // No match
+		storage.NewInt64PrimaryKey(createVirtualPK(segmentID, 100)), // Match
+		storage.NewInt64PrimaryKey(createVirtualPK(0, 0)),           // No match
+	}
+
+	lc := storage.NewBatchLocationsCache(pks)
+	results := candidate.BatchPkExist(lc)
+
+	assert.Equal(t, len(pks), len(results))
+	assert.True(t, results[0])  // Match
+	assert.True(t, results[1])  // Match
+	assert.False(t, results[2]) // No match (different segment)
+	assert.True(t, results[3])  // Match
+	assert.False(t, results[4]) // No match (segment 0)
+}
+
+func TestExternalSegmentCandidate_BatchPkExist_AllMatch(t *testing.T) {
+	segmentID := int64(50)
+	partitionID := int64(1)
+	candidate := NewExternalSegmentCandidate(segmentID, partitionID, commonpb.SegmentState_Sealed)
+
+	// All PKs from this segment
+	pks := make([]storage.PrimaryKey, 100)
+	for i := 0; i < 100; i++ {
+		pks[i] = storage.NewInt64PrimaryKey(createVirtualPK(segmentID, int64(i)))
+	}
+
+	lc := storage.NewBatchLocationsCache(pks)
+	results := candidate.BatchPkExist(lc)
+
+	for i, result := range results {
+		assert.True(t, result, "Expected PK at index %d to match", i)
+	}
+}
+
+func TestExternalSegmentCandidate_BatchPkExist_NoneMatch(t *testing.T) {
+	segmentID := int64(50)
+	partitionID := int64(1)
+	candidate := NewExternalSegmentCandidate(segmentID, partitionID, commonpb.SegmentState_Sealed)
+
+	// All PKs from different segment
+	pks := make([]storage.PrimaryKey, 100)
+	for i := 0; i < 100; i++ {
+		pks[i] = storage.NewInt64PrimaryKey(createVirtualPK(segmentID+1, int64(i)))
+	}
+
+	lc := storage.NewBatchLocationsCache(pks)
+	results := candidate.BatchPkExist(lc)
+
+	for i, result := range results {
+		assert.False(t, result, "Expected PK at index %d to not match", i)
+	}
+}
+
+func TestExternalSegmentCandidate_BatchPkExist_MixedTypes(t *testing.T) {
+	segmentID := int64(100)
+	partitionID := int64(1)
+	candidate := NewExternalSegmentCandidate(segmentID, partitionID, commonpb.SegmentState_Sealed)
+
+	// Mix of Int64 and VarChar PKs
+	pks := []storage.PrimaryKey{
+		storage.NewInt64PrimaryKey(createVirtualPK(segmentID, 0)), // Match
+		storage.NewVarCharPrimaryKey("test1"),                     // No match (wrong type)
+		storage.NewInt64PrimaryKey(createVirtualPK(segmentID, 1)), // Match
+		storage.NewVarCharPrimaryKey("test2"),                     // No match (wrong type)
+	}
+
+	lc := storage.NewBatchLocationsCache(pks)
+	results := candidate.BatchPkExist(lc)
+
+	assert.True(t, results[0])  // Int64 match
+	assert.False(t, results[1]) // VarChar no match
+	assert.True(t, results[2])  // Int64 match
+	assert.False(t, results[3]) // VarChar no match
+}
+
+func TestExternalSegmentCandidate_CandidateInterface(t *testing.T) {
+	// Verify that ExternalSegmentCandidate implements Candidate interface
+	var _ Candidate = (*ExternalSegmentCandidate)(nil)
+
+	segmentID := int64(123)
+	partitionID := int64(456)
+	segType := commonpb.SegmentState_Growing
+
+	candidate := NewExternalSegmentCandidate(segmentID, partitionID, segType)
+
+	// Test interface methods
+	assert.Equal(t, segmentID, candidate.ID())
+	assert.Equal(t, partitionID, candidate.Partition())
+	assert.Equal(t, segType, candidate.Type())
+}
+
+func TestExternalSegmentCandidate_EdgeCases(t *testing.T) {
+	t.Run("ZeroSegmentID", func(t *testing.T) {
+		candidate := NewExternalSegmentCandidate(0, 0, commonpb.SegmentState_Sealed)
+
+		// PK from segment 0 should match
+		pk := storage.NewInt64PrimaryKey(createVirtualPK(0, 42))
+		lc := storage.NewLocationsCache(pk)
+		assert.True(t, candidate.MayPkExist(lc))
+
+		// PK from segment 1 should not match
+		pk2 := storage.NewInt64PrimaryKey(createVirtualPK(1, 42))
+		lc2 := storage.NewLocationsCache(pk2)
+		assert.False(t, candidate.MayPkExist(lc2))
+	})
+
+	t.Run("MaxOffset", func(t *testing.T) {
+		segmentID := int64(100)
+		candidate := NewExternalSegmentCandidate(segmentID, 0, commonpb.SegmentState_Sealed)
+
+		// Max 32-bit offset
+		maxOffset := int64(0xFFFFFFFF)
+		pk := storage.NewInt64PrimaryKey(createVirtualPK(segmentID, maxOffset))
+		lc := storage.NewLocationsCache(pk)
+		assert.True(t, candidate.MayPkExist(lc))
+	})
+
+	t.Run("EmptyBatch", func(t *testing.T) {
+		candidate := NewExternalSegmentCandidate(100, 0, commonpb.SegmentState_Sealed)
+
+		pks := []storage.PrimaryKey{}
+		lc := storage.NewBatchLocationsCache(pks)
+		results := candidate.BatchPkExist(lc)
+		assert.Empty(t, results)
+	})
+}

--- a/internal/querynodev2/segments/mock_segment.go
+++ b/internal/querynodev2/segments/mock_segment.go
@@ -1988,6 +1988,39 @@ func (_c *MockSegment_SetBloomFilter_Call) RunAndReturn(run func(*pkoracle.Bloom
 	return _c
 }
 
+// SetPKCandidate provides a mock function with given fields: candidate
+func (_m *MockSegment) SetPKCandidate(candidate pkoracle.Candidate) {
+	_m.Called(candidate)
+}
+
+// MockSegment_SetPKCandidate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetPKCandidate'
+type MockSegment_SetPKCandidate_Call struct {
+	*mock.Call
+}
+
+// SetPKCandidate is a helper method to define mock.On call
+//   - candidate pkoracle.Candidate
+func (_e *MockSegment_Expecter) SetPKCandidate(candidate interface{}) *MockSegment_SetPKCandidate_Call {
+	return &MockSegment_SetPKCandidate_Call{Call: _e.mock.On("SetPKCandidate", candidate)}
+}
+
+func (_c *MockSegment_SetPKCandidate_Call) Run(run func(candidate pkoracle.Candidate)) *MockSegment_SetPKCandidate_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(pkoracle.Candidate))
+	})
+	return _c
+}
+
+func (_c *MockSegment_SetPKCandidate_Call) Return() *MockSegment_SetPKCandidate_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockSegment_SetPKCandidate_Call) RunAndReturn(run func(pkoracle.Candidate)) *MockSegment_SetPKCandidate_Call {
+	_c.Run(run)
+	return _c
+}
+
 // Shard provides a mock function with no fields
 func (_m *MockSegment) Shard() metautil.Channel {
 	ret := _m.Called()

--- a/internal/querynodev2/segments/segment_interface.go
+++ b/internal/querynodev2/segments/segment_interface.go
@@ -89,8 +89,9 @@ type Segment interface {
 	FinishLoad() error
 	Release(ctx context.Context, opts ...releaseOption)
 
-	// Bloom filter related
+	// Bloom filter / PK candidate related
 	SetBloomFilter(bf *pkoracle.BloomFilterSet)
+	SetPKCandidate(candidate pkoracle.Candidate) // For external collections using ExternalSegmentCandidate
 	BloomFilterExist() bool
 	UpdateBloomFilter(pks []storage.PrimaryKey)
 	MayPkExist(lc *storage.LocationsCache) bool

--- a/internal/querynodev2/segments/utils_test.go
+++ b/internal/querynodev2/segments/utils_test.go
@@ -204,3 +204,198 @@ func TestIsDataMmmapEnable(t *testing.T) {
 		assert.True(t, enable)
 	})
 }
+
+// Tests for external collection utilities
+
+func TestIsExternalCollection(t *testing.T) {
+	t.Run("ExternalCollection", func(t *testing.T) {
+		schema := &schemapb.CollectionSchema{
+			Name:           "test_collection",
+			ExternalSource: "s3://bucket/path",
+		}
+		assert.True(t, IsExternalCollection(schema))
+	})
+
+	t.Run("RegularCollection", func(t *testing.T) {
+		schema := &schemapb.CollectionSchema{
+			Name:           "test_collection",
+			ExternalSource: "",
+		}
+		assert.False(t, IsExternalCollection(schema))
+	})
+
+	t.Run("NilExternalSource", func(t *testing.T) {
+		schema := &schemapb.CollectionSchema{
+			Name: "test_collection",
+		}
+		assert.False(t, IsExternalCollection(schema))
+	})
+}
+
+func TestIsExternalField(t *testing.T) {
+	t.Run("ExternalField", func(t *testing.T) {
+		field := &schemapb.FieldSchema{
+			FieldID:       100,
+			Name:          "vector",
+			ExternalField: "external_vector_col",
+		}
+		assert.True(t, IsExternalField(field))
+	})
+
+	t.Run("RegularField", func(t *testing.T) {
+		field := &schemapb.FieldSchema{
+			FieldID:       100,
+			Name:          "vector",
+			ExternalField: "",
+		}
+		assert.False(t, IsExternalField(field))
+	})
+
+	t.Run("NilExternalField", func(t *testing.T) {
+		field := &schemapb.FieldSchema{
+			FieldID: 100,
+			Name:    "vector",
+		}
+		assert.False(t, IsExternalField(field))
+	})
+}
+
+func TestGetVirtualPK(t *testing.T) {
+	t.Run("BasicGeneration", func(t *testing.T) {
+		segmentID := int64(12345)
+		offset := int64(100)
+		virtualPK := GetVirtualPK(segmentID, offset)
+
+		expected := (segmentID << 32) | offset
+		assert.Equal(t, expected, virtualPK)
+	})
+
+	t.Run("ZeroOffset", func(t *testing.T) {
+		segmentID := int64(1)
+		offset := int64(0)
+		virtualPK := GetVirtualPK(segmentID, offset)
+
+		assert.Equal(t, int64(1)<<32, virtualPK)
+	})
+
+	t.Run("LargeOffset", func(t *testing.T) {
+		segmentID := int64(1)
+		offset := int64(0xFFFFFFFF) // Max 32-bit value
+		virtualPK := GetVirtualPK(segmentID, offset)
+
+		extractedSegment := ExtractSegmentIDFromVirtualPK(virtualPK)
+		extractedOffset := ExtractOffsetFromVirtualPK(virtualPK)
+
+		assert.Equal(t, int64(1), extractedSegment)
+		assert.Equal(t, int64(0xFFFFFFFF), extractedOffset)
+	})
+}
+
+func TestExtractSegmentIDFromVirtualPK(t *testing.T) {
+	t.Run("BasicExtraction", func(t *testing.T) {
+		segmentID := int64(999)
+		offset := int64(500)
+		virtualPK := GetVirtualPK(segmentID, offset)
+
+		extracted := ExtractSegmentIDFromVirtualPK(virtualPK)
+		assert.Equal(t, segmentID, extracted)
+	})
+
+	t.Run("ZeroSegmentID", func(t *testing.T) {
+		virtualPK := GetVirtualPK(0, 100)
+		extracted := ExtractSegmentIDFromVirtualPK(virtualPK)
+		assert.Equal(t, int64(0), extracted)
+	})
+
+	t.Run("LargeSegmentID", func(t *testing.T) {
+		// Only lower 32 bits are preserved
+		segmentID := int64(0xFFFFFFFF)
+		virtualPK := GetVirtualPK(segmentID, 0)
+		extracted := ExtractSegmentIDFromVirtualPK(virtualPK)
+		assert.Equal(t, segmentID, extracted)
+	})
+}
+
+func TestExtractOffsetFromVirtualPK(t *testing.T) {
+	t.Run("BasicExtraction", func(t *testing.T) {
+		segmentID := int64(999)
+		offset := int64(500)
+		virtualPK := GetVirtualPK(segmentID, offset)
+
+		extracted := ExtractOffsetFromVirtualPK(virtualPK)
+		assert.Equal(t, offset, extracted)
+	})
+
+	t.Run("ZeroOffset", func(t *testing.T) {
+		virtualPK := GetVirtualPK(100, 0)
+		extracted := ExtractOffsetFromVirtualPK(virtualPK)
+		assert.Equal(t, int64(0), extracted)
+	})
+
+	t.Run("MaxOffset", func(t *testing.T) {
+		maxOffset := int64(0xFFFFFFFF)
+		virtualPK := GetVirtualPK(100, maxOffset)
+		extracted := ExtractOffsetFromVirtualPK(virtualPK)
+		assert.Equal(t, maxOffset, extracted)
+	})
+}
+
+func TestIsVirtualPKFromSegment(t *testing.T) {
+	t.Run("Matching", func(t *testing.T) {
+		segmentID := int64(12345)
+		virtualPK := GetVirtualPK(segmentID, 100)
+
+		assert.True(t, IsVirtualPKFromSegment(virtualPK, segmentID))
+	})
+
+	t.Run("NotMatching", func(t *testing.T) {
+		segmentID := int64(12345)
+		virtualPK := GetVirtualPK(segmentID, 100)
+
+		assert.False(t, IsVirtualPKFromSegment(virtualPK, segmentID+1))
+		assert.False(t, IsVirtualPKFromSegment(virtualPK, 0))
+	})
+
+	t.Run("TruncatedSegmentID", func(t *testing.T) {
+		// Segment ID with upper bits set
+		segmentID := int64(0x100000001) // 33-bit value, lower 32 bits = 1
+		virtualPK := GetVirtualPK(segmentID, 100)
+
+		// Should match both the original and truncated segment ID
+		assert.True(t, IsVirtualPKFromSegment(virtualPK, segmentID))
+		assert.True(t, IsVirtualPKFromSegment(virtualPK, 1)) // Truncated
+	})
+}
+
+func TestVirtualPKRoundTrip(t *testing.T) {
+	testCases := []struct {
+		segmentID int64
+		offset    int64
+	}{
+		{0, 0},
+		{1, 0},
+		{0, 1},
+		{100, 100},
+		{12345, 67890},
+		{0xFFFFFFFF, 0xFFFFFFFF},
+		{1, 0xFFFFFFFF},
+		{0xFFFFFFFF, 1},
+	}
+
+	for _, tc := range testCases {
+		virtualPK := GetVirtualPK(tc.segmentID, tc.offset)
+		extractedSegment := ExtractSegmentIDFromVirtualPK(virtualPK)
+		extractedOffset := ExtractOffsetFromVirtualPK(virtualPK)
+
+		// Note: segment ID is truncated to 32 bits
+		expectedSegment := tc.segmentID & 0xFFFFFFFF
+		expectedOffset := tc.offset & 0xFFFFFFFF
+
+		assert.Equal(t, expectedSegment, extractedSegment,
+			"Segment ID mismatch for input segmentID=%d, offset=%d", tc.segmentID, tc.offset)
+		assert.Equal(t, expectedOffset, extractedOffset,
+			"Offset mismatch for input segmentID=%d, offset=%d", tc.segmentID, tc.offset)
+		assert.True(t, IsVirtualPKFromSegment(virtualPK, tc.segmentID),
+			"IsVirtualPKFromSegment should return true for input segmentID=%d", tc.segmentID)
+	}
+}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -64,6 +64,10 @@ const (
 	// MetaFieldName is the field name of dynamic schema
 	MetaFieldName = "$meta"
 
+	// VirtualPKFieldName is the field name of virtual primary key for external collections
+	// Virtual PK format: (segmentID << 32) | offset
+	VirtualPKFieldName = "__virtual_pk__"
+
 	// DefaultShardsNum defines the default number of shards when creating a collection
 	DefaultShardsNum = int32(1)
 


### PR DESCRIPTION
issue: #45881 
Implement loading external collections in QueryNode with:
- Virtual PK generation: (segmentID << 32) | offset format
- VirtualPKChunkedColumn for on-the-fly virtual PK generation
- ExternalFieldChunkedColumn for lazy loading external fields via milvus-storage
- ExternalSegmentCandidate for PK-based segment matching (replaces bloom filter)
- Automatic virtual PK field injection for external collections without PK
- Skip delta logs and bloom filters for external collections