### PR TITLE
feat: implement MOL data type storage and query support in C++ layer

### DIFF
--- a/internal/core/src/common/Array.h
+++ b/internal/core/src/common/Array.h
@@ -235,8 +235,9 @@ class Array {
             }
             case DataType::STRING:
             case DataType::VARCHAR:
-            //treat Geometry as wkb string
-            case DataType::GEOMETRY: {
+            //treat Geometry and MOL as string
+            case DataType::GEOMETRY:
+            case DataType::MOL: {
                 for (int i = 0; i < length_; ++i) {
                     if (get_data<std::string_view>(i) !=
                         arr.get_data<std::string_view>(i)) {
@@ -366,6 +367,15 @@ class Array {
                 }
                 break;
             }
+            case DataType::MOL: {
+                data_array.mutable_mol_data()->mutable_data()->Reserve(length_);
+                for (int j = 0; j < length_; ++j) {
+                    auto element = get_data<std::string_view>(j);
+                    data_array.mutable_mol_data()->add_data(element.data(),
+                                                            element.size());
+                }
+                break;
+            }
             default: {
                 // empty array
             }
@@ -460,7 +470,8 @@ class Array {
             }
             case DataType::VARCHAR:
             case DataType::STRING:
-            case DataType::GEOMETRY: {
+            case DataType::GEOMETRY:
+            case DataType::MOL: {
                 for (int i = 0; i < length_; i++) {
                     auto val = get_data<std::string>(i);
                     if (val != arr2.array(i).string_val()) {
@@ -631,6 +642,15 @@ class ArrayView {
                 }
                 break;
             }
+            case DataType::MOL: {
+                data_array.mutable_mol_data()->mutable_data()->Reserve(length_);
+                for (int j = 0; j < length_; ++j) {
+                    auto element = get_data<std::string_view>(j);
+                    data_array.mutable_mol_data()->add_data(element.data(),
+                                                            element.size());
+                }
+                break;
+            }
             default: {
                 // empty array
             }
@@ -733,7 +753,8 @@ class ArrayView {
             }
             case DataType::VARCHAR:
             case DataType::STRING:
-            case DataType::GEOMETRY: {
+            case DataType::GEOMETRY:
+            case DataType::MOL: {
                 for (int i = 0; i < length_; i++) {
                     auto val = get_data<std::string>(i);
                     if (val != arr2.array(i).string_val()) {

--- a/internal/core/src/common/Chunk.h
+++ b/internal/core/src/common/Chunk.h
@@ -37,6 +37,7 @@
 namespace milvus {
 constexpr uint64_t MMAP_STRING_PADDING = 1;
 constexpr uint64_t MMAP_GEOMETRY_PADDING = 1;
+constexpr uint64_t MMAP_MOL_PADDING = 1;
 constexpr uint64_t MMAP_ARRAY_PADDING = 1;
 
 // Shared mmap region manager for group chunks
@@ -319,6 +320,7 @@ class StringChunk : public Chunk {
 
 using JSONChunk = StringChunk;
 using GeometryChunk = StringChunk;
+using MolChunk = StringChunk;
 
 // An ArrayChunk is a class that represents a collection of arrays stored in a contiguous memory block.
 // It is initialized with the number of rows, a pointer to the data, the size of the data, the element type,

--- a/internal/core/src/common/ChunkWriter.cpp
+++ b/internal/core/src/common/ChunkWriter.cpp
@@ -247,6 +247,71 @@ GeometryChunkWriter::write_to_target(
 }
 
 std::pair<size_t, size_t>
+MolChunkWriter::calculate_size(const arrow::ArrayVector& array_vec) {
+    row_nums_ = 0;
+    size_t size = 0;
+    for (const auto& data : array_vec) {
+        auto array = std::dynamic_pointer_cast<arrow::BinaryArray>(data);
+        for (int64_t i = 0; i < array->length(); ++i) {
+            auto str = array->GetView(i);
+            size += str.size();
+        }
+        row_nums_ += array->length();
+    }
+    if (nullable_) {
+        size += (row_nums_ + 7) / 8;
+    }
+    size += sizeof(uint32_t) * (row_nums_ + 1) + MMAP_MOL_PADDING;
+    return {size, row_nums_};
+}
+
+void
+MolChunkWriter::write_to_target(const arrow::ArrayVector& array_vec,
+                                const std::shared_ptr<ChunkTarget>& target) {
+    std::vector<std::string_view> mol_strs;
+    std::vector<std::tuple<const uint8_t*, int64_t, int64_t>> null_bitmaps;
+    mol_strs.reserve(row_nums_);
+
+    for (const auto& data : array_vec) {
+        auto array = std::dynamic_pointer_cast<arrow::BinaryArray>(data);
+        for (int64_t i = 0; i < array->length(); ++i) {
+            auto str = array->GetView(i);
+            mol_strs.emplace_back(str);
+        }
+        if (nullable_) {
+            null_bitmaps.emplace_back(
+                data->null_bitmap_data(), data->length(), data->offset());
+        }
+    }
+
+    // chunk layout: null bitmap, offsets, mol strings, padding
+    write_null_bit_maps(null_bitmaps, target);
+
+    const int offset_num = row_nums_ + 1;
+    const uint32_t null_bitmap_bytes =
+        nullable_ ? static_cast<uint32_t>((row_nums_ + 7) / 8) : 0;
+    uint32_t offset_start_pos =
+        null_bitmap_bytes +
+        static_cast<uint32_t>(sizeof(uint32_t) * offset_num);
+    std::vector<uint32_t> offsets;
+    offsets.reserve(offset_num);
+    for (const auto& str : mol_strs) {
+        offsets.push_back(offset_start_pos);
+        offset_start_pos += str.size();
+    }
+    offsets.push_back(offset_start_pos);
+
+    target->write(offsets.data(), offsets.size() * sizeof(uint32_t));
+
+    for (const auto& str : mol_strs) {
+        target->write(str.data(), str.size());
+    }
+
+    char padding[MMAP_MOL_PADDING];
+    target->write(padding, MMAP_MOL_PADDING);
+}
+
+std::pair<size_t, size_t>
 ArrayChunkWriter::calculate_size(const arrow::ArrayVector& array_vec) {
     row_nums_ = 0;
     size_t size = 0;
@@ -606,6 +671,9 @@ create_chunk_writer(const FieldMeta& field_meta) {
         case milvus::DataType::GEOMETRY: {
             return std::make_shared<GeometryChunkWriter>(nullable);
         }
+        case milvus::DataType::MOL: {
+            return std::make_shared<MolChunkWriter>(nullable);
+        }
         case milvus::DataType::ARRAY:
             return std::make_shared<ArrayChunkWriter>(
                 field_meta.get_element_type(), nullable);
@@ -745,6 +813,10 @@ make_chunk(const FieldMeta& field_meta,
                 row_nums, data, size, nullable, chunk_mmap_guard);
         case milvus::DataType::GEOMETRY: {
             return std::make_unique<GeometryChunk>(
+                row_nums, data, size, nullable, chunk_mmap_guard);
+        }
+        case milvus::DataType::MOL: {
+            return std::make_unique<MolChunk>(
                 row_nums, data, size, nullable, chunk_mmap_guard);
         }
         case milvus::DataType::ARRAY:

--- a/internal/core/src/common/ChunkWriter.h
+++ b/internal/core/src/common/ChunkWriter.h
@@ -260,6 +260,18 @@ class GeometryChunkWriter : public ChunkWriterBase {
                     const std::shared_ptr<ChunkTarget>& target) override;
 };
 
+class MolChunkWriter : public ChunkWriterBase {
+ public:
+    using ChunkWriterBase::ChunkWriterBase;
+
+    std::pair<size_t, size_t>
+    calculate_size(const arrow::ArrayVector& array_vec) override;
+
+    void
+    write_to_target(const arrow::ArrayVector& array_vec,
+                    const std::shared_ptr<ChunkTarget>& target) override;
+};
+
 class ArrayChunkWriter : public ChunkWriterBase {
  public:
     ArrayChunkWriter(const milvus::DataType element_type, bool nullable)

--- a/internal/core/src/common/FieldData.cpp
+++ b/internal/core/src/common/FieldData.cpp
@@ -279,6 +279,23 @@ FieldDataImpl<Type, is_type_entire_row>::FillFieldData(
             }
             return FillFieldData(values.data(), element_count);
         }
+        case DataType::MOL: {
+            AssertInfo(array->type()->id() == arrow::Type::type::BINARY,
+                       "inconsistent data type");
+            auto mol_array =
+                std::dynamic_pointer_cast<arrow::BinaryArray>(array);
+            std::vector<std::string> values(element_count);
+            for (size_t index = 0; index < element_count; ++index) {
+                values[index] = mol_array->GetString(index);
+            }
+            if (nullable_) {
+                return FillFieldData(values.data(),
+                                     array->null_bitmap_data(),
+                                     element_count,
+                                     array->offset());
+            }
+            return FillFieldData(values.data(), element_count);
+        }
         case DataType::ARRAY: {
             auto array_array =
                 std::dynamic_pointer_cast<arrow::BinaryArray>(array);
@@ -560,6 +577,16 @@ FieldDataImpl<Type, is_type_entire_row>::FillFieldData(
             return FillFieldData(
                 values.data(), valid_data_ptr.get(), element_count, 0);
         }
+        case DataType::MOL: {
+            FixedVector<std::string> values(element_count);
+            if (default_value.has_value()) {
+                std::fill(
+                    values.begin(), values.end(), default_value->string_data());
+                return FillFieldData(values.data(), nullptr, element_count, 0);
+            }
+            return FillFieldData(
+                values.data(), valid_data_ptr.get(), element_count, 0);
+        }
         case DataType::ARRAY: {
             // todo: add array default_value
             FixedVector<Array> values(element_count);
@@ -721,6 +748,9 @@ InitScalarFieldData(const DataType& type, bool nullable, int64_t cap_rows) {
         case DataType::JSON:
             return std::make_shared<FieldData<Json>>(type, nullable, cap_rows);
         case DataType::GEOMETRY:
+            return std::make_shared<FieldData<std::string>>(
+                type, nullable, cap_rows);
+        case DataType::MOL:
             return std::make_shared<FieldData<std::string>>(
                 type, nullable, cap_rows);
         default:

--- a/internal/core/src/common/FieldData.h
+++ b/internal/core/src/common/FieldData.h
@@ -83,6 +83,17 @@ class FieldData<Geometry> : public FieldDataGeometryImpl {
 };
 
 template <>
+class FieldData<Mol> : public FieldDataMolImpl {
+ public:
+    static_assert(IsScalar<Mol>);
+    explicit FieldData(DataType data_type,
+                       bool nullable,
+                       int64_t buffered_num_rows = 0)
+        : FieldDataMolImpl(data_type, nullable, buffered_num_rows) {
+    }
+};
+
+template <>
 class FieldData<Array> : public FieldDataArrayImpl {
  public:
     static_assert(IsScalar<Array> || std::is_same_v<std::string, PkType>);

--- a/internal/core/src/common/FieldDataInterface.h
+++ b/internal/core/src/common/FieldDataInterface.h
@@ -694,6 +694,75 @@ class FieldDataGeometryImpl : public FieldDataImpl<std::string, true> {
     }
 };
 
+class FieldDataMolImpl : public FieldDataImpl<std::string, true> {
+ public:
+    explicit FieldDataMolImpl(DataType data_type,
+                              bool nullable,
+                              int64_t total_num_rows = 0)
+        : FieldDataImpl<std::string, true>(
+              1, data_type, nullable, total_num_rows) {
+    }
+
+    int64_t
+    DataSize() const override {
+        int64_t data_size = 0;
+        for (size_t offset = 0; offset < length(); ++offset) {
+            data_size += data_[offset].size();
+        }
+        return data_size;
+    }
+
+    int64_t
+    DataSize(ssize_t offset) const override {
+        AssertInfo(offset < get_num_rows(),
+                   "field data subscript out of range");
+        AssertInfo(offset < length(),
+                   "subscript position don't has valid value");
+        return data_[offset].size();
+    }
+
+    void
+    FillFieldData(const std::shared_ptr<arrow::Array> array) override {
+        AssertInfo(array->type()->id() == arrow::Type::type::BINARY,
+                   "inconsistent data type, expected: {}, got: {}",
+                   "BINARY",
+                   array->type()->ToString());
+        auto mol_array = std::dynamic_pointer_cast<arrow::BinaryArray>(array);
+        FillFieldData(mol_array);
+    }
+
+    void
+    FillFieldData(const std::shared_ptr<arrow::BinaryArray>& array) override {
+        auto n = array->length();
+        if (n == 0) {
+            return;
+        }
+        null_count_ = array->null_count();
+
+        std::lock_guard lck(tell_mutex_);
+        if (length_ + n > get_num_rows()) {
+            resize_field_data(length_ + n);
+        }
+        for (int64_t i = 0; i < n; ++i) {
+            if (array->IsNull(i))
+                continue;
+            data_[length_ + i] = array->GetString(i);
+        }
+        if (IsNullable()) {
+            auto valid_data = array->null_bitmap_data();
+            if (valid_data != nullptr) {
+                bitset::detail::ElementWiseBitsetPolicy<uint8_t>::op_copy(
+                    valid_data,
+                    array->offset(),
+                    valid_data_.data(),
+                    length_,
+                    n);
+            }
+        }
+        length_ += n;
+    }
+};
+
 class FieldDataJsonImpl : public FieldDataImpl<Json, true> {
  public:
     explicit FieldDataJsonImpl(DataType data_type,

--- a/internal/core/src/common/Mol.h
+++ b/internal/core/src/common/Mol.h
@@ -1,0 +1,17 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+#pragma once
+
+namespace milvus {
+
+class Mol {};
+
+}  // namespace milvus

--- a/internal/core/src/common/MolChunkWriterTest.cpp
+++ b/internal/core/src/common/MolChunkWriterTest.cpp
@@ -1,0 +1,235 @@
+// Copyright (C) 2019-2025 Zilliz. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License.
+
+#include <gtest/gtest.h>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "arrow/api.h"
+#include "arrow/array/array_binary.h"
+#include "arrow/array/builder_binary.h"
+
+#include "common/Chunk.h"
+#include "common/ChunkWriter.h"
+#include "common/FieldMeta.h"
+#include "common/Types.h"
+
+using milvus::create_chunk;
+using milvus::DataType;
+using milvus::FieldId;
+using milvus::FieldMeta;
+using milvus::FieldName;
+using milvus::MolChunk;
+
+namespace {
+
+std::shared_ptr<arrow::BinaryArray>
+BuildMolBinaryArray(const std::vector<std::optional<std::string>>& values) {
+    arrow::BinaryBuilder builder;
+    for (const auto& v : values) {
+        if (v.has_value()) {
+            auto st =
+                builder.Append(v->data(), static_cast<int32_t>(v->size()));
+            EXPECT_TRUE(st.ok());
+        } else {
+            auto st = builder.AppendNull();
+            EXPECT_TRUE(st.ok());
+        }
+    }
+    std::shared_ptr<arrow::Array> arr;
+    auto st = builder.Finish(&arr);
+    EXPECT_TRUE(st.ok());
+    return std::static_pointer_cast<arrow::BinaryArray>(arr);
+}
+
+FieldMeta
+MakeMolFieldMeta(bool nullable) {
+    return FieldMeta(
+        FieldName("mol"), FieldId(1), DataType::MOL, nullable, std::nullopt);
+}
+
+}  // namespace
+
+TEST(MolChunkWriterTest, NoNullsMultiBatches) {
+    // Prepare two batches of MOL data (SMILES strings stored as binary)
+    std::vector<std::optional<std::string>> b1 = {
+        std::string("C"),
+        std::string("CC"),
+        std::string("CCO"),
+        std::string("c1ccccc1"),
+        std::string("CC(=O)O"),
+    };
+    std::vector<std::optional<std::string>> b2 = {
+        std::string("CCN"),
+        std::string("CCOCC"),
+        std::string("CC(C)C"),
+    };
+
+    auto a1 = BuildMolBinaryArray(b1);
+    auto a2 = BuildMolBinaryArray(b2);
+
+    arrow::ArrayVector vec{a1, a2};
+
+    auto field_meta = MakeMolFieldMeta(/*nullable=*/false);
+    auto chunk_up = create_chunk(field_meta, vec);
+
+    auto* chunk = dynamic_cast<MolChunk*>(chunk_up.get());
+    ASSERT_NE(chunk, nullptr);
+
+    // Verify rows and content
+    int64_t total_rows = static_cast<int64_t>(b1.size() + b2.size());
+    EXPECT_EQ(chunk->RowNums(), total_rows);
+
+    for (int64_t i = 0; i < static_cast<int64_t>(b1.size()); ++i) {
+        auto sv = (*chunk)[static_cast<int>(i)];
+        ASSERT_TRUE(chunk->isValid(static_cast<int>(i)));
+        EXPECT_EQ(sv, b1[static_cast<size_t>(i)].value());
+    }
+    for (int64_t i = 0; i < static_cast<int64_t>(b2.size()); ++i) {
+        auto idx = static_cast<int>(b1.size() + i);
+        auto sv = (*chunk)[idx];
+        ASSERT_TRUE(chunk->isValid(idx));
+        EXPECT_EQ(sv, b2[static_cast<size_t>(i)].value());
+    }
+}
+
+TEST(MolChunkWriterTest, WithNullsMergedBitmap) {
+    // Prepare batches with nulls
+    std::vector<std::optional<std::string>> b1 = {
+        std::nullopt,
+        std::string("C"),
+        std::nullopt,
+        std::string("CCO"),
+        std::string("c1ccccc1"),
+    };
+    std::vector<std::optional<std::string>> b2 = {
+        std::string("CC(=O)O"),
+        std::nullopt,
+        std::string("CCN"),
+        std::string(""),
+    };
+
+    auto a1 = BuildMolBinaryArray(b1);
+    auto a2 = BuildMolBinaryArray(b2);
+
+    arrow::ArrayVector vec{a1, a2};
+
+    auto field_meta = MakeMolFieldMeta(/*nullable=*/true);
+    auto chunk_up = create_chunk(field_meta, vec);
+
+    auto* chunk = dynamic_cast<MolChunk*>(chunk_up.get());
+    ASSERT_NE(chunk, nullptr);
+
+    // Verify validity and content for non-null entries only
+    std::vector<std::optional<std::string>> all;
+    all.reserve(b1.size() + b2.size());
+    all.insert(all.end(), b1.begin(), b1.end());
+    all.insert(all.end(), b2.begin(), b2.end());
+
+    for (int i = 0; i < static_cast<int>(all.size()); ++i) {
+        bool expect_valid = all[static_cast<size_t>(i)].has_value();
+        EXPECT_EQ(chunk->isValid(i), expect_valid);
+        if (expect_valid) {
+            EXPECT_EQ((*chunk)[i], all[static_cast<size_t>(i)].value());
+        }
+    }
+}
+
+TEST(MolChunkWriterTest, EmptyBatch) {
+    // Test with an empty array
+    std::vector<std::optional<std::string>> empty_batch;
+    auto a1 = BuildMolBinaryArray(empty_batch);
+
+    arrow::ArrayVector vec{a1};
+
+    auto field_meta = MakeMolFieldMeta(/*nullable=*/false);
+    auto chunk_up = create_chunk(field_meta, vec);
+
+    auto* chunk = dynamic_cast<MolChunk*>(chunk_up.get());
+    ASSERT_NE(chunk, nullptr);
+    EXPECT_EQ(chunk->RowNums(), 0);
+}
+
+TEST(MolChunkWriterTest, LargeBatch) {
+    // Test with a large batch of MOL data
+    static const std::vector<std::string> smiles_list = {
+        "C",
+        "CC",
+        "CCC",
+        "CCO",
+        "CCCO",
+        "c1ccccc1",
+        "CC(=O)O",
+        "CCN",
+        "CCOCC",
+        "CC(C)C",
+    };
+
+    std::vector<std::optional<std::string>> batch;
+    for (int i = 0; i < 1000; ++i) {
+        batch.emplace_back(smiles_list[i % smiles_list.size()]);
+    }
+
+    auto arr = BuildMolBinaryArray(batch);
+    arrow::ArrayVector vec{arr};
+
+    auto field_meta = MakeMolFieldMeta(/*nullable=*/false);
+    auto chunk_up = create_chunk(field_meta, vec);
+
+    auto* chunk = dynamic_cast<MolChunk*>(chunk_up.get());
+    ASSERT_NE(chunk, nullptr);
+    EXPECT_EQ(chunk->RowNums(), 1000);
+
+    for (int i = 0; i < 1000; ++i) {
+        auto sv = (*chunk)[i];
+        EXPECT_EQ(sv, smiles_list[i % smiles_list.size()]);
+    }
+}
+
+TEST(MolChunkWriterTest, SingleRow) {
+    // Test with a single row
+    std::vector<std::optional<std::string>> batch = {
+        std::string("c1ccc(O)cc1"),  // Phenol
+    };
+
+    auto arr = BuildMolBinaryArray(batch);
+    arrow::ArrayVector vec{arr};
+
+    auto field_meta = MakeMolFieldMeta(/*nullable=*/false);
+    auto chunk_up = create_chunk(field_meta, vec);
+
+    auto* chunk = dynamic_cast<MolChunk*>(chunk_up.get());
+    ASSERT_NE(chunk, nullptr);
+    EXPECT_EQ(chunk->RowNums(), 1);
+    EXPECT_EQ((*chunk)[0], "c1ccc(O)cc1");
+}
+
+TEST(MolChunkWriterTest, NullableSingleNull) {
+    // Test with all nulls
+    std::vector<std::optional<std::string>> batch = {
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
+    };
+
+    auto arr = BuildMolBinaryArray(batch);
+    arrow::ArrayVector vec{arr};
+
+    auto field_meta = MakeMolFieldMeta(/*nullable=*/true);
+    auto chunk_up = create_chunk(field_meta, vec);
+
+    auto* chunk = dynamic_cast<MolChunk*>(chunk_up.get());
+    ASSERT_NE(chunk, nullptr);
+    EXPECT_EQ(chunk->RowNums(), 3);
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_FALSE(chunk->isValid(i));
+    }
+}

--- a/internal/core/src/common/TypeTraits.h
+++ b/internal/core/src/common/TypeTraits.h
@@ -35,8 +35,9 @@ template <typename T>
 constexpr bool IsScalar =
     std::is_fundamental_v<T> || std::is_same_v<T, std::string> ||
     std::is_same_v<T, Json> || std::is_same_v<T, Geometry> ||
-    std::is_same_v<T, std::string_view> || std::is_same_v<T, Array> ||
-    std::is_same_v<T, ArrayView> || std::is_same_v<T, proto::plan::Array>;
+    std::is_same_v<T, Mol> || std::is_same_v<T, std::string_view> ||
+    std::is_same_v<T, Array> || std::is_same_v<T, ArrayView> ||
+    std::is_same_v<T, proto::plan::Array>;
 
 template <typename T>
 constexpr bool IsSparse =

--- a/internal/core/src/common/Types.h
+++ b/internal/core/src/common/Types.h
@@ -48,6 +48,7 @@
 #include "pb/schema.pb.h"
 #include "pb/segcore.pb.h"
 #include "type_c.h"
+#include "Mol.h"
 
 namespace milvus {
 
@@ -83,6 +84,7 @@ enum class DataType {
     GEOMETRY = 24,
     TEXT = 25,
     TIMESTAMPTZ = 26,  // Timestamp with timezone, stored as int64
+    MOL = 27,
 
     // Some special Data type, start from after 50
     // just for internal use now, may sync proto in future
@@ -206,6 +208,8 @@ ToProtoDataType(DataType data_type) {
             return proto::schema::DataType::ArrayOfVector;
         case DataType::GEOMETRY:
             return proto::schema::DataType::Geometry;
+        case DataType::MOL:
+            return proto::schema::DataType::Mol;
 
         // Internal-only or unsupported mappings
         case DataType::ROW:
@@ -245,6 +249,8 @@ GetArrowDataType(DataType data_type, int dim = 1) {
         case DataType::JSON:
             return arrow::binary();
         case DataType::GEOMETRY:
+            return arrow::binary();
+        case DataType::MOL:
             return arrow::binary();
         case DataType::VECTOR_FLOAT:
             return arrow::fixed_size_binary(dim * 4);
@@ -337,6 +343,8 @@ GetDataTypeName(DataType data_type) {
             return "text";
         case DataType::GEOMETRY:
             return "geometry";
+        case DataType::MOL:
+            return "mol";
         case DataType::VECTOR_FLOAT:
             return "vector_float";
         case DataType::VECTOR_BINARY:
@@ -437,6 +445,11 @@ IsGeometryDataType(DataType data_type) {
 }
 
 inline bool
+IsMolDataType(DataType data_type) {
+    return data_type == DataType::MOL;
+}
+
+inline bool
 IsArrayDataType(DataType data_type) {
     return data_type == DataType::ARRAY || data_type == DataType::VECTOR_ARRAY;
 }
@@ -444,7 +457,7 @@ IsArrayDataType(DataType data_type) {
 inline bool
 IsBinaryDataType(DataType data_type) {
     return IsJsonDataType(data_type) || IsArrayDataType(data_type) ||
-           IsGeometryDataType(data_type);
+           IsGeometryDataType(data_type) || IsMolDataType(data_type);
 }
 
 inline bool
@@ -944,6 +957,9 @@ struct fmt::formatter<milvus::DataType> : formatter<string_view> {
                 break;
             case milvus::DataType::GEOMETRY:
                 name = "GEOMETRY";
+                break;
+            case milvus::DataType::MOL:
+                name = "MOL";
                 break;
             case milvus::DataType::ROW:
                 name = "ROW";

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -1645,7 +1645,8 @@ class SegmentExpr : public Expr {
                     case DataType::VARCHAR: {
                         return ProcessIndexChunksForValid<std::string>();
                     }
-                    case DataType::GEOMETRY: {
+                    case DataType::GEOMETRY:
+                    case DataType::MOL: {
                         return ProcessIndexChunksForValid<std::string>();
                     }
                     default:

--- a/internal/core/src/exec/expression/NullExpr.cpp
+++ b/internal/core/src/exec/expression/NullExpr.cpp
@@ -110,6 +110,17 @@ PhyNullExpr::Eval(EvalCtx& context, VectorPtr& result) {
             }
             break;
         }
+        case DataType::MOL: {
+            if (segment_->type() == SegmentType::Growing &&
+                !storage::MmapManager::GetInstance()
+                     .GetMmapConfig()
+                     .growing_enable_mmap) {
+                result = ExecVisitorImpl<std::string>(input);
+            } else {
+                result = ExecVisitorImpl<std::string_view>(input);
+            }
+            break;
+        }
         default:
             ThrowInfo(DataTypeInvalid,
                       "unsupported data type: {}",

--- a/internal/core/src/mmap/ChunkedColumnInterface.h
+++ b/internal/core/src/mmap/ChunkedColumnInterface.h
@@ -254,7 +254,8 @@ class ChunkedColumnInterface {
     IsChunkedVariableColumnDataType(DataType data_type) {
         return data_type == DataType::STRING ||
                data_type == DataType::VARCHAR || data_type == DataType::TEXT ||
-               data_type == DataType::JSON || data_type == DataType::GEOMETRY;
+               data_type == DataType::JSON || data_type == DataType::GEOMETRY ||
+               data_type == DataType::MOL;
     }
 
     static bool

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -1680,7 +1680,8 @@ ChunkedSegmentSealedImpl::bulk_subscript(milvus::OpContext* op_ctx,
                                           static_cast<Json*>(data));
             break;
         }
-        case DataType::GEOMETRY: {
+        case DataType::GEOMETRY:
+        case DataType::MOL: {
             // dst must have at least count elements; the callback's offset
             // parameter is guaranteed to be in [0, count)
             bulk_subscript_ptr_impl<std::string>(
@@ -2107,6 +2108,16 @@ ChunkedSegmentSealedImpl::get_raw_data(milvus::OpContext* op_ctx,
                                                  ret->mutable_scalars()
                                                      ->mutable_geometry_data()
                                                      ->mutable_data());
+            break;
+        }
+
+        case DataType::MOL: {
+            bulk_subscript_ptr_impl<std::string>(
+                op_ctx,
+                column.get(),
+                seg_offsets,
+                count,
+                ret->mutable_scalars()->mutable_mol_data()->mutable_data());
             break;
         }
 

--- a/internal/core/src/segcore/ConcurrentVector.cpp
+++ b/internal/core/src/segcore/ConcurrentVector.cpp
@@ -131,6 +131,17 @@ VectorBase::set_data_raw(ssize_t element_offset,
             }
             return set_data_raw(element_offset, data_raw.data(), element_count);
         }
+        case DataType::MOL: {
+            // get the mol array of a column from proto message
+            auto& mol_data = FIELD_DATA(data, mol);
+            std::vector<std::string> data_raw{};
+            data_raw.reserve(mol_data.size());
+            for (auto& mol_bytes : mol_data) {
+                data_raw.emplace_back(
+                    std::string(mol_bytes.data(), mol_bytes.size()));
+            }
+            return set_data_raw(element_offset, data_raw.data(), element_count);
+        }
         case DataType::ARRAY: {
             auto& array_data = FIELD_DATA(data, array);
             std::vector<Array> data_raw{};

--- a/internal/core/src/segcore/InsertRecord.h
+++ b/internal/core/src/segcore/InsertRecord.h
@@ -938,6 +938,11 @@ class InsertRecordGrowing {
                     field_id, size_per_chunk, scalar_mmap_descriptor);
                 return;
             }
+            case DataType::MOL: {
+                this->append_data<std::string>(
+                    field_id, size_per_chunk, scalar_mmap_descriptor);
+                return;
+            }
             default: {
                 ThrowInfo(DataTypeInvalid,
                           fmt::format("unsupported scalar type",

--- a/internal/core/src/segcore/ReduceUtils.cpp
+++ b/internal/core/src/segcore/ReduceUtils.cpp
@@ -175,6 +175,19 @@ AssembleGroupByValues(
                 }
                 break;
             }
+            case DataType::MOL: {
+                mutable_group_by_field_value->set_type(
+                    milvus::proto::schema::DataType::Mol);
+                auto field_data = group_by_res_values->mutable_mol_data();
+                for (std::size_t idx = 0; idx < group_by_val_size; idx++) {
+                    if (group_by_vals[idx].has_value()) {
+                        std::string val =
+                            std::get<std::string>(group_by_vals[idx].value());
+                        *(field_data->mutable_data()->Add()) = val;
+                    }
+                }
+                break;
+            }
             case DataType::JSON: {
                 auto json_path = plan->plan_node_->search_info_.json_path_;
                 auto json_type = plan->plan_node_->search_info_.json_type_;

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -406,7 +406,8 @@ SegmentGrowingImpl::EstimateSegmentResourceUsage() const {
                     break;
                 case DataType::VARCHAR:
                 case DataType::TEXT:
-                case DataType::GEOMETRY: {
+                case DataType::GEOMETRY:
+                case DataType::MOL: {
                     auto avg_size =
                         SegmentInternalInterface::get_field_avg_size(field_id);
                     field_bytes = num_rows * avg_size;
@@ -1402,6 +1403,15 @@ SegmentGrowingImpl::bulk_subscript(milvus::OpContext* op_ctx,
                                                      ->mutable_data());
             break;
         }
+        case DataType::MOL: {
+            bulk_subscript_ptr_impl<std::string>(
+                op_ctx,
+                vec_ptr,
+                seg_offsets,
+                count,
+                result->mutable_scalars()->mutable_mol_data()->mutable_data());
+            break;
+        }
         case DataType::ARRAY: {
             // element
             bulk_subscript_array_impl(op_ctx,
@@ -1723,7 +1733,8 @@ SegmentGrowingImpl::bulk_subscript(milvus::OpContext* op_ctx,
                 vec_ptr, seg_offsets, count, static_cast<Json*>(data));
             break;
         }
-        case DataType::GEOMETRY: {
+        case DataType::GEOMETRY:
+        case DataType::MOL: {
             bulk_subscript_ptr_impl<std::string>(
                 vec_ptr, seg_offsets, count, static_cast<std::string*>(data));
             break;

--- a/internal/core/src/segcore/SegmentGrowingTest.cpp
+++ b/internal/core/src/segcore/SegmentGrowingTest.cpp
@@ -193,6 +193,7 @@ TEST_P(GrowingTest, FillData) {
     auto varchar_field = schema->AddDebugField("varchar", DataType::VARCHAR);
     auto json_field = schema->AddDebugField("json", DataType::JSON);
     auto geometry_field = schema->AddDebugField("geometry", DataType::GEOMETRY);
+    auto mol_field = schema->AddDebugField("mol", DataType::MOL);
     auto int_array_field =
         schema->AddDebugField("int_array", DataType::ARRAY, DataType::INT8);
     auto long_array_field =
@@ -260,6 +261,8 @@ TEST_P(GrowingTest, FillData) {
             nullptr, json_field, ids_ds->GetIds(), num_inserted);
         auto geometry_result = segment->bulk_subscript(
             nullptr, geometry_field, ids_ds->GetIds(), num_inserted);
+        auto mol_result = segment->bulk_subscript(
+            nullptr, mol_field, ids_ds->GetIds(), num_inserted);
         auto int_array_result = segment->bulk_subscript(
             nullptr, int_array_field, ids_ds->GetIds(), num_inserted);
         auto long_array_result = segment->bulk_subscript(
@@ -292,6 +295,7 @@ TEST_P(GrowingTest, FillData) {
         EXPECT_EQ(json_result->scalars().json_data().data_size(), num_inserted);
         EXPECT_EQ(geometry_result->scalars().geometry_data().data_size(),
                   num_inserted);
+        EXPECT_EQ(mol_result->scalars().mol_data().data_size(), num_inserted);
         if (data_type == DataType::VECTOR_FLOAT) {
             EXPECT_EQ(vec_result->vectors().float_vector().data_size(),
                       num_inserted * dim);
@@ -349,6 +353,7 @@ TEST(Growing, FillNullableData) {
     auto varchar_field =
         schema->AddDebugField("varchar", DataType::VARCHAR, true);
     auto json_field = schema->AddDebugField("json", DataType::JSON, true);
+    auto mol_field = schema->AddDebugField("mol", DataType::MOL, true);
     auto int_array_field = schema->AddDebugField(
         "int_array", DataType::ARRAY, DataType::INT8, true);
     auto long_array_field = schema->AddDebugField(
@@ -415,6 +420,8 @@ TEST(Growing, FillNullableData) {
             nullptr, varchar_field, ids_ds->GetIds(), num_inserted);
         auto json_result = segment->bulk_subscript(
             nullptr, json_field, ids_ds->GetIds(), num_inserted);
+        auto mol_result = segment->bulk_subscript(
+            nullptr, mol_field, ids_ds->GetIds(), num_inserted);
         auto int_array_result = segment->bulk_subscript(
             nullptr, int_array_field, ids_ds->GetIds(), num_inserted);
         auto long_array_result = segment->bulk_subscript(
@@ -445,6 +452,7 @@ TEST(Growing, FillNullableData) {
         EXPECT_EQ(varchar_result->scalars().string_data().data_size(),
                   num_inserted);
         EXPECT_EQ(json_result->scalars().json_data().data_size(), num_inserted);
+        EXPECT_EQ(mol_result->scalars().mol_data().data_size(), num_inserted);
         EXPECT_EQ(vec_result->vectors().float_vector().data_size(),
                   num_inserted * dim);
         EXPECT_EQ(int_array_result->scalars().array_data().data_size(),
@@ -468,6 +476,7 @@ TEST(Growing, FillNullableData) {
         EXPECT_EQ(timestamptz_result->valid_data_size(), num_inserted);
         EXPECT_EQ(varchar_result->valid_data_size(), num_inserted);
         EXPECT_EQ(json_result->valid_data_size(), num_inserted);
+        EXPECT_EQ(mol_result->valid_data_size(), num_inserted);
         EXPECT_EQ(int_array_result->valid_data_size(), num_inserted);
         EXPECT_EQ(long_array_result->valid_data_size(), num_inserted);
         EXPECT_EQ(bool_array_result->valid_data_size(), num_inserted);

--- a/internal/core/src/segcore/SegmentInterface.cpp
+++ b/internal/core/src/segcore/SegmentInterface.cpp
@@ -669,6 +669,16 @@ SegmentInternalInterface::bulk_subscript_not_exist_field(
                 }
                 break;
             }
+            case DataType::MOL: {
+                auto data_ptr = result->mutable_scalars()
+                                    ->mutable_mol_data()
+                                    ->mutable_data();
+
+                for (int64_t i = 0; i < count; ++i) {
+                    data_ptr->at(i) = field_meta.default_value()->bytes_data();
+                }
+                break;
+            }
             default: {
                 ThrowInfo(DataTypeInvalid,
                           fmt::format("unsupported default value type {}",

--- a/internal/core/src/storage/Event.cpp
+++ b/internal/core/src/storage/Event.cpp
@@ -342,6 +342,17 @@ BaseEventData::Serialize() {
                 }
                 break;
             }
+            case DataType::MOL: {
+                for (size_t offset = 0; offset < field_data->get_num_rows();
+                     ++offset) {
+                    auto mol_ptr = static_cast<const std::string*>(
+                        field_data->RawValue(offset));
+                    payload_writer->add_one_binary_payload(
+                        reinterpret_cast<const uint8_t*>(mol_ptr->data()),
+                        mol_ptr->size());
+                }
+                break;
+            }
             case DataType::VECTOR_SPARSE_U32_F32: {
                 for (size_t offset = 0; offset < field_data->get_num_rows();
                      ++offset) {

--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -444,7 +444,8 @@ CreateArrowBuilder(DataType data_type) {
         }
         case DataType::ARRAY:
         case DataType::JSON:
-        case DataType::GEOMETRY: {
+        case DataType::GEOMETRY:
+        case DataType::MOL: {
             return std::make_shared<arrow::BinaryBuilder>();
         }
         // sparse float vector doesn't require a dim
@@ -655,7 +656,8 @@ CreateArrowSchema(DataType data_type, bool nullable) {
         }
         case DataType::ARRAY:
         case DataType::JSON:
-        case DataType::GEOMETRY: {
+        case DataType::GEOMETRY:
+        case DataType::MOL: {
             return arrow::schema(
                 {arrow::field("val", arrow::binary(), nullable)});
         }
@@ -1224,6 +1226,9 @@ CreateFieldData(const DataType& type,
                 type, nullable, total_num_rows);
         case DataType::GEOMETRY:
             return std::make_shared<FieldData<Geometry>>(
+                type, nullable, total_num_rows);
+        case DataType::MOL:
+            return std::make_shared<FieldData<Mol>>(
                 type, nullable, total_num_rows);
         case DataType::ARRAY:
             return std::make_shared<FieldData<Array>>(

--- a/internal/core/unittest/test_sealed.cpp
+++ b/internal/core/unittest/test_sealed.cpp
@@ -506,6 +506,7 @@ TEST(Sealed, LoadFieldData) {
     schema->AddDebugField("float", DataType::FLOAT);
     schema->AddDebugField("json", DataType::JSON);
     schema->AddDebugField("geometry", DataType::GEOMETRY);
+    schema->AddDebugField("mol", DataType::MOL);
     schema->AddDebugField("array", DataType::ARRAY, DataType::INT64);
     schema->set_primary_field_id(counter_id);
     auto int8_nullable_id =
@@ -671,6 +672,7 @@ TEST(Sealed, ClearData) {
     schema->AddDebugField("float", DataType::FLOAT);
     schema->AddDebugField("json", DataType::JSON);
     schema->AddDebugField("geometry", DataType::GEOMETRY);
+    schema->AddDebugField("mol", DataType::MOL);
     schema->AddDebugField("array", DataType::ARRAY, DataType::INT64);
     schema->set_primary_field_id(counter_id);
 
@@ -758,6 +760,7 @@ TEST(Sealed, LoadFieldDataMmap) {
     schema->AddDebugField("float", DataType::FLOAT);
     schema->AddDebugField("json", DataType::JSON);
     schema->AddDebugField("geometry", DataType::GEOMETRY);
+    schema->AddDebugField("mol", DataType::MOL);
     schema->AddDebugField("array", DataType::ARRAY, DataType::INT64);
     schema->set_primary_field_id(counter_id);
 
@@ -1931,6 +1934,7 @@ TEST(Sealed, QueryAllFields) {
     auto varchar_field = schema->AddDebugField("varchar", DataType::VARCHAR);
     auto json_field = schema->AddDebugField("json", DataType::JSON);
     auto geometry_field = schema->AddDebugField("geometry", DataType::GEOMETRY);
+    auto mol_field = schema->AddDebugField("mol", DataType::MOL);
     auto int_array_field =
         schema->AddDebugField("int_array", DataType::ARRAY, DataType::INT8);
     auto long_array_field =
@@ -2020,6 +2024,8 @@ TEST(Sealed, QueryAllFields) {
         nullptr, json_field, ids_ds->GetIds(), dataset_size);
     auto geometry_result = segment->bulk_subscript(
         nullptr, geometry_field, ids_ds->GetIds(), dataset_size);
+    auto mol_result = segment->bulk_subscript(
+        nullptr, mol_field, ids_ds->GetIds(), dataset_size);
     auto int_array_result = segment->bulk_subscript(
         nullptr, int_array_field, ids_ds->GetIds(), dataset_size);
     auto long_array_result = segment->bulk_subscript(
@@ -2053,6 +2059,7 @@ TEST(Sealed, QueryAllFields) {
     EXPECT_EQ(json_result->scalars().json_data().data_size(), dataset_size);
     EXPECT_EQ(geometry_result->scalars().geometry_data().data_size(),
               dataset_size);
+    EXPECT_EQ(mol_result->scalars().mol_data().data_size(), dataset_size);
     EXPECT_EQ(vec_result->vectors().float_vector().data_size(),
               dataset_size * dim);
     EXPECT_EQ(float16_vec_result->vectors().float16_vector().size(),
@@ -2107,6 +2114,7 @@ TEST(Sealed, QueryAllNullableFields) {
     auto json_field = schema->AddDebugField("json", DataType::JSON, true);
     auto geometry_field =
         schema->AddDebugField("geometry", DataType::GEOMETRY, true);
+    auto mol_field = schema->AddDebugField("mol", DataType::MOL, true);
     auto int_array_field = schema->AddDebugField(
         "int_array", DataType::ARRAY, DataType::INT8, true);
     auto long_array_field = schema->AddDebugField(
@@ -2175,6 +2183,7 @@ TEST(Sealed, QueryAllNullableFields) {
     auto varchar_valid_values = dataset.get_col_valid(varchar_field);
     auto json_valid_values = dataset.get_col_valid(json_field);
     auto geometry_valid_values = dataset.get_col_valid(geometry_field);
+    auto mol_valid_values = dataset.get_col_valid(mol_field);
     auto int_array_valid_values = dataset.get_col_valid(int_array_field);
     auto long_array_valid_values = dataset.get_col_valid(long_array_field);
     auto bool_array_valid_values = dataset.get_col_valid(bool_array_field);
@@ -2203,6 +2212,8 @@ TEST(Sealed, QueryAllNullableFields) {
         nullptr, json_field, ids_ds->GetIds(), dataset_size);
     auto geometry_result = segment->bulk_subscript(
         nullptr, geometry_field, ids_ds->GetIds(), dataset_size);
+    auto mol_result = segment->bulk_subscript(
+        nullptr, mol_field, ids_ds->GetIds(), dataset_size);
     auto int_array_result = segment->bulk_subscript(
         nullptr, int_array_field, ids_ds->GetIds(), dataset_size);
     auto long_array_result = segment->bulk_subscript(
@@ -2230,6 +2241,7 @@ TEST(Sealed, QueryAllNullableFields) {
     EXPECT_EQ(json_result->scalars().json_data().data_size(), dataset_size);
     EXPECT_EQ(geometry_result->scalars().geometry_data().data_size(),
               dataset_size);
+    EXPECT_EQ(mol_result->scalars().mol_data().data_size(), dataset_size);
     EXPECT_EQ(vec_result->vectors().float_vector().data_size(),
               dataset_size * dim);
     EXPECT_EQ(int_array_result->scalars().array_data().data_size(),
@@ -2254,6 +2266,7 @@ TEST(Sealed, QueryAllNullableFields) {
     EXPECT_EQ(varchar_result->valid_data_size(), dataset_size);
     EXPECT_EQ(json_result->valid_data_size(), dataset_size);
     EXPECT_EQ(geometry_result->valid_data_size(), dataset_size);
+    EXPECT_EQ(mol_result->valid_data_size(), dataset_size);
     EXPECT_EQ(int_array_result->valid_data_size(), dataset_size);
     EXPECT_EQ(long_array_result->valid_data_size(), dataset_size);
     EXPECT_EQ(bool_array_result->valid_data_size(), dataset_size);


### PR DESCRIPTION
## Related to
- milvus-io/milvus#47229

## Design Doc
- milvus-io/milvus-design-docs#30

This PR is part of the MOL feature stack and should be reviewed together with the design doc above.

## Changes

- Add Mol.h header file for MOL data type definition
- Support MOL in core data structures:
  * Array: handle MOL in comparison and serialization
  * FieldData: support MOL data filling and initialization
  * Types: add MOL to DataType enum and type mappings
  * TypeTraits: add MOL type traits

- Support MOL in expression evaluation:
  * Expr.h: process MOL in index chunks
  * NullExpr.cpp: handle MOL in NULL expression evaluation

- Support MOL in segment operations:
  * SegmentGrowingImpl: handle MOL in growing segments
  * ChunkedSegmentSealedImpl: handle MOL in sealed segments
  * SegmentInterface: support MOL in field data operations
  * Utils: handle MOL in data array operations
  * ReduceUtils: support MOL in reduce operations

- Support MOL in storage layer:
  * Event.cpp: handle MOL in storage events
  * Util.cpp: support MOL in storage utilities
  * ChunkWriter: support MOL in chunk writing