### PR TITLE
enhance: add user/segment level task concurrency limit when using user-task-polling

### DIFF
--- a/internal/querynodev2/segments/limiter/segment_sq_limiter.go
+++ b/internal/querynodev2/segments/limiter/segment_sq_limiter.go
@@ -1,0 +1,186 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package limiter
+
+import (
+	"time"
+
+	"go.uber.org/atomic"
+	"go.uber.org/zap"
+
+	"github.com/milvus-io/milvus/internal/util/searchutil/scheduler"
+	"github.com/milvus-io/milvus/pkg/v2/log"
+	"github.com/milvus-io/milvus/pkg/v2/metrics"
+	"github.com/milvus-io/milvus/pkg/v2/util/hardware"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
+)
+
+var limiter *concurrentLimiter
+
+func init() {
+	limiter = newConcurrentLimiter()
+	hardware.RegisterSystemMetricsListener(&hardware.SystemMetricsListener{
+		Cooldown:  5 * time.Second, // update the limit every 5 seconds.
+		Condition: func(metrics hardware.SystemMetrics, listener *hardware.SystemMetricsListener) bool { return true },
+		Callback: func(metrics hardware.SystemMetrics, listener *hardware.SystemMetricsListener) {
+			limiter.UpdateLimit(metrics)
+		},
+	})
+}
+
+// GetCurrentSegmentSQConcurrentLimit returns the current segment SQ concurrent limit.
+// Return -1 if there's no limit.
+func GetCurrentSegmentSQConcurrentLimit() int {
+	return int(limiter.GetCurrentConcurrent())
+}
+
+func newConcurrentLimiter() *concurrentLimiter {
+	return &concurrentLimiter{
+		Limit: atomic.NewInt64(-1),
+	}
+}
+
+type concurrentLimiter struct {
+	Limit *atomic.Int64
+}
+
+func (l *concurrentLimiter) GetCurrentConcurrent() int64 {
+	return l.Limit.Load()
+}
+
+func (l *concurrentLimiter) SetLimit(limit int64) {
+	l.Limit.Store(limit)
+}
+
+func (l *concurrentLimiter) UpdateLimit(m hardware.SystemMetrics) {
+	previous := l.GetCurrentConcurrent()
+	defer func() {
+		current := l.GetCurrentConcurrent()
+		if current != previous {
+			log.Info(
+				"segment level search/query concurrency limit updates",
+				log.FieldComponent("limiter"),
+				log.FieldModule(typeutil.QueryNodeRole),
+				zap.Int64("previous", previous),
+				zap.Int64("current", current),
+			)
+		}
+		if nodeID := paramtable.GetStringNodeID(); nodeID != "" {
+			metrics.QueryNodeSegmentSQPerTaskConcurrencyLimit.WithLabelValues(nodeID).Set(float64(current))
+		}
+	}()
+
+	if !isSegmentSearchConcurrentLimitEnabled() {
+		// if the segment search concurrent limit is disabled, set the limit to -1 to disable the limit.
+		l.SetLimit(-1)
+		return
+	}
+
+	threshold, err := getThreshold(m)
+	if err != nil {
+		log.Warn("failed to get threshold for segment search concurrent limit",
+			log.FieldComponent("limiter"),
+			log.FieldModule(typeutil.QueryNodeRole),
+			zap.Error(err),
+		)
+		return
+	}
+
+	newLimit := threshold.GetLimit(m.AverageCPUUsage)
+	threshold.RegisterMetrics()
+	l.SetLimit(newLimit)
+}
+
+type threshold struct {
+	lwmThreshold        float64
+	hwmThreshold        float64
+	lwmConcurrencyLimit int64
+	hwmConcurrencyLimit int64
+}
+
+func (t *threshold) RegisterMetrics() {
+	nodeID := paramtable.GetStringNodeID()
+
+	metrics.QueryNodeSegmentSQPerTaskConcurrencyLimitLwmThreshold.WithLabelValues(nodeID).Set(t.lwmThreshold)
+	metrics.QueryNodeSegmentSQPerTaskConcurrencyLimitHwmThreshold.WithLabelValues(nodeID).Set(t.hwmThreshold)
+	metrics.QueryNodeSegmentSQPerTaskConcurrencyLimitOfCPULwm.WithLabelValues(nodeID).Set(float64(t.lwmConcurrencyLimit))
+	metrics.QueryNodeSegmentSQPerTaskConcurrencyLimitOfCPUHwm.WithLabelValues(nodeID).Set(float64(t.hwmConcurrencyLimit))
+}
+
+func (t *threshold) GetLimit(cpuUsage float64) int64 {
+	if cpuUsage <= t.lwmThreshold {
+		return t.lwmConcurrencyLimit
+	} else if cpuUsage >= t.hwmThreshold {
+		return t.hwmConcurrencyLimit
+	} else {
+		diff := t.hwmThreshold - t.lwmThreshold
+		k := float64(t.hwmConcurrencyLimit-t.lwmConcurrencyLimit) / diff
+
+		offset := cpuUsage - t.lwmThreshold
+		return int64(offset*k + float64(t.lwmConcurrencyLimit))
+	}
+}
+
+// getThreshold gets the threshold for the segment search concurrent limit.
+func getThreshold(m hardware.SystemMetrics) (*threshold, error) {
+	lwmThreshold := paramtable.Get().QueryNodeCfg.SchedulePolicySegmentSQConcurrencyLimitCPUUsageLwmThreshold.GetAsFloat()
+	hwmThreshold := paramtable.Get().QueryNodeCfg.SchedulePolicySegmentSQConcurrencyLimitCPUUsageHwmThreshold.GetAsFloat()
+	maxConcurrencyRatio := paramtable.Get().QueryNodeCfg.SchedulePolicySegmentSQConcurrencyLimitOfLwm.GetAsFloat()
+
+	if maxConcurrencyRatio < 0 || maxConcurrencyRatio > 1 {
+		return nil, merr.WrapErrServiceInternalInvalidMsg("max concurrency ratio is invalid, should be in [0, 1], got: %f", maxConcurrencyRatio)
+	}
+
+	if lwmThreshold < 0 || lwmThreshold > 1 {
+		return nil, merr.WrapErrServiceInternalInvalidMsg("lwm threshold is invalid, should be in [0, 1], got: %f", lwmThreshold)
+	}
+
+	if hwmThreshold < 0 || hwmThreshold > 1 {
+		return nil, merr.WrapErrServiceInternalInvalidMsg("hwm threshold is invalid, should be in [0, 1], got: %f", hwmThreshold)
+	}
+	if lwmThreshold >= hwmThreshold {
+		return nil, merr.WrapErrServiceInternalInvalidMsg("lwm threshold should be less than hwm threshold, got: lwm=%f, hwm=%f", lwmThreshold, hwmThreshold)
+	}
+	if hwmThreshold-lwmThreshold < 1e-2 {
+		return nil, merr.WrapErrServiceInternalInvalidMsg("hwm threshold and lwm threshold are too close, got: lwm=%f, hwm=%f", lwmThreshold, hwmThreshold)
+	}
+
+	lwmConcurrencyLimit := int64(float64(m.CPUNum) * maxConcurrencyRatio)
+	hwmConcurrencyLimit := int64(1)
+	if lwmConcurrencyLimit < hwmConcurrencyLimit {
+		lwmConcurrencyLimit = hwmConcurrencyLimit
+	}
+	return &threshold{
+		lwmThreshold:        lwmThreshold,
+		hwmThreshold:        hwmThreshold,
+		lwmConcurrencyLimit: lwmConcurrencyLimit,
+		hwmConcurrencyLimit: hwmConcurrencyLimit,
+	}, nil
+}
+
+// isSegmentSearchConcurrentLimitEnabled checks if the segment search concurrent limit is enabled.
+func isSegmentSearchConcurrentLimitEnabled() bool {
+	enabledVal := paramtable.Get().QueryNodeCfg.SchedulePolicySegmentSQLimitEnabled.GetValue()
+	if len(enabledVal) != 0 {
+		// if the enabled is set, return the value of enabled.
+		return paramtable.Get().QueryNodeCfg.SchedulePolicySegmentSQLimitEnabled.GetAsBool()
+	}
+	// otherwise, open it automatically when the schedule policy is user-task-polling.
+	return paramtable.Get().QueryNodeCfg.SchedulePolicyName.GetValue() == scheduler.SchedulePolicyNameUserTaskPolling
+}

--- a/internal/querynodev2/segments/limiter/segment_sq_limiter_test.go
+++ b/internal/querynodev2/segments/limiter/segment_sq_limiter_test.go
@@ -39,22 +39,22 @@ func TestConcurrentLimiter(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		limiter.UpdateLimit(hardware.SystemMetrics{
+		l.UpdateLimit(hardware.SystemMetrics{
 			CPUNum:          cpu,
 			AverageCPUUsage: threshold.hwmThreshold,
 		})
-		assert.Equal(t, threshold.hwmConcurrencyLimit, limiter.GetCurrentConcurrent())
+		assert.Equal(t, threshold.hwmConcurrencyLimit, l.GetCurrentConcurrent())
 
-		limiter.UpdateLimit(hardware.SystemMetrics{
+		l.UpdateLimit(hardware.SystemMetrics{
 			CPUNum:          cpu,
 			AverageCPUUsage: threshold.lwmThreshold,
 		})
-		assert.Equal(t, threshold.lwmConcurrencyLimit, limiter.GetCurrentConcurrent())
+		assert.Equal(t, threshold.lwmConcurrencyLimit, l.GetCurrentConcurrent())
 
-		limiter.UpdateLimit(hardware.SystemMetrics{
+		l.UpdateLimit(hardware.SystemMetrics{
 			CPUNum:          cpu,
 			AverageCPUUsage: (threshold.lwmThreshold + threshold.hwmThreshold) / 2,
 		})
-		assert.Equal(t, (threshold.lwmConcurrencyLimit+threshold.hwmConcurrencyLimit)/2, limiter.GetCurrentConcurrent())
+		assert.Equal(t, (threshold.lwmConcurrencyLimit+threshold.hwmConcurrencyLimit)/2, l.GetCurrentConcurrent())
 	}
 }

--- a/internal/querynodev2/segments/limiter/segment_sq_limiter_test.go
+++ b/internal/querynodev2/segments/limiter/segment_sq_limiter_test.go
@@ -1,0 +1,60 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package limiter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus/pkg/v2/util/hardware"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+)
+
+func TestConcurrentLimiter(t *testing.T) {
+	l := newConcurrentLimiter()
+	assert.Equal(t, int64(-1), l.GetCurrentConcurrent())
+
+	paramtable.Get().QueryNodeCfg.SchedulePolicyName.SwapTempValue("user-task-polling")
+	cpuNum := []int{1, 2, 4, 8, 16, 32, 64, 128, 256}
+
+	for _, cpu := range cpuNum {
+		threshold, err := getThreshold(hardware.SystemMetrics{
+			CPUNum: cpu,
+		})
+		require.NoError(t, err)
+
+		limiter.UpdateLimit(hardware.SystemMetrics{
+			CPUNum:          cpu,
+			AverageCPUUsage: threshold.hwmThreshold,
+		})
+		assert.Equal(t, threshold.hwmConcurrencyLimit, limiter.GetCurrentConcurrent())
+
+		limiter.UpdateLimit(hardware.SystemMetrics{
+			CPUNum:          cpu,
+			AverageCPUUsage: threshold.lwmThreshold,
+		})
+		assert.Equal(t, threshold.lwmConcurrencyLimit, limiter.GetCurrentConcurrent())
+
+		limiter.UpdateLimit(hardware.SystemMetrics{
+			CPUNum:          cpu,
+			AverageCPUUsage: (threshold.lwmThreshold + threshold.hwmThreshold) / 2,
+		})
+		assert.Equal(t, (threshold.lwmConcurrencyLimit+threshold.hwmConcurrencyLimit)/2, limiter.GetCurrentConcurrent())
+	}
+}

--- a/internal/querynodev2/segments/search.go
+++ b/internal/querynodev2/segments/search.go
@@ -26,6 +26,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus/internal/querynodev2/segments/limiter"
 	"github.com/milvus-io/milvus/internal/querynodev2/segments/metricsutil"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/metrics"
@@ -61,6 +62,7 @@ func searchSegments(ctx context.Context, mgr *Manager, segments []Segment, segTy
 
 	// calling segment search in goroutines
 	errGroup, ctx := errgroup.WithContext(ctx)
+	errGroup.SetLimit(limiter.GetCurrentSegmentSQConcurrentLimit())
 	segmentsWithoutIndex := make([]int64, 0)
 	for _, segment := range segments {
 		seg := segment
@@ -154,6 +156,7 @@ func searchSegmentsStreamly(ctx context.Context,
 
 	// calling segment search in goroutines
 	errGroup, ctx := errgroup.WithContext(ctx)
+	errGroup.SetLimit(limiter.GetCurrentSegmentSQConcurrentLimit())
 	log := log.Ctx(ctx)
 	for _, segment := range segments {
 		seg := segment

--- a/internal/util/searchutil/scheduler/concurrent_safe_scheduler_test.go
+++ b/internal/util/searchutil/scheduler/concurrent_safe_scheduler_test.go
@@ -19,6 +19,7 @@ import (
 func TestScheduler(t *testing.T) {
 	paramtable.Init()
 	t.Run("user-task-polling", func(t *testing.T) {
+		paramtable.Get().QueryNodeCfg.SchedulePolicyMaxConcurrentRatioPerUser.SwapTempValue("1")
 		testScheduler(t, newUserTaskPollingPolicy())
 	})
 	t.Run("fifo", func(t *testing.T) {

--- a/internal/util/searchutil/scheduler/policy_test.go
+++ b/internal/util/searchutil/scheduler/policy_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestUserTaskPollingPolicy(t *testing.T) {
 	paramtable.Init()
+	paramtable.Get().QueryNodeCfg.SchedulePolicyMaxConcurrentRatioPerUser.SwapTempValue("1")
 	testCommonPolicyOperation(t, newUserTaskPollingPolicy())
 	testCrossUserMerge(t, newUserTaskPollingPolicy())
 }

--- a/internal/util/searchutil/scheduler/queues.go
+++ b/internal/util/searchutil/scheduler/queues.go
@@ -168,7 +168,7 @@ func (q *fairPollingTaskQueue) push(group string, task Task) {
 }
 
 // pop pop next ready task.
-func (q *fairPollingTaskQueue) pop(queueExpire time.Duration) (task Task) {
+func (q *fairPollingTaskQueue) pop(queueExpire time.Duration, skipper ...func(t Task) bool) (task Task) {
 	// Return directly if there's no task exists.
 	if q.count == 0 {
 		return
@@ -197,6 +197,9 @@ func (q *fairPollingTaskQueue) pop(queueExpire time.Duration) (task Task) {
 			continue
 		}
 		task = queue.front()
+		if len(skipper) > 0 && skipper[0](task) {
+			continue
+		}
 		queue.pop()
 		q.count--
 		checkpoint = next

--- a/internal/util/searchutil/scheduler/queues.go
+++ b/internal/util/searchutil/scheduler/queues.go
@@ -196,10 +196,12 @@ func (q *fairPollingTaskQueue) pop(queueExpire time.Duration, skipper ...func(t 
 			checkpoint = next
 			continue
 		}
-		task = queue.front()
-		if len(skipper) > 0 && skipper[0](task) {
+		newTask := queue.front()
+		if len(skipper) > 0 && skipper[0](newTask) {
+			checkpoint = next
 			continue
 		}
+		task = newTask
 		queue.pop()
 		q.count--
 		checkpoint = next

--- a/internal/util/searchutil/scheduler/tasks.go
+++ b/internal/util/searchutil/scheduler/tasks.go
@@ -118,6 +118,8 @@ type taskWrapper struct {
 
 // Done notify the task finished.
 func (t *taskWrapper) Done(err error) {
-	t.callbackWhenDone()
+	if t.callbackWhenDone != nil {
+		t.callbackWhenDone()
+	}
 	t.Task.Done(err)
 }

--- a/internal/util/searchutil/scheduler/tasks.go
+++ b/internal/util/searchutil/scheduler/tasks.go
@@ -3,8 +3,8 @@ package scheduler
 import "github.com/milvus-io/milvus/pkg/v2/proto/internalpb"
 
 const (
-	schedulePolicyNameFIFO            = "fifo"
-	schedulePolicyNameUserTaskPolling = "user-task-polling"
+	SchedulePolicyNameFIFO            = "fifo"
+	SchedulePolicyNameUserTaskPolling = "user-task-polling"
 )
 
 // NewScheduler create a scheduler by policyName.
@@ -12,11 +12,11 @@ func NewScheduler(policyName string) Scheduler {
 	switch policyName {
 	case "":
 		fallthrough
-	case schedulePolicyNameFIFO:
+	case SchedulePolicyNameFIFO:
 		return newScheduler(
 			newFIFOPolicy(),
 		)
-	case schedulePolicyNameUserTaskPolling:
+	case SchedulePolicyNameUserTaskPolling:
 		return newScheduler(
 			newUserTaskPollingPolicy(),
 		)
@@ -108,4 +108,16 @@ type Task interface {
 	NQ() int64
 
 	SearchResult() *internalpb.SearchResults
+}
+
+// taskWrapper is a wrapper of Task that can be used to add a callback when task is done.
+type taskWrapper struct {
+	Task
+	callbackWhenDone func()
+}
+
+// Done notify the task finished.
+func (t *taskWrapper) Done(err error) {
+	t.callbackWhenDone()
+	t.Task.Done(err)
 }

--- a/pkg/metrics/hardware_metrics.go
+++ b/pkg/metrics/hardware_metrics.go
@@ -1,0 +1,27 @@
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var (
+	CPUUsage        = newHardwareGauge("cpu_usage", "the cpu usage of milvus process")
+	MemoryUsage     = newHardwareGauge("memory_usage", "the memory usage of milvus process")
+	AverageCPUUsage = newHardwareGauge("avg_cpu_usage", "the average cpu usage of milvus process")
+)
+
+// newHardwareGauge creates a new hardware gauge.
+func newHardwareGauge(name string, help string) prometheus.Gauge {
+	return prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: milvusNamespace,
+			Subsystem: "hardware",
+			Name:      name,
+			Help:      help,
+		},
+	)
+}
+
+func registerHardwareMetrics(registry prometheus.Registerer) {
+	registry.MustRegister(CPUUsage)
+	registry.MustRegister(MemoryUsage)
+	registry.MustRegister(AverageCPUUsage)
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -193,5 +193,6 @@ func Register(r prometheus.Registerer) {
 	r.MustRegister(BuildInfo)
 	r.MustRegister(RuntimeInfo)
 	r.MustRegister(ThreadNum)
+	registerHardwareMetrics(r)
 	metricRegisterer = r
 }

--- a/pkg/metrics/querynode_metrics.go
+++ b/pkg/metrics/querynode_metrics.go
@@ -523,6 +523,46 @@ var (
 			segmentStateLabelName,
 		})
 
+	QueryNodeSegmentSQPerTaskConcurrencyLimit = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.QueryNodeRole,
+			Name:      "segment_sq_per_task_concurrency_limit",
+			Help:      "the concurrency limit of search or query per task at segment level",
+		}, []string{nodeIDLabelName})
+
+	QueryNodeSegmentSQPerTaskConcurrencyLimitLwmThreshold = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.QueryNodeRole,
+			Name:      "segment_sq_per_task_concurrency_limit_cpu_lwm_threshold",
+			Help:      "the CPU usage low water mark threshold of search or query per task at segment level",
+		}, []string{nodeIDLabelName})
+
+	QueryNodeSegmentSQPerTaskConcurrencyLimitHwmThreshold = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.QueryNodeRole,
+			Name:      "segment_sq_per_task_concurrency_limit_cpu_hwm_threshold",
+			Help:      "the CPU usage high water mark threshold of search or query per task at segment level",
+		}, []string{nodeIDLabelName})
+
+	QueryNodeSegmentSQPerTaskConcurrencyLimitOfCPULwm = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.QueryNodeRole,
+			Name:      "segment_sq_per_task_concurrency_limit_of_cpu_lwm",
+			Help:      "the concurrency limit when CPU usage is less than low water mark threshold",
+		}, []string{nodeIDLabelName})
+
+	QueryNodeSegmentSQPerTaskConcurrencyLimitOfCPUHwm = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.QueryNodeRole,
+			Name:      "segment_sq_per_task_concurrency_limit_of_cpu_hwm",
+			Help:      "the concurrency limit when CPU usage is greater than high water mark threshold",
+		}, []string{nodeIDLabelName})
+
 	QueryNodeWatchDmlChannelLatency = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: milvusNamespace,
@@ -865,6 +905,11 @@ func RegisterQueryNode(registry *prometheus.Registry) {
 	registry.MustRegister(QueryNodeConsumeTimeTickLag)
 	registry.MustRegister(QueryNodeMsgDispatcherTtLag)
 	registry.MustRegister(QueryNodeSegmentSearchLatencyPerVector)
+	registry.MustRegister(QueryNodeSegmentSQPerTaskConcurrencyLimit)
+	registry.MustRegister(QueryNodeSegmentSQPerTaskConcurrencyLimitLwmThreshold)
+	registry.MustRegister(QueryNodeSegmentSQPerTaskConcurrencyLimitHwmThreshold)
+	registry.MustRegister(QueryNodeSegmentSQPerTaskConcurrencyLimitOfCPULwm)
+	registry.MustRegister(QueryNodeSegmentSQPerTaskConcurrencyLimitOfCPUHwm)
 	registry.MustRegister(QueryNodeWatchDmlChannelLatency)
 	registry.MustRegister(QueryNodeDiskUsedSize)
 	registry.MustRegister(QueryNodeProcessCost)

--- a/pkg/util/hardware/listener_test.go
+++ b/pkg/util/hardware/listener_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestListener(t *testing.T) {
-	w := NewSystemMetricsWatcher(20 * time.Millisecond)
+	w := newSystemMetricsWatcher(20 * time.Millisecond)
 	called := atomic.NewInt32(0)
 	l := &SystemMetricsListener{
 		Cooldown: 100 * time.Millisecond,

--- a/pkg/util/merr/utils.go
+++ b/pkg/util/merr/utils.go
@@ -375,6 +375,10 @@ func WrapErrTooManyRequests(limit int32, msg ...string) error {
 	return err
 }
 
+func WrapErrServiceInternalInvalidMsg(fmt string, args ...any) error {
+	return errors.Wrapf(ErrServiceInternal, fmt, args...)
+}
+
 func WrapErrServiceInternal(reason string, msg ...string) error {
 	err := wrapFieldsWithDesc(ErrServiceInternal, reason)
 	if len(msg) > 0 {

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -4460,7 +4460,7 @@ otherwise parse as boolean value to determine if the segment search concurrent l
 		Version:      "2.6.8",
 		DefaultValue: "0.3",
 		Doc: `CPU usage low water mark threshold to limit segment search concurrent limit per task,
-when CPU usage is less than this threshold, the concurrent limit will be equal to hardware.CPUNum * segmentSQLimitMxaConcurrencyRatio`,
+when CPU usage is less than this threshold, the concurrent limit will be equal to hardware.CPUNum * segmentSQConcurrencyLimitCPUUsageLwmThreshold`,
 		Export: false,
 	}
 	p.SchedulePolicySegmentSQConcurrencyLimitCPUUsageLwmThreshold.Init(base.mgr)

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -3352,10 +3352,15 @@ type queryNodeConfig struct {
 	DiskSizeFetchInterval       ParamItem `refreshable:"false"`
 
 	// schedule task policy.
-	SchedulePolicyName                    ParamItem `refreshable:"false"`
-	SchedulePolicyTaskQueueExpire         ParamItem `refreshable:"true"`
-	SchedulePolicyEnableCrossUserGrouping ParamItem `refreshable:"true"`
-	SchedulePolicyMaxPendingTaskPerUser   ParamItem `refreshable:"true"`
+	SchedulePolicyName                                          ParamItem `refreshable:"false"`
+	SchedulePolicyTaskQueueExpire                               ParamItem `refreshable:"true"`
+	SchedulePolicyEnableCrossUserGrouping                       ParamItem `refreshable:"true"`
+	SchedulePolicyMaxPendingTaskPerUser                         ParamItem `refreshable:"true"`
+	SchedulePolicyMaxConcurrentRatioPerUser                     ParamItem `refreshable:"true"`
+	SchedulePolicySegmentSQLimitEnabled                         ParamItem `refreshable:"true"`
+	SchedulePolicySegmentSQConcurrencyLimitCPUUsageLwmThreshold ParamItem `refreshable:"true"`
+	SchedulePolicySegmentSQConcurrencyLimitCPUUsageHwmThreshold ParamItem `refreshable:"true"`
+	SchedulePolicySegmentSQConcurrencyLimitOfLwm                ParamItem `refreshable:"true"`
 
 	// CGOPoolSize ratio to MaxReadConcurrency
 	CGOPoolSizeRatio ParamItem `refreshable:"true"`
@@ -4428,6 +4433,57 @@ user-task-polling:
 		Export:       true,
 	}
 	p.SchedulePolicyMaxPendingTaskPerUser.Init(base.mgr)
+
+	p.SchedulePolicyMaxConcurrentRatioPerUser = ParamItem{
+		Key:          "queryNode.scheduler.scheduleReadPolicy.maxConcurrentRatioPerUser",
+		Version:      "2.6.8",
+		DefaultValue: "0.4",
+		Doc: `Max concurrent ratio per user in scheduler, 
+which means the user can have at most (maxReadConcurrentRatio * hardware.CPUNum * maxConcurrentRatioPerUser, at least 1) concurrent tasks running in scheduler`,
+		Export: false,
+	}
+	p.SchedulePolicyMaxConcurrentRatioPerUser.Init(base.mgr)
+
+	p.SchedulePolicySegmentSQLimitEnabled = ParamItem{
+		Key:          "queryNode.scheduler.scheduleReadPolicy.segmentSQLimitEnabled",
+		Version:      "2.6.8",
+		DefaultValue: "",
+		Doc: `Enable segment search concurrent limit for scheduler.
+if not set, enabled by default when SchedulePolicyName is user-task-polling,
+otherwise parse as boolean value to determine if the segment search concurrent limit is enabled.`,
+		Export: false,
+	}
+	p.SchedulePolicySegmentSQLimitEnabled.Init(base.mgr)
+
+	p.SchedulePolicySegmentSQConcurrencyLimitCPUUsageLwmThreshold = ParamItem{
+		Key:          "queryNode.scheduler.scheduleReadPolicy.segmentSQConcurrencyLimitCPUUsageLwmThreshold",
+		Version:      "2.6.8",
+		DefaultValue: "0.3",
+		Doc: `CPU usage low water mark threshold to limit segment search concurrent limit per task,
+when CPU usage is less than this threshold, the concurrent limit will be equal to hardware.CPUNum * segmentSQLimitMxaConcurrencyRatio`,
+		Export: false,
+	}
+	p.SchedulePolicySegmentSQConcurrencyLimitCPUUsageLwmThreshold.Init(base.mgr)
+
+	p.SchedulePolicySegmentSQConcurrencyLimitCPUUsageHwmThreshold = ParamItem{
+		Key:          "queryNode.scheduler.scheduleReadPolicy.segmentSQConcurrencyLimitCPUUsageHwmThreshold",
+		Version:      "2.6.8",
+		DefaultValue: "0.9",
+		Doc: `CPU usage high water mark threshold to limit segment search concurrent limit per task,
+when CPU usage is greater than this threshold, the concurrent limit will be equal to 1`,
+		Export: false,
+	}
+	p.SchedulePolicySegmentSQConcurrencyLimitCPUUsageHwmThreshold.Init(base.mgr)
+
+	p.SchedulePolicySegmentSQConcurrencyLimitOfLwm = ParamItem{
+		Key:          "queryNode.scheduler.scheduleReadPolicy.segmentSQConcurrencyLimitOfLwm",
+		Version:      "2.6.8",
+		DefaultValue: "0.5",
+		Doc: `Concurrency limit of low water mark to limit segment search concurrent limit per task,
+when CPU usage is less than the low water mark threshold, the concurrent limit will be equal to hardware.CPUNum * segmentSQConcurrencyLimitOfLwm`,
+		Export: false,
+	}
+	p.SchedulePolicySegmentSQConcurrencyLimitOfLwm.Init(base.mgr)
 
 	p.CGOPoolSizeRatio = ParamItem{
 		Key:          "queryNode.segcore.cgoPoolSizeRatio",

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -532,6 +532,26 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, 5*time.Second, Params.CatchUpStreamingDataTsLag.GetAsDurationByParse())
 		params.Save(Params.CatchUpStreamingDataTsLag.Key, "0s")
 		assert.Equal(t, time.Duration(0), Params.CatchUpStreamingDataTsLag.GetAsDurationByParse())
+
+		assert.Equal(t, 0.4, Params.SchedulePolicyMaxConcurrentRatioPerUser.GetAsFloat())
+		params.Save("queryNode.scheduler.scheduleReadPolicy.maxConcurrentRatioPerUser", "0.5")
+		assert.Equal(t, 0.5, Params.SchedulePolicyMaxConcurrentRatioPerUser.GetAsFloat())
+
+		assert.Equal(t, false, Params.SchedulePolicySegmentSQLimitEnabled.GetAsBool())
+		params.Save("queryNode.scheduler.scheduleReadPolicy.segmentSQLimitEnabled", "true")
+		assert.Equal(t, true, Params.SchedulePolicySegmentSQLimitEnabled.GetAsBool())
+
+		assert.Equal(t, 0.5, Params.SchedulePolicySegmentSQConcurrencyLimitOfLwm.GetAsFloat())
+		params.Save("queryNode.scheduler.scheduleReadPolicy.segmentSQConcurrencyLimitOfLwm", "0.7")
+		assert.Equal(t, 0.7, Params.SchedulePolicySegmentSQConcurrencyLimitOfLwm.GetAsFloat())
+
+		assert.Equal(t, 0.3, Params.SchedulePolicySegmentSQConcurrencyLimitCPUUsageLwmThreshold.GetAsFloat())
+		params.Save("queryNode.scheduler.scheduleReadPolicy.segmentSQConcurrencyLimitCPUUsageLwmThreshold", "0.4")
+		assert.Equal(t, 0.4, Params.SchedulePolicySegmentSQConcurrencyLimitCPUUsageLwmThreshold.GetAsFloat())
+
+		assert.Equal(t, 0.9, Params.SchedulePolicySegmentSQConcurrencyLimitCPUUsageHwmThreshold.GetAsFloat())
+		params.Save("queryNode.scheduler.scheduleReadPolicy.segmentSQConcurrencyLimitCPUUsageHwmThreshold", "0.8")
+		assert.Equal(t, 0.8, Params.SchedulePolicySegmentSQConcurrencyLimitCPUUsageHwmThreshold.GetAsFloat())
 	})
 
 	t.Run("test dataCoordConfig", func(t *testing.T) {


### PR DESCRIPTION
issue: #46586

- limit the task concurrency by user.
- limit the segment sq concurrency when cpu is high.
- add more metric to observe the behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Core invariant: when SchedulePolicyNameUserTaskPolling is active, hierarchical concurrency caps are enforced — per-user concurrent tasks are limited by SchedulePolicyMaxConcurrentRatioPerUser (internal/util/searchutil/scheduler/user_task_polling_policy.go) and node-level segment SQ concurrency is capped by a CPU-aware limiter (internal/querynodev2/segments/limiter.GetCurrentSegmentSQConcurrentLimit()) driven from rolling-average AverageCPUUsage (pkg/util/hardware/listener.go) and exposed via new Prometheus gauges (pkg/metrics/querynode_metrics.go, pkg/metrics/hardware_metrics.go).
- Logic removed/simplified: the legacy pool-based parallel path doOnSegmentsWithPool has been removed; all segment work now executes under a single errgroup with SetLimit derived from the segment SQ limiter (internal/querynodev2/segments/segment_do.go, search.go), and per-user bookkeeping is centralized via a taskWrapper and in-policy metrics (internal/util/searchutil/scheduler/tasks.go, user_task_polling_policy.go), removing external pool/accounting complexity.
- Why this does NOT introduce data loss or behavior regression: task execution and lifecycle code paths are unchanged — searchSegments/searchSegmentsStreamly and doOnSegments still run the same handlers; the new skipper in queue.pop only defers popping (does not drop tasks); taskWrapper.Done ensures decrement/cleanup on completion; the limiter only sets errgroup concurrency (no task cancellation/mutation); config flags, threshold validation, and added metrics make limits observable and deterministic.
- New capability and scope: adds per-user concurrency enforcement (configurable via paramtable/component_param.go), a CPU-aware segment-SQ concurrency limiter with unit tests (internal/querynodev2/segments/limiter), rolling-average CPU sampling and AverageCPUUsage metric (pkg/util/hardware/listener.go), and five Prometheus gauges to monitor limits and thresholds (pkg/metrics/querynode_metrics.go).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->