### PR TITLE
enhance: use StorageV3 to mark loon manifest segment info

### DIFF
--- a/internal/compaction/params.go
+++ b/internal/compaction/params.go
@@ -35,8 +35,12 @@ type Params struct {
 }
 
 func GenParams() Params {
+	storageVersion := storage.StorageV2
+	if paramtable.Get().CommonCfg.UseLoonFFI.GetAsBool() {
+		storageVersion = storage.StorageV3
+	}
 	return Params{
-		StorageVersion:            storage.StorageV2,
+		StorageVersion:            storageVersion,
 		BinLogMaxSize:             paramtable.Get().DataNodeCfg.BinLogMaxSize.GetAsUint64(),
 		UseMergeSort:              paramtable.Get().DataNodeCfg.UseMergeSort.GetAsBool(),
 		MaxSegmentMergeSort:       paramtable.Get().DataNodeCfg.MaxSegmentMergeSort.GetAsInt(),

--- a/internal/compaction/params_test.go
+++ b/internal/compaction/params_test.go
@@ -31,11 +31,16 @@ func TestGetJSONParams(t *testing.T) {
 	jsonStr, err := GenerateJSONParams()
 	assert.NoError(t, err)
 
+	storageVersion := storage.StorageV2
+	if paramtable.Get().CommonCfg.UseLoonFFI.GetAsBool() {
+		storageVersion = storage.StorageV3
+	}
+
 	var result Params
 	err = json.Unmarshal([]byte(jsonStr), &result)
 	assert.NoError(t, err)
 	assert.Equal(t, Params{
-		StorageVersion:            storage.StorageV2,
+		StorageVersion:            storageVersion,
 		BinLogMaxSize:             paramtable.Get().DataNodeCfg.BinLogMaxSize.GetAsUint64(),
 		UseMergeSort:              paramtable.Get().DataNodeCfg.UseMergeSort.GetAsBool(),
 		MaxSegmentMergeSort:       paramtable.Get().DataNodeCfg.MaxSegmentMergeSort.GetAsInt(),

--- a/internal/core/src/common/Consts.h
+++ b/internal/core/src/common/Consts.h
@@ -127,6 +127,7 @@ const std::string LOON_FFI_PROPERTIES_KEY = "loon_ffi_properties";
 // storage version
 const int64_t STORAGE_V1 = 1;
 const int64_t STORAGE_V2 = 2;
+const int64_t STORAGE_V3 = 3;
 
 const std::string UNKNOW_CAST_FUNCTION_NAME = "unknown";
 

--- a/internal/core/src/indexbuilder/index_c.cpp
+++ b/internal/core/src/indexbuilder/index_c.cpp
@@ -175,7 +175,8 @@ get_config(std::unique_ptr<milvus::proto::indexcgo::BuildIndexInfo>& info) {
     }
     config[INDEX_NUM_ROWS_KEY] = info->num_rows();
     config[STORAGE_VERSION_KEY] = info->storage_version();
-    if (info->storage_version() == STORAGE_V2) {
+    if (info->storage_version() == STORAGE_V2 ||
+        info->storage_version() == STORAGE_V3) {
         config[SEGMENT_INSERT_FILES_KEY] =
             get_segment_insert_files(info->segment_insert_files());
         config[SEGMENT_MANIFEST_KEY] = info->manifest();

--- a/internal/core/src/storage/MemFileManagerImpl.cpp
+++ b/internal/core/src/storage/MemFileManagerImpl.cpp
@@ -164,7 +164,7 @@ MemFileManagerImpl::CacheRawDataToMemory(const Config& config) {
     auto storage_version =
         index::GetValueFromConfig<int64_t>(config, STORAGE_VERSION_KEY)
             .value_or(0);
-    if (storage_version == STORAGE_V2) {
+    if (storage_version == STORAGE_V2 || storage_version == STORAGE_V3) {
         return cache_raw_data_to_memory_storage_v2(config);
     }
     return cache_raw_data_to_memory_internal(config);

--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -1603,11 +1603,6 @@ CacheRawDataAndFillMissing(const MemFileManagerImplPtr& file_manager,
     // download field data
     auto field_datas = file_manager->CacheRawDataToMemory(config);
 
-    // check storage version
-    auto storage_version =
-        index::GetValueFromConfig<int64_t>(config, STORAGE_VERSION_KEY)
-            .value_or(0);
-
     int64_t lack_binlog_rows =
         index::GetValueFromConfig<int64_t>(config, INDEX_NUM_ROWS_KEY)
             .value_or(0);

--- a/internal/datacoord/import_util.go
+++ b/internal/datacoord/import_util.go
@@ -171,6 +171,11 @@ func AssignSegments(job ImportJob, task ImportTask, alloc allocator.Allocator, m
 		segmentLevel = datapb.SegmentLevel_L0
 	}
 
+	storageVersion := storage.StorageV2
+	if paramtable.Get().CommonCfg.UseLoonFFI.GetAsBool() {
+		storageVersion = storage.StorageV3
+	}
+
 	// alloc new segments
 	segments := make([]int64, 0)
 	addSegment := func(vchannel string, partitionID int64, size int64) error {
@@ -179,7 +184,7 @@ func AssignSegments(job ImportJob, task ImportTask, alloc allocator.Allocator, m
 		for size > 0 {
 			segmentInfo, err := AllocImportSegment(ctx, alloc, meta,
 				task.GetJobID(), task.GetTaskID(), task.GetCollectionID(),
-				partitionID, vchannel, job.GetDataTs(), segmentLevel, storage.StorageV2)
+				partitionID, vchannel, job.GetDataTs(), segmentLevel, storageVersion)
 			if err != nil {
 				return err
 			}
@@ -355,6 +360,11 @@ func AssembleImportRequest(task ImportTask, job ImportJob, meta *meta, alloc all
 		return fileStat.GetImportFile()
 	})
 
+	storageVersion := storage.StorageV2
+	if paramtable.Get().CommonCfg.UseLoonFFI.GetAsBool() {
+		storageVersion = storage.StorageV3
+	}
+
 	req := &datapb.ImportRequest{
 		ClusterID:       Params.CommonCfg.ClusterPrefix.GetValue(),
 		JobID:           task.GetJobID(),
@@ -370,7 +380,7 @@ func AssembleImportRequest(task ImportTask, job ImportJob, meta *meta, alloc all
 		RequestSegments: requestSegments,
 		StorageConfig:   createStorageConfig(),
 		TaskSlot:        task.GetTaskSlot(),
-		StorageVersion:  storage.StorageV2,
+		StorageVersion:  storageVersion,
 		PluginContext:   GetReadPluginContext(job.GetOptions()),
 		UseLoonFfi:      Params.CommonCfg.UseLoonFFI.GetAsBool(),
 	}

--- a/internal/datanode/compactor/clustering_compactor.go
+++ b/internal/datanode/compactor/clustering_compactor.go
@@ -934,7 +934,7 @@ func (t *clusteringCompactionTask) scalarAnalyzeSegment(
 				binlogs = append(binlogs, fieldBinlog)
 			}
 		}
-	case storage.StorageV2:
+	case storage.StorageV2, storage.StorageV3:
 		binlogs = segment.GetFieldBinlogs()
 	default:
 		log.Warn("unsupported storage version", zap.Int64("storage version", segment.GetStorageVersion()))

--- a/internal/datanode/compactor/sort_compaction.go
+++ b/internal/datanode/compactor/sort_compaction.go
@@ -437,7 +437,7 @@ func (t *sortCompactionTask) createTextIndex(ctx context.Context,
 	})
 
 	getInsertFiles := func(fieldID int64) ([]string, error) {
-		if t.storageVersion == storage.StorageV2 {
+		if t.storageVersion == storage.StorageV2 || t.storageVersion == storage.StorageV3 {
 			return []string{}, nil
 		}
 		binlogs, ok := fieldBinlogs[fieldID]
@@ -512,7 +512,7 @@ func (t *sortCompactionTask) createTextIndex(ctx context.Context,
 				buildIndexParams.AnalyzerExtraInfo = analyzerExtraInfo
 			}
 
-			if t.storageVersion == storage.StorageV2 {
+			if t.storageVersion == storage.StorageV2 || t.storageVersion == storage.StorageV3 {
 				buildIndexParams.SegmentInsertFiles = util.GetSegmentInsertFiles(
 					insertBinlogs,
 					t.compactionParams.StorageConfig,

--- a/internal/datanode/index/task_index.go
+++ b/internal/datanode/index/task_index.go
@@ -306,7 +306,7 @@ func (it *indexBuildTask) Execute(ctx context.Context) error {
 		LackBinlogRows:            it.req.GetLackBinlogRows(),
 		StorageVersion:            it.req.GetStorageVersion(),
 	}
-	if buildIndexParams.StorageVersion == storage.StorageV2 {
+	if buildIndexParams.StorageVersion == storage.StorageV2 || buildIndexParams.StorageVersion == storage.StorageV3 {
 		buildIndexParams.SegmentInsertFiles = util.GetSegmentInsertFiles(
 			it.req.GetInsertLogs(),
 			it.req.GetStorageConfig(),

--- a/internal/datanode/index/task_stats.go
+++ b/internal/datanode/index/task_stats.go
@@ -460,7 +460,7 @@ func (st *statsTask) createTextIndex(ctx context.Context,
 	})
 
 	getInsertFiles := func(fieldID int64, enableNull bool) ([]string, error) {
-		if st.req.GetStorageVersion() == storage.StorageV2 {
+		if st.req.GetStorageVersion() == storage.StorageV2 || st.req.GetStorageVersion() == storage.StorageV3 {
 			return []string{}, nil
 		}
 		binlogs, ok := fieldBinlogs[fieldID]
@@ -605,7 +605,7 @@ func (st *statsTask) createJSONKeyStats(ctx context.Context,
 	})
 
 	getInsertFiles := func(fieldID int64) ([]string, error) {
-		if st.req.GetStorageVersion() == storage.StorageV2 {
+		if st.req.GetStorageVersion() == storage.StorageV2 || st.req.GetStorageVersion() == storage.StorageV3 {
 			return []string{}, nil
 		}
 		binlogs, ok := fieldBinlogs[fieldID]
@@ -739,7 +739,7 @@ func buildIndexParams(
 		Manifest:                         req.GetManifestPath(),
 	}
 
-	if req.GetStorageVersion() == storage.StorageV2 {
+	if req.GetStorageVersion() == storage.StorageV2 || req.GetStorageVersion() == storage.StorageV3 {
 		params.SegmentInsertFiles = util.GetSegmentInsertFiles(
 			req.GetInsertLogs(),
 			req.GetStorageConfig(),

--- a/internal/flushcommon/metacache/segment.go
+++ b/internal/flushcommon/metacache/segment.go
@@ -167,7 +167,7 @@ func NewSegmentInfo(info *datapb.SegmentInfo, bfs pkoracle.PkStat, bm25Stats *Se
 	// legacy split also share same field here
 	// shall be checked by caller
 	var currentSplit []storagecommon.ColumnGroup
-	if info.GetStorageVersion() == storage.StorageV2 && len(info.Binlogs) > 0 {
+	if info.GetStorageVersion() >= storage.StorageV2 && len(info.Binlogs) > 0 {
 		currentSplit = make([]storagecommon.ColumnGroup, 0, len(info.Binlogs))
 		for _, group := range info.Binlogs {
 			currentSplit = append(currentSplit, storagecommon.ColumnGroup{

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -796,7 +796,7 @@ func separateLoadInfoV2(loadInfo *querypb.SegmentLoadInfo, schema *schemapb.Coll
 	indexedFieldInfos := make(map[int64]*IndexedFieldInfo)
 	fieldBinlogs := make([]*datapb.FieldBinlog, 0, len(loadInfo.BinlogPaths))
 
-	if storageVersion == storage.StorageV2 {
+	if storageVersion == storage.StorageV2 || storageVersion == storage.StorageV3 {
 		for _, fieldBinlog := range loadInfo.BinlogPaths {
 			fieldID := fieldBinlog.FieldID
 

--- a/internal/storage/rw.go
+++ b/internal/storage/rw.go
@@ -39,8 +39,12 @@ import (
 )
 
 const (
+	// StorageV1 is milvus 2.0 legacy binlog format
 	StorageV1 int64 = 0
+	// StorageV2 is milvus-storage packed writer binlog format(parquet)
 	StorageV2 int64 = 2
+	// StorageV3 is loon manifest format
+	StorageV3 int64 = 3
 )
 
 type (
@@ -84,7 +88,7 @@ func (o *rwOptions) validate() error {
 		if o.op == OpRead && o.downloader == nil {
 			return merr.WrapErrServiceInternal("downloader is nil for v1 reader")
 		}
-	case StorageV2:
+	case StorageV2, StorageV3:
 		if o.storageConfig == nil {
 			return merr.WrapErrServiceInternal("storage config is nil")
 		}
@@ -287,7 +291,7 @@ func NewBinlogRecordReader(ctx context.Context, binlogs []*datapb.FieldBinlog, s
 			return nil, err
 		}
 		rr = newIterativeCompositeBinlogRecordReader(schema, rwOptions.neededFields, blobsReader, binlogReaderOpts...)
-	case StorageV2:
+	case StorageV2, StorageV3:
 		if len(binlogs) <= 0 {
 			return nil, sio.EOF
 		}
@@ -398,21 +402,19 @@ func NewBinlogRecordWriter(ctx context.Context, collectionID, partitionID, segme
 			blobsWriter, allocator, chunkSize, rootPath, maxRowNum, opts...,
 		)
 	case StorageV2:
-		if rwOptions.useLoonFFI {
-			return newPackedManifestRecordWriter(collectionID, partitionID, segmentID, schema,
-				blobsWriter, allocator, maxRowNum,
-				rwOptions.bufferSize, rwOptions.multiPartUploadSize, rwOptions.columnGroups,
-				rwOptions.storageConfig,
-				pluginContext,
-			)
-		} else {
-			return newPackedBinlogRecordWriter(collectionID, partitionID, segmentID, schema,
-				blobsWriter, allocator, maxRowNum,
-				rwOptions.bufferSize, rwOptions.multiPartUploadSize, rwOptions.columnGroups,
-				rwOptions.storageConfig,
-				pluginContext,
-			)
-		}
+		return newPackedBinlogRecordWriter(collectionID, partitionID, segmentID, schema,
+			blobsWriter, allocator, maxRowNum,
+			rwOptions.bufferSize, rwOptions.multiPartUploadSize, rwOptions.columnGroups,
+			rwOptions.storageConfig,
+			pluginContext,
+		)
+	case StorageV3:
+		return newPackedManifestRecordWriter(collectionID, partitionID, segmentID, schema,
+			blobsWriter, allocator, maxRowNum,
+			rwOptions.bufferSize, rwOptions.multiPartUploadSize, rwOptions.columnGroups,
+			rwOptions.storageConfig,
+			pluginContext,
+		)
 	}
 	return nil, merr.WrapErrServiceInternal(fmt.Sprintf("unsupported storage version %d", rwOptions.version))
 }

--- a/internal/streamingnode/server/wal/interceptors/shard/shards/segment_alloc_worker.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/shards/segment_alloc_worker.go
@@ -14,6 +14,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
 
 // asyncAllocSegment allocates a new growing segment asynchronously.
@@ -107,6 +108,10 @@ func (w *segmentAllocWorker) generateNewGrowingSegmentMessage() error {
 		w.Logger().Warn("failed to allocate segment id", zap.Error(err))
 		return err
 	}
+	storageVersion := storage.StorageV2
+	if paramtable.Get().CommonCfg.UseLoonFFI.GetAsBool() {
+		storageVersion = storage.StorageV3
+	}
 	// Getnerate growing segment limitation.
 	limitation := getSegmentLimitationPolicy().GenerateLimitation(datapb.SegmentLevel_L1)
 	// Create a new segment by sending a create segment message into wal directly.
@@ -116,7 +121,7 @@ func (w *segmentAllocWorker) generateNewGrowingSegmentMessage() error {
 			CollectionId:   w.collectionID,
 			PartitionId:    w.partitionID,
 			SegmentId:      int64(segmentID),
-			StorageVersion: storage.StorageV2,
+			StorageVersion: storageVersion,
 			MaxRows:        limitation.SegmentRows,
 			MaxSegmentSize: limitation.SegmentSize,
 			Level:          datapb.SegmentLevel_L1,

--- a/internal/util/importutilv2/option.go
+++ b/internal/util/importutilv2/option.go
@@ -147,10 +147,16 @@ func GetStorageVersion(options Options) (int64, error) {
 	if err != nil {
 		return 0, merr.WrapErrImportFailed(fmt.Sprintf("parse storage_version failed, value=%s, err=%s", storageVersion, err))
 	}
-	if version == storage.StorageV2 {
+	switch version {
+	case storage.StorageV2:
 		return storage.StorageV2, nil
+	case storage.StorageV3:
+		return storage.StorageV3, nil
+	case storage.StorageV1:
+		fallthrough
+	default:
+		return storage.StorageV1, nil
 	}
-	return storage.StorageV1, nil
 }
 
 // SkipDiskQuotaCheck indicates whether the import skips the disk quota check.

--- a/tests/integration/stats_task/stats_task_test.go
+++ b/tests/integration/stats_task/stats_task_test.go
@@ -353,7 +353,7 @@ func (s *StatsTaskCheckerSuite) checkBinlogIsSorted(ctx context.Context, binlogP
 }
 
 func (s *StatsTaskCheckerSuite) checkSegmentIsSorted(ctx context.Context, segment *datapb.SegmentInfo) {
-	if segment.GetStorageVersion() == storage.StorageV2 {
+	if segment.GetStorageVersion() == storage.StorageV2 || segment.GetStorageVersion() == storage.StorageV3 {
 		// TODO: check sorted segment in storage v2
 		return
 	}


### PR DESCRIPTION
Related to #44956

Introduce StorageV3 constant to distinguish loon manifest format from StorageV2 packed writer format. When UseLoonFFI is enabled, segments are now marked with StorageVersion=3 instead of 2.

The V3 format currently shares most V2 logic paths since the underlying storage format is similar. In a future refactor, V3-specific logic will be separated from the V2 code path for better readability.

Changes:
- Add StorageV3 constant (value=3) in Go and C++ code
- Set StorageVersion=3 when UseLoonFFI is enabled for:
- Compaction params
- Import segments allocation
- Write buffer growing segments
- Streaming node segment allocation
- Add V3 support to existing V2 code paths (read/write/sync)
- Separate V2 and V3 writer creation in NewBinlogRecordWriter