### PR TITLE
enhance: save BM25 stats to the disk while loading the segment

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -582,7 +582,6 @@ queryNode:
     size: 10 # the size for worker querynode client pool
   idfOracle:
     enableDisk: true
-    writeConcurrency: 4
   ip:  # TCP/IP address of queryNode. If not specified, use the first unicastable address
   port: 21123 # TCP port of queryNode
   grpc:
@@ -924,6 +923,7 @@ common:
     highPriority: 10 # This parameter specify how many times the number of threads is the number of cores in high priority pool
     middlePriority: 5 # This parameter specify how many times the number of threads is the number of cores in middle priority pool
     lowPriority: 1 # This parameter specify how many times the number of threads is the number of cores in low priority pool
+    bm25Load: 1 # This parameter specify how many times the number of threads is the number of cores in BM25 load pool
   buildIndexThreadPoolRatio: 0.75
   DiskIndex:
     MaxDegree: 56

--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -155,7 +155,7 @@ func (sd *shardDelegator) ProcessInsert(insertRecords map[int64]*InsertData) {
 				// register created growing segment after insert, avoid to add empty growing to delegator
 				sd.pkOracle.Register(growing, paramtable.GetNodeID())
 				if sd.idfOracle != nil {
-					sd.idfOracle.Register(segmentID, insertData.BM25Stats, segments.SegmentTypeGrowing)
+					sd.idfOracle.RegisterGrowing(segmentID, insertData.BM25Stats)
 				}
 				sd.segmentManager.Put(context.Background(), segments.SegmentTypeGrowing, growing)
 				sd.addGrowing(SegmentEntry{
@@ -379,7 +379,7 @@ func (sd *shardDelegator) LoadGrowing(ctx context.Context, infos []*querypb.Segm
 	for _, segment := range loaded {
 		sd.pkOracle.Register(segment, paramtable.GetNodeID())
 		if sd.idfOracle != nil {
-			sd.idfOracle.Register(segment.ID(), segment.GetBM25Stats(), segments.SegmentTypeGrowing)
+			sd.idfOracle.RegisterGrowing(segment.ID(), segment.GetBM25Stats())
 		}
 	}
 	sd.addGrowing(lo.Map(loaded, func(segment segments.Segment, _ int) SegmentEntry {
@@ -391,6 +391,51 @@ func (sd *shardDelegator) LoadGrowing(ctx context.Context, infos []*querypb.Segm
 			TargetVersion: sd.distribution.getTargetVersion(),
 		}
 	})...)
+	return nil
+}
+
+// load bm25 stats for sealed segments
+func (sd *shardDelegator) loadBM25Stats(ctx context.Context, infos []*querypb.SegmentLoadInfo, req *querypb.LoadSegmentsRequest) error {
+	if sd.idfOracle == nil {
+		return nil
+	}
+
+	pool := segments.GetBM25LoadPool()
+
+	future := pool.Submit(func() (any, error) {
+		bm25Stats, err := sd.loader.LoadBM25Stats(ctx, req.GetCollectionID(), infos...)
+		if err != nil {
+			log.Warn("failed to load bm25 stats for segment", zap.Int64("collectionID", req.GetCollectionID()), zap.Error(err))
+			return nil, err
+		}
+
+		if bm25Stats != nil {
+			bm25Stats.Range(func(segmentID int64, stats map[int64]*storage.BM25Stats) bool {
+				log.Info("register sealed segment bm25 stats into idforacle",
+					zap.Int64("segmentID", segmentID),
+				)
+				err = sd.idfOracle.RegisterSealed(segmentID, stats)
+				if err != nil {
+					log.Warn("failed to register sealed segment bm25 stats into idforacle", zap.Error(err))
+					return false
+				}
+				return true
+			})
+
+			if err != nil {
+				log.Warn("failed to register sealed segment bm25 stats into idforacle", zap.Error(err))
+				return nil, err
+			}
+		}
+
+		return nil, nil
+	})
+
+	err := conc.BlockOnAll(future)
+	if err != nil {
+		log.Warn("failed to load bm25 stats", zap.Error(err))
+		return err
+	}
 	return nil
 }
 
@@ -485,19 +530,10 @@ func (sd *shardDelegator) LoadSegments(ctx context.Context, req *querypb.LoadSeg
 			Level:       info.GetLevel(),
 		}
 	})
-	// load bloom filter only when candidate not exists
+
 	infos := lo.Filter(req.GetInfos(), func(info *querypb.SegmentLoadInfo, _ int) bool {
 		return !sd.pkOracle.Exists(pkoracle.NewCandidateKey(info.GetSegmentID(), info.GetPartitionID(), commonpb.SegmentState_Sealed), targetNodeID)
 	})
-
-	var bm25Stats *typeutil.ConcurrentMap[int64, map[int64]*storage.BM25Stats]
-	if sd.idfOracle != nil {
-		bm25Stats, err = sd.loader.LoadBM25Stats(ctx, req.GetCollectionID(), infos...)
-		if err != nil {
-			log.Warn("failed to load bm25 stats for segment", zap.Error(err))
-			return err
-		}
-	}
 
 	candidates, err := sd.loader.LoadBloomFilterSet(ctx, req.GetCollectionID(), infos...)
 	if err != nil {
@@ -506,10 +542,24 @@ func (sd *shardDelegator) LoadSegments(ctx context.Context, req *querypb.LoadSeg
 	}
 
 	log.Debug("load delete...")
-	err = sd.loadStreamDelete(ctx, candidates, bm25Stats, infos, req, targetNodeID, worker)
+	err = sd.loadStreamDelete(ctx, candidates, infos, req, targetNodeID, worker)
 	if err != nil {
 		log.Warn("load stream delete failed", zap.Error(err))
 		return err
+	}
+
+	err = sd.loadBM25Stats(ctx, infos, req)
+	if err != nil {
+		log.Warn("failed to load BM25 stats", zap.Error(err))
+		return err
+	}
+
+	// add candidate after load success
+	for _, candidate := range candidates {
+		log.Info("register sealed segment bfs into pko candidates",
+			zap.Int64("segmentID", candidate.ID()),
+		)
+		sd.pkOracle.Register(candidate, targetNodeID)
 	}
 
 	return sd.addDistributionIfVersionOK(req.GetLoadMeta().GetSchemaVersion(), entries...)
@@ -660,7 +710,6 @@ func (sd *shardDelegator) RefreshLevel0DeletionStats() {
 
 func (sd *shardDelegator) loadStreamDelete(ctx context.Context,
 	candidates []*pkoracle.BloomFilterSet,
-	bm25Stats *typeutil.ConcurrentMap[int64, map[int64]*storage.BM25Stats],
 	infos []*querypb.SegmentLoadInfo,
 	req *querypb.LoadSegmentsRequest,
 	targetNodeID int64,
@@ -745,28 +794,7 @@ func (sd *shardDelegator) loadStreamDelete(ctx context.Context,
 			return err
 		}
 	}
-
-	// add candidate after load success
-	for _, candidate := range candidates {
-		log.Info("register sealed segment bfs into pko candidates",
-			zap.Int64("segmentID", candidate.ID()),
-		)
-		sd.pkOracle.Register(candidate, targetNodeID)
-	}
-
-	if sd.idfOracle != nil && bm25Stats != nil {
-		bm25Stats.Range(func(segmentID int64, stats map[int64]*storage.BM25Stats) bool {
-			log.Info("register sealed segment bm25 stats into idforacle",
-				zap.Int64("segmentID", segmentID),
-			)
-			sd.idfOracle.Register(segmentID, stats, segments.SegmentTypeSealed)
-			// continue iterating to register all segments' stats
-			return true
-		})
-	}
-
 	log.Info("load delete done")
-
 	return nil
 }
 

--- a/internal/querynodev2/delegator/delegator_data_test.go
+++ b/internal/querynodev2/delegator/delegator_data_test.go
@@ -618,6 +618,7 @@ func (s *DelegatorDataSuite) TestLoadSegmentsWithBm25() {
 			s.loader.ExpectedCalls = nil
 		}()
 
+		s.loader.EXPECT().LoadBloomFilterSet(mock.Anything, s.collectionID, mock.Anything).Return(nil, nil)
 		s.loader.EXPECT().LoadBM25Stats(mock.Anything, s.collectionID, mock.Anything).Return(nil, errors.New("mock error"))
 
 		workers := make(map[int64]*cluster.MockWorker)
@@ -1009,7 +1010,7 @@ func (s *DelegatorDataSuite) TestBuildBM25IDF() {
 		sealedSegs := []int64{1, 2, 3, 4}
 		for _, segID := range sealedSegs {
 			// every segment stats only has one token, avgdl = 1
-			s.delegator.idfOracle.Register(segID, genBM25Stats(uint32(segID), uint32(segID)+1), commonpb.SegmentState_Sealed)
+			s.delegator.idfOracle.RegisterSealed(segID, genBM25Stats(uint32(segID), uint32(segID)+1))
 		}
 		snapshot := genSnapShot([]int64{1, 2, 3, 4}, []int64{}, 100)
 
@@ -1166,7 +1167,7 @@ func (s *DelegatorDataSuite) TestBuildBM25IDF() {
 		sealedSegs := []int64{1, 2, 3, 4}
 		for _, segID := range sealedSegs {
 			// every segment stats only has one token, avgdl = 1
-			s.delegator.idfOracle.Register(segID, genBM25Stats(uint32(segID), uint32(segID)+1), commonpb.SegmentState_Sealed)
+			s.delegator.idfOracle.RegisterSealed(segID, genBM25Stats(uint32(segID), uint32(segID)+1))
 		}
 		snapshot := genSnapShot([]int64{1, 2, 3, 4}, []int64{}, 100)
 

--- a/internal/querynodev2/delegator/idf_oracle_test.go
+++ b/internal/querynodev2/delegator/idf_oracle_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
-	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
@@ -128,18 +127,18 @@ func (suite *IDFOracleSuite) TestSealed() {
 	// register sealed
 	sealedSegs := []int64{1, 2, 3, 4}
 	for _, segID := range sealedSegs {
-		suite.idfOracle.Register(segID, suite.genStats(uint32(segID), uint32(segID)+1), commonpb.SegmentState_Sealed)
+		suite.idfOracle.RegisterSealed(segID, suite.genStats(uint32(segID), uint32(segID)+1))
 	}
 
 	// reduplicate register
 	for _, segID := range sealedSegs {
-		suite.idfOracle.Register(segID, suite.genStats(uint32(segID), uint32(segID)+1), commonpb.SegmentState_Sealed)
+		suite.idfOracle.RegisterSealed(segID, suite.genStats(uint32(segID), uint32(segID)+1))
 	}
 
 	// some sealed not in target
 	invalidSealedSegs := []int64{5, 6}
 	for _, segID := range invalidSealedSegs {
-		suite.idfOracle.Register(segID, suite.genStats(uint32(segID), uint32(segID)+1), commonpb.SegmentState_Sealed)
+		suite.idfOracle.RegisterSealed(segID, suite.genStats(uint32(segID), uint32(segID)+1))
 	}
 
 	// register sealed segment and all preload to current
@@ -177,11 +176,11 @@ func (suite *IDFOracleSuite) TestGrow() {
 	// register grow
 	growSegs := []int64{1, 2, 3, 4}
 	for _, segID := range growSegs {
-		suite.idfOracle.Register(segID, suite.genStats(uint32(segID), uint32(segID)+1), commonpb.SegmentState_Growing)
+		suite.idfOracle.RegisterGrowing(segID, suite.genStats(uint32(segID), uint32(segID)+1))
 	}
 	// reduplicate register
 	for _, segID := range growSegs {
-		suite.idfOracle.Register(segID, suite.genStats(uint32(segID), uint32(segID)+1), commonpb.SegmentState_Growing)
+		suite.idfOracle.RegisterGrowing(segID, suite.genStats(uint32(segID), uint32(segID)+1))
 	}
 
 	// register sealed segment but all deactvate
@@ -217,13 +216,13 @@ func (suite *IDFOracleSuite) TestLocalCache() {
 	// register sealed
 	sealedSegs := []int64{1, 2, 3, 4}
 	for _, segID := range sealedSegs {
-		suite.idfOracle.Register(segID, suite.genStats(uint32(segID), uint32(segID)+1), commonpb.SegmentState_Sealed)
+		suite.idfOracle.RegisterSealed(segID, suite.genStats(uint32(segID), uint32(segID)+1))
 	}
 
 	// some sealed not in target
 	invalidSealedSegs := []int64{5, 6}
 	for _, segID := range invalidSealedSegs {
-		suite.idfOracle.Register(segID, suite.genStats(uint32(segID), uint32(segID)+1), commonpb.SegmentState_Sealed)
+		suite.idfOracle.RegisterSealed(segID, suite.genStats(uint32(segID), uint32(segID)+1))
 	}
 
 	// register sealed segment and all preload to current

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -47,6 +47,7 @@ const (
 	DefaultHighPriorityThreadCoreCoefficient   = 10
 	DefaultMiddlePriorityThreadCoreCoefficient = 5
 	DefaultLowPriorityThreadCoreCoefficient    = 1
+	DefaultBM25LoadThreadCoreCoefficient       = 1
 
 	DefaultSessionTTL        = 15 // s
 	DefaultSessionRetryTimes = 30
@@ -227,6 +228,7 @@ type commonConfig struct {
 	HighPriorityThreadCoreCoefficient   ParamItem `refreshable:"true"`
 	MiddlePriorityThreadCoreCoefficient ParamItem `refreshable:"true"`
 	LowPriorityThreadCoreCoefficient    ParamItem `refreshable:"true"`
+	BM25LoadThreadCoreCoefficient       ParamItem `refreshable:"true"`
 	EnableMaterializedView              ParamItem `refreshable:"false"`
 	BuildIndexThreadPoolRatio           ParamItem `refreshable:"false"`
 	MaxDegree                           ParamItem `refreshable:"true"`
@@ -659,6 +661,16 @@ This configuration is only used by querynode and indexnode, it selects CPU instr
 		Export: true,
 	}
 	p.LowPriorityThreadCoreCoefficient.Init(base.mgr)
+
+	p.BM25LoadThreadCoreCoefficient = ParamItem{
+		Key:          "common.threadCoreCoefficient.bm25Load",
+		Version:      "2.6.8",
+		DefaultValue: strconv.Itoa(DefaultBM25LoadThreadCoreCoefficient),
+		Doc: "This parameter specify how many times the number of threads " +
+			"is the number of cores in BM25 load pool",
+		Export: true,
+	}
+	p.BM25LoadThreadCoreCoefficient.Init(base.mgr)
 
 	p.DiskWriteMode = ParamItem{
 		Key:          "common.diskWriteMode",
@@ -3344,8 +3356,7 @@ type queryNodeConfig struct {
 	EnabledGrowingSegmentJSONKeyStats ParamItem `refreshable:"false"`
 
 	// Idf Oracle
-	IDFEnableDisk       ParamItem `refreshable:"true"`
-	IDFWriteConcurrenct ParamItem `refreshable:"true"`
+	IDFEnableDisk ParamItem `refreshable:"true"`
 	// partial search
 	PartialResultRequiredDataRatio ParamItem `refreshable:"true"`
 }
@@ -3358,14 +3369,6 @@ func (p *queryNodeConfig) init(base *BaseTable) {
 		DefaultValue: "true",
 	}
 	p.IDFEnableDisk.Init(base.mgr)
-
-	p.IDFWriteConcurrenct = ParamItem{
-		Key:          "queryNode.idfOracle.writeConcurrency",
-		Version:      "2.6.0",
-		Export:       true,
-		DefaultValue: "4",
-	}
-	p.IDFWriteConcurrenct.Init(base.mgr)
 
 	p.SoPath = ParamItem{
 		Key:          "queryNode.soPath",


### PR DESCRIPTION
Add a thread pool to load BM25 stats and save them to local disk during loading, reducing peak memory usage.
relate: https://github.com/milvus-io/milvus/issues/41424

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Core invariant: sealed-segment BM25 statistics are immutable and may be persisted to disk independently from growing-segment stats; IDF state is reconstructed by combining persisted sealed stats (preloaded from disk) with in-memory growing stats at runtime (preloadSealed + RegisterGrowing).
- Capability added: asynchronous BM25 loading via a dedicated BM25LoadPool (config key common.threadCoreCoefficient.bm25Load and param BM25LoadThreadCoreCoefficient) — delegator.loadBM25Stats is executed on the pool to load sealed BM25 stats and call idfOracle.RegisterSealed, reducing peak memory during segment load.
- Logic removed/simplified and why: the previous single Register(segID, stats, state) + background local-writer/spool loop was split into RegisterGrowing (in-memory) and RegisterSealed (sealed + on-disk persistence) and the localloop removed; RegisterSealed writes sealed stats directly (ToLocal) and uses singleflight to deduplicate, eliminating redundant spooling and lifecycle complexity while clarifying sealed vs growing flows.
- Why this does NOT introduce data loss or behavior regression: sealed stats are still written and reloaded (RegisterSealed persists to dirPath; preloadSealed merges disk and memory on first load), growing segments continue to register in-memory via RegisterGrowing, loadSegments now defers sealed BM25 handling to loadBM25Stats but still registers sealed candidates after load, and tests were updated to reflect RegisterSealed/RegisterGrowing usage—so serialization/deserialization, preload semantics, and test coverage preserve existing persisted state and runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->