### PR TITLE
enhance: [2.6] use specified manifest version in loon ffi reader (#46101)

### DIFF
--- a/internal/core/src/storage/loon_ffi/util.h
+++ b/internal/core/src/storage/loon_ffi/util.h
@@ -77,21 +77,6 @@ CStorageConfig
 ToCStorageConfig(const milvus::storage::StorageConfig& config);
 
 /**
- * @brief Retrieve manifest/column groups from storage via FFI
- *
- * Parses the manifest path JSON to extract base_path and version,
- * then fetches the latest column groups from storage using FFI.
- *
- * @param path JSON string containing "base_path" and "ver" fields
- * @param properties Storage properties for accessing the manifest
- * @return JSON string containing column groups information
- * @throws std::runtime_error If JSON parsing fails or FFI call fails
- */
-std::string
-GetManifest(const std::string& path,
-            const std::shared_ptr<Properties>& properties);
-
-/**
  * @brief Retrieve ColumnGroups metadata from manifest path
  *
  * Parses the manifest path JSON and fetches the latest manifest

--- a/internal/core/thirdparty/milvus-storage/CMakeLists.txt
+++ b/internal/core/thirdparty/milvus-storage/CMakeLists.txt
@@ -14,7 +14,7 @@
 # Update milvus-storage_VERSION for the first occurrence
 milvus_add_pkg_config("milvus-storage")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( milvus-storage_VERSION 5fff4f5)
+set( milvus-storage_VERSION 33bf815)
 set( GIT_REPOSITORY  "https://github.com/milvus-io/milvus-storage.git")
 message(STATUS "milvus-storage repo: ${GIT_REPOSITORY}")
 message(STATUS "milvus-storage version: ${milvus-storage_VERSION}")

--- a/internal/storagev2/packed/packed_reader_ffi.go
+++ b/internal/storagev2/packed/packed_reader_ffi.go
@@ -201,8 +201,7 @@ func GetColumnGroups(manifestPath string, storageConfig *indexpb.StorageConfig) 
 	cBasePath := C.CString(basePath)
 	defer C.free(unsafe.Pointer(cBasePath))
 
-	var cVersion C.int64_t
-	result := C.get_latest_column_groups(cBasePath, cProperties, &cColumnGroups, &cVersion)
+	result := C.get_column_groups_by_version(cBasePath, cProperties, C.int64_t(version), &cColumnGroups)
 	err = HandleFFIResult(result)
 	if err != nil {
 		return cColumnGroups, err


### PR DESCRIPTION
Cherry-pick from master
pr: #46101
Related to #44956

Use the exact manifest version from the path parameter instead of always fetching the latest manifest. This ensures data consistency by reading from the specific version that was requested.

Changes:
- Update GetColumnGroups to use transaction.begin(version) with the specified version from the path JSON
- Replace get_latest_manifest() with get_current_manifest() after beginning transaction at the target version
- Update Go FFI binding to call get_column_groups_by_version instead of get_latest_column_groups
- Remove unused GetManifest function from util.cpp/util.h
- Bump milvus-storage version from 5fff4f5 to 33bf815