### PR TITLE
feat: Add nullable vector support in import utility layer

### DIFF
--- a/internal/datanode/importv2/util.go
+++ b/internal/datanode/importv2/util.go
@@ -374,6 +374,19 @@ func AppendNullableDefaultFieldsData(schema *schemapb.CollectionSchema, data *st
 				appender := &nullDefaultAppender[*schemapb.ScalarField]{}
 				err = appender.AppendNull(fieldData, rowNum)
 			}
+		case schemapb.DataType_FloatVector,
+			schemapb.DataType_Float16Vector,
+			schemapb.DataType_BFloat16Vector,
+			schemapb.DataType_BinaryVector,
+			schemapb.DataType_SparseFloatVector,
+			schemapb.DataType_Int8Vector:
+			if nullable {
+				for i := 0; i < rowNum; i++ {
+					if err = fieldData.AppendRow(nil); err != nil {
+						return err
+					}
+				}
+			}
 		default:
 			return fmt.Errorf("Unexpected data type: %d, cannot be filled with default value", dataType)
 		}

--- a/internal/util/importutilv2/csv/row_parser_test.go
+++ b/internal/util/importutilv2/csv/row_parser_test.go
@@ -131,35 +131,41 @@ func (suite *RowParserSuite) createAllTypesSchema() *schemapb.CollectionSchema {
 				Name:       "float_vector",
 				DataType:   schemapb.DataType_FloatVector,
 				TypeParams: []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "2"}},
+				Nullable:   suite.hasNullable,
 			},
 			{
 				FieldID:    22,
 				Name:       "bin_vector",
 				DataType:   schemapb.DataType_BinaryVector,
 				TypeParams: []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "16"}},
+				Nullable:   suite.hasNullable,
 			},
 			{
 				FieldID:  23,
 				Name:     "sparse_vector",
 				DataType: schemapb.DataType_SparseFloatVector,
+				Nullable: suite.hasNullable,
 			},
 			{
 				FieldID:    24,
 				Name:       "f16_vector",
 				DataType:   schemapb.DataType_Float16Vector,
 				TypeParams: []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "2"}},
+				Nullable:   suite.hasNullable,
 			},
 			{
 				FieldID:    25,
 				Name:       "bf16_vector",
 				DataType:   schemapb.DataType_BFloat16Vector,
 				TypeParams: []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "2"}},
+				Nullable:   suite.hasNullable,
 			},
 			{
 				FieldID:    26,
 				Name:       "int8_vector",
 				DataType:   schemapb.DataType_Int8Vector,
 				TypeParams: []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "2"}},
+				Nullable:   suite.hasNullable,
 			},
 			{
 				FieldID:          27,
@@ -648,6 +654,12 @@ func (suite *RowParserSuite) TestValid() {
 	suite.runValid(&testCase{name: "A/N/D nullable field varchar is nil", content: suite.genAllTypesRowData("varchar", suite.nullKey)})
 	suite.runValid(&testCase{name: "A/N/D nullable field json is nil", content: suite.genAllTypesRowData("json", suite.nullKey)})
 	suite.runValid(&testCase{name: "A/N/D nullable field array_int8 is nil", content: suite.genAllTypesRowData("array_int8", suite.nullKey)})
+	suite.runValid(&testCase{name: "A/N/D nullable field float_vector is nil", content: suite.genAllTypesRowData("float_vector", suite.nullKey)})
+	suite.runValid(&testCase{name: "A/N/D nullable field bin_vector is nil", content: suite.genAllTypesRowData("bin_vector", suite.nullKey)})
+	suite.runValid(&testCase{name: "A/N/D nullable field sparse_vector is nil", content: suite.genAllTypesRowData("sparse_vector", suite.nullKey)})
+	suite.runValid(&testCase{name: "A/N/D nullable field f16_vector is nil", content: suite.genAllTypesRowData("f16_vector", suite.nullKey)})
+	suite.runValid(&testCase{name: "A/N/D nullable field bf16_vector is nil", content: suite.genAllTypesRowData("bf16_vector", suite.nullKey)})
+	suite.runValid(&testCase{name: "A/N/D nullable field int8_vector is nil", content: suite.genAllTypesRowData("int8_vector", suite.nullKey)})
 
 	// Test struct array parsing
 	suite.runValid(&testCase{name: "A/N/D struct array valid", content: suite.genAllTypesRowData("x", "2")})
@@ -699,13 +711,6 @@ func (suite *RowParserSuite) TestParseError() {
 
 	// auto-generated pk no need to provide
 	content["id"] = "1"
-	header, _ = suite.genRowContent(schema, content)
-	parser, err = NewRowParser(schema, header, suite.nullKey)
-	suite.Error(err)
-	suite.Nil(parser)
-
-	// field value missed
-	content = suite.genAllTypesRowData("x", "2", "float_vector")
 	header, _ = suite.genRowContent(schema, content)
 	parser, err = NewRowParser(schema, header, suite.nullKey)
 	suite.Error(err)

--- a/internal/util/importutilv2/json/row_parser_test.go
+++ b/internal/util/importutilv2/json/row_parser_test.go
@@ -110,35 +110,41 @@ func (suite *RowParserSuite) createAllTypesSchema() *schemapb.CollectionSchema {
 				Name:       "float_vector",
 				DataType:   schemapb.DataType_FloatVector,
 				TypeParams: []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "2"}},
+				Nullable:   suite.hasNullable,
 			},
 			{
 				FieldID:    22,
 				Name:       "bin_vector",
 				DataType:   schemapb.DataType_BinaryVector,
 				TypeParams: []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "16"}},
+				Nullable:   suite.hasNullable,
 			},
 			{
 				FieldID:  23,
 				Name:     "sparse_vector",
 				DataType: schemapb.DataType_SparseFloatVector,
+				Nullable: suite.hasNullable,
 			},
 			{
 				FieldID:    24,
 				Name:       "f16_vector",
 				DataType:   schemapb.DataType_Float16Vector,
 				TypeParams: []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "2"}},
+				Nullable:   suite.hasNullable,
 			},
 			{
 				FieldID:    25,
 				Name:       "bf16_vector",
 				DataType:   schemapb.DataType_BFloat16Vector,
 				TypeParams: []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "2"}},
+				Nullable:   suite.hasNullable,
 			},
 			{
 				FieldID:    26,
 				Name:       "int8_vector",
 				DataType:   schemapb.DataType_Int8Vector,
 				TypeParams: []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "2"}},
+				Nullable:   suite.hasNullable,
 			},
 			{
 				FieldID:          27,
@@ -633,6 +639,12 @@ func (suite *RowParserSuite) TestValid() {
 	suite.runValid(&testCase{name: "A/N/D nullable field varchar is nil", content: suite.genAllTypesRowData("varchar", nil)})
 	suite.runValid(&testCase{name: "A/N/D nullable field json is nil", content: suite.genAllTypesRowData("json", nil)})
 	suite.runValid(&testCase{name: "A/N/D nullable field array_int8 is nil", content: suite.genAllTypesRowData("array_int8", nil)})
+	suite.runValid(&testCase{name: "A/N/D nullable field float_vector is nil", content: suite.genAllTypesRowData("float_vector", nil)})
+	suite.runValid(&testCase{name: "A/N/D nullable field bin_vector is nil", content: suite.genAllTypesRowData("bin_vector", nil)})
+	suite.runValid(&testCase{name: "A/N/D nullable field sparse_vector is nil", content: suite.genAllTypesRowData("sparse_vector", nil)})
+	suite.runValid(&testCase{name: "A/N/D nullable field f16_vector is nil", content: suite.genAllTypesRowData("f16_vector", nil)})
+	suite.runValid(&testCase{name: "A/N/D nullable field bf16_vector is nil", content: suite.genAllTypesRowData("bf16_vector", nil)})
+	suite.runValid(&testCase{name: "A/N/D nullable field int8_vector is nil", content: suite.genAllTypesRowData("int8_vector", nil)})
 
 	suite.setSchema(false, true, true)
 	suite.runValid(&testCase{name: "N/D valid parse", content: suite.genAllTypesRowData("x", 2)})
@@ -675,7 +687,6 @@ func (suite *RowParserSuite) TestParseError() {
 			{name: "not a JSON for dynamic", content: suite.genAllTypesRowData("$meta", []int{})},
 			{name: "exceeds max length varchar", content: suite.genAllTypesRowData("varchar", "aaaaaaaaaa")},
 			{name: "exceeds max capacity", content: suite.genAllTypesRowData("array_int8", []int{1, 2, 3, 4, 5})},
-			{name: "field value missed", content: suite.genAllTypesRowData("x", 2, "float_vector")},
 			{name: "type error bool", content: suite.genAllTypesRowData("bool", 0.2)},
 			{name: "type error int8", content: suite.genAllTypesRowData("int8", []int32{})},
 			{name: "type error int16", content: suite.genAllTypesRowData("int16", []int32{})},

--- a/internal/util/importutilv2/numpy/reader_test.go
+++ b/internal/util/importutilv2/numpy/reader_test.go
@@ -433,18 +433,18 @@ func (suite *ReaderSuite) TestStringPK() {
 }
 
 func (suite *ReaderSuite) TestVector() {
-	suite.vecDataType = schemapb.DataType_BinaryVector
-	suite.run(schemapb.DataType_Int32)
-	suite.vecDataType = schemapb.DataType_FloatVector
-	suite.run(schemapb.DataType_Int32)
-	suite.vecDataType = schemapb.DataType_Float16Vector
-	suite.run(schemapb.DataType_Int32)
-	suite.vecDataType = schemapb.DataType_BFloat16Vector
-	suite.run(schemapb.DataType_Int32)
-	// suite.vecDataType = schemapb.DataType_SparseFloatVector
-	// suite.run(schemapb.DataType_Int32)
-	suite.vecDataType = schemapb.DataType_Int8Vector
-	suite.run(schemapb.DataType_Int32)
+	dataTypes := []schemapb.DataType{
+		schemapb.DataType_BinaryVector,
+		schemapb.DataType_FloatVector,
+		schemapb.DataType_Float16Vector,
+		schemapb.DataType_BFloat16Vector,
+		schemapb.DataType_Int8Vector,
+	}
+
+	for _, dataType := range dataTypes {
+		suite.vecDataType = dataType
+		suite.run(schemapb.DataType_Int32)
+	}
 }
 
 func TestNumpyCreateReaders(t *testing.T) {

--- a/internal/util/importutilv2/parquet/reader_test.go
+++ b/internal/util/importutilv2/parquet/reader_test.go
@@ -450,8 +450,10 @@ func (s *ReaderSuite) runWithSparseVector(indicesType arrow.DataType, valuesType
 		builder.AppendValues(int64Data, validData)
 		arrowColumns = append(arrowColumns, builder.NewInt64Array())
 
-		contents := insertData.Data[schema.Fields[1].FieldID].(*storage.SparseFloatVectorFieldData).GetContents()
-		arr, err := testutil.BuildSparseVectorData(mem, contents, arrowFields[1].Type)
+		sparseFieldData := insertData.Data[schema.Fields[1].FieldID].(*storage.SparseFloatVectorFieldData)
+		contents := sparseFieldData.GetContents()
+		sparseValidData := sparseFieldData.ValidData
+		arr, err := testutil.BuildSparseVectorData(mem, contents, arrowFields[1].Type, sparseValidData)
 		assert.NoError(s.T(), err)
 		arrowColumns = append(arrowColumns, arr)
 
@@ -545,65 +547,34 @@ func (s *ReaderSuite) TestReadScalarFieldsWithDefaultValue() {
 }
 
 func (s *ReaderSuite) TestReadScalarFields() {
-	s.run(schemapb.DataType_Bool, schemapb.DataType_None, false, 0)
-	s.run(schemapb.DataType_Int8, schemapb.DataType_None, false, 0)
-	s.run(schemapb.DataType_Int16, schemapb.DataType_None, false, 0)
-	s.run(schemapb.DataType_Int32, schemapb.DataType_None, false, 0)
-	s.run(schemapb.DataType_Int64, schemapb.DataType_None, false, 0)
-	s.run(schemapb.DataType_Float, schemapb.DataType_None, false, 0)
-	s.run(schemapb.DataType_Double, schemapb.DataType_None, false, 0)
-	s.run(schemapb.DataType_String, schemapb.DataType_None, false, 0)
-	s.run(schemapb.DataType_VarChar, schemapb.DataType_None, false, 0)
-	s.run(schemapb.DataType_JSON, schemapb.DataType_None, false, 0)
-	s.run(schemapb.DataType_Geometry, schemapb.DataType_None, false, 0)
+	elementTypes := []schemapb.DataType{
+		schemapb.DataType_Bool,
+		schemapb.DataType_Int8,
+		schemapb.DataType_Int16,
+		schemapb.DataType_Int32,
+		schemapb.DataType_Int64,
+		schemapb.DataType_Float,
+		schemapb.DataType_Double,
+		schemapb.DataType_String,
+	}
 
-	s.run(schemapb.DataType_Array, schemapb.DataType_Bool, false, 0)
-	s.run(schemapb.DataType_Array, schemapb.DataType_Int8, false, 0)
-	s.run(schemapb.DataType_Array, schemapb.DataType_Int16, false, 0)
-	s.run(schemapb.DataType_Array, schemapb.DataType_Int32, false, 0)
-	s.run(schemapb.DataType_Array, schemapb.DataType_Int64, false, 0)
-	s.run(schemapb.DataType_Array, schemapb.DataType_Float, false, 0)
-	s.run(schemapb.DataType_Array, schemapb.DataType_Double, false, 0)
-	s.run(schemapb.DataType_Array, schemapb.DataType_String, false, 0)
+	scalarTypes := append(elementTypes, []schemapb.DataType{schemapb.DataType_VarChar, schemapb.DataType_JSON, schemapb.DataType_Geometry, schemapb.DataType_Array}...)
 
-	s.run(schemapb.DataType_Bool, schemapb.DataType_None, true, 50)
-	s.run(schemapb.DataType_Int8, schemapb.DataType_None, true, 50)
-	s.run(schemapb.DataType_Int16, schemapb.DataType_None, true, 50)
-	s.run(schemapb.DataType_Int32, schemapb.DataType_None, true, 50)
-	s.run(schemapb.DataType_Int64, schemapb.DataType_None, true, 50)
-	s.run(schemapb.DataType_Float, schemapb.DataType_None, true, 50)
-	s.run(schemapb.DataType_String, schemapb.DataType_None, true, 50)
-	s.run(schemapb.DataType_VarChar, schemapb.DataType_None, true, 50)
-	s.run(schemapb.DataType_JSON, schemapb.DataType_None, true, 50)
-
-	s.run(schemapb.DataType_Array, schemapb.DataType_Bool, true, 50)
-	s.run(schemapb.DataType_Array, schemapb.DataType_Int8, true, 50)
-	s.run(schemapb.DataType_Array, schemapb.DataType_Int16, true, 50)
-	s.run(schemapb.DataType_Array, schemapb.DataType_Int32, true, 50)
-	s.run(schemapb.DataType_Array, schemapb.DataType_Int64, true, 50)
-	s.run(schemapb.DataType_Array, schemapb.DataType_Float, true, 50)
-	s.run(schemapb.DataType_Array, schemapb.DataType_Double, true, 50)
-	s.run(schemapb.DataType_Array, schemapb.DataType_String, true, 50)
-
-	s.run(schemapb.DataType_Bool, schemapb.DataType_None, true, 100)
-	s.run(schemapb.DataType_Int8, schemapb.DataType_None, true, 100)
-	s.run(schemapb.DataType_Int16, schemapb.DataType_None, true, 100)
-	s.run(schemapb.DataType_Int32, schemapb.DataType_None, true, 100)
-	s.run(schemapb.DataType_Int64, schemapb.DataType_None, true, 100)
-	s.run(schemapb.DataType_Float, schemapb.DataType_None, true, 100)
-	s.run(schemapb.DataType_String, schemapb.DataType_None, true, 100)
-	s.run(schemapb.DataType_VarChar, schemapb.DataType_None, true, 100)
-	s.run(schemapb.DataType_JSON, schemapb.DataType_None, true, 100)
-	s.run(schemapb.DataType_Geometry, schemapb.DataType_None, true, 100)
-
-	s.run(schemapb.DataType_Array, schemapb.DataType_Bool, true, 100)
-	s.run(schemapb.DataType_Array, schemapb.DataType_Int8, true, 100)
-	s.run(schemapb.DataType_Array, schemapb.DataType_Int16, true, 100)
-	s.run(schemapb.DataType_Array, schemapb.DataType_Int32, true, 100)
-	s.run(schemapb.DataType_Array, schemapb.DataType_Int64, true, 100)
-	s.run(schemapb.DataType_Array, schemapb.DataType_Float, true, 100)
-	s.run(schemapb.DataType_Array, schemapb.DataType_Double, true, 100)
-	s.run(schemapb.DataType_Array, schemapb.DataType_String, true, 100)
+	for _, dataType := range scalarTypes {
+		if dataType == schemapb.DataType_Array {
+			for _, elementType := range elementTypes {
+				s.run(dataType, elementType, false, 0)
+				for _, nullPercent := range []int{0, 50, 100} {
+					s.run(dataType, elementType, true, nullPercent)
+				}
+			}
+		} else {
+			s.run(dataType, schemapb.DataType_None, false, 0)
+			for _, nullPercent := range []int{0, 50, 100} {
+				s.run(dataType, schemapb.DataType_None, true, nullPercent)
+			}
+		}
+	}
 
 	s.failRun(schemapb.DataType_JSON, true)
 }
@@ -611,24 +582,28 @@ func (s *ReaderSuite) TestReadScalarFields() {
 func (s *ReaderSuite) TestStringPK() {
 	s.pkDataType = schemapb.DataType_VarChar
 	s.run(schemapb.DataType_Int32, schemapb.DataType_None, false, 0)
-	s.run(schemapb.DataType_Int32, schemapb.DataType_None, true, 50)
-	s.run(schemapb.DataType_Int32, schemapb.DataType_None, true, 100)
+	for _, nullPercent := range []int{0, 50, 100} {
+		s.run(schemapb.DataType_Int32, schemapb.DataType_None, true, nullPercent)
+	}
 }
 
 func (s *ReaderSuite) TestVector() {
-	s.vecDataType = schemapb.DataType_BinaryVector
-	s.run(schemapb.DataType_Int32, schemapb.DataType_None, false, 0)
-	s.vecDataType = schemapb.DataType_FloatVector
-	s.run(schemapb.DataType_Int32, schemapb.DataType_None, false, 0)
-	s.vecDataType = schemapb.DataType_Float16Vector
-	s.run(schemapb.DataType_Int32, schemapb.DataType_None, false, 0)
-	s.vecDataType = schemapb.DataType_BFloat16Vector
-	s.run(schemapb.DataType_Int32, schemapb.DataType_None, false, 0)
-	// this test case only test parsing sparse vector from JSON-format string
-	s.vecDataType = schemapb.DataType_SparseFloatVector
-	s.run(schemapb.DataType_Int32, schemapb.DataType_None, false, 0)
-	s.vecDataType = schemapb.DataType_Int8Vector
-	s.run(schemapb.DataType_Int32, schemapb.DataType_None, false, 0)
+	dataTypes := []schemapb.DataType{
+		schemapb.DataType_BinaryVector,
+		schemapb.DataType_FloatVector,
+		schemapb.DataType_Float16Vector,
+		schemapb.DataType_BFloat16Vector,
+		schemapb.DataType_SparseFloatVector,
+		schemapb.DataType_Int8Vector,
+	}
+
+	for _, dataType := range dataTypes {
+		s.vecDataType = dataType
+		s.run(schemapb.DataType_Int32, schemapb.DataType_None, false, 0)
+		for _, nullPercent := range []int{0, 50, 100} {
+			s.run(schemapb.DataType_Int32, schemapb.DataType_None, true, nullPercent)
+		}
+	}
 }
 
 func (s *ReaderSuite) TestSparseVector() {


### PR DESCRIPTION
related: #45993 

Add nullable vector support in import utility layer
    
Key changes:

ImportV2 util:
- Add nullable vector types (FloatVector, Float16Vector, BFloat16Vector,
  BinaryVector, SparseFloatVector, Int8Vector) to AppendNullableDefaultFieldsData()
- Add tests for nullable vector field data appending

CSV/JSON/Numpy readers:
- Add nullPercent parameter to test data generation for better null coverage
- Mark vector fields as nullable in test schemas
- Add test cases for nullable vector field parsing
- Refactor tests to use loop-based approach with 0%, 50%, 100% null percentages

Parquet field reader:
- Add ReadNullableBinaryData() for nullable BinaryVector/Float16Vector/BFloat16Vector
- Add ReadNullableFloatVectorData() for nullable FloatVector
- Add ReadNullableSparseFloatVectorData() for nullable SparseFloatVector
- Add ReadNullableInt8VectorData() for nullable Int8Vector
- Add ReadNullableStructData() for generic nullable struct data
- Update Next() to use nullable read methods when field is nullable
- Add null data validation for non-nullable fields

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Core invariant: import must preserve per-row alignment and validity for every field — nullable vector fields are expected to be encoded with per-row validity masks and all readers/writers must emit arrays aligned to original input rows (null entries represented explicitly).
- New feature & scope: adds end-to-end nullable-vector support in the import utility layer — AppendNullableDefaultFieldsData in internal/datanode/importv2/util.go now appends nil placeholders for nullable vectors (FloatVector, Float16Vector, BFloat16Vector, BinaryVector, SparseFloatVector, Int8Vector); parquet reader (internal/util/importutilv2/parquet/field_reader.go) adds ReadNullableBinaryData, ReadNullableFloatVectorData, ReadNullableSparseFloatVectorData, ReadNullableInt8VectorData, ReadNullableStructData and routes nullable branches to these helpers; CSV/JSON/Numpy readers and test utilities updated to generate and validate 0/50/100% null scenarios and mark vector fields as nullable in test schemas.
- Logic removed / simplified: eliminates ad-hoc "parameter-invalid" rejections for nullable vectors inside FieldReader.Next by centralizing nullable handling into ReadNullable* helpers and shared validators (getArrayDataNullable, checkNullableVectorAlignWithDim/checkNullableVectorAligned), simplifying control flow and removing scattered special-case checks.
- No data loss / no regression (concrete code paths): nulls are preserved end-to-end — AppendNullableDefaultFieldsData explicitly inserts nil entries per null row (datanode import append path); ReadNullable*Data helpers return both data and []bool validity masks so callers in field_reader.go and downstream readers receive exact per-row validity; testutil.BuildSparseVectorData was extended to accept validData so sparse vectors are materialized only for valid rows while null rows are represented as missing. These concrete paths ensure null rows are represented rather than dropped, preventing data loss or behavioral regression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->