### PR TITLE
fix: [hotfix] correct loop logic for timestamptz scalar index output (#46100)

### DIFF
--- a/internal/core/src/segcore/Utils.cpp
+++ b/internal/core/src/segcore/Utils.cpp
@@ -1000,10 +1000,10 @@ ReverseDataFromIndex(const index::IndexBase* index,
                     valid_data[i] = true;
                 }
                 raw_data[i] = raw.value();
-                auto obj = scalar_array->mutable_timestamptz_data();
-                *(obj->mutable_data()) = {raw_data.begin(), raw_data.end()};
-                break;
             }
+            auto obj = scalar_array->mutable_timestamptz_data();
+            *(obj->mutable_data()) = {raw_data.begin(), raw_data.end()};
+            break;
         }
         case DataType::VARCHAR: {
             using IndexType = index::ScalarIndex<std::string>;

--- a/tests/python_client/requirements.txt
+++ b/tests/python_client/requirements.txt
@@ -39,7 +39,7 @@ python-benedict==0.24.3
 timeout-decorator==0.5.0
 
 # for bulk insert test
-minio==7.1.5
+minio==7.2.0
 npy-append-array==0.9.15
 Faker==19.2.0
 

--- a/tests/restful_client_v2/requirements.txt
+++ b/tests/restful_client_v2/requirements.txt
@@ -9,7 +9,7 @@ Faker==19.2.0
 pymilvus==2.5.0rc108
 scikit-learn>=1.5.2
 pytest-xdist==2.5.0
-minio==7.1.14
+minio==7.2.0
 tenacity==8.1.0
 # for bf16 datatype
 ml-dtypes==0.2.0


### PR DESCRIPTION
Cherry-pick from master
pr: #46100
Related to #46098

Fix the ReverseDataFromIndex function where the assignment of raw_data to scalar_array and the break statement were incorrectly placed inside the for loop for TIMESTAMPTZ data type. This caused QueryNode to panic when outputting timestamptz fields from scalar index.

Move the assignment and break statement outside the loop to match the pattern used by other data types like VARCHAR.