### PR TITLE
enhance: Go search path optimizations for improved QPS

### DIFF
--- a/internal/proxy/search_pipeline.go
+++ b/internal/proxy/search_pipeline.go
@@ -1589,7 +1589,7 @@ func (p *pipeline) AddNodes(t *searchTask, nodes ...*nodeDef) error {
 }
 
 func (p *pipeline) Run(ctx context.Context, span trace.Span, toReduceResults []*internalpb.SearchResults, storageCost segcore.StorageCost) (*milvuspb.SearchResults, segcore.StorageCost, error) {
-	log.Ctx(ctx).Debug("SearchPipeline run", zap.String("pipeline", p.String()))
+	log.Ctx(ctx).Debug("SearchPipeline run", zap.String("pipeline", p.name))
 	msg := opMsg{}
 	msg[pipelineInput] = toReduceResults
 	msg[pipelineStorageCost] = storageCost

--- a/internal/proxy/shardclient/lb_policy.go
+++ b/internal/proxy/shardclient/lb_policy.go
@@ -313,8 +313,19 @@ func (lb *LBPolicyImpl) Execute(ctx context.Context, workload CollectionWorkLoad
 		return merr.WrapErrCollectionNotLoaded(workload.CollectionID)
 	}
 
+	// Single channel fast path: skip errgroup/goroutine overhead
+	if len(channelList) == 1 {
+		return lb.ExecuteWithRetry(ctx, ChannelWorkload{
+			Db:             workload.Db,
+			CollectionName: workload.CollectionName,
+			CollectionID:   workload.CollectionID,
+			Channel:        channelList[0],
+			Nq:             workload.Nq,
+			Exec:           workload.Exec,
+		})
+	}
+
 	wg, _ := errgroup.WithContext(ctx)
-	// Launch a goroutine for each channel
 	for _, channel := range channelList {
 		wg.Go(func() error {
 			return lb.ExecuteWithRetry(ctx, ChannelWorkload{

--- a/internal/proxy/task_scheduler.go
+++ b/internal/proxy/task_scheduler.go
@@ -159,13 +159,11 @@ func (queue *baseTaskQueue) getTaskByReqID(reqID UniqueID) task {
 	queue.utLock.RUnlock()
 
 	queue.atLock.RLock()
-	for tID, t := range queue.activeTasks {
-		if tID == reqID {
-			queue.atLock.RUnlock()
-			return t
-		}
-	}
+	t, ok := queue.activeTasks[reqID]
 	queue.atLock.RUnlock()
+	if ok {
+		return t
+	}
 	return nil
 }
 

--- a/internal/querynodev2/delegator/delegator.go
+++ b/internal/querynodev2/delegator/delegator.go
@@ -427,7 +427,7 @@ func (sd *shardDelegator) Search(ctx context.Context, req *querypb.SearchRequest
 	}
 
 	metrics.QueryNodeSQLatencyWaitTSafe.WithLabelValues(
-		fmt.Sprint(paramtable.GetNodeID()), metrics.SearchLabel).
+		paramtable.GetStringNodeID(), metrics.SearchLabel).
 		Observe(float64(waitTr.ElapseSpan().Milliseconds()))
 
 	sealed, growing, sealedRowCount, version, err := sd.distribution.PinReadableSegments(partialResultRequiredDataRatio, req.GetReq().GetPartitionIDs()...)

--- a/internal/querynodev2/handlers.go
+++ b/internal/querynodev2/handlers.go
@@ -414,26 +414,26 @@ func (node *QueryNode) searchChannel(ctx context.Context, req *querypb.SearchReq
 		zap.String("scope", req.GetScope().String()),
 		zap.Int64("nq", req.GetReq().GetNq()),
 	)
-	traceID := trace.SpanFromContext(ctx).SpanContext().TraceID()
 
 	if err := node.lifetime.Add(merr.IsHealthy); err != nil {
 		return nil, err
 	}
 	defer node.lifetime.Done()
 
+	nodeIDStr := paramtable.GetStringNodeID()
+	collIDStr := strconv.FormatInt(req.GetReq().GetCollectionID(), 10)
+
 	var err error
-	metrics.QueryNodeSQCount.WithLabelValues(fmt.Sprint(node.GetNodeID()), metrics.SearchLabel, metrics.TotalLabel, metrics.Leader, fmt.Sprint(req.GetReq().GetCollectionID())).Inc()
+	metrics.QueryNodeSQCount.WithLabelValues(nodeIDStr, metrics.SearchLabel, metrics.TotalLabel, metrics.Leader, collIDStr).Inc()
 	defer func() {
 		if err != nil {
-			metrics.QueryNodeSQCount.WithLabelValues(fmt.Sprint(node.GetNodeID()), metrics.SearchLabel, metrics.FailLabel, metrics.Leader, fmt.Sprint(req.GetReq().GetCollectionID())).Inc()
+			metrics.QueryNodeSQCount.WithLabelValues(nodeIDStr, metrics.SearchLabel, metrics.FailLabel, metrics.Leader, collIDStr).Inc()
 		}
 	}()
 
 	log.Debug("start to search channel",
 		zap.Int64s("segmentIDs", req.GetSegmentIDs()),
 	)
-	searchCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
 
 	// From Proxy
 	tr := timerecord.NewTimeRecorder("searchDelegator")
@@ -445,18 +445,13 @@ func (node *QueryNode) searchChannel(ctx context.Context, req *querypb.SearchReq
 		return nil, err
 	}
 	// do search
-	results, err := sd.Search(searchCtx, req)
+	results, err := sd.Search(ctx, req)
 	if err != nil {
 		log.Warn("failed to search on delegator", zap.Error(err))
 		return nil, err
 	}
 
-	// reduce result
-	tr.CtxElapse(ctx, fmt.Sprintf("start reduce query result, traceID = %s,  vChannel = %s, segmentIDs = %v",
-		traceID,
-		channel,
-		req.GetSegmentIDs(),
-	))
+	tr.CtxElapse(ctx, "start reduce query result, ch="+channel)
 
 	resp, err := segments.ReduceSearchOnQueryNode(ctx, results,
 		reduce.NewReduceSearchResultInfo(req.GetReq().GetNq(),
@@ -465,24 +460,21 @@ func (node *QueryNode) searchChannel(ctx context.Context, req *querypb.SearchReq
 
 	reduceLatency := tr.RecordSpan()
 	metrics.QueryNodeReduceLatency.
-		WithLabelValues(fmt.Sprint(node.GetNodeID()), metrics.SearchLabel, metrics.ReduceShards, metrics.BatchReduce).
+		WithLabelValues(nodeIDStr, metrics.SearchLabel, metrics.ReduceShards, metrics.BatchReduce).
 		Observe(float64(reduceLatency.Milliseconds()))
 
 	if err != nil {
 		return nil, err
 	}
 
-	tr.CtxElapse(ctx, fmt.Sprintf("do search with channel done , vChannel = %s, segmentIDs = %v",
-		channel,
-		req.GetSegmentIDs(),
-	))
+	tr.CtxElapse(ctx, "search with channel done, ch="+channel)
 
 	// update metric to prometheus
 	latency := tr.ElapseSpan()
-	metrics.QueryNodeSQReqLatency.WithLabelValues(fmt.Sprint(node.GetNodeID()), metrics.SearchLabel, metrics.Leader).Observe(float64(latency.Milliseconds()))
-	metrics.QueryNodeSQCount.WithLabelValues(fmt.Sprint(node.GetNodeID()), metrics.SearchLabel, metrics.SuccessLabel, metrics.Leader, fmt.Sprint(req.GetReq().GetCollectionID())).Inc()
-	metrics.QueryNodeSearchNQ.WithLabelValues(fmt.Sprint(node.GetNodeID())).Observe(float64(req.Req.GetNq()))
-	metrics.QueryNodeSearchTopK.WithLabelValues(fmt.Sprint(node.GetNodeID())).Observe(float64(req.Req.GetTopk()))
+	metrics.QueryNodeSQReqLatency.WithLabelValues(nodeIDStr, metrics.SearchLabel, metrics.Leader).Observe(float64(latency.Milliseconds()))
+	metrics.QueryNodeSQCount.WithLabelValues(nodeIDStr, metrics.SearchLabel, metrics.SuccessLabel, metrics.Leader, collIDStr).Inc()
+	metrics.QueryNodeSearchNQ.WithLabelValues(nodeIDStr).Observe(float64(req.Req.GetNq()))
+	metrics.QueryNodeSearchTopK.WithLabelValues(nodeIDStr).Observe(float64(req.Req.GetTopk()))
 	return resp, nil
 }
 

--- a/internal/querynodev2/segments/search.go
+++ b/internal/querynodev2/segments/search.go
@@ -18,7 +18,6 @@ package segments
 
 import (
 	"context"
-	"fmt"
 
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
@@ -40,56 +39,69 @@ func searchSegments(ctx context.Context, mgr *Manager, segments []Segment, segTy
 		searchLabel = metrics.GrowingSegmentLabel
 	}
 
-	resultCh := make(chan *SearchResult, len(segments))
-	searcher := func(ctx context.Context, s Segment) error {
-		// record search time
+	nodeIDStr := paramtable.GetStringNodeID()
+	searchResults := make([]*SearchResult, len(segments))
+	searcher := func(ctx context.Context, s Segment, idx int) error {
 		tr := timerecord.NewTimeRecorder("searchOnSegments")
 		searchResult, err := s.Search(ctx, searchReq)
 		if err != nil {
 			return err
 		}
-		resultCh <- searchResult
-		// update metrics
+		searchResults[idx] = searchResult
 		elapsed := tr.ElapseSpan().Milliseconds()
-		metrics.QueryNodeSQSegmentLatency.WithLabelValues(fmt.Sprint(paramtable.GetNodeID()),
+		metrics.QueryNodeSQSegmentLatency.WithLabelValues(nodeIDStr,
 			metrics.SearchLabel, searchLabel).Observe(float64(elapsed))
-		metrics.QueryNodeSegmentSearchLatencyPerVector.WithLabelValues(fmt.Sprint(paramtable.GetNodeID()),
+		metrics.QueryNodeSegmentSearchLatencyPerVector.WithLabelValues(nodeIDStr,
 			metrics.SearchLabel, searchLabel).Observe(float64(elapsed) / float64(searchReq.GetNumOfQuery()))
 		return nil
 	}
 
-	// calling segment search in goroutines
-	errGroup, ctx := errgroup.WithContext(ctx)
-	segmentsWithoutIndex := make([]int64, 0)
-	for _, segment := range segments {
-		seg := segment
+	executeSegment := func(ctx context.Context, seg Segment, idx int) error {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		var err error
+		accessRecord := metricsutil.NewSearchSegmentAccessRecord(getSegmentMetricLabel(seg))
+		defer func() {
+			accessRecord.Finish(err)
+		}()
+
+		return searcher(ctx, seg, idx)
+	}
+
+	segmentsWithoutIndex := make([]int64, 0, len(segments))
+	for _, seg := range segments {
 		if !seg.ExistIndex(searchReq.SearchFieldID()) {
 			segmentsWithoutIndex = append(segmentsWithoutIndex, seg.ID())
 		}
-		errGroup.Go(func() error {
-			if ctx.Err() != nil {
-				return ctx.Err()
-			}
-
-			var err error
-			accessRecord := metricsutil.NewSearchSegmentAccessRecord(getSegmentMetricLabel(seg))
-			defer func() {
-				accessRecord.Finish(err)
-			}()
-
-			return searcher(ctx, seg)
-		})
 	}
-	err := errGroup.Wait()
-	close(resultCh)
 
-	searchResults := make([]*SearchResult, 0, len(segments))
-	for result := range resultCh {
-		searchResults = append(searchResults, result)
+	var err error
+	if len(segments) == 1 {
+		// Single segment fast path: skip errgroup/goroutine overhead
+		err = executeSegment(ctx, segments[0], 0)
+	} else {
+		errGroup, groupCtx := errgroup.WithContext(ctx)
+		for i, segment := range segments {
+			segIdx := i
+			seg := segment
+			errGroup.Go(func() error {
+				return executeSegment(groupCtx, seg, segIdx)
+			})
+		}
+		err = errGroup.Wait()
 	}
 
 	if err != nil {
-		DeleteSearchResults(searchResults)
+		// Collect non-nil results for cleanup
+		validResults := make([]*SearchResult, 0, len(segments))
+		for _, r := range searchResults {
+			if r != nil {
+				validResults = append(validResults, r)
+			}
+		}
+		DeleteSearchResults(validResults)
 		return nil, err
 	}
 

--- a/internal/querynodev2/segments/search_reduce.go
+++ b/internal/querynodev2/segments/search_reduce.go
@@ -36,13 +36,15 @@ func (scr *SearchCommonReduce) ReduceSearchResultData(ctx context.Context, searc
 			Topks:      make([]int64, 0),
 		}, nil
 	}
+	nq := info.GetNq()
+	topk := info.GetTopK()
 	ret := &schemapb.SearchResultData{
-		NumQueries: info.GetNq(),
-		TopK:       info.GetTopK(),
+		NumQueries: nq,
+		TopK:       topk,
 		FieldsData: make([]*schemapb.FieldData, len(searchResultData[0].FieldsData)),
-		Scores:     make([]float32, 0),
+		Scores:     make([]float32, 0, nq*topk),
 		Ids:        &schemapb.IDs{},
-		Topks:      make([]int64, 0),
+		Topks:      make([]int64, 0, nq),
 	}
 
 	// Check element-level consistency: all results must have ElementIndices or none
@@ -60,9 +62,16 @@ func (scr *SearchCommonReduce) ReduceSearchResultData(ctx context.Context, searc
 	}
 
 	resultOffsets := make([][]int64, len(searchResultData))
+	totalOffsetElements := 0
+	for i := range searchResultData {
+		totalOffsetElements += len(searchResultData[i].Topks)
+	}
+	offsetBacking := make([]int64, totalOffsetElements)
 	for i := 0; i < len(searchResultData); i++ {
-		resultOffsets[i] = make([]int64, len(searchResultData[i].Topks))
-		for j := int64(1); j < info.GetNq(); j++ {
+		n := len(searchResultData[i].Topks)
+		resultOffsets[i] = offsetBacking[:n:n]
+		offsetBacking = offsetBacking[n:]
+		for j := int64(1); j < nq; j++ {
 			resultOffsets[i][j] = resultOffsets[i][j-1] + searchResultData[i].Topks[j-1]
 		}
 		ret.AllSearchCount += searchResultData[i].GetAllSearchCount()
@@ -73,14 +82,15 @@ func (scr *SearchCommonReduce) ReduceSearchResultData(ctx context.Context, searc
 		idxComputers[i] = typeutil.NewFieldDataIdxComputer(srd.FieldsData)
 	}
 
+	numResults := len(searchResultData)
 	var skipDupCnt int64
 	var retSize int64
 	maxOutputSize := paramtable.Get().QuotaConfig.MaxOutputSize.GetAsInt64()
-	for i := int64(0); i < info.GetNq(); i++ {
-		offsets := make([]int64, len(searchResultData))
+	for i := int64(0); i < nq; i++ {
+		offsets := make([]int64, numResults)
 		idSet := make(map[interface{}]struct{})
 		var j int64
-		for j = 0; j < info.GetTopK(); {
+		for j = 0; j < topk; {
 			sel := SelectSearchResultData(searchResultData, resultOffsets, offsets, i)
 			if sel == -1 {
 				break
@@ -142,13 +152,15 @@ func (sbr *SearchGroupByReduce) ReduceSearchResultData(ctx context.Context, sear
 			Topks:      make([]int64, 0),
 		}, nil
 	}
+	nq := info.GetNq()
+	topk := info.GetTopK()
 	ret := &schemapb.SearchResultData{
-		NumQueries: info.GetNq(),
-		TopK:       info.GetTopK(),
+		NumQueries: nq,
+		TopK:       topk,
 		FieldsData: make([]*schemapb.FieldData, len(searchResultData[0].FieldsData)),
-		Scores:     make([]float32, 0),
+		Scores:     make([]float32, 0, nq*topk),
 		Ids:        &schemapb.IDs{},
-		Topks:      make([]int64, 0),
+		Topks:      make([]int64, 0, nq),
 	}
 
 	// Check element-level consistency: all results must have ElementIndices or none
@@ -166,10 +178,17 @@ func (sbr *SearchGroupByReduce) ReduceSearchResultData(ctx context.Context, sear
 	}
 
 	resultOffsets := make([][]int64, len(searchResultData))
+	totalOffsetElements := 0
+	for i := range searchResultData {
+		totalOffsetElements += len(searchResultData[i].Topks)
+	}
+	offsetBacking := make([]int64, totalOffsetElements)
 	groupByValIterator := make([]func(int) any, len(searchResultData))
 	for i := range searchResultData {
-		resultOffsets[i] = make([]int64, len(searchResultData[i].Topks))
-		for j := int64(1); j < info.GetNq(); j++ {
+		n := len(searchResultData[i].Topks)
+		resultOffsets[i] = offsetBacking[:n:n]
+		offsetBacking = offsetBacking[n:]
+		for j := int64(1); j < nq; j++ {
 			resultOffsets[i][j] = resultOffsets[i][j-1] + searchResultData[i].Topks[j-1]
 		}
 		ret.AllSearchCount += searchResultData[i].GetAllSearchCount()

--- a/internal/querynodev2/services.go
+++ b/internal/querynodev2/services.go
@@ -745,10 +745,12 @@ func (node *QueryNode) SearchSegments(ctx context.Context, req *querypb.SearchRe
 	}
 	defer node.lifetime.Done()
 
-	metrics.QueryNodeSQCount.WithLabelValues(fmt.Sprint(node.GetNodeID()), metrics.SearchLabel, metrics.TotalLabel, metrics.FromLeader, fmt.Sprint(req.GetReq().GetCollectionID())).Inc()
+	nodeIDStr := paramtable.GetStringNodeID()
+	collIDStr := strconv.FormatInt(req.GetReq().GetCollectionID(), 10)
+	metrics.QueryNodeSQCount.WithLabelValues(nodeIDStr, metrics.SearchLabel, metrics.TotalLabel, metrics.FromLeader, collIDStr).Inc()
 	defer func() {
 		if !merr.Ok(resp.GetStatus()) {
-			metrics.QueryNodeSQCount.WithLabelValues(fmt.Sprint(node.GetNodeID()), metrics.SearchLabel, metrics.FailLabel, metrics.FromLeader, fmt.Sprint(req.GetReq().GetCollectionID())).Inc()
+			metrics.QueryNodeSQCount.WithLabelValues(nodeIDStr, metrics.SearchLabel, metrics.FailLabel, metrics.FromLeader, collIDStr).Inc()
 		}
 	}()
 
@@ -787,14 +789,11 @@ func (node *QueryNode) SearchSegments(ctx context.Context, req *querypb.SearchRe
 		return resp, nil
 	}
 
-	tr.CtxElapse(ctx, fmt.Sprintf("search segments done, channel = %s, segmentIDs = %v",
-		channel,
-		req.GetSegmentIDs(),
-	))
+	tr.CtxElapse(ctx, "search segments done")
 
 	latency := tr.ElapseSpan()
-	metrics.QueryNodeSQReqLatency.WithLabelValues(fmt.Sprint(node.GetNodeID()), metrics.SearchLabel, metrics.FromLeader).Observe(float64(latency.Milliseconds()))
-	metrics.QueryNodeSQCount.WithLabelValues(fmt.Sprint(node.GetNodeID()), metrics.SearchLabel, metrics.SuccessLabel, metrics.FromLeader, fmt.Sprint(req.GetReq().GetCollectionID())).Inc()
+	metrics.QueryNodeSQReqLatency.WithLabelValues(nodeIDStr, metrics.SearchLabel, metrics.FromLeader).Observe(float64(latency.Milliseconds()))
+	metrics.QueryNodeSQCount.WithLabelValues(nodeIDStr, metrics.SearchLabel, metrics.SuccessLabel, metrics.FromLeader, collIDStr).Inc()
 
 	resp = task.SearchResult()
 	resp.GetCostAggregation().ResponseTime = tr.ElapseSpan().Milliseconds()


### PR DESCRIPTION
issue: #47827

Key optimizations:
- O(1) task lookup in scheduler via unissuedTasksIndex map 
- Channel→indexed slice in searchSegments, eliminating channel alloc/sync 
- Single segment fast path skipping errgroup/goroutine overhead 
- Single channel fast path in LB policy 
- Shallow copy SearchRequest instead of proto.Clone deep copy 
- Pipeline.String()→p.name in debug log to avoid eager evaluation 
- TimeRecorder: fix double time.Now(), pre-compute logLabel, IsRecording guard 
- Batch 2D array allocation for resultOffsets in search reduce 
- Pre-allocate Scores/Topks slices with nq*topk capacity 
- Replace fmt.Sprint(nodeID) with paramtable.GetStringNodeID() on hot paths 
- Eliminate fmt.Sprintf in CtxElapse calls, use static strings 