### PR TITLE
test: upgrade minio sdk from 7.1.5 to 7.2.0

### DIFF
--- a/tests/python_client/requirements.txt
+++ b/tests/python_client/requirements.txt
@@ -38,7 +38,7 @@ python-benedict==0.24.3
 timeout-decorator==0.5.0
 
 # for bulk insert test
-minio==7.1.5
+minio==7.2.0
 npy-append-array==0.9.15
 Faker==19.2.0
 

--- a/tests/restful_client_v2/requirements.txt
+++ b/tests/restful_client_v2/requirements.txt
@@ -9,7 +9,7 @@ Faker==19.2.0
 pymilvus==2.5.0rc108
 scikit-learn>=1.5.2
 pytest-xdist==2.5.0
-minio==7.1.14
+minio==7.2.0
 tenacity==8.1.0
 # for bf16 datatype
 ml-dtypes==0.2.0

--- a/tests/scripts/ci-util.sh
+++ b/tests/scripts/ci-util.sh
@@ -37,10 +37,12 @@ function install_pytest_requirements(){
  echo "Install pytest requirements"
  cd ${ROOT}/tests/python_client
  
-export PIP_TRUSTED_HOST="nexus-nexus-repository-manager.nexus"
-export PIP_INDEX_URL="http://nexus-nexus-repository-manager.nexus:8081/repository/pypi-all/simple"
-export PIP_INDEX="http://nexus-nexus-repository-manager.nexus:8081/repository/pypi-all/pypi"
-export PIP_FIND_LINKS="http://nexus-nexus-repository-manager.nexus:8081/repository/pypi-all/pypi"
+
+
+export PIP_TRUSTED_HOST="nexus.zilliz.cc"
+export PIP_INDEX_URL="https://nexus.zilliz.cc/repository/pypi-proxy/simple"
+export PIP_INDEX="https://nexus.zilliz.cc/repository/pypi-proxy/pypi"
+export PIP_FIND_LINKS="https://nexus.zilliz.cc/repository/pypi-proxy/pypi"
  python3 -m pip install --no-cache-dir -r requirements.txt --timeout 300 --retries 6
 }
 


### PR DESCRIPTION

/kind improvement


fix minio sdk error
```
2025-12-08T07:54:48Z {container="step-test"} def _put_object(self, bucket_name, object_name, data, headers, 

2025-12-08T07:54:48Z {container="step-test"} query_params=None): 

2025-12-08T07:54:48Z {container="step-test"} """Execute PutObject S3 API.""" 

2025-12-08T07:54:48Z {container="step-test"} response = self._execute( 

2025-12-08T07:54:48Z {container="step-test"} "PUT", 

2025-12-08T07:54:48Z {container="step-test"} bucket_name, 

2025-12-08T07:54:48Z {container="step-test"} object_name, 

2025-12-08T07:54:48Z {container="step-test"} body=data, 

2025-12-08T07:54:48Z {container="step-test"} headers=headers, 

2025-12-08T07:54:48Z {container="step-test"} query_params=query_params, 

2025-12-08T07:54:48Z {container="step-test"} no_body_trace=True, 

2025-12-08T07:54:48Z {container="step-test"} ) 

2025-12-08T07:54:48Z {container="step-test"} return ObjectWriteResult( 

2025-12-08T07:54:48Z {container="step-test"} bucket_name, 

2025-12-08T07:54:48Z {container="step-test"} object_name, 

2025-12-08T07:54:48Z {container="step-test"} >           response.getheader("x-amz-version-id"), 

2025-12-08T07:54:48Z {container="step-test"} response.getheader("etag").replace('"', ""), 

2025-12-08T07:54:48Z {container="step-test"} response.getheaders(), 

2025-12-08T07:54:48Z {container="step-test"} ) 

2025-12-08T07:54:48Z {container="step-test"} E       AttributeError: 'HTTPResponse' object has no attribute 'getheader' 

2025-12-08T07:54:48Z {container="step-test"}  

2025-12-08T07:54:48Z {container="step-test"} /usr/local/lib/python3.10/site-packages/minio/api.py:1582: AttributeError
```