### PR TITLE
enhance: support user-defined loadbalancing via custom resolver

### DIFF
--- a/client/milvusclient/client.go
+++ b/client/milvusclient/client.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"slices"
 	"strconv"
 	"sync"
 	"time"
@@ -71,8 +72,13 @@ func New(ctx context.Context, config *ClientConfig) (*Client, error) {
 		currentDB: config.DBName,
 	}
 
-	// Parse remote address.
-	addr := c.config.getParsedAddress()
+	// pass through address if scheme is not tcp, http or https
+	// user-defined resolver will handle the scheme
+	addr := c.config.Address
+	// for http(s) scheme, use parsed address
+	if slices.Contains([]string{"tcp", "http", "https"}, c.config.parsedAddress.Scheme) {
+		addr = c.config.getParsedAddress()
+	}
 
 	// parse authentication parameters
 	c.parseAuthentication()

--- a/client/milvusclient/client_config.go
+++ b/client/milvusclient/client_config.go
@@ -75,7 +75,7 @@ type RetryRateLimitOption struct {
 func (cfg *ClientConfig) parse() error {
 	// Prepend default fake tcp:// scheme for remote address.
 	address := cfg.Address
-	if _, err := url.Parse(address); err != nil {
+	if parts := strings.Split(address, "://"); len(parts) != 2 {
 		address = fmt.Sprintf("tcp://%s", address)
 	}
 

--- a/client/milvusclient/client_config.go
+++ b/client/milvusclient/client_config.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math"
 	"net/url"
-	"regexp"
 	"strings"
 	"time"
 
@@ -21,8 +20,6 @@ const (
 	disableDynamicSchema
 	disableParitionKey
 )
-
-var regexValidScheme = regexp.MustCompile(`^https?:\/\/`)
 
 // DefaultGrpcOpts is GRPC options for milvus client.
 var DefaultGrpcOpts = []grpc.DialOption{
@@ -78,7 +75,7 @@ type RetryRateLimitOption struct {
 func (cfg *ClientConfig) parse() error {
 	// Prepend default fake tcp:// scheme for remote address.
 	address := cfg.Address
-	if !regexValidScheme.MatchString(address) {
+	if _, err := url.Parse(address); err != nil {
 		address = fmt.Sprintf("tcp://%s", address)
 	}
 

--- a/client/milvusclient/client_test.go
+++ b/client/milvusclient/client_test.go
@@ -36,6 +36,36 @@ func (s *ClientSuite) TestNewClient() {
 		s.Error(err)
 		s.T().Log(err)
 	})
+
+	s.Run("add_tcp_scheme", func() {
+		c, err := New(ctx,
+			&ClientConfig{
+				Address: "xxxxx:19530",
+				DialOptions: []grpc.DialOption{
+					grpc.WithBlock(),
+					grpc.WithTransportCredentials(insecure.NewCredentials()),
+					grpc.WithContextDialer(s.mockDialer),
+				},
+			})
+		s.NoError(err)
+		s.NotNil(c)
+		s.Equal("tcp", c.config.parsedAddress.Scheme)
+	})
+
+	s.Run("use_provided_scheme", func() {
+		c, err := New(ctx,
+			&ClientConfig{
+				Address: "xds://xxxxx:19530",
+				DialOptions: []grpc.DialOption{
+					grpc.WithBlock(),
+					grpc.WithTransportCredentials(insecure.NewCredentials()),
+					grpc.WithContextDialer(s.mockDialer),
+				},
+			})
+		s.NoError(err)
+		s.NotNil(c)
+		s.Equal("xds", c.config.parsedAddress.Scheme)
+	})
 }
 
 func TestClient(t *testing.T) {


### PR DESCRIPTION
## enhance: support passthrough addr to enable custom LB via custom resolver

## Description
This PR adds support for passing through the original target address (addr) to the resolver layer, enabling developers to implement custom load balancing (LB) strategies by leveraging custom resolvers.

### Background
Previously, the address resolution process would encapsulate the target addr, making it difficult for custom resolvers to access the original target information when implementing advanced LB logic (e.g., weighted round-robin, region-aware routing, or dynamic endpoint selection).

### Changes Made
Expose original target addr to grpc if the scheme is not 'tcp/http/https', so grpc resolvers can handle this addr.
This PR will fix issue #47266

### Benefits
- Developers can now implement custom LB strategies (e.g., weighted LB, sticky sessions) directly via custom resolvers by using the passthrough addr
- No breaking changes to existing codebase; all legacy resolver implementations remain compatible
- Simplifies integration with service discovery systems (ETCD/Consul) that rely on raw target addr for endpoint lookup

### Usage Example
```go
type customBuilder struct {}
func (b *customBuilder) Scheme() string { return "xxx"}
func (b *customBuilder) Build(target resolver.Target, cc resolver.ClientConn, opts resolver.BuildOptions) (resolver.Resolver, error) {
    // user custom resolver .
    return &customResolver{originalAddr: originalAddr, cc: cc}, nil
}

// then register the resolver before build milvus client
resolver.Register(&customBuilder{})
```