### PR TITLE
enhance: Enable split by average size policy by default in storage v2

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -1021,7 +1021,7 @@ common:
         enabled: true # enable split system column policy in storage v2
         includePK: true # whether split system column policy include pk field
       splitByAvgSize:
-        enabled: false # enable split by average size policy in storage v2
+        enabled: true # enable split by average size policy in storage v2
         threshold: 1024 # split by average size policy threshold(in bytes) in storage v2
     useLoonFFI: false
   traceLogMode: 0 # trace request info

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -995,7 +995,7 @@ Large numeric passwords require double quotes to avoid yaml parsing precision is
 	p.Stv2SplitByAvgSize = ParamItem{
 		Key:          "common.storage.stv2.splitByAvgSize.enabled",
 		Version:      "2.6.2",
-		DefaultValue: "false",
+		DefaultValue: "true",
 		Doc:          "enable split by average size policy in storage v2",
 		Export:       true,
 	}


### PR DESCRIPTION
Related to #44257

Enable the splitByAvgSize policy by default for storage v2, which optimizes data layout by splitting columns based on average size rather than fixed boundaries.