### PR TITLE
test: refine partition insert testcases and add all-datatype case

### DIFF
--- a/tests/python_client/testcases/test_insert.py
+++ b/tests/python_client/testcases/test_insert.py
@@ -785,20 +785,6 @@ class TestInsertOperation(TestcaseBase):
 
         assert collection_w.num_entities == nb
 
-    @pytest.mark.tags(CaseLabel.L1)
-    def test_insert_all_datatype_collection(self):
-        """
-        target: test insert into collection that contains all datatype fields
-        method: 1.create all datatype collection 2.insert data
-        expected: verify num entities
-        """
-        self._connect()
-        nb = 100
-        df = cf.gen_dataframe_all_data_type(nb=nb)
-        self.collection_wrap.construct_from_dataframe(cf.gen_unique_str(prefix), df,
-                                                      primary_field=ct.default_int64_field_name)
-        assert self.collection_wrap.num_entities == nb
-
     @pytest.mark.tags(CaseLabel.L2)
     def test_insert_equal_to_resource_limit(self):
         """


### PR DESCRIPTION
\kind improvement
\assign @yanliang567 

- Skip duplicated partition insert tests:
  - test_insert_default_partition (covered by test_milvus_client_insert_partition)
  - test_insert_partition_not_existed (covered by test_milvus_client_insert_not_exist_partition_name)

- Fix the docstring of test_milvus_client_insert_not_exist_partition_name to correctly describe insert behavior with a non-existent partition.

- Strengthen assertions for partition insert tests:

  - Verify total entity count after inserting into multiple partitions.

  - Validate returned primary key IDs when inserting with explicit IDs.

- Fix mismatched test expectations in `test_insert_auto_id_false_same_values` by aligning the docstring with actual behavior.
- Add test_insert_all_datatype_collection to validate insert behavior for collections containing all supported data types using row-based client insert.