### PR TITLE
enhance: switch default balancer to ChannelLevelScoreBalancer [querycoord]

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -400,7 +400,7 @@ queryCoord:
   autoHandoff: true
   autoBalance: true # Switch value to control if to automatically balance the memory usage among query nodes by distributing segment loading and releasing operations evenly.
   autoBalanceChannel: true # Enable auto balance channel
-  balancer: ScoreBasedBalancer # auto balancer used for segments on queryNodes
+  balancer: ChannelLevelScoreBalancer # auto balancer used for segments on queryNodes
   globalRowCountFactor: 0.1 # the weight used when balancing segments among queryNodes
   scoreUnbalanceTolerationFactor: 0.05 # the least value for unbalanced extent between from and to nodes when doing balance
   reverseUnBalanceTolerationFactor: 1.3 # the largest value for unbalanced extent between from and to nodes after doing balance
@@ -444,7 +444,7 @@ queryCoord:
   gracefulStopTimeout: 5 # seconds. force stop node without graceful stop
   enableStoppingBalance: true # whether enable stopping balance
   stoppingBalanceAssignPolicy: ScoreBased # assign policy for stopping balance, options: RoundRobin, RowCount, ScoreBased
-  channelExclusiveNodeFactor: 4 # the least node number for enable channel's exclusive mode
+  channelExclusiveNodeFactor: 1 # the least node number for enable channel's exclusive mode
   collectionObserverInterval: 200 # the interval of collection observer
   checkExecutedFlagInterval: 100 # the interval of check executed flag to force to pull dist
   updateCollectionLoadStatusInterval: 5 # 5m, max interval of updating collection loaded status for check health

--- a/internal/querycoordv2/balance/balancer_factory.go
+++ b/internal/querycoordv2/balance/balancer_factory.go
@@ -127,8 +127,8 @@ func (f *BalancerFactory) GetBalancer() Balance {
 	default:
 		log.Info("Unknown balancer type, using default",
 			zap.String("requested", balanceKey),
-			zap.String("default", meta.ScoreBasedBalancerName))
-		balancer = NewScoreBasedBalancer(f.scheduler, f.nodeManager, f.dist, f.meta, f.targetMgr)
+			zap.String("default", meta.ChannelLevelScoreBalancerName))
+		balancer = NewChannelLevelScoreBalancer(f.scheduler, f.nodeManager, f.dist, f.meta, f.targetMgr)
 	}
 
 	f.balancerMap[balanceKey] = balancer

--- a/internal/querycoordv2/balance/balancer_factory_test.go
+++ b/internal/querycoordv2/balance/balancer_factory_test.go
@@ -1,0 +1,50 @@
+package balance
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/internal/querycoordv2/assign"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+)
+
+func TestBalancerFactory_GetBalancer(t *testing.T) {
+	paramtable.Init()
+	// Init global assign policy factory to avoid panic in ScoreBasedBalancer creation
+	assign.ResetGlobalAssignPolicyFactoryForTest()
+	assign.InitGlobalAssignPolicyFactory(nil, nil, nil, nil, nil)
+
+	// Create a factory with nil dependencies (constructors don't use them immediately)
+	f := NewBalancerFactory(nil, nil, nil, nil, nil)
+
+	t.Run("Test Default Balancer", func(t *testing.T) {
+		// Ensure config is set to default
+		paramtable.Get().Save("queryCoord.balancer", "ChannelLevelScoreBalancer")
+
+		balancer := f.GetBalancer()
+		assert.IsType(t, &ChannelLevelScoreBalancer{}, balancer)
+	})
+
+	t.Run("Test Fallback Logic", func(t *testing.T) {
+		// Set to an unknown balancer name
+		paramtable.Get().Save("queryCoord.balancer", "UnknownBalancerType")
+
+		balancer := f.GetBalancer()
+		// Should fall back to ChannelLevelScoreBalancer
+		assert.IsType(t, &ChannelLevelScoreBalancer{}, balancer)
+	})
+
+	t.Run("Test Explicit ScoreBasedBalancer", func(t *testing.T) {
+		paramtable.Get().Save("queryCoord.balancer", "ScoreBasedBalancer")
+
+		balancer := f.GetBalancer()
+		assert.IsType(t, &ScoreBasedBalancer{}, balancer)
+	})
+
+	t.Run("Test RoundRobinBalancer", func(t *testing.T) {
+		paramtable.Get().Save("queryCoord.balancer", "RoundRobinBalancer")
+		balancer := f.GetBalancer()
+		assert.IsType(t, &RoundRobinBalancer{}, balancer)
+	})
+}

--- a/internal/querycoordv2/meta/replica_manager_test.go
+++ b/internal/querycoordv2/meta/replica_manager_test.go
@@ -174,12 +174,16 @@ func (suite *ReplicaManagerSuite) TestSpawn() {
 	suite.Len(replicas, 0)
 
 	mgr.idAllocator = suite.idAllocator
+
+	// First test with ScoreBasedBalancer (which doesn't populate ChannelNodeInfos)
+	paramtable.Get().Save(paramtable.Get().QueryCoordCfg.Balancer.Key, ScoreBasedBalancerName)
 	replicas, err = mgr.Spawn(ctx, 1, map[string]int{DefaultResourceGroupName: 1}, []string{"channel1", "channel2"}, commonpb.LoadPriority_LOW)
 	suite.NoError(err)
 	for _, replica := range replicas {
 		suite.Len(replica.replicaPB.GetChannelNodeInfos(), 0)
 	}
 
+	// Then test with ChannelLevelScoreBalancer (which populates ChannelNodeInfos)
 	paramtable.Get().Save(paramtable.Get().QueryCoordCfg.Balancer.Key, ChannelLevelScoreBalancerName)
 	defer paramtable.Get().Reset(paramtable.Get().QueryCoordCfg.Balancer.Key)
 	replicas, err = mgr.Spawn(ctx, 2, map[string]int{DefaultResourceGroupName: 1}, []string{"channel1", "channel2"}, commonpb.LoadPriority_LOW)

--- a/internal/querycoordv2/meta/replica_test.go
+++ b/internal/querycoordv2/meta/replica_test.go
@@ -232,6 +232,8 @@ func (suite *ReplicaSuite) testRead(r *Replica) {
 func (suite *ReplicaSuite) TestChannelExclusiveMode() {
 	paramtable.Get().Save(paramtable.Get().QueryCoordCfg.Balancer.Key, ChannelLevelScoreBalancerName)
 	defer paramtable.Get().Reset(paramtable.Get().QueryCoordCfg.Balancer.Key)
+	paramtable.Get().Save(paramtable.Get().QueryCoordCfg.ChannelExclusiveNodeFactor.Key, "4")
+	defer paramtable.Get().Reset(paramtable.Get().QueryCoordCfg.ChannelExclusiveNodeFactor.Key)
 
 	r := newReplica(&querypb.Replica{
 		ID:            1,

--- a/internal/querycoordv2/observers/replica_observer_test.go
+++ b/internal/querycoordv2/observers/replica_observer_test.go
@@ -93,10 +93,17 @@ func (suite *ReplicaObserverSuite) SetupTest() {
 
 	suite.distMgr = meta.NewDistributionManager(suite.nodeMgr)
 	suite.targetMgr = meta.NewMockTargetManager(suite.T())
-	suite.targetMgr.EXPECT().GetDmChannelsByCollection(mock.Anything, mock.Anything, mock.Anything).Return(map[string]*meta.DmChannel{}).Maybe()
+	suite.collectionID = int64(1000)
+	suite.targetMgr.EXPECT().GetDmChannelsByCollection(mock.Anything, mock.Anything, mock.Anything).Return(map[string]*meta.DmChannel{
+		"test-insert-channel1": {
+			VchannelInfo: &datapb.VchannelInfo{
+				CollectionID: suite.collectionID,
+				ChannelName:  "test-insert-channel1",
+			},
+		},
+	}).Maybe()
 	suite.observer = NewReplicaObserver(suite.meta, suite.distMgr, suite.targetMgr)
 	suite.observer.Start()
-	suite.collectionID = int64(1000)
 	suite.partitionID = int64(100)
 }
 
@@ -140,7 +147,7 @@ func (suite *ReplicaObserverSuite) TestCheckNodesInReplica() {
 	replicas, err := suite.meta.Spawn(ctx, suite.collectionID, map[string]int{
 		"rg1": 1,
 		"rg2": 1,
-	}, nil, commonpb.LoadPriority_LOW)
+	}, []string{"test-insert-channel1"}, commonpb.LoadPriority_LOW)
 	suite.NoError(err)
 	suite.Equal(2, len(replicas))
 
@@ -256,7 +263,7 @@ func (suite *ReplicaObserverSuite) TestCheckSQnodesInReplica() {
 	replicas, err := suite.meta.Spawn(ctx, suite.collectionID, map[string]int{
 		"rg1": 1,
 		"rg2": 1,
-	}, nil, commonpb.LoadPriority_LOW)
+	}, []string{"test-insert-channel1"}, commonpb.LoadPriority_LOW)
 	suite.NoError(err)
 	suite.Equal(2, len(replicas))
 

--- a/internal/querycoordv2/observers/replica_observer_test.go
+++ b/internal/querycoordv2/observers/replica_observer_test.go
@@ -93,6 +93,7 @@ func (suite *ReplicaObserverSuite) SetupTest() {
 
 	suite.distMgr = meta.NewDistributionManager(suite.nodeMgr)
 	suite.targetMgr = meta.NewMockTargetManager(suite.T())
+	suite.targetMgr.EXPECT().GetDmChannelsByCollection(mock.Anything, mock.Anything, mock.Anything).Return(map[string]*meta.DmChannel{}).Maybe()
 	suite.observer = NewReplicaObserver(suite.meta, suite.distMgr, suite.targetMgr)
 	suite.observer.Start()
 	suite.collectionID = int64(1000)

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -2653,7 +2653,7 @@ If this parameter is set false, Milvus simply searches the growing segments with
 	p.Balancer = ParamItem{
 		Key:          "queryCoord.balancer",
 		Version:      "2.0.0",
-		DefaultValue: "ScoreBasedBalancer",
+		DefaultValue: "ChannelLevelScoreBalancer",
 		PanicIfEmpty: false,
 		Doc:          "auto balancer used for segments on queryNodes",
 		Export:       true,
@@ -3119,7 +3119,7 @@ If this parameter is set false, Milvus simply searches the growing segments with
 	p.ChannelExclusiveNodeFactor = ParamItem{
 		Key:          "queryCoord.channelExclusiveNodeFactor",
 		Version:      "2.4.2",
-		DefaultValue: "4",
+		DefaultValue: "1",
 		Doc:          "the least node number for enable channel's exclusive mode",
 		Export:       true,
 	}

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -383,7 +383,9 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, 100*time.Second, Params.GracefulStopTimeout.GetAsDuration(time.Second))
 		assert.Equal(t, true, Params.EnableStoppingBalance.GetAsBool())
 
-		assert.Equal(t, 4, Params.ChannelExclusiveNodeFactor.GetAsInt())
+		assert.Equal(t, "ChannelLevelScoreBalancer", Params.Balancer.GetValue())
+
+		assert.Equal(t, 1, Params.ChannelExclusiveNodeFactor.GetAsInt())
 
 		assert.Equal(t, 200, Params.CollectionObserverInterval.GetAsInt())
 		params.Save("queryCoord.collectionObserverInterval", "100")


### PR DESCRIPTION
## Summary

pr: #47505
Backport of #47505 to 2.6 branch.

Enable channel-level exclusive mode by default to reduce query fanout and improve performance by avoiding channel sharing among query nodes.

## Changes

- Switch default balancer from `ScoreBasedBalancer` to `ChannelLevelScoreBalancer` in configuration
- Lower `channelExclusiveNodeFactor` from 4 to 1 for wider deployment support
- Update fallback balancer in `BalancerFactory`
- Add comprehensive unit tests in `balancer_factory_test.go` to verify default balancer creation and fallback logic

## Benefits

- Each channel is assigned to specific nodes (exclusive mode)
- Reduces query fanout by avoiding cross-channel node communication
- Improves query performance through better cache locality
- Reduces resource contention between channels
- Segments from different channels no longer compete for same nodes

## Related Issue

Related to #47500

## Backport Note

Cherry-picked from master branch PR #47505 with no conflicts.

🤖 Generated with [Claude Code](https://claude.ai/code)