### PR TITLE
fix: populate LevelZeroSegmentIds in GetDataVChanPositions

### DIFF
--- a/internal/datacoord/handler.go
+++ b/internal/datacoord/handler.go
@@ -80,6 +80,10 @@ func newServerHandler(s *Server) *ServerHandler {
 }
 
 // GetDataVChanPositions gets vchannel latest positions with provided dml channel names for DataNode.
+// unflushend segmentIDs ---> L1, growing segments
+// flushend segmentIDs   ---> L1&L2, flushed segments
+// dropped segmentIDs    ---> dropped segments
+// level zero segmentIDs ---> L0 segments
 func (h *ServerHandler) GetDataVChanPositions(channel RWChannel, partitionID UniqueID) *datapb.VchannelInfo {
 	segments := h.s.meta.GetRealSegmentsForChannel(channel.GetName())
 	log.Info("GetDataVChanPositions",
@@ -88,6 +92,7 @@ func (h *ServerHandler) GetDataVChanPositions(channel RWChannel, partitionID Uni
 		zap.Int("numOfSegments", len(segments)),
 	)
 	var (
+		levelZeroIDs = make(typeutil.UniqueSet)
 		flushedIDs   = make(typeutil.UniqueSet)
 		unflushedIDs = make(typeutil.UniqueSet)
 		droppedIDs   = make(typeutil.UniqueSet)
@@ -104,12 +109,14 @@ func (h *ServerHandler) GetDataVChanPositions(channel RWChannel, partitionID Uni
 			continue
 		}
 
-		if s.GetState() == commonpb.SegmentState_Dropped {
+		switch {
+		case s.GetState() == commonpb.SegmentState_Dropped:
 			droppedIDs.Insert(s.GetID())
-			continue
-		} else if s.GetState() == commonpb.SegmentState_Flushing || s.GetState() == commonpb.SegmentState_Flushed {
+		case s.GetLevel() == datapb.SegmentLevel_L0:
+			levelZeroIDs.Insert(s.GetID())
+		case isFlushState(s.GetState()):
 			flushedIDs.Insert(s.GetID())
-		} else {
+		default:
 			unflushedIDs.Insert(s.GetID())
 		}
 	}
@@ -121,6 +128,7 @@ func (h *ServerHandler) GetDataVChanPositions(channel RWChannel, partitionID Uni
 		FlushedSegmentIds:   flushedIDs.Collect(),
 		UnflushedSegmentIds: unflushedIDs.Collect(),
 		DroppedSegmentIds:   droppedIDs.Collect(),
+		LevelZeroSegmentIds: levelZeroIDs.Collect(),
 	}
 }
 

--- a/internal/datacoord/handler_test.go
+++ b/internal/datacoord/handler_test.go
@@ -1473,6 +1473,25 @@ func TestGetDataVChanPositions(t *testing.T) {
 	}
 	err = svr.meta.AddSegment(context.TODO(), NewSegmentInfo(s3))
 	require.Nil(t, err)
+	l0Segment := &datapb.SegmentInfo{
+		ID:            4,
+		CollectionID:  0,
+		PartitionID:   1,
+		InsertChannel: "ch1",
+		State:         commonpb.SegmentState_Flushed,
+		StartPosition: &msgpb.MsgPosition{
+			ChannelName: "ch1",
+			MsgID:       []byte{8, 9, 10},
+		},
+		DmlPosition: &msgpb.MsgPosition{
+			ChannelName: "ch1",
+			MsgID:       []byte{11, 12, 13},
+			Timestamp:   2,
+		},
+		Level: datapb.SegmentLevel_L0,
+	}
+	err = svr.meta.AddSegment(context.TODO(), NewSegmentInfo(l0Segment))
+	require.Nil(t, err)
 
 	t.Run("get unexisted channel", func(t *testing.T) {
 		vchan := svr.handler.GetDataVChanPositions(&channelMeta{Name: "chx1", CollectionID: 0}, allPartitionID)
@@ -1486,6 +1505,8 @@ func TestGetDataVChanPositions(t *testing.T) {
 		assert.EqualValues(t, 1, vchan.FlushedSegmentIds[0])
 		assert.EqualValues(t, 2, len(vchan.UnflushedSegmentIds))
 		assert.ElementsMatch(t, []int64{s2.ID, s3.ID}, vchan.UnflushedSegmentIds)
+		assert.EqualValues(t, 1, len(vchan.LevelZeroSegmentIds))
+		assert.ElementsMatch(t, []int64{l0Segment.ID}, vchan.LevelZeroSegmentIds)
 	})
 
 	t.Run("empty collection", func(t *testing.T) {


### PR DESCRIPTION
Related to #47577

Previously, GetDataVChanPositions only categorized segments by state (flushed/unflushed/dropped) without handling L0 segments separately. This caused L0 segments to be incorrectly included in FlushedSegmentIds or UnflushedSegmentIds based on their state.

This fix adds L0 segment level check before state-based categorization, ensuring L0 segments are correctly populated in the LevelZeroSegmentIds field. This aligns the behavior with GetQueryVChanPositions which already handles L0 segments correctly.