### PR TITLE
fix: ScoreBasedBalancer priority queue not refreshed after score updates

### DIFF
--- a/internal/querycoordv2/balance/priority_queue.go
+++ b/internal/querycoordv2/balance/priority_queue.go
@@ -23,10 +23,13 @@ import (
 type Item interface {
 	getPriority() int
 	setPriority(priority int)
+	getIndex() int
+	setIndex(idx int)
 }
 
 type BaseItem struct {
 	priority int
+	index    int
 }
 
 func (b *BaseItem) getPriority() int {
@@ -35,6 +38,14 @@ func (b *BaseItem) getPriority() int {
 
 func (b *BaseItem) setPriority(priority int) {
 	b.priority = priority
+}
+
+func (b *BaseItem) getIndex() int {
+	return b.index
+}
+
+func (b *BaseItem) setIndex(idx int) {
+	b.index = idx
 }
 
 type heapQueue []Item
@@ -49,11 +60,16 @@ func (hq heapQueue) Less(i, j int) bool {
 
 func (hq heapQueue) Swap(i, j int) {
 	hq[i], hq[j] = hq[j], hq[i]
+	// update indices after swap
+	hq[i].setIndex(i)
+	hq[j].setIndex(j)
 }
 
 func (hq *heapQueue) Push(x any) {
 	i := x.(Item)
 	*hq = append(*hq, i)
+	// set index for the newly pushed item
+	i.setIndex(len(*hq) - 1)
 }
 
 func (hq *heapQueue) Pop() any {
@@ -61,6 +77,8 @@ func (hq *heapQueue) Pop() any {
 	l := len(arr)
 	ret := arr[l-1]
 	*hq = arr[0 : l-1]
+	// clear index for popped item
+	ret.setIndex(-1)
 	return ret
 }
 
@@ -90,4 +108,8 @@ func (pq *PriorityQueue) Push(item Item) {
 
 func (pq *PriorityQueue) Pop() Item {
 	return heap.Pop(&pq.heapQueue).(Item)
+}
+
+func (pq *PriorityQueue) Fix(it Item) {
+	heap.Fix(&pq.heapQueue, it.getIndex())
 }

--- a/internal/querycoordv2/balance/score_based_balancer.go
+++ b/internal/querycoordv2/balance/score_based_balancer.go
@@ -142,6 +142,10 @@ func (b *ScoreBasedBalancer) assignSegment(br *balanceReport, collectionID int64
 			// update the sourceNode and targetNode's score
 			if sourceNode != nil {
 				sourceNode.AddCurrentScoreDelta(-scoreChanges)
+				// sourceNode is still in the queue, fix its position
+				if sourceNode.getIndex() >= 0 {
+					queue.Fix(sourceNode)
+				}
 			}
 			targetNode.AddCurrentScoreDelta(scoreChanges)
 		}(s)
@@ -248,6 +252,10 @@ func (b *ScoreBasedBalancer) assignChannel(br *balanceReport, collectionID int64
 			// update the sourceNode and targetNode's score
 			if sourceNode != nil {
 				sourceNode.AddCurrentScoreDelta(-scoreChanges)
+				// sourceNode is still in the queue, fix its position
+				if sourceNode.getIndex() >= 0 {
+					queue.Fix(sourceNode)
+				}
 			}
 			targetNode.AddCurrentScoreDelta(scoreChanges)
 		}(ch)


### PR DESCRIPTION
If ScoreBasedBalancer updates node scores after generating balance plans, the source node remains in the priority queue with stale priority because the heap is not fixed. Subsequent pops use outdated ordering, slowing or skewing balancing. This change:
Track heap index in nodeItem and call heap.Fix only when the node is still in the heap, so priority is refreshed after score changes.
Prevent repeated selection based on stale priorities, improving balance convergence and plan quality.
issue: #46951 
Core invariant: after any balance plan adjusts node score, the priority queue must reflect the latest priority before the next pop, so the lowest-priority node is always chosen based on up-to-date scores.
Bug fix: previously, source nodes had their score changed in-place while still inside the heap, but no heap.Fix was invoked, breaking the heap invariant. The fix maintains an index on nodeItem and calls heap.Fix only when the item is in the heap (index ≥ 0), ensuring the heap order stays consistent with current scores.
No behavior regression: the change only touches the heap maintenance path in score_based_balancer.go and priority queue helper, does not alter plan generation logic, scheduler behavior, or non-balance code paths.