### PR TITLE
fix: rename CColumnGroups to CColumnSplits and bump milvus-storage version

### DIFF
--- a/internal/core/src/segcore/ColumnGroupsCTest.cpp
+++ b/internal/core/src/segcore/ColumnGroupsCTest.cpp
@@ -19,8 +19,8 @@
 #include <cstring>
 #include "segcore/column_groups_c.h"
 
-TEST(CColumnGroups, TestCColumnGroups) {
-    CColumnGroups cgs = NewCColumnGroups();
+TEST(CColumnSplits, TestCColumnSplits) {
+    CColumnSplits cgs = NewCColumnSplits();
     int group1[] = {2, 4, 5};
     int group2[] = {0, 1};
     int group3[] = {3, 6, 7, 8};
@@ -29,10 +29,10 @@ TEST(CColumnGroups, TestCColumnGroups) {
     int group_sizes[] = {3, 2, 4};
 
     for (int i = 0; i < 3; i++) {
-        AddCColumnGroup(cgs, test_groups[i], group_sizes[i]);
+        AddCColumnSplit(cgs, test_groups[i], group_sizes[i]);
     }
 
-    ASSERT_EQ(CColumnGroupsSize(cgs), 3);
+    ASSERT_EQ(CColumnSplitsSize(cgs), 3);
     auto vv = static_cast<std::vector<std::vector<int>>*>(cgs);
 
     for (int i = 0; i < 3; i++) {
@@ -42,5 +42,5 @@ TEST(CColumnGroups, TestCColumnGroups) {
         }
     }
 
-    FreeCColumnGroups(cgs);
+    FreeCColumnSplits(cgs);
 }

--- a/internal/core/src/segcore/PackedReaderWriterTest.cpp
+++ b/internal/core/src/segcore/PackedReaderWriterTest.cpp
@@ -60,9 +60,9 @@ TEST(CPackedTest, PackedWriterAndReader) {
     char* paths[] = {const_cast<char*>("/tmp/0")};
     int64_t part_upload_size = 0;
 
-    CColumnGroups cgs = NewCColumnGroups();
+    CColumnSplits cgs = NewCColumnSplits();
     int group[] = {0};
-    AddCColumnGroup(cgs, group, 1);
+    AddCColumnSplit(cgs, group, 1);
 
     auto c_status = InitLocalArrowFileSystemSingleton(path);
     EXPECT_EQ(c_status.error_code, 0);
@@ -102,5 +102,5 @@ TEST(CPackedTest, PackedWriterAndReader) {
 
     c_status = CloseReader(c_packed_reader);
     EXPECT_EQ(c_status.error_code, 0);
-    FreeCColumnGroups(cgs);
+    FreeCColumnSplits(cgs);
 }

--- a/internal/core/src/segcore/column_groups_c.cpp
+++ b/internal/core/src/segcore/column_groups_c.cpp
@@ -23,8 +23,8 @@ using VecVecInt = std::vector<std::vector<int>>;
 
 extern "C" {
 
-CColumnGroups
-NewCColumnGroups() {
+CColumnSplits
+NewCColumnSplits() {
     SCOPE_CGO_CALL_METRIC();
 
     auto vv = std::make_unique<VecVecInt>();
@@ -32,7 +32,7 @@ NewCColumnGroups() {
 }
 
 void
-AddCColumnGroup(CColumnGroups cgs, int* group, int group_size) {
+AddCColumnSplit(CColumnSplits cgs, int* group, int group_size) {
     SCOPE_CGO_CALL_METRIC();
 
     if (!cgs || !group)
@@ -44,7 +44,7 @@ AddCColumnGroup(CColumnGroups cgs, int* group, int group_size) {
 }
 
 int
-CColumnGroupsSize(CColumnGroups cgs) {
+CColumnSplitsSize(CColumnSplits cgs) {
     SCOPE_CGO_CALL_METRIC();
 
     if (!cgs)
@@ -55,7 +55,7 @@ CColumnGroupsSize(CColumnGroups cgs) {
 }
 
 void
-FreeCColumnGroups(CColumnGroups cgs) {
+FreeCColumnSplits(CColumnSplits cgs) {
     SCOPE_CGO_CALL_METRIC();
 
     delete static_cast<VecVecInt*>(cgs);

--- a/internal/core/src/segcore/column_groups_c.h
+++ b/internal/core/src/segcore/column_groups_c.h
@@ -20,19 +20,18 @@
 extern "C" {
 #endif
 
-typedef void* CColumnGroups;
-
-CColumnGroups
-NewCColumnGroups();
+typedef void* CColumnSplits;
+CColumnSplits
+NewCColumnSplits();
 
 void
-AddCColumnGroup(CColumnGroups cgs, int* group, int group_size);
+AddCColumnSplit(CColumnSplits cgs, int* group, int group_size);
 
 int
-CColumnGroupsSize(CColumnGroups cgs);
+CColumnSplitsSize(CColumnSplits cgs);
 
 void
-FreeCColumnGroups(CColumnGroups cgs);
+FreeCColumnSplits(CColumnSplits cgs);
 
 #ifdef __cplusplus
 }

--- a/internal/core/src/segcore/packed_writer_c.cpp
+++ b/internal/core/src/segcore/packed_writer_c.cpp
@@ -41,7 +41,7 @@ NewPackedWriterWithStorageConfig(struct ArrowSchema* schema,
                                  char** paths,
                                  int64_t num_paths,
                                  int64_t part_upload_size,
-                                 CColumnGroups column_groups,
+                                 CColumnSplits column_splits,
                                  CStorageConfig c_storage_config,
                                  CPackedWriter* c_packed_writer,
                                  CPluginContext* c_plugin_context) {
@@ -83,7 +83,7 @@ NewPackedWriterWithStorageConfig(struct ArrowSchema* schema,
         auto trueSchema = arrow::ImportSchema(schema).ValueOrDie();
 
         auto columnGroups =
-            *static_cast<std::vector<std::vector<int>>*>(column_groups);
+            *static_cast<std::vector<std::vector<int>>*>(column_splits);
 
         parquet::WriterProperties::Builder builder;
         auto plugin_ptr =
@@ -135,7 +135,7 @@ NewPackedWriter(struct ArrowSchema* schema,
                 char** paths,
                 int64_t num_paths,
                 int64_t part_upload_size,
-                CColumnGroups column_groups,
+                CColumnSplits column_splits,
                 CPackedWriter* c_packed_writer,
                 CPluginContext* c_plugin_context) {
     SCOPE_CGO_CALL_METRIC();
@@ -157,7 +157,7 @@ NewPackedWriter(struct ArrowSchema* schema,
         auto trueSchema = arrow::ImportSchema(schema).ValueOrDie();
 
         auto columnGroups =
-            *static_cast<std::vector<std::vector<int>>*>(column_groups);
+            *static_cast<std::vector<std::vector<int>>*>(column_splits);
 
         parquet::WriterProperties::Builder builder;
         auto plugin_ptr =

--- a/internal/core/src/segcore/packed_writer_c.h
+++ b/internal/core/src/segcore/packed_writer_c.h
@@ -31,7 +31,7 @@ NewPackedWriterWithStorageConfig(struct ArrowSchema* schema,
                                  char** paths,
                                  int64_t num_paths,
                                  int64_t part_upload_size,
-                                 CColumnGroups column_groups,
+                                 CColumnSplits column_splits,
                                  CStorageConfig c_storage_config,
                                  CPackedWriter* c_packed_writer,
                                  CPluginContext* c_plugin_context);
@@ -42,7 +42,7 @@ NewPackedWriter(struct ArrowSchema* schema,
                 char** paths,
                 int64_t num_paths,
                 int64_t part_upload_size,
-                CColumnGroups column_groups,
+                CColumnSplits column_splits,
                 CPackedWriter* c_packed_writer,
                 CPluginContext* c_plugin_context);
 

--- a/internal/core/thirdparty/milvus-storage/CMakeLists.txt
+++ b/internal/core/thirdparty/milvus-storage/CMakeLists.txt
@@ -14,7 +14,7 @@
 # Update milvus-storage_VERSION for the first occurrence
 milvus_add_pkg_config("milvus-storage")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( milvus-storage_VERSION 839a8e5)
+set( milvus-storage_VERSION ba7fe82)
 set( GIT_REPOSITORY  "https://github.com/milvus-io/milvus-storage.git")
 message(STATUS "milvus-storage repo: ${GIT_REPOSITORY}")
 message(STATUS "milvus-storage version: ${milvus-storage_VERSION}")

--- a/internal/storagev2/packed/packed_reader_ffi.go
+++ b/internal/storagev2/packed/packed_reader_ffi.go
@@ -177,9 +177,6 @@ func (r *FFIPackedReader) Schema() *arrow.Schema {
 
 // Retain increases the reference count
 func (r *FFIPackedReader) Retain() {
-	// if r.recordReader != nil {
-	// r.recordReader.Retain()
-	// }
 }
 
 // Release decreases the reference count

--- a/internal/storagev2/packed/packed_reader_ffi_test.go
+++ b/internal/storagev2/packed/packed_reader_ffi_test.go
@@ -9,13 +9,14 @@ import (
 	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/apache/arrow/go/v17/arrow/array"
 	"github.com/apache/arrow/go/v17/arrow/memory"
-	"github.com/magiconair/properties/assert"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/rand"
+
 	"github.com/milvus-io/milvus/internal/storagecommon"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
-	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/rand"
 )
 
 func TestPackedFFIReader(t *testing.T) {

--- a/internal/storagev2/packed/packed_reader_ffi_test.go
+++ b/internal/storagev2/packed/packed_reader_ffi_test.go
@@ -1,0 +1,409 @@
+package packed
+
+import (
+	"fmt"
+	"io"
+	"math"
+	"testing"
+
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/array"
+	"github.com/apache/arrow/go/v17/arrow/memory"
+	"github.com/magiconair/properties/assert"
+	"github.com/milvus-io/milvus/internal/storagecommon"
+	"github.com/milvus-io/milvus/pkg/v2/common"
+	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/rand"
+)
+
+func TestPackedFFIReader(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	pt.Save(pt.CommonCfg.StorageType.Key, "local")
+	dir := t.TempDir()
+	t.Log("Case temp dir: ", dir)
+	pt.Save(pt.LocalStorageCfg.Path.Key, dir)
+
+	t.Cleanup(func() {
+		pt.Reset(pt.CommonCfg.StorageType.Key)
+		pt.Reset(pt.LocalStorageCfg.Path.Key)
+	})
+
+	const (
+		numRows = 1000
+		dim     = 128
+	)
+
+	// Create schema: int64 primary key + 128-dim float vector
+	schema := arrow.NewSchema([]arrow.Field{
+		{
+			Name:     "pk",
+			Type:     arrow.PrimitiveTypes.Int64,
+			Nullable: false,
+			Metadata: arrow.NewMetadata([]string{ArrowFieldIdMetadataKey}, []string{"100"}),
+		},
+		{
+			Name:     "vector",
+			Type:     &arrow.FixedSizeBinaryType{ByteWidth: dim * 4}, // float32 = 4 bytes
+			Nullable: false,
+			Metadata: arrow.NewMetadata([]string{ArrowFieldIdMetadataKey}, []string{"101"}),
+		},
+	}, nil)
+
+	basePath := "files/packed_reader_test/1"
+	version := int64(0)
+
+	// Build record batch
+	b := array.NewRecordBuilder(memory.DefaultAllocator, schema)
+	defer b.Release()
+
+	pkBuilder := b.Field(0).(*array.Int64Builder)
+	vectorBuilder := b.Field(1).(*array.FixedSizeBinaryBuilder)
+
+	// Store expected values for verification
+	expectedPks := make([]int64, numRows)
+	expectedVectors := make([][]byte, numRows)
+
+	for i := 0; i < numRows; i++ {
+		// Append primary key
+		expectedPks[i] = int64(i)
+		pkBuilder.Append(expectedPks[i])
+
+		// Generate random float vector and convert to bytes
+		vectorBytes := make([]byte, dim*4)
+		for j := 0; j < dim; j++ {
+			floatVal := rand.Float32()
+			bits := math.Float32bits(floatVal)
+			common.Endian.PutUint32(vectorBytes[j*4:], bits)
+		}
+		expectedVectors[i] = vectorBytes
+		vectorBuilder.Append(vectorBytes)
+	}
+
+	rec := b.NewRecord()
+	defer rec.Release()
+
+	require.Equal(t, int64(numRows), rec.NumRows())
+
+	// Define column groups
+	columnGroups := []storagecommon.ColumnGroup{
+		{Columns: []int{0, 1}, GroupID: storagecommon.DefaultShortColumnGroupID},
+	}
+
+	// Create FFI packed writer and write data
+	pw, err := NewFFIPackedWriter(basePath, version, schema, columnGroups, nil, nil)
+	require.NoError(t, err)
+
+	err = pw.WriteRecordBatch(rec)
+	require.NoError(t, err)
+
+	manifest, err := pw.Close()
+	require.NoError(t, err)
+	require.NotEmpty(t, manifest)
+
+	t.Logf("Successfully wrote %d rows with %d-dim float vectors, manifest: %s", numRows, dim, manifest)
+
+	// Create storage config for reader
+	storageConfig := &indexpb.StorageConfig{
+		RootPath:    dir,
+		StorageType: "local",
+	}
+
+	// Create FFI packed reader
+	neededColumns := []string{"pk", "vector"}
+	reader, err := NewFFIPackedReader(manifest, schema, neededColumns, 8196, storageConfig, nil)
+	require.NoError(t, err)
+	require.NotNil(t, reader)
+
+	// Verify schema
+	assert.Equal(t, schema, reader.Schema())
+
+	// Read all records and verify data
+	totalRowsRead := int64(0)
+	for {
+		record, err := reader.ReadNext()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		require.NotNil(t, record)
+
+		// Verify column count
+		assert.Equal(t, int64(2), record.NumCols())
+
+		// Verify pk column
+		pkCol := record.Column(0).(*array.Int64)
+		for i := 0; i < pkCol.Len(); i++ {
+			expectedIdx := int(totalRowsRead) + i
+			assert.Equal(t, expectedPks[expectedIdx], pkCol.Value(i), fmt.Sprintf("pk mismatch at row %d", expectedIdx))
+		}
+
+		// Verify vector column
+		vectorCol := record.Column(1).(*array.FixedSizeBinary)
+		for i := 0; i < vectorCol.Len(); i++ {
+			expectedIdx := int(totalRowsRead) + i
+			assert.Equal(t, expectedVectors[expectedIdx], vectorCol.Value(i), fmt.Sprintf("vector mismatch at row %d", expectedIdx))
+		}
+
+		totalRowsRead += record.NumRows()
+	}
+
+	// Verify total rows read
+	assert.Equal(t, int64(numRows), totalRowsRead)
+
+	t.Logf("Successfully read %d rows", totalRowsRead)
+
+	// Close reader
+	err = reader.Close()
+	require.NoError(t, err)
+}
+
+func TestPackedFFIReaderPartialColumns(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	pt.Save(pt.CommonCfg.StorageType.Key, "local")
+	dir := t.TempDir()
+	pt.Save(pt.LocalStorageCfg.Path.Key, dir)
+
+	t.Cleanup(func() {
+		pt.Reset(pt.CommonCfg.StorageType.Key)
+		pt.Reset(pt.LocalStorageCfg.Path.Key)
+	})
+
+	const (
+		numRows = 500
+		dim     = 64
+	)
+
+	// Create schema with 3 columns
+	schema := arrow.NewSchema([]arrow.Field{
+		{
+			Name:     "pk",
+			Type:     arrow.PrimitiveTypes.Int64,
+			Nullable: false,
+			Metadata: arrow.NewMetadata([]string{ArrowFieldIdMetadataKey}, []string{"100"}),
+		},
+		{
+			Name:     "score",
+			Type:     arrow.PrimitiveTypes.Float64,
+			Nullable: false,
+			Metadata: arrow.NewMetadata([]string{ArrowFieldIdMetadataKey}, []string{"101"}),
+		},
+		{
+			Name:     "vector",
+			Type:     &arrow.FixedSizeBinaryType{ByteWidth: dim * 4},
+			Nullable: false,
+			Metadata: arrow.NewMetadata([]string{ArrowFieldIdMetadataKey}, []string{"102"}),
+		},
+	}, nil)
+
+	basePath := "files/packed_reader_partial_test/1"
+	version := int64(0)
+
+	// Build record batch
+	b := array.NewRecordBuilder(memory.DefaultAllocator, schema)
+	defer b.Release()
+
+	pkBuilder := b.Field(0).(*array.Int64Builder)
+	scoreBuilder := b.Field(1).(*array.Float64Builder)
+	vectorBuilder := b.Field(2).(*array.FixedSizeBinaryBuilder)
+
+	expectedPks := make([]int64, numRows)
+	expectedScores := make([]float64, numRows)
+
+	for i := 0; i < numRows; i++ {
+		expectedPks[i] = int64(i)
+		pkBuilder.Append(expectedPks[i])
+
+		expectedScores[i] = rand.Float64() * 100
+		scoreBuilder.Append(expectedScores[i])
+
+		vectorBytes := make([]byte, dim*4)
+		for j := 0; j < dim; j++ {
+			floatVal := rand.Float32()
+			bits := math.Float32bits(floatVal)
+			common.Endian.PutUint32(vectorBytes[j*4:], bits)
+		}
+		vectorBuilder.Append(vectorBytes)
+	}
+
+	rec := b.NewRecord()
+	defer rec.Release()
+
+	// Define column groups
+	columnGroups := []storagecommon.ColumnGroup{
+		{Columns: []int{0, 1, 2}, GroupID: storagecommon.DefaultShortColumnGroupID},
+	}
+
+	// Write data
+	pw, err := NewFFIPackedWriter(basePath, version, schema, columnGroups, nil, nil)
+	require.NoError(t, err)
+
+	err = pw.WriteRecordBatch(rec)
+	require.NoError(t, err)
+
+	manifest, err := pw.Close()
+	require.NoError(t, err)
+
+	// Create storage config
+	storageConfig := &indexpb.StorageConfig{
+		RootPath:    dir,
+		StorageType: "local",
+	}
+
+	// Read only pk and score columns (skip vector)
+	neededColumns := []string{"pk", "score"}
+	partialSchema := arrow.NewSchema([]arrow.Field{
+		schema.Field(0),
+		schema.Field(1),
+	}, nil)
+
+	reader, err := NewFFIPackedReader(manifest, partialSchema, neededColumns, 8196, storageConfig, nil)
+	require.NoError(t, err)
+	require.NotNil(t, reader)
+
+	totalRowsRead := int64(0)
+	for {
+		record, err := reader.ReadNext()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+
+		// Verify only 2 columns are returned
+		assert.Equal(t, int64(2), record.NumCols())
+
+		// Verify pk column
+		pkCol := record.Column(0).(*array.Int64)
+		for i := 0; i < pkCol.Len(); i++ {
+			expectedIdx := int(totalRowsRead) + i
+			assert.Equal(t, expectedPks[expectedIdx], pkCol.Value(i))
+		}
+
+		// Verify score column
+		scoreCol := record.Column(1).(*array.Float64)
+		for i := 0; i < scoreCol.Len(); i++ {
+			expectedIdx := int(totalRowsRead) + i
+			assert.Equal(t, expectedScores[expectedIdx], scoreCol.Value(i))
+		}
+
+		totalRowsRead += record.NumRows()
+	}
+
+	assert.Equal(t, int64(numRows), totalRowsRead)
+	t.Logf("Successfully read %d rows with partial columns", totalRowsRead)
+
+	err = reader.Close()
+	require.NoError(t, err)
+}
+
+func TestPackedFFIReaderMultipleBatches(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	pt.Save(pt.CommonCfg.StorageType.Key, "local")
+	dir := t.TempDir()
+	pt.Save(pt.LocalStorageCfg.Path.Key, dir)
+
+	t.Cleanup(func() {
+		pt.Reset(pt.CommonCfg.StorageType.Key)
+		pt.Reset(pt.LocalStorageCfg.Path.Key)
+	})
+
+	const (
+		numRows   = 500
+		dim       = 64
+		numWrites = 3
+	)
+
+	schema := arrow.NewSchema([]arrow.Field{
+		{
+			Name:     "pk",
+			Type:     arrow.PrimitiveTypes.Int64,
+			Nullable: false,
+			Metadata: arrow.NewMetadata([]string{ArrowFieldIdMetadataKey}, []string{"100"}),
+		},
+		{
+			Name:     "vector",
+			Type:     &arrow.FixedSizeBinaryType{ByteWidth: dim * 4},
+			Nullable: false,
+			Metadata: arrow.NewMetadata([]string{ArrowFieldIdMetadataKey}, []string{"101"}),
+		},
+	}, nil)
+
+	basePath := "files/packed_reader_multi_batch_test/1"
+	version := int64(0)
+
+	columnGroups := []storagecommon.ColumnGroup{
+		{Columns: []int{0, 1}, GroupID: storagecommon.DefaultShortColumnGroupID},
+	}
+
+	var manifest string
+	totalWrittenRows := 0
+
+	// Write multiple batches
+	for batch := 0; batch < numWrites; batch++ {
+		b := array.NewRecordBuilder(memory.DefaultAllocator, schema)
+
+		pkBuilder := b.Field(0).(*array.Int64Builder)
+		vectorBuilder := b.Field(1).(*array.FixedSizeBinaryBuilder)
+
+		for i := 0; i < numRows; i++ {
+			pkBuilder.Append(int64(totalWrittenRows + i))
+
+			vectorBytes := make([]byte, dim*4)
+			for j := 0; j < dim; j++ {
+				floatVal := rand.Float32()
+				bits := math.Float32bits(floatVal)
+				common.Endian.PutUint32(vectorBytes[j*4:], bits)
+			}
+			vectorBuilder.Append(vectorBytes)
+		}
+
+		rec := b.NewRecord()
+
+		pw, err := NewFFIPackedWriter(basePath, version, schema, columnGroups, nil, nil)
+		require.NoError(t, err)
+
+		err = pw.WriteRecordBatch(rec)
+		require.NoError(t, err)
+
+		manifest, err = pw.Close()
+		require.NoError(t, err)
+
+		_, version, err = UnmarshalManfestPath(manifest)
+		require.NoError(t, err)
+
+		totalWrittenRows += numRows
+
+		b.Release()
+		rec.Release()
+	}
+
+	// Read all data
+	storageConfig := &indexpb.StorageConfig{
+		RootPath:    dir,
+		StorageType: "local",
+	}
+
+	neededColumns := []string{"pk", "vector"}
+	reader, err := NewFFIPackedReader(manifest, schema, neededColumns, 8196, storageConfig, nil)
+	require.NoError(t, err)
+
+	totalRowsRead := int64(0)
+	for {
+		record, err := reader.ReadNext()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		totalRowsRead += record.NumRows()
+	}
+
+	assert.Equal(t, int64(totalWrittenRows), totalRowsRead)
+	t.Logf("Successfully read %d rows from %d batches", totalRowsRead, numWrites)
+
+	err = reader.Close()
+	require.NoError(t, err)
+}

--- a/internal/storagev2/packed/packed_reader_ffi_test.go
+++ b/internal/storagev2/packed/packed_reader_ffi_test.go
@@ -114,7 +114,7 @@ func TestPackedFFIReader(t *testing.T) {
 
 	// Create FFI packed reader
 	neededColumns := []string{"pk", "vector"}
-	reader, err := NewFFIPackedReader(manifest, schema, neededColumns, 8196, storageConfig, nil)
+	reader, err := NewFFIPackedReader(manifest, schema, neededColumns, 8192, storageConfig, nil)
 	require.NoError(t, err)
 	require.NotNil(t, reader)
 
@@ -261,7 +261,7 @@ func TestPackedFFIReaderPartialColumns(t *testing.T) {
 		schema.Field(1),
 	}, nil)
 
-	reader, err := NewFFIPackedReader(manifest, partialSchema, neededColumns, 8196, storageConfig, nil)
+	reader, err := NewFFIPackedReader(manifest, partialSchema, neededColumns, 8192, storageConfig, nil)
 	require.NoError(t, err)
 	require.NotNil(t, reader)
 
@@ -389,7 +389,7 @@ func TestPackedFFIReaderMultipleBatches(t *testing.T) {
 	}
 
 	neededColumns := []string{"pk", "vector"}
-	reader, err := NewFFIPackedReader(manifest, schema, neededColumns, 8196, storageConfig, nil)
+	reader, err := NewFFIPackedReader(manifest, schema, neededColumns, 8192, storageConfig, nil)
 	require.NoError(t, err)
 
 	totalRowsRead := int64(0)

--- a/internal/storagev2/packed/packed_writer.go
+++ b/internal/storagev2/packed/packed_writer.go
@@ -55,7 +55,7 @@ func NewPackedWriter(filePaths []string, schema *arrow.Schema, bufferSize int64,
 
 	cMultiPartUploadSize := C.int64_t(multiPartUploadSize)
 
-	cColumnGroups := C.NewCColumnGroups()
+	cColumnSplits := C.NewCColumnSplits()
 	for _, group := range columnGroups {
 		cGroup := C.malloc(C.size_t(len(group.Columns)) * C.size_t(unsafe.Sizeof(C.int(0))))
 		if cGroup == nil {
@@ -65,7 +65,7 @@ func NewPackedWriter(filePaths []string, schema *arrow.Schema, bufferSize int64,
 		for i, val := range group.Columns {
 			cGroupSlice[i] = C.int(val)
 		}
-		C.AddCColumnGroup(cColumnGroups, (*C.int)(cGroup), C.int(len(group.Columns)))
+		C.AddCColumnSplit(cColumnSplits, (*C.int)(cGroup), C.int(len(group.Columns)))
 		C.free(cGroup)
 	}
 
@@ -117,9 +117,9 @@ func NewPackedWriter(filePaths []string, schema *arrow.Schema, bufferSize int64,
 		defer C.free(unsafe.Pointer(cStorageConfig.sslCACert))
 		defer C.free(unsafe.Pointer(cStorageConfig.region))
 		defer C.free(unsafe.Pointer(cStorageConfig.gcp_credential_json))
-		status = C.NewPackedWriterWithStorageConfig(cSchema, cBufferSize, cFilePathsArray, cNumPaths, cMultiPartUploadSize, cColumnGroups, cStorageConfig, &cPackedWriter, pluginContextPtr)
+		status = C.NewPackedWriterWithStorageConfig(cSchema, cBufferSize, cFilePathsArray, cNumPaths, cMultiPartUploadSize, cColumnSplits, cStorageConfig, &cPackedWriter, pluginContextPtr)
 	} else {
-		status = C.NewPackedWriter(cSchema, cBufferSize, cFilePathsArray, cNumPaths, cMultiPartUploadSize, cColumnGroups, &cPackedWriter, pluginContextPtr)
+		status = C.NewPackedWriter(cSchema, cBufferSize, cFilePathsArray, cNumPaths, cMultiPartUploadSize, cColumnSplits, &cPackedWriter, pluginContextPtr)
 	}
 	if err := ConsumeCStatusIntoError(&status); err != nil {
 		return nil, err

--- a/internal/storagev2/packed/packed_writer_ffi_test.go
+++ b/internal/storagev2/packed/packed_writer_ffi_test.go
@@ -1,0 +1,116 @@
+package packed
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/array"
+	"github.com/apache/arrow/go/v17/arrow/memory"
+	"github.com/magiconair/properties/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus/internal/storagecommon"
+	"github.com/milvus-io/milvus/pkg/v2/common"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+)
+
+func TestPackedFFIWriter(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	pt.Save(pt.CommonCfg.StorageType.Key, "local")
+	dir := t.TempDir()
+	t.Log("Case temp dir: ", dir)
+	pt.Save(pt.LocalStorageCfg.Path.Key, dir)
+
+	t.Cleanup(func() {
+		pt.Reset(pt.CommonCfg.StorageType.Key)
+		pt.Reset(pt.LocalStorageCfg.Path.Key)
+	})
+
+	const (
+		numRows = 5000
+		dim     = 768
+		batch   = 10
+	)
+
+	// Create schema: int64 primary key + 768-dim float vector
+	schema := arrow.NewSchema([]arrow.Field{
+		{
+			Name:     "pk",
+			Type:     arrow.PrimitiveTypes.Int64,
+			Nullable: false,
+			Metadata: arrow.NewMetadata([]string{ArrowFieldIdMetadataKey}, []string{"100"}),
+		},
+		{
+			Name:     "vector",
+			Type:     &arrow.FixedSizeBinaryType{ByteWidth: dim * 4}, // float32 = 4 bytes
+			Nullable: false,
+			Metadata: arrow.NewMetadata([]string{ArrowFieldIdMetadataKey}, []string{"101"}),
+		},
+	}, nil)
+
+	basePath := "files/packed_writer_test/1"
+	version := int64(0)
+
+	for i := 0; i < batch; i++ {
+		// Build record batch with 5000 rows
+		b := array.NewRecordBuilder(memory.DefaultAllocator, schema)
+		defer b.Release()
+
+		pkBuilder := b.Field(0).(*array.Int64Builder)
+		vectorBuilder := b.Field(1).(*array.FixedSizeBinaryBuilder)
+
+		for i := 0; i < numRows; i++ {
+			// Append primary key
+			pkBuilder.Append(int64(i))
+
+			// Generate random float vector and convert to bytes
+			vectorBytes := make([]byte, dim*4)
+			for j := 0; j < dim; j++ {
+				floatVal := rand.Float32()
+				bits := math.Float32bits(floatVal)
+				common.Endian.PutUint32(vectorBytes[j*4:], bits)
+			}
+			vectorBuilder.Append(vectorBytes)
+		}
+
+		rec := b.NewRecord()
+		defer rec.Release()
+
+		require.Equal(t, int64(numRows), rec.NumRows())
+
+		// // Setup storage config for local filesystem
+		// storageConfig := &indexpb.StorageConfig{
+		// 	RootPath:    dir,
+		// 	StorageType: "local",
+		// }
+
+		// Define column groups: pk and vector in the same group
+		columnGroups := []storagecommon.ColumnGroup{
+			{Columns: []int{0, 1}, GroupID: storagecommon.DefaultShortColumnGroupID},
+		}
+
+		// Create FFI packed writer
+		pw, err := NewFFIPackedWriter(basePath, version, schema, columnGroups, nil, nil)
+		require.NoError(t, err)
+
+		// Write record batch
+		err = pw.WriteRecordBatch(rec)
+		require.NoError(t, err)
+
+		// Close writer and get manifest
+		manifest, err := pw.Close()
+		require.NoError(t, err)
+		require.NotEmpty(t, manifest)
+
+		p, pv, err := UnmarshalManfestPath(manifest)
+		require.NoError(t, err)
+		assert.Equal(t, p, basePath)
+		assert.Equal(t, pv, version+1)
+		version = pv
+
+		t.Logf("Successfully wrote %d rows with %d-dim float vectors, manifest: %s", numRows, dim, manifest)
+	}
+}


### PR DESCRIPTION
Related to #46617

- Rename CColumnGroups/CColumnGroups to CColumnSplits to resolve naming conflict with milvus-storage library's ColumnGroups type
- Update milvus-storage from 839a8e5 to ba7fe82 which includes the fix for local filesystem not following root path configuration
- Add unit tests for FFI packed reader and writer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Core invariant: this PR is a pure FFI surface rename and dependency bump — all C FFI symbols and typedefs for CColumnGroups are renamed to CColumnSplits across headers, implementations and Go call sites, and the embedded milvus-storage submodule/GIT_TAG is bumped from 839a8e5 → ba7fe82 to pick up a local-filesystem root-path fix. The data layout, ownership model and binary interfaces (pointer/value semantics) are preserved.

- Logic removed/simplified: FFIPackedReader.Retain() is simplified to a no-op (previously forwarded to recordReader.Retain when non-nil). This removes redundant lifecycle forwarding because the FFI reader does not own the underlying record reader; ownership and lifetime remain with the caller/parent.

- Why this does NOT cause data loss or regressions: the change is limited to identifier/type renames (NewCColumnGroups → NewCColumnSplits, AddCColumnGroup → AddCColumnSplit, CColumnGroupsSize → CColumnSplitsSize, FreeCColumnGroups → FreeCColumnSplits) and corresponding call-site updates. Internals still static_cast the same pointer to std::vector<std::vector<int>>* and perform the same allocations, writes and reads; packed writer paths, manifest formats, and Arrow data handling are unchanged. The milvus-storage bump fixes filesystem root-path handling (not data format), and the added unit tests exercise writer→manifest→reader round-trips (full/partial/multi-batch) to validate no serialization/deserialization regressions.

- Bug fix and verification: this PR resolves the naming conflict and pulls in the milvus-storage commit that fixes the local filesystem root-path issue referenced by #46617. The new FFI unit tests (packed writer and packed reader: full, partial columns, and multiple batches) provide concrete end-to-end verification of writer→manifest→reader behavior and confirm the rename and storage bump are safe.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->