### PR TITLE
enhance: refactor thread pool usage for better separation of concerns

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -475,12 +475,9 @@ ChunkedSegmentSealedImpl::load_field_data_internal(
                 DEFAULT_FIELD_MAX_MEMORY_LIMIT / FILE_SLICE_SIZE);
             field_data_info.arrow_reader_channel->set_capacity(parallel_degree *
                                                                2);
-            auto& pool =
-                ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::MIDDLE);
-            pool.Submit(LoadArrowReaderFromRemote,
-                        insert_files,
-                        field_data_info.arrow_reader_channel,
-                        load_info.load_priority);
+            LoadArrowReaderFromRemote(insert_files,
+                                      field_data_info.arrow_reader_channel,
+                                      load_info.load_priority);
 
             LOG_INFO("segment {} submits load field {} task to thread pool",
                      this->get_segment_id(),
@@ -3043,7 +3040,7 @@ ChunkedSegmentSealedImpl::LoadColumnGroups(
     std::vector<std::pair<int, std::vector<FieldId>>>& cg_field_ids,
     bool eager_load,
     milvus::OpContext* op_ctx) {
-    auto& pool = ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::LOW);
+    auto& pool = ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::MIDDLE);
     std::vector<std::future<void>> load_group_futures;
     for (const auto& pair : cg_field_ids) {
         auto cg_index = pair.first;
@@ -3070,25 +3067,7 @@ ChunkedSegmentSealedImpl::LoadColumnGroups(
         load_group_futures.emplace_back(std::move(future));
     }
 
-    std::vector<std::exception_ptr> load_exceptions;
-    for (auto& future : load_group_futures) {
-        try {
-            future.get();
-        } catch (...) {
-            load_exceptions.push_back(std::current_exception());
-        }
-    }
-
-    // If any exceptions occurred during index loading, handle them
-    if (!load_exceptions.empty()) {
-        LOG_ERROR("Failed to load {} out of {} indexes for segment {}",
-                  load_exceptions.size(),
-                  load_group_futures.size(),
-                  id_);
-
-        // Rethrow the first exception
-        std::rethrow_exception(load_exceptions[0]);
-    }
+    storage::WaitAllFutures(load_group_futures);
 }
 
 void
@@ -3213,18 +3192,25 @@ ChunkedSegmentSealedImpl::LoadColumnGroup(
 void
 ChunkedSegmentSealedImpl::ReloadColumns(const std::vector<FieldId>& field_ids,
                                         milvus::OpContext* op_ctx) {
+    auto& pool = ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::MIDDLE);
+    std::vector<std::future<void>> reload_futures;
     for (auto& field_id : field_ids) {
-        auto column = get_column(field_id);
-        AssertInfo(column != nullptr,
-                   "cannot reload non-existing field column {}",
-                   field_id.get());
-        auto num_chunks = column->num_chunks();
-        std::vector<int64_t> chunk_ids(num_chunks);
-        for (int64_t chunk_id = 0; chunk_id < num_chunks; chunk_id++) {
-            chunk_ids[chunk_id] = chunk_id;
-        }
-        column->PrefetchChunks(op_ctx, chunk_ids);
+        auto future = pool.Submit([this, field_id, op_ctx]() {
+            auto column = get_column(field_id);
+            AssertInfo(column != nullptr,
+                       "cannot reload non-existing field column {}",
+                       field_id.get());
+            auto num_chunks = column->num_chunks();
+            std::vector<int64_t> chunk_ids(num_chunks);
+            for (int64_t chunk_id = 0; chunk_id < num_chunks; chunk_id++) {
+                chunk_ids[chunk_id] = chunk_id;
+            }
+            column->PrefetchChunks(op_ctx, chunk_ids);
+        });
+        reload_futures.push_back(std::move(future));
     }
+
+    storage::WaitAllFutures(reload_futures);
 }
 
 void
@@ -3234,7 +3220,7 @@ ChunkedSegmentSealedImpl::LoadBatchIndexes(
         field_id_to_index_info,
     milvus::OpContext* op_ctx) {
     auto num_rows = segment_load_info_.GetNumOfRows();
-    auto& pool = ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::LOW);
+    auto& pool = ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::MIDDLE);
     std::vector<std::future<void>> load_index_futures;
     load_index_futures.reserve(field_id_to_index_info.size());
 
@@ -3268,27 +3254,7 @@ ChunkedSegmentSealedImpl::LoadBatchIndexes(
         }
     }
 
-    // Wait for all index loading to complete and collect exceptions
-    std::vector<std::exception_ptr> index_exceptions;
-    index_exceptions.reserve(load_index_futures.size());
-    for (auto& future : load_index_futures) {
-        try {
-            future.get();
-        } catch (...) {
-            index_exceptions.push_back(std::current_exception());
-        }
-    }
-
-    // If any exceptions occurred during index loading, handle them
-    if (!index_exceptions.empty()) {
-        LOG_ERROR("Failed to load {} out of {} indexes for segment {}",
-                  index_exceptions.size(),
-                  load_index_futures.size(),
-                  id_);
-
-        // Rethrow the first exception
-        std::rethrow_exception(index_exceptions[0]);
-    }
+    storage::WaitAllFutures(load_index_futures);
 }
 
 void
@@ -3306,8 +3272,6 @@ ChunkedSegmentSealedImpl::LoadBatchFieldData(
         LoadFieldDataInfo load_field_data_info;
         load_field_data_info.storage_version =
             segment_load_info_.GetStorageVersion();
-        // const auto& field_binlog = segment_load_info_.GetBinlogPath(i);
-        // std::vector<FieldId> field_ids;
         // when child fields specified, field id is group id, child field ids are actual id values here
         if (field_binlog.child_fields_size() > 0) {
             field_ids.reserve(field_binlog.child_fields_size());
@@ -3387,7 +3351,7 @@ ChunkedSegmentSealedImpl::LoadBatchFieldData(
         field_data_to_load[FieldId(group_id)] = load_field_data_info;
     }
 
-    auto& pool = ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::LOW);
+    auto& pool = ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::MIDDLE);
     std::vector<std::future<void>> load_field_futures;
     load_field_futures.reserve(field_data_to_load.size());
 
@@ -3408,27 +3372,7 @@ ChunkedSegmentSealedImpl::LoadBatchFieldData(
         load_field_futures.push_back(std::move(future));
     }
 
-    // Wait for all field data loading to complete and collect exceptions
-    std::vector<std::exception_ptr> field_exceptions;
-    field_exceptions.reserve(load_field_futures.size());
-    for (auto& future : load_field_futures) {
-        try {
-            future.get();
-        } catch (...) {
-            field_exceptions.push_back(std::current_exception());
-        }
-    }
-
-    // If any exceptions occurred during field data loading, handle them
-    if (!field_exceptions.empty()) {
-        LOG_ERROR("Failed to load {} out of {} field data for segment {}",
-                  field_exceptions.size(),
-                  load_field_futures.size(),
-                  id_);
-
-        // Rethrow the first exception
-        std::rethrow_exception(field_exceptions[0]);
-    }
+    storage::WaitAllFutures(load_field_futures);
 }
 
 void

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -1990,7 +1990,7 @@ SegmentGrowingImpl::LoadColumnsGroups(std::string manifest_path) {
     reader_ = milvus_storage::api::Reader::create(
         column_groups, arrow_schema, nullptr, *properties);
 
-    auto& pool = ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::LOW);
+    auto& pool = ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::MIDDLE);
     std::vector<
         std::future<std::unordered_map<FieldId, std::vector<FieldDataPtr>>>>
         load_group_futures;

--- a/internal/core/src/segcore/SegmentLoadInfo.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfo.cpp
@@ -321,6 +321,7 @@ SegmentLoadInfo::GetLoadDiff() {
     LoadDiff diff;
 
     SegmentLoadInfo empty_info;
+    empty_info.schema_ = schema_;
 
     // Handle index changes
     empty_info.ComputeDiffIndexes(diff, *this);

--- a/internal/core/src/segcore/memory_planner.h
+++ b/internal/core/src/segcore/memory_planner.h
@@ -18,6 +18,8 @@
 #include <vector>
 #include <cstdint>
 #include <cstddef>
+#include <future>
+#include "common/OpContext.h"
 #include "milvus-storage/common/metadata.h"
 #include <arrow/record_batch.h>
 #include <vector>
@@ -69,7 +71,7 @@ class ParallelDegreeSplitStrategy : public RowGroupSplitStrategy {
     uint64_t parallel_degree_;
 };
 
-/*
+/**
  * Load storage v2 files with specified strategy. The number of row group readers is determined by the strategy.
  *
  * @param remote_files: list of remote files
@@ -89,5 +91,29 @@ LoadWithStrategy(const std::vector<std::string>& remote_files,
                  const std::shared_ptr<arrow::Schema> schema = nullptr,
                  milvus::proto::common::LoadPriority priority =
                      milvus::proto::common::LoadPriority::HIGH);
+
+/**
+ * Load storage v2 files with specified strategy. The number of row group readers is determined by the strategy.
+ *
+ * @param remote_files: list of remote files
+ * @param memory_limit: memory limit for each chunk
+ * @param strategy: strategy to split row groups
+ * @param row_group_lists: list of row group lists
+ * @param fs: the arrow filesystem pointer used to load
+ * @param schema: schema of the data, if not provided, storage v2 will read all columns of the files.
+ * @param priority: load priority
+ * @return vector of futures, encapuslating the loading tasks and potential exceptions
+ */
+std::vector<std::future<void>>
+LoadWithStrategyAsync(milvus::OpContext* op_ctx,
+                      const std::vector<std::string>& remote_files,
+                      std::shared_ptr<ArrowReaderChannel>& channel,
+                      int64_t memory_limit,
+                      std::unique_ptr<RowGroupSplitStrategy> strategy,
+                      const std::vector<std::vector<int64_t>>& row_group_lists,
+                      const milvus_storage::ArrowFileSystemPtr& fs,
+                      const std::shared_ptr<arrow::Schema>& schema = nullptr,
+                      milvus::proto::common::LoadPriority priority =
+                          milvus::proto::common::LoadPriority::HIGH);
 
 }  // namespace milvus::segcore

--- a/internal/core/src/segcore/storagev1translator/ChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/ChunkTranslator.cpp
@@ -165,14 +165,12 @@ ChunkTranslator::get_cells(
         remote_files.push_back(file_infos_[cid].file_path);
     }
 
-    auto& pool = ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::MIDDLE);
     auto channel = std::make_shared<ArrowReaderChannel>();
     LOG_INFO("segment {} submits load field {} chunks {} task to thread pool",
              segment_id_,
              field_id_,
              fmt::format("{}", fmt::join(cids, " ")));
-    pool.Submit(
-        LoadArrowReaderFromRemote, remote_files, channel, load_priority_);
+    LoadArrowReaderFromRemote(remote_files, channel, load_priority_);
 
     auto data_type = field_meta_.get_data_type();
 

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
@@ -42,6 +42,7 @@
 #include "cachinglayer/Utils.h"
 #include "common/ChunkWriter.h"
 #include "segcore/Utils.h"
+#include "storage/Util.h"
 
 namespace milvus::segcore::storagev2translator {
 
@@ -323,24 +324,19 @@ GroupChunkTranslator::get_cells(milvus::OpContext* ctx,
     auto strategy =
         std::make_unique<ParallelDegreeSplitStrategy>(parallel_degree);
 
-    auto& pool = ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::MIDDLE);
     auto channel = std::make_shared<ArrowReaderChannel>();
     auto fs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
                   .GetArrowFileSystem();
 
-    auto load_future = pool.Submit([&, ctx]() {
-        // Early exit if cancelled while queued
-        CheckCancellation(
-            ctx, segment_id_, "GroupChunkTranslator::get_cells()");
-        return LoadWithStrategy(insert_files_,
-                                channel,
-                                DEFAULT_FIELD_MAX_MEMORY_LIMIT,
-                                std::move(strategy),
-                                row_group_lists,
-                                fs,
-                                nullptr,
-                                load_priority_);
-    });
+    auto load_futures = LoadWithStrategyAsync(ctx,
+                                              insert_files_,
+                                              channel,
+                                              DEFAULT_FIELD_MAX_MEMORY_LIMIT,
+                                              std::move(strategy),
+                                              row_group_lists,
+                                              fs,
+                                              nullptr,
+                                              load_priority_);
     LOG_INFO(
         "[StorageV2] translator {} submits load column group {} task to thread "
         "pool",
@@ -367,7 +363,7 @@ GroupChunkTranslator::get_cells(milvus::OpContext* ctx,
     }
 
     // access underlying feature to get exception if any
-    load_future.get();
+    storage::WaitAllFutures(load_futures);
 
     // Build cells from collected tables
     for (auto cid : cids) {

--- a/internal/core/src/storage/ThreadPool.cpp
+++ b/internal/core/src/storage/ThreadPool.cpp
@@ -130,6 +130,7 @@ ThreadPool::Worker() {
         lock.unlock();
         if (dequeue) {
             func();
+            func = nullptr;
         }
     }
 }

--- a/internal/core/src/storage/Util.h
+++ b/internal/core/src/storage/Util.h
@@ -186,6 +186,27 @@ GetObjectData(
 
 // Helper function to wait for all futures and collect exceptions
 // This ensures all background threads complete before rethrowing exception
+inline void
+WaitAllFutures(std::vector<std::future<void>>& futures) {
+    std::exception_ptr first_exception = nullptr;
+
+    for (auto& future : futures) {
+        try {
+            future.get();  // return type is void
+        } catch (...) {
+            if (!first_exception) {
+                first_exception = std::current_exception();
+            }
+        }
+    }
+
+    if (first_exception) {
+        std::rethrow_exception(first_exception);
+    }
+}
+
+// Helper function to wait for all futures and collect exceptions
+// This ensures all background threads complete before rethrowing exception
 template <typename T>
 std::vector<T>
 WaitAllFutures(std::vector<std::future<T>> futures) {


### PR DESCRIPTION
Related to #47298

Refactor thread pool assignments to properly separate entity-level parallelism (MIDDLE pool) from I/O operations (HIGH/LOW pool), eliminating pool re-entry risks and improving resource utilization.

**Changes**

**Thread Pool Reassignments (LOW → MIDDLE)**
- LoadColumnGroups: Field/column group level parallelism
- LoadBatchIndexes: Index level parallelism
- LoadBatchFieldData: Field level parallelism
- LoadColumnsGroups (SegmentGrowingImpl): Column group level parallelism

**Remove Unnecessary MIDDLE Pool Wrappers**
- load_field_data_internal: LoadArrowReaderFromRemote internally uses HIGH/LOW
- ChunkTranslator::get_cells: LoadArrowReaderFromRemote internally uses HIGH/LOW

**New Async Pattern for GroupChunkTranslator**
- Add LoadWithStrategyAsync() in memory_planner.cpp
- Returns futures immediately, submits I/O to HIGH/LOW pool
- GroupChunkTranslator::get_cells now waits on HIGH/LOW futures (cross-pool)
- Eliminates re-entry deadlock risk while preserving I/O parallelism

**Add ReloadColumns Parallelism**
- Previously sequential loop now uses MIDDLE pool for field-level parallelism

**Code Quality Improvements**
- Add WaitAllFutures() helper in Util.h for centralized exception handling
- Simplify exception handling across LoadColumnGroups, LoadBatchIndexes, LoadBatchFieldData using WaitAllFutures()

**Thread Pool Design After This Change**

- MIDDLE pool: Entity-level parallelism (fields, indexes, column groups)
- HIGH/LOW pool: I/O operations (file reads, network fetches)
- Cross-pool waits are safe (MIDDLE waiting on HIGH/LOW)
- Same-pool re-entry eliminated
