### PR TITLE
fix: fix ARM build failures (cmake policy, xxHash target, x86 intrins…

### DIFF
--- a/internal/core/src/exec/HashTable.h
+++ b/internal/core/src/exec/HashTable.h
@@ -14,7 +14,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #pragma once
-#include <emmintrin.h>
 #include <algorithm>
 #include <cstdint>
 #include <cstring>

--- a/internal/core/src/minhash/CMakeLists.txt
+++ b/internal/core/src/minhash/CMakeLists.txt
@@ -56,11 +56,6 @@ elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "(aarch64)|(ARM64)")
     message(STATUS "Building with SVE support")
 endif()
 
-target_link_libraries(milvus_minhash PUBLIC
-    xxhash::xxhash
-    OpenSSL::SSL
-)
-
 target_include_directories(milvus_minhash PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/..
     ${CMAKE_CURRENT_SOURCE_DIR}/fusion_compute

--- a/scripts/3rdparty_build.sh
+++ b/scripts/3rdparty_build.sh
@@ -88,6 +88,11 @@ export CONAN_REVISIONS_ENABLED=1
 export CXXFLAGS="-Wno-error=address -Wno-error=deprecated-declarations -include cstdint"
 export CFLAGS="-Wno-error=address -Wno-error=deprecated-declarations"
 
+# In case any conan package (e.g. google-cloud-cpp) built from source requires
+# a minimum CMake version lower than 3.5, which cmake 3.31+ rejects by default.
+# Same workaround as in core_build.sh (added in #46029).
+export CMAKE_POLICY_VERSION_MINIMUM=3.5
+
 # Determine the Conan remote URL, using the environment variable if set, otherwise defaulting
 CONAN_ARTIFACTORY_URL="${CONAN_ARTIFACTORY_URL:-https://milvus01.jfrog.io/artifactory/api/conan/default-conan-local}"
 


### PR DESCRIPTION
…ics guard)

1. Add CMAKE_POLICY_VERSION_MINIMUM=3.5 to scripts/3rdparty_build.sh so conan packages built from source (e.g. google-cloud-cpp) don't fail with cmake 3.31+ policy rejection. Same workaround as core_build.sh (added in #46029).

2. Fix xxhash::xxhash -> xxHash::xxHash in minhash/CMakeLists.txt to match the target name from conan's cmake_find_package generator.

3. Guard #include <emmintrin.h> (x86 SSE2) with arch check in HashTable.h. IWYU fix #47477 added it unconditionally but it doesn't exist on ARM.