### PR TITLE
enhance: support new server label rule for milvus and MILVUS_SERVER_LABEL_RESOURCE_GROUP

### DIFF
--- a/internal/querycoordv2/meta/resource_group.go
+++ b/internal/querycoordv2/meta/resource_group.go
@@ -13,7 +13,6 @@ import (
 var (
 	DefaultResourceGroupName           = "__default_resource_group"
 	defaultResourceGroupCapacity int32 = 1000000
-	resourceGroupTransferBoost         = 10000
 )
 
 func NewResourceGroupConfig(request int32, limit int32) *rgpb.ResourceGroupConfig {
@@ -197,13 +196,17 @@ func (rg *ResourceGroup) SelectNodeForRG(targetRG *ResourceGroup) int64 {
 
 // return node and priority.
 func (rg *ResourceGroup) AcceptNode(nodeID int64) bool {
-	if rg.GetName() == DefaultResourceGroupName {
-		return true
-	}
-
 	nodeInfo := rg.nodeMgr.Get(nodeID)
 	if nodeInfo == nil {
 		return false
+	}
+
+	if nodeInfo.ResourceGroupName() != "" && nodeInfo.ResourceGroupName() != rg.GetName() {
+		return false
+	}
+
+	if rg.GetName() == DefaultResourceGroupName {
+		return true
 	}
 
 	requiredNodeLabels := rg.GetConfig().GetNodeFilter().GetNodeLabels()

--- a/internal/querycoordv2/meta/resource_group_test.go
+++ b/internal/querycoordv2/meta/resource_group_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/rgpb"
 	"github.com/milvus-io/milvus/internal/querycoordv2/session"
+	"github.com/milvus-io/milvus/internal/util/sessionutil"
 	"github.com/milvus-io/milvus/pkg/v2/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
@@ -450,4 +451,34 @@ func TestRGNodeFilter(t *testing.T) {
 		},
 	}, nodeMgr)
 	assert.Equal(t, rg.SelectNodeForRG(rg3), int64(-1))
+}
+
+func TestRGAcceptNode(t *testing.T) {
+	nodeMgr := session.NewNodeManager()
+
+	nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{
+		NodeID: 1,
+		Labels: map[string]string{
+			sessionutil.LabelResourceGroup: "rg1",
+		},
+	}))
+
+	nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{
+		NodeID: 2,
+		Labels: map[string]string{
+			sessionutil.LabelResourceGroup: "rg2",
+		},
+	}))
+
+	rg := NewResourceGroup("rg1", &rgpb.ResourceGroupConfig{
+		Requests: &rgpb.ResourceGroupLimit{
+			NodeNum: 1,
+		},
+		Limits: &rgpb.ResourceGroupLimit{
+			NodeNum: 1,
+		},
+	}, nodeMgr)
+
+	assert.True(t, rg.AcceptNode(1))
+	assert.False(t, rg.AcceptNode(2))
 }

--- a/internal/querycoordv2/meta/resource_manager_test.go
+++ b/internal/querycoordv2/meta/resource_manager_test.go
@@ -232,6 +232,17 @@ func (suite *ResourceManagerSuite) TestManipulateResourceGroup() {
 		},
 	}))
 	suite.manager.HandleNodeUp(ctx, 10)
+
+	suite.manager.nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{
+		NodeID:   11,
+		Address:  "localhost",
+		Hostname: "localhost",
+		Labels: map[string]string{
+			sessionutil.LabelResourceGroup: "rg11",
+		},
+	}))
+	suite.manager.HandleNodeUp(ctx, 11)
+	suite.Equal(1, suite.manager.GetResourceGroup(ctx, "rg11").NodeNum())
 }
 
 func (suite *ResourceManagerSuite) TestNodeUpAndDown() {

--- a/internal/querycoordv2/session/node_manager.go
+++ b/internal/querycoordv2/session/node_manager.go
@@ -171,7 +171,15 @@ func (n *NodeInfo) IsInStandalone() bool {
 }
 
 func (n *NodeInfo) IsEmbeddedQueryNodeInStreamingNode() bool {
-	return n.immutableInfo.Labels[sessionutil.LabelStreamingNodeEmbeddedQueryNode] == "1"
+	// Since 2.6.8, we introduce a new label rule for session,
+	// the LegacyLabelStreamingNodeEmbeddedQueryNode is used before 2.6.8, so we need to check both key to keep compatibility.
+	return n.immutableInfo.Labels[sessionutil.LabelStreamingNodeEmbeddedQueryNode] == "1" ||
+		n.immutableInfo.Labels[sessionutil.LegacyLabelStreamingNodeEmbeddedQueryNode] == "1"
+}
+
+// ResourceGroupName returns the resource group name of the current node.
+func (n *NodeInfo) ResourceGroupName() string {
+	return n.immutableInfo.Labels[sessionutil.LabelResourceGroup]
 }
 
 func (n *NodeInfo) SegmentCnt() int {

--- a/internal/querycoordv2/session/node_manager_test.go
+++ b/internal/querycoordv2/session/node_manager_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/milvus-io/milvus/internal/util/sessionutil"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -228,6 +229,29 @@ func (s *NodeManagerSuite) TestMemCapacityFunctionality() {
 	// Test updating memory capacity
 	node.UpdateStats(WithMemCapacity(2048.75))
 	s.Equal(2048.75, node.MemCapacity())
+}
+
+func (s *NodeManagerSuite) TestNodeInfoLabels() {
+	info := ImmutableNodeInfo{
+		NodeID:   1,
+		Address:  "localhost",
+		Hostname: "localhost",
+		Labels: map[string]string{
+			sessionutil.LegacyLabelStreamingNodeEmbeddedQueryNode: "1",
+		},
+	}
+
+	info2 := NodeInfo{
+		immutableInfo: info,
+	}
+	s.True(info2.IsEmbeddedQueryNodeInStreamingNode())
+
+	info2.immutableInfo.Labels[sessionutil.LabelStreamingNodeEmbeddedQueryNode] = "1"
+	delete(info2.immutableInfo.Labels, sessionutil.LegacyLabelStreamingNodeEmbeddedQueryNode)
+	s.True(info2.IsEmbeddedQueryNodeInStreamingNode())
+
+	info.Labels[sessionutil.LabelResourceGroup] = "rg1"
+	s.Equal("rg1", info2.ResourceGroupName())
 }
 
 func TestNodeManagerSuite(t *testing.T) {

--- a/internal/querycoordv2/session/node_manager_test.go
+++ b/internal/querycoordv2/session/node_manager_test.go
@@ -20,8 +20,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/milvus-io/milvus/internal/util/sessionutil"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/milvus-io/milvus/internal/util/sessionutil"
 )
 
 type NodeManagerSuite struct {

--- a/internal/util/sessionutil/labels.go
+++ b/internal/util/sessionutil/labels.go
@@ -117,6 +117,9 @@ func getRoleFromEnvKey(key string) (string, string, bool) {
 	if role == "" {
 		return "", labelWithRole, true
 	}
+	if len(splits) <= 1 {
+		return "", "", false
+	}
 	// else, it's a selected role label, only can be seen in the selected role.
 	return role, strings.Join(splits[1:], "_"), true
 }

--- a/internal/util/sessionutil/labels.go
+++ b/internal/util/sessionutil/labels.go
@@ -1,0 +1,122 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sessionutil
+
+import (
+	"os"
+	"strings"
+
+	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
+)
+
+// milvus server label rules:
+// The server label of milvus will be injected into the session of milvus server,
+// which can be found at SessionRaw.ServerLabels.
+// The label is a envionment variable, the key must be prefixed with "MILVUS_SERVER_LABEL_".
+// There are two types of labels:
+//
+// role-specific labels and non-role-specific labels.
+// The key of role-specific labels have the format of "MILVUS_SERVER_LABEL_<ROLE>_<LABEL>",
+// only the session of the role can see the label.
+// The key of non-role-specific labels have the format of "MILVUS_SERVER_LABEL_<LABEL>",
+// all sessions can see the label.
+// e.g.
+// export MILVUS_SERVER_LABEL_label1=value1, all roles can see the `label1:value1` in the server label of session.
+// export MILVUS_SERVER_LABEL_querynode_label2=value2, only the session of querynode can see the `label2:value2` in the server label of session.
+//
+// the key of non-role-specific labels will be overwritten by the key of role-specific labels.
+// e.g.
+// export MILVUS_SERVER_LABEL_label1=value1, export MILVUS_SERVER_LABEL_querynode_label1=value2,
+// the session of querynode will see the `label1:value2` in the server label of session because of the overwrite.
+// the session of other roles will see the `label1:value1` in the server label of session.
+const (
+	SupportedLabelPrefix = "MILVUS_SERVER_LABEL_"
+
+	// QueryNode
+	LabelStreamingNodeEmbeddedQueryNode       = "STREAMING-EMBEDDED"
+	LegacyLabelStreamingNodeEmbeddedQueryNode = "QUERYNODE_" + LabelStreamingNodeEmbeddedQueryNode
+
+	// All Roles
+	LabelStandalone    = "STANDALONE"
+	LabelResourceGroup = "RESOURCE_GROUP"
+)
+
+// NewServerLabel creates a new server label with the given role and label.
+func NewServerLabel(role string, label string) string {
+	if role == "" {
+		return SupportedLabelPrefix + strings.ToUpper(label)
+	}
+	return SupportedLabelPrefix + strings.ToUpper(role) + "_" + strings.ToUpper(label)
+}
+
+func getServerLabelsFromEnv(role string) map[string]string {
+	labelsSpecifiedByRole := make(map[string]string)
+	labels := make(map[string]string)
+	for _, value := range os.Environ() {
+		rs := []rune(value)
+		in := strings.Index(value, "=")
+		key := string(rs[0:in])
+		value := string(rs[in+1:])
+
+		roleFromEnv, label, ok := getRoleFromEnvKey(key)
+		if !ok || (roleFromEnv != "" && roleFromEnv != role) {
+			continue
+		}
+		if roleFromEnv == "" {
+			labels[label] = value
+		} else {
+			labelsSpecifiedByRole[label] = value
+		}
+	}
+	// use role specified labels to overwrite labels not specified by role.
+	for label, value := range labelsSpecifiedByRole {
+		labels[label] = value
+	}
+	return labels
+}
+
+func getRoleFromEnvKey(key string) (string, string, bool) {
+	if !strings.HasPrefix(key, SupportedLabelPrefix) {
+		return "", "", false
+	}
+	labelWithRole := strings.TrimPrefix(key, SupportedLabelPrefix)
+	if len(labelWithRole) == 0 {
+		return "", "", false
+	}
+	splits := strings.Split(labelWithRole, "_")
+	var role string
+	switch strings.ToLower(splits[0]) {
+	case typeutil.MixCoordRole, "coord":
+		role = typeutil.MixCoordRole
+	case typeutil.QueryNodeRole, "qn":
+		role = typeutil.QueryNodeRole
+	case typeutil.DataNodeRole, "dn":
+		role = typeutil.DataNodeRole
+	case typeutil.StreamingNodeRole, "sn":
+		role = typeutil.StreamingNodeRole
+	case typeutil.ProxyRole:
+		role = typeutil.ProxyRole
+	default:
+	}
+
+	// if role is not found, the label can be seen session in all roles.
+	if role == "" {
+		return "", labelWithRole, true
+	}
+	// else, it's a selected role label, only can be seen in the selected role.
+	return role, strings.Join(splits[1:], "_"), true
+}

--- a/internal/util/sessionutil/session_util_test.go
+++ b/internal/util/sessionutil/session_util_test.go
@@ -763,6 +763,8 @@ func (s *SessionSuite) TestGetSessions() {
 	os.Setenv("MILVUS_SERVER_LABEL_qn_key3", "value33")
 	os.Setenv("MILVUS_SERVER_LABEL_sn_key3", "value33")
 	os.Setenv("key4", "value4")
+	os.Setenv("MILVUS_SERVER_LABEL_", "value5")
+	os.Setenv("MILVUS_SERVER_LABEL_qn", "value6")
 
 	defer os.Unsetenv("MILVUS_SERVER_LABEL_key1")
 	defer os.Unsetenv("MILVUS_SERVER_LABEL_key2")

--- a/internal/util/sessionutil/session_util_test.go
+++ b/internal/util/sessionutil/session_util_test.go
@@ -759,16 +759,34 @@ func (s *SessionSuite) TestKeepAliveRetryChannelClose() {
 func (s *SessionSuite) TestGetSessions() {
 	os.Setenv("MILVUS_SERVER_LABEL_key1", "value1")
 	os.Setenv("MILVUS_SERVER_LABEL_key2", "value2")
-	os.Setenv("key3", "value3")
+	os.Setenv("MILVUS_SERVER_LABEL_key3", "value3")
+	os.Setenv("MILVUS_SERVER_LABEL_qn_key3", "value33")
+	os.Setenv("MILVUS_SERVER_LABEL_sn_key3", "value33")
+	os.Setenv("key4", "value4")
 
 	defer os.Unsetenv("MILVUS_SERVER_LABEL_key1")
 	defer os.Unsetenv("MILVUS_SERVER_LABEL_key2")
-	defer os.Unsetenv("key3")
+	defer os.Unsetenv("MILVUS_SERVER_LABEL_qn_key3")
+	defer os.Unsetenv("MILVUS_SERVER_LABEL_sn_key3")
+	defer os.Unsetenv("key4")
 
-	ret := GetServerLabelsFromEnv("querynode")
-	assert.Equal(s.T(), 2, len(ret))
-	assert.Equal(s.T(), "value1", ret["key1"])
-	assert.Equal(s.T(), "value2", ret["key2"])
+	roles := []string{typeutil.QueryNodeRole, typeutil.MixCoordRole, typeutil.StreamingNodeRole, typeutil.ProxyRole}
+
+	for _, role := range roles {
+		ret := getServerLabelsFromEnv(role)
+		switch role {
+		case typeutil.QueryNodeRole, typeutil.StreamingNodeRole:
+			assert.Equal(s.T(), 3, len(ret))
+			assert.Equal(s.T(), "value1", ret["key1"])
+			assert.Equal(s.T(), "value2", ret["key2"])
+			assert.Equal(s.T(), "value33", ret["key3"], "role: %s", role)
+		default:
+			assert.Equal(s.T(), 3, len(ret))
+			assert.Equal(s.T(), "value1", ret["key1"])
+			assert.Equal(s.T(), "value2", ret["key2"])
+			assert.Equal(s.T(), "value3", ret["key3"])
+		}
+	}
 }
 
 func (s *SessionSuite) TestVersionKey() {


### PR DESCRIPTION
issue: #46400

- add new server label rule.
- add `MILVUS_SERVER_LABEL_RESOURCE_GROUP` to determine the resource group of querynode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic creation of resource groups when nodes with resource-group labels join.
  * Expanded server-label system supporting role-specific and global labels.

* **Bug Fixes**
  * Node acceptance now enforces resource-group name compatibility, preventing cross-group assignment.

* **Refactor**
  * Node handling flows updated to use richer node information for assignment and validation.

* **Tests**
  * Added tests validating resource-group labeling and node acceptance behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->