### PR TITLE
test: fix insert resource-limit expectation and add async insert testcases

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_insert.py
+++ b/tests/python_client/milvus_client/test_milvus_client_insert.py
@@ -1464,7 +1464,7 @@ class TestInsertOperation(TestMilvusClientV2Base):
         """
         target: test insert data equal to RPC limitation 64MB (67108864)
         method: calculated critical value and insert equivalent data
-        expected: raise exception
+        expected: insert succeeds
         """
         client = self._client()
         collection_name = cf.gen_collection_name_by_testcase_name()
@@ -1590,3 +1590,121 @@ class TestInsertOperation(TestMilvusClientV2Base):
         assert len(res) == nb
 
         self.drop_collection(client, collection_name)
+
+
+class TestInsertAsync(TestMilvusClientV2Base):
+    """
+    ******************************************************************
+      The following cases are used to test insert async
+    ******************************************************************
+    """
+
+    @pytest.mark.tags(CaseLabel.L1)
+    @pytest.mark.asyncio
+    async def test_async_milvus_client_insert(self):
+        """
+        target: test async insert via Milvus async client
+        method: insert with async milvus client
+        expected: verify insert_count / row_count
+        """
+        self.init_async_milvus_client()
+        async_client = self.async_milvus_client_wrap
+
+        collection_name = cf.gen_collection_name_by_testcase_name()
+
+        # 1. create collection
+        await async_client.create_collection(collection_name, default_dim)
+
+        # 2. prepare data
+        rng = np.random.default_rng(seed=19530)
+        rows = [{default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, default_dim))[0]),
+                 default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(default_nb)]
+
+        # 3. insert
+        res, _ = await async_client.insert(collection_name, rows)
+
+        assert res["insert_count"] == ct.default_nb
+
+        # 4. verify count
+        await async_client.flush(collection_name)
+        num_entities, _ = await async_client.get_collection_stats(collection_name)
+        assert num_entities["row_count"] == ct.default_nb
+
+        await async_client.drop_collection(collection_name)
+
+    @pytest.mark.tags(CaseLabel.L2)
+    @pytest.mark.asyncio
+    async def test_async_milvus_client_insert_large(self):
+        """
+        target: test insert with async
+        method: insert 5w entities
+        expected: verify num entities
+        """
+        self.init_async_milvus_client()
+        async_client = self.async_milvus_client_wrap
+
+        nb = 50000
+        collection_name = cf.gen_collection_name_by_testcase_name()
+
+        await async_client.create_collection(collection_name, default_dim)
+
+        rng = np.random.default_rng(seed=19530)
+        rows = [{default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, default_dim))[0]),
+                 default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(nb)]
+
+        res, _ = await async_client.insert(collection_name, rows)
+        assert res["insert_count"] == nb
+
+        await async_client.flush(collection_name)
+        num_entities, _ = await async_client.get_collection_stats(collection_name)
+        assert num_entities["row_count"] == nb
+
+        await async_client.drop_collection(collection_name)
+
+    @pytest.mark.tags(CaseLabel.L2)
+    @pytest.mark.asyncio
+    async def test_async_milvus_client_insert_invalid_data(self):
+        """
+        target: test insert async with invalid data
+        method: insert async with invalid data
+        expected: raise exception
+        """
+        self.init_async_milvus_client()
+        async_client = self.async_milvus_client_wrap
+
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        await async_client.create_collection(collection_name, default_dim)
+
+        # missing vector field
+        rows = [{ct.default_int64_field_name: 1}]
+
+        error = {ct.err_code: 0, ct.err_msg: "Insert missed an field `id` to collection without set nullable==true or set default_value"}
+
+        await async_client.insert(collection_name, rows, check_task=CheckTasks.err_res, check_items=error)
+
+        await async_client.drop_collection(collection_name)
+
+    @pytest.mark.tags(CaseLabel.L2)
+    @pytest.mark.asyncio
+    async def test_async_milvus_client_insert_invalid_partition(self):
+        """
+        target: test insert async with invalid partition
+        method: insert async with invalid partition
+        expected: raise exception
+        """
+        self.init_async_milvus_client()
+        async_client = self.async_milvus_client_wrap
+
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        partition_name = cf.gen_unique_str("partition")
+        await async_client.create_collection(collection_name, default_dim)
+
+        rng = np.random.default_rng(seed=19530)
+        rows = [{default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, default_dim))[0]),
+                 default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(default_nb)]
+        error = {ct.err_code: 200, ct.err_msg: f"partition not found"}
+
+        await async_client.insert(collection_name, data=rows, partition_name=partition_name,
+                                  check_task=CheckTasks.err_res, check_items=error)
+
+        await async_client.drop_collection(collection_name)

--- a/tests/python_client/milvus_client/test_milvus_client_insert.py
+++ b/tests/python_client/milvus_client/test_milvus_client_insert.py
@@ -1676,9 +1676,9 @@ class TestInsertAsync(TestMilvusClientV2Base):
         await async_client.create_collection(collection_name, default_dim)
 
         # missing vector field
-        rows = [{ct.default_int64_field_name: 1}]
+        rows = [{ct.default_primary_key_field_name: 1}]
 
-        error = {ct.err_code: 0, ct.err_msg: "Insert missed an field `id` to collection without set nullable==true or set default_value"}
+        error = {ct.err_code: 1, ct.err_msg: "Insert missed an field `vector` to collection without set nullable==true or set default_value"}
 
         await async_client.insert(collection_name, rows, check_task=CheckTasks.err_res, check_items=error)
 
@@ -1702,7 +1702,7 @@ class TestInsertAsync(TestMilvusClientV2Base):
         rng = np.random.default_rng(seed=19530)
         rows = [{default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, default_dim))[0]),
                  default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(default_nb)]
-        error = {ct.err_code: 200, ct.err_msg: f"partition not found"}
+        error = {ct.err_code: 200, ct.err_msg: f"partition not found[partition={partition_name}]"}
 
         await async_client.insert(collection_name, data=rows, partition_name=partition_name,
                                   check_task=CheckTasks.err_res, check_items=error)

--- a/tests/python_client/testcases/test_insert.py
+++ b/tests/python_client/testcases/test_insert.py
@@ -871,24 +871,6 @@ class TestInsertAsync(TestcaseBase):
     """
 
     @pytest.mark.tags(CaseLabel.L1)
-    def test_insert_sync(self):
-        """
-        target: test async insert
-        method: insert with async=True
-        expected: verify num entities
-        """
-        collection_w = self.init_collection_wrap(
-            name=cf.gen_unique_str(prefix))
-        df = cf.gen_default_dataframe_data()
-        future, _ = collection_w.insert(data=df, _async=True)
-        future.done()
-        mutation_res = future.result()
-        assert mutation_res.insert_count == ct.default_nb
-        assert mutation_res.primary_keys == df[ct.default_int64_field_name].values.tolist(
-        )
-        assert collection_w.num_entities == ct.default_nb
-
-    @pytest.mark.tags(CaseLabel.L1)
     def test_insert_async_false(self):
         """
         target: test insert with false async
@@ -923,25 +905,6 @@ class TestInsertAsync(TestcaseBase):
         assert collection_w.num_entities == ct.default_nb
 
     @pytest.mark.tags(CaseLabel.L2)
-    def test_insert_async_long(self):
-        """
-        target: test insert with async
-        method: insert 5w entities with callback func
-        expected: verify num entities
-        """
-        nb = 50000
-        collection_w = self.init_collection_wrap(
-            name=cf.gen_unique_str(prefix))
-        df = cf.gen_default_dataframe_data(nb)
-        future, _ = collection_w.insert(data=df, _async=True)
-        future.done()
-        mutation_res = future.result()
-        assert mutation_res.insert_count == nb
-        assert mutation_res.primary_keys == df[ct.default_int64_field_name].values.tolist(
-        )
-        assert collection_w.num_entities == nb
-
-    @pytest.mark.tags(CaseLabel.L2)
     def test_insert_async_callback_timeout(self):
         """
         target: test insert async with callback
@@ -956,39 +919,6 @@ class TestInsertAsync(TestcaseBase):
             data=df, _async=True, _callback=None, timeout=0.2)
         with pytest.raises(MilvusException):
             future.result()
-
-    @pytest.mark.tags(CaseLabel.L2)
-    def test_insert_async_invalid_data(self):
-        """
-        target: test insert async with invalid data
-        method: insert async with invalid data
-        expected: raise exception
-        """
-        collection_w = self.init_collection_wrap(
-            name=cf.gen_unique_str(prefix))
-        columns = [ct.default_int64_field_name,
-                   ct.default_float_vec_field_name]
-        df = pd.DataFrame(columns=columns)
-        error = {ct.err_code: 0,
-                 ct.err_msg: "The fields don't match with schema fields"}
-        collection_w.insert(data=df, _async=True,
-                            check_task=CheckTasks.err_res, check_items=error)
-
-    @pytest.mark.tags(CaseLabel.L2)
-    def test_insert_async_invalid_partition(self):
-        """
-        target: test insert async with invalid partition
-        method: insert async with invalid partition
-        expected: raise exception
-        """
-        collection_w = self.init_collection_wrap(name=cf.gen_unique_str(prefix))
-        df = cf.gen_default_dataframe_data()
-        err_msg = "partition not found"
-        future, _ = collection_w.insert(data=df, partition_name="p", _async=True)
-        future.done()
-        with pytest.raises(MilvusException, match=err_msg):
-            future.result()
-
 
 def assert_mutation_result(mutation_res):
     assert mutation_res.insert_count == ct.default_nb


### PR DESCRIPTION
/kind improvement
/assign @yanliang567 

**PR Summary**

- Fix mismatched expectations in the insert resource-limit test.
- Migrate async insert test cases from ORM-based cases, including normal insert, large insert, invalid data, and invalid partition scenarios.