### PR TITLE
fix: Fill log & memory size in TextIndexStats meta

### DIFF
--- a/internal/datanode/compactor/sort_compaction.go
+++ b/internal/datanode/compactor/sort_compaction.go
@@ -526,11 +526,14 @@ func (t *sortCompactionTask) createTextIndex(ctx context.Context,
 			}
 
 			mu.Lock()
+			totalSize := lo.SumBy(lo.Values(uploaded), func(fileSize int64) int64 { return fileSize })
 			textIndexLogs[field.GetFieldID()] = &datapb.TextIndexStats{
-				FieldID: field.GetFieldID(),
-				Version: 0,
-				BuildID: taskID,
-				Files:   lo.Keys(uploaded),
+				FieldID:    field.GetFieldID(),
+				Version:    0,
+				BuildID:    taskID,
+				Files:      lo.Keys(uploaded),
+				LogSize:    totalSize,
+				MemorySize: totalSize,
 			}
 			mu.Unlock()
 

--- a/internal/datanode/index/task_stats.go
+++ b/internal/datanode/index/task_stats.go
@@ -531,11 +531,14 @@ func (st *statsTask) createTextIndex(ctx context.Context,
 			}
 
 			mu.Lock()
+			totalSize := lo.SumBy(lo.Values(uploaded), func(fileSize int64) int64 { return fileSize })
 			textIndexLogs[field.GetFieldID()] = &datapb.TextIndexStats{
-				FieldID: field.GetFieldID(),
-				Version: version,
-				BuildID: taskID,
-				Files:   lo.Keys(uploaded),
+				FieldID:    field.GetFieldID(),
+				Version:    version,
+				BuildID:    taskID,
+				Files:      lo.Keys(uploaded),
+				LogSize:    totalSize,
+				MemorySize: totalSize,
 			}
 			mu.Unlock()
 


### PR DESCRIPTION
Related to #47434

This PR fixes size not recorded by filling total size in stats task and sort compaction logic.