### PR TITLE
fix: Changed the container group owership to run as any user

### DIFF
--- a/build/docker/milvus/amazonlinux2023/Dockerfile
+++ b/build/docker/milvus/amazonlinux2023/Dockerfile
@@ -37,7 +37,7 @@ ENV MALLOC_CONF=background_thread:true
 # Change user to milvus
 RUN groupadd -r milvus && useradd -r -g milvus milvus && \
     mkdir -p /var/lib/milvus && \
-    chown -R milvus:0 /milvus /var/lib/milvus && \
+    chown -R milvus:root /milvus /var/lib/milvus && \
     chmod -R g=u /milvus /var/lib/milvus
 USER milvus
 

--- a/build/docker/milvus/amazonlinux2023/Dockerfile
+++ b/build/docker/milvus/amazonlinux2023/Dockerfile
@@ -37,8 +37,9 @@ ENV MALLOC_CONF=background_thread:true
 # Change user to milvus
 RUN groupadd -r milvus && useradd -r -g milvus milvus && \
     mkdir -p /var/lib/milvus && \
-    chown -R milvus:milvus /milvus /var/lib/milvus
-USER milvus:milvus
+    chown -R milvus:0 /milvus /var/lib/milvus && \
+    chmod -R g=u /milvus /var/lib/milvus
+USER milvus
 
 ENTRYPOINT ["/tini", "--"]
 

--- a/build/docker/milvus/gpu/ubuntu20.04/Dockerfile
+++ b/build/docker/milvus/gpu/ubuntu20.04/Dockerfile
@@ -28,6 +28,6 @@ ENV MALLOC_CONF=background_thread:true
 # Change user to milvus
 RUN groupadd -r milvus && useradd -r -g milvus milvus && \
     mkdir -p /var/lib/milvus && \
-    chown -R milvus:0 /milvus /var/lib/milvus && \
+    chown -R milvus:root /milvus /var/lib/milvus && \
     chmod -R g=u /milvus /var/lib/milvus
 USER milvus

--- a/build/docker/milvus/gpu/ubuntu20.04/Dockerfile
+++ b/build/docker/milvus/gpu/ubuntu20.04/Dockerfile
@@ -28,5 +28,6 @@ ENV MALLOC_CONF=background_thread:true
 # Change user to milvus
 RUN groupadd -r milvus && useradd -r -g milvus milvus && \
     mkdir -p /var/lib/milvus && \
-    chown -R milvus:milvus /milvus /var/lib/milvus
-USER milvus:milvus
+    chown -R milvus:0 /milvus /var/lib/milvus && \
+    chmod -R g=u /milvus /var/lib/milvus
+USER milvus

--- a/build/docker/milvus/gpu/ubuntu22.04/Dockerfile
+++ b/build/docker/milvus/gpu/ubuntu22.04/Dockerfile
@@ -31,7 +31,7 @@ ENV MALLOC_CONF=background_thread:true
 # Change user to milvus
 RUN groupadd -r milvus && useradd -r -g milvus milvus && \
     mkdir -p /var/lib/milvus && \
-    chown -R milvus:0 /milvus /var/lib/milvus && \
+    chown -R milvus:root /milvus /var/lib/milvus && \
     chmod -R g=u /milvus /var/lib/milvus
 USER milvus
 

--- a/build/docker/milvus/gpu/ubuntu22.04/Dockerfile
+++ b/build/docker/milvus/gpu/ubuntu22.04/Dockerfile
@@ -9,8 +9,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends curl libaio-dev libgomp1 libopenblas-dev && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata && \
-        ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
-        echo "Etc/UTC" > /etc/timezone && \
+    ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
+    echo "Etc/UTC" > /etc/timezone && \
     apt-get remove --purge -y && \
     rm -rf /var/lib/apt/lists/*
 
@@ -31,8 +31,9 @@ ENV MALLOC_CONF=background_thread:true
 # Change user to milvus
 RUN groupadd -r milvus && useradd -r -g milvus milvus && \
     mkdir -p /var/lib/milvus && \
-    chown -R milvus:milvus /milvus /var/lib/milvus
-USER milvus:milvus
+    chown -R milvus:0 /milvus /var/lib/milvus && \
+    chmod -R g=u /milvus /var/lib/milvus
+USER milvus
 
 ENTRYPOINT ["/tini", "--"]
 

--- a/build/docker/milvus/rockylinux8/Dockerfile
+++ b/build/docker/milvus/rockylinux8/Dockerfile
@@ -41,8 +41,9 @@ ENV MALLOC_CONF=background_thread:true
 # Change user to milvus
 RUN groupadd -r milvus && useradd -r -g milvus milvus && \
     mkdir -p /var/lib/milvus && \
-    chown -R milvus:milvus /milvus /var/lib/milvus
-USER milvus:milvus
+    chown -R milvus:0 /milvus /var/lib/milvus && \
+    chmod -R g=u /milvus /var/lib/milvus
+USER milvus
 
 ENTRYPOINT ["/tini", "--"]
 

--- a/build/docker/milvus/rockylinux8/Dockerfile
+++ b/build/docker/milvus/rockylinux8/Dockerfile
@@ -41,7 +41,7 @@ ENV MALLOC_CONF=background_thread:true
 # Change user to milvus
 RUN groupadd -r milvus && useradd -r -g milvus milvus && \
     mkdir -p /var/lib/milvus && \
-    chown -R milvus:0 /milvus /var/lib/milvus && \
+    chown -R milvus:root /milvus /var/lib/milvus && \
     chmod -R g=u /milvus /var/lib/milvus
 USER milvus
 

--- a/build/docker/milvus/ubuntu20.04/Dockerfile
+++ b/build/docker/milvus/ubuntu20.04/Dockerfile
@@ -21,8 +21,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends curl libaio-dev libgomp1 libopenblas-dev && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata && \
-        ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
-        echo "Etc/UTC" > /etc/timezone && \
+    ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
+    echo "Etc/UTC" > /etc/timezone && \
     apt-get remove --purge -y && \
     rm -rf /var/lib/apt/lists/*
 
@@ -45,8 +45,9 @@ ENV MALLOC_CONF=background_thread:true
 # Change user to milvus
 RUN groupadd -r milvus && useradd -r -g milvus milvus && \
     mkdir -p /var/lib/milvus && \
-    chown -R milvus:milvus /milvus /var/lib/milvus
-USER milvus:milvus
+    chown -R milvus:0 /milvus /var/lib/milvus && \
+    chmod -R g=u /milvus /var/lib/milvus
+USER milvus
 
 ENTRYPOINT ["/tini", "--"]
 

--- a/build/docker/milvus/ubuntu20.04/Dockerfile
+++ b/build/docker/milvus/ubuntu20.04/Dockerfile
@@ -45,7 +45,7 @@ ENV MALLOC_CONF=background_thread:true
 # Change user to milvus
 RUN groupadd -r milvus && useradd -r -g milvus milvus && \
     mkdir -p /var/lib/milvus && \
-    chown -R milvus:0 /milvus /var/lib/milvus && \
+    chown -R milvus:root /milvus /var/lib/milvus && \
     chmod -R g=u /milvus /var/lib/milvus
 USER milvus
 

--- a/build/docker/milvus/ubuntu22.04/Dockerfile
+++ b/build/docker/milvus/ubuntu22.04/Dockerfile
@@ -46,9 +46,10 @@ ENV MALLOC_CONF=background_thread:true
 ENV ASAN_OPTIONS=detect_leaks=0
 RUN groupadd -r milvus && useradd -r -g milvus milvus && \
     mkdir -p /var/lib/milvus && \
-    chown -R milvus:milvus /milvus /var/lib/milvus
+    chown -R milvus:0 /milvus /var/lib/milvus && \
+    chmod -R g=u /milvus /var/lib/milvus
 ENV ASAN_OPTIONS=detect_leaks=1
-USER milvus:milvus
+USER milvus
 
 ENTRYPOINT ["/tini", "--"]
 

--- a/build/docker/milvus/ubuntu22.04/Dockerfile
+++ b/build/docker/milvus/ubuntu22.04/Dockerfile
@@ -21,8 +21,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends curl libaio-dev libgomp1 libopenblas-dev && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata && \
-        ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
-        echo "Etc/UTC" > /etc/timezone && \
+    ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
+    echo "Etc/UTC" > /etc/timezone && \
     apt-get remove --purge -y && \
     rm -rf /var/lib/apt/lists/*
 
@@ -46,7 +46,7 @@ ENV MALLOC_CONF=background_thread:true
 ENV ASAN_OPTIONS=detect_leaks=0
 RUN groupadd -r milvus && useradd -r -g milvus milvus && \
     mkdir -p /var/lib/milvus && \
-    chown -R milvus:0 /milvus /var/lib/milvus && \
+    chown -R milvus:root /milvus /var/lib/milvus && \
     chmod -R g=u /milvus /var/lib/milvus
 ENV ASAN_OPTIONS=detect_leaks=1
 USER milvus


### PR DESCRIPTION
Adapted the dockerfile to run on redhat openshift container platform. This was already done in a previous commit, but a recent commit (7cb7651) reverted the changes.
To quote the original fix:
> "OpenShift runs Pods with a random uid and gid 0. As Milvus needs to write into the /milvus directory, this fix modifies the group permissions to allow the root group (gid 0) to write into it."

Fixes #46897