### PR TITLE
fix: increase expiry time for huawei cloud(#46296)

### DIFF
--- a/internal/core/src/storage/RemoteOutputStream.cpp
+++ b/internal/core/src/storage/RemoteOutputStream.cpp
@@ -14,7 +14,9 @@ RemoteOutputStream::RemoteOutputStream(
 RemoteOutputStream::~RemoteOutputStream() {
     // temp solution, will expose `Close` method in OutputStream later
     auto status = output_stream_->Close();
-    AssertInfo(status.ok(), "Failed to close output stream");
+    AssertInfo(status.ok(),
+               "Failed to close output stream, error: {}",
+               status.ToString());
 }
 
 size_t

--- a/internal/core/src/storage/huawei/HuaweiCloudCredentialsProvider.cpp
+++ b/internal/core/src/storage/huawei/HuaweiCloudCredentialsProvider.cpp
@@ -21,7 +21,7 @@
 static const char STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG[] =
     "HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider";
 static const int STS_CREDENTIAL_PROVIDER_EXPIRATION_GRACE_PERIOD =
-    7200;  // huawei cloud support 7200s.
+    180 * 1000;  // huawei cloud support 180s.
 namespace Aws {
 namespace Auth {
 
@@ -155,10 +155,13 @@ HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider::Reload() {
             m_region, m_providerId, m_token, m_roleArn, m_sessionName};
 
     auto result = m_client->GetAssumeRoleWithWebIdentityCredentials(request);
-    AWS_LOGSTREAM_TRACE(
+    AWS_LOGSTREAM_DEBUG(
         STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
         "Successfully retrieved credentials with AWS_ACCESS_KEY: "
-            << result.creds.GetAWSAccessKeyId());
+            << result.creds.GetAWSAccessKeyId()
+            << ", expiration_count_diff_ms: "
+            << (result.creds.GetExpiration() - Aws::Utils::DateTime::Now())
+                   .count());
     m_credentials = result.creds;
 }
 

--- a/internal/core/src/storage/huawei/HuaweiCloudSTSClient.cpp
+++ b/internal/core/src/storage/huawei/HuaweiCloudSTSClient.cpp
@@ -16,6 +16,7 @@
 #include <aws/core/utils/json/JsonSerializer.h>
 #include <aws/core/http/HttpRequest.h>
 #include <aws/core/utils/DateTime.h>
+#include <iostream>
 
 namespace Aws {
 namespace Http {
@@ -141,7 +142,10 @@ HuaweiCloudSTSCredentialsClient::callHuaweiCloudSTS(
     *body << R"({
             "auth": {
             "identity": {
-                "methods": ["token"]
+                "methods": ["token"],
+                "token":{
+                    "duration_seconds": 7200
+                }
             }
             }
         })";
@@ -161,8 +165,10 @@ HuaweiCloudSTSCredentialsClient::callHuaweiCloudSTS(
         result.errorMessage = "Get an empty credential from Huawei Cloud STS";
         return result;
     }
-    auto json = Utils::Json::JsonView(credentialsStr);
+    Aws::Utils::Json::JsonValue jsonValue(credentialsStr);
+    auto json = jsonValue.View();
     auto rootNode = json.GetObject("credential");
+
     if (rootNode.IsNull()) {
         result.errorMessage = "Get credential from STS result failed";
         return result;

--- a/internal/core/src/storage/tencent/TencentCloudCredentialsProvider.cpp
+++ b/internal/core/src/storage/tencent/TencentCloudCredentialsProvider.cpp
@@ -25,7 +25,7 @@
 static const char STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG[] =
     "TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider";
 static const int STS_CREDENTIAL_PROVIDER_EXPIRATION_GRACE_PERIOD =
-    7200;  // tencent cloud support 7200s.
+    180 * 1000;  // tencent cloud support 180s.
 
 namespace Aws {
 namespace Auth {


### PR DESCRIPTION
related: #46296

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Core invariant: expiration comparisons use Aws::Utils::DateTime::Now().count() which returns milliseconds; any expiration grace period must be expressed in milliseconds and compared via (GetExpiration() - Now()).count() in ExpiresSoon() (Huawei and Tencent providers).
- Root cause and fix: the grace period constant was authored as 7200 (seconds) but used against millisecond counts, causing premature refreshes. The PR changes STS_CREDENTIAL_PROVIDER_EXPIRATION_GRACE_PERIOD to 180 * 1000 (180000 ms) in HuaweiCloudCredentialsProvider.cpp and TencentCloudCredentialsProvider.cpp to align units and stop unnecessary refreshes.
- Removed/replaced redundant/incorrect behavior: the PR does not add new control flow but corrects unit mismatch and simplifies logging/STS request handling — HuaweiCloudSTSClient now explicitly requests a 7200-second token by adding "token": {"duration_seconds": 7200} to the JSON body and uses JsonValue(...).View() for parsing; Huawei logging level raised from TRACE to DEBUG and now logs expiration_count_diff_ms for clarity. These changes remove ambiguity about requested token lifetime and improve diagnostic output.
- No data loss or regression: credential contents and assignment are unchanged — Reload()/RefreshIfExpired()/ExpiresSoon() still populate m_credentials from STS responses and return them via GetAWSCredentials(); only the grace-period unit and the Huawei STS request body/parsing/logging were adjusted. Code paths affected are ExpiresSoon()/RefreshIfExpired()/Reload() in both providers and HuaweiCloudSTSCredentialsClient::callHuaweiCloudSTS; since credentials are still read from the same response fields (access, secret, securitytoken, expires_at) and assigned to result.creds, there is no data loss or altered persistence/authorization semantics beyond aligning requested token duration and correct refresh timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->