### PR TITLE
test: reduce test time for TestSparsePlaceholderGroupSize

### DIFF
--- a/pkg/util/typeutil/schema_test.go
+++ b/pkg/util/typeutil/schema_test.go
@@ -2926,8 +2926,8 @@ func TestParseJsonSparseFloatRowBytes(t *testing.T) {
 // with various nq and averageNNZ, test if the estimated number of non-zero
 // elements is close to the actual number.
 func TestSparsePlaceholderGroupSize(t *testing.T) {
-	nqs := []int{1, 10, 100, 1000, 10000}
-	averageNNZs := []int{1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048}
+	nqs := []int{1, 100, 10000}
+	averageNNZs := []int{1, 4, 16, 64, 256, 1024}
 	numCases := 0
 	casesWithLargeError := 0
 	for _, nq := range nqs {


### PR DESCRIPTION
issue: #44452

## Summary
Reduce test combinations in `TestSparsePlaceholderGroupSize` to decrease test execution time:
- `nqs`: from `[1, 10, 100, 1000, 10000]` to `[1, 100, 10000]`
- `averageNNZs`: from `[1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048]` to `[1, 4, 16, 64, 256, 1024]`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## TestSparsePlaceholderGroupSize Test Reduction

**Core Invariant:** The sparse vector NNZ estimation algorithm (`EstimateSparseVectorNNZFromPlaceholderGroup`) must maintain accuracy within bounded error thresholds—individual cases < 10% error and no more than 2% of cases exceeding 5% error—across representative parameter ranges.

**Test Coverage Optimized, Not Removed:** Test combinations reduced from 60 to 18 by pruning redundant parameter points while retaining critical coverage: nqs now tests [1, 100, 10000] (min, mid, max) and averageNNZs tests [1, 4, 16, 64, 256, 1024] (exponential spacing). Variant generation logic (powers of 2 scaling) remains unchanged, ensuring error scenarios are still exercised.

**No Behavioral Regression:** The algorithm under test is untouched; only test case frequency decreases. The same assertions validate error bounds are satisfied—individual assertions (`assert.Less(errorRatio, 10.0)`) and statistical assertions (`assert.Less(largeErrorRatio, 2.0)`) remain identical, confirming that estimation quality is still verified.

**Why Safe:** Exponential spacing of removed parameters (e.g., nqs: 10, 1000 removed; averageNNZs: 2, 8, 32, 128, 512, 2048 removed) addresses diminishing returns—intermediate values provide no new error scenarios beyond what surrounding powers-of-2 values expose, while keeping test execution time proportional to coverage value gained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->