### PR TITLE
fix: three-valued logic for NullExpr, ExistsExpr and logical operators

### DIFF
--- a/internal/core/src/common/ThreeValuedLogicOpTest.cpp
+++ b/internal/core/src/common/ThreeValuedLogicOpTest.cpp
@@ -513,14 +513,14 @@ TEST(ThreeValuedLogicOpTest, DeMorganOrToAnd) {
     // Test: NOT (A OR B) == NOT A AND NOT B
     // With all 9 combinations of A, B in {T, F, NULL}
 
-    std::vector<bool> a_data = {true, true,  true,  false, false,
-                                false, false, false, false};
-    std::vector<bool> a_valid = {true, true,  true,  true, true,
-                                 true, false, false, false};
-    std::vector<bool> b_data = {true, false, false, true, false,
-                                false, true,  false, false};
-    std::vector<bool> b_valid = {true, true, false, true, true,
-                                 false, true, true,  false};
+    std::vector<bool> a_data = {
+        true, true, true, false, false, false, false, false, false};
+    std::vector<bool> a_valid = {
+        true, true, true, true, true, true, false, false, false};
+    std::vector<bool> b_data = {
+        true, false, false, true, false, false, true, false, false};
+    std::vector<bool> b_valid = {
+        true, true, false, true, true, false, true, true, false};
 
     // Method 1: NOT (A OR B)
     auto left1 = CreateColumnVector(a_data, a_valid);
@@ -549,14 +549,14 @@ TEST(ThreeValuedLogicOpTest, DeMorganAndToOr) {
     // Test: NOT (A AND B) == NOT A OR NOT B
     // With all 9 combinations of A, B in {T, F, NULL}
 
-    std::vector<bool> a_data = {true, true,  true,  false, false,
-                                false, false, false, false};
-    std::vector<bool> a_valid = {true, true,  true,  true, true,
-                                 true, false, false, false};
-    std::vector<bool> b_data = {true, false, false, true, false,
-                                false, true,  false, false};
-    std::vector<bool> b_valid = {true, true, false, true, true,
-                                 false, true, true,  false};
+    std::vector<bool> a_data = {
+        true, true, true, false, false, false, false, false, false};
+    std::vector<bool> a_valid = {
+        true, true, true, true, true, true, false, false, false};
+    std::vector<bool> b_data = {
+        true, false, false, true, false, false, true, false, false};
+    std::vector<bool> b_valid = {
+        true, true, false, true, true, false, true, true, false};
 
     // Method 1: NOT (A AND B)
     auto left1 = CreateColumnVector(a_data, a_valid);
@@ -620,11 +620,12 @@ TEST(ThreeValuedLogicOpTest, LargeScaleAnd) {
         // OR (both are valid)
         bool left_definitely_false = l_valid && !l_data;
         bool right_definitely_false = r_valid && !r_data;
-        bool exp_valid =
-            left_definitely_false || right_definitely_false || (l_valid && r_valid);
+        bool exp_valid = left_definitely_false || right_definitely_false ||
+                         (l_valid && r_valid);
 
         EXPECT_EQ(result_data[i], exp_data) << "Data mismatch at index " << i;
-        EXPECT_EQ(result_valid[i], exp_valid) << "Valid mismatch at index " << i;
+        EXPECT_EQ(result_valid[i], exp_valid)
+            << "Valid mismatch at index " << i;
     }
 }
 
@@ -663,10 +664,11 @@ TEST(ThreeValuedLogicOpTest, LargeScaleOr) {
         // OR (both are valid)
         bool left_definitely_true = l_valid && l_data;
         bool right_definitely_true = r_valid && r_data;
-        bool exp_valid =
-            left_definitely_true || right_definitely_true || (l_valid && r_valid);
+        bool exp_valid = left_definitely_true || right_definitely_true ||
+                         (l_valid && r_valid);
 
         EXPECT_EQ(result_data[i], exp_data) << "Data mismatch at index " << i;
-        EXPECT_EQ(result_valid[i], exp_valid) << "Valid mismatch at index " << i;
+        EXPECT_EQ(result_valid[i], exp_valid)
+            << "Valid mismatch at index " << i;
     }
 }

--- a/internal/core/src/common/ThreeValuedLogicOpTest.cpp
+++ b/internal/core/src/common/ThreeValuedLogicOpTest.cpp
@@ -1,0 +1,672 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include "common/ValueOp.h"
+#include "common/Vector.h"
+
+using namespace milvus;
+using namespace milvus::common;
+
+// Helper function to create a ColumnVector with given data and valid bitmaps
+ColumnVectorPtr
+CreateColumnVector(const std::vector<bool>& data,
+                   const std::vector<bool>& valid) {
+    size_t size = data.size();
+    TargetBitmap data_bitmap(size);
+    TargetBitmap valid_bitmap(size);
+    for (size_t i = 0; i < size; ++i) {
+        if (data[i]) {
+            data_bitmap.set(i);
+        }
+        if (valid[i]) {
+            valid_bitmap.set(i);
+        }
+    }
+    return std::make_shared<ColumnVector>(std::move(data_bitmap),
+                                          std::move(valid_bitmap));
+}
+
+// Helper function to extract results from ColumnVector
+void
+ExtractResults(const ColumnVectorPtr& vec,
+               std::vector<bool>& data,
+               std::vector<bool>& valid) {
+    size_t size = vec->size();
+    data.resize(size);
+    valid.resize(size);
+    TargetBitmapView data_view(vec->GetRawData(), size);
+    TargetBitmapView valid_view(vec->GetValidRawData(), size);
+    for (size_t i = 0; i < size; ++i) {
+        data[i] = data_view[i];
+        valid[i] = valid_view[i];
+    }
+}
+
+// ============================================================================
+// NOT Operation Tests
+// ============================================================================
+
+// Three-valued logic NOT truth table:
+// | A     | NOT A |
+// |-------|-------|
+// | T     | F     |
+// | F     | T     |
+// | NULL  | NULL  |
+
+TEST(ThreeValuedLogicOpTest, NotTrueReturnsFalse) {
+    // NOT TRUE = FALSE
+    auto vec = CreateColumnVector({true}, {true});
+    ThreeValuedLogicOp::Not(vec);
+
+    std::vector<bool> data, valid;
+    ExtractResults(vec, data, valid);
+
+    EXPECT_FALSE(data[0]);  // NOT TRUE = FALSE
+    EXPECT_TRUE(valid[0]);  // Result is valid (determined)
+}
+
+TEST(ThreeValuedLogicOpTest, NotFalseReturnsTrue) {
+    // NOT FALSE = TRUE
+    auto vec = CreateColumnVector({false}, {true});
+    ThreeValuedLogicOp::Not(vec);
+
+    std::vector<bool> data, valid;
+    ExtractResults(vec, data, valid);
+
+    EXPECT_TRUE(data[0]);   // NOT FALSE = TRUE
+    EXPECT_TRUE(valid[0]);  // Result is valid (determined)
+}
+
+TEST(ThreeValuedLogicOpTest, NotNullReturnsNull) {
+    // NOT NULL = NULL
+    auto vec = CreateColumnVector({false}, {false});
+    ThreeValuedLogicOp::Not(vec);
+
+    std::vector<bool> data, valid;
+    ExtractResults(vec, data, valid);
+
+    EXPECT_FALSE(data[0]);   // Data is false (but meaningless since invalid)
+    EXPECT_FALSE(valid[0]);  // Result is NULL (undetermined)
+}
+
+TEST(ThreeValuedLogicOpTest, NotMultipleValues) {
+    // Test multiple values at once
+    // Input:  [T,    F,    NULL]
+    // Output: [F,    T,    NULL]
+    auto vec = CreateColumnVector({true, false, false}, {true, true, false});
+    ThreeValuedLogicOp::Not(vec);
+
+    std::vector<bool> data, valid;
+    ExtractResults(vec, data, valid);
+
+    EXPECT_FALSE(data[0]);   // NOT TRUE = FALSE
+    EXPECT_TRUE(valid[0]);   // Valid
+    EXPECT_TRUE(data[1]);    // NOT FALSE = TRUE
+    EXPECT_TRUE(valid[1]);   // Valid
+    EXPECT_FALSE(data[2]);   // NOT NULL -> data is false
+    EXPECT_FALSE(valid[2]);  // NULL
+}
+
+// ============================================================================
+// AND Operation Tests
+// ============================================================================
+
+// Three-valued logic AND truth table:
+// | A     | B     | A AND B |
+// |-------|-------|---------|
+// | T     | T     | T       |
+// | T     | F     | F       |
+// | T     | NULL  | NULL    |
+// | F     | T     | F       |
+// | F     | F     | F       |
+// | F     | NULL  | F       |  <- F AND NULL = F (determined)
+// | NULL  | T     | NULL    |
+// | NULL  | F     | F       |  <- NULL AND F = F (determined)
+// | NULL  | NULL  | NULL    |
+
+TEST(ThreeValuedLogicOpTest, AndTrueTrue) {
+    auto left = CreateColumnVector({true}, {true});
+    auto right = CreateColumnVector({true}, {true});
+    ThreeValuedLogicOp::And(left, right);
+
+    std::vector<bool> data, valid;
+    ExtractResults(left, data, valid);
+
+    EXPECT_TRUE(data[0]);   // T AND T = T
+    EXPECT_TRUE(valid[0]);  // Valid
+}
+
+TEST(ThreeValuedLogicOpTest, AndTrueFalse) {
+    auto left = CreateColumnVector({true}, {true});
+    auto right = CreateColumnVector({false}, {true});
+    ThreeValuedLogicOp::And(left, right);
+
+    std::vector<bool> data, valid;
+    ExtractResults(left, data, valid);
+
+    EXPECT_FALSE(data[0]);  // T AND F = F
+    EXPECT_TRUE(valid[0]);  // Valid
+}
+
+TEST(ThreeValuedLogicOpTest, AndTrueNull) {
+    auto left = CreateColumnVector({true}, {true});
+    auto right = CreateColumnVector({false}, {false});  // NULL
+    ThreeValuedLogicOp::And(left, right);
+
+    std::vector<bool> data, valid;
+    ExtractResults(left, data, valid);
+
+    EXPECT_FALSE(data[0]);   // T AND NULL -> data is false
+    EXPECT_FALSE(valid[0]);  // NULL (undetermined)
+}
+
+TEST(ThreeValuedLogicOpTest, AndFalseTrue) {
+    auto left = CreateColumnVector({false}, {true});
+    auto right = CreateColumnVector({true}, {true});
+    ThreeValuedLogicOp::And(left, right);
+
+    std::vector<bool> data, valid;
+    ExtractResults(left, data, valid);
+
+    EXPECT_FALSE(data[0]);  // F AND T = F
+    EXPECT_TRUE(valid[0]);  // Valid
+}
+
+TEST(ThreeValuedLogicOpTest, AndFalseFalse) {
+    auto left = CreateColumnVector({false}, {true});
+    auto right = CreateColumnVector({false}, {true});
+    ThreeValuedLogicOp::And(left, right);
+
+    std::vector<bool> data, valid;
+    ExtractResults(left, data, valid);
+
+    EXPECT_FALSE(data[0]);  // F AND F = F
+    EXPECT_TRUE(valid[0]);  // Valid
+}
+
+TEST(ThreeValuedLogicOpTest, AndFalseNull) {
+    // Key test: F AND NULL = F (determined, not NULL!)
+    auto left = CreateColumnVector({false}, {true});
+    auto right = CreateColumnVector({false}, {false});  // NULL
+    ThreeValuedLogicOp::And(left, right);
+
+    std::vector<bool> data, valid;
+    ExtractResults(left, data, valid);
+
+    EXPECT_FALSE(data[0]);  // F AND NULL = F
+    EXPECT_TRUE(valid[0]);  // Valid! (determined because F AND anything = F)
+}
+
+TEST(ThreeValuedLogicOpTest, AndNullTrue) {
+    auto left = CreateColumnVector({false}, {false});  // NULL
+    auto right = CreateColumnVector({true}, {true});
+    ThreeValuedLogicOp::And(left, right);
+
+    std::vector<bool> data, valid;
+    ExtractResults(left, data, valid);
+
+    EXPECT_FALSE(data[0]);   // NULL AND T -> data is false
+    EXPECT_FALSE(valid[0]);  // NULL (undetermined)
+}
+
+TEST(ThreeValuedLogicOpTest, AndNullFalse) {
+    // Key test: NULL AND F = F (determined, not NULL!)
+    auto left = CreateColumnVector({false}, {false});  // NULL
+    auto right = CreateColumnVector({false}, {true});
+    ThreeValuedLogicOp::And(left, right);
+
+    std::vector<bool> data, valid;
+    ExtractResults(left, data, valid);
+
+    EXPECT_FALSE(data[0]);  // NULL AND F = F
+    EXPECT_TRUE(valid[0]);  // Valid! (determined because anything AND F = F)
+}
+
+TEST(ThreeValuedLogicOpTest, AndNullNull) {
+    auto left = CreateColumnVector({false}, {false});   // NULL
+    auto right = CreateColumnVector({false}, {false});  // NULL
+    ThreeValuedLogicOp::And(left, right);
+
+    std::vector<bool> data, valid;
+    ExtractResults(left, data, valid);
+
+    EXPECT_FALSE(data[0]);   // NULL AND NULL -> data is false
+    EXPECT_FALSE(valid[0]);  // NULL
+}
+
+TEST(ThreeValuedLogicOpTest, AndMultipleValues) {
+    // Test all 9 combinations in one test
+    // Left:  [T,    T,    T,    F,    F,    F,    NULL, NULL, NULL]
+    // Right: [T,    F,    NULL, T,    F,    NULL, T,    F,    NULL]
+    // Exp:   [T,    F,    NULL, F,    F,    F,    NULL, F,    NULL]
+    auto left = CreateColumnVector(
+        {true, true, true, false, false, false, false, false, false},
+        {true, true, true, true, true, true, false, false, false});
+    auto right = CreateColumnVector(
+        {true, false, false, true, false, false, true, false, false},
+        {true, true, false, true, true, false, true, true, false});
+    ThreeValuedLogicOp::And(left, right);
+
+    std::vector<bool> data, valid;
+    ExtractResults(left, data, valid);
+
+    // T AND T = T
+    EXPECT_TRUE(data[0]);
+    EXPECT_TRUE(valid[0]);
+    // T AND F = F
+    EXPECT_FALSE(data[1]);
+    EXPECT_TRUE(valid[1]);
+    // T AND NULL = NULL
+    EXPECT_FALSE(data[2]);
+    EXPECT_FALSE(valid[2]);
+    // F AND T = F
+    EXPECT_FALSE(data[3]);
+    EXPECT_TRUE(valid[3]);
+    // F AND F = F
+    EXPECT_FALSE(data[4]);
+    EXPECT_TRUE(valid[4]);
+    // F AND NULL = F (determined!)
+    EXPECT_FALSE(data[5]);
+    EXPECT_TRUE(valid[5]);
+    // NULL AND T = NULL
+    EXPECT_FALSE(data[6]);
+    EXPECT_FALSE(valid[6]);
+    // NULL AND F = F (determined!)
+    EXPECT_FALSE(data[7]);
+    EXPECT_TRUE(valid[7]);
+    // NULL AND NULL = NULL
+    EXPECT_FALSE(data[8]);
+    EXPECT_FALSE(valid[8]);
+}
+
+TEST(ThreeValuedLogicOpTest, AndDoesNotModifyRight) {
+    auto left = CreateColumnVector({true}, {true});
+    auto right = CreateColumnVector({false}, {false});  // NULL
+
+    // Store original right values
+    std::vector<bool> orig_right_data, orig_right_valid;
+    ExtractResults(right, orig_right_data, orig_right_valid);
+
+    ThreeValuedLogicOp::And(left, right);
+
+    // Verify right was not modified
+    std::vector<bool> new_right_data, new_right_valid;
+    ExtractResults(right, new_right_data, new_right_valid);
+
+    EXPECT_EQ(orig_right_data, new_right_data);
+    EXPECT_EQ(orig_right_valid, new_right_valid);
+}
+
+// ============================================================================
+// OR Operation Tests
+// ============================================================================
+
+// Three-valued logic OR truth table:
+// | A     | B     | A OR B |
+// |-------|-------|--------|
+// | T     | T     | T      |
+// | T     | F     | T      |
+// | T     | NULL  | T      |  <- T OR NULL = T (determined)
+// | F     | T     | T      |
+// | F     | F     | F      |
+// | F     | NULL  | NULL   |
+// | NULL  | T     | T      |  <- NULL OR T = T (determined)
+// | NULL  | F     | NULL   |
+// | NULL  | NULL  | NULL   |
+
+TEST(ThreeValuedLogicOpTest, OrTrueTrue) {
+    auto left = CreateColumnVector({true}, {true});
+    auto right = CreateColumnVector({true}, {true});
+    ThreeValuedLogicOp::Or(left, right);
+
+    std::vector<bool> data, valid;
+    ExtractResults(left, data, valid);
+
+    EXPECT_TRUE(data[0]);   // T OR T = T
+    EXPECT_TRUE(valid[0]);  // Valid
+}
+
+TEST(ThreeValuedLogicOpTest, OrTrueFalse) {
+    auto left = CreateColumnVector({true}, {true});
+    auto right = CreateColumnVector({false}, {true});
+    ThreeValuedLogicOp::Or(left, right);
+
+    std::vector<bool> data, valid;
+    ExtractResults(left, data, valid);
+
+    EXPECT_TRUE(data[0]);   // T OR F = T
+    EXPECT_TRUE(valid[0]);  // Valid
+}
+
+TEST(ThreeValuedLogicOpTest, OrTrueNull) {
+    // Key test: T OR NULL = T (determined, not NULL!)
+    auto left = CreateColumnVector({true}, {true});
+    auto right = CreateColumnVector({false}, {false});  // NULL
+    ThreeValuedLogicOp::Or(left, right);
+
+    std::vector<bool> data, valid;
+    ExtractResults(left, data, valid);
+
+    EXPECT_TRUE(data[0]);   // T OR NULL = T
+    EXPECT_TRUE(valid[0]);  // Valid! (determined because T OR anything = T)
+}
+
+TEST(ThreeValuedLogicOpTest, OrFalseTrue) {
+    auto left = CreateColumnVector({false}, {true});
+    auto right = CreateColumnVector({true}, {true});
+    ThreeValuedLogicOp::Or(left, right);
+
+    std::vector<bool> data, valid;
+    ExtractResults(left, data, valid);
+
+    EXPECT_TRUE(data[0]);   // F OR T = T
+    EXPECT_TRUE(valid[0]);  // Valid
+}
+
+TEST(ThreeValuedLogicOpTest, OrFalseFalse) {
+    auto left = CreateColumnVector({false}, {true});
+    auto right = CreateColumnVector({false}, {true});
+    ThreeValuedLogicOp::Or(left, right);
+
+    std::vector<bool> data, valid;
+    ExtractResults(left, data, valid);
+
+    EXPECT_FALSE(data[0]);  // F OR F = F
+    EXPECT_TRUE(valid[0]);  // Valid
+}
+
+TEST(ThreeValuedLogicOpTest, OrFalseNull) {
+    auto left = CreateColumnVector({false}, {true});
+    auto right = CreateColumnVector({false}, {false});  // NULL
+    ThreeValuedLogicOp::Or(left, right);
+
+    std::vector<bool> data, valid;
+    ExtractResults(left, data, valid);
+
+    EXPECT_FALSE(data[0]);   // F OR NULL -> data is false
+    EXPECT_FALSE(valid[0]);  // NULL (undetermined)
+}
+
+TEST(ThreeValuedLogicOpTest, OrNullTrue) {
+    // Key test: NULL OR T = T (determined, not NULL!)
+    auto left = CreateColumnVector({false}, {false});  // NULL
+    auto right = CreateColumnVector({true}, {true});
+    ThreeValuedLogicOp::Or(left, right);
+
+    std::vector<bool> data, valid;
+    ExtractResults(left, data, valid);
+
+    EXPECT_TRUE(data[0]);   // NULL OR T = T
+    EXPECT_TRUE(valid[0]);  // Valid! (determined because anything OR T = T)
+}
+
+TEST(ThreeValuedLogicOpTest, OrNullFalse) {
+    auto left = CreateColumnVector({false}, {false});  // NULL
+    auto right = CreateColumnVector({false}, {true});
+    ThreeValuedLogicOp::Or(left, right);
+
+    std::vector<bool> data, valid;
+    ExtractResults(left, data, valid);
+
+    EXPECT_FALSE(data[0]);   // NULL OR F -> data is false
+    EXPECT_FALSE(valid[0]);  // NULL (undetermined)
+}
+
+TEST(ThreeValuedLogicOpTest, OrNullNull) {
+    auto left = CreateColumnVector({false}, {false});   // NULL
+    auto right = CreateColumnVector({false}, {false});  // NULL
+    ThreeValuedLogicOp::Or(left, right);
+
+    std::vector<bool> data, valid;
+    ExtractResults(left, data, valid);
+
+    EXPECT_FALSE(data[0]);   // NULL OR NULL -> data is false
+    EXPECT_FALSE(valid[0]);  // NULL
+}
+
+TEST(ThreeValuedLogicOpTest, OrMultipleValues) {
+    // Test all 9 combinations in one test
+    // Left:  [T,    T,    T,    F,    F,    F,    NULL, NULL, NULL]
+    // Right: [T,    F,    NULL, T,    F,    NULL, T,    F,    NULL]
+    // Exp:   [T,    T,    T,    T,    F,    NULL, T,    NULL, NULL]
+    auto left = CreateColumnVector(
+        {true, true, true, false, false, false, false, false, false},
+        {true, true, true, true, true, true, false, false, false});
+    auto right = CreateColumnVector(
+        {true, false, false, true, false, false, true, false, false},
+        {true, true, false, true, true, false, true, true, false});
+    ThreeValuedLogicOp::Or(left, right);
+
+    std::vector<bool> data, valid;
+    ExtractResults(left, data, valid);
+
+    // T OR T = T
+    EXPECT_TRUE(data[0]);
+    EXPECT_TRUE(valid[0]);
+    // T OR F = T
+    EXPECT_TRUE(data[1]);
+    EXPECT_TRUE(valid[1]);
+    // T OR NULL = T (determined!)
+    EXPECT_TRUE(data[2]);
+    EXPECT_TRUE(valid[2]);
+    // F OR T = T
+    EXPECT_TRUE(data[3]);
+    EXPECT_TRUE(valid[3]);
+    // F OR F = F
+    EXPECT_FALSE(data[4]);
+    EXPECT_TRUE(valid[4]);
+    // F OR NULL = NULL
+    EXPECT_FALSE(data[5]);
+    EXPECT_FALSE(valid[5]);
+    // NULL OR T = T (determined!)
+    EXPECT_TRUE(data[6]);
+    EXPECT_TRUE(valid[6]);
+    // NULL OR F = NULL
+    EXPECT_FALSE(data[7]);
+    EXPECT_FALSE(valid[7]);
+    // NULL OR NULL = NULL
+    EXPECT_FALSE(data[8]);
+    EXPECT_FALSE(valid[8]);
+}
+
+TEST(ThreeValuedLogicOpTest, OrDoesNotModifyRight) {
+    auto left = CreateColumnVector({false}, {true});
+    auto right = CreateColumnVector({true}, {false});  // NULL with data=true
+
+    // Store original right values
+    std::vector<bool> orig_right_data, orig_right_valid;
+    ExtractResults(right, orig_right_data, orig_right_valid);
+
+    ThreeValuedLogicOp::Or(left, right);
+
+    // Verify right was not modified
+    std::vector<bool> new_right_data, new_right_valid;
+    ExtractResults(right, new_right_data, new_right_valid);
+
+    EXPECT_EQ(orig_right_data, new_right_data);
+    EXPECT_EQ(orig_right_valid, new_right_valid);
+}
+
+// ============================================================================
+// De Morgan's Law Tests
+// ============================================================================
+
+// De Morgan's Law: NOT (A OR B) = NOT A AND NOT B
+// De Morgan's Law: NOT (A AND B) = NOT A OR NOT B
+// These should hold even with NULL values in three-valued logic
+
+TEST(ThreeValuedLogicOpTest, DeMorganOrToAnd) {
+    // Test: NOT (A OR B) == NOT A AND NOT B
+    // With all 9 combinations of A, B in {T, F, NULL}
+
+    std::vector<bool> a_data = {true, true,  true,  false, false,
+                                false, false, false, false};
+    std::vector<bool> a_valid = {true, true,  true,  true, true,
+                                 true, false, false, false};
+    std::vector<bool> b_data = {true, false, false, true, false,
+                                false, true,  false, false};
+    std::vector<bool> b_valid = {true, true, false, true, true,
+                                 false, true, true,  false};
+
+    // Method 1: NOT (A OR B)
+    auto left1 = CreateColumnVector(a_data, a_valid);
+    auto right1 = CreateColumnVector(b_data, b_valid);
+    ThreeValuedLogicOp::Or(left1, right1);
+    ThreeValuedLogicOp::Not(left1);
+
+    // Method 2: NOT A AND NOT B
+    auto left2 = CreateColumnVector(a_data, a_valid);
+    auto right2 = CreateColumnVector(b_data, b_valid);
+    ThreeValuedLogicOp::Not(left2);
+    ThreeValuedLogicOp::Not(right2);
+    ThreeValuedLogicOp::And(left2, right2);
+
+    std::vector<bool> result1_data, result1_valid;
+    std::vector<bool> result2_data, result2_valid;
+    ExtractResults(left1, result1_data, result1_valid);
+    ExtractResults(left2, result2_data, result2_valid);
+
+    // Results should be identical
+    EXPECT_EQ(result1_data, result2_data);
+    EXPECT_EQ(result1_valid, result2_valid);
+}
+
+TEST(ThreeValuedLogicOpTest, DeMorganAndToOr) {
+    // Test: NOT (A AND B) == NOT A OR NOT B
+    // With all 9 combinations of A, B in {T, F, NULL}
+
+    std::vector<bool> a_data = {true, true,  true,  false, false,
+                                false, false, false, false};
+    std::vector<bool> a_valid = {true, true,  true,  true, true,
+                                 true, false, false, false};
+    std::vector<bool> b_data = {true, false, false, true, false,
+                                false, true,  false, false};
+    std::vector<bool> b_valid = {true, true, false, true, true,
+                                 false, true, true,  false};
+
+    // Method 1: NOT (A AND B)
+    auto left1 = CreateColumnVector(a_data, a_valid);
+    auto right1 = CreateColumnVector(b_data, b_valid);
+    ThreeValuedLogicOp::And(left1, right1);
+    ThreeValuedLogicOp::Not(left1);
+
+    // Method 2: NOT A OR NOT B
+    auto left2 = CreateColumnVector(a_data, a_valid);
+    auto right2 = CreateColumnVector(b_data, b_valid);
+    ThreeValuedLogicOp::Not(left2);
+    ThreeValuedLogicOp::Not(right2);
+    ThreeValuedLogicOp::Or(left2, right2);
+
+    std::vector<bool> result1_data, result1_valid;
+    std::vector<bool> result2_data, result2_valid;
+    ExtractResults(left1, result1_data, result1_valid);
+    ExtractResults(left2, result2_data, result2_valid);
+
+    // Results should be identical
+    EXPECT_EQ(result1_data, result2_data);
+    EXPECT_EQ(result1_valid, result2_valid);
+}
+
+// ============================================================================
+// Large Scale Tests
+// ============================================================================
+
+TEST(ThreeValuedLogicOpTest, LargeScaleAnd) {
+    const size_t size = 10000;
+    std::vector<bool> left_data(size), left_valid(size);
+    std::vector<bool> right_data(size), right_valid(size);
+
+    // Generate test data
+    for (size_t i = 0; i < size; ++i) {
+        left_data[i] = (i % 3) == 0;
+        left_valid[i] = (i % 5) != 0;
+        right_data[i] = (i % 2) == 0;
+        right_valid[i] = (i % 7) != 0;
+    }
+
+    auto left = CreateColumnVector(left_data, left_valid);
+    auto right = CreateColumnVector(right_data, right_valid);
+    ThreeValuedLogicOp::And(left, right);
+
+    std::vector<bool> result_data, result_valid;
+    ExtractResults(left, result_data, result_valid);
+
+    // Verify results match expected three-valued logic
+    for (size_t i = 0; i < size; ++i) {
+        bool l_data = left_data[i];
+        bool l_valid = left_valid[i];
+        bool r_data = right_data[i];
+        bool r_valid = right_valid[i];
+
+        // Expected data: left AND right
+        bool exp_data = l_data && r_data;
+
+        // Expected valid for AND:
+        // Valid if: (left is definitely false) OR (right is definitely false)
+        // OR (both are valid)
+        bool left_definitely_false = l_valid && !l_data;
+        bool right_definitely_false = r_valid && !r_data;
+        bool exp_valid =
+            left_definitely_false || right_definitely_false || (l_valid && r_valid);
+
+        EXPECT_EQ(result_data[i], exp_data) << "Data mismatch at index " << i;
+        EXPECT_EQ(result_valid[i], exp_valid) << "Valid mismatch at index " << i;
+    }
+}
+
+TEST(ThreeValuedLogicOpTest, LargeScaleOr) {
+    const size_t size = 10000;
+    std::vector<bool> left_data(size), left_valid(size);
+    std::vector<bool> right_data(size), right_valid(size);
+
+    // Generate test data
+    for (size_t i = 0; i < size; ++i) {
+        left_data[i] = (i % 3) == 0;
+        left_valid[i] = (i % 5) != 0;
+        right_data[i] = (i % 2) == 0;
+        right_valid[i] = (i % 7) != 0;
+    }
+
+    auto left = CreateColumnVector(left_data, left_valid);
+    auto right = CreateColumnVector(right_data, right_valid);
+    ThreeValuedLogicOp::Or(left, right);
+
+    std::vector<bool> result_data, result_valid;
+    ExtractResults(left, result_data, result_valid);
+
+    // Verify results match expected three-valued logic
+    for (size_t i = 0; i < size; ++i) {
+        bool l_data = left_data[i];
+        bool l_valid = left_valid[i];
+        bool r_data = right_data[i];
+        bool r_valid = right_valid[i];
+
+        // Expected data: left OR right
+        bool exp_data = l_data || r_data;
+
+        // Expected valid for OR:
+        // Valid if: (left is definitely true) OR (right is definitely true)
+        // OR (both are valid)
+        bool left_definitely_true = l_valid && l_data;
+        bool right_definitely_true = r_valid && r_data;
+        bool exp_valid =
+            left_definitely_true || right_definitely_true || (l_valid && r_valid);
+
+        EXPECT_EQ(result_data[i], exp_data) << "Data mismatch at index " << i;
+        EXPECT_EQ(result_valid[i], exp_valid) << "Valid mismatch at index " << i;
+    }
+}

--- a/internal/core/src/common/ValueOp.h
+++ b/internal/core/src/common/ValueOp.h
@@ -1,0 +1,123 @@
+#pragma once
+
+#include "common/Types.h"
+#include "common/Vector.h"
+namespace milvus {
+namespace common {
+
+class ThreeValuedLogicOp {
+ public:
+    // apply not operation to the left column vector
+    // and store the result in the left column vector
+    static void
+    Not(ColumnVectorPtr left) {
+        TargetBitmapView data(left->GetRawData(), left->size());
+        TargetBitmapView valid_data(left->GetValidRawData(), left->size());
+
+        data.flip();
+        data.inplace_and(valid_data, left->size());
+    }
+
+    // apply and operation to the left and right column vectors
+    // and store the result in the left column vector (right is not modified)
+    //
+    // Three-valued logic AND truth table:
+    // | A     | B     | A AND B |
+    // |-------|-------|---------|
+    // | T     | T     | T       |
+    // | T     | F     | F       |
+    // | T     | NULL  | NULL    |
+    // | F     | T     | F       |
+    // | F     | F     | F       |
+    // | F     | NULL  | F       |  <- F AND NULL = F (determined)
+    // | NULL  | T     | NULL    |
+    // | NULL  | F     | F       |  <- NULL AND F = F (determined)
+    // | NULL  | NULL  | NULL    |
+    //
+    // result_valid = (left_valid & ~left_data) |    // left is definitely false
+    //                (right_valid & ~right_data) |  // right is definitely false
+    //                (left_valid & right_valid)     // both are valid
+    // =>
+    // result_valid = left_valid & (right_valid | ~left_data) |
+    //                right_valid & ~right_data
+    static void
+    And(ColumnVectorPtr left, ColumnVectorPtr right) {
+        const size_t size = left->size();
+        TargetBitmapView left_data(left->GetRawData(), size);
+        TargetBitmapView left_valid(left->GetValidRawData(), size);
+        TargetBitmapView right_data(right->GetRawData(), size);
+        TargetBitmapView right_valid(right->GetValidRawData(), size);
+
+        // tmp = ~left_data | right_valid
+        TargetBitmap tmp(size, true);
+        tmp.inplace_xor(left_data, size);
+        tmp.inplace_or(right_valid, size);
+
+        // left_valid = left_valid & (right_valid | ~left_data)
+        left_valid.inplace_and(tmp, size);
+
+        // tmp = right_valid & ~right_data (reuse tmp)
+        tmp.set();
+        tmp.inplace_xor(right_data, size);   // tmp = ~right_data
+        tmp.inplace_and(right_valid, size);  // tmp = right_valid & ~right_data
+
+        // left_valid |= (right_valid & ~right_data)
+        left_valid.inplace_or(tmp, size);
+
+        // left_data = left_data & right_data
+        left_data.inplace_and(right_data, size);
+    }
+
+    // apply or operation to the left and right column vectors
+    // and store the result in the left column vector (right is not modified)
+    //
+    // Three-valued logic OR truth table:
+    // | A     | B     | A OR B |
+    // |-------|-------|--------|
+    // | T     | T     | T      |
+    // | T     | F     | T      |
+    // | T     | NULL  | T      |  <- T OR NULL = T (determined)
+    // | F     | T     | T      |
+    // | F     | F     | F      |
+    // | F     | NULL  | NULL   |
+    // | NULL  | T     | T      |  <- NULL OR T = T (determined)
+    // | NULL  | F     | NULL   |
+    // | NULL  | NULL  | NULL   |
+    //
+    // result_valid = (left_valid & left_data) |     // left is definitely true
+    //                (right_valid & right_data) |   // right is definitely true
+    //                (left_valid & right_valid)     // both are valid
+    // =>
+    // result_valid = left_valid & (right_valid | left_data) |
+    //                right_valid & right_data
+    static void
+    Or(ColumnVectorPtr left, ColumnVectorPtr right) {
+        const size_t size = left->size();
+        TargetBitmapView left_data(left->GetRawData(), size);
+        TargetBitmapView left_valid(left->GetValidRawData(), size);
+        TargetBitmapView right_data(right->GetRawData(), size);
+        TargetBitmapView right_valid(right->GetValidRawData(), size);
+
+        // tmp = left_data | right_valid
+        TargetBitmap tmp(size);
+        tmp.inplace_or(left_data, size);
+        tmp.inplace_or(right_valid, size);
+
+        // left_valid = left_valid & (right_valid | left_data)
+        left_valid.inplace_and(tmp, size);
+
+        // tmp = right_valid & right_data (reuse tmp)
+        tmp.reset();
+        tmp.inplace_or(right_data, size);
+        tmp.inplace_and(right_valid, size);
+
+        // left_valid |= (right_valid & right_data)
+        left_valid.inplace_or(tmp, size);
+
+        // left_data = left_data | right_data
+        left_data.inplace_or(right_data, size);
+    }
+};
+
+}  // namespace common
+}  // namespace milvus

--- a/internal/core/src/common/ValueOp.h
+++ b/internal/core/src/common/ValueOp.h
@@ -1,3 +1,14 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+
 #pragma once
 
 #include "common/Types.h"

--- a/internal/core/src/common/ValueOp.h
+++ b/internal/core/src/common/ValueOp.h
@@ -128,7 +128,15 @@ class ThreeValuedLogicOp {
         // left_data = left_data | right_data
         left_data.inplace_or(right_data, size);
     }
-};
 
+    static size_t
+    TrueCount(ColumnVectorPtr res) {
+        TargetBitmapView data(res->GetRawData(), res->size());
+        TargetBitmapView valid_data(res->GetValidRawData(), res->size());
+        TargetBitmap tmp(data);
+        tmp.inplace_and(valid_data, res->size());
+        return tmp.count();
+    }
+};
 }  // namespace common
 }  // namespace milvus

--- a/internal/core/src/exec/expression/ConjunctExpr.cpp
+++ b/internal/core/src/exec/expression/ConjunctExpr.cpp
@@ -41,30 +41,6 @@ PhyConjunctFilterExpr::ResolveType(const std::vector<DataType>& inputs) {
     return DataType::BOOL;
 }
 
-static bool
-AllTrue(ColumnVectorPtr& vec) {
-    TargetBitmapView data(vec->GetRawData(), vec->size());
-    return data.all();
-}
-
-static void
-AllSet(ColumnVectorPtr& vec) {
-    TargetBitmapView data(vec->GetRawData(), vec->size());
-    data.set();
-}
-
-static void
-AllReset(ColumnVectorPtr& vec) {
-    TargetBitmapView data(vec->GetRawData(), vec->size());
-    data.reset();
-}
-
-static bool
-AllFalse(ColumnVectorPtr& vec) {
-    TargetBitmapView data(vec->GetRawData(), vec->size());
-    return data.none();
-}
-
 int64_t
 PhyConjunctFilterExpr::UpdateResult(ColumnVectorPtr& input_result,
                                     EvalCtx& ctx,
@@ -88,7 +64,9 @@ PhyConjunctFilterExpr::UpdateResult(ColumnVectorPtr& input_result,
 
 bool
 PhyConjunctFilterExpr::CanSkipFollowingExprs(ColumnVectorPtr& vec) {
-    if ((is_and_ && AllFalse(vec)) || (!is_and_ && AllTrue(vec))) {
+    if ((is_and_ && common::ThreeValuedLogicOp::TrueCount(vec) == 0) ||
+        (!is_and_ &&
+         common::ThreeValuedLogicOp::TrueCount(vec) == vec->size())) {
         return true;
     }
     return false;

--- a/internal/core/src/exec/expression/ConjunctExpr.cpp
+++ b/internal/core/src/exec/expression/ConjunctExpr.cpp
@@ -19,6 +19,7 @@
 #include "LikeConjunctExpr.h"
 
 #include <algorithm>
+#include "common/ValueOp.h"
 
 namespace milvus {
 namespace exec {
@@ -69,11 +70,19 @@ PhyConjunctFilterExpr::UpdateResult(ColumnVectorPtr& input_result,
                                     EvalCtx& ctx,
                                     ColumnVectorPtr& result) {
     if (is_and_) {
-        ConjunctElementFunc<true> func;
-        return func(input_result, result);
+        common::ThreeValuedLogicOp::And(result, input_result);
     } else {
-        ConjunctElementFunc<false> func;
-        return func(input_result, result);
+        common::ThreeValuedLogicOp::Or(result, input_result);
+    }
+
+    // Return the count of active rows for short-circuit optimization
+    // For AND: return count of true (if 0, all false, can skip)
+    // For OR: return count of false (if 0, all true, can skip)
+    TargetBitmapView res_data(result->GetRawData(), result->size());
+    if (is_and_) {
+        return static_cast<int64_t>(res_data.count());
+    } else {
+        return static_cast<int64_t>(result->size() - res_data.count());
     }
 }
 

--- a/internal/core/src/exec/expression/EvalCtx.h
+++ b/internal/core/src/exec/expression/EvalCtx.h
@@ -73,16 +73,6 @@ class EvalCtx {
         bitmap_input_.clear();
     }
 
-    void
-    set_apply_valid_data_after_flip(bool apply_valid_data_after_flip) {
-        apply_valid_data_after_flip_ = apply_valid_data_after_flip;
-    }
-
-    bool
-    get_apply_valid_data_after_flip() const {
-        return apply_valid_data_after_flip_;
-    }
-
  private:
     ExecContext* exec_ctx_ = nullptr;
     // we may accept offsets array as input and do expr filtering on these data
@@ -91,9 +81,6 @@ class EvalCtx {
 
     // used for expr pre filter, that avoid unnecessary execution on filtered data
     TargetBitmap bitmap_input_;
-
-    // for some expr(eg. exists), we do not need to apply valid data after flip
-    bool apply_valid_data_after_flip_ = true;
 };
 
 }  // namespace exec

--- a/internal/core/src/exec/expression/ExistsExpr.cpp
+++ b/internal/core/src/exec/expression/ExistsExpr.cpp
@@ -32,7 +32,6 @@ PhyExistsFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
     span.GetSpan()->SetAttribute("data_type",
                                  static_cast<int>(expr_->column_.data_type_));
 
-    context.set_apply_valid_data_after_flip(false);
     auto input = context.get_offset_input();
     SetHasOffsetInput((input != nullptr));
     auto data_type = expr_->column_.data_type_;
@@ -141,16 +140,16 @@ PhyExistsFilterExpr::EvalJsonExistsForDataSegment(EvalCtx& context) {
 
     auto pointer = milvus::Json::pointer(expr_->column_.nested_path_);
     int processed_cursor = 0;
-    auto execute_sub_batch =
-        [&bitmap_input, &
-         processed_cursor ]<FilterType filter_type = FilterType::sequential>(
-            const milvus::Json* data,
-            const bool* valid_data,
-            const int32_t* offsets,
-            const int size,
-            TargetBitmapView res,
-            TargetBitmapView valid_res,
-            const std::string& pointer) {
+    auto execute_sub_batch = [&bitmap_input,
+                              &processed_cursor]<FilterType filter_type =
+                                                     FilterType::sequential>(
+                                 const milvus::Json* data,
+                                 const bool* valid_data,
+                                 const int32_t* offsets,
+                                 const int size,
+                                 TargetBitmapView res,
+                                 TargetBitmapView valid_res,
+                                 const std::string& pointer) {
         // If data is nullptr, this chunk was skipped by SkipIndex.
         // We only need to update processed_cursor for bitmap_input indexing.
         if (data == nullptr) {
@@ -164,7 +163,7 @@ PhyExistsFilterExpr::EvalJsonExistsForDataSegment(EvalCtx& context) {
                 offset = (offsets) ? offsets[i] : i;
             }
             if (valid_data != nullptr && !valid_data[offset]) {
-                res[i] = valid_res[i] = false;
+                res[i] = false;
                 continue;
             }
             if (has_bitmap_input && !bitmap_input[processed_cursor + i]) {

--- a/internal/core/src/exec/expression/ExistsExpr.cpp
+++ b/internal/core/src/exec/expression/ExistsExpr.cpp
@@ -140,16 +140,16 @@ PhyExistsFilterExpr::EvalJsonExistsForDataSegment(EvalCtx& context) {
 
     auto pointer = milvus::Json::pointer(expr_->column_.nested_path_);
     int processed_cursor = 0;
-    auto execute_sub_batch = [&bitmap_input,
-                              &processed_cursor]<FilterType filter_type =
-                                                     FilterType::sequential>(
-                                 const milvus::Json* data,
-                                 const bool* valid_data,
-                                 const int32_t* offsets,
-                                 const int size,
-                                 TargetBitmapView res,
-                                 TargetBitmapView valid_res,
-                                 const std::string& pointer) {
+    auto execute_sub_batch =
+        [&bitmap_input, &
+         processed_cursor ]<FilterType filter_type = FilterType::sequential>(
+            const milvus::Json* data,
+            const bool* valid_data,
+            const int32_t* offsets,
+            const int size,
+            TargetBitmapView res,
+            TargetBitmapView valid_res,
+            const std::string& pointer) {
         // If data is nullptr, this chunk was skipped by SkipIndex.
         // We only need to update processed_cursor for bitmap_input indexing.
         if (data == nullptr) {

--- a/internal/core/src/exec/expression/LogicalUnaryExpr.cpp
+++ b/internal/core/src/exec/expression/LogicalUnaryExpr.cpp
@@ -15,7 +15,7 @@
 // limitations under the License.
 
 #include "LogicalUnaryExpr.h"
-
+#include "common/ValueOp.h"
 namespace milvus {
 namespace exec {
 
@@ -29,14 +29,7 @@ PhyLogicalUnaryExpr::Eval(EvalCtx& context, VectorPtr& result) {
 
     inputs_[0]->Eval(context, result);
     if (expr_->op_type_ == milvus::expr::LogicalUnaryExpr::OpType::LogicalNot) {
-        auto flat_vec = GetColumnVector(result);
-        TargetBitmapView data(flat_vec->GetRawData(), flat_vec->size());
-        data.flip();
-        if (context.get_apply_valid_data_after_flip()) {
-            TargetBitmapView valid_data(flat_vec->GetValidRawData(),
-                                        flat_vec->size());
-            data &= valid_data;
-        }
+        common::ThreeValuedLogicOp::Not(GetColumnVector(result));
     }
 }
 

--- a/internal/core/src/exec/expression/NullExpr.cpp
+++ b/internal/core/src/exec/expression/NullExpr.cpp
@@ -119,8 +119,8 @@ PhyNullExpr::ExecVisitorImpl(OffsetVector* input) {
     if (expr_->op_ == proto::plan::NullExpr_NullOp_IsNull) {
         res.flip();
     }
-    auto res_vec =
-        std::make_shared<ColumnVector>(std::move(res), std::move(valid_res));
+    auto res_vec = std::make_shared<ColumnVector>(
+        std::move(res), TargetBitmap(valid_res.size(), true));
     return res_vec;
 }
 

--- a/internal/core/unittest/test_string_expr.cpp
+++ b/internal/core/unittest/test_string_expr.cpp
@@ -1664,3 +1664,184 @@ TEST(AlwaysTrueStringPlan, QueryWithOutputFieldsNullable) {
               N / 2);
     ASSERT_EQ(retrieved->fields_data(0).valid_data().size(), N / 2);
 }
+
+// Test: NOT (a IS NOT NULL) - verifies that the result valid bits are always true
+// because IsNull/IsNotNull expressions always produce valid (non-NULL) results,
+// and NOT applied to valid results also produces valid results.
+TEST(StringExpr, NotIsNotNullExpr) {
+    auto schema = std::make_shared<Schema>();
+    schema->AddDebugField("str", DataType::VARCHAR, true);
+    schema->AddDebugField(
+        "fvec", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
+    auto pk = schema->AddDebugField("int64", DataType::INT64);
+    schema->set_primary_field_id(pk);
+    const auto& str_meta = schema->operator[](FieldName("str"));
+
+    auto seg = CreateGrowingSegment(schema, empty_index_meta);
+    int N = 1000;
+    FixedVector<bool> valid_data;
+    int num_iters = 10;
+    for (int iter = 0; iter < num_iters; ++iter) {
+        auto raw_data = DataGen(schema, N, iter);
+        auto new_str_valid_col = raw_data.get_col_valid(str_meta.get_id());
+        valid_data.insert(valid_data.end(),
+                          new_str_valid_col.begin(),
+                          new_str_valid_col.end());
+        seg->PreInsert(N);
+        seg->Insert(iter * N,
+                    N,
+                    raw_data.row_ids_.data(),
+                    raw_data.timestamps_.data(),
+                    raw_data.raw_);
+    }
+
+    auto seg_promote = dynamic_cast<SegmentGrowingImpl*>(seg.get());
+
+    // Create NullExpr for IS NOT NULL
+    auto null_expr = std::make_shared<milvus::expr::NullExpr>(
+        expr::ColumnInfo(str_meta.get_id(), DataType::VARCHAR, {}, true),
+        NullExprType::NullExpr_NullOp_IsNotNull);
+
+    // Wrap with LogicalUnaryExpr (NOT)
+    auto not_expr = std::make_shared<milvus::expr::LogicalUnaryExpr>(
+        milvus::expr::LogicalUnaryExpr::OpType::LogicalNot, null_expr);
+
+    // Execute the expression using ExecuteQueryExpr
+    auto plan = milvus::test::CreateRetrievePlanByExpr(not_expr);
+    auto filter_node = plan->sources()[0];  // MvccNode -> FilterBitsNode
+    BitsetType final = ExecuteQueryExpr(
+        filter_node, seg_promote, N * num_iters, MAX_TIMESTAMP);
+
+    EXPECT_EQ(final.size(), N * num_iters);
+
+    for (int i = 0; i < N * num_iters; ++i) {
+        // NOT (IS NOT NULL) should equal IS NULL
+        // data[i] should be true if original was null, false if original was valid
+        bool expected_data = !valid_data[i];
+        ASSERT_EQ(final[i], expected_data)
+            << "Data mismatch at index " << i;
+    }
+}
+
+// Test: NOT (a IS NULL) - verifies that the result valid bits are always true
+TEST(StringExpr, NotIsNullExpr) {
+    auto schema = std::make_shared<Schema>();
+    schema->AddDebugField("str", DataType::VARCHAR, true);
+    schema->AddDebugField(
+        "fvec", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
+    auto pk = schema->AddDebugField("int64", DataType::INT64);
+    schema->set_primary_field_id(pk);
+    const auto& str_meta = schema->operator[](FieldName("str"));
+
+    auto seg = CreateGrowingSegment(schema, empty_index_meta);
+    int N = 1000;
+    FixedVector<bool> valid_data;
+    int num_iters = 10;
+    for (int iter = 0; iter < num_iters; ++iter) {
+        auto raw_data = DataGen(schema, N, iter);
+        auto new_str_valid_col = raw_data.get_col_valid(str_meta.get_id());
+        valid_data.insert(valid_data.end(),
+                          new_str_valid_col.begin(),
+                          new_str_valid_col.end());
+        seg->PreInsert(N);
+        seg->Insert(iter * N,
+                    N,
+                    raw_data.row_ids_.data(),
+                    raw_data.timestamps_.data(),
+                    raw_data.raw_);
+    }
+
+    auto seg_promote = dynamic_cast<SegmentGrowingImpl*>(seg.get());
+
+    // Create NullExpr for IS NULL
+    auto null_expr = std::make_shared<milvus::expr::NullExpr>(
+        expr::ColumnInfo(str_meta.get_id(), DataType::VARCHAR, {}, true),
+        NullExprType::NullExpr_NullOp_IsNull);
+
+    // Wrap with LogicalUnaryExpr (NOT)
+    auto not_expr = std::make_shared<milvus::expr::LogicalUnaryExpr>(
+        milvus::expr::LogicalUnaryExpr::OpType::LogicalNot, null_expr);
+
+    // Execute the expression using ExecuteQueryExpr
+    auto plan = milvus::test::CreateRetrievePlanByExpr(not_expr);
+    auto filter_node = plan->sources()[0];  // MvccNode -> FilterBitsNode
+    BitsetType final = ExecuteQueryExpr(
+        filter_node, seg_promote, N * num_iters, MAX_TIMESTAMP);
+
+    EXPECT_EQ(final.size(), N * num_iters);
+
+    for (int i = 0; i < N * num_iters; ++i) {
+        // NOT (IS NULL) should equal IS NOT NULL
+        // data[i] should be true if original was valid, false if original was null
+        bool expected_data = valid_data[i];
+        ASSERT_EQ(final[i], expected_data)
+            << "Data mismatch at index " << i;
+    }
+}
+
+// Test: (a IS NOT NULL) AND (b IS NOT NULL)
+// This tests the interaction between NullExpr and three-valued logic
+TEST(StringExpr, IsNotNullAndNullCondition) {
+    auto schema = std::make_shared<Schema>();
+    schema->AddDebugField("str", DataType::VARCHAR, true);
+    schema->AddDebugField("int_val", DataType::INT64, true);  // nullable int
+    schema->AddDebugField(
+        "fvec", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
+    auto pk = schema->AddDebugField("pk", DataType::INT64);
+    schema->set_primary_field_id(pk);
+    const auto& str_meta = schema->operator[](FieldName("str"));
+    const auto& int_meta = schema->operator[](FieldName("int_val"));
+
+    auto seg = CreateGrowingSegment(schema, empty_index_meta);
+    int N = 1000;
+    FixedVector<bool> str_valid_data;
+    FixedVector<bool> int_valid_data;
+    int num_iters = 10;
+    for (int iter = 0; iter < num_iters; ++iter) {
+        auto raw_data = DataGen(schema, N, iter);
+        auto new_str_valid = raw_data.get_col_valid(str_meta.get_id());
+        auto new_int_valid = raw_data.get_col_valid(int_meta.get_id());
+        str_valid_data.insert(
+            str_valid_data.end(), new_str_valid.begin(), new_str_valid.end());
+        int_valid_data.insert(
+            int_valid_data.end(), new_int_valid.begin(), new_int_valid.end());
+        seg->PreInsert(N);
+        seg->Insert(iter * N,
+                    N,
+                    raw_data.row_ids_.data(),
+                    raw_data.timestamps_.data(),
+                    raw_data.raw_);
+    }
+
+    auto seg_promote = dynamic_cast<SegmentGrowingImpl*>(seg.get());
+
+    // Create: (str IS NOT NULL) AND (int_val IS NOT NULL)
+    auto str_is_not_null = std::make_shared<milvus::expr::NullExpr>(
+        expr::ColumnInfo(str_meta.get_id(), DataType::VARCHAR, {}, true),
+        NullExprType::NullExpr_NullOp_IsNotNull);
+
+    auto int_is_not_null = std::make_shared<milvus::expr::NullExpr>(
+        expr::ColumnInfo(int_meta.get_id(), DataType::INT64, {}, true),
+        NullExprType::NullExpr_NullOp_IsNotNull);
+
+    auto and_expr = std::make_shared<milvus::expr::LogicalBinaryExpr>(
+        milvus::expr::LogicalBinaryExpr::OpType::And,
+        str_is_not_null,
+        int_is_not_null);
+
+    // Execute the expression using ExecuteQueryExpr
+    auto plan = milvus::test::CreateRetrievePlanByExpr(and_expr);
+    auto filter_node = plan->sources()[0];  // MvccNode -> FilterBitsNode
+    BitsetType final = ExecuteQueryExpr(
+        filter_node, seg_promote, N * num_iters, MAX_TIMESTAMP);
+
+    EXPECT_EQ(final.size(), N * num_iters);
+
+    for (int i = 0; i < N * num_iters; ++i) {
+        // (str IS NOT NULL) AND (int IS NOT NULL)
+        // Both operands always have valid=true, so result is always valid
+        bool expected_data = str_valid_data[i] && int_valid_data[i];
+        ASSERT_EQ(final[i], expected_data)
+            << "Data mismatch at index " << i;
+    }
+}

--- a/internal/core/unittest/test_string_expr.cpp
+++ b/internal/core/unittest/test_string_expr.cpp
@@ -1718,8 +1718,7 @@ TEST(StringExpr, NotIsNotNullExpr) {
         // NOT (IS NOT NULL) should equal IS NULL
         // data[i] should be true if original was null, false if original was valid
         bool expected_data = !valid_data[i];
-        ASSERT_EQ(final[i], expected_data)
-            << "Data mismatch at index " << i;
+        ASSERT_EQ(final[i], expected_data) << "Data mismatch at index " << i;
     }
 }
 
@@ -1774,8 +1773,7 @@ TEST(StringExpr, NotIsNullExpr) {
         // NOT (IS NULL) should equal IS NOT NULL
         // data[i] should be true if original was valid, false if original was null
         bool expected_data = valid_data[i];
-        ASSERT_EQ(final[i], expected_data)
-            << "Data mismatch at index " << i;
+        ASSERT_EQ(final[i], expected_data) << "Data mismatch at index " << i;
     }
 }
 
@@ -1841,7 +1839,6 @@ TEST(StringExpr, IsNotNullAndNullCondition) {
         // (str IS NOT NULL) AND (int IS NOT NULL)
         // Both operands always have valid=true, so result is always valid
         bool expected_data = str_valid_data[i] && int_valid_data[i];
-        ASSERT_EQ(final[i], expected_data)
-            << "Data mismatch at index " << i;
+        ASSERT_EQ(final[i], expected_data) << "Data mismatch at index " << i;
     }
 }


### PR DESCRIPTION
Implement proper three-valued logic (TRUE/FALSE/NULL) support:
issue: https://github.com/milvus-io/milvus/issues/46820


1. NullExpr/ExistsExpr: valid bits always true (results are deterministic)
2. LogicalUnaryExpr (NOT): NULL input produces NULL output
3. ConjunctExpr (AND/OR): F AND NULL=F, T OR NULL=T (short-circuit)

Add unit tests for NOT (IS NOT NULL), NOT (IS NULL), and combined expressions.