### PR TITLE
enhance: [hotfix] remove redundant bitset count operations in filter execution

### DIFF
--- a/internal/core/src/exec/operator/FilterBitsNode.cpp
+++ b/internal/core/src/exec/operator/FilterBitsNode.cpp
@@ -110,7 +110,7 @@ PhyFilterBitsNode::GetOutput() {
                bitset.size(),
                need_process_rows_);
     Assert(valid_bitset.size() == need_process_rows_);
-    
+
     // num_processed_rows_ = need_process_rows_;
     std::vector<VectorPtr> col_res;
     col_res.push_back(std::make_shared<ColumnVector>(std::move(bitset),

--- a/internal/core/src/exec/operator/FilterBitsNode.cpp
+++ b/internal/core/src/exec/operator/FilterBitsNode.cpp
@@ -110,11 +110,7 @@ PhyFilterBitsNode::GetOutput() {
                bitset.size(),
                need_process_rows_);
     Assert(valid_bitset.size() == need_process_rows_);
-
-    auto filtered_count = bitset.count();
-    auto filter_ratio =
-        bitset.size() != 0 ? 1 - float(filtered_count) / bitset.size() : 0;
-    milvus::monitor::internal_core_expr_filter_ratio.Observe(filter_ratio);
+    
     // num_processed_rows_ = need_process_rows_;
     std::vector<VectorPtr> col_res;
     col_res.push_back(std::make_shared<ColumnVector>(std::move(bitset),
@@ -126,10 +122,6 @@ PhyFilterBitsNode::GetOutput() {
             .count();
     milvus::monitor::internal_core_search_latency_scalar.Observe(scalar_cost /
                                                                  1000);
-
-    tracer::AddEvent(fmt::format("output_rows: {}, filtered: {}",
-                                 need_process_rows_ - filtered_count,
-                                 filtered_count));
 
     return std::make_shared<RowVector>(col_res);
 }

--- a/internal/core/src/exec/operator/MvccNode.cpp
+++ b/internal/core/src/exec/operator/MvccNode.cpp
@@ -78,10 +78,6 @@ PhyMvccNode::GetOutput() {
     segment_->mask_with_delete(data, active_count_, query_timestamp_);
     is_finished_ = true;
 
-    auto output_rows = active_count_ - data.count();
-    tracer::AddEvent(fmt::format(
-        "output_rows: {}, filtered: {}", output_rows, data.count()));
-
     // input_ have already been updated
     return std::make_shared<RowVector>(std::vector<VectorPtr>{col_input});
 }


### PR DESCRIPTION
Cherry-pick from master
pr: #47534
Remove unnecessary bitset.count() calls in FilterBitsNode and MvccNode that were only used for metrics reporting and tracing. These count operations traverse the entire bitset which adds overhead during query execution.