### PR TITLE
enhance: [GoSDK] support pointer types for nullable columns in row-based API

### DIFF
--- a/client/row/schema.go
+++ b/client/row/schema.go
@@ -65,8 +65,10 @@ func ParseSchema(r interface{}) (*entity.Schema, error) {
 			Name: f.Name,
 		}
 		ft := f.Type
-		if f.Type.Kind() == reflect.Ptr {
+		isPtr := f.Type.Kind() == reflect.Ptr
+		if isPtr {
 			ft = ft.Elem()
+			field.Nullable = true
 		}
 		fv := reflect.New(ft)
 		tag := f.Tag.Get(MilvusTag)
@@ -76,6 +78,7 @@ func ParseSchema(r interface{}) (*entity.Schema, error) {
 		tagSettings := ParseTagSetting(tag, MilvusTagSep)
 		if _, has := tagSettings[MilvusPrimaryKey]; has {
 			field.PrimaryKey = true
+			field.Nullable = false
 		}
 		if _, has := tagSettings[MilvusAutoID]; has {
 			field.AutoID = true


### PR DESCRIPTION
Related to #47711

Enable Go pointer struct fields (*string, *int32, etc.) to represent nullable columns in the row-based data processing path. A nil pointer maps to a NULL value in Milvus; a non-nil pointer dereferences to the actual value.

Changes:
- ParseSchema: pointer fields auto-infer Nullable=true (PK excluded)
- AnyToColumns: use reflect.Value.IsNil() to call AppendNull for nil pointers, Elem().Interface() for non-nil — bypasses Go's typed-nil problem where (*T)(nil) as interface{} is != nil
- SetField: wrap/unwrap pointer values during field assignment
- fillData/fillPKEntry: check IsNull() on columns and set nil pointers for null values, wrap non-null values in reflect.New pointers
- Dynamic field path: same nil/deref logic for pointer fields going into the JSON dynamic column