### PR TITLE
fix: /_cluster/configs should return latest config 

### DIFF
--- a/internal/proxy/http_req_impl.go
+++ b/internal/proxy/http_req_impl.go
@@ -74,7 +74,8 @@ func hideSensitive(configs map[string]string) {
 	}
 }
 
-func getConfigs(configs map[string]string) gin.HandlerFunc {
+func getConfigs(configFunc func() map[string]string) gin.HandlerFunc {
+	configs := configFunc()
 	hideSensitive(configs)
 	return func(c *gin.Context) {
 		bs, err := json.Marshal(configs)

--- a/internal/proxy/http_req_impl.go
+++ b/internal/proxy/http_req_impl.go
@@ -75,9 +75,9 @@ func hideSensitive(configs map[string]string) {
 }
 
 func getConfigs(configFunc func() map[string]string) gin.HandlerFunc {
-	configs := configFunc()
-	hideSensitive(configs)
 	return func(c *gin.Context) {
+		configs := configFunc()
+		hideSensitive(configs)
 		bs, err := json.Marshal(configs)
 		if err != nil {
 			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{

--- a/internal/proxy/http_req_impl_test.go
+++ b/internal/proxy/http_req_impl_test.go
@@ -65,17 +65,27 @@ func TestHideSensitive(t *testing.T) {
 	}
 }
 
-func TestGetConfigs(t *testing.T) {
+func TestGetUpdatedConfigs(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 
 	configs := map[string]string{"key": "value"}
-	handler := getConfigs(configs)
+	handler := getConfigs(func() map[string]string { return configs })
 	handler(c)
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Contains(t, w.Body.String(), "key")
 	assert.Contains(t, w.Body.String(), "value")
+	
+	configs["key"] = "value2"
+	configs["new_key"] = "new_value"
+	handler(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "key")
+	assert.Contains(t, w.Body.String(), "value2")
+	assert.Contains(t, w.Body.String(), "new_key")
+	assert.Contains(t, w.Body.String(), "new_value")
 }
 
 func TestGetClusterInfo(t *testing.T) {

--- a/internal/proxy/http_req_impl_test.go
+++ b/internal/proxy/http_req_impl_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"golang.org/x/exp/maps"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
@@ -70,13 +71,13 @@ func TestGetUpdatedConfigs(t *testing.T) {
 	c, _ := gin.CreateTestContext(w)
 
 	configs := map[string]string{"key": "value"}
-	handler := getConfigs(func() map[string]string { return configs })
+	handler := getConfigs(func() map[string]string { return maps.Clone(configs) })
 	handler(c)
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Contains(t, w.Body.String(), "key")
 	assert.Contains(t, w.Body.String(), "value")
-	
+
 	configs["key"] = "value2"
 	configs["new_key"] = "new_value"
 	handler(c)

--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -6676,12 +6676,12 @@ func DeregisterSubLabel(subLabel string) {
 func (node *Proxy) RegisterRestRouter(router gin.IRouter) {
 	// Cluster request that executed by proxy
 	router.GET(http.ClusterInfoPath, getClusterInfo(node))
-	router.GET(http.ClusterConfigsPath, getConfigs(paramtable.Get().GetConfigsView()))
+	router.GET(http.ClusterConfigsPath, getConfigs(paramtable.Get().GetConfigsView))
 	router.GET(http.ClusterClientsPath, getConnectedClients)
 	router.GET(http.ClusterDependenciesPath, getDependencies)
 
 	// Hook request that executed by proxy
-	router.GET(http.HookConfigsPath, getConfigs(paramtable.GetHookParams().GetAll()))
+	router.GET(http.HookConfigsPath, getConfigs(paramtable.GetHookParams().GetAll))
 
 	// Slow query request that executed by proxy
 	router.GET(http.SlowQueryPath, getSlowQuery(node))


### PR DESCRIPTION
Signed-off-by: dragonpower beatjean1314@gmail.com
issue: https://github.com/milvus-io/milvus/issues/47659

**Summary**
This PR fixes the Proxy REST config endpoints so they return the latest configuration values instead of a potentially stale snapshot captured at router registration time.

**What changed**

Updated the shared handler to accept a config getter function (func() map[string]string) rather than a precomputed map, enabling the endpoint to serve up-to-date config values.
Wired Proxy routes to pass the getter functions for:
/_cluster/configs
/_hook/configs
Kept sensitive config masking behavior (hideSensitive) intact.
Extended unit tests to verify that subsequent requests reflect updated config values.