### PR TITLE
fix: [hotfix] use LoadDeltaData instead of Delete for L0 growing forward (#46657)

### DIFF
--- a/internal/querynodev2/delegator/delta_forward.go
+++ b/internal/querynodev2/delegator/delta_forward.go
@@ -101,7 +101,11 @@ func (sd *shardDelegator) addL0ForGrowing(ctx context.Context, segment segments.
 func (sd *shardDelegator) addL0GrowingBF(ctx context.Context, segment segments.Segment) error {
 	bufferedForwarder := NewBufferedForwarder(paramtable.Get().QueryNodeCfg.ForwardBatchSize.GetAsInt64(),
 		func(pks storage.PrimaryKeys, tss []uint64) error {
-			return segment.Delete(ctx, pks, tss)
+			dd, err := storage.NewDeltaDataWithData(pks, tss)
+			if err != nil {
+				return err
+			}
+			return segment.LoadDeltaData(ctx, dd)
 		})
 
 	if err := sd.rangeHitL0Deletions(segment.Partition(), segment, func(pk storage.PrimaryKey, ts uint64) error {

--- a/internal/querynodev2/delegator/delta_forward_test.go
+++ b/internal/querynodev2/delegator/delta_forward_test.go
@@ -425,16 +425,16 @@ func (s *GrowingMergeL0Suite) TestAddL0ForGrowingBF() {
 	seg.EXPECT().ID().Return(1)
 	seg.EXPECT().Partition().Return(100)
 	seg.EXPECT().BatchPkExist(mock.Anything).Return(lo.RepeatBy(n, func(i int) bool { return true }))
-	seg.EXPECT().Delete(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, pk storage.PrimaryKeys, u []uint64) error {
-		s.Equal(deltaData.DeletePks(), pk)
-		s.Equal(deltaData.DeleteTimestamps(), u)
+	seg.EXPECT().LoadDeltaData(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, dd *storage.DeltaData) error {
+		s.Equal(deltaData.DeletePks(), dd.DeletePks())
+		s.Equal(deltaData.DeleteTimestamps(), dd.DeleteTimestamps())
 		return nil
 	}).Once()
 
 	err = sd.addL0ForGrowing(context.Background(), seg)
 	s.NoError(err)
 
-	seg.EXPECT().Delete(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, pk storage.PrimaryKeys, u []uint64) error {
+	seg.EXPECT().LoadDeltaData(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, dd *storage.DeltaData) error {
 		return errors.New("mocked")
 	}).Once()
 	err = sd.addL0ForGrowing(context.Background(), seg)


### PR DESCRIPTION
Cherry-pick from master
pr: #46657
Related to #46660
Replace segment.Delete() with segment.LoadDeltaData() when forwarding L0 deletions to growing segments. LoadDeltaData is the more appropriate API for bulk loading delta data compared to individual Delete calls.