### PR TITLE
fix: fill partition_id in load index info and close RemoteOutputStream properly

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -259,6 +259,7 @@ ChunkedSegmentSealedImpl::ConvertFieldIndexInfoToLoadIndexInfo(
     // Extract field ID
     auto field_id = FieldId(field_index_info->fieldid());
     load_index_info.field_id = field_id.get();
+    load_index_info.partition_id = segment_load_info_.partitionid();
 
     // Get field type from schema
     const auto& field_meta = get_schema()[field_id];

--- a/internal/core/src/storage/RemoteOutputStream.cpp
+++ b/internal/core/src/storage/RemoteOutputStream.cpp
@@ -11,6 +11,12 @@ RemoteOutputStream::RemoteOutputStream(
     : output_stream_(std::move(output_stream)) {
 }
 
+RemoteOutputStream::~RemoteOutputStream() {
+    // temp solution, will expose `Close` method in OutputStream later
+    auto status = output_stream_->Close();
+    AssertInfo(status.ok(), "Failed to close output stream");
+}
+
 size_t
 RemoteOutputStream::Tell() const {
     auto status = output_stream_->Tell();

--- a/internal/core/src/storage/RemoteOutputStream.h
+++ b/internal/core/src/storage/RemoteOutputStream.h
@@ -21,7 +21,7 @@ class RemoteOutputStream : public milvus::OutputStream {
     explicit RemoteOutputStream(
         std::shared_ptr<arrow::io::OutputStream>&& output_stream);
 
-    ~RemoteOutputStream() override = default;
+    ~RemoteOutputStream() override;
 
     size_t
     Tell() const override;


### PR DESCRIPTION
This PR fixes two issues related to segment loading and index deserialization:

1. Fill partition_id in LoadIndexInfo when converting field index info, which is required by cardinal (DiskANN) index deserialization.

2. Close RemoteOutputStream in destructor to ensure buffer flushed and resources released properly.

issue: #46141