### PR TITLE
fix: Remove extra binlog in flaky unit test

### DIFF
--- a/internal/datanode/importv2/copy_segment_utils_test.go
+++ b/internal/datanode/importv2/copy_segment_utils_test.go
@@ -645,7 +645,6 @@ func TestCopySegmentAndIndexFiles_ReturnsFileList(t *testing.T) {
 					Binlogs: []*datapb.Binlog{
 						{LogPath: "files/insert_log/111/222/333/1/10001", LogSize: 100},
 						{LogPath: "files/insert_log/111/222/333/1/10002", LogSize: 200},
-						{LogPath: "files/insert_log/111/222/333/1/10003", LogSize: 300},
 					},
 				},
 			},


### PR DESCRIPTION
Fixes: #46840

The test "failure_returns_partial_file_list" had 3 binlog entries but only mocked 2 Copy calls, causing flaky behavior. Remove the unmocked third binlog to make the test deterministic.