### PR TITLE
fix: [2.6] Remove stale proxy clients on rewatch etcd

### DIFF
--- a/internal/querycoordv2/server.go
+++ b/internal/querycoordv2/server.go
@@ -319,7 +319,7 @@ func (s *Server) initQueryCoord() error {
 	s.proxyClientManager = proxyutil.NewProxyClientManager(proxyutil.DefaultProxyCreator)
 	s.proxyWatcher = proxyutil.NewProxyWatcher(
 		s.etcdCli,
-		s.proxyClientManager.AddProxyClients,
+		s.proxyClientManager.SetProxyClients,
 	)
 	s.proxyWatcher.AddSessionFunc(s.proxyClientManager.AddProxyClient)
 	s.proxyWatcher.DelSessionFunc(s.proxyClientManager.DelProxyClient)

--- a/internal/rootcoord/root_coord.go
+++ b/internal/rootcoord/root_coord.go
@@ -445,7 +445,7 @@ func (c *Core) initInternal() error {
 	c.proxyWatcher = proxyutil.NewProxyWatcher(
 		c.etcdCli,
 		c.chanTimeTick.initSessions,
-		c.proxyClientManager.AddProxyClients,
+		c.proxyClientManager.SetProxyClients,
 	)
 	c.proxyWatcher.AddSessionFunc(c.chanTimeTick.addSession, c.proxyClientManager.AddProxyClient)
 	c.proxyWatcher.DelSessionFunc(c.chanTimeTick.delSession, c.proxyClientManager.DelProxyClient)

--- a/internal/util/proxyutil/mock_proxy_client_manager.go
+++ b/internal/util/proxyutil/mock_proxy_client_manager.go
@@ -63,39 +63,6 @@ func (_c *MockProxyClientManager_AddProxyClient_Call) RunAndReturn(run func(*ses
 	return _c
 }
 
-// AddProxyClients provides a mock function with given fields: session
-func (_m *MockProxyClientManager) AddProxyClients(session []*sessionutil.Session) {
-	_m.Called(session)
-}
-
-// MockProxyClientManager_AddProxyClients_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddProxyClients'
-type MockProxyClientManager_AddProxyClients_Call struct {
-	*mock.Call
-}
-
-// AddProxyClients is a helper method to define mock.On call
-//   - session []*sessionutil.Session
-func (_e *MockProxyClientManager_Expecter) AddProxyClients(session interface{}) *MockProxyClientManager_AddProxyClients_Call {
-	return &MockProxyClientManager_AddProxyClients_Call{Call: _e.mock.On("AddProxyClients", session)}
-}
-
-func (_c *MockProxyClientManager_AddProxyClients_Call) Run(run func(session []*sessionutil.Session)) *MockProxyClientManager_AddProxyClients_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].([]*sessionutil.Session))
-	})
-	return _c
-}
-
-func (_c *MockProxyClientManager_AddProxyClients_Call) Return() *MockProxyClientManager_AddProxyClients_Call {
-	_c.Call.Return()
-	return _c
-}
-
-func (_c *MockProxyClientManager_AddProxyClients_Call) RunAndReturn(run func([]*sessionutil.Session)) *MockProxyClientManager_AddProxyClients_Call {
-	_c.Run(run)
-	return _c
-}
-
 // DelProxyClient provides a mock function with given fields: s
 func (_m *MockProxyClientManager) DelProxyClient(s *sessionutil.Session) {
 	_m.Called(s)
@@ -537,6 +504,39 @@ func (_c *MockProxyClientManager_RefreshPolicyInfoCache_Call) Return(_a0 error) 
 
 func (_c *MockProxyClientManager_RefreshPolicyInfoCache_Call) RunAndReturn(run func(context.Context, *proxypb.RefreshPolicyInfoCacheRequest) error) *MockProxyClientManager_RefreshPolicyInfoCache_Call {
 	_c.Call.Return(run)
+	return _c
+}
+
+// SetProxyClients provides a mock function with given fields: session
+func (_m *MockProxyClientManager) SetProxyClients(session []*sessionutil.Session) {
+	_m.Called(session)
+}
+
+// MockProxyClientManager_SetProxyClients_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetProxyClients'
+type MockProxyClientManager_SetProxyClients_Call struct {
+	*mock.Call
+}
+
+// SetProxyClients is a helper method to define mock.On call
+//   - session []*sessionutil.Session
+func (_e *MockProxyClientManager_Expecter) SetProxyClients(session interface{}) *MockProxyClientManager_SetProxyClients_Call {
+	return &MockProxyClientManager_SetProxyClients_Call{Call: _e.mock.On("SetProxyClients", session)}
+}
+
+func (_c *MockProxyClientManager_SetProxyClients_Call) Run(run func(session []*sessionutil.Session)) *MockProxyClientManager_SetProxyClients_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].([]*sessionutil.Session))
+	})
+	return _c
+}
+
+func (_c *MockProxyClientManager_SetProxyClients_Call) Return() *MockProxyClientManager_SetProxyClients_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockProxyClientManager_SetProxyClients_Call) RunAndReturn(run func([]*sessionutil.Session)) *MockProxyClientManager_SetProxyClients_Call {
+	_c.Run(run)
 	return _c
 }
 


### PR DESCRIPTION
### **User description**
AddProxyClients now removes clients not in the new snapshot before adding new ones. This ensures proper cleanup when ProxyWatcher re-watche etcd.

issue: https://github.com/milvus-io/milvus/issues/46397

pr: https://github.com/milvus-io/milvus/pull/46398


___

### **PR Type**
Bug fix


___

### **Description**
- Rename `AddProxyClients` to `SetProxyClients` for clearer semantics

- Implement stale client cleanup before adding new ones

- Remove clients not present in new etcd snapshot

- Update mock and test implementations accordingly


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ProxyWatcher detects etcd change"] -->|calls SetProxyClients| B["SetProxyClients receives new snapshot"]
  B -->|identifies stale clients| C["Remove clients not in snapshot"]
  C -->|close connections| D["Add new clients from snapshot"]
  D -->|updated client pool| E["Clean proxy client state"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server.go</strong><dd><code>Update ProxyWatcher to use SetProxyClients</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/querycoordv2/server.go

<ul><li>Updated <code>ProxyWatcher</code> initialization to use <code>SetProxyClients</code> instead of <br><code>AddProxyClients</code><br> <li> Maintains existing session add/delete function callbacks</ul>


</details>


  </td>
  <td><a href="https://github.com/milvus-io/milvus/pull/46490/files#diff-87d7712e6df027656ba9d433fb77b702c185486130879be54204da2b8f092230">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>root_coord.go</strong><dd><code>Update ProxyWatcher to use SetProxyClients</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/rootcoord/root_coord.go

<ul><li>Updated <code>ProxyWatcher</code> initialization to use <code>SetProxyClients</code> instead of <br><code>AddProxyClients</code><br> <li> Maintains existing session add/delete function callbacks</ul>


</details>


  </td>
  <td><a href="https://github.com/milvus-io/milvus/pull/46490/files#diff-8fab0705c4ddb5f98e5955d3c3013fa795c87237a8525e189c3296d98dcce47f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>proxy_client_manager.go</strong><dd><code>Implement stale client cleanup in SetProxyClients</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/util/proxyutil/proxy_client_manager.go

<ul><li>Renamed <code>AddProxyClients</code> method to <code>SetProxyClients</code> in interface and <br>implementation<br> <li> Added logic to remove stale proxy clients not present in new snapshot<br> <li> Closes removed client connections and logs cleanup operations<br> <li> Added import for <code>github.com/samber/lo</code> utility library</ul>


</details>


  </td>
  <td><a href="https://github.com/milvus-io/milvus/pull/46490/files#diff-1a13e14654661bffe70ce626777d527871fcae62361a5fc18b7dca93e66afe1e">+22/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mock_proxy_client_manager.go</strong><dd><code>Update mock to use SetProxyClients</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/util/proxyutil/mock_proxy_client_manager.go

<ul><li>Removed mock implementation of <code>AddProxyClients</code> method<br> <li> Added mock implementation of <code>SetProxyClients</code> method<br> <li> Updated mock call helpers and expectation methods</ul>


</details>


  </td>
  <td><a href="https://github.com/milvus-io/milvus/pull/46490/files#diff-8cc3cfe21d2694f58ebe7f2d44e12c467d9e83ac9edb37bcb6c7262e7b2ca09d">+33/-33</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>proxy_client_manager_test.go</strong><dd><code>Test stale client removal in SetProxyClients</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/util/proxyutil/proxy_client_manager_test.go

<ul><li>Renamed test from <code>TestProxyClientManager_AddProxyClients</code> to <br><code>TestProxyClientManager_SetProxyClients</code><br> <li> Rewrote test to verify stale client removal behavior<br> <li> Tests initial state with proxies 1 and 2, new snapshot with proxies 2 <br>and 4<br> <li> Verifies proxy 1 is removed, proxy 2 is kept, and proxy 4 is added</ul>


</details>


  </td>
  <td><a href="https://github.com/milvus-io/milvus/pull/46490/files#diff-fb82a84e67ec187c1bfbdc4335c18b504b2f4392758d859e54115684ea8a526d">+26/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

