### PR TITLE
fix: fix bloom filter leak when worker node crashes

### DIFF
--- a/internal/querynodev2/delegator/delegator.go
+++ b/internal/querynodev2/delegator/delegator.go
@@ -42,7 +42,6 @@ import (
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
 	"github.com/milvus-io/milvus/internal/querynodev2/cluster"
 	"github.com/milvus-io/milvus/internal/querynodev2/delegator/deletebuffer"
-	"github.com/milvus-io/milvus/internal/querynodev2/pkoracle"
 	"github.com/milvus-io/milvus/internal/querynodev2/segments"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/util/function"
@@ -134,7 +133,6 @@ type shardDelegator struct {
 	idfOracle    IDFOracle
 
 	segmentManager segments.SegmentManager
-	pkOracle       pkoracle.PkOracle
 	// stream delete buffer
 	deleteMut    sync.RWMutex
 	deleteBuffer deletebuffer.DeleteBuffer[*deletebuffer.Item]
@@ -149,7 +147,7 @@ type shardDelegator struct {
 	chunkManager   storage.ChunkManager
 
 	excludedSegments *ExcludedSegments
-	// cause growing segment meta has been stored in segmentManager/distribution/pkOracle/excludeSegments
+	// cause growing segment meta has been stored in segmentManager/distribution/excludeSegments
 	// in order to make add/remove growing be atomic, need lock before modify these meta info
 	growingSegmentLock sync.RWMutex
 	partitionStatsMut  sync.RWMutex
@@ -1141,6 +1139,8 @@ func (sd *shardDelegator) Close() {
 	sd.tsCond.Broadcast()
 	sd.lifetime.Wait()
 
+	// Refund all sealed segment candidates in distribution
+	sd.distribution.RefundAllCandidates()
 	// clean idf oracle
 	if sd.idfOracle != nil {
 		sd.idfOracle.Close()
@@ -1245,7 +1245,6 @@ func NewShardDelegator(ctx context.Context, collectionID UniqueID, replicaID Uni
 		distribution:   NewDistribution(channel, queryView),
 		deleteBuffer: deletebuffer.NewListDeleteBuffer[*deletebuffer.Item](startTs, sizePerBlock,
 			[]string{fmt.Sprint(paramtable.GetNodeID()), channel}),
-		pkOracle:                   pkoracle.NewPkOracle(),
 		latestTsafe:                atomic.NewUint64(startTs),
 		loader:                     loader,
 		queryHook:                  queryHook,

--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -186,6 +186,12 @@ func (sd *shardDelegator) ProcessInsert(insertRecords map[int64]*InsertData) {
 // delegator puts deleteData into buffer first,
 // then dispatch data to segments according to the result of bloom filter check.
 func (sd *shardDelegator) ProcessDelete(deleteData []*DeleteData, ts uint64) {
+	// Early return if delegator is stopped - ProcessDelete becomes a no-op
+	// This prevents unnecessary processing and side effects during shutdown
+	if sd.Stopped() {
+		return
+	}
+
 	method := "ProcessDelete"
 	tr := timerecord.NewTimeRecorder(method)
 	// block load segment handle delete buffer

--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -151,9 +151,8 @@ func (sd *shardDelegator) ProcessInsert(insertRecords map[int64]*InsertData) {
 				continue
 			}
 
-			if !sd.pkOracle.Exists(growing, paramtable.GetNodeID()) {
+			if !sd.distribution.GrowingSegmentExists(segmentID) {
 				// register created growing segment after insert, avoid to add empty growing to delegator
-				sd.pkOracle.Register(growing, paramtable.GetNodeID())
 				if sd.idfOracle != nil {
 					sd.idfOracle.RegisterGrowing(segmentID, insertData.BM25Stats)
 				}
@@ -164,6 +163,7 @@ func (sd *shardDelegator) ProcessInsert(insertRecords map[int64]*InsertData) {
 					PartitionID:   insertData.PartitionID,
 					Version:       0,
 					TargetVersion: initialTargetVersion,
+					Candidate:     growing, // growing segment itself is the Candidate
 				})
 			}
 
@@ -184,7 +184,7 @@ func (sd *shardDelegator) ProcessInsert(insertRecords map[int64]*InsertData) {
 
 // ProcessDelete handles delete data in delegator.
 // delegator puts deleteData into buffer first,
-// then dispatch data to segments acoording to the result of pkOracle.
+// then dispatch data to segments according to the result of bloom filter check.
 func (sd *shardDelegator) ProcessDelete(deleteData []*DeleteData, ts uint64) {
 	method := "ProcessDelete"
 	tr := timerecord.NewTimeRecorder(method)
@@ -225,6 +225,9 @@ type BatchApplyRet = struct {
 	Segment2Hits  map[int64][]bool
 }
 
+// applyBFInParallel applies bloom filter check in parallel using distribution's BatchGet.
+// IMPORTANT: Caller must ensure segments are protected (e.g., via Pin) during this call,
+// otherwise candidates may be released concurrently leading to use-after-free.
 func (sd *shardDelegator) applyBFInParallel(deleteDatas []*DeleteData, pool *conc.Pool[any]) *typeutil.ConcurrentMap[int, *BatchApplyRet] {
 	retIdx := 0
 	retMap := typeutil.NewConcurrentMap[int, *BatchApplyRet]()
@@ -245,7 +248,7 @@ func (sd *shardDelegator) applyBFInParallel(deleteDatas []*DeleteData, pool *con
 			deleteDataId := didx
 			partitionID := data.PartitionID
 			future := pool.Submit(func() (any, error) {
-				ret := sd.pkOracle.BatchGet(pks[startIdx:endIdx], pkoracle.WithPartitionID(partitionID))
+				ret := sd.distribution.BatchGet(pks[startIdx:endIdx], partitionID)
 				retMap.Insert(tmpRetIndex, &BatchApplyRet{
 					DeleteDataIdx: deleteDataId,
 					StartIdx:      startIdx,
@@ -377,7 +380,6 @@ func (sd *shardDelegator) LoadGrowing(ctx context.Context, infos []*querypb.Segm
 	log.Info("load growing segments done", zap.Int64s("segmentIDs", segmentIDs))
 
 	for _, segment := range loaded {
-		sd.pkOracle.Register(segment, paramtable.GetNodeID())
 		if sd.idfOracle != nil {
 			sd.idfOracle.RegisterGrowing(segment.ID(), segment.GetBM25Stats())
 		}
@@ -389,6 +391,7 @@ func (sd *shardDelegator) LoadGrowing(ctx context.Context, infos []*querypb.Segm
 			PartitionID:   segment.Partition(),
 			Version:       version,
 			TargetVersion: sd.distribution.getTargetVersion(),
+			Candidate:     segment, // growing segment itself is the Candidate
 		}
 	})...)
 	return nil
@@ -521,18 +524,8 @@ func (sd *shardDelegator) LoadSegments(ctx context.Context, req *querypb.LoadSeg
 		return nil
 	}
 
-	entries := lo.Map(req.GetInfos(), func(info *querypb.SegmentLoadInfo, _ int) SegmentEntry {
-		return SegmentEntry{
-			SegmentID:   info.GetSegmentID(),
-			PartitionID: info.GetPartitionID(),
-			NodeID:      req.GetDstNodeID(),
-			Version:     req.GetVersion(),
-			Level:       info.GetLevel(),
-		}
-	})
-
 	infos := lo.Filter(req.GetInfos(), func(info *querypb.SegmentLoadInfo, _ int) bool {
-		return !sd.pkOracle.Exists(pkoracle.NewCandidateKey(info.GetSegmentID(), info.GetPartitionID(), commonpb.SegmentState_Sealed), targetNodeID)
+		return !sd.distribution.SealedSegmentExistsOnNode(info.GetSegmentID(), targetNodeID)
 	})
 
 	candidates, err := sd.loader.LoadBloomFilterSet(ctx, req.GetCollectionID(), infos...)
@@ -554,12 +547,28 @@ func (sd *shardDelegator) LoadSegments(ctx context.Context, req *querypb.LoadSeg
 		return err
 	}
 
-	// add candidate after load success
+	// Build a map from segmentID to BloomFilterSet
+	bfMap := make(map[int64]pkoracle.Candidate)
 	for _, candidate := range candidates {
-		log.Info("register sealed segment bfs into pko candidates",
+		log.Info("loaded bloom filter set for sealed segment",
 			zap.Int64("segmentID", candidate.ID()),
 		)
-		sd.pkOracle.Register(candidate, targetNodeID)
+		bfMap[candidate.ID()] = candidate
+	}
+
+	// Build entries with Candidate - use filtered infos instead of req.GetInfos()
+	// This ensures we only add entries for segments that were actually loaded (not skipped as duplicates)
+	entries := make([]SegmentEntry, 0, len(infos))
+	for _, info := range infos {
+		entry := SegmentEntry{
+			SegmentID:   info.GetSegmentID(),
+			PartitionID: info.GetPartitionID(),
+			NodeID:      req.GetDstNodeID(),
+			Version:     req.GetVersion(),
+			Level:       info.GetLevel(),
+			Candidate:   bfMap[info.GetSegmentID()],
+		}
+		entries = append(entries, entry)
 	}
 
 	return sd.addDistributionIfVersionOK(req.GetLoadMeta().GetSchemaVersion(), entries...)
@@ -862,19 +871,9 @@ func (sd *shardDelegator) ReleaseSegments(ctx context.Context, req *querypb.Rele
 	})
 	sd.AddExcludedSegments(droppedInfos)
 
-	if len(sealed) > 0 {
-		sd.pkOracle.Remove(
-			pkoracle.WithSegmentIDs(lo.Map(sealed, func(entry SegmentEntry, _ int) int64 { return entry.SegmentID })...),
-			pkoracle.WithSegmentType(commonpb.SegmentState_Sealed),
-			pkoracle.WithWorkerID(targetNodeID),
-		)
-	}
-	if len(growing) > 0 {
-		sd.pkOracle.Remove(
-			pkoracle.WithSegmentIDs(lo.Map(growing, func(entry SegmentEntry, _ int) int64 { return entry.SegmentID })...),
-			pkoracle.WithSegmentType(commonpb.SegmentState_Growing),
-		)
-	}
+	// Note: Candidate cleanup is handled by RemoveDistributions above
+	// - Sealed segment candidates (BloomFilterSet) are refunded in RemoveDistributions
+	// - Growing segment candidates (LocalSegment) are managed by segmentManager.Release()
 
 	var releaseErr error
 	if !force {

--- a/internal/querynodev2/delegator/delegator_data_test.go
+++ b/internal/querynodev2/delegator/delegator_data_test.go
@@ -538,8 +538,10 @@ func (s *DelegatorDataSuite) TestProcessDelete() {
 	s.True(s.delegator.distribution.Serviceable())
 
 	s.delegator.Close()
-	// After Close(), distribution candidates are cleared, so ProcessDelete becomes a no-op.
+	// After Close(), ProcessDelete becomes a no-op because sd.Stopped() returns true.
 	// This is expected behavior - the delegator is being decommissioned.
+	// Note: Serviceable() state is not changed by ProcessDelete when delegator is stopped,
+	// since ProcessDelete returns early without processing any deletes.
 	s.delegator.ProcessDelete([]*DeleteData{
 		{
 			PartitionID: 500,
@@ -549,7 +551,8 @@ func (s *DelegatorDataSuite) TestProcessDelete() {
 		},
 	}, 10)
 	s.Require().NoError(err)
-	s.False(s.delegator.distribution.Serviceable())
+	// Serviceable state remains unchanged since ProcessDelete is a no-op after Close()
+	s.True(s.delegator.distribution.Serviceable())
 }
 
 func (s *DelegatorDataSuite) TestLoadGrowingWithBM25() {

--- a/internal/querynodev2/delegator/delegator_data_test.go
+++ b/internal/querynodev2/delegator/delegator_data_test.go
@@ -61,6 +61,25 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
 
+// segmentEntryCoreFields extracts core fields from SegmentEntry for comparison,
+// excluding Candidate field which varies between tests.
+func segmentEntryCoreFields(entries []SegmentEntry) []SegmentEntry {
+	result := make([]SegmentEntry, len(entries))
+	for i, e := range entries {
+		result[i] = SegmentEntry{
+			NodeID:        e.NodeID,
+			SegmentID:     e.SegmentID,
+			PartitionID:   e.PartitionID,
+			Version:       e.Version,
+			TargetVersion: e.TargetVersion,
+			Level:         e.Level,
+			Offline:       e.Offline,
+			// Candidate is intentionally excluded
+		}
+	}
+	return result
+}
+
 type DelegatorDataSuite struct {
 	suite.Suite
 
@@ -519,6 +538,8 @@ func (s *DelegatorDataSuite) TestProcessDelete() {
 	s.True(s.delegator.distribution.Serviceable())
 
 	s.delegator.Close()
+	// After Close(), distribution candidates are cleared, so ProcessDelete becomes a no-op.
+	// This is expected behavior - the delegator is being decommissioned.
 	s.delegator.ProcessDelete([]*DeleteData{
 		{
 			PartitionID: 500,
@@ -536,9 +557,10 @@ func (s *DelegatorDataSuite) TestLoadGrowingWithBM25() {
 	mockSegment := segments.NewMockSegment(s.T())
 	s.loader.EXPECT().Load(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]segments.Segment{mockSegment}, nil)
 
-	mockSegment.EXPECT().Partition().Return(111)
-	mockSegment.EXPECT().ID().Return(111)
-	mockSegment.EXPECT().Type().Return(commonpb.SegmentState_Growing)
+	mockSegment.EXPECT().Partition().Return(int64(111))
+	mockSegment.EXPECT().ID().Return(int64(111))
+	// Note: Type() is no longer called since pkOracle was removed
+	// Candidate is now stored directly in SegmentEntry
 	mockSegment.EXPECT().GetBM25Stats().Return(map[int64]*storage.BM25Stats{})
 
 	err := s.delegator.LoadGrowing(context.Background(), []*querypb.SegmentLoadInfo{{SegmentID: 1}}, 1)
@@ -609,7 +631,7 @@ func (s *DelegatorDataSuite) TestLoadSegmentsWithBm25() {
 				TargetVersion: unreadableTargetVersion,
 				Level:         datapb.SegmentLevel_L1,
 			},
-		}, sealed[0].Segments)
+		}, segmentEntryCoreFields(sealed[0].Segments))
 	})
 
 	s.Run("loadBM25_failed", func() {
@@ -709,7 +731,7 @@ func (s *DelegatorDataSuite) TestLoadSegments() {
 				TargetVersion: unreadableTargetVersion,
 				Level:         datapb.SegmentLevel_L1,
 			},
-		}, sealed[0].Segments)
+		}, segmentEntryCoreFields(sealed[0].Segments))
 	})
 
 	s.Run("load_segments_with_delete", func() {
@@ -1278,7 +1300,7 @@ func (s *DelegatorDataSuite) TestReleaseSegment() {
 			PartitionID:   500,
 			TargetVersion: unreadableTargetVersion,
 		},
-	}, sealed[0].Segments)
+	}, segmentEntryCoreFields(sealed[0].Segments))
 
 	s.ElementsMatch([]SegmentEntry{
 		{
@@ -1287,7 +1309,7 @@ func (s *DelegatorDataSuite) TestReleaseSegment() {
 			PartitionID:   500,
 			TargetVersion: unreadableTargetVersion,
 		},
-	}, growing)
+	}, segmentEntryCoreFields(growing))
 
 	err = s.delegator.ReleaseSegments(ctx, &querypb.ReleaseSegmentsRequest{
 		Base:       commonpbutil.NewMsgBase(),

--- a/internal/querynodev2/delegator/delta_forward.go
+++ b/internal/querynodev2/delegator/delta_forward.go
@@ -194,7 +194,8 @@ func (sd *shardDelegator) forwardStreamingByBF(ctx context.Context, deleteData [
 	sealed, growing, version := sd.distribution.PinOnlineSegments()
 
 	start := time.Now()
-	retMap := sd.applyBFInParallel(deleteData, segments.GetBFApplyPool())
+	// Pass pinned segments to ensure consistency between BF check and delete application
+	retMap := sd.applyBFInParallel(deleteData, segments.GetBFApplyPool(), sealed, growing)
 	// segment => delete data
 	delRecords := make(map[int64]DeleteData)
 	retMap.Range(func(key int, value *BatchApplyRet) bool {

--- a/internal/querynodev2/delegator/distribution.go
+++ b/internal/querynodev2/delegator/distribution.go
@@ -23,6 +23,9 @@ import (
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
 
+	"github.com/milvus-io/milvus/internal/querynodev2/pkoracle"
+	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/querypb"
@@ -133,6 +136,12 @@ type SegmentEntry struct {
 	TargetVersion int64
 	Level         datapb.SegmentLevel
 	Offline       bool // if delegator failed to execute forwardDelete/Query/Search on segment, it will be offline
+
+	// Candidate for PK existence check (BF query)
+	// - For sealed segments: *pkoracle.BloomFilterSet
+	// - For growing segments: segments.Segment (LocalSegment)
+	// Note: nil for offline segments or L0 segments
+	Candidate pkoracle.Candidate
 }
 
 func NewDistribution(channelName string, queryView *channelQueryView) *distribution {
@@ -327,7 +336,7 @@ func (d *distribution) updateServiceable(triggerAction string) {
 // AddDistributions add multiple segment entries.
 func (d *distribution) AddDistributions(entries ...SegmentEntry) {
 	d.mut.Lock()
-	defer d.mut.Unlock()
+	var toRefund []pkoracle.Candidate
 
 	for _, entry := range entries {
 		oldEntry, ok := d.sealedSegments[entry.SegmentID]
@@ -339,12 +348,20 @@ func (d *distribution) AddDistributions(entries ...SegmentEntry) {
 				zap.Int64("newVersion", entry.Version),
 				zap.Int64("newNode", entry.NodeID),
 			)
+			// if new entry has candidate but we skip it, refund the new candidate
+			if entry.Candidate != nil {
+				toRefund = append(toRefund, entry.Candidate)
+			}
 			continue
 		}
 
 		if ok {
 			// remain the target version for already loaded segment to void skipping this segment when executing search
 			entry.TargetVersion = oldEntry.TargetVersion
+			// if old entry has candidate and we're replacing it, refund old candidate
+			if oldEntry.Candidate != nil {
+				toRefund = append(toRefund, oldEntry.Candidate)
+			}
 		} else {
 			entry.TargetVersion = unreadableTargetVersion
 		}
@@ -353,6 +370,19 @@ func (d *distribution) AddDistributions(entries ...SegmentEntry) {
 
 	d.genSnapshot()
 	d.updateServiceable("AddDistributions")
+	d.mut.Unlock()
+
+	// refund old candidates after releasing lock (synchronous to avoid use-after-free)
+	refundCandidates(toRefund)
+}
+
+// refundCandidates refunds resources for candidates that implement Refundable.
+func refundCandidates(candidates []pkoracle.Candidate) {
+	for _, c := range candidates {
+		if r, ok := c.(pkoracle.Refundable); ok {
+			r.Refund()
+		}
+	}
 }
 
 // AddGrowing adds growing segment distribution.
@@ -480,7 +510,7 @@ func (d *distribution) GetQueryView() *channelQueryView {
 // RemoveDistributions remove segments distributions and returns the clear signal channel.
 func (d *distribution) RemoveDistributions(sealedSegments []SegmentEntry, growingSegments []SegmentEntry) chan struct{} {
 	d.mut.Lock()
-	defer d.mut.Unlock()
+	var toRefund []pkoracle.Candidate
 
 	for _, sealed := range sealedSegments {
 		entry, ok := d.sealedSegments[sealed.SegmentID]
@@ -488,6 +518,10 @@ func (d *distribution) RemoveDistributions(sealedSegments []SegmentEntry, growin
 			continue
 		}
 		if entry.NodeID == sealed.NodeID || sealed.NodeID == wildcardNodeID {
+			// collect candidate before deletion
+			if entry.Candidate != nil {
+				toRefund = append(toRefund, entry.Candidate)
+			}
 			delete(d.sealedSegments, sealed.SegmentID)
 		}
 	}
@@ -497,7 +531,9 @@ func (d *distribution) RemoveDistributions(sealedSegments []SegmentEntry, growin
 		if !ok {
 			continue
 		}
-
+		// Note: growing segment's Candidate (LocalSegment) is NOT refunded here
+		// because the segment lifecycle is managed by segmentManager
+		// The BF inside LocalSegment will be cleaned when segment.Release() is called
 		delete(d.growingSegments, growing.SegmentID)
 	}
 
@@ -505,12 +541,19 @@ func (d *distribution) RemoveDistributions(sealedSegments []SegmentEntry, growin
 		zap.String("channelName", d.channelName),
 		zap.Int64s("growing", lo.Map(growingSegments, func(s SegmentEntry, _ int) int64 { return s.SegmentID })),
 		zap.Int64s("sealed", lo.Map(sealedSegments, func(s SegmentEntry, _ int) int64 { return s.SegmentID })),
+		zap.Int("sealedCandidatesRefunded", len(toRefund)),
 	)
 
 	d.updateServiceable("RemoveDistributions")
 	// wait previous read even not distribution changed
 	// in case of segment balance caused segment lost track
-	return d.genSnapshot()
+	signal := d.genSnapshot()
+	d.mut.Unlock()
+
+	// refund sealed segment candidates after releasing lock (synchronous to avoid use-after-free)
+	refundCandidates(toRefund)
+
+	return signal
 }
 
 // getSnapshot converts current distribution to snapshot format.
@@ -581,4 +624,84 @@ func (d *distribution) getCleanup(version int64) snapshotCleanup {
 	return func() {
 		d.snapshots.GetAndRemove(version)
 	}
+}
+
+// SealedSegmentExists checks if a sealed segment exists in distribution.
+func (d *distribution) SealedSegmentExists(segmentID int64) bool {
+	d.mut.RLock()
+	defer d.mut.RUnlock()
+	_, ok := d.sealedSegments[segmentID]
+	return ok
+}
+
+// SealedSegmentExistsOnNode checks if a sealed segment exists on a specific node.
+func (d *distribution) SealedSegmentExistsOnNode(segmentID int64, nodeID int64) bool {
+	d.mut.RLock()
+	defer d.mut.RUnlock()
+	entry, ok := d.sealedSegments[segmentID]
+	return ok && entry.NodeID == nodeID
+}
+
+// GrowingSegmentExists checks if a growing segment exists in distribution.
+func (d *distribution) GrowingSegmentExists(segmentID int64) bool {
+	d.mut.RLock()
+	defer d.mut.RUnlock()
+	_, ok := d.growingSegments[segmentID]
+	return ok
+}
+
+// BatchGet performs batch PK existence check across all candidates in distribution.
+// Returns map[segmentID][]bool indicating which PKs exist in each segment.
+// Caller should Pin before calling and Unpin after to ensure candidates are protected.
+func (d *distribution) BatchGet(pks []storage.PrimaryKey, partitionID int64) map[int64][]bool {
+	d.mut.RLock()
+	defer d.mut.RUnlock()
+
+	result := make(map[int64][]bool)
+	lc := storage.NewBatchLocationsCache(pks)
+
+	// Check sealed segments
+	for _, entry := range d.sealedSegments {
+		if entry.Offline || entry.Candidate == nil {
+			continue
+		}
+		if partitionID != common.AllPartitionsID && entry.Candidate.Partition() != partitionID {
+			continue
+		}
+		result[entry.SegmentID] = entry.Candidate.BatchPkExist(lc)
+	}
+
+	// Check growing segments
+	for _, entry := range d.growingSegments {
+		if entry.Candidate == nil {
+			continue
+		}
+		if partitionID != common.AllPartitionsID && entry.Candidate.Partition() != partitionID {
+			continue
+		}
+		result[entry.SegmentID] = entry.Candidate.BatchPkExist(lc)
+	}
+
+	return result
+}
+
+// RefundAllCandidates refunds resources for all sealed segment candidates.
+// Used during shutdown to clean up and refund resources.
+// Note: Growing segment candidates (LocalSegment) are managed by segmentManager.
+func (d *distribution) RefundAllCandidates() {
+	d.mut.Lock()
+	var toRefund []pkoracle.Candidate
+
+	// Only refund sealed segment candidates
+	// Growing segment candidates (LocalSegment) are managed by segmentManager
+	for segmentID, entry := range d.sealedSegments {
+		if entry.Candidate != nil {
+			toRefund = append(toRefund, entry.Candidate)
+			entry.Candidate = nil
+			d.sealedSegments[segmentID] = entry
+		}
+	}
+	d.mut.Unlock()
+
+	refundCandidates(toRefund)
 }

--- a/internal/querynodev2/delegator/distribution_test.go
+++ b/internal/querynodev2/delegator/distribution_test.go
@@ -25,6 +25,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
@@ -1661,4 +1664,216 @@ func TestPinReadableSegments_PartialResultNotEmpty(t *testing.T) {
 	// Before the fix, this would return 0 because segments were filtered by target version
 	// After the fix, this returns 2 because segments are filtered by query view's segment list
 	assert.Equal(t, 2, actualSealedCount, "Should return segments filtered by query view, not empty list")
+}
+
+// mockCandidate is a mock implementation of pkoracle.Candidate for testing BatchGet.
+type mockCandidate struct {
+	id        int64
+	partition int64
+	hits      []bool
+}
+
+func (m *mockCandidate) MayPkExist(lc *storage.LocationsCache) bool {
+	return true
+}
+
+func (m *mockCandidate) BatchPkExist(lc *storage.BatchLocationsCache) []bool {
+	return m.hits
+}
+
+func (m *mockCandidate) ID() int64 {
+	return m.id
+}
+
+func (m *mockCandidate) Partition() int64 {
+	return m.partition
+}
+
+func (m *mockCandidate) Type() commonpb.SegmentState {
+	return commonpb.SegmentState_Sealed
+}
+
+func TestDistribution_BatchGet(t *testing.T) {
+	paramtable.Init()
+
+	t.Run("basic_batch_get", func(t *testing.T) {
+		dist := NewDistribution("test-channel", NewChannelQueryView(nil, nil, []int64{1}, initialTargetVersion))
+
+		// Add sealed segments with candidates
+		candidate1 := &mockCandidate{id: 1, partition: 1, hits: []bool{true, false, true}}
+		candidate2 := &mockCandidate{id: 2, partition: 1, hits: []bool{false, true, false}}
+
+		dist.AddDistributions(
+			SegmentEntry{NodeID: 1, SegmentID: 1, PartitionID: 1, Version: 1, Candidate: candidate1},
+			SegmentEntry{NodeID: 1, SegmentID: 2, PartitionID: 1, Version: 1, Candidate: candidate2},
+		)
+
+		pks := []storage.PrimaryKey{
+			storage.NewInt64PrimaryKey(100),
+			storage.NewInt64PrimaryKey(200),
+			storage.NewInt64PrimaryKey(300),
+		}
+
+		result := dist.BatchGet(pks, common.AllPartitionsID)
+
+		assert.Len(t, result, 2)
+		assert.Equal(t, []bool{true, false, true}, result[1])
+		assert.Equal(t, []bool{false, true, false}, result[2])
+	})
+
+	t.Run("filter_by_partition", func(t *testing.T) {
+		dist := NewDistribution("test-channel", NewChannelQueryView(nil, nil, []int64{1, 2}, initialTargetVersion))
+
+		candidate1 := &mockCandidate{id: 1, partition: 1, hits: []bool{true}}
+		candidate2 := &mockCandidate{id: 2, partition: 2, hits: []bool{false}}
+
+		dist.AddDistributions(
+			SegmentEntry{NodeID: 1, SegmentID: 1, PartitionID: 1, Version: 1, Candidate: candidate1},
+			SegmentEntry{NodeID: 1, SegmentID: 2, PartitionID: 2, Version: 1, Candidate: candidate2},
+		)
+
+		pks := []storage.PrimaryKey{storage.NewInt64PrimaryKey(100)}
+
+		// Filter by partition 1
+		result := dist.BatchGet(pks, 1)
+		assert.Len(t, result, 1)
+		assert.Contains(t, result, int64(1))
+		assert.NotContains(t, result, int64(2))
+	})
+
+	t.Run("skip_offline_segments", func(t *testing.T) {
+		dist := NewDistribution("test-channel", NewChannelQueryView(nil, nil, []int64{1}, initialTargetVersion))
+
+		candidate1 := &mockCandidate{id: 1, partition: 1, hits: []bool{true}}
+
+		dist.AddDistributions(
+			SegmentEntry{NodeID: 1, SegmentID: 1, PartitionID: 1, Version: 1, Candidate: candidate1},
+		)
+
+		// Mark segment offline
+		dist.MarkOfflineSegments(1)
+
+		pks := []storage.PrimaryKey{storage.NewInt64PrimaryKey(100)}
+		result := dist.BatchGet(pks, common.AllPartitionsID)
+
+		// Offline segment should be skipped
+		assert.Empty(t, result)
+	})
+
+	t.Run("skip_nil_candidates", func(t *testing.T) {
+		dist := NewDistribution("test-channel", NewChannelQueryView(nil, nil, []int64{1}, initialTargetVersion))
+
+		// Add segment without candidate
+		dist.AddDistributions(
+			SegmentEntry{NodeID: 1, SegmentID: 1, PartitionID: 1, Version: 1, Candidate: nil},
+		)
+
+		pks := []storage.PrimaryKey{storage.NewInt64PrimaryKey(100)}
+		result := dist.BatchGet(pks, common.AllPartitionsID)
+
+		// Segment without candidate should be skipped
+		assert.Empty(t, result)
+	})
+
+	t.Run("growing_segments", func(t *testing.T) {
+		dist := NewDistribution("test-channel", NewChannelQueryView(nil, nil, []int64{1}, initialTargetVersion))
+
+		growingCandidate := &mockCandidate{id: 10, partition: 1, hits: []bool{true, true}}
+
+		dist.AddGrowing(
+			SegmentEntry{NodeID: 1, SegmentID: 10, PartitionID: 1, Version: 1, Candidate: growingCandidate},
+		)
+
+		pks := []storage.PrimaryKey{
+			storage.NewInt64PrimaryKey(100),
+			storage.NewInt64PrimaryKey(200),
+		}
+
+		result := dist.BatchGet(pks, common.AllPartitionsID)
+
+		assert.Len(t, result, 1)
+		assert.Equal(t, []bool{true, true}, result[10])
+	})
+
+	t.Run("mixed_sealed_and_growing", func(t *testing.T) {
+		dist := NewDistribution("test-channel", NewChannelQueryView(nil, nil, []int64{1}, initialTargetVersion))
+
+		sealedCandidate := &mockCandidate{id: 1, partition: 1, hits: []bool{true, false}}
+		growingCandidate := &mockCandidate{id: 10, partition: 1, hits: []bool{false, true}}
+
+		dist.AddDistributions(
+			SegmentEntry{NodeID: 1, SegmentID: 1, PartitionID: 1, Version: 1, Candidate: sealedCandidate},
+		)
+		dist.AddGrowing(
+			SegmentEntry{NodeID: 1, SegmentID: 10, PartitionID: 1, Version: 1, Candidate: growingCandidate},
+		)
+
+		pks := []storage.PrimaryKey{
+			storage.NewInt64PrimaryKey(100),
+			storage.NewInt64PrimaryKey(200),
+		}
+
+		result := dist.BatchGet(pks, common.AllPartitionsID)
+
+		assert.Len(t, result, 2)
+		assert.Equal(t, []bool{true, false}, result[1])
+		assert.Equal(t, []bool{false, true}, result[10])
+	})
+}
+
+func TestDistribution_SealedSegmentExistsOnNode(t *testing.T) {
+	t.Run("segment_exists_on_correct_node", func(t *testing.T) {
+		dist := NewDistribution("test-channel", NewChannelQueryView(nil, nil, []int64{1}, initialTargetVersion))
+
+		dist.AddDistributions(
+			SegmentEntry{NodeID: 1, SegmentID: 100, PartitionID: 1, Version: 1},
+			SegmentEntry{NodeID: 2, SegmentID: 200, PartitionID: 1, Version: 1},
+		)
+
+		// Segment 100 exists on node 1
+		assert.True(t, dist.SealedSegmentExistsOnNode(100, 1))
+		// Segment 100 does not exist on node 2
+		assert.False(t, dist.SealedSegmentExistsOnNode(100, 2))
+		// Segment 200 exists on node 2
+		assert.True(t, dist.SealedSegmentExistsOnNode(200, 2))
+		// Segment 200 does not exist on node 1
+		assert.False(t, dist.SealedSegmentExistsOnNode(200, 1))
+	})
+
+	t.Run("segment_not_exists", func(t *testing.T) {
+		dist := NewDistribution("test-channel", NewChannelQueryView(nil, nil, []int64{1}, initialTargetVersion))
+
+		dist.AddDistributions(
+			SegmentEntry{NodeID: 1, SegmentID: 100, PartitionID: 1, Version: 1},
+		)
+
+		// Non-existent segment
+		assert.False(t, dist.SealedSegmentExistsOnNode(999, 1))
+		assert.False(t, dist.SealedSegmentExistsOnNode(999, 2))
+	})
+
+	t.Run("empty_distribution", func(t *testing.T) {
+		dist := NewDistribution("test-channel", NewChannelQueryView(nil, nil, []int64{1}, initialTargetVersion))
+
+		assert.False(t, dist.SealedSegmentExistsOnNode(100, 1))
+	})
+
+	t.Run("segment_migrated_to_different_node", func(t *testing.T) {
+		dist := NewDistribution("test-channel", NewChannelQueryView(nil, nil, []int64{1}, initialTargetVersion))
+
+		// Initial: segment 100 on node 1
+		dist.AddDistributions(
+			SegmentEntry{NodeID: 1, SegmentID: 100, PartitionID: 1, Version: 1},
+		)
+		assert.True(t, dist.SealedSegmentExistsOnNode(100, 1))
+		assert.False(t, dist.SealedSegmentExistsOnNode(100, 2))
+
+		// Migration: segment 100 moved to node 2 with higher version
+		dist.AddDistributions(
+			SegmentEntry{NodeID: 2, SegmentID: 100, PartitionID: 1, Version: 2},
+		)
+		// After migration, segment should be on node 2, not node 1
+		assert.False(t, dist.SealedSegmentExistsOnNode(100, 1))
+		assert.True(t, dist.SealedSegmentExistsOnNode(100, 2))
+	})
 }

--- a/internal/querynodev2/delegator/distribution_test.go
+++ b/internal/querynodev2/delegator/distribution_test.go
@@ -1754,7 +1754,7 @@ func TestBatchGetFromSegments(t *testing.T) {
 				NodeID: 1,
 				Segments: []SegmentEntry{
 					{SegmentID: 1, PartitionID: 1, Candidate: candidate1, Offline: true}, // offline
-					{SegmentID: 2, PartitionID: 1, Candidate: nil},                        // nil candidate
+					{SegmentID: 2, PartitionID: 1, Candidate: nil},                       // nil candidate
 				},
 			},
 		}

--- a/internal/querynodev2/pkoracle/candidate.go
+++ b/internal/querynodev2/pkoracle/candidate.go
@@ -34,6 +34,12 @@ type Candidate interface {
 	Type() commonpb.SegmentState
 }
 
+// Refundable is an optional interface for candidates that need resource cleanup.
+// BloomFilterSet implements this interface to refund charged memory resources.
+type Refundable interface {
+	Refund()
+}
+
 type candidateWithWorker struct {
 	Candidate
 	workerID int64


### PR DESCRIPTION

## Summary

- Fix bloom filter leak when worker node crashes by merging pkOracle and distribution management
- Add Candidate field to SegmentEntry for BF lifecycle management
- Add BatchGet to distribution for PK existence check
- Add refund logic in AddDistributions and RemoveDistributions

## Problem

When loading segments on remote worker (qnB) via delegator (qnA), the BloomFilterSet is registered in pkOracle and cleaned up during ReleaseSegment. However, if qnB crashes directly, ReleaseSegment is never triggered, causing bloom filters to leak in pkOracle.

**Root cause**: pkOracle uses `SegmentType_channelName_workerID` as map key, binding the key to worker ID. When worker crashes, leaked resources cannot be cleaned up.

**Impact**:
- Accumulated bloom filters severely slow down delete msg processing
- Causes high tsafe latency
- Affects strong consistency query latency, leading to slow queries

**Affected versions**: 2.4 / 2.5 / 2.6

## Test plan

- [x] Unit tests pass: `TestDelegatorDataSuite/TestProcessDelete`
- [x] Distribution tests pass: `TestDistribution*`
- [x] New test added: `TestDistribution_SealedSegmentExistsOnNode`

issue: #47449
pr: #47450

Cherry-picked from master PR #47450

🤖 Generated with [Claude Code](https://claude.com/claude-code)