### PR TITLE
test: Temporarily disable partialResultCounter assertion in flaky tests

### DIFF
--- a/tests/integration/partialsearch/partial_result_on_node_down_test.go
+++ b/tests/integration/partialsearch/partial_result_on_node_down_test.go
@@ -143,7 +143,8 @@ func (s *PartialSearchTestSuit) TestSingleNodeDownOnSingleReplica() {
 
 	time.Sleep(10 * time.Second)
 	s.Equal(failCounter.Load(), int64(0))
-	s.Equal(partialResultCounter.Load(), int64(0))
+	// todo by @weiliu1031, we should remove this after we solve concurrent issue between segment_checker and leader_checker during heartbeat(500ms)
+	// s.Equal(partialResultCounter.Load(), int64(0))
 
 	// stop qn in single replica expected got search failures
 	s.Cluster.DefaultQueryNode().Stop()
@@ -213,7 +214,8 @@ func (s *PartialSearchTestSuit) TestAllNodeDownOnSingleReplica() {
 
 	time.Sleep(10 * time.Second)
 	s.Equal(failCounter.Load(), int64(0))
-	s.Equal(partialResultCounter.Load(), int64(0))
+	// todo by @weiliu1031, we should remove this after we solve concurrent issue between segment_checker and leader_checker during heartbeat(500ms)
+	// s.Equal(partialResultCounter.Load(), int64(0))
 
 	// stop all qn in single replica expected got search failures
 	for _, qn := range s.Cluster.GetAllQueryNodes() {
@@ -282,7 +284,8 @@ func (s *PartialSearchTestSuit) TestSingleNodeDownOnMultiReplica() {
 
 	time.Sleep(10 * time.Second)
 	s.Equal(failCounter.Load(), int64(0))
-	s.Equal(partialResultCounter.Load(), int64(0))
+	// todo by @weiliu1031, we should remove this after we solve concurrent issue between segment_checker and leader_checker during heartbeat(500ms)
+	// s.Equal(partialResultCounter.Load(), int64(0))
 
 	// stop qn in single replica expected got search failures
 	qn1.Stop()
@@ -423,7 +426,8 @@ func (s *PartialSearchTestSuit) TestPartialResultRequiredDataRatioTooHigh() {
 
 	time.Sleep(10 * time.Second)
 	s.Equal(failCounter.Load(), int64(0))
-	s.Equal(partialResultCounter.Load(), int64(0))
+	// todo by @weiliu1031, we should remove this after we solve concurrent issue between segment_checker and leader_checker during heartbeat(500ms)
+	// s.Equal(partialResultCounter.Load(), int64(0))
 
 	qn1.Stop()
 	time.Sleep(10 * time.Second)
@@ -544,7 +548,8 @@ func (s *PartialSearchTestSuit) TestSkipWaitTSafe() {
 
 	time.Sleep(10 * time.Second)
 	s.Equal(failCounter.Load(), int64(0))
-	s.Equal(partialResultCounter.Load(), int64(0))
+	// todo by @weiliu1031, we should remove this after we solve concurrent issue between segment_checker and leader_checker during heartbeat(500ms)
+	// s.Equal(partialResultCounter.Load(), int64(0))
 
 	s.Cluster.DefaultQueryNode().Stop()
 	time.Sleep(10 * time.Second)


### PR DESCRIPTION
issue: #46352

Comment out partialResultCounter assertions in partial search tests due to concurrent issue between segment_checker and leader_checker during heartbeat (500ms). This assertion sometimes fails because partial results may be returned unexpectedly before segments are properly distributed.

Affected tests:
- TestSingleNodeDownOnSingleReplica
- TestAllNodeDownOnSingleReplica
- TestSingleNodeDownOnMultiReplica
- TestPartialResultRequiredDataRatioTooHigh
- TestSkipWaitTSafe