### PR TITLE
enhance: [2.6]fast stop when resource limited

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -454,6 +454,9 @@ queryCoord:
   # Set to 0 to disable the penalty period.
   resourceExhaustionPenaltyDuration: 30
   resourceExhaustionCleanupInterval: 10 # Interval (in seconds) for cleaning up expired resource exhaustion marks on query nodes.
+  fastStopEnable: false # Whether to enable fast-stop skip logic for collections with repeated resource-limit load failures.
+  resourceLimitFastStopWindow: 300 # Window (in seconds) for resource-limit load failure counting used by fast-stop collection skipping.
+  resourceLimitFastStopThreshold: 100 # Threshold of resource-limit load failures for a collection to be skipped during QueryNode graceful stop.
   cleanExcludeSegmentInterval: 60 # the time duration of clean pipeline exclude segment which used for filter invalid data, in seconds
   ip:  # TCP/IP address of queryCoord. If not specified, use the first unicastable address
   port: 19531 # TCP port of queryCoord

--- a/internal/querycoordv2/checkers/balance_checker.go
+++ b/internal/querycoordv2/checkers/balance_checker.go
@@ -29,6 +29,7 @@ import (
 	"github.com/milvus-io/milvus/internal/querycoordv2/balance"
 	"github.com/milvus-io/milvus/internal/querycoordv2/meta"
 	. "github.com/milvus-io/milvus/internal/querycoordv2/params"
+	"github.com/milvus-io/milvus/internal/querycoordv2/resourcelimit"
 	"github.com/milvus-io/milvus/internal/querycoordv2/session"
 	"github.com/milvus-io/milvus/internal/querycoordv2/task"
 	"github.com/milvus-io/milvus/internal/querycoordv2/utils"
@@ -344,7 +345,7 @@ func (b *BalanceChecker) getReplicaForNormalBalance(ctx context.Context, collect
 // Returns:
 //   - segmentTasks: tasks for moving segments between nodes
 //   - channelTasks: tasks for moving channels between nodes
-func (b *BalanceChecker) generateBalanceTasksFromReplicas(ctx context.Context, balancer balance.Balance, replicas []int64, config balanceConfig, isStoppingBalance bool) ([]task.Task, []task.Task) {
+func (b *BalanceChecker) generateBalanceTasksFromReplicas(ctx context.Context, balancer balance.Balance, replicas []int64, config balanceConfig, isStoppingBalance bool, fastStopReduceOnly bool) ([]task.Task, []task.Task) {
 	if len(replicas) == 0 {
 		return nil, nil
 	}
@@ -372,6 +373,30 @@ func (b *BalanceChecker) generateBalanceTasksFromReplicas(ctx context.Context, b
 	}
 	for i := range segmentPlans {
 		segmentPlans[i].LoadPriority = loadPriority
+	}
+
+	if fastStopReduceOnly {
+		log.Ctx(ctx).RatedInfo(10, "apply fast-stop reduce-only drain for stopping balance")
+
+		reduceOnlySegPlans := make([]assign.SegmentAssignPlan, 0, len(segmentPlans))
+		for _, p := range segmentPlans {
+			if p.From == -1 {
+				continue
+			}
+			p.To = -1
+			reduceOnlySegPlans = append(reduceOnlySegPlans, p)
+		}
+		segmentPlans = reduceOnlySegPlans
+
+		reduceOnlyChanPlans := make([]assign.ChannelAssignPlan, 0, len(channelPlans))
+		for _, p := range channelPlans {
+			if p.From == -1 {
+				continue
+			}
+			p.To = -1
+			reduceOnlyChanPlans = append(reduceOnlyChanPlans, p)
+		}
+		channelPlans = reduceOnlyChanPlans
 	}
 
 	segmentTasks := make([]task.Task, 0)
@@ -460,7 +485,15 @@ func (b *BalanceChecker) processBalanceQueue(
 			continue
 		}
 
-		newSegmentTasks, newChannelTasks := b.generateBalanceTasksFromReplicas(ctx, balancer, replicasToBalance, config, isStoppingBalance)
+		fastStopReduceOnly := isStoppingBalance && resourcelimit.ShouldFastStop(item.collectionID)
+		if fastStopReduceOnly {
+			log.Ctx(ctx).RatedInfo(10,
+				"resource limit fast-stop enabled, use reduce-only drain in stopping balance",
+				zap.Int64("collectionID", item.collectionID),
+			)
+		}
+
+		newSegmentTasks, newChannelTasks := b.generateBalanceTasksFromReplicas(ctx, balancer, replicasToBalance, config, isStoppingBalance, fastStopReduceOnly)
 		generatedSegmentTaskNum += len(newSegmentTasks)
 		generatedChannelTaskNum += len(newChannelTasks)
 		b.submitTasks(newSegmentTasks, newChannelTasks)

--- a/internal/querycoordv2/checkers/balance_checker_test.go
+++ b/internal/querycoordv2/checkers/balance_checker_test.go
@@ -422,7 +422,7 @@ func TestBalanceChecker_GenerateBalanceTasksFromReplicas_EmptyReplicas(t *testin
 	config := balanceConfig{}
 	balancer := balance.GetGlobalBalancerFactory().GetBalancer()
 
-	segmentTasks, channelTasks := checker.generateBalanceTasksFromReplicas(ctx, balancer, []int64{}, config, false)
+	segmentTasks, channelTasks := checker.generateBalanceTasksFromReplicas(ctx, balancer, []int64{}, config, false, false)
 
 	assert.Empty(t, segmentTasks)
 	assert.Empty(t, channelTasks)
@@ -492,7 +492,7 @@ func TestBalanceChecker_GenerateBalanceTasksFromReplicas_Success(t *testing.T) {
 	defer mockPrintPlans.UnPatch()
 
 	balancer := balance.GetGlobalBalancerFactory().GetBalancer()
-	segmentTasks, channelTasks := checker.generateBalanceTasksFromReplicas(ctx, balancer, replicaIDs, config, false)
+	segmentTasks, channelTasks := checker.generateBalanceTasksFromReplicas(ctx, balancer, replicaIDs, config, false, false)
 
 	assert.Len(t, segmentTasks, 1)
 	assert.Len(t, channelTasks, 1)
@@ -511,7 +511,7 @@ func TestBalanceChecker_GenerateBalanceTasksFromReplicas_NilReplica(t *testing.T
 	defer mockReplicaGet.UnPatch()
 
 	balancer := balance.GetGlobalBalancerFactory().GetBalancer()
-	segmentTasks, channelTasks := checker.generateBalanceTasksFromReplicas(ctx, balancer, replicaIDs, config, false)
+	segmentTasks, channelTasks := checker.generateBalanceTasksFromReplicas(ctx, balancer, replicaIDs, config, false, false)
 
 	assert.Empty(t, segmentTasks)
 	assert.Empty(t, channelTasks)
@@ -572,7 +572,7 @@ func TestBalanceChecker_GenerateBalanceTasksFromReplicas_StoppingBalanceHighPrio
 
 	balancer := balance.GetGlobalBalancerFactory().GetBalancer()
 	// Call with isStoppingBalance=true
-	checker.generateBalanceTasksFromReplicas(ctx, balancer, replicaIDs, config, true)
+	checker.generateBalanceTasksFromReplicas(ctx, balancer, replicaIDs, config, true, false)
 
 	// Verify LoadPriority is set to HIGH for stopping balance
 	assert.Len(t, capturedPlans, 1)
@@ -631,7 +631,7 @@ func TestBalanceChecker_GenerateBalanceTasksFromReplicas_NormalBalanceLowPriorit
 
 	balancer := balance.GetGlobalBalancerFactory().GetBalancer()
 	// Call with isStoppingBalance=false
-	checker.generateBalanceTasksFromReplicas(ctx, balancer, replicaIDs, config, false)
+	checker.generateBalanceTasksFromReplicas(ctx, balancer, replicaIDs, config, false, false)
 
 	// Verify LoadPriority is set to LOW for normal balance
 	assert.Len(t, capturedPlans, 1)

--- a/internal/querycoordv2/job/job_load.go
+++ b/internal/querycoordv2/job/job_load.go
@@ -30,6 +30,7 @@ import (
 	"github.com/milvus-io/milvus/internal/querycoordv2/checkers"
 	"github.com/milvus-io/milvus/internal/querycoordv2/meta"
 	"github.com/milvus-io/milvus/internal/querycoordv2/observers"
+	"github.com/milvus-io/milvus/internal/querycoordv2/resourcelimit"
 	"github.com/milvus-io/milvus/internal/querycoordv2/session"
 	"github.com/milvus-io/milvus/internal/querycoordv2/utils"
 	"github.com/milvus-io/milvus/internal/util/proxyutil"
@@ -95,6 +96,7 @@ func (job *LoadCollectionJob) Execute() error {
 	log := log.Ctx(job.ctx).With(zap.Int64("collectionID", req.GetCollectionId()))
 	meta.GlobalFailedLoadCache.Remove(req.GetCollectionId())
 
+	resourcelimit.Clear(req.GetCollectionId())
 	collInfo, err := job.broker.DescribeCollection(job.ctx, req.GetCollectionId())
 	if errors.Is(err, merr.ErrCollectionNotFound) {
 		return nil

--- a/internal/querycoordv2/job/job_release.go
+++ b/internal/querycoordv2/job/job_release.go
@@ -26,6 +26,7 @@ import (
 	"github.com/milvus-io/milvus/internal/querycoordv2/checkers"
 	"github.com/milvus-io/milvus/internal/querycoordv2/meta"
 	"github.com/milvus-io/milvus/internal/querycoordv2/observers"
+	"github.com/milvus-io/milvus/internal/querycoordv2/resourcelimit"
 	"github.com/milvus-io/milvus/internal/querycoordv2/session"
 	"github.com/milvus-io/milvus/internal/util/proxyutil"
 	"github.com/milvus-io/milvus/pkg/v2/log"
@@ -72,6 +73,7 @@ func NewReleaseCollectionJob(ctx context.Context,
 func (job *ReleaseCollectionJob) Execute() error {
 	collectionID := job.result.Message.Header().GetCollectionId()
 	log := log.Ctx(job.ctx).With(zap.Int64("collectionID", collectionID))
+	resourcelimit.Clear(collectionID)
 
 	if !job.meta.CollectionManager.Exist(job.ctx, collectionID) {
 		log.Info("release collection end, the collection has not been loaded into QueryNode")

--- a/internal/querycoordv2/resourcelimit/counter.go
+++ b/internal/querycoordv2/resourcelimit/counter.go
@@ -1,0 +1,108 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourcelimit
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/milvus-io/milvus/pkg/v2/log"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+)
+
+type counterState struct {
+	count     int64
+	lastWrite time.Time
+}
+
+var counterStore = struct {
+	mu       sync.RWMutex
+	counters map[int64]counterState
+}{
+	counters: make(map[int64]counterState),
+}
+
+func Increase(ctx context.Context, collectionID int64) {
+	if collectionID <= 0 {
+		log.Ctx(ctx).Warn("skip increase resource limit counter due to invalid collectionID", zap.Int64("collectionID", collectionID))
+		return
+	}
+
+	now := time.Now()
+	window := paramtable.Get().QueryCoordCfg.ResourceLimitFastStopWindow.GetAsDuration(time.Second)
+
+	counterStore.mu.Lock()
+	defer counterStore.mu.Unlock()
+
+	state, ok := counterStore.counters[collectionID]
+	if ok && window > 0 && now.Sub(state.lastWrite) > window {
+		state.count = 0
+	}
+	state.count++
+	state.lastWrite = now
+	counterStore.counters[collectionID] = state
+
+	log.Ctx(ctx).Info("increased resource limit counter",
+		zap.Int64("collectionID", collectionID),
+		zap.Int64("counter", state.count),
+	)
+}
+
+func ShouldFastStop(collectionID int64) bool {
+	if collectionID <= 0 {
+		return false
+	}
+	if !paramtable.Get().QueryCoordCfg.ResourceLimitFastStopEnable.GetAsBool() {
+		return false
+	}
+
+	threshold := paramtable.Get().QueryCoordCfg.ResourceLimitFastStopThreshold.GetAsInt64()
+	if threshold <= 0 {
+		return false
+	}
+
+	return GetCounter(collectionID) >= threshold
+}
+
+func GetCounter(collectionID int64) int64 {
+	counterStore.mu.RLock()
+	state, ok := counterStore.counters[collectionID]
+	counterStore.mu.RUnlock()
+	if !ok {
+		return 0
+	}
+
+	window := paramtable.Get().QueryCoordCfg.ResourceLimitFastStopWindow.GetAsDuration(time.Second)
+	if window > 0 && time.Since(state.lastWrite) > window {
+		return 0
+	}
+
+	return state.count
+}
+
+func Clear(collectionID int64) {
+	if collectionID <= 0 {
+		return
+	}
+
+	counterStore.mu.Lock()
+	delete(counterStore.counters, collectionID)
+	counterStore.mu.Unlock()
+}

--- a/internal/querycoordv2/task/scheduler.go
+++ b/internal/querycoordv2/task/scheduler.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/milvus-io/milvus/internal/json"
 	"github.com/milvus-io/milvus/internal/querycoordv2/meta"
+	"github.com/milvus-io/milvus/internal/querycoordv2/resourcelimit"
 	"github.com/milvus-io/milvus/internal/querycoordv2/session"
 	"github.com/milvus-io/milvus/internal/querycoordv2/utils"
 	"github.com/milvus-io/milvus/pkg/v2/log"
@@ -1002,6 +1003,14 @@ func (scheduler *taskScheduler) recordSegmentTaskError(task *SegmentTask) {
 		zap.Error(task.err),
 	)
 	meta.GlobalFailedLoadCache.Put(task.collectionID, task.Err())
+	if errors.IsAny(task.Err(),
+		merr.ErrServiceMemoryLimitExceeded,
+		merr.ErrServiceDiskLimitExceeded,
+		merr.ErrServiceResourceInsufficient,
+		merr.ErrSegmentRequestResourceFailed,
+	) {
+		resourcelimit.Increase(scheduler.ctx, task.CollectionID())
+	}
 }
 
 func (scheduler *taskScheduler) remove(task Task) {

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -2581,6 +2581,9 @@ type queryCoordConfig struct {
 	BalanceCheckCollectionMaxCount    ParamItem `refreshable:"true"`
 	ResourceExhaustionPenaltyDuration ParamItem `refreshable:"true"`
 	ResourceExhaustionCleanupInterval ParamItem `refreshable:"true"`
+	ResourceLimitFastStopEnable       ParamItem `refreshable:"true"`
+	ResourceLimitFastStopWindow       ParamItem `refreshable:"true"`
+	ResourceLimitFastStopThreshold    ParamItem `refreshable:"true"`
 
 	UpdateTargetNeedSegmentDataReady ParamItem `refreshable:"true"`
 
@@ -3272,6 +3275,33 @@ Set to 0 to disable the penalty period.`,
 		Export:       true,
 	}
 	p.ResourceExhaustionCleanupInterval.Init(base.mgr)
+
+	p.ResourceLimitFastStopEnable = ParamItem{
+		Key:          "queryCoord.fastStopEnable",
+		Version:      "2.6.11",
+		DefaultValue: "false",
+		Doc:          "Whether to enable fast-stop skip logic for collections with repeated resource-limit load failures.",
+		Export:       true,
+	}
+	p.ResourceLimitFastStopEnable.Init(base.mgr)
+
+	p.ResourceLimitFastStopWindow = ParamItem{
+		Key:          "queryCoord.resourceLimitFastStopWindow",
+		Version:      "2.6.11",
+		DefaultValue: "300",
+		Doc:          "Window (in seconds) for resource-limit load failure counting used by fast-stop collection skipping.",
+		Export:       true,
+	}
+	p.ResourceLimitFastStopWindow.Init(base.mgr)
+
+	p.ResourceLimitFastStopThreshold = ParamItem{
+		Key:          "queryCoord.resourceLimitFastStopThreshold",
+		Version:      "2.6.11",
+		DefaultValue: "100",
+		Doc:          "Threshold of resource-limit load failures for a collection to be skipped during QueryNode graceful stop.",
+		Export:       true,
+	}
+	p.ResourceLimitFastStopThreshold.Init(base.mgr)
 
 	p.UpdateTargetNeedSegmentDataReady = ParamItem{
 		Key:          "queryCoord.updateTargetNeedSegmentDataReady",

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -416,6 +416,8 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, 100, Params.BalanceCheckCollectionMaxCount.GetAsInt())
 		assert.Equal(t, 30, Params.ResourceExhaustionPenaltyDuration.GetAsInt())
 		assert.Equal(t, 10, Params.ResourceExhaustionCleanupInterval.GetAsInt())
+		assert.Equal(t, false, Params.ResourceLimitFastStopEnable.GetAsBool())
+		assert.Equal(t, 100, Params.ResourceLimitFastStopThreshold.GetAsInt())
 	})
 
 	t.Run("test queryNodeConfig", func(t *testing.T) {


### PR DESCRIPTION
This PR introduces a __fast-stop mechanism for QueryCoord under resource-limited conditions__ to make QueryNode graceful stop more responsive and avoid repeated, low-value retries.

### What’s changed

- Added a new per-collection __resource-limit failure counter__ (`internal/querycoordv2/resourcelimit/counter.go`).

- The counter is increased when segment load fails due to resource-related errors (memory/disk/resource insufficiency).

- During stopping balance, once a collection reaches the configured threshold, QueryCoord switches to a __reduce-only drain mode__:

  - it only drains data from the stopping node (`to = -1`),
  - and skips re-assigning those segments/channels to other nodes immediately.

- The counter is cleared when a collection load job starts, preventing stale state from affecting future load cycles.

### New configuration

Three refreshable QueryCoord params are introduced:

- `queryCoord.fastStopEnable` (default: `false`)
- `queryCoord.resourceLimitFastStopWindow` (default: `300` seconds)
- `queryCoord.resourceLimitFastStopThreshold` (default: `100`)

These control whether fast-stop is enabled, how long failures are accumulated, and when the reduce-only behavior is triggered.

### Why

Under heavy resource pressure, repeated rebalance attempts can slow down graceful stop and create unnecessary scheduling churn. This change lets QueryCoord fail fast for repeatedly resource-limited collections during stop, improving stop efficiency and cluster stability.


issue: https://github.com/milvus-io/milvus/issues/47591