### PR TITLE
enhance: Explicitly set StartMessageIDInclusive to true for pulsar consumer

### DIFF
--- a/pkg/mq/msgstream/mqwrapper/pulsar/pulsar_client.go
+++ b/pkg/mq/msgstream/mqwrapper/pulsar/pulsar_client.go
@@ -119,6 +119,7 @@ func (pc *pulsarClient) Subscribe(ctx context.Context, options mqwrapper.Consume
 		Type:                        pulsar.Exclusive,
 		SubscriptionInitialPosition: pulsar.SubscriptionInitialPosition(options.SubscriptionInitialPosition),
 		MessageChannel:              receiveChannel,
+		StartMessageIDInclusive:     true,
 	})
 	if err != nil {
 		metrics.MsgStreamOpCounter.WithLabelValues(metrics.CreateConsumerLabel, metrics.FailLabel).Inc()


### PR DESCRIPTION
In pulsar-client-go v0.12, `Consumer.Seek()` **includes** the message at the seek position by default. However, in v0.17+, the default behavior changed to **exclude** the seek position message.
This commit explicitly sets `StartMessageIDInclusive=true` when creating pulsar consumers to ensure consistent seek behavior and prevent potential message loss after upgrading the Pulsar client library.

issue: https://github.com/milvus-io/milvus/issues/46589

pr: https://github.com/milvus-io/milvus/pull/46501