### PR TITLE
fix: Skip Finished tasks when recovery with compatibility

### DIFF
--- a/internal/datacoord/compaction_inspector.go
+++ b/internal/datacoord/compaction_inspector.go
@@ -318,11 +318,7 @@ func (c *compactionInspector) loadMeta() {
 	triggers := c.meta.GetCompactionTasks(context.TODO())
 	for _, tasks := range triggers {
 		for _, task := range tasks {
-			state := task.GetState()
-			if state == datapb.CompactionTaskState_completed ||
-				state == datapb.CompactionTaskState_cleaned ||
-				state == datapb.CompactionTaskState_timeout ||
-				state == datapb.CompactionTaskState_unknown {
+			if isCompactionTaskFinished(task) {
 				log.Info("compactionInspector loadMeta abandon compactionTask",
 					zap.Int64("planID", task.GetPlanID()),
 					zap.String("type", task.GetType().String()),

--- a/internal/datacoord/compaction_task_meta.go
+++ b/internal/datacoord/compaction_task_meta.go
@@ -89,7 +89,7 @@ func (csm *compactionTaskMeta) reloadFromKV() error {
 	for _, task := range compactionTasks {
 		// Compatibility handling: for milvus ≤v2.4, since compaction task has no PreAllocatedSegmentIDs field,
 		// here we just mark the task as failed and wait for the compaction trigger to generate a new one.
-		if task.PreAllocatedSegmentIDs == nil {
+		if !isCompactionTaskFinished(task) && task.PreAllocatedSegmentIDs == nil {
 			log.Warn("PreAllocatedSegmentIDs is nil, mark the task as failed",
 				zap.Int64("taskID", task.GetPlanID()),
 				zap.String("type", task.GetType().String()),

--- a/internal/datacoord/compaction_util.go
+++ b/internal/datacoord/compaction_util.go
@@ -110,3 +110,11 @@ func WrapPluginContext(collectionID int64, properties []*commonpb.KeyValuePair, 
 		return
 	}
 }
+
+func isCompactionTaskFinished(t *datapb.CompactionTask) bool {
+	return t.GetState() == datapb.CompactionTaskState_failed ||
+		t.GetState() == datapb.CompactionTaskState_timeout ||
+		t.GetState() == datapb.CompactionTaskState_completed ||
+		t.GetState() == datapb.CompactionTaskState_cleaned ||
+		t.GetState() == datapb.CompactionTaskState_unknown
+}

--- a/internal/datacoord/compaction_util.go
+++ b/internal/datacoord/compaction_util.go
@@ -111,10 +111,16 @@ func WrapPluginContext(collectionID int64, properties []*commonpb.KeyValuePair, 
 	}
 }
 
+// isCompactionTaskFinished returns true if the task has reached a terminal state
+// (timeout, completed, cleaned, or unknown) and requires no further processing.
 func isCompactionTaskFinished(t *datapb.CompactionTask) bool {
-	return t.GetState() == datapb.CompactionTaskState_failed ||
-		t.GetState() == datapb.CompactionTaskState_timeout ||
-		t.GetState() == datapb.CompactionTaskState_completed ||
-		t.GetState() == datapb.CompactionTaskState_cleaned ||
-		t.GetState() == datapb.CompactionTaskState_unknown
+	switch t.GetState() {
+	case datapb.CompactionTaskState_timeout,
+		datapb.CompactionTaskState_completed,
+		datapb.CompactionTaskState_cleaned,
+		datapb.CompactionTaskState_unknown:
+		return true
+	default:
+		return false
+	}
 }


### PR DESCRIPTION
### **User description**
issue: #46466


___

### **PR Type**
Bug fix


___

### **Description**
- Extract finished task state check into reusable helper function

- Skip finished tasks during compaction recovery to prevent reprocessing

- Add backward compatibility check for pre-allocated segment IDs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Compaction Task States"] -->|"Check with helper"| B["isCompactionTaskFinished()"]
  B -->|"Used in"| C["compactionInspector.loadMeta()"]
  B -->|"Used in"| D["compactionTaskMeta.reloadFromKV()"]
  C -->|"Skip finished tasks"| E["Recovery Process"]
  D -->|"Backward compatibility"| E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>compaction_util.go</strong><dd><code>Add isCompactionTaskFinished helper function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/datacoord/compaction_util.go

<ul><li>Added new helper function <code>isCompactionTaskFinished()</code> to check if a <br>compaction task is in a terminal state<br> <li> Function checks for failed, timeout, completed, cleaned, or unknown <br>states<br> <li> Centralizes task state validation logic for reuse across multiple <br>components</ul>


</details>


  </td>
  <td><a href="https://github.com/milvus-io/milvus/pull/46515/files#diff-8f2cb8d0fef37617202c5a2290ad2bdbf2df5b5983604b5b505bc73a65c7eb43">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>compaction_inspector.go</strong><dd><code>Refactor to use finished task helper function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/datacoord/compaction_inspector.go

<ul><li>Replaced inline state checks with call to <code>isCompactionTaskFinished()</code> <br>helper<br> <li> Simplifies code by removing repetitive state comparison logic<br> <li> Maintains same behavior of skipping finished tasks during recovery</ul>


</details>


  </td>
  <td><a href="https://github.com/milvus-io/milvus/pull/46515/files#diff-1c884001f2e84de177fea22b584f3de70a6e73695dbffa34031be9890d17da6d">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>compaction_task_meta.go</strong><dd><code>Add finished task check for backward compatibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/datacoord/compaction_task_meta.go

<ul><li>Added check to skip finished tasks before processing pre-allocated <br>segment IDs<br> <li> Ensures backward compatibility for tasks without pre-allocated segment <br>IDs<br> <li> Prevents marking already-finished tasks as failed during reload</ul>


</details>


  </td>
  <td><a href="https://github.com/milvus-io/milvus/pull/46515/files#diff-0dae7214c4c79ddf5106bd51d375b5fb2f41239d5d433798afa90708e443eca8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of finished compaction tasks to reduce false failures.
  * Prevented finished tasks with missing pre-allocations from being incorrectly marked as failed.
  * Simplified abandonment logic for completed/timeout/cleaned tasks to reduce erroneous retries and noisy logs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->