### PR TITLE
enhance: [2.6] bump milvus-storage to resolve credentials provider namespace conflict

### DIFF
--- a/internal/core/thirdparty/milvus-storage/CMakeLists.txt
+++ b/internal/core/thirdparty/milvus-storage/CMakeLists.txt
@@ -14,7 +14,7 @@
 # Update milvus-storage_VERSION for the first occurrence
 milvus_add_pkg_config("milvus-storage")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( milvus-storage_VERSION 33bf815)
+set( milvus-storage_VERSION 91df193)
 set( GIT_REPOSITORY  "https://github.com/milvus-io/milvus-storage.git")
 message(STATUS "milvus-storage repo: ${GIT_REPOSITORY}")
 message(STATUS "milvus-storage version: ${milvus-storage_VERSION}")


### PR DESCRIPTION
Cherry-pick from master
pr: #46263 

Upgrade milvus-storage from 33bf815 to 91df193.

This includes the fix from milvus-io/milvus-storage#337, which resolves a namespace collision where both Milvus and milvus-storage defined identical credentials provider classes in the same namespace. Although no compile-time redefinition errors occurred, the dynamic linker could resolve to the wrong implementation at runtime, potentially causing cloud authentication failures due to configuration mismatches.

The fix changes milvus-storage's credentials provider namespace to `milvus_storage`, ensuring each project uses its own implementation.