### PR TITLE
fix: fix bloom filter leak when worker node crashes [hotfix-2.6.10]

### DIFF
--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -151,9 +151,8 @@ func (sd *shardDelegator) ProcessInsert(insertRecords map[int64]*InsertData) {
 				continue
 			}
 
-			if !sd.pkOracle.Exists(growing, paramtable.GetNodeID()) {
+			if !sd.distribution.GrowingSegmentExists(segmentID) {
 				// register created growing segment after insert, avoid to add empty growing to delegator
-				sd.pkOracle.Register(growing, paramtable.GetNodeID())
 				if sd.idfOracle != nil {
 					sd.idfOracle.RegisterGrowing(segmentID, insertData.BM25Stats)
 				}
@@ -164,6 +163,7 @@ func (sd *shardDelegator) ProcessInsert(insertRecords map[int64]*InsertData) {
 					PartitionID:   insertData.PartitionID,
 					Version:       0,
 					TargetVersion: initialTargetVersion,
+					Candidate:     growing, // growing segment itself is the Candidate
 				})
 			}
 
@@ -184,8 +184,14 @@ func (sd *shardDelegator) ProcessInsert(insertRecords map[int64]*InsertData) {
 
 // ProcessDelete handles delete data in delegator.
 // delegator puts deleteData into buffer first,
-// then dispatch data to segments acoording to the result of pkOracle.
+// then dispatch data to segments according to the result of bloom filter check.
 func (sd *shardDelegator) ProcessDelete(deleteData []*DeleteData, ts uint64) {
+	// Early return if delegator is stopped - ProcessDelete becomes a no-op
+	// This prevents unnecessary processing and side effects during shutdown
+	if sd.Stopped() {
+		return
+	}
+
 	method := "ProcessDelete"
 	tr := timerecord.NewTimeRecorder(method)
 	// block load segment handle delete buffer
@@ -225,7 +231,11 @@ type BatchApplyRet = struct {
 	Segment2Hits  map[int64][]bool
 }
 
-func (sd *shardDelegator) applyBFInParallel(deleteDatas []*DeleteData, pool *conc.Pool[any]) *typeutil.ConcurrentMap[int, *BatchApplyRet] {
+// applyBFInParallel applies bloom filter check in parallel on the provided pinned segments.
+// Using pinned segments ensures consistency between BF check and delete application,
+// preventing race conditions where new segments could be added between PinOnlineSegments
+// and this call.
+func (sd *shardDelegator) applyBFInParallel(deleteDatas []*DeleteData, pool *conc.Pool[any], sealed []SnapshotItem, growing []SegmentEntry) *typeutil.ConcurrentMap[int, *BatchApplyRet] {
 	retIdx := 0
 	retMap := typeutil.NewConcurrentMap[int, *BatchApplyRet]()
 	batchSize := paramtable.Get().CommonCfg.BloomFilterApplyBatchSize.GetAsInt()
@@ -245,7 +255,7 @@ func (sd *shardDelegator) applyBFInParallel(deleteDatas []*DeleteData, pool *con
 			deleteDataId := didx
 			partitionID := data.PartitionID
 			future := pool.Submit(func() (any, error) {
-				ret := sd.pkOracle.BatchGet(pks[startIdx:endIdx], pkoracle.WithPartitionID(partitionID))
+				ret := BatchGetFromSegments(pks[startIdx:endIdx], partitionID, sealed, growing)
 				retMap.Insert(tmpRetIndex, &BatchApplyRet{
 					DeleteDataIdx: deleteDataId,
 					StartIdx:      startIdx,
@@ -377,7 +387,6 @@ func (sd *shardDelegator) LoadGrowing(ctx context.Context, infos []*querypb.Segm
 	log.Info("load growing segments done", zap.Int64s("segmentIDs", segmentIDs))
 
 	for _, segment := range loaded {
-		sd.pkOracle.Register(segment, paramtable.GetNodeID())
 		if sd.idfOracle != nil {
 			sd.idfOracle.RegisterGrowing(segment.ID(), segment.GetBM25Stats())
 		}
@@ -389,6 +398,7 @@ func (sd *shardDelegator) LoadGrowing(ctx context.Context, infos []*querypb.Segm
 			PartitionID:   segment.Partition(),
 			Version:       version,
 			TargetVersion: sd.distribution.getTargetVersion(),
+			Candidate:     segment, // growing segment itself is the Candidate
 		}
 	})...)
 	return nil
@@ -521,18 +531,8 @@ func (sd *shardDelegator) LoadSegments(ctx context.Context, req *querypb.LoadSeg
 		return nil
 	}
 
-	entries := lo.Map(req.GetInfos(), func(info *querypb.SegmentLoadInfo, _ int) SegmentEntry {
-		return SegmentEntry{
-			SegmentID:   info.GetSegmentID(),
-			PartitionID: info.GetPartitionID(),
-			NodeID:      req.GetDstNodeID(),
-			Version:     req.GetVersion(),
-			Level:       info.GetLevel(),
-		}
-	})
-
 	infos := lo.Filter(req.GetInfos(), func(info *querypb.SegmentLoadInfo, _ int) bool {
-		return !sd.pkOracle.Exists(pkoracle.NewCandidateKey(info.GetSegmentID(), info.GetPartitionID(), commonpb.SegmentState_Sealed), targetNodeID)
+		return !sd.distribution.SealedSegmentExistsOnNode(info.GetSegmentID(), targetNodeID)
 	})
 
 	candidates, err := sd.loader.LoadBloomFilterSet(ctx, req.GetCollectionID(), infos...)
@@ -554,12 +554,28 @@ func (sd *shardDelegator) LoadSegments(ctx context.Context, req *querypb.LoadSeg
 		return err
 	}
 
-	// add candidate after load success
+	// Build a map from segmentID to BloomFilterSet
+	bfMap := make(map[int64]pkoracle.Candidate)
 	for _, candidate := range candidates {
-		log.Info("register sealed segment bfs into pko candidates",
+		log.Info("loaded bloom filter set for sealed segment",
 			zap.Int64("segmentID", candidate.ID()),
 		)
-		sd.pkOracle.Register(candidate, targetNodeID)
+		bfMap[candidate.ID()] = candidate
+	}
+
+	// Build entries with Candidate - use filtered infos instead of req.GetInfos()
+	// This ensures we only add entries for segments that were actually loaded (not skipped as duplicates)
+	entries := make([]SegmentEntry, 0, len(infos))
+	for _, info := range infos {
+		entry := SegmentEntry{
+			SegmentID:   info.GetSegmentID(),
+			PartitionID: info.GetPartitionID(),
+			NodeID:      req.GetDstNodeID(),
+			Version:     req.GetVersion(),
+			Level:       info.GetLevel(),
+			Candidate:   bfMap[info.GetSegmentID()],
+		}
+		entries = append(entries, entry)
 	}
 
 	return sd.addDistributionIfVersionOK(req.GetLoadMeta().GetSchemaVersion(), entries...)
@@ -862,19 +878,9 @@ func (sd *shardDelegator) ReleaseSegments(ctx context.Context, req *querypb.Rele
 	})
 	sd.AddExcludedSegments(droppedInfos)
 
-	if len(sealed) > 0 {
-		sd.pkOracle.Remove(
-			pkoracle.WithSegmentIDs(lo.Map(sealed, func(entry SegmentEntry, _ int) int64 { return entry.SegmentID })...),
-			pkoracle.WithSegmentType(commonpb.SegmentState_Sealed),
-			pkoracle.WithWorkerID(targetNodeID),
-		)
-	}
-	if len(growing) > 0 {
-		sd.pkOracle.Remove(
-			pkoracle.WithSegmentIDs(lo.Map(growing, func(entry SegmentEntry, _ int) int64 { return entry.SegmentID })...),
-			pkoracle.WithSegmentType(commonpb.SegmentState_Growing),
-		)
-	}
+	// Note: Candidate cleanup is handled by RemoveDistributions above
+	// - Sealed segment candidates (BloomFilterSet) are refunded in RemoveDistributions
+	// - Growing segment candidates (LocalSegment) are managed by segmentManager.Release()
 
 	var releaseErr error
 	if !force {

--- a/internal/querynodev2/delegator/delegator_data_test.go
+++ b/internal/querynodev2/delegator/delegator_data_test.go
@@ -61,6 +61,25 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
 
+// segmentEntryCoreFields extracts core fields from SegmentEntry for comparison,
+// excluding Candidate field which varies between tests.
+func segmentEntryCoreFields(entries []SegmentEntry) []SegmentEntry {
+	result := make([]SegmentEntry, len(entries))
+	for i, e := range entries {
+		result[i] = SegmentEntry{
+			NodeID:        e.NodeID,
+			SegmentID:     e.SegmentID,
+			PartitionID:   e.PartitionID,
+			Version:       e.Version,
+			TargetVersion: e.TargetVersion,
+			Level:         e.Level,
+			Offline:       e.Offline,
+			// Candidate is intentionally excluded
+		}
+	}
+	return result
+}
+
 type DelegatorDataSuite struct {
 	suite.Suite
 
@@ -519,6 +538,10 @@ func (s *DelegatorDataSuite) TestProcessDelete() {
 	s.True(s.delegator.distribution.Serviceable())
 
 	s.delegator.Close()
+	// After Close(), ProcessDelete becomes a no-op because sd.Stopped() returns true.
+	// This is expected behavior - the delegator is being decommissioned.
+	// Note: Serviceable() state is not changed by ProcessDelete when delegator is stopped,
+	// since ProcessDelete returns early without processing any deletes.
 	s.delegator.ProcessDelete([]*DeleteData{
 		{
 			PartitionID: 500,
@@ -528,7 +551,8 @@ func (s *DelegatorDataSuite) TestProcessDelete() {
 		},
 	}, 10)
 	s.Require().NoError(err)
-	s.False(s.delegator.distribution.Serviceable())
+	// Serviceable state remains unchanged since ProcessDelete is a no-op after Close()
+	s.True(s.delegator.distribution.Serviceable())
 }
 
 func (s *DelegatorDataSuite) TestLoadGrowingWithBM25() {
@@ -536,9 +560,10 @@ func (s *DelegatorDataSuite) TestLoadGrowingWithBM25() {
 	mockSegment := segments.NewMockSegment(s.T())
 	s.loader.EXPECT().Load(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]segments.Segment{mockSegment}, nil)
 
-	mockSegment.EXPECT().Partition().Return(111)
-	mockSegment.EXPECT().ID().Return(111)
-	mockSegment.EXPECT().Type().Return(commonpb.SegmentState_Growing)
+	mockSegment.EXPECT().Partition().Return(int64(111))
+	mockSegment.EXPECT().ID().Return(int64(111))
+	// Note: Type() is no longer called since pkOracle was removed
+	// Candidate is now stored directly in SegmentEntry
 	mockSegment.EXPECT().GetBM25Stats().Return(map[int64]*storage.BM25Stats{})
 
 	err := s.delegator.LoadGrowing(context.Background(), []*querypb.SegmentLoadInfo{{SegmentID: 1}}, 1)
@@ -609,7 +634,7 @@ func (s *DelegatorDataSuite) TestLoadSegmentsWithBm25() {
 				TargetVersion: unreadableTargetVersion,
 				Level:         datapb.SegmentLevel_L1,
 			},
-		}, sealed[0].Segments)
+		}, segmentEntryCoreFields(sealed[0].Segments))
 	})
 
 	s.Run("loadBM25_failed", func() {
@@ -709,7 +734,7 @@ func (s *DelegatorDataSuite) TestLoadSegments() {
 				TargetVersion: unreadableTargetVersion,
 				Level:         datapb.SegmentLevel_L1,
 			},
-		}, sealed[0].Segments)
+		}, segmentEntryCoreFields(sealed[0].Segments))
 	})
 
 	s.Run("load_segments_with_delete", func() {
@@ -1278,7 +1303,7 @@ func (s *DelegatorDataSuite) TestReleaseSegment() {
 			PartitionID:   500,
 			TargetVersion: unreadableTargetVersion,
 		},
-	}, sealed[0].Segments)
+	}, segmentEntryCoreFields(sealed[0].Segments))
 
 	s.ElementsMatch([]SegmentEntry{
 		{
@@ -1287,7 +1312,7 @@ func (s *DelegatorDataSuite) TestReleaseSegment() {
 			PartitionID:   500,
 			TargetVersion: unreadableTargetVersion,
 		},
-	}, growing)
+	}, segmentEntryCoreFields(growing))
 
 	err = s.delegator.ReleaseSegments(ctx, &querypb.ReleaseSegmentsRequest{
 		Base:       commonpbutil.NewMsgBase(),

--- a/internal/querynodev2/pkoracle/candidate.go
+++ b/internal/querynodev2/pkoracle/candidate.go
@@ -34,6 +34,12 @@ type Candidate interface {
 	Type() commonpb.SegmentState
 }
 
+// Refundable is an optional interface for candidates that need resource cleanup.
+// BloomFilterSet implements this interface to refund charged memory resources.
+type Refundable interface {
+	Refund()
+}
+
 type candidateWithWorker struct {
 	Candidate
 	workerID int64


### PR DESCRIPTION
## Summary

Backport of #47450 to hotfix-2.6.10 branch.

pr: #47450

Fix bloom filter leak when worker node crashes by merging pkOracle and distribution management:
- Add Candidate field to SegmentEntry for BF lifecycle management
- Add BatchGet to distribution for PK existence check
- Add SealedSegmentExistsOnNode for segment existence check
- Add refund logic in AddDistributions and RemoveDistributions
- Add early return in ProcessDelete when delegator is stopped
- Ensure consistency between BF check and delete application

## Related Issue

issue: #47449

## Notes

Cherry-picked from master (commit 490a5c36eb) with conflicts resolved in:
- internal/querynodev2/delegator/delegator.go
- internal/querynodev2/delegator/delegator_data.go
- internal/querynodev2/delegator/delegator_data_test.go

Conflicts were resolved using theirs strategy to accept the incoming changes.