### PR TITLE
enhance: make openssl dependency shared

### DIFF
--- a/internal/core/conanfile.py
+++ b/internal/core/conanfile.py
@@ -49,6 +49,7 @@ class MilvusConan(ConanFile):
 
     generators = ("cmake", "cmake_find_package")
     default_options = {
+        "openssl:shared": True,
         "libevent:shared": True,
         "double-conversion:shared": True,
         "folly:shared": True,


### PR DESCRIPTION
After integrating Loon FFI (#46076), segment loading switched from
  Go-side S3 downloads (Go TLS) to C++-side loading via SegmentLoad()
  (C++ AWS SDK → libcurl → OpenSSL). This exposed a latent symbol
  interposition bug between libmilvus-storage.so and librdkafka.so.1,
  both of which statically link their own copy of OpenSSL.

  Root cause:
  - libmilvus-storage.so statically links libcrypto.a, which causes
    OPENSSL_cpuid_setup to be exported as a global dynamic symbol (T).
  - librdkafka.so.1 also statically links OpenSSL and exports
    OPENSSL_cpuid_setup (T), but keeps OPENSSL_armcap_P as a local
    symbol (b).
  - libmilvus-storage.so is loaded first (NEEDED by libmilvus_core.so),
    so its OPENSSL_cpuid_setup takes precedence in the global scope.
  - When librdkafka.so.1's init code calls OPENSSL_cpuid_setup via PLT,
    the dynamic linker resolves it to libmilvus-storage.so's version,
    which writes ARM CPU capabilities to its own OPENSSL_armcap_P.
  - librdkafka.so.1's local OPENSSL_armcap_P is never initialized (=0),
    so OpenSSL thinks there is no ARMv8 Crypto Extension support.
  - All TLS decryption falls back to software AES_encrypt + gcm_ghash_4bit
    (~86% CPU), instead of hardware armv8_aes_gcm_decrypt (~33% CPU).

  Fix:
  Set "openssl:shared": True in conan default_options so that
  libmilvus-storage.so links against the shared libssl.so.3 /
  libcrypto.so.3 instead of static libssl.a / libcrypto.a.

  The shared libcrypto.so.3 properly hides OPENSSL_cpuid_setup and
  OPENSSL_armcap_P as local symbols (lowercase t/b), preventing any
  cross-library interposition. librdkafka.so.1's PLT call now resolves
  to its own OPENSSL_cpuid_setup, correctly initializing its own
  OPENSSL_armcap_P for hardware-accelerated AES-GCM.