### PR TITLE
enhance: add logging for force merge algorithm selection

### DIFF
--- a/internal/datacoord/compaction_view_forcemerge.go
+++ b/internal/datacoord/compaction_view_forcemerge.go
@@ -188,9 +188,17 @@ func adaptiveGroupSegments(segments []*SegmentView, targetSize float64) [][]*Seg
 	// Use maxFull for small segment counts to maximize full segments
 	// Use larger for large segment counts for O(n) performance
 	if n <= threshold {
+		log.Info("adaptiveGroupSegments: using maxFullSegmentsGrouping algorithm",
+			zap.Int("segmentCount", n),
+			zap.Int("threshold", threshold),
+			zap.Float64("targetSize", targetSize))
 		return maxFullSegmentsGrouping(segments, targetSize)
 	}
 
+	log.Info("adaptiveGroupSegments: using largerGroupingSegments algorithm",
+		zap.Int("segmentCount", n),
+		zap.Int("threshold", threshold),
+		zap.Float64("targetSize", targetSize))
 	return largerGroupingSegments(segments, targetSize)
 }
 


### PR DESCRIPTION
## Summary

Add INFO level logging to the `adaptiveGroupSegments` function to show which grouping algorithm is selected during force merge operations:

- `maxFullSegmentsGrouping`: Used when `segmentCount <= maxFullSegmentThreshold` (DP algorithm, O(n²))
- `largerGroupingSegments`: Used when `segmentCount > maxFullSegmentThreshold` (Greedy algorithm, O(n))

### Log output example:
```
[INFO] ["adaptiveGroupSegments: using maxFullSegmentsGrouping algorithm"] [segmentCount=5] [threshold=10] [targetSize=67108864]
```

### Why this change?
This improves observability for force merge operations and helps:
1. Verify that `maxFullSegmentThreshold` configuration is working correctly
2. Debug unexpected compaction behavior
3. Monitor and understand compaction performance characteristics

issue: #47209

## Test plan

- [ ] Verify log output appears when triggering force merge with segment count <= threshold
- [ ] Verify log output appears when triggering force merge with segment count > threshold
- [ ] Verify segmentCount, threshold, and targetSize values are logged correctly