### PR TITLE
fix: Fix concurrent map access panic in CopySegmentTask

### DIFF
--- a/internal/datanode/importv2/task_copy_segment_test.go
+++ b/internal/datanode/importv2/task_copy_segment_test.go
@@ -244,8 +244,8 @@ func TestCopySegmentTaskExecute(t *testing.T) {
 		_, err := futures[0].Await()
 		assert.NoError(t, err)
 
-		// Verify segment results are updated
-		copyTask := task.(*CopySegmentTask)
+		// Verify segment results are updated (get updated task from manager)
+		copyTask := mockManager.Get(task.GetTaskID()).(*CopySegmentTask)
 		segmentResults := copyTask.GetSegmentResults()
 		assert.Equal(t, 1, len(segmentResults))
 		assert.NotNil(t, segmentResults[666])
@@ -336,8 +336,8 @@ func TestCopySegmentTaskExecute(t *testing.T) {
 			assert.NoError(t, err)
 		}
 
-		// Verify both segment results are updated
-		copyTask := task.(*CopySegmentTask)
+		// Verify both segment results are updated (get updated task from manager)
+		copyTask := mockManager.Get(task.GetTaskID()).(*CopySegmentTask)
 		segmentResults := copyTask.GetSegmentResults()
 		assert.Equal(t, 2, len(segmentResults))
 
@@ -994,8 +994,8 @@ func TestCopySegmentTaskEdgeCases(t *testing.T) {
 		_, err := futures[0].Await()
 		assert.NoError(t, err)
 
-		// Verify total rows
-		copyTask := task.(*CopySegmentTask)
+		// Verify total rows (get updated task from manager)
+		copyTask := mockManager.Get(task.GetTaskID()).(*CopySegmentTask)
 		segmentResults := copyTask.GetSegmentResults()
 		assert.Equal(t, int64(10000), segmentResults[666].ImportedRows) // 100 files * 100 rows each
 	})


### PR DESCRIPTION
issue: #44358

The panic "concurrent map iteration and map write" was introduced in PR #44361. It occurred when QueryCopySegment RPC iterated segmentResults while copySingleSegment was updating it concurrently.

- Deep copy segmentResults in Clone() to avoid shared map reference
- Return map copy in GetSegmentResults() to prevent iteration conflict
- Update tests to get task from manager after Update() operations

This fix follows the same deep-copy pattern used in ImportTask and L0ImportTask.