### PR TITLE
test: [2.6] fix test_search_param_missing and bump pymilvus to 2.6.9rc3

### DIFF
--- a/tests/python_client/milvus_client_v2/test_milvus_client_search_invalid.py
+++ b/tests/python_client/milvus_client_v2/test_milvus_client_search_invalid.py
@@ -174,11 +174,9 @@ class TestCollectionSearchInvalid(TestcaseBase):
         # 2. search collection with missing parameters
         log.info("test_search_param_missing: Searching collection %s "
                  "with missing parameters" % collection_w.name)
-        try:
-            collection_w.search()
-        except TypeError as e:
-            assert "missing 4 required positional arguments: 'data', " \
-                   "'anns_field', 'param', and 'limit'" in str(e)
+        collection_w.search(check_task=CheckTasks.err_res,
+                            check_items={"err_code": 1,
+                                         "err_msg": "Either ids or data must be provided"})
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_search_param_invalid_vectors(self, get_invalid_vectors):

--- a/tests/python_client/requirements.txt
+++ b/tests/python_client/requirements.txt
@@ -28,8 +28,8 @@ pytest-parallel
 pytest-random-order
 
 # pymilvus
-pymilvus==2.6.7rc21
-pymilvus[bulk_writer]==2.6.7rc21
+pymilvus==2.6.9rc3
+pymilvus[bulk_writer]==2.6.9rc3
 # for protobuf
 protobuf>=5.29.5
 


### PR DESCRIPTION
## Summary
- **Fix `test_search_param_missing`**: The pymilvus `search()` method signature changed — parameters are no longer required positional args. Calling `search()` without args no longer raises `TypeError`, instead returns `ParamError(code=1, message="Either ids or data must be provided")`. Updated the test to use the `check_task=CheckTasks.err_res` pattern.
- **Bump pymilvus from `2.6.7rc21` to `2.6.9rc3`** (latest 2.6.x on test.pypi.org).

## Test plan
- [ ] Verify `test_search_param_missing` passes with the updated assertion
- [ ] Verify other search invalid tests are not affected
- [ ] Confirm pymilvus 2.6.9rc3 installs correctly from test.pypi.org

🤖 Generated with [Claude Code](https://claude.com/claude-code)