### PR TITLE
enhance: add tracing for build bm25 idf

### DIFF
--- a/internal/querynodev2/delegator/delegator.go
+++ b/internal/querynodev2/delegator/delegator.go
@@ -325,7 +325,7 @@ func (sd *shardDelegator) search(ctx context.Context, req *querypb.SearchRequest
 			return nil, merr.WrapErrParameterInvalid("BM25", req.GetReq().GetMetricType(), "must use BM25 metric type when searching against BM25 Function output field")
 		}
 		// build idf for bm25 search
-		avgdl, err := sd.buildBM25IDF(req.GetReq())
+		avgdl, err := sd.buildBM25IDF(ctx, req.GetReq())
 		if err != nil {
 			return nil, err
 		}

--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
+	"go.opentelemetry.io/otel"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/proto"
@@ -927,7 +928,10 @@ func (sd *shardDelegator) TryCleanExcludedSegments(ts uint64) {
 	}
 }
 
-func (sd *shardDelegator) buildBM25IDF(req *internalpb.SearchRequest) (float64, error) {
+func (sd *shardDelegator) buildBM25IDF(ctx context.Context, req *internalpb.SearchRequest) (float64, error) {
+	ctx, span := otel.Tracer(typeutil.StreamingNodeRole).Start(ctx, fmt.Sprintf("build-bm25-idf-%s", sd.vchannelName))
+	defer span.End()
+
 	pb := &commonpb.PlaceholderGroup{}
 	proto.Unmarshal(req.GetPlaceholderGroup(), pb)
 

--- a/internal/querynodev2/delegator/delegator_data_test.go
+++ b/internal/querynodev2/delegator/delegator_data_test.go
@@ -955,6 +955,8 @@ func (s *DelegatorDataSuite) waitTargetVersion(targetVersion int64) {
 }
 
 func (s *DelegatorDataSuite) TestBuildBM25IDF() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	s.genCollectionWithFunction()
 
 	genBM25Stats := func(start uint32, end uint32) map[int64]*storage.BM25Stats {
@@ -1032,7 +1034,7 @@ func (s *DelegatorDataSuite) TestBuildBM25IDF() {
 			SerializedExprPlan: plan,
 			FieldId:            101,
 		}
-		avgdl, err := s.delegator.buildBM25IDF(req)
+		avgdl, err := s.delegator.buildBM25IDF(ctx, req)
 		s.NoError(err)
 		s.Equal(float64(1), avgdl)
 
@@ -1062,7 +1064,7 @@ func (s *DelegatorDataSuite) TestBuildBM25IDF() {
 			PlaceholderGroup: placeholderGroupBytes,
 			FieldId:          101,
 		}
-		_, err = s.delegator.buildBM25IDF(req)
+		_, err = s.delegator.buildBM25IDF(ctx, req)
 		s.Error(err)
 	})
 
@@ -1075,7 +1077,7 @@ func (s *DelegatorDataSuite) TestBuildBM25IDF() {
 			FieldId:          103, // invalid field id
 		}
 
-		_, err = s.delegator.buildBM25IDF(req)
+		_, err = s.delegator.buildBM25IDF(ctx, req)
 		s.Error(err)
 	})
 
@@ -1102,7 +1104,7 @@ func (s *DelegatorDataSuite) TestBuildBM25IDF() {
 			PlaceholderGroup: placeholderGroupBytes,
 			FieldId:          101,
 		}
-		_, err = s.delegator.buildBM25IDF(req)
+		_, err = s.delegator.buildBM25IDF(ctx, req)
 		s.Error(err)
 	})
 
@@ -1129,7 +1131,7 @@ func (s *DelegatorDataSuite) TestBuildBM25IDF() {
 			PlaceholderGroup: placeholderGroupBytes,
 			FieldId:          101,
 		}
-		_, err = s.delegator.buildBM25IDF(req)
+		_, err = s.delegator.buildBM25IDF(ctx, req)
 		s.Error(err)
 	})
 
@@ -1156,7 +1158,7 @@ func (s *DelegatorDataSuite) TestBuildBM25IDF() {
 			PlaceholderGroup: placeholderGroupBytes,
 			FieldId:          103, // invalid field
 		}
-		_, err = s.delegator.buildBM25IDF(req)
+		_, err = s.delegator.buildBM25IDF(ctx, req)
 		s.Error(err)
 		log.Info("test", zap.Error(err))
 	})
@@ -1179,7 +1181,7 @@ func (s *DelegatorDataSuite) TestBuildBM25IDF() {
 			PlaceholderGroup: placeholderGroupBytes,
 			FieldId:          101,
 		}
-		_, err = s.delegator.buildBM25IDF(req)
+		_, err = s.delegator.buildBM25IDF(ctx, req)
 		s.Error(err)
 	})
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary: OpenTelemetry Tracing for BM25 IDF Construction

**Core invariant:** Context must propagate through method signatures to enable distributed tracing instrumentation without changing application behavior.

**What's added:** OpenTelemetry tracing spans are instrumented around BM25 IDF building in the shard delegator. The `buildBM25IDF` method now accepts `context.Context` as the first parameter and immediately creates a named span ("build-bm25-idf-{vchannel}") using `otel.Tracer().Start()` with proper cleanup via `defer span.End()`. The context is passed from the existing search request context in the caller.

**Why this introduces no behavior regression:** The tracing instrumentation is purely observational. The method signature accepts an already-available context from the caller (existing in the search path), the deferred span end ensures no resource leaks, and all validation logic, data preparation, IDF calculation, and error handling paths remain identical. The method returns the same values in the same code paths—only observability metadata is added.

**Code evidence:** Call site in delegator.go now passes context: `avgdl, err := sd.buildBM25IDF(ctx, req.GetReq())`. Implementation in delegator_data.go creates the span immediately with channel-specific naming for request tracing: `ctx, span := otel.Tracer(typeutil.StreamingNodeRole).Start(ctx, fmt.Sprintf("build-bm25-idf-%s", sd.vchannelName))` followed by cleanup. This pattern matches established OpenTelemetry instrumentation used throughout the codebase in proxy, data node, and other components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->