### PR TITLE
test: add empty struct array test coverage for bulk writer

### DIFF
--- a/tests/python_client/requirements.txt
+++ b/tests/python_client/requirements.txt
@@ -28,8 +28,8 @@ pytest-parallel
 pytest-random-order
 
 # pymilvus
-pymilvus==2.7.0rc100
-pymilvus[bulk_writer]==2.7.0rc100
+pymilvus==2.7.0rc102
+pymilvus[bulk_writer]==2.7.0rc102
 # for protobuf
 protobuf>=5.29.5
 


### PR DESCRIPTION
## Summary
- Remove xfail marker from `test_import_struct_array_with_local_bulk_writer` as the related pymilvus issue is fixed
- Add test coverage for empty struct_array in bulk writer tests

## Changes
1. Remove `@pytest.mark.xfail(reason="issue: https://github.com/milvus-io/pymilvus/issues/3050")` marker
2. Add 10% probability to generate empty `struct_array` (`[]`) in test data
3. Add logging for empty array count to track test coverage

## Related PRs
- pymilvus fix: https://github.com/milvus-io/pymilvus/pull/3182

## Test Plan
- [x] Tested with Milvus 2.6.8 and pymilvus fix
- [x] Both PARQUET and JSON formats pass
- [x] Empty struct arrays are correctly written, imported, and queried