### PR TITLE
enhance: [2.6] allow c++ ut to write plain expr instead of text proto

### DIFF
--- a/internal/core/src/common/Schema.h
+++ b/internal/core/src/common/Schema.h
@@ -50,8 +50,19 @@ class Schema {
                   bool nullable = false) {
         auto field_id = FieldId(debug_id);
         debug_id++;
-        this->AddField(
-            FieldName(name), field_id, data_type, nullable, std::nullopt);
+        if (IsStringDataType(data_type)) {
+            // String types require max_length to be set for proper serialization
+            constexpr int64_t kDefaultMaxLength = 65535;
+            this->AddField(FieldName(name),
+                           field_id,
+                           data_type,
+                           kDefaultMaxLength,
+                           nullable,
+                           std::nullopt);
+        } else {
+            this->AddField(
+                FieldName(name), field_id, data_type, nullable, std::nullopt);
+        }
         return field_id;
     }
 
@@ -62,8 +73,22 @@ class Schema {
                                   bool nullable = true) {
         auto field_id = FieldId(debug_id);
         debug_id++;
-        this->AddField(
-            FieldName(name), field_id, data_type, nullable, std::move(value));
+        if (IsStringDataType(data_type)) {
+            // String types require max_length to be set for proper serialization
+            constexpr int64_t kDefaultMaxLength = 65535;
+            this->AddField(FieldName(name),
+                           field_id,
+                           data_type,
+                           kDefaultMaxLength,
+                           nullable,
+                           std::move(value));
+        } else {
+            this->AddField(FieldName(name),
+                           field_id,
+                           data_type,
+                           nullable,
+                           std::move(value));
+        }
         return field_id;
     }
 

--- a/internal/core/unittest/CMakeLists.txt
+++ b/internal/core/unittest/CMakeLists.txt
@@ -21,6 +21,12 @@ include_directories(
     ${MILVUS_STORAGE_INCLUDE_DIR}
 )
 
+# Plan parser shared library
+set(PLANPARSER_INCLUDE_DIR ${CMAKE_HOME_DIRECTORY}/output/include)
+set(PLANPARSER_LIB_DIR ${CMAKE_HOME_DIRECTORY}/output/lib)
+include_directories(${PLANPARSER_INCLUDE_DIR})
+link_directories(${PLANPARSER_LIB_DIR})
+
 add_definitions(-DMILVUS_TEST_SEGCORE_YAML_PATH="${CMAKE_CURRENT_SOURCE_DIR}/test_utils/test_segcore.yaml")
 
 # Collect test files from source directories using glob pattern
@@ -110,6 +116,13 @@ target_link_libraries(all_tests
         knowhere
         milvus-storage
         milvus-common
+        milvus-planparser-cpp
+        )
+
+# Add RPATH for plan parser library to find libmilvus-planparser.so at runtime
+set_target_properties(all_tests PROPERTIES
+        BUILD_RPATH "${PLANPARSER_LIB_DIR}"
+        INSTALL_RPATH "${PLANPARSER_LIB_DIR}"
         )
 
 install(TARGETS all_tests DESTINATION unittest)

--- a/internal/core/unittest/bench/CMakeLists.txt
+++ b/internal/core/unittest/bench/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(all_bench ${bench_srcs})
 target_link_libraries(all_bench
         milvus_core
         knowhere
+        milvus-planparser-cpp
         pthread
         )
 

--- a/internal/core/unittest/bench/bench_search.cpp
+++ b/internal/core/unittest/bench/bench_search.cpp
@@ -37,17 +37,14 @@ const auto schema = []() {
 }();
 
 const auto search_plan = [] {
-    const char* raw_plan = R"(vector_anns: <
-                                field_id: 100
-                                query_info: <
-                                  topk: 5
-                                  round_decimal: -1
-                                  metric_type: "L2"
-                                  search_params: "{\"nprobe\": 10}"
-                                >
-                                placeholder_tag: "$0"
-        >)";
-    auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
+    ScopedSchemaHandle handle(*schema);
+    auto plan_str = handle.ParseSearch("",         // no filter expression
+                                       "fakevec",  // vector field name
+                                       5,          // topk
+                                       "L2",       // metric type
+                                       "{\"nprobe\": 10}",  // search params
+                                       -1                   // round_decimal
+    );
     auto plan =
         CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     return plan;

--- a/internal/core/unittest/test_float16.cpp
+++ b/internal/core/unittest/test_float16.cpp
@@ -93,17 +93,14 @@ TEST(Float16, ExecWithoutPredicateFlat) {
     schema->AddDebugField("age", DataType::FLOAT);
     auto i64_fid = schema->AddDebugField("counter", DataType::INT64);
     schema->set_primary_field_id(i64_fid);
-    const char* raw_plan = R"(vector_anns: <
-                                    field_id: 100
-                                    query_info: <
-                                      topk: 5
-                                      round_decimal: 3
-                                      metric_type: "L2"
-                                      search_params: "{\"nprobe\": 10}"
-                                    >
-                                    placeholder_tag: "$0"
-        >)";
-    auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
+    ScopedSchemaHandle handle(*schema);
+    auto plan_str = handle.ParseSearch("",         // no predicate
+                                       "fakevec",  // vector field name
+                                       5,          // topk
+                                       "L2",       // metric_type
+                                       R"({"nprobe": 10})",  // search_params
+                                       3                     // round_decimal
+    );
     auto plan =
         CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     int64_t N = ROW_COUNT;
@@ -235,32 +232,6 @@ TEST(Float16, ExecWithPredicate) {
     schema->AddDebugField("age", DataType::FLOAT);
     auto i64_fid = schema->AddDebugField("counter", DataType::INT64);
     schema->set_primary_field_id(i64_fid);
-    const char* raw_plan = R"(vector_anns: <
-                                    field_id: 100
-                                    predicates: <
-                                      binary_range_expr: <
-                                        column_info: <
-                                          field_id: 101
-                                          data_type: Float
-                                        >
-                                        lower_inclusive: true,
-                                        upper_inclusive: false,
-                                        lower_value: <
-                                          float_val: -1
-                                        >
-                                        upper_value: <
-                                          float_val: 1
-                                        >
-                                      >
-                                    >
-                                    query_info: <
-                                      topk: 5
-                                      round_decimal: 3
-                                      metric_type: "L2"
-                                      search_params: "{\"nprobe\": 10}"
-                                    >
-                                    placeholder_tag: "$0"
-     >)";
     int64_t N = ROW_COUNT;
     auto dataset = DataGen(schema, N);
     auto segment = CreateGrowingSegment(schema, empty_index_meta);
@@ -271,7 +242,15 @@ TEST(Float16, ExecWithPredicate) {
                     dataset.timestamps_.data(),
                     dataset.raw_);
 
-    auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
+    ScopedSchemaHandle handle(*schema);
+    auto plan_str = handle.ParseSearch(
+        "age >= -1 and age < 1",  // predicate: lower_inclusive=true, upper_inclusive=false
+        "fakevec",                // vector field name
+        5,                        // topk
+        "L2",                     // metric_type
+        R"({"nprobe": 10})",  // search_params
+        3                     // round_decimal
+    );
     auto plan =
         CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     auto num_queries = 5;
@@ -331,17 +310,14 @@ TEST(BFloat16, ExecWithoutPredicateFlat) {
     schema->AddDebugField("age", DataType::FLOAT);
     auto i64_fid = schema->AddDebugField("counter", DataType::INT64);
     schema->set_primary_field_id(i64_fid);
-    const char* raw_plan = R"(vector_anns: <
-                                    field_id: 100
-                                    query_info: <
-                                      topk: 5
-                                      round_decimal: 3
-                                      metric_type: "L2"
-                                      search_params: "{\"nprobe\": 10}"
-                                    >
-                                    placeholder_tag: "$0"
-        >)";
-    auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
+    ScopedSchemaHandle handle(*schema);
+    auto plan_str = handle.ParseSearch("",         // no predicate
+                                       "fakevec",  // vector field name
+                                       5,          // topk
+                                       "L2",       // metric_type
+                                       R"({"nprobe": 10})",  // search_params
+                                       3                     // round_decimal
+    );
     auto plan =
         CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     int64_t N = ROW_COUNT;
@@ -473,32 +449,6 @@ TEST(BFloat16, ExecWithPredicate) {
     schema->AddDebugField("age", DataType::FLOAT);
     auto i64_fid = schema->AddDebugField("counter", DataType::INT64);
     schema->set_primary_field_id(i64_fid);
-    const char* raw_plan = R"(vector_anns: <
-                                    field_id: 100
-                                    predicates: <
-                                      binary_range_expr: <
-                                        column_info: <
-                                          field_id: 101
-                                          data_type: Float
-                                        >
-                                        lower_inclusive: true,
-                                        upper_inclusive: false,
-                                        lower_value: <
-                                          float_val: -1
-                                        >
-                                        upper_value: <
-                                          float_val: 1
-                                        >
-                                      >
-                                    >
-                                    query_info: <
-                                      topk: 5
-                                      round_decimal: 3
-                                      metric_type: "L2"
-                                      search_params: "{\"nprobe\": 10}"
-                                    >
-                                    placeholder_tag: "$0"
-     >)";
     int64_t N = ROW_COUNT;
     auto dataset = DataGen(schema, N);
     auto segment = CreateGrowingSegment(schema, empty_index_meta);
@@ -509,7 +459,15 @@ TEST(BFloat16, ExecWithPredicate) {
                     dataset.timestamps_.data(),
                     dataset.raw_);
 
-    auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
+    ScopedSchemaHandle handle(*schema);
+    auto plan_str = handle.ParseSearch(
+        "age >= -1 and age < 1",  // predicate: lower_inclusive=true, upper_inclusive=false
+        "fakevec",                // vector field name
+        5,                        // topk
+        "L2",                     // metric_type
+        R"({"nprobe": 10})",  // search_params
+        3                     // round_decimal
+    );
     auto plan =
         CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     auto num_queries = 5;

--- a/internal/core/unittest/test_group_by.cpp
+++ b/internal/core/unittest/test_group_by.cpp
@@ -69,24 +69,22 @@ TEST(GroupBY, SealedIndex) {
     int topK = 15;
     int group_size = 3;
 
+    // Create ScopedSchemaHandle for parsing expressions
+    ScopedSchemaHandle handle(*schema);
+
     //4. search group by int8
     {
-        const char* raw_plan = R"(vector_anns: <
-                                        field_id: 100
-                                        query_info: <
-                                          topk: 15
-                                          metric_type: "L2"
-                                          search_params: "{\"ef\": 10}"
-                                          group_by_field_id: 101
-                                          group_size: 3
-                                        >
-                                        placeholder_tag: "$0"
-
-         >)";
-        proto::plan::PlanNode plan_node;
-        auto ok =
-            google::protobuf::TextFormat::ParseFromString(raw_plan, &plan_node);
-        auto plan = CreateSearchPlanFromPlanNode(schema, plan_node);
+        auto plan_str =
+            handle.ParseGroupBySearch("",         // empty filter expression
+                                      "fakevec",  // vector field name
+                                      topK,       // topk
+                                      "L2",       // metric type
+                                      "{\"ef\": 10}",  // search params
+                                      int8_fid.get(),  // group_by_field_id
+                                      group_size       // group_size
+            );
+        auto plan =
+            CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
         auto num_queries = 1;
         auto seed = 1024;
         auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, seed);
@@ -123,23 +121,17 @@ TEST(GroupBY, SealedIndex) {
 
     //5. search group by int16
     {
-        const char* raw_plan = R"(vector_anns: <
-                                        field_id: 100
-                                        query_info: <
-                                          topk: 100
-                                          metric_type: "L2"
-                                          search_params: "{\"ef\": 10}"
-                                          group_by_field_id: 102
-                                          group_size: 3
-                                        >
-                                        placeholder_tag: "$0"
-
-         >)";
-
-        proto::plan::PlanNode plan_node;
-        auto ok =
-            google::protobuf::TextFormat::ParseFromString(raw_plan, &plan_node);
-        auto plan = CreateSearchPlanFromPlanNode(schema, plan_node);
+        auto plan_str =
+            handle.ParseGroupBySearch("",         // empty filter expression
+                                      "fakevec",  // vector field name
+                                      100,        // topk
+                                      "L2",       // metric type
+                                      "{\"ef\": 10}",   // search params
+                                      int16_fid.get(),  // group_by_field_id
+                                      group_size        // group_size
+            );
+        auto plan =
+            CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
         auto num_queries = 1;
         auto seed = 1024;
         auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, seed);
@@ -173,23 +165,17 @@ TEST(GroupBY, SealedIndex) {
     }
     //6. search group by int32
     {
-        const char* raw_plan = R"(vector_anns: <
-                                        field_id: 100
-                                        query_info: <
-                                          topk: 100
-                                          metric_type: "L2"
-                                          search_params: "{\"ef\": 10}"
-                                          group_by_field_id: 103
-                                          group_size: 3
-                                        >
-                                        placeholder_tag: "$0"
-
-         >)";
-
-        proto::plan::PlanNode plan_node;
-        auto ok =
-            google::protobuf::TextFormat::ParseFromString(raw_plan, &plan_node);
-        auto plan = CreateSearchPlanFromPlanNode(schema, plan_node);
+        auto plan_str =
+            handle.ParseGroupBySearch("",         // empty filter expression
+                                      "fakevec",  // vector field name
+                                      100,        // topk
+                                      "L2",       // metric type
+                                      "{\"ef\": 10}",   // search params
+                                      int32_fid.get(),  // group_by_field_id
+                                      group_size        // group_size
+            );
+        auto plan =
+            CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
         auto num_queries = 1;
         auto seed = 1024;
         auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, seed);
@@ -224,23 +210,17 @@ TEST(GroupBY, SealedIndex) {
 
     //7. search group by int64
     {
-        const char* raw_plan = R"(vector_anns: <
-                                        field_id: 100
-                                        query_info: <
-                                          topk: 100
-                                          metric_type: "L2"
-                                          search_params: "{\"ef\": 10}"
-                                          group_by_field_id: 104
-                                          group_size: 3
-                                        >
-                                        placeholder_tag: "$0"
-
-         >)";
-
-        proto::plan::PlanNode plan_node;
-        auto ok =
-            google::protobuf::TextFormat::ParseFromString(raw_plan, &plan_node);
-        auto plan = CreateSearchPlanFromPlanNode(schema, plan_node);
+        auto plan_str =
+            handle.ParseGroupBySearch("",         // empty filter expression
+                                      "fakevec",  // vector field name
+                                      100,        // topk
+                                      "L2",       // metric type
+                                      "{\"ef\": 10}",   // search params
+                                      int64_fid.get(),  // group_by_field_id
+                                      group_size        // group_size
+            );
+        auto plan =
+            CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
         auto num_queries = 1;
         auto seed = 1024;
         auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, seed);
@@ -274,23 +254,17 @@ TEST(GroupBY, SealedIndex) {
 
     //8. search group by string
     {
-        const char* raw_plan = R"(vector_anns: <
-                                        field_id: 100
-                                        query_info: <
-                                          topk: 100
-                                          metric_type: "L2"
-                                          search_params: "{\"ef\": 10}"
-                                          group_by_field_id: 105
-                                          group_size: 3
-                                        >
-                                        placeholder_tag: "$0"
-
-         >)";
-
-        proto::plan::PlanNode plan_node;
-        auto ok =
-            google::protobuf::TextFormat::ParseFromString(raw_plan, &plan_node);
-        auto plan = CreateSearchPlanFromPlanNode(schema, plan_node);
+        auto plan_str =
+            handle.ParseGroupBySearch("",         // empty filter expression
+                                      "fakevec",  // vector field name
+                                      100,        // topk
+                                      "L2",       // metric type
+                                      "{\"ef\": 10}",  // search params
+                                      str_fid.get(),   // group_by_field_id
+                                      group_size       // group_size
+            );
+        auto plan =
+            CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
         auto num_queries = 1;
         auto seed = 1024;
         auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, seed);
@@ -324,23 +298,17 @@ TEST(GroupBY, SealedIndex) {
 
     //9. search group by bool
     {
-        const char* raw_plan = R"(vector_anns: <
-                                        field_id: 100
-                                        query_info: <
-                                          topk: 100
-                                          metric_type: "L2"
-                                          search_params: "{\"ef\": 10}"
-                                          group_by_field_id: 106
-                                          group_size: 3
-                                        >
-                                        placeholder_tag: "$0"
-
-         >)";
-
-        proto::plan::PlanNode plan_node;
-        auto ok =
-            google::protobuf::TextFormat::ParseFromString(raw_plan, &plan_node);
-        auto plan = CreateSearchPlanFromPlanNode(schema, plan_node);
+        auto plan_str =
+            handle.ParseGroupBySearch("",         // empty filter expression
+                                      "fakevec",  // vector field name
+                                      100,        // topk
+                                      "L2",       // metric type
+                                      "{\"ef\": 10}",  // search params
+                                      bool_fid.get(),  // group_by_field_id
+                                      group_size       // group_size
+            );
+        auto plan =
+            CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
         auto num_queries = 1;
         auto seed = 1024;
         auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, seed);
@@ -375,23 +343,17 @@ TEST(GroupBY, SealedIndex) {
 
     //10. search group by timestamptz
     {
-        const char* raw_plan = R"(vector_anns: <
-                                        field_id: 100
-                                        query_info: <
-                                          topk: 100
-                                          metric_type: "L2"
-                                          search_params: "{\"ef\": 10}"
-                                          group_by_field_id: 107
-                                          group_size: 3
-                                        >
-                                        placeholder_tag: "$0"
-
-         >)";
-
-        proto::plan::PlanNode plan_node;
-        auto ok =
-            google::protobuf::TextFormat::ParseFromString(raw_plan, &plan_node);
-        auto plan = CreateSearchPlanFromPlanNode(schema, plan_node);
+        auto plan_str = handle.ParseGroupBySearch(
+            "",                     // empty filter expression
+            "fakevec",              // vector field name
+            100,                    // topk
+            "L2",                   // metric type
+            "{\"ef\": 10}",         // search params
+            timestamptz_fid.get(),  // group_by_field_id
+            group_size              // group_size
+        );
+        auto plan =
+            CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
         auto num_queries = 1;
         auto seed = 1024;
         auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, seed);
@@ -447,22 +409,24 @@ TEST(GroupBY, SealedData) {
 
     int topK = 10;
     int group_size = 5;
+
+    // Create ScopedSchemaHandle for parsing expressions
+    ScopedSchemaHandle handle(*schema);
+
     //3. search group by int8
     {
-        const char* raw_plan = R"(vector_anns: <
-                                        field_id: 100
-                                        query_info: <
-                                          topk: 10
-                                          metric_type: "L2"
-                                          search_params: "{\"ef\": 10}"
-                                          group_by_field_id: 101,
-                                          group_size: 5,
-                                          strict_group_size: true,
-                                        >
-                                        placeholder_tag: "$0"
-
-         >)";
-        auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
+        auto plan_str = handle.ParseGroupBySearch(
+            "",                                     // empty filter expression
+            "fakevec",                              // vector field name
+            topK,                                   // topk
+            "L2",                                   // metric type
+            "{\"ef\": 10}",                         // search params
+            int8_fid.get(),                         // group_by_field_id
+            group_size,                             // group_size
+            "",                                     // json_path (not used)
+            milvus::proto::schema::DataType::None,  // json_type (not used)
+            true                                    // strict_group_size
+        );
         auto plan =
             CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
         auto num_queries = 1;
@@ -571,9 +535,20 @@ TEST(GroupBY, Reduce) {
     auto slice_nqs = std::vector<int64_t>{num_queries / 2, num_queries / 2};
     auto slice_topKs = std::vector<int64_t>{topK / 2, topK};
 
-    // Lambda function to execute search and reduce with given raw plan
-    auto executeGroupBySearchAndReduce = [&](const char* raw_plan) {
-        auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
+    // Create ScopedSchemaHandle for parsing expressions
+    ScopedSchemaHandle handle(*schema);
+
+    // Lambda function to execute search and reduce with given group_by_field_id
+    auto executeGroupBySearchAndReduce = [&](int64_t group_by_field_id) {
+        auto plan_str =
+            handle.ParseGroupBySearch("",         // empty filter expression
+                                      "fakevec",  // vector field name
+                                      topK,       // topk
+                                      "L2",       // metric type
+                                      "{\"ef\": 10}",     // search params
+                                      group_by_field_id,  // group_by_field_id
+                                      group_size          // group_size
+            );
         auto plan =
             CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
         auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, seed);
@@ -611,89 +586,23 @@ TEST(GroupBY, Reduce) {
         DeletePlaceholderGroup(c_ph_group);
     };
 
-    // Execute the test with the original plan (INT64)
-    const char* raw_plan = R"(vector_anns: <
-                                        field_id: 100
-                                        query_info: <
-                                          topk: 10
-                                          metric_type: "L2"
-                                          search_params: "{\"ef\": 10}"
-                                          group_by_field_id: 101
-                                          group_size: 3
-                                        >
-                                        placeholder_tag: "$0"
-         >)";
-    executeGroupBySearchAndReduce(raw_plan);
+    // Execute the test with group by INT64 field
+    executeGroupBySearchAndReduce(int64_fid.get());
 
     // Test Case: Group by INT32 field
-    const char* raw_plan_int32 = R"(vector_anns: <
-                                        field_id: 100
-                                        query_info: <
-                                          topk: 10
-                                          metric_type: "L2"
-                                          search_params: "{\"ef\": 10}"
-                                          group_by_field_id: 102
-                                          group_size: 3
-                                        >
-                                        placeholder_tag: "$0"
-         >)";
-    executeGroupBySearchAndReduce(raw_plan_int32);
+    executeGroupBySearchAndReduce(int32_fid.get());
 
     // Test Case: Group by INT16 field
-    const char* raw_plan_int16 = R"(vector_anns: <
-                                        field_id: 100
-                                        query_info: <
-                                          topk: 10
-                                          metric_type: "L2"
-                                          search_params: "{\"ef\": 10}"
-                                          group_by_field_id: 103
-                                          group_size: 3
-                                        >
-                                        placeholder_tag: "$0"
-         >)";
-    executeGroupBySearchAndReduce(raw_plan_int16);
+    executeGroupBySearchAndReduce(int16_fid.get());
 
     // Test Case: Group by INT8 field
-    const char* raw_plan_int8 = R"(vector_anns: <
-                                        field_id: 100
-                                        query_info: <
-                                          topk: 10
-                                          metric_type: "L2"
-                                          search_params: "{\"ef\": 10}"
-                                          group_by_field_id: 104
-                                          group_size: 3
-                                        >
-                                        placeholder_tag: "$0"
-         >)";
-    executeGroupBySearchAndReduce(raw_plan_int8);
+    executeGroupBySearchAndReduce(int8_fid.get());
 
     // Test Case: Group by BOOL field
-    const char* raw_plan_bool = R"(vector_anns: <
-                                        field_id: 100
-                                        query_info: <
-                                          topk: 10
-                                          metric_type: "L2"
-                                          search_params: "{\"ef\": 10}"
-                                          group_by_field_id: 105
-                                          group_size: 3
-                                        >
-                                        placeholder_tag: "$0"
-         >)";
-    executeGroupBySearchAndReduce(raw_plan_bool);
+    executeGroupBySearchAndReduce(bool_fid.get());
 
     // Test Case: Group by VARCHAR field
-    const char* raw_plan_string = R"(vector_anns: <
-                                        field_id: 100
-                                        query_info: <
-                                          topk: 10
-                                          metric_type: "L2"
-                                          search_params: "{\"ef\": 10}"
-                                          group_by_field_id: 106
-                                          group_size: 3
-                                        >
-                                        placeholder_tag: "$0"
-         >)";
-    executeGroupBySearchAndReduce(raw_plan_string);
+    executeGroupBySearchAndReduce(string_fid.get());
 
     DeleteSegment(c_segment_1);
     DeleteSegment(c_segment_2);
@@ -737,19 +646,19 @@ TEST(GroupBY, GrowingRawData) {
     auto num_queries = 10;
     auto topK = 100;
     int group_size = 1;
-    const char* raw_plan = R"(vector_anns: <
-                                        field_id: 102
-                                        query_info: <
-                                          topk: 100
-                                          metric_type: "L2"
-                                          search_params: "{\"ef\": 10}"
-                                          group_by_field_id: 101
-                                          group_size: 1
-                                        >
-                                        placeholder_tag: "$0"
 
-         >)";
-    auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
+    // Create ScopedSchemaHandle for parsing expressions
+    ScopedSchemaHandle handle(*schema);
+
+    auto plan_str =
+        handle.ParseGroupBySearch("",              // empty filter expression
+                                  "embeddings",    // vector field name
+                                  topK,            // topk
+                                  "L2",            // metric type
+                                  "{\"ef\": 10}",  // search params
+                                  int32_field_id.get(),  // group_by_field_id
+                                  group_size             // group_size
+        );
     auto plan =
         CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, seed);
@@ -836,20 +745,22 @@ TEST(GroupBY, GrowingIndex) {
     auto num_queries = 10;
     auto topK = 100;
     int group_size = 3;
-    const char* raw_plan = R"(vector_anns: <
-                                        field_id: 102
-                                        query_info: <
-                                          topk: 100
-                                          metric_type: "L2"
-                                          search_params: "{\"ef\": 10}"
-                                          group_by_field_id: 101
-                                          group_size: 3
-                                          strict_group_size: true
-                                        >
-                                        placeholder_tag: "$0"
 
-         >)";
-    auto plan_str = translate_text_plan_to_binary_plan(raw_plan);
+    // Create ScopedSchemaHandle for parsing expressions
+    ScopedSchemaHandle handle(*schema);
+
+    auto plan_str = handle.ParseGroupBySearch(
+        "",                                     // empty filter expression
+        "embeddings",                           // vector field name
+        topK,                                   // topk
+        "L2",                                   // metric type
+        "{\"ef\": 10}",                         // search params
+        int32_field_id.get(),                   // group_by_field_id
+        group_size,                             // group_size
+        "",                                     // json_path (not used)
+        milvus::proto::schema::DataType::None,  // json_type (not used)
+        true                                    // strict_group_size
+    );
     auto plan =
         CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
     auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, seed);

--- a/internal/core/unittest/test_iterative_filter.cpp
+++ b/internal/core/unittest/test_iterative_filter.cpp
@@ -87,37 +87,19 @@ TEST(IterativeFilter, SealedIndex) {
     int topK = 10;
     int group_size = 3;
 
-    // int8 binaryRange
+    ScopedSchemaHandle handle(*schema);
+
+    // int8 binaryRange: int8 >= -1 AND int8 < 100
     {
-        const char* raw_plan = R"(vector_anns: <
-                                        field_id: 100
-                                        predicates: <
-                                      binary_range_expr: <
-                                        column_info: <
-                                          field_id: 101
-                                          data_type: Int8
-                                        >
-                                        lower_inclusive: true,
-                                        upper_inclusive: false,
-                                        lower_value: <
-                                          int64_val: -1
-                                        >
-                                        upper_value: <
-                                          int64_val: 100
-                                        >
-                                        >
-                                      >
-                                        query_info: <
-                                          topk: 10
-                                          metric_type: "L2"
-                                          hints: "iterative_filter"
-                                          search_params: "{\"ef\": 50}"
-                                        >
-                                        placeholder_tag: "$0">)";
-        proto::plan::PlanNode plan_node;
-        auto ok =
-            google::protobuf::TextFormat::ParseFromString(raw_plan, &plan_node);
-        auto plan = CreateSearchPlanFromPlanNode(schema, plan_node);
+        auto plan_bytes = handle.ParseSearch("int8 >= -1 AND int8 < 100",
+                                             "fakevec",
+                                             10,
+                                             "L2",
+                                             "{\"ef\": 50}",
+                                             -1,
+                                             "iterative_filter");
+        auto plan = CreateSearchPlanByExpr(
+            schema, plan_bytes.data(), plan_bytes.size());
         auto num_queries = 1;
         auto seed = 1024;
         auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, seed);
@@ -126,64 +108,27 @@ TEST(IterativeFilter, SealedIndex) {
         auto search_result =
             segment->Search(plan.get(), ph_group.get(), MAX_TIMESTAMP);
 
-        const char* raw_plan2 = R"(vector_anns: <
-                                        field_id: 100
-                                        predicates: <
-                                      binary_range_expr: <
-                                        column_info: <
-                                          field_id: 101
-                                          data_type: Int8
-                                        >
-                                        lower_inclusive: true,
-                                        upper_inclusive: false,
-                                        lower_value: <
-                                          int64_val: -1
-                                        >
-                                        upper_value: <
-                                          int64_val: 100
-                                        >
-                                        >
-                                      >
-                                        query_info: <
-                                          topk: 10
-                                          metric_type: "L2"
-                                          search_params: "{\"ef\": 50}"
-                                        >
-                                        placeholder_tag: "$0">)";
-        proto::plan::PlanNode plan_node2;
-        auto ok2 = google::protobuf::TextFormat::ParseFromString(raw_plan2,
-                                                                 &plan_node2);
-        auto plan2 = CreateSearchPlanFromPlanNode(schema, plan_node2);
+        auto plan_bytes2 = handle.ParseSearch(
+            "int8 >= -1 AND int8 < 100", "fakevec", 10, "L2", "{\"ef\": 50}");
+        auto plan2 = CreateSearchPlanByExpr(
+            schema, plan_bytes2.data(), plan_bytes2.size());
         auto search_result2 =
             segment->Search(plan2.get(), ph_group.get(), MAX_TIMESTAMP);
         CheckFilterSearchResult(
             *search_result, *search_result2, topK, num_queries);
     }
 
-    // int16 Termexpr
+    // int16 Termexpr: int16 in [1, 2]
     {
-        const char* raw_plan = R"(vector_anns: <
-                                        field_id: 100
-                                        predicates: <
-                                       term_expr: <
-                                        column_info: <
-                                          field_id: 102
-                                          data_type: Int16
-                                        >
-                                        values:<int64_val:1> values:<int64_val:2 >
-                                        >
-                                      >
-                                        query_info: <
-                                          topk: 10
-                                          metric_type: "L2"
-                                          hints: "iterative_filter"
-                                          search_params: "{\"ef\": 50}"
-                                        >
-                                        placeholder_tag: "$0">)";
-        proto::plan::PlanNode plan_node;
-        auto ok =
-            google::protobuf::TextFormat::ParseFromString(raw_plan, &plan_node);
-        auto plan = CreateSearchPlanFromPlanNode(schema, plan_node);
+        auto plan_bytes = handle.ParseSearch("int16 in [1, 2]",
+                                             "fakevec",
+                                             10,
+                                             "L2",
+                                             "{\"ef\": 50}",
+                                             -1,
+                                             "iterative_filter");
+        auto plan = CreateSearchPlanByExpr(
+            schema, plan_bytes.data(), plan_bytes.size());
         auto num_queries = 1;
         auto seed = 1024;
         auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, seed);
@@ -192,27 +137,10 @@ TEST(IterativeFilter, SealedIndex) {
         auto search_result =
             segment->Search(plan.get(), ph_group.get(), MAX_TIMESTAMP);
 
-        const char* raw_plan2 = R"(vector_anns: <
-                                        field_id: 100
-                                        predicates: <
-                                       term_expr: <
-                                        column_info: <
-                                          field_id: 102
-                                          data_type: Int16
-                                        >
-                                        values:<int64_val:1> values:<int64_val:2 >
-                                        >
-                                      >
-                                        query_info: <
-                                          topk: 10
-                                          metric_type: "L2"
-                                          search_params: "{\"ef\": 50}"
-                                        >
-                                        placeholder_tag: "$0">)";
-        proto::plan::PlanNode plan_node2;
-        auto ok2 = google::protobuf::TextFormat::ParseFromString(raw_plan2,
-                                                                 &plan_node2);
-        auto plan2 = CreateSearchPlanFromPlanNode(schema, plan_node2);
+        auto plan_bytes2 = handle.ParseSearch(
+            "int16 in [1, 2]", "fakevec", 10, "L2", "{\"ef\": 50}");
+        auto plan2 = CreateSearchPlanByExpr(
+            schema, plan_bytes2.data(), plan_bytes2.size());
         auto search_result2 =
             segment->Search(plan2.get(), ph_group.get(), MAX_TIMESTAMP);
         CheckFilterSearchResult(
@@ -221,19 +149,10 @@ TEST(IterativeFilter, SealedIndex) {
 
     // no expr
     {
-        const char* raw_plan = R"(vector_anns: <
-                                        field_id: 100
-                                        query_info: <
-                                          topk: 10
-                                          metric_type: "L2"
-                                          hints: "iterative_filter"
-                                          search_params: "{\"ef\": 50}"
-                                        >
-                                        placeholder_tag: "$0">)";
-        proto::plan::PlanNode plan_node;
-        auto ok =
-            google::protobuf::TextFormat::ParseFromString(raw_plan, &plan_node);
-        auto plan = CreateSearchPlanFromPlanNode(schema, plan_node);
+        auto plan_bytes = handle.ParseSearch(
+            "", "fakevec", 10, "L2", "{\"ef\": 50}", -1, "iterative_filter");
+        auto plan = CreateSearchPlanByExpr(
+            schema, plan_bytes.data(), plan_bytes.size());
         auto num_queries = 1;
         auto seed = 1024;
         auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, seed);
@@ -242,18 +161,10 @@ TEST(IterativeFilter, SealedIndex) {
         auto search_result =
             segment->Search(plan.get(), ph_group.get(), MAX_TIMESTAMP);
 
-        const char* raw_plan2 = R"(vector_anns: <
-                                        field_id: 100
-                                        query_info: <
-                                          topk: 10
-                                          metric_type: "L2"
-                                          search_params: "{\"ef\": 50}"
-                                        >
-                                        placeholder_tag: "$0">)";
-        proto::plan::PlanNode plan_node2;
-        auto ok2 = google::protobuf::TextFormat::ParseFromString(raw_plan2,
-                                                                 &plan_node2);
-        auto plan2 = CreateSearchPlanFromPlanNode(schema, plan_node2);
+        auto plan_bytes2 =
+            handle.ParseSearch("", "fakevec", 10, "L2", "{\"ef\": 50}");
+        auto plan2 = CreateSearchPlanByExpr(
+            schema, plan_bytes2.data(), plan_bytes2.size());
         auto search_result2 =
             segment->Search(plan2.get(), ph_group.get(), MAX_TIMESTAMP);
         CheckFilterSearchResult(
@@ -285,37 +196,20 @@ TEST(IterativeFilter, SealedData) {
     auto segment = CreateSealedWithFieldDataLoaded(schema, raw_data);
 
     int topK = 10;
-    // int8 binaryRange
+
+    ScopedSchemaHandle handle(*schema);
+
+    // int8 binaryRange: int8 >= -1 AND int8 < 100
     {
-        const char* raw_plan = R"(vector_anns: <
-                                        field_id: 100
-                                        predicates: <
-                                      binary_range_expr: <
-                                        column_info: <
-                                          field_id: 101
-                                          data_type: Int8
-                                        >
-                                        lower_inclusive: true,
-                                        upper_inclusive: false,
-                                        lower_value: <
-                                          int64_val: -1
-                                        >
-                                        upper_value: <
-                                          int64_val: 100
-                                        >
-                                        >
-                                      >
-                                        query_info: <
-                                          topk: 10
-                                          metric_type: "L2"
-                                          hints: "iterative_filter"
-                                          search_params: "{\"ef\": 50}"
-                                        >
-                                        placeholder_tag: "$0">)";
-        proto::plan::PlanNode plan_node;
-        auto ok =
-            google::protobuf::TextFormat::ParseFromString(raw_plan, &plan_node);
-        auto plan = CreateSearchPlanFromPlanNode(schema, plan_node);
+        auto plan_bytes = handle.ParseSearch("int8 >= -1 AND int8 < 100",
+                                             "fakevec",
+                                             10,
+                                             "L2",
+                                             "{\"ef\": 50}",
+                                             -1,
+                                             "iterative_filter");
+        auto plan = CreateSearchPlanByExpr(
+            schema, plan_bytes.data(), plan_bytes.size());
         auto num_queries = 1;
         auto seed = 1024;
         auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, seed);
@@ -324,34 +218,10 @@ TEST(IterativeFilter, SealedData) {
         auto search_result =
             segment->Search(plan.get(), ph_group.get(), MAX_TIMESTAMP);
 
-        const char* raw_plan2 = R"(vector_anns: <
-                                        field_id: 100
-                                        predicates: <
-                                      binary_range_expr: <
-                                        column_info: <
-                                          field_id: 101
-                                          data_type: Int8
-                                        >
-                                        lower_inclusive: true,
-                                        upper_inclusive: false,
-                                        lower_value: <
-                                          int64_val: -1
-                                        >
-                                        upper_value: <
-                                          int64_val: 100
-                                        >
-                                        >
-                                      >
-                                        query_info: <
-                                          topk: 10
-                                          metric_type: "L2"
-                                          search_params: "{\"ef\": 50}"
-                                        >
-                                        placeholder_tag: "$0">)";
-        proto::plan::PlanNode plan_node2;
-        auto ok2 = google::protobuf::TextFormat::ParseFromString(raw_plan2,
-                                                                 &plan_node2);
-        auto plan2 = CreateSearchPlanFromPlanNode(schema, plan_node2);
+        auto plan_bytes2 = handle.ParseSearch(
+            "int8 >= -1 AND int8 < 100", "fakevec", 10, "L2", "{\"ef\": 50}");
+        auto plan2 = CreateSearchPlanByExpr(
+            schema, plan_bytes2.data(), plan_bytes2.size());
         auto search_result2 =
             segment->Search(plan2.get(), ph_group.get(), MAX_TIMESTAMP);
         CheckFilterSearchResult(
@@ -392,37 +262,20 @@ TEST(IterativeFilter, GrowingRawData) {
     }
 
     auto topK = 10;
-    // int8 binaryRange
+
+    ScopedSchemaHandle handle(*schema);
+
+    // int64 binaryRange: int64 >= -1 AND int64 < 1
     {
-        const char* raw_plan = R"(vector_anns: <
-                                        field_id: 102
-                                        predicates: <
-                                      binary_range_expr: <
-                                        column_info: <
-                                          field_id: 100
-                                          data_type: Int64
-                                        >
-                                        lower_inclusive: true,
-                                        upper_inclusive: false,
-                                        lower_value: <
-                                          int64_val: -1
-                                        >
-                                        upper_value: <
-                                          int64_val: 1
-                                        >
-                                        >
-                                      >
-                                        query_info: <
-                                          topk: 10
-                                          metric_type: "L2"
-                                          hints: "iterative_filter"
-                                          search_params: "{\"ef\": 50}"
-                                        >
-                                        placeholder_tag: "$0">)";
-        proto::plan::PlanNode plan_node;
-        auto ok =
-            google::protobuf::TextFormat::ParseFromString(raw_plan, &plan_node);
-        auto plan = CreateSearchPlanFromPlanNode(schema, plan_node);
+        auto plan_bytes = handle.ParseSearch("int64 >= -1 AND int64 < 1",
+                                             "embeddings",
+                                             10,
+                                             "L2",
+                                             "{\"ef\": 50}",
+                                             -1,
+                                             "iterative_filter");
+        auto plan = CreateSearchPlanByExpr(
+            schema, plan_bytes.data(), plan_bytes.size());
         auto num_queries = 1;
         auto seed = 1024;
         auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, seed);
@@ -431,34 +284,13 @@ TEST(IterativeFilter, GrowingRawData) {
         auto search_result = segment_growing_impl->Search(
             plan.get(), ph_group.get(), MAX_TIMESTAMP);
 
-        const char* raw_plan2 = R"(vector_anns: <
-                                        field_id: 102
-                                        predicates: <
-                                      binary_range_expr: <
-                                        column_info: <
-                                          field_id: 100
-                                          data_type: Int64
-                                        >
-                                        lower_inclusive: true,
-                                        upper_inclusive: false,
-                                        lower_value: <
-                                          int64_val: -1
-                                        >
-                                        upper_value: <
-                                          int64_val: 1
-                                        >
-                                        >
-                                      >
-                                        query_info: <
-                                          topk: 10
-                                          metric_type: "L2"
-                                          search_params: "{\"ef\": 50}"
-                                        >
-                                        placeholder_tag: "$0">)";
-        proto::plan::PlanNode plan_node2;
-        auto ok2 = google::protobuf::TextFormat::ParseFromString(raw_plan2,
-                                                                 &plan_node2);
-        auto plan2 = CreateSearchPlanFromPlanNode(schema, plan_node2);
+        auto plan_bytes2 = handle.ParseSearch("int64 >= -1 AND int64 < 1",
+                                              "embeddings",
+                                              10,
+                                              "L2",
+                                              "{\"ef\": 50}");
+        auto plan2 = CreateSearchPlanByExpr(
+            schema, plan_bytes2.data(), plan_bytes2.size());
         auto search_result2 = segment_growing_impl->Search(
             plan2.get(), ph_group.get(), MAX_TIMESTAMP);
         CheckFilterSearchResult(
@@ -513,36 +345,20 @@ TEST(IterativeFilter, GrowingIndex) {
     }
 
     auto topK = 10;
+
+    ScopedSchemaHandle handle(*schema);
+
+    // int64 binaryRange: int64 >= -1 AND int64 < 1
     {
-        const char* raw_plan = R"(vector_anns: <
-                                        field_id: 102
-                                        predicates: <
-                                      binary_range_expr: <
-                                        column_info: <
-                                          field_id: 100
-                                          data_type: Int64
-                                        >
-                                        lower_inclusive: true,
-                                        upper_inclusive: false,
-                                        lower_value: <
-                                          int64_val: -1
-                                        >
-                                        upper_value: <
-                                          int64_val: 1
-                                        >
-                                        >
-                                      >
-                                        query_info: <
-                                          topk: 10
-                                          metric_type: "L2"
-                                          hints: "iterative_filter"
-                                          search_params: "{\"nprobe\": 4}"
-                                        >
-                                        placeholder_tag: "$0">)";
-        proto::plan::PlanNode plan_node;
-        auto ok =
-            google::protobuf::TextFormat::ParseFromString(raw_plan, &plan_node);
-        auto plan = CreateSearchPlanFromPlanNode(schema, plan_node);
+        auto plan_bytes = handle.ParseSearch("int64 >= -1 AND int64 < 1",
+                                             "embeddings",
+                                             10,
+                                             "L2",
+                                             "{\"nprobe\": 4}",
+                                             -1,
+                                             "iterative_filter");
+        auto plan = CreateSearchPlanByExpr(
+            schema, plan_bytes.data(), plan_bytes.size());
         auto num_queries = 1;
         auto seed = 1024;
         auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, seed);
@@ -551,34 +367,13 @@ TEST(IterativeFilter, GrowingIndex) {
         auto search_result = segment_growing_impl->Search(
             plan.get(), ph_group.get(), MAX_TIMESTAMP);
 
-        const char* raw_plan2 = R"(vector_anns: <
-                                        field_id: 102
-                                        predicates: <
-                                      binary_range_expr: <
-                                        column_info: <
-                                          field_id: 100
-                                          data_type: Int64
-                                        >
-                                        lower_inclusive: true,
-                                        upper_inclusive: false,
-                                        lower_value: <
-                                          int64_val: -1
-                                        >
-                                        upper_value: <
-                                          int64_val: 1
-                                        >
-                                        >
-                                      >
-                                        query_info: <
-                                          topk: 10
-                                          metric_type: "L2"
-                                          search_params: "{\"nprobe\": 4}"
-                                        >
-                                        placeholder_tag: "$0">)";
-        proto::plan::PlanNode plan_node2;
-        auto ok2 = google::protobuf::TextFormat::ParseFromString(raw_plan2,
-                                                                 &plan_node2);
-        auto plan2 = CreateSearchPlanFromPlanNode(schema, plan_node2);
+        auto plan_bytes2 = handle.ParseSearch("int64 >= -1 AND int64 < 1",
+                                              "embeddings",
+                                              10,
+                                              "L2",
+                                              "{\"nprobe\": 4}");
+        auto plan2 = CreateSearchPlanByExpr(
+            schema, plan_bytes2.data(), plan_bytes2.size());
         auto search_result2 = segment_growing_impl->Search(
             plan2.get(), ph_group.get(), MAX_TIMESTAMP);
         CheckFilterSearchResult(

--- a/internal/core/unittest/test_utils/DataGen.h
+++ b/internal/core/unittest/test_utils/DataGen.h
@@ -43,6 +43,8 @@
 #include "segcore/ChunkedSegmentSealedImpl.h"
 #include "storage/Util.h"
 #include "milvus-storage/common/constants.h"
+#include "milvus_plan_parser.h"
+#include "pb/plan.pb.h"
 
 using boost::algorithm::starts_with;
 
@@ -1650,6 +1652,178 @@ replace_metric_and_translate_text_plan_to_binary_plan(
     }
     return translate_text_plan_to_binary_plan(plan.c_str());
 }
+
+// Parse a string expression using the plan parser shared library.
+// This function takes a schema and expression string and returns the binary plan.
+// The schema is serialized to protobuf and registered with the plan parser,
+// then the expression is parsed and the schema is unregistered.
+inline std::vector<char>
+parse_expr_to_binary_plan(const Schema& schema, const std::string& expr) {
+    // Serialize schema to protobuf
+    auto schema_proto = schema.ToProto();
+    std::string schema_bytes;
+    schema_proto.SerializeToString(&schema_bytes);
+
+    // Register schema with plan parser
+    std::vector<uint8_t> schema_vec(schema_bytes.begin(), schema_bytes.end());
+    auto handle = milvus::planparserv2::PlanParser::RegisterSchema(schema_vec);
+
+    // Parse expression
+    std::vector<uint8_t> plan_bytes;
+    try {
+        plan_bytes = milvus::planparserv2::PlanParser::Parse(handle, expr);
+    } catch (...) {
+        // Ensure schema is unregistered even on error
+        milvus::planparserv2::PlanParser::UnregisterSchema(handle);
+        throw;
+    }
+
+    // Unregister schema
+    milvus::planparserv2::PlanParser::UnregisterSchema(handle);
+
+    // Convert to vector<char>
+    std::vector<char> ret(plan_bytes.begin(), plan_bytes.end());
+    return ret;
+}
+
+// RAII wrapper for PlanParser schema registration to ensure proper cleanup.
+// This is useful when you need to parse multiple expressions with the same schema.
+class ScopedSchemaHandle {
+ public:
+    explicit ScopedSchemaHandle(const Schema& schema) {
+        auto schema_proto = schema.ToProto();
+        std::string schema_bytes;
+        schema_proto.SerializeToString(&schema_bytes);
+        std::vector<uint8_t> schema_vec(schema_bytes.begin(),
+                                        schema_bytes.end());
+        handle_ = milvus::planparserv2::PlanParser::RegisterSchema(schema_vec);
+    }
+
+    ~ScopedSchemaHandle() {
+        if (handle_ != milvus::planparserv2::kInvalidSchemaHandle) {
+            milvus::planparserv2::PlanParser::UnregisterSchema(handle_);
+        }
+    }
+
+    ScopedSchemaHandle(const ScopedSchemaHandle&) = delete;
+    ScopedSchemaHandle&
+    operator=(const ScopedSchemaHandle&) = delete;
+
+    ScopedSchemaHandle(ScopedSchemaHandle&& other) noexcept
+        : handle_(other.handle_) {
+        other.handle_ = milvus::planparserv2::kInvalidSchemaHandle;
+    }
+
+    ScopedSchemaHandle&
+    operator=(ScopedSchemaHandle&& other) noexcept {
+        if (this != &other) {
+            if (handle_ != milvus::planparserv2::kInvalidSchemaHandle) {
+                milvus::planparserv2::PlanParser::UnregisterSchema(handle_);
+            }
+            handle_ = other.handle_;
+            other.handle_ = milvus::planparserv2::kInvalidSchemaHandle;
+        }
+        return *this;
+    }
+
+    milvus::planparserv2::SchemaHandle
+    get() const {
+        return handle_;
+    }
+
+    std::vector<char>
+    Parse(const std::string& expr) const {
+        auto plan_bytes =
+            milvus::planparserv2::PlanParser::Parse(handle_, expr);
+        return std::vector<char>(plan_bytes.begin(), plan_bytes.end());
+    }
+
+    // Parse a search expression with vector search parameters.
+    // This creates a VectorANNS plan node for search operations.
+    std::vector<char>
+    ParseSearch(const std::string& expr,
+                const std::string& vector_field_name,
+                int64_t topk,
+                const std::string& metric_type,
+                const std::string& search_params = "{}",
+                int64_t round_decimal = -1,
+                const std::string& hints = "",
+                bool materialized_view_involved = false) const {
+        // Build QueryInfo protobuf
+        milvus::proto::plan::QueryInfo query_info;
+        query_info.set_topk(topk);
+        query_info.set_metric_type(metric_type);
+        query_info.set_search_params(search_params);
+        query_info.set_round_decimal(round_decimal);
+        if (!hints.empty()) {
+            query_info.set_hints(hints);
+        }
+        query_info.set_materialized_view_involved(materialized_view_involved);
+
+        // Serialize QueryInfo
+        std::string query_info_bytes;
+        query_info.SerializeToString(&query_info_bytes);
+        std::vector<uint8_t> query_info_vec(query_info_bytes.begin(),
+                                            query_info_bytes.end());
+
+        auto plan_bytes = milvus::planparserv2::PlanParser::ParseSearch(
+            handle_, expr, vector_field_name, query_info_vec);
+        return std::vector<char>(plan_bytes.begin(), plan_bytes.end());
+    }
+
+    // Parse a group-by search expression with vector search parameters.
+    // This creates a VectorANNS plan node with group-by settings for search operations.
+    // group_by_field_id: the field to group by
+    // group_size: number of results per group
+    // json_path: path within JSON field (e.g., "/int8")
+    // json_type: data type of the JSON value (e.g., milvus::proto::schema::DataType::Int8)
+    // strict_group_size: if true, return exactly group_size results per group
+    // strict_cast: if true, throw error for type mismatch
+    std::vector<char>
+    ParseGroupBySearch(const std::string& expr,
+                       const std::string& vector_field_name,
+                       int64_t topk,
+                       const std::string& metric_type,
+                       const std::string& search_params,
+                       int64_t group_by_field_id,
+                       int64_t group_size,
+                       const std::string& json_path = "",
+                       milvus::proto::schema::DataType json_type =
+                           milvus::proto::schema::DataType::None,
+                       bool strict_group_size = false,
+                       bool strict_cast = false,
+                       int64_t round_decimal = -1) const {
+        // Build QueryInfo protobuf
+        milvus::proto::plan::QueryInfo query_info;
+        query_info.set_topk(topk);
+        query_info.set_metric_type(metric_type);
+        query_info.set_search_params(search_params);
+        query_info.set_round_decimal(round_decimal);
+        query_info.set_group_by_field_id(group_by_field_id);
+        query_info.set_group_size(group_size);
+        query_info.set_strict_group_size(strict_group_size);
+        if (!json_path.empty()) {
+            query_info.set_json_path(json_path);
+        }
+        if (json_type != milvus::proto::schema::DataType::None) {
+            query_info.set_json_type(json_type);
+        }
+        query_info.set_strict_cast(strict_cast);
+
+        // Serialize QueryInfo
+        std::string query_info_bytes;
+        query_info.SerializeToString(&query_info_bytes);
+        std::vector<uint8_t> query_info_vec(query_info_bytes.begin(),
+                                            query_info_bytes.end());
+
+        auto plan_bytes = milvus::planparserv2::PlanParser::ParseSearch(
+            handle_, expr, vector_field_name, query_info_vec);
+        return std::vector<char>(plan_bytes.begin(), plan_bytes.end());
+    }
+
+ private:
+    milvus::planparserv2::SchemaHandle handle_;
+};
 
 inline auto
 GenTss(int64_t num, int64_t begin_ts) {

--- a/internal/parser/planparserv2/cwrapper/milvus_plan_parser.h
+++ b/internal/parser/planparserv2/cwrapper/milvus_plan_parser.h
@@ -60,7 +60,7 @@ public:
     static std::string UnregisterSchema(SchemaHandle handle);
 
     /**
-     * @brief Parse an expression string into a serialized PlanNode protobuf.
+     * @brief Parse an expression string into a serialized PlanNode protobuf (RetrievePlan).
      *
      * Thread-safe and lock-free. Multiple threads can call Parse() concurrently
      * with the same or different handles.
@@ -74,6 +74,27 @@ public:
      *   - parsing fails
      */
     static std::vector<uint8_t> Parse(SchemaHandle handle, const std::string& expr);
+
+    /**
+     * @brief Parse an expression string into a serialized SearchPlan PlanNode protobuf.
+     *
+     * Thread-safe and lock-free. Creates a VectorANNS plan node for search operations.
+     *
+     * @param handle The handle returned by RegisterSchema.
+     * @param expr The filter expression string to parse (can be empty).
+     * @param vector_field_name The name of the vector field to search.
+     * @param query_info_proto The serialized QueryInfo protobuf containing topk, metric_type, etc.
+     * @return std::vector<uint8_t> The serialized PlanNode protobuf.
+     * @throws std::runtime_error if:
+     *   - handle is invalid or not found
+     *   - schema was unregistered
+     *   - vector field not found
+     *   - parsing fails
+     */
+    static std::vector<uint8_t> ParseSearch(SchemaHandle handle,
+                                            const std::string& expr,
+                                            const std::string& vector_field_name,
+                                            const std::vector<uint8_t>& query_info_proto);
 };
 
 } // namespace planparserv2


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/44452
pr: #47384

added the ability to create SearchPlan to plan parser so; updated all c++ ut to use plan parser so to create retrieve/search plan, instead of writting literal text protos
