### PR TITLE
fix: enable diskann option by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,17 @@ PGO_PATH := $(PWD)/configs/pgo
 OS := $(shell uname -s)
 mode = Release
 
-use_disk_index = OFF
+# Set disk_index default based on OS
+# macOS (Darwin) does not support aio, so disable disk_index
+ifeq ($(OS),Darwin)
+    use_disk_index = OFF
+else
+    use_disk_index = ON
+endif
+
+# Allow manual override via disk_index variable
 ifdef disk_index
-	use_disk_index = ${disk_index}
+    use_disk_index = ${disk_index}
 endif
 
 use_asan = OFF


### PR DESCRIPTION
issue: #46481 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Core invariant: DiskANN requires OS support for asynchronous I/O (AIO); the Makefile now encodes this by defaulting disk_index=OFF on Darwin (macOS) and disk_index=ON on other OSes where AIO is available.
- Simplified logic: the build-time default was inverted for non-Darwin platforms so DiskANN is enabled by default; redundant conditional handling that previously forced OFF everywhere has been removed in favor of an OS-based default while preserving the single manual override variable.
- No data loss or regression: this is a compile-time change only — it toggles inclusion of DiskANN code paths at build time and does not modify runtime persistence or existing index files. macOS builds still skip AIO-dependent DiskANN code paths, and Linux/other builds merely compile support by default; no migration or runtime data-path changes are introduced.
- Backward compatibility / fix for issue #46481: addresses the reported need to enable DiskANN by default (issue #46481) while keeping explicit disk_index overrides intact for CI and developer workflows, so existing build scripts and deployments that pass disk_index continue to behave unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->