### PR TITLE
enhance: Unify segment Load and Reopen through diff-based loading

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -3126,63 +3126,6 @@ ChunkedSegmentSealedImpl::Load(milvus::tracer::TraceContext& trace_ctx) {
     auto diff = segment_load_info_.GetLoadDiff();
     ApplyLoadDiff(segment_load_info_, diff);
 
-    // // Step 1: Separate indexed and non-indexed fields
-    // std::map<FieldId, std::vector<const proto::segcore::FieldIndexInfo*>>
-    //     field_id_to_index_info;
-    // std::set<FieldId> indexed_fields;
-
-    // for (int i = 0; i < segment_load_info_.GetIndexInfoCount(); i++) {
-    //     const auto& index_info = segment_load_info_.GetIndexInfo(i);
-    //     if (index_info.index_file_paths_size() == 0) {
-    //         continue;
-    //     }
-    //     auto field_id = FieldId(index_info.fieldid());
-    //     field_id_to_index_info[field_id].push_back(&index_info);
-    //     indexed_fields.insert(field_id);
-    // }
-
-    // // Step 2: Load indexes in parallel using thread pool
-    // LoadBatchIndexes(trace_ctx, field_id_to_index_info);
-
-    // LOG_INFO("Finished loading {} indexes for segment {}",
-    //          field_id_to_index_info.size(),
-    //          id_);
-
-    // // Step 3.a: Load with manifest
-    // auto manifest_path = segment_load_info_.GetManifestPath();
-    // if (manifest_path != "") {
-    //     LoadManifest(manifest_path);
-    //     return;
-    // }
-
-    // // Step 3.b: Load with field binlog
-    // std::vector<std::pair<std::vector<FieldId>, proto::segcore::FieldBinlog>>
-    //     field_binlog_to_load;
-    // for (int i = 0; i < segment_load_info_.GetBinlogPathCount(); i++) {
-    //     LoadFieldDataInfo load_field_data_info;
-    //     load_field_data_info.storage_version =
-    //         segment_load_info_.GetStorageVersion();
-
-    //     const auto& field_binlog = segment_load_info_.GetBinlogPath(i);
-
-    //     std::vector<FieldId> field_ids;
-    //     // when child fields specified, field id is group id, child field ids are actual id values here
-    //     if (field_binlog.child_fields_size() > 0) {
-    //         field_ids.reserve(field_binlog.child_fields_size());
-    //         for (auto field_id : field_binlog.child_fields()) {
-    //             field_ids.emplace_back(field_id);
-    //         }
-    //     } else {
-    //         field_ids.emplace_back(field_binlog.fieldid());
-    //     }
-
-    //     field_binlog_to_load.emplace_back(field_ids, field_binlog);
-    // }
-
-    // if (!field_binlog_to_load.empty()) {
-    //     LoadBatchFieldData(trace_ctx, field_binlog_to_load);
-    // }
-
     LOG_INFO("Successfully loaded segment {} with {} rows", id_, num_rows);
 }
 

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -2542,7 +2542,14 @@ ChunkedSegmentSealedImpl::Reopen(
 
     // compute load diff
     auto diff = current.ComputeDiff(new_seg_load_info);
+    ApplyLoadDiff(new_seg_load_info, diff);
 
+    LOG_INFO("Reopen segment {} done", id_);
+}
+
+void
+ChunkedSegmentSealedImpl::ApplyLoadDiff(SegmentLoadInfo& segment_load_info,
+                                        LoadDiff& diff) {
     milvus::tracer::TraceContext trace_ctx;
     if (!diff.indexes_to_load.empty()) {
         LoadBatchIndexes(trace_ctx, diff.indexes_to_load);
@@ -2560,9 +2567,11 @@ ChunkedSegmentSealedImpl::Reopen(
         auto properties =
             milvus::storage::LoonFFIPropertiesSingleton::GetInstance()
                 .GetProperties();
-        LoadColumnGroups(new_seg_load_info.GetColumnGroups(),
-                         properties,
-                         diff.column_groups_to_load);
+        auto column_groups = segment_load_info.GetColumnGroups();
+        auto arrow_schema = schema_->ConvertToArrowSchema();
+        reader_ = milvus_storage::api::Reader::create(
+            column_groups, arrow_schema, nullptr, *properties);
+        LoadColumnGroups(column_groups, properties, diff.column_groups_to_load);
     }
 
     // load field binlog
@@ -2576,8 +2585,6 @@ ChunkedSegmentSealedImpl::Reopen(
             DropFieldData(field_id);
         }
     }
-
-    LOG_INFO("Reopen segment {} done", id_);
 }
 
 void
@@ -2739,7 +2746,7 @@ ChunkedSegmentSealedImpl::LoadManifest(const std::string& manifest_path) {
     reader_ = milvus_storage::api::Reader::create(
         column_groups, arrow_schema, nullptr, *properties);
 
-    std::map<int, std::vector<FieldId>> cg_field_ids_map;
+    std::vector<std::pair<int, std::vector<FieldId>>> cg_field_ids;
     for (int i = 0; i < column_groups->size(); ++i) {
         auto column_group = column_groups->get_column_group(i);
         std::vector<FieldId> milvus_field_ids;
@@ -2747,22 +2754,22 @@ ChunkedSegmentSealedImpl::LoadManifest(const std::string& manifest_path) {
             auto field_id = std::stoll(column);
             milvus_field_ids.emplace_back(field_id);
         }
-        cg_field_ids_map[i] = milvus_field_ids;
+        cg_field_ids.emplace_back(i, std::move(milvus_field_ids));
     }
 
-    LoadColumnGroups(column_groups, properties, cg_field_ids_map);
+    LoadColumnGroups(column_groups, properties, cg_field_ids);
 }
 
 void
 ChunkedSegmentSealedImpl::LoadColumnGroups(
     const std::shared_ptr<milvus_storage::api::ColumnGroups>& column_groups,
     const std::shared_ptr<milvus_storage::api::Properties>& properties,
-    std::map<int, std::vector<FieldId>>& cg_field_ids_map) {
+    std::vector<std::pair<int, std::vector<FieldId>>>& cg_field_ids) {
     auto& pool = ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::LOW);
     std::vector<std::future<void>> load_group_futures;
-    for (const auto& kv : cg_field_ids_map) {
-        auto cg_index = kv.first;
-        const auto& field_ids = kv.second;
+    for (const auto& pair : cg_field_ids) {
+        auto cg_index = pair.first;
+        const auto& field_ids = pair.second;
         auto future =
             pool.Submit([this, column_groups, properties, cg_index, field_ids] {
                 LoadColumnGroup(column_groups, properties, cg_index, field_ids);
@@ -3116,62 +3123,65 @@ ChunkedSegmentSealedImpl::Load(milvus::tracer::TraceContext& trace_ctx) {
     auto num_rows = segment_load_info_.GetNumOfRows();
     LOG_INFO("Loading segment {} with {} rows", id_, num_rows);
 
-    // Step 1: Separate indexed and non-indexed fields
-    std::map<FieldId, std::vector<const proto::segcore::FieldIndexInfo*>>
-        field_id_to_index_info;
-    std::set<FieldId> indexed_fields;
+    auto diff = segment_load_info_.GetLoadDiff();
+    ApplyLoadDiff(segment_load_info_, diff);
 
-    for (int i = 0; i < segment_load_info_.GetIndexInfoCount(); i++) {
-        const auto& index_info = segment_load_info_.GetIndexInfo(i);
-        if (index_info.index_file_paths_size() == 0) {
-            continue;
-        }
-        auto field_id = FieldId(index_info.fieldid());
-        field_id_to_index_info[field_id].push_back(&index_info);
-        indexed_fields.insert(field_id);
-    }
+    // // Step 1: Separate indexed and non-indexed fields
+    // std::map<FieldId, std::vector<const proto::segcore::FieldIndexInfo*>>
+    //     field_id_to_index_info;
+    // std::set<FieldId> indexed_fields;
 
-    // Step 2: Load indexes in parallel using thread pool
-    LoadBatchIndexes(trace_ctx, field_id_to_index_info);
+    // for (int i = 0; i < segment_load_info_.GetIndexInfoCount(); i++) {
+    //     const auto& index_info = segment_load_info_.GetIndexInfo(i);
+    //     if (index_info.index_file_paths_size() == 0) {
+    //         continue;
+    //     }
+    //     auto field_id = FieldId(index_info.fieldid());
+    //     field_id_to_index_info[field_id].push_back(&index_info);
+    //     indexed_fields.insert(field_id);
+    // }
 
-    LOG_INFO("Finished loading {} indexes for segment {}",
-             field_id_to_index_info.size(),
-             id_);
+    // // Step 2: Load indexes in parallel using thread pool
+    // LoadBatchIndexes(trace_ctx, field_id_to_index_info);
 
-    // Step 3.a: Load with manifest
-    auto manifest_path = segment_load_info_.GetManifestPath();
-    if (manifest_path != "") {
-        LoadManifest(manifest_path);
-        return;
-    }
+    // LOG_INFO("Finished loading {} indexes for segment {}",
+    //          field_id_to_index_info.size(),
+    //          id_);
 
-    // Step 3.b: Load with field binlog
-    std::vector<std::pair<std::vector<FieldId>, proto::segcore::FieldBinlog>>
-        field_binlog_to_load;
-    for (int i = 0; i < segment_load_info_.GetBinlogPathCount(); i++) {
-        LoadFieldDataInfo load_field_data_info;
-        load_field_data_info.storage_version =
-            segment_load_info_.GetStorageVersion();
+    // // Step 3.a: Load with manifest
+    // auto manifest_path = segment_load_info_.GetManifestPath();
+    // if (manifest_path != "") {
+    //     LoadManifest(manifest_path);
+    //     return;
+    // }
 
-        const auto& field_binlog = segment_load_info_.GetBinlogPath(i);
+    // // Step 3.b: Load with field binlog
+    // std::vector<std::pair<std::vector<FieldId>, proto::segcore::FieldBinlog>>
+    //     field_binlog_to_load;
+    // for (int i = 0; i < segment_load_info_.GetBinlogPathCount(); i++) {
+    //     LoadFieldDataInfo load_field_data_info;
+    //     load_field_data_info.storage_version =
+    //         segment_load_info_.GetStorageVersion();
 
-        std::vector<FieldId> field_ids;
-        // when child fields specified, field id is group id, child field ids are actual id values here
-        if (field_binlog.child_fields_size() > 0) {
-            field_ids.reserve(field_binlog.child_fields_size());
-            for (auto field_id : field_binlog.child_fields()) {
-                field_ids.emplace_back(field_id);
-            }
-        } else {
-            field_ids.emplace_back(field_binlog.fieldid());
-        }
+    //     const auto& field_binlog = segment_load_info_.GetBinlogPath(i);
 
-        field_binlog_to_load.emplace_back(field_ids, field_binlog);
-    }
+    //     std::vector<FieldId> field_ids;
+    //     // when child fields specified, field id is group id, child field ids are actual id values here
+    //     if (field_binlog.child_fields_size() > 0) {
+    //         field_ids.reserve(field_binlog.child_fields_size());
+    //         for (auto field_id : field_binlog.child_fields()) {
+    //             field_ids.emplace_back(field_id);
+    //         }
+    //     } else {
+    //         field_ids.emplace_back(field_binlog.fieldid());
+    //     }
 
-    if (!field_binlog_to_load.empty()) {
-        LoadBatchFieldData(trace_ctx, field_binlog_to_load);
-    }
+    //     field_binlog_to_load.emplace_back(field_ids, field_binlog);
+    // }
+
+    // if (!field_binlog_to_load.empty()) {
+    //     LoadBatchFieldData(trace_ctx, field_binlog_to_load);
+    // }
 
     LOG_INFO("Successfully loaded segment {} with {} rows", id_, num_rows);
 }

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -972,7 +972,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     LoadColumnGroups(
         const std::shared_ptr<milvus_storage::api::ColumnGroups>& column_groups,
         const std::shared_ptr<milvus_storage::api::Properties>& properties,
-        std::map<int, std::vector<FieldId>>& cg_field_ids_map);
+        std::vector<std::pair<int, std::vector<FieldId>>>& cg_field_ids);
 
     /**
      * @brief Load a single column group at the specified index
@@ -990,6 +990,19 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         const std::shared_ptr<milvus_storage::api::Properties>& properties,
         int64_t index,
         const std::vector<FieldId>& milvus_field_ids);
+
+    /**
+     * @brief Apply load differences to update segment load information
+     *
+     * This method processes the differences between current and new load states,
+     * updating the segment's loaded fields and indexes accordingly. It handles
+     * incremental updates during segment reopen operations.
+     *
+     * @param segment_load_info The segment load information to be updated
+     * @param load_diff The differences to apply, containing fields and indexes to add/remove
+     */
+    void
+    ApplyLoadDiff(SegmentLoadInfo& segment_load_info, LoadDiff& load_diff);
 
     void
     load_field_data_common(

--- a/internal/core/src/segcore/SegmentLoadInfo.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfo.cpp
@@ -13,8 +13,10 @@
 
 #include <algorithm>
 #include <cctype>
+#include <memory>
 
 #include "common/FieldMeta.h"
+#include "milvus-storage/column_groups.h"
 #include "storage/LocalChunkManagerSingleton.h"
 #include "storage/loon_ffi/property_singleton.h"
 #include "storage/MmapManager.h"
@@ -152,12 +154,18 @@ SegmentLoadInfo::ComputeDiffIndexes(LoadDiff& diff, SegmentLoadInfo& new_info) {
     // Get current indexed field IDs
     std::set<int64_t> current_index_ids;
     for (auto const& index_info : GetIndexInfos()) {
+        if (index_info.index_file_paths_size() == 0) {
+            continue;
+        }
         current_index_ids.insert(index_info.indexid());
     }
 
     std::set<int64_t> new_index_ids;
     // Find indexes to load: indexes in new_info but not in current
     for (const auto& new_index_info : new_info.GetIndexInfos()) {
+        if (new_index_info.index_file_paths_size() == 0) {
+            continue;
+        }
         new_index_ids.insert(new_index_info.indexid());
         if (current_index_ids.find(new_index_info.indexid()) ==
             current_index_ids.end()) {
@@ -168,6 +176,9 @@ SegmentLoadInfo::ComputeDiffIndexes(LoadDiff& diff, SegmentLoadInfo& new_info) {
 
     // Find indexes to drop: fields that have indexes in current but not in new_info
     for (const auto& index_info : GetIndexInfos()) {
+        if (index_info.index_file_paths_size() == 0) {
+            continue;
+        }
         if (new_index_ids.find(index_info.indexid()) == new_index_ids.end()) {
             diff.indexes_to_drop.insert(FieldId(index_info.fieldid()));
         }
@@ -234,6 +245,7 @@ SegmentLoadInfo::ComputeDiffColumnGroups(LoadDiff& diff,
     std::map<int64_t, int> new_field_ids;
     for (int i = 0; i < new_column_group->size(); i++) {
         auto cg = new_column_group->get_column_group(i);
+        std::vector<FieldId> fields;
         for (const auto& column : cg->columns) {
             auto field_id = std::stoll(column);
             new_field_ids.emplace(field_id, i);
@@ -241,8 +253,11 @@ SegmentLoadInfo::ComputeDiffColumnGroups(LoadDiff& diff,
             auto iter = cur_field_ids.find(field_id);
             // If this field doesn't exist in current, mark the column group for loading
             if (iter == cur_field_ids.end() || iter->second != i) {
-                diff.column_groups_to_load[i].emplace_back(field_id);
+                fields.emplace_back(field_id);
             }
+        }
+        if (!fields.empty()) {
+            diff.column_groups_to_load.emplace_back(i, fields);
         }
     }
 
@@ -275,6 +290,33 @@ SegmentLoadInfo::ComputeDiff(SegmentLoadInfo& new_info) {
             !new_info.HasManifestPath(),
             "field binlogs could only be updated with non-manfest load info");
         ComputeDiffBinlogs(diff, new_info);
+    }
+
+    return diff;
+}
+
+LoadDiff
+SegmentLoadInfo::GetLoadDiff() {
+    LoadDiff diff;
+
+    SegmentLoadInfo empty_info;
+
+    // Handle index changes
+    empty_info.ComputeDiffIndexes(diff, *this);
+
+    // Handle field data changes
+    // Note: Updates can only happen within the same category:
+    // - binlog -> binlog
+    // - manifest -> manifest
+    // Cross-category changes are not supported.
+    if (HasManifestPath()) {
+        // set mock path for null check
+        empty_info.info_.set_manifest_path("mocked manifest path");
+        empty_info.column_groups_ =
+            std::make_shared<milvus_storage::api::ColumnGroups>();
+        empty_info.ComputeDiffColumnGroups(diff, *this);
+    } else {
+        empty_info.ComputeDiffBinlogs(diff, *this);
     }
 
     return diff;

--- a/internal/core/src/segcore/SegmentLoadInfo.h
+++ b/internal/core/src/segcore/SegmentLoadInfo.h
@@ -44,8 +44,9 @@ struct LoadDiff {
     std::vector<std::pair<std::vector<FieldId>, proto::segcore::FieldBinlog>>
         binlogs_to_load;
 
-    // Field id to column group index to be loaded
-    std::map<int, std::vector<FieldId>> column_groups_to_load;
+    // list of column group indices and related field ids to load
+    // same index could appear multiple times if same group using different setups
+    std::vector<std::pair<int, std::vector<FieldId>>> column_groups_to_load;
 
     // Indexes that need to be dropped (field_id set)
     std::set<FieldId> indexes_to_drop;
@@ -576,6 +577,17 @@ class SegmentLoadInfo {
      */
     [[nodiscard]] LoadDiff
     ComputeDiff(SegmentLoadInfo& new_info);
+
+    /**
+     * @brief Get the LoadDiff from the current SegmentLoadInfo
+     *
+     * This method produces a LoadDiff that describes what needs to be loaded when 
+     * load with current load info.
+     *
+     * @return LoadDiff containing the differences
+     */
+    [[nodiscard]] LoadDiff
+    GetLoadDiff();
 
     // ==================== Underlying Proto Access ====================
 


### PR DESCRIPTION
Related to #46358

Refactor segment loading to use a unified diff-based approach for both initial Load and Reopen operations:

- Extract ApplyLoadDiff from Reopen to share loading logic
- Add GetLoadDiff to compute diff from empty state for initial load
- Change column_groups_to_load from map to vector<pair> to preserve order
- Add validation for empty index file paths in diff computation
- Add comprehensive unit tests for GetLoadDiff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved segment loading efficiency through incremental updates, reducing memory overhead and enhancing performance during data updates.

* **Tests**
  * Expanded test coverage for load operation scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->