### PR TITLE
fix: scalar bench builds on its own, removing related target from milvus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -270,19 +270,19 @@ generated-proto: download-milvus-proto build-3rdparty get-proto-deps
 	@echo "Generate proto ..."
 	@(env bash $(PWD)/scripts/generate_proto.sh ${INSTALL_PATH})
 
-build-cpp: generated-proto
+build-cpp: generated-proto plan-parser-so
 	@echo "Building Milvus cpp library ..."
 	@(env bash $(PWD)/scripts/core_build.sh -t ${mode} -a ${use_asan} -n ${use_disk_index} -y ${use_dynamic_simd} ${AZURE_OPTION} -x ${index_engine} -o ${use_opendal} -f $(tantivy_features))
 
-build-cpp-gpu: generated-proto
+build-cpp-gpu: generated-proto plan-parser-so
 	@echo "Building Milvus cpp gpu library ... "
 	@(env bash $(PWD)/scripts/core_build.sh -t ${mode} -g -n ${use_disk_index} -y ${use_dynamic_simd} ${AZURE_OPTION} -x ${index_engine} -o ${use_opendal} -f $(tantivy_features))
 
-build-cpp-with-unittest: generated-proto
+build-cpp-with-unittest: generated-proto plan-parser-so
 	@echo "Building Milvus cpp library with unittest ... "
 	@(env bash $(PWD)/scripts/core_build.sh -t ${mode} -a ${use_asan} -u -n ${use_disk_index} -y ${use_dynamic_simd} ${AZURE_OPTION} -x ${index_engine} -o ${use_opendal} -f $(tantivy_features))
 
-build-cpp-with-coverage: generated-proto
+build-cpp-with-coverage: generated-proto plan-parser-so
 	@echo "Building Milvus cpp library with coverage and unittest ..."
 	@(env bash $(PWD)/scripts/core_build.sh -t ${mode} -a ${use_asan} -u -c -n ${use_disk_index} -y ${use_dynamic_simd} ${AZURE_OPTION} -x ${index_engine} -o ${use_opendal} -f $(tantivy_features))
 
@@ -402,15 +402,6 @@ plan-parser-so:
 			-I$(PWD)/internal/core/output/include \
 			-L$(PWD)/internal/core/output/lib -lmilvus-planparser \
 			-Wl,-rpath,'$$ORIGIN'
-
-# Build unittest with external scalar-benchmark enabled
-scalar-bench: generated-proto plan-parser-so
-	@echo "Building Milvus cpp unittest with scalar-benchmark ... "
-	@(export CMAKE_EXTRA_ARGS="-DENABLE_SCALAR_BENCH=ON"; env bash $(PWD)/scripts/core_build.sh -t ${mode} -a ${use_asan} -u -n ${use_disk_index} -y ${use_dynamic_simd} ${AZURE_OPTION} -x ${index_engine} -o ${use_opendal} -f $(tantivy_features))
-
-scalar-bench-ui:
-	@echo "Starting scalar-benchmark ui ... "
-	@(cd cmake_build/unittest/scalar-benchmark-src/ui && ./serve_ui_dev.sh)
 
 # Run code coverage.
 codecov: codecov-go codecov-cpp

--- a/internal/core/unittest/CMakeLists.txt
+++ b/internal/core/unittest/CMakeLists.txt
@@ -119,33 +119,6 @@ install(TARGETS all_tests DESTINATION unittest)
 add_subdirectory(bench)
 add_subdirectory(test_json_stats)
 
-# Optionally include external scalar-benchmark project
-option(ENABLE_SCALAR_BENCH "Enable fetching and building scalar-benchmark" OFF)
-set(SCALAR_BENCHMARK_GIT_URL "https://github.com/zilliztech/scalar-benchmark" CACHE STRING "Scalar benchmark git repo URL")
-set(SCALAR_BENCHMARK_GIT_TAG "main" CACHE STRING "Scalar benchmark git tag/branch")
-
-if (ENABLE_SCALAR_BENCH)
-    include(FetchContent)
-    if (DEFINED SCALAR_BENCHMARK_SOURCE_DIR AND EXISTS ${SCALAR_BENCHMARK_SOURCE_DIR}/CMakeLists.txt)
-        message(STATUS "Using local scalar-benchmark from ${SCALAR_BENCHMARK_SOURCE_DIR}")
-        add_subdirectory(${SCALAR_BENCHMARK_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}/scalar-benchmark-build)
-    else()
-        message(STATUS "Fetching scalar-benchmark from ${SCALAR_BENCHMARK_GIT_URL} (${SCALAR_BENCHMARK_GIT_TAG})")
-        FetchContent_Declare(
-            scalar_benchmark
-            GIT_REPOSITORY ${SCALAR_BENCHMARK_GIT_URL}
-            GIT_TAG        ${SCALAR_BENCHMARK_GIT_TAG}
-            SOURCE_DIR     ${CMAKE_CURRENT_BINARY_DIR}/scalar-benchmark-src
-            BINARY_DIR     ${CMAKE_CURRENT_BINARY_DIR}/scalar-benchmark-build
-        )
-        FetchContent_GetProperties(scalar_benchmark)
-        if (NOT scalar_benchmark_POPULATED)
-            FetchContent_Populate(scalar_benchmark)
-            add_subdirectory(${scalar_benchmark_SOURCE_DIR} ${scalar_benchmark_BINARY_DIR})
-        endif()
-    endif()
-endif()
-
 # bitset unit test
 include(CheckCXXCompilerFlag)
 include(CheckIncludeFileCXX)


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/44452

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**Scalar Bench Decoupled from Milvus Build System**

- **Core assumption**: Scalar-bench is now managed as an independent build artifact outside the milvus repository, eliminating the need for conditional compilation integration within milvus's Makefile and CMakeLists.txt.

- **Build infrastructure simplified**: Removed `scalar-bench` and `scalar-bench-ui` targets from Makefile and deleted the entire `ENABLE_SCALAR_BENCH` conditional block in `internal/core/unittest/CMakeLists.txt` (which handled FetchContent, cache variables, and subdirectory integration)—this eliminates optional, redundant build-time coupling that is no longer necessary.

- **No regression introduced**: The removal only affects optional build-time integration paths. Core C++ builds continue functioning as before, and unit tests remain unaffected since `ENABLE_SCALAR_BENCH` was always optional (not a required dependency); the newly added `plan-parser-so` dependency on core build targets appears to be a separate, required component.

- **Decoupling benefit**: Scalar-benchmark can now evolve and release on its own schedule independent of milvus release cycles, while maintaining clean separation of concerns between the two projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->