### PR TITLE
enhance: [2.6][GoSDK] Pick GoSDK commits & bump version

### DIFF
--- a/client/column/struct.go
+++ b/client/column/struct.go
@@ -1,0 +1,138 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package column
+
+import (
+	"github.com/cockroachdb/errors"
+	"github.com/samber/lo"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/client/v2/entity"
+)
+
+type columnStructArray struct {
+	fields []Column
+	name   string
+}
+
+func NewColumnStructArray(name string, fields []Column) Column {
+	return &columnStructArray{
+		fields: fields,
+		name:   name,
+	}
+}
+
+func (c *columnStructArray) Name() string {
+	return c.name
+}
+
+func (c *columnStructArray) Type() entity.FieldType {
+	return entity.FieldTypeArray
+}
+
+func (c *columnStructArray) Len() int {
+	for _, field := range c.fields {
+		return field.Len()
+	}
+	return 0
+}
+
+func (c *columnStructArray) Slice(start, end int) Column {
+	fields := make([]Column, len(c.fields))
+	for idx, subField := range c.fields {
+		fields[idx] = subField.Slice(start, end)
+	}
+	c.fields = fields
+	return c
+}
+
+func (c *columnStructArray) FieldData() *schemapb.FieldData {
+	return &schemapb.FieldData{
+		Type:      schemapb.DataType_Array,
+		FieldName: c.name,
+		Field: &schemapb.FieldData_StructArrays{
+			StructArrays: &schemapb.StructArrayField{
+				Fields: lo.Map(c.fields, func(field Column, _ int) *schemapb.FieldData {
+					return field.FieldData()
+				}),
+			},
+		},
+	}
+}
+
+func (c *columnStructArray) AppendValue(value any) error {
+	return errors.New("not implemented")
+}
+
+func (c *columnStructArray) Get(idx int) (any, error) {
+	m := make(map[string]any)
+	for _, field := range c.fields {
+		v, err := field.Get(idx)
+		if err != nil {
+			return nil, err
+		}
+		m[field.Name()] = v
+	}
+	return m, nil
+}
+
+func (c *columnStructArray) GetAsInt64(idx int) (int64, error) {
+	return 0, errors.New("not implemented")
+}
+
+func (c *columnStructArray) GetAsString(idx int) (string, error) {
+	return "", errors.New("not implemented")
+}
+
+func (c *columnStructArray) GetAsDouble(idx int) (float64, error) {
+	return 0, errors.New("not implemented")
+}
+
+func (c *columnStructArray) GetAsBool(idx int) (bool, error) {
+	return false, errors.New("not implemented")
+}
+
+func (c *columnStructArray) IsNull(idx int) (bool, error) {
+	return false, errors.New("not implemented")
+}
+
+func (c *columnStructArray) AppendNull() error {
+	return errors.New("not implemented")
+}
+
+func (c *columnStructArray) Nullable() bool {
+	return false
+}
+
+func (c *columnStructArray) SetNullable(nullable bool) {
+	// Shall not be set
+}
+
+func (c *columnStructArray) ValidateNullable() error {
+	for _, field := range c.fields {
+		if err := field.ValidateNullable(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *columnStructArray) CompactNullableValues() {
+	for _, field := range c.fields {
+		field.CompactNullableValues()
+	}
+}

--- a/client/column/struct_test.go
+++ b/client/column/struct_test.go
@@ -1,0 +1,292 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package column
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/client/v2/entity"
+)
+
+type StructArraySuite struct {
+	suite.Suite
+}
+
+func (s *StructArraySuite) TestBasic() {
+	name := fmt.Sprintf("struct_array_%d", rand.Intn(100))
+
+	// Create sub-fields for the struct
+	int32Data := []int32{1, 2, 3, 4, 5}
+	floatData := []float32{1.1, 2.2, 3.3, 4.4, 5.5}
+	varcharData := []string{"a", "b", "c", "d", "e"}
+
+	int32Col := NewColumnInt32("int_field", int32Data)
+	floatCol := NewColumnFloat("float_field", floatData)
+	varcharCol := NewColumnVarChar("varchar_field", varcharData)
+
+	fields := []Column{int32Col, floatCol, varcharCol}
+	column := NewColumnStructArray(name, fields)
+
+	// Test Name()
+	s.Equal(name, column.Name())
+
+	// Test Type()
+	s.Equal(entity.FieldTypeArray, column.Type())
+
+	// Test Len()
+	s.EqualValues(5, column.Len())
+
+	// Test FieldData()
+	fd := column.FieldData()
+	s.Equal(schemapb.DataType_Array, fd.GetType())
+	s.Equal(name, fd.GetFieldName())
+
+	structArrays := fd.GetStructArrays()
+	s.NotNil(structArrays)
+	s.Equal(3, len(structArrays.GetFields()))
+
+	// Verify each field in the struct array
+	fieldNames := []string{"int_field", "float_field", "varchar_field"}
+	for i, field := range structArrays.GetFields() {
+		s.Equal(fieldNames[i], field.GetFieldName())
+	}
+
+	// Test Get() - retrieve values as map
+	val, err := column.Get(0)
+	s.NoError(err)
+	m, ok := val.(map[string]any)
+	s.True(ok)
+	s.Equal(int32(1), m["int_field"])
+	s.Equal(float32(1.1), m["float_field"])
+	s.Equal("a", m["varchar_field"])
+
+	val, err = column.Get(2)
+	s.NoError(err)
+	m, ok = val.(map[string]any)
+	s.True(ok)
+	s.Equal(int32(3), m["int_field"])
+	s.Equal(float32(3.3), m["float_field"])
+	s.Equal("c", m["varchar_field"])
+}
+
+func (s *StructArraySuite) TestSlice() {
+	name := "struct_array_slice"
+
+	// Create sub-fields
+	int64Data := []int64{10, 20, 30, 40, 50}
+	boolData := []bool{true, false, true, false, true}
+
+	int64Col := NewColumnInt64("id", int64Data)
+	boolCol := NewColumnBool("flag", boolData)
+
+	fields := []Column{int64Col, boolCol}
+	column := NewColumnStructArray(name, fields)
+
+	// Test Slice(1, 4) - should slice all sub-fields
+	sliced := column.Slice(1, 4)
+	s.NotNil(sliced)
+
+	// Verify sliced data
+	val, err := sliced.Get(0)
+	s.NoError(err)
+	m, ok := val.(map[string]any)
+	s.True(ok)
+	s.Equal(int64(20), m["id"])
+	s.Equal(false, m["flag"])
+
+	val, err = sliced.Get(2)
+	s.NoError(err)
+	m, ok = val.(map[string]any)
+	s.True(ok)
+	s.Equal(int64(40), m["id"])
+	s.Equal(false, m["flag"])
+}
+
+func (s *StructArraySuite) TestNullable() {
+	name := "struct_array_nullable"
+
+	// Create sub-fields
+	int32Data := []int32{1, 2, 3}
+	int32Col := NewColumnInt32("field1", int32Data)
+
+	varcharData := []string{"x", "y", "z"}
+	varcharCol := NewColumnVarChar("field2", varcharData)
+
+	fields := []Column{int32Col, varcharCol}
+	column := NewColumnStructArray(name, fields)
+
+	// Test Nullable() - should return false by default
+	s.False(column.Nullable())
+
+	// Test ValidateNullable() - should validate all sub-fields
+	err := column.ValidateNullable()
+	s.NoError(err)
+
+	// Test CompactNullableValues() - should not panic
+	s.NotPanics(func() {
+		column.CompactNullableValues()
+	})
+}
+
+func (s *StructArraySuite) TestNotImplementedMethods() {
+	name := "struct_array_not_impl"
+
+	int32Data := []int32{1, 2, 3}
+	int32Col := NewColumnInt32("field1", int32Data)
+	fields := []Column{int32Col}
+	column := NewColumnStructArray(name, fields)
+
+	// Test AppendValue - should return error
+	err := column.AppendValue(map[string]any{"field1": int32(4)})
+	s.Error(err)
+	s.Contains(err.Error(), "not implemented")
+
+	// Test GetAsInt64 - should return error
+	_, err = column.GetAsInt64(0)
+	s.Error(err)
+	s.Contains(err.Error(), "not implemented")
+
+	// Test GetAsString - should return error
+	_, err = column.GetAsString(0)
+	s.Error(err)
+	s.Contains(err.Error(), "not implemented")
+
+	// Test GetAsDouble - should return error
+	_, err = column.GetAsDouble(0)
+	s.Error(err)
+	s.Contains(err.Error(), "not implemented")
+
+	// Test GetAsBool - should return error
+	_, err = column.GetAsBool(0)
+	s.Error(err)
+	s.Contains(err.Error(), "not implemented")
+
+	// Test IsNull - should return error
+	_, err = column.IsNull(0)
+	s.Error(err)
+	s.Contains(err.Error(), "not implemented")
+
+	// Test AppendNull - should return error
+	err = column.AppendNull()
+	s.Error(err)
+	s.Contains(err.Error(), "not implemented")
+}
+
+func (s *StructArraySuite) TestParseStructArrayData() {
+	// Create a FieldData with struct array
+	int32FieldData := &schemapb.FieldData{
+		Type:      schemapb.DataType_Int32,
+		FieldName: "age",
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_IntData{
+					IntData: &schemapb.IntArray{
+						Data: []int32{10, 20, 30},
+					},
+				},
+			},
+		},
+	}
+
+	varcharFieldData := &schemapb.FieldData{
+		Type:      schemapb.DataType_VarChar,
+		FieldName: "name",
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_StringData{
+					StringData: &schemapb.StringArray{
+						Data: []string{"alice", "bob", "charlie"},
+					},
+				},
+			},
+		},
+	}
+
+	structArrayField := &schemapb.StructArrayField{
+		Fields: []*schemapb.FieldData{int32FieldData, varcharFieldData},
+	}
+
+	// Test parseStructArrayData
+	column, err := parseStructArrayData("person", structArrayField, 0, -1)
+	s.NoError(err)
+	s.NotNil(column)
+	s.Equal("person", column.Name())
+	s.Equal(entity.FieldTypeArray, column.Type())
+
+	// Verify we can get values
+	val, err := column.Get(0)
+	s.NoError(err)
+	m, ok := val.(map[string]any)
+	s.True(ok)
+	s.Equal(int32(10), m["age"])
+	s.Equal("alice", m["name"])
+
+	val, err = column.Get(1)
+	s.NoError(err)
+	m, ok = val.(map[string]any)
+	s.True(ok)
+	s.Equal(int32(20), m["age"])
+	s.Equal("bob", m["name"])
+}
+
+func (s *StructArraySuite) TestParseStructArrayDataWithRange() {
+	// Create a FieldData with struct array
+	int64FieldData := &schemapb.FieldData{
+		Type:      schemapb.DataType_Int64,
+		FieldName: "id",
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_LongData{
+					LongData: &schemapb.LongArray{
+						Data: []int64{100, 200, 300, 400, 500},
+					},
+				},
+			},
+		},
+	}
+
+	structArrayField := &schemapb.StructArrayField{
+		Fields: []*schemapb.FieldData{int64FieldData},
+	}
+
+	// Test parseStructArrayData with range [1, 4)
+	column, err := parseStructArrayData("data", structArrayField, 1, 4)
+	s.NoError(err)
+	s.NotNil(column)
+
+	// Verify sliced data (should contain indices 1, 2, 3)
+	val, err := column.Get(0)
+	s.NoError(err)
+	m, ok := val.(map[string]any)
+	s.True(ok)
+	s.Equal(int64(200), m["id"])
+
+	val, err = column.Get(2)
+	s.NoError(err)
+	m, ok = val.(map[string]any)
+	s.True(ok)
+	s.Equal(int64(400), m["id"])
+}
+
+func TestStructArray(t *testing.T) {
+	suite.Run(t, new(StructArraySuite))
+}

--- a/client/common/version.go
+++ b/client/common/version.go
@@ -18,5 +18,5 @@ package common
 
 const (
 	// SDKVersion const value for current version
-	SDKVersion = `2.6.1`
+	SDKVersion = `2.6.2`
 )

--- a/client/entity/common.go
+++ b/client/entity/common.go
@@ -33,6 +33,14 @@ const (
 	SUPERSTRUCTURE MetricType = "SUPERSTRUCTURE"
 	BM25           MetricType = "BM25"
 	MHJACCARD      MetricType = "MHJACCARD"
+
+	// The same with MaxSimCosine
+	MaxSim        MetricType = "MAX_SIM"
+	MaxSimCosine  MetricType = "MAX_SIM_COSINE"
+	MaxSimL2      MetricType = "MAX_SIM_L2"
+	MaxSimIP      MetricType = "MAX_SIM_IP"
+	MaxSimHamming MetricType = "MAX_SIM_HAMMING"
+	MaxSimJaccard MetricType = "MAX_SIM_JACCARD"
 )
 
 // CompactionState enum type for compaction state

--- a/client/entity/field.go
+++ b/client/entity/field.go
@@ -201,6 +201,9 @@ const (
 	FieldTypeSparseVector FieldType = 104
 	// FieldTypeInt8Vector field type int8 vector
 	FieldTypeInt8Vector FieldType = 105
+
+	// FieldTypeStruct field type struct
+	FieldTypeStruct FieldType = 201
 )
 
 // Field represent field schema in milvus
@@ -219,6 +222,7 @@ type Field struct {
 	ElementType     FieldType
 	DefaultValue    *schemapb.ValueField
 	Nullable        bool
+	StructSchema    *StructSchema
 }
 
 // ProtoMessage generates corresponding FieldSchema
@@ -440,6 +444,11 @@ func (f *Field) WithEnableMatch(enable bool) *Field {
 	return f
 }
 
+func (f *Field) WithStructSchema(schema *StructSchema) *Field {
+	f.StructSchema = schema
+	return f
+}
+
 // ReadProto parses FieldSchema
 func (f *Field) ReadProto(p *schemapb.FieldSchema) *Field {
 	f.ID = p.GetFieldID()
@@ -457,5 +466,19 @@ func (f *Field) ReadProto(p *schemapb.FieldSchema) *Field {
 	f.DefaultValue = p.GetDefaultValue()
 	f.Nullable = p.GetNullable()
 
+	return f
+}
+
+// StructArrayField represents a struct array field
+type StructSchema struct {
+	Fields []*Field
+}
+
+func NewStructSchema() *StructSchema {
+	return &StructSchema{}
+}
+
+func (f *StructSchema) WithField(field *Field) *StructSchema {
+	f.Fields = append(f.Fields, field)
 	return f
 }

--- a/client/entity/field_test.go
+++ b/client/entity/field_test.go
@@ -72,3 +72,45 @@ func TestFieldSchema(t *testing.T) {
 		(&Field{}).WithTypeParams("a", "b")
 	})
 }
+
+func TestStructSchema(t *testing.T) {
+	// Test NewStructSchema
+	schema := NewStructSchema()
+	assert.NotNil(t, schema)
+	assert.Empty(t, schema.Fields)
+
+	// Test WithField
+	field1 := NewField().WithName("age").WithDataType(FieldTypeInt32)
+	field2 := NewField().WithName("name").WithDataType(FieldTypeVarChar).WithMaxLength(100)
+	field3 := NewField().WithName("score").WithDataType(FieldTypeFloat)
+
+	schema.WithField(field1).WithField(field2).WithField(field3)
+	assert.Equal(t, 3, len(schema.Fields))
+	assert.Equal(t, "age", schema.Fields[0].Name)
+	assert.Equal(t, FieldTypeInt32, schema.Fields[0].DataType)
+	assert.Equal(t, "name", schema.Fields[1].Name)
+	assert.Equal(t, FieldTypeVarChar, schema.Fields[1].DataType)
+	assert.Equal(t, "score", schema.Fields[2].Name)
+	assert.Equal(t, FieldTypeFloat, schema.Fields[2].DataType)
+}
+
+func TestFieldWithStructSchema(t *testing.T) {
+	// Create a struct schema
+	structSchema := NewStructSchema().
+		WithField(NewField().WithName("id").WithDataType(FieldTypeInt64)).
+		WithField(NewField().WithName("value").WithDataType(FieldTypeDouble))
+
+	// Create a field with struct schema
+	field := NewField().
+		WithName("struct_array_field").
+		WithDataType(FieldTypeArray).
+		WithElementType(FieldTypeStruct).
+		WithStructSchema(structSchema)
+
+	assert.NotNil(t, field.StructSchema)
+	assert.Equal(t, 2, len(field.StructSchema.Fields))
+	assert.Equal(t, "id", field.StructSchema.Fields[0].Name)
+	assert.Equal(t, FieldTypeInt64, field.StructSchema.Fields[0].DataType)
+	assert.Equal(t, "value", field.StructSchema.Fields[1].Name)
+	assert.Equal(t, FieldTypeDouble, field.StructSchema.Fields[1].DataType)
+}

--- a/client/entity/schema_test.go
+++ b/client/entity/schema_test.go
@@ -89,6 +89,117 @@ func (s *SchemaSuite) TestBasic() {
 	}
 }
 
+func (s *SchemaSuite) TestStructArrayField() {
+	// Create a struct schema
+	structSchema := NewStructSchema().
+		WithField(NewField().WithName("age").WithDataType(FieldTypeInt32)).
+		WithField(NewField().WithName("name").WithDataType(FieldTypeVarChar).WithMaxLength(100)).
+		WithField(NewField().WithName("score").WithDataType(FieldTypeFloat))
+
+	// Create a schema with struct array field
+	schema := NewSchema().
+		WithName("test_struct_array_collection").
+		WithDescription("collection with struct array field").
+		WithAutoID(false).
+		WithField(NewField().WithName("ID").WithDataType(FieldTypeInt64).WithIsPrimaryKey(true)).
+		WithField(NewField().WithName("vector").WithDataType(FieldTypeFloatVector).WithDim(128)).
+		WithField(NewField().
+			WithName("person_data").
+			WithDataType(FieldTypeArray).
+			WithElementType(FieldTypeStruct).
+			WithStructSchema(structSchema))
+
+	// Convert to proto
+	p := schema.ProtoMessage()
+
+	// Verify basic schema properties
+	s.Equal("test_struct_array_collection", p.GetName())
+	s.Equal("collection with struct array field", p.GetDescription())
+	s.Equal(false, p.GetAutoID())
+
+	// Verify regular fields (should not include struct array field)
+	s.Equal(2, len(p.GetFields()))
+	s.Equal("ID", p.GetFields()[0].GetName())
+	s.Equal("vector", p.GetFields()[1].GetName())
+
+	// Verify struct array fields
+	s.Equal(1, len(p.GetStructArrayFields()))
+	structArrayField := p.GetStructArrayFields()[0]
+	s.Equal("person_data", structArrayField.GetName())
+	s.Equal(3, len(structArrayField.GetFields()))
+
+	// Verify struct array sub-fields
+	s.Equal("age", structArrayField.GetFields()[0].GetName())
+	s.Equal("name", structArrayField.GetFields()[1].GetName())
+	s.Equal("score", structArrayField.GetFields()[2].GetName())
+}
+
+func (s *SchemaSuite) TestStructArrayFieldWithVectorElement() {
+	// Create a struct schema with vector field
+	structSchema := NewStructSchema().
+		WithField(NewField().WithName("id").WithDataType(FieldTypeInt64)).
+		WithField(NewField().WithName("embedding").WithDataType(FieldTypeFloatVector).WithDim(256))
+
+	schema := NewSchema().
+		WithName("test_struct_with_vector").
+		WithAutoID(true).
+		WithField(NewField().WithName("pk").WithDataType(FieldTypeVarChar).WithMaxLength(100).WithIsPrimaryKey(true)).
+		WithField(NewField().
+			WithName("data").
+			WithDataType(FieldTypeArray).
+			WithElementType(FieldTypeStruct).
+			WithStructSchema(structSchema))
+
+	p := schema.ProtoMessage()
+
+	// Verify struct array field with vector element
+	s.Equal(1, len(p.GetStructArrayFields()))
+	structArrayField := p.GetStructArrayFields()[0]
+	s.Equal("data", structArrayField.GetName())
+	s.Equal(2, len(structArrayField.GetFields()))
+
+	// Verify that vector field is converted to ArrayOfVector
+	embeddingField := structArrayField.GetFields()[1]
+	s.Equal("embedding", embeddingField.GetName())
+	// The DataType should be changed to ArrayOfVector for vector types
+	s.NotEqual(FieldTypeFloatVector, embeddingField.GetDataType())
+}
+
+func (s *SchemaSuite) TestMultipleStructArrayFields() {
+	// Create multiple struct schemas
+	structSchema1 := NewStructSchema().
+		WithField(NewField().WithName("field1").WithDataType(FieldTypeInt32))
+
+	structSchema2 := NewStructSchema().
+		WithField(NewField().WithName("field2").WithDataType(FieldTypeVarChar).WithMaxLength(50)).
+		WithField(NewField().WithName("field3").WithDataType(FieldTypeDouble))
+
+	schema := NewSchema().
+		WithName("test_multiple_struct_arrays").
+		WithField(NewField().WithName("pk").WithDataType(FieldTypeInt64).WithIsPrimaryKey(true)).
+		WithField(NewField().
+			WithName("struct_array_1").
+			WithDataType(FieldTypeArray).
+			WithElementType(FieldTypeStruct).
+			WithStructSchema(structSchema1)).
+		WithField(NewField().
+			WithName("struct_array_2").
+			WithDataType(FieldTypeArray).
+			WithElementType(FieldTypeStruct).
+			WithStructSchema(structSchema2))
+
+	p := schema.ProtoMessage()
+
+	// Verify we have 2 struct array fields
+	s.Equal(2, len(p.GetStructArrayFields()))
+	s.Equal("struct_array_1", p.GetStructArrayFields()[0].GetName())
+	s.Equal("struct_array_2", p.GetStructArrayFields()[1].GetName())
+
+	// Verify each struct array has correct number of fields
+	s.Equal(1, len(p.GetStructArrayFields()[0].GetFields()))
+	s.Equal(2, len(p.GetStructArrayFields()[1].GetFields()))
+}
+
 func TestSchema(t *testing.T) {
 	suite.Run(t, new(SchemaSuite))
 }

--- a/client/milvusclient/iterator.go
+++ b/client/milvusclient/iterator.go
@@ -20,10 +20,13 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strconv"
+	"strings"
 
 	"github.com/cockroachdb/errors"
 	"google.golang.org/grpc"
 
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/milvus-io/milvus/client/v2/entity"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
@@ -210,4 +213,232 @@ func (c *Client) SearchIterator(ctx context.Context, option SearchIteratorOption
 	}
 
 	return newSearchIteratorV1(c)
+}
+
+// QueryIterator is the interface for query iterator.
+type QueryIterator interface {
+	// Next returns next batch of iterator
+	// when iterator reaches the end, return `io.EOF`.
+	Next(ctx context.Context) (ResultSet, error)
+}
+
+type queryIterator struct {
+	client *Client
+	option QueryIteratorOption
+	schema *entity.Schema
+
+	// pagination state
+	expr         string   // base expression from option
+	outputFields []string // override output fields(force include pk field)
+	pkField      *entity.Field
+	lastPK       any
+	batchSize    int
+	limit        int64
+
+	// cached results
+	cached ResultSet
+}
+
+// composeIteratorExpr builds the filter expression for pagination.
+// It combines the user's original expression with a PK range filter.
+func (it *queryIterator) composeIteratorExpr() string {
+	if it.lastPK == nil {
+		return it.expr
+	}
+
+	expr := strings.TrimSpace(it.expr)
+	pkName := it.pkField.Name
+
+	switch it.pkField.DataType {
+	case entity.FieldTypeInt64:
+		pkFilter := fmt.Sprintf("%s > %d", pkName, it.lastPK)
+		if len(expr) == 0 {
+			return pkFilter
+		}
+		return fmt.Sprintf("(%s) and %s", expr, pkFilter)
+	case entity.FieldTypeVarChar:
+		pkFilter := fmt.Sprintf(`%s > "%s"`, pkName, it.lastPK)
+		if len(expr) == 0 {
+			return pkFilter
+		}
+		return fmt.Sprintf(`(%s) and %s`, expr, pkFilter)
+	default:
+		return it.expr
+	}
+}
+
+// fetchNextBatch fetches the next batch of data from the server.
+func (it *queryIterator) fetchNextBatch(ctx context.Context) (ResultSet, error) {
+	req, err := it.option.Request()
+	if err != nil {
+		return ResultSet{}, err
+	}
+
+	// override expression and limit for pagination
+	req.Expr = it.composeIteratorExpr()
+	req.OutputFields = it.outputFields
+	req.QueryParams = append(req.QueryParams,
+		&commonpb.KeyValuePair{Key: spLimit, Value: strconv.Itoa(it.batchSize)},
+	)
+
+	var resultSet ResultSet
+	err = it.client.callService(func(milvusService milvuspb.MilvusServiceClient) error {
+		resp, err := milvusService.Query(ctx, req)
+		err = merr.CheckRPCCall(resp, err)
+		if err != nil {
+			return err
+		}
+
+		columns, err := it.client.parseSearchResult(it.schema, resp.GetOutputFields(), resp.GetFieldsData(), 0, 0, -1)
+		if err != nil {
+			return err
+		}
+		resultSet = ResultSet{
+			sch:    it.schema,
+			Fields: columns,
+		}
+		if len(columns) > 0 {
+			resultSet.ResultCount = columns[0].Len()
+		}
+
+		return nil
+	})
+
+	return resultSet, err
+}
+
+// cacheNextBatch returns the next batch and updates the cache.
+func (it *queryIterator) cacheNextBatch(rs ResultSet) (ResultSet, error) {
+	var result ResultSet
+	if rs.ResultCount > it.batchSize {
+		result = rs.Slice(0, it.batchSize)
+		it.cached = rs.Slice(it.batchSize, rs.ResultCount)
+	} else {
+		result = rs
+		it.cached = ResultSet{}
+	}
+
+	if result.ResultCount == 0 {
+		return ResultSet{}, io.EOF
+	}
+
+	// extract and update the last PK for pagination
+	pkColumn := result.GetColumn(it.pkField.Name)
+	if pkColumn == nil {
+		// try to find PK in Fields
+		for _, col := range result.Fields {
+			if col.Name() == it.pkField.Name {
+				pkColumn = col
+				break
+			}
+		}
+	}
+
+	if pkColumn != nil && pkColumn.Len() > 0 {
+		pk, err := pkColumn.Get(pkColumn.Len() - 1)
+		if err != nil {
+			return ResultSet{}, errors.Wrapf(err, "failed to get last pk value")
+		}
+		it.lastPK = pk
+	}
+
+	return result, nil
+}
+
+// Next returns the next batch of results.
+func (it *queryIterator) Next(ctx context.Context) (ResultSet, error) {
+	// limit reached, return EOF
+	if it.limit == 0 {
+		return ResultSet{}, io.EOF
+	}
+
+	// if cache is empty, fetch new data
+	if it.cached.ResultCount == 0 {
+		rs, err := it.fetchNextBatch(ctx)
+		if err != nil {
+			return ResultSet{}, err
+		}
+		it.cached = rs
+	}
+
+	// if still no data, return EOF
+	if it.cached.ResultCount == 0 {
+		return ResultSet{}, io.EOF
+	}
+
+	result, err := it.cacheNextBatch(it.cached)
+	if err != nil {
+		return ResultSet{}, err
+	}
+
+	// handle overall limit
+	if it.limit != Unlimited {
+		if int64(result.ResultCount) > it.limit {
+			result = result.Slice(0, int(it.limit))
+		}
+		it.limit -= int64(result.ResultCount)
+	}
+
+	return result, nil
+}
+
+// newQueryIterator creates a new query iterator.
+func newQueryIterator(ctx context.Context, client *Client, option QueryIteratorOption) (*queryIterator, error) {
+	req, err := option.Request()
+	if err != nil {
+		return nil, err
+	}
+
+	collection, err := client.getCollection(ctx, req.GetCollectionName())
+	if err != nil {
+		return nil, err
+	}
+
+	pkField := collection.Schema.PKField()
+	if pkField == nil {
+		return nil, errors.New("primary key field not found in schema")
+	}
+
+	// ensure PK field is included in output fields for pagination
+	outputFields := req.GetOutputFields()
+	hasPK := false
+	for _, f := range outputFields {
+		if f == pkField.Name {
+			hasPK = true
+			break
+		}
+	}
+	if !hasPK && len(outputFields) > 0 {
+		// modify the underlying option to include PK field
+		outputFields = append(outputFields, pkField.Name)
+	}
+
+	iter := &queryIterator{
+		client:       client,
+		option:       option,
+		schema:       collection.Schema,
+		expr:         req.GetExpr(),
+		outputFields: outputFields,
+		pkField:      pkField,
+		batchSize:    option.BatchSize(),
+		limit:        option.Limit(),
+	}
+
+	// init: fetch the first batch to validate parameters
+	rs, err := iter.fetchNextBatch(ctx)
+	if err != nil {
+		return nil, err
+	}
+	iter.cached = rs
+
+	return iter, nil
+}
+
+// QueryIterator creates a query iterator from a collection.
+func (c *Client) QueryIterator(ctx context.Context, option QueryIteratorOption, callOptions ...grpc.CallOption) (QueryIterator, error) {
+	if err := option.ValidateParams(); err != nil {
+		return nil, err
+	}
+
+	return newQueryIterator(ctx, c, option)
 }

--- a/tests/go_client/base/milvus_client.go
+++ b/tests/go_client/base/milvus_client.go
@@ -9,24 +9,20 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
-	"github.com/milvus-io/milvus/client/v2/entity"
 	client "github.com/milvus-io/milvus/client/v2/milvusclient"
 	"github.com/milvus-io/milvus/pkg/v2/log"
+	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
 
 func LoggingUnaryInterceptor() grpc.UnaryClientInterceptor {
 	// Limit debug logging for these methods
-	rateLogMethods := map[string]struct{}{
-		"GetFlushState":      {},
-		"GetLoadingProgress": {},
-		"DescribeIndex":      {},
-	}
+	ratedLogMethods := typeutil.NewSet("GetFlushState", "GetLoadingProgress", "DescribeIndex")
 
-	logWithRateLimit := func(_methodShortName string, logFunc func(msg string, fields ...zap.Field),
+	logWithRateLimit := func(methodShortName string, logFunc func(msg string, fields ...zap.Field),
 		logRateFunc func(cost float64, msg string, fields ...zap.Field) bool,
 		msg string, fields ...zap.Field,
 	) {
-		if _, exists := rateLogMethods[_methodShortName]; exists {
+		if ratedLogMethods.Contain(methodShortName) {
 			logRateFunc(10, msg, fields...)
 		} else {
 			logFunc(msg, fields...)
@@ -55,7 +51,7 @@ func LoggingUnaryInterceptor() grpc.UnaryClientInterceptor {
 		reqStr := marshalWithFallback(req, "could not marshal request")
 		logWithRateLimit(_methodShortName, log.Info, log.RatedInfo, "Request", zap.String("method", _methodShortName), zap.String("reqs", reqStr))
 
-		// Ike the actual method
+		// Invoke the actual method
 		start := time.Now()
 		errResp := invoker(ctx, method, req, reply, cc, opts...)
 		cost := time.Since(start)
@@ -70,403 +66,18 @@ func LoggingUnaryInterceptor() grpc.UnaryClientInterceptor {
 }
 
 type MilvusClient struct {
-	mClient *client.Client
+	*client.Client
 }
 
 func NewMilvusClient(ctx context.Context, cfg *client.ClientConfig) (*MilvusClient, error) {
 	cfg.DialOptions = append(cfg.DialOptions, grpc.WithUnaryInterceptor(LoggingUnaryInterceptor()))
 	mClient, err := client.New(ctx, cfg)
 	return &MilvusClient{
-		mClient,
+		Client: mClient,
 	}, err
 }
 
 func (mc *MilvusClient) Close(ctx context.Context) error {
-	err := mc.mClient.Close(ctx)
-	return err
-}
-
-// -- database --
-
-// UseDatabase list all database in milvus cluster.
-func (mc *MilvusClient) UseDatabase(ctx context.Context, option client.UseDatabaseOption) error {
-	err := mc.mClient.UseDatabase(ctx, option)
-	return err
-}
-
-// ListDatabase list all database in milvus cluster.
-func (mc *MilvusClient) ListDatabase(ctx context.Context, option client.ListDatabaseOption, callOptions ...grpc.CallOption) ([]string, error) {
-	databaseNames, err := mc.mClient.ListDatabase(ctx, option, callOptions...)
-	return databaseNames, err
-}
-
-// CreateDatabase create database with the given name.
-func (mc *MilvusClient) CreateDatabase(ctx context.Context, option client.CreateDatabaseOption, callOptions ...grpc.CallOption) error {
-	err := mc.mClient.CreateDatabase(ctx, option, callOptions...)
-	return err
-}
-
-// DropDatabase drop database with the given db name.
-func (mc *MilvusClient) DropDatabase(ctx context.Context, option client.DropDatabaseOption, callOptions ...grpc.CallOption) error {
-	err := mc.mClient.DropDatabase(ctx, option, callOptions...)
-	return err
-}
-
-// DescribeDatabase describe database with the given db name.
-func (mc *MilvusClient) DescribeDatabase(ctx context.Context, option client.DescribeDatabaseOption, callOptions ...grpc.CallOption) (*entity.Database, error) {
-	database, err := mc.mClient.DescribeDatabase(ctx, option, callOptions...)
-	return database, err
-}
-
-// AlterDatabaseProperties alter database properties
-func (mc *MilvusClient) AlterDatabaseProperties(ctx context.Context, option client.AlterDatabasePropertiesOption, callOptions ...grpc.CallOption) error {
-	err := mc.mClient.AlterDatabaseProperties(ctx, option, callOptions...)
-	return err
-}
-
-// DropDatabaseProperties drop database properties
-func (mc *MilvusClient) DropDatabaseProperties(ctx context.Context, option client.DropDatabasePropertiesOption, callOptions ...grpc.CallOption) error {
-	err := mc.mClient.AlterDatabaseProperties(ctx, option, callOptions...)
-	return err
-}
-
-// -- collection --
-
-// CreateCollection Create Collection
-func (mc *MilvusClient) CreateCollection(ctx context.Context, option client.CreateCollectionOption, callOptions ...grpc.CallOption) error {
-	err := mc.mClient.CreateCollection(ctx, option, callOptions...)
-	return err
-}
-
-// ListCollections Create Collection
-func (mc *MilvusClient) ListCollections(ctx context.Context, option client.ListCollectionOption, callOptions ...grpc.CallOption) ([]string, error) {
-	collectionNames, err := mc.mClient.ListCollections(ctx, option, callOptions...)
-	return collectionNames, err
-}
-
-// DescribeCollection Describe collection
-func (mc *MilvusClient) DescribeCollection(ctx context.Context, option client.DescribeCollectionOption, callOptions ...grpc.CallOption) (*entity.Collection, error) {
-	collection, err := mc.mClient.DescribeCollection(ctx, option, callOptions...)
-	return collection, err
-}
-
-// HasCollection Has collection
-func (mc *MilvusClient) HasCollection(ctx context.Context, option client.HasCollectionOption, callOptions ...grpc.CallOption) (bool, error) {
-	has, err := mc.mClient.HasCollection(ctx, option, callOptions...)
-	return has, err
-}
-
-// DropCollection Drop Collection
-func (mc *MilvusClient) DropCollection(ctx context.Context, option client.DropCollectionOption, callOptions ...grpc.CallOption) error {
-	err := mc.mClient.DropCollection(ctx, option, callOptions...)
-	return err
-}
-
-// RenameCollection Rename Collection
-func (mc *MilvusClient) RenameCollection(ctx context.Context, option client.RenameCollectionOption, callOptions ...grpc.CallOption) error {
-	err := mc.mClient.RenameCollection(ctx, option, callOptions...)
-	return err
-}
-
-// AlterCollectionProperties Alter collection properties
-func (mc *MilvusClient) AlterCollectionProperties(ctx context.Context, option client.AlterCollectionPropertiesOption, callOptions ...grpc.CallOption) error {
-	err := mc.mClient.AlterCollectionProperties(ctx, option, callOptions...)
-	return err
-}
-
-// DropCollectionProperties Drop collection properties
-func (mc *MilvusClient) DropCollectionProperties(ctx context.Context, option client.DropCollectionPropertiesOption, callOptions ...grpc.CallOption) error {
-	err := mc.mClient.DropCollectionProperties(ctx, option, callOptions...)
-	return err
-}
-
-// AlterCollectionField Alter collection field
-func (mc *MilvusClient) AlterCollectionField(ctx context.Context, option client.AlterCollectionFieldPropertiesOption, callOptions ...grpc.CallOption) error {
-	err := mc.mClient.AlterCollectionFieldProperty(ctx, option, callOptions...)
-	return err
-}
-
-// GetCollectionStats Get collection stats
-func (mc *MilvusClient) GetCollectionStats(ctx context.Context, option client.GetCollectionOption) (map[string]string, error) {
-	stats, err := mc.mClient.GetCollectionStats(ctx, option)
-	return stats, err
-}
-
-// -- partition --
-
-// CreatePartition Create Partition
-func (mc *MilvusClient) CreatePartition(ctx context.Context, option client.CreatePartitionOption, callOptions ...grpc.CallOption) error {
-	err := mc.mClient.CreatePartition(ctx, option, callOptions...)
-	return err
-}
-
-// DropPartition Drop Partition
-func (mc *MilvusClient) DropPartition(ctx context.Context, option client.DropPartitionOption, callOptions ...grpc.CallOption) error {
-	err := mc.mClient.DropPartition(ctx, option, callOptions...)
-	return err
-}
-
-// HasPartition Has Partition
-func (mc *MilvusClient) HasPartition(ctx context.Context, option client.HasPartitionOption, callOptions ...grpc.CallOption) (bool, error) {
-	has, err := mc.mClient.HasPartition(ctx, option, callOptions...)
-	return has, err
-}
-
-// ListPartitions List Partitions
-func (mc *MilvusClient) ListPartitions(ctx context.Context, option client.ListPartitionsOption, callOptions ...grpc.CallOption) ([]string, error) {
-	partitionNames, err := mc.mClient.ListPartitions(ctx, option, callOptions...)
-	return partitionNames, err
-}
-
-// LoadPartitions Load Partitions into memory
-func (mc *MilvusClient) LoadPartitions(ctx context.Context, option client.LoadPartitionsOption, callOptions ...grpc.CallOption) (client.LoadTask, error) {
-	loadTask, err := mc.mClient.LoadPartitions(ctx, option, callOptions...)
-	return loadTask, err
-}
-
-// ReleasePartitions Release Partitions from memory
-func (mc *MilvusClient) ReleasePartitions(ctx context.Context, option client.ReleasePartitionsOption, callOptions ...grpc.CallOption) error {
-	err := mc.mClient.ReleasePartitions(ctx, option, callOptions...)
-	return err
-}
-
-// -- index --
-
-// CreateIndex Create Index
-func (mc *MilvusClient) CreateIndex(ctx context.Context, option client.CreateIndexOption, callOptions ...grpc.CallOption) (*client.CreateIndexTask, error) {
-	createIndexTask, err := mc.mClient.CreateIndex(ctx, option, callOptions...)
-	return createIndexTask, err
-}
-
-// ListIndexes List Indexes
-func (mc *MilvusClient) ListIndexes(ctx context.Context, option client.ListIndexOption, callOptions ...grpc.CallOption) ([]string, error) {
-	indexes, err := mc.mClient.ListIndexes(ctx, option, callOptions...)
-	return indexes, err
-}
-
-// DescribeIndex Describe Index
-func (mc *MilvusClient) DescribeIndex(ctx context.Context, option client.DescribeIndexOption, callOptions ...grpc.CallOption) (client.IndexDescription, error) {
-	idxDesc, err := mc.mClient.DescribeIndex(ctx, option, callOptions...)
-	return idxDesc, err
-}
-
-// DropIndex Drop Index
-func (mc *MilvusClient) DropIndex(ctx context.Context, option client.DropIndexOption, callOptions ...grpc.CallOption) error {
-	err := mc.mClient.DropIndex(ctx, option, callOptions...)
-	return err
-}
-
-// -- write --
-
-// Insert insert data
-func (mc *MilvusClient) Insert(ctx context.Context, option client.InsertOption, callOptions ...grpc.CallOption) (client.InsertResult, error) {
-	insertRes, err := mc.mClient.Insert(ctx, option, callOptions...)
-	if err == nil {
-		log.Info("Insert", zap.Any("result", insertRes))
-	}
-	return insertRes, err
-}
-
-// Flush flush data
-func (mc *MilvusClient) Flush(ctx context.Context, option client.FlushOption, callOptions ...grpc.CallOption) (*client.FlushTask, error) {
-	flushTask, err := mc.mClient.Flush(ctx, option, callOptions...)
-	return flushTask, err
-}
-
-// Delete deletes data
-func (mc *MilvusClient) Delete(ctx context.Context, option client.DeleteOption, callOptions ...grpc.CallOption) (client.DeleteResult, error) {
-	deleteRes, err := mc.mClient.Delete(ctx, option, callOptions...)
-	return deleteRes, err
-}
-
-// Upsert upsert data
-func (mc *MilvusClient) Upsert(ctx context.Context, option client.UpsertOption, callOptions ...grpc.CallOption) (client.UpsertResult, error) {
-	upsertRes, err := mc.mClient.Upsert(ctx, option, callOptions...)
-	return upsertRes, err
-}
-
-// -- read --
-
-// LoadCollection Load Collection
-func (mc *MilvusClient) LoadCollection(ctx context.Context, option client.LoadCollectionOption, callOptions ...grpc.CallOption) (client.LoadTask, error) {
-	loadTask, err := mc.mClient.LoadCollection(ctx, option, callOptions...)
-	return loadTask, err
-}
-
-// ReleaseCollection Release Collection
-func (mc *MilvusClient) ReleaseCollection(ctx context.Context, option client.ReleaseCollectionOption, callOptions ...grpc.CallOption) error {
-	err := mc.mClient.ReleaseCollection(ctx, option, callOptions...)
-	return err
-}
-
-// Search search from collection
-func (mc *MilvusClient) Search(ctx context.Context, option client.SearchOption, callOptions ...grpc.CallOption) ([]client.ResultSet, error) {
-	resultSets, err := mc.mClient.Search(ctx, option, callOptions...)
-	return resultSets, err
-}
-
-// Query query from collection
-func (mc *MilvusClient) Query(ctx context.Context, option client.QueryOption, callOptions ...grpc.CallOption) (client.ResultSet, error) {
-	resultSet, err := mc.mClient.Query(ctx, option, callOptions...)
-	return resultSet, err
-}
-
-// Get get from collection
-func (mc *MilvusClient) Get(ctx context.Context, option client.QueryOption, callOptions ...grpc.CallOption) (client.ResultSet, error) {
-	resultSet, err := mc.mClient.Get(ctx, option, callOptions...)
-	return resultSet, err
-}
-
-// HybridSearch hybrid search from collection
-func (mc *MilvusClient) HybridSearch(ctx context.Context, option client.HybridSearchOption, callOptions ...grpc.CallOption) ([]client.ResultSet, error) {
-	resultSets, err := mc.mClient.HybridSearch(ctx, option, callOptions...)
-	return resultSets, err
-}
-
-func (mc *MilvusClient) SearchIterator(ctx context.Context, option client.SearchIteratorOption, callOptions ...grpc.CallOption) (client.SearchIterator, error) {
-	searchIterator, err := mc.mClient.SearchIterator(ctx, option, callOptions...)
-	return searchIterator, err
-}
-
-// ListResourceGroups list all resource groups
-func (mc *MilvusClient) ListResourceGroups(ctx context.Context, option client.ListResourceGroupsOption, callOptions ...grpc.CallOption) ([]string, error) {
-	resourceGroups, err := mc.mClient.ListResourceGroups(ctx, option, callOptions...)
-	return resourceGroups, err
-}
-
-// CreateResourceGroup create resource group
-func (mc *MilvusClient) CreateResourceGroup(ctx context.Context, option client.CreateResourceGroupOption, callOptions ...grpc.CallOption) error {
-	err := mc.mClient.CreateResourceGroup(ctx, option, callOptions...)
-	return err
-}
-
-// DropResourceGroup drop resource group
-func (mc *MilvusClient) DropResourceGroup(ctx context.Context, option client.DropResourceGroupOption, callOptions ...grpc.CallOption) error {
-	err := mc.mClient.DropResourceGroup(ctx, option, callOptions...)
-	return err
-}
-
-// DescribeResourceGroup describe resource group
-func (mc *MilvusClient) DescribeResourceGroup(ctx context.Context, option client.DescribeResourceGroupOption, callOptions ...grpc.CallOption) (*entity.ResourceGroup, error) {
-	resourceGroup, err := mc.mClient.DescribeResourceGroup(ctx, option, callOptions...)
-	return resourceGroup, err
-}
-
-// UpdateResourceGroup update resource group
-func (mc *MilvusClient) UpdateResourceGroup(ctx context.Context, option client.UpdateResourceGroupOption, callOptions ...grpc.CallOption) error {
-	err := mc.mClient.UpdateResourceGroup(ctx, option, callOptions...)
-	return err
-}
-
-// TransferReplica transfer replica
-func (mc *MilvusClient) TransferReplica(ctx context.Context, option client.TransferReplicaOption, callOptions ...grpc.CallOption) error {
-	err := mc.mClient.TransferReplica(ctx, option, callOptions...)
-	return err
-}
-
-func (mc *MilvusClient) CreateUser(ctx context.Context, option client.CreateUserOption, callOptions ...grpc.CallOption) error {
-	err := mc.mClient.CreateUser(ctx, option, callOptions...)
-	return err
-}
-
-func (mc *MilvusClient) UpdatePassword(ctx context.Context, option client.UpdatePasswordOption, callOptions ...grpc.CallOption) error {
-	err := mc.mClient.UpdatePassword(ctx, option, callOptions...)
-	return err
-}
-
-func (mc *MilvusClient) DropUser(ctx context.Context, option client.DropUserOption, callOptions ...grpc.CallOption) error {
-	err := mc.mClient.DropUser(ctx, option, callOptions...)
-	return err
-}
-
-func (mc *MilvusClient) ListUsers(ctx context.Context, option client.ListUserOption, callOptions ...grpc.CallOption) ([]string, error) {
-	users, err := mc.mClient.ListUsers(ctx, option, callOptions...)
-	return users, err
-}
-
-func (mc *MilvusClient) DescribeUser(ctx context.Context, option client.DescribeUserOption, callOptions ...grpc.CallOption) (*entity.User, error) {
-	user, err := mc.mClient.DescribeUser(ctx, option, callOptions...)
-	return user, err
-}
-
-func (mc *MilvusClient) ListRoles(ctx context.Context, option client.ListRoleOption, callOptions ...grpc.CallOption) ([]string, error) {
-	roles, err := mc.mClient.ListRoles(ctx, option, callOptions...)
-	return roles, err
-}
-
-func (mc *MilvusClient) CreateRole(ctx context.Context, option client.CreateRoleOption, callOptions ...grpc.CallOption) error {
-	err := mc.mClient.CreateRole(ctx, option, callOptions...)
-	return err
-}
-
-func (mc *MilvusClient) GrantRole(ctx context.Context, option client.GrantRoleOption, callOptions ...grpc.CallOption) error {
-	err := mc.mClient.GrantRole(ctx, option, callOptions...)
-	return err
-}
-
-func (mc *MilvusClient) RevokeRole(ctx context.Context, option client.RevokeRoleOption, callOptions ...grpc.CallOption) error {
-	err := mc.mClient.RevokeRole(ctx, option, callOptions...)
-	return err
-}
-
-func (mc *MilvusClient) DropRole(ctx context.Context, option client.DropRoleOption, callOptions ...grpc.CallOption) error {
-	err := mc.mClient.DropRole(ctx, option, callOptions...)
-	return err
-}
-
-func (mc *MilvusClient) DescribeRole(ctx context.Context, option client.DescribeRoleOption, callOptions ...grpc.CallOption) (*entity.Role, error) {
-	role, err := mc.mClient.DescribeRole(ctx, option, callOptions...)
-	return role, err
-}
-
-func (mc *MilvusClient) GrantPrivilege(ctx context.Context, option client.GrantPrivilegeOption, callOptions ...grpc.CallOption) error {
-	err := mc.mClient.GrantPrivilege(ctx, option, callOptions...)
-	return err
-}
-
-func (mc *MilvusClient) RevokePrivilege(ctx context.Context, option client.RevokePrivilegeOption, callOptions ...grpc.CallOption) error {
-	err := mc.mClient.RevokePrivilege(ctx, option, callOptions...)
-	return err
-}
-
-func (mc *MilvusClient) GrantPrivilegeV2(ctx context.Context, option client.GrantPrivilegeV2Option, callOptions ...grpc.CallOption) error {
-	err := mc.mClient.GrantPrivilegeV2(ctx, option, callOptions...)
-	return err
-}
-
-func (mc *MilvusClient) RevokePrivilegeV2(ctx context.Context, option client.RevokePrivilegeV2Option, callOptions ...grpc.CallOption) error {
-	err := mc.mClient.RevokePrivilegeV2(ctx, option, callOptions...)
-	return err
-}
-
-func (mc *MilvusClient) CreatePrivilegeGroup(ctx context.Context, option client.CreatePrivilegeGroupOption, callOptions ...grpc.CallOption) error {
-	err := mc.mClient.CreatePrivilegeGroup(ctx, option, callOptions...)
-	return err
-}
-
-func (mc *MilvusClient) DropPrivilegeGroup(ctx context.Context, option client.DropPrivilegeGroupOption, callOptions ...grpc.CallOption) error {
-	err := mc.mClient.DropPrivilegeGroup(ctx, option, callOptions...)
-	return err
-}
-
-func (mc *MilvusClient) ListPrivilegeGroups(ctx context.Context, option client.ListPrivilegeGroupsOption, callOptions ...grpc.CallOption) ([]*entity.PrivilegeGroup, error) {
-	privilegeGroups, err := mc.mClient.ListPrivilegeGroups(ctx, option, callOptions...)
-	return privilegeGroups, err
-}
-
-func (mc *MilvusClient) OperatePrivilegeGroup(ctx context.Context, option client.OperatePrivilegeGroupOption, callOptions ...grpc.CallOption) error {
-	err := mc.mClient.OperatePrivilegeGroup(ctx, option, callOptions...)
-	return err
-}
-
-// RunAnalyzer run analyzer with params
-func (mc *MilvusClient) RunAnalyzer(ctx context.Context, option client.RunAnalyzerOption, callOptions ...grpc.CallOption) ([]*entity.AnalyzerResult, error) {
-	tokenSets, err := mc.mClient.RunAnalyzer(ctx, option, callOptions...)
-	return tokenSets, err
-}
-
-// AddCollectionField Add collection field
-func (mc *MilvusClient) AddCollectionField(ctx context.Context, option client.AddCollectionFieldOption, callOptions ...grpc.CallOption) error {
-	err := mc.mClient.AddCollectionField(ctx, option, callOptions...)
+	err := mc.Client.Close(ctx)
 	return err
 }

--- a/tests/go_client/testcases/query_iterator_test.go
+++ b/tests/go_client/testcases/query_iterator_test.go
@@ -1,0 +1,425 @@
+package testcases
+
+import (
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/milvus-io/milvus/client/v2/entity"
+	client "github.com/milvus-io/milvus/client/v2/milvusclient"
+	"github.com/milvus-io/milvus/pkg/v2/log"
+	"github.com/milvus-io/milvus/tests/go_client/common"
+	hp "github.com/milvus-io/milvus/tests/go_client/testcases/helper"
+)
+
+// TestQueryIteratorDefault tests query iterator with default parameters
+func TestQueryIteratorDefault(t *testing.T) {
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	// create -> insert -> flush -> index -> load
+	prepare, schema := hp.CollPrepare.CreateCollection(ctx, t, mc, hp.NewCreateCollectionParams(hp.Int64Vec), hp.TNewFieldsOption(), hp.TNewSchemaOption().TWithEnableDynamicField(true),
+		hp.TWithConsistencyLevel(entity.ClStrong))
+	prepare.InsertData(ctx, t, mc, hp.NewInsertParams(schema), hp.TNewDataOption().TWithNb(common.DefaultNb))
+	prepare.InsertData(ctx, t, mc, hp.NewInsertParams(schema), hp.TNewDataOption().TWithNb(common.DefaultNb*2).TWithStart(common.DefaultNb))
+	prepare.FlushData(ctx, t, mc, schema.CollectionName)
+	prepare.CreateIndex(ctx, t, mc, hp.TNewIndexParams(schema))
+	prepare.Load(ctx, t, mc, hp.NewLoadParams(schema.CollectionName))
+
+	// query iterator with default batch
+	itr, err := mc.QueryIterator(ctx, client.NewQueryIteratorOption(schema.CollectionName))
+	common.CheckErr(t, err, true)
+	common.CheckQueryIteratorResult(ctx, t, itr, common.DefaultNb*3, common.WithExpBatchSize(hp.GenBatchSizes(common.DefaultNb*3, common.DefaultBatchSize)))
+}
+
+// TestQueryIteratorHitEmpty tests query iterator on empty collection
+func TestQueryIteratorHitEmpty(t *testing.T) {
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	// create -> index -> load (no data inserted)
+	prepare, schema := hp.CollPrepare.CreateCollection(ctx, t, mc, hp.NewCreateCollectionParams(hp.Int64Vec), hp.TNewFieldsOption(), hp.TNewSchemaOption().TWithEnableDynamicField(true),
+		hp.TWithConsistencyLevel(entity.ClStrong))
+	prepare.CreateIndex(ctx, t, mc, hp.TNewIndexParams(schema))
+	prepare.Load(ctx, t, mc, hp.NewLoadParams(schema.CollectionName))
+
+	// query iterator with default batch
+	itr, err := mc.QueryIterator(ctx, client.NewQueryIteratorOption(schema.CollectionName))
+	common.CheckErr(t, err, true)
+	rs, err := itr.Next(ctx)
+	require.Empty(t, rs.Fields)
+	require.ErrorIs(t, err, io.EOF)
+	common.CheckQueryIteratorResult(ctx, t, itr, 0, common.WithExpBatchSize(hp.GenBatchSizes(0, common.DefaultBatchSize)))
+}
+
+// TestQueryIteratorBatchSize tests query iterator with different batch sizes
+func TestQueryIteratorBatchSize(t *testing.T) {
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	// create -> insert -> flush -> index -> load
+	nb := 201
+	prepare, schema := hp.CollPrepare.CreateCollection(ctx, t, mc, hp.NewCreateCollectionParams(hp.Int64Vec), hp.TNewFieldsOption(), hp.TNewSchemaOption().TWithEnableDynamicField(true),
+		hp.TWithConsistencyLevel(entity.ClStrong))
+	prepare.InsertData(ctx, t, mc, hp.NewInsertParams(schema), hp.TNewDataOption().TWithNb(nb))
+	prepare.FlushData(ctx, t, mc, schema.CollectionName)
+	prepare.CreateIndex(ctx, t, mc, hp.TNewIndexParams(schema))
+	prepare.Load(ctx, t, mc, hp.NewLoadParams(schema.CollectionName))
+
+	type batchStruct struct {
+		batch        int
+		expBatchSize []int
+	}
+	batchStructs := []batchStruct{
+		{batch: nb / 2, expBatchSize: hp.GenBatchSizes(nb, nb/2)},
+		{batch: nb, expBatchSize: hp.GenBatchSizes(nb, nb)},
+		{batch: nb + 1, expBatchSize: hp.GenBatchSizes(nb, nb+1)},
+	}
+
+	for _, _batchStruct := range batchStructs {
+		// query iterator with different batch sizes
+		itr, err := mc.QueryIterator(ctx, client.NewQueryIteratorOption(schema.CollectionName).WithBatchSize(_batchStruct.batch))
+		common.CheckErr(t, err, true)
+		common.CheckQueryIteratorResult(ctx, t, itr, nb, common.WithExpBatchSize(_batchStruct.expBatchSize))
+	}
+}
+
+// TestQueryIteratorOutputAllFields tests query iterator with all fields output
+func TestQueryIteratorOutputAllFields(t *testing.T) {
+	t.Parallel()
+	for _, dynamic := range [2]bool{false, true} {
+		ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+		mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+		prepare, schema := hp.CollPrepare.CreateCollection(ctx, t, mc, hp.NewCreateCollectionParams(hp.AllFields), hp.TNewFieldsOption(),
+			hp.TNewSchemaOption().TWithEnableDynamicField(dynamic), hp.TWithConsistencyLevel(entity.ClStrong))
+		prepare.InsertData(ctx, t, mc, hp.NewInsertParams(schema), hp.TNewDataOption())
+		prepare.FlushData(ctx, t, mc, schema.CollectionName)
+		prepare.CreateIndex(ctx, t, mc, hp.TNewIndexParams(schema))
+		prepare.Load(ctx, t, mc, hp.NewLoadParams(schema.CollectionName))
+
+		var allFieldsName []string
+		for _, field := range schema.Fields {
+			allFieldsName = append(allFieldsName, field.Name)
+		}
+		if dynamic {
+			allFieldsName = append(allFieldsName, common.DefaultDynamicFieldName)
+		}
+
+		// output * fields
+		nbFilter := 1001
+		batch := 500
+		expr := fmt.Sprintf("%s < %d", common.DefaultInt64FieldName, nbFilter)
+
+		itr, err := mc.QueryIterator(ctx, client.NewQueryIteratorOption(schema.CollectionName).WithBatchSize(batch).WithOutputFields("*").WithFilter(expr))
+		common.CheckErr(t, err, true)
+		common.CheckQueryIteratorResult(ctx, t, itr, nbFilter, common.WithExpBatchSize(hp.GenBatchSizes(nbFilter, batch)), common.WithExpOutputFields(allFieldsName))
+	}
+}
+
+// TestQueryIteratorSparseVecFields tests query iterator with sparse vector fields
+func TestQueryIteratorSparseVecFields(t *testing.T) {
+	t.Parallel()
+	for _, withRows := range [2]bool{true, false} {
+		ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+		mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+		prepare, schema := hp.CollPrepare.CreateCollection(ctx, t, mc, hp.NewCreateCollectionParams(hp.Int64VarcharSparseVec), hp.TNewFieldsOption(),
+			hp.TNewSchemaOption().TWithEnableDynamicField(true), hp.TWithConsistencyLevel(entity.ClStrong))
+		prepare.InsertData(ctx, t, mc, hp.NewInsertParams(schema).TWithIsRows(withRows), hp.TNewDataOption())
+		prepare.FlushData(ctx, t, mc, schema.CollectionName)
+		prepare.CreateIndex(ctx, t, mc, hp.TNewIndexParams(schema))
+		prepare.Load(ctx, t, mc, hp.NewLoadParams(schema.CollectionName))
+
+		fieldsName := []string{common.DefaultDynamicFieldName}
+		for _, field := range schema.Fields {
+			fieldsName = append(fieldsName, field.Name)
+		}
+
+		// output * fields
+		itr, err := mc.QueryIterator(ctx, client.NewQueryIteratorOption(schema.CollectionName).WithBatchSize(400).WithOutputFields("*"))
+		common.CheckErr(t, err, true)
+		common.CheckQueryIteratorResult(ctx, t, itr, common.DefaultNb, common.WithExpBatchSize(hp.GenBatchSizes(common.DefaultNb, 400)), common.WithExpOutputFields(fieldsName))
+	}
+}
+
+// TestQueryIteratorInvalid tests query iterator with invalid parameters
+func TestQueryIteratorInvalid(t *testing.T) {
+	nb := 201
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	// create -> insert -> flush -> index -> load
+	prepare, schema := hp.CollPrepare.CreateCollection(ctx, t, mc, hp.NewCreateCollectionParams(hp.Int64Vec), hp.TNewFieldsOption(), hp.TNewSchemaOption(),
+		hp.TWithConsistencyLevel(entity.ClStrong))
+	prepare.InsertData(ctx, t, mc, hp.NewInsertParams(schema), hp.TNewDataOption().TWithNb(nb))
+	prepare.FlushData(ctx, t, mc, schema.CollectionName)
+	prepare.CreateIndex(ctx, t, mc, hp.TNewIndexParams(schema))
+	prepare.Load(ctx, t, mc, hp.NewLoadParams(schema.CollectionName))
+
+	// query iterator with not exist collection name
+	_, err := mc.QueryIterator(ctx, client.NewQueryIteratorOption(common.GenRandomString("c", 5)))
+	common.CheckErr(t, err, false, "collection not found", "can't find collection")
+
+	// query iterator with not exist partition name
+	_, errPar := mc.QueryIterator(ctx, client.NewQueryIteratorOption(schema.CollectionName).WithPartitions(common.GenRandomString("p", 5)))
+	common.CheckErr(t, errPar, false, "partition name", "not found")
+
+	// query iterator with not exist partition name
+	_, errPar = mc.QueryIterator(ctx, client.NewQueryIteratorOption(schema.CollectionName).WithPartitions(common.GenRandomString("p", 5), common.DefaultPartition))
+	common.CheckErr(t, errPar, false, "partition name", "not found")
+
+	// query iterator with count(*)
+	_, errOutput := mc.QueryIterator(ctx, client.NewQueryIteratorOption(schema.CollectionName).WithOutputFields(common.QueryCountFieldName))
+	common.CheckErr(t, errOutput, false, "count entities with pagination is not allowed", "count(*)")
+
+	// query iterator with invalid batch size
+	for _, batch := range []int{-1, 0} {
+		_, err := mc.QueryIterator(ctx, client.NewQueryIteratorOption(schema.CollectionName).WithBatchSize(batch))
+		common.CheckErr(t, err, false, "batch size", "must be greater than 0", "cannot less than 1")
+	}
+}
+
+// TestQueryIteratorInvalidExpr tests query iterator with invalid expressions
+func TestQueryIteratorInvalidExpr(t *testing.T) {
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	// create -> insert -> flush -> index -> load
+	prepare, schema := hp.CollPrepare.CreateCollection(ctx, t, mc, hp.NewCreateCollectionParams(hp.Int64VecJSON), hp.TNewFieldsOption(), hp.TNewSchemaOption().TWithEnableDynamicField(true),
+		hp.TWithConsistencyLevel(entity.ClStrong))
+	prepare.InsertData(ctx, t, mc, hp.NewInsertParams(schema), hp.TNewDataOption().TWithNb(common.DefaultNb))
+	prepare.FlushData(ctx, t, mc, schema.CollectionName)
+	prepare.CreateIndex(ctx, t, mc, hp.TNewIndexParams(schema))
+	prepare.Load(ctx, t, mc, hp.NewLoadParams(schema.CollectionName))
+
+	for _, _invalidExprs := range common.InvalidExpressions {
+		t.Log(_invalidExprs)
+		_, err := mc.QueryIterator(ctx, client.NewQueryIteratorOption(schema.CollectionName).WithFilter(_invalidExprs.Expr))
+		common.CheckErr(t, err, _invalidExprs.ErrNil, _invalidExprs.ErrMsg, "")
+	}
+}
+
+// TestQueryIteratorOutputFieldDynamic tests query iterator with non-existed field when dynamic enabled or not
+func TestQueryIteratorOutputFieldDynamic(t *testing.T) {
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+	nb := 201
+
+	for _, dynamic := range [2]bool{true, false} {
+		// create -> insert -> flush -> index -> load
+		prepare, schema := hp.CollPrepare.CreateCollection(ctx, t, mc, hp.NewCreateCollectionParams(hp.Int64Vec), hp.TNewFieldsOption(),
+			hp.TNewSchemaOption().TWithEnableDynamicField(dynamic), hp.TWithConsistencyLevel(entity.ClStrong))
+		prepare.InsertData(ctx, t, mc, hp.NewInsertParams(schema), hp.TNewDataOption().TWithNb(nb))
+		prepare.FlushData(ctx, t, mc, schema.CollectionName)
+		prepare.CreateIndex(ctx, t, mc, hp.TNewIndexParams(schema))
+		prepare.Load(ctx, t, mc, hp.NewLoadParams(schema.CollectionName))
+
+		// query iterator with not existed output fields: if dynamic, non-existent field are equivalent to dynamic field
+		itr, errOutput := mc.QueryIterator(ctx, client.NewQueryIteratorOption(schema.CollectionName).WithOutputFields("aaa"))
+		if dynamic {
+			common.CheckErr(t, errOutput, true)
+			expFields := []string{common.DefaultInt64FieldName, "aaa"}
+			common.CheckQueryIteratorResult(ctx, t, itr, nb, common.WithExpBatchSize(hp.GenBatchSizes(nb, common.DefaultBatchSize)), common.WithExpOutputFields(expFields))
+		} else {
+			common.CheckErr(t, errOutput, false, "field aaa not exist", "field not exist")
+		}
+	}
+}
+
+// TestQueryIteratorExpr tests query iterator with various expressions
+func TestQueryIteratorExpr(t *testing.T) {
+	type exprCount struct {
+		expr  string
+		count int
+	}
+	capacity := common.TestCapacity
+	exprLimits := []exprCount{
+		{expr: fmt.Sprintf("%s in [0, 1, 2]", common.DefaultInt64FieldName), count: 3},
+		{expr: fmt.Sprintf("%s >= 1000 || %s > 2000", common.DefaultInt64FieldName, common.DefaultInt64FieldName), count: 2000},
+		{expr: fmt.Sprintf("%s >= 1000 and %s < 2000", common.DefaultInt64FieldName, common.DefaultInt64FieldName), count: 1000},
+
+		// json and dynamic field filter expr: == < in bool/ list/ int
+		// {expr: fmt.Sprintf("%s['number'] == 0", common.DefaultJSONFieldName), count: 1500},
+		// {expr: fmt.Sprintf("%s['number'] < 100 and %s['number'] != 0", common.DefaultJSONFieldName, common.DefaultJSONFieldName), count: 99},
+		{expr: fmt.Sprintf("%s < 100", common.DefaultDynamicNumberField), count: 100},
+		{expr: "dynamicNumber % 2 == 0", count: 1500},
+		{expr: fmt.Sprintf("%s == false", common.DefaultDynamicBoolField), count: 1500},
+		{expr: fmt.Sprintf("%s in ['1', '2'] ", common.DefaultDynamicStringField), count: 2},
+		{expr: fmt.Sprintf("%s['string'] in ['1', '2', '5'] ", common.DefaultJSONFieldName), count: 3},
+		{expr: fmt.Sprintf("%s['list'] == [1, 2] ", common.DefaultJSONFieldName), count: 1},
+		{expr: fmt.Sprintf("%s['list'][0] < 10 ", common.DefaultJSONFieldName), count: 10},
+		{expr: fmt.Sprintf("%s[\"dynamicList\"] != [2, 3]", common.DefaultDynamicFieldName), count: 0},
+
+		// json contains
+		{expr: fmt.Sprintf("json_contains (%s['list'], 2)", common.DefaultJSONFieldName), count: 1},
+		{expr: fmt.Sprintf("json_contains (%s['number'], 0)", common.DefaultJSONFieldName), count: 0},
+		{expr: fmt.Sprintf("JSON_CONTAINS_ANY (%s['list'], [1, 3])", common.DefaultJSONFieldName), count: 2},
+		// string like
+		{expr: "dynamicString like '1%' ", count: 1111},
+
+		// key exist
+		{expr: fmt.Sprintf("exists %s['list']", common.DefaultJSONFieldName), count: common.DefaultNb},
+		{expr: "exists a ", count: 0},
+		{expr: fmt.Sprintf("exists %s ", common.DefaultDynamicStringField), count: common.DefaultNb},
+
+		// data type not match and no error
+		{expr: fmt.Sprintf("%s['number'] == '0' ", common.DefaultJSONFieldName), count: 0},
+
+		// json field
+		{expr: fmt.Sprintf("%s >= 1500", common.DefaultJSONFieldName), count: 1500},                                      // json >= 1500
+		{expr: fmt.Sprintf("%s > 1499.5", common.DefaultJSONFieldName), count: 1500},                                     // json >= 1500.0
+		{expr: fmt.Sprintf("%s like '21%%'", common.DefaultJSONFieldName), count: 100},                                   // json like '21%'
+		{expr: fmt.Sprintf("%s == [1503, 1504]", common.DefaultJSONFieldName), count: 1},                                 // json == [1,2]
+		{expr: fmt.Sprintf("%s[0] > 1", common.DefaultJSONFieldName), count: 1500},                                       // json[0] > 1
+		{expr: fmt.Sprintf("%s[0][0] > 1", common.DefaultJSONFieldName), count: 0},                                       // json == [1,2]
+		{expr: fmt.Sprintf("%s[0] == false", common.DefaultBoolArrayField), count: common.DefaultNb / 2},                 //  array[0] ==
+		{expr: fmt.Sprintf("%s[0] > 0", common.DefaultInt64ArrayField), count: common.DefaultNb - 1},                     //  array[0] >
+		{expr: fmt.Sprintf("array_contains (%s, %d)", common.DefaultInt16ArrayField, capacity), count: capacity},         // array_contains(array, 1)
+		{expr: fmt.Sprintf("json_contains (%s, 1)", common.DefaultInt32ArrayField), count: 2},                            // json_contains(array, 1)
+		{expr: fmt.Sprintf("array_contains (%s, 1000000)", common.DefaultInt32ArrayField), count: 0},                     // array_contains(array, 1)
+		{expr: fmt.Sprintf("json_contains_all (%s, [90, 91])", common.DefaultInt64ArrayField), count: 91},                // json_contains_all(array, [x])
+		{expr: fmt.Sprintf("json_contains_any (%s, [0, 100, 10])", common.DefaultFloatArrayField), count: 101},           // json_contains_any (array, [x])
+		{expr: fmt.Sprintf("%s == [0, 1]", common.DefaultDoubleArrayField), count: 0},                                    //  array ==
+		{expr: fmt.Sprintf("array_length(%s) == %d", common.DefaultDoubleArrayField, capacity), count: common.DefaultNb}, //  array_length
+	}
+
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	// create -> insert -> flush -> index -> load
+	prepare, schema := hp.CollPrepare.CreateCollection(ctx, t, mc, hp.NewCreateCollectionParams(hp.AllFields), hp.TNewFieldsOption(),
+		hp.TNewSchemaOption().TWithEnableDynamicField(true), hp.TWithConsistencyLevel(entity.ClStrong))
+	prepare.InsertData(ctx, t, mc, hp.NewInsertParams(schema), hp.TNewDataOption())
+	prepare.FlushData(ctx, t, mc, schema.CollectionName)
+	prepare.CreateIndex(ctx, t, mc, hp.TNewIndexParams(schema))
+	prepare.Load(ctx, t, mc, hp.NewLoadParams(schema.CollectionName))
+
+	batch := 500
+	for _, exprLimit := range exprLimits {
+		rs, err := mc.Query(ctx, client.NewQueryOption(schema.CollectionName).WithFilter(exprLimit.expr).WithOutputFields("count(*)"))
+		common.CheckErr(t, err, true)
+		expectCount, err := rs.GetColumn("count(*)").GetAsInt64(0)
+		common.CheckErr(t, err, true)
+
+		log.Info("case expr is", zap.String("expr", exprLimit.expr), zap.Int64("expectedCount", expectCount))
+		itr, err := mc.QueryIterator(ctx, client.NewQueryIteratorOption(schema.CollectionName).WithBatchSize(batch).WithFilter(exprLimit.expr))
+		common.CheckErr(t, err, true)
+		common.CheckQueryIteratorResult(ctx, t, itr, int(expectCount), common.WithExpBatchSize(hp.GenBatchSizes(int(expectCount), batch)))
+	}
+}
+
+// TestQueryIteratorPartitions tests query iterator with partition filtering
+func TestQueryIteratorPartitions(t *testing.T) {
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	// create collection
+	prepare, schema := hp.CollPrepare.CreateCollection(ctx, t, mc, hp.NewCreateCollectionParams(hp.Int64Vec), hp.TNewFieldsOption(), hp.TNewSchemaOption(),
+		hp.TWithConsistencyLevel(entity.ClStrong))
+
+	// create partition
+	pName := "p1"
+	err := mc.CreatePartition(ctx, client.NewCreatePartitionOption(schema.CollectionName, pName))
+	common.CheckErr(t, err, true)
+
+	// insert [0, nb) into partition: _default
+	nb := 1500
+	prepare.InsertData(ctx, t, mc, hp.NewInsertParams(schema), hp.TNewDataOption().TWithNb(nb))
+
+	// insert [nb, nb*2) into partition: p1
+	prepare.InsertData(ctx, t, mc, hp.NewInsertParams(schema).TWithPartitionName(pName), hp.TNewDataOption().TWithNb(nb).TWithStart(nb))
+
+	prepare.FlushData(ctx, t, mc, schema.CollectionName)
+	prepare.CreateIndex(ctx, t, mc, hp.TNewIndexParams(schema))
+	prepare.Load(ctx, t, mc, hp.NewLoadParams(schema.CollectionName))
+
+	// query iterator with partition
+	expr := fmt.Sprintf("%s < %d", common.DefaultInt64FieldName, nb)
+	mParLimit := map[string]int{
+		common.DefaultPartition: nb,
+		pName:                   0,
+	}
+	for par, limit := range mParLimit {
+		itr, err := mc.QueryIterator(ctx, client.NewQueryIteratorOption(schema.CollectionName).WithFilter(expr).WithPartitions(par))
+		common.CheckErr(t, err, true)
+		common.CheckQueryIteratorResult(ctx, t, itr, limit, common.WithExpBatchSize(hp.GenBatchSizes(limit, common.DefaultBatchSize)))
+	}
+}
+
+// TestQueryIteratorWithLimit tests query iterator with limit
+func TestQueryIteratorWithLimit(t *testing.T) {
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	// create -> insert -> flush -> index -> load
+	prepare, schema := hp.CollPrepare.CreateCollection(ctx, t, mc, hp.NewCreateCollectionParams(hp.Int64Vec), hp.TNewFieldsOption(), hp.TNewSchemaOption().TWithEnableDynamicField(true),
+		hp.TWithConsistencyLevel(entity.ClStrong))
+	prepare.InsertData(ctx, t, mc, hp.NewInsertParams(schema), hp.TNewDataOption().TWithNb(common.DefaultNb*2))
+	prepare.FlushData(ctx, t, mc, schema.CollectionName)
+	prepare.CreateIndex(ctx, t, mc, hp.TNewIndexParams(schema))
+	prepare.Load(ctx, t, mc, hp.NewLoadParams(schema.CollectionName))
+
+	// query iterator with limit
+	limit := int64(2000)
+	batch := 500
+	itr, err := mc.QueryIterator(ctx, client.NewQueryIteratorOption(schema.CollectionName).WithIteratorLimit(limit).WithBatchSize(batch))
+	common.CheckErr(t, err, true)
+	common.CheckQueryIteratorResult(ctx, t, itr, int(limit), common.WithExpBatchSize(hp.GenBatchSizes(int(limit), batch)))
+}
+
+// TestQueryIteratorGrowing tests query iterator on growing segments
+func TestQueryIteratorGrowing(t *testing.T) {
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	// create -> index -> load -> insert (growing)
+	prepare, schema := hp.CollPrepare.CreateCollection(ctx, t, mc, hp.NewCreateCollectionParams(hp.Int64Vec), hp.TNewFieldsOption(), hp.TNewSchemaOption(),
+		hp.TWithConsistencyLevel(entity.ClStrong))
+	prepare.CreateIndex(ctx, t, mc, hp.TNewIndexParams(schema))
+	prepare.Load(ctx, t, mc, hp.NewLoadParams(schema.CollectionName))
+	prepare.InsertData(ctx, t, mc, hp.NewInsertParams(schema), hp.TNewDataOption().TWithNb(common.DefaultNb*2))
+
+	// query iterator growing
+	limit := int64(1000)
+	itr, err := mc.QueryIterator(ctx, client.NewQueryIteratorOption(schema.CollectionName).WithIteratorLimit(limit).WithBatchSize(100))
+	common.CheckErr(t, err, true)
+	common.CheckQueryIteratorResult(ctx, t, itr, int(limit), common.WithExpBatchSize(hp.GenBatchSizes(int(limit), 100)))
+}
+
+// TestQueryIteratorConsistencyLevel tests query iterator with different consistency levels
+func TestQueryIteratorConsistencyLevel(t *testing.T) {
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	// create -> insert -> flush -> index -> load
+	prepare, schema := hp.CollPrepare.CreateCollection(ctx, t, mc, hp.NewCreateCollectionParams(hp.Int64Vec), hp.TNewFieldsOption(), hp.TNewSchemaOption(),
+		hp.TWithConsistencyLevel(entity.ClStrong))
+	prepare.InsertData(ctx, t, mc, hp.NewInsertParams(schema), hp.TNewDataOption().TWithNb(common.DefaultNb))
+	prepare.FlushData(ctx, t, mc, schema.CollectionName)
+	prepare.CreateIndex(ctx, t, mc, hp.TNewIndexParams(schema))
+	prepare.Load(ctx, t, mc, hp.NewLoadParams(schema.CollectionName))
+
+	// query iterator with different consistency levels
+	for _, cl := range []entity.ConsistencyLevel{entity.ClStrong, entity.ClBounded, entity.ClEventually} {
+		itr, err := mc.QueryIterator(ctx, client.NewQueryIteratorOption(schema.CollectionName).WithConsistencyLevel(cl).WithBatchSize(500))
+		common.CheckErr(t, err, true)
+		actualLimit := 0
+		for {
+			rs, err := itr.Next(ctx)
+			if err != nil {
+				if err == io.EOF {
+					break
+				}
+				log.Error("QueryIterator next gets error", zap.Error(err))
+				break
+			}
+			actualLimit = actualLimit + rs.ResultCount
+		}
+		require.LessOrEqual(t, actualLimit, common.DefaultNb)
+	}
+}

--- a/tests/go_client/testcases/search_test.go
+++ b/tests/go_client/testcases/search_test.go
@@ -702,7 +702,6 @@ func TestSearchJsonFieldExpr(t *testing.T) {
 
 	for _, dynamicField := range []bool{false, true} {
 		// create collection
-
 		prepare, schema := hp.CollPrepare.CreateCollection(ctx, t, mc, hp.NewCreateCollectionParams(hp.Int64VecJSON), hp.TNewFieldsOption(), hp.TNewSchemaOption().
 			TWithEnableDynamicField(dynamicField))
 		prepare.InsertData(ctx, t, mc, hp.NewInsertParams(schema), hp.TNewDataOption())
@@ -712,13 +711,15 @@ func TestSearchJsonFieldExpr(t *testing.T) {
 
 		// search with jsonField expr key datatype and json data type mismatch
 		for _, expr := range exprs {
-			log.Debug("TestSearchJsonFieldExpr", zap.String("expr", expr))
-			vectors := hp.GenSearchVectors(common.DefaultNq, common.DefaultDim, entity.FieldTypeFloatVector)
-			searchRes, errSearch := mc.Search(ctx, client.NewSearchOption(schema.CollectionName, common.DefaultLimit, vectors).WithConsistencyLevel(entity.ClStrong).
-				WithFilter(expr).WithANNSField(common.DefaultFloatVecFieldName).WithOutputFields(common.DefaultInt64FieldName, common.DefaultJSONFieldName))
-			common.CheckErr(t, errSearch, true)
-			common.CheckOutputFields(t, []string{common.DefaultInt64FieldName, common.DefaultJSONFieldName}, searchRes[0].Fields)
-			common.CheckSearchResult(t, searchRes, common.DefaultNq, common.DefaultLimit)
+			t.Run(fmt.Sprintf("expr=%s_dynamic-%t", expr, dynamicField), func(t *testing.T) {
+				log.Debug("TestSearchJsonFieldExpr", zap.String("expr", expr))
+				vectors := hp.GenSearchVectors(common.DefaultNq, common.DefaultDim, entity.FieldTypeFloatVector)
+				searchRes, errSearch := mc.Search(ctx, client.NewSearchOption(schema.CollectionName, common.DefaultLimit, vectors).WithConsistencyLevel(entity.ClStrong).
+					WithFilter(expr).WithANNSField(common.DefaultFloatVecFieldName).WithOutputFields(common.DefaultInt64FieldName, common.DefaultJSONFieldName))
+				common.CheckErr(t, errSearch, true)
+				common.CheckOutputFields(t, []string{common.DefaultInt64FieldName, common.DefaultJSONFieldName}, searchRes[0].Fields)
+				common.CheckSearchResult(t, searchRes, common.DefaultNq, common.DefaultLimit)
+			})
 		}
 	}
 }


### PR DESCRIPTION
Cherry-pick from master
Related to #31293 #42148 #45105
pr: #45113 #45291 #46633

## Summary
Bump Go SDK version to v2.6.2 with new features and enhancements.

## New Features
- Add QueryIterator support for efficient iteration over large query
  result sets using PK-based pagination (#46633)
  - Support Int64 and VarChar primary key types for pagination
  - Add QueryIteratorOption with batchSize, limit, filter, outputFields

## Enhancements
- Support struct array field type in Go SDK (#45291)
  - Add columnStructArray type with Column interface implementation
  - Support parsing StructArrayField from protobuf
  - Add schema construction for struct array fields

- Refactor go_client test wrapper to use embedding and improve
  test structure (#45113)