### PR TITLE
fix: [2.6] prevent field data drop for multi-field column groups and reload on index drop

### DIFF
--- a/internal/core/src/mmap/ChunkedColumn.h
+++ b/internal/core/src/mmap/ChunkedColumn.h
@@ -128,11 +128,6 @@ class ChunkedColumnBase : public ChunkedColumnInterface {
 
     virtual ~ChunkedColumnBase() = default;
 
-    void
-    ManualEvictCache() const override {
-        slot_->ManualEvictAll();
-    }
-
     PinWrapper<const char*>
     DataOfChunk(milvus::OpContext* op_ctx, int chunk_id) const override {
         auto ca = SemiInlineGet(slot_->PinCells(op_ctx, {chunk_id}));

--- a/internal/core/src/mmap/ChunkedColumnGroup.h
+++ b/internal/core/src/mmap/ChunkedColumnGroup.h
@@ -55,11 +55,6 @@ class ChunkedColumnGroup {
 
     virtual ~ChunkedColumnGroup() = default;
 
-    void
-    ManualEvictCache() const {
-        slot_->ManualEvictAll();
-    }
-
     // Get the number of group chunks
     size_t
     num_chunks() const {
@@ -184,11 +179,9 @@ class ProxyChunkColumn : public ChunkedColumnInterface {
           data_type_(field_meta.get_data_type()) {
     }
 
-    void
-    ManualEvictCache() const override {
-        if (group_->NumFieldsInGroup() == 1) {
-            group_->ManualEvictCache();
-        }
+    bool
+    IsInMultiFieldColumnGroup() const override {
+        return group_->NumFieldsInGroup() > 1;
     }
 
     PinWrapper<const char*>

--- a/internal/core/src/mmap/ChunkedColumnInterface.h
+++ b/internal/core/src/mmap/ChunkedColumnInterface.h
@@ -26,9 +26,12 @@ class ChunkedColumnInterface {
  public:
     virtual ~ChunkedColumnInterface() = default;
 
-    // Default implementation does nothing.
-    virtual void
-    ManualEvictCache() const {
+    // Check if the field is part of a multi-field column group.
+    // If true, the field data should not be dropped independently
+    // because it shares storage with other fields.
+    virtual bool
+    IsInMultiFieldColumnGroup() const {
+        return false;
     }
 
     // Get raw data pointer of a specific chunk

--- a/internal/core/src/segcore/ChunkedSegmentSealedBinlogIndexTest.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedBinlogIndexTest.cpp
@@ -222,7 +222,9 @@ TEST_P(BinlogIndexTest, AccuracyWithLoadFieldData) {
     EXPECT_TRUE(segment->HasIndex(vec_field_id));
     EXPECT_EQ(segment->get_row_count(), data_n);
 
-    EXPECT_TRUE(segment->HasFieldData(vec_field_id));
+    // When interim index has raw data, field data is dropped to save memory
+    EXPECT_EQ(segment->HasFieldData(vec_field_id),
+              !intermin_index_has_raw_data);
 
     // 2. search binlog index
     auto num_queries = 10;
@@ -318,7 +320,9 @@ TEST_P(BinlogIndexTest, AccuracyWithMapFieldData) {
     //assert segment has been built binlog index
     EXPECT_TRUE(segment->HasIndex(vec_field_id));
     EXPECT_EQ(segment->get_row_count(), data_n);
-    EXPECT_TRUE(segment->HasFieldData(vec_field_id));
+    // When interim index has raw data, field data is dropped to save memory
+    EXPECT_EQ(segment->HasFieldData(vec_field_id),
+              !intermin_index_has_raw_data);
 
     // 2. search binlog index
     auto num_queries = 10;

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -119,15 +119,6 @@ ChunkedSegmentSealedImpl::LoadVecIndex(const LoadIndexInfo& info) {
                "Can't get metric_type in index_params");
     auto metric_type = info.index_params.at("metric_type");
 
-    std::unique_lock lck(mutex_);
-    AssertInfo(
-        !get_bit(index_ready_bitset_, field_id),
-        "vector index has been exist at " + std::to_string(field_id.get()));
-    LOG_INFO(
-        "Before setting field_bit for field index, fieldID:{}. "
-        "segmentID:{}, ",
-        info.field_id,
-        id_);
     auto& field_meta = schema_->operator[](field_id);
     LoadResourceRequest request =
         milvus::index::IndexFactory::GetInstance().VecIndexLoadResource(
@@ -140,8 +131,47 @@ ChunkedSegmentSealedImpl::LoadVecIndex(const LoadIndexInfo& info) {
             info.num_rows,
             info.dim);
 
+    // Check if we need to reload field data before acquiring the exclusive lock
+    // This happens when the new index doesn't have raw data but field data
+    // was previously dropped (e.g., because the interim index had raw data)
+    bool need_reload_field_data = false;
+    {
+        std::shared_lock lck(mutex_);
+        if (!request.has_raw_data &&
+            // for drop index, field data must be exist, so no need to reload
+            !get_bit(field_data_ready_bitset_, field_id)) {
+            // Only reload if there was a previous index and it had raw data
+            // 1. for new segment loading, no previous index, so no need to reload, leave it to load_field_data_common()
+            // 2. for new index loading, check if the previous index had raw data (must be true), if so, reload field data
+            auto iter = index_has_raw_data_.find(field_id);
+            if (iter != index_has_raw_data_.end() && iter->second) {
+                need_reload_field_data = true;
+            }
+        }
+    }
+
+    // Reload field data first if needed (before acquiring the exclusive lock)
+    if (need_reload_field_data) {
+        LOG_INFO(
+            "Reloading field data for field {} in segment {} because new "
+            "index doesn't have raw data",
+            field_id.get(),
+            id_);
+        reload_field_data(field_id);
+    }
+
+    std::unique_lock lck(mutex_);
+    AssertInfo(
+        !get_bit(index_ready_bitset_, field_id),
+        "vector index has been exist at " + std::to_string(field_id.get()));
+    LOG_INFO(
+        "Before setting field_bit for field index, fieldID:{}. "
+        "segmentID:{}, ",
+        info.field_id,
+        id_);
+
     if (request.has_raw_data && get_bit(field_data_ready_bitset_, field_id)) {
-        fields_.rlock()->at(field_id)->ManualEvictCache();
+        drop_field_data_locked(field_id);
     }
     if (get_bit(binlog_index_bitset_, field_id)) {
         set_bit(binlog_index_bitset_, field_id, false);
@@ -240,7 +270,7 @@ ChunkedSegmentSealedImpl::LoadScalarIndex(const LoadIndexInfo& info) {
         !is_pk) {
         // We do not erase the primary key field: if insert record is evicted from memory, when reloading it'll
         // need the pk field again.
-        fields_.rlock()->at(field_id)->ManualEvictCache();
+        drop_field_data_locked(field_id);
     }
     LOG_INFO(
         "Has load scalar index done, fieldID:{}. segmentID:{}, has_raw_data:{}",
@@ -1156,15 +1186,122 @@ ChunkedSegmentSealedImpl::get_vector(milvus::OpContext* op_ctx,
 }
 
 void
+ChunkedSegmentSealedImpl::drop_field_data_locked(const FieldId field_id) {
+    // NOTE: mutex_ must be already held by caller
+    if (get_bit(field_data_ready_bitset_, field_id)) {
+        // Check if the field is in a multi-field column group.
+        // If so, skip dropping because it shares storage with other fields.
+        auto column = get_column(field_id);
+        if (column && column->IsInMultiFieldColumnGroup()) {
+            LOG_INFO(
+                "Skip dropping field data for field {} in segment {} because "
+                "it is part of a multi-field column group",
+                field_id.get(),
+                id_);
+            return;
+        }
+        fields_.wlock()->erase(field_id);
+        set_bit(field_data_ready_bitset_, field_id, false);
+    }
+}
+
+void
+ChunkedSegmentSealedImpl::reload_field_data(const FieldId field_id) {
+    // NOTE: This function should be called WITHOUT holding mutex_
+
+    // Check if field data is already loaded
+    {
+        std::shared_lock lck(mutex_);
+        if (get_bit(field_data_ready_bitset_, field_id)) {
+            LOG_INFO(
+                "Skip reloading field data for field {} in segment {} because "
+                "it is already loaded",
+                field_id.get(),
+                id_);
+            return;
+        }
+    }
+
+    auto manifest_path = segment_load_info_.manifest_path();
+    if (!manifest_path.empty()) {
+        // match LoadColumnGroups() path: find and reload the specific column group
+        auto properties =
+            milvus::storage::LoonFFIPropertiesSingleton::GetInstance()
+                .GetProperties();
+        auto column_groups = GetColumnGroups(manifest_path, properties);
+
+        // Find which column group contains the field_id
+        int64_t target_index = -1;
+        for (int64_t i = 0; i < column_groups->size(); ++i) {
+            auto column_group = column_groups->get_column_group(i);
+            for (const auto& column : column_group->columns) {
+                if (std::stoll(column) == field_id.get()) {
+                    target_index = i;
+                    break;
+                }
+            }
+            if (target_index != -1) {
+                break;
+            }
+        }
+
+        if (target_index != -1) {
+            LoadColumnGroup(column_groups, properties, target_index);
+        } else {
+            LOG_WARN(
+                "Cannot reload field data for field {} in segment {} "
+                "because field not found in manifest column groups",
+                field_id.get(),
+                id_);
+        }
+    } else {
+        // match LoadFieldData() path: find the column group ID and reload
+        // For non-column group scenarios, the key is the field ID itself
+        int64_t column_group_id = field_id.get();
+        for (const auto& [id, info] : field_data_info_.field_infos) {
+            if (info.child_field_ids.empty()) {
+                // Non-column group: key is the field ID itself
+                if (id == field_id.get()) {
+                    column_group_id = id;
+                    break;
+                }
+            } else {
+                // Column group: check if field_id is in child_field_ids
+                for (const auto& child_id : info.child_field_ids) {
+                    if (child_id == field_id.get()) {
+                        column_group_id = id;
+                        break;
+                    }
+                }
+            }
+        }
+
+        auto field_info_iter =
+            field_data_info_.field_infos.find(column_group_id);
+        if (field_info_iter != field_data_info_.field_infos.end()) {
+            LoadFieldDataInfo reload_info;
+            reload_info.storage_version = field_data_info_.storage_version;
+            reload_info.load_priority = field_data_info_.load_priority;
+            reload_info.field_infos[column_group_id] = field_info_iter->second;
+
+            LoadFieldData(reload_info);
+        } else {
+            LOG_WARN(
+                "Cannot reload field data for field {} in segment {} "
+                "because field info not found in field_data_info_",
+                field_id.get(),
+                id_);
+        }
+    }
+}
+
+void
 ChunkedSegmentSealedImpl::DropFieldData(const FieldId field_id) {
     AssertInfo(!SystemProperty::Instance().IsSystem(field_id),
                "Dropping system field is not supported, field id: {}",
                field_id.get());
     std::unique_lock<std::shared_mutex> lck(mutex_);
-    if (get_bit(field_data_ready_bitset_, field_id)) {
-        fields_.wlock()->erase(field_id);
-        set_bit(field_data_ready_bitset_, field_id, false);
-    }
+    drop_field_data_locked(field_id);
     if (get_bit(binlog_index_bitset_, field_id)) {
         set_bit(binlog_index_bitset_, field_id, false);
         vector_indexings_.drop_field_indexing(field_id);
@@ -1179,13 +1316,40 @@ ChunkedSegmentSealedImpl::DropIndex(const FieldId field_id) {
     auto& field_meta = schema_->operator[](field_id);
     AssertInfo(!field_meta.is_vector(), "vector field cannot drop index");
 
-    std::unique_lock lck(mutex_);
-    auto [scalar_indexings, ngram_fields] =
-        lock(folly::wlock(scalar_indexings_), folly::wlock(ngram_fields_));
-    scalar_indexings->erase(field_id);
-    ngram_fields->erase(field_id);
+    // Check if we need to reload field data
+    bool need_reload_field_data = false;
+    {
+        std::shared_lock lck(mutex_);
+        // If index had raw data and field data was dropped, we need to reload
+        auto iter = index_has_raw_data_.find(field_id);
+        if (iter != index_has_raw_data_.end() && iter->second &&
+            !get_bit(field_data_ready_bitset_, field_id)) {
+            need_reload_field_data = true;
+        }
+    }
 
-    set_bit(index_ready_bitset_, field_id, false);
+    // Reload field data first if needed (before erasing the index)
+    // This ensures we don't end up in a broken state with neither index nor raw data
+    if (need_reload_field_data) {
+        LOG_INFO(
+            "Reloading field data for field {} in segment {} after dropping "
+            "index with raw data",
+            field_id.get(),
+            id_);
+        reload_field_data(field_id);
+    }
+
+    // Erase the index after raw data is loaded successfully
+    {
+        std::unique_lock lck(mutex_);
+        auto [scalar_indexings, ngram_fields] =
+            lock(folly::wlock(scalar_indexings_), folly::wlock(ngram_fields_));
+        scalar_indexings->erase(field_id);
+        ngram_fields->erase(field_id);
+
+        set_bit(index_ready_bitset_, field_id, false);
+        index_has_raw_data_.erase(field_id);
+    }
 }
 
 void
@@ -2623,11 +2787,13 @@ ChunkedSegmentSealedImpl::load_field_data_common(
                field_id.get());
     set_bit(field_data_ready_bitset_, field_id, true);
     update_row_count(num_rows);
-    if (generated_interim_index) {
-        auto column = get_column(field_id);
-        if (column) {
-            column->ManualEvictCache();
-        }
+    // Only drop field data when the interim index has raw data.
+    // If the interim index doesn't have raw data, we need to keep the field data
+    // because the data cannot be retrieved from the index.
+    auto iter = index_has_raw_data_.find(field_id);
+    if (generated_interim_index && iter != index_has_raw_data_.end() &&
+        iter->second) {
+        drop_field_data_locked(field_id);
     }
     if (data_type == DataType::GEOMETRY &&
         segcore_config_.get_enable_geometry_cache()) {

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -392,6 +392,14 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
 
  private:
     void
+    drop_field_data_locked(const FieldId field_id);
+
+    // Reload field data from storage (used when index without raw data replaces
+    // an interim index that had raw data)
+    void
+    reload_field_data(const FieldId field_id);
+
+    void
     load_system_field_internal(
         FieldId field_id,
         FieldDataInfo& data,

--- a/internal/core/src/segcore/ChunkedSegmentSealedStorageV2Test.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedStorageV2Test.cpp
@@ -351,3 +351,52 @@ TEST_P(TestChunkSegmentStorageV2, TestCompareExpr) {
         plan, segment.get(), chunk_num * test_data_count, MAX_TIMESTAMP);
     ASSERT_EQ(chunk_num * test_data_count, final.count());
 }
+
+// Test DropFieldData behavior based on parquet file structure.
+// In this test setup, the parquet files are organized as:
+//   - paths[0] contains columns {0, 4, 3} = int64, ts, string2 (multi-field column group)
+//   - paths[1] contains column {2} = string1 (single-field group)
+//   - paths[2] contains column {1} = pk (single-field group)
+// When storage_version=2 reads a parquet file with multiple columns, they become
+// a multi-field column group, so DropFieldData should be skipped for those fields.
+TEST_P(TestChunkSegmentStorageV2, TestDropFieldDataWithColumnGroups) {
+    auto segment_impl = dynamic_cast<ChunkedSegmentSealedImpl*>(segment.get());
+    ASSERT_NE(segment_impl, nullptr);
+
+    // Verify fields have data initially
+    auto int64_fid = fields.at("int64");
+    auto string1_fid = fields.at("string1");
+    auto string2_fid = fields.at("string2");
+
+    EXPECT_TRUE(segment_impl->HasFieldData(int64_fid))
+        << "int64 field data should be ready";
+    EXPECT_TRUE(segment_impl->HasFieldData(string1_fid))
+        << "string1 field data should be ready";
+    EXPECT_TRUE(segment_impl->HasFieldData(string2_fid))
+        << "string2 field data should be ready";
+
+    // int64 and string2 are in the same parquet file (multi-field column group)
+    // DropFieldData should be SKIPPED for these fields
+    segment_impl->DropFieldData(int64_fid);
+
+    // int64 should still have data because it's in a multi-field column group
+    EXPECT_TRUE(segment_impl->HasFieldData(int64_fid))
+        << "int64 field data should still be ready (multi-field column group)";
+
+    // string2 is in the same group, should also still have data
+    EXPECT_TRUE(segment_impl->HasFieldData(string2_fid))
+        << "string2 field data should still be ready (same column group as "
+           "int64)";
+
+    // string1 is in its own parquet file (single-field group)
+    // DropFieldData SHOULD work for this field
+    segment_impl->DropFieldData(string1_fid);
+    EXPECT_FALSE(segment_impl->HasFieldData(string1_fid))
+        << "string1 field data should be dropped (single-field column group)";
+
+    // int64 and string2 should still have data
+    EXPECT_TRUE(segment_impl->HasFieldData(int64_fid))
+        << "int64 field data should still be ready";
+    EXPECT_TRUE(segment_impl->HasFieldData(string2_fid))
+        << "string2 field data should still be ready";
+}


### PR DESCRIPTION
issue: #46427

1. Replace the non-thread-safe ManualEvictCache() with DropFieldData()

2. DropFieldData() now skips dropping for multi-field column groups
   - Fields sharing storage with others cannot be dropped independently
   - Add IsInMultiFieldColumnGroup() to check if field shares storage with other fields
   - Logs info message when skip occurs

3. DropIndex() now reloads field data when index with raw data is dropped
   - Check if index had raw data and field data was previously dropped
   - Reload field data BEFORE erasing the index to avoid broken state
   - Support both LoadColumnGroups() (manifest) and LoadFieldData() paths
   - Find correct column group ID for the field being reloaded