### PR TITLE
enhance: change credential provider to singleton(#46649)

### DIFF
--- a/internal/core/src/storage/ChunkManager.cpp
+++ b/internal/core/src/storage/ChunkManager.cpp
@@ -14,7 +14,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <fstream>
 #include <aws/core/auth/AWSCredentials.h>
 #include <aws/core/auth/AWSCredentialsProviderChain.h>
 #include <aws/core/auth/STSCredentialsProvider.h>
@@ -29,15 +28,9 @@
 #include <aws/s3/model/PutObjectRequest.h>
 
 #include "storage/minio/MinioChunkManager.h"
-#include "storage/aliyun/AliyunSTSClient.h"
-#include "storage/aliyun/AliyunCredentialsProvider.h"
-#include "storage/tencent/TencentCloudSTSClient.h"
-#include "storage/tencent/TencentCloudCredentialsProvider.h"
-#include "storage/huawei/HuaweiCloudCredentialsProvider.h"
 #include "common/Consts.h"
 #include "common/EasyAssert.h"
 #include "log/Log.h"
-#include "signal.h"
 
 namespace milvus::storage {
 
@@ -172,9 +165,8 @@ AliyunChunkManager::AliyunChunkManager(const StorageConfig& storage_config) {
     StorageConfig mutable_config = storage_config;
     mutable_config.useVirtualHost = true;
     if (storage_config.useIAM) {
-        auto aliyun_provider = Aws::MakeShared<
-            Aws::Auth::AliyunSTSAssumeRoleWebIdentityCredentialsProvider>(
-            "AliyunSTSAssumeRoleWebIdentityCredentialsProvider");
+        auto aliyun_provider = AliyunChunkManager::
+            GetAliyunSTSAssumeRoleWebIdentityCredentialsProvider();
         auto aliyun_credentials = aliyun_provider->GetAWSCredentials();
         AssertInfo(!aliyun_credentials.GetAWSAccessKeyId().empty(),
                    "if use iam, access key id should not be empty");
@@ -214,9 +206,8 @@ TencentCloudChunkManager::TencentCloudChunkManager(
     StorageConfig mutable_config = storage_config;
     mutable_config.useVirtualHost = true;
     if (storage_config.useIAM) {
-        auto tencent_cloud_provider = Aws::MakeShared<
-            Aws::Auth::TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider>(
-            "TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider");
+        auto tencent_cloud_provider = TencentCloudChunkManager::
+            GetTencentCloudSTSAssumeRoleWebIdentityCredentialsProvider();
         auto tencent_cloud_credentials =
             tencent_cloud_provider->GetAWSCredentials();
         AssertInfo(!tencent_cloud_credentials.GetAWSAccessKeyId().empty(),
@@ -254,9 +245,8 @@ HuaweiCloudChunkManager::HuaweiCloudChunkManager(
     StorageConfig mutable_config = storage_config;
     mutable_config.useVirtualHost = true;
     if (storage_config.useIAM) {
-        auto huawei_cloud_provider = Aws::MakeShared<
-            Aws::Auth::HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider>(
-            "HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider");
+        auto huawei_cloud_provider = HuaweiCloudChunkManager::
+            GetHuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider();
         auto huawei_cloud_credentials =
             huawei_cloud_provider->GetAWSCredentials();
         AssertInfo(!huawei_cloud_credentials.GetAWSAccessKeyId().empty(),
@@ -283,6 +273,39 @@ HuaweiCloudChunkManager::HuaweiCloudChunkManager(
         storage_config.bucket_name,
         storage_config.root_path,
         storage_config.useSSL);
+}
+
+std::shared_ptr<
+    Aws::Auth::HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider>
+HuaweiCloudChunkManager::
+    GetHuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider() {
+    static std::shared_ptr<
+        Aws::Auth::HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider>
+        provider = std::make_shared<
+            Aws::Auth::
+                HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider>();
+    return provider;
+}
+
+std::shared_ptr<Aws::Auth::AliyunSTSAssumeRoleWebIdentityCredentialsProvider>
+AliyunChunkManager::GetAliyunSTSAssumeRoleWebIdentityCredentialsProvider() {
+    static std::shared_ptr<
+        Aws::Auth::AliyunSTSAssumeRoleWebIdentityCredentialsProvider>
+        provider = std::make_shared<
+            Aws::Auth::AliyunSTSAssumeRoleWebIdentityCredentialsProvider>();
+    return provider;
+}
+
+std::shared_ptr<
+    Aws::Auth::TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider>
+TencentCloudChunkManager::
+    GetTencentCloudSTSAssumeRoleWebIdentityCredentialsProvider() {
+    static std::shared_ptr<
+        Aws::Auth::TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider>
+        provider = std::make_shared<
+            Aws::Auth::
+                TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider>();
+    return provider;
 }
 
 }  // namespace milvus::storage

--- a/internal/core/src/storage/minio/MinioChunkManager.h
+++ b/internal/core/src/storage/minio/MinioChunkManager.h
@@ -43,6 +43,9 @@
 #include "storage/ChunkManager.h"
 #include "storage/Types.h"
 #include "log/Log.h"
+#include "storage/huawei/HuaweiCloudCredentialsProvider.h"
+#include "storage/aliyun/AliyunCredentialsProvider.h"
+#include "storage/tencent/TencentCloudCredentialsProvider.h"
 
 namespace milvus::storage {
 
@@ -271,6 +274,10 @@ class AliyunChunkManager : public MinioChunkManager {
     GetName() const {
         return "AliyunChunkManager";
     }
+
+    static std::shared_ptr<
+        Aws::Auth::AliyunSTSAssumeRoleWebIdentityCredentialsProvider>
+    GetAliyunSTSAssumeRoleWebIdentityCredentialsProvider();
 };
 
 class TencentCloudChunkManager : public MinioChunkManager {
@@ -280,6 +287,10 @@ class TencentCloudChunkManager : public MinioChunkManager {
     GetName() const {
         return "TencentCloudChunkManager";
     }
+
+    static std::shared_ptr<
+        Aws::Auth::TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider>
+    GetTencentCloudSTSAssumeRoleWebIdentityCredentialsProvider();
 };
 
 class HuaweiCloudChunkManager : public MinioChunkManager {
@@ -289,6 +300,10 @@ class HuaweiCloudChunkManager : public MinioChunkManager {
     GetName() const {
         return "HuaweiCloudChunkManager";
     }
+
+    static std::shared_ptr<
+        Aws::Auth::HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider>
+    GetHuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider();
 };
 
 using MinioChunkManagerPtr = std::unique_ptr<MinioChunkManager>;


### PR DESCRIPTION
related: #46649

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Core invariant: STS IAM credential providers for Aliyun, Tencent Cloud, and Huawei Cloud are global, stateless resources that must be instantiated once and reused across all ChunkManager instances (singleton), rather than created per-manager.
- Logic removed/simplified: Removed per-instance Aws::MakeShared instantiation of STSAssumeRoleWebIdentityCredentialsProvider inside Aliyun/Tencent/Huawei ChunkManager constructors and replaced them with public static Get...CredentialsProvider() methods that return a thread-safe, lazily-initialized shared_ptr singleton (static local variable). This eliminates duplicate provider construction and header/signal dependency usages tied to per-constructor instantiation.
- Why this does NOT introduce data loss or behavior regression: Credential acquisition and usage paths are unchanged — callers still call provider->GetAWSCredentials() and use the returned AWSCredentials to construct Aws::S3::S3Client. The singleton returns the same provider object but the provider is stateless with respect to per-manager data (it only reads environment/platform credentials and produces AWSCredentials). C++11+ static local initialization provides atomic, thread-safe construction, so first-access semantics and validation checks (AssertInfo on access key/secret/token) remain intact.
- PR type (Enhancement/Refactor): Improves credential management by centralizing provider lifecycle, removing redundant allocations and header dependencies, and enforcing a single shared provider per cloud vendor where IAM is used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->