### PR TITLE
fix: [Loon] pass mmap directory path to ManifestGroupTranslator

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -2854,6 +2854,10 @@ ChunkedSegmentSealedImpl::LoadColumnGroup(
     LOG_INFO("[StorageV2] segment {} loads manifest cg index {}",
              this->get_segment_id(),
              index);
+    auto mmap_dir_path =
+        milvus::storage::LocalChunkManagerSingleton::GetInstance()
+            .GetChunkManager()
+            ->GetRootPath();
 
     auto translator =
         std::make_unique<storagev2translator::ManifestGroupTranslator>(
@@ -2862,6 +2866,7 @@ ChunkedSegmentSealedImpl::LoadColumnGroup(
             std::move(chunk_reader),
             field_metas,
             use_mmap,
+            mmap_dir_path,
             column_group->columns.size(),
             segment_load_info_.GetPriority());
     auto chunked_column_group =

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
@@ -53,6 +53,7 @@ ManifestGroupTranslator::ManifestGroupTranslator(
     std::unique_ptr<milvus_storage::api::ChunkReader> chunk_reader,
     const std::unordered_map<FieldId, FieldMeta>& field_metas,
     bool use_mmap,
+    const std::string& mmap_dir_path,
     int64_t num_fields,
     milvus::proto::common::LoadPriority load_priority)
     : segment_id_(segment_id),
@@ -60,6 +61,7 @@ ManifestGroupTranslator::ManifestGroupTranslator(
       chunk_reader_(std::move(chunk_reader)),
       key_(fmt::format("seg_{}_cg_{}", segment_id, column_group_index)),
       field_metas_(field_metas),
+      mmap_dir_path_(mmap_dir_path),
       meta_(num_fields,
             use_mmap ? milvus::cachinglayer::StorageType::DISK
                      : milvus::cachinglayer::StorageType::MEMORY,

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.h
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.h
@@ -51,6 +51,7 @@ class ManifestGroupTranslator
      * @param chunk_reader Reader for accessing chunks from storage
      * @param field_metas Metadata for all fields in this column group
      * @param use_mmap Whether to use memory mapping for data loading
+     * @param mmap_dir_path Directory path for memory mapping
      * @param num_fields Total number of fields in the column group
      * @param load_priority Priority level for loading operations
      */
@@ -60,6 +61,7 @@ class ManifestGroupTranslator
         std::unique_ptr<milvus_storage::api::ChunkReader> chunk_reader,
         const std::unordered_map<FieldId, FieldMeta>& field_metas,
         bool use_mmap,
+        const std::string& mmap_dir_path,
         int64_t num_fields,
         milvus::proto::common::LoadPriority load_priority);
     ~ManifestGroupTranslator() = default;


### PR DESCRIPTION
Related to #44956

When loading column groups with mmap enabled, the ManifestGroupTranslator needs the mmap directory path to properly handle memory-mapped data loading. This change retrieves the root path from LocalChunkManagerSingleton and passes it to the translator during construction.