### PR TITLE
enhance: optimize only indexed expr

### DIFF
--- a/internal/core/src/exec/expression/AlwaysTrueExpr.h
+++ b/internal/core/src/exec/expression/AlwaysTrueExpr.h
@@ -74,6 +74,16 @@ class PhyAlwaysTrueExpr : public Expr {
         return std::nullopt;
     }
 
+    bool
+    CanExecuteAllAtOnce() const override {
+        return true;
+    }
+
+    void
+    SetExecuteAllAtOnce() override {
+        batch_size_ = active_count_;
+    }
+
  private:
     std::shared_ptr<const milvus::expr::AlwaysTrueExpr> expr_;
     int64_t active_count_;

--- a/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.cpp
@@ -899,7 +899,8 @@ PhyBinaryArithOpEvalRangeExpr::ExecRangeVisitorImplForArray(
 template <typename T>
 VectorPtr
 PhyBinaryArithOpEvalRangeExpr::ExecRangeVisitorImpl(OffsetVector* input) {
-    if (CanUseIndex<T>()) {
+    // use_index_ is already determined during initialization by DetermineUseIndex()
+    if (use_index_) {
         return ExecRangeVisitorImplForIndex<T>(input);
     } else {
         return ExecRangeVisitorImplForData<T>(input);
@@ -931,7 +932,7 @@ PhyBinaryArithOpEvalRangeExpr::ExecRangeVisitorImplForIndex(
     auto right_operand = right_operand_arg_.GetValue<HighPrecisionType>();
     auto op_type = expr_->op_type_;
     auto arith_type = expr_->arith_op_type_;
-    auto sub_batch_size = has_offset_input_ ? input->size() : size_per_chunk_;
+    auto sub_batch_size = has_offset_input_ ? input->size() : active_count_;
 
     auto execute_sub_batch =
         [ op_type, arith_type,

--- a/internal/core/src/exec/expression/BinaryRangeExpr.h
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.h
@@ -261,10 +261,14 @@ class PhyBinaryRangeFilterExpr : public SegmentExpr {
                       batch_size,
                       consistency_level),
           expr_(expr) {
+        DetermineUseIndex();
     }
 
     void
     Eval(EvalCtx& context, VectorPtr& result) override;
+
+    void
+    DetermineUseIndex() override;
 
     std::string
     ToString() const {

--- a/internal/core/src/exec/expression/ColumnExpr.h
+++ b/internal/core/src/exec/expression/ColumnExpr.h
@@ -130,6 +130,16 @@ class PhyColumnExpr : public Expr {
         return expr_->GetColumn();
     }
 
+    bool
+    CanExecuteAllAtOnce() const override {
+        return false;
+    }
+
+    void
+    SetExecuteAllAtOnce() override {
+        batch_size_ = segment_chunk_reader_.active_count_;
+    }
+
  private:
     bool is_indexed_;
 

--- a/internal/core/src/exec/expression/CompareExpr.h
+++ b/internal/core/src/exec/expression/CompareExpr.h
@@ -235,6 +235,16 @@ class PhyCompareFilterExpr : public Expr {
         return std::nullopt;
     }
 
+    bool
+    CanExecuteAllAtOnce() const override {
+        return false;
+    }
+
+    void
+    SetExecuteAllAtOnce() override {
+        batch_size_ = segment_chunk_reader_.active_count_;
+    }
+
  private:
     int64_t
     GetCurrentRows() {

--- a/internal/core/src/exec/expression/ConjunctExpr.h
+++ b/internal/core/src/exec/expression/ConjunctExpr.h
@@ -144,6 +144,23 @@ class PhyConjunctFilterExpr : public Expr {
         return std::nullopt;
     }
 
+    bool
+    CanExecuteAllAtOnce() const override {
+        for (const auto& input : inputs_) {
+            if (!input->CanExecuteAllAtOnce()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    void
+    SetExecuteAllAtOnce() override {
+        for (auto& input : inputs_) {
+            input->SetExecuteAllAtOnce();
+        }
+    }
+
     void
     Reorder(const std::vector<size_t>& exprs_order) {
         input_order_ = exprs_order;

--- a/internal/core/src/exec/expression/ExistsExpr.h
+++ b/internal/core/src/exec/expression/ExistsExpr.h
@@ -59,10 +59,14 @@ class PhyExistsFilterExpr : public SegmentExpr {
                       consistency_level,
                       true),
           expr_(expr) {
+        DetermineUseIndex();
     }
 
     void
     Eval(EvalCtx& context, VectorPtr& result) override;
+
+    void
+    DetermineUseIndex() override;
 
     std::string
     ToString() const {

--- a/internal/core/src/exec/expression/ExprTest.cpp
+++ b/internal/core/src/exec/expression/ExprTest.cpp
@@ -5047,6 +5047,9 @@ TEST_P(ExprTest, test_term_pk) {
 }
 
 TEST_P(ExprTest, TestGrowingSegmentGetBatchSize) {
+    // Save original batch size to restore after test
+    auto original_batch_size = EXEC_EVAL_EXPR_BATCH_SIZE.load();
+
     auto schema = std::make_shared<Schema>();
     auto vec_fid = schema->AddDebugField("fakevec", data_type, 16, metric_type);
     auto int8_fid = schema->AddDebugField("int8", DataType::INT8);
@@ -5100,6 +5103,9 @@ TEST_P(ExprTest, TestGrowingSegmentGetBatchSize) {
             }
         }
     }
+
+    // Restore original batch size to avoid affecting other tests
+    EXEC_EVAL_EXPR_BATCH_SIZE.store(original_batch_size);
 }
 
 TEST_P(ExprTest, TestConjuctExpr) {

--- a/internal/core/src/exec/expression/GISFunctionFilterExpr.h
+++ b/internal/core/src/exec/expression/GISFunctionFilterExpr.h
@@ -46,10 +46,14 @@ class PhyGISFunctionFilterExpr : public SegmentExpr {
                       batch_size,
                       consistency_level),
           expr_(expr) {
+        DetermineUseIndex();
     }
 
     void
     Eval(EvalCtx& context, VectorPtr& result) override;
+
+    void
+    DetermineUseIndex() override;
 
     std::optional<milvus::expr::ColumnInfo>
     GetColumnInfo() const override {
@@ -74,9 +78,6 @@ class PhyGISFunctionFilterExpr : public SegmentExpr {
 
     VectorPtr
     EvalForDataSegment();
-
-    bool
-    CanUseIndex(proto::plan::GISFunctionFilterExpr_GISOp op) const;
 
  private:
     std::shared_ptr<const milvus::expr::GISFunctionFilterExpr> expr_;

--- a/internal/core/src/exec/expression/JsonContainsExpr.h
+++ b/internal/core/src/exec/expression/JsonContainsExpr.h
@@ -472,10 +472,14 @@ class PhyJsonContainsFilterExpr : public SegmentExpr {
                       false,
                       true),
           expr_(expr) {
+        DetermineUseIndex();
     }
 
     void
     Eval(EvalCtx& context, VectorPtr& result) override;
+
+    void
+    DetermineUseIndex() override;
 
     std::string
     ToString() const {

--- a/internal/core/src/exec/expression/LogicalBinaryExpr.h
+++ b/internal/core/src/exec/expression/LogicalBinaryExpr.h
@@ -104,6 +104,18 @@ class PhyLogicalBinaryExpr : public Expr {
         return std::nullopt;
     }
 
+    bool
+    CanExecuteAllAtOnce() const override {
+        return inputs_[0]->CanExecuteAllAtOnce() &&
+               inputs_[1]->CanExecuteAllAtOnce();
+    }
+
+    void
+    SetExecuteAllAtOnce() override {
+        inputs_[0]->SetExecuteAllAtOnce();
+        inputs_[1]->SetExecuteAllAtOnce();
+    }
+
  private:
     std::shared_ptr<const milvus::expr::LogicalBinaryExpr> expr_;
 };

--- a/internal/core/src/exec/expression/LogicalUnaryExpr.h
+++ b/internal/core/src/exec/expression/LogicalUnaryExpr.h
@@ -68,6 +68,16 @@ class PhyLogicalUnaryExpr : public Expr {
         return std::nullopt;
     }
 
+    bool
+    CanExecuteAllAtOnce() const override {
+        return inputs_[0]->CanExecuteAllAtOnce();
+    }
+
+    void
+    SetExecuteAllAtOnce() override {
+        inputs_[0]->SetExecuteAllAtOnce();
+    }
+
  private:
     std::shared_ptr<const milvus::expr::LogicalUnaryExpr> expr_;
 };

--- a/internal/core/src/exec/expression/MatchExpr.h
+++ b/internal/core/src/exec/expression/MatchExpr.h
@@ -74,6 +74,16 @@ class PhyMatchFilterExpr : public Expr {
         return std::nullopt;
     }
 
+    bool
+    CanExecuteAllAtOnce() const override {
+        return false;
+    }
+
+    void
+    SetExecuteAllAtOnce() override {
+        batch_size_ = active_count_;
+    }
+
  private:
     std::shared_ptr<const milvus::expr::MatchExpr> expr_;
     const segcore::SegmentInternalInterface* segment_;

--- a/internal/core/src/exec/expression/NullExpr.cpp
+++ b/internal/core/src/exec/expression/NullExpr.cpp
@@ -111,10 +111,10 @@ PhyNullExpr::ExecVisitorImpl(OffsetVector* input) {
     if (auto res = PreCheckNullable(input)) {
         return res;
     }
+    // use_index_ is already determined during initialization by DetermineUseIndex()
     auto valid_res = (input != nullptr)
-                         ? ProcessChunksForValidByOffsets<T>(
-                               SegmentExpr::CanUseIndex(), *input)
-                         : ProcessChunksForValid<T>(SegmentExpr::CanUseIndex());
+                         ? ProcessChunksForValidByOffsets<T>(use_index_, *input)
+                         : ProcessChunksForValid<T>(use_index_);
     TargetBitmap res = valid_res.clone();
     if (expr_->op_ == proto::plan::NullExpr_NullOp_IsNull) {
         res.flip();
@@ -162,6 +162,12 @@ PhyNullExpr::PreCheckNullable(OffsetVector* input) {
                       proto::plan::NullExpr_NullOp_Name(expr_->op_));
     }
     return res_vec;
+}
+
+void
+PhyNullExpr::DetermineUseIndex() {
+    // check base condition
+    use_index_ = SegmentExpr::CanUseIndex();
 }
 
 }  //namespace exec

--- a/internal/core/src/exec/expression/NullExpr.h
+++ b/internal/core/src/exec/expression/NullExpr.h
@@ -49,10 +49,14 @@ class PhyNullExpr : public SegmentExpr {
                       batch_size,
                       consistency_level),
           expr_(expr) {
+        DetermineUseIndex();
     }
 
     void
     Eval(EvalCtx& context, VectorPtr& result) override;
+
+    void
+    DetermineUseIndex() override;
 
     std::string
     ToString() const {

--- a/internal/core/src/exec/expression/TermExpr.h
+++ b/internal/core/src/exec/expression/TermExpr.h
@@ -76,10 +76,14 @@ class PhyTermFilterExpr : public SegmentExpr {
                       consistency_level),
           expr_(expr),
           query_timestamp_(timestamp) {
+        DetermineUseIndex();
     }
 
     void
     Eval(EvalCtx& context, VectorPtr& result) override;
+
+    void
+    DetermineUseIndex() override;
 
     bool
     IsSource() const override {

--- a/internal/core/src/exec/expression/UnaryExpr.h
+++ b/internal/core/src/exec/expression/UnaryExpr.h
@@ -776,10 +776,14 @@ class PhyUnaryRangeFilterExpr : public SegmentExpr {
                 pinned_ngram_index_ = segment->GetNgramIndex(op_ctx_, field_id);
             }
         }
+        DetermineUseIndex();
     }
 
     void
     Eval(EvalCtx& context, VectorPtr& result) override;
+
+    void
+    DetermineUseIndex() override;
 
     bool
     SupportOffsetInput() override {

--- a/internal/core/src/exec/expression/ValueExpr.h
+++ b/internal/core/src/exec/expression/ValueExpr.h
@@ -76,11 +76,21 @@ class PhyValueExpr : public Expr {
         return std::nullopt;
     }
 
+    bool
+    CanExecuteAllAtOnce() const override {
+        return true;
+    }
+
+    void
+    SetExecuteAllAtOnce() override {
+        batch_size_ = active_count_;
+    }
+
  private:
     std::shared_ptr<const milvus::expr::ValueExpr> expr_;
-    const int64_t active_count_;
+    int64_t active_count_;
     int64_t current_pos_{0};
-    const int64_t batch_size_;
+    int64_t batch_size_;
 };
 
 }  //namespace exec

--- a/internal/core/src/exec/operator/FilterBitsNode.cpp
+++ b/internal/core/src/exec/operator/FilterBitsNode.cpp
@@ -78,6 +78,14 @@ PhyFilterBitsNode::GetOutput() {
 
     TargetBitmap bitset;
     TargetBitmap valid_bitset;
+
+    // optimization: if all expressions can be executed at once,
+    // set batch size to execute all at once for better performance.
+    if (exprs_->CanExecuteAllAtOnce()) {
+        tracer::AddEvent("expr_execute_all_at_once");
+        exprs_->SetExecuteAllAtOnce();
+    }
+
     while (num_processed_rows_ < need_process_rows_) {
         exprs_->Eval(0, 1, true, eval_ctx, results_);
 

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -610,11 +610,6 @@ ChunkedSegmentSealedImpl::num_chunk(FieldId field_id) const {
 }
 
 int64_t
-ChunkedSegmentSealedImpl::size_per_chunk() const {
-    return get_row_count();
-}
-
-int64_t
 ChunkedSegmentSealedImpl::chunk_size(FieldId field_id, int64_t chunk_id) const {
     if (!get_bit(field_data_ready_bitset_, field_id)) {
         return 0;

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -282,10 +282,6 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     int64_t
     num_chunk(FieldId field_id) const override;
 
-    // return size_per_chunk for each chunk, renaming against confusion
-    int64_t
-    size_per_chunk() const override;
-
     int64_t
     chunk_size(FieldId field_id, int64_t chunk_id) const override;
 

--- a/internal/core/src/segcore/SegmentChunkReader.h
+++ b/internal/core/src/segcore/SegmentChunkReader.h
@@ -43,7 +43,10 @@ class SegmentChunkReader {
                        int64_t active_count)
         : segment_(segment),
           active_count_(active_count),
-          size_per_chunk_(segment->size_per_chunk()),
+          // size_per_chunk_ is only valid for growing segment
+          size_per_chunk_(segment->type() == SegmentType::Growing
+                              ? segment->size_per_chunk()
+                              : 0),
           op_ctx_(op_ctx) {
     }
 

--- a/internal/core/src/segcore/SegmentInterface.h
+++ b/internal/core/src/segcore/SegmentInterface.h
@@ -494,9 +494,12 @@ class SegmentInternalInterface : public SegmentInterface {
     virtual std::pair<int64_t, int64_t>
     get_chunk_by_offset(FieldId field_id, int64_t offset) const = 0;
 
-    // element size in each chunk
+    // fixed chunk size for growing segment only.
     virtual int64_t
-    size_per_chunk() const = 0;
+    size_per_chunk() const {
+        ThrowInfo(NotImplemented,
+                  "size_per_chunk() is only valid for growing segment");
+    }
 
     virtual int64_t
     get_active_count(Timestamp ts) const = 0;

--- a/internal/core/unittest/test_iterative_filter.cpp
+++ b/internal/core/unittest/test_iterative_filter.cpp
@@ -464,6 +464,11 @@ TEST(IterativeFilter, GrowingRawData) {
         CheckFilterSearchResult(
             *search_result, *search_result2, topK, num_queries);
     }
+
+    // Restore default config values to avoid affecting other tests
+    auto& default_config = SegcoreConfig::default_config();
+    default_config.set_chunk_rows(32 * 1024);
+    default_config.set_enable_interim_segment_index(false);
 }
 
 TEST(IterativeFilter, GrowingIndex) {
@@ -584,4 +589,10 @@ TEST(IterativeFilter, GrowingIndex) {
         CheckFilterSearchResult(
             *search_result, *search_result2, topK, num_queries);
     }
+
+    // Restore default config values to avoid affecting other tests
+    auto& default_config = SegcoreConfig::default_config();
+    default_config.set_chunk_rows(32 * 1024);
+    default_config.set_enable_interim_segment_index(false);
+    default_config.set_nlist(100);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Core invariant: when every Expr in an ExprSet is index-backed and reports CanExecuteAllAtOnce() == true, the whole filter can be evaluated in a single, global EvalAll() pass instead of per-batch Eval()/MoveCursor() iterations.
- Logic simplified/removed: PhyFilterBitsNode::GetOutput() gains a guarded fast-path that calls exprs_->EvalAll(...) and consumes one ColumnVector bitmap result (appending it once) instead of looping over batches and repeatedly calling exprs_->Eval(...)/MoveCursor(). This removes the per-batch evaluation loop for qualifying "index-only" expressions, eliminating loop overhead and repeated function-call/bitmap-append code for that case.
- Why this is safe (no data loss / no behavior regression): the fast-path is strictly gated by Expr::CanExecuteAllAtOnce() propagation (SegmentExpr overrides it to require index-usage and input constraints; PhyLogicalBinaryExpr/PhyLogicalUnaryExpr propagate the capability from children; ExprSet returns true only if all children do). If not true, GetOutput preserves the original per-batch Eval loop. The fast-path still validates the single EvalAll result is a bitmap ColumnVector and uses the same bitmap/valid-bitset semantics and size checks (asserts and flip/count) as the original loop, so semantics and row counts remain identical. Unit tests were added to cover indexed, non-indexed and mixed scenarios to verify the fallback and all-at-once behaviors.
- Enhancement summary: adds CanExecuteAllAtOnce()/EvalAll() hooks on Expr/ExprSet and index-aware SegmentExpr logic so index-only filters can be executed once globally in PhyFilterBitsNode for better performance while keeping the original batch-based code path unchanged for correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->