### PR TITLE
fix: restore disk capacity validation for index build

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -803,6 +803,8 @@ dataNode:
     updateChannelCheckpointRPCTimeout: 20 # timeout in seconds for UpdateChannelCheckpoint RPC call
     maxChannelCheckpointsPerPRC: 128 # The maximum number of channel checkpoints per UpdateChannelCheckpoint RPC.
     channelCheckpointUpdateTickInSeconds: 10 # The frequency, in seconds, at which the channel checkpoint updater executes updates.
+  index:
+    maxDiskUsagePercentage: 95 # Maximum disk usage percentage allowed for disk-intensive index building (DISKANN, etc.)
   import:
     concurrencyPerCPUCore: 4 # The execution concurrency unit for import/pre-import tasks per CPU core.
     maxImportFileSizeInGB: 16 # The maximum file size (in GB) for an import file, where an import file refers to either a Row-Based file or a set of Column-Based files.

--- a/internal/datanode/index/task_index.go
+++ b/internal/datanode/index/task_index.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/shirou/gopsutil/v3/disk"
@@ -45,6 +46,36 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/util/timerecord"
 )
 
+// committedDiskSpace tracks disk space reserved by concurrent index build tasks.
+// This prevents race conditions where multiple tasks pass disk checks but their
+// combined requirements exceed available space.
+var (
+	committedDiskSpace     uint64
+	committedDiskSpaceLock sync.Mutex
+)
+
+func addCommittedDiskSpace(size uint64) {
+	committedDiskSpaceLock.Lock()
+	defer committedDiskSpaceLock.Unlock()
+	committedDiskSpace += size
+}
+
+func subCommittedDiskSpace(size uint64) {
+	committedDiskSpaceLock.Lock()
+	defer committedDiskSpaceLock.Unlock()
+	if committedDiskSpace < size {
+		committedDiskSpace = 0
+	} else {
+		committedDiskSpace -= size
+	}
+}
+
+func getCommittedDiskSpace() uint64 {
+	committedDiskSpaceLock.Lock()
+	defer committedDiskSpaceLock.Unlock()
+	return committedDiskSpace
+}
+
 // IndexBuildTask is used to record the information of the index tasks.
 type indexBuildTask struct {
 	ident  string
@@ -60,7 +91,8 @@ type indexBuildTask struct {
 	queueDur       time.Duration
 	manager        *TaskManager
 
-	pluginContext *indexcgopb.StoragePluginContext
+	pluginContext     *indexcgopb.StoragePluginContext
+	reservedDiskSpace uint64 // disk space reserved for this task, released after PostExecute
 }
 
 func NewIndexBuildTask(ctx context.Context,
@@ -107,6 +139,7 @@ func (it *indexBuildTask) Reset() {
 	it.newIndexParams = nil
 	it.tr = nil
 	it.manager = nil
+	it.reservedDiskSpace = 0
 }
 
 // Ctx is the context of index tasks.
@@ -237,18 +270,31 @@ func (it *indexBuildTask) Execute(ctx context.Context) error {
 	indexType := it.newIndexParams[common.IndexTypeKey]
 	var fieldDataSize uint64
 	var err error
+	var executeSuccess bool
 
 	// Ignore the error here, this param will only be used for diskann and aisaq
 	fieldDataSize, _ = estimateFieldDataSize(it.req.GetDim(), it.req.GetNumRows(), it.req.GetField().GetDataType())
-	if vecindexmgr.GetVecIndexMgrInstance().IsDiskANN(indexType) {
-		// Check disk capacity before building disk-intensive index
-		if err := checkDiskCapacityForBuild(ctx, indexType, fieldDataSize); err != nil {
+	if vecindexmgr.GetVecIndexMgrInstance().IsDiskVecIndex(indexType) {
+		// Check disk capacity and reserve space before building disk-intensive index
+		reserved, err := checkDiskCapacityForBuild(ctx, indexType, fieldDataSize)
+		if err != nil {
 			log.Warn("disk capacity check failed for disk index build",
 				zap.String("indexType", indexType),
 				zap.Uint64("fieldDataSize", fieldDataSize),
 				zap.Error(err))
 			return err
 		}
+		it.reservedDiskSpace = reserved
+
+		// Release reserved space if Execute fails after this point
+		defer func() {
+			if !executeSuccess && it.reservedDiskSpace > 0 {
+				subCommittedDiskSpace(it.reservedDiskSpace)
+				log.Info("released reserved disk space due to execute failure",
+					zap.Uint64("released", it.reservedDiskSpace))
+				it.reservedDiskSpace = 0
+			}
+		}()
 
 		err = indexparams.SetDiskIndexBuildParams(it.newIndexParams, int64(fieldDataSize))
 		if err != nil {
@@ -346,6 +392,7 @@ func (it *indexBuildTask) Execute(ctx context.Context) error {
 	metrics.DataNodeKnowhereBuildIndexLatency.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10)).Observe(buildIndexLatency.Seconds())
 
 	log.Info("Successfully build index")
+	executeSuccess = true
 	return nil
 }
 
@@ -353,6 +400,16 @@ func (it *indexBuildTask) PostExecute(ctx context.Context) error {
 	log := log.Ctx(ctx).With(zap.String("clusterID", it.req.GetClusterID()), zap.Int64("buildID", it.req.GetBuildID()),
 		zap.Int64("collection", it.req.GetCollectionID()), zap.Int64("segmentID", it.req.GetSegmentID()),
 		zap.Int32("currentIndexVersion", it.req.GetCurrentIndexVersion()))
+
+	// Release reserved disk space when PostExecute completes (success or failure)
+	defer func() {
+		if it.reservedDiskSpace > 0 {
+			subCommittedDiskSpace(it.reservedDiskSpace)
+			log.Info("released reserved disk space after PostExecute",
+				zap.Uint64("released", it.reservedDiskSpace))
+			it.reservedDiskSpace = 0
+		}
+	}()
 
 	gcIndex := func() {
 		if err := it.index.Delete(); err != nil {
@@ -435,8 +492,9 @@ func (it *indexBuildTask) parseFieldMetaFromBinlog(ctx context.Context) error {
 }
 
 // checkDiskCapacityForBuild checks disk space for disk-intensive index build.
-// Returns error if projected usage (diskUsed + fieldDataSize * 3) exceeds threshold.
-func checkDiskCapacityForBuild(ctx context.Context, indexType string, fieldDataSize uint64) error {
+// Returns the reserved size if check passes, or error if projected usage exceeds threshold.
+// The caller must release the reserved space after task completes.
+func checkDiskCapacityForBuild(ctx context.Context, indexType string, fieldDataSize uint64) (uint64, error) {
 	log := log.Ctx(ctx)
 	localStoragePath := paramtable.Get().LocalStorageCfg.Path.GetValue()
 
@@ -444,7 +502,7 @@ func checkDiskCapacityForBuild(ctx context.Context, indexType string, fieldDataS
 	diskUsage, err := disk.Usage(localStoragePath)
 	if err != nil {
 		log.Warn("failed to get disk usage, skipping disk capacity check", zap.Error(err))
-		return nil
+		return 0, nil
 	}
 
 	// 2. Estimate index build disk cost (raw data + index files)
@@ -455,28 +513,35 @@ func checkDiskCapacityForBuild(ctx context.Context, indexType string, fieldDataS
 	maxUsageRatio := paramtable.Get().DataNodeCfg.IndexMaxDiskUsagePercentage.GetAsFloat()
 	maxAllowedUsage := uint64(float64(diskUsage.Total) * maxUsageRatio)
 
-	// 4. Check if space is sufficient
-	projectedUsage := diskUsage.Used + requiredSize
+	// 4. Check if space is sufficient (including already committed space from concurrent tasks)
+	committed := getCommittedDiskSpace()
+	projectedUsage := diskUsage.Used + committed + requiredSize
 	if projectedUsage > maxAllowedUsage {
 		log.Warn("insufficient disk space for index build",
 			zap.String("indexType", indexType),
 			zap.Uint64("diskUsed", diskUsage.Used),
+			zap.Uint64("committed", committed),
 			zap.Uint64("diskTotal", diskUsage.Total),
 			zap.Uint64("required", requiredSize),
 			zap.Uint64("projectedUsage", projectedUsage),
 			zap.Uint64("maxAllowed", maxAllowedUsage),
 			zap.Float64("maxUsageRatio", maxUsageRatio))
-		return fmt.Errorf("insufficient disk space for index build: projected usage %d bytes exceeds limit %d bytes (%.1f%% of %d total)",
+		return 0, fmt.Errorf("insufficient disk space for index build: projected usage %d bytes exceeds limit %d bytes (%.1f%% of %d total)",
 			projectedUsage, maxAllowedUsage, maxUsageRatio*100, diskUsage.Total)
 	}
 
-	log.Info("disk capacity check passed",
+	// 5. Reserve disk space
+	addCommittedDiskSpace(requiredSize)
+
+	log.Info("disk capacity check passed, space reserved",
 		zap.String("indexType", indexType),
 		zap.Uint64("diskUsed", diskUsage.Used),
-		zap.Uint64("required", requiredSize),
+		zap.Uint64("committed", committed),
+		zap.Uint64("reserved", requiredSize),
+		zap.Uint64("totalCommitted", getCommittedDiskSpace()),
 		zap.Uint64("maxAllowed", maxAllowedUsage))
 
-	return nil
+	return requiredSize, nil
 }
 
 // estimateIndexDiskCost estimates disk cost for index build.

--- a/internal/datanode/index/task_index.go
+++ b/internal/datanode/index/task_index.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/shirou/gopsutil/v3/disk"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
@@ -240,6 +241,15 @@ func (it *indexBuildTask) Execute(ctx context.Context) error {
 	// Ignore the error here, this param will only be used for diskann and aisaq
 	fieldDataSize, _ = estimateFieldDataSize(it.req.GetDim(), it.req.GetNumRows(), it.req.GetField().GetDataType())
 	if vecindexmgr.GetVecIndexMgrInstance().IsDiskANN(indexType) {
+		// Check disk capacity before building disk-intensive index
+		if err := checkDiskCapacityForBuild(ctx, indexType, fieldDataSize); err != nil {
+			log.Warn("disk capacity check failed for disk index build",
+				zap.String("indexType", indexType),
+				zap.Uint64("fieldDataSize", fieldDataSize),
+				zap.Error(err))
+			return err
+		}
+
 		err = indexparams.SetDiskIndexBuildParams(it.newIndexParams, int64(fieldDataSize))
 		if err != nil {
 			log.Warn("failed to fill disk index params", zap.Error(err))
@@ -422,4 +432,57 @@ func (it *indexBuildTask) parseFieldMetaFromBinlog(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// checkDiskCapacityForBuild checks disk space for disk-intensive index build.
+// Returns error if projected usage (diskUsed + fieldDataSize * 3) exceeds threshold.
+func checkDiskCapacityForBuild(ctx context.Context, indexType string, fieldDataSize uint64) error {
+	log := log.Ctx(ctx)
+	localStoragePath := paramtable.Get().LocalStorageCfg.Path.GetValue()
+
+	// 1. Get disk usage of the mounted filesystem
+	diskUsage, err := disk.Usage(localStoragePath)
+	if err != nil {
+		log.Warn("failed to get disk usage, skipping disk capacity check", zap.Error(err))
+		return nil
+	}
+
+	// 2. Estimate index build disk cost (raw data + index files)
+	indexDiskCost := estimateIndexDiskCost(fieldDataSize)
+	requiredSize := fieldDataSize + uint64(indexDiskCost)
+
+	// 3. Calculate threshold
+	maxUsageRatio := paramtable.Get().DataNodeCfg.IndexMaxDiskUsagePercentage.GetAsFloat()
+	maxAllowedUsage := uint64(float64(diskUsage.Total) * maxUsageRatio)
+
+	// 4. Check if space is sufficient
+	projectedUsage := diskUsage.Used + requiredSize
+	if projectedUsage > maxAllowedUsage {
+		log.Warn("insufficient disk space for index build",
+			zap.String("indexType", indexType),
+			zap.Uint64("diskUsed", diskUsage.Used),
+			zap.Uint64("diskTotal", diskUsage.Total),
+			zap.Uint64("required", requiredSize),
+			zap.Uint64("projectedUsage", projectedUsage),
+			zap.Uint64("maxAllowed", maxAllowedUsage),
+			zap.Float64("maxUsageRatio", maxUsageRatio))
+		return fmt.Errorf("insufficient disk space for index build: projected usage %d bytes exceeds limit %d bytes (%.1f%% of %d total)",
+			projectedUsage, maxAllowedUsage, maxUsageRatio*100, diskUsage.Total)
+	}
+
+	log.Info("disk capacity check passed",
+		zap.String("indexType", indexType),
+		zap.Uint64("diskUsed", diskUsage.Used),
+		zap.Uint64("required", requiredSize),
+		zap.Uint64("maxAllowed", maxAllowedUsage))
+
+	return nil
+}
+
+// estimateIndexDiskCost estimates disk cost for index build.
+// Uses 2x multiplier. TODO: use CGO for accurate estimation.
+const diskUsageRatioForBuild = 2.0
+
+func estimateIndexDiskCost(fieldDataSize uint64) int64 {
+	return int64(float64(fieldDataSize) * diskUsageRatioForBuild)
 }

--- a/internal/datanode/index/task_test.go
+++ b/internal/datanode/index/task_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/shirou/gopsutil/v3/disk"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
@@ -129,6 +130,45 @@ func (suite *IndexBuildTaskSuite) TestBuildMemoryIndex() {
 	suite.NoError(err)
 	err = t.PostExecute(context.Background())
 	suite.NoError(err)
+}
+
+func (suite *IndexBuildTaskSuite) TestEstimateIndexDiskCost() {
+	testCases := []struct {
+		fieldDataSize uint64
+		expected      int64
+	}{
+		{0, 0},
+		{1024 * 1024, 2 * 1024 * 1024}, // 1MB -> 2MB
+		{1024 * 1024 * 1024, 2 * 1024 * 1024 * 1024}, // 1GB -> 2GB
+	}
+
+	for _, tc := range testCases {
+		actual := estimateIndexDiskCost(tc.fieldDataSize)
+		suite.Equal(tc.expected, actual, "disk cost should be 2x field data size for input %d", tc.fieldDataSize)
+	}
+}
+
+func (suite *IndexBuildTaskSuite) TestCheckDiskCapacityForBuild() {
+	ctx := context.Background()
+
+	// Test with small data size - should pass
+	err := checkDiskCapacityForBuild(ctx, "DISKANN", 1024*1024) // 1MB
+	suite.Nil(err, "disk capacity check should succeed for small data size")
+
+	// Test with zero data size - should pass
+	err = checkDiskCapacityForBuild(ctx, "DISKANN", 0)
+	suite.Nil(err, "disk capacity check should succeed for zero data size")
+}
+
+func (suite *IndexBuildTaskSuite) TestDiskUsage() {
+	localStoragePath := paramtable.Get().LocalStorageCfg.Path.GetValue()
+
+	// Test disk.Usage returns valid data
+	diskUsage, err := disk.Usage(localStoragePath)
+	suite.NoError(err, "disk.Usage should succeed")
+	suite.NotNil(diskUsage)
+	suite.Greater(diskUsage.Total, uint64(0), "disk total should be positive")
+	suite.LessOrEqual(diskUsage.Used, diskUsage.Total, "disk used should not exceed total")
 }
 
 func TestIndexBuildTask(t *testing.T) {

--- a/internal/datanode/index/task_test.go
+++ b/internal/datanode/index/task_test.go
@@ -151,13 +151,94 @@ func (suite *IndexBuildTaskSuite) TestEstimateIndexDiskCost() {
 func (suite *IndexBuildTaskSuite) TestCheckDiskCapacityForBuild() {
 	ctx := context.Background()
 
-	// Test with small data size - should pass
-	err := checkDiskCapacityForBuild(ctx, "DISKANN", 1024*1024) // 1MB
+	// Reset committed disk space before test
+	committedDiskSpaceLock.Lock()
+	committedDiskSpace = 0
+	committedDiskSpaceLock.Unlock()
+
+	// Test with small data size - should pass and reserve space
+	reserved, err := checkDiskCapacityForBuild(ctx, "DISKANN", 1024*1024) // 1MB
 	suite.Nil(err, "disk capacity check should succeed for small data size")
+	suite.Greater(reserved, uint64(0), "should reserve space when check passes")
+
+	// Verify space was reserved
+	committed := getCommittedDiskSpace()
+	suite.Equal(reserved, committed, "committed space should equal reserved space")
+
+	// Release the reserved space
+	subCommittedDiskSpace(reserved)
 
 	// Test with zero data size - should pass
-	err = checkDiskCapacityForBuild(ctx, "DISKANN", 0)
+	reserved, err = checkDiskCapacityForBuild(ctx, "DISKANN", 0)
 	suite.Nil(err, "disk capacity check should succeed for zero data size")
+	suite.Equal(uint64(0), reserved, "should reserve 0 for zero data size")
+}
+
+func (suite *IndexBuildTaskSuite) TestCommittedDiskSpace() {
+	// Reset committed disk space before test
+	committedDiskSpaceLock.Lock()
+	committedDiskSpace = 0
+	committedDiskSpaceLock.Unlock()
+
+	// Test add
+	addCommittedDiskSpace(1000)
+	suite.Equal(uint64(1000), getCommittedDiskSpace())
+
+	addCommittedDiskSpace(500)
+	suite.Equal(uint64(1500), getCommittedDiskSpace())
+
+	// Test sub
+	subCommittedDiskSpace(500)
+	suite.Equal(uint64(1000), getCommittedDiskSpace())
+
+	// Test sub with underflow protection
+	subCommittedDiskSpace(2000)
+	suite.Equal(uint64(0), getCommittedDiskSpace(), "should not go negative")
+}
+
+func (suite *IndexBuildTaskSuite) TestConcurrentDiskReservation() {
+	ctx := context.Background()
+
+	// Reset committed disk space before test
+	committedDiskSpaceLock.Lock()
+	committedDiskSpace = 0
+	committedDiskSpaceLock.Unlock()
+
+	// Get disk usage to calculate a size that would fail if not considering committed space
+	localStoragePath := paramtable.Get().LocalStorageCfg.Path.GetValue()
+	diskUsage, err := disk.Usage(localStoragePath)
+	suite.NoError(err)
+
+	maxUsageRatio := paramtable.Get().DataNodeCfg.IndexMaxDiskUsagePercentage.GetAsFloat()
+	maxAllowedUsage := uint64(float64(diskUsage.Total) * maxUsageRatio)
+	availableSpace := maxAllowedUsage - diskUsage.Used
+
+	// If available space is less than 100MB, skip this test
+	if availableSpace < 100*1024*1024 {
+		suite.T().Skip("not enough disk space for concurrent reservation test")
+	}
+
+	// Request half of available space
+	halfAvailable := availableSpace / 2
+
+	// First reservation should succeed
+	reserved1, err := checkDiskCapacityForBuild(ctx, "DISKANN", halfAvailable/3) // /3 because requiredSize = fieldDataSize * 3
+	suite.Nil(err, "first reservation should succeed")
+	suite.Greater(reserved1, uint64(0))
+
+	// Second reservation with same size should also succeed (still within limits)
+	reserved2, err := checkDiskCapacityForBuild(ctx, "DISKANN", halfAvailable/3)
+	suite.Nil(err, "second reservation should succeed")
+	suite.Greater(reserved2, uint64(0))
+
+	// Verify total committed space
+	totalCommitted := getCommittedDiskSpace()
+	suite.Equal(reserved1+reserved2, totalCommitted)
+
+	// Cleanup
+	subCommittedDiskSpace(reserved1)
+	subCommittedDiskSpace(reserved2)
+	suite.Equal(uint64(0), getCommittedDiskSpace())
 }
 
 func (suite *IndexBuildTaskSuite) TestDiskUsage() {

--- a/internal/util/indexcgowrapper/helper.go
+++ b/internal/util/indexcgowrapper/helper.go
@@ -94,3 +94,15 @@ func GetLocalUsedSize(path string) (int64, error) {
 
 	return availableSize, nil
 }
+
+// IndexBuildResource represents estimated resource for index building.
+type IndexBuildResource struct {
+	MemoryCost int64
+	DiskCost   int64
+}
+
+// EstimateIndexBuildResource estimates resource required for building an index.
+// TODO: Implement CGO call to knowhere for accurate estimation.
+func EstimateIndexBuildResource(indexType string, dim int64, numRows int64, fieldDataSize uint64) (*IndexBuildResource, error) {
+	return nil, errors.New("EstimateIndexBuildResource not yet implemented")
+}

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -6253,6 +6253,9 @@ type dataNodeConfig struct {
 	MaxChannelCheckpointsPerRPC          ParamItem `refreshable:"true"`
 	ChannelCheckpointUpdateTickInSeconds ParamItem `refreshable:"true"`
 
+	// index services config
+	IndexMaxDiskUsagePercentage ParamItem `refreshable:"true"`
+
 	// import
 	ImportConcurrencyPerCPUCore ParamItem `refreshable:"true"`
 	MaxImportFileSizeInGB       ParamItem `refreshable:"true"`
@@ -6549,6 +6552,18 @@ if this parameter <= 0, will set it as 10`,
 		Export:       true,
 	}
 	p.ChannelCheckpointUpdateTickInSeconds.Init(base.mgr)
+
+	p.IndexMaxDiskUsagePercentage = ParamItem{
+		Key:          "dataNode.index.maxDiskUsagePercentage",
+		Version:      "2.6.0",
+		DefaultValue: "95",
+		Doc:          "Maximum disk usage percentage allowed for disk-intensive index building (DISKANN, etc.)",
+		Export:       true,
+		Formatter: func(v string) string {
+			return fmt.Sprintf("%f", getAsFloat(v)/100)
+		},
+	}
+	p.IndexMaxDiskUsagePercentage.Init(base.mgr)
 
 	p.ImportConcurrencyPerCPUCore = ParamItem{
 		Key:          "dataNode.import.concurrencyPerCPUCore",


### PR DESCRIPTION
Add disk space check before building disk-intensive indexes (DISKANN, etc.) to prevent build failures due to insufficient disk space.

- Add checkDiskCapacityForBuild() using disk.Usage for accurate disk usage
- Add IndexMaxDiskUsagePercentage config parameter (default 95%)
- Use 2x multiplier for disk cost estimation (fieldDataSize * 3 total)
- Add EstimateIndexBuildResource stub for future CGO-based estimation
- Add TestDiskUsage test case

issue: #46996