### PR TITLE
fix: print result size in error message

### DIFF
--- a/internal/core/src/segcore/SegmentInterface.cpp
+++ b/internal/core/src/segcore/SegmentInterface.cpp
@@ -142,9 +142,10 @@ SegmentInternalInterface::Retrieve(tracer::TraceContext* trace_ctx,
         output_data_size += get_field_avg_size(field_id) * result_rows;
     }
     if (output_data_size > limit_size) {
-        ThrowInfo(
-            RetrieveError,
-            fmt::format("query results exceed the limit size ", limit_size));
+        ThrowInfo(RetrieveError,
+                  fmt::format("query results exceed the limit size {} vs {}",
+                              output_data_size,
+                              limit_size));
     }
 
     results->set_all_retrieve_count(retrieve_results.total_data_cnt_);

--- a/internal/proxy/task_query.go
+++ b/internal/proxy/task_query.go
@@ -823,7 +823,7 @@ func reduceRetrieveResults(ctx context.Context, retrieveResults []*internalpb.Re
 
 		// limit retrieve result to avoid oom
 		if retSize > maxOutputSize {
-			return nil, fmt.Errorf("query results exceed the maxOutputSize Limit %d", maxOutputSize)
+			return nil, fmt.Errorf("query results exceed the maxOutputSize Limit %d vs %d", retSize, maxOutputSize)
 		}
 
 		cursors[sel]++


### PR DESCRIPTION
properly printing result size and limit in error message