### PR TITLE
enhance: allow c++ ut to write plain expr instead of text proto

### DIFF
--- a/internal/core/src/common/Schema.h
+++ b/internal/core/src/common/Schema.h
@@ -50,8 +50,19 @@ class Schema {
                   bool nullable = false) {
         auto field_id = FieldId(debug_id);
         debug_id++;
-        this->AddField(
-            FieldName(name), field_id, data_type, nullable, std::nullopt);
+        if (IsStringDataType(data_type)) {
+            // String types require max_length to be set for proper serialization
+            constexpr int64_t kDefaultMaxLength = 65535;
+            this->AddField(FieldName(name),
+                           field_id,
+                           data_type,
+                           kDefaultMaxLength,
+                           nullable,
+                           std::nullopt);
+        } else {
+            this->AddField(
+                FieldName(name), field_id, data_type, nullable, std::nullopt);
+        }
         return field_id;
     }
 
@@ -62,8 +73,22 @@ class Schema {
                                   bool nullable = true) {
         auto field_id = FieldId(debug_id);
         debug_id++;
-        this->AddField(
-            FieldName(name), field_id, data_type, nullable, std::move(value));
+        if (IsStringDataType(data_type)) {
+            // String types require max_length to be set for proper serialization
+            constexpr int64_t kDefaultMaxLength = 65535;
+            this->AddField(FieldName(name),
+                           field_id,
+                           data_type,
+                           kDefaultMaxLength,
+                           nullable,
+                           std::move(value));
+        } else {
+            this->AddField(FieldName(name),
+                           field_id,
+                           data_type,
+                           nullable,
+                           std::move(value));
+        }
         return field_id;
     }
 

--- a/internal/core/unittest/CMakeLists.txt
+++ b/internal/core/unittest/CMakeLists.txt
@@ -21,6 +21,12 @@ include_directories(
     ${MILVUS_STORAGE_INCLUDE_DIR}
 )
 
+# Plan parser shared library
+set(PLANPARSER_INCLUDE_DIR ${CMAKE_HOME_DIRECTORY}/output/include)
+set(PLANPARSER_LIB_DIR ${CMAKE_HOME_DIRECTORY}/output/lib)
+include_directories(${PLANPARSER_INCLUDE_DIR})
+link_directories(${PLANPARSER_LIB_DIR})
+
 add_definitions(-DMILVUS_TEST_SEGCORE_YAML_PATH="${CMAKE_CURRENT_SOURCE_DIR}/test_utils/test_segcore.yaml")
 
 # Collect test files from source directories using glob pattern
@@ -114,6 +120,13 @@ target_link_libraries(all_tests
         knowhere
         milvus-storage
         milvus-common
+        milvus-planparser-cpp
+        )
+
+# Add RPATH for plan parser library to find libmilvus-planparser.so at runtime
+set_target_properties(all_tests PROPERTIES
+        BUILD_RPATH "${PLANPARSER_LIB_DIR}"
+        INSTALL_RPATH "${PLANPARSER_LIB_DIR}"
         )
 
 install(TARGETS all_tests DESTINATION unittest)

--- a/internal/core/unittest/bench/CMakeLists.txt
+++ b/internal/core/unittest/bench/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(all_bench ${bench_srcs})
 target_link_libraries(all_bench
         milvus_core
         knowhere
+        milvus-planparser-cpp
         pthread
         )
 

--- a/internal/core/unittest/bench/bench_search.cpp
+++ b/internal/core/unittest/bench/bench_search.cpp
@@ -37,17 +37,14 @@ const auto schema = []() {
 }();
 
 const auto search_plan = [] {
-    const char* raw_plan = R"(vector_anns: <
-                                field_id: 100
-                                query_info: <
-                                  topk: 5
-                                  round_decimal: -1
-                                  metric_type: "L2"
-                                  search_params: "{\"nprobe\": 10}"
-                                >
-                                placeholder_tag: "$0"
-        >)";
-    auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
+    ScopedSchemaHandle handle(*schema);
+    auto plan_str = handle.ParseSearch("",         // no filter expression
+                                       "fakevec",  // vector field name
+                                       5,          // topk
+                                       "L2",       // metric type
+                                       "{\"nprobe\": 10}",  // search params
+                                       -1                   // round_decimal
+    );
     auto plan =
         CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     return plan;

--- a/internal/core/unittest/test_float16.cpp
+++ b/internal/core/unittest/test_float16.cpp
@@ -93,17 +93,14 @@ TEST(Float16, ExecWithoutPredicateFlat) {
     schema->AddDebugField("age", DataType::FLOAT);
     auto i64_fid = schema->AddDebugField("counter", DataType::INT64);
     schema->set_primary_field_id(i64_fid);
-    const char* raw_plan = R"(vector_anns: <
-                                    field_id: 100
-                                    query_info: <
-                                      topk: 5
-                                      round_decimal: 3
-                                      metric_type: "L2"
-                                      search_params: "{\"nprobe\": 10}"
-                                    >
-                                    placeholder_tag: "$0"
-        >)";
-    auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
+    ScopedSchemaHandle handle(*schema);
+    auto plan_str = handle.ParseSearch("",         // no predicate
+                                       "fakevec",  // vector field name
+                                       5,          // topk
+                                       "L2",       // metric_type
+                                       R"({"nprobe": 10})",  // search_params
+                                       3                     // round_decimal
+    );
     auto plan =
         CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     int64_t N = ROW_COUNT;
@@ -235,32 +232,6 @@ TEST(Float16, ExecWithPredicate) {
     schema->AddDebugField("age", DataType::FLOAT);
     auto i64_fid = schema->AddDebugField("counter", DataType::INT64);
     schema->set_primary_field_id(i64_fid);
-    const char* raw_plan = R"(vector_anns: <
-                                    field_id: 100
-                                    predicates: <
-                                      binary_range_expr: <
-                                        column_info: <
-                                          field_id: 101
-                                          data_type: Float
-                                        >
-                                        lower_inclusive: true,
-                                        upper_inclusive: false,
-                                        lower_value: <
-                                          float_val: -1
-                                        >
-                                        upper_value: <
-                                          float_val: 1
-                                        >
-                                      >
-                                    >
-                                    query_info: <
-                                      topk: 5
-                                      round_decimal: 3
-                                      metric_type: "L2"
-                                      search_params: "{\"nprobe\": 10}"
-                                    >
-                                    placeholder_tag: "$0"
-     >)";
     int64_t N = ROW_COUNT;
     auto dataset = DataGen(schema, N);
     auto segment = CreateGrowingSegment(schema, empty_index_meta);
@@ -271,7 +242,15 @@ TEST(Float16, ExecWithPredicate) {
                     dataset.timestamps_.data(),
                     dataset.raw_);
 
-    auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
+    ScopedSchemaHandle handle(*schema);
+    auto plan_str = handle.ParseSearch(
+        "age >= -1 and age < 1",  // predicate: lower_inclusive=true, upper_inclusive=false
+        "fakevec",                // vector field name
+        5,                        // topk
+        "L2",                     // metric_type
+        R"({"nprobe": 10})",  // search_params
+        3                     // round_decimal
+    );
     auto plan =
         CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     auto num_queries = 5;
@@ -331,17 +310,14 @@ TEST(BFloat16, ExecWithoutPredicateFlat) {
     schema->AddDebugField("age", DataType::FLOAT);
     auto i64_fid = schema->AddDebugField("counter", DataType::INT64);
     schema->set_primary_field_id(i64_fid);
-    const char* raw_plan = R"(vector_anns: <
-                                    field_id: 100
-                                    query_info: <
-                                      topk: 5
-                                      round_decimal: 3
-                                      metric_type: "L2"
-                                      search_params: "{\"nprobe\": 10}"
-                                    >
-                                    placeholder_tag: "$0"
-        >)";
-    auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
+    ScopedSchemaHandle handle(*schema);
+    auto plan_str = handle.ParseSearch("",         // no predicate
+                                       "fakevec",  // vector field name
+                                       5,          // topk
+                                       "L2",       // metric_type
+                                       R"({"nprobe": 10})",  // search_params
+                                       3                     // round_decimal
+    );
     auto plan =
         CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     int64_t N = ROW_COUNT;
@@ -473,32 +449,6 @@ TEST(BFloat16, ExecWithPredicate) {
     schema->AddDebugField("age", DataType::FLOAT);
     auto i64_fid = schema->AddDebugField("counter", DataType::INT64);
     schema->set_primary_field_id(i64_fid);
-    const char* raw_plan = R"(vector_anns: <
-                                    field_id: 100
-                                    predicates: <
-                                      binary_range_expr: <
-                                        column_info: <
-                                          field_id: 101
-                                          data_type: Float
-                                        >
-                                        lower_inclusive: true,
-                                        upper_inclusive: false,
-                                        lower_value: <
-                                          float_val: -1
-                                        >
-                                        upper_value: <
-                                          float_val: 1
-                                        >
-                                      >
-                                    >
-                                    query_info: <
-                                      topk: 5
-                                      round_decimal: 3
-                                      metric_type: "L2"
-                                      search_params: "{\"nprobe\": 10}"
-                                    >
-                                    placeholder_tag: "$0"
-     >)";
     int64_t N = ROW_COUNT;
     auto dataset = DataGen(schema, N);
     auto segment = CreateGrowingSegment(schema, empty_index_meta);
@@ -509,7 +459,15 @@ TEST(BFloat16, ExecWithPredicate) {
                     dataset.timestamps_.data(),
                     dataset.raw_);
 
-    auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
+    ScopedSchemaHandle handle(*schema);
+    auto plan_str = handle.ParseSearch(
+        "age >= -1 and age < 1",  // predicate: lower_inclusive=true, upper_inclusive=false
+        "fakevec",                // vector field name
+        5,                        // topk
+        "L2",                     // metric_type
+        R"({"nprobe": 10})",  // search_params
+        3                     // round_decimal
+    );
     auto plan =
         CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     auto num_queries = 5;

--- a/internal/core/unittest/test_iterative_filter.cpp
+++ b/internal/core/unittest/test_iterative_filter.cpp
@@ -87,37 +87,19 @@ TEST(IterativeFilter, SealedIndex) {
     int topK = 10;
     int group_size = 3;
 
-    // int8 binaryRange
+    ScopedSchemaHandle handle(*schema);
+
+    // int8 binaryRange: int8 >= -1 AND int8 < 100
     {
-        const char* raw_plan = R"(vector_anns: <
-                                        field_id: 100
-                                        predicates: <
-                                      binary_range_expr: <
-                                        column_info: <
-                                          field_id: 101
-                                          data_type: Int8
-                                        >
-                                        lower_inclusive: true,
-                                        upper_inclusive: false,
-                                        lower_value: <
-                                          int64_val: -1
-                                        >
-                                        upper_value: <
-                                          int64_val: 100
-                                        >
-                                        >
-                                      >
-                                        query_info: <
-                                          topk: 10
-                                          metric_type: "L2"
-                                          hints: "iterative_filter"
-                                          search_params: "{\"ef\": 50}"
-                                        >
-                                        placeholder_tag: "$0">)";
-        proto::plan::PlanNode plan_node;
-        auto ok =
-            google::protobuf::TextFormat::ParseFromString(raw_plan, &plan_node);
-        auto plan = CreateSearchPlanFromPlanNode(schema, plan_node);
+        auto plan_bytes = handle.ParseSearch("int8 >= -1 AND int8 < 100",
+                                             "fakevec",
+                                             10,
+                                             "L2",
+                                             "{\"ef\": 50}",
+                                             -1,
+                                             "iterative_filter");
+        auto plan = CreateSearchPlanByExpr(
+            schema, plan_bytes.data(), plan_bytes.size());
         auto num_queries = 1;
         auto seed = 1024;
         auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, seed);
@@ -126,64 +108,27 @@ TEST(IterativeFilter, SealedIndex) {
         auto search_result =
             segment->Search(plan.get(), ph_group.get(), MAX_TIMESTAMP);
 
-        const char* raw_plan2 = R"(vector_anns: <
-                                        field_id: 100
-                                        predicates: <
-                                      binary_range_expr: <
-                                        column_info: <
-                                          field_id: 101
-                                          data_type: Int8
-                                        >
-                                        lower_inclusive: true,
-                                        upper_inclusive: false,
-                                        lower_value: <
-                                          int64_val: -1
-                                        >
-                                        upper_value: <
-                                          int64_val: 100
-                                        >
-                                        >
-                                      >
-                                        query_info: <
-                                          topk: 10
-                                          metric_type: "L2"
-                                          search_params: "{\"ef\": 50}"
-                                        >
-                                        placeholder_tag: "$0">)";
-        proto::plan::PlanNode plan_node2;
-        auto ok2 = google::protobuf::TextFormat::ParseFromString(raw_plan2,
-                                                                 &plan_node2);
-        auto plan2 = CreateSearchPlanFromPlanNode(schema, plan_node2);
+        auto plan_bytes2 = handle.ParseSearch(
+            "int8 >= -1 AND int8 < 100", "fakevec", 10, "L2", "{\"ef\": 50}");
+        auto plan2 = CreateSearchPlanByExpr(
+            schema, plan_bytes2.data(), plan_bytes2.size());
         auto search_result2 =
             segment->Search(plan2.get(), ph_group.get(), MAX_TIMESTAMP);
         CheckFilterSearchResult(
             *search_result, *search_result2, topK, num_queries);
     }
 
-    // int16 Termexpr
+    // int16 Termexpr: int16 in [1, 2]
     {
-        const char* raw_plan = R"(vector_anns: <
-                                        field_id: 100
-                                        predicates: <
-                                       term_expr: <
-                                        column_info: <
-                                          field_id: 102
-                                          data_type: Int16
-                                        >
-                                        values:<int64_val:1> values:<int64_val:2 >
-                                        >
-                                      >
-                                        query_info: <
-                                          topk: 10
-                                          metric_type: "L2"
-                                          hints: "iterative_filter"
-                                          search_params: "{\"ef\": 50}"
-                                        >
-                                        placeholder_tag: "$0">)";
-        proto::plan::PlanNode plan_node;
-        auto ok =
-            google::protobuf::TextFormat::ParseFromString(raw_plan, &plan_node);
-        auto plan = CreateSearchPlanFromPlanNode(schema, plan_node);
+        auto plan_bytes = handle.ParseSearch("int16 in [1, 2]",
+                                             "fakevec",
+                                             10,
+                                             "L2",
+                                             "{\"ef\": 50}",
+                                             -1,
+                                             "iterative_filter");
+        auto plan = CreateSearchPlanByExpr(
+            schema, plan_bytes.data(), plan_bytes.size());
         auto num_queries = 1;
         auto seed = 1024;
         auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, seed);
@@ -192,27 +137,10 @@ TEST(IterativeFilter, SealedIndex) {
         auto search_result =
             segment->Search(plan.get(), ph_group.get(), MAX_TIMESTAMP);
 
-        const char* raw_plan2 = R"(vector_anns: <
-                                        field_id: 100
-                                        predicates: <
-                                       term_expr: <
-                                        column_info: <
-                                          field_id: 102
-                                          data_type: Int16
-                                        >
-                                        values:<int64_val:1> values:<int64_val:2 >
-                                        >
-                                      >
-                                        query_info: <
-                                          topk: 10
-                                          metric_type: "L2"
-                                          search_params: "{\"ef\": 50}"
-                                        >
-                                        placeholder_tag: "$0">)";
-        proto::plan::PlanNode plan_node2;
-        auto ok2 = google::protobuf::TextFormat::ParseFromString(raw_plan2,
-                                                                 &plan_node2);
-        auto plan2 = CreateSearchPlanFromPlanNode(schema, plan_node2);
+        auto plan_bytes2 = handle.ParseSearch(
+            "int16 in [1, 2]", "fakevec", 10, "L2", "{\"ef\": 50}");
+        auto plan2 = CreateSearchPlanByExpr(
+            schema, plan_bytes2.data(), plan_bytes2.size());
         auto search_result2 =
             segment->Search(plan2.get(), ph_group.get(), MAX_TIMESTAMP);
         CheckFilterSearchResult(
@@ -221,19 +149,10 @@ TEST(IterativeFilter, SealedIndex) {
 
     // no expr
     {
-        const char* raw_plan = R"(vector_anns: <
-                                        field_id: 100
-                                        query_info: <
-                                          topk: 10
-                                          metric_type: "L2"
-                                          hints: "iterative_filter"
-                                          search_params: "{\"ef\": 50}"
-                                        >
-                                        placeholder_tag: "$0">)";
-        proto::plan::PlanNode plan_node;
-        auto ok =
-            google::protobuf::TextFormat::ParseFromString(raw_plan, &plan_node);
-        auto plan = CreateSearchPlanFromPlanNode(schema, plan_node);
+        auto plan_bytes = handle.ParseSearch(
+            "", "fakevec", 10, "L2", "{\"ef\": 50}", -1, "iterative_filter");
+        auto plan = CreateSearchPlanByExpr(
+            schema, plan_bytes.data(), plan_bytes.size());
         auto num_queries = 1;
         auto seed = 1024;
         auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, seed);
@@ -242,18 +161,10 @@ TEST(IterativeFilter, SealedIndex) {
         auto search_result =
             segment->Search(plan.get(), ph_group.get(), MAX_TIMESTAMP);
 
-        const char* raw_plan2 = R"(vector_anns: <
-                                        field_id: 100
-                                        query_info: <
-                                          topk: 10
-                                          metric_type: "L2"
-                                          search_params: "{\"ef\": 50}"
-                                        >
-                                        placeholder_tag: "$0">)";
-        proto::plan::PlanNode plan_node2;
-        auto ok2 = google::protobuf::TextFormat::ParseFromString(raw_plan2,
-                                                                 &plan_node2);
-        auto plan2 = CreateSearchPlanFromPlanNode(schema, plan_node2);
+        auto plan_bytes2 =
+            handle.ParseSearch("", "fakevec", 10, "L2", "{\"ef\": 50}");
+        auto plan2 = CreateSearchPlanByExpr(
+            schema, plan_bytes2.data(), plan_bytes2.size());
         auto search_result2 =
             segment->Search(plan2.get(), ph_group.get(), MAX_TIMESTAMP);
         CheckFilterSearchResult(
@@ -285,37 +196,20 @@ TEST(IterativeFilter, SealedData) {
     auto segment = CreateSealedWithFieldDataLoaded(schema, raw_data);
 
     int topK = 10;
-    // int8 binaryRange
+
+    ScopedSchemaHandle handle(*schema);
+
+    // int8 binaryRange: int8 >= -1 AND int8 < 100
     {
-        const char* raw_plan = R"(vector_anns: <
-                                        field_id: 100
-                                        predicates: <
-                                      binary_range_expr: <
-                                        column_info: <
-                                          field_id: 101
-                                          data_type: Int8
-                                        >
-                                        lower_inclusive: true,
-                                        upper_inclusive: false,
-                                        lower_value: <
-                                          int64_val: -1
-                                        >
-                                        upper_value: <
-                                          int64_val: 100
-                                        >
-                                        >
-                                      >
-                                        query_info: <
-                                          topk: 10
-                                          metric_type: "L2"
-                                          hints: "iterative_filter"
-                                          search_params: "{\"ef\": 50}"
-                                        >
-                                        placeholder_tag: "$0">)";
-        proto::plan::PlanNode plan_node;
-        auto ok =
-            google::protobuf::TextFormat::ParseFromString(raw_plan, &plan_node);
-        auto plan = CreateSearchPlanFromPlanNode(schema, plan_node);
+        auto plan_bytes = handle.ParseSearch("int8 >= -1 AND int8 < 100",
+                                             "fakevec",
+                                             10,
+                                             "L2",
+                                             "{\"ef\": 50}",
+                                             -1,
+                                             "iterative_filter");
+        auto plan = CreateSearchPlanByExpr(
+            schema, plan_bytes.data(), plan_bytes.size());
         auto num_queries = 1;
         auto seed = 1024;
         auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, seed);
@@ -324,34 +218,10 @@ TEST(IterativeFilter, SealedData) {
         auto search_result =
             segment->Search(plan.get(), ph_group.get(), MAX_TIMESTAMP);
 
-        const char* raw_plan2 = R"(vector_anns: <
-                                        field_id: 100
-                                        predicates: <
-                                      binary_range_expr: <
-                                        column_info: <
-                                          field_id: 101
-                                          data_type: Int8
-                                        >
-                                        lower_inclusive: true,
-                                        upper_inclusive: false,
-                                        lower_value: <
-                                          int64_val: -1
-                                        >
-                                        upper_value: <
-                                          int64_val: 100
-                                        >
-                                        >
-                                      >
-                                        query_info: <
-                                          topk: 10
-                                          metric_type: "L2"
-                                          search_params: "{\"ef\": 50}"
-                                        >
-                                        placeholder_tag: "$0">)";
-        proto::plan::PlanNode plan_node2;
-        auto ok2 = google::protobuf::TextFormat::ParseFromString(raw_plan2,
-                                                                 &plan_node2);
-        auto plan2 = CreateSearchPlanFromPlanNode(schema, plan_node2);
+        auto plan_bytes2 = handle.ParseSearch(
+            "int8 >= -1 AND int8 < 100", "fakevec", 10, "L2", "{\"ef\": 50}");
+        auto plan2 = CreateSearchPlanByExpr(
+            schema, plan_bytes2.data(), plan_bytes2.size());
         auto search_result2 =
             segment->Search(plan2.get(), ph_group.get(), MAX_TIMESTAMP);
         CheckFilterSearchResult(
@@ -392,37 +262,20 @@ TEST(IterativeFilter, GrowingRawData) {
     }
 
     auto topK = 10;
-    // int8 binaryRange
+
+    ScopedSchemaHandle handle(*schema);
+
+    // int64 binaryRange: int64 >= -1 AND int64 < 1
     {
-        const char* raw_plan = R"(vector_anns: <
-                                        field_id: 102
-                                        predicates: <
-                                      binary_range_expr: <
-                                        column_info: <
-                                          field_id: 100
-                                          data_type: Int64
-                                        >
-                                        lower_inclusive: true,
-                                        upper_inclusive: false,
-                                        lower_value: <
-                                          int64_val: -1
-                                        >
-                                        upper_value: <
-                                          int64_val: 1
-                                        >
-                                        >
-                                      >
-                                        query_info: <
-                                          topk: 10
-                                          metric_type: "L2"
-                                          hints: "iterative_filter"
-                                          search_params: "{\"ef\": 50}"
-                                        >
-                                        placeholder_tag: "$0">)";
-        proto::plan::PlanNode plan_node;
-        auto ok =
-            google::protobuf::TextFormat::ParseFromString(raw_plan, &plan_node);
-        auto plan = CreateSearchPlanFromPlanNode(schema, plan_node);
+        auto plan_bytes = handle.ParseSearch("int64 >= -1 AND int64 < 1",
+                                             "embeddings",
+                                             10,
+                                             "L2",
+                                             "{\"ef\": 50}",
+                                             -1,
+                                             "iterative_filter");
+        auto plan = CreateSearchPlanByExpr(
+            schema, plan_bytes.data(), plan_bytes.size());
         auto num_queries = 1;
         auto seed = 1024;
         auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, seed);
@@ -431,34 +284,13 @@ TEST(IterativeFilter, GrowingRawData) {
         auto search_result = segment_growing_impl->Search(
             plan.get(), ph_group.get(), MAX_TIMESTAMP);
 
-        const char* raw_plan2 = R"(vector_anns: <
-                                        field_id: 102
-                                        predicates: <
-                                      binary_range_expr: <
-                                        column_info: <
-                                          field_id: 100
-                                          data_type: Int64
-                                        >
-                                        lower_inclusive: true,
-                                        upper_inclusive: false,
-                                        lower_value: <
-                                          int64_val: -1
-                                        >
-                                        upper_value: <
-                                          int64_val: 1
-                                        >
-                                        >
-                                      >
-                                        query_info: <
-                                          topk: 10
-                                          metric_type: "L2"
-                                          search_params: "{\"ef\": 50}"
-                                        >
-                                        placeholder_tag: "$0">)";
-        proto::plan::PlanNode plan_node2;
-        auto ok2 = google::protobuf::TextFormat::ParseFromString(raw_plan2,
-                                                                 &plan_node2);
-        auto plan2 = CreateSearchPlanFromPlanNode(schema, plan_node2);
+        auto plan_bytes2 = handle.ParseSearch("int64 >= -1 AND int64 < 1",
+                                              "embeddings",
+                                              10,
+                                              "L2",
+                                              "{\"ef\": 50}");
+        auto plan2 = CreateSearchPlanByExpr(
+            schema, plan_bytes2.data(), plan_bytes2.size());
         auto search_result2 = segment_growing_impl->Search(
             plan2.get(), ph_group.get(), MAX_TIMESTAMP);
         CheckFilterSearchResult(
@@ -513,36 +345,20 @@ TEST(IterativeFilter, GrowingIndex) {
     }
 
     auto topK = 10;
+
+    ScopedSchemaHandle handle(*schema);
+
+    // int64 binaryRange: int64 >= -1 AND int64 < 1
     {
-        const char* raw_plan = R"(vector_anns: <
-                                        field_id: 102
-                                        predicates: <
-                                      binary_range_expr: <
-                                        column_info: <
-                                          field_id: 100
-                                          data_type: Int64
-                                        >
-                                        lower_inclusive: true,
-                                        upper_inclusive: false,
-                                        lower_value: <
-                                          int64_val: -1
-                                        >
-                                        upper_value: <
-                                          int64_val: 1
-                                        >
-                                        >
-                                      >
-                                        query_info: <
-                                          topk: 10
-                                          metric_type: "L2"
-                                          hints: "iterative_filter"
-                                          search_params: "{\"nprobe\": 4}"
-                                        >
-                                        placeholder_tag: "$0">)";
-        proto::plan::PlanNode plan_node;
-        auto ok =
-            google::protobuf::TextFormat::ParseFromString(raw_plan, &plan_node);
-        auto plan = CreateSearchPlanFromPlanNode(schema, plan_node);
+        auto plan_bytes = handle.ParseSearch("int64 >= -1 AND int64 < 1",
+                                             "embeddings",
+                                             10,
+                                             "L2",
+                                             "{\"nprobe\": 4}",
+                                             -1,
+                                             "iterative_filter");
+        auto plan = CreateSearchPlanByExpr(
+            schema, plan_bytes.data(), plan_bytes.size());
         auto num_queries = 1;
         auto seed = 1024;
         auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, seed);
@@ -551,34 +367,13 @@ TEST(IterativeFilter, GrowingIndex) {
         auto search_result = segment_growing_impl->Search(
             plan.get(), ph_group.get(), MAX_TIMESTAMP);
 
-        const char* raw_plan2 = R"(vector_anns: <
-                                        field_id: 102
-                                        predicates: <
-                                      binary_range_expr: <
-                                        column_info: <
-                                          field_id: 100
-                                          data_type: Int64
-                                        >
-                                        lower_inclusive: true,
-                                        upper_inclusive: false,
-                                        lower_value: <
-                                          int64_val: -1
-                                        >
-                                        upper_value: <
-                                          int64_val: 1
-                                        >
-                                        >
-                                      >
-                                        query_info: <
-                                          topk: 10
-                                          metric_type: "L2"
-                                          search_params: "{\"nprobe\": 4}"
-                                        >
-                                        placeholder_tag: "$0">)";
-        proto::plan::PlanNode plan_node2;
-        auto ok2 = google::protobuf::TextFormat::ParseFromString(raw_plan2,
-                                                                 &plan_node2);
-        auto plan2 = CreateSearchPlanFromPlanNode(schema, plan_node2);
+        auto plan_bytes2 = handle.ParseSearch("int64 >= -1 AND int64 < 1",
+                                              "embeddings",
+                                              10,
+                                              "L2",
+                                              "{\"nprobe\": 4}");
+        auto plan2 = CreateSearchPlanByExpr(
+            schema, plan_bytes2.data(), plan_bytes2.size());
         auto search_result2 = segment_growing_impl->Search(
             plan2.get(), ph_group.get(), MAX_TIMESTAMP);
         CheckFilterSearchResult(

--- a/internal/core/unittest/test_sealed.cpp
+++ b/internal/core/unittest/test_sealed.cpp
@@ -9,7 +9,6 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
-#include <boost/format.hpp>
 #include <optional>
 #include <gtest/gtest.h>
 
@@ -55,17 +54,6 @@ TEST(Sealed, without_predicate) {
     auto i64_fid = schema->AddDebugField("counter", DataType::INT64);
     schema->set_primary_field_id(i64_fid);
 
-    const char* raw_plan = R"(vector_anns: <
-                                    field_id: 100
-                                    query_info: <
-                                      topk: 5
-                                      round_decimal: 3
-                                      metric_type: "L2"
-                                      search_params: "{\"nprobe\": 10}"
-                                    >
-                                    placeholder_tag: "$0"
-        >)";
-
     auto N = ROW_COUNT;
 
     auto dataset = DataGen(schema, N);
@@ -82,7 +70,9 @@ TEST(Sealed, without_predicate) {
                     dataset.timestamps_.data(),
                     dataset.raw_);
 
-    auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
+    ScopedSchemaHandle handle(*schema);
+    auto plan_str =
+        handle.ParseSearch("", "fakevec", 5, "L2", "{\"nprobe\": 10}", 3);
     auto plan =
         CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     auto num_queries = 5;
@@ -172,24 +162,15 @@ TEST(Sealed, without_search_ef_less_than_limit) {
     auto i64_fid = schema->AddDebugField("counter", DataType::INT64);
     schema->set_primary_field_id(i64_fid);
 
-    const char* raw_plan = R"(vector_anns: <
-                                    field_id: 100
-                                    query_info: <
-                                      topk: 100
-                                      round_decimal: 3
-                                      metric_type: "L2"
-                                      search_params: "{\"ef\": 10}"
-                                    >
-                                    placeholder_tag: "$0"
-        >)";
-
     auto N = ROW_COUNT;
 
     auto dataset = DataGen(schema, N);
     auto vec_col = dataset.get_col<float>(fake_id);
     auto query_ptr = vec_col.data() + BIAS * dim;
 
-    auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
+    ScopedSchemaHandle handle(*schema);
+    auto plan_str =
+        handle.ParseSearch("", "fakevec", 100, "L2", "{\"ef\": 10}", 3);
     auto plan =
         CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     auto num_queries = 5;
@@ -253,32 +234,6 @@ TEST(Sealed, with_predicate) {
         "fakevec", DataType::VECTOR_FLOAT, dim, metric_type);
     auto i64_fid = schema->AddDebugField("counter", DataType::INT64);
     schema->set_primary_field_id(i64_fid);
-    const char* raw_plan = R"(vector_anns: <
-                                field_id: 100
-                                predicates: <
-                                  binary_range_expr: <
-                                    column_info: <
-                                      field_id: 101
-                                      data_type: Int64
-                                    >
-                                    lower_inclusive: true,
-                                    upper_inclusive: false,
-                                    lower_value: <
-                                      int64_val: 1000
-                                    >
-                                    upper_value: <
-                                      int64_val: 1005
-                                    >
-                                  >
-                                >
-                                query_info: <
-                                  topk: 5
-                                  round_decimal: 6
-                                  metric_type: "L2"
-                                  search_params: "{\"nprobe\": 10}"
-                                >
-                                placeholder_tag: "$0"
-     >)";
 
     auto N = ROW_COUNT;
 
@@ -293,7 +248,14 @@ TEST(Sealed, with_predicate) {
                     dataset.timestamps_.data(),
                     dataset.raw_);
 
-    auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
+    ScopedSchemaHandle handle(*schema);
+    // counter >= 1000 AND counter < 1005
+    auto plan_str = handle.ParseSearch("counter >= 1000 && counter < 1005",
+                                       "fakevec",
+                                       5,
+                                       "L2",
+                                       "{\"nprobe\": 10}",
+                                       6);
     auto plan =
         CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     auto num_queries = 5;
@@ -369,39 +331,20 @@ TEST(Sealed, with_predicate_filter_all) {
         "fakevec", DataType::VECTOR_FLOAT, dim, metric_type);
     auto i64_fid = schema->AddDebugField("counter", DataType::INT64);
     schema->set_primary_field_id(i64_fid);
-    const char* raw_plan = R"(vector_anns: <
-                                field_id: 100
-                                predicates: <
-                                  binary_range_expr: <
-                                    column_info: <
-                                      field_id: 101
-                                      data_type: Int64
-                                    >
-                                    lower_inclusive: true,
-                                    upper_inclusive: false,
-                                    lower_value: <
-                                      int64_val: 4200
-                                    >
-                                    upper_value: <
-                                      int64_val: 4199
-                                    >
-                                  >
-                                >
-                                query_info: <
-                                  topk: 5
-                                  round_decimal: 6
-                                  metric_type: "L2"
-                                  search_params: "{\"nprobe\": 10}"
-                                >
-                                placeholder_tag: "$0"
-     >)";
 
     auto N = ROW_COUNT;
 
     auto dataset = DataGen(schema, N);
     auto vec_col = dataset.get_col<float>(fake_id);
     auto query_ptr = vec_col.data() + BIAS * dim;
-    auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
+    ScopedSchemaHandle handle(*schema);
+    // counter >= 4200 AND counter < 4199 (impossible range, filters all)
+    auto plan_str = handle.ParseSearch("counter >= 4200 && counter < 4199",
+                                       "fakevec",
+                                       5,
+                                       "L2",
+                                       "{\"nprobe\": 10}",
+                                       6);
     auto plan =
         CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     auto num_queries = 5;
@@ -531,34 +474,15 @@ TEST(Sealed, LoadFieldData) {
         N, dim, fakevec.data(), knowhere::IndexEnum::INDEX_FAISS_IVFFLAT);
     //
     auto segment = CreateSealedSegment(schema);
-    const char* raw_plan = R"(vector_anns: <
-                                    field_id: 100
-                                    predicates: <
-                                      binary_range_expr: <
-                                        column_info: <
-                                          field_id: 102
-                                          data_type: Double
-                                        >
-                                        lower_inclusive: true,
-                                        upper_inclusive: false,
-                                        lower_value: <
-                                          float_val: -1
-                                        >
-                                        upper_value: <
-                                          float_val: 1
-                                        >
-                                      >
-                                    >
-                                    query_info: <
-                                      topk: 5
-                                      round_decimal: 3
-                                      metric_type: "L2"
-                                      search_params: "{\"nprobe\": 10}"
-                                    >
-                                    placeholder_tag: "$0"
-     >)";
     Timestamp timestamp = 1000000;
-    auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
+    ScopedSchemaHandle handle(*schema);
+    // double >= -1 AND double < 1
+    auto plan_str = handle.ParseSearch("double >= -1 && double < 1",
+                                       "fakevec",
+                                       5,
+                                       "L2",
+                                       "{\"nprobe\": 10}",
+                                       3);
     auto plan =
         CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     auto num_queries = 5;
@@ -701,34 +625,15 @@ TEST(Sealed, ClearData) {
         N, dim, fakevec.data(), knowhere::IndexEnum::INDEX_FAISS_IVFFLAT);
 
     auto segment = CreateSealedSegment(schema);
-    const char* raw_plan = R"(vector_anns: <
-                                    field_id: 100
-                                    predicates: <
-                                      binary_range_expr: <
-                                        column_info: <
-                                          field_id: 102
-                                          data_type: Double
-                                        >
-                                        lower_inclusive: true,
-                                        upper_inclusive: false,
-                                        lower_value: <
-                                          float_val: -1
-                                        >
-                                        upper_value: <
-                                          float_val: 1
-                                        >
-                                      >
-                                    >
-                                    query_info: <
-                                      topk: 5
-                                      round_decimal: 3
-                                      metric_type: "L2"
-                                      search_params: "{\"nprobe\": 10}"
-                                    >
-                                    placeholder_tag: "$0"
-     >)";
     Timestamp timestamp = 1000000;
-    auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
+    ScopedSchemaHandle handle(*schema);
+    // double >= -1 AND double < 1
+    auto plan_str = handle.ParseSearch("double >= -1 && double < 1",
+                                       "fakevec",
+                                       5,
+                                       "L2",
+                                       "{\"nprobe\": 10}",
+                                       3);
     auto plan =
         CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     auto num_queries = 5;
@@ -807,34 +712,15 @@ TEST(Sealed, LoadFieldDataMmap) {
         N, dim, fakevec.data(), knowhere::IndexEnum::INDEX_FAISS_IVFFLAT);
 
     auto segment = CreateSealedSegment(schema);
-    const char* raw_plan = R"(vector_anns: <
-                                    field_id: 100
-                                    predicates: <
-                                      binary_range_expr: <
-                                        column_info: <
-                                          field_id: 102
-                                          data_type: Double
-                                        >
-                                        lower_inclusive: true,
-                                        upper_inclusive: false,
-                                        lower_value: <
-                                          float_val: -1
-                                        >
-                                        upper_value: <
-                                          float_val: 1
-                                        >
-                                      >
-                                    >
-                                    query_info: <
-                                      topk: 5
-                                      round_decimal: 3
-                                      metric_type: "L2"
-                                      search_params: "{\"nprobe\": 10}"
-                                    >
-                                    placeholder_tag: "$0"
-     >)";
     Timestamp timestamp = 1000000;
-    auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
+    ScopedSchemaHandle handle(*schema);
+    // double >= -1 AND double < 1
+    auto plan_str = handle.ParseSearch("double >= -1 && double < 1",
+                                       "fakevec",
+                                       5,
+                                       "L2",
+                                       "{\"nprobe\": 10}",
+                                       3);
     auto plan =
         CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     auto num_queries = 5;
@@ -919,34 +805,15 @@ TEST(Sealed, LoadScalarIndex) {
     auto indexing = GenVecIndexing(
         N, dim, fakevec.data(), knowhere::IndexEnum::INDEX_FAISS_IVFFLAT);
 
-    const char* raw_plan = R"(vector_anns: <
-                                    field_id: 100
-                                    predicates: <
-                                      binary_range_expr: <
-                                        column_info: <
-                                          field_id: 102
-                                          data_type: Double
-                                        >
-                                        lower_inclusive: true,
-                                        upper_inclusive: false,
-                                        lower_value: <
-                                          float_val: -1
-                                        >
-                                        upper_value: <
-                                          float_val: 1
-                                        >
-                                      >
-                                    >
-                                    query_info: <
-                                      topk: 5
-                                      round_decimal: 3
-                                      metric_type: "L2"
-                                      search_params: "{\"nprobe\": 10}"
-                                    >
-                                    placeholder_tag: "$0"
-     >)";
     Timestamp timestamp = 1000000;
-    auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
+    ScopedSchemaHandle handle(*schema);
+    // double >= -1 AND double < 1
+    auto plan_str = handle.ParseSearch("double >= -1 && double < 1",
+                                       "fakevec",
+                                       5,
+                                       "L2",
+                                       "{\"nprobe\": 10}",
+                                       3);
     auto plan =
         CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     auto num_queries = 5;
@@ -1026,34 +893,15 @@ TEST(Sealed, Delete) {
     auto fakevec = dataset.get_col<float>(fakevec_id);
 
     auto segment = CreateSealedSegment(schema);
-    const char* raw_plan = R"(vector_anns: <
-                                    field_id: 100
-                                    predicates: <
-                                      binary_range_expr: <
-                                        column_info: <
-                                          field_id: 102
-                                          data_type: Double
-                                        >
-                                        lower_inclusive: true,
-                                        upper_inclusive: false,
-                                        lower_value: <
-                                          float_val: -1
-                                        >
-                                        upper_value: <
-                                          float_val: 1
-                                        >
-                                      >
-                                    >
-                                    query_info: <
-                                      topk: 5
-                                      round_decimal: 3
-                                      metric_type: "L2"
-                                      search_params: "{\"nprobe\": 10}"
-                                    >
-                                    placeholder_tag: "$0"
-     >)";
     Timestamp timestamp = 1000000;
-    auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
+    ScopedSchemaHandle handle(*schema);
+    // double >= -1 AND double < 1
+    auto plan_str = handle.ParseSearch("double >= -1 && double < 1",
+                                       "fakevec",
+                                       5,
+                                       "L2",
+                                       "{\"nprobe\": 10}",
+                                       3);
     auto plan =
         CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     auto num_queries = 5;
@@ -1069,9 +917,9 @@ TEST(Sealed, Delete) {
     std::vector<idx_t> pks{1, 2, 3, 4, 5};
     auto ids = std::make_unique<IdArray>();
     ids->mutable_int_id()->mutable_data()->Add(pks.begin(), pks.end());
-    std::vector<Timestamp> timestamps{10, 10, 10, 10, 10};
+    std::vector<Timestamp> timestamps_del{10, 10, 10, 10, 10};
 
-    LoadDeletedRecordInfo info = {timestamps.data(), ids.get(), row_count};
+    LoadDeletedRecordInfo info = {timestamps_del.data(), ids.get(), row_count};
     segment->LoadDeletedRecord(info);
 
     BitsetType bitset(N, false);
@@ -1108,34 +956,15 @@ TEST(Sealed, OverlapDelete) {
     auto fakevec = dataset.get_col<float>(fakevec_id);
 
     auto segment = CreateSealedSegment(schema);
-    const char* raw_plan = R"(vector_anns: <
-                                    field_id: 100
-                                    predicates: <
-                                      binary_range_expr: <
-                                        column_info: <
-                                          field_id: 102
-                                          data_type: Double
-                                        >
-                                        lower_inclusive: true,
-                                        upper_inclusive: false,
-                                        lower_value: <
-                                          float_val: -1
-                                        >
-                                        upper_value: <
-                                          float_val: 1
-                                        >
-                                      >
-                                    >
-                                    query_info: <
-                                      topk: 5
-                                      round_decimal: 3
-                                      metric_type: "L2"
-                                      search_params: "{\"nprobe\": 10}"
-                                    >
-                                    placeholder_tag: "$0"
-     >)";
     Timestamp timestamp = 1000000;
-    auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
+    ScopedSchemaHandle handle(*schema);
+    // double >= -1 AND double < 1
+    auto plan_str = handle.ParseSearch("double >= -1 && double < 1",
+                                       "fakevec",
+                                       5,
+                                       "L2",
+                                       "{\"nprobe\": 10}",
+                                       3);
     auto plan =
         CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     auto num_queries = 5;
@@ -1151,9 +980,9 @@ TEST(Sealed, OverlapDelete) {
     std::vector<idx_t> pks{1, 2, 3, 4, 5};
     auto ids = std::make_unique<IdArray>();
     ids->mutable_int_id()->mutable_data()->Add(pks.begin(), pks.end());
-    std::vector<Timestamp> timestamps{10, 10, 10, 10, 10};
+    std::vector<Timestamp> timestamps_del{10, 10, 10, 10, 10};
 
-    LoadDeletedRecordInfo info = {timestamps.data(), ids.get(), row_count};
+    LoadDeletedRecordInfo info = {timestamps_del.data(), ids.get(), row_count};
     segment->LoadDeletedRecord(info);
     ASSERT_EQ(segment->get_deleted_count(), pks.size())
         << "deleted_count=" << segment->get_deleted_count()
@@ -1164,9 +993,9 @@ TEST(Sealed, OverlapDelete) {
     pks.insert(pks.end(), {6, 7, 8});
     auto new_ids = std::make_unique<IdArray>();
     new_ids->mutable_int_id()->mutable_data()->Add(pks.begin(), pks.end());
-    timestamps.insert(timestamps.end(), {11, 11, 11});
+    timestamps_del.insert(timestamps_del.end(), {11, 11, 11});
     LoadDeletedRecordInfo overlap_info = {
-        timestamps.data(), new_ids.get(), row_count};
+        timestamps_del.data(), new_ids.get(), row_count};
     segment->LoadDeletedRecord(overlap_info);
     // NOTE: need to change delete timestamp, so not to hit the cache
     ASSERT_EQ(segment->get_deleted_count(), pks.size())
@@ -1247,21 +1076,11 @@ TEST(Sealed, BF) {
     segment->LoadFieldData(load_info);
 
     auto topK = 1;
-    auto fmt = boost::format(R"(vector_anns: <
-                                            field_id: 100
-                                            query_info: <
-                                                topk: %1%
-                                                metric_type: "L2"
-                                                search_params: "{\"nprobe\": 10}"
-                                            >
-                                            placeholder_tag: "$0">
-                                            output_field_ids: 101)") %
-               topK;
-    auto serialized_expr_plan = fmt.str();
-    auto binary_plan =
-        translate_text_plan_to_binary_plan(serialized_expr_plan.data());
+    ScopedSchemaHandle handle(*schema);
+    auto plan_str =
+        handle.ParseSearch("", "fakevec", topK, "L2", "{\"nprobe\": 10}");
     auto plan =
-        CreateSearchPlanByExpr(schema, binary_plan.data(), binary_plan.size());
+        CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
 
     auto num_queries = 10;
     auto query = GenQueryVecs(num_queries, dim);
@@ -1310,21 +1129,11 @@ TEST(Sealed, BF_Overflow) {
     segment->LoadFieldData(vec_load_info);
 
     auto topK = 1;
-    auto fmt = boost::format(R"(vector_anns: <
-                                            field_id: 100
-                                            query_info: <
-                                                topk: %1%
-                                                metric_type: "L2"
-                                                search_params: "{\"nprobe\": 10}"
-                                            >
-                                            placeholder_tag: "$0">
-                                            output_field_ids: 101)") %
-               topK;
-    auto serialized_expr_plan = fmt.str();
-    auto binary_plan =
-        translate_text_plan_to_binary_plan(serialized_expr_plan.data());
+    ScopedSchemaHandle handle(*schema);
+    auto plan_str =
+        handle.ParseSearch("", "fakevec", topK, "L2", "{\"nprobe\": 10}");
     auto plan =
-        CreateSearchPlanByExpr(schema, binary_plan.data(), binary_plan.size());
+        CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
 
     auto num_queries = 10;
     auto query = GenQueryVecs(num_queries, dim);
@@ -1491,29 +1300,10 @@ TEST(Sealed, LoadArrayFieldData) {
     auto fakevec = dataset.get_col<float>(fakevec_id);
     auto segment = CreateSealedSegment(schema);
 
-    const char* raw_plan = R"(vector_anns:<
-            field_id:100
-            predicates:<
-                json_contains_expr:<
-                    column_info:<
-                        field_id:102
-                        data_type:Array
-                        element_type:Int64
-                    >
-                    elements:<int64_val:1 >
-                    op:Contains
-                    elements_same_type:true
-                >
-            >
-            query_info:<
-                topk: 5
-                round_decimal: 3
-                metric_type: "L2"
-                search_params: "{\"nprobe\": 10}"
-            > placeholder_tag:"$0"
-        >)";
-
-    auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
+    ScopedSchemaHandle handle(*schema);
+    // array contains 1
+    auto plan_str = handle.ParseSearch(
+        "array_contains(array, 1)", "fakevec", 5, "L2", "{\"nprobe\": 10}", 3);
     auto plan =
         CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     auto num_queries = 5;
@@ -1549,29 +1339,10 @@ TEST(Sealed, LoadArrayFieldDataWithMMap) {
     auto fakevec = dataset.get_col<float>(fakevec_id);
     auto segment = CreateSealedSegment(schema);
 
-    const char* raw_plan = R"(vector_anns:<
-            field_id:100
-            predicates:<
-                json_contains_expr:<
-                    column_info:<
-                        field_id:102
-                        data_type:Array
-                        element_type:Int64
-                    >
-                    elements:<int64_val:1 >
-                    op:Contains
-                    elements_same_type:true
-                >
-            >
-            query_info:<
-                topk: 5
-                round_decimal: 3
-                metric_type: "L2"
-                search_params: "{\"nprobe\": 10}"
-            > placeholder_tag:"$0"
-        >)";
-
-    auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
+    ScopedSchemaHandle handle(*schema);
+    // array contains 1
+    auto plan_str = handle.ParseSearch(
+        "array_contains(array, 1)", "fakevec", 5, "L2", "{\"nprobe\": 10}", 3);
     auto plan =
         CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     auto num_queries = 5;
@@ -2561,20 +2332,12 @@ TEST_P(SealedVectorArrayTest, SearchVectorArray) {
     // create sealed segment
     auto sealed_segment = CreateSealedWithFieldDataLoaded(schema, dataset);
 
+    ScopedSchemaHandle handle(*schema);
+
     // brute force search
     {
-        std::string raw_plan = fmt::format(R"(vector_anns: <
-                                    field_id: 101
-                                    query_info: <
-                                      topk: 5
-                                      round_decimal: 3
-                                      metric_type: "{}"
-                                      search_params: "{{\"nprobe\": 10}}"
-                                    >
-                                    placeholder_tag: "$0"
-        >)",
-                                           metric_type);
-        auto plan_str = translate_text_plan_to_binary_plan(raw_plan.c_str());
+        auto plan_str = handle.ParseSearch(
+            "", "array_vec", 5, metric_type, "{\"nprobe\": 10}", 3);
         auto plan =
             CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
 
@@ -2643,18 +2406,8 @@ TEST_P(SealedVectorArrayTest, SearchVectorArray) {
         sealed_segment->DropFieldData(array_vec);
         sealed_segment->LoadIndex(load_info);
 
-        std::string raw_plan = fmt::format(R"(vector_anns: <
-                                    field_id: 101
-                                    query_info: <
-                                      topk: 5
-                                      round_decimal: 3
-                                      metric_type: "{}"
-                                      search_params: "{{\"nprobe\": 10}}"
-                                    >
-                                    placeholder_tag: "$0"
-        >)",
-                                           metric_type);
-        auto plan_str = translate_text_plan_to_binary_plan(raw_plan.c_str());
+        auto plan_str = handle.ParseSearch(
+            "", "array_vec", 5, metric_type, "{\"nprobe\": 10}", 3);
         auto plan =
             CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
 

--- a/internal/core/unittest/test_search_group_by.cpp
+++ b/internal/core/unittest/test_search_group_by.cpp
@@ -69,24 +69,22 @@ TEST(GroupBY, SealedIndex) {
     int topK = 15;
     int group_size = 3;
 
+    // Create ScopedSchemaHandle for parsing expressions
+    ScopedSchemaHandle handle(*schema);
+
     //4. search group by int8
     {
-        const char* raw_plan = R"(vector_anns: <
-                                        field_id: 100
-                                        query_info: <
-                                          topk: 15
-                                          metric_type: "L2"
-                                          search_params: "{\"ef\": 10}"
-                                          group_by_field_id: 101
-                                          group_size: 3
-                                        >
-                                        placeholder_tag: "$0"
-
-         >)";
-        proto::plan::PlanNode plan_node;
-        auto ok =
-            google::protobuf::TextFormat::ParseFromString(raw_plan, &plan_node);
-        auto plan = CreateSearchPlanFromPlanNode(schema, plan_node);
+        auto plan_str =
+            handle.ParseGroupBySearch("",         // empty filter expression
+                                      "fakevec",  // vector field name
+                                      topK,       // topk
+                                      "L2",       // metric type
+                                      "{\"ef\": 10}",  // search params
+                                      int8_fid.get(),  // group_by_field_id
+                                      group_size       // group_size
+            );
+        auto plan =
+            CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
         auto num_queries = 1;
         auto seed = 1024;
         auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, seed);
@@ -123,23 +121,17 @@ TEST(GroupBY, SealedIndex) {
 
     //5. search group by int16
     {
-        const char* raw_plan = R"(vector_anns: <
-                                        field_id: 100
-                                        query_info: <
-                                          topk: 100
-                                          metric_type: "L2"
-                                          search_params: "{\"ef\": 10}"
-                                          group_by_field_id: 102
-                                          group_size: 3
-                                        >
-                                        placeholder_tag: "$0"
-
-         >)";
-
-        proto::plan::PlanNode plan_node;
-        auto ok =
-            google::protobuf::TextFormat::ParseFromString(raw_plan, &plan_node);
-        auto plan = CreateSearchPlanFromPlanNode(schema, plan_node);
+        auto plan_str =
+            handle.ParseGroupBySearch("",         // empty filter expression
+                                      "fakevec",  // vector field name
+                                      100,        // topk
+                                      "L2",       // metric type
+                                      "{\"ef\": 10}",   // search params
+                                      int16_fid.get(),  // group_by_field_id
+                                      group_size        // group_size
+            );
+        auto plan =
+            CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
         auto num_queries = 1;
         auto seed = 1024;
         auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, seed);
@@ -173,23 +165,17 @@ TEST(GroupBY, SealedIndex) {
     }
     //6. search group by int32
     {
-        const char* raw_plan = R"(vector_anns: <
-                                        field_id: 100
-                                        query_info: <
-                                          topk: 100
-                                          metric_type: "L2"
-                                          search_params: "{\"ef\": 10}"
-                                          group_by_field_id: 103
-                                          group_size: 3
-                                        >
-                                        placeholder_tag: "$0"
-
-         >)";
-
-        proto::plan::PlanNode plan_node;
-        auto ok =
-            google::protobuf::TextFormat::ParseFromString(raw_plan, &plan_node);
-        auto plan = CreateSearchPlanFromPlanNode(schema, plan_node);
+        auto plan_str =
+            handle.ParseGroupBySearch("",         // empty filter expression
+                                      "fakevec",  // vector field name
+                                      100,        // topk
+                                      "L2",       // metric type
+                                      "{\"ef\": 10}",   // search params
+                                      int32_fid.get(),  // group_by_field_id
+                                      group_size        // group_size
+            );
+        auto plan =
+            CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
         auto num_queries = 1;
         auto seed = 1024;
         auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, seed);
@@ -224,23 +210,17 @@ TEST(GroupBY, SealedIndex) {
 
     //7. search group by int64
     {
-        const char* raw_plan = R"(vector_anns: <
-                                        field_id: 100
-                                        query_info: <
-                                          topk: 100
-                                          metric_type: "L2"
-                                          search_params: "{\"ef\": 10}"
-                                          group_by_field_id: 104
-                                          group_size: 3
-                                        >
-                                        placeholder_tag: "$0"
-
-         >)";
-
-        proto::plan::PlanNode plan_node;
-        auto ok =
-            google::protobuf::TextFormat::ParseFromString(raw_plan, &plan_node);
-        auto plan = CreateSearchPlanFromPlanNode(schema, plan_node);
+        auto plan_str =
+            handle.ParseGroupBySearch("",         // empty filter expression
+                                      "fakevec",  // vector field name
+                                      100,        // topk
+                                      "L2",       // metric type
+                                      "{\"ef\": 10}",   // search params
+                                      int64_fid.get(),  // group_by_field_id
+                                      group_size        // group_size
+            );
+        auto plan =
+            CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
         auto num_queries = 1;
         auto seed = 1024;
         auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, seed);
@@ -274,23 +254,17 @@ TEST(GroupBY, SealedIndex) {
 
     //8. search group by string
     {
-        const char* raw_plan = R"(vector_anns: <
-                                        field_id: 100
-                                        query_info: <
-                                          topk: 100
-                                          metric_type: "L2"
-                                          search_params: "{\"ef\": 10}"
-                                          group_by_field_id: 105
-                                          group_size: 3
-                                        >
-                                        placeholder_tag: "$0"
-
-         >)";
-
-        proto::plan::PlanNode plan_node;
-        auto ok =
-            google::protobuf::TextFormat::ParseFromString(raw_plan, &plan_node);
-        auto plan = CreateSearchPlanFromPlanNode(schema, plan_node);
+        auto plan_str =
+            handle.ParseGroupBySearch("",         // empty filter expression
+                                      "fakevec",  // vector field name
+                                      100,        // topk
+                                      "L2",       // metric type
+                                      "{\"ef\": 10}",  // search params
+                                      str_fid.get(),   // group_by_field_id
+                                      group_size       // group_size
+            );
+        auto plan =
+            CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
         auto num_queries = 1;
         auto seed = 1024;
         auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, seed);
@@ -324,23 +298,17 @@ TEST(GroupBY, SealedIndex) {
 
     //9. search group by bool
     {
-        const char* raw_plan = R"(vector_anns: <
-                                        field_id: 100
-                                        query_info: <
-                                          topk: 100
-                                          metric_type: "L2"
-                                          search_params: "{\"ef\": 10}"
-                                          group_by_field_id: 106
-                                          group_size: 3
-                                        >
-                                        placeholder_tag: "$0"
-
-         >)";
-
-        proto::plan::PlanNode plan_node;
-        auto ok =
-            google::protobuf::TextFormat::ParseFromString(raw_plan, &plan_node);
-        auto plan = CreateSearchPlanFromPlanNode(schema, plan_node);
+        auto plan_str =
+            handle.ParseGroupBySearch("",         // empty filter expression
+                                      "fakevec",  // vector field name
+                                      100,        // topk
+                                      "L2",       // metric type
+                                      "{\"ef\": 10}",  // search params
+                                      bool_fid.get(),  // group_by_field_id
+                                      group_size       // group_size
+            );
+        auto plan =
+            CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
         auto num_queries = 1;
         auto seed = 1024;
         auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, seed);
@@ -375,23 +343,17 @@ TEST(GroupBY, SealedIndex) {
 
     //10. search group by timestamptz
     {
-        const char* raw_plan = R"(vector_anns: <
-                                        field_id: 100
-                                        query_info: <
-                                          topk: 100
-                                          metric_type: "L2"
-                                          search_params: "{\"ef\": 10}"
-                                          group_by_field_id: 107
-                                          group_size: 3
-                                        >
-                                        placeholder_tag: "$0"
-
-         >)";
-
-        proto::plan::PlanNode plan_node;
-        auto ok =
-            google::protobuf::TextFormat::ParseFromString(raw_plan, &plan_node);
-        auto plan = CreateSearchPlanFromPlanNode(schema, plan_node);
+        auto plan_str = handle.ParseGroupBySearch(
+            "",                     // empty filter expression
+            "fakevec",              // vector field name
+            100,                    // topk
+            "L2",                   // metric type
+            "{\"ef\": 10}",         // search params
+            timestamptz_fid.get(),  // group_by_field_id
+            group_size              // group_size
+        );
+        auto plan =
+            CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
         auto num_queries = 1;
         auto seed = 1024;
         auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, seed);
@@ -447,22 +409,24 @@ TEST(GroupBY, SealedData) {
 
     int topK = 10;
     int group_size = 5;
+
+    // Create ScopedSchemaHandle for parsing expressions
+    ScopedSchemaHandle handle(*schema);
+
     //3. search group by int8
     {
-        const char* raw_plan = R"(vector_anns: <
-                                        field_id: 100
-                                        query_info: <
-                                          topk: 10
-                                          metric_type: "L2"
-                                          search_params: "{\"ef\": 10}"
-                                          group_by_field_id: 101,
-                                          group_size: 5,
-                                          strict_group_size: true,
-                                        >
-                                        placeholder_tag: "$0"
-
-         >)";
-        auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
+        auto plan_str = handle.ParseGroupBySearch(
+            "",                                     // empty filter expression
+            "fakevec",                              // vector field name
+            topK,                                   // topk
+            "L2",                                   // metric type
+            "{\"ef\": 10}",                         // search params
+            int8_fid.get(),                         // group_by_field_id
+            group_size,                             // group_size
+            "",                                     // json_path (not used)
+            milvus::proto::schema::DataType::None,  // json_type (not used)
+            true                                    // strict_group_size
+        );
         auto plan =
             CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
         auto num_queries = 1;
@@ -571,9 +535,20 @@ TEST(GroupBY, Reduce) {
     auto slice_nqs = std::vector<int64_t>{num_queries / 2, num_queries / 2};
     auto slice_topKs = std::vector<int64_t>{topK / 2, topK};
 
-    // Lambda function to execute search and reduce with given raw plan
-    auto executeGroupBySearchAndReduce = [&](const char* raw_plan) {
-        auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
+    // Create ScopedSchemaHandle for parsing expressions
+    ScopedSchemaHandle handle(*schema);
+
+    // Lambda function to execute search and reduce with given group_by_field_id
+    auto executeGroupBySearchAndReduce = [&](int64_t group_by_field_id) {
+        auto plan_str =
+            handle.ParseGroupBySearch("",         // empty filter expression
+                                      "fakevec",  // vector field name
+                                      topK,       // topk
+                                      "L2",       // metric type
+                                      "{\"ef\": 10}",     // search params
+                                      group_by_field_id,  // group_by_field_id
+                                      group_size          // group_size
+            );
         auto plan =
             CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
         auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, seed);
@@ -611,89 +586,23 @@ TEST(GroupBY, Reduce) {
         DeletePlaceholderGroup(c_ph_group);
     };
 
-    // Execute the test with the original plan (INT64)
-    const char* raw_plan = R"(vector_anns: <
-                                        field_id: 100
-                                        query_info: <
-                                          topk: 10
-                                          metric_type: "L2"
-                                          search_params: "{\"ef\": 10}"
-                                          group_by_field_id: 101
-                                          group_size: 3
-                                        >
-                                        placeholder_tag: "$0"
-         >)";
-    executeGroupBySearchAndReduce(raw_plan);
+    // Execute the test with group by INT64 field
+    executeGroupBySearchAndReduce(int64_fid.get());
 
     // Test Case: Group by INT32 field
-    const char* raw_plan_int32 = R"(vector_anns: <
-                                        field_id: 100
-                                        query_info: <
-                                          topk: 10
-                                          metric_type: "L2"
-                                          search_params: "{\"ef\": 10}"
-                                          group_by_field_id: 102
-                                          group_size: 3
-                                        >
-                                        placeholder_tag: "$0"
-         >)";
-    executeGroupBySearchAndReduce(raw_plan_int32);
+    executeGroupBySearchAndReduce(int32_fid.get());
 
     // Test Case: Group by INT16 field
-    const char* raw_plan_int16 = R"(vector_anns: <
-                                        field_id: 100
-                                        query_info: <
-                                          topk: 10
-                                          metric_type: "L2"
-                                          search_params: "{\"ef\": 10}"
-                                          group_by_field_id: 103
-                                          group_size: 3
-                                        >
-                                        placeholder_tag: "$0"
-         >)";
-    executeGroupBySearchAndReduce(raw_plan_int16);
+    executeGroupBySearchAndReduce(int16_fid.get());
 
     // Test Case: Group by INT8 field
-    const char* raw_plan_int8 = R"(vector_anns: <
-                                        field_id: 100
-                                        query_info: <
-                                          topk: 10
-                                          metric_type: "L2"
-                                          search_params: "{\"ef\": 10}"
-                                          group_by_field_id: 104
-                                          group_size: 3
-                                        >
-                                        placeholder_tag: "$0"
-         >)";
-    executeGroupBySearchAndReduce(raw_plan_int8);
+    executeGroupBySearchAndReduce(int8_fid.get());
 
     // Test Case: Group by BOOL field
-    const char* raw_plan_bool = R"(vector_anns: <
-                                        field_id: 100
-                                        query_info: <
-                                          topk: 10
-                                          metric_type: "L2"
-                                          search_params: "{\"ef\": 10}"
-                                          group_by_field_id: 105
-                                          group_size: 3
-                                        >
-                                        placeholder_tag: "$0"
-         >)";
-    executeGroupBySearchAndReduce(raw_plan_bool);
+    executeGroupBySearchAndReduce(bool_fid.get());
 
     // Test Case: Group by VARCHAR field
-    const char* raw_plan_string = R"(vector_anns: <
-                                        field_id: 100
-                                        query_info: <
-                                          topk: 10
-                                          metric_type: "L2"
-                                          search_params: "{\"ef\": 10}"
-                                          group_by_field_id: 106
-                                          group_size: 3
-                                        >
-                                        placeholder_tag: "$0"
-         >)";
-    executeGroupBySearchAndReduce(raw_plan_string);
+    executeGroupBySearchAndReduce(string_fid.get());
 
     DeleteSegment(c_segment_1);
     DeleteSegment(c_segment_2);
@@ -739,19 +648,19 @@ TEST(GroupBY, GrowingRawData) {
     auto num_queries = 10;
     auto topK = 100;
     int group_size = 1;
-    const char* raw_plan = R"(vector_anns: <
-                                        field_id: 102
-                                        query_info: <
-                                          topk: 100
-                                          metric_type: "L2"
-                                          search_params: "{\"ef\": 10}"
-                                          group_by_field_id: 101
-                                          group_size: 1
-                                        >
-                                        placeholder_tag: "$0"
 
-         >)";
-    auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
+    // Create ScopedSchemaHandle for parsing expressions
+    ScopedSchemaHandle handle(*schema);
+
+    auto plan_str =
+        handle.ParseGroupBySearch("",              // empty filter expression
+                                  "embeddings",    // vector field name
+                                  topK,            // topk
+                                  "L2",            // metric type
+                                  "{\"ef\": 10}",  // search params
+                                  int32_field_id.get(),  // group_by_field_id
+                                  group_size             // group_size
+        );
     auto plan =
         CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, seed);
@@ -840,20 +749,22 @@ TEST(GroupBY, GrowingIndex) {
     auto num_queries = 10;
     auto topK = 100;
     int group_size = 3;
-    const char* raw_plan = R"(vector_anns: <
-                                        field_id: 102
-                                        query_info: <
-                                          topk: 100
-                                          metric_type: "L2"
-                                          search_params: "{\"ef\": 10}"
-                                          group_by_field_id: 101
-                                          group_size: 3
-                                          strict_group_size: true
-                                        >
-                                        placeholder_tag: "$0"
 
-         >)";
-    auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
+    // Create ScopedSchemaHandle for parsing expressions
+    ScopedSchemaHandle handle(*schema);
+
+    auto plan_str = handle.ParseGroupBySearch(
+        "",                                     // empty filter expression
+        "embeddings",                           // vector field name
+        topK,                                   // topk
+        "L2",                                   // metric type
+        "{\"ef\": 10}",                         // search params
+        int32_field_id.get(),                   // group_by_field_id
+        group_size,                             // group_size
+        "",                                     // json_path (not used)
+        milvus::proto::schema::DataType::None,  // json_type (not used)
+        true                                    // strict_group_size
+    );
     auto plan =
         CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, seed);

--- a/internal/parser/planparserv2/cwrapper/milvus_plan_parser.h
+++ b/internal/parser/planparserv2/cwrapper/milvus_plan_parser.h
@@ -60,7 +60,7 @@ public:
     static std::string UnregisterSchema(SchemaHandle handle);
 
     /**
-     * @brief Parse an expression string into a serialized PlanNode protobuf.
+     * @brief Parse an expression string into a serialized PlanNode protobuf (RetrievePlan).
      *
      * Thread-safe and lock-free. Multiple threads can call Parse() concurrently
      * with the same or different handles.
@@ -74,6 +74,27 @@ public:
      *   - parsing fails
      */
     static std::vector<uint8_t> Parse(SchemaHandle handle, const std::string& expr);
+
+    /**
+     * @brief Parse an expression string into a serialized SearchPlan PlanNode protobuf.
+     *
+     * Thread-safe and lock-free. Creates a VectorANNS plan node for search operations.
+     *
+     * @param handle The handle returned by RegisterSchema.
+     * @param expr The filter expression string to parse (can be empty).
+     * @param vector_field_name The name of the vector field to search.
+     * @param query_info_proto The serialized QueryInfo protobuf containing topk, metric_type, etc.
+     * @return std::vector<uint8_t> The serialized PlanNode protobuf.
+     * @throws std::runtime_error if:
+     *   - handle is invalid or not found
+     *   - schema was unregistered
+     *   - vector field not found
+     *   - parsing fails
+     */
+    static std::vector<uint8_t> ParseSearch(SchemaHandle handle,
+                                            const std::string& expr,
+                                            const std::string& vector_field_name,
+                                            const std::vector<uint8_t>& query_info_proto);
 };
 
 } // namespace planparserv2


### PR DESCRIPTION
issue: #44452

added the ability to create SearchPlan to plan parser so; updated all c++ ut to use plan parser so to create retrieve/search plan, instead of writting literal text protos
