### PR TITLE
fix: [2.6] Fill log & memory size in TextIndexStats meta (#47435)

### DIFF
--- a/internal/datanode/compactor/sort_compaction.go
+++ b/internal/datanode/compactor/sort_compaction.go
@@ -486,11 +486,14 @@ func (t *sortCompactionTask) createTextIndex(ctx context.Context,
 			}
 
 			mu.Lock()
+			totalSize := lo.SumBy(lo.Values(uploaded), func(fileSize int64) int64 { return fileSize })
 			textIndexLogs[field.GetFieldID()] = &datapb.TextIndexStats{
-				FieldID: field.GetFieldID(),
-				Version: 0,
-				BuildID: taskID,
-				Files:   lo.Keys(uploaded),
+				FieldID:    field.GetFieldID(),
+				Version:    0,
+				BuildID:    taskID,
+				Files:      lo.Keys(uploaded),
+				LogSize:    totalSize,
+				MemorySize: totalSize,
 			}
 			mu.Unlock()
 

--- a/internal/datanode/index/task_stats.go
+++ b/internal/datanode/index/task_stats.go
@@ -509,11 +509,14 @@ func (st *statsTask) createTextIndex(ctx context.Context,
 			}
 
 			mu.Lock()
+			totalSize := lo.SumBy(lo.Values(uploaded), func(fileSize int64) int64 { return fileSize })
 			textIndexLogs[field.GetFieldID()] = &datapb.TextIndexStats{
-				FieldID: field.GetFieldID(),
-				Version: version,
-				BuildID: taskID,
-				Files:   lo.Keys(uploaded),
+				FieldID:    field.GetFieldID(),
+				Version:    version,
+				BuildID:    taskID,
+				Files:      lo.Keys(uploaded),
+				LogSize:    totalSize,
+				MemorySize: totalSize,
 			}
 			mu.Unlock()
 


### PR DESCRIPTION
Cherry-pick from master
pr: #47435
Related to #47434

This PR fixes size not recorded by filling total size in stats task and sort compaction logic.