### PR TITLE
enhance: [2.6] avoid unnecessary PinWrapper copy in SearchPksWith lambda (#47487)

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -662,7 +662,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
 
         auto get_val_view = [&](int chunk_id,
                                 int in_chunk_offset) -> PKViewType {
-            auto pw = all_chunk_pins[chunk_id];
+            auto& pw = all_chunk_pins[chunk_id];
             if constexpr (std::is_same_v<PK, int64_t>) {
                 auto src =
                     reinterpret_cast<const int64_t*>(pw.get()->RawData());


### PR DESCRIPTION
Cherry-pick from master
pr: #47487

Use reference instead of copy when capturing PinWrapper from all_chunk_pins vector to reduce copy construction overhead.