### PR TITLE
enhance: integrate default value filling into LoadDiff computation

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -1417,6 +1417,7 @@ ChunkedSegmentSealedImpl::ChunkedSegmentSealedImpl(
       scalar_indexings_(std::unordered_map<FieldId, index::CacheIndexBasePtr>(
           schema->size())),
       insert_record_(*schema, MAX_ROW_COUNT),
+      segment_load_info_(milvus::proto::segcore::SegmentLoadInfo(), schema),
       schema_(schema),
       id_(segment_id),
       col_index_meta_(index_meta),
@@ -2827,12 +2828,10 @@ ChunkedSegmentSealedImpl::Reopen(
     const milvus::proto::segcore::SegmentLoadInfo& new_load_info) {
     SegmentLoadInfo new_seg_load_info(new_load_info, schema_);
 
-    SegmentLoadInfo current;
-    {
-        std::unique_lock lck(mutex_);
-        current = segment_load_info_;
-        segment_load_info_ = new_seg_load_info;
-    }
+    std::unique_lock lck(mutex_);
+    SegmentLoadInfo current(segment_load_info_);
+    segment_load_info_ = new_seg_load_info;
+    lck.unlock();
 
     // compute load diff
     auto diff = current.ComputeDiff(new_seg_load_info);
@@ -2895,32 +2894,16 @@ ChunkedSegmentSealedImpl::ApplyLoadDiff(SegmentLoadInfo& segment_load_info,
         LoadBatchFieldData(trace_ctx, diff.binlogs_to_load, op_ctx);
     }
 
+    // fill default values for fields without data sources (schema evolution)
+    if (!diff.fields_to_fill_default.empty()) {
+        FillDefaultValueFields(diff.fields_to_fill_default);
+    }
+
     // drop field
     if (!diff.field_data_to_drop.empty()) {
         for (auto field_id : diff.field_data_to_drop) {
             DropFieldData(field_id);
         }
-    }
-}
-
-void
-ChunkedSegmentSealedImpl::FinishLoad() {
-    std::unique_lock lck(mutex_);
-    for (const auto& [field_id, field_meta] : schema_->get_fields()) {
-        if (field_id.get() < START_USER_FIELDID) {
-            // no filling system fields
-            continue;
-        }
-        if (get_bit(field_data_ready_bitset_, field_id)) {
-            // no filling fields that data already loaded
-            continue;
-        }
-        if (get_bit(index_ready_bitset_, field_id) &&
-            (index_has_raw_data_[field_id])) {
-            // no filling fields that index already loaded and has raw data
-            continue;
-        }
-        fill_empty_field(field_meta);
     }
 }
 
@@ -2971,6 +2954,25 @@ ChunkedSegmentSealedImpl::fill_empty_field(const FieldMeta& field_meta) {
         field_meta.get_data_type(),
         field_id.get(),
         id_);
+}
+
+void
+ChunkedSegmentSealedImpl::FillDefaultValueFields(
+    const std::vector<FieldId>& field_ids) {
+    std::unique_lock lck(mutex_);
+    for (const auto& field_id : field_ids) {
+        // Skip if field data already loaded
+        if (get_bit(field_data_ready_bitset_, field_id)) {
+            continue;
+        }
+        // Skip if index has raw data
+        if (get_bit(index_ready_bitset_, field_id) &&
+            index_has_raw_data_[field_id]) {
+            continue;
+        }
+        const auto& field_meta = schema_->operator[](field_id);
+        fill_empty_field(field_meta);
+    }
 }
 
 void

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -200,9 +200,6 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     LazyCheckSchema(SchemaPtr sch) override;
 
     void
-    FinishLoad() override;
-
-    void
     SetLoadInfo(
         const milvus::proto::segcore::SegmentLoadInfo& load_info) override;
 
@@ -969,6 +966,18 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
 
     void
     fill_empty_field(const FieldMeta& field_meta);
+
+    /**
+     * @brief Fill default values for fields without data sources
+     *
+     * This method fills default values for fields that exist in the schema
+     * but have no data source (binlog, index with raw data, or column group).
+     * Used during schema evolution when new fields are added.
+     *
+     * @param field_ids Vector of field IDs that need default value filling
+     */
+    void
+    FillDefaultValueFields(const std::vector<FieldId>& field_ids);
 
     void
     init_timestamp_index(const std::vector<Timestamp>& timestamps,

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -1952,10 +1952,7 @@ SegmentGrowingImpl::Load(milvus::tracer::TraceContext& trace_ctx,
     if (!field_data_info.field_infos.empty()) {
         LoadFieldData(field_data_info);
     }
-}
 
-void
-SegmentGrowingImpl::FinishLoad() {
     for (const auto& [field_id, field_meta] : schema_->get_fields()) {
         if (field_id.get() < START_USER_FIELDID) {
             continue;

--- a/internal/core/src/segcore/SegmentGrowingImpl.h
+++ b/internal/core/src/segcore/SegmentGrowingImpl.h
@@ -114,9 +114,6 @@ class SegmentGrowingImpl : public SegmentGrowing {
     LazyCheckSchema(SchemaPtr sch) override;
 
     void
-    FinishLoad() override;
-
-    void
     Load(milvus::tracer::TraceContext& trace_ctx,
          milvus::OpContext* op_ctx = nullptr) override;
 

--- a/internal/core/src/segcore/SegmentInterface.h
+++ b/internal/core/src/segcore/SegmentInterface.h
@@ -232,11 +232,6 @@ class SegmentInterface {
     virtual void
     Reopen(const milvus::proto::segcore::SegmentLoadInfo& new_load_info) = 0;
 
-    // FinishLoad notifies the segment that all load operation are done
-    // currently it's used to sync field data list with updated schema.
-    virtual void
-    FinishLoad() = 0;
-
     virtual void
     SetLoadInfo(const milvus::proto::segcore::SegmentLoadInfo& load_info) = 0;
 

--- a/internal/core/src/segcore/SegmentLoadInfoTest.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfoTest.cpp
@@ -134,8 +134,9 @@ class SegmentLoadInfoTest : public ::testing::Test {
     proto::segcore::SegmentLoadInfo proto_;
 };
 
-TEST_F(SegmentLoadInfoTest, DefaultConstructor) {
-    SegmentLoadInfo info;
+TEST_F(SegmentLoadInfoTest, EmptyProtoConstructor) {
+    proto::segcore::SegmentLoadInfo empty_proto;
+    SegmentLoadInfo info(empty_proto, schema_);
     EXPECT_TRUE(info.IsEmpty());
     EXPECT_EQ(info.GetSegmentID(), 0);
     EXPECT_EQ(info.GetNumOfRows(), 0);
@@ -170,7 +171,8 @@ TEST_F(SegmentLoadInfoTest, MoveConstructor) {
 
 TEST_F(SegmentLoadInfoTest, CopyAssignment) {
     SegmentLoadInfo info1(proto_, schema_);
-    SegmentLoadInfo info2;
+    proto::segcore::SegmentLoadInfo empty_proto;
+    SegmentLoadInfo info2(empty_proto, schema_);
     info2 = info1;
 
     EXPECT_EQ(info2.GetSegmentID(), 12345);
@@ -178,7 +180,8 @@ TEST_F(SegmentLoadInfoTest, CopyAssignment) {
 }
 
 TEST_F(SegmentLoadInfoTest, SetMethod) {
-    SegmentLoadInfo info;
+    proto::segcore::SegmentLoadInfo empty_proto;
+    SegmentLoadInfo info(empty_proto, schema_);
     info.Set(proto_, schema_);
 
     EXPECT_EQ(info.GetSegmentID(), 12345);
@@ -351,20 +354,6 @@ TEST_F(SegmentLoadInfoTest, IndexWithoutFiles) {
 }
 
 // ==================== GetLoadDiff Tests ====================
-
-TEST_F(SegmentLoadInfoTest, GetLoadDiffWithEmptyInfo) {
-    // Empty SegmentLoadInfo should return empty diff
-    SegmentLoadInfo empty_info;
-    auto diff = empty_info.GetLoadDiff();
-
-    EXPECT_FALSE(diff.HasChanges());
-    EXPECT_TRUE(diff.indexes_to_load.empty());
-    EXPECT_TRUE(diff.binlogs_to_load.empty());
-    EXPECT_TRUE(diff.column_groups_to_load.empty());
-    EXPECT_TRUE(diff.indexes_to_drop.empty());
-    EXPECT_TRUE(diff.field_data_to_drop.empty());
-    EXPECT_FALSE(diff.manifest_updated);
-}
 
 TEST_F(SegmentLoadInfoTest, GetLoadDiffWithIndexesOnly) {
     // Create info with only indexes (no binlogs, no manifest)
@@ -812,10 +801,239 @@ TEST_F(SegmentLoadInfoTest, ComputeDiffNoChangesLegacyFormat) {
     log->set_entries_num(500);
 
     SegmentLoadInfo current_info(proto, schema_);
+    // calculate first diff to set default value fields
+    auto diff = current_info.GetLoadDiff();
     SegmentLoadInfo new_info(proto, schema_);
-    auto diff = current_info.ComputeDiff(new_info);
+    diff = current_info.ComputeDiff(new_info);
 
     EXPECT_FALSE(diff.HasChanges());
     EXPECT_TRUE(diff.binlogs_to_load.empty());
     EXPECT_TRUE(diff.field_data_to_drop.empty());
+}
+
+// ==================== Default Value Filling Tests ====================
+
+TEST_F(SegmentLoadInfoTest, ComputeDiffDefaultFieldsBasic) {
+    // Test that fields without data sources are added to fields_to_fill_default
+    // Schema has fields 100-110, but we only provide binlog for field 100 (pk)
+    proto::segcore::SegmentLoadInfo proto;
+    proto.set_segmentid(100);
+    proto.set_num_of_rows(1000);
+
+    // Only add binlog for pk field (100)
+    auto* binlog = proto.add_binlog_paths();
+    binlog->set_fieldid(100);
+    auto* log = binlog->add_binlogs();
+    log->set_log_path("/path/to/pk_binlog");
+    log->set_entries_num(1000);
+
+    SegmentLoadInfo empty_info(milvus::proto::segcore::SegmentLoadInfo(),
+                               schema_);
+    SegmentLoadInfo new_info(proto, schema_);
+
+    auto diff = empty_info.ComputeDiff(new_info);
+
+    // Fields 101-110 should be in fields_to_fill_default (no data source)
+    // Field 100 has binlog, so it should NOT be in fields_to_fill_default
+    EXPECT_TRUE(diff.HasChanges());
+    EXPECT_FALSE(diff.fields_to_fill_default.empty());
+
+    // Check that field 100 is NOT in fields_to_fill_default
+    for (const auto& field_id : diff.fields_to_fill_default) {
+        EXPECT_NE(field_id.get(), 100);
+    }
+
+    // Fields 101-110 should be in fields_to_fill_default
+    std::set<int64_t> expected_fields = {
+        101, 102, 103, 104, 105, 106, 107, 108, 109, 110};
+    std::set<int64_t> actual_fields;
+    for (const auto& field_id : diff.fields_to_fill_default) {
+        actual_fields.insert(field_id.get());
+    }
+    EXPECT_EQ(actual_fields, expected_fields);
+}
+
+TEST_F(SegmentLoadInfoTest, ComputeDiffDefaultFieldsSkipAlreadyFilled) {
+    // Test that fields already filled with default values are skipped
+    // on subsequent ComputeDiff calls
+    proto::segcore::SegmentLoadInfo proto;
+    proto.set_segmentid(100);
+    proto.set_num_of_rows(1000);
+
+    // Only add binlog for pk field (100)
+    auto* binlog = proto.add_binlog_paths();
+    binlog->set_fieldid(100);
+    auto* log = binlog->add_binlogs();
+    log->set_log_path("/path/to/pk_binlog");
+    log->set_entries_num(1000);
+
+    // First diff: empty -> proto (simulates initial load)
+    SegmentLoadInfo empty_info(milvus::proto::segcore::SegmentLoadInfo(),
+                               schema_);
+    SegmentLoadInfo first_new_info(proto, schema_);
+    auto first_diff = empty_info.ComputeDiff(first_new_info);
+
+    // Verify fields were added to fields_to_fill_default
+    EXPECT_FALSE(first_diff.fields_to_fill_default.empty());
+    size_t first_count = first_diff.fields_to_fill_default.size();
+
+    // Second diff: first_new_info -> same proto (simulates reopen)
+    // first_new_info should now have fields_filled_with_default_ populated
+    SegmentLoadInfo second_new_info(proto, schema_);
+    auto second_diff = first_new_info.ComputeDiff(second_new_info);
+
+    // All previously filled fields should be skipped
+    EXPECT_TRUE(second_diff.fields_to_fill_default.empty());
+
+    // Verify that second_new_info inherited the filled status
+    // by doing a third diff
+    SegmentLoadInfo third_new_info(proto, schema_);
+    auto third_diff = second_new_info.ComputeDiff(third_new_info);
+    EXPECT_TRUE(third_diff.fields_to_fill_default.empty());
+}
+
+TEST_F(SegmentLoadInfoTest, ComputeDiffDefaultFieldsWithIndex) {
+    // Test that fields with index (that has raw data) are NOT added
+    // to fields_to_fill_default
+    proto::segcore::SegmentLoadInfo proto;
+    proto.set_segmentid(100);
+    proto.set_num_of_rows(1000);
+
+    // Add binlog for pk field (100)
+    auto* binlog = proto.add_binlog_paths();
+    binlog->set_fieldid(100);
+    auto* log = binlog->add_binlogs();
+    log->set_log_path("/path/to/pk_binlog");
+    log->set_entries_num(1000);
+
+    // Add index for field 101 (vec field) - FLAT index has raw data
+    auto* index_info = proto.add_index_infos();
+    index_info->set_fieldid(101);
+    index_info->set_indexid(1001);
+    index_info->add_index_file_paths("/path/to/index");
+    auto* index_param = index_info->add_index_params();
+    index_param->set_key("index_type");
+    index_param->set_value(knowhere::IndexEnum::INDEX_FAISS_IDMAP);
+
+    SegmentLoadInfo empty_info(milvus::proto::segcore::SegmentLoadInfo(),
+                               schema_);
+    SegmentLoadInfo new_info(proto, schema_);
+    auto diff = empty_info.ComputeDiff(new_info);
+
+    // Field 101 should NOT be in fields_to_fill_default (has index with raw
+    // data)
+    for (const auto& field_id : diff.fields_to_fill_default) {
+        EXPECT_NE(field_id.get(), 101);
+    }
+
+    // Field 101 should be in indexes_to_load
+    EXPECT_TRUE(diff.indexes_to_load.find(FieldId(101)) !=
+                diff.indexes_to_load.end());
+}
+
+TEST_F(SegmentLoadInfoTest, ComputeDiffDefaultFieldsNotInBinlogsToLoad) {
+    // Test that fields being loaded via binlogs_to_load are NOT added
+    // to fields_to_fill_default
+    proto::segcore::SegmentLoadInfo current_proto;
+    current_proto.set_segmentid(100);
+    current_proto.set_num_of_rows(1000);
+
+    // Current has only pk field
+    auto* binlog1 = current_proto.add_binlog_paths();
+    binlog1->set_fieldid(100);
+    auto* log1 = binlog1->add_binlogs();
+    log1->set_log_path("/path/to/pk_binlog");
+    log1->set_entries_num(1000);
+
+    // New has pk + field 101
+    proto::segcore::SegmentLoadInfo new_proto;
+    new_proto.set_segmentid(100);
+    new_proto.set_num_of_rows(1000);
+
+    auto* new_binlog1 = new_proto.add_binlog_paths();
+    new_binlog1->set_fieldid(100);
+    auto* new_log1 = new_binlog1->add_binlogs();
+    new_log1->set_log_path("/path/to/pk_binlog");
+    new_log1->set_entries_num(1000);
+
+    auto* new_binlog2 = new_proto.add_binlog_paths();
+    new_binlog2->set_fieldid(101);
+    auto* new_log2 = new_binlog2->add_binlogs();
+    new_log2->set_log_path("/path/to/field101_binlog");
+    new_log2->set_entries_num(1000);
+
+    SegmentLoadInfo current_info(current_proto, schema_);
+    SegmentLoadInfo new_info(new_proto, schema_);
+    auto diff = current_info.ComputeDiff(new_info);
+
+    // Field 101 should be in binlogs_to_load, NOT in fields_to_fill_default
+    bool found_in_binlogs = false;
+    for (const auto& [field_ids, binlog_ptr] : diff.binlogs_to_load) {
+        for (const auto& fid : field_ids) {
+            if (fid.get() == 101) {
+                found_in_binlogs = true;
+                break;
+            }
+        }
+    }
+    EXPECT_TRUE(found_in_binlogs);
+
+    // Field 101 should NOT be in fields_to_fill_default
+    for (const auto& field_id : diff.fields_to_fill_default) {
+        EXPECT_NE(field_id.get(), 101);
+    }
+}
+
+TEST_F(SegmentLoadInfoTest, GetLoadDiffDefaultFields) {
+    // Test GetLoadDiff includes fields_to_fill_default for initial load
+    proto::segcore::SegmentLoadInfo proto;
+    proto.set_segmentid(100);
+    proto.set_num_of_rows(1000);
+
+    // Only add binlog for pk field (100) and vec field (101)
+    auto* binlog1 = proto.add_binlog_paths();
+    binlog1->set_fieldid(100);
+    auto* log1 = binlog1->add_binlogs();
+    log1->set_log_path("/path/to/pk_binlog");
+    log1->set_entries_num(1000);
+
+    auto* binlog2 = proto.add_binlog_paths();
+    binlog2->set_fieldid(101);
+    auto* log2 = binlog2->add_binlogs();
+    log2->set_log_path("/path/to/vec_binlog");
+    log2->set_entries_num(1000);
+
+    SegmentLoadInfo info(proto, schema_);
+    auto diff = info.GetLoadDiff();
+
+    // Fields 102-110 should be in fields_to_fill_default
+    std::set<int64_t> expected_fields = {
+        102, 103, 104, 105, 106, 107, 108, 109, 110};
+    std::set<int64_t> actual_fields;
+    for (const auto& field_id : diff.fields_to_fill_default) {
+        actual_fields.insert(field_id.get());
+    }
+    EXPECT_EQ(actual_fields, expected_fields);
+}
+
+TEST_F(SegmentLoadInfoTest, LoadDiffToStringIncludesDefaultFields) {
+    // Test that LoadDiff::ToString includes fields_to_fill_default
+    LoadDiff diff;
+    diff.fields_to_fill_default.push_back(FieldId(102));
+    diff.fields_to_fill_default.push_back(FieldId(103));
+
+    std::string str = diff.ToString();
+    EXPECT_TRUE(str.find("fields_to_fill_default") != std::string::npos);
+    EXPECT_TRUE(str.find("102") != std::string::npos);
+    EXPECT_TRUE(str.find("103") != std::string::npos);
+}
+
+TEST_F(SegmentLoadInfoTest, LoadDiffHasChangesWithDefaultFields) {
+    // Test that HasChanges returns true when only fields_to_fill_default
+    // is non-empty
+    LoadDiff diff;
+    EXPECT_FALSE(diff.HasChanges());
+
+    diff.fields_to_fill_default.push_back(FieldId(102));
+    EXPECT_TRUE(diff.HasChanges());
 }

--- a/internal/core/src/segcore/segment_c.cpp
+++ b/internal/core/src/segcore/segment_c.cpp
@@ -821,20 +821,6 @@ CreateTextIndex(CSegmentInterface c_segment,
 }
 
 CStatus
-FinishLoad(CSegmentInterface c_segment) {
-    SCOPE_CGO_CALL_METRIC();
-
-    try {
-        auto segment_interface =
-            reinterpret_cast<milvus::segcore::SegmentInterface*>(c_segment);
-        segment_interface->FinishLoad();
-        return milvus::SuccessCStatus();
-    } catch (std::exception& e) {
-        return milvus::FailureCStatus(milvus::UnexpectedError, e.what());
-    }
-}
-
-CStatus
 ExprResCacheEraseSegment(int64_t segment_id) {
     SCOPE_CGO_CALL_METRIC();
 

--- a/internal/core/src/segcore/segment_c.h
+++ b/internal/core/src/segcore/segment_c.h
@@ -266,9 +266,6 @@ CreateTextIndex(CSegmentInterface c_segment,
                 CLoadCancellationSource source);
 
 CStatus
-FinishLoad(CSegmentInterface c_segment);
-
-CStatus
 ExprResCacheEraseSegment(int64_t segment_id);
 
 #ifdef __cplusplus

--- a/internal/mocks/util/mock_segcore/mock_CSegment.go
+++ b/internal/mocks/util/mock_segcore/mock_CSegment.go
@@ -235,51 +235,6 @@ func (_c *MockCSegment_DropJSONIndex_Call) RunAndReturn(run func(context.Context
 	return _c
 }
 
-// FinishLoad provides a mock function with no fields
-func (_m *MockCSegment) FinishLoad() error {
-	ret := _m.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for FinishLoad")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func() error); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// MockCSegment_FinishLoad_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FinishLoad'
-type MockCSegment_FinishLoad_Call struct {
-	*mock.Call
-}
-
-// FinishLoad is a helper method to define mock.On call
-func (_e *MockCSegment_Expecter) FinishLoad() *MockCSegment_FinishLoad_Call {
-	return &MockCSegment_FinishLoad_Call{Call: _e.mock.On("FinishLoad")}
-}
-
-func (_c *MockCSegment_FinishLoad_Call) Run(run func()) *MockCSegment_FinishLoad_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *MockCSegment_FinishLoad_Call) Return(_a0 error) *MockCSegment_FinishLoad_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockCSegment_FinishLoad_Call) RunAndReturn(run func() error) *MockCSegment_FinishLoad_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // HasFieldData provides a mock function with given fields: fieldID
 func (_m *MockCSegment) HasFieldData(fieldID int64) bool {
 	ret := _m.Called(fieldID)
@@ -977,7 +932,8 @@ func (_c *MockCSegment_Search_Call) RunAndReturn(run func(context.Context, *segc
 func NewMockCSegment(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *MockCSegment {
+},
+) *MockCSegment {
 	mock := &MockCSegment{}
 	mock.Mock.Test(t)
 

--- a/internal/querynodev2/segments/mock_segment.go
+++ b/internal/querynodev2/segments/mock_segment.go
@@ -410,51 +410,6 @@ func (_c *MockSegment_ExistIndex_Call) RunAndReturn(run func(int64) bool) *MockS
 	return _c
 }
 
-// FinishLoad provides a mock function with no fields
-func (_m *MockSegment) FinishLoad() error {
-	ret := _m.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for FinishLoad")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func() error); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// MockSegment_FinishLoad_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FinishLoad'
-type MockSegment_FinishLoad_Call struct {
-	*mock.Call
-}
-
-// FinishLoad is a helper method to define mock.On call
-func (_e *MockSegment_Expecter) FinishLoad() *MockSegment_FinishLoad_Call {
-	return &MockSegment_FinishLoad_Call{Call: _e.mock.On("FinishLoad")}
-}
-
-func (_c *MockSegment_FinishLoad_Call) Run(run func()) *MockSegment_FinishLoad_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *MockSegment_FinishLoad_Call) Return(_a0 error) *MockSegment_FinishLoad_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockSegment_FinishLoad_Call) RunAndReturn(run func() error) *MockSegment_FinishLoad_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // GetBM25Stats provides a mock function with no fields
 func (_m *MockSegment) GetBM25Stats() map[int64]*storage.BM25Stats {
 	ret := _m.Called()
@@ -2320,7 +2275,8 @@ func (_c *MockSegment_Version_Call) RunAndReturn(run func() int64) *MockSegment_
 func NewMockSegment(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *MockSegment {
+},
+) *MockSegment {
 	mock := &MockSegment{}
 	mock.Mock.Test(t)
 

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -1378,20 +1378,6 @@ func (s *LocalSegment) CreateTextIndex(ctx context.Context, fieldID int64) error
 	return nil
 }
 
-func (s *LocalSegment) FinishLoad() error {
-	err := s.csegment.FinishLoad()
-	if err != nil {
-		return err
-	}
-	// TODO: disable logical resource handling for now
-	// usage := s.ResourceUsageEstimate()
-	// s.manager.AddLogicalResource(usage)
-	binlogSize := calculateSegmentMemorySize(s.LoadInfo())
-	s.manager.AddLoadedBinlogSize(binlogSize)
-	s.binlogSize.Store(binlogSize)
-	return nil
-}
-
 func (s *LocalSegment) Load(ctx context.Context) error {
 	return s.csegment.Load(ctx)
 }

--- a/internal/querynodev2/segments/segment_interface.go
+++ b/internal/querynodev2/segments/segment_interface.go
@@ -86,7 +86,6 @@ type Segment interface {
 	LoadDeltaData(ctx context.Context, deltaData *storage.DeltaData) error
 	LastDeltaTimestamp() uint64
 	Load(ctx context.Context) error
-	FinishLoad() error
 	Release(ctx context.Context, opts ...releaseOption)
 	Reopen(ctx context.Context, newLoadInfo *querypb.SegmentLoadInfo) error
 

--- a/internal/querynodev2/segments/segment_l0.go
+++ b/internal/querynodev2/segments/segment_l0.go
@@ -178,10 +178,6 @@ func (s *L0Segment) DeleteRecords() ([]storage.PrimaryKey, []uint64) {
 	return s.pks, s.tss
 }
 
-func (s *L0Segment) FinishLoad() error {
-	return nil
-}
-
 func (s *L0Segment) Load(ctx context.Context) error {
 	return nil
 }

--- a/internal/util/segcore/segment.go
+++ b/internal/util/segcore/segment.go
@@ -303,15 +303,6 @@ func (s *cSegmentImpl) AddFieldDataInfo(ctx context.Context, request *AddFieldDa
 	return &AddFieldDataInfoResult{}, nil
 }
 
-// FinishLoad wraps up the load process and let segcore do the leftover jobs.
-func (s *cSegmentImpl) FinishLoad() error {
-	status := C.FinishLoad(s.ptr)
-	if err := ConsumeCStatusIntoError(&status); err != nil {
-		return errors.Wrap(err, "failed to finish load segment")
-	}
-	return nil
-}
-
 func (s *cSegmentImpl) Load(ctx context.Context) error {
 	traceCtx := ParseCTraceContext(ctx)
 	defer runtime.KeepAlive(traceCtx)

--- a/internal/util/segcore/segment_interface.go
+++ b/internal/util/segcore/segment_interface.go
@@ -79,9 +79,6 @@ type basicSegmentMethodSet interface {
 	// Delete deletes data from the segment.
 	Delete(ctx context.Context, request *DeleteRequest) (*DeleteResult, error)
 
-	// FinishLoad wraps up the load process and let segcore do the leftover jobs.
-	FinishLoad() error
-
 	// Load invokes segment managed loading.
 	Load(ctx context.Context) error
 


### PR DESCRIPTION
Related to #46358

This PR refactors how default values are filled for newly added schema fields by integrating this logic into the LoadDiff computation flow, removing the separate FinishLoad() step.

**Changes**

**Remove FinishLoad API**
- Remove `FinishLoad()` from `SegmentInterface` and all implementations (ChunkedSegmentSealedImpl, SegmentGrowingImpl)
- Remove `FinishLoad()` from C API (`segment_c.cpp/h`)
- Remove `FinishLoad()` from Go layer (CSegment, Segment interfaces)
- Remove `FinishLoad()` calls from segment_loader.go

**Integrate default value filling into LoadDiff**
- Add `fields_to_fill_default` field to `LoadDiff` struct to track fields that need default value filling during schema evolution
- Add `ComputeDiffDefaultFields()` method to `SegmentLoadInfo` to compute which fields need default values (fields in schema but without data source: binlog, index with raw data, or column group)
- Add `fields_filled_with_default_` to `SegmentLoadInfo` to track fields that have already been filled, preventing duplicate filling on reopen
- Add `FillDefaultValueFields()` method to `ChunkedSegmentSealedImpl`

**Behavioral changes**
- Default value filling now happens as part of `ApplyLoadDiff()` instead of a separate `FinishLoad()` call
- `SegmentLoadInfo` no longer has a default constructor; it must be initialized with a schema to properly track default value state
- Growing segment continues to fill defaults in `Load()` method