### PR TITLE
fix: [2.6] Use same pk handling logic in `deletePreExecute`&`packDeleteMessage` (#47146)

### DIFF
--- a/internal/proxy/task_upsert_streaming.go
+++ b/internal/proxy/task_upsert_streaming.go
@@ -98,7 +98,10 @@ func (ut *upsertTask) packInsertMessage(ctx context.Context, ez *message.CipherC
 func (ut *upsertTask) packDeleteMessage(ctx context.Context, ez *message.CipherConfig) ([]message.MutableMessage, error) {
 	tr := timerecord.NewTimeRecorder(fmt.Sprintf("proxy deleteExecute upsert %d", ut.ID()))
 	collID := ut.upsertMsg.DeleteMsg.CollectionID
-	ut.upsertMsg.DeleteMsg.PrimaryKeys = ut.oldIDs
+	if ut.upsertMsg.DeleteMsg.PrimaryKeys == nil {
+		// if primary keys are not set by queryPreExecute, use oldIDs to delete all given records
+		ut.upsertMsg.DeleteMsg.PrimaryKeys = ut.oldIDs
+	}
 	log := log.Ctx(ctx).With(
 		zap.Int64("collectionID", collID))
 	// hash primary keys to channels


### PR DESCRIPTION
Cherry-pick from master
pr: #47146
Related to #47145

Handle delete message primary keys in `packedDeleteMessage` with same logic in `deletePreExecute` for upsert task. Preventing send delete message with 0 partition id when all ids in upsert request do not exist in current collection.