### PR TITLE
enhance: [2.6] Disable storageVersion upgrade compaction by default

### DIFF
--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -5191,7 +5191,7 @@ During compaction, the size of segment # of rows is able to exceed segment max #
 	p.StorageVersionCompactionEnabled = ParamItem{
 		Key:          "dataCoord.compaction.storageVersion.enabled",
 		Version:      "2.6.9",
-		DefaultValue: "true",
+		DefaultValue: "false",
 		Doc:          "Enable storage version compaction",
 		Export:       false,
 	}


### PR DESCRIPTION
Cherry-pick from master
pr: #47382

Before query cluster minimal session version requirement merged, make the storage version upgrade compaction "off" by default for protection