### PR TITLE
enhance: add CLAUDE.md to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,8 +113,9 @@ internal/core/src/pb/*.pb.cc
 **/legacypb/*.pb.go
 pkg/streaming/proto/**/*.pb.go
 
-#AI rules
+# AI rules
 WARP.md
+CLAUDE.md
 
 # Antlr
 .antlr


### PR DESCRIPTION
prevents users of Claude Code from commiting their personal CLAUDE.md files

if desired, a CLAUDE.md could be added at the project level as a tracked file as an alternative