### PR TITLE
fix: fix xxhash::xxhash not found in milvus_minhash

### DIFF
--- a/internal/core/src/minhash/CMakeLists.txt
+++ b/internal/core/src/minhash/CMakeLists.txt
@@ -56,11 +56,6 @@ elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "(aarch64)|(ARM64)")
     message(STATUS "Building with SVE support")
 endif()
 
-target_link_libraries(milvus_minhash PUBLIC
-    xxhash::xxhash
-    OpenSSL::SSL
-)
-
 target_include_directories(milvus_minhash PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/..
     ${CMAKE_CURRENT_SOURCE_DIR}/fusion_compute


### PR DESCRIPTION
Why those target_link_libraries are not need? Because `add_library(milvus_minhash OBJECT ${SOURCE_FILES})` defines `milvus_minhash` as an object. So, we don't need to care about link stage.

`milvus_minhash` is only linked by `milvus_core` which links `${CONAN_LIBS}`. `${CONAN_LIBS}` contains both OpenSSL and xxHash.

Fix: https://github.com/milvus-io/milvus/issues/47454
