### PR TITLE
enhance: remove --html and --self-contained-html pytest parameters

### DIFF
--- a/tests/scripts/ci_e2e.sh
+++ b/tests/scripts/ci_e2e.sh
@@ -71,9 +71,7 @@ fi
 # Pytest is not able to have both --timeout & --workers, so do not add --timeout or --workers in the shell script
 if [[ -n "${TEST_TIMEOUT:-}" ]]; then
   
-  timeout  "${TEST_TIMEOUT}" pytest --host ${MILVUS_SERVICE_NAME} --port ${MILVUS_SERVICE_PORT} --minio_host ${MINIO_SERVICE_NAME}\
-                                     --html=${CI_LOG_PATH}/report.html  --self-contained-html ${@:-}
+  timeout  "${TEST_TIMEOUT}" pytest --host ${MILVUS_SERVICE_NAME} --port ${MILVUS_SERVICE_PORT} --minio_host ${MINIO_SERVICE_NAME} ${@:-}
 else
-  pytest --host ${MILVUS_SERVICE_NAME} --port ${MILVUS_SERVICE_PORT} --minio_host ${MINIO_SERVICE_NAME}\
-                                     --html=${CI_LOG_PATH}/report.html --self-contained-html ${@:-}
+  pytest --host ${MILVUS_SERVICE_NAME} --port ${MILVUS_SERVICE_PORT} --minio_host ${MINIO_SERVICE_NAME} ${@:-}
 fi

--- a/tests/scripts/ci_e2e_4am.sh
+++ b/tests/scripts/ci_e2e_4am.sh
@@ -72,9 +72,9 @@ cd ${ROOT}/tests/restful_client
 
 if [[ -n "${TEST_TIMEOUT:-}" ]]; then
 
-  timeout "${TEST_TIMEOUT}" pytest testcases --endpoint http://${MILVUS_SERVICE_NAME}:${MILVUS_SERVICE_PORT} -v -x -m L0 -n 6 --timeout 180 --html=${CI_LOG_PATH}/report_restful.html --self-contained-html
+  timeout "${TEST_TIMEOUT}" pytest testcases --endpoint http://${MILVUS_SERVICE_NAME}:${MILVUS_SERVICE_PORT} -v -x -m L0 -n 6 --timeout 180
 else
-  pytest testcases --endpoint http://${MILVUS_SERVICE_NAME}:${MILVUS_SERVICE_PORT} -v -x -m L0 -n 6 --timeout 180 --html=${CI_LOG_PATH}/report_restful.html --self-contained-html
+  pytest testcases --endpoint http://${MILVUS_SERVICE_NAME}:${MILVUS_SERVICE_PORT} -v -x -m L0 -n 6 --timeout 180
 fi
 
 # Run restful test v2
@@ -82,17 +82,17 @@ cd ${ROOT}/tests/restful_client_v2
 
 if [[ -n "${TEST_TIMEOUT:-}" ]]; then
 
-  timeout "${TEST_TIMEOUT}" pytest testcases --endpoint http://${MILVUS_SERVICE_NAME}:${MILVUS_SERVICE_PORT} --minio_host ${MINIO_SERVICE_NAME} -v -x -m L0 -n 6 --timeout 360 --html=${CI_LOG_PATH}/report_restful.html --self-contained-html
+  timeout "${TEST_TIMEOUT}" pytest testcases --endpoint http://${MILVUS_SERVICE_NAME}:${MILVUS_SERVICE_PORT} --minio_host ${MINIO_SERVICE_NAME} -v -x -m L0 -n 6 --timeout 360
 else
-  pytest testcases --endpoint http://${MILVUS_SERVICE_NAME}:${MILVUS_SERVICE_PORT} --minio_host ${MINIO_SERVICE_NAME} -v -x -m L0 -n 6 --timeout 360 --html=${CI_LOG_PATH}/report_restful.html --self-contained-html
+  pytest testcases --endpoint http://${MILVUS_SERVICE_NAME}:${MILVUS_SERVICE_PORT} --minio_host ${MINIO_SERVICE_NAME} -v -x -m L0 -n 6 --timeout 360
 fi
 
 if [[ "${MILVUS_HELM_RELEASE_NAME}" != *"msop"* ]]; then
   if [[ -n "${TEST_TIMEOUT:-}" ]]; then
 
-    timeout "${TEST_TIMEOUT}" pytest testcases --endpoint http://${MILVUS_SERVICE_NAME}:${MILVUS_SERVICE_PORT} --minio_host ${MINIO_SERVICE_NAME} -v -x -m BulkInsert -n 6 --timeout 360 --html=${CI_LOG_PATH}/report_restful.html --self-contained-html
+    timeout "${TEST_TIMEOUT}" pytest testcases --endpoint http://${MILVUS_SERVICE_NAME}:${MILVUS_SERVICE_PORT} --minio_host ${MINIO_SERVICE_NAME} -v -x -m BulkInsert -n 6 --timeout 360
   else
-    pytest testcases --endpoint http://${MILVUS_SERVICE_NAME}:${MILVUS_SERVICE_PORT} --minio_host ${MINIO_SERVICE_NAME} -v -x -m BulkInsert -n 6 --timeout 360 --html=${CI_LOG_PATH}/report_restful.html --self-contained-html
+    pytest testcases --endpoint http://${MILVUS_SERVICE_NAME}:${MILVUS_SERVICE_PORT} --minio_host ${MINIO_SERVICE_NAME} -v -x -m BulkInsert -n 6 --timeout 360
   fi
 fi
 
@@ -101,10 +101,8 @@ cd ${ROOT}/tests/python_client
 # Pytest is not able to have both --timeout & --workers, so do not add --timeout or --workers in the shell script
 if [[ -n "${TEST_TIMEOUT:-}" ]]; then
 
-  timeout "${TEST_TIMEOUT}" pytest --host ${MILVUS_SERVICE_NAME} --port ${MILVUS_SERVICE_PORT} --minio_host ${MINIO_SERVICE_NAME}\
-    --html=${CI_LOG_PATH}/report.html --self-contained-html --dist loadgroup ${@:-}
+  timeout "${TEST_TIMEOUT}" pytest --host ${MILVUS_SERVICE_NAME} --port ${MILVUS_SERVICE_PORT} --minio_host ${MINIO_SERVICE_NAME} --dist loadgroup ${@:-}
 else
-  pytest --host ${MILVUS_SERVICE_NAME} --port ${MILVUS_SERVICE_PORT} --minio_host ${MINIO_SERVICE_NAME}\
-    --html=${CI_LOG_PATH}/report.html --self-contained-html --dist loadgroup ${@:-}
+  pytest --host ${MILVUS_SERVICE_NAME} --port ${MILVUS_SERVICE_PORT} --minio_host ${MINIO_SERVICE_NAME} --dist loadgroup ${@:-}
 fi
 

--- a/tests/scripts/ci_e2e_4am_without_restful.sh
+++ b/tests/scripts/ci_e2e_4am_without_restful.sh
@@ -70,10 +70,8 @@ cd ${ROOT}/tests/python_client
 # Pytest is not able to have both --timeout & --workers, so do not add --timeout or --workers in the shell script
 if [[ -n "${TEST_TIMEOUT:-}" ]]; then
 
-  timeout "${TEST_TIMEOUT}" pytest --host ${MILVUS_SERVICE_NAME} --port ${MILVUS_SERVICE_PORT} --minio_host ${MINIO_SERVICE_NAME}\
-    --html=${CI_LOG_PATH}/report.html --self-contained-html --dist loadgroup ${@:-}
+  timeout "${TEST_TIMEOUT}" pytest --host ${MILVUS_SERVICE_NAME} --port ${MILVUS_SERVICE_PORT} --minio_host ${MINIO_SERVICE_NAME} --dist loadgroup ${@:-}
 else
-  pytest --host ${MILVUS_SERVICE_NAME} --port ${MILVUS_SERVICE_PORT} --minio_host ${MINIO_SERVICE_NAME}\
-    --html=${CI_LOG_PATH}/report.html --self-contained-html --dist loadgroup ${@:-}
+  pytest --host ${MILVUS_SERVICE_NAME} --port ${MILVUS_SERVICE_PORT} --minio_host ${MINIO_SERVICE_NAME} --dist loadgroup ${@:-}
 fi
 

--- a/tests/scripts/ci_e2e_with_restful.sh
+++ b/tests/scripts/ci_e2e_with_restful.sh
@@ -73,9 +73,9 @@ cd ${ROOT}/tests/restful_client
 
 if [[ -n "${TEST_TIMEOUT:-}" ]]; then
 
-  timeout "${TEST_TIMEOUT}" pytest testcases --endpoint http://${MILVUS_SERVICE_NAME}:${MILVUS_SERVICE_PORT} -v -x -m L0 -n 6 --timeout 180 --html=${CI_LOG_PATH}/report_restful.html --self-contained-html
+  timeout "${TEST_TIMEOUT}" pytest testcases --endpoint http://${MILVUS_SERVICE_NAME}:${MILVUS_SERVICE_PORT} -v -x -m L0 -n 6 --timeout 180
 else
-  pytest testcases --endpoint http://${MILVUS_SERVICE_NAME}:${MILVUS_SERVICE_PORT} -v -x -m L0 -n 6 --timeout 180 --html=${CI_LOG_PATH}/report_restful.html --self-contained-html
+  pytest testcases --endpoint http://${MILVUS_SERVICE_NAME}:${MILVUS_SERVICE_PORT} -v -x -m L0 -n 6 --timeout 180
 fi
 
 # Run restful test v2
@@ -83,17 +83,17 @@ cd ${ROOT}/tests/restful_client_v2
 
 if [[ -n "${TEST_TIMEOUT:-}" ]]; then
 
-  timeout "${TEST_TIMEOUT}" pytest testcases --endpoint http://${MILVUS_SERVICE_NAME}:${MILVUS_SERVICE_PORT} --minio_host ${MINIO_SERVICE_NAME} -v -x -m L0 -n 6 --timeout 360 --html=${CI_LOG_PATH}/report_restful.html --self-contained-html
+  timeout "${TEST_TIMEOUT}" pytest testcases --endpoint http://${MILVUS_SERVICE_NAME}:${MILVUS_SERVICE_PORT} --minio_host ${MINIO_SERVICE_NAME} -v -x -m L0 -n 6 --timeout 360
 else
-  pytest testcases --endpoint http://${MILVUS_SERVICE_NAME}:${MILVUS_SERVICE_PORT} --minio_host ${MINIO_SERVICE_NAME} -v -x -m L0 -n 6 --timeout 360 --html=${CI_LOG_PATH}/report_restful.html --self-contained-html
+  pytest testcases --endpoint http://${MILVUS_SERVICE_NAME}:${MILVUS_SERVICE_PORT} --minio_host ${MINIO_SERVICE_NAME} -v -x -m L0 -n 6 --timeout 360
 fi
 
 if [[ "${MILVUS_HELM_RELEASE_NAME}" != *"msop"* ]]; then
   if [[ -n "${TEST_TIMEOUT:-}" ]]; then
 
-    timeout "${TEST_TIMEOUT}" pytest testcases --endpoint http://${MILVUS_SERVICE_NAME}:${MILVUS_SERVICE_PORT} --minio_host ${MINIO_SERVICE_NAME} -v -x -m BulkInsert -n 6 --timeout 360 --html=${CI_LOG_PATH}/report_restful.html --self-contained-html
+    timeout "${TEST_TIMEOUT}" pytest testcases --endpoint http://${MILVUS_SERVICE_NAME}:${MILVUS_SERVICE_PORT} --minio_host ${MINIO_SERVICE_NAME} -v -x -m BulkInsert -n 6 --timeout 360
   else
-    pytest testcases --endpoint http://${MILVUS_SERVICE_NAME}:${MILVUS_SERVICE_PORT} --minio_host ${MINIO_SERVICE_NAME} -v -x -m BulkInsert -n 6 --timeout 360 --html=${CI_LOG_PATH}/report_restful.html --self-contained-html
+    pytest testcases --endpoint http://${MILVUS_SERVICE_NAME}:${MILVUS_SERVICE_PORT} --minio_host ${MINIO_SERVICE_NAME} -v -x -m BulkInsert -n 6 --timeout 360
   fi
 fi
 
@@ -102,9 +102,7 @@ cd ${ROOT}/tests/python_client
 # Pytest is not able to have both --timeout & --workers, so do not add --timeout or --workers in the shell script
 if [[ -n "${TEST_TIMEOUT:-}" ]]; then
   
-  timeout  "${TEST_TIMEOUT}" pytest --host ${MILVUS_SERVICE_NAME} --port ${MILVUS_SERVICE_PORT} --minio_host ${MINIO_SERVICE_NAME}\
-                                     --html=${CI_LOG_PATH}/report.html  --self-contained-html ${@:-}
+  timeout  "${TEST_TIMEOUT}" pytest --host ${MILVUS_SERVICE_NAME} --port ${MILVUS_SERVICE_PORT} --minio_host ${MINIO_SERVICE_NAME} ${@:-}
 else
-  pytest --host ${MILVUS_SERVICE_NAME} --port ${MILVUS_SERVICE_PORT} --minio_host ${MINIO_SERVICE_NAME}\
-                                     --html=${CI_LOG_PATH}/report.html --self-contained-html ${@:-}
+  pytest --host ${MILVUS_SERVICE_NAME} --port ${MILVUS_SERVICE_PORT} --minio_host ${MINIO_SERVICE_NAME} ${@:-}
 fi

--- a/tests/scripts/e2e.sh
+++ b/tests/scripts/e2e.sh
@@ -85,8 +85,7 @@ fi
     if [[ "${MILVUS_CLIENT}" == "pymilvus" ]]; then
       # Better to run pytest under pytest workspace
       export MILVUS_PYTEST_WORKSPACE="/milvus/tests/python_client"
-      docker compose run --rm pytest /bin/bash -c "pytest -n ${PARALLEL_NUM} --host ${MILVUS_SERVICE_IP} --port ${MILVUS_SERVICE_PORT} \
-                                                   --html=\${CI_LOG_PATH}/report.html --self-contained-html ${@:-}"
+      docker compose run --rm pytest /bin/bash -c "pytest -n ${PARALLEL_NUM} --host ${MILVUS_SERVICE_IP} --port ${MILVUS_SERVICE_PORT} ${@:-}"
     fi
   fi
   popd


### PR DESCRIPTION
Remove HTML report generation parameters from CI test scripts:
- ci_e2e.sh
- ci_e2e_4am.sh
- ci_e2e_4am_without_restful.sh
- ci_e2e_with_restful.sh
- e2e.sh