### PR TITLE
test: test case json_contains_any is not stable

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_query.py
+++ b/tests/python_client/milvus_client/test_milvus_client_query.py
@@ -1902,7 +1902,7 @@ class TestMilvusClientQueryValid(TestMilvusClientV2Base):
                 "listFlt": [m * 1.0 for m in range(i, i + limit)],
                 "listBool": [bool(i % 2)],
                 "listList": [[i, str(i + 1)], [i * 1.0, i + 1]],
-                "listMix": [i, i * 1.1, str(i), bool(i % 2), [i, str(i)]]
+                "listMix": [i, i * 1.111, str(i), bool(i % 2), [i, str(i)]]
             }
             rows[i][ct.default_json_field_name] = content
         self.insert(client, collection_name, rows)


### PR DESCRIPTION
### **User description**
issue: #46367


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix unstable test case by adjusting float precision

- Change listMix float value from 1.1 to 1.111

- Improves test stability for json_contains_any query


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Data Generation"] -- "Adjust float precision" --> B["listMix field value"]
  B -- "1.1 to 1.111" --> C["Improved test stability"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_milvus_client_query.py</strong><dd><code>Adjust float precision in test data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/python_client/milvus_client/test_milvus_client_query.py

<ul><li>Modified test data generation in <br><code>test_milvus_client_query_expr_all_datatype_json_contains_all</code> method<br> <li> Changed <code>listMix</code> field float value from <code>1.1</code> to <code>1.111</code> for improved <br>precision<br> <li> Addresses test instability issue by adjusting floating-point test data</ul>


</details>


  </td>
  <td><a href="https://github.com/milvus-io/milvus/pull/46506/files#diff-d6fe357e4678415bc62596b802571043fa571c7d1b8e841aa43124437dd2f739">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Core invariant: the test assumes stable float equality/containment behavior for JSON-typed fields when generating test rows; small changes in stored float precision can make json_contains_any assertions flaky.
- Exact fix for the bug (refs #46367): in tests/python_client/milvus_client/test_milvus_client_query.py, the test data value for the second element of the "listMix" JSON field was adjusted from i * 1.1 to i * 1.111 in test_milvus_client_query_expr_all_datatype_json_contains_all to increase numeric precision and remove instability in json_contains_any assertions.
- Logic removed/simplified: no production logic was changed or removed — only a one-line test-data change. There is no control-flow or algorithmic simplification because the test’s intent and checks remain identical; the change removes the redundant dependence on a borderline float value that caused flakiness.
- No data loss or behavior regression: this change only updates test-generated input (test_milvus_client_query_expr_all_datatype_json_contains_all) and does not touch any library or runtime code paths. Production code paths (query parsing/execution, JSON handling) are unchanged, so no persisted data, API behavior, or client logic is affected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->