### PR TITLE
feat: update scalar index serialized format to V3

### DIFF
--- a/internal/core/conanfile.py
+++ b/internal/core/conanfile.py
@@ -40,6 +40,7 @@ class MilvusConan(ConanFile):
         "roaring/3.0.0#25a703f80eda0764a31ef939229e202d",
         "grpc/1.67.1@milvus/dev#5aa62c51bced448b83d7db9e5b3a13c7",
         "rapidjson/cci.20230929#624c0094d741e6a3749d2e44d834b96c",
+        "crc32c/1.1.1",
         "simde/0.8.2#5e1edfd5cba92f25d79bf6ef4616b972",
         "xxhash/0.8.3#199e63ab9800302c232d030b27accec0",
         "unordered_dense/4.4.0#6a855c992618cc4c63019109a2e47298",

--- a/internal/core/src/index/BitmapIndex.cpp
+++ b/internal/core/src/index/BitmapIndex.cpp
@@ -21,6 +21,8 @@
 #include <unistd.h>
 #include <yaml-cpp/yaml.h>
 
+#include "nlohmann/json.hpp"
+
 #include "index/BitmapIndex.h"
 
 #include "common/Consts.h"
@@ -36,6 +38,8 @@
 #include "query/Utils.h"
 
 #include "storage/FileWriter.h"
+#include "storage/IndexEntryReader.h"
+#include "storage/IndexEntryWriter.h"
 
 namespace milvus {
 namespace index {
@@ -50,9 +54,10 @@ BitmapIndex<T>::BitmapIndex(
       schema_(file_manager_context.fieldDataMeta.field_schema),
       is_mmap_(false) {
     if (file_manager_context.Valid()) {
-        file_manager_ =
+        this->file_manager_ =
             std::make_shared<storage::MemFileManagerImpl>(file_manager_context);
-        AssertInfo(file_manager_ != nullptr, "create file manager failed!");
+        AssertInfo(this->file_manager_ != nullptr,
+                   "create file manager failed!");
     }
 }
 
@@ -77,7 +82,7 @@ BitmapIndex<T>::Build(const Config& config) {
     }
 
     auto field_datas =
-        storage::CacheRawDataAndFillMissing(file_manager_, config);
+        storage::CacheRawDataAndFillMissing(this->file_manager_, config);
     BuildWithFieldData(field_datas);
 }
 
@@ -286,13 +291,16 @@ BitmapIndex<T>::Serialize(const Config& config) {
 template <typename T>
 IndexStatsPtr
 BitmapIndex<T>::Upload(const Config& config) {
+    if (kScalarIndexUseV3) {
+        return this->UploadV3(config);
+    }
     auto binary_set = Serialize(config);
 
-    file_manager_->AddFile(binary_set);
+    this->file_manager_->AddFile(binary_set);
 
-    auto remote_path_to_size = file_manager_->GetRemotePathsToFileSize();
-    return IndexStats::NewFromSizeMap(file_manager_->GetAddedTotalMemSize(),
-                                      remote_path_to_size);
+    auto remote_path_to_size = this->file_manager_->GetRemotePathsToFileSize();
+    return IndexStats::NewFromSizeMap(
+        this->file_manager_->GetAddedTotalMemSize(), remote_path_to_size);
 }
 
 template <typename T>
@@ -317,13 +325,21 @@ template <typename T>
 std::pair<size_t, size_t>
 BitmapIndex<T>::DeserializeIndexMeta(const uint8_t* data_ptr,
                                      size_t data_size) {
-    YAML::Node node = YAML::Load(
-        std::string(reinterpret_cast<const char*>(data_ptr), data_size));
+    std::string meta_str(reinterpret_cast<const char*>(data_ptr), data_size);
 
-    auto index_length = node[BITMAP_INDEX_LENGTH].as<size_t>();
-    auto index_num_rows = node[BITMAP_INDEX_NUM_ROWS].as<size_t>();
-
-    return std::make_pair(index_length, index_num_rows);
+    // Try JSON first (V3 format), fall back to YAML (V2 format)
+    try {
+        auto j = nlohmann::json::parse(meta_str);
+        auto index_length = j[BITMAP_INDEX_LENGTH].get<size_t>();
+        auto index_num_rows = j[BITMAP_INDEX_NUM_ROWS].get<size_t>();
+        return std::make_pair(index_length, index_num_rows);
+    } catch (const nlohmann::json::parse_error&) {
+        // Fall back to YAML for backward compatibility with V2
+        YAML::Node node = YAML::Load(meta_str);
+        auto index_length = node[BITMAP_INDEX_LENGTH].as<size_t>();
+        auto index_num_rows = node[BITMAP_INDEX_NUM_ROWS].as<size_t>();
+        return std::make_pair(index_length, index_num_rows);
+    }
 }
 
 template <typename T>
@@ -554,7 +570,7 @@ BitmapIndex<T>::LoadWithoutAssemble(const BinarySet& binary_set,
         BuildOffsetCache();
     }
 
-    auto file_index_meta = file_manager_->GetIndexMeta();
+    auto file_index_meta = this->file_manager_->GetIndexMeta();
     LOG_INFO(
         "load bitmap index with cardinality = {}, num_rows = {} for segment_id "
         "= {}, field_id = {}, mmap = {}",
@@ -572,6 +588,10 @@ template <typename T>
 void
 BitmapIndex<T>::Load(milvus::tracer::TraceContext ctx, const Config& config) {
     LOG_INFO("load bitmap index with config {}", config.dump());
+    if (kScalarIndexUseV3) {
+        this->LoadV3(config);
+        return;
+    }
     auto index_files =
         GetValueFromConfig<std::vector<std::string>>(config, "index_files");
     AssertInfo(index_files.has_value(),
@@ -580,8 +600,8 @@ BitmapIndex<T>::Load(milvus::tracer::TraceContext ctx, const Config& config) {
         GetValueFromConfig<milvus::proto::common::LoadPriority>(
             config, milvus::LOAD_PRIORITY)
             .value_or(milvus::proto::common::LoadPriority::HIGH);
-    auto index_datas =
-        file_manager_->LoadIndexToMemory(index_files.value(), load_priority);
+    auto index_datas = this->file_manager_->LoadIndexToMemory(
+        index_files.value(), load_priority);
     BinarySet binary_set;
     AssembleIndexDatas(index_datas, binary_set);
     // clear index_datas to free memory early
@@ -1328,6 +1348,80 @@ BitmapIndex<std::string>::RegexQuery(const std::string& regex_pattern) {
         }
     }
     return res;
+}
+
+template <typename T>
+void
+BitmapIndex<T>::WriteEntries(storage::IndexEntryWriter* writer) {
+    AssertInfo(is_built_, "index has not been built yet");
+
+    // V3 format: meta goes into __meta__ entry
+    writer->PutMeta(BITMAP_INDEX_LENGTH, data_.size());
+    writer->PutMeta(BITMAP_INDEX_NUM_ROWS, total_num_rows_);
+
+    auto index_data_size = GetIndexDataSize();
+    std::shared_ptr<uint8_t[]> index_data(new uint8_t[index_data_size]);
+    uint8_t* data_ptr = index_data.get();
+    SerializeIndexData(data_ptr);
+    writer->WriteEntry(BITMAP_INDEX_DATA, index_data.get(), index_data_size);
+
+    LOG_INFO("write bitmap index entries with cardinality = {}, num_rows = {}",
+             data_.size(),
+             total_num_rows_);
+}
+
+template <typename T>
+void
+BitmapIndex<T>::LoadEntries(storage::IndexEntryReader& reader,
+                            const Config& config) {
+    auto enable_offset_cache =
+        GetValueFromConfig<bool>(config, ENABLE_OFFSET_CACHE);
+
+    // V3 format: meta is in __meta__ entry
+    auto index_length = reader.GetMeta<size_t>(BITMAP_INDEX_LENGTH);
+    total_num_rows_ = reader.GetMeta<size_t>(BITMAP_INDEX_NUM_ROWS);
+    valid_bitset_ = TargetBitmap(total_num_rows_, false);
+
+    auto data_entry = reader.ReadEntry(BITMAP_INDEX_DATA);
+
+    ChooseIndexLoadMode(index_length);
+
+    if (config.contains(MMAP_FILE_PATH) &&
+        build_mode_ == BitmapIndexBuildMode::ROARING) {
+        auto mmap_filepath =
+            GetValueFromConfig<std::string>(config, MMAP_FILE_PATH);
+        auto priority =
+            GetValueFromConfig<milvus::proto::common::LoadPriority>(
+                config, milvus::LOAD_PRIORITY)
+                .value_or(milvus::proto::common::LoadPriority::HIGH);
+        AssertInfo(mmap_filepath.has_value(),
+                   "mmap filepath is empty when load index");
+        MMapIndexData(mmap_filepath.value(),
+                      data_entry.data.data(),
+                      data_entry.data.size(),
+                      index_length,
+                      priority);
+    } else {
+        DeserializeIndexData(data_entry.data.data(), index_length);
+    }
+
+    if (enable_offset_cache.has_value() && enable_offset_cache.value()) {
+        BuildOffsetCache();
+    }
+
+    auto file_index_meta = this->file_manager_->GetIndexMeta();
+
+    LOG_INFO(
+        "LoadEntries bitmap index with cardinality = {}, num_rows = {} for "
+        "segment_id = {}, field_id = {}, mmap = {}",
+        Cardinality(),
+        total_num_rows_,
+        file_index_meta.segment_id,
+        file_index_meta.field_id,
+        is_mmap_);
+
+    is_built_ = true;
+    ComputeByteSize();
 }
 
 template class BitmapIndex<bool>;

--- a/internal/core/src/index/BitmapIndex.h
+++ b/internal/core/src/index/BitmapIndex.h
@@ -195,6 +195,13 @@ class BitmapIndex : public ScalarIndex<T> {
     const TargetBitmap
     Query(const DatasetPtr& dataset) override;
 
+    void
+    WriteEntries(storage::IndexEntryWriter* writer) override;
+
+    void
+    LoadEntries(storage::IndexEntryReader& reader,
+                const Config& config) override;
+
     bool
     SupportPatternMatch() const override {
         return SupportRegexQuery();
@@ -340,7 +347,6 @@ class BitmapIndex : public ScalarIndex<T> {
         bitsets_offsets_cache_;
     std::vector<typename std::map<T, roaring::Roaring>::iterator>
         mmap_offsets_cache_;
-    std::shared_ptr<storage::MemFileManagerImpl> file_manager_;
 
     // generate valid_bitset to speed up NotIn and IsNull and IsNotNull operate
     TargetBitmap valid_bitset_;

--- a/internal/core/src/index/HybridScalarIndex.cpp
+++ b/internal/core/src/index/HybridScalarIndex.cpp
@@ -45,6 +45,8 @@
 #include "storage/ThreadPools.h"
 #include "storage/Types.h"
 #include "storage/Util.h"
+#include "storage/IndexEntryReader.h"
+#include "storage/IndexEntryWriter.h"
 
 namespace milvus {
 namespace index {
@@ -62,9 +64,10 @@ HybridScalarIndex<T>::HybridScalarIndex(
       high_cardinality_index_type_(ScalarIndexType::STLSORT),
       file_manager_context_(file_manager_context) {
     if (file_manager_context.Valid()) {
-        mem_file_manager_ =
+        this->file_manager_ =
             std::make_shared<storage::MemFileManagerImpl>(file_manager_context);
-        AssertInfo(mem_file_manager_ != nullptr, "create file manager failed!");
+        AssertInfo(this->file_manager_ != nullptr,
+                   "create file manager failed!");
     }
     field_type_ = file_manager_context.fieldDataMeta.field_schema.data_type();
     internal_index_type_ = ScalarIndexType::NONE;
@@ -179,13 +182,13 @@ HybridScalarIndex<T>::GetInternalIndex() {
     }
     if (internal_index_type_ == ScalarIndexType::BITMAP) {
         internal_index_ =
-            std::make_shared<BitmapIndex<T>>(file_manager_context_);
+            std::make_shared<BitmapIndex<T>>(this->file_manager_context_);
     } else if (internal_index_type_ == ScalarIndexType::STLSORT) {
         internal_index_ =
-            std::make_shared<ScalarIndexSort<T>>(file_manager_context_);
+            std::make_shared<ScalarIndexSort<T>>(this->file_manager_context_);
     } else if (internal_index_type_ == ScalarIndexType::INVERTED) {
         internal_index_ = std::make_shared<InvertedIndexTantivy<T>>(
-            tantivy_index_version_, file_manager_context_);
+            tantivy_index_version_, this->file_manager_context_);
     } else {
         ThrowInfo(UnexpectedError,
                   "unknown index type when get internal index");
@@ -201,17 +204,17 @@ HybridScalarIndex<std::string>::GetInternalIndex() {
     }
 
     if (internal_index_type_ == ScalarIndexType::BITMAP) {
-        internal_index_ =
-            std::make_shared<BitmapIndex<std::string>>(file_manager_context_);
+        internal_index_ = std::make_shared<BitmapIndex<std::string>>(
+            this->file_manager_context_);
     } else if (internal_index_type_ == ScalarIndexType::MARISA) {
         internal_index_ =
-            std::make_shared<StringIndexMarisa>(file_manager_context_);
+            std::make_shared<StringIndexMarisa>(this->file_manager_context_);
     } else if (internal_index_type_ == ScalarIndexType::STLSORT) {
         internal_index_ =
-            std::make_shared<StringIndexSort>(file_manager_context_);
+            std::make_shared<StringIndexSort>(this->file_manager_context_);
     } else if (internal_index_type_ == ScalarIndexType::INVERTED) {
         internal_index_ = std::make_shared<InvertedIndexTantivy<std::string>>(
-            tantivy_index_version_, file_manager_context_);
+            tantivy_index_version_, this->file_manager_context_);
     } else {
         ThrowInfo(UnexpectedError,
                   "unknown index type when get internal index");
@@ -265,11 +268,11 @@ HybridScalarIndex<T>::Build(const Config& config) {
         ToString(high_cardinality_index_type_),
         scalar_index_version);
     auto field_datas =
-        storage::CacheRawDataAndFillMissing(mem_file_manager_, config);
+        storage::CacheRawDataAndFillMissing(this->file_manager_, config);
 
     SelectIndexBuildType(field_datas);
     BuildInternal(field_datas);
-    auto index_meta = file_manager_context_.indexMeta;
+    auto index_meta = this->file_manager_context_.indexMeta;
     LOG_INFO(
         "build hybrid index with internal index:{}, for segment_id:{}, "
         "field_id:{}",
@@ -302,9 +305,9 @@ HybridScalarIndex<T>::SerializeIndexType() {
     std::shared_ptr<uint8_t[]> index_type_buf(new uint8_t[sizeof(uint8_t)]);
     index_type_buf[0] = static_cast<uint8_t>(internal_index_type_);
     index_binary_set.Append(index::INDEX_TYPE, index_type_buf, sizeof(uint8_t));
-    mem_file_manager_->AddFile(index_binary_set);
+    this->file_manager_->AddFile(index_binary_set);
 
-    auto remote_paths_to_size = mem_file_manager_->GetRemotePathsToFileSize();
+    auto remote_paths_to_size = this->file_manager_->GetRemotePathsToFileSize();
     BinarySet ret_set;
     Assert(remote_paths_to_size.size() == 1);
     for (auto& file : remote_paths_to_size) {
@@ -316,6 +319,9 @@ HybridScalarIndex<T>::SerializeIndexType() {
 template <typename T>
 IndexStatsPtr
 HybridScalarIndex<T>::Upload(const Config& config) {
+    if (kScalarIndexUseV3) {
+        return this->UploadV3(config);
+    }
     auto internal_index = GetInternalIndex();
     auto index_ret = internal_index->Upload(config);
 
@@ -370,6 +376,10 @@ template <typename T>
 void
 HybridScalarIndex<T>::Load(milvus::tracer::TraceContext ctx,
                            const Config& config) {
+    if (kScalarIndexUseV3) {
+        this->LoadV3(config);
+        return;
+    }
     auto index_files =
         GetValueFromConfig<std::vector<std::string>>(config, "index_files");
     AssertInfo(index_files.has_value(),
@@ -381,7 +391,7 @@ HybridScalarIndex<T>::Load(milvus::tracer::TraceContext ctx,
         GetValueFromConfig<milvus::proto::common::LoadPriority>(
             config, milvus::LOAD_PRIORITY)
             .value_or(milvus::proto::common::LoadPriority::HIGH);
-    auto index_datas = mem_file_manager_->LoadIndexToMemory(
+    auto index_datas = this->file_manager_->LoadIndexToMemory(
         std::vector<std::string>{index_type_file}, load_priority);
     BinarySet binary_set;
     AssembleIndexDatas(index_datas, binary_set);
@@ -393,6 +403,38 @@ HybridScalarIndex<T>::Load(milvus::tracer::TraceContext ctx,
     LOG_INFO("load hybrid index with internal index:{}",
              ToString(internal_index_type_));
     index->Load(ctx, config);
+
+    is_built_ = true;
+    ComputeByteSize();
+}
+
+template <typename T>
+void
+HybridScalarIndex<T>::WriteEntries(storage::IndexEntryWriter* writer) {
+    AssertInfo(is_built_, "index has not been built yet");
+
+    // Write internal index entries (which adds internal meta via PutMeta)
+    internal_index_->WriteEntries(writer);
+
+    // Add hybrid-level meta
+    writer->PutMeta("index_type", static_cast<uint8_t>(internal_index_type_));
+
+    LOG_INFO("write hybrid index entries with internal index type: {}",
+             ToString(internal_index_type_));
+}
+
+template <typename T>
+void
+HybridScalarIndex<T>::LoadEntries(storage::IndexEntryReader& reader,
+                                  const Config& config) {
+    internal_index_type_ =
+        static_cast<ScalarIndexType>(reader.GetMeta<uint8_t>("index_type"));
+
+    LOG_INFO("LoadEntries hybrid index with internal index type: {}",
+             ToString(internal_index_type_));
+
+    auto index = GetInternalIndex();
+    index->LoadEntries(reader, config);
 
     is_built_ = true;
     ComputeByteSize();

--- a/internal/core/src/index/HybridScalarIndex.h
+++ b/internal/core/src/index/HybridScalarIndex.h
@@ -180,6 +180,13 @@ class HybridScalarIndex : public ScalarIndex<T> {
     IndexStatsPtr
     Upload(const Config& config = {}) override;
 
+    void
+    WriteEntries(storage::IndexEntryWriter* writer) override;
+
+    void
+    LoadEntries(storage::IndexEntryReader& reader,
+                const Config& config) override;
+
  private:
     ScalarIndexType
     SelectBuildTypeForPrimitiveType(
@@ -221,7 +228,6 @@ class HybridScalarIndex : public ScalarIndex<T> {
     ScalarIndexType internal_index_type_;
     std::shared_ptr<ScalarIndex<T>> internal_index_{nullptr};
     storage::FileManagerContext file_manager_context_;
-    std::shared_ptr<storage::MemFileManagerImpl> mem_file_manager_{nullptr};
 
     // `tantivy_index_version_` is used to control which kind of tantivy index should be used.
     // There could be the case where milvus version of read node is lower than the version of index builder node(and read node

--- a/internal/core/src/index/Index.h
+++ b/internal/core/src/index/Index.h
@@ -64,6 +64,16 @@ class IndexBase {
     virtual IndexStatsPtr
     Upload(const Config& config = {}) = 0;
 
+    virtual void
+    LoadV3(const Config& config) {
+        ThrowInfo(Unsupported, "LoadV3 is not supported for this index type");
+    }
+
+    virtual IndexStatsPtr
+    UploadV3(const Config& config) {
+        ThrowInfo(Unsupported, "UploadV3 is not supported for this index type");
+    }
+
     virtual const bool
     HasRawData() const = 0;
 

--- a/internal/core/src/index/InvertedIndexTantivy.cpp
+++ b/internal/core/src/index/InvertedIndexTantivy.cpp
@@ -11,7 +11,9 @@
 
 #include <boost/uuid/random_generator.hpp>
 #include <boost/uuid/uuid_io.hpp>
+#include <fcntl.h>
 #include <string.h>
+#include <unistd.h>
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
@@ -42,8 +44,11 @@
 #include "nlohmann/detail/iterators/iter_impl.hpp"
 #include "nlohmann/json.hpp"
 #include "pb/common.pb.h"
+#include "storage/FileWriter.h"
+#include "storage/IndexEntryReader.h"
 #include "storage/DataCodec.h"
 #include "storage/FileManager.h"
+#include "storage/IndexEntryWriter.h"
 #include "storage/LocalChunkManager.h"
 #include "storage/LocalChunkManagerSingleton.h"
 #include "storage/ThreadPools.h"
@@ -97,7 +102,7 @@ InvertedIndexTantivy<T>::InvertedIndexTantivy(
       inverted_index_single_segment_(inverted_index_single_segment),
       user_specified_doc_id_(user_specified_doc_id),
       is_nested_index_(is_nested_index) {
-    mem_file_manager_ = std::make_shared<MemFileManager>(ctx);
+    this->file_manager_ = std::make_shared<MemFileManager>(ctx);
     disk_file_manager_ = std::make_shared<DiskFileManager>(ctx);
     // push init wrapper to load process
     if (ctx.for_loading_index) {
@@ -150,6 +155,9 @@ InvertedIndexTantivy<T>::Serialize(const Config& config) {
 template <typename T>
 IndexStatsPtr
 InvertedIndexTantivy<T>::Upload(const Config& config) {
+    if (kScalarIndexUseV3) {
+        return this->UploadV3(config);
+    }
     finish();
 
     boost::filesystem::path p(path_);
@@ -180,9 +188,9 @@ InvertedIndexTantivy<T>::Upload(const Config& config) {
     auto remote_paths_to_size = disk_file_manager_->GetRemotePathsToFileSize();
 
     auto binary_set = Serialize(config);
-    mem_file_manager_->AddFile(binary_set);
+    this->file_manager_->AddFile(binary_set);
     auto remote_mem_path_to_size =
-        mem_file_manager_->GetRemotePathsToFileSize();
+        this->file_manager_->GetRemotePathsToFileSize();
 
     std::vector<SerializedIndexFileInfo> index_files;
     index_files.reserve(remote_paths_to_size.size() +
@@ -193,7 +201,7 @@ InvertedIndexTantivy<T>::Upload(const Config& config) {
     for (auto& file : remote_mem_path_to_size) {
         index_files.emplace_back(file.first, file.second);
     }
-    return IndexStats::New(mem_file_manager_->GetAddedTotalMemSize() +
+    return IndexStats::New(this->file_manager_->GetAddedTotalMemSize() +
                                disk_file_manager_->GetAddedTotalFileSize(),
                            std::move(index_files));
 }
@@ -201,8 +209,8 @@ InvertedIndexTantivy<T>::Upload(const Config& config) {
 template <typename T>
 void
 InvertedIndexTantivy<T>::Build(const Config& config) {
-    auto field_datas =
-        storage::CacheRawDataAndFillMissing(mem_file_manager_, config);
+    auto field_datas = storage::CacheRawDataAndFillMissing(
+        std::static_pointer_cast<MemFileManager>(this->file_manager_), config);
     BuildWithFieldData(field_datas);
 }
 
@@ -210,6 +218,10 @@ template <typename T>
 void
 InvertedIndexTantivy<T>::Load(milvus::tracer::TraceContext ctx,
                               const Config& config) {
+    if (kScalarIndexUseV3) {
+        this->LoadV3(config);
+        return;
+    }
     auto index_files =
         GetValueFromConfig<std::vector<std::string>>(config, INDEX_FILES);
     AssertInfo(index_files.has_value(),
@@ -264,7 +276,7 @@ InvertedIndexTantivy<T>::LoadIndexMetas(
 
     if (null_offset_file_itr != index_files.end()) {
         // null offset file is not sliced
-        auto index_datas = mem_file_manager_->LoadIndexToMemory(
+        auto index_datas = this->file_manager_->LoadIndexToMemory(
             {*null_offset_file_itr}, load_priority);
         auto null_offset_data =
             std::move(index_datas.at(INDEX_NULL_OFFSET_FILE_NAME));
@@ -287,7 +299,7 @@ InvertedIndexTantivy<T>::LoadIndexMetas(
 
     if (null_offset_files.size() > 0) {
         // null offset file is sliced
-        auto index_datas = mem_file_manager_->LoadIndexToMemory(
+        auto index_datas = this->file_manager_->LoadIndexToMemory(
             null_offset_files, load_priority);
 
         auto null_offsets_data = CompactIndexDatas(index_datas);
@@ -845,6 +857,102 @@ InvertedIndexTantivy<std::string>::build_index_for_array_nested(
             offset += length;
         }
     }
+}
+
+template <typename T>
+nlohmann::json
+InvertedIndexTantivy<T>::BuildTantivyMeta(
+    const std::vector<std::string>& file_names, bool has_null) {
+    return {{"file_names", file_names}, {"has_null", has_null}};
+}
+
+template <typename T>
+void
+InvertedIndexTantivy<T>::WriteEntries(storage::IndexEntryWriter* writer) {
+    finish();
+
+    boost::filesystem::path p(path_);
+    std::vector<boost::filesystem::path> files;
+    for (boost::filesystem::directory_iterator iter(p);
+         iter != boost::filesystem::directory_iterator();
+         iter++) {
+        if (!boost::filesystem::is_directory(*iter)) {
+            files.push_back(iter->path());
+        }
+    }
+    std::sort(files.begin(), files.end());
+
+    std::vector<std::string> file_names;
+    for (const auto& f : files) {
+        file_names.push_back(f.filename().string());
+    }
+
+    std::shared_lock<folly::SharedMutex> lock(mutex_);
+    bool has_null = !null_offset_.empty();
+    lock.unlock();
+
+    writer->PutMeta("file_names", file_names);
+    writer->PutMeta("has_null", has_null);
+
+    for (const auto& file_path : files) {
+        auto file_name = file_path.filename().string();
+        int fd = open(file_path.c_str(), O_RDONLY | O_CLOEXEC);
+        AssertInfo(fd != -1, "failed to open file: {}", file_path.string());
+        auto file_size = boost::filesystem::file_size(file_path);
+        writer->WriteEntry(file_name, fd, file_size);
+        close(fd);
+    }
+
+    lock.lock();
+    if (has_null) {
+        writer->WriteEntry(INDEX_NULL_OFFSET_FILE_NAME,
+                           null_offset_.data(),
+                           null_offset_.size() * sizeof(size_t));
+    }
+    lock.unlock();
+}
+
+template <typename T>
+void
+InvertedIndexTantivy<T>::LoadEntries(storage::IndexEntryReader& reader,
+                                     const Config& config) {
+    auto file_names = reader.GetMeta<std::vector<std::string>>("file_names");
+    bool has_null = reader.GetMeta<bool>("has_null");
+
+    path_ = disk_file_manager_->GetLocalIndexObjectPrefix();
+    boost::filesystem::create_directories(path_);
+
+    std::vector<std::pair<std::string, std::string>> pairs;
+    for (const auto& fn : file_names) {
+        pairs.emplace_back(fn, path_ + "/" + fn);
+    }
+    reader.ReadEntriesToFiles(pairs);
+
+    if (has_null) {
+        auto null_entry = reader.ReadEntry(INDEX_NULL_OFFSET_FILE_NAME);
+        null_offset_.resize(null_entry.data.size() / sizeof(size_t));
+        std::memcpy(null_offset_.data(),
+                    null_entry.data.data(),
+                    null_entry.data.size());
+    }
+
+    auto load_in_mmap =
+        GetValueFromConfig<bool>(config, ENABLE_MMAP).value_or(true);
+    wrapper_ = std::make_shared<TantivyIndexWrapper>(
+        path_.c_str(), load_in_mmap, milvus::index::SetBitsetSealed);
+
+    if (!load_in_mmap) {
+        disk_file_manager_->RemoveIndexFiles();
+    }
+
+    ComputeByteSize();
+
+    LOG_INFO(
+        "LoadEntries InvertedIndexTantivy done, file_count: {}, has_null: "
+        "{}, mmap: {}",
+        file_names.size(),
+        has_null,
+        load_in_mmap);
 }
 
 template class InvertedIndexTantivy<bool>;

--- a/internal/core/src/index/JsonInvertedIndex.cpp
+++ b/internal/core/src/index/JsonInvertedIndex.cpp
@@ -13,12 +13,17 @@
 
 #include <algorithm>
 #include <exception>
+#include <fcntl.h>
 #include <list>
 #include <optional>
 #include <string>
+#include <unistd.h>
 #include <utility>
 
+#include "boost/filesystem/directory.hpp"
+#include "boost/filesystem/operations.hpp"
 #include "boost/filesystem/path.hpp"
+#include "folly/SharedMutex.h"
 #include "common/Json.h"
 #include "common/Types.h"
 #include "index/JsonIndexBuilder.h"
@@ -27,6 +32,9 @@
 #include "nlohmann/json.hpp"
 #include "pb/common.pb.h"
 #include "simdjson/error.h"
+#include "storage/FileWriter.h"
+#include "storage/IndexEntryReader.h"
+#include "storage/IndexEntryWriter.h"
 #include "storage/ThreadPools.h"
 
 namespace milvus::index {
@@ -120,7 +128,7 @@ JsonInvertedIndex<T>::LoadIndexMetas(
 
     if (non_exist_offset_file_itr != index_files.end()) {
         // null offset file is not sliced
-        auto index_datas = this->mem_file_manager_->LoadIndexToMemory(
+        auto index_datas = this->file_manager_->LoadIndexToMemory(
             {*non_exist_offset_file_itr}, load_priority);
         auto non_exist_offset_data =
             std::move(index_datas.at(INDEX_NON_EXIST_OFFSET_FILE_NAME));
@@ -142,7 +150,7 @@ JsonInvertedIndex<T>::LoadIndexMetas(
     }
     if (non_exist_offset_files.size() > 0) {
         // null offset file is sliced
-        auto index_datas = this->mem_file_manager_->LoadIndexToMemory(
+        auto index_datas = this->file_manager_->LoadIndexToMemory(
             non_exist_offset_files, load_priority);
 
         auto non_exist_offset_data = CompactIndexDatas(index_datas);
@@ -181,6 +189,52 @@ JsonInvertedIndex<T>::RetainTantivyIndexFiles(
             }),
         index_files.end());
     InvertedIndexTantivy<T>::RetainTantivyIndexFiles(index_files);
+}
+
+template <typename T>
+nlohmann::json
+JsonInvertedIndex<T>::BuildTantivyMeta(
+    const std::vector<std::string>& file_names, bool has_null) {
+    auto meta = InvertedIndexTantivy<T>::BuildTantivyMeta(file_names, has_null);
+    std::shared_lock<folly::SharedMutex> lock(this->mutex_);
+    meta["has_non_exist"] = !this->non_exist_offsets_.empty();
+    return meta;
+}
+
+template <typename T>
+void
+JsonInvertedIndex<T>::WriteEntries(storage::IndexEntryWriter* writer) {
+    // Call parent to write tantivy index files and null_offset
+    InvertedIndexTantivy<T>::WriteEntries(writer);
+
+    // Write json-specific data (non_exist_offsets)
+    std::shared_lock<folly::SharedMutex> lock(this->mutex_);
+    bool has_non_exist = !this->non_exist_offsets_.empty();
+    writer->PutMeta("has_non_exist", has_non_exist);
+    if (has_non_exist) {
+        writer->WriteEntry(INDEX_NON_EXIST_OFFSET_FILE_NAME,
+                           this->non_exist_offsets_.data(),
+                           this->non_exist_offsets_.size() * sizeof(size_t));
+    }
+}
+
+template <typename T>
+void
+JsonInvertedIndex<T>::LoadEntries(storage::IndexEntryReader& reader,
+                                  const Config& config) {
+    // Call parent to load tantivy index files and null_offset
+    InvertedIndexTantivy<T>::LoadEntries(reader, config);
+
+    // Load json-specific data (non_exist_offsets)
+    bool has_non_exist = reader.GetMeta<bool>("has_non_exist", false);
+    if (has_non_exist) {
+        auto e = reader.ReadEntry(INDEX_NON_EXIST_OFFSET_FILE_NAME);
+        this->non_exist_offsets_.resize(e.data.size() / sizeof(size_t));
+        std::memcpy(
+            this->non_exist_offsets_.data(), e.data.data(), e.data.size());
+    }
+    LOG_INFO("LoadEntries JsonInvertedIndex done, has_non_exist: {}",
+             has_non_exist);
 }
 
 template class JsonInvertedIndex<bool>;

--- a/internal/core/src/index/JsonInvertedIndex.h
+++ b/internal/core/src/index/JsonInvertedIndex.h
@@ -12,6 +12,8 @@
 #pragma once
 #include <cstdint>
 #include <shared_mutex>
+#include "nlohmann/json_fwd.hpp"
+
 #include "common/Slice.h"
 #include "common/FieldDataInterface.h"
 #include "common/JsonCastFunction.h"
@@ -88,7 +90,7 @@ class JsonInvertedIndex : public index::InvertedIndexTantivy<T> {
           cast_type_(cast_type),
           cast_function_(cast_function) {
         this->schema_ = ctx.fieldDataMeta.field_schema;
-        this->mem_file_manager_ =
+        this->file_manager_ =
             std::make_shared<storage::MemFileManagerImpl>(ctx);
         this->disk_file_manager_ =
             std::make_shared<storage::DiskFileManagerImpl>(ctx);
@@ -171,7 +173,18 @@ class JsonInvertedIndex : public index::InvertedIndexTantivy<T> {
     TargetBitmap
     Exists();
 
+    void
+    WriteEntries(storage::IndexEntryWriter* writer) override;
+
+    void
+    LoadEntries(storage::IndexEntryReader& reader,
+                const Config& config) override;
+
  protected:
+    nlohmann::json
+    BuildTantivyMeta(const std::vector<std::string>& file_names,
+                     bool has_null) override;
+
     void
     LoadIndexMetas(const std::vector<std::string>& index_files,
                    const Config& config) override final;

--- a/internal/core/src/index/Meta.cpp
+++ b/internal/core/src/index/Meta.cpp
@@ -1,0 +1,21 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "index/Meta.h"
+
+namespace milvus::index {
+bool kScalarIndexUseV3 = false;
+}  // namespace milvus::index

--- a/internal/core/src/index/Meta.h
+++ b/internal/core/src/index/Meta.h
@@ -112,4 +112,8 @@ constexpr const char* DISK_ANN_PREPARE_USE_BFS_CACHE = "use_bfs_cache";
 // DiskAnn query params
 constexpr const char* DISK_ANN_QUERY_LIST = "search_list";
 constexpr const char* DISK_ANN_QUERY_BEAMWIDTH = "beamwidth";
+// UT-only flag: when true, index Upload()/Load() route to V3 paths.
+// In production, V2/V3 routing is handled by callers (ScalarIndexCreator, SealedIndexTranslator).
+// Delete this along with V2 Upload/Load code when V2 compatibility is dropped.
+extern bool kScalarIndexUseV3;
 }  // namespace milvus::index

--- a/internal/core/src/index/NgramInvertedIndex.h
+++ b/internal/core/src/index/NgramInvertedIndex.h
@@ -104,6 +104,13 @@ class NgramInvertedIndex : public InvertedIndexTantivy<std::string> {
         this->wrapper_->create_reader(set_bitset);
     }
 
+    void
+    WriteEntries(storage::IndexEntryWriter* writer) override;
+
+    void
+    LoadEntries(storage::IndexEntryReader& reader,
+                const Config& config) override;
+
  private:
     void
     ApplyIterativeNgramFilter(const std::vector<std::string>& sorted_terms,

--- a/internal/core/src/index/RTreeIndex.cpp
+++ b/internal/core/src/index/RTreeIndex.cpp
@@ -10,6 +10,8 @@
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
 #include <string.h>
+#include <fcntl.h>
+#include <unistd.h>
 #include <algorithm>
 #include <cstdint>
 #include <exception>
@@ -42,6 +44,9 @@
 #include "storage/LocalChunkManager.h"
 #include "storage/LocalChunkManagerSingleton.h"
 #include "storage/ThreadPools.h"
+#include "storage/FileWriter.h"
+#include "storage/IndexEntryReader.h"
+#include "storage/IndexEntryWriter.h"
 #include "storage/Types.h"
 
 namespace milvus::index {
@@ -87,6 +92,7 @@ RTreeIndex<T>::RTreeIndex(const storage::FileManagerContext& ctx)
       schema_(ctx.fieldDataMeta.field_schema) {
     mem_file_manager_ = std::make_shared<MemFileManager>(ctx);
     disk_file_manager_ = std::make_shared<DiskFileManager>(ctx);
+    this->file_manager_ = mem_file_manager_;
 
     if (ctx.for_loading_index) {
         return;
@@ -123,6 +129,10 @@ template <typename T>
 void
 RTreeIndex<T>::Load(milvus::tracer::TraceContext ctx, const Config& config) {
     LOG_DEBUG("Load RTreeIndex with config {}", config.dump());
+    if (kScalarIndexUseV3) {
+        this->LoadV3(config);
+        return;
+    }
 
     auto index_files_opt =
         GetValueFromConfig<std::vector<std::string>>(config, "index_files");
@@ -328,6 +338,9 @@ RTreeIndex<T>::finish() {
 template <typename T>
 IndexStatsPtr
 RTreeIndex<T>::Upload(const Config& config) {
+    if (kScalarIndexUseV3) {
+        return this->UploadV3(config);
+    }
     // 1. Ensure all buffered data flushed to disk
     finish();
 
@@ -615,6 +628,122 @@ RTreeIndex<T>::AddGeometry(const std::string& wkb_data, int64_t row_offset) {
 
         LOG_DEBUG("Added null geometry at row offset {}", row_offset);
     }
+}
+
+template <typename T>
+void
+RTreeIndex<T>::WriteEntries(storage::IndexEntryWriter* writer) {
+    finish();
+
+    std::vector<boost::filesystem::path> files;
+    if (!path_.empty()) {
+        boost::filesystem::path dir(path_);
+        for (boost::filesystem::directory_iterator iter(dir);
+             iter != boost::filesystem::directory_iterator();
+             ++iter) {
+            if (!boost::filesystem::is_directory(*iter)) {
+                files.push_back(iter->path());
+            }
+        }
+        std::sort(files.begin(), files.end());
+    }
+
+    std::vector<std::string> file_names;
+    for (const auto& f : files) {
+        file_names.push_back(f.filename().string());
+    }
+
+    std::shared_lock<folly::SharedMutexWritePriority> lock(mutex_);
+    bool has_null = !null_offset_.empty();
+    lock.unlock();
+
+    writer->PutMeta("file_names", file_names);
+    writer->PutMeta("has_null", has_null);
+
+    for (const auto& file_path : files) {
+        auto file = file_path.string();
+        auto fd = open(file.c_str(), O_RDONLY | O_CLOEXEC);
+        AssertInfo(fd != -1, "open file failed: {}", file);
+        auto file_size = boost::filesystem::file_size(file);
+        auto file_name = file_path.filename().string();
+        writer->WriteEntry(file_name, fd, file_size);
+        close(fd);
+    }
+
+    if (has_null) {
+        std::shared_lock<folly::SharedMutexWritePriority> lock2(mutex_);
+        writer->WriteEntry("index_null_offset",
+                           null_offset_.data(),
+                           null_offset_.size() * sizeof(size_t));
+    }
+
+    LOG_INFO("write rtree index entries: {} files, {} null offsets",
+             files.size(),
+             null_offset_.size());
+}
+
+template <typename T>
+void
+RTreeIndex<T>::LoadEntries(storage::IndexEntryReader& reader,
+                           const Config& config) {
+    auto file_names = reader.GetMeta<std::vector<std::string>>("file_names");
+    bool has_null = reader.GetMeta<bool>("has_null");
+
+    path_ = disk_file_manager_->GetLocalIndexObjectPrefix();
+    boost::filesystem::create_directories(path_);
+
+    std::vector<std::pair<std::string, std::string>> pairs;
+    for (const auto& fn : file_names) {
+        pairs.emplace_back(fn, path_ + "/" + fn);
+    }
+    reader.ReadEntriesToFiles(pairs);
+
+    if (has_null) {
+        auto null_entry = reader.ReadEntry("index_null_offset");
+        null_offset_.resize(null_entry.data.size() / sizeof(size_t));
+        std::memcpy(null_offset_.data(),
+                    null_entry.data.data(),
+                    null_entry.data.size());
+    }
+
+    // Determine base path (without extension) from local file names,
+    // same logic as V2 Load.
+    std::string base_path;
+    for (const auto& fn : file_names) {
+        auto local = path_ + "/" + fn;
+        if (ends_with(local, ".bgi")) {
+            base_path = local.substr(0, local.size() - 4);
+            break;
+        }
+    }
+    if (base_path.empty()) {
+        for (const auto& fn : file_names) {
+            auto local = path_ + "/" + fn;
+            if (ends_with(local, ".meta.json")) {
+                base_path = local.substr(
+                    0, local.size() - std::string(".meta.json").size());
+                break;
+            }
+        }
+    }
+    AssertInfo(!base_path.empty(),
+               "RTreeIndex LoadEntries: cannot determine base path from files");
+    path_ = base_path;
+
+    wrapper_ =
+        std::make_shared<RTreeIndexWrapper>(path_, /*is_build_mode=*/false);
+    wrapper_->load();
+
+    total_num_rows_ =
+        wrapper_->count() + static_cast<int64_t>(null_offset_.size());
+    is_built_ = true;
+    ComputeByteSize();
+    LOG_INFO(
+        "LoadEntries RTreeIndex done, file_count: {}, has_null: {}, "
+        "base_path: {}",
+        file_names.size(),
+        has_null,
+        path_);
 }
 
 // Explicit template instantiation for std::string as we only support string field for now.

--- a/internal/core/src/index/RTreeIndex.h
+++ b/internal/core/src/index/RTreeIndex.h
@@ -191,11 +191,17 @@ class RTreeIndex : public ScalarIndex<T> {
     void
     BuildWithFieldData(const std::vector<FieldDataPtr>& datas) override;
 
+    void
+    WriteEntries(storage::IndexEntryWriter* writer) override;
+
+    void
+    LoadEntries(storage::IndexEntryReader& reader,
+                const Config& config) override;
+
  protected:
     void
     finish();
 
- protected:
     std::shared_ptr<RTreeIndexWrapper> wrapper_;
     std::string path_;
     proto::schema::FieldSchema schema_;

--- a/internal/core/src/index/RTreeIndexTest.cpp
+++ b/internal/core/src/index/RTreeIndexTest.cpp
@@ -259,9 +259,13 @@ TEST_F(RTreeIndexTest, Load_WithFileNamesOnly) {
     for (const auto& path : stats->GetIndexFiles()) {
         filenames.emplace_back(
             boost::filesystem::path(path).filename().string());
-        // make sure file exists in remote storage
-        ASSERT_TRUE(chunk_manager_->Exist(path));
-        ASSERT_GT(chunk_manager_->Size(path), 0);
+        // In V2 mode, files are stored via chunk_manager.
+        // In V3 mode, files are stored via ArrowFileSystem (fs_),
+        // so chunk_manager won't find them.
+        if (!milvus::index::kScalarIndexUseV3) {
+            ASSERT_TRUE(chunk_manager_->Exist(path));
+            ASSERT_GT(chunk_manager_->Size(path), 0);
+        }
     }
 
     // Load using filename only list
@@ -363,6 +367,24 @@ TEST_F(RTreeIndexTest, Build_ConfigAndMetaJson) {
 
     rtree.Build(build_cfg);
     auto stats = rtree.Upload({});
+
+    if (milvus::index::kScalarIndexUseV3) {
+        // V3 mode: verify upload produced a single packed file and can be loaded
+        auto index_files = stats->GetIndexFiles();
+        ASSERT_EQ(index_files.size(), 1);
+
+        milvus::storage::FileManagerContext ctx_load(
+            field_meta_, index_meta_, chunk_manager_, fs_);
+        ctx_load.set_for_loading_index(true);
+        milvus::index::RTreeIndex<std::string> rtree_load(ctx_load);
+
+        nlohmann::json cfg;
+        cfg["index_files"] = index_files;
+        milvus::tracer::TraceContext trace_ctx;
+        rtree_load.Load(trace_ctx, cfg);
+        ASSERT_EQ(rtree_load.Count(), 2);
+        return;
+    }
 
     // Cache remote index files locally
     milvus::storage::DiskFileManagerImpl diskfm(

--- a/internal/core/src/index/ScalarIndex.cpp
+++ b/internal/core/src/index/ScalarIndex.cpp
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 #include <stddef.h>
+#include <algorithm>
 #include <cstdint>
 #include <iostream>
 #include <string>
@@ -22,10 +23,17 @@
 
 #include "common/Types.h"
 #include "fmt/core.h"
+#include "index/IndexStats.h"
 #include "index/Meta.h"
 #include "index/ScalarIndex.h"
+#include "index/Utils.h"
 #include "knowhere/dataset.h"
+#include "log/Log.h"
 #include "pb/schema.pb.h"
+#include "storage/FileManager.h"
+#include "storage/IndexEntryReader.h"
+#include "storage/IndexEntryWriter.h"
+#include "storage/Util.h"
 
 namespace milvus::index {
 template <typename T>
@@ -151,6 +159,89 @@ ScalarIndex<double>::BuildWithRawDataForUT(size_t n,
                                            const Config& config) {
     auto data = reinterpret_cast<double*>(const_cast<void*>(values));
     Build(n, data);
+}
+
+template <typename T>
+IndexStatsPtr
+ScalarIndex<T>::UploadV3(const Config& config) {
+    AssertInfo(file_manager_ != nullptr,
+               "file_manager_ is null, UploadV3 requires a valid file manager");
+
+    // Build filename: milvus_packed_<type>_index.v3
+    auto type_str = ToString(GetIndexType());
+    std::transform(
+        type_str.begin(), type_str.end(), type_str.begin(), ::tolower);
+    auto filename = "milvus_packed_" + type_str + "_index.v3";
+
+    // Create the IndexEntryWriter
+    auto writer =
+        file_manager_->CreateIndexEntryWriterV3(filename, is_index_file_);
+    AssertInfo(writer != nullptr,
+               "failed to create IndexEntryWriter for V3 format");
+
+    // Call subclass implementation to write all entries.
+    // Subclasses use writer->PutMeta() to add their metadata.
+    WriteEntries(writer.get());
+
+    // Finish writing - writes __meta__ entry, Directory Table and Footer
+    writer->Finish();
+
+    // Get actual file size from writer
+    auto file_size = writer->GetTotalBytesWritten();
+
+    LOG_INFO("UploadV3 completed for index type: {}, file size: {}",
+             index_type_,
+             file_size);
+
+    // Return IndexStats with the single packed file (full remote path)
+    std::vector<SerializedIndexFileInfo> index_files;
+    auto remote_prefix = is_index_file_
+                             ? file_manager_->GetRemoteIndexObjectPrefixV2()
+                             : file_manager_->GetRemoteTextLogPrefixV2();
+    auto remote_path = remote_prefix + "/" + filename;
+    index_files.emplace_back(remote_path, file_size);
+
+    return IndexStats::New(file_size, std::move(index_files));
+}
+
+template <typename T>
+void
+ScalarIndex<T>::LoadV3(const Config& config) {
+    AssertInfo(file_manager_ != nullptr,
+               "file_manager_ is null, LoadV3 requires a valid file manager");
+
+    // Get the packed index file path from config
+    auto index_files =
+        GetValueFromConfig<std::vector<std::string>>(config, INDEX_FILES);
+    AssertInfo(index_files.has_value() && !index_files.value().empty(),
+               "index_files is required for LoadV3");
+
+    // For V3 format, there should be exactly one packed file
+    AssertInfo(index_files.value().size() == 1,
+               "LoadV3 expects exactly one packed index file, got: {}",
+               index_files.value().size());
+    const auto& packed_file = index_files.value()[0];
+
+    LOG_INFO("LoadV3: loading packed index file: {}", packed_file);
+
+    // Open the file using the file manager
+    auto input = file_manager_->OpenInputStream(packed_file, is_index_file_);
+    AssertInfo(input != nullptr,
+               "failed to open input stream for packed index file: {}",
+               packed_file);
+
+    size_t file_size = input->Size();
+
+    auto collection_id =
+        GetValueFromConfig<int64_t>(config, COLLECTION_ID).value_or(0);
+
+    auto reader =
+        storage::IndexEntryReader::Open(input, file_size, collection_id);
+    AssertInfo(reader != nullptr, "failed to create IndexEntryReader");
+
+    LoadEntries(*reader, config);
+
+    LOG_INFO("LoadV3 completed for index type: {}", index_type_);
 }
 
 template class ScalarIndex<bool>;

--- a/internal/core/src/index/ScalarIndex.h
+++ b/internal/core/src/index/ScalarIndex.h
@@ -27,6 +27,13 @@
 #include "fmt/format.h"
 #include "index/Meta.h"
 
+namespace milvus::storage {
+class IndexEntryWriter;
+class IndexEntryReader;
+class MemFileManagerImpl;
+using MemFileManagerImplPtr = std::shared_ptr<MemFileManagerImpl>;
+}  // namespace milvus::storage
+
 namespace milvus::index {
 
 enum class ScalarIndexType {
@@ -206,6 +213,34 @@ class ScalarIndex : public IndexBase {
     LoadWithoutAssemble(const BinarySet& binary_set, const Config& config) {
         ThrowInfo(Unsupported, "LoadWithoutAssemble is not supported");
     }
+
+    // V3 streaming upload - subclasses must implement WriteEntries() instead
+    IndexStatsPtr
+    UploadV3(const Config& config) override;
+
+    // V3 streaming load - loads index from a packed V3 format file
+    // Opens the file and calls LoadEntries() for subclass-specific loading
+    void
+    LoadV3(const Config& config) override;
+
+    virtual void
+    WriteEntries(storage::IndexEntryWriter* writer) {
+        ThrowInfo(Unsupported, "WriteEntries is not implemented");
+    }
+
+    virtual void
+    LoadEntries(storage::IndexEntryReader& reader, const Config& config) {
+        ThrowInfo(Unsupported, "LoadEntries is not implemented");
+    }
+
+ protected:
+    // File manager for V3 upload/load operations
+    storage::MemFileManagerImplPtr file_manager_;
+
+    // Controls the remote path prefix for V3 upload/load.
+    // true  → index_files/...  (default, for normal scalar indexes)
+    // false → text_log/...     (for TextMatchIndex)
+    bool is_index_file_ = true;
 };
 
 template <typename T>

--- a/internal/core/src/index/ScalarIndexSort.cpp
+++ b/internal/core/src/index/ScalarIndexSort.cpp
@@ -48,6 +48,8 @@
 #include "pb/common.pb.h"
 #include "storage/DiskFileManagerImpl.h"
 #include "storage/FileWriter.h"
+#include "storage/IndexEntryReader.h"
+#include "storage/IndexEntryWriter.h"
 #include "storage/MemFileManagerImpl.h"
 #include "storage/ThreadPools.h"
 #include "storage/Types.h"
@@ -74,7 +76,7 @@ ScalarIndexSort<T>::ScalarIndexSort(
     // not valid means we are in unit test
     if (file_manager_context.Valid()) {
         field_id_ = file_manager_context.fieldDataMeta.field_id;
-        file_manager_ =
+        this->file_manager_ =
             std::make_shared<storage::MemFileManagerImpl>(file_manager_context);
         disk_file_manager_ = std::make_shared<storage::DiskFileManagerImpl>(
             file_manager_context);
@@ -87,8 +89,10 @@ ScalarIndexSort<T>::Build(const Config& config) {
     if (is_built_) {
         return;
     }
-    auto field_datas =
-        storage::CacheRawDataAndFillMissing(file_manager_, config);
+    auto field_datas = storage::CacheRawDataAndFillMissing(
+        std::static_pointer_cast<storage::MemFileManagerImpl>(
+            this->file_manager_),
+        config);
 
     BuildWithFieldData(field_datas);
 }
@@ -256,6 +260,9 @@ ScalarIndexSort<T>::Serialize(const Config& config) {
 template <typename T>
 IndexStatsPtr
 ScalarIndexSort<T>::Upload(const Config& config) {
+    if (kScalarIndexUseV3) {
+        return this->UploadV3(config);
+    }
     auto index_build_duration =
         std::chrono::duration_cast<std::chrono::milliseconds>(
             std::chrono::system_clock::now() - index_build_begin_)
@@ -269,11 +276,64 @@ ScalarIndexSort<T>::Upload(const Config& config) {
         index_build_duration);
 
     auto binary_set = Serialize(config);
-    file_manager_->AddFile(binary_set);
+    this->file_manager_->AddFile(binary_set);
 
-    auto remote_paths_to_size = file_manager_->GetRemotePathsToFileSize();
-    return IndexStats::NewFromSizeMap(file_manager_->GetAddedTotalMemSize(),
-                                      remote_paths_to_size);
+    auto remote_paths_to_size = this->file_manager_->GetRemotePathsToFileSize();
+    return IndexStats::NewFromSizeMap(
+        this->file_manager_->GetAddedTotalMemSize(), remote_paths_to_size);
+}
+
+template <typename T>
+void
+ScalarIndexSort<T>::SetupMmapFromData(
+    const uint8_t* data,
+    size_t size,
+    milvus::proto::common::LoadPriority priority) {
+    // Setup mmap file path
+    mmap_filepath_ = disk_file_manager_ != nullptr
+                         ? disk_file_manager_->GetLocalIndexObjectPrefix() +
+                               STLSORT_INDEX_FILE_NAME
+                         : MMAP_PATH_FOR_TEST;
+    std::filesystem::create_directories(
+        std::filesystem::path(mmap_filepath_).parent_path());
+
+    auto aligned_size = ((size + ALIGNMENT - 1) / ALIGNMENT) * ALIGNMENT;
+
+    // Write data to file with alignment padding
+    {
+        auto file_writer = storage::FileWriter(
+            mmap_filepath_, storage::io::GetPriorityFromLoadPriority(priority));
+        file_writer.Write(data, size);
+
+        if (aligned_size > size) {
+            std::vector<uint8_t> padding(aligned_size - size, 0);
+            file_writer.Write(padding.data(), padding.size());
+        }
+        // Write extra padding for safety
+        std::vector<uint8_t> padding(MMAP_INDEX_PADDING, 0);
+        file_writer.Write(padding.data(), padding.size());
+        file_writer.Finish();
+    }
+
+    // mmap the file
+    auto file = File::Open(mmap_filepath_, O_RDONLY);
+    mmap_data_ = static_cast<char*>(mmap(NULL,
+                                         aligned_size + MMAP_INDEX_PADDING,
+                                         PROT_READ,
+                                         MAP_PRIVATE,
+                                         file.Descriptor(),
+                                         0));
+
+    if (mmap_data_ == MAP_FAILED) {
+        file.Close();
+        remove(mmap_filepath_.c_str());
+        ThrowInfo(
+            ErrorCode::UnexpectedError, "failed to mmap: {}", strerror(errno));
+    }
+
+    mmap_size_ = aligned_size + MMAP_INDEX_PADDING;
+    data_size_ = size;
+    file.Close();
 }
 
 template <typename T>
@@ -296,57 +356,14 @@ ScalarIndexSort<T>::LoadWithoutAssemble(const BinarySet& index_binary,
     auto index_data = index_binary.GetByName("index_data");
 
     if (is_mmap_) {
-        // some test may pass invalid file_manager_context in constructor which results in a nullptr disk_file_manager_
-        mmap_filepath_ = disk_file_manager_ != nullptr
-                             ? disk_file_manager_->GetLocalIndexObjectPrefix() +
-                                   STLSORT_INDEX_FILE_NAME
-                             : MMAP_PATH_FOR_TEST;
-        std::filesystem::create_directories(
-            std::filesystem::path(mmap_filepath_).parent_path());
-
-        auto aligned_size =
-            ((index_data->size + ALIGNMENT - 1) / ALIGNMENT) * ALIGNMENT;
-        {
-            auto load_priority =
-                GetValueFromConfig<milvus::proto::common::LoadPriority>(
-                    config, milvus::LOAD_PRIORITY)
-                    .value_or(milvus::proto::common::LoadPriority::HIGH);
-            auto file_writer = storage::FileWriter(
-                mmap_filepath_,
-                storage::io::GetPriorityFromLoadPriority(load_priority));
-            file_writer.Write(index_data->data.get(), (size_t)index_data->size);
-
-            if (aligned_size > index_data->size) {
-                std::vector<uint8_t> padding(aligned_size - index_data->size,
-                                             0);
-                file_writer.Write(padding.data(), padding.size());
-            }
-            // write padding in case of all null values
-            std::vector<uint8_t> padding(MMAP_INDEX_PADDING, 0);
-            file_writer.Write(padding.data(), padding.size());
-            file_writer.Finish();
-        }
-
-        auto file = File::Open(mmap_filepath_, O_RDONLY);
-        mmap_data_ = static_cast<char*>(mmap(NULL,
-                                             aligned_size + MMAP_INDEX_PADDING,
-                                             PROT_READ,
-                                             MAP_PRIVATE,
-                                             file.Descriptor(),
-                                             0));
-
-        if (mmap_data_ == MAP_FAILED) {
-            file.Close();
-            remove(mmap_filepath_.c_str());
-            ThrowInfo(ErrorCode::UnexpectedError,
-                      "failed to mmap: {}",
-                      strerror(errno));
-        }
-
-        mmap_size_ = aligned_size + MMAP_INDEX_PADDING;
-        data_size_ = index_data->size;
-
-        file.Close();
+        auto load_priority =
+            GetValueFromConfig<milvus::proto::common::LoadPriority>(
+                config, milvus::LOAD_PRIORITY)
+                .value_or(milvus::proto::common::LoadPriority::HIGH);
+        SetupMmapFromData(
+            reinterpret_cast<const uint8_t*>(index_data->data.get()),
+            index_data->size,
+            load_priority);
     } else {
         data_.resize(index_size);
         memcpy(data_.data(), index_data->data.get(), (size_t)index_data->size);
@@ -391,6 +408,10 @@ template <typename T>
 void
 ScalarIndexSort<T>::Load(milvus::tracer::TraceContext ctx,
                          const Config& config) {
+    if (kScalarIndexUseV3) {
+        this->LoadV3(config);
+        return;
+    }
     auto index_files =
         GetValueFromConfig<std::vector<std::string>>(config, "index_files");
     AssertInfo(index_files.has_value(),
@@ -399,8 +420,8 @@ ScalarIndexSort<T>::Load(milvus::tracer::TraceContext ctx,
         GetValueFromConfig<milvus::proto::common::LoadPriority>(
             config, milvus::LOAD_PRIORITY)
             .value_or(milvus::proto::common::LoadPriority::HIGH);
-    auto index_datas =
-        file_manager_->LoadIndexToMemory(index_files.value(), load_priority);
+    auto index_datas = this->file_manager_->LoadIndexToMemory(
+        index_files.value(), load_priority);
     BinarySet binary_set;
     AssembleIndexDatas(index_datas, binary_set);
     // clear index_datas to free memory early
@@ -642,6 +663,63 @@ ScalarIndexSort<T>::ShouldSkip(const T lower_value,
         return shouldSkip;
     }
     return true;
+}
+
+template <typename T>
+void
+ScalarIndexSort<T>::WriteEntries(storage::IndexEntryWriter* writer) {
+    AssertInfo(is_built_, "index has not been built");
+
+    writer->PutMeta("index_length", data_.size());
+    writer->PutMeta("num_rows", total_num_rows_);
+    writer->PutMeta("is_nested", is_nested_index_);
+
+    writer->WriteEntry(
+        "index_data", data_.data(), data_.size() * sizeof(IndexStructure<T>));
+}
+
+template <typename T>
+void
+ScalarIndexSort<T>::LoadEntries(storage::IndexEntryReader& reader,
+                                const Config& config) {
+    size_t index_size = reader.GetMeta<size_t>("index_length");
+    total_num_rows_ = reader.GetMeta<size_t>("num_rows");
+    is_nested_index_ = reader.GetMeta<bool>("is_nested");
+
+    auto data_entry = reader.ReadEntry("index_data");
+
+    is_mmap_ = GetValueFromConfig<bool>(config, ENABLE_MMAP).value_or(true);
+
+    if (is_mmap_) {
+        auto load_priority =
+            GetValueFromConfig<milvus::proto::common::LoadPriority>(
+                config, milvus::LOAD_PRIORITY)
+                .value_or(milvus::proto::common::LoadPriority::HIGH);
+        SetupMmapFromData(
+            data_entry.data.data(), data_entry.data.size(), load_priority);
+    } else {
+        data_.resize(index_size);
+        std::memcpy(
+            data_.data(), data_entry.data.data(), data_entry.data.size());
+    }
+
+    setup_data_pointers();
+
+    idx_to_offsets_.resize(total_num_rows_);
+    valid_bitset_ = TargetBitmap(total_num_rows_, false);
+
+    for (size_t i = 0; i < Size(); ++i) {
+        const auto& item = operator[](i);
+        idx_to_offsets_[item.idx_] = i;
+        valid_bitset_.set(item.idx_);
+    }
+
+    is_built_ = true;
+    ComputeByteSize();
+
+    LOG_INFO("LoadEntries ScalarIndexSort done, field_id: {}, is_mmap:{}",
+             field_id_,
+             is_mmap_);
 }
 
 template class ScalarIndexSort<bool>;

--- a/internal/core/src/index/ScalarIndexSort.h
+++ b/internal/core/src/index/ScalarIndexSort.h
@@ -186,6 +186,13 @@ class ScalarIndexSort : public ScalarIndex<T> {
     LoadWithoutAssemble(const BinarySet& binary_set,
                         const Config& config) override;
 
+    void
+    WriteEntries(storage::IndexEntryWriter* writer) override;
+
+    void
+    LoadEntries(storage::IndexEntryReader& reader,
+                const Config& config) override;
+
  public:
     // zero-cost data acess api
     ALWAYS_INLINE const IndexStructure<T>&
@@ -213,6 +220,15 @@ class ScalarIndexSort : public ScalarIndex<T> {
     }
 
  private:
+    /**
+     * Write data to mmap file and setup mmap pointers.
+     * Sets mmap_data_, mmap_size_, data_size_.
+     */
+    void
+    SetupMmapFromData(const uint8_t* data,
+                      size_t size,
+                      milvus::proto::common::LoadPriority priority);
+
     void
     setup_data_pointers() const {
         if (is_mmap_) {
@@ -232,7 +248,6 @@ class ScalarIndexSort : public ScalarIndex<T> {
     bool is_built_ = false;
     Config config_;
     std::vector<int32_t> idx_to_offsets_;  // used to retrieve.
-    std::shared_ptr<storage::MemFileManagerImpl> file_manager_;
     std::shared_ptr<storage::DiskFileManagerImpl> disk_file_manager_;
     size_t total_num_rows_{0};
     // generate valid_bitset_ to speed up NotIn and IsNull and IsNotNull operate

--- a/internal/core/src/index/ScalarIndexSortTest.cpp
+++ b/internal/core/src/index/ScalarIndexSortTest.cpp
@@ -5,16 +5,24 @@
 #include <functional>
 #include <memory>
 #include <optional>
+#include <string>
 #include <vector>
 
 #include "bitset/bitset.h"
+#include "common/Tracer.h"
 #include "common/TracerBase.h"
 #include "common/Types.h"
 #include "gtest/gtest.h"
 #include "index/Meta.h"
 #include "index/ScalarIndexSort.h"
+#include "milvus-storage/filesystem/fs.h"
 #include "pb/common.pb.h"
+#include "storage/ChunkManager.h"
+#include "storage/FileManager.h"
 #include "storage/ThreadPools.h"
+#include "storage/Util.h"
+#include "test_utils/TmpPath.h"
+#include "test_utils/storage_test_utils.h"
 
 using namespace milvus;
 using namespace milvus::index;
@@ -102,4 +110,114 @@ TEST(StlSortIndexTest, TestIn) {
 
     test_stlsort_for_range(
         data, DataType::INT64, true, exec_expr, expected_result);
+}
+
+// Verify that forcing kScalarIndexUseV3=false still produces valid V2
+// index files (multiple files) and that the data round-trips correctly.
+TEST(ScalarIndexV2Compat, ForceV2Upload) {
+    // RAII guard to save and restore kScalarIndexUseV3
+    const bool original_value = milvus::index::kScalarIndexUseV3;
+    struct VersionGuard {
+        bool saved;
+        ~VersionGuard() {
+            milvus::index::kScalarIndexUseV3 = saved;
+        }
+    } guard{original_value};
+
+    // Force V2 mode
+    milvus::index::kScalarIndexUseV3 = false;
+
+    // Setup local storage and ArrowFileSystem via TmpPath
+    milvus::test::TmpPath temp_path;
+    auto storage_config = gen_local_storage_config(temp_path.get().string());
+    auto chunk_manager = milvus::storage::CreateChunkManager(storage_config);
+    auto fs = milvus::storage::InitArrowFileSystem(storage_config);
+
+    // Prepare field and index metadata
+    auto field_meta = milvus::segcore::gen_field_meta(
+        /*collection_id=*/1,
+        /*partition_id=*/1,
+        /*segment_id=*/1,
+        /*field_id=*/100,
+        DataType::INT64);
+    auto index_meta = gen_index_meta(
+        /*segment_id=*/1,
+        /*field_id=*/100,
+        /*index_build_id=*/1,
+        /*index_version=*/1);
+
+    // Create FileManagerContext for building
+    milvus::storage::FileManagerContext ctx_build(
+        field_meta, index_meta, chunk_manager, fs);
+
+    // Build index with test data
+    const size_t nb = 100;
+    std::vector<int64_t> data(nb);
+    for (size_t i = 0; i < nb; ++i) {
+        data[i] = static_cast<int64_t>(nb - i);  // reverse order: 100..1
+    }
+
+    auto index_build =
+        std::make_shared<milvus::index::ScalarIndexSort<int64_t>>(ctx_build);
+    index_build->Build(nb, data.data());
+    ASSERT_EQ(index_build->Count(), static_cast<int64_t>(nb));
+
+    // Upload (should use V2 path since kScalarIndexUseV3 == false)
+    auto stats = index_build->Upload({});
+    ASSERT_NE(stats, nullptr);
+
+    // V2 format produces multiple files (index_data, index_length, etc.)
+    auto index_files = stats->GetIndexFiles();
+    ASSERT_GT(index_files.size(), 1)
+        << "V2 upload should produce multiple files, got "
+        << index_files.size();
+
+    // Verify the files exist in chunk manager
+    for (const auto& file : index_files) {
+        ASSERT_TRUE(chunk_manager->Exist(file))
+            << "Index file should exist: " << file;
+        ASSERT_GT(chunk_manager->Size(file), 0)
+            << "Index file should be non-empty: " << file;
+    }
+
+    // Load back the index using the V2 Load path
+    milvus::storage::FileManagerContext ctx_load(
+        field_meta, index_meta, chunk_manager, fs);
+    auto index_load =
+        std::make_shared<milvus::index::ScalarIndexSort<int64_t>>(ctx_load);
+
+    nlohmann::json load_config;
+    load_config[milvus::index::INDEX_FILES] = index_files;
+    load_config[milvus::index::ENABLE_MMAP] = false;
+    load_config[milvus::LOAD_PRIORITY] =
+        milvus::proto::common::LoadPriority::HIGH;
+
+    milvus::tracer::TraceContext trace_ctx;
+    index_load->Load(trace_ctx, load_config);
+
+    ASSERT_EQ(index_load->Count(), static_cast<int64_t>(nb));
+
+    // Verify data correctness via Reverse_Lookup
+    for (size_t i = 0; i < nb; ++i) {
+        auto val = index_load->Reverse_Lookup(i);
+        ASSERT_TRUE(val.has_value())
+            << "Reverse_Lookup should succeed at " << i;
+        ASSERT_EQ(val.value(), data[i]) << "Value mismatch at offset " << i;
+    }
+
+    // Verify query correctness: Range [50, 60] inclusive
+    auto bitset = index_load->Range(
+        static_cast<int64_t>(50), true, static_cast<int64_t>(60), true);
+    int64_t count = 0;
+    for (size_t i = 0; i < nb; ++i) {
+        if (data[i] >= 50 && data[i] <= 60) {
+            ASSERT_TRUE(bitset[i])
+                << "Expected bit set for value " << data[i] << " at " << i;
+            count++;
+        } else {
+            ASSERT_FALSE(bitset[i])
+                << "Expected bit unset for value " << data[i] << " at " << i;
+        }
+    }
+    ASSERT_EQ(count, 11);  // values 50..60 inclusive = 11 values
 }

--- a/internal/core/src/index/StringIndexMarisa.cpp
+++ b/internal/core/src/index/StringIndexMarisa.cpp
@@ -50,6 +50,9 @@
 #include "nlohmann/json.hpp"
 #include "pb/common.pb.h"
 #include "storage/FileWriter.h"
+#include "storage/LocalChunkManager.h"
+#include "storage/IndexEntryReader.h"
+#include "storage/IndexEntryWriter.h"
 #include "storage/MemFileManagerImpl.h"
 #include "storage/ThreadPools.h"
 #include "storage/Util.h"
@@ -60,7 +63,7 @@ StringIndexMarisa::StringIndexMarisa(
     const storage::FileManagerContext& file_manager_context)
     : StringIndex(MARISA_TRIE) {
     if (file_manager_context.Valid()) {
-        file_manager_ =
+        this->file_manager_ =
             std::make_shared<storage::MemFileManagerImpl>(file_manager_context);
     }
 }
@@ -124,8 +127,10 @@ StringIndexMarisa::Build(const Config& config) {
     if (built_) {
         ThrowInfo(IndexAlreadyBuild, "index has been built");
     }
-    auto field_datas =
-        storage::CacheRawDataAndFillMissing(file_manager_, config);
+    auto field_datas = storage::CacheRawDataAndFillMissing(
+        std::static_pointer_cast<storage::MemFileManagerImpl>(
+            this->file_manager_),
+        config);
 
     BuildWithFieldData(field_datas);
 }
@@ -234,12 +239,15 @@ StringIndexMarisa::Serialize(const Config& config) {
 
 IndexStatsPtr
 StringIndexMarisa::Upload(const Config& config) {
+    if (kScalarIndexUseV3) {
+        return UploadV3(config);
+    }
     auto binary_set = Serialize(config);
-    file_manager_->AddFile(binary_set);
+    this->file_manager_->AddFile(binary_set);
 
-    auto remote_paths_to_size = file_manager_->GetRemotePathsToFileSize();
-    return IndexStats::NewFromSizeMap(file_manager_->GetAddedTotalMemSize(),
-                                      remote_paths_to_size);
+    auto remote_paths_to_size = this->file_manager_->GetRemotePathsToFileSize();
+    return IndexStats::NewFromSizeMap(
+        this->file_manager_->GetAddedTotalMemSize(), remote_paths_to_size);
 }
 
 void
@@ -297,6 +305,10 @@ StringIndexMarisa::Load(const BinarySet& set, const Config& config) {
 void
 StringIndexMarisa::Load(milvus::tracer::TraceContext ctx,
                         const Config& config) {
+    if (kScalarIndexUseV3) {
+        this->LoadV3(config);
+        return;
+    }
     auto index_files =
         GetValueFromConfig<std::vector<std::string>>(config, "index_files");
     AssertInfo(index_files.has_value(),
@@ -305,8 +317,8 @@ StringIndexMarisa::Load(milvus::tracer::TraceContext ctx,
         GetValueFromConfig<milvus::proto::common::LoadPriority>(
             config, milvus::LOAD_PRIORITY)
             .value_or(milvus::proto::common::LoadPriority::HIGH);
-    auto index_datas =
-        file_manager_->LoadIndexToMemory(index_files.value(), load_priority);
+    auto index_datas = this->file_manager_->LoadIndexToMemory(
+        index_files.value(), load_priority);
     BinarySet binary_set;
     AssembleIndexDatas(index_datas, binary_set);
     // clear index_datas to free memory early
@@ -658,4 +670,90 @@ StringIndexMarisa::in_lexicographic_order() {
 
     return false;
 }
+
+void
+StringIndexMarisa::WriteEntries(storage::IndexEntryWriter* writer) {
+    // Write trie data via temp file (marisa trie writes to file descriptor)
+    auto local_cm =
+        storage::LocalChunkManagerSingleton::GetInstance().GetChunkManager();
+    std::string tmp_dir =
+        local_cm ? local_cm->GetRootPath() : std::string("/tmp");
+    auto uuid = boost::uuids::random_generator()();
+    auto uuid_string = boost::uuids::to_string(uuid);
+    auto file = tmp_dir + "/" + uuid_string;
+
+    auto fd = open(file.c_str(),
+                   O_RDWR | O_CREAT | O_EXCL | O_CLOEXEC,
+                   S_IRUSR | S_IWUSR | S_IXUSR);
+    AssertInfo(fd != -1, "open file failed: {}", file);
+
+    // Immediately unlink the file so it will be deleted when fd is closed,
+    // even if an exception occurs or the process crashes
+    unlink(file.c_str());
+
+    trie_.write(fd);
+
+    auto size = get_file_size(fd);
+    lseek(fd, 0, SEEK_SET);
+    writer->WriteEntry(MARISA_TRIE_INDEX, fd, size);
+
+    close(fd);
+
+    // Write str_ids
+    auto str_ids_len = str_ids_.size() * sizeof(size_t);
+    writer->WriteEntry(MARISA_STR_IDS, str_ids_.data(), str_ids_len);
+}
+
+void
+StringIndexMarisa::LoadEntries(storage::IndexEntryReader& reader,
+                               const Config& config) {
+    auto trie_entry = reader.ReadEntry(MARISA_TRIE_INDEX);
+
+    auto local_cm =
+        storage::LocalChunkManagerSingleton::GetInstance().GetChunkManager();
+    std::string tmp_dir =
+        local_cm ? local_cm->GetRootPath() : std::string("/tmp");
+    auto uuid = boost::uuids::random_generator()();
+    auto uuid_string = boost::uuids::to_string(uuid);
+    auto file_name = tmp_dir + "/" + uuid_string;
+
+    auto load_priority =
+        GetValueFromConfig<milvus::proto::common::LoadPriority>(
+            config, milvus::LOAD_PRIORITY)
+            .value_or(milvus::proto::common::LoadPriority::HIGH);
+
+    {
+        auto file_writer = storage::FileWriter(
+            file_name, storage::io::GetPriorityFromLoadPriority(load_priority));
+        file_writer.Write(trie_entry.data.data(), trie_entry.data.size());
+        file_writer.Finish();
+    }
+
+    if (config.contains(MMAP_FILE_PATH)) {
+        trie_.mmap(file_name.c_str());
+        mmap_file_raii_ = std::make_unique<MmapFileRAII>(file_name);
+    } else {
+        auto file = File::Open(file_name, O_RDONLY);
+        trie_.read(file.Descriptor());
+        mmap_file_raii_ = nullptr;
+    }
+
+    if (!config.contains(MMAP_FILE_PATH)) {
+        unlink(file_name.c_str());
+    }
+
+    auto str_ids_entry = reader.ReadEntry(MARISA_STR_IDS);
+
+    auto str_ids_len = str_ids_entry.data.size();
+    str_ids_.resize(str_ids_len / sizeof(size_t), MARISA_NULL_KEY_ID);
+    memcpy(str_ids_.data(), str_ids_entry.data.data(), str_ids_len);
+
+    fill_offsets();
+    built_ = true;
+    total_size_ = CalculateTotalSize();
+    ComputeByteSize();
+
+    LOG_INFO("LoadEntries StringIndexMarisa done");
+}
+
 }  // namespace milvus::index

--- a/internal/core/src/index/StringIndexMarisa.h
+++ b/internal/core/src/index/StringIndexMarisa.h
@@ -133,13 +133,19 @@ class StringIndexMarisa : public StringIndex {
     int64_t
     CalculateTotalSize() const;
 
+    void
+    WriteEntries(storage::IndexEntryWriter* writer) override;
+
+    void
+    LoadEntries(storage::IndexEntryReader& reader,
+                const Config& config) override;
+
  private:
     Config config_;
     marisa::Trie trie_;
     std::vector<int64_t> str_ids_;  // used to retrieve.
     std::map<size_t, std::vector<size_t>> str_ids_to_offsets_;
     bool built_ = false;
-    std::shared_ptr<storage::MemFileManagerImpl> file_manager_;
     int64_t total_size_ = 0;  // Cached total size to avoid runtime calculation
 };
 

--- a/internal/core/src/index/StringIndexSort.cpp
+++ b/internal/core/src/index/StringIndexSort.cpp
@@ -48,6 +48,8 @@
 #include "nlohmann/json.hpp"
 #include "pb/common.pb.h"
 #include "storage/FileWriter.h"
+#include "storage/IndexEntryReader.h"
+#include "storage/IndexEntryWriter.h"
 #include "storage/MemFileManagerImpl.h"
 #include "storage/ThreadPools.h"
 #include "storage/Types.h"
@@ -124,7 +126,7 @@ StringIndexSort::StringIndexSort(
       is_nested_index_(is_nested_index) {
     if (file_manager_context.Valid()) {
         field_id_ = file_manager_context.fieldDataMeta.field_id;
-        file_manager_ =
+        this->file_manager_ =
             std::make_shared<storage::MemFileManagerImpl>(file_manager_context);
     }
 }
@@ -170,8 +172,10 @@ StringIndexSort::Build(const Config& config) {
         return;
     }
     config_ = config;
-    auto field_datas =
-        storage::CacheRawDataAndFillMissing(file_manager_, config);
+    auto field_datas = storage::CacheRawDataAndFillMissing(
+        std::static_pointer_cast<storage::MemFileManagerImpl>(
+            this->file_manager_),
+        config);
     BuildWithFieldData(field_datas);
 }
 
@@ -277,6 +281,9 @@ StringIndexSort::Serialize(const Config& config) {
 
 IndexStatsPtr
 StringIndexSort::Upload(const Config& config) {
+    if (kScalarIndexUseV3) {
+        return UploadV3(config);
+    }
     auto index_build_duration =
         std::chrono::duration_cast<std::chrono::milliseconds>(
             std::chrono::system_clock::now() - index_build_begin_)
@@ -287,11 +294,11 @@ StringIndexSort::Upload(const Config& config) {
         index_build_duration);
 
     auto binary_set = Serialize(config);
-    file_manager_->AddFile(binary_set);
+    this->file_manager_->AddFile(binary_set);
 
-    auto remote_paths_to_size = file_manager_->GetRemotePathsToFileSize();
-    return IndexStats::NewFromSizeMap(file_manager_->GetAddedTotalMemSize(),
-                                      remote_paths_to_size);
+    auto remote_paths_to_size = this->file_manager_->GetRemotePathsToFileSize();
+    return IndexStats::NewFromSizeMap(
+        this->file_manager_->GetAddedTotalMemSize(), remote_paths_to_size);
 }
 
 void
@@ -302,6 +309,10 @@ StringIndexSort::Load(const BinarySet& index_binary, const Config& config) {
 
 void
 StringIndexSort::Load(milvus::tracer::TraceContext ctx, const Config& config) {
+    if (kScalarIndexUseV3) {
+        this->LoadV3(config);
+        return;
+    }
     auto index_files =
         GetValueFromConfig<std::vector<std::string>>(config, "index_files");
     AssertInfo(index_files.has_value() && !index_files.value().empty(),
@@ -312,8 +323,8 @@ StringIndexSort::Load(milvus::tracer::TraceContext ctx, const Config& config) {
             config, milvus::LOAD_PRIORITY)
             .value_or(milvus::proto::common::LoadPriority::HIGH);
 
-    auto index_datas =
-        file_manager_->LoadIndexToMemory(index_files.value(), load_priority);
+    auto index_datas = this->file_manager_->LoadIndexToMemory(
+        index_files.value(), load_priority);
 
     BinarySet binary_set;
     AssembleIndexDatas(index_datas, binary_set);
@@ -508,6 +519,92 @@ StringIndexSort::ComputeByteSize() {
     }
 
     cached_byte_size_ = total;
+}
+
+void
+StringIndexSort::WriteEntries(storage::IndexEntryWriter* writer) {
+    AssertInfo(is_built_, "index has not been built");
+    AssertInfo(impl_ != nullptr, "impl_ is null, cannot write entries");
+
+    auto* memory_impl = dynamic_cast<StringIndexSortMemoryImpl*>(impl_.get());
+    AssertInfo(memory_impl != nullptr,
+               "WriteEntries requires StringIndexSortMemoryImpl");
+
+    size_t total_size = memory_impl->GetSerializedSize();
+    std::vector<uint8_t> data_buffer(total_size);
+    size_t offset = 0;
+    memory_impl->SerializeToBinary(data_buffer.data(), offset);
+
+    size_t valid_bitset_size = (total_num_rows_ + 7) / 8;
+    std::vector<uint8_t> valid_bitset_data(valid_bitset_size, 0);
+    for (size_t i = 0; i < total_num_rows_; ++i) {
+        if (valid_bitset_[i]) {
+            valid_bitset_data[i / 8] |= (1 << (i % 8));
+        }
+    }
+
+    writer->PutMeta("version", SERIALIZATION_VERSION);
+    writer->PutMeta("num_rows", total_num_rows_);
+    writer->PutMeta("is_nested", is_nested_index_);
+    writer->WriteEntry("index_data", data_buffer.data(), total_size);
+    writer->WriteEntry(
+        "valid_bitset", valid_bitset_data.data(), valid_bitset_size);
+}
+
+void
+StringIndexSort::LoadEntries(storage::IndexEntryReader& reader,
+                             const Config& config) {
+    config_ = config;
+
+    uint32_t version = reader.GetMeta<uint32_t>("version");
+    if (version != SERIALIZATION_VERSION) {
+        ThrowInfo(milvus::ErrorCode::Unsupported,
+                  fmt::format("Unsupported StringIndexSort serialization "
+                              "version: {}, expected: {}",
+                              version,
+                              SERIALIZATION_VERSION));
+    }
+    total_num_rows_ = reader.GetMeta<size_t>("num_rows");
+    is_nested_index_ = reader.GetMeta<bool>("is_nested");
+
+    idx_to_offsets_.resize(total_num_rows_);
+
+    auto valid_bitset_entry = reader.ReadEntry("valid_bitset");
+    valid_bitset_ = TargetBitmap(total_num_rows_, false);
+    for (size_t i = 0; i < total_num_rows_; ++i) {
+        uint8_t byte = valid_bitset_entry.data[i / 8];
+        if (byte & (1 << (i % 8))) {
+            valid_bitset_.set(i);
+        }
+    }
+
+    auto index_data_entry = reader.ReadEntry("index_data");
+
+    if (config.contains(MMAP_FILE_PATH)) {
+        LOG_INFO("StringIndexSort::LoadEntries: loading with mmap strategy");
+        auto mmap_impl = std::make_unique<StringIndexSortMmapImpl>();
+        auto mmap_path =
+            GetValueFromConfig<std::string>(config, MMAP_FILE_PATH).value();
+        mmap_impl->SetMmapFilePath(mmap_path);
+        mmap_impl->LoadFromData(index_data_entry.data.data(),
+                                index_data_entry.data.size(),
+                                total_num_rows_,
+                                valid_bitset_,
+                                idx_to_offsets_);
+        impl_ = std::move(mmap_impl);
+    } else {
+        LOG_INFO("StringIndexSort::LoadEntries: loading with memory strategy");
+        impl_ = std::make_unique<StringIndexSortMemoryImpl>();
+        impl_->LoadFromData(index_data_entry.data.data(),
+                            index_data_entry.data.size(),
+                            total_num_rows_,
+                            valid_bitset_,
+                            idx_to_offsets_);
+    }
+
+    is_built_ = true;
+    total_size_ = CalculateTotalSize();
+    ComputeByteSize();
 }
 
 void
@@ -720,7 +817,20 @@ StringIndexSortMemoryImpl::LoadFromBinary(
     AssertInfo(index_data != nullptr,
                "Failed to find 'index_data' in binary_set");
 
-    auto parsed = ParseBinaryData(index_data->data.get(), index_data->size);
+    LoadFromData(index_data->data.get(),
+                 index_data->size,
+                 total_num_rows,
+                 valid_bitset,
+                 idx_to_offsets);
+}
+
+void
+StringIndexSortMemoryImpl::LoadFromData(const uint8_t* data,
+                                        size_t data_size,
+                                        size_t total_num_rows,
+                                        TargetBitmap& valid_bitset,
+                                        std::vector<int32_t>& idx_to_offsets) {
+    auto parsed = ParseBinaryData(data, data_size);
     unique_values_.clear();
     posting_lists_.clear();
     unique_values_.reserve(parsed.unique_count);
@@ -1125,20 +1235,31 @@ StringIndexSortMmapImpl::LoadFromBinary(const BinarySet& binary_set,
                                         TargetBitmap& valid_bitset,
                                         std::vector<int32_t>& idx_to_offsets) {
     auto index_data = binary_set.GetByName("index_data");
+    LoadFromData(index_data->data.get(),
+                 index_data->size,
+                 total_num_rows,
+                 valid_bitset,
+                 idx_to_offsets);
+}
 
+void
+StringIndexSortMmapImpl::LoadFromData(const uint8_t* data,
+                                      size_t data_size,
+                                      size_t total_num_rows,
+                                      TargetBitmap& valid_bitset,
+                                      std::vector<int32_t>& idx_to_offsets) {
     AssertInfo(!mmap_filepath_.empty(), "mmap filepath is not set");
 
     std::filesystem::create_directories(
         std::filesystem::path(mmap_filepath_).parent_path());
 
-    auto aligned_size =
-        ((index_data->size + ALIGNMENT - 1) / ALIGNMENT) * ALIGNMENT;
+    auto aligned_size = ((data_size + ALIGNMENT - 1) / ALIGNMENT) * ALIGNMENT;
     {
         auto file_writer = storage::FileWriter(mmap_filepath_);
-        file_writer.Write(index_data->data.get(), index_data->size);
+        file_writer.Write(data, data_size);
 
-        if (aligned_size > index_data->size) {
-            std::vector<uint8_t> padding(aligned_size - index_data->size, 0);
+        if (aligned_size > data_size) {
+            std::vector<uint8_t> padding(aligned_size - data_size, 0);
             file_writer.Write(padding.data(), padding.size());
         }
         // write padding in case of all null values
@@ -1153,7 +1274,7 @@ StringIndexSortMmapImpl::LoadFromBinary(const BinarySet& binary_set,
     }
 
     mmap_size_ = aligned_size + MMAP_INDEX_PADDING;
-    data_size_ = index_data->size;
+    data_size_ = data_size;
     mmap_data_ = static_cast<char*>(
         mmap(nullptr, mmap_size_, PROT_READ, MAP_PRIVATE, fd, 0));
     close(fd);

--- a/internal/core/src/indexbuilder/ScalarIndexCreator.cpp
+++ b/internal/core/src/indexbuilder/ScalarIndexCreator.cpp
@@ -120,6 +120,12 @@ ScalarIndexCreator::index_type() {
 
 index::IndexStatsPtr
 ScalarIndexCreator::Upload() {
-    return index_->Upload();
+    auto version = index::GetValueFromConfig<int32_t>(
+                       config_, index::SCALAR_INDEX_ENGINE_VERSION)
+                       .value_or(1);
+    if (version >= 3) {
+        return index_->UploadV3(config_);
+    }
+    return index_->Upload(config_);
 }
 }  // namespace milvus::indexbuilder

--- a/internal/core/src/storage/Crc32cUtil.h
+++ b/internal/core/src/storage/Crc32cUtil.h
@@ -1,0 +1,135 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <string>
+
+#include "crc32c/crc32c.h"
+
+namespace milvus::storage {
+
+inline uint32_t
+Crc32cUpdate(uint32_t crc, const void* data, size_t len) {
+    return crc32c::Extend(crc, reinterpret_cast<const uint8_t*>(data), len);
+}
+
+inline uint32_t
+Crc32cValue(const void* data, size_t len) {
+    return crc32c::Crc32c(reinterpret_cast<const uint8_t*>(data), len);
+}
+
+// crc32c_combine: combine two CRC-32C values without needing original data.
+// Given crc_a = CRC(A), crc_b = CRC(B), len_b = len(B),
+// returns CRC(A || B).
+//
+// Uses GF(2) matrix exponentiation with the CRC-32C polynomial (Castagnoli).
+// Equivalent to zlib's crc32_combine but for the CRC-32C polynomial.
+namespace detail {
+
+// The CRC-32C polynomial in reversed (reflected) form: 0x82F63B78
+// x^32 + x^28 + x^27 + x^26 + x^25 + x^23 + x^22 + x^20 +
+// x^19 + x^18 + x^14 + x^13 + x^11 + x^10 + x^9 + x^8 + x^6 + 1
+
+// Multiply a 32x32 GF(2) matrix by a 32-bit vector
+inline uint32_t
+Gf2MatrixTimes(const uint32_t* mat, uint32_t vec) {
+    uint32_t sum = 0;
+    while (vec) {
+        if (vec & 1) {
+            sum ^= *mat;
+        }
+        vec >>= 1;
+        mat++;
+    }
+    return sum;
+}
+
+// Square a 32x32 GF(2) matrix in-place
+inline void
+Gf2MatrixSquare(uint32_t* square, const uint32_t* mat) {
+    for (int n = 0; n < 32; n++) {
+        square[n] = Gf2MatrixTimes(mat, mat[n]);
+    }
+}
+
+}  // namespace detail
+
+inline uint32_t
+Crc32cCombine(uint32_t crc1, uint32_t crc2, size_t len2) {
+    if (len2 == 0) {
+        return crc1;
+    }
+
+    // Build the "zeros operator" matrices for CRC-32C polynomial 0x82F63B78
+    uint32_t even[32];  // even-power-of-two zeros operator
+    uint32_t odd[32];   // odd-power-of-two zeros operator
+
+    // Put operator for one zero bit in odd
+    odd[0] = 0x82F63B78U;  // CRC-32C polynomial
+    uint32_t row = 1;
+    for (int n = 1; n < 32; n++) {
+        odd[n] = row;
+        row <<= 1;
+    }
+
+    // Put operator for two zero bits in even (square the odd operator)
+    detail::Gf2MatrixSquare(even, odd);
+
+    // Put operator for four zero bits in odd
+    detail::Gf2MatrixSquare(odd, even);
+
+    // Apply len2 zeros to crc1 using repeated squaring
+    do {
+        // Apply zeros operator for this bit of len2
+        detail::Gf2MatrixSquare(even, odd);
+        if (len2 & 1) {
+            crc1 = detail::Gf2MatrixTimes(even, crc1);
+        }
+        len2 >>= 1;
+        if (len2 == 0) {
+            break;
+        }
+
+        // Another iteration: square, apply
+        detail::Gf2MatrixSquare(odd, even);
+        if (len2 & 1) {
+            crc1 = detail::Gf2MatrixTimes(odd, crc1);
+        }
+        len2 >>= 1;
+    } while (len2 != 0);
+
+    // Combine the CRC values
+    crc1 ^= crc2;
+    return crc1;
+}
+
+inline std::string
+Crc32cToHex(uint32_t crc) {
+    char buf[9];
+    std::snprintf(buf, sizeof(buf), "%08X", crc);
+    return std::string(buf);
+}
+
+inline uint32_t
+Crc32cFromHex(const std::string& hex) {
+    return static_cast<uint32_t>(std::stoul(hex, nullptr, 16));
+}
+
+}  // namespace milvus::storage

--- a/internal/core/src/storage/DiskFileManagerImpl.cpp
+++ b/internal/core/src/storage/DiskFileManagerImpl.cpp
@@ -61,7 +61,6 @@
 #include "storage/FileWriter.h"
 #include "storage/LocalChunkManager.h"
 #include "storage/LocalChunkManagerSingleton.h"
-#include "storage/RemoteInputStream.h"
 #include "storage/RemoteOutputStream.h"
 #include "storage/ThreadPool.h"
 #include "storage/ThreadPools.h"
@@ -101,7 +100,7 @@ DiskFileManagerImpl::GetRemoteIndexPath(const std::string& file_name,
 
 std::string
 DiskFileManagerImpl::GetRemoteIndexPathV2(const std::string& file_name) const {
-    std::string remote_prefix = GetRemoteIndexFilePrefixV2();
+    std::string remote_prefix = GetRemoteIndexObjectPrefixV2();
     return remote_prefix + "/" + file_name;
 }
 
@@ -196,42 +195,6 @@ DiskFileManagerImpl::AddFileInternal(
 
     return true;
 }  // namespace knowhere
-
-// Opens an input stream with fs_
-// note that `fs_` must not be nullptr.
-std::shared_ptr<InputStream>
-DiskFileManagerImpl::OpenInputStream(const std::string& filename) {
-    auto local_file_name = GetFileName(filename);
-    auto remote_file_path = GetRemoteIndexPathV2(local_file_name);
-
-    auto fs = fs_;
-    AssertInfo(fs, "fs is nullptr");
-
-    auto remote_file = fs->OpenInputFile(remote_file_path);
-    AssertInfo(remote_file.ok(), "failed to open remote file");
-    return std::static_pointer_cast<milvus::InputStream>(
-        std::make_shared<milvus::storage::RemoteInputStream>(
-            std::move(remote_file.ValueOrDie())));
-}
-
-// Opens an output stream with fs_
-// note that `fs_` must not be nullptr.
-std::shared_ptr<OutputStream>
-DiskFileManagerImpl::OpenOutputStream(const std::string& filename) {
-    auto local_file_name = GetFileName(filename);
-    auto remote_file_path = GetRemoteIndexPathV2(local_file_name);
-
-    auto fs = fs_;
-    AssertInfo(fs, "fs is nullptr");
-
-    auto remote_stream = fs->OpenOutputStream(remote_file_path);
-    AssertInfo(remote_stream.ok(),
-               "failed to open remote stream, reason: {}",
-               remote_stream.status().ToString());
-
-    return std::make_shared<milvus::storage::RemoteOutputStream>(
-        std::move(remote_stream.ValueOrDie()));
-}
 
 bool
 DiskFileManagerImpl::AddFile(const std::string& file) noexcept {
@@ -1357,10 +1320,5 @@ template std::string
 DiskFileManagerImpl::CacheRawDataToDisk<sparse_u32_f32>(const Config& config);
 template std::string
 DiskFileManagerImpl::CacheRawDataToDisk<int8_t>(const Config& config);
-
-std::string
-DiskFileManagerImpl::GetRemoteIndexFilePrefixV2() const {
-    return FileManagerImpl::GetRemoteIndexFilePrefixV2();
-}
 
 }  // namespace milvus::storage

--- a/internal/core/src/storage/DiskFileManagerImpl.h
+++ b/internal/core/src/storage/DiskFileManagerImpl.h
@@ -52,34 +52,6 @@ class DiskFileManagerImpl : public FileManagerImpl {
     bool
     RemoveFile(const std::string& filename) noexcept override;
 
-    /**
-    * @brief Opens an output stream for provided filename
-    * 
-    *  This function utilizes the arrow file system to open an output stream for the provided filename.
-    * 
-    * @param filename the filename to open
-    * @return std::shared_ptr<OutputStream> a shared pointer to the output stream
-    * @throws milvus::SegcoreError
-    * 
-    * @note the internal `fs_` must be initialized to use this API.
-    */
-    std::shared_ptr<InputStream>
-    OpenInputStream(const std::string& filename) override;
-
-    /**
-    * @brief Opens an output stream for provided filename
-    * 
-    *  This function utilizes the arrow file system to open an output stream for the provided filename.
-    * 
-    * @param filename the filename to open
-    * @return std::shared_ptr<OutputStream> a shared pointer to the output stream
-    * @throws milvus::SegcoreError if fs_ is nullptr
-    * 
-    * @note the internal `fs_` must be initialized to use this API.
-    */
-    std::shared_ptr<OutputStream>
-    OpenOutputStream(const std::string& filename) override;
-
  public:
     bool
     AddTextLog(const std::string& filename) noexcept;
@@ -227,9 +199,6 @@ class DiskFileManagerImpl : public FileManagerImpl {
 
     std::string
     GetFileName(const std::string& localfile);
-
-    std::string
-    GetRemoteIndexFilePrefixV2() const override;
 
  private:
     int64_t

--- a/internal/core/src/storage/DiskFileManagerTest.cpp
+++ b/internal/core/src/storage/DiskFileManagerTest.cpp
@@ -71,6 +71,9 @@
 #include "test_utils/Constants.h"
 #include "test_utils/DataGen.h"
 #include "test_utils/storage_test_utils.h"
+#include "index/BitmapIndex.h"
+#include "index/StringIndexMarisa.h"
+#include "index/StringIndexSort.h"
 
 class DiskAnnFileManagerTest_CacheOptFieldToDiskCorrectDOUBLE_Test;
 class DiskAnnFileManagerTest_CacheOptFieldToDiskCorrectFLOAT_Test;
@@ -267,6 +270,29 @@ TEST_F(DiskAnnFileManagerTest, ReadAndWriteWithStream) {
     lcm->Remove(small_index_file_path_read);
     lcm->Remove(large_index_file_path);
     lcm->Remove(small_index_file_path);
+}
+
+// Ensure that index v3 generated path is the same as v2 path, only with different
+// file name.
+TEST_F(DiskAnnFileManagerTest, V3PackedIndexPathMismatch) {
+    FieldDataMeta filed_data_meta = {1, 2, 3, 100};
+    IndexMeta index_meta = {3, 100, 1000, 1, "index"};
+    storage::FileManagerContext context(filed_data_meta, index_meta, cm_, fs_);
+
+    milvus::index::ScalarIndexSort<int64_t> index(context);
+    std::vector<int64_t> values = {1, 2, 3};
+    index.Build(values.size(), values.data());
+
+    auto stats = index.UploadV3({});
+    auto files = stats->GetIndexFiles();
+    ASSERT_EQ(files.size(), 1);
+
+    storage::MemFileManagerImpl file_manager(context);
+    std::string v2_path = file_manager.GetRemoteIndexObjectPrefixV2() +
+                          "/milvus_packed_stlsort_index.v3";
+    std::string v3_path = files[0];
+
+    EXPECT_EQ(v3_path, v2_path);
 }
 
 int
@@ -1021,4 +1047,198 @@ TEST_F(DiskAnnFileManagerTest, CacheRawDataToDiskNoValidDataForNonNullable) {
 
     local_chunk_manager->Remove(local_data_path);
     cm_->Remove(insert_file_path);
+}
+
+TEST_F(DiskAnnFileManagerTest, ScalarIndexSortV3Roundtrip) {
+    FieldDataMeta filed_data_meta = {1, 2, 3, 100};
+    IndexMeta index_meta = {3, 100, 1000, 1, "index"};
+    storage::FileManagerContext context(filed_data_meta, index_meta, cm_, fs_);
+
+    const size_t N = 1000;
+    std::vector<int64_t> values(N);
+    for (size_t i = 0; i < N; ++i) {
+        values[i] = static_cast<int64_t>(i * 3);
+    }
+
+    milvus::index::ScalarIndexSort<int64_t> build_index(context);
+    build_index.Build(N, values.data());
+    ASSERT_EQ(build_index.Count(), static_cast<int64_t>(N));
+
+    auto stats = build_index.UploadV3({});
+    ASSERT_NE(stats, nullptr);
+    auto files = stats->GetIndexFiles();
+    ASSERT_EQ(files.size(), 1);
+
+    milvus::index::ScalarIndexSort<int64_t> load_index(context);
+    milvus::Config load_config;
+    load_config[milvus::index::INDEX_FILES] =
+        std::vector<std::string>{files[0]};
+    load_config[milvus::index::ENABLE_MMAP] = false;
+    load_index.LoadV3(load_config);
+
+    EXPECT_EQ(load_index.Count(), static_cast<int64_t>(N));
+
+    {
+        std::vector<int64_t> query_vals = {0, 3, 6};
+        auto bitset = load_index.In(query_vals.size(), query_vals.data());
+        EXPECT_TRUE(bitset[0]);
+        EXPECT_TRUE(bitset[1]);
+        EXPECT_TRUE(bitset[2]);
+        EXPECT_FALSE(bitset[3]);
+    }
+
+    {
+        auto bitset =
+            load_index.Range(static_cast<int64_t>(6), milvus::OpType::LessThan);
+        EXPECT_TRUE(bitset[0]);
+        EXPECT_TRUE(bitset[1]);
+        EXPECT_FALSE(bitset[2]);
+    }
+
+    {
+        auto bitset = load_index.Range(
+            static_cast<int64_t>(3), true, static_cast<int64_t>(9), false);
+        EXPECT_FALSE(bitset[0]);
+        EXPECT_TRUE(bitset[1]);
+        EXPECT_TRUE(bitset[2]);
+        EXPECT_FALSE(bitset[3]);
+    }
+
+    for (size_t i = 0; i < N; ++i) {
+        auto val = load_index.Reverse_Lookup(i);
+        ASSERT_TRUE(val.has_value());
+        EXPECT_EQ(val.value(), values[i]);
+    }
+}
+
+TEST_F(DiskAnnFileManagerTest, BitmapIndexV3Roundtrip) {
+    FieldDataMeta filed_data_meta = {1, 2, 3, 100};
+    IndexMeta index_meta = {3, 100, 1000, 1, "index"};
+    storage::FileManagerContext context(filed_data_meta, index_meta, cm_, fs_);
+
+    const size_t N = 1000;
+    std::vector<int64_t> values(N);
+    for (size_t i = 0; i < N; ++i) {
+        values[i] = static_cast<int64_t>(i % 100);
+    }
+
+    milvus::index::BitmapIndex<int64_t> build_index(context);
+    build_index.Build(N, values.data());
+    ASSERT_EQ(build_index.Count(), static_cast<int64_t>(N));
+
+    auto stats = build_index.UploadV3({});
+    ASSERT_NE(stats, nullptr);
+    auto files = stats->GetIndexFiles();
+    ASSERT_EQ(files.size(), 1);
+
+    milvus::index::BitmapIndex<int64_t> load_index(context);
+    milvus::Config load_config;
+    load_config[milvus::index::INDEX_FILES] =
+        std::vector<std::string>{files[0]};
+    load_config[milvus::index::ENABLE_MMAP] = false;
+    load_index.LoadV3(load_config);
+
+    EXPECT_EQ(load_index.Count(), static_cast<int64_t>(N));
+
+    {
+        std::vector<int64_t> query_vals = {0, 1};
+        auto bitset = load_index.In(query_vals.size(), query_vals.data());
+        for (size_t i = 0; i < N; ++i) {
+            if (values[i] == 0 || values[i] == 1) {
+                EXPECT_TRUE(bitset[i]) << "offset " << i;
+            } else {
+                EXPECT_FALSE(bitset[i]) << "offset " << i;
+            }
+        }
+    }
+}
+
+TEST_F(DiskAnnFileManagerTest, StringIndexMarisaV3Roundtrip) {
+    FieldDataMeta filed_data_meta = {1, 2, 3, 100};
+    IndexMeta index_meta = {3, 100, 1000, 1, "index"};
+    storage::FileManagerContext context(filed_data_meta, index_meta, cm_, fs_);
+
+    const size_t N = 500;
+    std::vector<std::string> values(N);
+    for (size_t i = 0; i < N; ++i) {
+        char buf[16];
+        snprintf(buf, sizeof(buf), "str_%03zu", i);
+        values[i] = buf;
+    }
+
+    milvus::index::StringIndexMarisa build_index(context);
+    build_index.Build(N, values.data());
+    ASSERT_EQ(build_index.Count(), static_cast<int64_t>(N));
+
+    auto stats = build_index.UploadV3({});
+    ASSERT_NE(stats, nullptr);
+    auto files = stats->GetIndexFiles();
+    ASSERT_EQ(files.size(), 1);
+
+    milvus::index::StringIndexMarisa load_index(context);
+    milvus::Config load_config;
+    load_config[milvus::index::INDEX_FILES] =
+        std::vector<std::string>{files[0]};
+    load_config[milvus::index::ENABLE_MMAP] = false;
+    load_index.LoadV3(load_config);
+
+    EXPECT_EQ(load_index.Count(), static_cast<int64_t>(N));
+
+    {
+        std::vector<std::string> query_vals = {"str_000", "str_001"};
+        auto bitset = load_index.In(query_vals.size(), query_vals.data());
+        EXPECT_TRUE(bitset[0]);
+        EXPECT_TRUE(bitset[1]);
+        for (size_t i = 2; i < N; ++i) {
+            EXPECT_FALSE(bitset[i]) << "offset " << i;
+        }
+    }
+}
+
+TEST_F(DiskAnnFileManagerTest, StringIndexSortV3Roundtrip) {
+    FieldDataMeta filed_data_meta = {1, 2, 3, 100};
+    IndexMeta index_meta = {3, 100, 1000, 1, "index"};
+    storage::FileManagerContext context(filed_data_meta, index_meta, cm_, fs_);
+
+    const size_t N = 500;
+    std::vector<std::string> values(N);
+    for (size_t i = 0; i < N; ++i) {
+        char buf[16];
+        snprintf(buf, sizeof(buf), "str_%03zu", i);
+        values[i] = buf;
+    }
+
+    milvus::index::StringIndexSort build_index(context);
+    build_index.Build(N, values.data());
+    ASSERT_EQ(build_index.Count(), static_cast<int64_t>(N));
+
+    auto stats = build_index.UploadV3({});
+    ASSERT_NE(stats, nullptr);
+    auto files = stats->GetIndexFiles();
+    ASSERT_EQ(files.size(), 1);
+
+    milvus::index::StringIndexSort load_index(context);
+    milvus::Config load_config;
+    load_config[milvus::index::INDEX_FILES] =
+        std::vector<std::string>{files[0]};
+    load_config[milvus::index::ENABLE_MMAP] = false;
+    load_index.LoadV3(load_config);
+
+    EXPECT_EQ(load_index.Count(), static_cast<int64_t>(N));
+
+    {
+        std::vector<std::string> query_vals = {"str_000", "str_001"};
+        auto bitset = load_index.In(query_vals.size(), query_vals.data());
+        EXPECT_TRUE(bitset[0]);
+        EXPECT_TRUE(bitset[1]);
+        for (size_t i = 2; i < N; ++i) {
+            EXPECT_FALSE(bitset[i]) << "offset " << i;
+        }
+    }
+
+    {
+        auto val = load_index.Reverse_Lookup(0);
+        ASSERT_TRUE(val.has_value());
+        EXPECT_EQ(val.value(), "str_000");
+    }
 }

--- a/internal/core/src/storage/FileManager.h
+++ b/internal/core/src/storage/FileManager.h
@@ -31,6 +31,14 @@
 #include "milvus-storage/filesystem/fs.h"
 #include "milvus-storage/properties.h"
 #include "storage/ChunkManager.h"
+#include "storage/LocalChunkManager.h"
+#include "storage/LocalChunkManagerSingleton.h"
+#include "storage/IndexEntryDirectStreamWriter.h"
+#include "storage/IndexEntryEncryptedLocalWriter.h"
+#include "storage/IndexEntryWriter.h"
+#include "storage/PluginLoader.h"
+#include "storage/RemoteInputStream.h"
+#include "storage/RemoteOutputStream.h"
 #include "storage/Types.h"
 
 namespace milvus::storage {
@@ -163,11 +171,84 @@ class FileManagerImpl : public milvus::FileManager {
     virtual bool
     AddFileMeta(const FileMeta& file_meta) override = 0;
 
-    virtual std::shared_ptr<InputStream>
-    OpenInputStream(const std::string& filename) override = 0;
+    std::shared_ptr<InputStream>
+    OpenInputStream(const std::string& filename) override final {
+        return OpenInputStream(filename, /*is_index_file=*/true);
+    }
 
-    virtual std::shared_ptr<OutputStream>
-    OpenOutputStream(const std::string& filename) override = 0;
+    std::shared_ptr<OutputStream>
+    OpenOutputStream(const std::string& filename) override final {
+        return OpenOutputStream(filename, /*is_index_file=*/true);
+    }
+
+    std::shared_ptr<InputStream>
+    OpenInputStream(const std::string& filename, bool is_index_file) {
+        AssertInfo(fs_, "fs_ is nullptr, cannot open input stream");
+        auto local_file_name = GetFileName(filename);
+        auto remote_file_path = is_index_file ? GetRemoteIndexObjectPrefixV2()
+                                              : GetRemoteTextLogPrefixV2();
+        remote_file_path += "/" + local_file_name;
+        auto remote_file = fs_->OpenInputFile(remote_file_path);
+        AssertInfo(remote_file.ok(),
+                   "failed to open remote file, reason: {}",
+                   remote_file.status().ToString());
+        return std::static_pointer_cast<milvus::InputStream>(
+            std::make_shared<milvus::storage::RemoteInputStream>(
+                std::move(remote_file.ValueOrDie())));
+    }
+
+    std::shared_ptr<OutputStream>
+    OpenOutputStream(const std::string& filename, bool is_index_file) {
+        AssertInfo(fs_, "fs_ is nullptr, cannot open output stream");
+        auto local_file_name = GetFileName(filename);
+        auto remote_file_path = is_index_file ? GetRemoteIndexObjectPrefixV2()
+                                              : GetRemoteTextLogPrefixV2();
+        remote_file_path += "/" + local_file_name;
+        // Ensure parent directory exists before opening the output stream.
+        // Only needed for local filesystems; object stores don't require
+        // explicit directory creation and the call would waste I/O.
+        if (milvus_storage::IsLocalFileSystem(fs_)) {
+            auto dir_path =
+                remote_file_path.substr(0, remote_file_path.find_last_of('/'));
+            if (!dir_path.empty()) {
+                auto status = fs_->CreateDir(dir_path, /*recursive=*/true);
+                AssertInfo(status.ok(),
+                           "failed to create directory {}, reason: {}",
+                           dir_path,
+                           status.ToString());
+            }
+        }
+        auto remote_stream = fs_->OpenOutputStream(remote_file_path);
+        AssertInfo(remote_stream.ok(),
+                   "failed to open remote stream, reason: {}",
+                   remote_stream.status().ToString());
+        return std::make_shared<milvus::storage::RemoteOutputStream>(
+            std::move(remote_stream.ValueOrDie()));
+    }
+
+    std::unique_ptr<IndexEntryWriter>
+    CreateIndexEntryWriterV3(const std::string& filename,
+                             bool is_index_file = true) {
+        if (plugin_context_) {
+            auto cipher_plugin = PluginLoader::GetInstance().getCipherPlugin();
+            if (cipher_plugin) {
+                auto local_file_name = GetFileName(filename);
+                auto remote_path = is_index_file
+                                       ? GetRemoteIndexObjectPrefixV2()
+                                       : GetRemoteTextLogPrefixV2();
+                remote_path += "/" + local_file_name;
+                return std::make_unique<IndexEntryEncryptedLocalWriter>(
+                    remote_path,
+                    fs_,
+                    cipher_plugin,
+                    plugin_context_->ez_id,
+                    plugin_context_->collection_id,
+                    GetLocalTempDir());
+            }
+        }
+        return std::make_unique<IndexEntryDirectStreamWriter>(
+            OpenOutputStream(filename, is_index_file));
+    }
 
  public:
     virtual std::string
@@ -210,11 +291,6 @@ class FileManagerImpl : public milvus::FileManager {
     }
 
     virtual std::string
-    GetRemoteIndexFilePrefixV2() const {
-        return GetRemoteIndexObjectPrefixV2();
-    }
-
-    virtual std::string
     GetRemoteTextLogPrefix() const {
         boost::filesystem::path prefix = rcm_->GetRootPath();
         boost::filesystem::path path = std::string(TEXT_LOG_ROOT_PATH);
@@ -226,6 +302,32 @@ class FileManagerImpl : public milvus::FileManager {
             std::to_string(field_meta_.segment_id) + "/" +
             std::to_string(field_meta_.field_id);
         return NormalizePath(prefix / path / path1);
+    }
+
+    virtual std::string
+    GetRemoteTextLogPrefixV2() const {
+        return std::string(TEXT_LOG_ROOT_PATH) + "/" +
+               std::to_string(index_meta_.build_id) + "/" +
+               std::to_string(index_meta_.index_version) + "/" +
+               std::to_string(field_meta_.collection_id) + "/" +
+               std::to_string(field_meta_.partition_id) + "/" +
+               std::to_string(field_meta_.segment_id) + "/" +
+               std::to_string(field_meta_.field_id);
+    }
+
+    static std::string
+    GetFileName(const std::string& filepath) {
+        return boost::filesystem::path(filepath).filename().string();
+    }
+
+    std::string
+    GetLocalTempDir() const {
+        auto local_cm =
+            LocalChunkManagerSingleton::GetInstance().GetChunkManager();
+        if (local_cm) {
+            return local_cm->GetRootPath();
+        }
+        return "";
     }
 
  protected:

--- a/internal/core/src/storage/IndexEntryDirectStreamWriter.cpp
+++ b/internal/core/src/storage/IndexEntryDirectStreamWriter.cpp
@@ -1,0 +1,136 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/IndexEntryDirectStreamWriter.h"
+
+#include <cerrno>
+#include <cstring>
+#include <unistd.h>
+#include <algorithm>
+#include <utility>
+
+#include "common/EasyAssert.h"
+#include "nlohmann/json.hpp"
+#include "storage/Crc32cUtil.h"
+
+namespace milvus::storage {
+
+IndexEntryDirectStreamWriter::IndexEntryDirectStreamWriter(
+    std::shared_ptr<milvus::OutputStream> output, size_t read_buf_size)
+    : output_(std::move(output)), read_buf_(read_buf_size) {
+    output_->Write(MILVUS_V3_MAGIC, MILVUS_V3_MAGIC_SIZE);
+}
+
+void
+IndexEntryDirectStreamWriter::WriteEntry(const std::string& name,
+                                         const void* data,
+                                         size_t size) {
+    AssertInfo(!finished_, "Cannot write after Finish() has been called");
+    CheckDuplicateName(name);
+
+    uint32_t crc = Crc32cValue(data, size);
+    output_->Write(data, size);
+    dir_entries_.push_back({name, current_offset_, size, crc});
+    current_offset_ += size;
+}
+
+void
+IndexEntryDirectStreamWriter::WriteEntry(const std::string& name,
+                                         int fd,
+                                         size_t size) {
+    AssertInfo(!finished_, "Cannot write after Finish() has been called");
+    CheckDuplicateName(name);
+
+    size_t remaining = size;
+    size_t entry_start = current_offset_;
+    uint32_t crc = 0;
+
+    while (remaining > 0) {
+        size_t to_read = std::min(remaining, read_buf_.size());
+        size_t chunk_read = 0;
+
+        while (chunk_read < to_read) {
+            ssize_t bytes_read =
+                ::read(fd, read_buf_.data() + chunk_read, to_read - chunk_read);
+            if (bytes_read == -1 && errno == EINTR) {
+                continue;
+            }
+            AssertInfo(bytes_read > 0,
+                       "Failed to read from file descriptor: {}",
+                       strerror(errno));
+            chunk_read += bytes_read;
+        }
+
+        crc = Crc32cUpdate(crc, read_buf_.data(), chunk_read);
+        output_->Write(read_buf_.data(), chunk_read);
+        current_offset_ += chunk_read;
+        remaining -= chunk_read;
+    }
+
+    dir_entries_.push_back({name, entry_start, size, crc});
+}
+
+void
+IndexEntryDirectStreamWriter::Finish() {
+    AssertInfo(!finished_, "Finish() has already been called");
+
+    // Write __meta__ entry as the last entry in Data Region
+    std::string meta_str = meta_json_.dump();
+    uint32_t meta_crc = Crc32cValue(meta_str.data(), meta_str.size());
+    output_->Write(meta_str.data(), meta_str.size());
+    dir_entries_.push_back({MILVUS_V3_META_ENTRY_NAME,
+                            current_offset_,
+                            meta_str.size(),
+                            meta_crc});
+    size_t meta_entry_size = meta_str.size();
+    current_offset_ += meta_str.size();
+
+    // Build Directory Table JSON (no "version" — version is in Footer)
+    nlohmann::json dir_json;
+    dir_json["entries"] = nlohmann::json::array();
+
+    for (const auto& entry : dir_entries_) {
+        dir_json["entries"].push_back({{"name", entry.name},
+                                       {"offset", entry.offset},
+                                       {"size", entry.size},
+                                       {"crc32", Crc32cToHex(entry.crc32)}});
+    }
+
+    std::string dir_str = dir_json.dump();
+    output_->Write(dir_str.data(), dir_str.size());
+
+    // Write 32-byte Footer:
+    // [2B version][22B reserved][4B meta_entry_size][4B directory_table_size]
+    uint8_t footer[MILVUS_V3_FOOTER_SIZE] = {};
+    uint16_t version = MILVUS_V3_FORMAT_VERSION;
+    uint32_t meta_size_u32 = static_cast<uint32_t>(meta_entry_size);
+    uint32_t dir_size_u32 = static_cast<uint32_t>(dir_str.size());
+
+    std::memcpy(footer + 0, &version, sizeof(uint16_t));
+    // bytes 2..23 are reserved (zero-filled, already zeroed)
+    std::memcpy(footer + 24, &meta_size_u32, sizeof(uint32_t));
+    std::memcpy(footer + 28, &dir_size_u32, sizeof(uint32_t));
+
+    output_->Write(footer, MILVUS_V3_FOOTER_SIZE);
+
+    total_bytes_written_ = MILVUS_V3_MAGIC_SIZE + current_offset_ +
+                           dir_str.size() + MILVUS_V3_FOOTER_SIZE;
+
+    output_->Close();
+    finished_ = true;
+}
+
+}  // namespace milvus::storage

--- a/internal/core/src/storage/IndexEntryDirectStreamWriter.h
+++ b/internal/core/src/storage/IndexEntryDirectStreamWriter.h
@@ -1,0 +1,55 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "storage/IndexEntryWriter.h"
+#include "filemanager/OutputStream.h"
+
+namespace milvus::storage {
+
+class IndexEntryDirectStreamWriter : public IndexEntryWriter {
+ public:
+    explicit IndexEntryDirectStreamWriter(
+        std::shared_ptr<milvus::OutputStream> output,
+        size_t read_buf_size = 16 * 1024 * 1024);
+
+    void
+    WriteEntry(const std::string& name, const void* data, size_t size) override;
+    void
+    WriteEntry(const std::string& name, int fd, size_t size) override;
+    void
+    Finish() override;
+    size_t
+    GetTotalBytesWritten() const override {
+        return total_bytes_written_;
+    }
+
+ private:
+    std::shared_ptr<milvus::OutputStream> output_;
+    std::vector<char> read_buf_;
+    std::vector<DirectoryEntry> dir_entries_;
+    size_t current_offset_ = 0;
+    size_t total_bytes_written_ = 0;
+    bool finished_ = false;
+};
+
+}  // namespace milvus::storage

--- a/internal/core/src/storage/IndexEntryEncryptedLocalWriter.cpp
+++ b/internal/core/src/storage/IndexEntryEncryptedLocalWriter.cpp
@@ -1,0 +1,298 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/IndexEntryEncryptedLocalWriter.h"
+
+#include <fcntl.h>
+#include <unistd.h>
+#include <cerrno>
+#include <cstring>
+#include <algorithm>
+#include <utility>
+#include <vector>
+
+#include <boost/uuid/random_generator.hpp>
+#include <boost/uuid/uuid_io.hpp>
+
+#include "common/EasyAssert.h"
+#include "nlohmann/json.hpp"
+#include "storage/Crc32cUtil.h"
+#include "storage/RemoteOutputStream.h"
+
+namespace milvus::storage {
+
+IndexEntryEncryptedLocalWriter::IndexEntryEncryptedLocalWriter(
+    const std::string& remote_path,
+    milvus_storage::ArrowFileSystemPtr fs,
+    std::shared_ptr<plugin::ICipherPlugin> cipher_plugin,
+    int64_t ez_id,
+    int64_t collection_id,
+    const std::string& temp_dir,
+    size_t slice_size)
+    : remote_path_(remote_path),
+      fs_(std::move(fs)),
+      cipher_plugin_(std::move(cipher_plugin)),
+      ez_id_(ez_id),
+      collection_id_(collection_id),
+      slice_size_(slice_size),
+      pool_(ThreadPools::GetThreadPool(ThreadPoolPriority::MIDDLE)) {
+    auto [encryptor, edek] =
+        cipher_plugin_->GetEncryptor(ez_id_, collection_id_);
+    edek_ = std::move(edek);
+
+    auto uuid = boost::uuids::random_generator()();
+    std::string dir = temp_dir.empty() ? "/tmp" : temp_dir;
+    local_path_ = dir + "/milvus_enc_" + boost::uuids::to_string(uuid);
+
+    local_fd_ = ::open(local_path_.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0600);
+    AssertInfo(
+        local_fd_ != -1, "Failed to create temp file: {}", strerror(errno));
+
+    try {
+        auto written =
+            ::write(local_fd_, MILVUS_V3_MAGIC, MILVUS_V3_MAGIC_SIZE);
+        AssertInfo(written == static_cast<ssize_t>(MILVUS_V3_MAGIC_SIZE),
+                   "Failed to write magic number");
+    } catch (...) {
+        ::close(local_fd_);
+        local_fd_ = -1;
+        ::unlink(local_path_.c_str());
+        throw;
+    }
+}
+
+IndexEntryEncryptedLocalWriter::~IndexEntryEncryptedLocalWriter() {
+    if (local_fd_ != -1) {
+        ::close(local_fd_);
+        ::unlink(local_path_.c_str());
+    }
+}
+
+void
+IndexEntryEncryptedLocalWriter::WriteEntry(const std::string& name,
+                                           const void* data,
+                                           size_t size) {
+    AssertInfo(!finished_, "Cannot write after Finish() has been called");
+    CheckDuplicateName(name);
+    EncryptAndWriteSlices(name, reinterpret_cast<const uint8_t*>(data), size);
+}
+
+static std::string
+ReadExact(int fd, size_t len) {
+    std::string buf(len, '\0');
+    size_t total_read = 0;
+    while (total_read < len) {
+        ssize_t n = ::read(fd, buf.data() + total_read, len - total_read);
+        if (n == -1 && errno == EINTR) {
+            continue;
+        }
+        AssertInfo(
+            n > 0, "Failed to read from file descriptor: {}", strerror(errno));
+        total_read += n;
+    }
+    return buf;
+}
+
+void
+IndexEntryEncryptedLocalWriter::WriteEntry(const std::string& name,
+                                           int fd,
+                                           size_t size) {
+    AssertInfo(!finished_, "Cannot write after Finish() has been called");
+    CheckDuplicateName(name);
+
+    std::vector<SliceMeta> slices;
+    const size_t W = std::max(static_cast<size_t>(pool_.GetMaxThreadNum()),
+                              static_cast<size_t>(1));
+    std::deque<std::future<std::string>> pending;
+    size_t remaining = size;
+    uint32_t crc = 0;
+
+    while (remaining > 0 || !pending.empty()) {
+        // Fill the sliding window: read one slice from fd and submit encryption
+        while (pending.size() < W && remaining > 0) {
+            size_t len = std::min(remaining, slice_size_);
+            auto slice_data = ReadExact(fd, len);
+            crc = Crc32cUpdate(
+                crc, reinterpret_cast<const uint8_t*>(slice_data.data()), len);
+            pending.push_back(pool_.Submit([this, s = std::move(slice_data)]() {
+                auto [enc, unused_edek] =
+                    cipher_plugin_->GetEncryptor(ez_id_, collection_id_);
+                return enc->Encrypt(s);
+            }));
+            remaining -= len;
+        }
+        // Drain the oldest completed future
+        if (!pending.empty()) {
+            auto encrypted = pending.front().get();
+            pending.pop_front();
+            auto written =
+                ::write(local_fd_, encrypted.data(), encrypted.size());
+            AssertInfo(written == static_cast<ssize_t>(encrypted.size()),
+                       "Failed to write encrypted slice");
+            slices.push_back(
+                {current_offset_, static_cast<uint64_t>(encrypted.size())});
+            current_offset_ += encrypted.size();
+        }
+    }
+    dir_entries_.push_back(
+        {name, static_cast<uint64_t>(size), crc, std::move(slices)});
+}
+
+void
+IndexEntryEncryptedLocalWriter::EncryptAndWriteSlices(const std::string& name,
+                                                      const uint8_t* data,
+                                                      size_t size) {
+    std::vector<SliceMeta> slices;
+    const size_t W = std::max(static_cast<size_t>(pool_.GetMaxThreadNum()),
+                              static_cast<size_t>(1));
+    std::deque<std::future<std::string>> pending;
+    size_t remaining = size;
+    size_t read_offset = 0;
+    uint32_t crc = 0;
+
+    while (remaining > 0 || !pending.empty()) {
+        while (pending.size() < W && remaining > 0) {
+            size_t len = std::min(remaining, slice_size_);
+            crc = Crc32cUpdate(crc, data + read_offset, len);
+            auto slice_data = std::string(
+                reinterpret_cast<const char*>(data + read_offset), len);
+            pending.push_back(pool_.Submit([this, s = std::move(slice_data)]() {
+                auto [enc, unused_edek] =
+                    cipher_plugin_->GetEncryptor(ez_id_, collection_id_);
+                return enc->Encrypt(s);
+            }));
+            read_offset += len;
+            remaining -= len;
+        }
+        if (!pending.empty()) {
+            auto encrypted = pending.front().get();
+            pending.pop_front();
+            auto written =
+                ::write(local_fd_, encrypted.data(), encrypted.size());
+            AssertInfo(written == static_cast<ssize_t>(encrypted.size()),
+                       "Failed to write encrypted slice");
+            slices.push_back(
+                {current_offset_, static_cast<uint64_t>(encrypted.size())});
+            current_offset_ += encrypted.size();
+        }
+    }
+    dir_entries_.push_back({name, size, crc, std::move(slices)});
+}
+
+void
+IndexEntryEncryptedLocalWriter::Finish() {
+    AssertInfo(!finished_, "Finish() has already been called");
+
+    // Write __meta__ entry (encrypted, as last entry in Data Region)
+    std::string meta_str = meta_json_.dump();
+    EncryptAndWriteSlices(MILVUS_V3_META_ENTRY_NAME,
+                          reinterpret_cast<const uint8_t*>(meta_str.data()),
+                          meta_str.size());
+    // meta_entry_size is the on-disk (ciphertext) size of the meta entry
+    size_t meta_entry_size = 0;
+    const auto& meta_dir = dir_entries_.back();
+    for (const auto& s : meta_dir.slices) {
+        meta_entry_size += s.size;
+    }
+
+    // Build Directory Table JSON
+    nlohmann::json dir_json;
+    dir_json["slice_size"] = slice_size_;
+    dir_json["entries"] = nlohmann::json::array();
+
+    for (const auto& entry : dir_entries_) {
+        nlohmann::json e;
+        e["name"] = entry.name;
+        e["original_size"] = entry.original_size;
+        e["crc32"] = Crc32cToHex(entry.crc32);
+        e["slices"] = nlohmann::json::array();
+        for (const auto& s : entry.slices) {
+            e["slices"].push_back({{"offset", s.offset}, {"size", s.size}});
+        }
+        dir_json["entries"].push_back(std::move(e));
+    }
+
+    dir_json["__edek__"] = edek_;
+    dir_json["__ez_id__"] = std::to_string(ez_id_);
+
+    auto dir_str = dir_json.dump();
+    auto written = ::write(local_fd_, dir_str.data(), dir_str.size());
+    AssertInfo(written == static_cast<ssize_t>(dir_str.size()),
+               "Failed to write directory table");
+
+    // Write 32-byte Footer
+    uint8_t footer[MILVUS_V3_FOOTER_SIZE] = {};
+    uint16_t version = MILVUS_V3_FORMAT_VERSION;
+    uint32_t meta_size_u32 = static_cast<uint32_t>(meta_entry_size);
+    uint32_t dir_size_u32 = static_cast<uint32_t>(dir_str.size());
+
+    std::memcpy(footer + 0, &version, sizeof(uint16_t));
+    std::memcpy(footer + 24, &meta_size_u32, sizeof(uint32_t));
+    std::memcpy(footer + 28, &dir_size_u32, sizeof(uint32_t));
+
+    written = ::write(local_fd_, footer, MILVUS_V3_FOOTER_SIZE);
+    AssertInfo(written == static_cast<ssize_t>(MILVUS_V3_FOOTER_SIZE),
+               "Failed to write footer");
+
+    ::close(local_fd_);
+    local_fd_ = -1;
+
+    total_bytes_written_ = MILVUS_V3_MAGIC_SIZE + current_offset_ +
+                           dir_str.size() + MILVUS_V3_FOOTER_SIZE;
+
+    UploadLocalFile();
+
+    ::unlink(local_path_.c_str());
+    finished_ = true;
+}
+
+void
+IndexEntryEncryptedLocalWriter::UploadLocalFile() {
+    auto result = fs_->OpenOutputStream(remote_path_);
+    AssertInfo(result.ok(),
+               "Failed to open remote output stream: {}",
+               result.status().ToString());
+    auto remote_stream =
+        std::make_shared<RemoteOutputStream>(std::move(result.ValueOrDie()));
+
+    int read_fd = ::open(local_path_.c_str(), O_RDONLY);
+    AssertInfo(
+        read_fd != -1, "Failed to open local file for upload: {}", local_path_);
+
+    constexpr size_t kBufSize = 16 * 1024 * 1024;
+    std::vector<char> buf(kBufSize);
+    while (true) {
+        ssize_t n = ::read(read_fd, buf.data(), kBufSize);
+        if (n > 0) {
+            remote_stream->Write(buf.data(), n);
+        } else if (n == 0) {
+            break;  // EOF
+        } else {
+            if (errno == EINTR) {
+                continue;
+            }
+            ::close(read_fd);
+            ThrowInfo(ErrorCode::UnexpectedError,
+                      fmt::format("Failed to read local file {}: {}",
+                                  local_path_,
+                                  strerror(errno)));
+        }
+    }
+    ::close(read_fd);
+    remote_stream->Close();
+}
+
+}  // namespace milvus::storage

--- a/internal/core/src/storage/IndexEntryEncryptedLocalWriter.h
+++ b/internal/core/src/storage/IndexEntryEncryptedLocalWriter.h
@@ -1,0 +1,90 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <future>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "storage/IndexEntryWriter.h"
+#include "storage/plugin/PluginInterface.h"
+#include "storage/ThreadPools.h"
+#include "milvus-storage/filesystem/fs.h"
+
+namespace milvus::storage {
+
+class IndexEntryEncryptedLocalWriter : public IndexEntryWriter {
+ public:
+    IndexEntryEncryptedLocalWriter(
+        const std::string& remote_path,
+        milvus_storage::ArrowFileSystemPtr fs,
+        std::shared_ptr<plugin::ICipherPlugin> cipher_plugin,
+        int64_t ez_id,
+        int64_t collection_id,
+        const std::string& temp_dir = "",
+        size_t slice_size = 16 * 1024 * 1024);
+    ~IndexEntryEncryptedLocalWriter();
+
+    void
+    WriteEntry(const std::string& name, const void* data, size_t size) override;
+    void
+    WriteEntry(const std::string& name, int fd, size_t size) override;
+    void
+    Finish() override;
+    size_t
+    GetTotalBytesWritten() const override {
+        return total_bytes_written_;
+    }
+
+ private:
+    void
+    EncryptAndWriteSlices(const std::string& name,
+                          const uint8_t* data,
+                          size_t size);
+
+    void
+    UploadLocalFile();
+
+    std::string remote_path_;
+    milvus_storage::ArrowFileSystemPtr fs_;
+    std::shared_ptr<plugin::ICipherPlugin> cipher_plugin_;
+    int64_t ez_id_;
+    int64_t collection_id_;
+    std::string edek_;
+    size_t slice_size_;
+
+    ThreadPool& pool_;
+    std::string local_path_;
+    int local_fd_ = -1;
+    size_t current_offset_ = 0;
+    size_t total_bytes_written_ = 0;
+    bool finished_ = false;
+
+    struct EncDirEntry {
+        std::string name;
+        uint64_t original_size;
+        uint32_t crc32;
+        std::vector<SliceMeta> slices;
+    };
+    std::vector<EncDirEntry> dir_entries_;
+};
+
+}  // namespace milvus::storage

--- a/internal/core/src/storage/IndexEntryReader.cpp
+++ b/internal/core/src/storage/IndexEntryReader.cpp
@@ -1,0 +1,552 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/IndexEntryReader.h"
+
+#include <fcntl.h>
+#include <unistd.h>
+#include <algorithm>
+#include <cerrno>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <future>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "common/EasyAssert.h"
+#include "nlohmann/json.hpp"
+#include "storage/Crc32cUtil.h"
+#include "storage/PluginLoader.h"
+
+namespace milvus::storage {
+
+std::unique_ptr<IndexEntryReader>
+IndexEntryReader::Open(std::shared_ptr<milvus::InputStream> input,
+                       int64_t file_size,
+                       int64_t collection_id,
+                       ThreadPoolPriority priority) {
+    auto reader = std::unique_ptr<IndexEntryReader>(new IndexEntryReader());
+    reader->input_ = std::move(input);
+    reader->file_size_ = file_size;
+    reader->collection_id_ = collection_id;
+    reader->priority_ = priority;
+    reader->ValidateMagic();
+    reader->ReadFooterAndDirectory();
+
+    // Parse __meta__ entry
+    auto meta_entry = reader->ReadEntry(MILVUS_V3_META_ENTRY_NAME);
+    if (!meta_entry.data.empty()) {
+        try {
+            reader->meta_json_ = nlohmann::json::parse(meta_entry.data.begin(),
+                                                       meta_entry.data.end());
+        } catch (const nlohmann::json::parse_error& e) {
+            AssertInfo(
+                false, "Failed to parse V3 index meta JSON: {}", e.what());
+        }
+    }
+
+    return reader;
+}
+
+void
+IndexEntryReader::ValidateMagic() {
+    char magic_buf[MILVUS_V3_MAGIC_SIZE];
+    size_t bytes_read = input_->ReadAt(magic_buf, 0, MILVUS_V3_MAGIC_SIZE);
+    AssertInfo(bytes_read == MILVUS_V3_MAGIC_SIZE,
+               "Failed to read V3 magic number");
+    AssertInfo(
+        std::memcmp(magic_buf, MILVUS_V3_MAGIC, MILVUS_V3_MAGIC_SIZE) == 0,
+        "Invalid V3 magic number");
+}
+
+void
+IndexEntryReader::ReadFooterAndDirectory() {
+    constexpr size_t kTailBufferSize = 64 * 1024UL;
+    size_t tail_size =
+        std::min(static_cast<size_t>(file_size_), kTailBufferSize);
+    size_t tail_offset = file_size_ - tail_size;
+
+    std::vector<uint8_t> tail_data(tail_size);
+    size_t bytes_read =
+        input_->ReadAt(tail_data.data(), tail_offset, tail_size);
+    AssertInfo(bytes_read == tail_size, "Failed to read file tail");
+
+    // Parse 32-byte Footer from the last 32 bytes
+    AssertInfo(tail_size >= MILVUS_V3_FOOTER_SIZE,
+               "File too small for V3 footer");
+    const uint8_t* footer_ptr =
+        tail_data.data() + tail_size - MILVUS_V3_FOOTER_SIZE;
+
+    uint16_t version;
+    uint32_t meta_entry_size;
+    uint32_t dir_size;
+
+    std::memcpy(&version, footer_ptr + 0, sizeof(uint16_t));
+    std::memcpy(&meta_entry_size, footer_ptr + 24, sizeof(uint32_t));
+    std::memcpy(&dir_size, footer_ptr + 28, sizeof(uint32_t));
+
+    AssertInfo(version == MILVUS_V3_FORMAT_VERSION,
+               "Unsupported V3 format version: {}",
+               version);
+    AssertInfo(dir_size > 0, "Directory table size is zero");
+    AssertInfo(static_cast<size_t>(dir_size) + meta_entry_size +
+                       MILVUS_V3_FOOTER_SIZE + MILVUS_V3_MAGIC_SIZE <=
+                   static_cast<size_t>(file_size_),
+               "Directory table + meta entry + footer size exceeds file size");
+
+    // Check if we need a second read
+    size_t needed =
+        static_cast<size_t>(dir_size) + meta_entry_size + MILVUS_V3_FOOTER_SIZE;
+    size_t available_before_footer = tail_size - MILVUS_V3_FOOTER_SIZE;
+
+    if (static_cast<size_t>(dir_size) + meta_entry_size >
+        available_before_footer) {
+        size_t new_tail_size = needed;
+        size_t new_tail_offset = file_size_ - new_tail_size;
+
+        std::vector<uint8_t> full_tail_data(new_tail_size);
+        size_t need_more = new_tail_size - tail_size;
+
+        size_t additional_read =
+            input_->ReadAt(full_tail_data.data(), new_tail_offset, need_more);
+        AssertInfo(additional_read == need_more,
+                   "Failed to read additional directory data");
+
+        std::memcpy(
+            full_tail_data.data() + need_more, tail_data.data(), tail_size);
+
+        tail_data = std::move(full_tail_data);
+        tail_size = new_tail_size;
+    }
+
+    // Parse Directory Table JSON
+    const uint8_t* dir_start =
+        tail_data.data() + tail_size - MILVUS_V3_FOOTER_SIZE - dir_size;
+    const uint8_t* dir_end = dir_start + dir_size;
+
+    nlohmann::json dir_json;
+    try {
+        dir_json = nlohmann::json::parse(dir_start, dir_end);
+    } catch (const nlohmann::json::parse_error& e) {
+        AssertInfo(false,
+                   "Failed to parse V3 index directory table JSON: {}",
+                   e.what());
+    }
+
+    AssertInfo(dir_json.contains("entries"), "Directory table missing entries");
+
+    if (dir_json.contains("__edek__")) {
+        is_encrypted_ = true;
+        edek_ = dir_json["__edek__"].get<std::string>();
+        ez_id_ = std::stoll(dir_json["__ez_id__"].get<std::string>());
+        slice_size_ = dir_json["slice_size"].get<size_t>();
+
+        cipher_plugin_ = PluginLoader::GetInstance().getCipherPlugin();
+        AssertInfo(cipher_plugin_ != nullptr,
+                   "Cipher plugin required for encrypted V3 index");
+
+        for (const auto& entry : dir_json["entries"]) {
+            EntryMeta meta;
+            meta.encrypted = true;
+            meta.enc.original_size = entry["original_size"].get<uint64_t>();
+            meta.enc.crc32 = Crc32cFromHex(entry["crc32"].get<std::string>());
+            for (const auto& s : entry["slices"]) {
+                meta.enc.slices.push_back(
+                    {s["offset"].get<uint64_t>(), s["size"].get<uint64_t>()});
+            }
+            std::string name = entry["name"].get<std::string>();
+            entry_names_.push_back(name);
+            entry_index_.emplace(std::move(name), std::move(meta));
+        }
+    } else {
+        is_encrypted_ = false;
+
+        for (const auto& entry : dir_json["entries"]) {
+            EntryMeta meta;
+            meta.encrypted = false;
+            meta.plain.offset = entry["offset"].get<uint64_t>();
+            meta.plain.size = entry["size"].get<uint64_t>();
+            meta.plain.crc32 = Crc32cFromHex(entry["crc32"].get<std::string>());
+            std::string name = entry["name"].get<std::string>();
+            entry_names_.push_back(name);
+            entry_index_.emplace(std::move(name), std::move(meta));
+        }
+    }
+}
+
+std::vector<std::string>
+IndexEntryReader::GetEntryNames() const {
+    return entry_names_;
+}
+
+void
+IndexEntryReader::VerifyCrc32c(uint32_t expected,
+                               const uint8_t* data,
+                               size_t size,
+                               const std::string& name) {
+    uint32_t actual = Crc32cValue(data, size);
+    AssertInfo(actual == expected,
+               "CRC-32C mismatch for entry '{}': expected {}, got {}",
+               name,
+               Crc32cToHex(expected),
+               Crc32cToHex(actual));
+}
+
+Entry
+IndexEntryReader::ReadEntry(const std::string& name) {
+    auto cache_it = small_entry_cache_.find(name);
+    if (cache_it != small_entry_cache_.end()) {
+        return cache_it->second;
+    }
+
+    auto it = entry_index_.find(name);
+    AssertInfo(it != entry_index_.end(), "Entry not found: {}", name);
+    const auto& meta = it->second;
+
+    Entry result;
+    if (meta.encrypted) {
+        result = ReadEncryptedEntry(meta);
+    } else {
+        result = ReadPlainEntry(meta);
+    }
+
+    if (result.data.size() <= kSmallEntryCacheThreshold) {
+        small_entry_cache_[name] = result;
+    }
+
+    return result;
+}
+
+Entry
+IndexEntryReader::ReadPlainEntry(const EntryMeta& meta) {
+    const auto& pm = meta.plain;
+    Entry result;
+    result.data.resize(pm.size);
+
+    constexpr size_t kRangeSize = 16 * 1024 * 1024;
+
+    if (pm.size <= kRangeSize) {
+        size_t n = input_->ReadAt(
+            result.data.data(), MILVUS_V3_MAGIC_SIZE + pm.offset, pm.size);
+        AssertInfo(n == pm.size, "Failed to read entry data");
+        VerifyCrc32c(pm.crc32, result.data.data(), pm.size, "");
+        return result;
+    }
+
+    auto& pool = ThreadPools::GetThreadPool(priority_);
+    uint8_t* dest = result.data.data();
+
+    std::vector<std::future<void>> futures;
+    size_t remaining = pm.size;
+    size_t offset = 0;
+
+    while (remaining > 0) {
+        size_t len = std::min(remaining, kRangeSize);
+        size_t this_offset = offset;
+
+        futures.push_back(pool.Submit([this, dest, this_offset, len, &pm]() {
+            size_t n =
+                input_->ReadAt(dest + this_offset,
+                               MILVUS_V3_MAGIC_SIZE + pm.offset + this_offset,
+                               len);
+            AssertInfo(n == len, "Failed to read entry data range");
+        }));
+
+        remaining -= len;
+        offset += len;
+    }
+
+    for (auto& f : futures) {
+        f.get();
+    }
+
+    // CRC verification: sequential pass over the assembled buffer
+    VerifyCrc32c(pm.crc32, result.data.data(), pm.size, "");
+
+    return result;
+}
+
+Entry
+IndexEntryReader::ReadEncryptedEntry(const EntryMeta& meta) {
+    const auto& em = meta.enc;
+    Entry result;
+    result.data.resize(em.original_size);
+
+    auto& pool = ThreadPools::GetThreadPool(priority_);
+    uint8_t* dest = result.data.data();
+
+    std::vector<std::future<void>> futures;
+    size_t cur_output_offset = 0;
+
+    for (const auto& slice : em.slices) {
+        size_t this_output_offset = cur_output_offset;
+        size_t remaining = em.original_size - cur_output_offset;
+        size_t plain_len = std::min(remaining, slice_size_);
+        cur_output_offset += plain_len;
+
+        futures.push_back(
+            pool.Submit([this, &slice, dest, this_output_offset, plain_len]() {
+                std::vector<uint8_t> cipher(slice.size);
+                size_t n = input_->ReadAt(cipher.data(),
+                                          MILVUS_V3_MAGIC_SIZE + slice.offset,
+                                          slice.size);
+                AssertInfo(n == slice.size, "Failed to read encrypted slice");
+
+                auto dec =
+                    cipher_plugin_->GetDecryptor(ez_id_, collection_id_, edek_);
+                auto plain = dec->Decrypt(cipher.data(), cipher.size());
+
+                AssertInfo(plain.size() == plain_len,
+                           "Decrypted size mismatch: expected {}, got {}",
+                           plain_len,
+                           plain.size());
+                std::memcpy(
+                    dest + this_output_offset, plain.data(), plain.size());
+            }));
+    }
+
+    for (auto& f : futures) {
+        f.get();
+    }
+
+    // CRC verification over full plaintext buffer
+    VerifyCrc32c(em.crc32, result.data.data(), em.original_size, "");
+
+    return result;
+}
+
+IndexEntryReader::EntryDownloadState
+IndexEntryReader::PrepareEntryDownload(const std::string& name,
+                                       const std::string& local_path,
+                                       const EntryMeta& meta) {
+    constexpr size_t kRangeSize = 16 * 1024 * 1024;
+
+    int fd = ::open(local_path.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0600);
+    AssertInfo(fd != -1, "Failed to create file: {}", local_path);
+
+    EntryDownloadState state;
+    state.name = name;
+    state.fd = fd;
+
+    try {
+        if (meta.encrypted) {
+            state.expected_crc = meta.enc.crc32;
+            state.range_crcs.resize(meta.enc.slices.size());
+            auto trc_ret = ::ftruncate(fd, meta.enc.original_size);
+            AssertInfo(trc_ret == 0,
+                       "Failed to ftruncate file {}: {}",
+                       local_path,
+                       strerror(errno));
+        } else {
+            state.expected_crc = meta.plain.crc32;
+            size_t num_ranges = (meta.plain.size + kRangeSize - 1) / kRangeSize;
+            state.range_crcs.resize(num_ranges);
+        }
+    } catch (...) {
+        ::close(fd);
+        throw;
+    }
+
+    return state;
+}
+
+void
+IndexEntryReader::SubmitEntryDownloadTasks(
+    const EntryMeta& meta,
+    EntryDownloadState& state,
+    std::vector<std::future<void>>& futures) {
+    constexpr size_t kRangeSize = 16 * 1024 * 1024;
+    auto& pool = ThreadPools::GetThreadPool(priority_);
+
+    if (meta.encrypted) {
+        const auto& em = meta.enc;
+        size_t output_offset = 0;
+
+        for (size_t i = 0; i < em.slices.size(); i++) {
+            const auto& slice = em.slices[i];
+            size_t this_output_offset = output_offset;
+            size_t remaining = em.original_size - output_offset;
+            size_t plain_len = std::min(remaining, slice_size_);
+            output_offset += plain_len;
+
+            futures.push_back(pool.Submit([this,
+                                           slice,
+                                           fd = state.fd,
+                                           this_output_offset,
+                                           plain_len,
+                                           i,
+                                           &state]() {
+                std::vector<uint8_t> cipher(slice.size);
+                size_t n = input_->ReadAt(cipher.data(),
+                                          MILVUS_V3_MAGIC_SIZE + slice.offset,
+                                          slice.size);
+                AssertInfo(n == slice.size, "Failed to read encrypted slice");
+
+                auto dec =
+                    cipher_plugin_->GetDecryptor(ez_id_, collection_id_, edek_);
+                auto plain = dec->Decrypt(cipher.data(), cipher.size());
+
+                AssertInfo(plain.size() == plain_len,
+                           "Decrypted size mismatch: expected {}, got {}",
+                           plain_len,
+                           plain.size());
+                auto written = ::pwrite(
+                    fd, plain.data(), plain.size(), this_output_offset);
+                AssertInfo(written == static_cast<ssize_t>(plain.size()),
+                           "Failed to pwrite");
+                state.range_crcs[i] = {
+                    Crc32cValue(reinterpret_cast<const uint8_t*>(plain.data()),
+                                plain.size()),
+                    plain.size()};
+            }));
+        }
+    } else {
+        const auto& pm = meta.plain;
+        size_t remaining = pm.size;
+        size_t file_offset = 0;
+        size_t src_offset = pm.offset;
+        size_t range_idx = 0;
+
+        while (remaining > 0) {
+            size_t len = std::min(remaining, kRangeSize);
+            size_t this_file_offset = file_offset;
+            size_t this_src_offset = src_offset;
+            size_t this_range_idx = range_idx;
+
+            futures.push_back(pool.Submit([this,
+                                           this_src_offset,
+                                           len,
+                                           fd = state.fd,
+                                           this_file_offset,
+                                           this_range_idx,
+                                           &state]() {
+                std::vector<uint8_t> buf(len);
+                size_t n = input_->ReadAt(
+                    buf.data(), MILVUS_V3_MAGIC_SIZE + this_src_offset, len);
+                AssertInfo(n == len, "Failed to read data for file");
+                auto written = ::pwrite(fd, buf.data(), len, this_file_offset);
+                AssertInfo(written == static_cast<ssize_t>(len),
+                           "Failed to pwrite");
+                state.range_crcs[this_range_idx] = {
+                    Crc32cValue(buf.data(), len), len};
+            }));
+
+            remaining -= len;
+            file_offset += len;
+            src_offset += len;
+            range_idx++;
+        }
+    }
+}
+
+void
+IndexEntryReader::FinalizeEntryDownload(EntryDownloadState& state) {
+    uint32_t combined_crc = 0;
+    if (!state.range_crcs.empty()) {
+        combined_crc = state.range_crcs[0].crc;
+        for (size_t i = 1; i < state.range_crcs.size(); i++) {
+            combined_crc = Crc32cCombine(
+                combined_crc, state.range_crcs[i].crc, state.range_crcs[i].len);
+        }
+    }
+    AssertInfo(combined_crc == state.expected_crc,
+               "CRC-32C mismatch for entry '{}': expected {}, got {}",
+               state.name,
+               Crc32cToHex(state.expected_crc),
+               Crc32cToHex(combined_crc));
+
+    ::close(state.fd);
+    state.fd = -1;
+}
+
+void
+IndexEntryReader::ReadEntryToFile(const std::string& name,
+                                  const std::string& local_path) {
+    auto it = entry_index_.find(name);
+    AssertInfo(it != entry_index_.end(), "Entry not found: {}", name);
+    const auto& meta = it->second;
+
+    auto state = PrepareEntryDownload(name, local_path, meta);
+    try {
+        std::vector<std::future<void>> futures;
+        SubmitEntryDownloadTasks(meta, state, futures);
+
+        for (auto& f : futures) {
+            f.get();
+        }
+
+        FinalizeEntryDownload(state);
+    } catch (...) {
+        if (state.fd != -1) {
+            ::close(state.fd);
+        }
+        throw;
+    }
+}
+
+void
+IndexEntryReader::ReadEntriesToFiles(
+    const std::vector<std::pair<std::string, std::string>>& name_path_pairs) {
+    if (name_path_pairs.empty()) {
+        return;
+    }
+
+    // Prepare all download states
+    std::vector<EntryDownloadState> states;
+    states.reserve(name_path_pairs.size());
+
+    // Helper to close all open fds in states
+    auto close_all_fds = [&states]() {
+        for (auto& s : states) {
+            if (s.fd != -1) {
+                ::close(s.fd);
+                s.fd = -1;
+            }
+        }
+    };
+
+    try {
+        for (const auto& [name, path] : name_path_pairs) {
+            auto it = entry_index_.find(name);
+            AssertInfo(it != entry_index_.end(), "Entry not found: {}", name);
+            states.push_back(PrepareEntryDownload(name, path, it->second));
+        }
+
+        // Submit ALL tasks for ALL entries at once (avoids thread pool deadlock)
+        std::vector<std::future<void>> all_futures;
+        for (size_t i = 0; i < name_path_pairs.size(); i++) {
+            const auto& meta = entry_index_.at(name_path_pairs[i].first);
+            SubmitEntryDownloadTasks(meta, states[i], all_futures);
+        }
+
+        // Wait for ALL tasks to complete
+        for (auto& f : all_futures) {
+            f.get();
+        }
+
+        // Verify CRCs and close all file descriptors
+        for (auto& state : states) {
+            FinalizeEntryDownload(state);
+        }
+    } catch (...) {
+        close_all_fds();
+        throw;
+    }
+}
+
+}  // namespace milvus::storage

--- a/internal/core/src/storage/IndexEntryReader.h
+++ b/internal/core/src/storage/IndexEntryReader.h
@@ -1,0 +1,172 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <future>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "common/EasyAssert.h"
+#include "filemanager/InputStream.h"
+#include "nlohmann/json.hpp"
+#include "storage/IndexEntryWriter.h"
+#include "storage/ThreadPools.h"
+#include "storage/plugin/PluginInterface.h"
+
+namespace milvus::storage {
+
+struct Entry {
+    std::vector<uint8_t> data;
+};
+
+class IndexEntryReader {
+ public:
+    static std::unique_ptr<IndexEntryReader>
+    Open(std::shared_ptr<milvus::InputStream> input,
+         int64_t file_size,
+         int64_t collection_id = 0,
+         ThreadPoolPriority priority = ThreadPoolPriority::HIGH);
+
+    std::vector<std::string>
+    GetEntryNames() const;
+
+    Entry
+    ReadEntry(const std::string& name);
+
+    void
+    ReadEntryToFile(const std::string& name, const std::string& local_path);
+
+    void
+    ReadEntriesToFiles(const std::vector<std::pair<std::string, std::string>>&
+                           name_path_pairs);
+
+    template <typename T>
+    T
+    GetMeta(const std::string& key) const {
+        AssertInfo(meta_json_.contains(key), "Meta key not found: {}", key);
+        return meta_json_[key].get<T>();
+    }
+
+    template <typename T>
+    T
+    GetMeta(const std::string& key, const T& default_value) const {
+        if (!meta_json_.contains(key)) {
+            return default_value;
+        }
+        return meta_json_[key].get<T>();
+    }
+
+    bool
+    HasMeta(const std::string& key) const {
+        return meta_json_.contains(key);
+    }
+
+    IndexEntryReader(const IndexEntryReader&) = delete;
+    IndexEntryReader&
+    operator=(const IndexEntryReader&) = delete;
+
+ private:
+    struct PlainEntryMeta {
+        uint64_t offset;
+        uint64_t size;
+        uint32_t crc32;
+    };
+
+    struct EncryptedEntryMeta {
+        uint64_t original_size;
+        uint32_t crc32;
+        std::vector<SliceMeta> slices;
+    };
+
+    struct EntryMeta {
+        bool encrypted;
+        PlainEntryMeta plain;
+        EncryptedEntryMeta enc;
+    };
+
+    IndexEntryReader() = default;
+
+    void
+    ReadFooterAndDirectory();
+    void
+    ValidateMagic();
+
+    Entry
+    ReadPlainEntry(const EntryMeta& meta);
+    Entry
+    ReadEncryptedEntry(const EntryMeta& meta);
+
+    void
+    VerifyCrc32c(uint32_t expected,
+                 const uint8_t* data,
+                 size_t size,
+                 const std::string& name);
+
+    // Helper struct for tracking entry download state
+    struct RangeCrc {
+        uint32_t crc;
+        size_t len;
+    };
+
+    struct EntryDownloadState {
+        std::string name;
+        int fd;
+        uint32_t expected_crc;
+        std::vector<RangeCrc> range_crcs;
+    };
+
+    // Prepare download state for an entry (open file, allocate CRC vector)
+    EntryDownloadState
+    PrepareEntryDownload(const std::string& name,
+                         const std::string& local_path,
+                         const EntryMeta& meta);
+
+    // Submit download tasks for an entry to the futures vector (does not wait)
+    void
+    SubmitEntryDownloadTasks(const EntryMeta& meta,
+                             EntryDownloadState& state,
+                             std::vector<std::future<void>>& futures);
+
+    // Verify CRC and close file descriptor
+    void
+    FinalizeEntryDownload(EntryDownloadState& state);
+
+    std::shared_ptr<milvus::InputStream> input_;
+    int64_t file_size_ = 0;
+    int64_t collection_id_ = 0;
+    ThreadPoolPriority priority_ = ThreadPoolPriority::HIGH;
+
+    bool is_encrypted_ = false;
+    std::string edek_;
+    int64_t ez_id_ = 0;
+    size_t slice_size_ = 0;
+
+    std::shared_ptr<plugin::ICipherPlugin> cipher_plugin_;
+
+    std::unordered_map<std::string, EntryMeta> entry_index_;
+    std::vector<std::string> entry_names_;
+
+    static constexpr size_t kSmallEntryCacheThreshold = 1 * 1024 * 1024;
+    std::unordered_map<std::string, Entry> small_entry_cache_;
+    nlohmann::json meta_json_;
+};
+
+}  // namespace milvus::storage

--- a/internal/core/src/storage/IndexEntryWriter.h
+++ b/internal/core/src/storage/IndexEntryWriter.h
@@ -1,0 +1,96 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include "common/EasyAssert.h"
+#include "nlohmann/json.hpp"
+
+namespace milvus::storage {
+
+constexpr char MILVUS_V3_MAGIC[] = "MVSIDXV3";
+constexpr size_t MILVUS_V3_MAGIC_SIZE = 8;
+constexpr size_t MILVUS_V3_FOOTER_SIZE = 32;
+constexpr uint16_t MILVUS_V3_FORMAT_VERSION = 3;
+constexpr char MILVUS_V3_META_ENTRY_NAME[] = "__meta__";
+
+struct DirectoryEntry {
+    std::string name;
+    // Offset within the Data Region (i.e., bytes after the 8-byte magic header).
+    // To get the absolute file position, add MILVUS_V3_MAGIC_SIZE.
+    uint64_t offset;
+    uint64_t size;
+    uint32_t crc32;
+};
+
+struct SliceMeta {
+    // Offset within the Data Region (i.e., bytes after the 8-byte magic header).
+    // To get the absolute file position, add MILVUS_V3_MAGIC_SIZE.
+    uint64_t offset;
+    uint64_t size;
+};
+
+struct EncryptedDirectoryEntry {
+    std::string name;
+    uint64_t original_size;
+    uint32_t crc32;
+    std::vector<SliceMeta> slices;
+};
+
+class IndexEntryWriter {
+ public:
+    virtual ~IndexEntryWriter() = default;
+    virtual void
+    WriteEntry(const std::string& name, const void* data, size_t size) = 0;
+    virtual void
+    WriteEntry(const std::string& name, int fd, size_t size) = 0;
+    template <typename T>
+    void
+    PutMeta(const std::string& key, T&& value) {
+        AssertInfo(!meta_json_.contains(key), "Duplicate meta key: {}", key);
+        meta_json_[key] = std::forward<T>(value);
+    }
+
+    virtual void
+    Finish() = 0;
+    virtual size_t
+    GetTotalBytesWritten() const = 0;
+
+    IndexEntryWriter(const IndexEntryWriter&) = delete;
+    IndexEntryWriter&
+    operator=(const IndexEntryWriter&) = delete;
+
+ protected:
+    IndexEntryWriter() : meta_json_(nlohmann::json::object()) {
+    }
+
+    void
+    CheckDuplicateName(const std::string& name) {
+        auto [it, inserted] = written_names_.insert(name);
+        AssertInfo(inserted, "Duplicate entry name: {}", name);
+    }
+
+    std::unordered_set<std::string> written_names_;
+    nlohmann::json meta_json_;
+};
+
+}  // namespace milvus::storage

--- a/internal/core/src/storage/IndexEntryWriterTest.cpp
+++ b/internal/core/src/storage/IndexEntryWriterTest.cpp
@@ -1,0 +1,917 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+
+#include <fcntl.h>
+#include <gtest/gtest.h>
+#include <unistd.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "common/EasyAssert.h"
+#include "test_utils/Constants.h"
+#include "milvus-storage/filesystem/fs.h"
+#include "storage/IndexEntryDirectStreamWriter.h"
+#include "storage/IndexEntryEncryptedLocalWriter.h"
+#include "storage/IndexEntryReader.h"
+#include "storage/PluginLoader.h"
+#include "storage/RemoteInputStream.h"
+#include "storage/RemoteOutputStream.h"
+
+using namespace milvus::storage;
+
+namespace {
+
+// Simple XOR-based mock cipher for testing (NOT for production use!)
+class MockEncryptor : public plugin::IEncryptor {
+ public:
+    explicit MockEncryptor(uint8_t key) : key_(key) {
+    }
+
+    std::string
+    Encrypt(const std::string& plaintext) const override {
+        return Encrypt(plaintext.data(), plaintext.size());
+    }
+
+    std::string
+    Encrypt(std::string_view plaintext) const override {
+        return Encrypt(plaintext.data(), plaintext.size());
+    }
+
+    std::string
+    Encrypt(const void* data, size_t len) const override {
+        // Format: [1-byte key][XOR'd data]
+        std::string result;
+        result.reserve(1 + len);
+        result.push_back(static_cast<char>(key_));
+        const auto* src = static_cast<const uint8_t*>(data);
+        for (size_t i = 0; i < len; i++) {
+            result.push_back(static_cast<char>(src[i] ^ key_));
+        }
+        return result;
+    }
+
+    std::string
+    GetKey() const override {
+        return std::string(1, static_cast<char>(key_));
+    }
+
+ private:
+    uint8_t key_;
+};
+
+class MockDecryptor : public plugin::IDecryptor {
+ public:
+    std::string
+    Decrypt(const std::string& ciphertext) const override {
+        return Decrypt(ciphertext.data(), ciphertext.size());
+    }
+
+    std::string
+    Decrypt(std::string_view ciphertext) const override {
+        return Decrypt(ciphertext.data(), ciphertext.size());
+    }
+
+    std::string
+    Decrypt(const void* data, size_t len) const override {
+        if (len < 1) {
+            return "";
+        }
+        const auto* src = static_cast<const uint8_t*>(data);
+        uint8_t key = src[0];
+        std::string result;
+        result.reserve(len - 1);
+        for (size_t i = 1; i < len; i++) {
+            result.push_back(static_cast<char>(src[i] ^ key));
+        }
+        return result;
+    }
+
+    std::string
+    GetKey() const override {
+        return "";
+    }
+};
+
+class MockCipherPlugin : public plugin::ICipherPlugin {
+ public:
+    std::string
+    getPluginName() const override {
+        return "CipherPlugin";
+    }
+
+    void
+    Update(int64_t, int64_t, const std::string&) override {
+    }
+
+    std::pair<std::shared_ptr<plugin::IEncryptor>, std::string>
+    GetEncryptor(int64_t, int64_t) const override {
+        return {std::make_shared<MockEncryptor>(0x5A), "mock_edek"};
+    }
+
+    std::shared_ptr<plugin::IDecryptor>
+    GetDecryptor(int64_t, int64_t, const std::string&) const override {
+        return std::make_shared<MockDecryptor>();
+    }
+};
+
+}  // namespace
+
+namespace {
+
+std::string
+GetRootPath() {
+    return TestLocalPath + "index_writer_test";
+}
+const std::string kV3FilePath = "test_v3_index";
+
+std::vector<uint8_t>
+GeneratePattern(size_t size) {
+    std::vector<uint8_t> data(size);
+    for (size_t i = 0; i < size; ++i) {
+        data[i] = static_cast<uint8_t>(i % 256);
+    }
+    return data;
+}
+
+void
+VerifyPattern(const std::vector<uint8_t>& data, size_t expected_size) {
+    ASSERT_EQ(data.size(), expected_size);
+    for (size_t i = 0; i < expected_size; ++i) {
+        ASSERT_EQ(data[i], static_cast<uint8_t>(i % 256))
+            << "Mismatch at byte " << i;
+    }
+}
+
+}  // namespace
+
+class IndexEntryWriterV3Test : public testing::Test {
+ public:
+    void
+    SetUp() override {
+        auto conf = milvus_storage::ArrowFileSystemConfig();
+        conf.storage_type = "local";
+        conf.root_path = GetRootPath();
+        auto result = milvus_storage::CreateArrowFileSystem(conf);
+        ASSERT_TRUE(result.ok()) << result.status().ToString();
+        fs_ = result.ValueOrDie();
+    }
+
+    void
+    TearDown() override {
+        if (fs_) {
+            fs_->DeleteDirContents("");
+        }
+    }
+
+ protected:
+    std::shared_ptr<milvus::OutputStream>
+    CreateOutputStream(const std::string& path) {
+        auto result = fs_->OpenOutputStream(path);
+        EXPECT_TRUE(result.ok()) << result.status().ToString();
+        return std::make_shared<RemoteOutputStream>(
+            std::move(result.ValueOrDie()));
+    }
+
+    std::shared_ptr<milvus::InputStream>
+    CreateInputStream(const std::string& path) {
+        auto result = fs_->OpenInputFile(path);
+        EXPECT_TRUE(result.ok()) << result.status().ToString();
+        return std::make_shared<RemoteInputStream>(
+            std::move(result.ValueOrDie()));
+    }
+
+    int64_t
+    GetFileSize(const std::string& path) {
+        auto info = fs_->GetFileInfo(path);
+        EXPECT_TRUE(info.ok()) << info.status().ToString();
+        return info.ValueOrDie().size();
+    }
+
+    milvus_storage::ArrowFileSystemPtr fs_;
+};
+
+TEST_F(IndexEntryWriterV3Test, SmallMemoryEntryRoundtrip) {
+    const std::string file_path = kV3FilePath + "_small";
+    const size_t entry_size =
+        512 * 1024;  // 512 KB, well under 1MB cache threshold
+    auto data = GeneratePattern(entry_size);
+
+    {
+        auto output = CreateOutputStream(file_path);
+        IndexEntryDirectStreamWriter writer(output);
+        writer.WriteEntry("small_entry", data.data(), data.size());
+        writer.Finish();
+    }
+
+    auto input = CreateInputStream(file_path);
+    int64_t file_size = GetFileSize(file_path);
+    auto reader = IndexEntryReader::Open(input, file_size);
+
+    auto entry = reader->ReadEntry("small_entry");
+    VerifyPattern(entry.data, entry_size);
+}
+
+TEST_F(IndexEntryWriterV3Test, LargeMemoryEntryRoundtrip) {
+    const std::string file_path = kV3FilePath + "_large";
+    const size_t entry_size =
+        17 * 1024 * 1024;  // 17 MB, exceeds 16MB threshold
+    auto data = GeneratePattern(entry_size);
+
+    {
+        auto output = CreateOutputStream(file_path);
+        IndexEntryDirectStreamWriter writer(output);
+        writer.WriteEntry("large_entry", data.data(), data.size());
+        writer.Finish();
+    }
+
+    auto input = CreateInputStream(file_path);
+    int64_t file_size = GetFileSize(file_path);
+    auto reader = IndexEntryReader::Open(input, file_size);
+
+    auto entry = reader->ReadEntry("large_entry");
+    VerifyPattern(entry.data, entry_size);
+}
+
+TEST_F(IndexEntryWriterV3Test, FdEntryRoundtrip) {
+    const std::string file_path = kV3FilePath + "_fd";
+    const size_t entry_size = 2 * 1024 * 1024;  // 2 MB
+    auto data = GeneratePattern(entry_size);
+
+    std::string tmp_relative = "fd_source.bin";
+    std::string tmp_absolute = GetRootPath() + "/" + tmp_relative;
+    {
+        auto tmp_out = CreateOutputStream(tmp_relative);
+        tmp_out->Write(data.data(), data.size());
+        tmp_out->Close();
+    }
+
+    int fd = ::open(tmp_absolute.c_str(), O_RDONLY);
+    ASSERT_NE(fd, -1) << "Failed to open temp file: " << strerror(errno);
+
+    {
+        auto output = CreateOutputStream(file_path);
+        IndexEntryDirectStreamWriter writer(output);
+        writer.WriteEntry("fd_entry", fd, entry_size);
+        writer.Finish();
+    }
+    ::close(fd);
+
+    auto input = CreateInputStream(file_path);
+    int64_t file_size = GetFileSize(file_path);
+    auto reader = IndexEntryReader::Open(input, file_size);
+
+    auto entry = reader->ReadEntry("fd_entry");
+    VerifyPattern(entry.data, entry_size);
+}
+
+TEST_F(IndexEntryWriterV3Test, MultipleEntriesRoundtrip) {
+    const std::string file_path = kV3FilePath + "_multi";
+    const size_t meta_size = 128;
+    const size_t data_size = 4 * 1024 * 1024;  // 4 MB
+
+    auto meta_data = GeneratePattern(meta_size);
+    auto index_data = GeneratePattern(data_size);
+
+    {
+        auto output = CreateOutputStream(file_path);
+        IndexEntryDirectStreamWriter writer(output);
+        writer.WriteEntry("META", meta_data.data(), meta_data.size());
+        writer.WriteEntry("DATA", index_data.data(), index_data.size());
+        writer.Finish();
+    }
+
+    auto input = CreateInputStream(file_path);
+    int64_t file_size = GetFileSize(file_path);
+    auto reader = IndexEntryReader::Open(input, file_size);
+
+    auto meta_entry = reader->ReadEntry("META");
+    VerifyPattern(meta_entry.data, meta_size);
+
+    auto data_entry = reader->ReadEntry("DATA");
+    VerifyPattern(data_entry.data, data_size);
+}
+
+TEST_F(IndexEntryWriterV3Test, DuplicateNameThrows) {
+    const std::string file_path = kV3FilePath + "_dup";
+    auto data = GeneratePattern(64);
+
+    auto output = CreateOutputStream(file_path);
+    IndexEntryDirectStreamWriter writer(output);
+    writer.WriteEntry("entry", data.data(), data.size());
+
+    EXPECT_THROW(writer.WriteEntry("entry", data.data(), data.size()),
+                 milvus::SegcoreError);
+}
+
+TEST_F(IndexEntryWriterV3Test, ReadEntryToFile) {
+    const std::string file_path = kV3FilePath + "_tofile";
+    const size_t entry_size = 1024 * 1024;  // 1 MB
+    auto data = GeneratePattern(entry_size);
+
+    {
+        auto output = CreateOutputStream(file_path);
+        IndexEntryDirectStreamWriter writer(output);
+        writer.WriteEntry("file_entry", data.data(), data.size());
+        writer.Finish();
+    }
+
+    auto input = CreateInputStream(file_path);
+    int64_t file_size = GetFileSize(file_path);
+    auto reader = IndexEntryReader::Open(input, file_size);
+
+    std::string local_file = GetRootPath() + "/read_entry_output.bin";
+    reader->ReadEntryToFile("file_entry", local_file);
+
+    std::ifstream ifs(local_file, std::ios::binary | std::ios::ate);
+    ASSERT_TRUE(ifs.is_open());
+    size_t read_size = ifs.tellg();
+    ASSERT_EQ(read_size, entry_size);
+
+    ifs.seekg(0);
+    std::vector<uint8_t> read_data(read_size);
+    ifs.read(reinterpret_cast<char*>(read_data.data()), read_size);
+    VerifyPattern(read_data, entry_size);
+
+    ::unlink(local_file.c_str());
+}
+
+TEST_F(IndexEntryWriterV3Test, ReadEntriesToFiles) {
+    const std::string file_path = kV3FilePath + "_tofiles";
+    const size_t size_a = 256 * 1024;
+    const size_t size_b = 512 * 1024;
+
+    auto data_a = GeneratePattern(size_a);
+    auto data_b = GeneratePattern(size_b);
+
+    {
+        auto output = CreateOutputStream(file_path);
+        IndexEntryDirectStreamWriter writer(output);
+        writer.WriteEntry("entry_a", data_a.data(), data_a.size());
+        writer.WriteEntry("entry_b", data_b.data(), data_b.size());
+        writer.Finish();
+    }
+
+    auto input = CreateInputStream(file_path);
+    int64_t file_size = GetFileSize(file_path);
+    auto reader = IndexEntryReader::Open(input, file_size);
+
+    std::string file_a = GetRootPath() + "/output_a.bin";
+    std::string file_b = GetRootPath() + "/output_b.bin";
+
+    std::vector<std::pair<std::string, std::string>> pairs = {
+        {"entry_a", file_a}, {"entry_b", file_b}};
+    reader->ReadEntriesToFiles(pairs);
+
+    auto verify_file = [](const std::string& path, size_t expected_size) {
+        std::ifstream ifs(path, std::ios::binary | std::ios::ate);
+        ASSERT_TRUE(ifs.is_open()) << "Failed to open: " << path;
+        size_t read_size = ifs.tellg();
+        ASSERT_EQ(read_size, expected_size);
+        ifs.seekg(0);
+        std::vector<uint8_t> buf(read_size);
+        ifs.read(reinterpret_cast<char*>(buf.data()), read_size);
+        VerifyPattern(buf, expected_size);
+    };
+
+    verify_file(file_a, size_a);
+    verify_file(file_b, size_b);
+
+    ::unlink(file_a.c_str());
+    ::unlink(file_b.c_str());
+}
+
+TEST_F(IndexEntryWriterV3Test, GetEntryNames) {
+    const std::string file_path = kV3FilePath + "_names";
+    auto data = GeneratePattern(64);
+
+    {
+        auto output = CreateOutputStream(file_path);
+        IndexEntryDirectStreamWriter writer(output);
+        writer.WriteEntry("alpha", data.data(), data.size());
+        writer.WriteEntry("beta", data.data(), data.size());
+        writer.WriteEntry("gamma", data.data(), data.size());
+        writer.Finish();
+    }
+
+    auto input = CreateInputStream(file_path);
+    int64_t file_size = GetFileSize(file_path);
+    auto reader = IndexEntryReader::Open(input, file_size);
+
+    auto names = reader->GetEntryNames();
+    ASSERT_EQ(names.size(), 4);
+    EXPECT_EQ(names[0], "alpha");
+    EXPECT_EQ(names[1], "beta");
+    EXPECT_EQ(names[2], "gamma");
+    EXPECT_EQ(names[3], "__meta__");
+}
+
+TEST_F(IndexEntryWriterV3Test, EntryNotFound) {
+    const std::string file_path = kV3FilePath + "_notfound";
+    auto data = GeneratePattern(64);
+
+    {
+        auto output = CreateOutputStream(file_path);
+        IndexEntryDirectStreamWriter writer(output);
+        writer.WriteEntry("exists", data.data(), data.size());
+        writer.Finish();
+    }
+
+    auto input = CreateInputStream(file_path);
+    int64_t file_size = GetFileSize(file_path);
+    auto reader = IndexEntryReader::Open(input, file_size);
+
+    EXPECT_THROW(reader->ReadEntry("does_not_exist"), milvus::SegcoreError);
+}
+
+TEST_F(IndexEntryWriterV3Test, SmallEntryCache) {
+    const std::string file_path = kV3FilePath + "_cache";
+    const size_t entry_size = 256;  // well under 1MB cache threshold
+    auto data = GeneratePattern(entry_size);
+
+    {
+        auto output = CreateOutputStream(file_path);
+        IndexEntryDirectStreamWriter writer(output);
+        writer.WriteEntry("cached_entry", data.data(), data.size());
+        writer.Finish();
+    }
+
+    auto input = CreateInputStream(file_path);
+    int64_t file_size = GetFileSize(file_path);
+    auto reader = IndexEntryReader::Open(input, file_size);
+
+    auto entry1 = reader->ReadEntry("cached_entry");
+    auto entry2 = reader->ReadEntry("cached_entry");
+
+    ASSERT_EQ(entry1.data.size(), entry2.data.size());
+    EXPECT_EQ(
+        std::memcmp(entry1.data.data(), entry2.data.data(), entry1.data.size()),
+        0);
+    VerifyPattern(entry1.data, entry_size);
+}
+
+TEST_F(IndexEntryWriterV3Test, GetTotalBytesWritten) {
+    const std::string file_path = kV3FilePath + "_totalbytes";
+    const size_t entry_size = 1024;
+    auto data = GeneratePattern(entry_size);
+
+    auto output = CreateOutputStream(file_path);
+    IndexEntryDirectStreamWriter writer(output);
+    writer.WriteEntry("entry", data.data(), data.size());
+    writer.Finish();
+
+    size_t total = writer.GetTotalBytesWritten();
+    EXPECT_GT(total, entry_size);
+
+    int64_t actual_file_size = GetFileSize(file_path);
+    EXPECT_EQ(total, static_cast<size_t>(actual_file_size));
+}
+
+TEST_F(IndexEntryWriterV3Test, WriteAfterFinishThrows) {
+    const std::string file_path = kV3FilePath + "_afterfinish";
+    auto data = GeneratePattern(64);
+
+    auto output = CreateOutputStream(file_path);
+    IndexEntryDirectStreamWriter writer(output);
+    writer.WriteEntry("entry", data.data(), data.size());
+    writer.Finish();
+
+    EXPECT_THROW(writer.WriteEntry("another", data.data(), data.size()),
+                 milvus::SegcoreError);
+}
+
+TEST_F(IndexEntryWriterV3Test, MixedSizeEntries) {
+    const std::string file_path = kV3FilePath + "_mixed";
+    const size_t tiny_size = 48;
+    const size_t large_size = 17 * 1024 * 1024;  // 17 MB
+
+    auto tiny_data = GeneratePattern(tiny_size);
+    auto large_data = GeneratePattern(large_size);
+
+    {
+        auto output = CreateOutputStream(file_path);
+        IndexEntryDirectStreamWriter writer(output);
+        writer.WriteEntry("tiny_meta", tiny_data.data(), tiny_data.size());
+        writer.WriteEntry("large_data", large_data.data(), large_data.size());
+        writer.Finish();
+    }
+
+    auto input = CreateInputStream(file_path);
+    int64_t file_size = GetFileSize(file_path);
+    auto reader = IndexEntryReader::Open(input, file_size);
+
+    auto names = reader->GetEntryNames();
+    ASSERT_EQ(names.size(), 3);
+    EXPECT_EQ(names[0], "tiny_meta");
+    EXPECT_EQ(names[1], "large_data");
+    EXPECT_EQ(names[2], "__meta__");
+
+    auto tiny_entry = reader->ReadEntry("tiny_meta");
+    VerifyPattern(tiny_entry.data, tiny_size);
+
+    auto large_entry = reader->ReadEntry("large_data");
+    VerifyPattern(large_entry.data, large_size);
+}
+
+TEST_F(IndexEntryWriterV3Test, SetMetaRoundtrip) {
+    const std::string file_path = kV3FilePath + "_meta";
+    auto data = GeneratePattern(256);
+
+    {
+        auto output = CreateOutputStream(file_path);
+        IndexEntryDirectStreamWriter writer(output);
+        writer.WriteEntry("data", data.data(), data.size());
+        writer.PutMeta("index_type", std::string("bitmap"));
+        writer.PutMeta("build_id", 42);
+        writer.Finish();
+    }
+
+    auto input = CreateInputStream(file_path);
+    int64_t file_size = GetFileSize(file_path);
+    auto reader = IndexEntryReader::Open(input, file_size);
+
+    // Verify __meta__ entry is present
+    auto names = reader->GetEntryNames();
+    EXPECT_EQ(names.back(), "__meta__");
+
+    // Read and verify the meta content via GetMeta
+    EXPECT_EQ(reader->GetMeta<std::string>("index_type"), "bitmap");
+    EXPECT_EQ(reader->GetMeta<int>("build_id"), 42);
+
+    // Regular data entry should still be readable
+    auto data_entry = reader->ReadEntry("data");
+    VerifyPattern(data_entry.data, 256);
+}
+
+TEST_F(IndexEntryWriterV3Test, EmptyMetaRoundtrip) {
+    const std::string file_path = kV3FilePath + "_emptymeta";
+    auto data = GeneratePattern(128);
+
+    {
+        auto output = CreateOutputStream(file_path);
+        IndexEntryDirectStreamWriter writer(output);
+        writer.WriteEntry("entry", data.data(), data.size());
+        // No PutMeta calls - meta_json_ defaults to empty JSON object
+        writer.Finish();
+    }
+
+    auto input = CreateInputStream(file_path);
+    int64_t file_size = GetFileSize(file_path);
+    auto reader = IndexEntryReader::Open(input, file_size);
+
+    // __meta__ entry should exist with empty JSON object "{}"
+    auto meta_entry = reader->ReadEntry("__meta__");
+    std::string meta_str(reinterpret_cast<const char*>(meta_entry.data.data()),
+                         meta_entry.data.size());
+    EXPECT_EQ(meta_str, "{}");
+
+    auto data_entry = reader->ReadEntry("entry");
+    VerifyPattern(data_entry.data, 128);
+}
+
+TEST_F(IndexEntryWriterV3Test, ReadEntriesToFilesMultiRangeParallel) {
+    // Test ReadEntriesToFiles with multiple large entries, each requiring
+    // multiple ranges (> 16MB each). This tests the parallel download path
+    // where all ranges from all entries are submitted at once.
+    const std::string file_path = kV3FilePath + "_multirange";
+
+    // Each entry > 16MB to require multiple ranges
+    const size_t size_a = 35 * 1024 * 1024;  // 35 MB = 3 ranges
+    const size_t size_b = 50 * 1024 * 1024;  // 50 MB = 4 ranges
+    const size_t size_c = 20 * 1024 * 1024;  // 20 MB = 2 ranges
+    // Total: 9 parallel range tasks across 3 entries
+
+    auto data_a = GeneratePattern(size_a);
+    auto data_b = GeneratePattern(size_b);
+    auto data_c = GeneratePattern(size_c);
+
+    {
+        auto output = CreateOutputStream(file_path);
+        IndexEntryDirectStreamWriter writer(output);
+        writer.WriteEntry("entry_a", data_a.data(), data_a.size());
+        writer.WriteEntry("entry_b", data_b.data(), data_b.size());
+        writer.WriteEntry("entry_c", data_c.data(), data_c.size());
+        writer.Finish();
+    }
+
+    auto input = CreateInputStream(file_path);
+    int64_t file_size = GetFileSize(file_path);
+    auto reader = IndexEntryReader::Open(input, file_size);
+
+    std::string file_a = GetRootPath() + "/multirange_a.bin";
+    std::string file_b = GetRootPath() + "/multirange_b.bin";
+    std::string file_c = GetRootPath() + "/multirange_c.bin";
+
+    std::vector<std::pair<std::string, std::string>> pairs = {
+        {"entry_a", file_a}, {"entry_b", file_b}, {"entry_c", file_c}};
+    reader->ReadEntriesToFiles(pairs);
+
+    auto verify_file = [](const std::string& path, size_t expected_size) {
+        std::ifstream ifs(path, std::ios::binary | std::ios::ate);
+        ASSERT_TRUE(ifs.is_open()) << "Failed to open: " << path;
+        size_t read_size = ifs.tellg();
+        ASSERT_EQ(read_size, expected_size);
+        ifs.seekg(0);
+        std::vector<uint8_t> buf(read_size);
+        ifs.read(reinterpret_cast<char*>(buf.data()), read_size);
+        VerifyPattern(buf, expected_size);
+    };
+
+    verify_file(file_a, size_a);
+    verify_file(file_b, size_b);
+    verify_file(file_c, size_c);
+
+    ::unlink(file_a.c_str());
+    ::unlink(file_b.c_str());
+    ::unlink(file_c.c_str());
+}
+
+// =============================================================================
+// Edge Case Tests: Directory Table and Meta Entry size boundaries
+// =============================================================================
+
+TEST_F(IndexEntryWriterV3Test, LargeDirectoryTableNeedsSecondIO) {
+    // Create many entries with long names to make directory table > 64KB
+    // This tests the second IO path in ReadFooterAndDirectory()
+    const std::string file_path = kV3FilePath + "_largedir";
+    auto small_data = GeneratePattern(64);
+
+    // Each entry in directory table is roughly:
+    // {"name":"...", "offset":N, "size":N, "crc32":"XXXXXXXX"}
+    // ~60 bytes per entry + name length
+    // Need ~1100 entries with 50-char names to exceed 64KB
+    const size_t num_entries = 1200;
+    const std::string name_prefix =
+        "entry_with_a_very_long_name_to_inflate_dir_";
+
+    {
+        auto output = CreateOutputStream(file_path);
+        IndexEntryDirectStreamWriter writer(output);
+        for (size_t i = 0; i < num_entries; i++) {
+            std::string name = name_prefix + std::to_string(i);
+            writer.WriteEntry(name, small_data.data(), small_data.size());
+        }
+        writer.Finish();
+    }
+
+    auto input = CreateInputStream(file_path);
+    int64_t file_size = GetFileSize(file_path);
+    auto reader = IndexEntryReader::Open(input, file_size);
+
+    auto names = reader->GetEntryNames();
+    // +1 for __meta__
+    ASSERT_EQ(names.size(), num_entries + 1);
+
+    // Verify a few entries
+    auto entry0 = reader->ReadEntry(name_prefix + "0");
+    VerifyPattern(entry0.data, 64);
+
+    auto entry_last = reader->ReadEntry(name_prefix + "1199");
+    VerifyPattern(entry_last.data, 64);
+}
+
+TEST_F(IndexEntryWriterV3Test, DirectoryFitsButMetaDoesNotFitFirstIO) {
+    // Directory table fits in first 64KB, but meta entry is large enough
+    // that dir_size + meta_entry_size > 64KB - 32
+    // This tests the boundary where we need second IO for meta only
+    const std::string file_path = kV3FilePath + "_largemetasmalldir";
+
+    // Create a large meta JSON
+    // We need meta_entry_size to be large (> ~60KB)
+    // but directory table should be small (< 64KB - 32 - meta_size)
+    auto data = GeneratePattern(1024);
+
+    {
+        auto output = CreateOutputStream(file_path);
+        IndexEntryDirectStreamWriter writer(output);
+        writer.WriteEntry("data", data.data(), data.size());
+
+        // Add a large meta value (~70KB of repeated string)
+        std::string large_value(70 * 1024, 'X');
+        writer.PutMeta("large_field", large_value);
+        writer.Finish();
+    }
+
+    auto input = CreateInputStream(file_path);
+    int64_t file_size = GetFileSize(file_path);
+    auto reader = IndexEntryReader::Open(input, file_size);
+
+    // Verify meta can be read
+    auto meta_value = reader->GetMeta<std::string>("large_field");
+    ASSERT_EQ(meta_value.size(), 70 * 1024);
+    ASSERT_EQ(meta_value, std::string(70 * 1024, 'X'));
+
+    // Verify data entry
+    auto entry = reader->ReadEntry("data");
+    VerifyPattern(entry.data, 1024);
+}
+
+TEST_F(IndexEntryWriterV3Test, LargeMetaEntryMultiRange) {
+    // Meta entry > 16MB requires multiple range reads
+    const std::string file_path = kV3FilePath + "_hugemetamultirange";
+
+    auto data = GeneratePattern(256);
+
+    {
+        auto output = CreateOutputStream(file_path);
+        IndexEntryDirectStreamWriter writer(output);
+        writer.WriteEntry("data", data.data(), data.size());
+
+        // Create meta with ~20MB of data (will need 2 ranges to read)
+        std::string huge_value(20 * 1024 * 1024, 'Y');
+        writer.PutMeta("huge_field", huge_value);
+        writer.Finish();
+    }
+
+    auto input = CreateInputStream(file_path);
+    int64_t file_size = GetFileSize(file_path);
+    auto reader = IndexEntryReader::Open(input, file_size);
+
+    // Verify large meta
+    auto meta_value = reader->GetMeta<std::string>("huge_field");
+    ASSERT_EQ(meta_value.size(), 20 * 1024 * 1024);
+    ASSERT_EQ(meta_value[0], 'Y');
+    ASSERT_EQ(meta_value[meta_value.size() - 1], 'Y');
+
+    // Verify data entry
+    auto entry = reader->ReadEntry("data");
+    VerifyPattern(entry.data, 256);
+}
+
+// =============================================================================
+// Encrypted Entry Tests (using MockCipherPlugin)
+// =============================================================================
+
+class IndexEntryEncryptedV3Test : public IndexEntryWriterV3Test {
+ protected:
+    void
+    SetUp() override {
+        IndexEntryWriterV3Test::SetUp();
+        mock_cipher_ = std::make_shared<MockCipherPlugin>();
+    }
+
+    std::shared_ptr<MockCipherPlugin> mock_cipher_;
+};
+
+TEST_F(IndexEntryEncryptedV3Test, EncryptedSmallEntryRoundtrip) {
+    const std::string file_path = kV3FilePath + "_enc_small";
+    const size_t entry_size = 1024;
+    auto data = GeneratePattern(entry_size);
+
+    // Use small slice_size for testing multi-slice behavior
+    const size_t slice_size = 512;
+
+    {
+        // Note: remote_path should be relative to fs root
+        IndexEntryEncryptedLocalWriter writer(file_path,
+                                              fs_,
+                                              mock_cipher_,
+                                              /*ez_id=*/1,
+                                              /*collection_id=*/100,
+                                              GetRootPath(),
+                                              slice_size);
+        writer.WriteEntry("enc_entry", data.data(), data.size());
+        writer.Finish();
+    }
+
+    // Verify file was created
+    auto info = fs_->GetFileInfo(file_path);
+    ASSERT_TRUE(info.ok());
+    EXPECT_GT(info.ValueOrDie().size(), entry_size);  // ciphertext > plaintext
+}
+
+TEST_F(IndexEntryEncryptedV3Test, EncryptedMultiSliceEntry) {
+    // Entry larger than slice_size, requiring multiple slices
+    const std::string file_path = kV3FilePath + "_enc_multislice";
+    const size_t slice_size = 1024;            // 1KB slices
+    const size_t entry_size = 5 * 1024 + 100;  // 5KB + 100B = 6 slices
+    auto data = GeneratePattern(entry_size);
+
+    {
+        IndexEntryEncryptedLocalWriter writer(file_path,
+                                              fs_,
+                                              mock_cipher_,
+                                              /*ez_id=*/1,
+                                              /*collection_id=*/100,
+                                              GetRootPath(),
+                                              slice_size);
+        writer.WriteEntry("large_enc", data.data(), data.size());
+        writer.Finish();
+    }
+
+    auto info = fs_->GetFileInfo(file_path);
+    ASSERT_TRUE(info.ok());
+    EXPECT_GT(info.ValueOrDie().size(), entry_size);
+}
+
+TEST_F(IndexEntryEncryptedV3Test, EncryptedMultipleEntriesMultiSlice) {
+    // Multiple entries, each requiring multiple slices
+    const std::string file_path = kV3FilePath + "_enc_multi_multi";
+    const size_t slice_size = 1024;  // 1KB slices
+
+    const size_t size_a = 3 * 1024 + 500;  // 4 slices
+    const size_t size_b = 2 * 1024 + 100;  // 3 slices
+    const size_t size_c = 5 * 1024;        // 5 slices
+
+    auto data_a = GeneratePattern(size_a);
+    auto data_b = GeneratePattern(size_b);
+    auto data_c = GeneratePattern(size_c);
+
+    {
+        IndexEntryEncryptedLocalWriter writer(file_path,
+                                              fs_,
+                                              mock_cipher_,
+                                              /*ez_id=*/1,
+                                              /*collection_id=*/100,
+                                              GetRootPath(),
+                                              slice_size);
+        writer.WriteEntry("entry_a", data_a.data(), data_a.size());
+        writer.WriteEntry("entry_b", data_b.data(), data_b.size());
+        writer.WriteEntry("entry_c", data_c.data(), data_c.size());
+        writer.Finish();
+    }
+
+    auto info = fs_->GetFileInfo(file_path);
+    ASSERT_TRUE(info.ok());
+    EXPECT_GT(info.ValueOrDie().size(), size_a + size_b + size_c);
+}
+
+TEST_F(IndexEntryEncryptedV3Test, EncryptedLargeMetaMultiSlice) {
+    // Large meta entry requiring multiple slices
+    const std::string file_path = kV3FilePath + "_enc_largemeta";
+    const size_t slice_size = 1024;  // 1KB slices
+
+    auto data = GeneratePattern(256);
+
+    {
+        IndexEntryEncryptedLocalWriter writer(file_path,
+                                              fs_,
+                                              mock_cipher_,
+                                              /*ez_id=*/1,
+                                              /*collection_id=*/100,
+                                              GetRootPath(),
+                                              slice_size);
+        writer.WriteEntry("data", data.data(), data.size());
+
+        // Meta will be ~5KB = 5 slices
+        std::string meta_value(5000, 'M');
+        writer.PutMeta("large_meta", meta_value);
+        writer.Finish();
+    }
+
+    auto info = fs_->GetFileInfo(file_path);
+    ASSERT_TRUE(info.ok());
+}
+
+TEST_F(IndexEntryEncryptedV3Test, EncryptedFdEntryMultiSlice) {
+    // Test fd-based entry with multiple slices
+    const std::string file_path = kV3FilePath + "_enc_fd";
+    const size_t slice_size = 1024;            // 1KB slices
+    const size_t entry_size = 4 * 1024 + 200;  // 5 slices
+    auto data = GeneratePattern(entry_size);
+
+    // Write source file
+    std::string tmp_relative = "enc_fd_source.bin";
+    std::string tmp_absolute = GetRootPath() + "/" + tmp_relative;
+    {
+        auto tmp_out = CreateOutputStream(tmp_relative);
+        tmp_out->Write(data.data(), data.size());
+        tmp_out->Close();
+    }
+
+    int fd = ::open(tmp_absolute.c_str(), O_RDONLY);
+    ASSERT_NE(fd, -1);
+
+    {
+        IndexEntryEncryptedLocalWriter writer(file_path,
+                                              fs_,
+                                              mock_cipher_,
+                                              /*ez_id=*/1,
+                                              /*collection_id=*/100,
+                                              GetRootPath(),
+                                              slice_size);
+        writer.WriteEntry("fd_entry", fd, entry_size);
+        writer.Finish();
+    }
+    ::close(fd);
+
+    auto info = fs_->GetFileInfo(file_path);
+    ASSERT_TRUE(info.ok());
+    EXPECT_GT(info.ValueOrDie().size(), entry_size);
+
+    ::unlink(tmp_absolute.c_str());
+}

--- a/internal/core/src/storage/MemFileManagerImpl.cpp
+++ b/internal/core/src/storage/MemFileManagerImpl.cpp
@@ -107,16 +107,6 @@ MemFileManagerImpl::AddBinarySet(const BinarySet& binary_set,
     return true;
 }
 
-std::shared_ptr<InputStream>
-MemFileManagerImpl::OpenInputStream(const std::string& filename) {
-    return nullptr;
-}
-
-std::shared_ptr<OutputStream>
-MemFileManagerImpl::OpenOutputStream(const std::string& filename) {
-    return nullptr;
-}
-
 bool
 MemFileManagerImpl::AddFileMeta(const FileMeta& file_meta) {
     return true;

--- a/internal/core/src/storage/MemFileManagerImpl.h
+++ b/internal/core/src/storage/MemFileManagerImpl.h
@@ -50,12 +50,6 @@ class MemFileManagerImpl : public FileManagerImpl {
     virtual bool
     AddFileMeta(const FileMeta& file_meta) override;
 
-    virtual std::shared_ptr<InputStream>
-    OpenInputStream(const std::string& filename) override;
-
-    virtual std::shared_ptr<OutputStream>
-    OpenOutputStream(const std::string& filename) override;
-
  public:
     virtual std::string
     GetName() const override {

--- a/internal/core/src/storage/plugin/PluginInterface.h
+++ b/internal/core/src/storage/plugin/PluginInterface.h
@@ -10,12 +10,11 @@
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
 #pragma once
+#include <cstddef>
 #include <cstdint>
-#include <vector>
-#include <string>
-#include <unordered_map>
 #include <memory>
 #include <string>
+#include <string_view>
 
 namespace milvus::storage {
 namespace plugin {
@@ -45,32 +44,46 @@ class ICipherPlugin : public IPlugin {
     Update(int64_t ez_id, int64_t coll_id, const std::string& key) = 0;
 
     virtual std::pair<std::shared_ptr<IEncryptor>, std::string>
-    GetEncryptor(int64_t ez_id, int64_t coll_id) = 0;
+    GetEncryptor(int64_t ez_id, int64_t coll_id) const = 0;
 
     virtual std::shared_ptr<IDecryptor>
     GetDecryptor(int64_t ez_id,
                  int64_t coll_id,
-                 const std::string& safeKey) = 0;
+                 const std::string& safeKey) const = 0;
 };
 
 class IEncryptor {
  public:
     virtual ~IEncryptor() = default;
-    virtual std::string
-    Encrypt(const std::string& plaintext) = 0;
 
     virtual std::string
-    GetKey() = 0;
+    Encrypt(const std::string& plaintext) const = 0;
+
+    virtual std::string
+    Encrypt(std::string_view plaintext) const = 0;
+
+    virtual std::string
+    Encrypt(const void* data, size_t len) const = 0;
+
+    virtual std::string
+    GetKey() const = 0;
 };
 
 class IDecryptor {
  public:
     virtual ~IDecryptor() = default;
-    virtual std::string
-    Decrypt(const std::string& ciphertext) = 0;
 
     virtual std::string
-    GetKey() = 0;
+    Decrypt(const std::string& ciphertext) const = 0;
+
+    virtual std::string
+    Decrypt(std::string_view ciphertext) const = 0;
+
+    virtual std::string
+    Decrypt(const void* data, size_t len) const = 0;
+
+    virtual std::string
+    GetKey() const = 0;
 };
 
 }  // namespace plugin

--- a/internal/core/unittest/init_gtest.cpp
+++ b/internal/core/unittest/init_gtest.cpp
@@ -33,6 +33,7 @@
 #include "storage/LocalChunkManagerSingleton.h"
 #include "storage/MmapManager.h"
 #include "storage/RemoteChunkManagerSingleton.h"
+#include "index/Meta.h"
 #include "test_utils/Constants.h"
 #include "test_utils/storage_test_utils.h"
 
@@ -119,5 +120,6 @@ main(int argc, char** argv) {
         {10, true, 30},
         std::chrono::milliseconds(0));
 
+    milvus::index::kScalarIndexUseV3 = false;
     return RUN_ALL_TESTS();
 }

--- a/internal/datanode/compactor/sort_compaction.go
+++ b/internal/datanode/compactor/sort_compaction.go
@@ -587,12 +587,13 @@ func (t *sortCompactionTask) createTextIndex(ctx context.Context,
 			mu.Lock()
 			totalSize := lo.SumBy(lo.Values(uploaded), func(fileSize int64) int64 { return fileSize })
 			textIndexLogs[field.GetFieldID()] = &datapb.TextIndexStats{
-				FieldID:    field.GetFieldID(),
-				Version:    0,
-				BuildID:    taskID,
-				Files:      lo.Keys(uploaded),
-				LogSize:    totalSize,
-				MemorySize: totalSize,
+				FieldID:                   field.GetFieldID(),
+				Version:                   0,
+				BuildID:                   taskID,
+				Files:                     lo.Keys(uploaded),
+				LogSize:                   totalSize,
+				MemorySize:                totalSize,
+				CurrentScalarIndexVersion: common.CurrentScalarIndexEngineVersion,
 			}
 			mu.Unlock()
 

--- a/internal/datanode/index/task_stats.go
+++ b/internal/datanode/index/task_stats.go
@@ -528,12 +528,13 @@ func (st *statsTask) createTextIndex(ctx context.Context,
 			mu.Lock()
 			totalSize := lo.SumBy(lo.Values(uploaded), func(fileSize int64) int64 { return fileSize })
 			textIndexLogs[field.GetFieldID()] = &datapb.TextIndexStats{
-				FieldID:    field.GetFieldID(),
-				Version:    version,
-				BuildID:    taskID,
-				Files:      lo.Keys(uploaded),
-				LogSize:    totalSize,
-				MemorySize: totalSize,
+				FieldID:                   field.GetFieldID(),
+				Version:                   version,
+				BuildID:                   taskID,
+				Files:                     lo.Keys(uploaded),
+				LogSize:                   totalSize,
+				MemorySize:                totalSize,
+				CurrentScalarIndexVersion: common.CurrentScalarIndexEngineVersion,
 			}
 			mu.Unlock()
 

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -91,6 +91,8 @@ const (
 
 const (
 	MinimalScalarIndexEngineVersion = int32(0)
+	// TODO: scalar index version 3 is still in development, so we use 2 as the current version.
+	// Do not use version 3 until this TODO is resolved.
 	CurrentScalarIndexEngineVersion = int32(2)
 )
 


### PR DESCRIPTION
This PR added support for scalar index format V3, packing each scalar index into a single file, reducing the amount of metadata in ETCD, and number of files in S3.

~All C++ UTs are updated to run with V3 format. Production code will still run on V2.~

issue: https://github.com/milvus-io/milvus/issues/47417
design doc: https://github.com/milvus-io/milvus-design-docs/blob/main/design_docs/20260209-scalar-index-unified-format.md
