### PR TITLE
enhance: [2.6] move jemalloc_stats from pkg to internal/util/segcore (#46560)

### DIFF
--- a/internal/querynodev2/metrics_info.go
+++ b/internal/querynodev2/metrics_info.go
@@ -30,6 +30,7 @@ import (
 	"github.com/milvus-io/milvus/internal/querynodev2/collector"
 	"github.com/milvus-io/milvus/internal/querynodev2/delegator"
 	"github.com/milvus-io/milvus/internal/querynodev2/segments"
+	"github.com/milvus-io/milvus/internal/util/segcore"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/metrics"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/types"
@@ -269,7 +270,7 @@ func getSystemInfoMetrics(ctx context.Context, req *milvuspb.GetMetricsRequest, 
 	}
 
 	// Get jemalloc memory statistics
-	jemallocStats := hardware.GetJemallocStats()
+	jemallocStats := segcore.GetJemallocStats()
 
 	hardwareInfos := metricsinfo.HardwareMetrics{
 		IP:               node.session.Address,

--- a/internal/util/segcore/jemalloc_stats.go
+++ b/internal/util/segcore/jemalloc_stats.go
@@ -11,7 +11,7 @@
 
 //go:build linux || darwin
 
-package hardware
+package segcore
 
 /*
 #cgo pkg-config: milvus_core

--- a/internal/util/segcore/jemalloc_stats_test.go
+++ b/internal/util/segcore/jemalloc_stats_test.go
@@ -9,7 +9,7 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied. See the License for the specific language governing permissions and limitations under the License.
 
-package hardware
+package segcore
 
 import (
 	"testing"


### PR DESCRIPTION
Cherry-pick from master
pr: #46560
Related to #46133

Move jemalloc_stats.go and its test file from pkg/util/hardware to internal/util/segcore. This is a more appropriate location because:
- jemalloc_stats depends on milvus_core C++ library via cgo
- The pkg directory should remain independent of internal C++ dependencies
- segcore is the natural home for core memory allocator utilities