### PR TITLE
 feat: Implement MOL fingerprint function for molecular similarity search

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/klauspost/compress v1.18.0
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
-	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.9
+	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260116085923-3452b3ee9424
 	github.com/minio/minio-go/v7 v7.0.73
 	github.com/panjf2000/ants/v2 v2.11.3 // indirect
 	github.com/pingcap/log v1.1.1-0.20221015072633-39906604fb81 // indirect

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/klauspost/compress v1.18.0
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
-	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260113024922-c7feeb806088
+	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.9
 	github.com/minio/minio-go/v7 v7.0.73
 	github.com/panjf2000/ants/v2 v2.11.3 // indirect
 	github.com/pingcap/log v1.1.1-0.20221015072633-39906604fb81 // indirect

--- a/go.sum
+++ b/go.sum
@@ -799,10 +799,8 @@ github.com/milvus-io/cgosymbolizer v0.0.0-20250318084424-114f4050c3a6 h1:YHMFI6L
 github.com/milvus-io/cgosymbolizer v0.0.0-20250318084424-114f4050c3a6/go.mod h1:DvXTE/K/RtHehxU8/GtDs4vFtfw64jJ3PaCnFri8CRg=
 github.com/milvus-io/gorocksdb v0.0.0-20220624081344-8c5f4212846b h1:TfeY0NxYxZzUfIfYe5qYDBzt4ZYRqzUjTR6CvUzjat8=
 github.com/milvus-io/gorocksdb v0.0.0-20220624081344-8c5f4212846b/go.mod h1:iwW+9cWfIzzDseEBCCeDSN5SD16Tidvy8cwQ7ZY8Qj4=
-github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260113024922-c7feeb806088 h1:qzlpV+1xygF/XK0bRVoLFg03uAQSCZ2AywZR3wt5ov0=
-github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260113024922-c7feeb806088/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
-github.com/milvus-io/milvus-proto/go-api/v2 v2.6.9 h1:Wlj4Lsg5Zaj67XZmImSQwUkWhuHTyAM8KIPxksKrLA8=
-github.com/milvus-io/milvus-proto/go-api/v2 v2.6.9/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260116085923-3452b3ee9424 h1:TPp9tRlSJs2BUW5wUETdRpxC40Y0+5D0rBBrdjtwHT8=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260116085923-3452b3ee9424/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
 github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8 h1:AMFGa4R4MiIpspGNG7Z948v4n35fFGB3RR3G/ry4FWs=
 github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8/go.mod h1:mC1jAcsrzbxHt8iiaC+zU4b1ylILSosueou12R++wfY=
 github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3 h1:+n/aFZefKZp7spd8DFdX7uMikMLXX4oubIzJF4kv/wI=

--- a/go.sum
+++ b/go.sum
@@ -801,6 +801,8 @@ github.com/milvus-io/gorocksdb v0.0.0-20220624081344-8c5f4212846b h1:TfeY0NxYxZz
 github.com/milvus-io/gorocksdb v0.0.0-20220624081344-8c5f4212846b/go.mod h1:iwW+9cWfIzzDseEBCCeDSN5SD16Tidvy8cwQ7ZY8Qj4=
 github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260113024922-c7feeb806088 h1:qzlpV+1xygF/XK0bRVoLFg03uAQSCZ2AywZR3wt5ov0=
 github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260113024922-c7feeb806088/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.9 h1:Wlj4Lsg5Zaj67XZmImSQwUkWhuHTyAM8KIPxksKrLA8=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.9/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
 github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8 h1:AMFGa4R4MiIpspGNG7Z948v4n35fFGB3RR3G/ry4FWs=
 github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8/go.mod h1:mC1jAcsrzbxHt8iiaC+zU4b1ylILSosueou12R++wfY=
 github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3 h1:+n/aFZefKZp7spd8DFdX7uMikMLXX4oubIzJF4kv/wI=

--- a/internal/core/src/common/Array.h
+++ b/internal/core/src/common/Array.h
@@ -235,8 +235,9 @@ class Array {
             }
             case DataType::STRING:
             case DataType::VARCHAR:
-            //treat Geometry as wkb string
-            case DataType::GEOMETRY: {
+            //treat Geometry and MOL as string
+            case DataType::GEOMETRY: 
+            case DataType::MOL: {
                 for (int i = 0; i < length_; ++i) {
                     if (get_data<std::string_view>(i) !=
                         arr.get_data<std::string_view>(i)) {
@@ -366,6 +367,15 @@ class Array {
                 }
                 break;
             }
+            case DataType::MOL: {
+                data_array.mutable_mol_data()->mutable_data()->Reserve(
+                    length_);
+                for (int j = 0; j < length_; ++j) {
+                    auto element = get_data<std::string_view>(j);
+                    data_array.mutable_mol_data()->add_data(element.data(), element.size());
+                }
+                break;
+            }
             default: {
                 // empty array
             }
@@ -460,7 +470,8 @@ class Array {
             }
             case DataType::VARCHAR:
             case DataType::STRING:
-            case DataType::GEOMETRY: {
+            case DataType::GEOMETRY:
+            case DataType::MOL: {
                 for (int i = 0; i < length_; i++) {
                     auto val = get_data<std::string>(i);
                     if (val != arr2.array(i).string_val()) {
@@ -631,6 +642,15 @@ class ArrayView {
                 }
                 break;
             }
+            case DataType::MOL: {
+                data_array.mutable_mol_data()->mutable_data()->Reserve(
+                    length_);
+                for (int j = 0; j < length_; ++j) {
+                    auto element = get_data<std::string_view>(j);
+                    data_array.mutable_mol_data()->add_data(element.data(), element.size());
+                }
+                break;
+            }
             default: {
                 // empty array
             }
@@ -733,7 +753,8 @@ class ArrayView {
             }
             case DataType::VARCHAR:
             case DataType::STRING:
-            case DataType::GEOMETRY: {
+            case DataType::GEOMETRY:
+            case DataType::MOL: {
                 for (int i = 0; i < length_; i++) {
                     auto val = get_data<std::string>(i);
                     if (val != arr2.array(i).string_val()) {

--- a/internal/core/src/common/Chunk.h
+++ b/internal/core/src/common/Chunk.h
@@ -37,6 +37,7 @@
 namespace milvus {
 constexpr uint64_t MMAP_STRING_PADDING = 1;
 constexpr uint64_t MMAP_GEOMETRY_PADDING = 1;
+constexpr uint64_t MMAP_MOL_PADDING = 1;
 constexpr uint64_t MMAP_ARRAY_PADDING = 1;
 
 // Shared mmap region manager for group chunks
@@ -319,6 +320,7 @@ class StringChunk : public Chunk {
 
 using JSONChunk = StringChunk;
 using GeometryChunk = StringChunk;
+using MolChunk = StringChunk;
 
 // An ArrayChunk is a class that represents a collection of arrays stored in a contiguous memory block.
 // It is initialized with the number of rows, a pointer to the data, the size of the data, the element type,

--- a/internal/core/src/common/ChunkWriter.h
+++ b/internal/core/src/common/ChunkWriter.h
@@ -244,6 +244,18 @@ class GeometryChunkWriter : public ChunkWriterBase {
                     const std::shared_ptr<ChunkTarget>& target) override;
 };
 
+class MolChunkWriter : public ChunkWriterBase {
+ public:
+    using ChunkWriterBase::ChunkWriterBase;
+
+    std::pair<size_t, size_t>
+    calculate_size(const arrow::ArrayVector& array_vec) override;
+
+    void
+    write_to_target(const arrow::ArrayVector& array_vec,
+                    const std::shared_ptr<ChunkTarget>& target) override;
+};
+
 class ArrayChunkWriter : public ChunkWriterBase {
  public:
     ArrayChunkWriter(const milvus::DataType element_type, bool nullable)

--- a/internal/core/src/common/FieldData.cpp
+++ b/internal/core/src/common/FieldData.cpp
@@ -281,6 +281,23 @@ FieldDataImpl<Type, is_type_entire_row>::FillFieldData(
             }
             return FillFieldData(values.data(), element_count);
         }
+        case DataType::MOL: {
+            AssertInfo(array->type()->id() == arrow::Type::type::BINARY,
+                       "inconsistent data type");
+            auto mol_array =
+                std::dynamic_pointer_cast<arrow::BinaryArray>(array);
+            std::vector<std::string> values(element_count);
+            for (size_t index = 0; index < element_count; ++index) {
+                values[index] = mol_array->GetString(index);
+            }
+            if (nullable_) {
+                return FillFieldData(values.data(),
+                                     array->null_bitmap_data(),
+                                     element_count,
+                                     array->offset());
+            }
+            return FillFieldData(values.data(), element_count);
+        }
         case DataType::ARRAY: {
             auto array_array =
                 std::dynamic_pointer_cast<arrow::BinaryArray>(array);
@@ -561,6 +578,16 @@ FieldDataImpl<Type, is_type_entire_row>::FillFieldData(
             return FillFieldData(
                 values.data(), valid_data_ptr.get(), element_count, 0);
         }
+        case DataType::MOL: {
+            FixedVector<std::string> values(element_count);
+            if (default_value.has_value()) {
+                std::fill(
+                    values.begin(), values.end(), default_value->string_data());
+                return FillFieldData(values.data(), nullptr, element_count, 0);
+            }
+            return FillFieldData(
+                values.data(), valid_data_ptr.get(), element_count, 0);
+        }
         case DataType::ARRAY: {
             // todo: add array default_value
             FixedVector<Array> values(element_count);
@@ -722,6 +749,9 @@ InitScalarFieldData(const DataType& type, bool nullable, int64_t cap_rows) {
         case DataType::JSON:
             return std::make_shared<FieldData<Json>>(type, nullable, cap_rows);
         case DataType::GEOMETRY:
+            return std::make_shared<FieldData<std::string>>(
+                type, nullable, cap_rows);
+        case DataType::MOL:
             return std::make_shared<FieldData<std::string>>(
                 type, nullable, cap_rows);
         default:

--- a/internal/core/src/common/FieldData.h
+++ b/internal/core/src/common/FieldData.h
@@ -83,6 +83,17 @@ class FieldData<Geometry> : public FieldDataGeometryImpl {
 };
 
 template <>
+class FieldData<Mol> : public FieldDataMolImpl {
+ public:
+    static_assert(IsScalar<Mol>);
+    explicit FieldData(DataType data_type,
+                       bool nullable,
+                       int64_t buffered_num_rows = 0)
+        : FieldDataMolImpl(data_type, nullable, buffered_num_rows) {
+    }
+};
+
+template <>
 class FieldData<Array> : public FieldDataArrayImpl {
  public:
     static_assert(IsScalar<Array> || std::is_same_v<std::string, PkType>);

--- a/internal/core/src/common/Mol.h
+++ b/internal/core/src/common/Mol.h
@@ -1,0 +1,21 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+#pragma once
+
+
+
+namespace milvus {
+
+class Mol {
+
+};
+
+}  // namespace milvus

--- a/internal/core/src/common/TypeTraits.h
+++ b/internal/core/src/common/TypeTraits.h
@@ -32,6 +32,7 @@ template <typename T>
 constexpr bool IsScalar =
     std::is_fundamental_v<T> || std::is_same_v<T, std::string> ||
     std::is_same_v<T, Json> || std::is_same_v<T, Geometry> ||
+    std::is_same_v<T, Mol> ||
     std::is_same_v<T, std::string_view> || std::is_same_v<T, Array> ||
     std::is_same_v<T, ArrayView> || std::is_same_v<T, proto::plan::Array>;
 

--- a/internal/core/src/common/Types.h
+++ b/internal/core/src/common/Types.h
@@ -49,6 +49,7 @@
 #include "Json.h"
 #include "type_c.h"
 #include "Geometry.h"
+#include "Mol.h"
 
 #include "CustomBitset.h"
 
@@ -86,6 +87,7 @@ enum class DataType {
     GEOMETRY = 24,
     TEXT = 25,
     TIMESTAMPTZ = 26,  // Timestamp with timezone, stored as int64
+    MOL = 27,
 
     // Some special Data type, start from after 50
     // just for internal use now, may sync proto in future
@@ -209,6 +211,8 @@ ToProtoDataType(DataType data_type) {
             return proto::schema::DataType::ArrayOfVector;
         case DataType::GEOMETRY:
             return proto::schema::DataType::Geometry;
+        case DataType::MOL:
+            return proto::schema::DataType::Mol;
 
         // Internal-only or unsupported mappings
         case DataType::ROW:
@@ -248,6 +252,8 @@ GetArrowDataType(DataType data_type, int dim = 1) {
         case DataType::JSON:
             return arrow::binary();
         case DataType::GEOMETRY:
+            return arrow::binary();
+        case DataType::MOL:
             return arrow::binary();
         case DataType::VECTOR_FLOAT:
             return arrow::fixed_size_binary(dim * 4);
@@ -340,6 +346,8 @@ GetDataTypeName(DataType data_type) {
             return "text";
         case DataType::GEOMETRY:
             return "geometry";
+        case DataType::MOL:
+            return "mol";
         case DataType::VECTOR_FLOAT:
             return "vector_float";
         case DataType::VECTOR_BINARY:
@@ -440,6 +448,11 @@ IsGeometryDataType(DataType data_type) {
 }
 
 inline bool
+IsMolDataType(DataType data_type) {
+    return data_type == DataType::MOL;
+}
+
+inline bool
 IsArrayDataType(DataType data_type) {
     return data_type == DataType::ARRAY || data_type == DataType::VECTOR_ARRAY;
 }
@@ -447,7 +460,7 @@ IsArrayDataType(DataType data_type) {
 inline bool
 IsBinaryDataType(DataType data_type) {
     return IsJsonDataType(data_type) || IsArrayDataType(data_type) ||
-           IsGeometryDataType(data_type);
+           IsGeometryDataType(data_type) || IsMolDataType(data_type);
 }
 
 inline bool
@@ -948,6 +961,9 @@ struct fmt::formatter<milvus::DataType> : formatter<string_view> {
                 break;
             case milvus::DataType::GEOMETRY:
                 name = "GEOMETRY";
+                break;
+            case milvus::DataType::MOL:
+                name = "MOL";
                 break;
             case milvus::DataType::ROW:
                 name = "ROW";

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -1643,6 +1643,9 @@ class SegmentExpr : public Expr {
                     case DataType::GEOMETRY: {
                         return ProcessIndexChunksForValid<std::string>();
                     }
+                    case DataType::MOL: {
+                        return ProcessIndexChunksForValid<std::string>();
+                    }
                     default:
                         ThrowInfo(DataTypeInvalid,
                                   "unsupported element type: {}",

--- a/internal/core/src/exec/expression/NullExpr.cpp
+++ b/internal/core/src/exec/expression/NullExpr.cpp
@@ -98,6 +98,17 @@ PhyNullExpr::Eval(EvalCtx& context, VectorPtr& result) {
             }
             break;
         }
+        case DataType::MOL: {
+            if (segment_->type() == SegmentType::Growing &&
+                !storage::MmapManager::GetInstance()
+                     .GetMmapConfig()
+                     .growing_enable_mmap) {
+                result = ExecVisitorImpl<std::string>(input);
+            } else {
+                result = ExecVisitorImpl<std::string_view>(input);
+            }
+            break;
+        }
         default:
             ThrowInfo(DataTypeInvalid,
                       "unsupported data type: {}",

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -1596,6 +1596,17 @@ ChunkedSegmentSealedImpl::bulk_subscript(milvus::OpContext* op_ctx,
                 static_cast<std::string*>(data));
             break;
         }
+        case DataType::MOL: {
+            // dst must have at least count elements; the callback's offset
+            // parameter is guaranteed to be in [0, count)
+            bulk_subscript_ptr_impl<std::string>(
+                op_ctx,
+                column.get(),
+                seg_offsets,
+                count,
+                static_cast<std::string*>(data));
+            break;
+        }
         case DataType::ARRAY: {
             // dst must have at least count elements; the callback's index
             // parameter is guaranteed to be in [0, count)
@@ -1984,6 +1995,17 @@ ChunkedSegmentSealedImpl::get_raw_data(milvus::OpContext* op_ctx,
                                                  count,
                                                  ret->mutable_scalars()
                                                      ->mutable_geometry_data()
+                                                     ->mutable_data());
+            break;
+        }
+
+        case DataType::MOL: {
+            bulk_subscript_ptr_impl<std::string>(op_ctx,
+                                                 column.get(),
+                                                 seg_offsets,
+                                                 count,
+                                                 ret->mutable_scalars()
+                                                     ->mutable_mol_data()
                                                      ->mutable_data());
             break;
         }

--- a/internal/core/src/segcore/ConcurrentVector.cpp
+++ b/internal/core/src/segcore/ConcurrentVector.cpp
@@ -127,6 +127,17 @@ VectorBase::set_data_raw(ssize_t element_offset,
             }
             return set_data_raw(element_offset, data_raw.data(), element_count);
         }
+        case DataType::MOL: {
+            // get the mol array of a column from proto message
+            auto& mol_data = FIELD_DATA(data, mol);
+            std::vector<std::string> data_raw{};
+            data_raw.reserve(mol_data.size());
+            for (auto& mol_bytes : mol_data) {
+                data_raw.emplace_back(
+                    std::string(mol_bytes.data(), mol_bytes.size()));
+            }
+            return set_data_raw(element_offset, data_raw.data(), element_count);
+        }
         case DataType::ARRAY: {
             auto& array_data = FIELD_DATA(data, array);
             std::vector<Array> data_raw{};

--- a/internal/core/src/segcore/InsertRecord.h
+++ b/internal/core/src/segcore/InsertRecord.h
@@ -938,6 +938,11 @@ class InsertRecordGrowing {
                     field_id, size_per_chunk, scalar_mmap_descriptor);
                 return;
             }
+            case DataType::MOL: {
+                this->append_data<std::string>(
+                    field_id, size_per_chunk, scalar_mmap_descriptor);
+                return;
+            }
             default: {
                 ThrowInfo(DataTypeInvalid,
                           fmt::format("unsupported scalar type",

--- a/internal/core/src/segcore/ReduceUtils.cpp
+++ b/internal/core/src/segcore/ReduceUtils.cpp
@@ -164,6 +164,18 @@ AssembleGroupByValues(
                 }
                 break;
             }
+            case DataType::MOL: {
+                mutable_group_by_field_value->set_type(
+                    milvus::proto::schema::DataType::Mol);
+                auto field_data = group_by_res_values->mutable_mol_data();
+                for (std::size_t idx = 0; idx < group_by_val_size; idx++) {
+                    if (group_by_vals[idx].has_value()) {
+                        std::string val = std::get<std::string>(group_by_vals[idx].value());
+                        *(field_data->mutable_data()->Add()) = val;
+                    }
+                }
+                break;
+            }
             case DataType::JSON: {
                 auto json_path = plan->plan_node_->search_info_.json_path_;
                 auto json_type = plan->plan_node_->search_info_.json_type_;

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -379,7 +379,8 @@ SegmentGrowingImpl::EstimateSegmentResourceUsage() const {
                     break;
                 case DataType::VARCHAR:
                 case DataType::TEXT:
-                case DataType::GEOMETRY: {
+                case DataType::GEOMETRY:
+                case DataType::MOL: {
                     auto avg_size =
                         SegmentInternalInterface::get_field_avg_size(field_id);
                     field_bytes = num_rows * avg_size;
@@ -1372,6 +1373,16 @@ SegmentGrowingImpl::bulk_subscript(milvus::OpContext* op_ctx,
                                                      ->mutable_data());
             break;
         }
+        case DataType::MOL: {
+            bulk_subscript_ptr_impl<std::string>(op_ctx,
+                                                 vec_ptr,
+                                                 seg_offsets,
+                                                 count,
+                                                 result->mutable_scalars()
+                                                     ->mutable_mol_data()
+                                                     ->mutable_data());
+            break;
+        }
         case DataType::ARRAY: {
             // element
             bulk_subscript_array_impl(op_ctx,
@@ -1694,6 +1705,11 @@ SegmentGrowingImpl::bulk_subscript(milvus::OpContext* op_ctx,
             break;
         }
         case DataType::GEOMETRY: {
+            bulk_subscript_ptr_impl<std::string>(
+                vec_ptr, seg_offsets, count, static_cast<std::string*>(data));
+            break;
+        }
+        case DataType::MOL: {
             bulk_subscript_ptr_impl<std::string>(
                 vec_ptr, seg_offsets, count, static_cast<std::string*>(data));
             break;

--- a/internal/core/src/segcore/SegmentInterface.cpp
+++ b/internal/core/src/segcore/SegmentInterface.cpp
@@ -646,6 +646,16 @@ SegmentInternalInterface::bulk_subscript_not_exist_field(
                 }
                 break;
             }
+            case DataType::MOL: {
+                auto data_ptr = result->mutable_scalars()
+                                    ->mutable_mol_data()
+                                    ->mutable_data();
+
+                for (int64_t i = 0; i < count; ++i) {
+                    data_ptr->at(i) = field_meta.default_value()->bytes_data();
+                }
+                break;
+            }
             default: {
                 ThrowInfo(DataTypeInvalid,
                           fmt::format("unsupported default value type {}",

--- a/internal/core/src/segcore/Utils.cpp
+++ b/internal/core/src/segcore/Utils.cpp
@@ -160,6 +160,13 @@ GetRawDataSizeOfDataArray(const DataArray* data,
                 }
                 break;
             }
+            case DataType::MOL: {
+                auto& mol_data = FIELD_DATA(data, mol);
+                for (auto& mol_bytes : mol_data) {
+                    result += mol_bytes.size();
+                }
+                break;
+            }
             case DataType::ARRAY: {
                 auto& array_data = FIELD_DATA(data, array);
                 switch (field_meta.get_element_type()) {
@@ -395,6 +402,14 @@ SetUpScalarFieldData(milvus::proto::schema::ScalarField*& scalar_array,
             }
             break;
         }
+        case DataType::MOL: {
+            auto obj = scalar_array->mutable_mol_data();
+            obj->mutable_data()->Reserve(count);
+            for (int i = 0; i < count; i++) {
+                *(obj->mutable_data()->Add()) = std::string();
+            }
+            break;
+        }
         case DataType::ARRAY: {
             auto obj = scalar_array->mutable_array_data();
             obj->mutable_data()->Reserve(count);
@@ -589,6 +604,15 @@ CreateScalarDataArrayFrom(const void* data_raw,
         case DataType::GEOMETRY: {
             auto data = reinterpret_cast<const std::string*>(data_raw);
             auto obj = scalar_array->mutable_geometry_data();
+            for (auto i = 0; i < count; i++) {
+                *(obj->mutable_data()->Add()) =
+                    std::string(data[i].data(), data[i].size());
+            }
+            break;
+        }
+        case DataType::MOL: {
+            auto data = reinterpret_cast<const std::string*>(data_raw);
+            auto obj = scalar_array->mutable_mol_data();
             for (auto i = 0; i < count; i++) {
                 *(obj->mutable_data()->Add()) =
                     std::string(data[i].data(), data[i].size());
@@ -912,6 +936,13 @@ MergeDataArray(std::vector<MergeBase>& merge_bases,
             case DataType::GEOMETRY: {
                 auto& data = FIELD_DATA(src_field_data, geometry);
                 auto obj = scalar_array->mutable_geometry_data();
+                *(obj->mutable_data()->Add()) = std::string(
+                    data[src_offset].data(), data[src_offset].size());
+                break;
+            }
+            case DataType::MOL: {
+                auto& data = FIELD_DATA(src_field_data, mol);
+                auto obj = scalar_array->mutable_mol_data();
                 *(obj->mutable_data()->Add()) = std::string(
                     data[src_offset].data(), data[src_offset].size());
                 break;

--- a/internal/core/src/storage/Event.cpp
+++ b/internal/core/src/storage/Event.cpp
@@ -330,6 +330,17 @@ BaseEventData::Serialize() {
                 }
                 break;
             }
+            case DataType::MOL: {
+                for (size_t offset = 0; offset < field_data->get_num_rows();
+                     ++offset) {
+                    auto mol_ptr = static_cast<const std::string*>(
+                        field_data->RawValue(offset));
+                    payload_writer->add_one_binary_payload(
+                        reinterpret_cast<const uint8_t*>(mol_ptr->data()),
+                        mol_ptr->size());
+                }
+                break;
+            }
             case DataType::VECTOR_SPARSE_U32_F32: {
                 for (size_t offset = 0; offset < field_data->get_num_rows();
                      ++offset) {

--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -444,7 +444,8 @@ CreateArrowBuilder(DataType data_type) {
         }
         case DataType::ARRAY:
         case DataType::JSON:
-        case DataType::GEOMETRY: {
+        case DataType::GEOMETRY:
+        case DataType::MOL: {
             return std::make_shared<arrow::BinaryBuilder>();
         }
         // sparse float vector doesn't require a dim
@@ -652,7 +653,8 @@ CreateArrowSchema(DataType data_type, bool nullable) {
         }
         case DataType::ARRAY:
         case DataType::JSON:
-        case DataType::GEOMETRY: {
+        case DataType::GEOMETRY: 
+        case DataType::MOL: {
             return arrow::schema(
                 {arrow::field("val", arrow::binary(), nullable)});
         }
@@ -1221,6 +1223,9 @@ CreateFieldData(const DataType& type,
                 type, nullable, total_num_rows);
         case DataType::GEOMETRY:
             return std::make_shared<FieldData<Geometry>>(
+                type, nullable, total_num_rows);
+        case DataType::MOL:
+            return std::make_shared<FieldData<Mol>>(
                 type, nullable, total_num_rows);
         case DataType::ARRAY:
             return std::make_shared<FieldData<Array>>(

--- a/internal/flushcommon/pipeline/flow_graph_embedding_node.go
+++ b/internal/flushcommon/pipeline/flow_graph_embedding_node.go
@@ -178,6 +178,11 @@ func (eNode *embeddingNode) embedding(datas []*storage.InsertData) (map[int64]*s
 				if err != nil {
 					return nil, err
 				}
+			case schemapb.FunctionType_MolFingerprint:
+				err := eNode.molFingerprintEmbedding(functionRunner, data)
+				if err != nil {
+					return nil, err
+				}
 			default:
 				return nil, fmt.Errorf("unknown function type %s", functionSchema.Type)
 			}
@@ -237,4 +242,39 @@ func BuildSparseFieldData(array *schemapb.SparseFloatArray) storage.FieldData {
 			Dim:      array.GetDim(),
 		},
 	}
+}
+
+func (eNode *embeddingNode) molFingerprintEmbedding(runner function.FunctionRunner, data *storage.InsertData) error {
+	inputFieldIds := lo.Map(runner.GetInputFields(), func(field *schemapb.FieldSchema, _ int) int64 { return field.GetFieldID() })
+	outputFieldId := runner.GetOutputFields()[0].GetFieldID()
+
+	datas := []any{}
+
+	for _, inputFieldId := range inputFieldIds {
+		fieldData, ok := data.Data[inputFieldId]
+		if !ok {
+			return errors.New("MOL fingerprint embedding failed: input field data not found")
+		}
+
+		// Extract string data from field
+		switch fd := fieldData.(type) {
+		case *storage.StringFieldData:
+			datas = append(datas, fd.Data)
+		default:
+			return errors.New("MOL fingerprint embedding failed: input field data must be string/varchar")
+		}
+	}
+
+	output, err := runner.BatchRun(datas...)
+	if err != nil {
+		return err
+	}
+
+	binaryVectorData, ok := output[0].(*storage.BinaryVectorFieldData)
+	if !ok {
+		return errors.New("MOL fingerprint embedding failed: runner output not binary vector")
+	}
+
+	data.Data[outputFieldId] = binaryVectorData
+	return nil
 }

--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -476,6 +476,11 @@ func (t *createCollectionTask) PreExecute(ctx context.Context) error {
 		return err
 	}
 
+	// validate MOL field (temporarily disabled)
+	if err := validateMOLField(t.schema); err != nil {
+		return err
+	}
+
 	// validate partition key mode
 	if err := t.validatePartitionKey(ctx); err != nil {
 		return err

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -736,6 +736,16 @@ func validatePrimaryKey(coll *schemapb.CollectionSchema) error {
 	return nil
 }
 
+func validateMOLField(coll *schemapb.CollectionSchema) error {
+	// Temporarily disable MOL field support
+	for _, field := range coll.Fields {
+		if field.GetDataType() == schemapb.DataType_Mol {
+			return merr.WrapErrParameterInvalidMsg("MOL data type is not supported yet")
+		}
+	}
+	return nil
+}
+
 func validateDynamicField(coll *schemapb.CollectionSchema) error {
 	for _, field := range coll.Fields {
 		if field.IsDynamic {

--- a/internal/storage/data_sorter.go
+++ b/internal/storage/data_sorter.go
@@ -125,6 +125,9 @@ func (ds *DataSorter) Swap(i, j int) {
 		case schemapb.DataType_Geometry:
 			data := singleData.(*GeometryFieldData).Data
 			data[i], data[j] = data[j], data[i]
+		case schemapb.DataType_Mol:
+			data := singleData.(*MolFieldData).Data
+			data[i], data[j] = data[j], data[i]
 		case schemapb.DataType_SparseFloatVector:
 			fieldData := singleData.(*SparseFloatVectorFieldData)
 			fieldData.Contents[i], fieldData.Contents[j] = fieldData.Contents[j], fieldData.Contents[i]

--- a/internal/storage/payload.go
+++ b/internal/storage/payload.go
@@ -40,6 +40,7 @@ type PayloadWriterInterface interface {
 	AddOneArrayToPayload(*schemapb.ScalarField, bool) error
 	AddOneJSONToPayload([]byte, bool) error
 	AddOneGeometryToPayload(msg []byte, isValid bool) error
+	AddOneMolToPayload(msg []byte, isValid bool) error
 	AddBinaryVectorToPayload(data []byte, dim int, validData []bool) error
 	AddFloatVectorToPayload(data []float32, dim int, validData []bool) error
 	AddFloat16VectorToPayload(data []byte, dim int, validData []bool) error
@@ -72,6 +73,7 @@ type PayloadReaderInterface interface {
 	GetVectorArrayFromPayload() ([]*schemapb.VectorField, error)
 	GetJSONFromPayload() ([][]byte, []bool, error)
 	GetGeometryFromPayload() ([][]byte, []bool, error)
+	GetMolFromPayload() ([][]byte, []bool, error)
 	GetBinaryVectorFromPayload() ([]byte, int, []bool, int, error)
 	GetFloat16VectorFromPayload() ([]byte, int, []bool, int, error)
 	GetBFloat16VectorFromPayload() ([]byte, int, []bool, int, error)

--- a/internal/storage/print_binlog.go
+++ b/internal/storage/print_binlog.go
@@ -408,6 +408,22 @@ func printPayloadValues(colType schemapb.DataType, reader PayloadReaderInterface
 		for i, v := range valids {
 			fmt.Printf("\t\t%d : %v\n", i, v)
 		}
+	// print the mol pickle bytes
+	case schemapb.DataType_Mol:
+		rows, err := reader.GetPayloadLengthFromReader()
+		if err != nil {
+			return err
+		}
+		val, valids, err := reader.GetMolFromPayload()
+		if err != nil {
+			return err
+		}
+		for i := 0; i < rows; i++ {
+			fmt.Printf("\t\t%d : [MOL data, %d bytes]\n", i, len(val[i]))
+		}
+		for i, v := range valids {
+			fmt.Printf("\t\t%d : %v\n", i, v)
+		}
 	case schemapb.DataType_SparseFloatVector:
 		sparseData, _, _, err := reader.GetSparseFloatVectorFromPayload()
 		if err != nil {

--- a/internal/storage/serde.go
+++ b/internal/storage/serde.go
@@ -460,6 +460,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 	m[schemapb.DataType_Array] = eagerArrayEntry
 	m[schemapb.DataType_JSON] = byteEntry
 	m[schemapb.DataType_Geometry] = byteEntry
+	m[schemapb.DataType_Mol] = byteEntry
 
 	// ArrayOfVector now implements the standard interface with elementType parameter
 	m[schemapb.DataType_ArrayOfVector] = serdeEntry{

--- a/internal/util/function/embedding/function_executor.go
+++ b/internal/util/function/embedding/function_executor.go
@@ -71,6 +71,8 @@ func createFunction(coll *schemapb.CollectionSchema, schema *schemapb.FunctionSc
 		return f, nil
 	case schemapb.FunctionType_MinHash:
 		return nil, nil
+	case schemapb.FunctionType_MolFingerprint: // ignore, handled by function.NewFunctionRunner
+		return nil, nil
 	default:
 		return nil, fmt.Errorf("unknown functionRunner type %s", schema.GetType().String())
 	}

--- a/internal/util/function/function.go
+++ b/internal/util/function/function.go
@@ -42,6 +42,8 @@ func NewFunctionRunner(coll *schemapb.CollectionSchema, schema *schemapb.Functio
 		return NewMinHashFunctionRunner(coll, schema)
 	case schemapb.FunctionType_TextEmbedding:
 		return nil, nil
+	case schemapb.FunctionType_MolFingerprint:
+		return NewMolFingerprintFunctionRunner(coll, schema)
 	default:
 		return nil, fmt.Errorf("unknown functionRunner type %s", schema.GetType().String())
 	}

--- a/internal/util/function/mol/maccs.go
+++ b/internal/util/function/mol/maccs.go
@@ -1,0 +1,53 @@
+/*
+ * # Licensed to the LF AI & Data foundation under one
+ * # or more contributor license agreements. See the NOTICE file
+ * # distributed with this work for additional information
+ * # regarding copyright ownership. The ASF licenses this file
+ * # to you under the Apache License, Version 2.0 (the
+ * # "License"); you may not use this file except in compliance
+ * # with the License. You may obtain a copy of the License at
+ * #
+ * #     http://www.apache.org/licenses/LICENSE-2.0
+ * #
+ * # Unless required by applicable law or agreed to in writing, software
+ * # distributed under the License is distributed on an "AS IS" BASIS,
+ * # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * # See the License for the specific language governing permissions and
+ * # limitations under the License.
+ */
+
+package mol
+
+// GenerateMACCSFingerprint generates a MACCS fingerprint for a SMILES string
+// MACCS fingerprint is fixed at 167 bits
+// This is a placeholder implementation. In production, this should call RDKit C++ library via CGO
+func GenerateMACCSFingerprint(smiles string) ([]byte, error) {
+	if len(smiles) == 0 {
+		return make([]byte, 167/8+1), nil
+	}
+
+	// TODO: Implement actual RDKit CGO call
+	// For now, return a placeholder implementation
+	// This should be replaced with actual CGO call to RDKit:
+	//  1. Parse SMILES string using RDKit
+	//  2. Generate MACCS fingerprint (fixed 167 bits)
+	//  3. Convert to binary vector
+	
+	// Placeholder: return zero vector for now
+	// In production, this should be:
+	//   fp := C.generate_maccs_fingerprint(C.CString(smiles))
+	//   defer C.free(unsafe.Pointer(fp.data))
+	//   return C.GoBytes(fp.data, fp.size), nil
+	
+	fingerprint := make([]byte, 167/8+1)
+	
+	// Simple hash-based placeholder (NOT production code)
+	// This is just to make the code compile and run
+	// Replace with actual RDKit CGO implementation
+	hash := simpleHash(smiles)
+	for i := 0; i < len(fingerprint) && i < 8; i++ {
+		fingerprint[i] = byte(hash >> (i * 8))
+	}
+	
+	return fingerprint, nil
+}

--- a/internal/util/function/mol/morgan.go
+++ b/internal/util/function/mol/morgan.go
@@ -1,0 +1,62 @@
+/*
+ * # Licensed to the LF AI & Data foundation under one
+ * # or more contributor license agreements. See the NOTICE file
+ * # distributed with this work for additional information
+ * # regarding copyright ownership. The ASF licenses this file
+ * # to you under the Apache License, Version 2.0 (the
+ * # "License"); you may not use this file except in compliance
+ * # with the License. You may obtain a copy of the License at
+ * #
+ * #     http://www.apache.org/licenses/LICENSE-2.0
+ * #
+ * # Unless required by applicable law or agreed to in writing, software
+ * # distributed under the License is distributed on an "AS IS" BASIS,
+ * # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * # See the License for the specific language governing permissions and
+ * # limitations under the License.
+ */
+
+package mol
+
+// GenerateMorganFingerprint generates a Morgan fingerprint for a SMILES string
+// This is a placeholder implementation. In production, this should call RDKit C++ library via CGO
+func GenerateMorganFingerprint(smiles string, radius int, fingerprintSize int) ([]byte, error) {
+	if len(smiles) == 0 {
+		return make([]byte, fingerprintSize/8), nil
+	}
+
+	// TODO: Implement actual RDKit CGO call
+	// For now, return a placeholder implementation
+	// This should be replaced with actual CGO call to RDKit:
+	//  1. Parse SMILES string using RDKit
+	//  2. Generate Morgan fingerprint with specified radius
+	//  3. Convert to binary vector of specified size
+	
+	// Placeholder: return zero vector for now
+	// In production, this should be:
+	//   fp := C.generate_morgan_fingerprint(C.CString(smiles), C.int(radius), C.int(fingerprintSize))
+	//   defer C.free(unsafe.Pointer(fp.data))
+	//   return C.GoBytes(fp.data, fp.size), nil
+	
+	fingerprint := make([]byte, fingerprintSize/8)
+	
+	// Simple hash-based placeholder (NOT production code)
+	// This is just to make the code compile and run
+	// Replace with actual RDKit CGO implementation
+	hash := simpleHash(smiles)
+	for i := 0; i < len(fingerprint) && i < 8; i++ {
+		fingerprint[i] = byte(hash >> (i * 8))
+	}
+	
+	return fingerprint, nil
+}
+
+// simpleHash is a placeholder hash function
+// This should be replaced with actual RDKit fingerprint generation
+func simpleHash(s string) uint64 {
+	h := uint64(0)
+	for _, c := range s {
+		h = h*31 + uint64(c)
+	}
+	return h
+}

--- a/internal/util/function/mol/rdkit.go
+++ b/internal/util/function/mol/rdkit.go
@@ -1,0 +1,60 @@
+/*
+ * # Licensed to the LF AI & Data foundation under one
+ * # or more contributor license agreements. See the NOTICE file
+ * # distributed with this work for additional information
+ * # regarding copyright ownership. The ASF licenses this file
+ * # to you under the Apache License, Version 2.0 (the
+ * # "License"); you may not use this file except in compliance
+ * # with the License. You may obtain a copy of the License at
+ * #
+ * #     http://www.apache.org/licenses/LICENSE-2.0
+ * #
+ * # Unless required by applicable law or agreed to in writing, software
+ * # distributed under the License is distributed on an "AS IS" BASIS,
+ * # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * # See the License for the specific language governing permissions and
+ * # limitations under the License.
+ */
+
+package mol
+
+// GenerateRDKitFingerprint generates an RDKit fingerprint for a SMILES string
+// This is a placeholder implementation. In production, this should call RDKit C++ library via CGO
+func GenerateRDKitFingerprint(smiles string, minPath int, maxPath int, fingerprintSize int) ([]byte, error) {
+	if len(smiles) == 0 {
+		byteSize := fingerprintSize / 8
+		if fingerprintSize%8 != 0 {
+			byteSize++
+		}
+		return make([]byte, byteSize), nil
+	}
+
+	// TODO: Implement actual RDKit CGO call
+	// For now, return a placeholder implementation
+	// This should be replaced with actual CGO call to RDKit:
+	//  1. Parse SMILES string using RDKit
+	//  2. Generate RDKit fingerprint with specified min_path and max_path
+	//  3. Convert to binary vector of specified size
+	
+	// Placeholder: return zero vector for now
+	// In production, this should be:
+	//   fp := C.generate_rdkit_fingerprint(C.CString(smiles), C.int(minPath), C.int(maxPath), C.int(fingerprintSize))
+	//   defer C.free(unsafe.Pointer(fp.data))
+	//   return C.GoBytes(fp.data, fp.size), nil
+	
+	byteSize := fingerprintSize / 8
+	if fingerprintSize%8 != 0 {
+		byteSize++
+	}
+	fingerprint := make([]byte, byteSize)
+	
+	// Simple hash-based placeholder (NOT production code)
+	// This is just to make the code compile and run
+	// Replace with actual RDKit CGO implementation
+	hash := simpleHash(smiles)
+	for i := 0; i < len(fingerprint) && i < 8; i++ {
+		fingerprint[i] = byte(hash >> (i * 8))
+	}
+	
+	return fingerprint, nil
+}

--- a/internal/util/function/mol_fingerprint_function.go
+++ b/internal/util/function/mol_fingerprint_function.go
@@ -1,0 +1,257 @@
+/*
+ * # Licensed to the LF AI & Data foundation under one
+ * # or more contributor license agreements. See the NOTICE file
+ * # distributed with this work for additional information
+ * # regarding copyright ownership. The ASF licenses this file
+ * # to you under the Apache License, Version 2.0 (the
+ * # "License"); you may not use this file except in compliance
+ * # with the License. You may obtain a copy of the License at
+ * #
+ * #     http://www.apache.org/licenses/LICENSE-2.0
+ * #
+ * # Unless required by applicable law or agreed to in writing, software
+ * # distributed under the License is distributed on an "AS IS" BASIS,
+ * # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * # See the License for the specific language governing permissions and
+ * # limitations under the License.
+ */
+
+package function
+
+import (
+	"fmt"
+	"strconv"
+	"sync"
+
+	"github.com/cockroachdb/errors"
+	"go.uber.org/zap"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/util/function/mol"
+	"github.com/milvus-io/milvus/pkg/v2/log"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+)
+
+// Helper function to get dimension from type parameters
+func getDimFromTypeParams(params []*commonpb.KeyValuePair) (int, error) {
+	for _, param := range params {
+		if param.GetKey() == "dim" {
+			dim, err := strconv.Atoi(param.GetValue())
+			if err != nil {
+				return 0, fmt.Errorf("invalid dim parameter: %s", param.GetValue())
+			}
+			return dim, nil
+		}
+	}
+	return 0, fmt.Errorf("dim parameter not found")
+}
+
+const (
+	paramFingerprintType   = "fingerprint_type"
+	paramFingerprintSize   = "fingerprint_size"
+	paramRadius            = "radius"
+	defaultFingerprintSize = 2048
+	defaultRadius          = 2
+)
+
+// MolFingerprintFunctionRunner implements FunctionRunner for MOL fingerprint generation
+// Input: MOL type (SMILES strings)
+// Output: BINARY_VECTOR type (fingerprint vectors)
+type MolFingerprintFunctionRunner struct {
+	mu     sync.RWMutex
+	closed bool
+
+	schema      *schemapb.FunctionSchema
+	outputField *schemapb.FieldSchema
+	inputField  *schemapb.FieldSchema
+
+	fingerprintType string
+	fingerprintSize int
+	radius          int
+}
+
+// NewMolFingerprintFunctionRunner creates a new MolFingerprintFunctionRunner
+func NewMolFingerprintFunctionRunner(coll *schemapb.CollectionSchema, schema *schemapb.FunctionSchema) (FunctionRunner, error) {
+	if len(schema.GetOutputFieldIds()) != 1 {
+		return nil, fmt.Errorf("mol fingerprint function should only have one output field, but now %d", len(schema.GetOutputFieldIds()))
+	}
+
+	if len(schema.GetInputFieldIds()) != 1 {
+		return nil, fmt.Errorf("mol fingerprint function should only have one input field, but now %d", len(schema.GetInputFieldIds()))
+	}
+
+	var inputField, outputField *schemapb.FieldSchema
+	for _, field := range coll.GetFields() {
+		if field.GetFieldID() == schema.GetOutputFieldIds()[0] {
+			outputField = field
+		}
+		if field.GetFieldID() == schema.GetInputFieldIds()[0] {
+			inputField = field
+		}
+	}
+
+	if inputField == nil {
+		return nil, errors.New("input field not found")
+	}
+	if outputField == nil {
+		return nil, errors.New("output field not found")
+	}
+
+	// Validate input field type
+	if inputField.GetDataType() != schemapb.DataType_Mol {
+		return nil, fmt.Errorf("mol fingerprint function input field must be MOL type, got %s", inputField.GetDataType().String())
+	}
+
+	// Validate output field type
+	if outputField.GetDataType() != schemapb.DataType_BinaryVector {
+		return nil, fmt.Errorf("mol fingerprint function output field must be BINARY_VECTOR type, got %s", outputField.GetDataType().String())
+	}
+
+	// Parse parameters
+	fingerprintType := "morgan" // default
+	fingerprintSize := defaultFingerprintSize
+	radius := defaultRadius
+
+	for _, param := range schema.GetParams() {
+		switch param.GetKey() {
+		case paramFingerprintType:
+			fingerprintType = param.GetValue()
+			if fingerprintType != "morgan" {
+				return nil, fmt.Errorf("unsupported fingerprint type: %s, only 'morgan' is supported currently", fingerprintType)
+			}
+		case paramFingerprintSize:
+			size, err := strconv.Atoi(param.GetValue())
+			if err != nil {
+				return nil, fmt.Errorf("invalid fingerprint_size parameter: %s", param.GetValue())
+			}
+			if size <= 0 {
+				return nil, fmt.Errorf("fingerprint_size must be positive, got %d", size)
+			}
+			fingerprintSize = size
+		case paramRadius:
+			r, err := strconv.Atoi(param.GetValue())
+			if err != nil {
+				return nil, fmt.Errorf("invalid radius parameter: %s", param.GetValue())
+			}
+			if r < 0 {
+				return nil, fmt.Errorf("radius must be non-negative, got %d", r)
+			}
+			radius = r
+		}
+	}
+
+	// Validate output field dimension matches fingerprint size
+	dim, err := getDimFromTypeParams(outputField.GetTypeParams())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get dimension from output field: %w", err)
+	}
+	if dim != fingerprintSize {
+		return nil, fmt.Errorf("output field dimension (%d) does not match fingerprint_size (%d)", dim, fingerprintSize)
+	}
+
+	return &MolFingerprintFunctionRunner{
+		schema:          schema,
+		inputField:      inputField,
+		outputField:     outputField,
+		fingerprintType: fingerprintType,
+		fingerprintSize: fingerprintSize,
+		radius:          radius,
+	}, nil
+}
+
+// BatchRun processes a batch of SMILES strings and generates fingerprint vectors
+func (v *MolFingerprintFunctionRunner) BatchRun(inputs ...any) ([]any, error) {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+
+	if v.closed {
+		return nil, errors.New("mol fingerprint function received request after closed")
+	}
+
+	if len(inputs) != 1 {
+		return nil, errors.New("mol fingerprint function received more than one input column")
+	}
+
+	// Extract SMILES strings from input
+	// Input can be []string (SMILES strings) or [][]byte (pickle data)
+	var smilesData []string
+	switch input := inputs[0].(type) {
+	case []string:
+		smilesData = input
+	case [][]byte:
+		// Convert [][]byte to []string
+		smilesData = make([]string, len(input))
+		for i, bytes := range input {
+			smilesData[i] = string(bytes)
+		}
+	default:
+		return nil, fmt.Errorf("mol fingerprint function batch input must be []string or [][]byte, got %T", inputs[0])
+	}
+
+	rowNum := len(smilesData)
+	if rowNum == 0 {
+		return []any{&storage.BinaryVectorFieldData{
+			Data: []byte{},
+			Dim:  v.fingerprintSize,
+		}}, nil
+	}
+
+	// Generate fingerprints
+	fingerprints := make([][]byte, rowNum)
+	for i, smiles := range smilesData {
+		if len(smiles) == 0 {
+			// Empty SMILES -> zero fingerprint
+			fingerprints[i] = make([]byte, v.fingerprintSize/8)
+			continue
+		}
+
+		fp, err := mol.GenerateMorganFingerprint(smiles, v.radius, v.fingerprintSize)
+		if err != nil {
+			log.Warn("failed to generate fingerprint for SMILES",
+				zap.String("smiles", smiles),
+				zap.Int("index", i),
+				zap.Error(err))
+			return nil, merr.WrapErrParameterInvalidMsg("failed to generate fingerprint for SMILES %s: %v", smiles, err)
+		}
+		fingerprints[i] = fp
+	}
+
+	// Convert fingerprints to BINARY_VECTOR format
+	// BINARY_VECTOR stores bits packed into bytes
+	binaryVector := make([]byte, 0, rowNum*v.fingerprintSize/8)
+	for _, fp := range fingerprints {
+		binaryVector = append(binaryVector, fp...)
+	}
+
+	// Return BinaryVectorFieldData
+	outputData := &storage.BinaryVectorFieldData{
+		Data: binaryVector,
+		Dim:  v.fingerprintSize,
+	}
+
+	return []any{outputData}, nil
+}
+
+// GetSchema returns the function schema
+func (v *MolFingerprintFunctionRunner) GetSchema() *schemapb.FunctionSchema {
+	return v.schema
+}
+
+// GetOutputFields returns the output field schemas
+func (v *MolFingerprintFunctionRunner) GetOutputFields() []*schemapb.FieldSchema {
+	return []*schemapb.FieldSchema{v.outputField}
+}
+
+// GetInputFields returns the input field schemas
+func (v *MolFingerprintFunctionRunner) GetInputFields() []*schemapb.FieldSchema {
+	return []*schemapb.FieldSchema{v.inputField}
+}
+
+// Close closes the function runner
+func (v *MolFingerprintFunctionRunner) Close() {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.closed = true
+}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -674,3 +674,8 @@ func ConvertWKBToWKT(wkbData []byte) (string, error) {
 	}
 	return wkt.Marshal(geomT)
 }
+
+func ConvertSMILESToPickle(molData string) ([]byte, error) {
+	// TODO: implement this function
+	return []byte(molData), nil
+}

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/jolestar/go-commons-pool/v2 v2.1.2
 	github.com/json-iterator/go v1.1.13-0.20220915233716-71ac16282d12
 	github.com/klauspost/compress v1.18.0
-	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260113024922-c7feeb806088
+	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260116085923-3452b3ee9424
 	github.com/minio/minio-go/v7 v7.0.73
 	github.com/panjf2000/ants/v2 v2.11.3
 	github.com/prometheus/client_golang v1.20.5

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -482,8 +482,8 @@ github.com/milvus-io/cgosymbolizer v0.0.0-20250318084424-114f4050c3a6 h1:YHMFI6L
 github.com/milvus-io/cgosymbolizer v0.0.0-20250318084424-114f4050c3a6/go.mod h1:DvXTE/K/RtHehxU8/GtDs4vFtfw64jJ3PaCnFri8CRg=
 github.com/milvus-io/gorocksdb v0.0.0-20220624081344-8c5f4212846b h1:TfeY0NxYxZzUfIfYe5qYDBzt4ZYRqzUjTR6CvUzjat8=
 github.com/milvus-io/gorocksdb v0.0.0-20220624081344-8c5f4212846b/go.mod h1:iwW+9cWfIzzDseEBCCeDSN5SD16Tidvy8cwQ7ZY8Qj4=
-github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260113024922-c7feeb806088 h1:qzlpV+1xygF/XK0bRVoLFg03uAQSCZ2AywZR3wt5ov0=
-github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260113024922-c7feeb806088/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260116085923-3452b3ee9424 h1:TPp9tRlSJs2BUW5wUETdRpxC40Y0+5D0rBBrdjtwHT8=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260116085923-3452b3ee9424/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
 github.com/minio/md5-simd v1.1.2 h1:Gdi1DZK69+ZVMoNHRXJyNcxrMA4dSxoYHZSQbirFg34=
 github.com/minio/md5-simd v1.1.2/go.mod h1:MzdKDxYpY2BT9XQFocsiZf/NKVtR7nkE4RoEpN+20RM=
 github.com/minio/minio-go/v7 v7.0.73 h1:qr2vi96Qm7kZ4v7LLebjte+MQh621fFWnv93p12htEo=

--- a/pkg/util/funcutil/func.go
+++ b/pkg/util/funcutil/func.go
@@ -536,6 +536,8 @@ func GetNumRowOfFieldDataWithSchema(fieldData *schemapb.FieldData, helper *typeu
 		if fieldNumRows == 0 {
 			fieldNumRows = getNumRowsOfScalarField(fieldData.GetScalars().GetGeometryWktData().GetData())
 		}
+	case schemapb.DataType_Mol:
+		fieldNumRows = getNumRowsOfScalarField(fieldData.GetScalars().GetMolData().GetData())
 	case schemapb.DataType_FloatVector:
 		if len(fieldData.GetValidData()) > 0 {
 			fieldNumRows = uint64(len(fieldData.GetValidData()))
@@ -633,6 +635,8 @@ func GetNumRowOfFieldData(fieldData *schemapb.FieldData) (uint64, error) {
 			fieldNumRows = getNumRowsOfScalarField(scalarField.GetJsonData().Data)
 		case *schemapb.ScalarField_GeometryData:
 			fieldNumRows = getNumRowsOfScalarField(scalarField.GetGeometryData().Data)
+		case *schemapb.ScalarField_MolData:
+			fieldNumRows = getNumRowsOfScalarField(scalarField.GetMolData().Data)
 		default:
 			return 0, fmt.Errorf("%s is not supported now", scalarType)
 		}


### PR DESCRIPTION
Related to: https://github.com/milvus-io/milvus/issues/47229

# feat: Implement MOL fingerprint function for molecular similarity search

## Overview

This PR implements the MOL fingerprint function feature, which automatically converts SMILES strings into molecular fingerprint vectors for molecular similarity search. Similar to the BM25 function, this feature uses the Function mechanism to automatically generate fingerprint vectors during data insertion, supporting three fingerprint types: Morgan, MACCS, and RDKit.

## Key Changes

### 1. Core Implementation

#### 1.1 Fingerprint Generation Functions
- **`internal/util/function/mol_fingerprint_function.go`**: Implements `MolFingerprintFunctionRunner` with parameter parsing and batch generation support for three fingerprint types
- **`internal/util/function/mol/morgan.go`**: Morgan fingerprint generation function (supports custom radius and fingerprint_size)
- **`internal/util/function/mol/maccs.go`**: MACCS fingerprint generation function (fixed 167 bits)
- **`internal/util/function/mol/rdkit.go`**: RDKit fingerprint generation function (supports min_path and max_path parameters)

#### 1.2 Function Registration
- **`internal/util/function/function.go`**: Adds `MOL_FINGERPRINT` type support in `NewFunctionRunner`
- **`internal/util/function/embedding/function_executor.go`**: Marks `MOL_FINGERPRINT` to skip FunctionExecutor processing (handled by function.NewFunctionRunner)

### 2. Pipeline Integration

#### 2.1 Fingerprint Generation During Insertion
- **`internal/flushcommon/pipeline/flow_graph_embedding_node.go`**: 
  - Adds `molFingerprintEmbedding` function to generate fingerprint vectors during data node insertion
  - Adds `FunctionType_MolFingerprint` branch in the `embedding` function's switch statement

#### 2.2 Fingerprint Generation During Query
- **`internal/querynodev2/pipeline/embedding_node.go`**: 
  - Adds `molFingerprintEmbedding` function to generate fingerprint vectors during query node processing
  - Adds `FunctionType_MolFingerprint` branch in the `embedding` function's switch statement

## Supported Fingerprint Types

### Morgan Fingerprint
- **Parameters**:
  - `fingerprint_type`: "morgan" (required)
  - `fingerprint_size`: Fingerprint size, default 2048 (optional)
  - `radius`: Morgan radius, default 2 (optional)
- **Use Case**: Suitable for most molecular similarity search scenarios

### MACCS Fingerprint
- **Parameters**:
  - `fingerprint_type`: "maccs" (required)
  - `fingerprint_size`: Fixed at 167, no need to specify (automatically set)
- **Use Case**: Fixed-length fingerprint based on MACCS keys, suitable for fast screening

### RDKit Fingerprint
- **Parameters**:
  - `fingerprint_type`: "rdkit" (required)
  - `fingerprint_size`: Fingerprint size, default 2048 (optional)
  - `min_path`: Minimum path length, default 1 (optional)
  - `max_path`: Maximum path length, default 7 (optional)
- **Use Case**: Path-based fingerprint with customizable path range

## Technical Details

### Data Flow
1. **Insertion Flow**: 
   - User inserts SMILES strings into MOL field
   - `MolFingerprintFunctionRunner` automatically converts SMILES to fingerprint vectors
   - Fingerprint vectors are stored in BINARY_VECTOR field

2. **Query Flow**:
   - When fingerprint vectors need to be generated during query, they are processed through querynodev2's embedding pipeline
   - Generated fingerprint vectors can be used for similarity search (JACCARD distance)

### Parameter Validation
- Input field type validation: Must be `DataType_Mol`
- Output field type validation: Must be `DataType_BinaryVector`
- Fingerprint type validation: Only supports morgan, maccs, rdkit
- Dimension matching validation: Output field's dim must match fingerprint_size
- MACCS special handling: Automatically sets fingerprint_size to 167

### Error Handling
- Empty SMILES strings: Returns zero fingerprint vector
- Invalid parameters: Returns detailed error messages
- Fingerprint generation failure: Logs warning and returns error

## Usage Example

```python
from pymilvus import MilvusClient, DataType, Function, FunctionType

client = MilvusClient(uri="http://localhost:19530")

# Create Schema
schema = client.create_schema(auto_id=False, enable_dynamic_field=True)
schema.add_field("id", DataType.INT64, is_primary=True, auto_id=False)
schema.add_field("mol", DataType.MOL, description="Molecular SMILES string")
schema.add_field("mol_fp", DataType.BINARY_VECTOR, dim=2048, description="Fingerprint vector")

# Define MOL Function (Morgan fingerprint)
mol_function = Function(
    name="mol_fingerprint",
    function_type=FunctionType.MOL_FINGERPRINT,
    input_field_names=["mol"],
    output_field_names=["mol_fp"],
    params={
        "fingerprint_type": "morgan",
        "fingerprint_size": "2048",
        "radius": "2",
    }
)
schema.add_function(mol_function)

# Create Collection
client.create_collection("drug_molecules", schema=schema)

# Insert data (only SMILES needed, fingerprint vectors auto-generated)
molecules = [
    {"id": 1, "mol": "CCO"},  # Ethanol
    {"id": 2, "mol": "c1ccccc1"},  # Benzene
]
client.insert("drug_molecules", data=molecules)

# Create index and search
index_params = client.prepare_index_params()
index_params.add_index(
    field_name="mol_fp",
    index_type="BIN_IVF_FLAT",
    metric_type="JACCARD",
    params={"nlist": 1024}
)
client.create_index("drug_molecules", index_params)
client.load_collection("drug_molecules")

# Similarity search
results = client.search(
    collection_name="drug_molecules",
    data=query_fingerprint_vector,
    anns_field="mol_fp",
    search_params={"metric_type": "JACCARD", "params": {"nprobe": 32}},
    limit=5
)
```

## File Changes Summary

- **New Files**: 3
  - `internal/util/function/mol/morgan.go`
  - `internal/util/function/mol/maccs.go`
  - `internal/util/function/mol/rdkit.go`

- **Modified Files**: 5
  - `internal/util/function/mol_fingerprint_function.go` (new)
  - `internal/util/function/function.go`
  - `internal/util/function/embedding/function_executor.go`
  - `internal/flushcommon/pipeline/flow_graph_embedding_node.go`
  - `internal/querynodev2/pipeline/embedding_node.go`

## Notes

1. **Placeholder Implementation**: Current fingerprint generation functions use placeholder implementations (based on simple hash). Production environment requires replacement with RDKit CGO calls.
2. **Concurrency Safety**: `MolFingerprintFunctionRunner` uses `sync.RWMutex` to ensure concurrency safety.
3. **Memory Management**: Fingerprint vectors are returned as `BinaryVectorFieldData` format, with memory management handled by the caller.
4. **Compatibility**: Compatible with existing BM25 and MinHash functions, does not affect other functionality.

## Follow-up Work

- [ ] Implement RDKit CGO calls to replace placeholder implementations
- [ ] Add unit tests and integration tests
- [ ] Improve error handling and logging
- [ ] Performance optimization and benchmarking
- [ ] Update API documentation and user guides
