### PR TITLE
fix: prevent DropSnapshot while restore jobs reference the snapshot

### DIFF
--- a/internal/datacoord/copy_segment_checker.go
+++ b/internal/datacoord/copy_segment_checker.go
@@ -127,50 +127,6 @@ func NewCopySegmentChecker(
 	}
 }
 
-// updateJobStateAndReleaseRef updates job state and releases snapshot reference
-// if the job transitions to a terminal state (Completed/Failed).
-//
-// This ensures snapshot references are released immediately when restore jobs finish,
-// while Job records are retained for audit purposes (3 hours).
-//
-// Parameters:
-//   - jobID: The job to update
-//   - snapshotName: Snapshot name for reference counting
-//   - actions: State update actions to apply
-//
-// Returns:
-//   - error: If update fails
-func (c *copySegmentChecker) updateJobStateAndReleaseRef(
-	jobID int64,
-	snapshotName string,
-	actions ...UpdateCopySegmentJobAction,
-) error {
-	// Update job state first
-	err := c.copyMeta.UpdateJob(c.ctx, jobID, actions...)
-	if err != nil {
-		return err
-	}
-
-	// Check if job transitioned to terminal state
-	job := c.copyMeta.GetJob(c.ctx, jobID)
-	if job == nil {
-		return nil
-	}
-
-	if job.GetState() == datapb.CopySegmentJobState_CopySegmentJobCompleted ||
-		job.GetState() == datapb.CopySegmentJobState_CopySegmentJobFailed {
-
-		// Release snapshot reference immediately
-		c.copyMeta.DecrementRestoreRef(snapshotName)
-		log.Info("released snapshot reference on job completion",
-			zap.Int64("jobID", jobID),
-			zap.String("snapshot", snapshotName),
-			zap.String("state", job.GetState().String()))
-	}
-
-	return nil
-}
-
 // Start begins the background checker loop that drives job state transitions.
 //
 // This runs in a goroutine and periodically checks all copy segment jobs,
@@ -345,10 +301,11 @@ func (c *copySegmentChecker) checkPendingJob(job CopySegmentJob) {
 	idMappings := job.GetIdMappings()
 	if len(idMappings) == 0 {
 		log.Warn("no id mappings to copy, mark job as completed")
-		c.updateJobStateAndReleaseRef(job.GetJobId(),
-			job.GetSnapshotName(),
+		if err := c.copyMeta.UpdateJobStateAndReleaseRef(c.ctx, job.GetJobId(),
 			UpdateCopyJobState(datapb.CopySegmentJobState_CopySegmentJobCompleted),
-			UpdateCopyJobReason("no segments to copy"))
+			UpdateCopyJobReason("no segments to copy")); err != nil {
+			log.Warn("failed to update empty job state to Completed", zap.Error(err))
+		}
 		return
 	}
 
@@ -487,9 +444,11 @@ func (c *copySegmentChecker) checkCopyingJob(job CopySegmentJob) {
 		log.Warn("copy segment job has failed tasks",
 			zap.Int("failedTasks", failedTasks),
 			zap.Int("totalTasks", totalTasks))
-		c.updateJobStateAndReleaseRef(job.GetJobId(), job.GetSnapshotName(),
+		if err := c.copyMeta.UpdateJobStateAndReleaseRef(c.ctx, job.GetJobId(),
 			UpdateCopyJobState(datapb.CopySegmentJobState_CopySegmentJobFailed),
-			UpdateCopyJobReason(fmt.Sprintf("%d/%d tasks failed", failedTasks, totalTasks)))
+			UpdateCopyJobReason(fmt.Sprintf("%d/%d tasks failed", failedTasks, totalTasks))); err != nil {
+			log.Warn("failed to update job state to Failed", zap.Error(err))
+		}
 		return
 	}
 
@@ -568,7 +527,7 @@ func (c *copySegmentChecker) finishJob(job CopySegmentJob, totalRows int64) {
 
 	// Step 3: Update job state to Completed
 	completeTs := uint64(time.Now().UnixNano())
-	err := c.updateJobStateAndReleaseRef(job.GetJobId(), job.GetSnapshotName(),
+	err := c.copyMeta.UpdateJobStateAndReleaseRef(c.ctx, job.GetJobId(),
 		UpdateCopyJobState(datapb.CopySegmentJobState_CopySegmentJobCompleted),
 		UpdateCopyJobCompleteTs(completeTs),
 		UpdateCopyJobTotalRows(totalRows))
@@ -664,9 +623,12 @@ func (c *copySegmentChecker) tryTimeoutJob(job CopySegmentJob) {
 	log.Warn("copy segment job timeout",
 		zap.Int64("jobID", job.GetJobId()),
 		zap.Time("timeoutTime", timeoutTime))
-	c.updateJobStateAndReleaseRef(job.GetJobId(), job.GetSnapshotName(),
+	if err := c.copyMeta.UpdateJobStateAndReleaseRef(c.ctx, job.GetJobId(),
 		UpdateCopyJobState(datapb.CopySegmentJobState_CopySegmentJobFailed),
-		UpdateCopyJobReason("timeout"))
+		UpdateCopyJobReason("timeout")); err != nil {
+		log.Warn("failed to update timed-out job state to Failed",
+			zap.Int64("jobID", job.GetJobId()), zap.Error(err))
+	}
 }
 
 // checkGC performs garbage collection for completed/failed jobs.

--- a/internal/datacoord/copy_segment_checker_test.go
+++ b/internal/datacoord/copy_segment_checker_test.go
@@ -660,8 +660,8 @@ func (s *CopySegmentCheckerSuite) TestUpdateJobStateAndReleaseRef_Completed() {
 	s.copyMeta.IncrementRestoreRef(snapshotName)
 	s.Equal(int32(1), s.copyMeta.GetRestoreRefCount(snapshotName))
 
-	// Execute: Update job to Completed
-	err := s.checker.updateJobStateAndReleaseRef(jobID, snapshotName,
+	// Execute: Update job to Completed via atomic meta method
+	err := s.copyMeta.UpdateJobStateAndReleaseRef(context.TODO(), jobID,
 		UpdateCopyJobState(datapb.CopySegmentJobState_CopySegmentJobCompleted))
 	s.NoError(err)
 
@@ -688,8 +688,8 @@ func (s *CopySegmentCheckerSuite) TestUpdateJobStateAndReleaseRef_Failed() {
 	s.copyMeta.IncrementRestoreRef(snapshotName)
 	s.Equal(int32(1), s.copyMeta.GetRestoreRefCount(snapshotName))
 
-	// Execute: Update job to Failed
-	err := s.checker.updateJobStateAndReleaseRef(jobID, snapshotName,
+	// Execute: Update job to Failed via atomic meta method
+	err := s.copyMeta.UpdateJobStateAndReleaseRef(context.TODO(), jobID,
 		UpdateCopyJobState(datapb.CopySegmentJobState_CopySegmentJobFailed))
 	s.NoError(err)
 
@@ -716,8 +716,8 @@ func (s *CopySegmentCheckerSuite) TestUpdateJobStateAndReleaseRef_Executing() {
 	s.copyMeta.IncrementRestoreRef(snapshotName)
 	s.Equal(int32(1), s.copyMeta.GetRestoreRefCount(snapshotName))
 
-	// Execute: Update job to Executing (non-terminal state)
-	err := s.checker.updateJobStateAndReleaseRef(jobID, snapshotName,
+	// Execute: Update job to Executing (non-terminal state) via atomic meta method
+	err := s.copyMeta.UpdateJobStateAndReleaseRef(context.TODO(), jobID,
 		UpdateCopyJobState(datapb.CopySegmentJobState_CopySegmentJobExecuting))
 	s.NoError(err)
 

--- a/internal/datacoord/copy_segment_meta.go
+++ b/internal/datacoord/copy_segment_meta.go
@@ -550,6 +550,7 @@ func (m *copySegmentMeta) UpdateJobStateAndReleaseRef(ctx context.Context, jobID
 
 	job, ok := m.jobs[jobID]
 	if !ok {
+		log.Warn("UpdateJobStateAndReleaseRef: job not found", zap.Int64("jobID", jobID))
 		return nil
 	}
 
@@ -798,7 +799,8 @@ func (m *copySegmentMeta) IncrementRestoreRef(snapshotName string) {
 }
 
 // DecrementRestoreRef decrements the restore reference count for a snapshot.
-// This is called when a CopySegmentJob is garbage collected.
+// This is called when a CopySegmentJob transitions to a terminal state (Completed/Failed),
+// not during garbage collection.
 func (m *copySegmentMeta) DecrementRestoreRef(snapshotName string) {
 	m.restoreRefTracker.DecrementRestoreRef(snapshotName)
 }

--- a/internal/datacoord/copy_segment_meta_test.go
+++ b/internal/datacoord/copy_segment_meta_test.go
@@ -18,6 +18,7 @@ package datacoord
 
 import (
 	"context"
+	"math"
 	"sync"
 	"testing"
 
@@ -943,6 +944,18 @@ func TestSnapshotRestoreRefTracker_UnderflowProtection(t *testing.T) {
 	tracker.DecrementRestoreRef(snapshotName)
 	tracker.DecrementRestoreRef(snapshotName)
 	assert.Equal(t, int32(0), tracker.GetRestoreRefCount(snapshotName))
+}
+
+func TestSnapshotRestoreRefTracker_OverflowProtection(t *testing.T) {
+	tracker := NewSnapshotRestoreRefTracker()
+	snapshotName := "test_snapshot"
+
+	// Set ref count to MaxInt32 directly
+	tracker.refCount[snapshotName] = math.MaxInt32
+
+	// IncrementRestoreRef should not overflow past MaxInt32
+	tracker.IncrementRestoreRef(snapshotName)
+	assert.Equal(t, int32(math.MaxInt32), tracker.GetRestoreRefCount(snapshotName))
 }
 
 // TestNewCopySegmentMeta_CrashRecoveryRefFiltering verifies that terminal jobs

--- a/internal/datacoord/copy_segment_meta_test.go
+++ b/internal/datacoord/copy_segment_meta_test.go
@@ -944,3 +944,143 @@ func TestSnapshotRestoreRefTracker_UnderflowProtection(t *testing.T) {
 	tracker.DecrementRestoreRef(snapshotName)
 	assert.Equal(t, int32(0), tracker.GetRestoreRefCount(snapshotName))
 }
+
+// TestNewCopySegmentMeta_CrashRecoveryRefFiltering verifies that terminal jobs
+// (Completed/Failed) do not get their ref counts re-incremented during crash recovery.
+// Before the fix, ALL persisted jobs got IncrementRestoreRef, causing permanent ref leaks
+// for terminal jobs (no code path decrements them again).
+func (s *CopySegmentMetaSuite) TestNewCopySegmentMeta_CrashRecoveryRefFiltering() {
+	catalog := mocks.NewDataCoordCatalog(s.T())
+
+	restoredJobs := []*datapb.CopySegmentJob{
+		{
+			JobId:        100,
+			CollectionId: 1,
+			SnapshotName: "snap_active",
+			State:        datapb.CopySegmentJobState_CopySegmentJobPending,
+		},
+		{
+			JobId:        200,
+			CollectionId: 1,
+			SnapshotName: "snap_active",
+			State:        datapb.CopySegmentJobState_CopySegmentJobExecuting,
+		},
+		{
+			JobId:        300,
+			CollectionId: 1,
+			SnapshotName: "snap_done",
+			State:        datapb.CopySegmentJobState_CopySegmentJobCompleted,
+		},
+		{
+			JobId:        400,
+			CollectionId: 1,
+			SnapshotName: "snap_done",
+			State:        datapb.CopySegmentJobState_CopySegmentJobFailed,
+		},
+	}
+
+	catalog.EXPECT().ListCopySegmentJobs(mock.Anything).Return(restoredJobs, nil)
+	catalog.EXPECT().ListCopySegmentTasks(mock.Anything).Return(nil, nil)
+	catalog.EXPECT().ListChannelCheckpoint(mock.Anything).Return(nil, nil)
+	catalog.EXPECT().ListIndexes(mock.Anything).Return(nil, nil)
+	catalog.EXPECT().ListSegmentIndexes(mock.Anything).Return(nil, nil)
+	catalog.EXPECT().ListAnalyzeTasks(mock.Anything).Return(nil, nil)
+	catalog.EXPECT().ListCompactionTask(mock.Anything).Return(nil, nil)
+	catalog.EXPECT().ListPartitionStatsInfos(mock.Anything).Return(nil, nil)
+	catalog.EXPECT().ListStatsTasks(mock.Anything).Return(nil, nil)
+	catalog.EXPECT().ListSnapshots(mock.Anything).Return(nil, nil)
+
+	broker := broker.NewMockBroker(s.T())
+	broker.EXPECT().ShowCollectionIDs(mock.Anything).Return(nil, nil)
+
+	meta, err := newMeta(context.TODO(), catalog, nil, broker)
+	s.NoError(err)
+
+	copyMeta, err := NewCopySegmentMeta(context.TODO(), catalog, meta, nil)
+	s.NoError(err)
+
+	// Only active (Pending+Executing) jobs should contribute to ref count
+	// snap_active: 2 active jobs => ref count = 2
+	s.Equal(int32(2), copyMeta.GetRestoreRefCount("snap_active"))
+
+	// snap_done: 2 terminal jobs (Completed+Failed) => ref count = 0
+	s.Equal(int32(0), copyMeta.GetRestoreRefCount("snap_done"))
+}
+
+// TestUpdateJobStateAndReleaseRef_DoubleDecrementProtection verifies that calling
+// UpdateJobStateAndReleaseRef multiple times on the same job only decrements once.
+// Before the fix, multiple callers (checker + task) could both transition the same job
+// to Failed, each triggering a decrement.
+func (s *CopySegmentMetaSuite) TestUpdateJobStateAndReleaseRef_DoubleDecrementProtection() {
+	s.catalog.EXPECT().SaveCopySegmentJob(mock.Anything, mock.Anything).Return(nil)
+
+	snapshotName := "snap_double"
+	job := &copySegmentJob{
+		CopySegmentJob: &datapb.CopySegmentJob{
+			JobId:        500,
+			CollectionId: s.collectionID,
+			SnapshotName: snapshotName,
+			State:        datapb.CopySegmentJobState_CopySegmentJobExecuting,
+		},
+		tr: timerecord.NewTimeRecorder("test job"),
+	}
+	s.copyMeta.AddJob(context.TODO(), job)
+	s.copyMeta.IncrementRestoreRef(snapshotName)
+	s.Equal(int32(1), s.copyMeta.GetRestoreRefCount(snapshotName))
+
+	// First call: Executing → Failed (should decrement)
+	err := s.copyMeta.UpdateJobStateAndReleaseRef(context.TODO(), 500,
+		UpdateCopyJobState(datapb.CopySegmentJobState_CopySegmentJobFailed),
+		UpdateCopyJobReason("task failed"))
+	s.NoError(err)
+	s.Equal(int32(0), s.copyMeta.GetRestoreRefCount(snapshotName))
+
+	// Second call: Failed → Failed (should NOT decrement again)
+	err = s.copyMeta.UpdateJobStateAndReleaseRef(context.TODO(), 500,
+		UpdateCopyJobState(datapb.CopySegmentJobState_CopySegmentJobFailed),
+		UpdateCopyJobReason("timeout"))
+	s.NoError(err)
+	// Ref count should still be 0, not -1 or underflow
+	s.Equal(int32(0), s.copyMeta.GetRestoreRefCount(snapshotName))
+}
+
+// TestUpdateJobStateAndReleaseRef_NotFound verifies that updating a non-existent
+// job is a no-op and does not error.
+func (s *CopySegmentMetaSuite) TestUpdateJobStateAndReleaseRef_NotFound() {
+	err := s.copyMeta.UpdateJobStateAndReleaseRef(context.TODO(), 999,
+		UpdateCopyJobState(datapb.CopySegmentJobState_CopySegmentJobFailed))
+	s.NoError(err)
+}
+
+// TestUpdateJobStateAndReleaseRef_CatalogError verifies that if the catalog save fails,
+// the ref count is NOT decremented (preserving consistency).
+func (s *CopySegmentMetaSuite) TestUpdateJobStateAndReleaseRef_CatalogError() {
+	s.catalog.EXPECT().SaveCopySegmentJob(mock.Anything, mock.Anything).Return(nil).Once()
+	s.catalog.EXPECT().SaveCopySegmentJob(mock.Anything, mock.Anything).Return(errors.New("catalog error")).Once()
+
+	snapshotName := "snap_err"
+	job := &copySegmentJob{
+		CopySegmentJob: &datapb.CopySegmentJob{
+			JobId:        600,
+			CollectionId: s.collectionID,
+			SnapshotName: snapshotName,
+			State:        datapb.CopySegmentJobState_CopySegmentJobExecuting,
+		},
+		tr: timerecord.NewTimeRecorder("test job"),
+	}
+	s.copyMeta.AddJob(context.TODO(), job)
+	s.copyMeta.IncrementRestoreRef(snapshotName)
+	s.Equal(int32(1), s.copyMeta.GetRestoreRefCount(snapshotName))
+
+	// Update fails at catalog layer
+	err := s.copyMeta.UpdateJobStateAndReleaseRef(context.TODO(), 600,
+		UpdateCopyJobState(datapb.CopySegmentJobState_CopySegmentJobFailed))
+	s.Error(err)
+
+	// Ref count should NOT be decremented (job state didn't actually change)
+	s.Equal(int32(1), s.copyMeta.GetRestoreRefCount(snapshotName))
+
+	// Job should still be in Executing state
+	savedJob := s.copyMeta.GetJob(context.TODO(), 600)
+	s.Equal(datapb.CopySegmentJobState_CopySegmentJobExecuting, savedJob.GetState())
+}

--- a/internal/datacoord/copy_segment_task.go
+++ b/internal/datacoord/copy_segment_task.go
@@ -354,7 +354,7 @@ func (t *copySegmentTask) markTaskAndJobFailed(reason string) {
 	// Sync job state immediately (fail-fast)
 	job := t.copyMeta.GetJob(context.TODO(), t.GetJobId())
 	if job != nil && job.GetState() != datapb.CopySegmentJobState_CopySegmentJobFailed {
-		updateErr = t.copyMeta.UpdateJob(context.TODO(), t.GetJobId(),
+		updateErr = t.copyMeta.UpdateJobStateAndReleaseRef(context.TODO(), t.GetJobId(),
 			UpdateCopyJobState(datapb.CopySegmentJobState_CopySegmentJobFailed),
 			UpdateCopyJobReason(reason))
 		if updateErr != nil {
@@ -654,7 +654,7 @@ func SyncCopySegmentTask(task CopySegmentTask, resp *datapb.QueryCopySegmentResp
 						zap.Int64("taskID", task.GetTaskId()), zap.Error(updateErr))
 				}
 
-				updateErr = copyMeta.UpdateJob(ctx, task.GetJobId(),
+				updateErr = copyMeta.UpdateJobStateAndReleaseRef(ctx, task.GetJobId(),
 					UpdateCopyJobState(datapb.CopySegmentJobState_CopySegmentJobFailed),
 					UpdateCopyJobReason(err.Error()))
 				if updateErr != nil {
@@ -797,7 +797,7 @@ func syncVectorScalarIndexes(ctx context.Context, result *datapb.CopySegmentResu
 					zap.Int64("taskID", task.GetTaskId()), zap.Error(updateErr))
 			}
 
-			updateErr = copyMeta.UpdateJob(ctx, task.GetJobId(),
+			updateErr = copyMeta.UpdateJobStateAndReleaseRef(ctx, task.GetJobId(),
 				UpdateCopyJobState(datapb.CopySegmentJobState_CopySegmentJobFailed),
 				UpdateCopyJobReason(err.Error()))
 			if updateErr != nil {
@@ -866,7 +866,7 @@ func syncTextIndexes(ctx context.Context, result *datapb.CopySegmentResult,
 				zap.Int64("taskID", task.GetTaskId()), zap.Error(updateErr))
 		}
 
-		updateErr = copyMeta.UpdateJob(ctx, task.GetJobId(),
+		updateErr = copyMeta.UpdateJobStateAndReleaseRef(ctx, task.GetJobId(),
 			UpdateCopyJobState(datapb.CopySegmentJobState_CopySegmentJobFailed),
 			UpdateCopyJobReason(err.Error()))
 		if updateErr != nil {
@@ -932,7 +932,7 @@ func syncJsonKeyIndexes(ctx context.Context, result *datapb.CopySegmentResult,
 				zap.Int64("taskID", task.GetTaskId()), zap.Error(updateErr))
 		}
 
-		updateErr = copyMeta.UpdateJob(ctx, task.GetJobId(),
+		updateErr = copyMeta.UpdateJobStateAndReleaseRef(ctx, task.GetJobId(),
 			UpdateCopyJobState(datapb.CopySegmentJobState_CopySegmentJobFailed),
 			UpdateCopyJobReason(err.Error()))
 		if updateErr != nil {

--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -2153,10 +2153,7 @@ func (s *Server) DropSnapshot(ctx context.Context, req *datapb.DropSnapshotReque
 		log.Warn("cannot drop snapshot with active restore operations",
 			zap.String("snapshot", snapshotName),
 			zap.Int32("activeRestoreCount", refCount))
-		return &commonpb.Status{
-			ErrorCode: commonpb.ErrorCode_UnexpectedError,
-			Reason:    reason,
-		}, nil
+		return merr.Status(merr.WrapErrServiceInternal(reason)), nil
 	}
 
 	// Broadcast DropSnapshot message via DDL framework

--- a/internal/datacoord/snapshot_manager_test.go
+++ b/internal/datacoord/snapshot_manager_test.go
@@ -1781,3 +1781,15 @@ func TestSnapshotManager_RestoreCollection_SchemaNameAndDbName(t *testing.T) {
 	assert.Equal(t, targetCollectionName, schema.Name, "schema.Name should be updated to target collection name")
 	assert.Equal(t, targetDbName, schema.DbName, "schema.DbName should be updated to target database name")
 }
+
+func TestSnapshotManager_GetSnapshotRestoreRefCount(t *testing.T) {
+	mockGetRef := mockey.Mock((*copySegmentMeta).GetRestoreRefCount).Return(int32(5)).Build()
+	defer mockGetRef.UnPatch()
+
+	sm := &snapshotManager{
+		copySegmentMeta: &copySegmentMeta{},
+	}
+
+	count := sm.GetSnapshotRestoreRefCount("test_snapshot")
+	assert.Equal(t, int32(5), count)
+}


### PR DESCRIPTION
issue: #47578
issue: #44358
Implement snapshot restore reference tracking to prevent DropSnapshot from deleting snapshots that are actively being restored. This fixes issue #47578 where CopySegmentJob tasks could fail indefinitely if their source snapshot was deleted mid-restore.

Architecture:
- Add SnapshotRestoreRefTracker in CopySegmentMeta to track active restore operations per snapshot using reference counting
- Increment ref count when CopySegmentJob is created (in RestoreData)
- Decrement ref count when job transitions to a terminal state (Completed/Failed)
- Check ref count in DropSnapshot RPC and reject deletion if non-zero

Implementation details:
- SnapshotRestoreRefTracker uses sync.RWMutex for thread-safe operations
- Integrated into CopySegmentMeta for data cohesion
- Job lifecycle: Pending → Executing → Completed/Failed
- Snapshot protected from job creation until terminal state transition

Testing:
- TestSnapshotRestoreRefTracker: Basic increment/decrement operations
- TestSnapshotRestoreRefTracker_Concurrent: 20 goroutines concurrent safety
- TestSnapshotRestoreRefTracker_UnderflowProtection: Negative count prevention