### PR TITLE
fix: prevent server crash on division/modulo by zero in filter expressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,18 @@ WARP.md
 **/.gocache/
 claude.md
 docs/plans/
+
+# Claude sandbox env
+.bash_profile
+.bashrc
+.claude/
+.gitconfig
+.gitmodules
+.idea
+.mcp.json
+.profile
+.ripgreprc
+.zprofile
+.zshrc
+
+

--- a/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.cpp
@@ -149,6 +149,15 @@ PhyBinaryArithOpEvalRangeExpr::ExecRangeVisitorImplForJson(
     auto value = value_arg_.GetValue<ValueType>();
     auto right_operand = right_operand_arg_.GetValue<ValueType>();
 
+    // Validate divisor for division/modulo operations
+    if ((arith_type == proto::plan::ArithOpType::Div ||
+         arith_type == proto::plan::ArithOpType::Mod) &&
+        right_operand == 0) {
+        ThrowInfo(
+            ErrorCode::ExprInvalid,
+            "division or modulus by zero in JSON field arithmetic expression");
+    }
+
 #define BinaryArithRangeJSONCompare(cmp)                                \
     do {                                                                \
         for (size_t i = 0; i < size; ++i) {                             \
@@ -558,6 +567,15 @@ PhyBinaryArithOpEvalRangeExpr::ExecRangeVisitorImplForArray(
     auto arith_type = expr_->arith_op_type_;
     auto value = value_arg_.GetValue<ValueType>();
     auto right_operand = right_operand_arg_.GetValue<ValueType>();
+
+    // Validate divisor for division/modulo operations
+    if ((arith_type == proto::plan::ArithOpType::Div ||
+         arith_type == proto::plan::ArithOpType::Mod) &&
+        right_operand == 0) {
+        ThrowInfo(
+            ErrorCode::ExprInvalid,
+            "division or modulus by zero in Array field arithmetic expression");
+    }
 
 #define BinaryArithRangeArrayCompare(cmp)                       \
     do {                                                        \

--- a/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.h
+++ b/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.h
@@ -34,6 +34,10 @@ namespace {
 template <typename T, typename U>
 decltype(auto)
 safe_mod(T a, U b) {
+    if (b == 0) {
+        ThrowInfo(ErrorCode::ExprInvalid,
+                  "modulus by zero in arithmetic expression");
+    }
     if constexpr (std::is_floating_point_v<T> || std::is_floating_point_v<U>) {
         return std::fmod(a, b);
     } else {
@@ -114,6 +118,16 @@ struct ArithOpElementFunc {
                HighPrecisonType right_operand,
                TargetBitmapView res,
                const int32_t* offsets = nullptr) {
+        // Validate divisor for division/modulo operations
+        if constexpr (arith_op == proto::plan::ArithOpType::Div ||
+                      arith_op == proto::plan::ArithOpType::Mod) {
+            if (right_operand == 0) {
+                ThrowInfo(
+                    ErrorCode::ExprInvalid,
+                    "division or modulus by zero in arithmetic expression");
+            }
+        }
+
         // This is the original code, kept here for the documentation purposes
         // and also this code will be used for iterative filter since iterative filter does not execute as a batch manner
         if constexpr (filter_type == FilterType::random) {
@@ -301,6 +315,16 @@ struct ArithOpIndexFunc {
                HighPrecisonType val,
                HighPrecisonType right_operand,
                const int32_t* offsets = nullptr) {
+        // Validate divisor for division/modulo operations
+        if constexpr (arith_op == proto::plan::ArithOpType::Div ||
+                      arith_op == proto::plan::ArithOpType::Mod) {
+            if (right_operand == 0) {
+                ThrowInfo(
+                    ErrorCode::ExprInvalid,
+                    "division or modulus by zero in arithmetic expression");
+            }
+        }
+
         TargetBitmap res(size);
         for (size_t i = 0; i < size; ++i) {
             auto offset = i;

--- a/internal/parser/planparserv2/fill_expression_value.go
+++ b/internal/parser/planparserv2/fill_expression_value.go
@@ -211,6 +211,15 @@ func FillBinaryArithOpEvalRangeExpressionValue(expr *planpb.BinaryArithOpEvalRan
 		if err != nil {
 			return err
 		}
+
+		// Validate divisor for division/modulo operations
+		if expr.ArithOp == planpb.ArithOpType_Div || expr.ArithOp == planpb.ArithOpType_Mod {
+			if (IsInteger(castedOperand) && castedOperand.GetInt64Val() == 0) ||
+				(IsFloating(castedOperand) && castedOperand.GetFloatVal() == 0) {
+				return errors.New("division or modulus by zero")
+			}
+		}
+
 		expr.RightOperand = castedOperand
 	}
 

--- a/internal/parser/planparserv2/fill_expression_value_test.go
+++ b/internal/parser/planparserv2/fill_expression_value_test.go
@@ -579,3 +579,52 @@ func (s *FillExpressionValueSuite) TestBinaryRangeWithMixedNumericTypesForJSON()
 		s.Equal(float64(100.5), bre.GetUpperValue().GetFloatVal())
 	})
 }
+
+func (s *FillExpressionValueSuite) TestBinaryArithOpEvalRangeDivisionByZero() {
+	schemaH := newTestSchemaHelper(s.T())
+
+	s.Run("division by integer zero should fail", func() {
+		exprStr := `Int64Field / {divisor} == {value}`
+		templateValues := map[string]*schemapb.TemplateValue{
+			"divisor": generateTemplateValue(schemapb.DataType_Int64, int64(0)),
+			"value":   generateTemplateValue(schemapb.DataType_Int64, int64(5)),
+		}
+		s.assertInvalidExpr(schemaH, exprStr, templateValues)
+	})
+
+	s.Run("division by float zero should fail", func() {
+		exprStr := `FloatField / {divisor} == {value}`
+		templateValues := map[string]*schemapb.TemplateValue{
+			"divisor": generateTemplateValue(schemapb.DataType_Double, float64(0.0)),
+			"value":   generateTemplateValue(schemapb.DataType_Double, float64(5.0)),
+		}
+		s.assertInvalidExpr(schemaH, exprStr, templateValues)
+	})
+
+	s.Run("modulo by integer zero should fail", func() {
+		exprStr := `Int64Field % {divisor} == {value}`
+		templateValues := map[string]*schemapb.TemplateValue{
+			"divisor": generateTemplateValue(schemapb.DataType_Int64, int64(0)),
+			"value":   generateTemplateValue(schemapb.DataType_Int64, int64(1)),
+		}
+		s.assertInvalidExpr(schemaH, exprStr, templateValues)
+	})
+
+	s.Run("division by non-zero should succeed", func() {
+		exprStr := `Int64Field / {divisor} == {value}`
+		templateValues := map[string]*schemapb.TemplateValue{
+			"divisor": generateTemplateValue(schemapb.DataType_Int64, int64(2)),
+			"value":   generateTemplateValue(schemapb.DataType_Int64, int64(5)),
+		}
+		s.assertValidExpr(schemaH, exprStr, templateValues)
+	})
+
+	s.Run("modulo by non-zero should succeed", func() {
+		exprStr := `Int64Field % {divisor} == {value}`
+		templateValues := map[string]*schemapb.TemplateValue{
+			"divisor": generateTemplateValue(schemapb.DataType_Int64, int64(3)),
+			"value":   generateTemplateValue(schemapb.DataType_Int64, int64(1)),
+		}
+		s.assertValidExpr(schemaH, exprStr, templateValues)
+	})
+}


### PR DESCRIPTION
issue: #47285 

Fix critical DoS vulnerability where filter expressions containing division or modulo by zero operations cause Milvus server to crash with SIGFPE . 
Any client with query access could crash the server remotely using expressions like `"int_field / {d} == 1", params:{"d": 0}`.                                                                                                      