### PR TITLE
feat: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/all-contributors.yaml
+++ b/.github/workflows/all-contributors.yaml
@@ -19,7 +19,7 @@ jobs:
     if: github.repository == 'milvus-io/milvus'
     steps:
       - name: checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
          token: ${{ secrets.ALL_CONTRIBUTORS_TOKEN }}
     

--- a/.github/workflows/bump-version-only-for-standalone-embed-milvus.yaml
+++ b/.github/workflows/bump-version-only-for-standalone-embed-milvus.yaml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Update milvus image tag
         # continue-on-error: true
         shell: bash
@@ -30,7 +30,7 @@ jobs:
       - name: Create Pull Request
         id: cpr
         continue-on-error: true
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.ALL_CONTRIBUTORS_TOKEN }}
           author: sre-ci-robot <sre-ci-robot@users.noreply.github.com>

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Update milvus image tag
         # continue-on-error: true
         shell: bash
@@ -32,7 +32,7 @@ jobs:
       - name: Create Pull Request
         id: cpr
         continue-on-error: true
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.ALL_CONTRIBUTORS_TOKEN }}
           author: sre-ci-robot <sre-ci-robot@users.noreply.github.com>

--- a/.github/workflows/check-issue.yaml
+++ b/.github/workflows/check-issue.yaml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Check Issue
         shell: bash
         run: |

--- a/.github/workflows/code-checker.yaml
+++ b/.github/workflows/code-checker.yaml
@@ -51,7 +51,7 @@ jobs:
           remove-android: 'true'
           remove-haskell: 'true'
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Download Caches
         uses: ./.github/actions/cache-restore
         with:
@@ -84,7 +84,7 @@ jobs:
           remove-android: 'true'
           remove-haskell: 'true'
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Download Caches
         uses: ./.github/actions/cache-restore
         with:
@@ -116,7 +116,7 @@ jobs:
           remove-android: 'true'
           remove-haskell: 'true'
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Download Caches
         uses: ./.github/actions/cache-restore
         with:

--- a/.github/workflows/daily-release.yml
+++ b/.github/workflows/daily-release.yml
@@ -24,7 +24,7 @@ jobs:
       TAG_PREFIX: "master-"
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v6
       with:
         fetch-depth: '0'
 
@@ -40,7 +40,7 @@ jobs:
         docker tag "${IMAGE_REPO}/${DEV}:${{ env.tag }}" "${IMAGE_REPO}/${DAILY}:${{ env.tag }}"
 
     - name: Log in to Docker Hub
-      uses: docker/login-action@v1
+      uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKERHUB_USER }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/deploy-test.yaml
+++ b/.github/workflows/deploy-test.yaml
@@ -66,10 +66,10 @@ jobs:
           echo "NEW_IMAGE_REPO=${{ github.event.inputs.new_image_repo || env.DEFAULT_NEW_IMAGE_REPO }}" >> $GITHUB_ENV
           echo "NEW_IMAGE_TAG=${{ github.event.inputs.new_image_tag || env.DEFAULT_NEW_IMAGE_TAG }}" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: 3.8
 
@@ -212,7 +212,7 @@ jobs:
       
       - name: 'Send mail'
         if: ${{ failure() }}
-        uses: dawidd6/action-send-mail@v3
+        uses: dawidd6/action-send-mail@v7
         with:
           server_address: ${{ secrets.EMAIL_SERVICE_NAME }}
           server_port: 465
@@ -225,7 +225,7 @@ jobs:
 
       - name: Upload logs
         if: ${{ ! success() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v6
         with:
           name: docker-compose-logs-${{ matrix.mode }}-${{ matrix.task }}
           path: tests/python_client/deploy/${{ matrix.mode }}/logs
@@ -256,10 +256,10 @@ jobs:
           helm version
           kubectl version
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: 3.8
 
@@ -394,7 +394,7 @@ jobs:
 
       - name: Upload logs
         if: ${{ ! success() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v6
         with:
           name: helm-log-${{ matrix.mq_type }}-${{ matrix.mode }}-${{ matrix.task }}
           path: tests/python_client/deploy/k8s_logs

--- a/.github/workflows/io-latency-chaos-test.yaml
+++ b/.github/workflows/io-latency-chaos-test.yaml
@@ -31,10 +31,10 @@ jobs:
           helm version
           kubectl version
       
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: 3.8
 
@@ -189,7 +189,7 @@ jobs:
       
       - name: Upload logs
         if: ${{ always() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v6
         with:
           name: logs-${{ matrix.pod }}
           path: |

--- a/.github/workflows/jenkins-checker.yaml
+++ b/.github/workflows/jenkins-checker.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Validate Jenkinsfile
         shell: bash
         run: |

--- a/.github/workflows/license-checker.yaml
+++ b/.github/workflows/license-checker.yaml
@@ -6,7 +6,7 @@ jobs:
   check-license:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Check License Header
         uses: apache/skywalking-eyes@main
         with:

--- a/.github/workflows/mac.yaml
+++ b/.github/workflows/mac.yaml
@@ -47,11 +47,11 @@ jobs:
     timeout-minutes: 480
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.branch || github.ref }}
       - name: Setup Python environment
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '<3.12'
       - name: Install CMake 3.31.8
@@ -76,7 +76,7 @@ jobs:
           cmake --version
           which cmake
       - name: Setup Go environment
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
           go-version: '1.24.12'
           cache: false
@@ -103,7 +103,7 @@ jobs:
           pip3 install conan==1.64.1
           make milvus
       - name: Upload Cmake log
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: ${{ failure() }}
         with:
           name: cmake-log

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -68,12 +68,12 @@ jobs:
           remove-android: 'true'
           remove-haskell: 'true'
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: 'Check Changed files'
         id: changed-files-cpp
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@v47
         with:
           since_last_remote_commit: 'true'
           files: |
@@ -100,7 +100,7 @@ jobs:
       - run: |
           zip -r code.zip . -x "./.docker/*" -x "./cmake_build/thirdparty/**" -x ".git/**"
       - name: Archive code
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: code
           path: code.zip
@@ -129,7 +129,7 @@ jobs:
           remove-android: 'true'
           remove-haskell: 'true'
       - name: Download code
-        uses: actions/download-artifact@v4.1.3
+        uses: actions/download-artifact@v7
         with:
           name: code
       - run: |
@@ -151,7 +151,7 @@ jobs:
           chmod +x internal/core/output/unittest/*
           ./build/builder.sh /bin/bash -c ./scripts/run_cpp_codecov.sh
       - name: Archive result
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: cpp-result
           path: |
@@ -181,7 +181,7 @@ jobs:
           remove-android: 'true'
           remove-haskell: 'true'
       - name: Download code
-        uses: actions/download-artifact@v4.1.3
+        uses: actions/download-artifact@v7
         with:
           name: code
       - run: |
@@ -202,7 +202,7 @@ jobs:
           chmod +x scripts/run_go_codecov.sh
           ./build/builder.sh /bin/bash -c "make codecov-go-without-build"
       - name: Archive result
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: go-result
           path: |
@@ -233,7 +233,7 @@ jobs:
           remove-android: 'true'
           remove-haskell: 'true'
       - name: Download code
-        uses: actions/download-artifact@v4.1.3
+        uses: actions/download-artifact@v7
         with:
           name: code
       - run: |
@@ -254,7 +254,7 @@ jobs:
           chmod +x scripts/run_intergration_test.sh
           ./build/builder.sh /bin/bash -c "make build-go && make integration-test" 
       - name: Archive result
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: it-result
           path: |
@@ -275,15 +275,15 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Download Go code coverage results
-        uses: actions/download-artifact@v4.1.3
+        uses: actions/download-artifact@v7
         with:
           name: go-result
       - name: Download Integration Test coverage results
-        uses: actions/download-artifact@v4.1.3
+        uses: actions/download-artifact@v7
         with:
           name: it-result
       - name: Display structure of code coverage results
@@ -291,7 +291,7 @@ jobs:
           ls -lah
       - name: Upload coverage to Codecov
         if: ${{ github.repository == 'milvus-io/milvus' }}
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         id: upload_cov
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -302,7 +302,7 @@ jobs:
           verbose: true
       - name: Retry Upload coverage to Codecov
         if: ${{ failure()  && github.repository == 'milvus-io/milvus' }}
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         id: retry_upload_cov
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/mem-stress-chaos-test.yaml
+++ b/.github/workflows/mem-stress-chaos-test.yaml
@@ -31,10 +31,10 @@ jobs:
           helm version
           kubectl version
       
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: 3.8
 
@@ -189,7 +189,7 @@ jobs:
       
       - name: Upload logs
         if: ${{ always() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v6
         with:
           name: logs-${{ matrix.pod }}
           path: |

--- a/.github/workflows/network-latency-chaos-test.yaml
+++ b/.github/workflows/network-latency-chaos-test.yaml
@@ -31,10 +31,10 @@ jobs:
           helm version
           kubectl version
       
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: 3.8
 
@@ -189,7 +189,7 @@ jobs:
       
       - name: Upload logs
         if: ${{ always() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v6
         with:
           name: logs-${{ matrix.pod }}
           path: |

--- a/.github/workflows/network-partition-chaos-test.yaml
+++ b/.github/workflows/network-partition-chaos-test.yaml
@@ -27,10 +27,10 @@ jobs:
           helm version
           kubectl version
       
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: 3.8
 
@@ -89,7 +89,7 @@ jobs:
       
       - name: Upload logs
         if: ${{ always() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v6
         with:
           name: logs-${{ matrix.pod }}
           path: tests/python_client/chaos/k8s_logs     

--- a/.github/workflows/pod-failure-chaos-test.yaml
+++ b/.github/workflows/pod-failure-chaos-test.yaml
@@ -48,10 +48,10 @@ jobs:
           helm version
           kubectl version
       
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: 3.8
 
@@ -186,7 +186,7 @@ jobs:
       
       - name: Upload logs
         if: ${{ ! success() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v6
         with:
           name: logs-${{ matrix.pod }}-${{ matrix.chaos_type }}
           path: tests/python_client/chaos/k8s_logs

--- a/.github/workflows/pod-kill-chaos-test-kafka-version.yaml
+++ b/.github/workflows/pod-kill-chaos-test-kafka-version.yaml
@@ -47,10 +47,10 @@ jobs:
           helm version
           kubectl version
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: 3.8
 
@@ -180,7 +180,7 @@ jobs:
       
       - name: Upload logs
         if: ${{ ! success() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v6
         with:
           name: logs-${{ matrix.pod }}
           path: |

--- a/.github/workflows/pod-kill-chaos-test.yaml
+++ b/.github/workflows/pod-kill-chaos-test.yaml
@@ -47,10 +47,10 @@ jobs:
           helm version
           kubectl version
       
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: 3.8
 
@@ -180,7 +180,7 @@ jobs:
       
       - name: Upload logs
         if: ${{ ! success() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v6
         with:
           name: logs-${{ matrix.pod }}
           path: |

--- a/.github/workflows/publish-builder.yaml
+++ b/.github/workflows/publish-builder.yaml
@@ -46,7 +46,7 @@ jobs:
           remove-codeql: 'true'
           remove-docker-images: 'true'
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Get version from system time after release step
         id: extracter
         run: |
@@ -76,7 +76,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/publish-gpu-builder.yaml
+++ b/.github/workflows/publish-gpu-builder.yaml
@@ -35,7 +35,7 @@ jobs:
       OS: ubuntu22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Get version from system time after release step
         id: extracter
         run: |
@@ -65,7 +65,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/publish-krte-images.yaml
+++ b/.github/workflows/publish-krte-images.yaml
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Get version from system time after release step
         id: extracter
         run: |
@@ -66,7 +66,7 @@ jobs:
         id: cpr
         if: success() && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' ) && github.repository == 'milvus-io/milvus'
         continue-on-error: true
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.ALL_CONTRIBUTORS_TOKEN }}
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>

--- a/.github/workflows/publish-test-images.yaml
+++ b/.github/workflows/publish-test-images.yaml
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Get version from system time after release step
         id: extracter
         run: |
@@ -78,7 +78,7 @@ jobs:
         id: cpr
         if: success() && github.event_name == 'push' && github.repository == 'milvus-io/milvus'
         continue-on-error: true
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.ALL_CONTRIBUTORS_TOKEN }}
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>

--- a/.github/workflows/rerun-failure-checks.yaml
+++ b/.github/workflows/rerun-failure-checks.yaml
@@ -25,14 +25,14 @@ jobs:
           fi
       - name: Create Comment for Non-Org Member
         if: "github.event_name == 'issue_comment' && steps.is_organization_member.outputs.is-member == 'false'"
-        uses: actions-cool/issues-helper@v2.5.0       
+        uses: actions-cool/issues-helper@v3       
         with:
           actions: 'create-comment'
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.issue.number }}
           body: |
             Hello ${{ github.event.sender.login }}, you are not in the organization, so you do not have the permission to rerun the workflow, please contact `@milvus-io/milvus-maintainers` for help.
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Rerun Failure Checks
         if: "github.event_name == 'issue_comment' && steps.is_organization_member.outputs.is-member == 'true'"
         uses: zymap/bot@master

--- a/.github/workflows/simd-compatibility-test.yaml
+++ b/.github/workflows/simd-compatibility-test.yaml
@@ -26,10 +26,10 @@ jobs:
           helm version
           kubectl version
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: 3.8
 

--- a/.github/workflows/update-knowhere-commit.yaml
+++ b/.github/workflows/update-knowhere-commit.yaml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Install GitHub CLI
         run: |
           sudo apt update
@@ -73,7 +73,7 @@ jobs:
       - name: Create Pull Request
         id: cpr
         continue-on-error: true
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.ALL_CONTRIBUTORS_TOKEN }}
           author: sre-ci-robot <sre-ci-robot@users.noreply.github.com>

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -24,7 +24,7 @@ jobs:
       TAG_PREFIX: "master-"
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v6
       with:
         fetch-depth: '0'
 
@@ -40,7 +40,7 @@ jobs:
         docker tag "${IMAGE_REPO}/${DEV}:${{ env.tag }}" "${IMAGE_REPO}/${WEEKLY}:${{ env.tag }}"
 
     - name: Log in to Docker Hub
-      uses: docker/login-action@v1
+      uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKERHUB_USER }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
This PR updates outdated GitHub Action versions.

- Updated `actions/checkout` from `v2` to `v6` in `.github/workflows/update-knowhere-commit.yaml`
- Updated `actions/checkout` from `v2` to `v6` in `.github/workflows/publish-krte-images.yaml`
- Updated `actions/setup-python` from `v2` to `v6` in `.github/workflows/network-partition-chaos-test.yaml`
- Updated `actions/checkout` from `v2` to `v6` in `.github/workflows/io-latency-chaos-test.yaml`
- Updated `actions/checkout` from `v2` to `v6` in `.github/workflows/bump-version.yaml`
- Updated `actions/upload-artifact` from `v2` to `v6` in `.github/workflows/io-latency-chaos-test.yaml`
- Updated `actions/checkout` from `v2` to `v6` in `.github/workflows/publish-gpu-builder.yaml`
- Updated `actions/checkout` from `v2` to `v6` in `.github/workflows/pod-kill-chaos-test.yaml`
- Updated `actions/setup-python` from `v2` to `v6` in `.github/workflows/io-latency-chaos-test.yaml`
- Updated `docker/build-push-action` from `v5` to `v6` in `.github/workflows/publish-builder.yaml`
- Updated `actions/setup-python` from `v2` to `v6` in `.github/workflows/simd-compatibility-test.yaml`
- Updated `actions/checkout` from `v2` to `v6` in `.github/workflows/jenkins-checker.yaml`
- Updated `actions/checkout` from `v2` to `v6` in `.github/workflows/network-latency-chaos-test.yaml`
- Updated `actions/setup-python` from `v2` to `v6` in `.github/workflows/pod-kill-chaos-test.yaml`
- Updated `actions/checkout` from `v2` to `v6` in `.github/workflows/pod-kill-chaos-test-kafka-version.yaml`
- Updated `actions/checkout` from `v2` to `v6` in `.github/workflows/daily-release.yml`
- Updated `actions/checkout` from `v2` to `v6` in `.github/workflows/publish-builder.yaml`
- Updated `actions/upload-artifact` from `v2` to `v6` in `.github/workflows/network-partition-chaos-test.yaml`
- Updated `actions/upload-artifact` from `v4` to `v6` in `.github/workflows/main.yaml`
- Updated `docker/login-action` from `v1` to `v3` in `.github/workflows/weekly-release.yml`
- Updated `actions/checkout` from `v2` to `v6` in `.github/workflows/deploy-test.yaml`
- Updated `actions/checkout` from `v2` to `v6` in `.github/workflows/bump-version-only-for-standalone-embed-milvus.yaml`
- Updated `actions/upload-artifact` from `v2` to `v6` in `.github/workflows/pod-kill-chaos-test-kafka-version.yaml`
- Updated `peter-evans/create-pull-request` from `v3` to `v8` in `.github/workflows/bump-version-only-for-standalone-embed-milvus.yaml`
- Updated `actions-cool/issues-helper` from `v2.5.0` to `v3` in `.github/workflows/rerun-failure-checks.yaml`
- Updated `actions/upload-artifact` from `v4` to `v6` in `.github/workflows/mac.yaml`
- Updated `actions/setup-python` from `v2` to `v6` in `.github/workflows/deploy-test.yaml`
- Updated `peter-evans/create-pull-request` from `v3` to `v8` in `.github/workflows/update-knowhere-commit.yaml`
- Updated `actions/checkout` from `v2` to `v6` in `.github/workflows/license-checker.yaml`
- Updated `actions/upload-artifact` from `v2` to `v6` in `.github/workflows/pod-failure-chaos-test.yaml`
- Updated `docker/login-action` from `v1` to `v3` in `.github/workflows/daily-release.yml`
- Updated `actions/checkout` from `v2` to `v6` in `.github/workflows/weekly-release.yml`
- Updated `actions/setup-python` from `v4` to `v6` in `.github/workflows/mac.yaml`
- Updated `actions/checkout` from `v2` to `v6` in `.github/workflows/pod-failure-chaos-test.yaml`
- Updated `codecov/codecov-action` from `v4` to `v5` in `.github/workflows/main.yaml`
- Updated `actions/checkout` from `v2` to `v6` in `.github/workflows/mem-stress-chaos-test.yaml`
- Updated `actions/upload-artifact` from `v2` to `v6` in `.github/workflows/mem-stress-chaos-test.yaml`
- Updated `actions/upload-artifact` from `v2` to `v6` in `.github/workflows/pod-kill-chaos-test.yaml`
- Updated `docker/build-push-action` from `v5` to `v6` in `.github/workflows/publish-gpu-builder.yaml`
- Updated `peter-evans/create-pull-request` from `v3` to `v8` in `.github/workflows/publish-test-images.yaml`
- Updated `actions/setup-go` from `v4` to `v6` in `.github/workflows/mac.yaml`
- Updated `actions/setup-python` from `v2` to `v6` in `.github/workflows/network-latency-chaos-test.yaml`
- Updated `actions/upload-artifact` from `v2` to `v6` in `.github/workflows/deploy-test.yaml`
- Updated `actions/checkout` from `v2` to `v6` in `.github/workflows/main.yaml`
- Updated `peter-evans/create-pull-request` from `v3` to `v8` in `.github/workflows/bump-version.yaml`
- Updated `actions/checkout` from `v2` to `v6` in `.github/workflows/check-issue.yaml`
- Updated `dawidd6/action-send-mail` from `v3` to `v7` in `.github/workflows/deploy-test.yaml`
- Updated `actions/download-artifact` from `v4.1.3` to `v7` in `.github/workflows/main.yaml`
- Updated `actions/checkout` from `v2` to `v6` in `.github/workflows/code-checker.yaml`
- Updated `actions/checkout` from `v2` to `v6` in `.github/workflows/simd-compatibility-test.yaml`
- Updated `actions/checkout` from `v2` to `v6` in `.github/workflows/network-partition-chaos-test.yaml`
- Updated `actions/setup-python` from `v2` to `v6` in `.github/workflows/pod-failure-chaos-test.yaml`
- Updated `peter-evans/create-pull-request` from `v3` to `v8` in `.github/workflows/publish-krte-images.yaml`
- Updated `actions/upload-artifact` from `v2` to `v6` in `.github/workflows/network-latency-chaos-test.yaml`
- Updated `tj-actions/changed-files` from `v46` to `v47` in `.github/workflows/main.yaml`
- Updated `actions/setup-python` from `v2` to `v6` in `.github/workflows/pod-kill-chaos-test-kafka-version.yaml`
- Updated `actions/setup-python` from `v2` to `v6` in `.github/workflows/mem-stress-chaos-test.yaml`
- Updated `actions/checkout` from `v2` to `v6` in `.github/workflows/publish-test-images.yaml`
- Updated `actions/checkout` from `v2` to `v6` in `.github/workflows/mac.yaml`
- Updated `actions/checkout` from `v2` to `v6` in `.github/workflows/all-contributors.yaml`
- Updated `actions/checkout` from `v2` to `v6` in `.github/workflows/rerun-failure-checks.yaml`
