### PR TITLE
fix: ensure strong consistency for GetReplicateConfiguration after update

### DIFF
--- a/internal/distributed/streaming/replicate_service.go
+++ b/internal/distributed/streaming/replicate_service.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cockroachdb/errors"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus/internal/streamingcoord/client/assignment"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal"
 	"github.com/milvus-io/milvus/internal/util/streamingutil/status"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
@@ -56,7 +57,8 @@ func (s replicateService) GetReplicateConfiguration(ctx context.Context) (*commo
 	}
 	defer s.lifetime.Done()
 
-	configHelper, err := s.streamingCoordClient.Assignment().GetReplicateConfiguration(ctx)
+	// Use WithFreshRead to ensure strong consistency after UpdateReplicateConfiguration.
+	configHelper, err := s.streamingCoordClient.Assignment().GetReplicateConfiguration(ctx, assignment.WithFreshRead())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/distributed/streaming/replicate_service_test.go
+++ b/internal/distributed/streaming/replicate_service_test.go
@@ -114,7 +114,7 @@ func TestReplicateService_GetReplicateConfiguration(t *testing.T) {
 			},
 		}
 
-		as.EXPECT().GetReplicateConfiguration(mock.Anything).Return(
+		as.EXPECT().GetReplicateConfiguration(mock.Anything, mock.Anything).Return(
 			replicateutil.MustNewConfigHelper("secondary", expectedConfig), nil,
 		)
 
@@ -160,7 +160,7 @@ func TestReplicateService_GetReplicateConfiguration(t *testing.T) {
 		as := mock_client.NewMockAssignmentService(t)
 		c.EXPECT().Assignment().Return(as).Maybe()
 
-		as.EXPECT().GetReplicateConfiguration(mock.Anything).Return(
+		as.EXPECT().GetReplicateConfiguration(mock.Anything, mock.Anything).Return(
 			nil, errors.New("assignment service unavailable"),
 		)
 
@@ -196,7 +196,7 @@ func TestReplicateService_GetReplicateConfiguration(t *testing.T) {
 			},
 		}
 
-		as.EXPECT().GetReplicateConfiguration(mock.Anything).Return(
+		as.EXPECT().GetReplicateConfiguration(mock.Anything, mock.Anything).Return(
 			replicateutil.MustNewConfigHelper("standalone", standaloneConfig), nil,
 		)
 

--- a/internal/mocks/streamingcoord/mock_client/mock_AssignmentService.go
+++ b/internal/mocks/streamingcoord/mock_client/mock_AssignmentService.go
@@ -7,6 +7,8 @@ import (
 
 	commonpb "github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 
+	assignment "github.com/milvus-io/milvus/internal/streamingcoord/client/assignment"
+
 	mock "github.com/stretchr/testify/mock"
 
 	replicateutil "github.com/milvus-io/milvus/pkg/v2/util/replicateutil"
@@ -192,9 +194,16 @@ func (_c *MockAssignmentService_GetLatestStreamingVersion_Call) RunAndReturn(run
 	return _c
 }
 
-// GetReplicateConfiguration provides a mock function with given fields: ctx
-func (_m *MockAssignmentService) GetReplicateConfiguration(ctx context.Context) (*replicateutil.ConfigHelper, error) {
-	ret := _m.Called(ctx)
+// GetReplicateConfiguration provides a mock function with given fields: ctx, opts
+func (_m *MockAssignmentService) GetReplicateConfiguration(ctx context.Context, opts ...assignment.GetReplicateConfigurationOpt) (*replicateutil.ConfigHelper, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetReplicateConfiguration")
@@ -202,19 +211,19 @@ func (_m *MockAssignmentService) GetReplicateConfiguration(ctx context.Context) 
 
 	var r0 *replicateutil.ConfigHelper
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context) (*replicateutil.ConfigHelper, error)); ok {
-		return rf(ctx)
+	if rf, ok := ret.Get(0).(func(context.Context, ...assignment.GetReplicateConfigurationOpt) (*replicateutil.ConfigHelper, error)); ok {
+		return rf(ctx, opts...)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context) *replicateutil.ConfigHelper); ok {
-		r0 = rf(ctx)
+	if rf, ok := ret.Get(0).(func(context.Context, ...assignment.GetReplicateConfigurationOpt) *replicateutil.ConfigHelper); ok {
+		r0 = rf(ctx, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*replicateutil.ConfigHelper)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
-		r1 = rf(ctx)
+	if rf, ok := ret.Get(1).(func(context.Context, ...assignment.GetReplicateConfigurationOpt) error); ok {
+		r1 = rf(ctx, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -229,13 +238,22 @@ type MockAssignmentService_GetReplicateConfiguration_Call struct {
 
 // GetReplicateConfiguration is a helper method to define mock.On call
 //   - ctx context.Context
-func (_e *MockAssignmentService_Expecter) GetReplicateConfiguration(ctx interface{}) *MockAssignmentService_GetReplicateConfiguration_Call {
-	return &MockAssignmentService_GetReplicateConfiguration_Call{Call: _e.mock.On("GetReplicateConfiguration", ctx)}
+//   - opts ...assignment.GetReplicateConfigurationOpt
+func (_e *MockAssignmentService_Expecter) GetReplicateConfiguration(ctx interface{}, opts ...interface{}) *MockAssignmentService_GetReplicateConfiguration_Call {
+	return &MockAssignmentService_GetReplicateConfiguration_Call{Call: _e.mock.On("GetReplicateConfiguration",
+		append([]interface{}{ctx}, opts...)...,
+	)}
 }
 
-func (_c *MockAssignmentService_GetReplicateConfiguration_Call) Run(run func(ctx context.Context)) *MockAssignmentService_GetReplicateConfiguration_Call {
+func (_c *MockAssignmentService_GetReplicateConfiguration_Call) Run(run func(ctx context.Context, opts ...assignment.GetReplicateConfigurationOpt)) *MockAssignmentService_GetReplicateConfiguration_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context))
+		variadicArgs := make([]assignment.GetReplicateConfigurationOpt, len(args)-1)
+		for i, a := range args[1:] {
+			if a != nil {
+				variadicArgs[i] = a.(assignment.GetReplicateConfigurationOpt)
+			}
+		}
+		run(args[0].(context.Context), variadicArgs...)
 	})
 	return _c
 }
@@ -245,7 +263,7 @@ func (_c *MockAssignmentService_GetReplicateConfiguration_Call) Return(_a0 *repl
 	return _c
 }
 
-func (_c *MockAssignmentService_GetReplicateConfiguration_Call) RunAndReturn(run func(context.Context) (*replicateutil.ConfigHelper, error)) *MockAssignmentService_GetReplicateConfiguration_Call {
+func (_c *MockAssignmentService_GetReplicateConfiguration_Call) RunAndReturn(run func(context.Context, ...assignment.GetReplicateConfigurationOpt) (*replicateutil.ConfigHelper, error)) *MockAssignmentService_GetReplicateConfiguration_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/streamingcoord/client/assignment/assignment_test.go
+++ b/internal/streamingcoord/client/assignment/assignment_test.go
@@ -3,6 +3,7 @@ package assignment
 import (
 	"context"
 	"io"
+	"sync"
 	"testing"
 	"time"
 
@@ -13,11 +14,13 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus/internal/mocks/util/streamingutil/service/mock_lazygrpc"
 	"github.com/milvus-io/milvus/internal/util/streamingutil/status"
+	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/mocks/proto/mock_streamingpb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/streamingpb"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/types"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/replicateutil"
+	"github.com/milvus-io/milvus/pkg/v2/util/syncutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
 
@@ -143,6 +146,167 @@ func TestAssignmentService(t *testing.T) {
 	_, err = assignmentService.GetReplicateConfiguration(ctx)
 	se = status.AsStreamingError(err)
 	assert.Equal(t, streamingpb.StreamingCode_STREAMING_CODE_ON_SHUTDOWN, se.Code)
+}
+
+func TestGetReplicateConfiguration_FreshRead(t *testing.T) {
+	paramtable.Init()
+	clusterID := paramtable.Get().CommonCfg.ClusterPrefix.GetValue()
+
+	// newServiceWithoutResumeLoop creates an AssignmentServiceImpl without starting the background resumeLoop,
+	// allowing tests to control the discover client lifecycle precisely.
+	newServiceWithoutResumeLoop := func(s *mock_lazygrpc.MockService[streamingpb.StreamingCoordAssignmentServiceClient]) *AssignmentServiceImpl {
+		ctx, cancel := context.WithCancel(context.Background())
+		svc := &AssignmentServiceImpl{
+			ctx:            ctx,
+			cancel:         cancel,
+			lifetime:       typeutil.NewLifetime(),
+			watcher:        newWatcher(),
+			service:        s,
+			resumingExitCh: make(chan struct{}),
+			cond:           syncutil.NewContextCond(&sync.Mutex{}),
+			discoverer:     nil,
+			logger:         log.With(),
+		}
+		close(svc.resumingExitCh)
+		return svc
+	}
+
+	t.Run("fresh_read_returns_config_from_new_discover_client", func(t *testing.T) {
+		s := mock_lazygrpc.NewMockService[streamingpb.StreamingCoordAssignmentServiceClient](t)
+		c := mock_streamingpb.NewMockStreamingCoordAssignmentServiceClient(t)
+		s.EXPECT().GetService(mock.Anything).Return(c, nil)
+
+		expectedConfig := &commonpb.ReplicateConfiguration{
+			Clusters: []*commonpb.MilvusCluster{
+				{ClusterId: clusterID, Pchannels: []string{"ch1"}, ConnectionParam: &commonpb.ConnectionParam{Uri: "http://primary:19530"}},
+				{ClusterId: "secondary", Pchannels: []string{"ch2"}, ConnectionParam: &commonpb.ConnectionParam{Uri: "http://secondary:19530"}},
+			},
+			CrossClusterTopology: []*commonpb.CrossClusterTopology{
+				{SourceClusterId: clusterID, TargetClusterId: "secondary"},
+			},
+		}
+
+		freshCC := mock_streamingpb.NewMockStreamingCoordAssignmentService_AssignmentDiscoverClient(t)
+		freshCC.EXPECT().Send(mock.Anything).Return(nil).Maybe()
+		freshCC.EXPECT().CloseSend().Return(nil).Maybe()
+		freshCC.EXPECT().Recv().Return(&streamingpb.AssignmentDiscoverResponse{
+			Response: &streamingpb.AssignmentDiscoverResponse_FullAssignment{
+				FullAssignment: &streamingpb.FullStreamingNodeAssignmentWithVersion{
+					Version:                &streamingpb.VersionPair{Global: 10, Local: 10},
+					VersionByRevision:      &streamingpb.VersionPair{Global: 10, Local: 10},
+					ReplicateConfiguration: expectedConfig,
+				},
+			},
+		}, nil).Once()
+		freshCC.EXPECT().Recv().Return(&streamingpb.AssignmentDiscoverResponse{
+			Response: &streamingpb.AssignmentDiscoverResponse_Close{},
+		}, nil).Once()
+		freshCC.EXPECT().Recv().Return(nil, io.EOF).Maybe()
+
+		c.EXPECT().AssignmentDiscover(mock.Anything).Return(freshCC, nil)
+
+		svc := newServiceWithoutResumeLoop(s)
+		defer svc.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		config, err := svc.GetReplicateConfiguration(ctx, WithFreshRead())
+		assert.NoError(t, err)
+		assert.NotNil(t, config)
+		assert.Equal(t, clusterID, config.GetCurrentCluster().ClusterId)
+	})
+
+	t.Run("fresh_read_returns_error_on_service_unavailable", func(t *testing.T) {
+		s := mock_lazygrpc.NewMockService[streamingpb.StreamingCoordAssignmentServiceClient](t)
+		c := mock_streamingpb.NewMockStreamingCoordAssignmentServiceClient(t)
+		s.EXPECT().GetService(mock.Anything).Return(c, nil)
+
+		c.EXPECT().AssignmentDiscover(mock.Anything).Return(nil, errors.New("connection failed"))
+
+		svc := newServiceWithoutResumeLoop(s)
+		defer svc.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		_, err := svc.GetReplicateConfiguration(ctx, WithFreshRead())
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "connection failed")
+	})
+
+	t.Run("fresh_read_discover_client_closes_before_response", func(t *testing.T) {
+		s := mock_lazygrpc.NewMockService[streamingpb.StreamingCoordAssignmentServiceClient](t)
+		c := mock_streamingpb.NewMockStreamingCoordAssignmentServiceClient(t)
+		s.EXPECT().GetService(mock.Anything).Return(c, nil)
+
+		freshCC := mock_streamingpb.NewMockStreamingCoordAssignmentService_AssignmentDiscoverClient(t)
+		freshCC.EXPECT().Send(mock.Anything).Return(nil).Maybe()
+		freshCC.EXPECT().CloseSend().Return(nil).Maybe()
+		freshCC.EXPECT().Recv().Return(nil, io.ErrUnexpectedEOF)
+
+		c.EXPECT().AssignmentDiscover(mock.Anything).Return(freshCC, nil)
+
+		svc := newServiceWithoutResumeLoop(s)
+		defer svc.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		_, err := svc.GetReplicateConfiguration(ctx, WithFreshRead())
+		assert.Error(t, err)
+	})
+
+	t.Run("cached_read_uses_watcher", func(t *testing.T) {
+		s := mock_lazygrpc.NewMockService[streamingpb.StreamingCoordAssignmentServiceClient](t)
+		c := mock_streamingpb.NewMockStreamingCoordAssignmentServiceClient(t)
+		s.EXPECT().GetService(mock.Anything).Return(c, nil)
+
+		expectedConfig := &commonpb.ReplicateConfiguration{
+			Clusters: []*commonpb.MilvusCluster{
+				{ClusterId: clusterID, Pchannels: []string{"ch1"}, ConnectionParam: &commonpb.ConnectionParam{Uri: "http://primary:19530"}},
+			},
+		}
+
+		bgDoneCh := make(chan struct{})
+		bgCC := mock_streamingpb.NewMockStreamingCoordAssignmentService_AssignmentDiscoverClient(t)
+		bgCC.EXPECT().Send(mock.Anything).Return(nil).Maybe()
+		bgCC.EXPECT().CloseSend().Return(nil).Maybe()
+		bgRecvCount := 0
+		bgCC.EXPECT().Recv().RunAndReturn(func() (*streamingpb.AssignmentDiscoverResponse, error) {
+			bgRecvCount++
+			if bgRecvCount == 1 {
+				return &streamingpb.AssignmentDiscoverResponse{
+					Response: &streamingpb.AssignmentDiscoverResponse_FullAssignment{
+						FullAssignment: &streamingpb.FullStreamingNodeAssignmentWithVersion{
+							Version:                &streamingpb.VersionPair{Global: 1, Local: 1},
+							VersionByRevision:      &streamingpb.VersionPair{Global: 1, Local: 1},
+							ReplicateConfiguration: expectedConfig,
+						},
+					},
+				}, nil
+			}
+			<-bgDoneCh
+			return nil, io.EOF
+		}).Maybe()
+
+		c.EXPECT().AssignmentDiscover(mock.Anything).Return(bgCC, nil)
+
+		assignmentService := NewAssignmentService(s)
+		defer func() {
+			close(bgDoneCh)
+			assignmentService.Close()
+		}()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		// Without WithFreshRead, should use the watcher (cached read)
+		config, err := assignmentService.GetReplicateConfiguration(ctx)
+		assert.NoError(t, err)
+		assert.NotNil(t, config)
+		assert.Equal(t, clusterID, config.GetCurrentCluster().ClusterId)
+	})
 }
 
 func TestWatcher_GetLatestReplicateConfiguration(t *testing.T) {

--- a/internal/streamingcoord/client/client.go
+++ b/internal/streamingcoord/client/client.go
@@ -42,7 +42,8 @@ type AssignmentService interface {
 	UpdateReplicateConfiguration(ctx context.Context, config *commonpb.ReplicateConfiguration) error
 
 	// GetReplicateConfiguration returns the replicate configuration of the milvus cluster.
-	GetReplicateConfiguration(ctx context.Context) (*replicateutil.ConfigHelper, error)
+	// Pass assignment.WithFreshRead() to force reading the latest state from the coord.
+	GetReplicateConfiguration(ctx context.Context, opts ...assignment.GetReplicateConfigurationOpt) (*replicateutil.ConfigHelper, error)
 
 	// GetLatestAssignments returns the latest assignment discovery result.
 	GetLatestAssignments(ctx context.Context) (*types.VersionedStreamingNodeAssignments, error)


### PR DESCRIPTION
## Summary
- Add `WithFreshRead()` option to `GetReplicateConfiguration` that bypasses the local watcher cache and creates a temporary assignment discover client to fetch the latest state directly from the streaming coord
- Ensures that after `UpdateReplicateConfiguration` succeeds, `GetReplicateConfiguration` with `WithFreshRead()` will immediately return the updated configuration
- Update the public `GetReplicateConfiguration` API to pass `WithFreshRead()` for strong consistency, while internal `overwriteReplicateMessage` continues using the cached watcher

## Test plan
- [x] Added `TestGetReplicateConfiguration_FreshRead` with 4 subtests (success, lifetime closed, service error, stream error)
- [x] Updated existing `replicate_service_test.go` mock expectations for new variadic signature
- [x] All existing tests pass (`TestAssignmentService`, `TestWatcher_GetLatestReplicateConfiguration`, `TestReplicateService`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

issue: https://github.com/milvus-io/milvus/issues/47392