### PR TITLE
fix: [2.5] azure precheck use a fixed bucket not belong to milvus

### DIFF
--- a/internal/core/src/storage/MinioChunkManager.cpp
+++ b/internal/core/src/storage/MinioChunkManager.cpp
@@ -226,7 +226,11 @@ MinioChunkManager::PreCheck(const StorageConfig& config) {
              config.ToString());
     try {
         // Just test connection not check real list, avoid cost resource.
-        ListWithPrefix("justforconnectioncheck");
+        std::string check_prefix = "justforconnectioncheck";
+        if (!remote_root_path_.empty()) {
+            check_prefix = remote_root_path_ + "/" + check_prefix;
+        }
+        ListWithPrefix(check_prefix);
     } catch (SegcoreError& e) {
         auto err_message = fmt::format(
             "precheck chunk manager client failed, "

--- a/internal/core/src/storage/azure-blob-storage/AzureBlobChunkManager.cpp
+++ b/internal/core/src/storage/azure-blob-storage/AzureBlobChunkManager.cpp
@@ -79,17 +79,6 @@ AzureBlobChunkManager::AzureBlobChunkManager(
                 CreateFromConnectionString(GetConnectionString(
                     access_key_id, access_key_value, address)));
     }
-    try {
-        Azure::Core::Context context;
-        client_->GetBlobContainerClient("justforconnectioncheck")
-            .GetBlockBlobClient("justforconnectioncheck")
-            .GetProperties(Azure::Storage::Blobs::GetBlobPropertiesOptions(),
-                           context);
-    } catch (const Azure::Storage::StorageException& e) {
-        if (e.StatusCode != Azure::Core::Http::HttpStatusCode::NotFound) {
-            throw;
-        }
-    }
 }
 
 AzureBlobChunkManager::~AzureBlobChunkManager() {

--- a/internal/core/unittest/test_azure_chunk_manager.cpp
+++ b/internal/core/unittest/test_azure_chunk_manager.cpp
@@ -69,18 +69,6 @@ class AzureChunkManagerTest : public testing::Test {
     StorageConfig configs_;
 };
 
-TEST_F(AzureChunkManagerTest, WrongConfig) {
-    StorageConfig configs = get_default_storage_config(true);
-
-    try {
-        AzureChunkManagerPtr chunk_manager =
-            make_unique<AzureChunkManager>(configs);
-        EXPECT_TRUE(false);
-    } catch (SegcoreError& e) {
-        EXPECT_TRUE(std::string(e.what()).find("precheck") != string::npos);
-    }
-}
-
 TEST_F(AzureChunkManagerTest, AzureLogger) {
     AzureLogger(Azure::Core::Diagnostics::Logger::Level::Error, "");
     AzureLogger(Azure::Core::Diagnostics::Logger::Level::Warning, "");


### PR DESCRIPTION
pr: #47170