### PR TITLE
feat: [NCS] Enable Near-Compute Storage (NCS) in Milvus

### DIFF
--- a/build/docker/builder/cpu/ubuntu20.04/Dockerfile
+++ b/build/docker/builder/cpu/ubuntu20.04/Dockerfile
@@ -13,15 +13,18 @@ FROM ubuntu:focal-20220426
 
 ARG TARGETARCH
 
-RUN apt-get update && apt-get install -y --no-install-recommends wget curl ca-certificates gnupg2 \
+RUN apt-get update && apt-get install -y --no-install-recommends ssh wget curl ca-certificates gnupg2 \
     g++ gcc gdb gdbserver ninja-build git make ccache libssl-dev zlib1g-dev zip unzip \
     clang-format-12 clang-tidy-12 lcov libtool m4 autoconf automake python3 python3-pip \
-    pkg-config uuid-dev libaio-dev libopenblas-dev && \
+    pkg-config uuid-dev libaio-dev libopenblas-dev libpci3 && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata && \
         ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
         echo "Etc/UTC" > /etc/timezone && \
     apt-get remove --purge -y && \
     rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /root/.ssh && ssh-keyscan bitbucket.org >> /root/.ssh/known_hosts
+
 
 RUN pip3 install conan==1.64.1
 

--- a/build/docker/builder/cpu/ubuntu22.04/Dockerfile
+++ b/build/docker/builder/cpu/ubuntu22.04/Dockerfile
@@ -13,15 +13,17 @@ FROM ubuntu:jammy-20240530
 
 ARG TARGETARCH
 
-RUN apt-get update && apt-get install -y --no-install-recommends wget curl ca-certificates gnupg2 \
+RUN apt-get update && apt-get install -y --no-install-recommends ssh wget curl ca-certificates gnupg2 \
     g++ gcc gdb gdbserver ninja-build git make ccache libssl-dev zlib1g-dev zip unzip \
     clang-format-12 clang-tidy-12 lcov libtool m4 autoconf automake python3 python3-pip \
-    pkg-config uuid-dev libaio-dev libopenblas-dev && \
+    pkg-config uuid-dev libaio-dev libopenblas-dev libpci3 && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata && \
         ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
         echo "Etc/UTC" > /etc/timezone && \
     apt-get remove --purge -y && \
     rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /root/.ssh && ssh-keyscan bitbucket.org >> /root/.ssh/known_hosts
 
 # upgrade gcc to 12
 RUN apt-get update && apt-get install -y gcc-12 g++-12 && cd /usr/bin \

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -931,6 +931,19 @@ common:
     SearchCacheBudgetGBRatio: 0.1
     LoadNumThreadRatio: 8
     BeamWidthRatio: 4
+
+    NcsEnable: true
+    NcsKind: "in_memory" #in_memory, redis
+    NcsExtras: '{}'
+
+    # Example for redis NCS:
+    # NcsKind: "redis"
+    # NcsExtras: '{"redis_host": "localhost", "redis_port": 6379}'
+
+    # Example for in_memory NCS:
+    # NcsKind: "in_memory"
+    # NcsExtras: '{}'
+
   gracefulTime: 5000 # milliseconds. it represents the interval (in ms) by which the request arrival time needs to be subtracted in the case of Bounded Consistency.
   gracefulStopTimeout: 1800 # seconds. it will force quit the server if the graceful stop process is not completed during this time.
   namespace:

--- a/deployments/docker/dev/docker-compose-redis.yml
+++ b/deployments/docker/dev/docker-compose-redis.yml
@@ -1,0 +1,121 @@
+version: '3.5'
+
+services:
+  etcd:
+    image: quay.io/coreos/etcd:v3.5.18
+    environment:
+      - ETCD_AUTO_COMPACTION_MODE=revision
+      - ETCD_AUTO_COMPACTION_RETENTION=1000
+      - ETCD_QUOTA_BACKEND_BYTES=4294967296
+      - ETCD_SNAPSHOT_COUNT=50000
+    volumes:
+      - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/etcd:/etcd
+    command: etcd -listen-peer-urls=http://127.0.0.1:2380 -advertise-client-urls=http://127.0.0.1:2379 -listen-client-urls http://0.0.0.0:2379,http://0.0.0.0:4001 -initial-advertise-peer-urls=http://127.0.0.1:2380 --initial-cluster default=http://127.0.0.1:2380 --data-dir /etcd
+    ports:
+      - "2379:2379"
+      - "2380:2380"
+      - "4001:4001"
+
+  pulsar:
+    image: apachepulsar/pulsar:2.8.2
+    volumes:
+      - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/pulsar:/pulsar/data
+    environment:
+      # bin/apply-config-from-env.py script will modify the configuration file based on the environment variables
+      # nettyMaxFrameSizeBytes must be calculated from maxMessageSize + 10240 (padding)
+      - nettyMaxFrameSizeBytes=104867840 # this is 104857600 + 10240 (padding)
+      - defaultRetentionTimeInMinutes=10080
+      - defaultRetentionSizeInMB=8192
+      # maxMessageSize is missing from standalone.conf, must use PULSAR_PREFIX_ to get it configured
+      - PULSAR_PREFIX_maxMessageSize=104857600
+      - PULSAR_GC=-XX:+UseG1GC
+    command: |
+      /bin/bash -c \
+      "bin/apply-config-from-env.py conf/standalone.conf && \
+      exec bin/pulsar standalone --no-functions-worker --no-stream-storage"
+    ports:
+      - "6650:6650"
+      - "18080:8080"
+
+  minio:
+    image: minio/minio:RELEASE.2024-05-28T17-19-04Z
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    environment:
+      MINIO_ACCESS_KEY: minioadmin
+      MINIO_SECRET_KEY: minioadmin
+    volumes:
+      - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/minio:/minio_data
+    command: minio server /minio_data --console-address ":9001"
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "curl",
+          "-f",
+          "http://localhost:9000/minio/health/live"
+        ]
+      interval: 30s
+      timeout: 20s
+      retries: 3
+
+  azurite:
+    image: mcr.microsoft.com/azure-storage/azurite
+    volumes:
+      - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/azurite:/data
+    command: azurite-blob --blobHost 0.0.0.0
+    ports:
+      - "10000:10000"
+
+  jaeger:
+    image: jaegertracing/all-in-one:latest
+    ports:
+      - "6831:6831/udp"
+      - "4317:4317" # OLTP over gRPC
+      - "4318:4318" # OLTP over HTTP
+      - "16686:16686" # frontent
+      - "14268:14268" # jaeger.thirft
+
+  zookeeper:
+    image: wurstmeister/zookeeper:latest
+    ports:
+      - "2181:2181"
+
+  kafka:
+    image: 'bitnamilegacy/kafka:3.1.0'
+    ports:
+      - '9092:9092'
+    environment:
+      - KAFKA_BROKER_ID=0
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://127.0.0.1:9092
+      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
+      - ALLOW_PLAINTEXT_LISTENER=yes
+      # set kafka server config
+      - KAFKA_CFG_MAX_PARTITION_FETCH_BYTES=5242880
+      - KAFKA_CFG_MAX_REQUEST_SIZE=5242880
+      - KAFKA_CFG_MESSAGE_MAX_BYTES=5242880
+      - KAFKA_CFG_REPLICA_FETCH_MAX_BYTES=5242880
+      - KAFKA_CFG_FETCH_MESSAGE_MAX_BYTES=5242880
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
+    depends_on:
+      - zookeeper
+
+  gcpnative:
+    image: fsouza/fake-gcs-server
+    command: -scheme http -public-host storage.gcs.127.0.0.1.nip.io:4443
+    ports:
+      - "4443:4443"
+  
+  redis:
+    image: redis:7.2-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/redis:/data
+    command: ["redis-server", "--appendonly", "yes"]
+
+networks:
+  default:
+    name: milvus_dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,13 +33,17 @@ services:
       AZURE_STORAGE_CONNECTION_STRING: ${AZURITE_CONNECTION_STRING}
       ENABLE_GCP_NATIVE: ${ENABLE_GCP_NATIVE}
       USE_ASAN: ${USE_ASAN}
+      SSH_AUTH_SOCK: /ssh-agent
+      
     volumes: &builder-volumes
       - .:/go/src/github.com/milvus-io/milvus:delegated
       - ${DOCKER_VOLUME_DIRECTORY:-.docker}/${IMAGE_ARCH}-${OS_NAME}-ccache:/ccache:delegated
       - ${DOCKER_VOLUME_DIRECTORY:-.docker}/${IMAGE_ARCH}-${OS_NAME}-go-mod:/go/pkg/mod:delegated
       - ${DOCKER_VOLUME_DIRECTORY:-.docker}/${IMAGE_ARCH}-${OS_NAME}-vscode-extensions:/home/milvus/.vscode-server/extensions:delegated
-      - ${DOCKER_VOLUME_DIRECTORY:-.docker}/${IMAGE_ARCH}-${OS_NAME}-conan:/home/milvus/.conan:delegated
+      - ${HOME}/.conan:/home/milvus/.conan:delegated
+      - ${SSH_AUTH_SOCK}:/ssh-agent:ro
     working_dir: '/go/src/github.com/milvus-io/milvus'
+
     depends_on:
       - etcd
       - minio
@@ -81,6 +85,7 @@ services:
       - ${DOCKER_VOLUME_DIRECTORY:-.docker-gpu}/${OS_NAME}-go-mod:/go/pkg/mod:delegated
       - ${DOCKER_VOLUME_DIRECTORY:-.docker-gpu}/${OS_NAME}-vscode-extensions:/home/milvus/.vscode-server/extensions:delegated
       - ${DOCKER_VOLUME_DIRECTORY:-.docker-gpu}/${OS_NAME}-conan:/home/milvus/.conan:delegated
+
     working_dir: '/go/src/github.com/milvus-io/milvus'
     depends_on:
       - etcd

--- a/internal/core/CMakeLists.txt
+++ b/internal/core/CMakeLists.txt
@@ -311,6 +311,12 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src/indexbuilder/
         FILES_MATCHING PATTERN "*_c.h"
 )
 
+# Install ncs
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src/ncs/
+        DESTINATION include/ncs
+        FILES_MATCHING PATTERN "*_c.h"
+)
+
 # Install clustering
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src/clustering/
         DESTINATION include/clustering

--- a/internal/core/conanfile.py
+++ b/internal/core/conanfile.py
@@ -46,6 +46,7 @@ class MilvusConan(ConanFile):
         "geos/3.12.0#0b177c90c25a8ca210578fb9e2899c37",
         "icu/74.2#cd1937b9561b8950a2ae6311284c5813",
         "libavrocpp/1.12.1@milvus/dev",
+        "hiredis/1.2.0"
     )
 
     generators = ("cmake", "cmake_find_package")

--- a/internal/core/src/CMakeLists.txt
+++ b/internal/core/src/CMakeLists.txt
@@ -52,6 +52,7 @@ add_subdirectory( exec )
 add_subdirectory( bitset )
 add_subdirectory( futures )
 add_subdirectory( rescores )
+add_subdirectory( ncs )
 
 milvus_add_pkg_config("milvus_core")
 
@@ -70,6 +71,7 @@ add_library(milvus_core SHARED
     $<TARGET_OBJECTS:milvus_bitset>
     $<TARGET_OBJECTS:milvus_futures>
     $<TARGET_OBJECTS:milvus_rescores>
+    $<TARGET_OBJECTS:milvus_ncs>
 )
 
 set(LINK_TARGETS

--- a/internal/core/src/index/Meta.h
+++ b/internal/core/src/index/Meta.h
@@ -85,6 +85,14 @@ constexpr const char* EMB_LIST_META_PATH = "emb_list_meta_file_path";
 constexpr const char* EMB_LIST_META_FILE_NAME = "emb_list_meta";
 constexpr const char* EMB_LIST_OFFSETS_PATH = "emb_list_offset_file_path";
 
+// VectorDiskIndex NCS config
+//same as key strings in pkg/util/indexparams/index_params.go
+constexpr const char* NCS_ENABLE = "ncs_enable";
+constexpr const char* NCS_KIND = "ncs_kind";
+constexpr const char* NCS_EXTRAS = "ncs_extras";
+// internal key, not exposed to users. key match member name in knowhere (src/index/diskann/diskann_config.h).
+constexpr const char* NCS_DESCRIPTOR = "ncs_descriptor";
+
 // VecIndex node filtering
 constexpr const char* VEC_OPT_FIELDS_PATH = "opt_fields_path";
 

--- a/internal/core/src/index/VectorDiskIndex.h
+++ b/internal/core/src/index/VectorDiskIndex.h
@@ -99,6 +99,13 @@ class VectorDiskAnnIndex : public VectorIndex {
     knowhere::Json
     update_load_json(const Config& config);
 
+    void
+    ncsUpload(const Config& config);
+
+    std::vector<std::string>
+    filterIndexFiles(const std::vector<std::string>& index_files,
+                     bool ncs_enabled);
+
  private:
     knowhere::Index<knowhere::IndexNode> index_;
     std::shared_ptr<storage::DiskFileManagerImpl> file_manager_;

--- a/internal/core/src/ncs/CMakeLists.txt
+++ b/internal/core/src/ncs/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Copyright (C) 2019-2020 Zilliz. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under the License
+
+add_source_at_current_directory_recursively()
+add_library(milvus_ncs OBJECT ${SOURCE_FILES})

--- a/internal/core/src/ncs/ncs_c.cpp
+++ b/internal/core/src/ncs/ncs_c.cpp
@@ -1,0 +1,115 @@
+#include "ncs/ncs_c.h"
+#include "ncs/ncs.h"
+#include "common/EasyAssert.h"
+#include <stdexcept>
+#include <string>
+#include <nlohmann/json.hpp>
+
+using json = nlohmann::json;
+
+// C wrapper implementation for NCS singleton initialization
+
+CStatus
+initNcsSingleton(const char* ncsKind, const char* ncsExtras) {
+    if (ncsKind == nullptr) {
+        return milvus::FailureCStatus(milvus::InvalidParameter,
+                                      "NCS kind parameter is null");
+    }
+
+    try {
+        std::string kind(ncsKind);
+        json extras = json::object();
+
+        // Parse extras if provided
+        if (ncsExtras != nullptr && ncsExtras[0] != '\0') {
+            try {
+                extras = json::parse(ncsExtras);
+            } catch (const json::exception& e) {
+                return milvus::FailureCStatus(
+                    milvus::InvalidParameter,
+                    std::string("Failed to parse NCS extras JSON: ") +
+                        e.what());
+            }
+        }
+
+        // Initialize NCS with kind and extras
+        milvus::NcsSingleton::initNcs(kind, extras);
+
+        // Success
+        return milvus::SuccessCStatus();
+
+    } catch (const std::exception& e) {
+        return milvus::FailureCStatus(&e);
+    }
+}
+
+CStatus
+createBucket(uint64_t bucketId) {
+    try {
+        auto* ncs = milvus::NcsSingleton::Instance();
+        if (ncs == nullptr) {
+            return milvus::FailureCStatus(milvus::UnexpectedError,
+                                          "NCS singleton not initialized");
+        }
+
+        milvus::NcsStatus status = ncs->createBucket(bucketId);
+        if (status != milvus::NcsStatus::OK) {
+            std::string errMsg =
+                "Failed to create bucket with ID: " + std::to_string(bucketId);
+            return milvus::FailureCStatus(milvus::UnexpectedError,
+                                          errMsg.c_str());
+        }
+
+        return milvus::SuccessCStatus();
+
+    } catch (const std::exception& e) {
+        return milvus::FailureCStatus(&e);
+    }
+}
+
+CStatus
+deleteBucket(uint64_t bucketId) {
+    try {
+        auto* ncs = milvus::NcsSingleton::Instance();
+        if (ncs == nullptr) {
+            return milvus::FailureCStatus(milvus::UnexpectedError,
+                                          "NCS singleton not initialized");
+        }
+
+        milvus::NcsStatus status = ncs->deleteBucket(bucketId);
+        if (status != milvus::NcsStatus::OK) {
+            std::string errMsg =
+                "Failed to delete bucket with ID: " + std::to_string(bucketId);
+            return milvus::FailureCStatus(milvus::UnexpectedError,
+                                          errMsg.c_str());
+        }
+
+        return milvus::SuccessCStatus();
+
+    } catch (const std::exception& e) {
+        return milvus::FailureCStatus(&e);
+    }
+}
+
+CStatus
+isBucketExist(uint64_t bucketId, bool* exists) {
+    if (exists == nullptr) {
+        return milvus::FailureCStatus(milvus::InvalidParameter,
+                                      "exists parameter is null");
+    }
+
+    try {
+        auto* ncs = milvus::NcsSingleton::Instance();
+        if (ncs == nullptr) {
+            return milvus::FailureCStatus(milvus::UnexpectedError,
+                                          "NCS singleton not initialized");
+        }
+
+        *exists = ncs->isBucketExist(bucketId);
+
+        return milvus::SuccessCStatus();
+
+    } catch (const std::exception& e) {
+        return milvus::FailureCStatus(&e);
+    }
+}

--- a/internal/core/src/ncs/ncs_c.h
+++ b/internal/core/src/ncs/ncs_c.h
@@ -1,0 +1,51 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+
+#pragma once
+
+#include "common/type_c.h"
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Initialize the NCS singleton with a specific factory implementation
+// This must be called before any NCS operations
+// ncsExtras: JSON string containing factory-specific configuration (can be NULL or empty for defaults)
+CStatus
+initNcsSingleton(const char* ncsKind, const char* ncsExtras);
+
+// Create a bucket with the given bucket ID
+// Returns CStatus indicating success or failure
+CStatus
+createBucket(uint64_t bucketId);
+
+// Delete a bucket with the given bucket ID
+// Returns CStatus indicating success or failure
+CStatus
+deleteBucket(uint64_t bucketId);
+
+// Check if a bucket exists
+// Returns true if bucket exists, false otherwise
+// The result is returned via the 'exists' output parameter
+CStatus
+isBucketExist(uint64_t bucketId, bool* exists);
+
+// Get bucket status information
+// Note: NcsBucketStatus is currently a placeholder (TBD: capacity, occupancy, etc.)
+// This is reserved for future implementation
+// CStatus getBucketNcsStatus(uint64_t bucketId, CNcsBucketStatus* status);
+
+#ifdef __cplusplus
+}
+#endif

--- a/internal/core/src/storage/RemoteOutputStream.cpp
+++ b/internal/core/src/storage/RemoteOutputStream.cpp
@@ -12,11 +12,18 @@ RemoteOutputStream::RemoteOutputStream(
 }
 
 RemoteOutputStream::~RemoteOutputStream() {
-    // temp solution, will expose `Close` method in OutputStream later
-    auto status = output_stream_->Close();
-    AssertInfo(status.ok(),
-               "Failed to close output stream, error: {}",
-               status.ToString());
+    Close();
+}
+
+void
+RemoteOutputStream::Close() {
+    if (output_stream_) {
+        auto status = output_stream_->Close();
+        AssertInfo(status.ok(),
+                   "Failed to close output stream, error: {}",
+                   status.ToString());
+        output_stream_ = nullptr;
+    }
 }
 
 size_t

--- a/internal/core/src/storage/RemoteOutputStream.h
+++ b/internal/core/src/storage/RemoteOutputStream.h
@@ -32,6 +32,9 @@ class RemoteOutputStream : public milvus::OutputStream {
     size_t
     Write(int fd, size_t size) override;
 
+    void
+    Close() override;
+
  private:
     std::shared_ptr<arrow::io::OutputStream> output_stream_;
 };

--- a/internal/core/thirdparty/knowhere/CMakeLists.txt
+++ b/internal/core/thirdparty/knowhere/CMakeLists.txt
@@ -14,7 +14,7 @@
 # Update KNOWHERE_VERSION for the first occurrence
 milvus_add_pkg_config("knowhere")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( KNOWHERE_VERSION dcff880 )
+set( KNOWHERE_VERSION 1f54ba46 )
 set( GIT_REPOSITORY  "https://github.com/ronmarcus/knowhere.git")
 
 message(STATUS "Knowhere repo: ${GIT_REPOSITORY}")

--- a/internal/core/thirdparty/knowhere/CMakeLists.txt
+++ b/internal/core/thirdparty/knowhere/CMakeLists.txt
@@ -14,8 +14,8 @@
 # Update KNOWHERE_VERSION for the first occurrence
 milvus_add_pkg_config("knowhere")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( KNOWHERE_VERSION 1752b41 )
-set( GIT_REPOSITORY  "https://github.com/zilliztech/knowhere.git")
+set( KNOWHERE_VERSION dcff880 )
+set( GIT_REPOSITORY  "https://github.com/ronmarcus/knowhere.git")
 
 message(STATUS "Knowhere repo: ${GIT_REPOSITORY}")
 message(STATUS "Knowhere version: ${KNOWHERE_VERSION}")

--- a/internal/core/thirdparty/milvus-common/CMakeLists.txt
+++ b/internal/core/thirdparty/milvus-common/CMakeLists.txt
@@ -13,8 +13,8 @@
 
 milvus_add_pkg_config("milvus-common")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( MILVUS-COMMON-VERSION 4d7781d )
-set( GIT_REPOSITORY "https://github.com/zilliztech/milvus-common.git")
+set( MILVUS-COMMON-VERSION 26d515a)
+set( GIT_REPOSITORY "https://github.com/ronmarcus/milvus-common.git")
 
 message(STATUS "milvus-common repo: ${GIT_REPOSITORY}")
 message(STATUS "milvus-common version: ${MILVUS-COMMON-VERSION}")

--- a/internal/core/thirdparty/milvus-common/CMakeLists.txt
+++ b/internal/core/thirdparty/milvus-common/CMakeLists.txt
@@ -13,7 +13,7 @@
 
 milvus_add_pkg_config("milvus-common")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( MILVUS-COMMON-VERSION 26d515a)
+set( MILVUS-COMMON-VERSION b0a5e9ba)
 set( GIT_REPOSITORY "https://github.com/ronmarcus/milvus-common.git")
 
 message(STATUS "milvus-common repo: ${GIT_REPOSITORY}")

--- a/internal/core/unittest/test_utils/indexbuilder_test_utils.h
+++ b/internal/core/unittest/test_utils/indexbuilder_test_utils.h
@@ -131,16 +131,26 @@ template <typename DataType = float>
 inline auto
 generate_load_conf(const milvus::IndexType& index_type,
                    const milvus::MetricType& metric_type,
-                   int64_t nb) {
+                   int64_t nb,
+                   bool ncs_enable = false) {
     if (index_type == knowhere::IndexEnum::INDEX_DISKANN) {
-        return knowhere::Json{
+        auto j = knowhere::Json{
             {knowhere::meta::METRIC_TYPE, metric_type},
             {knowhere::meta::DIM, std::to_string(DIM)},
             {milvus::index::DISK_ANN_LOAD_THREAD_NUM, std::to_string(2)},
             {milvus::index::DISK_ANN_SEARCH_CACHE_BUDGET,
              std::to_string(0.05 * sizeof(DataType) * nb /
                             (1024.0 * 1024.0 * 1024.0))},
+            {milvus::index::NCS_ENABLE, ncs_enable},
         };
+        if(ncs_enable){
+            j.update({
+                {milvus::index::NCS_KIND, "in_memory"},
+                {milvus::index::NCS_EXTRAS,
+                    knowhere::Json{{"note", "unit test"}}},
+            });
+        }
+        return j;
     }
     return knowhere::Json{
         {knowhere::meta::METRIC_TYPE, metric_type},

--- a/internal/datacoord/server.go
+++ b/internal/datacoord/server.go
@@ -52,6 +52,7 @@ import (
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/dependency"
 	"github.com/milvus-io/milvus/internal/util/importutilv2"
+	"github.com/milvus-io/milvus/internal/util/initcore"
 	"github.com/milvus-io/milvus/internal/util/sessionutil"
 	"github.com/milvus-io/milvus/internal/util/streamingutil/status"
 	"github.com/milvus-io/milvus/pkg/v2/kv"
@@ -266,6 +267,14 @@ func (s *Server) initDataCoord() error {
 
 	log.Info("DataCoord try to wait for MixCoord ready")
 	if err := s.initMixCoord(); err != nil {
+		return err
+	}
+
+	// Initialize NCS singleton
+	ncsKind := paramtable.Get().CommonCfg.NcsKind.GetValue()
+	ncsExtras := paramtable.Get().CommonCfg.NcsExtras.GetValue()
+	if err := initcore.InitNcsSingleton(ncsKind, ncsExtras); err != nil {
+		log.Error("DataCoord init NCS singleton failed", zap.Error(err))
 		return err
 	}
 

--- a/internal/datanode/data_node.go
+++ b/internal/datanode/data_node.go
@@ -216,7 +216,9 @@ func (node *DataNode) Init() error {
 		err := index.InitSegcore(serverID)
 		if err != nil {
 			initError = err
+			return
 		}
+
 		log.Info("init datanode done", zap.String("Address", node.address))
 	})
 	return initError

--- a/internal/querycoordv2/server.go
+++ b/internal/querycoordv2/server.go
@@ -52,6 +52,7 @@ import (
 	"github.com/milvus-io/milvus/internal/querycoordv2/session"
 	"github.com/milvus-io/milvus/internal/querycoordv2/task"
 	"github.com/milvus-io/milvus/internal/types"
+	"github.com/milvus-io/milvus/internal/util/initcore"
 	"github.com/milvus-io/milvus/internal/util/proxyutil"
 	"github.com/milvus-io/milvus/internal/util/sessionutil"
 	"github.com/milvus-io/milvus/internal/util/tsoutil"
@@ -262,6 +263,15 @@ func (s *Server) initQueryCoord() error {
 	log := log.Ctx(s.ctx)
 	s.UpdateStateCode(commonpb.StateCode_Initializing)
 	log.Info("start init querycoord", zap.Any("State", commonpb.StateCode_Initializing))
+
+	// Initialize NCS singleton
+	ncsKind := paramtable.Get().CommonCfg.NcsKind.GetValue()
+	ncsExtras := paramtable.Get().CommonCfg.NcsExtras.GetValue()
+	if err := initcore.InitNcsSingleton(ncsKind, ncsExtras); err != nil {
+		log.Error("QueryCoord init NCS singleton failed", zap.Error(err))
+		return err
+	}
+
 	// Init KV and ID allocator
 	metaType := Params.MetaStoreCfg.MetaStoreType.GetValue()
 	var idAllocatorKV kv.TxnKV

--- a/internal/util/initcore/init_core.go
+++ b/internal/util/initcore/init_core.go
@@ -25,6 +25,7 @@ package initcore
 #include "segcore/segcore_init_c.h"
 #include "storage/storage_c.h"
 #include "segcore/arrow_fs_c.h"
+#include "ncs/ncs_c.h"
 */
 import "C"
 
@@ -658,4 +659,23 @@ func InitPluginLoader() error {
 
 func CleanPluginLoader() {
 	C.CleanPluginLoader()
+}
+
+// InitNcsSingleton initializes the NCS singleton with the specified kind and extras.
+// This should be called during node initialization before any NCS operations.
+func InitNcsSingleton(ncsKind string, ncsExtras string) error {
+	cNcsKind := C.CString(ncsKind)
+	defer C.free(unsafe.Pointer(cNcsKind))
+
+	cNcsExtras := C.CString(ncsExtras)
+	defer C.free(unsafe.Pointer(cNcsExtras))
+
+	status := C.initNcsSingleton(cNcsKind, cNcsExtras)
+	err := HandleCStatus(&status, "failed to initialize NCS singleton")
+	if err != nil {
+		return err
+	}
+
+	log.Info("NCS singleton initialized successfully", zap.String("ncsKind", ncsKind), zap.String("ncsExtras", ncsExtras))
+	return nil
 }

--- a/internal/util/ncscgowrapper/ncs_wrapper.go
+++ b/internal/util/ncscgowrapper/ncs_wrapper.go
@@ -1,0 +1,92 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ncscgowrapper
+
+/*
+#cgo pkg-config: milvus_core
+
+#include <stdlib.h>
+#include <stdint.h>
+typedef uint64_t uint64_t_cgo;
+#include "common/type_c.h"
+#include "ncs/ncs_c.h"
+*/
+import "C"
+
+import (
+	"fmt"
+	"unsafe"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus/pkg/v2/log"
+	"go.uber.org/zap"
+)
+
+// HandleCStatus deals with the error returned from CGO
+func HandleCStatus(status *C.CStatus, extraInfo string) error {
+	if status.error_code == 0 {
+		return nil
+	}
+	errorCode := status.error_code
+	errorName, ok := commonpb.ErrorCode_name[int32(errorCode)]
+	if !ok {
+		errorName = "UnknownError"
+	}
+	errorMsg := C.GoString(status.error_msg)
+	defer C.free(unsafe.Pointer(status.error_msg))
+
+	finalMsg := fmt.Sprintf("[%s] %s", errorName, errorMsg)
+	logMsg := fmt.Sprintf("%s, C Runtime Exception: %s\n", extraInfo, finalMsg)
+	log.Warn(logMsg)
+	return fmt.Errorf("%s", finalMsg)
+}
+
+// CreateBucket creates a bucket with the given bucket ID in NCS.
+func CreateBucket(bucketId uint64) error {
+	status := C.createBucket(C.uint64_t(bucketId))
+	err := HandleCStatus(&status, "failed to create bucket")
+	if err != nil {
+		log.Warn("CreateBucket failed", zap.Uint64("bucketId", bucketId), zap.Error(err))
+		return err
+	}
+	log.Info("CreateBucket succeeded", zap.Uint64("bucketId", bucketId))
+	return nil
+}
+
+// DeleteBucket deletes a bucket with the given bucket ID from NCS.
+func DeleteBucket(bucketId uint64) error {
+	status := C.deleteBucket(C.uint64_t(bucketId))
+	err := HandleCStatus(&status, "failed to delete bucket")
+	if err != nil {
+		log.Warn("DeleteBucket failed", zap.Uint64("bucketId", bucketId), zap.Error(err))
+		return err
+	}
+	log.Info("DeleteBucket succeeded", zap.Uint64("bucketId", bucketId))
+	return nil
+}
+
+// IsBucketExist checks if a bucket with the given bucket ID exists in NCS.
+func IsBucketExist(bucketId uint64) (bool, error) {
+	var exists C.bool
+	status := C.isBucketExist(C.uint64_t(bucketId), &exists)
+	err := HandleCStatus(&status, "failed to check if bucket exists")
+	if err != nil {
+		log.Warn("IsBucketExist failed", zap.Uint64("bucketId", bucketId), zap.Error(err))
+		return false, err
+	}
+	return bool(exists), nil
+}

--- a/pkg/util/indexparams/index_params.go
+++ b/pkg/util/indexparams/index_params.go
@@ -41,6 +41,9 @@ const (
 
 	MaxDegreeKey         = "max_degree"
 	SearchListSizeKey    = "search_list_size"
+	NcsEnableKey         = "ncs_enable"
+	NcsKindKey           = "ncs_kind"
+	NcsExtrasKey         = "ncs_extras"
 	PQCodeBudgetKey      = "pq_code_budget_gb"
 	BuildDramBudgetKey   = "build_dram_budget_gb"
 	NumBuildThreadKey    = "num_build_thread"
@@ -202,6 +205,10 @@ func FillDiskIndexParams(params *paramtable.ComponentParam, indexParams map[stri
 
 	indexParams[MaxDegreeKey] = maxDegree
 	indexParams[SearchListSizeKey] = searchListSize
+	//TODO: add ncs params to auto index config?
+	indexParams[NcsEnableKey] = params.CommonCfg.NcsEnable.GetValue()
+	indexParams[NcsKindKey] = params.CommonCfg.NcsKind.GetValue()
+	indexParams[NcsExtrasKey] = params.CommonCfg.NcsExtras.GetValue()
 	indexParams[PQCodeBudgetRatioKey] = pqCodeBudgetGBRatio
 	indexParams[NumBuildThreadRatioKey] = buildNumThreadsRatio
 	indexParams[SearchCacheBudgetRatioKey] = searchCacheBudgetGBRatio

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -237,6 +237,9 @@ type commonConfig struct {
 	SearchCacheBudgetGBRatio            ParamItem `refreshable:"true"`
 	LoadNumThreadRatio                  ParamItem `refreshable:"true"`
 	BeamWidthRatio                      ParamItem `refreshable:"true"`
+	NcsEnable                           ParamItem `refreshable:"false"`
+	NcsKind                             ParamItem `refreshable:"false"`
+	NcsExtras                           ParamItem `refreshable:"false"`
 	GracefulTime                        ParamItem `refreshable:"true"`
 	GracefulStopTimeout                 ParamItem `refreshable:"true"`
 	EnableNamespace                     ParamItem `refreshable:"false"`
@@ -570,6 +573,33 @@ This configuration is only used by querynode and indexnode, it selects CPU instr
 		Export:       true,
 	}
 	p.SearchListSize.Init(base.mgr)
+
+	p.NcsEnable = ParamItem{
+		Key:          "common.DiskIndex.NcsEnable",
+		Version:      "2.5.0",
+		DefaultValue: "false",
+		Export:       true,
+		Doc:          "Enable NCS for disk based indexes",
+	}
+	p.NcsEnable.Init(base.mgr)
+
+	p.NcsKind = ParamItem{
+		Key:          "common.DiskIndex.NcsKind",
+		Version:      "2.5.0",
+		DefaultValue: "in_memory",
+		Export:       true,
+		Doc:          "NCS kind for disk based indexes",
+	}
+	p.NcsKind.Init(base.mgr)
+
+	p.NcsExtras = ParamItem{
+		Key:          "common.DiskIndex.NcsExtras",
+		Version:      "2.5.0",
+		DefaultValue: "{}",
+		Export:       true,
+		Doc:          "NCS extra params, in JSON string format",
+	}
+	p.NcsExtras.Init(base.mgr)
 
 	p.PQCodeBudgetGBRatio = ParamItem{
 		Key:          "common.DiskIndex.PQCodeBudgetGBRatio",

--- a/run_sanity_check_diskann_biuld_and_search.py
+++ b/run_sanity_check_diskann_biuld_and_search.py
@@ -1,0 +1,101 @@
+from pymilvus import (
+    connections, FieldSchema, CollectionSchema, DataType, Collection, utility
+)
+import random, math
+import time
+import matplotlib.pyplot as plt
+import json
+import sys
+import os
+
+# ---------- CONFIG ----------
+HOST = "127.0.0.1"   # or your Minikube/cluster IP
+PORT = "19530"
+COLLECTION = "demo_vectors"
+METRIC = "L2"
+
+# ---------- CONNECT ----------
+connections.connect("default", host=HOST, port=PORT)
+print("✅ Connected to Milvus", utility.get_server_version())
+
+
+results_json = []
+
+for INDEX_TYPE in ["DISKANN"]:
+    for DIM in [8, 64, 512]:
+        for N in [2000, 100_000]:
+            # Clean up old demo if it exists
+            if utility.has_collection(COLLECTION):
+                utility.drop_collection(COLLECTION)
+
+            # ---------- DEFINE SCHEMA ----------
+            id_field = FieldSchema("id", DataType.INT64, is_primary=True, auto_id=False)
+            vec_field = FieldSchema("embedding", DataType.FLOAT_VECTOR, dim=DIM)
+            schema = CollectionSchema(fields=[id_field, vec_field], description="demo collection")
+
+            coll = Collection(COLLECTION, schema)
+
+            # ---------- INSERT DATA ----------
+            def make_vec(dim=DIM):
+                return [random.random() for _ in range(dim)]
+
+            ids = list(range(N))
+            vectors = [make_vec() for _ in range(N)]
+            for i in range(N//1000):
+                coll.insert([ids[i:i+1000], vectors[i:i+1000]])
+            coll.flush()
+
+            # ---------- CREATE INDEX ----------
+            build_start = time.time()
+            coll.create_index(
+                field_name="embedding",
+                index_params={"index_type": INDEX_TYPE, "metric_type": METRIC, "params": {"nlist": 64}},
+            )
+            coll.load()
+            build_end = time.time()
+            build_latency = build_end - build_start
+
+            # ---------- SEARCH ----------
+            query_vec = [make_vec()]
+            search_start = time.time()
+            results = coll.search(
+                data=query_vec,
+                anns_field="embedding",
+                param={"metric_type": METRIC, "params": {"nprobe": 8}},
+                limit=5,
+                output_fields=["id"]
+            )
+            search_end = time.time()
+            search_latency = search_end - search_start
+
+            print(f"INDEX_TYPE={INDEX_TYPE}, D={DIM}, N={N}, build_latency = {build_latency:.4f}, search_latency = {search_latency:.4f}")
+            print("\nTop-5 nearest vectors:")
+            search_results = []
+            for hit in results[0]:
+                print(f"  id={hit.id}, distance={hit.distance:.4f}")
+                search_results.append({"id": hit.id, "distance": hit.distance})
+
+            results_json.append({
+                "INDEX_TYPE": INDEX_TYPE,
+                "DIM": DIM,
+                "N": N,
+                "build_latency": build_latency,
+                "search_latency": search_latency,
+                "search_results": search_results
+            })
+
+            # ---------- OPTIONAL CLEANUP ----------
+            coll.release()
+
+# Get suffix from command-line argument (default: "")
+suffix = ""
+if len(sys.argv) > 1:
+    suffix = sys.argv[1]
+    if not suffix.startswith("_") and suffix != "":
+        suffix = "_" + suffix
+
+results_folder = "milvus_benchmark_results"
+os.makedirs(results_folder, exist_ok=True)
+results_filename = f"{results_folder}/milvus_benchmark_results{suffix}.json"
+with open(results_filename, "w") as f:
+    json.dump(results_json, f, indent=2)

--- a/run_sanity_check_diskann_build_and_search.py
+++ b/run_sanity_check_diskann_build_and_search.py
@@ -42,7 +42,9 @@ for INDEX_TYPE in ["DISKANN"]:
             ids = list(range(N))
             vectors = [make_vec() for _ in range(N)]
             for i in range(N//1000):
-                coll.insert([ids[i:i+1000], vectors[i:i+1000]])
+                start = i*1000
+                end = min((i+1)*1000, N)
+                coll.insert([ids[start:end], vectors[start:end]])
             coll.flush()
 
             # ---------- CREATE INDEX ----------
@@ -69,7 +71,7 @@ for INDEX_TYPE in ["DISKANN"]:
             search_latency = search_end - search_start
 
             print(f"INDEX_TYPE={INDEX_TYPE}, D={DIM}, N={N}, build_latency = {build_latency:.4f}, search_latency = {search_latency:.4f}")
-            print("\nTop-5 nearest vectors:")
+            print("Top-5 nearest vectors:")
             search_results = []
             for hit in results[0]:
                 print(f"  id={hit.id}, distance={hit.distance:.4f}")

--- a/scripts/restart_with_dev_deployment.sh
+++ b/scripts/restart_with_dev_deployment.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Parse params
+USE_GDB=false
+MODE=""
+
+for arg in "$@"; do
+    if [ "$arg" == "--gdb" ]; then
+        USE_GDB=true
+    elif [ -z "$MODE" ]; then
+        MODE=$arg
+    fi
+done
+
+if [ -z "$MODE" ]; then
+    MODE="standalone"
+else
+    if [ "$MODE" != "standalone" ] && [ "$MODE" != "cluster" ]; then
+        echo "invalid mode: $MODE"
+        echo "usage : bash restart_with_dev_deployment.sh [mode] [--gdb]. mode: standalone / cluster. default is standalone"
+        exit 1
+    fi
+fi
+
+# Validate --gdb flag
+if [ "$USE_GDB" == "true" ] && [ "$MODE" != "standalone" ]; then
+    echo "Error: --gdb flag is only supported in standalone mode"
+    exit 1
+fi
+
+
+script_path=$(dirname "$0")
+docker_compose_path=$script_path/../deployments/docker/dev
+
+$script_path/stop.sh
+docker compose -f $docker_compose_path/docker-compose-redis.yml down -v
+sudo rm -rf $docker_compose_path/volumes/*
+sudo rm -rf /tmp/milvus/*
+sudo rm -rf /var/lib/milvus/*
+
+docker compose -f $docker_compose_path/docker-compose-redis.yml up -d
+sleep 5
+
+if [ "$MODE" == "cluster" ]; then
+    $script_path/start_cluster.sh
+else
+    if [ "$USE_GDB" == "true" ]; then
+        $script_path/start_standalone.sh --gdb
+    else
+        $script_path/start_standalone.sh
+    fi
+fi
+
+

--- a/tests/python_client/deploy/scripts/first_recall_test.py
+++ b/tests/python_client/deploy/scripts/first_recall_test.py
@@ -16,8 +16,8 @@ from pymilvus import (
 pymilvus_version = pymilvus.__version__
 
 
-all_index_types = ["IVF_FLAT", "IVF_SQ8", "HNSW"]
-default_index_params = [{"nlist": 128}, {"nlist": 128}, {"M": 48, "efConstruction": 200}]
+all_index_types = ["IVF_FLAT", "IVF_SQ8", "HNSW", "DISKANN"]
+default_index_params = [{"nlist": 128}, {"nlist": 128}, {"M": 48, "efConstruction": 200}, {}]
 index_params_map = dict(zip(all_index_types, default_index_params))
 
 
@@ -49,6 +49,10 @@ def gen_search_param(index_type, metric_type="L2"):
         for search_k in [1000]:
             annoy_search_param = {"metric_type": metric_type, "params": {"search_k": search_k}}
             search_params.append(annoy_search_param)
+    elif index_type == "DISKANN":
+        for search_list in [150]:
+            diskann_search_param = {"metric_type": metric_type, "params": {"search_list": search_list}}
+            search_params.append(diskann_search_param)
     else:
         logger.info("Invalid index_type.")
         raise Exception("Invalid index_type.")
@@ -151,7 +155,8 @@ def milvus_recall_test(host='127.0.0.1', index_type="HNSW"):
     # define output_fields of search result
     for i in range(3):
         t0 = time.time()
-        logger.info(f"Search...")
+        logger.info(f"Search... TIMEOUT={TIMEOUT}")
+        logger.info(f"params={current_search_params}")
         res = collection.search(
             test[:nq], "float_vector", current_search_params, topK, output_fields=["int64"], timeout=TIMEOUT
         )
@@ -196,6 +201,6 @@ if __name__ == "__main__":
     args = parser.parse_args()
     host = args.host
     tasks = []
-    for index_type in ["HNSW"]:
+    for index_type in ["HNSW", "DISKANN"]:
         milvus_recall_test(host, index_type)
 


### PR DESCRIPTION
This commit integrates Near-Compute Storage (NCS) into the Milvus control plane, enabling the system to utilize disaggregated storage for DiskANN indices.

Key changes:
- Added NCS configuration parameters (`ncs.enable`, `ncs.kind`, `ncs.extras`) to `milvus.yaml` and `ParamTable`.
- Integrated `ncscgowrapper` to bridge Go components with the C++ NCS core.
- Updated `QueryCoord` and `DataNode` to initialize NCS singletons.
- Updated `DataCoord` to manage NCS bucket lifecycle (currently - the creation) for segments.
- Updated `QueryCoord` to verify bucket existence.
- Passed NCS parameters to Knowhere during index loading and search operations.
- Added tests to `internal/core/unittest/test_indexing.cpp` for C++ core NCS testing.
- Added DiskANN algorithm to the first_recall_test.py test.
- Updated developer scripts (`restart_with_dev_deployment.sh`, `start_standalone.sh`) for better dev experience.

issue: milvus-io/milvus#45178

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Near-Compute Storage (NCS) Integration for Milvus

**Core Invariant:** This PR integrates NCS as an optional, conditionally-enabled storage backend for DiskANN indices, controlled by a configuration flag (`NcsEnable`, default `true`) with fallback to in-memory mode. All NCS operations remain guarded by explicit `ncs_enabled` conditional checks, ensuring non-NCS code paths remain unaffected.

**Feature Addition:** Adds support for disaggregated storage via NCS for DiskANN indices, enabling compute-storage separation. NCS is wired into four critical paths: (1) DataCoord creates NCS buckets for segments during index allocation (via `createBucket`), (2) Index building embeds NCS descriptors during build/load via `ncsUpload`, (3) QueryCoord verifies bucket existence before segment load via `isBucketExist`, and (4) Index loading conditionally filters index files when NCS is enabled. The feature is exposed through new paramtable fields (`NcsEnable`, `NcsKind`, `NcsExtras`) and C/Go wrapper APIs (`initNcsSingleton`, `createBucket`, `deleteBucket`, `isBucketExist`).

**No Data Loss / No Regression:** All NCS-specific logic is conditional on the `ncs_enabled` flag extracted from configuration; when disabled (or defaulting to in-memory), existing code paths execute unchanged (e.g., `VectorDiskIndex.cpp` skips `ncsUpload` and file filtering if NCS is disabled). Load operations enforce bucket existence checks *before* attempting to load segments, preventing orphaned segment loads. Initialization failures in DataCoord, QueryCoord, and DataNode are logged and return errors early, blocking partial initialization rather than silently degrading.

**Dependency and Build Changes:** Updates Knowhere and milvus-common dependencies to NCS-aware versions (from ronmarcus/knowhere and ronmarcus/milvus-common forks), adds hiredis dependency for potential Redis NCS backend support, installs NCS C headers into the build output, and updates Docker build images to include SSH and libpci3 for development infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->