### PR TITLE
enhance: avoid extra memory copy for logging from C++, add benchmark

### DIFF
--- a/internal/core/src/common/logging_c.cpp
+++ b/internal/core/src/common/logging_c.cpp
@@ -80,7 +80,7 @@ GoZapSink::send(google::LogSeverity severity,
     if (full_filename == nullptr || full_filename[0] == '\0') {
         return;
     }
-    int last_two_slash_index[] = {0, 0};
+    int last_two_slash_index[] = {-1, -1};
     int idx = 0;
     while (full_filename[idx] != '\0') {
         if (full_filename[idx] == '/') {

--- a/internal/core/src/common/logging_c.cpp
+++ b/internal/core/src/common/logging_c.cpp
@@ -15,13 +15,18 @@
 // limitations under the License.
 
 #include "logging_c.h"
+#include <glog/logging.h>
 
 #ifdef WITHOUT_GO_LOGGING
 
 // Empty implementation when there's no go logging implementation.
 void
-goZapLogExt(
-    int severity, const char* file, int line, const char* msg, int msg_len) {
+goZapLogExt(int severity,
+            const char* file,
+            int file_len,
+            int line,
+            const char* msg,
+            int msg_len) {
 }
 
 #elif defined(__APPLE__)
@@ -30,8 +35,12 @@ goZapLogExt(
 // will be implemented in github.com/milvus-io/milvus/internal/util/cgo/logging
 // macOS linker requires weak_import to allow unresolved symbols.
 extern "C" void
-goZapLogExt(
-    int severity, const char* file, int line, const char* msg, int msg_len) {
+goZapLogExt(int severity,
+            const char* file,
+            int file_len,
+            int line,
+            const char* msg,
+            int msg_len) {
 }
 __attribute__((weak_import));
 
@@ -40,10 +49,25 @@ __attribute__((weak_import));
 // Go export function.
 // will be implemented in github.com/milvus-io/milvus/internal/util/cgo/logging
 extern "C" void
-goZapLogExt(
-    int severity, const char* file, int line, const char* msg, int msg_len);
+goZapLogExt(int severity,
+            const char* file,
+            int file_len,
+            int line,
+            const char* msg,
+            int msg_len);
 
 #endif
+
+class GoZapSink : public google::LogSink {
+    void
+    send(google::LogSeverity severity,
+         const char* full_filename,
+         const char* base_filename,
+         int line,
+         const struct tm*,
+         const char* message,
+         size_t message_len) override;
+};
 
 void
 GoZapSink::send(google::LogSeverity severity,
@@ -53,10 +77,63 @@ GoZapSink::send(google::LogSeverity severity,
                 const struct tm*,
                 const char* message,
                 size_t message_len) {
-    // remove the '\n' added by glog
-    int len = static_cast<int>(message_len);
-    if (len > 0 && message[len - 1] == '\n') {
-        len--;
+    if (full_filename == nullptr || full_filename[0] == '\0') {
+        return;
     }
-    goZapLogExt(static_cast<int>(severity), full_filename, line, message, len);
+    int last_two_slash_index[] = {0, 0};
+    int idx = 0;
+    while (full_filename[idx] != '\0') {
+        if (full_filename[idx] == '/') {
+            last_two_slash_index[0] = last_two_slash_index[1];
+            last_two_slash_index[1] = idx;
+        }
+        idx++;
+    }
+
+    int from_index = last_two_slash_index[0] + 1;
+    goZapLogExt(static_cast<int>(severity),
+                full_filename + from_index,
+                idx - from_index,
+                line,
+                message,
+                message_len);
 };
+
+static GoZapSink g_sink;
+
+extern "C" {
+void
+InitGoogleLoggingWithZapSink() {
+    if (google::IsGoogleLoggingInitialized()) {
+        return;
+    }
+    google::InitGoogleLogging("milvus");
+    google::AddLogSink(&g_sink);
+
+    // log is catched by zap, so we don't need to log to stderr/stdout/files anymore.
+    FLAGS_logtostdout = false;
+    FLAGS_logtostderr = false;
+    FLAGS_alsologtostderr = false;
+    FLAGS_log_dir = "";
+    return;
+}
+
+void
+InitGoogleLoggingWithoutZapSink() {
+    if (google::IsGoogleLoggingInitialized()) {
+        return;
+    }
+    google::InitGoogleLogging("milvus");
+    // log is catched by zap, so we don't need to log to stderr/stdout/files anymore.
+    FLAGS_logtostdout = true;
+    FLAGS_logtostderr = false;
+    FLAGS_alsologtostderr = false;
+    FLAGS_log_dir = "";
+    return;
+}
+
+void
+GoogleLoggingAtLevel(int severity, const char* msg) {
+    google::LogAtLevel(severity, msg);
+}
+}

--- a/internal/core/src/common/logging_c.cpp
+++ b/internal/core/src/common/logging_c.cpp
@@ -77,23 +77,9 @@ GoZapSink::send(google::LogSeverity severity,
                 const struct tm*,
                 const char* message,
                 size_t message_len) {
-    if (full_filename == nullptr || full_filename[0] == '\0') {
-        return;
-    }
-    int last_two_slash_index[] = {-1, -1};
-    int idx = 0;
-    while (full_filename[idx] != '\0') {
-        if (full_filename[idx] == '/') {
-            last_two_slash_index[0] = last_two_slash_index[1];
-            last_two_slash_index[1] = idx;
-        }
-        idx++;
-    }
-
-    int from_index = last_two_slash_index[0] + 1;
     goZapLogExt(static_cast<int>(severity),
-                full_filename + from_index,
-                idx - from_index,
+                full_filename,
+                strlen(full_filename),
                 line,
                 message,
                 message_len);

--- a/internal/core/src/config/ConfigKnowhere.cpp
+++ b/internal/core/src/config/ConfigKnowhere.cpp
@@ -18,7 +18,6 @@
 
 #include "ConfigKnowhere.h"
 #include "common/EasyAssert.h"
-#include "glog/logging.h"
 #include "log/Log.h"
 #include "knowhere/comp/knowhere_config.h"
 #include "knowhere/version.h"
@@ -28,24 +27,13 @@ namespace milvus::config {
 
 std::once_flag init_knowhere_once_;
 
-static GoZapSink g_sink;
-
 void
 KnowhereInitImpl(const char* conf_file) {
     auto init = [&]() {
         knowhere::KnowhereConfig::SetBlasThreshold(16384);
         knowhere::KnowhereConfig::SetEarlyStopThreshold(0);
         knowhere::KnowhereConfig::ShowVersion();
-        if (!google::IsGoogleLoggingInitialized()) {
-            google::InitGoogleLogging("milvus");
-            google::AddLogSink(&g_sink);
-
-            // log is catched by zap, so we don't need to log to stderr/stdout/files anymore.
-            FLAGS_logtostdout = false;
-            FLAGS_logtostderr = false;
-            FLAGS_alsologtostderr = false;
-            FLAGS_log_dir = "";
-        }
+        InitGoogleLoggingWithZapSink();
 
 #ifdef EMBEDDED_MILVUS
         // always disable all logs for embedded milvus

--- a/internal/util/cgo/logging/glog_logging.go
+++ b/internal/util/cgo/logging/glog_logging.go
@@ -27,17 +27,7 @@ package logging
 import "C"
 import "unsafe"
 
-// GlogSeverity describes the GLOG severity level.
-type GlogSeverity int
-
-const (
-	GlogInfo    GlogSeverity = 0
-	GlogWarning GlogSeverity = 1
-	GlogError   GlogSeverity = 2
-	GlogFatal   GlogSeverity = 3
-)
-
-func GoogleLoggingAtLevel(severity GlogSeverity, msg string) {
+func GoogleLoggingAtLevel(severity glogSeverity, msg string) {
 	cmsg := C.CString(msg)
 	defer C.free(unsafe.Pointer(cmsg))
 	C.GoogleLoggingAtLevel(C.int(severity), cmsg)

--- a/internal/util/cgo/logging/glog_logging.go
+++ b/internal/util/cgo/logging/glog_logging.go
@@ -1,4 +1,4 @@
-// Licensed to the LF AI& Data foundation under one
+/// Licensed to the LF AI & Data foundation under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
 // regarding copyright ownership. The ASF licenses this file
@@ -14,21 +14,34 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#pragma once
+package logging
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+/*
+#cgo pkg-config: milvus_core
+#include <stdlib.h>
+#include "common/logging_c.h"
+*/
+import "C"
 
-void
-InitGoogleLoggingWithZapSink();
+// GlogSeverity describes the GLOG severity level.
+type GlogSeverity int
 
-void
-InitGoogleLoggingWithoutZapSink();
+const (
+	GlogInfo    GlogSeverity = 0
+	GlogWarning GlogSeverity = 1
+	GlogError   GlogSeverity = 2
+	GlogFatal   GlogSeverity = 3
+)
 
-void
-GoogleLoggingAtLevel(int severity, const char* msg);
-
-#ifdef __cplusplus
+// PrintGlogLog prints a log with the specified severity, file, line, and message using GLOG via cgo.
+func GoogleLoggingAtLevel(severity GlogSeverity, msg string) {
+	C.GoogleLoggingAtLevel(C.int(severity), C.CString(msg))
 }
-#endif
+
+func InitGoogleLoggingWithZapSink() {
+	C.InitGoogleLoggingWithZapSink()
+}
+
+func InitGoogleLogging() {
+	C.InitGoogleLoggingWithoutZapSink()
+}

--- a/internal/util/cgo/logging/glog_logging.go
+++ b/internal/util/cgo/logging/glog_logging.go
@@ -14,6 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build test
+// +build test
+
 package logging
 
 /*
@@ -22,6 +25,7 @@ package logging
 #include "common/logging_c.h"
 */
 import "C"
+import "unsafe"
 
 // GlogSeverity describes the GLOG severity level.
 type GlogSeverity int
@@ -33,9 +37,10 @@ const (
 	GlogFatal   GlogSeverity = 3
 )
 
-// PrintGlogLog prints a log with the specified severity, file, line, and message using GLOG via cgo.
 func GoogleLoggingAtLevel(severity GlogSeverity, msg string) {
-	C.GoogleLoggingAtLevel(C.int(severity), C.CString(msg))
+	cmsg := C.CString(msg)
+	defer C.free(unsafe.Pointer(cmsg))
+	C.GoogleLoggingAtLevel(C.int(severity), cmsg)
 }
 
 func InitGoogleLoggingWithZapSink() {

--- a/internal/util/cgo/logging/logging.go
+++ b/internal/util/cgo/logging/logging.go
@@ -67,8 +67,7 @@ func goZapLogExt(sev C.int,
 		return
 	}
 	// otherwise, we perform a synchronous write, Write directly to the underlying buffered write syncer.
-	b := unsafe.Slice((*byte)(unsafe.Pointer(msg)), int(msgLen))
-	msgStr := unsafe.String(&b[0], len(b))
+	msgStr := C.GoStringN(msg, int(msgLen))
 	ent := zapcore.Entry{
 		Level:      lv,
 		Time:       time.Now(),

--- a/internal/util/cgo/logging/logging.go
+++ b/internal/util/cgo/logging/logging.go
@@ -62,12 +62,11 @@ func goZapLogExt(sev C.int,
 			Message:     unsafe.Pointer(msg),
 			MessageLen:  int(msgLen),
 		})
-		metrics.LoggingCGOWriteTotal.Inc()
-		metrics.LoggingCGOWriteBytes.Add(float64(msgLen))
 		return
 	}
 	// otherwise, we perform a synchronous write, Write directly to the underlying buffered write syncer.
-	msgStr := C.GoStringN(msg, int(msgLen))
+	b := unsafe.Slice((*byte)(unsafe.Pointer(msg)), int(msgLen))
+	msgStr := unsafe.String(&b[0], len(b))
 	ent := zapcore.Entry{
 		Level:      lv,
 		Time:       time.Now(),

--- a/internal/util/cgo/logging/logging.go
+++ b/internal/util/cgo/logging/logging.go
@@ -33,10 +33,19 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	"github.com/milvus-io/milvus/pkg/v2/log"
-	"github.com/milvus-io/milvus/pkg/v2/metrics"
 )
 
 const cgoLoggerName = "CGO"
+
+const (
+	glogInfo    glogSeverity = 0
+	glogWarning glogSeverity = 1
+	glogError   glogSeverity = 2
+	glogFatal   glogSeverity = 3
+)
+
+// glogSeverity describes the GLOG severity level.
+type glogSeverity = int
 
 //export goZapLogExt
 func goZapLogExt(sev C.int,
@@ -64,6 +73,8 @@ func goZapLogExt(sev C.int,
 		})
 		return
 	}
+
+	// Currently, milvus will enable async log by default, so following code is never executed.
 	// otherwise, we perform a synchronous write, Write directly to the underlying buffered write syncer.
 	b := unsafe.Slice((*byte)(unsafe.Pointer(msg)), int(msgLen))
 	msgStr := unsafe.String(&b[0], len(b))
@@ -79,21 +90,19 @@ func goZapLogExt(sev C.int,
 		},
 	}
 	if ce := log.L().Core().Check(ent, nil); ce != nil {
-		metrics.LoggingCGOWriteTotal.Inc()
-		metrics.LoggingCGOWriteBytes.Add(float64(msgLen))
 		ce.Write()
 	}
 }
 
 func mapGlogSeverity(s int) zapcore.Level {
 	switch s {
-	case 0: // GLOG_INFO
+	case glogInfo: // GLOG_INFO
 		return zapcore.InfoLevel
-	case 1: // GLOG_WARNING
+	case glogWarning: // GLOG_WARNING
 		return zapcore.WarnLevel
-	case 2: // GLOG_ERROR
+	case glogError: // GLOG_ERROR
 		return zapcore.ErrorLevel
-	case 3: // GLOG_FATAL
+	case glogFatal: // GLOG_FATAL
 		// glog fatal will call std::abort,
 		// zap will call os.Exit(1),
 		// we don't want to double exit, so we use error level instead

--- a/internal/util/cgo/logging/logging_benchmark_test.go
+++ b/internal/util/cgo/logging/logging_benchmark_test.go
@@ -95,7 +95,7 @@ func writeLogsWithConcurrency(logs []string) {
 	writeLogs := func(logs chan string) {
 		defer wg.Done()
 		for log := range logs {
-			GoogleLoggingAtLevel(GlogInfo, log)
+			GoogleLoggingAtLevel(glogInfo, log)
 		}
 	}
 	wg.Add(currency)

--- a/internal/util/cgo/logging/logging_benchmark_test.go
+++ b/internal/util/cgo/logging/logging_benchmark_test.go
@@ -1,0 +1,106 @@
+package logging
+
+import (
+	"math/rand"
+	"sync"
+	"testing"
+
+	"github.com/milvus-io/milvus/pkg/v2/log"
+	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/v2/util/logutil"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+)
+
+func BenchmarkGlog(b *testing.B) {
+	InitGoogleLogging()
+	logs := generateTestLogs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		writeLogsWithConcurrency(logs)
+	}
+}
+
+func BenchmarkZapLog(b *testing.B) {
+	InitGoogleLoggingWithZapSink()
+	logs := generateTestLogs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		writeLogsWithConcurrency(logs)
+	}
+}
+
+var initOnce sync.Once
+
+func BenchmarkZapAsyncLog4KB(b *testing.B) {
+	benchmarkZapAsyncLog(b, 4*1024)
+}
+
+func BenchmarkZapAsyncLog4MB(b *testing.B) {
+	benchmarkZapAsyncLog(b, 4*1024*1024)
+}
+
+func benchmarkZapAsyncLog(b *testing.B, bufferSize int) {
+	initOnce.Do(func() {
+		params := paramtable.Get()
+		logConfig := log.Config{
+			Level:     params.LogCfg.Level.GetValue(),
+			GrpcLevel: params.LogCfg.GrpcLogLevel.GetValue(),
+			Format:    params.LogCfg.Format.GetValue(),
+			Stdout:    params.LogCfg.Stdout.GetAsBool(),
+			File: log.FileLogConfig{
+				RootPath:   params.LogCfg.RootPath.GetValue(),
+				MaxSize:    params.LogCfg.MaxSize.GetAsInt(),
+				MaxDays:    params.LogCfg.MaxAge.GetAsInt(),
+				MaxBackups: params.LogCfg.MaxBackups.GetAsInt(),
+			},
+			AsyncWriteEnable:         params.LogCfg.AsyncWriteEnable.GetAsBool(),
+			AsyncWriteFlushInterval:  params.LogCfg.AsyncWriteFlushInterval.GetAsDurationByParse(),
+			AsyncWriteDroppedTimeout: params.LogCfg.AsyncWriteDroppedTimeout.GetAsDurationByParse(),
+			AsyncWriteStopTimeout:    params.LogCfg.AsyncWriteStopTimeout.GetAsDurationByParse(),
+			AsyncWritePendingLength:  params.LogCfg.AsyncWritePendingLength.GetAsInt(),
+			AsyncWriteBufferSize:     bufferSize,
+			AsyncWriteMaxBytesPerLog: int(params.LogCfg.AsyncWriteMaxBytesPerLog.GetAsSize()),
+		}
+		logutil.SetupLogger(&logConfig)
+	})
+
+	InitGoogleLoggingWithZapSink()
+	logs := generateTestLogs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		writeLogsWithConcurrency(logs)
+	}
+}
+
+func generateTestLogs() []string {
+	seed := int64(123456)
+	r := rand.New(rand.NewSource(seed))
+
+	logs := make([]string, 1000)
+	for i := 0; i < len(logs); i++ {
+		n := r.Intn(4*1024) + 10
+		logs[i] = funcutil.RandomString(n)
+	}
+	return logs
+}
+
+func writeLogsWithConcurrency(logs []string) {
+	currency := 24
+	ch := make(chan string, len(logs))
+	for _, log := range logs {
+		ch <- log
+	}
+	close(ch)
+	wg := sync.WaitGroup{}
+	writeLogs := func(logs chan string) {
+		defer wg.Done()
+		for log := range logs {
+			GoogleLoggingAtLevel(GlogInfo, log)
+		}
+	}
+	wg.Add(currency)
+	for i := 0; i < currency; i++ {
+		go writeLogs(ch)
+	}
+	wg.Wait()
+}

--- a/pkg/log/zap_async_buffered_write_core.go
+++ b/pkg/log/zap_async_buffered_write_core.go
@@ -130,8 +130,8 @@ func (s *asyncTextIOCore) Write(ent zapcore.Entry, fields []zapcore.Field) error
 // Use this method to avoid the memory copy of the log message to the heap.
 func (s *asyncTextIOCore) WriteWithCEntry(ent CEntry) {
 	buf, err := s.enc.EncodeEntry(zapcore.Entry{
-		Time:       ent.Time,
 		Level:      ent.Level,
+		Time:       ent.Time,
 		LoggerName: "CGO",
 		Message:    unsafe.String((*byte)(ent.Message), ent.MessageLen),
 		Caller: zapcore.EntryCaller{
@@ -183,7 +183,6 @@ type CEntry struct {
 	Line        int
 	Message     unsafe.Pointer
 	MessageLen  int
-	ready       chan struct{}
 }
 
 // Sync syncs the underlying buffered write syncer.

--- a/pkg/log/zap_async_buffered_write_core.go
+++ b/pkg/log/zap_async_buffered_write_core.go
@@ -217,13 +217,16 @@ func (s *asyncTextIOCore) consumeCEntry(ent CEntry) {
 	metrics.LoggingPendingWriteTotal.Dec()
 
 	s.bws.Write([]byte("["))
-	s.bws.Write([]byte(ent.Time.Format(defaultTimeFormat)))
+	var buf [64]byte
+	tformat := ent.Time.AppendFormat(buf[:], defaultTimeFormat)
+	s.bws.Write(tformat)
 	s.bws.Write([]byte("] ["))
 	s.bws.Write([]byte(ent.Level.CapitalString()))
 	s.bws.Write([]byte("] [CGO] ["))
 	s.bws.Write(unsafe.Slice((*byte)(ent.Filename), ent.FilenameLen))
 	s.bws.Write([]byte(":"))
-	s.bws.Write([]byte(strconv.Itoa(ent.Line)))
+	lineNoFormat := strconv.AppendInt(buf[:], int64(ent.Line), 10)
+	s.bws.Write(lineNoFormat)
 	s.bws.Write([]byte("] [\""))
 	s.bws.Write(unsafe.Slice((*byte)(ent.Message), (ent.MessageLen)))
 	s.bws.Write([]byte("\"]\n"))

--- a/pkg/log/zap_text_encoder.go
+++ b/pkg/log/zap_text_encoder.go
@@ -46,9 +46,11 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
+const defaultTimeFormat = "2006/01/02 15:04:05.000 -07:00"
+
 // DefaultTimeEncoder serializes time.Time to a human-readable formatted string
 func DefaultTimeEncoder(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
-	s := t.Format("2006/01/02 15:04:05.000 -07:00")
+	s := t.Format(defaultTimeFormat)
 	if e, ok := enc.(*textEncoder); ok {
 		for _, c := range []byte(s) {
 			e.buf.AppendByte(c)


### PR DESCRIPTION
issue: #45640

Low log operation, concurrency = 24, log size ranging from 10 bytes to 128 bytes, with no I/O pressure:
BenchmarkGlog-12              96    11075869 ns/op     19092 B/op        32 allocs/op
BenchmarkZapAsyncLog4KB-12    51    20600912 ns/op    574172 B/op     16040 allocs/op
BenchmarkZapAsyncLog4MB-12    52    19306323 ns/op    575164 B/op     16042 allocs/op

Moderate log operation, concurrency = 24, log size ranging from 10 bytes to 4 KB, under low I/O pressure:

BenchmarkGlog-12             100    11167773 ns/op     19257 B/op        32 allocs/op
BenchmarkZapAsyncLog4KB-12    31    35078185 ns/op    573914 B/op     16040 allocs/op
BenchmarkZapAsyncLog4MB-12    49    24192142 ns/op    569985 B/op     16033 allocs/op

High log operation, concurrency = 24, log size ranging from 10 bytes to 1 MB, under high I/O pressure:

BenchmarkGlog-12               6   395734217 ns/op     23962 B/op        42 allocs/op
BenchmarkZapAsyncLog4KB-12     5   520454474 ns/op    577532 B/op     16062 allocs/op
BenchmarkZapAsyncLog4MB-12     6   203577753 ns/op    766194 B/op     18472 allocs/op
