### PR TITLE
enhance: [2.6] Align the monitoring of last_replicated_time_tick with wal_last_confirm_time_tick

### DIFF
--- a/internal/cdc/replication/replicatestream/metrics.go
+++ b/internal/cdc/replication/replicatestream/metrics.go
@@ -23,6 +23,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/proto/streamingpb"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v2/util/timerecord"
+	"github.com/milvus-io/milvus/pkg/v2/util/tsoutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
 
@@ -90,7 +91,7 @@ func (m *replicateMetrics) OnConfirmed(msg message.ImmutableMessage) {
 	metrics.CDCLastReplicatedTimeTick.WithLabelValues(
 		m.replicateInfo.GetSourceChannelName(),
 		m.replicateInfo.GetTargetChannelName(),
-	).Set(float64(msg.TimeTick()))
+	).Set(tsoutil.PhysicalTimeSeconds(msg.TimeTick()))
 }
 
 func (m *replicateMetrics) OnInitiate() {

--- a/pkg/metrics/cdc_metrics.go
+++ b/pkg/metrics/cdc_metrics.go
@@ -33,7 +33,7 @@ const (
 
 	// CDC metric labels
 	CDCLabelTargetCluster     = "target_cluster"
-	CDCLabelSourceChannelName = "source_channel_name"
+	CDCLabelSourceChannelName = WALChannelLabelName
 	CDCLabelTargetChannelName = "target_channel_name"
 	CDCLabelMsgType           = msgTypeLabelName
 	CDCLabelConnectionStatus  = "connection_status"
@@ -87,7 +87,7 @@ var CDCLastReplicatedTimeTick = prometheus.NewGaugeVec(
 		Namespace: milvusNamespace,
 		Subsystem: typeutil.CDCRole,
 		Name:      CDCMetricLastReplicatedTimeTick,
-		Help:      "The time tick of the last replicated message",
+		Help:      "The time tick in seconds of the last replicated message",
 	}, []string{
 		CDCLabelSourceChannelName,
 		CDCLabelTargetChannelName,


### PR DESCRIPTION
### **User description**
issue: https://github.com/milvus-io/milvus/issues/46116

pr: https://github.com/milvus-io/milvus/pull/46469


___

### **PR Type**
Enhancement


___

### **Description**
- Convert last_replicated_time_tick metric to physical time seconds

- Align metric with wal_last_confirm_time_tick for consistency

- Standardize source channel label naming across CDC metrics

- Update metric documentation to reflect time unit change


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["OnConfirmed callback"] -->|"msg.TimeTick()"| B["tsoutil.PhysicalTimeSeconds"]
  B -->|"physical time in seconds"| C["CDCLastReplicatedTimeTick metric"]
  D["WALChannelLabelName"] -->|"standardized label"| C
  C -->|"aligned with wal_last_confirm_time_tick"| E["Consistent monitoring"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>metrics.go</strong><dd><code>Convert metric to physical time seconds</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/cdc/replication/replicatestream/metrics.go

<ul><li>Added import for <code>tsoutil</code> package to enable time conversion<br> <li> Modified <code>OnConfirmed</code> method to convert <code>msg.TimeTick()</code> to physical time <br>seconds using <code>tsoutil.PhysicalTimeSeconds()</code><br> <li> Ensures last_replicated_time_tick metric uses consistent time unit <br>with wal_last_confirm_time_tick</ul>


</details>


  </td>
  <td><a href="https://github.com/milvus-io/milvus/pull/46492/files#diff-4c5aba6600819586b37abb60bd1a8df11510f263595ef75a1b2f3e88bbdb7335">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cdc_metrics.go</strong><dd><code>Standardize labels and update metric documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/metrics/cdc_metrics.go

<ul><li>Changed <code>CDCLabelSourceChannelName</code> to use <code>WALChannelLabelName</code> constant <br>for label standardization<br> <li> Updated <code>CDCLastReplicatedTimeTick</code> metric help text to clarify time <br>unit is in seconds<br> <li> Aligns CDC metric labeling with WAL metrics for consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/milvus-io/milvus/pull/46492/files#diff-bae6ee5ee538c3bc1f0cb58a427b7376fc26df3b60791b1fadd22dc3d0d3c45a">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

