### PR TITLE
enhance: use specified manifest version in loon ffi reader

### DIFF
--- a/internal/core/src/storage/loon_ffi/util.cpp
+++ b/internal/core/src/storage/loon_ffi/util.cpp
@@ -250,44 +250,6 @@ ToCStorageConfig(const milvus::storage::StorageConfig& config) {
                           config.max_connections};
 }
 
-std::string
-GetManifest(const std::string& path,
-            const std::shared_ptr<Properties>& properties) {
-    try {
-        // Parse the JSON string
-        json j = json::parse(path);
-
-        // Extract base_path
-        std::string base_path = j.at("base_path").get<std::string>();
-
-        ColumnGroupsHandle out_column_groups = 0;
-        int64_t out_read_version = 0;
-        FFIResult result = get_latest_column_groups(base_path.c_str(),
-                                                    properties.get(),
-                                                    &out_column_groups,
-                                                    &out_read_version);
-        if (!IsSuccess(&result)) {
-            auto message = GetErrorMessage(&result);
-            // Copy the error message before freeing the FFIResult
-            std::string error_msg = message ? message : "Unknown error";
-            FreeFFIResult(&result);
-            throw std::runtime_error(error_msg);
-        }
-
-        FreeFFIResult(&result);
-        return {out_column_groups};
-    } catch (const json::parse_error& e) {
-        throw std::runtime_error(
-            std::string("Failed to parse manifest JSON: ") + e.what());
-    } catch (const json::out_of_range& e) {
-        throw std::runtime_error(
-            std::string("Missing required field in manifest: ") + e.what());
-    } catch (const json::type_error& e) {
-        throw std::runtime_error(
-            std::string("Invalid field type in manifest: ") + e.what());
-    }
-}
-
 std::shared_ptr<milvus_storage::api::ColumnGroups>
 GetColumnGroups(
     const std::string& path,
@@ -296,20 +258,24 @@ GetColumnGroups(
         // Parse the JSON string
         json j = json::parse(path);
 
-        // Extract base_path
+        // Extract base_path & version
         std::string base_path = j.at("base_path").get<std::string>();
+        int64_t version = j.at("ver").get<int64_t>();
 
-        // TODO fetch manifest based on version after api supported
         auto transaction =
             std::make_unique<milvus_storage::api::transaction::TransactionImpl<
                 milvus_storage::api::ColumnGroups>>(*properties, base_path);
-        auto latest_manifest_result = transaction->get_latest_manifest();
-        if (!latest_manifest_result.ok()) {
-            throw(
-                std::runtime_error(latest_manifest_result.status().ToString()));
+        auto status = transaction->begin(version);
+        if (!status.ok()) {
+            throw(std::runtime_error(status.ToString()));
         }
-        auto latest_manifest = latest_manifest_result.ValueOrDie();
-        return latest_manifest;
+        auto current_manifest_result = transaction->get_current_manifest();
+        if (!current_manifest_result.ok()) {
+            throw(std::runtime_error(
+                current_manifest_result.status().ToString()));
+        }
+        auto current_manifest = current_manifest_result.ValueOrDie();
+        return current_manifest;
     } catch (const json::parse_error& e) {
         throw std::runtime_error(
             std::string("Failed to parse manifest JSON: ") + e.what());

--- a/internal/core/src/storage/loon_ffi/util.h
+++ b/internal/core/src/storage/loon_ffi/util.h
@@ -77,21 +77,6 @@ CStorageConfig
 ToCStorageConfig(const milvus::storage::StorageConfig& config);
 
 /**
- * @brief Retrieve manifest/column groups from storage via FFI
- *
- * Parses the manifest path JSON to extract base_path and version,
- * then fetches the latest column groups from storage using FFI.
- *
- * @param path JSON string containing "base_path" and "ver" fields
- * @param properties Storage properties for accessing the manifest
- * @return JSON string containing column groups information
- * @throws std::runtime_error If JSON parsing fails or FFI call fails
- */
-std::string
-GetManifest(const std::string& path,
-            const std::shared_ptr<Properties>& properties);
-
-/**
  * @brief Retrieve ColumnGroups metadata from manifest path
  *
  * Parses the manifest path JSON and fetches the latest manifest

--- a/internal/core/thirdparty/milvus-storage/CMakeLists.txt
+++ b/internal/core/thirdparty/milvus-storage/CMakeLists.txt
@@ -14,7 +14,7 @@
 # Update milvus-storage_VERSION for the first occurrence
 milvus_add_pkg_config("milvus-storage")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( milvus-storage_VERSION 5fff4f5)
+set( milvus-storage_VERSION 33bf815)
 set( GIT_REPOSITORY  "https://github.com/milvus-io/milvus-storage.git")
 message(STATUS "milvus-storage repo: ${GIT_REPOSITORY}")
 message(STATUS "milvus-storage version: ${milvus-storage_VERSION}")

--- a/internal/storagev2/packed/packed_reader_ffi.go
+++ b/internal/storagev2/packed/packed_reader_ffi.go
@@ -202,8 +202,7 @@ func GetColumnGroups(manifestPath string, storageConfig *indexpb.StorageConfig) 
 	cBasePath := C.CString(basePath)
 	defer C.free(unsafe.Pointer(cBasePath))
 
-	var cVersion C.int64_t
-	result := C.get_latest_column_groups(cBasePath, cProperties, &cColumnGroups, &cVersion)
+	result := C.get_column_groups_by_version(cBasePath, cProperties, C.int64_t(version), &cColumnGroups)
 	err = HandleFFIResult(result)
 	if err != nil {
 		return cColumnGroups, err


### PR DESCRIPTION
Related to #44956

Use the exact manifest version from the path parameter instead of always fetching the latest manifest. This ensures data consistency by reading from the specific version that was requested.

Changes:
- Update GetColumnGroups to use transaction.begin(version) with the specified version from the path JSON
- Replace get_latest_manifest() with get_current_manifest() after beginning transaction at the target version
- Update Go FFI binding to call get_column_groups_by_version instead of get_latest_column_groups
- Remove unused GetManifest function from util.cpp/util.h
- Bump milvus-storage version from 5fff4f5 to 33bf815