### PR TITLE
fix: [GoSDK] align timestamptz field type and data format with server

### DIFF
--- a/client/column/columns.go
+++ b/client/column/columns.go
@@ -210,7 +210,7 @@ func FieldDataColumn(fd *schemapb.FieldData, begin, end int) (Column, error) {
 		return parseScalarData(fd.GetFieldName(), fd.GetScalars().GetDoubleData().GetData(), begin, end, validData, NewColumnDouble, NewNullableColumnDouble)
 
 	case schemapb.DataType_Timestamptz:
-		return parseScalarData(fd.GetFieldName(), fd.GetScalars().GetTimestamptzData().GetData(), begin, end, validData, NewColumnTimestamptz, NewNullableColumnTimestamptz)
+		return parseScalarData(fd.GetFieldName(), fd.GetScalars().GetStringData().GetData(), begin, end, validData, NewColumnTimestamptzIsoString, NewNullableColumnTimestamptzIsoString)
 
 	case schemapb.DataType_String:
 		return parseScalarData(fd.GetFieldName(), fd.GetScalars().GetStringData().GetData(), begin, end, validData, NewColumnString, NewNullableColumnString)

--- a/client/column/conversion.go
+++ b/client/column/conversion.go
@@ -118,7 +118,8 @@ func values2FieldData[T any](values []T, fieldType entity.FieldType, dim int) *s
 		entity.FieldTypeVarChar,
 		entity.FieldTypeString,
 		entity.FieldTypeJSON,
-		entity.FieldTypeGeometry:
+		entity.FieldTypeGeometry,
+		entity.FieldTypeTimestamptz:
 		fd.Field = &schemapb.FieldData_Scalars{
 			Scalars: values2Scalars(values, fieldType), // scalars,
 		}
@@ -174,7 +175,7 @@ func values2Scalars[T any](values []T, fieldType entity.FieldType) *schemapb.Sca
 		scalars.Data = &schemapb.ScalarField_LongData{
 			LongData: &schemapb.LongArray{Data: int64s},
 		}
-	case entity.FieldTypeVarChar, entity.FieldTypeString:
+	case entity.FieldTypeVarChar, entity.FieldTypeString, entity.FieldTypeTimestamptz:
 		var strVals []string
 		strVals, ok = any(values).([]string)
 		scalars.Data = &schemapb.ScalarField_StringData{

--- a/client/column/nullable.go
+++ b/client/column/nullable.go
@@ -17,6 +17,8 @@
 package column
 
 import (
+	"time"
+
 	"github.com/cockroachdb/errors"
 
 	"github.com/milvus-io/milvus/client/v2/entity"
@@ -24,18 +26,18 @@ import (
 
 var (
 	// scalars
-	NewNullableColumnBool        NullableColumnCreateFunc[bool, *ColumnBool]          = NewNullableColumnCreator(NewColumnBool).New
-	NewNullableColumnInt8        NullableColumnCreateFunc[int8, *ColumnInt8]          = NewNullableColumnCreator(NewColumnInt8).New
-	NewNullableColumnInt16       NullableColumnCreateFunc[int16, *ColumnInt16]        = NewNullableColumnCreator(NewColumnInt16).New
-	NewNullableColumnInt32       NullableColumnCreateFunc[int32, *ColumnInt32]        = NewNullableColumnCreator(NewColumnInt32).New
-	NewNullableColumnInt64       NullableColumnCreateFunc[int64, *ColumnInt64]        = NewNullableColumnCreator(NewColumnInt64).New
-	NewNullableColumnVarChar     NullableColumnCreateFunc[string, *ColumnVarChar]     = NewNullableColumnCreator(NewColumnVarChar).New
-	NewNullableColumnString      NullableColumnCreateFunc[string, *ColumnString]      = NewNullableColumnCreator(NewColumnString).New
-	NewNullableColumnFloat       NullableColumnCreateFunc[float32, *ColumnFloat]      = NewNullableColumnCreator(NewColumnFloat).New
-	NewNullableColumnDouble      NullableColumnCreateFunc[float64, *ColumnDouble]     = NewNullableColumnCreator(NewColumnDouble).New
-	NewNullableColumnTimestamptz NullableColumnCreateFunc[int64, *ColumnTimestamptz]  = NewNullableColumnCreator(NewColumnTimestamptz).New
-	NewNullableColumnJSONBytes   NullableColumnCreateFunc[[]byte, *ColumnJSONBytes]   = NewNullableColumnCreator(NewColumnJSONBytes).New
-	NewNullableColumnGeometryWKT NullableColumnCreateFunc[string, *ColumnGeometryWKT] = NewNullableColumnCreator(NewColumnGeometryWKT).New
+	NewNullableColumnBool                 NullableColumnCreateFunc[bool, *ColumnBool]                   = NewNullableColumnCreator(NewColumnBool).New
+	NewNullableColumnInt8                 NullableColumnCreateFunc[int8, *ColumnInt8]                   = NewNullableColumnCreator(NewColumnInt8).New
+	NewNullableColumnInt16                NullableColumnCreateFunc[int16, *ColumnInt16]                 = NewNullableColumnCreator(NewColumnInt16).New
+	NewNullableColumnInt32                NullableColumnCreateFunc[int32, *ColumnInt32]                 = NewNullableColumnCreator(NewColumnInt32).New
+	NewNullableColumnInt64                NullableColumnCreateFunc[int64, *ColumnInt64]                 = NewNullableColumnCreator(NewColumnInt64).New
+	NewNullableColumnVarChar              NullableColumnCreateFunc[string, *ColumnVarChar]              = NewNullableColumnCreator(NewColumnVarChar).New
+	NewNullableColumnString               NullableColumnCreateFunc[string, *ColumnString]               = NewNullableColumnCreator(NewColumnString).New
+	NewNullableColumnFloat                NullableColumnCreateFunc[float32, *ColumnFloat]               = NewNullableColumnCreator(NewColumnFloat).New
+	NewNullableColumnDouble               NullableColumnCreateFunc[float64, *ColumnDouble]              = NewNullableColumnCreator(NewColumnDouble).New
+	NewNullableColumnTimestamptzIsoString NullableColumnCreateFunc[string, *ColumnTimestampTzIsoString] = NewNullableColumnCreator(NewColumnTimestamptzIsoString).New
+	NewNullableColumnJSONBytes            NullableColumnCreateFunc[[]byte, *ColumnJSONBytes]            = NewNullableColumnCreator(NewColumnJSONBytes).New
+	NewNullableColumnGeometryWKT          NullableColumnCreateFunc[string, *ColumnGeometryWKT]          = NewNullableColumnCreator(NewColumnGeometryWKT).New
 	// array
 	NewNullableColumnBoolArray    NullableColumnCreateFunc[[]bool, *ColumnBoolArray]      = NewNullableColumnCreator(NewColumnBoolArray).New
 	NewNullableColumnInt8Array    NullableColumnCreateFunc[[]int8, *ColumnInt8Array]      = NewNullableColumnCreator(NewColumnInt8Array).New
@@ -150,4 +152,15 @@ func NewNullableColumnCreator[col interface {
 	return NullableColumnCreator[col, T]{
 		base: base,
 	}
+}
+
+func NewNullableColumnTimestamptz(name string, values []time.Time, validData []bool, opts ...ColumnOption[string]) (*ColumnTimestamptz, error) {
+	result := NewColumnTimestamptz(name, values)
+	result.withValidData(validData)
+
+	for _, opt := range opts {
+		opt(result.genericColumnBase)
+	}
+
+	return result, result.ValidateNullable()
 }

--- a/client/column/scalar.go
+++ b/client/column/scalar.go
@@ -17,6 +17,10 @@
 package column
 
 import (
+	"time"
+
+	"github.com/samber/lo"
+
 	"github.com/milvus-io/milvus/client/v2/entity"
 )
 
@@ -186,7 +190,7 @@ func (c *ColumnFloat) GetAsDouble(idx int) (float64, error) {
 
 /* Double */
 
-var _ Column = (*ColumnFloat)(nil)
+var _ Column = (*ColumnDouble)(nil)
 
 type ColumnDouble struct {
 	*genericColumnBase[float64]
@@ -212,16 +216,46 @@ func (c *ColumnDouble) Slice(start, end int) Column {
 var _ Column = (*ColumnTimestamptz)(nil)
 
 type ColumnTimestamptz struct {
-	*genericColumnBase[int64]
+	*genericColumnBase[string]
 }
 
-func NewColumnTimestamptz(name string, values []int64) *ColumnTimestamptz {
+func NewColumnTimestamptz(name string, values []time.Time) *ColumnTimestamptz {
 	return &ColumnTimestamptz{
-		genericColumnBase: &genericColumnBase[int64]{
+		genericColumnBase: &genericColumnBase[string]{
+			name:      name,
+			fieldType: entity.FieldTypeTimestamptz,
+			values: lo.Map(values, func(t time.Time, _ int) string {
+				return t.Format(time.RFC3339Nano)
+			}),
+		},
+	}
+}
+
+func (c *ColumnTimestamptz) Slice(start, end int) Column {
+	return &ColumnTimestamptz{
+		genericColumnBase: c.genericColumnBase.slice(start, end),
+	}
+}
+
+var _ Column = (*ColumnTimestampTzIsoString)(nil)
+
+type ColumnTimestampTzIsoString struct {
+	*genericColumnBase[string]
+}
+
+func NewColumnTimestamptzIsoString(name string, values []string) *ColumnTimestampTzIsoString {
+	return &ColumnTimestampTzIsoString{
+		genericColumnBase: &genericColumnBase[string]{
 			name:      name,
 			fieldType: entity.FieldTypeTimestamptz,
 			values:    values,
 		},
+	}
+}
+
+func (c *ColumnTimestampTzIsoString) Slice(start, end int) Column {
+	return &ColumnTimestampTzIsoString{
+		genericColumnBase: c.genericColumnBase.slice(start, end),
 	}
 }
 

--- a/client/entity/field.go
+++ b/client/entity/field.go
@@ -177,8 +177,6 @@ const (
 	FieldTypeFloat FieldType = 10
 	// FieldTypeDouble field type double
 	FieldTypeDouble FieldType = 11
-	// FieldTypeTimestamptz field type timestamptz
-	FieldTypeTimestamptz FieldType = 15
 	// FieldTypeString field type string
 	FieldTypeString FieldType = 20
 	// FieldTypeVarChar field type varchar
@@ -189,6 +187,8 @@ const (
 	FieldTypeJSON FieldType = 23
 	// FieldTypeGeometry field type Geometry
 	FieldTypeGeometry FieldType = 24
+	// FieldTypeTimestamptz field type timestamptz
+	FieldTypeTimestamptz FieldType = 26
 	// FieldTypeBinaryVector field type binary vector
 	FieldTypeBinaryVector FieldType = 100
 	// FieldTypeFloatVector field type float vector

--- a/client/go.mod
+++ b/client/go.mod
@@ -6,13 +6,15 @@ require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/cockroachdb/errors v1.9.1
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
-	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20251215075310-deda9c0dcece
+	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260113024922-c7feeb806088
 	github.com/milvus-io/milvus/pkg/v2 v2.6.4-0.20251104142533-a2ce70d25256
 	github.com/quasilyte/go-ruleguard/dsl v0.3.23
 	github.com/samber/lo v1.27.0
 	github.com/stretchr/testify v1.11.1
 	github.com/tidwall/gjson v1.17.1
+	go.opentelemetry.io/otel v1.34.0
 	go.uber.org/atomic v1.11.0
+	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842
 	google.golang.org/grpc v1.71.0
 	google.golang.org/protobuf v1.36.5
 )
@@ -92,7 +94,6 @@ require (
 	go.etcd.io/etcd/server/v3 v3.5.5 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.59.0 // indirect
-	go.opentelemetry.io/otel v1.34.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.20.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.20.0 // indirect
 	go.opentelemetry.io/otel/metric v1.34.0 // indirect
@@ -103,7 +104,6 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/crypto v0.45.0 // indirect
-	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842 // indirect
 	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/sync v0.18.0 // indirect
 	golang.org/x/sys v0.38.0 // indirect

--- a/client/go.sum
+++ b/client/go.sum
@@ -330,8 +330,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/mediocregopher/radix/v3 v3.4.2/go.mod h1:8FL3F6UQRXHXIBSPUs5h0RybMF8i4n7wVopoX3x7Bv8=
 github.com/microcosm-cc/bluemonday v1.0.2/go.mod h1:iVP4YcDBq+n/5fb23BhYFvIMq/leAFZyRl6bYmGDlGc=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
-github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20251215075310-deda9c0dcece h1:s0TFMZBxADKSzIr7LW/TE3L/WgCuo7QOfzkYX92Xog0=
-github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20251215075310-deda9c0dcece/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260113024922-c7feeb806088 h1:qzlpV+1xygF/XK0bRVoLFg03uAQSCZ2AywZR3wt5ov0=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260113024922-c7feeb806088/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
 github.com/milvus-io/milvus/pkg/v2 v2.6.4-0.20251104142533-a2ce70d25256 h1:M2waty0w2k4YT2HHzJk3fx6EFPD4DKxNJatitIV+gGU=
 github.com/milvus-io/milvus/pkg/v2 v2.6.4-0.20251104142533-a2ce70d25256/go.mod h1:HT6Wxahwj/l8+i+D/C3iwDzCjDa36U9gyVw6CjjK4pE=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=

--- a/client/milvusclient/mock_milvus_server_test.go
+++ b/client/milvusclient/mock_milvus_server_test.go
@@ -853,6 +853,65 @@ func (_c *MilvusServiceServer_BatchDescribeCollection_Call) RunAndReturn(run fun
 	return _c
 }
 
+// BatchUpdateManifest provides a mock function with given fields: _a0, _a1
+func (_m *MilvusServiceServer) BatchUpdateManifest(_a0 context.Context, _a1 *milvuspb.BatchUpdateManifestRequest) (*commonpb.Status, error) {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for BatchUpdateManifest")
+	}
+
+	var r0 *commonpb.Status
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *milvuspb.BatchUpdateManifestRequest) (*commonpb.Status, error)); ok {
+		return rf(_a0, _a1)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *milvuspb.BatchUpdateManifestRequest) *commonpb.Status); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*commonpb.Status)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *milvuspb.BatchUpdateManifestRequest) error); ok {
+		r1 = rf(_a0, _a1)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MilvusServiceServer_BatchUpdateManifest_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'BatchUpdateManifest'
+type MilvusServiceServer_BatchUpdateManifest_Call struct {
+	*mock.Call
+}
+
+// BatchUpdateManifest is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *milvuspb.BatchUpdateManifestRequest
+func (_e *MilvusServiceServer_Expecter) BatchUpdateManifest(_a0 interface{}, _a1 interface{}) *MilvusServiceServer_BatchUpdateManifest_Call {
+	return &MilvusServiceServer_BatchUpdateManifest_Call{Call: _e.mock.On("BatchUpdateManifest", _a0, _a1)}
+}
+
+func (_c *MilvusServiceServer_BatchUpdateManifest_Call) Run(run func(_a0 context.Context, _a1 *milvuspb.BatchUpdateManifestRequest)) *MilvusServiceServer_BatchUpdateManifest_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*milvuspb.BatchUpdateManifestRequest))
+	})
+	return _c
+}
+
+func (_c *MilvusServiceServer_BatchUpdateManifest_Call) Return(_a0 *commonpb.Status, _a1 error) *MilvusServiceServer_BatchUpdateManifest_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MilvusServiceServer_BatchUpdateManifest_Call) RunAndReturn(run func(context.Context, *milvuspb.BatchUpdateManifestRequest) (*commonpb.Status, error)) *MilvusServiceServer_BatchUpdateManifest_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CalcDistance provides a mock function with given fields: _a0, _a1
 func (_m *MilvusServiceServer) CalcDistance(_a0 context.Context, _a1 *milvuspb.CalcDistanceRequest) (*milvuspb.CalcDistanceResults, error) {
 	ret := _m.Called(_a0, _a1)

--- a/internal/core/src/segcore/SegmentLoadInfo.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfo.cpp
@@ -321,6 +321,7 @@ SegmentLoadInfo::GetLoadDiff() {
     LoadDiff diff;
 
     SegmentLoadInfo empty_info;
+    empty_info.schema_ = schema_;
 
     // Handle index changes
     empty_info.ComputeDiffIndexes(diff, *this);

--- a/internal/core/src/storage/ThreadPool.cpp
+++ b/internal/core/src/storage/ThreadPool.cpp
@@ -130,6 +130,7 @@ ThreadPool::Worker() {
         lock.unlock();
         if (dequeue) {
             func();
+            func = nullptr;
         }
     }
 }

--- a/tests/go_client/go.mod
+++ b/tests/go_client/go.mod
@@ -3,7 +3,7 @@ module github.com/milvus-io/milvus/tests/go_client
 go 1.24.11
 
 require (
-	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20251215075310-deda9c0dcece
+	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260113024922-c7feeb806088
 	github.com/milvus-io/milvus/client/v2 v2.0.0-20241125024034-0b9edb62a92d
 	github.com/milvus-io/milvus/pkg/v2 v2.6.4-0.20251104142533-a2ce70d25256
 	github.com/peterstace/simplefeatures v0.54.0

--- a/tests/go_client/go.sum
+++ b/tests/go_client/go.sum
@@ -332,8 +332,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/mediocregopher/radix/v3 v3.4.2/go.mod h1:8FL3F6UQRXHXIBSPUs5h0RybMF8i4n7wVopoX3x7Bv8=
 github.com/microcosm-cc/bluemonday v1.0.2/go.mod h1:iVP4YcDBq+n/5fb23BhYFvIMq/leAFZyRl6bYmGDlGc=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
-github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20251215075310-deda9c0dcece h1:s0TFMZBxADKSzIr7LW/TE3L/WgCuo7QOfzkYX92Xog0=
-github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20251215075310-deda9c0dcece/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260113024922-c7feeb806088 h1:qzlpV+1xygF/XK0bRVoLFg03uAQSCZ2AywZR3wt5ov0=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260113024922-c7feeb806088/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
 github.com/milvus-io/milvus/pkg/v2 v2.6.4-0.20251104142533-a2ce70d25256 h1:M2waty0w2k4YT2HHzJk3fx6EFPD4DKxNJatitIV+gGU=
 github.com/milvus-io/milvus/pkg/v2 v2.6.4-0.20251104142533-a2ce70d25256/go.mod h1:HT6Wxahwj/l8+i+D/C3iwDzCjDa36U9gyVw6CjjK4pE=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=


### PR DESCRIPTION
Related to #47303

The Go SDK had two issues with Timestamptz field type:

1. FieldTypeTimestamptz was incorrectly defined as 15, but server expects 26
2. Timestamptz data was serialized as int64 via TimestamptzData, but server expects ISO 8601 strings (RFC3339Nano format) via StringData

Changes:
- Update FieldTypeTimestamptz value from 15 to 26
- Modify ColumnTimestamptz to store data as RFC3339Nano strings internally
- Change NewColumnTimestamptz to accept []time.Time and convert to ISO strings
- Add ColumnTimestampTzIsoString for direct ISO string input
- Update FieldDataColumn to parse Timestamptz from StringData
- Update values2Scalars to handle Timestamptz as string type
- Add NewNullableColumnTimestamptz for nullable time.Time input
- Update NewNullableColumnTimestamptzIsoString for nullable ISO string input
- Add corresponding unit tests