### PR TITLE
enhance: Cherry-pick load-diff based segment loading patches

### DIFF
--- a/internal/core/src/common/RegexQueryTest.cpp
+++ b/internal/core/src/common/RegexQueryTest.cpp
@@ -246,11 +246,10 @@ class SealedSegmentRegexQueryTest : public ::testing::Test {
     LoadStlSortIndex() {
         auto index = index::CreateScalarIndexSort<int64_t>();
         index->BuildWithRawDataForUT(N, raw_int.data());
-        LoadIndexInfo info{
-            .field_id = schema->get_field_id(FieldName("another_int64")).get(),
-            .index_params = GenIndexParams(index.get()),
-            .cache_index = CreateTestCacheIndex("test", std::move(index)),
-        };
+        LoadIndexInfo info{};
+        info.field_id = schema->get_field_id(FieldName("another_int64")).get();
+        info.index_params = GenIndexParams(index.get());
+        info.cache_index = CreateTestCacheIndex("test", std::move(index));
         seg->LoadIndex(info);
     }
 
@@ -259,11 +258,10 @@ class SealedSegmentRegexQueryTest : public ::testing::Test {
         auto index =
             std::make_unique<index::InvertedIndexTantivy<std::string>>();
         index->BuildWithRawDataForUT(N, raw_str.data());
-        LoadIndexInfo info{
-            .field_id = schema->get_field_id(FieldName("str")).get(),
-            .index_params = GenIndexParams(index.get()),
-            .cache_index = CreateTestCacheIndex("test", std::move(index)),
-        };
+        LoadIndexInfo info{};
+        info.field_id = schema->get_field_id(FieldName("str")).get();
+        info.index_params = GenIndexParams(index.get());
+        info.cache_index = CreateTestCacheIndex("test", std::move(index));
         seg->LoadIndex(info);
     }
 
@@ -277,11 +275,10 @@ class SealedSegmentRegexQueryTest : public ::testing::Test {
         std::vector<uint8_t> buffer(arr.ByteSizeLong());
         ASSERT_TRUE(arr.SerializeToArray(buffer.data(), arr.ByteSizeLong()));
         index->BuildWithRawDataForUT(arr.ByteSizeLong(), buffer.data());
-        LoadIndexInfo info{
-            .field_id = schema->get_field_id(FieldName("str")).get(),
-            .index_params = GenIndexParams(index.get()),
-            .cache_index = CreateTestCacheIndex("test", std::move(index)),
-        };
+        LoadIndexInfo info{};
+        info.field_id = schema->get_field_id(FieldName("str")).get();
+        info.index_params = GenIndexParams(index.get());
+        info.cache_index = CreateTestCacheIndex("test", std::move(index));
         seg->LoadIndex(info);
     }
 

--- a/internal/core/src/index/InvertedIndexArrayTest.cpp
+++ b/internal/core/src/index/InvertedIndexArrayTest.cpp
@@ -117,11 +117,10 @@ class ArrayInvertedIndexTest : public ::testing::Test {
         Config cfg;
         cfg["is_array"] = true;
         index->BuildWithRawDataForUT(N_, vec_of_array_.data(), cfg);
-        LoadIndexInfo info{
-            .field_id = schema_->get_field_id(FieldName("array")).get(),
-            .index_params = GenIndexParams(index.get()),
-            .cache_index = CreateTestCacheIndex("test", std::move(index)),
-        };
+        LoadIndexInfo info{};
+        info.field_id = schema_->get_field_id(FieldName("array")).get();
+        info.index_params = GenIndexParams(index.get());
+        info.cache_index = CreateTestCacheIndex("test", std::move(index));
         seg_->LoadIndex(info);
     }
 

--- a/internal/core/src/index/NgramInvertedIndexTest.cpp
+++ b/internal/core/src/index/NgramInvertedIndexTest.cpp
@@ -172,32 +172,30 @@ test_ngram_with_data(const boost::container::vector<std::string>& data,
             {milvus::index::MAX_GRAM, "4"},
             {milvus::LOAD_PRIORITY, "HIGH"},
         };
-        milvus::segcore::LoadIndexInfo load_index_info{
-            .collection_id = collection_id,
-            .partition_id = partition_id,
-            .segment_id = segment_id,
-            .field_id = field_id.get(),
-            .field_type = DataType::VARCHAR,
-            .enable_mmap = true,
-            .mmap_dir_path = "/tmp/test-ngram-index-mmap-dir",
-            .index_id = index_id,
-            .index_build_id = index_build_id,
-            .index_version = index_version,
-            .index_params = index_params,
-            .index_files = index_files,
-            .schema = field_meta.field_schema,
-            .index_size = index_size,
-        };
+        milvus::segcore::LoadIndexInfo load_index_info{};
+        load_index_info.collection_id = collection_id;
+        load_index_info.partition_id = partition_id;
+        load_index_info.segment_id = segment_id;
+        load_index_info.field_id = field_id.get();
+        load_index_info.field_type = DataType::VARCHAR;
+        load_index_info.enable_mmap = true;
+        load_index_info.mmap_dir_path = "/tmp/test-ngram-index-mmap-dir";
+        load_index_info.index_id = index_id;
+        load_index_info.index_build_id = index_build_id;
+        load_index_info.index_version = index_version;
+        load_index_info.index_params = index_params;
+        load_index_info.index_files = index_files;
+        load_index_info.schema = field_meta.field_schema;
+        load_index_info.index_size = index_size;
 
         uint8_t trace_id[16] = {0};
         uint8_t span_id[8] = {0};
         trace_id[0] = 1;
         span_id[0] = 2;
-        CTraceContext trace{
-            .traceID = trace_id,
-            .spanID = span_id,
-            .traceFlags = 0,
-        };
+        CTraceContext trace{};
+        trace.traceID = trace_id;
+        trace.spanID = span_id;
+        trace.traceFlags = 0;
         auto cload_index_info = static_cast<CLoadIndexInfo>(&load_index_info);
         AppendIndexV2(trace, cload_index_info);
         UpdateSealedSegmentIndex(segment.get(), cload_index_info);
@@ -454,32 +452,30 @@ TEST(NgramIndex, TestNonLikeExpressionsWithNgram) {
             {milvus::index::MAX_GRAM, "4"},
             {milvus::LOAD_PRIORITY, "HIGH"},
         };
-        milvus::segcore::LoadIndexInfo load_index_info{
-            .collection_id = collection_id,
-            .partition_id = partition_id,
-            .segment_id = segment_id,
-            .field_id = field_id.get(),
-            .field_type = DataType::VARCHAR,
-            .enable_mmap = true,
-            .mmap_dir_path = "/tmp/test-ngram-index-mmap-dir",
-            .index_id = index_id,
-            .index_build_id = index_build_id,
-            .index_version = index_version,
-            .index_params = index_params,
-            .index_files = index_files,
-            .schema = field_meta.field_schema,
-            .index_size = 1024 * 1024 * 1024,
-        };
+        milvus::segcore::LoadIndexInfo load_index_info{};
+        load_index_info.collection_id = collection_id;
+        load_index_info.partition_id = partition_id;
+        load_index_info.segment_id = segment_id;
+        load_index_info.field_id = field_id.get();
+        load_index_info.field_type = DataType::VARCHAR;
+        load_index_info.enable_mmap = true;
+        load_index_info.mmap_dir_path = "/tmp/test-ngram-index-mmap-dir";
+        load_index_info.index_id = index_id;
+        load_index_info.index_build_id = index_build_id;
+        load_index_info.index_version = index_version;
+        load_index_info.index_params = index_params;
+        load_index_info.index_files = index_files;
+        load_index_info.schema = field_meta.field_schema;
+        load_index_info.index_size = 1024 * 1024 * 1024;
 
         uint8_t trace_id[16] = {0};
         uint8_t span_id[8] = {0};
         trace_id[0] = 1;
         span_id[0] = 2;
-        CTraceContext trace{
-            .traceID = trace_id,
-            .spanID = span_id,
-            .traceFlags = 0,
-        };
+        CTraceContext trace{};
+        trace.traceID = trace_id;
+        trace.spanID = span_id;
+        trace.traceFlags = 0;
         auto cload_index_info = static_cast<CLoadIndexInfo>(&load_index_info);
         AppendIndexV2(trace, cload_index_info);
         UpdateSealedSegmentIndex(segment.get(), cload_index_info);

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -2651,7 +2651,7 @@ ChunkedSegmentSealedImpl::Reopen(
     const milvus::proto::segcore::SegmentLoadInfo& new_load_info) {
     // TODO: add op_ctx for Reopen
     milvus::OpContext* op_ctx = nullptr;
-    SegmentLoadInfo new_seg_load_info(new_load_info);
+    SegmentLoadInfo new_seg_load_info(new_load_info, schema_);
 
     SegmentLoadInfo current;
     {
@@ -2676,7 +2676,12 @@ ChunkedSegmentSealedImpl::ApplyLoadDiff(SegmentLoadInfo& segment_load_info,
         LoadBatchIndexes(trace_ctx, diff.indexes_to_load, op_ctx);
     }
 
-    // drop index
+    // reload fields
+    if (!diff.fields_to_reload.empty()) {
+        ReloadColumns(diff.fields_to_reload);
+    }
+
+    // drop index, must after reload binlog
     if (!diff.indexes_to_drop.empty()) {
         for (auto field_id : diff.indexes_to_drop) {
             DropIndex(field_id);
@@ -2684,7 +2689,8 @@ ChunkedSegmentSealedImpl::ApplyLoadDiff(SegmentLoadInfo& segment_load_info,
     }
 
     // load column groups
-    if (!diff.column_groups_to_load.empty()) {
+    if (!diff.column_groups_to_load.empty() ||
+        !diff.column_groups_to_lazyload.empty()) {
         auto properties =
             milvus::storage::LoonFFIPropertiesSingleton::GetInstance()
                 .GetProperties();
@@ -2692,7 +2698,16 @@ ChunkedSegmentSealedImpl::ApplyLoadDiff(SegmentLoadInfo& segment_load_info,
         auto arrow_schema = schema_->ConvertToArrowSchema();
         reader_ = milvus_storage::api::Reader::create(
             column_groups, arrow_schema, nullptr, *properties);
-        LoadColumnGroups(column_groups, properties, diff.column_groups_to_load);
+        if (!diff.column_groups_to_load.empty()) {
+            LoadColumnGroups(
+                column_groups, properties, diff.column_groups_to_load, true);
+        }
+        if (!diff.column_groups_to_lazyload.empty()) {
+            LoadColumnGroups(column_groups,
+                             properties,
+                             diff.column_groups_to_lazyload,
+                             false);
+        }
     }
 
     // load field binlog
@@ -2846,7 +2861,7 @@ void
 ChunkedSegmentSealedImpl::SetLoadInfo(
     const proto::segcore::SegmentLoadInfo& load_info) {
     std::unique_lock lck(mutex_);
-    segment_load_info_ = SegmentLoadInfo(load_info);
+    segment_load_info_ = SegmentLoadInfo(load_info, schema_);
     LOG_INFO(
         "SetLoadInfo for segment {}, num_rows: {}, index count: {}, "
         "storage_version: {}",
@@ -2857,48 +2872,26 @@ ChunkedSegmentSealedImpl::SetLoadInfo(
 }
 
 void
-ChunkedSegmentSealedImpl::LoadManifest(const std::string& manifest_path,
-                                       milvus::OpContext* op_ctx) {
-    LOG_INFO(
-        "Loading segment {} field data with manifest {}", id_, manifest_path);
-    auto properties = milvus::storage::LoonFFIPropertiesSingleton::GetInstance()
-                          .GetProperties();
-
-    auto column_groups = segment_load_info_.GetColumnGroups();
-
-    auto arrow_schema = schema_->ConvertToArrowSchema();
-    reader_ = milvus_storage::api::Reader::create(
-        column_groups, arrow_schema, nullptr, *properties);
-
-    std::vector<std::pair<int, std::vector<FieldId>>> cg_field_ids;
-    for (int i = 0; i < column_groups->size(); ++i) {
-        auto column_group = column_groups->get_column_group(i);
-        std::vector<FieldId> milvus_field_ids;
-        for (auto& column : column_group->columns) {
-            auto field_id = std::stoll(column);
-            milvus_field_ids.emplace_back(field_id);
-        }
-        cg_field_ids.emplace_back(i, std::move(milvus_field_ids));
-    }
-
-    LoadColumnGroups(column_groups, properties, cg_field_ids, op_ctx);
-}
-
-void
 ChunkedSegmentSealedImpl::LoadColumnGroups(
     const std::shared_ptr<milvus_storage::api::ColumnGroups>& column_groups,
     const std::shared_ptr<milvus_storage::api::Properties>& properties,
     std::vector<std::pair<int, std::vector<FieldId>>>& cg_field_ids,
+    bool eager_load,
     milvus::OpContext* op_ctx) {
     auto& pool = ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::LOW);
     std::vector<std::future<void>> load_group_futures;
     for (const auto& pair : cg_field_ids) {
         auto cg_index = pair.first;
         const auto& field_ids = pair.second;
-        auto future =
-            pool.Submit([this, column_groups, properties, cg_index, field_ids] {
-                LoadColumnGroup(column_groups, properties, cg_index, field_ids);
-            });
+        auto future = pool.Submit([this,
+                                   column_groups,
+                                   properties,
+                                   cg_index,
+                                   field_ids,
+                                   eager_load]() {
+            LoadColumnGroup(
+                column_groups, properties, cg_index, field_ids, eager_load);
+        });
         load_group_futures.emplace_back(std::move(future));
     }
 
@@ -2929,6 +2922,7 @@ ChunkedSegmentSealedImpl::LoadColumnGroup(
     const std::shared_ptr<milvus_storage::api::Properties>& properties,
     int64_t index,
     const std::vector<FieldId>& milvus_field_ids,
+    bool eager_load,
     milvus::OpContext* op_ctx) {
     AssertInfo(index < column_groups->size(),
                "load column group index out of range");
@@ -2938,7 +2932,6 @@ ChunkedSegmentSealedImpl::LoadColumnGroup(
 
     // assumption: vector field occupies whole column group
     bool is_vector = false;
-    bool index_has_rawdata = true;
     bool has_mmap_setting = false;
     bool mmap_enabled = false;
     bool has_warmup_setting = false;
@@ -2949,11 +2942,6 @@ ChunkedSegmentSealedImpl::LoadColumnGroup(
         }
         std::shared_lock lck(mutex_);
         auto iter = index_has_raw_data_.find(field_id);
-        if (iter != index_has_raw_data_.end()) {
-            index_has_rawdata = index_has_rawdata && iter->second;
-        } else {
-            index_has_rawdata = false;
-        }
 
         // if field has mmap setting, use it
         // - mmap setting at collection level, then all field are the same
@@ -3027,6 +3015,7 @@ ChunkedSegmentSealedImpl::LoadColumnGroup(
             mmap_dir_path,
             column_group->columns.size(),
             segment_load_info_.GetPriority(),
+            eager_load,
             warmup_policy);
     auto chunked_column_group =
         std::make_shared<ChunkedColumnGroup>(std::move(translator));
@@ -3077,9 +3066,25 @@ ChunkedSegmentSealedImpl::LoadColumnGroup(
 }
 
 void
+ChunkedSegmentSealedImpl::ReloadColumns(const std::vector<FieldId>& field_ids) {
+    for (auto& field_id : field_ids) {
+        auto column = get_column(field_id);
+        AssertInfo(column != nullptr,
+                   "cannot reload non-existing field column {}",
+                   field_id.get());
+        auto num_chunks = column->num_chunks();
+        std::vector<int64_t> chunk_ids(num_chunks);
+        for (int64_t chunk_id = 0; chunk_id < num_chunks; chunk_id++) {
+            chunk_ids[chunk_id] = chunk_id;
+        }
+        column->PrefetchChunks(nullptr, chunk_ids);
+    }
+}
+
+void
 ChunkedSegmentSealedImpl::LoadBatchIndexes(
     milvus::tracer::TraceContext& trace_ctx,
-    std::map<FieldId, std::vector<const proto::segcore::FieldIndexInfo*>>&
+    std::unordered_map<FieldId, std::vector<LoadIndexInfo>>&
         field_id_to_index_info,
     milvus::OpContext* op_ctx) {
     auto num_rows = segment_load_info_.GetNumOfRows();
@@ -3087,30 +3092,27 @@ ChunkedSegmentSealedImpl::LoadBatchIndexes(
     std::vector<std::future<void>> load_index_futures;
     load_index_futures.reserve(field_id_to_index_info.size());
 
-    for (const auto& pair : field_id_to_index_info) {
+    for (auto& pair : field_id_to_index_info) {
         auto field_id = pair.first;
-        auto index_infos = pair.second;
-        for (const auto& index_info_ptr : index_infos) {
+        auto& index_infos = pair.second;
+        for (auto& load_index_info : index_infos) {
+            auto* load_index_info_ptr = &load_index_info;
             auto future = pool.Submit([this,
                                        trace_ctx,
                                        field_id,
-                                       index_info_ptr,
+                                       load_index_info_ptr,
                                        num_rows,
                                        op_ctx]() mutable -> void {
-                CheckCancellation(op_ctx, id_, field_id.get(), "LoadIndex");
-                auto load_index_info =
-                    segment_load_info_.ConvertFieldIndexInfoToLoadIndexInfo(
-                        index_info_ptr, *schema_, id_);
                 LOG_INFO("Loading index for segment {} field {} with {} files",
                          id_,
                          field_id.get(),
-                         load_index_info.index_files.size());
+                         load_index_info_ptr->index_files.size());
 
                 // Download & compose index
-                LoadIndexData(trace_ctx, &load_index_info, op_ctx);
+                LoadIndexData(trace_ctx, load_index_info_ptr, op_ctx);
 
                 // Load index into segment
-                LoadIndex(load_index_info);
+                LoadIndex(*load_index_info_ptr);
             });
 
             load_index_futures.push_back(std::move(future));

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -2662,6 +2662,7 @@ ChunkedSegmentSealedImpl::Reopen(
 
     // compute load diff
     auto diff = current.ComputeDiff(new_seg_load_info);
+    LOG_INFO("Reopen segment {} with diff {}", id_, diff.ToString());
     ApplyLoadDiff(new_seg_load_info, diff);
 
     LOG_INFO("Reopen segment {} done", id_);
@@ -3305,6 +3306,7 @@ ChunkedSegmentSealedImpl::Load(milvus::tracer::TraceContext& trace_ctx,
     LOG_INFO("Loading segment {} with {} rows", id_, num_rows);
 
     auto diff = segment_load_info_.GetLoadDiff();
+    LOG_WARN("Load segment {} with diff {}", id_, diff.ToString());
     ApplyLoadDiff(segment_load_info_, diff);
 
     LOG_INFO("Successfully loaded segment {} with {} rows", id_, num_rows);

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -2880,11 +2880,7 @@ ChunkedSegmentSealedImpl::LoadManifest(const std::string& manifest_path,
         cg_field_ids.emplace_back(i, std::move(milvus_field_ids));
     }
 
-<<<<<<< HEAD
-    LoadColumnGroups(column_groups, properties, cg_field_ids_map, op_ctx);
-=======
-    LoadColumnGroups(column_groups, properties, cg_field_ids);
->>>>>>> 48f8b3b585 (enhance: Unify segment Load and Reopen through diff-based loading (#46536))
+    LoadColumnGroups(column_groups, properties, cg_field_ids, op_ctx);
 }
 
 void
@@ -3013,6 +3009,10 @@ ChunkedSegmentSealedImpl::LoadColumnGroup(
     LOG_INFO("[StorageV2] segment {} loads manifest cg index {}",
              this->get_segment_id(),
              index);
+    auto mmap_dir_path =
+        milvus::storage::LocalChunkManagerSingleton::GetInstance()
+            .GetChunkManager()
+            ->GetRootPath();
 
     auto translator =
         std::make_unique<storagev2translator::ManifestGroupTranslator>(

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -979,7 +979,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     LoadColumnGroups(
         const std::shared_ptr<milvus_storage::api::ColumnGroups>& column_groups,
         const std::shared_ptr<milvus_storage::api::Properties>& properties,
-        std::map<int, std::vector<FieldId>>& cg_field_ids_map,
+        std::vector<std::pair<int, std::vector<FieldId>>>& cg_field_ids,
         milvus::OpContext* op_ctx = nullptr);
 
     /**
@@ -999,6 +999,19 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         int64_t index,
         const std::vector<FieldId>& milvus_field_ids,
         milvus::OpContext* op_ctx = nullptr);
+
+    /**
+     * @brief Apply load differences to update segment load information
+     *
+     * This method processes the differences between current and new load states,
+     * updating the segment's loaded fields and indexes accordingly. It handles
+     * incremental updates during segment reopen operations.
+     *
+     * @param segment_load_info The segment load information to be updated
+     * @param load_diff The differences to apply, containing fields and indexes to add/remove
+     */
+    void
+    ApplyLoadDiff(SegmentLoadInfo& segment_load_info, LoadDiff& load_diff);
 
     void
     load_field_data_common(

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -1009,9 +1009,12 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
      *
      * @param segment_load_info The segment load information to be updated
      * @param load_diff The differences to apply, containing fields and indexes to add/remove
+     * @param op_ctx The operation context
      */
     void
-    ApplyLoadDiff(SegmentLoadInfo& segment_load_info, LoadDiff& load_diff);
+    ApplyLoadDiff(SegmentLoadInfo& segment_load_info,
+                  LoadDiff& load_diff,
+                  milvus::OpContext* op_ctx = nullptr);
 
     void
     load_field_data_common(

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -952,7 +952,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     LoadBatchIndexes(milvus::tracer::TraceContext& trace_ctx,
                      std::unordered_map<FieldId, std::vector<LoadIndexInfo>>&
                          field_id_to_index_info,
-        milvus::OpContext* op_ctx = nullptr);
+                     milvus::OpContext* op_ctx = nullptr);
 
     void
     LoadBatchFieldData(milvus::tracer::TraceContext& trace_ctx,
@@ -994,9 +994,11 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
      * @brief Reloads columns from the specified field IDs
      *
      * @param field_ids_to_reload A vector of field IDs to reload
+     * @param op_ctx The operation context
      */
     void
-    ReloadColumns(const std::vector<FieldId>& field_ids_to_reload);
+    ReloadColumns(const std::vector<FieldId>& field_ids_to_reload,
+                  milvus::OpContext* op_ctx = nullptr);
 
     /**
      * @brief Apply load differences to update segment load information

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -949,10 +949,9 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                                     milvus::OpContext* op_ctx = nullptr);
 
     void
-    LoadBatchIndexes(
-        milvus::tracer::TraceContext& trace_ctx,
-        std::map<FieldId, std::vector<const proto::segcore::FieldIndexInfo*>>&
-            field_id_to_index_info,
+    LoadBatchIndexes(milvus::tracer::TraceContext& trace_ctx,
+                     std::unordered_map<FieldId, std::vector<LoadIndexInfo>>&
+                         field_id_to_index_info,
         milvus::OpContext* op_ctx = nullptr);
 
     void
@@ -962,24 +961,12 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                            field_binlog_to_load,
                        milvus::OpContext* op_ctx = nullptr);
 
-    /**
-     * @brief Load all column groups from a manifest file path
-     *
-     * This method reads the manifest file to retrieve column groups metadata
-     * and loads each column group into the segment.
-     *
-     * @param manifest_path JSON string containing base_path and version fields
-     * @param op_ctx Operation context
-     */
-    void
-    LoadManifest(const std::string& manifest_path,
-                 milvus::OpContext* op_ctx = nullptr);
-
     void
     LoadColumnGroups(
         const std::shared_ptr<milvus_storage::api::ColumnGroups>& column_groups,
         const std::shared_ptr<milvus_storage::api::Properties>& properties,
         std::vector<std::pair<int, std::vector<FieldId>>>& cg_field_ids,
+        bool eager_load,
         milvus::OpContext* op_ctx = nullptr);
 
     /**
@@ -991,6 +978,8 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
      * @param column_groups Metadata about all available column groups
      * @param properties Storage properties for accessing the data
      * @param index Index of the column group to load
+     * @param milvus_field_ids A vector of field IDs to load
+     * @param eager_load Whether to eagerly load provided columns
      */
     void
     LoadColumnGroup(
@@ -998,7 +987,16 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         const std::shared_ptr<milvus_storage::api::Properties>& properties,
         int64_t index,
         const std::vector<FieldId>& milvus_field_ids,
+        bool eager_load,
         milvus::OpContext* op_ctx = nullptr);
+
+    /**
+     * @brief Reloads columns from the specified field IDs
+     *
+     * @param field_ids_to_reload A vector of field IDs to reload
+     */
+    void
+    ReloadColumns(const std::vector<FieldId>& field_ids_to_reload);
 
     /**
      * @brief Apply load differences to update segment load information

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -1411,7 +1411,7 @@ SegmentGrowingImpl::LoadColumnsGroups(std::string manifest_path) {
     reader_ = milvus_storage::api::Reader::create(
         column_groups, arrow_schema, nullptr, *properties);
 
-    auto& pool = ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::LOW);
+    auto& pool = ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::MIDDLE);
     std::vector<
         std::future<std::unordered_map<FieldId, std::vector<FieldDataPtr>>>>
         load_group_futures;

--- a/internal/core/src/segcore/SegmentLoadInfo.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfo.cpp
@@ -195,7 +195,14 @@ SegmentLoadInfo::ComputeDiffBinlogs(LoadDiff& diff, SegmentLoadInfo& new_info) {
     std::map<int64_t, int64_t> current_fields;
     for (int i = 0; i < GetBinlogPathCount(); i++) {
         auto& field_binlog = GetBinlogPath(i);
-        for (auto child_id : field_binlog.child_fields()) {
+        std::vector<int64_t> child_fields(field_binlog.child_fields().begin(),
+                                          field_binlog.child_fields().end());
+        // v1 or legacy, group id == field id
+        if (child_fields.empty()) {
+            child_fields.emplace_back(field_binlog.fieldid());
+        }
+
+        for (auto child_id : child_fields) {
             current_fields[child_id] = field_binlog.fieldid();
         }
     }
@@ -204,7 +211,14 @@ SegmentLoadInfo::ComputeDiffBinlogs(LoadDiff& diff, SegmentLoadInfo& new_info) {
     for (int i = 0; i < new_info.GetBinlogPathCount(); i++) {
         auto& new_field_binlog = new_info.GetBinlogPath(i);
         std::vector<FieldId> ids_to_load;
-        for (auto child_id : new_field_binlog.child_fields()) {
+        std::vector<int64_t> child_fields(
+            new_field_binlog.child_fields().begin(),
+            new_field_binlog.child_fields().end());
+        // v1 or legacy, group id == field id
+        if (child_fields.empty()) {
+            child_fields.emplace_back(new_field_binlog.fieldid());
+        }
+        for (auto child_id : child_fields) {
             new_binlog_fields[child_id] = new_field_binlog.fieldid();
             auto iter = current_fields.find(new_field_binlog.fieldid());
             // Find binlogs to load: fields in new_info match current

--- a/internal/core/src/segcore/SegmentLoadInfo.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfo.cpp
@@ -9,6 +9,7 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
+#include "index/IndexFactory.h"
 #include "segcore/SegmentLoadInfo.h"
 
 #include <algorithm>
@@ -43,7 +44,6 @@ SegmentLoadInfo::GetColumnGroups() {
 LoadIndexInfo
 SegmentLoadInfo::ConvertFieldIndexInfoToLoadIndexInfo(
     const proto::segcore::FieldIndexInfo* field_index_info,
-    const Schema& schema,
     int64_t segment_id) const {
     LoadIndexInfo load_index_info;
 
@@ -54,7 +54,7 @@ SegmentLoadInfo::ConvertFieldIndexInfoToLoadIndexInfo(
     load_index_info.partition_id = GetPartitionID();
 
     // Get field type from schema
-    const auto& field_meta = schema[field_id];
+    const auto& field_meta = schema_->operator[](field_id);
     load_index_info.field_type = field_meta.get_data_type();
     load_index_info.element_type = field_meta.get_element_type();
 
@@ -119,72 +119,48 @@ SegmentLoadInfo::ConvertFieldIndexInfoToLoadIndexInfo(
     return load_index_info;
 }
 
-std::vector<LoadIndexInfo>
-SegmentLoadInfo::GetAllLoadIndexInfos(FieldId field_id,
-                                      const Schema& schema,
-                                      int64_t segment_id) const {
-    auto field_index_infos = GetFieldIndexInfos(field_id);
-    std::vector<LoadIndexInfo> result;
-    result.reserve(field_index_infos.size());
+bool
+SegmentLoadInfo::CheckIndexHasRawData(const LoadIndexInfo& load_index_info) {
+    auto request = milvus::index::IndexFactory::GetInstance().IndexLoadResource(
+        load_index_info.field_type,
+        load_index_info.element_type,
+        load_index_info.index_engine_version,
+        load_index_info.index_size,
+        load_index_info.index_params,
+        load_index_info.enable_mmap,
+        load_index_info.num_rows,
+        load_index_info.dim);
 
-    for (const auto* index_info : field_index_infos) {
-        result.push_back(ConvertFieldIndexInfoToLoadIndexInfo(
-            index_info, schema, segment_id));
-    }
-
-    return result;
-}
-
-std::map<FieldId, std::vector<LoadIndexInfo>>
-SegmentLoadInfo::GetAllLoadIndexInfos(const Schema& schema,
-                                      int64_t segment_id) const {
-    std::map<FieldId, std::vector<LoadIndexInfo>> result;
-
-    for (const auto& [field_id, index_infos] : field_index_cache_) {
-        std::vector<LoadIndexInfo> converted;
-        converted.reserve(index_infos.size());
-        for (const auto* index_info : index_infos) {
-            converted.push_back(ConvertFieldIndexInfoToLoadIndexInfo(
-                index_info, schema, segment_id));
-        }
-        result.emplace(field_id, std::move(converted));
-    }
-
-    return result;
+    return request.has_raw_data;
 }
 
 void
 SegmentLoadInfo::ComputeDiffIndexes(LoadDiff& diff, SegmentLoadInfo& new_info) {
-    // Get current indexed field IDs
+    // Get current index IDs from converted cache
     std::set<int64_t> current_index_ids;
-    for (auto const& index_info : GetIndexInfos()) {
-        if (index_info.index_file_paths_size() == 0) {
-            continue;
-        }
-        current_index_ids.insert(index_info.indexid());
+    for (const auto& load_index_info : converted_index_infos_) {
+        current_index_ids.insert(load_index_info.index_id);
     }
 
     std::set<int64_t> new_index_ids;
     // Find indexes to load: indexes in new_info but not in current
-    for (const auto& new_index_info : new_info.GetIndexInfos()) {
-        if (new_index_info.index_file_paths_size() == 0) {
-            continue;
-        }
-        new_index_ids.insert(new_index_info.indexid());
-        if (current_index_ids.find(new_index_info.indexid()) ==
-            current_index_ids.end()) {
-            diff.indexes_to_load[FieldId(new_index_info.fieldid())]
-                .emplace_back(&new_index_info);
+    // Use converted_field_index_cache_ from new_info
+    for (const auto& [field_id, load_index_infos] :
+         new_info.converted_field_index_cache_) {
+        for (const auto& load_index_info : load_index_infos) {
+            new_index_ids.insert(load_index_info.index_id);
+            if (current_index_ids.find(load_index_info.index_id) ==
+                current_index_ids.end()) {
+                diff.indexes_to_load[field_id].push_back(load_index_info);
+            }
         }
     }
 
     // Find indexes to drop: fields that have indexes in current but not in new_info
-    for (const auto& index_info : GetIndexInfos()) {
-        if (index_info.index_file_paths_size() == 0) {
-            continue;
-        }
-        if (new_index_ids.find(index_info.indexid()) == new_index_ids.end()) {
-            diff.indexes_to_drop.insert(FieldId(index_info.fieldid()));
+    for (const auto& load_index_info : converted_index_infos_) {
+        if (new_index_ids.find(load_index_info.index_id) ==
+            new_index_ids.end()) {
+            diff.indexes_to_drop.insert(FieldId(load_index_info.field_id));
         }
     }
 }
@@ -264,6 +240,7 @@ SegmentLoadInfo::ComputeDiffColumnGroups(LoadDiff& diff,
     for (int i = 0; i < new_column_group->size(); i++) {
         auto cg = new_column_group->get_column_group(i);
         std::vector<FieldId> fields;
+        std::vector<FieldId> lazy_fields;
         for (const auto& column : cg->columns) {
             auto field_id = std::stoll(column);
             new_field_ids.emplace(field_id, i);
@@ -271,11 +248,21 @@ SegmentLoadInfo::ComputeDiffColumnGroups(LoadDiff& diff,
             auto iter = cur_field_ids.find(field_id);
             // If this field doesn't exist in current, mark the column group for loading
             if (iter == cur_field_ids.end() || iter->second != i) {
-                fields.emplace_back(field_id);
+                if (schema_->ShouldLoadField(FieldId(field_id)) &&
+                    field_index_has_raw_data_.find(FieldId(field_id)) ==
+                        field_index_has_raw_data_.end()) {
+                    fields.emplace_back(field_id);
+                } else {
+                    // put lazy load & index_has_raw_data field in lazy_fields
+                    lazy_fields.emplace_back(field_id);
+                }
             }
         }
         if (!fields.empty()) {
             diff.column_groups_to_load.emplace_back(i, fields);
+        }
+        if (!lazy_fields.empty()) {
+            diff.column_groups_to_lazyload.emplace_back(i, lazy_fields);
         }
     }
 
@@ -287,12 +274,30 @@ SegmentLoadInfo::ComputeDiffColumnGroups(LoadDiff& diff,
     }
 }
 
+void
+SegmentLoadInfo::ComputeDiffReloadFields(LoadDiff& diff,
+                                         SegmentLoadInfo& new_info) {
+    // Find fields that were previously skipped (index had raw data)
+    // but now need loading (index no longer has raw data or was dropped)
+    for (const auto& field_id : field_index_has_raw_data_) {
+        // If new_info doesn't have this field in index_has_raw_data_,
+        // we need to reload the field data
+        if (new_info.field_index_has_raw_data_.find(field_id) ==
+            new_info.field_index_has_raw_data_.end()) {
+            diff.fields_to_reload.emplace_back(field_id);
+        }
+    }
+}
+
 LoadDiff
 SegmentLoadInfo::ComputeDiff(SegmentLoadInfo& new_info) {
     LoadDiff diff;
 
     // Handle index changes
     ComputeDiffIndexes(diff, new_info);
+
+    // Compute fields that need to be reloaded due to index raw data changes
+    ComputeDiffReloadFields(diff, new_info);
 
     // Handle field data changes
     // Note: Updates can only happen within the same category:

--- a/internal/core/src/segcore/SegmentLoadInfo.h
+++ b/internal/core/src/segcore/SegmentLoadInfo.h
@@ -44,8 +44,9 @@ struct LoadDiff {
     std::vector<std::pair<std::vector<FieldId>, proto::segcore::FieldBinlog>>
         binlogs_to_load;
 
-    // Field id to column group index to be loaded
-    std::map<int, std::vector<FieldId>> column_groups_to_load;
+    // list of column group indices and related field ids to load
+    // same index could appear multiple times if same group using different setups
+    std::vector<std::pair<int, std::vector<FieldId>>> column_groups_to_load;
 
     // Indexes that need to be dropped (field_id set)
     std::set<FieldId> indexes_to_drop;
@@ -576,6 +577,17 @@ class SegmentLoadInfo {
      */
     [[nodiscard]] LoadDiff
     ComputeDiff(SegmentLoadInfo& new_info);
+
+    /**
+     * @brief Get the LoadDiff from the current SegmentLoadInfo
+     *
+     * This method produces a LoadDiff that describes what needs to be loaded when 
+     * load with current load info.
+     *
+     * @return LoadDiff containing the differences
+     */
+    [[nodiscard]] LoadDiff
+    GetLoadDiff();
 
     // ==================== Underlying Proto Access ====================
 

--- a/internal/core/src/segcore/SegmentLoadInfo.h
+++ b/internal/core/src/segcore/SegmentLoadInfo.h
@@ -16,6 +16,8 @@
 #include <set>
 #include <sstream>
 #include <string>
+#include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "common/Schema.h"
@@ -36,9 +38,8 @@ namespace milvus::segcore {
  * Cross-category changes (binlog <-> manifest) are not supported.
  */
 struct LoadDiff {
-    // Indexes that need to be loaded (field_id -> list of FieldIndexInfo pointers)
-    std::map<FieldId, std::vector<const proto::segcore::FieldIndexInfo*>>
-        indexes_to_load;
+    // Indexes that need to be loaded (field_id -> list of LoadIndexInfo)
+    std::unordered_map<FieldId, std::vector<LoadIndexInfo>> indexes_to_load;
 
     // Field binlog paths that need to be loaded [field_ids,FieldBinlog]
     // Only populated when both current and new use binlog mode
@@ -49,12 +50,18 @@ struct LoadDiff {
     // same index could appear multiple times if same group using different setups
     std::vector<std::pair<int, std::vector<FieldId>>> column_groups_to_load;
 
+    // list of column group indices and related field ids to lazy load
+    // used for lazy load fields or fields with index has raw data
+    std::vector<std::pair<int, std::vector<FieldId>>> column_groups_to_lazyload;
+
+    std::vector<FieldId> fields_to_reload;
+
     // Indexes that need to be dropped (field_id set)
     std::set<FieldId> indexes_to_drop;
 
     // Field data that need to be dropped (field_id set)
     // Only populated when both current and new use binlog mode
-    std::set<FieldId> field_data_to_drop;
+    std::unordered_set<FieldId> field_data_to_drop;
 
     // Whether manifest path has changed (only when both use manifest mode)
     bool manifest_updated = false;
@@ -65,8 +72,9 @@ struct LoadDiff {
     [[nodiscard]] bool
     HasChanges() const {
         return !indexes_to_load.empty() || !binlogs_to_load.empty() ||
-               !column_groups_to_load.empty() || !indexes_to_drop.empty() ||
-               !field_data_to_drop.empty() || manifest_updated;
+               !column_groups_to_load.empty() || !fields_to_reload.empty() ||
+               !indexes_to_drop.empty() || !field_data_to_drop.empty() ||
+               manifest_updated;
     }
 
     [[nodiscard]] bool
@@ -178,26 +186,29 @@ class SegmentLoadInfo {
      * @brief Construct from a protobuf SegmentLoadInfo (copy)
      * @param info The protobuf SegmentLoadInfo to wrap
      */
-    explicit SegmentLoadInfo(const ProtoType& info) : info_(info) {
-        BuildIndexCache();
+    explicit SegmentLoadInfo(const ProtoType& info, SchemaPtr schema)
+        : info_(info), schema_(std::move(schema)) {
+        BuildCache();
     }
 
     /**
      * @brief Construct from a protobuf SegmentLoadInfo (move)
      * @param info The protobuf SegmentLoadInfo to wrap
      */
-    explicit SegmentLoadInfo(ProtoType&& info) : info_(std::move(info)) {
-        BuildIndexCache();
+    explicit SegmentLoadInfo(ProtoType&& info, SchemaPtr schema)
+        : info_(std::move(info)), schema_(std::move(schema)) {
+        BuildCache();
     }
 
     /**
      * @brief Copy constructor
+     * @note Rebuilds cache instead of copying (LoadIndexInfo is not copyable)
      */
     SegmentLoadInfo(const SegmentLoadInfo& other)
         : info_(other.info_),
-          field_index_cache_(other.field_index_cache_),
-          field_binlog_cache_(other.field_binlog_cache_),
+          schema_(other.schema_),
           column_groups_(other.column_groups_) {
+        BuildCache();
     }
 
     /**
@@ -205,21 +216,25 @@ class SegmentLoadInfo {
      */
     SegmentLoadInfo(SegmentLoadInfo&& other) noexcept
         : info_(std::move(other.info_)),
-          field_index_cache_(std::move(other.field_index_cache_)),
+          schema_(std::move(other.schema_)),
+          converted_index_infos_(std::move(other.converted_index_infos_)),
+          converted_field_index_cache_(
+              std::move(other.converted_field_index_cache_)),
           field_binlog_cache_(std::move(other.field_binlog_cache_)),
           column_groups_(std::move(other.column_groups_)) {
     }
 
     /**
      * @brief Copy assignment operator
+     * @note Rebuilds cache instead of copying (LoadIndexInfo is not copyable)
      */
     SegmentLoadInfo&
     operator=(const SegmentLoadInfo& other) {
         if (this != &other) {
             info_ = other.info_;
-            field_index_cache_ = other.field_index_cache_;
-            field_binlog_cache_ = other.field_binlog_cache_;
+            schema_ = other.schema_;
             column_groups_ = other.column_groups_;
+            BuildCache();
         }
         return *this;
     }
@@ -231,7 +246,10 @@ class SegmentLoadInfo {
     operator=(SegmentLoadInfo&& other) noexcept {
         if (this != &other) {
             info_ = std::move(other.info_);
-            field_index_cache_ = std::move(other.field_index_cache_);
+            schema_ = std::move(other.schema_);
+            converted_index_infos_ = std::move(other.converted_index_infos_);
+            converted_field_index_cache_ =
+                std::move(other.converted_field_index_cache_);
             field_binlog_cache_ = std::move(other.field_binlog_cache_);
             column_groups_ = std::move(other.column_groups_);
         }
@@ -242,18 +260,20 @@ class SegmentLoadInfo {
      * @brief Set from protobuf (copy)
      */
     void
-    Set(const ProtoType& info) {
+    Set(const ProtoType& info, SchemaPtr schema) {
         info_ = info;
-        BuildIndexCache();
+        schema_ = std::move(schema);
+        BuildCache();
     }
 
     /**
      * @brief Set from protobuf (move)
      */
     void
-    Set(ProtoType&& info) {
+    Set(ProtoType&& info, SchemaPtr schema) {
         info_ = std::move(info);
-        BuildIndexCache();
+        schema_ = std::move(schema);
+        BuildCache();
     }
 
     // ==================== Basic Accessors ====================
@@ -365,7 +385,8 @@ class SegmentLoadInfo {
      */
     [[nodiscard]] bool
     HasIndexInfo(FieldId field_id) const {
-        return field_index_cache_.find(field_id) != field_index_cache_.end();
+        return converted_field_index_cache_.find(field_id) !=
+               converted_field_index_cache_.end();
     }
 
     /**
@@ -373,27 +394,13 @@ class SegmentLoadInfo {
      * @param field_id The field ID
      * @return Vector of pointers to FieldIndexInfo, empty if field has no index
      */
-    [[nodiscard]] std::vector<const proto::segcore::FieldIndexInfo*>
+    [[nodiscard]] std::vector<LoadIndexInfo>
     GetFieldIndexInfos(FieldId field_id) const {
-        auto it = field_index_cache_.find(field_id);
-        if (it != field_index_cache_.end()) {
+        auto it = converted_field_index_cache_.find(field_id);
+        if (it != converted_field_index_cache_.end()) {
             return it->second;
         }
         return {};
-    }
-
-    /**
-     * @brief Get the first index info for a specific field
-     * @param field_id The field ID
-     * @return Pointer to FieldIndexInfo, nullptr if field has no index
-     */
-    [[nodiscard]] const proto::segcore::FieldIndexInfo*
-    GetFirstFieldIndexInfo(FieldId field_id) const {
-        auto it = field_index_cache_.find(field_id);
-        if (it != field_index_cache_.end() && !it->second.empty()) {
-            return it->second[0];
-        }
-        return nullptr;
     }
 
     /**
@@ -403,7 +410,7 @@ class SegmentLoadInfo {
     [[nodiscard]] std::set<FieldId>
     GetIndexedFieldIds() const {
         std::set<FieldId> result;
-        for (const auto& pair : field_index_cache_) {
+        for (const auto& pair : converted_field_index_cache_) {
             result.insert(pair.first);
         }
         return result;
@@ -696,7 +703,7 @@ class SegmentLoadInfo {
      */
     void
     RebuildCache() {
-        BuildIndexCache();
+        BuildCache();
     }
 
     /**
@@ -716,65 +723,56 @@ class SegmentLoadInfo {
      * LoadIndexInfo structure used for loading indexes.
      *
      * @param field_index_info Pointer to the FieldIndexInfo to convert
-     * @param schema The schema to get field metadata from
      * @param segment_id The segment ID for the LoadIndexInfo
      * @return LoadIndexInfo structure populated with the converted data
      */
     [[nodiscard]] LoadIndexInfo
     ConvertFieldIndexInfoToLoadIndexInfo(
         const proto::segcore::FieldIndexInfo* field_index_info,
-        const Schema& schema,
         int64_t segment_id) const;
 
     /**
-     * @brief Get all LoadIndexInfos for a specific field
-     *
-     * Converts all index infos for the given field to LoadIndexInfo structures.
-     * A field may have multiple indexes (e.g., for JSON fields with multiple paths).
-     *
-     * @param field_id The field ID to get LoadIndexInfos for
-     * @param schema The schema to get field metadata from
-     * @param segment_id The segment ID for the LoadIndexInfo
-     * @return Vector of LoadIndexInfo structures, empty if field has no indexes
-     */
-    [[nodiscard]] std::vector<LoadIndexInfo>
-    GetAllLoadIndexInfos(FieldId field_id,
-                         const Schema& schema,
-                         int64_t segment_id) const;
-
-    /**
-     * @brief Get LoadIndexInfos for all indexed fields
-     *
-     * Converts all index infos in this SegmentLoadInfo to LoadIndexInfo structures.
-     *
-     * @param schema The schema to get field metadata from
-     * @param segment_id The segment ID for the LoadIndexInfo
-     * @return Map from field ID to vector of LoadIndexInfo structures
-     */
-    [[nodiscard]] std::map<FieldId, std::vector<LoadIndexInfo>>
-    GetAllLoadIndexInfos(const Schema& schema, int64_t segment_id) const;
+    * @brief Check if a field's index has raw data
+    *
+    * Determines whether the index for a given field contains raw data
+    * by querying the IndexFactory with the index parameters.
+    *
+    * @param load_index_info The LoadIndexInfo containing index parameters
+    * @return true if the index has raw data, false otherwise
+    */
+    [[nodiscard]] static bool
+    CheckIndexHasRawData(const LoadIndexInfo& load_index_info);
 
  private:
     void
-    BuildIndexCache() {
-        field_index_cache_.clear();
+    BuildCache() {
         field_binlog_cache_.clear();
-
-        // Build index cache
-        for (int i = 0; i < info_.index_infos_size(); i++) {
-            const auto& index_info = info_.index_infos(i);
-            if (index_info.index_file_paths_size() == 0) {
-                continue;
-            }
-            auto field_id = FieldId(index_info.fieldid());
-            field_index_cache_[field_id].push_back(&index_info);
-        }
-
         // Build binlog cache
         for (int i = 0; i < info_.binlog_paths_size(); i++) {
             const auto& binlog = info_.binlog_paths(i);
             auto field_id = FieldId(binlog.fieldid());
             field_binlog_cache_[field_id] = &binlog;
+        }
+
+        // Convert index infos to LoadIndexInfo and build per-field cache
+        converted_index_infos_.clear();
+        converted_field_index_cache_.clear();
+        field_index_has_raw_data_.clear();
+        for (int i = 0; i < info_.index_infos_size(); i++) {
+            const auto& index_info = info_.index_infos(i);
+            if (index_info.index_file_paths_size() == 0) {
+                continue;
+            }
+            auto load_index_info = ConvertFieldIndexInfoToLoadIndexInfo(
+                &index_info, info_.segmentid());
+            converted_index_infos_.push_back(load_index_info);
+            auto field_id = FieldId(index_info.fieldid());
+            // Check if index has raw data before moving
+            if (CheckIndexHasRawData(load_index_info)) {
+                field_index_has_raw_data_.insert(field_id);
+            }
+            converted_field_index_cache_[field_id].push_back(
+                std::move(load_index_info));
         }
     }
 
@@ -787,11 +785,21 @@ class SegmentLoadInfo {
     void
     ComputeDiffColumnGroups(LoadDiff& diff, SegmentLoadInfo& new_info);
 
+    void
+    ComputeDiffReloadFields(LoadDiff& diff, SegmentLoadInfo& new_info);
+
     ProtoType info_;
 
-    // Cache for quick field -> index info lookup
-    std::map<FieldId, std::vector<const proto::segcore::FieldIndexInfo*>>
-        field_index_cache_;
+    SchemaPtr schema_;
+
+    std::vector<LoadIndexInfo> converted_index_infos_;
+
+    // Cache for quick field -> converted LoadIndexInfo lookup
+    std::unordered_map<FieldId, std::vector<LoadIndexInfo>>
+        converted_field_index_cache_;
+
+    // set of field ids that corresponding index has raw data
+    std::set<FieldId> field_index_has_raw_data_;
 
     // Cache for quick field -> binlog lookup
     std::map<FieldId, const proto::segcore::FieldBinlog*> field_binlog_cache_;

--- a/internal/core/src/segcore/SegmentLoadInfo.h
+++ b/internal/core/src/segcore/SegmentLoadInfo.h
@@ -14,6 +14,7 @@
 #include <map>
 #include <optional>
 #include <set>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -71,6 +72,88 @@ struct LoadDiff {
     [[nodiscard]] bool
     HasManifestChange() const {
         return manifest_updated;
+    }
+
+    [[nodiscard]] std::string
+    ToString() const {
+        std::ostringstream oss;
+        oss << "LoadDiff{";
+
+        // indexes_to_load
+        oss << "indexes_to_load=[";
+        bool first = true;
+        for (const auto& [field_id, infos] : indexes_to_load) {
+            if (!first)
+                oss << ", ";
+            first = false;
+            oss << field_id.get() << ":" << infos.size() << " indexes";
+        }
+        oss << "], ";
+
+        // binlogs_to_load
+        oss << "binlogs_to_load=[";
+        first = true;
+        for (const auto& [field_ids, binlog] : binlogs_to_load) {
+            if (!first)
+                oss << ", ";
+            first = false;
+            oss << "[";
+            for (size_t i = 0; i < field_ids.size(); ++i) {
+                if (i > 0)
+                    oss << ",";
+                oss << field_ids[i].get();
+            }
+            oss << "]";
+        }
+        oss << "], ";
+
+        // column_groups_to_load
+        oss << "column_groups_to_load=[";
+        first = true;
+        for (const auto& [group_idx, field_ids] : column_groups_to_load) {
+            if (!first)
+                oss << ", ";
+            first = false;
+            oss << "group" << group_idx << ":[";
+            for (size_t i = 0; i < field_ids.size(); ++i) {
+                if (i > 0)
+                    oss << ",";
+                oss << field_ids[i].get();
+            }
+            oss << "]";
+        }
+        oss << "], ";
+
+        // indexes_to_drop
+        oss << "indexes_to_drop=[";
+        first = true;
+        for (const auto& field_id : indexes_to_drop) {
+            if (!first)
+                oss << ", ";
+            first = false;
+            oss << field_id.get();
+        }
+        oss << "], ";
+
+        // field_data_to_drop
+        oss << "field_data_to_drop=[";
+        first = true;
+        for (const auto& field_id : field_data_to_drop) {
+            if (!first)
+                oss << ", ";
+            first = false;
+            oss << field_id.get();
+        }
+        oss << "], ";
+
+        // manifest_updated and new_manifest_path
+        oss << "manifest_updated=" << (manifest_updated ? "true" : "false");
+        if (manifest_updated) {
+            oss << ", new_manifest_path=" << new_manifest_path;
+        }
+
+        oss << "}";
+        return oss.str();
     }
 };
 

--- a/internal/core/src/segcore/Types.h
+++ b/internal/core/src/segcore/Types.h
@@ -58,6 +58,71 @@ struct LoadIndexInfo {
     int64_t dim;
     std::string
         warmup_policy;  // "disable" or "sync", empty means use global config
+
+    // Default constructor
+    LoadIndexInfo() = default;
+
+    // Move constructor and assignment - use defaults
+    LoadIndexInfo(LoadIndexInfo&&) = default;
+    LoadIndexInfo&
+    operator=(LoadIndexInfo&&) = default;
+
+    // Copy constructor - copies metadata, leaves index pointers as nullptr
+    // since they are populated later during actual index loading
+    LoadIndexInfo(const LoadIndexInfo& other)
+        : collection_id(other.collection_id),
+          partition_id(other.partition_id),
+          segment_id(other.segment_id),
+          field_id(other.field_id),
+          field_type(other.field_type),
+          element_type(other.element_type),
+          enable_mmap(other.enable_mmap),
+          mmap_dir_path(other.mmap_dir_path),
+          index_id(other.index_id),
+          index_build_id(other.index_build_id),
+          index_version(other.index_version),
+          index_params(other.index_params),
+          index_files(other.index_files),
+          index(nullptr),
+          cache_index(nullptr),
+          uri(other.uri),
+          index_store_version(other.index_store_version),
+          index_engine_version(other.index_engine_version),
+          schema(other.schema),
+          index_size(other.index_size),
+          num_rows(other.num_rows),
+          dim(other.dim) {
+    }
+
+    // Copy assignment operator
+    LoadIndexInfo&
+    operator=(const LoadIndexInfo& other) {
+        if (this != &other) {
+            collection_id = other.collection_id;
+            partition_id = other.partition_id;
+            segment_id = other.segment_id;
+            field_id = other.field_id;
+            field_type = other.field_type;
+            element_type = other.element_type;
+            enable_mmap = other.enable_mmap;
+            mmap_dir_path = other.mmap_dir_path;
+            index_id = other.index_id;
+            index_build_id = other.index_build_id;
+            index_version = other.index_version;
+            index_params = other.index_params;
+            index_files = other.index_files;
+            index = nullptr;
+            cache_index = nullptr;
+            uri = other.uri;
+            index_store_version = other.index_store_version;
+            index_engine_version = other.index_engine_version;
+            schema = other.schema;
+            index_size = other.index_size;
+            num_rows = other.num_rows;
+            dim = other.dim;
+        }
+        return *this;
+    }
 };
 
 }  // namespace milvus::segcore

--- a/internal/core/src/segcore/Types.h
+++ b/internal/core/src/segcore/Types.h
@@ -91,7 +91,8 @@ struct LoadIndexInfo {
           schema(other.schema),
           index_size(other.index_size),
           num_rows(other.num_rows),
-          dim(other.dim) {
+          dim(other.dim),
+          warmup_policy(other.warmup_policy) {
     }
 
     // Copy assignment operator
@@ -120,6 +121,7 @@ struct LoadIndexInfo {
             index_size = other.index_size;
             num_rows = other.num_rows;
             dim = other.dim;
+            warmup_policy = other.warmup_policy;
         }
         return *this;
     }

--- a/internal/core/src/segcore/storagev1translator/ChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/ChunkTranslator.cpp
@@ -168,14 +168,12 @@ ChunkTranslator::get_cells(
         remote_files.push_back(file_infos_[cid].file_path);
     }
 
-    auto& pool = ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::MIDDLE);
     auto channel = std::make_shared<ArrowReaderChannel>();
     LOG_INFO("segment {} submits load field {} chunks {} task to thread pool",
              segment_id_,
              field_id_,
              fmt::format("{}", fmt::join(cids, " ")));
-    pool.Submit(
-        LoadArrowReaderFromRemote, remote_files, channel, load_priority_);
+    LoadArrowReaderFromRemote(remote_files, channel, load_priority_);
 
     auto data_type = field_meta_.get_data_type();
 

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
@@ -60,6 +60,7 @@ ManifestGroupTranslator::ManifestGroupTranslator(
     const std::string& mmap_dir_path,
     int64_t num_fields,
     milvus::proto::common::LoadPriority load_priority,
+    bool eager_load,
     const std::string& warmup_policy)
     : segment_id_(segment_id),
       group_chunk_type_(group_chunk_type),
@@ -95,7 +96,8 @@ ManifestGroupTranslator::ManifestGroupTranslator(
                     }
                     return false;
                 }(),
-                /* is_index */ false),
+                /* is_index */ false,
+                /* in_load_list*/ eager_load),
             /* support_eviction */ true),
       use_mmap_(use_mmap),
       mmap_populate_(mmap_populate),

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.h
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.h
@@ -68,6 +68,7 @@ class ManifestGroupTranslator
         const std::string& mmap_dir_path,
         int64_t num_fields,
         milvus::proto::common::LoadPriority load_priority,
+        bool eager_load,
         const std::string& warmup_policy);
     ~ManifestGroupTranslator() = default;
 


### PR DESCRIPTION
Cherry-pick from master
pr: #46536 #46471 #46598 #47061 #47299
Related to #45060

Refactor segment loading to use a unified diff-based approach for both
initial Load and Reopen operations:

- Extract ApplyLoadDiff from Reopen to share loading logic
- Add GetLoadDiff to compute diff from empty state for initial load
- Change column_groups_to_load from map to vector<pair> to preserve
order
- Add validation for empty index file paths in diff computation
- Add comprehensive unit tests for GetLoadDiff
---------

When loading column groups with mmap enabled, the
ManifestGroupTranslator needs the mmap directory path to properly handle
memory-mapped data loading. This change retrieves the root path from
LocalChunkManagerSingleton and passes it to the translator during
construction.

---------

When computing load diff, binlogs in v1/legacy format have empty
child_fields. In this case, the field_id itself should be used as the
child_id (group_id == field_id for legacy format).

Without this fix, legacy format binlogs are not recognized during diff
computation, causing segments to fail loading and TestProxy to timeout.

Changes:
- Add fallback to use fieldid as child_id when child_fields is empty
- Add LoadDiff::ToString() for debugging
- Add logging for diff in Load/Reopen operations
- Add comprehensive unit tests for legacy format handling

---------

This commit extends the LoadDiff framework to support lazy loading for
column groups in the Storage V3 (manifest) path, specifically optimizing
memory usage for fields whose index already contains raw data.

Key changes:

1. LoadDiff framework now distinguishes between eager and lazy loading:
   - Added `column_groups_to_lazyload` for on-demand column loading
- Added `fields_to_reload` for tracking fields that need warmup after
index drop

2. Index-has-raw-data detection and lazy loading:
- SegmentLoadInfo::BuildCache() now converts index infos upfront and
checks `CheckIndexHasRawData()` via IndexFactory
- ComputeDiffColumnGroups() categorizes fields into eager vs lazy based
on schema.ShouldLoadField() and index_has_raw_data_ status
- ManifestGroupTranslator accepts `eager_load` parameter to control
cache eviction behavior (in_load_list)

3. ReloadColumns() for index drop scenarios:
- When segment reopens and index_has_raw_data changes from true to
false, ComputeDiffReloadFields() detects fields needing warmup
- ReloadColumns() uses PrefetchChunks() to warm up previously
lazy-loaded column data before dropping the index

4. LoadIndexInfo copy semantics:
- Added explicit copy constructor/assignment that copies metadata but
leaves index pointers as nullptr (populated during actual loading)
- SegmentLoadInfo now stores converted LoadIndexInfo instead of raw
proto pointers

Execution order in ApplyLoadDiff():
  1. Load new indexes
  2. Reload columns that lost index raw data (MUST before drop index)
  3. Drop indexes (MUST after reload to maintain data availability)
  4. Load new column groups (eager + lazy)

---------

Refactor thread pool assignments to properly separate entity-level
parallelism (MIDDLE pool) from I/O operations (HIGH/LOW pool),
eliminating pool re-entry risks and improving resource utilization.

**Changes**

**Thread Pool Reassignments (LOW → MIDDLE)**
- LoadColumnGroups: Field/column group level parallelism
- LoadBatchIndexes: Index level parallelism
- LoadBatchFieldData: Field level parallelism
- LoadColumnsGroups (SegmentGrowingImpl): Column group level parallelism

**Remove Unnecessary MIDDLE Pool Wrappers**
- load_field_data_internal: LoadArrowReaderFromRemote internally uses
HIGH/LOW
- ChunkTranslator::get_cells: LoadArrowReaderFromRemote internally uses
HIGH/LOW

**New Async Pattern for GroupChunkTranslator**
- Add LoadWithStrategyAsync() in memory_planner.cpp
- Returns futures immediately, submits I/O to HIGH/LOW pool
- GroupChunkTranslator::get_cells now waits on HIGH/LOW futures
(cross-pool)
- Eliminates re-entry deadlock risk while preserving I/O parallelism

**Add ReloadColumns Parallelism**
- Previously sequential loop now uses MIDDLE pool for field-level
parallelism

**Code Quality Improvements**
- Add WaitAllFutures() helper in Util.h for centralized exception
handling
- Simplify exception handling across LoadColumnGroups, LoadBatchIndexes,
LoadBatchFieldData using WaitAllFutures()

**Thread Pool Design After This Change**

- MIDDLE pool: Entity-level parallelism (fields, indexes, column groups)
- HIGH/LOW pool: I/O operations (file reads, network fetches)
- Cross-pool waits are safe (MIDDLE waiting on HIGH/LOW)
- Same-pool re-entry eliminated