### PR TITLE
fix: add valid range validation for collection TTL

### DIFF
--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -362,8 +362,8 @@ func validateCollectionTTL(props []*commonpb.KeyValuePair) (bool, error) {
 			if err != nil {
 				return true, merr.WrapErrParameterInvalidMsg("collection TTL is not a valid positive integer")
 			}
-			if val <= 0 || val > common.MaxTTLSeconds {
-				return true, merr.WrapErrParameterInvalidMsg("collection TTL is out of range, expect (0, 31557600000], got %d", val)
+			if val < -1 || val > common.MaxTTLSeconds {
+				return true, merr.WrapErrParameterInvalidMsg("collection TTL is out of range, expect [-1, 3155760000], got %d", val)
 			}
 			return true, nil
 		}

--- a/internal/proxy/task_test.go
+++ b/internal/proxy/task_test.go
@@ -5930,7 +5930,7 @@ func TestValidateCollectionTTL(t *testing.T) {
 		{"at_min_boundary", "-1", true, false},         // val <= -1
 		{"out_of_lower_boundary", "-2", true, true},    // val < -1
 		{"exceed_max", "3155760001", true, true},       // val > MaxTTLSeconds
-		{"at_max_boundary", "3155760000", true, false}, // val == MaxTTLSeconds (边界)
+		{"at_max_boundary", "3155760000", true, false}, // val == MaxTTLSeconds
 		{"valid_value", "3600", true, false},
 		{"min_valid", "1", true, false},
 		{"invalid_format", "abc", true, true},

--- a/internal/proxy/task_test.go
+++ b/internal/proxy/task_test.go
@@ -5927,10 +5927,10 @@ func TestValidateCollectionTTL(t *testing.T) {
 		hasTTL    bool
 		expectErr bool
 	}{
-		{"zero_value", "0", true, true},                 // val <= 0
-		{"negative_value", "-1", true, true},            // val <= 0
-		{"exceed_max", "31557600001", true, true},       // val > MaxTTLSeconds
-		{"at_max_boundary", "31557600000", true, false}, // val == MaxTTLSeconds (边界)
+		{"at_min_boundary", "-1", true, false},         // val <= -1
+		{"out_of_lower_boundary", "-2", true, true},    // val < -1
+		{"exceed_max", "3155760001", true, true},       // val > MaxTTLSeconds
+		{"at_max_boundary", "3155760000", true, false}, // val == MaxTTLSeconds (边界)
 		{"valid_value", "3600", true, false},
 		{"min_valid", "1", true, false},
 		{"invalid_format", "abc", true, true},

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -190,6 +190,7 @@ const (
 	CollectionAutoCompactionKey = "collection.autocompaction.enabled"
 	CollectionDescription       = "collection.description"
 	CollectionTTLFieldKey       = "ttl_field"
+	MaxTTLSeconds               = 31557600000 // 1000 years
 
 	// Deprecated: will be removed in the 3.0 after implementing ack sync up semantic.
 	CollectionOnTruncatingKey = "collection.on.truncating" // when collection is on truncating, forbid the compaction of current collection.

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -190,7 +190,7 @@ const (
 	CollectionAutoCompactionKey = "collection.autocompaction.enabled"
 	CollectionDescription       = "collection.description"
 	CollectionTTLFieldKey       = "ttl_field"
-	MaxTTLSeconds               = 31557600000 // 1000 years
+	MaxTTLSeconds               = 3155760000 // 100 years
 
 	// Deprecated: will be removed in the 3.0 after implementing ack sync up semantic.
 	CollectionOnTruncatingKey = "collection.on.truncating" // when collection is on truncating, forbid the compaction of current collection.


### PR DESCRIPTION
Related to #46716

Add range validation for collection TTL to prevent invalid values:
- TTL must be greater than or equal to -1 and at most 3155760000 seconds (100 years)
- Remove redundant TTL validation in alterCollectionTask.PreExecute
- Add unit tests covering boundary cases