### PR TITLE
enhance: unify filesystem cache and metrics support

### DIFF
--- a/internal/core/src/storage/StorageV2FSCache.cpp
+++ b/internal/core/src/storage/StorageV2FSCache.cpp
@@ -50,11 +50,15 @@ StorageV2FSCache::Get(const Key& key) {
     props[PROPERTY_FS_USE_CUSTOM_PART_UPLOAD] = key.use_custom_part_upload;
     props[PROPERTY_FS_MAX_CONNECTIONS] = key.max_connections;
 
-    LOG_INFO("StorageV2FSCache::Get: address={}, bucket={}, root_path={}, storage_type={}",
-             key.address, key.bucket_name, key.root_path, key.storage_type);
+    LOG_INFO(
+        "StorageV2FSCache::Get: address={}, bucket={}, root_path={}, "
+        "storage_type={}",
+        key.address,
+        key.bucket_name,
+        key.root_path,
+        key.storage_type);
 
-    auto result =
-        milvus_storage::FilesystemCache::getInstance().get(props, "");
+    auto result = milvus_storage::FilesystemCache::getInstance().get(props, "");
 
     if (!result.ok()) {
         LOG_WARN("create arrow file system failed, error: {}",

--- a/internal/core/src/storage/StorageV2FSCache.cpp
+++ b/internal/core/src/storage/StorageV2FSCache.cpp
@@ -14,6 +14,7 @@
 #include <mutex>
 #include <shared_mutex>
 #include "milvus-storage/filesystem/fs.h"
+#include "milvus-storage/properties.h"
 #include "log/Log.h"
 
 namespace milvus::storage {
@@ -26,79 +27,43 @@ StorageV2FSCache::Instance() {
 
 milvus_storage::ArrowFileSystemPtr
 StorageV2FSCache::Get(const Key& key) {
-    {
-        std::shared_lock lck(mutex_);
-        auto it = concurrent_map_.find(key);
-        if (it != concurrent_map_.end()) {
-            return it->second.second.get();
-        }
-    }
+    // Convert Key to api::Properties and delegate to FilesystemCache
+    // This ensures all filesystems are managed by a single cache with metrics support
+    milvus_storage::api::Properties props;
+    props[PROPERTY_FS_ADDRESS] = key.address;
+    props[PROPERTY_FS_BUCKET_NAME] = key.bucket_name;
+    props[PROPERTY_FS_ACCESS_KEY_ID] = key.access_key_id;
+    props[PROPERTY_FS_ACCESS_KEY_VALUE] = key.access_key_value;
+    props[PROPERTY_FS_ROOT_PATH] = key.root_path;
+    props[PROPERTY_FS_STORAGE_TYPE] = key.storage_type;
+    props[PROPERTY_FS_CLOUD_PROVIDER] = key.cloud_provider;
+    props[PROPERTY_FS_IAM_ENDPOINT] = key.iam_endpoint;
+    props[PROPERTY_FS_LOG_LEVEL] = key.log_level;
+    props[PROPERTY_FS_REGION] = key.region;
+    props[PROPERTY_FS_USE_SSL] = key.useSSL;
+    props[PROPERTY_FS_SSL_CA_CERT] = key.sslCACert;
+    props[PROPERTY_FS_USE_IAM] = key.useIAM;
+    props[PROPERTY_FS_USE_VIRTUAL_HOST] = key.useVirtualHost;
+    props[PROPERTY_FS_REQUEST_TIMEOUT_MS] = key.requestTimeoutMs;
+    props[PROPERTY_FS_GCP_NATIVE_WITHOUT_AUTH] = key.gcp_native_without_auth;
+    props[PROPERTY_FS_GCP_CREDENTIAL_JSON] = key.gcp_credential_json;
+    props[PROPERTY_FS_USE_CUSTOM_PART_UPLOAD] = key.use_custom_part_upload;
+    props[PROPERTY_FS_MAX_CONNECTIONS] = key.max_connections;
 
-    std::promise<milvus_storage::ArrowFileSystemPtr> p;
-    std::shared_future<milvus_storage::ArrowFileSystemPtr> f = p.get_future();
+    LOG_INFO("StorageV2FSCache::Get: address={}, bucket={}, root_path={}, storage_type={}",
+             key.address, key.bucket_name, key.root_path, key.storage_type);
 
-    std::shared_lock lck(mutex_);
-    auto [iter, inserted] =
-        concurrent_map_.emplace(key, Value(std::move(p), f));
-    lck.unlock();
+    auto result =
+        milvus_storage::FilesystemCache::getInstance().get(props, "");
 
-    if (!inserted) {
-        std::shared_lock lck(mutex_);
-        // double check: avoid iter has been erased by other thread
-        auto it = concurrent_map_.find(key);
-        if (it != concurrent_map_.end()) {
-            return it->second.second.get();
-        }
-        lck.unlock();
-        // retry if already delete
-        return Get(key);
-    }
-
-    try {
-        milvus_storage::ArrowFileSystemConfig conf;
-        conf.address = std::string(key.address);
-        conf.bucket_name = std::string(key.bucket_name);
-        conf.access_key_id = std::string(key.access_key_id);
-        conf.access_key_value = std::string(key.access_key_value);
-        conf.root_path = std::string(key.root_path);
-        conf.storage_type = std::string(key.storage_type);
-        conf.cloud_provider = std::string(key.cloud_provider);
-        conf.iam_endpoint = std::string(key.iam_endpoint);
-        conf.log_level = std::string(key.log_level);
-        conf.region = std::string(key.region);
-        conf.use_ssl = key.useSSL;
-        conf.ssl_ca_cert = std::string(key.sslCACert);
-        conf.use_iam = key.useIAM;
-        conf.use_virtual_host = key.useVirtualHost;
-        conf.request_timeout_ms = key.requestTimeoutMs;
-        conf.gcp_credential_json = std::string(key.gcp_credential_json);
-        conf.use_custom_part_upload = key.use_custom_part_upload;
-        conf.max_connections = key.max_connections;
-
-        auto result = milvus_storage::CreateArrowFileSystem(conf);
-
-        if (!result.ok()) {
-            LOG_WARN("create arrow file system failed, error: {}",
-                     result.status().ToString());
-            iter->second.first.set_value(nullptr);
-            std::unique_lock lck(mutex_);
-            concurrent_map_.unsafe_erase(iter);
-            return nullptr;
-        }
-
-        auto fs = result.ValueOrDie();
-        iter->second.first.set_value(fs);
-        return fs;
-    } catch (...) {
-        try {
-            iter->second.first.set_exception(std::current_exception());
-        } catch (...) {
-        }
-
-        std::unique_lock lck(mutex_);
-        concurrent_map_.unsafe_erase(iter);
+    if (!result.ok()) {
+        LOG_WARN("create arrow file system failed, error: {}",
+                 result.status().ToString());
         return nullptr;
     }
+
+    LOG_INFO("StorageV2FSCache::Get: got filesystem successfully");
+    return result.ValueOrDie();
 }
 
 }  // namespace milvus::storage

--- a/internal/core/thirdparty/milvus-storage/CMakeLists.txt
+++ b/internal/core/thirdparty/milvus-storage/CMakeLists.txt
@@ -14,7 +14,7 @@
 # Update milvus-storage_VERSION for the first occurrence
 milvus_add_pkg_config("milvus-storage")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( milvus-storage_VERSION 88c2551)
+set( milvus-storage_VERSION f372333)
 set( GIT_REPOSITORY  "https://github.com/milvus-io/milvus-storage.git")
 message(STATUS "milvus-storage repo: ${GIT_REPOSITORY}")
 message(STATUS "milvus-storage version: ${milvus-storage_VERSION}")
@@ -49,3 +49,8 @@ if ( NOT milvus-storage_POPULATED )
 endif()
 
 set( MILVUS_STORAGE_INCLUDE_DIR ${milvus-storage_SOURCE_DIR}/cpp/include CACHE INTERNAL "Path to milvus-storage include directory" )
+
+# Add the milvus-storage include directory to the target's interface include directories
+# This ensures that consumers of milvus-storage can find <arrow/c/abi.h> which is bundled
+# inside the milvus-storage include directory
+target_include_directories(milvus-storage PUBLIC ${MILVUS_STORAGE_INCLUDE_DIR})

--- a/internal/datanode/compactor/clustering_compactor.go
+++ b/internal/datanode/compactor/clustering_compactor.go
@@ -46,6 +46,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/metrics"
 	"github.com/milvus-io/milvus/pkg/v2/proto/clusteringpb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v2/util/conc"
 	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/hardware"
@@ -320,7 +321,6 @@ func (t *clusteringCompactionTask) Compact() (*datapb.CompactionPlanResult, erro
 	log.Info("Clustering compaction finished", zap.Duration("elapse", t.tr.ElapseSpan()), zap.Int64("flushTimes", t.flushCount.Load()))
 	// clear the buffer cache
 	t.keyToBufferFunc = nil
-
 	return planResult, nil
 }
 
@@ -1103,4 +1103,8 @@ func (t *clusteringCompactionTask) splitClusterByScalarValue(dict map[interface{
 
 func (t *clusteringCompactionTask) GetSlotUsage() int64 {
 	return t.plan.GetSlotUsage()
+}
+
+func (t *clusteringCompactionTask) GetStorageConfig() *indexpb.StorageConfig {
+	return t.compactionParams.StorageConfig
 }

--- a/internal/datanode/compactor/compactor.go
+++ b/internal/datanode/compactor/compactor.go
@@ -18,6 +18,7 @@ package compactor
 
 import (
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
 
@@ -31,4 +32,5 @@ type Compactor interface {
 	GetChannelName() string
 	GetCompactionType() datapb.CompactionType
 	GetSlotUsage() int64
+	GetStorageConfig() *indexpb.StorageConfig
 }

--- a/internal/datanode/compactor/l0_compactor.go
+++ b/internal/datanode/compactor/l0_compactor.go
@@ -37,6 +37,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/metrics"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v2/util/conc"
 	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/hardware"
@@ -485,4 +486,8 @@ func (t *LevelZeroCompactionTask) loadBF(ctx context.Context, targetSegments []*
 
 func (t *LevelZeroCompactionTask) GetSlotUsage() int64 {
 	return t.plan.GetSlotUsage()
+}
+
+func (t *LevelZeroCompactionTask) GetStorageConfig() *indexpb.StorageConfig {
+	return t.compactionParams.StorageConfig
 }

--- a/internal/datanode/compactor/l0_compactor_test.go
+++ b/internal/datanode/compactor/l0_compactor_test.go
@@ -834,6 +834,13 @@ func (s *LevelZeroCompactionTaskSuite) TestFailed() {
 	})
 }
 
+func (s *LevelZeroCompactionTaskSuite) TestGetStorageConfig() {
+	// Verify GetStorageConfig returns the storage config from compaction params
+	storageConfig := s.task.GetStorageConfig()
+	s.NotNil(storageConfig)
+	s.Equal(s.task.compactionParams.StorageConfig, storageConfig)
+}
+
 func (s *LevelZeroCompactionTaskSuite) TestLoadBFWithDecompression() {
 	s.Run("successful decompression with root path", func() {
 		// Test that DecompressBinLogWithRootPath is called with correct parameters

--- a/internal/datanode/compactor/mix_compactor.go
+++ b/internal/datanode/compactor/mix_compactor.go
@@ -39,6 +39,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/metrics"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/timerecord"
@@ -458,6 +459,10 @@ func (t *mixCompactionTask) GetCollection() typeutil.UniqueID {
 
 func (t *mixCompactionTask) GetSlotUsage() int64 {
 	return t.plan.GetSlotUsage()
+}
+
+func (t *mixCompactionTask) GetStorageConfig() *indexpb.StorageConfig {
+	return t.compactionParams.StorageConfig
 }
 
 func GetBM25FieldIDs(coll *schemapb.CollectionSchema) []int64 {

--- a/internal/datanode/compactor/mix_compactor_test.go
+++ b/internal/datanode/compactor/mix_compactor_test.go
@@ -675,6 +675,13 @@ func (s *MixCompactionTaskStorageV1Suite) TestMergeNoExpiration() {
 	}
 }
 
+func (s *MixCompactionTaskStorageV1Suite) TestGetStorageConfig() {
+	// Verify GetStorageConfig returns the storage config from compaction params
+	storageConfig := s.task.GetStorageConfig()
+	s.NotNil(storageConfig)
+	s.Equal(s.task.compactionParams.StorageConfig, storageConfig)
+}
+
 func (s *MixCompactionTaskStorageV1Suite) TestGetBM25FieldIDs() {
 	fieldIDs := GetBM25FieldIDs(&schemapb.CollectionSchema{
 		Functions: []*schemapb.FunctionSchema{{}},

--- a/internal/datanode/compactor/mock_compactor.go
+++ b/internal/datanode/compactor/mock_compactor.go
@@ -4,6 +4,8 @@ package compactor
 
 import (
 	datapb "github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+	indexpb "github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
+
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -330,6 +332,53 @@ func (_c *MockCompactor_GetSlotUsage_Call) Return(_a0 int64) *MockCompactor_GetS
 }
 
 func (_c *MockCompactor_GetSlotUsage_Call) RunAndReturn(run func() int64) *MockCompactor_GetSlotUsage_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetStorageConfig provides a mock function with no fields
+func (_m *MockCompactor) GetStorageConfig() *indexpb.StorageConfig {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetStorageConfig")
+	}
+
+	var r0 *indexpb.StorageConfig
+	if rf, ok := ret.Get(0).(func() *indexpb.StorageConfig); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*indexpb.StorageConfig)
+		}
+	}
+
+	return r0
+}
+
+// MockCompactor_GetStorageConfig_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetStorageConfig'
+type MockCompactor_GetStorageConfig_Call struct {
+	*mock.Call
+}
+
+// GetStorageConfig is a helper method to define mock.On call
+func (_e *MockCompactor_Expecter) GetStorageConfig() *MockCompactor_GetStorageConfig_Call {
+	return &MockCompactor_GetStorageConfig_Call{Call: _e.mock.On("GetStorageConfig")}
+}
+
+func (_c *MockCompactor_GetStorageConfig_Call) Run(run func()) *MockCompactor_GetStorageConfig_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockCompactor_GetStorageConfig_Call) Return(_a0 *indexpb.StorageConfig) *MockCompactor_GetStorageConfig_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockCompactor_GetStorageConfig_Call) RunAndReturn(run func() *indexpb.StorageConfig) *MockCompactor_GetStorageConfig_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/datanode/compactor/sort_compaction.go
+++ b/internal/datanode/compactor/sort_compaction.go
@@ -44,6 +44,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/indexcgopb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/metautil"
@@ -417,6 +418,10 @@ func (t *sortCompactionTask) GetCollection() typeutil.UniqueID {
 
 func (t *sortCompactionTask) GetSlotUsage() int64 {
 	return t.plan.GetSlotUsage()
+}
+
+func (t *sortCompactionTask) GetStorageConfig() *indexpb.StorageConfig {
+	return t.compactionParams.StorageConfig
 }
 
 func (t *sortCompactionTask) createTextIndex(ctx context.Context,

--- a/internal/datanode/index/scheduler.go
+++ b/internal/datanode/index/scheduler.go
@@ -257,13 +257,13 @@ func (sched *TaskScheduler) processTask(t Task) {
 	// Publish filesystem metrics after index task completion
 	// Only publish for index build tasks (not stats or analyze tasks)
 	if indexTask, ok := t.(*indexBuildTask); ok {
-		// Extract storage config from task to get the filesystem path
-		var fsPath string
+		// Extract storage config from task to get the filesystem key
+		var fsKey string
 		if indexTask.req != nil && indexTask.req.GetStorageConfig() != nil {
-			fsPath = storagev2.GetFilesystemKeyFromStorageConfig(indexTask.req.GetStorageConfig())
+			fsKey = storagev2.GetFilesystemKeyFromStorageConfig(indexTask.req.GetStorageConfig())
 		}
-		// If no storage config or empty path, use default filesystem (empty path)
-		storagev2.PublishFilesystemMetrics(fsPath)
+		// If no storage config or empty key, use default filesystem (empty key)
+		storagev2.PublishCachedFilesystemMetrics(fsKey)
 	}
 }
 

--- a/internal/datanode/index/scheduler.go
+++ b/internal/datanode/index/scheduler.go
@@ -26,6 +26,7 @@ import (
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
 
+	"github.com/milvus-io/milvus/internal/storagev2"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
@@ -252,6 +253,18 @@ func (sched *TaskScheduler) processTask(t Task) {
 		}
 	}
 	t.SetState(indexpb.JobState_JobStateFinished, "")
+
+	// Publish filesystem metrics after index task completion
+	// Only publish for index build tasks (not stats or analyze tasks)
+	if indexTask, ok := t.(*indexBuildTask); ok {
+		// Extract storage config from task to get the filesystem path
+		var fsPath string
+		if indexTask.req != nil && indexTask.req.GetStorageConfig() != nil {
+			fsPath = storagev2.GetFilesystemKeyFromStorageConfig(indexTask.req.GetStorageConfig())
+		}
+		// If no storage config or empty path, use default filesystem (empty path)
+		storagev2.PublishFilesystemMetrics(fsPath)
+	}
 }
 
 func (sched *TaskScheduler) indexBuildLoop() {

--- a/internal/datanode/services_test.go
+++ b/internal/datanode/services_test.go
@@ -168,6 +168,7 @@ func (s *DataNodeServicesSuite) TestGetCompactionState() {
 			PlanID: 1,
 			State:  datapb.CompactionTaskState_completed,
 		}, nil)
+		mockC.EXPECT().GetStorageConfig().Return(s.storageConfig)
 		s.node.compactionExecutor.Enqueue(mockC)
 
 		mockC2 := compactor.NewMockCompactor(s.T())
@@ -181,6 +182,7 @@ func (s *DataNodeServicesSuite) TestGetCompactionState() {
 			PlanID: 2,
 			State:  datapb.CompactionTaskState_failed,
 		}, nil)
+		mockC2.EXPECT().GetStorageConfig().Return(s.storageConfig)
 		s.node.compactionExecutor.Enqueue(mockC2)
 
 		s.Eventually(func() bool {

--- a/internal/flushcommon/syncmgr/task.go
+++ b/internal/flushcommon/syncmgr/task.go
@@ -32,6 +32,7 @@ import (
 	"github.com/milvus-io/milvus/internal/json"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/storagecommon"
+	"github.com/milvus-io/milvus/internal/storagev2"
 	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/metrics"
@@ -202,6 +203,11 @@ func (t *SyncTask) Run(ctx context.Context) (err error) {
 		metrics.DataNodeAutoFlushBufferCount.WithLabelValues(fmt.Sprint(paramtable.GetNodeID()), metrics.SuccessLabel, t.level.String()).Inc()
 	}
 	metrics.DataNodeFlushBufferCount.WithLabelValues(fmt.Sprint(paramtable.GetNodeID()), metrics.SuccessLabel, t.level.String()).Inc()
+
+	// Publish filesystem metrics after sync task completion
+	// Use default filesystem (empty path) for sync tasks
+	fs := fmt.Sprintf("%s/%s", t.storageConfig.GetAddress(), t.storageConfig.GetBucketName())
+	storagev2.PublishFilesystemMetrics(fs)
 
 	return nil
 }

--- a/internal/flushcommon/syncmgr/task.go
+++ b/internal/flushcommon/syncmgr/task.go
@@ -205,9 +205,7 @@ func (t *SyncTask) Run(ctx context.Context) (err error) {
 	metrics.DataNodeFlushBufferCount.WithLabelValues(fmt.Sprint(paramtable.GetNodeID()), metrics.SuccessLabel, t.level.String()).Inc()
 
 	// Publish filesystem metrics after sync task completion
-	// Use default filesystem (empty path) for sync tasks
-	fs := fmt.Sprintf("%s/%s", t.storageConfig.GetAddress(), t.storageConfig.GetBucketName())
-	storagev2.PublishFilesystemMetrics(fs)
+	storagev2.PublishFilesystemMetricsWithConfig(t.storageConfig)
 
 	return nil
 }

--- a/internal/querynodev2/services.go
+++ b/internal/querynodev2/services.go
@@ -37,6 +37,7 @@ import (
 	"github.com/milvus-io/milvus/internal/querynodev2/segments"
 	"github.com/milvus-io/milvus/internal/querynodev2/tasks"
 	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/storagev2"
 	"github.com/milvus-io/milvus/internal/util/analyzer"
 	"github.com/milvus-io/milvus/internal/util/fileresource"
 	"github.com/milvus-io/milvus/internal/util/searchutil/scheduler"
@@ -536,6 +537,10 @@ func (node *QueryNode) LoadSegments(ctx context.Context, req *querypb.LoadSegmen
 
 	log.Info("load segments done...",
 		zap.Int64s("segments", lo.Map(loaded, func(s segments.Segment, _ int) int64 { return s.ID() })))
+
+	// Publish filesystem metrics after load task completion
+	// Use default filesystem (empty path) for load tasks
+	storagev2.PublishDefaultFilesystemMetrics()
 
 	return merr.Success(), nil
 }

--- a/internal/storagev2/filesystem_metrics.go
+++ b/internal/storagev2/filesystem_metrics.go
@@ -1,0 +1,327 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storagev2
+
+/*
+#cgo pkg-config: milvus_core milvus-storage
+
+#include <stdlib.h>
+#include "milvus-storage/ffi_c.h"
+#include "milvus-storage/ffi_filesystem_c.h"
+#include "milvus-storage/ffi_filesystem_metrics_c.h"
+*/
+import "C"
+
+import (
+	"fmt"
+	"strconv"
+	"unsafe"
+
+	"go.uber.org/zap"
+
+	"github.com/milvus-io/milvus/pkg/v2/log"
+	"github.com/milvus-io/milvus/pkg/v2/metrics"
+	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+)
+
+// FilesystemMetrics holds the 8 filesystem metrics retrieved from the default filesystem
+type FilesystemMetrics struct {
+	ReadCount               int64
+	WriteCount              int64
+	ReadBytes               int64
+	WriteBytes              int64
+	GetFileInfoCount        int64
+	FailedCount             int64
+	MultiPartUploadCreated  int64
+	MultiPartUploadFinished int64
+}
+
+// GetFilesystemMetricsWithConfig retrieves metrics from a filesystem using storage config properties.
+// This is the preferred method when you have a StorageConfig, as it will find the exact
+// filesystem instance in the cache (with proper metrics tracking).
+func GetFilesystemMetricsWithConfig(storageConfig *indexpb.StorageConfig) (*FilesystemMetrics, error) {
+	if storageConfig == nil {
+		return GetFilesystemMetrics("")
+	}
+
+	// Debug logging for cache key verification
+	fsKey := GetFilesystemKeyFromStorageConfig(storageConfig)
+	log.Info("GetFilesystemMetricsWithConfig: looking up filesystem",
+		zap.String("fsKey", fsKey),
+		zap.String("address", storageConfig.GetAddress()),
+		zap.String("bucketName", storageConfig.GetBucketName()),
+		zap.String("rootPath", storageConfig.GetRootPath()),
+		zap.String("storageType", storageConfig.GetStorageType()))
+
+	// Build properties from storage config
+	keys := []string{
+		C.GoString(C.loon_properties_fs_address),
+		C.GoString(C.loon_properties_fs_bucket_name),
+		C.GoString(C.loon_properties_fs_access_key_id),
+		C.GoString(C.loon_properties_fs_access_key_value),
+		C.GoString(C.loon_properties_fs_root_path),
+		C.GoString(C.loon_properties_fs_storage_type),
+		C.GoString(C.loon_properties_fs_cloud_provider),
+		C.GoString(C.loon_properties_fs_iam_endpoint),
+		C.GoString(C.loon_properties_fs_log_level),
+		C.GoString(C.loon_properties_fs_region),
+		C.GoString(C.loon_properties_fs_use_ssl),
+		C.GoString(C.loon_properties_fs_ssl_ca_cert),
+		C.GoString(C.loon_properties_fs_use_iam),
+		C.GoString(C.loon_properties_fs_use_virtual_host),
+		C.GoString(C.loon_properties_fs_request_timeout_ms),
+		C.GoString(C.loon_properties_fs_gcp_credential_json),
+		C.GoString(C.loon_properties_fs_use_custom_part_upload),
+		C.GoString(C.loon_properties_fs_max_connections),
+	}
+	values := []string{
+		storageConfig.GetAddress(),
+		storageConfig.GetBucketName(),
+		storageConfig.GetAccessKeyID(),
+		storageConfig.GetSecretAccessKey(),
+		storageConfig.GetRootPath(),
+		storageConfig.GetStorageType(),
+		storageConfig.GetCloudProvider(),
+		storageConfig.GetIAMEndpoint(),
+		"warn",
+		storageConfig.GetRegion(),
+		strconv.FormatBool(storageConfig.GetUseSSL()),
+		storageConfig.GetSslCACert(),
+		strconv.FormatBool(storageConfig.GetUseIAM()),
+		strconv.FormatBool(storageConfig.GetUseVirtualHost()),
+		strconv.FormatInt(storageConfig.GetRequestTimeoutMs(), 10),
+		storageConfig.GetGcpCredentialJSON(),
+		"true",
+		strconv.FormatUint(uint64(storageConfig.GetMaxConnections()), 10),
+	}
+
+	// Convert to C arrays
+	cKeys := make([]*C.char, len(keys))
+	cValues := make([]*C.char, len(values))
+	for i := range keys {
+		cKeys[i] = C.CString(keys[i])
+		cValues[i] = C.CString(values[i])
+	}
+	defer func() {
+		for i := range cKeys {
+			C.free(unsafe.Pointer(cKeys[i]))
+			C.free(unsafe.Pointer(cValues[i]))
+		}
+	}()
+
+	// Create LoonProperties
+	var properties C.LoonProperties
+	result := C.loon_properties_create(&cKeys[0], &cValues[0], C.size_t(len(keys)), &properties)
+	if err := HandleLoonFFIResult(result); err != nil {
+		return nil, fmt.Errorf("failed to create properties: %w", err)
+	}
+	defer C.loon_properties_free(&properties)
+
+	// Get filesystem using properties
+	var cFilesystem C.FileSystemHandle
+	result = C.loon_filesystem_get(&properties, nil, 0, &cFilesystem)
+	if err := HandleLoonFFIResult(result); err != nil {
+		return nil, fmt.Errorf("failed to get filesystem: %w", err)
+	}
+
+	return getMetricsFromHandle(cFilesystem)
+}
+
+// GetFilesystemMetrics retrieves metrics from a filesystem
+// If path is empty, returns metrics from the singleton filesystem (initialized by InitLocalArrowFileSystem or InitRemoteArrowFileSystem)
+// If path is provided (format: "address/bucketName" or root_path for local), returns metrics from that specific filesystem in the cache
+// Note: When using StorageConfig, prefer GetFilesystemMetricsWithConfig for accurate cache lookup.
+func GetFilesystemMetrics(path string) (*FilesystemMetrics, error) {
+	var cFilesystem C.FileSystemHandle
+
+	// If path is empty, try to use singleton filesystem first, otherwise get filesystem from cache by path
+	if path == "" {
+		result := C.loon_get_filesystem_singleton_handle(&cFilesystem)
+		if err := HandleLoonFFIResult(result); err != nil {
+			return nil, fmt.Errorf("failed to get filesystem singleton: %w", err)
+		}
+	} else {
+		cPath := C.CString(path)
+		defer C.free(unsafe.Pointer(cPath))
+		pathLen := C.uint32_t(len(path))
+
+		// Create an empty properties struct (required by loon_filesystem_get)
+		var properties C.LoonProperties
+		properties.properties = nil
+		properties.count = 0
+
+		result := C.loon_filesystem_get(&properties, cPath, pathLen, &cFilesystem)
+		if err := HandleLoonFFIResult(result); err != nil {
+			return nil, fmt.Errorf("failed to get filesystem for path %q: %w", path, err)
+		}
+	}
+
+	return getMetricsFromHandle(cFilesystem)
+}
+
+// getMetricsFromHandle retrieves metrics from a filesystem handle
+func getMetricsFromHandle(cFilesystem C.FileSystemHandle) (*FilesystemMetrics, error) {
+	// Get metrics from the filesystem
+	var cMetrics C.LoonFilesystemMetricsSnapshot
+	metricsResult := C.loon_filesystem_get_metrics(cFilesystem, &cMetrics)
+	if err := HandleLoonFFIResult(metricsResult); err != nil {
+		// Clean up filesystem handle
+		C.loon_filesystem_destroy(cFilesystem)
+		return nil, fmt.Errorf("failed to get filesystem metrics: %w", err)
+	}
+
+	// Extract the 8 metrics from C struct
+	fsMetrics := &FilesystemMetrics{
+		ReadCount:               int64(cMetrics.read_count),
+		WriteCount:              int64(cMetrics.write_count),
+		ReadBytes:               int64(cMetrics.read_bytes),
+		WriteBytes:              int64(cMetrics.write_bytes),
+		GetFileInfoCount:        int64(cMetrics.get_file_info_count),
+		FailedCount:             int64(cMetrics.failed_count),
+		MultiPartUploadCreated:  int64(cMetrics.multi_part_upload_created),
+		MultiPartUploadFinished: int64(cMetrics.multi_part_upload_finished),
+	}
+
+	// Clean up C resources
+	C.loon_filesystem_destroy(cFilesystem)
+
+	return fsMetrics, nil
+}
+
+// HandleLoonFFIResult handles the result from loon FFI calls
+func HandleLoonFFIResult(ffiResult C.LoonFFIResult) error {
+	defer C.loon_ffi_free_result(&ffiResult)
+	if C.loon_ffi_is_success(&ffiResult) == 0 {
+		errMsg := C.loon_ffi_get_errmsg(&ffiResult)
+		errStr := "Unknown error"
+		if errMsg != nil {
+			errStr = C.GoString(errMsg)
+		}
+		return fmt.Errorf("loon FFI error: %s", errStr)
+	}
+	return nil
+}
+
+// GetFilesystemKeyFromStorageConfig extracts filesystem key from StorageConfig
+// Format: "address/bucketName" (e.g., "localhost:9000/a-bucket")
+// Returns empty string if address/bucketName not available
+func GetFilesystemKeyFromStorageConfig(storageConfig *indexpb.StorageConfig) string {
+	if storageConfig == nil {
+		return ""
+	}
+
+	address := storageConfig.GetAddress()
+	bucketName := storageConfig.GetBucketName()
+
+	if address == "" || bucketName == "" {
+		return ""
+	}
+
+	return fmt.Sprintf("%s/%s", address, bucketName)
+}
+
+// PublishDefaultFilesystemMetrics retrieves and publishes metrics from the default filesystem.
+// It builds a StorageConfig using the same logic as compaction.CreateStorageConfig() to ensure
+// the cache key matches the filesystem used by compaction and other components.
+func PublishDefaultFilesystemMetrics() (*FilesystemMetrics, error) {
+	// Build storage config matching compaction.CreateStorageConfig() logic
+	params := paramtable.Get()
+	var storageConfig *indexpb.StorageConfig
+
+	if params.CommonCfg.StorageType.GetValue() == "local" {
+		// For local storage, use LocalStorageCfg.Path as RootPath (same as compaction.CreateStorageConfig)
+		storageConfig = &indexpb.StorageConfig{
+			RootPath:    params.LocalStorageCfg.Path.GetValue(),
+			StorageType: params.CommonCfg.StorageType.GetValue(),
+		}
+	} else {
+		// For remote storage, use full MinioCfg (same as compaction.CreateStorageConfig)
+		storageConfig = &indexpb.StorageConfig{
+			Address:           params.MinioCfg.Address.GetValue(),
+			AccessKeyID:       params.MinioCfg.AccessKeyID.GetValue(),
+			SecretAccessKey:   params.MinioCfg.SecretAccessKey.GetValue(),
+			UseSSL:            params.MinioCfg.UseSSL.GetAsBool(),
+			SslCACert:         params.MinioCfg.SslCACert.GetValue(),
+			BucketName:        params.MinioCfg.BucketName.GetValue(),
+			RootPath:          params.MinioCfg.RootPath.GetValue(),
+			UseIAM:            params.MinioCfg.UseIAM.GetAsBool(),
+			IAMEndpoint:       params.MinioCfg.IAMEndpoint.GetValue(),
+			StorageType:       params.CommonCfg.StorageType.GetValue(),
+			Region:            params.MinioCfg.Region.GetValue(),
+			UseVirtualHost:    params.MinioCfg.UseVirtualHost.GetAsBool(),
+			CloudProvider:     params.MinioCfg.CloudProvider.GetValue(),
+			RequestTimeoutMs:  params.MinioCfg.RequestTimeoutMs.GetAsInt64(),
+			GcpCredentialJSON: params.MinioCfg.GcpCredentialJSON.GetValue(),
+		}
+	}
+	return PublishFilesystemMetricsWithConfig(storageConfig)
+}
+
+// PublishFilesystemMetricsWithConfig retrieves and publishes filesystem metrics using storage config.
+// This is the preferred method when you have a StorageConfig.
+func PublishFilesystemMetricsWithConfig(storageConfig *indexpb.StorageConfig) (*FilesystemMetrics, error) {
+	metricSnapshot, err := GetFilesystemMetricsWithConfig(storageConfig)
+	if err != nil {
+		log.Warn("failed to get filesystem metrics", zap.Error(err))
+		return nil, err
+	}
+	fsKey := GetFilesystemKeyFromStorageConfig(storageConfig)
+	metrics.PublishFilesystemMetrics(
+		fsKey,
+		metricSnapshot.ReadCount,
+		metricSnapshot.WriteCount,
+		metricSnapshot.ReadBytes,
+		metricSnapshot.WriteBytes,
+		metricSnapshot.GetFileInfoCount,
+		metricSnapshot.FailedCount,
+		metricSnapshot.MultiPartUploadCreated,
+		metricSnapshot.MultiPartUploadFinished,
+	)
+
+	return metricSnapshot, nil
+}
+
+// PublishFilesystemMetrics retrieves default filesystem metrics and filesystem key
+// If path is provided (format: "address/bucketName"), uses that filesystem; otherwise uses default
+// Returns metrics, filesystem key, and error
+// The caller should use the metrics package to publish these metrics with the fs key
+func PublishFilesystemMetrics(path string) (*FilesystemMetrics, error) {
+	metricSnapshot, err := GetFilesystemMetrics(path)
+	if err != nil {
+		log.Warn("failed to get filesystem metrics", zap.Error(err))
+		return nil, err
+	}
+
+	fsKey := path
+	if fsKey == "" {
+		fsKey = "default"
+	}
+	metrics.PublishFilesystemMetrics(
+		fsKey,
+		metricSnapshot.ReadCount,
+		metricSnapshot.WriteCount,
+		metricSnapshot.ReadBytes,
+		metricSnapshot.WriteBytes,
+		metricSnapshot.GetFileInfoCount,
+		metricSnapshot.FailedCount,
+		metricSnapshot.MultiPartUploadCreated,
+		metricSnapshot.MultiPartUploadFinished,
+	)
+
+	return metricSnapshot, nil
+}

--- a/internal/storagev2/filesystem_metrics_test.go
+++ b/internal/storagev2/filesystem_metrics_test.go
@@ -1,0 +1,200 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storagev2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus/internal/util/initcore"
+	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+)
+
+func TestGetFilesystemKeyFromStorageConfig(t *testing.T) {
+	tests := []struct {
+		name          string
+		storageConfig *indexpb.StorageConfig
+		expected      string
+	}{
+		{
+			name:          "nil storage config",
+			storageConfig: nil,
+			expected:      "",
+		},
+		{
+			name: "valid address and bucket",
+			storageConfig: &indexpb.StorageConfig{
+				Address:    "localhost:9000",
+				BucketName: "test-bucket",
+			},
+			expected: "localhost:9000/test-bucket",
+		},
+		{
+			name: "empty address",
+			storageConfig: &indexpb.StorageConfig{
+				Address:    "",
+				BucketName: "test-bucket",
+			},
+			expected: "",
+		},
+		{
+			name: "empty bucket name",
+			storageConfig: &indexpb.StorageConfig{
+				Address:    "localhost:9000",
+				BucketName: "",
+			},
+			expected: "",
+		},
+		{
+			name: "both empty",
+			storageConfig: &indexpb.StorageConfig{
+				Address:    "",
+				BucketName: "",
+			},
+			expected: "",
+		},
+		{
+			name: "S3 endpoint format",
+			storageConfig: &indexpb.StorageConfig{
+				Address:    "s3.amazonaws.com",
+				BucketName: "my-bucket",
+			},
+			expected: "s3.amazonaws.com/my-bucket",
+		},
+		{
+			name: "IP address format",
+			storageConfig: &indexpb.StorageConfig{
+				Address:    "192.168.1.100:9000",
+				BucketName: "data-bucket",
+			},
+			expected: "192.168.1.100:9000/data-bucket",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetFilesystemKeyFromStorageConfig(tt.storageConfig)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetFilesystemKeyFromStorageConfigWithOtherFields(t *testing.T) {
+	// Test that other fields in StorageConfig don't affect the result
+	storageConfig := &indexpb.StorageConfig{
+		Address:           "localhost:9000",
+		BucketName:        "test-bucket",
+		AccessKeyID:       "access-key",
+		SecretAccessKey:   "secret-key",
+		UseSSL:            true,
+		RootPath:          "/root/path",
+		UseIAM:            false,
+		IAMEndpoint:       "iam-endpoint",
+		StorageType:       "s3",
+		UseVirtualHost:    true,
+		Region:            "us-east-1",
+		CloudProvider:     "aws",
+		RequestTimeoutMs:  30000,
+		SslCACert:         "cert",
+		GcpCredentialJSON: "json",
+		MaxConnections:    10,
+	}
+
+	result := GetFilesystemKeyFromStorageConfig(storageConfig)
+	assert.Equal(t, "localhost:9000/test-bucket", result)
+}
+
+// TestGetFilesystemMetricsDefault tests GetFilesystemMetrics with empty path (default filesystem)
+func TestGetFilesystemMetricsDefault(t *testing.T) {
+	// Set up local storage for testing
+	dir := t.TempDir()
+	pt := paramtable.Get()
+	pt.Save(pt.CommonCfg.StorageType.Key, "local")
+	pt.Save(pt.LocalStorageCfg.Path.Key, dir)
+
+	t.Cleanup(func() {
+		pt.Reset(pt.CommonCfg.StorageType.Key)
+		pt.Reset(pt.LocalStorageCfg.Path.Key)
+	})
+
+	// Initialize local arrow filesystem
+	err := initcore.InitLocalArrowFileSystem(dir)
+	require.NoError(t, err, "Failed to initialize local arrow filesystem")
+
+	// Test getting metrics from default filesystem (empty path)
+	metrics, err := GetFilesystemMetrics("")
+	if err != nil {
+		// If CGO libraries aren't available, skip the test
+		t.Skipf("Skipping CGO test: %v", err)
+		return
+	}
+
+	// Verify metrics struct is not nil
+	require.NotNil(t, metrics, "Metrics should not be nil")
+
+	// Verify all 8 metrics fields are present (values may be 0 or positive)
+	assert.GreaterOrEqual(t, metrics.ReadCount, int64(0))
+	assert.GreaterOrEqual(t, metrics.WriteCount, int64(0))
+	assert.GreaterOrEqual(t, metrics.ReadBytes, int64(0))
+	assert.GreaterOrEqual(t, metrics.WriteBytes, int64(0))
+	assert.GreaterOrEqual(t, metrics.GetFileInfoCount, int64(0))
+	assert.GreaterOrEqual(t, metrics.FailedCount, int64(0))
+	assert.GreaterOrEqual(t, metrics.MultiPartUploadCreated, int64(0))
+	assert.GreaterOrEqual(t, metrics.MultiPartUploadFinished, int64(0))
+}
+
+// TestPublishFilesystemMetrics tests PublishFilesystemMetrics function
+func TestPublishFilesystemMetrics(t *testing.T) {
+	// Set up local storage for testing
+	dir := t.TempDir()
+	pt := paramtable.Get()
+	pt.Save(pt.CommonCfg.StorageType.Key, "local")
+	pt.Save(pt.LocalStorageCfg.Path.Key, dir)
+
+	t.Cleanup(func() {
+		pt.Reset(pt.CommonCfg.StorageType.Key)
+		pt.Reset(pt.LocalStorageCfg.Path.Key)
+	})
+
+	// Initialize local arrow filesystem
+	err := initcore.InitLocalArrowFileSystem(dir)
+	require.NoError(t, err, "Failed to initialize local arrow filesystem")
+
+	// Test with empty path (default filesystem)
+	metrics, err := PublishFilesystemMetrics("")
+	if err != nil {
+		// If CGO libraries aren't available, skip the test
+		t.Skipf("Skipping CGO test: %v", err)
+		return
+	}
+
+	// Verify metrics struct is not nil
+	require.NotNil(t, metrics, "Metrics should not be nil")
+
+	// Verify all 8 metrics fields are present
+	assert.GreaterOrEqual(t, metrics.ReadCount, int64(0))
+	assert.GreaterOrEqual(t, metrics.WriteCount, int64(0))
+	assert.GreaterOrEqual(t, metrics.ReadBytes, int64(0))
+	assert.GreaterOrEqual(t, metrics.WriteBytes, int64(0))
+	assert.GreaterOrEqual(t, metrics.GetFileInfoCount, int64(0))
+	assert.GreaterOrEqual(t, metrics.FailedCount, int64(0))
+	assert.GreaterOrEqual(t, metrics.MultiPartUploadCreated, int64(0))
+	assert.GreaterOrEqual(t, metrics.MultiPartUploadFinished, int64(0))
+}

--- a/internal/storagev2/filesystem_metrics_test.go
+++ b/internal/storagev2/filesystem_metrics_test.go
@@ -39,50 +39,72 @@ func TestGetFilesystemKeyFromStorageConfig(t *testing.T) {
 			expected:      "",
 		},
 		{
-			name: "valid address and bucket",
+			name: "local storage with root path",
 			storageConfig: &indexpb.StorageConfig{
-				Address:    "localhost:9000",
-				BucketName: "test-bucket",
+				StorageType: "local",
+				RootPath:    "/var/lib/milvus/data",
+			},
+			expected: "/var/lib/milvus/data",
+		},
+		{
+			name: "local storage with empty root path",
+			storageConfig: &indexpb.StorageConfig{
+				StorageType: "local",
+				RootPath:    "",
+			},
+			expected: "",
+		},
+		{
+			name: "minio storage valid address and bucket",
+			storageConfig: &indexpb.StorageConfig{
+				StorageType: "minio",
+				Address:     "localhost:9000",
+				BucketName:  "test-bucket",
 			},
 			expected: "localhost:9000/test-bucket",
 		},
 		{
-			name: "empty address",
+			name: "minio storage empty address",
 			storageConfig: &indexpb.StorageConfig{
-				Address:    "",
-				BucketName: "test-bucket",
+				StorageType: "minio",
+				Address:     "",
+				BucketName:  "test-bucket",
 			},
 			expected: "",
 		},
 		{
-			name: "empty bucket name",
+			name: "minio storage empty bucket name",
 			storageConfig: &indexpb.StorageConfig{
-				Address:    "localhost:9000",
-				BucketName: "",
+				StorageType: "minio",
+				Address:     "localhost:9000",
+				BucketName:  "",
 			},
 			expected: "",
 		},
 		{
-			name: "both empty",
+			name: "minio storage both empty",
 			storageConfig: &indexpb.StorageConfig{
-				Address:    "",
-				BucketName: "",
+				StorageType: "minio",
+				Address:     "",
+				BucketName:  "",
 			},
 			expected: "",
 		},
 		{
 			name: "S3 endpoint format",
 			storageConfig: &indexpb.StorageConfig{
-				Address:    "s3.amazonaws.com",
-				BucketName: "my-bucket",
+				StorageType: "s3",
+				Address:     "s3.amazonaws.com",
+				BucketName:  "my-bucket",
 			},
 			expected: "s3.amazonaws.com/my-bucket",
 		},
 		{
-			name: "IP address format",
+			name: "minio with IP address",
 			storageConfig: &indexpb.StorageConfig{
-				Address:    "192.168.1.100:9000",
-				BucketName: "data-bucket",
+				StorageType: "minio",
+				Address:     "192.168.1.100:9000",
+				BucketName:  "data-bucket",
 			},
 			expected: "192.168.1.100:9000/data-bucket",
 		},
@@ -97,7 +119,7 @@ func TestGetFilesystemKeyFromStorageConfig(t *testing.T) {
 }
 
 func TestGetFilesystemKeyFromStorageConfigWithOtherFields(t *testing.T) {
-	// Test that other fields in StorageConfig don't affect the result
+	// Test that other fields in StorageConfig don't affect the result for object storage
 	storageConfig := &indexpb.StorageConfig{
 		Address:           "localhost:9000",
 		BucketName:        "test-bucket",
@@ -119,10 +141,33 @@ func TestGetFilesystemKeyFromStorageConfigWithOtherFields(t *testing.T) {
 
 	result := GetFilesystemKeyFromStorageConfig(storageConfig)
 	assert.Equal(t, "localhost:9000/test-bucket", result)
+
+	// Test that other fields don't affect the result for local storage
+	localConfig := &indexpb.StorageConfig{
+		Address:           "localhost:9000", // Should be ignored for local
+		BucketName:        "test-bucket",    // Should be ignored for local
+		AccessKeyID:       "access-key",
+		SecretAccessKey:   "secret-key",
+		UseSSL:            true,
+		RootPath:          "/var/lib/milvus/data",
+		UseIAM:            false,
+		IAMEndpoint:       "iam-endpoint",
+		StorageType:       "local",
+		UseVirtualHost:    true,
+		Region:            "us-east-1",
+		CloudProvider:     "aws",
+		RequestTimeoutMs:  30000,
+		SslCACert:         "cert",
+		GcpCredentialJSON: "json",
+		MaxConnections:    10,
+	}
+
+	result = GetFilesystemKeyFromStorageConfig(localConfig)
+	assert.Equal(t, "/var/lib/milvus/data", result)
 }
 
-// TestGetFilesystemMetricsDefault tests GetFilesystemMetrics with empty path (default filesystem)
-func TestGetFilesystemMetricsDefault(t *testing.T) {
+// TestGetCachedFilesystemMetricsDefault tests GetCachedFilesystemMetrics with empty key (default filesystem)
+func TestGetCachedFilesystemMetricsDefault(t *testing.T) {
 	// Set up local storage for testing
 	dir := t.TempDir()
 	pt := paramtable.Get()
@@ -138,8 +183,8 @@ func TestGetFilesystemMetricsDefault(t *testing.T) {
 	err := initcore.InitLocalArrowFileSystem(dir)
 	require.NoError(t, err, "Failed to initialize local arrow filesystem")
 
-	// Test getting metrics from default filesystem (empty path)
-	metrics, err := GetFilesystemMetrics("")
+	// Test getting metrics from default filesystem (empty key)
+	metrics, err := GetCachedFilesystemMetrics("")
 	if err != nil {
 		// If CGO libraries aren't available, skip the test
 		t.Skipf("Skipping CGO test: %v", err)
@@ -160,8 +205,8 @@ func TestGetFilesystemMetricsDefault(t *testing.T) {
 	assert.GreaterOrEqual(t, metrics.MultiPartUploadFinished, int64(0))
 }
 
-// TestPublishFilesystemMetrics tests PublishFilesystemMetrics function
-func TestPublishFilesystemMetrics(t *testing.T) {
+// TestPublishCachedFilesystemMetrics tests PublishCachedFilesystemMetrics function
+func TestPublishCachedFilesystemMetrics(t *testing.T) {
 	// Set up local storage for testing
 	dir := t.TempDir()
 	pt := paramtable.Get()
@@ -177,8 +222,8 @@ func TestPublishFilesystemMetrics(t *testing.T) {
 	err := initcore.InitLocalArrowFileSystem(dir)
 	require.NoError(t, err, "Failed to initialize local arrow filesystem")
 
-	// Test with empty path (default filesystem)
-	metrics, err := PublishFilesystemMetrics("")
+	// Test with empty key (default filesystem)
+	metrics, err := PublishCachedFilesystemMetrics("")
 	if err != nil {
 		// If CGO libraries aren't available, skip the test
 		t.Skipf("Skipping CGO test: %v", err)
@@ -197,4 +242,178 @@ func TestPublishFilesystemMetrics(t *testing.T) {
 	assert.GreaterOrEqual(t, metrics.FailedCount, int64(0))
 	assert.GreaterOrEqual(t, metrics.MultiPartUploadCreated, int64(0))
 	assert.GreaterOrEqual(t, metrics.MultiPartUploadFinished, int64(0))
+}
+
+// TestPublishFilesystemMetricsWithConfig tests PublishFilesystemMetricsWithConfig function
+func TestPublishFilesystemMetricsWithConfig(t *testing.T) {
+	// Set up local storage for testing
+	dir := t.TempDir()
+	pt := paramtable.Get()
+	pt.Save(pt.CommonCfg.StorageType.Key, "local")
+	pt.Save(pt.LocalStorageCfg.Path.Key, dir)
+
+	t.Cleanup(func() {
+		pt.Reset(pt.CommonCfg.StorageType.Key)
+		pt.Reset(pt.LocalStorageCfg.Path.Key)
+	})
+
+	// Initialize local arrow filesystem
+	err := initcore.InitLocalArrowFileSystem(dir)
+	require.NoError(t, err, "Failed to initialize local arrow filesystem")
+
+	// Test with local storage config
+	localConfig := &indexpb.StorageConfig{
+		StorageType: "local",
+		RootPath:    dir,
+	}
+
+	metrics, err := PublishFilesystemMetricsWithConfig(localConfig)
+	assert.NoError(t, err)
+
+	// Verify metrics struct is not nil
+	require.NotNil(t, metrics, "Metrics should not be nil")
+
+	// Verify all 8 metrics fields are present
+	assert.GreaterOrEqual(t, metrics.ReadCount, int64(0))
+	assert.GreaterOrEqual(t, metrics.WriteCount, int64(0))
+	assert.GreaterOrEqual(t, metrics.ReadBytes, int64(0))
+	assert.GreaterOrEqual(t, metrics.WriteBytes, int64(0))
+	assert.GreaterOrEqual(t, metrics.GetFileInfoCount, int64(0))
+	assert.GreaterOrEqual(t, metrics.FailedCount, int64(0))
+	assert.GreaterOrEqual(t, metrics.MultiPartUploadCreated, int64(0))
+	assert.GreaterOrEqual(t, metrics.MultiPartUploadFinished, int64(0))
+}
+
+// TestPublishFilesystemMetricsWithNilConfig tests PublishFilesystemMetricsWithConfig with nil config
+func TestPublishFilesystemMetricsWithNilConfig(t *testing.T) {
+	// Set up local storage for testing
+	dir := t.TempDir()
+	pt := paramtable.Get()
+	pt.Save(pt.CommonCfg.StorageType.Key, "local")
+	pt.Save(pt.LocalStorageCfg.Path.Key, dir)
+
+	t.Cleanup(func() {
+		pt.Reset(pt.CommonCfg.StorageType.Key)
+		pt.Reset(pt.LocalStorageCfg.Path.Key)
+	})
+
+	// Initialize local arrow filesystem
+	err := initcore.InitLocalArrowFileSystem(dir)
+	require.NoError(t, err, "Failed to initialize local arrow filesystem")
+
+	// Test with nil config - should use empty key (default filesystem)
+	metrics, err := PublishFilesystemMetricsWithConfig(nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, metrics, "Metrics should not be nil")
+}
+
+// TestPublishDefaultFilesystemMetrics tests PublishDefaultFilesystemMetrics function
+func TestPublishDefaultFilesystemMetrics(t *testing.T) {
+	// Set up local storage for testing
+	dir := t.TempDir()
+	pt := paramtable.Get()
+	pt.Save(pt.CommonCfg.StorageType.Key, "local")
+	pt.Save(pt.LocalStorageCfg.Path.Key, dir)
+
+	t.Cleanup(func() {
+		pt.Reset(pt.CommonCfg.StorageType.Key)
+		pt.Reset(pt.LocalStorageCfg.Path.Key)
+	})
+
+	// Initialize local arrow filesystem
+	err := initcore.InitLocalArrowFileSystem(dir)
+	require.NoError(t, err, "Failed to initialize local arrow filesystem")
+
+	// Test PublishDefaultFilesystemMetrics
+	metrics, err := PublishDefaultFilesystemMetrics()
+	assert.NoError(t, err)
+	assert.NotNil(t, metrics, "Metrics should not be nil")
+}
+
+// TestGetCachedFilesystemMetricsWithInvalidKey tests error handling for non-existent cache key
+func TestInvalidKey(t *testing.T) {
+	// Set up local storage for testing
+	dir := t.TempDir()
+	pt := paramtable.Get()
+	pt.Save(pt.CommonCfg.StorageType.Key, "local")
+	pt.Save(pt.LocalStorageCfg.Path.Key, dir)
+
+	t.Cleanup(func() {
+		pt.Reset(pt.CommonCfg.StorageType.Key)
+		pt.Reset(pt.LocalStorageCfg.Path.Key)
+	})
+
+	// Initialize local arrow filesystem
+	err := initcore.InitLocalArrowFileSystem(dir)
+	require.NoError(t, err, "Failed to initialize local arrow filesystem")
+
+	// Test with a key that doesn't exist in cache
+	// FIXME: FilesystemCache::get from milvus-storage will return default filesystem if the key is not in cache and path is schemeless.
+	_, err = GetCachedFilesystemMetrics("s3://non-existent-key")
+	assert.Error(t, err)
+
+	_, err = PublishCachedFilesystemMetrics("s3://non-existent-key")
+	assert.Error(t, err)
+}
+
+// TestGetFilesystemKeyFromStorageConfigEdgeCases tests edge cases for key generation
+func TestGetFilesystemKeyFromStorageConfigEdgeCases(t *testing.T) {
+	tests := []struct {
+		name          string
+		storageConfig *indexpb.StorageConfig
+		expected      string
+	}{
+		{
+			name: "empty storage type defaults to object storage logic",
+			storageConfig: &indexpb.StorageConfig{
+				StorageType: "",
+				Address:     "localhost:9000",
+				BucketName:  "bucket",
+			},
+			expected: "localhost:9000/bucket",
+		},
+		{
+			name: "unknown storage type uses object storage logic",
+			storageConfig: &indexpb.StorageConfig{
+				StorageType: "unknown",
+				Address:     "localhost:9000",
+				BucketName:  "bucket",
+			},
+			expected: "localhost:9000/bucket",
+		},
+		{
+			name: "azure storage type",
+			storageConfig: &indexpb.StorageConfig{
+				StorageType: "azure",
+				Address:     "account.blob.core.windows.net",
+				BucketName:  "container",
+			},
+			expected: "account.blob.core.windows.net/container",
+		},
+		{
+			name: "gcp storage type",
+			storageConfig: &indexpb.StorageConfig{
+				StorageType: "gcp",
+				Address:     "storage.googleapis.com",
+				BucketName:  "my-gcp-bucket",
+			},
+			expected: "storage.googleapis.com/my-gcp-bucket",
+		},
+		{
+			name: "address with special characters",
+			storageConfig: &indexpb.StorageConfig{
+				StorageType: "minio",
+				Address:     "minio-service.namespace.svc.cluster.local:9000",
+				BucketName:  "bucket-name-with-dashes",
+			},
+			expected: "minio-service.namespace.svc.cluster.local:9000/bucket-name-with-dashes",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetFilesystemKeyFromStorageConfig(tt.storageConfig)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
 }

--- a/internal/storagev2/packed/ffi_common.go
+++ b/internal/storagev2/packed/ffi_common.go
@@ -95,9 +95,8 @@ func MakePropertiesFromStorageConfig(storageConfig *indexpb.StorageConfig, extra
 		keys = append(keys, PropertyFSIAMEndpoint)
 		values = append(values, storageConfig.GetIAMEndpoint())
 	}
-	// Always add log level if any string field is set (matching C++ behavior)
 	keys = append(keys, PropertyFSLogLevel)
-	values = append(values, "Warn")
+	values = append(values, "warn")
 
 	if storageConfig.GetRegion() != "" {
 		keys = append(keys, PropertyFSRegion)

--- a/internal/storagev2/packed/packed_reader_ffi.go
+++ b/internal/storagev2/packed/packed_reader_ffi.go
@@ -74,7 +74,7 @@ func NewFFIPackedReader(manifestPath string, schema *arrow.Schema, neededColumns
 			storage_type:           C.CString(storageConfig.GetStorageType()),
 			cloud_provider:         C.CString(storageConfig.GetCloudProvider()),
 			iam_endpoint:           C.CString(storageConfig.GetIAMEndpoint()),
-			log_level:              C.CString("Warn"), // TODO use config after storage support lower case configuration
+			log_level:              C.CString("warn"),
 			useSSL:                 C.bool(storageConfig.GetUseSSL()),
 			sslCACert:              C.CString(storageConfig.GetSslCACert()),
 			useIAM:                 C.bool(storageConfig.GetUseIAM()),

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -142,6 +142,8 @@ const (
 
 	TaskTypeLabel  = "task_type"
 	TaskStateLabel = "task_state"
+
+	filesystemKeyLabelName = "fs"
 )
 
 var (

--- a/pkg/metrics/persistent_store_metrics.go
+++ b/pkg/metrics/persistent_store_metrics.go
@@ -16,7 +16,9 @@
 
 package metrics
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
 
 const (
 	DataGetLabel    = "get"
@@ -54,6 +56,87 @@ var (
 			Name:      "op_count",
 			Help:      "count of persistent data operation",
 		}, []string{persistentDataOpType, statusLabelName})
+
+	// Filesystem metrics (default filesystem only) - common across all nodes
+	FilesystemReadCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: milvusNamespace,
+			Subsystem: "storage",
+			Name:      "filesystem_read_count",
+			Help:      "number of filesystem read operations",
+		}, []string{
+			filesystemKeyLabelName,
+		})
+
+	FilesystemWriteCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: milvusNamespace,
+			Subsystem: "storage",
+			Name:      "filesystem_write_count",
+			Help:      "number of filesystem write operations",
+		}, []string{
+			filesystemKeyLabelName,
+		})
+
+	FilesystemReadBytes = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: milvusNamespace,
+			Subsystem: "storage",
+			Name:      "filesystem_read_bytes",
+			Help:      "total bytes read from filesystem",
+		}, []string{
+			filesystemKeyLabelName,
+		})
+
+	FilesystemWriteBytes = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: milvusNamespace,
+			Subsystem: "storage",
+			Name:      "filesystem_write_bytes",
+			Help:      "total bytes written to filesystem",
+		}, []string{
+			filesystemKeyLabelName,
+		})
+
+	FilesystemGetFileInfoCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: milvusNamespace,
+			Subsystem: "storage",
+			Name:      "filesystem_get_file_info_count",
+			Help:      "number of get file info operations",
+		}, []string{
+			filesystemKeyLabelName,
+		})
+
+	FilesystemFailedCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: milvusNamespace,
+			Subsystem: "storage",
+			Name:      "filesystem_failed_count",
+			Help:      "number of failed filesystem operations",
+		}, []string{
+			filesystemKeyLabelName,
+		})
+
+	FilesystemMultiPartUploadCreated = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: milvusNamespace,
+			Subsystem: "storage",
+			Name:      "filesystem_multi_part_upload_created",
+			Help:      "number of multi-part uploads created",
+		}, []string{
+			filesystemKeyLabelName,
+		})
+
+	FilesystemMultiPartUploadFinished = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: milvusNamespace,
+			Subsystem: "storage",
+			Name:      "filesystem_multi_part_upload_finished",
+			Help:      "number of multi-part uploads finished",
+		}, []string{
+			filesystemKeyLabelName,
+		})
 )
 
 // RegisterStorageMetrics registers storage metrics
@@ -61,4 +144,30 @@ func RegisterStorageMetrics(registry *prometheus.Registry) {
 	registry.MustRegister(PersistentDataKvSize)
 	registry.MustRegister(PersistentDataRequestLatency)
 	registry.MustRegister(PersistentDataOpCounter)
+
+	// filesystem metrics
+	registry.MustRegister(FilesystemReadCount)
+	registry.MustRegister(FilesystemWriteCount)
+	registry.MustRegister(FilesystemReadBytes)
+	registry.MustRegister(FilesystemWriteBytes)
+	registry.MustRegister(FilesystemGetFileInfoCount)
+	registry.MustRegister(FilesystemFailedCount)
+	registry.MustRegister(FilesystemMultiPartUploadCreated)
+	registry.MustRegister(FilesystemMultiPartUploadFinished)
+}
+
+// PublishFilesystemMetrics publishes filesystem metrics (common across all nodes)
+func PublishFilesystemMetrics(fs string, readCount, writeCount, readBytes, writeBytes, getFileInfoCount, failedCount, multiPartUploadCreated, multiPartUploadFinished int64) {
+	labels := prometheus.Labels{
+		filesystemKeyLabelName: fs,
+	}
+
+	FilesystemReadCount.With(labels).Set(float64(readCount))
+	FilesystemWriteCount.With(labels).Set(float64(writeCount))
+	FilesystemReadBytes.With(labels).Set(float64(readBytes))
+	FilesystemWriteBytes.With(labels).Set(float64(writeBytes))
+	FilesystemGetFileInfoCount.With(labels).Set(float64(getFileInfoCount))
+	FilesystemFailedCount.With(labels).Set(float64(failedCount))
+	FilesystemMultiPartUploadCreated.With(labels).Set(float64(multiPartUploadCreated))
+	FilesystemMultiPartUploadFinished.With(labels).Set(float64(multiPartUploadFinished))
 }

--- a/pkg/metrics/persistent_store_metrics_test.go
+++ b/pkg/metrics/persistent_store_metrics_test.go
@@ -1,0 +1,117 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPublishFilesystemMetrics(t *testing.T) {
+	// Test values
+	fsName := "test-filesystem"
+	readCount := int64(100)
+	writeCount := int64(50)
+	readBytes := int64(1024000)
+	writeBytes := int64(512000)
+	getFileInfoCount := int64(200)
+	failedCount := int64(5)
+	multiPartUploadCreated := int64(10)
+	multiPartUploadFinished := int64(8)
+
+	// Call the function
+	PublishFilesystemMetrics(fsName, readCount, writeCount, readBytes, writeBytes,
+		getFileInfoCount, failedCount, multiPartUploadCreated, multiPartUploadFinished)
+
+	// Verify each metric
+	labels := prometheus.Labels{filesystemKeyLabelName: fsName}
+
+	// Check FilesystemReadCount
+	readCountMetric := FilesystemReadCount.With(labels)
+	assert.NotNil(t, readCountMetric)
+
+	// Check FilesystemWriteCount
+	writeCountMetric := FilesystemWriteCount.With(labels)
+	assert.NotNil(t, writeCountMetric)
+
+	// Check FilesystemReadBytes
+	readBytesMetric := FilesystemReadBytes.With(labels)
+	assert.NotNil(t, readBytesMetric)
+
+	// Check FilesystemWriteBytes
+	writeBytesMetric := FilesystemWriteBytes.With(labels)
+	assert.NotNil(t, writeBytesMetric)
+
+	// Check FilesystemGetFileInfoCount
+	getFileInfoMetric := FilesystemGetFileInfoCount.With(labels)
+	assert.NotNil(t, getFileInfoMetric)
+
+	// Check FilesystemFailedCount
+	failedMetric := FilesystemFailedCount.With(labels)
+	assert.NotNil(t, failedMetric)
+
+	// Check FilesystemMultiPartUploadCreated
+	multiPartCreatedMetric := FilesystemMultiPartUploadCreated.With(labels)
+	assert.NotNil(t, multiPartCreatedMetric)
+
+	// Check FilesystemMultiPartUploadFinished
+	multiPartFinishedMetric := FilesystemMultiPartUploadFinished.With(labels)
+	assert.NotNil(t, multiPartFinishedMetric)
+}
+
+func TestPublishFilesystemMetricsMultipleFilesystems(t *testing.T) {
+	// Test with multiple filesystem names to ensure labels work correctly
+	fs1 := "minio"
+	fs2 := "s3"
+
+	// Publish metrics for first filesystem
+	PublishFilesystemMetrics(fs1, 100, 50, 1000, 500, 10, 1, 5, 3)
+
+	// Publish metrics for second filesystem
+	PublishFilesystemMetrics(fs2, 200, 100, 2000, 1000, 20, 2, 10, 6)
+
+	// Verify both filesystems have their own metric values
+	labels1 := prometheus.Labels{filesystemKeyLabelName: fs1}
+	labels2 := prometheus.Labels{filesystemKeyLabelName: fs2}
+
+	// Both should be non-nil and independently tracked
+	assert.NotNil(t, FilesystemReadCount.With(labels1))
+	assert.NotNil(t, FilesystemReadCount.With(labels2))
+	assert.NotNil(t, FilesystemWriteCount.With(labels1))
+	assert.NotNil(t, FilesystemWriteCount.With(labels2))
+}
+
+func TestPublishFilesystemMetricsZeroValues(t *testing.T) {
+	// Test with zero values to ensure no issues with edge cases
+	fsName := "empty-filesystem"
+
+	PublishFilesystemMetrics(fsName, 0, 0, 0, 0, 0, 0, 0, 0)
+
+	labels := prometheus.Labels{filesystemKeyLabelName: fsName}
+
+	// All metrics should still be created with zero values
+	assert.NotNil(t, FilesystemReadCount.With(labels))
+	assert.NotNil(t, FilesystemWriteCount.With(labels))
+	assert.NotNil(t, FilesystemReadBytes.With(labels))
+	assert.NotNil(t, FilesystemWriteBytes.With(labels))
+	assert.NotNil(t, FilesystemGetFileInfoCount.With(labels))
+	assert.NotNil(t, FilesystemFailedCount.With(labels))
+	assert.NotNil(t, FilesystemMultiPartUploadCreated.With(labels))
+	assert.NotNil(t, FilesystemMultiPartUploadFinished.With(labels))
+}

--- a/tests/integration/compaction/mix_compaction_test.go
+++ b/tests/integration/compaction/mix_compaction_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
-	"github.com/milvus-io/milvus/internal/storagev2"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
@@ -265,11 +264,5 @@ func (s *CompactionSuite) TestMixCompactionV2() {
 	defer cancel()
 
 	collectionName := "TestCompaction_" + funcutil.GenRandomStr()
-	beforeMetrics, err := storagev2.PublishDefaultFilesystemMetrics()
-	s.NoError(err)
 	s.assertMixCompaction(ctx, collectionName, true)
-	afterMetrics, err := storagev2.PublishDefaultFilesystemMetrics()
-	s.NoError(err)
-	s.Greater(afterMetrics.ReadBytes, beforeMetrics.ReadBytes, "read bytes should increase")
-	s.Greater(afterMetrics.WriteBytes, beforeMetrics.WriteBytes, "write bytes should increase")
 }

--- a/tests/integration/compaction/mix_compaction_test.go
+++ b/tests/integration/compaction/mix_compaction_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/storagev2"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
@@ -264,5 +265,11 @@ func (s *CompactionSuite) TestMixCompactionV2() {
 	defer cancel()
 
 	collectionName := "TestCompaction_" + funcutil.GenRandomStr()
+	beforeMetrics, err := storagev2.PublishDefaultFilesystemMetrics()
+	s.NoError(err)
 	s.assertMixCompaction(ctx, collectionName, true)
+	afterMetrics, err := storagev2.PublishDefaultFilesystemMetrics()
+	s.NoError(err)
+	s.Greater(afterMetrics.ReadBytes, beforeMetrics.ReadBytes, "read bytes should increase")
+	s.Greater(afterMetrics.WriteBytes, beforeMetrics.WriteBytes, "write bytes should increase")
 }


### PR DESCRIPTION
See #47520

This update refactors the StorageV2FSCache to convert the Key structure into api::Properties, allowing for a unified filesystem cache that integrates metrics tracking. The changes improve the management of filesystem instances and enhance logging for filesystem retrieval operations. Additionally, new filesystem metrics are introduced to monitor read/write operations and other relevant statistics.

- Converted Key to api::Properties in StorageV2FSCache::Get
- Introduced metrics for filesystem operations