### PR TITLE
fix: enforce strictGroupSize in search group by reduce (#46734)

### DIFF
--- a/internal/querynodev2/segments/search_reduce_test.go
+++ b/internal/querynodev2/segments/search_reduce_test.go
@@ -254,6 +254,162 @@ func (suite *SearchReduceSuite) TestResult_SearchGroupByResult() {
 	})
 }
 
+func (suite *SearchReduceSuite) TestResult_SearchGroupByStrictGroupSize() {
+	const (
+		nq   = 1
+		topk = 4
+	)
+
+	suite.Run("strict_group_size_filters_incomplete_groups", func() {
+		// Group "1" has 2 elements (ids 1, 4), Group "2" has 2 elements (ids 2, 5)
+		// Group "3" has 1 element (id 3), Group "4" has 1 element (id 6)
+		// With groupSize=2 and strictGroupSize=true, only groups "1" and "2" should be returned
+		ids1 := []int64{1, 2, 3}
+		scores1 := []float32{-1.0, -2.0, -3.0}
+		topks1 := []int64{int64(len(ids1))}
+		ids2 := []int64{4, 5, 6}
+		scores2 := []float32{-1.5, -2.5, -3.5}
+		topks2 := []int64{int64(len(ids2))}
+		data1 := mock_segcore.GenSearchResultData(nq, topk, ids1, scores1, topks1)
+		data2 := mock_segcore.GenSearchResultData(nq, topk, ids2, scores2, topks2)
+		data1.GroupByFieldValue = &schemapb.FieldData{
+			Type: schemapb.DataType_VarChar,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_StringData{
+						StringData: &schemapb.StringArray{
+							Data: []string{"1", "2", "3"},
+						},
+					},
+				},
+			},
+		}
+		data2.GroupByFieldValue = &schemapb.FieldData{
+			Type: schemapb.DataType_VarChar,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_StringData{
+						StringData: &schemapb.StringArray{
+							Data: []string{"1", "2", "4"},
+						},
+					},
+				},
+			},
+		}
+		dataArray := make([]*schemapb.SearchResultData, 0)
+		dataArray = append(dataArray, data1)
+		dataArray = append(dataArray, data2)
+
+		// With strictGroupSize=true, only complete groups (with groupSize elements) should be returned
+		reduceInfo := reduce.NewReduceSearchResultInfo(nq, topk).WithGroupSize(2).WithGroupByField(101).WithStrictGroupSize(true)
+		searchReduce := InitSearchReducer(reduceInfo)
+		res, err := searchReduce.ReduceSearchResultData(context.TODO(), dataArray, reduceInfo)
+		suite.Nil(err)
+		// Only groups "1" and "2" have 2 elements each, groups "3" and "4" have only 1 element
+		// So we expect 4 results (2 groups * 2 elements)
+		suite.Equal(4, len(res.Ids.GetIntId().Data))
+		suite.ElementsMatch([]int64{1, 4, 2, 5}, res.Ids.GetIntId().Data)
+		suite.ElementsMatch([]string{"1", "1", "2", "2"}, res.GroupByFieldValue.GetScalars().GetStringData().Data)
+	})
+
+	suite.Run("strict_group_size_false_includes_incomplete_groups", func() {
+		// Same data as above, but with strictGroupSize=false
+		ids1 := []int64{1, 2, 3}
+		scores1 := []float32{-1.0, -2.0, -3.0}
+		topks1 := []int64{int64(len(ids1))}
+		ids2 := []int64{4, 5, 6}
+		scores2 := []float32{-1.5, -2.5, -3.5}
+		topks2 := []int64{int64(len(ids2))}
+		data1 := mock_segcore.GenSearchResultData(nq, topk, ids1, scores1, topks1)
+		data2 := mock_segcore.GenSearchResultData(nq, topk, ids2, scores2, topks2)
+		data1.GroupByFieldValue = &schemapb.FieldData{
+			Type: schemapb.DataType_VarChar,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_StringData{
+						StringData: &schemapb.StringArray{
+							Data: []string{"1", "2", "3"},
+						},
+					},
+				},
+			},
+		}
+		data2.GroupByFieldValue = &schemapb.FieldData{
+			Type: schemapb.DataType_VarChar,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_StringData{
+						StringData: &schemapb.StringArray{
+							Data: []string{"1", "2", "4"},
+						},
+					},
+				},
+			},
+		}
+		dataArray := make([]*schemapb.SearchResultData, 0)
+		dataArray = append(dataArray, data1)
+		dataArray = append(dataArray, data2)
+
+		// With strictGroupSize=false (default), all groups should be returned including incomplete ones
+		reduceInfo := reduce.NewReduceSearchResultInfo(nq, topk).WithGroupSize(2).WithGroupByField(101).WithStrictGroupSize(false)
+		searchReduce := InitSearchReducer(reduceInfo)
+		res, err := searchReduce.ReduceSearchResultData(context.TODO(), dataArray, reduceInfo)
+		suite.Nil(err)
+		// All 4 groups should be returned: "1" (2 elements), "2" (2 elements), "3" (1 element), "4" (1 element)
+		// Total: 6 results
+		suite.Equal(6, len(res.Ids.GetIntId().Data))
+		suite.ElementsMatch([]int64{1, 4, 2, 5, 3, 6}, res.Ids.GetIntId().Data)
+	})
+
+	suite.Run("strict_group_size_all_groups_complete", func() {
+		// All groups have exactly groupSize elements
+		ids1 := []int64{1, 2}
+		scores1 := []float32{-1.0, -2.0}
+		topks1 := []int64{int64(len(ids1))}
+		ids2 := []int64{3, 4}
+		scores2 := []float32{-1.5, -2.5}
+		topks2 := []int64{int64(len(ids2))}
+		data1 := mock_segcore.GenSearchResultData(nq, topk, ids1, scores1, topks1)
+		data2 := mock_segcore.GenSearchResultData(nq, topk, ids2, scores2, topks2)
+		data1.GroupByFieldValue = &schemapb.FieldData{
+			Type: schemapb.DataType_VarChar,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_StringData{
+						StringData: &schemapb.StringArray{
+							Data: []string{"A", "B"},
+						},
+					},
+				},
+			},
+		}
+		data2.GroupByFieldValue = &schemapb.FieldData{
+			Type: schemapb.DataType_VarChar,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_StringData{
+						StringData: &schemapb.StringArray{
+							Data: []string{"A", "B"},
+						},
+					},
+				},
+			},
+		}
+		dataArray := make([]*schemapb.SearchResultData, 0)
+		dataArray = append(dataArray, data1)
+		dataArray = append(dataArray, data2)
+
+		// With strictGroupSize=true, all groups have 2 elements, so all should be returned
+		reduceInfo := reduce.NewReduceSearchResultInfo(nq, topk).WithGroupSize(2).WithGroupByField(101).WithStrictGroupSize(true)
+		searchReduce := InitSearchReducer(reduceInfo)
+		res, err := searchReduce.ReduceSearchResultData(context.TODO(), dataArray, reduceInfo)
+		suite.Nil(err)
+		// Both groups "A" and "B" have 2 elements each
+		suite.Equal(4, len(res.Ids.GetIntId().Data))
+		suite.ElementsMatch([]int64{1, 3, 2, 4}, res.Ids.GetIntId().Data)
+	})
+}
+
 func TestSearchReduce(t *testing.T) {
 	paramtable.Init()
 	suite.Run(t, new(SearchReduceSuite))

--- a/internal/util/function/rerank/util.go
+++ b/internal/util/function/rerank/util.go
@@ -340,8 +340,17 @@ func newGroupingIDScores[T PKType](idScores map[T]float32, idLocations map[T]IDL
 		0,
 		make([]IDLoc, 0, searchParams.limit),
 	}
-	for index := int(searchParams.offset); index < len(groupList); index++ {
+	// Ensure we only output limit groups starting from offset
+	endIndex := int(searchParams.offset) + int(searchParams.limit)
+	if endIndex > len(groupList) {
+		endIndex = len(groupList)
+	}
+	for index := int(searchParams.offset); index < endIndex; index++ {
 		group := groupList[index]
+		// If strictGroupSize is true, skip groups that don't have exactly groupSize elements
+		if searchParams.strictGroupSize && int64(len(group.idList)) < searchParams.groupSize {
+			continue
+		}
 		for i, score := range group.scoreList {
 			// idList and scoreList must have same length
 			if searchParams.roundDecimal != -1 {

--- a/internal/util/function/rerank/util_test.go
+++ b/internal/util/function/rerank/util_test.go
@@ -338,3 +338,140 @@ func (s *UtilSuite) TestAppendResultWithEmptyFieldsData() {
 	// FieldsData should still be empty
 	s.Equal(0, len(outputs.searchResultData.FieldsData))
 }
+
+// TestNewGroupingIDScoresWithStrictGroupSize tests newGroupingIDScores with strictGroupSize parameter
+func (s *UtilSuite) TestNewGroupingIDScoresWithStrictGroupSize() {
+	// Test case 1: strictGroupSize=true should filter incomplete groups
+	s.Run("strict_group_size_filters_incomplete_groups", func() {
+		// ID -> Score mapping
+		idScores := map[int64]float32{
+			1: 0.9, 2: 0.85, 3: 0.8, // Group "a" has 2 elements (ids 1, 2), group "b" has 1 element (id 3)
+			4: 0.75, 5: 0.7, // Group "a" has 1 more element (id 4), group "c" has 1 element (id 5)
+		}
+
+		// ID -> Location mapping
+		idLocations := map[int64]IDLoc{
+			1: {batchIdx: 0, offset: 0},
+			2: {batchIdx: 0, offset: 1},
+			3: {batchIdx: 0, offset: 2},
+			4: {batchIdx: 0, offset: 3},
+			5: {batchIdx: 0, offset: 4},
+		}
+
+		// ID -> Group value mapping
+		// Group "a": ids 1, 2, 4 (3 elements)
+		// Group "b": id 3 (1 element)
+		// Group "c": id 5 (1 element)
+		idGroup := map[int64]any{
+			1: "a", 2: "a", 4: "a",
+			3: "b",
+			5: "c",
+		}
+
+		// With limit=3, groupSize=2, strictGroupSize=true
+		// Only group "a" has >= 2 elements, so only group "a" should be returned
+		searchParams := NewSearchParams(1, 3, 0, -1, 101, 2, true, "max", nil)
+		result, err := newGroupingIDScores(idScores, idLocations, searchParams, idGroup)
+
+		s.NoError(err)
+		s.NotNil(result)
+		// Only group "a" with 2 elements (limited by groupSize)
+		s.Equal(2, len(result.ids))
+		s.ElementsMatch([]int64{1, 2}, result.ids)
+	})
+
+	// Test case 2: strictGroupSize=false should include all groups
+	s.Run("strict_group_size_false_includes_incomplete_groups", func() {
+		// Same data as above
+		idScores := map[int64]float32{
+			1: 0.9, 2: 0.85, 3: 0.8,
+			4: 0.75, 5: 0.7,
+		}
+		idLocations := map[int64]IDLoc{
+			1: {batchIdx: 0, offset: 0},
+			2: {batchIdx: 0, offset: 1},
+			3: {batchIdx: 0, offset: 2},
+			4: {batchIdx: 0, offset: 3},
+			5: {batchIdx: 0, offset: 4},
+		}
+		idGroup := map[int64]any{
+			1: "a", 2: "a", 4: "a",
+			3: "b",
+			5: "c",
+		}
+
+		// With limit=3, groupSize=2, strictGroupSize=false
+		// All 3 groups should be returned (group "a" with 2 elements, "b" with 1, "c" with 1)
+		searchParams := NewSearchParams(1, 3, 0, -1, 101, 2, false, "max", nil)
+		result, err := newGroupingIDScores(idScores, idLocations, searchParams, idGroup)
+
+		s.NoError(err)
+		s.NotNil(result)
+		// Group "a": 2 elements, Group "b": 1 element, Group "c": 1 element = 4 total
+		s.Equal(4, len(result.ids))
+		s.ElementsMatch([]int64{1, 2, 3, 5}, result.ids)
+	})
+
+	// Test case 3: All groups complete with strictGroupSize=true
+	s.Run("strict_group_size_all_complete", func() {
+		idScores := map[int64]float32{
+			1: 0.9, 2: 0.85, // Group "a"
+			3: 0.8, 4: 0.75, // Group "b"
+		}
+		idLocations := map[int64]IDLoc{
+			1: {batchIdx: 0, offset: 0},
+			2: {batchIdx: 0, offset: 1},
+			3: {batchIdx: 0, offset: 2},
+			4: {batchIdx: 0, offset: 3},
+		}
+		idGroup := map[int64]any{
+			1: "a", 2: "a",
+			3: "b", 4: "b",
+		}
+
+		// With limit=2, groupSize=2, strictGroupSize=true
+		// Both groups have 2 elements, so both should be returned
+		searchParams := NewSearchParams(1, 2, 0, -1, 101, 2, true, "max", nil)
+		result, err := newGroupingIDScores(idScores, idLocations, searchParams, idGroup)
+
+		s.NoError(err)
+		s.NotNil(result)
+		// Both groups have 2 elements = 4 total
+		s.Equal(4, len(result.ids))
+		s.ElementsMatch([]int64{1, 2, 3, 4}, result.ids)
+	})
+
+	// Test case 4: Limit output to specified number of groups
+	s.Run("limit_output_groups", func() {
+		idScores := map[int64]float32{
+			1: 0.9, 2: 0.85, // Group "a"
+			3: 0.8, 4: 0.75, // Group "b"
+			5: 0.7, 6: 0.65, // Group "c"
+		}
+		idLocations := map[int64]IDLoc{
+			1: {batchIdx: 0, offset: 0},
+			2: {batchIdx: 0, offset: 1},
+			3: {batchIdx: 0, offset: 2},
+			4: {batchIdx: 0, offset: 3},
+			5: {batchIdx: 0, offset: 4},
+			6: {batchIdx: 0, offset: 5},
+		}
+		idGroup := map[int64]any{
+			1: "a", 2: "a",
+			3: "b", 4: "b",
+			5: "c", 6: "c",
+		}
+
+		// With limit=2, groupSize=2, strictGroupSize=false
+		// Only first 2 groups (by max score) should be returned
+		searchParams := NewSearchParams(1, 2, 0, -1, 101, 2, false, "max", nil)
+		result, err := newGroupingIDScores(idScores, idLocations, searchParams, idGroup)
+
+		s.NoError(err)
+		s.NotNil(result)
+		// Only 2 groups (4 elements total)
+		s.Equal(4, len(result.ids))
+		// Should be groups "a" and "b" (highest scores)
+		s.ElementsMatch([]int64{1, 2, 3, 4}, result.ids)
+	})
+}

--- a/internal/util/reduce/reduce_info.go
+++ b/internal/util/reduce/reduce_info.go
@@ -5,14 +5,15 @@ import (
 )
 
 type ResultInfo struct {
-	nq             int64
-	topK           int64
-	metricType     string
-	pkType         schemapb.DataType
-	offset         int64
-	groupByFieldId int64
-	groupSize      int64
-	isAdvance      bool
+	nq              int64
+	topK            int64
+	metricType      string
+	pkType          schemapb.DataType
+	offset          int64
+	groupByFieldId  int64
+	groupSize       int64
+	strictGroupSize bool
+	isAdvance       bool
 }
 
 func NewReduceSearchResultInfo(
@@ -50,6 +51,11 @@ func (r *ResultInfo) WithGroupSize(groupSize int64) *ResultInfo {
 	return r
 }
 
+func (r *ResultInfo) WithStrictGroupSize(strictGroupSize bool) *ResultInfo {
+	r.strictGroupSize = strictGroupSize
+	return r
+}
+
 func (r *ResultInfo) WithAdvance(advance bool) *ResultInfo {
 	r.isAdvance = advance
 	return r
@@ -81,6 +87,10 @@ func (r *ResultInfo) GetGroupByFieldId() int64 {
 
 func (r *ResultInfo) GetGroupSize() int64 {
 	return r.groupSize
+}
+
+func (r *ResultInfo) GetStrictGroupSize() bool {
+	return r.strictGroupSize
 }
 
 func (r *ResultInfo) GetIsAdvance() bool {


### PR DESCRIPTION
- Add strictGroupSize field to reduce.ResultInfo and propagate it through the reduce pipeline
- Update QueryNode SearchGroupByReduce to filter incomplete groups when strictGroupSize=true
- Update Proxy reduceSearchResultDataWithGroupBy to filter incomplete groups when strictGroupSize=true
- Fix hybrid search group by to limit output to exactly limit groups and filter incomplete groups