### PR TITLE
enhance: Reduce memory allocations and copies in data loading

### DIFF
--- a/internal/core/src/common/ArrayOffsets.cpp
+++ b/internal/core/src/common/ArrayOffsets.cpp
@@ -134,6 +134,8 @@ ArrayOffsetsSealed::BuildFromSegment(const void* segment,
     std::vector<int32_t> element_row_ids;
     // Size is row_count + 1, last element stores total_element_count
     std::vector<int32_t> row_to_element_start(row_count + 1);
+    // Pre-reserve element_row_ids assuming average 4 elements per row
+    element_row_ids.reserve(row_count * 4);
 
     auto temp_op_ctx = std::make_unique<OpContext>();
     auto op_ctx_ptr = temp_op_ctx.get();
@@ -315,6 +317,13 @@ ArrayOffsetsGrowing::Insert(int64_t row_id_start,
     std::unique_lock lock(mutex_);
 
     row_to_element_start_.reserve(row_id_start + count + 1);
+
+    // Estimate total elements needed and reserve capacity
+    int64_t total_elements = 0;
+    for (int64_t i = 0; i < count; ++i) {
+        total_elements += array_lengths[i];
+    }
+    element_row_ids_.reserve(element_row_ids_.size() + total_elements);
 
     int32_t original_committed_count = committed_row_count_;
 

--- a/internal/core/src/common/ChunkWriter.h
+++ b/internal/core/src/common/ChunkWriter.h
@@ -20,6 +20,7 @@
 #include "common/ChunkTarget.h"
 #include "arrow/record_batch.h"
 #include "common/Chunk.h"
+#include "common/Json.h"
 #include "pb/common.pb.h"
 
 namespace milvus {
@@ -230,6 +231,9 @@ class JSONChunkWriter : public ChunkWriterBase {
     void
     write_to_target(const arrow::ArrayVector& array_vec,
                     const std::shared_ptr<ChunkTarget>& target) override;
+
+ private:
+    std::vector<Json> cached_jsons_;
 };
 
 class GeometryChunkWriter : public ChunkWriterBase {

--- a/internal/core/src/common/FieldData.cpp
+++ b/internal/core/src/common/FieldData.cpp
@@ -334,6 +334,7 @@ FieldDataImpl<Type, is_type_entire_row>::FillFieldData(
                        "inconsistent data type");
             auto arr = std::dynamic_pointer_cast<arrow::BinaryArray>(array);
             std::vector<knowhere::sparse::SparseRow<SparseValueType>> values;
+            values.reserve(element_count);
 
             if (nullable_) {
                 for (int64_t i = 0; i < element_count; ++i) {

--- a/internal/core/src/common/FieldData.cpp
+++ b/internal/core/src/common/FieldData.cpp
@@ -230,17 +230,7 @@ FieldDataImpl<Type, is_type_entire_row>::FillFieldData(
                        "inconsistent data type");
             auto string_array =
                 std::dynamic_pointer_cast<arrow::StringArray>(array);
-            std::vector<std::string> values(element_count);
-            for (size_t index = 0; index < element_count; ++index) {
-                values[index] = string_array->GetString(index);
-            }
-            if (nullable_) {
-                return FillFieldData(values.data(),
-                                     array->null_bitmap_data(),
-                                     element_count,
-                                     array->offset());
-            }
-            return FillFieldData(values.data(), element_count);
+            return FillFieldData(string_array);
         }
         case DataType::JSON: {
             // The code here is not referenced.

--- a/internal/core/src/common/FieldDataInterface.h
+++ b/internal/core/src/common/FieldDataInterface.h
@@ -603,10 +603,8 @@ class FieldDataStringImpl : public FieldDataImpl<std::string, true> {
             resize_field_data(length_ + n);
         }
 
-        auto i = 0;
-        for (const auto& str : *array) {
-            data_[length_ + i] = str.value();
-            i++;
+        for (int64_t i = 0; i < n; ++i) {
+            data_[length_ + i] = std::string(array->GetView(i));
         }
         if (IsNullable()) {
             auto valid_data = array->null_bitmap_data();

--- a/internal/core/src/common/IndexMeta.cpp
+++ b/internal/core/src/common/IndexMeta.cpp
@@ -49,10 +49,9 @@ CollectionIndexMeta::CollectionIndexMeta(
 CollectionIndexMeta::CollectionIndexMeta(
     const milvus::proto::segcore::CollectionIndexMeta& collectionIndexMeta) {
     max_index_row_cnt_ = collectionIndexMeta.maxindexrowcount();
-    for (auto& filed_index_meta : collectionIndexMeta.index_metas()) {
-        FieldIndexMeta fieldIndexMeta(filed_index_meta);
+    for (const auto& filed_index_meta : collectionIndexMeta.index_metas()) {
         fieldMetas_.emplace(FieldId(filed_index_meta.fieldid()),
-                            fieldIndexMeta);
+                            FieldIndexMeta(filed_index_meta));
     }
 }
 
@@ -76,15 +75,15 @@ std::string
 CollectionIndexMeta::ToString() {
     std::stringstream ss;
     ss << "maxRowCount : {" << max_index_row_cnt_ << "} ";
-    for (auto& filed_meta : fieldMetas_) {
+    for (const auto& filed_meta : fieldMetas_) {
         ss << "FieldId : {" << abs(filed_meta.first.get()) << " ";
         ss << "IndexParams : { ";
-        for (auto& kv : filed_meta.second.GetIndexParams()) {
+        for (const auto& kv : filed_meta.second.GetIndexParams()) {
             ss << kv.first << " : " << kv.second << ", ";
         }
         ss << " }";
         ss << "TypeParams : {";
-        for (auto& kv : filed_meta.second.GetTypeParams()) {
+        for (const auto& kv : filed_meta.second.GetTypeParams()) {
             ss << kv.first << " : " << kv.second << ", ";
         }
         ss << "}";

--- a/internal/core/src/common/Schema.cpp
+++ b/internal/core/src/common/Schema.cpp
@@ -118,8 +118,9 @@ const FieldMeta FieldMeta::RowIdMeta(
 const ArrowSchemaPtr
 Schema::ConvertToArrowSchema() const {
     arrow::FieldVector arrow_fields;
-    for (auto& field : fields_) {
-        auto meta = field.second;
+    arrow_fields.reserve(fields_.size());
+    for (const auto& field : fields_) {
+        const auto& meta = field.second;
         int dim = IsVectorDataType(meta.get_data_type()) &&
                           !IsSparseFloatVectorDataType(meta.get_data_type())
                       ? meta.get_dim()
@@ -171,6 +172,7 @@ Schema::ToProto() const {
 std::unique_ptr<std::vector<FieldMeta>>
 Schema::AbsentFields(Schema& old_schema) const {
     std::vector<FieldMeta> result;
+    result.reserve(fields_.size());
     for (const auto& [field_id, field_meta] : fields_) {
         auto it = old_schema.fields_.find(field_id);
         if (it == old_schema.fields_.end()) {
@@ -178,7 +180,7 @@ Schema::AbsentFields(Schema& old_schema) const {
         }
     }
 
-    return std::make_unique<std::vector<FieldMeta>>(result);
+    return std::make_unique<std::vector<FieldMeta>>(std::move(result));
 }
 
 std::pair<bool, bool>

--- a/internal/core/src/common/Slice.cpp
+++ b/internal/core/src/common/Slice.cpp
@@ -89,6 +89,7 @@ Disassemble(BinarySet& binarySet) {
     }
 
     std::vector<std::string> slice_key_list;
+    slice_key_list.reserve(binarySet.binary_map_.size());
     for (auto& kv : binarySet.binary_map_) {
         if (kv.second->size > FILE_SLICE_SIZE.load()) {
             slice_key_list.push_back(kv.first);

--- a/internal/core/src/exec/expression/JsonContainsExpr.cpp
+++ b/internal/core/src/exec/expression/JsonContainsExpr.cpp
@@ -439,6 +439,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsByStats() {
             auto sort_arg_set =
                 std::dynamic_pointer_cast<SortVectorElement<int64_t>>(arg_set_);
             std::vector<double> double_vals;
+            double_vals.reserve(sort_arg_set->GetElements().size());
             for (const auto& val : sort_arg_set->GetElements()) {
                 double_vals.emplace_back(static_cast<double>(val));
             }
@@ -660,6 +661,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsArrayByStats() {
         return nullptr;
     }
     std::vector<proto::plan::Array> elements;
+    elements.reserve(expr_->vals_.size());
     auto pointer = milvus::Json::pointer(expr_->column_.nested_path_);
     for (auto const& element : expr_->vals_) {
         elements.emplace_back(GetValueFromProto<proto::plan::Array>(element));
@@ -1126,7 +1128,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllWithDiffType(EvalCtx& context) {
             TargetBitmapView valid_res,
             const std::string& pointer,
             const std::vector<proto::plan::GenericValue>& elements,
-            const std::unordered_set<int> elements_index) {
+            const std::unordered_set<int>& elements_index) {
         // If data is nullptr, this chunk was skipped by SkipIndex.
         // We only need to update processed_cursor for bitmap_input indexing.
         if (data == nullptr) {
@@ -1443,6 +1445,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllArray(EvalCtx& context) {
     auto pointer = milvus::Json::pointer(expr_->column_.nested_path_);
 
     std::vector<proto::plan::Array> elements;
+    elements.reserve(expr_->vals_.size());
     for (auto const& element : expr_->vals_) {
         elements.emplace_back(GetValueFromProto<proto::plan::Array>(element));
     }
@@ -1547,6 +1550,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllArrayByStats() {
     }
     auto pointer = milvus::Json::pointer(expr_->column_.nested_path_);
     std::vector<proto::plan::Array> elements;
+    elements.reserve(expr_->vals_.size());
     for (auto const& element : expr_->vals_) {
         elements.emplace_back(GetValueFromProto<proto::plan::Array>(element));
     }

--- a/internal/core/src/exec/expression/function/FunctionFactory.cpp
+++ b/internal/core/src/exec/expression/function/FunctionFactory.cpp
@@ -65,8 +65,8 @@ FunctionFactory::RegisterAllFunctions() {
 
 void
 FunctionFactory::RegisterFilterFunction(
-    std::string func_name,
-    std::vector<DataType> func_param_type_list,
+    const std::string& func_name,
+    const std::vector<DataType>& func_param_type_list,
     FilterFunctionPtr func) {
     filter_function_map_[FilterFunctionRegisterKey{
         func_name, func_param_type_list}] = func;

--- a/internal/core/src/exec/expression/function/FunctionFactory.h
+++ b/internal/core/src/exec/expression/function/FunctionFactory.h
@@ -74,8 +74,8 @@ class FunctionFactory {
     Initialize();
 
     void
-    RegisterFilterFunction(std::string func_name,
-                           std::vector<DataType> func_param_type_list,
+    RegisterFilterFunction(const std::string& func_name,
+                           const std::vector<DataType>& func_param_type_list,
                            FilterFunctionPtr func);
 
     void

--- a/internal/core/src/exec/operator/RescoresNode.cpp
+++ b/internal/core/src/exec/operator/RescoresNode.cpp
@@ -78,6 +78,8 @@ PhyRescoresNode::GetOutput() {
     // prepare segment offset
     FixedVector<int32_t> offsets;
     std::vector<size_t> offset_idx;
+    offsets.reserve(search_result.seg_offsets_.size());
+    offset_idx.reserve(search_result.seg_offsets_.size());
 
     for (size_t i = 0; i < search_result.seg_offsets_.size(); i++) {
         // remain offset will be placeholder(-1) if result count not enough (less than topk)

--- a/internal/core/src/index/IndexStats.cpp
+++ b/internal/core/src/index/IndexStats.cpp
@@ -34,7 +34,8 @@ IndexStats::New(int64_t mem_size,
 IndexStats::IndexStats(
     int64_t mem_size,
     std::vector<SerializedIndexFileInfo>&& serialized_index_infos)
-    : mem_size_(mem_size), serialized_index_infos_(serialized_index_infos) {
+    : mem_size_(mem_size),
+      serialized_index_infos_(std::move(serialized_index_infos)) {
 }
 
 void
@@ -58,7 +59,8 @@ IndexStats::SerializeAt(milvus::ProtoLayout* layout) {
 std::vector<std::string>
 IndexStats::GetIndexFiles() const {
     std::vector<std::string> files;
-    for (auto& info : serialized_index_infos_) {
+    files.reserve(serialized_index_infos_.size());
+    for (const auto& info : serialized_index_infos_) {
         files.push_back(info.file_name);
     }
     return files;

--- a/internal/core/src/index/JsonFlatIndex.cpp
+++ b/internal/core/src/index/JsonFlatIndex.cpp
@@ -57,11 +57,14 @@ JsonFlatIndex::build_index_for_json(
                     }
                     std::string_view str = str_result.value();
                     // Resize scratch buffer if needed (with some growth factor)
-                    if (scratch_buffer.size() < str.size()) {
+                    // Need space for str.size() + 1 for null terminator
+                    if (scratch_buffer.size() < str.size() + 1) {
                         scratch_buffer =
-                            simdjson::padded_string(str.size() * 2);
+                            simdjson::padded_string((str.size() + 1) * 2);
                     }
                     std::memcpy(scratch_buffer.data(), str.data(), str.size());
+                    // Add null terminator - required for C string FFI to Rust
+                    scratch_buffer.data()[str.size()] = '\0';
                     // Create Json referencing scratch buffer (non-owning)
                     Json subpath_json(scratch_buffer.data(), str.size());
                     wrapper_->add_json_data(&subpath_json, 1, offset++);

--- a/internal/core/src/index/json_stats/bson_inverted.cpp
+++ b/internal/core/src/index/json_stats/bson_inverted.cpp
@@ -91,6 +91,9 @@ BsonInvertedIndex::BuildIndex() {
     std::vector<const char*> keys;
     std::vector<const int64_t*> json_offsets;
     std::vector<uintptr_t> json_offsets_lens;
+    keys.reserve(inverted_index_map_.size());
+    json_offsets.reserve(inverted_index_map_.size());
+    json_offsets_lens.reserve(inverted_index_map_.size());
     for (const auto& [key, offsets] : inverted_index_map_) {
         keys.push_back(key.c_str());
         json_offsets.push_back(offsets.data());
@@ -109,9 +112,9 @@ BsonInvertedIndex::LoadIndex(const std::vector<std::string>& index_files,
     if (is_load_) {
         // convert shared_key_index/... to remote_prefix/shared_key_index/...
         std::vector<std::string> remote_files;
-        for (auto& file : index_files) {
-            auto remote_prefix =
-                disk_file_manager_->GetRemoteJsonStatsLogPrefix();
+        remote_files.reserve(index_files.size());
+        auto remote_prefix = disk_file_manager_->GetRemoteJsonStatsLogPrefix();
+        for (const auto& file : index_files) {
             boost::filesystem::path full_path =
                 boost::filesystem::path(remote_prefix) / file;
             remote_files.emplace_back(full_path.string());

--- a/internal/core/src/index/json_stats/parquet_writer.cpp
+++ b/internal/core/src/index/json_stats/parquet_writer.cpp
@@ -81,12 +81,13 @@ JsonStatsParquetWriter::WriteCurrentBatch() {
     }
 
     std::vector<std::shared_ptr<arrow::Array>> arrays;
+    arrays.reserve(builders_.size());
     for (auto& builder : builders_) {
         std::shared_ptr<arrow::Array> array;
         auto status = builder->Finish(&array);
         AssertInfo(
             status.ok(), "failed to finish builder: {}", status.ToString());
-        arrays.push_back(array);
+        arrays.push_back(std::move(array));
         builder->Reset();
     }
 

--- a/internal/core/src/index/json_stats/utils.cpp
+++ b/internal/core/src/index/json_stats/utils.cpp
@@ -134,7 +134,7 @@ CreateArrowField(const JsonKey& key,
 
 std::pair<std::vector<std::shared_ptr<arrow::ArrayBuilder>>,
           std::map<std::string, std::shared_ptr<arrow::ArrayBuilder>>>
-CreateArrowBuilders(std::map<JsonKey, JsonKeyLayoutType> column_map) {
+CreateArrowBuilders(const std::map<JsonKey, JsonKeyLayoutType>& column_map) {
     std::shared_ptr<arrow::ArrayBuilder> shared_builder =
         CreateSharedArrowBuilder();
     std::vector<std::shared_ptr<arrow::ArrayBuilder>> builders;
@@ -164,7 +164,7 @@ CreateArrowBuilders(std::map<JsonKey, JsonKeyLayoutType> column_map) {
 }
 
 std::shared_ptr<arrow::Schema>
-CreateArrowSchema(std::map<JsonKey, JsonKeyLayoutType> column_map) {
+CreateArrowSchema(const std::map<JsonKey, JsonKeyLayoutType>& column_map) {
     std::vector<std::shared_ptr<arrow::Field>> fields;
     std::shared_ptr<arrow::Field> shared_field = nullptr;
     bool shared_field_name_conflict = false;
@@ -207,7 +207,8 @@ CreateArrowSchema(std::map<JsonKey, JsonKeyLayoutType> column_map) {
 }
 
 std::vector<std::pair<std::string, std::string>>
-CreateParquetKVMetadata(std::map<JsonKey, JsonKeyLayoutType> column_map) {
+CreateParquetKVMetadata(
+    const std::map<JsonKey, JsonKeyLayoutType>& column_map) {
     // layout type map is now stored in a separate meta file to reduce parquet file size.
     // return empty metadata vector.
     return {};

--- a/internal/core/src/index/json_stats/utils.h
+++ b/internal/core/src/index/json_stats/utils.h
@@ -424,13 +424,13 @@ CreateArrowField(const JsonKey& key, const JsonKeyLayoutType& key_type);
 
 std::pair<std::vector<std::shared_ptr<arrow::ArrayBuilder>>,
           std::map<std::string, std::shared_ptr<arrow::ArrayBuilder>>>
-CreateArrowBuilders(std::map<JsonKey, JsonKeyLayoutType> column_map);
+CreateArrowBuilders(const std::map<JsonKey, JsonKeyLayoutType>& column_map);
 
 std::shared_ptr<arrow::Schema>
-CreateArrowSchema(std::map<JsonKey, JsonKeyLayoutType> column_map);
+CreateArrowSchema(const std::map<JsonKey, JsonKeyLayoutType>& column_map);
 
 std::vector<std::pair<std::string, std::string>>
-CreateParquetKVMetadata(std::map<JsonKey, JsonKeyLayoutType> column_map);
+CreateParquetKVMetadata(const std::map<JsonKey, JsonKeyLayoutType>& column_map);
 
 inline size_t
 GetArrowArrayMemorySize(const std::shared_ptr<arrow::Array>& array) {

--- a/internal/core/src/query/PlanProto.cpp
+++ b/internal/core/src/query/PlanProto.cpp
@@ -656,7 +656,8 @@ ProtoParser::ParseUnaryRangeExprs(const proto::plan::UnaryRangeExpr& expr_pb) {
         Assert(data_type == static_cast<DataType>(column_info.data_type()));
     }
     std::vector<::milvus::proto::plan::GenericValue> extra_values;
-    for (auto val : expr_pb.extra_values()) {
+    extra_values.reserve(expr_pb.extra_values_size());
+    for (const auto& val : expr_pb.extra_values()) {
         extra_values.emplace_back(val);
     }
     return std::make_shared<milvus::expr::UnaryRangeFilterExpr>(
@@ -751,9 +752,12 @@ ProtoParser::ParseMatchExprs(const proto::plan::MatchExpr& expr_pb) {
 
 expr::TypedExprPtr
 ProtoParser::ParseCallExprs(const proto::plan::CallExpr& expr_pb) {
+    const auto param_count = expr_pb.function_parameters_size();
     std::vector<expr::TypedExprPtr> parameters;
+    parameters.reserve(param_count);
     std::vector<DataType> func_param_type_list;
-    for (auto& param_expr : expr_pb.function_parameters()) {
+    func_param_type_list.reserve(param_count);
+    for (const auto& param_expr : expr_pb.function_parameters()) {
         // function parameter can be any type
         auto e = this->ParseExprs(param_expr, TypeIsAny);
         parameters.push_back(e);
@@ -823,6 +827,7 @@ ProtoParser::ParseTermExprs(const proto::plan::TermExpr& expr_pb) {
         Assert(data_type == (DataType)columnInfo.data_type());
     }
     std::vector<::milvus::proto::plan::GenericValue> values;
+    values.reserve(expr_pb.values_size());
     for (size_t i = 0; i < expr_pb.values_size(); i++) {
         values.emplace_back(expr_pb.values(i));
     }
@@ -901,6 +906,7 @@ ProtoParser::ParseJsonContainsExprs(
         Assert(data_type == (DataType)columnInfo.data_type());
     }
     std::vector<::milvus::proto::plan::GenericValue> values;
+    values.reserve(expr_pb.elements_size());
     for (size_t i = 0; i < expr_pb.elements_size(); i++) {
         values.emplace_back(expr_pb.elements(i));
     }

--- a/internal/core/src/query/SubSearchResult.cpp
+++ b/internal/core/src/query/SubSearchResult.cpp
@@ -27,6 +27,10 @@ SubSearchResult::merge_impl(const SubSearchResult& right) {
     AssertInfo(is_desc == PositivelyRelated(metric_type_),
                "[SubSearchResult]Metric type isn't desc");
 
+    // Pre-allocate buffers outside the loop to avoid per-iteration allocations
+    std::vector<float> buf_distances(topk_);
+    std::vector<int64_t> buf_ids(topk_);
+
     for (int64_t qn = 0; qn < num_queries_; ++qn) {
         auto offset = qn * topk_;
 
@@ -35,9 +39,6 @@ SubSearchResult::merge_impl(const SubSearchResult& right) {
 
         auto right_ids = right.get_ids() + offset;
         auto right_distances = right.get_distances() + offset;
-
-        std::vector<float> buf_distances(topk_);
-        std::vector<int64_t> buf_ids(topk_);
 
         auto lit = 0;  // left iter
         auto rit = 0;  // right iter

--- a/internal/core/src/segcore/ReduceUtils.cpp
+++ b/internal/core/src/segcore/ReduceUtils.cpp
@@ -140,9 +140,8 @@ AssembleGroupByValues(
                 auto field_data = group_by_res_values->mutable_string_data();
                 for (std::size_t idx = 0; idx < group_by_val_size; idx++) {
                     if (group_by_vals[idx].has_value()) {
-                        std::string val =
+                        *(field_data->mutable_data()->Add()) =
                             std::get<std::string>(group_by_vals[idx].value());
-                        *(field_data->mutable_data()->Add()) = val;
                     } else {
                         valid_data->Set(idx, false);
                     }
@@ -155,9 +154,8 @@ AssembleGroupByValues(
                 auto field_data = group_by_res_values->mutable_geometry_data();
                 for (std::size_t idx = 0; idx < group_by_val_size; idx++) {
                     if (group_by_vals[idx].has_value()) {
-                        std::string val =
+                        *(field_data->mutable_data()->Add()) =
                             std::get<std::string>(group_by_vals[idx].value());
-                        *(field_data->mutable_data()->Add()) = val;
                     } else {
                         valid_data->Set(idx, false);
                     }
@@ -274,9 +272,9 @@ AssembleGroupByValues(
                         for (std::size_t idx = 0; idx < group_by_val_size;
                              idx++) {
                             if (group_by_vals[idx].has_value()) {
-                                std::string val = std::get<std::string>(
-                                    group_by_vals[idx].value());
-                                *(field_data->mutable_data()->Add()) = val;
+                                *(field_data->mutable_data()->Add()) =
+                                    std::get<std::string>(
+                                        group_by_vals[idx].value());
                             } else {
                                 valid_data->Set(idx, false);
                             }

--- a/internal/core/src/segcore/segment_c.cpp
+++ b/internal/core/src/segcore/segment_c.cpp
@@ -603,6 +603,7 @@ LoadJsonKeyIndex(CTraceContext c_trace,
 
         milvus::Config config;
         std::vector<std::string> files;
+        files.reserve(info_proto->files_size());
         for (const auto& f : info_proto->files()) {
             files.push_back(f);
         }

--- a/internal/core/src/storage/DataCodecTest.cpp
+++ b/internal/core/src/storage/DataCodecTest.cpp
@@ -65,7 +65,8 @@ TEST(storage, InsertDataBoolNullable) {
     FixedVector<bool> data = {true, false, false, false, true};
     auto field_data = milvus::storage::CreateFieldData(
         storage::DataType::BOOL, DataType::NONE, true);
-    uint8_t* valid_data = new uint8_t[1]{0xF3};
+    uint8_t valid_data_storage[1] = {0xF3};
+    uint8_t* valid_data = valid_data_storage;
 
     field_data->FillFieldData(data.data(), valid_data, data.size(), 0);
 
@@ -95,7 +96,6 @@ TEST(storage, InsertDataBoolNullable) {
     ASSERT_EQ(data[1], new_data[1]);
     ASSERT_EQ(data[4], new_data[4]);
     ASSERT_EQ(*new_payload->ValidData(), *valid_data);
-    delete[] valid_data;
 }
 
 TEST(storage, InsertDataInt8) {
@@ -132,7 +132,8 @@ TEST(storage, InsertDataInt8Nullable) {
     FixedVector<int8_t> data = {1, 2, 3, 4, 5};
     auto field_data = milvus::storage::CreateFieldData(
         storage::DataType::INT8, DataType::NONE, true);
-    uint8_t* valid_data = new uint8_t[1]{0xF3};
+    uint8_t valid_data_storage[1] = {0xF3};
+    uint8_t* valid_data = valid_data_storage;
     field_data->FillFieldData(data.data(), valid_data, data.size(), 0);
 
     auto payload_reader =
@@ -159,7 +160,6 @@ TEST(storage, InsertDataInt8Nullable) {
     ASSERT_EQ(data, new_data);
     ASSERT_EQ(new_payload->get_null_count(), 2);
     ASSERT_EQ(*new_payload->ValidData(), *valid_data);
-    delete[] valid_data;
 }
 
 TEST(storage, InsertDataInt16) {
@@ -196,7 +196,8 @@ TEST(storage, InsertDataInt16Nullable) {
     FixedVector<int16_t> data = {1, 2, 3, 4, 5};
     auto field_data = milvus::storage::CreateFieldData(
         storage::DataType::INT16, DataType::NONE, true);
-    uint8_t* valid_data = new uint8_t[1]{0xF3};
+    uint8_t valid_data_storage[1] = {0xF3};
+    uint8_t* valid_data = valid_data_storage;
     field_data->FillFieldData(data.data(), valid_data, data.size(), 0);
 
     auto payload_reader =
@@ -223,7 +224,6 @@ TEST(storage, InsertDataInt16Nullable) {
     ASSERT_EQ(data, new_data);
     ASSERT_EQ(new_payload->get_null_count(), 2);
     ASSERT_EQ(*new_payload->ValidData(), *valid_data);
-    delete[] valid_data;
 }
 
 TEST(storage, InsertDataInt32) {
@@ -260,7 +260,8 @@ TEST(storage, InsertDataInt32Nullable) {
     FixedVector<int32_t> data = {1, 2, 3, 4, 5};
     auto field_data = milvus::storage::CreateFieldData(
         storage::DataType::INT32, DataType::NONE, true);
-    uint8_t* valid_data = new uint8_t[1]{0xF3};
+    uint8_t valid_data_storage[1] = {0xF3};
+    uint8_t* valid_data = valid_data_storage;
     field_data->FillFieldData(data.data(), valid_data, data.size(), 0);
 
     auto payload_reader =
@@ -287,7 +288,6 @@ TEST(storage, InsertDataInt32Nullable) {
     ASSERT_EQ(data, new_data);
     ASSERT_EQ(new_payload->get_null_count(), 2);
     ASSERT_EQ(*new_payload->ValidData(), *valid_data);
-    delete[] valid_data;
 }
 
 TEST(storage, InsertDataInt64) {
@@ -324,7 +324,8 @@ TEST(storage, InsertDataInt64Nullable) {
     FixedVector<int64_t> data = {1, 2, 3, 4, 5};
     auto field_data = milvus::storage::CreateFieldData(
         storage::DataType::INT64, DataType::NONE, true);
-    uint8_t* valid_data = new uint8_t[1]{0xF3};
+    uint8_t valid_data_storage[1] = {0xF3};
+    uint8_t* valid_data = valid_data_storage;
     field_data->FillFieldData(data.data(), valid_data, data.size(), 0);
 
     auto payload_reader =
@@ -351,7 +352,6 @@ TEST(storage, InsertDataInt64Nullable) {
     ASSERT_EQ(data, new_data);
     ASSERT_EQ(new_payload->get_null_count(), 2);
     ASSERT_EQ(*new_payload->ValidData(), *valid_data);
-    delete[] valid_data;
 }
 
 TEST(storage, InsertDataGeometry) {
@@ -426,7 +426,8 @@ TEST(storage, InsertDataGeometryNullable) {
     auto field_data = milvus::storage::CreateFieldData(
         storage::DataType::GEOMETRY, storage::DataType::NONE, true);
     // valid_data bitmap: 0xF3 (11110011 b) – rows 0,1,4 valid; rows 2,3 null
-    uint8_t* valid_data = new uint8_t[1]{0xF3};
+    uint8_t valid_data_storage[1] = {0xF3};
+    uint8_t* valid_data = valid_data_storage;
     field_data->FillFieldData(data.data(), valid_data, data.size(), 0);
 
     // Round-trip the payload through InsertData serialization pipeline
@@ -461,8 +462,6 @@ TEST(storage, InsertDataGeometryNullable) {
         ASSERT_EQ(new_payload->DataSize(i), data[i].size());
     }
     ASSERT_EQ(data, new_data);
-
-    delete[] valid_data;
 }
 TEST(storage, InsertDataString) {
     FixedVector<std::string> data = {
@@ -504,7 +503,8 @@ TEST(storage, InsertDataStringNullable) {
         "test1", "test2", "test3", "test4", "test5"};
     auto field_data = milvus::storage::CreateFieldData(
         storage::DataType::STRING, DataType::NONE, true);
-    uint8_t* valid_data = new uint8_t[1]{0xF3};
+    uint8_t valid_data_storage[1] = {0xF3};
+    uint8_t* valid_data = valid_data_storage;
     field_data->FillFieldData(data.data(), valid_data, data.size(), 0);
 
     auto payload_reader =
@@ -534,7 +534,6 @@ TEST(storage, InsertDataStringNullable) {
     }
     ASSERT_EQ(new_payload->get_null_count(), 2);
     ASSERT_EQ(*new_payload->ValidData(), *valid_data);
-    delete[] valid_data;
 }
 
 TEST(storage, InsertDataFloat) {
@@ -634,7 +633,8 @@ TEST(storage, InsertDataDoubleNullable) {
     FixedVector<double> data = {1, 2, 3, 4, 5};
     auto field_data = milvus::storage::CreateFieldData(
         storage::DataType::DOUBLE, DataType::NONE, true);
-    uint8_t* valid_data = new uint8_t[1]{0xF3};
+    uint8_t valid_data_storage[1] = {0xF3};
+    uint8_t* valid_data = valid_data_storage;
     field_data->FillFieldData(data.data(), valid_data, data.size(), 0);
 
     auto payload_reader =
@@ -661,7 +661,6 @@ TEST(storage, InsertDataDoubleNullable) {
     ASSERT_EQ(data, new_data);
     ASSERT_EQ(new_payload->get_null_count(), 2);
     ASSERT_EQ(*new_payload->ValidData(), *valid_data);
-    delete[] valid_data;
 }
 
 TEST(storage, InsertDataTimestamptz) {
@@ -700,7 +699,8 @@ TEST(storage, InsertDataTimestamptzNullable) {
         1000000000, 2000000000, 3000000000, 400000, 5000};
     auto field_data = milvus::storage::CreateFieldData(
         DataType::TIMESTAMPTZ, DataType::NONE, true);
-    uint8_t* valid_data = new uint8_t[1]{0xF3};
+    uint8_t valid_data_storage[1] = {0xF3};
+    uint8_t* valid_data = valid_data_storage;
     field_data->FillFieldData(data.data(), valid_data, data.size(), 0);
 
     auto payload_reader =
@@ -727,7 +727,6 @@ TEST(storage, InsertDataTimestamptzNullable) {
     ASSERT_EQ(data, new_data);
     ASSERT_EQ(new_payload->get_null_count(), 2);
     ASSERT_EQ(*new_payload->ValidData(), *valid_data);
-    delete[] valid_data;
 }
 
 TEST(storage, InsertDataFloatVector) {
@@ -1230,7 +1229,8 @@ TEST(storage, InsertDataStringArrayNullable) {
     FixedVector<Array> data = {string_array, int_array};
     auto field_data = milvus::storage::CreateFieldData(
         storage::DataType::ARRAY, DataType::NONE, true);
-    uint8_t* valid_data = new uint8_t[1]{0xFD};
+    uint8_t valid_data_storage[1] = {0xFD};
+    uint8_t* valid_data = valid_data_storage;
     field_data->FillFieldData(data.data(), valid_data, data.size(), 0);
 
     auto payload_reader =
@@ -1260,7 +1260,6 @@ TEST(storage, InsertDataStringArrayNullable) {
         ASSERT_TRUE(expected_data[i].operator==(new_data[i]));
     }
     ASSERT_EQ(*new_payload->ValidData(), *valid_data);
-    delete[] valid_data;
 }
 
 TEST(storage, InsertDataJsonNullable) {
@@ -1268,7 +1267,8 @@ TEST(storage, InsertDataJsonNullable) {
                               Json(simdjson::padded_string(std::string("A")))};
     auto field_data = milvus::storage::CreateFieldData(
         storage::DataType::JSON, DataType::NONE, true);
-    uint8_t* valid_data = new uint8_t[1]{0xFC};
+    uint8_t valid_data_storage[1] = {0xFC};
+    uint8_t* valid_data = valid_data_storage;
     field_data->FillFieldData(data.data(), valid_data, data.size(), 0);
 
     auto payload_reader =
@@ -1291,14 +1291,14 @@ TEST(storage, InsertDataJsonNullable) {
     ASSERT_EQ(new_payload->get_num_rows(), data.size());
     ASSERT_EQ(new_payload->get_null_count(), 2);
     ASSERT_EQ(*new_payload->ValidData(), *valid_data);
-    delete[] valid_data;
 }
 
 TEST(storage, InsertDataJsonFillWithNull) {
     auto field_data = milvus::storage::CreateFieldData(
         storage::DataType::JSON, DataType::NONE, true);
     int64_t size = 2;
-    uint8_t* valid_data = new uint8_t[1]{0xFC};
+    uint8_t valid_data_storage[1] = {0xFC};
+    uint8_t* valid_data = valid_data_storage;
     field_data->FillFieldData(std::nullopt, size);
 
     auto payload_reader =
@@ -1321,5 +1321,4 @@ TEST(storage, InsertDataJsonFillWithNull) {
     ASSERT_EQ(new_payload->get_num_rows(), size);
     ASSERT_EQ(new_payload->get_null_count(), size);
     ASSERT_EQ(*new_payload->ValidData(), *valid_data);
-    delete[] valid_data;
 }

--- a/internal/core/src/storage/RemoteInputStream.cpp
+++ b/internal/core/src/storage/RemoteInputStream.cpp
@@ -41,9 +41,9 @@ RemoteInputStream::Read(int fd, size_t size) {
         ssize_t ret = ::write(fd, data.data(), read_size);
         AssertInfo(ret == static_cast<ssize_t>(read_size),
                    "Failed to write to file");
-        ::fsync(fd);
         rest_size -= read_size;
     }
+    ::fsync(fd);
     return size;
 }
 


### PR DESCRIPTION
Performance optimizations to reduce memory allocations and unnecessary copies:

- **JSON processing**: Reuse scratch buffers and cache parsed Json objects in ChunkWriter
- **String handling**: Avoid intermediate vector copy when loading VARCHAR/TEXT from Arrow
- **General**: Use const references, `reserve()`, and `std::move()` to reduce allocations

issue: #44452
