### PR TITLE
fix: [2.6] unify ro node handling to avoid balance channel task stuck

### DIFF
--- a/internal/querycoordv2/checkers/leader_checker.go
+++ b/internal/querycoordv2/checkers/leader_checker.go
@@ -92,13 +92,9 @@ func (c *LeaderChecker) Check(ctx context.Context) []task.Task {
 
 		replicas := c.meta.ReplicaManager.GetByCollection(ctx, collectionID)
 		for _, replica := range replicas {
-			// note: should enable sync segment distribution to ro node, to avoid balance channel from ro node stucks
-			nodes := replica.GetNodes()
+			nodes := replica.GetRWNodes()
 			if streamingutil.IsStreamingServiceEnabled() {
-				sqNodes := make([]int64, 0, len(replica.GetROSQNodes())+len(replica.GetRWSQNodes()))
-				sqNodes = append(sqNodes, replica.GetROSQNodes()...)
-				sqNodes = append(sqNodes, replica.GetRWSQNodes()...)
-				nodes = sqNodes
+				nodes = replica.GetRWSQNodes()
 			}
 			for _, node := range nodes {
 				delegatorList := c.dist.ChannelDistManager.GetByFilter(meta.WithCollectionID2Channel(replica.GetCollectionID()), meta.WithNodeID2Channel(node))

--- a/internal/querycoordv2/checkers/leader_checker_test.go
+++ b/internal/querycoordv2/checkers/leader_checker_test.go
@@ -291,7 +291,7 @@ func (suite *LeaderCheckerTestSuite) TestStoppingNode() {
 	observer.meta.ReplicaManager.Put(ctx, mutableReplica.IntoReplica())
 
 	tasks := suite.checker.Check(context.TODO())
-	suite.Len(tasks, 1)
+	suite.Len(tasks, 0)
 }
 
 func (suite *LeaderCheckerTestSuite) TestIgnoreSyncLoadedSegments() {


### PR DESCRIPTION
### **User description**
issue: #46393
pr: #46440

RO node can be created from two sources: stopping a QueryNode or replica node transfer (e.g., suspend node). Before this fix, there were two defects and one constraint that caused a deadlock:

Defects:
1. LeaderChecker does not sync segment distribution to RO nodes
2. Scheduler only cancels tasks on stopping nodes, not RO nodes

Constraint:
- Balance channel task blocks waiting for new delegator to become serviceable (via sync segment) before executing release action

Deadlock scenario:
When target node becomes RO node (but not stopping) during balance channel execution, the task gets stuck because:
- Cannot sync segment to RO node (defect 1) -> task blocks
- Task is not cancelled since node is not stopping (defect 2)

PR #45949 attempted to fix defect 1 but was not successful.

This PR unifies RO node handling by:
- LeaderChecker: only sync segment distribution to RW nodes
- Scheduler: cancel task when target node becomes RO node
- Simplify checkStale logic with unified node state checking


___

### **PR Type**
Bug fix


___

### **Description**
- Unify RO node handling to prevent balance channel task deadlock

- LeaderChecker only syncs segment distribution to RW nodes

- Scheduler cancels tasks when target node becomes RO node

- Simplify checkStale logic with unified node state checking


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["RO Node State Change"] -->|"LeaderChecker"| B["Skip RO Nodes<br/>Sync Only RW Nodes"]
  A -->|"Scheduler"| C["Detect RO Node<br/>Cancel Task"]
  B --> D["Prevent Task Deadlock"]
  C --> D
  E["Simplified checkStale"] -->|"Unified Logic"| D
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>leader_checker.go</strong><dd><code>Restrict segment sync to RW nodes only</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/querycoordv2/checkers/leader_checker.go

<ul><li>Changed to only sync segment distribution to RW nodes instead of all <br>nodes<br> <li> Removed RO node syncing logic that was causing deadlock<br> <li> For streaming service, only sync to RW SQ nodes, excluding RO SQ nodes</ul>


</details>


  </td>
  <td><a href="https://github.com/milvus-io/milvus/pull/46513/files#diff-8e2188e8d967ba7ab7d0ccc6aaa30a2283150cc8d0ca2a6f46055ca6f749f1f5">+2/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>scheduler.go</strong><dd><code>Unify checkStale logic with RO node detection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/querycoordv2/task/scheduler.go

<ul><li>Consolidated checkStale logic from 4 separate methods into unified <br>implementation<br> <li> Added RO node detection to cancel tasks when target node becomes RO or <br>RO SQ node<br> <li> Simplified node state checking using IsStoppingState method<br> <li> Removed redundant task-type-specific stale checking logic</ul>


</details>


  </td>
  <td><a href="https://github.com/milvus-io/milvus/pull/46513/files#diff-dc5303993f892a9220d6d63d5d7c734fde225d22a15efa99f0cc691dd1ccd8c1">+20/-120</a></td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>leader_checker_test.go</strong><dd><code>Update test expectations for RO node handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/querycoordv2/checkers/leader_checker_test.go

<ul><li>Updated TestStoppingNode to expect 0 tasks instead of 1<br> <li> Reflects the change that RO nodes are no longer synced</ul>


</details>


  </td>
  <td><a href="https://github.com/milvus-io/milvus/pull/46513/files#diff-cce6f8ccbb3cf4536c9645b5c3a68ed72d9ff95b03ab906ea08a34d64792c3aa">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>task_test.go</strong><dd><code>Replace stale task tests with RO node detection tests</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/querycoordv2/task/task_test.go

<ul><li>Removed TestSegmentTaskStale and TestMoveSegmentTaskStale test cases<br> <li> Added new comprehensive TestTaskStaleByRONode test with three <br>sub-cases<br> <li> Tests RO node detection, RO SQ node detection, and Reduce action <br>immunity<br> <li> Updated BeforeTest to include new test case in setup</ul>


</details>


  </td>
  <td><a href="https://github.com/milvus-io/milvus/pull/46513/files#diff-6668736a70a14262a7a49372c45715f212205287dd4819b1675c5f3d43c5621d">+156/-168</a></td>

</tr>
</table></td></tr></tbody></table>

</details>

___

