### PR TITLE
fix: set ManifestPath in GetRecoveryInfoV2 response

### DIFF
--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -1046,6 +1046,7 @@ func (s *Server) GetRecoveryInfoV2(ctx context.Context, req *datapb.GetRecoveryI
 			NumOfRows:     rowCount,
 			Level:         segment.GetLevel(),
 			IsSorted:      segment.GetIsSorted(),
+			ManifestPath:  segment.GetManifestPath(),
 		})
 	}
 


### PR DESCRIPTION
Add ManifestPath field to SegmentInfo in GetRecoveryInfoV2 response, enabling QueryCoord to detect manifest path changes and trigger segment reopen for storage v2 incremental updates.

Related to #46394