### PR TITLE
Fix typos in cmd folder

### DIFF
--- a/cmd/milvus/util.go
+++ b/cmd/milvus/util.go
@@ -137,7 +137,7 @@ func GetMilvusRoles(args []string, flags *flag.FlagSet) *roles.MilvusRoles {
 	case typeutil.DataNodeRole:
 		role.EnableDataNode = true
 	case typeutil.StreamingNodeRole:
-		sessionutil.EnableEmbededQueryNodeLabel()
+		sessionutil.EnableEmbeddedQueryNodeLabel()
 		role.EnableStreamingNode = true
 		role.EnableQueryNode = true
 	case typeutil.StandaloneRole, typeutil.EmbeddedRole:
@@ -161,7 +161,7 @@ func GetMilvusRoles(args []string, flags *flag.FlagSet) *roles.MilvusRoles {
 		role.EnableStreamingNode = enableStreamingNode
 		if enableStreamingNode && !enableQueryNode {
 			role.EnableQueryNode = true
-			sessionutil.EnableEmbededQueryNodeLabel()
+			sessionutil.EnableEmbeddedQueryNodeLabel()
 		}
 
 	case typeutil.CDCRole:

--- a/cmd/tools/config-docs-generator/main.go
+++ b/cmd/tools/config-docs-generator/main.go
@@ -26,7 +26,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	log.Print("generate successed")
+	log.Print("generate succeeded")
 }
 
 func run() error {
@@ -71,7 +71,7 @@ func parseSections(root *yaml.Node) []Section {
 	return sections
 }
 
-// head commet + line comment, remove # prefix, then join with '\n'
+// head comment + line comment, remove # prefix, then join with '\n'
 func getDescriptionFromNode(node *yaml.Node) []string {
 	var retLines []string
 	if node.HeadComment != "" {
@@ -172,7 +172,7 @@ For the convenience of maintenance, Milvus classifies its configurations into %s
 	const fileName = "system_configuration.md"
 	fileContent := head
 	for _, sec := range secs {
-		fileContent += sec.systemConfiguratinContent()
+		fileContent += sec.systemConfigurationContent()
 		sectionFileContent := sec.sectionPageContent()
 		os.WriteFile(filepath.Join(outputPath, sec.fileName()), []byte(sectionFileContent), 0o644)
 	}
@@ -186,7 +186,7 @@ type Section struct {
 	Fields      []Field
 }
 
-func (s Section) systemConfiguratinContent() string {
+func (s Section) systemConfigurationContent() string {
 	return fmt.Sprintf("### `%s`"+mdNextLine+
 		"%s"+mdNextLine+
 		"See [%s-related Configurations](%s) for detailed description for each parameter under this section."+mdNextLine,
@@ -236,7 +236,7 @@ const fieldTableTemplate = `<table id="%s">
   <thead>
     <tr>
       <th class="width80">Description</th>
-      <th class="width20">Default Value</th> 
+      <th class="width20">Default Value</th>
     </tr>
   </thead>
   <tbody>

--- a/cmd/tools/config/generate.go
+++ b/cmd/tools/config/generate.go
@@ -79,7 +79,7 @@ func collectRecursive(params *paramtable.ComponentParam, data *[]DocContent, val
 			log.Ctx(context.TODO()).Debug("got key", zap.String("key", item.KeyPrefix), zap.String("variable", val.Type().Field(j).Name))
 			refreshable := tag.Get("refreshable")
 
-			// Sort group items to stablize the output order
+			// Sort group items to stabilize the output order
 			m := item.GetValue()
 			keys := make([]string, 0, len(m))
 			for k := range m {

--- a/cmd/tools/migration/meta/210_to_220.go
+++ b/cmd/tools/migration/meta/210_to_220.go
@@ -244,7 +244,7 @@ func combineToSegmentIndexesMeta220(segmentIndexes SegmentIndexesMeta210, indexB
 			for i, filePath := range buildMeta.GetIndexFilePaths() {
 				parts := strings.Split(filePath, "/")
 				if len(parts) == 0 {
-					return nil, fmt.Errorf("invaild index file path: %s", filePath)
+					return nil, fmt.Errorf("invalid index file path: %s", filePath)
 				}
 
 				fileKeys[i] = parts[len(parts)-1]


### PR DESCRIPTION
Found via `codespell cmd -L thw` and `typos --hidden --format brief`