### PR TITLE
fix: Use actual data timestamps for imported segment positions

### DIFF
--- a/internal/datacoord/import_task_import_test.go
+++ b/internal/datacoord/import_task_import_test.go
@@ -413,8 +413,17 @@ func TestImportTask_QueryTaskOnWorker(t *testing.T) {
 		catalog.EXPECT().ListPreImportTasks(mock.Anything).Return(nil, nil)
 		catalog.EXPECT().ListImportTasks(mock.Anything).Return(nil, nil)
 		catalog.EXPECT().SaveImportTask(mock.Anything, mock.Anything).Return(nil)
+		catalog.EXPECT().SaveImportJob(mock.Anything, mock.Anything).Return(nil)
 
 		im, err := NewImportMeta(context.TODO(), catalog, nil, nil)
+		assert.NoError(t, err)
+
+		var job ImportJob = &importJob{
+			ImportJob: &datapb.ImportJob{
+				JobID: 1,
+			},
+		}
+		err = im.AddJob(context.TODO(), job)
 		assert.NoError(t, err)
 
 		taskProto := &datapb.ImportTaskV2{

--- a/internal/datacoord/import_util.go
+++ b/internal/datacoord/import_util.go
@@ -246,11 +246,6 @@ func AllocImportSegment(ctx context.Context,
 			return nil, err
 		}
 	}
-	position := &msgpb.MsgPosition{
-		ChannelName: channelName,
-		MsgID:       nil,
-		Timestamp:   ts,
-	}
 
 	segmentInfo := &datapb.SegmentInfo{
 		ID:             id,
@@ -262,8 +257,6 @@ func AllocImportSegment(ctx context.Context,
 		MaxRowNum:      0,
 		Level:          level,
 		LastExpireTime: math.MaxUint64,
-		StartPosition:  position,
-		DmlPosition:    position,
 		StorageVersion: storageVersion,
 	}
 	segmentInfo.IsImporting = true

--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -1262,6 +1262,35 @@ func UpdateIsImporting(segmentID int64, isImporting bool) UpdateOperator {
 	}
 }
 
+// UpdateImportSegmentPosition updates the segment's StartPosition and DmlPosition
+// for import segments using actual timestamps from the imported data.
+// Unlike UpdateStartPosition/UpdateDmlPosition, this operator allows nil MsgID
+// since import segments don't have message queue positions.
+func UpdateImportSegmentPosition(segmentID int64, minTs, maxTs uint64) UpdateOperator {
+	return func(modPack *updateSegmentPack) bool {
+		segment := modPack.Get(segmentID)
+		if segment == nil {
+			log.Ctx(context.TODO()).Warn("meta update: update import segment position failed - segment not found",
+				zap.Int64("segmentID", segmentID))
+			return false
+		}
+		channelName := segment.GetInsertChannel()
+		// Use actual min timestamp for StartPosition
+		segment.StartPosition = &msgpb.MsgPosition{
+			ChannelName: channelName,
+			MsgID:       nil,
+			Timestamp:   minTs,
+		}
+		// Use actual max timestamp for DmlPosition
+		segment.DmlPosition = &msgpb.MsgPosition{
+			ChannelName: channelName,
+			MsgID:       nil,
+			Timestamp:   maxTs,
+		}
+		return true
+	}
+}
+
 // UpdateAsDroppedIfEmptyWhenFlushing updates segment state to Dropped if segment is empty and in Flushing state
 // It's used to make a empty flushing segment to be dropped directly.
 func UpdateAsDroppedIfEmptyWhenFlushing(segmentID int64) UpdateOperator {

--- a/internal/datacoord/segment_operator_test.go
+++ b/internal/datacoord/segment_operator_test.go
@@ -19,6 +19,7 @@ package datacoord
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
@@ -46,4 +47,70 @@ func (s *TestSegmentOperatorSuite) TestSetMaxRowCount() {
 
 func TestSegmentOperators(t *testing.T) {
 	suite.Run(t, new(TestSegmentOperatorSuite))
+}
+
+func TestUpdateImportSegmentPosition(t *testing.T) {
+	t.Run("segment not found", func(t *testing.T) {
+		// Create a meta with empty segments to properly test the "not found" case
+		segments := NewSegmentsInfo()
+		m := &meta{segments: segments}
+		modPack := &updateSegmentPack{
+			meta:     m,
+			segments: make(map[int64]*SegmentInfo),
+		}
+		op := UpdateImportSegmentPosition(100, 1000, 2000)
+		result := op(modPack)
+		assert.False(t, result)
+	})
+
+	t.Run("update position successfully", func(t *testing.T) {
+		segment := &SegmentInfo{
+			SegmentInfo: &datapb.SegmentInfo{
+				ID:            100,
+				InsertChannel: "test_channel",
+			},
+		}
+		modPack := &updateSegmentPack{
+			segments: map[int64]*SegmentInfo{
+				100: segment,
+			},
+		}
+		op := UpdateImportSegmentPosition(100, 1000, 2000)
+		result := op(modPack)
+		assert.True(t, result)
+
+		// Verify StartPosition
+		assert.NotNil(t, segment.GetStartPosition())
+		assert.Equal(t, "test_channel", segment.GetStartPosition().GetChannelName())
+		assert.Nil(t, segment.GetStartPosition().GetMsgID())
+		assert.Equal(t, uint64(1000), segment.GetStartPosition().GetTimestamp())
+
+		// Verify DmlPosition
+		assert.NotNil(t, segment.GetDmlPosition())
+		assert.Equal(t, "test_channel", segment.GetDmlPosition().GetChannelName())
+		assert.Nil(t, segment.GetDmlPosition().GetMsgID())
+		assert.Equal(t, uint64(2000), segment.GetDmlPosition().GetTimestamp())
+	})
+
+	t.Run("update position with zero timestamps", func(t *testing.T) {
+		segment := &SegmentInfo{
+			SegmentInfo: &datapb.SegmentInfo{
+				ID:            101,
+				InsertChannel: "channel_2",
+			},
+		}
+		modPack := &updateSegmentPack{
+			segments: map[int64]*SegmentInfo{
+				101: segment,
+			},
+		}
+		op := UpdateImportSegmentPosition(101, 0, 0)
+		result := op(modPack)
+		assert.True(t, result)
+
+		assert.NotNil(t, segment.GetStartPosition())
+		assert.Equal(t, uint64(0), segment.GetStartPosition().GetTimestamp())
+		assert.NotNil(t, segment.GetDmlPosition())
+		assert.Equal(t, uint64(0), segment.GetDmlPosition().GetTimestamp())
+	})
 }

--- a/internal/datanode/importv2/util.go
+++ b/internal/datanode/importv2/util.go
@@ -105,7 +105,6 @@ func NewSyncTask(ctx context.Context,
 		WithPartitionID(partitionID).
 		WithChannelName(vchannel).
 		WithSegmentID(segmentID).
-		WithTimeRange(ts, ts).
 		WithLevel(segmentLevel).
 		WithDataSource(metrics.BulkinsertDataSourceLabel).
 		WithBatchRows(int64(insertData.GetRowNum()))

--- a/internal/flushcommon/syncmgr/pack_writer_test.go
+++ b/internal/flushcommon/syncmgr/pack_writer_test.go
@@ -121,10 +121,12 @@ func TestBulkPackWriter_Write(t *testing.T) {
 				FieldID: 100,
 				Binlogs: []*datapb.Binlog{
 					{
-						EntriesNum: 10,
-						LogPath:    "files/delta_log/123/456/789/10000",
-						LogSize:    60,
-						MemorySize: 240,
+						EntriesNum:    10,
+						TimestampFrom: 100,
+						TimestampTo:   109,
+						LogPath:       "files/delta_log/123/456/789/10000",
+						LogSize:       60,
+						MemorySize:    240,
 					},
 				},
 			},


### PR DESCRIPTION
This PR:
1. Modifies the import mechanism to use actual timestamps from the imported data for segment positions instead of using the channel checkpoint.
2. Fix writeDelta() to extract actual min/max timestamps from deltaData.Tss instead of using pack.tsFrom/tsTo.
3. Integration test TestBinlogImport updated to verify L1 and L0 segment positions.

issue: https://github.com/milvus-io/milvus/issues/47275