### PR TITLE
fix: less empty time tick filtering interval

### DIFF
--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -6959,9 +6959,9 @@ If the schema is older than (the channel checkpoint - tolerance), it will be rem
 	p.DelegatorEmptyTimeTickMaxFilterInterval = ParamItem{
 		Key:     "streaming.delegator.emptyTimeTick.maxFilterInterval",
 		Version: "2.6.9",
-		Doc: `The max filter interval for empty time tick of delegator, 1m by default.
+		Doc: `The max filter interval for empty time tick of delegator, 2s by default.
 If the interval since last timetick is less than this config, the empty time tick will be filtered.`,
-		DefaultValue: "1m",
+		DefaultValue: "2s",
 		Export:       false,
 	}
 	p.DelegatorEmptyTimeTickMaxFilterInterval.Init(base.mgr)

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -711,7 +711,7 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, 10*time.Minute, params.StreamingCfg.FlushL0MaxLifetime.GetAsDurationByParse())
 		assert.Equal(t, 500000, params.StreamingCfg.FlushL0MaxRowNum.GetAsInt())
 		assert.Equal(t, int64(32*1024*1024), params.StreamingCfg.FlushL0MaxSize.GetAsSize())
-		assert.Equal(t, 1*time.Minute, params.StreamingCfg.DelegatorEmptyTimeTickMaxFilterInterval.GetAsDurationByParse())
+		assert.Equal(t, 2*time.Second, params.StreamingCfg.DelegatorEmptyTimeTickMaxFilterInterval.GetAsDurationByParse())
 		assert.Equal(t, 1*time.Second, params.StreamingCfg.FlushEmptyTimeTickMaxFilterInterval.GetAsDurationByParse())
 		assert.Equal(t, 0, params.StreamingCfg.WALBalancerExpectedInitialStreamingNodeNum.GetAsInt())
 


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/46540
pr: https://github.com/milvus-io/milvus/pull/47470