### PR TITLE
fix: failed to check invalid timestamptz default value

### DIFF
--- a/internal/datacoord/compaction_policy_forcemerge.go
+++ b/internal/datacoord/compaction_policy_forcemerge.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/samber/lo"
 	"go.uber.org/zap"
 
+	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
 	"github.com/milvus-io/milvus/internal/datacoord/session"
 	"github.com/milvus-io/milvus/internal/types"

--- a/internal/datacoord/compaction_view_forcemerge.go
+++ b/internal/datacoord/compaction_view_forcemerge.go
@@ -21,10 +21,11 @@ import (
 	"math"
 	"time"
 
-	"github.com/milvus-io/milvus/pkg/v2/log"
-	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/samber/lo"
 	"go.uber.org/zap"
+
+	"github.com/milvus-io/milvus/pkg/v2/log"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
 
 const (

--- a/internal/datacoord/compaction_view_forcemerge_test.go
+++ b/internal/datacoord/compaction_view_forcemerge_test.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/samber/lo"
-
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/proxy/task_search.go
+++ b/internal/proxy/task_search.go
@@ -763,7 +763,7 @@ func (t *searchTask) tryGeneratePlan(params []*commonpb.KeyValuePair, dsl string
 
 	searchInfo.planInfo.QueryFieldId = annField.GetFieldID()
 	start := time.Now()
-	plan, planErr := planparserv2.CreateSearchPlan(t.schema.schemaHelper, dsl, annsFieldName, searchInfo.planInfo, exprTemplateValues, t.request.GetFunctionScore())
+	plan, planErr := planparserv2.CreateSearchPlanArgs(t.schema.schemaHelper, dsl, annsFieldName, searchInfo.planInfo, exprTemplateValues, t.request.GetFunctionScore(), &planparserv2.ParserVisitorArgs{Timezone: t.resolvedTimezoneStr})
 	if planErr != nil {
 		log.Ctx(t.ctx).Warn("failed to create query plan", zap.Error(planErr),
 			zap.String("dsl", dsl), // may be very large if large term passed.

--- a/internal/rootcoord/ddl_callbacks_alter_collection_add_field.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_add_field.go
@@ -42,13 +42,14 @@ func (c *Core) broadcastAlterCollectionForAddField(ctx context.Context, req *mil
 	if err := checkFieldSchema([]*schemapb.FieldSchema{fieldSchema}); err != nil {
 		return errors.Wrap(err, "failed to check field schema")
 	}
-
 	if fieldSchema.GetDataType() == schemapb.DataType_Timestamptz {
 		timezone, exist := funcutil.TryGetAttrByKeyFromRepeatedKV(common.TimezoneKey, coll.Properties)
 		if !exist {
 			timezone = common.DefaultTimezone
 		}
-		timestamptz.CheckAndRewriteTimestampTzDefaultValueForFieldSchema(fieldSchema, timezone)
+		if err := timestamptz.CheckAndRewriteTimestampTzDefaultValueForFieldSchema(fieldSchema, timezone); err != nil {
+			return merr.WrapErrParameterInvalidMsg("invalid default value of field, name: %s, err: %w", fieldSchema.Name, err)
+		}
 	}
 
 	// check if the field already exists


### PR DESCRIPTION
Also support space separator and offset in TIMESTAMPTZ
issue: https://github.com/milvus-io/milvus/issues/46376 https://github.com/milvus-io/milvus/issues/46365

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## PR Summary: Fix Invalid TIMESTAMPTZ Default Value Validation

**Core Invariant**: TIMESTAMPTZ default values with explicit UTC offsets (space-separated format like `2025-12-23 13:33:08+08:00` or short offset `2025-12-23 13:33:08+08`) must be validated and rejected if they violate UTC offset bounds before being persisted in field schema definitions.

**Root Cause & Fix**: The bug prevented invalid TIMESTAMPTZ defaults with space-separated offset syntax from being caught during collection schema creation. The fix introduces two complementary mechanisms:
- Added `validateOffset()` function in `pkg/util/timestamptz/timestamptz.go` that enforces UTC offset boundaries (±14 hours per PostgreSQL standard)
- Extended `ParseTimeTz()` to recognize space-separated absolute timestamp formats via new `extraAbsoluteLayouts` templates (`YYYY-MM-DD HH:MM:SSZ07:00` and `YYYY-MM-DD HH:MM:SSZ07`)
- Modified `internal/rootcoord/ddl_callbacks_alter_collection_add_field.go` to explicitly validate TIMESTAMPTZ default values via `CheckAndRewriteTimestampTzDefaultValueForFieldSchema` with error handling, returning a wrapped parameter-invalid error on validation failure

**No Data Loss or Regression**: Existing valid RFC3339Nano timestamps and naive timestamps continue through the same validation paths. The changes only tighten validation of previously-unhandled space-separated offset formats. The timezone information is now propagated through the query planner via `ParserVisitorArgs{Timezone: ...}` in `internal/proxy/task_search.go`, ensuring consistent timezone handling across the execution pipeline without changing behavior for validly-formatted inputs.

**PR Type**: Bug fix addressing issues #46376 and #46365 where space-separated TIMESTAMPTZ default values were not properly validated during schema definition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->