### PR TITLE
fix: [2.6 hotfix] skip json path index if the query path includes number

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_search.py
+++ b/tests/python_client/milvus_client/test_milvus_client_search.py
@@ -3633,7 +3633,6 @@ class TestMilvusClientSearchNullExpr(TestMilvusClientV2Base):
                                  "limit": limit})
 
 
-@pytest.mark.skip(reason="issue #45511")
 class TestMilvusClientSearchJsonPathIndex(TestMilvusClientV2Base):
     """ Test case of search interface """
 


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/45511
pr: #46200
