### PR TITLE
fix: revert pre-filter bitset usage for ngram

### DIFF
--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -1912,14 +1912,8 @@ PhyUnaryRangeFilterExpr::ExecNgramMatch(EvalCtx& context) {
                    "ngram index should not be null, field_id: {}",
                    field_id_.get());
 
-        // Get pre_filter from previous expressions in the conjunction.
-        // This optimization reduces the number of rows that need post-filtering.
-        const auto& bitmap_input = context.get_bitmap_input();
-        const TargetBitmap* pre_filter =
-            bitmap_input.empty() ? nullptr : &bitmap_input;
-
         auto res_opt =
-            index->ExecuteQuery(literal, expr_->op_type_, this, pre_filter);
+            index->ExecuteQuery(literal, expr_->op_type_, this, nullptr);
         if (!res_opt.has_value()) {
             return std::nullopt;
         }


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/46813
Pre-filter bitset is for batch size while ngram used it as segment size bitset.
Revert it first.