### PR TITLE
enhance: set dynamic field as nullable with default empty JSON

### DIFF
--- a/internal/rootcoord/create_collection_task.go
+++ b/internal/rootcoord/create_collection_task.go
@@ -269,6 +269,12 @@ func (t *createCollectionTask) appendDynamicField(ctx context.Context, schema *s
 			Description: "dynamic schema",
 			DataType:    schemapb.DataType_JSON,
 			IsDynamic:   true,
+			Nullable:    true,
+			DefaultValue: &schemapb.ValueField{
+				Data: &schemapb.ValueField_BytesData{
+					BytesData: []byte("{}"),
+				},
+			},
 		})
 		log.Ctx(ctx).Info("append dynamic field", zap.String("collection", schema.Name))
 	}


### PR DESCRIPTION
Set the auto-appended dynamic field to be nullable with a default value of empty JSON object `{}`. This allows collections with dynamic schema to handle rows that don't have any dynamic fields more gracefully, avoiding potential null reference issues when the dynamic field is not explicitly set during insert.