### PR TITLE
fix: minor fixes and improvements related to regex, data race and utils

### DIFF
--- a/pkg/mq/msgdispatcher/dispatcher.go
+++ b/pkg/mq/msgdispatcher/dispatcher.go
@@ -350,14 +350,12 @@ func (d *Dispatcher) groupAndParseMsgs(pack *msgstream.ConsumeMsgPack, unmarshal
 				targets = append(targets, k)
 			}
 			if len(targets) > 0 {
-				tsMsg, err := msg.Unmarshal(unmarshalDispatcher)
-				if err != nil {
-					log.Warn("unmarshl message failed", zap.Error(err))
-					continue
-				}
-				// TODO: There's data race when non-dml msg is sent to different flow graph.
-				// Wrong open-trancing information is generated, Fix in future.
 				for _, target := range targets {
+					tsMsg, err := msg.Unmarshal(unmarshalDispatcher)
+					if err != nil {
+						log.Warn("unmarshal message failed", zap.Error(err))
+						continue
+					}
 					targetPacks[target].Msgs = append(targetPacks[target].Msgs, tsMsg)
 				}
 			}
@@ -366,7 +364,7 @@ func (d *Dispatcher) groupAndParseMsgs(pack *msgstream.ConsumeMsgPack, unmarshal
 		if _, ok := targetPacks[vchannel]; ok {
 			tsMsg, err := msg.Unmarshal(unmarshalDispatcher)
 			if err != nil {
-				log.Warn("unmarshl message failed", zap.Error(err))
+				log.Warn("unmarshal message failed", zap.Error(err))
 				continue
 			}
 			targetPacks[vchannel].Msgs = append(targetPacks[vchannel].Msgs, tsMsg)

--- a/pkg/mq/msgdispatcher/dispatcher_race_test.go
+++ b/pkg/mq/msgdispatcher/dispatcher_race_test.go
@@ -5,11 +5,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
 	"github.com/milvus-io/milvus/pkg/v2/mq/common"
 	"github.com/milvus-io/milvus/pkg/v2/mq/msgstream"
-	"github.com/stretchr/testify/assert"
 )
 
 type mockConsumeMsg struct {

--- a/pkg/mq/msgdispatcher/dispatcher_race_test.go
+++ b/pkg/mq/msgdispatcher/dispatcher_race_test.go
@@ -1,0 +1,74 @@
+package msgdispatcher
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
+	"github.com/milvus-io/milvus/pkg/v2/mq/common"
+	"github.com/milvus-io/milvus/pkg/v2/mq/msgstream"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockConsumeMsg struct {
+	collectionID string
+}
+
+func (m *mockConsumeMsg) GetPosition() *msgpb.MsgPosition { return nil }
+func (m *mockConsumeMsg) SetPosition(*msgpb.MsgPosition)  {}
+func (m *mockConsumeMsg) GetSize() int                    { return 0 }
+func (m *mockConsumeMsg) GetTimestamp() uint64            { return 0 }
+func (m *mockConsumeMsg) GetVChannel() string             { return "" }
+func (m *mockConsumeMsg) GetPChannel() string             { return "" }
+func (m *mockConsumeMsg) GetMessageID() []byte            { return nil }
+func (m *mockConsumeMsg) GetID() int64                    { return 0 }
+func (m *mockConsumeMsg) GetCollectionID() string         { return m.collectionID }
+func (m *mockConsumeMsg) GetType() commonpb.MsgType       { return commonpb.MsgType_CreateCollection }
+func (m *mockConsumeMsg) SetTraceCtx(ctx context.Context) {}
+
+func (m *mockConsumeMsg) Unmarshal(unmarshalDispatcher msgstream.UnmarshalDispatcher) (msgstream.TsMsg, error) {
+	// Return a new instance every time
+	return &msgstream.CreateCollectionMsg{
+		BaseMsg: msgstream.BaseMsg{
+			Ctx: context.Background(),
+		},
+		CreateCollectionRequest: &msgpb.CreateCollectionRequest{
+			CollectionID: 100, // Dummy
+		},
+	}, nil
+}
+
+func TestGroupMessageDataRaceFix(t *testing.T) {
+	d, err := NewDispatcher(context.Background(), newMockFactory(), time.Now().UnixNano(), "mock_pchannel_0",
+		nil, common.SubscriptionPositionEarliest, 0, false)
+	assert.NoError(t, err)
+
+	// Add two targets that both match collectionID "100"
+	// vchannel names must contain "100"
+	d.AddTarget(newTarget(&StreamConfig{VChannel: "mock_pchannel_0_100v0"}, false))
+	d.AddTarget(newTarget(&StreamConfig{VChannel: "mock_pchannel_0_100v1"}, false))
+
+	pack := &msgstream.ConsumeMsgPack{
+		Msgs: []msgstream.ConsumeMsg{
+			&mockConsumeMsg{collectionID: "100"},
+		},
+	}
+
+	targetPacks := d.groupAndParseMsgs(pack, nil)
+
+	// Verify we have 2 target packs
+	assert.Len(t, targetPacks, 2)
+
+	// Collect the TsMsg objects
+	var msgs []msgstream.TsMsg
+	for _, tp := range targetPacks {
+		assert.Len(t, tp.Msgs, 1)
+		msgs = append(msgs, tp.Msgs[0])
+	}
+
+	assert.Len(t, msgs, 2)
+	// Check if they are different instances
+	assert.NotSame(t, msgs[0], msgs[1], "Messages should be different instances to avoid data race")
+}

--- a/pkg/util/funcutil/func.go
+++ b/pkg/util/funcutil/func.go
@@ -421,9 +421,10 @@ func ConvertChannelName(chanName string, tokenFrom string, tokenTo string) (stri
 	return strings.Replace(chanName, tokenFrom, tokenTo, 1), nil
 }
 
+var collectionIDRegexp = regexp.MustCompile(`.*_(\d+)v\d+`)
+
 func GetCollectionIDFromVChannel(vChannelName string) int64 {
-	re := regexp.MustCompile(`.*_(\d+)v\d+`)
-	matches := re.FindStringSubmatch(vChannelName)
+	matches := collectionIDRegexp.FindStringSubmatch(vChannelName)
 	if len(matches) > 1 {
 		number, err := strconv.ParseInt(matches[1], 0, 64)
 		if err == nil {

--- a/pkg/util/funcutil/map.go
+++ b/pkg/util/funcutil/map.go
@@ -2,8 +2,7 @@ package funcutil
 
 import "fmt"
 
-func MapReduce(results []map[string]string, method map[string]func(string) error) error {
-	// TODO: use generic type to reconstruct map[string]string -> [T any] map[string]T
+func MapReduce[T any](results []map[string]T, method map[string]func(T) error) error {
 	for _, result := range results {
 		for k, v := range result {
 			fn, ok := method[k]

--- a/pkg/util/funcutil/map_test.go
+++ b/pkg/util/funcutil/map_test.go
@@ -1,0 +1,90 @@
+package funcutil
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMapReduce(t *testing.T) {
+	t.Run("map[string]string", func(t *testing.T) {
+		results := []map[string]string{
+			{"a": "1", "b": "2"},
+			{"a": "3", "b": "4"},
+		}
+
+		sum := 0
+		method := map[string]func(string) error{
+			"a": func(s string) error {
+				val, err := strconv.Atoi(s)
+				if err != nil {
+					return err
+				}
+				sum += val
+				return nil
+			},
+			"b": func(s string) error {
+				val, err := strconv.Atoi(s)
+				if err != nil {
+					return err
+				}
+				sum += val
+				return nil
+			},
+		}
+
+		err := MapReduce(results, method)
+		assert.NoError(t, err)
+		assert.Equal(t, 10, sum) // 1+2+3+4 = 10
+	})
+
+	t.Run("map[string]int", func(t *testing.T) {
+		results := []map[string]int{
+			{"a": 1, "b": 2},
+			{"a": 3, "b": 4},
+		}
+
+		sum := 0
+		method := map[string]func(int) error{
+			"a": func(i int) error {
+				sum += i
+				return nil
+			},
+			"b": func(i int) error {
+				sum += i
+				return nil
+			},
+		}
+
+		err := MapReduce(results, method)
+		assert.NoError(t, err)
+		assert.Equal(t, 10, sum)
+	})
+
+	t.Run("unknown field", func(t *testing.T) {
+		results := []map[string]string{
+			{"c": "1"},
+		}
+		method := map[string]func(string) error{
+			"a": func(s string) error { return nil },
+		}
+		err := MapReduce(results, method)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown field c")
+	})
+
+	t.Run("method error", func(t *testing.T) {
+		results := []map[string]string{
+			{"a": "invalid"},
+		}
+		method := map[string]func(string) error{
+			"a": func(s string) error {
+				_, err := strconv.Atoi(s)
+				return err
+			},
+		}
+		err := MapReduce(results, method)
+		assert.Error(t, err)
+	})
+}

--- a/tests/go_client/testcases/helper/helper.go
+++ b/tests/go_client/testcases/helper/helper.go
@@ -183,8 +183,9 @@ func CreateMilvusClient(ctx context.Context, t *testing.T, cfg *client.ClientCon
 type CollectionPrepare struct{}
 
 var (
-	CollPrepare CollectionPrepare
-	FieldsFact  FieldsFactory
+	CollPrepare      CollectionPrepare
+	FieldsFact       FieldsFactory
+	nonAlphaNumRegex = regexp.MustCompile("[^a-zA-Z0-9]")
 )
 
 func mergeOptions(schema *entity.Schema, opts ...CreateCollectionOpt) client.CreateCollectionOption {
@@ -242,7 +243,7 @@ func (chainTask *CollectionPrepare) CreateCollection(ctx context.Context, t *tes
 
 	schemaOpt.Fields = fields
 	if schemaOpt.CollectionName == "" {
-		testName := regexp.MustCompile("[^a-zA-Z0-9]").ReplaceAllString(t.Name(), "_")
+		testName := nonAlphaNumRegex.ReplaceAllString(t.Name(), "_")
 		schemaOpt.CollectionName = common.GenRandomString(testName, 6)
 	}
 	schema := GenSchema(schemaOpt)


### PR DESCRIPTION
issue: #44452

- perf: optimize regex compilation in GetCollectionIDFromVChannel
- fix: data race in message dispatcher for non-DML messages
- refactor: MapReduce to use generics