### PR TITLE
fix: Handle v2.5/v2.6 compatibility in syncTargetVersion [QueryNode]

### DIFF
--- a/internal/querynodev2/services.go
+++ b/internal/querynodev2/services.go
@@ -1343,6 +1343,18 @@ func (node *QueryNode) SyncDistribution(ctx context.Context, req *querypb.SyncDi
 				})
 			})
 		case querypb.SyncType_UpdateVersion:
+			// Version compatibility check: reject messages with inconsistent sealed segment fields
+			// In v2.6, SealedInTarget and SealedSegmentRowCount have consistent keys (same length)
+			// A mismatch indicates the message is from v2.5 which lacks SealedSegmentRowCount
+			if len(action.GetSealedInTarget()) != len(action.GetSealedSegmentRowCount()) {
+				log.Warn("Reject syncTargetVersion from older version Coordinator",
+					zap.String("channel", req.GetChannel()),
+					zap.Int("sealedInTarget", len(action.GetSealedInTarget())),
+					zap.Int("sealedSegmentRowCount", len(action.GetSealedSegmentRowCount())),
+				)
+				continue
+			}
+
 			log.Info("sync action",
 				zap.Int64("TargetVersion", action.GetTargetVersion()),
 				zap.Time("checkPoint", tsoutil.PhysicalTime(action.GetCheckpoint().GetTimestamp())),


### PR DESCRIPTION
issue: #47652

## Summary

Prevent tsafe latency during 2.5→2.6 upgrade by rejecting incomplete
v2.5 syncTargetVersion RPC messages that lack SealedSegmentRowCount field.

During standalone upgrade from 2.5 to 2.6, the old coordinator sends
syncTargetVersion RPC to new 2.6 nodes. The 2.5 RPC proto lacks the
SealedSegmentRowCount field, causing 2.6 delegator to incorrectly skip
the serviceable check and be marked as serviceable prematurely.

## Changes

- Add field consistency check (`SealedInTarget` vs `SealedSegmentRowCount`
  length mismatch) in SyncDistribution UpdateVersion handler to detect
  and reject v2.5 format messages
- Add test for v2.5 message rejection scenario

## Impact

This fix prevents delegator from prematurely entering serviceable state
when stream message consumption is delayed during cluster upgrade, which
was causing query timeouts due to unmet tsafe constraints.