### PR TITLE
fix: highlight with multi analyzer failed

### DIFF
--- a/internal/proxy/task_search.go
+++ b/internal/proxy/task_search.go
@@ -602,7 +602,7 @@ func (t *searchTask) createLexicalHighlighter(highlighter *commonpb.Highlighter,
 		if err != nil {
 			return err
 		}
-		err = h.addTaskWithSearchText(fieldId, fieldName, analyzerName, texts)
+		err = h.addTaskWithSearchText(t.schema, fieldId, fieldName, analyzerName, texts)
 		if err != nil {
 			return err
 		}

--- a/internal/proxy/task_search_test.go
+++ b/internal/proxy/task_search_test.go
@@ -4920,6 +4920,8 @@ func TestSearchTask_AddHighlightTask(t *testing.T) {
 		},
 	}
 
+	schemaInfo := newSchemaInfo(schema)
+
 	placeholder := &commonpb.PlaceholderGroup{
 		Placeholders: []*commonpb.PlaceholderValue{{
 			Type:   commonpb.PlaceholderType_VarChar,
@@ -4932,9 +4934,7 @@ func TestSearchTask_AddHighlightTask(t *testing.T) {
 
 	t.Run("lexical highlight success", func(t *testing.T) {
 		task := &searchTask{
-			schema: &schemaInfo{
-				CollectionSchema: schema,
-			},
+			schema: schemaInfo,
 		}
 
 		highlighter := &commonpb.Highlighter{
@@ -4954,9 +4954,7 @@ func TestSearchTask_AddHighlightTask(t *testing.T) {
 
 	t.Run("Lexical highlight with custom tags", func(t *testing.T) {
 		task := &searchTask{
-			schema: &schemaInfo{
-				CollectionSchema: schema,
-			},
+			schema: schemaInfo,
 		}
 
 		highlighter := &commonpb.Highlighter{
@@ -4977,9 +4975,7 @@ func TestSearchTask_AddHighlightTask(t *testing.T) {
 
 	t.Run("lexical highlight with wrong metric type", func(t *testing.T) {
 		task := &searchTask{
-			schema: &schemaInfo{
-				CollectionSchema: schema,
-			},
+			schema:        schemaInfo,
 			SearchRequest: &internalpb.SearchRequest{},
 			request:       &milvuspb.SearchRequest{},
 		}
@@ -4995,9 +4991,7 @@ func TestSearchTask_AddHighlightTask(t *testing.T) {
 
 	t.Run("lexical highlight with invalid pre_tags type", func(t *testing.T) {
 		task := &searchTask{
-			schema: &schemaInfo{
-				CollectionSchema: schema,
-			},
+			schema: schemaInfo,
 		}
 
 		highlighter := &commonpb.Highlighter{
@@ -5021,10 +5015,9 @@ func TestSearchTask_AddHighlightTask(t *testing.T) {
 			},
 		}
 
+		schemaInfo := newSchemaInfo(schemaWithoutBM25)
 		task := &searchTask{
-			schema: &schemaInfo{
-				CollectionSchema: schemaWithoutBM25,
-			},
+			schema: schemaInfo,
 		}
 
 		highlighter := &commonpb.Highlighter{
@@ -5038,9 +5031,7 @@ func TestSearchTask_AddHighlightTask(t *testing.T) {
 
 	t.Run("highlight without highlight search text", func(t *testing.T) {
 		task := &searchTask{
-			schema: &schemaInfo{
-				CollectionSchema: schema,
-			},
+			schema: schemaInfo,
 		}
 
 		highlighter := &commonpb.Highlighter{
@@ -5054,9 +5045,7 @@ func TestSearchTask_AddHighlightTask(t *testing.T) {
 
 	t.Run("highlight with invalid highlight search key", func(t *testing.T) {
 		task := &searchTask{
-			schema: &schemaInfo{
-				CollectionSchema: schema,
-			},
+			schema: schemaInfo,
 		}
 
 		highlighter := &commonpb.Highlighter{
@@ -5070,9 +5059,7 @@ func TestSearchTask_AddHighlightTask(t *testing.T) {
 
 	t.Run("highlight with unknown type", func(t *testing.T) {
 		task := &searchTask{
-			schema: &schemaInfo{
-				CollectionSchema: schema,
-			},
+			schema: schemaInfo,
 		}
 
 		highlighter := &commonpb.Highlighter{

--- a/pkg/util/typeutil/field_schema.go
+++ b/pkg/util/typeutil/field_schema.go
@@ -72,7 +72,7 @@ func (h *FieldSchemaHelper) EnableAnalyzer() bool {
 }
 
 func (h *FieldSchemaHelper) GetMultiAnalyzerParams() (string, bool) {
-	if !IsStringType(h.schema.GetDataType()) {
+	if !h.EnableAnalyzer() {
 		return "", false
 	}
 	value, err := h.typeParams.Get("multi_analyzer_params")


### PR DESCRIPTION
relate: https://github.com/milvus-io/milvus/issues/46498

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Core invariant: text fields configured with multi_analyzer_params must include a "by_field" string that names another field containing per-row analyzer choices; schemaInfo.GetMultiAnalyzerNameFieldID caches and returns the dependent field ID (or 0 if none) and relies on that mapping to make per-row analyzer names available to the highlighter.
- What changed / simplified: the highlighter is now schema-aware — addTaskWithSearchText accepts *schemaInfo and uses GetMultiAnalyzerNameFieldID to resolve the analyzer-name field; resolution and caching moved into schemaInfo.multiAnalyzerFieldMap (meta_cache.go), eliminating ad-hoc/typeutil-only lookups and duplicated logic; GetMultiAnalyzerParams now gates on EnableAnalyzer(), centralizing analyzer enablement checks.
- Why this fixes the bug (root cause): fixes #46498 — previously the highlighter failed when the analyzer-by-field was not in output_fields. The change (1) populates task.AnalyzerNames (defaulting missing names to "default") when multi-analyzer is configured and (2) appends the analyzer-name field ID to LexicalHighlighter.extraFields so FieldIDs includes it; the operator then requests the analyzer-name column at search time, ensuring per-row analyzer selection is available for highlighting.
- No data-loss or regression: when no multi-analyzer is configured GetMultiAnalyzerNameFieldID returns 0 and behavior is unchanged; the patch only adds the analyzer-name field to requested output IDs (no mutation of stored data). Error handling on malformed params is preserved (errors are returned instead of silently changing data), and single-analyzer behavior remains untouched.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->