### PR TITLE
fix: Bump master version to 3.0.0-dev

### DIFF
--- a/internal/util/sessionutil/session_util_test.go
+++ b/internal/util/sessionutil/session_util_test.go
@@ -812,7 +812,7 @@ func (s *SessionSuite) TestVersionKey() {
 	s.Equal(1, len(resp.Kvs))
 	s.Equal(common.Version.String(), string(resp.Kvs[0].Value))
 
-	common.Version = semver.MustParse("2.5.6")
+	common.Version = semver.MustParse("2.0.6")
 
 	s.Panics(func() {
 		session2 := NewSessionWithEtcd(ctx, s.metaRoot, s.client)
@@ -827,7 +827,7 @@ func (s *SessionSuite) TestVersionKey() {
 
 	session.Stop()
 
-	common.Version = semver.MustParse("2.6.4")
+	common.Version = semver.MustParse("3.0.4")
 	session = NewSessionWithEtcd(ctx, s.metaRoot, s.client)
 	session.Init(typeutil.MixCoordRole, "normal", false, false)
 	session.Register()
@@ -839,7 +839,7 @@ func (s *SessionSuite) TestVersionKey() {
 
 	session.Stop()
 
-	common.Version = semver.MustParse("2.6.7")
+	common.Version = semver.MustParse("3.0.7")
 	session = NewSessionWithEtcd(ctx, s.metaRoot, s.client)
 	session.Init(typeutil.MixCoordRole, "normal", false, false)
 	session.Register()
@@ -850,7 +850,7 @@ func (s *SessionSuite) TestVersionKey() {
 	s.Equal(common.Version.String(), string(resp.Kvs[0].Value))
 	session.Stop()
 
-	common.Version = semver.MustParse("3.0.0")
+	common.Version = semver.MustParse("4.0.0")
 	session = NewSessionWithEtcd(ctx, s.metaRoot, s.client)
 	session.Init(typeutil.MixCoordRole, "normal", false, false)
 	session.Register()

--- a/pkg/common/version.go
+++ b/pkg/common/version.go
@@ -6,5 +6,5 @@ import semver "github.com/blang/semver/v4"
 var Version semver.Version
 
 func init() {
-	Version = semver.MustParse("2.6.6")
+	Version = semver.MustParse("3.0.0-dev")
 }


### PR DESCRIPTION
## Summary
- Bump `pkg/common/version.go` from `2.6.6` to `3.0.0-dev` to correctly reflect that master is now targeting v3.0
- The stale version causes misleading output when building images from master, especially during bug analysis where the reported version `2.6.x` suggests a release branch rather than the 3.0 development branch

issue: #47573

## Test plan
- [ ] Verify `common.Version.String()` returns `3.0.0-dev`
- [ ] Verify existing version compatibility checks (`versionChecker260`, `versionChecker265`) are not affected