### PR TITLE
fix: handle L0 segment drop in SaveBinlogPaths

### DIFF
--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -566,43 +566,69 @@ func (s *Server) SaveBinlogPaths(ctx context.Context, req *datapb.SaveBinlogPath
 
 	operators := []UpdateOperator{}
 
-	if req.GetSegLevel() == datapb.SegmentLevel_L0 {
-		operators = append(operators, CreateL0Operator(req.GetCollectionID(), req.GetPartitionID(), req.GetSegmentID(), req.GetChannel()))
-	} else {
+	// Handle dropped segments first for all levels
+	if req.GetDropped() {
 		segment := s.meta.GetSegment(ctx, req.GetSegmentID())
-		// validate level one segment
 		if segment == nil {
+			if req.GetSegLevel() == datapb.SegmentLevel_L0 {
+				// Might happen if L0 segment is compacted and gced already
+				log.Warn("try to drop L0 segment which doesn't exist", zap.Int64("segmentID", req.GetSegmentID()))
+				return merr.Success(), nil
+			}
 			err := merr.WrapErrSegmentNotFound(req.GetSegmentID())
-			log.Warn("failed to get segment", zap.Error(err))
+			log.Warn("failed to get segment when dropping", zap.Error(err))
 			return merr.Status(err), nil
 		}
-
 		if segment.State == commonpb.SegmentState_Dropped {
-			log.Info("save to dropped segment, ignore this request")
+			log.Info("segment already dropped, ignore this request")
 			return merr.Success(), nil
 		}
 
-		if !isSegmentHealthy(segment) {
+		// For non-L0 segments, also check segment health before dropping
+		if req.GetSegLevel() != datapb.SegmentLevel_L0 && !isSegmentHealthy(segment) {
 			err := merr.WrapErrSegmentNotFound(req.GetSegmentID())
-			log.Warn("failed to get segment, the segment not healthy", zap.Error(err))
+			log.Warn("failed to drop segment, the segment not healthy", zap.Error(err))
 			return merr.Status(err), nil
 		}
 
-		// Set storage version
-		operators = append(operators, SetStorageVersion(req.GetSegmentID(), req.GetStorageVersion()))
-
-		// Set segment state
-		if req.GetDropped() {
-			// segmentManager manages growing segments
-			s.segmentManager.DropSegment(ctx, req.GetChannel(), req.GetSegmentID())
-			operators = append(operators, UpdateStatusOperator(req.GetSegmentID(), commonpb.SegmentState_Dropped))
-		} else if req.GetFlushed() {
-			s.segmentManager.DropSegment(ctx, req.GetChannel(), req.GetSegmentID())
-			if enableSortCompaction() && req.GetSegLevel() != datapb.SegmentLevel_L0 {
-				operators = append(operators, SetSegmentIsInvisible(req.GetSegmentID(), true))
+		// Drop segment from segmentManager and mark as dropped
+		s.segmentManager.DropSegment(ctx, req.GetChannel(), req.GetSegmentID())
+		operators = append(operators, UpdateStatusOperator(req.GetSegmentID(), commonpb.SegmentState_Dropped))
+	} else {
+		// Not dropping, handle normal create/update logic
+		if req.GetSegLevel() == datapb.SegmentLevel_L0 {
+			operators = append(operators, CreateL0Operator(req.GetCollectionID(), req.GetPartitionID(), req.GetSegmentID(), req.GetChannel()))
+		} else {
+			segment := s.meta.GetSegment(ctx, req.GetSegmentID())
+			// validate level one segment
+			if segment == nil {
+				err := merr.WrapErrSegmentNotFound(req.GetSegmentID())
+				log.Warn("failed to get segment", zap.Error(err))
+				return merr.Status(err), nil
 			}
-			// set segment to SegmentState_Flushed
-			operators = append(operators, UpdateStatusOperator(req.GetSegmentID(), commonpb.SegmentState_Flushed))
+
+			if segment.State == commonpb.SegmentState_Dropped {
+				log.Info("save to dropped segment, ignore this request")
+				return merr.Success(), nil
+			}
+
+			if !isSegmentHealthy(segment) {
+				err := merr.WrapErrSegmentNotFound(req.GetSegmentID())
+				log.Warn("failed to get segment, the segment not healthy", zap.Error(err))
+				return merr.Status(err), nil
+			}
+
+			// Set storage version
+			operators = append(operators, SetStorageVersion(req.GetSegmentID(), req.GetStorageVersion()))
+
+			// Set segment state for flushed
+			if req.GetFlushed() {
+				s.segmentManager.DropSegment(ctx, req.GetChannel(), req.GetSegmentID())
+				if enableSortCompaction() && req.GetSegLevel() != datapb.SegmentLevel_L0 {
+					operators = append(operators, SetSegmentIsInvisible(req.GetSegmentID(), true))
+				}
+				operators = append(operators, UpdateStatusOperator(req.GetSegmentID(), commonpb.SegmentState_Flushed))
+			}
 		}
 	}
 

--- a/internal/datacoord/services_test.go
+++ b/internal/datacoord/services_test.go
@@ -373,6 +373,157 @@ func (s *ServerSuite) TestSaveBinlogPath_L0Segment() {
 	s.EqualValues(datapb.SegmentLevel_L0, segment.GetLevel())
 }
 
+func (s *ServerSuite) TestSaveBinlogPath_DropL0Segment() {
+	s.testServer.meta.AddCollection(&collectionInfo{ID: 0})
+
+	// Test case 1: Drop L0 segment that doesn't exist (already compacted/gc'ed)
+	// This should return success, not an error
+	s.Run("drop non-existent L0 segment returns success", func() {
+		ctx := context.Background()
+		resp, err := s.testServer.SaveBinlogPaths(ctx, &datapb.SaveBinlogPathsRequest{
+			Base: &commonpb.MsgBase{
+				Timestamp: uint64(time.Now().Unix()),
+			},
+			SegmentID:    999, // non-existent segment
+			PartitionID:  1,
+			CollectionID: 0,
+			SegLevel:     datapb.SegmentLevel_L0,
+			Channel:      "ch1",
+			Dropped:      true,
+		})
+		s.NoError(err)
+		s.EqualValues(commonpb.ErrorCode_Success, resp.ErrorCode)
+	})
+
+	// Test case 2: Drop L0 segment that exists
+	s.Run("drop existing L0 segment", func() {
+		// First create the L0 segment
+		ctx := context.Background()
+		resp, err := s.testServer.SaveBinlogPaths(ctx, &datapb.SaveBinlogPathsRequest{
+			Base: &commonpb.MsgBase{
+				Timestamp: uint64(time.Now().Unix()),
+			},
+			SegmentID:    100,
+			PartitionID:  1,
+			CollectionID: 0,
+			SegLevel:     datapb.SegmentLevel_L0,
+			Channel:      "ch1",
+			Deltalogs: []*datapb.FieldBinlog{
+				{
+					FieldID: 1,
+					Binlogs: []*datapb.Binlog{
+						{
+							LogPath:    "/by-dev/test/0/1/100/1/1",
+							EntriesNum: 5,
+						},
+					},
+				},
+			},
+			CheckPoints: []*datapb.CheckPoint{
+				{
+					SegmentID: 100,
+					Position: &msgpb.MsgPosition{
+						ChannelName: "ch1",
+						MsgID:       []byte{1, 2, 3},
+						Timestamp:   0,
+					},
+					NumOfRows: 5,
+				},
+			},
+		})
+		s.NoError(err)
+		s.EqualValues(commonpb.ErrorCode_Success, resp.ErrorCode)
+
+		segment := s.testServer.meta.GetHealthySegment(context.TODO(), 100)
+		s.NotNil(segment)
+
+		// Now drop the L0 segment
+		resp, err = s.testServer.SaveBinlogPaths(ctx, &datapb.SaveBinlogPathsRequest{
+			Base: &commonpb.MsgBase{
+				Timestamp: uint64(time.Now().Unix()),
+			},
+			SegmentID:    100,
+			PartitionID:  1,
+			CollectionID: 0,
+			SegLevel:     datapb.SegmentLevel_L0,
+			Channel:      "ch1",
+			Dropped:      true,
+		})
+		s.NoError(err)
+		s.EqualValues(commonpb.ErrorCode_Success, resp.ErrorCode)
+
+		// Verify segment is now dropped
+		segment = s.testServer.meta.GetSegment(context.TODO(), 100)
+		s.NotNil(segment)
+		s.Equal(commonpb.SegmentState_Dropped, segment.GetState())
+	})
+
+	// Test case 3: Drop L0 segment that is already dropped (idempotent)
+	s.Run("drop already dropped L0 segment returns success", func() {
+		// Create and then drop the segment first
+		ctx := context.Background()
+		resp, err := s.testServer.SaveBinlogPaths(ctx, &datapb.SaveBinlogPathsRequest{
+			Base: &commonpb.MsgBase{
+				Timestamp: uint64(time.Now().Unix()),
+			},
+			SegmentID:    101,
+			PartitionID:  1,
+			CollectionID: 0,
+			SegLevel:     datapb.SegmentLevel_L0,
+			Channel:      "ch1",
+		})
+		s.NoError(err)
+		s.EqualValues(commonpb.ErrorCode_Success, resp.ErrorCode)
+
+		// Drop it
+		resp, err = s.testServer.SaveBinlogPaths(ctx, &datapb.SaveBinlogPathsRequest{
+			Base: &commonpb.MsgBase{
+				Timestamp: uint64(time.Now().Unix()),
+			},
+			SegmentID:    101,
+			PartitionID:  1,
+			CollectionID: 0,
+			SegLevel:     datapb.SegmentLevel_L0,
+			Channel:      "ch1",
+			Dropped:      true,
+		})
+		s.NoError(err)
+		s.EqualValues(commonpb.ErrorCode_Success, resp.ErrorCode)
+
+		// Try to drop again - should return success
+		resp, err = s.testServer.SaveBinlogPaths(ctx, &datapb.SaveBinlogPathsRequest{
+			Base: &commonpb.MsgBase{
+				Timestamp: uint64(time.Now().Unix()),
+			},
+			SegmentID:    101,
+			PartitionID:  1,
+			CollectionID: 0,
+			SegLevel:     datapb.SegmentLevel_L0,
+			Channel:      "ch1",
+			Dropped:      true,
+		})
+		s.NoError(err)
+		s.EqualValues(commonpb.ErrorCode_Success, resp.ErrorCode)
+	})
+
+	// Test case 4: Drop non-L0 segment that doesn't exist should return error
+	s.Run("drop non-existent non-L0 segment returns error", func() {
+		ctx := context.Background()
+		resp, err := s.testServer.SaveBinlogPaths(ctx, &datapb.SaveBinlogPathsRequest{
+			Base: &commonpb.MsgBase{
+				Timestamp: uint64(time.Now().Unix()),
+			},
+			SegmentID:    998, // non-existent segment
+			CollectionID: 0,
+			SegLevel:     datapb.SegmentLevel_L1,
+			Channel:      "ch1",
+			Dropped:      true,
+		})
+		s.NoError(err)
+		s.ErrorIs(merr.Error(resp), merr.ErrSegmentNotFound)
+	})
+}
+
 func (s *ServerSuite) TestSaveBinlogPath_NormalCase() {
 	s.testServer.meta.AddCollection(&collectionInfo{ID: 0})
 


### PR DESCRIPTION
Previously the Dropped flag was ignored for L0 segments, causing them to go through CreateL0Operator instead of being marked as dropped.

Restructure the drop/create/flush branching so that Dropped is checked first for all segment levels. For L0 segments that no longer exist (already compacted and GC'd), return success gracefully instead of an error.

See also: #47726