### PR TITLE
enhance: [2.5] Add resource exhaustion querynode penalty policy (#45808)

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -393,6 +393,11 @@ queryCoord:
   collectionObserverInterval: 200 # the interval of collection observer
   checkExecutedFlagInterval: 100 # the interval of check executed flag to force to pull dist
   updateCollectionLoadStatusInterval: 5 # 5m, max interval of updating collection loaded status for check health
+  # Duration (in seconds) that a query node remains marked as resource exhausted after reaching resource limits.
+  # During this period, the node won't receive new tasks to loading resource.
+  # Set to 0 to disable the penalty period.
+  resourceExhaustionPenaltyDuration: 30
+  resourceExhaustionCleanupInterval: 10 # Interval (in seconds) for cleaning up expired resource exhaustion marks on query nodes.
   cleanExcludeSegmentInterval: 60 # the time duration of clean pipeline exclude segment which used for filter invalid data, in seconds
   ip:  # TCP/IP address of queryCoord. If not specified, use the first unicastable address
   port: 19531 # TCP port of queryCoord

--- a/internal/datacoord/session/indexnode_manager.go
+++ b/internal/datacoord/session/indexnode_manager.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"sync"
 
+	"github.com/samber/lo"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
@@ -32,7 +33,6 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/util/lock"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	typeutil "github.com/milvus-io/milvus/pkg/v2/util/typeutil"
-	"github.com/samber/lo"
 )
 
 func defaultIndexNodeCreatorFunc(ctx context.Context, addr string, nodeID int64) (types.IndexNodeClient, error) {

--- a/internal/querycoordv2/server.go
+++ b/internal/querycoordv2/server.go
@@ -328,6 +328,7 @@ func (s *Server) initQueryCoord() error {
 
 	// Init meta
 	s.nodeMgr = session.NewNodeManager()
+	s.nodeMgr.Start(s.ctx)
 	err = s.initMeta()
 	if err != nil {
 		return err

--- a/internal/querycoordv2/session/node_manager.go
+++ b/internal/querycoordv2/session/node_manager.go
@@ -17,6 +17,7 @@
 package session
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -25,7 +26,9 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/milvus-io/milvus/internal/util/sessionutil"
+	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/metrics"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
 
 type Manager interface {
@@ -35,13 +38,16 @@ type Manager interface {
 	Get(nodeID int64) *NodeInfo
 	GetAll() []*NodeInfo
 
-	Suspend(nodeID int64) error
-	Resume(nodeID int64) error
+	MarkResourceExhaustion(nodeID int64, duration time.Duration)
+	IsResourceExhausted(nodeID int64) bool
+	ClearExpiredResourceExhaustion()
+	Start(ctx context.Context)
 }
 
 type NodeManager struct {
-	mu    sync.RWMutex
-	nodes map[int64]*NodeInfo
+	mu        sync.RWMutex
+	nodes     map[int64]*NodeInfo
+	startOnce sync.Once
 }
 
 func (m *NodeManager) Add(node *NodeInfo) {
@@ -135,6 +141,12 @@ type NodeInfo struct {
 	immutableInfo ImmutableNodeInfo
 	state         State
 	lastHeartbeat *atomic.Int64
+
+	// resourceExhaustionExpireAt is the timestamp when the resource exhaustion penalty expires.
+	// When a query node reports resource exhaustion (OOM, disk full, etc.), it gets marked
+	// with a penalty duration during which it won't receive new loading tasks.
+	// Zero value means no active penalty.
+	resourceExhaustionExpireAt time.Time
 }
 
 func (n *NodeInfo) ID() int64 {
@@ -239,5 +251,99 @@ func WithChannelCnt(cnt int) StatsOption {
 func WithMemCapacity(capacity float64) StatsOption {
 	return func(n *NodeInfo) {
 		n.setMemCapacity(capacity)
+	}
+}
+
+// MarkResourceExhaustion marks a query node as resource exhausted for the specified duration.
+// During this period, the node won't receive new segment/channel loading tasks.
+// If duration is 0 or negative, the resource exhaustion mark is cleared immediately.
+// This is typically called when a query node reports resource exhaustion errors (OOM, disk full, etc.).
+func (m *NodeManager) MarkResourceExhaustion(nodeID int64, duration time.Duration) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if node, ok := m.nodes[nodeID]; ok {
+		node.mu.Lock()
+		if duration > 0 {
+			node.resourceExhaustionExpireAt = time.Now().Add(duration)
+		} else {
+			node.resourceExhaustionExpireAt = time.Time{}
+		}
+		node.mu.Unlock()
+	}
+}
+
+// IsResourceExhausted checks if a query node is currently marked as resource exhausted.
+// Returns true if the node has an active (non-expired) resource exhaustion mark.
+// This is a pure read-only operation with no side effects - expired marks are not
+// automatically cleared here. Use ClearExpiredResourceExhaustion for cleanup.
+func (m *NodeManager) IsResourceExhausted(nodeID int64) bool {
+	m.mu.RLock()
+	node := m.nodes[nodeID]
+	m.mu.RUnlock()
+
+	if node == nil {
+		return false
+	}
+
+	node.mu.RLock()
+	defer node.mu.RUnlock()
+
+	return !node.resourceExhaustionExpireAt.IsZero() &&
+		time.Now().Before(node.resourceExhaustionExpireAt)
+}
+
+// ClearExpiredResourceExhaustion iterates through all nodes and clears any expired
+// resource exhaustion marks. This is called periodically by the cleanup loop started
+// via Start(). It only clears marks that have already expired; active marks are preserved.
+func (m *NodeManager) ClearExpiredResourceExhaustion() {
+	m.mu.RLock()
+	nodes := make([]*NodeInfo, 0, len(m.nodes))
+	for _, node := range m.nodes {
+		nodes = append(nodes, node)
+	}
+	m.mu.RUnlock()
+
+	now := time.Now()
+	for _, node := range nodes {
+		node.mu.Lock()
+		if !node.resourceExhaustionExpireAt.IsZero() && !now.Before(node.resourceExhaustionExpireAt) {
+			node.resourceExhaustionExpireAt = time.Time{}
+		}
+		node.mu.Unlock()
+	}
+}
+
+// Start begins the background cleanup loop for expired resource exhaustion marks.
+// The cleanup interval is controlled by queryCoord.resourceExhaustionCleanupInterval config.
+// The loop will stop when the provided context is canceled.
+// This method is idempotent - multiple calls will only start one cleanup loop.
+func (m *NodeManager) Start(ctx context.Context) {
+	m.startOnce.Do(func() {
+		go m.cleanupLoop(ctx)
+	})
+}
+
+// cleanupLoop is the internal goroutine that periodically clears expired resource
+// exhaustion marks from all nodes. It supports dynamic interval refresh.
+func (m *NodeManager) cleanupLoop(ctx context.Context) {
+	interval := paramtable.Get().QueryCoordCfg.ResourceExhaustionCleanupInterval.GetAsDuration(time.Second)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Info("cleanupLoop stopped")
+			return
+		case <-ticker.C:
+			m.ClearExpiredResourceExhaustion()
+			// Support dynamic interval refresh
+			newInterval := paramtable.Get().QueryCoordCfg.ResourceExhaustionCleanupInterval.GetAsDuration(time.Second)
+			if newInterval != interval {
+				interval = newInterval
+				ticker.Reset(interval)
+			}
+		}
 	}
 }

--- a/internal/querycoordv2/task/task_test.go
+++ b/internal/querycoordv2/task/task_test.go
@@ -1983,6 +1983,27 @@ func (suite *TaskSuite) TestRemoveTaskWithError() {
 	// when try to remove task with ErrSegmentNotFound, should trigger UpdateNextTarget
 	scheduler.remove(task1)
 	mockTarget.AssertExpectations(suite.T())
+
+	// test remove task with ErrSegmentRequestResourceFailed
+	task2, err := NewSegmentTask(
+		ctx,
+		10*time.Second,
+		WrapIDSource(0),
+		coll,
+		suite.replica,
+		NewSegmentActionWithScope(nodeID, ActionTypeGrow, "", 1, querypb.DataScope_Historical, 100),
+	)
+	suite.NoError(err)
+	err = scheduler.Add(task2)
+	suite.NoError(err)
+
+	task2.Fail(merr.ErrSegmentRequestResourceFailed)
+	paramtable.Get().Save(paramtable.Get().QueryCoordCfg.ResourceExhaustionPenaltyDuration.Key, "3")
+	scheduler.remove(task2)
+	suite.True(suite.nodeMgr.IsResourceExhausted(nodeID))
+	// expect the penalty duration is expired
+	time.Sleep(3 * time.Second)
+	suite.False(suite.nodeMgr.IsResourceExhausted(nodeID))
 }
 
 func TestTask(t *testing.T) {

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -1500,20 +1500,26 @@ func (loader *segmentLoader) checkSegmentSize(ctx context.Context, segmentLoadIn
 	)
 
 	if predictMemUsage > uint64(float64(totalMem)*paramtable.Get().QueryNodeCfg.OverloadedMemoryThresholdPercentage.GetAsFloat()) {
-		return 0, 0, fmt.Errorf("load segment failed, OOM if load, maxSegmentSize = %v MB,  memUsage = %v MB, predictMemUsage = %v MB, totalMem = %v MB thresholdFactor = %f",
-			toMB(maxSegmentSize),
-			toMB(memUsage),
-			toMB(predictMemUsage),
-			toMB(totalMem),
-			paramtable.Get().QueryNodeCfg.OverloadedMemoryThresholdPercentage.GetAsFloat())
+		log.Warn("load segment failed, OOM if load",
+			zap.String("resourceType", "Memory"),
+			zap.Float64("maxSegmentSizeMB", toMB(maxSegmentSize)),
+			zap.Float64("memUsageMB", toMB(memUsage)),
+			zap.Float64("predictMemUsageMB", toMB(predictMemUsage)),
+			zap.Float64("totalMemMB", toMB(totalMem)),
+			zap.Float64("thresholdFactor", paramtable.Get().QueryNodeCfg.OverloadedMemoryThresholdPercentage.GetAsFloat()),
+		)
+		return 0, 0, merr.WrapErrSegmentRequestResourceFailed("Memory")
 	}
 
 	if predictDiskUsage > uint64(float64(paramtable.Get().QueryNodeCfg.DiskCapacityLimit.GetAsInt64())*paramtable.Get().QueryNodeCfg.MaxDiskUsagePercentage.GetAsFloat()) {
-		return 0, 0, merr.WrapErrServiceDiskLimitExceeded(float32(predictDiskUsage), float32(paramtable.Get().QueryNodeCfg.DiskCapacityLimit.GetAsInt64()), fmt.Sprintf("load segment failed, disk space is not enough, diskUsage = %v MB, predictDiskUsage = %v MB, totalDisk = %v MB, thresholdFactor = %f",
-			toMB(diskUsage),
-			toMB(predictDiskUsage),
-			toMB(uint64(paramtable.Get().QueryNodeCfg.DiskCapacityLimit.GetAsInt64())),
-			paramtable.Get().QueryNodeCfg.MaxDiskUsagePercentage.GetAsFloat()))
+		log.Warn("load segment failed, disk space is not enough",
+			zap.String("resourceType", "Disk"),
+			zap.Float64("diskUsageMB", toMB(diskUsage)),
+			zap.Float64("predictDiskUsageMB", toMB(predictDiskUsage)),
+			zap.Float64("totalDiskMB", toMB(uint64(paramtable.Get().QueryNodeCfg.DiskCapacityLimit.GetAsInt64()))),
+			zap.Float64("thresholdFactor", paramtable.Get().QueryNodeCfg.MaxDiskUsagePercentage.GetAsFloat()),
+		)
+		return 0, 0, merr.WrapErrSegmentRequestResourceFailed("Disk")
 	}
 
 	return predictMemUsage - memUsage, predictDiskUsage - diskUsage, nil

--- a/internal/querynodev2/segments/segment_loader_test.go
+++ b/internal/querynodev2/segments/segment_loader_test.go
@@ -960,6 +960,100 @@ func (suite *SegmentLoaderDetailSuite) TestRequestResource() {
 	})
 }
 
+func (suite *SegmentLoaderDetailSuite) TestCheckSegmentSizeWithDiskLimit() {
+	ctx := context.Background()
+
+	// Save original value and restore after test
+	paramtable.Get().Save(paramtable.Get().QueryNodeCfg.DiskCapacityLimit.Key, "1") // 1MB
+	defer paramtable.Get().Reset(paramtable.Get().QueryNodeCfg.DiskCapacityLimit.Key)
+
+	// Set disk usage threshold
+	paramtable.Get().Save(paramtable.Get().QueryNodeCfg.MaxDiskUsagePercentage.Key, "0.8") // 80% threshold
+	defer paramtable.Get().Reset(paramtable.Get().QueryNodeCfg.MaxDiskUsagePercentage.Key)
+
+	// set mmap, trigger dist cost
+	paramtable.Get().Save(paramtable.Get().QueryNodeCfg.MmapScalarField.Key, "true")
+	defer paramtable.Get().Reset(paramtable.Get().QueryNodeCfg.MmapScalarField.Key)
+
+	// Create a test segment that would exceed the disk limit
+	loadInfo := &querypb.SegmentLoadInfo{
+		SegmentID:    suite.segmentID,
+		PartitionID:  suite.partitionID,
+		CollectionID: suite.collectionID,
+		NumOfRows:    1000,
+		BinlogPaths: []*datapb.FieldBinlog{
+			{
+				FieldID: 1,
+				Binlogs: []*datapb.Binlog{
+					{
+						LogPath:    "test_path",
+						LogSize:    1024 * 1024 * 1024 * 2, // 2GB
+						MemorySize: 1024 * 1024 * 1024 * 4,
+					},
+				},
+			},
+			{
+				FieldID: 105,
+				Binlogs: []*datapb.Binlog{
+					{
+						LogPath:    "test_path",
+						LogSize:    1024 * 1024 * 1024 * 2, // 2GB
+						MemorySize: 1024 * 1024 * 1024 * 4,
+					},
+				},
+			},
+		},
+	}
+
+	// Mock collection manager to return a valid collection
+	collection, err := NewCollection(suite.collectionID, suite.schema, nil, nil)
+	suite.NoError(err)
+	suite.collectionManager.EXPECT().Get(suite.collectionID).Return(collection)
+
+	memUsage := uint64(100 * 1024 * 1024)  // 100MB
+	totalMem := uint64(1024 * 1024 * 1024) // 1GB
+	localDiskUsage := int64(100 * 1024)    // 100KB
+
+	_, _, err = suite.loader.checkSegmentSize(ctx, []*querypb.SegmentLoadInfo{loadInfo}, memUsage, totalMem, localDiskUsage)
+	suite.Error(err)
+	suite.True(errors.Is(err, merr.ErrSegmentRequestResourceFailed))
+}
+
+func (suite *SegmentLoaderDetailSuite) TestCheckSegmentSizeWithMemoryLimit() {
+	ctx := context.Background()
+
+	// Create a test segment that would exceed the memory limit
+	loadInfo := &querypb.SegmentLoadInfo{
+		SegmentID:    suite.segmentID,
+		PartitionID:  suite.partitionID,
+		CollectionID: suite.collectionID,
+		NumOfRows:    1000,
+		BinlogPaths: []*datapb.FieldBinlog{
+			{
+				FieldID: 1,
+				Binlogs: []*datapb.Binlog{
+					{
+						LogPath:    "test_path",
+						LogSize:    1024 * 1024,       // 1MB
+						MemorySize: 1024 * 1024 * 900, // 900MB
+					},
+				},
+			},
+		},
+	}
+
+	memUsage := uint64(100 * 1024 * 1024)  // 100MB
+	totalMem := uint64(1024 * 1024 * 1024) // 1GB
+	localDiskUsage := int64(100 * 1024)    // 100KB
+
+	// Set memory threshold to 80%
+	paramtable.Get().Save("queryNode.overloadedMemoryThresholdPercentage", "0.8")
+
+	_, _, err := suite.loader.checkSegmentSize(ctx, []*querypb.SegmentLoadInfo{loadInfo}, memUsage, totalMem, localDiskUsage)
+	suite.Error(err)
+	suite.True(errors.Is(err, merr.ErrSegmentRequestResourceFailed))
+}
+
 func TestSegmentLoader(t *testing.T) {
 	suite.Run(t, &SegmentLoaderSuite{})
 	suite.Run(t, &SegmentLoaderDetailSuite{})

--- a/pkg/util/merr/errors.go
+++ b/pkg/util/merr/errors.go
@@ -106,6 +106,11 @@ var (
 	ErrSegmentLack        = newMilvusError("segment lacks", 602, false)
 	ErrSegmentReduplicate = newMilvusError("segment reduplicates", 603, false)
 	ErrSegmentLoadFailed  = newMilvusError("segment load failed", 604, false)
+	// ErrSegmentRequestResourceFailed indicates the query node cannot load the segment
+	// due to resource exhaustion (Memory, Disk, or GPU). When this error is returned,
+	// the query coordinator will mark the node as resource exhausted and apply a
+	// penalty period during which the node won't receive new loading tasks.
+	ErrSegmentRequestResourceFailed = newMilvusError("segment request resource failed", 605, false)
 
 	// Index related
 	ErrIndexNotFound     = newMilvusError("index not found", 700, false)

--- a/pkg/util/merr/errors_test.go
+++ b/pkg/util/merr/errors_test.go
@@ -116,6 +116,7 @@ func (s *ErrSuite) TestWrap() {
 	s.ErrorIs(WrapErrSegmentNotLoaded(1, "failed to query"), ErrSegmentNotLoaded)
 	s.ErrorIs(WrapErrSegmentLack(1, "lack of segment"), ErrSegmentLack)
 	s.ErrorIs(WrapErrSegmentReduplicate(1, "redundancy of segment"), ErrSegmentReduplicate)
+	s.ErrorIs(WrapErrSegmentRequestResourceFailed("Memory"), ErrSegmentRequestResourceFailed)
 
 	// Index related
 	s.ErrorIs(WrapErrIndexNotFound("failed to get Index"), ErrIndexNotFound)

--- a/pkg/util/merr/utils.go
+++ b/pkg/util/merr/utils.go
@@ -755,6 +755,24 @@ func WrapErrSegmentLoadFailed(id int64, msg ...string) error {
 	return err
 }
 
+// WrapErrSegmentRequestResourceFailed creates a resource exhaustion error for segment loading.
+// resourceType should be one of: "Memory", "Disk", "GPU".
+// This error triggers the query coordinator to mark the node as resource exhausted,
+// applying a penalty period controlled by queryCoord.resourceExhaustionPenaltyDuration.
+func WrapErrSegmentRequestResourceFailed(
+	resourceType string,
+	msg ...string,
+) error {
+	err := wrapFields(ErrSegmentRequestResourceFailed,
+		value("resourceType", resourceType),
+	)
+
+	if len(msg) > 0 {
+		err = errors.Wrap(err, strings.Join(msg, "->"))
+	}
+	return err
+}
+
 func WrapErrSegmentNotLoaded(id int64, msg ...string) error {
 	err := wrapFields(ErrSegmentNotLoaded, value("segment", id))
 	if len(msg) > 0 {

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -2131,7 +2131,9 @@ type queryCoordConfig struct {
 	BalanceChannelBatchSize            ParamItem `refreshable:"true"`
 	EnableBalanceOnMultipleCollections ParamItem `refreshable:"true"`
 
-	BalanceCheckCollectionMaxCount ParamItem `refreshable:"true"`
+	BalanceCheckCollectionMaxCount    ParamItem `refreshable:"true"`
+	ResourceExhaustionPenaltyDuration ParamItem `refreshable:"true"`
+	ResourceExhaustionCleanupInterval ParamItem `refreshable:"true"`
 }
 
 func (p *queryCoordConfig) init(base *BaseTable) {
@@ -2764,6 +2766,25 @@ If this parameter is set false, Milvus simply searches the growing segments with
 		Export:       false,
 	}
 	p.BalanceCheckCollectionMaxCount.Init(base.mgr)
+	p.ResourceExhaustionPenaltyDuration = ParamItem{
+		Key:          "queryCoord.resourceExhaustionPenaltyDuration",
+		Version:      "2.6.7",
+		DefaultValue: "30",
+		Doc: `Duration (in seconds) that a query node remains marked as resource exhausted after reaching resource limits.
+During this period, the node won't receive new tasks to loading resource.
+Set to 0 to disable the penalty period.`,
+		Export: true,
+	}
+	p.ResourceExhaustionPenaltyDuration.Init(base.mgr)
+
+	p.ResourceExhaustionCleanupInterval = ParamItem{
+		Key:          "queryCoord.resourceExhaustionCleanupInterval",
+		Version:      "2.6.7",
+		DefaultValue: "10",
+		Doc:          "Interval (in seconds) for cleaning up expired resource exhaustion marks on query nodes.",
+		Export:       true,
+	}
+	p.ResourceExhaustionCleanupInterval.Init(base.mgr)
 }
 
 // /////////////////////////////////////////////////////////////////////////////

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -394,6 +394,8 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, true, Params.EnableBalanceOnMultipleCollections.GetAsBool())
 
 		assert.Equal(t, 100, Params.BalanceCheckCollectionMaxCount.GetAsInt())
+		assert.Equal(t, 30, Params.ResourceExhaustionPenaltyDuration.GetAsInt())
+		assert.Equal(t, 10, Params.ResourceExhaustionCleanupInterval.GetAsInt())
 	})
 
 	t.Run("test queryNodeConfig", func(t *testing.T) {


### PR DESCRIPTION
issue: #40513
pr: #45808
for querynode which return resource exhausted error, add a penalty duration on it, and suspend loading new resource until penalty duration expired.

---------