### PR TITLE
fix: change queryPreExecute merge logic from row-based to column-based

### DIFF
--- a/internal/proxy/task_upsert.go
+++ b/internal/proxy/task_upsert.go
@@ -382,7 +382,11 @@ func (it *upsertTask) queryPreExecute(ctx context.Context) error {
 		for i, upsertIdx := range updateIdxInUpsert {
 			typeutil.AppendIDs(it.deletePKs, upsertIDs, upsertIdx)
 			oldPK := typeutil.GetPK(upsertIDs, int64(upsertIdx))
-			existIndices[i] = int64(existPKToIndex[oldPK])
+			idx, ok := existPKToIndex[oldPK]
+			if !ok {
+				return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("upsert pk %v not found in query result", oldPK))
+			}
+			existIndices[i] = int64(idx)
 		}
 
 		for fieldIdx, existField := range existFieldData {

--- a/internal/proxy/task_upsert.go
+++ b/internal/proxy/task_upsert.go
@@ -368,88 +368,88 @@ func (it *upsertTask) queryPreExecute(ctx context.Context) error {
 		upsertFieldMap := lo.SliceToMap(it.upsertMsg.InsertMsg.GetFieldsData(), func(field *schemapb.FieldData) (int64, *schemapb.FieldData) {
 			return field.FieldId, field
 		})
-		nullableVectorContexts := make(map[int64]*nullableVectorMergeContext)
-		for _, fieldData := range existFieldData {
-			fieldSchema, err := it.schema.schemaHelper.GetFieldFromName(fieldData.GetFieldName())
-			if err != nil {
-				log.Info("get field schema failed", zap.Error(err))
-				return err
-			}
-
-			if fieldSchema.GetNullable() && typeutil.IsVectorType(fieldSchema.GetDataType()) {
-				ctx := &nullableVectorMergeContext{
-					existIdxMap: buildNullableVectorIdxMap(fieldData.GetValidData()),
-					existField:  fieldData,
-					mergedValid: make([]bool, 0, len(updateIdxInUpsert)),
-				}
-
-				if upsertField, ok := upsertFieldMap[fieldData.FieldId]; ok {
-					ctx.upsertIdxMap = buildNullableVectorIdxMap(upsertField.GetValidData())
-					ctx.upsertField = upsertField
-					ctx.hasUpsertData = true
-				}
-
-				nullableVectorContexts[fieldData.FieldId] = ctx
-			} else if fieldSchema.GetDefaultValue() != nil {
-				// Note: For fields containing default values, default values need to be set according to valid data during insertion,
-				// but query results fields do not set valid data when returning default value fields,
-				// therefore valid data needs to be manually set to true
-				if len(fieldData.GetValidData()) == 0 {
-					fieldData.ValidData = make([]bool, upsertIDSize)
-					for i := range fieldData.ValidData {
-						fieldData.ValidData[i] = true
-					}
-				}
-			}
-		}
 
 		// Build mapping from existing primary keys to their positions in query result
 		// This ensures we can correctly locate data even if query results are not in the same order as request
 		existIDsLen := typeutil.GetSizeOfIDs(existIDs)
 		existPKToIndex := make(map[interface{}]int, existIDsLen)
-		for j := 0; j < existIDsLen; j++ {
-			pk := typeutil.GetPK(existIDs, int64(j))
-			existPKToIndex[pk] = j
+		for i := 0; i < existIDsLen; i++ {
+			pk := typeutil.GetPK(existIDs, int64(i))
+			existPKToIndex[pk] = i
 		}
 
-		baseIdx := 0
-		idxComputer := typeutil.NewFieldDataIdxComputer(existFieldData)
-		for _, idx := range updateIdxInUpsert {
-			typeutil.AppendIDs(it.deletePKs, upsertIDs, idx)
-			oldPK := typeutil.GetPK(upsertIDs, int64(idx))
-			existIndex, ok := existPKToIndex[oldPK]
-			if !ok {
-				return merr.WrapErrParameterInvalidMsg("primary key not found in exist data mapping")
-			}
-			fieldIdxs := idxComputer.Compute(int64(existIndex))
-			typeutil.AppendFieldData(it.insertFieldData, existFieldData, int64(existIndex), fieldIdxs...)
-			err := typeutil.UpdateFieldData(it.insertFieldData, it.upsertMsg.InsertMsg.GetFieldsData(), int64(baseIdx), int64(idx))
-			baseIdx += 1
+		existIndices := make([]int64, len(updateIdxInUpsert))
+		for i, upsertIdx := range updateIdxInUpsert {
+			typeutil.AppendIDs(it.deletePKs, upsertIDs, upsertIdx)
+			oldPK := typeutil.GetPK(upsertIDs, int64(upsertIdx))
+			existIndices[i] = int64(existPKToIndex[oldPK])
+		}
+
+		for fieldIdx, existField := range existFieldData {
+			fieldSchema, err := it.schema.schemaHelper.GetFieldFromName(existField.GetFieldName())
 			if err != nil {
-				log.Info("update field data failed", zap.Error(err))
+				log.Info("get field schema failed", zap.Error(err))
 				return err
 			}
 
-			// Collect merged validity for nullable vector fields
-			for _, ctx := range nullableVectorContexts {
-				if ctx.hasUpsertData {
-					ctx.mergedValid = append(ctx.mergedValid, ctx.upsertField.GetValidData()[idx])
-				} else {
-					ctx.mergedValid = append(ctx.mergedValid, ctx.existField.GetValidData()[existIndex])
+			// Note: For fields containing default values, default values need to be set according to valid data during insertion,
+			// but query results fields do not set valid data when returning default value fields,
+			// therefore valid data needs to be manually set to true
+			if fieldSchema.GetDefaultValue() != nil && len(existField.GetValidData()) == 0 {
+				existField.ValidData = make([]bool, existIDsLen)
+				for i := range existField.ValidData {
+					existField.ValidData[i] = true
 				}
 			}
-		}
 
-		// Rebuild nullable vector fields
-		for i, fieldData := range it.insertFieldData {
-			ctx, ok := nullableVectorContexts[fieldData.FieldId]
-			if !ok {
-				continue
+			dstField := it.insertFieldData[fieldIdx]
+			upsertField := upsertFieldMap[existField.FieldId]
+			isNullableVector := len(existField.GetValidData()) > 0 && typeutil.IsVectorType(existField.GetType())
+			existComputer := typeutil.NewFieldDataIdxComputer([]*schemapb.FieldData{existField})
+			existSrcIndices := make([]int64, len(updateIdxInUpsert))
+			for i, existIdx := range existIndices {
+				existSrcIndices[i] = existComputer.Compute(existIdx)[0]
 			}
 
-			newFieldData := rebuildNullableVectorFieldData(ctx, updateIdxInUpsert, upsertIDs, existPKToIndex)
-			if newFieldData != nil {
-				it.insertFieldData[i] = newFieldData
+			if upsertField != nil {
+				upsertComputer := typeutil.NewFieldDataIdxComputer([]*schemapb.FieldData{upsertField})
+				upsertSrcIndices := make([]int64, len(updateIdxInUpsert))
+				for i, upsertIdx := range updateIdxInUpsert {
+					upsertSrcIndices[i] = upsertComputer.Compute(int64(upsertIdx))[0]
+				}
+				if isNullableVector {
+					// For nullable vector: only copy data for non-null rows
+					upsertRowIndices := make([]int64, len(updateIdxInUpsert))
+					validDataIndices := make([]int64, 0, len(updateIdxInUpsert))
+					for i, upsertIdx := range updateIdxInUpsert {
+						upsertRowIndices[i] = int64(upsertIdx)
+						if upsertField.ValidData[upsertIdx] {
+							validDataIndices = append(validDataIndices, upsertSrcIndices[i])
+						}
+					}
+					typeutil.AppendFieldDataByColumn(dstField, upsertField, validDataIndices, upsertRowIndices)
+				} else {
+					typeutil.AppendFieldDataByColumn(dstField, existField, existSrcIndices)
+					dstIndices := make([]int64, len(updateIdxInUpsert))
+					for i := range dstIndices {
+						dstIndices[i] = int64(i)
+					}
+					if err := typeutil.UpdateFieldDataByColumn(dstField, upsertField, dstIndices, upsertSrcIndices); err != nil {
+						return err
+					}
+				}
+			} else {
+				if isNullableVector {
+					validDataIndices := make([]int64, 0, len(existIndices))
+					for i, existIdx := range existIndices {
+						if existField.ValidData[int(existIdx)] {
+							validDataIndices = append(validDataIndices, existSrcIndices[i])
+						}
+					}
+					typeutil.AppendFieldDataByColumn(dstField, existField, validDataIndices, existIndices)
+				} else {
+					typeutil.AppendFieldDataByColumn(dstField, existField, existSrcIndices)
+				}
 			}
 		}
 	}
@@ -483,32 +483,47 @@ func (it *upsertTask) queryPreExecute(ctx context.Context) error {
 				insertWithNullField = append(insertWithNullField, fieldData)
 			}
 		}
-		vectorIdxMap := make([][]int64, len(insertIdxInUpsert))
-		for rowIdx, offset := range insertIdxInUpsert {
-			vectorIdxMap[rowIdx] = make([]int64, len(insertWithNullField))
-			for fieldIdx := range insertWithNullField {
-				vectorIdxMap[rowIdx][fieldIdx] = int64(offset)
-			}
-		}
-		for fieldIdx, fieldData := range insertWithNullField {
-			validData := fieldData.GetValidData()
-			if len(validData) > 0 && typeutil.IsVectorType(fieldData.Type) {
-				dataIdx := int64(0)
-				rowIdx := 0
-				for i := 0; i < len(validData) && rowIdx < len(insertIdxInUpsert); i++ {
-					if i == insertIdxInUpsert[rowIdx] {
-						vectorIdxMap[rowIdx][fieldIdx] = dataIdx
-						rowIdx++
-					}
-					if validData[i] {
-						dataIdx++
-					}
-				}
-			}
+
+		// Build mapping from FieldId to index in it.insertFieldData
+		insertFieldDataMap := make(map[int64]int, len(it.insertFieldData))
+		for i, fd := range it.insertFieldData {
+			insertFieldDataMap[fd.FieldId] = i
 		}
 
-		for rowIdx, idx := range insertIdxInUpsert {
-			typeutil.AppendFieldData(it.insertFieldData, insertWithNullField, int64(idx), vectorIdxMap[rowIdx]...)
+		// Process insert data by column (field), similar to update path
+		for _, srcField := range insertWithNullField {
+			isNullableVector := len(srcField.GetValidData()) > 0 && typeutil.IsVectorType(srcField.GetType())
+			srcComputer := typeutil.NewFieldDataIdxComputer([]*schemapb.FieldData{srcField})
+
+			// Find or create destination field in it.insertFieldData
+			var dstField *schemapb.FieldData
+			if idx, ok := insertFieldDataMap[srcField.FieldId]; ok {
+				dstField = it.insertFieldData[idx]
+			} else {
+				// New field not in existFieldData, create empty field data and append
+				newFields := typeutil.PrepareResultFieldData([]*schemapb.FieldData{srcField}, int64(len(insertIdxInUpsert)))
+				dstField = newFields[0]
+				it.insertFieldData = append(it.insertFieldData, dstField)
+			}
+
+			if isNullableVector {
+				rowIndices := make([]int64, len(insertIdxInUpsert))
+				validDataIndices := make([]int64, 0, len(insertIdxInUpsert))
+				for i, upsertIdx := range insertIdxInUpsert {
+					rowIndices[i] = int64(upsertIdx)
+					srcIdx := srcComputer.Compute(int64(upsertIdx))[0]
+					if srcField.ValidData[upsertIdx] {
+						validDataIndices = append(validDataIndices, srcIdx)
+					}
+				}
+				typeutil.AppendFieldDataByColumn(dstField, srcField, validDataIndices, rowIndices)
+			} else {
+				srcIndices := make([]int64, len(insertIdxInUpsert))
+				for i, upsertIdx := range insertIdxInUpsert {
+					srcIndices[i] = srcComputer.Compute(int64(upsertIdx))[0]
+				}
+				typeutil.AppendFieldDataByColumn(dstField, srcField, srcIndices)
+			}
 		}
 	}
 
@@ -522,196 +537,6 @@ func (it *upsertTask) queryPreExecute(ctx context.Context) error {
 		}
 	}
 	return nil
-}
-
-func buildNullableVectorIdxMap(validData []bool) []int64 {
-	if len(validData) == 0 {
-		return nil
-	}
-	idxMap := make([]int64, len(validData))
-	dataIdx := int64(0)
-	for i, valid := range validData {
-		if valid {
-			idxMap[i] = dataIdx
-			dataIdx++
-		} else {
-			idxMap[i] = -1
-		}
-	}
-	return idxMap
-}
-
-type nullableVectorMergeContext struct {
-	existIdxMap   []int64 // row index -> data index for exist data
-	upsertIdxMap  []int64 // row index -> data index for upsert data
-	mergedValid   []bool  // merged validity for the output
-	existField    *schemapb.FieldData
-	upsertField   *schemapb.FieldData
-	hasUpsertData bool // whether upsert request contains this field
-}
-
-func rebuildNullableVectorFieldData(
-	ctx *nullableVectorMergeContext,
-	updateIdxInUpsert []int,
-	upsertIDs *schemapb.IDs,
-	existPKToIndex map[interface{}]int,
-) *schemapb.FieldData {
-	var sourceField *schemapb.FieldData
-	var sourceIdxMap []int64
-
-	if ctx.hasUpsertData {
-		sourceField = ctx.upsertField
-		sourceIdxMap = ctx.upsertIdxMap
-	} else {
-		sourceField = ctx.existField
-		sourceIdxMap = ctx.existIdxMap
-	}
-
-	if sourceField == nil {
-		return nil
-	}
-
-	newFieldData := prepareNullableVectorFieldData(sourceField, int64(len(updateIdxInUpsert)))
-	newFieldData.ValidData = ctx.mergedValid
-
-	// Append vectors from source using the correct indices
-	for rowIdx, idx := range updateIdxInUpsert {
-		var sourceRowIdx int
-		if ctx.hasUpsertData {
-			sourceRowIdx = idx // upsertMsg uses updateIdxInUpsert
-		} else {
-			// existFieldData uses existIndex
-			oldPK := typeutil.GetPK(upsertIDs, int64(idx))
-			sourceRowIdx = existPKToIndex[oldPK]
-		}
-
-		// Check if this row is valid (has vector data)
-		if rowIdx < len(ctx.mergedValid) && ctx.mergedValid[rowIdx] {
-			dataIdx := int64(sourceRowIdx)
-			if len(sourceIdxMap) > 0 && sourceRowIdx < len(sourceIdxMap) {
-				dataIdx = sourceIdxMap[sourceRowIdx]
-			}
-			if dataIdx >= 0 {
-				appendSingleVector(newFieldData, sourceField, dataIdx)
-			}
-		}
-	}
-
-	return newFieldData
-}
-
-func prepareNullableVectorFieldData(sample *schemapb.FieldData, capacity int64) *schemapb.FieldData {
-	fd := &schemapb.FieldData{
-		Type:      sample.Type,
-		FieldName: sample.FieldName,
-		FieldId:   sample.FieldId,
-		IsDynamic: sample.IsDynamic,
-		ValidData: make([]bool, 0, capacity),
-	}
-
-	vectorField := sample.GetVectors()
-	if vectorField == nil {
-		return fd
-	}
-	dim := vectorField.GetDim()
-	vectors := &schemapb.FieldData_Vectors{
-		Vectors: &schemapb.VectorField{
-			Dim: dim,
-		},
-	}
-
-	switch vectorField.Data.(type) {
-	case *schemapb.VectorField_FloatVector:
-		vectors.Vectors.Data = &schemapb.VectorField_FloatVector{
-			FloatVector: &schemapb.FloatArray{
-				Data: make([]float32, 0, dim*capacity),
-			},
-		}
-	case *schemapb.VectorField_Float16Vector:
-		vectors.Vectors.Data = &schemapb.VectorField_Float16Vector{
-			Float16Vector: make([]byte, 0, dim*2*capacity),
-		}
-	case *schemapb.VectorField_Bfloat16Vector:
-		vectors.Vectors.Data = &schemapb.VectorField_Bfloat16Vector{
-			Bfloat16Vector: make([]byte, 0, dim*2*capacity),
-		}
-	case *schemapb.VectorField_BinaryVector:
-		vectors.Vectors.Data = &schemapb.VectorField_BinaryVector{
-			BinaryVector: make([]byte, 0, dim/8*capacity),
-		}
-	case *schemapb.VectorField_Int8Vector:
-		vectors.Vectors.Data = &schemapb.VectorField_Int8Vector{
-			Int8Vector: make([]byte, 0, dim*capacity),
-		}
-	case *schemapb.VectorField_SparseFloatVector:
-		vectors.Vectors.Data = &schemapb.VectorField_SparseFloatVector{
-			SparseFloatVector: &schemapb.SparseFloatArray{
-				Contents: make([][]byte, 0, capacity),
-				Dim:      vectorField.GetSparseFloatVector().GetDim(),
-			},
-		}
-	}
-	fd.Field = vectors
-	return fd
-}
-
-func appendSingleVector(target *schemapb.FieldData, source *schemapb.FieldData, dataIdx int64) {
-	targetVectors := target.GetVectors()
-	sourceVectors := source.GetVectors()
-	if targetVectors == nil || sourceVectors == nil {
-		return
-	}
-	dim := sourceVectors.GetDim()
-
-	switch sv := sourceVectors.Data.(type) {
-	case *schemapb.VectorField_FloatVector:
-		tv := targetVectors.Data.(*schemapb.VectorField_FloatVector)
-		start := dataIdx * dim
-		end := start + dim
-		if end <= int64(len(sv.FloatVector.Data)) {
-			tv.FloatVector.Data = append(tv.FloatVector.Data, sv.FloatVector.Data[start:end]...)
-		}
-	case *schemapb.VectorField_Float16Vector:
-		tv := targetVectors.Data.(*schemapb.VectorField_Float16Vector)
-		unitSize := dim * 2
-		start := dataIdx * unitSize
-		end := start + unitSize
-		if end <= int64(len(sv.Float16Vector)) {
-			tv.Float16Vector = append(tv.Float16Vector, sv.Float16Vector[start:end]...)
-		}
-	case *schemapb.VectorField_Bfloat16Vector:
-		tv := targetVectors.Data.(*schemapb.VectorField_Bfloat16Vector)
-		unitSize := dim * 2
-		start := dataIdx * unitSize
-		end := start + unitSize
-		if end <= int64(len(sv.Bfloat16Vector)) {
-			tv.Bfloat16Vector = append(tv.Bfloat16Vector, sv.Bfloat16Vector[start:end]...)
-		}
-	case *schemapb.VectorField_BinaryVector:
-		tv := targetVectors.Data.(*schemapb.VectorField_BinaryVector)
-		unitSize := dim / 8
-		start := dataIdx * unitSize
-		end := start + unitSize
-		if end <= int64(len(sv.BinaryVector)) {
-			tv.BinaryVector = append(tv.BinaryVector, sv.BinaryVector[start:end]...)
-		}
-	case *schemapb.VectorField_Int8Vector:
-		tv := targetVectors.Data.(*schemapb.VectorField_Int8Vector)
-		start := dataIdx * dim
-		end := start + dim
-		if end <= int64(len(sv.Int8Vector)) {
-			tv.Int8Vector = append(tv.Int8Vector, sv.Int8Vector[start:end]...)
-		}
-	case *schemapb.VectorField_SparseFloatVector:
-		tv := targetVectors.Data.(*schemapb.VectorField_SparseFloatVector)
-		if dataIdx < int64(len(sv.SparseFloatVector.Contents)) {
-			tv.SparseFloatVector.Contents = append(tv.SparseFloatVector.Contents, sv.SparseFloatVector.Contents[dataIdx])
-			// Update dimension if necessary
-			if sv.SparseFloatVector.Dim > tv.SparseFloatVector.Dim {
-				tv.SparseFloatVector.Dim = sv.SparseFloatVector.Dim
-			}
-		}
-	}
 }
 
 // ToCompressedFormatNullable converts the field data from full format nullable to compressed format nullable
@@ -1073,8 +898,115 @@ func GenNullableFieldData(field *schemapb.FieldSchema, upsertIDSize int) (*schem
 				},
 			},
 		}, nil
+
+	// Nullable vector types
+	case schemapb.DataType_FloatVector:
+		dim, err := typeutil.GetDim(field)
+		if err != nil {
+			return nil, err
+		}
+		return &schemapb.FieldData{
+			FieldId:   field.FieldID,
+			FieldName: field.Name,
+			Type:      field.DataType,
+			ValidData: make([]bool, upsertIDSize), // all false = all null
+			Field: &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Dim:  dim,
+					Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: []float32{}}},
+				},
+			},
+		}, nil
+
+	case schemapb.DataType_Float16Vector:
+		dim, err := typeutil.GetDim(field)
+		if err != nil {
+			return nil, err
+		}
+		return &schemapb.FieldData{
+			FieldId:   field.FieldID,
+			FieldName: field.Name,
+			Type:      field.DataType,
+			ValidData: make([]bool, upsertIDSize), // all false = all null
+			Field: &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Dim:  dim,
+					Data: &schemapb.VectorField_Float16Vector{Float16Vector: []byte{}},
+				},
+			},
+		}, nil
+
+	case schemapb.DataType_BFloat16Vector:
+		dim, err := typeutil.GetDim(field)
+		if err != nil {
+			return nil, err
+		}
+		return &schemapb.FieldData{
+			FieldId:   field.FieldID,
+			FieldName: field.Name,
+			Type:      field.DataType,
+			ValidData: make([]bool, upsertIDSize), // all false = all null
+			Field: &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Dim:  dim,
+					Data: &schemapb.VectorField_Bfloat16Vector{Bfloat16Vector: []byte{}},
+				},
+			},
+		}, nil
+
+	case schemapb.DataType_BinaryVector:
+		dim, err := typeutil.GetDim(field)
+		if err != nil {
+			return nil, err
+		}
+		return &schemapb.FieldData{
+			FieldId:   field.FieldID,
+			FieldName: field.Name,
+			Type:      field.DataType,
+			ValidData: make([]bool, upsertIDSize), // all false = all null
+			Field: &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Dim:  dim,
+					Data: &schemapb.VectorField_BinaryVector{BinaryVector: []byte{}},
+				},
+			},
+		}, nil
+
+	case schemapb.DataType_SparseFloatVector:
+		return &schemapb.FieldData{
+			FieldId:   field.FieldID,
+			FieldName: field.Name,
+			Type:      field.DataType,
+			ValidData: make([]bool, upsertIDSize), // all false = all null
+			Field: &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Data: &schemapb.VectorField_SparseFloatVector{SparseFloatVector: &schemapb.SparseFloatArray{
+						Contents: [][]byte{},
+					}},
+				},
+			},
+		}, nil
+
+	case schemapb.DataType_Int8Vector:
+		dim, err := typeutil.GetDim(field)
+		if err != nil {
+			return nil, err
+		}
+		return &schemapb.FieldData{
+			FieldId:   field.FieldID,
+			FieldName: field.Name,
+			Type:      field.DataType,
+			ValidData: make([]bool, upsertIDSize), // all false = all null
+			Field: &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Dim:  dim,
+					Data: &schemapb.VectorField_Int8Vector{Int8Vector: []byte{}},
+				},
+			},
+		}, nil
+
 	default:
-		return nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("undefined scalar data type:%s", field.DataType.String()))
+		return nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("undefined data type:%s", field.DataType.String()))
 	}
 }
 

--- a/pkg/util/typeutil/schema.go
+++ b/pkg/util/typeutil/schema.go
@@ -786,6 +786,12 @@ func PrepareResultFieldData(sample []*schemapb.FieldData, topK int64) []*schemap
 						Data: make([][]byte, 0, topK),
 					},
 				}
+			case *schemapb.ScalarField_GeometryWktData:
+				scalar.Scalars.Data = &schemapb.ScalarField_GeometryWktData{
+					GeometryWktData: &schemapb.GeometryWktArray{
+						Data: make([]string, 0, topK),
+					},
+				}
 			case *schemapb.ScalarField_ArrayData:
 				scalar.Scalars.Data = &schemapb.ScalarField_ArrayData{
 					ArrayData: &schemapb.ArrayArray{
@@ -1187,6 +1193,232 @@ func AppendFieldData(dst, src []*schemapb.FieldData, idx int64, fieldIdxs ...int
 	return
 }
 
+func AppendFieldDataByColumn(dst, src *schemapb.FieldData, dataIndices []int64, rowIndices ...[]int64) {
+	if dst == nil || src == nil {
+		return
+	}
+
+	// Handle ValidData: use rowIndices if provided, otherwise use dataIndices
+	if len(src.GetValidData()) > 0 {
+		validIndices := dataIndices
+		if len(rowIndices) > 0 {
+			validIndices = rowIndices[0]
+		}
+		if dst.ValidData == nil {
+			dst.ValidData = make([]bool, 0, len(validIndices))
+		}
+		for _, idx := range validIndices {
+			dst.ValidData = append(dst.ValidData, src.ValidData[int(idx)])
+		}
+	}
+
+	// Return early if no data to copy
+	if len(dataIndices) == 0 {
+		return
+	}
+
+	switch srcField := src.Field.(type) {
+	case *schemapb.FieldData_Scalars:
+		if dst.GetScalars() == nil {
+			dst.Field = &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{},
+			}
+		}
+		dstScalar := dst.GetScalars()
+		switch srcScalar := srcField.Scalars.Data.(type) {
+		case *schemapb.ScalarField_BoolData:
+			if dstScalar.GetBoolData() == nil {
+				dstScalar.Data = &schemapb.ScalarField_BoolData{
+					BoolData: &schemapb.BoolArray{Data: make([]bool, 0, len(dataIndices))},
+				}
+			}
+			for _, idx := range dataIndices {
+				dstScalar.GetBoolData().Data = append(dstScalar.GetBoolData().Data, srcScalar.BoolData.Data[idx])
+			}
+		case *schemapb.ScalarField_IntData:
+			if dstScalar.GetIntData() == nil {
+				dstScalar.Data = &schemapb.ScalarField_IntData{
+					IntData: &schemapb.IntArray{Data: make([]int32, 0, len(dataIndices))},
+				}
+			}
+			for _, idx := range dataIndices {
+				dstScalar.GetIntData().Data = append(dstScalar.GetIntData().Data, srcScalar.IntData.Data[idx])
+			}
+		case *schemapb.ScalarField_LongData:
+			if dstScalar.GetLongData() == nil {
+				dstScalar.Data = &schemapb.ScalarField_LongData{
+					LongData: &schemapb.LongArray{Data: make([]int64, 0, len(dataIndices))},
+				}
+			}
+			for _, idx := range dataIndices {
+				dstScalar.GetLongData().Data = append(dstScalar.GetLongData().Data, srcScalar.LongData.Data[idx])
+			}
+		case *schemapb.ScalarField_FloatData:
+			if dstScalar.GetFloatData() == nil {
+				dstScalar.Data = &schemapb.ScalarField_FloatData{
+					FloatData: &schemapb.FloatArray{Data: make([]float32, 0, len(dataIndices))},
+				}
+			}
+			for _, idx := range dataIndices {
+				dstScalar.GetFloatData().Data = append(dstScalar.GetFloatData().Data, srcScalar.FloatData.Data[idx])
+			}
+		case *schemapb.ScalarField_DoubleData:
+			if dstScalar.GetDoubleData() == nil {
+				dstScalar.Data = &schemapb.ScalarField_DoubleData{
+					DoubleData: &schemapb.DoubleArray{Data: make([]float64, 0, len(dataIndices))},
+				}
+			}
+			for _, idx := range dataIndices {
+				dstScalar.GetDoubleData().Data = append(dstScalar.GetDoubleData().Data, srcScalar.DoubleData.Data[idx])
+			}
+		case *schemapb.ScalarField_StringData:
+			if dstScalar.GetStringData() == nil {
+				dstScalar.Data = &schemapb.ScalarField_StringData{
+					StringData: &schemapb.StringArray{Data: make([]string, 0, len(dataIndices))},
+				}
+			}
+			for _, idx := range dataIndices {
+				dstScalar.GetStringData().Data = append(dstScalar.GetStringData().Data, srcScalar.StringData.Data[idx])
+			}
+		case *schemapb.ScalarField_ArrayData:
+			if dstScalar.GetArrayData() == nil {
+				dstScalar.Data = &schemapb.ScalarField_ArrayData{
+					ArrayData: &schemapb.ArrayArray{
+						Data:        make([]*schemapb.ScalarField, 0, len(dataIndices)),
+						ElementType: srcScalar.ArrayData.ElementType,
+					},
+				}
+			}
+			for _, idx := range dataIndices {
+				dstScalar.GetArrayData().Data = append(dstScalar.GetArrayData().Data, srcScalar.ArrayData.Data[idx])
+			}
+		case *schemapb.ScalarField_JsonData:
+			if dstScalar.GetJsonData() == nil {
+				dstScalar.Data = &schemapb.ScalarField_JsonData{
+					JsonData: &schemapb.JSONArray{Data: make([][]byte, 0, len(dataIndices))},
+				}
+			}
+			for _, idx := range dataIndices {
+				dstScalar.GetJsonData().Data = append(dstScalar.GetJsonData().Data, srcScalar.JsonData.Data[idx])
+			}
+		case *schemapb.ScalarField_GeometryData:
+			if dstScalar.GetGeometryData() == nil {
+				dstScalar.Data = &schemapb.ScalarField_GeometryData{
+					GeometryData: &schemapb.GeometryArray{Data: make([][]byte, 0, len(dataIndices))},
+				}
+			}
+			for _, idx := range dataIndices {
+				dstScalar.GetGeometryData().Data = append(dstScalar.GetGeometryData().Data, srcScalar.GeometryData.Data[idx])
+			}
+		case *schemapb.ScalarField_GeometryWktData:
+			if dstScalar.GetGeometryWktData() == nil {
+				dstScalar.Data = &schemapb.ScalarField_GeometryWktData{
+					GeometryWktData: &schemapb.GeometryWktArray{Data: make([]string, 0, len(dataIndices))},
+				}
+			}
+			for _, idx := range dataIndices {
+				dstScalar.GetGeometryWktData().Data = append(dstScalar.GetGeometryWktData().Data, srcScalar.GeometryWktData.Data[idx])
+			}
+		case *schemapb.ScalarField_TimestamptzData:
+			if dstScalar.GetTimestamptzData() == nil {
+				dstScalar.Data = &schemapb.ScalarField_TimestamptzData{
+					TimestamptzData: &schemapb.TimestamptzArray{Data: make([]int64, 0, len(dataIndices))},
+				}
+			}
+			for _, idx := range dataIndices {
+				dstScalar.GetTimestamptzData().Data = append(dstScalar.GetTimestamptzData().Data, srcScalar.TimestamptzData.Data[idx])
+			}
+		}
+	case *schemapb.FieldData_Vectors:
+		dim := srcField.Vectors.Dim
+		if dst.GetVectors() == nil {
+			dst.Field = &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{Dim: dim},
+			}
+		}
+		dstVector := dst.GetVectors()
+		switch srcVector := srcField.Vectors.Data.(type) {
+		case *schemapb.VectorField_BinaryVector:
+			if dstVector.GetBinaryVector() == nil {
+				dstVector.Data = &schemapb.VectorField_BinaryVector{
+					BinaryVector: make([]byte, 0, len(dataIndices)*int(dim/8)),
+				}
+			}
+			for _, idx := range dataIndices {
+				start := idx * (dim / 8)
+				end := (idx + 1) * (dim / 8)
+				dstVector.Data.(*schemapb.VectorField_BinaryVector).BinaryVector = append(
+					dstVector.Data.(*schemapb.VectorField_BinaryVector).BinaryVector,
+					srcVector.BinaryVector[start:end]...)
+			}
+		case *schemapb.VectorField_FloatVector:
+			if dstVector.GetFloatVector() == nil {
+				dstVector.Data = &schemapb.VectorField_FloatVector{
+					FloatVector: &schemapb.FloatArray{Data: make([]float32, 0, len(dataIndices)*int(dim))},
+				}
+			}
+			for _, idx := range dataIndices {
+				start := idx * dim
+				end := (idx + 1) * dim
+				dstVector.GetFloatVector().Data = append(dstVector.GetFloatVector().Data, srcVector.FloatVector.Data[start:end]...)
+			}
+		case *schemapb.VectorField_Float16Vector:
+			if dstVector.GetFloat16Vector() == nil {
+				dstVector.Data = &schemapb.VectorField_Float16Vector{
+					Float16Vector: make([]byte, 0, len(dataIndices)*int(dim*2)),
+				}
+			}
+			for _, idx := range dataIndices {
+				start := idx * (dim * 2)
+				end := (idx + 1) * (dim * 2)
+				dstVector.Data.(*schemapb.VectorField_Float16Vector).Float16Vector = append(
+					dstVector.Data.(*schemapb.VectorField_Float16Vector).Float16Vector,
+					srcVector.Float16Vector[start:end]...)
+			}
+		case *schemapb.VectorField_Bfloat16Vector:
+			if dstVector.GetBfloat16Vector() == nil {
+				dstVector.Data = &schemapb.VectorField_Bfloat16Vector{
+					Bfloat16Vector: make([]byte, 0, len(dataIndices)*int(dim*2)),
+				}
+			}
+			for _, idx := range dataIndices {
+				start := idx * (dim * 2)
+				end := (idx + 1) * (dim * 2)
+				dstVector.Data.(*schemapb.VectorField_Bfloat16Vector).Bfloat16Vector = append(
+					dstVector.Data.(*schemapb.VectorField_Bfloat16Vector).Bfloat16Vector,
+					srcVector.Bfloat16Vector[start:end]...)
+			}
+		case *schemapb.VectorField_SparseFloatVector:
+			if dstVector.GetSparseFloatVector() == nil {
+				dstVector.Data = &schemapb.VectorField_SparseFloatVector{
+					SparseFloatVector: &schemapb.SparseFloatArray{
+						Dim:      srcVector.SparseFloatVector.Dim,
+						Contents: make([][]byte, 0, len(dataIndices)),
+					},
+				}
+			}
+			for _, idx := range dataIndices {
+				dstVector.GetSparseFloatVector().Contents = append(
+					dstVector.GetSparseFloatVector().Contents,
+					srcVector.SparseFloatVector.Contents[idx])
+			}
+		case *schemapb.VectorField_Int8Vector:
+			if dstVector.GetInt8Vector() == nil {
+				dstVector.Data = &schemapb.VectorField_Int8Vector{
+					Int8Vector: make([]byte, 0, len(dataIndices)*int(dim)),
+				}
+			}
+			for _, idx := range dataIndices {
+				start := idx * dim
+				end := (idx + 1) * dim
+				dstVector.Data.(*schemapb.VectorField_Int8Vector).Int8Vector = append(
+					dstVector.Data.(*schemapb.VectorField_Int8Vector).Int8Vector,
+					srcVector.Int8Vector[start:end]...)
+			}
+		}
+	}
+}
+
 // DeleteFieldData delete fields data appended last time
 func DeleteFieldData(dst []*schemapb.FieldData) {
 	for i, fieldData := range dst {
@@ -1460,6 +1692,180 @@ func UpdateFieldData(base, update []*schemapb.FieldData, baseIdx, updateIdx int6
 			}
 		default:
 			return fmt.Errorf("unsupported field type: %s", baseFieldData.Type.String())
+		}
+	}
+
+	return nil
+}
+
+func UpdateFieldDataByColumn(base, update *schemapb.FieldData, baseIndices, updateIndices []int64) error {
+	if base == nil || update == nil || len(baseIndices) == 0 {
+		return nil
+	}
+	if len(baseIndices) != len(updateIndices) {
+		return fmt.Errorf("baseIndices and updateIndices length mismatch: %d vs %d", len(baseIndices), len(updateIndices))
+	}
+
+	// Handle ValidData
+	if len(update.GetValidData()) > 0 && len(base.GetValidData()) > 0 {
+		for i, baseIdx := range baseIndices {
+			updateIdx := updateIndices[i]
+			base.ValidData[baseIdx] = update.ValidData[updateIdx]
+		}
+	}
+
+	switch baseField := base.Field.(type) {
+	case *schemapb.FieldData_Scalars:
+		updateField := update.Field.(*schemapb.FieldData_Scalars)
+		baseScalar := baseField.Scalars
+		updateScalar := updateField.Scalars
+
+		switch baseScalar.Data.(type) {
+		case *schemapb.ScalarField_BoolData:
+			baseData := baseScalar.GetBoolData().Data
+			updateData := updateScalar.GetBoolData().Data
+			for i, baseIdx := range baseIndices {
+				baseData[baseIdx] = updateData[updateIndices[i]]
+			}
+		case *schemapb.ScalarField_IntData:
+			baseData := baseScalar.GetIntData().Data
+			updateData := updateScalar.GetIntData().Data
+			for i, baseIdx := range baseIndices {
+				baseData[baseIdx] = updateData[updateIndices[i]]
+			}
+		case *schemapb.ScalarField_LongData:
+			baseData := baseScalar.GetLongData().Data
+			updateData := updateScalar.GetLongData().Data
+			for i, baseIdx := range baseIndices {
+				baseData[baseIdx] = updateData[updateIndices[i]]
+			}
+		case *schemapb.ScalarField_FloatData:
+			baseData := baseScalar.GetFloatData().Data
+			updateData := updateScalar.GetFloatData().Data
+			for i, baseIdx := range baseIndices {
+				baseData[baseIdx] = updateData[updateIndices[i]]
+			}
+		case *schemapb.ScalarField_DoubleData:
+			baseData := baseScalar.GetDoubleData().Data
+			updateData := updateScalar.GetDoubleData().Data
+			for i, baseIdx := range baseIndices {
+				baseData[baseIdx] = updateData[updateIndices[i]]
+			}
+		case *schemapb.ScalarField_StringData:
+			baseData := baseScalar.GetStringData().Data
+			updateData := updateScalar.GetStringData().Data
+			for i, baseIdx := range baseIndices {
+				baseData[baseIdx] = updateData[updateIndices[i]]
+			}
+		case *schemapb.ScalarField_ArrayData:
+			baseData := baseScalar.GetArrayData().Data
+			updateData := updateScalar.GetArrayData().Data
+			for i, baseIdx := range baseIndices {
+				baseData[baseIdx] = updateData[updateIndices[i]]
+			}
+		case *schemapb.ScalarField_JsonData:
+			baseData := baseScalar.GetJsonData().Data
+			updateData := updateScalar.GetJsonData().Data
+			if base.GetIsDynamic() {
+				// dynamic field is a json with only 1 level nested struct,
+				// so we need to unmarshal and iterate updateData's key value, and update the baseData's key value
+				for i, baseIdx := range baseIndices {
+					updateIdx := updateIndices[i]
+					var baseMap map[string]interface{}
+					var updateMap map[string]interface{}
+					// unmarshal base and update
+					if err := json.Unmarshal(baseData[baseIdx], &baseMap); err != nil {
+						return fmt.Errorf("failed to unmarshal base json: %v", err)
+					}
+					if err := json.Unmarshal(updateData[updateIdx], &updateMap); err != nil {
+						return fmt.Errorf("failed to unmarshal update json: %v", err)
+					}
+					// merge
+					for k, v := range updateMap {
+						baseMap[k] = v
+					}
+					// marshal back
+					newJSON, err := json.Marshal(baseMap)
+					if err != nil {
+						return fmt.Errorf("failed to marshal merged json: %v", err)
+					}
+					baseData[baseIdx] = newJSON
+				}
+			} else {
+				for i, baseIdx := range baseIndices {
+					baseData[baseIdx] = updateData[updateIndices[i]]
+				}
+			}
+		case *schemapb.ScalarField_GeometryData:
+			baseData := baseScalar.GetGeometryData().Data
+			updateData := updateScalar.GetGeometryData().Data
+			for i, baseIdx := range baseIndices {
+				baseData[baseIdx] = updateData[updateIndices[i]]
+			}
+		case *schemapb.ScalarField_GeometryWktData:
+			baseData := baseScalar.GetGeometryWktData().Data
+			updateData := updateScalar.GetGeometryWktData().Data
+			for i, baseIdx := range baseIndices {
+				baseData[baseIdx] = updateData[updateIndices[i]]
+			}
+		case *schemapb.ScalarField_TimestamptzData:
+			baseData := baseScalar.GetTimestamptzData().Data
+			updateData := updateScalar.GetTimestamptzData().Data
+			for i, baseIdx := range baseIndices {
+				baseData[baseIdx] = updateData[updateIndices[i]]
+			}
+		}
+	case *schemapb.FieldData_Vectors:
+		updateField := update.Field.(*schemapb.FieldData_Vectors)
+		baseVector := baseField.Vectors
+		updateVector := updateField.Vectors
+		dim := baseVector.Dim
+
+		switch baseVector.Data.(type) {
+		case *schemapb.VectorField_BinaryVector:
+			baseData := baseVector.GetBinaryVector()
+			updateData := updateVector.GetBinaryVector()
+			elemSize := dim / 8
+			for i, baseIdx := range baseIndices {
+				updateIdx := updateIndices[i]
+				copy(baseData[baseIdx*elemSize:(baseIdx+1)*elemSize], updateData[updateIdx*elemSize:(updateIdx+1)*elemSize])
+			}
+		case *schemapb.VectorField_FloatVector:
+			baseData := baseVector.GetFloatVector().Data
+			updateData := updateVector.GetFloatVector().Data
+			for i, baseIdx := range baseIndices {
+				updateIdx := updateIndices[i]
+				copy(baseData[baseIdx*dim:(baseIdx+1)*dim], updateData[updateIdx*dim:(updateIdx+1)*dim])
+			}
+		case *schemapb.VectorField_Float16Vector:
+			baseData := baseVector.GetFloat16Vector()
+			updateData := updateVector.GetFloat16Vector()
+			elemSize := dim * 2
+			for i, baseIdx := range baseIndices {
+				updateIdx := updateIndices[i]
+				copy(baseData[baseIdx*elemSize:(baseIdx+1)*elemSize], updateData[updateIdx*elemSize:(updateIdx+1)*elemSize])
+			}
+		case *schemapb.VectorField_Bfloat16Vector:
+			baseData := baseVector.GetBfloat16Vector()
+			updateData := updateVector.GetBfloat16Vector()
+			elemSize := dim * 2
+			for i, baseIdx := range baseIndices {
+				updateIdx := updateIndices[i]
+				copy(baseData[baseIdx*elemSize:(baseIdx+1)*elemSize], updateData[updateIdx*elemSize:(updateIdx+1)*elemSize])
+			}
+		case *schemapb.VectorField_SparseFloatVector:
+			baseData := baseVector.GetSparseFloatVector().Contents
+			updateData := updateVector.GetSparseFloatVector().Contents
+			for i, baseIdx := range baseIndices {
+				baseData[baseIdx] = updateData[updateIndices[i]]
+			}
+		case *schemapb.VectorField_Int8Vector:
+			baseData := baseVector.GetInt8Vector()
+			updateData := updateVector.GetInt8Vector()
+			for i, baseIdx := range baseIndices {
+				updateIdx := updateIndices[i]
+				copy(baseData[baseIdx*dim:(baseIdx+1)*dim], updateData[updateIdx*dim:(updateIdx+1)*dim])
+			}
 		}
 	}
 


### PR DESCRIPTION
issue: #46953 
- GenNullableFieldData only supported scalar types, causing error when partial upsert after adding nullable vector fields

issue: #47160  
- pickFieldData used row index directly to access Contents array without converting to data index, causing index out of range panic

relate: #45993


Row-based processing had two problems:
- Nullable vector handling was tightly coupled with other field types, requiring complex special-case logic
- Update path was inefficient for nullable vectors: data had to be read first then updated in-place. For example, changing a valid vector to null requires shifting subsequent data since null values are not stored, which is very inefficient.

Column-based processing solves both:
- Each field type is processed independently, nullable vector logic is cleanly separated from other types
- Nullable vectors are appended directly without read-then-update, avoiding expensive data shifting operations                                                                                                                                                                                                                                                                                                                                                - Iterate over fields instead of rows when merging upsert and existing data                                                                                                                                         

key changes:
- Remove nullable vector special handling: nullableVectorMergeContext, buildNullableVectorIdxMap, rebuildNullableVectorFieldData, etc.                                                                                                                                                   
- Use generic column utilities: AppendFieldDataByColumn, UpdateFieldDataByColumn                                                                                                                                    
- Add vector type support to GenNullableFieldData                                                                                                                                                                   
- Add unit test for nullable vector upsert scenarios