### PR TITLE
fix: pass manifest path when loading growing segments

### DIFF
--- a/internal/querynodev2/handlers.go
+++ b/internal/querynodev2/handlers.go
@@ -96,6 +96,7 @@ func loadGrowingSegments(ctx context.Context, delegator delegator.ShardDelegator
 					InsertChannel:  segmentInfo.InsertChannel,
 					StartPosition:  segmentInfo.GetStartPosition(),
 					StorageVersion: segmentInfo.GetStorageVersion(),
+					ManifestPath:   segmentInfo.GetManifestPath(),
 				})
 			} else {
 				log.Info("skip segment which binlog is empty", zap.Int64("segmentID", segmentInfo.ID))


### PR DESCRIPTION
Related to #44956

Pass ManifestPath field to SegmentLoadInfo when loading growing segments in loadGrowingSegments function. This ensures storage v2 can properly locate segment data via manifest path, consistent with other segment loading paths.