### PR TITLE
fix: treat 200 and 404 as successful DeleteObject response

### DIFF
--- a/internal/storage/minio_object_storage.go
+++ b/internal/storage/minio_object_storage.go
@@ -19,6 +19,7 @@ package storage
 import (
 	"context"
 	"io"
+	"net/http"
 
 	"github.com/minio/minio-go/v7"
 	"go.uber.org/zap"
@@ -105,7 +106,26 @@ func (minioObjectStorage *MinioObjectStorage) WalkWithObjects(ctx context.Contex
 }
 
 func (minioObjectStorage *MinioObjectStorage) RemoveObject(ctx context.Context, bucketName, objectName string) error {
+	// isDeleteSuccessful treats 200 and 404 as successful deletion.
+	// Some S3-compatible storage doesn't fully comply with S3 spec (minio SDK expects 204).
+	isDeleteSuccessful := func(err error) bool {
+		if err == nil {
+			return true
+		}
+		statusCode := minio.ToErrorResponse(err).StatusCode
+		return statusCode == http.StatusOK || statusCode == http.StatusNotFound
+	}
+
 	err := minioObjectStorage.Client.RemoveObject(ctx, bucketName, objectName, minio.RemoveObjectOptions{})
+	if isDeleteSuccessful(err) {
+		if err != nil {
+			log.Debug("object already removed or storage returned non-standard success code",
+				zap.String("bucket", bucketName),
+				zap.String("object", objectName),
+				zap.Int("statusCode", minio.ToErrorResponse(err).StatusCode))
+		}
+		return nil
+	}
 	return checkObjectStorageError(objectName, err)
 }
 

--- a/internal/storage/minio_object_storage_test.go
+++ b/internal/storage/minio_object_storage_test.go
@@ -416,3 +416,4 @@ func listAllObjectsWithPrefixAtBucket(ctx context.Context, objectStorage ObjectS
 	}
 	return dirs, mods, nil
 }
+


### PR DESCRIPTION
## Summary
- Handle HTTP 200 and 404 response as successful deletion in `RemoveObject` method
- Add debug log to track non-standard S3 responses

## Background
Some S3-compatible storage doesn't fully comply with S3 spec and returns HTTP 200 instead of 204 for successful object deletion. The minio SDK treats 200 as an error since S3 spec expects 204, but the deletion actually succeeded. Also treat 404 as success for idempotent delete.

Related: 
- https://github.com/zilliztech/milvus-backup/pull/931
- https://github.com/milvus-io/milvus/pull/47507