### PR TITLE
enhance: [2.5] Retry reads from object storage on rate limit error

### DIFF
--- a/internal/storage/options.go
+++ b/internal/storage/options.go
@@ -1,5 +1,7 @@
 package storage
 
+import "github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+
 // Option for setting params used by chunk manager client.
 type config struct {
 	address              string
@@ -18,10 +20,13 @@ type config struct {
 	requestTimeoutMs     int64
 	gcpCredentialJSON    string
 	gcpNativeWithoutAuth bool // used for Unit Testing
+	readRetryAttempts    uint
 }
 
 func newDefaultConfig() *config {
-	return &config{}
+	return &config{
+		readRetryAttempts: paramtable.Get().CommonCfg.StorageReadRetryAttempts.GetAsUint(),
+	}
 }
 
 // Option is used to config the retry function.

--- a/internal/storage/remote_chunk_manager.go
+++ b/internal/storage/remote_chunk_manager.go
@@ -148,7 +148,7 @@ func (mcm *RemoteChunkManager) Reader(ctx context.Context, filePath string) (Fil
 func (mcm *RemoteChunkManager) Size(ctx context.Context, filePath string) (int64, error) {
 	var objectInfo int64
 	var err error
-	retry.Handle(ctx, func() (bool, error) {
+	err = retry.Handle(ctx, func() (bool, error) {
 		objectInfo, err = mcm.getObjectSize(ctx, mcm.bucketName, filePath)
 		if err == nil {
 			return false, nil

--- a/internal/storage/remote_chunk_manager.go
+++ b/internal/storage/remote_chunk_manager.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"syscall"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/bloberror"
@@ -72,6 +73,8 @@ type RemoteChunkManager struct {
 	//	ctx        context.Context
 	bucketName string
 	rootPath   string
+
+	readRetryAttempts uint
 }
 
 var _ ChunkManager = (*RemoteChunkManager)(nil)
@@ -90,9 +93,10 @@ func NewRemoteChunkManager(ctx context.Context, c *config) (*RemoteChunkManager,
 		return nil, err
 	}
 	mcm := &RemoteChunkManager{
-		client:     client,
-		bucketName: c.bucketName,
-		rootPath:   strings.TrimLeft(c.rootPath, "/"),
+		client:            client,
+		bucketName:        c.bucketName,
+		rootPath:          strings.TrimLeft(c.rootPath, "/"),
+		readRetryAttempts: c.readRetryAttempts,
 	}
 	log.Info("remote chunk manager init success.", zap.String("remote", c.cloudProvider), zap.String("bucketname", c.bucketName), zap.String("root", mcm.RootPath()))
 	return mcm, nil
@@ -101,9 +105,10 @@ func NewRemoteChunkManager(ctx context.Context, c *config) (*RemoteChunkManager,
 // NewRemoteChunkManagerForTesting is used for testing.
 func NewRemoteChunkManagerForTesting(c *minio.Client, bucket string, rootPath string) *RemoteChunkManager {
 	mcm := &RemoteChunkManager{
-		client:     &MinioObjectStorage{c},
-		bucketName: bucket,
-		rootPath:   rootPath,
+		client:            &MinioObjectStorage{c},
+		bucketName:        bucket,
+		rootPath:          rootPath,
+		readRetryAttempts: 10,
 	}
 	return mcm
 }
@@ -220,7 +225,7 @@ func (mcm *RemoteChunkManager) Read(ctx context.Context, filePath string) ([]byt
 		}
 		metrics.PersistentDataKvSize.WithLabelValues(metrics.DataGetLabel).Observe(float64(size))
 		return nil
-	}, retry.Attempts(3), retry.RetryErr(merr.IsRetryableErr))
+	}, retry.Attempts(mcm.readRetryAttempts), retry.RetryErr(merr.IsRetryableErr))
 	if err != nil {
 		return nil, err
 	}
@@ -408,6 +413,10 @@ func (mcm *RemoteChunkManager) removeObject(ctx context.Context, bucketName, obj
 	return err
 }
 
+func ToMilvusIoError(fileName string, err error) error {
+	return checkObjectStorageError(fileName, err)
+}
+
 func checkObjectStorageError(fileName string, err error) error {
 	if err == nil {
 		return nil
@@ -418,17 +427,31 @@ func checkObjectStorageError(fileName string, err error) error {
 		if err.ErrorCode == string(bloberror.BlobNotFound) {
 			return merr.WrapErrIoKeyNotFound(fileName, err.Error())
 		}
+		if err.ErrorCode == string(bloberror.ServerBusy) {
+			return merr.WrapErrIoTooManyRequests(fileName, err)
+		}
 		return merr.WrapErrIoFailed(fileName, err)
 	case minio.ErrorResponse:
 		if err.Code == "NoSuchKey" {
 			return merr.WrapErrIoKeyNotFound(fileName, err.Error())
+		}
+		if err.Code == "SlowDown" || err.Code == "TooManyRequestsException" {
+			return merr.WrapErrIoTooManyRequests(fileName, err)
 		}
 		return merr.WrapErrIoFailed(fileName, err)
 	case *googleapi.Error:
 		if err.Code == http.StatusNotFound {
 			return merr.WrapErrIoKeyNotFound(fileName, err.Error())
 		}
+		if err.Code == http.StatusTooManyRequests {
+			return merr.WrapErrIoTooManyRequests(fileName, err)
+		}
 		return merr.WrapErrIoFailed(fileName, err)
+	}
+	// syscall.ECONNRESET is typically triggered by rate limiting, with errors such as: `read tcp xxxxx:xx->xxxxxx:xxxxx: read: connection reset by peer`
+	// so we need to wrap it as ErrIoTooManyRequests and trigger retry.
+	if errors.Is(err, syscall.ECONNRESET) {
+		return merr.WrapErrIoTooManyRequests(fileName, err)
 	}
 	if err == io.ErrUnexpectedEOF {
 		return merr.WrapErrIoUnexpectEOF(fileName, err)

--- a/internal/storage/remote_chunk_manager.go
+++ b/internal/storage/remote_chunk_manager.go
@@ -146,13 +146,21 @@ func (mcm *RemoteChunkManager) Reader(ctx context.Context, filePath string) (Fil
 }
 
 func (mcm *RemoteChunkManager) Size(ctx context.Context, filePath string) (int64, error) {
-	objectInfo, err := mcm.getObjectSize(ctx, mcm.bucketName, filePath)
-	if err != nil {
-		log.Warn("failed to stat object", zap.String("bucket", mcm.bucketName), zap.String("path", filePath), zap.Error(err))
-		return 0, err
-	}
-
-	return objectInfo, nil
+	var objectInfo int64
+	var err error
+	retry.Handle(ctx, func() (bool, error) {
+		objectInfo, err = mcm.getObjectSize(ctx, mcm.bucketName, filePath)
+		if err == nil {
+			return false, nil
+		}
+		log.Warn("failed to get object size", zap.String("bucket", mcm.bucketName), zap.String("path", filePath), zap.Error(err))
+		err = checkObjectStorageError(filePath, err)
+		if merr.IsRetryableErr(err) {
+			return true, err
+		}
+		return false, err
+	}, retry.Attempts(mcm.readRetryAttempts))
+	return objectInfo, err
 }
 
 // Write writes the data to minio storage.

--- a/internal/util/importutilv2/common/mock_reader.go
+++ b/internal/util/importutilv2/common/mock_reader.go
@@ -1,0 +1,82 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"io"
+	"strings"
+
+	"github.com/milvus-io/milvus/internal/storage"
+)
+
+// mockFileReader is a mock implementation of storage.FileReader for testing.
+type mockFileReader struct {
+	io.Reader
+	io.Closer
+	io.ReaderAt
+	io.Seeker
+	size int64
+
+	err      error
+	errCount int
+}
+
+func NewMockReader(content string) storage.FileReader {
+	reader := strings.NewReader(content)
+	return &mockFileReader{
+		Reader:   reader,
+		Closer:   io.NopCloser(reader),
+		ReaderAt: reader,
+		Seeker:   reader,
+		size:     int64(len(content)),
+		err:      nil,
+		errCount: 0,
+	}
+}
+
+func CustomMockReader(reader io.Reader) storage.FileReader {
+	return &mockFileReader{
+		Reader: reader,
+		Closer: io.NopCloser(reader),
+		size:   0,
+	}
+}
+
+func newErrorMockReader(content string, err error, errCount int) storage.FileReader {
+	reader := strings.NewReader(content)
+	return &mockFileReader{
+		Reader:   reader,
+		Closer:   io.NopCloser(reader),
+		ReaderAt: reader,
+		Seeker:   reader,
+		size:     int64(len(content)),
+		err:      err,
+		errCount: errCount,
+	}
+}
+
+func (m *mockFileReader) Read(p []byte) (int, error) {
+	if m.errCount > 0 {
+		m.errCount--
+		return 0, m.err
+	}
+	return m.Reader.Read(p)
+}
+
+func (m *mockFileReader) Size() (int64, error) {
+	return m.size, nil
+}

--- a/internal/util/importutilv2/common/retryable_reader.go
+++ b/internal/util/importutilv2/common/retryable_reader.go
@@ -57,7 +57,7 @@ func NewRetryableReader(ctx context.Context, path string, reader storage.FileRea
 func (r *retryableReader) Read(p []byte) (int, error) {
 	var n int
 	var err error
-	retry.Handle(r.ctx, func() (bool, error) {
+	err = retry.Handle(r.ctx, func() (bool, error) {
 		n, err = r.FileReader.Read(p)
 		if err == nil {
 			return false, nil

--- a/internal/util/importutilv2/common/retryable_reader.go
+++ b/internal/util/importutilv2/common/retryable_reader.go
@@ -1,0 +1,79 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"context"
+	"io"
+
+	"github.com/cockroachdb/errors"
+	"go.uber.org/zap"
+
+	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/pkg/v2/log"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v2/util/retry"
+)
+
+// RetryableReader is a wrapper around a FileReader that retries reads on errors.
+type RetryableReader interface {
+	storage.FileReader
+}
+
+// retryableReader is the implementation of RetryableReader.
+type retryableReader struct {
+	storage.FileReader
+	ctx           context.Context
+	path          string
+	retryAttempts uint
+}
+
+// NewRetryableReader creates a new RetryableReader.
+func NewRetryableReader(ctx context.Context, path string, reader storage.FileReader) RetryableReader {
+	return &retryableReader{
+		FileReader:    reader,
+		ctx:           ctx,
+		path:          path,
+		retryAttempts: paramtable.Get().CommonCfg.StorageReadRetryAttempts.GetAsUint(),
+	}
+}
+
+// Read reads from the underlying FileReader and retries on errors.
+func (r *retryableReader) Read(p []byte) (int, error) {
+	var n int
+	var err error
+	retry.Handle(r.ctx, func() (bool, error) {
+		n, err = r.FileReader.Read(p)
+		if err == nil {
+			return false, nil
+		}
+		if errors.Is(err, io.EOF) {
+			return false, err
+		}
+		log.Ctx(r.ctx).Warn("retryable reader read failed",
+			zap.String("path", r.path),
+			zap.Error(err),
+		)
+		err = storage.ToMilvusIoError(r.path, err)
+		if merr.IsRetryableErr(err) {
+			return true, err
+		}
+		return false, err
+	}, retry.Attempts(r.retryAttempts))
+	return n, err
+}

--- a/internal/util/importutilv2/common/retryable_reader_test.go
+++ b/internal/util/importutilv2/common/retryable_reader_test.go
@@ -26,7 +26,12 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
+
+func init() {
+	paramtable.Init()
+}
 
 func TestRetryableReader_ReadSuccess(t *testing.T) {
 	ctx := context.Background()

--- a/internal/util/importutilv2/common/retryable_reader_test.go
+++ b/internal/util/importutilv2/common/retryable_reader_test.go
@@ -1,0 +1,89 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"context"
+	"io"
+	"math"
+	"testing"
+
+	"github.com/minio/minio-go/v7"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+)
+
+func TestRetryableReader_ReadSuccess(t *testing.T) {
+	ctx := context.Background()
+	path := "/test/path"
+	expectedData := "hello world"
+
+	mockReader := NewMockReader(expectedData)
+
+	reader := NewRetryableReader(ctx, path, mockReader)
+
+	buf := make([]byte, len(expectedData))
+	n, err := reader.Read(buf)
+	assert.NoError(t, err)
+	assert.Equal(t, len(expectedData), n)
+	assert.Equal(t, expectedData, string(buf))
+
+	buf = make([]byte, len(expectedData))
+	n, err = reader.Read(buf)
+	assert.ErrorIs(t, err, io.EOF)
+	assert.Equal(t, 0, n)
+}
+
+func TestRetryableReader_ReadWithRetryableError(t *testing.T) {
+	ctx := context.Background()
+	path := "/test/path"
+	expectedData := "data after retry"
+
+	mockReader := newErrorMockReader(expectedData,
+		minio.ErrorResponse{
+			Code: "TooManyRequestsException",
+		},
+		3,
+	)
+
+	reader := NewRetryableReader(ctx, path, mockReader)
+	buf := make([]byte, len(expectedData))
+	n, err := reader.Read(buf)
+
+	assert.NoError(t, err)
+	assert.Equal(t, len(expectedData), n)
+	assert.Equal(t, expectedData, string(buf))
+}
+
+func TestRetryableReader_ReadWithNonRetryableError(t *testing.T) {
+	ctx := context.Background()
+	path := "/test/path"
+
+	mockReader := newErrorMockReader("",
+		merr.WrapErrIoFailed(path, io.ErrNoProgress),
+		math.MaxInt,
+	)
+
+	reader := NewRetryableReader(ctx, path, mockReader)
+	buf := make([]byte, 10)
+	n, err := reader.Read(buf)
+
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, merr.ErrIoFailed)
+	assert.Equal(t, 0, n)
+}

--- a/internal/util/importutilv2/csv/reader_test.go
+++ b/internal/util/importutilv2/csv/reader_test.go
@@ -34,16 +34,16 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
 
+func init() {
+	paramtable.Init()
+}
+
 type ReaderSuite struct {
 	suite.Suite
 
 	numRows     int
 	pkDataType  schemapb.DataType
 	vecDataType schemapb.DataType
-}
-
-func (suite *ReaderSuite) SetupSuite() {
-	paramtable.Get().Init(paramtable.NewBaseTable())
 }
 
 func (suite *ReaderSuite) SetupTest() {

--- a/internal/util/importutilv2/json/reader_test.go
+++ b/internal/util/importutilv2/json/reader_test.go
@@ -19,9 +19,7 @@ package json
 import (
 	"context"
 	"encoding/json"
-	"io"
 	"math"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
@@ -31,23 +29,12 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/mocks"
 	"github.com/milvus-io/milvus/internal/storage"
+	importcommon "github.com/milvus-io/milvus/internal/util/importutilv2/common"
 	"github.com/milvus-io/milvus/internal/util/nullutil"
 	"github.com/milvus-io/milvus/internal/util/testutil"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
-
-type mockReader struct {
-	io.Reader
-	io.Closer
-	io.ReaderAt
-	io.Seeker
-	size int64
-}
-
-func (mr *mockReader) Size() (int64, error) {
-	return mr.size, nil
-}
 
 type ReaderSuite struct {
 	suite.Suite
@@ -144,7 +131,7 @@ func (suite *ReaderSuite) run(dataType schemapb.DataType, elemType schemapb.Data
 
 	cm := mocks.NewChunkManager(suite.T())
 	cm.EXPECT().Reader(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, s string) (storage.FileReader, error) {
-		r := &mockReader{Reader: strings.NewReader(string(jsonBytes))}
+		r := importcommon.NewMockReader(string(jsonBytes))
 		return r, nil
 	})
 	reader, err := NewReader(context.Background(), cm, schema, "mockPath", math.MaxInt)
@@ -213,7 +200,7 @@ func (suite *ReaderSuite) runWithDefaultValue(dataType schemapb.DataType, elemTy
 
 	cm := mocks.NewChunkManager(suite.T())
 	cm.EXPECT().Reader(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, s string) (storage.FileReader, error) {
-		r := &mockReader{Reader: strings.NewReader(string(jsonBytes))}
+		r := importcommon.NewMockReader(string(jsonBytes))
 		return r, nil
 	})
 	reader, err := NewReader(context.Background(), cm, schema, "mockPath", math.MaxInt)
@@ -355,7 +342,7 @@ func (suite *ReaderSuite) TestAllowInsertAutoID_KeepUserPK() {
 	{
 		cm := mocks.NewChunkManager(suite.T())
 		cm.EXPECT().Reader(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, s string) (storage.FileReader, error) {
-			r := &mockReader{Reader: strings.NewReader(string(jsonBytes))}
+			r := importcommon.NewMockReader(string(jsonBytes))
 			return r, nil
 		})
 		reader, err := NewReader(context.Background(), cm, schema, "mockPath", math.MaxInt)
@@ -370,7 +357,7 @@ func (suite *ReaderSuite) TestAllowInsertAutoID_KeepUserPK() {
 		schema.Properties = []*commonpb.KeyValuePair{{Key: common.AllowInsertAutoIDKey, Value: "true"}}
 		cm := mocks.NewChunkManager(suite.T())
 		cm.EXPECT().Reader(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, s string) (storage.FileReader, error) {
-			r := &mockReader{Reader: strings.NewReader(string(jsonBytes))}
+			r := importcommon.NewMockReader(string(jsonBytes))
 			return r, nil
 		})
 		reader, err := NewReader(context.Background(), cm, schema, "mockPath", math.MaxInt)

--- a/internal/util/importutilv2/json/reader_test.go
+++ b/internal/util/importutilv2/json/reader_test.go
@@ -36,16 +36,16 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
 
+func init() {
+	paramtable.Init()
+}
+
 type ReaderSuite struct {
 	suite.Suite
 
 	numRows     int
 	pkDataType  schemapb.DataType
 	vecDataType schemapb.DataType
-}
-
-func (suite *ReaderSuite) SetupSuite() {
-	paramtable.Get().Init(paramtable.NewBaseTable())
 }
 
 func (suite *ReaderSuite) SetupTest() {

--- a/internal/util/importutilv2/numpy/field_reader_test.go
+++ b/internal/util/importutilv2/numpy/field_reader_test.go
@@ -29,7 +29,12 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
+
+func init() {
+	paramtable.Init()
+}
 
 func encodeToGB2312(input string) ([]byte, error) {
 	encoder := simplifiedchinese.GB18030.NewEncoder() // GB18030 is compatible with GB2312.

--- a/internal/util/importutilv2/numpy/reader.go
+++ b/internal/util/importutilv2/numpy/reader.go
@@ -161,7 +161,8 @@ func CreateReaders(ctx context.Context, cm storage.ChunkManager, schema *schemap
 			return nil, merr.WrapErrImportFailed(
 				fmt.Sprintf("failed to read the file '%s', error: %s", path, err.Error()))
 		}
-		readers[field.GetFieldID()] = reader
+		retryableReader := common.NewRetryableReader(ctx, path, reader)
+		readers[field.GetFieldID()] = retryableReader
 	}
 	return readers, nil
 }

--- a/internal/util/importutilv2/numpy/reader_test.go
+++ b/internal/util/importutilv2/numpy/reader_test.go
@@ -36,23 +36,12 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/mocks"
 	"github.com/milvus-io/milvus/internal/storage"
+	importcommon "github.com/milvus-io/milvus/internal/util/importutilv2/common"
 	"github.com/milvus-io/milvus/internal/util/testutil"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
-
-type mockReader struct {
-	io.Reader
-	io.Closer
-	io.ReaderAt
-	io.Seeker
-	size int64
-}
-
-func (mr *mockReader) Size() (int64, error) {
-	return mr.size, nil
-}
 
 type ReaderSuite struct {
 	suite.Suite
@@ -201,9 +190,7 @@ func (suite *ReaderSuite) run(dt schemapb.DataType) {
 
 		reader, err := CreateReader(data)
 		suite.NoError(err)
-		cm.EXPECT().Reader(mock.Anything, files[fieldID]).Return(&mockReader{
-			Reader: reader,
-		}, nil)
+		cm.EXPECT().Reader(mock.Anything, files[fieldID]).Return(importcommon.CustomMockReader(reader), nil)
 	}
 
 	reader, err := NewReader(context.Background(), cm, schema, lo.Values(files), math.MaxInt)
@@ -328,9 +315,7 @@ func (suite *ReaderSuite) failRun(dt schemapb.DataType, isDynamic bool) {
 
 		reader, err := CreateReader(data)
 		suite.NoError(err)
-		cm.EXPECT().Reader(mock.Anything, files[fieldID]).Return(&mockReader{
-			Reader: reader,
-		}, nil)
+		cm.EXPECT().Reader(mock.Anything, files[fieldID]).Return(importcommon.CustomMockReader(reader), nil)
 	}
 
 	reader, err := NewReader(context.Background(), cm, schema, lo.Values(files), math.MaxInt)

--- a/internal/util/importutilv2/numpy/reader_test.go
+++ b/internal/util/importutilv2/numpy/reader_test.go
@@ -39,7 +39,6 @@ import (
 	importcommon "github.com/milvus-io/milvus/internal/util/importutilv2/common"
 	"github.com/milvus-io/milvus/internal/util/testutil"
 	"github.com/milvus-io/milvus/pkg/v2/common"
-	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
 
@@ -49,10 +48,6 @@ type ReaderSuite struct {
 	numRows     int
 	pkDataType  schemapb.DataType
 	vecDataType schemapb.DataType
-}
-
-func (suite *ReaderSuite) SetupSuite() {
-	paramtable.Get().Init(paramtable.NewBaseTable())
 }
 
 func (suite *ReaderSuite) SetupTest() {

--- a/internal/util/importutilv2/parquet/field_reader_test.go
+++ b/internal/util/importutilv2/parquet/field_reader_test.go
@@ -19,8 +19,13 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/util/testutil"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
+
+func init() {
+	paramtable.Init()
+}
 
 func TestInvalidUTF8(t *testing.T) {
 	const (

--- a/internal/util/importutilv2/parquet/reader_test.go
+++ b/internal/util/importutilv2/parquet/reader_test.go
@@ -42,7 +42,6 @@ import (
 	"github.com/milvus-io/milvus/internal/util/nullutil"
 	"github.com/milvus-io/milvus/internal/util/testutil"
 	"github.com/milvus-io/milvus/pkg/v2/common"
-	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
 
@@ -52,10 +51,6 @@ type ReaderSuite struct {
 	numRows     int
 	pkDataType  schemapb.DataType
 	vecDataType schemapb.DataType
-}
-
-func (s *ReaderSuite) SetupSuite() {
-	paramtable.Get().Init(paramtable.NewBaseTable())
 }
 
 func (s *ReaderSuite) SetupTest() {

--- a/pkg/util/merr/errors.go
+++ b/pkg/util/merr/errors.go
@@ -127,9 +127,10 @@ var (
 	ErrNodeStateUnexpected = newMilvusError("node state unexpected", 906, false)
 
 	// IO related
-	ErrIoKeyNotFound = newMilvusError("key not found", 1000, false)
-	ErrIoFailed      = newMilvusError("IO failed", 1001, false)
-	ErrIoUnexpectEOF = newMilvusError("unexpected EOF", 1002, true)
+	ErrIoKeyNotFound     = newMilvusError("key not found", 1000, false)
+	ErrIoFailed          = newMilvusError("IO failed", 1001, false)
+	ErrIoUnexpectEOF     = newMilvusError("unexpected EOF", 1002, true)
+	ErrIoTooManyRequests = newMilvusError("too many requests", 1003, true)
 
 	// Parameter related
 	ErrParameterInvalid  = newMilvusError("invalid parameter", 1100, false)

--- a/pkg/util/merr/utils.go
+++ b/pkg/util/merr/utils.go
@@ -922,6 +922,13 @@ func WrapErrIoUnexpectEOF(key string, err error) error {
 	return wrapFieldsWithDesc(ErrIoUnexpectEOF, err.Error(), value("key", key))
 }
 
+func WrapErrIoTooManyRequests(key string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return wrapFieldsWithDesc(ErrIoTooManyRequests, err.Error(), value("key", key))
+}
+
 // Parameter related
 func WrapErrParameterInvalid[T any](expected, actual T, msg ...string) error {
 	err := wrapFields(ErrParameterInvalid,

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -285,6 +285,7 @@ type commonConfig struct {
 	StorageScheme             ParamItem `refreshable:"false"`
 	EnableStorageV2           ParamItem `refreshable:"false"`
 	StoragePathPrefix         ParamItem `refreshable:"false"`
+	StorageReadRetryAttempts  ParamItem `refreshable:"true"`
 	TTMsgEnabled              ParamItem `refreshable:"true"`
 	TraceLogMode              ParamItem `refreshable:"true"`
 	BloomFilterSize           ParamItem `refreshable:"true"`
@@ -943,6 +944,15 @@ Large numeric passwords require double quotes to avoid yaml parsing precision is
 		DefaultValue: "",
 	}
 	p.StoragePathPrefix.Init(base.mgr)
+
+	p.StorageReadRetryAttempts = ParamItem{
+		Key:          "common.storage.readRetryAttempts",
+		Version:      "2.6.8",
+		DefaultValue: "10",
+		Doc:          "The number of retry attempts for reading from object storage; only retryable errors will trigger a retry.",
+		Export:       false,
+	}
+	p.StorageReadRetryAttempts.Init(base.mgr)
 
 	p.TTMsgEnabled = ParamItem{
 		Key:          "common.ttMsgEnabled",


### PR DESCRIPTION
This PR improves the robustness of object storage operations by retrying both explicit throttling errors (e.g. HTTP 429, SlowDown, ServerBusy). These errors commonly occur under high concurrency and are typically recoverable with bounded retries.

issue: https://github.com/milvus-io/milvus/issues/44772

pr: https://github.com/milvus-io/milvus/pull/46455