### PR TITLE
enhance: Add grpc metadata header for client request time (#44059)

### DIFF
--- a/internal/proxy/accesslog/info/grpc_info.go
+++ b/internal/proxy/accesslog/info/grpc_info.go
@@ -36,6 +36,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/proxy/connection"
+	"github.com/milvus-io/milvus/pkg/v2/util/logutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/requestutil"
 )
@@ -370,4 +371,15 @@ func (i *GrpcAccessInfo) TemplateValueLength() string {
 	})
 
 	return fmt.Sprint(m)
+}
+
+// ClientRequestTime returns client-side request time string
+// this attribute is passed via grpc metadata
+func (i *GrpcAccessInfo) ClientRequestTime() string {
+	unixmsec, ok := logutil.GetClientReqUnixmsecGrpc(i.ctx)
+	if !ok {
+		return Unknown
+	}
+
+	return time.UnixMilli(unixmsec).Format(timeFormat)
 }

--- a/internal/proxy/accesslog/info/grpc_info_test.go
+++ b/internal/proxy/accesslog/info/grpc_info_test.go
@@ -20,7 +20,9 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/suite"
@@ -34,6 +36,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/proxy/connection"
+	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/util"
 	"github.com/milvus-io/milvus/pkg/v2/util/crypto"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
@@ -304,6 +307,17 @@ func (s *GrpcAccessInfoSuite) TestTemplateValueLength() {
 	}
 
 	s.Equal(`map[store_id:2]`, Get(s.info, "$template_value_length")[0])
+}
+
+func (s *GrpcAccessInfoSuite) TestClientRequestTime() {
+	result := Get(s.info, "$method_expr")
+	s.Equal(Unknown, result[0])
+
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.MD{
+		common.ClientRequestMsecKey: []string{strconv.FormatInt(time.Now().UnixMilli(), 10)},
+	})
+	s.info.ctx = ctx
+	s.NotEqual(Unknown, Get(s.info, "$client_request_time")[0])
 }
 
 func TestGrpcAccssInfo(t *testing.T) {

--- a/internal/proxy/accesslog/info/info.go
+++ b/internal/proxy/accesslog/info/info.go
@@ -55,6 +55,7 @@ var MetricFuncMap = map[string]getMetricFunc{
 	"$search_params":         getSearchParams,
 	"$query_params":          getQueryParams,
 	"$template_value_length": getTemplateValueLength,
+	"$client_request_time":   getClientRequestTime,
 }
 
 type AccessInfo interface {
@@ -84,6 +85,7 @@ type AccessInfo interface {
 	QueryParams() string
 	TemplateValueLength() string
 	SetActualConsistencyLevel(commonpb.ConsistencyLevel)
+	ClientRequestTime() string
 }
 
 func Get(i AccessInfo, keys ...string) []any {
@@ -201,4 +203,8 @@ func getQueryParams(i AccessInfo) string {
 
 func getTemplateValueLength(i AccessInfo) string {
 	return i.TemplateValueLength()
+}
+
+func getClientRequestTime(i AccessInfo) string {
+	return i.ClientRequestTime()
 }

--- a/internal/proxy/accesslog/info/restful_info.go
+++ b/internal/proxy/accesslog/info/restful_info.go
@@ -282,3 +282,7 @@ func (i *RestfulInfo) TemplateValueLength() string {
 
 	return fmt.Sprint(m)
 }
+
+func (i *RestfulInfo) ClientRequestTime() string {
+	return Unknown
+}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -222,8 +222,9 @@ const (
 )
 
 const (
-	PropertiesKey string = "properties"
-	TraceIDKey    string = "uber-trace-id"
+	PropertiesKey        string = "properties"
+	TraceIDKey           string = "uber-trace-id"
+	ClientRequestMsecKey string = "client-request-unixmsec"
 )
 
 func IsSystemField(fieldID int64) bool {


### PR DESCRIPTION
Related to #44058

This PR:
- Add common grpc metadata key for client request time
- Add gosdk & milvus inteceptor related logic for this attribute
- Bump go sdk version

pr: #44059