### PR TITLE
enhance: Change RootCoord default port to non-ephemeral port

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -301,7 +301,7 @@ rootCoord:
   maxGeneralCapacity: 65536 # upper limit for the sum of of product of partitionNumber and shardNumber
   gracefulStopTimeout: 5 # seconds. force stop node without graceful stop
   ip:  # TCP/IP address of rootCoord. If not specified, use the first unicastable address
-  port: 53100 # TCP port of rootCoord
+  port: 22125 # TCP port of rootCoord
   grpc:
     serverMaxSendSize: 536870912 # The maximum size of each RPC request that the rootCoord can send, unit: byte
     serverMaxRecvSize: 268435456 # The maximum size of each RPC request that the rootCoord can receive, unit: byte


### PR DESCRIPTION
Related to #46255

Change RootCoord default gRPC port from 53100 to 22125 to avoid conflicts with ephemeral port range.

The previous port 53100 falls within the Linux ephemeral port range (32768-60999), which could cause conflicts with other connections including Milvus's own outbound connections. Port 22125 is outside the ephemeral range and provides more reliable service binding.