### PR TITLE
enhance: limit segment load concurrency by submitting to load pool

### DIFF
--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -956,13 +956,18 @@ func (loader *segmentLoader) loadSealedSegment(ctx context.Context, loadInfo *qu
 		zap.Int64s("unindexed text fields", lo.Keys(unindexedTextFields)),
 		zap.Int64s("indexed json key fields", lo.Keys(jsonKeyStats)),
 	)
+	_, err = GetLoadPool().Submit(func() (any, error) {
+		if err = segment.Load(ctx); err != nil {
+			return struct{}{}, errors.Wrap(err, "At Load")
+		}
 
-	if err = segment.Load(ctx); err != nil {
-		return errors.Wrap(err, "At Load")
-	}
-
-	if err = segment.FinishLoad(); err != nil {
-		return errors.Wrap(err, "At FinishLoad")
+		if err = segment.FinishLoad(); err != nil {
+			return struct{}{}, errors.Wrap(err, "At FinishLoad")
+		}
+		return struct{}{}, nil
+	}).Await()
+	if err != nil {
+		return err
 	}
 
 	for _, indexInfo := range loadInfo.IndexInfos {


### PR DESCRIPTION
Wrap segment.Load() and segment.FinishLoad() calls inside GetLoadPool().Submit() to control the concurrency of segment loading operations, preventing resource exhaustion during high-load scenarios.