### PR TITLE
test: fix timestamptz e2e case failure on Jenkins Weekly (#46210)

### DIFF
--- a/tests/python_client/check/param_check.py
+++ b/tests/python_client/check/param_check.py
@@ -190,6 +190,12 @@ def compare_lists_with_epsilon_ignore_dict_order_deepdiff(a, b, epsilon=epsilon)
     # Normalize both lists to handle type differences
     a_normalized = normalize_value(a)
     b_normalized = normalize_value(b)
+
+    # Check length first
+    if len(a_normalized) != len(b_normalized):
+        log.debug(f"[COMPARE_LISTS] Length mismatch: Query result length({len(a_normalized)}) != Expected result length({len(b_normalized)})")
+        return False
+    
     for i in range(len(a_normalized)):
         diff = DeepDiff(
             a_normalized[i],
@@ -202,6 +208,8 @@ def compare_lists_with_epsilon_ignore_dict_order_deepdiff(a, b, epsilon=epsilon)
         )
         if diff:
             log.debug(f"[COMPARE_LISTS] Found differences at row {i}: {diff}")
+            return False
+    return True
 
 def ip_check(ip):
     if ip == "localhost":

--- a/tests/python_client/common/common_func.py
+++ b/tests/python_client/common/common_func.py
@@ -4229,9 +4229,9 @@ def convert_timestamptz(rows, timestamptz_field_name, timezone="UTC"):
     iso_offset_re = re.compile(r"([+-])(\d{2}):(\d{2})$")
 
     def _days_in_month(year: int, month: int) -> int:
-        if month in (1, 3, 5, 7, 9, 10, 12):
+        if month in (1, 3, 5, 7, 8, 10, 12):
             return 31
-        if month in (4, 6, 8, 11):
+        if month in (4, 6, 9, 11):
             return 30
         # February
         is_leap = (year % 4 == 0 and (year % 100 != 0 or year % 400 == 0))
@@ -4391,11 +4391,11 @@ def convert_timestamptz(rows, timestamptz_field_name, timezone="UTC"):
             target_minutes = 480 if timezone == 'Asia/Shanghai' else 0
             try:
                 # Try to get actual offset from timezone if possible
-                if 1 <= uy <= 9999:
-                    test_dt = datetime(uy, um, ud, uh, umi, uss, tzinfo=tzmod.utc)
-                    test_target = test_dt.astimezone(ZoneInfo(timezone))
-                    off_td = test_target.utcoffset() or tzmod.utc.utcoffset(test_target)
-                    target_minutes = int(off_td.total_seconds() // 60)
+                test_year = uy if (1 <= uy <= 9999) else 2004
+                test_dt = datetime(test_year, um, ud, uh, umi, uss, tzinfo=tzmod.utc)
+                test_target = test_dt.astimezone(ZoneInfo(timezone))
+                off_td = test_target.utcoffset() or tzmod.utc.utcoffset(test_target)
+                target_minutes = int(off_td.total_seconds() // 60)
             except Exception:
                 pass
             # Convert UTC to local time: UTC + offset = local

--- a/tests/python_client/requirements.txt
+++ b/tests/python_client/requirements.txt
@@ -85,3 +85,6 @@ python-dotenv<=2.0.0
 
 # for geometry
 shapely==2.1.1
+
+# for time zone
+tzdata>=2024.1


### PR DESCRIPTION
Issue: #46188 
pr: #46210 

Bug was caused by inconsistent version of tzdata as well as wrong month assignment in convert_timestamptz function.
Also fix when debug_mode=True the compare function can correctly return True or False.
