### PR TITLE
enhance: refactor WithClusterLevelBroadcast to use external channel list and add FlushAll integration test (#47647)

### DIFF
--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -36,7 +36,6 @@ import (
 	"github.com/milvus-io/milvus/internal/metastore/kv/binlog"
 	"github.com/milvus-io/milvus/internal/metastore/model"
 	"github.com/milvus-io/milvus/internal/storage"
-	"github.com/milvus-io/milvus/internal/streamingcoord/server/balancer/balance"
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/balancer/channel"
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/broadcaster/broadcast"
 	"github.com/milvus-io/milvus/internal/util/componentutil"
@@ -195,35 +194,11 @@ func (s *Server) FlushAll(ctx context.Context, req *datapb.FlushAllRequest) (*da
 	}
 	defer broadcaster.Close()
 
-	// Get broadcast pchannels
-	balancer, err := balance.GetWithContext(ctx)
-	if err != nil {
-		return &datapb.FlushAllResponse{
-			Status: merr.Status(err),
-		}, nil
-	}
-	latestAssignment, err := balancer.GetLatestChannelAssignment()
-	if err != nil {
-		return &datapb.FlushAllResponse{
-			Status: merr.Status(err),
-		}, nil
-	}
-	controlChannel := streaming.WAL().ControlChannel()
-	pchannels := lo.MapToSlice(latestAssignment.PChannelView.Channels, func(_ channel.ChannelID, channel *channel.PChannelMeta) string {
-		return channel.Name()
-	})
-	broadcastPChannels := lo.Map(pchannels, func(pchannel string, _ int) string {
-		if funcutil.IsOnPhysicalChannel(controlChannel, pchannel) {
-			// return control channel if the control channel is on the pchannel.
-			return controlChannel
-		}
-		return pchannel
-	})
-
+	cc := channel.GetClusterChannels()
 	broadcastFlushAllMsg := message.NewFlushAllMessageBuilderV2().
 		WithHeader(&message.FlushAllMessageHeader{}).
 		WithBody(&message.FlushAllMessageBody{}).
-		WithBroadcast(broadcastPChannels).
+		WithClusterLevelBroadcast(cc).
 		MustBuildBroadcast()
 	res, err := broadcaster.Broadcast(ctx, broadcastFlushAllMsg)
 	if err != nil {
@@ -238,20 +213,20 @@ func (s *Server) FlushAll(ctx context.Context, req *datapb.FlushAllRequest) (*da
 	for _, msg := range msgs {
 		appendResult := res.GetAppendResult(msg.VChannel())
 		// if is control channel, convert it to physical channel.
-		channel := funcutil.ToPhysicalChannel(msg.VChannel())
-		flushAllMsgs[channel] = msg.WithTimeTick(appendResult.TimeTick).
+		pchannel := msg.PChannel()
+		flushAllMsgs[pchannel] = msg.WithTimeTick(appendResult.TimeTick).
 			WithLastConfirmed(appendResult.LastConfirmedMessageID).
 			IntoImmutableMessage(appendResult.MessageID).
 			IntoImmutableMessageProto()
 	}
-	log.Ctx(ctx).Info("FlushAll successfully", zap.Strings("broadcastedPChannels", broadcastPChannels), log.FieldMessages(msgs))
+	log.Ctx(ctx).Info("FlushAll successfully", log.FieldMessages(msgs))
 	return &datapb.FlushAllResponse{
 		Status:       merr.Success(),
 		FlushAllMsgs: flushAllMsgs,
 		ClusterInfo: &milvuspb.ClusterInfo{
 			ClusterId: Params.CommonCfg.ClusterID.GetValue(),
-			Cchannel:  controlChannel,
-			Pchannels: pchannels,
+			Cchannel:  cc.ControlChannel,
+			Pchannels: cc.Channels,
 		},
 	}, nil
 }

--- a/internal/datacoord/services_test.go
+++ b/internal/datacoord/services_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/milvus-io/milvus/internal/coordinator/snmanager"
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
 	"github.com/milvus-io/milvus/internal/datacoord/broker"
-	"github.com/milvus-io/milvus/internal/distributed/streaming"
 	etcdkv "github.com/milvus-io/milvus/internal/kv/etcd"
 	"github.com/milvus-io/milvus/internal/metastore/mocks"
 	"github.com/milvus-io/milvus/internal/metastore/model"
@@ -2118,10 +2117,12 @@ func TestServer_FlushAll(t *testing.T) {
 		server := createTestFlushAllServer()
 		server.handler = NewNMockHandler(t)
 
-		// Mock WAL
-		wal := mock_streaming.NewMockWALAccesser(t)
-		wal.EXPECT().ControlChannel().Return(funcutil.GetControlChannel("by-dev-rootcoord-dml_0")).Maybe()
-		streaming.SetWALForTest(wal)
+		// Mock channel.GetClusterChannels
+		mockGetClusterChannels := mockey.Mock(channel.GetClusterChannels).Return(message.ClusterChannels{
+			Channels:       []string{"by-dev-rootcoord-dml_0", "by-dev-rootcoord-dml_1"},
+			ControlChannel: funcutil.GetControlChannel("by-dev-rootcoord-dml_0"),
+		}).Build()
+		defer mockGetClusterChannels.UnPatch()
 
 		// Mock broadcaster
 		bapi := mock_broadcaster.NewMockBroadcastAPI(t)
@@ -2158,23 +2159,6 @@ func TestServer_FlushAll(t *testing.T) {
 		mb.EXPECT().Close().Return().Maybe()
 		broadcast.ResetBroadcaster()
 		broadcast.Register(mb)
-
-		// Register mock balancer
-		snmanager.ResetStreamingNodeManager()
-		b := mock_balancer.NewMockBalancer(t)
-		b.EXPECT().WatchChannelAssignments(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, callback balancer.WatchChannelAssignmentsCallback) error {
-			<-ctx.Done()
-			return ctx.Err()
-		}).Maybe()
-		b.EXPECT().GetLatestChannelAssignment().Return(&balancer.WatchChannelAssignmentsCallbackParam{
-			PChannelView: &channel.PChannelView{
-				Channels: map[channel.ChannelID]*channel.PChannelMeta{
-					{Name: "by-dev-1"}: channel.NewPChannelMeta("by-dev-1", types2.AccessModeRW),
-				},
-			},
-		}, nil)
-		b.EXPECT().WaitUntilWALbasedDDLReady(mock.Anything).Return(nil)
-		balance.Register(b)
 
 		req := &datapb.FlushAllRequest{}
 		resp, err := server.FlushAll(context.Background(), req)

--- a/internal/distributed/streaming/append.go
+++ b/internal/distributed/streaming/append.go
@@ -6,13 +6,11 @@ import (
 	"github.com/milvus-io/milvus/internal/distributed/streaming/internal/producer"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/types"
-	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
 )
 
 // appendToWAL appends the message to the wal.
 func (w *walAccesserImpl) appendToWAL(ctx context.Context, msg message.MutableMessage) (*types.AppendResult, error) {
-	pchannel := funcutil.ToPhysicalChannel(msg.VChannel())
-	p := w.getProducer(pchannel)
+	p := w.getProducer(msg.PChannel())
 	return p.Produce(ctx, msg)
 }
 

--- a/internal/streamingcoord/server/balancer/channel/manager_test.go
+++ b/internal/streamingcoord/server/balancer/channel/manager_test.go
@@ -64,6 +64,14 @@ func TestChannelManager(t *testing.T) {
 	assert.NotNil(t, m)
 	assert.NoError(t, err)
 
+	// Test getClusterChannels and singleton GetClusterChannels.
+	cc := m.getClusterChannels()
+	assert.Equal(t, []string{"test-channel"}, cc.Channels)
+	assert.NotEmpty(t, cc.ControlChannel)
+	assert.True(t, strings.HasPrefix(cc.ControlChannel, "test"))
+	singletonCC := GetClusterChannels()
+	assert.Equal(t, cc, singletonCC)
+
 	// Test update non exist pchannel
 	modified, err := m.AssignPChannels(ctx, map[ChannelID]types.PChannelInfoAssigned{newChannelID("non-exist-channel"): {
 		Channel: types.PChannelInfo{

--- a/internal/streamingcoord/server/balancer/channel/singleton.go
+++ b/internal/streamingcoord/server/balancer/channel/singleton.go
@@ -1,0 +1,19 @@
+package channel
+
+import (
+	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v2/util/syncutil"
+)
+
+var singleton = syncutil.NewFuture[*ChannelManager]()
+
+// Register sets the global ChannelManager singleton.
+func register(cm *ChannelManager) {
+	singleton.Set(cm)
+}
+
+// GetClusterChannels blocks until the ChannelManager is registered,
+// then returns the cluster channel topology.
+func GetClusterChannels() message.ClusterChannels {
+	return singleton.Get().getClusterChannels()
+}

--- a/internal/streamingcoord/server/balancer/channel/test_utility.go
+++ b/internal/streamingcoord/server/balancer/channel/test_utility.go
@@ -7,4 +7,5 @@ import "github.com/milvus-io/milvus/pkg/v2/util/syncutil"
 
 func ResetStaticPChannelStatsManager() {
 	StaticPChannelStatsManager = syncutil.NewFuture[*PchannelStatsManager]()
+	singleton = syncutil.NewFuture[*ChannelManager]()
 }

--- a/internal/streamingcoord/server/service/assignment.go
+++ b/internal/streamingcoord/server/service/assignment.go
@@ -5,12 +5,10 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/samber/lo"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
-	"github.com/milvus-io/milvus/internal/distributed/streaming"
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/balancer"
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/balancer/balance"
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/balancer/channel"
@@ -21,7 +19,6 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/metrics"
 	"github.com/milvus-io/milvus/pkg/v2/proto/streamingpb"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
-	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/replicateutil"
 )
@@ -145,23 +142,13 @@ func (s *assignmentServiceImpl) validateReplicateConfiguration(ctx context.Conte
 		return nil, errReplicateConfigurationSame
 	}
 
-	controlChannel := streaming.WAL().ControlChannel()
-	pchannels := lo.MapToSlice(latestAssignment.PChannelView.Channels, func(_ channel.ChannelID, channel *channel.PChannelMeta) string {
-		return channel.Name()
-	})
-	broadcastPChannels := lo.Map(pchannels, func(pchannel string, _ int) string {
-		if funcutil.IsOnPhysicalChannel(controlChannel, pchannel) {
-			// return control channel if the control channel is on the pchannel.
-			return controlChannel
-		}
-		return pchannel
-	})
+	cc := channel.GetClusterChannels()
 
 	// validate the configuration itself
 	currentClusterID := paramtable.Get().CommonCfg.ClusterPrefix.GetValue()
 	currentConfig := latestAssignment.ReplicateConfiguration
 	incomingConfig := config
-	validator := replicateutil.NewReplicateConfigValidator(incomingConfig, currentConfig, currentClusterID, pchannels)
+	validator := replicateutil.NewReplicateConfigValidator(incomingConfig, currentConfig, currentClusterID, cc.Channels)
 	if err := validator.Validate(); err != nil {
 		log.Ctx(ctx).Warn("UpdateReplicateConfiguration fail", zap.Error(err))
 		return nil, err
@@ -176,7 +163,7 @@ func (s *assignmentServiceImpl) validateReplicateConfiguration(ctx context.Conte
 			ReplicateConfiguration: config,
 		}).
 		WithBody(&message.AlterReplicateConfigMessageBody{}).
-		WithBroadcast(broadcastPChannels).
+		WithClusterLevelBroadcast(cc).
 		MustBuildBroadcast()
 	return b, nil
 }

--- a/internal/streamingnode/server/flusher/flusherimpl/flusher_components.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/flusher_components.go
@@ -114,7 +114,7 @@ func (impl *flusherComponents) WhenDropCollection(vchannel string) {
 // HandleMessage handles the plain message.
 func (impl *flusherComponents) HandleMessage(ctx context.Context, msg message.ImmutableMessage) error {
 	vchannel := msg.VChannel()
-	if vchannel == "" || msg.MessageType().IsBroadcastToAll() {
+	if vchannel == "" || msg.IsPChannelLevel() || funcutil.IsPhysicalChannel(vchannel) {
 		return impl.broadcastToAllDataSyncService(ctx, msg)
 	}
 	if _, ok := impl.dataServices[vchannel]; !ok {

--- a/internal/streamingnode/server/flusher/flusherimpl/wal_flusher.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/wal_flusher.go
@@ -244,8 +244,8 @@ func (impl *WALFlusherImpl) dispatch(msg message.ImmutableMessage) (err error) {
 		}()
 	}
 
-	// wal flusher will not handle the control channel message.
-	if funcutil.IsControlChannel(msg.VChannel()) && !msg.MessageType().IsBroadcastToAll() {
+	// wal flusher will not handle the control channel message unless it's a pchannel-level message.
+	if funcutil.IsControlChannel(msg.VChannel()) && !msg.IsPChannelLevel() {
 		return nil
 	}
 

--- a/internal/streamingnode/server/wal/interceptors/lock/lock_interceptor.go
+++ b/internal/streamingnode/server/wal/interceptors/lock/lock_interceptor.go
@@ -30,7 +30,7 @@ func (r *lockAppendInterceptor) acquireLockGuard(_ context.Context, msg message.
 	// Acquire the write lock for the vchannel.
 	vchannel := msg.VChannel()
 	if msg.MessageType().IsExclusiveRequired() {
-		if vchannel == "" || vchannel == r.channel.Name {
+		if vchannel == "" || vchannel == r.channel.Name || msg.IsPChannelLevel() {
 			r.glock.Lock()
 			return func() {
 				// fail all transactions at all vchannels.

--- a/internal/streamingnode/server/wal/interceptors/lock/lock_interceptor_test.go
+++ b/internal/streamingnode/server/wal/interceptors/lock/lock_interceptor_test.go
@@ -1,0 +1,104 @@
+package lock
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bytedance/mockey"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/txn"
+	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v2/streaming/util/types"
+	"github.com/milvus-io/milvus/pkg/v2/util/lock"
+)
+
+// TestAcquireLockGuard_PChannelLevelMessage tests that pchannel-level messages
+// acquire the glock (global write lock) even when their VChannel is a control channel name
+// that doesn't match the pchannel name directly.
+func TestAcquireLockGuard_PChannelLevelMessage(t *testing.T) {
+	mock := mockey.Mock((*txn.TxnManager).FailTxnAtVChannel).Return().Build()
+	defer mock.UnPatch()
+
+	interceptor := &lockAppendInterceptor{
+		channel:        types.PChannelInfo{Name: "pchannel1"},
+		glock:          sync.RWMutex{},
+		vchannelLocker: lock.NewKeyLock[string](),
+		txnManager:     &txn.TxnManager{},
+	}
+
+	// Create a FlushAll message that is pchannel-level.
+	// Its VChannel will be a control channel name like "pchannel1_cchannel",
+	// which is different from the pchannel name "pchannel1".
+	msg := message.NewFlushAllMessageBuilderV2().
+		WithHeader(&message.FlushAllMessageHeader{}).
+		WithBody(&message.FlushAllMessageBody{}).
+		WithVChannel("pchannel1_cchannel"). // control channel on this pchannel
+		MustBuildMutable()
+
+	// Manually set the pchannel-level property to simulate what
+	// WithClusterLevelBroadcast does after SplitIntoMutableMessage.
+	msg.Properties().(message.Properties).Set("_pcl", "")
+
+	// This message's VChannel is "pchannel1_cchannel" which is != "" and != "pchannel1".
+	// Without the IsPChannelLevel() fix, it would acquire per-vchannel lock instead of glock.
+	// With the fix, it should acquire glock.
+	guard := interceptor.acquireLockGuard(context.Background(), msg)
+
+	// Verify glock is held (write lock) by trying to RLock it - should block.
+	glockHeld := make(chan bool, 1)
+	go func() {
+		done := make(chan struct{})
+		go func() {
+			interceptor.glock.RLock()
+			close(done)
+			interceptor.glock.RUnlock()
+		}()
+		// Give the RLock goroutine time to attempt the lock.
+		time.Sleep(10 * time.Millisecond)
+		select {
+		case <-done:
+			glockHeld <- false // glock was not write-locked
+		default:
+			glockHeld <- true // glock is write-locked (RLock blocked)
+		}
+	}()
+
+	assert.True(t, <-glockHeld, "glock should be write-locked for pchannel-level message")
+	guard()
+}
+
+// TestAcquireLockGuard_RegularExclusiveMessage tests that regular exclusive messages
+// with a specific VChannel acquire per-vchannel lock, not glock.
+func TestAcquireLockGuard_RegularExclusiveMessage(t *testing.T) {
+	mock := mockey.Mock((*txn.TxnManager).FailTxnAtVChannel).Return().Build()
+	defer mock.UnPatch()
+
+	interceptor := &lockAppendInterceptor{
+		channel:        types.PChannelInfo{Name: "pchannel1"},
+		glock:          sync.RWMutex{},
+		vchannelLocker: lock.NewKeyLock[string](),
+		txnManager:     &txn.TxnManager{},
+	}
+
+	msg := message.NewFlushAllMessageBuilderV2().
+		WithHeader(&message.FlushAllMessageHeader{}).
+		WithBody(&message.FlushAllMessageBody{}).
+		WithVChannel("pchannel1_vchannel1").
+		MustBuildMutable()
+
+	// This is a regular exclusive message (not pchannel-level).
+	// It should acquire per-vchannel lock, not glock.
+	assert.False(t, msg.IsPChannelLevel())
+
+	guard := interceptor.acquireLockGuard(context.Background(), msg)
+
+	// glock should not be write-locked (should be able to RLock it).
+	interceptor.glock.RLock()
+	assert.False(t, msg.IsPChannelLevel())
+	interceptor.glock.RUnlock()
+
+	guard()
+}

--- a/internal/streamingnode/server/wal/interceptors/shard/shard_interceptor.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/shard_interceptor.go
@@ -57,7 +57,7 @@ func (impl *shardInterceptor) Name() string {
 // DoAppend assigns segment for every partition in the message.
 func (impl *shardInterceptor) DoAppend(ctx context.Context, msg message.MutableMessage, appendOp interceptors.Append) (msgID message.MessageID, err error) {
 	op, ok := impl.ops[msg.MessageType()]
-	if ok && (!funcutil.IsControlChannel(msg.VChannel()) || msg.MessageType().IsBroadcastToAll()) {
+	if ok && (!funcutil.IsControlChannel(msg.VChannel()) || msg.IsPChannelLevel()) {
 		// If the message type is registered in the interceptor, use the registered operation.
 		// control channel message is only used to determine the DDL/DCL order,
 		// perform no effect on the shard manager, so skip it.

--- a/internal/streamingnode/server/wal/recovery/recovery_storage_impl.go
+++ b/internal/streamingnode/server/wal/recovery/recovery_storage_impl.go
@@ -287,13 +287,13 @@ func (r *recoveryStorageImpl) updateCheckpoint(msg message.ImmutableMessage) {
 
 // The incoming message id is always sorted with timetick.
 func (r *recoveryStorageImpl) handleMessage(msg message.ImmutableMessage) {
-	if funcutil.IsControlChannel(msg.VChannel()) && msg.MessageType() != message.MessageTypeAlterReplicateConfig {
-		// message on control channel except AlterReplicateConfig message is just used to determine the DDL/DCL order,
+	if funcutil.IsControlChannel(msg.VChannel()) && !msg.IsPChannelLevel() {
+		// message on control channel except pchannel-level messages is just used to determine the DDL/DCL order,
 		// will not affect the recovery storage, so skip it.
 		return
 	}
 
-	if msg.VChannel() != "" && msg.MessageType() != message.MessageTypeCreateCollection &&
+	if msg.VChannel() != "" && !msg.IsPChannelLevel() && msg.MessageType() != message.MessageTypeCreateCollection &&
 		msg.MessageType() != message.MessageTypeDropCollection && r.vchannels[msg.VChannel()] == nil && !funcutil.IsControlChannel(msg.VChannel()) {
 		r.detectInconsistency(msg, "vchannel not found")
 	}

--- a/pkg/mocks/streaming/util/mock_message/mock_BroadcastMutableMessage.go
+++ b/pkg/mocks/streaming/util/mock_message/mock_BroadcastMutableMessage.go
@@ -208,6 +208,51 @@ func (_c *MockBroadcastMutableMessage_IntoMessageProto_Call) RunAndReturn(run fu
 	return _c
 }
 
+// IsPChannelLevel provides a mock function with no fields
+func (_m *MockBroadcastMutableMessage) IsPChannelLevel() bool {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsPChannelLevel")
+	}
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
+// MockBroadcastMutableMessage_IsPChannelLevel_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsPChannelLevel'
+type MockBroadcastMutableMessage_IsPChannelLevel_Call struct {
+	*mock.Call
+}
+
+// IsPChannelLevel is a helper method to define mock.On call
+func (_e *MockBroadcastMutableMessage_Expecter) IsPChannelLevel() *MockBroadcastMutableMessage_IsPChannelLevel_Call {
+	return &MockBroadcastMutableMessage_IsPChannelLevel_Call{Call: _e.mock.On("IsPChannelLevel")}
+}
+
+func (_c *MockBroadcastMutableMessage_IsPChannelLevel_Call) Run(run func()) *MockBroadcastMutableMessage_IsPChannelLevel_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockBroadcastMutableMessage_IsPChannelLevel_Call) Return(_a0 bool) *MockBroadcastMutableMessage_IsPChannelLevel_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockBroadcastMutableMessage_IsPChannelLevel_Call) RunAndReturn(run func() bool) *MockBroadcastMutableMessage_IsPChannelLevel_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // IsPersisted provides a mock function with no fields
 func (_m *MockBroadcastMutableMessage) IsPersisted() bool {
 	ret := _m.Called()

--- a/pkg/mocks/streaming/util/mock_message/mock_ImmutableMessage.go
+++ b/pkg/mocks/streaming/util/mock_message/mock_ImmutableMessage.go
@@ -304,6 +304,51 @@ func (_c *MockImmutableMessage_IntoMessageProto_Call) RunAndReturn(run func() *m
 	return _c
 }
 
+// IsPChannelLevel provides a mock function with no fields
+func (_m *MockImmutableMessage) IsPChannelLevel() bool {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsPChannelLevel")
+	}
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
+// MockImmutableMessage_IsPChannelLevel_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsPChannelLevel'
+type MockImmutableMessage_IsPChannelLevel_Call struct {
+	*mock.Call
+}
+
+// IsPChannelLevel is a helper method to define mock.On call
+func (_e *MockImmutableMessage_Expecter) IsPChannelLevel() *MockImmutableMessage_IsPChannelLevel_Call {
+	return &MockImmutableMessage_IsPChannelLevel_Call{Call: _e.mock.On("IsPChannelLevel")}
+}
+
+func (_c *MockImmutableMessage_IsPChannelLevel_Call) Run(run func()) *MockImmutableMessage_IsPChannelLevel_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockImmutableMessage_IsPChannelLevel_Call) Return(_a0 bool) *MockImmutableMessage_IsPChannelLevel_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockImmutableMessage_IsPChannelLevel_Call) RunAndReturn(run func() bool) *MockImmutableMessage_IsPChannelLevel_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // IsPersisted provides a mock function with no fields
 func (_m *MockImmutableMessage) IsPersisted() bool {
 	ret := _m.Called()
@@ -575,6 +620,51 @@ func (_c *MockImmutableMessage_MessageTypeWithVersion_Call) Return(_a0 message.M
 }
 
 func (_c *MockImmutableMessage_MessageTypeWithVersion_Call) RunAndReturn(run func() message.MessageTypeWithVersion) *MockImmutableMessage_MessageTypeWithVersion_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// PChannel provides a mock function with no fields
+func (_m *MockImmutableMessage) PChannel() string {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for PChannel")
+	}
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// MockImmutableMessage_PChannel_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PChannel'
+type MockImmutableMessage_PChannel_Call struct {
+	*mock.Call
+}
+
+// PChannel is a helper method to define mock.On call
+func (_e *MockImmutableMessage_Expecter) PChannel() *MockImmutableMessage_PChannel_Call {
+	return &MockImmutableMessage_PChannel_Call{Call: _e.mock.On("PChannel")}
+}
+
+func (_c *MockImmutableMessage_PChannel_Call) Run(run func()) *MockImmutableMessage_PChannel_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockImmutableMessage_PChannel_Call) Return(_a0 string) *MockImmutableMessage_PChannel_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockImmutableMessage_PChannel_Call) RunAndReturn(run func() string) *MockImmutableMessage_PChannel_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/mocks/streaming/util/mock_message/mock_ImmutableTxnMessage.go
+++ b/pkg/mocks/streaming/util/mock_message/mock_ImmutableTxnMessage.go
@@ -398,6 +398,51 @@ func (_c *MockImmutableTxnMessage_IntoMessageProto_Call) RunAndReturn(run func()
 	return _c
 }
 
+// IsPChannelLevel provides a mock function with no fields
+func (_m *MockImmutableTxnMessage) IsPChannelLevel() bool {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsPChannelLevel")
+	}
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
+// MockImmutableTxnMessage_IsPChannelLevel_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsPChannelLevel'
+type MockImmutableTxnMessage_IsPChannelLevel_Call struct {
+	*mock.Call
+}
+
+// IsPChannelLevel is a helper method to define mock.On call
+func (_e *MockImmutableTxnMessage_Expecter) IsPChannelLevel() *MockImmutableTxnMessage_IsPChannelLevel_Call {
+	return &MockImmutableTxnMessage_IsPChannelLevel_Call{Call: _e.mock.On("IsPChannelLevel")}
+}
+
+func (_c *MockImmutableTxnMessage_IsPChannelLevel_Call) Run(run func()) *MockImmutableTxnMessage_IsPChannelLevel_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockImmutableTxnMessage_IsPChannelLevel_Call) Return(_a0 bool) *MockImmutableTxnMessage_IsPChannelLevel_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockImmutableTxnMessage_IsPChannelLevel_Call) RunAndReturn(run func() bool) *MockImmutableTxnMessage_IsPChannelLevel_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // IsPersisted provides a mock function with no fields
 func (_m *MockImmutableTxnMessage) IsPersisted() bool {
 	ret := _m.Called()
@@ -669,6 +714,51 @@ func (_c *MockImmutableTxnMessage_MessageTypeWithVersion_Call) Return(_a0 messag
 }
 
 func (_c *MockImmutableTxnMessage_MessageTypeWithVersion_Call) RunAndReturn(run func() message.MessageTypeWithVersion) *MockImmutableTxnMessage_MessageTypeWithVersion_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// PChannel provides a mock function with no fields
+func (_m *MockImmutableTxnMessage) PChannel() string {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for PChannel")
+	}
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// MockImmutableTxnMessage_PChannel_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PChannel'
+type MockImmutableTxnMessage_PChannel_Call struct {
+	*mock.Call
+}
+
+// PChannel is a helper method to define mock.On call
+func (_e *MockImmutableTxnMessage_Expecter) PChannel() *MockImmutableTxnMessage_PChannel_Call {
+	return &MockImmutableTxnMessage_PChannel_Call{Call: _e.mock.On("PChannel")}
+}
+
+func (_c *MockImmutableTxnMessage_PChannel_Call) Run(run func()) *MockImmutableTxnMessage_PChannel_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockImmutableTxnMessage_PChannel_Call) Return(_a0 string) *MockImmutableTxnMessage_PChannel_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockImmutableTxnMessage_PChannel_Call) RunAndReturn(run func() string) *MockImmutableTxnMessage_PChannel_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/mocks/streaming/util/mock_message/mock_MutableMessage.go
+++ b/pkg/mocks/streaming/util/mock_message/mock_MutableMessage.go
@@ -256,6 +256,51 @@ func (_c *MockMutableMessage_IntoMessageProto_Call) RunAndReturn(run func() *mes
 	return _c
 }
 
+// IsPChannelLevel provides a mock function with no fields
+func (_m *MockMutableMessage) IsPChannelLevel() bool {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsPChannelLevel")
+	}
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
+// MockMutableMessage_IsPChannelLevel_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsPChannelLevel'
+type MockMutableMessage_IsPChannelLevel_Call struct {
+	*mock.Call
+}
+
+// IsPChannelLevel is a helper method to define mock.On call
+func (_e *MockMutableMessage_Expecter) IsPChannelLevel() *MockMutableMessage_IsPChannelLevel_Call {
+	return &MockMutableMessage_IsPChannelLevel_Call{Call: _e.mock.On("IsPChannelLevel")}
+}
+
+func (_c *MockMutableMessage_IsPChannelLevel_Call) Run(run func()) *MockMutableMessage_IsPChannelLevel_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockMutableMessage_IsPChannelLevel_Call) Return(_a0 bool) *MockMutableMessage_IsPChannelLevel_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockMutableMessage_IsPChannelLevel_Call) RunAndReturn(run func() bool) *MockMutableMessage_IsPChannelLevel_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // IsPersisted provides a mock function with no fields
 func (_m *MockMutableMessage) IsPersisted() bool {
 	ret := _m.Called()
@@ -433,6 +478,51 @@ func (_c *MockMutableMessage_MessageTypeWithVersion_Call) Return(_a0 message.Mes
 }
 
 func (_c *MockMutableMessage_MessageTypeWithVersion_Call) RunAndReturn(run func() message.MessageTypeWithVersion) *MockMutableMessage_MessageTypeWithVersion_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// PChannel provides a mock function with no fields
+func (_m *MockMutableMessage) PChannel() string {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for PChannel")
+	}
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// MockMutableMessage_PChannel_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PChannel'
+type MockMutableMessage_PChannel_Call struct {
+	*mock.Call
+}
+
+// PChannel is a helper method to define mock.On call
+func (_e *MockMutableMessage_Expecter) PChannel() *MockMutableMessage_PChannel_Call {
+	return &MockMutableMessage_PChannel_Call{Call: _e.mock.On("PChannel")}
+}
+
+func (_c *MockMutableMessage_PChannel_Call) Run(run func()) *MockMutableMessage_PChannel_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockMutableMessage_PChannel_Call) Return(_a0 string) *MockMutableMessage_PChannel_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockMutableMessage_PChannel_Call) RunAndReturn(run func() string) *MockMutableMessage_PChannel_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/streaming/util/message/cluster_broadcast.go
+++ b/pkg/streaming/util/message/cluster_broadcast.go
@@ -1,0 +1,12 @@
+package message
+
+// ClusterChannels describes the physical channel topology of the cluster.
+// Channels is the raw pchannel name list.
+// ControlChannel is the control channel name (e.g. "pchannel0_vcchan").
+//
+// WithClusterLevelBroadcast uses this to build the broadcast channel list,
+// substituting the control channel for the pchannel it resides on.
+type ClusterChannels struct {
+	Channels       []string
+	ControlChannel string
+}

--- a/pkg/streaming/util/message/cluster_broadcast_test.go
+++ b/pkg/streaming/util/message/cluster_broadcast_test.go
@@ -1,0 +1,148 @@
+package message
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithClusterLevelBroadcast(t *testing.T) {
+	cc := ClusterChannels{
+		Channels:       []string{"pchannel1", "pchannel2"},
+		ControlChannel: "pchannel1_vcchan",
+	}
+
+	msg := NewFlushAllMessageBuilderV2().
+		WithHeader(&FlushAllMessageHeader{}).
+		WithBody(&FlushAllMessageBody{}).
+		WithClusterLevelBroadcast(cc).
+		MustBuildBroadcast()
+
+	// The message should be marked as pchannel-level.
+	assert.True(t, msg.IsPChannelLevel())
+
+	// The broadcast header should contain control channel substituted for pchannel1.
+	bh := msg.BroadcastHeader()
+	assert.NotNil(t, bh)
+	assert.ElementsMatch(t, []string{"pchannel1_vcchan", "pchannel2"}, bh.VChannels)
+
+	// Split should produce messages each marked as pchannel-level.
+	msg.WithBroadcastID(1)
+	splitMsgs := msg.SplitIntoMutableMessage()
+	assert.Len(t, splitMsgs, 2)
+	for _, sm := range splitMsgs {
+		assert.True(t, sm.IsPChannelLevel())
+	}
+}
+
+func TestWithClusterLevelBroadcastPanics(t *testing.T) {
+	t.Run("EmptyChannels", func(t *testing.T) {
+		assert.Panics(t, func() {
+			NewFlushAllMessageBuilderV2().
+				WithHeader(&FlushAllMessageHeader{}).
+				WithBody(&FlushAllMessageBody{}).
+				WithClusterLevelBroadcast(ClusterChannels{
+					ControlChannel: "pchannel1_vcchan",
+				}).
+				MustBuildBroadcast()
+		})
+	})
+
+	t.Run("EmptyControlChannel", func(t *testing.T) {
+		assert.Panics(t, func() {
+			NewFlushAllMessageBuilderV2().
+				WithHeader(&FlushAllMessageHeader{}).
+				WithBody(&FlushAllMessageBody{}).
+				WithClusterLevelBroadcast(ClusterChannels{
+					Channels: []string{"pchannel1"},
+				}).
+				MustBuildBroadcast()
+		})
+	})
+
+	t.Run("NonPChannelInChannels", func(t *testing.T) {
+		assert.Panics(t, func() {
+			NewFlushAllMessageBuilderV2().
+				WithHeader(&FlushAllMessageHeader{}).
+				WithBody(&FlushAllMessageBody{}).
+				WithClusterLevelBroadcast(ClusterChannels{
+					Channels:       []string{"pchannel1", "pchannel2_100v0"},
+					ControlChannel: "pchannel1_vcchan",
+				}).
+				MustBuildBroadcast()
+		})
+	})
+
+	t.Run("ControlChannelNotOnAnyPChannel", func(t *testing.T) {
+		assert.Panics(t, func() {
+			NewFlushAllMessageBuilderV2().
+				WithHeader(&FlushAllMessageHeader{}).
+				WithBody(&FlushAllMessageBody{}).
+				WithClusterLevelBroadcast(ClusterChannels{
+					Channels:       []string{"pchannel1", "pchannel2"},
+					ControlChannel: "pchannel3_vcchan",
+				}).
+				MustBuildBroadcast()
+		})
+	})
+}
+
+func TestPChannel(t *testing.T) {
+	t.Run("WithVChannel", func(t *testing.T) {
+		msg := &messageImpl{
+			payload: []byte("test"),
+			properties: propertiesImpl{
+				messageVChannel: "pchannel1_v0",
+			},
+		}
+		assert.Equal(t, "pchannel1", msg.PChannel())
+	})
+
+	t.Run("EmptyVChannel", func(t *testing.T) {
+		msg := &messageImpl{
+			payload:    []byte("test"),
+			properties: propertiesImpl{},
+		}
+		assert.Equal(t, "", msg.PChannel())
+	})
+
+	t.Run("SplitBroadcastMessages", func(t *testing.T) {
+		cc := ClusterChannels{
+			Channels:       []string{"pchannel1", "pchannel2"},
+			ControlChannel: "pchannel1_vcchan",
+		}
+		msg := NewFlushAllMessageBuilderV2().
+			WithHeader(&FlushAllMessageHeader{}).
+			WithBody(&FlushAllMessageBody{}).
+			WithClusterLevelBroadcast(cc).
+			MustBuildBroadcast()
+		msg.WithBroadcastID(1)
+
+		splitMsgs := msg.SplitIntoMutableMessage()
+		pchannels := make([]string, 0, len(splitMsgs))
+		for _, sm := range splitMsgs {
+			pchannels = append(pchannels, sm.PChannel())
+		}
+		assert.ElementsMatch(t, []string{"pchannel1", "pchannel2"}, pchannels)
+	})
+}
+
+func TestIsPChannelLevel(t *testing.T) {
+	t.Run("NotPChannelLevel", func(t *testing.T) {
+		msg := &messageImpl{
+			payload:    []byte("test"),
+			properties: propertiesImpl{},
+		}
+		assert.False(t, msg.IsPChannelLevel())
+	})
+
+	t.Run("IsPChannelLevel", func(t *testing.T) {
+		msg := &messageImpl{
+			payload: []byte("test"),
+			properties: propertiesImpl{
+				messagePChannelLevel: "",
+			},
+		}
+		assert.True(t, msg.IsPChannelLevel())
+	})
+}

--- a/pkg/streaming/util/message/message.go
+++ b/pkg/streaming/util/message/message.go
@@ -67,6 +67,11 @@ type BasicMessage interface {
 	// IsPersisted returns true if the message is persisted into underlying log storage.
 	IsPersisted() bool
 
+	// IsPChannelLevel returns true if the message is a pchannel-level message.
+	// A pchannel-level message is broadcast to all pchannels and should be handled
+	// at pchannel scope rather than vchannel scope.
+	IsPChannelLevel() bool
+
 	// IntoMessageProto converts the message to a protobuf message.
 	IntoMessageProto() *messagespb.Message
 }
@@ -80,6 +85,10 @@ type MutableMessage interface {
 	// Available only when the message's version greater than 0.
 	// Return "" or Pchannel if message is can be seen by all vchannels on the pchannel.
 	VChannel() string
+
+	// PChannel returns the physical channel derived from VChannel.
+	// It strips the virtual channel suffix to return the underlying physical channel name.
+	PChannel() string
 
 	// WithBarrierTimeTick sets the barrier time tick of current message.
 	// these time tick is used to promised the message will be sent after that time tick.
@@ -156,6 +165,10 @@ type ImmutableMessage interface {
 	// Available only when the message's version greater than 0.
 	// Return "" if message is can be seen by all vchannels on the pchannel.
 	VChannel() string
+
+	// PChannel returns the physical channel derived from VChannel.
+	// It strips the virtual channel suffix to return the underlying physical channel name.
+	PChannel() string
 
 	// MessageID returns the message id of current message.
 	MessageID() MessageID

--- a/pkg/streaming/util/message/message_impl.go
+++ b/pkg/streaming/util/message/message_impl.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/messagespb"
+	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
 )
 
 type messageImpl struct {
@@ -65,6 +66,11 @@ func (m *messageImpl) Properties() RProperties {
 // IsPersisted returns true if the message is persisted.
 func (m *messageImpl) IsPersisted() bool {
 	return !m.properties.Exist(messageNotPersisteted)
+}
+
+// IsPChannelLevel returns true if the message is a pchannel-level message.
+func (m *messageImpl) IsPChannelLevel() bool {
+	return m.properties.Exist(messagePChannelLevel)
 }
 
 // IntoMessageProto converts the message to a protobuf message.
@@ -276,6 +282,11 @@ func (m *messageImpl) BarrierTimeTick() uint64 {
 		panic(fmt.Sprintf("there's a bug in the message codes, dirty barrier timetick %s in properties of message", value))
 	}
 	return tt
+}
+
+// PChannel returns the physical channel derived from VChannel.
+func (m *messageImpl) PChannel() string {
+	return funcutil.ToPhysicalChannel(m.VChannel())
 }
 
 // VChannel returns the vchannel of current message.

--- a/pkg/streaming/util/message/properties.go
+++ b/pkg/streaming/util/message/properties.go
@@ -15,6 +15,7 @@ const (
 	messageTxnContext                       = "_tx"  // transaction context.
 	messageCipherHeader                     = "_ch"  // message cipher header.
 	messageNotPersisteted                   = "_np"  // check if the message is unpersisted.
+	messagePChannelLevel                    = "_pcl" // mark the message as pchannel level message.
 	messageReplicateMesssageHeader          = "_rh"  // replicate message header.
 )
 

--- a/tests/integration/flushall/flushall_with_restart_test.go
+++ b/tests/integration/flushall/flushall_with_restart_test.go
@@ -1,0 +1,154 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flushall
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/pkg/v2/log"
+	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+	"github.com/milvus-io/milvus/pkg/v2/util/metric"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+	"github.com/milvus-io/milvus/tests/integration"
+)
+
+const dmlChannelNum = 2
+
+type FlushAllWithRestartSuite struct {
+	FlushAllSuite
+}
+
+func (s *FlushAllWithRestartSuite) SetupSuite() {
+	s.WithMilvusConfig(paramtable.Get().RootCoordCfg.DmlChannelNum.Key, "2")
+	s.WithMilvusConfig(paramtable.Get().StreamingCfg.WALBalancerPolicyMinRebalanceIntervalThreshold.Key, "1ms")
+	s.MiniClusterSuite.SetupSuite()
+}
+
+func (s *FlushAllWithRestartSuite) TestFlushAllWithStreamingNodeRestart() {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+	c := s.Cluster
+
+	const (
+		dim    = 128
+		rowNum = 1000
+	)
+
+	// Use the cluster pchannel count as shard number.
+	shardsNum := dmlChannelNum
+	collectionName := "TestFlushAllWithRestart_" + funcutil.GenRandomStr()
+
+	// Create collection with shard count equal to pchannel count.
+	schema := integration.ConstructSchema(collectionName, dim, false)
+	marshaledSchema, err := proto.Marshal(schema)
+	s.NoError(err)
+
+	createStatus, err := c.MilvusClient.CreateCollection(ctx, &milvuspb.CreateCollectionRequest{
+		CollectionName: collectionName,
+		Schema:         marshaledSchema,
+		ShardsNum:      int32(shardsNum),
+	})
+	s.NoError(merr.CheckRPCCall(createStatus, err))
+
+	// Step 1: Insert 1000 rows and FlushAll.
+	fVecColumn := integration.NewFloatVectorFieldData(integration.FloatVecField, rowNum, dim)
+	pkColumn := integration.NewInt64FieldDataWithStart(integration.Int64Field, rowNum, 0)
+	insertResult, err := c.MilvusClient.Insert(ctx, &milvuspb.InsertRequest{
+		CollectionName: collectionName,
+		FieldsData:     []*schemapb.FieldData{pkColumn, fVecColumn},
+		NumRows:        uint32(rowNum),
+	})
+	s.NoError(merr.CheckRPCCall(insertResult, err))
+
+	flushAllResp, err := c.MilvusClient.FlushAll(ctx, &milvuspb.FlushAllRequest{})
+	s.NoError(merr.CheckRPCCall(flushAllResp, err))
+	s.WaitForFlushAll(ctx, flushAllResp.GetFlushAllMsgs())
+	log.Info("first FlushAll completed")
+
+	// Step 2: Restart all streaming nodes, then insert another 1000 rows and FlushAll.
+	for _, sn := range c.GetAllStreamingNodes() {
+		sn.Stop()
+	}
+	c.AddStreamingNode()
+	log.Info("streaming node restarted")
+
+	// Wait for channel rebalance to complete after streaming node restart,
+	// then insert data with retry.
+	s.Eventually(func() bool {
+		fVecColumn2 := integration.NewFloatVectorFieldData(integration.FloatVecField, rowNum, dim)
+		pkColumn2 := integration.NewInt64FieldDataWithStart(integration.Int64Field, rowNum, int64(rowNum))
+		insertResult2, err := c.MilvusClient.Insert(ctx, &milvuspb.InsertRequest{
+			CollectionName: collectionName,
+			FieldsData:     []*schemapb.FieldData{pkColumn2, fVecColumn2},
+			NumRows:        uint32(rowNum),
+		})
+		if err != nil {
+			return false
+		}
+		return merr.Ok(insertResult2.GetStatus())
+	}, 2*time.Minute, 3*time.Second)
+
+	flushAllResp2, err := c.MilvusClient.FlushAll(ctx, &milvuspb.FlushAllRequest{})
+	s.NoError(merr.CheckRPCCall(flushAllResp2, err))
+	s.WaitForFlushAll(ctx, flushAllResp2.GetFlushAllMsgs())
+	log.Info("second FlushAll completed after streaming node restart")
+
+	// Step 3: Create index, load collection, and query count(*) to verify total is 2000.
+	createIndexStatus, err := c.MilvusClient.CreateIndex(ctx, &milvuspb.CreateIndexRequest{
+		CollectionName: collectionName,
+		FieldName:      integration.FloatVecField,
+		IndexName:      "_default",
+		ExtraParams:    integration.ConstructIndexParam(dim, integration.IndexFaissIvfFlat, metric.L2),
+	})
+	s.NoError(merr.CheckRPCCall(createIndexStatus, err))
+	s.WaitForIndexBuilt(ctx, collectionName, integration.FloatVecField)
+
+	loadStatus, err := c.MilvusClient.LoadCollection(ctx, &milvuspb.LoadCollectionRequest{
+		CollectionName: collectionName,
+	})
+	s.NoError(merr.CheckRPCCall(loadStatus, err))
+	s.WaitForLoad(ctx, collectionName)
+
+	queryResult, err := c.MilvusClient.Query(ctx, &milvuspb.QueryRequest{
+		CollectionName:   collectionName,
+		OutputFields:     []string{"count(*)"},
+		ConsistencyLevel: commonpb.ConsistencyLevel_Strong,
+	})
+	s.NoError(merr.CheckRPCCall(queryResult, err))
+	count := queryResult.GetFieldsData()[0].GetScalars().GetLongData().GetData()[0]
+	s.Equal(int64(2*rowNum), count)
+	log.Info("query count(*) verified: 2000 rows")
+
+	// Cleanup.
+	dropStatus, err := c.MilvusClient.DropCollection(ctx, &milvuspb.DropCollectionRequest{
+		CollectionName: collectionName,
+	})
+	s.NoError(merr.CheckRPCCall(dropStatus, err))
+}
+
+func TestFlushAllWithRestart(t *testing.T) {
+	suite.Run(t, new(FlushAllWithRestartSuite))
+}


### PR DESCRIPTION
issue: #47647
pr: #47656

Refactor the cluster-level broadcast mechanism to decouple the message package from the channel registration lifecycle:

- Replace internal provider pattern with opaque ClusterChannels type passed externally to WithClusterLevelBroadcast()
- Add channel package singleton (syncutil.Future) exposing GetClusterChannels() and GetPChannelNames() blocking accessors
- Add PChannel() interface to MutableMessage/ImmutableMessage for deriving physical channel from virtual channel
- Validate non-control-channel entries are physical channels using funcutil.IsPhysicalChannel and use funcutil.IsOnPhysicalChannel for control channel matching
- Move control channel substitution logic into WithClusterLevelBroadcast to simplify callers (datacoord, coordinator, assignment service)
- Add lock interceptor unit tests and cluster broadcast test coverage
- Add integration test for FlushAll with streaming node restart to verify data integrity across node lifecycle