### PR TITLE
fix: [2.5] add authentication to metrics endpoint when authorization enabled

### DIFF
--- a/internal/distributed/proxy/service.go
+++ b/internal/distributed/proxy/service.go
@@ -168,6 +168,11 @@ func (s *Server) registerHTTPServer() {
 	metricsGinHandler := gin.Default()
 	apiv1 := metricsGinHandler.Group(apiPathPrefix)
 	apiv1.Use(httpserver.RequestHandlerFunc)
+	// Add authentication middleware if authorization is enabled
+	// This ensures the metrics port follows the same security policy as the main HTTP server
+	if proxy.Params.CommonCfg.AuthorizationEnabled.GetAsBool() {
+		apiv1.Use(authenticate)
+	}
 	handlers := httpserver.NewHandlers(s.proxy)
 	handlers.RegisterRoutesTo(apiv1)
 	if p, ok := s.proxy.(*proxy.Proxy); ok {


### PR DESCRIPTION
## Summary
- Cherry-pick of #47278 (2.6 backport) to the 2.5 branch
- Adds authentication to the metrics endpoint when authorization is enabled

issue: #46817
master pr: #47277
2.6 pr: #47278

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Cai Zhang <cai.zhang@zilliz.com>
Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>