### PR TITLE
fix: [hotfix] bump milvus-storage to fix initialization race condition

### DIFF
--- a/internal/core/thirdparty/milvus-storage/CMakeLists.txt
+++ b/internal/core/thirdparty/milvus-storage/CMakeLists.txt
@@ -14,7 +14,7 @@
 # Update milvus-storage_VERSION for the first occurrence
 milvus_add_pkg_config("milvus-storage")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( milvus-storage_VERSION 73a678f8)
+set( milvus-storage_VERSION 839a8e5)
 set( GIT_REPOSITORY  "https://github.com/milvus-io/milvus-storage.git")
 message(STATUS "milvus-storage repo: ${GIT_REPOSITORY}")
 message(STATUS "milvus-storage version: ${milvus-storage_VERSION}")


### PR DESCRIPTION
Cherry-pick from master
pr: #46336
Related to #44647
Update milvus-storage from 91df193 to 839a8e5 to include milvus-io/milvus-storage#342, which fixes a race condition in S3GlobalContext initialization.

The fix moves the is_initialized_ flag update from before DoInitialize() to after it completes. This ensures the initialization flag is only set to true after the actual initialization is done, preventing potential issues if DoInitialize() fails or if other code checks the flag during initialization.