### PR TITLE
enhance: [hotfix] set dynamic field as nullable with default empty JSON (#46419)

### DIFF
--- a/internal/rootcoord/create_collection_task.go
+++ b/internal/rootcoord/create_collection_task.go
@@ -252,6 +252,12 @@ func (t *createCollectionTask) appendDynamicField(ctx context.Context, schema *s
 			Description: "dynamic schema",
 			DataType:    schemapb.DataType_JSON,
 			IsDynamic:   true,
+			Nullable:    true,
+			DefaultValue: &schemapb.ValueField{
+				Data: &schemapb.ValueField_BytesData{
+					BytesData: []byte("{}"),
+				},
+			},
 		})
 		log.Ctx(ctx).Info("append dynamic field", zap.String("collection", schema.Name))
 	}


### PR DESCRIPTION
### **User description**
Cherry-pick from master
pr: #46419
Set the auto-appended dynamic field to be nullable with a default value of empty JSON object `{}`. This allows collections with dynamic schema to handle rows that don't have any dynamic fields more gracefully, avoiding potential null reference issues when the dynamic field is not explicitly set during insert.


___

### **PR Type**
Enhancement


___

### **Description**
- Make dynamic field nullable with empty JSON default

- Prevents null reference issues in dynamic schema collections

- Gracefully handles rows without explicit dynamic fields


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Dynamic Field Schema"] -->|Add Nullable Flag| B["Nullable: true"]
  A -->|Add Default Value| C["DefaultValue: {}"]
  B --> D["Graceful Null Handling"]
  C --> D
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>create_collection_task.go</strong><dd><code>Add nullable flag and default value to dynamic field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/rootcoord/create_collection_task.go

<ul><li>Added <code>Nullable: true</code> flag to auto-appended dynamic field schema<br> <li> Added <code>DefaultValue</code> with empty JSON object <code>{}</code> as default<br> <li> Prevents null reference errors when dynamic fields are not explicitly <br>set during insert<br> <li> Improves handling of collections with dynamic schema</ul>


</details>


  </td>
  <td><a href="https://github.com/milvus-io/milvus/pull/46478/files#diff-ad20ad66d7f39ed527f1ba6dd37c1d13d8ef202aa7e05daaa1b27c905f85fbd5">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

