### PR TITLE
fix: unify ro node handling to avoid balance channel task stuck

### DIFF
--- a/internal/querycoordv2/checkers/leader_checker.go
+++ b/internal/querycoordv2/checkers/leader_checker.go
@@ -92,13 +92,9 @@ func (c *LeaderChecker) Check(ctx context.Context) []task.Task {
 
 		replicas := c.meta.ReplicaManager.GetByCollection(ctx, collectionID)
 		for _, replica := range replicas {
-			// note: should enable sync segment distribution to ro node, to avoid balance channel from ro node stucks
-			nodes := replica.GetNodes()
+			nodes := replica.GetRWNodes()
 			if streamingutil.IsStreamingServiceEnabled() {
-				sqNodes := make([]int64, 0, len(replica.GetROSQNodes())+len(replica.GetRWSQNodes()))
-				sqNodes = append(sqNodes, replica.GetROSQNodes()...)
-				sqNodes = append(sqNodes, replica.GetRWSQNodes()...)
-				nodes = sqNodes
+				nodes = replica.GetRWSQNodes()
 			}
 			for _, node := range nodes {
 				delegatorList := c.dist.ChannelDistManager.GetByFilter(meta.WithCollectionID2Channel(replica.GetCollectionID()), meta.WithNodeID2Channel(node))

--- a/internal/querycoordv2/checkers/leader_checker_test.go
+++ b/internal/querycoordv2/checkers/leader_checker_test.go
@@ -291,7 +291,7 @@ func (suite *LeaderCheckerTestSuite) TestStoppingNode() {
 	observer.meta.ReplicaManager.Put(ctx, mutableReplica.IntoReplica())
 
 	tasks := suite.checker.Check(context.TODO())
-	suite.Len(tasks, 1)
+	suite.Len(tasks, 0)
 }
 
 func (suite *LeaderCheckerTestSuite) TestIgnoreSyncLoadedSegments() {


### PR DESCRIPTION
issue: #46393

RO node can be created from two sources: stopping a QueryNode or replica node transfer (e.g., suspend node). Before this fix, there were two defects and one constraint that caused a deadlock:

Defects:
1. LeaderChecker does not sync segment distribution to RO nodes
2. Scheduler only cancels tasks on stopping nodes, not RO nodes

Constraint:
- Balance channel task blocks waiting for new delegator to become serviceable (via sync segment) before executing release action

Deadlock scenario:
When target node becomes RO node (but not stopping) during balance channel execution, the task gets stuck because:
- Cannot sync segment to RO node (defect 1) -> task blocks
- Task is not cancelled since node is not stopping (defect 2)

PR #45949 attempted to fix defect 1 but was not successful.

This PR unifies RO node handling by:
- LeaderChecker: only sync segment distribution to RW nodes
- Scheduler: cancel task when target node becomes RO node
- Simplify checkStale logic with unified node state checking