### PR TITLE
enhance: allow multi replica per resource group

### DIFF
--- a/internal/querycoordv2/utils/meta.go
+++ b/internal/querycoordv2/utils/meta.go
@@ -107,8 +107,8 @@ func RecoverAllCollection(m *meta.Meta) {
 }
 
 func AssignReplica(ctx context.Context, m *meta.Meta, resourceGroups []string, replicaNumber int32, checkNodeNum bool) (map[string]int, error) {
-	if len(resourceGroups) != 0 && len(resourceGroups) != 1 && len(resourceGroups) != int(replicaNumber) {
-		return nil, merr.WrapErrParameterInvalidMsg("replica=[%d] resource group=[%s], resource group num can only be 0, 1 or same as replica number", replicaNumber, strings.Join(resourceGroups, ","))
+	if len(resourceGroups) != 0 && len(resourceGroups) != 1 && int(replicaNumber) % len(resourceGroups) == 0 {
+		return nil, merr.WrapErrParameterInvalidMsg("replica=[%d] resource group=[%s], resource group num can only be 0, 1 or divisor of replica number", replicaNumber, strings.Join(resourceGroups, ","))
 	}
 
 	if streamingutil.IsStreamingServiceEnabled() {
@@ -128,7 +128,7 @@ func AssignReplica(ctx context.Context, m *meta.Meta, resourceGroups []string, r
 	} else {
 		// replicas should be spawned in different resource groups one by one.
 		for _, rgName := range resourceGroups {
-			replicaNumInRG[rgName] += 1
+			replicaNumInRG[rgName] += int(replicaNumber) / len(resourceGroups)
 		}
 	}
 


### PR DESCRIPTION
related: #46667 

Currently, there's a restriction that resource group num can only be 0, 1 or same as replica number when load data. That means if we assigned multiple replica in load request, then each rg can only have 1 replica. In fact we can allow multi replicas per resource group.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary for Senior Maintainers

**Core Invariant Change**
- Previous constraint: Resource group count must be 0, 1, or exactly equal to replica count
- New constraint: Resource group count must be 0, 1, or evenly divide into replica count (enabling `replicaNumber / len(resourceGroups)` replicas per group)
- Enables configurations like 4 replicas across 2 resource groups (2 per group) instead of requiring exactly 4 resource groups for 4 replicas

**Logic Removed and Why It Was Restrictive**
- Removed the equality requirement (`len(resourceGroups) == replicaNumber`) that forced one replica per resource group when multiple groups were specified
- Replaced single-increment loop (`replicaNumInRG[rgName] += 1`) with proportional distribution (`replicaNumInRG[rgName] += int(replicaNumber) / len(resourceGroups)`)
- The old design unnecessarily limited multi-replica deployments; it prevented efficient use of resource groups by requiring group count to match replica count exactly

**No Data Loss or Behavior Regression**
- The new divisibility constraint is less restrictive than the old equality constraint: all previously valid configurations remain valid (e.g., 3 replicas + 3 groups satisfies both `3==3` and `3%3==0`)
- Validation still ensures complete replica distribution with no partial replicas (integer division with modulo check)
- The downstream ReplicaManager.Spawn() receives balanced per-group counts and places replicas identically to the previous implementation
- No changes to segment placement, query execution, or load semantics

**Enhancement Outcome**
- Collections can now leverage multiple resource groups for balanced workload distribution without artificial 1:1 constraints
- Example: 6 replicas now load as 2+2+2 across 3 resource groups instead of requiring exactly 6 resource groups or being limited to 1 group

<!-- end of auto-generated comment: release notes by coderabbit.ai -->