### PR TITLE
enhance: [Loon] Use separate PackWriter for v3 sync task

### DIFF
--- a/internal/datanode/compactor/clustering_compactor_storage_v2_test.go
+++ b/internal/datanode/compactor/clustering_compactor_storage_v2_test.go
@@ -213,7 +213,7 @@ func (s *ClusteringCompactionTaskStorageV2Suite) initStorageV2Segments(rows int,
 	bw := syncmgr.NewBulkPackWriterV2(mc, sch, cm, s.mockAlloc, packed.DefaultWriteBufferSize, 0, &indexpb.StorageConfig{
 		StorageType: "local",
 		RootPath:    rootPath,
-	}, columnGroups, "")
+	}, columnGroups)
 	return bw.Write(context.Background(), pack)
 }
 

--- a/internal/datanode/compactor/mix_compactor_storage_v2_test.go
+++ b/internal/datanode/compactor/mix_compactor_storage_v2_test.go
@@ -293,7 +293,7 @@ func (s *MixCompactionTaskStorageV2Suite) initStorageV2Segments(rows int, seed i
 	bw := syncmgr.NewBulkPackWriterV2(mc, s.meta.Schema, cm, alloc, packed.DefaultWriteBufferSize, 0, &indexpb.StorageConfig{
 		StorageType: "local",
 		RootPath:    rootPath,
-	}, columnGroups, "")
+	}, columnGroups)
 	return bw.Write(context.Background(), pack)
 }
 

--- a/internal/datanode/compactor/namespace_compactor_test.go
+++ b/internal/datanode/compactor/namespace_compactor_test.go
@@ -110,7 +110,7 @@ func (s *NamespaceCompactorTestSuite) setupSortedSegments() {
 		bw := syncmgr.NewBulkPackWriterV2(mc, s.schema, cm, alloc, packed.DefaultWriteBufferSize, 0, &indexpb.StorageConfig{
 			StorageType: "local",
 			RootPath:    rootPath,
-		}, columnGroups, "")
+		}, columnGroups)
 		inserts, _, _, _, _, _, err := bw.Write(context.Background(), pack)
 		s.Require().NoError(err)
 		s.sortedSegments = append(s.sortedSegments, &datapb.CompactionSegmentBinlogs{

--- a/internal/datanode/importv2/util.go
+++ b/internal/datanode/importv2/util.go
@@ -81,9 +81,6 @@ func NewSyncTask(ctx context.Context,
 		if useLoonFFI {
 			k := metautil.JoinIDPath(collectionID, partitionID, segmentID)
 			basePath := path.Join(storageConfig.GetRootPath(), common.SegmentInsertLogPath, k)
-			if storageConfig.GetStorageType() != "local" {
-				basePath = path.Join(storageConfig.GetBucketName(), basePath)
-			}
 			// -1 for first write
 			segment.ManifestPath = packed.MarshalManifestPath(basePath, -1)
 		}

--- a/internal/flushcommon/syncmgr/pack_writer_v2.go
+++ b/internal/flushcommon/syncmgr/pack_writer_v2.go
@@ -44,13 +44,11 @@ import (
 
 type BulkPackWriterV2 struct {
 	*BulkPackWriter
-	schema              *schemapb.CollectionSchema
 	bufferSize          int64
 	multiPartUploadSize int64
 
 	storageConfig *indexpb.StorageConfig
 	columnGroups  []storagecommon.ColumnGroup
-	manifestPath  string
 }
 
 func NewBulkPackWriterV2(metaCache metacache.MetaCache, schema *schemapb.CollectionSchema, chunkManager storage.ChunkManager,
@@ -65,7 +63,6 @@ func NewBulkPackWriterV2(metaCache metacache.MetaCache, schema *schemapb.Collect
 			allocator:      allocator,
 			writeRetryOpts: writeRetryOpts,
 		},
-		schema:              schema,
 		bufferSize:          bufferSize,
 		multiPartUploadSize: multiPartUploadSize,
 		storageConfig:       storageConfig,

--- a/internal/flushcommon/syncmgr/pack_writer_v3.go
+++ b/internal/flushcommon/syncmgr/pack_writer_v3.go
@@ -37,13 +37,8 @@ import (
 
 type BulkPackWriterV3 struct {
 	*BulkPackWriterV2
-	schema              *schemapb.CollectionSchema
-	bufferSize          int64
-	multiPartUploadSize int64
 
-	storageConfig *indexpb.StorageConfig
-	columnGroups  []storagecommon.ColumnGroup
-	manifestPath  string
+	manifestPath string
 }
 
 func NewBulkPackWriterV3(metaCache metacache.MetaCache, schema *schemapb.CollectionSchema, chunkManager storage.ChunkManager,
@@ -53,13 +48,8 @@ func NewBulkPackWriterV3(metaCache metacache.MetaCache, schema *schemapb.Collect
 	bwV2 := NewBulkPackWriterV2(metaCache, schema, chunkManager, allocator, bufferSize,
 		multiPartUploadSize, storageConfig, columnGroups, writeRetryOpts...)
 	return &BulkPackWriterV3{
-		BulkPackWriterV2:    bwV2,
-		schema:              schema,
-		bufferSize:          bufferSize,
-		multiPartUploadSize: multiPartUploadSize,
-		storageConfig:       storageConfig,
-		columnGroups:        columnGroups,
-		manifestPath:        curManifestPath,
+		BulkPackWriterV2: bwV2,
+		manifestPath:     curManifestPath,
 	}
 }
 
@@ -97,7 +87,7 @@ func (bw *BulkPackWriterV3) Write(ctx context.Context, pack *SyncPack) (
 
 func (bw *BulkPackWriterV3) writeInserts(ctx context.Context, pack *SyncPack) (map[int64]*datapb.FieldBinlog, string, error) {
 	if len(pack.insertData) == 0 {
-		return make(map[int64]*datapb.FieldBinlog), "", nil
+		return make(map[int64]*datapb.FieldBinlog), bw.manifestPath, nil
 	}
 
 	rec, err := bw.serializeBinlog(ctx, pack)

--- a/internal/flushcommon/syncmgr/pack_writer_v3.go
+++ b/internal/flushcommon/syncmgr/pack_writer_v3.go
@@ -18,32 +18,25 @@ package syncmgr
 
 import (
 	"context"
-	"encoding/base64"
-	"math"
 
-	"github.com/apache/arrow/go/v17/arrow/array"
-	"github.com/apache/arrow/go/v17/arrow/memory"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/allocator"
 	"github.com/milvus-io/milvus/internal/flushcommon/metacache"
-	"github.com/milvus-io/milvus/internal/storage"
+	storage "github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/storagecommon"
-	"github.com/milvus-io/milvus/internal/util/hookutil"
-	"github.com/milvus-io/milvus/pkg/v2/common"
+	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/indexcgopb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
-	"github.com/milvus-io/milvus/pkg/v2/util/metautil"
-	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/retry"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
 
-type BulkPackWriterV2 struct {
-	*BulkPackWriter
+type BulkPackWriterV3 struct {
+	*BulkPackWriterV2
 	schema              *schemapb.CollectionSchema
 	bufferSize          int64
 	multiPartUploadSize int64
@@ -53,27 +46,24 @@ type BulkPackWriterV2 struct {
 	manifestPath  string
 }
 
-func NewBulkPackWriterV2(metaCache metacache.MetaCache, schema *schemapb.CollectionSchema, chunkManager storage.ChunkManager,
+func NewBulkPackWriterV3(metaCache metacache.MetaCache, schema *schemapb.CollectionSchema, chunkManager storage.ChunkManager,
 	allocator allocator.Interface, bufferSize, multiPartUploadSize int64,
-	storageConfig *indexpb.StorageConfig, columnGroups []storagecommon.ColumnGroup, writeRetryOpts ...retry.Option,
-) *BulkPackWriterV2 {
-	return &BulkPackWriterV2{
-		BulkPackWriter: &BulkPackWriter{
-			metaCache:      metaCache,
-			schema:         schema,
-			chunkManager:   chunkManager,
-			allocator:      allocator,
-			writeRetryOpts: writeRetryOpts,
-		},
+	storageConfig *indexpb.StorageConfig, columnGroups []storagecommon.ColumnGroup, curManifestPath string, writeRetryOpts ...retry.Option,
+) *BulkPackWriterV3 {
+	bwV2 := NewBulkPackWriterV2(metaCache, schema, chunkManager, allocator, bufferSize,
+		multiPartUploadSize, storageConfig, columnGroups, writeRetryOpts...)
+	return &BulkPackWriterV3{
+		BulkPackWriterV2:    bwV2,
 		schema:              schema,
 		bufferSize:          bufferSize,
 		multiPartUploadSize: multiPartUploadSize,
 		storageConfig:       storageConfig,
 		columnGroups:        columnGroups,
+		manifestPath:        curManifestPath,
 	}
 }
 
-func (bw *BulkPackWriterV2) Write(ctx context.Context, pack *SyncPack) (
+func (bw *BulkPackWriterV3) Write(ctx context.Context, pack *SyncPack) (
 	inserts map[int64]*datapb.FieldBinlog,
 	deltas *datapb.FieldBinlog,
 	stats map[int64]*datapb.FieldBinlog,
@@ -82,6 +72,8 @@ func (bw *BulkPackWriterV2) Write(ctx context.Context, pack *SyncPack) (
 	size int64,
 	err error,
 ) {
+	log := log.Ctx(ctx)
+
 	if inserts, manifest, err = bw.writeInserts(ctx, pack); err != nil {
 		log.Error("failed to write insert data", zap.Error(err))
 		return
@@ -100,65 +92,10 @@ func (bw *BulkPackWriterV2) Write(ctx context.Context, pack *SyncPack) (
 	}
 
 	size = bw.sizeWritten
-
 	return
 }
 
-// getRootPath returns the rootPath current task shall use.
-// when storageConfig is set, use the rootPath in it.
-// otherwise, use chunkManager.RootPath() instead.
-func (bw *BulkPackWriterV2) getRootPath() string {
-	if bw.storageConfig != nil {
-		return bw.storageConfig.RootPath
-	}
-	return bw.chunkManager.RootPath()
-}
-
-func (bw *BulkPackWriterV2) getBucketName() string {
-	if bw.storageConfig != nil {
-		return bw.storageConfig.BucketName
-	}
-	return paramtable.Get().ServiceParam.MinioCfg.BucketName.GetValue()
-}
-
-func (bw *BulkPackWriterV2) getPluginContext(collectionID int64) *indexcgopb.StoragePluginContext {
-	if !hookutil.IsClusterEncryptionEnabled() {
-		return nil
-	}
-	ez := hookutil.GetEzByCollProperties(bw.schema.GetProperties(), collectionID)
-	if ez == nil {
-		return nil
-	}
-	unsafe := hookutil.GetCipher().GetUnsafeKey(ez.EzID, ez.CollectionID)
-	if len(unsafe) == 0 {
-		return nil
-	}
-
-	return &indexcgopb.StoragePluginContext{
-		EncryptionZoneId: ez.EzID,
-		CollectionId:     ez.CollectionID,
-		EncryptionKey:    base64.StdEncoding.EncodeToString(unsafe),
-	}
-}
-
-func (bw *BulkPackWriterV2) getTsRange(rec storage.Record) (tsFrom, tsTo uint64) {
-	tsArray := rec.Column(common.TimeStampField).(*array.Int64)
-	rows := rec.Len()
-	tsFrom = math.MaxUint64
-	tsTo = 0
-	for i := 0; i < rows; i++ {
-		ts := typeutil.Timestamp(tsArray.Value(i))
-		if ts < tsFrom {
-			tsFrom = ts
-		}
-		if ts > tsTo {
-			tsTo = ts
-		}
-	}
-	return tsFrom, tsTo
-}
-
-func (bw *BulkPackWriterV2) writeInserts(ctx context.Context, pack *SyncPack) (map[int64]*datapb.FieldBinlog, string, error) {
+func (bw *BulkPackWriterV3) writeInserts(ctx context.Context, pack *SyncPack) (map[int64]*datapb.FieldBinlog, string, error) {
 	if len(pack.insertData) == 0 {
 		return make(map[int64]*datapb.FieldBinlog), "", nil
 	}
@@ -177,7 +114,7 @@ func (bw *BulkPackWriterV2) writeInserts(ctx context.Context, pack *SyncPack) (m
 
 	if err := retry.Do(ctx, func() error {
 		var err error
-		logs, manifestPath, err = bw.writeInsertsIntoStorage(ctx, pluginContextPtr, pack, rec, tsFrom, tsTo)
+		logs, manifestPath, err = bw.writeInsertsIntoStorage(ctx, pluginContextPtr, rec, tsFrom, tsTo)
 		if err != nil {
 			log.Warn("failed to write inserts into storage",
 				zap.Int64("collectionID", pack.collectionID),
@@ -192,16 +129,15 @@ func (bw *BulkPackWriterV2) writeInserts(ctx context.Context, pack *SyncPack) (m
 	return logs, manifestPath, nil
 }
 
-func (bw *BulkPackWriterV2) writeInsertsIntoStorage(_ context.Context,
+func (bw *BulkPackWriterV3) writeInsertsIntoStorage(ctx context.Context,
 	pluginContextPtr *indexcgopb.StoragePluginContext,
-	pack *SyncPack,
 	rec storage.Record,
 	tsFrom typeutil.Timestamp,
 	tsTo typeutil.Timestamp,
 ) (map[int64]*datapb.FieldBinlog, string, error) {
+	log := log.Ctx(ctx)
 	logs := make(map[int64]*datapb.FieldBinlog)
 	columnGroups := bw.columnGroups
-	bucketName := bw.getBucketName()
 
 	var err error
 	doWrite := func(w storage.RecordWriter) error {
@@ -226,23 +162,17 @@ func (bw *BulkPackWriterV2) writeInsertsIntoStorage(_ context.Context,
 		return result
 	}
 
-	paths := make([]string, 0)
-	for _, columnGroup := range columnGroups {
-		id, err := bw.allocator.AllocOne()
-		if err != nil {
-			return nil, "", err
-		}
-		path := metautil.BuildInsertLogPath(bw.getRootPath(), pack.collectionID, pack.partitionID, pack.segmentID, columnGroup.GroupID, id)
-		paths = append(paths, path)
+	basePath, version, err := packed.UnmarshalManfestPath(bw.manifestPath)
+	if err != nil {
+		return nil, "", err
 	}
-	w, err := storage.NewPackedRecordWriter(bucketName, paths, bw.schema, bw.bufferSize, bw.multiPartUploadSize, columnGroups, bw.storageConfig, pluginContextPtr)
+	w, err := storage.NewPackedRecordManifestWriter(basePath, version, bw.schema, bw.bufferSize, bw.multiPartUploadSize, columnGroups, bw.storageConfig, pluginContextPtr)
 	if err != nil {
 		return nil, "", err
 	}
 	if err = doWrite(w); err != nil {
 		return nil, "", err
 	}
-	// workaround to store row num
 	for _, columnGroup := range columnGroups {
 		columnGroupID := columnGroup.GroupID
 		logs[columnGroupID] = &datapb.FieldBinlog{
@@ -261,32 +191,6 @@ func (bw *BulkPackWriterV2) writeInsertsIntoStorage(_ context.Context,
 			},
 		}
 	}
-
+	manifestPath = w.GetWrittenManifest()
 	return logs, manifestPath, nil
-}
-
-func (bw *BulkPackWriterV2) serializeBinlog(_ context.Context, pack *SyncPack) (storage.Record, error) {
-	if len(pack.insertData) == 0 {
-		return nil, nil
-	}
-	arrowSchema, err := storage.ConvertToArrowSchema(bw.schema, true)
-	if err != nil {
-		return nil, err
-	}
-	builder := array.NewRecordBuilder(memory.DefaultAllocator, arrowSchema)
-	defer builder.Release()
-
-	for _, chunk := range pack.insertData {
-		if err := storage.BuildRecord(builder, chunk, bw.schema); err != nil {
-			return nil, err
-		}
-	}
-
-	rec := builder.NewRecord()
-	allFields := typeutil.GetAllFieldSchemas(bw.schema)
-	field2Col := make(map[storage.FieldID]int, len(allFields))
-	for c, field := range allFields {
-		field2Col[field.FieldID] = c
-	}
-	return storage.NewSimpleArrowRecord(rec, field2Col), nil
 }

--- a/internal/flushcommon/syncmgr/task.go
+++ b/internal/flushcommon/syncmgr/task.go
@@ -135,17 +135,19 @@ func (t *SyncTask) Run(ctx context.Context) (err error) {
 	columnGroups := t.getColumnGroups(segmentInfo)
 
 	switch segmentInfo.GetStorageVersion() {
-	case storage.StorageV2, storage.StorageV3:
+	case storage.StorageV2:
 		// New sync task means needs to flush data immediately, so do not need to buffer data in writer again.
 		writer := NewBulkPackWriterV2(t.metacache, t.schema, t.chunkManager, t.allocator, 0,
-			packed.DefaultMultiPartUploadSize, t.storageConfig, columnGroups, segmentInfo.ManifestPath(), t.writeRetryOpts...)
+			packed.DefaultMultiPartUploadSize, t.storageConfig, columnGroups, t.writeRetryOpts...)
 		t.insertBinlogs, t.deltaBinlog, t.statsBinlogs, t.bm25Binlogs, t.manifestPath, t.flushedSize, err = writer.Write(ctx, t.pack)
 		if err != nil {
 			log.Warn("failed to write sync data with storage v2 format", zap.Error(err))
 			return err
 		}
-	// case storage.StorageV3:
-
+	case storage.StorageV3:
+		writer := NewBulkPackWriterV3(t.metacache, t.schema, t.chunkManager, t.allocator, 0,
+			packed.DefaultMultiPartUploadSize, t.storageConfig, columnGroups, segmentInfo.ManifestPath(), t.writeRetryOpts...)
+		writer.Write(ctx, t.pack)
 	default:
 		writer := NewBulkPackWriter(t.metacache, t.schema, t.chunkManager, t.allocator, t.writeRetryOpts...)
 		t.insertBinlogs, t.deltaBinlog, t.statsBinlogs, t.bm25Binlogs, t.flushedSize, err = writer.Write(ctx, t.pack)

--- a/internal/flushcommon/syncmgr/task.go
+++ b/internal/flushcommon/syncmgr/task.go
@@ -147,7 +147,7 @@ func (t *SyncTask) Run(ctx context.Context) (err error) {
 	case storage.StorageV3:
 		writer := NewBulkPackWriterV3(t.metacache, t.schema, t.chunkManager, t.allocator, 0,
 			packed.DefaultMultiPartUploadSize, t.storageConfig, columnGroups, segmentInfo.ManifestPath(), t.writeRetryOpts...)
-		writer.Write(ctx, t.pack)
+		t.insertBinlogs, t.deltaBinlog, t.statsBinlogs, t.bm25Binlogs, t.manifestPath, t.flushedSize, err = writer.Write(ctx, t.pack)
 	default:
 		writer := NewBulkPackWriter(t.metacache, t.schema, t.chunkManager, t.allocator, t.writeRetryOpts...)
 		t.insertBinlogs, t.deltaBinlog, t.statsBinlogs, t.bm25Binlogs, t.flushedSize, err = writer.Write(ctx, t.pack)

--- a/internal/storage/binlog_record_writer.go
+++ b/internal/storage/binlog_record_writer.go
@@ -424,7 +424,7 @@ func (pw *PackedManifestRecordWriter) initWriters(r Record) error {
 		var err error
 		k := metautil.JoinIDPath(pw.collectionID, pw.partitionID, pw.segmentID)
 		basePath := path.Join(pw.storageConfig.GetRootPath(), common.SegmentInsertLogPath, k)
-		pw.writer, err = NewPackedRecordManifestWriter(pw.storageConfig.GetBucketName(), basePath, -1, pw.schema, pw.bufferSize, pw.multiPartUploadSize, pw.columnGroups, pw.storageConfig, pw.storagePluginContext)
+		pw.writer, err = NewPackedRecordManifestWriter(basePath, -1, pw.schema, pw.bufferSize, pw.multiPartUploadSize, pw.columnGroups, pw.storageConfig, pw.storagePluginContext)
 		if err != nil {
 			return merr.WrapErrServiceInternal(fmt.Sprintf("can not new packed record writer %s", err.Error()))
 		}

--- a/internal/storage/record_writer.go
+++ b/internal/storage/record_writer.go
@@ -70,7 +70,6 @@ func (pw *packedRecordWriter) Write(r Record) error {
 	}
 	pw.rowNum += int64(r.Len())
 	for col, arr := range rec.Columns() {
-		// size := arr.Data().SizeInBytes()
 		size := calculateActualDataSize(arr)
 		pw.writtenUncompressed += size
 		for _, columnGroup := range pw.columnGroups {
@@ -218,7 +217,6 @@ func (pw *packedRecordManifestWriter) Write(r Record) error {
 	}
 	pw.rowNum += int64(r.Len())
 	for col, arr := range rec.Columns() {
-		// size := arr.Data().SizeInBytes()
 		size := calculateActualDataSize(arr)
 		pw.writtenUncompressed += size
 		for _, columnGroup := range pw.columnGroups {
@@ -279,7 +277,6 @@ func (pw *packedRecordManifestWriter) Close() error {
 }
 
 func NewPackedRecordManifestWriter(
-	bucketName string,
 	basePath string,
 	baseVersion int64,
 	schema *schemapb.CollectionSchema,
@@ -324,7 +321,6 @@ func NewPackedRecordManifestWriter(
 		schema:                  schema,
 		arrowSchema:             arrowSchema,
 		bufferSize:              bufferSize,
-		bucketName:              bucketName,
 		pathsMap:                pathsMap,
 		columnGroups:            columnGroups,
 		columnGroupUncompressed: columnGroupUncompressed,


### PR DESCRIPTION
Related to #44956
See also #46976

This PR:
- Add `BulkPackWriterV3` for v3 segment sync task
- Remove not needed params for legacy usage
- Fix import task still use bucketname concatenation