### PR TITLE
test: fix timestamptz e2e case failure on Jenkins Weekly

### DIFF
--- a/tests/python_client/check/param_check.py
+++ b/tests/python_client/check/param_check.py
@@ -190,6 +190,12 @@ def compare_lists_with_epsilon_ignore_dict_order_deepdiff(a, b, epsilon=epsilon)
     # Normalize both lists to handle type differences
     a_normalized = normalize_value(a)
     b_normalized = normalize_value(b)
+
+    # Check length first
+    if len(a_normalized) != len(b_normalized):
+        log.debug(f"[COMPARE_LISTS] Length mismatch: Query result length({len(a_normalized)}) != Expected result length({len(b_normalized)})")
+        return False
+    
     for i in range(len(a_normalized)):
         diff = DeepDiff(
             a_normalized[i],
@@ -201,7 +207,9 @@ def compare_lists_with_epsilon_ignore_dict_order_deepdiff(a, b, epsilon=epsilon)
             ignore_string_type_changes=True,
         )
         if diff:
-            log.debug(f"[COMPARE_LISTS] Found differences at row {i}: {diff}")
+            log.debug(f"[COMPARE_LISTS] Found differences: {diff}")
+            return False
+    return True
 
 def ip_check(ip):
     if ip == "localhost":

--- a/tests/python_client/check/param_check.py
+++ b/tests/python_client/check/param_check.py
@@ -207,7 +207,7 @@ def compare_lists_with_epsilon_ignore_dict_order_deepdiff(a, b, epsilon=epsilon)
             ignore_string_type_changes=True,
         )
         if diff:
-            log.debug(f"[COMPARE_LISTS] Found differences: {diff}")
+            log.debug(f"[COMPARE_LISTS] Found differences at row {i}: {diff}")
             return False
     return True
 

--- a/tests/python_client/common/common_func.py
+++ b/tests/python_client/common/common_func.py
@@ -4370,11 +4370,11 @@ def convert_timestamptz(rows, timestamptz_field_name, timezone="UTC"):
             target_minutes = 480 if timezone == 'Asia/Shanghai' else 0
             try:
                 # Try to get actual offset from timezone if possible
-                if 1 <= uy <= 9999:
-                    test_dt = datetime(uy, um, ud, uh, umi, uss, tzinfo=tzmod.utc)
-                    test_target = test_dt.astimezone(ZoneInfo(timezone))
-                    off_td = test_target.utcoffset() or tzmod.utc.utcoffset(test_target)
-                    target_minutes = int(off_td.total_seconds() // 60)
+                test_year = uy if (1 <= uy <= 9999) else 2004
+                test_dt = datetime(test_year, um, ud, uh, umi, uss, tzinfo=tzmod.utc)
+                test_target = test_dt.astimezone(ZoneInfo(timezone))
+                off_td = test_target.utcoffset() or tzmod.utc.utcoffset(test_target)
+                target_minutes = int(off_td.total_seconds() // 60)
             except Exception:
                 pass
             # Convert UTC to local time: UTC + offset = local

--- a/tests/python_client/common/common_func.py
+++ b/tests/python_client/common/common_func.py
@@ -4208,9 +4208,9 @@ def convert_timestamptz(rows, timestamptz_field_name, timezone="UTC"):
     iso_offset_re = re.compile(r"([+-])(\d{2}):(\d{2})$")
 
     def _days_in_month(year: int, month: int) -> int:
-        if month in (1, 3, 5, 7, 9, 10, 12):
+        if month in (1, 3, 5, 7, 8, 10, 12):
             return 31
-        if month in (4, 6, 8, 11):
+        if month in (4, 6, 9, 11):
             return 30
         # February
         is_leap = (year % 4 == 0 and (year % 100 != 0 or year % 400 == 0))

--- a/tests/python_client/milvus_client/test_milvus_client_timestamptz.py
+++ b/tests/python_client/milvus_client/test_milvus_client_timestamptz.py
@@ -53,8 +53,6 @@ class TestMilvusClientTimestamptzValid(TestMilvusClientV2Base):
         expected: Step 3 should result success
         """
         # step 1: create collection
-        # default_dim = 3
-        # default_nb = 3
         client = self._client()
         collection_name = cf.gen_collection_name_by_testcase_name()
         schema = self.create_schema(client, enable_dynamic_field=False)[0]

--- a/tests/python_client/milvus_client/test_milvus_client_timestamptz.py
+++ b/tests/python_client/milvus_client/test_milvus_client_timestamptz.py
@@ -74,18 +74,6 @@ class TestMilvusClientTimestamptzValid(TestMilvusClientV2Base):
 
         # step 3: query the rows
         rows = cf.convert_timestamptz(rows, default_timestamp_field_name, "UTC")
-        result = self.query(client, collection_name, filter=f"{default_primary_key_field_name} >= 0")
-        for i in range(default_nb):
-            expected_result = rows[i]
-            result_result = result[0][i]
-            print("================================")
-            print(f"expected_result: {expected_result[default_timestamp_field_name]}")
-            print(f"result_result: {result_result[default_timestamp_field_name]}")
-            if expected_result[default_timestamp_field_name] != result_result[default_timestamp_field_name]:
-                print(f"results mismatch❌")
-            else:
-                print(f"results match✅")
-            print("================================")
         self.query(client, collection_name, filter=f"{default_primary_key_field_name} >= 0",
                             check_task=CheckTasks.check_query_results,
                             check_items={exp_res: rows,

--- a/tests/python_client/milvus_client/test_milvus_client_timestamptz.py
+++ b/tests/python_client/milvus_client/test_milvus_client_timestamptz.py
@@ -86,13 +86,6 @@ class TestMilvusClientTimestamptzValid(TestMilvusClientV2Base):
             else:
                 print(f"results match✅")
             print("================================")
-            print(f"expected_result: {expected_result[default_vector_field_name]}")
-            print(f"result_result: {result_result[default_vector_field_name]}")
-            if expected_result[default_vector_field_name] != result_result[default_vector_field_name]:
-                print(f"vector results mismatch❌")
-            else:
-                print(f"vector results match✅")
-            print("================================")
         self.query(client, collection_name, filter=f"{default_primary_key_field_name} >= 0",
                             check_task=CheckTasks.check_query_results,
                             check_items={exp_res: rows,
@@ -145,7 +138,8 @@ class TestMilvusClientTimestamptzValid(TestMilvusClientV2Base):
         self.query(client, collection_name, filter=f"{default_primary_key_field_name} >= 0",
                             check_task=CheckTasks.check_query_results,
                             check_items={exp_res: new_rows,
-                                         "pk_name": default_primary_key_field_name})
+                                         "pk_name": default_primary_key_field_name,
+                                         "debug_mode": True})
         
         self.drop_collection(client, collection_name)
         self.drop_database(client, db_name)
@@ -189,7 +183,8 @@ class TestMilvusClientTimestamptzValid(TestMilvusClientV2Base):
         self.query(client, collection_name, filter=f"{default_primary_key_field_name} >= 0",
                    check_task=CheckTasks.check_query_results,
                    check_items={exp_res: new_rows,
-                                "pk_name": default_primary_key_field_name})
+                                "pk_name": default_primary_key_field_name,
+                                "debug_mode": True})
         
         self.drop_collection(client, collection_name)
 
@@ -227,7 +222,8 @@ class TestMilvusClientTimestamptzValid(TestMilvusClientV2Base):
         self.query(client, collection_name, filter=f"{default_primary_key_field_name} >= 0",
                 check_task=CheckTasks.check_query_results,
                 check_items={exp_res: rows,
-                            "pk_name": default_primary_key_field_name})
+                            "pk_name": default_primary_key_field_name,
+                            "debug_mode": True})
 
         # step 3: alter collection properties
         self.alter_collection_properties(client, collection_name, properties={"timezone": IANA_timezone})
@@ -239,7 +235,8 @@ class TestMilvusClientTimestamptzValid(TestMilvusClientV2Base):
         self.query(client, collection_name, filter=f"{default_primary_key_field_name} >= 0",
                     check_task=CheckTasks.check_query_results,
                     check_items={exp_res: new_rows,
-                                    "pk_name": default_primary_key_field_name})
+                                    "pk_name": default_primary_key_field_name,
+                                    "debug_mode": True})
         
         self.drop_collection(client, collection_name)
 

--- a/tests/python_client/milvus_client/test_milvus_client_timestamptz.py
+++ b/tests/python_client/milvus_client/test_milvus_client_timestamptz.py
@@ -135,6 +135,17 @@ class TestMilvusClientTimestamptzValid(TestMilvusClientV2Base):
 
         # step 3: query the rows
         new_rows = cf.convert_timestamptz(rows, default_timestamp_field_name, IANA_timezone)
+        result = self.query(client, collection_name, filter=f"{default_primary_key_field_name} >= 0", output_fields=[default_timestamp_field_name])
+        for i in range(default_nb):
+            print("===========================================")
+            print(f"original_result[{i}]: {rows[i][default_timestamp_field_name]}")
+            print(f"expected_result[{i}]: {new_rows[i][default_timestamp_field_name]}")
+            print(f"result_result[{i}]: {result[0][i][default_timestamp_field_name]}")
+            if new_rows[i][default_timestamp_field_name] != result[0][i][default_timestamp_field_name]:
+                print(f"❌")
+            else:
+                print(f"✅")
+
         self.query(client, collection_name, filter=f"{default_primary_key_field_name} >= 0",
                             check_task=CheckTasks.check_query_results,
                             check_items={exp_res: new_rows,

--- a/tests/python_client/milvus_client/test_milvus_client_timestamptz.py
+++ b/tests/python_client/milvus_client/test_milvus_client_timestamptz.py
@@ -89,8 +89,7 @@ class TestMilvusClientTimestamptzValid(TestMilvusClientV2Base):
         self.query(client, collection_name, filter=f"{default_primary_key_field_name} >= 0",
                             check_task=CheckTasks.check_query_results,
                             check_items={exp_res: rows,
-                                         "pk_name": default_primary_key_field_name,
-                                         "debug_mode": True})
+                                         "pk_name": default_primary_key_field_name})
 
         self.drop_collection(client, collection_name)
 
@@ -135,22 +134,10 @@ class TestMilvusClientTimestamptzValid(TestMilvusClientV2Base):
 
         # step 3: query the rows
         new_rows = cf.convert_timestamptz(rows, default_timestamp_field_name, IANA_timezone)
-        result = self.query(client, collection_name, filter=f"{default_primary_key_field_name} >= 0", output_fields=[default_timestamp_field_name])
-        for i in range(default_nb):
-            print("===========================================")
-            print(f"original_result[{i}]: {rows[i][default_timestamp_field_name]}")
-            print(f"expected_result[{i}]: {new_rows[i][default_timestamp_field_name]}")
-            print(f"result_result[{i}]: {result[0][i][default_timestamp_field_name]}")
-            if new_rows[i][default_timestamp_field_name] != result[0][i][default_timestamp_field_name]:
-                print(f"❌")
-            else:
-                print(f"✅")
-
         self.query(client, collection_name, filter=f"{default_primary_key_field_name} >= 0",
                             check_task=CheckTasks.check_query_results,
                             check_items={exp_res: new_rows,
-                                         "pk_name": default_primary_key_field_name,
-                                         "debug_mode": True})
+                                         "pk_name": default_primary_key_field_name})
         
         self.drop_collection(client, collection_name)
         self.drop_database(client, db_name)
@@ -194,8 +181,7 @@ class TestMilvusClientTimestamptzValid(TestMilvusClientV2Base):
         self.query(client, collection_name, filter=f"{default_primary_key_field_name} >= 0",
                    check_task=CheckTasks.check_query_results,
                    check_items={exp_res: new_rows,
-                                "pk_name": default_primary_key_field_name,
-                                "debug_mode": True})
+                                "pk_name": default_primary_key_field_name})
         
         self.drop_collection(client, collection_name)
 
@@ -233,8 +219,7 @@ class TestMilvusClientTimestamptzValid(TestMilvusClientV2Base):
         self.query(client, collection_name, filter=f"{default_primary_key_field_name} >= 0",
                 check_task=CheckTasks.check_query_results,
                 check_items={exp_res: rows,
-                            "pk_name": default_primary_key_field_name,
-                            "debug_mode": True})
+                            "pk_name": default_primary_key_field_name})
 
         # step 3: alter collection properties
         self.alter_collection_properties(client, collection_name, properties={"timezone": IANA_timezone})
@@ -246,8 +231,7 @@ class TestMilvusClientTimestamptzValid(TestMilvusClientV2Base):
         self.query(client, collection_name, filter=f"{default_primary_key_field_name} >= 0",
                     check_task=CheckTasks.check_query_results,
                     check_items={exp_res: new_rows,
-                                    "pk_name": default_primary_key_field_name,
-                                    "debug_mode": True})
+                                    "pk_name": default_primary_key_field_name})
         
         self.drop_collection(client, collection_name)
 

--- a/tests/python_client/milvus_client/test_milvus_client_timestamptz.py
+++ b/tests/python_client/milvus_client/test_milvus_client_timestamptz.py
@@ -53,6 +53,8 @@ class TestMilvusClientTimestamptzValid(TestMilvusClientV2Base):
         expected: Step 3 should result success
         """
         # step 1: create collection
+        # default_dim = 3
+        # default_nb = 3
         client = self._client()
         collection_name = cf.gen_collection_name_by_testcase_name()
         schema = self.create_schema(client, enable_dynamic_field=False)[0]
@@ -72,10 +74,30 @@ class TestMilvusClientTimestamptzValid(TestMilvusClientV2Base):
 
         # step 3: query the rows
         rows = cf.convert_timestamptz(rows, default_timestamp_field_name, "UTC")
+        result = self.query(client, collection_name, filter=f"{default_primary_key_field_name} >= 0")
+        for i in range(default_nb):
+            expected_result = rows[i]
+            result_result = result[0][i]
+            print("================================")
+            print(f"expected_result: {expected_result[default_timestamp_field_name]}")
+            print(f"result_result: {result_result[default_timestamp_field_name]}")
+            if expected_result[default_timestamp_field_name] != result_result[default_timestamp_field_name]:
+                print(f"results mismatch❌")
+            else:
+                print(f"results match✅")
+            print("================================")
+            print(f"expected_result: {expected_result[default_vector_field_name]}")
+            print(f"result_result: {result_result[default_vector_field_name]}")
+            if expected_result[default_vector_field_name] != result_result[default_vector_field_name]:
+                print(f"vector results mismatch❌")
+            else:
+                print(f"vector results match✅")
+            print("================================")
         self.query(client, collection_name, filter=f"{default_primary_key_field_name} >= 0",
                             check_task=CheckTasks.check_query_results,
                             check_items={exp_res: rows,
-                                         "pk_name": default_primary_key_field_name})
+                                         "pk_name": default_primary_key_field_name,
+                                         "debug_mode": True})
 
         self.drop_collection(client, collection_name)
 

--- a/tests/python_client/requirements.txt
+++ b/tests/python_client/requirements.txt
@@ -84,3 +84,6 @@ python-dotenv<=2.0.0
 
 # for geometry
 shapely==2.1.1
+
+# for time zone
+tzdata>=2024.1


### PR DESCRIPTION
Issue: #46188 

Bug was caused by inconsistent version of tzdata as well as wrong month assignment in convert_timestamptz function.
Also fix when debug_mode=True the compare function can correctly return True or False.