### PR TITLE
feat: [ExternalTable Part1] Enable create external collection

### DIFF
--- a/client/entity/field.go
+++ b/client/entity/field.go
@@ -234,6 +234,7 @@ type Field struct {
 	DefaultValue    *schemapb.ValueField
 	Nullable        bool
 	StructSchema    *StructSchema
+	ExternalField   string // external field name - maps to column name in external source
 }
 
 // ProtoMessage generates corresponding FieldSchema
@@ -253,6 +254,7 @@ func (f *Field) ProtoMessage() *schemapb.FieldSchema {
 		ElementType:     schemapb.DataType(f.ElementType),
 		Nullable:        f.Nullable,
 		DefaultValue:    f.DefaultValue,
+		ExternalField:   f.ExternalField,
 	}
 }
 
@@ -460,6 +462,12 @@ func (f *Field) WithStructSchema(schema *StructSchema) *Field {
 	return f
 }
 
+// WithExternalField sets the external field name for external collection fields.
+func (f *Field) WithExternalField(externalField string) *Field {
+	f.ExternalField = externalField
+	return f
+}
+
 // ReadProto parses FieldSchema
 func (f *Field) ReadProto(p *schemapb.FieldSchema) *Field {
 	f.ID = p.GetFieldID()
@@ -476,6 +484,7 @@ func (f *Field) ReadProto(p *schemapb.FieldSchema) *Field {
 	f.ElementType = FieldType(p.GetElementType())
 	f.DefaultValue = p.GetDefaultValue()
 	f.Nullable = p.GetNullable()
+	f.ExternalField = p.GetExternalField()
 
 	return f
 }

--- a/client/entity/schema.go
+++ b/client/entity/schema.go
@@ -65,6 +65,8 @@ type Schema struct {
 	Fields             []*Field
 	EnableDynamicField bool
 	Functions          []*Function
+	ExternalSource     string // External data source (e.g., "s3://bucket/path")
+	ExternalSpec       string // External source config (JSON)
 
 	pkField *Field
 }
@@ -96,6 +98,18 @@ func (s *Schema) WithDynamicFieldEnabled(dynamicEnabled bool) *Schema {
 	return s
 }
 
+// WithExternalSource sets the external source for the schema (e.g., "s3://bucket/path").
+func (s *Schema) WithExternalSource(externalSource string) *Schema {
+	s.ExternalSource = externalSource
+	return s
+}
+
+// WithExternalSpec sets the external spec configuration (JSON format).
+func (s *Schema) WithExternalSpec(externalSpec string) *Schema {
+	s.ExternalSpec = externalSpec
+	return s
+}
+
 // WithField adds a field into schema and returns schema itself.
 func (s *Schema) WithField(f *Field) *Schema {
 	if f.PrimaryKey {
@@ -117,6 +131,8 @@ func (s *Schema) ProtoMessage() *schemapb.CollectionSchema {
 		Description:        s.Description,
 		AutoID:             s.AutoID,
 		EnableDynamicField: s.EnableDynamicField,
+		ExternalSource:     s.ExternalSource,
+		ExternalSpec:       s.ExternalSpec,
 	}
 	r.Fields = lo.FilterMap(s.Fields, func(field *Field, _ int) (*schemapb.FieldSchema, bool) {
 		if field.DataType == FieldTypeArray && field.ElementType == FieldTypeStruct {
@@ -162,6 +178,8 @@ func (s *Schema) ReadProto(p *schemapb.CollectionSchema) *Schema {
 	s.Description = p.GetDescription()
 	s.CollectionName = p.GetName()
 	s.EnableDynamicField = p.GetEnableDynamicField()
+	s.ExternalSource = p.GetExternalSource()
+	s.ExternalSpec = p.GetExternalSpec()
 	// fields
 	s.Fields = make([]*Field, 0, len(p.GetFields()))
 	for _, fp := range p.GetFields() {

--- a/docs/design_docs/20260105-external_table.md
+++ b/docs/design_docs/20260105-external_table.md
@@ -1,0 +1,1095 @@
+# External Table (External Collection) Design Document
+
+## 1. Overview
+
+### 1.1 Background
+
+External Table (External Collection) is a special type of data collection in Milvus that allows users to access data from external storage systems (such as S3, Iceberg, Delta Lake, etc.) without copying the data into Milvus local storage. This enables Milvus to serve as a query layer over existing data lakes while maintaining compatibility with standard Milvus query interfaces.
+
+### 1.2 Goals
+
+1. **Support External Table Creation**
+   - Create external collections through standard `CreateCollection` API with `external_source` parameter
+   - Map external data files (Parquet, etc.) to Milvus storage format via manifest files
+   - Support field mapping between external columns and Milvus schema fields
+   - Auto-inject virtual primary key for external collections
+
+2. **Support Vector Index Building on External Tables**
+   - Enable index creation on vector fields of external collections
+   - Leverage milvus-storage library for efficient data access during index building
+   - Support common index types (IVF, HNSW, etc.) on external data
+
+3. **Support External Table Loading**
+   - Load external collection segments into QueryNode memory
+   - Use `ExternalFieldChunkedColumn` for lazy data loading from external sources
+   - Generate virtual PKs using `(segmentID << 32) | offset` encoding
+   - Use `ExternalSegmentCandidate` for PK-based segment matching (replacing bloom filters)
+
+4. **Support External Table Querying**
+   - Provide unified query interface consistent with regular collections
+   - Support vector similarity search on external data
+   - Support scalar filtering and hybrid search
+   - Enable search/query operations while blocking write operations
+
+5. **Support External Table Data Updates**
+   - Support manual trigger to refresh external table data (automatic detection not supported yet)
+   - Synchronize external data changes with segment-level granularity
+   - Implement incremental update strategy: keep unchanged segments, drop obsolete segments, add new segments
+   - Balance orphan fragments into new segments using bin-packing algorithm
+
+### 1.3 Non-Goals
+
+The following features are explicitly **NOT supported** for external tables in the current implementation:
+
+1. **Write Operations**
+   - No support for insert, delete, upsert, or import operations
+   - External tables are read-only; data modifications must be done at the source
+
+2. **Function Features**
+   - No support for user-defined functions (UDFs)
+   - No support for embedding functions or built-in transformation functions
+
+3. **Schema Modifications**
+   - No support for schema evolution or alterations after creation
+   - No support for adding new columns (AddField)
+   - No support for altering existing field properties (AlterField)
+
+4. **Dynamic Schema Features**
+   - No support for dynamic fields (`EnableDynamicField`)
+   - Schema must be fixed and fully defined at creation time
+
+5. **Auto ID**
+   - No support for auto-generated IDs (`AutoID`)
+   - Virtual PK is generated using `(segmentID << 32) | offset` encoding instead
+
+6. **Automatic Data Source Synchronization**
+   - No support for automatic/periodic detection of external data source changes
+   - Data updates must be triggered manually
+
+7. **Other Limitations**
+   - No support for partition key fields
+   - No support for clustering key fields
+   - No support for text match functionality
+   - No support for struct array fields
+   - No support for namespace fields
+
+---
+
+## 2. Architecture
+
+### 2.1 System Architecture Diagram
+
+```
++-------------------------------------------------------------------------+
+|                              Client                                      |
+|  - CreateCollection(schema with external_source)                         |
+|  - AlterCollection (modify data source / trigger manual refresh)         |
++-----------------------------------+-------------------------------------+
+                                    |
+                                    v
++-------------------------------------------------------------------------+
+|                             Proxy                                        |
+|  - ValidateExternalCollectionSchema()                                    |
+|  - Block write operations for external collections                       |
++-----------------------------------+-------------------------------------+
+                                    |
+                                    v
++-------------------------------------------------------------------------+
+|                           RootCoord                                      |
+|  - ValidateExternalCollectionSchema()                                    |
+|  - Store ExternalSource/ExternalSpec in collection model                 |
++-----------------------------------+-------------------------------------+
+                                    |
+                                    v
++-------------------------------------------------------------------------+
+|                           DataCoord                                      |
+|  +---------------------------------------------------------------+      |
+|  |              Compaction (DISABLED for external)                |      |
+|  |  - Single/L0/Clustering compaction skipped                     |      |
+|  +---------------------------------------------------------------+      |
+|  +---------------------------------------------------------------+      |
+|  |              Stats Inspector (DISABLED for external)           |      |
+|  |  - Text/JSON/BM25 stats tasks skipped                          |      |
+|  +---------------------------------------------------------------+      |
+|  +---------------------------------------------------------------+      |
+|  |              UpdateExternalCollectionTask                      |      |
+|  |  - Handle manual refresh requests                              |      |
+|  |  - Coordinate with DataNode for data sync                      |      |
+|  +---------------------------------------------------------------+      |
++-----------------------------------+-------------------------------------+
+                                    |
+                                    v
++-------------------------------------------------------------------------+
+|                           DataNode                                       |
+|  +---------------------------------------------------------------+      |
+|  |              ExternalCollectionManager                         |      |
+|  |  - Task lifecycle management                                   |      |
+|  |  - Worker pool for async execution                             |      |
+|  +---------------------------------------------------------------+      |
+|  +---------------------------------------------------------------+      |
+|  |              UpdateExternalTask                                |      |
+|  |  - Fetch fragments from external source                        |      |
+|  |  - Compare with current segments                               |      |
+|  |  - Organize orphan fragments into new segments                 |      |
+|  |  - Create manifest files for segments                          |      |
+|  +---------------------------------------------------------------+      |
++-----------------------------------+-------------------------------------+
+                                    |
+                                    v
++-------------------------------------------------------------------------+
+|                           QueryNode                                      |
+|  - Virtual PK generation: (segmentID << 32) | offset                    |
+|  - ExternalFieldChunkedColumn: Lazy load via milvus-storage             |
+|  - ExternalSegmentCandidate: PK-based segment matching                  |
+|  - Skip delta logs and bloom filters for external collections           |
++-------------------------------------------------------------------------+
+```
+
+### 2.2 Component Responsibilities
+
+| Component | Responsibility |
+|-----------|---------------|
+| `Proxy` | Validate external collection schema, skip PK validation, block write operations, handle refresh requests |
+| `RootCoord` | Validate schema, store external source configuration |
+| `DataCoord` | Disable compaction/stats, manage external collection update tasks |
+| `DataNode` | Execute external source scanning, organize segments, create manifests |
+| `QueryNode` | Load external data with virtual PK support, execute queries |
+
+---
+
+## 3. External Table API Design
+
+### 3.1 API Reuse Strategy
+
+External tables reuse existing Milvus APIs to minimize API surface and maintain consistency:
+
+| Operation | API | Description |
+|-----------|-----|-------------|
+| Create external table | `CreateCollection` | Set `external_source` in schema to create external table |
+| Drop external table | `DropCollection` | Standard drop collection API |
+| Load external table | `LoadCollection` | Standard load collection API |
+| Query external table | `Search` / `Query` | Standard search and query APIs |
+
+### 3.1.1 New APIs for Data Refresh
+
+The following new APIs are introduced specifically for external table data refresh:
+
+| Operation | API | Description |
+|-----------|-----|-------------|
+| Trigger refresh | `RefreshExternalTable` | Manually trigger data refresh from external source |
+| Get refresh progress | `GetRefreshExternalTableProgress` | Get progress of a specific refresh job |
+| List refresh jobs | `ListRefreshExternalTableJobs` | List all refresh jobs for a collection |
+
+### 3.1.2 RefreshExternalTable API
+
+Manually triggers a data refresh job for an external collection.
+
+**Proto Definition** (`milvus.proto`):
+```protobuf
+// Job state enumeration for external table refresh
+enum RefreshExternalTableState {
+    RefreshStatePending = 0;      // Job is queued, waiting to execute
+    RefreshStateInProgress = 1;   // Job is currently executing
+    RefreshStateCompleted = 2;    // Job completed successfully
+    RefreshStateFailed = 3;       // Job failed with error
+}
+
+message RefreshExternalTableRequest {
+    common.MsgBase base = 1;
+    string db_name = 2;              // Database name
+    string collection_name = 3;      // Collection name (required)
+    string external_source = 4;      // Optional: new external source path
+    string external_spec = 5;        // Optional: new external spec configuration
+}
+
+message RefreshExternalTableResponse {
+    common.Status status = 1;
+    string job_id = 2;               // Unique job identifier for tracking
+}
+```
+
+**Behavior**:
+- If `external_source` or `external_spec` is provided, updates the collection's external configuration before triggering refresh
+- If not provided, refreshes using the current external source configuration
+- Returns a `job_id` that can be used to track progress
+- Job runs asynchronously; use `GetRefreshExternalTableProgress` to monitor
+
+**Example Usage**:
+```python
+# Refresh with current data source
+response = client.refresh_external_table(
+    collection_name="my_external_collection"
+)
+job_id = response.job_id
+
+# Refresh with updated data source path
+response = client.refresh_external_table(
+    collection_name="my_external_collection",
+    external_source="s3://my-bucket/new-path/",
+    external_spec='{"format": "parquet"}'
+)
+```
+
+### 3.1.3 GetRefreshExternalTableProgress API
+
+Gets the current progress and status of a refresh job.
+
+**Proto Definition** (`milvus.proto`):
+```protobuf
+message GetRefreshExternalTableProgressRequest {
+    common.MsgBase base = 1;
+    string job_id = 2;               // Job ID from RefreshExternalTable response
+}
+
+message RefreshExternalTableJobInfo {
+    string job_id = 1;                   // Job identifier
+    string collection_name = 2;          // Collection name
+    RefreshExternalTableState state = 3; // Current job state
+    int64 progress = 4;                  // Progress percentage (0-100)
+    string reason = 5;                   // Error message if failed
+    string external_source = 6;          // External source used for this job
+    int64 start_time = 7;                // Job start timestamp
+    int64 end_time = 8;                  // Job end timestamp (0 if not completed)
+}
+
+message GetRefreshExternalTableProgressResponse {
+    common.Status status = 1;
+    RefreshExternalTableJobInfo job_info = 2;
+}
+```
+
+**Behavior**:
+- Returns detailed progress information for the specified job
+- State transitions: Pending → InProgress → Completed/Failed
+
+**Example Usage**:
+```python
+# Get progress of a specific job
+progress = client.get_refresh_external_table_progress(job_id="job_123456")
+print(f"State: {progress.state}")
+print(f"Progress: {progress.progress}%")
+```
+
+### 3.1.4 ListRefreshExternalTableJobs API
+
+Lists all refresh jobs for a collection.
+
+**Proto Definition** (`milvus.proto`):
+```protobuf
+message ListRefreshExternalTableJobsRequest {
+    common.MsgBase base = 1;
+    string db_name = 2;              // Database name
+    string collection_name = 3;      // Collection name (optional, if empty lists all)
+    int64 limit = 4;                 // Max number of jobs to return (default: 100)
+}
+
+message ListRefreshExternalTableJobsResponse {
+    common.Status status = 1;
+    repeated RefreshExternalTableJobInfo jobs = 2;
+}
+```
+
+**Behavior**:
+- Returns jobs sorted by start_time (most recent first)
+- If `collection_name` is empty, returns jobs for all external collections
+- Jobs are retained for a configurable period after completion (default: 24 hours)
+
+**Example Usage**:
+```python
+# List all jobs for a collection
+jobs = client.list_refresh_external_table_jobs(
+    collection_name="my_external_collection"
+)
+for job in jobs:
+    print(f"Job {job.job_id}: {job.state} ({job.progress}%)")
+
+# List all external table refresh jobs
+all_jobs = client.list_refresh_external_table_jobs()
+```
+
+### 3.2 Create External Table
+
+External collections are created through the standard `CreateCollection` API by setting `external_source` in the schema:
+
+```go
+schema := &schemapb.CollectionSchema{
+    Name:           "my_external_collection",
+    ExternalSource: "s3://bucket/path/to/data",
+    ExternalSpec:   `{"format": "parquet"}`,
+    Fields: []*schemapb.FieldSchema{
+        {
+            Name:          "text_field",
+            DataType:      schemapb.DataType_VarChar,
+            ExternalField: "source_text_column",  // Maps to external column
+            TypeParams:    []*commonpb.KeyValuePair{{Key: "max_length", Value: "256"}},
+        },
+        {
+            Name:          "vector_field",
+            DataType:      schemapb.DataType_FloatVector,
+            ExternalField: "source_embedding",
+            TypeParams:    []*commonpb.KeyValuePair{{Key: "dim", Value: "128"}},
+        },
+    },
+}
+```
+
+### 3.3 Schema Restrictions
+
+External collections have the following restrictions enforced by `ValidateExternalCollectionSchema()`:
+
+| Feature | Status | Reason |
+|---------|--------|--------|
+| Primary Key | Not Allowed | Virtual PK generated automatically |
+| Dynamic Field | Not Allowed | Schema must be fixed |
+| Partition Key | Not Allowed | External data partitioning not supported |
+| Clustering Key | Not Allowed | No clustering compaction |
+| Auto ID | Not Allowed | IDs come from external source |
+| Text Match | Not Allowed | Requires internal indexing |
+| Struct Array Fields | Not Allowed | Complex types not supported |
+| Namespace Field | Not Allowed | External isolation not supported |
+
+**Implementation**: `pkg/util/typeutil/schema.go`
+
+```go
+// IsExternalCollection returns true when schema describes an external collection.
+func IsExternalCollection(schema *schemapb.CollectionSchema) bool {
+    if schema == nil {
+        return false
+    }
+    return strings.TrimSpace(schema.GetExternalSource()) != ""
+}
+
+// ValidateExternalCollectionSchema ensures unsupported features are disabled for external collections.
+func ValidateExternalCollectionSchema(schema *schemapb.CollectionSchema) error {
+    if !IsExternalCollection(schema) {
+        return nil
+    }
+
+    if schema.GetEnableDynamicField() {
+        return fmt.Errorf("external collection %s does not support dynamic field", schema.GetName())
+    }
+
+    if len(schema.GetStructArrayFields()) > 0 {
+        return fmt.Errorf("external collection %s does not support struct fields", schema.GetName())
+    }
+
+    for _, field := range schema.GetFields() {
+        // Skip system fields (RowID and Timestamp)
+        if field.GetName() == common.RowIDFieldName || field.GetName() == common.TimeStampFieldName {
+            continue
+        }
+
+        if field.GetIsPrimaryKey() {
+            return fmt.Errorf("external collection %s does not support primary key field %s", schema.GetName(), field.GetName())
+        }
+        if field.GetIsPartitionKey() {
+            return fmt.Errorf("external collection %s does not support partition key field %s", schema.GetName(), field.GetName())
+        }
+        if field.GetIsClusteringKey() {
+            return fmt.Errorf("external collection %s does not support clustering key field %s", schema.GetName(), field.GetName())
+        }
+        if field.GetAutoID() {
+            return fmt.Errorf("external collection %s does not support auto id on field %s", schema.GetName(), field.GetName())
+        }
+
+        helper := CreateFieldSchemaHelper(field)
+        if helper.EnableMatch() {
+            return fmt.Errorf("external collection %s does not support text match on field %s", schema.GetName(), field.GetName())
+        }
+
+        // Validate external_field mapping is set for all user fields
+        if field.GetExternalField() == "" {
+            return fmt.Errorf("field '%s' in external collection %s must have external_field mapping", field.GetName(), schema.GetName())
+        }
+    }
+
+    return nil
+}
+```
+
+### 3.4 No Primary Key
+**Primary Key Validation**: `internal/proxy/task.go`
+
+For external collections, primary key validation is skipped during `CreateCollection`:
+
+```go
+func (t *createCollectionTask) PreExecute(ctx context.Context) error {
+    // ...
+    isExternalCollection := typeutil.IsExternalCollection(t.schema)
+    if err := typeutil.ValidateExternalCollectionSchema(t.schema); err != nil {
+        return err
+    }
+
+    // validate primary key definition when needed
+    if !isExternalCollection {
+        if err := validatePrimaryKey(t.schema); err != nil {
+            return err
+        }
+    }
+    // ...
+}
+```
+
+### 3.5 External Field Mapping
+
+Each field in the schema must specify `external_field` to map to the external data source column. This field is defined in `milvus-proto` schema definition:
+
+**Proto Definition** (`schema.proto`):
+```protobuf
+message FieldSchema {
+    // ... other fields ...
+    string external_field = 17;  // external field name - maps to column name in external source
+}
+```
+
+**Validation Rules** (`internal/proxy/util.go`):
+- All fields in external collections (except system fields like RowID and Timestamp) must have `external_field` set
+- If `external_field` is empty, validation will fail with error: `field 'xxx' in external collection must have external_field mapping`
+
+**Example Usage**:
+```go
+field := &schemapb.FieldSchema{
+    Name:          "vector",           // Milvus field name
+    DataType:      schemapb.DataType_FloatVector,
+    ExternalField: "embedding_col",    // Column name in external Parquet file
+}
+```
+
+---
+
+## 4. Data Structures
+
+### 4.1 CollectionSchema Extension
+
+**File**: Proto definition
+
+```protobuf
+message CollectionSchema {
+    string name = 1;
+    // ... other fields ...
+    string external_source = 11;  // External data source (e.g., "s3://bucket/path")
+    string external_spec = 12;    // External source config (JSON)
+}
+```
+
+### 4.2 Collection Model Extension
+
+**File**: `internal/metastore/model/collection.go`
+
+```go
+type Collection struct {
+    // ... existing fields ...
+    ExternalSource string
+    ExternalSpec   string
+}
+```
+
+### 4.3 External Spec Format
+
+```json
+{
+    "format": "parquet"
+}
+```
+
+Supported formats:
+- `parquet` - Apache Parquet files
+- More formats to be added (e.g., `iceberg`, `delta`)
+
+### 4.4 Fragment Structure
+
+**File**: `internal/storagev2/exttable/manifest_ffi.go`
+
+```go
+type Fragment struct {
+    FragmentID int64   // Unique fragment identifier
+    FilePath   string  // File path in external storage
+    StartRow   int64   // Start row index within the file (inclusive)
+    EndRow     int64   // End row index within the file (exclusive)
+    RowCount   int64   // Number of rows (EndRow - StartRow)
+}
+```
+
+### 4.5 Segment Row Mapping
+
+**File**: `internal/datanode/external/task_update.go`
+
+```go
+type SegmentRowMapping struct {
+    SegmentID int64
+    TotalRows int64
+    Ranges    []FragmentRowRange
+    Fragments []exttable.Fragment
+}
+
+type FragmentRowRange struct {
+    FragmentID int64
+    StartRow   int64  // inclusive
+    EndRow     int64  // exclusive
+}
+```
+
+---
+
+## 5. Disabled Features for External Collections
+
+### 5.1 Compaction Disabled
+
+**Files**:
+- `internal/datacoord/compaction_policy_single.go`
+- `internal/datacoord/compaction_policy_l0.go`
+- `internal/datacoord/compaction_policy_clustering.go`
+- `internal/datacoord/compaction_trigger.go`
+- `internal/datacoord/compaction_trigger_v2.go`
+
+All compaction types are skipped for external collections:
+
+```go
+// In each compaction policy/trigger
+if collection.IsExternal() {
+    log.Info("skip compaction for external collection", zap.Int64("collectionID", collection.ID))
+    continue  // or return nil
+}
+```
+
+| Compaction Type | Status |
+|-----------------|--------|
+| Single Compaction | Disabled |
+| L0 Compaction | Disabled |
+| Clustering Compaction | Disabled |
+| Sort Compaction | Disabled |
+
+### 5.2 Stats Tasks Disabled
+
+**File**: `internal/datacoord/stats_inspector.go`
+
+All stats task types are skipped for external collections:
+
+```go
+func (si *statsInspector) SubmitStatsTask(...) {
+    if si.isExternalCollection(segment.GetCollectionID()) {
+        log.Info("skip submit stats task for external collection")
+        return nil
+    }
+    // ... submit task
+}
+```
+
+| Stats Task Type | Status |
+|-----------------|--------|
+| Text Index Stats | Disabled |
+| JSON Key Index Stats | Disabled |
+| BM25 Stats | Disabled |
+
+### 5.3 Write Operations Blocked
+
+**Files**:
+- `internal/proxy/task_insert.go`
+- `internal/proxy/task_delete.go`
+- `internal/proxy/task_upsert.go`
+- `internal/proxy/task_import.go`
+- `internal/proxy/task_flush.go`
+- `internal/proxy/task.go` (add field, alter field, create/drop partition)
+- `internal/proxy/impl.go` (manual compaction)
+
+| Operation | Status | Error Message |
+|-----------|--------|---------------|
+| Insert | Blocked | "insert operation is not supported for external collection" |
+| Delete | Blocked | "delete operation is not supported for external collection" |
+| Upsert | Blocked | "upsert operation is not supported for external collection" |
+| Import | Blocked | "import operation is not supported for external collection" |
+| Flush | Blocked | "flush operation is not supported for external collection" |
+| Add Field | Blocked | "add field operation is not supported for external collection" |
+| Alter Field | Blocked | "alter field operation is not supported for external collection" |
+| Create Partition | Blocked | "create partition operation is not supported for external collection" |
+| Drop Partition | Blocked | "drop partition operation is not supported for external collection" |
+| Manual Compaction | Blocked | "manual compaction is not supported for external collection" |
+
+---
+
+## 6. QueryNode Loading Support
+
+### 6.1 Virtual Primary Key
+
+External collections don't have a primary key field. Instead, a **virtual PK** is generated:
+
+**Format**: `(segmentID << 32) | offset`
+
+**File**: `internal/core/src/common/VirtualPK.h`
+
+```cpp
+inline int64_t GenerateVirtualPK(int64_t segment_id, int32_t offset) {
+    return (segment_id << 32) | static_cast<int64_t>(offset);
+}
+
+inline std::pair<int64_t, int32_t> ParseVirtualPK(int64_t virtual_pk) {
+    int64_t segment_id = virtual_pk >> 32;
+    int32_t offset = static_cast<int32_t>(virtual_pk & 0xFFFFFFFF);
+    return {segment_id, offset};
+}
+```
+
+This encoding allows:
+- Up to 2^32 segments per collection
+- Up to 2^32 rows per segment
+- Efficient segment identification from PK
+
+### 6.2 VirtualPKChunkedColumn
+
+**File**: `internal/core/src/mmap/VirtualPKChunkedColumn.h`
+
+Generates virtual PKs on-the-fly during loading without storing actual data:
+
+```cpp
+class VirtualPKChunkedColumn : public ChunkedColumnBase {
+public:
+    // Generates PKs based on segment ID and row offset
+    // No actual data storage needed
+    int64_t GetPK(int64_t row_offset) const {
+        return GenerateVirtualPK(segment_id_, row_offset);
+    }
+};
+```
+
+### 6.3 ExternalFieldChunkedColumn
+
+**File**: `internal/core/src/mmap/ExternalFieldChunkedColumn.h`
+
+Lazy-loads field data from external storage via milvus-storage library:
+
+```cpp
+class ExternalFieldChunkedColumn : public ChunkedColumnBase {
+    // Loads data chunks from external source on demand
+    // Uses milvus-storage library for S3/HDFS/etc. access
+};
+```
+
+### 6.4 ExternalSegmentCandidate
+
+**File**: `internal/querynodev2/pkoracle/external_segment_candidate.go`
+
+Replaces bloom filter for PK-based segment matching:
+
+```go
+type ExternalSegmentCandidate struct {
+    segmentID int64
+    partition int64
+    typ       commonpb.SegmentState
+}
+
+func (c *ExternalSegmentCandidate) MayPkExist(pk storage.PrimaryKey) bool {
+    // Parse virtual PK to extract segment ID
+    virtualPK := pk.GetValue().(int64)
+    segmentID := virtualPK >> 32
+    return segmentID == c.segmentID
+}
+```
+
+### 6.5 Loading Flow
+
+**File**: `internal/querynodev2/segments/segment_loader.go`
+
+```go
+func (loader *segmentLoader) Load(...) {
+    if isExternalCollection(collectionSchema) {
+        // 1. Virtual PK field already injected during creation
+
+        // 2. Skip delta logs (no delete support)
+        // 3. Skip bloom filter building
+        // 4. Use ExternalFieldChunkedColumn for field data
+        // 5. Use VirtualPKChunkedColumn for PK field
+        // 6. Use ExternalSegmentCandidate instead of bloom filter
+    }
+}
+```
+
+---
+
+## 7. Update Task System
+
+### 7.1 Task Flow Overview
+
+External table data refresh is **manually triggered** through the `RefreshExternalTable` API. This design provides users with full control over when data synchronization occurs and allows them to track progress.
+
+```
+                            Client
+                              |
+                              | RefreshExternalTable(collection_name)
+                              v
+                            Proxy
+                              |
+                              | Validate & Forward
+                              v
+                          DataCoord
+                              |
+                              | Create RefreshJob
+                              v
+                    ExternalCollectionTaskMeta
+                    (Store job with Pending state)
+                              |
+                              v
+                    ExternalCollectionScheduler
+                              |
+                              | Schedule job execution
+                              v
+                    CreateTaskOnWorker
+                              |
+                              v
+                        DataNode
+                (ExternalCollectionManager)
+                              |
+                              v
+                    UpdateExternalTask
+                              |
+    +-------------------------+-------------------------+
+    |                         |                         |
+    v                         v                         v
+Fetch fragments      Compare with          Organize orphan
+from source         current segments       fragments to new
+                                           segments
+                              |
+                              v
+                    Create manifests
+                              |
+                              | Report progress
+                              v
+                        DataCoord
+                  (UpdateJobProgress callback)
+                              |
+                              | Update job state & progress
+                              v
+                    ExternalCollectionTaskMeta
+                              |
+    +-------------------------+-------------------------+
+    |                         |                         |
+    v                         v                         v
+Keep unchanged       Drop obsolete         Add new
+segments             segments              segments
+                              |
+                              v
+                    Mark job as Completed/Failed
+                              |
+                              v
+                        Client
+                              |
+              GetRefreshExternalTableProgress(job_id)
+                              |
+                    [Poll until completed]
+```
+
+### 7.1.1 Job Lifecycle
+
+```
+     RefreshExternalTable()
+              |
+              v
+       +------+------+
+       |   Pending   |  <-- Job created, queued for execution
+       +------+------+
+              |
+              | (Scheduler picks up job)
+              v
+       +------+------+
+       | InProgress  |  <-- DataNode executing refresh task
+       +------+------+
+              |
+        +-----+-----+
+        |           |
+        v           v
+  +-----+----+  +---+-----+
+  | Completed|  | Failed  |
+  +----------+  +---------+
+```
+
+**State Descriptions**:
+- **Pending**: Job is created and waiting to be scheduled
+- **InProgress**: Job is actively being executed by DataNode
+- **Completed**: Job finished successfully, segments updated
+- **Failed**: Job encountered an error, reason stored in job info
+
+### 7.2 ExternalCollectionScheduler
+
+**File**: `internal/datacoord/external_collection_scheduler.go`
+
+Manages the scheduling and execution of external collection refresh jobs:
+
+```go
+type ExternalCollectionScheduler interface {
+    Start()
+    Stop()
+
+    // SubmitRefreshJob creates a new refresh job for the collection
+    // Returns job_id for tracking
+    SubmitRefreshJob(ctx context.Context, req *RefreshJobRequest) (string, error)
+
+    // GetJobProgress returns the current progress of a job
+    GetJobProgress(ctx context.Context, jobID string) (*RefreshJobProgress, error)
+
+    // ListJobs returns all jobs for a collection (or all if collectionID is 0)
+    ListJobs(ctx context.Context, collectionID int64, limit int) ([]*RefreshJobInfo, error)
+}
+
+type RefreshJobRequest struct {
+    CollectionID   int64
+    CollectionName string
+    ExternalSource string  // Optional: update source before refresh
+    ExternalSpec   string  // Optional: update spec before refresh
+}
+
+func (s *externalCollectionScheduler) SubmitRefreshJob(ctx context.Context, req *RefreshJobRequest) (string, error) {
+    // 1. Generate unique job ID
+    jobID := fmt.Sprintf("refresh_%d_%d", req.CollectionID, time.Now().UnixNano())
+
+    // 2. If external source/spec provided, update collection metadata
+    if req.ExternalSource != "" || req.ExternalSpec != "" {
+        if err := s.updateCollectionExternalConfig(ctx, req); err != nil {
+            return "", err
+        }
+    }
+
+    // 3. Create job record with Pending state
+    job := &ExternalCollectionTask{
+        JobID:          jobID,
+        CollectionID:   req.CollectionID,
+        CollectionName: req.CollectionName,
+        ExternalSource: req.ExternalSource,
+        ExternalSpec:   req.ExternalSpec,
+        State:          RefreshStatePending,
+        StartTime:      time.Now().UnixMilli(),
+    }
+
+    if err := s.taskMeta.AddTask(job); err != nil {
+        return "", err
+    }
+
+    // 4. Enqueue for execution
+    s.jobQueue <- job
+
+    return jobID, nil
+}
+```
+
+### 7.3 ExternalCollectionTaskMeta
+
+**File**: `internal/datacoord/external_collection_task_meta.go`
+
+Manages job records and state persistence:
+
+```go
+type ExternalCollectionTaskMeta interface {
+    // Job management
+    GetJob(jobID string) (*ExternalCollectionTask, error)
+    AddTask(task *ExternalCollectionTask) error
+    UpdateTask(task *ExternalCollectionTask) error
+
+    // Query methods
+    ListJobsByCollection(collectionID int64, limit int) ([]*ExternalCollectionTask, error)
+    ListAllJobs(limit int) ([]*ExternalCollectionTask, error)
+
+    // Cleanup
+    CleanupCompletedJobs(olderThan time.Duration) error
+}
+
+type ExternalCollectionTask struct {
+    JobID          string                     // Unique job identifier
+    CollectionID   int64                      // Collection ID
+    CollectionName string                     // Collection name
+    ExternalSource string                     // External source path used for this job
+    ExternalSpec   string                     // External spec used for this job
+    State          RefreshExternalTableState  // Current job state
+
+    // Progress tracking
+    TotalFragments     int64  // Total fragments to process
+    ProcessedFragments int64  // Fragments processed so far
+    NewSegments        int64  // Number of new segments created
+    DroppedSegments    int64  // Number of segments dropped
+    KeptSegments       int64  // Number of segments kept unchanged
+
+    // Timestamps
+    StartTime int64  // Job start time (Unix epoch ms)
+    EndTime   int64  // Job end time (0 if not completed)
+
+    // Error info
+    Reason string  // Error message if failed
+}
+```
+
+**Job Retention Policy**:
+- Completed/Failed jobs are retained for `external.collection.job.retention.duration` (default: 24 hours)
+- A background goroutine periodically cleans up old jobs
+
+### 7.4 UpdateExternalCollectionTask (DataCoord side)
+
+**File**: `internal/datacoord/task_update_external_collection.go`
+
+Manages the lifecycle of external collection updates on coordinator:
+
+```go
+type UpdateExternalCollectionTask struct {
+    taskID         int64
+    collectionID   int64
+    externalSource string
+    externalSpec   string
+    // ...
+}
+
+// Task lifecycle methods
+func (t *UpdateExternalCollectionTask) CreateTaskOnWorker() error
+func (t *UpdateExternalCollectionTask) QueryTaskOnWorker() error
+func (t *UpdateExternalCollectionTask) SetJobInfo() error      // Process results
+func (t *UpdateExternalCollectionTask) DropTaskOnWorker() error
+```
+
+### 7.5 ExternalCollectionManager (DataNode side)
+
+**File**: `internal/datanode/external/manager.go`
+
+Manages task execution on DataNode:
+
+```go
+type ExternalCollectionManager struct {
+    ctx       context.Context
+    mu        sync.RWMutex
+    tasks     map[TaskKey]*TaskInfo
+    pool      *conc.Pool[any]
+}
+
+func (m *ExternalCollectionManager) SubmitTask(
+    clusterID string,
+    req *datapb.UpdateExternalCollectionRequest,
+    taskFunc func(context.Context) (*datapb.UpdateExternalCollectionResponse, error),
+) error
+```
+
+### 7.6 UpdateExternalTask (DataNode side)
+
+**File**: `internal/datanode/external/task_update.go`
+
+Executes the actual update logic:
+
+```go
+type UpdateExternalTask struct {
+    ctx    context.Context
+    req    *datapb.UpdateExternalCollectionRequest
+    // ...
+}
+
+func (t *UpdateExternalTask) Execute(ctx context.Context) error {
+    // 1. Fetch fragments from external source
+    newFragments, err := t.fetchFragmentsFromExternalSource(ctx)
+
+    // 2. Build current segment -> fragments mapping
+    currentSegmentFragments := t.buildCurrentSegmentFragments()
+
+    // 3. Compare and organize segments
+    updatedSegments, err := t.organizeSegments(ctx, currentSegmentFragments, newFragments)
+
+    return nil
+}
+```
+
+### 7.7 Segment Update Strategy
+
+```
+Current Segments in Milvus:  [S1, S2, S3, S4, S5]
+
+Worker Response:
+  - keptSegments: [S1, S3]      (fragments unchanged)
+  - updatedSegments: [S6', S7']  (new segments from orphan fragments)
+
+Processing:
+  1. Keep: S1, S3 (unchanged)
+  2. Drop: S2, S4, S5 (mark as Dropped)
+  3. Add:  S6, S7 (allocate new segment IDs)
+
+Final Segments: [S1, S3, S6, S7]
+```
+
+### 7.8 Fragment to Segment Organization
+
+The `balanceFragmentsToSegments` function organizes orphan fragments into balanced segments:
+
+```go
+func (t *UpdateExternalTask) balanceFragmentsToSegments(
+    ctx context.Context,
+    fragments []exttable.Fragment,
+) ([]*datapb.SegmentInfo, error) {
+    // 1. Calculate total rows
+    // 2. Determine target rows per segment (default: 1M rows)
+    // 3. Sort fragments by row count descending
+    // 4. Greedy bin-packing: assign each fragment to bin with lowest row count
+    // 5. Create manifest for each segment
+    // 6. Return SegmentInfo list
+}
+```
+
+---
+
+## 8. Manifest System
+
+### 8.1 Manifest Creation
+
+**File**: `internal/storagev2/exttable/manifest_ffi.go`
+
+Manifests are created to describe segment contents:
+
+```go
+func CreateManifestForSegment(
+    basePath string,
+    columns []string,
+    format string,
+    fragments []Fragment,
+    storageConfig *indexpb.StorageConfig,
+) (string, error) {
+    // 1. Create column groups from fragments
+    // 2. Begin transaction
+    // 3. Commit transaction with column groups
+    // 4. Return manifest path
+}
+```
+
+### 8.2 Manifest Reading
+
+```go
+func ReadFragmentsFromManifest(
+    manifestPath string,
+    storageConfig *indexpb.StorageConfig,
+) ([]Fragment, error) {
+    // 1. Parse manifest path to get base path
+    // 2. Create properties from storage config
+    // 3. Call exttable_read_column_groups FFI
+    // 4. Extract fragments from column groups
+    // 5. Return fragment list
+}
+```
+
+---
+
+## 9. Configuration Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `external.collection.target.rows.per.segment` | Target rows per segment | 1,000,000 |
+| `external.collection.worker.pool.size` | DataNode worker pool size | 4 |
+| `external.collection.job.retention.duration` | How long to keep completed/failed jobs | 24h |
+| `external.collection.job.max.concurrent` | Max concurrent refresh jobs | 2 |
+| `external.collection.job.timeout` | Timeout for a single refresh job | 1h |
+
+---
+
+## 10. Future Enhancements
+
+1. **Index Building**: Support index creation on external collections
+2. **AlterCollection Support**: Add API to modify `external_source`/`external_spec`
+3. **More Data Formats**: Support Iceberg, Delta Lake, ORC, etc.
+4. **Partition Mapping**: Map external data partitions to Milvus partitions
+5. **Change Data Capture**: Support CDC-based incremental updates
+6. **Cross-source Query**: Query across multiple external sources
+
+---
+
+## 11. References
+
+- [Milvus Storage Library](https://github.com/milvus-io/milvus-storage)
+- [Apache Parquet Format](https://parquet.apache.org/)
+- [Data Lakehouse Architecture](https://www.databricks.com/glossary/data-lakehouse)

--- a/docs/design_docs/20260105-external_table.md
+++ b/docs/design_docs/20260105-external_table.md
@@ -352,11 +352,18 @@ External collections have the following restrictions enforced by `ValidateExtern
 
 ```go
 // IsExternalCollection returns true when schema describes an external collection.
+// External collections are identified by having fields with ExternalField set,
+// since ExternalSource can be null for empty external collections.
 func IsExternalCollection(schema *schemapb.CollectionSchema) bool {
     if schema == nil {
         return false
     }
-    return strings.TrimSpace(schema.GetExternalSource()) != ""
+    for _, field := range schema.GetFields() {
+        if field.GetExternalField() != "" {
+            return true
+        }
+    }
+    return false
 }
 
 // ValidateExternalCollectionSchema ensures unsupported features are disabled for external collections.

--- a/docs/user_guides/external_table.md
+++ b/docs/user_guides/external_table.md
@@ -1,0 +1,691 @@
+# Milvus External Table User Guide
+
+## 1. Overview
+
+### 1.1 What is External Table
+
+External Table (External Collection) is a special type of data collection in Milvus that allows users to directly access data stored in external storage systems (such as S3, HDFS, etc.) without copying the data into Milvus local storage.
+
+This enables Milvus to serve as a query layer over existing data lakes while maintaining compatibility with standard Milvus query interfaces.
+
+### 1.2 Core Benefits
+
+- **Zero Data Copy**: Query data directly from external storage without ETL process
+- **Unified Query Interface**: Use standard Search/Query APIs to query external data
+- **Vector Index Support**: Build vector indexes on external data for efficient similarity search
+- **Data Lake Integration**: Seamlessly integrate with existing data lake infrastructure
+
+### 1.3 Use Cases
+
+- Large amounts of vector data already stored in S3 or other object storage
+- Need to perform vector search on data lake data
+- Want to maintain separation between data storage and query engine
+- Need to query periodically updated external data
+
+---
+
+## 2. Quick Start
+
+### 2.1 Create External Collection
+
+External Collection is created through the standard `CreateCollection` API by setting `external_source` in the schema.
+
+#### Python SDK Example
+
+```python
+from pymilvus import MilvusClient, DataType
+
+client = MilvusClient("http://localhost:19530")
+
+# Define Schema
+schema = client.create_schema()
+
+# Add fields - must specify external_field to map to column names in external data source
+schema.add_field(
+    field_name="text",
+    datatype=DataType.VARCHAR,
+    max_length=256,
+    external_field="source_text_column"  # Maps to column name in external Parquet file
+)
+
+schema.add_field(
+    field_name="vector",
+    datatype=DataType.FLOAT_VECTOR,
+    dim=128,
+    external_field="embedding_column"    # Maps to column name in external Parquet file
+)
+
+# Set external data source
+schema.external_source = "s3://my-bucket/path/to/data"
+schema.external_spec = '{"format": "parquet"}'
+
+# Create Collection
+client.create_collection(
+    collection_name="my_external_collection",
+    schema=schema
+)
+```
+
+#### Go SDK Example
+
+```go
+package main
+
+import (
+    "context"
+    "log"
+
+    "github.com/milvus-io/milvus/client/v2"
+    "github.com/milvus-io/milvus/client/v2/entity"
+)
+
+func main() {
+    ctx := context.Background()
+
+    // Connect to Milvus
+    cli, err := client.New(ctx, &client.ClientConfig{
+        Address: "localhost:19530",
+    })
+    if err != nil {
+        log.Fatal(err)
+    }
+    defer cli.Close(ctx)
+
+    // Define Schema with external source
+    schema := entity.NewSchema().
+        WithName("my_external_collection").
+        WithExternalSource("s3://my-bucket/path/to/data").
+        WithExternalSpec(`{"format": "parquet"}`).
+        WithField(entity.NewField().
+            WithName("text").
+            WithDataType(entity.FieldTypeVarChar).
+            WithMaxLength(256).
+            WithExternalField("source_text_column")).  // Maps to external column
+        WithField(entity.NewField().
+            WithName("vector").
+            WithDataType(entity.FieldTypeFloatVector).
+            WithDim(128).
+            WithExternalField("embedding_column"))     // Maps to external column
+
+    // Create Collection
+    err = cli.CreateCollection(ctx, client.NewCreateCollectionOption(
+        "my_external_collection",
+        schema,
+    ))
+    if err != nil {
+        log.Fatal(err)
+    }
+}
+```
+
+### 2.2 Field Mapping Rules
+
+| Schema Parameter | Description | Example |
+|-----------------|-------------|---------|
+| `external_source` | External data source path | `s3://bucket/path` |
+| `external_spec` | Data source configuration (JSON format) | `{"format": "parquet"}` |
+| `external_field` | Maps field to external column name | Must be specified for each field |
+
+**Note**: All user-defined fields must set `external_field` to map to column names in the external data source.
+
+
+---
+
+## 3. Supported Operations
+
+### 3.1 Load Collection
+
+```python
+# Load External Collection into memory
+client.load_collection("my_external_collection")
+```
+
+### 3.2 Vector Search
+
+```python
+# Execute vector search
+results = client.search(
+    collection_name="my_external_collection",
+    data=[[0.1, 0.2, ...]],  # Query vector
+    anns_field="vector",
+    limit=10,
+    output_fields=["text"]
+)
+```
+
+### 3.3 Scalar Query
+
+```python
+# Execute scalar query
+results = client.query(
+    collection_name="my_external_collection",
+    filter="text like 'hello%'",
+    output_fields=["text", "vector"],
+    limit=10
+)
+```
+
+### 3.4 Create Index
+
+```python
+# Create index on vector field
+index_params = client.prepare_index_params()
+index_params.add_index(
+    field_name="vector",
+    index_type="HNSW",
+    metric_type="L2",
+    params={"M": 16, "efConstruction": 200}
+)
+
+client.create_index(
+    collection_name="my_external_collection",
+    index_params=index_params
+)
+```
+
+### 3.5 Drop Collection
+
+```python
+# Drop External Collection
+client.drop_collection("my_external_collection")
+```
+
+---
+
+## 4. Unsupported Operations
+
+External Collection is **read-only**. The following operations are not supported:
+
+| Operation | Status | Description |
+|-----------|--------|-------------|
+| Insert | Not Supported | Data must be modified at external source |
+| Delete | Not Supported | Data must be modified at external source |
+| Upsert | Not Supported | Data must be modified at external source |
+| Import | Not Supported | Data comes directly from external source |
+| Flush | Not Supported | No local data cache |
+| Add Field | Not Supported | Schema is fixed after creation |
+| Alter Field | Not Supported | Schema is fixed after creation |
+| Create/Drop Partition | Not Supported | Partitions not supported |
+| Manual Compaction | Not Supported | Not needed |
+
+### 4.1 Schema Restrictions
+
+When creating an External Collection, the following features cannot be used:
+
+| Feature | Status | Reason |
+|---------|--------|--------|
+| Primary Key Field | Not Allowed | System auto-generates virtual PK |
+| Dynamic Field | Not Allowed | Schema must be fixed |
+| Partition Key | Not Allowed | External data partitioning not supported |
+| Clustering Key | Not Allowed | No clustering compaction |
+| Auto ID | Not Allowed | Uses virtual PK |
+| Text Match | Not Allowed | Requires internal indexing |
+| Namespace Field | Not Allowed | External isolation not supported |
+
+---
+
+## 5. Data Updates
+
+External table data refresh is **manually triggered** using the `RefreshExternalTable` API. This design gives you full control over when data synchronization occurs and allows you to track progress.
+
+### 5.1 Refresh APIs
+
+#### 5.1.1 RefreshExternalTable
+
+Triggers a data refresh job for an external collection.
+
+```python
+# Basic refresh - re-scan current data source
+response = client.refresh_external_table(
+    collection_name="my_external_collection"
+)
+job_id = response.job_id
+print(f"Refresh job started: {job_id}")
+
+# Refresh with updated data source path
+response = client.refresh_external_table(
+    collection_name="my_external_collection",
+    external_source="s3://my-bucket/path/to/new_data",
+    external_spec='{"format": "parquet"}'
+)
+```
+
+**Parameters:**
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `collection_name` | str | Yes | Name of the external collection |
+| `external_source` | str | No | New external source path (optional) |
+| `external_spec` | str | No | New external spec configuration (optional) |
+
+**Returns:** `job_id` for tracking progress
+
+#### 5.1.2 GetRefreshExternalTableProgress
+
+Gets the current progress and status of a refresh job.
+
+```python
+# Get progress of a specific job
+progress = client.get_refresh_external_table_progress(job_id="job_123456")
+
+print(f"State: {progress.state}")           # Pending/InProgress/Completed/Failed
+print(f"Progress: {progress.progress}%")
+print(f"New segments: {progress.new_segments}")
+print(f"Dropped segments: {progress.dropped_segments}")
+print(f"Kept segments: {progress.kept_segments}")
+
+if progress.state == "Failed":
+    print(f"Error: {progress.reason}")
+```
+
+**Progress States:**
+| State | Description |
+|-------|-------------|
+| `Pending` | Job is queued, waiting to execute |
+| `InProgress` | Job is currently executing |
+| `Completed` | Job completed successfully |
+| `Failed` | Job failed with error |
+
+#### 5.1.3 ListRefreshExternalTableJobs
+
+Lists all refresh jobs for a collection.
+
+```python
+# List all jobs for a specific collection
+jobs = client.list_refresh_external_table_jobs(
+    collection_name="my_external_collection",
+    limit=10
+)
+
+for job in jobs:
+    print(f"Job: {job.job_id}")
+    print(f"  State: {job.state}")
+    print(f"  Progress: {job.progress}%")
+    print(f"  Started: {job.start_time}")
+    print(f"  Source: {job.external_source}")
+
+# List all external table refresh jobs across all collections
+all_jobs = client.list_refresh_external_table_jobs()
+```
+
+### 5.2 Complete Refresh Workflow
+
+```python
+from pymilvus import MilvusClient
+import time
+
+client = MilvusClient("http://localhost:19530")
+
+# Step 1: Trigger refresh
+response = client.refresh_external_table(
+    collection_name="my_external_collection"
+)
+job_id = response.job_id
+print(f"Refresh job started: {job_id}")
+
+# Step 2: Poll for completion
+while True:
+    progress = client.get_refresh_external_table_progress(job_id=job_id)
+
+    print(f"Progress: {progress.progress}% ({progress.state})")
+
+    if progress.state == "Completed":
+        print("Refresh completed successfully!")
+        print(f"  New segments: {progress.new_segments}")
+        print(f"  Dropped segments: {progress.dropped_segments}")
+        print(f"  Kept segments: {progress.kept_segments}")
+        break
+    elif progress.state == "Failed":
+        print(f"Refresh failed: {progress.reason}")
+        break
+
+    time.sleep(5)  # Poll every 5 seconds
+
+# Step 3: Re-load collection to query refreshed data
+client.load_collection("my_external_collection")
+```
+
+### 5.3 Incremental Update Strategy
+
+The system uses segment-level incremental update strategy:
+
+1. **Keep**: Segments whose external fragments are unchanged remain intact
+2. **Drop**: Segments whose corresponding external fragments are deleted/modified are removed
+3. **Add**: New external fragments are organized into new segments
+
+This strategy minimizes data reloading during updates.
+
+**Note**: Current version does not support automatic detection of external data source changes. Users must manually trigger refresh using `refresh_external_table`.
+
+---
+
+## 6. Supported Data Formats
+
+| Format | Status | Description |
+|--------|--------|-------------|
+| Parquet | Supported | Apache Parquet format |
+
+---
+
+## 7. Storage Configuration
+
+### 7.1 S3 Configuration Example
+
+```python
+schema.external_source = "s3://my-bucket/vector-data/"
+schema.external_spec = '''
+{
+    "format": "parquet"
+}
+'''
+```
+
+External Collection reuses storage configuration from Milvus configuration file (`minio.*` or `s3.*` configuration items).
+
+---
+
+## 8. Important Notes
+
+1. **Immutable Schema**: Schema cannot be modified after creation. Plan carefully before creation.
+2. **Read-Only Mode**: All data modifications must be done at the external data source.
+3. **Manual Refresh**: External data changes require manual trigger using `refresh_external_table` API. Use `get_refresh_external_table_progress` to track progress.
+4. **Field Mapping**: Each field must correctly map to column names in the external data source.
+5. **Data Type Matching**: Ensure Milvus field types are compatible with external data column types.
+6. **Re-load After Refresh**: After refresh job completes, call `load_collection` to make the updated data available for queries.
+
+---
+
+## 9. Complete Example
+
+### 9.1 Python SDK Complete Example
+
+```python
+from pymilvus import MilvusClient, DataType
+
+# Connect to Milvus
+client = MilvusClient("http://localhost:19530")
+
+# Create Schema
+schema = client.create_schema()
+
+# Add text field
+schema.add_field(
+    field_name="title",
+    datatype=DataType.VARCHAR,
+    max_length=512,
+    external_field="doc_title"
+)
+
+# Add vector field
+schema.add_field(
+    field_name="embedding",
+    datatype=DataType.FLOAT_VECTOR,
+    dim=768,
+    external_field="text_embedding"
+)
+
+# Configure external data source
+schema.external_source = "s3://my-data-lake/documents/"
+schema.external_spec = '{"format": "parquet"}'
+
+# Create External Collection
+client.create_collection(
+    collection_name="document_search",
+    schema=schema
+)
+
+# Create vector index
+index_params = client.prepare_index_params()
+index_params.add_index(
+    field_name="embedding",
+    index_type="HNSW",
+    metric_type="COSINE",
+    params={"M": 32, "efConstruction": 256}
+)
+client.create_index("document_search", index_params)
+
+# ============================================
+# Refresh data when external source changes
+# ============================================
+import time
+
+# Step 1: Trigger refresh job
+response = client.refresh_external_table(
+    collection_name="document_search",
+    external_source="s3://my-data-lake/documents/v1",
+    external_spec='{"format": "parquet"}',
+)
+job_id = response.job_id
+print(f"Refresh job started: {job_id}")
+
+# Step 2: Poll for completion
+while True:
+    progress = client.get_refresh_external_table_progress(job_id=job_id)
+    print(f"Progress: {progress.progress}% ({progress.state})")
+
+    if progress.state == "Completed":
+        print("Refresh completed!")
+        break
+    elif progress.state == "Failed":
+        print(f"Refresh failed: {progress.reason}")
+        break
+
+    time.sleep(5)
+
+# Step 3: Re-load collection to query refreshed data
+client.load_collection("document_search")
+
+# Now search will use the refreshed data
+results = client.search(
+    collection_name="document_search",
+    data=[query_embedding],
+    anns_field="embedding",
+    limit=10,
+    output_fields=["title"]
+)
+
+# ============================================
+# List all refresh jobs for this collection
+# ============================================
+jobs = client.list_refresh_external_table_jobs(
+    collection_name="document_search"
+)
+for job in jobs:
+    print(f"Job {job.job_id}: {job.state} ({job.progress}%)")
+```
+
+### 9.2 Go SDK Complete Example
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+
+    "github.com/milvus-io/milvus/client/v2"
+    "github.com/milvus-io/milvus/client/v2/entity"
+    "github.com/milvus-io/milvus/client/v2/index"
+)
+
+func main() {
+    ctx := context.Background()
+
+    // Connect to Milvus
+    cli, err := client.New(ctx, &client.ClientConfig{
+        Address: "localhost:19530",
+    })
+    if err != nil {
+        log.Fatal(err)
+    }
+    defer cli.Close(ctx)
+
+    collectionName := "document_search"
+
+    // ============================================
+    // Create External Collection
+    // ============================================
+
+    // Define Schema with external source
+    schema := entity.NewSchema().
+        WithName(collectionName).
+        WithExternalSource("s3://my-data-lake/documents/").
+        WithExternalSpec(`{"format": "parquet"}`).
+        WithField(entity.NewField().
+            WithName("title").
+            WithDataType(entity.FieldTypeVarChar).
+            WithMaxLength(512).
+            WithExternalField("doc_title")).
+        WithField(entity.NewField().
+            WithName("embedding").
+            WithDataType(entity.FieldTypeFloatVector).
+            WithDim(768).
+            WithExternalField("text_embedding"))
+
+    // Create Collection
+    err = cli.CreateCollection(ctx, client.NewCreateCollectionOption(collectionName, schema))
+    if err != nil {
+        log.Fatal(err)
+    }
+    fmt.Println("External collection created successfully")
+
+    // ============================================
+    // Create Vector Index
+    // ============================================
+
+    indexTask, err := cli.CreateIndex(ctx, client.NewCreateIndexOption(
+        collectionName,
+        "embedding",
+        index.NewHNSWIndex(entity.COSINE, 32, 256),
+    ))
+    if err != nil {
+        log.Fatal(err)
+    }
+    err = indexTask.Await(ctx)
+    if err != nil {
+        log.Fatal(err)
+    }
+    fmt.Println("Index created successfully")
+
+    // ============================================
+    // Load Collection
+    // ============================================
+
+    loadTask, err := cli.LoadCollection(ctx, client.NewLoadCollectionOption(collectionName))
+    if err != nil {
+        log.Fatal(err)
+    }
+    err = loadTask.Await(ctx)
+    if err != nil {
+        log.Fatal(err)
+    }
+    fmt.Println("Collection loaded successfully")
+
+    // ============================================
+    // Search
+    // ============================================
+
+    // Query embedding (replace with actual query vector)
+    queryEmbedding := make([]float32, 768)
+    for i := range queryEmbedding {
+        queryEmbedding[i] = 0.1
+    }
+
+    results, err := cli.Search(ctx, client.NewSearchOption(
+        collectionName,
+        10, // limit
+        []entity.Vector{entity.FloatVector(queryEmbedding)},
+    ).WithANNSField("embedding").WithOutputFields("title"))
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    for _, result := range results {
+        for i := 0; i < result.ResultCount; i++ {
+            title, _ := result.Fields.GetColumn("title").Get(i)
+            fmt.Printf("Result %d: title=%v, score=%f\n", i, title, result.Scores[i])
+        }
+    }
+
+    // ============================================
+    // Drop Collection (cleanup)
+    // ============================================
+
+    err = cli.DropCollection(ctx, client.NewDropCollectionOption(collectionName))
+    if err != nil {
+        log.Fatal(err)
+    }
+    fmt.Println("Collection dropped successfully")
+}
+```
+
+---
+
+## 10. Future Plans (Roadmap)
+
+The following features are planned for future releases:
+
+### 10.1 Scalar Index Support
+
+Support creating scalar indexes on external collections to accelerate filtering queries:
+
+```python
+# Future: Create scalar index on external collection
+index_params.add_index(
+    field_name="category",
+    index_type="INVERTED"
+)
+```
+
+### 10.2 Function Support
+
+Support embedding functions and other built-in transformation functions for external collections:
+
+```python
+# Future: Use embedding function with external collection
+schema.add_function(
+    name="text_to_vector",
+    function_type=FunctionType.EMBEDDING,
+    input_field="text",
+    output_field="vector",
+    params={"model": "text-embedding-3-small"}
+)
+```
+
+### 10.3 Schema Evolution (Add/Drop Fields)
+
+Support adding or removing fields from external collections after creation:
+
+```python
+# Future: Add new field to external collection
+client.add_field(
+    collection_name="my_external_collection",
+    field_name="new_column",
+    datatype=DataType.VARCHAR,
+    max_length=128,
+    external_field="source_new_column"
+)
+
+# Future: Drop field from external collection
+client.drop_field(
+    collection_name="my_external_collection",
+    field_name="old_column"
+)
+```
+
+### 10.4 Additional Planned Features
+
+| Feature | Description | Priority |
+|---------|-------------|----------|
+| **More Data Formats** | Support Apache Iceberg, Delta Lake, ORC formats | High |
+| **Auto Data Sync** | Automatic detection of external data source changes with scheduled refresh | Low |
+| **Partition Mapping** | Map external data partitions to Milvus partitions | Medium |
+| **Text Match** | Support full-text search on external collections | Medium |
+| **Cross-source Query** | Query across multiple external data sources | Low |
+| **Change Data Capture** | Support CDC-based incremental updates | Low |
+
+---
+
+## 11. Related Documentation
+
+- [Design Document: External Table](../design_docs/20260105-external_table.md)

--- a/internal/flushcommon/pipeline/flow_graph_write_node.go
+++ b/internal/flushcommon/pipeline/flow_graph_write_node.go
@@ -149,7 +149,7 @@ func newWriteNode(
 	// pkfield is a immutable property of the collection, so we can get it from any schema
 	collSchema := config.metacache.GetSchema(0)
 	pkField, err := typeutil.GetPrimaryFieldSchema(collSchema)
-	if err != nil {
+	if err != nil && !typeutil.IsExternalCollection(collSchema) {
 		return nil, err
 	}
 

--- a/internal/metastore/model/collection.go
+++ b/internal/metastore/model/collection.go
@@ -55,6 +55,8 @@ type Collection struct {
 	SchemaVersion        int32
 	ShardInfos           map[string]*ShardInfo
 	FileResourceIds      []int64
+	ExternalSource       string
+	ExternalSpec         string
 }
 
 type ShardInfo struct {
@@ -94,6 +96,8 @@ func (c *Collection) ShallowClone() *Collection {
 		SchemaVersion:        c.SchemaVersion,
 		ShardInfos:           c.ShardInfos,
 		FileResourceIds:      c.FileResourceIds,
+		ExternalSource:       c.ExternalSource,
+		ExternalSpec:         c.ExternalSpec,
 	}
 }
 
@@ -132,6 +136,8 @@ func (c *Collection) Clone() *Collection {
 		SchemaVersion:        c.SchemaVersion,
 		ShardInfos:           shardInfos,
 		FileResourceIds:      slices.Clone(c.FileResourceIds),
+		ExternalSource:       c.ExternalSource,
+		ExternalSpec:         c.ExternalSpec,
 	}
 }
 
@@ -180,6 +186,8 @@ func (c *Collection) ApplyUpdates(header *message.AlterCollectionMessageHeader, 
 			c.Functions = UnmarshalFunctionModels(updates.Schema.Functions)
 			c.StructArrayFields = UnmarshalStructArrayFieldModels(updates.Schema.StructArrayFields)
 			c.SchemaVersion = updates.Schema.Version
+			c.ExternalSource = updates.Schema.ExternalSource
+			c.ExternalSpec = updates.Schema.ExternalSpec
 		}
 	}
 }
@@ -238,6 +246,8 @@ func UnmarshalCollectionModel(coll *pb.CollectionInfo) *Collection {
 		SchemaVersion:        coll.Schema.Version,
 		ShardInfos:           shardInfos,
 		FileResourceIds:      coll.Schema.GetFileResourceIds(),
+		ExternalSource:       coll.Schema.ExternalSource,
+		ExternalSpec:         coll.Schema.ExternalSpec,
 	}
 }
 
@@ -290,6 +300,8 @@ func marshalCollectionModelWithConfig(coll *Collection, c *config) *pb.Collectio
 		DbName:             coll.DBName,
 		Version:            coll.SchemaVersion,
 		FileResourceIds:    coll.FileResourceIds,
+		ExternalSource:     coll.ExternalSource,
+		ExternalSpec:       coll.ExternalSpec,
 	}
 
 	if c.withFields {

--- a/internal/metastore/model/field.go
+++ b/internal/metastore/model/field.go
@@ -25,6 +25,7 @@ type Field struct {
 	DefaultValue     *schemapb.ValueField
 	ElementType      schemapb.DataType
 	Nullable         bool
+	ExternalField    string
 }
 
 func (f *Field) Available() bool {
@@ -49,6 +50,7 @@ func (f *Field) Clone() *Field {
 		DefaultValue:     f.DefaultValue,
 		ElementType:      f.ElementType,
 		Nullable:         f.Nullable,
+		ExternalField:    f.ExternalField,
 	}
 }
 
@@ -80,7 +82,8 @@ func (f *Field) Equal(other Field) bool {
 		proto.Equal(f.DefaultValue, other.DefaultValue) &&
 		f.ElementType == other.ElementType &&
 		f.IsFunctionOutput == other.IsFunctionOutput &&
-		f.Nullable == other.Nullable
+		f.Nullable == other.Nullable &&
+		f.ExternalField == other.ExternalField
 }
 
 func CheckFieldsEqual(fieldsA, fieldsB []*Field) bool {
@@ -121,6 +124,7 @@ func MarshalFieldModel(field *Field) *schemapb.FieldSchema {
 		DefaultValue:     proto.Clone(field.DefaultValue).(*schemapb.ValueField),
 		ElementType:      field.ElementType,
 		Nullable:         field.Nullable,
+		ExternalField:    field.ExternalField,
 	}
 }
 
@@ -157,6 +161,7 @@ func UnmarshalFieldModel(fieldSchema *schemapb.FieldSchema) *Field {
 		DefaultValue:     fieldSchema.DefaultValue,
 		ElementType:      fieldSchema.ElementType,
 		Nullable:         fieldSchema.Nullable,
+		ExternalField:    fieldSchema.ExternalField,
 	}
 }
 

--- a/internal/proxy/service_provider.go
+++ b/internal/proxy/service_provider.go
@@ -210,6 +210,8 @@ func (node *CachedProxyServiceProvider) DescribeCollection(ctx context.Context,
 		Properties:         c.schema.CollectionSchema.Properties,
 		Functions:          c.schema.CollectionSchema.Functions,
 		DbName:             c.schema.CollectionSchema.DbName,
+		ExternalSource:     c.schema.CollectionSchema.ExternalSource,
+		ExternalSpec:       c.schema.CollectionSchema.ExternalSpec,
 	}
 
 	// Restore struct field names from internal format (structName[fieldName]) to original format

--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -415,6 +415,11 @@ func (t *createCollectionTask) PreExecute(ctx context.Context) error {
 	t.schema.AutoID = false
 	t.schema.DbName = t.GetDbName()
 
+	isExternalCollection := typeutil.IsExternalCollection(t.schema)
+	if err := typeutil.ValidateExternalCollectionSchema(t.schema); err != nil {
+		return err
+	}
+
 	disableCheck, err := common.IsDisableFuncRuntimeCheck(t.GetProperties()...)
 	if err != nil {
 		return err
@@ -446,9 +451,11 @@ func (t *createCollectionTask) PreExecute(ctx context.Context) error {
 		return err
 	}
 
-	// validate primary key definition
-	if err := validatePrimaryKey(t.schema); err != nil {
-		return err
+	// validate primary key definition when needed
+	if !isExternalCollection {
+		if err := validatePrimaryKey(t.schema); err != nil {
+			return err
+		}
 	}
 
 	// validate dynamic field
@@ -1004,6 +1011,8 @@ func (t *describeCollectionTask) Execute(ctx context.Context) error {
 	t.result.Schema.Description = result.Schema.Description
 	t.result.Schema.AutoID = result.Schema.AutoID
 	t.result.Schema.EnableDynamicField = result.Schema.EnableDynamicField
+	t.result.Schema.ExternalSource = result.Schema.ExternalSource
+	t.result.Schema.ExternalSpec = result.Schema.ExternalSpec
 	t.result.CollectionID = result.CollectionID
 	t.result.VirtualChannelNames = result.VirtualChannelNames
 	t.result.PhysicalChannelNames = result.PhysicalChannelNames
@@ -1035,6 +1044,7 @@ func (t *describeCollectionTask) Execute(ctx context.Context) error {
 			ElementType:      field.ElementType,
 			Nullable:         field.Nullable,
 			IsFunctionOutput: field.IsFunctionOutput,
+			ExternalField:    field.GetExternalField(),
 		}
 	}
 

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -722,7 +722,10 @@ func validatePrimaryKey(coll *schemapb.CollectionSchema) error {
 		}
 	}
 	if idx == -1 {
-		return errors.New("primary key is not specified")
+		// External collections may not have a primary key
+		if !typeutil.IsExternalCollection(coll) {
+			return errors.New("primary key is not specified")
+		}
 	}
 
 	for _, structArrayField := range coll.StructArrayFields {

--- a/internal/rootcoord/create_collection_task.go
+++ b/internal/rootcoord/create_collection_task.go
@@ -177,6 +177,10 @@ func (t *createCollectionTask) validateSchema(ctx context.Context, schema *schem
 		return err
 	}
 
+	if err := typeutil.ValidateExternalCollectionSchema(schema); err != nil {
+		return err
+	}
+
 	if hasSystemFields(schema, []string{RowIDFieldName, TimeStampFieldName, MetaFieldName, NamespaceFieldName}) {
 		log.Ctx(ctx).Error("schema contains system field",
 			zap.String("RowIDFieldName", RowIDFieldName),
@@ -315,6 +319,10 @@ func (t *createCollectionTask) handleNamespaceField(ctx context.Context, schema 
 	}
 	if !has || !enabled {
 		return nil
+	}
+
+	if typeutil.IsExternalCollection(schema) {
+		return merr.WrapErrParameterInvalidMsg("external collection does not support namespace field")
 	}
 
 	if hasIsolation {

--- a/internal/rootcoord/create_collection_task_test.go
+++ b/internal/rootcoord/create_collection_task_test.go
@@ -1893,8 +1893,31 @@ func TestNamespaceProperty(t *testing.T) {
 	})
 
 	t.Run("test namespace enabled with external collection", func(t *testing.T) {
-		schema := initSchema()
-		schema.ExternalSource = "s3://bucket/path"
+		// External collection is identified by having ExternalField set on fields
+		schema := &schemapb.CollectionSchema{
+			Name:           collectionName,
+			ExternalSource: "s3://bucket/path",
+			Fields: []*schemapb.FieldSchema{
+				{
+					FieldID:       100,
+					Name:          "text",
+					DataType:      schemapb.DataType_VarChar,
+					ExternalField: "text_col",
+					TypeParams: []*commonpb.KeyValuePair{
+						{Key: common.MaxLengthKey, Value: "256"},
+					},
+				},
+				{
+					FieldID:       101,
+					Name:          "vector",
+					DataType:      schemapb.DataType_FloatVector,
+					ExternalField: "vector_col",
+					TypeParams: []*commonpb.KeyValuePair{
+						{Key: common.DimKey, Value: "1024"},
+					},
+				},
+			},
+		}
 
 		task := &createCollectionTask{
 			Req: &milvuspb.CreateCollectionRequest{

--- a/internal/rootcoord/create_collection_task_test.go
+++ b/internal/rootcoord/create_collection_task_test.go
@@ -901,6 +901,107 @@ func Test_createCollectionTask_validateSchema(t *testing.T) {
 		err := task.validateSchema(context.TODO(), schema)
 		assert.NoError(t, err)
 	})
+
+	t.Run("external schema valid case", func(t *testing.T) {
+		collectionName := funcutil.GenRandomStr()
+		task := createCollectionTask{
+			Req: &milvuspb.CreateCollectionRequest{
+				Base:           &commonpb.MsgBase{MsgType: commonpb.MsgType_CreateCollection},
+				CollectionName: collectionName,
+			},
+		}
+		schema := &schemapb.CollectionSchema{
+			Name:           collectionName,
+			ExternalSource: "s3://bucket/object",
+			Fields: []*schemapb.FieldSchema{
+				{
+					Name:          "text_field",
+					DataType:      schemapb.DataType_VarChar,
+					ExternalField: "text_col",
+					TypeParams: []*commonpb.KeyValuePair{
+						{Key: common.MaxLengthKey, Value: "64"},
+					},
+				},
+				{
+					Name:          "vec_field",
+					DataType:      schemapb.DataType_FloatVector,
+					ExternalField: "vec_col",
+					TypeParams: []*commonpb.KeyValuePair{
+						{Key: common.DimKey, Value: "16"},
+					},
+				},
+			},
+		}
+		err := task.validateSchema(context.TODO(), schema)
+		assert.NoError(t, err)
+	})
+
+	t.Run("external schema reject primary key", func(t *testing.T) {
+		collectionName := funcutil.GenRandomStr()
+		task := createCollectionTask{
+			Req: &milvuspb.CreateCollectionRequest{
+				Base:           &commonpb.MsgBase{MsgType: commonpb.MsgType_CreateCollection},
+				CollectionName: collectionName,
+			},
+		}
+		schema := &schemapb.CollectionSchema{
+			Name:           collectionName,
+			ExternalSource: "s3://bucket/object",
+			Fields: []*schemapb.FieldSchema{
+				{
+					Name:          "pk",
+					DataType:      schemapb.DataType_Int64,
+					IsPrimaryKey:  true,
+					ExternalField: "pk_col",
+				},
+				{
+					Name:          "vec_field",
+					DataType:      schemapb.DataType_FloatVector,
+					ExternalField: "vec_col",
+					TypeParams: []*commonpb.KeyValuePair{
+						{Key: common.DimKey, Value: "16"},
+					},
+				},
+			},
+		}
+		err := task.validateSchema(context.TODO(), schema)
+		assert.Error(t, err)
+	})
+
+	t.Run("external schema reject functions", func(t *testing.T) {
+		collectionName := funcutil.GenRandomStr()
+		task := createCollectionTask{
+			Req: &milvuspb.CreateCollectionRequest{
+				Base:           &commonpb.MsgBase{MsgType: commonpb.MsgType_CreateCollection},
+				CollectionName: collectionName,
+			},
+		}
+		schema := &schemapb.CollectionSchema{
+			Name:           collectionName,
+			ExternalSource: "s3://bucket/object",
+			Fields: []*schemapb.FieldSchema{
+				{
+					Name:          "text_field",
+					DataType:      schemapb.DataType_VarChar,
+					ExternalField: "text_col",
+					TypeParams: []*commonpb.KeyValuePair{
+						{Key: common.MaxLengthKey, Value: "64"},
+					},
+				},
+				{
+					Name:          "vec_field",
+					DataType:      schemapb.DataType_FloatVector,
+					ExternalField: "vec_col",
+					TypeParams: []*commonpb.KeyValuePair{
+						{Key: common.DimKey, Value: "16"},
+					},
+				},
+			},
+			Functions: []*schemapb.FunctionSchema{{Name: "test_func"}},
+		}
+		err := task.validateSchema(context.TODO(), schema)
+		assert.Error(t, err)
+	})
 }
 
 func Test_createCollectionTask_prepareSchema(t *testing.T) {
@@ -1770,6 +1871,30 @@ func TestNamespaceProperty(t *testing.T) {
 			DataType:       schemapb.DataType_Int64,
 			IsPartitionKey: true,
 		})
+
+		task := &createCollectionTask{
+			Req: &milvuspb.CreateCollectionRequest{
+				CollectionName: collectionName,
+				Properties: []*commonpb.KeyValuePair{
+					{
+						Key:   common.NamespaceEnabledKey,
+						Value: "true",
+					},
+				},
+			},
+			header: &message.CreateCollectionMessageHeader{},
+			body: &message.CreateCollectionRequest{
+				CollectionSchema: schema,
+			},
+		}
+
+		err := task.handleNamespaceField(ctx, schema)
+		assert.Error(t, err)
+	})
+
+	t.Run("test namespace enabled with external collection", func(t *testing.T) {
+		schema := initSchema()
+		schema.ExternalSource = "s3://bucket/path"
 
 		task := &createCollectionTask{
 			Req: &milvuspb.CreateCollectionRequest{

--- a/internal/rootcoord/ddl_callbacks_create_collection.go
+++ b/internal/rootcoord/ddl_callbacks_create_collection.go
@@ -212,6 +212,8 @@ func newCollectionModel(header *message.CreateCollectionMessageHeader, body *mes
 		SchemaVersion:        0,
 		ShardInfos:           shardInfos,
 		FileResourceIds:      body.CollectionSchema.GetFileResourceIds(),
+		ExternalSource:       body.CollectionSchema.ExternalSource,
+		ExternalSpec:         body.CollectionSchema.ExternalSpec,
 	}
 }
 

--- a/internal/rootcoord/root_coord.go
+++ b/internal/rootcoord/root_coord.go
@@ -1078,6 +1078,8 @@ func convertModelToDesc(collInfo *model.Collection, aliases []string, dbName str
 		EnableDynamicField: collInfo.EnableDynamicField,
 		Properties:         collInfo.Properties,
 		FileResourceIds:    collInfo.FileResourceIds,
+		ExternalSource:     collInfo.ExternalSource,
+		ExternalSpec:       collInfo.ExternalSpec,
 	}
 	resp.CollectionID = collInfo.CollectionID
 	resp.VirtualChannelNames = collInfo.VirtualChannelNames

--- a/pkg/util/typeutil/schema.go
+++ b/pkg/util/typeutil/schema.go
@@ -1705,6 +1705,14 @@ func GetAllFieldSchemas(schema *schemapb.CollectionSchema) []*schemapb.FieldSche
 	return all
 }
 
+// IsExternalCollection returns true when schema describes an external collection.
+func IsExternalCollection(schema *schemapb.CollectionSchema) bool {
+	if schema == nil {
+		return false
+	}
+	return strings.TrimSpace(schema.GetExternalSource()) != ""
+}
+
 // GetVectorFieldSchemas get vector fields schema from collection schema.
 func GetVectorFieldSchemas(schema *schemapb.CollectionSchema) []*schemapb.FieldSchema {
 	ret := make([]*schemapb.FieldSchema, 0)
@@ -1743,6 +1751,57 @@ func GetPrimaryFieldSchema(schema *schemapb.CollectionSchema) (*schemapb.FieldSc
 	}
 
 	return nil, errors.New("primary field is not found")
+}
+
+// ValidateExternalCollectionSchema ensures unsupported features are disabled for external collections.
+func ValidateExternalCollectionSchema(schema *schemapb.CollectionSchema) error {
+	if !IsExternalCollection(schema) {
+		return nil
+	}
+
+	if len(schema.GetFunctions()) > 0 {
+		return fmt.Errorf("external collection %s does not support functions", schema.GetName())
+	}
+
+	if schema.GetEnableDynamicField() {
+		return fmt.Errorf("external collection %s does not support dynamic field", schema.GetName())
+	}
+
+	if len(schema.GetStructArrayFields()) > 0 {
+		return fmt.Errorf("external collection %s does not support struct fields", schema.GetName())
+	}
+
+	for _, field := range schema.GetFields() {
+		// Skip system fields (RowID and Timestamp)
+		if field.GetName() == common.RowIDFieldName || field.GetName() == common.TimeStampFieldName {
+			continue
+		}
+
+		if field.GetIsPrimaryKey() {
+			return fmt.Errorf("external collection %s does not support primary key field %s", schema.GetName(), field.GetName())
+		}
+		if field.GetIsPartitionKey() {
+			return fmt.Errorf("external collection %s does not support partition key field %s", schema.GetName(), field.GetName())
+		}
+		if field.GetIsClusteringKey() {
+			return fmt.Errorf("external collection %s does not support clustering key field %s", schema.GetName(), field.GetName())
+		}
+		if field.GetAutoID() {
+			return fmt.Errorf("external collection %s does not support auto id on field %s", schema.GetName(), field.GetName())
+		}
+
+		helper := CreateFieldSchemaHelper(field)
+		if helper.EnableMatch() {
+			return fmt.Errorf("external collection %s does not support text match on field %s", schema.GetName(), field.GetName())
+		}
+
+		// Validate external_field mapping is set for all user fields
+		if field.GetExternalField() == "" {
+			return fmt.Errorf("field '%s' in external collection %s must have external_field mapping", field.GetName(), schema.GetName())
+		}
+	}
+
+	return nil
 }
 
 func IsFieldSparseFloatVector(schema *schemapb.CollectionSchema, fieldID int64) bool {

--- a/pkg/util/typeutil/schema.go
+++ b/pkg/util/typeutil/schema.go
@@ -1706,11 +1706,18 @@ func GetAllFieldSchemas(schema *schemapb.CollectionSchema) []*schemapb.FieldSche
 }
 
 // IsExternalCollection returns true when schema describes an external collection.
+// External collections are identified by having fields with ExternalField set,
+// since ExternalSource can be null for empty external collections.
 func IsExternalCollection(schema *schemapb.CollectionSchema) bool {
 	if schema == nil {
 		return false
 	}
-	return strings.TrimSpace(schema.GetExternalSource()) != ""
+	for _, field := range schema.GetFields() {
+		if field.GetExternalField() != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // GetVectorFieldSchemas get vector fields schema from collection schema.

--- a/pkg/util/typeutil/schema_test.go
+++ b/pkg/util/typeutil/schema_test.go
@@ -4976,3 +4976,117 @@ func TestSchemaHelper_CanRetrieveRawFieldData(t *testing.T) {
 	}
 	assert.False(t, helper.CanRetrieveRawFieldData(orphanField))
 }
+
+func TestIsExternalCollection(t *testing.T) {
+	assert.False(t, IsExternalCollection(nil))
+
+	schema := &schemapb.CollectionSchema{}
+	assert.False(t, IsExternalCollection(schema))
+
+	schema.ExternalSource = "   "
+	assert.False(t, IsExternalCollection(schema))
+
+	schema.ExternalSource = "s3://bucket/path"
+	assert.True(t, IsExternalCollection(schema))
+}
+
+func TestValidateExternalCollectionSchema(t *testing.T) {
+	buildSchema := func() *schemapb.CollectionSchema {
+		return &schemapb.CollectionSchema{
+			Name:           "external",
+			ExternalSource: "s3://bucket/path",
+			Fields: []*schemapb.FieldSchema{
+				{
+					Name:          "text",
+					DataType:      schemapb.DataType_VarChar,
+					ExternalField: "text_col",
+					TypeParams: []*commonpb.KeyValuePair{
+						{Key: common.MaxLengthKey, Value: "32"},
+					},
+				},
+				{
+					Name:          "vec",
+					DataType:      schemapb.DataType_FloatVector,
+					ExternalField: "vec_col",
+					TypeParams: []*commonpb.KeyValuePair{
+						{Key: common.DimKey, Value: "16"},
+					},
+				},
+			},
+		}
+	}
+
+	t.Run("non external schema skipped", func(t *testing.T) {
+		schema := buildSchema()
+		schema.ExternalSource = ""
+		assert.NoError(t, ValidateExternalCollectionSchema(schema))
+	})
+
+	t.Run("functions disabled", func(t *testing.T) {
+		schema := buildSchema()
+		schema.Functions = []*schemapb.FunctionSchema{{Name: "test_func"}}
+		err := ValidateExternalCollectionSchema(schema)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "does not support functions")
+	})
+
+	t.Run("dynamic field disabled", func(t *testing.T) {
+		schema := buildSchema()
+		schema.EnableDynamicField = true
+		assert.Error(t, ValidateExternalCollectionSchema(schema))
+	})
+
+	t.Run("struct fields disabled", func(t *testing.T) {
+		schema := buildSchema()
+		schema.StructArrayFields = []*schemapb.StructArrayFieldSchema{
+			{Name: "struct_field", Fields: []*schemapb.FieldSchema{{Name: "nested", DataType: schemapb.DataType_Array}}},
+		}
+		assert.Error(t, ValidateExternalCollectionSchema(schema))
+	})
+
+	t.Run("primary key disabled", func(t *testing.T) {
+		schema := buildSchema()
+		schema.Fields[0].IsPrimaryKey = true
+		assert.Error(t, ValidateExternalCollectionSchema(schema))
+	})
+
+	t.Run("partition key disabled", func(t *testing.T) {
+		schema := buildSchema()
+		schema.Fields[0].IsPartitionKey = true
+		assert.Error(t, ValidateExternalCollectionSchema(schema))
+	})
+
+	t.Run("clustering key disabled", func(t *testing.T) {
+		schema := buildSchema()
+		schema.Fields[0].IsClusteringKey = true
+		assert.Error(t, ValidateExternalCollectionSchema(schema))
+	})
+
+	t.Run("auto id disabled", func(t *testing.T) {
+		schema := buildSchema()
+		schema.Fields[0].AutoID = true
+		assert.Error(t, ValidateExternalCollectionSchema(schema))
+	})
+
+	t.Run("text match disabled", func(t *testing.T) {
+		schema := buildSchema()
+		schema.Fields[0].TypeParams = append(schema.Fields[0].TypeParams, &commonpb.KeyValuePair{
+			Key:   "enable_match",
+			Value: "true",
+		})
+		assert.Error(t, ValidateExternalCollectionSchema(schema))
+	})
+
+	t.Run("external_field mapping required", func(t *testing.T) {
+		schema := buildSchema()
+		schema.Fields[0].ExternalField = ""
+		err := ValidateExternalCollectionSchema(schema)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "must have external_field mapping")
+	})
+
+	t.Run("valid schema passes", func(t *testing.T) {
+		err := ValidateExternalCollectionSchema(buildSchema())
+		assert.NoError(t, err)
+	})
+}

--- a/tests/go_client/testcases/external_table_test.go
+++ b/tests/go_client/testcases/external_table_test.go
@@ -1,0 +1,316 @@
+package testcases
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus/client/v2/entity"
+	client "github.com/milvus-io/milvus/client/v2/milvusclient"
+	"github.com/milvus-io/milvus/tests/go_client/common"
+	hp "github.com/milvus-io/milvus/tests/go_client/testcases/helper"
+)
+
+// TestCreateExternalCollection tests creating an external collection
+func TestCreateExternalCollection(t *testing.T) {
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	collName := common.GenRandomString("external", 6)
+
+	// Create schema with external source
+	schema := entity.NewSchema().
+		WithName(collName).
+		WithExternalSource("s3://test-bucket/data/").
+		WithExternalSpec(`{"format": "parquet"}`).
+		WithField(
+			entity.NewField().
+				WithName("text").
+				WithDataType(entity.FieldTypeVarChar).
+				WithMaxLength(256).
+				WithExternalField("text_column"),
+		).
+		WithField(
+			entity.NewField().
+				WithName("embedding").
+				WithDataType(entity.FieldTypeFloatVector).
+				WithDim(common.DefaultDim).
+				WithExternalField("embedding_column"),
+		)
+
+	// Create collection
+	err := mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema))
+	common.CheckErr(t, err, true)
+
+	// Verify collection exists
+	has, err := mc.HasCollection(ctx, client.NewHasCollectionOption(collName))
+	common.CheckErr(t, err, true)
+	require.True(t, has)
+
+	// Describe collection and verify schema
+	coll, err := mc.DescribeCollection(ctx, client.NewDescribeCollectionOption(collName))
+	common.CheckErr(t, err, true)
+
+	// Verify external source and spec
+	require.Equal(t, "s3://test-bucket/data/", coll.Schema.ExternalSource)
+	require.Equal(t, `{"format": "parquet"}`, coll.Schema.ExternalSpec)
+
+	// Verify fields
+	require.Len(t, coll.Schema.Fields, 2)
+
+	// Verify text field
+	textField := findFieldByName(coll.Schema.Fields, "text")
+	require.NotNil(t, textField)
+	require.Equal(t, entity.FieldTypeVarChar, textField.DataType)
+	require.Equal(t, "text_column", textField.ExternalField)
+
+	// Verify embedding field
+	embeddingField := findFieldByName(coll.Schema.Fields, "embedding")
+	require.NotNil(t, embeddingField)
+	require.Equal(t, entity.FieldTypeFloatVector, embeddingField.DataType)
+	require.Equal(t, "embedding_column", embeddingField.ExternalField)
+
+	// List collections and verify
+	collections, err := mc.ListCollections(ctx, client.NewListCollectionOption())
+	common.CheckErr(t, err, true)
+	require.Contains(t, collections, collName)
+}
+
+// TestCreateExternalCollectionMissingExternalField tests that creating external collection
+// without external_field mapping fails
+func TestCreateExternalCollectionMissingExternalField(t *testing.T) {
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	collName := common.GenRandomString("external", 6)
+
+	// Create schema with external source but missing external_field
+	schema := entity.NewSchema().
+		WithName(collName).
+		WithExternalSource("s3://test-bucket/data/").
+		WithExternalSpec(`{"format": "parquet"}`).
+		WithField(
+			entity.NewField().
+				WithName("text").
+				WithDataType(entity.FieldTypeVarChar).
+				WithMaxLength(256),
+			// Missing WithExternalField()
+		).
+		WithField(
+			entity.NewField().
+				WithName("embedding").
+				WithDataType(entity.FieldTypeFloatVector).
+				WithDim(common.DefaultDim).
+				WithExternalField("embedding_column"),
+		)
+
+	// Create collection should fail
+	err := mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema))
+	common.CheckErr(t, err, false, "must have external_field mapping")
+}
+
+// TestCreateExternalCollectionWithPrimaryKey tests that creating external collection
+// with primary key field fails
+func TestCreateExternalCollectionWithPrimaryKey(t *testing.T) {
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	collName := common.GenRandomString("external", 6)
+
+	// Create schema with external source and primary key (not allowed)
+	schema := entity.NewSchema().
+		WithName(collName).
+		WithExternalSource("s3://test-bucket/data/").
+		WithExternalSpec(`{"format": "parquet"}`).
+		WithField(
+			entity.NewField().
+				WithName("id").
+				WithDataType(entity.FieldTypeInt64).
+				WithIsPrimaryKey(true).
+				WithExternalField("id_column"),
+		).
+		WithField(
+			entity.NewField().
+				WithName("embedding").
+				WithDataType(entity.FieldTypeFloatVector).
+				WithDim(common.DefaultDim).
+				WithExternalField("embedding_column"),
+		)
+
+	// Create collection should fail - external collections don't support primary key
+	err := mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema))
+	common.CheckErr(t, err, false, "does not support primary key")
+}
+
+// TestCreateExternalCollectionWithDynamicField tests that creating external collection
+// with dynamic field enabled fails
+func TestCreateExternalCollectionWithDynamicField(t *testing.T) {
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	collName := common.GenRandomString("external", 6)
+
+	// Create schema with external source and dynamic field (not allowed)
+	schema := entity.NewSchema().
+		WithName(collName).
+		WithExternalSource("s3://test-bucket/data/").
+		WithExternalSpec(`{"format": "parquet"}`).
+		WithDynamicFieldEnabled(true).
+		WithField(
+			entity.NewField().
+				WithName("text").
+				WithDataType(entity.FieldTypeVarChar).
+				WithMaxLength(256).
+				WithExternalField("text_column"),
+		).
+		WithField(
+			entity.NewField().
+				WithName("embedding").
+				WithDataType(entity.FieldTypeFloatVector).
+				WithDim(common.DefaultDim).
+				WithExternalField("embedding_column"),
+		)
+
+	// Create collection should fail - external collections don't support dynamic field
+	err := mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema))
+	common.CheckErr(t, err, false, "does not support dynamic field")
+}
+
+// TestCreateExternalCollectionWithAutoID tests that creating external collection
+// with auto ID field fails
+func TestCreateExternalCollectionWithAutoID(t *testing.T) {
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	collName := common.GenRandomString("external", 6)
+
+	// Create schema with external source and auto ID (not allowed)
+	schema := entity.NewSchema().
+		WithName(collName).
+		WithExternalSource("s3://test-bucket/data/").
+		WithExternalSpec(`{"format": "parquet"}`).
+		WithField(
+			entity.NewField().
+				WithName("id").
+				WithDataType(entity.FieldTypeInt64).
+				WithIsAutoID(true).
+				WithExternalField("id_column"),
+		).
+		WithField(
+			entity.NewField().
+				WithName("embedding").
+				WithDataType(entity.FieldTypeFloatVector).
+				WithDim(common.DefaultDim).
+				WithExternalField("embedding_column"),
+		)
+
+	// Create collection should fail - external collections don't support auto ID
+	err := mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema))
+	common.CheckErr(t, err, false, "does not support auto id")
+}
+
+// TestCreateExternalCollectionWithPartitionKey tests that creating external collection
+// with partition key field fails
+func TestCreateExternalCollectionWithPartitionKey(t *testing.T) {
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	collName := common.GenRandomString("external", 6)
+
+	// Create schema with external source and partition key (not allowed)
+	schema := entity.NewSchema().
+		WithName(collName).
+		WithExternalSource("s3://test-bucket/data/").
+		WithExternalSpec(`{"format": "parquet"}`).
+		WithField(
+			entity.NewField().
+				WithName("category").
+				WithDataType(entity.FieldTypeVarChar).
+				WithMaxLength(256).
+				WithIsPartitionKey(true).
+				WithExternalField("category_column"),
+		).
+		WithField(
+			entity.NewField().
+				WithName("embedding").
+				WithDataType(entity.FieldTypeFloatVector).
+				WithDim(common.DefaultDim).
+				WithExternalField("embedding_column"),
+		)
+
+	// Create collection should fail - external collections don't support partition key
+	err := mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema))
+	common.CheckErr(t, err, false, "does not support partition key")
+}
+
+// TestCreateExternalCollectionMultipleVectorFields tests creating external collection
+// with multiple vector fields
+func TestCreateExternalCollectionMultipleVectorFields(t *testing.T) {
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	collName := common.GenRandomString("external", 6)
+
+	// Create schema with external source and multiple vector fields
+	schema := entity.NewSchema().
+		WithName(collName).
+		WithExternalSource("s3://test-bucket/data/").
+		WithExternalSpec(`{"format": "parquet"}`).
+		WithField(
+			entity.NewField().
+				WithName("text").
+				WithDataType(entity.FieldTypeVarChar).
+				WithMaxLength(256).
+				WithExternalField("text_column"),
+		).
+		WithField(
+			entity.NewField().
+				WithName("dense_embedding").
+				WithDataType(entity.FieldTypeFloatVector).
+				WithDim(common.DefaultDim).
+				WithExternalField("dense_embedding_column"),
+		).
+		WithField(
+			entity.NewField().
+				WithName("binary_embedding").
+				WithDataType(entity.FieldTypeBinaryVector).
+				WithDim(common.DefaultDim).
+				WithExternalField("binary_embedding_column"),
+		)
+
+	// Create collection
+	err := mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema))
+	common.CheckErr(t, err, true)
+
+	// Describe collection and verify schema
+	coll, err := mc.DescribeCollection(ctx, client.NewDescribeCollectionOption(collName))
+	common.CheckErr(t, err, true)
+
+	// Verify external source
+	require.Equal(t, "s3://test-bucket/data/", coll.Schema.ExternalSource)
+
+	// Verify fields
+	require.Len(t, coll.Schema.Fields, 3)
+
+	// Verify vector fields
+	denseField := findFieldByName(coll.Schema.Fields, "dense_embedding")
+	require.NotNil(t, denseField)
+	require.Equal(t, entity.FieldTypeFloatVector, denseField.DataType)
+	require.Equal(t, "dense_embedding_column", denseField.ExternalField)
+
+	binaryField := findFieldByName(coll.Schema.Fields, "binary_embedding")
+	require.NotNil(t, binaryField)
+	require.Equal(t, entity.FieldTypeBinaryVector, binaryField.DataType)
+	require.Equal(t, "binary_embedding_column", binaryField.ExternalField)
+}
+
+// findFieldByName finds a field by name in the fields slice
+func findFieldByName(fields []*entity.Field, name string) *entity.Field {
+	for _, f := range fields {
+		if f.Name == name {
+			return f
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
issue: #45881

- Add ExternalSource and ExternalSpec fields to collection schema
- Add ExternalField mapping for field schema to map external columns
- Implement ValidateExternalCollectionSchema() to enforce restrictions:
  - No primary key (virtual PK generated automatically)
  - No dynamic fields, partition keys, clustering keys, or auto ID
  - No text match or function features
  - All user fields must have external_field mapping
- Return virtual PK schema for external collections in GetPrimaryFieldSchema()
- Skip primary key validation for external collections during creation
- Add comprehensive unit tests and integration tests
- Add design document and user guide