### PR TITLE
fix: correct typo CredentialSeperator to CredentialSeparator

### DIFF
--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -83,7 +83,7 @@ func ParseUsernamePassword(c *gin.Context) (string, string, bool) {
 	username, password, ok := c.Request.BasicAuth()
 	if !ok {
 		token := GetAuthorization(c)
-		i := strings.IndexAny(token, util.CredentialSeperator)
+		i := strings.IndexAny(token, util.CredentialSeparator)
 		if i != -1 {
 			username = token[:i]
 			password = token[i+1:]

--- a/internal/distributed/proxy/service.go
+++ b/internal/distributed/proxy/service.go
@@ -130,12 +130,12 @@ func authenticate(c *gin.Context) {
 		if proxy.PasswordVerify(c, username, password) {
 			log.Ctx(context.TODO()).Debug("auth successful", zap.String("username", username))
 			c.Set(httpserver.ContextUsername, username)
-			c.Set(httpserver.ContextToken, fmt.Sprintf("%s%s%s", username, util.CredentialSeperator, password))
+			c.Set(httpserver.ContextToken, fmt.Sprintf("%s%s%s", username, util.CredentialSeparator, password))
 			return
 		}
 	}
 	rawToken := httpserver.GetAuthorization(c)
-	if rawToken != "" && !strings.Contains(rawToken, util.CredentialSeperator) {
+	if rawToken != "" && !strings.Contains(rawToken, util.CredentialSeparator) {
 		user, err := proxy.VerifyAPIKey(rawToken)
 		if err == nil {
 			c.Set(httpserver.ContextUsername, user)

--- a/internal/proxy/accesslog/info/util.go
+++ b/internal/proxy/accesslog/info/util.go
@@ -49,7 +49,7 @@ func getCurUserFromContext(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("fail to decode the token, token: %s", token)
 	}
-	secrets := strings.SplitN(rawToken, util.CredentialSeperator, 2)
+	secrets := strings.SplitN(rawToken, util.CredentialSeparator, 2)
 	if len(secrets) < 2 {
 		return "", fmt.Errorf("fail to get user info from the raw token, raw token: %s", rawToken)
 	}

--- a/internal/proxy/authentication_interceptor.go
+++ b/internal/proxy/authentication_interceptor.go
@@ -23,7 +23,7 @@ import (
 )
 
 func parseMD(rawToken string) (username, password string) {
-	secrets := strings.SplitN(rawToken, util.CredentialSeperator, 2)
+	secrets := strings.SplitN(rawToken, util.CredentialSeparator, 2)
 	if len(secrets) < 2 {
 		log.Warn("invalid token format, length of secrets less than 2")
 		return
@@ -81,14 +81,14 @@ func AuthenticationInterceptor(ctx context.Context) (context.Context, error) {
 			return nil, status.Error(codes.Unauthenticated, "invalid token format")
 		}
 
-		if !strings.Contains(rawToken, util.CredentialSeperator) {
+		if !strings.Contains(rawToken, util.CredentialSeparator) {
 			user, err := VerifyAPIKey(rawToken)
 			if err != nil {
 				log.Warn("fail to verify apikey", zap.Error(err))
 				return nil, status.Error(codes.Unauthenticated, "auth check failure, please check api key is correct")
 			}
 			metrics.UserRPCCounter.WithLabelValues(user).Inc()
-			userToken := fmt.Sprintf("%s%s%s", user, util.CredentialSeperator, util.PasswordHolder)
+			userToken := fmt.Sprintf("%s%s%s", user, util.CredentialSeparator, util.PasswordHolder)
 			md[strings.ToLower(util.HeaderAuthorize)] = []string{crypto.Base64Encode(userToken)}
 			md[util.HeaderToken] = []string{rawToken}
 			ctx = metadata.NewIncomingContext(ctx, md)

--- a/internal/proxy/trace_log_interceptor_test.go
+++ b/internal/proxy/trace_log_interceptor_test.go
@@ -48,7 +48,7 @@ func TestTraceLogInterceptor(t *testing.T) {
 	_, _ = TraceLogInterceptor(context.Background(), &milvuspb.ShowCollectionsRequest{}, &grpc.UnaryServerInfo{}, handler)
 
 	// simple mode
-	ctx := GetContext(context.Background(), fmt.Sprintf("%s%s%s", "foo", util.CredentialSeperator, "FOO123456"))
+	ctx := GetContext(context.Background(), fmt.Sprintf("%s%s%s", "foo", util.CredentialSeparator, "FOO123456"))
 	_ = paramtable.Get().Save(paramtable.Get().CommonCfg.TraceLogMode.Key, "1")
 	{
 		_, _ = TraceLogInterceptor(ctx, &milvuspb.CreateCollectionRequest{

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -1409,7 +1409,7 @@ func NewContextWithMetadata(ctx context.Context, username string, dbName string)
 		ctx = contextutil.AppendToIncomingContext(ctx, dbKey, dbName)
 	}
 	if username != "" {
-		originValue := fmt.Sprintf("%s%s%s", username, util.CredentialSeperator, username)
+		originValue := fmt.Sprintf("%s%s%s", username, util.CredentialSeparator, username)
 		authKey := strings.ToLower(util.HeaderAuthorize)
 		authValue := crypto.Base64Encode(originValue)
 		ctx = contextutil.AppendToIncomingContext(ctx, authKey, authValue)
@@ -1420,7 +1420,7 @@ func NewContextWithMetadata(ctx context.Context, username string, dbName string)
 func AppendUserInfoForRPC(ctx context.Context) context.Context {
 	curUser, _ := GetCurUserFromContext(ctx)
 	if curUser != "" {
-		originValue := fmt.Sprintf("%s%s%s", curUser, util.CredentialSeperator, curUser)
+		originValue := fmt.Sprintf("%s%s%s", curUser, util.CredentialSeparator, curUser)
 		authKey := strings.ToLower(util.HeaderAuthorize)
 		authValue := crypto.Base64Encode(originValue)
 		ctx = metadata.AppendToOutgoingContext(ctx, authKey, authValue)

--- a/internal/proxy/util_test.go
+++ b/internal/proxy/util_test.go
@@ -802,7 +802,7 @@ func TestGetCurUserFromContext(t *testing.T) {
 
 	root := "root"
 	password := "123456"
-	username, err := GetCurUserFromContext(GetContext(context.Background(), fmt.Sprintf("%s%s%s", root, util.CredentialSeperator, password)))
+	username, err := GetCurUserFromContext(GetContext(context.Background(), fmt.Sprintf("%s%s%s", root, util.CredentialSeparator, password)))
 	assert.NoError(t, err)
 	assert.Equal(t, "root", username)
 }

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -46,7 +46,7 @@ const (
 
 	HeaderAuthorize     = "authorization"
 	HeaderToken         = "token"
-	CredentialSeperator = ":"
+	CredentialSeparator = ":"
 	UserRoot            = "root"
 	PasswordHolder      = "___"
 	DefaultTenant       = ""

--- a/pkg/util/contextutil/context_util.go
+++ b/pkg/util/contextutil/context_util.go
@@ -101,7 +101,7 @@ func GetAuthInfoFromContext(ctx context.Context) (string, string, error) {
 	if err != nil {
 		return "", "", fmt.Errorf("fail to decode the token, token: %s", token)
 	}
-	secrets := strings.SplitN(rawToken, util.CredentialSeperator, 2)
+	secrets := strings.SplitN(rawToken, util.CredentialSeparator, 2)
 	if len(secrets) < 2 {
 		return "", "", fmt.Errorf("fail to get user info from the raw token, raw token: %s", rawToken)
 	}

--- a/pkg/util/contextutil/context_util_test.go
+++ b/pkg/util/contextutil/context_util_test.go
@@ -82,12 +82,12 @@ func TestGetCurUserFromContext(t *testing.T) {
 
 	root := "root"
 	password := "123456"
-	username, err := GetCurUserFromContext(GetContext(context.Background(), fmt.Sprintf("%s%s%s", root, util.CredentialSeperator, password)))
+	username, err := GetCurUserFromContext(GetContext(context.Background(), fmt.Sprintf("%s%s%s", root, util.CredentialSeparator, password)))
 	assert.NoError(t, err)
 	assert.Equal(t, root, username)
 
 	{
-		u, p, e := GetAuthInfoFromContext(GetContext(context.Background(), fmt.Sprintf("%s%s%s", root, util.CredentialSeperator, password)))
+		u, p, e := GetAuthInfoFromContext(GetContext(context.Background(), fmt.Sprintf("%s%s%s", root, util.CredentialSeparator, password)))
 		assert.NoError(t, e)
 		assert.Equal(t, "root", u)
 		assert.Equal(t, password, p)


### PR DESCRIPTION
issue: #46635

## Summary
- Fix spelling error in constant name: `CredentialSeperator` -> `CredentialSeparator`
- Updated all usages across the codebase to use the correct spelling

## Changes
- `pkg/util/constant.go`: Renamed the constant
- `pkg/util/contextutil/context_util.go`: Updated usage
- `pkg/util/contextutil/context_util_test.go`: Updated usage
- `internal/proxy/authentication_interceptor.go`: Updated usage
- `internal/proxy/util.go`: Updated usage
- `internal/proxy/util_test.go`: Updated usage
- `internal/proxy/trace_log_interceptor_test.go`: Updated usage
- `internal/proxy/accesslog/info/util.go`: Updated usage
- `internal/distributed/proxy/service.go`: Updated usage
- `internal/distributed/proxy/httpserver/utils.go`: Updated usage

## Test Plan
- [x] All references updated consistently
- [x] No functional changes - only constant name spelling correction

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Core invariant: the separator character for credentials remains ":" everywhere — only the exported identifier was renamed from CredentialSeperator → CredentialSeparator; the constant value and split/join semantics are unchanged.
- Change (bug fix): corrected the misspelled exported constant in pkg/util/constant.go and updated all references across the codebase (parsing, token construction, header handling and tests) to use the new identifier; this is an identifier rename that removes an inconsistent symbol and prevents compile-time/reference errors.
- Logic simplified/redundant work removed: no runtime logic was removed; the simplification is purely maintenance-focused — eliminating a misspelled exported name that could cause developers to introduce duplicate or incorrect constants.
- No data loss or behavior regression: runtime code paths are unchanged — e.g., GetAuthInfoFromContext, ParseUsernamePassword, AuthenticationInterceptor, proxy service token construction and access-log extraction still use ":" to split/join credentials; updated and added unit tests (parsing and metadata extraction) exercise these paths and validate identical semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->