### PR TITLE
fix: [2.5] Endless L0 compaction tasks on empty partition. (#46435)

### DIFF
--- a/internal/datacoord/compaction_task_l0_test.go
+++ b/internal/datacoord/compaction_task_l0_test.go
@@ -159,8 +159,10 @@ func (s *L0CompactionTaskSuite) TestProcessRefreshPlan_SelectZeroSegmentsL0() {
 		State:         datapb.CompactionTaskState_executing,
 		InputSegments: []int64{100, 101},
 	}, nil, s.mockMeta, nil)
-	_, err := task.BuildCompactionRequest()
-	s.Error(err)
+	plan, err := task.BuildCompactionRequest()
+	// Fast finish: should return an error indicating fast finish
+	s.ErrorIs(err, errFastFinishL0)
+	s.Nil(plan)
 }
 
 func (s *L0CompactionTaskSuite) TestBuildCompactionRequestFailed_AllocFailed() {


### PR DESCRIPTION
Previously, L0 compaction tasks would fail to build a compaction plan and retry indefinitely if no L1/L2 segments were available to merge with (e.g., after deleting data from an empty table or a new partition). This caused excessive etcd writes and continuous log spamming as the trigger would repeatedly pick up the same L0 segments.

See also: https://github.com/milvus-io/milvus/issues/46435