### PR TITLE
fix: use {} placeholder in LOG_* macros to avoid treating error as format string

### DIFF
--- a/internal/core/src/config/ConfigKnowhere.cpp
+++ b/internal/core/src/config/ConfigKnowhere.cpp
@@ -66,7 +66,7 @@ KnowhereSetSimdType(const char* value) {
     try {
         return knowhere::KnowhereConfig::SetSimdType(simd_type);
     } catch (std::exception& e) {
-        LOG_ERROR(e.what());
+        LOG_ERROR("{}", e.what());
         ThrowInfo(ConfigInvalid, e.what());
     }
 }

--- a/internal/core/src/exec/Driver.cpp
+++ b/internal/core/src/exec/Driver.cpp
@@ -254,7 +254,7 @@ Driver::Next(std::shared_ptr<BlockingState>& blocking_state) {
             operator->get_plannode_id(),                           \
             e.what(),                                              \
             stack_trace);                                          \
-        LOG_ERROR(err_msg);                                        \
+        LOG_ERROR("{}", err_msg);                                  \
         throw ExecOperatorException(err_msg);                      \
     }
 

--- a/internal/core/src/index/Utils.cpp
+++ b/internal/core/src/index/Utils.cpp
@@ -134,7 +134,7 @@ GetDimFromConfig(const Config& config) {
     } catch (const std::logic_error& e) {
         auto err_message = fmt::format(
             "invalided dimension:{}, error:{}", dimension.value(), e.what());
-        LOG_ERROR(err_message);
+        LOG_ERROR("{}", err_message);
         throw std::logic_error(err_message);
     }
 }
@@ -166,7 +166,7 @@ GetIndexEngineVersionFromConfig(const Config& config) {
             fmt::format("invalided index engine version:{}, error:{}",
                         index_engine_version.value(),
                         e.what());
-        LOG_ERROR(err_message);
+        LOG_ERROR("{}", err_message);
         throw std::logic_error(err_message);
     }
 }
@@ -183,7 +183,7 @@ GetBitmapCardinalityLimitFromConfig(const Config& config) {
         auto err_message = fmt::format("invalided bitmap limit:{}, error:{}",
                                        bitmap_limit.value(),
                                        e.what());
-        LOG_ERROR(err_message);
+        LOG_ERROR("{}", err_message);
         throw std::logic_error(err_message);
     }
 }

--- a/internal/core/src/storage/DiskFileManagerImpl.cpp
+++ b/internal/core/src/storage/DiskFileManagerImpl.cpp
@@ -352,7 +352,7 @@ DiskFileManagerImpl::CacheIndexToDiskInternal(
         } catch (const std::logic_error& e) {
             auto err_message = fmt::format(
                 "invalided index file path:{}, error:{}", file_path, e.what());
-            LOG_ERROR(err_message);
+            LOG_ERROR("{}", err_message);
             throw std::logic_error(err_message);
         }
     }

--- a/internal/core/src/storage/MmapChunkManager.cpp
+++ b/internal/core/src/storage/MmapChunkManager.cpp
@@ -119,7 +119,7 @@ MmapBlock::~MmapBlock() {
         try {
             Close();
         } catch (const std::exception& e) {
-            LOG_ERROR(e.what());
+            LOG_ERROR("{}", e.what());
         }
     }
 }

--- a/internal/core/src/storage/azure/AzureChunkManager.h
+++ b/internal/core/src/storage/azure/AzureChunkManager.h
@@ -49,7 +49,7 @@ ThrowAzureError(const std::string& func,
                 Args&&... args) {
     std::string error_message =
         AzureErrorMessage(func, err, fmt_string, args...);
-    LOG_WARN(error_message);
+    LOG_WARN("{}", error_message);
     throw SegcoreError(S3Error, error_message);
 }
 

--- a/internal/core/src/storage/gcp-native-storage/GcpNativeChunkManager.h
+++ b/internal/core/src/storage/gcp-native-storage/GcpNativeChunkManager.h
@@ -43,7 +43,7 @@ ThrowGcpNativeError(const std::string& func,
                     const std::string& fmt_string,
                     Args&&... args) {
     std::string error_message = GcpErrorMessage(func, err, fmt_string, args...);
-    LOG_WARN(error_message);
+    LOG_WARN("{}", error_message);
     throw SegcoreError(GcpNativeError, error_message);
 }
 

--- a/internal/core/src/storage/minio/MinioChunkManager.cpp
+++ b/internal/core/src/storage/minio/MinioChunkManager.cpp
@@ -238,7 +238,7 @@ MinioChunkManager::PreCheck(const StorageConfig& config) {
             "configuration:{}",
             e.what(),
             config.ToString());
-        LOG_ERROR(err_message);
+        LOG_ERROR("{}", err_message);
         throw SegcoreError(S3Error, err_message);
     } catch (std::exception& e) {
         throw e;

--- a/internal/core/src/storage/minio/MinioChunkManager.h
+++ b/internal/core/src/storage/minio/MinioChunkManager.h
@@ -76,7 +76,7 @@ ThrowS3Error(const std::string& func,
              const std::string& fmt_string,
              Args&&... args) {
     std::string error_message = S3ErrorMessage(func, err, fmt_string, args...);
-    LOG_WARN(error_message);
+    LOG_WARN("{}", error_message);
     throw SegcoreError(S3Error, error_message);
 }
 


### PR DESCRIPTION
issue: #47484