### PR TITLE
fix: [GoSDK][2.6] align timestamptz field type and data format with server(#47304)

### DIFF
--- a/client/column/columns.go
+++ b/client/column/columns.go
@@ -209,7 +209,7 @@ func FieldDataColumn(fd *schemapb.FieldData, begin, end int) (Column, error) {
 		return parseScalarData(fd.GetFieldName(), fd.GetScalars().GetDoubleData().GetData(), begin, end, validData, NewColumnDouble, NewNullableColumnDouble)
 
 	case schemapb.DataType_Timestamptz:
-		return parseScalarData(fd.GetFieldName(), fd.GetScalars().GetTimestamptzData().GetData(), begin, end, validData, NewColumnTimestamptz, NewNullableColumnTimestamptz)
+		return parseScalarData(fd.GetFieldName(), fd.GetScalars().GetStringData().GetData(), begin, end, validData, NewColumnTimestamptzIsoString, NewNullableColumnTimestamptzIsoString)
 
 	case schemapb.DataType_String:
 		return parseScalarData(fd.GetFieldName(), fd.GetScalars().GetStringData().GetData(), begin, end, validData, NewColumnString, NewNullableColumnString)

--- a/client/column/conversion.go
+++ b/client/column/conversion.go
@@ -118,7 +118,8 @@ func values2FieldData[T any](values []T, fieldType entity.FieldType, dim int) *s
 		entity.FieldTypeVarChar,
 		entity.FieldTypeString,
 		entity.FieldTypeJSON,
-		entity.FieldTypeGeometry:
+		entity.FieldTypeGeometry,
+		entity.FieldTypeTimestamptz:
 		fd.Field = &schemapb.FieldData_Scalars{
 			Scalars: values2Scalars(values, fieldType), // scalars,
 		}
@@ -174,7 +175,7 @@ func values2Scalars[T any](values []T, fieldType entity.FieldType) *schemapb.Sca
 		scalars.Data = &schemapb.ScalarField_LongData{
 			LongData: &schemapb.LongArray{Data: int64s},
 		}
-	case entity.FieldTypeVarChar, entity.FieldTypeString:
+	case entity.FieldTypeVarChar, entity.FieldTypeString, entity.FieldTypeTimestamptz:
 		var strVals []string
 		strVals, ok = any(values).([]string)
 		scalars.Data = &schemapb.ScalarField_StringData{

--- a/client/column/nullable.go
+++ b/client/column/nullable.go
@@ -16,20 +16,24 @@
 
 package column
 
+import (
+	"time"
+)
+
 var (
 	// scalars
-	NewNullableColumnBool        NullableColumnCreateFunc[bool, *ColumnBool]          = NewNullableColumnCreator(NewColumnBool).New
-	NewNullableColumnInt8        NullableColumnCreateFunc[int8, *ColumnInt8]          = NewNullableColumnCreator(NewColumnInt8).New
-	NewNullableColumnInt16       NullableColumnCreateFunc[int16, *ColumnInt16]        = NewNullableColumnCreator(NewColumnInt16).New
-	NewNullableColumnInt32       NullableColumnCreateFunc[int32, *ColumnInt32]        = NewNullableColumnCreator(NewColumnInt32).New
-	NewNullableColumnInt64       NullableColumnCreateFunc[int64, *ColumnInt64]        = NewNullableColumnCreator(NewColumnInt64).New
-	NewNullableColumnVarChar     NullableColumnCreateFunc[string, *ColumnVarChar]     = NewNullableColumnCreator(NewColumnVarChar).New
-	NewNullableColumnString      NullableColumnCreateFunc[string, *ColumnString]      = NewNullableColumnCreator(NewColumnString).New
-	NewNullableColumnFloat       NullableColumnCreateFunc[float32, *ColumnFloat]      = NewNullableColumnCreator(NewColumnFloat).New
-	NewNullableColumnDouble      NullableColumnCreateFunc[float64, *ColumnDouble]     = NewNullableColumnCreator(NewColumnDouble).New
-	NewNullableColumnTimestamptz NullableColumnCreateFunc[int64, *ColumnTimestamptz]  = NewNullableColumnCreator(NewColumnTimestamptz).New
-	NewNullableColumnJSONBytes   NullableColumnCreateFunc[[]byte, *ColumnJSONBytes]   = NewNullableColumnCreator(NewColumnJSONBytes).New
-	NewNullableColumnGeometryWKT NullableColumnCreateFunc[string, *ColumnGeometryWKT] = NewNullableColumnCreator(NewColumnGeometryWKT).New
+	NewNullableColumnBool                 NullableColumnCreateFunc[bool, *ColumnBool]                   = NewNullableColumnCreator(NewColumnBool).New
+	NewNullableColumnInt8                 NullableColumnCreateFunc[int8, *ColumnInt8]                   = NewNullableColumnCreator(NewColumnInt8).New
+	NewNullableColumnInt16                NullableColumnCreateFunc[int16, *ColumnInt16]                 = NewNullableColumnCreator(NewColumnInt16).New
+	NewNullableColumnInt32                NullableColumnCreateFunc[int32, *ColumnInt32]                 = NewNullableColumnCreator(NewColumnInt32).New
+	NewNullableColumnInt64                NullableColumnCreateFunc[int64, *ColumnInt64]                 = NewNullableColumnCreator(NewColumnInt64).New
+	NewNullableColumnVarChar              NullableColumnCreateFunc[string, *ColumnVarChar]              = NewNullableColumnCreator(NewColumnVarChar).New
+	NewNullableColumnString               NullableColumnCreateFunc[string, *ColumnString]               = NewNullableColumnCreator(NewColumnString).New
+	NewNullableColumnFloat                NullableColumnCreateFunc[float32, *ColumnFloat]               = NewNullableColumnCreator(NewColumnFloat).New
+	NewNullableColumnDouble               NullableColumnCreateFunc[float64, *ColumnDouble]              = NewNullableColumnCreator(NewColumnDouble).New
+	NewNullableColumnTimestamptzIsoString NullableColumnCreateFunc[string, *ColumnTimestampTzIsoString] = NewNullableColumnCreator(NewColumnTimestamptzIsoString).New
+	NewNullableColumnJSONBytes            NullableColumnCreateFunc[[]byte, *ColumnJSONBytes]            = NewNullableColumnCreator(NewColumnJSONBytes).New
+	NewNullableColumnGeometryWKT          NullableColumnCreateFunc[string, *ColumnGeometryWKT]          = NewNullableColumnCreator(NewColumnGeometryWKT).New
 	// array
 	NewNullableColumnBoolArray    NullableColumnCreateFunc[[]bool, *ColumnBoolArray]      = NewNullableColumnCreator(NewColumnBoolArray).New
 	NewNullableColumnInt8Array    NullableColumnCreateFunc[[]int8, *ColumnInt8Array]      = NewNullableColumnCreator(NewColumnInt8Array).New
@@ -74,4 +78,15 @@ func NewNullableColumnCreator[col interface {
 	return NullableColumnCreator[col, T]{
 		base: base,
 	}
+}
+
+func NewNullableColumnTimestamptz(name string, values []time.Time, validData []bool, opts ...ColumnOption[string]) (*ColumnTimestamptz, error) {
+	result := NewColumnTimestamptz(name, values)
+	result.withValidData(validData)
+
+	for _, opt := range opts {
+		opt(result.genericColumnBase)
+	}
+
+	return result, result.ValidateNullable()
 }

--- a/client/column/scalar.go
+++ b/client/column/scalar.go
@@ -17,6 +17,10 @@
 package column
 
 import (
+	"time"
+
+	"github.com/samber/lo"
+
 	"github.com/milvus-io/milvus/client/v2/entity"
 )
 
@@ -186,7 +190,7 @@ func (c *ColumnFloat) GetAsDouble(idx int) (float64, error) {
 
 /* Double */
 
-var _ Column = (*ColumnFloat)(nil)
+var _ Column = (*ColumnDouble)(nil)
 
 type ColumnDouble struct {
 	*genericColumnBase[float64]
@@ -212,16 +216,46 @@ func (c *ColumnDouble) Slice(start, end int) Column {
 var _ Column = (*ColumnTimestamptz)(nil)
 
 type ColumnTimestamptz struct {
-	*genericColumnBase[int64]
+	*genericColumnBase[string]
 }
 
-func NewColumnTimestamptz(name string, values []int64) *ColumnTimestamptz {
+func NewColumnTimestamptz(name string, values []time.Time) *ColumnTimestamptz {
 	return &ColumnTimestamptz{
-		genericColumnBase: &genericColumnBase[int64]{
+		genericColumnBase: &genericColumnBase[string]{
+			name:      name,
+			fieldType: entity.FieldTypeTimestamptz,
+			values: lo.Map(values, func(t time.Time, _ int) string {
+				return t.Format(time.RFC3339Nano)
+			}),
+		},
+	}
+}
+
+func (c *ColumnTimestamptz) Slice(start, end int) Column {
+	return &ColumnTimestamptz{
+		genericColumnBase: c.genericColumnBase.slice(start, end),
+	}
+}
+
+var _ Column = (*ColumnTimestampTzIsoString)(nil)
+
+type ColumnTimestampTzIsoString struct {
+	*genericColumnBase[string]
+}
+
+func NewColumnTimestamptzIsoString(name string, values []string) *ColumnTimestampTzIsoString {
+	return &ColumnTimestampTzIsoString{
+		genericColumnBase: &genericColumnBase[string]{
 			name:      name,
 			fieldType: entity.FieldTypeTimestamptz,
 			values:    values,
 		},
+	}
+}
+
+func (c *ColumnTimestampTzIsoString) Slice(start, end int) Column {
+	return &ColumnTimestampTzIsoString{
+		genericColumnBase: c.genericColumnBase.slice(start, end),
 	}
 }
 

--- a/client/entity/field.go
+++ b/client/entity/field.go
@@ -177,8 +177,6 @@ const (
 	FieldTypeFloat FieldType = 10
 	// FieldTypeDouble field type double
 	FieldTypeDouble FieldType = 11
-	// FieldTypeTimestamptz field type timestamptz
-	FieldTypeTimestamptz FieldType = 15
 	// FieldTypeString field type string
 	FieldTypeString FieldType = 20
 	// FieldTypeVarChar field type varchar
@@ -189,6 +187,8 @@ const (
 	FieldTypeJSON FieldType = 23
 	// FieldTypeGeometry field type Geometry
 	FieldTypeGeometry FieldType = 24
+	// FieldTypeTimestamptz field type timestamptz
+	FieldTypeTimestamptz FieldType = 26
 	// FieldTypeBinaryVector field type binary vector
 	FieldTypeBinaryVector FieldType = 100
 	// FieldTypeFloatVector field type float vector

--- a/client/milvusclient/mock_milvus_server_test.go
+++ b/client/milvusclient/mock_milvus_server_test.go
@@ -6686,8 +6686,7 @@ func (_c *MilvusServiceServer_Upsert_Call) RunAndReturn(run func(context.Context
 func NewMilvusServiceServer(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *MilvusServiceServer {
+}) *MilvusServiceServer {
 	mock := &MilvusServiceServer{}
 	mock.Mock.Test(t)
 


### PR DESCRIPTION
Cherry-pick from master
pr: #47304
Related to #47303

The Go SDK had two issues with Timestamptz field type:

1. FieldTypeTimestamptz was incorrectly defined as 15, but server expects 26
2. Timestamptz data was serialized as int64 via TimestamptzData, but server expects ISO 8601 strings (RFC3339Nano format) via StringData

Changes:
- Update FieldTypeTimestamptz value from 15 to 26
- Modify ColumnTimestamptz to store data as RFC3339Nano strings internally
- Change NewColumnTimestamptz to accept []time.Time and convert to ISO strings
- Add ColumnTimestampTzIsoString for direct ISO string input
- Update FieldDataColumn to parse Timestamptz from StringData
- Update values2Scalars to handle Timestamptz as string type
- Add NewNullableColumnTimestamptz for nullable time.Time input
- Update NewNullableColumnTimestamptzIsoString for nullable ISO string input
- Add corresponding unit tests

---------