### PR TITLE
fix: Improve snapshot restore and RefIndex loading reliability

### DIFF
--- a/internal/datacoord/ddl_callbacks_snapshot_test.go
+++ b/internal/datacoord/ddl_callbacks_snapshot_test.go
@@ -251,11 +251,12 @@ func TestDDLCallbacks_RestoreSnapshotV2AckCallback_Success(t *testing.T) {
 	mockRestoreData := mockey.Mock((*snapshotManager).RestoreData).To(func(
 		sm *snapshotManager,
 		ctx context.Context,
-		snapshotData *SnapshotData,
+		snapshotName string,
 		collectionID int64,
 		jobID int64,
 	) (int64, error) {
 		restoreDataCalled = true
+		assert.Equal(t, "test_snapshot", snapshotName)
 		assert.Equal(t, int64(200), collectionID)
 		assert.Equal(t, int64(12345), jobID) // Verify jobID is passed from header
 		return jobID, nil
@@ -305,55 +306,10 @@ func TestDDLCallbacks_RestoreSnapshotV2AckCallback_Success(t *testing.T) {
 
 	// Verify
 	assert.NoError(t, err)
-	assert.True(t, readSnapshotDataCalled)
+	// restoreSnapshotV2AckCallback no longer reads snapshot data directly.
+	assert.False(t, readSnapshotDataCalled)
 	assert.True(t, restoreDataCalled)
-	assert.True(t, getRestoreStateCalled)
-}
-
-func TestDDLCallbacks_RestoreSnapshotV2AckCallback_ReadSnapshotDataError(t *testing.T) {
-	ctx := context.Background()
-
-	expectedErr := errors.New("snapshot not found")
-
-	// Mock snapshotManager.ReadSnapshotData to return error
-	mockReadSnapshotData := mockey.Mock((*snapshotManager).ReadSnapshotData).To(func(
-		sm *snapshotManager,
-		ctx context.Context,
-		name string,
-	) (*SnapshotData, error) {
-		return nil, expectedErr
-	}).Build()
-	defer mockReadSnapshotData.UnPatch()
-
-	// Create DDLCallbacks
-	server := &Server{
-		snapshotManager: &snapshotManager{},
-	}
-	callbacks := &DDLCallbacks{Server: server}
-
-	// Create test broadcast result
-	broadcastMsg := message.NewRestoreSnapshotMessageBuilderV2().
-		WithHeader(&message.RestoreSnapshotMessageHeader{
-			SnapshotName: "test_snapshot",
-			CollectionId: 200,
-			JobId:        12345,
-		}).
-		WithBody(&message.RestoreSnapshotMessageBody{}).
-		WithBroadcast([]string{"control_channel"}).
-		MustBuildBroadcast()
-
-	typedMsg := message.MustAsBroadcastRestoreSnapshotMessageV2(broadcastMsg)
-
-	result := message.BroadcastResultRestoreSnapshotMessageV2{
-		Message: typedMsg,
-	}
-
-	// Execute
-	err := callbacks.restoreSnapshotV2AckCallback(ctx, result)
-
-	// Verify
-	assert.Error(t, err)
-	assert.Equal(t, expectedErr, err)
+	assert.False(t, getRestoreStateCalled)
 }
 
 func TestDDLCallbacks_RestoreSnapshotV2AckCallback_RestoreDataError(t *testing.T) {
@@ -361,99 +317,17 @@ func TestDDLCallbacks_RestoreSnapshotV2AckCallback_RestoreDataError(t *testing.T
 
 	expectedErr := errors.New("restore data error")
 
-	// Mock snapshotManager.ReadSnapshotData to return success
-	mockReadSnapshotData := mockey.Mock((*snapshotManager).ReadSnapshotData).To(func(
-		sm *snapshotManager,
-		ctx context.Context,
-		name string,
-	) (*SnapshotData, error) {
-		return &SnapshotData{
-			SnapshotInfo: &datapb.SnapshotInfo{Name: name},
-		}, nil
-	}).Build()
-	defer mockReadSnapshotData.UnPatch()
-
 	// Mock snapshotManager.RestoreData to return error
 	mockRestoreData := mockey.Mock((*snapshotManager).RestoreData).To(func(
 		sm *snapshotManager,
 		ctx context.Context,
-		snapshotData *SnapshotData,
+		snapshotName string,
 		collectionID int64,
 		jobID int64,
 	) (int64, error) {
 		return 0, expectedErr
 	}).Build()
 	defer mockRestoreData.UnPatch()
-
-	// Create DDLCallbacks
-	server := &Server{
-		snapshotManager: &snapshotManager{},
-	}
-	callbacks := &DDLCallbacks{Server: server}
-
-	// Create test broadcast result
-	broadcastMsg := message.NewRestoreSnapshotMessageBuilderV2().
-		WithHeader(&message.RestoreSnapshotMessageHeader{
-			SnapshotName: "test_snapshot",
-			CollectionId: 200,
-			JobId:        12345,
-		}).
-		WithBody(&message.RestoreSnapshotMessageBody{}).
-		WithBroadcast([]string{"control_channel"}).
-		MustBuildBroadcast()
-
-	typedMsg := message.MustAsBroadcastRestoreSnapshotMessageV2(broadcastMsg)
-
-	result := message.BroadcastResultRestoreSnapshotMessageV2{
-		Message: typedMsg,
-	}
-
-	// Execute
-	err := callbacks.restoreSnapshotV2AckCallback(ctx, result)
-
-	// Verify
-	assert.Error(t, err)
-	assert.Equal(t, expectedErr, err)
-}
-
-func TestDDLCallbacks_RestoreSnapshotV2AckCallback_GetRestoreStateError(t *testing.T) {
-	ctx := context.Background()
-
-	expectedErr := errors.New("get restore state error")
-
-	// Mock snapshotManager.ReadSnapshotData to return success
-	mockReadSnapshotData := mockey.Mock((*snapshotManager).ReadSnapshotData).To(func(
-		sm *snapshotManager,
-		ctx context.Context,
-		name string,
-	) (*SnapshotData, error) {
-		return &SnapshotData{
-			SnapshotInfo: &datapb.SnapshotInfo{Name: name},
-		}, nil
-	}).Build()
-	defer mockReadSnapshotData.UnPatch()
-
-	// Mock snapshotManager.RestoreData to return success
-	mockRestoreData := mockey.Mock((*snapshotManager).RestoreData).To(func(
-		sm *snapshotManager,
-		ctx context.Context,
-		snapshotData *SnapshotData,
-		collectionID int64,
-		jobID int64,
-	) (int64, error) {
-		return jobID, nil
-	}).Build()
-	defer mockRestoreData.UnPatch()
-
-	// Mock snapshotManager.GetRestoreState to return error
-	mockGetRestoreState := mockey.Mock((*snapshotManager).GetRestoreState).To(func(
-		sm *snapshotManager,
-		ctx context.Context,
-		jobID int64,
-	) (*datapb.RestoreSnapshotInfo, error) {
-		return nil, expectedErr
-	}).Build()
-	defer mockGetRestoreState.UnPatch()
 
 	// Create DDLCallbacks
 	server := &Server{

--- a/internal/datacoord/garbage_collector_test.go
+++ b/internal/datacoord/garbage_collector_test.go
@@ -594,7 +594,7 @@ func TestGarbageCollector_recycleUnusedSegIndexes(t *testing.T) {
 		gc := newGarbageCollector(createMetaForRecycleUnusedSegIndexes(catalog), nil, GcOption{
 			cli: mockChunkManager,
 		})
-		mockIsRefIndexLoaded := mockey.Mock((*snapshotMeta).IsRefIndexLoaded).Return(true).Build()
+		mockIsRefIndexLoaded := mockey.Mock((*snapshotMeta).IsRefIndexLoadedForCollection).Return(true).Build()
 		defer mockIsRefIndexLoaded.UnPatch()
 		mockGetSnapshotByIndex := mockey.Mock((*snapshotMeta).GetSnapshotByIndex).Return([]UniqueID{}).Build()
 		defer mockGetSnapshotByIndex.UnPatch()
@@ -616,7 +616,7 @@ func TestGarbageCollector_recycleUnusedSegIndexes(t *testing.T) {
 		gc := newGarbageCollector(createMetaForRecycleUnusedSegIndexes(catalog), nil, GcOption{
 			cli: mockChunkManager,
 		})
-		mockIsRefIndexLoaded := mockey.Mock((*snapshotMeta).IsRefIndexLoaded).Return(true).Build()
+		mockIsRefIndexLoaded := mockey.Mock((*snapshotMeta).IsRefIndexLoadedForCollection).Return(true).Build()
 		defer mockIsRefIndexLoaded.UnPatch()
 		mockGetSnapshotByIndex := mockey.Mock((*snapshotMeta).GetSnapshotByIndex).Return([]UniqueID{}).Build()
 		defer mockGetSnapshotByIndex.UnPatch()
@@ -1409,7 +1409,7 @@ func TestGarbageCollector_clearETCD(t *testing.T) {
 			cli:           cm,
 			dropTolerance: 1,
 		})
-	mockIsRefIndexLoaded := mockey.Mock((*snapshotMeta).IsRefIndexLoaded).Return(true).Build()
+	mockIsRefIndexLoaded := mockey.Mock((*snapshotMeta).IsRefIndexLoadedForCollection).Return(true).Build()
 	defer mockIsRefIndexLoaded.UnPatch()
 	mockGetSnapshotBySegment := mockey.Mock((*snapshotMeta).GetSnapshotBySegment).Return([]UniqueID{}).Build()
 	defer mockGetSnapshotBySegment.UnPatch()
@@ -1894,7 +1894,7 @@ func TestGarbageCollector_recycleDroppedSegments_SnapshotReference(t *testing.T)
 	mock1 := mockey.Mock(meta.GetSnapshotMeta).Return(smMeta).Build()
 	defer mock1.UnPatch()
 
-	mockIsRefIndexLoaded := mockey.Mock((*snapshotMeta).IsRefIndexLoaded).Return(true).Build()
+	mockIsRefIndexLoaded := mockey.Mock((*snapshotMeta).IsRefIndexLoadedForCollection).Return(true).Build()
 	defer mockIsRefIndexLoaded.UnPatch()
 
 	mock2 := mockey.Mock((*snapshotMeta).GetSnapshotBySegment).To(func(ctx context.Context, collectionID, segmentID int64) []int64 {
@@ -2016,7 +2016,7 @@ func TestGarbageCollector_recycleUnusedSegIndexes_SnapshotReference(t *testing.T
 	}
 
 	// Setup mocks
-	mockIsRefIndexLoaded := mockey.Mock((*snapshotMeta).IsRefIndexLoaded).Return(true).Build()
+	mockIsRefIndexLoaded := mockey.Mock((*snapshotMeta).IsRefIndexLoadedForCollection).Return(true).Build()
 	defer mockIsRefIndexLoaded.UnPatch()
 
 	mock1 := mockey.Mock((*snapshotMeta).GetSnapshotByIndex).To(func(ctx context.Context, collectionID, indexID int64) []int64 {

--- a/internal/datacoord/server.go
+++ b/internal/datacoord/server.go
@@ -1105,6 +1105,11 @@ func (s *Server) Stop() error {
 	s.garbageCollector.close()
 	log.Info("datacoord garbage collector stopped")
 
+	if s.meta != nil {
+		s.meta.GetSnapshotMeta().Close()
+		log.Info("datacoord snapshot meta closed")
+	}
+
 	s.stopServerLoop()
 	log.Info("datacoord stopServerLoop stopped")
 

--- a/pkg/proto/data_coord.proto
+++ b/pkg/proto/data_coord.proto
@@ -1518,7 +1518,7 @@ message RestoreSnapshotRequest {
 message RestoreSnapshotResponse {
   common.Status status = 1;
   int64 job_id = 2; // restore job ID for async tracking (deprecated, use ListRestoreJobs)
-  int64 collection_id = 3; // target collection ID
+  int64 collection_id = 3; // deprecated
 }
 
 message GetRestoreSnapshotStateRequest {

--- a/pkg/proto/datapb/data_coord.pb.go
+++ b/pkg/proto/datapb/data_coord.pb.go
@@ -11876,7 +11876,7 @@ type RestoreSnapshotResponse struct {
 
 	Status       *commonpb.Status `protobuf:"bytes,1,opt,name=status,proto3" json:"status,omitempty"`
 	JobId        int64            `protobuf:"varint,2,opt,name=job_id,json=jobId,proto3" json:"job_id,omitempty"`                      // restore job ID for async tracking (deprecated, use ListRestoreJobs)
-	CollectionId int64            `protobuf:"varint,3,opt,name=collection_id,json=collectionId,proto3" json:"collection_id,omitempty"` // target collection ID
+	CollectionId int64            `protobuf:"varint,3,opt,name=collection_id,json=collectionId,proto3" json:"collection_id,omitempty"` // deprecated
 }
 
 func (x *RestoreSnapshotResponse) Reset() {

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -4658,15 +4658,16 @@ type dataCoordConfig struct {
 	LevelZeroCompactionTriggerDeltalogMaxNum ParamItem `refreshable:"true"`
 
 	// Garbage Collection
-	EnableGarbageCollection     ParamItem `refreshable:"false"`
-	GCInterval                  ParamItem `refreshable:"false"`
-	GCMissingTolerance          ParamItem `refreshable:"false"`
-	GCDropTolerance             ParamItem `refreshable:"false"`
-	GCRemoveConcurrent          ParamItem `refreshable:"false"`
-	GCScanIntervalInHour        ParamItem `refreshable:"false"`
-	GCSlowDownCPUUsageThreshold ParamItem `refreshable:"false"`
-	SnapshotPendingTimeout      ParamItem `refreshable:"true"`
-	EnableActiveStandby         ParamItem `refreshable:"false"`
+	EnableGarbageCollection      ParamItem `refreshable:"false"`
+	GCInterval                   ParamItem `refreshable:"false"`
+	GCMissingTolerance           ParamItem `refreshable:"false"`
+	GCDropTolerance              ParamItem `refreshable:"false"`
+	GCRemoveConcurrent           ParamItem `refreshable:"false"`
+	GCScanIntervalInHour         ParamItem `refreshable:"false"`
+	GCSlowDownCPUUsageThreshold  ParamItem `refreshable:"false"`
+	SnapshotPendingTimeout       ParamItem `refreshable:"true"`
+	SnapshotRefIndexLoadInterval ParamItem `refreshable:"true"`
+	EnableActiveStandby          ParamItem `refreshable:"false"`
 
 	BindIndexNodeMode    ParamItem `refreshable:"false"`
 	IndexNodeAddress     ParamItem `refreshable:"false"`
@@ -5454,6 +5455,14 @@ During compaction, the size of segment # of rows is able to exceed segment max #
 		Export:       true,
 	}
 	p.SnapshotPendingTimeout.Init(base.mgr)
+
+	p.SnapshotRefIndexLoadInterval = ParamItem{
+		Key:          "dataCoord.snapshot.refIndexLoadInterval",
+		Version:      "2.6.10",
+		DefaultValue: "60s",
+		Doc:          "The interval for loading snapshot RefIndex from S3",
+	}
+	p.SnapshotRefIndexLoadInterval.Init(base.mgr)
 
 	p.EnableActiveStandby = ParamItem{
 		Key:          "dataCoord.enableActiveStandby",


### PR DESCRIPTION
issue: #44358

- Change RestoreSnapshot API to return jobID instead of collectionID, making the async restore pattern more explicit
- Refactor RestoreData to accept snapshotName instead of snapshotData, moving the ReadSnapshotData call inside for better encapsulation
- Remove synchronous wait loop from restoreSnapshotV2AckCallback to avoid blocking the WAL callback
- Implement per-collection RefIndex loading state (Pending/Loaded/Failed) replacing the global refIndexLoadDone channel
- Add background loader retry mechanism for failed RefIndex loads
- Fix recyclePendingSnapshots to keep catalog record when S3 cleanup fails, allowing retry in next GC cycle
- Add snapshotMeta.Close() method and call it during server shutdown
- Add SnapshotRefIndexLoadInterval configuration parameter
- Update e2e tests to explicitly wait for restore completion