### PR TITLE
feat: [2.6] query coord support segment reopen when manifest path changes (#46394)

### DIFF
--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -1045,6 +1045,7 @@ func (s *Server) GetRecoveryInfoV2(ctx context.Context, req *datapb.GetRecoveryI
 			NumOfRows:     rowCount,
 			Level:         segment.GetLevel(),
 			IsSorted:      segment.GetIsSorted(),
+			ManifestPath:  segment.GetManifestPath(),
 		})
 	}
 

--- a/internal/querycoordv2/checkers/segment_checker_test.go
+++ b/internal/querycoordv2/checkers/segment_checker_test.go
@@ -692,12 +692,13 @@ func (suite *SegmentCheckerTestSuite) TestLoadPriority() {
 	suite.checker.targetMgr.UpdateCollectionNextTarget(ctx, collectionID)
 
 	// test getSealedSegmentDiff
-	toLoad, loadPriorities, toRelease := suite.checker.getSealedSegmentDiff(ctx, collectionID, replicaID)
+	toLoad, loadPriorities, toRelease, toUpdate := suite.checker.getSealedSegmentDiff(ctx, collectionID, replicaID)
 
 	// verify results
 	suite.Equal(2, len(toLoad))
 	suite.Equal(2, len(loadPriorities))
 	suite.Equal(0, len(toRelease))
+	suite.Equal(0, len(toUpdate))
 
 	// segment2 not in current target, should use replica's priority
 	suite.True(segment2.GetID() == toLoad[0].GetID() || segment2.GetID() == toLoad[1].GetID())
@@ -713,11 +714,12 @@ func (suite *SegmentCheckerTestSuite) TestLoadPriority() {
 	// update current target to include segment2
 	suite.checker.targetMgr.UpdateCollectionCurrentTarget(ctx, collectionID)
 	// test again
-	toLoad, loadPriorities, toRelease = suite.checker.getSealedSegmentDiff(ctx, collectionID, replicaID)
+	toLoad, loadPriorities, toRelease, toUpdate = suite.checker.getSealedSegmentDiff(ctx, collectionID, replicaID)
 	// verify results
 	suite.Equal(0, len(toLoad))
 	suite.Equal(0, len(loadPriorities))
 	suite.Equal(0, len(toRelease))
+	suite.Equal(0, len(toUpdate))
 }
 
 func (suite *SegmentCheckerTestSuite) TestFilterOutExistedOnLeader() {

--- a/internal/querycoordv2/dist/dist_handler.go
+++ b/internal/querycoordv2/dist/dist_handler.go
@@ -206,6 +206,7 @@ func (dh *distHandler) updateSegmentsDistribution(ctx context.Context, resp *que
 			LastDeltaTimestamp: s.GetLastDeltaTimestamp(),
 			IndexInfo:          s.GetIndexInfo(),
 			JSONStatsField:     s.GetJsonStatsInfo(),
+			ManifestPath:       s.GetManifestPath(),
 		})
 	}
 

--- a/internal/querycoordv2/meta/segment_dist_manager.go
+++ b/internal/querycoordv2/meta/segment_dist_manager.go
@@ -126,6 +126,7 @@ type Segment struct {
 	LastDeltaTimestamp uint64                            // The timestamp of the last delta record
 	IndexInfo          map[int64]*querypb.FieldIndexInfo // index info of loaded segment, indexID -> FieldIndexInfo
 	JSONStatsField     map[int64]*querypb.JsonStatsInfo  // json index info of loaded segment
+	ManifestPath       string                            // current manifest path of loaded segment
 }
 
 func SegmentFromInfo(info *datapb.SegmentInfo) *Segment {

--- a/internal/querycoordv2/task/action.go
+++ b/internal/querycoordv2/task/action.go
@@ -35,6 +35,7 @@ const (
 	ActionTypeUpdate
 	ActionTypeStatsUpdate
 	ActionTypeDropIndex
+	ActionTypeReopen
 )
 
 var ActionTypeName = map[ActionType]string{
@@ -42,6 +43,8 @@ var ActionTypeName = map[ActionType]string{
 	ActionTypeReduce:      "Reduce",
 	ActionTypeUpdate:      "Update",
 	ActionTypeStatsUpdate: "StatsUpdate",
+	ActionTypeDropIndex:   "DropIndex",
+	ActionTypeReopen:      "Reopen",
 }
 
 func (t ActionType) String() string {

--- a/internal/querycoordv2/task/utils.go
+++ b/internal/querycoordv2/task/utils.go
@@ -141,6 +141,10 @@ func packLoadSegmentRequest(
 		loadScope = querypb.LoadScope_Stats
 	}
 
+	if action.Type() == ActionTypeReopen {
+		loadScope = querypb.LoadScope_Reopen
+	}
+
 	if task.Source() == utils.LeaderChecker {
 		loadScope = querypb.LoadScope_Delta
 	}

--- a/internal/querycoordv2/utils/util.go
+++ b/internal/querycoordv2/utils/util.go
@@ -87,6 +87,33 @@ func CheckDelegatorDataReady(nodeMgr *session.NodeManager, targetMgr meta.Target
 	return nil
 }
 
+func CheckSegmentDataReady(ctx context.Context, collectionID int64, distManager *meta.DistributionManager, targetMgr meta.TargetManagerInterface, scope int32) error {
+	log := log.Ctx(ctx).
+		WithRateGroup(fmt.Sprintf("util.CheckSegmentDataReady-%d", collectionID), 1, 60).
+		With(zap.Int64("collectionID", collectionID))
+
+	// Check whether segments are fully loaded
+	segmentDist := targetMgr.GetSealedSegmentsByCollection(ctx, collectionID, scope)
+	for segmentID, segmentInfo := range segmentDist {
+		segments := distManager.SegmentDistManager.GetByFilter(meta.WithCollectionID(collectionID), meta.WithSegmentID(segmentID))
+		if len(segments) == 0 {
+			log.RatedInfo(10, "segment is not available", zap.Int64("segmentID", segmentID))
+			return merr.WrapErrSegmentLack(segmentID)
+		}
+
+		for _, segment := range segments {
+			// Compare manifest path for now
+			// alternative is to compare version, but it's not recommended to add extra info in segmentinfo
+			// we may use data view version in the future
+			if segment.ManifestPath != segmentInfo.GetManifestPath() {
+				log.RatedInfo(10, "segment is not updated", zap.Int64("segmentID", segmentID))
+				return merr.WrapErrSegmentNotLoaded(segmentID)
+			}
+		}
+	}
+	return nil
+}
+
 func checkLoadStatus(ctx context.Context, m *meta.Meta, collectionID int64) error {
 	percentage := m.CollectionManager.CalculateLoadPercentage(ctx, collectionID)
 	if percentage < 0 {

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -2545,6 +2545,8 @@ type queryCoordConfig struct {
 	BalanceCheckCollectionMaxCount    ParamItem `refreshable:"true"`
 	ResourceExhaustionPenaltyDuration ParamItem `refreshable:"true"`
 	ResourceExhaustionCleanupInterval ParamItem `refreshable:"true"`
+
+	UpdateTargetNeedSegmentDataReady ParamItem `refreshable:"true"`
 }
 
 func (p *queryCoordConfig) init(base *BaseTable) {
@@ -3205,6 +3207,15 @@ Set to 0 to disable the penalty period.`,
 		Export:       true,
 	}
 	p.ResourceExhaustionCleanupInterval.Init(base.mgr)
+
+	p.UpdateTargetNeedSegmentDataReady = ParamItem{
+		Key:          "queryCoord.updateTargetNeedSegmentDataReady",
+		Version:      "2.6.8",
+		DefaultValue: "true",
+		Doc:          "update target need segment data ready",
+		Export:       false,
+	}
+	p.UpdateTargetNeedSegmentDataReady.Init(base.mgr)
 }
 
 // /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Cherry-pick from master
pr: #46394 #46470

Related to #46358

Add segment reopen mechanism in QueryCoord to handle segment data
updates when the manifest path changes. This enables QueryNode to reload
segment data without full segment reload, supporting storage v2
incremental updates.

Changes:
- Add ActionTypeReopen action type and LoadScope_Reopen in protobuf
- Track ManifestPath in segment distribution metadata
- Add CheckSegmentDataReady utility to verify segment data matches
target
- Extend getSealedSegmentDiff to detect segments needing reopen
- Create segment reopen tasks when manifest path differs from target
- Block target update until segment data is ready

-----------------------------------------

Add ManifestPath field to SegmentInfo in GetRecoveryInfoV2 response,
enabling QueryCoord to detect manifest path changes and trigger segment
reopen for storage v2 incremental updates.
