### PR TITLE
fix: [hotfix-2.6.9] azure precheck use a fixed bucket not belong to milvus

### DIFF
--- a/internal/core/src/storage/MinioChunkManager.cpp
+++ b/internal/core/src/storage/MinioChunkManager.cpp
@@ -226,7 +226,11 @@ MinioChunkManager::PreCheck(const StorageConfig& config) {
              config.ToString());
     try {
         // Just test connection not check real list, avoid cost resource.
-        ListWithPrefix("justforconnectioncheck");
+        std::string check_prefix = "justforconnectioncheck";
+        if (!remote_root_path_.empty()) {
+            check_prefix = remote_root_path_ + "/" + check_prefix;
+        }
+        ListWithPrefix(check_prefix);
     } catch (SegcoreError& e) {
         auto err_message = fmt::format(
             "precheck chunk manager client failed, "

--- a/internal/core/src/storage/azure/AzureBlobChunkManager.cpp
+++ b/internal/core/src/storage/azure/AzureBlobChunkManager.cpp
@@ -79,17 +79,6 @@ AzureBlobChunkManager::AzureBlobChunkManager(
                 CreateFromConnectionString(GetConnectionString(
                     access_key_id, access_key_value, address)));
     }
-    try {
-        Azure::Core::Context context;
-        client_->GetBlobContainerClient("justforconnectioncheck")
-            .GetBlockBlobClient("justforconnectioncheck")
-            .GetProperties(Azure::Storage::Blobs::GetBlobPropertiesOptions(),
-                           context);
-    } catch (const Azure::Storage::StorageException& e) {
-        if (e.StatusCode != Azure::Core::Http::HttpStatusCode::NotFound) {
-            throw;
-        }
-    }
 }
 
 AzureBlobChunkManager::~AzureBlobChunkManager() {


### PR DESCRIPTION
pr: #47170