### PR TITLE
fix: [2.6] Use actual data timestamps for imported segment positions

### DIFF
--- a/internal/datacoord/import_task_import_test.go
+++ b/internal/datacoord/import_task_import_test.go
@@ -18,6 +18,7 @@ package datacoord
 
 import (
 	"context"
+	"math"
 	"testing"
 	"time"
 
@@ -413,8 +414,17 @@ func TestImportTask_QueryTaskOnWorker(t *testing.T) {
 		catalog.EXPECT().ListPreImportTasks(mock.Anything).Return(nil, nil)
 		catalog.EXPECT().ListImportTasks(mock.Anything).Return(nil, nil)
 		catalog.EXPECT().SaveImportTask(mock.Anything, mock.Anything).Return(nil)
+		catalog.EXPECT().SaveImportJob(mock.Anything, mock.Anything).Return(nil)
 
 		im, err := NewImportMeta(context.TODO(), catalog, nil, nil)
+		assert.NoError(t, err)
+
+		var job ImportJob = &importJob{
+			ImportJob: &datapb.ImportJob{
+				JobID: 1,
+			},
+		}
+		err = im.AddJob(context.TODO(), job)
 		assert.NoError(t, err)
 
 		taskProto := &datapb.ImportTaskV2{
@@ -473,6 +483,101 @@ func TestImportTask_QueryTaskOnWorker(t *testing.T) {
 		assert.Equal(t, datapb.ImportTaskStateV2_Completed, task.GetState())
 		assert.Equal(t, int64(100), task.meta.segments.GetSegment(5).GetNumOfRows())
 		assert.Equal(t, int64(200), task.meta.segments.GetSegment(6).GetNumOfRows())
+	})
+}
+
+func TestExtractTimestampFromBinlogs(t *testing.T) {
+	t.Run("empty binlogs", func(t *testing.T) {
+		minTs, maxTs := extractTimestampFromBinlogs(nil)
+		assert.Equal(t, uint64(math.MaxUint64), minTs)
+		assert.Equal(t, uint64(0), maxTs)
+	})
+
+	t.Run("empty field binlogs", func(t *testing.T) {
+		binlogs := []*datapb.FieldBinlog{}
+		minTs, maxTs := extractTimestampFromBinlogs(binlogs)
+		assert.Equal(t, uint64(math.MaxUint64), minTs)
+		assert.Equal(t, uint64(0), maxTs)
+	})
+
+	t.Run("single binlog", func(t *testing.T) {
+		binlogs := []*datapb.FieldBinlog{
+			{
+				FieldID: 100,
+				Binlogs: []*datapb.Binlog{
+					{
+						TimestampFrom: 1000,
+						TimestampTo:   2000,
+					},
+				},
+			},
+		}
+		minTs, maxTs := extractTimestampFromBinlogs(binlogs)
+		assert.Equal(t, uint64(1000), minTs)
+		assert.Equal(t, uint64(2000), maxTs)
+	})
+
+	t.Run("multiple binlogs in single field", func(t *testing.T) {
+		binlogs := []*datapb.FieldBinlog{
+			{
+				FieldID: 100,
+				Binlogs: []*datapb.Binlog{
+					{
+						TimestampFrom: 1000,
+						TimestampTo:   2000,
+					},
+					{
+						TimestampFrom: 500,
+						TimestampTo:   3000,
+					},
+				},
+			},
+		}
+		minTs, maxTs := extractTimestampFromBinlogs(binlogs)
+		assert.Equal(t, uint64(500), minTs)
+		assert.Equal(t, uint64(3000), maxTs)
+	})
+
+	t.Run("multiple fields with multiple binlogs", func(t *testing.T) {
+		binlogs := []*datapb.FieldBinlog{
+			{
+				FieldID: 100,
+				Binlogs: []*datapb.Binlog{
+					{
+						TimestampFrom: 1000,
+						TimestampTo:   2000,
+					},
+				},
+			},
+			{
+				FieldID: 101,
+				Binlogs: []*datapb.Binlog{
+					{
+						TimestampFrom: 500,
+						TimestampTo:   1500,
+					},
+					{
+						TimestampFrom: 800,
+						TimestampTo:   3000,
+					},
+				},
+			},
+		}
+		minTs, maxTs := extractTimestampFromBinlogs(binlogs)
+		assert.Equal(t, uint64(500), minTs)
+		assert.Equal(t, uint64(3000), maxTs)
+	})
+
+	t.Run("field binlog with no binlogs inside", func(t *testing.T) {
+		binlogs := []*datapb.FieldBinlog{
+			{
+				FieldID: 100,
+				Binlogs: []*datapb.Binlog{},
+			},
+		}
+		minTs, maxTs := extractTimestampFromBinlogs(binlogs)
+		assert.Equal(t, uint64(math.MaxUint64), minTs)
+		assert.Equal(t, uint64(0), maxTs)
 	})
 }
 

--- a/internal/datacoord/import_util.go
+++ b/internal/datacoord/import_util.go
@@ -241,11 +241,6 @@ func AllocImportSegment(ctx context.Context,
 			return nil, err
 		}
 	}
-	position := &msgpb.MsgPosition{
-		ChannelName: channelName,
-		MsgID:       nil,
-		Timestamp:   ts,
-	}
 
 	segmentInfo := &datapb.SegmentInfo{
 		ID:             id,
@@ -257,8 +252,6 @@ func AllocImportSegment(ctx context.Context,
 		MaxRowNum:      0,
 		Level:          level,
 		LastExpireTime: math.MaxUint64,
-		StartPosition:  position,
-		DmlPosition:    position,
 		StorageVersion: storageVersion,
 	}
 	segmentInfo.IsImporting = true

--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -1226,6 +1226,35 @@ func UpdateIsImporting(segmentID int64, isImporting bool) UpdateOperator {
 	}
 }
 
+// UpdateImportSegmentPosition updates the segment's StartPosition and DmlPosition
+// for import segments using actual timestamps from the imported data.
+// Unlike UpdateStartPosition/UpdateDmlPosition, this operator allows nil MsgID
+// since import segments don't have message queue positions.
+func UpdateImportSegmentPosition(segmentID int64, minTs, maxTs uint64) UpdateOperator {
+	return func(modPack *updateSegmentPack) bool {
+		segment := modPack.Get(segmentID)
+		if segment == nil {
+			log.Ctx(context.TODO()).Warn("meta update: update import segment position failed - segment not found",
+				zap.Int64("segmentID", segmentID))
+			return false
+		}
+		channelName := segment.GetInsertChannel()
+		// Use actual min timestamp for StartPosition
+		segment.StartPosition = &msgpb.MsgPosition{
+			ChannelName: channelName,
+			MsgID:       nil,
+			Timestamp:   minTs,
+		}
+		// Use actual max timestamp for DmlPosition
+		segment.DmlPosition = &msgpb.MsgPosition{
+			ChannelName: channelName,
+			MsgID:       nil,
+			Timestamp:   maxTs,
+		}
+		return true
+	}
+}
+
 // UpdateAsDroppedIfEmptyWhenFlushing updates segment state to Dropped if segment is empty and in Flushing state
 // It's used to make a empty flushing segment to be dropped directly.
 func UpdateAsDroppedIfEmptyWhenFlushing(segmentID int64) UpdateOperator {

--- a/internal/datacoord/segment_operator_test.go
+++ b/internal/datacoord/segment_operator_test.go
@@ -19,6 +19,7 @@ package datacoord
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
@@ -46,4 +47,70 @@ func (s *TestSegmentOperatorSuite) TestSetMaxRowCount() {
 
 func TestSegmentOperators(t *testing.T) {
 	suite.Run(t, new(TestSegmentOperatorSuite))
+}
+
+func TestUpdateImportSegmentPosition(t *testing.T) {
+	t.Run("segment not found", func(t *testing.T) {
+		// Create a meta with empty segments to properly test the "not found" case
+		segments := NewSegmentsInfo()
+		m := &meta{segments: segments}
+		modPack := &updateSegmentPack{
+			meta:     m,
+			segments: make(map[int64]*SegmentInfo),
+		}
+		op := UpdateImportSegmentPosition(100, 1000, 2000)
+		result := op(modPack)
+		assert.False(t, result)
+	})
+
+	t.Run("update position successfully", func(t *testing.T) {
+		segment := &SegmentInfo{
+			SegmentInfo: &datapb.SegmentInfo{
+				ID:            100,
+				InsertChannel: "test_channel",
+			},
+		}
+		modPack := &updateSegmentPack{
+			segments: map[int64]*SegmentInfo{
+				100: segment,
+			},
+		}
+		op := UpdateImportSegmentPosition(100, 1000, 2000)
+		result := op(modPack)
+		assert.True(t, result)
+
+		// Verify StartPosition
+		assert.NotNil(t, segment.GetStartPosition())
+		assert.Equal(t, "test_channel", segment.GetStartPosition().GetChannelName())
+		assert.Nil(t, segment.GetStartPosition().GetMsgID())
+		assert.Equal(t, uint64(1000), segment.GetStartPosition().GetTimestamp())
+
+		// Verify DmlPosition
+		assert.NotNil(t, segment.GetDmlPosition())
+		assert.Equal(t, "test_channel", segment.GetDmlPosition().GetChannelName())
+		assert.Nil(t, segment.GetDmlPosition().GetMsgID())
+		assert.Equal(t, uint64(2000), segment.GetDmlPosition().GetTimestamp())
+	})
+
+	t.Run("update position with zero timestamps", func(t *testing.T) {
+		segment := &SegmentInfo{
+			SegmentInfo: &datapb.SegmentInfo{
+				ID:            101,
+				InsertChannel: "channel_2",
+			},
+		}
+		modPack := &updateSegmentPack{
+			segments: map[int64]*SegmentInfo{
+				101: segment,
+			},
+		}
+		op := UpdateImportSegmentPosition(101, 0, 0)
+		result := op(modPack)
+		assert.True(t, result)
+
+		assert.NotNil(t, segment.GetStartPosition())
+		assert.Equal(t, uint64(0), segment.GetStartPosition().GetTimestamp())
+		assert.NotNil(t, segment.GetDmlPosition())
+		assert.Equal(t, uint64(0), segment.GetDmlPosition().GetTimestamp())
+	})
 }

--- a/internal/datanode/importv2/util.go
+++ b/internal/datanode/importv2/util.go
@@ -104,7 +104,6 @@ func NewSyncTask(ctx context.Context,
 		WithPartitionID(partitionID).
 		WithChannelName(vchannel).
 		WithSegmentID(segmentID).
-		WithTimeRange(ts, ts).
 		WithLevel(segmentLevel).
 		WithDataSource(metrics.BulkinsertDataSourceLabel).
 		WithBatchRows(int64(insertData.GetRowNum()))

--- a/internal/flushcommon/syncmgr/pack_writer_test.go
+++ b/internal/flushcommon/syncmgr/pack_writer_test.go
@@ -121,10 +121,12 @@ func TestBulkPackWriter_Write(t *testing.T) {
 				FieldID: 100,
 				Binlogs: []*datapb.Binlog{
 					{
-						EntriesNum: 10,
-						LogPath:    "files/delta_log/123/456/789/10000",
-						LogSize:    60,
-						MemorySize: 240,
+						EntriesNum:    10,
+						TimestampFrom: 100,
+						TimestampTo:   109,
+						LogPath:       "files/delta_log/123/456/789/10000",
+						LogSize:       60,
+						MemorySize:    240,
 					},
 				},
 			},


### PR DESCRIPTION
This PR:
1. Modifies the import mechanism to use actual timestamps from the imported data for segment positions instead of using the channel checkpoint.
2. Fix writeDelta() to extract actual min/max timestamps from deltaData.Tss instead of using pack.tsFrom/tsTo.
3. Integration test TestBinlogImport updated to verify L1 and L0 segment positions.

issue: https://github.com/milvus-io/milvus/issues/47275

pr: https://github.com/milvus-io/milvus/pull/47276