### PR TITLE
enhance: Add channel-based node blacklist for LB policy retry

### DIFF
--- a/internal/proxy/shardclient/channel_blacklist.go
+++ b/internal/proxy/shardclient/channel_blacklist.go
@@ -1,0 +1,153 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shardclient
+
+import (
+	"sync"
+	"time"
+
+	"github.com/milvus-io/milvus/pkg/v2/log"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+)
+
+// ChannelBlacklist manages blacklisted nodes per channel with expiration.
+// When a query fails on a delegator, the node is added to the blacklist
+// for the corresponding channel. The node will be automatically removed
+// from the blacklist after the configured duration (default 30s).
+type ChannelBlacklist struct {
+	mu sync.RWMutex
+	// channel -> nodeID -> expireAt
+	blacklist map[string]map[int64]time.Time
+
+	closeCh   chan struct{}
+	closeOnce sync.Once
+	wg        sync.WaitGroup
+}
+
+// NewChannelBlacklist creates a new ChannelBlacklist
+func NewChannelBlacklist() *ChannelBlacklist {
+	return &ChannelBlacklist{
+		blacklist: make(map[string]map[int64]time.Time),
+		closeCh:   make(chan struct{}),
+	}
+}
+
+// Start starts the background cleanup loop
+func (b *ChannelBlacklist) Start() {
+	b.wg.Add(1)
+	go b.cleanupLoop()
+}
+
+// Close stops the background cleanup loop
+func (b *ChannelBlacklist) Close() {
+	b.closeOnce.Do(func() {
+		close(b.closeCh)
+		b.wg.Wait()
+	})
+}
+
+// cleanupLoop periodically removes expired entries from the blacklist
+func (b *ChannelBlacklist) cleanupLoop() {
+	defer b.wg.Done()
+
+	interval := paramtable.Get().ProxyCfg.ReplicaBlacklistCleanupInterval.GetAsDurationByParse()
+	if interval <= 0 {
+		interval = 10 * time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	log.Info("Start blacklist cleanup loop")
+	for {
+		select {
+		case <-b.closeCh:
+			log.Info("Blacklist cleanup loop exit")
+			return
+		case <-ticker.C:
+			b.cleanup()
+		}
+	}
+}
+
+// cleanup removes expired entries from the blacklist
+func (b *ChannelBlacklist) cleanup() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	now := time.Now()
+	for channel, nodes := range b.blacklist {
+		for nodeID, expireAt := range nodes {
+			if now.After(expireAt) {
+				delete(nodes, nodeID)
+			}
+		}
+		// Remove empty channel entries
+		if len(nodes) == 0 {
+			delete(b.blacklist, channel)
+		}
+	}
+}
+
+// Add adds a node to the blacklist for a specific channel.
+// The node will be blacklisted for the duration configured by
+// proxy.replicaBlacklistDuration (default 30s).
+// If duration is <= 0, the blacklist is disabled and this is a no-op.
+func (b *ChannelBlacklist) Add(channel string, nodeID int64) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	duration := paramtable.Get().ProxyCfg.ReplicaBlacklistDuration.GetAsDurationByParse()
+	if duration <= 0 {
+		// blacklist is disabled
+		return
+	}
+
+	if _, ok := b.blacklist[channel]; !ok {
+		b.blacklist[channel] = make(map[int64]time.Time)
+	}
+	b.blacklist[channel][nodeID] = time.Now().Add(duration)
+}
+
+// GetBlacklistedNodes returns unexpired blacklisted node IDs for a channel.
+// Returns nil if no nodes are blacklisted for the channel.
+func (b *ChannelBlacklist) GetBlacklistedNodes(channel string) []int64 {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	nodes, ok := b.blacklist[channel]
+	if !ok {
+		return nil
+	}
+
+	now := time.Now()
+	result := make([]int64, 0, len(nodes))
+	for nodeID, expireAt := range nodes {
+		if now.Before(expireAt) {
+			result = append(result, nodeID)
+		}
+	}
+	return result
+}
+
+// Clear clears blacklist for a specific channel.
+// This is called when all replicas are excluded and we need to retry.
+func (b *ChannelBlacklist) Clear(channel string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	delete(b.blacklist, channel)
+}

--- a/internal/proxy/shardclient/channel_blacklist_test.go
+++ b/internal/proxy/shardclient/channel_blacklist_test.go
@@ -1,0 +1,240 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shardclient
+
+import (
+	"testing"
+	"time"
+
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+)
+
+func TestChannelBlacklist(t *testing.T) {
+	paramtable.Init()
+
+	t.Run("test add and get blacklisted nodes", func(t *testing.T) {
+		// Set blacklist duration to 1 second for testing
+		paramtable.Get().Save(paramtable.Get().ProxyCfg.ReplicaBlacklistDuration.Key, "1s")
+		defer paramtable.Get().Reset(paramtable.Get().ProxyCfg.ReplicaBlacklistDuration.Key)
+
+		blacklist := NewChannelBlacklist()
+		channel := "test_channel"
+
+		// Add nodes to blacklist
+		blacklist.Add(channel, 1)
+		blacklist.Add(channel, 2)
+
+		// Get blacklisted nodes
+		nodes := blacklist.GetBlacklistedNodes(channel)
+		if len(nodes) != 2 {
+			t.Errorf("expected 2 blacklisted nodes, got %d", len(nodes))
+		}
+
+		// Check that both nodes are in the list
+		nodeSet := make(map[int64]bool)
+		for _, n := range nodes {
+			nodeSet[n] = true
+		}
+		if !nodeSet[1] || !nodeSet[2] {
+			t.Errorf("expected nodes 1 and 2 to be blacklisted, got %v", nodes)
+		}
+	})
+
+	t.Run("test blacklist expiration", func(t *testing.T) {
+		// Set blacklist duration to 100ms for testing
+		paramtable.Get().Save(paramtable.Get().ProxyCfg.ReplicaBlacklistDuration.Key, "100ms")
+		defer paramtable.Get().Reset(paramtable.Get().ProxyCfg.ReplicaBlacklistDuration.Key)
+
+		blacklist := NewChannelBlacklist()
+		channel := "test_channel"
+
+		// Add node to blacklist
+		blacklist.Add(channel, 1)
+
+		// Node should be blacklisted
+		nodes := blacklist.GetBlacklistedNodes(channel)
+		if len(nodes) != 1 {
+			t.Errorf("expected 1 blacklisted node, got %d", len(nodes))
+		}
+
+		// Wait for expiration
+		time.Sleep(150 * time.Millisecond)
+
+		// Node should no longer be blacklisted
+		nodes = blacklist.GetBlacklistedNodes(channel)
+		if len(nodes) != 0 {
+			t.Errorf("expected 0 blacklisted nodes after expiration, got %d", len(nodes))
+		}
+	})
+
+	t.Run("test clear blacklist", func(t *testing.T) {
+		paramtable.Get().Save(paramtable.Get().ProxyCfg.ReplicaBlacklistDuration.Key, "1s")
+		defer paramtable.Get().Reset(paramtable.Get().ProxyCfg.ReplicaBlacklistDuration.Key)
+
+		blacklist := NewChannelBlacklist()
+		channel := "test_channel"
+
+		// Add nodes to blacklist
+		blacklist.Add(channel, 1)
+		blacklist.Add(channel, 2)
+
+		// Clear blacklist
+		blacklist.Clear(channel)
+
+		// Should have no blacklisted nodes
+		nodes := blacklist.GetBlacklistedNodes(channel)
+		if len(nodes) != 0 {
+			t.Errorf("expected 0 blacklisted nodes after clear, got %d", len(nodes))
+		}
+	})
+
+	t.Run("test blacklist disabled when duration is 0", func(t *testing.T) {
+		paramtable.Get().Save(paramtable.Get().ProxyCfg.ReplicaBlacklistDuration.Key, "0s")
+		defer paramtable.Get().Reset(paramtable.Get().ProxyCfg.ReplicaBlacklistDuration.Key)
+
+		blacklist := NewChannelBlacklist()
+		channel := "test_channel"
+
+		// Add node to blacklist - should be a no-op
+		blacklist.Add(channel, 1)
+
+		// Should have no blacklisted nodes
+		nodes := blacklist.GetBlacklistedNodes(channel)
+		if len(nodes) != 0 {
+			t.Errorf("expected 0 blacklisted nodes when disabled, got %d", len(nodes))
+		}
+	})
+
+	t.Run("test different channels have separate blacklists", func(t *testing.T) {
+		paramtable.Get().Save(paramtable.Get().ProxyCfg.ReplicaBlacklistDuration.Key, "1s")
+		defer paramtable.Get().Reset(paramtable.Get().ProxyCfg.ReplicaBlacklistDuration.Key)
+
+		blacklist := NewChannelBlacklist()
+
+		// Add different nodes to different channels
+		blacklist.Add("channel1", 1)
+		blacklist.Add("channel2", 2)
+
+		// Check channel1
+		nodes1 := blacklist.GetBlacklistedNodes("channel1")
+		if len(nodes1) != 1 || nodes1[0] != 1 {
+			t.Errorf("expected node 1 in channel1, got %v", nodes1)
+		}
+
+		// Check channel2
+		nodes2 := blacklist.GetBlacklistedNodes("channel2")
+		if len(nodes2) != 1 || nodes2[0] != 2 {
+			t.Errorf("expected node 2 in channel2, got %v", nodes2)
+		}
+	})
+
+	t.Run("test cleanup removes expired entries", func(t *testing.T) {
+		paramtable.Get().Save(paramtable.Get().ProxyCfg.ReplicaBlacklistDuration.Key, "50ms")
+		defer paramtable.Get().Reset(paramtable.Get().ProxyCfg.ReplicaBlacklistDuration.Key)
+
+		blacklist := NewChannelBlacklist()
+		channel := "test_channel"
+
+		// Add node to blacklist
+		blacklist.Add(channel, 1)
+
+		// Wait for expiration
+		time.Sleep(100 * time.Millisecond)
+
+		// Manually trigger cleanup
+		blacklist.cleanup()
+
+		// The internal map should be cleaned up
+		blacklist.mu.RLock()
+		_, exists := blacklist.blacklist[channel]
+		blacklist.mu.RUnlock()
+
+		if exists {
+			t.Errorf("expected channel to be removed from blacklist after cleanup")
+		}
+	})
+
+	t.Run("test start and close cleanup loop", func(t *testing.T) {
+		blacklist := NewChannelBlacklist()
+		blacklist.Start()
+		// Give some time for goroutine to start
+		time.Sleep(10 * time.Millisecond)
+		blacklist.Close()
+		// Should not panic or hang
+	})
+
+	t.Run("test get non-existent channel", func(t *testing.T) {
+		blacklist := NewChannelBlacklist()
+
+		// Get blacklisted nodes for a channel that was never added
+		nodes := blacklist.GetBlacklistedNodes("non_existent_channel")
+		if nodes != nil {
+			t.Errorf("expected nil for non-existent channel, got %v", nodes)
+		}
+	})
+
+	t.Run("test add same node updates expiration", func(t *testing.T) {
+		paramtable.Get().Save(paramtable.Get().ProxyCfg.ReplicaBlacklistDuration.Key, "200ms")
+		defer paramtable.Get().Reset(paramtable.Get().ProxyCfg.ReplicaBlacklistDuration.Key)
+
+		blacklist := NewChannelBlacklist()
+		channel := "test_channel"
+
+		// Add node to blacklist
+		blacklist.Add(channel, 1)
+
+		// Wait 100ms
+		time.Sleep(100 * time.Millisecond)
+
+		// Add same node again - should refresh expiration
+		blacklist.Add(channel, 1)
+
+		// Wait another 150ms (total 250ms from first add, but only 150ms from second add)
+		time.Sleep(150 * time.Millisecond)
+
+		// Node should still be blacklisted because expiration was refreshed
+		nodes := blacklist.GetBlacklistedNodes(channel)
+		if len(nodes) != 1 {
+			t.Errorf("expected 1 blacklisted node after refresh, got %d", len(nodes))
+		}
+	})
+
+	t.Run("test close can be called multiple times", func(t *testing.T) {
+		blacklist := NewChannelBlacklist()
+		blacklist.Start()
+		time.Sleep(10 * time.Millisecond)
+
+		// Close multiple times - should not panic due to closeOnce
+		blacklist.Close()
+		blacklist.Close()
+		blacklist.Close()
+		// Should not panic
+	})
+
+	t.Run("test cleanup loop with default interval", func(t *testing.T) {
+		// Set cleanup interval to 0 to trigger default value
+		paramtable.Get().Save(paramtable.Get().ProxyCfg.ReplicaBlacklistCleanupInterval.Key, "0s")
+		defer paramtable.Get().Reset(paramtable.Get().ProxyCfg.ReplicaBlacklistCleanupInterval.Key)
+
+		blacklist := NewChannelBlacklist()
+		blacklist.Start()
+		// Give some time for goroutine to start with default interval
+		time.Sleep(10 * time.Millisecond)
+		blacklist.Close()
+		// Should not panic or hang - default interval (10s) should be used
+	})
+}

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -1843,42 +1843,44 @@ type proxyConfig struct {
 	// Alias  string
 	SoPath ParamItem `refreshable:"false"`
 
-	TimeTickInterval               ParamItem `refreshable:"false"`
-	HealthCheckTimeout             ParamItem `refreshable:"true"`
-	MsgStreamTimeTickBufSize       ParamItem `refreshable:"true"`
-	MaxNameLength                  ParamItem `refreshable:"true"`
-	MaxUsernameLength              ParamItem `refreshable:"true"`
-	MinPasswordLength              ParamItem `refreshable:"true"`
-	MaxPasswordLength              ParamItem `refreshable:"true"`
-	MaxFieldNum                    ParamItem `refreshable:"true"`
-	MaxVectorFieldNum              ParamItem `refreshable:"true"`
-	MaxShardNum                    ParamItem `refreshable:"true"`
-	MaxDimension                   ParamItem `refreshable:"true"`
-	GinLogging                     ParamItem `refreshable:"false"`
-	GinLogSkipPaths                ParamItem `refreshable:"false"`
-	MaxUserNum                     ParamItem `refreshable:"true"`
-	MaxRoleNum                     ParamItem `refreshable:"true"`
-	NameValidationAllowedChars     ParamItem `refreshable:"true"`
-	RoleNameValidationAllowedChars ParamItem `refreshable:"true"`
-	MaxTaskNum                     ParamItem `refreshable:"false"`
-	DDLConcurrency                 ParamItem `refreshable:"true"`
-	DCLConcurrency                 ParamItem `refreshable:"true"`
-	ShardLeaderCacheInterval       ParamItem `refreshable:"false"`
-	ReplicaSelectionPolicy         ParamItem `refreshable:"false"`
-	CheckQueryNodeHealthInterval   ParamItem `refreshable:"false"`
-	CostMetricsExpireTime          ParamItem `refreshable:"false"`
-	CheckWorkloadRequestNum        ParamItem `refreshable:"false"`
-	WorkloadToleranceFactor        ParamItem `refreshable:"false"`
-	RetryTimesOnReplica            ParamItem `refreshable:"true"`
-	RetryTimesOnHealthCheck        ParamItem `refreshable:"true"`
-	PartitionNameRegexp            ParamItem `refreshable:"true"`
-	MustUsePartitionKey            ParamItem `refreshable:"true"`
-	SkipAutoIDCheck                ParamItem `refreshable:"true"`
-	SkipPartitionKeyCheck          ParamItem `refreshable:"true"`
-	MaxVarCharLength               ParamItem `refreshable:"false"`
-	MaxTextLength                  ParamItem `refreshable:"false"`
-	MaxResultEntries               ParamItem `refreshable:"true"`
-	EnableCachedServiceProvider    ParamItem `refreshable:"true"`
+	TimeTickInterval                ParamItem `refreshable:"false"`
+	HealthCheckTimeout              ParamItem `refreshable:"true"`
+	MsgStreamTimeTickBufSize        ParamItem `refreshable:"true"`
+	MaxNameLength                   ParamItem `refreshable:"true"`
+	MaxUsernameLength               ParamItem `refreshable:"true"`
+	MinPasswordLength               ParamItem `refreshable:"true"`
+	MaxPasswordLength               ParamItem `refreshable:"true"`
+	MaxFieldNum                     ParamItem `refreshable:"true"`
+	MaxVectorFieldNum               ParamItem `refreshable:"true"`
+	MaxShardNum                     ParamItem `refreshable:"true"`
+	MaxDimension                    ParamItem `refreshable:"true"`
+	GinLogging                      ParamItem `refreshable:"false"`
+	GinLogSkipPaths                 ParamItem `refreshable:"false"`
+	MaxUserNum                      ParamItem `refreshable:"true"`
+	MaxRoleNum                      ParamItem `refreshable:"true"`
+	NameValidationAllowedChars      ParamItem `refreshable:"true"`
+	RoleNameValidationAllowedChars  ParamItem `refreshable:"true"`
+	MaxTaskNum                      ParamItem `refreshable:"false"`
+	DDLConcurrency                  ParamItem `refreshable:"true"`
+	DCLConcurrency                  ParamItem `refreshable:"true"`
+	ShardLeaderCacheInterval        ParamItem `refreshable:"false"`
+	ReplicaSelectionPolicy          ParamItem `refreshable:"false"`
+	CheckQueryNodeHealthInterval    ParamItem `refreshable:"false"`
+	CostMetricsExpireTime           ParamItem `refreshable:"false"`
+	CheckWorkloadRequestNum         ParamItem `refreshable:"false"`
+	WorkloadToleranceFactor         ParamItem `refreshable:"false"`
+	RetryTimesOnReplica             ParamItem `refreshable:"true"`
+	RetryTimesOnHealthCheck         ParamItem `refreshable:"true"`
+	ReplicaBlacklistDuration        ParamItem `refreshable:"true"`
+	ReplicaBlacklistCleanupInterval ParamItem `refreshable:"true"`
+	PartitionNameRegexp             ParamItem `refreshable:"true"`
+	MustUsePartitionKey             ParamItem `refreshable:"true"`
+	SkipAutoIDCheck                 ParamItem `refreshable:"true"`
+	SkipPartitionKeyCheck           ParamItem `refreshable:"true"`
+	MaxVarCharLength                ParamItem `refreshable:"false"`
+	MaxTextLength                   ParamItem `refreshable:"false"`
+	MaxResultEntries                ParamItem `refreshable:"true"`
+	EnableCachedServiceProvider     ParamItem `refreshable:"true"`
 
 	AccessLog AccessLogConfig
 
@@ -2268,6 +2270,22 @@ please adjust in embedded Milvus: false`,
 		Doc:          "set query node unavailable on proxy when heartbeat failures reach this limit",
 	}
 	p.RetryTimesOnHealthCheck.Init(base.mgr)
+
+	p.ReplicaBlacklistDuration = ParamItem{
+		Key:          "proxy.replicaBlacklistDuration",
+		Version:      "2.6.8",
+		DefaultValue: "30s",
+		Doc:          "The duration a replica is blacklisted after a query failure, in seconds",
+	}
+	p.ReplicaBlacklistDuration.Init(base.mgr)
+
+	p.ReplicaBlacklistCleanupInterval = ParamItem{
+		Key:          "proxy.replicaBlacklistCleanupInterval",
+		Version:      "2.6.8",
+		DefaultValue: "10s",
+		Doc:          "The interval to cleanup expired entries from the replica blacklist, in seconds",
+	}
+	p.ReplicaBlacklistCleanupInterval.Init(base.mgr)
 
 	p.PartitionNameRegexp = ParamItem{
 		Key:          "proxy.partitionNameRegexp",

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -229,6 +229,16 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, Params.RetryTimesOnReplica.GetAsInt(), 5)
 		assert.EqualValues(t, Params.HealthCheckTimeout.GetAsInt64(), 3000)
 
+		// Test ReplicaBlacklistDuration default value
+		assert.Equal(t, 30*time.Second, Params.ReplicaBlacklistDuration.GetAsDurationByParse())
+		params.Save("proxy.replicaBlacklistDuration", "60s")
+		assert.Equal(t, 60*time.Second, Params.ReplicaBlacklistDuration.GetAsDurationByParse())
+
+		// Test ReplicaBlacklistCleanupInterval default value
+		assert.Equal(t, 10*time.Second, Params.ReplicaBlacklistCleanupInterval.GetAsDurationByParse())
+		params.Save("proxy.replicaBlacklistCleanupInterval", "30s")
+		assert.Equal(t, 30*time.Second, Params.ReplicaBlacklistCleanupInterval.GetAsDurationByParse())
+
 		params.Save("proxy.gracefulStopTimeout", "100")
 		assert.Equal(t, 100*time.Second, Params.GracefulStopTimeout.GetAsDuration(time.Second))
 


### PR DESCRIPTION
issue: #46090
This change introduces a global node blacklist mechanism to immediately cut off query traffic to failed delegators across all concurrent requests.

Key features:
- Introduce ChannelBlacklist to track failed delegator nodes per channel
- When a query fails, the node is immediately blacklisted and excluded from ALL subsequent requests (not just retries within the same request)
- Blacklisted nodes are automatically excluded during node selection
- Entries expire after configurable duration (default 30s) to allow automatic recovery when nodes become healthy again
- Background cleanup loop removes expired entries periodically
- Add proxy.replicaBlacklistDuration and proxy.replicaBlacklistCleanupInterval configuration parameters
- Blacklist can be disabled by setting duration to 0

Before this change:
- Failed nodes were only excluded within the same request's retry loop
- Concurrent requests would still attempt to query the failed node
- Each request had to experience its own failure before avoiding the node

After this change:
- Once a node fails, it is immediately excluded from all requests
- New requests arriving during the blacklist period will skip the failed node without experiencing any failure
- This significantly reduces latency spikes during node failures