### PR TITLE
fix:[hotfix] char_group tokenizer only support one byte char as delimiters

### DIFF
--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/tokenizers/char_group_tokenizer.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/tokenizers/char_group_tokenizer.rs
@@ -85,7 +85,7 @@ impl CharGroupTokenizer {
                                         .to_string(),
                                 )),
                                 |v| {
-                                    if v.len() == 1 {
+                                    if v.chars().count() == 1 {
                                         delimiters.insert(v.chars().next().unwrap());
                                         return Ok(());
                                     }
@@ -204,7 +204,7 @@ mod tests {
     fn test_char_group_tokenizer() {
         let params = r#"{
             "type": "chargroup",
-            "delimiters": ["o", "punctuation","digit"]
+            "delimiters": ["o", "punctuation","digit", "，"]
         }"#;
         let json_param = json::from_str::<json::Map<String, json::Value>>(&params);
         assert!(json_param.is_ok());


### PR DESCRIPTION
pr: https://github.com/milvus-io/milvus/pull/46193
relate: https://github.com/milvus-io/milvus/issues/46192