### PR TITLE
fix: Changed the container group owership for openshift compatibility

### DIFF
--- a/build/docker/milvus/amazonlinux2023/Dockerfile
+++ b/build/docker/milvus/amazonlinux2023/Dockerfile
@@ -38,7 +38,7 @@ ENV MALLOC_CONF=background_thread:true
 # protobuf 5.x RepeatedField adds container annotations that trigger ASAN
 # container-overflow false positives during static initialization, disable it.
 ENV ASAN_OPTIONS=detect_leaks=0:detect_container_overflow=0
-RUN groupadd -r milvus && useradd -r -g milvus milvus && \
+RUN useradd -r -g root milvus && \
     mkdir -p /var/lib/milvus && \
     chown -R milvus:root /milvus /var/lib/milvus && \
     chmod -R g=u /milvus /var/lib/milvus

--- a/build/docker/milvus/amazonlinux2023/Dockerfile
+++ b/build/docker/milvus/amazonlinux2023/Dockerfile
@@ -40,9 +40,10 @@ ENV MALLOC_CONF=background_thread:true
 ENV ASAN_OPTIONS=detect_leaks=0:detect_container_overflow=0
 RUN groupadd -r milvus && useradd -r -g milvus milvus && \
     mkdir -p /var/lib/milvus && \
-    chown -R milvus:milvus /milvus /var/lib/milvus
+    chown -R milvus:root /milvus /var/lib/milvus && \
+    chmod -R g=u /milvus /var/lib/milvus
 ENV ASAN_OPTIONS=detect_leaks=1:detect_container_overflow=0
-USER milvus:milvus
+USER milvus
 
 ENTRYPOINT ["/tini", "--"]
 

--- a/build/docker/milvus/gpu/ubuntu20.04/Dockerfile
+++ b/build/docker/milvus/gpu/ubuntu20.04/Dockerfile
@@ -26,7 +26,7 @@ ENV LD_PRELOAD=/milvus/lib/libjemalloc.so
 ENV MALLOC_CONF=background_thread:true
 
 # Change user to milvus
-RUN groupadd -r milvus && useradd -r -g milvus milvus && \
+RUN useradd -r -g root milvus && \
     mkdir -p /var/lib/milvus && \
     chown -R milvus:root /milvus /var/lib/milvus && \
     chmod -R g=u /milvus /var/lib/milvus

--- a/build/docker/milvus/gpu/ubuntu20.04/Dockerfile
+++ b/build/docker/milvus/gpu/ubuntu20.04/Dockerfile
@@ -28,5 +28,6 @@ ENV MALLOC_CONF=background_thread:true
 # Change user to milvus
 RUN groupadd -r milvus && useradd -r -g milvus milvus && \
     mkdir -p /var/lib/milvus && \
-    chown -R milvus:milvus /milvus /var/lib/milvus
-USER milvus:milvus
+    chown -R milvus:root /milvus /var/lib/milvus && \
+    chmod -R g=u /milvus /var/lib/milvus
+USER milvus

--- a/build/docker/milvus/gpu/ubuntu22.04/Dockerfile
+++ b/build/docker/milvus/gpu/ubuntu22.04/Dockerfile
@@ -9,8 +9,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends curl libaio-dev libgomp1 libopenblas-dev && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata && \
-        ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
-        echo "Etc/UTC" > /etc/timezone && \
+    ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
+    echo "Etc/UTC" > /etc/timezone && \
     apt-get remove --purge -y && \
     rm -rf /var/lib/apt/lists/*
 
@@ -31,8 +31,9 @@ ENV MALLOC_CONF=background_thread:true
 # Change user to milvus
 RUN groupadd -r milvus && useradd -r -g milvus milvus && \
     mkdir -p /var/lib/milvus && \
-    chown -R milvus:milvus /milvus /var/lib/milvus
-USER milvus:milvus
+    chown -R milvus:root /milvus /var/lib/milvus && \
+    chmod -R g=u /milvus /var/lib/milvus
+USER milvus
 
 ENTRYPOINT ["/tini", "--"]
 

--- a/build/docker/milvus/gpu/ubuntu22.04/Dockerfile
+++ b/build/docker/milvus/gpu/ubuntu22.04/Dockerfile
@@ -29,7 +29,7 @@ ENV LD_PRELOAD=/milvus/lib/libjemalloc.so
 ENV MALLOC_CONF=background_thread:true
 
 # Change user to milvus
-RUN groupadd -r milvus && useradd -r -g milvus milvus && \
+RUN useradd -r -g root milvus && \
     mkdir -p /var/lib/milvus && \
     chown -R milvus:root /milvus /var/lib/milvus && \
     chmod -R g=u /milvus /var/lib/milvus

--- a/build/docker/milvus/rockylinux9/Dockerfile
+++ b/build/docker/milvus/rockylinux9/Dockerfile
@@ -41,7 +41,7 @@ ENV MALLOC_CONF=background_thread:true
 # protobuf 5.x RepeatedField adds container annotations that trigger ASAN
 # container-overflow false positives during static initialization, disable it.
 ENV ASAN_OPTIONS=detect_leaks=0:detect_container_overflow=0
-RUN groupadd -r milvus && useradd -r -g milvus milvus && \
+RUN useradd -r -g root milvus && \
     mkdir -p /var/lib/milvus && \
     chown -R milvus:root /milvus /var/lib/milvus && \
     chmod -R g=u /milvus /var/lib/milvus

--- a/build/docker/milvus/rockylinux9/Dockerfile
+++ b/build/docker/milvus/rockylinux9/Dockerfile
@@ -43,9 +43,10 @@ ENV MALLOC_CONF=background_thread:true
 ENV ASAN_OPTIONS=detect_leaks=0:detect_container_overflow=0
 RUN groupadd -r milvus && useradd -r -g milvus milvus && \
     mkdir -p /var/lib/milvus && \
-    chown -R milvus:milvus /milvus /var/lib/milvus
+    chown -R milvus:root /milvus /var/lib/milvus && \
+    chmod -R g=u /milvus /var/lib/milvus
 ENV ASAN_OPTIONS=detect_leaks=1:detect_container_overflow=0
-USER milvus:milvus
+USER milvus
 
 ENTRYPOINT ["/tini", "--"]
 

--- a/build/docker/milvus/ubuntu20.04/Dockerfile
+++ b/build/docker/milvus/ubuntu20.04/Dockerfile
@@ -21,8 +21,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends gpgv curl libaio-dev libgomp1 libopenblas-dev && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata && \
-        ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
-        echo "Etc/UTC" > /etc/timezone && \
+    ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
+    echo "Etc/UTC" > /etc/timezone && \
     apt-get remove --purge -y && \
     rm -rf /var/lib/apt/lists/*
 
@@ -48,9 +48,10 @@ ENV MALLOC_CONF=background_thread:true
 ENV ASAN_OPTIONS=detect_leaks=0:detect_container_overflow=0
 RUN groupadd -r milvus && useradd -r -g milvus milvus && \
     mkdir -p /var/lib/milvus && \
-    chown -R milvus:milvus /milvus /var/lib/milvus
+    chown -R milvus:root /milvus /var/lib/milvus && \
+    chmod -R g=u /milvus /var/lib/milvus
 ENV ASAN_OPTIONS=detect_leaks=1:detect_container_overflow=0
-USER milvus:milvus
+USER milvus
 
 ENTRYPOINT ["/tini", "--"]
 

--- a/build/docker/milvus/ubuntu20.04/Dockerfile
+++ b/build/docker/milvus/ubuntu20.04/Dockerfile
@@ -46,7 +46,7 @@ ENV MALLOC_CONF=background_thread:true
 # protobuf 5.x RepeatedField adds container annotations that trigger ASAN
 # container-overflow false positives during static initialization, disable it.
 ENV ASAN_OPTIONS=detect_leaks=0:detect_container_overflow=0
-RUN groupadd -r milvus && useradd -r -g milvus milvus && \
+RUN useradd -r -g root milvus && \
     mkdir -p /var/lib/milvus && \
     chown -R milvus:root /milvus /var/lib/milvus && \
     chmod -R g=u /milvus /var/lib/milvus

--- a/build/docker/milvus/ubuntu22.04/Dockerfile
+++ b/build/docker/milvus/ubuntu22.04/Dockerfile
@@ -21,8 +21,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends gpgv curl libaio-dev libgomp1 libopenblas-dev && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata && \
-        ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
-        echo "Etc/UTC" > /etc/timezone && \
+    ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
+    echo "Etc/UTC" > /etc/timezone && \
     apt-get remove --purge -y && \
     rm -rf /var/lib/apt/lists/*
 
@@ -48,9 +48,10 @@ ENV MALLOC_CONF=background_thread:true
 ENV ASAN_OPTIONS=detect_leaks=0:detect_container_overflow=0
 RUN groupadd -r milvus && useradd -r -g milvus milvus && \
     mkdir -p /var/lib/milvus && \
-    chown -R milvus:milvus /milvus /var/lib/milvus
+    chown -R milvus:root /milvus /var/lib/milvus && \
+    chmod -R g=u /milvus /var/lib/milvus
 ENV ASAN_OPTIONS=detect_leaks=1:detect_container_overflow=0
-USER milvus:milvus
+USER milvus
 
 ENTRYPOINT ["/tini", "--"]
 

--- a/build/docker/milvus/ubuntu22.04/Dockerfile
+++ b/build/docker/milvus/ubuntu22.04/Dockerfile
@@ -46,7 +46,7 @@ ENV MALLOC_CONF=background_thread:true
 # protobuf 5.x RepeatedField adds container annotations that trigger ASAN
 # container-overflow false positives during static initialization, disable it.
 ENV ASAN_OPTIONS=detect_leaks=0:detect_container_overflow=0
-RUN groupadd -r milvus && useradd -r -g milvus milvus && \
+RUN useradd -r -g root milvus && \
     mkdir -p /var/lib/milvus && \
     chown -R milvus:root /milvus /var/lib/milvus && \
     chmod -R g=u /milvus /var/lib/milvus


### PR DESCRIPTION
Adapted the dockerfile to run on redhat openshift container platform. This was already done in a previous commit, but a recent commit (7cb7651) reverted the changes.
To quote the original fix:
>"OpenShift runs Pods with a random uid and gid 0. As Milvus needs to write into the /milvus directory, this fix modifies the group permissions to allow the root group (gid 0) to write into it."

Fixes #46897