### PR TITLE
build tantivy as release instead of debug

### DIFF
--- a/internal/core/thirdparty/tantivy/tantivy-binding/Cargo.toml
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/Cargo.toml
@@ -15,7 +15,8 @@ lindera-cc-cedict = ["lindera/cc-cedict"]
 
 [profile.release]
 opt-level = 3
-debug = true
+debug = false
+strip = true
 lto = true
 debug-assertions = false
 codegen-units = 1


### PR DESCRIPTION
Just test the size of milvus_core.so when tantivy is compiled with debug=false. 
When debug=true, the size of milvus_core.so is 1.2GB. Normally, debug=true doesn't affect the performance of tantivy, and is friendly for debugging.