### PR TITLE
fix: quota center should ignore the delegator is on recovering

### DIFF
--- a/internal/querynodev2/delegator/mock_delegator.go
+++ b/internal/querynodev2/delegator/mock_delegator.go
@@ -63,6 +63,51 @@ func (_c *MockShardDelegator_AddExcludedSegments_Call) RunAndReturn(run func(map
 	return _c
 }
 
+// CatchingUpStreamingData provides a mock function with no fields
+func (_m *MockShardDelegator) CatchingUpStreamingData() bool {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for CatchingUpStreamingData")
+	}
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
+// MockShardDelegator_CatchingUpStreamingData_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CatchingUpStreamingData'
+type MockShardDelegator_CatchingUpStreamingData_Call struct {
+	*mock.Call
+}
+
+// CatchingUpStreamingData is a helper method to define mock.On call
+func (_e *MockShardDelegator_Expecter) CatchingUpStreamingData() *MockShardDelegator_CatchingUpStreamingData_Call {
+	return &MockShardDelegator_CatchingUpStreamingData_Call{Call: _e.mock.On("CatchingUpStreamingData")}
+}
+
+func (_c *MockShardDelegator_CatchingUpStreamingData_Call) Run(run func()) *MockShardDelegator_CatchingUpStreamingData_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockShardDelegator_CatchingUpStreamingData_Call) Return(_a0 bool) *MockShardDelegator_CatchingUpStreamingData_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockShardDelegator_CatchingUpStreamingData_Call) RunAndReturn(run func() bool) *MockShardDelegator_CatchingUpStreamingData_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Close provides a mock function with no fields
 func (_m *MockShardDelegator) Close() {
 	_m.Called()
@@ -1129,51 +1174,6 @@ func (_c *MockShardDelegator_Serviceable_Call) Return(_a0 bool) *MockShardDelega
 }
 
 func (_c *MockShardDelegator_Serviceable_Call) RunAndReturn(run func() bool) *MockShardDelegator_Serviceable_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// CatchingUpStreamingData provides a mock function with no fields
-func (_m *MockShardDelegator) CatchingUpStreamingData() bool {
-	ret := _m.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for CatchingUpStreamingData")
-	}
-
-	var r0 bool
-	if rf, ok := ret.Get(0).(func() bool); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-
-	return r0
-}
-
-// MockShardDelegator_CatchingUpStreamingData_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CatchingUpStreamingData'
-type MockShardDelegator_CatchingUpStreamingData_Call struct {
-	*mock.Call
-}
-
-// CatchingUpStreamingData is a helper method to define mock.On call
-func (_e *MockShardDelegator_Expecter) CatchingUpStreamingData() *MockShardDelegator_CatchingUpStreamingData_Call {
-	return &MockShardDelegator_CatchingUpStreamingData_Call{Call: _e.mock.On("CatchingUpStreamingData")}
-}
-
-func (_c *MockShardDelegator_CatchingUpStreamingData_Call) Run(run func()) *MockShardDelegator_CatchingUpStreamingData_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *MockShardDelegator_CatchingUpStreamingData_Call) Return(_a0 bool) *MockShardDelegator_CatchingUpStreamingData_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockShardDelegator_CatchingUpStreamingData_Call) RunAndReturn(run func() bool) *MockShardDelegator_CatchingUpStreamingData_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/querynodev2/metrics_info.go
+++ b/internal/querynodev2/metrics_info.go
@@ -68,6 +68,11 @@ func getQuotaMetrics(node *QueryNode) (*metricsinfo.QueryNodeQuotaMetrics, error
 	minTsafe := uint64(math.MaxUint64)
 	node.delegators.Range(func(channel string, delegator delegator.ShardDelegator) bool {
 		tsafe := delegator.GetTSafe()
+		if delegator.CatchingUpStreamingData() {
+			// If the channel is on-catching up with streaming data.
+			// We should skip this channel to avoid the quota center to make wrong decision.
+			return true
+		}
 		if tsafe < minTsafe {
 			minTsafeChannel = channel
 			minTsafe = tsafe

--- a/internal/querynodev2/services_test.go
+++ b/internal/querynodev2/services_test.go
@@ -1860,6 +1860,7 @@ func (suite *ServiceSuite) TestGetMetric_Normal() {
 	suite.NoError(err)
 
 	sd1 := delegator.NewMockShardDelegator(suite.T())
+	sd1.EXPECT().CatchingUpStreamingData().Return(false).Maybe()
 	sd1.EXPECT().Collection().Return(100)
 	sd1.EXPECT().GetDeleteBufferSize().Return(10, 1000)
 	sd1.EXPECT().GetTSafe().Return(100)
@@ -1868,6 +1869,7 @@ func (suite *ServiceSuite) TestGetMetric_Normal() {
 	defer suite.node.delegators.GetAndRemove("qn_unitest_dml_0_100v0")
 
 	sd2 := delegator.NewMockShardDelegator(suite.T())
+	sd2.EXPECT().CatchingUpStreamingData().Return(false).Maybe()
 	sd2.EXPECT().Collection().Return(100)
 	sd2.EXPECT().GetTSafe().Return(200)
 	sd2.EXPECT().GetDeleteBufferSize().Return(10, 1000)


### PR DESCRIPTION
issue: #46856

if the delegator is no recovering, the tslag may be huge. so the quota center may see the huge lag, forbid the writing.