### PR TITLE
test: Add HNSW_PQ test cases and update HNSW_SQ

### DIFF
--- a/tests/python_client/testcases/indexes/idx_hnsw_pq.py
+++ b/tests/python_client/testcases/indexes/idx_hnsw_pq.py
@@ -1,0 +1,524 @@
+from pymilvus import DataType
+from common import common_type as ct
+
+success = "success"
+
+
+class HNSW_PQ:
+    supported_vector_types = [
+        DataType.FLOAT_VECTOR,
+        DataType.FLOAT16_VECTOR,
+        DataType.BFLOAT16_VECTOR,
+        DataType.INT8_VECTOR
+    ]
+
+    supported_metrics = ['L2', 'IP', 'COSINE']
+
+    build_params = [
+
+        # M params test
+        {
+            "description": "Minimum Boundary Test",
+            "params": {"M": 2},
+            "expected": success
+        },
+        {
+            "description": "Maximum Boundary Test",
+            "params": {"M": 2048},
+            "expected": success
+        },
+        {
+            "description": "Out of Range Test - Negative",
+            "params": {"M": -1},
+            "expected": {"err_code": 1100, "err_msg": "param 'M' (-1) should be in range [2, 2048]"}
+        },
+        {
+            "description": "Out of Range Test - Too Large",
+            "params": {"M": 2049},
+            "expected": {"err_code": 1100, "err_msg": "param 'M' (2049) should be in range [2, 2048]"}
+        },
+        {
+            "description": "String Type Test will ignore the wrong type",
+            "params": {"M": "16"},
+            "expected": success
+        },
+        {
+            "description": "Float Type Test",
+            "params": {"M": 16.0},
+            "expected": {"err_code": 1100, "err_msg": "wrong data type in json"}
+        },
+        {
+            "description": "Boolean Type Test",
+            "params": {"M": True},
+            "expected": {"err_code": 1100, "err_msg": "invalid integer value, key: 'M', value: 'True': invalid parameter"}
+        },
+        {
+            "description": "None Type Test, use default value",
+            "params": {"M": None},
+            "expected": success
+        },
+        {
+            "description": "List Type Test",
+            "params": {"M": [16]},
+            "expected": {"err_code": 1100, "err_msg": "invalid integer value, key: 'M', value: '[16]': invalid parameter"}
+        },
+        {
+            "description": "Nested dict in params",
+            "params": {"M": {"value": 16}},
+            "expected": {"err_code": 1100, "err_msg": "invalid integer value"}
+        },
+        # efConstruction params test
+        {
+            "description": "Minimum Boundary Test",
+            "params": {"efConstruction": 1},
+            "expected": success
+        },
+        {
+            "description": "Large Value Test",
+            "params": {"efConstruction": 10000},
+            "expected": success
+        },
+        {
+            "description": "Out of Range Test - Negative",
+            "params": {"efConstruction": -1},
+            "expected": {"err_code": 1100, "err_msg": "param 'efConstruction' (-1) should be in range [1, 2147483647]"}
+        },
+        {
+            "description": "String Type Test will ignore the wrong type",
+            "params": {"efConstruction": "100"},
+            "expected": success
+        },
+        {
+            "description": "Float Type Test",
+            "params": {"efConstruction": 100.0},
+            "expected": {"err_code": 1100, "err_msg": "wrong data type in json"}
+        },
+        {
+            "description": "Boolean Type Test",
+            "params": {"efConstruction": True},
+            "expected": {"err_code": 1100, "err_msg": "invalid integer value, key: 'efConstruction', value: 'True': invalid parameter"}
+        },
+        {
+            "description": "None Type Test, use default value",
+            "params": {"efConstruction": None},
+            "expected": success
+        },
+        {
+            "description": "List Type Test",
+            "params": {"efConstruction": [100]},
+            "expected": {"err_code": 1100, "err_msg": "invalid integer value, key: 'efConstruction', value: '[100]': invalid parameter"}
+        },
+        {
+            "description": "Nested List in Params",
+            "params": {"efConstruction": [[100]]},
+            "expected": {"err_code": 1100, "err_msg": "invalid integer value"}
+        },
+        # m params test
+        {
+            "description": "Minimum Boundary Test",
+            "params": {"m": 1},
+            "expected": success
+        },
+        {
+            "description": "Half of Dimension Value Test",
+            "params": {"m": 64},
+            "expected": success
+        },
+        {
+            "description": "Maximum Boundary Test (Dimension)",
+            "params": {"m": 128},
+            "expected": success
+        },
+        {
+            "description": "Negative Value Test",
+            "params": {"m": -1},
+            "expected": {
+                "err_code": 1100,
+                "err_msg": "Out of range in json: param 'm' (-1) should be in range [1, 65536]"
+            }
+        },
+        {
+            "description": "Larger Value Test",
+            "params": {"m": 256},
+            "expected": {
+                "err_code": 1100,
+                "err_msg": "The dimension of the vector (dim) should be a multiple of the number of subquantizers (m)."
+            }
+        },
+        {
+            "description": "Not Divisible by Dimension Value Test",
+            "params": {"m": 7},
+            "expected": {
+                "err_code": 1100,
+                "err_msg": "The dimension of the vector (dim) should be a multiple of the number of subquantizers (m)."
+            }
+        },
+        {
+            "description": "String Type Test",
+            "params": {"m": "16"},
+            "expected": success
+        },
+        {
+            "description": "Float Type Test",
+            "params": {"m": 16.0},
+            "expected": {
+                "err_code": 1100,
+                "err_msg": "wrong data type in json, key: 'm', value: '16.0': invalid parameter"
+            }
+        },
+        {
+            "description": "Boolean Type Test",
+            "params": {"m": True},
+            "expected": {
+                "err_code": 1100,
+                "err_msg": "invalid integer value"
+            }
+        },
+        {
+            "description": "List Type Test",
+            "params": {"m": [16]},
+            "expected": {
+                "err_code": 1100,
+                "err_msg": "invalid integer value"
+            }
+        },
+        {
+            "description": "None Type Test",
+            "params": {"m": None},
+            "expected": success
+        },
+        # nbits params test
+        {
+            "description": "Minimum Boundary Test",
+            "params": {"nbits": 1},
+            "expected": success
+        },
+        {
+            "description": "Maximum Boundary Test (doc:24) ",
+            "params": {"nbits": 10},
+            "expected": success
+        },
+        {
+            "description": "Default Value Test",
+            "params": {"nbits": 8},
+            "expected": success
+        },
+        {
+            "description": "Negative Value Test",
+            "params": {"nbits": -1},
+            "expected": {
+                "err_code": 1100,
+                "err_msg": "Out of range in json: param 'nbits' (-1) should be in range [1, 24]: invalid parameter"
+            }
+        },
+        {
+            "description": "Large Value Test",
+            "params": {"nbits": 25},
+            "expected": {
+                "err_code": 1100,
+                "err_msg": "Out of range in json: param 'nbits' (25) should be in range [1, 24]"
+            }
+        },
+        {
+            "description": "String Type Test",
+            "params": {"nbits": "8"},
+            "expected": success
+        },
+        {
+            "description": "Float Type Test",
+            "params": {"nbits": 8.0},
+            "expected": {
+                "err_code": 1100,
+                "err_msg": "wrong data type in json, key: 'nbits', value: '8.0'"
+            }
+        },
+        {
+            "description": "Boolean Type Test",
+            "params": {"nbits": True},
+            "expected": {
+                "err_code": 1100,
+                "err_msg": "invalid integer value"
+            }
+        },
+        {
+            "description": "List Type Test",
+            "params": {"nbits": [8]},
+            "expected": {
+                "err_code": 1100,
+                "err_msg": "invalid integer value"
+            }
+        },
+        {
+            "description": "None Type Test",
+            "params": {"nbits": None},
+            "expected": success
+        },
+
+
+        # refine params test
+        {
+            "description": "refine = True",
+            "params": {"refine": True},
+            "expected": success
+        },
+        {
+            "description": "String Type Test",
+            "params": {"refine": "true"},
+            "expected": success
+        },
+        {
+            "description": "Invalid String Type Test",
+            "params": {"refine": "test"},
+            "expected": {"err_code": 1100, "err_msg": "should be a boolean: invalid parameter"}
+
+        },
+        {
+            "description": "Integer Type Test",
+            "params": {"refine": 1},
+            "expected": {"err_code": 1100, "err_msg": "should be a boolean: invalid parameter"}
+        },
+        {
+            "description": "Float Type Test",
+            "params": {"refine": 1.0},
+            "expected": {"err_code": 1100, "err_msg": "should be a boolean: invalid parameter"}
+        },
+        {
+            "description": "List Type Test",
+            "params": {"refine": [True]},
+            "expected": {"err_code": 1100, "err_msg": "should be a boolean: invalid parameter"}
+        },
+        {
+            "description": "None Type Test, use default value",
+            "params": {"refine": None},
+            "expected": success
+        },
+
+        # refine_type params test
+        {
+            "description": "Valid refine_type - SQ6",
+            "params": {"refine_type": "SQ6"},
+            "expected": success
+        },
+        {
+            "description": "Valid refine_type - SQ8",
+            "params": {"refine_type": "SQ8"},
+            "expected": success
+        },
+        {
+            "description": "Valid refine_type - BF16",
+            "params": {"refine_type": "BF16"},
+            "expected": success
+        },
+        {
+            "description": "Valid refine_type - FP16",
+            "params": {"refine_type": "FP16"},
+            "expected": success
+        },
+        {
+            "description": "Valid refine_type - FP32",
+            "params": {"refine_type": "FP32"},
+            "expected": success
+        },
+        {
+            "description": "Out of Range Test - unknown value",
+            "params": {"refine_type": "INT8"},
+            "expected": {"err_code": 1100, "err_msg": "invalid refine type : INT8, optional types are [sq6, sq8, fp16, bf16, fp32, flat]: invalid parameter"}
+        },
+        {
+            "description": "Integer Type Test",
+            "params": {"refine_type": 1},
+            "expected": {"err_code": 1100, "err_msg": "invalid refine type : 1, optional types are [sq6, sq8, fp16, bf16, fp32, flat]: invalid parameter"}
+        },
+        {
+            "description": "Float Type Test",
+            "params": {"refine_type": 1.0},
+            "expected": {"err_code": 1100, "err_msg": "invalid refine type : 1.0, optional types are [sq6, sq8, fp16, bf16, fp32, flat]: invalid parameter"}
+        },
+        {
+            "description": "List Type Test",
+            "params": {"refine_type": ["FP16"]},
+            "expected": {"err_code": 1100, "err_msg": "['FP16'], optional types are [sq6, sq8, fp16, bf16, fp32, flat]: invalid parameter"}
+        },
+        {
+            "description": "None Type Test, use default value",
+            "params": {"refine_type": None},
+            "expected": success
+        },
+        {
+            "description": "refine_type lower precision than sq_type but refine disabled",
+            "params": {"sq_type": "FP16", "refine_type": "SQ8"},
+            "expected": success
+        },
+        {
+            "description": "refine_type lower than sq_type",
+            "params": {"sq_type": "FP16", "refine_type": "SQ8", "refine": True},
+            "expected": success
+        },
+        # combination params test
+        {
+            "description": "empty dict params",
+            "params": {},
+            "expected": success
+        },
+        {
+            "description": "All optional parameters None",
+            "params": {"M": None, "efConstruction": None, "m": None, "nbits":None, "refine": None, "refine_type": None},
+            "expected": success
+        },
+        {
+            "description": "Typical valid combination",
+            "params": {"M": 16, "efConstruction": 200, "m": 64, "nbits": 8,"refine": True, "refine_type": "FP16"},
+            "expected": success
+        },
+        {
+            "description": "Refine Disabled",
+            "params": {"M": 16, "efConstruction": 200, "m": 32, "nbits": 8},
+            "expected": "success"
+        },
+        {
+            "description": "Minimum Boundary Combination",
+            "params": {"M": 2, "efConstruction": 1, "m": 1, "nbits": 1, "refine": True, "refine_type": "SQ8"},
+            "expected": "success"
+        },
+        {
+            "description": "Maximum Boundary Combination",
+            "params": {"M": 2048, "efConstruction": 10000, "m": 128, "nbits": 10, "refine": True, "refine_type": "FP32"},
+            "expected": success
+        },
+        {
+            "description": "Unknown extra parameter in combination",
+            "params": {"M": 16, "efConstruction": 200, "m": 32, "nbits": 8, "refine": True, "refine_type": "FP16", "unknown_param": "nothing"},
+            "expected": success
+        },
+        {
+            "description": "Partial parameters set (M + m only)",
+            "params": {"M": 32, "m": 32},
+            "expected": success
+        },
+        {
+            "description": "Partial parameters set (efConstruction + nbits only)",
+            "params": {"efConstruction": 500,"nbits": 8},
+            "expected": success
+        },
+        {
+            "description": "Invalid PQ m (not divisor of dimension)",
+            "params": {"M": 16,"efConstruction": 200,"m": 7, "nbits": 8, "refine": True, "refine_type": "FP32"},
+            "expected": {"err_code": 999, "err_msg": "m"}
+        },
+
+    ]
+
+    search_params = [
+        # ef params test
+        {
+            "description": "Boundary Test - ef equals k",
+            "params": {"ef": 10},
+            "expected": success
+        },
+        {
+            "description": "Minimum Boundary Test",
+            "params": {"ef": 1},
+            "expected": success
+        },
+        {
+            "description": "Large Value Test",
+            "params": {"ef": 10000},
+            "expected": success
+        },
+        {
+            "description": "Out of Range Test - Negative",
+            "params": {"ef": -1},
+            "expected": {"err_code": 65535, "err_msg": "param 'ef' (-1) should be in range [1, 2147483647]"}
+        },
+
+        {
+            "description": "String Type Test, not check data type",
+            "params": {"ef": "32"},
+            "expected": success
+        },
+        {
+            "description": "Float Type Test",
+            "params": {"ef": 32.0},
+            "expected": {"err_code": 65535, "err_msg": "Type conflict in json: param 'ef' (32.0) should be integer"}
+        },
+        {
+            "description": "Boolean Type Test",
+            "params": {"ef": True},
+            "expected": {"err_code": 65535, "err_msg": "Type conflict in json: param 'ef' (true) should be integer"}
+        },
+        {
+            "description": "None Type Test",
+            "params": {"ef": None},
+            "expected": {"err_code": 65535, "err_msg": "Type conflict in json: param 'ef' (null) should be integer"}
+        },
+        {
+            "description": "List Type Test",
+            "params": {"ef": [32]},
+            "expected": {"err_code": 65535, "err_msg": "param 'ef' ([32]) should be integer"}
+        },
+
+        # refine_k params test
+        {
+            "description": "refine_k default boundary",
+            "params": {"refine_k": 1},
+            "expected": success
+        },
+        {
+            "description": "refine_k valid float",
+            "params": {"refine_k": 2.5},
+            "expected": success
+        },
+        {
+            "description": "refine_k out of range",
+            "params": {"refine_k": 0},
+            "expected": {"err_code": 65535, "err_msg": "Out of range in json"}
+        },
+        {
+            "description": "refine_k integer type",
+            "params": {"refine_k": 20},
+            "expected": success
+        },
+        {
+            "description": "String Type Test, not check data type",
+            "params": {"refine_k": "2.5"},
+            "expected": success
+        },
+        {
+            "description": "empty string type",
+            "params": {"refine_k": ""},
+            "expected": {"err_code": 65535, "err_msg": "invalid float value"}
+        },
+        {
+            "description": "refine_k boolean type",
+            "params": {"refine_k": True},
+            "expected": {"err_code": 65535, "err_msg": "Type conflict in json: param 'refine_k' (true) should be a number"}
+        },
+        {
+            "description": "None Type Test",
+            "params": {"refine_k": None},
+            "expected": {"err_code": 65535, "err_msg": "Type conflict in json"}
+        },
+        {
+            "description": "List Type Test",
+            "params": {"refine_k": [15]},
+            "expected": {"err_code": 65535, "err_msg":"Type conflict in json"}
+        },
+
+        # combination params test
+        {
+            "description": "HNSW ef + SQ refine_k combination",
+            "params": {"ef": 64, "refine_k": 2},
+            "expected": success
+        },
+        {
+            "description": "Valid ef with invalid refine_k",
+            "params": {"ef": 64, "refine_k": 0},
+            "expected": {"err_code": 65535, "err_msg":"Out of range in json"}
+        },
+        {
+            "description": "empty dict params",
+            "params": {},
+            "expected": success
+        },
+
+    ]

--- a/tests/python_client/testcases/indexes/test_hnsw_pq.py
+++ b/tests/python_client/testcases/indexes/test_hnsw_pq.py
@@ -5,24 +5,24 @@ from common import common_type as ct
 from common import common_func as cf
 from base.client_v2_base import TestMilvusClientV2Base
 import pytest
-from idx_hnsw_sq import HNSW_SQ
+from idx_hnsw_pq import HNSW_PQ
 
-index_type = "HNSW_SQ"
+index_type = "HNSW_PQ"
 success = "success"
 pk_field_name = 'id'
 vector_field_name = 'vector'
 dim = ct.default_dim
 default_nb = 2000
-default_build_params = {"M": 16, "efConstruction": 200, "sq_type": "SQ8"}
+default_build_params = {"M": 16, "efConstruction": 200, "m": 64, "nbits": 8}
 default_search_params = {"ef": 64, "refine_k": 1}
 
 
-class TestHnswSQBuildParams(TestMilvusClientV2Base):
+class TestHnswPQBuildParams(TestMilvusClientV2Base):
     @pytest.mark.tags(CaseLabel.L1)
-    @pytest.mark.parametrize("params", HNSW_SQ.build_params)
-    def test_hnsw_sq_build_params(self, params):
+    @pytest.mark.parametrize("params", HNSW_PQ.build_params)
+    def test_hnsw_pq_build_params(self, params):
         """
-        Test the build params of HNSW_SQ index
+        Test the build params of HNSW_PQ index
         """
         client = self._client()
         collection_name = cf.gen_collection_name_by_testcase_name()
@@ -82,9 +82,9 @@ class TestHnswSQBuildParams(TestMilvusClientV2Base):
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("vector_data_type", ct.all_vector_types)
-    def test_hnsw_sq_on_all_vector_types(self, vector_data_type):
+    def test_hnsw_pq_on_all_vector_types(self, vector_data_type):
         """
-        Test HNSW_SQ index on all the vector types and metrics
+        Test HNSW_PQ index on all the vector types and metrics
         """
         client = self._client()
         collection_name = cf.gen_collection_name_by_testcase_name()
@@ -113,11 +113,11 @@ class TestHnswSQBuildParams(TestMilvusClientV2Base):
                                metric_type=metric_type,
                                index_type=index_type,
                                params=default_build_params)
-        if vector_data_type not in HNSW_SQ.supported_vector_types:
+        if vector_data_type not in HNSW_PQ.supported_vector_types:
             self.create_index(client, collection_name, index_params,
                               check_task=CheckTasks.err_res,
                               check_items={"err_code": 999,
-                                           "err_msg": f"can't build with this index HNSW_SQ: invalid parameter"})
+                                           "err_msg": f"can't build with this index HNSW_PQ: invalid parameter"})
 
         else:
             self.create_index(client, collection_name, index_params)
@@ -137,10 +137,10 @@ class TestHnswSQBuildParams(TestMilvusClientV2Base):
                                      "pk_name": pk_field_name})
 
     @pytest.mark.tags(CaseLabel.L2)
-    @pytest.mark.parametrize("metric", HNSW_SQ.supported_metrics)
-    def test_hnsw_sq_on_all_metrics(self, metric):
+    @pytest.mark.parametrize("metric", HNSW_PQ.supported_metrics)
+    def test_hnsw_pq_on_all_metrics(self, metric):
         """
-        Test the search params of HNSW_SQ index
+        Test the search params of HNSW_PQ index
         """
         client = self._client()
         collection_name = cf.gen_collection_name_by_testcase_name()
@@ -182,13 +182,13 @@ class TestHnswSQBuildParams(TestMilvusClientV2Base):
                                  "pk_name": pk_field_name})
 
 
-@pytest.mark.xdist_group("TestHnswSQSearchParams")
-class TestHnswSQSearchParams(TestMilvusClientV2Base):
-    """Test search with pagination functionality for HNSW_SQ index"""
+@pytest.mark.xdist_group("TestHnswPQSearchParams")
+class TestHnswPQSearchParams(TestMilvusClientV2Base):
+    """Test search with pagination functionality for HNSW_PQ index"""
 
     def setup_class(self):
         super().setup_class(self)
-        self.collection_name = "TestHnswSQSearchParams" + cf.gen_unique_str("_")
+        self.collection_name = "TestHnswPQSearchParams" + cf.gen_unique_str("_")
         self.float_vector_field_name = vector_field_name
         self.float_vector_dim = dim
         self.primary_keys = []
@@ -206,6 +206,9 @@ class TestHnswSQSearchParams(TestMilvusClientV2Base):
         collection_schema.add_field(self.float_vector_field_name, DataType.FLOAT_VECTOR, dim=128)
         self.create_collection(client, self.collection_name, schema=collection_schema,
                                enable_dynamic_field=self.enable_dynamic_field, force_teardown=False)
+        insert_times = 2
+        float_vectors = cf.gen_vectors(default_nb * insert_times, dim=self.float_vector_dim,
+                                       vector_data_type=DataType.FLOAT_VECTOR)
         all_data = cf.gen_row_data_by_schema(
             nb=default_nb,
             schema=collection_schema,
@@ -214,9 +217,8 @@ class TestHnswSQSearchParams(TestMilvusClientV2Base):
         )
         self.insert(client, self.collection_name, data=all_data)
         self.primary_keys.extend([i for i in range(default_nb)])
-
         self.flush(client, self.collection_name)
-        # Create HNSW_SQ index
+        # Create HNSW_PQ index
         index_params = self.prepare_index_params(client)[0]
         index_params.add_index(field_name=self.float_vector_field_name,
                                metric_type="COSINE",
@@ -231,10 +233,10 @@ class TestHnswSQSearchParams(TestMilvusClientV2Base):
         request.addfinalizer(teardown)
 
     @pytest.mark.tags(CaseLabel.L1)
-    @pytest.mark.parametrize("params", HNSW_SQ.search_params)
-    def test_hnsw_sq_search_params(self, params):
+    @pytest.mark.parametrize("params", HNSW_PQ.search_params)
+    def test_hnsw_pq_search_params(self, params):
         """
-        Test the search params of HNSW_SQ index
+        Test the search params of HNSW_PQ index
         """
         client = self._client()
         collection_name = self.collection_name


### PR DESCRIPTION
/kind improvement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Pull Request Summary

**Core Invariant**: This PR assumes single-batch, deterministic data generation (`random_pk=False`) is sufficient to validate HNSW index behavior; multi-batch insertion patterns are not required for parameter/vector-type/metric validation.

**New Feature Added**: HNSW_PQ index test suite with comprehensive coverage:
- `idx_hnsw_pq.py` defines 50+ parameter test cases covering build parameters (M, efConstruction, m, nbits, refine, refine_type) and search parameters (ef), including boundary conditions, type validation, and error cases
- `test_hnsw_pq.py` implements TestHnswPQBuildParams and TestHnswPQSearchParams classes exercising index creation, parameter persistence verification, and search validation across 4 supported vector types (FLOAT_VECTOR, FLOAT16_VECTOR, BFLOAT16_VECTOR, INT8_VECTOR) and 3 metrics (L2, IP, COSINE)

**Refactoring in HNSW_SQ Tests**: Simplified data insertion logic by consolidating multi-batch inserts into single bulk insert:
- Replaced per-batch creation loops with one call to `cf.gen_row_data_by_schema(nb=default_nb, start=0, random_pk=False)`, removing redundant per-batch primary-key generation logic that did not test batch-handling behavior
- Applied uniformly across test_hnsw_sq_build_params, test_hnsw_sq_on_all_vector_types, test_hnsw_sq_on_all_metrics, and prepare_collection fixture

**No Behavior Regression**: Single-batch insertion still exercises the complete index lifecycle—creation, loading, and search—with identical data volume (2000 rows). Parameter persistence is verified via `describe_index()` checks, and search results are validated through existing result-verification assertions. The refactor removes only insertion pattern complexity that was not testing index functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->