### PR TITLE
enhance: [2.6] add storage version upgrade compaction policy (#46990)

### DIFF
--- a/internal/datacoord/compaction_policy_storage_version.go
+++ b/internal/datacoord/compaction_policy_storage_version.go
@@ -1,0 +1,142 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datacoord
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/milvus-io/milvus/internal/datacoord/allocator"
+	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/pkg/v2/common"
+	"github.com/milvus-io/milvus/pkg/v2/log"
+	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+)
+
+type storageVersionUpgradePolicy struct {
+	meta      *meta
+	allocator allocator.Allocator
+	handler   Handler
+
+	// Rate limiting state, no need to be thread-safe since it is only used in one goroutine
+	lastPeriod   time.Time
+	currentCount int
+}
+
+func newStorageVersionUpgradePolicy(meta *meta, allocator allocator.Allocator, handler Handler) *storageVersionUpgradePolicy {
+	return &storageVersionUpgradePolicy{
+		meta:      meta,
+		allocator: allocator,
+		handler:   handler,
+	}
+}
+
+func (policy *storageVersionUpgradePolicy) Enable() bool {
+	return paramtable.Get().DataCoordCfg.StorageVersionCompactionEnabled.GetAsBool()
+}
+
+func (policy *storageVersionUpgradePolicy) targetVersion() int64 {
+	targetVersion := storage.StorageV2
+	// Uncomment after stv3 cp to 2.6
+	// if paramtable.Get().CommonCfg.UseLoonFFI.GetAsBool() {
+	// 	targetVersion = storage.StorageV3
+	// }
+	return targetVersion
+}
+
+func (policy *storageVersionUpgradePolicy) Trigger(ctx context.Context) (map[CompactionTriggerType][]CompactionView, error) {
+	collections := policy.meta.GetCollections()
+
+	if time.Since(policy.lastPeriod) > paramtable.Get().DataCoordCfg.StorageVersionCompactionRateLimitInterval.GetAsDuration(time.Second) {
+		policy.currentCount = 0
+		policy.lastPeriod = time.Now()
+	}
+
+	maxCount := paramtable.Get().DataCoordCfg.StorageVersionCompactionRateLimitTokens.GetAsInt()
+
+	views := make([]CompactionView, 0)
+	for _, collection := range collections {
+		if policy.currentCount >= maxCount {
+			break
+		}
+		collectionViews, err := policy.triggerOneCollection(ctx, collection.ID, maxCount)
+		if err != nil {
+			// not throw this error because no need to fail because of one collection
+			log.Warn("fail to trigger storage version compaction", zap.Int64("collectionID", collection.ID), zap.Error(err))
+			continue
+		}
+		views = append(views, collectionViews...)
+	}
+	return map[CompactionTriggerType][]CompactionView{TriggerTypeStorageVersionUpgrade: views}, nil
+}
+
+func (policy *storageVersionUpgradePolicy) triggerOneCollection(ctx context.Context, collectionID int64, maxCount int) ([]CompactionView, error) {
+	log := log.With(zap.Int64("collectionID", collectionID))
+	collection, err := policy.handler.GetCollection(ctx, collectionID)
+	if err != nil {
+		log.Warn("fail to apply storageVersionUpgradePolicy, unable to get collection from handler",
+			zap.Error(err))
+		return nil, err
+	}
+	if collection == nil {
+		log.Warn("fail to apply storageVersionUpgradePolicy, collection not exist")
+		return nil, nil
+	}
+
+	collectionTTL, err := common.GetCollectionTTLFromMap(collection.Properties, paramtable.Get().CommonCfg.EntityExpirationTTL.GetAsDuration(time.Second))
+	if err != nil {
+		log.Warn("failed to apply storageVersionUpgradePolicy, get collection ttl failed")
+		return nil, err
+	}
+
+	newTriggerID, err := policy.allocator.AllocID(ctx)
+	if err != nil {
+		log.Warn("fail to apply storageVersionUpgradePolicy, unable to allocate triggerID", zap.Error(err))
+		return nil, err
+	}
+
+	targetVersion := policy.targetVersion()
+
+	segments := policy.meta.SelectSegments(ctx, WithCollection(collectionID), SegmentFilterFunc(func(segment *SegmentInfo) bool {
+		return isSegmentHealthy(segment) &&
+			isFlushed(segment) &&
+			!segment.isCompacting &&
+			!segment.GetIsImporting() &&
+			segment.GetLevel() != datapb.SegmentLevel_L0 &&
+			segment.GetStorageVersion() != targetVersion
+	}))
+
+	views := make([]CompactionView, 0, len(segments))
+	for _, segment := range segments {
+		if policy.currentCount >= maxCount {
+			break
+		}
+		segmentViews := GetViewsByInfo(segment)
+		view := &MixSegmentView{
+			label:         segmentViews[0].label,
+			segments:      segmentViews,
+			collectionTTL: collectionTTL,
+			triggerID:     newTriggerID,
+		}
+		views = append(views, view)
+		policy.currentCount++
+	}
+	return views, nil
+}

--- a/internal/datacoord/compaction_policy_storage_version_test.go
+++ b/internal/datacoord/compaction_policy_storage_version_test.go
@@ -1,0 +1,692 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datacoord
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus/internal/datacoord/allocator"
+	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
+)
+
+func TestStorageVersionUpgradePolicySuite(t *testing.T) {
+	suite.Run(t, new(StorageVersionUpgradePolicySuite))
+}
+
+type StorageVersionUpgradePolicySuite struct {
+	suite.Suite
+
+	mockAlloc *allocator.MockAllocator
+	testLabel *CompactionGroupLabel
+	handler   *NMockHandler
+
+	policy *storageVersionUpgradePolicy
+}
+
+func (s *StorageVersionUpgradePolicySuite) SetupTest() {
+	s.testLabel = &CompactionGroupLabel{
+		CollectionID: 1,
+		PartitionID:  10,
+		Channel:      "ch-1",
+	}
+
+	meta := &meta{
+		segments:    NewSegmentsInfo(),
+		collections: typeutil.NewConcurrentMap[UniqueID, *collectionInfo](),
+	}
+
+	s.mockAlloc = allocator.NewMockAllocator(s.T())
+	s.handler = NewNMockHandler(s.T())
+	s.policy = newStorageVersionUpgradePolicy(meta, s.mockAlloc, s.handler)
+}
+
+func (s *StorageVersionUpgradePolicySuite) TestEnable() {
+	defer paramtable.Get().Reset(paramtable.Get().DataCoordCfg.StorageVersionCompactionEnabled.Key)
+
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.StorageVersionCompactionEnabled.Key, "false")
+	s.False(s.policy.Enable())
+
+	// Test with enabled
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.StorageVersionCompactionEnabled.Key, "true")
+	s.True(s.policy.Enable())
+}
+
+func (s *StorageVersionUpgradePolicySuite) TestTargetVersion() {
+	s.T().Skip("storage v3 not supported yet")
+	// Default: UseLoonFFI is false, target should be StorageV2
+	// paramtable.Get().Save(paramtable.Get().CommonCfg.UseLoonFFI.Key, "false")
+	// defer paramtable.Get().Reset(paramtable.Get().CommonCfg.UseLoonFFI.Key)
+	// s.Equal(storage.StorageV2, s.policy.targetVersion())
+
+	// // When UseLoonFFI is true, target should be StorageV3
+	// paramtable.Get().Save(paramtable.Get().CommonCfg.UseLoonFFI.Key, "true")
+	// s.Equal(storage.StorageV3, s.policy.targetVersion())
+}
+
+func (s *StorageVersionUpgradePolicySuite) TestTriggerNoCollections() {
+	// Test with no collections
+	events, err := s.policy.Trigger(context.Background())
+	s.NoError(err)
+	s.NotNil(events)
+	gotViews, ok := events[TriggerTypeStorageVersionUpgrade]
+	s.True(ok)
+	s.Empty(gotViews)
+}
+
+func (s *StorageVersionUpgradePolicySuite) TestTriggerWithSegments() {
+	ctx := context.Background()
+	collID := int64(100)
+
+	// Setup params
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.StorageVersionCompactionEnabled.Key, "true")
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.StorageVersionCompactionRateLimitInterval.Key, "1")
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.StorageVersionCompactionRateLimitTokens.Key, "10")
+	// paramtable.Get().Save(paramtable.Get().CommonCfg.UseLoonFFI.Key, "true") // target is StorageV3
+	defer func() {
+		paramtable.Get().Reset(paramtable.Get().DataCoordCfg.StorageVersionCompactionEnabled.Key)
+		paramtable.Get().Reset(paramtable.Get().DataCoordCfg.StorageVersionCompactionRateLimitInterval.Key)
+		paramtable.Get().Reset(paramtable.Get().DataCoordCfg.StorageVersionCompactionRateLimitTokens.Key)
+		// paramtable.Get().Reset(paramtable.Get().CommonCfg.UseLoonFFI.Key)
+	}()
+
+	coll := &collectionInfo{
+		ID:     collID,
+		Schema: newTestSchema(),
+	}
+	s.handler.EXPECT().GetCollection(mock.Anything, mock.Anything).Return(coll, nil)
+	s.mockAlloc.EXPECT().AllocID(mock.Anything).Return(int64(1000), nil)
+
+	// Create segments with different storage versions
+	segments := make(map[UniqueID]*SegmentInfo)
+	// Segment with old storage version (should be upgraded)
+	segments[101] = &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:             101,
+			CollectionID:   collID,
+			PartitionID:    10,
+			InsertChannel:  "ch-1",
+			Level:          datapb.SegmentLevel_L1,
+			State:          commonpb.SegmentState_Flushed,
+			NumOfRows:      10000,
+			StorageVersion: storage.StorageV1, // Old version
+		},
+	}
+	// Segment already at target version (should NOT be upgraded)
+	segments[102] = &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:             102,
+			CollectionID:   collID,
+			PartitionID:    10,
+			InsertChannel:  "ch-1",
+			Level:          datapb.SegmentLevel_L1,
+			State:          commonpb.SegmentState_Flushed,
+			NumOfRows:      10000,
+			StorageVersion: storage.StorageV2, // Already at target
+		},
+	}
+	// L0 segment (should NOT be upgraded)
+	segments[103] = &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:             103,
+			CollectionID:   collID,
+			PartitionID:    10,
+			InsertChannel:  "ch-1",
+			Level:          datapb.SegmentLevel_L0,
+			State:          commonpb.SegmentState_Flushed,
+			NumOfRows:      1000,
+			StorageVersion: storage.StorageV2,
+		},
+	}
+
+	segmentsInfo := &SegmentsInfo{
+		segments: segments,
+		secondaryIndexes: segmentInfoIndexes{
+			coll2Segments: map[UniqueID]map[UniqueID]*SegmentInfo{
+				collID: segments,
+			},
+		},
+	}
+
+	collections := typeutil.NewConcurrentMap[UniqueID, *collectionInfo]()
+	collections.Insert(collID, coll)
+
+	s.policy.meta = &meta{
+		segments:    segmentsInfo,
+		collections: collections,
+	}
+
+	views, err := s.policy.triggerOneCollection(ctx, collID, 10)
+	s.NoError(err)
+	// Only segment 101 should be triggered (old version, not L0)
+	s.Equal(1, len(views))
+}
+
+func (s *StorageVersionUpgradePolicySuite) TestTriggerWithCompactingSegment() {
+	ctx := context.Background()
+	collID := int64(100)
+
+	// Setup params
+	// paramtable.Get().Save(paramtable.Get().CommonCfg.UseLoonFFI.Key, "true")
+	// defer paramtable.Get().Reset(paramtable.Get().CommonCfg.UseLoonFFI.Key)
+
+	coll := &collectionInfo{
+		ID:     collID,
+		Schema: newTestSchema(),
+	}
+	s.handler.EXPECT().GetCollection(mock.Anything, mock.Anything).Return(coll, nil)
+	s.mockAlloc.EXPECT().AllocID(mock.Anything).Return(int64(1000), nil)
+
+	// Create a compacting segment (should NOT be upgraded)
+	segments := make(map[UniqueID]*SegmentInfo)
+	segments[101] = &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:             101,
+			CollectionID:   collID,
+			PartitionID:    10,
+			InsertChannel:  "ch-1",
+			Level:          datapb.SegmentLevel_L1,
+			State:          commonpb.SegmentState_Flushed,
+			NumOfRows:      10000,
+			StorageVersion: storage.StorageV1,
+		},
+		isCompacting: true, // Already compacting
+	}
+
+	segmentsInfo := &SegmentsInfo{
+		segments: segments,
+		secondaryIndexes: segmentInfoIndexes{
+			coll2Segments: map[UniqueID]map[UniqueID]*SegmentInfo{
+				collID: segments,
+			},
+		},
+	}
+
+	collections := typeutil.NewConcurrentMap[UniqueID, *collectionInfo]()
+	collections.Insert(collID, coll)
+
+	s.policy.meta = &meta{
+		segments:    segmentsInfo,
+		collections: collections,
+	}
+
+	views, err := s.policy.triggerOneCollection(ctx, collID, 10)
+	s.NoError(err)
+	s.Equal(0, len(views)) // No segments should be triggered
+}
+
+func (s *StorageVersionUpgradePolicySuite) TestTriggerWithImportingSegment() {
+	ctx := context.Background()
+	collID := int64(100)
+
+	// Setup params
+	// paramtable.Get().Save(paramtable.Get().CommonCfg.UseLoonFFI.Key, "true")
+	// defer paramtable.Get().Reset(paramtable.Get().CommonCfg.UseLoonFFI.Key)
+
+	coll := &collectionInfo{
+		ID:     collID,
+		Schema: newTestSchema(),
+	}
+	s.handler.EXPECT().GetCollection(mock.Anything, mock.Anything).Return(coll, nil)
+	s.mockAlloc.EXPECT().AllocID(mock.Anything).Return(int64(1000), nil)
+
+	// Create an importing segment (should NOT be upgraded)
+	segments := make(map[UniqueID]*SegmentInfo)
+	segments[101] = &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:             101,
+			CollectionID:   collID,
+			PartitionID:    10,
+			InsertChannel:  "ch-1",
+			Level:          datapb.SegmentLevel_L1,
+			State:          commonpb.SegmentState_Flushed,
+			NumOfRows:      10000,
+			StorageVersion: storage.StorageV1,
+			IsImporting:    true, // Importing
+		},
+	}
+
+	segmentsInfo := &SegmentsInfo{
+		segments: segments,
+		secondaryIndexes: segmentInfoIndexes{
+			coll2Segments: map[UniqueID]map[UniqueID]*SegmentInfo{
+				collID: segments,
+			},
+		},
+	}
+
+	collections := typeutil.NewConcurrentMap[UniqueID, *collectionInfo]()
+	collections.Insert(collID, coll)
+
+	s.policy.meta = &meta{
+		segments:    segmentsInfo,
+		collections: collections,
+	}
+
+	views, err := s.policy.triggerOneCollection(ctx, collID, 10)
+	s.NoError(err)
+	s.Equal(0, len(views)) // No segments should be triggered
+}
+
+func (s *StorageVersionUpgradePolicySuite) TestTriggerRateLimiting() {
+	ctx := context.Background()
+	collID := int64(100)
+
+	// Setup params
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.StorageVersionCompactionEnabled.Key, "true")
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.StorageVersionCompactionRateLimitInterval.Key, "3600") // 1 hour
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.StorageVersionCompactionRateLimitTokens.Key, "2")      // Max 2 per interval
+	// paramtable.Get().Save(paramtable.Get().CommonCfg.UseLoonFFI.Key, "true")
+	defer func() {
+		paramtable.Get().Reset(paramtable.Get().DataCoordCfg.StorageVersionCompactionEnabled.Key)
+		paramtable.Get().Reset(paramtable.Get().DataCoordCfg.StorageVersionCompactionRateLimitInterval.Key)
+		paramtable.Get().Reset(paramtable.Get().DataCoordCfg.StorageVersionCompactionRateLimitTokens.Key)
+		// paramtable.Get().Reset(paramtable.Get().CommonCfg.UseLoonFFI.Key)
+	}()
+
+	coll := &collectionInfo{
+		ID:     collID,
+		Schema: newTestSchema(),
+	}
+	s.handler.EXPECT().GetCollection(mock.Anything, mock.Anything).Return(coll, nil)
+	s.mockAlloc.EXPECT().AllocID(mock.Anything).Return(int64(1000), nil)
+
+	// Create 5 segments that need upgrade
+	segments := make(map[UniqueID]*SegmentInfo)
+	for i := int64(101); i <= 105; i++ {
+		segments[i] = &SegmentInfo{
+			SegmentInfo: &datapb.SegmentInfo{
+				ID:             i,
+				CollectionID:   collID,
+				PartitionID:    10,
+				InsertChannel:  "ch-1",
+				Level:          datapb.SegmentLevel_L1,
+				State:          commonpb.SegmentState_Flushed,
+				NumOfRows:      10000,
+				StorageVersion: storage.StorageV1,
+			},
+		}
+	}
+
+	segmentsInfo := &SegmentsInfo{
+		segments: segments,
+		secondaryIndexes: segmentInfoIndexes{
+			coll2Segments: map[UniqueID]map[UniqueID]*SegmentInfo{
+				collID: segments,
+			},
+		},
+	}
+
+	collections := typeutil.NewConcurrentMap[UniqueID, *collectionInfo]()
+	collections.Insert(collID, coll)
+
+	s.policy.meta = &meta{
+		segments:    segmentsInfo,
+		collections: collections,
+	}
+
+	// Should only trigger 2 segments due to rate limiting
+	views, err := s.policy.triggerOneCollection(ctx, collID, 2)
+	s.NoError(err)
+	s.Equal(2, len(views))
+}
+
+func (s *StorageVersionUpgradePolicySuite) TestTriggerIntervalReset() {
+	// Setup params
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.StorageVersionCompactionEnabled.Key, "true")
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.StorageVersionCompactionRateLimitInterval.Key, "1") // 1 second interval
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.StorageVersionCompactionRateLimitTokens.Key, "5")
+	defer func() {
+		paramtable.Get().Reset(paramtable.Get().DataCoordCfg.StorageVersionCompactionEnabled.Key)
+		paramtable.Get().Reset(paramtable.Get().DataCoordCfg.StorageVersionCompactionRateLimitInterval.Key)
+		paramtable.Get().Reset(paramtable.Get().DataCoordCfg.StorageVersionCompactionRateLimitTokens.Key)
+	}()
+
+	// Set last period to a time before the interval
+	s.policy.lastPeriod = time.Now().Add(-2 * time.Second)
+	s.policy.currentCount = 100 // Some high count
+
+	// Trigger should reset the counter because interval has passed
+	_, err := s.policy.Trigger(context.Background())
+	s.NoError(err)
+	s.Equal(0, s.policy.currentCount)
+}
+
+func (s *StorageVersionUpgradePolicySuite) TestTriggerCollectionNotFound() {
+	ctx := context.Background()
+	collID := int64(100)
+
+	coll := &collectionInfo{
+		ID:     collID,
+		Schema: newTestSchema(),
+	}
+
+	// Handler returns nil collection
+	s.handler.EXPECT().GetCollection(mock.Anything, mock.Anything).Return(nil, nil)
+
+	collections := typeutil.NewConcurrentMap[UniqueID, *collectionInfo]()
+	collections.Insert(collID, coll)
+
+	s.policy.meta = &meta{
+		segments:    NewSegmentsInfo(),
+		collections: collections,
+	}
+
+	views, err := s.policy.triggerOneCollection(ctx, collID, 10)
+	s.NoError(err)
+	s.Nil(views)
+}
+
+func (s *StorageVersionUpgradePolicySuite) TestTriggerGetCollectionError() {
+	ctx := context.Background()
+	collID := int64(100)
+
+	coll := &collectionInfo{
+		ID:     collID,
+		Schema: newTestSchema(),
+	}
+
+	// Handler returns error
+	s.handler.EXPECT().GetCollection(mock.Anything, mock.Anything).Return(nil, context.DeadlineExceeded)
+
+	collections := typeutil.NewConcurrentMap[UniqueID, *collectionInfo]()
+	collections.Insert(collID, coll)
+
+	s.policy.meta = &meta{
+		segments:    NewSegmentsInfo(),
+		collections: collections,
+	}
+
+	views, err := s.policy.triggerOneCollection(ctx, collID, 10)
+	s.Error(err)
+	s.Nil(views)
+}
+
+func (s *StorageVersionUpgradePolicySuite) TestTriggerAllocIDError() {
+	ctx := context.Background()
+	collID := int64(100)
+
+	coll := &collectionInfo{
+		ID:     collID,
+		Schema: newTestSchema(),
+	}
+	s.handler.EXPECT().GetCollection(mock.Anything, mock.Anything).Return(coll, nil)
+	s.mockAlloc.EXPECT().AllocID(mock.Anything).Return(int64(0), context.DeadlineExceeded)
+
+	collections := typeutil.NewConcurrentMap[UniqueID, *collectionInfo]()
+	collections.Insert(collID, coll)
+
+	s.policy.meta = &meta{
+		segments:    NewSegmentsInfo(),
+		collections: collections,
+	}
+
+	views, err := s.policy.triggerOneCollection(ctx, collID, 10)
+	s.Error(err)
+	s.Nil(views)
+}
+
+func (s *StorageVersionUpgradePolicySuite) TestTriggerMultipleCollections() {
+	ctx := context.Background()
+
+	// Setup params
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.StorageVersionCompactionEnabled.Key, "true")
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.StorageVersionCompactionRateLimitInterval.Key, "1")
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.StorageVersionCompactionRateLimitTokens.Key, "10")
+	// paramtable.Get().Save(paramtable.Get().CommonCfg.UseLoonFFI.Key, "true")
+	defer func() {
+		paramtable.Get().Reset(paramtable.Get().DataCoordCfg.StorageVersionCompactionEnabled.Key)
+		paramtable.Get().Reset(paramtable.Get().DataCoordCfg.StorageVersionCompactionRateLimitInterval.Key)
+		paramtable.Get().Reset(paramtable.Get().DataCoordCfg.StorageVersionCompactionRateLimitTokens.Key)
+		// paramtable.Get().Reset(paramtable.Get().CommonCfg.UseLoonFFI.Key)
+	}()
+
+	coll1 := &collectionInfo{
+		ID:     100,
+		Schema: newTestSchema(),
+	}
+	coll2 := &collectionInfo{
+		ID:     200,
+		Schema: newTestSchema(),
+	}
+	s.handler.EXPECT().GetCollection(mock.Anything, mock.Anything).Return(coll1, nil).Times(1)
+	s.handler.EXPECT().GetCollection(mock.Anything, mock.Anything).Return(coll2, nil).Times(1)
+	s.mockAlloc.EXPECT().AllocID(mock.Anything).Return(int64(1000), nil).Times(2)
+
+	// Create segments for collection 100
+	segments := make(map[UniqueID]*SegmentInfo)
+	segments[101] = &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:             101,
+			CollectionID:   100,
+			PartitionID:    10,
+			InsertChannel:  "ch-1",
+			Level:          datapb.SegmentLevel_L1,
+			State:          commonpb.SegmentState_Flushed,
+			NumOfRows:      10000,
+			StorageVersion: storage.StorageV1,
+		},
+	}
+	// Create segment for collection 200
+	segments[201] = &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:             201,
+			CollectionID:   200,
+			PartitionID:    20,
+			InsertChannel:  "ch-2",
+			Level:          datapb.SegmentLevel_L1,
+			State:          commonpb.SegmentState_Flushed,
+			NumOfRows:      10000,
+			StorageVersion: storage.StorageV1,
+		},
+	}
+
+	segmentsInfo := &SegmentsInfo{
+		segments: segments,
+		secondaryIndexes: segmentInfoIndexes{
+			coll2Segments: map[UniqueID]map[UniqueID]*SegmentInfo{
+				100: {101: segments[101]},
+				200: {201: segments[201]},
+			},
+		},
+	}
+
+	collections := typeutil.NewConcurrentMap[UniqueID, *collectionInfo]()
+	collections.Insert(100, coll1)
+	collections.Insert(200, coll2)
+
+	s.policy.meta = &meta{
+		segments:    segmentsInfo,
+		collections: collections,
+	}
+
+	events, err := s.policy.Trigger(ctx)
+	s.NoError(err)
+	s.NotNil(events)
+	gotViews, ok := events[TriggerTypeStorageVersionUpgrade]
+	s.True(ok)
+	s.Equal(2, len(gotViews)) // One from each collection
+}
+
+func (s *StorageVersionUpgradePolicySuite) TestViewContent() {
+	ctx := context.Background()
+	collID := int64(100)
+
+	coll := &collectionInfo{
+		ID:     collID,
+		Schema: newTestSchema(),
+	}
+	s.handler.EXPECT().GetCollection(mock.Anything, mock.Anything).Return(coll, nil)
+	s.mockAlloc.EXPECT().AllocID(mock.Anything).Return(int64(1000), nil)
+
+	segments := make(map[UniqueID]*SegmentInfo)
+	segments[101] = &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:             101,
+			CollectionID:   collID,
+			PartitionID:    10,
+			InsertChannel:  "ch-1",
+			Level:          datapb.SegmentLevel_L1,
+			State:          commonpb.SegmentState_Flushed,
+			NumOfRows:      10000,
+			StorageVersion: storage.StorageV1,
+		},
+	}
+
+	segmentsInfo := &SegmentsInfo{
+		segments: segments,
+		secondaryIndexes: segmentInfoIndexes{
+			coll2Segments: map[UniqueID]map[UniqueID]*SegmentInfo{
+				collID: segments,
+			},
+		},
+	}
+
+	collections := typeutil.NewConcurrentMap[UniqueID, *collectionInfo]()
+	collections.Insert(collID, coll)
+
+	s.policy.meta = &meta{
+		segments:    segmentsInfo,
+		collections: collections,
+	}
+
+	views, err := s.policy.triggerOneCollection(ctx, collID, 10)
+	s.NoError(err)
+	s.Equal(1, len(views))
+
+	// Verify view content
+	mixView, ok := views[0].(*MixSegmentView)
+	s.True(ok)
+	s.NotNil(mixView.GetGroupLabel())
+	s.Equal(collID, mixView.GetGroupLabel().CollectionID)
+	s.Equal(int64(10), mixView.GetGroupLabel().PartitionID)
+	s.Equal("ch-1", mixView.GetGroupLabel().Channel)
+	s.Equal(1, len(mixView.GetSegmentsView()))
+	s.Equal(int64(101), mixView.GetSegmentsView()[0].ID)
+}
+
+func (s *StorageVersionUpgradePolicySuite) TestDroppedSegmentFiltered() {
+	ctx := context.Background()
+	collID := int64(100)
+
+	// Setup params
+	// paramtable.Get().Save(paramtable.Get().CommonCfg.UseLoonFFI.Key, "true")
+	// defer paramtable.Get().Reset(paramtable.Get().CommonCfg.UseLoonFFI.Key)
+
+	coll := &collectionInfo{
+		ID:     collID,
+		Schema: newTestSchema(),
+	}
+	s.handler.EXPECT().GetCollection(mock.Anything, mock.Anything).Return(coll, nil)
+	s.mockAlloc.EXPECT().AllocID(mock.Anything).Return(int64(1000), nil)
+
+	// Create a dropped segment (should NOT be upgraded)
+	segments := make(map[UniqueID]*SegmentInfo)
+	segments[101] = &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:             101,
+			CollectionID:   collID,
+			PartitionID:    10,
+			InsertChannel:  "ch-1",
+			Level:          datapb.SegmentLevel_L1,
+			State:          commonpb.SegmentState_Dropped,
+			NumOfRows:      10000,
+			StorageVersion: storage.StorageV1,
+		},
+	}
+
+	segmentsInfo := &SegmentsInfo{
+		segments: segments,
+		secondaryIndexes: segmentInfoIndexes{
+			coll2Segments: map[UniqueID]map[UniqueID]*SegmentInfo{
+				collID: segments,
+			},
+		},
+	}
+
+	collections := typeutil.NewConcurrentMap[UniqueID, *collectionInfo]()
+	collections.Insert(collID, coll)
+
+	s.policy.meta = &meta{
+		segments:    segmentsInfo,
+		collections: collections,
+	}
+
+	views, err := s.policy.triggerOneCollection(ctx, collID, 10)
+	s.NoError(err)
+	s.Equal(0, len(views)) // Dropped segment should not be triggered
+}
+
+func (s *StorageVersionUpgradePolicySuite) TestGrowingSegmentFiltered() {
+	ctx := context.Background()
+	collID := int64(100)
+
+	// Setup params
+	// paramtable.Get().Save(paramtable.Get().CommonCfg.UseLoonFFI.Key, "true")
+	// defer paramtable.Get().Reset(paramtable.Get().CommonCfg.UseLoonFFI.Key)
+
+	coll := &collectionInfo{
+		ID:     collID,
+		Schema: newTestSchema(),
+	}
+	s.handler.EXPECT().GetCollection(mock.Anything, mock.Anything).Return(coll, nil)
+	s.mockAlloc.EXPECT().AllocID(mock.Anything).Return(int64(1000), nil)
+
+	// Create a growing segment (should NOT be upgraded - not flushed)
+	segments := make(map[UniqueID]*SegmentInfo)
+	segments[101] = &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:             101,
+			CollectionID:   collID,
+			PartitionID:    10,
+			InsertChannel:  "ch-1",
+			Level:          datapb.SegmentLevel_L1,
+			State:          commonpb.SegmentState_Growing,
+			NumOfRows:      10000,
+			StorageVersion: storage.StorageV1,
+		},
+	}
+
+	segmentsInfo := &SegmentsInfo{
+		segments: segments,
+		secondaryIndexes: segmentInfoIndexes{
+			coll2Segments: map[UniqueID]map[UniqueID]*SegmentInfo{
+				collID: segments,
+			},
+		},
+	}
+
+	collections := typeutil.NewConcurrentMap[UniqueID, *collectionInfo]()
+	collections.Insert(collID, coll)
+
+	s.policy.meta = &meta{
+		segments:    segmentsInfo,
+		collections: collections,
+	}
+
+	views, err := s.policy.triggerOneCollection(ctx, collID, 10)
+	s.NoError(err)
+	s.Equal(0, len(views)) // Growing segment should not be triggered
+}

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -4632,6 +4632,10 @@ type dataCoordConfig struct {
 	SingleCompactionExpiredLogMaxSize ParamItem `refreshable:"true"`
 	SingleCompactionDeltalogMaxNum    ParamItem `refreshable:"true"`
 
+	StorageVersionCompactionEnabled           ParamItem `refreshable:"true"`
+	StorageVersionCompactionRateLimitTokens   ParamItem `refreshable:"true"`
+	StorageVersionCompactionRateLimitInterval ParamItem `refreshable:"true"`
+
 	ChannelCheckpointMaxLag ParamItem `refreshable:"true"`
 	SyncSegmentsInterval    ParamItem `refreshable:"false"`
 
@@ -5143,6 +5147,33 @@ During compaction, the size of segment # of rows is able to exceed segment max #
 		Export:       true,
 	}
 	p.SingleCompactionDeltalogMaxNum.Init(base.mgr)
+
+	p.StorageVersionCompactionEnabled = ParamItem{
+		Key:          "dataCoord.compaction.storageVersion.enabled",
+		Version:      "2.6.9",
+		DefaultValue: "true",
+		Doc:          "Enable storage version compaction",
+		Export:       false,
+	}
+	p.StorageVersionCompactionEnabled.Init(base.mgr)
+
+	p.StorageVersionCompactionRateLimitTokens = ParamItem{
+		Key:          "dataCoord.compaction.storageVersion.rateLimitTokens",
+		Version:      "2.6.9",
+		DefaultValue: "3",
+		Doc:          "The storage version compaction tokens per period, applying rate limit",
+		Export:       false,
+	}
+	p.StorageVersionCompactionRateLimitTokens.Init(base.mgr)
+
+	p.StorageVersionCompactionRateLimitInterval = ParamItem{
+		Key:          "dataCoord.compaction.storageVersion.rateLimitInterval",
+		Version:      "2.6.9",
+		DefaultValue: "120",
+		Doc:          "The storage version compaction rate limit interval, in seconds",
+		Export:       false,
+	}
+	p.StorageVersionCompactionRateLimitInterval.Init(base.mgr)
 
 	p.GlobalCompactionInterval = ParamItem{
 		Key:          "dataCoord.compaction.global.interval",


### PR DESCRIPTION
Cherry-pick from master
pr: #46990
Related to #46988

This PR introduces an automated compaction mechanism to upgrade segments from older storage formats (StorageV1/V2) to newer versions (StorageV2/V3) without manual intervention.

Key changes:
- Add storageVersionUpgradePolicy to automatically identify and trigger compaction for segments with outdated storage versions
- Implement token-bucket rate limiting (default: 3 tasks per 120 seconds) to prevent resource contention during upgrades
- Add TriggerTypeStorageVersionUpgrade to compaction trigger types
- Add StorageV3 constant for Loon manifest format support
- Add configuration parameters:
- dataCoord.compaction.storageVersion.enabled (default: true)
- dataCoord.compaction.storageVersion.rateLimitTokens (default: 3)
- dataCoord.compaction.storageVersion.rateLimitInterval (default: 120s)

The policy filters segments based on:
- Healthy and flushed state
- Not currently compacting or importing
- Not L0 level segments
- Storage version differs from target version