### PR TITLE
fix: avoid coredump and print more info for PhyRescoresNode

### DIFF
--- a/internal/core/src/exec/operator/RescoresNode.cpp
+++ b/internal/core/src/exec/operator/RescoresNode.cpp
@@ -16,6 +16,7 @@
 
 #include "RescoresNode.h"
 #include "common/Tracer.h"
+#include "common/EasyAssert.h"
 #include "fmt/format.h"
 #include <cstddef>
 #include "exec/operator/Utils.h"
@@ -126,7 +127,17 @@ PhyRescoresNode::GetOutput() {
             expr_set->Eval(0, 1, true, eval_ctx, results);
 
             // filter result for offsets[i] was resut bitset[i]
+            AssertInfo(!results.empty() && results[0] != nullptr,
+                       "PhyRescoresNode: filter expr returned null result, "
+                       "offsets size: {}, filter: {}",
+                       offsets.size(),
+                       filter->ToString());
             auto col_vec = std::dynamic_pointer_cast<ColumnVector>(results[0]);
+            AssertInfo(
+                col_vec != nullptr,
+                "PhyRescoresNode: failed to cast result to ColumnVector, "
+                "filter: {}",
+                filter->ToString());
             auto col_vec_size = col_vec->size();
             TargetBitmapView bitsetview(col_vec->GetRawData(), col_vec_size);
             scorer->batch_score(op_context,
@@ -140,8 +151,17 @@ PhyRescoresNode::GetOutput() {
             expr_set->Eval(0, 1, true, eval_ctx, results);
 
             // filter result for offsets[i] was bitset[offset[i]]
-            TargetBitmap bitset;
+            AssertInfo(!results.empty() && results[0] != nullptr,
+                       "PhyRescoresNode: filter expr returned null result, "
+                       "filter: {}",
+                       filter->ToString());
             auto col_vec = std::dynamic_pointer_cast<ColumnVector>(results[0]);
+            AssertInfo(
+                col_vec != nullptr,
+                "PhyRescoresNode: failed to cast result to ColumnVector, "
+                "filter: {}",
+                filter->ToString());
+            TargetBitmap bitset;
             auto col_vec_size = col_vec->size();
             TargetBitmapView view(col_vec->GetRawData(), col_vec_size);
             bitset.append(view);


### PR DESCRIPTION
issue: #47339
