### PR TITLE
fix: skip index creation for nullable vector fields with insufficient valid rows

### DIFF
--- a/internal/flushcommon/syncmgr/pack_writer_v2.go
+++ b/internal/flushcommon/syncmgr/pack_writer_v2.go
@@ -206,6 +206,16 @@ func (bw *BulkPackWriterV2) writeInsertsIntoStorage(_ context.Context,
 	}
 
 	var manifestPath string
+	getFieldNullCounts := func(columnGroup storagecommon.ColumnGroup) map[int64]int64 {
+		result := make(map[int64]int64, len(columnGroup.Fields))
+		for _, fieldID := range columnGroup.Fields {
+			if col := rec.Column(fieldID); col != nil {
+				result[fieldID] = int64(col.NullN())
+			}
+		}
+		return result
+	}
+
 	if bw.manifestPath != "" {
 		basePath, version, err := packed.UnmarshalManfestPath(bw.manifestPath)
 		if err != nil {
@@ -225,12 +235,13 @@ func (bw *BulkPackWriterV2) writeInsertsIntoStorage(_ context.Context,
 				ChildFields: columnGroup.Fields,
 				Binlogs: []*datapb.Binlog{
 					{
-						LogSize:       int64(w.GetColumnGroupWrittenCompressed(columnGroup.GroupID)),
-						MemorySize:    int64(w.GetColumnGroupWrittenUncompressed(columnGroup.GroupID)),
-						LogPath:       w.GetWrittenPaths(columnGroupID),
-						EntriesNum:    w.GetWrittenRowNum(),
-						TimestampFrom: tsFrom,
-						TimestampTo:   tsTo,
+						LogSize:         int64(w.GetColumnGroupWrittenCompressed(columnGroup.GroupID)),
+						MemorySize:      int64(w.GetColumnGroupWrittenUncompressed(columnGroup.GroupID)),
+						LogPath:         w.GetWrittenPaths(columnGroupID),
+						EntriesNum:      w.GetWrittenRowNum(),
+						TimestampFrom:   tsFrom,
+						TimestampTo:     tsTo,
+						FieldNullCounts: getFieldNullCounts(columnGroup),
 					},
 				},
 			}
@@ -261,12 +272,13 @@ func (bw *BulkPackWriterV2) writeInsertsIntoStorage(_ context.Context,
 				ChildFields: columnGroup.Fields,
 				Binlogs: []*datapb.Binlog{
 					{
-						LogSize:       int64(w.GetColumnGroupWrittenCompressed(columnGroup.GroupID)),
-						MemorySize:    int64(w.GetColumnGroupWrittenUncompressed(columnGroup.GroupID)),
-						LogPath:       w.GetWrittenPaths(columnGroupID),
-						EntriesNum:    w.GetWrittenRowNum(),
-						TimestampFrom: tsFrom,
-						TimestampTo:   tsTo,
+						LogSize:         int64(w.GetColumnGroupWrittenCompressed(columnGroup.GroupID)),
+						MemorySize:      int64(w.GetColumnGroupWrittenUncompressed(columnGroup.GroupID)),
+						LogPath:         w.GetWrittenPaths(columnGroupID),
+						EntriesNum:      w.GetWrittenRowNum(),
+						TimestampFrom:   tsFrom,
+						TimestampTo:     tsTo,
+						FieldNullCounts: getFieldNullCounts(columnGroup),
 					},
 				},
 			}

--- a/pkg/proto/data_coord.proto
+++ b/pkg/proto/data_coord.proto
@@ -555,6 +555,8 @@ message Binlog {
   // log_size represents the size after data serialized.
   // for stats_log, the memory_size always equal log_size.
   int64 memory_size = 7;
+  // null counts per field in this column group.
+  map<int64, int64> field_null_counts = 8;
 }
 
 message GetRecoveryInfoResponse {

--- a/pkg/proto/datapb/data_coord.pb.go
+++ b/pkg/proto/datapb/data_coord.pb.go
@@ -4029,6 +4029,8 @@ type Binlog struct {
 	// log_size represents the size after data serialized.
 	// for stats_log, the memory_size always equal log_size.
 	MemorySize int64 `protobuf:"varint,7,opt,name=memory_size,json=memorySize,proto3" json:"memory_size,omitempty"`
+	// null counts per field in this column group.
+	FieldNullCounts map[int64]int64 `protobuf:"bytes,8,rep,name=field_null_counts,json=fieldNullCounts,proto3" json:"field_null_counts,omitempty" protobuf_key:"varint,1,opt,name=key,proto3" protobuf_val:"varint,2,opt,name=value,proto3"`
 }
 
 func (x *Binlog) Reset() {
@@ -4110,6 +4112,13 @@ func (x *Binlog) GetMemorySize() int64 {
 		return x.MemorySize
 	}
 	return 0
+}
+
+func (x *Binlog) GetFieldNullCounts() map[int64]int64 {
+	if x != nil {
+		return x.FieldNullCounts
+	}
+	return nil
 }
 
 type GetRecoveryInfoResponse struct {
@@ -12856,7 +12865,7 @@ var file_data_coord_proto_rawDesc = []byte{
 	0x6f, 0x6e, 0x5f, 0x6b, 0x65, 0x79, 0x5f, 0x73, 0x74, 0x61, 0x74, 0x73, 0x5f, 0x64, 0x61, 0x74,
 	0x61, 0x5f, 0x66, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x18, 0x07, 0x20, 0x01, 0x28, 0x03, 0x52, 0x16,
 	0x6a, 0x73, 0x6f, 0x6e, 0x4b, 0x65, 0x79, 0x53, 0x74, 0x61, 0x74, 0x73, 0x44, 0x61, 0x74, 0x61,
-	0x46, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x22, 0xe0, 0x01, 0x0a, 0x06, 0x42, 0x69, 0x6e, 0x6c, 0x6f,
+	0x46, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x22, 0x80, 0x03, 0x0a, 0x06, 0x42, 0x69, 0x6e, 0x6c, 0x6f,
 	0x67, 0x12, 0x1f, 0x0a, 0x0b, 0x65, 0x6e, 0x74, 0x72, 0x69, 0x65, 0x73, 0x5f, 0x6e, 0x75, 0x6d,
 	0x18, 0x01, 0x20, 0x01, 0x28, 0x03, 0x52, 0x0a, 0x65, 0x6e, 0x74, 0x72, 0x69, 0x65, 0x73, 0x4e,
 	0x75, 0x6d, 0x12, 0x25, 0x0a, 0x0e, 0x74, 0x69, 0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d, 0x70, 0x5f,
@@ -12870,7 +12879,17 @@ var file_data_coord_proto_rawDesc = []byte{
 	0x7a, 0x65, 0x12, 0x14, 0x0a, 0x05, 0x6c, 0x6f, 0x67, 0x49, 0x44, 0x18, 0x06, 0x20, 0x01, 0x28,
 	0x03, 0x52, 0x05, 0x6c, 0x6f, 0x67, 0x49, 0x44, 0x12, 0x1f, 0x0a, 0x0b, 0x6d, 0x65, 0x6d, 0x6f,
 	0x72, 0x79, 0x5f, 0x73, 0x69, 0x7a, 0x65, 0x18, 0x07, 0x20, 0x01, 0x28, 0x03, 0x52, 0x0a, 0x6d,
-	0x65, 0x6d, 0x6f, 0x72, 0x79, 0x53, 0x69, 0x7a, 0x65, 0x22, 0xc8, 0x01, 0x0a, 0x17, 0x47, 0x65,
+	0x65, 0x6d, 0x6f, 0x72, 0x79, 0x53, 0x69, 0x7a, 0x65, 0x12, 0x5a, 0x0a, 0x11, 0x66, 0x69, 0x65,
+	0x6c, 0x64, 0x5f, 0x6e, 0x75, 0x6c, 0x6c, 0x5f, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x73, 0x18, 0x08,
+	0x20, 0x03, 0x28, 0x0b, 0x32, 0x2e, 0x2e, 0x6d, 0x69, 0x6c, 0x76, 0x75, 0x73, 0x2e, 0x70, 0x72,
+	0x6f, 0x74, 0x6f, 0x2e, 0x64, 0x61, 0x74, 0x61, 0x2e, 0x42, 0x69, 0x6e, 0x6c, 0x6f, 0x67, 0x2e,
+	0x46, 0x69, 0x65, 0x6c, 0x64, 0x4e, 0x75, 0x6c, 0x6c, 0x43, 0x6f, 0x75, 0x6e, 0x74, 0x73, 0x45,
+	0x6e, 0x74, 0x72, 0x79, 0x52, 0x0f, 0x66, 0x69, 0x65, 0x6c, 0x64, 0x4e, 0x75, 0x6c, 0x6c, 0x43,
+	0x6f, 0x75, 0x6e, 0x74, 0x73, 0x1a, 0x42, 0x0a, 0x14, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4e, 0x75,
+	0x6c, 0x6c, 0x43, 0x6f, 0x75, 0x6e, 0x74, 0x73, 0x45, 0x6e, 0x74, 0x72, 0x79, 0x12, 0x10, 0x0a,
+	0x03, 0x6b, 0x65, 0x79, 0x18, 0x01, 0x20, 0x01, 0x28, 0x03, 0x52, 0x03, 0x6b, 0x65, 0x79, 0x12,
+	0x14, 0x0a, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x03, 0x52, 0x05,
+	0x76, 0x61, 0x6c, 0x75, 0x65, 0x3a, 0x02, 0x38, 0x01, 0x22, 0xc8, 0x01, 0x0a, 0x17, 0x47, 0x65,
 	0x74, 0x52, 0x65, 0x63, 0x6f, 0x76, 0x65, 0x72, 0x79, 0x49, 0x6e, 0x66, 0x6f, 0x52, 0x65, 0x73,
 	0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x33, 0x0a, 0x06, 0x73, 0x74, 0x61, 0x74, 0x75, 0x73, 0x18,
 	0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x6d, 0x69, 0x6c, 0x76, 0x75, 0x73, 0x2e, 0x70,
@@ -15193,7 +15212,7 @@ func file_data_coord_proto_rawDescGZIP() []byte {
 }
 
 var file_data_coord_proto_enumTypes = make([]protoimpl.EnumInfo, 12)
-var file_data_coord_proto_msgTypes = make([]protoimpl.MessageInfo, 162)
+var file_data_coord_proto_msgTypes = make([]protoimpl.MessageInfo, 163)
 var file_data_coord_proto_goTypes = []interface{}{
 	(SegmentType)(0),                               // 0: milvus.proto.data.SegmentType
 	(SegmentLevel)(0),                              // 1: milvus.proto.data.SegmentLevel
@@ -15356,143 +15375,144 @@ var file_data_coord_proto_goTypes = []interface{}{
 	nil,                                            // 158: milvus.proto.data.SegmentInfo.TextStatsLogsEntry
 	nil,                                            // 159: milvus.proto.data.SegmentInfo.JsonKeyStatsEntry
 	nil,                                            // 160: milvus.proto.data.SegmentBinlogs.TextStatsLogsEntry
-	nil,                                            // 161: milvus.proto.data.SyncSegmentsRequest.SegmentInfosEntry
-	nil,                                            // 162: milvus.proto.data.CompactionSegment.TextStatsLogsEntry
-	nil,                                            // 163: milvus.proto.data.PartitionImportStats.PartitionRowsEntry
-	nil,                                            // 164: milvus.proto.data.PartitionImportStats.PartitionDataSizeEntry
-	nil,                                            // 165: milvus.proto.data.ImportFileStats.HashedStatsEntry
-	nil,                                            // 166: milvus.proto.data.CopySegmentSource.TextIndexFilesEntry
-	nil,                                            // 167: milvus.proto.data.CopySegmentSource.JsonKeyIndexFilesEntry
-	nil,                                            // 168: milvus.proto.data.CopySegmentResult.IndexInfosEntry
-	nil,                                            // 169: milvus.proto.data.CopySegmentResult.TextIndexInfosEntry
-	nil,                                            // 170: milvus.proto.data.CopySegmentResult.JsonKeyIndexInfosEntry
-	nil,                                            // 171: milvus.proto.data.SegmentDescription.TextIndexFilesEntry
-	nil,                                            // 172: milvus.proto.data.SegmentDescription.JsonKeyIndexFilesEntry
-	nil,                                            // 173: milvus.proto.data.CollectionDescription.PartitionsEntry
-	(*commonpb.MsgBase)(nil),                       // 174: milvus.proto.common.MsgBase
-	(*commonpb.Status)(nil),                        // 175: milvus.proto.common.Status
-	(*milvuspb.ClusterInfo)(nil),                   // 176: milvus.proto.milvus.ClusterInfo
-	(commonpb.SegmentState)(0),                     // 177: milvus.proto.common.SegmentState
-	(*msgpb.MsgPosition)(nil),                      // 178: milvus.proto.msg.MsgPosition
-	(*internalpb.StringList)(nil),                  // 179: milvus.proto.internal.StringList
-	(*commonpb.KeyValuePair)(nil),                  // 180: milvus.proto.common.KeyValuePair
-	(*schemapb.CollectionSchema)(nil),              // 181: milvus.proto.schema.CollectionSchema
-	(*internalpb.FileResourceInfo)(nil),            // 182: milvus.proto.internal.FileResourceInfo
-	(*commonpb.KeyDataPair)(nil),                   // 183: milvus.proto.common.KeyDataPair
-	(*commonpb.SegmentStats)(nil),                  // 184: milvus.proto.common.SegmentStats
-	(*schemapb.FieldSchema)(nil),                   // 185: milvus.proto.schema.FieldSchema
-	(*msgpb.DataNodeTtMsg)(nil),                    // 186: milvus.proto.msg.DataNodeTtMsg
-	(*internalpb.ImportFile)(nil),                  // 187: milvus.proto.internal.ImportFile
-	(*indexpb.StorageConfig)(nil),                  // 188: milvus.proto.index.StorageConfig
-	(*indexpb.IndexFilePathInfo)(nil),              // 189: milvus.proto.index.IndexFilePathInfo
-	(internalpb.ImportJobState)(0),                 // 190: milvus.proto.internal.ImportJobState
-	(indexpb.JobState)(0),                          // 191: milvus.proto.index.JobState
-	(commonpb.ConsistencyLevel)(0),                 // 192: milvus.proto.common.ConsistencyLevel
-	(*indexpb.IndexInfo)(nil),                      // 193: milvus.proto.index.IndexInfo
-	(*commonpb.ImmutableMessage)(nil),              // 194: milvus.proto.common.ImmutableMessage
-	(*msgpb.CreateCollectionRequest)(nil),          // 195: milvus.proto.msg.CreateCollectionRequest
-	(*milvuspb.GetFlushAllStateRequest)(nil),       // 196: milvus.proto.milvus.GetFlushAllStateRequest
-	(*internalpb.ShowConfigurationsRequest)(nil),   // 197: milvus.proto.internal.ShowConfigurationsRequest
-	(*milvuspb.GetMetricsRequest)(nil),             // 198: milvus.proto.milvus.GetMetricsRequest
-	(*milvuspb.ManualCompactionRequest)(nil),       // 199: milvus.proto.milvus.ManualCompactionRequest
-	(*milvuspb.GetCompactionStateRequest)(nil),     // 200: milvus.proto.milvus.GetCompactionStateRequest
-	(*milvuspb.GetCompactionPlansRequest)(nil),     // 201: milvus.proto.milvus.GetCompactionPlansRequest
-	(*milvuspb.CheckHealthRequest)(nil),            // 202: milvus.proto.milvus.CheckHealthRequest
-	(*indexpb.CreateIndexRequest)(nil),             // 203: milvus.proto.index.CreateIndexRequest
-	(*indexpb.AlterIndexRequest)(nil),              // 204: milvus.proto.index.AlterIndexRequest
-	(*indexpb.GetIndexStateRequest)(nil),           // 205: milvus.proto.index.GetIndexStateRequest
-	(*indexpb.GetSegmentIndexStateRequest)(nil),    // 206: milvus.proto.index.GetSegmentIndexStateRequest
-	(*indexpb.GetIndexInfoRequest)(nil),            // 207: milvus.proto.index.GetIndexInfoRequest
-	(*indexpb.DropIndexRequest)(nil),               // 208: milvus.proto.index.DropIndexRequest
-	(*indexpb.DescribeIndexRequest)(nil),           // 209: milvus.proto.index.DescribeIndexRequest
-	(*indexpb.GetIndexStatisticsRequest)(nil),      // 210: milvus.proto.index.GetIndexStatisticsRequest
-	(*indexpb.GetIndexBuildProgressRequest)(nil),   // 211: milvus.proto.index.GetIndexBuildProgressRequest
-	(*indexpb.ListIndexesRequest)(nil),             // 212: milvus.proto.index.ListIndexesRequest
-	(*internalpb.ImportRequestInternal)(nil),       // 213: milvus.proto.internal.ImportRequestInternal
-	(*internalpb.GetImportProgressRequest)(nil),    // 214: milvus.proto.internal.GetImportProgressRequest
-	(*internalpb.ListImportsRequestInternal)(nil),  // 215: milvus.proto.internal.ListImportsRequestInternal
-	(*milvuspb.AddFileResourceRequest)(nil),        // 216: milvus.proto.milvus.AddFileResourceRequest
-	(*milvuspb.RemoveFileResourceRequest)(nil),     // 217: milvus.proto.milvus.RemoveFileResourceRequest
-	(*milvuspb.ListFileResourcesRequest)(nil),      // 218: milvus.proto.milvus.ListFileResourcesRequest
-	(*milvuspb.GetComponentStatesRequest)(nil),     // 219: milvus.proto.milvus.GetComponentStatesRequest
-	(*internalpb.GetStatisticsChannelRequest)(nil), // 220: milvus.proto.internal.GetStatisticsChannelRequest
-	(*internalpb.SyncFileResourceRequest)(nil),     // 221: milvus.proto.internal.SyncFileResourceRequest
-	(*milvuspb.StringResponse)(nil),                // 222: milvus.proto.milvus.StringResponse
-	(*milvuspb.GetFlushAllStateResponse)(nil),      // 223: milvus.proto.milvus.GetFlushAllStateResponse
-	(*internalpb.ShowConfigurationsResponse)(nil),  // 224: milvus.proto.internal.ShowConfigurationsResponse
-	(*milvuspb.GetMetricsResponse)(nil),            // 225: milvus.proto.milvus.GetMetricsResponse
-	(*milvuspb.ManualCompactionResponse)(nil),      // 226: milvus.proto.milvus.ManualCompactionResponse
-	(*milvuspb.GetCompactionStateResponse)(nil),    // 227: milvus.proto.milvus.GetCompactionStateResponse
-	(*milvuspb.GetCompactionPlansResponse)(nil),    // 228: milvus.proto.milvus.GetCompactionPlansResponse
-	(*milvuspb.GetFlushStateResponse)(nil),         // 229: milvus.proto.milvus.GetFlushStateResponse
-	(*milvuspb.CheckHealthResponse)(nil),           // 230: milvus.proto.milvus.CheckHealthResponse
-	(*indexpb.GetIndexStateResponse)(nil),          // 231: milvus.proto.index.GetIndexStateResponse
-	(*indexpb.GetSegmentIndexStateResponse)(nil),   // 232: milvus.proto.index.GetSegmentIndexStateResponse
-	(*indexpb.GetIndexInfoResponse)(nil),           // 233: milvus.proto.index.GetIndexInfoResponse
-	(*indexpb.DescribeIndexResponse)(nil),          // 234: milvus.proto.index.DescribeIndexResponse
-	(*indexpb.GetIndexStatisticsResponse)(nil),     // 235: milvus.proto.index.GetIndexStatisticsResponse
-	(*indexpb.GetIndexBuildProgressResponse)(nil),  // 236: milvus.proto.index.GetIndexBuildProgressResponse
-	(*indexpb.ListIndexesResponse)(nil),            // 237: milvus.proto.index.ListIndexesResponse
-	(*internalpb.ImportResponse)(nil),              // 238: milvus.proto.internal.ImportResponse
-	(*internalpb.GetImportProgressResponse)(nil),   // 239: milvus.proto.internal.GetImportProgressResponse
-	(*internalpb.ListImportsResponse)(nil),         // 240: milvus.proto.internal.ListImportsResponse
-	(*milvuspb.ListFileResourcesResponse)(nil),     // 241: milvus.proto.milvus.ListFileResourcesResponse
-	(*milvuspb.ComponentStates)(nil),               // 242: milvus.proto.milvus.ComponentStates
+	nil,                                            // 161: milvus.proto.data.Binlog.FieldNullCountsEntry
+	nil,                                            // 162: milvus.proto.data.SyncSegmentsRequest.SegmentInfosEntry
+	nil,                                            // 163: milvus.proto.data.CompactionSegment.TextStatsLogsEntry
+	nil,                                            // 164: milvus.proto.data.PartitionImportStats.PartitionRowsEntry
+	nil,                                            // 165: milvus.proto.data.PartitionImportStats.PartitionDataSizeEntry
+	nil,                                            // 166: milvus.proto.data.ImportFileStats.HashedStatsEntry
+	nil,                                            // 167: milvus.proto.data.CopySegmentSource.TextIndexFilesEntry
+	nil,                                            // 168: milvus.proto.data.CopySegmentSource.JsonKeyIndexFilesEntry
+	nil,                                            // 169: milvus.proto.data.CopySegmentResult.IndexInfosEntry
+	nil,                                            // 170: milvus.proto.data.CopySegmentResult.TextIndexInfosEntry
+	nil,                                            // 171: milvus.proto.data.CopySegmentResult.JsonKeyIndexInfosEntry
+	nil,                                            // 172: milvus.proto.data.SegmentDescription.TextIndexFilesEntry
+	nil,                                            // 173: milvus.proto.data.SegmentDescription.JsonKeyIndexFilesEntry
+	nil,                                            // 174: milvus.proto.data.CollectionDescription.PartitionsEntry
+	(*commonpb.MsgBase)(nil),                       // 175: milvus.proto.common.MsgBase
+	(*commonpb.Status)(nil),                        // 176: milvus.proto.common.Status
+	(*milvuspb.ClusterInfo)(nil),                   // 177: milvus.proto.milvus.ClusterInfo
+	(commonpb.SegmentState)(0),                     // 178: milvus.proto.common.SegmentState
+	(*msgpb.MsgPosition)(nil),                      // 179: milvus.proto.msg.MsgPosition
+	(*internalpb.StringList)(nil),                  // 180: milvus.proto.internal.StringList
+	(*commonpb.KeyValuePair)(nil),                  // 181: milvus.proto.common.KeyValuePair
+	(*schemapb.CollectionSchema)(nil),              // 182: milvus.proto.schema.CollectionSchema
+	(*internalpb.FileResourceInfo)(nil),            // 183: milvus.proto.internal.FileResourceInfo
+	(*commonpb.KeyDataPair)(nil),                   // 184: milvus.proto.common.KeyDataPair
+	(*commonpb.SegmentStats)(nil),                  // 185: milvus.proto.common.SegmentStats
+	(*schemapb.FieldSchema)(nil),                   // 186: milvus.proto.schema.FieldSchema
+	(*msgpb.DataNodeTtMsg)(nil),                    // 187: milvus.proto.msg.DataNodeTtMsg
+	(*internalpb.ImportFile)(nil),                  // 188: milvus.proto.internal.ImportFile
+	(*indexpb.StorageConfig)(nil),                  // 189: milvus.proto.index.StorageConfig
+	(*indexpb.IndexFilePathInfo)(nil),              // 190: milvus.proto.index.IndexFilePathInfo
+	(internalpb.ImportJobState)(0),                 // 191: milvus.proto.internal.ImportJobState
+	(indexpb.JobState)(0),                          // 192: milvus.proto.index.JobState
+	(commonpb.ConsistencyLevel)(0),                 // 193: milvus.proto.common.ConsistencyLevel
+	(*indexpb.IndexInfo)(nil),                      // 194: milvus.proto.index.IndexInfo
+	(*commonpb.ImmutableMessage)(nil),              // 195: milvus.proto.common.ImmutableMessage
+	(*msgpb.CreateCollectionRequest)(nil),          // 196: milvus.proto.msg.CreateCollectionRequest
+	(*milvuspb.GetFlushAllStateRequest)(nil),       // 197: milvus.proto.milvus.GetFlushAllStateRequest
+	(*internalpb.ShowConfigurationsRequest)(nil),   // 198: milvus.proto.internal.ShowConfigurationsRequest
+	(*milvuspb.GetMetricsRequest)(nil),             // 199: milvus.proto.milvus.GetMetricsRequest
+	(*milvuspb.ManualCompactionRequest)(nil),       // 200: milvus.proto.milvus.ManualCompactionRequest
+	(*milvuspb.GetCompactionStateRequest)(nil),     // 201: milvus.proto.milvus.GetCompactionStateRequest
+	(*milvuspb.GetCompactionPlansRequest)(nil),     // 202: milvus.proto.milvus.GetCompactionPlansRequest
+	(*milvuspb.CheckHealthRequest)(nil),            // 203: milvus.proto.milvus.CheckHealthRequest
+	(*indexpb.CreateIndexRequest)(nil),             // 204: milvus.proto.index.CreateIndexRequest
+	(*indexpb.AlterIndexRequest)(nil),              // 205: milvus.proto.index.AlterIndexRequest
+	(*indexpb.GetIndexStateRequest)(nil),           // 206: milvus.proto.index.GetIndexStateRequest
+	(*indexpb.GetSegmentIndexStateRequest)(nil),    // 207: milvus.proto.index.GetSegmentIndexStateRequest
+	(*indexpb.GetIndexInfoRequest)(nil),            // 208: milvus.proto.index.GetIndexInfoRequest
+	(*indexpb.DropIndexRequest)(nil),               // 209: milvus.proto.index.DropIndexRequest
+	(*indexpb.DescribeIndexRequest)(nil),           // 210: milvus.proto.index.DescribeIndexRequest
+	(*indexpb.GetIndexStatisticsRequest)(nil),      // 211: milvus.proto.index.GetIndexStatisticsRequest
+	(*indexpb.GetIndexBuildProgressRequest)(nil),   // 212: milvus.proto.index.GetIndexBuildProgressRequest
+	(*indexpb.ListIndexesRequest)(nil),             // 213: milvus.proto.index.ListIndexesRequest
+	(*internalpb.ImportRequestInternal)(nil),       // 214: milvus.proto.internal.ImportRequestInternal
+	(*internalpb.GetImportProgressRequest)(nil),    // 215: milvus.proto.internal.GetImportProgressRequest
+	(*internalpb.ListImportsRequestInternal)(nil),  // 216: milvus.proto.internal.ListImportsRequestInternal
+	(*milvuspb.AddFileResourceRequest)(nil),        // 217: milvus.proto.milvus.AddFileResourceRequest
+	(*milvuspb.RemoveFileResourceRequest)(nil),     // 218: milvus.proto.milvus.RemoveFileResourceRequest
+	(*milvuspb.ListFileResourcesRequest)(nil),      // 219: milvus.proto.milvus.ListFileResourcesRequest
+	(*milvuspb.GetComponentStatesRequest)(nil),     // 220: milvus.proto.milvus.GetComponentStatesRequest
+	(*internalpb.GetStatisticsChannelRequest)(nil), // 221: milvus.proto.internal.GetStatisticsChannelRequest
+	(*internalpb.SyncFileResourceRequest)(nil),     // 222: milvus.proto.internal.SyncFileResourceRequest
+	(*milvuspb.StringResponse)(nil),                // 223: milvus.proto.milvus.StringResponse
+	(*milvuspb.GetFlushAllStateResponse)(nil),      // 224: milvus.proto.milvus.GetFlushAllStateResponse
+	(*internalpb.ShowConfigurationsResponse)(nil),  // 225: milvus.proto.internal.ShowConfigurationsResponse
+	(*milvuspb.GetMetricsResponse)(nil),            // 226: milvus.proto.milvus.GetMetricsResponse
+	(*milvuspb.ManualCompactionResponse)(nil),      // 227: milvus.proto.milvus.ManualCompactionResponse
+	(*milvuspb.GetCompactionStateResponse)(nil),    // 228: milvus.proto.milvus.GetCompactionStateResponse
+	(*milvuspb.GetCompactionPlansResponse)(nil),    // 229: milvus.proto.milvus.GetCompactionPlansResponse
+	(*milvuspb.GetFlushStateResponse)(nil),         // 230: milvus.proto.milvus.GetFlushStateResponse
+	(*milvuspb.CheckHealthResponse)(nil),           // 231: milvus.proto.milvus.CheckHealthResponse
+	(*indexpb.GetIndexStateResponse)(nil),          // 232: milvus.proto.index.GetIndexStateResponse
+	(*indexpb.GetSegmentIndexStateResponse)(nil),   // 233: milvus.proto.index.GetSegmentIndexStateResponse
+	(*indexpb.GetIndexInfoResponse)(nil),           // 234: milvus.proto.index.GetIndexInfoResponse
+	(*indexpb.DescribeIndexResponse)(nil),          // 235: milvus.proto.index.DescribeIndexResponse
+	(*indexpb.GetIndexStatisticsResponse)(nil),     // 236: milvus.proto.index.GetIndexStatisticsResponse
+	(*indexpb.GetIndexBuildProgressResponse)(nil),  // 237: milvus.proto.index.GetIndexBuildProgressResponse
+	(*indexpb.ListIndexesResponse)(nil),            // 238: milvus.proto.index.ListIndexesResponse
+	(*internalpb.ImportResponse)(nil),              // 239: milvus.proto.internal.ImportResponse
+	(*internalpb.GetImportProgressResponse)(nil),   // 240: milvus.proto.internal.GetImportProgressResponse
+	(*internalpb.ListImportsResponse)(nil),         // 241: milvus.proto.internal.ListImportsResponse
+	(*milvuspb.ListFileResourcesResponse)(nil),     // 242: milvus.proto.milvus.ListFileResourcesResponse
+	(*milvuspb.ComponentStates)(nil),               // 243: milvus.proto.milvus.ComponentStates
 }
 var file_data_coord_proto_depIdxs = []int32{
-	174, // 0: milvus.proto.data.FlushRequest.base:type_name -> milvus.proto.common.MsgBase
-	175, // 1: milvus.proto.data.FlushResponse.status:type_name -> milvus.proto.common.Status
+	175, // 0: milvus.proto.data.FlushRequest.base:type_name -> milvus.proto.common.MsgBase
+	176, // 1: milvus.proto.data.FlushResponse.status:type_name -> milvus.proto.common.Status
 	153, // 2: milvus.proto.data.FlushResponse.channel_cps:type_name -> milvus.proto.data.FlushResponse.ChannelCpsEntry
 	154, // 3: milvus.proto.data.FlushResult.channel_cps:type_name -> milvus.proto.data.FlushResult.ChannelCpsEntry
-	174, // 4: milvus.proto.data.FlushAllRequest.base:type_name -> milvus.proto.common.MsgBase
+	175, // 4: milvus.proto.data.FlushAllRequest.base:type_name -> milvus.proto.common.MsgBase
 	17,  // 5: milvus.proto.data.FlushAllRequest.flush_targets:type_name -> milvus.proto.data.FlushAllTarget
-	175, // 6: milvus.proto.data.FlushAllResponse.status:type_name -> milvus.proto.common.Status
+	176, // 6: milvus.proto.data.FlushAllResponse.status:type_name -> milvus.proto.common.Status
 	15,  // 7: milvus.proto.data.FlushAllResponse.flush_results:type_name -> milvus.proto.data.FlushResult
 	155, // 8: milvus.proto.data.FlushAllResponse.flush_all_msgs:type_name -> milvus.proto.data.FlushAllResponse.FlushAllMsgsEntry
-	176, // 9: milvus.proto.data.FlushAllResponse.cluster_info:type_name -> milvus.proto.milvus.ClusterInfo
-	174, // 10: milvus.proto.data.FlushChannelsRequest.base:type_name -> milvus.proto.common.MsgBase
+	177, // 9: milvus.proto.data.FlushAllResponse.cluster_info:type_name -> milvus.proto.milvus.ClusterInfo
+	175, // 10: milvus.proto.data.FlushChannelsRequest.base:type_name -> milvus.proto.common.MsgBase
 	1,   // 11: milvus.proto.data.SegmentIDRequest.level:type_name -> milvus.proto.data.SegmentLevel
 	42,  // 12: milvus.proto.data.AllocSegmentResponse.segment_info:type_name -> milvus.proto.data.SegmentInfo
-	175, // 13: milvus.proto.data.AllocSegmentResponse.status:type_name -> milvus.proto.common.Status
+	176, // 13: milvus.proto.data.AllocSegmentResponse.status:type_name -> milvus.proto.common.Status
 	20,  // 14: milvus.proto.data.AssignSegmentIDRequest.segmentIDRequests:type_name -> milvus.proto.data.SegmentIDRequest
-	175, // 15: milvus.proto.data.SegmentIDAssignment.status:type_name -> milvus.proto.common.Status
+	176, // 15: milvus.proto.data.SegmentIDAssignment.status:type_name -> milvus.proto.common.Status
 	24,  // 16: milvus.proto.data.AssignSegmentIDResponse.segIDAssignments:type_name -> milvus.proto.data.SegmentIDAssignment
-	175, // 17: milvus.proto.data.AssignSegmentIDResponse.status:type_name -> milvus.proto.common.Status
-	174, // 18: milvus.proto.data.GetSegmentStatesRequest.base:type_name -> milvus.proto.common.MsgBase
-	177, // 19: milvus.proto.data.SegmentStateInfo.state:type_name -> milvus.proto.common.SegmentState
-	178, // 20: milvus.proto.data.SegmentStateInfo.start_position:type_name -> milvus.proto.msg.MsgPosition
-	178, // 21: milvus.proto.data.SegmentStateInfo.end_position:type_name -> milvus.proto.msg.MsgPosition
-	175, // 22: milvus.proto.data.SegmentStateInfo.status:type_name -> milvus.proto.common.Status
-	175, // 23: milvus.proto.data.GetSegmentStatesResponse.status:type_name -> milvus.proto.common.Status
+	176, // 17: milvus.proto.data.AssignSegmentIDResponse.status:type_name -> milvus.proto.common.Status
+	175, // 18: milvus.proto.data.GetSegmentStatesRequest.base:type_name -> milvus.proto.common.MsgBase
+	178, // 19: milvus.proto.data.SegmentStateInfo.state:type_name -> milvus.proto.common.SegmentState
+	179, // 20: milvus.proto.data.SegmentStateInfo.start_position:type_name -> milvus.proto.msg.MsgPosition
+	179, // 21: milvus.proto.data.SegmentStateInfo.end_position:type_name -> milvus.proto.msg.MsgPosition
+	176, // 22: milvus.proto.data.SegmentStateInfo.status:type_name -> milvus.proto.common.Status
+	176, // 23: milvus.proto.data.GetSegmentStatesResponse.status:type_name -> milvus.proto.common.Status
 	27,  // 24: milvus.proto.data.GetSegmentStatesResponse.states:type_name -> milvus.proto.data.SegmentStateInfo
-	174, // 25: milvus.proto.data.GetSegmentInfoRequest.base:type_name -> milvus.proto.common.MsgBase
-	175, // 26: milvus.proto.data.GetSegmentInfoResponse.status:type_name -> milvus.proto.common.Status
+	175, // 25: milvus.proto.data.GetSegmentInfoRequest.base:type_name -> milvus.proto.common.MsgBase
+	176, // 26: milvus.proto.data.GetSegmentInfoResponse.status:type_name -> milvus.proto.common.Status
 	42,  // 27: milvus.proto.data.GetSegmentInfoResponse.infos:type_name -> milvus.proto.data.SegmentInfo
 	156, // 28: milvus.proto.data.GetSegmentInfoResponse.channel_checkpoint:type_name -> milvus.proto.data.GetSegmentInfoResponse.ChannelCheckpointEntry
-	174, // 29: milvus.proto.data.GetInsertBinlogPathsRequest.base:type_name -> milvus.proto.common.MsgBase
-	179, // 30: milvus.proto.data.GetInsertBinlogPathsResponse.paths:type_name -> milvus.proto.internal.StringList
-	175, // 31: milvus.proto.data.GetInsertBinlogPathsResponse.status:type_name -> milvus.proto.common.Status
-	174, // 32: milvus.proto.data.GetCollectionStatisticsRequest.base:type_name -> milvus.proto.common.MsgBase
-	180, // 33: milvus.proto.data.GetCollectionStatisticsResponse.stats:type_name -> milvus.proto.common.KeyValuePair
-	175, // 34: milvus.proto.data.GetCollectionStatisticsResponse.status:type_name -> milvus.proto.common.Status
-	174, // 35: milvus.proto.data.GetPartitionStatisticsRequest.base:type_name -> milvus.proto.common.MsgBase
-	180, // 36: milvus.proto.data.GetPartitionStatisticsResponse.stats:type_name -> milvus.proto.common.KeyValuePair
-	175, // 37: milvus.proto.data.GetPartitionStatisticsResponse.status:type_name -> milvus.proto.common.Status
-	178, // 38: milvus.proto.data.VchannelInfo.seek_position:type_name -> milvus.proto.msg.MsgPosition
+	175, // 29: milvus.proto.data.GetInsertBinlogPathsRequest.base:type_name -> milvus.proto.common.MsgBase
+	180, // 30: milvus.proto.data.GetInsertBinlogPathsResponse.paths:type_name -> milvus.proto.internal.StringList
+	176, // 31: milvus.proto.data.GetInsertBinlogPathsResponse.status:type_name -> milvus.proto.common.Status
+	175, // 32: milvus.proto.data.GetCollectionStatisticsRequest.base:type_name -> milvus.proto.common.MsgBase
+	181, // 33: milvus.proto.data.GetCollectionStatisticsResponse.stats:type_name -> milvus.proto.common.KeyValuePair
+	176, // 34: milvus.proto.data.GetCollectionStatisticsResponse.status:type_name -> milvus.proto.common.Status
+	175, // 35: milvus.proto.data.GetPartitionStatisticsRequest.base:type_name -> milvus.proto.common.MsgBase
+	181, // 36: milvus.proto.data.GetPartitionStatisticsResponse.stats:type_name -> milvus.proto.common.KeyValuePair
+	176, // 37: milvus.proto.data.GetPartitionStatisticsResponse.status:type_name -> milvus.proto.common.Status
+	179, // 38: milvus.proto.data.VchannelInfo.seek_position:type_name -> milvus.proto.msg.MsgPosition
 	42,  // 39: milvus.proto.data.VchannelInfo.unflushedSegments:type_name -> milvus.proto.data.SegmentInfo
 	42,  // 40: milvus.proto.data.VchannelInfo.flushedSegments:type_name -> milvus.proto.data.SegmentInfo
 	42,  // 41: milvus.proto.data.VchannelInfo.dropped_segments:type_name -> milvus.proto.data.SegmentInfo
 	42,  // 42: milvus.proto.data.VchannelInfo.indexed_segments:type_name -> milvus.proto.data.SegmentInfo
 	157, // 43: milvus.proto.data.VchannelInfo.partition_stats_versions:type_name -> milvus.proto.data.VchannelInfo.PartitionStatsVersionsEntry
-	178, // 44: milvus.proto.data.VchannelInfo.delete_checkpoint:type_name -> milvus.proto.msg.MsgPosition
-	174, // 45: milvus.proto.data.WatchDmChannelsRequest.base:type_name -> milvus.proto.common.MsgBase
+	179, // 44: milvus.proto.data.VchannelInfo.delete_checkpoint:type_name -> milvus.proto.msg.MsgPosition
+	175, // 45: milvus.proto.data.WatchDmChannelsRequest.base:type_name -> milvus.proto.common.MsgBase
 	38,  // 46: milvus.proto.data.WatchDmChannelsRequest.vchannels:type_name -> milvus.proto.data.VchannelInfo
-	174, // 47: milvus.proto.data.FlushSegmentsRequest.base:type_name -> milvus.proto.common.MsgBase
-	174, // 48: milvus.proto.data.SegmentMsg.base:type_name -> milvus.proto.common.MsgBase
+	175, // 47: milvus.proto.data.FlushSegmentsRequest.base:type_name -> milvus.proto.common.MsgBase
+	175, // 48: milvus.proto.data.SegmentMsg.base:type_name -> milvus.proto.common.MsgBase
 	42,  // 49: milvus.proto.data.SegmentMsg.segment:type_name -> milvus.proto.data.SegmentInfo
-	177, // 50: milvus.proto.data.SegmentInfo.state:type_name -> milvus.proto.common.SegmentState
-	178, // 51: milvus.proto.data.SegmentInfo.start_position:type_name -> milvus.proto.msg.MsgPosition
-	178, // 52: milvus.proto.data.SegmentInfo.dml_position:type_name -> milvus.proto.msg.MsgPosition
+	178, // 50: milvus.proto.data.SegmentInfo.state:type_name -> milvus.proto.common.SegmentState
+	179, // 51: milvus.proto.data.SegmentInfo.start_position:type_name -> milvus.proto.msg.MsgPosition
+	179, // 52: milvus.proto.data.SegmentInfo.dml_position:type_name -> milvus.proto.msg.MsgPosition
 	50,  // 53: milvus.proto.data.SegmentInfo.binlogs:type_name -> milvus.proto.data.FieldBinlog
 	50,  // 54: milvus.proto.data.SegmentInfo.statslogs:type_name -> milvus.proto.data.FieldBinlog
 	50,  // 55: milvus.proto.data.SegmentInfo.deltalogs:type_name -> milvus.proto.data.FieldBinlog
@@ -15501,8 +15521,8 @@ var file_data_coord_proto_depIdxs = []int32{
 	158, // 58: milvus.proto.data.SegmentInfo.textStatsLogs:type_name -> milvus.proto.data.SegmentInfo.TextStatsLogsEntry
 	50,  // 59: milvus.proto.data.SegmentInfo.bm25statslogs:type_name -> milvus.proto.data.FieldBinlog
 	159, // 60: milvus.proto.data.SegmentInfo.jsonKeyStats:type_name -> milvus.proto.data.SegmentInfo.JsonKeyStatsEntry
-	178, // 61: milvus.proto.data.SegmentStartPosition.start_position:type_name -> milvus.proto.msg.MsgPosition
-	174, // 62: milvus.proto.data.SaveBinlogPathsRequest.base:type_name -> milvus.proto.common.MsgBase
+	179, // 61: milvus.proto.data.SegmentStartPosition.start_position:type_name -> milvus.proto.msg.MsgPosition
+	175, // 62: milvus.proto.data.SaveBinlogPathsRequest.base:type_name -> milvus.proto.common.MsgBase
 	50,  // 63: milvus.proto.data.SaveBinlogPathsRequest.field2BinlogPaths:type_name -> milvus.proto.data.FieldBinlog
 	45,  // 64: milvus.proto.data.SaveBinlogPathsRequest.checkPoints:type_name -> milvus.proto.data.CheckPoint
 	43,  // 65: milvus.proto.data.SaveBinlogPathsRequest.start_positions:type_name -> milvus.proto.data.SegmentStartPosition
@@ -15510,7 +15530,7 @@ var file_data_coord_proto_depIdxs = []int32{
 	50,  // 67: milvus.proto.data.SaveBinlogPathsRequest.deltalogs:type_name -> milvus.proto.data.FieldBinlog
 	1,   // 68: milvus.proto.data.SaveBinlogPathsRequest.seg_level:type_name -> milvus.proto.data.SegmentLevel
 	50,  // 69: milvus.proto.data.SaveBinlogPathsRequest.field2Bm25logPaths:type_name -> milvus.proto.data.FieldBinlog
-	178, // 70: milvus.proto.data.CheckPoint.position:type_name -> milvus.proto.msg.MsgPosition
+	179, // 70: milvus.proto.data.CheckPoint.position:type_name -> milvus.proto.msg.MsgPosition
 	2,   // 71: milvus.proto.data.ChannelStatus.state:type_name -> milvus.proto.data.ChannelWatchState
 	47,  // 72: milvus.proto.data.DataNodeInfo.channels:type_name -> milvus.proto.data.ChannelStatus
 	50,  // 73: milvus.proto.data.SegmentBinlogs.fieldBinlogs:type_name -> milvus.proto.data.FieldBinlog
@@ -15518,386 +15538,387 @@ var file_data_coord_proto_depIdxs = []int32{
 	50,  // 75: milvus.proto.data.SegmentBinlogs.deltalogs:type_name -> milvus.proto.data.FieldBinlog
 	160, // 76: milvus.proto.data.SegmentBinlogs.textStatsLogs:type_name -> milvus.proto.data.SegmentBinlogs.TextStatsLogsEntry
 	53,  // 77: milvus.proto.data.FieldBinlog.binlogs:type_name -> milvus.proto.data.Binlog
-	175, // 78: milvus.proto.data.GetRecoveryInfoResponse.status:type_name -> milvus.proto.common.Status
-	38,  // 79: milvus.proto.data.GetRecoveryInfoResponse.channels:type_name -> milvus.proto.data.VchannelInfo
-	49,  // 80: milvus.proto.data.GetRecoveryInfoResponse.binlogs:type_name -> milvus.proto.data.SegmentBinlogs
-	174, // 81: milvus.proto.data.GetRecoveryInfoRequest.base:type_name -> milvus.proto.common.MsgBase
-	175, // 82: milvus.proto.data.GetRecoveryInfoResponseV2.status:type_name -> milvus.proto.common.Status
-	38,  // 83: milvus.proto.data.GetRecoveryInfoResponseV2.channels:type_name -> milvus.proto.data.VchannelInfo
-	42,  // 84: milvus.proto.data.GetRecoveryInfoResponseV2.segments:type_name -> milvus.proto.data.SegmentInfo
-	174, // 85: milvus.proto.data.GetRecoveryInfoRequestV2.base:type_name -> milvus.proto.common.MsgBase
-	174, // 86: milvus.proto.data.GetChannelRecoveryInfoRequest.base:type_name -> milvus.proto.common.MsgBase
-	175, // 87: milvus.proto.data.GetChannelRecoveryInfoResponse.status:type_name -> milvus.proto.common.Status
-	38,  // 88: milvus.proto.data.GetChannelRecoveryInfoResponse.info:type_name -> milvus.proto.data.VchannelInfo
-	181, // 89: milvus.proto.data.GetChannelRecoveryInfoResponse.schema:type_name -> milvus.proto.schema.CollectionSchema
-	60,  // 90: milvus.proto.data.GetChannelRecoveryInfoResponse.segments_not_created_by_streaming:type_name -> milvus.proto.data.SegmentNotCreatedByStreaming
-	174, // 91: milvus.proto.data.GetSegmentsByStatesRequest.base:type_name -> milvus.proto.common.MsgBase
-	177, // 92: milvus.proto.data.GetSegmentsByStatesRequest.states:type_name -> milvus.proto.common.SegmentState
-	175, // 93: milvus.proto.data.GetSegmentsByStatesResponse.status:type_name -> milvus.proto.common.Status
-	174, // 94: milvus.proto.data.GetFlushedSegmentsRequest.base:type_name -> milvus.proto.common.MsgBase
-	175, // 95: milvus.proto.data.GetFlushedSegmentsResponse.status:type_name -> milvus.proto.common.Status
-	174, // 96: milvus.proto.data.SegmentFlushCompletedMsg.base:type_name -> milvus.proto.common.MsgBase
-	42,  // 97: milvus.proto.data.SegmentFlushCompletedMsg.segment:type_name -> milvus.proto.data.SegmentInfo
-	38,  // 98: milvus.proto.data.ChannelWatchInfo.vchan:type_name -> milvus.proto.data.VchannelInfo
-	2,   // 99: milvus.proto.data.ChannelWatchInfo.state:type_name -> milvus.proto.data.ChannelWatchState
-	181, // 100: milvus.proto.data.ChannelWatchInfo.schema:type_name -> milvus.proto.schema.CollectionSchema
-	180, // 101: milvus.proto.data.ChannelWatchInfo.dbProperties:type_name -> milvus.proto.common.KeyValuePair
-	174, // 102: milvus.proto.data.CompactionStateRequest.base:type_name -> milvus.proto.common.MsgBase
-	50,  // 103: milvus.proto.data.SyncSegmentInfo.pk_stats_log:type_name -> milvus.proto.data.FieldBinlog
-	177, // 104: milvus.proto.data.SyncSegmentInfo.state:type_name -> milvus.proto.common.SegmentState
-	1,   // 105: milvus.proto.data.SyncSegmentInfo.level:type_name -> milvus.proto.data.SegmentLevel
-	50,  // 106: milvus.proto.data.SyncSegmentsRequest.stats_logs:type_name -> milvus.proto.data.FieldBinlog
-	161, // 107: milvus.proto.data.SyncSegmentsRequest.segment_infos:type_name -> milvus.proto.data.SyncSegmentsRequest.SegmentInfosEntry
-	50,  // 108: milvus.proto.data.CompactionSegmentBinlogs.fieldBinlogs:type_name -> milvus.proto.data.FieldBinlog
-	50,  // 109: milvus.proto.data.CompactionSegmentBinlogs.field2StatslogPaths:type_name -> milvus.proto.data.FieldBinlog
-	50,  // 110: milvus.proto.data.CompactionSegmentBinlogs.deltalogs:type_name -> milvus.proto.data.FieldBinlog
-	1,   // 111: milvus.proto.data.CompactionSegmentBinlogs.level:type_name -> milvus.proto.data.SegmentLevel
-	70,  // 112: milvus.proto.data.CompactionPlan.segmentBinlogs:type_name -> milvus.proto.data.CompactionSegmentBinlogs
-	3,   // 113: milvus.proto.data.CompactionPlan.type:type_name -> milvus.proto.data.CompactionType
-	181, // 114: milvus.proto.data.CompactionPlan.schema:type_name -> milvus.proto.schema.CollectionSchema
-	98,  // 115: milvus.proto.data.CompactionPlan.pre_allocated_segmentIDs:type_name -> milvus.proto.data.IDRange
-	98,  // 116: milvus.proto.data.CompactionPlan.pre_allocated_logIDs:type_name -> milvus.proto.data.IDRange
-	180, // 117: milvus.proto.data.CompactionPlan.plugin_context:type_name -> milvus.proto.common.KeyValuePair
-	182, // 118: milvus.proto.data.CompactionPlan.file_resources:type_name -> milvus.proto.internal.FileResourceInfo
-	50,  // 119: milvus.proto.data.CompactionSegment.insert_logs:type_name -> milvus.proto.data.FieldBinlog
-	50,  // 120: milvus.proto.data.CompactionSegment.field2StatslogPaths:type_name -> milvus.proto.data.FieldBinlog
-	50,  // 121: milvus.proto.data.CompactionSegment.deltalogs:type_name -> milvus.proto.data.FieldBinlog
-	50,  // 122: milvus.proto.data.CompactionSegment.bm25logs:type_name -> milvus.proto.data.FieldBinlog
-	162, // 123: milvus.proto.data.CompactionSegment.text_stats_logs:type_name -> milvus.proto.data.CompactionSegment.TextStatsLogsEntry
-	11,  // 124: milvus.proto.data.CompactionPlanResult.state:type_name -> milvus.proto.data.CompactionTaskState
-	72,  // 125: milvus.proto.data.CompactionPlanResult.segments:type_name -> milvus.proto.data.CompactionSegment
-	3,   // 126: milvus.proto.data.CompactionPlanResult.type:type_name -> milvus.proto.data.CompactionType
-	175, // 127: milvus.proto.data.CompactionStateResponse.status:type_name -> milvus.proto.common.Status
-	73,  // 128: milvus.proto.data.CompactionStateResponse.results:type_name -> milvus.proto.data.CompactionPlanResult
-	183, // 129: milvus.proto.data.WatchChannelsRequest.start_positions:type_name -> milvus.proto.common.KeyDataPair
-	181, // 130: milvus.proto.data.WatchChannelsRequest.schema:type_name -> milvus.proto.schema.CollectionSchema
-	180, // 131: milvus.proto.data.WatchChannelsRequest.db_properties:type_name -> milvus.proto.common.KeyValuePair
-	175, // 132: milvus.proto.data.WatchChannelsResponse.status:type_name -> milvus.proto.common.Status
-	174, // 133: milvus.proto.data.SetSegmentStateRequest.base:type_name -> milvus.proto.common.MsgBase
-	177, // 134: milvus.proto.data.SetSegmentStateRequest.new_state:type_name -> milvus.proto.common.SegmentState
-	175, // 135: milvus.proto.data.SetSegmentStateResponse.status:type_name -> milvus.proto.common.Status
-	174, // 136: milvus.proto.data.DropVirtualChannelRequest.base:type_name -> milvus.proto.common.MsgBase
-	81,  // 137: milvus.proto.data.DropVirtualChannelRequest.segments:type_name -> milvus.proto.data.DropVirtualChannelSegment
-	50,  // 138: milvus.proto.data.DropVirtualChannelSegment.field2BinlogPaths:type_name -> milvus.proto.data.FieldBinlog
-	50,  // 139: milvus.proto.data.DropVirtualChannelSegment.field2StatslogPaths:type_name -> milvus.proto.data.FieldBinlog
-	50,  // 140: milvus.proto.data.DropVirtualChannelSegment.deltalogs:type_name -> milvus.proto.data.FieldBinlog
-	178, // 141: milvus.proto.data.DropVirtualChannelSegment.startPosition:type_name -> milvus.proto.msg.MsgPosition
-	178, // 142: milvus.proto.data.DropVirtualChannelSegment.checkPoint:type_name -> milvus.proto.msg.MsgPosition
-	175, // 143: milvus.proto.data.DropVirtualChannelResponse.status:type_name -> milvus.proto.common.Status
-	174, // 144: milvus.proto.data.UpdateSegmentStatisticsRequest.base:type_name -> milvus.proto.common.MsgBase
-	184, // 145: milvus.proto.data.UpdateSegmentStatisticsRequest.stats:type_name -> milvus.proto.common.SegmentStats
-	174, // 146: milvus.proto.data.UpdateChannelCheckpointRequest.base:type_name -> milvus.proto.common.MsgBase
-	178, // 147: milvus.proto.data.UpdateChannelCheckpointRequest.position:type_name -> milvus.proto.msg.MsgPosition
-	178, // 148: milvus.proto.data.UpdateChannelCheckpointRequest.channel_checkpoints:type_name -> milvus.proto.msg.MsgPosition
-	174, // 149: milvus.proto.data.ResendSegmentStatsRequest.base:type_name -> milvus.proto.common.MsgBase
-	175, // 150: milvus.proto.data.ResendSegmentStatsResponse.status:type_name -> milvus.proto.common.Status
-	174, // 151: milvus.proto.data.MarkSegmentsDroppedRequest.base:type_name -> milvus.proto.common.MsgBase
-	181, // 152: milvus.proto.data.AlterCollectionRequest.schema:type_name -> milvus.proto.schema.CollectionSchema
-	183, // 153: milvus.proto.data.AlterCollectionRequest.start_positions:type_name -> milvus.proto.common.KeyDataPair
-	180, // 154: milvus.proto.data.AlterCollectionRequest.properties:type_name -> milvus.proto.common.KeyValuePair
-	185, // 155: milvus.proto.data.AddCollectionFieldRequest.field_schema:type_name -> milvus.proto.schema.FieldSchema
-	181, // 156: milvus.proto.data.AddCollectionFieldRequest.schema:type_name -> milvus.proto.schema.CollectionSchema
-	183, // 157: milvus.proto.data.AddCollectionFieldRequest.start_positions:type_name -> milvus.proto.common.KeyDataPair
-	180, // 158: milvus.proto.data.AddCollectionFieldRequest.properties:type_name -> milvus.proto.common.KeyValuePair
-	175, // 159: milvus.proto.data.GcConfirmResponse.status:type_name -> milvus.proto.common.Status
-	174, // 160: milvus.proto.data.ReportDataNodeTtMsgsRequest.base:type_name -> milvus.proto.common.MsgBase
-	186, // 161: milvus.proto.data.ReportDataNodeTtMsgsRequest.msgs:type_name -> milvus.proto.msg.DataNodeTtMsg
-	66,  // 162: milvus.proto.data.ChannelOperationsRequest.infos:type_name -> milvus.proto.data.ChannelWatchInfo
-	175, // 163: milvus.proto.data.ChannelOperationProgressResponse.status:type_name -> milvus.proto.common.Status
-	2,   // 164: milvus.proto.data.ChannelOperationProgressResponse.state:type_name -> milvus.proto.data.ChannelWatchState
-	181, // 165: milvus.proto.data.PreImportRequest.schema:type_name -> milvus.proto.schema.CollectionSchema
-	187, // 166: milvus.proto.data.PreImportRequest.import_files:type_name -> milvus.proto.internal.ImportFile
-	180, // 167: milvus.proto.data.PreImportRequest.options:type_name -> milvus.proto.common.KeyValuePair
-	188, // 168: milvus.proto.data.PreImportRequest.storage_config:type_name -> milvus.proto.index.StorageConfig
-	180, // 169: milvus.proto.data.PreImportRequest.plugin_context:type_name -> milvus.proto.common.KeyValuePair
-	181, // 170: milvus.proto.data.ImportRequest.schema:type_name -> milvus.proto.schema.CollectionSchema
-	187, // 171: milvus.proto.data.ImportRequest.files:type_name -> milvus.proto.internal.ImportFile
-	180, // 172: milvus.proto.data.ImportRequest.options:type_name -> milvus.proto.common.KeyValuePair
-	98,  // 173: milvus.proto.data.ImportRequest.ID_range:type_name -> milvus.proto.data.IDRange
-	99,  // 174: milvus.proto.data.ImportRequest.request_segments:type_name -> milvus.proto.data.ImportRequestSegment
-	188, // 175: milvus.proto.data.ImportRequest.storage_config:type_name -> milvus.proto.index.StorageConfig
-	180, // 176: milvus.proto.data.ImportRequest.plugin_context:type_name -> milvus.proto.common.KeyValuePair
-	163, // 177: milvus.proto.data.PartitionImportStats.partition_rows:type_name -> milvus.proto.data.PartitionImportStats.PartitionRowsEntry
-	164, // 178: milvus.proto.data.PartitionImportStats.partition_data_size:type_name -> milvus.proto.data.PartitionImportStats.PartitionDataSizeEntry
-	187, // 179: milvus.proto.data.ImportFileStats.import_file:type_name -> milvus.proto.internal.ImportFile
-	165, // 180: milvus.proto.data.ImportFileStats.hashed_stats:type_name -> milvus.proto.data.ImportFileStats.HashedStatsEntry
-	175, // 181: milvus.proto.data.QueryPreImportResponse.status:type_name -> milvus.proto.common.Status
-	8,   // 182: milvus.proto.data.QueryPreImportResponse.state:type_name -> milvus.proto.data.ImportTaskStateV2
-	103, // 183: milvus.proto.data.QueryPreImportResponse.file_stats:type_name -> milvus.proto.data.ImportFileStats
-	50,  // 184: milvus.proto.data.ImportSegmentInfo.binlogs:type_name -> milvus.proto.data.FieldBinlog
-	50,  // 185: milvus.proto.data.ImportSegmentInfo.statslogs:type_name -> milvus.proto.data.FieldBinlog
-	50,  // 186: milvus.proto.data.ImportSegmentInfo.deltalogs:type_name -> milvus.proto.data.FieldBinlog
-	50,  // 187: milvus.proto.data.ImportSegmentInfo.bm25logs:type_name -> milvus.proto.data.FieldBinlog
-	175, // 188: milvus.proto.data.QueryImportResponse.status:type_name -> milvus.proto.common.Status
-	8,   // 189: milvus.proto.data.QueryImportResponse.state:type_name -> milvus.proto.data.ImportTaskStateV2
-	106, // 190: milvus.proto.data.QueryImportResponse.import_segments_info:type_name -> milvus.proto.data.ImportSegmentInfo
-	50,  // 191: milvus.proto.data.CopySegmentSource.insert_binlogs:type_name -> milvus.proto.data.FieldBinlog
-	50,  // 192: milvus.proto.data.CopySegmentSource.stats_binlogs:type_name -> milvus.proto.data.FieldBinlog
-	50,  // 193: milvus.proto.data.CopySegmentSource.delta_binlogs:type_name -> milvus.proto.data.FieldBinlog
-	189, // 194: milvus.proto.data.CopySegmentSource.index_files:type_name -> milvus.proto.index.IndexFilePathInfo
-	50,  // 195: milvus.proto.data.CopySegmentSource.bm25_binlogs:type_name -> milvus.proto.data.FieldBinlog
-	166, // 196: milvus.proto.data.CopySegmentSource.text_index_files:type_name -> milvus.proto.data.CopySegmentSource.TextIndexFilesEntry
-	167, // 197: milvus.proto.data.CopySegmentSource.json_key_index_files:type_name -> milvus.proto.data.CopySegmentSource.JsonKeyIndexFilesEntry
-	109, // 198: milvus.proto.data.CopySegmentRequest.sources:type_name -> milvus.proto.data.CopySegmentSource
-	110, // 199: milvus.proto.data.CopySegmentRequest.targets:type_name -> milvus.proto.data.CopySegmentTarget
-	188, // 200: milvus.proto.data.CopySegmentRequest.storage_config:type_name -> milvus.proto.index.StorageConfig
-	175, // 201: milvus.proto.data.QueryCopySegmentResponse.status:type_name -> milvus.proto.common.Status
-	5,   // 202: milvus.proto.data.QueryCopySegmentResponse.state:type_name -> milvus.proto.data.CopySegmentTaskState
-	116, // 203: milvus.proto.data.QueryCopySegmentResponse.segment_results:type_name -> milvus.proto.data.CopySegmentResult
-	50,  // 204: milvus.proto.data.CopySegmentResult.binlogs:type_name -> milvus.proto.data.FieldBinlog
-	50,  // 205: milvus.proto.data.CopySegmentResult.statslogs:type_name -> milvus.proto.data.FieldBinlog
-	50,  // 206: milvus.proto.data.CopySegmentResult.deltalogs:type_name -> milvus.proto.data.FieldBinlog
-	50,  // 207: milvus.proto.data.CopySegmentResult.bm25logs:type_name -> milvus.proto.data.FieldBinlog
-	168, // 208: milvus.proto.data.CopySegmentResult.index_infos:type_name -> milvus.proto.data.CopySegmentResult.IndexInfosEntry
-	169, // 209: milvus.proto.data.CopySegmentResult.text_index_infos:type_name -> milvus.proto.data.CopySegmentResult.TextIndexInfosEntry
-	170, // 210: milvus.proto.data.CopySegmentResult.json_key_index_infos:type_name -> milvus.proto.data.CopySegmentResult.JsonKeyIndexInfosEntry
-	5,   // 211: milvus.proto.data.CopySegmentTask.state:type_name -> milvus.proto.data.CopySegmentTaskState
-	118, // 212: milvus.proto.data.CopySegmentTask.id_mappings:type_name -> milvus.proto.data.CopySegmentIDMapping
-	4,   // 213: milvus.proto.data.CopySegmentJob.state:type_name -> milvus.proto.data.CopySegmentJobState
-	118, // 214: milvus.proto.data.CopySegmentJob.id_mappings:type_name -> milvus.proto.data.CopySegmentIDMapping
-	180, // 215: milvus.proto.data.CopySegmentJob.options:type_name -> milvus.proto.common.KeyValuePair
-	181, // 216: milvus.proto.data.ImportJob.schema:type_name -> milvus.proto.schema.CollectionSchema
-	190, // 217: milvus.proto.data.ImportJob.state:type_name -> milvus.proto.internal.ImportJobState
-	187, // 218: milvus.proto.data.ImportJob.files:type_name -> milvus.proto.internal.ImportFile
-	180, // 219: milvus.proto.data.ImportJob.options:type_name -> milvus.proto.common.KeyValuePair
-	8,   // 220: milvus.proto.data.PreImportTask.state:type_name -> milvus.proto.data.ImportTaskStateV2
-	103, // 221: milvus.proto.data.PreImportTask.file_stats:type_name -> milvus.proto.data.ImportFileStats
-	8,   // 222: milvus.proto.data.ImportTaskV2.state:type_name -> milvus.proto.data.ImportTaskStateV2
-	103, // 223: milvus.proto.data.ImportTaskV2.file_stats:type_name -> milvus.proto.data.ImportFileStats
-	9,   // 224: milvus.proto.data.ImportTaskV2.source:type_name -> milvus.proto.data.ImportTaskSourceV2
-	174, // 225: milvus.proto.data.GcControlRequest.base:type_name -> milvus.proto.common.MsgBase
-	10,  // 226: milvus.proto.data.GcControlRequest.command:type_name -> milvus.proto.data.GcCommand
-	180, // 227: milvus.proto.data.GcControlRequest.params:type_name -> milvus.proto.common.KeyValuePair
-	175, // 228: milvus.proto.data.QuerySlotResponse.status:type_name -> milvus.proto.common.Status
-	3,   // 229: milvus.proto.data.CompactionTask.type:type_name -> milvus.proto.data.CompactionType
-	11,  // 230: milvus.proto.data.CompactionTask.state:type_name -> milvus.proto.data.CompactionTaskState
-	178, // 231: milvus.proto.data.CompactionTask.pos:type_name -> milvus.proto.msg.MsgPosition
-	181, // 232: milvus.proto.data.CompactionTask.schema:type_name -> milvus.proto.schema.CollectionSchema
-	185, // 233: milvus.proto.data.CompactionTask.clustering_key_field:type_name -> milvus.proto.schema.FieldSchema
-	98,  // 234: milvus.proto.data.CompactionTask.pre_allocated_segmentIDs:type_name -> milvus.proto.data.IDRange
-	175, // 235: milvus.proto.data.CreateExternalCollectionResponse.status:type_name -> milvus.proto.common.Status
-	174, // 236: milvus.proto.data.UpdateExternalCollectionRequest.base:type_name -> milvus.proto.common.MsgBase
-	42,  // 237: milvus.proto.data.UpdateExternalCollectionRequest.currentSegments:type_name -> milvus.proto.data.SegmentInfo
-	175, // 238: milvus.proto.data.UpdateExternalCollectionResponse.status:type_name -> milvus.proto.common.Status
-	42,  // 239: milvus.proto.data.UpdateExternalCollectionResponse.updatedSegments:type_name -> milvus.proto.data.SegmentInfo
-	191, // 240: milvus.proto.data.UpdateExternalCollectionResponse.state:type_name -> milvus.proto.index.JobState
-	174, // 241: milvus.proto.data.CreateSnapshotRequest.base:type_name -> milvus.proto.common.MsgBase
-	174, // 242: milvus.proto.data.DropSnapshotRequest.base:type_name -> milvus.proto.common.MsgBase
-	174, // 243: milvus.proto.data.ListSnapshotsRequest.base:type_name -> milvus.proto.common.MsgBase
-	175, // 244: milvus.proto.data.ListSnapshotsResponse.status:type_name -> milvus.proto.common.Status
-	1,   // 245: milvus.proto.data.SegmentDescription.segment_level:type_name -> milvus.proto.data.SegmentLevel
-	50,  // 246: milvus.proto.data.SegmentDescription.binlogs:type_name -> milvus.proto.data.FieldBinlog
-	50,  // 247: milvus.proto.data.SegmentDescription.deltalogs:type_name -> milvus.proto.data.FieldBinlog
-	50,  // 248: milvus.proto.data.SegmentDescription.statslogs:type_name -> milvus.proto.data.FieldBinlog
-	50,  // 249: milvus.proto.data.SegmentDescription.bm25_statslogs:type_name -> milvus.proto.data.FieldBinlog
-	171, // 250: milvus.proto.data.SegmentDescription.text_index_files:type_name -> milvus.proto.data.SegmentDescription.TextIndexFilesEntry
-	172, // 251: milvus.proto.data.SegmentDescription.json_key_index_files:type_name -> milvus.proto.data.SegmentDescription.JsonKeyIndexFilesEntry
-	189, // 252: milvus.proto.data.SegmentDescription.index_files:type_name -> milvus.proto.index.IndexFilePathInfo
-	178, // 253: milvus.proto.data.SegmentDescription.start_position:type_name -> milvus.proto.msg.MsgPosition
-	178, // 254: milvus.proto.data.SegmentDescription.dml_position:type_name -> milvus.proto.msg.MsgPosition
-	181, // 255: milvus.proto.data.CollectionDescription.schema:type_name -> milvus.proto.schema.CollectionSchema
-	192, // 256: milvus.proto.data.CollectionDescription.consistency_level:type_name -> milvus.proto.common.ConsistencyLevel
-	180, // 257: milvus.proto.data.CollectionDescription.properties:type_name -> milvus.proto.common.KeyValuePair
-	173, // 258: milvus.proto.data.CollectionDescription.partitions:type_name -> milvus.proto.data.CollectionDescription.PartitionsEntry
-	6,   // 259: milvus.proto.data.SnapshotInfo.state:type_name -> milvus.proto.data.SnapshotState
-	141, // 260: milvus.proto.data.SnapshotMetadata.snapshot_info:type_name -> milvus.proto.data.SnapshotInfo
-	140, // 261: milvus.proto.data.SnapshotMetadata.collection:type_name -> milvus.proto.data.CollectionDescription
-	193, // 262: milvus.proto.data.SnapshotMetadata.indexes:type_name -> milvus.proto.index.IndexInfo
-	142, // 263: milvus.proto.data.SnapshotMetadata.storagev2_manifest_list:type_name -> milvus.proto.data.StorageV2SegmentManifest
-	7,   // 264: milvus.proto.data.RestoreSnapshotInfo.state:type_name -> milvus.proto.data.RestoreSnapshotState
-	174, // 265: milvus.proto.data.DescribeSnapshotRequest.base:type_name -> milvus.proto.common.MsgBase
-	175, // 266: milvus.proto.data.DescribeSnapshotResponse.status:type_name -> milvus.proto.common.Status
-	141, // 267: milvus.proto.data.DescribeSnapshotResponse.snapshot_info:type_name -> milvus.proto.data.SnapshotInfo
-	140, // 268: milvus.proto.data.DescribeSnapshotResponse.collection_info:type_name -> milvus.proto.data.CollectionDescription
-	193, // 269: milvus.proto.data.DescribeSnapshotResponse.index_infos:type_name -> milvus.proto.index.IndexInfo
-	174, // 270: milvus.proto.data.RestoreSnapshotRequest.base:type_name -> milvus.proto.common.MsgBase
-	175, // 271: milvus.proto.data.RestoreSnapshotResponse.status:type_name -> milvus.proto.common.Status
-	174, // 272: milvus.proto.data.GetRestoreSnapshotStateRequest.base:type_name -> milvus.proto.common.MsgBase
-	175, // 273: milvus.proto.data.GetRestoreSnapshotStateResponse.status:type_name -> milvus.proto.common.Status
-	144, // 274: milvus.proto.data.GetRestoreSnapshotStateResponse.info:type_name -> milvus.proto.data.RestoreSnapshotInfo
-	174, // 275: milvus.proto.data.ListRestoreSnapshotJobsRequest.base:type_name -> milvus.proto.common.MsgBase
-	175, // 276: milvus.proto.data.ListRestoreSnapshotJobsResponse.status:type_name -> milvus.proto.common.Status
-	144, // 277: milvus.proto.data.ListRestoreSnapshotJobsResponse.jobs:type_name -> milvus.proto.data.RestoreSnapshotInfo
-	178, // 278: milvus.proto.data.FlushResponse.ChannelCpsEntry.value:type_name -> milvus.proto.msg.MsgPosition
-	178, // 279: milvus.proto.data.FlushResult.ChannelCpsEntry.value:type_name -> milvus.proto.msg.MsgPosition
-	194, // 280: milvus.proto.data.FlushAllResponse.FlushAllMsgsEntry.value:type_name -> milvus.proto.common.ImmutableMessage
-	178, // 281: milvus.proto.data.GetSegmentInfoResponse.ChannelCheckpointEntry.value:type_name -> milvus.proto.msg.MsgPosition
-	51,  // 282: milvus.proto.data.SegmentInfo.TextStatsLogsEntry.value:type_name -> milvus.proto.data.TextIndexStats
-	52,  // 283: milvus.proto.data.SegmentInfo.JsonKeyStatsEntry.value:type_name -> milvus.proto.data.JsonKeyStats
-	51,  // 284: milvus.proto.data.SegmentBinlogs.TextStatsLogsEntry.value:type_name -> milvus.proto.data.TextIndexStats
-	68,  // 285: milvus.proto.data.SyncSegmentsRequest.SegmentInfosEntry.value:type_name -> milvus.proto.data.SyncSegmentInfo
-	51,  // 286: milvus.proto.data.CompactionSegment.TextStatsLogsEntry.value:type_name -> milvus.proto.data.TextIndexStats
-	102, // 287: milvus.proto.data.ImportFileStats.HashedStatsEntry.value:type_name -> milvus.proto.data.PartitionImportStats
-	51,  // 288: milvus.proto.data.CopySegmentSource.TextIndexFilesEntry.value:type_name -> milvus.proto.data.TextIndexStats
-	52,  // 289: milvus.proto.data.CopySegmentSource.JsonKeyIndexFilesEntry.value:type_name -> milvus.proto.data.JsonKeyStats
-	115, // 290: milvus.proto.data.CopySegmentResult.IndexInfosEntry.value:type_name -> milvus.proto.data.VectorScalarIndexInfo
-	51,  // 291: milvus.proto.data.CopySegmentResult.TextIndexInfosEntry.value:type_name -> milvus.proto.data.TextIndexStats
-	52,  // 292: milvus.proto.data.CopySegmentResult.JsonKeyIndexInfosEntry.value:type_name -> milvus.proto.data.JsonKeyStats
-	51,  // 293: milvus.proto.data.SegmentDescription.TextIndexFilesEntry.value:type_name -> milvus.proto.data.TextIndexStats
-	52,  // 294: milvus.proto.data.SegmentDescription.JsonKeyIndexFilesEntry.value:type_name -> milvus.proto.data.JsonKeyStats
-	13,  // 295: milvus.proto.data.DataCoord.Flush:input_type -> milvus.proto.data.FlushRequest
-	16,  // 296: milvus.proto.data.DataCoord.FlushAll:input_type -> milvus.proto.data.FlushAllRequest
-	195, // 297: milvus.proto.data.DataCoord.CreateExternalCollection:input_type -> milvus.proto.msg.CreateCollectionRequest
-	21,  // 298: milvus.proto.data.DataCoord.AllocSegment:input_type -> milvus.proto.data.AllocSegmentRequest
-	23,  // 299: milvus.proto.data.DataCoord.AssignSegmentID:input_type -> milvus.proto.data.AssignSegmentIDRequest
-	29,  // 300: milvus.proto.data.DataCoord.GetSegmentInfo:input_type -> milvus.proto.data.GetSegmentInfoRequest
-	26,  // 301: milvus.proto.data.DataCoord.GetSegmentStates:input_type -> milvus.proto.data.GetSegmentStatesRequest
-	31,  // 302: milvus.proto.data.DataCoord.GetInsertBinlogPaths:input_type -> milvus.proto.data.GetInsertBinlogPathsRequest
-	33,  // 303: milvus.proto.data.DataCoord.GetCollectionStatistics:input_type -> milvus.proto.data.GetCollectionStatisticsRequest
-	35,  // 304: milvus.proto.data.DataCoord.GetPartitionStatistics:input_type -> milvus.proto.data.GetPartitionStatisticsRequest
-	37,  // 305: milvus.proto.data.DataCoord.GetSegmentInfoChannel:input_type -> milvus.proto.data.GetSegmentInfoChannelRequest
-	44,  // 306: milvus.proto.data.DataCoord.SaveBinlogPaths:input_type -> milvus.proto.data.SaveBinlogPathsRequest
-	55,  // 307: milvus.proto.data.DataCoord.GetRecoveryInfo:input_type -> milvus.proto.data.GetRecoveryInfoRequest
-	57,  // 308: milvus.proto.data.DataCoord.GetRecoveryInfoV2:input_type -> milvus.proto.data.GetRecoveryInfoRequestV2
-	58,  // 309: milvus.proto.data.DataCoord.GetChannelRecoveryInfo:input_type -> milvus.proto.data.GetChannelRecoveryInfoRequest
-	63,  // 310: milvus.proto.data.DataCoord.GetFlushedSegments:input_type -> milvus.proto.data.GetFlushedSegmentsRequest
-	61,  // 311: milvus.proto.data.DataCoord.GetSegmentsByStates:input_type -> milvus.proto.data.GetSegmentsByStatesRequest
-	196, // 312: milvus.proto.data.DataCoord.GetFlushAllState:input_type -> milvus.proto.milvus.GetFlushAllStateRequest
-	197, // 313: milvus.proto.data.DataCoord.ShowConfigurations:input_type -> milvus.proto.internal.ShowConfigurationsRequest
-	198, // 314: milvus.proto.data.DataCoord.GetMetrics:input_type -> milvus.proto.milvus.GetMetricsRequest
-	199, // 315: milvus.proto.data.DataCoord.ManualCompaction:input_type -> milvus.proto.milvus.ManualCompactionRequest
-	200, // 316: milvus.proto.data.DataCoord.GetCompactionState:input_type -> milvus.proto.milvus.GetCompactionStateRequest
-	201, // 317: milvus.proto.data.DataCoord.GetCompactionStateWithPlans:input_type -> milvus.proto.milvus.GetCompactionPlansRequest
-	76,  // 318: milvus.proto.data.DataCoord.WatchChannels:input_type -> milvus.proto.data.WatchChannelsRequest
-	94,  // 319: milvus.proto.data.DataCoord.GetFlushState:input_type -> milvus.proto.data.GetFlushStateRequest
-	80,  // 320: milvus.proto.data.DataCoord.DropVirtualChannel:input_type -> milvus.proto.data.DropVirtualChannelRequest
-	78,  // 321: milvus.proto.data.DataCoord.SetSegmentState:input_type -> milvus.proto.data.SetSegmentStateRequest
-	83,  // 322: milvus.proto.data.DataCoord.UpdateSegmentStatistics:input_type -> milvus.proto.data.UpdateSegmentStatisticsRequest
-	84,  // 323: milvus.proto.data.DataCoord.UpdateChannelCheckpoint:input_type -> milvus.proto.data.UpdateChannelCheckpointRequest
-	87,  // 324: milvus.proto.data.DataCoord.MarkSegmentsDropped:input_type -> milvus.proto.data.MarkSegmentsDroppedRequest
-	89,  // 325: milvus.proto.data.DataCoord.BroadcastAlteredCollection:input_type -> milvus.proto.data.AlterCollectionRequest
-	202, // 326: milvus.proto.data.DataCoord.CheckHealth:input_type -> milvus.proto.milvus.CheckHealthRequest
-	203, // 327: milvus.proto.data.DataCoord.CreateIndex:input_type -> milvus.proto.index.CreateIndexRequest
-	204, // 328: milvus.proto.data.DataCoord.AlterIndex:input_type -> milvus.proto.index.AlterIndexRequest
-	205, // 329: milvus.proto.data.DataCoord.GetIndexState:input_type -> milvus.proto.index.GetIndexStateRequest
-	206, // 330: milvus.proto.data.DataCoord.GetSegmentIndexState:input_type -> milvus.proto.index.GetSegmentIndexStateRequest
-	207, // 331: milvus.proto.data.DataCoord.GetIndexInfos:input_type -> milvus.proto.index.GetIndexInfoRequest
-	208, // 332: milvus.proto.data.DataCoord.DropIndex:input_type -> milvus.proto.index.DropIndexRequest
-	209, // 333: milvus.proto.data.DataCoord.DescribeIndex:input_type -> milvus.proto.index.DescribeIndexRequest
-	210, // 334: milvus.proto.data.DataCoord.GetIndexStatistics:input_type -> milvus.proto.index.GetIndexStatisticsRequest
-	211, // 335: milvus.proto.data.DataCoord.GetIndexBuildProgress:input_type -> milvus.proto.index.GetIndexBuildProgressRequest
-	212, // 336: milvus.proto.data.DataCoord.ListIndexes:input_type -> milvus.proto.index.ListIndexesRequest
-	91,  // 337: milvus.proto.data.DataCoord.GcConfirm:input_type -> milvus.proto.data.GcConfirmRequest
-	93,  // 338: milvus.proto.data.DataCoord.ReportDataNodeTtMsgs:input_type -> milvus.proto.data.ReportDataNodeTtMsgsRequest
-	123, // 339: milvus.proto.data.DataCoord.GcControl:input_type -> milvus.proto.data.GcControlRequest
-	213, // 340: milvus.proto.data.DataCoord.ImportV2:input_type -> milvus.proto.internal.ImportRequestInternal
-	214, // 341: milvus.proto.data.DataCoord.GetImportProgress:input_type -> milvus.proto.internal.GetImportProgressRequest
-	215, // 342: milvus.proto.data.DataCoord.ListImports:input_type -> milvus.proto.internal.ListImportsRequestInternal
-	216, // 343: milvus.proto.data.DataCoord.AddFileResource:input_type -> milvus.proto.milvus.AddFileResourceRequest
-	217, // 344: milvus.proto.data.DataCoord.RemoveFileResource:input_type -> milvus.proto.milvus.RemoveFileResourceRequest
-	218, // 345: milvus.proto.data.DataCoord.ListFileResources:input_type -> milvus.proto.milvus.ListFileResourcesRequest
-	135, // 346: milvus.proto.data.DataCoord.CreateSnapshot:input_type -> milvus.proto.data.CreateSnapshotRequest
-	136, // 347: milvus.proto.data.DataCoord.DropSnapshot:input_type -> milvus.proto.data.DropSnapshotRequest
-	137, // 348: milvus.proto.data.DataCoord.ListSnapshots:input_type -> milvus.proto.data.ListSnapshotsRequest
-	145, // 349: milvus.proto.data.DataCoord.DescribeSnapshot:input_type -> milvus.proto.data.DescribeSnapshotRequest
-	147, // 350: milvus.proto.data.DataCoord.RestoreSnapshot:input_type -> milvus.proto.data.RestoreSnapshotRequest
-	149, // 351: milvus.proto.data.DataCoord.GetRestoreSnapshotState:input_type -> milvus.proto.data.GetRestoreSnapshotStateRequest
-	151, // 352: milvus.proto.data.DataCoord.ListRestoreSnapshotJobs:input_type -> milvus.proto.data.ListRestoreSnapshotJobsRequest
-	219, // 353: milvus.proto.data.DataNode.GetComponentStates:input_type -> milvus.proto.milvus.GetComponentStatesRequest
-	220, // 354: milvus.proto.data.DataNode.GetStatisticsChannel:input_type -> milvus.proto.internal.GetStatisticsChannelRequest
-	39,  // 355: milvus.proto.data.DataNode.WatchDmChannels:input_type -> milvus.proto.data.WatchDmChannelsRequest
-	40,  // 356: milvus.proto.data.DataNode.FlushSegments:input_type -> milvus.proto.data.FlushSegmentsRequest
-	197, // 357: milvus.proto.data.DataNode.ShowConfigurations:input_type -> milvus.proto.internal.ShowConfigurationsRequest
-	198, // 358: milvus.proto.data.DataNode.GetMetrics:input_type -> milvus.proto.milvus.GetMetricsRequest
-	71,  // 359: milvus.proto.data.DataNode.CompactionV2:input_type -> milvus.proto.data.CompactionPlan
-	67,  // 360: milvus.proto.data.DataNode.GetCompactionState:input_type -> milvus.proto.data.CompactionStateRequest
-	69,  // 361: milvus.proto.data.DataNode.SyncSegments:input_type -> milvus.proto.data.SyncSegmentsRequest
-	85,  // 362: milvus.proto.data.DataNode.ResendSegmentStats:input_type -> milvus.proto.data.ResendSegmentStatsRequest
-	19,  // 363: milvus.proto.data.DataNode.FlushChannels:input_type -> milvus.proto.data.FlushChannelsRequest
-	95,  // 364: milvus.proto.data.DataNode.NotifyChannelOperation:input_type -> milvus.proto.data.ChannelOperationsRequest
-	66,  // 365: milvus.proto.data.DataNode.CheckChannelOperationProgress:input_type -> milvus.proto.data.ChannelWatchInfo
-	97,  // 366: milvus.proto.data.DataNode.PreImport:input_type -> milvus.proto.data.PreImportRequest
-	100, // 367: milvus.proto.data.DataNode.ImportV2:input_type -> milvus.proto.data.ImportRequest
-	101, // 368: milvus.proto.data.DataNode.QueryPreImport:input_type -> milvus.proto.data.QueryPreImportRequest
-	105, // 369: milvus.proto.data.DataNode.QueryImport:input_type -> milvus.proto.data.QueryImportRequest
-	108, // 370: milvus.proto.data.DataNode.DropImport:input_type -> milvus.proto.data.DropImportRequest
-	125, // 371: milvus.proto.data.DataNode.QuerySlot:input_type -> milvus.proto.data.QuerySlotRequest
-	129, // 372: milvus.proto.data.DataNode.DropCompactionPlan:input_type -> milvus.proto.data.DropCompactionPlanRequest
-	221, // 373: milvus.proto.data.DataNode.SyncFileResource:input_type -> milvus.proto.internal.SyncFileResourceRequest
-	14,  // 374: milvus.proto.data.DataCoord.Flush:output_type -> milvus.proto.data.FlushResponse
-	18,  // 375: milvus.proto.data.DataCoord.FlushAll:output_type -> milvus.proto.data.FlushAllResponse
-	130, // 376: milvus.proto.data.DataCoord.CreateExternalCollection:output_type -> milvus.proto.data.CreateExternalCollectionResponse
-	22,  // 377: milvus.proto.data.DataCoord.AllocSegment:output_type -> milvus.proto.data.AllocSegmentResponse
-	25,  // 378: milvus.proto.data.DataCoord.AssignSegmentID:output_type -> milvus.proto.data.AssignSegmentIDResponse
-	30,  // 379: milvus.proto.data.DataCoord.GetSegmentInfo:output_type -> milvus.proto.data.GetSegmentInfoResponse
-	28,  // 380: milvus.proto.data.DataCoord.GetSegmentStates:output_type -> milvus.proto.data.GetSegmentStatesResponse
-	32,  // 381: milvus.proto.data.DataCoord.GetInsertBinlogPaths:output_type -> milvus.proto.data.GetInsertBinlogPathsResponse
-	34,  // 382: milvus.proto.data.DataCoord.GetCollectionStatistics:output_type -> milvus.proto.data.GetCollectionStatisticsResponse
-	36,  // 383: milvus.proto.data.DataCoord.GetPartitionStatistics:output_type -> milvus.proto.data.GetPartitionStatisticsResponse
-	222, // 384: milvus.proto.data.DataCoord.GetSegmentInfoChannel:output_type -> milvus.proto.milvus.StringResponse
-	175, // 385: milvus.proto.data.DataCoord.SaveBinlogPaths:output_type -> milvus.proto.common.Status
-	54,  // 386: milvus.proto.data.DataCoord.GetRecoveryInfo:output_type -> milvus.proto.data.GetRecoveryInfoResponse
-	56,  // 387: milvus.proto.data.DataCoord.GetRecoveryInfoV2:output_type -> milvus.proto.data.GetRecoveryInfoResponseV2
-	59,  // 388: milvus.proto.data.DataCoord.GetChannelRecoveryInfo:output_type -> milvus.proto.data.GetChannelRecoveryInfoResponse
-	64,  // 389: milvus.proto.data.DataCoord.GetFlushedSegments:output_type -> milvus.proto.data.GetFlushedSegmentsResponse
-	62,  // 390: milvus.proto.data.DataCoord.GetSegmentsByStates:output_type -> milvus.proto.data.GetSegmentsByStatesResponse
-	223, // 391: milvus.proto.data.DataCoord.GetFlushAllState:output_type -> milvus.proto.milvus.GetFlushAllStateResponse
-	224, // 392: milvus.proto.data.DataCoord.ShowConfigurations:output_type -> milvus.proto.internal.ShowConfigurationsResponse
-	225, // 393: milvus.proto.data.DataCoord.GetMetrics:output_type -> milvus.proto.milvus.GetMetricsResponse
-	226, // 394: milvus.proto.data.DataCoord.ManualCompaction:output_type -> milvus.proto.milvus.ManualCompactionResponse
-	227, // 395: milvus.proto.data.DataCoord.GetCompactionState:output_type -> milvus.proto.milvus.GetCompactionStateResponse
-	228, // 396: milvus.proto.data.DataCoord.GetCompactionStateWithPlans:output_type -> milvus.proto.milvus.GetCompactionPlansResponse
-	77,  // 397: milvus.proto.data.DataCoord.WatchChannels:output_type -> milvus.proto.data.WatchChannelsResponse
-	229, // 398: milvus.proto.data.DataCoord.GetFlushState:output_type -> milvus.proto.milvus.GetFlushStateResponse
-	82,  // 399: milvus.proto.data.DataCoord.DropVirtualChannel:output_type -> milvus.proto.data.DropVirtualChannelResponse
-	79,  // 400: milvus.proto.data.DataCoord.SetSegmentState:output_type -> milvus.proto.data.SetSegmentStateResponse
-	175, // 401: milvus.proto.data.DataCoord.UpdateSegmentStatistics:output_type -> milvus.proto.common.Status
-	175, // 402: milvus.proto.data.DataCoord.UpdateChannelCheckpoint:output_type -> milvus.proto.common.Status
-	175, // 403: milvus.proto.data.DataCoord.MarkSegmentsDropped:output_type -> milvus.proto.common.Status
-	175, // 404: milvus.proto.data.DataCoord.BroadcastAlteredCollection:output_type -> milvus.proto.common.Status
-	230, // 405: milvus.proto.data.DataCoord.CheckHealth:output_type -> milvus.proto.milvus.CheckHealthResponse
-	175, // 406: milvus.proto.data.DataCoord.CreateIndex:output_type -> milvus.proto.common.Status
-	175, // 407: milvus.proto.data.DataCoord.AlterIndex:output_type -> milvus.proto.common.Status
-	231, // 408: milvus.proto.data.DataCoord.GetIndexState:output_type -> milvus.proto.index.GetIndexStateResponse
-	232, // 409: milvus.proto.data.DataCoord.GetSegmentIndexState:output_type -> milvus.proto.index.GetSegmentIndexStateResponse
-	233, // 410: milvus.proto.data.DataCoord.GetIndexInfos:output_type -> milvus.proto.index.GetIndexInfoResponse
-	175, // 411: milvus.proto.data.DataCoord.DropIndex:output_type -> milvus.proto.common.Status
-	234, // 412: milvus.proto.data.DataCoord.DescribeIndex:output_type -> milvus.proto.index.DescribeIndexResponse
-	235, // 413: milvus.proto.data.DataCoord.GetIndexStatistics:output_type -> milvus.proto.index.GetIndexStatisticsResponse
-	236, // 414: milvus.proto.data.DataCoord.GetIndexBuildProgress:output_type -> milvus.proto.index.GetIndexBuildProgressResponse
-	237, // 415: milvus.proto.data.DataCoord.ListIndexes:output_type -> milvus.proto.index.ListIndexesResponse
-	92,  // 416: milvus.proto.data.DataCoord.GcConfirm:output_type -> milvus.proto.data.GcConfirmResponse
-	175, // 417: milvus.proto.data.DataCoord.ReportDataNodeTtMsgs:output_type -> milvus.proto.common.Status
-	175, // 418: milvus.proto.data.DataCoord.GcControl:output_type -> milvus.proto.common.Status
-	238, // 419: milvus.proto.data.DataCoord.ImportV2:output_type -> milvus.proto.internal.ImportResponse
-	239, // 420: milvus.proto.data.DataCoord.GetImportProgress:output_type -> milvus.proto.internal.GetImportProgressResponse
-	240, // 421: milvus.proto.data.DataCoord.ListImports:output_type -> milvus.proto.internal.ListImportsResponse
-	175, // 422: milvus.proto.data.DataCoord.AddFileResource:output_type -> milvus.proto.common.Status
-	175, // 423: milvus.proto.data.DataCoord.RemoveFileResource:output_type -> milvus.proto.common.Status
-	241, // 424: milvus.proto.data.DataCoord.ListFileResources:output_type -> milvus.proto.milvus.ListFileResourcesResponse
-	175, // 425: milvus.proto.data.DataCoord.CreateSnapshot:output_type -> milvus.proto.common.Status
-	175, // 426: milvus.proto.data.DataCoord.DropSnapshot:output_type -> milvus.proto.common.Status
-	138, // 427: milvus.proto.data.DataCoord.ListSnapshots:output_type -> milvus.proto.data.ListSnapshotsResponse
-	146, // 428: milvus.proto.data.DataCoord.DescribeSnapshot:output_type -> milvus.proto.data.DescribeSnapshotResponse
-	148, // 429: milvus.proto.data.DataCoord.RestoreSnapshot:output_type -> milvus.proto.data.RestoreSnapshotResponse
-	150, // 430: milvus.proto.data.DataCoord.GetRestoreSnapshotState:output_type -> milvus.proto.data.GetRestoreSnapshotStateResponse
-	152, // 431: milvus.proto.data.DataCoord.ListRestoreSnapshotJobs:output_type -> milvus.proto.data.ListRestoreSnapshotJobsResponse
-	242, // 432: milvus.proto.data.DataNode.GetComponentStates:output_type -> milvus.proto.milvus.ComponentStates
-	222, // 433: milvus.proto.data.DataNode.GetStatisticsChannel:output_type -> milvus.proto.milvus.StringResponse
-	175, // 434: milvus.proto.data.DataNode.WatchDmChannels:output_type -> milvus.proto.common.Status
-	175, // 435: milvus.proto.data.DataNode.FlushSegments:output_type -> milvus.proto.common.Status
-	224, // 436: milvus.proto.data.DataNode.ShowConfigurations:output_type -> milvus.proto.internal.ShowConfigurationsResponse
-	225, // 437: milvus.proto.data.DataNode.GetMetrics:output_type -> milvus.proto.milvus.GetMetricsResponse
-	175, // 438: milvus.proto.data.DataNode.CompactionV2:output_type -> milvus.proto.common.Status
-	74,  // 439: milvus.proto.data.DataNode.GetCompactionState:output_type -> milvus.proto.data.CompactionStateResponse
-	175, // 440: milvus.proto.data.DataNode.SyncSegments:output_type -> milvus.proto.common.Status
-	86,  // 441: milvus.proto.data.DataNode.ResendSegmentStats:output_type -> milvus.proto.data.ResendSegmentStatsResponse
-	175, // 442: milvus.proto.data.DataNode.FlushChannels:output_type -> milvus.proto.common.Status
-	175, // 443: milvus.proto.data.DataNode.NotifyChannelOperation:output_type -> milvus.proto.common.Status
-	96,  // 444: milvus.proto.data.DataNode.CheckChannelOperationProgress:output_type -> milvus.proto.data.ChannelOperationProgressResponse
-	175, // 445: milvus.proto.data.DataNode.PreImport:output_type -> milvus.proto.common.Status
-	175, // 446: milvus.proto.data.DataNode.ImportV2:output_type -> milvus.proto.common.Status
-	104, // 447: milvus.proto.data.DataNode.QueryPreImport:output_type -> milvus.proto.data.QueryPreImportResponse
-	107, // 448: milvus.proto.data.DataNode.QueryImport:output_type -> milvus.proto.data.QueryImportResponse
-	175, // 449: milvus.proto.data.DataNode.DropImport:output_type -> milvus.proto.common.Status
-	126, // 450: milvus.proto.data.DataNode.QuerySlot:output_type -> milvus.proto.data.QuerySlotResponse
-	175, // 451: milvus.proto.data.DataNode.DropCompactionPlan:output_type -> milvus.proto.common.Status
-	175, // 452: milvus.proto.data.DataNode.SyncFileResource:output_type -> milvus.proto.common.Status
-	374, // [374:453] is the sub-list for method output_type
-	295, // [295:374] is the sub-list for method input_type
-	295, // [295:295] is the sub-list for extension type_name
-	295, // [295:295] is the sub-list for extension extendee
-	0,   // [0:295] is the sub-list for field type_name
+	161, // 78: milvus.proto.data.Binlog.field_null_counts:type_name -> milvus.proto.data.Binlog.FieldNullCountsEntry
+	176, // 79: milvus.proto.data.GetRecoveryInfoResponse.status:type_name -> milvus.proto.common.Status
+	38,  // 80: milvus.proto.data.GetRecoveryInfoResponse.channels:type_name -> milvus.proto.data.VchannelInfo
+	49,  // 81: milvus.proto.data.GetRecoveryInfoResponse.binlogs:type_name -> milvus.proto.data.SegmentBinlogs
+	175, // 82: milvus.proto.data.GetRecoveryInfoRequest.base:type_name -> milvus.proto.common.MsgBase
+	176, // 83: milvus.proto.data.GetRecoveryInfoResponseV2.status:type_name -> milvus.proto.common.Status
+	38,  // 84: milvus.proto.data.GetRecoveryInfoResponseV2.channels:type_name -> milvus.proto.data.VchannelInfo
+	42,  // 85: milvus.proto.data.GetRecoveryInfoResponseV2.segments:type_name -> milvus.proto.data.SegmentInfo
+	175, // 86: milvus.proto.data.GetRecoveryInfoRequestV2.base:type_name -> milvus.proto.common.MsgBase
+	175, // 87: milvus.proto.data.GetChannelRecoveryInfoRequest.base:type_name -> milvus.proto.common.MsgBase
+	176, // 88: milvus.proto.data.GetChannelRecoveryInfoResponse.status:type_name -> milvus.proto.common.Status
+	38,  // 89: milvus.proto.data.GetChannelRecoveryInfoResponse.info:type_name -> milvus.proto.data.VchannelInfo
+	182, // 90: milvus.proto.data.GetChannelRecoveryInfoResponse.schema:type_name -> milvus.proto.schema.CollectionSchema
+	60,  // 91: milvus.proto.data.GetChannelRecoveryInfoResponse.segments_not_created_by_streaming:type_name -> milvus.proto.data.SegmentNotCreatedByStreaming
+	175, // 92: milvus.proto.data.GetSegmentsByStatesRequest.base:type_name -> milvus.proto.common.MsgBase
+	178, // 93: milvus.proto.data.GetSegmentsByStatesRequest.states:type_name -> milvus.proto.common.SegmentState
+	176, // 94: milvus.proto.data.GetSegmentsByStatesResponse.status:type_name -> milvus.proto.common.Status
+	175, // 95: milvus.proto.data.GetFlushedSegmentsRequest.base:type_name -> milvus.proto.common.MsgBase
+	176, // 96: milvus.proto.data.GetFlushedSegmentsResponse.status:type_name -> milvus.proto.common.Status
+	175, // 97: milvus.proto.data.SegmentFlushCompletedMsg.base:type_name -> milvus.proto.common.MsgBase
+	42,  // 98: milvus.proto.data.SegmentFlushCompletedMsg.segment:type_name -> milvus.proto.data.SegmentInfo
+	38,  // 99: milvus.proto.data.ChannelWatchInfo.vchan:type_name -> milvus.proto.data.VchannelInfo
+	2,   // 100: milvus.proto.data.ChannelWatchInfo.state:type_name -> milvus.proto.data.ChannelWatchState
+	182, // 101: milvus.proto.data.ChannelWatchInfo.schema:type_name -> milvus.proto.schema.CollectionSchema
+	181, // 102: milvus.proto.data.ChannelWatchInfo.dbProperties:type_name -> milvus.proto.common.KeyValuePair
+	175, // 103: milvus.proto.data.CompactionStateRequest.base:type_name -> milvus.proto.common.MsgBase
+	50,  // 104: milvus.proto.data.SyncSegmentInfo.pk_stats_log:type_name -> milvus.proto.data.FieldBinlog
+	178, // 105: milvus.proto.data.SyncSegmentInfo.state:type_name -> milvus.proto.common.SegmentState
+	1,   // 106: milvus.proto.data.SyncSegmentInfo.level:type_name -> milvus.proto.data.SegmentLevel
+	50,  // 107: milvus.proto.data.SyncSegmentsRequest.stats_logs:type_name -> milvus.proto.data.FieldBinlog
+	162, // 108: milvus.proto.data.SyncSegmentsRequest.segment_infos:type_name -> milvus.proto.data.SyncSegmentsRequest.SegmentInfosEntry
+	50,  // 109: milvus.proto.data.CompactionSegmentBinlogs.fieldBinlogs:type_name -> milvus.proto.data.FieldBinlog
+	50,  // 110: milvus.proto.data.CompactionSegmentBinlogs.field2StatslogPaths:type_name -> milvus.proto.data.FieldBinlog
+	50,  // 111: milvus.proto.data.CompactionSegmentBinlogs.deltalogs:type_name -> milvus.proto.data.FieldBinlog
+	1,   // 112: milvus.proto.data.CompactionSegmentBinlogs.level:type_name -> milvus.proto.data.SegmentLevel
+	70,  // 113: milvus.proto.data.CompactionPlan.segmentBinlogs:type_name -> milvus.proto.data.CompactionSegmentBinlogs
+	3,   // 114: milvus.proto.data.CompactionPlan.type:type_name -> milvus.proto.data.CompactionType
+	182, // 115: milvus.proto.data.CompactionPlan.schema:type_name -> milvus.proto.schema.CollectionSchema
+	98,  // 116: milvus.proto.data.CompactionPlan.pre_allocated_segmentIDs:type_name -> milvus.proto.data.IDRange
+	98,  // 117: milvus.proto.data.CompactionPlan.pre_allocated_logIDs:type_name -> milvus.proto.data.IDRange
+	181, // 118: milvus.proto.data.CompactionPlan.plugin_context:type_name -> milvus.proto.common.KeyValuePair
+	183, // 119: milvus.proto.data.CompactionPlan.file_resources:type_name -> milvus.proto.internal.FileResourceInfo
+	50,  // 120: milvus.proto.data.CompactionSegment.insert_logs:type_name -> milvus.proto.data.FieldBinlog
+	50,  // 121: milvus.proto.data.CompactionSegment.field2StatslogPaths:type_name -> milvus.proto.data.FieldBinlog
+	50,  // 122: milvus.proto.data.CompactionSegment.deltalogs:type_name -> milvus.proto.data.FieldBinlog
+	50,  // 123: milvus.proto.data.CompactionSegment.bm25logs:type_name -> milvus.proto.data.FieldBinlog
+	163, // 124: milvus.proto.data.CompactionSegment.text_stats_logs:type_name -> milvus.proto.data.CompactionSegment.TextStatsLogsEntry
+	11,  // 125: milvus.proto.data.CompactionPlanResult.state:type_name -> milvus.proto.data.CompactionTaskState
+	72,  // 126: milvus.proto.data.CompactionPlanResult.segments:type_name -> milvus.proto.data.CompactionSegment
+	3,   // 127: milvus.proto.data.CompactionPlanResult.type:type_name -> milvus.proto.data.CompactionType
+	176, // 128: milvus.proto.data.CompactionStateResponse.status:type_name -> milvus.proto.common.Status
+	73,  // 129: milvus.proto.data.CompactionStateResponse.results:type_name -> milvus.proto.data.CompactionPlanResult
+	184, // 130: milvus.proto.data.WatchChannelsRequest.start_positions:type_name -> milvus.proto.common.KeyDataPair
+	182, // 131: milvus.proto.data.WatchChannelsRequest.schema:type_name -> milvus.proto.schema.CollectionSchema
+	181, // 132: milvus.proto.data.WatchChannelsRequest.db_properties:type_name -> milvus.proto.common.KeyValuePair
+	176, // 133: milvus.proto.data.WatchChannelsResponse.status:type_name -> milvus.proto.common.Status
+	175, // 134: milvus.proto.data.SetSegmentStateRequest.base:type_name -> milvus.proto.common.MsgBase
+	178, // 135: milvus.proto.data.SetSegmentStateRequest.new_state:type_name -> milvus.proto.common.SegmentState
+	176, // 136: milvus.proto.data.SetSegmentStateResponse.status:type_name -> milvus.proto.common.Status
+	175, // 137: milvus.proto.data.DropVirtualChannelRequest.base:type_name -> milvus.proto.common.MsgBase
+	81,  // 138: milvus.proto.data.DropVirtualChannelRequest.segments:type_name -> milvus.proto.data.DropVirtualChannelSegment
+	50,  // 139: milvus.proto.data.DropVirtualChannelSegment.field2BinlogPaths:type_name -> milvus.proto.data.FieldBinlog
+	50,  // 140: milvus.proto.data.DropVirtualChannelSegment.field2StatslogPaths:type_name -> milvus.proto.data.FieldBinlog
+	50,  // 141: milvus.proto.data.DropVirtualChannelSegment.deltalogs:type_name -> milvus.proto.data.FieldBinlog
+	179, // 142: milvus.proto.data.DropVirtualChannelSegment.startPosition:type_name -> milvus.proto.msg.MsgPosition
+	179, // 143: milvus.proto.data.DropVirtualChannelSegment.checkPoint:type_name -> milvus.proto.msg.MsgPosition
+	176, // 144: milvus.proto.data.DropVirtualChannelResponse.status:type_name -> milvus.proto.common.Status
+	175, // 145: milvus.proto.data.UpdateSegmentStatisticsRequest.base:type_name -> milvus.proto.common.MsgBase
+	185, // 146: milvus.proto.data.UpdateSegmentStatisticsRequest.stats:type_name -> milvus.proto.common.SegmentStats
+	175, // 147: milvus.proto.data.UpdateChannelCheckpointRequest.base:type_name -> milvus.proto.common.MsgBase
+	179, // 148: milvus.proto.data.UpdateChannelCheckpointRequest.position:type_name -> milvus.proto.msg.MsgPosition
+	179, // 149: milvus.proto.data.UpdateChannelCheckpointRequest.channel_checkpoints:type_name -> milvus.proto.msg.MsgPosition
+	175, // 150: milvus.proto.data.ResendSegmentStatsRequest.base:type_name -> milvus.proto.common.MsgBase
+	176, // 151: milvus.proto.data.ResendSegmentStatsResponse.status:type_name -> milvus.proto.common.Status
+	175, // 152: milvus.proto.data.MarkSegmentsDroppedRequest.base:type_name -> milvus.proto.common.MsgBase
+	182, // 153: milvus.proto.data.AlterCollectionRequest.schema:type_name -> milvus.proto.schema.CollectionSchema
+	184, // 154: milvus.proto.data.AlterCollectionRequest.start_positions:type_name -> milvus.proto.common.KeyDataPair
+	181, // 155: milvus.proto.data.AlterCollectionRequest.properties:type_name -> milvus.proto.common.KeyValuePair
+	186, // 156: milvus.proto.data.AddCollectionFieldRequest.field_schema:type_name -> milvus.proto.schema.FieldSchema
+	182, // 157: milvus.proto.data.AddCollectionFieldRequest.schema:type_name -> milvus.proto.schema.CollectionSchema
+	184, // 158: milvus.proto.data.AddCollectionFieldRequest.start_positions:type_name -> milvus.proto.common.KeyDataPair
+	181, // 159: milvus.proto.data.AddCollectionFieldRequest.properties:type_name -> milvus.proto.common.KeyValuePair
+	176, // 160: milvus.proto.data.GcConfirmResponse.status:type_name -> milvus.proto.common.Status
+	175, // 161: milvus.proto.data.ReportDataNodeTtMsgsRequest.base:type_name -> milvus.proto.common.MsgBase
+	187, // 162: milvus.proto.data.ReportDataNodeTtMsgsRequest.msgs:type_name -> milvus.proto.msg.DataNodeTtMsg
+	66,  // 163: milvus.proto.data.ChannelOperationsRequest.infos:type_name -> milvus.proto.data.ChannelWatchInfo
+	176, // 164: milvus.proto.data.ChannelOperationProgressResponse.status:type_name -> milvus.proto.common.Status
+	2,   // 165: milvus.proto.data.ChannelOperationProgressResponse.state:type_name -> milvus.proto.data.ChannelWatchState
+	182, // 166: milvus.proto.data.PreImportRequest.schema:type_name -> milvus.proto.schema.CollectionSchema
+	188, // 167: milvus.proto.data.PreImportRequest.import_files:type_name -> milvus.proto.internal.ImportFile
+	181, // 168: milvus.proto.data.PreImportRequest.options:type_name -> milvus.proto.common.KeyValuePair
+	189, // 169: milvus.proto.data.PreImportRequest.storage_config:type_name -> milvus.proto.index.StorageConfig
+	181, // 170: milvus.proto.data.PreImportRequest.plugin_context:type_name -> milvus.proto.common.KeyValuePair
+	182, // 171: milvus.proto.data.ImportRequest.schema:type_name -> milvus.proto.schema.CollectionSchema
+	188, // 172: milvus.proto.data.ImportRequest.files:type_name -> milvus.proto.internal.ImportFile
+	181, // 173: milvus.proto.data.ImportRequest.options:type_name -> milvus.proto.common.KeyValuePair
+	98,  // 174: milvus.proto.data.ImportRequest.ID_range:type_name -> milvus.proto.data.IDRange
+	99,  // 175: milvus.proto.data.ImportRequest.request_segments:type_name -> milvus.proto.data.ImportRequestSegment
+	189, // 176: milvus.proto.data.ImportRequest.storage_config:type_name -> milvus.proto.index.StorageConfig
+	181, // 177: milvus.proto.data.ImportRequest.plugin_context:type_name -> milvus.proto.common.KeyValuePair
+	164, // 178: milvus.proto.data.PartitionImportStats.partition_rows:type_name -> milvus.proto.data.PartitionImportStats.PartitionRowsEntry
+	165, // 179: milvus.proto.data.PartitionImportStats.partition_data_size:type_name -> milvus.proto.data.PartitionImportStats.PartitionDataSizeEntry
+	188, // 180: milvus.proto.data.ImportFileStats.import_file:type_name -> milvus.proto.internal.ImportFile
+	166, // 181: milvus.proto.data.ImportFileStats.hashed_stats:type_name -> milvus.proto.data.ImportFileStats.HashedStatsEntry
+	176, // 182: milvus.proto.data.QueryPreImportResponse.status:type_name -> milvus.proto.common.Status
+	8,   // 183: milvus.proto.data.QueryPreImportResponse.state:type_name -> milvus.proto.data.ImportTaskStateV2
+	103, // 184: milvus.proto.data.QueryPreImportResponse.file_stats:type_name -> milvus.proto.data.ImportFileStats
+	50,  // 185: milvus.proto.data.ImportSegmentInfo.binlogs:type_name -> milvus.proto.data.FieldBinlog
+	50,  // 186: milvus.proto.data.ImportSegmentInfo.statslogs:type_name -> milvus.proto.data.FieldBinlog
+	50,  // 187: milvus.proto.data.ImportSegmentInfo.deltalogs:type_name -> milvus.proto.data.FieldBinlog
+	50,  // 188: milvus.proto.data.ImportSegmentInfo.bm25logs:type_name -> milvus.proto.data.FieldBinlog
+	176, // 189: milvus.proto.data.QueryImportResponse.status:type_name -> milvus.proto.common.Status
+	8,   // 190: milvus.proto.data.QueryImportResponse.state:type_name -> milvus.proto.data.ImportTaskStateV2
+	106, // 191: milvus.proto.data.QueryImportResponse.import_segments_info:type_name -> milvus.proto.data.ImportSegmentInfo
+	50,  // 192: milvus.proto.data.CopySegmentSource.insert_binlogs:type_name -> milvus.proto.data.FieldBinlog
+	50,  // 193: milvus.proto.data.CopySegmentSource.stats_binlogs:type_name -> milvus.proto.data.FieldBinlog
+	50,  // 194: milvus.proto.data.CopySegmentSource.delta_binlogs:type_name -> milvus.proto.data.FieldBinlog
+	190, // 195: milvus.proto.data.CopySegmentSource.index_files:type_name -> milvus.proto.index.IndexFilePathInfo
+	50,  // 196: milvus.proto.data.CopySegmentSource.bm25_binlogs:type_name -> milvus.proto.data.FieldBinlog
+	167, // 197: milvus.proto.data.CopySegmentSource.text_index_files:type_name -> milvus.proto.data.CopySegmentSource.TextIndexFilesEntry
+	168, // 198: milvus.proto.data.CopySegmentSource.json_key_index_files:type_name -> milvus.proto.data.CopySegmentSource.JsonKeyIndexFilesEntry
+	109, // 199: milvus.proto.data.CopySegmentRequest.sources:type_name -> milvus.proto.data.CopySegmentSource
+	110, // 200: milvus.proto.data.CopySegmentRequest.targets:type_name -> milvus.proto.data.CopySegmentTarget
+	189, // 201: milvus.proto.data.CopySegmentRequest.storage_config:type_name -> milvus.proto.index.StorageConfig
+	176, // 202: milvus.proto.data.QueryCopySegmentResponse.status:type_name -> milvus.proto.common.Status
+	5,   // 203: milvus.proto.data.QueryCopySegmentResponse.state:type_name -> milvus.proto.data.CopySegmentTaskState
+	116, // 204: milvus.proto.data.QueryCopySegmentResponse.segment_results:type_name -> milvus.proto.data.CopySegmentResult
+	50,  // 205: milvus.proto.data.CopySegmentResult.binlogs:type_name -> milvus.proto.data.FieldBinlog
+	50,  // 206: milvus.proto.data.CopySegmentResult.statslogs:type_name -> milvus.proto.data.FieldBinlog
+	50,  // 207: milvus.proto.data.CopySegmentResult.deltalogs:type_name -> milvus.proto.data.FieldBinlog
+	50,  // 208: milvus.proto.data.CopySegmentResult.bm25logs:type_name -> milvus.proto.data.FieldBinlog
+	169, // 209: milvus.proto.data.CopySegmentResult.index_infos:type_name -> milvus.proto.data.CopySegmentResult.IndexInfosEntry
+	170, // 210: milvus.proto.data.CopySegmentResult.text_index_infos:type_name -> milvus.proto.data.CopySegmentResult.TextIndexInfosEntry
+	171, // 211: milvus.proto.data.CopySegmentResult.json_key_index_infos:type_name -> milvus.proto.data.CopySegmentResult.JsonKeyIndexInfosEntry
+	5,   // 212: milvus.proto.data.CopySegmentTask.state:type_name -> milvus.proto.data.CopySegmentTaskState
+	118, // 213: milvus.proto.data.CopySegmentTask.id_mappings:type_name -> milvus.proto.data.CopySegmentIDMapping
+	4,   // 214: milvus.proto.data.CopySegmentJob.state:type_name -> milvus.proto.data.CopySegmentJobState
+	118, // 215: milvus.proto.data.CopySegmentJob.id_mappings:type_name -> milvus.proto.data.CopySegmentIDMapping
+	181, // 216: milvus.proto.data.CopySegmentJob.options:type_name -> milvus.proto.common.KeyValuePair
+	182, // 217: milvus.proto.data.ImportJob.schema:type_name -> milvus.proto.schema.CollectionSchema
+	191, // 218: milvus.proto.data.ImportJob.state:type_name -> milvus.proto.internal.ImportJobState
+	188, // 219: milvus.proto.data.ImportJob.files:type_name -> milvus.proto.internal.ImportFile
+	181, // 220: milvus.proto.data.ImportJob.options:type_name -> milvus.proto.common.KeyValuePair
+	8,   // 221: milvus.proto.data.PreImportTask.state:type_name -> milvus.proto.data.ImportTaskStateV2
+	103, // 222: milvus.proto.data.PreImportTask.file_stats:type_name -> milvus.proto.data.ImportFileStats
+	8,   // 223: milvus.proto.data.ImportTaskV2.state:type_name -> milvus.proto.data.ImportTaskStateV2
+	103, // 224: milvus.proto.data.ImportTaskV2.file_stats:type_name -> milvus.proto.data.ImportFileStats
+	9,   // 225: milvus.proto.data.ImportTaskV2.source:type_name -> milvus.proto.data.ImportTaskSourceV2
+	175, // 226: milvus.proto.data.GcControlRequest.base:type_name -> milvus.proto.common.MsgBase
+	10,  // 227: milvus.proto.data.GcControlRequest.command:type_name -> milvus.proto.data.GcCommand
+	181, // 228: milvus.proto.data.GcControlRequest.params:type_name -> milvus.proto.common.KeyValuePair
+	176, // 229: milvus.proto.data.QuerySlotResponse.status:type_name -> milvus.proto.common.Status
+	3,   // 230: milvus.proto.data.CompactionTask.type:type_name -> milvus.proto.data.CompactionType
+	11,  // 231: milvus.proto.data.CompactionTask.state:type_name -> milvus.proto.data.CompactionTaskState
+	179, // 232: milvus.proto.data.CompactionTask.pos:type_name -> milvus.proto.msg.MsgPosition
+	182, // 233: milvus.proto.data.CompactionTask.schema:type_name -> milvus.proto.schema.CollectionSchema
+	186, // 234: milvus.proto.data.CompactionTask.clustering_key_field:type_name -> milvus.proto.schema.FieldSchema
+	98,  // 235: milvus.proto.data.CompactionTask.pre_allocated_segmentIDs:type_name -> milvus.proto.data.IDRange
+	176, // 236: milvus.proto.data.CreateExternalCollectionResponse.status:type_name -> milvus.proto.common.Status
+	175, // 237: milvus.proto.data.UpdateExternalCollectionRequest.base:type_name -> milvus.proto.common.MsgBase
+	42,  // 238: milvus.proto.data.UpdateExternalCollectionRequest.currentSegments:type_name -> milvus.proto.data.SegmentInfo
+	176, // 239: milvus.proto.data.UpdateExternalCollectionResponse.status:type_name -> milvus.proto.common.Status
+	42,  // 240: milvus.proto.data.UpdateExternalCollectionResponse.updatedSegments:type_name -> milvus.proto.data.SegmentInfo
+	192, // 241: milvus.proto.data.UpdateExternalCollectionResponse.state:type_name -> milvus.proto.index.JobState
+	175, // 242: milvus.proto.data.CreateSnapshotRequest.base:type_name -> milvus.proto.common.MsgBase
+	175, // 243: milvus.proto.data.DropSnapshotRequest.base:type_name -> milvus.proto.common.MsgBase
+	175, // 244: milvus.proto.data.ListSnapshotsRequest.base:type_name -> milvus.proto.common.MsgBase
+	176, // 245: milvus.proto.data.ListSnapshotsResponse.status:type_name -> milvus.proto.common.Status
+	1,   // 246: milvus.proto.data.SegmentDescription.segment_level:type_name -> milvus.proto.data.SegmentLevel
+	50,  // 247: milvus.proto.data.SegmentDescription.binlogs:type_name -> milvus.proto.data.FieldBinlog
+	50,  // 248: milvus.proto.data.SegmentDescription.deltalogs:type_name -> milvus.proto.data.FieldBinlog
+	50,  // 249: milvus.proto.data.SegmentDescription.statslogs:type_name -> milvus.proto.data.FieldBinlog
+	50,  // 250: milvus.proto.data.SegmentDescription.bm25_statslogs:type_name -> milvus.proto.data.FieldBinlog
+	172, // 251: milvus.proto.data.SegmentDescription.text_index_files:type_name -> milvus.proto.data.SegmentDescription.TextIndexFilesEntry
+	173, // 252: milvus.proto.data.SegmentDescription.json_key_index_files:type_name -> milvus.proto.data.SegmentDescription.JsonKeyIndexFilesEntry
+	190, // 253: milvus.proto.data.SegmentDescription.index_files:type_name -> milvus.proto.index.IndexFilePathInfo
+	179, // 254: milvus.proto.data.SegmentDescription.start_position:type_name -> milvus.proto.msg.MsgPosition
+	179, // 255: milvus.proto.data.SegmentDescription.dml_position:type_name -> milvus.proto.msg.MsgPosition
+	182, // 256: milvus.proto.data.CollectionDescription.schema:type_name -> milvus.proto.schema.CollectionSchema
+	193, // 257: milvus.proto.data.CollectionDescription.consistency_level:type_name -> milvus.proto.common.ConsistencyLevel
+	181, // 258: milvus.proto.data.CollectionDescription.properties:type_name -> milvus.proto.common.KeyValuePair
+	174, // 259: milvus.proto.data.CollectionDescription.partitions:type_name -> milvus.proto.data.CollectionDescription.PartitionsEntry
+	6,   // 260: milvus.proto.data.SnapshotInfo.state:type_name -> milvus.proto.data.SnapshotState
+	141, // 261: milvus.proto.data.SnapshotMetadata.snapshot_info:type_name -> milvus.proto.data.SnapshotInfo
+	140, // 262: milvus.proto.data.SnapshotMetadata.collection:type_name -> milvus.proto.data.CollectionDescription
+	194, // 263: milvus.proto.data.SnapshotMetadata.indexes:type_name -> milvus.proto.index.IndexInfo
+	142, // 264: milvus.proto.data.SnapshotMetadata.storagev2_manifest_list:type_name -> milvus.proto.data.StorageV2SegmentManifest
+	7,   // 265: milvus.proto.data.RestoreSnapshotInfo.state:type_name -> milvus.proto.data.RestoreSnapshotState
+	175, // 266: milvus.proto.data.DescribeSnapshotRequest.base:type_name -> milvus.proto.common.MsgBase
+	176, // 267: milvus.proto.data.DescribeSnapshotResponse.status:type_name -> milvus.proto.common.Status
+	141, // 268: milvus.proto.data.DescribeSnapshotResponse.snapshot_info:type_name -> milvus.proto.data.SnapshotInfo
+	140, // 269: milvus.proto.data.DescribeSnapshotResponse.collection_info:type_name -> milvus.proto.data.CollectionDescription
+	194, // 270: milvus.proto.data.DescribeSnapshotResponse.index_infos:type_name -> milvus.proto.index.IndexInfo
+	175, // 271: milvus.proto.data.RestoreSnapshotRequest.base:type_name -> milvus.proto.common.MsgBase
+	176, // 272: milvus.proto.data.RestoreSnapshotResponse.status:type_name -> milvus.proto.common.Status
+	175, // 273: milvus.proto.data.GetRestoreSnapshotStateRequest.base:type_name -> milvus.proto.common.MsgBase
+	176, // 274: milvus.proto.data.GetRestoreSnapshotStateResponse.status:type_name -> milvus.proto.common.Status
+	144, // 275: milvus.proto.data.GetRestoreSnapshotStateResponse.info:type_name -> milvus.proto.data.RestoreSnapshotInfo
+	175, // 276: milvus.proto.data.ListRestoreSnapshotJobsRequest.base:type_name -> milvus.proto.common.MsgBase
+	176, // 277: milvus.proto.data.ListRestoreSnapshotJobsResponse.status:type_name -> milvus.proto.common.Status
+	144, // 278: milvus.proto.data.ListRestoreSnapshotJobsResponse.jobs:type_name -> milvus.proto.data.RestoreSnapshotInfo
+	179, // 279: milvus.proto.data.FlushResponse.ChannelCpsEntry.value:type_name -> milvus.proto.msg.MsgPosition
+	179, // 280: milvus.proto.data.FlushResult.ChannelCpsEntry.value:type_name -> milvus.proto.msg.MsgPosition
+	195, // 281: milvus.proto.data.FlushAllResponse.FlushAllMsgsEntry.value:type_name -> milvus.proto.common.ImmutableMessage
+	179, // 282: milvus.proto.data.GetSegmentInfoResponse.ChannelCheckpointEntry.value:type_name -> milvus.proto.msg.MsgPosition
+	51,  // 283: milvus.proto.data.SegmentInfo.TextStatsLogsEntry.value:type_name -> milvus.proto.data.TextIndexStats
+	52,  // 284: milvus.proto.data.SegmentInfo.JsonKeyStatsEntry.value:type_name -> milvus.proto.data.JsonKeyStats
+	51,  // 285: milvus.proto.data.SegmentBinlogs.TextStatsLogsEntry.value:type_name -> milvus.proto.data.TextIndexStats
+	68,  // 286: milvus.proto.data.SyncSegmentsRequest.SegmentInfosEntry.value:type_name -> milvus.proto.data.SyncSegmentInfo
+	51,  // 287: milvus.proto.data.CompactionSegment.TextStatsLogsEntry.value:type_name -> milvus.proto.data.TextIndexStats
+	102, // 288: milvus.proto.data.ImportFileStats.HashedStatsEntry.value:type_name -> milvus.proto.data.PartitionImportStats
+	51,  // 289: milvus.proto.data.CopySegmentSource.TextIndexFilesEntry.value:type_name -> milvus.proto.data.TextIndexStats
+	52,  // 290: milvus.proto.data.CopySegmentSource.JsonKeyIndexFilesEntry.value:type_name -> milvus.proto.data.JsonKeyStats
+	115, // 291: milvus.proto.data.CopySegmentResult.IndexInfosEntry.value:type_name -> milvus.proto.data.VectorScalarIndexInfo
+	51,  // 292: milvus.proto.data.CopySegmentResult.TextIndexInfosEntry.value:type_name -> milvus.proto.data.TextIndexStats
+	52,  // 293: milvus.proto.data.CopySegmentResult.JsonKeyIndexInfosEntry.value:type_name -> milvus.proto.data.JsonKeyStats
+	51,  // 294: milvus.proto.data.SegmentDescription.TextIndexFilesEntry.value:type_name -> milvus.proto.data.TextIndexStats
+	52,  // 295: milvus.proto.data.SegmentDescription.JsonKeyIndexFilesEntry.value:type_name -> milvus.proto.data.JsonKeyStats
+	13,  // 296: milvus.proto.data.DataCoord.Flush:input_type -> milvus.proto.data.FlushRequest
+	16,  // 297: milvus.proto.data.DataCoord.FlushAll:input_type -> milvus.proto.data.FlushAllRequest
+	196, // 298: milvus.proto.data.DataCoord.CreateExternalCollection:input_type -> milvus.proto.msg.CreateCollectionRequest
+	21,  // 299: milvus.proto.data.DataCoord.AllocSegment:input_type -> milvus.proto.data.AllocSegmentRequest
+	23,  // 300: milvus.proto.data.DataCoord.AssignSegmentID:input_type -> milvus.proto.data.AssignSegmentIDRequest
+	29,  // 301: milvus.proto.data.DataCoord.GetSegmentInfo:input_type -> milvus.proto.data.GetSegmentInfoRequest
+	26,  // 302: milvus.proto.data.DataCoord.GetSegmentStates:input_type -> milvus.proto.data.GetSegmentStatesRequest
+	31,  // 303: milvus.proto.data.DataCoord.GetInsertBinlogPaths:input_type -> milvus.proto.data.GetInsertBinlogPathsRequest
+	33,  // 304: milvus.proto.data.DataCoord.GetCollectionStatistics:input_type -> milvus.proto.data.GetCollectionStatisticsRequest
+	35,  // 305: milvus.proto.data.DataCoord.GetPartitionStatistics:input_type -> milvus.proto.data.GetPartitionStatisticsRequest
+	37,  // 306: milvus.proto.data.DataCoord.GetSegmentInfoChannel:input_type -> milvus.proto.data.GetSegmentInfoChannelRequest
+	44,  // 307: milvus.proto.data.DataCoord.SaveBinlogPaths:input_type -> milvus.proto.data.SaveBinlogPathsRequest
+	55,  // 308: milvus.proto.data.DataCoord.GetRecoveryInfo:input_type -> milvus.proto.data.GetRecoveryInfoRequest
+	57,  // 309: milvus.proto.data.DataCoord.GetRecoveryInfoV2:input_type -> milvus.proto.data.GetRecoveryInfoRequestV2
+	58,  // 310: milvus.proto.data.DataCoord.GetChannelRecoveryInfo:input_type -> milvus.proto.data.GetChannelRecoveryInfoRequest
+	63,  // 311: milvus.proto.data.DataCoord.GetFlushedSegments:input_type -> milvus.proto.data.GetFlushedSegmentsRequest
+	61,  // 312: milvus.proto.data.DataCoord.GetSegmentsByStates:input_type -> milvus.proto.data.GetSegmentsByStatesRequest
+	197, // 313: milvus.proto.data.DataCoord.GetFlushAllState:input_type -> milvus.proto.milvus.GetFlushAllStateRequest
+	198, // 314: milvus.proto.data.DataCoord.ShowConfigurations:input_type -> milvus.proto.internal.ShowConfigurationsRequest
+	199, // 315: milvus.proto.data.DataCoord.GetMetrics:input_type -> milvus.proto.milvus.GetMetricsRequest
+	200, // 316: milvus.proto.data.DataCoord.ManualCompaction:input_type -> milvus.proto.milvus.ManualCompactionRequest
+	201, // 317: milvus.proto.data.DataCoord.GetCompactionState:input_type -> milvus.proto.milvus.GetCompactionStateRequest
+	202, // 318: milvus.proto.data.DataCoord.GetCompactionStateWithPlans:input_type -> milvus.proto.milvus.GetCompactionPlansRequest
+	76,  // 319: milvus.proto.data.DataCoord.WatchChannels:input_type -> milvus.proto.data.WatchChannelsRequest
+	94,  // 320: milvus.proto.data.DataCoord.GetFlushState:input_type -> milvus.proto.data.GetFlushStateRequest
+	80,  // 321: milvus.proto.data.DataCoord.DropVirtualChannel:input_type -> milvus.proto.data.DropVirtualChannelRequest
+	78,  // 322: milvus.proto.data.DataCoord.SetSegmentState:input_type -> milvus.proto.data.SetSegmentStateRequest
+	83,  // 323: milvus.proto.data.DataCoord.UpdateSegmentStatistics:input_type -> milvus.proto.data.UpdateSegmentStatisticsRequest
+	84,  // 324: milvus.proto.data.DataCoord.UpdateChannelCheckpoint:input_type -> milvus.proto.data.UpdateChannelCheckpointRequest
+	87,  // 325: milvus.proto.data.DataCoord.MarkSegmentsDropped:input_type -> milvus.proto.data.MarkSegmentsDroppedRequest
+	89,  // 326: milvus.proto.data.DataCoord.BroadcastAlteredCollection:input_type -> milvus.proto.data.AlterCollectionRequest
+	203, // 327: milvus.proto.data.DataCoord.CheckHealth:input_type -> milvus.proto.milvus.CheckHealthRequest
+	204, // 328: milvus.proto.data.DataCoord.CreateIndex:input_type -> milvus.proto.index.CreateIndexRequest
+	205, // 329: milvus.proto.data.DataCoord.AlterIndex:input_type -> milvus.proto.index.AlterIndexRequest
+	206, // 330: milvus.proto.data.DataCoord.GetIndexState:input_type -> milvus.proto.index.GetIndexStateRequest
+	207, // 331: milvus.proto.data.DataCoord.GetSegmentIndexState:input_type -> milvus.proto.index.GetSegmentIndexStateRequest
+	208, // 332: milvus.proto.data.DataCoord.GetIndexInfos:input_type -> milvus.proto.index.GetIndexInfoRequest
+	209, // 333: milvus.proto.data.DataCoord.DropIndex:input_type -> milvus.proto.index.DropIndexRequest
+	210, // 334: milvus.proto.data.DataCoord.DescribeIndex:input_type -> milvus.proto.index.DescribeIndexRequest
+	211, // 335: milvus.proto.data.DataCoord.GetIndexStatistics:input_type -> milvus.proto.index.GetIndexStatisticsRequest
+	212, // 336: milvus.proto.data.DataCoord.GetIndexBuildProgress:input_type -> milvus.proto.index.GetIndexBuildProgressRequest
+	213, // 337: milvus.proto.data.DataCoord.ListIndexes:input_type -> milvus.proto.index.ListIndexesRequest
+	91,  // 338: milvus.proto.data.DataCoord.GcConfirm:input_type -> milvus.proto.data.GcConfirmRequest
+	93,  // 339: milvus.proto.data.DataCoord.ReportDataNodeTtMsgs:input_type -> milvus.proto.data.ReportDataNodeTtMsgsRequest
+	123, // 340: milvus.proto.data.DataCoord.GcControl:input_type -> milvus.proto.data.GcControlRequest
+	214, // 341: milvus.proto.data.DataCoord.ImportV2:input_type -> milvus.proto.internal.ImportRequestInternal
+	215, // 342: milvus.proto.data.DataCoord.GetImportProgress:input_type -> milvus.proto.internal.GetImportProgressRequest
+	216, // 343: milvus.proto.data.DataCoord.ListImports:input_type -> milvus.proto.internal.ListImportsRequestInternal
+	217, // 344: milvus.proto.data.DataCoord.AddFileResource:input_type -> milvus.proto.milvus.AddFileResourceRequest
+	218, // 345: milvus.proto.data.DataCoord.RemoveFileResource:input_type -> milvus.proto.milvus.RemoveFileResourceRequest
+	219, // 346: milvus.proto.data.DataCoord.ListFileResources:input_type -> milvus.proto.milvus.ListFileResourcesRequest
+	135, // 347: milvus.proto.data.DataCoord.CreateSnapshot:input_type -> milvus.proto.data.CreateSnapshotRequest
+	136, // 348: milvus.proto.data.DataCoord.DropSnapshot:input_type -> milvus.proto.data.DropSnapshotRequest
+	137, // 349: milvus.proto.data.DataCoord.ListSnapshots:input_type -> milvus.proto.data.ListSnapshotsRequest
+	145, // 350: milvus.proto.data.DataCoord.DescribeSnapshot:input_type -> milvus.proto.data.DescribeSnapshotRequest
+	147, // 351: milvus.proto.data.DataCoord.RestoreSnapshot:input_type -> milvus.proto.data.RestoreSnapshotRequest
+	149, // 352: milvus.proto.data.DataCoord.GetRestoreSnapshotState:input_type -> milvus.proto.data.GetRestoreSnapshotStateRequest
+	151, // 353: milvus.proto.data.DataCoord.ListRestoreSnapshotJobs:input_type -> milvus.proto.data.ListRestoreSnapshotJobsRequest
+	220, // 354: milvus.proto.data.DataNode.GetComponentStates:input_type -> milvus.proto.milvus.GetComponentStatesRequest
+	221, // 355: milvus.proto.data.DataNode.GetStatisticsChannel:input_type -> milvus.proto.internal.GetStatisticsChannelRequest
+	39,  // 356: milvus.proto.data.DataNode.WatchDmChannels:input_type -> milvus.proto.data.WatchDmChannelsRequest
+	40,  // 357: milvus.proto.data.DataNode.FlushSegments:input_type -> milvus.proto.data.FlushSegmentsRequest
+	198, // 358: milvus.proto.data.DataNode.ShowConfigurations:input_type -> milvus.proto.internal.ShowConfigurationsRequest
+	199, // 359: milvus.proto.data.DataNode.GetMetrics:input_type -> milvus.proto.milvus.GetMetricsRequest
+	71,  // 360: milvus.proto.data.DataNode.CompactionV2:input_type -> milvus.proto.data.CompactionPlan
+	67,  // 361: milvus.proto.data.DataNode.GetCompactionState:input_type -> milvus.proto.data.CompactionStateRequest
+	69,  // 362: milvus.proto.data.DataNode.SyncSegments:input_type -> milvus.proto.data.SyncSegmentsRequest
+	85,  // 363: milvus.proto.data.DataNode.ResendSegmentStats:input_type -> milvus.proto.data.ResendSegmentStatsRequest
+	19,  // 364: milvus.proto.data.DataNode.FlushChannels:input_type -> milvus.proto.data.FlushChannelsRequest
+	95,  // 365: milvus.proto.data.DataNode.NotifyChannelOperation:input_type -> milvus.proto.data.ChannelOperationsRequest
+	66,  // 366: milvus.proto.data.DataNode.CheckChannelOperationProgress:input_type -> milvus.proto.data.ChannelWatchInfo
+	97,  // 367: milvus.proto.data.DataNode.PreImport:input_type -> milvus.proto.data.PreImportRequest
+	100, // 368: milvus.proto.data.DataNode.ImportV2:input_type -> milvus.proto.data.ImportRequest
+	101, // 369: milvus.proto.data.DataNode.QueryPreImport:input_type -> milvus.proto.data.QueryPreImportRequest
+	105, // 370: milvus.proto.data.DataNode.QueryImport:input_type -> milvus.proto.data.QueryImportRequest
+	108, // 371: milvus.proto.data.DataNode.DropImport:input_type -> milvus.proto.data.DropImportRequest
+	125, // 372: milvus.proto.data.DataNode.QuerySlot:input_type -> milvus.proto.data.QuerySlotRequest
+	129, // 373: milvus.proto.data.DataNode.DropCompactionPlan:input_type -> milvus.proto.data.DropCompactionPlanRequest
+	222, // 374: milvus.proto.data.DataNode.SyncFileResource:input_type -> milvus.proto.internal.SyncFileResourceRequest
+	14,  // 375: milvus.proto.data.DataCoord.Flush:output_type -> milvus.proto.data.FlushResponse
+	18,  // 376: milvus.proto.data.DataCoord.FlushAll:output_type -> milvus.proto.data.FlushAllResponse
+	130, // 377: milvus.proto.data.DataCoord.CreateExternalCollection:output_type -> milvus.proto.data.CreateExternalCollectionResponse
+	22,  // 378: milvus.proto.data.DataCoord.AllocSegment:output_type -> milvus.proto.data.AllocSegmentResponse
+	25,  // 379: milvus.proto.data.DataCoord.AssignSegmentID:output_type -> milvus.proto.data.AssignSegmentIDResponse
+	30,  // 380: milvus.proto.data.DataCoord.GetSegmentInfo:output_type -> milvus.proto.data.GetSegmentInfoResponse
+	28,  // 381: milvus.proto.data.DataCoord.GetSegmentStates:output_type -> milvus.proto.data.GetSegmentStatesResponse
+	32,  // 382: milvus.proto.data.DataCoord.GetInsertBinlogPaths:output_type -> milvus.proto.data.GetInsertBinlogPathsResponse
+	34,  // 383: milvus.proto.data.DataCoord.GetCollectionStatistics:output_type -> milvus.proto.data.GetCollectionStatisticsResponse
+	36,  // 384: milvus.proto.data.DataCoord.GetPartitionStatistics:output_type -> milvus.proto.data.GetPartitionStatisticsResponse
+	223, // 385: milvus.proto.data.DataCoord.GetSegmentInfoChannel:output_type -> milvus.proto.milvus.StringResponse
+	176, // 386: milvus.proto.data.DataCoord.SaveBinlogPaths:output_type -> milvus.proto.common.Status
+	54,  // 387: milvus.proto.data.DataCoord.GetRecoveryInfo:output_type -> milvus.proto.data.GetRecoveryInfoResponse
+	56,  // 388: milvus.proto.data.DataCoord.GetRecoveryInfoV2:output_type -> milvus.proto.data.GetRecoveryInfoResponseV2
+	59,  // 389: milvus.proto.data.DataCoord.GetChannelRecoveryInfo:output_type -> milvus.proto.data.GetChannelRecoveryInfoResponse
+	64,  // 390: milvus.proto.data.DataCoord.GetFlushedSegments:output_type -> milvus.proto.data.GetFlushedSegmentsResponse
+	62,  // 391: milvus.proto.data.DataCoord.GetSegmentsByStates:output_type -> milvus.proto.data.GetSegmentsByStatesResponse
+	224, // 392: milvus.proto.data.DataCoord.GetFlushAllState:output_type -> milvus.proto.milvus.GetFlushAllStateResponse
+	225, // 393: milvus.proto.data.DataCoord.ShowConfigurations:output_type -> milvus.proto.internal.ShowConfigurationsResponse
+	226, // 394: milvus.proto.data.DataCoord.GetMetrics:output_type -> milvus.proto.milvus.GetMetricsResponse
+	227, // 395: milvus.proto.data.DataCoord.ManualCompaction:output_type -> milvus.proto.milvus.ManualCompactionResponse
+	228, // 396: milvus.proto.data.DataCoord.GetCompactionState:output_type -> milvus.proto.milvus.GetCompactionStateResponse
+	229, // 397: milvus.proto.data.DataCoord.GetCompactionStateWithPlans:output_type -> milvus.proto.milvus.GetCompactionPlansResponse
+	77,  // 398: milvus.proto.data.DataCoord.WatchChannels:output_type -> milvus.proto.data.WatchChannelsResponse
+	230, // 399: milvus.proto.data.DataCoord.GetFlushState:output_type -> milvus.proto.milvus.GetFlushStateResponse
+	82,  // 400: milvus.proto.data.DataCoord.DropVirtualChannel:output_type -> milvus.proto.data.DropVirtualChannelResponse
+	79,  // 401: milvus.proto.data.DataCoord.SetSegmentState:output_type -> milvus.proto.data.SetSegmentStateResponse
+	176, // 402: milvus.proto.data.DataCoord.UpdateSegmentStatistics:output_type -> milvus.proto.common.Status
+	176, // 403: milvus.proto.data.DataCoord.UpdateChannelCheckpoint:output_type -> milvus.proto.common.Status
+	176, // 404: milvus.proto.data.DataCoord.MarkSegmentsDropped:output_type -> milvus.proto.common.Status
+	176, // 405: milvus.proto.data.DataCoord.BroadcastAlteredCollection:output_type -> milvus.proto.common.Status
+	231, // 406: milvus.proto.data.DataCoord.CheckHealth:output_type -> milvus.proto.milvus.CheckHealthResponse
+	176, // 407: milvus.proto.data.DataCoord.CreateIndex:output_type -> milvus.proto.common.Status
+	176, // 408: milvus.proto.data.DataCoord.AlterIndex:output_type -> milvus.proto.common.Status
+	232, // 409: milvus.proto.data.DataCoord.GetIndexState:output_type -> milvus.proto.index.GetIndexStateResponse
+	233, // 410: milvus.proto.data.DataCoord.GetSegmentIndexState:output_type -> milvus.proto.index.GetSegmentIndexStateResponse
+	234, // 411: milvus.proto.data.DataCoord.GetIndexInfos:output_type -> milvus.proto.index.GetIndexInfoResponse
+	176, // 412: milvus.proto.data.DataCoord.DropIndex:output_type -> milvus.proto.common.Status
+	235, // 413: milvus.proto.data.DataCoord.DescribeIndex:output_type -> milvus.proto.index.DescribeIndexResponse
+	236, // 414: milvus.proto.data.DataCoord.GetIndexStatistics:output_type -> milvus.proto.index.GetIndexStatisticsResponse
+	237, // 415: milvus.proto.data.DataCoord.GetIndexBuildProgress:output_type -> milvus.proto.index.GetIndexBuildProgressResponse
+	238, // 416: milvus.proto.data.DataCoord.ListIndexes:output_type -> milvus.proto.index.ListIndexesResponse
+	92,  // 417: milvus.proto.data.DataCoord.GcConfirm:output_type -> milvus.proto.data.GcConfirmResponse
+	176, // 418: milvus.proto.data.DataCoord.ReportDataNodeTtMsgs:output_type -> milvus.proto.common.Status
+	176, // 419: milvus.proto.data.DataCoord.GcControl:output_type -> milvus.proto.common.Status
+	239, // 420: milvus.proto.data.DataCoord.ImportV2:output_type -> milvus.proto.internal.ImportResponse
+	240, // 421: milvus.proto.data.DataCoord.GetImportProgress:output_type -> milvus.proto.internal.GetImportProgressResponse
+	241, // 422: milvus.proto.data.DataCoord.ListImports:output_type -> milvus.proto.internal.ListImportsResponse
+	176, // 423: milvus.proto.data.DataCoord.AddFileResource:output_type -> milvus.proto.common.Status
+	176, // 424: milvus.proto.data.DataCoord.RemoveFileResource:output_type -> milvus.proto.common.Status
+	242, // 425: milvus.proto.data.DataCoord.ListFileResources:output_type -> milvus.proto.milvus.ListFileResourcesResponse
+	176, // 426: milvus.proto.data.DataCoord.CreateSnapshot:output_type -> milvus.proto.common.Status
+	176, // 427: milvus.proto.data.DataCoord.DropSnapshot:output_type -> milvus.proto.common.Status
+	138, // 428: milvus.proto.data.DataCoord.ListSnapshots:output_type -> milvus.proto.data.ListSnapshotsResponse
+	146, // 429: milvus.proto.data.DataCoord.DescribeSnapshot:output_type -> milvus.proto.data.DescribeSnapshotResponse
+	148, // 430: milvus.proto.data.DataCoord.RestoreSnapshot:output_type -> milvus.proto.data.RestoreSnapshotResponse
+	150, // 431: milvus.proto.data.DataCoord.GetRestoreSnapshotState:output_type -> milvus.proto.data.GetRestoreSnapshotStateResponse
+	152, // 432: milvus.proto.data.DataCoord.ListRestoreSnapshotJobs:output_type -> milvus.proto.data.ListRestoreSnapshotJobsResponse
+	243, // 433: milvus.proto.data.DataNode.GetComponentStates:output_type -> milvus.proto.milvus.ComponentStates
+	223, // 434: milvus.proto.data.DataNode.GetStatisticsChannel:output_type -> milvus.proto.milvus.StringResponse
+	176, // 435: milvus.proto.data.DataNode.WatchDmChannels:output_type -> milvus.proto.common.Status
+	176, // 436: milvus.proto.data.DataNode.FlushSegments:output_type -> milvus.proto.common.Status
+	225, // 437: milvus.proto.data.DataNode.ShowConfigurations:output_type -> milvus.proto.internal.ShowConfigurationsResponse
+	226, // 438: milvus.proto.data.DataNode.GetMetrics:output_type -> milvus.proto.milvus.GetMetricsResponse
+	176, // 439: milvus.proto.data.DataNode.CompactionV2:output_type -> milvus.proto.common.Status
+	74,  // 440: milvus.proto.data.DataNode.GetCompactionState:output_type -> milvus.proto.data.CompactionStateResponse
+	176, // 441: milvus.proto.data.DataNode.SyncSegments:output_type -> milvus.proto.common.Status
+	86,  // 442: milvus.proto.data.DataNode.ResendSegmentStats:output_type -> milvus.proto.data.ResendSegmentStatsResponse
+	176, // 443: milvus.proto.data.DataNode.FlushChannels:output_type -> milvus.proto.common.Status
+	176, // 444: milvus.proto.data.DataNode.NotifyChannelOperation:output_type -> milvus.proto.common.Status
+	96,  // 445: milvus.proto.data.DataNode.CheckChannelOperationProgress:output_type -> milvus.proto.data.ChannelOperationProgressResponse
+	176, // 446: milvus.proto.data.DataNode.PreImport:output_type -> milvus.proto.common.Status
+	176, // 447: milvus.proto.data.DataNode.ImportV2:output_type -> milvus.proto.common.Status
+	104, // 448: milvus.proto.data.DataNode.QueryPreImport:output_type -> milvus.proto.data.QueryPreImportResponse
+	107, // 449: milvus.proto.data.DataNode.QueryImport:output_type -> milvus.proto.data.QueryImportResponse
+	176, // 450: milvus.proto.data.DataNode.DropImport:output_type -> milvus.proto.common.Status
+	126, // 451: milvus.proto.data.DataNode.QuerySlot:output_type -> milvus.proto.data.QuerySlotResponse
+	176, // 452: milvus.proto.data.DataNode.DropCompactionPlan:output_type -> milvus.proto.common.Status
+	176, // 453: milvus.proto.data.DataNode.SyncFileResource:output_type -> milvus.proto.common.Status
+	375, // [375:454] is the sub-list for method output_type
+	296, // [296:375] is the sub-list for method input_type
+	296, // [296:296] is the sub-list for extension type_name
+	296, // [296:296] is the sub-list for extension extendee
+	0,   // [0:296] is the sub-list for field type_name
 }
 
 func init() { file_data_coord_proto_init() }
@@ -17605,7 +17626,7 @@ func file_data_coord_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_data_coord_proto_rawDesc,
 			NumEnums:      12,
-			NumMessages:   162,
+			NumMessages:   163,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/tests/go_client/testcases/nullable_default_value_test.go
+++ b/tests/go_client/testcases/nullable_default_value_test.go
@@ -1962,7 +1962,7 @@ func TestNullableVectorAllNull(t *testing.T) {
 			common.CheckErr(t, err, true)
 
 			// Generate test data with 100% null (nullPercent = 100)
-			nb := 100
+			nb := 10000
 			testData := GenerateNullableVectorTestData(t, vt, nb, 100, "vector")
 
 			pkData := make([]int64, nb)
@@ -1982,8 +1982,34 @@ func TestNullableVectorAllNull(t *testing.T) {
 			err = flushTask.Await(ctx)
 			common.CheckErr(t, err, true)
 
-			// create index and load
-			vecIndex := CreateNullableVectorIndex(vt)
+			// create index (use IVF for dense vectors, requires training)
+			var vecIndex index.Index
+			switch vt.FieldType {
+			case entity.FieldTypeBinaryVector:
+				vecIndex = index.NewGenericIndex("vector", map[string]string{
+					index.MetricTypeKey: string(entity.JACCARD),
+					index.IndexTypeKey:  "BIN_IVF_FLAT",
+					"nlist":             "128",
+				})
+			case entity.FieldTypeSparseVector:
+				vecIndex = index.NewGenericIndex("vector", map[string]string{
+					index.MetricTypeKey: string(entity.IP),
+					index.IndexTypeKey:  "SPARSE_INVERTED_INDEX",
+				})
+			case entity.FieldTypeInt8Vector:
+				vecIndex = index.NewGenericIndex("vector", map[string]string{
+					index.MetricTypeKey: string(entity.COSINE),
+					index.IndexTypeKey:  "HNSW",
+					"M":                 "16",
+					"efConstruction":    "200",
+				})
+			default:
+				vecIndex = index.NewGenericIndex("vector", map[string]string{
+					index.MetricTypeKey: string(entity.L2),
+					index.IndexTypeKey:  "IVF_FLAT",
+					"nlist":             "128",
+				})
+			}
 			indexTask, err := mc.CreateIndex(ctx, client.NewCreateIndexOption(collName, "vector", vecIndex))
 			common.CheckErr(t, err, true)
 			err = indexTask.Await(ctx)


### PR DESCRIPTION
issue: #46890 
related: #45993

Add null_count to binlog metadata and use it to calculate valid rows for nullable vector fields. Skip index creation when valid rows are less than MinSegmentNumRowsToEnableIndex.