### PR TITLE
fix: add compaction ID validation in GetCompactionState and GetCompactionStateWithPlans

### DIFF
--- a/internal/datacoord/server_test.go
+++ b/internal/datacoord/server_test.go
@@ -1615,10 +1615,11 @@ func TestGetCompactionState(t *testing.T) {
 
 		mockHandler := NewMockCompactionInspector(t)
 		mockHandler.EXPECT().getCompactionInfo(mock.Anything, mock.Anything).Return(&compactionInfo{
-			state: commonpb.CompactionState_Completed,
+			state:        commonpb.CompactionState_Completed,
+			completedCnt: 1,
 		})
 		svr.compactionInspector = mockHandler
-		resp, err := svr.GetCompactionState(context.Background(), &milvuspb.GetCompactionStateRequest{})
+		resp, err := svr.GetCompactionState(context.Background(), &milvuspb.GetCompactionStateRequest{CompactionID: 1})
 		assert.NoError(t, err)
 		assert.Equal(t, commonpb.ErrorCode_Success, resp.GetStatus().GetErrorCode())
 		assert.Equal(t, commonpb.CompactionState_Completed, resp.GetState())
@@ -1659,6 +1660,47 @@ func TestGetCompactionState(t *testing.T) {
 		resp, err := svr.GetCompactionState(context.Background(), &milvuspb.GetCompactionStateRequest{})
 		assert.NoError(t, err)
 		assert.ErrorIs(t, merr.Error(resp.GetStatus()), merr.ErrServiceNotReady)
+	})
+
+	t.Run("test get compaction state with invalid compactionID", func(t *testing.T) {
+		svr := &Server{}
+		svr.stateCode.Store(commonpb.StateCode_Healthy)
+
+		// Test with compactionID = -1
+		resp, err := svr.GetCompactionState(context.Background(), &milvuspb.GetCompactionStateRequest{
+			CompactionID: -1,
+		})
+		assert.NoError(t, err)
+		assert.ErrorIs(t, merr.Error(resp.GetStatus()), merr.ErrParameterInvalid)
+
+		// Test with compactionID = 0
+		resp, err = svr.GetCompactionState(context.Background(), &milvuspb.GetCompactionStateRequest{
+			CompactionID: 0,
+		})
+		assert.NoError(t, err)
+		assert.ErrorIs(t, merr.Error(resp.GetStatus()), merr.ErrParameterInvalid)
+	})
+
+	t.Run("test get compaction state with non-existent compactionID", func(t *testing.T) {
+		svr := &Server{}
+		svr.stateCode.Store(commonpb.StateCode_Healthy)
+
+		mockHandler := NewMockCompactionInspector(t)
+		mockHandler.EXPECT().getCompactionInfo(mock.Anything, mock.Anything).Return(&compactionInfo{
+			state:        commonpb.CompactionState_Completed,
+			executingCnt: 0,
+			completedCnt: 0,
+			failedCnt:    0,
+			timeoutCnt:   0,
+			mergeInfos:   nil,
+		})
+		svr.compactionInspector = mockHandler
+
+		resp, err := svr.GetCompactionState(context.Background(), &milvuspb.GetCompactionStateRequest{
+			CompactionID: 999999,
+		})
+		assert.NoError(t, err)
+		assert.ErrorIs(t, merr.Error(resp.GetStatus()), merr.ErrParameterInvalid)
 	})
 }
 
@@ -1776,6 +1818,47 @@ func TestGetCompactionStateWithPlans(t *testing.T) {
 		})
 		assert.NoError(t, err)
 		assert.ErrorIs(t, merr.Error(resp.GetStatus()), merr.ErrServiceNotReady)
+	})
+
+	t.Run("test get compaction state with plans with invalid compactionID", func(t *testing.T) {
+		svr := &Server{}
+		svr.stateCode.Store(commonpb.StateCode_Healthy)
+
+		// Test with compactionID = -1
+		resp, err := svr.GetCompactionStateWithPlans(context.TODO(), &milvuspb.GetCompactionPlansRequest{
+			CompactionID: -1,
+		})
+		assert.NoError(t, err)
+		assert.ErrorIs(t, merr.Error(resp.GetStatus()), merr.ErrParameterInvalid)
+
+		// Test with compactionID = 0
+		resp, err = svr.GetCompactionStateWithPlans(context.TODO(), &milvuspb.GetCompactionPlansRequest{
+			CompactionID: 0,
+		})
+		assert.NoError(t, err)
+		assert.ErrorIs(t, merr.Error(resp.GetStatus()), merr.ErrParameterInvalid)
+	})
+
+	t.Run("test get compaction state with plans with non-existent compactionID", func(t *testing.T) {
+		svr := &Server{}
+		svr.stateCode.Store(commonpb.StateCode_Healthy)
+
+		mockHandler := NewMockCompactionInspector(t)
+		mockHandler.EXPECT().getCompactionInfo(mock.Anything, mock.Anything).Return(&compactionInfo{
+			state:        commonpb.CompactionState_Completed,
+			executingCnt: 0,
+			completedCnt: 0,
+			failedCnt:    0,
+			timeoutCnt:   0,
+			mergeInfos:   nil,
+		})
+		svr.compactionInspector = mockHandler
+
+		resp, err := svr.GetCompactionStateWithPlans(context.TODO(), &milvuspb.GetCompactionPlansRequest{
+			CompactionID: 999999,
+		})
+		assert.NoError(t, err)
+		assert.ErrorIs(t, merr.Error(resp.GetStatus()), merr.ErrParameterInvalid)
 	})
 }
 

--- a/internal/datacoord/server_test.go
+++ b/internal/datacoord/server_test.go
@@ -1666,19 +1666,23 @@ func TestGetCompactionState(t *testing.T) {
 		svr := &Server{}
 		svr.stateCode.Store(commonpb.StateCode_Healthy)
 
+		mockHandler := NewMockCompactionInspector(t)
+		mockHandler.EXPECT().getCompactionInfo(mock.Anything, mock.Anything).Return(&compactionInfo{})
+		svr.compactionInspector = mockHandler
+
 		// Test with compactionID = -1
 		resp, err := svr.GetCompactionState(context.Background(), &milvuspb.GetCompactionStateRequest{
 			CompactionID: -1,
 		})
 		assert.NoError(t, err)
-		assert.ErrorIs(t, merr.Error(resp.GetStatus()), merr.ErrParameterInvalid)
+		assert.ErrorIs(t, merr.Error(resp.GetStatus()), merr.ErrCompactionResultNotFound)
 
 		// Test with compactionID = 0
 		resp, err = svr.GetCompactionState(context.Background(), &milvuspb.GetCompactionStateRequest{
 			CompactionID: 0,
 		})
 		assert.NoError(t, err)
-		assert.ErrorIs(t, merr.Error(resp.GetStatus()), merr.ErrParameterInvalid)
+		assert.ErrorIs(t, merr.Error(resp.GetStatus()), merr.ErrCompactionResultNotFound)
 	})
 
 	t.Run("test get compaction state with non-existent compactionID", func(t *testing.T) {
@@ -1686,21 +1690,14 @@ func TestGetCompactionState(t *testing.T) {
 		svr.stateCode.Store(commonpb.StateCode_Healthy)
 
 		mockHandler := NewMockCompactionInspector(t)
-		mockHandler.EXPECT().getCompactionInfo(mock.Anything, mock.Anything).Return(&compactionInfo{
-			state:        commonpb.CompactionState_Completed,
-			executingCnt: 0,
-			completedCnt: 0,
-			failedCnt:    0,
-			timeoutCnt:   0,
-			mergeInfos:   nil,
-		})
+		mockHandler.EXPECT().getCompactionInfo(mock.Anything, mock.Anything).Return(&compactionInfo{})
 		svr.compactionInspector = mockHandler
 
 		resp, err := svr.GetCompactionState(context.Background(), &milvuspb.GetCompactionStateRequest{
 			CompactionID: 999999,
 		})
 		assert.NoError(t, err)
-		assert.ErrorIs(t, merr.Error(resp.GetStatus()), merr.ErrParameterInvalid)
+		assert.ErrorIs(t, merr.Error(resp.GetStatus()), merr.ErrCompactionResultNotFound)
 	})
 }
 
@@ -1824,19 +1821,23 @@ func TestGetCompactionStateWithPlans(t *testing.T) {
 		svr := &Server{}
 		svr.stateCode.Store(commonpb.StateCode_Healthy)
 
+		mockHandler := NewMockCompactionInspector(t)
+		mockHandler.EXPECT().getCompactionInfo(mock.Anything, mock.Anything).Return(&compactionInfo{})
+		svr.compactionInspector = mockHandler
+
 		// Test with compactionID = -1
 		resp, err := svr.GetCompactionStateWithPlans(context.TODO(), &milvuspb.GetCompactionPlansRequest{
 			CompactionID: -1,
 		})
 		assert.NoError(t, err)
-		assert.ErrorIs(t, merr.Error(resp.GetStatus()), merr.ErrParameterInvalid)
+		assert.ErrorIs(t, merr.Error(resp.GetStatus()), merr.ErrCompactionResultNotFound)
 
 		// Test with compactionID = 0
 		resp, err = svr.GetCompactionStateWithPlans(context.TODO(), &milvuspb.GetCompactionPlansRequest{
 			CompactionID: 0,
 		})
 		assert.NoError(t, err)
-		assert.ErrorIs(t, merr.Error(resp.GetStatus()), merr.ErrParameterInvalid)
+		assert.ErrorIs(t, merr.Error(resp.GetStatus()), merr.ErrCompactionResultNotFound)
 	})
 
 	t.Run("test get compaction state with plans with non-existent compactionID", func(t *testing.T) {
@@ -1844,21 +1845,14 @@ func TestGetCompactionStateWithPlans(t *testing.T) {
 		svr.stateCode.Store(commonpb.StateCode_Healthy)
 
 		mockHandler := NewMockCompactionInspector(t)
-		mockHandler.EXPECT().getCompactionInfo(mock.Anything, mock.Anything).Return(&compactionInfo{
-			state:        commonpb.CompactionState_Completed,
-			executingCnt: 0,
-			completedCnt: 0,
-			failedCnt:    0,
-			timeoutCnt:   0,
-			mergeInfos:   nil,
-		})
+		mockHandler.EXPECT().getCompactionInfo(mock.Anything, mock.Anything).Return(&compactionInfo{})
 		svr.compactionInspector = mockHandler
 
 		resp, err := svr.GetCompactionStateWithPlans(context.TODO(), &milvuspb.GetCompactionPlansRequest{
 			CompactionID: 999999,
 		})
 		assert.NoError(t, err)
-		assert.ErrorIs(t, merr.Error(resp.GetStatus()), merr.ErrParameterInvalid)
+		assert.ErrorIs(t, merr.Error(resp.GetStatus()), merr.ErrCompactionResultNotFound)
 	})
 }
 

--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -1269,6 +1269,21 @@ func (s *Server) ManualCompaction(ctx context.Context, req *milvuspb.ManualCompa
 	return resp, nil
 }
 
+// getValidatedCompactionInfo retrieves compaction info and validates that the compaction job exists.
+// Returns the compaction info or an error if the job is not found.
+func (s *Server) getValidatedCompactionInfo(ctx context.Context, compactionID int64) (*compactionInfo, error) {
+	info := s.compactionInspector.getCompactionInfo(ctx, compactionID)
+
+	// No tasks means it was never created or already cleaned up
+	if len(info.mergeInfos) == 0 && info.executingCnt == 0 && info.completedCnt == 0 &&
+		info.failedCnt == 0 && info.timeoutCnt == 0 {
+		log.Ctx(ctx).Warn("compaction task not found", zap.Int64("compactionID", compactionID))
+		return nil, merr.WrapErrCompactionResultNotFound(fmt.Sprintf("compaction job not found: %d", compactionID))
+	}
+
+	return info, nil
+}
+
 // GetCompactionState gets the state of a compaction
 func (s *Server) GetCompactionState(ctx context.Context, req *milvuspb.GetCompactionStateRequest) (*milvuspb.GetCompactionStateResponse, error) {
 	log := log.Ctx(ctx).With(zap.Int64("compactionID", req.GetCompactionID()))
@@ -1286,22 +1301,10 @@ func (s *Server) GetCompactionState(ctx context.Context, req *milvuspb.GetCompac
 		}, nil
 	}
 
-	compactionID := req.GetCompactionID()
-	if compactionID <= 0 {
-		log.Warn("invalid compaction ID in request")
+	info, err := s.getValidatedCompactionInfo(ctx, req.GetCompactionID())
+	if err != nil {
 		return &milvuspb.GetCompactionStateResponse{
-			Status: merr.Status(merr.WrapErrParameterInvalidMsg("compaction job not found: %d", compactionID)),
-		}, nil
-	}
-
-	info := s.compactionInspector.getCompactionInfo(ctx, compactionID)
-
-	// Check if compaction exists (no tasks means it was never created or already cleaned up)
-	if len(info.mergeInfos) == 0 && info.executingCnt == 0 && info.completedCnt == 0 &&
-		info.failedCnt == 0 && info.timeoutCnt == 0 {
-		log.Warn("compaction task not found", zap.Int64("compactionID", compactionID))
-		return &milvuspb.GetCompactionStateResponse{
-			Status: merr.Status(merr.WrapErrParameterInvalidMsg("compaction job not found: %d", compactionID)),
+			Status: merr.Status(err),
 		}, nil
 	}
 
@@ -1337,34 +1340,23 @@ func (s *Server) GetCompactionStateWithPlans(ctx context.Context, req *milvuspb.
 		}, nil
 	}
 
+	if !Params.DataCoordCfg.EnableCompaction.GetAsBool() {
+		return &milvuspb.GetCompactionPlansResponse{
+			Status: merr.Status(merr.WrapErrServiceUnavailable("compaction disabled")),
+		}, nil
+	}
+
+	info, err := s.getValidatedCompactionInfo(ctx, req.GetCompactionID())
+	if err != nil {
+		return &milvuspb.GetCompactionPlansResponse{
+			Status: merr.Status(err),
+		}, nil
+	}
+
 	resp := &milvuspb.GetCompactionPlansResponse{
 		Status: merr.Success(),
+		State:  info.state,
 	}
-	if !Params.DataCoordCfg.EnableCompaction.GetAsBool() {
-		resp.Status = merr.Status(merr.WrapErrServiceUnavailable("compaction disabled"))
-		return resp, nil
-	}
-
-	compactionID := req.GetCompactionID()
-	if compactionID <= 0 {
-		log.Warn("invalid compaction ID in request", zap.Int64("compactionID", compactionID))
-		return &milvuspb.GetCompactionPlansResponse{
-			Status: merr.Status(merr.WrapErrParameterInvalidMsg("compaction job not found: %d", compactionID)),
-		}, nil
-	}
-
-	info := s.compactionInspector.getCompactionInfo(ctx, compactionID)
-
-	// Check if compaction exists (no tasks means it was never created or already cleaned up)
-	if len(info.mergeInfos) == 0 && info.executingCnt == 0 && info.completedCnt == 0 &&
-		info.failedCnt == 0 && info.timeoutCnt == 0 {
-		log.Warn("compaction task not found", zap.Int64("compactionID", compactionID))
-		return &milvuspb.GetCompactionPlansResponse{
-			Status: merr.Status(merr.WrapErrParameterInvalidMsg("compaction job not found: %d", compactionID)),
-		}, nil
-	}
-
-	resp.State = info.state
 	resp.MergeInfos = lo.MapToSlice[int64, *milvuspb.CompactionMergeInfo](info.mergeInfos, func(_ int64, merge *milvuspb.CompactionMergeInfo) *milvuspb.CompactionMergeInfo {
 		return merge
 	})

--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -1271,13 +1271,8 @@ func (s *Server) ManualCompaction(ctx context.Context, req *milvuspb.ManualCompa
 
 // GetCompactionState gets the state of a compaction
 func (s *Server) GetCompactionState(ctx context.Context, req *milvuspb.GetCompactionStateRequest) (*milvuspb.GetCompactionStateResponse, error) {
-	log := log.Ctx(ctx).With(
-		zap.Int64("compactionID", req.GetCompactionID()),
-	)
+	log := log.Ctx(ctx).With(zap.Int64("compactionID", req.GetCompactionID()))
 	log.Info("received get compaction state request")
-	resp := &milvuspb.GetCompactionStateResponse{
-		Status: merr.Success(),
-	}
 
 	if err := merr.CheckHealthy(s.GetStateCode()); err != nil {
 		return &milvuspb.GetCompactionStateResponse{
@@ -1286,19 +1281,45 @@ func (s *Server) GetCompactionState(ctx context.Context, req *milvuspb.GetCompac
 	}
 
 	if !Params.DataCoordCfg.EnableCompaction.GetAsBool() {
-		resp.Status = merr.Status(merr.WrapErrServiceUnavailable("compaction disabled"))
-		return resp, nil
+		return &milvuspb.GetCompactionStateResponse{
+			Status: merr.Status(merr.WrapErrServiceUnavailable("compaction disabled")),
+		}, nil
 	}
 
-	info := s.compactionInspector.getCompactionInfo(ctx, req.GetCompactionID())
+	compactionID := req.GetCompactionID()
+	if compactionID <= 0 {
+		log.Warn("invalid compaction ID in request")
+		return &milvuspb.GetCompactionStateResponse{
+			Status: merr.Status(merr.WrapErrParameterInvalidMsg("compaction job not found: %d", compactionID)),
+		}, nil
+	}
 
-	resp.State = info.state
-	resp.ExecutingPlanNo = int64(info.executingCnt)
-	resp.CompletedPlanNo = int64(info.completedCnt)
-	resp.TimeoutPlanNo = int64(info.timeoutCnt)
-	resp.FailedPlanNo = int64(info.failedCnt)
-	log.Info("success to get compaction state", zap.Any("state", info.state), zap.Int("executing", info.executingCnt),
-		zap.Int("completed", info.completedCnt), zap.Int("failed", info.failedCnt), zap.Int("timeout", info.timeoutCnt))
+	info := s.compactionInspector.getCompactionInfo(ctx, compactionID)
+
+	// Check if compaction exists (no tasks means it was never created or already cleaned up)
+	if len(info.mergeInfos) == 0 && info.executingCnt == 0 && info.completedCnt == 0 &&
+		info.failedCnt == 0 && info.timeoutCnt == 0 {
+		log.Warn("compaction task not found", zap.Int64("compactionID", compactionID))
+		return &milvuspb.GetCompactionStateResponse{
+			Status: merr.Status(merr.WrapErrParameterInvalidMsg("compaction job not found: %d", compactionID)),
+		}, nil
+	}
+
+	resp := &milvuspb.GetCompactionStateResponse{
+		Status:          merr.Success(),
+		State:           info.state,
+		ExecutingPlanNo: int64(info.executingCnt),
+		CompletedPlanNo: int64(info.completedCnt),
+		TimeoutPlanNo:   int64(info.timeoutCnt),
+		FailedPlanNo:    int64(info.failedCnt),
+	}
+
+	log.Info("success to get compaction state",
+		zap.Any("state", info.state),
+		zap.Int("executing", info.executingCnt),
+		zap.Int("completed", info.completedCnt),
+		zap.Int("failed", info.failedCnt),
+		zap.Int("timeout", info.timeoutCnt))
 
 	return resp, nil
 }
@@ -1324,7 +1345,25 @@ func (s *Server) GetCompactionStateWithPlans(ctx context.Context, req *milvuspb.
 		return resp, nil
 	}
 
-	info := s.compactionInspector.getCompactionInfo(ctx, req.GetCompactionID())
+	compactionID := req.GetCompactionID()
+	if compactionID <= 0 {
+		log.Warn("invalid compaction ID in request", zap.Int64("compactionID", compactionID))
+		return &milvuspb.GetCompactionPlansResponse{
+			Status: merr.Status(merr.WrapErrParameterInvalidMsg("compaction job not found: %d", compactionID)),
+		}, nil
+	}
+
+	info := s.compactionInspector.getCompactionInfo(ctx, compactionID)
+
+	// Check if compaction exists (no tasks means it was never created or already cleaned up)
+	if len(info.mergeInfos) == 0 && info.executingCnt == 0 && info.completedCnt == 0 &&
+		info.failedCnt == 0 && info.timeoutCnt == 0 {
+		log.Warn("compaction task not found", zap.Int64("compactionID", compactionID))
+		return &milvuspb.GetCompactionPlansResponse{
+			Status: merr.Status(merr.WrapErrParameterInvalidMsg("compaction job not found: %d", compactionID)),
+		}, nil
+	}
+
 	resp.State = info.state
 	resp.MergeInfos = lo.MapToSlice[int64, *milvuspb.CompactionMergeInfo](info.mergeInfos, func(_ int64, merge *milvuspb.CompactionMergeInfo) *milvuspb.CompactionMergeInfo {
 		return merge

--- a/tests/python_client/base/client_v2_base.py
+++ b/tests/python_client/base/client_v2_base.py
@@ -603,6 +603,8 @@ class TestMilvusClientV2Base(Base):
         return False
 
     def wait_for_compaction_ready(self, client, compact_id, timeout=None, **kwargs):
+        if compact_id is not None and compact_id <= 0:
+            return True
         timeout = TIMEOUT if timeout is None else timeout
         start_time = time.time()
         while start_time + timeout > time.time():

--- a/tests/python_client/base/collection_wrapper.py
+++ b/tests/python_client/base/collection_wrapper.py
@@ -336,6 +336,14 @@ class ApiCollectionWrapper:
     def get_compaction_state(self, timeout=None, check_task=None, check_items=None, **kwargs):
         timeout = TIMEOUT if timeout is None else timeout
         func_name = sys._getframe().f_code.co_name
+        # Skip if compaction was not triggered (compaction_id <= 0 means no compaction job)
+        compaction_id = getattr(self.collection, 'compaction_id', -1)
+        is_clustering = kwargs.get('is_clustering', False)
+        if is_clustering:
+            compaction_id = getattr(self.collection, 'clustering_compaction_id', -1)
+        if compaction_id is not None and compaction_id <= 0:
+            log.warning(f"get_compaction_state skipped: compaction_id={compaction_id} (<= 0, no compaction triggered)")
+            return None, True
         res, check = api_request([self.collection.get_compaction_state, timeout], **kwargs)
         check_result = ResponseChecker(res, func_name, check_task, check_items, check, **kwargs).run()
         return res, check_result
@@ -344,12 +352,25 @@ class ApiCollectionWrapper:
     def get_compaction_plans(self, timeout=None, check_task=None, check_items={}, **kwargs):
         timeout = TIMEOUT if timeout is None else timeout
         func_name = sys._getframe().f_code.co_name
+        # Skip if compaction was not triggered (compaction_id <= 0 means no compaction job)
+        compaction_id = getattr(self.collection, 'compaction_id', -1)
+        is_clustering = kwargs.get('is_clustering', False)
+        if is_clustering:
+            compaction_id = getattr(self.collection, 'clustering_compaction_id', -1)
+        if compaction_id is not None and compaction_id <= 0:
+            log.warning(f"get_compaction_plans skipped: compaction_id={compaction_id} (<= 0, no compaction triggered)")
+            return None, True
         res, check = api_request([self.collection.get_compaction_plans, timeout], **kwargs)
         check_result = ResponseChecker(res, func_name, check_task, check_items, check, **kwargs).run()
         return res, check_result
 
     def wait_for_compaction_completed(self, timeout=None, **kwargs):
         timeout = TIMEOUT * 3 if timeout is None else timeout
+        # Skip if compaction was not triggered (compaction_id <= 0 means no compaction job)
+        compaction_id = getattr(self.collection, 'compaction_id', -1)
+        if compaction_id is not None and compaction_id <= 0:
+            log.warning(f"wait_for_compaction_completed skipped: compaction_id={compaction_id} (<= 0, no compaction triggered)")
+            return True
         res = self.collection.wait_for_compaction_completed(timeout, **kwargs)
         # log.debug(res)
         return res

--- a/tests/python_client/milvus_client/test_milvus_client_collection.py
+++ b/tests/python_client/milvus_client/test_milvus_client_collection.py
@@ -1311,14 +1311,15 @@ class TestMilvusClientCollectionValid(TestMilvusClientV2Base):
 
         # trigger compaction
         compact_id = self.compact(client, collection_name, is_clustering=False)[0]
-        start = time.time()
-        while True:
-            time.sleep(1)
-            state = self.get_compaction_state(client, compact_id, is_clustering=False)[0]
-            if state == "Completed":
-                break
-            if time.time() - start > 180:
-                raise Exception("Compaction did not complete within 180s")
+        if compact_id > 0:
+            start = time.time()
+            while True:
+                time.sleep(1)
+                state = self.get_compaction_state(client, compact_id, is_clustering=False)[0]
+                if state == "Completed":
+                    break
+                if time.time() - start > 180:
+                    raise Exception("Compaction did not complete within 180s")
 
         # verify data integrity after compaction
         res = self.query(client, collection_name, filter="", output_fields=["count(*)"])[0]

--- a/tests/python_client/milvus_client/test_milvus_client_compact.py
+++ b/tests/python_client/milvus_client/test_milvus_client_compact.py
@@ -175,15 +175,16 @@ class TestMilvusClientCompactValid(TestMilvusClientV2Base):
         self.flush(client, collection_name)
         # 3. compact
         compact_id = self.compact(client, collection_name, is_clustering=is_clustering)[0]
-        cost = 180
-        start = time.time()
-        while True:
-            time.sleep(1)
-            res = self.get_compaction_state(client, compact_id, is_clustering=is_clustering)[0]
-            if res == "Completed":
-                break
-            if time.time() - start > cost:
-                raise Exception(1, f"Compact after index cost more than {cost}s")
+        if compact_id > 0:
+            cost = 180
+            start = time.time()
+            while True:
+                time.sleep(1)
+                res = self.get_compaction_state(client, compact_id, is_clustering=is_clustering)[0]
+                if res == "Completed":
+                    break
+                if time.time() - start > cost:
+                    raise Exception(1, f"Compact after index cost more than {cost}s")
 
         self.drop_collection(client, collection_name)
 
@@ -264,14 +265,15 @@ class TestMilvusClientCompactValid(TestMilvusClientV2Base):
         self.flush(client, collection_name)
         # 3. compact
         compact_id = self.compact(client, collection_name, is_clustering=is_clustering)[0]
-        cost = 180
-        start = time.time()
-        while True:
-            time.sleep(1)
-            res = self.get_compaction_state(client, compact_id, is_clustering=is_clustering)[0]
-            if res == "Completed":
-                break
-            if time.time() - start > cost:
-                raise Exception(1, f"Compact after index cost more than {cost}s")
+        if compact_id > 0:
+            cost = 180
+            start = time.time()
+            while True:
+                time.sleep(1)
+                res = self.get_compaction_state(client, compact_id, is_clustering=is_clustering)[0]
+                if res == "Completed":
+                    break
+                if time.time() - start > cost:
+                    raise Exception(1, f"Compact after index cost more than {cost}s")
 
         self.drop_collection(client, collection_name)

--- a/tests/python_client/milvus_client/test_milvus_client_timestamptz.py
+++ b/tests/python_client/milvus_client/test_milvus_client_timestamptz.py
@@ -626,15 +626,16 @@ class TestMilvusClientTimestamptzValid(TestMilvusClientV2Base):
         
         # step 4: compact
         compact_id = self.compact(client, collection_name, is_clustering=False)[0]
-        cost = 180
-        start = time.time()
-        while True:
-            time.sleep(1)
-            res = self.get_compaction_state(client, compact_id, is_clustering=False)[0]
-            if res == "Completed":
-                break
-            if time.time() - start > cost:
-                raise Exception(1, f"Compact after index cost more than {cost}s")
+        if compact_id > 0:
+            cost = 180
+            start = time.time()
+            while True:
+                time.sleep(1)
+                res = self.get_compaction_state(client, compact_id, is_clustering=False)[0]
+                if res == "Completed":
+                    break
+                if time.time() - start > cost:
+                    raise Exception(1, f"Compact after index cost more than {cost}s")
         
         # step 5: query the rows
         # first release the collection

--- a/tests/restful_client_v2/api/milvus.py
+++ b/tests/restful_client_v2/api/milvus.py
@@ -586,11 +586,11 @@ class CollectionClient(Requests):
         response = self.post(url, headers=self.update_headers(), data=payload)
         return response.json()
 
-    def get_compaction_state(self, collection_name, db_name="default"):
+    def get_compaction_state(self, job_id, db_name="default"):
         """Get compaction state"""
         url = f"{self.endpoint}/v2/vectordb/collections/get_compaction_state"
         payload = {
-            "collectionName": collection_name
+            "jobID": job_id
         }
         if self.db_name is not None:
             payload["dbName"] = self.db_name

--- a/tests/restful_client_v2/testcases/test_collection_operations.py
+++ b/tests/restful_client_v2/testcases/test_collection_operations.py
@@ -2061,11 +2061,13 @@ class TestCollectionMaintenance(TestBase):
         # Compact collection
         response = client.compact(name)
         assert response["code"] == 0
+        compaction_id = response["data"]["compactionID"]
 
-        # Get compaction state
-        response = client.get_compaction_state(name)
-        assert response["code"] == 0
-        assert "state" in response["data"]
-        assert "compactionID" in response["data"]
+        # Get compaction state (compactionID <= 0 means no compaction was generated)
+        if compaction_id > 0:
+            response = client.get_compaction_state(compaction_id)
+            assert response["code"] == 0
+            assert "state" in response["data"]
+            assert "compactionID" in response["data"]
         # TODO need verification by pymilvus
 


### PR DESCRIPTION
## Summary
- Add parameter validation for `compactionID <= 0` in both `GetCompactionState` and `GetCompactionStateWithPlans`, returning `ErrParameterInvalid`
- Add "not found" check in `GetCompactionState` (matching existing logic in `GetCompactionStateWithPlans`) when all counts are zero and no merge infos exist
- Fix and update unit tests accordingly

See also: #46705

## Test plan
- [x] Unit tests pass for `TestGetCompactionState` and `TestGetCompactionStateWithPlans`
- [x] Static check passes (`make static-check`)