### PR TITLE
fix: runtime config updates not triggering watchers

### DIFF
--- a/pkg/config/event_dispatcher.go
+++ b/pkg/config/event_dispatcher.go
@@ -42,15 +42,13 @@ func (ed *EventDispatcher) Get(key string) []EventHandler {
 func (ed *EventDispatcher) Dispatch(event *Event) {
 	ed.mut.RLock()
 	defer ed.mut.RUnlock()
-	var hs []EventHandler
 	realKey := formatKey(event.Key)
-	hs, ok := ed.registry[realKey]
-	if !ok {
-		for _, v := range ed.keyPrefix {
-			if strings.HasPrefix(realKey, v) {
-				if _, exist := ed.registry[v]; exist {
-					hs = append(hs, ed.registry[v]...)
-				}
+	hs := append([]EventHandler(nil), ed.registry[realKey]...)
+	// Dispatch prefix handlers in addition to exact-key handlers.
+	for _, v := range ed.keyPrefix {
+		if strings.HasPrefix(realKey, v) {
+			if _, exist := ed.registry[v]; exist {
+				hs = append(hs, ed.registry[v]...)
 			}
 		}
 	}

--- a/pkg/config/event_dispatcher_test.go
+++ b/pkg/config/event_dispatcher_test.go
@@ -134,6 +134,19 @@ func (s *EventDispatcherSuite) TestDispatch() {
 
 		s.True(called.Load())
 	})
+
+	s.Run("dispatch_key_and_prefix_both_fire", func() {
+		keyCalled := atomic.NewBool(false)
+		prefixCalled := atomic.NewBool(false)
+
+		dispatcher.Register("trace.exporter", NewHandler("key_handler", func(*Event) { keyCalled.Store(true) }))
+		dispatcher.RegisterForKeyPrefix("trace", NewHandler("prefix_handler", func(*Event) { prefixCalled.Store(true) }))
+
+		dispatcher.Dispatch(newEvent("test", UpdateType, "trace.exporter", "stdout"))
+
+		s.True(keyCalled.Load())
+		s.True(prefixCalled.Load())
+	})
 }
 
 func TestEventDispatcher(t *testing.T) {

--- a/pkg/util/paramtable/base_table_event_test.go
+++ b/pkg/util/paramtable/base_table_event_test.go
@@ -1,0 +1,51 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package paramtable
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/pkg/v2/config"
+)
+
+func TestBaseTable_SaveFiresEvent(t *testing.T) {
+	bt := NewBaseTable(SkipRemote(true), SkipEnv(true))
+
+	called := make(chan *config.Event, 1)
+	bt.mgr.Dispatcher.RegisterForKeyPrefix("trace", config.NewHandler("test-trace-prefix", func(e *config.Event) {
+		select {
+		case called <- e:
+		default:
+		}
+	}))
+
+	err := bt.Save("trace.exporter", "stdout")
+	assert.NoError(t, err)
+
+	select {
+	case e := <-called:
+		assert.Equal(t, strings.ToLower("trace.exporter"), e.Key)
+		assert.Equal(t, config.UpdateType, e.EventType)
+		assert.Equal(t, "stdout", e.Value)
+		assert.True(t, e.HasUpdated)
+	default:
+		t.Fatalf("expected config event to be fired on Save()")
+	}
+}


### PR DESCRIPTION
Emit config events on paramtable Save/SaveGroup/Reset/Remove so tracing/log watchers can react without restart.

Fix EventDispatcher to dispatch keyPrefix handlers Dispatch prefix handlers in addition to exact key handlers to restore tracing hot-reload and global cache eviction after ParamItem handler registration.

issue: https://github.com/milvus-io/milvus/issues/47142
