### PR TITLE
enhance: increase L0 compaction max deltalog count to 1000

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -689,7 +689,7 @@ dataCoord:
         minSize: 8388608 # The minimum size in bytes to force trigger a LevelZero Compaction, default as 8MB
         maxSize: 67108864 # The maxmum size in bytes to force trigger a LevelZero Compaction, default as 64MB
         deltalogMinNum: 10 # The minimum number of deltalog files to force trigger a LevelZero Compaction
-        deltalogMaxNum: 30 # The maxmum number of deltalog files to force trigger a LevelZero Compaction, default as 30
+        deltalogMaxNum: 1000 # The maxmum number of deltalog files to force trigger a LevelZero Compaction, default as 1000
     expiry:
       tolerance: -1 # tolerant duration in hours for expiry data, negative value means no toleration and equivalent to zero
     backfill:

--- a/internal/datacoord/compaction_l0_view_test.go
+++ b/internal/datacoord/compaction_l0_view_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
 
 func TestLevelZeroSegmentsViewSuite(t *testing.T) {
@@ -107,7 +108,7 @@ func (s *LevelZeroSegmentsViewSuite) TestTrigger() {
 		{
 			"Trigger by > maxDeltaCount",
 			1,
-			24,
+			800,
 			30000,
 			[]UniqueID{100},
 		},
@@ -156,7 +157,7 @@ func (s *LevelZeroSegmentsViewSuite) TestMinCountSizeTrigger() {
 		{"donot trigger", []int64{100, 101, 102}, []int{1, 1, 1}, []float64{1, 1, 1}, nil},
 		{"trigger by count=15", []int64{100, 101, 102}, []int{5, 5, 5}, []float64{1, 1, 1}, []int64{100, 101, 102}},
 		{"trigger by count=10", []int64{100, 101, 102}, []int{5, 3, 2}, []float64{1, 1, 1}, []int64{100, 101, 102}},
-		{"trigger by count=50", []int64{100, 101, 102}, []int{32, 10, 8}, []float64{1, 1, 1}, []int64{100}},
+		{"trigger by count=50", []int64{100, 101, 102}, []int{32, 10, 8}, []float64{1, 1, 1}, []int64{100, 101, 102}},
 		{"trigger by size=24MB", []int64{100, 101, 102}, []int{1, 1, 1}, []float64{8 * 1024 * 1024, 8 * 1024 * 1024, 8 * 1024 * 1024}, []int64{100, 101, 102}},
 		{"trigger by size=8MB", []int64{100, 101, 102}, []int{1, 1, 1}, []float64{3 * 1024 * 1024, 3 * 1024 * 1024, 2 * 1024 * 1024}, []int64{100, 101, 102}},
 		{"trigger by size=128MB", []int64{100, 101, 102}, []int{1, 1, 1}, []float64{100 * 1024 * 1024, 20 * 1024 * 1024, 8 * 1024 * 1024}, []int64{100}},
@@ -200,7 +201,7 @@ func (s *LevelZeroSegmentsViewSuite) TestForceTrigger() {
 		{"force trigger", []int64{100, 101, 102}, []int{1, 1, 1}, []float64{1, 1, 1}, []int64{100, 101, 102}},
 		{"trigger by count=15", []int64{100, 101, 102}, []int{5, 5, 5}, []float64{1, 1, 1}, []int64{100, 101, 102}},
 		{"trigger by count=10", []int64{100, 101, 102}, []int{5, 3, 2}, []float64{1, 1, 1}, []int64{100, 101, 102}},
-		{"trigger by count=50", []int64{100, 101, 102}, []int{32, 10, 8}, []float64{1, 1, 1}, []int64{100}},
+		{"trigger by count=50", []int64{100, 101, 102}, []int{32, 10, 8}, []float64{1, 1, 1}, []int64{100, 101, 102}},
 		{"trigger by size=24MB", []int64{100, 101, 102}, []int{1, 1, 1}, []float64{8 * 1024 * 1024, 8 * 1024 * 1024, 8 * 1024 * 1024}, []int64{100, 101, 102}},
 		{"trigger by size=8MB", []int64{100, 101, 102}, []int{1, 1, 1}, []float64{3 * 1024 * 1024, 3 * 1024 * 1024, 2 * 1024 * 1024}, []int64{100, 101, 102}},
 		{"trigger by size=128MB", []int64{100, 101, 102}, []int{1, 1, 1}, []float64{100 * 1024 * 1024, 20 * 1024 * 1024, 8 * 1024 * 1024}, []int64{100}},
@@ -224,4 +225,23 @@ func (s *LevelZeroSegmentsViewSuite) TestForceTrigger() {
 			log.Info("test forceTrigger", zap.Any("trigger reason", reason))
 		})
 	}
+
+	// Test that exceeding maxCount from paramtable picks only the first segment.
+	s.Run("trigger by exceeding maxCount from param", func() {
+		maxCount := paramtable.Get().DataCoordCfg.LevelZeroCompactionTriggerDeltalogMaxNum.GetAsInt()
+		views := []*SegmentView{
+			genTestL0SegmentView(100, label, 10000),
+			genTestL0SegmentView(101, label, 10000),
+		}
+		views[0].DeltaSize = 1
+		views[0].DeltalogCount = maxCount
+		views[1].DeltaSize = 1
+		views[1].DeltalogCount = maxCount
+
+		picked, reason := s.v.forceTrigger(views)
+		s.ElementsMatch(lo.Map(picked, func(view *SegmentView, _ int) int64 {
+			return view.ID
+		}), []int64{100})
+		log.Info("test forceTrigger", zap.Any("trigger reason", reason))
+	})
 }

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -5430,8 +5430,8 @@ During compaction, the size of segment # of rows is able to exceed segment max #
 	p.LevelZeroCompactionTriggerDeltalogMaxNum = ParamItem{
 		Key:          "dataCoord.compaction.levelzero.forceTrigger.deltalogMaxNum",
 		Version:      "2.4.0",
-		Doc:          "The maxmum number of deltalog files to force trigger a LevelZero Compaction, default as 30",
-		DefaultValue: "30",
+		Doc:          "The maxmum number of deltalog files to force trigger a LevelZero Compaction, default as 1000",
+		DefaultValue: "1000",
 		Export:       true,
 	}
 	p.LevelZeroCompactionTriggerDeltalogMaxNum.Init(base.mgr)


### PR DESCRIPTION
This change increases the default value of deltalogMaxNum from 30 to 1000 in L0 compaction force trigger settings. This allows more segments to be included in a single L0 compaction operation.

The change is safe because:
- We already have a maxSize limiter (dataCoord.compaction.levelzero.forceTrigger.maxSize) that caps the total size at 64MB, preventing excessive memory usage
- This only affects the maximum count allowed, not the minimum force trigger threshold (deltalogMinNum: 10)
- Systems will still respect the size limit even if many small segments are present

Resolves #46650