### PR TITLE
enhance: [RBAC] support for /expr endpoint

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -1040,7 +1040,8 @@ common:
     defaultRootPassword: Milvus
     rootShouldBindRole: false # Whether the root user should bind a role when the authorization is enabled.
     enablePublicPrivilege: true # Whether to enable public privilege
-    exprEnabled: false # Whether to enable the /expr endpoint for debugging. When enabled, only root user can access it via HTTP Basic Auth on Proxy nodes.
+    exprEnabled: false # Whether to enable the /expr endpoint for debugging.
+    exprAuthMode: rootOnly # Authentication mode for the /expr endpoint. Valid values: rootOnly, rbac. rootOnly accepts only the root credentials via HTTP Basic Auth. rbac requires common.security.authorizationEnabled=true and grants access to any user holding the Expr privilege.
     internaltlsEnabled: false
     tlsMode: 0
   session:

--- a/internal/http/rbac.go
+++ b/internal/http/rbac.go
@@ -1,0 +1,235 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package http
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"go.uber.org/zap"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus/internal/proxy/privilege"
+	"github.com/milvus-io/milvus/pkg/v3/log"
+	"github.com/milvus-io/milvus/pkg/v3/util"
+	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+)
+
+const (
+	ExprAuthModeRootOnly = "rootOnly"
+	ExprAuthModeRBAC     = "rbac"
+)
+
+var (
+	// getUserRoleFunc is a callback function to get user roles.
+	// This is set by the proxy package to avoid circular dependency.
+	getUserRoleFunc func(username string) ([]string, error)
+)
+
+// RegisterGetUserRoleFunc registers a function to get user roles.
+// This should be called by the proxy package during initialization.
+func RegisterGetUserRoleFunc(fn func(username string) ([]string, error)) {
+	getUserRoleFunc = fn
+}
+
+// ErrAuthentication represents an authentication error (invalid credentials)
+type ErrAuthentication struct {
+	msg string
+}
+
+func (e *ErrAuthentication) Error() string {
+	return e.msg
+}
+
+// ErrPermissionDenied represents a permission denied error (valid credentials but no permission)
+type ErrPermissionDenied struct {
+	msg string
+}
+
+func (e *ErrPermissionDenied) Error() string {
+	return e.msg
+}
+
+// ErrServiceUnavailable represents an unavailable dependency needed for authz.
+type ErrServiceUnavailable struct {
+	msg string
+}
+
+func (e *ErrServiceUnavailable) Error() string {
+	return e.msg
+}
+
+// parseHTTPAuth extracts username and password from HTTP request.
+// Supports HTTP Basic Auth format only.
+func parseHTTPAuth(req *http.Request) (username, password string, ok bool) {
+	return req.BasicAuth()
+}
+
+// CheckExprAuth authenticates and authorizes access to the /expr endpoint.
+func CheckExprAuth(ctx context.Context, req *http.Request) error {
+	mode := paramtable.Get().CommonCfg.ExprAuthMode.GetValue()
+	switch strings.ToLower(mode) {
+	case "", strings.ToLower(ExprAuthModeRootOnly):
+		return checkExprRootAuth(ctx, req)
+	case ExprAuthModeRBAC:
+		if !paramtable.Get().CommonCfg.AuthorizationEnabled.GetAsBool() {
+			return &ErrPermissionDenied{msg: "authorization must be enabled when common.security.exprAuthMode is rbac"}
+		}
+		return CheckPrivilege(
+			ctx,
+			req,
+			commonpb.ObjectType_Global,
+			util.PrivilegeExpr,
+			util.AnyWord,
+			util.DefaultDBName,
+		)
+	default:
+		return &ErrPermissionDenied{msg: fmt.Sprintf("invalid expr auth mode %q", mode)}
+	}
+}
+
+func checkExprRootAuth(ctx context.Context, req *http.Request) error {
+	username, password, ok := parseHTTPAuth(req)
+	if !ok || username == "" || password == "" {
+		return &ErrAuthentication{msg: "authentication required. Use HTTP Basic Auth with root credentials"}
+	}
+	if username != util.UserRoot {
+		log.Warn("non-root user attempted to access /expr", zap.String("username", username))
+		return &ErrPermissionDenied{msg: "only root user can access /expr endpoint"}
+	}
+	if passwordVerifyFunc == nil {
+		return &ErrServiceUnavailable{msg: "password verification not available"}
+	}
+	if !passwordVerifyFunc(ctx, username, password) {
+		log.Warn("invalid root password for /expr access")
+		return &ErrAuthentication{msg: "invalid root password"}
+	}
+	log.Info("root user authenticated for /expr access")
+	return nil
+}
+
+// CheckPrivilege checks if the authenticated user has the specified privilege.
+func CheckPrivilege(ctx context.Context, req *http.Request, objectType commonpb.ObjectType,
+	objectPrivilege string, objectName string, dbName string) error {
+	// Check if authorization is enabled
+	if !paramtable.Get().CommonCfg.AuthorizationEnabled.GetAsBool() {
+		return &ErrPermissionDenied{msg: "authorization must be enabled for RBAC privilege checks"}
+	}
+
+	// Parse authentication from request
+	username, password, ok := parseHTTPAuth(req)
+	if !ok || username == "" || password == "" {
+		return &ErrAuthentication{msg: "authentication required"}
+	}
+
+	// Verify password
+	if passwordVerifyFunc == nil {
+		return &ErrServiceUnavailable{msg: "password verification not available"}
+	}
+	if !passwordVerifyFunc(ctx, username, password) {
+		log.Warn("invalid credentials for HTTP RBAC check", zap.String("username", username))
+		return &ErrAuthentication{msg: "invalid credentials"}
+	}
+
+	// Root bypass (unless RootShouldBindRole is enabled)
+	if !paramtable.Get().CommonCfg.RootShouldBindRole.GetAsBool() && username == util.UserRoot {
+		log.Info("root user authenticated for HTTP access", zap.String("privilege", objectPrivilege))
+		return nil
+	}
+
+	// Get user roles
+	if getUserRoleFunc == nil {
+		return &ErrServiceUnavailable{msg: "role lookup not available"}
+	}
+	roleNames, err := getUserRoleFunc(username)
+	if err != nil {
+		log.Warn("failed to get user roles", zap.String("username", username), zap.Error(err))
+		return &ErrServiceUnavailable{msg: fmt.Sprintf("failed to get user roles: %v", err)}
+	}
+	roleNames = append(roleNames, util.RolePublic)
+
+	// Check privilege using Casbin enforcer
+	e := privilege.GetEnforcer()
+	object := funcutil.PolicyForResource(dbName, objectType.String(), objectName)
+	privilegeName := objectPrivilege
+
+	for _, roleName := range roleNames {
+		// Check cache first
+		isPermit, cached, version := privilege.GetResultCache(roleName, object, privilegeName)
+		if cached {
+			if isPermit {
+				return nil
+			}
+			continue
+		}
+
+		// Enforce with Casbin
+		isPermit, err := e.Enforce(roleName, object, privilegeName)
+		if err != nil {
+			log.Warn("privilege check failed", zap.Error(err))
+			return fmt.Errorf("privilege check failed: %w", err)
+		}
+		privilege.SetResultCache(roleName, object, privilegeName, isPermit, version)
+		if isPermit {
+			return nil
+		}
+	}
+
+	log.Info("HTTP permission denied",
+		zap.String("username", username),
+		zap.Strings("roles", roleNames),
+		zap.String("privilege", util.MetaStore2API(privilegeName)))
+
+	return &ErrPermissionDenied{
+		msg: fmt.Sprintf("permission denied: user %s requires %s privilege", username, util.MetaStore2API(privilegeName)),
+	}
+}
+
+// IsAuthenticationError returns true if the error is an authentication error
+func IsAuthenticationError(err error) bool {
+	var target *ErrAuthentication
+	return errors.As(err, &target)
+}
+
+// IsPermissionDeniedError returns true if the error is a permission denied error
+func IsPermissionDeniedError(err error) bool {
+	var target *ErrPermissionDenied
+	return errors.As(err, &target)
+}
+
+// IsServiceUnavailableError returns true if an auth dependency is unavailable.
+func IsServiceUnavailableError(err error) bool {
+	var target *ErrServiceUnavailable
+	return errors.As(err, &target)
+}
+
+func HTTPStatusFromPrivilegeError(err error) int {
+	switch {
+	case IsAuthenticationError(err):
+		return http.StatusUnauthorized
+	case IsPermissionDeniedError(err):
+		return http.StatusForbidden
+	case IsServiceUnavailableError(err):
+		return http.StatusServiceUnavailable
+	default:
+		return http.StatusInternalServerError
+	}
+}

--- a/internal/http/rbac.go
+++ b/internal/http/rbac.go
@@ -18,11 +18,11 @@ package http
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"strings"
 
+	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
@@ -38,11 +38,9 @@ const (
 	ExprAuthModeRBAC     = "rbac"
 )
 
-var (
-	// getUserRoleFunc is a callback function to get user roles.
-	// This is set by the proxy package to avoid circular dependency.
-	getUserRoleFunc func(username string) ([]string, error)
-)
+// getUserRoleFunc is a callback function to get user roles.
+// This is set by the proxy package to avoid circular dependency.
+var getUserRoleFunc func(username string) ([]string, error)
 
 // RegisterGetUserRoleFunc registers a function to get user roles.
 // This should be called by the proxy package during initialization.
@@ -128,7 +126,8 @@ func checkExprRootAuth(ctx context.Context, req *http.Request) error {
 
 // CheckPrivilege checks if the authenticated user has the specified privilege.
 func CheckPrivilege(ctx context.Context, req *http.Request, objectType commonpb.ObjectType,
-	objectPrivilege string, objectName string, dbName string) error {
+	objectPrivilege string, objectName string, dbName string,
+) error {
 	// Check if authorization is enabled
 	if !paramtable.Get().CommonCfg.AuthorizationEnabled.GetAsBool() {
 		return &ErrPermissionDenied{msg: "authorization must be enabled for RBAC privilege checks"}

--- a/internal/http/rbac.go
+++ b/internal/http/rbac.go
@@ -184,7 +184,7 @@ func CheckPrivilege(ctx context.Context, req *http.Request, objectType commonpb.
 		isPermit, err := e.Enforce(roleName, object, privilegeName)
 		if err != nil {
 			log.Warn("privilege check failed", zap.Error(err))
-			return fmt.Errorf("privilege check failed: %w", err)
+			return errors.Wrapf(err, "privilege check failed")
 		}
 		privilege.SetResultCache(roleName, object, privilegeName, isPermit, version)
 		if isPermit {

--- a/internal/http/rbac_test.go
+++ b/internal/http/rbac_test.go
@@ -96,6 +96,17 @@ func TestErrorMessages(t *testing.T) {
 	assert.Equal(t, "service unavailable", unavailableErr.Error())
 }
 
+func TestEnforceErrorMapsToInternalServerError(t *testing.T) {
+	// A generic wrapped error from Casbin Enforce is not an authn/authz type,
+	// so the HTTP response should stay a server error instead of becoming 403.
+	err := errors.Wrapf(errors.New("casbin enforce boom"), "privilege check failed")
+
+	assert.False(t, IsAuthenticationError(err))
+	assert.False(t, IsPermissionDeniedError(err))
+	assert.False(t, IsServiceUnavailableError(err))
+	assert.Equal(t, http.StatusInternalServerError, HTTPStatusFromPrivilegeError(err))
+}
+
 func TestCheckExprAuth(t *testing.T) {
 	paramtable.Init()
 	originalPasswordVerify := passwordVerifyFunc

--- a/internal/http/rbac_test.go
+++ b/internal/http/rbac_test.go
@@ -1,0 +1,679 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package http
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus/internal/proxy/privilege"
+	"github.com/milvus-io/milvus/internal/types"
+	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
+	"github.com/milvus-io/milvus/pkg/v3/util"
+	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+	"google.golang.org/grpc"
+)
+
+func TestParseHTTPAuth(t *testing.T) {
+	t.Run("basic_auth", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/expr", nil)
+		req.SetBasicAuth("testuser", "testpass")
+
+		username, password, ok := parseHTTPAuth(req)
+		assert.True(t, ok)
+		assert.Equal(t, "testuser", username)
+		assert.Equal(t, "testpass", password)
+	})
+
+	t.Run("no_auth", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/expr", nil)
+
+		username, password, ok := parseHTTPAuth(req)
+		assert.False(t, ok)
+		assert.Empty(t, username)
+		assert.Empty(t, password)
+	})
+
+	t.Run("unsupported_auth_format", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/expr", nil)
+		req.Header.Set("Authorization", "Bearer some_token")
+
+		username, password, ok := parseHTTPAuth(req)
+		assert.False(t, ok)
+		assert.Empty(t, username)
+		assert.Empty(t, password)
+	})
+}
+
+func TestIsAuthenticationError(t *testing.T) {
+	authErr := &ErrAuthentication{msg: "test error"}
+	permErr := &ErrPermissionDenied{msg: "test error"}
+
+	assert.True(t, IsAuthenticationError(authErr))
+	assert.False(t, IsAuthenticationError(permErr))
+	assert.False(t, IsAuthenticationError(nil))
+}
+
+func TestIsPermissionDeniedError(t *testing.T) {
+	authErr := &ErrAuthentication{msg: "test error"}
+	permErr := &ErrPermissionDenied{msg: "test error"}
+
+	assert.False(t, IsPermissionDeniedError(authErr))
+	assert.True(t, IsPermissionDeniedError(permErr))
+	assert.False(t, IsPermissionDeniedError(nil))
+}
+
+func TestErrorMessages(t *testing.T) {
+	authErr := &ErrAuthentication{msg: "auth failed"}
+	permErr := &ErrPermissionDenied{msg: "permission denied"}
+	unavailableErr := &ErrServiceUnavailable{msg: "service unavailable"}
+
+	assert.Equal(t, "auth failed", authErr.Error())
+	assert.Equal(t, "permission denied", permErr.Error())
+	assert.Equal(t, "service unavailable", unavailableErr.Error())
+}
+
+func TestCheckExprAuth(t *testing.T) {
+	paramtable.Init()
+	originalPasswordVerify := passwordVerifyFunc
+	originalGetUserRole := getUserRoleFunc
+	defer func() {
+		passwordVerifyFunc = originalPasswordVerify
+		getUserRoleFunc = originalGetUserRole
+		paramtable.Get().Reset(paramtable.Get().CommonCfg.AuthorizationEnabled.Key)
+		paramtable.Get().Reset(paramtable.Get().CommonCfg.RootShouldBindRole.Key)
+		paramtable.Get().Reset(paramtable.Get().CommonCfg.ExprAuthMode.Key)
+	}()
+
+	t.Run("root_only_rejects_non_root_with_valid_credentials", func(t *testing.T) {
+		paramtable.Get().Save(paramtable.Get().CommonCfg.ExprAuthMode.Key, ExprAuthModeRootOnly)
+		RegisterPasswordVerifyFunc(func(ctx context.Context, username, password string) bool {
+			return username == "admin" && password == "admin123"
+		})
+		req := httptest.NewRequest(http.MethodGet, "/expr", nil)
+		req.SetBasicAuth("admin", "admin123")
+
+		err := CheckExprAuth(context.Background(), req)
+
+		assert.Error(t, err)
+		assert.True(t, IsPermissionDeniedError(err))
+		assert.Equal(t, http.StatusForbidden, HTTPStatusFromPrivilegeError(err))
+	})
+
+	t.Run("rbac_fails_closed_when_authorization_disabled", func(t *testing.T) {
+		paramtable.Get().Save(paramtable.Get().CommonCfg.ExprAuthMode.Key, ExprAuthModeRBAC)
+		paramtable.Get().Save(paramtable.Get().CommonCfg.AuthorizationEnabled.Key, "false")
+		req := httptest.NewRequest(http.MethodGet, "/expr", nil)
+		req.SetBasicAuth(util.UserRoot, "Milvus")
+
+		err := CheckExprAuth(context.Background(), req)
+
+		assert.Error(t, err)
+		assert.True(t, IsPermissionDeniedError(err))
+		assert.Contains(t, err.Error(), "authorization must be enabled")
+	})
+}
+
+// CheckPrivilegeTestSuite tests the CheckPrivilege function
+type CheckPrivilegeTestSuite struct {
+	suite.Suite
+	ctx                    context.Context
+	originalPasswordVerify func(ctx context.Context, username, password string) bool
+	originalGetUserRole    func(username string) ([]string, error)
+}
+
+func (s *CheckPrivilegeTestSuite) SetupSuite() {
+	paramtable.Init()
+}
+
+func (s *CheckPrivilegeTestSuite) SetupTest() {
+	s.ctx = context.Background()
+	// Save original functions to restore later
+	s.originalPasswordVerify = passwordVerifyFunc
+	s.originalGetUserRole = getUserRoleFunc
+}
+
+func (s *CheckPrivilegeTestSuite) TearDownTest() {
+	// Restore original functions
+	passwordVerifyFunc = s.originalPasswordVerify
+	getUserRoleFunc = s.originalGetUserRole
+	// Reset paramtable settings
+	paramtable.Get().Reset(paramtable.Get().CommonCfg.AuthorizationEnabled.Key)
+	paramtable.Get().Reset(paramtable.Get().CommonCfg.RootShouldBindRole.Key)
+	paramtable.Get().Reset(paramtable.Get().CommonCfg.ExprAuthMode.Key)
+}
+
+func (s *CheckPrivilegeTestSuite) TestAuthorizationDisabledFailsClosed() {
+	paramtable.Get().Save(paramtable.Get().CommonCfg.AuthorizationEnabled.Key, "false")
+
+	req := httptest.NewRequest(http.MethodGet, "/expr", nil)
+
+	err := CheckPrivilege(
+		s.ctx,
+		req,
+		commonpb.ObjectType_Global,
+		commonpb.ObjectPrivilege_PrivilegeAll.String(),
+		util.AnyWord,
+		util.DefaultDBName,
+	)
+
+	s.Error(err)
+	s.True(IsPermissionDeniedError(err))
+	s.Contains(err.Error(), "authorization must be enabled")
+}
+
+func (s *CheckPrivilegeTestSuite) TestMissingAuthHeader() {
+	paramtable.Get().Save(paramtable.Get().CommonCfg.AuthorizationEnabled.Key, "true")
+
+	req := httptest.NewRequest(http.MethodGet, "/expr", nil)
+	// No auth header
+
+	err := CheckPrivilege(
+		s.ctx,
+		req,
+		commonpb.ObjectType_Global,
+		commonpb.ObjectPrivilege_PrivilegeAll.String(),
+		util.AnyWord,
+		util.DefaultDBName,
+	)
+
+	s.Error(err)
+	s.True(IsAuthenticationError(err))
+	s.Contains(err.Error(), "authentication required")
+}
+
+func (s *CheckPrivilegeTestSuite) TestEmptyUsername() {
+	paramtable.Get().Save(paramtable.Get().CommonCfg.AuthorizationEnabled.Key, "true")
+
+	req := httptest.NewRequest(http.MethodGet, "/expr", nil)
+	req.SetBasicAuth("", "password")
+
+	err := CheckPrivilege(
+		s.ctx,
+		req,
+		commonpb.ObjectType_Global,
+		commonpb.ObjectPrivilege_PrivilegeAll.String(),
+		util.AnyWord,
+		util.DefaultDBName,
+	)
+
+	s.Error(err)
+	s.True(IsAuthenticationError(err))
+	s.Contains(err.Error(), "authentication required")
+}
+
+func (s *CheckPrivilegeTestSuite) TestEmptyPassword() {
+	paramtable.Get().Save(paramtable.Get().CommonCfg.AuthorizationEnabled.Key, "true")
+
+	req := httptest.NewRequest(http.MethodGet, "/expr", nil)
+	req.SetBasicAuth("username", "")
+
+	err := CheckPrivilege(
+		s.ctx,
+		req,
+		commonpb.ObjectType_Global,
+		commonpb.ObjectPrivilege_PrivilegeAll.String(),
+		util.AnyWord,
+		util.DefaultDBName,
+	)
+
+	s.Error(err)
+	s.True(IsAuthenticationError(err))
+	s.Contains(err.Error(), "authentication required")
+}
+
+func (s *CheckPrivilegeTestSuite) TestPasswordVerifyFuncNotSet() {
+	paramtable.Get().Save(paramtable.Get().CommonCfg.AuthorizationEnabled.Key, "true")
+
+	// Ensure passwordVerifyFunc is nil
+	passwordVerifyFunc = nil
+
+	req := httptest.NewRequest(http.MethodGet, "/expr", nil)
+	req.SetBasicAuth("testuser", "testpass")
+
+	err := CheckPrivilege(
+		s.ctx,
+		req,
+		commonpb.ObjectType_Global,
+		commonpb.ObjectPrivilege_PrivilegeAll.String(),
+		util.AnyWord,
+		util.DefaultDBName,
+	)
+
+	s.Error(err)
+	s.True(IsServiceUnavailableError(err))
+	s.Contains(err.Error(), "password verification not available")
+}
+
+func (s *CheckPrivilegeTestSuite) TestPasswordVerificationFailure() {
+	paramtable.Get().Save(paramtable.Get().CommonCfg.AuthorizationEnabled.Key, "true")
+
+	// Register a password verify function that always fails
+	RegisterPasswordVerifyFunc(func(ctx context.Context, username, password string) bool {
+		return false
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/expr", nil)
+	req.SetBasicAuth("testuser", "wrongpassword")
+
+	err := CheckPrivilege(
+		s.ctx,
+		req,
+		commonpb.ObjectType_Global,
+		commonpb.ObjectPrivilege_PrivilegeAll.String(),
+		util.AnyWord,
+		util.DefaultDBName,
+	)
+
+	s.Error(err)
+	s.True(IsAuthenticationError(err))
+	s.Contains(err.Error(), "invalid credentials")
+}
+
+func (s *CheckPrivilegeTestSuite) TestRootUserBypassWhenRootShouldBindRoleIsFalse() {
+	paramtable.Get().Save(paramtable.Get().CommonCfg.AuthorizationEnabled.Key, "true")
+	paramtable.Get().Save(paramtable.Get().CommonCfg.RootShouldBindRole.Key, "false")
+
+	// Register a password verify function that accepts root
+	RegisterPasswordVerifyFunc(func(ctx context.Context, username, password string) bool {
+		return username == util.UserRoot && password == "Milvus"
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/expr", nil)
+	req.SetBasicAuth(util.UserRoot, "Milvus")
+
+	err := CheckPrivilege(
+		s.ctx,
+		req,
+		commonpb.ObjectType_Global,
+		commonpb.ObjectPrivilege_PrivilegeAll.String(),
+		util.AnyWord,
+		util.DefaultDBName,
+	)
+
+	// Root user should bypass privilege check
+	s.NoError(err)
+}
+
+func (s *CheckPrivilegeTestSuite) TestRootUserNoBypassWhenRootShouldBindRoleIsTrue() {
+	paramtable.Get().Save(paramtable.Get().CommonCfg.AuthorizationEnabled.Key, "true")
+	paramtable.Get().Save(paramtable.Get().CommonCfg.RootShouldBindRole.Key, "true")
+
+	// Register a password verify function that accepts root
+	RegisterPasswordVerifyFunc(func(ctx context.Context, username, password string) bool {
+		return username == util.UserRoot && password == "Milvus"
+	})
+
+	// getUserRoleFunc not set, should fail
+	getUserRoleFunc = nil
+
+	req := httptest.NewRequest(http.MethodGet, "/expr", nil)
+	req.SetBasicAuth(util.UserRoot, "Milvus")
+
+	err := CheckPrivilege(
+		s.ctx,
+		req,
+		commonpb.ObjectType_Global,
+		commonpb.ObjectPrivilege_PrivilegeAll.String(),
+		util.AnyWord,
+		util.DefaultDBName,
+	)
+
+	// Root user should NOT bypass when RootShouldBindRole is true
+	// It will fail because getUserRoleFunc is nil
+	s.Error(err)
+	s.True(IsServiceUnavailableError(err))
+	s.Contains(err.Error(), "role lookup not available")
+}
+
+func (s *CheckPrivilegeTestSuite) TestRoleLookupFailure() {
+	paramtable.Get().Save(paramtable.Get().CommonCfg.AuthorizationEnabled.Key, "true")
+	paramtable.Get().Save(paramtable.Get().CommonCfg.RootShouldBindRole.Key, "false")
+
+	// Register a password verify function
+	RegisterPasswordVerifyFunc(func(ctx context.Context, username, password string) bool {
+		return username == "testuser" && password == "testpass"
+	})
+
+	// Register a getUserRoleFunc that returns an error
+	RegisterGetUserRoleFunc(func(username string) ([]string, error) {
+		return nil, errors.New("role lookup failed")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/expr", nil)
+	req.SetBasicAuth("testuser", "testpass")
+
+	err := CheckPrivilege(
+		s.ctx,
+		req,
+		commonpb.ObjectType_Global,
+		commonpb.ObjectPrivilege_PrivilegeAll.String(),
+		util.AnyWord,
+		util.DefaultDBName,
+	)
+
+	s.Error(err)
+	s.True(IsServiceUnavailableError(err))
+	s.Contains(err.Error(), "failed to get user roles")
+}
+
+func TestCheckPrivilegeSuite(t *testing.T) {
+	suite.Run(t, new(CheckPrivilegeTestSuite))
+}
+
+// CheckPrivilegeWithEnforcerTestSuite tests CheckPrivilege with Casbin enforcer
+// These tests require setting up the privilege cache and enforcer
+type CheckPrivilegeWithEnforcerTestSuite struct {
+	suite.Suite
+	ctx                    context.Context
+	originalPasswordVerify func(ctx context.Context, username, password string) bool
+	originalGetUserRole    func(username string) ([]string, error)
+}
+
+func (s *CheckPrivilegeWithEnforcerTestSuite) SetupSuite() {
+	paramtable.Init()
+}
+
+func (s *CheckPrivilegeWithEnforcerTestSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.originalPasswordVerify = passwordVerifyFunc
+	s.originalGetUserRole = getUserRoleFunc
+}
+
+func (s *CheckPrivilegeWithEnforcerTestSuite) TearDownTest() {
+	passwordVerifyFunc = s.originalPasswordVerify
+	getUserRoleFunc = s.originalGetUserRole
+	paramtable.Get().Reset(paramtable.Get().CommonCfg.AuthorizationEnabled.Key)
+	paramtable.Get().Reset(paramtable.Get().CommonCfg.RootShouldBindRole.Key)
+	paramtable.Get().Reset(paramtable.Get().CommonCfg.ExprAuthMode.Key)
+	privilege.CleanPrivilegeCache()
+}
+
+func loadPrivilegePoliciesForTest(t testing.TB, policies []string, userRoles ...string) {
+	t.Helper()
+	err := privilege.InitPrivilegeCache(context.Background(), &fakeMixCoordClient{policies: policies, userRoles: userRoles})
+	assert.NoError(t, err)
+}
+
+func (s *CheckPrivilegeWithEnforcerTestSuite) initPrivilegeCacheWithPolicies(policies []string, userRoles []string) {
+	loadPrivilegePoliciesForTest(s.T(), policies, userRoles...)
+	privilege.CleanPrivilegeCache()
+}
+
+type fakeMixCoordClient struct {
+	types.MixCoordClient
+	policies  []string
+	userRoles []string
+}
+
+func (f *fakeMixCoordClient) ListPolicy(ctx context.Context, in *internalpb.ListPolicyRequest, opts ...grpc.CallOption) (*internalpb.ListPolicyResponse, error) {
+	return &internalpb.ListPolicyResponse{
+		Status:      merr.Success(),
+		PolicyInfos: f.policies,
+		UserRoles:   f.userRoles,
+	}, nil
+}
+
+func (s *CheckPrivilegeWithEnforcerTestSuite) TestPermissionGrantedByRole() {
+	paramtable.Get().Save(paramtable.Get().CommonCfg.AuthorizationEnabled.Key, "true")
+	paramtable.Get().Save(paramtable.Get().CommonCfg.RootShouldBindRole.Key, "false")
+	privilege.InitPrivilegeGroups()
+
+	// Set up policies: role1 has PrivilegeAll on Global.*
+	policies := []string{
+		funcutil.PolicyForPrivilege("role1", commonpb.ObjectType_Global.String(), "*", commonpb.ObjectPrivilege_PrivilegeAll.String(), "default"),
+	}
+	userRoles := []string{
+		funcutil.EncodeUserRoleCache("testuser", "role1"),
+	}
+	s.initPrivilegeCacheWithPolicies(policies, userRoles)
+
+	// Register password verify function
+	RegisterPasswordVerifyFunc(func(ctx context.Context, username, password string) bool {
+		return username == "testuser" && password == "testpass"
+	})
+
+	// Register getUserRoleFunc to return role1
+	RegisterGetUserRoleFunc(func(username string) ([]string, error) {
+		if username == "testuser" {
+			return []string{"role1"}, nil
+		}
+		return nil, nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/expr", nil)
+	req.SetBasicAuth("testuser", "testpass")
+
+	err := CheckPrivilege(
+		s.ctx,
+		req,
+		commonpb.ObjectType_Global,
+		commonpb.ObjectPrivilege_PrivilegeAll.String(),
+		util.AnyWord,
+		util.DefaultDBName,
+	)
+
+	s.NoError(err)
+}
+
+func (s *CheckPrivilegeWithEnforcerTestSuite) TestPermissionDeniedForAllRoles() {
+	paramtable.Get().Save(paramtable.Get().CommonCfg.AuthorizationEnabled.Key, "true")
+	paramtable.Get().Save(paramtable.Get().CommonCfg.RootShouldBindRole.Key, "false")
+	privilege.InitPrivilegeGroups()
+
+	// Set up policies: role1 has only PrivilegeLoad on Collection
+	policies := []string{
+		funcutil.PolicyForPrivilege("role1", commonpb.ObjectType_Collection.String(), "col1", commonpb.ObjectPrivilege_PrivilegeLoad.String(), "default"),
+	}
+	userRoles := []string{
+		funcutil.EncodeUserRoleCache("testuser", "role1"),
+	}
+	s.initPrivilegeCacheWithPolicies(policies, userRoles)
+
+	// Register password verify function
+	RegisterPasswordVerifyFunc(func(ctx context.Context, username, password string) bool {
+		return username == "testuser" && password == "testpass"
+	})
+
+	// Register getUserRoleFunc to return role1
+	RegisterGetUserRoleFunc(func(username string) ([]string, error) {
+		if username == "testuser" {
+			return []string{"role1"}, nil
+		}
+		return nil, nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/expr", nil)
+	req.SetBasicAuth("testuser", "testpass")
+
+	// Request a privilege that role1 doesn't have
+	err := CheckPrivilege(
+		s.ctx,
+		req,
+		commonpb.ObjectType_Global,
+		commonpb.ObjectPrivilege_PrivilegeAll.String(),
+		util.AnyWord,
+		util.DefaultDBName,
+	)
+
+	s.Error(err)
+	s.True(IsPermissionDeniedError(err))
+	s.Contains(err.Error(), "permission denied")
+}
+
+func (s *CheckPrivilegeWithEnforcerTestSuite) TestCacheHitPermissionGranted() {
+	paramtable.Get().Save(paramtable.Get().CommonCfg.AuthorizationEnabled.Key, "true")
+	paramtable.Get().Save(paramtable.Get().CommonCfg.RootShouldBindRole.Key, "false")
+	privilege.InitPrivilegeGroups()
+
+	// Set up policies with permission granted
+	policies := []string{
+		funcutil.PolicyForPrivilege("role1", commonpb.ObjectType_Global.String(), "*", commonpb.ObjectPrivilege_PrivilegeAll.String(), "default"),
+	}
+	userRoles := []string{
+		funcutil.EncodeUserRoleCache("testuser", "role1"),
+	}
+	s.initPrivilegeCacheWithPolicies(policies, userRoles)
+
+	// Register password verify function
+	RegisterPasswordVerifyFunc(func(ctx context.Context, username, password string) bool {
+		return username == "testuser" && password == "testpass"
+	})
+
+	// Register getUserRoleFunc
+	RegisterGetUserRoleFunc(func(username string) ([]string, error) {
+		if username == "testuser" {
+			return []string{"role1"}, nil
+		}
+		return nil, nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/expr", nil)
+	req.SetBasicAuth("testuser", "testpass")
+
+	// First call - cache miss, will populate cache
+	err := CheckPrivilege(
+		s.ctx,
+		req,
+		commonpb.ObjectType_Global,
+		commonpb.ObjectPrivilege_PrivilegeAll.String(),
+		util.AnyWord,
+		util.DefaultDBName,
+	)
+	s.NoError(err)
+
+	// Second call - should hit cache
+	err = CheckPrivilege(
+		s.ctx,
+		req,
+		commonpb.ObjectType_Global,
+		commonpb.ObjectPrivilege_PrivilegeAll.String(),
+		util.AnyWord,
+		util.DefaultDBName,
+	)
+	s.NoError(err)
+}
+
+func (s *CheckPrivilegeWithEnforcerTestSuite) TestCacheHitPermissionDenied() {
+	paramtable.Get().Save(paramtable.Get().CommonCfg.AuthorizationEnabled.Key, "true")
+	paramtable.Get().Save(paramtable.Get().CommonCfg.RootShouldBindRole.Key, "false")
+	privilege.InitPrivilegeGroups()
+
+	// Set up policies without the requested permission
+	policies := []string{
+		funcutil.PolicyForPrivilege("role1", commonpb.ObjectType_Collection.String(), "col1", commonpb.ObjectPrivilege_PrivilegeLoad.String(), "default"),
+	}
+	userRoles := []string{
+		funcutil.EncodeUserRoleCache("testuser", "role1"),
+	}
+	s.initPrivilegeCacheWithPolicies(policies, userRoles)
+
+	// Register password verify function
+	RegisterPasswordVerifyFunc(func(ctx context.Context, username, password string) bool {
+		return username == "testuser" && password == "testpass"
+	})
+
+	// Register getUserRoleFunc
+	RegisterGetUserRoleFunc(func(username string) ([]string, error) {
+		if username == "testuser" {
+			return []string{"role1"}, nil
+		}
+		return nil, nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/expr", nil)
+	req.SetBasicAuth("testuser", "testpass")
+
+	// First call - cache miss, will populate cache with denied result
+	err := CheckPrivilege(
+		s.ctx,
+		req,
+		commonpb.ObjectType_Global,
+		commonpb.ObjectPrivilege_PrivilegeAll.String(),
+		util.AnyWord,
+		util.DefaultDBName,
+	)
+	s.Error(err)
+	s.True(IsPermissionDeniedError(err))
+
+	// Second call - should hit cache and still be denied
+	err = CheckPrivilege(
+		s.ctx,
+		req,
+		commonpb.ObjectType_Global,
+		commonpb.ObjectPrivilege_PrivilegeAll.String(),
+		util.AnyWord,
+		util.DefaultDBName,
+	)
+	s.Error(err)
+	s.True(IsPermissionDeniedError(err))
+}
+
+func (s *CheckPrivilegeWithEnforcerTestSuite) TestRootUserWithRootShouldBindRoleTrueAndAdminRole() {
+	paramtable.Get().Save(paramtable.Get().CommonCfg.AuthorizationEnabled.Key, "true")
+	paramtable.Get().Save(paramtable.Get().CommonCfg.RootShouldBindRole.Key, "true")
+	privilege.InitPrivilegeGroups()
+
+	// Set up policies: root user is assigned to admin role
+	// admin role bypasses privilege checks in Casbin model
+	policies := []string{}
+	userRoles := []string{
+		funcutil.EncodeUserRoleCache(util.UserRoot, "admin"),
+	}
+	s.initPrivilegeCacheWithPolicies(policies, userRoles)
+
+	// Register password verify function
+	RegisterPasswordVerifyFunc(func(ctx context.Context, username, password string) bool {
+		return username == util.UserRoot && password == "Milvus"
+	})
+
+	// Register getUserRoleFunc
+	RegisterGetUserRoleFunc(func(username string) ([]string, error) {
+		if username == util.UserRoot {
+			return []string{"admin"}, nil
+		}
+		return nil, nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/expr", nil)
+	req.SetBasicAuth(util.UserRoot, "Milvus")
+
+	err := CheckPrivilege(
+		s.ctx,
+		req,
+		commonpb.ObjectType_Global,
+		commonpb.ObjectPrivilege_PrivilegeAll.String(),
+		util.AnyWord,
+		util.DefaultDBName,
+	)
+
+	// Should succeed because admin role bypasses privilege checks
+	s.NoError(err)
+}
+
+func TestCheckPrivilegeWithEnforcerSuite(t *testing.T) {
+	suite.Run(t, new(CheckPrivilegeWithEnforcerTestSuite))
+}

--- a/internal/http/rbac_test.go
+++ b/internal/http/rbac_test.go
@@ -18,13 +18,14 @@ package http
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"google.golang.org/grpc"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus/internal/proxy/privilege"
@@ -34,7 +35,6 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
-	"google.golang.org/grpc"
 )
 
 func TestParseHTTPAuth(t *testing.T) {

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -19,6 +19,7 @@ package http
 import (
 	"context"
 	"embed"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
@@ -30,7 +31,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/internal/http/healthz"
-	"github.com/milvus-io/milvus/internal/json"
 	"github.com/milvus-io/milvus/pkg/v3/eventlog"
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/util/expr"
@@ -76,6 +76,12 @@ type Handler struct {
 	Handler     http.Handler
 }
 
+func writeJSONError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(map[string]string{"msg": msg})
+}
+
 func registerDefaults() {
 	Register(&Handler{
 		Path: LogLevelRouterPath,
@@ -116,8 +122,7 @@ func registerDefaults() {
 			}
 
 			if err := CheckExprAuth(req.Context(), req); err != nil {
-				w.WriteHeader(HTTPStatusFromPrivilegeError(err))
-				fmt.Fprintf(w, `{"msg": "%s"}`, err.Error()) //nolint:gosec // error message is authored by CheckExprAuth and safe to include in response
+				writeJSONError(w, HTTPStatusFromPrivilegeError(err), err.Error())
 				return
 			}
 			// Use bypass since we've already authenticated
@@ -125,8 +130,8 @@ func registerDefaults() {
 
 			output, err := expr.Exec(code, auth)
 			if err != nil {
-				w.WriteHeader(http.StatusInternalServerError)
-				fmt.Fprintf(w, `{"msg": "failed to execute expression, %s"}`, err.Error()) //nolint:gosec // error message is safe to include in response
+				writeJSONError(w, http.StatusInternalServerError,
+					fmt.Sprintf("failed to execute expression, %s", err.Error()))
 				return
 			}
 			w.Header().Set("Content-Type", "application/json")

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -34,7 +34,6 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/eventlog"
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/util/expr"
-	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -116,9 +115,8 @@ func registerDefaults() {
 				return
 			}
 
-			// On Proxy node: require root user authentication via HTTP Basic Auth
-			if err := checkExprRootAuth(req); err != nil {
-				w.WriteHeader(http.StatusUnauthorized)
+			if err := CheckExprAuth(req.Context(), req); err != nil {
+				w.WriteHeader(HTTPStatusFromPrivilegeError(err))
 				fmt.Fprintf(w, `{"msg": "%s"}`, err.Error())
 				return
 			}
@@ -313,43 +311,4 @@ func getHTTPAddr() string {
 	paramtable.Get().Save(paramtable.Get().CommonCfg.MetricsPort.Key, port)
 
 	return fmt.Sprintf(":%s", port)
-}
-
-// checkExprRootAuth verifies that the request is from the root user.
-// It supports HTTP Basic Auth and Bearer token formats.
-func checkExprRootAuth(req *http.Request) error {
-	// Try HTTP Basic Auth first
-	username, password, ok := req.BasicAuth()
-	if !ok {
-		// Try Bearer token format: "user:password"
-		auth := req.Header.Get("Authorization")
-		auth = strings.TrimPrefix(auth, "Bearer ")
-		parts := strings.SplitN(auth, ":", 2)
-		if len(parts) == 2 {
-			username, password = parts[0], parts[1]
-			ok = true
-		}
-	}
-
-	if !ok || username == "" || password == "" {
-		return merr.WrapErrParameterInvalidMsg("authentication required. Use HTTP Basic Auth with root credentials")
-	}
-
-	// Only root user can access /expr
-	if username != "root" {
-		log.Warn("non-root user attempted to access /expr", zap.String("username", username))
-		return merr.WrapErrParameterInvalidMsg("only root user can access /expr endpoint")
-	}
-
-	// Verify root password
-	if passwordVerifyFunc == nil {
-		return merr.WrapErrServiceInternalMsg("password verification not available")
-	}
-	if !passwordVerifyFunc(context.Background(), username, password) {
-		log.Warn("invalid root password for /expr access")
-		return merr.WrapErrParameterInvalidMsg("invalid root password")
-	}
-
-	log.Info("root user authenticated for /expr access")
-	return nil
 }

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -117,7 +117,7 @@ func registerDefaults() {
 
 			if err := CheckExprAuth(req.Context(), req); err != nil {
 				w.WriteHeader(HTTPStatusFromPrivilegeError(err))
-				fmt.Fprintf(w, `{"msg": "%s"}`, err.Error())
+				fmt.Fprintf(w, `{"msg": "%s"}`, err.Error()) //nolint:gosec // error message is authored by CheckExprAuth and safe to include in response
 				return
 			}
 			// Use bypass since we've already authenticated

--- a/internal/http/server_test.go
+++ b/internal/http/server_test.go
@@ -36,8 +36,11 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus/internal/http/healthz"
 	"github.com/milvus-io/milvus/internal/json"
+	"github.com/milvus-io/milvus/internal/proxy/privilege"
 	"github.com/milvus-io/milvus/pkg/v3/log"
+	"github.com/milvus-io/milvus/pkg/v3/util"
 	"github.com/milvus-io/milvus/pkg/v3/util/expr"
+	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -235,15 +238,73 @@ func (suite *HTTPServerTestSuite) TestExprHandler() {
 		suite.True(strings.Contains(string(body), "only available on Proxy nodes"))
 	})
 
-	suite.Run("enabled_on_proxy_requires_root_auth", func() {
-		// When enabled on Proxy node (proxy registered and passwordVerifyFunc set),
-		// it should require root user authentication
+	suite.Run("root_only_requires_root_when_authorization_disabled", func() {
 		paramtable.Get().Save("common.security.exprEnabled", "true")
+		paramtable.Get().Save("common.security.exprAuthMode", ExprAuthModeRootOnly)
+		paramtable.Get().Save("common.security.authorizationEnabled", "false")
 		expr.Register("proxy", "mock_proxy")
 
-		// Register a mock password verify function
+		RegisterPasswordVerifyFunc(func(ctx context.Context, username, password string) bool {
+			return (username == "root" && password == "Milvus") ||
+				(username == "admin" && password == "admin123")
+		})
+
+		url := "http://localhost:" + DefaultListenPort + ExprPath + "?code=foo"
+		client := http.Client{}
+		req, _ := http.NewRequest(http.MethodGet, url, nil)
+		req.SetBasicAuth("admin", "admin123")
+		resp, err := client.Do(req)
+		suite.Nil(err)
+		defer resp.Body.Close()
+		suite.Equal(http.StatusForbidden, resp.StatusCode)
+		body, _ := io.ReadAll(resp.Body)
+		suite.True(strings.Contains(string(body), "only root user can access"))
+
+		req, _ = http.NewRequest(http.MethodGet, url, nil)
+		req.SetBasicAuth("root", "Milvus")
+		resp, err = client.Do(req)
+		suite.Nil(err)
+		defer resp.Body.Close()
+		suite.Equal(http.StatusOK, resp.StatusCode)
+		body, _ = io.ReadAll(resp.Body)
+		suite.True(strings.Contains(string(body), "hello"))
+	})
+
+	suite.Run("rbac_mode_requires_authorization_enabled", func() {
+		paramtable.Get().Save("common.security.exprEnabled", "true")
+		paramtable.Get().Save("common.security.exprAuthMode", ExprAuthModeRBAC)
+		paramtable.Get().Save("common.security.authorizationEnabled", "false")
+		expr.Register("proxy", "mock_proxy")
+
 		RegisterPasswordVerifyFunc(func(ctx context.Context, username, password string) bool {
 			return username == "root" && password == "Milvus"
+		})
+
+		url := "http://localhost:" + DefaultListenPort + ExprPath + "?code=foo"
+		client := http.Client{}
+		req, _ := http.NewRequest(http.MethodGet, url, nil)
+		req.SetBasicAuth("root", "Milvus")
+		resp, err := client.Do(req)
+		suite.Nil(err)
+		defer resp.Body.Close()
+		suite.Equal(http.StatusForbidden, resp.StatusCode)
+		body, _ := io.ReadAll(resp.Body)
+		suite.True(strings.Contains(string(body), "authorization must be enabled"))
+	})
+
+	suite.Run("enabled_on_proxy_with_rbac_root_bypass", func() {
+		// When authorization is enabled but RootShouldBindRole is false,
+		// root user should be able to access via bypass
+		paramtable.Get().Save("common.security.exprEnabled", "true")
+		paramtable.Get().Save("common.security.exprAuthMode", ExprAuthModeRBAC)
+		paramtable.Get().Save("common.security.authorizationEnabled", "true")
+		paramtable.Get().Save("common.security.rootShouldBindRole", "false")
+		expr.Register("proxy", "mock_proxy")
+
+		// Register mock functions
+		RegisterPasswordVerifyFunc(func(ctx context.Context, username, password string) bool {
+			return (username == "root" && password == "Milvus") ||
+				(username == "admin" && password == "admin123")
 		})
 
 		// Without auth header - should fail with 401
@@ -257,16 +318,16 @@ func (suite *HTTPServerTestSuite) TestExprHandler() {
 		body, _ := io.ReadAll(resp.Body)
 		suite.True(strings.Contains(string(body), "authentication required"))
 
-		// With non-root user - should fail with 401
+		// With non-root user (without Expr privilege) - should fail with 401 (invalid credentials)
 		url = "http://localhost:" + DefaultListenPort + ExprPath + "?code=foo"
 		req, _ = http.NewRequest(http.MethodGet, url, nil)
-		req.SetBasicAuth("admin", "password")
+		req.SetBasicAuth("admin", "wrong_password")
 		resp, err = client.Do(req)
 		suite.Nil(err)
 		defer resp.Body.Close()
 		suite.Equal(http.StatusUnauthorized, resp.StatusCode)
 		body, _ = io.ReadAll(resp.Body)
-		suite.True(strings.Contains(string(body), "only root user"))
+		suite.True(strings.Contains(string(body), "invalid credentials"))
 
 		// With root user but wrong password - should fail with 401
 		url = "http://localhost:" + DefaultListenPort + ExprPath + "?code=foo"
@@ -277,9 +338,9 @@ func (suite *HTTPServerTestSuite) TestExprHandler() {
 		defer resp.Body.Close()
 		suite.Equal(http.StatusUnauthorized, resp.StatusCode)
 		body, _ = io.ReadAll(resp.Body)
-		suite.True(strings.Contains(string(body), "invalid root password"))
+		suite.True(strings.Contains(string(body), "invalid credentials"))
 
-		// With correct root credentials - should succeed
+		// With correct root credentials - should succeed via root bypass
 		url = "http://localhost:" + DefaultListenPort + ExprPath + "?code=foo"
 		req, _ = http.NewRequest(http.MethodGet, url, nil)
 		req.SetBasicAuth("root", "Milvus")
@@ -291,8 +352,95 @@ func (suite *HTTPServerTestSuite) TestExprHandler() {
 		suite.True(strings.Contains(string(body), "hello"))
 	})
 
+	suite.Run("enabled_on_proxy_non_root_user_without_privilege", func() {
+		// Non-root user with valid credentials but without PrivilegeExpr privilege
+		// should get 403 Forbidden
+		paramtable.Get().Save("common.security.exprEnabled", "true")
+		paramtable.Get().Save("common.security.exprAuthMode", ExprAuthModeRBAC)
+		paramtable.Get().Save("common.security.authorizationEnabled", "true")
+		paramtable.Get().Save("common.security.rootShouldBindRole", "false")
+		expr.Register("proxy", "mock_proxy")
+		privilege.InitPrivilegeGroups()
+
+		// Register mock password verify function
+		RegisterPasswordVerifyFunc(func(ctx context.Context, username, password string) bool {
+			return (username == "root" && password == "Milvus") ||
+				(username == "admin" && password == "admin123")
+		})
+
+		// Register mock getUserRoleFunc - admin has role1 but no PrivilegeExpr
+		RegisterGetUserRoleFunc(func(username string) ([]string, error) {
+			if username == "admin" {
+				return []string{"role1"}, nil
+			}
+			return []string{}, nil
+		})
+
+		loadPrivilegePoliciesForTest(suite.T(), []string{
+			funcutil.PolicyForPrivilege("role1", commonpb.ObjectType_Collection.String(), "col1", commonpb.ObjectPrivilege_PrivilegeLoad.String(), "default"),
+		})
+		defer privilege.CleanPrivilegeCache()
+
+		// Non-root user with valid credentials but without PrivilegeExpr - should fail with 403
+		url := "http://localhost:" + DefaultListenPort + ExprPath + "?code=foo"
+		client := http.Client{}
+		req, _ := http.NewRequest(http.MethodGet, url, nil)
+		req.SetBasicAuth("admin", "admin123")
+		resp, err := client.Do(req)
+		suite.Nil(err)
+		defer resp.Body.Close()
+		suite.Equal(http.StatusForbidden, resp.StatusCode)
+		body, _ := io.ReadAll(resp.Body)
+		suite.True(strings.Contains(string(body), "permission denied"))
+	})
+
+	suite.Run("enabled_on_proxy_non_root_user_with_privilege", func() {
+		// Non-root user with valid credentials and PrivilegeExpr privilege
+		// should get 200 OK
+		paramtable.Get().Save("common.security.exprEnabled", "true")
+		paramtable.Get().Save("common.security.exprAuthMode", ExprAuthModeRBAC)
+		paramtable.Get().Save("common.security.authorizationEnabled", "true")
+		paramtable.Get().Save("common.security.rootShouldBindRole", "false")
+		expr.Register("proxy", "mock_proxy")
+		privilege.InitPrivilegeGroups()
+
+		// Register mock password verify function
+		RegisterPasswordVerifyFunc(func(ctx context.Context, username, password string) bool {
+			return (username == "root" && password == "Milvus") ||
+				(username == "admin" && password == "admin123")
+		})
+
+		// Register mock getUserRoleFunc - admin has role1 with PrivilegeExpr
+		RegisterGetUserRoleFunc(func(username string) ([]string, error) {
+			if username == "admin" {
+				return []string{"role1"}, nil
+			}
+			return []string{}, nil
+		})
+
+		loadPrivilegePoliciesForTest(suite.T(), []string{
+			funcutil.PolicyForPrivilege("role1", commonpb.ObjectType_Global.String(), "*", util.PrivilegeExpr, "default"),
+		})
+		defer privilege.CleanPrivilegeCache()
+
+		// Non-root user with valid credentials and PrivilegeExpr - should succeed with 200
+		url := "http://localhost:" + DefaultListenPort + ExprPath + "?code=foo"
+		client := http.Client{}
+		req, _ := http.NewRequest(http.MethodGet, url, nil)
+		req.SetBasicAuth("admin", "admin123")
+		resp, err := client.Do(req)
+		suite.Nil(err)
+		defer resp.Body.Close()
+		suite.Equal(http.StatusOK, resp.StatusCode)
+		body, _ := io.ReadAll(resp.Body)
+		suite.True(strings.Contains(string(body), "hello"))
+	})
+
 	// Reset config
 	paramtable.Get().Save("common.security.exprEnabled", "false")
+	paramtable.Get().Save("common.security.exprAuthMode", ExprAuthModeRootOnly)
+	paramtable.Get().Save("common.security.authorizationEnabled", "false")
+	paramtable.Get().Save("common.security.rootShouldBindRole", "false")
 }
 
 func TestHTTPServerSuite(t *testing.T) {

--- a/internal/http/server_test.go
+++ b/internal/http/server_test.go
@@ -352,6 +352,63 @@ func (suite *HTTPServerTestSuite) TestExprHandler() {
 		suite.True(strings.Contains(string(body), "hello"))
 	})
 
+	suite.Run("invalid_auth_mode_returns_valid_json", func() {
+		paramtable.Get().Save("common.security.exprEnabled", "true")
+		paramtable.Get().Save("common.security.exprAuthMode", "rbca")
+		paramtable.Get().Save("common.security.authorizationEnabled", "true")
+		paramtable.Get().Save("common.security.rootShouldBindRole", "false")
+		expr.Register("proxy", "mock_proxy")
+
+		RegisterPasswordVerifyFunc(func(ctx context.Context, username, password string) bool {
+			return (username == "root" && password == "Milvus") ||
+				(username == "admin" && password == "admin123")
+		})
+
+		url := "http://localhost:" + DefaultListenPort + ExprPath + "?code=foo"
+		client := http.Client{}
+		req, _ := http.NewRequest(http.MethodGet, url, nil)
+		req.SetBasicAuth("root", "Milvus")
+		resp, err := client.Do(req)
+		suite.Nil(err)
+		defer resp.Body.Close()
+		suite.Equal(http.StatusForbidden, resp.StatusCode)
+
+		body, _ := io.ReadAll(resp.Body)
+		var parsed map[string]string
+		err = json.Unmarshal(body, &parsed)
+		suite.NoError(err)
+		suite.Contains(parsed["msg"], "rbca")
+	})
+
+	suite.Run("exec_error_returns_valid_json", func() {
+		paramtable.Get().Save("common.security.exprEnabled", "true")
+		paramtable.Get().Save("common.security.exprAuthMode", ExprAuthModeRootOnly)
+		paramtable.Get().Save("common.security.authorizationEnabled", "false")
+		paramtable.Get().Save("common.security.rootShouldBindRole", "false")
+		expr.Register("proxy", "mock_proxy")
+
+		RegisterPasswordVerifyFunc(func(ctx context.Context, username, password string) bool {
+			return (username == "root" && password == "Milvus") ||
+				(username == "admin" && password == "admin123")
+		})
+
+		url := "http://localhost:" + DefaultListenPort + ExprPath + "?code=1%2B"
+		client := http.Client{}
+		req, _ := http.NewRequest(http.MethodGet, url, nil)
+		req.SetBasicAuth("root", "Milvus")
+		resp, err := client.Do(req)
+		suite.Nil(err)
+		defer resp.Body.Close()
+		suite.Equal(http.StatusInternalServerError, resp.StatusCode)
+
+		body, _ := io.ReadAll(resp.Body)
+		var parsed map[string]string
+		err = json.Unmarshal(body, &parsed)
+		suite.NoError(err)
+		suite.Contains(parsed["msg"], "failed to execute expression")
+		suite.Contains(parsed["msg"], "unexpected token EOF")
+	})
+
 	suite.Run("enabled_on_proxy_non_root_user_without_privilege", func() {
 		// Non-root user with valid credentials but without PrivilegeExpr privilege
 		// should get 403 Forbidden

--- a/internal/proxy/meta_cache.go
+++ b/internal/proxy/meta_cache.go
@@ -408,6 +408,9 @@ func InitMetaCache(ctx context.Context, mixCoord types.MixCoordClient) error {
 	// Register password verify function for /expr endpoint authentication
 	internalhttp.RegisterPasswordVerifyFunc(PasswordVerify)
 
+	// Register get user role function for /expr endpoint RBAC check
+	internalhttp.RegisterGetUserRoleFunc(GetRole)
+
 	return nil
 }
 

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -73,6 +73,8 @@ const (
 	RoleConfigPrivilege  = "privilege"
 
 	PreserveFieldIdsKey = "preserve_field_ids"
+
+	PrivilegeExpr = "PrivilegeExpr"
 )
 
 var (
@@ -171,6 +173,8 @@ var (
 			MetaStore2API(commonpb.ObjectPrivilege_PrivilegeGroupCollectionReadWrite.String()),
 			MetaStore2API(commonpb.ObjectPrivilege_PrivilegeGroupCollectionAdmin.String()),
 			MetaStore2API(commonpb.ObjectPrivilege_PrivilegeUpdateReplicateConfiguration.String()),
+
+			MetaStore2API(PrivilegeExpr),
 		},
 		commonpb.ObjectType_User.String(): {
 			MetaStore2API(commonpb.ObjectPrivilege_PrivilegeUpdateUser.String()),
@@ -423,6 +427,7 @@ var (
 			commonpb.ObjectPrivilege_PrivilegeDropPrivilegeGroup.String(),
 			commonpb.ObjectPrivilege_PrivilegeOperatePrivilegeGroup.String(),
 			commonpb.ObjectPrivilege_PrivilegeUpdateReplicateConfiguration.String(),
+			PrivilegeExpr,
 		})...,
 	)
 )
@@ -477,8 +482,7 @@ func MetaStore2API(name string) string {
 }
 
 func PrivilegeNameForAPI(name string) string {
-	_, ok := commonpb.ObjectPrivilege_value[name]
-	if !ok {
+	if !isPrivilegeNameForMetastoreDefined(name) {
 		if strings.HasPrefix(name, PrivilegeGroupWord) {
 			return typeutil.After(name, PrivilegeGroupWord)
 		}
@@ -490,17 +494,22 @@ func PrivilegeNameForAPI(name string) string {
 func PrivilegeNameForMetastore(name string) string {
 	// check if name is single privilege
 	dbPrivilege := PrivilegeWord + name
-	_, ok := commonpb.ObjectPrivilege_value[dbPrivilege]
-	if !ok {
+	if !isPrivilegeNameForMetastoreDefined(dbPrivilege) {
 		// check if name is privilege group
 		dbPrivilege := PrivilegeGroupWord + name
-		_, ok := commonpb.ObjectPrivilege_value[dbPrivilege]
-		if !ok {
+		if !isPrivilegeNameForMetastoreDefined(dbPrivilege) {
 			return ""
 		}
 		return dbPrivilege
 	}
 	return dbPrivilege
+}
+
+func isPrivilegeNameForMetastoreDefined(name string) bool {
+	if _, ok := commonpb.ObjectPrivilege_value[name]; ok {
+		return true
+	}
+	return name == PrivilegeExpr
 }
 
 // check if the name is defined by built in privileges or privilege groups in system

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -509,6 +509,8 @@ func isPrivilegeNameForMetastoreDefined(name string) bool {
 	if _, ok := commonpb.ObjectPrivilege_value[name]; ok {
 		return true
 	}
+	// TODO: drop this special case once PrivilegeExpr is promoted to a proto enum value
+	// in milvus-io/milvus-proto (commonpb.ObjectPrivilege_PrivilegeExpr).
 	return name == PrivilegeExpr
 }
 

--- a/pkg/util/constant_test.go
+++ b/pkg/util/constant_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 )
 
 func TestGetReplicateConfigurationPrivilege(t *testing.T) {
@@ -36,4 +37,12 @@ func TestGetReplicateConfigurationPrivilege(t *testing.T) {
 		}
 	}
 	assert.True(t, found, "PrivilegeGetReplicateConfiguration should be in ClusterReadOnlyPrivileges")
+}
+
+func TestExprPrivilegeDefinition(t *testing.T) {
+	assert.Equal(t, "Expr", MetaStore2API(PrivilegeExpr))
+	assert.Equal(t, "Expr", PrivilegeNameForAPI(PrivilegeExpr))
+	assert.Equal(t, PrivilegeExpr, PrivilegeNameForMetastore("Expr"))
+	assert.True(t, IsPrivilegeNameDefined("Expr"))
+	assert.Equal(t, milvuspb.PrivilegeLevel_Cluster.String(), GetPrivilegeLevel("Expr"))
 }

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -944,8 +944,10 @@ Large numeric passwords require double quotes to avoid yaml parsing precision is
 		Key:          "common.security.exprAuthMode",
 		Version:      "2.6.0",
 		DefaultValue: "rootOnly",
-		Doc:          "Authentication mode for the /expr endpoint. Valid values: rootOnly, rbac.",
-		Export:       true,
+		Doc: "Authentication mode for the /expr endpoint. Valid values: rootOnly, rbac. " +
+			"rootOnly accepts only the root credentials via HTTP Basic Auth. " +
+			"rbac requires common.security.authorizationEnabled=true and grants access to any user holding the Expr privilege.",
+		Export: true,
 	}
 	p.ExprAuthMode.Init(base.mgr)
 

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -277,6 +277,7 @@ type commonConfig struct {
 	RootShouldBindRole    ParamItem `refreshable:"true"`
 	EnablePublicPrivilege ParamItem `refreshable:"false"`
 	ExprEnabled           ParamItem `refreshable:"false"`
+	ExprAuthMode          ParamItem `refreshable:"false"`
 
 	ClusterName ParamItem `refreshable:"false"`
 
@@ -934,10 +935,19 @@ Large numeric passwords require double quotes to avoid yaml parsing precision is
 		Key:          "common.security.exprEnabled",
 		Version:      "2.6.0",
 		DefaultValue: "false",
-		Doc:          "Whether to enable the /expr endpoint for debugging. When enabled, only root user can access it via HTTP Basic Auth on Proxy nodes.",
+		Doc:          "Whether to enable the /expr endpoint for debugging.",
 		Export:       true,
 	}
 	p.ExprEnabled.Init(base.mgr)
+
+	p.ExprAuthMode = ParamItem{
+		Key:          "common.security.exprAuthMode",
+		Version:      "2.6.0",
+		DefaultValue: "rootOnly",
+		Doc:          "Authentication mode for the /expr endpoint. Valid values: rootOnly, rbac.",
+		Export:       true,
+	}
+	p.ExprAuthMode.Init(base.mgr)
 
 	p.ClusterName = ParamItem{
 		Key:          "common.cluster.name",


### PR DESCRIPTION
related: #46442

This commit adds proper RBAC (Role-Based Access Control) support for the /expr HTTP endpoint, replacing the previous root-only authentication.

Changes:
- Add new rbac.go with CheckPrivilege function for HTTP endpoints
- Support HTTP Basic Auth only (removed non-standard Bearer token format)
- Integrate with existing Casbin RBAC framework
- Add PrivilegeExpr to GlobalLevelPrivileges and ClusterAdminPrivileges
- Register GetUserRoleFunc callback in meta_cache.go
- Update tests for new RBAC behavior

Security features:
- Authentication required when authorization is enabled
- Root user bypass when RootShouldBindRole is false
- Proper 401/403 status code differentiation
- Integration with privilege result cache