### PR TITLE
enhance: remove deprecated lazy load code

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -531,13 +531,6 @@ queryNode:
     growingMmapEnabled: false
     fixedFileSizeForMmapAlloc: 1 # tmp file size for mmap chunk manager
     maxDiskUsagePercentageForMmapAlloc: 50 # disk percentage used in mmap chunk manager
-  lazyload:
-    enabled: false # Enable lazyload for loading data
-    waitTimeout: 30000 # max wait timeout duration in milliseconds before start to do lazyload search and retrieve
-    requestResourceTimeout: 5000 # max timeout in milliseconds for waiting request resource for lazy load, 5s by default
-    requestResourceRetryInterval: 2000 # retry interval in milliseconds for waiting request resource for lazy load, 2s by default
-    maxRetryTimes: 1 # max retry times for lazy load, 1 by default
-    maxEvictPerRetry: 1 # max evict count for lazy load, 1 by default
   indexOffsetCacheEnabled: false # enable index offset cache for some scalar indexes, now is just for bitmap index, enable this param can improve performance for retrieving raw data from index
   scheduler:
     receiveChanSize: 10240

--- a/internal/core/src/segcore/segment_c.cpp
+++ b/internal/core/src/segcore/segment_c.cpp
@@ -794,26 +794,6 @@ DropSealedSegmentJSONIndex(CSegmentInterface c_segment,
     }
 }
 
-CStatus
-AddFieldDataInfoForSealed(CSegmentInterface c_segment,
-                          CLoadFieldDataInfo c_load_field_data_info) {
-    SCOPE_CGO_CALL_METRIC();
-
-    try {
-        auto segment_interface =
-            reinterpret_cast<milvus::segcore::SegmentInterface*>(c_segment);
-        auto segment =
-            dynamic_cast<milvus::segcore::SegmentSealed*>(segment_interface);
-        AssertInfo(segment != nullptr, "segment conversion failed");
-        auto load_info =
-            static_cast<LoadFieldDataInfo*>(c_load_field_data_info);
-        segment->AddFieldDataInfoForSealed(*load_info);
-        return milvus::SuccessCStatus();
-    } catch (std::exception& e) {
-        return milvus::FailureCStatus(milvus::UnexpectedError, e.what());
-    }
-}
-
 void
 RemoveFieldFile(CSegmentInterface c_segment, int64_t field_id) {
     SCOPE_CGO_CALL_METRIC();

--- a/internal/core/src/segcore/segment_c.h
+++ b/internal/core/src/segcore/segment_c.h
@@ -240,10 +240,6 @@ DropSealedSegmentJSONIndex(CSegmentInterface c_segment,
                            int64_t field_id,
                            const char* nested_path);
 
-CStatus
-AddFieldDataInfoForSealed(CSegmentInterface c_segment,
-                          CLoadFieldDataInfo c_load_field_data_info);
-
 //////////////////////////////    interfaces for SegmentInterface    //////////////////////////////
 CStatus
 ExistPk(CSegmentInterface c_segment,

--- a/internal/mocks/util/mock_segcore/mock_CSegment.go
+++ b/internal/mocks/util/mock_segcore/mock_CSegment.go
@@ -22,65 +22,6 @@ func (_m *MockCSegment) EXPECT() *MockCSegment_Expecter {
 	return &MockCSegment_Expecter{mock: &_m.Mock}
 }
 
-// AddFieldDataInfo provides a mock function with given fields: ctx, request
-func (_m *MockCSegment) AddFieldDataInfo(ctx context.Context, request *segcore.AddFieldDataInfoRequest) (*segcore.AddFieldDataInfoResult, error) {
-	ret := _m.Called(ctx, request)
-
-	if len(ret) == 0 {
-		panic("no return value specified for AddFieldDataInfo")
-	}
-
-	var r0 *segcore.AddFieldDataInfoResult
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, *segcore.AddFieldDataInfoRequest) (*segcore.AddFieldDataInfoResult, error)); ok {
-		return rf(ctx, request)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, *segcore.AddFieldDataInfoRequest) *segcore.AddFieldDataInfoResult); ok {
-		r0 = rf(ctx, request)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*segcore.AddFieldDataInfoResult)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, *segcore.AddFieldDataInfoRequest) error); ok {
-		r1 = rf(ctx, request)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// MockCSegment_AddFieldDataInfo_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddFieldDataInfo'
-type MockCSegment_AddFieldDataInfo_Call struct {
-	*mock.Call
-}
-
-// AddFieldDataInfo is a helper method to define mock.On call
-//   - ctx context.Context
-//   - request *segcore.AddFieldDataInfoRequest
-func (_e *MockCSegment_Expecter) AddFieldDataInfo(ctx interface{}, request interface{}) *MockCSegment_AddFieldDataInfo_Call {
-	return &MockCSegment_AddFieldDataInfo_Call{Call: _e.mock.On("AddFieldDataInfo", ctx, request)}
-}
-
-func (_c *MockCSegment_AddFieldDataInfo_Call) Run(run func(ctx context.Context, request *segcore.AddFieldDataInfoRequest)) *MockCSegment_AddFieldDataInfo_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*segcore.AddFieldDataInfoRequest))
-	})
-	return _c
-}
-
-func (_c *MockCSegment_AddFieldDataInfo_Call) Return(_a0 *segcore.AddFieldDataInfoResult, _a1 error) *MockCSegment_AddFieldDataInfo_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *MockCSegment_AddFieldDataInfo_Call) RunAndReturn(run func(context.Context, *segcore.AddFieldDataInfoRequest) (*segcore.AddFieldDataInfoResult, error)) *MockCSegment_AddFieldDataInfo_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // Delete provides a mock function with given fields: ctx, request
 func (_m *MockCSegment) Delete(ctx context.Context, request *segcore.DeleteRequest) (*segcore.DeleteResult, error) {
 	ret := _m.Called(ctx, request)

--- a/internal/proxy/task_test.go
+++ b/internal/proxy/task_test.go
@@ -6145,11 +6145,6 @@ func TestHasPropInDeletekeys(t *testing.T) {
 		assert.Equal(t, common.MmapEnabledKey, hasPropInDeletekeys(keys))
 	})
 
-	t.Run("has lazyload key", func(t *testing.T) {
-		keys := []string{common.LazyLoadEnableKey}
-		assert.Equal(t, common.LazyLoadEnableKey, hasPropInDeletekeys(keys))
-	})
-
 	t.Run("has generic warmup key", func(t *testing.T) {
 		keys := []string{common.WarmupKey}
 		assert.Equal(t, common.WarmupKey, hasPropInDeletekeys(keys))

--- a/internal/querynodev2/handlers.go
+++ b/internal/querynodev2/handlers.go
@@ -161,12 +161,6 @@ func (node *QueryNode) loadIndex(ctx context.Context, req *querypb.LoadSegmentsR
 			continue
 		}
 
-		if localSegment.IsLazyLoad() {
-			localSegment.SetLoadInfo(info)
-			localSegment.SetNeedUpdatedVersion(req.GetVersion())
-			node.manager.DiskCache.MarkItemNeedReload(ctx, localSegment.ID())
-			return nil
-		}
 		err := node.loader.LoadIndex(ctx, localSegment, info, req.Version)
 		if err != nil {
 			log.Warn("failed to load index", zap.Error(err))
@@ -200,12 +194,6 @@ func (node *QueryNode) loadStats(ctx context.Context, req *querypb.LoadSegmentsR
 			continue
 		}
 
-		if localSegment.IsLazyLoad() {
-			localSegment.SetLoadInfo(info)
-			localSegment.SetNeedUpdatedVersion(req.GetVersion())
-			node.manager.DiskCache.MarkItemNeedReload(ctx, localSegment.ID())
-			return nil
-		}
 		err := node.loader.LoadJSONIndex(ctx, localSegment, info)
 		if err != nil {
 			log.Warn("failed to load stats", zap.Error(err))

--- a/internal/querynodev2/segments/mock_loader.go
+++ b/internal/querynodev2/segments/mock_loader.go
@@ -402,54 +402,6 @@ func (_c *MockLoader_LoadJSONIndex_Call) RunAndReturn(run func(context.Context, 
 	return _c
 }
 
-// LoadLazySegment provides a mock function with given fields: ctx, segment, loadInfo
-func (_m *MockLoader) LoadLazySegment(ctx context.Context, segment Segment, loadInfo *querypb.SegmentLoadInfo) error {
-	ret := _m.Called(ctx, segment, loadInfo)
-
-	if len(ret) == 0 {
-		panic("no return value specified for LoadLazySegment")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, Segment, *querypb.SegmentLoadInfo) error); ok {
-		r0 = rf(ctx, segment, loadInfo)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// MockLoader_LoadLazySegment_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'LoadLazySegment'
-type MockLoader_LoadLazySegment_Call struct {
-	*mock.Call
-}
-
-// LoadLazySegment is a helper method to define mock.On call
-//   - ctx context.Context
-//   - segment Segment
-//   - loadInfo *querypb.SegmentLoadInfo
-func (_e *MockLoader_Expecter) LoadLazySegment(ctx interface{}, segment interface{}, loadInfo interface{}) *MockLoader_LoadLazySegment_Call {
-	return &MockLoader_LoadLazySegment_Call{Call: _e.mock.On("LoadLazySegment", ctx, segment, loadInfo)}
-}
-
-func (_c *MockLoader_LoadLazySegment_Call) Run(run func(ctx context.Context, segment Segment, loadInfo *querypb.SegmentLoadInfo)) *MockLoader_LoadLazySegment_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(Segment), args[2].(*querypb.SegmentLoadInfo))
-	})
-	return _c
-}
-
-func (_c *MockLoader_LoadLazySegment_Call) Return(_a0 error) *MockLoader_LoadLazySegment_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockLoader_LoadLazySegment_Call) RunAndReturn(run func(context.Context, Segment, *querypb.SegmentLoadInfo) error) *MockLoader_LoadLazySegment_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // ReopenSegments provides a mock function with given fields: ctx, loadInfos
 func (_m *MockLoader) ReopenSegments(ctx context.Context, loadInfos []*querypb.SegmentLoadInfo) error {
 	ret := _m.Called(ctx, loadInfos)

--- a/internal/querynodev2/segments/mock_segment.go
+++ b/internal/querynodev2/segments/mock_segment.go
@@ -926,51 +926,6 @@ func (_c *MockSegment_InsertCount_Call) RunAndReturn(run func() int64) *MockSegm
 	return _c
 }
 
-// IsLazyLoad provides a mock function with no fields
-func (_m *MockSegment) IsLazyLoad() bool {
-	ret := _m.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for IsLazyLoad")
-	}
-
-	var r0 bool
-	if rf, ok := ret.Get(0).(func() bool); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-
-	return r0
-}
-
-// MockSegment_IsLazyLoad_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsLazyLoad'
-type MockSegment_IsLazyLoad_Call struct {
-	*mock.Call
-}
-
-// IsLazyLoad is a helper method to define mock.On call
-func (_e *MockSegment_Expecter) IsLazyLoad() *MockSegment_IsLazyLoad_Call {
-	return &MockSegment_IsLazyLoad_Call{Call: _e.mock.On("IsLazyLoad")}
-}
-
-func (_c *MockSegment_IsLazyLoad_Call) Run(run func()) *MockSegment_IsLazyLoad_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *MockSegment_IsLazyLoad_Call) Return(_a0 bool) *MockSegment_IsLazyLoad_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockSegment_IsLazyLoad_Call) RunAndReturn(run func() bool) *MockSegment_IsLazyLoad_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // IsSorted provides a mock function with no fields
 func (_m *MockSegment) IsSorted() bool {
 	ret := _m.Called()
@@ -2275,8 +2230,7 @@ func (_c *MockSegment_Version_Call) RunAndReturn(run func() int64) *MockSegment_
 func NewMockSegment(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *MockSegment {
+}) *MockSegment {
 	mock := &MockSegment{}
 	mock.Mock.Test(t)
 

--- a/internal/querynodev2/segments/retrieve.go
+++ b/internal/querynodev2/segments/retrieve.go
@@ -47,15 +47,7 @@ type RetrieveSegmentResult struct {
 func retrieveOnSegments(ctx context.Context, mgr *Manager, segments []Segment, segType SegmentType, plan *RetrievePlan, req *querypb.QueryRequest) ([]RetrieveSegmentResult, error) {
 	resultCh := make(chan RetrieveSegmentResult, len(segments))
 
-	anySegIsLazyLoad := func() bool {
-		for _, seg := range segments {
-			if seg.IsLazyLoad() {
-				return true
-			}
-		}
-		return false
-	}()
-	plan.SetIgnoreNonPk(!anySegIsLazyLoad && len(segments) > 1 && req.GetReq().GetLimit() != typeutil.Unlimited && plan.ShouldIgnoreNonPk())
+	plan.SetIgnoreNonPk(len(segments) > 1 && req.GetReq().GetLimit() != typeutil.Unlimited && plan.ShouldIgnoreNonPk())
 
 	label := metrics.SealedSegmentLabel
 	if segType == commonpb.SegmentState_Growing {

--- a/internal/querynodev2/segments/search.go
+++ b/internal/querynodev2/segments/search.go
@@ -77,20 +77,6 @@ func searchSegments(ctx context.Context, mgr *Manager, segments []Segment, segTy
 				accessRecord.Finish(err)
 			}()
 
-			if seg.IsLazyLoad() {
-				ctx, cancel := withLazyLoadTimeoutContext(ctx)
-				defer cancel()
-
-				var missing bool
-				missing, err = mgr.DiskCache.Do(ctx, seg.ID(), searcher)
-				if missing {
-					accessRecord.CacheMissing()
-				}
-				if err != nil {
-					log.Warn("failed to do search for disk cache", zap.Int64("segID", seg.ID()), zap.Error(err))
-				}
-				return err
-			}
 			return searcher(ctx, seg)
 		})
 	}

--- a/internal/querynodev2/segments/segment_interface.go
+++ b/internal/querynodev2/segments/segment_interface.go
@@ -108,7 +108,6 @@ type Segment interface {
 	Search(ctx context.Context, searchReq *segcore.SearchRequest) (*segcore.SearchResult, error)
 	Retrieve(ctx context.Context, plan *segcore.RetrievePlan) (*segcorepb.RetrieveResults, error)
 	RetrieveByOffsets(ctx context.Context, plan *segcore.RetrievePlanWithOffsets) (*segcorepb.RetrieveResults, error)
-	IsLazyLoad() bool
 	ResetIndexesLazyLoad(lazyState bool)
 
 	// lazy load related

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -54,7 +54,6 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v2/util/conc"
-	"github.com/milvus-io/milvus/pkg/v2/util/contextutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/hardware"
 	"github.com/milvus-io/milvus/pkg/v2/util/indexparams"
@@ -94,11 +93,6 @@ type Loader interface {
 		segment Segment,
 		info *querypb.SegmentLoadInfo,
 		version int64) error
-
-	LoadLazySegment(ctx context.Context,
-		segment Segment,
-		loadInfo *querypb.SegmentLoadInfo,
-	) error
 
 	LoadJSONIndex(ctx context.Context,
 		segment Segment,
@@ -1077,55 +1071,6 @@ func (loader *segmentLoader) LoadSegment(ctx context.Context,
 		}
 	}
 	return nil
-}
-
-func (loader *segmentLoader) LoadLazySegment(ctx context.Context,
-	segment Segment,
-	loadInfo *querypb.SegmentLoadInfo,
-) (err error) {
-	result, err := loader.requestResourceWithTimeout(ctx, loadInfo)
-	if err != nil {
-		log.Ctx(ctx).Warn("request resource failed", zap.Error(err))
-		return err
-	}
-	// NOTE: logical resource is not used for lazy load, so set it to zero
-	defer loader.freeRequestResource(result)
-
-	return loader.LoadSegment(ctx, segment, loadInfo)
-}
-
-// requestResourceWithTimeout requests memory & storage to load segments with a timeout and retry.
-func (loader *segmentLoader) requestResourceWithTimeout(ctx context.Context, infos ...*querypb.SegmentLoadInfo) (requestResourceResult, error) {
-	retryInterval := paramtable.Get().QueryNodeCfg.LazyLoadRequestResourceRetryInterval.GetAsDuration(time.Millisecond)
-	timeoutStarted := false
-	for {
-		listener := loader.committedResourceNotifier.Listen(syncutil.VersionedListenAtLatest)
-
-		result, err := loader.requestResource(ctx, infos...)
-		if err == nil {
-			return result, nil
-		}
-
-		// start timeout if there's no committed resource in loading.
-		if !timeoutStarted && result.CommittedResource.IsZero() {
-			timeout := paramtable.Get().QueryNodeCfg.LazyLoadRequestResourceTimeout.GetAsDuration(time.Millisecond)
-			var cancel context.CancelFunc
-			// TODO: use context.WithTimeoutCause instead of contextutil.WithTimeoutCause in go1.21
-			ctx, cancel = contextutil.WithTimeoutCause(ctx, timeout, merr.ErrServiceResourceInsufficient)
-			defer cancel()
-			timeoutStarted = true
-		}
-
-		// TODO: use context.WithTimeoutCause instead of contextutil.WithTimeoutCause in go1.21
-		ctxWithRetryTimeout, cancelWithRetryTimeout := contextutil.WithTimeoutCause(ctx, retryInterval, errRetryTimerNotified)
-		err = listener.Wait(ctxWithRetryTimeout)
-		// if error is not caused by retry timeout, return it directly.
-		if err != nil && !errors.Is(err, errRetryTimerNotified) {
-			cancelWithRetryTimeout()
-			return requestResourceResult{}, err
-		}
-		cancelWithRetryTimeout()
-	}
 }
 
 func (loader *segmentLoader) filterPKStatsBinlogs(fieldBinlogs []*datapb.FieldBinlog, pkFieldID int64) ([]string, storage.StatsLogType) {

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -276,6 +276,15 @@ func (loader *segmentLoader) Load(ctx context.Context,
 	var err error
 	var requestResourceResult requestResourceResult
 
+	// Check memory & storage limit
+	// no need to check resource for lazy load here
+	requestResourceResult, err = loader.requestResource(ctx, infos...)
+	if err != nil {
+		log.Warn("request resource failed", zap.Error(err))
+		return nil, err
+	}
+	defer loader.freeRequestResource(requestResourceResult)
+
 	newSegments := typeutil.NewConcurrentMap[int64, Segment]()
 	loaded := typeutil.NewConcurrentMap[int64, Segment]()
 	defer func() {

--- a/internal/querynodev2/segments/segment_loader_test.go
+++ b/internal/querynodev2/segments/segment_loader_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/querypb"
-	"github.com/milvus-io/milvus/pkg/v2/util/contextutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/metric"
@@ -893,28 +892,6 @@ func (suite *SegmentLoaderDetailSuite) TestRequestResource() {
 
 		suite.NoError(err)
 		suite.EqualValues(1100000, resource.Resource.MemorySize)
-	})
-
-	suite.Run("request_resource_with_timeout", func() {
-		paramtable.Get().Save(paramtable.Get().QueryNodeCfg.DeltaDataExpansionRate.Key, "50")
-		defer paramtable.Get().Reset(paramtable.Get().QueryNodeCfg.DeltaDataExpansionRate.Key)
-
-		paramtable.Get().Save(paramtable.Get().QueryNodeCfg.LazyLoadRequestResourceTimeout.Key, "500")
-		paramtable.Get().Save(paramtable.Get().QueryNodeCfg.LazyLoadRequestResourceRetryInterval.Key, "100")
-		result, err := suite.loader.requestResourceWithTimeout(context.Background(), loadInfo)
-		suite.NoError(err)
-		suite.EqualValues(1100000, result.Resource.MemorySize)
-
-		suite.loader.committedResource.Add(LoadResource{
-			MemorySize: 1024 * 1024 * 1024 * 1024,
-		})
-
-		timeoutErr := errors.New("timeout")
-		ctx, cancel := contextutil.WithTimeoutCause(context.Background(), 1000*time.Millisecond, timeoutErr)
-		defer cancel()
-		result, err = suite.loader.requestResourceWithTimeout(ctx, loadInfo)
-		suite.Error(err)
-		suite.ErrorIs(err, timeoutErr)
 	})
 }
 

--- a/internal/querynodev2/segments/utils.go
+++ b/internal/querynodev2/segments/utils.go
@@ -13,12 +13,10 @@ import "C"
 
 import (
 	"bytes"
-	"context"
 	"encoding/binary"
 	"fmt"
 	"io"
 	"strconv"
-	"time"
 
 	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
@@ -35,9 +33,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/querypb"
-	"github.com/milvus-io/milvus/pkg/v2/util/contextutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
-	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
 
@@ -208,13 +204,6 @@ func FilterZeroValuesFromSlice(intVals []int64) []int64 {
 		}
 	}
 	return result
-}
-
-// withLazyLoadTimeoutContext returns a new context with lazy load timeout.
-func withLazyLoadTimeoutContext(ctx context.Context) (context.Context, context.CancelFunc) {
-	lazyLoadTimeout := paramtable.Get().QueryNodeCfg.LazyLoadWaitTimeout.GetAsDuration(time.Millisecond)
-	// TODO: use context.WithTimeoutCause instead of contextutil.WithTimeoutCause in go1.21
-	return contextutil.WithTimeoutCause(ctx, lazyLoadTimeout, errLazyLoadTimeout)
 }
 
 func GetSegmentRelatedDataSize(segment Segment) int64 {

--- a/internal/util/segcore/requests.go
+++ b/internal/util/segcore/requests.go
@@ -118,10 +118,6 @@ func (req *cLoadFieldDataRequest) Release() {
 	C.DeleteLoadFieldDataInfo(req.cLoadFieldDataInfo)
 }
 
-type AddFieldDataInfoRequest = LoadFieldDataRequest
-
-type AddFieldDataInfoResult struct{}
-
 type ReopenRequest struct {
 	LoadInfo *querypb.SegmentLoadInfo
 }

--- a/internal/util/segcore/segment.go
+++ b/internal/util/segcore/segment.go
@@ -288,21 +288,6 @@ func (s *cSegmentImpl) LoadFieldData(ctx context.Context, request *LoadFieldData
 	return &LoadFieldDataResult{}, nil
 }
 
-// AddFieldDataInfo adds field data info into the segment.
-func (s *cSegmentImpl) AddFieldDataInfo(ctx context.Context, request *AddFieldDataInfoRequest) (*AddFieldDataInfoResult, error) {
-	creq, err := request.getCLoadFieldDataRequest()
-	if err != nil {
-		return nil, err
-	}
-	defer creq.Release()
-
-	status := C.AddFieldDataInfoForSealed(s.ptr, creq.cLoadFieldDataInfo)
-	if err := ConsumeCStatusIntoError(&status); err != nil {
-		return nil, errors.Wrap(err, "failed to add field data info")
-	}
-	return &AddFieldDataInfoResult{}, nil
-}
-
 func (s *cSegmentImpl) Load(ctx context.Context) error {
 	traceCtx := ParseCTraceContext(ctx)
 	defer runtime.KeepAlive(traceCtx)

--- a/internal/util/segcore/segment_interface.go
+++ b/internal/util/segcore/segment_interface.go
@@ -35,9 +35,6 @@ type SealedSegment interface {
 	// LoadFieldData loads field data into the segment.
 	LoadFieldData(ctx context.Context, request *LoadFieldDataRequest) (*LoadFieldDataResult, error)
 
-	// AddFieldDataInfo adds field data info into the segment.
-	AddFieldDataInfo(ctx context.Context, request *AddFieldDataInfoRequest) (*AddFieldDataInfoResult, error)
-
 	// DropIndex drops the index of the segment.
 	DropIndex(ctx context.Context, fieldID int64) error
 

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -253,7 +253,6 @@ const (
 // common properties
 const (
 	MmapEnabledKey             = "mmap.enabled"
-	LazyLoadEnableKey          = "lazyload.enabled" // deprecated by warmup related params
 	LoadPriorityKey            = "load_priority"
 	PartitionKeyIsolationKey   = "partitionkey.isolation"
 	FieldSkipLoadKey           = "field.skipLoad"
@@ -441,24 +440,6 @@ func FieldHasMmapKey(schema *schemapb.CollectionSchema, fieldID int64) bool {
 				}
 				return false
 			}
-		}
-	}
-	return false
-}
-
-func HasLazyload(props []*commonpb.KeyValuePair) bool {
-	for _, kv := range props {
-		if kv.Key == LazyLoadEnableKey {
-			return true
-		}
-	}
-	return false
-}
-
-func IsCollectionLazyLoadEnabled(kvs ...*commonpb.KeyValuePair) bool {
-	for _, kv := range kvs {
-		if kv.Key == LazyLoadEnableKey && strings.ToLower(kv.Value) == "true" {
-			return true
 		}
 	}
 	return false

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -3315,13 +3315,6 @@ type queryNodeConfig struct {
 	FixedFileSizeForMmapManager         ParamItem `refreshable:"false"`
 	MaxMmapDiskPercentageForMmapManager ParamItem `refreshable:"false"`
 
-	LazyLoadEnabled                      ParamItem `refreshable:"false"`
-	LazyLoadWaitTimeout                  ParamItem `refreshable:"true"`
-	LazyLoadRequestResourceTimeout       ParamItem `refreshable:"true"`
-	LazyLoadRequestResourceRetryInterval ParamItem `refreshable:"true"`
-	LazyLoadMaxRetryTimes                ParamItem `refreshable:"true"`
-	LazyLoadMaxEvictPerRetry             ParamItem `refreshable:"true"`
-
 	IndexOffsetCacheEnabled ParamItem `refreshable:"true"`
 
 	ReadAheadPolicy     ParamItem `refreshable:"false"`
@@ -4108,57 +4101,6 @@ However, this optimization may come at the cost of a slight decrease in query la
 		Export:       true,
 	}
 	p.MaxMmapDiskPercentageForMmapManager.Init(base.mgr)
-
-	p.LazyLoadEnabled = ParamItem{
-		Key:          "queryNode.lazyload.enabled",
-		Version:      "2.4.2",
-		DefaultValue: "false",
-		Doc:          "Enable lazyload for loading data",
-		Export:       true,
-	}
-	p.LazyLoadEnabled.Init(base.mgr)
-	p.LazyLoadWaitTimeout = ParamItem{
-		Key:          "queryNode.lazyload.waitTimeout",
-		Version:      "2.4.2",
-		DefaultValue: "30000",
-		Doc:          "max wait timeout duration in milliseconds before start to do lazyload search and retrieve",
-		Export:       true,
-	}
-	p.LazyLoadWaitTimeout.Init(base.mgr)
-	p.LazyLoadRequestResourceTimeout = ParamItem{
-		Key:          "queryNode.lazyload.requestResourceTimeout",
-		Version:      "2.4.2",
-		DefaultValue: "5000",
-		Doc:          "max timeout in milliseconds for waiting request resource for lazy load, 5s by default",
-		Export:       true,
-	}
-	p.LazyLoadRequestResourceTimeout.Init(base.mgr)
-	p.LazyLoadRequestResourceRetryInterval = ParamItem{
-		Key:          "queryNode.lazyload.requestResourceRetryInterval",
-		Version:      "2.4.2",
-		DefaultValue: "2000",
-		Doc:          "retry interval in milliseconds for waiting request resource for lazy load, 2s by default",
-		Export:       true,
-	}
-	p.LazyLoadRequestResourceRetryInterval.Init(base.mgr)
-
-	p.LazyLoadMaxRetryTimes = ParamItem{
-		Key:          "queryNode.lazyload.maxRetryTimes",
-		Version:      "2.4.2",
-		DefaultValue: "1",
-		Doc:          "max retry times for lazy load, 1 by default",
-		Export:       true,
-	}
-	p.LazyLoadMaxRetryTimes.Init(base.mgr)
-
-	p.LazyLoadMaxEvictPerRetry = ParamItem{
-		Key:          "queryNode.lazyload.maxEvictPerRetry",
-		Version:      "2.4.2",
-		DefaultValue: "1",
-		Doc:          "max evict count for lazy load, 1 by default",
-		Export:       true,
-	}
-	p.LazyLoadMaxEvictPerRetry.Init(base.mgr)
 
 	p.ReadAheadPolicy = ParamItem{
 		Key:          "queryNode.cache.readAheadPolicy",

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -501,22 +501,6 @@ func TestComponentParam(t *testing.T) {
 		params.Save("queryNode.diskCacheCapacityLimit", "70m")
 		assert.Equal(t, int64(70*1024*1024), Params.DiskCacheCapacityLimit.GetAsSize())
 
-		assert.False(t, Params.LazyLoadEnabled.GetAsBool())
-		params.Save("queryNode.lazyload.enabled", "true")
-		assert.True(t, Params.LazyLoadEnabled.GetAsBool())
-
-		assert.Equal(t, 30*time.Second, Params.LazyLoadWaitTimeout.GetAsDuration(time.Millisecond))
-		params.Save("queryNode.lazyload.waitTimeout", "100")
-		assert.Equal(t, 100*time.Millisecond, Params.LazyLoadWaitTimeout.GetAsDuration(time.Millisecond))
-
-		assert.Equal(t, 5*time.Second, Params.LazyLoadRequestResourceTimeout.GetAsDuration(time.Millisecond))
-		params.Save("queryNode.lazyload.requestResourceTimeout", "100")
-		assert.Equal(t, 100*time.Millisecond, Params.LazyLoadRequestResourceTimeout.GetAsDuration(time.Millisecond))
-
-		assert.Equal(t, 2*time.Second, Params.LazyLoadRequestResourceRetryInterval.GetAsDuration(time.Millisecond))
-		params.Save("queryNode.lazyload.requestResourceRetryInterval", "3000")
-		assert.Equal(t, 3*time.Second, Params.LazyLoadRequestResourceRetryInterval.GetAsDuration(time.Millisecond))
-
 		assert.Equal(t, 2, Params.BloomFilterApplyParallelFactor.GetAsInt())
 		assert.Equal(t, true, Params.SkipGrowingSegmentBF.GetAsBool())
 		assert.Equal(t, true, Params.EnableSparseFilterInQuery.GetAsBool())

--- a/tests/python_client/milvus_client/test_milvus_client_alter.py
+++ b/tests/python_client/milvus_client/test_milvus_client_alter.py
@@ -225,7 +225,7 @@ class TestMilvusClientAlterCollection(TestMilvusClientV2Base):
         target: test alter collection
         method:
             1. alter collection properties after load
-            verify alter successfully if trying to altering lazyload.enabled, mmap.enabled or collection.ttl.seconds
+            verify alter successfully if trying to altering mmap.enabled or collection.ttl.seconds
             2. alter collection properties after release
             verify alter successfully
             3. drop collection properties after load
@@ -244,8 +244,6 @@ class TestMilvusClientAlterCollection(TestMilvusClientV2Base):
                  ct.err_msg: "can not alter mmap properties if collection loaded"}
         self.alter_collection_properties(client, collection_name, properties={"mmap.enabled": True},
                                          check_task=CheckTasks.err_res, check_items=error)
-        self.alter_collection_properties(client, collection_name, properties={"lazyload.enabled": True},
-                                         check_task=CheckTasks.err_res, check_items=error)
         error = {ct.err_code: 999,
                  ct.err_msg: "dynamic schema cannot supported to be disabled: invalid parameter"}
         self.alter_collection_properties(client, collection_name, properties={"dynamicfield.enabled": False},
@@ -253,8 +251,6 @@ class TestMilvusClientAlterCollection(TestMilvusClientV2Base):
         error = {ct.err_code: 999,
                  ct.err_msg: "can not delete mmap properties if collection loaded"}
         self.drop_collection_properties(client, collection_name, property_keys=["mmap.enabled"],
-                                        check_task=CheckTasks.err_res, check_items=error)
-        self.drop_collection_properties(client, collection_name, property_keys=["lazyload.enabled"],
                                         check_task=CheckTasks.err_res, check_items=error)
         # TODO                                
         error = {ct.err_code: 999,
@@ -271,13 +267,12 @@ class TestMilvusClientAlterCollection(TestMilvusClientV2Base):
         res2 = self.describe_collection(client, collection_name)[0]
         assert {'mmap.enabled': 'True'}.items() <= res2.get('properties', {}).items()
         self.alter_collection_properties(client, collection_name,
-                                         properties={"collection.ttl.seconds": 100, "lazyload.enabled": True})
+                                         properties={"collection.ttl.seconds": 100})
         res2 = self.describe_collection(client, collection_name)[0]
-        assert {'mmap.enabled': 'True', 'collection.ttl.seconds': '100', 'lazyload.enabled': 'True'}.items()  \
+        assert {'mmap.enabled': 'True', 'collection.ttl.seconds': '100'}.items()  \
                 <= res2.get('properties', {}).items()
         self.drop_collection_properties(client, collection_name,
-                                        property_keys=["mmap.enabled", "lazyload.enabled",
-                                                       "collection.ttl.seconds"])
+                                        property_keys=["mmap.enabled", "collection.ttl.seconds"])
         res3 = self.describe_collection(client, collection_name)[0]
         assert len(res1.get('properties', {})) == 1
 


### PR DESCRIPTION
Related to #44452

Remove the deprecated lazy load feature which has been superseded by warmup-related parameters. This cleanup includes:

- Remove AddFieldDataInfoForSealed from C++ segcore layer
- Remove IsLazyLoad() method and isLazyLoad field from segment
- Remove lazy load checks in proxy alterCollectionTask
- Remove DiskCache lazy load handling in search/retrieve paths
- Remove LazyLoadEnableKey constant and related helper functions
- Update mock files to reflect interface changes