### PR TITLE
fix: memory safety issues for nullable fields in growing and sealed segments

### DIFF
--- a/internal/core/src/mmap/ChunkedColumnTest.cpp
+++ b/internal/core/src/mmap/ChunkedColumnTest.cpp
@@ -49,4 +49,240 @@ TEST(test_chunked_column, test_get_chunkid) {
         }
     }
 }
+TEST(test_chunked_column, test_nullable_build_valid_row_ids) {
+    // Create 3 nullable chunks with varying valid/null patterns
+    // Chunk 0: 5 rows, valid pattern: [T, F, T, T, F] -> 3 valid
+    // Chunk 1: 3 rows, valid pattern: [F, F, F] -> 0 valid
+    // Chunk 2: 4 rows, valid pattern: [T, T, T, T] -> 4 valid
+
+    std::vector<int64_t> num_rows_per_chunk = {5, 3, 4};
+    auto num_chunks = num_rows_per_chunk.size();
+
+    std::vector<std::vector<bool>> valid_patterns = {
+        {true, false, true, true, false},
+        {false, false, false},
+        {true, true, true, true}};
+
+    // Pre-allocate buffers so chunk data pointers remain stable
+    int32_t element_size = 4;
+    std::vector<std::vector<char>> buffers(num_chunks);
+    for (size_t i = 0; i < num_chunks; i++) {
+        auto row_num = num_rows_per_chunk[i];
+        int32_t null_bitmap_bytes = (row_num + 7) / 8;
+        int32_t total_bytes = null_bitmap_bytes + row_num * element_size;
+        buffers[i].resize(total_bytes, 0);
+        // Set null bitmap: bit j = 1 means row j is valid
+        for (int j = 0; j < row_num; j++) {
+            if (valid_patterns[i][j]) {
+                buffers[i][j >> 3] |= (1 << (j & 0x07));
+            }
+        }
+    }
+
+    // Create chunks pointing to stable buffer addresses
+    std::vector<std::unique_ptr<Chunk>> chunks;
+    for (size_t i = 0; i < num_chunks; i++) {
+        auto row_num = num_rows_per_chunk[i];
+        auto chunk_mmap_guard =
+            std::make_shared<ChunkMmapGuard>(nullptr, 0, "");
+        auto chunk = std::make_unique<FixedWidthChunk>(row_num,
+                                                       1,
+                                                       buffers[i].data(),
+                                                       buffers[i].size(),
+                                                       element_size,
+                                                       true,
+                                                       chunk_mmap_guard);
+        chunks.push_back(std::move(chunk));
+    }
+
+    auto translator = std::make_unique<TestChunkTranslator>(
+        num_rows_per_chunk, "test_nullable", std::move(chunks));
+    FieldMeta field_meta(
+        FieldName("test"), FieldId(1), DataType::INT32, true, std::nullopt);
+    auto slot =
+        cachinglayer::Manager::GetInstance().CreateCacheSlot<milvus::Chunk>(
+            std::move(translator), nullptr);
+    ChunkedColumn column(std::move(slot), field_meta);
+
+    // Call BuildValidRowIds to populate valid row tracking
+    column.BuildValidRowIds(nullptr);
+
+    // Verify GetNumValidRowsUntilChunk()
+    // Expected cumulative valid counts: [0, 3, 3, 7]
+    auto& num_valid_rows = column.GetNumValidRowsUntilChunk();
+    ASSERT_EQ(num_valid_rows.size(), num_chunks + 1);
+    EXPECT_EQ(num_valid_rows[0], 0);
+    EXPECT_EQ(num_valid_rows[1], 3);  // chunk 0 has 3 valid
+    EXPECT_EQ(num_valid_rows[2], 3);  // chunk 1 has 0 valid
+    EXPECT_EQ(num_valid_rows[3], 7);  // chunk 2 has 4 valid
+
+    // Verify GetValidCountPerChunk()
+    auto& valid_counts = column.GetValidCountPerChunk();
+    ASSERT_EQ(valid_counts.size(), num_chunks);
+    EXPECT_EQ(valid_counts[0], 3);
+    EXPECT_EQ(valid_counts[1], 0);
+    EXPECT_EQ(valid_counts[2], 4);
+
+    // Verify GetValidData() matches the patterns
+    auto& valid_data = column.GetValidData();
+    int total_rows = 5 + 3 + 4;
+    ASSERT_EQ(valid_data.size(), total_rows);
+    int idx = 0;
+    for (size_t i = 0; i < num_chunks; i++) {
+        for (size_t j = 0; j < valid_patterns[i].size(); j++) {
+            EXPECT_EQ(valid_data[idx], valid_patterns[i][j])
+                << "Mismatch at global row " << idx << " (chunk " << i
+                << ", row " << j << ")";
+            idx++;
+        }
+    }
+}
+
+TEST(test_chunked_column, test_nullable_get_num_valid_rows_non_nullable) {
+    // For non-nullable columns, GetNumValidRowsUntilChunk() should
+    // fall back to GetNumRowsUntilChunk()
+    std::vector<int64_t> num_rows_per_chunk = {10, 20, 30};
+    auto num_chunks = num_rows_per_chunk.size();
+    std::vector<std::unique_ptr<Chunk>> chunks;
+    for (size_t i = 0; i < num_chunks; ++i) {
+        auto row_num = num_rows_per_chunk[i];
+        auto chunk_mmap_guard =
+            std::make_shared<ChunkMmapGuard>(nullptr, 0, "");
+        auto chunk = std::make_unique<FixedWidthChunk>(
+            row_num, 1, nullptr, 0, 4, false, chunk_mmap_guard);
+        chunks.push_back(std::move(chunk));
+    }
+    auto translator = std::make_unique<TestChunkTranslator>(
+        num_rows_per_chunk, "test_non_nullable", std::move(chunks));
+    FieldMeta field_meta(
+        FieldName("test"), FieldId(1), DataType::INT64, false, std::nullopt);
+    auto slot =
+        cachinglayer::Manager::GetInstance().CreateCacheSlot<milvus::Chunk>(
+            std::move(translator), nullptr);
+    ChunkedColumn column(std::move(slot), field_meta);
+
+    // For non-nullable, GetNumValidRowsUntilChunk should equal
+    // GetNumRowsUntilChunk
+    auto& valid_rows = column.GetNumValidRowsUntilChunk();
+    auto& total_rows = column.GetNumRowsUntilChunk();
+    ASSERT_EQ(valid_rows.size(), total_rows.size());
+    for (size_t i = 0; i < valid_rows.size(); i++) {
+        EXPECT_EQ(valid_rows[i], total_rows[i]);
+    }
+}
+
+TEST(test_chunked_column, test_nullable_all_valid) {
+    // All rows valid: physical offsets should equal logical offsets
+    std::vector<int64_t> num_rows_per_chunk = {4, 6};
+    auto num_chunks = num_rows_per_chunk.size();
+
+    std::vector<std::vector<bool>> valid_patterns = {
+        {true, true, true, true}, {true, true, true, true, true, true}};
+
+    int32_t element_size = 4;
+    std::vector<std::vector<char>> buffers(num_chunks);
+    for (size_t i = 0; i < num_chunks; i++) {
+        auto row_num = num_rows_per_chunk[i];
+        int32_t null_bitmap_bytes = (row_num + 7) / 8;
+        int32_t total_bytes = null_bitmap_bytes + row_num * element_size;
+        buffers[i].resize(total_bytes, 0);
+        for (int j = 0; j < row_num; j++) {
+            buffers[i][j >> 3] |= (1 << (j & 0x07));  // all valid
+        }
+    }
+
+    std::vector<std::unique_ptr<Chunk>> chunks;
+    for (size_t i = 0; i < num_chunks; i++) {
+        auto row_num = num_rows_per_chunk[i];
+        auto chunk_mmap_guard =
+            std::make_shared<ChunkMmapGuard>(nullptr, 0, "");
+        auto chunk = std::make_unique<FixedWidthChunk>(row_num,
+                                                       1,
+                                                       buffers[i].data(),
+                                                       buffers[i].size(),
+                                                       element_size,
+                                                       true,
+                                                       chunk_mmap_guard);
+        chunks.push_back(std::move(chunk));
+    }
+
+    auto translator = std::make_unique<TestChunkTranslator>(
+        num_rows_per_chunk, "test_all_valid", std::move(chunks));
+    FieldMeta field_meta(
+        FieldName("test"), FieldId(1), DataType::INT32, true, std::nullopt);
+    auto slot =
+        cachinglayer::Manager::GetInstance().CreateCacheSlot<milvus::Chunk>(
+            std::move(translator), nullptr);
+    ChunkedColumn column(std::move(slot), field_meta);
+
+    column.BuildValidRowIds(nullptr);
+
+    // When all rows are valid, num_valid_rows_until_chunk should equal
+    // num_rows_until_chunk
+    auto& num_valid_rows = column.GetNumValidRowsUntilChunk();
+    auto& num_rows = column.GetNumRowsUntilChunk();
+    ASSERT_EQ(num_valid_rows.size(), num_rows.size());
+    for (size_t i = 0; i < num_valid_rows.size(); i++) {
+        EXPECT_EQ(num_valid_rows[i], num_rows[i]);
+    }
+
+    // All valid counts should equal row counts
+    auto& valid_counts = column.GetValidCountPerChunk();
+    EXPECT_EQ(valid_counts[0], 4);
+    EXPECT_EQ(valid_counts[1], 6);
+}
+
+TEST(test_chunked_column, test_nullable_all_null) {
+    // All rows null: valid counts should all be 0
+    std::vector<int64_t> num_rows_per_chunk = {3, 5};
+    auto num_chunks = num_rows_per_chunk.size();
+
+    int32_t element_size = 4;
+    std::vector<std::vector<char>> buffers(num_chunks);
+    for (size_t i = 0; i < num_chunks; i++) {
+        auto row_num = num_rows_per_chunk[i];
+        int32_t null_bitmap_bytes = (row_num + 7) / 8;
+        int32_t total_bytes = null_bitmap_bytes + row_num * element_size;
+        buffers[i].resize(total_bytes, 0);  // all bits zero = all null
+    }
+
+    std::vector<std::unique_ptr<Chunk>> chunks;
+    for (size_t i = 0; i < num_chunks; i++) {
+        auto row_num = num_rows_per_chunk[i];
+        auto chunk_mmap_guard =
+            std::make_shared<ChunkMmapGuard>(nullptr, 0, "");
+        auto chunk = std::make_unique<FixedWidthChunk>(row_num,
+                                                       1,
+                                                       buffers[i].data(),
+                                                       buffers[i].size(),
+                                                       element_size,
+                                                       true,
+                                                       chunk_mmap_guard);
+        chunks.push_back(std::move(chunk));
+    }
+
+    auto translator = std::make_unique<TestChunkTranslator>(
+        num_rows_per_chunk, "test_all_null", std::move(chunks));
+    FieldMeta field_meta(
+        FieldName("test"), FieldId(1), DataType::INT32, true, std::nullopt);
+    auto slot =
+        cachinglayer::Manager::GetInstance().CreateCacheSlot<milvus::Chunk>(
+            std::move(translator), nullptr);
+    ChunkedColumn column(std::move(slot), field_meta);
+
+    column.BuildValidRowIds(nullptr);
+
+    auto& num_valid_rows = column.GetNumValidRowsUntilChunk();
+    ASSERT_EQ(num_valid_rows.size(), num_chunks + 1);
+    // All cumulative valid counts should be 0
+    for (size_t i = 0; i <= num_chunks; i++) {
+        EXPECT_EQ(num_valid_rows[i], 0);
+    }
+
+    auto& valid_counts = column.GetValidCountPerChunk();
+    for (size_t i = 0; i < num_chunks; i++) {
+        EXPECT_EQ(valid_counts[i], 0);
+    }
+}
+
 }  // namespace milvus

--- a/internal/core/src/query/CachedSearchIterator.cpp
+++ b/internal/core/src/query/CachedSearchIterator.cpp
@@ -161,6 +161,11 @@ CachedSearchIterator::CachedSearchIterator(
                               return static_cast<const void*>(x);
                           });
             int64_t chunk_size = column->chunk_row_nums(chunk_id);
+            const auto& offset_mapping = column->GetOffsetMapping();
+            const auto& valid_count_per_chunk = column->GetValidCountPerChunk();
+            if (offset_mapping.IsEnabled() && !valid_count_per_chunk.empty()) {
+                chunk_size = valid_count_per_chunk[chunk_id];
+            }
             // pw guarantees chunk_data is kept alive.
             auto chunk_data = pw.get();
             pin_wrappers_.emplace_back(std::move(pw));

--- a/internal/core/src/query/SearchOnSealed.cpp
+++ b/internal/core/src/query/SearchOnSealed.cpp
@@ -227,6 +227,9 @@ SearchOnSealedColumn(const Schema& schema,
                                          search_bitview,
                                          data_type);
         cached_iter.NextBatch(search_info, result);
+        if (offset_mapping.IsEnabled()) {
+            TransformOffset(result.seg_offsets_, offset_mapping);
+        }
         return;
     }
 

--- a/internal/core/src/segcore/ConcurrentVector.h
+++ b/internal/core/src/segcore/ConcurrentVector.h
@@ -100,8 +100,9 @@ class ThreadSafeValidData {
         return &data_[offset];
     }
 
-    const FixedVector<bool>&
+    FixedVector<bool>
     get_data() const {
+        std::shared_lock<std::shared_mutex> lck(mutex_);
         return data_;
     }
 
@@ -190,10 +191,9 @@ class VectorBase {
         return 0;
     }
 
-    virtual const FixedVector<bool>&
+    virtual FixedVector<bool>
     get_valid_data() const {
-        static const FixedVector<bool> empty;
-        return empty;
+        return FixedVector<bool>{};
     }
 
     virtual const OffsetMapping&
@@ -445,13 +445,12 @@ class ConcurrentVectorImpl : public VectorBase {
         return offset_mapping_;
     }
 
-    const FixedVector<bool>&
+    FixedVector<bool>
     get_valid_data() const override {
         if (valid_data_ptr_ != nullptr) {
             return valid_data_ptr_->get_data();
         }
-        static const FixedVector<bool> empty;
-        return empty;
+        return FixedVector<bool>{};
     }
 
  private:

--- a/internal/core/src/segcore/FieldIndexing.cpp
+++ b/internal/core/src/segcore/FieldIndexing.cpp
@@ -284,7 +284,7 @@ VectorFieldIndexing::AppendSegmentIndexSparse(int64_t reserved_offset,
     auto size_per_chunk = field_raw_data->get_size_per_chunk();
     auto build_threshold = get_build_threshold();
     bool is_mapping_storage = field_raw_data->is_mapping_storage();
-    auto& valid_data = field_raw_data->get_valid_data();
+    auto valid_data = field_raw_data->get_valid_data();
 
     if (!built_) {
         const void* data_ptr = nullptr;
@@ -411,7 +411,7 @@ VectorFieldIndexing::AppendSegmentIndexDense(int64_t reserved_offset,
     auto size_per_chunk = field_raw_data->get_size_per_chunk();
     auto build_threshold = get_build_threshold();
     bool is_mapping_storage = field_raw_data->is_mapping_storage();
-    auto& valid_data = field_raw_data->get_valid_data();
+    auto valid_data = field_raw_data->get_valid_data();
 
     AssertInfo(ConcurrentDenseVectorCheck(field_raw_data, get_data_type()),
                "vec_base can't cast to ConcurrentVector type");

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -2306,7 +2306,7 @@ SegmentGrowingImpl::FilterVectorValidOffsets(milvus::OpContext* op_ctx,
     } else {
         auto vec_base = insert_record_.get_data_base(field_id);
         if (vec_base != nullptr) {
-            const auto& valid_data_vec = vec_base->get_valid_data();
+            auto valid_data_vec = vec_base->get_valid_data();
             bool is_mapping_storage = vec_base->is_mapping_storage();
             if (!valid_data_vec.empty()) {
                 result.valid_data = std::make_unique<bool[]>(count);

--- a/internal/core/src/segcore/SegmentGrowingTest.cpp
+++ b/internal/core/src/segcore/SegmentGrowingTest.cpp
@@ -727,7 +727,7 @@ TEST_P(GrowingNullableTest, SearchAndQueryNullableVectors) {
         ASSERT_TRUE(insert_record.is_valid_data_exist(vec));
 
         auto valid_data_ptr = insert_record.get_data_base(vec);
-        const auto& valid_data = valid_data_ptr->get_valid_data();
+        auto valid_data = valid_data_ptr->get_valid_data();
 
         // Test search
         auto sr =


### PR DESCRIPTION
issue: #47160 
issue: #47666 

relate: #45993 

commit 1
ThreadSafeValidData::get_data() previously returned a const reference  without holding the lock, causing two issues:
- Data race: concurrent read/write without synchronization.
- Use-after-free: even with a lock, returning a reference allows callers to hold it after the lock is released. Concurrent writers calling set_data_raw() may resize the underlying vector, invalidating the reference and causing memory access violations.

commit 2
For nullable columns, the offsets passed to BulkValueAt and similar  methods are physical offsets (indexing only valid/non-null rows), but ToChunkIdAndOffset maps them as logical offsets (indexing all rows including nulls). This mismatch causes incorrect chunk/offset resolution. Add ToChunkIdAndOffsetByPhysical() which uses cumulative valid row counts per chunk to correctly map physical offsets, and use it in BulkValueAt, BulkPrimitiveValueAt, and BulkVectorValueAt for both ChunkedColumn and ProxyChunkColumn when the column is nullable.

commit 3
- CachedSearchIterator used chunk_row_nums() (total logical rows) as chunk_size, but nullable vector chunks only store valid vectors. This caused out-of-bounds reads during brute force search. 
- SearchOnSealedColumn's iterator_v2 path was missing TransformOffset after NextBatch, returning physical offsets instead of logical offsets