### PR TITLE
fix: [2.6]highlight queries not work when not BM25 search

### DIFF
--- a/internal/proxy/task_search.go
+++ b/internal/proxy/task_search.go
@@ -601,10 +601,8 @@ func (t *searchTask) createLexicalHighlighter(highlighter *commonpb.Highlighter,
 		if err != nil {
 			return err
 		}
-
-		return h.initHighlightQueries(t)
 	}
-	return nil
+	return h.initHighlightQueries(t)
 }
 
 func (t *searchTask) addHighlightTask(highlighter *commonpb.Highlighter, metricType string, annsField int64, placeholder []byte, analyzerName string) error {


### PR DESCRIPTION
Should aways init highlight queries.
relate: https://github.com/milvus-io/milvus/issues/42589
pr: https://github.com/milvus-io/milvus/pull/46288