### PR TITLE
enhance: add security controls for /expr endpoin

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -975,6 +975,7 @@ common:
     defaultRootPassword: Milvus
     rootShouldBindRole: false # Whether the root user should bind a role when the authorization is enabled.
     enablePublicPrivilege: true # Whether to enable public privilege
+    exprEnabled: false # Whether to enable the /expr endpoint for debugging. When enabled, only root user can access it via HTTP Basic Auth on Proxy nodes.
     rbac:
       overrideBuiltInPrivilegeGroups:
         enabled: false # Whether to override build-in privilege groups

--- a/internal/http/server_test.go
+++ b/internal/http/server_test.go
@@ -203,7 +203,27 @@ func (suite *HTTPServerTestSuite) TestPprofHandler() {
 func (suite *HTTPServerTestSuite) TestExprHandler() {
 	expr.Init()
 	expr.Register("foo", "hello")
-	suite.Run("fail", func() {
+
+	suite.Run("disabled_by_default", func() {
+		// By default, exprEnabled is false, should return 403
+		paramtable.Get().Save("common.security.exprEnabled", "false")
+		url := "http://localhost:" + DefaultListenPort + ExprPath + "?code=foo&auth=by-dev"
+		client := http.Client{}
+		req, _ := http.NewRequest(http.MethodGet, url, nil)
+		resp, err := client.Do(req)
+		suite.Nil(err)
+		defer resp.Body.Close()
+		suite.Equal(http.StatusForbidden, resp.StatusCode)
+		body, _ := io.ReadAll(resp.Body)
+		suite.True(strings.Contains(string(body), "expr endpoint is disabled"))
+	})
+
+	suite.Run("enabled_without_proxy_uses_auth_param", func() {
+		// When enabled but not on Proxy node (no proxy registered, no passwordVerifyFunc),
+		// it should use the original auth parameter
+		paramtable.Get().Save("common.security.exprEnabled", "true")
+
+		// Without auth param - should fail
 		url := "http://localhost:" + DefaultListenPort + ExprPath + "?code=foo"
 		client := http.Client{}
 		req, _ := http.NewRequest(http.MethodGet, url, nil)
@@ -212,17 +232,75 @@ func (suite *HTTPServerTestSuite) TestExprHandler() {
 		defer resp.Body.Close()
 		body, _ := io.ReadAll(resp.Body)
 		suite.True(strings.Contains(string(body), "failed to execute"))
+
+		// With correct auth param - should succeed
+		url = "http://localhost:" + DefaultListenPort + ExprPath + "?auth=by-dev&code=foo"
+		req, _ = http.NewRequest(http.MethodGet, url, nil)
+		resp, err = client.Do(req)
+		suite.Nil(err)
+		defer resp.Body.Close()
+		body, _ = io.ReadAll(resp.Body)
+		suite.True(strings.Contains(string(body), "hello"))
 	})
-	suite.Run("success", func() {
-		url := "http://localhost:" + DefaultListenPort + ExprPath + "?auth=by-dev&code=foo"
+
+	suite.Run("enabled_on_proxy_requires_root_auth", func() {
+		// When enabled on Proxy node (proxy registered and passwordVerifyFunc set),
+		// it should require root user authentication
+		paramtable.Get().Save("common.security.exprEnabled", "true")
+		expr.Register("proxy", "mock_proxy")
+
+		// Register a mock password verify function
+		RegisterPasswordVerifyFunc(func(ctx context.Context, username, password string) bool {
+			return username == "root" && password == "Milvus"
+		})
+
+		// Without auth header - should fail with 401
+		url := "http://localhost:" + DefaultListenPort + ExprPath + "?code=foo"
 		client := http.Client{}
 		req, _ := http.NewRequest(http.MethodGet, url, nil)
 		resp, err := client.Do(req)
 		suite.Nil(err)
 		defer resp.Body.Close()
+		suite.Equal(http.StatusUnauthorized, resp.StatusCode)
 		body, _ := io.ReadAll(resp.Body)
+		suite.True(strings.Contains(string(body), "authentication required"))
+
+		// With non-root user - should fail with 401
+		url = "http://localhost:" + DefaultListenPort + ExprPath + "?code=foo"
+		req, _ = http.NewRequest(http.MethodGet, url, nil)
+		req.SetBasicAuth("admin", "password")
+		resp, err = client.Do(req)
+		suite.Nil(err)
+		defer resp.Body.Close()
+		suite.Equal(http.StatusUnauthorized, resp.StatusCode)
+		body, _ = io.ReadAll(resp.Body)
+		suite.True(strings.Contains(string(body), "only root user"))
+
+		// With root user but wrong password - should fail with 401
+		url = "http://localhost:" + DefaultListenPort + ExprPath + "?code=foo"
+		req, _ = http.NewRequest(http.MethodGet, url, nil)
+		req.SetBasicAuth("root", "wrong_password")
+		resp, err = client.Do(req)
+		suite.Nil(err)
+		defer resp.Body.Close()
+		suite.Equal(http.StatusUnauthorized, resp.StatusCode)
+		body, _ = io.ReadAll(resp.Body)
+		suite.True(strings.Contains(string(body), "invalid root password"))
+
+		// With correct root credentials - should succeed
+		url = "http://localhost:" + DefaultListenPort + ExprPath + "?code=foo"
+		req, _ = http.NewRequest(http.MethodGet, url, nil)
+		req.SetBasicAuth("root", "Milvus")
+		resp, err = client.Do(req)
+		suite.Nil(err)
+		defer resp.Body.Close()
+		suite.Equal(http.StatusOK, resp.StatusCode)
+		body, _ = io.ReadAll(resp.Body)
 		suite.True(strings.Contains(string(body), "hello"))
 	})
+
+	// Reset config
+	paramtable.Get().Save("common.security.exprEnabled", "false")
 }
 
 func TestHTTPServerSuite(t *testing.T) {

--- a/internal/proxy/meta_cache.go
+++ b/internal/proxy/meta_cache.go
@@ -30,6 +30,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	internalhttp "github.com/milvus-io/milvus/internal/http"
 	"github.com/milvus-io/milvus/internal/proxy/privilege"
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/pkg/v2/common"
@@ -375,6 +376,9 @@ func InitMetaCache(ctx context.Context, mixCoord types.MixCoordClient) error {
 		log.Error("failed to init privilege cache", zap.Error(err))
 		return err
 	}
+
+	// Register password verify function for /expr endpoint authentication
+	internalhttp.RegisterPasswordVerifyFunc(PasswordVerify)
 
 	return nil
 }

--- a/pkg/util/expr/expr_test.go
+++ b/pkg/util/expr/expr_test.go
@@ -100,4 +100,32 @@ func TestExec(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, fmt.Sprintf("%d", innerSize(mockMessage)), out)
 	})
+
+	t.Run("auth bypass", func(t *testing.T) {
+		// AuthBypass should allow execution without checking the auth key
+		out, err := Exec("foo", AuthBypass)
+		assert.NoError(t, err)
+		assert.Equal(t, "hello", out)
+	})
+}
+
+func TestHasRegistered(t *testing.T) {
+	// Before init, should return false
+	env = nil
+	assert.False(t, HasRegistered("foo"))
+
+	// After init
+	Init()
+	Register("testKey", "testValue")
+
+	// Registered key should return true
+	assert.True(t, HasRegistered("testKey"))
+
+	// Non-registered key should return false
+	assert.False(t, HasRegistered("nonExistentKey"))
+
+	// Check for "proxy" key (used to detect Proxy node)
+	assert.False(t, HasRegistered("proxy"))
+	Register("proxy", "mock_proxy")
+	assert.True(t, HasRegistered("proxy"))
 }

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -259,6 +259,7 @@ type commonConfig struct {
 	DefaultRootPassword   ParamItem `refreshable:"false"`
 	RootShouldBindRole    ParamItem `refreshable:"true"`
 	EnablePublicPrivilege ParamItem `refreshable:"false"`
+	ExprEnabled           ParamItem `refreshable:"false"`
 
 	ClusterName ParamItem `refreshable:"false"`
 
@@ -811,6 +812,15 @@ Large numeric passwords require double quotes to avoid yaml parsing precision is
 		Export:       true,
 	}
 	p.EnablePublicPrivilege.Init(base.mgr)
+
+	p.ExprEnabled = ParamItem{
+		Key:          "common.security.exprEnabled",
+		Version:      "2.6.0",
+		DefaultValue: "false",
+		Doc:          "Whether to enable the /expr endpoint for debugging. When enabled, only root user can access it via HTTP Basic Auth on Proxy nodes.",
+		Export:       true,
+	}
+	p.ExprEnabled.Init(base.mgr)
 
 	p.ClusterName = ParamItem{
 		Key:          "common.cluster.name",


### PR DESCRIPTION
related: https://github.com/milvus-io/milvus/issues/46442

core changes:
- Add  config (default: false) to disable /expr endpoint by default
- On Proxy nodes, require root user authentication via HTTP Basic Auth when enabled
- On non-Proxy nodes, keep original auth parameter behavior for backward compatibility
- Add HasRegistered() and AuthBypass to expr package for node type detection
