### PR TITLE
test: Increase PyMilvus version to 2.5.19rc1 for 2.5 branch

### DIFF
--- a/tests/python_client/requirements.txt
+++ b/tests/python_client/requirements.txt
@@ -28,8 +28,8 @@ pytest-parallel
 pytest-random-order
 
 # pymilvus
-pymilvus==2.5.18
-pymilvus[bulk_writer]==2.5.18
+pymilvus==2.5.19rc1
+pymilvus[bulk_writer]==2.5.19rc1
 
 # for customize config test
 python-benedict==0.24.3


### PR DESCRIPTION
Automated daily bump from pymilvus 2.5 branch. Updates tests/python_client/requirements.txt.

