### PR TITLE
fix: correct AssertInfo in UnmapIndexData for bitmap index

### DIFF
--- a/internal/core/src/index/BitmapIndex.cpp
+++ b/internal/core/src/index/BitmapIndex.cpp
@@ -62,7 +62,7 @@ BitmapIndex<T>::UnmapIndexData() {
     if (mmap_data_ != nullptr && mmap_data_ != MAP_FAILED) {
         if (munmap(mmap_data_, mmap_size_) != 0) {
             AssertInfo(
-                true, "failed to unmap bitmap index, err={}", strerror(errno));
+                false, "failed to unmap bitmap index, err={}", strerror(errno));
         }
         mmap_data_ = nullptr;
         mmap_size_ = 0;


### PR DESCRIPTION
Correct AssertInfo condition in BitmapIndex::UnmapIndexData.
Should be AssertInfo(false, xxx) to correctly show info message.