### PR TITLE
fix: query node timetick metrics : change msg_type from insert to timetick

### DIFF
--- a/deployments/monitor/grafana/milvus-dashboard.json
+++ b/deployments/monitor/grafana/milvus-dashboard.json
@@ -7352,7 +7352,7 @@
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "avg(milvus_querynode_consume_tt_lag_ms{app_kubernetes_io_instance=~\"$instance\", app_kubernetes_io_name=\"$app_name\", namespace=\"$namespace\", msg_type=\"insert\"}) by (pod, node_id)",
+              "expr": "avg(milvus_querynode_consume_tt_lag_ms{app_kubernetes_io_instance=~\"$instance\", app_kubernetes_io_name=\"$app_name\", namespace=\"$namespace\", msg_type=\"timetick\"}) by (pod, node_id)",
               "hide": false,
               "interval": "",
               "intervalFactor": 2,
@@ -7366,7 +7366,7 @@
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "max(milvus_querynode_consume_tt_lag_ms{app_kubernetes_io_instance=~\"$instance\", app_kubernetes_io_name=\"$app_name\", namespace=\"$namespace\", msg_type=\"insert\"}) by (pod, node_id)",
+              "expr": "max(milvus_querynode_consume_tt_lag_ms{app_kubernetes_io_instance=~\"$instance\", app_kubernetes_io_name=\"$app_name\", namespace=\"$namespace\", msg_type=\"timetick\"}) by (pod, node_id)",
               "hide": false,
               "interval": "",
               "legendFormat": "{{pod}}-{{node_id}}-max",
@@ -7378,7 +7378,7 @@
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "min(milvus_querynode_consume_tt_lag_ms{app_kubernetes_io_instance=~\"$instance\", app_kubernetes_io_name=\"$app_name\", namespace=\"$namespace\", msg_type=\"insert\"}) by (pod, node_id)",
+              "expr": "min(milvus_querynode_consume_tt_lag_ms{app_kubernetes_io_instance=~\"$instance\", app_kubernetes_io_name=\"$app_name\", namespace=\"$namespace\", msg_type=\"timetick\"}) by (pod, node_id)",
               "hide": false,
               "interval": "",
               "legendFormat": "{{pod}}-{{node_id}}-min",


### PR DESCRIPTION
Issue: [47079](https://github.com/milvus-io/milvus/issues/47079)

Update Query to Fix Query Node TimeTick utilization

Metrics for Query node is not appearing correctly. Query needs to be updated. Already confirmed with James on a separate thread.

Currently, query shows No data.

<img width="1662" height="628" alt="image" src="https://github.com/user-attachments/assets/5ee5420f-9dbd-4eca-b694-cb14ece4f5dd" />

Post fix, Data is available.

<img width="1669" height="373" alt="image" src="https://github.com/user-attachments/assets/cda0845c-2ab4-4472-8fa2-89d4c04555ad" />

