### PR TITLE
enhance: bump milvus-storage commit with new manifest and FFI interface

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -2997,7 +2997,7 @@ ChunkedSegmentSealedImpl::LoadManifest(const std::string& manifest_path) {
 
     std::vector<std::pair<int, std::vector<FieldId>>> cg_field_ids;
     for (int i = 0; i < column_groups->size(); ++i) {
-        auto column_group = column_groups->get_column_group(i);
+        auto column_group = column_groups->at(i);
         std::vector<FieldId> milvus_field_ids;
         for (auto& column : column_group->columns) {
             auto field_id = std::stoll(column);
@@ -3055,7 +3055,7 @@ ChunkedSegmentSealedImpl::LoadColumnGroup(
     const std::vector<FieldId>& milvus_field_ids) {
     AssertInfo(index < column_groups->size(),
                "load column group index out of range");
-    auto column_group = column_groups->get_column_group(index);
+    auto column_group = column_groups->at(index);
 
     auto field_metas = schema_->get_field_metas(milvus_field_ids);
 

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -1971,7 +1971,9 @@ SegmentGrowingImpl::LoadColumnsGroups(std::string manifest_path) {
         schema_->get_primary_field_id().value_or(FieldId(-1));
     auto properties = milvus::storage::LoonFFIPropertiesSingleton::GetInstance()
                           .GetProperties();
-    auto column_groups = GetColumnGroups(manifest_path, properties);
+    auto loon_manifest = GetLoonManifest(manifest_path, properties);
+    auto column_groups = std::make_shared<milvus_storage::api::ColumnGroups>(
+        loon_manifest->columnGroups());
 
     auto arrow_schema = schema_->ConvertToArrowSchema();
     reader_ = milvus_storage::api::Reader::create(
@@ -2039,7 +2041,7 @@ SegmentGrowingImpl::LoadColumnGroup(
     int64_t index) {
     AssertInfo(index < column_groups->size(),
                "load column group index out of range");
-    auto column_group = column_groups->get_column_group(index);
+    auto column_group = column_groups->at(index);
     LOG_INFO("Loading segment {} column group {}", id_, index);
 
     auto chunk_reader_result = reader_->get_chunk_reader(index);

--- a/internal/core/src/segcore/SegmentGrowingImpl.h
+++ b/internal/core/src/segcore/SegmentGrowingImpl.h
@@ -37,6 +37,7 @@
 #include "query/PlanNode.h"
 #include "common/GeometryCache.h"
 #include "common/ArrayOffsets.h"
+#include "milvus-storage/reader.h"
 
 namespace milvus::segcore {
 

--- a/internal/core/src/segcore/SegmentLoadInfo.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfo.cpp
@@ -36,7 +36,9 @@ SegmentLoadInfo::GetColumnGroups() {
     auto properties = milvus::storage::LoonFFIPropertiesSingleton::GetInstance()
                           .GetProperties();
 
-    column_groups_ = ::GetColumnGroups(manifest_path, properties);
+    auto loon_manifest = ::GetLoonManifest(manifest_path, properties);
+    column_groups_ = std::make_shared<milvus_storage::api::ColumnGroups>(
+        loon_manifest->columnGroups());
     return column_groups_;
 }
 
@@ -248,7 +250,7 @@ SegmentLoadInfo::ComputeDiffColumnGroups(LoadDiff& diff,
     // Build a set of current FieldIds from current column groups
     std::map<int64_t, int> cur_field_ids;
     for (int i = 0; i < cur_column_group->size(); i++) {
-        auto cg = cur_column_group->get_column_group(i);
+        auto cg = cur_column_group->at(i);
         for (const auto& column : cg->columns) {
             auto field_id = std::stoll(column);
             cur_field_ids.emplace(field_id, i);
@@ -258,7 +260,7 @@ SegmentLoadInfo::ComputeDiffColumnGroups(LoadDiff& diff,
     // Build a set of new FieldIds and find column groups to load
     std::map<int64_t, int> new_field_ids;
     for (int i = 0; i < new_column_group->size(); i++) {
-        auto cg = new_column_group->get_column_group(i);
+        auto cg = new_column_group->at(i);
         std::vector<FieldId> fields;
         for (const auto& column : cg->columns) {
             auto field_id = std::stoll(column);

--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -1503,13 +1503,15 @@ GetFieldDatasFromManifest(
     std::optional<DataType> data_type,
     int64_t dim,
     std::optional<DataType> element_type) {
-    auto column_groups = GetColumnGroups(manifest_path, loon_ffi_properties);
+    auto loon_manifest = GetLoonManifest(manifest_path, loon_ffi_properties);
+    auto column_groups = std::make_shared<milvus_storage::api::ColumnGroups>(
+        loon_manifest->columnGroups());
 
     // TODO remove manual check after loon support read null for non-exists field
     bool field_exists = false;
     const auto field_id_to_find = std::to_string(field_meta.field_id);
     for (size_t i = 0; i < column_groups->size() && !field_exists; i++) {
-        auto column_group = column_groups->get_column_group(i);
+        auto column_group = column_groups->at(i);
         for (const auto& column : column_group->columns) {
             if (column == field_id_to_find) {
                 field_exists = true;

--- a/internal/core/src/storage/loon_ffi/ffi_reader_c.h
+++ b/internal/core/src/storage/loon_ffi/ffi_reader_c.h
@@ -78,9 +78,7 @@ NewPackedFFIReader(const char* manifest_path,
  * as a string instead of reading from a file path. This is useful when the
  * manifest has already been loaded or is generated dynamically.
  *
- * @param manifest_content      The manifest content as a null-terminated string.
- *                              Must be valid JSON or protobuf text format containing
- *                              the manifest data.
+ * @param loon_manifest         Loon Manifest to open FFI reader with
  * @param schema                Arrow schema defining the structure of the data.
  *                              Must be a valid ArrowSchema pointer conforming to
  *                              the Arrow C data interface specification.
@@ -105,7 +103,7 @@ NewPackedFFIReader(const char* manifest_path,
  *       be freed after this call returns.
  */
 CStatus
-NewPackedFFIReaderWithManifest(const ColumnGroupsHandle column_groups_handle,
+NewPackedFFIReaderWithManifest(const LoonManifest* loon_manifest,
                                struct ArrowSchema* schema,
                                char** needed_columns,
                                int64_t needed_columns_size,

--- a/internal/core/src/storage/loon_ffi/util.h
+++ b/internal/core/src/storage/loon_ffi/util.h
@@ -15,8 +15,9 @@
 #include "common/common_type_c.h"
 #include "common/type_c.h"
 #include "milvus-storage/ffi_c.h"
+#include "milvus-storage/manifest.h"
 #include "milvus-storage/properties.h"
-#include "milvus-storage/transaction/manifest.h"
+#include "milvus-storage/column_groups.h"
 #include "storage/Types.h"
 
 /**
@@ -37,7 +38,7 @@
  * @return std::shared_ptr<Properties> Shared pointer to the created Properties
  * @throws std::runtime_error If properties_create fails with error message from FFI
  */
-std::shared_ptr<Properties>
+std::shared_ptr<LoonProperties>
 MakePropertiesFromStorageConfig(CStorageConfig c_storage_config);
 
 /**
@@ -87,7 +88,7 @@ ToCStorageConfig(const milvus::storage::StorageConfig& config);
  * @return Shared pointer to ColumnGroups metadata
  * @throws std::runtime_error If JSON parsing or manifest fetch fails
  */
-std::shared_ptr<milvus_storage::api::ColumnGroups>
-GetColumnGroups(
+std::shared_ptr<milvus_storage::api::Manifest>
+GetLoonManifest(
     const std::string& path,
     const std::shared_ptr<milvus_storage::api::Properties>& properties);

--- a/internal/core/thirdparty/milvus-storage/CMakeLists.txt
+++ b/internal/core/thirdparty/milvus-storage/CMakeLists.txt
@@ -14,7 +14,7 @@
 # Update milvus-storage_VERSION for the first occurrence
 milvus_add_pkg_config("milvus-storage")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( milvus-storage_VERSION 2ab2904)
+set( milvus-storage_VERSION 88c2551)
 set( GIT_REPOSITORY  "https://github.com/milvus-io/milvus-storage.git")
 message(STATUS "milvus-storage repo: ${GIT_REPOSITORY}")
 message(STATUS "milvus-storage version: ${milvus-storage_VERSION}")

--- a/internal/storagev2/packed/ffi_common.go
+++ b/internal/storagev2/packed/ffi_common.go
@@ -53,7 +53,7 @@ const (
 // This function converts a StorageConfig structure into a Properties object by
 // calling the FFI properties_create function. All configuration fields from
 // StorageConfig are mapped to corresponding key-value pairs in Properties.
-func MakePropertiesFromStorageConfig(storageConfig *indexpb.StorageConfig, extraKVs map[string]string) (*C.Properties, error) {
+func MakePropertiesFromStorageConfig(storageConfig *indexpb.StorageConfig, extraKVs map[string]string) (*C.LoonProperties, error) {
 	if storageConfig == nil {
 		return nil, fmt.Errorf("storageConfig is required")
 	}
@@ -163,7 +163,7 @@ func MakePropertiesFromStorageConfig(storageConfig *indexpb.StorageConfig, extra
 	}()
 
 	// Create Properties using FFI
-	properties := &C.Properties{}
+	properties := &C.LoonProperties{}
 	var cKeysPtr **C.char
 	var cValuesPtr **C.char
 	if len(cKeys) > 0 {
@@ -171,24 +171,24 @@ func MakePropertiesFromStorageConfig(storageConfig *indexpb.StorageConfig, extra
 		cValuesPtr = &cValues[0]
 	}
 
-	result := C.properties_create(
+	result := C.loon_properties_create(
 		(**C.char)(unsafe.Pointer(cKeysPtr)),
 		(**C.char)(unsafe.Pointer(cValuesPtr)),
 		C.size_t(len(keys)),
 		properties,
 	)
 
-	err := HandleFFIResult(result)
+	err := HandleLoonFFIResult(result)
 	if err != nil {
 		return nil, err
 	}
 	return properties, nil
 }
 
-func HandleFFIResult(ffiResult C.FFIResult) error {
-	defer C.FreeFFIResult(&ffiResult)
-	if C.IsSuccess(&ffiResult) == 0 {
-		errMsg := C.GetErrorMessage(&ffiResult)
+func HandleLoonFFIResult(ffiResult C.LoonFFIResult) error {
+	defer C.loon_ffi_free_result(&ffiResult)
+	if C.loon_ffi_is_success(&ffiResult) == 0 {
+		errMsg := C.loon_ffi_get_errmsg(&ffiResult)
 		errStr := "Unknown error"
 		if errMsg != nil {
 			errStr = C.GoString(errMsg)

--- a/internal/storagev2/packed/type.go
+++ b/internal/storagev2/packed/type.go
@@ -37,8 +37,8 @@ type PackedWriter struct {
 type FFIPackedWriter struct {
 	basePath      string
 	baseVersion   int64
-	cWriterHandle C.WriterHandle
-	cProperties   *C.Properties
+	cWriterHandle C.LoonWriterHandle
+	cProperties   *C.LoonProperties
 }
 
 type PackedReader struct {


### PR DESCRIPTION
Related to #44956

Update milvus-storage dependency to use new Manifest structure where column groups are accessed via manifest->columnGroups(). Adapt to renamed FFI functions (loon_ prefix) and updated Transaction API.