### PR TITLE
enhance: Don't seal segments when only alter collection properties

### DIFF
--- a/internal/streamingnode/server/wal/interceptors/shard/shard_interceptor.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/shard_interceptor.go
@@ -16,6 +16,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/proto/messagespb"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message/messageutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
 )
 
@@ -251,10 +252,15 @@ func (impl *shardInterceptor) handleSchemaChange(ctx context.Context, msg messag
 func (impl *shardInterceptor) handleAlterCollection(ctx context.Context, msg message.MutableMessage, appendOp interceptors.Append) (message.MessageID, error) {
 	putCollectionMsg := message.MustAsMutableAlterCollectionMessageV2(msg)
 	header := putCollectionMsg.Header()
-	segmentIDs, err := impl.shardManager.FlushAndFenceSegmentAllocUntil(header.GetCollectionId(), msg.TimeTick())
-	if err != nil {
-		return nil, status.NewUnrecoverableError(err.Error())
+	var segmentIDs []int64
+	var err error
+	if messageutil.IsSchemaChange(header) {
+		segmentIDs, err = impl.shardManager.FlushAndFenceSegmentAllocUntil(header.GetCollectionId(), msg.TimeTick())
+		if err != nil {
+			return nil, status.NewUnrecoverableError(err.Error())
+		}
 	}
+
 	header.FlushedSegmentIds = segmentIDs
 	putCollectionMsg.OverwriteHeader(header)
 	return appendOp(ctx, msg)


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Only flush and fence segments for schema-changing alter collection messages

- Skip segment sealing for collection property-only alterations

- Add conditional check using messageutil.IsSchemaChange utility function


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Alter Collection Message"] --> B{"Is Schema Change?"}
  B -->|Yes| C["Flush and Fence Segments"]
  B -->|No| D["Skip Segment Operations"]
  C --> E["Set Flushed Segment IDs"]
  D --> E
  E --> F["Append Operation"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>shard_interceptor.go</strong><dd><code>Conditional segment sealing based on schema changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/streamingnode/server/wal/interceptors/shard/shard_interceptor.go

<ul><li>Added import for <code>messageutil</code> package to access schema change detection <br>utility<br> <li> Modified <code>handleAlterCollection</code> to conditionally flush and fence <br>segments only for schema-changing messages<br> <li> Wrapped segment flushing logic in <code>if </code><br><code>messageutil.IsSchemaChange(header)</code> check<br> <li> Skips unnecessary segment sealing when only collection properties are <br>altered</ul>


</details>


  </td>
  <td><a href="https://github.com/milvus-io/milvus/pull/46488/files#diff-c1acf785e5b530e59137b21584cf567ccd9aeeb613fb3684294b439289e80beb">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized collection schema alteration to conditionally perform segment allocation operations only when schema changes are detected, reducing unnecessary overhead in unmodified collection scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->