### PR TITLE
fix: enable error checking in setenv.sh to catch CMake failures

### DIFF
--- a/scripts/core_build.sh
+++ b/scripts/core_build.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Exit immediately if a command exits with non-zero status
+set -e
+
 # Licensed to the LF AI & Data foundation under one
 # or more contributor license agreements. See the NOTICE file
 # distributed with this work for additional information
@@ -219,7 +222,7 @@ pushd ${BUILD_OUTPUT_DIR}
 
 # Remove make cache since build.sh -l use default variables
 # Force update the variables each time
-make rebuild_cache >/dev/null 2>&1
+make rebuild_cache >/dev/null 2>&1 || true
 
 CPU_ARCH=$(get_cpu_arch $CPU_TARGET)
 

--- a/scripts/setenv.sh
+++ b/scripts/setenv.sh
@@ -17,7 +17,7 @@
 # limitations under the License.
 
 # Exit immediately for non zero status
-set +e
+set -e
 
 SOURCE="${BASH_SOURCE[0]}"
 # fix on zsh environment
@@ -38,7 +38,7 @@ unameOut="$(uname -s)"
 case "${unameOut}" in
     Linux*)
       # check if use asan.
-      MILVUS_ENABLE_ASAN_LIB=$(ldd $ROOT_DIR/internal/core/output/lib/libmilvus_core.so | grep asan | awk '{print $3}')
+      MILVUS_ENABLE_ASAN_LIB=$(ldd $ROOT_DIR/internal/core/output/lib/libmilvus_core.so 2>/dev/null | grep asan | awk '{print $3}' || true)
       if [ -n "$MILVUS_ENABLE_ASAN_LIB" ]; then
           echo "Enable ASAN With ${MILVUS_ENABLE_ASAN_LIB}"
           export MILVUS_ENABLE_ASAN_LIB="$MILVUS_ENABLE_ASAN_LIB"

--- a/scripts/setenv.sh
+++ b/scripts/setenv.sh
@@ -16,8 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Exit immediately for non zero status
-set -e
+# Note: This script is sourced by other scripts, so we don't set -e here
+# to avoid affecting the calling script's error handling behavior
 
 SOURCE="${BASH_SOURCE[0]}"
 # fix on zsh environment


### PR DESCRIPTION
## Summary

Fixes #47498 by enabling proper error checking in the build scripts.

The build system was silently continuing after CMake configuration failures because `core_build.sh` lacked error checking (`set -e`). This resulted in confusing build failures where critical CMake errors were buried in the logs.

## Root Cause

The original `setenv.sh` used `set +e` which **disabled** error checking when sourced. However, the real issue was that `core_build.sh` (where CMake runs) had no error checking at all.

## Changes

1. **Removed `set -e` from `setenv.sh`**: Since this script is sourced by other scripts, it shouldn't modify the caller's error handling state. Removed the previous `set +e` entirely.

2. **Added `set -e` to `core_build.sh`**: This is where CMake configuration happens, so this script should exit immediately on errors.

3. **Fixed commands allowed to fail**:
   - Added `|| true` to the `ldd` command in `setenv.sh` (library check before first build)
   - Added `|| true` to `make rebuild_cache` in `core_build.sh` (cleanup command)
   - Redirected stderr to `/dev/null` for `ldd` to suppress expected error messages

## Testing

The fix ensures that:
1. CMake configuration errors now cause immediate script failure in `core_build.sh`
2. The build script exits with non-zero status when CMake fails
3. Commands that are expected to fail (like ldd on non-existent libraries or make rebuild_cache before first build) don't trigger false failures
4. Other scripts that source `setenv.sh` are not affected by unexpected error handling changes

## Impact

This change makes build failures more discoverable and prevents developers from wasting time debugging compilation errors that were caused by hidden CMake configuration failures.

Signed-off-by: Varun Chawla <varun_6april@hotmail.com>