### PR TITLE
fix: fix nil pointer dereference in removeReplicas

### DIFF
--- a/internal/querycoordv2/meta/replica_manager.go
+++ b/internal/querycoordv2/meta/replica_manager.go
@@ -436,8 +436,10 @@ func (m *ReplicaManager) removeReplicas(ctx context.Context, collectionID typeut
 		}
 	}
 
-	if m.coll2Replicas[collectionID].removeReplicas(replicas...) {
-		delete(m.coll2Replicas, collectionID)
+	if collReplicas, ok := m.coll2Replicas[collectionID]; ok {
+		if collReplicas.removeReplicas(replicas...) {
+			delete(m.coll2Replicas, collectionID)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
*Vulnerability identified and fix provided by [Kolega.dev](https://kolega.dev/)*

## Nil Pointer Dereference in Replica Manager - Direct Map Access

issue: #47735

## Location
`internal/querycoordv2/meta/replica_manager.go:439`

## Description
The `removeReplicas` function directly dereferences `m.coll2Replicas[collectionID]` without checking if the key exists in the map. If `collectionID` is not present in the map, the lookup returns `nil`, and calling `removeReplicas()` on a nil pointer causes a panic, leading to denial of service.

The `removeReplicas` function is called from `RemoveReplicas` (a public interface method), which is invoked during rollback operations (`job_update.go:116`) and normal replica removal (`job_update.go:155`). While callers typically ensure the collection exists, the function itself should be defensive against invalid `collectionID` values.

## Analysis Notes
This is a genuine nil pointer dereference vulnerability. At line 439, the code calls `m.coll2Replicas[collectionID].removeReplicas(replicas...)` without first checking if the key exists in the map. If `collectionID` is not present in `coll2Replicas`, the map access returns `nil`, and calling `removeReplicas()` on nil will panic. Unlike a `delete` on a nil map (which is safe in Go), this is a method call on a nil pointer which will crash.

## Fix Applied
Added a map existence check (`if collReplicas, ok := m.coll2Replicas[collectionID]; ok`) before calling `removeReplicas()` on the value. This follows the exact same defensive pattern already used in `RemoveCollection` (line 404) and `removeRedundantReplicas` (line 216) within the same file, ensuring consistency with existing codebase conventions.

## Tests/Linters Ran
- `gofmt -e` — passed, no formatting issues
- `gofmt -w` — applied (no changes needed, code was already formatted)
- `go vet` / `go build` — could not fully run due to missing native C dependencies (`rocksdb`, `milvus_core`) in this environment; these are build-environment limitations, not code issues
- Existing tests in `replica_manager_test.go` cover `RemoveCollection` and `RemoveReplicas` paths; the fix is a safe guard that does not alter existing behavior when `collectionID` exists in the map

## Contribution Notes
- Commit includes DCO sign-off as required by CONTRIBUTING.md
- Code style follows the existing Go patterns in the file (checked with `gofmt`)
- Fix is minimal and follows the exact same defensive map-access pattern used elsewhere in the same file