### PR TITLE
fix: sync group_by_values when sorting equal scores

### DIFF
--- a/internal/core/src/segcore/reduce/Reduce.cpp
+++ b/internal/core/src/segcore/reduce/Reduce.cpp
@@ -216,6 +216,13 @@ ReduceHelper::SortEqualScoresOneNQ(size_t nq_begin,
                     search_result->element_level_
                         ? search_result->element_indices_[start + i]
                         : -1;
+                // Also save group_by_value if present (for group by search)
+                GroupByValueType temp_group_by_val;
+                bool has_group_by = search_result->group_by_values_.has_value();
+                if (has_group_by) {
+                    temp_group_by_val =
+                        search_result->group_by_values_.value()[start + i];
+                }
 
                 size_t curr = i;
                 while (indices[curr] != i) {
@@ -228,6 +235,11 @@ ReduceHelper::SortEqualScoresOneNQ(size_t nq_begin,
                         search_result->element_indices_[start + curr] =
                             search_result->element_indices_[start + next];
                     }
+                    if (has_group_by) {
+                        search_result->group_by_values_.value()[start + curr] =
+                            search_result->group_by_values_
+                                .value()[start + next];
+                    }
                     indices[curr] = curr;  // Mark as processed
                     curr = next;
                 }
@@ -237,6 +249,10 @@ ReduceHelper::SortEqualScoresOneNQ(size_t nq_begin,
                 if (search_result->element_level_) {
                     search_result->element_indices_[start + curr] =
                         temp_elem_idx;
+                }
+                if (has_group_by) {
+                    search_result->group_by_values_.value()[start + curr] =
+                        temp_group_by_val;
                 }
                 indices[curr] = curr;
             }


### PR DESCRIPTION
issue: #47225

When sorting search results with equal scores by primary key in SortEqualScoresOneNQ, the group_by_values array was not being moved along with other arrays (primary_keys, seg_offsets, etc.).

This caused a mismatch between output field values and group_by values in group by search results, where the same group would incorrectly show different group_by values.