### PR TITLE
enhance: update highlight ci

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_highlighter.py
+++ b/tests/python_client/milvus_client/test_milvus_client_highlighter.py
@@ -729,7 +729,7 @@ class TestMilvusClientHighlighter(TestMilvusClientV2Base):
                                fragment_offset=0, 
                                fragment_size = 10,
                                num_of_fragments=1,
-                               queries=[{"type": "TextMatch", "field": default_text_field_name_no_BM25, "text": "seat"}])
+                               highlight_query=[{"type": "TextMatch", "field": default_text_field_name_no_BM25, "text": "seat"}])
         search_params = {"params": {"nlist": 128}, "metric_type": "BM25"}
 
         expected = [[f"{pre_tags[0]}water{post_tags[0]}."],
@@ -764,7 +764,7 @@ class TestMilvusClientHighlighter(TestMilvusClientV2Base):
         
         highlight = LexicalHighlighter(pre_tags=["{", "<"], post_tags=["}", ">"], 
                                     highlight_search_text = False, 
-                                    queries=[{"type": "TextMatch", "field": default_text_field_name_no_BM25, "text": "water"}])
+                                    highlight_query=[{"type": "TextMatch", "field": default_text_field_name_no_BM25, "text": "water"}])
 
         new_search_params = {"metric_type": "COSINE"}
 
@@ -789,7 +789,7 @@ class TestMilvusClientHighlighter(TestMilvusClientV2Base):
         expected = ['{water}! Like, full of {water>!']
         highlight = LexicalHighlighter(pre_tags=["{"], post_tags=["}", ">"], 
                                     highlight_search_text = False, 
-                                    queries=[{"type": "TextMatch", "field": default_text_field_name_no_BM25, "text": "water"}])
+                                    highlight_query=[{"type": "TextMatch", "field": default_text_field_name_no_BM25, "text": "water"}])
 
         results = client.search(
             collection_name,
@@ -810,7 +810,7 @@ class TestMilvusClientHighlighter(TestMilvusClientV2Base):
                                     highlight_search_text = False, 
                                     fragment_size = 1,
                                     num_of_fragments=10,
-                                    queries=[{"type": "TextMatch", "field": default_text_field_name_no_BM25, "text": "water"}])
+                                    highlight_query=[{"type": "TextMatch", "field": default_text_field_name_no_BM25, "text": "water"}])
 
         results = client.search(
             collection_name,
@@ -829,7 +829,7 @@ class TestMilvusClientHighlighter(TestMilvusClientV2Base):
         expected = []
         highlight = LexicalHighlighter(pre_tags=["{"], post_tags=["}"], 
                                     highlight_search_text = False, 
-                                    queries=[{"type": "TextMatch", "field": default_text_field_name_no_BM25, "text": "nonexistent"}])
+                                    highlight_query=[{"type": "TextMatch", "field": default_text_field_name_no_BM25, "text": "nonexistent"}])
         vector = client.query(collection_name, filter=f"{default_primary_key_field_name} == 1", output_fields=[default_vector_field_name])[0][default_vector_field_name]
         results = client.search(
             collection_name,
@@ -992,7 +992,7 @@ class TestMilvusClientHighlighter(TestMilvusClientV2Base):
                                fragment_offset=0, 
                                fragment_size = 10,
                                num_of_fragments=1,
-                               queries=[{"type": "TextMatch", "field": default_text_field_name_no_BM25, "text": "seat"}])
+                               highlight_query=[{"type": "TextMatch", "field": default_text_field_name_no_BM25, "text": "seat"}])
         search_params = {"metric_type": "COSINE"}
         vector = client.query(collection_name, filter=f"{default_primary_key_field_name} == 2", output_fields=[default_vector_field_name])[0][default_vector_field_name]
 
@@ -1028,7 +1028,7 @@ class TestMilvusClientHighlighter(TestMilvusClientV2Base):
                                fragment_offset=0, 
                                fragment_size = 10,
                                num_of_fragments=1,
-                               queries=[{"type": "TextMatch", "field": default_text_field_name_no_BM25, "text": "seat"}])
+                               highlight_query=[{"type": "TextMatch", "field": default_text_field_name_no_BM25, "text": "seat"}])
         search_params = {"params": {"nlist": 128}, "metric_type": "BM25"}
         vector = client.query(collection_name, filter=f"{default_primary_key_field_name} == 2", output_fields=[default_vector_field_name])[0][default_vector_field_name]
   
@@ -1077,7 +1077,7 @@ class TestMilvusClientHighlighter(TestMilvusClientV2Base):
         
         highlight = LexicalHighlighter(pre_tags=["{", "<"], post_tags=["}", ">"], 
                                     highlight_search_text = True, 
-                                    queries=[{"type": "TextMatch", "field": default_text_field_name_no_BM25, "text": "water"}])
+                                    highlight_query=[{"type": "TextMatch", "field": default_text_field_name_no_BM25, "text": "water"}])
 
         new_search_params = {"metric_type": "COSINE"}
 

--- a/tests/python_client/requirements.txt
+++ b/tests/python_client/requirements.txt
@@ -28,8 +28,8 @@ pytest-parallel
 pytest-random-order
 
 # pymilvus
-pymilvus==2.7.0rc84
-pymilvus[bulk_writer]==2.7.0rc84
+pymilvus==2.7.0rc93
+pymilvus[bulk_writer]==2.7.0rc93
 # for protobuf
 protobuf>=5.29.5
 


### PR DESCRIPTION
relate: https://github.com/milvus-io/milvus/issues/46571

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Core invariant: the LexicalHighlighter API now expects the match queries under the parameter name highlight_query (not queries); all call sites must pass highlight_query to supply match data. This PR assumes the underlying highlighter behavior and processing of those query values are unchanged.
- Logic simplified/removed: removed the legacy keyword queries in tests and updated calls to use highlight_query (tests/python_client/milvus_client/test_milvus_client_highlighter.py). This eliminates a redundant/incorrect keyword alias and aligns tests with the consolidated LexicalHighlighter constructor parameter name.
- Why this does NOT introduce data loss or behavior regression: the change is a parameter-name rename only — no parsing, matching, or storage logic was modified. Tests now construct LexicalHighlighter with pre_tags/post_tags/highlight_search_text/fragment_* and pass the query list under highlight_query; the highlighter execution path (client.search → highlighter processing → result['highlight']) is untouched, so existing highlight outputs and stored data remain unchanged.
- Other changes: bumped pymilvus test dependency to 2.7.0rc93 in tests/python_client/requirements.txt to match the updated constructor signature; scope of change is limited to tests and dependency pinning (no production code changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->