### PR TITLE
enhance: add debug logs for collection load path

### DIFF
--- a/internal/querycoordv2/job/job_load.go
+++ b/internal/querycoordv2/job/job_load.go
@@ -93,15 +93,27 @@ func NewLoadCollectionJob(
 func (job *LoadCollectionJob) Execute() error {
 	req := job.result.Message.Header()
 	log := log.Ctx(job.ctx).With(zap.Int64("collectionID", req.GetCollectionId()))
+	log.Debug("start executing load collection job",
+		zap.Int64("dbID", req.GetDbId()),
+		zap.Int64s("partitionIDs", req.GetPartitionIds()),
+		zap.Int("numChannels", len(vchannels)),
+		zap.Int("numReplicas", len(req.GetReplicas())),
+	)
 	meta.GlobalFailedLoadCache.Remove(req.GetCollectionId())
 
+	log.Debug("describing collection from broker")
 	collInfo, err := job.broker.DescribeCollection(job.ctx, req.GetCollectionId())
 	if errors.Is(err, merr.ErrCollectionNotFound) {
 		return nil
 	}
 	if err != nil {
+		log.Debug("failed to describe collection", zap.Error(err))
 		return err
 	}
+	log.Debug("described collection successfully",
+		zap.String("collectionName", collInfo.GetSchema().GetName()),
+		zap.Int("numFields", len(collInfo.GetSchema().GetFields())),
+	)
 
 	// 1. resolve replica config: use local cluster-level config if this is a replicated message
 	replicas := req.GetReplicas()
@@ -116,13 +128,16 @@ func (job *LoadCollectionJob) Execute() error {
 	}
 
 	// 2. create replica if not exist (may also remove redundant replicas)
+	log.Debug("spawning replicas with replica config")
 	if _, err := utils.SpawnReplicasWithReplicaConfig(job.ctx, job.meta, meta.SpawnWithReplicaConfigParams{
 		CollectionID: req.GetCollectionId(),
 		Channels:     collInfo.GetVirtualChannelNames(),
 		Configs:      replicas,
 	}); err != nil {
+		log.Debug("failed to spawn replicas", zap.Error(err))
 		return err
 	}
+	log.Debug("spawned replicas successfully")
 
 	// 2.1 invalidate shard leader cache after replica changes, so proxies stop
 	// routing to released replicas' shard leaders before async cleanup happens.
@@ -201,11 +216,17 @@ func (job *LoadCollectionJob) Execute() error {
 	)
 
 	// 5. update next target, no need to rollback if pull target failed, target observer will pull target in periodically
+	log.Debug("updating next target")
 	if _, err = job.targetObserver.UpdateNextTarget(req.GetCollectionId()); err != nil {
+		log.Debug("failed to update next target", zap.Error(err))
 		return err
 	}
+	log.Debug("updated next target successfully")
 
 	// 6. register load task into collection observer
+	log.Debug("registering load task into collection observer",
+		zap.Int("numPartitions", len(incomingPartitions.Collect())),
+	)
 	job.collectionObserver.LoadPartitions(ctx, req.GetCollectionId(), incomingPartitions.Collect())
 
 	// 7. wait for partition released if any partition is released

--- a/internal/querycoordv2/observers/collection_observer.go
+++ b/internal/querycoordv2/observers/collection_observer.go
@@ -150,6 +150,10 @@ func (ob *CollectionObserver) LoadCollection(ctx context.Context, collectionID i
 		key = fmt.Sprintf("LoadCollection_%d", collectionID)
 	}
 
+	log.Ctx(ctx).Debug("registering load collection task",
+		zap.Int64("collectionID", collectionID),
+		zap.String("traceID", key),
+	)
 	ob.loadTasks.Insert(key, LoadTask{LoadType: querypb.LoadType_LoadCollection, CollectionID: collectionID})
 	ob.checkerController.Check()
 }
@@ -163,6 +167,11 @@ func (ob *CollectionObserver) LoadPartitions(ctx context.Context, collectionID i
 		key = fmt.Sprintf("LoadPartition_%d_%v", collectionID, partitionIDs)
 	}
 
+	log.Ctx(ctx).Debug("registering load partitions task",
+		zap.Int64("collectionID", collectionID),
+		zap.Int64s("partitionIDs", partitionIDs),
+		zap.String("traceID", key),
+	)
 	ob.loadTasks.Insert(key, LoadTask{LoadType: querypb.LoadType_LoadPartition, CollectionID: collectionID, PartitionIDs: partitionIDs})
 	ob.checkerController.Check()
 }


### PR DESCRIPTION
## Summary
Add debug logs at key checkpoints in the collection load process to help with debugging and monitoring.

### Changes
- LoadCollectionJob.Execute() entry with metadata
- Replica spawning start/completion
- Collection description from broker
- Target update operations
- Collection observer task registration

Closes #45864

## Type of change
- [x] Enhancement