### PR TITLE
fix: [2.5] Use actual data timestamps for imported segment positions

### DIFF
--- a/internal/datacoord/import_scheduler.go
+++ b/internal/datacoord/import_scheduler.go
@@ -18,6 +18,7 @@ package datacoord
 
 import (
 	"context"
+	"math"
 	"sort"
 	"strconv"
 	"sync"
@@ -30,6 +31,7 @@ import (
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
 	"github.com/milvus-io/milvus/internal/datacoord/session"
 	"github.com/milvus-io/milvus/internal/metastore/kv/binlog"
+	"github.com/milvus-io/milvus/internal/util/importutilv2"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/metrics"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
@@ -321,6 +323,7 @@ func (s *importScheduler) processInProgressImport(task ImportTask) {
 		).Add(float64(diff))
 	}
 	if resp.GetState() == datapb.ImportTaskStateV2_Completed {
+		job := s.importMeta.GetJob(s.ctx, task.GetJobID())
 		for _, info := range resp.GetImportSegmentsInfo() {
 			// try to parse path and fill logID
 			err = binlog.CompressBinLogs(info.GetBinlogs(), info.GetDeltalogs(), info.GetStatslogs(), info.GetBm25Logs())
@@ -329,9 +332,20 @@ func (s *importScheduler) processInProgressImport(task ImportTask) {
 					WrapTaskLog(task, zap.Int64("segmentID", info.GetSegmentID()), zap.Error(err))...)
 				return
 			}
-			op1 := UpdateBinlogsOperator(info.GetSegmentID(), info.GetBinlogs(), info.GetStatslogs(), info.GetDeltalogs(), info.GetBm25Logs())
-			op2 := UpdateStatusOperator(info.GetSegmentID(), commonpb.SegmentState_Flushed)
-			err = s.meta.UpdateSegmentsInfo(s.ctx, op1, op2)
+
+			// Extract actual timestamps from binlogs for segment positions
+			var minTs, maxTs uint64
+			isL0Import := importutilv2.IsL0Import(job.GetOptions())
+			if isL0Import {
+				minTs, maxTs = extractTimestampFromBinlogs(info.GetDeltalogs())
+			} else {
+				minTs, maxTs = extractTimestampFromBinlogs(info.GetBinlogs())
+			}
+
+			opBinlog := UpdateBinlogsOperator(info.GetSegmentID(), info.GetBinlogs(), info.GetStatslogs(), info.GetDeltalogs(), info.GetBm25Logs())
+			opState := UpdateStatusOperator(info.GetSegmentID(), commonpb.SegmentState_Flushed)
+			opPosition := UpdateImportSegmentPosition(info.GetSegmentID(), minTs, maxTs)
+			err = s.meta.UpdateSegmentsInfo(s.ctx, opBinlog, opState, opPosition)
 			if err != nil {
 				updateErr := s.importMeta.UpdateJob(s.ctx, task.GetJobID(), UpdateJobState(internalpb.ImportJobState_Failed), UpdateJobReason(err.Error()))
 				if updateErr != nil {
@@ -340,6 +354,10 @@ func (s *importScheduler) processInProgressImport(task ImportTask) {
 				log.Warn("update import segment binlogs failed", WrapTaskLog(task, zap.String("err", err.Error()))...)
 				return
 			}
+			log.Info("update import segment info done", WrapTaskLog(task,
+				zap.Int64("segmentID", info.GetSegmentID()),
+				zap.Uint64("minTs", minTs),
+				zap.Uint64("maxTs", maxTs))...)
 		}
 		completeTime := time.Now().Format("2006-01-02T15:04:05Z07:00")
 		err = s.importMeta.UpdateTask(s.ctx, task.GetTaskID(), UpdateState(datapb.ImportTaskStateV2_Completed), UpdateCompleteTime(completeTime))
@@ -386,4 +404,23 @@ func (s *importScheduler) processFailed(task ImportTask) {
 	if err != nil {
 		log.Warn("drop import failed", WrapTaskLog(task, zap.Error(err))...)
 	}
+}
+
+// extractTimestampFromBinlogs extracts min and max timestamps from binlogs.
+// The timestamps are stored in Binlog.TimestampFrom and Binlog.TimestampTo
+// by the sync task during import.
+func extractTimestampFromBinlogs(binlogs []*datapb.FieldBinlog) (minTs, maxTs uint64) {
+	minTs = math.MaxUint64
+	maxTs = 0
+	for _, fieldBinlog := range binlogs {
+		for _, binlog := range fieldBinlog.GetBinlogs() {
+			if binlog.GetTimestampFrom() < minTs {
+				minTs = binlog.GetTimestampFrom()
+			}
+			if binlog.GetTimestampTo() > maxTs {
+				maxTs = binlog.GetTimestampTo()
+			}
+		}
+	}
+	return minTs, maxTs
 }

--- a/internal/datacoord/import_scheduler_test.go
+++ b/internal/datacoord/import_scheduler_test.go
@@ -184,7 +184,6 @@ func (s *ImportSchedulerSuite) TestProcessImport() {
 	// pending -> inProgress
 	const nodeID = 10
 	s.alloc.EXPECT().AllocN(mock.Anything).Return(100, 200, nil)
-	s.alloc.EXPECT().AllocTimestamp(mock.Anything).Return(300, nil)
 	s.cluster.EXPECT().QueryImport(mock.Anything, mock.Anything).Return(&datapb.QueryImportResponse{
 		Slots: 1,
 	}, nil)

--- a/internal/datacoord/import_scheduler_test.go
+++ b/internal/datacoord/import_scheduler_test.go
@@ -183,6 +183,7 @@ func (s *ImportSchedulerSuite) TestProcessImport() {
 
 	// pending -> inProgress
 	const nodeID = 10
+	s.alloc.EXPECT().AllocTimestamp(mock.Anything).Return(uint64(300), nil)
 	s.alloc.EXPECT().AllocN(mock.Anything).Return(100, 200, nil)
 	s.cluster.EXPECT().QueryImport(mock.Anything, mock.Anything).Return(&datapb.QueryImportResponse{
 		Slots: 1,

--- a/internal/datacoord/import_util.go
+++ b/internal/datacoord/import_util.go
@@ -29,7 +29,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
-	"github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/util/importutilv2"
@@ -212,15 +211,6 @@ func AllocImportSegment(ctx context.Context,
 		log.Error("failed to alloc id for import segment", zap.Error(err))
 		return nil, err
 	}
-	ts, err := alloc.AllocTimestamp(ctx)
-	if err != nil {
-		return nil, err
-	}
-	position := &msgpb.MsgPosition{
-		ChannelName: channelName,
-		MsgID:       nil,
-		Timestamp:   ts,
-	}
 
 	segmentInfo := &datapb.SegmentInfo{
 		ID:             id,
@@ -232,8 +222,6 @@ func AllocImportSegment(ctx context.Context,
 		MaxRowNum:      0,
 		Level:          level,
 		LastExpireTime: math.MaxUint64,
-		StartPosition:  position,
-		DmlPosition:    position,
 	}
 	segmentInfo.IsImporting = true
 	segment := NewSegmentInfo(segmentInfo)

--- a/internal/datacoord/import_util_test.go
+++ b/internal/datacoord/import_util_test.go
@@ -192,6 +192,7 @@ func TestImportUtil_AssembleRequest(t *testing.T) {
 	catalog.EXPECT().ListStatsTasks(mock.Anything).Return(nil, nil)
 
 	alloc := allocator.NewMockAllocator(t)
+	alloc.EXPECT().AllocTimestamp(mock.Anything).Return(rand.Uint64(), nil)
 	alloc.EXPECT().AllocN(mock.Anything).RunAndReturn(func(n int64) (int64, int64, error) {
 		id := rand.Int63()
 		return id, id + n, nil

--- a/internal/datacoord/import_util_test.go
+++ b/internal/datacoord/import_util_test.go
@@ -127,7 +127,6 @@ func TestImportUtil_NewImportTasks(t *testing.T) {
 		return id, id + n, nil
 	})
 	alloc.EXPECT().AllocID(mock.Anything).Return(rand.Int63(), nil)
-	alloc.EXPECT().AllocTimestamp(mock.Anything).Return(rand.Uint64(), nil)
 
 	catalog := mocks.NewDataCoordCatalog(t)
 	catalog.EXPECT().ListChannelCheckpoint(mock.Anything).Return(nil, nil)
@@ -197,8 +196,6 @@ func TestImportUtil_AssembleRequest(t *testing.T) {
 		id := rand.Int63()
 		return id, id + n, nil
 	})
-	alloc.EXPECT().AllocTimestamp(mock.Anything).Return(800, nil)
-
 	broker := broker.NewMockBroker(t)
 	broker.EXPECT().ShowCollectionIDs(mock.Anything).Return(nil, nil)
 	meta, err := newMeta(context.TODO(), catalog, nil, broker)

--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -1116,6 +1116,35 @@ func UpdateIsImporting(segmentID int64, isImporting bool) UpdateOperator {
 	}
 }
 
+// UpdateImportSegmentPosition updates the segment's StartPosition and DmlPosition
+// for import segments using actual timestamps from the imported data.
+// Unlike UpdateStartPosition/UpdateDmlPosition, this operator allows nil MsgID
+// since import segments don't have message queue positions.
+func UpdateImportSegmentPosition(segmentID int64, minTs, maxTs uint64) UpdateOperator {
+	return func(modPack *updateSegmentPack) bool {
+		segment := modPack.Get(segmentID)
+		if segment == nil {
+			log.Ctx(context.TODO()).Warn("meta update: update import segment position failed - segment not found",
+				zap.Int64("segmentID", segmentID))
+			return false
+		}
+		channelName := segment.GetInsertChannel()
+		// Use actual min timestamp for StartPosition
+		segment.StartPosition = &msgpb.MsgPosition{
+			ChannelName: channelName,
+			MsgID:       nil,
+			Timestamp:   minTs,
+		}
+		// Use actual max timestamp for DmlPosition
+		segment.DmlPosition = &msgpb.MsgPosition{
+			ChannelName: channelName,
+			MsgID:       nil,
+			Timestamp:   maxTs,
+		}
+		return true
+	}
+}
+
 // UpdateAsDroppedIfEmptyWhenFlushing updates segment state to Dropped if segment is empty and in Flushing state
 // It's used to make a empty flushing segment to be dropped directly.
 func UpdateAsDroppedIfEmptyWhenFlushing(segmentID int64) UpdateOperator {

--- a/internal/datacoord/segment_operator_test.go
+++ b/internal/datacoord/segment_operator_test.go
@@ -19,6 +19,7 @@ package datacoord
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
@@ -46,4 +47,70 @@ func (s *TestSegmentOperatorSuite) TestSetMaxRowCount() {
 
 func TestSegmentOperators(t *testing.T) {
 	suite.Run(t, new(TestSegmentOperatorSuite))
+}
+
+func TestUpdateImportSegmentPosition(t *testing.T) {
+	t.Run("segment not found", func(t *testing.T) {
+		// Create a meta with empty segments to properly test the "not found" case
+		segments := NewSegmentsInfo()
+		m := &meta{segments: segments}
+		modPack := &updateSegmentPack{
+			meta:     m,
+			segments: make(map[int64]*SegmentInfo),
+		}
+		op := UpdateImportSegmentPosition(100, 1000, 2000)
+		result := op(modPack)
+		assert.False(t, result)
+	})
+
+	t.Run("update position successfully", func(t *testing.T) {
+		segment := &SegmentInfo{
+			SegmentInfo: &datapb.SegmentInfo{
+				ID:            100,
+				InsertChannel: "test_channel",
+			},
+		}
+		modPack := &updateSegmentPack{
+			segments: map[int64]*SegmentInfo{
+				100: segment,
+			},
+		}
+		op := UpdateImportSegmentPosition(100, 1000, 2000)
+		result := op(modPack)
+		assert.True(t, result)
+
+		// Verify StartPosition
+		assert.NotNil(t, segment.GetStartPosition())
+		assert.Equal(t, "test_channel", segment.GetStartPosition().GetChannelName())
+		assert.Nil(t, segment.GetStartPosition().GetMsgID())
+		assert.Equal(t, uint64(1000), segment.GetStartPosition().GetTimestamp())
+
+		// Verify DmlPosition
+		assert.NotNil(t, segment.GetDmlPosition())
+		assert.Equal(t, "test_channel", segment.GetDmlPosition().GetChannelName())
+		assert.Nil(t, segment.GetDmlPosition().GetMsgID())
+		assert.Equal(t, uint64(2000), segment.GetDmlPosition().GetTimestamp())
+	})
+
+	t.Run("update position with zero timestamps", func(t *testing.T) {
+		segment := &SegmentInfo{
+			SegmentInfo: &datapb.SegmentInfo{
+				ID:            101,
+				InsertChannel: "channel_2",
+			},
+		}
+		modPack := &updateSegmentPack{
+			segments: map[int64]*SegmentInfo{
+				101: segment,
+			},
+		}
+		op := UpdateImportSegmentPosition(101, 0, 0)
+		result := op(modPack)
+		assert.True(t, result)
+
+		assert.NotNil(t, segment.GetStartPosition())
+		assert.Equal(t, uint64(0), segment.GetStartPosition().GetTimestamp())
+		assert.NotNil(t, segment.GetDmlPosition())
+		assert.Equal(t, uint64(0), segment.GetDmlPosition().GetTimestamp())
+	})
 }

--- a/internal/datanode/importv2/util.go
+++ b/internal/datanode/importv2/util.go
@@ -92,7 +92,6 @@ func NewSyncTask(ctx context.Context,
 		WithPartitionID(partitionID).
 		WithChannelName(vchannel).
 		WithSegmentID(segmentID).
-		WithTimeRange(ts, ts).
 		WithLevel(segmentLevel).
 		WithDataSource(metrics.BulkinsertDataSourceLabel).
 		WithBatchRows(int64(insertData.GetRowNum()))


### PR DESCRIPTION
This PR (cherry-pick from master cc18864):
1. Modifies the import mechanism to use actual timestamps from the imported data for segment positions instead of using the channel checkpoint.
2. Removes initial position setting in AllocImportSegment() - positions are now set when import completes with actual timestamps.
3. Removes WithTimeRange(ts, ts) from import SyncTask since timestamps will come from actual data.

issue: https://github.com/milvus-io/milvus/issues/47275

pr: https://github.com/milvus-io/milvus/pull/47276