### PR TITLE
test: create e2e case for truncate collection

### DIFF
--- a/tests/python_client/base/async_milvus_client_wrapper.py
+++ b/tests/python_client/base/async_milvus_client_wrapper.py
@@ -125,6 +125,14 @@ class AsyncMilvusClientWrapper:
         return await self.async_milvus_client.release_collection(collection_name, timeout, **kwargs)
 
     @logger_interceptor()
+    async def truncate_collection(self, collection_name: str, timeout: Optional[float] = None, **kwargs):
+        return await self.async_milvus_client.truncate_collection(collection_name, timeout, **kwargs)
+    
+    @logger_interceptor()
+    async def list_persistent_segments(self, collection_name: str, timeout: Optional[float] = None, **kwargs):
+        return await self.async_milvus_client.list_persistent_segments(collection_name, timeout, **kwargs)
+
+    @logger_interceptor()
     async def create_index(self, collection_name: str, index_params, timeout: Optional[float] = None,
                            **kwargs):
         return await self.async_milvus_client.create_index(collection_name, index_params, timeout, **kwargs)

--- a/tests/python_client/base/client_v2_base.py
+++ b/tests/python_client/base/client_v2_base.py
@@ -385,6 +385,30 @@ class TestMilvusClientV2Base(Base):
         return res, check_result
 
     @trace()
+    def truncate_collection(self, client, collection_name, timeout=None, check_task=None, check_items=None, **kwargs):
+        timeout = TIMEOUT if timeout is None else timeout
+        kwargs.update({"timeout": timeout})
+
+        func_name = sys._getframe().f_code.co_name
+        res, check = api_request([client.truncate_collection, collection_name], **kwargs)
+        check_result = ResponseChecker(res, func_name, check_task,
+                                       check_items, check,
+                                       collection_name=collection_name, **kwargs).run()
+        return res, check_result
+
+    @trace()
+    def list_persistent_segments(self, client, collection_name, timeout=None, check_task=None, check_items=None, **kwargs):
+        timeout = TIMEOUT if timeout is None else timeout
+        kwargs.update({"timeout": timeout})
+
+        func_name = sys._getframe().f_code.co_name
+        res, check = api_request([client.list_persistent_segments, collection_name], **kwargs)
+        check_result = ResponseChecker(res, func_name, check_task,
+                                       check_items, check,
+                                       collection_name=collection_name, **kwargs).run()
+        return res, check_result
+
+    @trace()
     def load_partitions(self, client, collection_name, partition_names, timeout=None, check_task=None, check_items=None, **kwargs):
         timeout = TIMEOUT if timeout is None else timeout
         kwargs.update({"timeout": timeout})

--- a/tests/python_client/milvus_client/test_milvus_client_collection.py
+++ b/tests/python_client/milvus_client/test_milvus_client_collection.py
@@ -1,6 +1,7 @@
 import pytest
 import numpy
 import time
+import threading
 
 from base.client_v2_base import TestMilvusClientV2Base
 from common import common_func as cf
@@ -5232,8 +5233,6 @@ class TestMilvusClientTruncateCollection(TestMilvusClientV2Base):
         method: insert data and truncate collection at the same time in parallel
         expected: the collection is truncated regardless of timing
         """
-        import threading
-
         client_1 = self._client()
         client_2 = self._client(alias="client2_alias")
         collection_name = self.COLLECTION_NAME_STRONG
@@ -5280,8 +5279,6 @@ class TestMilvusClientTruncateCollection(TestMilvusClientV2Base):
         method: insert data first, then query and truncate collection at the same time in parallel
         expected: the collection is truncated regardless of timing
         """
-        import threading
-
         client_1 = self._client()
         client_2 = self._client(alias="client2_alias")
         collection_name = self.COLLECTION_NAME

--- a/tests/python_client/testcases/async_milvus_client/test_collection_async.py
+++ b/tests/python_client/testcases/async_milvus_client/test_collection_async.py
@@ -227,7 +227,6 @@ class TestAsyncMilvusClientCollectionValid(TestMilvusClientV2Base):
         """
         self.init_async_milvus_client()
         async_client = self.async_milvus_client_wrap
-        client = self._client()
         
         # 1. create collection
         collection_name = cf.gen_collection_name_by_testcase_name()
@@ -244,7 +243,7 @@ class TestAsyncMilvusClientCollectionValid(TestMilvusClientV2Base):
         # 4. query
         result = await async_client.query(collection_name, filter=default_search_exp, output_fields=["count(*)"])
         assert result[0][0].get("count(*)", -1) == 0
-        seg = self.list_persistent_segments(client, collection_name)
+        seg = await async_client.list_persistent_segments(collection_name)
         assert len(seg[0]) == 0
         # 5. drop collection
         await async_client.drop_collection(collection_name)

--- a/tests/python_client/testcases/async_milvus_client/test_collection_async.py
+++ b/tests/python_client/testcases/async_milvus_client/test_collection_async.py
@@ -216,3 +216,35 @@ class TestAsyncMilvusClientCollectionValid(TestMilvusClientV2Base):
             partitions, _ = await async_client.list_partitions(collection_name)
             assert partition_name not in partitions
         await async_client.drop_collection(collection_name)
+
+
+    @pytest.mark.tags(CaseLabel.L0)
+    async def test_async_milvus_client_truncate_collection(self):
+        """
+        target: test truncate collection with strong consistency level
+        method: truncate collection with strong consistency level
+        expected: the collection is truncated
+        """
+        self.init_async_milvus_client()
+        async_client = self.async_milvus_client_wrap
+        client = self._client()
+        
+        # 1. create collection
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        await async_client.create_collection(collection_name, default_dim)
+        collections, _ = await async_client.list_collections()
+        assert collection_name in collections
+        # 2. insert
+        rng = np.random.default_rng(seed=19530)
+        rows = [{default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, default_dim))[0]),
+                 default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(default_nb)]
+        await async_client.insert(collection_name, rows)
+        # 3. truncate collection
+        await async_client.truncate_collection(collection_name)
+        # 4. query
+        result = await async_client.query(collection_name, filter=default_search_exp, output_fields=["count(*)"])
+        assert result[0][0].get("count(*)", -1) == 0
+        seg = self.list_persistent_segments(client, collection_name)
+        assert len(seg[0]) == 0
+        # 5. drop collection
+        await async_client.drop_collection(collection_name)


### PR DESCRIPTION
 Issue: #47034 
 1. Create e2e cases for truncate collection
 2. Connect necessary sdk function to milvus client wrapper

 On branch feature/truncate
 Changes to be committed:
	modified:   base/async_milvus_client_wrapper.py
	modified:   base/client_v2_base.py
	modified:   milvus_client/test_milvus_client_collection.py
	modified:   testcases/async_milvus_client/test_collection_async.py