### PR TITLE
fix: Fix replicate lag metric calculation to prevent false-positive health

### DIFF
--- a/internal/cdc/replication/replicatestream/replicate_stream_client_impl.go
+++ b/internal/cdc/replication/replicatestream/replicate_stream_client_impl.go
@@ -170,10 +170,6 @@ func (r *replicateStreamClient) Replicate(msg message.ImmutableMessage) error {
 	default:
 		// TODO: Should be done at streamingnode, but after move it into streamingnode, the metric need to be adjusted.
 		if msg.MessageType().IsSelfControlled() {
-			if r.pendingMessages.Len() == 0 {
-				// if there is no pending messages, there's no lag between source and target.
-				r.metrics.OnNoIncomingMessages()
-			}
 			return ErrReplicateIgnored
 		}
 		r.metrics.StartReplicate(msg)

--- a/pkg/metrics/cdc_metrics.go
+++ b/pkg/metrics/cdc_metrics.go
@@ -27,7 +27,7 @@ const (
 	CDCMetricReplicatedMessagesTotal  = "replicated_messages_total"
 	CDCMetricReplicatedBytesTotal     = "replicated_bytes_total"
 	CDCMetricReplicateEndToEndLatency = "replicate_end_to_end_latency"
-	CDCMetricReplicateLag             = "replicate_lag"
+	CDCMetricLastReplicatedTimeTick   = "last_replicated_time_tick"
 	CDCMetricStreamRPCConnections     = "stream_rpc_connections"
 	CDCMetricStreamRPCReconnectTimes  = "stream_rpc_reconnect_times"
 
@@ -82,12 +82,12 @@ var CDCReplicateEndToEndLatency = prometheus.NewHistogramVec(
 	},
 )
 
-var CDCReplicateLag = prometheus.NewGaugeVec(
+var CDCLastReplicatedTimeTick = prometheus.NewGaugeVec(
 	prometheus.GaugeOpts{
 		Namespace: milvusNamespace,
 		Subsystem: typeutil.CDCRole,
-		Name:      CDCMetricReplicateLag,
-		Help:      "Lag in milliseconds between the latest synced Source message and the current time",
+		Name:      CDCMetricLastReplicatedTimeTick,
+		Help:      "The time tick of the last replicated message",
 	}, []string{
 		CDCLabelSourceChannelName,
 		CDCLabelTargetChannelName,
@@ -121,7 +121,7 @@ func RegisterCDC(registry *prometheus.Registry) {
 	registry.MustRegister(CDCReplicatedMessagesTotal)
 	registry.MustRegister(CDCReplicatedBytesTotal)
 	registry.MustRegister(CDCReplicateEndToEndLatency)
-	registry.MustRegister(CDCReplicateLag)
+	registry.MustRegister(CDCLastReplicatedTimeTick)
 	registry.MustRegister(CDCStreamRPCConnections)
 	registry.MustRegister(CDCStreamRPCReconnectTimes)
 }


### PR DESCRIPTION
This change fixes the calculation by using timestamp subtraction (WAL confirmed time - Last replicate time). This ensures the lag metric immediately spikes when replication is blocked, providing reliable monitoring.

issue: https://github.com/milvus-io/milvus/issues/46116