### PR TITLE
test: wait for all coverage uploads before posting Codecov comment

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,7 +3,8 @@ codecov:
   require_ci_to_pass: no
   notify:
     require_ci_to_pass: no
-    wait_for_ci: false
+    wait_for_ci: true
+    after_n_builds: 3  # Wait for all 3 coverage uploads: cpp-unit-test, go-test, integration-test
   ci:
     - jenkins.milvus.io:18080
 coverage:


### PR DESCRIPTION
Change wait_for_ci from false to true and add after_n_builds: 3 to ensure Codecov waits for all 3 coverage uploads (cpp-unit-test, go-test, integration-test) before posting the PR comment. This fixes the issue where the comment only shows partial coverage data.