### PR TITLE
fix: NPE when computing load diff with empty SegmentLoadInfo

### DIFF
--- a/internal/core/src/segcore/SegmentLoadInfo.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfo.cpp
@@ -321,6 +321,7 @@ SegmentLoadInfo::GetLoadDiff() {
     LoadDiff diff;
 
     SegmentLoadInfo empty_info;
+    empty_info.schema_ = schema_;
 
     // Handle index changes
     empty_info.ComputeDiffIndexes(diff, *this);


### PR DESCRIPTION
Related to #47061

In `GetLoadDiff()`, an empty `SegmentLoadInfo` object is created to compute the diff against the current segment's load state. However, the empty object's `schema_` member was not initialized, causing null pointer dereference when:

1. `ComputeDiffIndexes()` accesses `schema_->operator[](field_id)` to retrieve field metadata (line 59)
2. `ComputeDiffColumnGroups()` calls `schema_->ShouldLoadField()` to check if a field should be loaded (line 249)

This fix copies the current object's schema to the empty_info before calling the ComputeDiff methods, ensuring schema_ is valid when accessed.