### PR TITLE
enhance: [2.6] add security controls for /expr endpoint

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -974,6 +974,7 @@ common:
     defaultRootPassword: Milvus
     rootShouldBindRole: false # Whether the root user should bind a role when the authorization is enabled.
     enablePublicPrivilege: true # Whether to enable public privilege
+    exprEnabled: false # Whether to enable the /expr endpoint for debugging. When enabled, only root user can access it via HTTP Basic Auth on Proxy nodes.
     rbac:
       overrideBuiltInPrivilegeGroups:
         enabled: false # Whether to override build-in privilege groups

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -17,6 +17,7 @@
 package http
 
 import (
+	"context"
 	"embed"
 	"fmt"
 	"net/http"
@@ -44,7 +45,17 @@ const (
 var (
 	metricsServer *http.ServeMux
 	server        *http.Server
+
+	// passwordVerifyFunc is a callback function to verify user password.
+	// This is set by the proxy package to avoid circular dependency.
+	passwordVerifyFunc func(ctx context.Context, username, password string) bool
 )
+
+// RegisterPasswordVerifyFunc registers a function to verify user password.
+// This should be called by the proxy package during initialization.
+func RegisterPasswordVerifyFunc(fn func(ctx context.Context, username, password string) bool) {
+	passwordVerifyFunc = fn
+}
 
 // Embedding all static files of webui folder to binary
 //
@@ -87,8 +98,32 @@ func registerDefaults() {
 	Register(&Handler{
 		Path: ExprPath,
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			// Check if expr endpoint is enabled
+			if !paramtable.Get().CommonCfg.ExprEnabled.GetAsBool() {
+				w.WriteHeader(http.StatusForbidden)
+				w.Write([]byte(`{"msg": "expr endpoint is disabled. Set common.security.exprEnabled to true to enable it."}`))
+				return
+			}
+
 			code := req.URL.Query().Get("code")
-			auth := req.URL.Query().Get("auth")
+			var auth string
+
+			// Only Proxy nodes can access /expr endpoint
+			if !expr.HasRegistered("proxy") || passwordVerifyFunc == nil {
+				w.WriteHeader(http.StatusForbidden)
+				w.Write([]byte(`{"msg": "/expr endpoint is only available on Proxy nodes"}`))
+				return
+			}
+
+			// On Proxy node: require root user authentication via HTTP Basic Auth
+			if err := checkExprRootAuth(req); err != nil {
+				w.WriteHeader(http.StatusUnauthorized)
+				w.Write([]byte(fmt.Sprintf(`{"msg": "%s"}`, err.Error())))
+				return
+			}
+			// Use bypass since we've already authenticated
+			auth = expr.AuthBypass
+
 			output, err := expr.Exec(code, auth)
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
@@ -270,4 +305,43 @@ func getHTTPAddr() string {
 	paramtable.Get().Save(paramtable.Get().CommonCfg.MetricsPort.Key, port)
 
 	return fmt.Sprintf(":%s", port)
+}
+
+// checkExprRootAuth verifies that the request is from the root user.
+// It supports HTTP Basic Auth and Bearer token formats.
+func checkExprRootAuth(req *http.Request) error {
+	// Try HTTP Basic Auth first
+	username, password, ok := req.BasicAuth()
+	if !ok {
+		// Try Bearer token format: "user:password"
+		auth := req.Header.Get("Authorization")
+		auth = strings.TrimPrefix(auth, "Bearer ")
+		parts := strings.SplitN(auth, ":", 2)
+		if len(parts) == 2 {
+			username, password = parts[0], parts[1]
+			ok = true
+		}
+	}
+
+	if !ok || username == "" || password == "" {
+		return fmt.Errorf("authentication required. Use HTTP Basic Auth with root credentials")
+	}
+
+	// Only root user can access /expr
+	if username != "root" {
+		log.Warn("non-root user attempted to access /expr", zap.String("username", username))
+		return fmt.Errorf("only root user can access /expr endpoint")
+	}
+
+	// Verify root password
+	if passwordVerifyFunc == nil {
+		return fmt.Errorf("password verification not available")
+	}
+	if !passwordVerifyFunc(context.Background(), username, password) {
+		log.Warn("invalid root password for /expr access")
+		return fmt.Errorf("invalid root password")
+	}
+
+	log.Info("root user authenticated for /expr access")
+	return nil
 }

--- a/internal/proxy/meta_cache.go
+++ b/internal/proxy/meta_cache.go
@@ -30,6 +30,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	internalhttp "github.com/milvus-io/milvus/internal/http"
 	"github.com/milvus-io/milvus/internal/proxy/privilege"
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/pkg/v2/common"
@@ -374,6 +375,9 @@ func InitMetaCache(ctx context.Context, mixCoord types.MixCoordClient) error {
 		log.Error("failed to init privilege cache", zap.Error(err))
 		return err
 	}
+
+	// Register password verify function for /expr endpoint authentication
+	internalhttp.RegisterPasswordVerifyFunc(PasswordVerify)
 
 	return nil
 }

--- a/pkg/util/expr/expr_test.go
+++ b/pkg/util/expr/expr_test.go
@@ -100,4 +100,32 @@ func TestExec(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, fmt.Sprintf("%d", innerSize(mockMessage)), out)
 	})
+
+	t.Run("auth bypass", func(t *testing.T) {
+		// AuthBypass should allow execution without checking the auth key
+		out, err := Exec("foo", AuthBypass)
+		assert.NoError(t, err)
+		assert.Equal(t, "hello", out)
+	})
+}
+
+func TestHasRegistered(t *testing.T) {
+	// Before init, should return false
+	env = nil
+	assert.False(t, HasRegistered("foo"))
+
+	// After init
+	Init()
+	Register("testKey", "testValue")
+
+	// Registered key should return true
+	assert.True(t, HasRegistered("testKey"))
+
+	// Non-registered key should return false
+	assert.False(t, HasRegistered("nonExistentKey"))
+
+	// Check for "proxy" key (used to detect Proxy node)
+	assert.False(t, HasRegistered("proxy"))
+	Register("proxy", "mock_proxy")
+	assert.True(t, HasRegistered("proxy"))
 }

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -261,6 +261,7 @@ type commonConfig struct {
 	DefaultRootPassword   ParamItem `refreshable:"false"`
 	RootShouldBindRole    ParamItem `refreshable:"true"`
 	EnablePublicPrivilege ParamItem `refreshable:"false"`
+	ExprEnabled           ParamItem `refreshable:"false"`
 
 	ClusterName ParamItem `refreshable:"false"`
 
@@ -841,6 +842,15 @@ Large numeric passwords require double quotes to avoid yaml parsing precision is
 		Export:       true,
 	}
 	p.EnablePublicPrivilege.Init(base.mgr)
+
+	p.ExprEnabled = ParamItem{
+		Key:          "common.security.exprEnabled",
+		Version:      "2.6.0",
+		DefaultValue: "false",
+		Doc:          "Whether to enable the /expr endpoint for debugging. When enabled, only root user can access it via HTTP Basic Auth on Proxy nodes.",
+		Export:       true,
+	}
+	p.ExprEnabled.Init(base.mgr)
 
 	p.ClusterName = ParamItem{
 		Key:          "common.cluster.name",


### PR DESCRIPTION
cherry-pick from master: #46753 
related: #46442
pr: #46753

core changes:
* Add config (default: false) to disable /expr endpoint by default
* On Proxy nodes, require root user authentication via HTTP Basic Auth when enabled
* On non-Proxy nodes, keep original auth parameter behavior for backward compatibility
* Add HasRegistered() and AuthBypass to expr package for node type detection