### PR TITLE
fix: [2.6] Set replica field in balance plans to prevent panic (#45722)

### DIFF
--- a/internal/querycoordv2/balance/multi_target_balance.go
+++ b/internal/querycoordv2/balance/multi_target_balance.go
@@ -559,7 +559,11 @@ func (b *MultiTargetBalancer) genSegmentPlan(ctx context.Context, replica *meta.
 		globalNodeSegments[node] = b.dist.SegmentDistManager.GetByFilter(meta.WithNodeID(node))
 	}
 
-	return b.genPlanByDistributions(nodeSegments, globalNodeSegments)
+	plans := b.genPlanByDistributions(nodeSegments, globalNodeSegments)
+	for i := range plans {
+		plans[i].Replica = replica
+	}
+	return plans
 }
 
 func (b *MultiTargetBalancer) genPlanByDistributions(nodeSegments, globalNodeSegments map[int64][]*meta.Segment) []SegmentAssignPlan {

--- a/tests/integration/balance/balance_test.go
+++ b/tests/integration/balance/balance_test.go
@@ -170,6 +170,10 @@ func (s *BalanceTestSuit) initCollection(collectionName string, replica int, cha
 }
 
 func (s *BalanceTestSuit) TestBalanceOnSingleReplica() {
+	testBalanceOnSingleReplica(s)
+}
+
+func testBalanceOnSingleReplica(s *BalanceTestSuit) {
 	name := "test_balance_" + funcutil.GenRandomStr()
 	s.initCollection(name, 1, 2, 2, 2000, 500)
 
@@ -412,6 +416,16 @@ func (s *BalanceTestSuit) TestConcurrentBalanceChannelAndSegment() {
 	close(stopSearchCh)
 	wg.Wait()
 	s.Equal(int64(0), failCounter.Load())
+}
+
+func (s *BalanceTestSuit) TestMultiTargetBalancePolicy() {
+	// Set balance policy to MultipleTargetBalancer
+	revertGuard := s.Cluster.MustModifyMilvusConfig(map[string]string{
+		paramtable.Get().QueryCoordCfg.Balancer.Key: "MultipleTargetBalancer",
+	})
+	defer revertGuard()
+
+	testBalanceOnSingleReplica(s)
 }
 
 func TestBalance(t *testing.T) {


### PR DESCRIPTION
issue: #45598
pr: #45722
The MultiTargetBalancer was missing replica field assignment in the generated segment and channel plans, which caused panic during balance operations. This change ensures that all balance plans have the replica field properly set to fix the panic issue.

Also refactored the balance test to extract common test logic into a reusable helper function and added a new integration test specifically for MultipleTargetBalancer policy.