### PR TITLE
enhance: [2.6] use differentiate load priorities by scenario

### DIFF
--- a/internal/querycoordv2/checkers/index_checker.go
+++ b/internal/querycoordv2/checkers/index_checker.go
@@ -23,6 +23,7 @@ import (
 	"github.com/samber/lo"
 	"go.uber.org/zap"
 
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/querycoordv2/meta"
 	"github.com/milvus-io/milvus/internal/querycoordv2/params"
@@ -248,7 +249,7 @@ func (c *IndexChecker) createSegmentUpdateTask(ctx context.Context, segment *met
 		c.ID(),
 		segment.GetCollectionID(),
 		replica,
-		replica.LoadPriority(),
+		commonpb.LoadPriority_LOW, // Index update is not urgent
 		action,
 	)
 	if err != nil {
@@ -303,7 +304,7 @@ func (c *IndexChecker) createSegmentStatsUpdateTask(ctx context.Context, segment
 		c.ID(),
 		segment.GetCollectionID(),
 		replica,
-		replica.LoadPriority(),
+		commonpb.LoadPriority_LOW, // Stats update is not urgent
 		action,
 	)
 	if err != nil {

--- a/internal/querycoordv2/handlers.go
+++ b/internal/querycoordv2/handlers.go
@@ -135,7 +135,7 @@ func (s *Server) balanceSegments(ctx context.Context,
 			utils.ManualBalance,
 			collectionID,
 			plan.Replica,
-			replica.LoadPriority(),
+			commonpb.LoadPriority_LOW, // Manual balance is not urgent
 			actions...,
 		)
 		if err != nil {

--- a/internal/querycoordv2/utils/test.go
+++ b/internal/querycoordv2/utils/test.go
@@ -89,6 +89,16 @@ func CreateTestCollection(collection int64, replica int32) *meta.Collection {
 	}
 }
 
+func CreateTestCollectionWithStatus(collection int64, replica int32, status querypb.LoadStatus) *meta.Collection {
+	return &meta.Collection{
+		CollectionLoadInfo: &querypb.CollectionLoadInfo{
+			CollectionID:  collection,
+			ReplicaNumber: replica,
+			Status:        status,
+		},
+	}
+}
+
 func CreateTestPartition(collection int64, partitionID int64) *meta.Partition {
 	return &meta.Partition{
 		PartitionLoadInfo: &querypb.PartitionLoadInfo{


### PR DESCRIPTION
pr: #47410
issue: #43040

Implement intelligent LoadPriority assignment based on operation scenarios,
allowing QueryNodes to prioritize critical operations over background tasks.

**Background:**
Previously, all segment load operations used the same priority, which could
cause issues when urgent operations (like search requests) competed with background tasks (like balance) for resources.

**Solution:**
Centralize LoadPriority decisions in Checkers, with each Checker understanding
its operational context and assigning appropriate priorities:

| Scenario | LoadPriority | Rationale |
|------------------------|------------------------|------------------------------------| 
| Recovery | HIGH | Restore data availability ASAP | 
| User Load / Refresh | replica.LoadPriority() | Respect user's configured priority |
| Stopping Balance | HIGH | Drain nodes quickly for shutdown | 
| Normal Balance | LOW | Background optimization | 
| Manual Balance | LOW | User maintenance, not urgent | 
| Handoff | LOW | Growing→sealed, can wait |
| Index Update | LOW | Background maintenance |
| Stats Update | LOW | Background maintenance |

**Implementation:**

1. SegmentChecker: Determine priority by collection state
   - Check if segment exists in currentTarget (recovery vs new segment)
   - Check `collection.IsRefreshed()` to distinguish handoff from import

2. BalanceChecker: Add `isStoppingBalance` flag
   - Stopping balance uses HIGH to accelerate node draining
   - Normal balance uses LOW to avoid interfering with user operations

3. IndexChecker: Always use LOW for index/stats updates

4. Manual Balance: Manual balance uses LOW directly