### PR TITLE
fix: check field exists in column groups before reading from loon manifest

### DIFF
--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -1506,10 +1506,11 @@ GetFieldDatasFromManifest(
 
     // TODO remove manual check after loon support read null for non-exists field
     bool field_exists = false;
+    const auto field_id_to_find = std::to_string(field_meta.field_id);
     for (size_t i = 0; i < column_groups->size() && !field_exists; i++) {
         auto column_group = column_groups->get_column_group(i);
-        for (auto& column : column_group->columns) {
-            if (column == std::to_string((field_meta.field_id))) {
+        for (const auto& column : column_group->columns) {
+            if (column == field_id_to_find) {
                 field_exists = true;
                 break;
             }

--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -1504,7 +1504,20 @@ GetFieldDatasFromManifest(
     std::optional<DataType> element_type) {
     auto column_groups = GetColumnGroups(manifest_path, loon_ffi_properties);
 
-    // ReaderHandle reader_handler = 0;
+    // TODO remove manual check after loon support read null for non-exists field
+    bool field_exists = false;
+    for (size_t i = 0; i < column_groups->size() && !field_exists; i++) {
+        auto column_group = column_groups->get_column_group(i);
+        for (auto& column : column_group->columns) {
+            if (column == std::to_string((field_meta.field_id))) {
+                field_exists = true;
+                break;
+            }
+        }
+    }
+    if (!field_exists) {
+        return {};
+    }
 
     std::string field_id_str = std::to_string(field_meta.field_id);
     std::vector<std::string> needed_columns = {field_id_str};


### PR DESCRIPTION
Related to #44956

Before reading field data from loon manifest, check if the field exists in column groups first. If the field does not exist, return an empty result instead of proceeding with the read operation.

This is a workaround until loon natively supports returning null for non-existent fields.