### PR TITLE
enhance: refactor WithClusterLevelBroadcast to use external channel list and add FlushAll integration test

### DIFF
--- a/internal/datacoord/services_test.go
+++ b/internal/datacoord/services_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/milvus-io/milvus/internal/coordinator/snmanager"
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
 	"github.com/milvus-io/milvus/internal/datacoord/broker"
-	"github.com/milvus-io/milvus/internal/distributed/streaming"
 	etcdkv "github.com/milvus-io/milvus/internal/kv/etcd"
 	"github.com/milvus-io/milvus/internal/metastore/mocks"
 	"github.com/milvus-io/milvus/internal/metastore/model"
@@ -1819,10 +1818,12 @@ func TestServer_FlushAll(t *testing.T) {
 		server := createTestFlushAllServer()
 		server.handler = NewNMockHandler(t)
 
-		// Mock WAL
-		wal := mock_streaming.NewMockWALAccesser(t)
-		wal.EXPECT().ControlChannel().Return(funcutil.GetControlChannel("by-dev-rootcoord-dml_0")).Maybe()
-		streaming.SetWALForTest(wal)
+		// Mock channel.GetClusterChannels
+		mockGetClusterChannels := mockey.Mock(channel.GetClusterChannels).Return(message.ClusterChannels{
+			Channels:       []string{"by-dev-rootcoord-dml_0", "by-dev-rootcoord-dml_1"},
+			ControlChannel: funcutil.GetControlChannel("by-dev-rootcoord-dml_0"),
+		}).Build()
+		defer mockGetClusterChannels.UnPatch()
 
 		// Mock broadcaster
 		bapi := mock_broadcaster.NewMockBroadcastAPI(t)
@@ -1860,22 +1861,19 @@ func TestServer_FlushAll(t *testing.T) {
 		broadcast.ResetBroadcaster()
 		broadcast.Register(mb)
 
-		// Register mock balancer
-		snmanager.ResetStreamingNodeManager()
+		// Register mock balancer for balance.GetWithContext in StartBroadcastWithResourceKeys
 		b := mock_balancer.NewMockBalancer(t)
+		b.EXPECT().WaitUntilWALbasedDDLReady(mock.Anything).Return(nil)
 		b.EXPECT().WatchChannelAssignments(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, callback balancer.WatchChannelAssignmentsCallback) error {
 			<-ctx.Done()
 			return ctx.Err()
 		}).Maybe()
-		b.EXPECT().GetLatestChannelAssignment().Return(&balancer.WatchChannelAssignmentsCallbackParam{
-			PChannelView: &channel.PChannelView{
-				Channels: map[channel.ChannelID]*channel.PChannelMeta{
-					{Name: "by-dev-1"}: channel.NewPChannelMeta("by-dev-1", types2.AccessModeRW),
-				},
-			},
-		}, nil)
-		b.EXPECT().WaitUntilWALbasedDDLReady(mock.Anything).Return(nil)
+		b.EXPECT().Close().Return().Maybe()
+		balance.ResetBalancer()
 		balance.Register(b)
+
+		// Register DDL callbacks so registry.CallMessageAckCallback can resolve
+		RegisterDDLCallbacks(server)
 
 		req := &datapb.FlushAllRequest{}
 		resp, err := server.FlushAll(context.Background(), req)

--- a/internal/datacoord/services_test.go
+++ b/internal/datacoord/services_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/milvus-io/milvus/internal/coordinator/snmanager"
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
 	"github.com/milvus-io/milvus/internal/datacoord/broker"
+	"github.com/milvus-io/milvus/internal/distributed/streaming"
 	etcdkv "github.com/milvus-io/milvus/internal/kv/etcd"
 	"github.com/milvus-io/milvus/internal/metastore/mocks"
 	"github.com/milvus-io/milvus/internal/metastore/model"

--- a/internal/distributed/streaming/append.go
+++ b/internal/distributed/streaming/append.go
@@ -6,13 +6,11 @@ import (
 	"github.com/milvus-io/milvus/internal/distributed/streaming/internal/producer"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/types"
-	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
 )
 
 // appendToWAL appends the message to the wal.
 func (w *walAccesserImpl) appendToWAL(ctx context.Context, msg message.MutableMessage) (*types.AppendResult, error) {
-	pchannel := funcutil.ToPhysicalChannel(msg.VChannel())
-	p := w.getProducer(pchannel)
+	p := w.getProducer(msg.PChannel())
 	return p.Produce(ctx, msg)
 }
 

--- a/internal/proxy/impl_test.go
+++ b/internal/proxy/impl_test.go
@@ -2524,9 +2524,7 @@ func TestProxy_BatchUpdateManifest(t *testing.T) {
 			mockey.Mock(globalMetaCache.GetCollectionID).To(func(ctx context.Context, dbName, collectionName string) (UniqueID, error) {
 				return UniqueID(0), nil
 			}).Build()
-			mockey.Mock(globalMetaCache.RemoveDatabase).To(func(ctx context.Context, dbName string) error {
-				return nil
-			}).Build()
+			mockey.Mock(globalMetaCache.RemoveDatabase).To(func(ctx context.Context, dbName string) {}).Build()
 
 			mockey.Mock(paramtable.Init).Return().Build()
 			mockey.Mock((*paramtable.ComponentParam).Save).Return().Build()
@@ -2553,9 +2551,7 @@ func TestProxy_BatchUpdateManifest(t *testing.T) {
 			mockey.Mock((*MetaCache).GetCollectionID).To(func(m *MetaCache, ctx context.Context, dbName, collectionName string) (UniqueID, error) {
 				return UniqueID(100), nil
 			}).Build()
-			mockey.Mock((*MetaCache).RemoveDatabase).To(func(m *MetaCache, ctx context.Context, dbName string) error {
-				return nil
-			}).Build()
+			mockey.Mock((*MetaCache).RemoveDatabase).To(func(m *MetaCache, ctx context.Context, dbName string) {}).Build()
 
 			mockey.Mock(paramtable.Init).Return().Build()
 			mockey.Mock((*paramtable.ComponentParam).Save).Return().Build()

--- a/internal/streamingcoord/server/balancer/balancer_test.go
+++ b/internal/streamingcoord/server/balancer/balancer_test.go
@@ -399,6 +399,153 @@ func TestBalancer_WithRecoveryLag(t *testing.T) {
 	})
 }
 
+func TestBalancer_DynamicChannelFromProvider(t *testing.T) {
+	paramtable.Init()
+	etcdClient, _ := kvfactory.GetEtcdAndPath()
+	channel.ResetStaticPChannelStatsManager()
+	channel.RecoverPChannelStatsManager([]string{})
+
+	streamingNodeManager := mock_manager.NewMockManagerClient(t)
+	streamingNodeManager.EXPECT().WatchNodeChanged(mock.Anything).Return(make(chan struct{}), nil)
+	streamingNodeManager.EXPECT().Assign(mock.Anything, mock.Anything).Return(nil).Maybe()
+	streamingNodeManager.EXPECT().Remove(mock.Anything, mock.Anything).Return(nil).Maybe()
+	streamingNodeManager.EXPECT().GetAllStreamingNodes(mock.Anything).Return(map[int64]*types.StreamingNodeInfo{
+		1: {ServerID: 1, Address: "localhost:1"},
+		2: {ServerID: 2, Address: "localhost:2"},
+	}, nil).Maybe()
+	streamingNodeManager.EXPECT().CollectAllStatus(mock.Anything).Return(map[int64]*types.StreamingNodeStatus{
+		1: {StreamingNodeInfo: types.StreamingNodeInfo{ServerID: 1, Address: "localhost:1"}},
+		2: {StreamingNodeInfo: types.StreamingNodeInfo{ServerID: 2, Address: "localhost:2"}},
+	}, nil).Maybe()
+
+	catalog := mock_metastore.NewMockStreamingCoordCataLog(t)
+	s := sessionutil.NewMockSession(t)
+	s.EXPECT().GetRegisteredRevision().Return(int64(1))
+	resource.InitForTest(
+		resource.OptETCD(etcdClient),
+		resource.OptStreamingCatalog(catalog),
+		resource.OptStreamingManagerClient(streamingNodeManager),
+		resource.OptSession(s),
+	)
+	catalog.EXPECT().GetCChannel(mock.Anything).Return(nil, nil)
+	catalog.EXPECT().SaveCChannel(mock.Anything, mock.Anything).Return(nil)
+	catalog.EXPECT().GetVersion(mock.Anything).Return(nil, nil)
+	catalog.EXPECT().SaveVersion(mock.Anything, mock.Anything).Return(nil)
+	catalog.EXPECT().ListPChannel(mock.Anything).Unset()
+	catalog.EXPECT().ListPChannel(mock.Anything).Return([]*streamingpb.PChannelMeta{
+		{
+			Channel: &streamingpb.PChannelInfo{
+				Name:       "initial-channel",
+				Term:       1,
+				AccessMode: streamingpb.PChannelAccessMode_PCHANNEL_ACCESS_READONLY,
+			},
+			State: streamingpb.PChannelMetaState_PCHANNEL_META_STATE_ASSIGNED,
+			Node:  &streamingpb.StreamingNodeInfo{ServerId: 1},
+		},
+	}, nil)
+	catalog.EXPECT().SavePChannels(mock.Anything, mock.Anything).Return(nil).Maybe()
+	catalog.EXPECT().GetReplicateConfiguration(mock.Anything).Return(nil, nil)
+
+	provider := newStaticChannelProvider("initial-channel")
+	ctx := context.Background()
+	b, err := balancer.RecoverBalancer(ctx, provider)
+	assert.NoError(t, err)
+	assert.NotNil(t, b)
+
+	// Wait for initial assignment to stabilize (1 channel assigned).
+	doneErr := errors.New("done")
+	err = b.WatchChannelAssignments(ctx, func(param balancer.WatchChannelAssignmentsCallbackParam) error {
+		if len(param.Relations) >= 1 {
+			return doneErr
+		}
+		return nil
+	})
+	assert.ErrorIs(t, err, doneErr)
+
+	// Send dynamic channels through the provider.
+	provider.ch <- []string{"dynamic-channel-1", "dynamic-channel-2"}
+
+	// The balancer should pick them up and assign them.
+	err = b.WatchChannelAssignments(ctx, func(param balancer.WatchChannelAssignmentsCallbackParam) error {
+		if len(param.Relations) >= 3 {
+			return doneErr
+		}
+		return nil
+	})
+	assert.ErrorIs(t, err, doneErr)
+
+	b.Close()
+}
+
+func TestBalancer_DynamicChannelProviderClosed(t *testing.T) {
+	paramtable.Init()
+	etcdClient, _ := kvfactory.GetEtcdAndPath()
+	channel.ResetStaticPChannelStatsManager()
+	channel.RecoverPChannelStatsManager([]string{})
+
+	streamingNodeManager := mock_manager.NewMockManagerClient(t)
+	streamingNodeManager.EXPECT().WatchNodeChanged(mock.Anything).Return(make(chan struct{}), nil)
+	streamingNodeManager.EXPECT().Assign(mock.Anything, mock.Anything).Return(nil).Maybe()
+	streamingNodeManager.EXPECT().Remove(mock.Anything, mock.Anything).Return(nil).Maybe()
+	streamingNodeManager.EXPECT().GetAllStreamingNodes(mock.Anything).Return(map[int64]*types.StreamingNodeInfo{
+		1: {ServerID: 1, Address: "localhost:1"},
+	}, nil).Maybe()
+	streamingNodeManager.EXPECT().CollectAllStatus(mock.Anything).Return(map[int64]*types.StreamingNodeStatus{
+		1: {StreamingNodeInfo: types.StreamingNodeInfo{ServerID: 1, Address: "localhost:1"}},
+	}, nil).Maybe()
+
+	catalog := mock_metastore.NewMockStreamingCoordCataLog(t)
+	s := sessionutil.NewMockSession(t)
+	s.EXPECT().GetRegisteredRevision().Return(int64(1))
+	resource.InitForTest(
+		resource.OptETCD(etcdClient),
+		resource.OptStreamingCatalog(catalog),
+		resource.OptStreamingManagerClient(streamingNodeManager),
+		resource.OptSession(s),
+	)
+	catalog.EXPECT().GetCChannel(mock.Anything).Return(nil, nil)
+	catalog.EXPECT().SaveCChannel(mock.Anything, mock.Anything).Return(nil)
+	catalog.EXPECT().GetVersion(mock.Anything).Return(nil, nil)
+	catalog.EXPECT().SaveVersion(mock.Anything, mock.Anything).Return(nil)
+	catalog.EXPECT().ListPChannel(mock.Anything).Unset()
+	catalog.EXPECT().ListPChannel(mock.Anything).Return([]*streamingpb.PChannelMeta{
+		{
+			Channel: &streamingpb.PChannelInfo{
+				Name:       "ch1",
+				Term:       1,
+				AccessMode: streamingpb.PChannelAccessMode_PCHANNEL_ACCESS_READONLY,
+			},
+			State: streamingpb.PChannelMetaState_PCHANNEL_META_STATE_ASSIGNED,
+			Node:  &streamingpb.StreamingNodeInfo{ServerId: 1},
+		},
+	}, nil)
+	catalog.EXPECT().SavePChannels(mock.Anything, mock.Anything).Return(nil).Maybe()
+	catalog.EXPECT().GetReplicateConfiguration(mock.Anything).Return(nil, nil)
+
+	provider := newStaticChannelProvider("ch1")
+	ctx := context.Background()
+	b, err := balancer.RecoverBalancer(ctx, provider)
+	assert.NoError(t, err)
+
+	// Wait for initial assignment.
+	doneErr := errors.New("done")
+	err = b.WatchChannelAssignments(ctx, func(param balancer.WatchChannelAssignmentsCallbackParam) error {
+		if len(param.Relations) >= 1 {
+			return doneErr
+		}
+		return nil
+	})
+	assert.ErrorIs(t, err, doneErr)
+
+	// Close the provider channel — execute loop should exit via the !ok branch.
+	close(provider.ch)
+	// Wait for execute goroutine to finish (backgroundTaskNotifier will be done).
+	time.Sleep(100 * time.Millisecond)
+
+	// Close should still work cleanly after execute has already returned.
+	b.Close()
+}
+
 // staticChannelProvider is a test helper implementing balancer.ChannelProvider with static channels.
 type staticChannelProvider struct {
 	channels []string

--- a/internal/streamingcoord/server/balancer/balancer_test.go
+++ b/internal/streamingcoord/server/balancer/balancer_test.go
@@ -145,7 +145,7 @@ func TestBalancer(t *testing.T) {
 	resource.Resource().ETCD().Put(context.Background(), dataNodePath, string(data))
 
 	ctx := context.Background()
-	b, err := balancer.RecoverBalancer(ctx, "test-channel-1")
+	b, err := balancer.RecoverBalancer(ctx, newStaticChannelProvider("test-channel-1"))
 	assert.NoError(t, err)
 	assert.NotNil(t, b)
 
@@ -364,7 +364,7 @@ func TestBalancer_WithRecoveryLag(t *testing.T) {
 	catalog.EXPECT().GetReplicateConfiguration(mock.Anything).Return(nil, nil)
 
 	ctx := context.Background()
-	b, err := balancer.RecoverBalancer(ctx, "test-channel-1")
+	b, err := balancer.RecoverBalancer(ctx, newStaticChannelProvider("test-channel-1"))
 	assert.NoError(t, err)
 	assert.NotNil(t, b)
 
@@ -398,3 +398,26 @@ func TestBalancer_WithRecoveryLag(t *testing.T) {
 		return nil
 	})
 }
+
+// staticChannelProvider is a test helper implementing balancer.ChannelProvider with static channels.
+type staticChannelProvider struct {
+	channels []string
+	ch       chan []string
+}
+
+func newStaticChannelProvider(channels ...string) *staticChannelProvider {
+	return &staticChannelProvider{
+		channels: channels,
+		ch:       make(chan []string),
+	}
+}
+
+func (p *staticChannelProvider) GetInitialChannels() []string {
+	return p.channels
+}
+
+func (p *staticChannelProvider) NewIncomingChannels() <-chan []string {
+	return p.ch
+}
+
+func (p *staticChannelProvider) Close() {}

--- a/internal/streamingcoord/server/balancer/channel/manager.go
+++ b/internal/streamingcoord/server/balancer/channel/manager.go
@@ -237,6 +237,52 @@ func (cm *ChannelManager) ReplicateRole() replicateutil.Role {
 	return cm.replicateConfig.GetCurrentCluster().Role()
 }
 
+// AddPChannels adds new PChannels dynamically. Channels that already exist are skipped.
+// Only newly added channels are persisted and version is incremented.
+func (cm *ChannelManager) AddPChannels(ctx context.Context, newChannels []string) error {
+	cm.cond.LockAndBroadcast()
+	defer cm.cond.L.Unlock()
+
+	newMetas := make([]*streamingpb.PChannelMeta, 0, len(newChannels))
+	for _, name := range newChannels {
+		id := ChannelID{Name: name}
+		if _, ok := cm.channels[id]; ok {
+			continue
+		}
+		var meta *PChannelMeta
+		if cm.streamingVersion == nil {
+			meta = NewPChannelMeta(name, types.AccessModeRO)
+		} else {
+			meta = NewPChannelMeta(name, types.AccessModeRW)
+		}
+		cm.channels[id] = meta
+		cm.metrics.AssignPChannelStatus(meta)
+		newMetas = append(newMetas, meta.CopyForWrite().IntoRawMeta())
+	}
+
+	if len(newMetas) == 0 {
+		return nil
+	}
+
+	if err := resource.Resource().StreamingCatalog().SavePChannels(ctx, newMetas); err != nil {
+		// Rollback in-memory changes on persist failure
+		for _, m := range newMetas {
+			c := newPChannelMetaFromProto(m)
+			delete(cm.channels, c.ChannelID())
+		}
+		cm.Logger().Error("failed to save new pchannels", zap.Error(err))
+		return err
+	}
+
+	cm.version.Local++
+	cm.metrics.UpdateAssignmentVersion(cm.version.Local)
+
+	cm.Logger().Info("dynamically added new pchannels",
+		zap.Int("count", len(newMetas)),
+		zap.Strings("channels", newChannels))
+	return nil
+}
+
 // TriggerWatchUpdate triggers the watch update.
 // Because current watch must see new incoming streaming node right away,
 // so a watch updating trigger will be called if there's new incoming streaming node.

--- a/internal/streamingcoord/server/balancer/channel/manager.go
+++ b/internal/streamingcoord/server/balancer/channel/manager.go
@@ -63,7 +63,7 @@ func RecoverChannelManager(ctx context.Context, incomingChannel ...string) (*Cha
 	if err != nil {
 		return nil, err
 	}
-	channels, metrics, err := recoverFromConfigurationAndMeta(ctx, streamingVersion, incomingChannel...)
+	channels, metrics, err := recoverFromConfigurationAndMeta(ctx, streamingVersion, replicateConfig, incomingChannel...)
 	if err != nil {
 		return nil, err
 	}
@@ -88,13 +88,27 @@ func RecoverChannelManager(ctx context.Context, incomingChannel ...string) (*Cha
 	return cm, nil
 }
 
-// getClusterChannels returns the raw pchannel names and the control channel name.
-func (cm *ChannelManager) getClusterChannels() message.ClusterChannels {
+// getClusterChannels returns the pchannel names and the control channel name.
+// By default, only channels available in replication are returned.
+// Use OptIncludeUnavailableInReplication() to include unavailable channels.
+func (cm *ChannelManager) getClusterChannels(opts ...GetClusterChannelsOpt) message.ClusterChannels {
+	o := &getClusterChannelsOptions{}
+	for _, opt := range opts {
+		opt(o)
+	}
+
 	cm.cond.L.Lock()
 	defer cm.cond.L.Unlock()
 
+	channels := make([]string, 0, len(cm.channels))
+	for _, ch := range cm.channels {
+		if !o.includeUnavailableInReplication && !ch.AvailableInReplication() {
+			continue
+		}
+		channels = append(channels, ch.Name())
+	}
 	return message.ClusterChannels{
-		Channels:       lo.MapToSlice(cm.channels, func(_ ChannelID, ch *PChannelMeta) string { return ch.Name() }),
+		Channels:       channels,
 		ControlChannel: funcutil.GetControlChannel(cm.cchannelMeta.Pchannel),
 	}
 }
@@ -121,7 +135,7 @@ func recoverCChannelMeta(ctx context.Context, incomingChannel ...string) (*strea
 }
 
 // recoverFromConfigurationAndMeta recovers the channel manager from configuration and meta.
-func recoverFromConfigurationAndMeta(ctx context.Context, streamingVersion *streamingpb.StreamingVersion, incomingChannel ...string) (map[ChannelID]*PChannelMeta, *channelMetrics, error) {
+func recoverFromConfigurationAndMeta(ctx context.Context, streamingVersion *streamingpb.StreamingVersion, replicateConfig *replicateutil.ConfigHelper, incomingChannel ...string) (map[ChannelID]*PChannelMeta, *channelMetrics, error) {
 	// Recover metrics.
 	metrics := newPChannelMetrics()
 
@@ -135,6 +149,7 @@ func recoverFromConfigurationAndMeta(ctx context.Context, streamingVersion *stre
 	channels := make(map[ChannelID]*PChannelMeta, len(channelMetas))
 	for _, channel := range channelMetas {
 		c := newPChannelMetaFromProto(channel)
+		c.availableInReplication = isChannelAvailableInReplication(c.Name(), replicateConfig)
 		metrics.AssignPChannelStatus(c)
 		channels[c.ChannelID()] = c
 	}
@@ -149,6 +164,7 @@ func recoverFromConfigurationAndMeta(ctx context.Context, streamingVersion *stre
 			// once the streaming service is enabled, we treat all channels as read-write.
 			c = NewPChannelMeta(newChannel, types.AccessModeRW)
 		}
+		c.availableInReplication = isChannelAvailableInReplication(c.Name(), replicateConfig)
 		if _, ok := channels[c.ChannelID()]; !ok {
 			channels[c.ChannelID()] = c
 		}
@@ -165,6 +181,24 @@ func recoverReplicateConfiguration(ctx context.Context) (*replicateutil.ConfigHe
 		paramtable.Get().CommonCfg.ClusterPrefix.GetValue(),
 		config.GetReplicateConfiguration(),
 	), nil
+}
+
+// isChannelAvailableInReplication returns whether a channel is available for replication.
+// A channel is unavailable only when there's a multi-cluster replication topology
+// AND the channel is not in the current cluster's PChannel list.
+func isChannelAvailableInReplication(channelName string, config *replicateutil.ConfigHelper) bool {
+	if config == nil {
+		return true
+	}
+	if !config.IsJoinReplication() {
+		return true
+	}
+	for _, pchannel := range config.GetCurrentCluster().GetPchannels() {
+		if pchannel == channelName {
+			return true
+		}
+	}
+	return false
 }
 
 // ChannelManager manages the channels.
@@ -256,6 +290,7 @@ func (cm *ChannelManager) AddPChannels(ctx context.Context, newChannels []string
 		} else {
 			meta = NewPChannelMeta(name, types.AccessModeRW)
 		}
+		meta.availableInReplication = isChannelAvailableInReplication(name, cm.replicateConfig)
 		cm.channels[id] = meta
 		cm.metrics.AssignPChannelStatus(meta)
 		newMetas = append(newMetas, meta.CopyForWrite().IntoRawMeta())
@@ -353,15 +388,18 @@ func (cm *ChannelManager) CurrentPChannelsView() *PChannelView {
 }
 
 // AllocVirtualChannels allocates virtual channels for a collection.
+// Only channels that are available in replication are considered.
 func (cm *ChannelManager) AllocVirtualChannels(ctx context.Context, param AllocVChannelParam) ([]string, error) {
 	cm.cond.L.Lock()
 	defer cm.cond.L.Unlock()
-	if len(cm.channels) < param.Num {
-		return nil, errors.Errorf("not enough pchannels to allocate, expected: %d, got: %d", param.Num, len(cm.channels))
+
+	availableChannels := cm.sortAvailableChannelsByVChannelCount()
+	if len(availableChannels) < param.Num {
+		return nil, errors.Errorf("not enough pchannels to allocate, expected: %d, got: %d", param.Num, len(availableChannels))
 	}
 
 	vchannels := make([]string, 0, param.Num)
-	for _, channel := range cm.sortChannelsByVChannelCount() {
+	for _, channel := range availableChannels {
 		if len(vchannels) >= param.Num {
 			break
 		}
@@ -376,10 +414,14 @@ type withVChannelCount struct {
 	vchannelCount int
 }
 
-// sortChannelsByVChannelCount sorts the channels by the vchannel count.
-func (cm *ChannelManager) sortChannelsByVChannelCount() []withVChannelCount {
+// sortAvailableChannelsByVChannelCount sorts the available channels by the vchannel count.
+// Channels that are unavailable in replication are excluded.
+func (cm *ChannelManager) sortAvailableChannelsByVChannelCount() []withVChannelCount {
 	vchannelCounts := make([]withVChannelCount, 0, len(cm.channels))
-	for id := range cm.channels {
+	for id, ch := range cm.channels {
+		if !ch.AvailableInReplication() {
+			continue
+		}
 		vchannelCounts = append(vchannelCounts, withVChannelCount{
 			id:            id,
 			vchannelCount: StaticPChannelStatsManager.Get().GetPChannelStats(id).VChannelCount(),
@@ -577,6 +619,10 @@ func (cm *ChannelManager) UpdateReplicateConfiguration(ctx context.Context, resu
 	}
 
 	cm.replicateConfig = config
+	// Recompute availableInReplication for all channels after config update
+	for _, ch := range cm.channels {
+		ch.availableInReplication = isChannelAvailableInReplication(ch.Name(), cm.replicateConfig)
+	}
 	cm.cond.UnsafeBroadcast()
 	cm.version.Local++
 	cm.metrics.UpdateAssignmentVersion(cm.version.Local)

--- a/internal/streamingcoord/server/balancer/channel/manager.go
+++ b/internal/streamingcoord/server/balancer/channel/manager.go
@@ -238,9 +238,10 @@ func (cm *ChannelManager) ReplicateRole() replicateutil.Role {
 }
 
 // AddPChannels adds new PChannels dynamically. Channels that already exist are skipped.
-// Only newly added channels are persisted and version is incremented.
+// Only newly added channels are persisted. Local version is not incremented
+// because new PChannels should not trigger service discovery.
 func (cm *ChannelManager) AddPChannels(ctx context.Context, newChannels []string) error {
-	cm.cond.LockAndBroadcast()
+	cm.cond.L.Lock()
 	defer cm.cond.L.Unlock()
 
 	newMetas := make([]*streamingpb.PChannelMeta, 0, len(newChannels))
@@ -273,9 +274,6 @@ func (cm *ChannelManager) AddPChannels(ctx context.Context, newChannels []string
 		cm.Logger().Error("failed to save new pchannels", zap.Error(err))
 		return err
 	}
-
-	cm.version.Local++
-	cm.metrics.UpdateAssignmentVersion(cm.version.Local)
 
 	cm.Logger().Info("dynamically added new pchannels",
 		zap.Int("count", len(newMetas)),

--- a/internal/streamingcoord/server/balancer/channel/manager.go
+++ b/internal/streamingcoord/server/balancer/channel/manager.go
@@ -148,8 +148,7 @@ func recoverFromConfigurationAndMeta(ctx context.Context, streamingVersion *stre
 	// TODO: only support rw channel here now, add ro channel in future.
 	channels := make(map[ChannelID]*PChannelMeta, len(channelMetas))
 	for _, channel := range channelMetas {
-		c := newPChannelMetaFromProto(channel)
-		c.availableInReplication = isChannelAvailableInReplication(c.Name(), replicateConfig)
+		c := newPChannelMetaFromProto(channel, replicateConfig)
 		metrics.AssignPChannelStatus(c)
 		channels[c.ChannelID()] = c
 	}
@@ -303,7 +302,7 @@ func (cm *ChannelManager) AddPChannels(ctx context.Context, newChannels []string
 	if err := resource.Resource().StreamingCatalog().SavePChannels(ctx, newMetas); err != nil {
 		// Rollback in-memory changes on persist failure
 		for _, m := range newMetas {
-			c := newPChannelMetaFromProto(m)
+			c := newPChannelMetaFromProto(m, cm.replicateConfig)
 			delete(cm.channels, c.ChannelID())
 		}
 		cm.Logger().Error("failed to save new pchannels", zap.Error(err))
@@ -464,7 +463,7 @@ func (cm *ChannelManager) AssignPChannels(ctx context.Context, pChannelToStreami
 	}
 	updates := make(map[ChannelID]*PChannelMeta, len(pChannelMetas))
 	for _, pchannel := range pChannelMetas {
-		meta := newPChannelMetaFromProto(pchannel)
+		meta := newPChannelMetaFromProto(pchannel, cm.replicateConfig)
 		updates[meta.ChannelID()] = meta
 		cm.metrics.AssignPChannelStatus(meta)
 	}
@@ -497,7 +496,7 @@ func (cm *ChannelManager) AssignPChannelsDone(ctx context.Context, pChannels []C
 
 	// Update metrics.
 	for _, pchannel := range pChannelMetas {
-		cm.metrics.AssignPChannelStatus(newPChannelMetaFromProto(pchannel))
+		cm.metrics.AssignPChannelStatus(newPChannelMetaFromProto(pchannel, cm.replicateConfig))
 	}
 	return nil
 }
@@ -523,7 +522,7 @@ func (cm *ChannelManager) MarkAsUnavailable(ctx context.Context, pChannels []typ
 		return err
 	}
 	for _, pchannel := range pChannelMetas {
-		cm.metrics.AssignPChannelStatus(newPChannelMetaFromProto(pchannel))
+		cm.metrics.AssignPChannelStatus(newPChannelMetaFromProto(pchannel, cm.replicateConfig))
 	}
 	return nil
 }
@@ -541,7 +540,7 @@ func (cm *ChannelManager) updatePChannelMeta(ctx context.Context, pChannelMetas 
 
 	// update in-memory copy and increase the version.
 	for _, pchannel := range pChannelMetas {
-		c := newPChannelMetaFromProto(pchannel)
+		c := newPChannelMetaFromProto(pchannel, cm.replicateConfig)
 		cm.channels[c.ChannelID()] = c
 	}
 	cm.version.Local++

--- a/internal/streamingcoord/server/balancer/channel/manager_test.go
+++ b/internal/streamingcoord/server/balancer/channel/manager_test.go
@@ -64,6 +64,14 @@ func TestChannelManager(t *testing.T) {
 	assert.NotNil(t, m)
 	assert.NoError(t, err)
 
+	// Test getClusterChannels and singleton GetClusterChannels.
+	cc := m.getClusterChannels()
+	assert.Equal(t, []string{"test-channel"}, cc.Channels)
+	assert.NotEmpty(t, cc.ControlChannel)
+	assert.True(t, strings.HasPrefix(cc.ControlChannel, "test"))
+	singletonCC := GetClusterChannels()
+	assert.Equal(t, cc, singletonCC)
+
 	// Test update non exist pchannel
 	modified, err := m.AssignPChannels(ctx, map[ChannelID]types.PChannelInfoAssigned{newChannelID("non-exist-channel"): {
 		Channel: types.PChannelInfo{

--- a/internal/streamingcoord/server/balancer/channel/manager_test.go
+++ b/internal/streamingcoord/server/balancer/channel/manager_test.go
@@ -523,6 +523,91 @@ func TestChannelManagerWatch(t *testing.T) {
 	<-done
 }
 
+func TestChannelManager_AddPChannels(t *testing.T) {
+	ResetStaticPChannelStatsManager()
+	RecoverPChannelStatsManager([]string{})
+
+	catalog := mock_metastore.NewMockStreamingCoordCataLog(t)
+	s := sessionutil.NewMockSession(t)
+	s.EXPECT().GetRegisteredRevision().Return(int64(1))
+	resource.InitForTest(resource.OptStreamingCatalog(catalog), resource.OptSession(s))
+
+	ctx := context.Background()
+	catalog.EXPECT().GetCChannel(mock.Anything).Return(&streamingpb.CChannelMeta{
+		Pchannel: "test-channel",
+	}, nil)
+	catalog.EXPECT().GetVersion(mock.Anything).Return(&streamingpb.StreamingVersion{
+		Version: 1,
+	}, nil)
+	catalog.EXPECT().ListPChannel(mock.Anything).Return([]*streamingpb.PChannelMeta{
+		{
+			Channel: &streamingpb.PChannelInfo{Name: "test-channel", Term: 1},
+			Node:    &streamingpb.StreamingNodeInfo{ServerId: 1},
+		},
+	}, nil)
+	catalog.EXPECT().GetReplicateConfiguration(mock.Anything).Return(nil, nil)
+	catalog.EXPECT().SavePChannels(mock.Anything, mock.Anything).Return(nil)
+
+	m, err := RecoverChannelManager(ctx, "test-channel")
+	assert.NoError(t, err)
+	assert.NotNil(t, m)
+
+	// Initial state: 1 channel
+	view := m.CurrentPChannelsView()
+	assert.Len(t, view.Channels, 1)
+
+	// Add new channels
+	err = m.AddPChannels(ctx, []string{"new-channel-1", "new-channel-2"})
+	assert.NoError(t, err)
+
+	// Should now have 3 channels
+	view = m.CurrentPChannelsView()
+	assert.Len(t, view.Channels, 3)
+
+	// Adding existing channels should be idempotent
+	err = m.AddPChannels(ctx, []string{"test-channel", "new-channel-1"})
+	assert.NoError(t, err)
+	view = m.CurrentPChannelsView()
+	assert.Len(t, view.Channels, 3) // No change
+
+	// Adding a mix of existing and new
+	err = m.AddPChannels(ctx, []string{"test-channel", "brand-new-channel"})
+	assert.NoError(t, err)
+	view = m.CurrentPChannelsView()
+	assert.Len(t, view.Channels, 4)
+}
+
+func TestChannelManager_AddPChannels_ROWhenStreamingNotEnabled(t *testing.T) {
+	ResetStaticPChannelStatsManager()
+	RecoverPChannelStatsManager([]string{})
+
+	catalog := mock_metastore.NewMockStreamingCoordCataLog(t)
+	s := sessionutil.NewMockSession(t)
+	s.EXPECT().GetRegisteredRevision().Return(int64(1))
+	resource.InitForTest(resource.OptStreamingCatalog(catalog), resource.OptSession(s))
+
+	ctx := context.Background()
+	catalog.EXPECT().GetCChannel(mock.Anything).Return(&streamingpb.CChannelMeta{
+		Pchannel: "test-channel",
+	}, nil)
+	// streamingVersion is nil => streaming never enabled
+	catalog.EXPECT().GetVersion(mock.Anything).Return(nil, nil)
+	catalog.EXPECT().ListPChannel(mock.Anything).Return(nil, nil)
+	catalog.EXPECT().GetReplicateConfiguration(mock.Anything).Return(nil, nil)
+	catalog.EXPECT().SavePChannels(mock.Anything, mock.Anything).Return(nil)
+
+	m, err := RecoverChannelManager(ctx, "test-channel")
+	assert.NoError(t, err)
+
+	err = m.AddPChannels(ctx, []string{"new-ro-channel"})
+	assert.NoError(t, err)
+
+	view := m.CurrentPChannelsView()
+	ch, ok := view.Channels[ChannelID{Name: "new-ro-channel"}]
+	assert.True(t, ok)
+	assert.Equal(t, types.AccessModeRO, ch.ChannelInfo().AccessMode)
+}
+
 func newChannelID(name string) ChannelID {
 	return ChannelID{
 		Name: name,

--- a/internal/streamingcoord/server/balancer/channel/manager_test.go
+++ b/internal/streamingcoord/server/balancer/channel/manager_test.go
@@ -651,6 +651,264 @@ func TestChannelManager_AddPChannels_PersistFailureRollback(t *testing.T) {
 	assert.False(t, ok)
 }
 
+func TestAddPChannels_UnavailableInReplication(t *testing.T) {
+	ResetStaticPChannelStatsManager()
+	RecoverPChannelStatsManager([]string{})
+
+	catalog := mock_metastore.NewMockStreamingCoordCataLog(t)
+	s := sessionutil.NewMockSession(t)
+	s.EXPECT().GetRegisteredRevision().Return(int64(1))
+	resource.InitForTest(resource.OptStreamingCatalog(catalog), resource.OptSession(s))
+
+	ctx := context.Background()
+	catalog.EXPECT().GetCChannel(mock.Anything).Return(&streamingpb.CChannelMeta{
+		Pchannel: "ch1",
+	}, nil)
+	catalog.EXPECT().GetVersion(mock.Anything).Return(&streamingpb.StreamingVersion{Version: 1}, nil)
+	catalog.EXPECT().ListPChannel(mock.Anything).Return([]*streamingpb.PChannelMeta{
+		{Channel: &streamingpb.PChannelInfo{Name: "ch1", Term: 1}, Node: &streamingpb.StreamingNodeInfo{ServerId: 1}},
+		{Channel: &streamingpb.PChannelInfo{Name: "ch2", Term: 1}, Node: &streamingpb.StreamingNodeInfo{ServerId: 1}},
+	}, nil)
+	replicateCfg := &commonpb.ReplicateConfiguration{
+		Clusters: []*commonpb.MilvusCluster{
+			{ClusterId: "by-dev", Pchannels: []string{"ch1", "ch2"}},
+			{ClusterId: "by-dev2", Pchannels: []string{"ch3", "ch4"}},
+		},
+		CrossClusterTopology: []*commonpb.CrossClusterTopology{
+			{SourceClusterId: "by-dev", TargetClusterId: "by-dev2"},
+		},
+	}
+	catalog.EXPECT().GetReplicateConfiguration(mock.Anything).Return(
+		&streamingpb.ReplicateConfigurationMeta{ReplicateConfiguration: replicateCfg}, nil)
+	catalog.EXPECT().SavePChannels(mock.Anything, mock.Anything).Return(nil)
+
+	m, err := RecoverChannelManager(ctx, "ch1", "ch2")
+	assert.NoError(t, err)
+
+	// ch1 and ch2 should be available (in replicateConfig)
+	assert.True(t, m.channels[ChannelID{Name: "ch1"}].AvailableInReplication())
+	assert.True(t, m.channels[ChannelID{Name: "ch2"}].AvailableInReplication())
+
+	// Dynamically add ch5 — not in replicateConfig, should be unavailable
+	err = m.AddPChannels(ctx, []string{"ch5"})
+	assert.NoError(t, err)
+	assert.False(t, m.channels[ChannelID{Name: "ch5"}].AvailableInReplication())
+}
+
+func TestRecovery_NoReplicateConfig_AllAvailable(t *testing.T) {
+	ResetStaticPChannelStatsManager()
+	RecoverPChannelStatsManager([]string{})
+
+	catalog := mock_metastore.NewMockStreamingCoordCataLog(t)
+	s := sessionutil.NewMockSession(t)
+	s.EXPECT().GetRegisteredRevision().Return(int64(1))
+	resource.InitForTest(resource.OptStreamingCatalog(catalog), resource.OptSession(s))
+
+	ctx := context.Background()
+	catalog.EXPECT().GetCChannel(mock.Anything).Return(&streamingpb.CChannelMeta{Pchannel: "ch1"}, nil)
+	catalog.EXPECT().GetVersion(mock.Anything).Return(&streamingpb.StreamingVersion{Version: 1}, nil)
+	catalog.EXPECT().ListPChannel(mock.Anything).Return([]*streamingpb.PChannelMeta{
+		{Channel: &streamingpb.PChannelInfo{Name: "ch1", Term: 1}, Node: &streamingpb.StreamingNodeInfo{ServerId: 1}},
+	}, nil)
+	catalog.EXPECT().GetReplicateConfiguration(mock.Anything).Return(nil, nil)
+
+	m, err := RecoverChannelManager(ctx, "ch1")
+	assert.NoError(t, err)
+	assert.True(t, m.channels[ChannelID{Name: "ch1"}].AvailableInReplication())
+}
+
+func TestAllocVirtualChannels_SkipsUnavailableChannels(t *testing.T) {
+	ResetStaticPChannelStatsManager()
+	RecoverPChannelStatsManager([]string{})
+
+	catalog := mock_metastore.NewMockStreamingCoordCataLog(t)
+	s := sessionutil.NewMockSession(t)
+	s.EXPECT().GetRegisteredRevision().Return(int64(1))
+	resource.InitForTest(resource.OptStreamingCatalog(catalog), resource.OptSession(s))
+
+	ctx := context.Background()
+	catalog.EXPECT().GetCChannel(mock.Anything).Return(&streamingpb.CChannelMeta{Pchannel: "ch1"}, nil)
+	catalog.EXPECT().GetVersion(mock.Anything).Return(&streamingpb.StreamingVersion{Version: 1}, nil)
+	catalog.EXPECT().ListPChannel(mock.Anything).Return([]*streamingpb.PChannelMeta{
+		{Channel: &streamingpb.PChannelInfo{Name: "ch1", Term: 1}},
+		{Channel: &streamingpb.PChannelInfo{Name: "ch2", Term: 1}},
+		{Channel: &streamingpb.PChannelInfo{Name: "ch3", Term: 1}},
+	}, nil)
+	replicateCfg := &commonpb.ReplicateConfiguration{
+		Clusters: []*commonpb.MilvusCluster{
+			{ClusterId: "by-dev", Pchannels: []string{"ch1", "ch2"}},
+			{ClusterId: "by-dev2", Pchannels: []string{"ch4", "ch5"}},
+		},
+		CrossClusterTopology: []*commonpb.CrossClusterTopology{
+			{SourceClusterId: "by-dev", TargetClusterId: "by-dev2"},
+		},
+	}
+	catalog.EXPECT().GetReplicateConfiguration(mock.Anything).Return(
+		&streamingpb.ReplicateConfigurationMeta{ReplicateConfiguration: replicateCfg}, nil)
+
+	m, err := RecoverChannelManager(ctx, "ch1", "ch2", "ch3")
+	assert.NoError(t, err)
+
+	// ch3 is unavailable — only ch1, ch2 are allocatable
+	vchannels, err := m.AllocVirtualChannels(ctx, AllocVChannelParam{CollectionID: 1, Num: 2})
+	assert.NoError(t, err)
+	assert.Len(t, vchannels, 2)
+	for _, vc := range vchannels {
+		assert.False(t, strings.HasPrefix(vc, "ch3"))
+	}
+
+	// Requesting more than available channels should fail
+	_, err = m.AllocVirtualChannels(ctx, AllocVChannelParam{CollectionID: 2, Num: 3})
+	assert.Error(t, err)
+}
+
+func TestGetClusterChannels_ExcludesUnavailable(t *testing.T) {
+	ResetStaticPChannelStatsManager()
+	RecoverPChannelStatsManager([]string{})
+
+	catalog := mock_metastore.NewMockStreamingCoordCataLog(t)
+	s := sessionutil.NewMockSession(t)
+	s.EXPECT().GetRegisteredRevision().Return(int64(1))
+	resource.InitForTest(resource.OptStreamingCatalog(catalog), resource.OptSession(s))
+
+	ctx := context.Background()
+	catalog.EXPECT().GetCChannel(mock.Anything).Return(&streamingpb.CChannelMeta{Pchannel: "ch1"}, nil)
+	catalog.EXPECT().GetVersion(mock.Anything).Return(&streamingpb.StreamingVersion{Version: 1}, nil)
+	catalog.EXPECT().ListPChannel(mock.Anything).Return([]*streamingpb.PChannelMeta{
+		{Channel: &streamingpb.PChannelInfo{Name: "ch1", Term: 1}},
+		{Channel: &streamingpb.PChannelInfo{Name: "ch2", Term: 1}},
+		{Channel: &streamingpb.PChannelInfo{Name: "ch3", Term: 1}},
+	}, nil)
+	replicateCfg := &commonpb.ReplicateConfiguration{
+		Clusters: []*commonpb.MilvusCluster{
+			{ClusterId: "by-dev", Pchannels: []string{"ch1", "ch2"}},
+			{ClusterId: "by-dev2", Pchannels: []string{"ch4", "ch5"}},
+		},
+		CrossClusterTopology: []*commonpb.CrossClusterTopology{
+			{SourceClusterId: "by-dev", TargetClusterId: "by-dev2"},
+		},
+	}
+	catalog.EXPECT().GetReplicateConfiguration(mock.Anything).Return(
+		&streamingpb.ReplicateConfigurationMeta{ReplicateConfiguration: replicateCfg}, nil)
+
+	m, err := RecoverChannelManager(ctx, "ch1", "ch2", "ch3")
+	assert.NoError(t, err)
+
+	// getClusterChannels should only return ch1, ch2
+	cc := m.getClusterChannels()
+	assert.Len(t, cc.Channels, 2)
+	assert.ElementsMatch(t, []string{"ch1", "ch2"}, cc.Channels)
+
+	// getClusterChannels with OptIncludeUnavailableInReplication should return all 3
+	allCC := m.getClusterChannels(OptIncludeUnavailableInReplication())
+	assert.Len(t, allCC.Channels, 3)
+	assert.ElementsMatch(t, []string{"ch1", "ch2", "ch3"}, allCC.Channels)
+}
+
+func TestUpdateReplicateConfiguration_FlipsAvailability(t *testing.T) {
+	ResetStaticPChannelStatsManager()
+	RecoverPChannelStatsManager([]string{})
+
+	catalog := mock_metastore.NewMockStreamingCoordCataLog(t)
+	s := sessionutil.NewMockSession(t)
+	s.EXPECT().GetRegisteredRevision().Return(int64(1))
+	resource.InitForTest(resource.OptStreamingCatalog(catalog), resource.OptSession(s))
+
+	ctx := context.Background()
+	catalog.EXPECT().GetCChannel(mock.Anything).Return(&streamingpb.CChannelMeta{Pchannel: "ch1"}, nil)
+	catalog.EXPECT().GetVersion(mock.Anything).Return(&streamingpb.StreamingVersion{Version: 1}, nil)
+	catalog.EXPECT().ListPChannel(mock.Anything).Return([]*streamingpb.PChannelMeta{
+		{Channel: &streamingpb.PChannelInfo{Name: "ch1", Term: 1}},
+		{Channel: &streamingpb.PChannelInfo{Name: "ch2", Term: 1}},
+		{Channel: &streamingpb.PChannelInfo{Name: "ch3", Term: 1}},
+	}, nil)
+	// Initial config: only ch1, ch2 in current cluster
+	replicateCfg := &commonpb.ReplicateConfiguration{
+		Clusters: []*commonpb.MilvusCluster{
+			{ClusterId: "by-dev", Pchannels: []string{"ch1", "ch2"}},
+			{ClusterId: "by-dev2", Pchannels: []string{"ch4", "ch5"}},
+		},
+		CrossClusterTopology: []*commonpb.CrossClusterTopology{
+			{SourceClusterId: "by-dev", TargetClusterId: "by-dev2"},
+		},
+	}
+	catalog.EXPECT().GetReplicateConfiguration(mock.Anything).Return(
+		&streamingpb.ReplicateConfigurationMeta{ReplicateConfiguration: replicateCfg}, nil)
+
+	m, err := RecoverChannelManager(ctx, "ch1", "ch2", "ch3")
+	assert.NoError(t, err)
+
+	// ch3 should be unavailable initially
+	assert.False(t, m.channels[ChannelID{Name: "ch3"}].AvailableInReplication())
+	assert.True(t, m.channels[ChannelID{Name: "ch1"}].AvailableInReplication())
+	assert.True(t, m.channels[ChannelID{Name: "ch2"}].AvailableInReplication())
+
+	// Update config to include ch3
+	newCfg := &commonpb.ReplicateConfiguration{
+		Clusters: []*commonpb.MilvusCluster{
+			{ClusterId: "by-dev", Pchannels: []string{"ch1", "ch2", "ch3"}},
+			{ClusterId: "by-dev2", Pchannels: []string{"ch4", "ch5", "ch6"}},
+		},
+		CrossClusterTopology: []*commonpb.CrossClusterTopology{
+			{SourceClusterId: "by-dev", TargetClusterId: "by-dev2"},
+		},
+	}
+	msg := message.NewAlterReplicateConfigMessageBuilderV2().
+		WithHeader(&message.AlterReplicateConfigMessageHeader{ReplicateConfiguration: newCfg}).
+		WithBody(&message.AlterReplicateConfigMessageBody{}).
+		WithBroadcast([]string{"ch1", "ch2", "ch3"}).
+		MustBuildBroadcast()
+	result := message.BroadcastResultAlterReplicateConfigMessageV2{
+		Message: message.MustAsBroadcastAlterReplicateConfigMessageV2(msg),
+		Results: map[string]*message.AppendResult{
+			"ch1": {MessageID: walimplstest.NewTestMessageID(1), LastConfirmedMessageID: walimplstest.NewTestMessageID(2), TimeTick: 1},
+			"ch2": {MessageID: walimplstest.NewTestMessageID(3), LastConfirmedMessageID: walimplstest.NewTestMessageID(4), TimeTick: 1},
+			"ch3": {MessageID: walimplstest.NewTestMessageID(5), LastConfirmedMessageID: walimplstest.NewTestMessageID(6), TimeTick: 1},
+		},
+	}
+	catalog.EXPECT().SaveReplicateConfiguration(mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	err = m.UpdateReplicateConfiguration(ctx, result)
+	assert.NoError(t, err)
+
+	// ch3 should now be available
+	assert.True(t, m.channels[ChannelID{Name: "ch3"}].AvailableInReplication())
+	// ch1, ch2 still available
+	assert.True(t, m.channels[ChannelID{Name: "ch1"}].AvailableInReplication())
+	assert.True(t, m.channels[ChannelID{Name: "ch2"}].AvailableInReplication())
+}
+
+func TestIsChannelAvailableInReplication(t *testing.T) {
+	// No replicateConfig → always available
+	assert.True(t, isChannelAvailableInReplication("ch1", nil))
+
+	// Single cluster (no cross-cluster topology) → always available
+	singleCluster := replicateutil.MustNewConfigHelper("by-dev", &commonpb.ReplicateConfiguration{
+		Clusters: []*commonpb.MilvusCluster{
+			{ClusterId: "by-dev", Pchannels: []string{"ch1", "ch2"}},
+		},
+	})
+	assert.True(t, isChannelAvailableInReplication("ch1", singleCluster))
+	assert.True(t, isChannelAvailableInReplication("ch99", singleCluster))
+
+	// Multi-cluster: channel in current cluster's list → available
+	multiCluster := replicateutil.MustNewConfigHelper("by-dev", &commonpb.ReplicateConfiguration{
+		Clusters: []*commonpb.MilvusCluster{
+			{ClusterId: "by-dev", Pchannels: []string{"ch1", "ch2"}},
+			{ClusterId: "by-dev2", Pchannels: []string{"ch3", "ch4"}},
+		},
+		CrossClusterTopology: []*commonpb.CrossClusterTopology{
+			{SourceClusterId: "by-dev", TargetClusterId: "by-dev2"},
+		},
+	})
+	assert.True(t, isChannelAvailableInReplication("ch1", multiCluster))
+	assert.True(t, isChannelAvailableInReplication("ch2", multiCluster))
+
+	// Multi-cluster: channel NOT in current cluster's list → unavailable
+	assert.False(t, isChannelAvailableInReplication("ch5", multiCluster))
+	assert.False(t, isChannelAvailableInReplication("new-channel", multiCluster))
+}
+
 func newChannelID(name string) ChannelID {
 	return ChannelID{
 		Name: name,

--- a/internal/streamingcoord/server/balancer/channel/manager_test.go
+++ b/internal/streamingcoord/server/balancer/channel/manager_test.go
@@ -608,6 +608,49 @@ func TestChannelManager_AddPChannels_ROWhenStreamingNotEnabled(t *testing.T) {
 	assert.Equal(t, types.AccessModeRO, ch.ChannelInfo().AccessMode)
 }
 
+func TestChannelManager_AddPChannels_PersistFailureRollback(t *testing.T) {
+	ResetStaticPChannelStatsManager()
+	RecoverPChannelStatsManager([]string{})
+
+	catalog := mock_metastore.NewMockStreamingCoordCataLog(t)
+	s := sessionutil.NewMockSession(t)
+	s.EXPECT().GetRegisteredRevision().Return(int64(1))
+	resource.InitForTest(resource.OptStreamingCatalog(catalog), resource.OptSession(s))
+
+	ctx := context.Background()
+	catalog.EXPECT().GetCChannel(mock.Anything).Return(&streamingpb.CChannelMeta{
+		Pchannel: "test-channel",
+	}, nil)
+	catalog.EXPECT().GetVersion(mock.Anything).Return(&streamingpb.StreamingVersion{
+		Version: 1,
+	}, nil)
+	catalog.EXPECT().ListPChannel(mock.Anything).Return([]*streamingpb.PChannelMeta{
+		{
+			Channel: &streamingpb.PChannelInfo{Name: "test-channel", Term: 1},
+			Node:    &streamingpb.StreamingNodeInfo{ServerId: 1},
+		},
+	}, nil)
+	catalog.EXPECT().GetReplicateConfiguration(mock.Anything).Return(nil, nil)
+
+	persistErr := errors.New("persist failure")
+	catalog.EXPECT().SavePChannels(mock.Anything, mock.Anything).Return(persistErr)
+
+	m, err := RecoverChannelManager(ctx, "test-channel")
+	assert.NoError(t, err)
+
+	// Attempt to add channels; persist fails
+	err = m.AddPChannels(ctx, []string{"fail-channel-1", "fail-channel-2"})
+	assert.ErrorIs(t, err, persistErr)
+
+	// Channels should be rolled back — still only the original channel
+	view := m.CurrentPChannelsView()
+	assert.Len(t, view.Channels, 1)
+	_, ok := view.Channels[ChannelID{Name: "test-channel"}]
+	assert.True(t, ok)
+	_, ok = view.Channels[ChannelID{Name: "fail-channel-1"}]
+	assert.False(t, ok)
+}
+
 func newChannelID(name string) ChannelID {
 	return ChannelID{
 		Name: name,

--- a/internal/streamingcoord/server/balancer/channel/pchannel.go
+++ b/internal/streamingcoord/server/balancer/channel/pchannel.go
@@ -10,7 +10,13 @@ import (
 )
 
 // NewPChannelMeta creates a new PChannelMeta.
+// By default, the channel is available in replication.
 func NewPChannelMeta(name string, accessMode types.AccessMode) *PChannelMeta {
+	return newPChannelMetaWithAvailability(name, accessMode, true)
+}
+
+// newPChannelMetaWithAvailability creates a new PChannelMeta with explicit availability in replication.
+func newPChannelMetaWithAvailability(name string, accessMode types.AccessMode, availableInReplication bool) *PChannelMeta {
 	return &PChannelMeta{
 		inner: &streamingpb.PChannelMeta{
 			Channel: &streamingpb.PChannelInfo{
@@ -22,20 +28,30 @@ func NewPChannelMeta(name string, accessMode types.AccessMode) *PChannelMeta {
 			State:     streamingpb.PChannelMetaState_PCHANNEL_META_STATE_UNINITIALIZED,
 			Histories: make([]*streamingpb.PChannelAssignmentLog, 0),
 		},
+		availableInReplication: availableInReplication,
 	}
 }
 
 // newPChannelMetaFromProto creates a new PChannelMeta from proto.
+// By default, channels recovered from proto are available in replication.
 func newPChannelMetaFromProto(channel *streamingpb.PChannelMeta) *PChannelMeta {
 	return &PChannelMeta{
-		inner: channel,
+		inner:                  channel,
+		availableInReplication: true,
 	}
 }
 
 // PChannelMeta is the read only version of PChannelInfo, to be used in balancer,
 // If you need to update PChannelMeta, please use CopyForWrite to get mutablePChannel.
 type PChannelMeta struct {
-	inner *streamingpb.PChannelMeta
+	inner                  *streamingpb.PChannelMeta
+	availableInReplication bool
+}
+
+// AvailableInReplication returns whether the channel is available for VChannel allocation
+// and DDL broadcasts. Dynamically-added PChannels are gated until they appear in ReplicateConfig.
+func (c *PChannelMeta) AvailableInReplication() bool {
+	return c.availableInReplication
 }
 
 // Name returns the name of the channel.
@@ -113,7 +129,8 @@ func (c *PChannelMeta) State() streamingpb.PChannelMetaState {
 func (c *PChannelMeta) CopyForWrite() *mutablePChannel {
 	return &mutablePChannel{
 		PChannelMeta: &PChannelMeta{
-			inner: proto.Clone(c.inner).(*streamingpb.PChannelMeta),
+			inner:                  proto.Clone(c.inner).(*streamingpb.PChannelMeta),
+			availableInReplication: c.availableInReplication,
 		},
 	}
 }

--- a/internal/streamingcoord/server/balancer/channel/pchannel.go
+++ b/internal/streamingcoord/server/balancer/channel/pchannel.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/milvus-io/milvus/pkg/v2/proto/streamingpb"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/types"
+	"github.com/milvus-io/milvus/pkg/v2/util/replicateutil"
 )
 
 // NewPChannelMeta creates a new PChannelMeta.
@@ -33,11 +34,11 @@ func newPChannelMetaWithAvailability(name string, accessMode types.AccessMode, a
 }
 
 // newPChannelMetaFromProto creates a new PChannelMeta from proto.
-// By default, channels recovered from proto are available in replication.
-func newPChannelMetaFromProto(channel *streamingpb.PChannelMeta) *PChannelMeta {
+// The availableInReplication flag is computed from the given replicateConfig.
+func newPChannelMetaFromProto(channel *streamingpb.PChannelMeta, replicateConfig *replicateutil.ConfigHelper) *PChannelMeta {
 	return &PChannelMeta{
 		inner:                  channel,
-		availableInReplication: true,
+		availableInReplication: isChannelAvailableInReplication(channel.GetChannel().GetName(), replicateConfig),
 	}
 }
 

--- a/internal/streamingcoord/server/balancer/channel/pchannel_test.go
+++ b/internal/streamingcoord/server/balancer/channel/pchannel_test.go
@@ -5,8 +5,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/streamingpb"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/types"
+	"github.com/milvus-io/milvus/pkg/v2/util/replicateutil"
 )
 
 func TestPChannelAvailableInReplication(t *testing.T) {
@@ -22,12 +24,47 @@ func TestPChannelAvailableInReplication(t *testing.T) {
 	pchannel = newPChannelMetaWithAvailability("ch3", types.AccessModeRW, true)
 	assert.True(t, pchannel.AvailableInReplication())
 
-	// From proto: defaults to available (proto doesn't store this)
+	// From proto with nil config: defaults to available
 	pchannel = newPChannelMetaFromProto(&streamingpb.PChannelMeta{
 		Channel: &streamingpb.PChannelInfo{Name: "ch4", Term: 1},
 		State:   streamingpb.PChannelMetaState_PCHANNEL_META_STATE_UNINITIALIZED,
-	})
+	}, nil)
 	assert.True(t, pchannel.AvailableInReplication())
+
+	// From proto with config that has no replication topology: available
+	noTopoConfig := replicateutil.MustNewConfigHelper("by-dev", &commonpb.ReplicateConfiguration{
+		Clusters: []*commonpb.MilvusCluster{
+			{ClusterId: "by-dev", Pchannels: []string{"ch5"}},
+		},
+	})
+	pchannel = newPChannelMetaFromProto(&streamingpb.PChannelMeta{
+		Channel: &streamingpb.PChannelInfo{Name: "ch5", Term: 1},
+		State:   streamingpb.PChannelMetaState_PCHANNEL_META_STATE_UNINITIALIZED,
+	}, noTopoConfig)
+	assert.True(t, pchannel.AvailableInReplication())
+
+	// From proto with replication config, channel IN config: available
+	replicaConfig := replicateutil.MustNewConfigHelper("by-dev1", &commonpb.ReplicateConfiguration{
+		Clusters: []*commonpb.MilvusCluster{
+			{ClusterId: "by-dev1", Pchannels: []string{"ch6", "ch7"}},
+			{ClusterId: "by-dev2", Pchannels: []string{"ch6-s", "ch7-s"}},
+		},
+		CrossClusterTopology: []*commonpb.CrossClusterTopology{
+			{SourceClusterId: "by-dev1", TargetClusterId: "by-dev2"},
+		},
+	})
+	pchannel = newPChannelMetaFromProto(&streamingpb.PChannelMeta{
+		Channel: &streamingpb.PChannelInfo{Name: "ch6", Term: 1},
+		State:   streamingpb.PChannelMetaState_PCHANNEL_META_STATE_UNINITIALIZED,
+	}, replicaConfig)
+	assert.True(t, pchannel.AvailableInReplication())
+
+	// From proto with replication config, channel NOT in config: unavailable
+	pchannel = newPChannelMetaFromProto(&streamingpb.PChannelMeta{
+		Channel: &streamingpb.PChannelInfo{Name: "ch_new_not_in_config", Term: 1},
+		State:   streamingpb.PChannelMetaState_PCHANNEL_META_STATE_UNINITIALIZED,
+	}, replicaConfig)
+	assert.False(t, pchannel.AvailableInReplication())
 }
 
 func TestPChannel(t *testing.T) {
@@ -43,7 +80,7 @@ func TestPChannel(t *testing.T) {
 			ServerId: 123,
 		},
 		State: streamingpb.PChannelMetaState_PCHANNEL_META_STATE_UNINITIALIZED,
-	})
+	}, nil)
 	assert.Equal(t, "test-channel", pchannel.Name())
 	assert.Equal(t, int64(1), pchannel.CurrentTerm())
 	assert.Equal(t, int64(123), pchannel.CurrentServerID())
@@ -75,7 +112,7 @@ func TestPChannel(t *testing.T) {
 		ServerID: 456,
 	}
 	assert.True(t, mutablePChannel.TryAssignToServerID(types.AccessModeRW, newServerID))
-	updatedChannelInfo := newPChannelMetaFromProto(mutablePChannel.IntoRawMeta())
+	updatedChannelInfo := newPChannelMetaFromProto(mutablePChannel.IntoRawMeta(), nil)
 
 	assert.Equal(t, "test-channel", pchannel.Name())
 	assert.Equal(t, int64(1), pchannel.CurrentTerm())
@@ -91,7 +128,7 @@ func TestPChannel(t *testing.T) {
 	mutablePChannel = updatedChannelInfo.CopyForWrite()
 
 	mutablePChannel.TryAssignToServerID(types.AccessModeRW, types.StreamingNodeInfo{ServerID: 789})
-	updatedChannelInfo = newPChannelMetaFromProto(mutablePChannel.IntoRawMeta())
+	updatedChannelInfo = newPChannelMetaFromProto(mutablePChannel.IntoRawMeta(), nil)
 	assert.Equal(t, "test-channel", updatedChannelInfo.Name())
 	assert.Equal(t, int64(3), updatedChannelInfo.CurrentTerm())
 	assert.Equal(t, int64(789), updatedChannelInfo.CurrentServerID())
@@ -105,7 +142,7 @@ func TestPChannel(t *testing.T) {
 	// Test AssignToServerDone
 	mutablePChannel = updatedChannelInfo.CopyForWrite()
 	mutablePChannel.AssignToServerDone()
-	updatedChannelInfo = newPChannelMetaFromProto(mutablePChannel.IntoRawMeta())
+	updatedChannelInfo = newPChannelMetaFromProto(mutablePChannel.IntoRawMeta(), nil)
 	assert.Equal(t, "test-channel", updatedChannelInfo.Name())
 	assert.Equal(t, int64(3), updatedChannelInfo.CurrentTerm())
 	assert.Equal(t, int64(789), updatedChannelInfo.CurrentServerID())
@@ -120,12 +157,12 @@ func TestPChannel(t *testing.T) {
 	// Test MarkAsUnavailable
 	mutablePChannel = updatedChannelInfo.CopyForWrite()
 	mutablePChannel.MarkAsUnavailable(2)
-	updatedChannelInfo = newPChannelMetaFromProto(mutablePChannel.IntoRawMeta())
+	updatedChannelInfo = newPChannelMetaFromProto(mutablePChannel.IntoRawMeta(), nil)
 	assert.True(t, updatedChannelInfo.IsAssigned())
 
 	mutablePChannel = updatedChannelInfo.CopyForWrite()
 	mutablePChannel.MarkAsUnavailable(3)
-	updatedChannelInfo = newPChannelMetaFromProto(mutablePChannel.IntoRawMeta())
+	updatedChannelInfo = newPChannelMetaFromProto(mutablePChannel.IntoRawMeta(), nil)
 	assert.False(t, updatedChannelInfo.IsAssigned())
 	assert.Equal(t, streamingpb.PChannelMetaState_PCHANNEL_META_STATE_UNAVAILABLE, updatedChannelInfo.State())
 

--- a/internal/streamingcoord/server/balancer/channel/pchannel_test.go
+++ b/internal/streamingcoord/server/balancer/channel/pchannel_test.go
@@ -9,6 +9,27 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/types"
 )
 
+func TestPChannelAvailableInReplication(t *testing.T) {
+	// Default: available
+	pchannel := NewPChannelMeta("ch1", types.AccessModeRW)
+	assert.True(t, pchannel.AvailableInReplication())
+
+	// Explicitly unavailable
+	pchannel = newPChannelMetaWithAvailability("ch2", types.AccessModeRW, false)
+	assert.False(t, pchannel.AvailableInReplication())
+
+	// Explicitly available
+	pchannel = newPChannelMetaWithAvailability("ch3", types.AccessModeRW, true)
+	assert.True(t, pchannel.AvailableInReplication())
+
+	// From proto: defaults to available (proto doesn't store this)
+	pchannel = newPChannelMetaFromProto(&streamingpb.PChannelMeta{
+		Channel: &streamingpb.PChannelInfo{Name: "ch4", Term: 1},
+		State:   streamingpb.PChannelMetaState_PCHANNEL_META_STATE_UNINITIALIZED,
+	})
+	assert.True(t, pchannel.AvailableInReplication())
+}
+
 func TestPChannel(t *testing.T) {
 	ResetStaticPChannelStatsManager()
 	RecoverPChannelStatsManager([]string{})

--- a/internal/streamingcoord/server/balancer/channel/pchannel_view_test.go
+++ b/internal/streamingcoord/server/balancer/channel/pchannel_view_test.go
@@ -19,13 +19,13 @@ func TestPChannelView(t *testing.T) {
 		}: newPChannelMetaFromProto(&streamingpb.PChannelMeta{
 			Channel: &streamingpb.PChannelInfo{Name: "test", Term: 1},
 			State:   streamingpb.PChannelMetaState_PCHANNEL_META_STATE_UNINITIALIZED,
-		}),
+		}, nil),
 		types.ChannelID{
 			Name: "test2",
 		}: newPChannelMetaFromProto(&streamingpb.PChannelMeta{
 			Channel: &streamingpb.PChannelInfo{Name: "test2", Term: 1},
 			State:   streamingpb.PChannelMetaState_PCHANNEL_META_STATE_UNINITIALIZED,
-		}),
+		}, nil),
 	}
 	view := newPChannelView(metas)
 	assert.Len(t, view.Channels, 2)

--- a/internal/streamingcoord/server/balancer/channel/singleton.go
+++ b/internal/streamingcoord/server/balancer/channel/singleton.go
@@ -1,0 +1,19 @@
+package channel
+
+import (
+	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v2/util/syncutil"
+)
+
+var singleton = syncutil.NewFuture[*ChannelManager]()
+
+// Register sets the global ChannelManager singleton.
+func register(cm *ChannelManager) {
+	singleton.Set(cm)
+}
+
+// GetClusterChannels blocks until the ChannelManager is registered,
+// then returns the cluster channel topology.
+func GetClusterChannels() message.ClusterChannels {
+	return singleton.Get().getClusterChannels()
+}

--- a/internal/streamingcoord/server/balancer/channel/singleton.go
+++ b/internal/streamingcoord/server/balancer/channel/singleton.go
@@ -7,13 +7,29 @@ import (
 
 var singleton = syncutil.NewFuture[*ChannelManager]()
 
-// Register sets the global ChannelManager singleton.
+// register sets the global ChannelManager singleton.
 func register(cm *ChannelManager) {
 	singleton.Set(cm)
 }
 
+// GetClusterChannelsOpt is a functional option for GetClusterChannels.
+type GetClusterChannelsOpt func(*getClusterChannelsOptions)
+
+type getClusterChannelsOptions struct {
+	includeUnavailableInReplication bool
+}
+
+// OptIncludeUnavailableInReplication includes channels that are unavailable in replication.
+func OptIncludeUnavailableInReplication() GetClusterChannelsOpt {
+	return func(o *getClusterChannelsOptions) {
+		o.includeUnavailableInReplication = true
+	}
+}
+
 // GetClusterChannels blocks until the ChannelManager is registered,
 // then returns the cluster channel topology.
-func GetClusterChannels() message.ClusterChannels {
-	return singleton.Get().getClusterChannels()
+// By default, only channels available in replication are returned.
+// Use OptIncludeUnavailableInReplication() to include unavailable channels.
+func GetClusterChannels(opts ...GetClusterChannelsOpt) message.ClusterChannels {
+	return singleton.Get().getClusterChannels(opts...)
 }

--- a/internal/streamingcoord/server/balancer/channel/test_utility.go
+++ b/internal/streamingcoord/server/balancer/channel/test_utility.go
@@ -3,8 +3,32 @@
 
 package channel
 
-import "github.com/milvus-io/milvus/pkg/v2/util/syncutil"
+import (
+	"sync"
+
+	"github.com/milvus-io/milvus/pkg/v2/proto/streamingpb"
+	"github.com/milvus-io/milvus/pkg/v2/util/syncutil"
+)
 
 func ResetStaticPChannelStatsManager() {
 	StaticPChannelStatsManager = syncutil.NewFuture[*PchannelStatsManager]()
+	singleton = syncutil.NewFuture[*ChannelManager]()
+}
+
+// RegisterTestChannelManager registers a minimal ChannelManager for testing.
+// pchannels is the list of physical channel names.
+// controlChannelPchannel is the pchannel prefix used for the control channel.
+func RegisterTestChannelManager(pchannels []string, controlChannelPchannel string) {
+	channels := make(map[ChannelID]*PChannelMeta, len(pchannels))
+	for _, name := range pchannels {
+		channels[ChannelID{Name: name}] = NewPChannelMeta(name, 0)
+	}
+	cm := &ChannelManager{
+		cond:     syncutil.NewContextCond(&sync.Mutex{}),
+		channels: channels,
+		cchannelMeta: &streamingpb.CChannelMeta{
+			Pchannel: controlChannelPchannel,
+		},
+	}
+	register(cm)
 }

--- a/internal/streamingcoord/server/balancer/channel_provider.go
+++ b/internal/streamingcoord/server/balancer/channel_provider.go
@@ -1,0 +1,17 @@
+package balancer
+
+// ChannelProvider provides initial channels and ongoing notification
+// of dynamically added PChannels.
+type ChannelProvider interface {
+	// GetInitialChannels returns the initial set of channel names
+	// known at startup time. Called once during recovery.
+	GetInitialChannels() []string
+
+	// NewIncomingChannels returns a read-only channel that delivers
+	// slices of newly added channel names. Each send contains only
+	// names not previously sent. The channel is closed when the provider stops.
+	NewIncomingChannels() <-chan []string
+
+	// Close stops the provider and closes the notification channel.
+	Close()
+}

--- a/internal/streamingcoord/server/service/assignment.go
+++ b/internal/streamingcoord/server/service/assignment.go
@@ -5,12 +5,10 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/samber/lo"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
-	"github.com/milvus-io/milvus/internal/distributed/streaming"
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/balancer"
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/balancer/balance"
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/balancer/channel"
@@ -21,7 +19,6 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/metrics"
 	"github.com/milvus-io/milvus/pkg/v2/proto/streamingpb"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
-	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/replicateutil"
 )
@@ -145,23 +142,13 @@ func (s *assignmentServiceImpl) validateReplicateConfiguration(ctx context.Conte
 		return nil, errReplicateConfigurationSame
 	}
 
-	controlChannel := streaming.WAL().ControlChannel()
-	pchannels := lo.MapToSlice(latestAssignment.PChannelView.Channels, func(_ channel.ChannelID, channel *channel.PChannelMeta) string {
-		return channel.Name()
-	})
-	broadcastPChannels := lo.Map(pchannels, func(pchannel string, _ int) string {
-		if funcutil.IsOnPhysicalChannel(controlChannel, pchannel) {
-			// return control channel if the control channel is on the pchannel.
-			return controlChannel
-		}
-		return pchannel
-	})
+	cc := channel.GetClusterChannels()
 
 	// validate the configuration itself
 	currentClusterID := paramtable.Get().CommonCfg.ClusterPrefix.GetValue()
 	currentConfig := latestAssignment.ReplicateConfiguration
 	incomingConfig := config
-	validator := replicateutil.NewReplicateConfigValidator(incomingConfig, currentConfig, currentClusterID, pchannels)
+	validator := replicateutil.NewReplicateConfigValidator(incomingConfig, currentConfig, currentClusterID, cc.Channels)
 	if err := validator.Validate(); err != nil {
 		log.Ctx(ctx).Warn("UpdateReplicateConfiguration fail", zap.Error(err))
 		return nil, err
@@ -176,7 +163,7 @@ func (s *assignmentServiceImpl) validateReplicateConfiguration(ctx context.Conte
 			ReplicateConfiguration: config,
 		}).
 		WithBody(&message.AlterReplicateConfigMessageBody{}).
-		WithBroadcast(broadcastPChannels).
+		WithClusterLevelBroadcast(cc).
 		MustBuildBroadcast()
 	return b, nil
 }

--- a/internal/streamingcoord/server/service/assignment.go
+++ b/internal/streamingcoord/server/service/assignment.go
@@ -142,7 +142,7 @@ func (s *assignmentServiceImpl) validateReplicateConfiguration(ctx context.Conte
 		return nil, errReplicateConfigurationSame
 	}
 
-	cc := channel.GetClusterChannels()
+	cc := channel.GetClusterChannels(channel.OptIncludeUnavailableInReplication())
 
 	// validate the configuration itself
 	currentClusterID := paramtable.Get().CommonCfg.ClusterPrefix.GetValue()

--- a/internal/streamingnode/server/flusher/flusherimpl/flusher_components.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/flusher_components.go
@@ -117,7 +117,7 @@ func (impl *flusherComponents) WhenDropCollection(vchannel string) {
 // HandleMessage handles the plain message.
 func (impl *flusherComponents) HandleMessage(ctx context.Context, msg message.ImmutableMessage) error {
 	vchannel := msg.VChannel()
-	if vchannel == "" || msg.MessageType().IsBroadcastToAll() || funcutil.IsPhysicalChannel(vchannel) {
+	if vchannel == "" || msg.IsPChannelLevel() || funcutil.IsPhysicalChannel(vchannel) {
 		return impl.broadcastToAllDataSyncService(ctx, msg)
 	}
 	if _, ok := impl.dataServices[vchannel]; !ok {

--- a/internal/streamingnode/server/flusher/flusherimpl/flusher_components.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/flusher_components.go
@@ -24,7 +24,6 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message/adaptor"
 	"github.com/milvus-io/milvus/pkg/v2/util/conc"
-	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/retry"
 )
 
@@ -116,8 +115,12 @@ func (impl *flusherComponents) WhenDropCollection(vchannel string) {
 
 // HandleMessage handles the plain message.
 func (impl *flusherComponents) HandleMessage(ctx context.Context, msg message.ImmutableMessage) error {
+	// AlterReplicateConfig is a coordinator-only message, skip it in flusher.
+	if msg.MessageType() == message.MessageTypeAlterReplicateConfig {
+		return nil
+	}
 	vchannel := msg.VChannel()
-	if vchannel == "" || msg.IsPChannelLevel() || funcutil.IsPhysicalChannel(vchannel) {
+	if vchannel == "" || msg.IsPChannelLevel() {
 		return impl.broadcastToAllDataSyncService(ctx, msg)
 	}
 	if _, ok := impl.dataServices[vchannel]; !ok {

--- a/internal/streamingnode/server/flusher/flusherimpl/wal_flusher.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/wal_flusher.go
@@ -247,8 +247,8 @@ func (impl *WALFlusherImpl) dispatch(msg message.ImmutableMessage) (err error) {
 		}()
 	}
 
-	// wal flusher will not handle the control channel message.
-	if funcutil.IsControlChannel(msg.VChannel()) && !msg.MessageType().IsBroadcastToAll() {
+	// wal flusher will not handle the control channel message unless it's a pchannel-level message.
+	if funcutil.IsControlChannel(msg.VChannel()) && !msg.IsPChannelLevel() {
 		return nil
 	}
 

--- a/internal/streamingnode/server/wal/interceptors/lock/lock_interceptor.go
+++ b/internal/streamingnode/server/wal/interceptors/lock/lock_interceptor.go
@@ -8,7 +8,6 @@ import (
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/txn"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/types"
-	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/lock"
 )
 
@@ -31,7 +30,7 @@ func (r *lockAppendInterceptor) acquireLockGuard(_ context.Context, msg message.
 	// Acquire the write lock for the vchannel.
 	vchannel := msg.VChannel()
 	if msg.MessageType().IsExclusiveRequired() {
-		if vchannel == "" || vchannel == r.channel.Name || (funcutil.IsControlChannel(vchannel) && (msg.MessageType() == message.MessageTypeAlterReplicateConfig || msg.MessageType().IsBroadcastToAll())) {
+		if vchannel == "" || vchannel == r.channel.Name || msg.IsPChannelLevel() {
 			r.glock.Lock()
 			return func() {
 				// fail all transactions at all vchannels.

--- a/internal/streamingnode/server/wal/interceptors/lock/lock_interceptor_test.go
+++ b/internal/streamingnode/server/wal/interceptors/lock/lock_interceptor_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/proto/messagespb"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/types"
-	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/lock"
 )
 
@@ -30,67 +29,6 @@ func newTestInterceptor() *lockAppendInterceptor {
 }
 
 func TestAcquireLockGuard(t *testing.T) {
-	controlChannel := funcutil.GetControlChannel(testPChannelName)
-
-	// Test: FlushAll (BroadcastToAll + exclusive) on control channel should acquire global write lock.
-	t.Run("FlushAllOnControlChannel", func(t *testing.T) {
-		mocker := mockey.Mock((*txn.TxnManager).FailTxnAtVChannel).Return().Build()
-		defer mocker.UnPatch()
-
-		interceptor := newTestInterceptor()
-		msg := message.NewFlushAllMessageBuilderV2().
-			WithVChannel(controlChannel).
-			WithHeader(&message.FlushAllMessageHeader{}).
-			WithBody(&message.FlushAllMessageBody{}).
-			MustBuildMutable()
-
-		guard := interceptor.acquireLockGuard(context.Background(), msg)
-		// Global write lock held: TryRLock should fail.
-		assert.False(t, interceptor.glock.TryRLock(), "glock should be write-locked for FlushAll on control channel")
-		guard()
-		// Released: TryRLock should succeed.
-		assert.True(t, interceptor.glock.TryRLock())
-		interceptor.glock.RUnlock()
-	})
-
-	// Test: AlterWAL (BroadcastToAll + exclusive) on control channel should acquire global write lock.
-	t.Run("AlterWALOnControlChannel", func(t *testing.T) {
-		mocker := mockey.Mock((*txn.TxnManager).FailTxnAtVChannel).Return().Build()
-		defer mocker.UnPatch()
-
-		interceptor := newTestInterceptor()
-		msg := message.NewAlterWALMessageBuilderV2().
-			WithVChannel(controlChannel).
-			WithHeader(&message.AlterWALMessageHeader{}).
-			WithBody(&message.AlterWALMessageBody{}).
-			MustBuildMutable()
-
-		guard := interceptor.acquireLockGuard(context.Background(), msg)
-		assert.False(t, interceptor.glock.TryRLock(), "glock should be write-locked for AlterWAL on control channel")
-		guard()
-		assert.True(t, interceptor.glock.TryRLock())
-		interceptor.glock.RUnlock()
-	})
-
-	// Test: AlterReplicateConfig (exclusive, not BroadcastToAll) on control channel should acquire global write lock.
-	t.Run("AlterReplicateConfigOnControlChannel", func(t *testing.T) {
-		mocker := mockey.Mock((*txn.TxnManager).FailTxnAtVChannel).Return().Build()
-		defer mocker.UnPatch()
-
-		interceptor := newTestInterceptor()
-		msg := message.NewAlterReplicateConfigMessageBuilderV2().
-			WithVChannel(controlChannel).
-			WithHeader(&message.AlterReplicateConfigMessageHeader{}).
-			WithBody(&message.AlterReplicateConfigMessageBody{}).
-			MustBuildMutable()
-
-		guard := interceptor.acquireLockGuard(context.Background(), msg)
-		assert.False(t, interceptor.glock.TryRLock(), "glock should be write-locked for AlterReplicateConfig on control channel")
-		guard()
-		assert.True(t, interceptor.glock.TryRLock())
-		interceptor.glock.RUnlock()
-	})
-
 	// Test: Exclusive message with pchannel name as vchannel should acquire global write lock (existing behavior).
 	t.Run("ExclusiveWithPChannelName", func(t *testing.T) {
 		mocker := mockey.Mock((*txn.TxnManager).FailTxnAtVChannel).Return().Build()

--- a/internal/streamingnode/server/wal/interceptors/shard/shard_interceptor.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/shard_interceptor.go
@@ -57,7 +57,7 @@ func (impl *shardInterceptor) Name() string {
 // DoAppend assigns segment for every partition in the message.
 func (impl *shardInterceptor) DoAppend(ctx context.Context, msg message.MutableMessage, appendOp interceptors.Append) (msgID message.MessageID, err error) {
 	op, ok := impl.ops[msg.MessageType()]
-	if ok && (!funcutil.IsControlChannel(msg.VChannel()) || msg.MessageType().IsBroadcastToAll()) {
+	if ok && (!funcutil.IsControlChannel(msg.VChannel()) || msg.IsPChannelLevel()) {
 		// If the message type is registered in the interceptor, use the registered operation.
 		// control channel message is only used to determine the DDL/DCL order,
 		// perform no effect on the shard manager, so skip it.

--- a/internal/util/streamingutil/util/config_channel_provider.go
+++ b/internal/util/streamingutil/util/config_channel_provider.go
@@ -1,0 +1,92 @@
+package util
+
+import (
+	"context"
+	"sort"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/milvus-io/milvus/pkg/v2/log"
+	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
+)
+
+const defaultPollingInterval = 10 * time.Second
+
+// ConfigChannelProvider implements channel.ChannelProvider by polling
+// the Milvus configuration for new DML channel names.
+type ConfigChannelProvider struct {
+	initialChannels []string
+	ch              chan []string
+	cancel          context.CancelFunc
+}
+
+// NewConfigChannelProvider creates a ConfigChannelProvider that reads the
+// current set of topics from configuration and starts a background goroutine
+// to detect any newly added topics.
+func NewConfigChannelProvider() *ConfigChannelProvider {
+	currentTopics := GetAllTopicsFromConfiguration()
+	initial := currentTopics.Collect()
+	sort.Strings(initial)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	p := &ConfigChannelProvider{
+		initialChannels: initial,
+		ch:              make(chan []string, 1),
+		cancel:          cancel,
+	}
+	go p.pollLoop(ctx, currentTopics)
+	return p
+}
+
+// GetInitialChannels returns the channel names known at startup time.
+func (p *ConfigChannelProvider) GetInitialChannels() []string {
+	return p.initialChannels
+}
+
+// NewIncomingChannels returns a read-only channel that delivers slices
+// of newly discovered channel names.
+func (p *ConfigChannelProvider) NewIncomingChannels() <-chan []string {
+	return p.ch
+}
+
+// Close stops the background polling goroutine and closes the notification channel.
+func (p *ConfigChannelProvider) Close() {
+	p.cancel()
+}
+
+// pollLoop periodically checks the configuration for new topics and
+// sends any newly discovered names on the notification channel.
+func (p *ConfigChannelProvider) pollLoop(ctx context.Context, known typeutil.Set[string]) {
+	defer close(p.ch)
+
+	ticker := time.NewTicker(defaultPollingInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			current := GetAllTopicsFromConfiguration()
+			var newChannels []string
+			current.Range(func(name string) bool {
+				if !known.Contain(name) {
+					newChannels = append(newChannels, name)
+					known.Insert(name)
+				}
+				return true
+			})
+			if len(newChannels) > 0 {
+				sort.Strings(newChannels)
+				log.Info("ConfigChannelProvider detected new channels",
+					zap.Strings("newChannels", newChannels))
+				select {
+				case p.ch <- newChannels:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+	}
+}

--- a/internal/util/streamingutil/util/config_channel_provider.go
+++ b/internal/util/streamingutil/util/config_channel_provider.go
@@ -1,41 +1,52 @@
 package util
 
 import (
-	"context"
 	"sort"
-	"time"
 
 	"go.uber.org/zap"
 
+	"github.com/milvus-io/milvus/pkg/v2/config"
 	"github.com/milvus-io/milvus/pkg/v2/log"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v2/util/syncutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
 
-const defaultPollingInterval = 10 * time.Second
-
-// ConfigChannelProvider implements channel.ChannelProvider by polling
+// ConfigChannelProvider implements channel.ChannelProvider by watching
 // the Milvus configuration for new DML channel names.
 type ConfigChannelProvider struct {
+	notifier        *syncutil.AsyncTaskNotifier[struct{}]
+	known           typeutil.Set[string]
 	initialChannels []string
 	ch              chan []string
-	cancel          context.CancelFunc
+	trigger         chan struct{}
+	handler         config.EventHandler
 }
 
 // NewConfigChannelProvider creates a ConfigChannelProvider that reads the
-// current set of topics from configuration and starts a background goroutine
+// current set of topics from configuration and watches for config changes
 // to detect any newly added topics.
 func NewConfigChannelProvider() *ConfigChannelProvider {
 	currentTopics := GetAllTopicsFromConfiguration()
 	initial := currentTopics.Collect()
 	sort.Strings(initial)
 
-	ctx, cancel := context.WithCancel(context.Background())
 	p := &ConfigChannelProvider{
+		notifier:        syncutil.NewAsyncTaskNotifier[struct{}](),
+		known:           currentTopics,
 		initialChannels: initial,
-		ch:              make(chan []string, 1),
-		cancel:          cancel,
+		ch:              make(chan []string),
+		trigger:         make(chan struct{}, 1),
 	}
-	go p.pollLoop(ctx, currentTopics)
+	p.handler = config.NewHandler("config_channel_provider", func(event *config.Event) {
+		// Non-blocking send to coalesce rapid config changes.
+		select {
+		case p.trigger <- struct{}{}:
+		default:
+		}
+	})
+	go p.background()
+	paramtable.Get().Watch(paramtable.Get().RootCoordCfg.DmlChannelNum.Key, p.handler)
 	return p
 }
 
@@ -50,43 +61,44 @@ func (p *ConfigChannelProvider) NewIncomingChannels() <-chan []string {
 	return p.ch
 }
 
-// Close stops the background polling goroutine and closes the notification channel.
+// Close stops the provider and closes the notification channel.
 func (p *ConfigChannelProvider) Close() {
-	p.cancel()
+	paramtable.Get().Unwatch(paramtable.Get().RootCoordCfg.DmlChannelNum.Key, p.handler)
+	p.notifier.Cancel()
+	p.notifier.BlockUntilFinish()
+	close(p.ch)
 }
 
-// pollLoop periodically checks the configuration for new topics and
-// sends any newly discovered names on the notification channel.
-func (p *ConfigChannelProvider) pollLoop(ctx context.Context, known typeutil.Set[string]) {
-	defer close(p.ch)
-
-	ticker := time.NewTicker(defaultPollingInterval)
-	defer ticker.Stop()
-
+// background is the single goroutine that processes config change triggers.
+func (p *ConfigChannelProvider) background() {
+	defer p.notifier.Finish(struct{}{})
 	for {
 		select {
-		case <-ctx.Done():
+		case <-p.trigger:
+			p.onConfigChange()
+		case <-p.notifier.Context().Done():
 			return
-		case <-ticker.C:
-			current := GetAllTopicsFromConfiguration()
-			var newChannels []string
-			current.Range(func(name string) bool {
-				if !known.Contain(name) {
-					newChannels = append(newChannels, name)
-					known.Insert(name)
-				}
-				return true
-			})
-			if len(newChannels) > 0 {
-				sort.Strings(newChannels)
-				log.Info("ConfigChannelProvider detected new channels",
-					zap.Strings("newChannels", newChannels))
-				select {
-				case p.ch <- newChannels:
-				case <-ctx.Done():
-					return
-				}
-			}
+		}
+	}
+}
+
+func (p *ConfigChannelProvider) onConfigChange() {
+	current := GetAllTopicsFromConfiguration()
+	var newChannels []string
+	current.Range(func(name string) bool {
+		if !p.known.Contain(name) {
+			newChannels = append(newChannels, name)
+			p.known.Insert(name)
+		}
+		return true
+	})
+	if len(newChannels) > 0 {
+		sort.Strings(newChannels)
+		log.Info("ConfigChannelProvider detected new channels",
+			zap.Strings("newChannels", newChannels))
+		select {
+		case p.ch <- newChannels:
+		case <-p.notifier.Context().Done():
 		}
 	}
 }

--- a/internal/util/streamingutil/util/config_channel_provider_test.go
+++ b/internal/util/streamingutil/util/config_channel_provider_test.go
@@ -42,29 +42,69 @@ func TestConfigChannelProvider_DetectsNewChannels(t *testing.T) {
 	select {
 	case newChannels := <-provider.NewIncomingChannels():
 		assert.Len(t, newChannels, 1)
-	case <-time.After(15 * time.Second):
+	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for new channel notification")
 	}
 }
 
 func TestConfigChannelProvider_NoDuplicates(t *testing.T) {
 	paramtable.Init()
+
+	originalNum := paramtable.Get().RootCoordCfg.DmlChannelNum.GetValue()
 	provider := NewConfigChannelProvider()
 	defer provider.Close()
+
+	// Trigger a config change with the same value, should not produce new channels.
+	paramtable.Get().Save(paramtable.Get().RootCoordCfg.DmlChannelNum.Key, originalNum)
 
 	select {
 	case newChannels := <-provider.NewIncomingChannels():
 		t.Fatalf("unexpected new channels: %v", newChannels)
-	case <-time.After(3 * time.Second):
-		// Expected: no notification when config has not changed
+	case <-time.After(1 * time.Second):
+		// Expected: no notification when config produces the same channels
 	}
 }
 
-func TestConfigChannelProvider_CloseStopsPolling(t *testing.T) {
+func TestConfigChannelProvider_CloseStopsWatching(t *testing.T) {
 	paramtable.Init()
 	provider := NewConfigChannelProvider()
 	provider.Close()
 
 	_, ok := <-provider.NewIncomingChannels()
 	assert.False(t, ok, "channel should be closed after provider.Close()")
+}
+
+func TestConfigChannelProvider_CloseUnblocksInFlightSend(t *testing.T) {
+	paramtable.Init()
+
+	originalNum := paramtable.Get().RootCoordCfg.DmlChannelNum.GetValue()
+	provider := NewConfigChannelProvider()
+
+	initial := provider.GetInitialChannels()
+	initialCount := len(initial)
+
+	// Trigger a config change that will produce new channels.
+	// Nobody reads from NewIncomingChannels(), so the background goroutine
+	// will block on the channel send.
+	newNum := initialCount + 1
+	paramtable.Get().Save(paramtable.Get().RootCoordCfg.DmlChannelNum.Key, fmt.Sprintf("%d", newNum))
+	defer paramtable.Get().Save(paramtable.Get().RootCoordCfg.DmlChannelNum.Key, originalNum)
+
+	// Give the background goroutine time to pick up the trigger and block on send.
+	time.Sleep(200 * time.Millisecond)
+
+	// Close must not deadlock: it should cancel the blocked send and wait for
+	// the background goroutine to exit.
+	done := make(chan struct{})
+	go func() {
+		provider.Close()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Close returned successfully.
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close() deadlocked while background goroutine was blocked on channel send")
+	}
 }

--- a/internal/util/streamingutil/util/config_channel_provider_test.go
+++ b/internal/util/streamingutil/util/config_channel_provider_test.go
@@ -1,0 +1,70 @@
+package util
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+)
+
+func TestConfigChannelProvider_GetInitialChannels(t *testing.T) {
+	paramtable.Init()
+	provider := NewConfigChannelProvider()
+	defer provider.Close()
+
+	initial := provider.GetInitialChannels()
+	assert.NotEmpty(t, initial)
+
+	expected := GetAllTopicsFromConfiguration().Collect()
+	sort.Strings(expected)
+	sort.Strings(initial)
+	assert.Equal(t, expected, initial)
+}
+
+func TestConfigChannelProvider_DetectsNewChannels(t *testing.T) {
+	paramtable.Init()
+
+	originalNum := paramtable.Get().RootCoordCfg.DmlChannelNum.GetValue()
+	provider := NewConfigChannelProvider()
+	defer provider.Close()
+
+	initial := provider.GetInitialChannels()
+	initialCount := len(initial)
+
+	newNum := initialCount + 1
+	paramtable.Get().Save(paramtable.Get().RootCoordCfg.DmlChannelNum.Key, fmt.Sprintf("%d", newNum))
+	defer paramtable.Get().Save(paramtable.Get().RootCoordCfg.DmlChannelNum.Key, originalNum)
+
+	select {
+	case newChannels := <-provider.NewIncomingChannels():
+		assert.Len(t, newChannels, 1)
+	case <-time.After(15 * time.Second):
+		t.Fatal("timed out waiting for new channel notification")
+	}
+}
+
+func TestConfigChannelProvider_NoDuplicates(t *testing.T) {
+	paramtable.Init()
+	provider := NewConfigChannelProvider()
+	defer provider.Close()
+
+	select {
+	case newChannels := <-provider.NewIncomingChannels():
+		t.Fatalf("unexpected new channels: %v", newChannels)
+	case <-time.After(3 * time.Second):
+		// Expected: no notification when config has not changed
+	}
+}
+
+func TestConfigChannelProvider_CloseStopsPolling(t *testing.T) {
+	paramtable.Init()
+	provider := NewConfigChannelProvider()
+	provider.Close()
+
+	_, ok := <-provider.NewIncomingChannels()
+	assert.False(t, ok, "channel should be closed after provider.Close()")
+}

--- a/pkg/mocks/streaming/util/mock_message/mock_BroadcastMutableMessage.go
+++ b/pkg/mocks/streaming/util/mock_message/mock_BroadcastMutableMessage.go
@@ -208,6 +208,51 @@ func (_c *MockBroadcastMutableMessage_IntoMessageProto_Call) RunAndReturn(run fu
 	return _c
 }
 
+// IsPChannelLevel provides a mock function with no fields
+func (_m *MockBroadcastMutableMessage) IsPChannelLevel() bool {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsPChannelLevel")
+	}
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
+// MockBroadcastMutableMessage_IsPChannelLevel_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsPChannelLevel'
+type MockBroadcastMutableMessage_IsPChannelLevel_Call struct {
+	*mock.Call
+}
+
+// IsPChannelLevel is a helper method to define mock.On call
+func (_e *MockBroadcastMutableMessage_Expecter) IsPChannelLevel() *MockBroadcastMutableMessage_IsPChannelLevel_Call {
+	return &MockBroadcastMutableMessage_IsPChannelLevel_Call{Call: _e.mock.On("IsPChannelLevel")}
+}
+
+func (_c *MockBroadcastMutableMessage_IsPChannelLevel_Call) Run(run func()) *MockBroadcastMutableMessage_IsPChannelLevel_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockBroadcastMutableMessage_IsPChannelLevel_Call) Return(_a0 bool) *MockBroadcastMutableMessage_IsPChannelLevel_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockBroadcastMutableMessage_IsPChannelLevel_Call) RunAndReturn(run func() bool) *MockBroadcastMutableMessage_IsPChannelLevel_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // IsPersisted provides a mock function with no fields
 func (_m *MockBroadcastMutableMessage) IsPersisted() bool {
 	ret := _m.Called()

--- a/pkg/mocks/streaming/util/mock_message/mock_ImmutableMessage.go
+++ b/pkg/mocks/streaming/util/mock_message/mock_ImmutableMessage.go
@@ -304,6 +304,51 @@ func (_c *MockImmutableMessage_IntoMessageProto_Call) RunAndReturn(run func() *m
 	return _c
 }
 
+// IsPChannelLevel provides a mock function with no fields
+func (_m *MockImmutableMessage) IsPChannelLevel() bool {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsPChannelLevel")
+	}
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
+// MockImmutableMessage_IsPChannelLevel_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsPChannelLevel'
+type MockImmutableMessage_IsPChannelLevel_Call struct {
+	*mock.Call
+}
+
+// IsPChannelLevel is a helper method to define mock.On call
+func (_e *MockImmutableMessage_Expecter) IsPChannelLevel() *MockImmutableMessage_IsPChannelLevel_Call {
+	return &MockImmutableMessage_IsPChannelLevel_Call{Call: _e.mock.On("IsPChannelLevel")}
+}
+
+func (_c *MockImmutableMessage_IsPChannelLevel_Call) Run(run func()) *MockImmutableMessage_IsPChannelLevel_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockImmutableMessage_IsPChannelLevel_Call) Return(_a0 bool) *MockImmutableMessage_IsPChannelLevel_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockImmutableMessage_IsPChannelLevel_Call) RunAndReturn(run func() bool) *MockImmutableMessage_IsPChannelLevel_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // IsPersisted provides a mock function with no fields
 func (_m *MockImmutableMessage) IsPersisted() bool {
 	ret := _m.Called()
@@ -575,6 +620,51 @@ func (_c *MockImmutableMessage_MessageTypeWithVersion_Call) Return(_a0 message.M
 }
 
 func (_c *MockImmutableMessage_MessageTypeWithVersion_Call) RunAndReturn(run func() message.MessageTypeWithVersion) *MockImmutableMessage_MessageTypeWithVersion_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// PChannel provides a mock function with no fields
+func (_m *MockImmutableMessage) PChannel() string {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for PChannel")
+	}
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// MockImmutableMessage_PChannel_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PChannel'
+type MockImmutableMessage_PChannel_Call struct {
+	*mock.Call
+}
+
+// PChannel is a helper method to define mock.On call
+func (_e *MockImmutableMessage_Expecter) PChannel() *MockImmutableMessage_PChannel_Call {
+	return &MockImmutableMessage_PChannel_Call{Call: _e.mock.On("PChannel")}
+}
+
+func (_c *MockImmutableMessage_PChannel_Call) Run(run func()) *MockImmutableMessage_PChannel_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockImmutableMessage_PChannel_Call) Return(_a0 string) *MockImmutableMessage_PChannel_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockImmutableMessage_PChannel_Call) RunAndReturn(run func() string) *MockImmutableMessage_PChannel_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/mocks/streaming/util/mock_message/mock_ImmutableTxnMessage.go
+++ b/pkg/mocks/streaming/util/mock_message/mock_ImmutableTxnMessage.go
@@ -398,6 +398,51 @@ func (_c *MockImmutableTxnMessage_IntoMessageProto_Call) RunAndReturn(run func()
 	return _c
 }
 
+// IsPChannelLevel provides a mock function with no fields
+func (_m *MockImmutableTxnMessage) IsPChannelLevel() bool {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsPChannelLevel")
+	}
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
+// MockImmutableTxnMessage_IsPChannelLevel_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsPChannelLevel'
+type MockImmutableTxnMessage_IsPChannelLevel_Call struct {
+	*mock.Call
+}
+
+// IsPChannelLevel is a helper method to define mock.On call
+func (_e *MockImmutableTxnMessage_Expecter) IsPChannelLevel() *MockImmutableTxnMessage_IsPChannelLevel_Call {
+	return &MockImmutableTxnMessage_IsPChannelLevel_Call{Call: _e.mock.On("IsPChannelLevel")}
+}
+
+func (_c *MockImmutableTxnMessage_IsPChannelLevel_Call) Run(run func()) *MockImmutableTxnMessage_IsPChannelLevel_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockImmutableTxnMessage_IsPChannelLevel_Call) Return(_a0 bool) *MockImmutableTxnMessage_IsPChannelLevel_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockImmutableTxnMessage_IsPChannelLevel_Call) RunAndReturn(run func() bool) *MockImmutableTxnMessage_IsPChannelLevel_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // IsPersisted provides a mock function with no fields
 func (_m *MockImmutableTxnMessage) IsPersisted() bool {
 	ret := _m.Called()
@@ -669,6 +714,51 @@ func (_c *MockImmutableTxnMessage_MessageTypeWithVersion_Call) Return(_a0 messag
 }
 
 func (_c *MockImmutableTxnMessage_MessageTypeWithVersion_Call) RunAndReturn(run func() message.MessageTypeWithVersion) *MockImmutableTxnMessage_MessageTypeWithVersion_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// PChannel provides a mock function with no fields
+func (_m *MockImmutableTxnMessage) PChannel() string {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for PChannel")
+	}
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// MockImmutableTxnMessage_PChannel_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PChannel'
+type MockImmutableTxnMessage_PChannel_Call struct {
+	*mock.Call
+}
+
+// PChannel is a helper method to define mock.On call
+func (_e *MockImmutableTxnMessage_Expecter) PChannel() *MockImmutableTxnMessage_PChannel_Call {
+	return &MockImmutableTxnMessage_PChannel_Call{Call: _e.mock.On("PChannel")}
+}
+
+func (_c *MockImmutableTxnMessage_PChannel_Call) Run(run func()) *MockImmutableTxnMessage_PChannel_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockImmutableTxnMessage_PChannel_Call) Return(_a0 string) *MockImmutableTxnMessage_PChannel_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockImmutableTxnMessage_PChannel_Call) RunAndReturn(run func() string) *MockImmutableTxnMessage_PChannel_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/mocks/streaming/util/mock_message/mock_MutableMessage.go
+++ b/pkg/mocks/streaming/util/mock_message/mock_MutableMessage.go
@@ -256,6 +256,51 @@ func (_c *MockMutableMessage_IntoMessageProto_Call) RunAndReturn(run func() *mes
 	return _c
 }
 
+// IsPChannelLevel provides a mock function with no fields
+func (_m *MockMutableMessage) IsPChannelLevel() bool {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsPChannelLevel")
+	}
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
+// MockMutableMessage_IsPChannelLevel_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsPChannelLevel'
+type MockMutableMessage_IsPChannelLevel_Call struct {
+	*mock.Call
+}
+
+// IsPChannelLevel is a helper method to define mock.On call
+func (_e *MockMutableMessage_Expecter) IsPChannelLevel() *MockMutableMessage_IsPChannelLevel_Call {
+	return &MockMutableMessage_IsPChannelLevel_Call{Call: _e.mock.On("IsPChannelLevel")}
+}
+
+func (_c *MockMutableMessage_IsPChannelLevel_Call) Run(run func()) *MockMutableMessage_IsPChannelLevel_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockMutableMessage_IsPChannelLevel_Call) Return(_a0 bool) *MockMutableMessage_IsPChannelLevel_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockMutableMessage_IsPChannelLevel_Call) RunAndReturn(run func() bool) *MockMutableMessage_IsPChannelLevel_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // IsPersisted provides a mock function with no fields
 func (_m *MockMutableMessage) IsPersisted() bool {
 	ret := _m.Called()
@@ -433,6 +478,51 @@ func (_c *MockMutableMessage_MessageTypeWithVersion_Call) Return(_a0 message.Mes
 }
 
 func (_c *MockMutableMessage_MessageTypeWithVersion_Call) RunAndReturn(run func() message.MessageTypeWithVersion) *MockMutableMessage_MessageTypeWithVersion_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// PChannel provides a mock function with no fields
+func (_m *MockMutableMessage) PChannel() string {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for PChannel")
+	}
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// MockMutableMessage_PChannel_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PChannel'
+type MockMutableMessage_PChannel_Call struct {
+	*mock.Call
+}
+
+// PChannel is a helper method to define mock.On call
+func (_e *MockMutableMessage_Expecter) PChannel() *MockMutableMessage_PChannel_Call {
+	return &MockMutableMessage_PChannel_Call{Call: _e.mock.On("PChannel")}
+}
+
+func (_c *MockMutableMessage_PChannel_Call) Run(run func()) *MockMutableMessage_PChannel_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockMutableMessage_PChannel_Call) Return(_a0 string) *MockMutableMessage_PChannel_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockMutableMessage_PChannel_Call) RunAndReturn(run func() string) *MockMutableMessage_PChannel_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/streaming/util/message/cluster_broadcast.go
+++ b/pkg/streaming/util/message/cluster_broadcast.go
@@ -1,0 +1,12 @@
+package message
+
+// ClusterChannels describes the physical channel topology of the cluster.
+// Channels is the raw pchannel name list.
+// ControlChannel is the control channel name (e.g. "pchannel0_vcchan").
+//
+// WithClusterLevelBroadcast uses this to build the broadcast channel list,
+// substituting the control channel for the pchannel it resides on.
+type ClusterChannels struct {
+	Channels       []string
+	ControlChannel string
+}

--- a/pkg/streaming/util/message/cluster_broadcast_test.go
+++ b/pkg/streaming/util/message/cluster_broadcast_test.go
@@ -1,0 +1,148 @@
+package message
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithClusterLevelBroadcast(t *testing.T) {
+	cc := ClusterChannels{
+		Channels:       []string{"pchannel1", "pchannel2"},
+		ControlChannel: "pchannel1_vcchan",
+	}
+
+	msg := NewFlushAllMessageBuilderV2().
+		WithHeader(&FlushAllMessageHeader{}).
+		WithBody(&FlushAllMessageBody{}).
+		WithClusterLevelBroadcast(cc).
+		MustBuildBroadcast()
+
+	// The message should be marked as pchannel-level.
+	assert.True(t, msg.IsPChannelLevel())
+
+	// The broadcast header should contain control channel substituted for pchannel1.
+	bh := msg.BroadcastHeader()
+	assert.NotNil(t, bh)
+	assert.ElementsMatch(t, []string{"pchannel1_vcchan", "pchannel2"}, bh.VChannels)
+
+	// Split should produce messages each marked as pchannel-level.
+	msg.WithBroadcastID(1)
+	splitMsgs := msg.SplitIntoMutableMessage()
+	assert.Len(t, splitMsgs, 2)
+	for _, sm := range splitMsgs {
+		assert.True(t, sm.IsPChannelLevel())
+	}
+}
+
+func TestWithClusterLevelBroadcastPanics(t *testing.T) {
+	t.Run("EmptyChannels", func(t *testing.T) {
+		assert.Panics(t, func() {
+			NewFlushAllMessageBuilderV2().
+				WithHeader(&FlushAllMessageHeader{}).
+				WithBody(&FlushAllMessageBody{}).
+				WithClusterLevelBroadcast(ClusterChannels{
+					ControlChannel: "pchannel1_vcchan",
+				}).
+				MustBuildBroadcast()
+		})
+	})
+
+	t.Run("EmptyControlChannel", func(t *testing.T) {
+		assert.Panics(t, func() {
+			NewFlushAllMessageBuilderV2().
+				WithHeader(&FlushAllMessageHeader{}).
+				WithBody(&FlushAllMessageBody{}).
+				WithClusterLevelBroadcast(ClusterChannels{
+					Channels: []string{"pchannel1"},
+				}).
+				MustBuildBroadcast()
+		})
+	})
+
+	t.Run("NonPChannelInChannels", func(t *testing.T) {
+		assert.Panics(t, func() {
+			NewFlushAllMessageBuilderV2().
+				WithHeader(&FlushAllMessageHeader{}).
+				WithBody(&FlushAllMessageBody{}).
+				WithClusterLevelBroadcast(ClusterChannels{
+					Channels:       []string{"pchannel1", "pchannel2_100v0"},
+					ControlChannel: "pchannel1_vcchan",
+				}).
+				MustBuildBroadcast()
+		})
+	})
+
+	t.Run("ControlChannelNotOnAnyPChannel", func(t *testing.T) {
+		assert.Panics(t, func() {
+			NewFlushAllMessageBuilderV2().
+				WithHeader(&FlushAllMessageHeader{}).
+				WithBody(&FlushAllMessageBody{}).
+				WithClusterLevelBroadcast(ClusterChannels{
+					Channels:       []string{"pchannel1", "pchannel2"},
+					ControlChannel: "pchannel3_vcchan",
+				}).
+				MustBuildBroadcast()
+		})
+	})
+}
+
+func TestPChannel(t *testing.T) {
+	t.Run("WithVChannel", func(t *testing.T) {
+		msg := &messageImpl{
+			payload: []byte("test"),
+			properties: propertiesImpl{
+				messageVChannel: "pchannel1_v0",
+			},
+		}
+		assert.Equal(t, "pchannel1", msg.PChannel())
+	})
+
+	t.Run("EmptyVChannel", func(t *testing.T) {
+		msg := &messageImpl{
+			payload:    []byte("test"),
+			properties: propertiesImpl{},
+		}
+		assert.Equal(t, "", msg.PChannel())
+	})
+
+	t.Run("SplitBroadcastMessages", func(t *testing.T) {
+		cc := ClusterChannels{
+			Channels:       []string{"pchannel1", "pchannel2"},
+			ControlChannel: "pchannel1_vcchan",
+		}
+		msg := NewFlushAllMessageBuilderV2().
+			WithHeader(&FlushAllMessageHeader{}).
+			WithBody(&FlushAllMessageBody{}).
+			WithClusterLevelBroadcast(cc).
+			MustBuildBroadcast()
+		msg.WithBroadcastID(1)
+
+		splitMsgs := msg.SplitIntoMutableMessage()
+		pchannels := make([]string, 0, len(splitMsgs))
+		for _, sm := range splitMsgs {
+			pchannels = append(pchannels, sm.PChannel())
+		}
+		assert.ElementsMatch(t, []string{"pchannel1", "pchannel2"}, pchannels)
+	})
+}
+
+func TestIsPChannelLevel(t *testing.T) {
+	t.Run("NotPChannelLevel", func(t *testing.T) {
+		msg := &messageImpl{
+			payload:    []byte("test"),
+			properties: propertiesImpl{},
+		}
+		assert.False(t, msg.IsPChannelLevel())
+	})
+
+	t.Run("IsPChannelLevel", func(t *testing.T) {
+		msg := &messageImpl{
+			payload: []byte("test"),
+			properties: propertiesImpl{
+				messagePChannelLevel: "",
+			},
+		}
+		assert.True(t, msg.IsPChannelLevel())
+	})
+}

--- a/pkg/streaming/util/message/message.go
+++ b/pkg/streaming/util/message/message.go
@@ -67,6 +67,11 @@ type BasicMessage interface {
 	// IsPersisted returns true if the message is persisted into underlying log storage.
 	IsPersisted() bool
 
+	// IsPChannelLevel returns true if the message is a pchannel-level message.
+	// A pchannel-level message is broadcast to all pchannels and should be handled
+	// at pchannel scope rather than vchannel scope.
+	IsPChannelLevel() bool
+
 	// IntoMessageProto converts the message to a protobuf message.
 	IntoMessageProto() *messagespb.Message
 }
@@ -80,6 +85,10 @@ type MutableMessage interface {
 	// Available only when the message's version greater than 0.
 	// Return "" or Pchannel if message is can be seen by all vchannels on the pchannel.
 	VChannel() string
+
+	// PChannel returns the physical channel derived from VChannel.
+	// It strips the virtual channel suffix to return the underlying physical channel name.
+	PChannel() string
 
 	// WithBarrierTimeTick sets the barrier time tick of current message.
 	// these time tick is used to promised the message will be sent after that time tick.
@@ -156,6 +165,10 @@ type ImmutableMessage interface {
 	// Available only when the message's version greater than 0.
 	// Return "" if message is can be seen by all vchannels on the pchannel.
 	VChannel() string
+
+	// PChannel returns the physical channel derived from VChannel.
+	// It strips the virtual channel suffix to return the underlying physical channel name.
+	PChannel() string
 
 	// MessageID returns the message id of current message.
 	MessageID() MessageID

--- a/pkg/streaming/util/message/message_impl.go
+++ b/pkg/streaming/util/message/message_impl.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/messagespb"
+	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
 )
 
 type messageImpl struct {
@@ -65,6 +66,20 @@ func (m *messageImpl) Properties() RProperties {
 // IsPersisted returns true if the message is persisted.
 func (m *messageImpl) IsPersisted() bool {
 	return !m.properties.Exist(messageNotPersisteted)
+}
+
+// IsPChannelLevel returns true if the message is a pchannel-level message.
+// A message is pchannel-level if it has the explicit property set, or if it is
+// a broadcast-to-all or AlterReplicateConfig message sent on the control channel.
+func (m *messageImpl) IsPChannelLevel() bool {
+	if m.properties.Exist(messagePChannelLevel) {
+		return true
+	}
+	msgType := m.MessageType()
+	if msgType.IsBroadcastToAll() || msgType == MessageTypeAlterReplicateConfig {
+		return funcutil.IsControlChannel(m.VChannel())
+	}
+	return false
 }
 
 // IntoMessageProto converts the message to a protobuf message.
@@ -276,6 +291,11 @@ func (m *messageImpl) BarrierTimeTick() uint64 {
 		panic(fmt.Sprintf("there's a bug in the message codes, dirty barrier timetick %s in properties of message", value))
 	}
 	return tt
+}
+
+// PChannel returns the physical channel derived from VChannel.
+func (m *messageImpl) PChannel() string {
+	return funcutil.ToPhysicalChannel(m.VChannel())
 }
 
 // VChannel returns the vchannel of current message.

--- a/pkg/streaming/util/message/message_impl.go
+++ b/pkg/streaming/util/message/message_impl.go
@@ -69,17 +69,8 @@ func (m *messageImpl) IsPersisted() bool {
 }
 
 // IsPChannelLevel returns true if the message is a pchannel-level message.
-// A message is pchannel-level if it has the explicit property set, or if it is
-// a broadcast-to-all or AlterReplicateConfig message sent on the control channel.
 func (m *messageImpl) IsPChannelLevel() bool {
-	if m.properties.Exist(messagePChannelLevel) {
-		return true
-	}
-	msgType := m.MessageType()
-	if msgType.IsBroadcastToAll() || msgType == MessageTypeAlterReplicateConfig {
-		return funcutil.IsControlChannel(m.VChannel())
-	}
-	return false
+	return m.properties.Exist(messagePChannelLevel)
 }
 
 // IntoMessageProto converts the message to a protobuf message.

--- a/pkg/streaming/util/message/message_type.go
+++ b/pkg/streaming/util/message/message_type.go
@@ -21,8 +21,6 @@ type MessageTypeProperties struct {
 	ExclusiveRequired bool
 	// a cipher enabled message type will be encrypted before appending to the wal if cipher is enabled.
 	CipherEnabled bool
-	// A broadcast to all message type is a message that will be broadcasted to all vchannels.
-	BroadcastToAll bool
 }
 
 var messageTypePropertiesMap = map[MessageType]MessageTypeProperties{
@@ -115,11 +113,9 @@ var messageTypePropertiesMap = map[MessageType]MessageTypeProperties{
 	MessageTypeDropIndex:           {},
 	MessageTypeFlushAll: {
 		ExclusiveRequired: true,
-		BroadcastToAll:    true,
 	},
 	MessageTypeAlterWAL: {
 		ExclusiveRequired: true,
-		BroadcastToAll:    true,
 	},
 }
 
@@ -160,11 +156,6 @@ func (t MessageType) IsSystem() bool {
 // IsSelfControlled checks if the MessageType is self controlled.
 func (t MessageType) IsSelfControlled() bool {
 	return messageTypePropertiesMap[t].SelfControlled
-}
-
-// IsBroadcastToAll checks if the MessageType is broadcast to all.
-func (t MessageType) IsBroadcastToAll() bool {
-	return messageTypePropertiesMap[t].BroadcastToAll
 }
 
 // LogLevel returns the log level of the MessageType.

--- a/pkg/streaming/util/message/properties.go
+++ b/pkg/streaming/util/message/properties.go
@@ -15,6 +15,7 @@ const (
 	messageTxnContext                       = "_tx"  // transaction context.
 	messageCipherHeader                     = "_ch"  // message cipher header.
 	messageNotPersisteted                   = "_np"  // check if the message is unpersisted.
+	messagePChannelLevel                    = "_pcl" // mark the message as pchannel level message.
 	messageReplicateMesssageHeader          = "_rh"  // replicate message header.
 )
 

--- a/pkg/util/funcutil/func.go
+++ b/pkg/util/funcutil/func.go
@@ -384,9 +384,9 @@ func IsControlChannel(channel string) bool {
 	return strings.HasSuffix(channel, ControlChannelSuffix)
 }
 
-// IsOnPhysicalChannel checks if the channel is on the physical channel
+// IsOnPhysicalChannel checks if the channel is on the physical channel.
 func IsOnPhysicalChannel(channel string, physicalChannel string) bool {
-	return strings.HasPrefix(channel, physicalChannel)
+	return ToPhysicalChannel(channel) == physicalChannel
 }
 
 // ToPhysicalChannel get physical channel name from virtual channel name

--- a/pkg/util/funcutil/func_test.go
+++ b/pkg/util/funcutil/func_test.go
@@ -1021,6 +1021,29 @@ func TestChannelConvert(t *testing.T) {
 		channel := GetVirtualChannel("by-dev-rootcoord-dml_2", 1001, 0)
 		assert.Equal(t, "by-dev-rootcoord-dml_2_1001v0", channel)
 	})
+
+	t.Run("is on physical channel with prefix ambiguity", func(t *testing.T) {
+		// Two pchannels where one is a prefix of the other:
+		// by-dev-rootcoord-dml_1 vs by-dev-rootcoord-dml_10
+		pchannel1 := "by-dev-rootcoord-dml_1"
+		pchannel10 := "by-dev-rootcoord-dml_10"
+
+		// vchannel on pchannel_1
+		vchannel1 := "by-dev-rootcoord-dml_1_1001v0"
+		assert.True(t, IsOnPhysicalChannel(vchannel1, pchannel1))
+		assert.False(t, IsOnPhysicalChannel(vchannel1, pchannel10))
+
+		// vchannel on pchannel_10
+		vchannel10 := "by-dev-rootcoord-dml_10_1001v0"
+		assert.False(t, IsOnPhysicalChannel(vchannel10, pchannel1))
+		assert.True(t, IsOnPhysicalChannel(vchannel10, pchannel10))
+
+		// pchannel matches itself
+		assert.True(t, IsOnPhysicalChannel(pchannel1, pchannel1))
+		assert.True(t, IsOnPhysicalChannel(pchannel10, pchannel10))
+		assert.False(t, IsOnPhysicalChannel(pchannel1, pchannel10))
+		assert.False(t, IsOnPhysicalChannel(pchannel10, pchannel1))
+	})
 }
 
 func TestString2KeyValuePair(t *testing.T) {

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -1786,7 +1786,6 @@ func (p *rootCoordConfig) init(base *BaseTable) {
 		Key:          "rootCoord.dmlChannelNum",
 		Version:      "2.0.0",
 		DefaultValue: "16",
-		Forbidden:    true,
 		Doc:          "The number of DML-Channels to create at the root coord startup.",
 		Export:       true,
 	}

--- a/pkg/util/replicateutil/config_helper.go
+++ b/pkg/util/replicateutil/config_helper.go
@@ -135,6 +135,13 @@ func (g *ConfigHelper) GetCurrentCluster() *MilvusCluster {
 	return g.vs[g.currentClusterID]
 }
 
+// IsJoinReplication returns true if the current cluster participates in a
+// cross-cluster replication topology (either as primary with targets or as secondary with a source).
+func (g *ConfigHelper) IsJoinReplication() bool {
+	currentCluster := g.GetCurrentCluster()
+	return len(currentCluster.TargetClusters()) > 0 || currentCluster.SourceCluster() != nil
+}
+
 // GetCluster returns the cluster from the graph.
 func (g *ConfigHelper) GetCluster(clusterID string) *MilvusCluster {
 	return g.vs[clusterID]

--- a/pkg/util/replicateutil/config_helper_test.go
+++ b/pkg/util/replicateutil/config_helper_test.go
@@ -352,6 +352,25 @@ func TestConfigHelper_GetTargetChannel(t *testing.T) {
 	}
 }
 
+func TestConfigHelper_IsJoinReplication(t *testing.T) {
+	// Single cluster, no topology → not in replication
+	singleCfg := &commonpb.ReplicateConfiguration{
+		Clusters: []*commonpb.MilvusCluster{
+			{ClusterId: "by-dev", Pchannels: []string{"ch1"}},
+		},
+	}
+	h := MustNewConfigHelper("by-dev", singleCfg)
+	assert.False(t, h.IsJoinReplication())
+
+	// Multi-cluster with topology → primary is in replication
+	h = MustNewConfigHelper("source-cluster", createValidConfig())
+	assert.True(t, h.IsJoinReplication())
+
+	// Secondary is also in replication
+	h = MustNewConfigHelper("target-cluster-a", createValidConfig())
+	assert.True(t, h.IsJoinReplication())
+}
+
 func TestConfigHelper_EdgeCases(t *testing.T) {
 	t.Run("config with different channel counts", func(t *testing.T) {
 		config := createConfigWithDifferentChannelCounts()

--- a/tests/integration/flushall/flushall_with_restart_test.go
+++ b/tests/integration/flushall/flushall_with_restart_test.go
@@ -1,0 +1,154 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flushall
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/pkg/v2/log"
+	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+	"github.com/milvus-io/milvus/pkg/v2/util/metric"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+	"github.com/milvus-io/milvus/tests/integration"
+)
+
+const dmlChannelNum = 2
+
+type FlushAllWithRestartSuite struct {
+	FlushAllSuite
+}
+
+func (s *FlushAllWithRestartSuite) SetupSuite() {
+	s.WithMilvusConfig(paramtable.Get().RootCoordCfg.DmlChannelNum.Key, "2")
+	s.WithMilvusConfig(paramtable.Get().StreamingCfg.WALBalancerPolicyMinRebalanceIntervalThreshold.Key, "1ms")
+	s.MiniClusterSuite.SetupSuite()
+}
+
+func (s *FlushAllWithRestartSuite) TestFlushAllWithStreamingNodeRestart() {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+	c := s.Cluster
+
+	const (
+		dim    = 128
+		rowNum = 1000
+	)
+
+	// Use the cluster pchannel count as shard number.
+	shardsNum := dmlChannelNum
+	collectionName := "TestFlushAllWithRestart_" + funcutil.GenRandomStr()
+
+	// Create collection with shard count equal to pchannel count.
+	schema := integration.ConstructSchema(collectionName, dim, false)
+	marshaledSchema, err := proto.Marshal(schema)
+	s.NoError(err)
+
+	createStatus, err := c.MilvusClient.CreateCollection(ctx, &milvuspb.CreateCollectionRequest{
+		CollectionName: collectionName,
+		Schema:         marshaledSchema,
+		ShardsNum:      int32(shardsNum),
+	})
+	s.NoError(merr.CheckRPCCall(createStatus, err))
+
+	// Step 1: Insert 1000 rows and FlushAll.
+	fVecColumn := integration.NewFloatVectorFieldData(integration.FloatVecField, rowNum, dim)
+	pkColumn := integration.NewInt64FieldDataWithStart(integration.Int64Field, rowNum, 0)
+	insertResult, err := c.MilvusClient.Insert(ctx, &milvuspb.InsertRequest{
+		CollectionName: collectionName,
+		FieldsData:     []*schemapb.FieldData{pkColumn, fVecColumn},
+		NumRows:        uint32(rowNum),
+	})
+	s.NoError(merr.CheckRPCCall(insertResult, err))
+
+	flushAllResp, err := c.MilvusClient.FlushAll(ctx, &milvuspb.FlushAllRequest{})
+	s.NoError(merr.CheckRPCCall(flushAllResp, err))
+	s.WaitForFlushAll(ctx, flushAllResp.GetFlushAllMsgs())
+	log.Info("first FlushAll completed")
+
+	// Step 2: Restart all streaming nodes, then insert another 1000 rows and FlushAll.
+	for _, sn := range c.GetAllStreamingNodes() {
+		sn.Stop()
+	}
+	c.AddStreamingNode()
+	log.Info("streaming node restarted")
+
+	// Wait for channel rebalance to complete after streaming node restart,
+	// then insert data with retry.
+	s.Eventually(func() bool {
+		fVecColumn2 := integration.NewFloatVectorFieldData(integration.FloatVecField, rowNum, dim)
+		pkColumn2 := integration.NewInt64FieldDataWithStart(integration.Int64Field, rowNum, int64(rowNum))
+		insertResult2, err := c.MilvusClient.Insert(ctx, &milvuspb.InsertRequest{
+			CollectionName: collectionName,
+			FieldsData:     []*schemapb.FieldData{pkColumn2, fVecColumn2},
+			NumRows:        uint32(rowNum),
+		})
+		if err != nil {
+			return false
+		}
+		return merr.Ok(insertResult2.GetStatus())
+	}, 2*time.Minute, 3*time.Second)
+
+	flushAllResp2, err := c.MilvusClient.FlushAll(ctx, &milvuspb.FlushAllRequest{})
+	s.NoError(merr.CheckRPCCall(flushAllResp2, err))
+	s.WaitForFlushAll(ctx, flushAllResp2.GetFlushAllMsgs())
+	log.Info("second FlushAll completed after streaming node restart")
+
+	// Step 3: Create index, load collection, and query count(*) to verify total is 2000.
+	createIndexStatus, err := c.MilvusClient.CreateIndex(ctx, &milvuspb.CreateIndexRequest{
+		CollectionName: collectionName,
+		FieldName:      integration.FloatVecField,
+		IndexName:      "_default",
+		ExtraParams:    integration.ConstructIndexParam(dim, integration.IndexFaissIvfFlat, metric.L2),
+	})
+	s.NoError(merr.CheckRPCCall(createIndexStatus, err))
+	s.WaitForIndexBuilt(ctx, collectionName, integration.FloatVecField)
+
+	loadStatus, err := c.MilvusClient.LoadCollection(ctx, &milvuspb.LoadCollectionRequest{
+		CollectionName: collectionName,
+	})
+	s.NoError(merr.CheckRPCCall(loadStatus, err))
+	s.WaitForLoad(ctx, collectionName)
+
+	queryResult, err := c.MilvusClient.Query(ctx, &milvuspb.QueryRequest{
+		CollectionName:   collectionName,
+		OutputFields:     []string{"count(*)"},
+		ConsistencyLevel: commonpb.ConsistencyLevel_Strong,
+	})
+	s.NoError(merr.CheckRPCCall(queryResult, err))
+	count := queryResult.GetFieldsData()[0].GetScalars().GetLongData().GetData()[0]
+	s.Equal(int64(2*rowNum), count)
+	log.Info("query count(*) verified: 2000 rows")
+
+	// Cleanup.
+	dropStatus, err := c.MilvusClient.DropCollection(ctx, &milvuspb.DropCollectionRequest{
+		CollectionName: collectionName,
+	})
+	s.NoError(merr.CheckRPCCall(dropStatus, err))
+}
+
+func TestFlushAllWithRestart(t *testing.T) {
+	suite.Run(t, new(FlushAllWithRestartSuite))
+}


### PR DESCRIPTION
issue: #47647

Refactor the cluster-level broadcast mechanism to decouple the message package from the channel registration lifecycle:

- Replace internal provider pattern with opaque ClusterChannels type passed externally to WithClusterLevelBroadcast()
- Add channel package singleton (syncutil.Future) exposing GetClusterChannels() and GetPChannelNames() blocking accessors
- Add PChannel() interface to MutableMessage/ImmutableMessage for deriving physical channel from virtual channel
- Validate non-control-channel entries are physical channels using funcutil.IsPhysicalChannel and use funcutil.IsOnPhysicalChannel for control channel matching
- Move control channel substitution logic into WithClusterLevelBroadcast to simplify callers (datacoord, coordinator, assignment service)
- Add lock interceptor unit tests and cluster broadcast test coverage
- Add integration test for FlushAll with streaming node restart to verify data integrity across node lifecycle