### PR TITLE
fix: make snapshot creation idempotent to prevent callback retry loop [DataCoord]

### DIFF
--- a/internal/datacoord/services_test.go
+++ b/internal/datacoord/services_test.go
@@ -2688,6 +2688,16 @@ func TestServer_DropSnapshot(t *testing.T) {
 			}).Build()
 		defer mockGetSnapshot.UnPatch()
 
+		mockBroadCaster := &struct{ broadcaster.BroadcastAPI }{}
+		mockClose := mockey.Mock((*struct{ broadcaster.BroadcastAPI }).Close).Return().Build()
+		defer mockClose.UnPatch()
+
+		mockBroadcast := mockey.Mock(broadcast.StartBroadcastWithResourceKeys).To(
+			func(ctx context.Context, keys ...message.ResourceKey) (broadcaster.BroadcastAPI, error) {
+				return mockBroadCaster, nil
+			}).Build()
+		defer mockBroadcast.UnPatch()
+
 		server := &Server{
 			snapshotManager: NewSnapshotManager(nil, nil, nil, nil, nil, nil, nil),
 		}

--- a/tests/python_client/milvus_client/test_milvus_client_snapshot.py
+++ b/tests/python_client/milvus_client/test_milvus_client_snapshot.py
@@ -2835,7 +2835,6 @@ class TestMilvusClientSnapshotConcurrency(TestMilvusClientV2Base):
     """
 
     @pytest.mark.tags(CaseLabel.L2)
-    @pytest.mark.xfail(reason="https://github.com/milvus-io/milvus/issues/47101")
     def test_snapshot_concurrent_create_same_name(self):
         """
         target: verify only one concurrent create with same name succeeds
@@ -2853,7 +2852,9 @@ class TestMilvusClientSnapshotConcurrency(TestMilvusClientV2Base):
 
         def create_snapshot_thread():
             try:
-                self.create_snapshot(client, collection_name, snapshot_name)
+                # Directly call client method to bypass ResponseChecker framework
+                # This allows us to capture the real MilvusException with original error message
+                client.create_snapshot(collection_name, snapshot_name)
                 results.append("success")
             except Exception as e:
                 errors.append(str(e))


### PR DESCRIPTION
issue: #44358

## Summary

Move snapshot existence checks to occur after acquiring exclusive locks in CreateSnapshot and DropSnapshot. This ensures that when multiple concurrent requests attempt to create snapshots with the same name, only one succeeds and others immediately fail with "already exists" error, allowing DDL callbacks to handle the result properly without entering infinite retry loops.

## Related Issue

issue: #47101

## Changes

- **CreateSnapshot**: Move snapshot name existence check to after lock acquisition
- **DropSnapshot**: Move snapshot existence check to after lock acquisition
- **Test**: Fix concurrent snapshot creation test to verify "already exists" errors by directly calling client methods to bypass ResponseChecker framework masking

## Test Plan

- ✅ Unit test: `test_snapshot_concurrent_create_same_name` passes consistently
- ✅ Verified concurrent behavior: 1 success + 4 "already exists" errors
- ✅ No race conditions observed across multiple test runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)