### PR TITLE
fix: Call `singleflight.Forget` when remove collections in metacache

### DIFF
--- a/internal/proxy/meta_cache.go
+++ b/internal/proxy/meta_cache.go
@@ -873,6 +873,8 @@ func (m *MetaCache) removeCollectionByID(ctx context.Context, collectionID Uniqu
 				if version == 0 || curVersion <= version {
 					delete(m.collInfo[database], k)
 					collNames = append(collNames, k)
+					m.sfGlobal.Forget(buildSfKeyByName(database, k))
+					m.sfGlobal.Forget(buildSfKeyById(database, v.collID))
 				}
 			}
 		}


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/47216