### PR TITLE
test: Fix flaky test_job_import_binlog_file_type by waiting for index building

### DIFF
--- a/tests/restful_client_v2/testcases/test_jobs_operation.py
+++ b/tests/restful_client_v2/testcases/test_jobs_operation.py
@@ -968,7 +968,9 @@ class TestCreateImportJob(TestBase):
         # flush data to generate binlog file
         c = Collection(name)
         c.flush()
-        time.sleep(2)
+        # wait for index building to complete, which ensures sort compaction is done
+        for field_name in ["text_emb", "image_emb"]:
+            utility.wait_for_index_building_complete(name, field_name)
 
         # query data to make sure the data is inserted
         rsp = self.vector_client.vector_query({"collectionName": name, "filter": "user_id > 0", "limit": 50})


### PR DESCRIPTION
/kind improvement

The test was flaky because sort compaction may not complete within the sleep time. Instead of relying on sleep, wait for index building to complete after flush, which ensures sort compaction is done before getting binlog files.