### PR TITLE
enhance: add default CMD to Dockerfiles

### DIFF
--- a/build/docker/milvus/amazonlinux2023/Dockerfile
+++ b/build/docker/milvus/amazonlinux2023/Dockerfile
@@ -42,4 +42,6 @@ USER milvus:milvus
 
 ENTRYPOINT ["/tini", "--"]
 
+CMD ["milvus", "run", "standalone"]
+
 WORKDIR /milvus

--- a/build/docker/milvus/gpu/ubuntu20.04/Dockerfile
+++ b/build/docker/milvus/gpu/ubuntu20.04/Dockerfile
@@ -30,3 +30,5 @@ RUN groupadd -r milvus && useradd -r -g milvus milvus && \
     mkdir -p /var/lib/milvus && \
     chown -R milvus:milvus /milvus /var/lib/milvus
 USER milvus:milvus
+
+CMD ["milvus", "run", "standalone"]

--- a/build/docker/milvus/gpu/ubuntu22.04/Dockerfile
+++ b/build/docker/milvus/gpu/ubuntu22.04/Dockerfile
@@ -36,5 +36,7 @@ USER milvus:milvus
 
 ENTRYPOINT ["/tini", "--"]
 
+CMD ["milvus", "run", "standalone"]
+
 WORKDIR /milvus
 

--- a/build/docker/milvus/rockylinux8/Dockerfile
+++ b/build/docker/milvus/rockylinux8/Dockerfile
@@ -46,4 +46,6 @@ USER milvus:milvus
 
 ENTRYPOINT ["/tini", "--"]
 
+CMD ["milvus", "run", "standalone"]
+
 WORKDIR /milvus

--- a/build/docker/milvus/ubuntu20.04/Dockerfile
+++ b/build/docker/milvus/ubuntu20.04/Dockerfile
@@ -50,4 +50,6 @@ USER milvus:milvus
 
 ENTRYPOINT ["/tini", "--"]
 
+CMD ["milvus", "run", "standalone"]
+
 WORKDIR /milvus/

--- a/build/docker/milvus/ubuntu22.04/Dockerfile
+++ b/build/docker/milvus/ubuntu22.04/Dockerfile
@@ -52,4 +52,6 @@ USER milvus:milvus
 
 ENTRYPOINT ["/tini", "--"]
 
+CMD ["milvus", "run", "standalone"]
+
 WORKDIR /milvus/


### PR DESCRIPTION
## Add default CMD to Milvus Docker images

### Summary

This PR adds `CMD ["milvus", "run", "standalone"]` to all Milvus production Docker images, providing a sensible default command while maintaining full backwards compatibility.

### Motivation

The current Milvus Docker images define only an `ENTRYPOINT ["/tini", "--"]` with no `CMD`, which requires users to always specify a command when running the container. This creates friction in environments that don't easily support passing commands to containers, most notably:

- **GitHub Actions services** - The `services:` block in GitHub Actions workflows doesn't have a `command:` field, making it impossible to use the Milvus image directly as a service container
- **Simple local development** - New users must know to specify `milvus run standalone` even for the most common use case

### Changes

Added `CMD ["milvus", "run", "standalone"]` to all production Dockerfiles:

- `build/docker/milvus/ubuntu22.04/Dockerfile`
- `build/docker/milvus/ubuntu20.04/Dockerfile`
- `build/docker/milvus/rockylinux8/Dockerfile`
- `build/docker/milvus/amazonlinux2023/Dockerfile`
- `build/docker/milvus/gpu/ubuntu22.04/Dockerfile`
- `build/docker/milvus/gpu/ubuntu20.04/Dockerfile`

### Compatibility

This change is **fully backwards compatible**:

- **Existing docker-compose deployments**: Unaffected - `command:` in docker-compose overrides the image's CMD
- **Cluster deployments**: Unaffected - components (proxy, querynode, datanode, etc.) are started with explicit commands
- **Helm charts**: Typically specify commands explicitly in pod specs
- **Manual docker run with command**: Any command passed to `docker run` overrides the default CMD

The only behavioral change is that running the container without a command now starts Milvus in standalone mode instead of exiting immediately.

### Testing

```bash
# Before: container exits immediately
docker run milvusdb/milvus:latest

# After: starts Milvus standalone (equivalent to current explicit command)
docker run milvusdb/milvus:latest

# Explicit commands still work as before
docker run milvusdb/milvus:latest milvus run proxy
```

### Related

This enables simpler CI/CD integration, for example:

```yaml
# GitHub Actions - now possible without workarounds
services:
  milvus:
    image: milvusdb/milvus:latest
    environment:
      ETCD_USE_EMBED: 'true'
      COMMON_STORAGETYPE: local
      DEPLOY_MODE: STANDALONE
    ports:
      - 19530:19530
```
