### PR TITLE
enhance: add loading timeout and cancellation support

### DIFF
--- a/internal/core/src/index/SkipIndex.cpp
+++ b/internal/core/src/index/SkipIndex.cpp
@@ -37,6 +37,7 @@ SkipIndex::GetFieldChunkMetrics(milvus::FieldId field_id, int chunk_id) const {
 std::vector<std::pair<milvus::cachinglayer::cid_t,
                       std::unique_ptr<index::FieldChunkMetrics>>>
 FieldChunkMetricsTranslator::get_cells(
+    milvus::OpContext* ctx,
     const std::vector<milvus::cachinglayer::cid_t>& cids) {
     std::vector<std::pair<milvus::cachinglayer::cid_t,
                           std::unique_ptr<index::FieldChunkMetrics>>>

--- a/internal/core/src/index/SkipIndex.h
+++ b/internal/core/src/index/SkipIndex.h
@@ -71,7 +71,8 @@ class FieldChunkMetricsTranslatorFromStatistics
 
     std::vector<std::pair<milvus::cachinglayer::cid_t,
                           std::unique_ptr<index::FieldChunkMetrics>>>
-    get_cells(const std::vector<milvus::cachinglayer::cid_t>& cids) override {
+    get_cells(milvus::OpContext* ctx,
+              const std::vector<milvus::cachinglayer::cid_t>& cids) override {
         std::vector<std::pair<milvus::cachinglayer::cid_t,
                               std::unique_ptr<index::FieldChunkMetrics>>>
             cells;
@@ -139,7 +140,8 @@ class FieldChunkMetricsTranslator
     }
     std::vector<std::pair<milvus::cachinglayer::cid_t,
                           std::unique_ptr<index::FieldChunkMetrics>>>
-    get_cells(const std::vector<milvus::cachinglayer::cid_t>& cids) override;
+    get_cells(milvus::OpContext* ctx,
+              const std::vector<milvus::cachinglayer::cid_t>& cids) override;
 
     milvus::cachinglayer::Meta*
     meta() override {

--- a/internal/core/src/mmap/ChunkedColumn.h
+++ b/internal/core/src/mmap/ChunkedColumn.h
@@ -117,12 +117,12 @@ std::pair<std::vector<milvus::cachinglayer::cid_t>,
 
 class ChunkedColumnBase : public ChunkedColumnInterface {
  public:
-    explicit ChunkedColumnBase(std::unique_ptr<Translator<Chunk>> translator,
+    explicit ChunkedColumnBase(std::shared_ptr<CacheSlot<Chunk>> slot,
                                const FieldMeta& field_meta)
         : nullable_(field_meta.is_nullable()),
           data_type_(field_meta.get_data_type()),
-          num_chunks_(translator->num_cells()),
-          slot_(Manager::GetInstance().CreateCacheSlot(std::move(translator))) {
+          num_chunks_(slot->num_cells()),
+          slot_(std::move(slot)) {
         num_rows_ = GetNumRowsUntilChunk().back();
     }
 
@@ -406,10 +406,9 @@ class ChunkedColumnBase : public ChunkedColumnInterface {
 
 class ChunkedColumn : public ChunkedColumnBase {
  public:
-    // memory mode ctor
-    explicit ChunkedColumn(std::unique_ptr<Translator<Chunk>> translator,
+    explicit ChunkedColumn(std::shared_ptr<CacheSlot<Chunk>> slot,
                            const FieldMeta& field_meta)
-        : ChunkedColumnBase(std::move(translator), field_meta) {
+        : ChunkedColumnBase(std::move(slot), field_meta) {
     }
 
     // BulkValueAt() is used for custom data type in the future
@@ -542,11 +541,9 @@ class ChunkedVariableColumn : public ChunkedColumnBase {
         std::is_same_v<T, std::string> || std::is_same_v<T, Json>,
         "ChunkedVariableColumn only supports std::string or Json types");
 
-    // memory mode ctor
-    explicit ChunkedVariableColumn(
-        std::unique_ptr<Translator<Chunk>> translator,
-        const FieldMeta& field_meta)
-        : ChunkedColumnBase(std::move(translator), field_meta) {
+    explicit ChunkedVariableColumn(std::shared_ptr<CacheSlot<Chunk>> slot,
+                                   const FieldMeta& field_meta)
+        : ChunkedColumnBase(std::move(slot), field_meta) {
     }
 
     PinWrapper<std::pair<std::vector<std::string_view>, FixedVector<bool>>>
@@ -660,10 +657,9 @@ class ChunkedVariableColumn : public ChunkedColumnBase {
 
 class ChunkedArrayColumn : public ChunkedColumnBase {
  public:
-    // memory mode ctor
-    explicit ChunkedArrayColumn(std::unique_ptr<Translator<Chunk>> translator,
+    explicit ChunkedArrayColumn(std::shared_ptr<CacheSlot<Chunk>> slot,
                                 const FieldMeta& field_meta)
-        : ChunkedColumnBase(std::move(translator), field_meta) {
+        : ChunkedColumnBase(std::move(slot), field_meta) {
     }
 
     void
@@ -705,10 +701,9 @@ class ChunkedArrayColumn : public ChunkedColumnBase {
 
 class ChunkedVectorArrayColumn : public ChunkedColumnBase {
  public:
-    explicit ChunkedVectorArrayColumn(
-        std::unique_ptr<Translator<Chunk>> translator,
-        const FieldMeta& field_meta)
-        : ChunkedColumnBase(std::move(translator), field_meta) {
+    explicit ChunkedVectorArrayColumn(std::shared_ptr<CacheSlot<Chunk>> slot,
+                                      const FieldMeta& field_meta)
+        : ChunkedColumnBase(std::move(slot), field_meta) {
     }
 
     void
@@ -752,34 +747,34 @@ class ChunkedVectorArrayColumn : public ChunkedColumnBase {
 };
 
 inline std::shared_ptr<ChunkedColumnInterface>
-MakeChunkedColumnBase(DataType data_type,
-                      std::unique_ptr<Translator<milvus::Chunk>> translator,
-                      const FieldMeta& field_meta) {
+MakeChunkedColumnBase(
+    DataType data_type,
+    std::shared_ptr<cachinglayer::CacheSlot<milvus::Chunk>> slot,
+    const FieldMeta& field_meta) {
     if (ChunkedColumnInterface::IsChunkedVariableColumnDataType(data_type)) {
         if (data_type == DataType::JSON) {
             return std::static_pointer_cast<ChunkedColumnInterface>(
                 std::make_shared<ChunkedVariableColumn<milvus::Json>>(
-                    std::move(translator), field_meta));
+                    std::move(slot), field_meta));
         }
         return std::static_pointer_cast<ChunkedColumnInterface>(
             std::make_shared<ChunkedVariableColumn<std::string>>(
-                std::move(translator), field_meta));
+                std::move(slot), field_meta));
     }
 
     if (ChunkedColumnInterface::IsChunkedArrayColumnDataType(data_type)) {
         return std::static_pointer_cast<ChunkedColumnInterface>(
-            std::make_shared<ChunkedArrayColumn>(std::move(translator),
-                                                 field_meta));
+            std::make_shared<ChunkedArrayColumn>(std::move(slot), field_meta));
     }
 
     if (ChunkedColumnInterface::IsChunkedVectorArrayColumnDataType(data_type)) {
         return std::static_pointer_cast<ChunkedColumnInterface>(
-            std::make_shared<ChunkedVectorArrayColumn>(std::move(translator),
+            std::make_shared<ChunkedVectorArrayColumn>(std::move(slot),
                                                        field_meta));
     }
 
     return std::static_pointer_cast<ChunkedColumnInterface>(
-        std::make_shared<ChunkedColumn>(std::move(translator), field_meta));
+        std::make_shared<ChunkedColumn>(std::move(slot), field_meta));
 }
 
 }  // namespace milvus

--- a/internal/core/src/mmap/ChunkedColumnTest.cpp
+++ b/internal/core/src/mmap/ChunkedColumnTest.cpp
@@ -33,7 +33,10 @@ TEST(test_chunked_column, test_get_chunkid) {
         num_rows_per_chunk, "test", std::move(chunks));
     FieldMeta field_meta(
         FieldName("test"), FieldId(1), DataType::INT64, false, std::nullopt);
-    ChunkedColumn column(std::move(translator), field_meta);
+    auto slot =
+        cachinglayer::Manager::GetInstance().CreateCacheSlot<milvus::Chunk>(
+            std::move(translator), nullptr);
+    ChunkedColumn column(std::move(slot), field_meta);
 
     int offset = 0;
     for (int i = 0; i < num_chunks; ++i) {

--- a/internal/core/src/query/CachedSearchIteratorTest.cpp
+++ b/internal/core/src/query/CachedSearchIteratorTest.cpp
@@ -264,8 +264,10 @@ class CachedSearchIteratorTest
         }
         auto translator = std::make_unique<TestChunkTranslator>(
             num_rows_per_chunk, "", std::move(chunks));
-        column_ =
-            std::make_shared<ChunkedColumn>(std::move(translator), field_meta);
+        auto slot =
+            cachinglayer::Manager::GetInstance().CreateCacheSlot<milvus::Chunk>(
+                std::move(translator), nullptr);
+        column_ = std::make_shared<ChunkedColumn>(std::move(slot), field_meta);
     }
 
     static void

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -2597,8 +2597,8 @@ ChunkedSegmentSealedImpl::generate_interim_index(const FieldId field_id,
                     std::make_unique<milvus::segcore::storagev1translator::
                                          InterimSealedIndexTranslator>(
                         vec_data,
-                        std::to_string(id_),
-                        std::to_string(field_id.get()),
+                        id_,
+                        field_id.get(),
                         interim_index_type,
                         index_metric,
                         build_config,

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -2857,7 +2857,7 @@ ChunkedSegmentSealedImpl::ApplyLoadDiff(SegmentLoadInfo& segment_load_info,
 
     // reload fields
     if (!diff.fields_to_reload.empty()) {
-        ReloadColumns(diff.fields_to_reload);
+        ReloadColumns(diff.fields_to_reload, op_ctx);
     }
 
     // drop index, must after reload binlog
@@ -3211,7 +3211,8 @@ ChunkedSegmentSealedImpl::LoadColumnGroup(
 }
 
 void
-ChunkedSegmentSealedImpl::ReloadColumns(const std::vector<FieldId>& field_ids) {
+ChunkedSegmentSealedImpl::ReloadColumns(const std::vector<FieldId>& field_ids,
+                                        milvus::OpContext* op_ctx) {
     for (auto& field_id : field_ids) {
         auto column = get_column(field_id);
         AssertInfo(column != nullptr,
@@ -3222,7 +3223,7 @@ ChunkedSegmentSealedImpl::ReloadColumns(const std::vector<FieldId>& field_ids) {
         for (int64_t chunk_id = 0; chunk_id < num_chunks; chunk_id++) {
             chunk_ids[chunk_id] = chunk_id;
         }
-        column->PrefetchChunks(nullptr, chunk_ids);
+        column->PrefetchChunks(op_ctx, chunk_ids);
     }
 }
 

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -251,14 +251,15 @@ ChunkedSegmentSealedImpl::LoadScalarIndex(const LoadIndexInfo& info) {
 }
 
 void
-ChunkedSegmentSealedImpl::LoadFieldData(const LoadFieldDataInfo& load_info) {
+ChunkedSegmentSealedImpl::LoadFieldData(const LoadFieldDataInfo& load_info,
+                                        milvus::OpContext* op_ctx) {
     switch (load_info.storage_version) {
         case 2: {
-            load_column_group_data_internal(load_info);
+            load_column_group_data_internal(load_info, op_ctx);
             break;
         }
         default:
-            load_field_data_internal(load_info);
+            load_field_data_internal(load_info, op_ctx);
             break;
     }
 }
@@ -299,7 +300,7 @@ parse_parquet_statistics(
 
 void
 ChunkedSegmentSealedImpl::load_column_group_data_internal(
-    const LoadFieldDataInfo& load_info) {
+    const LoadFieldDataInfo& load_info, milvus::OpContext* op_ctx) {
     size_t num_rows = storage::GetNumRowsForLoadInfo(load_info);
     ArrowSchemaPtr arrow_schema = schema_->ConvertToArrowSchema();
     auto& mmap_config = storage::MmapManager::GetInstance().GetMmapConfig();
@@ -386,15 +387,15 @@ ChunkedSegmentSealedImpl::load_column_group_data_internal(
                     file_metas, field_id_mapping, field_id.get());
             }
 
-            load_field_data_common(field_id,
-                                   column,
-                                   num_rows,
-                                   data_type,
-                                   info.enable_mmap,
-                                   true,
-                                   ENABLE_PARQUET_STATS_SKIP_INDEX
-                                       ? statistics_opt
-                                       : std::nullopt);
+            load_field_data_common(
+                field_id,
+                column,
+                num_rows,
+                data_type,
+                info.enable_mmap,
+                true,
+                ENABLE_PARQUET_STATS_SKIP_INDEX ? statistics_opt : std::nullopt,
+                op_ctx);
             if (field_id == TimestampFieldID) {
                 auto timestamp_proxy_column = get_column(TimestampFieldID);
                 AssertInfo(timestamp_proxy_column != nullptr,
@@ -437,7 +438,7 @@ ChunkedSegmentSealedImpl::load_column_group_data_internal(
 
 void
 ChunkedSegmentSealedImpl::load_field_data_internal(
-    const LoadFieldDataInfo& load_info) {
+    const LoadFieldDataInfo& load_info, milvus::OpContext* op_ctx) {
     SCOPE_CGO_CALL_METRIC();
 
     auto& mmap_config = storage::MmapManager::GetInstance().GetMmapConfig();
@@ -515,11 +516,19 @@ ChunkedSegmentSealedImpl::load_field_data_internal(
                     load_info.load_priority);
 
             auto data_type = field_meta.get_data_type();
-            auto column = MakeChunkedColumnBase(
-                data_type, std::move(translator), field_meta);
+            auto slot = cachinglayer::Manager::GetInstance().CreateCacheSlot(
+                std::move(translator), op_ctx);
+            auto column =
+                MakeChunkedColumnBase(data_type, std::move(slot), field_meta);
 
-            load_field_data_common(
-                field_id, column, num_rows, data_type, info.enable_mmap, false);
+            load_field_data_common(field_id,
+                                   column,
+                                   num_rows,
+                                   data_type,
+                                   info.enable_mmap,
+                                   false,
+                                   std::nullopt,
+                                   op_ctx);
         }
     }
 }
@@ -1786,7 +1795,14 @@ ChunkedSegmentSealedImpl::fill_with_empty(FieldId field_id,
 }
 
 void
-ChunkedSegmentSealedImpl::CreateTextIndex(FieldId field_id) {
+ChunkedSegmentSealedImpl::CreateTextIndex(FieldId field_id,
+                                          milvus::OpContext* op_ctx) {
+    // Check for cancellation before starting
+    CheckCancellation(op_ctx,
+                      id_,
+                      field_id.get(),
+                      "ChunkedSegmentSealedImpl::CreateTextIndex()");
+
     std::unique_lock lck(mutex_);
 
     const auto& field_meta = schema_->operator[](field_id);
@@ -1815,6 +1831,11 @@ ChunkedSegmentSealedImpl::CreateTextIndex(FieldId field_id) {
         // build
         auto column = get_column(field_id);
         if (column) {
+            // Check for cancellation before bulk operation
+            CheckCancellation(op_ctx,
+                              id_,
+                              field_id.get(),
+                              "ChunkedSegmentSealedImpl::CreateTextIndex()");
             column->BulkRawStringAt(
                 nullptr,
                 [&](std::string_view value, size_t offset, bool is_valid) {
@@ -1851,6 +1872,12 @@ ChunkedSegmentSealedImpl::CreateTextIndex(FieldId field_id) {
         }
     }
 
+    // Check for cancellation before finalizing
+    CheckCancellation(op_ctx,
+                      id_,
+                      field_id.get(),
+                      "ChunkedSegmentSealedImpl::CreateTextIndex()");
+
     // create index reader.
     index->CreateReader(milvus::index::SetBitsetSealed);
     // release index writer.
@@ -1867,7 +1894,11 @@ ChunkedSegmentSealedImpl::CreateTextIndex(FieldId field_id) {
 
 void
 ChunkedSegmentSealedImpl::LoadTextIndex(
-    std::unique_ptr<milvus::proto::indexcgo::LoadTextIndexInfo> info_proto) {
+    std::unique_ptr<milvus::proto::indexcgo::LoadTextIndexInfo> info_proto,
+    milvus::OpContext* op_ctx) {
+    // Check for cancellation before starting
+    CheckCancellation(op_ctx, id_, "ChunkedSegmentSealedImpl::LoadTextIndex()");
+
     std::unique_lock lck(mutex_);
 
     milvus::storage::FieldDataMeta field_data_meta{info_proto->collectionid(),
@@ -1913,7 +1944,7 @@ ChunkedSegmentSealedImpl::LoadTextIndex(
             load_info, file_ctx, config);
     auto cache_slot =
         milvus::cachinglayer::Manager::GetInstance().CreateCacheSlot(
-            std::move(translator));
+            std::move(translator), op_ctx);
     text_indexes_[field_id] = std::move(cache_slot);
 }
 
@@ -2640,7 +2671,8 @@ ChunkedSegmentSealedImpl::load_field_data_common(
     DataType data_type,
     bool enable_mmap,
     bool is_proxy_column,
-    std::optional<ParquetStatistics> statistics) {
+    std::optional<ParquetStatistics> statistics,
+    milvus::OpContext* op_ctx) {
     {
         std::unique_lock lck(mutex_);
         AssertInfo(SystemProperty::Instance().IsSystem(field_id) ||
@@ -2664,7 +2696,7 @@ ChunkedSegmentSealedImpl::load_field_data_common(
     }
 
     if (column->IsNullable() && IsVectorDataType(data_type)) {
-        column->BuildValidRowIds(nullptr);
+        column->BuildValidRowIds(op_ctx);
     }
 
     if (!enable_mmap) {
@@ -2815,10 +2847,12 @@ ChunkedSegmentSealedImpl::Reopen(
 
 void
 ChunkedSegmentSealedImpl::ApplyLoadDiff(SegmentLoadInfo& segment_load_info,
-                                        LoadDiff& diff) {
+                                        LoadDiff& diff,
+                                        milvus::OpContext* op_ctx) {
+    // TODO: pass trace_ctx separately when needed
     milvus::tracer::TraceContext trace_ctx;
     if (!diff.indexes_to_load.empty()) {
-        LoadBatchIndexes(trace_ctx, diff.indexes_to_load);
+        LoadBatchIndexes(trace_ctx, diff.indexes_to_load, op_ctx);
     }
 
     // reload fields
@@ -2844,20 +2878,24 @@ ChunkedSegmentSealedImpl::ApplyLoadDiff(SegmentLoadInfo& segment_load_info,
         reader_ = milvus_storage::api::Reader::create(
             column_groups, arrow_schema, nullptr, *properties);
         if (!diff.column_groups_to_load.empty()) {
-            LoadColumnGroups(
-                column_groups, properties, diff.column_groups_to_load, true);
+            LoadColumnGroups(column_groups,
+                             properties,
+                             diff.column_groups_to_load,
+                             true,
+                             op_ctx);
         }
         if (!diff.column_groups_to_lazyload.empty()) {
             LoadColumnGroups(column_groups,
                              properties,
                              diff.column_groups_to_lazyload,
-                             false);
+                             false,
+                             op_ctx);
         }
     }
 
     // load field binlog
     if (!diff.binlogs_to_load.empty()) {
-        LoadBatchFieldData(trace_ctx, diff.binlogs_to_load);
+        LoadBatchFieldData(trace_ctx, diff.binlogs_to_load, op_ctx);
     }
 
     // drop field
@@ -2920,8 +2958,9 @@ ChunkedSegmentSealedImpl::fill_empty_field(const FieldMeta& field_meta) {
             field_data_info,
             use_mmap,
             mmap_config.GetMmapPopulate());
-    auto column =
-        MakeChunkedColumnBase(data_type, std::move(translator), field_meta);
+    auto slot = cachinglayer::Manager::GetInstance().CreateCacheSlot(
+        std::move(translator), nullptr);
+    auto column = MakeChunkedColumnBase(data_type, std::move(slot), field_meta);
 
     if (column->IsNullable() && IsVectorDataType(data_type)) {
         column->BuildValidRowIds(nullptr);
@@ -3002,7 +3041,8 @@ ChunkedSegmentSealedImpl::LoadColumnGroups(
     const std::shared_ptr<milvus_storage::api::ColumnGroups>& column_groups,
     const std::shared_ptr<milvus_storage::api::Properties>& properties,
     std::vector<std::pair<int, std::vector<FieldId>>>& cg_field_ids,
-    bool eager_load) {
+    bool eager_load,
+    milvus::OpContext* op_ctx) {
     auto& pool = ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::LOW);
     std::vector<std::future<void>> load_group_futures;
     for (const auto& pair : cg_field_ids) {
@@ -3013,9 +3053,19 @@ ChunkedSegmentSealedImpl::LoadColumnGroups(
                                    properties,
                                    cg_index,
                                    field_ids,
-                                   eager_load]() {
-            LoadColumnGroup(
-                column_groups, properties, cg_index, field_ids, eager_load);
+                                   eager_load,
+                                   op_ctx]() {
+            // Early exit if cancelled while queued
+            CheckCancellation(op_ctx,
+                              id_,
+                              cg_index,
+                              "ChunkedSegmentSealedImpl::LoadColumnGroup()");
+            LoadColumnGroup(column_groups,
+                            properties,
+                            cg_index,
+                            field_ids,
+                            eager_load,
+                            op_ctx);
         });
         load_group_futures.emplace_back(std::move(future));
     }
@@ -3047,7 +3097,8 @@ ChunkedSegmentSealedImpl::LoadColumnGroup(
     const std::shared_ptr<milvus_storage::api::Properties>& properties,
     int64_t index,
     const std::vector<FieldId>& milvus_field_ids,
-    bool eager_load) {
+    bool eager_load,
+    milvus::OpContext* op_ctx) {
     AssertInfo(index < column_groups->size(),
                "load column group index out of range");
     auto column_group = column_groups->at(index);
@@ -3126,7 +3177,8 @@ ChunkedSegmentSealedImpl::LoadColumnGroup(
             use_mmap,
             true,
             std::
-                nullopt);  // manifest cannot provide parquet skip index directly
+                nullopt,  // manifest cannot provide parquet skip index directly
+            op_ctx);
         if (field_id == TimestampFieldID) {
             auto timestamp_proxy_column = get_column(TimestampFieldID);
             AssertInfo(timestamp_proxy_column != nullptr,
@@ -3178,7 +3230,8 @@ void
 ChunkedSegmentSealedImpl::LoadBatchIndexes(
     milvus::tracer::TraceContext& trace_ctx,
     std::unordered_map<FieldId, std::vector<LoadIndexInfo>>&
-        field_id_to_index_info) {
+        field_id_to_index_info,
+    milvus::OpContext* op_ctx) {
     auto num_rows = segment_load_info_.GetNumOfRows();
     auto& pool = ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::LOW);
     std::vector<std::future<void>> load_index_futures;
@@ -3193,14 +3246,18 @@ ChunkedSegmentSealedImpl::LoadBatchIndexes(
                                        trace_ctx,
                                        field_id,
                                        load_index_info_ptr,
-                                       num_rows]() mutable -> void {
+                                       num_rows,
+                                       op_ctx]() mutable -> void {
+                // Early exit if cancelled while queued
+                CheckCancellation(op_ctx, id_, field_id.get(), "LoadIndex");
+
                 LOG_INFO("Loading index for segment {} field {} with {} files",
                          id_,
                          field_id.get(),
                          load_index_info_ptr->index_files.size());
 
                 // Download & compose index
-                LoadIndexData(trace_ctx, load_index_info_ptr);
+                LoadIndexData(trace_ctx, load_index_info_ptr, op_ctx);
 
                 // Load index into segment
                 LoadIndex(*load_index_info_ptr);
@@ -3237,7 +3294,8 @@ void
 ChunkedSegmentSealedImpl::LoadBatchFieldData(
     milvus::tracer::TraceContext& trace_ctx,
     std::vector<std::pair<std::vector<FieldId>, proto::segcore::FieldBinlog>>&
-        field_binlog_to_load) {
+        field_binlog_to_load,
+    milvus::OpContext* op_ctx) {
     LOG_INFO("Loading field binlog for {} fields in segment {}",
              field_binlog_to_load.size(),
              id_);
@@ -3289,7 +3347,8 @@ ChunkedSegmentSealedImpl::LoadBatchFieldData(
         // Skip if this field has an index with raw data
         if (index_has_raw_data) {
             LOG_INFO(
-                "Skip loading fielddata for segment {} group {} because index "
+                "Skip loading fielddata for segment {} group {} because "
+                "index "
                 "has raw data",
                 id_,
                 group_id);
@@ -3332,10 +3391,18 @@ ChunkedSegmentSealedImpl::LoadBatchFieldData(
     load_field_futures.reserve(field_data_to_load.size());
 
     for (const auto& [field_id, load_field_data_info] : field_data_to_load) {
-        // Create a local copy to capture in lambda (C++17 compatible)
+        // Create local copies to capture in lambda (C++17 compatible)
         const auto field_data = load_field_data_info;
+        const auto captured_field_id = field_id;
         auto future = pool.Submit(
-            [this, field_data]() -> void { LoadFieldData(field_data); });
+            [this, field_data, captured_field_id, op_ctx]() -> void {
+                // Early exit if cancelled while queued
+                CheckCancellation(op_ctx,
+                                  id_,
+                                  captured_field_id.get(),
+                                  "ChunkedSegmentSealedImpl::LoadFieldData()");
+                LoadFieldData(field_data, op_ctx);
+            });
 
         load_field_futures.push_back(std::move(future));
     }
@@ -3364,14 +3431,15 @@ ChunkedSegmentSealedImpl::LoadBatchFieldData(
 }
 
 void
-ChunkedSegmentSealedImpl::Load(milvus::tracer::TraceContext& trace_ctx) {
+ChunkedSegmentSealedImpl::Load(milvus::tracer::TraceContext& trace_ctx,
+                               milvus::OpContext* op_ctx) {
     // Get load info from segment_load_info_
     auto num_rows = segment_load_info_.GetNumOfRows();
     LOG_INFO("Loading segment {} with {} rows", id_, num_rows);
 
     auto diff = segment_load_info_.GetLoadDiff();
     LOG_WARN("Load segment {} with diff {}", id_, diff.ToString());
-    ApplyLoadDiff(segment_load_info_, diff);
+    ApplyLoadDiff(segment_load_info_, diff, op_ctx);
 
     LOG_INFO("Successfully loaded segment {} with {} rows", id_, num_rows);
 }

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -1014,6 +1014,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
      * @param index Index of the column group to load
      * @param milvus_field_ids A vector of field IDs to load
      * @param eager_load Whether to eagerly load provided columns
+     * @param op_ctx The operation context
      */
     void
     LoadColumnGroup(
@@ -1028,9 +1029,11 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
      * @brief Reloads columns from the specified field IDs
      *
      * @param field_ids_to_reload A vector of field IDs to reload
+     * @param op_ctx The operation context
      */
     void
-    ReloadColumns(const std::vector<FieldId>& field_ids_to_reload);
+    ReloadColumns(const std::vector<FieldId>& field_ids_to_reload,
+                  milvus::OpContext* op_ctx = nullptr);
 
     /**
      * @brief Apply load differences to update segment load information
@@ -1041,6 +1044,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
      *
      * @param segment_load_info The segment load information to be updated
      * @param load_diff The differences to apply, containing fields and indexes to add/remove
+     * @param op_ctx The operation context
      */
     void
     ApplyLoadDiff(SegmentLoadInfo& segment_load_info,

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -64,7 +64,8 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     void
     LoadIndex(const LoadIndexInfo& info) override;
     void
-    LoadFieldData(const LoadFieldDataInfo& info) override;
+    LoadFieldData(const LoadFieldDataInfo& info,
+                  milvus::OpContext* op_ctx = nullptr) override;
     void
     LoadDeletedRecord(const LoadDeletedRecordInfo& info) override;
     void
@@ -130,11 +131,13 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     RemoveFieldFile(const FieldId field_id) override;
 
     void
-    CreateTextIndex(FieldId field_id) override;
+    CreateTextIndex(FieldId field_id,
+                    milvus::OpContext* op_ctx = nullptr) override;
 
     void
-    LoadTextIndex(std::unique_ptr<milvus::proto::indexcgo::LoadTextIndexInfo>
-                      info_proto) override;
+    LoadTextIndex(
+        std::unique_ptr<milvus::proto::indexcgo::LoadTextIndexInfo> info_proto,
+        milvus::OpContext* op_ctx = nullptr) override;
 
     void
     RemoveJsonStats(FieldId field_id) override {
@@ -204,7 +207,8 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         const milvus::proto::segcore::SegmentLoadInfo& load_info) override;
 
     void
-    Load(milvus::tracer::TraceContext& trace_ctx) override;
+    Load(milvus::tracer::TraceContext& trace_ctx,
+         milvus::OpContext* op_ctx = nullptr) override;
 
  public:
     size_t
@@ -971,28 +975,33 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                          size_t num_rows);
 
     void
-    load_field_data_internal(const LoadFieldDataInfo& load_info);
+    load_field_data_internal(const LoadFieldDataInfo& load_info,
+                             milvus::OpContext* op_ctx = nullptr);
 
     void
-    load_column_group_data_internal(const LoadFieldDataInfo& load_info);
+    load_column_group_data_internal(const LoadFieldDataInfo& load_info,
+                                    milvus::OpContext* op_ctx = nullptr);
 
     void
     LoadBatchIndexes(milvus::tracer::TraceContext& trace_ctx,
                      std::unordered_map<FieldId, std::vector<LoadIndexInfo>>&
-                         field_id_to_index_info);
+                         field_id_to_index_info,
+                     milvus::OpContext* op_ctx = nullptr);
 
     void
     LoadBatchFieldData(milvus::tracer::TraceContext& trace_ctx,
                        std::vector<std::pair<std::vector<FieldId>,
                                              proto::segcore::FieldBinlog>>&
-                           field_binlog_to_load);
+                           field_binlog_to_load,
+                       milvus::OpContext* op_ctx = nullptr);
 
     void
     LoadColumnGroups(
         const std::shared_ptr<milvus_storage::api::ColumnGroups>& column_groups,
         const std::shared_ptr<milvus_storage::api::Properties>& properties,
         std::vector<std::pair<int, std::vector<FieldId>>>& cg_field_ids,
-        bool eager_load);
+        bool eager_load,
+        milvus::OpContext* op_ctx = nullptr);
 
     /**
      * @brief Load a single column group at the specified index
@@ -1012,7 +1021,8 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         const std::shared_ptr<milvus_storage::api::Properties>& properties,
         int64_t index,
         const std::vector<FieldId>& milvus_field_ids,
-        bool eager_load);
+        bool eager_load,
+        milvus::OpContext* op_ctx = nullptr);
 
     /**
      * @brief Reloads columns from the specified field IDs
@@ -1033,7 +1043,9 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
      * @param load_diff The differences to apply, containing fields and indexes to add/remove
      */
     void
-    ApplyLoadDiff(SegmentLoadInfo& segment_load_info, LoadDiff& load_diff);
+    ApplyLoadDiff(SegmentLoadInfo& segment_load_info,
+                  LoadDiff& load_diff,
+                  milvus::OpContext* op_ctx = nullptr);
 
     void
     load_field_data_common(
@@ -1043,7 +1055,8 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         DataType data_type,
         bool enable_mmap,
         bool is_proxy_column,
-        std::optional<ParquetStatistics> statistics = {});
+        std::optional<ParquetStatistics> statistics = {},
+        milvus::OpContext* op_ctx = nullptr);
 
     std::shared_ptr<ChunkedColumnInterface>
     get_column(FieldId field_id) const {

--- a/internal/core/src/segcore/ChunkedSegmentSealedTest.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedTest.cpp
@@ -104,8 +104,9 @@ TEST(test_chunk_segment, TestSearchOnSealed) {
 
     auto translator = std::make_unique<TestChunkTranslator>(
         num_rows_per_chunk, "", std::move(chunks));
-    auto column =
-        std::make_shared<ChunkedColumn>(std::move(translator), field_meta);
+    auto slot = cachinglayer::Manager::GetInstance().CreateCacheSlot(
+        std::move(translator), nullptr);
+    auto column = std::make_shared<ChunkedColumn>(std::move(slot), field_meta);
 
     SearchInfo search_info;
     auto search_conf = knowhere::Json{

--- a/internal/core/src/segcore/ChunkedSegmentSealedTest.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedTest.cpp
@@ -104,8 +104,9 @@ TEST(test_chunk_segment, TestSearchOnSealed) {
 
     auto translator = std::make_unique<TestChunkTranslator>(
         num_rows_per_chunk, "", std::move(chunks));
-    auto slot = cachinglayer::Manager::GetInstance().CreateCacheSlot(
-        std::move(translator), nullptr);
+    auto slot =
+        cachinglayer::Manager::GetInstance().CreateCacheSlot<milvus::Chunk>(
+            std::move(translator), nullptr);
     auto column = std::make_shared<ChunkedColumn>(std::move(slot), field_meta);
 
     SearchInfo search_info;

--- a/internal/core/src/segcore/LoadCancellationTest.cpp
+++ b/internal/core/src/segcore/LoadCancellationTest.cpp
@@ -1,0 +1,436 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+// Licensed under the Apache License, Version 2.0
+#include <gtest/gtest.h>
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include <folly/CancellationToken.h>
+#include "cachinglayer/Manager.h"
+#include "cachinglayer/Translator.h"
+#include "common/Chunk.h"
+#include "common/OpContext.h"
+#include "common/Schema.h"
+#include "segcore/ChunkedSegmentSealedImpl.h"
+#include "segcore/SegcoreConfig.h"
+#include "segcore/SegmentGrowingImpl.h"
+#include "segcore/Utils.h"
+#include "segcore/segment_c.h"
+#include "segcore/storagev1translator/ChunkTranslator.h"
+#include "test_utils/DataGen.h"
+
+using namespace milvus;
+using namespace milvus::segcore;
+using namespace milvus::cachinglayer;
+
+// C API Tests for Load Cancellation Source Management
+TEST(LoadCancellationCAPI, NewAndReleaseSource) {
+    CLoadCancellationSource source = NewLoadCancellationSource();
+    ASSERT_NE(source, nullptr);
+    ReleaseLoadCancellationSource(source);
+}
+
+TEST(LoadCancellationCAPI, CancelSource) {
+    CLoadCancellationSource source = NewLoadCancellationSource();
+    ASSERT_NE(source, nullptr);
+    CancelLoadCancellationSource(source);
+    auto* folly_source = static_cast<folly::CancellationSource*>(source);
+    EXPECT_TRUE(folly_source->getToken().isCancellationRequested());
+    ReleaseLoadCancellationSource(source);
+}
+
+TEST(LoadCancellationCAPI, CancelNullSource) {
+    CancelLoadCancellationSource(nullptr);
+}
+
+TEST(LoadCancellationCAPI, ReleaseNullSource) {
+    ReleaseLoadCancellationSource(nullptr);
+}
+
+TEST(LoadCancellationCAPI, MultipleCancellations) {
+    CLoadCancellationSource source = NewLoadCancellationSource();
+    CancelLoadCancellationSource(source);
+    CancelLoadCancellationSource(source);
+    auto* folly_source = static_cast<folly::CancellationSource*>(source);
+    EXPECT_TRUE(folly_source->getToken().isCancellationRequested());
+    ReleaseLoadCancellationSource(source);
+}
+
+// Test for Segment CreateTextIndex cancellation (sealed segment)
+TEST(LoadCancellationSegment, CreateTextIndexCancellationSealed) {
+    auto schema = std::make_shared<Schema>();
+    auto text_fid = schema->AddDebugField("text", DataType::VARCHAR);
+    auto pk_fid = schema->AddDebugField("pk", DataType::INT64);
+    schema->set_primary_field_id(pk_fid);
+    auto segment = CreateSealedSegment(
+        schema, nullptr, -1, SegcoreConfig::default_config(), true);
+    folly::CancellationSource source;
+    source.requestCancellation();
+    OpContext op_ctx(source.getToken());
+    EXPECT_THROW(
+        {
+            try {
+                segment->CreateTextIndex(text_fid, &op_ctx);
+            } catch (const SegcoreError& e) {
+                EXPECT_EQ(e.get_error_code(), ErrorCode::FollyCancel);
+                throw;
+            }
+        },
+        SegcoreError);
+}
+
+// Test for Segment CreateTextIndex cancellation (growing segment)
+TEST(LoadCancellationSegment, CreateTextIndexCancellationGrowing) {
+    auto schema = std::make_shared<Schema>();
+    auto text_fid = schema->AddDebugField("text", DataType::VARCHAR);
+    auto pk_fid = schema->AddDebugField("pk", DataType::INT64);
+    schema->set_primary_field_id(pk_fid);
+    auto segment = CreateGrowingSegment(
+        schema, nullptr, 1, SegcoreConfig::default_config());
+    folly::CancellationSource source;
+    source.requestCancellation();
+    OpContext op_ctx(source.getToken());
+    EXPECT_THROW(
+        {
+            try {
+                segment->CreateTextIndex(text_fid, &op_ctx);
+            } catch (const SegcoreError& e) {
+                EXPECT_EQ(e.get_error_code(), ErrorCode::FollyCancel);
+                throw;
+            }
+        },
+        SegcoreError);
+}
+
+// Note: CreateTextIndex with null context is implicitly tested by the cancellation tests
+// since the cancellation check happens before the analyzer validation. If cancellation
+// doesn't throw, the function continues and would need proper analyzer setup to succeed.
+
+// Test cancellation during loop operation
+TEST(LoadCancellationUtility, CancellationDuringLoop) {
+    folly::CancellationSource source;
+    OpContext op_ctx(source.getToken());
+    int iterations = 0;
+    bool caught = false;
+    try {
+        for (int i = 0; i < 100; ++i) {
+            CheckCancellation(&op_ctx, 123, i, "LoopOp");
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+            iterations++;
+            if (i == 4)
+                source.requestCancellation();
+        }
+    } catch (const SegcoreError& e) {
+        caught = true;
+        EXPECT_EQ(e.get_error_code(), ErrorCode::FollyCancel);
+    }
+    EXPECT_TRUE(caught);
+    EXPECT_EQ(iterations, 5);
+}
+
+// Test concurrent cancellation from another thread
+TEST(LoadCancellationUtility, ConcurrentCancellation) {
+    folly::CancellationSource source;
+    OpContext op_ctx(source.getToken());
+    std::atomic<int> iterations{0};
+    std::atomic<bool> caught{false};
+    std::thread worker([&]() {
+        try {
+            for (int i = 0; i < 1000; ++i) {
+                CheckCancellation(&op_ctx, 456, fmt::format("Iter{}", i));
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+                iterations++;
+            }
+        } catch (const SegcoreError& e) {
+            caught = true;
+            EXPECT_EQ(e.get_error_code(), ErrorCode::FollyCancel);
+        }
+    });
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    source.requestCancellation();
+    worker.join();
+    EXPECT_TRUE(caught.load());
+    EXPECT_GT(iterations.load(), 0);
+    EXPECT_LT(iterations.load(), 1000);
+}
+
+// Test that token is shared across contexts
+TEST(LoadCancellationUtility, TokenSharedAcrossContexts) {
+    folly::CancellationSource source;
+    OpContext op_ctx1(source.getToken());
+    OpContext op_ctx2(source.getToken());
+    source.requestCancellation();
+    EXPECT_THROW(CheckCancellation(&op_ctx1, 1, "T1"), SegcoreError);
+    EXPECT_THROW(CheckCancellation(&op_ctx2, 2, "T2"), SegcoreError);
+}
+
+// Test error message format
+TEST(LoadCancellationUtility, ErrorMessageFormat) {
+    folly::CancellationSource source;
+    OpContext op_ctx(source.getToken());
+    source.requestCancellation();
+    try {
+        CheckCancellation(&op_ctx, 12345, "TestOp");
+        FAIL() << "Expected exception";
+    } catch (const SegcoreError& e) {
+        std::string msg(e.what());
+        EXPECT_TRUE(msg.find("TestOp") != std::string::npos);
+        EXPECT_TRUE(msg.find("12345") != std::string::npos);
+    }
+    try {
+        CheckCancellation(&op_ctx, 12345, 67890, "FieldOp");
+        FAIL() << "Expected exception";
+    } catch (const SegcoreError& e) {
+        std::string msg(e.what());
+        EXPECT_TRUE(msg.find("FieldOp") != std::string::npos);
+        EXPECT_TRUE(msg.find("12345") != std::string::npos);
+        EXPECT_TRUE(msg.find("67890") != std::string::npos);
+    }
+}
+
+// OpContext tests
+TEST(OpContextTest, DefaultConstructor) {
+    OpContext op_ctx;
+    EXPECT_FALSE(op_ctx.cancellation_token.isCancellationRequested());
+}
+
+TEST(OpContextTest, ConstructorWithToken) {
+    folly::CancellationSource source;
+    OpContext op_ctx(source.getToken());
+    EXPECT_FALSE(op_ctx.cancellation_token.isCancellationRequested());
+    source.requestCancellation();
+    EXPECT_TRUE(op_ctx.cancellation_token.isCancellationRequested());
+}
+
+TEST(OpContextTest, TokenSharedFromSameSource) {
+    // OpContext is non-copyable, but multiple contexts can share the same token
+    folly::CancellationSource source;
+    OpContext op_ctx1(source.getToken());
+    OpContext op_ctx2(source.getToken());
+    source.requestCancellation();
+    EXPECT_TRUE(op_ctx1.cancellation_token.isCancellationRequested());
+    EXPECT_TRUE(op_ctx2.cancellation_token.isCancellationRequested());
+}
+
+// Integration test: Multiple cancellation check points
+TEST(LoadCancellationIntegration, MultipleCheckPoints) {
+    folly::CancellationSource source;
+    OpContext op_ctx(source.getToken());
+    std::vector<std::string> passed;
+    int64_t seg_id = 999, field_id = 100;
+
+    // No cancellation - all checkpoints pass
+    EXPECT_NO_THROW({
+        CheckCancellation(&op_ctx, seg_id, "BeforeLoad");
+        passed.push_back("BeforeLoad");
+        CheckCancellation(&op_ctx, seg_id, field_id, "LoadFieldData");
+        passed.push_back("LoadFieldData");
+        CheckCancellation(&op_ctx, seg_id, field_id, "LoadIndex");
+        passed.push_back("LoadIndex");
+        CheckCancellation(&op_ctx, seg_id, field_id, "CreateTextIndex");
+        passed.push_back("CreateTextIndex");
+        CheckCancellation(&op_ctx, seg_id, "AfterLoad");
+        passed.push_back("AfterLoad");
+    });
+    EXPECT_EQ(passed.size(), 5);
+
+    // Pre-cancelled - first checkpoint fails
+    passed.clear();
+    folly::CancellationSource source2;
+    OpContext op_ctx2(source2.getToken());
+    source2.requestCancellation();
+    try {
+        CheckCancellation(&op_ctx2, seg_id, "BeforeLoad");
+        FAIL() << "Expected exception";
+    } catch (const SegcoreError& e) {
+        EXPECT_EQ(e.get_error_code(), ErrorCode::FollyCancel);
+    }
+    EXPECT_TRUE(passed.empty());
+}
+
+// Test Translator with Cancellation Support
+class SlowChunkTranslator : public cachinglayer::Translator<milvus::Chunk> {
+ public:
+    SlowChunkTranslator(size_t num_chunks,
+                        std::chrono::milliseconds delay,
+                        std::string key)
+        : num_chunks_(num_chunks),
+          delay_(delay),
+          key_(std::move(key)),
+          meta_(storagev1translator::CTMeta(
+              cachinglayer::StorageType::MEMORY,
+              cachinglayer::CellIdMappingMode::IDENTICAL,
+              cachinglayer::CellDataType::SCALAR_FIELD,
+              CacheWarmupPolicy::CacheWarmupPolicy_Disable,
+              true)),
+          chunks_loaded_(0),
+          was_cancelled_(false) {
+        meta_.num_rows_until_chunk_.push_back(0);
+        for (size_t i = 0; i < num_chunks_; ++i) {
+            meta_.num_rows_until_chunk_.push_back(
+                meta_.num_rows_until_chunk_[i] + 100);
+        }
+        storagev1translator::virtual_chunk_config(100 * num_chunks_,
+                                                  num_chunks_,
+                                                  meta_.num_rows_until_chunk_,
+                                                  meta_.virt_chunk_order_,
+                                                  meta_.vcid_to_cid_arr_);
+    }
+    ~SlowChunkTranslator() override = default;
+    size_t
+    num_cells() const override {
+        return num_chunks_;
+    }
+    cachinglayer::cid_t
+    cell_id_of(cachinglayer::uid_t uid) const override {
+        return uid;
+    }
+    std::pair<cachinglayer::ResourceUsage, cachinglayer::ResourceUsage>
+    estimated_byte_size_of_cell(cachinglayer::cid_t) const override {
+        return {{0, 0}, {0, 0}};
+    }
+    int64_t
+    cells_storage_bytes(
+        const std::vector<cachinglayer::cid_t>&) const override {
+        return 0;
+    }
+    const std::string&
+    key() const override {
+        return key_;
+    }
+    cachinglayer::Meta*
+    meta() override {
+        return &meta_;
+    }
+
+    std::vector<std::pair<cachinglayer::cid_t, std::unique_ptr<milvus::Chunk>>>
+    get_cells(milvus::OpContext* ctx,
+              const std::vector<cachinglayer::cid_t>& cids) override {
+        std::vector<
+            std::pair<cachinglayer::cid_t, std::unique_ptr<milvus::Chunk>>>
+            res;
+        res.reserve(cids.size());
+        for (auto cid : cids) {
+            if (ctx && ctx->cancellation_token.isCancellationRequested()) {
+                was_cancelled_ = true;
+                throw SegcoreError(ErrorCode::FollyCancel,
+                                   fmt::format("cancelled at chunk {}", cid));
+            }
+            std::this_thread::sleep_for(delay_);
+            auto guard = std::make_shared<ChunkMmapGuard>(nullptr, 0, "");
+            auto chunk = std::make_unique<FixedWidthChunk>(
+                100, 1, nullptr, 0, sizeof(int64_t), false, guard);
+            res.emplace_back(cid, std::move(chunk));
+            chunks_loaded_++;
+        }
+        return res;
+    }
+    size_t
+    chunks_loaded() const {
+        return chunks_loaded_;
+    }
+    bool
+    was_cancelled() const {
+        return was_cancelled_;
+    }
+
+ private:
+    size_t num_chunks_;
+    std::chrono::milliseconds delay_;
+    std::string key_;
+    storagev1translator::CTMeta meta_;
+    std::atomic<size_t> chunks_loaded_;
+    std::atomic<bool> was_cancelled_;
+};
+
+// Test that translator respects cancellation during chunk loading
+TEST(LoadCancellationTranslator, RespectsCancellation) {
+    auto translator = std::make_unique<SlowChunkTranslator>(
+        10, std::chrono::milliseconds(50), "slow_translator");
+    auto* raw = translator.get();
+    folly::CancellationSource source;
+    OpContext op_ctx(source.getToken());
+    std::thread load_thread([&]() {
+        try {
+            std::vector<cachinglayer::cid_t> cids = {
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+            raw->get_cells(&op_ctx, cids);
+        } catch (const SegcoreError& e) {
+            EXPECT_EQ(e.get_error_code(), ErrorCode::FollyCancel);
+        }
+    });
+    std::this_thread::sleep_for(std::chrono::milliseconds(150));
+    source.requestCancellation();
+    load_thread.join();
+    EXPECT_TRUE(raw->was_cancelled());
+    EXPECT_LT(raw->chunks_loaded(), 10);
+}
+
+// Test that translator completes without cancellation
+TEST(LoadCancellationTranslator, CompletesWithoutCancellation) {
+    auto translator = std::make_unique<SlowChunkTranslator>(
+        5, std::chrono::milliseconds(10), "complete_translator");
+    auto* raw = translator.get();
+    folly::CancellationSource source;
+    OpContext op_ctx(source.getToken());
+    std::vector<cachinglayer::cid_t> cids = {0, 1, 2, 3, 4};
+    EXPECT_NO_THROW(raw->get_cells(&op_ctx, cids));
+    EXPECT_EQ(raw->chunks_loaded(), 5);
+    EXPECT_FALSE(raw->was_cancelled());
+}
+
+// Test that translator works with null context
+TEST(LoadCancellationTranslator, WorksWithNullContext) {
+    auto translator = std::make_unique<SlowChunkTranslator>(
+        3, std::chrono::milliseconds(5), "null_ctx_translator");
+    auto* raw = translator.get();
+    std::vector<cachinglayer::cid_t> cids = {0, 1, 2};
+    EXPECT_NO_THROW(raw->get_cells(nullptr, cids));
+    EXPECT_EQ(raw->chunks_loaded(), 3);
+    EXPECT_FALSE(raw->was_cancelled());
+}
+
+// Test cancellation before load starts
+TEST(LoadCancellationTranslator, CancellationBeforeLoad) {
+    auto translator = std::make_unique<SlowChunkTranslator>(
+        5, std::chrono::milliseconds(10), "pre_cancel_translator");
+    auto* raw = translator.get();
+    folly::CancellationSource source;
+    source.requestCancellation();
+    OpContext op_ctx(source.getToken());
+    std::vector<cachinglayer::cid_t> cids = {0, 1, 2, 3, 4};
+    EXPECT_THROW(raw->get_cells(&op_ctx, cids), SegcoreError);
+    EXPECT_EQ(raw->chunks_loaded(), 0);
+    EXPECT_TRUE(raw->was_cancelled());
+}
+
+// Test cancellation at specific checkpoint
+TEST(LoadCancellationTranslator, CancellationAtMiddleChunk) {
+    auto translator = std::make_unique<SlowChunkTranslator>(
+        10, std::chrono::milliseconds(20), "middle_cancel_translator");
+    auto* raw = translator.get();
+    folly::CancellationSource source;
+    OpContext op_ctx(source.getToken());
+    std::atomic<bool> started{false};
+    std::thread load_thread([&]() {
+        started = true;
+        try {
+            std::vector<cachinglayer::cid_t> cids = {
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+            raw->get_cells(&op_ctx, cids);
+        } catch (const SegcoreError& e) {
+            EXPECT_EQ(e.get_error_code(), ErrorCode::FollyCancel);
+        }
+    });
+    // Wait for load to start
+    while (!started) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    // Wait for approximately 3 chunks to load then cancel
+    std::this_thread::sleep_for(std::chrono::milliseconds(70));
+    source.requestCancellation();
+    load_thread.join();
+    EXPECT_TRUE(raw->was_cancelled());
+    // Should have loaded some chunks but not all
+    EXPECT_GT(raw->chunks_loaded(), 0);
+    EXPECT_LT(raw->chunks_loaded(), 10);
+}

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -36,6 +36,7 @@
 #include "nlohmann/json.hpp"
 #include "query/PlanNode.h"
 #include "query/SearchOnSealed.h"
+#include "segcore/Utils.h"
 #include "segcore/SegmentGrowingImpl.h"
 #include "segcore/SegmentGrowing.h"
 #include "segcore/Utils.h"
@@ -629,7 +630,10 @@ SegmentGrowingImpl::Insert(int64_t reserved_offset,
 }
 
 void
-SegmentGrowingImpl::LoadFieldData(const LoadFieldDataInfo& infos) {
+SegmentGrowingImpl::LoadFieldData(const LoadFieldDataInfo& infos,
+                                  milvus::OpContext* op_ctx) {
+    // Note: op_ctx is currently unused in growing segments but kept for interface consistency
+    (void)op_ctx;
     switch (infos.storage_version) {
         case 2:
             load_column_group_data_internal(infos);
@@ -1773,7 +1777,11 @@ SegmentGrowingImpl::mask_with_timestamps(BitsetTypeView& bitset_chunk,
 }
 
 void
-SegmentGrowingImpl::CreateTextIndex(FieldId field_id) {
+SegmentGrowingImpl::CreateTextIndex(FieldId field_id,
+                                    milvus::OpContext* op_ctx) {
+    // Check for cancellation before starting
+    CheckCancellation(op_ctx, id_, field_id.get(), "SegmentGrowingImpl::CreateTextIndex()");
+
     std::unique_lock lock(mutex_);
     const auto& field_meta = schema_->operator[](field_id);
     AssertInfo(IsStringDataType(field_meta.get_data_type()),
@@ -1893,7 +1901,8 @@ SegmentGrowingImpl::Reopen(
 }
 
 void
-SegmentGrowingImpl::Load(milvus::tracer::TraceContext& trace_ctx) {
+SegmentGrowingImpl::Load(milvus::tracer::TraceContext& trace_ctx,
+                         milvus::OpContext* op_ctx) {
     // Convert load_info_ (SegmentLoadInfo) to LoadFieldDataInfo
     LoadFieldDataInfo field_data_info;
 

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -39,7 +39,6 @@
 #include "segcore/Utils.h"
 #include "segcore/SegmentGrowingImpl.h"
 #include "segcore/SegmentGrowing.h"
-#include "segcore/Utils.h"
 #include "segcore/memory_planner.h"
 #include "storage/RemoteChunkManagerSingleton.h"
 #include "storage/loon_ffi/property_singleton.h"
@@ -1780,7 +1779,8 @@ void
 SegmentGrowingImpl::CreateTextIndex(FieldId field_id,
                                     milvus::OpContext* op_ctx) {
     // Check for cancellation before starting
-    CheckCancellation(op_ctx, id_, field_id.get(), "SegmentGrowingImpl::CreateTextIndex()");
+    CheckCancellation(
+        op_ctx, id_, field_id.get(), "SegmentGrowingImpl::CreateTextIndex()");
 
     std::unique_lock lock(mutex_);
     const auto& field_meta = schema_->operator[](field_id);

--- a/internal/core/src/segcore/SegmentGrowingImpl.h
+++ b/internal/core/src/segcore/SegmentGrowingImpl.h
@@ -70,7 +70,8 @@ class SegmentGrowingImpl : public SegmentGrowing {
     LoadDeletedRecord(const LoadDeletedRecordInfo& info) override;
 
     void
-    LoadFieldData(const LoadFieldDataInfo& info) override;
+    LoadFieldData(const LoadFieldDataInfo& info,
+                  milvus::OpContext* op_ctx = nullptr) override;
 
     int64_t
     get_segment_id() const override {
@@ -86,7 +87,8 @@ class SegmentGrowingImpl : public SegmentGrowing {
     };
 
     void
-    CreateTextIndex(FieldId field_id) override;
+    CreateTextIndex(FieldId field_id,
+                    milvus::OpContext* op_ctx = nullptr) override;
 
     void
     load_field_data_internal(const LoadFieldDataInfo& load_info);
@@ -115,7 +117,8 @@ class SegmentGrowingImpl : public SegmentGrowing {
     FinishLoad() override;
 
     void
-    Load(milvus::tracer::TraceContext& trace_ctx) override;
+    Load(milvus::tracer::TraceContext& trace_ctx,
+         milvus::OpContext* op_ctx = nullptr) override;
 
  private:
     // Build geometry cache for inserted data

--- a/internal/core/src/segcore/SegmentInterface.h
+++ b/internal/core/src/segcore/SegmentInterface.h
@@ -158,7 +158,8 @@ class SegmentInterface {
     LoadDeletedRecord(const LoadDeletedRecordInfo& info) = 0;
 
     virtual void
-    LoadFieldData(const LoadFieldDataInfo& info) = 0;
+    LoadFieldData(const LoadFieldDataInfo& info,
+                  milvus::OpContext* op_ctx = nullptr) = 0;
 
     virtual int64_t
     get_segment_id() const = 0;
@@ -176,7 +177,7 @@ class SegmentInterface {
     is_nullable(FieldId field_id) const = 0;
 
     virtual void
-    CreateTextIndex(FieldId field_id) = 0;
+    CreateTextIndex(FieldId field_id, milvus::OpContext* op_ctx = nullptr) = 0;
 
     virtual PinWrapper<index::TextMatchIndex*>
     GetTextIndex(milvus::OpContext* op_ctx, FieldId field_id) const = 0;
@@ -240,7 +241,8 @@ class SegmentInterface {
     SetLoadInfo(const milvus::proto::segcore::SegmentLoadInfo& load_info) = 0;
 
     virtual void
-    Load(milvus::tracer::TraceContext& trace_ctx) = 0;
+    Load(milvus::tracer::TraceContext& trace_ctx,
+         milvus::OpContext* op_ctx = nullptr) = 0;
 
     // Get IArrayOffsets for element-level filtering on array fields
     // Returns nullptr if the field doesn't have IArrayOffsets

--- a/internal/core/src/segcore/SegmentSealed.h
+++ b/internal/core/src/segcore/SegmentSealed.h
@@ -57,8 +57,9 @@ class SegmentSealed : public SegmentInternalInterface {
                int64_t count) const = 0;
 
     virtual void
-    LoadTextIndex(std::unique_ptr<milvus::proto::indexcgo::LoadTextIndexInfo>
-                      info_proto) = 0;
+    LoadTextIndex(
+        std::unique_ptr<milvus::proto::indexcgo::LoadTextIndexInfo> info_proto,
+        milvus::OpContext* op_ctx = nullptr) = 0;
 
     virtual InsertRecord<true>&
     get_insert_record() = 0;

--- a/internal/core/src/segcore/Utils.cpp
+++ b/internal/core/src/segcore/Utils.cpp
@@ -1313,7 +1313,8 @@ getCellDataType(bool is_vector, bool is_index) {
 
 void
 LoadIndexData(milvus::tracer::TraceContext& ctx,
-              milvus::segcore::LoadIndexInfo* load_index_info) {
+              milvus::segcore::LoadIndexInfo* load_index_info,
+              milvus::OpContext* op_ctx) {
     auto& index_params = load_index_info->index_params;
     auto field_type = load_index_info->field_type;
     auto engine_version = load_index_info->index_engine_version;
@@ -1420,7 +1421,7 @@ LoadIndexData(milvus::tracer::TraceContext& ctx,
 
     load_index_info->cache_index =
         milvus::cachinglayer::Manager::GetInstance().CreateCacheSlot(
-            std::move(translator));
+            std::move(translator), op_ctx);
 }
 
 FieldDataPtr

--- a/internal/core/src/segcore/Utils.h
+++ b/internal/core/src/segcore/Utils.h
@@ -189,7 +189,8 @@ getCellDataType(bool is_vector, bool is_index);
 
 void
 LoadIndexData(milvus::tracer::TraceContext& ctx,
-              milvus::segcore::LoadIndexInfo* load_index_info);
+              milvus::segcore::LoadIndexInfo* load_index_info,
+              milvus::OpContext* op_ctx = nullptr);
 
 /**
  * Convert Milvus timestamp to physical time in milliseconds.
@@ -214,4 +215,49 @@ bulk_script_field_data(milvus::OpContext* op_ctx,
                        const segcore::SegmentInternalInterface* segment,
                        TargetBitmap& valid_view,
                        bool small_int_raw_type = false);
+
+/**
+ * @brief Check if an operation has been cancelled and throw if so.
+ *
+ * This is a helper function to reduce boilerplate cancellation checking code.
+ *
+ * @param op_ctx The operation context containing the cancellation token (can be nullptr)
+ * @param segment_id The segment ID for error message context
+ * @param operation Description of the operation being performed
+ * @throws SegcoreError with ErrorCode::FollyCancel if cancellation was requested
+ */
+inline void
+CheckCancellation(milvus::OpContext* op_ctx,
+                  int64_t segment_id,
+                  const std::string& operation) {
+    if (op_ctx && op_ctx->cancellation_token.isCancellationRequested()) {
+        throw SegcoreError(
+            ErrorCode::FollyCancel,
+            fmt::format("{} cancelled for segment {}", operation, segment_id));
+    }
+}
+
+/**
+ * @brief Check if an operation has been cancelled and throw if so (with field context).
+ *
+ * @param op_ctx The operation context containing the cancellation token (can be nullptr)
+ * @param segment_id The segment ID for error message context
+ * @param field_id The field ID for error message context
+ * @param operation Description of the operation being performed
+ * @throws SegcoreError with ErrorCode::FollyCancel if cancellation was requested
+ */
+inline void
+CheckCancellation(milvus::OpContext* op_ctx,
+                  int64_t segment_id,
+                  int64_t field_id,
+                  const std::string& operation) {
+    if (op_ctx && op_ctx->cancellation_token.isCancellationRequested()) {
+        throw SegcoreError(ErrorCode::FollyCancel,
+                           fmt::format("{} cancelled for segment {} field {}",
+                                       operation,
+                                       segment_id,
+                                       field_id));
+    }
+}
+
 }  // namespace milvus::segcore

--- a/internal/core/src/segcore/segcore_init_c.cpp
+++ b/internal/core/src/segcore/segcore_init_c.cpp
@@ -10,6 +10,7 @@
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
 #include "pthread.h"
+#include <chrono>
 #include "config/ConfigKnowhere.h"
 #include "fmt/core.h"
 #include "log/Log.h"
@@ -218,7 +219,8 @@ ConfigureTieredStorage(const CacheWarmupPolicy scalarFieldCacheWarmupPolicy,
                        const float overloaded_memory_threshold_percentage,
                        const float loading_resource_factor,
                        const float max_disk_usage_percentage,
-                       const char* disk_path) {
+                       const char* disk_path,
+                       const int64_t loading_timeout_ms) {
     std::string disk_path_str(disk_path);
     milvus::cachinglayer::Manager::ConfigureTieredStorage(
         {scalarFieldCacheWarmupPolicy,
@@ -240,7 +242,8 @@ ConfigureTieredStorage(const CacheWarmupPolicy scalarFieldCacheWarmupPolicy,
          overloaded_memory_threshold_percentage,
          max_disk_usage_percentage,
          disk_path_str,
-         loading_resource_factor});
+         loading_resource_factor},
+        std::chrono::milliseconds(loading_timeout_ms));
 }
 
 }  // namespace milvus::segcore

--- a/internal/core/src/segcore/segcore_init_c.h
+++ b/internal/core/src/segcore/segcore_init_c.h
@@ -124,7 +124,8 @@ ConfigureTieredStorage(
     const float overloaded_memory_threshold_percentage,
     const float loading_resource_factor,
     const float max_disk_usage_percentage,
-    const char* disk_path);
+    const char* disk_path,
+    const int64_t loading_timeout_ms);
 
 #ifdef __cplusplus
 }

--- a/internal/core/src/segcore/segment_c.cpp
+++ b/internal/core/src/segcore/segment_c.cpp
@@ -21,6 +21,7 @@
 
 #include "common/FieldData.h"
 #include "common/LoadInfo.h"
+#include "common/OpContext.h"
 #include "common/Types.h"
 #include "common/Tracer.h"
 #include "common/type_c.h"
@@ -161,17 +162,46 @@ ReopenSegment(CTraceContext c_trace,
     }
 }
 
+CLoadCancellationSource
+NewLoadCancellationSource() {
+    return new folly::CancellationSource();
+}
+
+void
+CancelLoadCancellationSource(CLoadCancellationSource source) {
+    if (source) {
+        static_cast<folly::CancellationSource*>(source)->requestCancellation();
+    }
+}
+
+void
+ReleaseLoadCancellationSource(CLoadCancellationSource source) {
+    delete static_cast<folly::CancellationSource*>(source);
+}
+
 CStatus
-SegmentLoad(CTraceContext c_trace, CSegmentInterface c_segment) {
+SegmentLoad(CTraceContext c_trace,
+            CSegmentInterface c_segment,
+            CLoadCancellationSource source) {
     SCOPE_CGO_CALL_METRIC();
 
     try {
         auto segment =
             static_cast<milvus::segcore::SegmentInterface*>(c_segment);
-        // TODO unify trace context to op context after supported
         auto trace_ctx = milvus::tracer::TraceContext{
             c_trace.traceID, c_trace.spanID, c_trace.traceFlags};
-        segment->Load(trace_ctx);
+
+        if (source) {
+            // Create OpContext with cancellation token from source
+            auto cancellation_source =
+                static_cast<folly::CancellationSource*>(source);
+            milvus::OpContext op_ctx(cancellation_source->getToken());
+            segment->Load(trace_ctx, &op_ctx);
+        } else {
+            // No cancellation source
+            segment->Load(trace_ctx, nullptr);
+        }
+
         return milvus::SuccessCStatus();
     } catch (std::exception& e) {
         return milvus::FailureCStatus(&e);
@@ -544,7 +574,8 @@ UpdateSealedSegmentIndex(CSegmentInterface c_segment,
 CStatus
 LoadTextIndex(CSegmentInterface c_segment,
               const uint8_t* serialized_load_text_index_info,
-              const uint64_t len) {
+              const uint64_t len,
+              CLoadCancellationSource source) {
     SCOPE_CGO_CALL_METRIC();
 
     try {
@@ -558,7 +589,14 @@ LoadTextIndex(CSegmentInterface c_segment,
             std::make_unique<milvus::proto::indexcgo::LoadTextIndexInfo>();
         info_proto->ParseFromArray(serialized_load_text_index_info, len);
 
-        segment->LoadTextIndex(std::move(info_proto));
+        if (source) {
+            auto cancellation_source =
+                static_cast<folly::CancellationSource*>(source);
+            milvus::OpContext op_ctx(cancellation_source->getToken());
+            segment->LoadTextIndex(std::move(info_proto), &op_ctx);
+        } else {
+            segment->LoadTextIndex(std::move(info_proto), nullptr);
+        }
         return milvus::SuccessCStatus();
     } catch (std::exception& e) {
         return milvus::FailureCStatus(&e);
@@ -569,7 +607,8 @@ CStatus
 LoadJsonKeyIndex(CTraceContext c_trace,
                  CSegmentInterface c_segment,
                  const uint8_t* serialized_load_json_key_index_info,
-                 const uint64_t len) {
+                 const uint64_t len,
+                 CLoadCancellationSource source) {
     SCOPE_CGO_CALL_METRIC();
 
     try {
@@ -580,6 +619,18 @@ LoadJsonKeyIndex(CTraceContext c_trace,
         auto segment =
             dynamic_cast<milvus::segcore::SegmentSealed*>(segment_interface);
         AssertInfo(segment != nullptr, "segment conversion failed");
+
+        // Check for cancellation before starting
+        if (source) {
+            auto cancellation_source =
+                static_cast<folly::CancellationSource*>(source);
+            if (cancellation_source->getToken().isCancellationRequested()) {
+                throw milvus::SegcoreError(
+                    milvus::ErrorCode::FollyCancel,
+                    fmt::format("Load cancelled for segment {} json stats",
+                                segment->get_segment_id()));
+            }
+        }
 
         auto info_proto =
             std::make_unique<milvus::proto::indexcgo::LoadJsonKeyIndexInfo>();
@@ -616,6 +667,18 @@ LoadJsonKeyIndex(CTraceContext c_trace,
 
         milvus::storage::FileManagerContext file_ctx(
             field_meta, index_meta, remote_chunk_manager, fs);
+
+        // Check for cancellation before loading
+        if (source) {
+            auto cancellation_source =
+                static_cast<folly::CancellationSource*>(source);
+            if (cancellation_source->getToken().isCancellationRequested()) {
+                throw milvus::SegcoreError(
+                    milvus::ErrorCode::FollyCancel,
+                    fmt::format("Load cancelled for segment {} json stats",
+                                segment->get_segment_id()));
+            }
+        }
 
         auto index =
             std::make_shared<milvus::index::JsonKeyStats>(file_ctx, true);
@@ -744,13 +807,24 @@ RemoveFieldFile(CSegmentInterface c_segment, int64_t field_id) {
 }
 
 CStatus
-CreateTextIndex(CSegmentInterface c_segment, int64_t field_id) {
+CreateTextIndex(CSegmentInterface c_segment,
+                int64_t field_id,
+                CLoadCancellationSource source) {
     SCOPE_CGO_CALL_METRIC();
 
     try {
         auto segment_interface =
             reinterpret_cast<milvus::segcore::SegmentInterface*>(c_segment);
-        segment_interface->CreateTextIndex(milvus::FieldId(field_id));
+        if (source) {
+            auto cancellation_source =
+                static_cast<folly::CancellationSource*>(source);
+            milvus::OpContext op_ctx(cancellation_source->getToken());
+            segment_interface->CreateTextIndex(milvus::FieldId(field_id),
+                                               &op_ctx);
+        } else {
+            segment_interface->CreateTextIndex(milvus::FieldId(field_id),
+                                               nullptr);
+        }
         return milvus::SuccessCStatus();
     } catch (std::exception& e) {
         return milvus::FailureCStatus(milvus::UnexpectedError, e.what());

--- a/internal/core/src/segcore/segment_c.cpp
+++ b/internal/core/src/segcore/segment_c.cpp
@@ -668,18 +668,6 @@ LoadJsonKeyIndex(CTraceContext c_trace,
         milvus::storage::FileManagerContext file_ctx(
             field_meta, index_meta, remote_chunk_manager, fs);
 
-        // Check for cancellation before loading
-        if (source) {
-            auto cancellation_source =
-                static_cast<folly::CancellationSource*>(source);
-            if (cancellation_source->getToken().isCancellationRequested()) {
-                throw milvus::SegcoreError(
-                    milvus::ErrorCode::FollyCancel,
-                    fmt::format("Load cancelled for segment {} json stats",
-                                segment->get_segment_id()));
-            }
-        }
-
         auto index =
             std::make_shared<milvus::index::JsonKeyStats>(file_ctx, true);
         {

--- a/internal/core/src/segcore/segment_c.h
+++ b/internal/core/src/segcore/segment_c.h
@@ -66,8 +66,43 @@ NewSegmentWithLoadInfo(CCollection collection,
  * @param c_segment: segment handle indicate which segment to load
  * @return CStatus indicating success or failure
  */
+/**
+ * @brief Opaque handle to a cancellation source for load operations
+ */
+typedef void* CLoadCancellationSource;
+
+/**
+ * @brief Create a new cancellation source for load operations
+ * @return Handle to the cancellation source
+ */
+CLoadCancellationSource
+NewLoadCancellationSource();
+
+/**
+ * @brief Request cancellation through the source
+ * @param source: The cancellation source handle
+ */
+void
+CancelLoadCancellationSource(CLoadCancellationSource source);
+
+/**
+ * @brief Release the cancellation source
+ * @param source: The cancellation source handle to release
+ */
+void
+ReleaseLoadCancellationSource(CLoadCancellationSource source);
+
+/**
+ * @brief Load segment with cancellation support
+ * @param c_trace: tracing context param
+ * @param c_segment: segment handle indicate which segment to load
+ * @param source: cancellation source for cancelling the load operation (can be NULL)
+ * @return CStatus indicating success or failure
+ */
 CStatus
-SegmentLoad(CTraceContext c_trace, CSegmentInterface c_segment);
+SegmentLoad(CTraceContext c_trace,
+            CSegmentInterface c_segment,
+            CLoadCancellationSource source);
 
 /**
  * @brief Reopen an existing segment with updated load information
@@ -175,13 +210,15 @@ UpdateSealedSegmentIndex(CSegmentInterface c_segment,
 CStatus
 LoadTextIndex(CSegmentInterface c_segment,
               const uint8_t* serialized_load_text_index_info,
-              const uint64_t len);
+              const uint64_t len,
+              CLoadCancellationSource source);
 
 CStatus
 LoadJsonKeyIndex(CTraceContext c_trace,
                  CSegmentInterface c_segment,
                  const uint8_t* serialied_load_json_key_index_info,
-                 const uint64_t len);
+                 const uint64_t len,
+                 CLoadCancellationSource source);
 
 CStatus
 UpdateFieldRawDataSize(CSegmentInterface c_segment,
@@ -224,7 +261,9 @@ void
 RemoveFieldFile(CSegmentInterface c_segment, int64_t field_id);
 
 CStatus
-CreateTextIndex(CSegmentInterface c_segment, int64_t field_id);
+CreateTextIndex(CSegmentInterface c_segment,
+                int64_t field_id,
+                CLoadCancellationSource source);
 
 CStatus
 FinishLoad(CSegmentInterface c_segment);

--- a/internal/core/src/segcore/storagev1translator/BsonInvertedIndexTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/BsonInvertedIndexTranslator.cpp
@@ -20,6 +20,7 @@
 
 #include "cachinglayer/CacheSlot.h"
 #include "segcore/Utils.h"
+#include "segcore/Utils.h"
 #include "monitor/Monitor.h"
 #include "common/ScopedTimer.h"
 #include "log/Log.h"
@@ -85,7 +86,12 @@ BsonInvertedIndexTranslator::key() const {
 std::vector<std::pair<milvus::cachinglayer::cid_t,
                       std::unique_ptr<milvus::index::BsonInvertedIndex>>>
 BsonInvertedIndexTranslator::get_cells(
-    const std::vector<milvus::cachinglayer::cid_t>&) {
+    milvus::OpContext* ctx,
+    const std::vector<milvus::cachinglayer::cid_t>& cids) {
+    // Check for cancellation before loading BSON inverted index
+    CheckCancellation(
+        ctx, load_info_.segment_id, "BsonInvertedIndexTranslator::get_cells()");
+
     auto index =
         std::make_unique<milvus::index::BsonInvertedIndex>(disk_file_manager_);
 

--- a/internal/core/src/segcore/storagev1translator/BsonInvertedIndexTranslator.h
+++ b/internal/core/src/segcore/storagev1translator/BsonInvertedIndexTranslator.h
@@ -64,7 +64,8 @@ class BsonInvertedIndexTranslator : public milvus::cachinglayer::Translator<
 
     std::vector<std::pair<milvus::cachinglayer::cid_t,
                           std::unique_ptr<milvus::index::BsonInvertedIndex>>>
-    get_cells(const std::vector<milvus::cachinglayer::cid_t>& cids) override;
+    get_cells(milvus::OpContext* ctx,
+              const std::vector<milvus::cachinglayer::cid_t>& cids) override;
 
     milvus::cachinglayer::Meta*
     meta() override;

--- a/internal/core/src/segcore/storagev1translator/ChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/ChunkTranslator.cpp
@@ -178,7 +178,8 @@ ChunkTranslator::get_cells(
 
     for (auto cid : cids) {
         // Check for cancellation before processing each chunk
-        CheckCancellation(ctx, segment_id_, field_id_, "ChunkTranslator::get_cells()");
+        CheckCancellation(
+            ctx, segment_id_, field_id_, "ChunkTranslator::get_cells()");
 
         std::unique_ptr<milvus::Chunk> chunk = nullptr;
         if (!use_mmap_) {

--- a/internal/core/src/segcore/storagev1translator/ChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/ChunkTranslator.cpp
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include "cachinglayer/Utils.h"
+#include "segcore/Utils.h"
 #include "common/ChunkWriter.h"
 #include "common/EasyAssert.h"
 #include "common/Types.h"
@@ -151,6 +152,7 @@ ChunkTranslator::key() const {
 std::vector<
     std::pair<milvus::cachinglayer::cid_t, std::unique_ptr<milvus::Chunk>>>
 ChunkTranslator::get_cells(
+    milvus::OpContext* ctx,
     const std::vector<milvus::cachinglayer::cid_t>& cids) {
     std::vector<
         std::pair<milvus::cachinglayer::cid_t, std::unique_ptr<milvus::Chunk>>>
@@ -175,6 +177,9 @@ ChunkTranslator::get_cells(
     auto data_type = field_meta_.get_data_type();
 
     for (auto cid : cids) {
+        // Check for cancellation before processing each chunk
+        CheckCancellation(ctx, segment_id_, field_id_, "ChunkTranslator::get_cells()");
+
         std::unique_ptr<milvus::Chunk> chunk = nullptr;
         if (!use_mmap_) {
             std::shared_ptr<milvus::ArrowDataWrapper> r;

--- a/internal/core/src/segcore/storagev1translator/ChunkTranslator.h
+++ b/internal/core/src/segcore/storagev1translator/ChunkTranslator.h
@@ -78,7 +78,8 @@ class ChunkTranslator : public milvus::cachinglayer::Translator<milvus::Chunk> {
     key() const override;
     std::vector<
         std::pair<milvus::cachinglayer::cid_t, std::unique_ptr<milvus::Chunk>>>
-    get_cells(const std::vector<milvus::cachinglayer::cid_t>& cids) override;
+    get_cells(milvus::OpContext* ctx,
+              const std::vector<milvus::cachinglayer::cid_t>& cids) override;
 
     milvus::cachinglayer::Meta*
     meta() override {

--- a/internal/core/src/segcore/storagev1translator/DefaultValueChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/DefaultValueChunkTranslator.cpp
@@ -14,6 +14,7 @@
 #include "common/ChunkWriter.h"
 #include "common/Types.h"
 #include "segcore/Utils.h"
+#include "segcore/Utils.h"
 #include "storage/Util.h"
 
 namespace milvus::segcore::storagev1translator {
@@ -229,6 +230,7 @@ DefaultValueChunkTranslator::key() const {
 std::vector<
     std::pair<milvus::cachinglayer::cid_t, std::unique_ptr<milvus::Chunk>>>
 DefaultValueChunkTranslator::get_cells(
+    milvus::OpContext* ctx,
     const std::vector<milvus::cachinglayer::cid_t>& cids) {
     AssertInfo(primary_buffer_.has_value(),
                "primary buffer is not initialized");

--- a/internal/core/src/segcore/storagev1translator/DefaultValueChunkTranslator.h
+++ b/internal/core/src/segcore/storagev1translator/DefaultValueChunkTranslator.h
@@ -48,7 +48,8 @@ class DefaultValueChunkTranslator
     key() const override;
     std::vector<
         std::pair<milvus::cachinglayer::cid_t, std::unique_ptr<milvus::Chunk>>>
-    get_cells(const std::vector<milvus::cachinglayer::cid_t>& cids) override;
+    get_cells(milvus::OpContext* ctx,
+              const std::vector<milvus::cachinglayer::cid_t>& cids) override;
 
     milvus::cachinglayer::Meta*
     meta() override {

--- a/internal/core/src/segcore/storagev1translator/DefaultValueChunkTranslatorTest.cpp
+++ b/internal/core/src/segcore/storagev1translator/DefaultValueChunkTranslatorTest.cpp
@@ -92,7 +92,7 @@ TEST_P(DefaultValueChunkTranslatorTest, TestInt64WithDefaultValue) {
 
     // Test get_cells
     std::vector<cachinglayer::cid_t> cids = {0};
-    auto cells = translator->get_cells(cids);
+    auto cells = translator->get_cells(nullptr, cids);
     EXPECT_EQ(cells.size(), 1);
 
     auto& [cid, chunk] = cells[0];
@@ -130,7 +130,7 @@ TEST_P(DefaultValueChunkTranslatorTest, TestInt64WithoutDefaultValue) {
     EXPECT_GT(translator->num_cells(), 0);
 
     std::vector<cachinglayer::cid_t> cids = {0};
-    auto cells = translator->get_cells(cids);
+    auto cells = translator->get_cells(nullptr, cids);
     EXPECT_EQ(cells.size(), 1);
 
     auto& [cid, chunk] = cells[0];
@@ -242,7 +242,7 @@ TEST_P(DefaultValueChunkTranslatorTest, TestStringWithDefaultValue) {
     EXPECT_GT(translator->value_size(), 0);
 
     std::vector<cachinglayer::cid_t> cids = {0};
-    auto cells = translator->get_cells(cids);
+    auto cells = translator->get_cells(nullptr, cids);
     EXPECT_EQ(cells.size(), 1);
 
     auto& [cid, chunk] = cells[0];
@@ -274,7 +274,7 @@ TEST_P(DefaultValueChunkTranslatorTest, TestStringWithoutDefaultValue) {
     EXPECT_GT(translator->num_cells(), 0);
 
     std::vector<cachinglayer::cid_t> cids = {0};
-    auto cells = translator->get_cells(cids);
+    auto cells = translator->get_cells(nullptr, cids);
     EXPECT_EQ(cells.size(), 1);
 
     auto& [cid, chunk] = cells[0];
@@ -317,7 +317,7 @@ TEST_P(DefaultValueChunkTranslatorTest, TestMultipleCells) {
         cids.push_back(i);
     }
 
-    auto cells = translator->get_cells(cids);
+    auto cells = translator->get_cells(nullptr, cids);
     EXPECT_EQ(cells.size(), cids.size());
 
     int64_t total_rows = 0;
@@ -359,7 +359,7 @@ TEST_P(DefaultValueChunkTranslatorTest, TestSmallRowCount) {
     EXPECT_EQ(translator->num_cells(), 1);
 
     std::vector<cachinglayer::cid_t> cids = {0};
-    auto cells = translator->get_cells(cids);
+    auto cells = translator->get_cells(nullptr, cids);
     EXPECT_EQ(cells.size(), 1);
 
     auto& [cid, chunk] = cells[0];
@@ -417,7 +417,7 @@ TEST_P(DefaultValueChunkTranslatorTest, TestGetMultipleCells) {
             cids.push_back(i);
         }
 
-        auto cells = translator->get_cells(cids);
+        auto cells = translator->get_cells(nullptr, cids);
         EXPECT_EQ(cells.size(), cids.size());
 
         for (size_t i = 0; i < cells.size(); ++i) {
@@ -504,7 +504,7 @@ TEST_P(DefaultValueChunkTranslatorTest, TestTimestamptzType) {
     EXPECT_EQ(translator->value_size(), sizeof(int64_t));
 
     std::vector<cachinglayer::cid_t> cids = {0};
-    auto cells = translator->get_cells(cids);
+    auto cells = translator->get_cells(nullptr, cids);
     EXPECT_EQ(cells.size(), 1);
 
     auto& [cid, chunk] = cells[0];
@@ -626,7 +626,7 @@ TEST_F(DefaultValueChunkTranslatorMmapTest, TestMmapCreatesFile) {
 
     // Trigger cell creation
     std::vector<cachinglayer::cid_t> cids = {0};
-    auto cells = translator->get_cells(cids);
+    auto cells = translator->get_cells(nullptr, cids);
     ASSERT_EQ(cells.size(), 1);
 
     // Verify file was created
@@ -670,7 +670,7 @@ TEST_F(DefaultValueChunkTranslatorMmapTest, TestNoMmapNoFile) {
 
     // Trigger cell creation
     std::vector<cachinglayer::cid_t> cids = {0};
-    auto cells = translator->get_cells(cids);
+    auto cells = translator->get_cells(nullptr, cids);
     ASSERT_EQ(cells.size(), 1);
 
     // Verify no file was created (memory-only mode)
@@ -713,7 +713,7 @@ TEST_F(DefaultValueChunkTranslatorMmapTest, TestMmapWithString) {
         segment_id_, field_meta, field_data_info, true /* use_mmap */, true);
 
     std::vector<cachinglayer::cid_t> cids = {0};
-    auto cells = translator->get_cells(cids);
+    auto cells = translator->get_cells(nullptr, cids);
     ASSERT_EQ(cells.size(), 1);
 
     // Verify file was created
@@ -750,7 +750,7 @@ TEST_F(DefaultValueChunkTranslatorMmapTest, TestMmapWithNullableField) {
         segment_id_, field_meta, field_data_info, true /* use_mmap */, true);
 
     std::vector<cachinglayer::cid_t> cids = {0};
-    auto cells = translator->get_cells(cids);
+    auto cells = translator->get_cells(nullptr, cids);
     ASSERT_EQ(cells.size(), 1);
 
     // Verify file was created
@@ -798,7 +798,7 @@ TEST_F(DefaultValueChunkTranslatorMmapTest, TestMmapMultipleCells) {
     for (size_t i = 0; i < std::min<size_t>(3, num_cells); ++i) {
         cids.push_back(i);
     }
-    auto cells = translator->get_cells(cids);
+    auto cells = translator->get_cells(nullptr, cids);
     ASSERT_EQ(cells.size(), cids.size());
 
     // Verify file was created (all cells share the same buffer/file)
@@ -841,7 +841,7 @@ TEST_F(DefaultValueChunkTranslatorMmapTest, TestMmapFileSize) {
         segment_id_, field_meta, field_data_info, true /* use_mmap */, true);
 
     std::vector<cachinglayer::cid_t> cids = {0};
-    auto cells = translator->get_cells(cids);
+    auto cells = translator->get_cells(nullptr, cids);
     ASSERT_EQ(cells.size(), 1);
 
     auto expected_file =

--- a/internal/core/src/segcore/storagev1translator/InterimSealedIndexTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/InterimSealedIndexTranslator.cpp
@@ -1,5 +1,7 @@
 #include "segcore/storagev1translator/InterimSealedIndexTranslator.h"
+
 #include "index/VectorMemIndex.h"
+#include "segcore/Utils.h"
 #include "segcore/Utils.h"
 
 namespace milvus::segcore::storagev1translator {
@@ -89,7 +91,13 @@ InterimSealedIndexTranslator::key() const {
 std::vector<std::pair<milvus::cachinglayer::cid_t,
                       std::unique_ptr<milvus::index::IndexBase>>>
 InterimSealedIndexTranslator::get_cells(
+    milvus::OpContext* ctx,
     const std::vector<milvus::cachinglayer::cid_t>& cids) {
+    // Check for cancellation before building interim index
+    CheckCancellation(ctx,
+                      std::stoll(segment_id_),
+                      "InterimSealedIndexTranslator::get_cells()");
+
     std::unique_ptr<index::VectorIndex> vec_index = nullptr;
     if (!is_sparse_) {
         knowhere::ViewDataOp view_data = [field_raw_data_ptr =

--- a/internal/core/src/segcore/storagev1translator/InterimSealedIndexTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/InterimSealedIndexTranslator.cpp
@@ -8,8 +8,8 @@ namespace milvus::segcore::storagev1translator {
 
 InterimSealedIndexTranslator::InterimSealedIndexTranslator(
     std::shared_ptr<ChunkedColumnInterface> vec_data,
-    std::string segment_id,
-    std::string field_id,
+    int64_t segment_id,
+    int64_t field_id,
     knowhere::IndexType index_type,
     knowhere::MetricType metric_type,
     knowhere::Json build_config,
@@ -17,6 +17,8 @@ InterimSealedIndexTranslator::InterimSealedIndexTranslator(
     bool is_sparse,
     DataType vec_data_type)
     : vec_data_(vec_data),
+      segment_id_(segment_id),
+      field_id_(field_id),
       index_type_(index_type),
       metric_type_(metric_type),
       build_config_(build_config),
@@ -94,9 +96,8 @@ InterimSealedIndexTranslator::get_cells(
     milvus::OpContext* ctx,
     const std::vector<milvus::cachinglayer::cid_t>& cids) {
     // Check for cancellation before building interim index
-    CheckCancellation(ctx,
-                      std::stoll(segment_id_),
-                      "InterimSealedIndexTranslator::get_cells()");
+    CheckCancellation(
+        ctx, segment_id_, "InterimSealedIndexTranslator::get_cells()");
 
     std::unique_ptr<index::VectorIndex> vec_index = nullptr;
     if (!is_sparse_) {

--- a/internal/core/src/segcore/storagev1translator/InterimSealedIndexTranslator.h
+++ b/internal/core/src/segcore/storagev1translator/InterimSealedIndexTranslator.h
@@ -21,8 +21,8 @@ class InterimSealedIndexTranslator
  public:
     InterimSealedIndexTranslator(
         std::shared_ptr<ChunkedColumnInterface> vec_data,
-        std::string segment_id,
-        std::string field_id,
+        int64_t segment_id,
+        int64_t field_id,
         knowhere::IndexType index_type,
         knowhere::MetricType metric_type,
         knowhere::Json build_config,
@@ -53,8 +53,8 @@ class InterimSealedIndexTranslator
 
  private:
     std::shared_ptr<ChunkedColumnInterface> vec_data_;
-    std::string segment_id_;
-    std::string field_id_;
+    int64_t segment_id_;
+    int64_t field_id_;
     knowhere::IndexType index_type_;
     knowhere::MetricType metric_type_;
     knowhere::Json build_config_;

--- a/internal/core/src/segcore/storagev1translator/InterimSealedIndexTranslator.h
+++ b/internal/core/src/segcore/storagev1translator/InterimSealedIndexTranslator.h
@@ -40,7 +40,8 @@ class InterimSealedIndexTranslator
     key() const override;
     std::vector<std::pair<milvus::cachinglayer::cid_t,
                           std::unique_ptr<milvus::index::IndexBase>>>
-    get_cells(const std::vector<milvus::cachinglayer::cid_t>& cids) override;
+    get_cells(milvus::OpContext* ctx,
+              const std::vector<milvus::cachinglayer::cid_t>& cids) override;
     Meta*
     meta() override;
 

--- a/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.h
+++ b/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.h
@@ -37,7 +37,8 @@ class SealedIndexTranslator
     key() const override;
     std::vector<std::pair<milvus::cachinglayer::cid_t,
                           std::unique_ptr<milvus::index::IndexBase>>>
-    get_cells(const std::vector<milvus::cachinglayer::cid_t>& cids) override;
+    get_cells(milvus::OpContext* ctx,
+              const std::vector<milvus::cachinglayer::cid_t>& cids) override;
     Meta*
     meta() override;
 

--- a/internal/core/src/segcore/storagev1translator/TextMatchIndexTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/TextMatchIndexTranslator.cpp
@@ -20,6 +20,7 @@
 
 #include "cachinglayer/CacheSlot.h"
 #include "segcore/Utils.h"
+#include "segcore/Utils.h"
 #include "monitor/Monitor.h"
 #include "common/ScopedTimer.h"
 
@@ -87,7 +88,12 @@ TextMatchIndexTranslator::key() const {
 std::vector<std::pair<milvus::cachinglayer::cid_t,
                       std::unique_ptr<milvus::index::TextMatchIndex>>>
 TextMatchIndexTranslator::get_cells(
-    const std::vector<milvus::cachinglayer::cid_t>&) {
+    milvus::OpContext* ctx,
+    const std::vector<milvus::cachinglayer::cid_t>& cids) {
+    // Check for cancellation before loading text match index
+    CheckCancellation(
+        ctx, load_info_.segment_id, "TextMatchIndexTranslator::get_cells()");
+
     auto index =
         std::make_unique<milvus::index::TextMatchIndex>(file_manager_context_);
 

--- a/internal/core/src/segcore/storagev1translator/TextMatchIndexTranslator.h
+++ b/internal/core/src/segcore/storagev1translator/TextMatchIndexTranslator.h
@@ -63,7 +63,8 @@ class TextMatchIndexTranslator
 
     std::vector<std::pair<milvus::cachinglayer::cid_t,
                           std::unique_ptr<milvus::index::TextMatchIndex>>>
-    get_cells(const std::vector<milvus::cachinglayer::cid_t>& cids) override;
+    get_cells(milvus::OpContext* ctx,
+              const std::vector<milvus::cachinglayer::cid_t>& cids) override;
 
     milvus::cachinglayer::Meta*
     meta() override;

--- a/internal/core/src/segcore/storagev1translator/V1SealedIndexTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/V1SealedIndexTranslator.cpp
@@ -1,8 +1,11 @@
 #include "segcore/storagev1translator/V1SealedIndexTranslator.h"
+
+#include <utility>
+
 #include "index/IndexFactory.h"
+#include "segcore/Utils.h"
 #include "segcore/load_index_c.h"
 #include "segcore/Utils.h"
-#include <utility>
 #include "storage/RemoteChunkManagerSingleton.h"
 
 namespace milvus::segcore::storagev1translator {
@@ -68,7 +71,13 @@ V1SealedIndexTranslator::key() const {
 std::vector<std::pair<milvus::cachinglayer::cid_t,
                       std::unique_ptr<milvus::index::IndexBase>>>
 V1SealedIndexTranslator::get_cells(
+    milvus::OpContext* ctx,
     const std::vector<milvus::cachinglayer::cid_t>& cids) {
+    // Check for cancellation before loading index
+    CheckCancellation(ctx,
+                      index_load_info_.segment_id,
+                      "V1SealedIndexTranslator::get_cells()");
+
     std::vector<std::pair<cid_t, std::unique_ptr<milvus::index::IndexBase>>>
         result;
     if (milvus::IsVectorDataType(index_load_info_.field_type)) {

--- a/internal/core/src/segcore/storagev1translator/V1SealedIndexTranslator.h
+++ b/internal/core/src/segcore/storagev1translator/V1SealedIndexTranslator.h
@@ -36,7 +36,8 @@ class V1SealedIndexTranslator : public Translator<milvus::index::IndexBase> {
     key() const override;
     std::vector<std::pair<milvus::cachinglayer::cid_t,
                           std::unique_ptr<milvus::index::IndexBase>>>
-    get_cells(const std::vector<milvus::cachinglayer::cid_t>& cids) override;
+    get_cells(milvus::OpContext* ctx,
+              const std::vector<milvus::cachinglayer::cid_t>& cids) override;
     Meta*
     meta() override;
 

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
@@ -14,7 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include "segcore/storagev2translator/GroupChunkTranslator.h"
+
 #include "common/type_c.h"
+#include "segcore/Utils.h"
 #include "segcore/storagev2translator/GroupCTMeta.h"
 #include "common/GroupChunk.h"
 #include "mmap/Types.h"
@@ -279,7 +281,11 @@ GroupChunkTranslator::get_global_row_group_idx(size_t file_idx,
 }
 
 std::vector<std::pair<cachinglayer::cid_t, std::unique_ptr<milvus::GroupChunk>>>
-GroupChunkTranslator::get_cells(const std::vector<cachinglayer::cid_t>& cids) {
+GroupChunkTranslator::get_cells(milvus::OpContext* ctx,
+                                const std::vector<cachinglayer::cid_t>& cids) {
+    // Check for cancellation before loading group chunks
+    CheckCancellation(ctx, segment_id_, "GroupChunkTranslator::get_cells()");
+
     std::vector<std::pair<milvus::cachinglayer::cid_t,
                           std::unique_ptr<milvus::GroupChunk>>>
         cells;
@@ -322,7 +328,10 @@ GroupChunkTranslator::get_cells(const std::vector<cachinglayer::cid_t>& cids) {
     auto fs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
                   .GetArrowFileSystem();
 
-    auto load_future = pool.Submit([&]() {
+    auto load_future = pool.Submit([&, ctx]() {
+        // Early exit if cancelled while queued
+        CheckCancellation(
+            ctx, segment_id_, "GroupChunkTranslator::get_cells()");
         return LoadWithStrategy(insert_files_,
                                 channel,
                                 DEFAULT_FIELD_MAX_MEMORY_LIMIT,
@@ -346,6 +355,9 @@ GroupChunkTranslator::get_cells(const std::vector<cachinglayer::cid_t>& cids) {
     // !!! NOTE: the popped row group tables are sorted by the global row group index
     // !!! Never rely on the order of the popped row group tables.
     while (channel->pop(r)) {
+        // Check cancellation while processing results
+        CheckCancellation(
+            ctx, segment_id_, "GroupChunkTranslator::get_cells()");
         for (const auto& table_info : r->arrow_tables) {
             // Convert file_index and row_group_index (file inner index, not global index) to global row group index
             auto rg_idx = get_global_row_group_idx(table_info.file_index,

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.h
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.h
@@ -64,7 +64,8 @@ class GroupChunkTranslator
 
     std::vector<std::pair<milvus::cachinglayer::cid_t,
                           std::unique_ptr<milvus::GroupChunk>>>
-    get_cells(const std::vector<milvus::cachinglayer::cid_t>& cids) override;
+    get_cells(milvus::OpContext* ctx,
+              const std::vector<milvus::cachinglayer::cid_t>& cids) override;
 
     std::pair<size_t, size_t>
     get_file_and_row_group_offset(size_t global_row_group_idx) const;

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslatorTest.cpp
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslatorTest.cpp
@@ -170,7 +170,7 @@ TEST_P(GroupChunkTranslatorTest, TestWithMmap) {
     for (size_t i = 0; i < translator->num_cells(); ++i) {
         cids.push_back(i);
     }
-    auto cells = translator->get_cells(cids);
+    auto cells = translator->get_cells(nullptr, cids);
     EXPECT_EQ(cells.size(), cids.size());
 
     // Test DataByteSize from meta
@@ -315,7 +315,7 @@ TEST_P(GroupChunkTranslatorTest, TestMultipleFiles) {
     for (size_t i = 0; i < std::min(num_cells, static_cast<size_t>(2)); ++i) {
         first_cids.push_back(i);
     }
-    auto first_cells = translator->get_cells(first_cids);
+    auto first_cells = translator->get_cells(nullptr, first_cids);
     EXPECT_EQ(first_cells.size(), first_cids.size());
     int i = 0;
     for (const auto& [cid, chunk] : first_cells) {
@@ -328,7 +328,7 @@ TEST_P(GroupChunkTranslatorTest, TestMultipleFiles) {
     for (size_t j = num_cells; j > 0; --j) {
         reverse_cids.push_back(j - 1);
     }
-    auto cells = translator->get_cells(reverse_cids);
+    auto cells = translator->get_cells(nullptr, reverse_cids);
     // Returned cids should be in the same order as input (reverse order)
     i = 0;
     for (const auto& [cid, chunk] : cells) {

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
@@ -15,7 +15,9 @@
 // limitations under the License.
 
 #include "segcore/storagev2translator/ManifestGroupTranslator.h"
+
 #include "common/type_c.h"
+#include "segcore/Utils.h"
 #include "milvus-storage/reader.h"
 #include "segcore/storagev2translator/GroupCTMeta.h"
 #include "common/GroupChunk.h"
@@ -176,7 +178,11 @@ ManifestGroupTranslator::key() const {
 std::vector<
     std::pair<milvus::cachinglayer::cid_t, std::unique_ptr<milvus::GroupChunk>>>
 ManifestGroupTranslator::get_cells(
+    milvus::OpContext* ctx,
     const std::vector<milvus::cachinglayer::cid_t>& cids) {
+    // Check for cancellation before loading group chunks
+    CheckCancellation(ctx, segment_id_, "ManifestGroupTranslator::get_cells()");
+
     std::vector<std::pair<milvus::cachinglayer::cid_t,
                           std::unique_ptr<milvus::GroupChunk>>>
         cells;

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.h
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.h
@@ -122,7 +122,8 @@ class ManifestGroupTranslator
      */
     std::vector<std::pair<milvus::cachinglayer::cid_t,
                           std::unique_ptr<milvus::GroupChunk>>>
-    get_cells(const std::vector<milvus::cachinglayer::cid_t>& cids) override;
+    get_cells(milvus::OpContext* ctx,
+              const std::vector<milvus::cachinglayer::cid_t>& cids) override;
 
     /**
      * @brief Get the metadata object for this translator

--- a/internal/core/thirdparty/milvus-common/CMakeLists.txt
+++ b/internal/core/thirdparty/milvus-common/CMakeLists.txt
@@ -13,7 +13,7 @@
 
 milvus_add_pkg_config("milvus-common")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( MILVUS-COMMON-VERSION fbe5cf7 )
+set( MILVUS-COMMON-VERSION c37f138 )
 set( GIT_REPOSITORY "https://github.com/zilliztech/milvus-common.git")
 
 message(STATUS "milvus-common repo: ${GIT_REPOSITORY}")

--- a/internal/core/unittest/init_gtest.cpp
+++ b/internal/core/unittest/init_gtest.cpp
@@ -39,7 +39,8 @@ main(int argc, char** argv) {
         {1024 * mb, 1024 * mb, 1024 * mb, 1024 * mb, 1024 * mb, 1024 * mb},
         true,
         true,
-        {10, true, 30});
+        {10, true, 30},
+        std::chrono::milliseconds(0));
 
     return RUN_ALL_TESTS();
 }

--- a/internal/core/unittest/test_utils/cachinglayer_test_utils.h
+++ b/internal/core/unittest/test_utils/cachinglayer_test_utils.h
@@ -93,7 +93,7 @@ class TestChunkTranslator : public Translator<milvus::Chunk> {
     }
 
     std::vector<std::pair<cid_t, std::unique_ptr<milvus::Chunk>>>
-    get_cells(const std::vector<cid_t>& cids) override {
+    get_cells(milvus::OpContext* ctx, const std::vector<cid_t>& cids) override {
         std::vector<std::pair<cid_t, std::unique_ptr<milvus::Chunk>>> res;
         res.reserve(cids.size());
         for (auto cid : cids) {
@@ -169,7 +169,7 @@ class TestGroupChunkTranslator : public Translator<milvus::GroupChunk> {
     }
 
     std::vector<std::pair<cid_t, std::unique_ptr<milvus::GroupChunk>>>
-    get_cells(const std::vector<cid_t>& cids) override {
+    get_cells(milvus::OpContext* ctx, const std::vector<cid_t>& cids) override {
         std::vector<std::pair<cid_t, std::unique_ptr<milvus::GroupChunk>>> res;
         res.reserve(cids.size());
         for (auto cid : cids) {
@@ -234,7 +234,7 @@ class TestIndexTranslator : public Translator<milvus::index::IndexBase> {
     }
 
     std::vector<std::pair<cid_t, std::unique_ptr<milvus::index::IndexBase>>>
-    get_cells(const std::vector<cid_t>& cids) override {
+    get_cells(milvus::OpContext* ctx, const std::vector<cid_t>& cids) override {
         std::vector<std::pair<cid_t, std::unique_ptr<milvus::index::IndexBase>>>
             res;
         res.reserve(cids.size());

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -1221,9 +1221,12 @@ func (s *LocalSegment) LoadTextIndex(ctx context.Context, textLogs *datapb.TextI
 		return err
 	}
 
+	guard := segcore.NewCancellationGuard(ctx)
+	defer guard.Close()
+
 	var status C.CStatus
 	_, _ = GetLoadPool().Submit(func() (any, error) {
-		status = C.LoadTextIndex(s.ptr, (*C.uint8_t)(unsafe.Pointer(&marshaled[0])), (C.uint64_t)(len(marshaled)))
+		status = C.LoadTextIndex(s.ptr, (*C.uint8_t)(unsafe.Pointer(&marshaled[0])), (C.uint64_t)(len(marshaled)), (C.CLoadCancellationSource)(guard.Source()))
 		return nil, nil
 	}).Await()
 
@@ -1278,10 +1281,13 @@ func (s *LocalSegment) LoadJSONKeyIndex(ctx context.Context, jsonKeyStats *datap
 		return err
 	}
 
+	guard := segcore.NewCancellationGuard(ctx)
+	defer guard.Close()
+
 	var status C.CStatus
 	_, _ = GetLoadPool().Submit(func() (any, error) {
 		traceCtx := ParseCTraceContext(ctx)
-		status = C.LoadJsonKeyIndex(traceCtx.ctx, s.ptr, (*C.uint8_t)(unsafe.Pointer(&marshaled[0])), (C.uint64_t)(len(marshaled)))
+		status = C.LoadJsonKeyIndex(traceCtx.ctx, s.ptr, (*C.uint8_t)(unsafe.Pointer(&marshaled[0])), (C.uint64_t)(len(marshaled)), (C.CLoadCancellationSource)(guard.Source()))
 		return nil, nil
 	}).Await()
 
@@ -1356,8 +1362,11 @@ func (s *LocalSegment) CreateTextIndex(ctx context.Context, fieldID int64) error
 	var status C.CStatus
 	log.Ctx(ctx).Info("create text index for segment", zap.Int64("segmentID", s.ID()), zap.Int64("fieldID", fieldID))
 
+	guard := segcore.NewCancellationGuard(ctx)
+	defer guard.Close()
+
 	GetLoadPool().Submit(func() (any, error) {
-		status = C.CreateTextIndex(s.ptr, C.int64_t(fieldID))
+		status = C.CreateTextIndex(s.ptr, C.int64_t(fieldID), (C.CLoadCancellationSource)(guard.Source()))
 		return nil, nil
 	}).Await()
 

--- a/internal/util/initcore/init_core.go
+++ b/internal/util/initcore/init_core.go
@@ -372,6 +372,7 @@ func InitTieredStorage(params *paramtable.ComponentParam) error {
 	evictionIntervalMs := C.int64_t(params.QueryNodeCfg.TieredEvictionIntervalMs.GetAsInt64())
 	cacheCellUnaccessedSurvivalTime := C.int64_t(params.QueryNodeCfg.CacheCellUnaccessedSurvivalTime.GetAsInt64())
 	loadingResourceFactor := C.float(params.QueryNodeCfg.TieredLoadingResourceFactor.GetAsFloat())
+	loadingTimeoutMs := C.int64_t(params.QueryNodeCfg.TieredLoadingTimeoutMs.GetAsInt64())
 	overloadedMemoryThresholdPercentage := C.float(memoryMaxRatio)
 	maxDiskUsagePercentage := C.float(diskMaxRatio)
 	diskPath := C.CString(params.LocalStorageCfg.Path.GetValue())
@@ -386,7 +387,7 @@ func InitTieredStorage(params *paramtable.ComponentParam) error {
 		storageUsageTrackingEnabled,
 		evictionEnabled, cacheTouchWindowMs,
 		backgroundEvictionEnabled, evictionIntervalMs, cacheCellUnaccessedSurvivalTime,
-		overloadedMemoryThresholdPercentage, loadingResourceFactor, maxDiskUsagePercentage, diskPath)
+		overloadedMemoryThresholdPercentage, loadingResourceFactor, maxDiskUsagePercentage, diskPath, loadingTimeoutMs)
 
 	tieredEvictableMemoryCacheRatio := params.QueryNodeCfg.TieredEvictableMemoryCacheRatio.GetAsFloat()
 	tieredEvictableDiskCacheRatio := params.QueryNodeCfg.TieredEvictableDiskCacheRatio.GetAsFloat()

--- a/internal/util/segcore/cancellation.go
+++ b/internal/util/segcore/cancellation.go
@@ -1,0 +1,77 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package segcore
+
+/*
+#cgo pkg-config: milvus_core
+
+#include "segcore/segment_c.h"
+*/
+import "C"
+
+import (
+	"context"
+	"sync"
+	"unsafe"
+)
+
+// CancellationGuard manages a C cancellation source with proper lifecycle management.
+// It monitors context cancellation and propagates it to the C layer, ensuring
+// proper cleanup to prevent use-after-free issues.
+type CancellationGuard struct {
+	source C.CLoadCancellationSource
+	wg     sync.WaitGroup
+	done   chan struct{}
+}
+
+// NewCancellationGuard creates a new CancellationGuard that monitors the provided
+// context for cancellation and propagates it to the C layer.
+func NewCancellationGuard(ctx context.Context) *CancellationGuard {
+	source := C.NewLoadCancellationSource()
+	done := make(chan struct{})
+
+	guard := &CancellationGuard{
+		source: source,
+		done:   done,
+	}
+
+	guard.wg.Add(1)
+	go func() {
+		defer guard.wg.Done()
+		select {
+		case <-ctx.Done():
+			C.CancelLoadCancellationSource(source)
+		case <-done:
+		}
+	}()
+
+	return guard
+}
+
+// Source returns the underlying C cancellation source handle.
+func (g *CancellationGuard) Source() unsafe.Pointer {
+	return unsafe.Pointer(g.source)
+}
+
+// Close releases the cancellation guard resources.
+// It signals the monitoring goroutine to stop and waits for it to complete
+// before releasing the C resources, preventing use-after-free.
+func (g *CancellationGuard) Close() {
+	close(g.done)
+	g.wg.Wait()
+	C.ReleaseLoadCancellationSource(g.source)
+}

--- a/internal/util/segcore/cancellation_test.go
+++ b/internal/util/segcore/cancellation_test.go
@@ -1,0 +1,157 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package segcore
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCancellationGuard_Creation(t *testing.T) {
+	ctx := context.Background()
+	guard := NewCancellationGuard(ctx)
+
+	assert.NotNil(t, guard)
+	assert.NotNil(t, guard.Source())
+
+	guard.Close()
+}
+
+func TestCancellationGuard_SourceNotNil(t *testing.T) {
+	ctx := context.Background()
+	guard := NewCancellationGuard(ctx)
+	defer guard.Close()
+
+	// Source should return a non-nil pointer
+	source := guard.Source()
+	assert.NotNil(t, source)
+}
+
+func TestCancellationGuard_CloseIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	guard := NewCancellationGuard(ctx)
+
+	// Close should be safe to call
+	guard.Close()
+
+	// Note: Calling Close() twice would cause a panic due to closing
+	// a closed channel, so we only test single close here
+}
+
+func TestCancellationGuard_ContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	guard := NewCancellationGuard(ctx)
+
+	// Cancel the context
+	cancel()
+
+	// Give the goroutine time to process the cancellation
+	time.Sleep(10 * time.Millisecond)
+
+	// Close should still work properly after context cancellation
+	guard.Close()
+}
+
+func TestCancellationGuard_CloseBeforeContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	guard := NewCancellationGuard(ctx)
+
+	// Close the guard before context is canceled
+	guard.Close()
+
+	// Context cancel after guard close should not cause issues
+	cancel()
+}
+
+func TestCancellationGuard_ConcurrentAccess(t *testing.T) {
+	ctx := context.Background()
+	guard := NewCancellationGuard(ctx)
+
+	var wg sync.WaitGroup
+	// Multiple goroutines accessing Source() concurrently
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			source := guard.Source()
+			assert.NotNil(t, source)
+		}()
+	}
+
+	wg.Wait()
+	guard.Close()
+}
+
+func TestCancellationGuard_WithTimeout(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	guard := NewCancellationGuard(ctx)
+
+	// Wait for timeout to trigger
+	time.Sleep(100 * time.Millisecond)
+
+	// Close should still work properly after timeout
+	guard.Close()
+}
+
+func TestCancellationGuard_ImmediateClose(t *testing.T) {
+	ctx := context.Background()
+	guard := NewCancellationGuard(ctx)
+
+	// Immediately close after creation
+	guard.Close()
+}
+
+func TestCancellationGuard_MultipleGuards(t *testing.T) {
+	ctx := context.Background()
+
+	// Create multiple guards from the same context
+	guard1 := NewCancellationGuard(ctx)
+	guard2 := NewCancellationGuard(ctx)
+	guard3 := NewCancellationGuard(ctx)
+
+	// Each guard should have its own source
+	assert.NotNil(t, guard1.Source())
+	assert.NotNil(t, guard2.Source())
+	assert.NotNil(t, guard3.Source())
+
+	// Close all guards
+	guard1.Close()
+	guard2.Close()
+	guard3.Close()
+}
+
+func TestCancellationGuard_CancelledContext(t *testing.T) {
+	// Create an already canceled context
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	guard := NewCancellationGuard(ctx)
+
+	// Give the goroutine time to process
+	time.Sleep(10 * time.Millisecond)
+
+	// Should still be able to close properly
+	guard.Close()
+}

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -3283,6 +3283,7 @@ type queryNodeConfig struct {
 	TieredEvictionIntervalMs        ParamItem `refreshable:"false"`
 	CacheCellUnaccessedSurvivalTime ParamItem `refreshable:"false"`
 	TieredLoadingResourceFactor     ParamItem `refreshable:"false"`
+	TieredLoadingTimeoutMs          ParamItem `refreshable:"false"`
 	StorageUsageTrackingEnabled     ParamItem `refreshable:"false"`
 
 	KnowhereScoreConsistency ParamItem `refreshable:"false"`
@@ -3704,6 +3705,23 @@ If set to 0, time based eviction is disabled.`,
 		Export: false,
 	}
 	p.TieredLoadingResourceFactor.Init(base.mgr)
+
+	p.TieredLoadingTimeoutMs = ParamItem{
+		Key:          "queryNode.segcore.tieredStorage.loadingTimeoutMs",
+		Version:      "2.6.10",
+		DefaultValue: "0",
+		Forbidden:    true,
+		Formatter: func(v string) string {
+			timeout := getAsInt64(v)
+			if timeout < 0 {
+				return "0"
+			}
+			return fmt.Sprintf("%d", timeout)
+		},
+		Doc:    "Loading timeout in milliseconds for cache slot loading. 0 means no timeout.",
+		Export: false,
+	}
+	p.TieredLoadingTimeoutMs.Init(base.mgr)
 
 	p.EnableDisk = ParamItem{
 		Key:          "queryNode.enableDisk",


### PR DESCRIPTION
issue: #45353

This feature enables graceful cancellation of loading operations:
    
1. Add OpContext propagation through caching layer:
   - Add `OpContext*` parameter to `get_cells()` in all Translator implementations
   - Add seperate `loadingTimeoutMs` configuration for cache slot loading timeout

2. Add cancellation checks in load phases.