### PR TITLE
test: migrate invalid insert test cases to TestMilvusClientInsertInvalid

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_insert.py
+++ b/tests/python_client/milvus_client/test_milvus_client_insert.py
@@ -543,6 +543,224 @@ class TestMilvusClientInsertInvalid(TestMilvusClientV2Base):
 
         self.drop_collection(client, collection_name)
 
+    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.parametrize("primary_field", [ct.default_int64_field_name, ct.default_string_field_name])
+    def test_insert_with_invalid_field_value(self, primary_field):
+        """
+        target: verify error msg when inserting with invalid field value
+        method: insert with invalid field value
+        expected: raise exception
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        nb = 100
+
+        # 1. Create schema
+        schema = self.create_schema(client)[0]
+        if primary_field == ct.default_int64_field_name:
+            schema.add_field(primary_field, DataType.INT64, is_primary=True, auto_id=True)
+        else:
+            schema.add_field(primary_field, DataType.VARCHAR, max_length=ct.default_length, is_primary=True, auto_id=True)
+        schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
+        schema.add_field(default_float_field_name, DataType.FLOAT)
+        schema.add_field(default_bool_field_name, DataType.BOOL)
+        if primary_field != ct.default_string_field_name:
+            schema.add_field(default_string_field_name, DataType.VARCHAR, max_length=ct.default_length)
+
+        # 2. Create collection
+        self.create_collection(client, collection_name, dimension=default_dim, schema=schema)
+
+        # 3. Generate row data
+        rows = cf.gen_row_data_by_schema(nb=nb, schema=schema)
+
+        # 4. Test invalid field values at different positions
+        for dirty_i in [0, nb // 2, nb - 1]:  # check the dirty data at first, middle and last
+            # Iterate through all fields in the row
+            for field_name, field_value in rows[dirty_i].items():
+                # Get the actual value type
+                value_type = type(field_value)
+                error = {ct.err_code: 999, ct.err_msg: "The Input data type is inconsistent with defined schema"}
+
+                # Inject type errors based on value type (only for simple scalar types)
+                if value_type is int:
+                    tmp = rows[dirty_i][field_name]
+                    rows[dirty_i][field_name] = "iamstring"
+                    self.insert(client, collection_name, data=rows,
+                                check_task=CheckTasks.err_res, check_items=error)
+                    rows[dirty_i][field_name] = tmp
+                elif value_type is str:
+                    tmp = rows[dirty_i][field_name]
+                    rows[dirty_i][field_name] = random.randint(0, 1000)
+                    self.insert(client, collection_name, data=rows,
+                                check_task=CheckTasks.err_res, check_items=error)
+                    rows[dirty_i][field_name] = tmp
+                elif value_type is bool:
+                    tmp = rows[dirty_i][field_name]
+                    rows[dirty_i][field_name] = "iamstring"
+                    self.insert(client, collection_name, data=rows,
+                                check_task=CheckTasks.err_res, check_items=error)
+                    rows[dirty_i][field_name] = tmp
+                elif value_type is float:
+                    tmp = rows[dirty_i][field_name]
+                    rows[dirty_i][field_name] = "iamstring"
+                    self.insert(client, collection_name, data=rows,
+                                check_task=CheckTasks.err_res, check_items=error)
+                    rows[dirty_i][field_name] = tmp
+                else:
+                    continue
+
+        # 5. Verify correct data can be inserted
+        results = self.insert(client, collection_name, rows)[0]
+        assert results['insert_count'] == nb
+
+        self.drop_collection(client, collection_name)
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_insert_over_resource_limit(self):
+        """
+        target: test insert over RPC limitation 64MB (67108864)
+        method: insert excessive data
+        expected: raise exception
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        nb = 150000
+
+        # 1. Create collection
+        self.create_collection(client, collection_name, default_dim, auto_id=False)
+
+        # 2. Generate row data (150000 rows, which exceeds 64MB RPC limit)
+        rng = np.random.default_rng(seed=19530)
+        rows = [{default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, default_dim))[0]),
+                 default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(nb)]
+
+        # 3. Verify error on insert
+        error = {ct.err_code: 999, ct.err_msg: "message larger than max"}
+        self.insert(client, collection_name, data=rows,
+                    check_task=CheckTasks.err_res, check_items=error)
+
+        self.drop_collection(client, collection_name)
+
+    @pytest.mark.tags(CaseLabel.L2)
+    @pytest.mark.parametrize("default_value", [[], 123])
+    def test_insert_type_mismatch_with_default_value_field(self, default_value):
+        """
+        target: test insert with type mismatch for field that has default value
+        method: insert data with wrong type for varchar field that has default_value
+        expected: raise exception
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+
+        # 1. Create schema with default value field
+        schema = self.create_schema(client, enable_dynamic_field=False)[0]
+        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
+        schema.add_field(default_float_field_name, DataType.FLOAT)
+        schema.add_field(default_string_field_name, DataType.VARCHAR, max_length=ct.default_length, default_value="abc")
+        schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
+
+        # 2. Create collection
+        self.create_collection(client, collection_name, dimension=default_dim, schema=schema)
+
+        # 3. Generate vectors
+        vectors = cf.gen_vectors(ct.default_nb, ct.default_dim)
+
+        # 4. Prepare test data with invalid type for varchar field
+        data = [{default_primary_key_field_name: 1, default_float_field_name: vectors[1],
+                 default_string_field_name: default_value, default_vector_field_name: np.float32(1.0)}]
+
+        # 5. Verify error on upsert
+        error = {ct.err_code: 999, ct.err_msg: "The Input data type is inconsistent with defined schema"}
+        self.upsert(client, collection_name, data=data,
+                    check_task=CheckTasks.err_res, check_items=error)
+
+        self.drop_collection(client, collection_name)
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_insert_with_nan_value(self):
+        """
+        target: test insert with nan value
+        method: insert with nan value: None, float('nan'), np.NAN/np.nan, float('inf')
+        expected: raise exception
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+
+        # 1. Create collection
+        self.create_collection(client, collection_name, default_dim, auto_id=False)
+
+        # 2. Generate row data
+        rng = np.random.default_rng(seed=19530)
+        rows = [{default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, default_dim))[0]),
+                 default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(default_nb)]
+
+        # 3. Test None value in vector field
+        rows[0][default_vector_field_name][0] = None
+        error = {ct.err_code: 999, ct.err_msg: "The Input data type is inconsistent with defined schema"}
+        self.insert(client, collection_name, data=rows,
+                    check_task=CheckTasks.err_res, check_items=error)
+
+        # 4. Test float('nan') in vector field
+        rows[0][default_vector_field_name][0] = float('nan')
+        error = {ct.err_code: 999, ct.err_msg: "value 'NaN' is not a number or infinity"}
+        self.insert(client, collection_name, data=rows,
+                    check_task=CheckTasks.err_res, check_items=error)
+
+        # 5. Test np.NAN in vector field
+        rows[0][default_vector_field_name][0] = np.NAN
+        self.insert(client, collection_name, data=rows,
+                    check_task=CheckTasks.err_res, check_items=error)
+
+        # 6. Test float('inf') in vector field
+        rows[0][default_vector_field_name][0] = float('inf')
+        error = {ct.err_code: 65535, ct.err_msg: "value '+Inf' is not a number or infinity"}
+        self.insert(client, collection_name, data=rows,
+                    check_task=CheckTasks.err_res, check_items=error)
+
+        self.drop_collection(client, collection_name)
+
+    @pytest.mark.tags(CaseLabel.L2)
+    @pytest.mark.parametrize("invalid_vector_type", ct.all_dense_vector_types)
+    def test_invalid_sparse_vector_data(self, invalid_vector_type):
+        """
+        target: insert illegal data type
+        method: insert illegal dense vector type into sparse vector field
+        expected: raise exception
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        nb = 100
+
+        # 1. Create schema with sparse vector field
+        schema = self.create_schema(client, enable_dynamic_field=False)[0]
+        schema.add_field(ct.default_int64_field_name, DataType.INT64, is_primary=True, auto_id=False)
+        schema.add_field(ct.default_float_field_name, DataType.FLOAT)
+        schema.add_field(ct.default_string_field_name, DataType.VARCHAR, max_length=ct.default_length)
+        schema.add_field(ct.default_sparse_vec_field_name, DataType.SPARSE_FLOAT_VECTOR)
+
+        # 2. Create collection
+        self.create_collection(client, collection_name, dimension=default_dim, schema=schema)
+
+        # 3. Generate valid sparse vector data
+        sparse_vectors = cf.gen_sparse_vectors(nb, dim=128)
+        rows = []
+        for i in range(nb - 1):
+            row = {ct.default_int64_field_name: i, ct.default_float_field_name: np.float32(i),
+                   ct.default_string_field_name: str(i), ct.default_sparse_vec_field_name: sparse_vectors[i]}
+            rows.append(row)
+
+        # 4. Add invalid dense vector type as the last row
+        invalid_vec = cf.gen_vectors(1, dim=128, vector_data_type=invalid_vector_type)
+        invalid_row = {ct.default_int64_field_name: nb - 1, ct.default_float_field_name: np.float32(nb - 1),
+                       ct.default_string_field_name: str(nb - 1), ct.default_sparse_vec_field_name: invalid_vec[0]}
+        rows.append(invalid_row)
+
+        # 5. Verify error on insert
+        error = {ct.err_code: 1, ct.err_msg: 'invalid input for sparse float vector'}
+        self.insert(client, collection_name, data=rows, check_task=CheckTasks.err_res, check_items=error)
+
+        self.drop_collection(client, collection_name)
+
 class TestMilvusClientInsertValid(TestMilvusClientV2Base):
     """ Test case of search interface """
 

--- a/tests/python_client/milvus_client/test_milvus_client_insert.py
+++ b/tests/python_client/milvus_client/test_milvus_client_insert.py
@@ -582,7 +582,7 @@ class TestMilvusClientInsertInvalid(TestMilvusClientV2Base):
                 error = {ct.err_code: 999, ct.err_msg: "The Input data type is inconsistent with defined schema"}
 
                 # Inject type errors based on value type (only for simple scalar types)
-                if value_type is int:
+                if value_type in (int, bool, float):
                     tmp = rows[dirty_i][field_name]
                     rows[dirty_i][field_name] = "iamstring"
                     self.insert(client, collection_name, data=rows,
@@ -591,18 +591,6 @@ class TestMilvusClientInsertInvalid(TestMilvusClientV2Base):
                 elif value_type is str:
                     tmp = rows[dirty_i][field_name]
                     rows[dirty_i][field_name] = random.randint(0, 1000)
-                    self.insert(client, collection_name, data=rows,
-                                check_task=CheckTasks.err_res, check_items=error)
-                    rows[dirty_i][field_name] = tmp
-                elif value_type is bool:
-                    tmp = rows[dirty_i][field_name]
-                    rows[dirty_i][field_name] = "iamstring"
-                    self.insert(client, collection_name, data=rows,
-                                check_task=CheckTasks.err_res, check_items=error)
-                    rows[dirty_i][field_name] = tmp
-                elif value_type is float:
-                    tmp = rows[dirty_i][field_name]
-                    rows[dirty_i][field_name] = "iamstring"
                     self.insert(client, collection_name, data=rows,
                                 check_task=CheckTasks.err_res, check_items=error)
                     rows[dirty_i][field_name] = tmp
@@ -666,8 +654,8 @@ class TestMilvusClientInsertInvalid(TestMilvusClientV2Base):
         vectors = cf.gen_vectors(ct.default_nb, ct.default_dim)
 
         # 4. Prepare test data with invalid type for varchar field
-        data = [{default_primary_key_field_name: 1, default_float_field_name: vectors[1],
-                 default_string_field_name: default_value, default_vector_field_name: np.float32(1.0)}]
+        data = [{default_primary_key_field_name: 1, default_float_field_name: 1.0,
+                 default_string_field_name: default_value, default_vector_field_name: vectors[0]}]
 
         # 5. Verify error on upsert
         error = {ct.err_code: 999, ct.err_msg: "The Input data type is inconsistent with defined schema"}

--- a/tests/python_client/testcases/test_insert.py
+++ b/tests/python_client/testcases/test_insert.py
@@ -929,50 +929,6 @@ class TestInsertInvalid(TestcaseBase):
       The following cases are used to test insert invalid params
       ******************************************************************
     """
-    @pytest.mark.tags(CaseLabel.L0)
-    @pytest.mark.parametrize("primary_field", [ct.default_int64_field_name, ct.default_string_field_name])
-    def test_insert_with_invalid_field_value(self, primary_field):
-        """
-        target: verify error msg when inserting with invalid field value
-        method: insert with invalid field value
-        expected: raise exception
-        """
-        collection_w = self.init_collection_general(prefix, auto_id=False, insert_data=False,
-                                                    primary_field=primary_field, is_index=False,
-                                                    is_all_data_type=True, with_json=True)[0]
-        nb = 100
-        data = cf.gen_column_data_by_schema(schema=collection_w.schema, nb=nb)
-        for dirty_i in [0, nb // 2, nb - 1]:      # check the dirty data at first, middle and last
-            log.debug(f"dirty_i: {dirty_i}")
-            for i in range(len(data)):
-                if data[i][dirty_i].__class__ is int:
-                    tmp = data[i][0]
-                    data[i][dirty_i] = "iamstring"
-                    error = {ct.err_code: 999, ct.err_msg: "The Input data type is inconsistent with defined schema"}
-                    collection_w.insert(data=data, check_task=CheckTasks.err_res, check_items=error)
-                    data[i][dirty_i] = tmp
-                elif data[i][dirty_i].__class__ is str:
-                    tmp = data[i][dirty_i]
-                    data[i][dirty_i] = random.randint(0, 1000)
-                    error = {ct.err_code: 999, ct.err_msg: "field (varchar) expects string input, got: <class 'int'>"}
-                    collection_w.insert(data=data, check_task=CheckTasks.err_res, check_items=error)
-                    data[i][dirty_i] = tmp
-                elif data[i][dirty_i].__class__ is bool:
-                    tmp = data[i][dirty_i]
-                    data[i][dirty_i] = "iamstring"
-                    error = {ct.err_code: 999, ct.err_msg: "The Input data type is inconsistent with defined schema"}
-                    collection_w.insert(data=data, check_task=CheckTasks.err_res, check_items=error)
-                    data[i][dirty_i] = tmp
-                elif data[i][dirty_i].__class__ is float:
-                    tmp = data[i][dirty_i]
-                    data[i][dirty_i] = "iamstring"
-                    error = {ct.err_code: 999, ct.err_msg: "The Input data type is inconsistent with defined schema"}
-                    collection_w.insert(data=data, check_task=CheckTasks.err_res, check_items=error)
-                    data[i][dirty_i] = tmp
-                else:
-                    continue
-        res = collection_w.insert(data)[0]
-        assert res.insert_count == nb
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_insert_with_invalid_partition_name(self):
@@ -1006,39 +962,6 @@ class TestInsertInvalid(TestcaseBase):
         assert res.insert_count == 2
 
     @pytest.mark.tags(CaseLabel.L2)
-    def test_insert_over_resource_limit(self):
-        """
-        target: test insert over RPC limitation 64MB (67108864)
-        method: insert excessive data
-        expected: raise exception
-        """
-        nb = 150000
-        collection_name = cf.gen_unique_str(prefix)
-        collection_w = self.init_collection_wrap(name=collection_name)
-        data = cf.gen_default_dataframe_data(nb)
-        error = {ct.err_code: 999, ct.err_msg: "message larger than max"}
-        collection_w.insert(
-            data=data, check_task=CheckTasks.err_res, check_items=error)
-
-    @pytest.mark.tags(CaseLabel.L2)
-    @pytest.mark.parametrize("default_value", [[], 123])
-    def test_insert_rows_using_default_value(self, default_value):
-        """
-        target: test insert with rows
-        method: insert with invalid rows
-        expected: raise exception
-        """
-        fields = [cf.gen_int64_field(is_primary=True), cf.gen_float_field(),
-                  cf.gen_string_field(default_value="abc"), cf.gen_float_vec_field()]
-        schema = cf.gen_collection_schema(fields)
-        collection_w = self.init_collection_wrap(schema=schema)
-        vectors = cf.gen_vectors(ct.default_nb, ct.default_dim)
-        data = [{"int64": 1, "float_vector": vectors[1],
-                 "varchar": default_value, "float": np.float32(1.0)}]
-        error = {ct.err_code: 999, ct.err_msg: "The Input data type is inconsistent with defined schema"}
-        collection_w.upsert(data, check_task=CheckTasks.err_res, check_items=error)
-
-    @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("default_value", [[], None])
     def test_insert_tuple_using_default_value(self, default_value):
         """
@@ -1056,48 +979,6 @@ class TestInsertInvalid(TestcaseBase):
         data = (int_values, vectors, string_values, default_value)
         error = {ct.err_code: 999, ct.err_msg: "The type of data should be List, pd.DataFrame or Dict"}
         collection_w.upsert(data, check_task=CheckTasks.err_res, check_items=error)
-
-    @pytest.mark.tags(CaseLabel.L2)
-    def test_insert_with_nan_value(self):
-        """
-        target: test insert with nan value
-        method: insert with nan value: None, float('nan'), np.NAN/np.nan, float('inf')
-        expected: raise exception
-        """
-        vector_field = ct.default_float_vec_field_name
-        collection_name = cf.gen_unique_str(prefix)
-        collection_w = self.init_collection_wrap(name=collection_name)
-        data = cf.gen_default_dataframe_data()
-        data[vector_field][0][0] = None
-        error = {ct.err_code: 999, ct.err_msg: "The Input data type is inconsistent with defined schema"}
-        collection_w.insert(data=data, check_task=CheckTasks.err_res, check_items=error)
-        data[vector_field][0][0] = float('nan')
-        error = {ct.err_code: 999, ct.err_msg: "value 'NaN' is not a number or infinity"}
-        collection_w.insert(data=data, check_task=CheckTasks.err_res, check_items=error)
-        data[vector_field][0][0] = np.NAN
-        collection_w.insert(data=data, check_task=CheckTasks.err_res, check_items=error)
-        data[vector_field][0][0] = float('inf')
-        error = {ct.err_code: 65535, ct.err_msg: "value '+Inf' is not a number or infinity"}
-        collection_w.insert(data=data, check_task=CheckTasks.err_res, check_items=error)
-
-    @pytest.mark.tags(CaseLabel.L2)
-    @pytest.mark.parametrize("index ", ct.all_index_types[10:12])
-    @pytest.mark.parametrize("invalid_vector_type ", ct.all_dense_vector_types)
-    def test_invalid_sparse_vector_data(self, index, invalid_vector_type):
-        """
-        target: insert illegal data type
-        method: insert illegal data type
-        expected: raise exception
-        """
-        c_name = cf.gen_unique_str(prefix)
-        schema = cf.gen_default_sparse_schema()
-        collection_w = self.init_collection_wrap(name=c_name, schema=schema)
-        nb = 100
-        data = cf.gen_default_list_sparse_data(nb=nb)[:-1]
-        invalid_vec = cf.gen_vectors(nb, dim=128, vector_data_type=invalid_vector_type)
-        data.append(invalid_vec)
-        error = {ct.err_code: 1, ct.err_msg: 'input must be a sparse matrix in supported format'}
-        collection_w.insert(data=data, check_task=CheckTasks.err_res, check_items=error)
 
 class TestInsertString(TestcaseBase):
     """


### PR DESCRIPTION
/kind improvement
/assign @yanliang567 

**PR Summary**
Migrate invalid insert test cases to TestMilvusClientInsertInvalid:
- `test_insert_with_invalid_field_value`
- `test_insert_over_resource_limit`
- `test_insert_type_mismatch_with_default_value_field`
- `test_insert_with_nan_value`
- `test_invalid_sparse_vector_data`
