### PR TITLE
fix: use deterministic field order in ConvertToArrowSchema

### DIFF
--- a/internal/core/src/common/Schema.cpp
+++ b/internal/core/src/common/Schema.cpp
@@ -132,9 +132,9 @@ const FieldMeta FieldMeta::RowIdMeta(
 const ArrowSchemaPtr
 Schema::ConvertToArrowSchema() const {
     arrow::FieldVector arrow_fields;
-    arrow_fields.reserve(fields_.size());
-    for (const auto& field : fields_) {
-        const auto& meta = field.second;
+    arrow_fields.reserve(field_ids_.size());
+    for (const auto& field_id : field_ids_) {
+        const auto& meta = fields_.at(field_id);
         int dim = IsVectorDataType(meta.get_data_type()) &&
                           !IsSparseFloatVectorDataType(meta.get_data_type())
                       ? meta.get_dim()

--- a/internal/core/src/segcore/ChunkedSegmentSealedStorageV2Test.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedStorageV2Test.cpp
@@ -106,7 +106,7 @@ class TestChunkSegmentStorageV2 : public testing::TestWithParam<bool> {
         }
 
         std::vector<std::vector<int>> column_groups = {
-            {0, 4, 3}, {2}, {1}};  // narrow columns and wide columns
+            {0, 1, 4}, {2}, {3}};  // narrow columns and wide columns
         auto writer_memory = 16 * 1024 * 1024;
         auto storage_config = milvus_storage::StorageConfig();
 


### PR DESCRIPTION
issue: #44452

ConvertToArrowSchema iterated over fields_ (unordered_map) which produces non-deterministic column ordering. This caused StorageV2 column group loading to fail when the actual arrow schema order differed from the assumed order, resulting in fields being loaded into wrong column groups and duplicate load assertions. This caused test `TestVectorArrayStorageV2` to be flaky.

Use field_ids_ (insertion-ordered vector) instead, consistent with ToProto() which already uses field_ids_ for deterministic ordering.