### PR TITLE
test: migrate binary and integer overflow insert cases

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_insert.py
+++ b/tests/python_client/milvus_client/test_milvus_client_insert.py
@@ -381,7 +381,6 @@ class TestMilvusClientInsertInvalid(TestMilvusClientV2Base):
         """
         client = self._client()
         collection_name = cf.gen_collection_name_by_testcase_name()
-        nb = 100
 
         # 1. Create binary vector collection
         schema = self.create_schema(client, enable_dynamic_field=False)[0]
@@ -1698,7 +1697,7 @@ class TestInsertOperation(TestMilvusClientV2Base):
         # 2. Insert binary data multiple times
         nums = 2
         start_id = 0
-        for i in range(nums):
+        for _ in range(nums):
             # Generate data with unique primary keys for each insert
             rows = cf.gen_row_data_by_schema(nb=ct.default_nb, schema=schema, start=start_id)
             results = self.insert(client, collection_name, rows)[0]


### PR DESCRIPTION
/kind improvement
/assign @yanliang567 

**PR Summary**

- This PR migrates ORM-based insert test cases to the Milvus client API, including binary vector inserts, repeated binary vector inserts, binary vector index creation, invalid binary scenarios, and integer overflow validation (int8/int16/int32):
  - `test_insert_binary_partition`
  - `test_insert_binary_multi_times`
  - `test_insert_binary_create_index`
  - `test_insert_int8_overflow`
  - `test_insert_int16_overflow`
  - `test_insert_int32_overflow`
  - `test_insert_ids_binary_invalid`
  - `test_insert_with_invalid_binary_partition_name`