### PR TITLE
security: fix use-after-free in DecodeKeyMetadata key assignment

### DIFF
--- a/internal/core/src/storage/KeyRetriever.cpp
+++ b/internal/core/src/storage/KeyRetriever.cpp
@@ -1,5 +1,6 @@
 #include "storage/KeyRetriever.h"
 
+#include <cstring>
 #include <exception>
 
 #include "PluginInterface.h"
@@ -44,7 +45,12 @@ EncodeKeyMetadata(int64_t ez_id, int64_t collection_id, std::string key) {
 
 std::shared_ptr<CPluginContext>
 DecodeKeyMetadata(std::string key_metadata) {
-    auto context = std::make_shared<CPluginContext>();
+    auto context = std::shared_ptr<CPluginContext>(
+        new CPluginContext(), [](CPluginContext* ctx) {
+            free(const_cast<char*>(ctx->key));
+            delete ctx;
+        });
+    context->key = nullptr;
     try {
         auto first_pos = key_metadata.find("_");
         if (first_pos == std::string::npos) {
@@ -59,7 +65,7 @@ DecodeKeyMetadata(std::string key_metadata) {
         context->ez_id = std::stoll(key_metadata.substr(0, first_pos));
         context->collection_id = std::stoll(
             key_metadata.substr(first_pos + 1, second_pos - (first_pos + 1)));
-        context->key = key_metadata.substr(second_pos + 1).c_str();
+        context->key = strdup(key_metadata.substr(second_pos + 1).c_str());
     } catch (const std::exception& e) {
         LOG_WARN("failed to decode key metadata, reason: {}", e.what());
         return nullptr;


### PR DESCRIPTION
*Vulnerability identified and fix provided by [Kolega.dev](https://kolega.dev/)*

## Use-After-Free in DecodeKeyMetadata String Parsing

### Location
`internal/core/src/storage/KeyRetriever.cpp:62`

### Description
`DecodeKeyMetadata()` assigns `context->key` from `.c_str()` of a temporary `std::string` returned by `key_metadata.substr(second_pos + 1)`. When the temporary is destroyed at the end of the statement, `context->key` becomes a dangling pointer. Subsequent use in `GetKey()` at line 21 — `std::string(context->key)` — reads from freed memory.

### Analysis Notes
At line 62, `context->key = key_metadata.substr(second_pos + 1).c_str()` captures a pointer to a temporary `std::string`'s internal buffer. The temporary is destroyed at the end of the full-expression, leaving `context->key` as a dangling pointer. When `GetKey()` later constructs `std::string(context->key)`, it triggers a use-after-free. Since `CPluginContext` is a C-interop struct (`extern "C"`), changing `const char* key` to `std::string` is not viable.

### Fix Applied
Replaced the direct `.c_str()` capture with `strdup()`, which allocates a persistent heap copy of the key string. Added a custom deleter to the `shared_ptr<CPluginContext>` that calls `free()` on `context->key` to prevent memory leaks. Initialized `context->key` to `nullptr` so early-return paths safely invoke the deleter. This approach is consistent with the project's existing use of `strdup` for C-interop strings (e.g., in `plan_c.cpp`, `index_c.cpp`).

### Tests/Linters Ran
- **clang-format** (v14.0.6): Passed — no formatting differences with project `.clang-format` config
- **cppcheck** (`--enable=all --std=c++17`): Passed — all reported items are pre-existing warnings in unmodified code (unused functions, pass-by-value in `EncodeKeyMetadata`)
- **C++ build/unit tests**: Could not run full build (`conan` dependency manager not available in environment). No existing unit tests cover `DecodeKeyMetadata`
- **clang-tidy config** reviewed: Project enables `bugprone-dangling-handle` which targets this exact class of bug

### Contribution Notes
- Commit includes DCO `Signed-off-by` as required by CONTRIBUTING.md
- Single commit as required by CODE_REVIEW.md
- Follows Google C++ Style Guide with project modifications (4-space indent, .cpp extension, 120-char line limit)
- Code change is limited to `KeyRetriever.cpp` only — no interface changes to headers or the `CPluginContext` C struct