### PR TITLE
enhance: add glog sink to transfer cgo log into zap

### DIFF
--- a/configs/glog.conf
+++ b/configs/glog.conf
@@ -1,10 +1,5 @@
-# if true, only log to stdout
---logtostdout=true
---logtostderr=false
---alsologtostderr=false
 # `INFO``, ``WARNING``, ``ERROR``, and ``FATAL`` are 0, 1, 2, and 3
 --minloglevel=0
---log_dir=/var/lib/milvus/logs/
 # using vlog to implement debug and trace log
 # if set vmodule to 5, open debug level
 # if set vmodule to 6, open trace level

--- a/internal/core/CMakeLists.txt
+++ b/internal/core/CMakeLists.txt
@@ -25,6 +25,10 @@ add_definitions(-DELPP_THREAD_SAFE)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 message( STATUS "Building using CMake version: ${CMAKE_VERSION}" )
 
+if ( BUILD_UNIT_TEST STREQUAL "ON" )
+    add_definitions(-DWITHOUT_GO_LOGGING)
+endif()
+
 if ( MILVUS_GPU_VERSION )
     add_definitions(-DMILVUS_GPU_VERSION)
 endif ()

--- a/internal/core/src/common/logging_c.cpp
+++ b/internal/core/src/common/logging_c.cpp
@@ -1,0 +1,62 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "logging_c.h"
+
+#ifdef WITHOUT_GO_LOGGING
+
+// Empty implementation when there's no go logging implementation.
+void
+goZapLogExt(
+    int severity, const char* file, int line, const char* msg, int msg_len) {
+}
+
+#elif defined(__APPLE__)
+
+// Go export function.
+// will be implemented in github.com/milvus-io/milvus/internal/util/cgo/logging
+// macOS linker requires weak_import to allow unresolved symbols.
+extern "C" void
+goZapLogExt(
+    int severity, const char* file, int line, const char* msg, int msg_len) {
+}
+__attribute__((weak_import));
+
+#else
+
+// Go export function.
+// will be implemented in github.com/milvus-io/milvus/internal/util/cgo/logging
+extern "C" void
+goZapLogExt(
+    int severity, const char* file, int line, const char* msg, int msg_len);
+
+#endif
+
+void
+GoZapSink::send(google::LogSeverity severity,
+                const char* full_filename,
+                const char* base_filename,
+                int line,
+                const struct tm*,
+                const char* message,
+                size_t message_len) {
+    // remove the '\n' added by glog
+    int len = static_cast<int>(message_len);
+    if (len > 0 && message[len - 1] == '\n') {
+        len--;
+    }
+    goZapLogExt(static_cast<int>(severity), full_filename, line, message, len);
+};

--- a/internal/core/src/common/logging_c.h
+++ b/internal/core/src/common/logging_c.h
@@ -1,4 +1,4 @@
-// Licensed to the LF AI & Data foundation under one
+// Licensed to the LF AI& Data foundation under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
 // regarding copyright ownership. The ASF licenses this file
@@ -14,22 +14,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+#pragma once
+#include <glog/logging.h>
 
-import "C"
-
-import (
-	"os"
-
-	"github.com/milvus-io/milvus/cmd/milvus"
-	_ "github.com/milvus-io/milvus/internal/util/cgo"
-)
-
-//export startEmbedded
-func startEmbedded() {
-	os.Setenv("MILVUSCONF", "/tmp/milvus/configs/")
-	milvus.RunMilvus([]string{"", "run", "embedded"})
-}
-
-func main() {
-}
+class GoZapSink : public google::LogSink {
+    void
+    send(google::LogSeverity severity,
+         const char* full_filename,
+         const char* base_filename,
+         int line,
+         const struct tm*,
+         const char* message,
+         size_t message_len) override;
+};

--- a/internal/core/src/config/ConfigKnowhere.cpp
+++ b/internal/core/src/config/ConfigKnowhere.cpp
@@ -22,10 +22,13 @@
 #include "log/Log.h"
 #include "knowhere/comp/knowhere_config.h"
 #include "knowhere/version.h"
+#include "common/logging_c.h"
 
 namespace milvus::config {
 
 std::once_flag init_knowhere_once_;
+
+static GoZapSink g_sink;
 
 void
 KnowhereInitImpl(const char* conf_file) {
@@ -35,6 +38,13 @@ KnowhereInitImpl(const char* conf_file) {
         knowhere::KnowhereConfig::ShowVersion();
         if (!google::IsGoogleLoggingInitialized()) {
             google::InitGoogleLogging("milvus");
+            google::AddLogSink(&g_sink);
+
+            // log is catched by zap, so we don't need to log to stderr/stdout/files anymore.
+            FLAGS_logtostdout = false;
+            FLAGS_logtostderr = false;
+            FLAGS_alsologtostderr = false;
+            FLAGS_log_dir = "";
         }
 
 #ifdef EMBEDDED_MILVUS

--- a/internal/datanode/index/init_segcore.go
+++ b/internal/datanode/index/init_segcore.go
@@ -31,6 +31,7 @@ import (
 	"path"
 	"unsafe"
 
+	_ "github.com/milvus-io/milvus/internal/util/cgo"
 	"github.com/milvus-io/milvus/internal/util/initcore"
 	"github.com/milvus-io/milvus/internal/util/pathutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/hardware"

--- a/internal/proxy/cgo_util.go
+++ b/internal/proxy/cgo_util.go
@@ -32,6 +32,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	_ "github.com/milvus-io/milvus/internal/util/cgo"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/util/conc"
 	"github.com/milvus-io/milvus/pkg/v2/util/hardware"

--- a/internal/querynodev2/server.go
+++ b/internal/querynodev2/server.go
@@ -54,6 +54,7 @@ import (
 	"github.com/milvus-io/milvus/internal/registry"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/types"
+	_ "github.com/milvus-io/milvus/internal/util/cgo"
 	"github.com/milvus-io/milvus/internal/util/dependency"
 	"github.com/milvus-io/milvus/internal/util/hookutil"
 	"github.com/milvus-io/milvus/internal/util/initcore"

--- a/internal/storagev2/packed/ffi_common.go
+++ b/internal/storagev2/packed/ffi_common.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"unsafe"
 
+	_ "github.com/milvus-io/milvus/internal/util/cgo"
 	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
 )
 

--- a/internal/util/analyzecgowrapper/analyze.go
+++ b/internal/util/analyzecgowrapper/analyze.go
@@ -32,6 +32,7 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 
+	_ "github.com/milvus-io/milvus/internal/util/cgo"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/proto/clusteringpb"
 )

--- a/internal/util/analyzer/canalyzer/c_analyzer.go
+++ b/internal/util/analyzer/canalyzer/c_analyzer.go
@@ -12,6 +12,7 @@ import (
 	"unsafe"
 
 	"github.com/milvus-io/milvus/internal/util/analyzer/interfaces"
+	_ "github.com/milvus-io/milvus/internal/util/cgo"
 )
 
 var _ interfaces.Analyzer = (*CAnalyzer)(nil)

--- a/internal/util/cgo/futures.go
+++ b/internal/util/cgo/futures.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 
+	_ "github.com/milvus-io/milvus/internal/util/cgo/logging"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 )
 

--- a/internal/util/cgo/logging/logging.go
+++ b/internal/util/cgo/logging/logging.go
@@ -1,0 +1,84 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logging
+
+/*
+extern void goZapLogExt(int severity,
+            char* file,
+            int line,
+            char* msg,
+            int msg_len);
+*/
+import "C"
+
+import (
+	"time"
+
+	"go.uber.org/zap/zapcore"
+
+	"github.com/milvus-io/milvus/pkg/v2/log"
+	"github.com/milvus-io/milvus/pkg/v2/metrics"
+)
+
+const cgoLoggerName = "CGO"
+
+//export goZapLogExt
+func goZapLogExt(sev C.int,
+	file *C.char,
+	line C.int,
+	msg *C.char,
+	msgLen C.int,
+) {
+	lv := mapGlogSeverity(int(sev))
+	if !log.L().Core().Enabled(lv) {
+		return
+	}
+	ent := zapcore.Entry{
+		Level:      mapGlogSeverity(int(sev)),
+		Time:       time.Now(),
+		LoggerName: cgoLoggerName,
+		Message:    C.GoStringN(msg, msgLen),
+		Caller: zapcore.EntryCaller{
+			Defined: true,
+			File:    C.GoString(file),
+			Line:    int(line),
+		},
+	}
+	if ce := log.L().Core().Check(ent, nil); ce != nil {
+		metrics.LoggingCGOWriteTotal.Inc()
+		metrics.LoggingCGOWriteBytes.Add(float64(msgLen))
+		ce.Write()
+	}
+}
+
+func mapGlogSeverity(s int) zapcore.Level {
+	switch s {
+	case 0: // GLOG_INFO
+		return zapcore.InfoLevel
+	case 1: // GLOG_WARNING
+		return zapcore.WarnLevel
+	case 2: // GLOG_ERROR
+		return zapcore.ErrorLevel
+	case 3: // GLOG_FATAL
+		// glog fatal will call std::abort,
+		// zap will call os.Exit(1),
+		// we don't want to double exit, so we use error level instead
+		return zapcore.ErrorLevel
+	default:
+		return zapcore.InfoLevel
+	}
+}

--- a/internal/util/cgo/logging/logging_test.go
+++ b/internal/util/cgo/logging/logging_test.go
@@ -14,22 +14,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
-
-import "C"
+package logging
 
 import (
-	"os"
+	"testing"
 
-	"github.com/milvus-io/milvus/cmd/milvus"
-	_ "github.com/milvus-io/milvus/internal/util/cgo"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
 )
 
-//export startEmbedded
-func startEmbedded() {
-	os.Setenv("MILVUSCONF", "/tmp/milvus/configs/")
-	milvus.RunMilvus([]string{"", "run", "embedded"})
-}
-
-func main() {
+func TestLogging(t *testing.T) {
+	require.Equal(t, zapcore.InfoLevel, mapGlogSeverity(0))
+	require.Equal(t, zapcore.WarnLevel, mapGlogSeverity(1))
+	require.Equal(t, zapcore.ErrorLevel, mapGlogSeverity(2))
+	require.Equal(t, zapcore.ErrorLevel, mapGlogSeverity(3))
+	require.Equal(t, zapcore.InfoLevel, mapGlogSeverity(4))
 }

--- a/internal/util/cgoconverter/bytes_converter.go
+++ b/internal/util/cgoconverter/bytes_converter.go
@@ -10,6 +10,7 @@ import (
 	"sync/atomic"
 	"unsafe"
 
+	_ "github.com/milvus-io/milvus/internal/util/cgo"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
 

--- a/internal/util/indexcgowrapper/index.go
+++ b/internal/util/indexcgowrapper/index.go
@@ -23,6 +23,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/storage"
+	_ "github.com/milvus-io/milvus/internal/util/cgo"
 	"github.com/milvus-io/milvus/internal/util/segcore"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/proto/cgopb"

--- a/internal/util/indexparamcheck/vector_index_checker.go
+++ b/internal/util/indexparamcheck/vector_index_checker.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	_ "github.com/milvus-io/milvus/internal/util/cgo"
 	"github.com/milvus-io/milvus/internal/util/vecindexmgr"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/proto/indexcgopb"

--- a/internal/util/initcore/init_core.go
+++ b/internal/util/initcore/init_core.go
@@ -41,6 +41,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	_ "github.com/milvus-io/milvus/internal/util/cgo"
 	"github.com/milvus-io/milvus/internal/util/hookutil"
 	"github.com/milvus-io/milvus/internal/util/pathutil"
 	"github.com/milvus-io/milvus/pkg/v2/log"

--- a/internal/util/metrics/c_registry.go
+++ b/internal/util/metrics/c_registry.go
@@ -43,6 +43,7 @@ import (
 	"golang.org/x/exp/maps"
 	"google.golang.org/protobuf/proto"
 
+	_ "github.com/milvus-io/milvus/internal/util/cgo"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 )
 

--- a/internal/util/segcore/segcore_init.go
+++ b/internal/util/segcore/segcore_init.go
@@ -1,5 +1,9 @@
 package segcore
 
+import (
+	_ "github.com/milvus-io/milvus/internal/util/cgo"
+)
+
 /*
 #cgo pkg-config: milvus_core
 

--- a/internal/util/vecindexmgr/vector_index_mgr.go
+++ b/internal/util/vecindexmgr/vector_index_mgr.go
@@ -31,6 +31,7 @@ import (
 	"unsafe"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	_ "github.com/milvus-io/milvus/internal/util/cgo"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 )
 

--- a/pkg/metrics/logging_metrics.go
+++ b/pkg/metrics/logging_metrics.go
@@ -29,57 +29,81 @@ const (
 var (
 	LoggingMetricsRegisterOnce sync.Once
 
-	LoggingPendingWriteLength = prometheus.NewGauge(prometheus.GaugeOpts{
+	LoggingPendingWriteTotal = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: milvusNamespace,
 		Subsystem: loggingMetricSubsystem,
-		Name:      "pending_write_length",
+		Name:      "pending_write_total",
 		Help:      "The length of pending writes in the logging buffer",
 	})
 
-	LoggingPendingWriteBytes = prometheus.NewGauge(prometheus.GaugeOpts{
+	LoggingTruncatedWriteTotal = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: milvusNamespace,
 		Subsystem: loggingMetricSubsystem,
-		Name:      "pending_write_bytes",
-		Help:      "The total bytes of pending writes in the logging buffer",
-	})
-
-	LoggingTruncatedWrites = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: milvusNamespace,
-		Subsystem: loggingMetricSubsystem,
-		Name:      "truncated_writes",
+		Name:      "truncated_write_total",
 		Help:      "The number of truncated writes due to exceeding the max bytes per log",
 	})
 
-	LoggingTruncatedWriteBytes = prometheus.NewGauge(prometheus.GaugeOpts{
+	LoggingTruncatedWriteBytes = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: milvusNamespace,
 		Subsystem: loggingMetricSubsystem,
 		Name:      "truncated_write_bytes",
 		Help:      "The total bytes of truncated writes due to exceeding the max bytes per log",
 	})
 
-	LoggingDroppedWrites = prometheus.NewGauge(prometheus.GaugeOpts{
+	LoggingDroppedWriteTotal = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: milvusNamespace,
 		Subsystem: loggingMetricSubsystem,
-		Name:      "dropped_writes",
+		Name:      "dropped_write_total",
 		Help:      "The number of dropped writes due to buffer full or write timeout",
 	})
 
-	LoggingIOFailure = prometheus.NewGauge(prometheus.GaugeOpts{
+	LoggingIOFailureTotal = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: milvusNamespace,
 		Subsystem: loggingMetricSubsystem,
-		Name:      "io_failures",
+		Name:      "io_failure_total",
 		Help:      "The number of IO failures due to underlying write syncer is blocked or write timeout",
+	})
+
+	LoggingWriteTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: milvusNamespace,
+		Subsystem: loggingMetricSubsystem,
+		Name:      "write_total",
+		Help:      "The total number of writes",
+	})
+
+	LoggingWriteBytes = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: milvusNamespace,
+		Subsystem: loggingMetricSubsystem,
+		Name:      "write_bytes",
+		Help:      "The total bytes of written logs",
+	})
+
+	LoggingCGOWriteTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: milvusNamespace,
+		Subsystem: loggingMetricSubsystem,
+		Name:      "cgo_write_total",
+		Help:      "The total number of CGO writes",
+	})
+
+	LoggingCGOWriteBytes = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: milvusNamespace,
+		Subsystem: loggingMetricSubsystem,
+		Name:      "cgo_write_bytes",
+		Help:      "The total bytes of CGO write logs, the bytes is calculated before encoding, only considers the length of the message, so the actual bytes may be greater than the value",
 	})
 )
 
 // RegisterLoggingMetrics registers logging metrics
 func RegisterLoggingMetrics(registry *prometheus.Registry) {
 	LoggingMetricsRegisterOnce.Do(func() {
-		registry.MustRegister(LoggingPendingWriteLength)
-		registry.MustRegister(LoggingPendingWriteBytes)
-		registry.MustRegister(LoggingTruncatedWrites)
+		registry.MustRegister(LoggingPendingWriteTotal)
+		registry.MustRegister(LoggingTruncatedWriteTotal)
 		registry.MustRegister(LoggingTruncatedWriteBytes)
-		registry.MustRegister(LoggingDroppedWrites)
-		registry.MustRegister(LoggingIOFailure)
+		registry.MustRegister(LoggingDroppedWriteTotal)
+		registry.MustRegister(LoggingIOFailureTotal)
+		registry.MustRegister(LoggingWriteTotal)
+		registry.MustRegister(LoggingWriteBytes)
+		registry.MustRegister(LoggingCGOWriteTotal)
+		registry.MustRegister(LoggingCGOWriteBytes)
 	})
 }


### PR DESCRIPTION
issue: #45640
pr: #46721

- After async logging, the C log and go log has no order promise, meanwhile the C log format is not consistent with Go Log; so we close the output of glog, just forward the log result operation into Go side which will be handled by the async zap logger.
- Use CGO to filter all cgo logging and promise the order between c log and go log.
- Also fix the metric name, add new metric to count the logging.
- TODO: after woodpecker use the logger of milvus, we can add bigger buffer for logging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Core invariant: all C (glog) and Go logs must be routed through the same zap async pipeline so ordering and formatting are preserved; this PR ensures every glog emission is captured and forwarded to zap before any async buffering diverges the outputs.

- Logic removed/simplified: direct glog outputs and hard stdout/stderr/log_dir settings are disabled (configs/glog.conf and flags in internal/core/src/config/ConfigKnowhere.cpp) because they are redundant once a single zap sink handles all logs; logging metrics were simplified from per-length/volatile gauges to totalized counters (pkg/metrics/logging_metrics.go & pkg/log/*), removing duplicate length-tracking and making accounting consistent.

- No data loss or behavior regression (concrete code paths): Google logging now adds a GoZapSink (internal/core/src/common/logging_c.h, logging_c.cpp) that calls the exported CGO bridge goZapLogExt (internal/util/cgo/logging/logging.go). Go side uses C.GoStringN/C.GoString to capture full message and file, maps glog severities to zapcore levels, preserves caller info, and writes via the existing zap async core (same write path used by Go logs). The C++ send() trims glog's trailing newline and forwards exact buffers/lengths, so message content, file, line, and severity are preserved and serialized through the same async writer—no log entries are dropped or reordered relative to Go logs.

- Capability added (where it takes effect): a CGO bridge that forwards glog into zap—new Go-exported function goZapLogExt (internal/util/cgo/logging/logging.go), a GoZapSink in C++ that forwards glog sends (internal/core/src/common/logging_c.h/.cpp), and blank imports of the cgo initializer across multiple packages (various internal/* files) to ensure the bridge is registered early so all C logs are captured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->