### PR TITLE
fix: treat 200 and 404 as successful DeleteObject response

### DIFF
--- a/internal/storage/minio_object_storage_test.go
+++ b/internal/storage/minio_object_storage_test.go
@@ -243,3 +243,4 @@ func listAllObjectsWithPrefixAtBucket(ctx context.Context, objectStorage ObjectS
 	}
 	return dirs, mods, nil
 }
+


### PR DESCRIPTION
## Summary
- Handle HTTP 200 and 404 response as successful deletion in `RemoveObject` method
- Add debug log to track non-standard S3 responses

## Background
Some S3-compatible storage doesn't fully comply with S3 spec and returns HTTP 200 instead of 204 for successful object deletion. The minio SDK treats 200 as an error since S3 spec expects 204, but the deletion actually succeeded. Also treat 404 as success for idempotent delete.

Related: https://github.com/zilliztech/milvus-backup/pull/931