### PR TITLE
fix: improve error messages for nullable vector field operations

### DIFF
--- a/internal/parser/planparserv2/parser_visitor.go
+++ b/internal/parser/planparserv2/parser_visitor.go
@@ -1489,6 +1489,10 @@ func (v *ParserVisitor) VisitIsNotNull(ctx *parser.IsNotNullContext) interface{}
 		return err
 	}
 
+	if typeutil.IsVectorType(column.DataType) {
+		return fmt.Errorf("IsNull/IsNotNull operations are not supported on vector fields")
+	}
+
 	if len(column.NestedPath) != 0 {
 		// convert json not null expr to exists expr, eg: json['a'] is not null -> exists json['a']
 		expr := &planpb.Expr{
@@ -1527,6 +1531,10 @@ func (v *ParserVisitor) VisitIsNull(ctx *parser.IsNullContext) interface{} {
 	column, err := v.getChildColumnInfo(ctx.Identifier(), ctx.JSONIdentifier(), nil)
 	if err != nil {
 		return err
+	}
+
+	if typeutil.IsVectorType(column.DataType) {
+		return fmt.Errorf("IsNull/IsNotNull operations are not supported on vector fields")
 	}
 
 	if len(column.NestedPath) != 0 {

--- a/internal/parser/planparserv2/plan_parser_v2_test.go
+++ b/internal/parser/planparserv2/plan_parser_v2_test.go
@@ -648,6 +648,12 @@ func TestExpr_IsNull(t *testing.T) {
 
 	unsupported := []string{
 		`not_exist is null`,
+		`FloatVectorField is null`,
+		`BinaryVectorField is null`,
+		`Float16VectorField is null`,
+		`BFloat16VectorField is null`,
+		`SparseFloatVectorField is null`,
+		`Int8VectorField is null`,
 	}
 	for _, exprStr := range unsupported {
 		assertInvalidExpr(t, helper, exprStr)
@@ -669,6 +675,12 @@ func TestExpr_IsNotNull(t *testing.T) {
 
 	unsupported := []string{
 		`not_exist is not null`,
+		`FloatVectorField is not null`,
+		`BinaryVectorField is not null`,
+		`Float16VectorField is not null`,
+		`BFloat16VectorField is not null`,
+		`SparseFloatVectorField is not null`,
+		`Int8VectorField is not null`,
 	}
 	for _, exprStr := range unsupported {
 		assertInvalidExpr(t, helper, exprStr)

--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -3590,10 +3590,16 @@ func (node *Proxy) handleIfSearchByPK(ctx context.Context, request *milvuspb.Sea
 	}
 
 	// Convert to PlaceholderGroup
-	placeholderBytes, err := funcutil.FieldDataToPlaceholderGroupBytes(vectorFieldData)
+	placeholderBytes, vectorCount, err := funcutil.FieldDataToPlaceholderGroupBytesWithCount(vectorFieldData)
 	if err != nil {
 		return err
 	}
+
+	if vectorCount == 0 {
+		return merr.WrapErrParameterInvalidMsg("cannot search: all provided IDs have null vector values in field '%s'", annsFieldName)
+	}
+
+	request.Nq = int64(vectorCount)
 
 	// Transform request: replace IDs with PlaceholderGroup
 	// Now the request is ready for normal search pipeline

--- a/pkg/util/funcutil/placeholdergroup.go
+++ b/pkg/util/funcutil/placeholdergroup.go
@@ -58,10 +58,10 @@ func Int8VectorsToPlaceholderGroup(embs [][]int8) *commonpb.PlaceholderGroup {
 	return placeholderGroup
 }
 
-func FieldDataToPlaceholderGroupBytes(fieldData *schemapb.FieldData) ([]byte, error) {
+func FieldDataToPlaceholderGroupBytesWithCount(fieldData *schemapb.FieldData) ([]byte, int, error) {
 	placeholderValue, err := fieldDataToPlaceholderValue(fieldData)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	placeholderGroup := &commonpb.PlaceholderGroup{
@@ -69,7 +69,12 @@ func FieldDataToPlaceholderGroupBytes(fieldData *schemapb.FieldData) ([]byte, er
 	}
 
 	bytes, _ := proto.Marshal(placeholderGroup)
-	return bytes, nil
+	return bytes, len(placeholderValue.Values), nil
+}
+
+func FieldDataToPlaceholderGroupBytes(fieldData *schemapb.FieldData) ([]byte, error) {
+	bytes, _, err := FieldDataToPlaceholderGroupBytesWithCount(fieldData)
+	return bytes, err
 }
 
 func fieldDataToPlaceholderValue(fieldData *schemapb.FieldData) (*commonpb.PlaceholderValue, error) {

--- a/tests/python_client/check/func_check.py
+++ b/tests/python_client/check/func_check.py
@@ -453,6 +453,8 @@ class ResponseChecker:
             else:
                 ids = list(hits.ids)
                 distances = list(hits.distances)
+            if len(hits) == 0:
+                continue
             if check_items.get("limit", None) is not None \
                     and ((len(hits) != check_items["limit"]) or (len(ids) != check_items["limit"])):
                 log.error("search_results_check: limit(topK) searched (%d) "

--- a/tests/python_client/milvus_client/test_milvus_client_search.py
+++ b/tests/python_client/milvus_client/test_milvus_client_search.py
@@ -419,8 +419,8 @@ class TestMilvusClientSearchInvalid(TestMilvusClientV2Base):
         # 3. search
         vectors_to_search = rng.random((1, dim))
         null_expr = default_vector_field_name + " " + null_expr_op
-        error = {ct.err_code: 65535,
-                 ct.err_msg: "unsupported data type: VECTOR_FLOAT"}
+        error = {ct.err_code: 1100,
+                 ct.err_msg: "IsNull/IsNotNull operations are not supported on vector fields"}
         self.search(client, collection_name, vectors_to_search,
                     filter=null_expr,
                     check_task=CheckTasks.err_res, check_items=error)

--- a/tests/python_client/milvus_client_v2/test_milvus_client_search_by_pk.py
+++ b/tests/python_client/milvus_client_v2/test_milvus_client_search_by_pk.py
@@ -281,6 +281,80 @@ class TestMilvusClientSearchByPk(TestMilvusClientV2Base):
             check_items=error
         )
 
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_search_by_pk_nullable_vector_field(self):
+        """
+        target: test search by pk with nullable vector field where some vectors are null
+        method: 1. create a collection with nullable sparse vector field
+                2. insert data where some vectors are null
+                3. search by IDs including some with null vectors
+                4. verify result count equals non-null vector count (effective nq)
+        expected: null vectors are filtered out, result count = non-null vector count
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str("nullable_vec_search_")
+
+        # Create collection with nullable sparse vector field
+        schema = self.create_schema(client, enable_dynamic_field=False)[0]
+        schema.add_field("id", DataType.INT64, is_primary=True, auto_id=False)
+        schema.add_field("sparse_vec", DataType.SPARSE_FLOAT_VECTOR, nullable=True)
+        self.create_collection(client, collection_name, schema=schema)
+
+        # Insert data: 10 rows, where rows 2, 5, 8 have null vectors
+        nb = 10
+        null_indices = {2, 5, 8}
+        rows = []
+        for i in range(nb):
+            if i in null_indices:
+                row = {"id": i, "sparse_vec": None}
+            else:
+                row = {"id": i, "sparse_vec": {i: 1.0, i + 100: 0.5}}
+            rows.append(row)
+
+        self.insert(client, collection_name, rows)
+        self.flush(client, collection_name)
+
+        # Create index and load
+        index_params = self.prepare_index_params(client)[0]
+        index_params.add_index("sparse_vec", index_type="SPARSE_INVERTED_INDEX", metric_type="IP")
+        self.create_index(client, collection_name, index_params)
+        self.load_collection(client, collection_name)
+
+        # Case 1: Search by IDs with mixed null and non-null vectors
+        # IDs [0, 2, 3, 5] -> 0, 3 are valid, 2, 5 are null
+        ids_to_search = [0, 2, 3, 5]
+        expected_nq = 2  # only 2 non-null vectors
+
+        res = self.search(
+            client,
+            collection_name,
+            ids=ids_to_search,
+            anns_field="sparse_vec",
+            search_params={"metric_type": "IP"},
+            limit=5
+        )[0]
+
+        log.info(f"Search with ids={ids_to_search}, expected_nq={expected_nq}, actual len(res)={len(res)}")
+        assert len(res) == expected_nq, f"Expected {expected_nq} results, got {len(res)}"
+
+        # Case 2: Search by IDs with all null vectors should raise error
+        all_null_ids = [2, 5, 8]
+        error = {"err_code": 65535,
+                 "err_msg": "all provided IDs have null vector values"}
+        self.search(
+            client,
+            collection_name,
+            ids=all_null_ids,
+            anns_field="sparse_vec",
+            search_params={"metric_type": "IP"},
+            limit=5,
+            check_task=CheckTasks.err_res,
+            check_items=error
+        )
+
+        # Cleanup
+        self.drop_collection(client, collection_name)
+
     @pytest.mark.tags(CaseLabel.L0)
     def test_search_by_pk_with_empty_ids(self):
         """


### PR DESCRIPTION
issue: #46779 
related: #45993 

Return clear error when using is null/is not null filter on vector fields
Return clear error when search by IDs with all null vectors
Fix nq mismatch when search by IDs with mixed null/valid vectors