### PR TITLE
fix: correct typo Seperate to Separate in build script

### DIFF
--- a/build/build_image_gpu.sh
+++ b/build/build_image_gpu.sh
@@ -35,7 +35,7 @@ BUILD_ARGS=""
 pushd "${toplevel}"
 BUILD_BASE_IMAGE=${BUILD_BASE_IMAGE:-"false"}
 
-# Seperate base dockerfile to ignore install dependencies when build milvus image
+# Separate base dockerfile to ignore install dependencies when build milvus image
 if [[ ${OS_NAME} == "ubuntu20.04" && ${BUILD_BASE_IMAGE} == "true" ]]; then 
   docker build -f "./build/docker/milvus/gpu/${OS_NAME}/Dockerfile.base" -t "${MILVUS_BASE_IMAGE_REPO}:${MILVUS_BASE_IMAGE_TAG}" .
   BUILD_ARGS="--build-arg MILVUS_BASE_IMAGE_REPO=${MILVUS_BASE_IMAGE_REPO} --build-arg MILVUS_BASE_IMAGE_TAG=${MILVUS_BASE_IMAGE_TAG}"


### PR DESCRIPTION
issue: #46636

## Summary
- Fix spelling error in comment: `Seperate` -> `Separate`
- Location: `build/build_image_gpu.sh` line 38

## Test Plan
- [x] Comment-only change, no functional impact

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## PR Summary: Typo Correction in Build Script Comment

• **Core Assumption**: This change relies on the assumption that documentation and comments should reflect correct spelling to maintain code quality and readability for maintainers. The comment is purely informational describing the conditional logic below it.

• **What Changed**: A single spelling correction in a comment on line 38 of `build/build_image_gpu.sh`, changing "Seperate" to "Separate". No code logic, control flow, or build behavior is altered—this is a comment-only edit.

• **No Regression**: This change introduces zero behavioral or functional impact because the modified content is a comment that does not execute. The conditional logic immediately following (lines 39-42) and the docker build command remain completely unchanged. Build output, image creation, dependency installation, and all runtime behavior are identical before and after this change.

• **Rationale**: Correcting obvious spelling errors in comments improves code maintainability and reduces potential confusion for developers reading the build script, while incurring zero risk to the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->