### PR TITLE
enhance: don't explicitly rebuild cache

### DIFF
--- a/scripts/core_build.sh
+++ b/scripts/core_build.sh
@@ -217,10 +217,6 @@ fi
 
 pushd ${BUILD_OUTPUT_DIR}
 
-# Remove make cache since build.sh -l use default variables
-# Force update the variables each time
-make rebuild_cache >/dev/null 2>&1
-
 CPU_ARCH=$(get_cpu_arch $CPU_TARGET)
 
 # In case any 3rdparty (e.g. libavrocpp) requires a minimum version of CMake lower than 3.5


### PR DESCRIPTION
```
$ ninja rebuild_cache -n -v
[0/2] /usr/bin/cmake -P /home/fanta/source/milvus/cmake_build/CMakeFiles/VerifyGlobs.cmake
[1/2] /usr/bin/cmake --regenerate-during-build -S/home/fanta/source/milvus/internal/core -B/home/fanta/source/milvus/cmake_build
```

This `rebuild_cache` target only regenerates cmake configuration files. However, in core_build.sh, it will immediately invoke cmake to generate configuration files. So, this target is completely useless.