### PR TITLE
enhance: move text index loading into C++ LoadDiff pipeline

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -1945,12 +1945,10 @@ ChunkedSegmentSealedImpl::CreateTextIndex(FieldId field_id,
 
 void
 ChunkedSegmentSealedImpl::LoadTextIndex(
-    std::unique_ptr<milvus::proto::indexcgo::LoadTextIndexInfo> info_proto,
-    milvus::OpContext* op_ctx) {
+    milvus::OpContext* op_ctx,
+    std::shared_ptr<milvus::proto::indexcgo::LoadTextIndexInfo> info_proto) {
     // Check for cancellation before starting
     CheckCancellation(op_ctx, id_, "ChunkedSegmentSealedImpl::LoadTextIndex()");
-
-    std::unique_lock lck(mutex_);
 
     milvus::storage::FieldDataMeta field_data_meta{info_proto->collectionid(),
                                                    info_proto->partitionid(),
@@ -1961,6 +1959,7 @@ ChunkedSegmentSealedImpl::LoadTextIndex(
                                           info_proto->fieldid(),
                                           info_proto->buildid(),
                                           info_proto->version()};
+    auto field_meta = milvus::FieldMeta::ParseFrom(info_proto->schema());
     auto remote_chunk_manager =
         milvus::storage::RemoteChunkManagerSingleton::GetInstance()
             .GetRemoteChunkManager();
@@ -1983,7 +1982,7 @@ ChunkedSegmentSealedImpl::LoadTextIndex(
         field_data_meta, index_meta, remote_chunk_manager, fs);
 
     auto field_id = milvus::FieldId(info_proto->fieldid());
-    const auto& field_meta = schema_->operator[](field_id);
+    // const auto& field_meta = schema_->operator[](field_id);
     milvus::segcore::storagev1translator::TextMatchIndexLoadInfo load_info{
         info_proto->enable_mmap(),
         this->get_segment_id(),
@@ -2000,6 +1999,8 @@ ChunkedSegmentSealedImpl::LoadTextIndex(
     auto cache_slot =
         milvus::cachinglayer::Manager::GetInstance().CreateCacheSlot(
             std::move(translator), op_ctx);
+
+    std::unique_lock lck(mutex_);
     text_indexes_[field_id] = std::move(cache_slot);
 }
 
@@ -2946,6 +2947,11 @@ ChunkedSegmentSealedImpl::ApplyLoadDiff(SegmentLoadInfo& segment_load_info,
         }
     }
 
+    // load pre-built text indexes
+    if (!diff.text_indexes_to_load.empty()) {
+        LoadBatchTextIndexes(op_ctx, diff.text_indexes_to_load);
+    }
+
     // load field binlog
     if (!diff.binlogs_to_load.empty()) {
         LoadBatchFieldData(trace_ctx, diff.binlogs_to_load, op_ctx);
@@ -2954,6 +2960,14 @@ ChunkedSegmentSealedImpl::ApplyLoadDiff(SegmentLoadInfo& segment_load_info,
     // fill default values for fields without data sources (schema evolution)
     if (!diff.fields_to_fill_default.empty()) {
         FillDefaultValueFields(diff.fields_to_fill_default);
+    }
+
+    // create text indexes from raw data
+    if (!diff.text_indexes_to_create.empty()) {
+        for (const auto& field_id : diff.text_indexes_to_create) {
+            CreateTextIndex(field_id, op_ctx);
+            segment_load_info.SetTextIndexCreated(field_id);
+        }
     }
 
     // drop field
@@ -3295,6 +3309,26 @@ ChunkedSegmentSealedImpl::ReloadColumns(const std::vector<FieldId>& field_ids,
     }
 
     storage::WaitAllFutures(reload_futures);
+}
+
+void
+ChunkedSegmentSealedImpl::LoadBatchTextIndexes(
+    milvus::OpContext* op_ctx,
+    std::unordered_map<FieldId,
+                       std::shared_ptr<proto::indexcgo::LoadTextIndexInfo>>&
+        text_indexes_to_load) {
+    auto& pool = ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::MIDDLE);
+    std::vector<std::future<void>> load_index_futures;
+
+    load_index_futures.reserve(text_indexes_to_load.size());
+    for (auto& [field_id, load_text_index_info] : text_indexes_to_load) {
+        auto future = pool.Submit(
+            [this, op_ctx, info = std::move(load_text_index_info)]() mutable
+            -> void { LoadTextIndex(op_ctx, std::move(info)); });
+        load_index_futures.emplace_back(std::move(future));
+    }
+
+    storage::WaitAllFutures(load_index_futures);
 }
 
 void

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -171,9 +171,9 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                     milvus::OpContext* op_ctx = nullptr) override;
 
     void
-    LoadTextIndex(
-        std::unique_ptr<milvus::proto::indexcgo::LoadTextIndexInfo> info_proto,
-        milvus::OpContext* op_ctx = nullptr) override;
+    LoadTextIndex(milvus::OpContext* op_ctx,
+                  std::shared_ptr<milvus::proto::indexcgo::LoadTextIndexInfo>
+                      info_proto) override;
 
     void
     RemoveJsonStats(FieldId field_id) override {
@@ -1079,6 +1079,19 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     void
     ReloadColumns(const std::vector<FieldId>& field_ids_to_reload,
                   milvus::OpContext* op_ctx = nullptr);
+
+    /**
+     * @brief Load text indexes in batch
+     *
+     * @param op_ctx The operation context
+     * @param text_indices_to_load a map from field id to text indexes to load
+     */
+    void
+    LoadBatchTextIndexes(
+        milvus::OpContext* op_ctx,
+        std::unordered_map<FieldId,
+                           std::shared_ptr<proto::indexcgo::LoadTextIndexInfo>>&
+            text_indexes_to_load);
 
     /**
      * @brief Apply load differences to update segment load information

--- a/internal/core/src/segcore/SegmentSealed.h
+++ b/internal/core/src/segcore/SegmentSealed.h
@@ -57,9 +57,9 @@ class SegmentSealed : public SegmentInternalInterface {
                int64_t count) const = 0;
 
     virtual void
-    LoadTextIndex(
-        std::unique_ptr<milvus::proto::indexcgo::LoadTextIndexInfo> info_proto,
-        milvus::OpContext* op_ctx = nullptr) = 0;
+    LoadTextIndex(milvus::OpContext* op_ctx,
+                  std::shared_ptr<milvus::proto::indexcgo::LoadTextIndexInfo>
+                      info_proto) = 0;
 
     virtual InsertRecord<true>&
     get_insert_record() = 0;

--- a/internal/core/src/segcore/segment_c.cpp
+++ b/internal/core/src/segcore/segment_c.cpp
@@ -596,38 +596,6 @@ UpdateSealedSegmentIndex(CSegmentInterface c_segment,
 }
 
 CStatus
-LoadTextIndex(CSegmentInterface c_segment,
-              const uint8_t* serialized_load_text_index_info,
-              const uint64_t len,
-              CLoadCancellationSource source) {
-    SCOPE_CGO_CALL_METRIC();
-
-    try {
-        auto segment_interface =
-            reinterpret_cast<milvus::segcore::SegmentInterface*>(c_segment);
-        auto segment =
-            dynamic_cast<milvus::segcore::SegmentSealed*>(segment_interface);
-        AssertInfo(segment != nullptr, "segment conversion failed");
-
-        auto info_proto =
-            std::make_unique<milvus::proto::indexcgo::LoadTextIndexInfo>();
-        info_proto->ParseFromArray(serialized_load_text_index_info, len);
-
-        if (source) {
-            auto cancellation_source =
-                static_cast<folly::CancellationSource*>(source);
-            milvus::OpContext op_ctx(cancellation_source->getToken());
-            segment->LoadTextIndex(std::move(info_proto), &op_ctx);
-        } else {
-            segment->LoadTextIndex(std::move(info_proto), nullptr);
-        }
-        return milvus::SuccessCStatus();
-    } catch (std::exception& e) {
-        return milvus::FailureCStatus(&e);
-    }
-}
-
-CStatus
 LoadJsonKeyIndex(CTraceContext c_trace,
                  CSegmentInterface c_segment,
                  const uint8_t* serialized_load_json_key_index_info,
@@ -820,31 +788,6 @@ RemoveFieldFile(CSegmentInterface c_segment, int64_t field_id) {
 
     auto segment = reinterpret_cast<milvus::segcore::SegmentSealed*>(c_segment);
     segment->RemoveFieldFile(milvus::FieldId(field_id));
-}
-
-CStatus
-CreateTextIndex(CSegmentInterface c_segment,
-                int64_t field_id,
-                CLoadCancellationSource source) {
-    SCOPE_CGO_CALL_METRIC();
-
-    try {
-        auto segment_interface =
-            reinterpret_cast<milvus::segcore::SegmentInterface*>(c_segment);
-        if (source) {
-            auto cancellation_source =
-                static_cast<folly::CancellationSource*>(source);
-            milvus::OpContext op_ctx(cancellation_source->getToken());
-            segment_interface->CreateTextIndex(milvus::FieldId(field_id),
-                                               &op_ctx);
-        } else {
-            segment_interface->CreateTextIndex(milvus::FieldId(field_id),
-                                               nullptr);
-        }
-        return milvus::SuccessCStatus();
-    } catch (std::exception& e) {
-        return milvus::FailureCStatus(milvus::UnexpectedError, e.what());
-    }
 }
 
 CStatus

--- a/internal/core/src/segcore/segment_c.h
+++ b/internal/core/src/segcore/segment_c.h
@@ -209,12 +209,6 @@ UpdateSealedSegmentIndex(CSegmentInterface c_segment,
                          CLoadIndexInfo c_load_index_info);
 
 CStatus
-LoadTextIndex(CSegmentInterface c_segment,
-              const uint8_t* serialized_load_text_index_info,
-              const uint64_t len,
-              CLoadCancellationSource source);
-
-CStatus
 LoadJsonKeyIndex(CTraceContext c_trace,
                  CSegmentInterface c_segment,
                  const uint8_t* serialied_load_json_key_index_info,
@@ -260,11 +254,6 @@ Delete(CSegmentInterface c_segment,
 
 void
 RemoveFieldFile(CSegmentInterface c_segment, int64_t field_id);
-
-CStatus
-CreateTextIndex(CSegmentInterface c_segment,
-                int64_t field_id,
-                CLoadCancellationSource source);
 
 CStatus
 ExprResCacheEraseSegment(int64_t segment_id);

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -1156,55 +1156,6 @@ func (s *LocalSegment) innerLoadIndex(ctx context.Context,
 	return err
 }
 
-func (s *LocalSegment) LoadTextIndex(ctx context.Context, textLogs *datapb.TextIndexStats, schemaHelper *typeutil.SchemaHelper) error {
-	log.Ctx(ctx).Info("load text index", zap.Int64("field id", textLogs.GetFieldID()), zap.Any("text logs", textLogs))
-
-	if !s.ptrLock.PinIf(state.IsNotReleased) {
-		return merr.WrapErrSegmentNotLoaded(s.ID(), "segment released")
-	}
-	defer s.ptrLock.Unpin()
-
-	f, err := schemaHelper.GetFieldFromID(textLogs.GetFieldID())
-	if err != nil {
-		return err
-	}
-
-	// Text match index mmap config is based on the raw data mmap.
-	enableMmap := isDataMmapEnable(f)
-	// Text match index should based on scala field's warmup policy like mmap
-	warmupPolicy := getScalarDataWarmupPolicy(f)
-	cgoProto := &indexcgopb.LoadTextIndexInfo{
-		FieldID:                   textLogs.GetFieldID(),
-		Version:                   textLogs.GetVersion(),
-		BuildID:                   textLogs.GetBuildID(),
-		Files:                     textLogs.GetFiles(),
-		Schema:                    f,
-		CollectionID:              s.Collection(),
-		PartitionID:               s.Partition(),
-		LoadPriority:              s.LoadInfo().GetPriority(),
-		EnableMmap:                enableMmap,
-		IndexSize:                 textLogs.GetMemorySize(),
-		CurrentScalarIndexVersion: textLogs.GetCurrentScalarIndexVersion(),
-		WarmupPolicy:              warmupPolicy,
-	}
-
-	marshaled, err := proto.Marshal(cgoProto)
-	if err != nil {
-		return err
-	}
-
-	guard := segcore.NewCancellationGuard(ctx)
-	defer guard.Close()
-
-	var status C.CStatus
-	_, _ = GetLoadPool().Submit(func() (any, error) {
-		status = C.LoadTextIndex(s.ptr, (*C.uint8_t)(unsafe.Pointer(&marshaled[0])), (C.uint64_t)(len(marshaled)), (C.CLoadCancellationSource)(guard.Source()))
-		return nil, nil
-	}).Await()
-
-	return HandleCStatus(ctx, &status, "LoadTextIndex failed")
-}
-
 func (s *LocalSegment) LoadJSONKeyIndex(ctx context.Context, jsonKeyStats *datapb.JsonKeyStats, schemaHelper *typeutil.SchemaHelper) error {
 	if !s.ptrLock.PinIf(state.IsNotReleased) {
 		return merr.WrapErrSegmentNotLoaded(s.ID(), "segment released")
@@ -1330,27 +1281,6 @@ func (s *LocalSegment) UpdateFieldRawDataSize(ctx context.Context, numRows int64
 	}
 
 	log.Ctx(ctx).Info("updateFieldRawDataSize done", zap.Int64("segmentID", s.ID()))
-
-	return nil
-}
-
-func (s *LocalSegment) CreateTextIndex(ctx context.Context, fieldID int64) error {
-	var status C.CStatus
-	log.Ctx(ctx).Info("create text index for segment", zap.Int64("segmentID", s.ID()), zap.Int64("fieldID", fieldID))
-
-	guard := segcore.NewCancellationGuard(ctx)
-	defer guard.Close()
-
-	GetLoadPool().Submit(func() (any, error) {
-		status = C.CreateTextIndex(s.ptr, C.int64_t(fieldID), (C.CLoadCancellationSource)(guard.Source()))
-		return nil, nil
-	}).Await()
-
-	if err := HandleCStatus(ctx, &status, "CreateTextIndex failed"); err != nil {
-		return err
-	}
-
-	log.Ctx(ctx).Info("create text index for segment done", zap.Int64("segmentID", s.ID()), zap.Int64("fieldID", fieldID))
 
 	return nil
 }

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -977,21 +977,6 @@ func (loader *segmentLoader) loadSealedSegment(ctx context.Context, loadInfo *qu
 		})
 	}
 
-	// load text indexes.
-	for _, info := range textIndexes {
-		if err := segment.LoadTextIndex(ctx, info, schemaHelper); err != nil {
-			return err
-		}
-	}
-	loadTextIndexesSpan := tr.RecordSpan()
-
-	// create index for unindexed text fields.
-	for fieldID := range unindexedTextFields {
-		if err := segment.CreateTextIndex(ctx, fieldID); err != nil {
-			return err
-		}
-	}
-
 	for _, info := range jsonKeyStats {
 		if err := segment.LoadJSONKeyIndex(ctx, info, schemaHelper); err != nil {
 			return err
@@ -1007,11 +992,7 @@ func (loader *segmentLoader) loadSealedSegment(ctx context.Context, loadInfo *qu
 	}
 	patchEntryNumberSpan := tr.RecordSpan()
 	log.Info("Finish loading segment",
-		// zap.Duration("loadFieldsIndexSpan", loadFieldsIndexSpan),
-		// zap.Duration("complementScalarDataSpan", complementScalarDataSpan),
-		// zap.Duration("loadRawDataSpan", loadRawDataSpan),
 		zap.Duration("patchEntryNumberSpan", patchEntryNumberSpan),
-		zap.Duration("loadTextIndexesSpan", loadTextIndexesSpan),
 		zap.Duration("loadJsonKeyIndexSpan", loadJSONKeyIndexesSpan),
 	)
 	return nil


### PR DESCRIPTION
Related to #46358

Move text index loading/creation from Go CGO calls into the C++ SegmentLoadInfo diff computation and ApplyLoadDiff pipeline. This removes the LoadTextIndex and CreateTextIndex C API functions and their Go callers, replacing them with ComputeDiffTextIndexes() which handles both pre-built text index loading and raw-data text index creation as part of the unified segment load diff mechanism.