### PR TITLE
test: add test cases for alter function with invalid mock

### DIFF
--- a/tests/python_client/common/mock_tei_server.py
+++ b/tests/python_client/common/mock_tei_server.py
@@ -1,0 +1,414 @@
+"""
+Mock TEI (Text Embeddings Inference) Server for testing.
+
+This module provides utilities to mock TEI API using pytest-httpserver.
+It can be used to test scenarios where the embedding service becomes unavailable
+after a collection function has been created.
+
+TEI API Reference:
+- POST /embed: Generate embeddings for input texts
+  - Request: {"inputs": ["text1", "text2"], "truncate": true, "truncation_direction": "Left"}
+  - Response: [[0.1, 0.2, ...], [0.3, 0.4, ...]]
+
+Usage with pytest-httpserver (recommended):
+    @pytest.fixture
+    def mock_tei(httpserver):
+        return MockTEIHandler(httpserver, dim=768)
+
+    def test_example(mock_tei):
+        mock_tei.setup_embed()
+        endpoint = mock_tei.endpoint
+        # use endpoint...
+
+        # Simulate error
+        mock_tei.setup_error(503, "Service unavailable")
+
+Usage with standalone server (for environments without pytest-httpserver):
+    server = MockTEIServer(dim=768)
+    server.start()
+    endpoint = server.endpoint
+    server.set_error_mode(True)
+    server.stop()
+"""
+
+import json
+import threading
+import time
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from typing import Optional, Callable, Any
+import socket
+
+
+def generate_mock_embedding(text: str, dim: int) -> list:
+    """Generate a deterministic mock embedding based on text content."""
+    hash_val = hash(text) & 0xFFFFFFFF
+    embedding = []
+    for i in range(dim):
+        val = ((hash_val * (i + 1)) % 10000) / 10000.0 * 2 - 1
+        embedding.append(round(val, 6))
+    return embedding
+
+
+# =============================================================================
+# pytest-httpserver based implementation (recommended)
+# =============================================================================
+
+class MockTEIHandler:
+    """
+    TEI mock handler for pytest-httpserver.
+
+    This is the recommended way to mock TEI in pytest tests.
+
+    Example:
+        def test_with_tei(httpserver):
+            tei = MockTEIHandler(httpserver, dim=768)
+            tei.setup_embed()
+
+            # Your test code using tei.endpoint
+            ...
+
+            # Simulate service failure
+            tei.setup_error(503, "Model integration is not active")
+    """
+
+    def __init__(self, httpserver, dim: int = 768):
+        """
+        Initialize TEI handler.
+
+        Args:
+            httpserver: pytest-httpserver's HTTPServer fixture
+            dim: Embedding dimension
+        """
+        self.httpserver = httpserver
+        self.dim = dim
+
+    @property
+    def endpoint(self) -> str:
+        """Get the server endpoint URL."""
+        return self.httpserver.url_for("")
+
+    def setup_embed(self, permanent: bool = True):
+        """
+        Setup /embed endpoint to return mock embeddings.
+
+        Args:
+            permanent: If True, handler persists across requests
+        """
+        def handle_embed(request):
+            data = request.json
+            inputs = data.get("inputs", [])
+            embeddings = [generate_mock_embedding(text, self.dim) for text in inputs]
+            return json.dumps(embeddings)
+
+        handler = self.httpserver.expect_request(
+            "/embed",
+            method="POST"
+        )
+        if permanent:
+            handler = handler.respond_with_handler(handle_embed)
+        else:
+            handler = handler.respond_with_handler(handle_embed)
+
+        return self
+
+    def setup_error(self, status_code: int = 500, message: str = "Service unavailable"):
+        """
+        Setup server to return errors for all requests.
+
+        Args:
+            status_code: HTTP status code
+            message: Error message
+        """
+        self.httpserver.clear()
+
+        error_response = json.dumps({"error": message})
+
+        self.httpserver.expect_request(
+            "/embed",
+            method="POST"
+        ).respond_with_data(
+            error_response,
+            status=status_code,
+            content_type="application/json"
+        )
+
+        return self
+
+    def setup_health(self):
+        """Setup /health endpoint."""
+        self.httpserver.expect_request(
+            "/health",
+            method="GET"
+        ).respond_with_json({"status": "ok"})
+
+        return self
+
+    def clear(self):
+        """Clear all handlers."""
+        self.httpserver.clear()
+        return self
+
+
+# =============================================================================
+# Standalone server implementation (fallback for environments without pytest-httpserver)
+# =============================================================================
+
+def create_handler_class(server_state: dict):
+    """Create a handler class with instance-specific state."""
+
+    class _StandaloneHandler(BaseHTTPRequestHandler):
+        """HTTP request handler for standalone mock TEI server."""
+
+        def log_message(self, format, *args):
+            pass
+
+        def _send_json(self, data, status: int = 200):
+            self.send_response(status)
+            self.send_header('Content-Type', 'application/json')
+            self.end_headers()
+            self.wfile.write(json.dumps(data).encode('utf-8'))
+
+        def do_POST(self):
+            if server_state.get('error_mode', False):
+                self._send_json(
+                    {"error": server_state.get('error_message', 'Service unavailable')},
+                    server_state.get('error_status_code', 500)
+                )
+                return
+
+            if self.path == '/embed':
+                content_length = int(self.headers.get('Content-Length', 0))
+                body = json.loads(self.rfile.read(content_length).decode('utf-8'))
+                inputs = body.get('inputs', [])
+                dim = server_state.get('dim', 768)
+                embeddings = [generate_mock_embedding(text, dim) for text in inputs]
+                self._send_json(embeddings)
+            else:
+                self._send_json({"error": "Not found"}, 404)
+
+        def do_GET(self):
+            if server_state.get('error_mode', False):
+                self._send_json(
+                    {"error": server_state.get('error_message', 'Service unavailable')},
+                    server_state.get('error_status_code', 500)
+                )
+                return
+
+            if self.path == '/health':
+                self._send_json({"status": "ok"})
+            else:
+                self._send_json({"error": "Not found"}, 404)
+
+    return _StandaloneHandler
+
+
+def get_local_ip() -> str:
+    """
+    Get the local IP address that can be accessed from external hosts.
+    Returns the first non-loopback IPv4 address.
+    """
+    # Method 1: get IP from socket connection to external host
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.connect(('8.8.8.8', 80))
+        ip = s.getsockname()[0]
+        s.close()
+        if not ip.startswith('127.'):
+            return ip
+    except Exception:
+        pass
+
+    # Method 2: get from hostname
+    try:
+        hostname = socket.gethostname()
+        ip = socket.gethostbyname(hostname)
+        if not ip.startswith('127.'):
+            return ip
+    except Exception:
+        pass
+
+    return '127.0.0.1'
+
+
+def get_docker_host() -> str:
+    """
+    Get the hostname that Docker containers can use to access the host machine.
+
+    - macOS/Windows Docker Desktop: host.docker.internal
+    - Linux: returns the host's IP address (containers need --add-host or host network)
+    """
+    import platform
+    system = platform.system().lower()
+
+    if system in ('darwin', 'windows'):
+        # Docker Desktop provides this special DNS name
+        return 'host.docker.internal'
+    else:
+        # Linux: use host IP
+        return get_local_ip()
+
+
+class MockTEIServer:
+    """
+    Standalone mock TEI server.
+
+    Use this when pytest-httpserver is not available.
+    For pytest tests, prefer using MockTEIHandler with httpserver fixture.
+
+    Example:
+        with MockTEIServer(dim=768) as server:
+            endpoint = server.endpoint
+            # use endpoint...
+
+            server.set_error_mode(True, 503, "Service unavailable")
+
+    For remote Milvus access, use external_host parameter:
+        # Auto-detect external IP
+        server = MockTEIServer(dim=768, host='0.0.0.0', external_host='auto')
+
+        # For Docker container access (macOS/Windows)
+        server = MockTEIServer(dim=768, host='0.0.0.0', external_host='docker')
+
+        # Or specify explicit IP
+        server = MockTEIServer(dim=768, host='0.0.0.0', external_host='192.168.1.100')
+    """
+
+    def __init__(self, port: int = 0, dim: int = 768, host: str = '127.0.0.1', external_host: str = None):
+        self.host = host
+        self.port = port
+        self.dim = dim
+        self._external_host = external_host
+        self._server: Optional[HTTPServer] = None
+        self._thread: Optional[threading.Thread] = None
+        self._running = False
+        # Instance-specific state (not shared between servers)
+        self._state = {
+            'dim': dim,
+            'error_mode': False,
+            'error_status_code': 500,
+            'error_message': 'Service unavailable'
+        }
+
+    @property
+    def endpoint(self) -> str:
+        if self._server is None:
+            raise RuntimeError("Server not started")
+        # Use external_host for endpoint URL if specified
+        if self._external_host:
+            if self._external_host == 'auto':
+                host = get_local_ip()
+            elif self._external_host == 'docker':
+                host = get_docker_host()
+            else:
+                host = self._external_host
+        else:
+            host = self.host
+        return f"http://{host}:{self._server.server_address[1]}"
+
+    def start(self) -> str:
+        if self._running:
+            return self.endpoint
+
+        # Create handler class with instance-specific state
+        handler_class = create_handler_class(self._state)
+
+        self._server = HTTPServer((self.host, self.port), handler_class)
+        self.port = self._server.server_address[1]
+
+        self._thread = threading.Thread(target=self._server.serve_forever)
+        self._thread.daemon = True
+        self._thread.start()
+        self._running = True
+
+        self._wait_for_server()
+        return self.endpoint
+
+    def _wait_for_server(self, timeout: float = 5.0):
+        start = time.time()
+        while time.time() - start < timeout:
+            try:
+                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                sock.settimeout(1)
+                if sock.connect_ex((self.host, self.port)) == 0:
+                    sock.close()
+                    return
+                sock.close()
+            except Exception:
+                pass
+            time.sleep(0.1)
+        raise RuntimeError(f"Server failed to start within {timeout}s")
+
+    def stop(self):
+        if self._server:
+            self._server.shutdown()
+            self._server.server_close()
+            self._server = None
+        if self._thread:
+            self._thread.join(timeout=5)
+            self._thread = None
+        self._running = False
+
+    def set_error_mode(self, enabled: bool, status_code: int = 500, message: str = "Service unavailable"):
+        self._state['error_mode'] = enabled
+        self._state['error_status_code'] = status_code
+        self._state['error_message'] = message
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, *args):
+        self.stop()
+        return False
+
+
+# =============================================================================
+# Pytest fixtures
+# =============================================================================
+
+def pytest_httpserver_fixture(dim: int = 768):
+    """
+    Create a pytest fixture for MockTEIHandler.
+
+    Usage in conftest.py:
+        from common.mock_tei_server import pytest_httpserver_fixture
+
+        @pytest.fixture
+        def mock_tei(httpserver):
+            handler = MockTEIHandler(httpserver, dim=768)
+            handler.setup_embed()
+            yield handler
+    """
+    def fixture(httpserver):
+        handler = MockTEIHandler(httpserver, dim=dim)
+        handler.setup_embed()
+        return handler
+    return fixture
+
+
+if __name__ == '__main__':
+    import urllib.request
+    import urllib.error
+
+    print("Testing standalone MockTEIServer...")
+    with MockTEIServer(port=8080, dim=768) as server:
+        print(f"Server: {server.endpoint}")
+
+        # Test embed
+        req = urllib.request.Request(
+            f"{server.endpoint}/embed",
+            data=json.dumps({"inputs": ["Hello", "World"]}).encode(),
+            headers={'Content-Type': 'application/json'}
+        )
+        with urllib.request.urlopen(req) as resp:
+            result = json.loads(resp.read())
+            print(f"Embed: {len(result)} vectors, dim={len(result[0])}")
+
+        # Test error mode
+        server.set_error_mode(True, 503, "Model integration is not active")
+        try:
+            urllib.request.urlopen(req)
+        except urllib.error.HTTPError as e:
+            print(f"Error mode: {e.code} - {json.loads(e.read())}")
+
+    print("Done!")

--- a/tests/python_client/testcases/test_text_embedding_function_e2e.py
+++ b/tests/python_client/testcases/test_text_embedding_function_e2e.py
@@ -1392,7 +1392,7 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
         res, _ = collection_w.query(expr="id == 0", output_fields=["document"])
         assert "Updated document" in res[0]["document"]
 
-    @pytest.mark.tags(CaseLabel.L3)
+    @pytest.mark.tags(CaseLabel.L1)
     def test_alter_function_when_other_function_is_invalid(self, host):
         """
         target: test alter function succeeds even when another function in collection is invalid
@@ -1505,7 +1505,7 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
             mock_server_1.stop()
             mock_server_2.stop()
 
-    @pytest.mark.tags(CaseLabel.L3)
+    @pytest.mark.tags(CaseLabel.L1)
     def test_alter_invalid_function_to_valid_endpoint(self, host):
         """
         target: test user can fix an invalid function by altering it to a valid endpoint

--- a/tests/python_client/testcases/test_text_embedding_function_e2e.py
+++ b/tests/python_client/testcases/test_text_embedding_function_e2e.py
@@ -1393,7 +1393,7 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
         res, _ = collection_w.query(expr="id == 0", output_fields=["document"])
         assert "Updated document" in res[0]["document"]
 
-    @pytest.mark.tags(CaseLabel.L1)
+    @pytest.mark.tags(CaseLabel.L3)
     def test_alter_function_when_other_function_is_invalid(self, host):
         """
         target: test alter function succeeds even when another function in collection is invalid
@@ -1504,7 +1504,7 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
             mock_server_1.stop()
             mock_server_2.stop()
 
-    @pytest.mark.tags(CaseLabel.L1)
+    @pytest.mark.tags(CaseLabel.L3)
     def test_alter_invalid_function_to_valid_endpoint(self, host):
         """
         target: test user can fix an invalid function by altering it to a valid endpoint

--- a/tests/python_client/testcases/test_text_embedding_function_e2e.py
+++ b/tests/python_client/testcases/test_text_embedding_function_e2e.py
@@ -17,6 +17,7 @@ import numpy as np
 import pytest
 import pandas as pd
 from faker import Faker
+from common.mock_tei_server import MockTEIServer, get_local_ip, get_docker_host
 
 fake_zh = Faker("zh_CN")
 fake_jp = Faker("ja_JP")
@@ -1408,8 +1409,6 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
         - localhost/127.0.0.1: uses host.docker.internal for Docker containers
         - Remote host: skipped (network may not be reachable)
         """
-        from common.mock_tei_server import MockTEIServer, get_local_ip, get_docker_host
-
         # Skip if Milvus is on remote host (network may not be reachable)
         local_ip = get_local_ip()
         docker_host = get_docker_host()
@@ -1497,7 +1496,7 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
             # Verify function params are updated
             res, _ = collection_w.describe()
             content_func = next(f for f in res["functions"] if f["name"] == "content_embedding")
-            assert content_func["params"]["truncate"] == "True"
+            assert content_func["params"]["truncate"] == str(True)
 
             log.info("Successfully altered content_embedding function while title_embedding is invalid")
 
@@ -1521,8 +1520,6 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
         - localhost/127.0.0.1: uses host.docker.internal for Docker containers
         - Remote host: skipped (network may not be reachable)
         """
-        from common.mock_tei_server import MockTEIServer, get_local_ip, get_docker_host
-
         # Skip if Milvus is on remote host (network may not be reachable)
         local_ip = get_local_ip()
         docker_host = get_docker_host()

--- a/tests/python_client/testcases/test_text_embedding_function_e2e.py
+++ b/tests/python_client/testcases/test_text_embedding_function_e2e.py
@@ -1392,6 +1392,234 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
         res, _ = collection_w.query(expr="id == 0", output_fields=["document"])
         assert "Updated document" in res[0]["document"]
 
+    @pytest.mark.tags(CaseLabel.L3)
+    def test_alter_function_when_other_function_is_invalid(self, host):
+        """
+        target: test alter function succeeds even when another function in collection is invalid
+        method:
+            1. create collection with 2 text embedding functions using mock TEI servers
+            2. make one mock server return errors (simulate service becoming unavailable)
+            3. alter the other valid function
+        expected: alter should succeed (only validates the target function, not all functions)
+        issue: https://github.com/milvus-io/milvus/issues/46949
+        pr: https://github.com/milvus-io/milvus/pull/46984
+
+        NOTE: This test requires the Milvus server to be able to access the local mock TEI server.
+        - localhost/127.0.0.1: uses host.docker.internal for Docker containers
+        - Remote host: skipped (network may not be reachable)
+        """
+        from common.mock_tei_server import MockTEIServer, get_local_ip, get_docker_host
+
+        # Skip if Milvus is on remote host (network may not be reachable)
+        local_ip = get_local_ip()
+        docker_host = get_docker_host()
+        if host not in ['localhost', '127.0.0.1', local_ip, docker_host]:
+            pytest.skip(f"Skipping: Milvus host ({host}) may not be able to access local mock server. "
+                       "Run this test with Milvus on localhost or in the same network.")
+
+        self._connect()
+        dim = 768
+
+        # Start two mock TEI servers with external access enabled
+        # host='0.0.0.0' binds to all interfaces, external_host='docker' uses host.docker.internal
+        mock_server_1 = MockTEIServer(dim=dim, host='0.0.0.0', external_host='docker')
+        mock_server_2 = MockTEIServer(dim=dim, host='0.0.0.0', external_host='docker')
+
+        try:
+            endpoint_1 = mock_server_1.start()
+            endpoint_2 = mock_server_2.start()
+            log.info(f"Mock TEI servers started at: {endpoint_1}, {endpoint_2}")
+
+            fields = [
+                FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
+                FieldSchema(name="title", dtype=DataType.VARCHAR, max_length=65535),
+                FieldSchema(name="content", dtype=DataType.VARCHAR, max_length=65535),
+                FieldSchema(name="title_vector", dtype=DataType.FLOAT_VECTOR, dim=dim),
+                FieldSchema(name="content_vector", dtype=DataType.FLOAT_VECTOR, dim=dim),
+            ]
+            schema = CollectionSchema(fields=fields, description="test collection")
+
+            # Add two text embedding functions using different mock servers
+            title_embedding = Function(
+                name="title_embedding",
+                function_type=FunctionType.TEXTEMBEDDING,
+                input_field_names=["title"],
+                output_field_names="title_vector",
+                params={"provider": "TEI", "endpoint": endpoint_1}
+            )
+            schema.add_function(title_embedding)
+
+            content_embedding = Function(
+                name="content_embedding",
+                function_type=FunctionType.TEXTEMBEDDING,
+                input_field_names=["content"],
+                output_field_names="content_vector",
+                params={"provider": "TEI", "endpoint": endpoint_2}
+            )
+            schema.add_function(content_embedding)
+
+            c_name = cf.gen_unique_str(prefix)
+            collection_w = self.init_collection_wrap(name=c_name, schema=schema)
+
+            # Verify both functions exist
+            res, _ = collection_w.describe()
+            assert len(res["functions"]) == 2
+
+            # Make server_1 return errors (simulate "Model integration is not active")
+            mock_server_1.set_error_mode(
+                enabled=True,
+                status_code=400,
+                message="Model integration is not active"
+            )
+
+            # Now title_embedding function is invalid, but we should still be able to
+            # alter content_embedding function (PR #46984 fix)
+            new_content_embedding = Function(
+                name="content_embedding",
+                function_type=FunctionType.TEXTEMBEDDING,
+                input_field_names=["content"],
+                output_field_names="content_vector",
+                params={
+                    "provider": "TEI",
+                    "endpoint": endpoint_2,
+                    "truncate": True
+                }
+            )
+
+            # This should succeed after PR #46984 fix
+            # Before the fix, this would fail because it validated ALL functions
+            self.client.alter_collection_function(
+                collection_name=c_name,
+                function_name="content_embedding",
+                function=new_content_embedding
+            )
+
+            # Verify function params are updated
+            res, _ = collection_w.describe()
+            content_func = next(f for f in res["functions"] if f["name"] == "content_embedding")
+            assert content_func["params"]["truncate"] == "True"
+
+            log.info("Successfully altered content_embedding function while title_embedding is invalid")
+
+        finally:
+            mock_server_1.stop()
+            mock_server_2.stop()
+
+    @pytest.mark.tags(CaseLabel.L3)
+    def test_alter_invalid_function_to_valid_endpoint(self, host):
+        """
+        target: test user can fix an invalid function by altering it to a valid endpoint
+        method:
+            1. create collection with function using mock TEI server
+            2. make mock server return errors (function becomes invalid)
+            3. start a new valid server and alter function to use it
+        expected: alter should succeed, allowing user to fix the broken function
+        issue: https://github.com/milvus-io/milvus/issues/46949
+        pr: https://github.com/milvus-io/milvus/pull/46984
+
+        NOTE: This test requires the Milvus server to be able to access the local mock TEI server.
+        - localhost/127.0.0.1: uses host.docker.internal for Docker containers
+        - Remote host: skipped (network may not be reachable)
+        """
+        from common.mock_tei_server import MockTEIServer, get_local_ip, get_docker_host
+
+        # Skip if Milvus is on remote host (network may not be reachable)
+        local_ip = get_local_ip()
+        docker_host = get_docker_host()
+        if host not in ['localhost', '127.0.0.1', local_ip, docker_host]:
+            pytest.skip(f"Skipping: Milvus host ({host}) may not be able to access local mock server. "
+                       "Run this test with Milvus on localhost or in the same network.")
+
+        self._connect()
+        dim = 768
+
+        # Start mock servers with external access enabled
+        mock_server = MockTEIServer(dim=dim, host='0.0.0.0', external_host='docker')
+        backup_server = MockTEIServer(dim=dim, host='0.0.0.0', external_host='docker')
+
+        try:
+            endpoint = mock_server.start()
+            backup_endpoint = backup_server.start()
+            log.info(f"Mock TEI servers started at: {endpoint}, {backup_endpoint}")
+
+            fields = [
+                FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
+                FieldSchema(name="document", dtype=DataType.VARCHAR, max_length=65535),
+                FieldSchema(name="dense", dtype=DataType.FLOAT_VECTOR, dim=dim),
+            ]
+            schema = CollectionSchema(fields=fields, description="test collection")
+
+            text_embedding = Function(
+                name="tei",
+                function_type=FunctionType.TEXTEMBEDDING,
+                input_field_names=["document"],
+                output_field_names="dense",
+                params={"provider": "TEI", "endpoint": endpoint}
+            )
+            schema.add_function(text_embedding)
+
+            c_name = cf.gen_unique_str(prefix)
+            collection_w = self.init_collection_wrap(name=c_name, schema=schema)
+
+            # Insert some data while function is working
+            data = [{"id": i, "document": f"Document {i}"} for i in range(3)]
+            collection_w.insert(data)
+
+            # Create index and load
+            index_params = {"index_type": "AUTOINDEX", "metric_type": "COSINE", "params": {}}
+            collection_w.create_index("dense", index_params)
+            collection_w.load()
+
+            # Simulate the original endpoint becoming unavailable
+            mock_server.set_error_mode(
+                enabled=True,
+                status_code=400,
+                message="Model integration is not active"
+            )
+
+            # User wants to fix the function by switching to backup endpoint
+            # This is the exact scenario from issue #46949
+            new_function = Function(
+                name="tei",
+                function_type=FunctionType.TEXTEMBEDDING,
+                input_field_names=["document"],
+                output_field_names="dense",
+                params={"provider": "TEI", "endpoint": backup_endpoint}
+            )
+
+            # After PR #46984, this should succeed
+            self.client.alter_collection_function(
+                collection_name=c_name,
+                function_name="tei",
+                function=new_function
+            )
+
+            # Verify function is updated
+            res, _ = collection_w.describe()
+            func = res["functions"][0]
+            assert func["params"]["endpoint"] == backup_endpoint
+
+            # Verify the function works with new endpoint
+            new_data = [{"id": 10, "document": "New document after fix"}]
+            collection_w.insert(new_data)
+            assert collection_w.num_entities == 4
+
+            # Search should work
+            search_params = {"metric_type": "COSINE", "params": {}}
+            res, _ = collection_w.search(
+                data=["New document"],
+                anns_field="dense",
+                param=search_params,
+                limit=4,
+            )
+            assert len(res[0]) == 4
+
+            log.info("Successfully fixed invalid function by altering to valid endpoint")
+
+        finally:
+            mock_server.stop()
+            backup_server.stop()
+
     # ==================== drop_collection_function positive tests ====================
 
     def test_drop_collection_function_verify_crud(self, tei_endpoint):


### PR DESCRIPTION
## Summary
- Add mock TEI server utility (`common/mock_tei_server.py`) for testing text embedding functions
- Add test cases for PR #46984 fix (alter function when other function is invalid)

## Test Cases
1. `test_alter_function_when_other_function_is_invalid` - Verify that altering a valid function succeeds even when another function in the collection is invalid
2. `test_alter_invalid_function_to_valid_endpoint` - Verify that users can fix an invalid function by altering it to a valid endpoint

## Related Issues
- Issue: https://github.com/milvus-io/milvus/issues/46949
- Fix PR: https://github.com/milvus-io/milvus/pull/46984

## Test Plan
- [x] Verified test fails with unfixed Milvus (`master-20260112-7bcd3b10`)
- [x] Verified test passes with fixed Milvus (`master-20260112-b39ecb0`)