### PR TITLE
fix: [2.6] Submit TriggerTypeStorageVersionUpgrade compaction task (#47220)

### DIFF
--- a/internal/datacoord/compaction_trigger_v2.go
+++ b/internal/datacoord/compaction_trigger_v2.go
@@ -416,7 +416,7 @@ func (m *CompactionTriggerManager) notify(ctx context.Context, eventType Compact
 					m.SubmitL0ViewToScheduler(ctx, outView)
 				case TriggerTypeClustering:
 					m.SubmitClusteringViewToScheduler(ctx, outView)
-				case TriggerTypeSingle, TriggerTypeSort:
+				case TriggerTypeSingle, TriggerTypeSort, TriggerTypeStorageVersionUpgrade:
 					m.SubmitSingleViewToScheduler(ctx, outView, eventType)
 				case TriggerTypeForceMerge:
 					m.SubmitForceMergeViewToScheduler(ctx, outView)


### PR DESCRIPTION
Cherry-pick from master
pr: #47220
Related to #46988

Previously `TriggerTypeStorageVersionUpgrade` compaction task were only generated but no submitted, this patch add it to switch cases fixing this problem