### PR TITLE
fix: [2.6] correct loop logic for timestamptz scalar index output (#46100)

### DIFF
--- a/internal/core/src/segcore/Utils.cpp
+++ b/internal/core/src/segcore/Utils.cpp
@@ -1003,10 +1003,10 @@ ReverseDataFromIndex(const index::IndexBase* index,
                     valid_data[i] = true;
                 }
                 raw_data[i] = raw.value();
-                auto obj = scalar_array->mutable_timestamptz_data();
-                *(obj->mutable_data()) = {raw_data.begin(), raw_data.end()};
-                break;
             }
+            auto obj = scalar_array->mutable_timestamptz_data();
+            *(obj->mutable_data()) = {raw_data.begin(), raw_data.end()};
+            break;
         }
         case DataType::VARCHAR: {
             using IndexType = index::ScalarIndex<std::string>;


### PR DESCRIPTION
Cherry-pick from master
pr: #46100
Related to #46098

Fix the ReverseDataFromIndex function where the assignment of raw_data to scalar_array and the break statement were incorrectly placed inside the for loop for TIMESTAMPTZ data type. This caused QueryNode to panic when outputting timestamptz fields from scalar index.

Move the assignment and break statement outside the loop to match the pattern used by other data types like VARCHAR.