### PR TITLE
fix: use correct global offset for null_offset_ in BuildIndexFromFieldData

### DIFF
--- a/internal/core/src/index/InvertedIndexTantivy.cpp
+++ b/internal/core/src/index/InvertedIndexTantivy.cpp
@@ -660,17 +660,19 @@ InvertedIndexTantivy<T>::BuildWithFieldData(
                     }
                 }
             } else {
+                int64_t offset = 0;
                 for (const auto& data : field_datas) {
                     auto n = data->get_num_rows();
                     if (schema_.nullable()) {
                         for (int i = 0; i < n; i++) {
                             if (!data->is_valid(i)) {
-                                null_offset_.push_back(i);
+                                null_offset_.push_back(offset);
                             }
                             wrapper_
                                 ->add_array_data_by_single_segment_writer<T>(
                                     static_cast<const T*>(data->RawValue(i)),
                                     data->is_valid(i));
+                            offset++;
                         }
                         continue;
                     }

--- a/internal/core/src/index/TextMatchIndex.cpp
+++ b/internal/core/src/index/TextMatchIndex.cpp
@@ -245,11 +245,17 @@ TextMatchIndex::BuildIndexFromFieldData(
                 if (!data->is_valid(i)) {
                     std::unique_lock<folly::SharedMutex> lock(mutex_);
                     null_offset_.push_back(offset);
+                    // add empty array doc to register offset in tantivy,
+                    // same as AddNullSealed
+                    std::string empty = "";
+                    wrapper_->add_array_data(&empty, 0, offset);
+                } else {
+                    wrapper_->add_data(
+                        static_cast<const std::string*>(data->RawValue(i)),
+                        1,
+                        offset);
                 }
-                wrapper_->add_data(
-                    static_cast<const std::string*>(data->RawValue(i)),
-                    data->is_valid(i) ? 1 : 0,
-                    offset++);
+                offset++;
             }
         }
     } else {

--- a/internal/core/src/index/TextMatchIndex.cpp
+++ b/internal/core/src/index/TextMatchIndex.cpp
@@ -244,7 +244,7 @@ TextMatchIndex::BuildIndexFromFieldData(
             for (int i = 0; i < n; i++) {
                 if (!data->is_valid(i)) {
                     std::unique_lock<folly::SharedMutex> lock(mutex_);
-                    null_offset_.push_back(i);
+                    null_offset_.push_back(offset);
                 }
                 wrapper_->add_data(
                     static_cast<const std::string*>(data->RawValue(i)),

--- a/internal/core/src/index/TextMatchIndexTest.cpp
+++ b/internal/core/src/index/TextMatchIndexTest.cpp
@@ -267,9 +267,9 @@ TEST(TextMatch, BuildIndexFromFieldDataMultiBatchNullable) {
     using Index = index::TextMatchIndex;
 
     // Helper to create a nullable FieldData<std::string> batch.
-    auto make_batch = [](const std::vector<std::string>& texts,
-                         const std::vector<bool>& valids)
-        -> milvus::FieldDataPtr {
+    auto make_batch =
+        [](const std::vector<std::string>& texts,
+           const std::vector<bool>& valids) -> milvus::FieldDataPtr {
         auto fd = storage::CreateFieldData(
             DataType::VARCHAR, DataType::NONE, true, 1, texts.size());
         // Pack valid bits into uint8_t array (LSB first).
@@ -280,8 +280,7 @@ TEST(TextMatch, BuildIndexFromFieldDataMultiBatchNullable) {
                 valid_bytes[i >> 3] |= (1u << (i & 7));
             }
         }
-        fd->FillFieldData(
-            texts.data(), valid_bytes.data(), texts.size(), 0);
+        fd->FillFieldData(texts.data(), valid_bytes.data(), texts.size(), 0);
         return fd;
     };
 
@@ -378,8 +377,8 @@ TEST(TextMatch, BuildIndexFromFieldDataMultiBatchNullable) {
 TEST(TextMatch, BuildIndexFromFieldDataSingleBatchNullable) {
     using Index = index::TextMatchIndex;
 
-    auto fd = storage::CreateFieldData(
-        DataType::VARCHAR, DataType::NONE, true, 1, 4);
+    auto fd =
+        storage::CreateFieldData(DataType::VARCHAR, DataType::NONE, true, 1, 4);
     std::vector<std::string> texts = {"alpha", "", "beta", ""};
     std::vector<bool> valids = {true, false, true, false};
     size_t byte_count = (texts.size() + 7) / 8;


### PR DESCRIPTION
Related to #47695

When loading multi-batch nullable fields through LoadFieldData path, null_offset_ incorrectly recorded the batch-local index `i` instead of the global accumulated `offset`, causing wrong null tracking for all batches after the first. This affected IsNull()/IsNotNull() results and text_match queries with null filtering on GrowingSegments loaded via recovery/streaming replay.

Also fix the same bug in InvertedIndexTantivy::BuildWithFieldData for the single-segment path.