### PR TITLE
fix: pass scalar index version through load path to fix version 3 index loading

### DIFF
--- a/internal/core/src/index/Utils.h
+++ b/internal/core/src/index/Utils.h
@@ -103,6 +103,17 @@ GetValueFromConfig(const Config& cfg, const std::string& key) {
             return boost::algorithm::to_lower_copy(value.get<std::string>()) ==
                    "true";
         }
+        // compatibility for numeric string (e.g., from index_params which is map<string,string>)
+        if constexpr (std::is_integral_v<T>) {
+            if (value.is_string()) {
+                auto str = value.get<std::string>();
+                if constexpr (std::is_signed_v<T>) {
+                    return static_cast<T>(std::stoll(str));
+                } else {
+                    return static_cast<T>(std::stoull(str));
+                }
+            }
+        }
         return value.get<T>();
     } catch (const nlohmann::json::type_error& e) {
         if (!CONFIG_PARAM_TYPE_CHECK_ENABLED) {

--- a/internal/core/src/segcore/SegmentLoadInfo.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfo.cpp
@@ -17,6 +17,7 @@
 #include <memory>
 
 #include "common/FieldMeta.h"
+#include "index/Meta.h"
 #include "milvus-storage/column_groups.h"
 #include "storage/LocalChunkManagerSingleton.h"
 #include "storage/loon_ffi/property_singleton.h"
@@ -100,6 +101,13 @@ SegmentLoadInfo::ConvertFieldIndexInfoToLoadIndexInfo(
         load_index_info.index_params[kv_pair.key()] = kv_pair.value();
     }
 
+    // Inject scalar index version into index_params for scalar indexes
+    auto scalar_version = field_index_info->current_scalar_index_version();
+    if (scalar_version > 0) {
+        load_index_info
+            .index_params[milvus::index::SCALAR_INDEX_ENGINE_VERSION] =
+            std::to_string(scalar_version);
+    }
     size_t dim =
         IsVectorDataType(field_meta.get_data_type()) &&
                 !IsSparseFloatVectorDataType(field_meta.get_data_type())

--- a/internal/core/src/segcore/load_index_c.cpp
+++ b/internal/core/src/segcore/load_index_c.cpp
@@ -326,6 +326,13 @@ FinishLoadIndexInfo(CLoadIndexInfo c_load_index_info,
             load_index_info->uri = info_proto->uri();
             load_index_info->index_engine_version =
                 info_proto->index_engine_version();
+            // Inject scalar index version into index_params for scalar indexes
+            auto scalar_version = info_proto->current_scalar_index_version();
+            if (scalar_version > 0) {
+                load_index_info->index_params
+                    [milvus::index::SCALAR_INDEX_ENGINE_VERSION] =
+                        std::to_string(scalar_version);
+            }
             load_index_info->schema = info_proto->field();
             load_index_info->index_size = info_proto->index_file_size();
             load_index_info->num_rows = info_proto->num_rows();

--- a/internal/core/src/segcore/load_index_c.cpp
+++ b/internal/core/src/segcore/load_index_c.cpp
@@ -329,9 +329,9 @@ FinishLoadIndexInfo(CLoadIndexInfo c_load_index_info,
             // Inject scalar index version into index_params for scalar indexes
             auto scalar_version = info_proto->current_scalar_index_version();
             if (scalar_version > 0) {
-                load_index_info->index_params
-                    [milvus::index::SCALAR_INDEX_ENGINE_VERSION] =
-                        std::to_string(scalar_version);
+                load_index_info
+                    ->index_params[milvus::index::SCALAR_INDEX_ENGINE_VERSION] =
+                    std::to_string(scalar_version);
             }
             load_index_info->schema = info_proto->field();
             load_index_info->index_size = info_proto->index_file_size();

--- a/internal/datacoord/compaction_trigger_test.go
+++ b/internal/datacoord/compaction_trigger_test.go
@@ -1825,7 +1825,8 @@ func Test_compactionTrigger_shouldDoSingleCompaction(t *testing.T) {
 	assert.True(t, couldDo)
 
 	mockVersionManager := NewMockVersionManager(t)
-	mockVersionManager.On("GetCurrentIndexEngineVersion", mock.Anything).Return(int32(2), nil)
+	mockVersionManager.On("GetCurrentIndexEngineVersion").Return(int32(2)).Maybe()
+	mockVersionManager.On("GetCurrentScalarIndexEngineVersion").Return(int32(2)).Maybe()
 	trigger.indexEngineVersionManager = mockVersionManager
 	info4 := &SegmentInfo{
 		SegmentInfo: &datapb.SegmentInfo{
@@ -1881,6 +1882,9 @@ func Test_compactionTrigger_shouldDoSingleCompaction(t *testing.T) {
 			101: {
 				CollectionID: 2,
 				IndexID:      101,
+				IndexParams: []*commonpb.KeyValuePair{
+					{Key: common.IndexTypeKey, Value: "HNSW"},
+				},
 			},
 		},
 	}

--- a/internal/datacoord/handler.go
+++ b/internal/datacoord/handler.go
@@ -857,18 +857,19 @@ func uncompressIndexFiles(h *ServerHandler, collectionID int64, segID int64) []*
 			indexParams = append(indexParams, h.s.meta.indexMeta.GetTypeParams(segIdx.CollectionID, segIdx.IndexID)...)
 
 			indexesFiles = append(indexesFiles, &indexpb.IndexFilePathInfo{
-				SegmentID:           segID,
-				FieldID:             fieldID,
-				IndexID:             segIdx.IndexID,
-				BuildID:             segIdx.BuildID,
-				IndexName:           indexName,
-				IndexParams:         indexParams,
-				IndexFilePaths:      indexFilePaths,
-				SerializedSize:      segIdx.IndexSerializedSize,
-				MemSize:             segIdx.IndexMemSize,
-				IndexVersion:        segIdx.IndexVersion,
-				NumRows:             segIdx.NumRows,
-				CurrentIndexVersion: segIdx.CurrentIndexVersion,
+				SegmentID:                 segID,
+				FieldID:                   fieldID,
+				IndexID:                   segIdx.IndexID,
+				BuildID:                   segIdx.BuildID,
+				IndexName:                 indexName,
+				IndexParams:               indexParams,
+				IndexFilePaths:            indexFilePaths,
+				SerializedSize:            segIdx.IndexSerializedSize,
+				MemSize:                   segIdx.IndexMemSize,
+				IndexVersion:              segIdx.IndexVersion,
+				NumRows:                   segIdx.NumRows,
+				CurrentIndexVersion:       segIdx.CurrentIndexVersion,
+				CurrentScalarIndexVersion: segIdx.CurrentScalarIndexVersion,
 			})
 		}
 	}

--- a/internal/datacoord/index_engine_version_manager.go
+++ b/internal/datacoord/index_engine_version_manager.go
@@ -11,17 +11,36 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/util/lock"
 )
 
+// IndexEngineVersionManager manages the index engine versions reported by all QueryNodes in the cluster.
+//
+// Each QueryNode registers its supported index version range [MinimalIndexVersion, CurrentIndexVersion]
+// in its session. This manager aggregates versions from all QNs to determine cluster-wide compatibility:
+//
+//   - GetCurrent*Version(): Returns MIN of all QNs' CurrentIndexVersion.
+//     This is the highest version that ALL QueryNodes can load.
+//     Used when building new indexes to ensure all QNs can load them (rolling upgrade safe).
+//
+//   - GetMinimal*Version(): Returns MAX of all QNs' MinimalIndexVersion.
+//     This is the lowest version that ANY QueryNode requires.
+//     Indexes below this version may fail to load on some QNs.
+//     TODO: This is not currently used in the codebase, could be used to check if the index is of too old to
+//     load on any query nodes.
+//
+// Vector index versions come from knowhere library, while scalar index versions are defined by Milvus.
 type IndexEngineVersionManager interface {
 	Startup(sessions map[string]*sessionutil.Session)
 	AddNode(session *sessionutil.Session)
 	RemoveNode(session *sessionutil.Session)
 	Update(session *sessionutil.Session)
 
+	// Vector index version methods (from knowhere library)
 	GetCurrentIndexEngineVersion() int32
 	GetMinimalIndexEngineVersion() int32
 
+	// Scalar index version methods (Milvus-defined)
 	GetCurrentScalarIndexEngineVersion() int32
 	GetMinimalScalarIndexEngineVersion() int32
+
 	GetIndexNonEncoding() bool
 }
 

--- a/internal/datacoord/index_engine_version_manager.go
+++ b/internal/datacoord/index_engine_version_manager.go
@@ -108,7 +108,7 @@ func (m *versionManagerImpl) Update(session *sessionutil.Session) {
 }
 
 func (m *versionManagerImpl) addOrUpdate(session *sessionutil.Session) {
-	log.Info("addOrUpdate version", zap.Int64("nodeId", session.ServerID), zap.Int32("minimal", session.IndexEngineVersion.MinimalIndexVersion), zap.Int32("current", session.IndexEngineVersion.CurrentIndexVersion))
+	log.Info("addOrUpdate version", zap.Int64("nodeId", session.ServerID), zap.Int32("minimal", session.IndexEngineVersion.MinimalIndexVersion), zap.Int32("current", session.IndexEngineVersion.CurrentIndexVersion), zap.Int32("currentScalar", session.ScalarIndexEngineVersion.CurrentIndexVersion))
 	m.versions[session.ServerID] = session.IndexEngineVersion
 	m.scalarIndexVersions[session.ServerID] = session.ScalarIndexEngineVersion
 	m.indexNonEncoding[session.ServerID] = session.IndexNonEncoding

--- a/internal/datacoord/index_meta.go
+++ b/internal/datacoord/index_meta.go
@@ -1097,12 +1097,16 @@ func (m *indexMeta) getSegmentsIndexStates(collectionID UniqueID, segmentIDs []U
 
 		for _, segIdx := range segIndexInfos.Values() {
 			if index, ok := fieldIndexes[segIdx.IndexID]; ok && !index.IsDeleted {
+				indexVersion := segIdx.CurrentIndexVersion
+				if indexparamcheck.IsScalarIndexType(indexparamcheck.IndexType(segIdx.IndexType)) {
+					indexVersion = segIdx.CurrentScalarIndexVersion
+				}
 				ret[segID][segIdx.IndexID] = &indexpb.SegmentIndexState{
 					SegmentID:    segID,
 					State:        segIdx.IndexState,
 					FailReason:   segIdx.FailReason,
 					IndexName:    index.IndexName,
-					IndexVersion: segIdx.CurrentIndexVersion,
+					IndexVersion: indexVersion,
 				}
 			}
 		}

--- a/internal/datacoord/index_service.go
+++ b/internal/datacoord/index_service.go
@@ -1092,18 +1092,19 @@ func (s *Server) GetIndexInfos(ctx context.Context, req *indexpb.GetIndexInfoReq
 					}
 					ret.SegmentInfo[segID].IndexInfos = append(ret.SegmentInfo[segID].IndexInfos,
 						&indexpb.IndexFilePathInfo{
-							SegmentID:           segID,
-							FieldID:             s.meta.indexMeta.GetFieldIDByIndexID(segIdx.CollectionID, segIdx.IndexID),
-							IndexID:             segIdx.IndexID,
-							BuildID:             segIdx.BuildID,
-							IndexName:           indexName,
-							IndexParams:         indexParams,
-							IndexFilePaths:      indexFilePaths,
-							SerializedSize:      segIdx.IndexSerializedSize,
-							MemSize:             segIdx.IndexMemSize,
-							IndexVersion:        segIdx.IndexVersion,
-							NumRows:             segIdx.NumRows,
-							CurrentIndexVersion: segIdx.CurrentIndexVersion,
+							SegmentID:                 segID,
+							FieldID:                   s.meta.indexMeta.GetFieldIDByIndexID(segIdx.CollectionID, segIdx.IndexID),
+							IndexID:                   segIdx.IndexID,
+							BuildID:                   segIdx.BuildID,
+							IndexName:                 indexName,
+							IndexParams:               indexParams,
+							IndexFilePaths:            indexFilePaths,
+							SerializedSize:            segIdx.IndexSerializedSize,
+							MemSize:                   segIdx.IndexMemSize,
+							IndexVersion:              segIdx.IndexVersion,
+							NumRows:                   segIdx.NumRows,
+							CurrentIndexVersion:       segIdx.CurrentIndexVersion,
+							CurrentScalarIndexVersion: segIdx.CurrentScalarIndexVersion,
 						})
 				}
 			}

--- a/internal/datacoord/snapshot.go
+++ b/internal/datacoord/snapshot.go
@@ -244,6 +244,8 @@ type AvroIndexFilePathInfo struct {
 	NumRows int64 `avro:"num_rows"`
 	// CurrentIndexVersion is the current index algorithm version.
 	CurrentIndexVersion int32 `avro:"current_index_version"`
+	// CurrentScalarIndexVersion is the current scalar index version.
+	CurrentScalarIndexVersion int32 `avro:"current_scalar_index_version"`
 	// MemSize is the estimated memory consumption when loaded.
 	MemSize int64 `avro:"mem_size"`
 }
@@ -1066,18 +1068,19 @@ func convertFieldBinlogToAvro(fb *datapb.FieldBinlog) AvroFieldBinlog {
 // Handles size field conversion from uint64 (proto) to int64 (Avro).
 func convertIndexFilePathInfoToAvro(info *indexpb.IndexFilePathInfo) AvroIndexFilePathInfo {
 	avroInfo := AvroIndexFilePathInfo{
-		SegmentID:           info.GetSegmentID(),
-		FieldID:             info.GetFieldID(),
-		IndexID:             info.GetIndexID(),
-		BuildID:             info.GetBuildID(),
-		IndexName:           info.GetIndexName(),
-		IndexFilePaths:      info.GetIndexFilePaths(),
-		SerializedSize:      int64(info.GetSerializedSize()), // uint64 -> int64
-		IndexVersion:        info.GetIndexVersion(),
-		NumRows:             info.GetNumRows(),
-		CurrentIndexVersion: info.GetCurrentIndexVersion(),
-		MemSize:             int64(info.GetMemSize()), // uint64 -> int64
-		IndexParams:         make([]AvroKeyValuePair, len(info.GetIndexParams())),
+		SegmentID:                 info.GetSegmentID(),
+		FieldID:                   info.GetFieldID(),
+		IndexID:                   info.GetIndexID(),
+		BuildID:                   info.GetBuildID(),
+		IndexName:                 info.GetIndexName(),
+		IndexFilePaths:            info.GetIndexFilePaths(),
+		SerializedSize:            int64(info.GetSerializedSize()), // uint64 -> int64
+		IndexVersion:              info.GetIndexVersion(),
+		NumRows:                   info.GetNumRows(),
+		CurrentIndexVersion:       info.GetCurrentIndexVersion(),
+		CurrentScalarIndexVersion: info.GetCurrentScalarIndexVersion(),
+		MemSize:                   int64(info.GetMemSize()), // uint64 -> int64
+		IndexParams:               make([]AvroKeyValuePair, len(info.GetIndexParams())),
 	}
 
 	// Convert key-value parameters
@@ -1120,17 +1123,18 @@ func convertAvroToFieldBinlog(avroFB AvroFieldBinlog) *datapb.FieldBinlog {
 // Handles size field conversion from int64 (Avro) to uint64 (proto).
 func convertAvroToIndexFilePathInfo(avroInfo AvroIndexFilePathInfo) *indexpb.IndexFilePathInfo {
 	info := &indexpb.IndexFilePathInfo{
-		SegmentID:           avroInfo.SegmentID,
-		FieldID:             avroInfo.FieldID,
-		IndexID:             avroInfo.IndexID,
-		BuildID:             avroInfo.BuildID,
-		IndexName:           avroInfo.IndexName,
-		IndexFilePaths:      avroInfo.IndexFilePaths,
-		SerializedSize:      uint64(avroInfo.SerializedSize), // int64 -> uint64
-		IndexVersion:        avroInfo.IndexVersion,
-		NumRows:             avroInfo.NumRows,
-		CurrentIndexVersion: avroInfo.CurrentIndexVersion,
-		MemSize:             uint64(avroInfo.MemSize), // int64 -> uint64
+		SegmentID:                 avroInfo.SegmentID,
+		FieldID:                   avroInfo.FieldID,
+		IndexID:                   avroInfo.IndexID,
+		BuildID:                   avroInfo.BuildID,
+		IndexName:                 avroInfo.IndexName,
+		IndexFilePaths:            avroInfo.IndexFilePaths,
+		SerializedSize:            uint64(avroInfo.SerializedSize), // int64 -> uint64
+		IndexVersion:              avroInfo.IndexVersion,
+		NumRows:                   avroInfo.NumRows,
+		CurrentIndexVersion:       avroInfo.CurrentIndexVersion,
+		CurrentScalarIndexVersion: avroInfo.CurrentScalarIndexVersion,
+		MemSize:                   uint64(avroInfo.MemSize), // int64 -> uint64
 	}
 
 	// Convert key-value parameters

--- a/internal/datanode/importv2/copy_segment_utils.go
+++ b/internal/datanode/importv2/copy_segment_utils.go
@@ -497,13 +497,14 @@ func buildIndexInfoFromSource(
 		}
 
 		indexInfos[srcIndex.GetFieldID()] = &datapb.VectorScalarIndexInfo{
-			FieldId:             srcIndex.GetFieldID(),
-			IndexId:             srcIndex.GetIndexID(),
-			BuildId:             srcIndex.GetBuildID(),
-			Version:             srcIndex.GetIndexVersion(),
-			IndexFilePaths:      targetPaths,
-			IndexSize:           int64(srcIndex.GetSerializedSize()),
-			CurrentIndexVersion: srcIndex.GetCurrentIndexVersion(),
+			FieldId:                   srcIndex.GetFieldID(),
+			IndexId:                   srcIndex.GetIndexID(),
+			BuildId:                   srcIndex.GetBuildID(),
+			Version:                   srcIndex.GetIndexVersion(),
+			IndexFilePaths:            targetPaths,
+			IndexSize:                 int64(srcIndex.GetSerializedSize()),
+			CurrentIndexVersion:       srcIndex.GetCurrentIndexVersion(),
+			CurrentScalarIndexVersion: srcIndex.GetCurrentScalarIndexVersion(),
 		}
 	}
 

--- a/internal/datanode/index_services.go
+++ b/internal/datanode/index_services.go
@@ -153,6 +153,7 @@ func (node *DataNode) QueryJobs(ctx context.Context, req *workerpb.QueryJobsRequ
 			ret.IndexInfos[i].MemSize = info.MemSize
 			ret.IndexInfos[i].FailReason = info.FailReason
 			ret.IndexInfos[i].CurrentIndexVersion = info.CurrentIndexVersion
+			ret.IndexInfos[i].CurrentScalarIndexVersion = info.CurrentScalarIndexVersion
 			log.RatedDebug(5, "querying index build task",
 				zap.Int64("indexBuildID", buildID),
 				zap.String("state", info.State.String()),

--- a/internal/querycoordv2/meta/coordinator_broker.go
+++ b/internal/querycoordv2/meta/coordinator_broker.go
@@ -345,17 +345,18 @@ func (broker *CoordinatorBroker) GetIndexInfo(ctx context.Context, collectionID 
 		indexes[segmentID] = make([]*querypb.FieldIndexInfo, 0)
 		for _, info := range segmentInfo.GetIndexInfos() {
 			indexes[segmentID] = append(indexes[segmentID], &querypb.FieldIndexInfo{
-				FieldID:             info.GetFieldID(),
-				EnableIndex:         true, // deprecated, but keep it for compatibility
-				IndexName:           info.GetIndexName(),
-				IndexID:             info.GetIndexID(),
-				BuildID:             info.GetBuildID(),
-				IndexParams:         info.GetIndexParams(),
-				IndexFilePaths:      info.GetIndexFilePaths(),
-				IndexSize:           int64(info.GetMemSize()),
-				IndexVersion:        info.GetIndexVersion(),
-				NumRows:             info.GetNumRows(),
-				CurrentIndexVersion: info.GetCurrentIndexVersion(),
+				FieldID:                    info.GetFieldID(),
+				EnableIndex:                true, // deprecated, but keep it for compatibility
+				IndexName:                  info.GetIndexName(),
+				IndexID:                    info.GetIndexID(),
+				BuildID:                    info.GetBuildID(),
+				IndexParams:                info.GetIndexParams(),
+				IndexFilePaths:             info.GetIndexFilePaths(),
+				IndexSize:                  int64(info.GetMemSize()),
+				IndexVersion:               info.GetIndexVersion(),
+				NumRows:                    info.GetNumRows(),
+				CurrentIndexVersion:        info.GetCurrentIndexVersion(),
+				CurrentScalarIndexVersion:  info.GetCurrentScalarIndexVersion(),
 			})
 		}
 	}

--- a/internal/querycoordv2/meta/coordinator_broker.go
+++ b/internal/querycoordv2/meta/coordinator_broker.go
@@ -345,18 +345,18 @@ func (broker *CoordinatorBroker) GetIndexInfo(ctx context.Context, collectionID 
 		indexes[segmentID] = make([]*querypb.FieldIndexInfo, 0)
 		for _, info := range segmentInfo.GetIndexInfos() {
 			indexes[segmentID] = append(indexes[segmentID], &querypb.FieldIndexInfo{
-				FieldID:                    info.GetFieldID(),
-				EnableIndex:                true, // deprecated, but keep it for compatibility
-				IndexName:                  info.GetIndexName(),
-				IndexID:                    info.GetIndexID(),
-				BuildID:                    info.GetBuildID(),
-				IndexParams:                info.GetIndexParams(),
-				IndexFilePaths:             info.GetIndexFilePaths(),
-				IndexSize:                  int64(info.GetMemSize()),
-				IndexVersion:               info.GetIndexVersion(),
-				NumRows:                    info.GetNumRows(),
-				CurrentIndexVersion:        info.GetCurrentIndexVersion(),
-				CurrentScalarIndexVersion:  info.GetCurrentScalarIndexVersion(),
+				FieldID:                   info.GetFieldID(),
+				EnableIndex:               true, // deprecated, but keep it for compatibility
+				IndexName:                 info.GetIndexName(),
+				IndexID:                   info.GetIndexID(),
+				BuildID:                   info.GetBuildID(),
+				IndexParams:               info.GetIndexParams(),
+				IndexFilePaths:            info.GetIndexFilePaths(),
+				IndexSize:                 int64(info.GetMemSize()),
+				IndexVersion:              info.GetIndexVersion(),
+				NumRows:                   info.GetNumRows(),
+				CurrentIndexVersion:       info.GetCurrentIndexVersion(),
+				CurrentScalarIndexVersion: info.GetCurrentScalarIndexVersion(),
 			})
 		}
 	}

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -1073,19 +1073,20 @@ func GetCLoadInfoWithFunc(ctx context.Context,
 
 	enableMmap := isIndexMmapEnable(fieldSchema, indexInfo)
 	indexInfoProto := &cgopb.LoadIndexInfo{
-		CollectionID:       loadInfo.GetCollectionID(),
-		PartitionID:        loadInfo.GetPartitionID(),
-		SegmentID:          loadInfo.GetSegmentID(),
-		Field:              fieldSchema,
-		EnableMmap:         enableMmap,
-		IndexID:            indexInfo.GetIndexID(),
-		IndexBuildID:       indexInfo.GetBuildID(),
-		IndexVersion:       indexInfo.GetIndexVersion(),
-		IndexParams:        indexParams,
-		IndexFiles:         indexInfo.GetIndexFilePaths(),
-		IndexEngineVersion: indexInfo.GetCurrentIndexVersion(),
-		IndexFileSize:      indexInfo.GetIndexSize(),
-		NumRows:            indexInfo.GetNumRows(),
+		CollectionID:              loadInfo.GetCollectionID(),
+		PartitionID:               loadInfo.GetPartitionID(),
+		SegmentID:                 loadInfo.GetSegmentID(),
+		Field:                     fieldSchema,
+		EnableMmap:                enableMmap,
+		IndexID:                   indexInfo.GetIndexID(),
+		IndexBuildID:              indexInfo.GetBuildID(),
+		IndexVersion:              indexInfo.GetIndexVersion(),
+		IndexParams:               indexParams,
+		IndexFiles:                indexInfo.GetIndexFilePaths(),
+		IndexEngineVersion:        indexInfo.GetCurrentIndexVersion(),
+		IndexFileSize:             indexInfo.GetIndexSize(),
+		NumRows:                   indexInfo.GetNumRows(),
+		CurrentScalarIndexVersion: indexInfo.GetCurrentScalarIndexVersion(),
 	}
 
 	// 2.
@@ -1203,16 +1204,17 @@ func (s *LocalSegment) LoadTextIndex(ctx context.Context, textLogs *datapb.TextI
 	// Text match index mmap config is based on the raw data mmap.
 	enableMmap := isDataMmapEnable(f)
 	cgoProto := &indexcgopb.LoadTextIndexInfo{
-		FieldID:      textLogs.GetFieldID(),
-		Version:      textLogs.GetVersion(),
-		BuildID:      textLogs.GetBuildID(),
-		Files:        textLogs.GetFiles(),
-		Schema:       f,
-		CollectionID: s.Collection(),
-		PartitionID:  s.Partition(),
-		LoadPriority: s.LoadInfo().GetPriority(),
-		EnableMmap:   enableMmap,
-		IndexSize:    textLogs.GetMemorySize(),
+		FieldID:                    textLogs.GetFieldID(),
+		Version:                    textLogs.GetVersion(),
+		BuildID:                    textLogs.GetBuildID(),
+		Files:                      textLogs.GetFiles(),
+		Schema:                     f,
+		CollectionID:               s.Collection(),
+		PartitionID:                s.Partition(),
+		LoadPriority:               s.LoadInfo().GetPriority(),
+		EnableMmap:                 enableMmap,
+		IndexSize:                  textLogs.GetMemorySize(),
+		CurrentScalarIndexVersion:  textLogs.GetCurrentScalarIndexVersion(),
 	}
 
 	marshaled, err := proto.Marshal(cgoProto)

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -1204,17 +1204,17 @@ func (s *LocalSegment) LoadTextIndex(ctx context.Context, textLogs *datapb.TextI
 	// Text match index mmap config is based on the raw data mmap.
 	enableMmap := isDataMmapEnable(f)
 	cgoProto := &indexcgopb.LoadTextIndexInfo{
-		FieldID:                    textLogs.GetFieldID(),
-		Version:                    textLogs.GetVersion(),
-		BuildID:                    textLogs.GetBuildID(),
-		Files:                      textLogs.GetFiles(),
-		Schema:                     f,
-		CollectionID:               s.Collection(),
-		PartitionID:                s.Partition(),
-		LoadPriority:               s.LoadInfo().GetPriority(),
-		EnableMmap:                 enableMmap,
-		IndexSize:                  textLogs.GetMemorySize(),
-		CurrentScalarIndexVersion:  textLogs.GetCurrentScalarIndexVersion(),
+		FieldID:                   textLogs.GetFieldID(),
+		Version:                   textLogs.GetVersion(),
+		BuildID:                   textLogs.GetBuildID(),
+		Files:                     textLogs.GetFiles(),
+		Schema:                    f,
+		CollectionID:              s.Collection(),
+		PartitionID:               s.Partition(),
+		LoadPriority:              s.LoadInfo().GetPriority(),
+		EnableMmap:                enableMmap,
+		IndexSize:                 textLogs.GetMemorySize(),
+		CurrentScalarIndexVersion: textLogs.GetCurrentScalarIndexVersion(),
 	}
 
 	marshaled, err := proto.Marshal(cgoProto)

--- a/internal/util/segcore/segment.go
+++ b/internal/util/segcore/segment.go
@@ -454,17 +454,18 @@ func convertFieldIndexInfos(src []*querypb.FieldIndexInfo) []*segcorepb.FieldInd
 		}
 
 		result = append(result, &segcorepb.FieldIndexInfo{
-			FieldID:             fii.GetFieldID(),
-			EnableIndex:         fii.GetEnableIndex(),
-			IndexName:           fii.GetIndexName(),
-			IndexID:             fii.GetIndexID(),
-			BuildID:             fii.GetBuildID(),
-			IndexParams:         fii.GetIndexParams(),
-			IndexFilePaths:      fii.GetIndexFilePaths(),
-			IndexSize:           fii.GetIndexSize(),
-			IndexVersion:        fii.GetIndexVersion(),
-			NumRows:             fii.GetNumRows(),
-			CurrentIndexVersion: fii.GetCurrentIndexVersion(),
+			FieldID:                   fii.GetFieldID(),
+			EnableIndex:               fii.GetEnableIndex(),
+			IndexName:                 fii.GetIndexName(),
+			IndexID:                   fii.GetIndexID(),
+			BuildID:                   fii.GetBuildID(),
+			IndexParams:               fii.GetIndexParams(),
+			IndexFilePaths:            fii.GetIndexFilePaths(),
+			IndexSize:                 fii.GetIndexSize(),
+			IndexVersion:              fii.GetIndexVersion(),
+			NumRows:                   fii.GetNumRows(),
+			CurrentIndexVersion:       fii.GetCurrentIndexVersion(),
+			CurrentScalarIndexVersion: fii.GetCurrentScalarIndexVersion(),
 		})
 	}
 	return result


### PR DESCRIPTION
issue: #47083

The scalar index version was correctly passed and stored in ETCD during index build, but the load path was broken. After this PR:

- QueryCoord now passes CurrentScalarIndexVersion from etcd metadata to QueryNode
- QueryNode forwards the version to C++ via LoadIndexInfo proto
- C++ injects the version into index_params for scalar index implementations

This fixes the version chain: etcd -> QueryCoord -> QueryNode -> C++ -> Index::Load()

This PR also:

- Fixes `ShouldRebuildSegmentIndex()` to check index type and use scalar/vec index version
- DescribeIndex now returns scalar index version for scalar index