### PR TITLE
enhance: [Loon] Enable useLoonFFI by default

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -1021,7 +1021,7 @@ common:
       splitByAvgSize:
         enabled: false # enable split by average size policy in storage v2
         threshold: 1024 # split by average size policy threshold(in bytes) in storage v2
-    useLoonFFI: false
+    useLoonFFI: true
   traceLogMode: 0 # trace request info
   bloomFilterSize: 100000 # bloom filter initial size
   bloomFilterType: BlockedBloomFilter # bloom filter type, support BasicBloomFilter and BlockedBloomFilter

--- a/internal/compaction/params_test.go
+++ b/internal/compaction/params_test.go
@@ -46,6 +46,7 @@ func TestGetJSONParams(t *testing.T) {
 		PreferSegmentSizeRatio:    paramtable.Get().DataCoordCfg.ClusteringCompactionPreferSegmentSizeRatio.GetAsFloat(),
 		BloomFilterApplyBatchSize: paramtable.Get().CommonCfg.BloomFilterApplyBatchSize.GetAsInt(),
 		StorageConfig:             CreateStorageConfig(),
+		UseLoonFFI:                paramtable.Get().CommonCfg.UseLoonFFI.GetAsBool(),
 	}, result)
 }
 

--- a/internal/compaction/params_test.go
+++ b/internal/compaction/params_test.go
@@ -97,5 +97,6 @@ func TestGetParamsFromJSON_EmptyJSON(t *testing.T) {
 		PreferSegmentSizeRatio:    paramtable.Get().DataCoordCfg.ClusteringCompactionPreferSegmentSizeRatio.GetAsFloat(),
 		BloomFilterApplyBatchSize: paramtable.Get().CommonCfg.BloomFilterApplyBatchSize.GetAsInt(),
 		StorageConfig:             CreateStorageConfig(),
+		UseLoonFFI:                paramtable.Get().CommonCfg.UseLoonFFI.GetAsBool(),
 	}, result)
 }

--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -1504,7 +1504,20 @@ GetFieldDatasFromManifest(
     std::optional<DataType> element_type) {
     auto column_groups = GetColumnGroups(manifest_path, loon_ffi_properties);
 
-    // ReaderHandle reader_handler = 0;
+    // TODO remove manual check after loon support read null for non-exists field
+    bool field_exists = false;
+    for (size_t i = 0; i < column_groups->size() && !field_exists; i++) {
+        auto column_group = column_groups->get_column_group(i);
+        for (auto& column : column_group->columns) {
+            if (column == std::to_string((field_meta.field_id))) {
+                field_exists = true;
+                break;
+            }
+        }
+    }
+    if (!field_exists) {
+        return {};
+    }
 
     std::string field_id_str = std::to_string(field_meta.field_id);
     std::vector<std::string> needed_columns = {field_id_str};

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -958,7 +958,7 @@ Large numeric passwords require double quotes to avoid yaml parsing precision is
 	p.UseLoonFFI = ParamItem{
 		Key:          "common.storage.useLoonFFI",
 		Version:      "2.6.7",
-		DefaultValue: "false",
+		DefaultValue: "true",
 		Export:       true,
 	}
 	p.UseLoonFFI.Init(base.mgr)


### PR DESCRIPTION
Related to #44956
Change the default value of `common.storage.useLoonFFI` from false to true, enabling the LoonFFI storage feature by default.