### PR TITLE
fix: [2.6] add valid range validation for collection TTL (#46997)

### DIFF
--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -1230,11 +1230,6 @@ func (t *alterCollectionTask) PreExecute(ctx context.Context) error {
 			}
 		}
 
-		_, err = common.GetCollectionTTL(t.GetProperties(), -1)
-		if err != nil {
-			return merr.WrapErrParameterInvalidMsg("collection ttl properties value not valid, parse error: %s", err.Error())
-		}
-
 		enabled, _ := common.IsAllowInsertAutoID(t.Properties...)
 		if enabled {
 			primaryFieldSchema, err := typeutil.GetPrimaryFieldSchema(collSchema.CollectionSchema)

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -189,6 +189,7 @@ const (
 	CollectionTTLConfigKey      = "collection.ttl.seconds"
 	CollectionAutoCompactionKey = "collection.autocompaction.enabled"
 	CollectionDescription       = "collection.description"
+	MaxTTLSeconds               = 3155760000 // 100 years
 
 	// Note:
 	// Function output fields cannot be included in inserted data.


### PR DESCRIPTION
Cherry-pick from master
pr: #46997
Related to #46716

Add range validation for collection TTL to prevent invalid values:
- TTL must be greater than or equal to -1 and at most 3155760000 seconds (100 years)
- Remove redundant TTL validation in alterCollectionTask.PreExecute
- Add unit tests covering boundary cases