### PR TITLE
fix: add cstdint header for uint32_t

### DIFF
--- a/internal/core/src/index/Meta.h
+++ b/internal/core/src/index/Meta.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "knowhere/comp/index_param.h"
 
 namespace milvus::index {


### PR DESCRIPTION
When executing `make` in Ubuntu 24.04, I get
```
In file included from /home/fanta/source/milvus/internal/core/src/index/ScalarIndex.cpp:21:
/home/fanta/source/milvus/internal/core/src/index/Meta.h:54:11: error: ‘uint32_t’ does not name a type
   54 | constexpr uint32_t TANTIVY_INDEX_LATEST_VERSION = 7;
      |           ^~~~~~~~
/home/fanta/source/milvus/internal/core/src/index/Meta.h:20:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
   19 | #include "knowhere/comp/index_param.h"
  +++ |+#include <cstdint>
   20 | 
/home/fanta/source/milvus/internal/core/src/index/Meta.h:55:11: error: ‘uint32_t’ does not name a type
   55 | constexpr uint32_t TANTIVY_INDEX_MINIMUM_VERSION = 5;
      |           ^~~~~~~~
/home/fanta/source/milvus/internal/core/src/index/Meta.h:55:11: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
```

This patch solves this problem.