### PR TITLE
fix: remove EnableStorageV2 override in TestProxy (#46594)

### DIFF
--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -962,8 +962,6 @@ func TestProxy(t *testing.T) {
 	params.DataNodeGrpcServerCfg.IP = "localhost"
 	params.StreamingNodeGrpcServerCfg.IP = "localhost"
 	params.Save(params.MQCfg.Type.Key, "pulsar")
-	params.CommonCfg.EnableStorageV2.SwapTempValue("false")
-	defer params.CommonCfg.EnableStorageV2.SwapTempValue("")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	ctx = GetContext(ctx, "root:123456")


### PR DESCRIPTION
Related to #46594

Remove the temporary config override that forced EnableStorageV2 to false in TestProxy. This override caused test failures with the new load logic, as segments could not be loaded with v1 format.

This PR is a quick fix to make ut back to normal